### PR TITLE
research(erdos-1019): realign drifted gallery sections to full file (12→16)

### DIFF
--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -56,108 +56,140 @@
     {
       "id": "graph-basics",
       "title": "Graph Basics",
-      "summary": "Defines `edgeCount G` via `G.edgeFinset.card` and `vertexCount` via `Fintype.card V`. These parametrize the function $f(n,k)$ measuring the edge threshold.",
+      "summary": "Defines `edgeCount G` via `G.edgeFinset.card` and `vertexCount` via `Fintype.card V` over a finite simple graph.",
       "startLine": 22,
-      "endLine": 36,
+      "endLine": 40,
       "mathContext": "$e(G) = |E(G)|$, $v(G) = |V(G)|$ for finite simple graphs."
+    },
+    {
+      "id": "graph-minors",
+      "title": "Graph Minors",
+      "summary": "Defines the `GraphMinorWitness` structure (branch sets with disjointness + cross-edge conditions), `HasMinor`, the forbidden minors `K5` and `K33`, and the pigeonhole lemma `no_minor_of_card_lt` (a graph on fewer vertices than H cannot contain H as a minor).",
+      "startLine": 41,
+      "endLine": 87,
+      "mathContext": "Wagner's theorem: a finite graph is planar iff it has no $K_5$ or $K_{3,3}$ minor. `no_minor_of_card_lt`: $|V(G)| < |V(H)| \\Rightarrow \\neg \\text{HasMinor}\\,G\\,H$ via injecting branch-set representatives."
     },
     {
       "id": "planar-graphs",
       "title": "Planar Graphs",
-      "summary": "Defines graph minors (`GraphMinorWitness`, `HasMinor`), K₅ and K₃,₃, and `isPlanar` via Wagner's forbidden minor characterization. Axiomatizes Euler's bound $|E| \\le 3|V| - 6$.",
-      "startLine": 37,
-      "endLine": 50,
-      "mathContext": "Planar: embeds in $\\\\mathbb{R}^2$ without crossings. Euler: $|E| \\\\leq 3|V|-6$ for $|V| \\\\geq 3$."
+      "summary": "Defines `isPlanar G` via Wagner's forbidden-minor characterization (no K₅ and no K₃,₃ minor), with a note on the Euler edge bound $|E| \\le 3|V| - 6$.",
+      "startLine": 88,
+      "endLine": 99,
+      "mathContext": "$\\\\text{isPlanar}(G) \\\\iff \\\\neg\\\\text{HasMinor}\\\\,G\\\\,K_5 \\\\wedge \\\\neg\\\\text{HasMinor}\\\\,G\\\\,K_{3,3}$. Euler: $|E| \\\\leq 3|V|-6$ for $|V| \\\\geq 3$."
     },
     {
       "id": "saturated-planar",
       "title": "Saturated Planar Graphs",
-      "summary": "Defines `isSaturatedPlanar G` requiring planarity, $|V| \\ge 3$, and $|E| = 3|V| - 6$. Proves basic implications: saturated implies planar, saturated achieves the Euler bound.",
-      "startLine": 51,
-      "endLine": 72,
+      "summary": "Defines `isSaturatedPlanar G` (planar, $|V| \\ge 3$, $|E| = 3|V| - 6$) and proves `saturated_is_planar` and `saturated_achieves_bound`.",
+      "startLine": 100,
+      "endLine": 121,
       "mathContext": "Saturated planar: planar, $|V| \\\\geq 3$, $|E| = 3|V|-6$ (maximal). Adding any edge violates planarity."
     },
     {
       "id": "threshold",
       "title": "Edge Density Threshold",
       "summary": "Defines `turanEdges n` $= \\lfloor n^2/4 \\rfloor$, `additionalThreshold n` $= \\lfloor(n+1)/2\\rfloor$, `saturatedPlanarThreshold`, and `exceedsThreshold`.",
-      "startLine": 73,
-      "endLine": 91,
+      "startLine": 122,
+      "endLine": 140,
       "mathContext": "Threshold: $\\\\lfloor n^2/4 \\\\rfloor + \\\\lfloor(n+1)/2\\\\rfloor$ edges. Turan number plus a matching."
     },
     {
       "id": "triangles",
       "title": "Triangles and Turán's Theorem",
-      "summary": "Defines $K_3$, axiomatizes it as saturated planar, and axiomatizes Turán's theorem: $|E| > \\lfloor n^2/4 \\rfloor \\Rightarrow K_3 \\subseteq G$.",
-      "startLine": 92,
-      "endLine": 114,
-      "mathContext": "$K_3$ is the smallest saturated planar graph ($3 = 3\\\\cdot3-6$). Above Turan $\\\\Rightarrow$ contains $K_3$."
+      "summary": "Defines `completeGraph n` and `K3`, proves `K3_saturated_planar` (via no_minor_of_card_lt + native_decide), and proves `turan_triangle`: $|E| > \\lfloor n^2/4 \\rfloor \\Rightarrow$ a triangle exists, using Mathlib's `CliqueFree.card_edgeFinset_le`.",
+      "startLine": 141,
+      "endLine": 193,
+      "mathContext": "$K_3$ is the smallest saturated planar graph ($3 = 3\\\\cdot3-6$). Above Turán $\\\\Rightarrow$ contains $K_3$ (proved from the Mathlib Turán bound)."
     },
     {
-      "id": "subgraphs",
-      "title": "Subgraph Containment",
+      "id": "induced-subgraph",
+      "title": "The Induced Subgraph",
       "summary": "Defines `inducedSubgraph G S`, `hasSaturatedPlanarSubgraph G k`, and `hasLargeSaturatedPlanarSubgraph G` ($k > 3$).",
-      "startLine": 115,
-      "endLine": 135,
+      "startLine": 194,
+      "endLine": 214,
       "mathContext": "Saturated planar subgraph on $k \\\\geq 4$ vertices: $G[S]$ with $e(G[S]) = 3|S|-6$."
     },
     {
       "id": "k4",
       "title": "Complete Graph $K_4$",
-      "summary": "Axiomatizes $K_4$ as saturated planar (6 $= 3 \\cdot 4 - 6$ edges). Defines `containsK4` and proves it implies a large saturated planar subgraph.",
-      "startLine": 136,
-      "endLine": 153,
-      "mathContext": "$K_4$ is saturated planar: $6 = 3\\\\cdot4-6$. Does the threshold force $K_4$ or larger?"
+      "summary": "Defines `containsK4`, proves `K4_saturated_planar` (the induced subgraph on a 4-clique is ⊤ and is saturated planar — the final edge-count step `C(4,2)=6` carries the file's single sorry), and `K4_gives_large_saturated`.",
+      "startLine": 215,
+      "endLine": 274,
+      "mathContext": "$K_4$ is saturated planar: $6 = 3\\\\cdot4-6$. Does the threshold force $K_4$ or larger? (1 sorry: the $C(4,2)=6$ top-graph edge count.)"
     },
     {
       "id": "cycle-plus",
       "title": "Cycle Plus Independent Vertices: $C_\\ell + 2K_1$",
-      "summary": "Defines `containsCyclePlus2K1 G l` ($\\ell \\ge 3$ with 2 apex vertices). Axiomatizes it as saturated planar ($3\\ell = 3(\\ell+2) - 6$ edges). Proves it implies a large saturated planar subgraph.",
-      "startLine": 154,
-      "endLine": 179,
+      "summary": "Defines `containsCyclePlus2K1 G l` ($\\ell \\ge 3$ with 2 apex vertices). Axiomatizes it as saturated planar ($3\\ell = 3(\\ell+2) - 6$ edges) and proves `cyclePlus2K1_gives_large_saturated`.",
+      "startLine": 275,
+      "endLine": 305,
       "mathContext": "$C_\\\\ell + 2K_1$: cycle of length $\\\\ell$ with 2 apex vertices. Saturated planar on $\\\\ell+2$ vertices."
     },
     {
       "id": "construction",
       "title": "Erdős's Construction",
-      "summary": "Axiomatizes existence of graphs with $\\lfloor n^2/4 \\rfloor + \\lfloor(n-1)/2\\rfloor$ edges avoiding large saturated planar subgraphs.",
-      "startLine": 180,
-      "endLine": 198,
+      "summary": "Defines `lowerThreshold n` $= \\lfloor n^2/4 \\rfloor + \\lfloor(n-1)/2\\rfloor$ and axiomatizes `erdos_construction_exists`: graphs at the lower threshold avoiding large saturated planar subgraphs.",
+      "startLine": 306,
+      "endLine": 322,
       "mathContext": "Below threshold: graphs exist avoiding large saturated planar subgraphs. Shows threshold is tight."
+    },
+    {
+      "id": "main-question",
+      "title": "The Main Question",
+      "summary": "States `erdos_1019_question`: does exceeding the threshold guarantee a large saturated planar subgraph?",
+      "startLine": 323,
+      "endLine": 335,
+      "mathContext": "$\\\\text{exceedsThreshold}(G) \\\\Rightarrow \\\\text{hasLargeSaturatedPlanarSubgraph}(G)$ for $|V| \\\\geq 4$."
     },
     {
       "id": "simonovits",
       "title": "Simonovits's Theorem",
-      "summary": "Axiomatizes the dichotomy: exceeding the threshold forces $K_4$ or $C_\\ell + 2K_1$. Derives `erdos_1019_solved` resolving the problem.",
-      "startLine": 209,
-      "endLine": 229,
+      "summary": "Axiomatizes the dichotomy `simonovits_theorem` (exceeding the threshold forces $K_4$ or $C_\\ell + 2K_1$) and derives `erdos_1019_solved`, resolving the question affirmatively.",
+      "startLine": 336,
+      "endLine": 356,
       "mathContext": "Dichotomy: exceeding threshold forces $K_4$ or $C_\\\\ell + 2K_1$ as induced saturated planar subgraph."
     },
     {
-      "id": "size-bound",
-      "title": "Erdős Size Bound and Turán Connection",
-      "summary": "Quantitative bound: $\\lfloor n^2/4 \\rfloor + k$ edges force saturated planar on $\\gg k/n$ vertices. Connection to complete bipartite graphs via Kuratowski.",
-      "startLine": 230,
-      "endLine": 267,
-      "mathContext": "$\\\\lfloor n^2/4\\\\rfloor + k$ edges forces saturated planar on $\\\\Omega(k)$ vertices."
+      "id": "related-results",
+      "title": "Related Results",
+      "summary": "Defines `saturatedPlanarSize n k` $= k/n$ and notes Erdős (1969): graphs with $\\lfloor n^2/4 \\rfloor + k$ edges have saturated planar subgraphs on $\\gg k/n$ vertices.",
+      "startLine": 357,
+      "endLine": 366,
+      "mathContext": "$\\\\lfloor n^2/4\\\\rfloor + k$ edges forces saturated planar on $\\\\Omega(k/n)$ vertices."
+    },
+    {
+      "id": "turan-connection",
+      "title": "Connection to Turán Theory",
+      "summary": "Defines `completeBipartite m n` with its decidability instance, proves `completeBipartite_has_K33_minor` ($m,n \\ge 3$) and `bipartite_not_saturated` (such bipartite graphs are non-planar, hence not saturated planar).",
+      "startLine": 367,
+      "endLine": 417,
+      "mathContext": "$K_{m,n}$ with $m,n \\\\geq 3$ contains a $K_{3,3}$ minor (singleton branch sets), so it is not planar."
     },
     {
       "id": "threshold-gap",
-      "title": "Threshold Optimality",
-      "summary": "Proves the threshold gap is exactly 1 edge via `omega`. States the combined optimality theorem: above the threshold, structure exists; below, it can be avoided.",
-      "startLine": 268,
-      "endLine": 316,
-      "mathContext": "Gap is exactly 1 edge: one more edge above $\\\\lfloor n^2/4\\\\rfloor + \\\\lfloor(n+1)/2\\\\rfloor - 1$ forces the subgraph."
+      "title": "Threshold Gap",
+      "summary": "Proves `threshold_gap` (`saturatedPlanarThreshold n = lowerThreshold n + 1`, via omega) and the combined `threshold_optimal`: above the threshold structure is forced (Simonovits), below it can be avoided (Erdős construction).",
+      "startLine": 418,
+      "endLine": 454,
+      "mathContext": "Gap is exactly 1 edge: $\\\\text{saturatedPlanarThreshold}\\\\,n = \\\\text{lowerThreshold}\\\\,n + 1$, so the threshold is tight."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "Closing overview: the problem is SOLVED (Simonovits) — exceeding $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$ edges forces $K_4$ or $C_\\ell + 2K_1$, the threshold is optimal within 1 edge.",
+      "startLine": 455,
+      "endLine": 478,
+      "mathContext": "Status SOLVED; key results: Simonovits dichotomy, Erdős lower construction, 1-edge optimal threshold."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1019 on saturated planar subgraphs in dense graphs in a ~290-line Lean file spanning 12 sections. The framework defines saturated planarity ($|E| = 3|V| - 6$), the edge density threshold $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the two forced structures ($K_4$ and $C_\\ell + 2K_1$). Simonovits's theorem is axiomatized and used to derive the affirmative answer. The threshold is proved tight within 1 edge, with 5 sorries and several axioms encoding deep results.",
-    "implications": "**Theoretical Significance**: This result connects several major themes in graph theory:\n\n1. **Supersaturation in extremal graph theory**: Beyond the Turán threshold $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$, not only do forbidden subgraphs appear, but *topologically rich* (saturated planar) subgraphs are forced. The critical threshold is $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the quantitative bound shows forced subgraphs on $\\Omega(k/n)$ vertices when the graph has $\\lfloor n^2/4 \\rfloor + k$ edges. This bridges extremal combinatorics and topological graph theory.\n\n2. **Simonovits stability program**: The $K_4 \\lor C_\\ell + 2K_1$ dichotomy is an early example of the structure-theoretic approach to extremal problems. Rather than just counting edges, it characterizes *which* structures must appear. Both forced structures satisfy $|E| = 3|V| - 6$ exactly: $K_4$ with $6 = 3(4) - 6$ and $C_\\ell + 2K_1$ with $3\\ell = 3(\\ell + 2) - 6$. This anticipates the Szemerédi regularity lemma (1975) and the graph removal lemma.\n\n3. **Threshold phenomena**: The identity $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor = \\lfloor n^2/4 \\rfloor + \\lfloor(n-1)/2\\rfloor + 1$ (proved by `omega`) establishes a 1-edge gap between construction and forcing. This is a sharp threshold phenomenon analogous to phase transitions in the Erdős-Rényi model $G(n,p)$. Such precise thresholds are rare and mathematically significant.\n\n4. **Formalization challenges**: The `isPlanar` definition as `sorry` highlights a concrete gap in Mathlib: topological planarity (via Kuratowski's theorem — $G$ is planar iff it has no $K_5$ or $K_{3,3}$ subdivision) is not yet formalized. The Four Color Theorem, which implies $\\chi(G) \\le 4$ for planar $G$, is another deep result awaiting formalization. These are active targets for the formalization community.",
+    "summary": "This formalization captures Erdős Problem #1019 on saturated planar subgraphs in dense graphs in a 478-line Lean file spanning 16 sections. The framework defines saturated planarity ($|E| = 3|V| - 6$), planarity via Wagner's forbidden-minor characterization, the edge density threshold $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the two forced structures ($K_4$ and $C_\\ell + 2K_1$). Triangle/Turán and K₃,₃-minor results are proved from Mathlib, Simonovits's theorem is axiomatized and used to derive the affirmative answer, and the threshold is proved tight within 1 edge. The file has 3 axioms (Simonovits's dichotomy, the C_ℓ+2K₁ saturation, and Erdős's construction) and a single remaining sorry (the $C(4,2)=6$ edge count for $K_4$).",
+    "implications": "**Theoretical Significance**: This result connects several major themes in graph theory:\n\n1. **Supersaturation in extremal graph theory**: Beyond the Turán threshold $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$, not only do forbidden subgraphs appear, but *topologically rich* (saturated planar) subgraphs are forced. The critical threshold is $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor$, and the quantitative bound shows forced subgraphs on $\\Omega(k/n)$ vertices when the graph has $\\lfloor n^2/4 \\rfloor + k$ edges. This bridges extremal combinatorics and topological graph theory.\n\n2. **Simonovits stability program**: The $K_4 \\lor C_\\ell + 2K_1$ dichotomy is an early example of the structure-theoretic approach to extremal problems. Rather than just counting edges, it characterizes *which* structures must appear. Both forced structures satisfy $|E| = 3|V| - 6$ exactly: $K_4$ with $6 = 3(4) - 6$ and $C_\\ell + 2K_1$ with $3\\ell = 3(\\ell + 2) - 6$. This anticipates the Szemerédi regularity lemma (1975) and the graph removal lemma.\n\n3. **Threshold phenomena**: The identity $\\lfloor n^2/4 \\rfloor + \\lfloor(n+1)/2\\rfloor = \\lfloor n^2/4 \\rfloor + \\lfloor(n-1)/2\\rfloor + 1$ (proved by `omega`) establishes a 1-edge gap between construction and forcing. This is a sharp threshold phenomenon analogous to phase transitions in the Erdős-Rényi model $G(n,p)$. Such precise thresholds are rare and mathematically significant.\n\n4. **Formalization challenges**: `isPlanar` is now defined via Wagner's forbidden-minor characterization (no $K_5$ or $K_{3,3}$ minor) using an explicit `GraphMinorWitness` structure, rather than topological planarity — full topological planarity (via subdivisions) is still not in Mathlib. The single remaining sorry is the routine $C(4,2)=6$ edge count for the complete graph on a 4-element type. The Four Color Theorem, which implies $\\chi(G) \\le 4$ for planar $G$, is another deep result awaiting formalization. These are active targets for the formalization community.",
     "openQuestions": [
       "Can Simonovits's proof be made fully constructive, yielding a polynomial-time algorithm to find $K_4$ or $C_\\ell + 2K_1$ in dense graphs?",
       "What is the analogous threshold for forcing saturated graphs on other surfaces (torus: $|E| \\le 3|V| + 3$; projective plane: $|E| \\le 3|V| - 3$)?",
       "What is the extremal number for $C_\\ell + 2K_1$ as a function of $\\ell$ and $n$? This connects to Turán-type problems for specific planar graphs.",
-      "Can the planarity definition `isPlanar` be formalized in Mathlib using Kuratowski's theorem ($G$ is planar iff it has no $K_5$ or $K_{3,3}$ minor)?",
+      "Can the `isPlanar` definition (currently Wagner's minor characterization with a custom `GraphMinorWitness`) be connected to a full topological planarity formalization in Mathlib (planar embeddings / Kuratowski subdivisions)?",
       "What is the minimum number of saturated planar subgraphs (on $> 3$ vertices) in a graph with $\\lfloor n^2/4 \\rfloor + k$ edges? This is the supersaturation version of Problem #1019."
     ]
   },


