### PR TITLE
research(cantor-diagonalization-oq-01-oq-02): add header section for full-file coverage (9→10)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "module-header-setup",
+      "title": "Module Header and Setup",
+      "summary": "File header framing the open question — is the Continuum Hypothesis decided by large cardinal axioms? — with the partial answer: standard large cardinals (inaccessible, measurable, supercompact) do NOT decide CH (Lévy-Solovay), whereas forcing axioms (MA, PFA, MM) imply ¬CH, and Woodin's Ultimate-L program seeks a canonical resolution. Imports Mathlib cardinal/cofinality theory and the sibling `Proofs.ContinuumHypothesis`, sets linters, and opens the `CantorDiagOQ01OQ02` namespace. References: Lévy-Solovay (1967), Foreman-Magidor-Shelah (1988), Woodin (2001), Kanamori (2003).",
+      "startLine": 1,
+      "endLine": 57,
+      "mathContext": "Independence backdrop: CH is independent of ZFC (Gödel, Cohen); the question here is whether adding large cardinal axioms or forcing axioms settles it. Lévy-Solovay (1967): small forcing preserves large cardinals, so they cannot decide CH."
+    },
+    {
       "id": "large-cardinals",
       "title": "Large Cardinal Hierarchy",
       "startLine": 58,


### PR DESCRIPTION
## Summary

Doc-only gallery-metadata fix for **cantor-diagonalization-oq-01-oq-02** ("Large Cardinal Axioms and the Continuum Hypothesis"), the action explicitly recommended by the problem's `nextAction` (axiom elimination is blocked multi-year pending Mathlib forcing/inner-model theory).

The `sections` array started at L58, leaving the file header **L1-57 uncovered** in `Proofs/CantorDiagonalizationOQ01OQ02.lean` (361 lines). That region contains the imports, the Open Question framing, the partial-answer summary, and the References list.

### Changes
- Added a leading **"Module Header and Setup"** section (1-57) so coverage spans the full file **1-361**.
- The section surfaces the in-file citations into the gallery metadata as the `nextAction` requested: **Lévy-Solovay (1967)**, **Foreman-Magidor-Shelah (1988)**, **Woodin (2001)**, **Kanamori (2003)**.
- The existing 9 sections (58-361) were already accurately ranged and well-written — left unchanged.

### Counts (unchanged, verified accurate)
- axiomCount 7, sorries 0, theoremCount 19, definitionCount 10, lineCount 361 — all already correct; no count edits.

## Test plan
- [x] `pnpm research:build` completes with no errors/warnings for this slug
- [x] JSON validates; 10 sections ordered, contiguous, no gaps/overlaps; final endLine 361 == lineCount
- [x] New section range cross-checked against file (imports L1-6, header doc L8-49, set_options/namespace/open L51-57)