### PR TITLE
Enrich erdos-1056-oq-01: realign sections to full file (7→8) + fix stale k≤8 prose

### DIFF
--- a/src/data/proofs/erdos-1056-oq-01/meta.json
+++ b/src/data/proofs/erdos-1056-oq-01/meta.json
@@ -44,7 +44,7 @@
   "overview": {
     "historicalContext": "Erdős (1979) asked: do there exist a prime $p$ and $k$ disjoint intervals of consecutive integers $I_1, \\ldots, I_k$ such that $\\prod_{n \\in I_j} n \\equiv 1 \\pmod{p}$ for all $j$? Makowski (1983) found the first multi-interval solution: for $k=3$ with $p=17$, the intervals $[2,6)$, $[6,12)$, $[12,16)$ all have products $\\equiv 1 \\pmod{17}$.\n\nThe connection to Wilson's theorem is key: $(p-1)! \\equiv -1 \\pmod{p}$, so the product of all integers from 1 to $p-1$ is $\\equiv -1$, not $1$. Solutions require carefully chosen sub-intervals that \"balance\" to give product $\\equiv 1$. The boundary points $b_0 < b_1 < \\cdots < b_k$ define the intervals $[b_{i-1}, b_i)$, and the condition $\\prod_{n=b_{i-1}}^{b_i-1} n \\equiv 1 \\pmod{p}$ is equivalent to consecutive factorials being congruent: $b_{i-1}! \\equiv b_i! \\pmod{p}$.\n\nThis OQ-01 file extends the known solutions: Erdős's original $k=2$ with $p=11$, Makowski's $k=3$ with $p=17$, and new solutions $k=4$ ($p=23$), $k=5$ ($p=71$), $k=6$ ($p=71$), $k=7$ ($p=673$), $k=8$ ($p=599$), $k=9$ ($p=3011$). For $k = 7, 8, 9$ the primes were located by exhaustive search over primes up to 5000 of the largest residue class in the factorial sequence $(1!, 2!, \\ldots, (p-1)!)$ modulo $p$.",
     "problemStatement": "Do there exist a prime $p$ and $k \\geq 2$ disjoint intervals $I_1, \\ldots, I_k$ of consecutive positive integers such that $\\prod_{n \\in I_j} n \\equiv 1 \\pmod{p}$ for all $j = 1, \\ldots, k$?",
-    "proofStrategy": "The proofs are entirely computational: the intervals and primes are explicitly exhibited, and `native_decide` verifies all modular arithmetic. The definitions encode the combinatorial structure: `HasSolutionk` checks primality of $p$ and the interval-boundary ordering and product conditions. The main theorems `erdos_k2` through `erdos_k8` instantiate these with explicit witnesses, then `exists_k2` through `exists_k8` existentially quantify the witnesses. The `all_solutions_2_to_8` theorem collects all results. The high-k boundaries (k=7,8) are obtained by enumerating $\\{n! \\bmod p : 0 \\le n < p\\}$ for small primes and selecting residue classes with maximum multiplicity: $p=599$ has nine factorials in residue class 175, $p=673$ has eight in residue class 56.",
+    "proofStrategy": "The proofs are entirely computational: the intervals and primes are explicitly exhibited, and `native_decide` verifies all modular arithmetic. The definitions encode the combinatorial structure: `HasSolutionk` checks primality of $p$ and the interval-boundary ordering and product conditions. The main theorems `erdos_k2` through `erdos_k9` instantiate these with explicit witnesses, then `exists_k2` through `exists_k9` existentially quantify the witnesses. The `all_solutions_2_to_9` theorem collects all results. The high-k boundaries (k=7,8,9) are obtained by enumerating $\\{n! \\bmod p : 0 \\le n < p\\}$ for primes up to 5000 and selecting residue classes with maximum multiplicity: $p=599$ has nine factorials in residue class 175, $p=673$ has eight in residue class 56, and $p=3011$ has ten factorials in residue class 1.",
     "keyInsights": [
       "**Wilson's constraint as boundary**: $(p-1)! \\equiv -1 \\pmod{p}$ means the intervals must span [1, p-1) with boundary factorials congruent mod p. For $p=23$: $1! \\equiv 4! \\equiv 8! \\equiv 11! \\equiv 21! \\pmod{23}$ gives the 4-interval solution.",
       "**Factorial congruence reformulation**: $\\prod_{n=a}^{b-1} n \\equiv 1 \\pmod{p}$ iff $b!/a! \\equiv 1 \\pmod{p}$ iff $b! \\equiv a! \\pmod{p}$. Finding solutions reduces to finding primes where the factorial sequence has repeated values modulo $p$.",
@@ -52,70 +52,79 @@
       "**New k=5,6 solutions (p=71)**: The prime $p=71$ supports both 5- and 6-interval solutions using the same boundary set $\\{8,10,20,52,62,64,71\\}$. The $k=6$ solution adds one more interval $[64,71)$ to the $k=5$ solution.",
       "**New k=7 solution (p=673)**: Boundaries $\\{160, 317, 355, 394, 398, 507, 546, 648\\}$. The underlying factorial pattern is $159! \\equiv 316! \\equiv 354! \\equiv 393! \\equiv 397! \\equiv 506! \\equiv 545! \\equiv 647! \\equiv 56 \\pmod{673}$. All boundaries are positive, avoiding the zero-product issue that arises when $0! = 1!$ are in the residue class.",
       "**New k=8 solution (p=599, smallest)**: Boundaries $\\{29, 51, 123, 184, 251, 290, 501, 540, 556\\}$. The factorial pattern $28! \\equiv 50! \\equiv 122! \\equiv 183! \\equiv 250! \\equiv 289! \\equiv 500! \\equiv 539! \\equiv 555! \\equiv 175 \\pmod{599}$ gives nine factorial values in one residue class — the smallest prime $p < 1000$ admitting this multiplicity, hence the smallest $p$ giving $k=8$.",
-      "**Computational completeness**: All 52 theorems are proved by `native_decide` or by combining `native_decide` lemmas. No auxiliary mathematical lemmas are needed — the problem is fundamentally combinatorial and the instances are small enough for decision procedures."
+      "**New k=9 solution (p=3011)**: Boundaries $\\{1, 612, 724, 750, 806, 2206, 2262, 2288, 2400, 3010\\}$, the smallest prime (by exhaustive search up to 5000) with ten indices in a single factorial residue class. Strikingly, that residue is $1$: $0! \\equiv 611! \\equiv 723! \\equiv \\cdots \\equiv 3009! \\equiv 1 \\pmod{3011}$, so each interval product collapses to the identity directly.",
+      "**Computational completeness**: All 65 theorems are proved by `native_decide` or by combining `native_decide` lemmas. No auxiliary mathematical lemmas are needed — the problem is fundamentally combinatorial and the instances are small enough for decision procedures."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring stating Erdős Problem #1056 OQ-01 (extending the known k=2,3 interval-product solutions to k=4..9), the Wilson's-theorem connection, the factorial-residue search approach for the high-k primes, and the explicit residue-class data for p=599 and p=673. Imports Nat.Prime, Finset, and Mathlib.Tactic; opens namespace Erdos1056OQ01 and Finset.",
+      "mathContext": "Goal: primes $p$ and $k$ consecutive intervals each with product $\\equiv 1 \\pmod p$, reduced to chains of equal factorials $b_{i-1}! \\equiv b_i! \\pmod p$."
+    },
+    {
       "id": "definitions",
-      "title": "Part I: Core Definitions",
-      "startLine": 35,
-      "endLine": 80,
-      "summary": "Defines `intervalProd a b` (product of [a,b) via Finset.Ico), `HasSolution2/3/4/5/6` (witnesses for k-interval solutions), and `ExistsSolution k` (existential wrapper). All are purely definitional.",
+      "title": "Part I — Core Definitions",
+      "startLine": 49,
+      "endLine": 125,
+      "summary": "Defines `intervalProd a b` (product over [a,b) via Finset.Ico), the predicates `HasSolution2` through `HasSolution9` (a prime p with k+1 increasing boundaries whose consecutive interval products are all ≡ 1 mod p), and `ExistsSolution k` (a match on k existentially quantifying the appropriate HasSolution predicate, with True as placeholder for other k). All purely definitional.",
       "mathContext": "$\\text{intervalProd}(a,b) = \\prod_{n=a}^{b-1} n$. $\\text{HasSolution}_k(p, b_0, \\ldots, b_k)$: $p$ prime, $b_0 < \\cdots < b_k$, and $\\text{intervalProd}(b_{i-1}, b_i) \\equiv 1 \\pmod{p}$ for all $i$."
     },
     {
       "id": "wilson-constraints",
-      "title": "Part II: Wilson's Theorem Constraints",
-      "startLine": 82,
-      "endLine": 102,
-      "summary": "Four theorems: `wilson_11`, `wilson_17`, `wilson_23`, `wilson_71` verify $(p-1)! \\equiv p-1 \\pmod{p}$ for the four primes used. All proved by `native_decide`.",
-      "mathContext": "$10! \\equiv 10 \\pmod{11}$, $16! \\equiv 16 \\pmod{17}$, $22! \\equiv 22 \\pmod{23}$, $70! \\equiv 70 \\pmod{71}$. These confirm Wilson's theorem for the solution primes."
+      "title": "Part II — Wilson's Constraint for Key Primes",
+      "startLine": 126,
+      "endLine": 148,
+      "summary": "Seven theorems wilson_11, wilson_17, wilson_23, wilson_71, wilson_599, wilson_673, wilson_3011 verify $(p-1)! \\equiv p-1 \\pmod{p}$ for every prime used in a solution. All proved by `native_decide`.",
+      "mathContext": "$10! \\equiv 10 \\pmod{11}$, …, $3010! \\equiv 3010 \\pmod{3011}$: Wilson's theorem $(p-1)! \\equiv -1 \\pmod p$ for each solution prime."
     },
     {
-      "id": "k4-solution",
-      "title": "Part III: k=4 Solution (p=23)",
-      "startLine": 104,
-      "endLine": 118,
-      "summary": "Four interval lemmas verify the k=4 solution: `k4_interval_1` through `k4_interval_4` show `intervalProd(2,5)`, `intervalProd(5,9)`, `intervalProd(9,12)`, `intervalProd(12,22)` are all $\\equiv 1 \\pmod{23}$.",
-      "mathContext": "$[2,5)$: $2 \\cdot 3 \\cdot 4 = 24 \\equiv 1 \\pmod{23}$. $[5,9)$: $5 \\cdot 6 \\cdot 7 \\cdot 8 = 1680 \\equiv 1 \\pmod{23}$. Etc."
+      "id": "interval-verifications",
+      "title": "Part III — Individual Interval Verifications",
+      "startLine": 149,
+      "endLine": 277,
+      "summary": "Per-interval modular checks for each solution: the historical k=2 (p=11) and k=3 (p=17) intervals as `example`s, then named theorems k4_interval_1..4 (p=23), k5_interval_1..5 and k6_interval_6 (p=71), k7_interval_1..7 (p=673), k8_interval_1..8 (p=599), and k9_interval_1..9 (p=3011). Each shows the corresponding intervalProd is ≡ 1 mod p via `native_decide`.",
+      "mathContext": "Each interval $[b_{i-1}, b_i)$ satisfies $\\prod_{n=b_{i-1}}^{b_i-1} n \\equiv 1 \\pmod p$; e.g. $[2,5)$: $2\\cdot3\\cdot4 = 24 \\equiv 1 \\pmod{23}$."
     },
     {
-      "id": "k5k6-solution",
-      "title": "Part IV: k=5,6 Solutions (p=71)",
-      "startLine": 119,
-      "endLine": 136,
-      "summary": "Seven interval lemmas for k=5,6 with p=71. `k5_interval_1` through `k5_interval_5` cover the k=5 solution; `k6_interval_6` adds the final interval $[64,71)$ for k=6.",
-      "mathContext": "Boundary points $\\{8,10,20,52,62,64,71\\}$ for p=71. Each interval $[b_{i-1},b_i)$ has product $\\equiv 1 \\pmod{71}$."
+      "id": "combined-solutions",
+      "title": "Part IV — Combined Solution Theorems",
+      "startLine": 278,
+      "endLine": 334,
+      "summary": "Assembles full witnesses: erdos_k2 (Erdős 1979, p=11), makowski_k3 (Makowski 1983, p=17), and the new erdos_k4 (p=23), erdos_k5/erdos_k6 (p=71), erdos_k7 (p=673), erdos_k8 (p=599, smallest prime giving k=8), and erdos_k9 (p=3011). Each instantiates the HasSolution_k predicate with explicit boundaries, proved by `native_decide`.",
+      "mathContext": "Each `HasSolution_k p b_0 … b_k` is witnessed by an explicit prime and boundary sequence drawn from a common factorial residue class mod p."
     },
     {
-      "id": "main-solutions",
-      "title": "Part V: Main Solution Theorems",
-      "startLine": 138,
-      "endLine": 180,
-      "summary": "Main witnesses: `erdos_k2` (Erdős 1979), `makowski_k3` (Makowski 1983), `erdos_k4` (new), `erdos_k5` (new), `erdos_k6` (new). Then `exists_k2` through `exists_k6` existentially quantify each witness. `all_solutions_2_to_6` collects all.",
-      "mathContext": "Each `HasSolution_k` is witnessed explicitly. `ExistsSolution k = ∃ p b₀ ... bₖ, HasSolution_k p b₀ ... bₖ`. The existence witnesses are the explicit boundary sequences."
+      "id": "existence",
+      "title": "Part V — Existence Proofs",
+      "startLine": 335,
+      "endLine": 357,
+      "summary": "Existentially quantifies each witness: exists_k2 through exists_k9 give `ExistsSolution k` from the corresponding erdos_k* / makowski_k3 theorem, and `all_solutions_2_to_9` bundles all eight existence results into one conjunction.",
+      "mathContext": "$\\text{ExistsSolution}(k) = \\exists\\, p\\, b_0 \\cdots b_k,\\ \\text{HasSolution}_k(p, b_0, \\ldots, b_k)$, witnessed for every $2 \\le k \\le 9$."
     },
     {
       "id": "factorial-patterns",
-      "title": "Part VI: Factorial Pattern Theorems",
-      "startLine": 181,
-      "endLine": 220,
-      "summary": "`factorial_pattern_23`: $4! \\equiv 8! \\equiv 11! \\equiv 21! \\pmod{23}$. `factorial_pattern_71`: $7! \\equiv 9! \\equiv 19! \\equiv 51! \\equiv 61! \\equiv 63! \\equiv 70! \\pmod{71}$. Both proved by `native_decide`.",
-      "mathContext": "Factorial congruences characterize the interval boundaries: $b! \\equiv a! \\pmod{p}$ iff $\\prod_{n=a}^{b-1} n \\equiv 1 \\pmod{p}$."
+      "title": "Part VI — Factorial Pattern",
+      "startLine": 358,
+      "endLine": 422,
+      "summary": "The structural heart: factorial_pattern_23, _71, _673, _599, and _3011 verify that the boundary indices are exactly the points where the factorial sequence repeats a residue mod p (e.g. 28! ≡ 50! ≡ … ≡ 555! mod 599, nine values; for p=3011 the shared residue is 1). These congruences explain why each interval product collapses to 1.",
+      "mathContext": "$b! \\equiv a! \\pmod{p} \\iff \\prod_{n=a}^{b-1} n \\equiv 1 \\pmod{p}$; a residue class of size $k{+}1$ in $\\{n! \\bmod p\\}$ yields a $k$-interval solution."
     },
     {
       "id": "summary",
-      "title": "Part VII: Summary Theorems",
-      "startLine": 221,
-      "endLine": 227,
-      "summary": "`erdos_1056_new_solutions`: ExistsSolution 4 ∧ ExistsSolution 5 ∧ ExistsSolution 6. `wilson_constraints_verified`: collects Wilson's theorem for all four primes.",
-      "mathContext": "Main result: solutions exist for all $2 \\leq k \\leq 6$, extending Erdős (k=2) and Makowski (k=3)."
+      "title": "Part VII — Summary of New Results",
+      "startLine": 423,
+      "endLine": 446,
+      "summary": "`erdos_1056_new_solutions` collects ExistsSolution 4 through ExistsSolution 9 (the six new k-values beyond Erdős's k=2 and Makowski's k=3), and `wilson_constraints_verified` bundles Wilson's theorem for all seven solution primes. Closes the namespace.",
+      "mathContext": "Main result: solutions exist for all $2 \\leq k \\leq 9$, extending Erdős (k=2, 1979) and Makowski (k=3, 1983) with six new computationally-verified cases."
     }
   ],
   "conclusion": {
-    "summary": "OQ-01 computationally verifies new solutions to Erdős Problem #1056 for k=4, k=5, k=6, k=7, and k=8, with 52 theorems, 0 sorries, 0 axioms. The k=4 solution uses p=23, k=5,6 use p=71 with the same boundary points, k=7 uses p=673, and k=8 uses p=599 (the smallest prime giving k=8).",
-    "implications": "The existence of solutions for k up to 8 strongly suggests (but does not prove) solutions exist for all k. The smallest-prime sequence (k → p_min(k)) so far reads 11, 17, 23, 71, 71, 673, 599 — non-monotonic in k=8 because going from k=7 to k=8 admits a smaller prime. Finding such 'reversals' empirically is unusual and may suggest structure in the distribution of factorial residue classes mod p.",
+    "summary": "OQ-01 computationally verifies new solutions to Erdős Problem #1056 for k=4 through k=9, with 65 theorems, 0 sorries, 0 axioms. The k=4 solution uses p=23, k=5,6 use p=71 with the same boundary points, k=7 uses p=673, k=8 uses p=599 (the smallest prime giving k=8), and k=9 uses p=3011.",
+    "implications": "The existence of solutions for k up to 9 strongly suggests (but does not prove) solutions exist for all k. The smallest-prime sequence (k → p_min(k)) so far reads 11, 17, 23, 71, 71, 673, 599, 3011 — non-monotonic at k=8 because going from k=7 to k=8 admits a smaller prime. Finding such 'reversals' empirically is unusual and may suggest structure in the distribution of factorial residue classes mod p.",
     "openQuestions": [
       "Do solutions exist for all k ≥ 2?",
       "What is the smallest prime p admitting a k-interval solution for each k?",


### PR DESCRIPTION
## Summary

Both the `sections` array and much of the overview/conclusion prose in `erdos-1056-oq-01/meta.json` were authored for an older revision of `Proofs/Erdos1056OQ01.lean` that only reached **k=8 with 52 theorems**. The current file extends to **k=9 (p=3011) with 65 theorems**.

The old sections had wrong **titles and line ranges** (e.g. "Part III: k=4 Solution (p=23)" pointed at 104-118), covered only to line **227 of 446**, and omitted the entire k=7/8/9 interval verifications, combined solutions, and factorial patterns.

## Changes

- Rebuilt **8 sections** aligned to the file's own **Part I-VII** banners; now contiguous, covering lines 1-446 (added a header section).
- Surfaced the previously-hidden k=7/8/9 content (interval verifications, combined solution theorems, factorial patterns).
- **Fixed stale prose** that contradicted the current source:
  - `conclusion.summary` / `implications`: k≤8 → k≤9, 52 → 65 theorems, p_min sequence now includes 3011.
  - `proofStrategy`: `erdos_k8`→`erdos_k9`, `all_solutions_2_to_8`→`2_to_9`, high-k discussion now covers k=9.
  - `keyInsights`: added a k=9 insight and corrected "52 theorems" → "65 theorems".

Counts (65 theorems / 10 definitions / 0 axioms / 0 sorries) verified correct against the source.

## Validation

`pnpm research:build` exits 0 (accepts meta.json). Full `pnpm build` is not runnable in the linked worktree (no local node_modules for the `tsc`/`vite` step); per-proof JSON is fetched at runtime so that step does not affect this metadata change.