### PR TITLE
research(erdos-324): rebuild drifted gallery sections to full file (6→9) + fix stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -57,11 +57,11 @@
       "quintic_implies_324: proved QuinticConjecture → ErdosProblem324",
       "PowerPairSumDistinct: generalized for arbitrary exponent n",
       "lps_implies_power_distinct: LPS implies power-distinct for n ≥ 5",
-      "squares_not_distinct: axiom ¬PowerPairSumDistinct 2",
-      "cubes_not_distinct: axiom ¬PowerPairSumDistinct 3",
-      "quartics_not_distinct: axiom ¬PowerPairSumDistinct 4",
-      "linear_not_distinct: axiom for linear polynomials",
-      "min_degree_for_distinct: axiom degree ≥ 5",
+      "squares_not_distinct: proved theorem ¬PowerPairSumDistinct 2",
+      "cubes_not_distinct: proved theorem ¬PowerPairSumDistinct 3",
+      "quartics_not_distinct: proved theorem ¬PowerPairSumDistinct 4",
+      "linear_not_distinct: proved theorem for linear polynomials",
+      "min_degree_for_distinct: axiom degree ≥ 5 (the file's single axiom)",
       "distinctPairSumCount: count of distinct pair sum values",
       "distinct_count_eq_binomial: count = C(N+1,2)",
       "zeroth_power_not_distinct: ¬PowerPairSumDistinct 0 (constant X⁰ gives collision)",
