### PR TITLE
research(erdos-931): realign drifted gallery sections to full file (10→15)

### DIFF
--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -114,17 +114,57 @@
       "id": "sec-931-bertrand",
       "title": "Bertrand's Postulate and Prime Between Blocks",
       "startLine": 208,
-      "endLine": 277,
+      "endLine": 284,
       "summary": "NEW: Four theorems using Bertrand's postulate. (1) If the first block contains a prime, a prime exists in range (trivial). (2) By Bertrand, when k₁ ≥ n₁ the first block always has a prime. (3) Combined: exists_prime_between_blocks holds for k₁ ≥ n₁ without SamePrimeFactors. (4) If the first product has a large prime factor, SamePrimeFactors transfers it to bound q ≤ n₂+k₂ via Prime.dvd_finset_prod_iff.",
       "mathContext": "NEW: Four theorems using Bertrand's postulate. (1) If the first block contains a prime, a prime exists in range (trivial). (2) By Bertrand, when k₁ ≥ n₁ the first block always has a prime. (3) Combined: exists_prime_between_blocks holds for k₁ ≥ n₁ without SamePrimeFactors."
     },
     {
       "id": "sec-931-prime-between-proof",
       "title": "Prime Between Blocks: Proved from Refined Axiom",
-      "startLine": 274,
-      "endLine": 330,
-      "summary": "The general exists_prime_between_blocks statement is now a THEOREM proved by 4-way case analysis: (1) k₁≥n₁ via Bertrand, (2) n₂+k₂≥2n₁ via Bertrand, (3) large prime factor transfer via SamePrimeFactors, (4) refined axiom for the hard case (k₁<n₁, tight gap, all factors ≤n₁). The hard-case axiom is strictly weaker than the original, with 3 additional hypotheses constraining when Størmer-type smooth number theory is needed.",
-      "mathContext": "The general exists_prime_between_blocks statement is now a THEOREM proved by 4-way case analysis. Only the hard case (k₁<n₁, n₂+k₂<2n₁, all prime factors ≤n₁) remains as an axiom. This case forces both blocks to be n₁-smooth, making it likely vacuously true by Størmer-type results."
+      "startLine": 285,
+      "endLine": 345,
+      "summary": "The general exists_prime_between_blocks statement is a THEOREM proved by 4-way case analysis: (1) k₁≥n₁ via Bertrand, (2) n₂+k₂≥2n₁ via Bertrand, (3) large prime factor transfer via SamePrimeFactors, (4) the refined hard case (k₁<n₁, tight gap, all factors ≤n₁) discharged by exists_prime_between_blocks_hard, a theorem-with-sorry (formerly axiom) strictly weaker than the original with 3 additional constraining hypotheses.",
+      "mathContext": "The general exists_prime_between_blocks statement is proved by 4-way case analysis. Only the hard case (k₁<n₁, n₂+k₂<2n₁, all prime factors ≤n₁) remains a sorry-stated theorem. This case forces both blocks to be n₁-smooth, making it likely vacuously true by Størmer-type results."
+    },
+    {
+      "id": "sec-931-structural-lemmas",
+      "title": "Structural Lemmas",
+      "startLine": 346,
+      "endLine": 380,
+      "summary": "After 'Problem Status' and 'Structural Lemmas' markers: exists_multiple_in_block (among k consecutive integers, one is divisible by any d ≤ k), prime_le_k_mem_factors (every prime p ≤ k is a prime factor of the block product), and two_mem_factors (2 is a factor when k ≥ 2). Proved via division/modular arithmetic and omega.",
+      "mathContext": "Mathematical content: exists_multiple_in_block (among k consecutive integers, one is divisible by any d ≤ k), prime_le_k_mem_factors (every prime p ≤ k is a prime factor of the block product), and two_mem_factors. Proved via division/modular arithmetic and omega."
+    },
+    {
+      "id": "sec-931-hard-case-composite",
+      "title": "Hard Case Structure: Both Blocks Are Entirely Composite",
+      "startLine": 382,
+      "endLine": 465,
+      "summary": "In the hard case (k₁<n₁, n₂+k₂<2n₁, all prime factors ≤n₁), four theorems show both blocks consist entirely of composites: hard_case_first_block_composite, hard_case_second_block_composite (via SamePrimeFactors), hard_case_second_block_smooth (every prime factor of the second product ≤n₁), and hard_case_summary collecting all structural constraints.",
+      "mathContext": "Mathematical content: hard_case_first_block_composite, hard_case_second_block_composite (via SamePrimeFactors), hard_case_second_block_smooth, and hard_case_summary. Both blocks are forced to be n₁-smooth composites, the core structural constraint of the hard case."
+    },
+    {
+      "id": "sec-931-hard-case-lower-bound",
+      "title": "Hard Case: Lower Bound on n₁",
+      "startLine": 467,
+      "endLine": 483,
+      "summary": "The hard-case constraints k₁<n₁, k₁≥k₂≥3, n₁+k₁≤n₂, and n₂+k₂<2n₁ force n₁≥k₁+k₂+1≥7. hard_case_n1_lower_bound and hard_case_n2_range (the valid range [n₁+k₁, 2n₁−k₂−1] for n₂ is non-empty), both by omega.",
+      "mathContext": "Mathematical content: hard_case_n1_lower_bound (n₁ ≥ k₁+k₂+1 ≥ 7) and hard_case_n2_range (valid n₂ range [n₁+k₁, 2n₁−k₂−1] is non-empty), both discharged by omega."
+    },
+    {
+      "id": "sec-931-hard-case-no-prime",
+      "title": "Hard Case: No Prime in First Block",
+      "startLine": 485,
+      "endLine": 517,
+      "summary": "Since all prime factors of the first product are ≤n₁, there is no prime in {n₁+1,...,n₁+k₁}: hard_case_no_prime_in_first_block derives False from a prime in the block, and hard_case_next_prime_beyond_block concludes the next prime after n₁ must exceed n₁+k₁.",
+      "mathContext": "Mathematical content: hard_case_no_prime_in_first_block (a prime in the first block contradicts h₇) and hard_case_next_prime_beyond_block (the next prime after n₁ exceeds n₁+k₁). Combined with Bertrand this places the next prime in (n₁+k₁, 2n₁]."
+    },
+    {
+      "id": "sec-931-hard-case-computational",
+      "title": "Hard Case: Computational Verification for Small n₁",
+      "startLine": 519,
+      "endLine": 540,
+      "summary": "hard_case_vacuous_k3_n30: for k₁=k₂=3 and n₁∈[7,30], no valid hard-case instance exists — for every n₂∈[n₁+3, 2n₁−4] either the first block has a prime factor >n₁ or SamePrimeFactors fails. Proved by native_decide, giving empirical evidence the hard case is vacuously true.",
+      "mathContext": "Mathematical content: hard_case_vacuous_k3_n30 verifies via native_decide that for k₁=k₂=3 and n₁∈[7,30] the hard-case hypotheses are never simultaneously satisfiable, evidence that the remaining sorry-stated hard case is vacuously true."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The erdos-931 gallery meta described only the first 330 lines of the 540-line `Erdos931Problem.lean`, hiding the entire hard-case analysis (~210 lines / 6 banner sections) and leaving an overlapping section boundary.

- Sections **10 → 15**, now covering lines 1–540 contiguously
- Fixed the overlapping Bertrand / prime-between boundary (`208-277` + `274-330` → `208-284` + `285-345`)
- Restored 6 hidden sections: Structural Lemmas, Hard Case Structure (both blocks composite), Hard Case Lower Bound on n₁, Hard Case No Prime in First Block, and Hard Case Computational Verification (`hard_case_vacuous_k3_n30`)

Counts (46 thm / 5 def / 0 axiom / 2 sorry / 540 LC) were already correct — this is a sections-only realignment.

## Test plan
- [x] `pnpm research:build` exits 0
- [x] Sections cover full file 1–540, no overlaps or start>end
- [x] No open PR touches `src/data/proofs/erdos-931/meta.json`