### PR DESCRIPTION
## Summary
- The 12 gallery sections for `erdos-1019` were pinned to an older, shorter revision of `Erdos1019Problem.lean`: they stopped at line 316 of 478 (66% covered) and ranges no longer matched the actual `## ` banners (e.g. "Planar Graphs" labeled 37-50 but really 88-99; "Simonovits's Theorem" labeled 209-229 but really 336-356).
- Rebuilt to **16 contiguous sections (22-478)** tracking the 16 actual `## ` banners, surfacing six previously-missing/mismatched sections: **Graph Minors**, **The Induced Subgraph**, **The Main Question**, **Related Results**, **Connection to Turán Theory**, and **Summary**.
- Section summaries now name the actual declarations (the proved `turan_triangle`, the K₃,₃-minor lemma, the single `sorry` in `K4_saturated_planar`).

## Stale prose fixed
- `conclusion.summary`: "~290-line ... 12 sections ... 5 sorries" → 478-line, 16 sections, 3 axioms, 1 sorry.
- Corrected the "`isPlanar` is a sorry" claim — `isPlanar` is now defined via Wagner's forbidden-minor characterization (`GraphMinorWitness`), and the resolved-Kuratowski openQuestion was updated.

## Notes
- Counts (`axiomCount` 3, `theoremCount` 13, `definitionCount` 23, `sorries` 1, `lineCount` 478) were already correct and are unchanged.
- Metadata-only change; no Lean source touched.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Section ranges are ordered, contiguous, and cover 22-478 (maxEndLine == lineCount)
- [x] Section titles/ranges verified against the `## ` banners in the Lean file