### PR TITLE
research(picks-cross-poly): fix overlapping gallery sections + add header (7→8)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json
@@ -47,52 +47,74 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring for cross-polytope (hyperoctahedron) Ehrhart theory, the OQ-03 follow-up to Pick's theorem in higher dimensions: lists the key results (Ehrhart polynomials L_{β_d}, volumes 2^d/d!, interior counts, Ehrhart-Macdonald reciprocity, palindromic h*-vectors, reflexivity, cube duality, recurrences) and references. Opens `namespace CrossPolytopeEhrhart`.",
+      "mathContext": "Cross-polytope $\\beta_d = \\{x \\in \\mathbb{R}^d : \\sum |x_i| \\le 1\\}$, the polar dual of the cube $\\square_d$. The file develops its Ehrhart theory concretely for $d = 1, 2, 3$.",
+      "relatedConcepts": [],
+      "prerequisites": []
+    },
+    {
       "id": "ehrhart-polynomials",
       "title": "Parts 1–2: Ehrhart Polynomials and Evaluations",
       "startLine": 36,
-      "endLine": 153,
+      "endLine": 110,
       "summary": "Defines cross_d_L for d=1,2,3. Verifies L(0)=1, L(1)=2d+1, and further values by norm_num. All 3 polynomials stated and verified.",
-      "mathContext": "$L_{\\beta_1}(n)=2n+1$, $L_{\\beta_2}(n)=2n^2+2n+1$, $L_{\\beta_3}(n)=\\tfrac{4}{3}n^3+2n^2+\\tfrac{8}{3}n+1$."
+      "mathContext": "$L_{\\beta_1}(n)=2n+1$, $L_{\\beta_2}(n)=2n^2+2n+1$, $L_{\\beta_3}(n)=\\tfrac{4}{3}n^3+2n^2+\\tfrac{8}{3}n+1$.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "volume",
       "title": "Part 3: Volume and Leading Coefficient",
       "startLine": 111,
-      "endLine": 204,
+      "endLine": 152,
       "summary": "Proves vol(β_1)=2, vol(β_2)=2, vol(β_3)=4/3. Shows leading coefficient of L_{β_d}(n) equals vol(β_d) = 2^d/d!.",
-      "mathContext": "$\\text{vol}(\\beta_d) = 2^d/d!$: $d=1: 2$, $d=2: 2$, $d=3: 4/3$."
+      "mathContext": "$\\text{vol}(\\beta_d) = 2^d/d!$: $d=1: 2$, $d=2: 2$, $d=3: 4/3$.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "interior",
       "title": "Part 4: Interior Ehrhart Polynomials",
       "startLine": 153,
-      "endLine": 238,
+      "endLine": 203,
       "summary": "Defines L*(n) = L(n-1) for all three cross-polytopes. Verifies L*(0)=0, L*(1)=1 (unique interior point = origin). Proves interior counts.",
-      "mathContext": "$L^*_{\\beta_d}(n) = L_{\\beta_d}(n-1)$. The only interior lattice point of $\\beta_d$ is the origin."
+      "mathContext": "$L^*_{\\beta_d}(n) = L_{\\beta_d}(n-1)$. The only interior lattice point of $\\beta_d$ is the origin.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "reciprocity",
       "title": "Part 5: Ehrhart-Macdonald Reciprocity",
       "startLine": 204,
-      "endLine": 287,
+      "endLine": 237,
       "summary": "Verifies L*(n) = (-1)^d·L(-n) for d=1,2,3 by ring arithmetic. Core identity of Ehrhart theory for reflexive polytopes.",
-      "mathContext": "$L^*(n) = (-1)^d L(-n)$. For $d=1$: $L^*(n)=2n-1=-(2(-n)+1)$."
+      "mathContext": "$L^*(n) = (-1)^d L(-n)$. For $d=1$: $L^*(n)=2n-1=-(2(-n)+1)$.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "hstar-vectors",
       "title": "Parts 6–7: h*-Vectors and Palindromy",
       "startLine": 238,
-      "endLine": 373,
+      "endLine": 326,
       "summary": "Computes h*-vectors: β₁: (1,1), β₂: (1,2,1), β₃: (1,3,3,1). Verifies palindromy and the identity h*(1) = 2^d = d!·vol(β_d).",
-      "mathContext": "$h^*_{\\beta_d}(z) = (1+z)^d$. Palindromy: $h^*_i = h^*_{d-i}$ — confirming reflexivity."
+      "mathContext": "$h^*_{\\beta_d}(z) = (1+z)^d$. Palindromy: $h^*_i = h^*_{d-i}$ — confirming reflexivity.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "reflexivity-duality",
       "title": "Parts 8–9: Reflexivity and Cube Duality",
       "startLine": 327,
-      "endLine": 451,
+      "endLine": 415,
       "summary": "Proves β₁ is self-dual (β₁ = □₁). Shows β₂ Ehrhart ≠ □₂ Ehrhart. Duality: β_d is the polar dual of the hypercube □_d.",
-      "mathContext": "$\\text{vol}(\\beta_d)\\cdot\\text{vol}(\\square_d) = 4^d/d!$."
+      "mathContext": "$\\text{vol}(\\beta_d)\\cdot\\text{vol}(\\square_d) = 4^d/d!$.",
+      "relatedConcepts": [],
+      "prerequisites": []
     },
     {
       "id": "recurrence-and-structure",
@@ -100,7 +122,9 @@
       "startLine": 416,
       "endLine": 695,
       "summary": "Dimension recurrence for L_{β_d}(n). Monotonicity L(n+1) > L(n). Boundary B(1)=2d. Second coefficient = half surface volume. Ehrhart series numerator h*(z) = (1+z)^d via binomial expansion.",
-      "mathContext": "$h^*_{\\beta_d}(z) = \\sum_{k=0}^d \\binom{d}{k} z^k = (1+z)^d$ — the cleanest identity in cross-polytope Ehrhart theory."
+      "mathContext": "$h^*_{\\beta_d}(z) = \\sum_{k=0}^d \\binom{d}{k} z^k = (1+z)^d$ — the cleanest identity in cross-polytope Ehrhart theory.",
+      "relatedConcepts": [],
+      "prerequisites": []
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Metadata-only realignment of `src/data/proofs/picks-theorem-oq-03-cross-poly/meta.json`.

The gallery `sections` array for `PicksTheoremOQ03CrossPoly.lean` (cross-polytope Ehrhart theory) had **systematically overlapping line ranges** — every one of the 7 sections overshot its endLine into the next section's territory, so the boundaries no longer matched the file's `-- PART N` banner structure. Lines 1–35 (module docstring + `namespace`) were also uncovered.

This was invisible to tail-coverage scanners (maxEnd 695 already equalled the 695-line file); it only shows up as internal overlap.

## Changes
- Re-tiled the existing 7 section groupings (Parts 1–2, 3, 4, 5, 6–7, 8–9, 10–15) to be **contiguous and non-overlapping**, aligned to the actual `-- PART` banners.
- **Prepended a header section** (lines 1–35) → 7→8 sections, full-file coverage 1–695.
- Section summaries and `mathContext` preserved verbatim.

## Verification
- `jq empty` passes (valid JSON).
- Contiguity check: no overlaps, no internal gaps, `maxEnd == lineCount == 695`.
- Counts unchanged and already correct: 0 axioms, 69 theorems, 12 defs, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)