### PR TITLE
research(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01): rebuild gallery sections to full file (6→12)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -37,46 +37,88 @@
   },
   "sections": [
     {
-      "id": "indicator-lp",
-      "title": "Step 1: Indicator Functions in Lp",
-      "startLine": 46,
+      "id": "overview-architecture",
+      "title": "Overview: The Radon-Nikodým Route to Lp Duality",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "The module docstring (lines 1–41) frames the open question this file resolves: *can Mathlib's Radon–Nikodým machinery (`SignedMeasure.rnDeriv`) be composed with `Lp` membership to eliminate the surjectivity axiom of the Riesz representation theorem?* The answer formalized here is **yes** — the file gives a complete, axiom-free, sorry-free construction. The docstring lays out Rudin's *Real and Complex Analysis* Theorem 6.16 as a five-step architecture for representing a bounded functional φ ∈ (L^p)* by integration against some g ∈ L^q: (1) φ induces a signed measure ν(E) = φ(𝟙_E); (2) ν ≪ μ; (3) Radon–Nikodým yields g = dν/dμ; (4) g ∈ L^q via Hölder tightness; (5) φ(f) = ∫ fg dμ by density. The infrastructure setup (lines 43–51) imports all of Mathlib, opens `noncomputable section`, fixes a measurable space α with measure μ, and opens `namespace RieszLpSurjectivity`. **Note:** the docstring's phrasing about “remaining infrastructure needs as explicit sorries” and “~100–200 lines of additional infrastructure” is aspirational language from an early draft; per the Assessment Summary at the end of the file, every step is now fully proved (0 sorries, 0 axioms)."
+    },
+    {
+      "id": "step1-indicator-lp",
+      "title": "Step 1: Indicator Functions Belong to Lp",
+      "startLine": 54,
       "endLine": 67,
-      "summary": "Proves that indicator functions of finite-measure sets belong to $L^p$ and computes their $L^p$ norm as $\\mu(E)^{1/p}$."
+      "summary": "`indicator_memLp` (line 62) proves that the indicator 𝟙_E of a finite-measure measurable set E is a member of L^p for any 1 ≤ p ≤ ∞ (with p ≠ ∞). This is the foundational object: the entire construction runs by feeding Lp-indicators into the functional φ. The proof bounds the indicator by the constant 1 and invokes `MemLp.of_bound`, using that μ(E) is finite so the constant function 1 is itself in L^p on E."
     },
     {
-      "id": "absolute-continuity",
-      "title": "Step 2: Absolute Continuity of Functional-Induced Measure",
-      "startLine": 69,
-      "endLine": 108,
-      "summary": "Proves that the set function $E \\mapsto \\varphi(\\mathbf{1}_E)$ vanishes on $\\mu$-null sets, establishing absolute continuity of the induced signed measure."
+      "id": "step2-absolute-continuity",
+      "title": "Step 2: The Functional-Induced Set Function Vanishes on Null Sets",
+      "startLine": 68,
+      "endLine": 85,
+      "summary": "`indicator_eLpNorm_zero` (line 78) shows that when μ(E) = 0 the Lp-norm of the indicator 𝟙_E is zero, i.e. 𝟙_E = 0 in L^p. Composing with any continuous functional φ immediately gives φ(𝟙_E) = 0 on null sets — this is exactly the absolute-continuity seed ν ≪ μ of the Radon–Nikodým step. The proof reduces the `eLpNorm` of an indicator to a power of the set measure and uses μ(E) = 0."
     },
     {
-      "id": "rn-reconstruction",
-      "title": "Step 3: Radon-Nikodým Reconstruction",
-      "startLine": 110,
-      "endLine": 128,
-      "summary": "Applies Mathlib's Radon-Nikodým theorem: for $\\nu \\ll \\mu$, the derivative $g = d\\nu/d\\mu$ reconstructs $\\nu$ via $\\mu.\\mathrm{withDensity}_v(g) = \\nu$."
+      "id": "step3-signed-measure-setToFun",
+      "title": "Step 3: From Functional to a Set Function via setToFun",
+      "startLine": 86,
+      "endLine": 121,
+      "summary": "Defines `functionalSetFn` (line 101), the set function E ↦ φ(𝟙_E) that will be promoted to a signed measure, and proves `functionalSetFn_null` (line 108): the set function vanishes on μ-null sets, inheriting absolute continuity from Step 2. This packages the raw “φ applied to indicators” data into a measurable-set–indexed function suitable for the signed-measure construction later in the file."
     },
     {
-      "id": "lq-membership",
-      "title": "Step 4: Lq Membership via Hölder Extremizer",
-      "startLine": 130,
-      "endLine": 163,
-      "summary": "Proves $g \\in L^q$ via the Hölder extremizer: $h_n = \\mathrm{sign}(g_n)|g_n|^{q-1}$ satisfies $\\|g_n\\|_q \\leq \\|\\varphi\\|$ uniformly, then MCT gives $g \\in L^q$."
+      "id": "step4-radon-nikodym-reconstruction",
+      "title": "Step 4: Radon-Nikodým Reconstruction",
+      "startLine": 122,
+      "endLine": 144,
+      "summary": "`rn_reconstruction` (line 139) supplies the key bridge from Mathlib: for a signed measure s that is absolutely continuous with respect to a finite μ, the with-density reconstruction `μ.withDensityᵥ (s.rnDeriv μ) = s` holds. This is the formal content of the Radon–Nikodým theorem used downstream to recover ν(E) = ∫_E g dμ, where g = s.rnDeriv μ is the representing density."
     },
     {
-      "id": "density-extension",
-      "title": "Step 5: Integral Representation by Density",
-      "startLine": 165,
-      "endLine": 186,
-      "summary": "Extends the integral representation from indicator functions to all of $L^p$ via Lp.induction (indicator, addition, and closedness cases)."
+      "id": "step5-lq-membership-truncation",
+      "title": "Step 5: Lq Membership of the RN Derivative via Truncation + MCT",
+      "startLine": 145,
+      "endLine": 258,
+      "summary": "The crux of the argument. Rather than bounding g = dν/dμ directly, it works with truncations gₙ = clamp(g, −n, n). `truncated_rn_deriv_memLq` (line 167) shows each bounded truncation is trivially in L^q on a finite measure. `rn_deriv_memLq_from_trunc` (line 180) then upgrades a *uniform* L^q bound on the truncations to membership of the full g ∈ L^q. The proof is a careful Monotone-Convergence argument: it establishes the pointwise identity |gₙ| = min(|g|, n), shows ∫⁻ ‖gₙ‖^q ↑ ∫⁻ ‖g‖^q via `lintegral_iSup` (the supremum over n of the truncated integrals equals the full integral), and concludes eLpNorm g q μ ≤ ofReal M < ∞ from the uniform bound M. This is the step the docstring originally flagged as the missing ~100 lines; it is now fully discharged."
+    },
+    {
+      "id": "holder-pairing-integration-clm",
+      "title": "Hölder Pairing and the Integration Functional as a CLM",
+      "startLine": 259,
+      "endLine": 351,
+      "summary": "Builds the analytic pairing between L^p and L^q. `lintegral_mul_le_of_memLp` (line 259) is the lintegral-level Hölder inequality ∫⁻ ‖fg‖ ≤ ‖f‖_p · ‖g‖_q (via `ENNReal.lintegral_mul_le_Lp_mul_Lq`), and `integrable_mul_of_memLp` (line 279) derives Bochner integrability of the product fg from f ∈ L^p, g ∈ L^q. These feed `integrationCLM` (line 299), which packages f ↦ ∫ f·g dμ as a *continuous linear map* L^p →L[ℝ] ℝ via `LinearMap.mkContinuous`, with operator-norm bound ‖g‖_q supplied by Hölder. `integrationCLM_apply` (line 336) records the computation rule. This CLM is the candidate representative that the main theorem must show equals φ."
+    },
+    {
+      "id": "integral-representation-induction",
+      "title": "Integral Representation by Lp.induction",
+      "startLine": 352,
+      "endLine": 408,
+      "summary": "`integral_representation` (line 352) proves that once φ agrees with integration-against-g on every indicator (`hagree`), the two CLMs agree on *all* of L^p: φ(f) = ∫ f·g dμ for every f. The argument forms ψ = φ − integrationCLM and shows ψ vanishes on a dense, closed set via `Lp.induction` — the indicator base case comes from `hagree`, the additive case from linearity, and closedness from `isClosed_eq` of two continuous maps. This is the density-extension Step 5 of Rudin's architecture, fully proved (no remaining sorry despite the legacy comment on line 351)."
+    },
+    {
+      "id": "intermediate-sigma-additivity-signed-measure",
+      "title": "Intermediate Lemmas: σ-Additivity and Signed-Measure Construction",
+      "startLine": 409,
+      "endLine": 581,
+      "summary": "Assembles the measure-theoretic backbone that turns E ↦ φ(𝟙_E) into an honest signed measure. `indicator_lp_hasSum` (line 431) is the substantial lemma: for a pairwise-disjoint measurable family, the L^p partial sums of indicators converge in L^p-norm to the indicator of the union — proved by identifying terms with `indicatorConstLp`, reducing `HasSum` to `Tendsto`, and showing the symmetric-difference measures of the tails vanish (`tendsto_tsum_compl_atTop_zero`). `functional_hasSum_parts` (line 520) pushes this through the continuous φ to get σ-additivity of the set function. `signedMeasureOfFunctional` (line 536) then constructs the signed measure ν from φ, with `signedMeasureOfFunctional_indicator` (line 551) recording ν(E) = φ(𝟙_E) and `signedMeasureOfFunctional_ac` (line 560) its absolute continuity ν ≪ μ."
+    },
+    {
+      "id": "rn-identity-holder-extremizer",
+      "title": "RN Integrability, Reconstruction Identity, and the Hölder Extremizer Bound",
+      "startLine": 582,
+      "endLine": 987,
+      "summary": "Completes the L^q estimate that the truncation argument (Step 5) consumes. `rnDeriv_integrable_of_finite` (line 582) gives g = ν.rnDeriv μ ∈ L^1 from `SignedMeasure.integrable_rnDeriv`, and `rnDeriv_integral_eq` (line 591) proves the reconstruction identity ν(E) = ∫_E g dμ via Step 4 and `withDensityᵥ_apply`. The centerpiece is `holder_extremizer_lq_bound` (line 612, the longest proof in the file): for each truncation gₙ it produces the uniform estimate eLpNorm gₙ q μ ≤ ofReal‖φ‖ by testing against the Hölder extremizer hₙ = sign(gₙ)|gₙ|^{q−1}, whose L^p norm relates to ‖gₙ‖_q, then bounding ∫ hₙ g via simple-function approximation, φ-continuity, and dominated convergence (g ∈ L^1). Together these give the per-n bound fed into `rn_deriv_memLq_from_trunc`."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Riesz Lp Surjectivity from Radon-Nikodým",
       "startLine": 988,
-      "endLine": 1030,
-      "summary": "Combines all steps: given φ ∈ (Lp)*, constructs g ∈ Lq with φ(f) = ∫ fg dμ. Proves the parent file's riesz_lp_surjective axiom. 0 sorries, 0 axioms."
+      "endLine": 1042,
+      "summary": "`riesz_lp_surjective_from_rn` (line 1008) assembles all the pieces into the surjectivity direction of the Riesz representation theorem for L^p (1 < p < ∞, 1/p + 1/q = 1): every bounded linear functional φ on L^p is integration against some g ∈ L^q. The proof constructs ν = `signedMeasureOfFunctional` φ, takes g = ν.rnDeriv μ, establishes indicator agreement via `rnDeriv_integral_eq`, proves g ∈ L^q by combining `holder_extremizer_lq_bound` with `rn_deriv_memLq_from_trunc`, and extends to all of L^p via `integral_representation`. This eliminates the `riesz_lp_surjective` axiom assumed in the parent file — the headline result of the open question, with 0 sorries and 0 axioms."
+    },
+    {
+      "id": "assessment-summary",
+      "title": "Assessment Summary",
+      "startLine": 1043,
+      "endLine": 1077,
+      "summary": "The closing docstring (lines 1043–1073) inventories what the file proves sorry-free — Lp indicator membership, null-set vanishing, RN reconstruction, truncated and full L^q membership (via MCT), lintegral Hölder and integrationCLM, the Lp.induction representation, the signed-measure construction with absolute continuity, the RN reconstruction identity, σ-additivity (`indicator_lp_hasSum`), and the assembled main theorem — and records the final state: **0 sorries, 0 axioms** (complete as of 2026-04-23). It also documents the two dead-path theorems removed during development (`truncated_rn_deriv_lq_bound`, marked mathematically false, and the dependent `rn_deriv_memLq`) and the key milestones by session, explaining why the correct route is `rn_deriv_memLq_from_trunc` + `holder_extremizer_lq_bound`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Section metadata for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` (the Radon–Nikodým route to Lp duality / Riesz Lp surjectivity) had **drifted to an older file revision**. The 6 stored sections covered only:

- lines **46–186** — Steps 1–5 header material
- lines **988–1030** — the main theorem

…leaving the entire **187–987 block (~800 lines)** — the bulk of the actual proof — completely uncovered in the gallery view.

## Fix

Rebuilt to **12 contiguous full-file sections (1→1077)**, surfacing the previously hidden machinery:

- Step 5 Lq membership via truncation + Monotone Convergence (`rn_deriv_memLq_from_trunc`)
- Hölder pairing and the integration functional as a CLM (`integrationCLM`)
- Integral representation by `Lp.induction`
- σ-additivity and signed-measure construction (`indicator_lp_hasSum`, `signedMeasureOfFunctional`)
- RN integrability/reconstruction identity and the Hölder-extremizer bound (`holder_extremizer_lq_bound`)
- Main theorem `riesz_lp_surjective_from_rn` + assessment summary

Section summaries also note that the file's *header* docstring still uses early-draft "explicit sorries / ~200 lines remaining" framing, whereas the file is now complete (0 sorries, 0 axioms) per its own Assessment Summary.

## Verification

- Counts already correct and unchanged: **18 theorems / 3 defs / 0 axioms / 0 sorries** (the 10 grep "sorry" hits are all in comments).
- Sections now cover 1–1077 with no internal gaps.
- `pnpm research:build` exits 0.
- Metadata-only change; no Lean source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)