### PR TITLE
Fix: honest claims for four-color-theorem-oq-01 metadata

### DIFF
--- a/src/data/proofs/four-color-theorem-oq-01/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-01/meta.json
@@ -35,14 +35,15 @@
       }
     ],
     "originalContributions": [
-      "Formal proof that degree < k guarantees a free color (no swaps needed)",
-      "Kempe chain interference theorem for 4-color attempts",
-      "Structural comparison: why 5-color Kempe works but 4-color fails",
-      "Heawood crossing obstruction formalization"
+      "Color-swap preserves proper coloring (swapColors_proper) — fully formalized",
+      "Degree < k guarantees a free color, no swap needed (free_color_of_degree_lt) — fully formalized",
+      "Kempe chain interference obstruction (chain_interference_obstruction): after a (c₁,c₃)-swap a shared chain vertex leaves the {c₂,c₃} chain — fully formalized",
+      "Structural contrast between the 5-color and 4-color Kempe arguments, illustrated via counting/arithmetic witnesses (e.g. C(5,2) > C(4,2)), not the full geometric proof",
+      "Heawood crossing scenario stated with a placeholder hypothesis (paths_in_plane : True); the Jordan-curve crossing argument is described in prose, not formalized"
     ],
     "dateAdded": "2026-03-28",
     "axiomCount": 0,
-    "assumptions": "0 axioms. 0 sorries. All results fully proved.",
+    "assumptions": "0 axioms. 0 sorries. The graph-coloring lemmas (color-swap preserves proper coloring, free-color-from-low-degree, Kempe chain interference) are fully proved. The deep geometric facts — notably the Jordan-curve crossing that forces two Kempe chains to intersect — are illustrated via trivial arithmetic witnesses or a `True` placeholder hypothesis, not formalized. This is an exploratory entry; see the 'What a Human-Readable 4CT Proof Would Need' section.",
     "proofRepoPath": "Proofs/FourColorTheoremOQ01.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 458,


### PR DESCRIPTION
## Fix

Reword `assumptions` and `originalContributions` in `four-color-theorem-oq-01`'s meta.json so they no longer present trivial/vacuous theorems as deep formalizations. Metadata-only; no Lean changes.

## Evidence

**Before**
- `assumptions`: "0 axioms. 0 sorries. All results fully proved."
- `originalContributions` listed "Heawood crossing obstruction formalization" and "Kempe chain interference theorem", which read as if those obstructions are formalized.

But in `FourColorTheoremOQ01.lean`:
- `heawood_crossing_forced` takes a vacuous `(paths_in_plane : True)` and concludes its `Bool` hypotheses directly — the Jordan-curve crossing is asserted, not formalized.
- `four_color_degree_five_pigeonhole` proves `min 5 4 = 4` (`rfl`); `kempe_four_color_structure` proves `5 - 4 = 1`; `five_color_no_double_swap` proves `C(5,2) > C(4,2)`.

**After**
- `assumptions` distinguishes the genuinely proved graph-coloring lemmas (color-swap preserves proper coloring, free-color-from-low-degree, Kempe chain interference) from the deep geometric facts that are only illustrated via trivial witnesses / a `True` placeholder, and notes the exploratory framing.
- `originalContributions` names the genuinely formalized lemmas (`swapColors_proper`, `free_color_of_degree_lt`, `chain_interference_obstruction`) and qualifies the structural-contrast and Heawood-crossing items as illustrative.

Genuine content (`swapColors_proper`, `free_color_of_degree_lt`, `chain_interference_obstruction`) is preserved and credited; `status`/`badge`/counts are unchanged (the auditor recommended no Lean changes).

Closes #23606

---
Automated fix by lean-mechanic agent.