### PR TITLE
research(newton-inductive-step-oq-01): rebuild stale/scrambled sections to full file (5→11)

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -81,43 +81,91 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Elementary Symmetric Polynomials",
-      "startLine": 33,
-      "endLine": 58,
-      "summary": "Definition of esymm on lists of reals using the standard recurrence, with simp lemmas.",
-      "mathContext": "The elementary symmetric polynomial $e_k(x_1, \\ldots, x_n)$ satisfies the recurrence $e_k(x_1, \\ldots, x_n) = e_k(x_2, \\ldots, x_n) + x_1 \\cdot e_{k-1}(x_2, \\ldots, x_n)$."
+      "title": "Elementary Symmetric Polynomials on Lists",
+      "startLine": 35,
+      "endLine": 45,
+      "summary": "Defines esymm on lists of reals via the standard recurrence (noncomputable def esymm).",
+      "mathContext": "The elementary symmetric polynomial $e_k(x_1, \\ldots, x_n)$ satisfies $e_k(x_1, \\ldots, x_n) = e_k(x_2, \\ldots, x_n) + x_1 \\cdot e_{k-1}(x_2, \\ldots, x_n)$."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 59,
-      "endLine": 100,
-      "summary": "Proves e_0 = 1, vanishing for k > n, e_n = product, and nonnegativity for nonneg inputs.",
+      "startLine": 46,
+      "endLine": 107,
+      "summary": "Simp lemmas for the nil/cons recurrence (esymm_nil_zero/nil_succ/cons_zero/cons_succ) and the core properties: e_0 = 1 (esymm_zero), vanishing for k > n (esymm_eq_zero_of_gt), e_n = product (esymm_length), and nonnegativity for nonneg inputs (esymm_nonneg).",
       "mathContext": "$e_0 = 1$, $e_k = 0$ for $k > n$, $e_n = \\prod x_i$, and $e_k \\geq 0$ when all $x_i \\geq 0$."
     },
     {
-      "id": "binom-log-concave",
-      "title": "Log-Concavity of Binomial Coefficients",
-      "startLine": 117,
-      "endLine": 170,
-      "summary": "Proves C(n,k)² ≥ C(n,k-1)·C(n,k+1) using absorption identities, reducing to k(n-k) ≤ (n-k+1)(k+1).",
-      "mathContext": "The binomial coefficients are log-concave: $\\binom{n}{k}^2 \\geq \\binom{n}{k-1} \\binom{n}{k+1}$. Proved via the absorption identity $k \\binom{n}{k} = (n-k+1) \\binom{n}{k-1}$."
+      "id": "singleton-base-case",
+      "title": "Newton's Inequality: Single-Element Base Case",
+      "startLine": 108,
+      "endLine": 114,
+      "summary": "newton_ineq_singleton: the base case of the induction for a one-element list.",
+      "mathContext": "For a single nonneg real $a$, the (degenerate) Newton inequality holds trivially."
+    },
+    {
+      "id": "normalized-mean-form-statement",
+      "title": "Newton's Inequality: Normalized (Mean) Form",
+      "startLine": 115,
+      "endLine": 155,
+      "summary": "States newton_inequality_binomial, the general binomial-normalized Newton inequality e_k² ≥ ... for all k. The general k ≥ 2 inductive Cauchy–Schwarz step is the single remaining sorry (line 154); k = 1 is discharged separately below.",
+      "mathContext": "$\\binom{n}{k}^{-2} e_k^2 \\geq \\binom{n}{k-1}^{-1}\\binom{n}{k+1}^{-1} e_{k-1} e_{k+1}$ — the standard Newton inequality (general $k$ open)."
+    },
+    {
+      "id": "sum-of-squares-identity",
+      "title": "Sum-of-Squares Identity (Key Lemma for k = 1)",
+      "startLine": 156,
+      "endLine": 181,
+      "summary": "esymm_sum_sub_sq_nonneg: e_1² − 2·e_2 + n·t² − 2t·e_1 ≥ 0, the algebraic form of ∑(xᵢ − t)² ≥ 0, which powers the fully-proved k = 1 case.",
+      "mathContext": "$\\sum_i (x_i - t)^2 \\geq 0 \\iff e_1^2 - 2e_2 + n t^2 - 2 t\\, e_1 \\geq 0$ for all $t$."
+    },
+    {
+      "id": "k-one-case-proved",
+      "title": "Newton's Inequality, k = 1 Case: Fully Proved",
+      "startLine": 182,
+      "endLine": 335,
+      "summary": "newton_inequality_binomial_k_one: the k = 1 instance is proved (no sorry) by induction on the list using the sum-of-squares identity esymm_sum_sub_sq_nonneg.",
+      "mathContext": "$e_1^2 \\geq \\tfrac{2n}{n-1} e_2$ (the $k=1$ Newton inequality), fully machine-checked."
+    },
+    {
+      "id": "direct-form-binom-log-concave",
+      "title": "Newton's Inequality: Direct Form for Nonneg Reals",
+      "startLine": 336,
+      "endLine": 430,
+      "summary": "The unnormalized formulation, supported by log-concavity of binomial coefficients: binom_log_concave (C(n,k)² ≥ C(n,k-1)·C(n,k+1) via absorption identities) and binom_ultra_log_concave (the squared/ultra form).",
+      "mathContext": "$\\binom{n}{k}^2 \\geq \\binom{n}{k-1}\\binom{n}{k+1}$ (and the ultra-log-concave $\\binom{n}{k}^4 \\geq \\binom{n}{k-1}^2\\binom{n}{k+1}^2$), via $k\\binom{n}{k} = (n-k+1)\\binom{n}{k-1}$."
+    },
+    {
+      "id": "mean-form",
+      "title": "Newton's Inequality: Mean Form",
+      "startLine": 431,
+      "endLine": 471,
+      "summary": "Defines the elementary symmetric mean esymmMean (ē_k = e_k / C(n,k)) and proves newton_inequality_means: the means are log-concave, ē_k² ≥ ē_{k-1}·ē_{k+1}, derived from newton_inequality_binomial by clearing fractions.",
+      "mathContext": "$\\bar{e}_k = e_k / \\binom{n}{k}$ and $\\bar{e}_k^2 \\geq \\bar{e}_{k-1}\\,\\bar{e}_{k+1}$ for $1 \\leq k \\leq n-1$."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences of Newton's Inequality",
+      "startLine": 472,
+      "endLine": 511,
+      "summary": "maclaurin_first_step (first Maclaurin inequality ē₁² ≥ ē₂) and amgm_from_newton (the AM-GM connection). Both depend only on the proved k = 1 case, not on the remaining general sorry.",
+      "mathContext": "$\\bar{e}_1^2 \\geq \\bar{e}_2$, giving $(\\sum x_i / n)^2 \\geq \\sum_{i<j} x_i x_j / \\binom{n}{2}$ and the AM-GM linkage."
     },
     {
       "id": "small-cases",
       "title": "Explicit Small Cases",
-      "startLine": 193,
-      "endLine": 245,
-      "summary": "Newton's inequality for n=2 (via (x-y)² ≥ 0) and n=3 (both k=1 and k=2), each reduced to sum-of-squares by nlinarith.",
+      "startLine": 512,
+      "endLine": 556,
+      "summary": "Newton's inequality for n=2 (newton_two, via (x−y)² ≥ 0) and n=3 (newton_three_k1, newton_three_k2), each reduced to sum-of-squares by nlinarith, plus esymm_one_eq_sum (e₁ = ∑ xᵢ).",
       "mathContext": "For $n=2$: $(x+y)^2 \\geq 4xy$. For $n=3$: $(x+y+z)^2 \\geq 3(xy+xz+yz)$ and $(xy+xz+yz)^2 \\geq 3xyz(x+y+z)$."
     },
     {
-      "id": "consequences",
-      "title": "Consequences: Maclaurin and AM-GM",
-      "startLine": 172,
-      "endLine": 193,
-      "summary": "First Maclaurin inequality ē₁² ≥ ē₂ and the AM-GM connection (mean)² ≥ average pairwise product.",
-      "mathContext": "From Newton's inequality with $k=1$: $\\bar{e}_1^2 \\geq \\bar{e}_0 \\cdot \\bar{e}_2 = \\bar{e}_2$. This gives $(\\sum x_i / n)^2 \\geq \\sum_{i<j} x_i x_j / \\binom{n}{2}$."
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 557,
+      "endLine": 586,
+      "summary": "Closing module docstring (re-opening the namespace) cataloguing the key results, the single remaining sorry (newton_inequality_binomial for general k ≥ 2), and the note that the k = 1 case and downstream consequences are sorry-free.",
+      "mathContext": "Status: 0 axioms, 1 sorry (general-k inductive Cauchy–Schwarz step); k = 1 case and Maclaurin/AM-GM consequences fully proved."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The `newton-inductive-step-oq-01` gallery meta documented only 5 sections stopping at line 245 of 586 (58% of the file hidden), and the final two were out of order — "Explicit Small Cases" (193-245) was listed before "Consequences" (172-193) and overlapped at line 193 — with titles that had drifted off their real locations.
- Rebuilt the `sections` array to the file's 11 `/-! ## -/` banners, surfacing the previously undocumented Newton-inequality development: singleton base case, the normalized-form statement (which carries the single remaining general-k sorry at line 154), the sum-of-squares key lemma, the fully-proved k=1 case, the direct/log-concave form, the mean form, the consequences (Maclaurin / AM-GM), and the closing summary.

## Verification
- Sections now cover the full source contiguously (tail gap 0, no internal gaps), in monotonic order.
- Counts unchanged and already correct: 21 theorems / 2 defs / 0 axioms / 1 sorry / 586 lines.
- JSON validated; only the `sections` array changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)