### PR TITLE
research(erdos-533): rebuild drifted gallery sections to current file

### DIFF
--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -48,84 +48,84 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Mathlib Imports",
-      "startLine": 17,
-      "endLine": 21,
-      "summary": "Imports Finset, Nat, Real, and tactic libraries for graph definitions.",
-      "mathContext": "Formal definition: Imports Finset, Nat, Real, and tactic libraries for graph definitions."
+      "id": "problem-statement",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Erdős #533: if a graph G on n vertices is K₅-free and has at least δn² edges (any δ > 0), must G contain a triangle-free induced subgraph on ≫_δ n vertices? Records the known results — true for δ > 1/16 (Erdős–Hajnal–Simonovits–Sós–Szemerédi), true for K₄-free at all δ > 0, and false for K₇-free at δ = 1/4 (Erdős–Rogers). Status: OPEN.",
+      "mathContext": "Does $K_5$-freeness plus edge density $\\delta n^2$ force a triangle-free induced subgraph on $\\gg_\\delta n$ vertices? Open for $0 < \\delta \\le 1/16$."
     },
     {
-      "id": "graph-defs",
-      "title": "Graph Structure Definitions",
-      "startLine": 22,
-      "endLine": 37,
-      "summary": "Defines SGraph (simple graph), IsClique, and HasClique for clique existence.",
-      "mathContext": "Formal definition: Defines SGraph (simple graph), IsClique, and HasClique for clique existence."
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 19,
+      "endLine": 49,
+      "summary": "Defines the bespoke SGraph structure (adjacency with symmetry and irreflexivity), IsClique / HasClique, the InducedSubgraph, IsTriangleFree (no 3 distinct mutually-adjacent vertices), and the noncomputable edgeCount as the cardinality of the filtered set of strictly-ordered adjacent pairs.",
+      "mathContext": "$\\mathrm{edgeCount}(G) = |\\{(i,j) : i < j,\\ G.\\mathrm{adj}\\,i\\,j\\}|$; a set $S$ is triangle-free when no three distinct vertices of $S$ are pairwise adjacent."
     },
     {
-      "id": "induced-triangle",
-      "title": "Induced Subgraph and Triangle-Freeness",
-      "startLine": 38,
-      "endLine": 47,
-      "summary": "Defines induced subgraph restriction and IsTriangleFree for vertex subsets.",
-      "mathContext": "Formal definition: Defines induced subgraph restriction and IsTriangleFree for vertex subsets."
-    },
-    {
-      "id": "edge-count",
-      "title": "Edge Counting",
-      "startLine": 48,
-      "endLine": 52,
-      "summary": "Defines noncomputable edgeCount via Finset.filter over ordered pairs.",
-      "mathContext": "Formal definition: Defines noncomputable edgeCount via Finset.filter over ordered pairs."
+      "id": "simplegraph-bridge",
+      "title": "SimpleGraph Bridge",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "Bridges the bespoke SGraph to Mathlib's SimpleGraph via SGraph.toSimpleGraph (adjacency carried verbatim, symmetry and looplessness reused), with a defeq simp lemma identifying the two adjacency relations. This unlocks Mathlib's clique, independent-set, and Ramsey-theory API.",
+      "mathContext": "$G \\mapsto G.\\mathrm{toSimpleGraph}$ is the identity on adjacency, so all Mathlib graph lemmas apply to SGraph."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 53,
-      "endLine": 82,
-      "summary": "Proves basic properties: empty set is a clique/triangle-free, clique size ≤ n, K₅-freeness for small graphs, singleton is triangle-free.",
-      "mathContext": "Proved: isClique_empty, isTriangleFree_empty, hasClique_le_n, k5_free_of_small, isTriangleFree_singleton."
+      "startLine": 64,
+      "endLine": 210,
+      "summary": "Foundational clique and triangle-free lemmas: empty/singleton/pair triviality, subset-closure of both properties, clique monotonicity (hasClique_mono) and its contrapositive upward-closure (not_hasClique_mono), the trivial bound edgeCount ≤ n², and the tight bound edgeCount ≤ n(n-1)/2 proved via the private lemma card_strict_upper_tri (off-diagonal split plus swap symmetry). Concludes that K₅-free implies K₇-free, so the Erdős–Rogers K₇-free counterexample does not obstruct #533.",
+      "mathContext": "Maximum edge count $n(n-1)/2$ via $|\\{i<j\\}| = \\tfrac12|\\{i\\ne j\\}|$; clique-freeness is upward closed, so $\\neg K_5 \\Rightarrow \\neg K_7$."
     },
     {
-      "id": "structural-lemmas",
-      "title": "Structural Lemmas",
-      "startLine": 84,
-      "endLine": 134,
-      "summary": "Proves monotonicity and structural properties: triangle-free subsets, clique subsets, clique monotonicity, 0/1-cliques, pair triangle-freeness, and no-triangle implies all subsets triangle-free.",
-      "mathContext": "Proved: isTriangleFree_subset, isClique_subset, hasClique_mono, hasClique_zero, hasClique_one, isTriangleFree_pair, isTriangleFree_of_no_triangle."
+      "id": "neighborhood-structure",
+      "title": "Neighborhood Structure",
+      "startLine": 211,
+      "endLine": 268,
+      "summary": "Defines the open neighborhood and degree, then proves the pivotal structural fact: a clique contained in N(v) extends to a clique containing v (clique_in_neighborhood_extends), hence in a K₅-free graph every vertex neighborhood is K₄-free (neighborhood_k4_free / neighborhood_hasClique_4_false). This is the local reduction from K₅-freeness to K₄-freeness driving the proposed strategy.",
+      "mathContext": "If $S \\subseteq N(v)$ is a clique then $S \\cup \\{v\\}$ is a clique, so a $K_4$ in $N(v)$ would give a $K_5$ in $G$; thus $N(v)$ is $K_4$-free."
     },
     {
-      "id": "ehsss",
-      "title": "EHSSS Partial Result",
-      "startLine": 136,
-      "endLine": 144,
-      "summary": "Records the δ > 1/16 result for K₅-free graphs with linear-size triangle-free subsets.",
-      "mathContext": "Mathematical content: Records the δ > 1/16 result for K₅-free graphs with linear-size triangle-free subsets."
+      "id": "turan-bounds",
+      "title": "Turán-Type Bounds",
+      "startLine": 269,
+      "endLine": 287,
+      "summary": "Axiomatizes Turán's theorem for K₅-free graphs — edgeCount ≤ (3/8)n², tight at the balanced complete 4-partite graph T(n,4) — and derives density_bound_k5_free: the density parameter satisfies δ ≤ 3/8, so Problem 533 need only be settled for δ ∈ (0, 3/8].",
+      "mathContext": "Turán: a $K_{r+1}$-free graph has $\\le (1-1/r)n^2/2$ edges; for $r=4$ this is $(3/8)n^2$, forcing $\\delta \\le 3/8$."
     },
     {
-      "id": "k4-free",
-      "title": "K₄-Free Case",
-      "startLine": 146,
-      "endLine": 152,
-      "summary": "Records that the result holds for all δ > 0 when K₄ is excluded instead of K₅.",
-      "mathContext": "Mathematical content: Records that the result holds for all δ > 0 when K₄ is excluded instead of K₅."
+      "id": "known-partial-results",
+      "title": "Known Partial Results",
+      "startLine": 288,
+      "endLine": 306,
+      "summary": "Encodes the two deep extremal-graph-theory inputs as axioms: the Erdős–Hajnal–Simonovits–Sós–Szemerédi result (for δ > 1/16, a K₅-free δ-dense graph has a triangle-free subset of size ≥ (δ/2)n) and the K₄-free result (for all δ > 0, a K₄-free δ-dense graph has a linear-size triangle-free subset).",
+      "mathContext": "EHSSS handles $\\delta > 1/16$ under $K_5$-freeness; the $K_4$-free case is known for every $\\delta > 0$."
     },
     {
-      "id": "erdos-rogers",
-      "title": "Erdős-Rogers Counterexample",
-      "startLine": 154,
-      "endLine": 161,
-      "summary": "Records the K₇-free counterexample showing the result fails at density 1/4.",
-      "mathContext": "Mathematical content: Records the K₇-free counterexample showing the result fails at density 1/4."
+      "id": "partial-resolution",
+      "title": "Partial Resolution",
+      "startLine": 307,
+      "endLine": 331,
+      "summary": "Combines the axioms to resolve Problem 533 in two regimes: erdos_533_for_large_delta proves it for δ > 1/16 with constant c = δ/2 (from EHSSS), and erdos_533_for_k4_free settles all δ > 0 for the stronger K₄-free hypothesis. The remaining open gap is 0 < δ ≤ 1/16 with only K₅-freeness.",
+      "mathContext": "For $\\delta > 1/16$ take $c = \\delta/2$; the $K_4$-free hypothesis closes all $\\delta > 0$. Open: $0 < \\delta \\le 1/16$."
     },
     {
-      "id": "conjecture",
-      "title": "The Full Conjecture",
-      "startLine": 163,
-      "endLine": 173,
-      "summary": "States Problem 533: for all δ > 0, K₅-free dense graphs have linear-size triangle-free subsets.",
-      "mathContext": "Mathematical content: States Problem 533: for all δ > 0, K₅-free dense graphs have linear-size triangle-free subsets."
+      "id": "strategy",
+      "title": "Strategy: Neighborhood Approach",
+      "startLine": 332,
+      "endLine": 355,
+      "summary": "Outlines the proposed proof route: extract a high-degree vertex (average degree ≥ 2δn), use that its neighborhood is K₄-free, and apply the K₄-free result inside N(v). Identifies step 4 — controlling the edge density within N(v) — as the core difficulty. Includes the supporting bound degree_le (every degree ≤ n - 1).",
+      "mathContext": "Average degree $\\ge 2\\delta n$ yields a vertex $v$ with $\\deg(v) \\ge 2\\delta n$ and $K_4$-free $N(v)$; the open obstacle is the induced density inside $N(v)$."
+    },
+    {
+      "id": "open-question",
+      "title": "The Open Question",
+      "startLine": 356,
+      "endLine": 371,
+      "summary": "States the conjecture as a Prop erdos_533_conjecture δ (deliberately not an axiom, to avoid assuming the unknown): there exists c > 0 such that every K₅-free graph on n vertices with at least δn² edges has a triangle-free induced subgraph on ≥ c·n vertices.",
+      "mathContext": "$\\forall \\delta>0,\\ \\exists c>0$: every $K_5$-free $G$ with $\\ge \\delta n^2$ edges has a triangle-free induced subgraph of size $\\ge cn$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `erdos-533` gallery `meta.json` sections were stale from an older revision of `Proofs/Erdos533Problem.lean`. Titles such as *Edge Counting*, *EHSSS Partial Result*, *K₄-Free Case*, and *Erdős-Rogers Counterexample* no longer match any `##` banner in the file, and coverage stopped at line 173 of 371 (~53% of the file hidden).

This rebuilds all 10 sections to match the file's current banner structure, covering lines 1–371 contiguously:

| Range | Section |
|-------|---------|
| 1–18 | Problem Statement and References |
| 19–49 | Definitions |
| 50–63 | SimpleGraph Bridge |
| 64–210 | Basic Properties |
| 211–268 | Neighborhood Structure |
| 269–287 | Turán-Type Bounds |
| 288–306 | Known Partial Results |
| 307–331 | Partial Resolution |
| 332–355 | Strategy: Neighborhood Approach |
| 356–371 | The Open Question |

Each section gets an accurate `summary` and `mathContext`, including the three axioms (`turan_k5_free`, `ehsss_result`, `k4_free_triangle_free_subset`) and the open conjecture stated as a `Prop` (not an axiom).

## Verification
- Counts unchanged and already correct: 27 theorems / 10 definitions / 3 axioms / 0 sorries, `lineCount` 371 (matches `wc -l`).
- Metadata-only change; no Lean source modified.
- JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)