### PR TITLE
research(erdos-1065-oq-05): realign drifted gallery sections to full file (5→9)

### DIFF
--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -71,48 +71,80 @@
       "id": "definitions",
       "title": "Definitions",
       "startLine": 30,
-      "endLine": 50,
-      "summary": "IsFormAWithK (parameterized by k), IsFormA (existential), IsSafePrime.",
-      "mathContext": "$\\text{IsFormAWithK}(k, p) \\iff p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}: p = 2^k q + 1$"
+      "endLine": 47,
+      "summary": "IsFormAWithK (parameterized by k), IsFormA (existential over k), IsSafePrime.",
+      "mathContext": "$\\text{IsFormAWithK}(k, p) \\iff p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}: p = 2^k q + 1$; IsFormA existentially quantifies k; IsSafePrime is the k = 1 case $p = 2q+1$."
     },
     {
       "id": "safe-prime-equiv",
       "title": "Safe Prime Equivalence",
-      "startLine": 52,
-      "endLine": 75,
-      "summary": "Proves IsSafePrime p ↔ IsFormAWithK 1 p, and the inclusion chain safe primes ⊆ Form A.",
-      "mathContext": "$\\text{SafePrime}(p) \\iff \\text{FormA}(1, p)$"
+      "startLine": 48,
+      "endLine": 66,
+      "summary": "Proves IsSafePrime p ↔ IsFormAWithK 1 p, and the inclusion chain safe primes ⊆ Form A (via formAWithK_implies_formA, safePrime_implies_formA).",
+      "mathContext": "$\\text{SafePrime}(p) \\iff \\text{FormA}(1, p)$ by $\\text{pow\\_one}$; Form A with fixed k implies the existential Form A."
     },
     {
       "id": "uniqueness",
       "title": "Decomposition Uniqueness",
-      "startLine": 77,
-      "endLine": 100,
-      "summary": "Proves that if p = 2^{k₁}q₁+1 = 2^{k₂}q₂+1 with q₁,q₂ odd primes, then k₁=k₂ and q₁=q₂. Proved via padicValNat: v₂(2^k·q) = k when q is odd.",
-      "mathContext": "$v_2(2^k q) = k$ when $q$ is odd, so $2^{k_1} q_1 = 2^{k_2} q_2$ with $q_i$ odd implies $k_1 = k_2$."
+      "startLine": 67,
+      "endLine": 176,
+      "summary": "Uniqueness of the (k,q) decomposition: formA_decomposition_unique (q₁,q₂ odd, via padicValNat), the unconditional formA_decomposition_unique_full (case-split on q=2), formA_witnesses_agree (Prod form), and formAWithK_disjoint (distinct k-layers are disjoint).",
+      "mathContext": "$v_2(2^k q) = k$ when $q$ is odd, so $2^{k_1} q_1 = 2^{k_2} q_2$ forces $k_1 = k_2, q_1 = q_2$; the $q = 2$ (Fermat-like) case is handled separately. Consequence: the k-layers $\\{p \\mid \\text{FormA}(k,p)\\}$ are pairwise disjoint."
     },
     {
       "id": "examples",
       "title": "Verified Examples by k-value",
-      "startLine": 102,
-      "endLine": 185,
-      "summary": "All 15 Form A primes ≤ 100 verified with their specific k values: k=0 (3), k=1 (5,7,11,23,47,59,83), k=2 (13,29,53), k=3 (17,41,89), k=5 (97).",
-      "mathContext": "Complete k-value census ≤ 100. Safe primes (k=1) account for 7/15 ≈ 47%."
+      "startLine": 177,
+      "endLine": 273,
+      "summary": "All 15 Form A primes ≤ 100 verified with their specific k values: k=0 (3), k=1 (5,7,11,23,47,59,83), k=2 (13,29,53), k=3 (17,41,89), k=5 (97). Each via decide/norm_num.",
+      "mathContext": "Complete k-value census ≤ 100 as 15 individual example_* theorems. Safe primes (k=1) account for 7/15 ≈ 47%; no k=4 example exists ≤ 100."
+    },
+    {
+      "id": "census",
+      "title": "Census: All Safe Primes ≤ 100",
+      "startLine": 274,
+      "endLine": 289,
+      "summary": "safe_primes_le_100: every p ∈ {5,7,11,23,47,59,83} is a safe prime.",
+      "mathContext": "The 7 safe primes ≤ 100 listed and each shown to satisfy IsSafePrime via explicit (q) witnesses."
+    },
+    {
+      "id": "k-distribution",
+      "title": "k-value Distribution Statistics",
+      "startLine": 290,
+      "endLine": 304,
+      "summary": "k1_dominates_small: among the 15 Form A primes ≤ 100, safe primes (k=1) are 7/15 — strictly between 1/2-undershoot and 1/3-overshoot.",
+      "mathContext": "Records the finite-sample dominance of k=1 (7 of 15 ≈ 47%); BH predicts equal asymptotic density per k-layer, so this dominance is a small-range effect."
     },
     {
       "id": "bateman-horn",
-      "title": "Bateman-Horn Prediction",
-      "startLine": 215,
-      "endLine": 271,
-      "summary": "Axiomatizes BH: each k-layer is infinite. Proves k=1 equivalence with safe primes conjecture. Derives safe primes infinite as a BH consequence.",
-      "mathContext": "BH predicts $\\pi_k(x) \\sim 2C_2 \\cdot \\text{Li}_2(x)$ with $C_2 \\approx 0.6602$ independent of $k$."
+      "title": "Bateman-Horn Prediction (Axiomatized)",
+      "startLine": 305,
+      "endLine": 353,
+      "summary": "Axiom batemanHorn_formAWithK_infinite (each k-layer with k≥1 is infinite). Proves k=1 ↔ safe-primes conjecture (batemanHorn_k1_iff_safePrimes), BH for any k implies Form A infinite, and derives safe_primes_infinite.",
+      "mathContext": "BH predicts $\\#\\{q \\le x : 2^k q + 1 \\text{ prime}\\} \\sim 2C_2 \\cdot \\text{Li}_2(x)$ with $C_2 \\approx 0.6602$ independent of $k$ (local root count is 2 at every odd prime since $2^k$ is a unit; count is 1 at $p=2$ for $k\\ge1$)."
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge to Erdős 1065a",
+      "startLine": 354,
+      "endLine": 372,
+      "summary": "isFormA_unfold (local IsFormA matches the parent's IsTwoTimePrimePlusOne) and bh_k1_implies_formA_infinite: the BH axiom at k=1 alone implies Erdős 1065a (infinitely many Form A primes).",
+      "mathContext": "BH for k=1 is strictly stronger than Erdős 1065a: BH fixes k, while 1065a only requires existence of some k per prime."
+    },
+    {
+      "id": "k-characterizations",
+      "title": "k-Specific Characterizations of Form A",
+      "startLine": 373,
+      "endLine": 460,
+      "summary": "Explicit forms for fixed k: formAWithK0_iff/formAWithK2_iff/formAWithK3_iff (p = q+1, 4q+1, 8q+1), formAWithK0_unique (k=0 ⇒ p=3), and formAWithK0_layer_eq_three / formAWithK0_finite showing the k=0 layer is the singleton {3}.",
+      "mathContext": "The k=0 layer is finite ({3}), justifying the $1 \\le k$ hypothesis on the BH axiom: an unrestricted 'every k-layer is infinite' would be false at k=0 (parity obstruction forces q=2, p=3)."
     }
   ],
   "overview": {
     "historicalContext": "The Bateman-Horn conjecture (1962) generalizes the Hardy-Littlewood prime conjectures to predict the density of primes represented simultaneously by several polynomials. For the polynomial pair (n, 2^k·n+1), it predicts that the count of primes q ≤ x for which 2^k·q+1 is also prime grows as 2C₂·x/(ln x)², where C₂ ≈ 0.6602 is the twin primes constant. Hardy and Littlewood's 1923 'Conjecture B' was the k=1 special case: infinitely many safe prime pairs (q, 2q+1). The key insight of this file is that the Bateman-Horn constant is the same — exactly 2C₂ — for every k ≥ 1, because the local root count ω(p) = 2 at every odd prime p regardless of k (since 2^k is a unit mod any odd prime). This 2C₂ independence of k is non-obvious and has quantitative consequences: all k-layers of Form A primes are predicted to have equal asymptotic density, with the empirical dominance of k=1 among small primes being a finite-sample effect.",
     "problemStatement": "Can the Bateman-Horn conjecture provide quantitative density predictions for Form A primes (p = 2^k·q+1)? What is the predicted density as a function of k?",
-    "text": "A 271-line formalization of the Bateman-Horn density prediction for Erdős Problem #1065. Defines IsFormAWithK to parameterize Form A primes by their 2-adic exponent k, proves the safe prime equivalence (k=1), provides a complete k-value census of all 15 Form A primes ≤ 100, and axiomatizes the BH prediction that each k-layer is infinite. The key number-theoretic insight — that the BH constant 2C₂ is independent of k because the local root count at every odd prime p is always 2 — is documented and motivates the uniform axiom.",
-    "proofStrategy": "Define k-parameterized predicates, verify examples computationally, state uniqueness (sorry for now), axiomatize the BH prediction, derive consequences including the safe primes conjecture.",
+    "text": "A 460-line formalization of the Bateman-Horn density prediction for Erdős Problem #1065. Defines IsFormAWithK to parameterize Form A primes by their 2-adic exponent k, proves the safe prime equivalence (k=1), proves the (k,q) decomposition is unique (via 2-adic valuation) and that distinct k-layers are disjoint, provides a complete k-value census of all 15 Form A primes ≤ 100, and axiomatizes the BH prediction that each k-layer (k≥1) is infinite. The key number-theoretic insight — that the BH constant 2C₂ is independent of k because the local root count at every odd prime p is always 2 — is documented and motivates the uniform axiom.",
+    "proofStrategy": "Define k-parameterized predicates, prove the safe-prime equivalence, prove uniqueness of the (k,q) decomposition via 2-adic valuation (0 sorries), verify the k-value census computationally, axiomatize the BH prediction (k≥1), and derive consequences including the safe primes conjecture and k-specific characterizations.",
     "keyInsights": [
       "**BH constant independence**: The Bateman-Horn constant 2C₂ ≈ 1.32 is the same for all k ≥ 1, because 2^k is a unit mod every odd prime p, making the local root count ω(p) = 2 regardless of k. Only the p=2 factor differs, but it equals 1 for all k≥1 (since 2^k·n+1 is always odd). The infinite product is thus k-independent.",
       "**Safe primes as k=1 layer**: The safe primes conjecture is exactly the k=1 specialization of the BH prediction. This is formalized as a definitional equivalence: `simp [pow_one]` proves `IsSafePrime p ↔ IsFormAWithK 1 p`, making the reduction a one-line proof.",
@@ -124,7 +156,7 @@
   "conclusion": {
     "summary": "This formalization answers the open question by showing that the Bateman-Horn conjecture does provide quantitative density predictions: for each fixed k, the count of Form A primes is asymptotically 2C₂·x/(ln x)², and the constant is independent of k. The safe primes conjecture (k=1) is a special case.",
     "openQuestions": [
-      "Can `formA_decomposition_unique` be proved in Lean from `Nat.multiplicity`? The key step is `Nat.multiplicity 2 (2^k * q) = k` when `q` is odd — Mathlib has `multiplicity_pow_self` and `multiplicity_mul` but combining them for this case requires careful case analysis on whether k=0.",
+      "The (k,q) decomposition uniqueness is now fully proved (0 sorries) via `padicValNat 2 (2^k * q) = k` for odd q, and strengthened to the unconditional `formA_decomposition_unique_full` (handling the q=2 Fermat-like case). Remaining: can the proof be repackaged through Mathlib's general `multiplicity` API rather than `padicValNat`?",
       "Can the full BH asymptotic be formalized? This would require a Lean definition of `Li₂(x)` (logarithmic integral of order 2) and a density statement, neither of which currently exists in Mathlib. The axiom `batemanHorn_formAWithK_infinite` could be strengthened to a quantitative form.",
       "Is there a proof of Erdős #1065 (existence of infinitely many Form A primes) that avoids BH entirely? The problem asks for existence, not density. A sieve-theoretic argument might produce Form A primes without the full BH machinery — similar to how Chen's theorem produces twin-prime-like pairs unconditionally."
     ],


### PR DESCRIPTION
## Summary
- The 5 gallery sections for `erdos-1065-oq-05` were pinned to an older, shorter revision of `Erdos1065BatemanHorn.lean`: they stopped at line 271 of 460 (59% covered).
- Ranges were mislabeled — `examples` claimed lines 102-185, but that range is actually the Uniqueness theorems; the real Bateman-Horn banner is at line 305, not 215.
- Rebuilt to **9 contiguous sections (30-460)** tracking the actual `## ` banners, surfacing four previously-missing sections: **Census of safe primes ≤ 100**, **k-value Distribution Statistics**, **Bridge to Erdős 1065a**, and **k-Specific Characterizations of Form A** (incl. the k=0 layer = {3} results).

## Stale prose fixed
- `overview.text`: "271-line formalization" → 460-line.
- `proofStrategy` and an `openQuestion` described the (k,q) decomposition uniqueness as unproven / "sorry for now"; it is fully proved (0 sorries) via `padicValNat` and strengthened to the unconditional `formA_decomposition_unique_full`.

## Notes
- Counts (`theoremCount` 35, `definitionCount` 3, `axiomCount` 1, `lineCount` 460) were already correct and are unchanged.
- Metadata-only change; no Lean source touched.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Section ranges are ordered, contiguous, and cover 30-460 (maxEndLine == lineCount)
- [x] Section titles/ranges verified against the `## ` banners in the Lean file