### PR TITLE
research(erdos-1160): realign drifted gallery sections to full file (6→7)

### DIFF
--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -91,51 +91,59 @@
   "sections": [
     {
       "id": "group-counting",
-      "title": "The Group Counting Function",
+      "title": "Section I: The Group Counting Function",
       "startLine": 30,
-      "endLine": 59,
-      "summary": "Axiomatization of the group counting function numGroups : ℕ → ℕ (OEIS A000001) along with known values for small orders. Since Lean/Mathlib has no computable group enumeration, these are declared as axioms.",
-      "mathContext": "$g(n) = |\\{G : |G| = n\\}/\\cong|$, with known values $g(1)=1$, $g(4)=2$, $g(6)=2$, $g(8)=5$"
+      "endLine": 100,
+      "summary": "Axiomatization of the group counting function numGroups : ℕ → ℕ (OEIS A000001) plus structural axioms g(p)=1, g(p²)=2, g(p³)=5, the g(pq) classification, and specific values g(12)=5, g(16)=14. Derived theorems compute g(2), g(4), g(6), g(8) and the q|(p-1) split. Since Lean/Mathlib has no computable group enumeration, the base values are declared as axioms.",
+      "mathContext": "$g(n) = |\\{G : |G| = n\\}/\\cong|$; axioms $g(p)=1$, $g(p^2)=2$, $g(p^3)=5$, $g(pq) = 2$ iff $q \\mid p-1$ else $1$; derived $g(2)=1, g(4)=2, g(6)=2, g(8)=5$."
     },
     {
       "id": "basic-properties",
-      "title": "Basic Properties",
-      "startLine": 61,
-      "endLine": 83,
-      "summary": "Monotonicity of g(p^k) in k for fixed prime p (axiom), positivity of g(p^k) for k ≥ 1 (proved from g(p)=1 + monotonicity), and g(2^m) ≥ 1 (proved without general positivity axiom).",
+      "title": "Section II: Basic Properties",
+      "startLine": 101,
+      "endLine": 124,
+      "summary": "Monotonicity of g(p^k) in k for fixed prime p (axiom numGroups_prime_power_mono), positivity of g(p^k) for k ≥ 1 (proved from g(p)=1 + monotonicity), and g(2^m) ≥ 1 (proved without a general positivity axiom).",
       "mathContext": "$g(p^{k_1}) \\leq g(p^{k_2})$ for $k_1 \\leq k_2$; $g(p^k) > 0$ for $k \\geq 1$; $g(2^m) \\geq 1$"
     },
     {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "startLine": 85,
-      "endLine": 109,
-      "summary": "States the main conjecture in two equivalent forms and proves their equivalence. The universally quantified form (∀ m n, n ≤ 2^m → g(n) ≤ g(2^m)) is equivalent to the Finset-range form, enabling computational verification for fixed m.",
+      "title": "Section III: The Main Conjecture",
+      "startLine": 125,
+      "endLine": 150,
+      "summary": "States the main conjecture in two equivalent forms (erdos_1160 and erdos_1160_alt) and proves their equivalence (erdos_1160_equiv). The universally quantified form (∀ m n, n ≤ 2^m → g(n) ≤ g(2^m)) matches the Finset-range form, enabling computational verification for fixed m.",
       "mathContext": "$\\forall m, n \\in \\mathbb{N},\\; n \\leq 2^m \\implies g(n) \\leq g(2^m)$"
     },
     {
       "id": "stronger-conjecture",
-      "title": "Stronger Conjecture (BNV07)",
-      "startLine": 111,
-      "endLine": 128,
-      "summary": "Formalizes the dramatically stronger conjecture of Blackburn–Neumann–Venkataraman: the sum of g(n) over all n < 2^m is dominated by g(2^m) alone for sufficiently large m. Proves this implies the original conjecture via Finset.single_le_sum.",
+      "title": "Section IV: Stronger Conjecture (BNV07)",
+      "startLine": 151,
+      "endLine": 169,
+      "summary": "Formalizes the dramatically stronger conjecture of Blackburn–Neumann–Venkataraman (Question 22.18): the sum of g(n) over all n < 2^m is dominated by g(2^m) alone for sufficiently large m. Proves strong_implies_original via Finset.single_le_sum.",
       "mathContext": "$\\exists M,\\; \\forall m \\geq M: \\sum_{n=0}^{2^m-1} g(n) \\leq g(2^m)$"
     },
     {
       "id": "partial-results",
-      "title": "Known Partial Results",
-      "startLine": 130,
-      "endLine": 149,
-      "summary": "Verifies the conjecture for base cases: n = 1 (trivially g(1) = 1 ≤ g(2^m)), prime n (g(p) = 1), and axiomatizes Pantelidakis's 2003 result for odd n when m ≥ 3619.",
+      "title": "Section V: Known Partial Results",
+      "startLine": 170,
+      "endLine": 192,
+      "summary": "Verifies the conjecture for base cases: n = 1 (trivially g(1) = 1 ≤ g(2^m), erdos_1160_n_eq_one), prime n (g(p) = 1, erdos_1160_prime), and states Pantelidakis's 2003 result for odd n when m ≥ 3619 as a Prop def (unused known result).",
       "mathContext": "$g(1) = 1 \\leq g(2^m)$; $g(p) = 1$ for prime $p$; Pantelidakis: odd $n \\leq 2^m,\\, m \\geq 3619 \\implies g(n) \\leq g(2^m)$"
     },
     {
       "id": "asymptotics",
-      "title": "Asymptotic Growth",
-      "startLine": 151,
-      "endLine": 162,
-      "summary": "Axiomatizes the Higman–Sims asymptotic formula: log₂(g(2^m)) / m³ → 2/27 as m → ∞. This super-exponential growth is the fundamental reason powers of 2 are conjectured to maximize the group counting function.",
+      "title": "Section VI: Asymptotic Growth",
+      "startLine": 193,
+      "endLine": 207,
+      "summary": "States the Higman–Sims asymptotic formula log₂(g(2^m)) / m³ → 2/27 as m → ∞ as a Prop def (unused known result). This super-exponential growth is the fundamental reason powers of 2 are conjectured to maximize the group counting function.",
       "mathContext": "$\\lim_{m \\to \\infty} \\frac{\\log_2 g(2^m)}{m^3} = \\frac{2}{27}$"
+    },
+    {
+      "id": "structural-results",
+      "title": "Section VII: Structural Results",
+      "startLine": 208,
+      "endLine": 329,
+      "summary": "Proves the conjecture for all small bounds: n=0 (g(0)=0), powers of two (erdos_1160_power_of_two), reflexivity (erdos_1160_self), and exhaustive case checks for m=1 (n≤2), m=2 (n≤4), m=3 (n≤8), m=4 (n≤16) via interval_cases plus helper values g(9)=2, g(10)=2, g(14)=2, g(15)=1. Concludes with erdos_1160_lift extending a verified m to the range [0,2^m] at m+1.",
+      "mathContext": "Verified base cases $g(n) \\le g(2^m)$ for all $n \\le 2^m$ with $m \\le 4$; $g(2^k) \\le g(2^m)$ for $k \\le m$; an inductive lift step on the lower range."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The 6 gallery sections for `erdos-1160` were pinned to an older, shorter revision of `Erdos1160Problem.lean`: they stopped at line 162 of 329 (49% covered) and every range was shifted off the actual `## Section` banners (e.g. Asymptotic Growth was labeled 151-162 but really lives at 193-206).
- Rebuilt to **7 contiguous sections (30-329)** tracking the actual `## Section I-VII` banners, surfacing the **entirely-missing Section VII "Structural Results"** (lines 208-328): the exhaustive m=1..4 case verifications, helper values g(9)/g(10)/g(14)/g(15), and the inductive lift step.
- Retitled sections with their `Section N` prefixes; noted `pantelidakis_odd_theorem` / `numGroups_two_power_growth_theorem` are Prop defs (not axioms).

## Notes
- Counts (`axiomCount` 10, `theoremCount` 24, `definitionCount` 5, `lineCount` 329) were already correct and are unchanged.
- Metadata-only change; no Lean source touched.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Section ranges are ordered, contiguous, and cover 30-329 (maxEndLine == lineCount)
- [x] Section titles/ranges verified against the `## Section` banners in the Lean file