### PR TITLE
research(erdos-783): realign drifted sections to full file (8→8) + fix stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -32,78 +32,78 @@
       "id": "imports",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 26,
-      "summary": "Problem statement, conjecture description, and Mathlib import.",
-      "mathContext": "Mathematical content: Problem statement, conjecture description, and Mathlib import."
+      "endLine": 30,
+      "summary": "Header stating Erdős #783 (optimal coprime sieving under a reciprocal-sum budget C), the conjecture that the largest k primes are optimal, status OPEN, and `import Mathlib`. maxPrimeCount and maxPrimeCount_spec, once axioms, are now proved from Mathlib's prime reciprocal divergence — the file is axiom-free.",
+      "mathContext": "Problem statement, conjecture, OPEN status, imports."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 27,
-      "endLine": 59,
-      "summary": "Defines `IsValidSievingSet` (coprime elements with reciprocal sum budget), `unsievedCount` (integers surviving the sieve), and proves existence of an optimal set via `Nat.find` (well-ordering of ℕ).",
-      "mathContext": "Defines `IsValidSievingSet` (coprime elements with reciprocal sum budget), `unsievedCount` (integers surviving the sieve), and proves existence of an optimal set via `Nat.find` (well-ordering of $\\mathbb{N}$)."
-    },
-    {
-      "id": "prime-infrastructure",
-      "title": "Prime Number Infrastructure",
-      "startLine": 60,
-      "endLine": 95,
-      "summary": "Defines `nthPrime` via Mathlib's `Nat.nth Nat.Prime` with proved primality, strict monotonicity, injectivity, and coprimality of distinct primes. All previously axiomatized — now fully proved.",
-      "mathContext": "Formal definition: Defines `nthPrime` via Mathlib's `Nat.nth Nat.Prime` with proved primality, strict monotonicity, injectivity, and coprimality of distinct primes. All previously axiomatized — now fully proved."
+      "startLine": 31,
+      "endLine": 63,
+      "summary": "Defines `IsValidSievingSet` (pairwise-coprime elements with reciprocal sum ≤ C), `unsievedCount` (integers ≤ n surviving the sieve), and proves `optimal_sieving_set_exists` (an unsieved-count-minimizing valid set exists, via `Nat.find` / well-ordering of ℕ).",
+      "mathContext": "Valid sieving set, unsieved count, existence of an optimum."
     },
     {
       "id": "prime-sieving-set",
-      "title": "Prime Sieving Set",
-      "startLine": 96,
-      "endLine": 144,
-      "summary": "Constructs `primeSievingSet` as the first $k$ primes. Proves cardinality, all-prime, $\\geq 2$, pairwise coprime, and reciprocal sum bound properties. Axiomatizes `maxPrimeCount` for budget-constrained $k$.",
-      "mathContext": "Constructs `primeSievingSet` as the first $k$ primes. Proves cardinality, all-prime, $\\geq 2$, pairwise coprime, and reciprocal sum bound properties. Axiomatizes `maxPrimeCount` for budget-constrained $k$."
+      "title": "The Prime Sieving Set",
+      "startLine": 64,
+      "endLine": 131,
+      "summary": "Defines `nthPrime` via `Nat.nth Nat.Prime` with proved primality, strict monotonicity, injectivity, and pairwise coprimality of distinct primes; constructs `primeSievingSet` as the first k primes and proves its cardinality, all-prime, ≥2, and pairwise-coprime properties. All proved (no axioms).",
+      "mathContext": "nth prime infrastructure and the prime sieving set, fully proved."
     },
     {
-      "id": "validity",
-      "title": "Validity Proof",
-      "startLine": 145,
-      "endLine": 158,
-      "summary": "Proves the prime sieving set is a valid sieving set for large enough $n$, assembling range, coprimality, and budget conditions.",
-      "mathContext": "Verified: Proves the prime sieving set is a valid sieving set for large enough $n$, assembling range, coprimality, and budget conditions."
+      "id": "maxprimecount-construction",
+      "title": "Constructing maxPrimeCount from Prime Reciprocal Divergence",
+      "startLine": 132,
+      "endLine": 263,
+      "summary": "Uses Mathlib's `not_summable_one_div_on_primes` (Euler) to show partial sums of prime reciprocals are unbounded, letting `maxPrimeCount C` be defined by `Nat.find` rather than axiomatized. Proves `maxPrimeCount_spec`, `primeSievingSet_reciprocal_sum`, and `primeSievingSet_valid` (the prime set is valid for large n). Replaces the former axiomatization of maxPrimeCount.",
+      "mathContext": "Divergence bridge defining maxPrimeCount; validity of the prime sieve."
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture (OPEN)",
-      "startLine": 159,
-      "endLine": 168,
-      "summary": "Erdős Problem #783: the prime sieving set minimizes unsieved count among all valid sets for large $n$.",
-      "mathContext": "Mathematical content: Erdős Problem #783: the prime sieving set minimizes unsieved count among all valid sets for large $n$."
+      "title": "The Main Conjecture (OPEN)",
+      "startLine": 264,
+      "endLine": 268,
+      "summary": "States Erdős Problem #783: for large n the first k = maxPrimeCount C primes minimize the unsieved count among all valid sieving sets. This is the open conjecture (documented, not assumed as an axiom).",
+      "mathContext": "The open optimality statement."
     },
     {
-      "id": "analysis",
+      "id": "supporting-analysis",
       "title": "Supporting Analysis",
-      "startLine": 169,
-      "endLine": 187,
-      "summary": "Proved coprime sieve estimate (trivially: ∃ δ with no bound). Axiomatized: primes minimize the survival product $\\prod(1-1/a)$.",
-      "mathContext": "Axiomatized: Proved coprime sieve estimate (trivially: ∃ δ with no bound). Axiomatized: primes minimize the survival product $\\prod(1-1/a)$."
+      "startLine": 269,
+      "endLine": 282,
+      "summary": "Proves `coprime_sieve_estimate` relating the unsieved fraction to the survival product Π(1 − 1/a); the formal statement is deliberately weak (∃ δ with no bound on δ), serving as documentation of the inclusion-exclusion heuristic rather than a sharp estimate.",
+      "mathContext": "Inclusion-exclusion survival-product heuristic (weak form)."
     },
     {
-      "id": "baseline",
+      "id": "empty-sieve-baseline",
       "title": "Empty Sieve Baseline and Monotonicity",
-      "startLine": 188,
-      "endLine": 226,
-      "summary": "Proves the empty sieve is valid with unsieved count $= n$, and that adding any element $\\geq 2$ reduces the unsieved count (proved via filter monotonicity).",
-      "mathContext": "Verified: Proves the empty sieve is valid with unsieved count $= n$, and that adding any element $\\geq 2$ reduces the unsieved count (proved via filter monotonicity)."
+      "startLine": 283,
+      "endLine": 320,
+      "summary": "Proves `empty_is_valid` (the empty set is a valid sieve), `unsievedCount_empty` (unsieved count = n with no sieve), and `sieving_reduces_unsieved` (adding any element ≥2 reduces the unsieved count, via filter monotonicity).",
+      "mathContext": "Baseline empty sieve and sieve monotonicity."
+    },
+    {
+      "id": "infrastructure-minimize",
+      "title": "Infrastructure for primes_minimize_product",
+      "startLine": 321,
+      "endLine": 420,
+      "summary": "Proves the product-minimization infrastructure: `sieve_factor_bounds`/`sieve_factor_mono`, `prime_factor_better_sieve`, `sieve_product_pos`, `erase_increases_product`, `smaller_prime_better`, and `composite_replacement_improves_product` — replacing a composite by a prime factor improves the survival product Π(1 − 1/a). All proved (formerly the 'primes minimize product' axiom).",
+      "mathContext": "Lemmas showing primes minimize the survival product, fully proved."
     }
   ],
   "overview": {
     "historicalContext": "Erdős posed this sieve optimization problem in 1973, asking for the best way to eliminate integers using a coprime sieving set with a bounded reciprocal sum. The problem sits at the intersection of sieve theory and combinatorial optimization. Classical sieve methods — the sieve of Eratosthenes (antiquity), Brun's sieve (1919), and Selberg's sieve (1947) — focus on asymptotic estimates for counts of integers surviving a sieve. Erdős's problem instead asks an exact optimality question: given a 'budget' $C$ constraining $\\sum 1/a_i$, which coprime set maximizes the fraction of integers eliminated? The conjecture that the first $k$ primes are optimal is supported by the inclusion-exclusion identity for coprime moduli (related to the Chinese remainder theorem) and Mertens' theorem ($\\prod_{p \\leq x}(1 - 1/p) \\sim e^{-\\gamma}/\\ln x$), which shows primes are asymptotically efficient sieves.",
     "problemStatement": "Given $C > 0$ and large $n$, which pairwise coprime set $A \\subseteq \\{2, \\ldots, n\\}$ with $\\sum_{a \\in A} 1/a \\leq C$ minimizes $|\\{m \\leq n : \\forall a \\in A,\\; a \\nmid m\\}|$? Conjecture: the first $k$ primes, where $k$ is maximal with $\\sum_{i=1}^k 1/p_i \\leq C$.",
     "text": "Given budget C on reciprocal sums, which pairwise coprime A ⊆ {2,...,n} minimizes unsieved integers? Conjectured: first k primes with Σ 1/p_i ≤ C. Status: OPEN.",
-    "proofStrategy": "The formalization builds a complete framework: (1) precise definitions of valid sieving sets and the unsieved count; (2) axiomatized prime infrastructure with proved injectivity and coprimality; (3) the prime sieving set as a concrete Finset construction; (4) proved validity of the prime set; (5) the main conjecture as an axiom; (6) the inclusion-exclusion estimate connecting unsieved count to the survival product; (7) the axiom that primes minimize this product; (8) baseline results for the empty sieve and monotonicity of the sieve function.",
+    "proofStrategy": "The formalization builds a complete framework: (1) precise definitions of valid sieving sets and the unsieved count; (2) proved prime infrastructure (primality, injectivity, pairwise coprimality of distinct primes); (3) the prime sieving set as a concrete Finset construction; (4) proved validity of the prime set, with maxPrimeCount constructed — not axiomatized — from Mathlib’s prime reciprocal divergence; (5) the main conjecture stated as an open question; (6) the inclusion-exclusion estimate connecting unsieved count to the survival product; (7) proved lemmas showing primes minimize this product (composite_replacement_improves_product); (8) baseline results for the empty sieve and monotonicity of the sieve function. The file is axiom-free (0 axioms, 0 sorries).",
     "keyInsights": [
       "For coprime moduli, the Chinese remainder theorem makes inclusion-exclusion exact: the unsieved fraction is $\\prod_{a \\in A}(1 - 1/a)$ plus a bounded error, so minimizing the unsieved count reduces to minimizing this product",
       "Primes are optimal because replacing a composite $a$ with a prime divisor $p$ reduces the budget ($1/p < 1/a$ is wrong — actually $1/p > 1/a$) while improving sieving power: $p$ sieves $n/p$ integers vs $a$ sieving $n/a < n/p$, giving better return per unit budget",
       "The coprimality constraint is essential: without it, one could use $\\{2, 4, 8, \\ldots\\}$ which has small reciprocal sum but wastes budget on multiples already sieved by 2",
       "Mertens' theorem gives $\\prod_{p \\leq x}(1-1/p) \\sim e^{-\\gamma}/\\ln x$, showing that prime reciprocal sums grow like $\\ln\\ln x$ — so the budget $C$ determines roughly which primes fit",
-      "The monotonicity axiom (adding elements only helps) combined with the product minimization axiom gives a two-part strategy: use all your budget, and use it on primes",
+      "Sieve monotonicity (adding elements only reduces the unsieved count, sieving_reduces_unsieved) combined with product minimization (composite_replacement_improves_product) gives a two-part strategy: use all your budget, and use it on primes",
       "The 'large $n$' condition in the conjecture handles the edge case where some primes exceed $n$; for $n$ large enough, all first-$k$ primes fit in $\\{2, \\ldots, n\\}$"
     ],
     "prerequisites": [


### PR DESCRIPTION
## Summary
Gallery metadata for **erdos-783** (optimal coprime sieving under a reciprocal-sum budget) had drifted from `Proofs/Erdos783Problem.lean` (420 lines, axiom-free):

- **Section coverage** stopped at line 226 of 420 with labels/ranges from an older revision. The back-half banner `## Infrastructure for primes_minimize_product` (line 321) was entirely uncovered. Realigned all 8 sections to the file's actual `/- ## -/` banners for full 1-420 coverage.
- **Stale axiom prose** removed: `overview.proofStrategy`, `overview.keyInsights`, and several section summaries described "axiomatized prime infrastructure", "the main conjecture as an axiom", and "monotonicity/product-minimization axioms". The file is now **axiom-free** — `maxPrimeCount` is constructed via `Nat.find` from Mathlib's `not_summable_one_div_on_primes`, and the primes-minimize-product lemmas (`composite_replacement_improves_product`, `smaller_prime_better`, …) are all proved.

## Verification
- Section ranges match `/- ## … -/` banners in source.
- Counts unchanged and correct: 0 axioms, 31 theorems, 6 definitions, 0 sorries, lineCount 420. `meta.axiomCount`/`assumptions` were already accurate (0 axioms).
- Metadata-only change; no Lean source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)