### PR TITLE
research(erdos-896): realign drifted sections to full file (6→8) + fix stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -54,7 +54,7 @@
     "historicalContext": "**Erdős Problem #896: Unique Product Representations**\n\nPaul Erdős posed this problem in 1972 [Er72, p. 81], asking: for $A, B \\subseteq \\{1, \\ldots, N\\}$, how many products $ab$ can have exactly one representation as such a product? The question lies at the intersection of multiplicative number theory and extremal combinatorics.\n\nThe problem is intimately connected to the **Erdős multiplication table problem** (Problem #490), which asks how many distinct products appear in the $N \\times N$ multiplication table. Kevin Ford (2008) resolved the multiplication table problem, showing the number of distinct products is $\\Theta(N^2/(\\log N)^\\delta (\\log\\log N)^{3/2})$ where $\\delta = 1 - (1 + \\log\\log 2)/\\log 2 \\approx 0.086$. The same exponent $\\delta$ appears in Problem #896's upper bound — this is no coincidence, as the distribution of the divisor function $d(n)$ governs both problems.\n\n**Van Doorn** established the best known bounds:\n- **Lower bound:** $(1 + o(1))N^2/\\log N \\leq \\max F(A,B)$. The construction uses sets $A, B$ of primes in $[N/2, N]$, where products of distinct primes automatically have unique factorization.\n- **Upper bound:** $\\max F(A,B) \\ll N^2/(\\log N)^\\delta \\cdot (\\log\\log N)^{3/2}$ with $\\delta \\approx 0.086$. This relies on estimates for the number of integers with exactly one divisor in a given range.\n\nThe gap between the exponents — $1$ in the lower bound versus $\\approx 0.086$ in the upper bound — remains the central open question. The **Exact Order Conjecture** asserts that the true answer is $\\Theta(N^2/\\log N)$, which would mean the prime-based construction is asymptotically optimal.\n\nThe problem also connects to Erdős and Szemerédi's work on sum-product phenomena: understanding when arithmetic operations on finite sets produce few collisions is a fundamental theme in additive combinatorics.",
     "problemStatement": "**Problem Statement (Open)**\n\nFor $A, B \\subseteq \\{1, \\ldots, N\\}$, let $F(A,B)$ count the number of products $m = ab$ ($a \\in A$, $b \\in B$) that have exactly one such representation.\n\n**Questions:**\n1. Estimate $\\max_{A,B} F(A,B)$ as a function of $N$.\n2. Is the true order $\\Theta(N^2/\\log N)$?\n\n**Known:**\n- Van Doorn: $(1+o(1))N^2/\\log N \\leq \\max F \\ll N^2/(\\log N)^{0.086} (\\log\\log N)^{3/2}$\n- Conjecture: $\\max F(A,B) = \\Theta(N^2/\\log N)$",
     "text": "Estimate max F(A,B) where F counts products ab with exactly one representation. Van Doorn: N²/log N ≤ max F ≪ N²/(log N)^δ.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization builds the problem from computational definitions to asymptotic bounds:\n\n1. **Computational Core (Lines 29–40):** `reprCount A B m` counts representations of $m$ as $ab$, and `uniqueProductCount A B` ($= F(A,B)$) counts products with exactly one representation. Both use `Finset.filter` and `Finset.image` for finite computation.\n\n2. **Problem Statement (Lines 47–60):** `maxUniqueProducts N` axiomatizes the maximum, with an existence witness. `ErdosProblem896` states the exact order conjecture: $\\Theta(N^2/\\log N)$.\n\n3. **Van Doorn's Bounds (Lines 75–90):** `VanDoornLowerBound` encodes $(1-\\varepsilon)N^2/\\log N$ as asymptotic lower bound. `VanDoornUpperBound` encodes $CN^2/(\\log N)^\\delta (\\log\\log N)^{3/2}$ with $\\delta = 1 - (1+\\log\\log 2)/\\log 2$.\n\n4. **Verified Properties (Lines 97–116):** Proves $F(A,B) \\leq |A| \\cdot |B|$ via `card_filter_le`, `card_image_le`, `card_product`. Also proves $F(\\emptyset, B) = 0$.\n\n5. **Conjecture and Summary (Lines 128–146):** States `ExactOrderConjecture` ($= \\Theta(N^2/\\log N)$) and the summary theorem combining both Van Doorn bounds.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization builds the problem from computational definitions to asymptotic bounds:\n\n1. **Computational Core (Lines 25–41):** `reprCount A B m` counts representations of $m$ as $ab$, and `uniqueProductCount A B` ($= F(A,B)$) counts products with exactly one representation. Both use `Finset.filter` and `Finset.image` for finite computation.\n\n2. **Problem Statement (Lines 42–83):** `maxUniqueProducts N` is *defined* as `Finset.sup` of $F$ over all subset pairs (not axiomatized), and `maxUniqueProducts_achieved` proves the maximum is attained. `ErdosProblem896` states the exact order conjecture: $\\Theta(N^2/\\log N)$.\n\n3. **Van Doorn's Bounds (Lines 84–113):** `VanDoornLowerBound` encodes $(1-\\varepsilon)N^2/\\log N$ as asymptotic lower bound. `VanDoornUpperBound` encodes $CN^2/(\\log N)^\\delta (\\log\\log N)^{3/2}$ with $\\delta = 1 - (1+\\log\\log 2)/\\log 2$. Their conjunction is the single `axiom` `van_doorn_bounds`.\n\n4. **Verified Properties (Lines 114–371):** Proves $F(A,B) \\leq |A| \\cdot |B|$, commutativity $F(A,B) = F(B,A)$, the singleton/empty formulas, monotonicity, the divisor bounds on `reprCount`, and the sandwich $N \\leq \\max F \\leq N^2$ — all without further axioms.\n\n5. **Conjecture and Summary (Lines 373–401):** States `ExactOrderConjecture` ($= \\Theta(N^2/\\log N)$) and the summary theorem combining both Van Doorn bounds.",
     "keyInsights": [
       "**Divisor Function Connection:** The exponent $\\delta = 1 - (1 + \\log\\log 2)/\\log 2 \\approx 0.086$ appears in both the multiplication table problem and the unique product upper bound. It arises from the distribution of the number-of-divisors function $d(n)$: the proportion of $n \\leq x$ with $d(n) = k$ is controlled by $x/(\\log x)^\\delta$ when $k$ is fixed, by the Selberg-Sathe theorem.",
       "**Prime Construction for Lower Bound:** Van Doorn's lower bound uses $A = B = \\{\\text{primes in } [N/2, N]\\}$. By the prime number theorem, $|A| \\sim N/(2\\log N)$, so $|A|^2 \\sim N^2/(4(\\log N)^2)$. But products of distinct primes have unique factorization, and the product set has size $\\sim |A|^2/2$, giving $F \\sim N^2/(\\log N)^2 \\cdot \\log N = N^2/\\log N$ after accounting for the prime distribution.",
@@ -86,33 +86,47 @@
       "id": "main-problem",
       "title": "Main Problem",
       "startLine": 42,
-      "endLine": 61,
-      "summary": "Axiomatizes `maxUniqueProducts N = \\max_{A,B} F(A,B)` with existence witness. Formalizes `ErdosProblem896`: $\\exists C_1, C_2 > 0$ such that $C_1 N^2/\\log N \\leq \\max F \\leq C_2 N^2/\\log N$."
+      "endLine": 83,
+      "summary": "Defines `maxUniqueProducts N = \\max_{A,B} F(A,B)` via `Finset.sup` over all subset pairs and proves `maxUniqueProducts_achieved` (the supremum is attained, via `Finset.exists_max_image`). Formalizes `ErdosProblem896`: $\\exists C_1, C_2 > 0$ such that $C_1 N^2/\\log N \\leq \\max F \\leq C_2 N^2/\\log N$."
     },
     {
       "id": "van-doorn",
       "title": "Van Doorn's Bounds",
-      "startLine": 62,
-      "endLine": 91,
-      "summary": "States `VanDoornLowerBound`: $(1-\\varepsilon)N^2/\\log N \\leq \\max F$ eventually. States `VanDoornUpperBound`: $\\max F \\leq C N^2/(\\log N)^\\delta (\\log\\log N)^{3/2}$ where $\\delta = 1 - (1+\\log\\log 2)/\\log 2 \\approx 0.086$."
+      "startLine": 84,
+      "endLine": 113,
+      "summary": "States `VanDoornLowerBound`: $(1-\\varepsilon)N^2/\\log N \\leq \\max F$ eventually. States `VanDoornUpperBound`: $\\max F \\leq C N^2/(\\log N)^\\delta (\\log\\log N)^{3/2}$ where $\\delta = 1 - (1+\\log\\log 2)/\\log 2 \\approx 0.086$. The combined result `van_doorn_bounds` is the file's single `axiom`."
     },
     {
       "id": "basic",
       "title": "Basic Properties",
-      "startLine": 92,
-      "endLine": 117,
-      "summary": "Proves $F(A,B) \\leq |A| \\cdot |B|$ via `card_filter_le \\circ card_image_le \\circ card_product`. Axiomatizes $F(A,B) = F(B,A)$ by multiplicative commutativity. Proves $F(\\emptyset, B) = 0$ by `simp`."
+      "startLine": 114,
+      "endLine": 283,
+      "summary": "Proves $F(A,B) \\leq |A| \\cdot |B|$ via `card_filter_le \\circ card_image_le \\circ card_product`, and proves $F(A,B) = F(B,A)$ (`uniqueProductCount_comm`, from `reprCount_comm`) — no axiom used. Proves $F(\\emptyset, B) = F(A, \\emptyset) = 0$, the singleton formulas $F(\\{a\\},\\{b\\}) = 1$ and $F(\\{a\\}, B) = |B|$ (for $a \\geq 1$), and the lower bounds `maxUniqueProducts_pos` ($\\geq 1$) and `maxUniqueProducts_ge_range` ($\\geq N$ via $F(\\{1,\\ldots,N\\},\\{1\\}) = N$)."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity and Bounds",
+      "startLine": 285,
+      "endLine": 304,
+      "summary": "Proves `maxUniqueProducts_mono`: enlarging the range $N_1 \\leq N_2$ only adds subset pairs to optimize over, so $\\max F$ is monotone. Proves `uniqueProductCount_le_image_card`: unique products are a subset of all products, $F(A,B) \\leq |A \\cdot B|$."
+    },
+    {
+      "id": "structural",
+      "title": "Representation Count Structural Properties",
+      "startLine": 306,
+      "endLine": 371,
+      "summary": "Proves `reprCount_pos_of_mem` (each pair $(a,b)$ witnesses $\\text{reprCount}(ab) > 0$) and the divisor bounds `reprCount_le_card_left/right` ($\\leq |A|, |B|$ for $m > 0$, since a representation is determined by one factor). Derives the quadratic upper bound `maxUniqueProducts_le_sq` ($\\max F \\leq N^2$) and packages the linear–quadratic sandwich `maxUniqueProducts_bounds`: $N \\leq \\max F \\leq N^2$ for $N \\geq 1$."
     },
     {
       "id": "gap",
       "title": "Gap Between Bounds and Conjecture",
-      "startLine": 118,
-      "endLine": 146,
-      "summary": "States `ExactOrderConjecture`: $\\max F = \\Theta(N^2/\\log N)$. Proves `van_doorn_implies_lower` (identity extraction). Summary theorem `erdos_896_summary` packages both Van Doorn bounds."
+      "startLine": 373,
+      "endLine": 401,
+      "summary": "States `ExactOrderConjecture`: $\\max F = \\Theta(N^2/\\log N)$, the conjectured exact order making Van Doorn's lower bound tight. Proves `van_doorn_implies_lower` (extracting the lower-bound part). Summary theorem `erdos_896_summary` packages both Van Doorn bounds."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #896 asks for the maximum number of uniquely representable products from two subsets of $\\{1,\\ldots,N\\}$. Van Doorn established $(1+o(1))N^2/\\log N \\leq \\max F \\ll N^2/(\\log N)^{0.086} (\\log\\log N)^{3/2}$. The formalization has 0 sorry statements, with the trivial bound $F \\leq |A|\\cdot|B|$ and the empty set case verified, while Van Doorn's bounds and commutativity are axiomatized.",
+    "summary": "Erdős Problem #896 asks for the maximum number of uniquely representable products from two subsets of $\\{1,\\ldots,N\\}$. Van Doorn established $(1+o(1))N^2/\\log N \\leq \\max F \\ll N^2/(\\log N)^{0.086} (\\log\\log N)^{3/2}$. The formalization has 0 sorry statements: the trivial bound $F \\leq |A|\\cdot|B|$, commutativity $F(A,B) = F(B,A)$, the singleton formulas, and the linear–quadratic sandwich $N \\leq \\max F \\leq N^2$ are all proved, while only Van Doorn's two deep asymptotic bounds (`van_doorn_bounds`) are axiomatized.",
     "implications": "**Theoretical Significance**: **Broader Mathematical Connections**\n\n1. **Erdős Multiplication Table (Problem #490):** The same exponent $\\delta \\approx 0.086$ governs the count of distinct entries in the $N \\times N$ multiplication table (Ford 2008). Problem #896 asks the complementary question: among all products, how many have *unique* factorization?\n\n2. **Sum-Product Phenomena:** Erdős and Szemerédi's conjecture that $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{2-\\varepsilon}$ reflects the tension between additive and multiplicative structure. Problem #896 probes the multiplicative side: when can products be 'injective'?\n\n**3. Analytic Number Theory:** The divisor function $d(n)$ and the Selberg-Sathe formula for the distribution of $d(n)$ are central tools. The exponent $\\delta$ is a fundamental constant in multiplicative number theory, appearing in the Erdős-Kac theorem and related results.\n\n4. **Extremal Combinatorics:** The problem is an instance of extremal function estimation: given a combinatorial constraint (unique representation), maximize the count. This paradigm appears throughout Turán-type problems and Ramsey theory.\n\n5. **Computational Aspects:** Determining $\\max F(A,B)$ for specific $N$ is computationally feasible for small $N$ and could provide evidence for or against the Exact Order Conjecture.",
     "openQuestions": [
       "Is the true order $\\Theta(N^2/\\log N)$, making Van Doorn's lower bound tight? This is the central open question of Problem #896.",


### PR DESCRIPTION
## Summary
- **Section drift**: erdos-896 gallery sections covered only lines 21–146 of a 401-line file (64% hidden). The last section "Gap Between Bounds and Conjecture" was mislabeled to lines 118–146, but its actual `## ` banner is at line 374. Front sections (`van-doorn`, `basic`) were line-shifted from their real banners.
- **Realigned** all 8 sections to the file's actual `## ` banners (26/43/85/115/286/307/374), restoring two hidden back-half sections — **Monotonicity and Bounds** (285–304) and **Representation Count Structural Properties** (306–371) — and the real **Gap** section (373–401). Sections now cover the full file.
- **Fixed stale prose**: meta claimed `F(A,B)=F(B,A)` commutativity and `maxUniqueProducts` were "axiomatized" when both are proved (`uniqueProductCount_comm` theorem; `maxUniqueProducts` is a `Finset.sup` def with `maxUniqueProducts_achieved`). Only `van_doorn_bounds` is an axiom. Updated the conclusion summary and `proofStrategy` line references accordingly.

## Verification
- `leanFile` counts already correct and unchanged: 1 axiom, 24 theorems, 8 definitions, 0 sorries, lineCount 401.
- Metadata-only change (no Lean source touched); sections validated contiguous with maxEnd = lineCount = 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)