@@ -77,51 +77,75 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 19,
+      "summary": "Module docstring stating the problem (does some $f \\in \\mathbb{Z}[X]$ have all pair sums $f(a)+f(b)$ distinct?), the conjecture that $x^5$ works, the Lander-Parkin-Selfridge connection, OPEN status, and references (Erdős-Graham 1980, p. 53). Imports Mathlib and opens Polynomial.",
+      "mathContext": "Verified: documentation block with the problem statement, the $x^5$ conjecture, the LPS connection, OPEN status, and the Erdős-Graham (1980) reference."
+    },
+    {
       "id": "pair-sums",
-      "title": "Distinct Pair Sums",
-      "startLine": 25,
-      "endLine": 41,
-      "summary": "Defines the core machinery: `pairSumFn` maps $(a,b) \\mapsto f(a) + f(b)$ for $f \\in \\mathbb{Z}[X]$, `orderedPairs` restricts to $\\{(a,b) : a < b\\}$ to avoid commutative collisions, and `HasDistinctPairSums` formalizes injectivity via `Set.InjOn`. This captures the distinct pair sums property using Mathlib's function restriction framework.",
+      "title": "Section I: Distinct Pair Sums",
+      "startLine": 20,
+      "endLine": 36,
+      "summary": "Defines the core machinery: `pairSumFn` maps $(a,b) \\mapsto f(a) + f(b)$ for $f \\in \\mathbb{Z}[X]$, `orderedPairs` restricts to $\\{(a,b) : a < b\\}$ to avoid commutative collisions, and `HasDistinctPairSums` formalizes injectivity via `Set.InjOn`.",
       "mathContext": "$S_f(a,b) = f(a) + f(b)$; ordered pairs $\\{(a,b) : a < b\\}$; distinct pair sums $\\Leftrightarrow$ $S_f$ injective on ordered pairs."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 42,
-      "endLine": 50,
+      "title": "Section II: The Conjecture",
+      "startLine": 37,
+      "endLine": 45,
       "summary": "Formalizes Erdős Problem #324 as `ErdosProblem324 : Prop := \\exists f : \\mathbb{Z}[X], \\text{HasDistinctPairSums}\\, f`. The existential quantification asks whether *any* polynomial works, making this an existence problem. Erdős and Graham (1980, p. 53) called it 'very annoying.'",
       "mathContext": "$\\exists f \\in \\mathbb{Z}[X]: \\forall a < b, c < d, (a,b) \\neq (c,d) \\implies f(a)+f(b) \\neq f(c)+f(d)$."
     },
     {
       "id": "quintic",
-      "title": "The Quintic Conjecture",
-      "startLine": 51,
-      "endLine": 63,
-      "summary": "Defines `QuinticConjecture := HasDistinctPairSums (X^5)` and proves `quintic_implies_324 : QuinticConjecture \\to ErdosProblem324` by existential introduction $\\langle X^5, h\\rangle$. This is the only fully-proved theorem in the file (no sorry), demonstrating that the quintic conjecture is strictly stronger than the main problem.",
+      "title": "Section III: The Quintic Conjecture",
+      "startLine": 46,
+      "endLine": 58,
+      "summary": "Defines `QuinticConjecture := HasDistinctPairSums (X^5)` and proves `quintic_implies_324 : QuinticConjecture \\to ErdosProblem324` by existential introduction $\\langle X^5, h\\rangle$, showing the quintic conjecture is strictly stronger than the main problem.",
       "mathContext": "$\\text{QuinticConj}: \\forall a < b, c < d, (a,b) \\neq (c,d) \\implies a^5+b^5 \\neq c^5+d^5$. Implies P324 by $\\exists$-intro with $f = X^5$."
     },
     {
       "id": "powers",
-      "title": "Power Generalizations",
-      "startLine": 64,
-      "endLine": 88,
-      "summary": "Parametrizes the problem over exponents via `PowerPairSumDistinct(n) := HasDistinctPairSums(X^n)`. Axiomatizes: (1) LPS conjecture implies $\\text{PowerPairSumDistinct}(n)$ for $n \\geq 5$; (2) $\\neg\\text{PowerPairSumDistinct}(2)$ via $1^2 + 8^2 = 4^2 + 7^2 = 65$; (3) $\\neg\\text{PowerPairSumDistinct}(3)$ via $1^3 + 12^3 = 9^3 + 10^3 = 1729$; (4) $\\neg\\text{PowerPairSumDistinct}(4)$ via Euler (1772).",
+      "title": "Section IV: Power Generalizations",
+      "startLine": 59,
+      "endLine": 130,
+      "summary": "Parametrizes the problem via `PowerPairSumDistinct(n) := HasDistinctPairSums(X^n)`. lps_implies_power_distinct (axiom: LPS implies the property for n ≥ 5), then five PROVED impossibility theorems: squares_not_distinct ($1^2+8^2=4^2+7^2=65$), cubes_not_distinct (taxicab $1729$), quartics_not_distinct (Euler 1772), zeroth_power_not_distinct, first_power_not_distinct, and power_below_five_not_distinct collecting them into the full characterization that $x^n$ fails for all $n < 5$.",
       "mathContext": "Failures: $1^2+8^2 = 4^2+7^2 = 65$; $1^3+12^3 = 9^3+10^3 = 1729$; $59^4+158^4 = 133^4+134^4 = 635318657$. LPS conjecture: $a^n+b^n = c^n+d^n$ has no nontrivial solutions for $n \\geq 5$."
     },
     {
       "id": "lower-degree",
-      "title": "Lower Degree Impossibility",
-      "startLine": 89,
-      "endLine": 100,
-      "summary": "Axiomatizes two impossibility results: `linear_not_distinct` shows $f(x) = ax + b$ always produces collisions (pair sums depend only on $a_1 + b_1$, not individual values), and `min_degree_for_distinct` establishes $\\deg(f) \\geq 5$ as the sharp lower bound, combining failures at degrees 0-4.",
-      "mathContext": "Linear: $f(a)+f(b) = a(a_1+b_1)+2b$, so $f(0)+f(3) = f(1)+f(2)$. Combined: $\\deg(f) \\leq 4 \\implies \\neg\\text{HasDistinctPairSums}(f)$."
+      "title": "Section V: Lower Degree Impossibility",
+      "startLine": 131,
+      "endLine": 149,
+      "summary": "linear_not_distinct (PROVED theorem): $f(x) = ax + b$ always produces collisions (pair sums are affine in $a+b$, so $f(0)+f(3)=f(1)+f(2)$). min_degree_for_distinct (the file's single axiom): $\\deg(f) \\geq 5$ is necessary, combining the failures at degrees 0-4.",
+      "mathContext": "Linear: $f(a)+f(b) = a(a_1+b_1)+2b$, so $f(0)+f(3) = f(1)+f(2)$. Axiom min_degree_for_distinct: $\\deg(f) \\leq 4 \\implies \\neg\\text{HasDistinctPairSums}(f)$."
+    },
+    {
+      "id": "constant-polynomials",
+      "title": "Section V.b: Constant Polynomials",
+      "startLine": 150,
+      "endLine": 164,
+      "summary": "constant_not_distinct (PROVED): every constant polynomial $f(x) = c$ fails, since all pair sums collapse to $2c$ regardless of the inputs.",
+      "mathContext": "Constant $f \\equiv c$: $f(a)+f(b) = 2c$ for all $(a,b)$, so $S_f$ is not injective on ordered pairs."
+    },
+    {
+      "id": "quadratic-subcases",
+      "title": "Section V.c: Quadratic Impossibility Subcases",
+      "startLine": 165,
+      "endLine": 195,
+      "summary": "quadratic_no_linear_not_distinct (PROVED): quadratics $ax^2 + c$ with no linear term fail. monic_neg_linear_quad_not_distinct (PROVED): monic quadratics with a negative linear coefficient fail. Both are explicit subcases of the degree-2 impossibility.",
+      "mathContext": "Quadratic subcases of $\\deg(f) \\leq 4 \\implies \\neg\\text{HasDistinctPairSums}(f)$, proved by exhibiting concrete colliding ordered pairs."
     },
     {
       "id": "counting",
-      "title": "Counting Pair Sums",
-      "startLine": 101,
-      "endLine": 113,
-      "summary": "Defines `distinctPairSumCount f N` as the cardinality of $\\{f(a) + f(b) : 0 \\leq a < b \\leq N\\}$ using `Finset.image`. Axiomatizes that for $f$ with distinct pair sums, this count equals $\\binom{N+1}{2} = \\frac{N(N+1)}{2}$, the maximum possible — the Sidon-set-like property achieves the combinatorial upper bound.",
+      "title": "Section VI: Counting Pair Sums",
+      "startLine": 196,
+      "endLine": 303,
+      "summary": "Defines `distinctPairSumCount f N` as the cardinality of $\\{f(a) + f(b) : 0 \\leq a < b \\leq N\\}$ via `Finset.image`, and proves distinct_count_eq_binomial: for $f$ with distinct pair sums this count equals $\\binom{N+1}{2}$, the combinatorial maximum (a Sidon-set-like property).",
       "mathContext": "$|\\{f(a)+f(b) : 0 \\leq a < b \\leq N\\}| = \\binom{N+1}{2}$ when all pair sums are distinct. Maximum: $\\binom{N+1}{2} = N(N+1)/2$ ordered pairs."
     }
   ],


### PR DESCRIPTION
## Summary
The erdos-324 gallery meta carried 6 sections from an older revision — stopping at line 113 of the 303-line `Erdos324Problem.lean`, with line numbers misaligned against the file's `## Section N` banners.

- Sections **6 → 9**, now covering lines 1–303 contiguously and aligned to the file banners
- Restored hidden Sections **V.b** (Constant Polynomials), **V.c** (Quadratic Impossibility Subcases), and the full **Section VI** counting content (to line 303)
- Fixed stale prose: `squares_not_distinct`, `cubes_not_distinct`, `quartics_not_distinct`, and `linear_not_distinct` are **proved theorems**, not axioms — only `min_degree_for_distinct` is an axiom (axiomCount = 1)

Counts (14 thm / 7 def / 1 axiom / 0 sorry / 303 LC) were already correct.

## Test plan
- [x] `pnpm research:build` exits 0
- [x] Sections cover full file 1–303, no overlaps or start>end
- [x] No open PR touches `src/data/proofs/erdos-324/meta.json`