### PR TITLE
Enrich erdos-460: rebuild drifted sections 7→8 + de-stale axiomatic-sieve prose

### DIFF
--- a/src/data/proofs/erdos-460/annotations.json
+++ b/src/data/proofs/erdos-460/annotations.json
@@ -5,7 +5,7 @@
     "type": "concept",
     "range": {
       "startLine": 1,
-      "endLine": 14
+      "endLine": 22
     },
     "title": "Problem Background",
     "content": "Erdős Problem #460 concerns a greedy coprime sieve: given $n$, construct a sequence $a_0 = 0, a_1 = 1, a_2, \\ldots$ where each $a_k$ is the least integer exceeding $a_{k-1}$ such that $n - a_k$ is coprime to all previous $n - a_i$. The central question is whether the sum of reciprocals $\\sum_{0 < a_i < n} 1/a_i$ tends to infinity as $n \\to \\infty$. This connects greedy algorithms, coprimality structure, and divergence of reciprocal sums.",
@@ -24,13 +24,13 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 27,
-      "endLine": 32
+      "startLine": 35,
+      "endLine": 49
     },
     "title": "Greedy Coprime Sieve Sequence",
     "content": "The function `greedyCoprimeSieve n k` gives the $k$-th element of the greedy sequence for a fixed $n$. Starting with $a_0 = 0, a_1 = 1$, each subsequent $a_k$ is the least integer greater than $a_{k-1}$ such that $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. The sieve ensures the shifted values $n - a_0, n - a_1, \\ldots$ are pairwise coprime.",
     "significance": "key",
-    "mathContext": "a_k = \\min\\{m > a_{k-1} : \\gcd(n - m, n - a_i) = 1 \\; \\forall i < k\\}: Defined as a constant function with behavior specified by axioms sieve_initial and sieve_greedy. This separates specification from explicit construction, which would require implementing a computationally complex greedy search.",
+    "mathContext": "a_k = \\min\\{m > a_{k-1} : \\gcd(n - m, n - a_i) = 1 \\; \\forall i < k\\}: Implemented as a genuine well-founded recursive function (termination_by k, decreasing_by omega): a_{k+2} is the min' of the finite candidate set, or the sentinel n+1 when no candidate exists. Because the construction is explicit, sieve_initial and sieve_greedy are proved theorems rather than axioms.",
     "relatedConcepts": [
       "pairwise coprimality",
       "greedy sequence",
@@ -44,8 +44,8 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 35,
-      "endLine": 36
+      "startLine": 51,
+      "endLine": 54
     },
     "title": "Initial Values: $a_0 = 0, a_1 = 1$",
     "content": "The sieve starts with $a_0 = 0$ and $a_1 = 1$ for any $n \\geq 2$. The choice $a_0 = 0$ means $n - a_0 = n$, and $a_1 = 1$ gives $n - a_1 = n - 1$. Since $\\gcd(n, n-1) = 1$ always holds, the greedy condition is satisfied.",
@@ -62,11 +62,11 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 40,
-      "endLine": 45
+      "startLine": 56,
+      "endLine": 106
     },
     "title": "Greedy Selection Property",
-    "content": "For $k \\geq 2$, the axiom captures three properties: (1) $a_k > a_{k-1}$ (strict increase), (2) $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$ (pairwise coprimality of shifted values), and (3) minimality — every integer between $a_{k-1}$ and $a_k$ fails the coprimality condition for some earlier term.",
+    "content": "For $k \\geq 2$ with the sieve active ($a_k \\leq n$, i.e. not the sentinel), the proved theorem sieve_greedy establishes three properties: (1) $a_k > a_{k-1}$ (strict increase), (2) $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$ (pairwise coprimality of shifted values), and (3) minimality — every integer between $a_{k-1}$ and $a_k$ fails the coprimality condition for some earlier term. The proof reads these off from `Finset.min'_mem` of the candidate set; the `hactive` hypothesis is essential because the unguarded claim is false at the n+1 sentinel (e.g. n=2, k=2).",
     "significance": "key",
     "mathContext": "a_k > a_{k-1}, \\quad \\gcd(n - a_k, n - a_i) = 1 \\; \\forall i < k, \\quad \\nexists\\, m \\in (a_{k-1}, a_k) \\text{ satisfying coprimality}: The minimality clause is crucial: it ensures the sequence is uniquely defined by the greedy rule, not just any coprime subsequence. Without minimality, many sequences would satisfy the other two conditions.",
     "relatedConcepts": [
@@ -80,8 +80,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 52,
-      "endLine": 54
+      "startLine": 112,
+      "endLine": 115
     },
     "title": "Sieve Count",
     "content": "`sieveCount n` counts how many terms of the sieve sequence are less than $n$. Since the sequence is increasing and bounded by $n$, this is finite. The count determines the range of summation for the reciprocal sum.",
@@ -98,8 +98,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 60,
-      "endLine": 65
+      "startLine": 121,
+      "endLine": 126
     },
     "title": "Reciprocal Sum $\\sum 1/a_i$",
     "content": "The sum $\\sum_{0 < a_i < n} 1/a_i$ is computed over positive sieve terms less than $n$. This is a finite sum for each $n$. The central question is whether this sum diverges as $n \\to \\infty$. If the Eggleton-Erdős-Selfridge conjectured bound $a_k \\ll k \\log k$ holds, then the reciprocal sum would be $\\gg \\sum 1/(k \\log k) = \\infty$.",
@@ -116,8 +116,8 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 71,
-      "endLine": 79
+      "startLine": 132,
+      "endLine": 140
     },
     "title": "Main Conjecture: Divergence of Reciprocal Sum",
     "content": "Erdős Problem #460: for every $M > 0$, there exists $N_0$ such that for all $n \\geq N_0$, the reciprocal sum $\\sum_{0 < a_i < n} 1/a_i > M$. Equivalently, $\\lim_{n \\to \\infty} S(n) = \\infty$. The problem is OPEN — the known growth bound $a_k < k^{2+\\varepsilon}$ is too weak to imply divergence.",
@@ -135,8 +135,8 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 87,
-      "endLine": 90
+      "startLine": 146,
+      "endLine": 151
     },
     "title": "Eggleton-Erdős-Selfridge Bound: $a_k < k^{2+o(1)}$",
     "content": "Eggleton, Erdős, and Selfridge proved that the sieve sequence satisfies $a_k < k^{2+\\varepsilon}$ for any $\\varepsilon > 0$ and all sufficiently large $k$. This quadratic-type growth is the best known upper bound. It means the sieve doesn't grow too fast, but is insufficient for reciprocal sum divergence (since $\\sum 1/k^{2+\\varepsilon}$ converges).",
@@ -153,8 +153,8 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 93,
-      "endLine": 96
+      "startLine": 153,
+      "endLine": 158
     },
     "title": "Conjectured Bound: $a_k \\ll k \\log k$",
     "content": "It is conjectured that $a_k \\leq C \\cdot k \\log k$ for some constant $C > 0$. If true, this would immediately imply Problem #460 since $\\sum_{k=2}^{N} 1/(k \\log k)$ diverges (by the integral test, as $\\int dx/(x \\ln x) = \\ln \\ln x \\to \\infty$).",
@@ -171,8 +171,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 103,
-      "endLine": 105
+      "startLine": 173,
+      "endLine": 176
     },
     "title": "Least Prime Factor",
     "content": "The least prime factor $P^-(n)$ of $n$ is defined as `Nat.minFac n` for $n > 1$, and 0 for $n \\leq 1$. This function appears in the sufficient condition for Problem #460: the filtered sum over $a$ where $P^-(n-a) > a$.",
@@ -189,8 +189,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 110,
-      "endLine": 114
+      "startLine": 197,
+      "endLine": 204
     },
     "title": "Least Prime Factor Filtered Sum $f(n)$",
     "content": "The function $f(n) = \\sum_{\\substack{0 < a < n \\\\ P^-(n-a) > a}} 1/a$ sums reciprocals over those $a < n$ whose complement $n - a$ has all prime factors exceeding $a$. This is a 'smooth number' condition on $n - a$. Divergence of $f(n)$ would imply Problem #460.",
@@ -209,11 +209,11 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 117,
-      "endLine": 119
+      "startLine": 206,
+      "endLine": 225
     },
     "title": "Filtered Sum Implies Full Divergence",
-    "content": "If $f(n) \\to \\infty$ then Problem #460 holds. This is because the greedy coprime sieve must include at least the terms counted by the filtered sum — if $P^-(n-a) > a$, then $n - a$ is automatically coprime to all $n - a_i$ for $a_i < a$ (since $n - a$ has no prime factors $\\leq a$).",
+    "content": "If $f(n) \\to \\infty$ then Problem #460 holds. This is because the greedy coprime sieve must include at least the terms counted by the filtered sum — if $P^-(n-a) > a$, then $n - a$ is automatically coprime to all $n - a_i$ for $a_i < a$ (since $n - a$ has no prime factors $\\leq a$). In Lean this is `filtered_sum_implies_full`, the file's single `sorry`: it was converted from an axiom to a theorem-with-sorry for axiom integrity, leaving the reduction as an explicit unproved gap (rather than an assumed truth) for Aristotle to attempt.",
     "significance": "key",
     "mathContext": "f(n) \\to \\infty \\implies \\text{ErdosProblem460}: If P⁻(n-a) > a, then for any a' < a, gcd(n-a, n-a') cannot share a prime ≤ a since all prime factors of n-a exceed a. So the coprimality condition is automatically satisfied, meaning the greedy sieve includes these terms.",
     "relatedConcepts": [
@@ -227,8 +227,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 126,
-      "endLine": 132
+      "startLine": 231,
+      "endLine": 238
     },
     "title": "Small Prime Divisible Sum",
     "content": "The sum restricted to sieve terms $a_k$ where $n - a_k$ has a prime factor $p \\leq a_k$. These are the 'easy' terms to include in the sieve — their coprimality follows from avoiding specific small primes.",
@@ -246,8 +246,8 @@
     "proofId": "erdos-460",
     "type": "definition",
     "range": {
-      "startLine": 135,
-      "endLine": 140
+      "startLine": 240,
+      "endLine": 246
     },
     "title": "Large Prime Sum",
     "content": "The complementary sum over sieve terms where $P^-(n - a_k) > a_k$ — all prime factors of $n - a_k$ exceed $a_k$. These are the 'hard' terms where coprimality is automatic but the contribution to the reciprocal sum depends on the distribution of smooth numbers.",
@@ -265,8 +265,8 @@
     "proofId": "erdos-460",
     "type": "concept",
     "range": {
-      "startLine": 143,
-      "endLine": 146
+      "startLine": 276,
+      "endLine": 291
     },
     "title": "Restricted Sum Divergence Question",
     "content": "Erdős asked whether the two restricted sums (small-prime and large-prime) individually diverge. If either one diverges, Problem #460 follows since the full sum dominates each restricted sum. This splits the divergence question into two potentially easier subproblems with different flavors: the small-prime case is combinatorial, while the large-prime case involves smooth number estimates.",

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -48,11 +48,11 @@
       }
     ],
     "originalContributions": [
-      "Axiomatic definition of the greedy coprime sieve sequence with initial values and greedy selection property",
+      "Constructive well-founded recursive definition of the greedy coprime sieve sequence, with sieve_initial and sieve_greedy proved from the definition (sieve_greedy guarded by hactive to exclude the n+1 sentinel)",
       "Formal statement of ErdosProblem460 as divergence of reciprocal sums",
-      "Formalization of the Eggleton-Erdős-Selfridge bound a_k < k^{2+o(1)} and the conjectured a_k ≪ k log k",
-      "Definition of the least-prime-factor filtered sum f(n) and its sufficiency axiom",
-      "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
+      "Formalization of the Eggleton-Erdős-Selfridge bound a_k < k^{2+o(1)} (the sole axiom) and the conjectured a_k ≪ k log k as an open-conjecture def",
+      "Definition of the least-prime-factor filtered sum f(n) and the proved-modulo-sorry reduction filtered_sum_implies_full",
+      "Splitting into smallPrimeDivisibleSum and largePrimeSum with proved sub-sum bounds and erdos_460_restricted_question (divergence of either restricted sum implies the conjecture)"
     ],
     "axiomCount": 1,
     "lineCount": 327,
@@ -104,7 +104,7 @@
     "historicalContext": "Erdős posed this problem in 1977 (p.64) and it appears in Erdős-Graham (1980, p.91). Given n, one greedily selects a_0 = 0, a_1 = 1, and each a_k as the smallest integer exceeding a_{k-1} with n - a_k coprime to all previous n - a_i. The resulting shifted values {n - a_k} are pairwise coprime.\n\nEggleton, Erdős, and Selfridge proved a_k < k^{2+o(1)} and conjectured the stronger bound a_k ≪ k log k. The quadratic bound alone is insufficient for reciprocal sum divergence since Σ 1/k^{2+ε} converges, but the conjectured k log k bound would imply divergence since Σ 1/(k log k) diverges by the integral test.\n\nThe problem connects greedy algorithms in multiplicative number theory to reciprocal sum divergence, a theme appearing across many Erdős problems. The least-prime-factor sufficient condition links it to smooth number distribution.",
     "problemStatement": "Let $a_0 = 0$, $a_1 = 1$, and $a_k$ the least integer $> a_{k-1}$ with $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. Does $\\sum_{0 < a_i < n} \\frac{1}{a_i} \\to \\infty$ as $n \\to \\infty$?",
     "text": "Let $a_0 = 0$, $a_1 = 1$. Define $a_k$ as the least integer $> a_{k-1}$ with $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. Does $\\sum_{0 < a_i < n} \\frac{1}{a_i} \\to \\infty$ as $n \\to \\infty$? OPEN.",
-    "proofStrategy": "The formalization defines greedyCoprimeSieve axiomatically as a function ℕ → ℕ → ℕ, with sieve_initial and sieve_greedy capturing the initial conditions and the greedy minimality property. The reciprocal sum sieveReciprocalSum is defined via Finset.range and conditional summation. ErdosProblem460 states that for every M > 0, there exists N₀ such that Σ 1/a_i > M for all n ≥ N₀. The known growth bound and conjectured bound are axiomatized. A key structural insight is the least-prime-factor sufficient condition: if f(n) = Σ_{a < n, P⁻(n-a) > a} 1/a → ∞, then the full sum diverges. The formalization also splits the sum into small-prime and large-prime components.",
+    "proofStrategy": "The formalization defines greedyCoprimeSieve constructively as a well-founded recursive function ℕ → ℕ → ℕ (a_0 = 0, a_1 = 1, and a_{k+2} = the min' of the candidate set, with an n+1 sentinel when no candidate exists), so sieve_initial and sieve_greedy are now proved theorems rather than axioms — sieve_greedy carries an `hactive` guard because the unguarded statement is false at the sentinel. The reciprocal sum sieveReciprocalSum is defined via Finset.range and conditional summation. ErdosProblem460 states that for every M > 0, there exists N₀ such that Σ 1/a_i > M for all n ≥ N₀. Only the Eggleton-Erdős-Selfridge upper bound a_k < k^{2+ε} remains an axiom; the stronger k log k bound is a def (SieveConjecturedBound) marking it as an open conjecture. A key structural insight is the least-prime-factor sufficient condition: if f(n) = Σ_{a < n, P⁻(n-a) > a} 1/a → ∞, then the full sum diverges (filtered_sum_implies_full, the file's single sorry). The formalization also splits the sum into small-prime and large-prime components and proves (erdos_460_restricted_question) that divergence of either implies the conjecture.",
     "keyInsights": [
       "The greedy sieve produces a sequence whose shifted values n - a_k are pairwise coprime, connecting coprimality structure to sequence growth",
       "Eggleton-Erdős-Selfridge: a_k < k^{2+o(1)}, conjectured a_k ≪ k log k; the quadratic bound alone is insufficient to prove divergence via comparison",
@@ -120,56 +120,63 @@
   "sections": [
     {
       "id": "sieve-sequence",
-      "title": "The Greedy Coprime Sieve Sequence",
-      "startLine": 23,
-      "endLine": 46,
-      "summary": "Defines greedyCoprimeSieve axiomatically with sieve_initial and sieve_greedy"
+      "title": "Section I: The Greedy Coprime Sieve Sequence",
+      "startLine": 31,
+      "endLine": 107,
+      "summary": "Defines greedyCoprimeSieve as a genuine well-founded recursive function (a_0 = 0, a_1 = 1, and a_{k+2} = min' of the filtered candidate set, returning the sentinel n+1 when no valid candidate exists). sieve_initial proves the base values, and sieve_greedy proves — when the sieve is active (result ≤ n) — the three defining properties: strict increase, pairwise coprimality of the shifted values, and minimality. Both were previously axioms; sieve_greedy needs an hactive guard because the original unguarded axiom was false for the n+1 sentinel case (n=2, k=2)."
     },
     {
       "id": "sieve-count",
-      "title": "The Sequence Terminates Before n",
-      "startLine": 47,
-      "endLine": 55,
-      "summary": "sieveCount via Finset.filter on Finset.range n"
+      "title": "Section II: The Sequence Terminates Before n",
+      "startLine": 108,
+      "endLine": 116,
+      "summary": "sieveCount n counts how many sieve terms are < n, via Finset.card on Finset.range n filtered by existence of a sieve preimage. This finiteness makes the reciprocal sum well-defined."
     },
     {
       "id": "reciprocal-sum",
-      "title": "The Reciprocal Sum",
-      "startLine": 56,
-      "endLine": 66,
-      "summary": "sieveReciprocalSum with conditional summation excluding a_0 = 0"
+      "title": "Section III: The Reciprocal Sum",
+      "startLine": 117,
+      "endLine": 127,
+      "summary": "sieveReciprocalSum n sums 1/a_k over the first sieveCount n indices, with a conditional guard excluding a_0 = 0 and any term ≥ n. This is the quantity whose divergence the problem asks about."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 67,
-      "endLine": 80,
-      "summary": "ErdosProblem460: divergence of reciprocal sums in ε-N form"
+      "title": "Section IV: The Conjecture",
+      "startLine": 128,
+      "endLine": 141,
+      "summary": "ErdosProblem460 states divergence in ε-N form: for every M > 0 there is N_0 such that sieveReciprocalSum n > M for all n ≥ N_0. This is the central open question, encoded as a Prop."
     },
     {
       "id": "known-bounds",
-      "title": "Known Bounds",
-      "startLine": 81,
-      "endLine": 97,
-      "summary": "Eggleton-Erdős-Selfridge k^{2+o(1)} bound and conjectured k log k bound"
+      "title": "Section V: Known Bounds",
+      "startLine": 142,
+      "endLine": 168,
+      "summary": "The lone axiom eggleton_erdos_selfridge encodes the proved upper bound a_k < k^{2+ε}. SieveConjecturedBound is a def (an OPEN conjecture, demoted from axiom) stating a_k ≪ k log k. sieveReciprocalSum_nonneg proves the sum is non-negative. The quadratic bound gives Σ 1/k^{2+ε} (convergent, hence insufficient); the conjectured k log k bound would force divergence."
     },
     {
       "id": "least-prime-factor",
-      "title": "Least Prime Factor Connection",
-      "startLine": 98,
-      "endLine": 120,
-      "summary": "leastPrimeFactor, leastPrimeFilteredSum, and sufficiency axiom"
+      "title": "Section VI: Least Prime Factor Connection",
+      "startLine": 169,
+      "endLine": 226,
+      "summary": "Defines leastPrimeFactor (Nat.minFac for n ≥ 2, else 0) with three proved support lemmas (prime, dvd, le). leastPrimeFilteredSum n = Σ_{0<a<n, P⁻(n-a)>a} 1/a is a smooth-number-filtered sub-sum. filtered_sum_implies_full reduces the conjecture to divergence of this filtered sum — it carries the file's single sorry (converted from an axiom for axiom integrity, left for Aristotle to attempt)."
     },
     {
       "id": "restricted-sums",
-      "title": "Restricted Sums",
-      "startLine": 121,
-      "endLine": 146,
-      "summary": "smallPrimeDivisibleSum, largePrimeSum, and restricted divergence question"
+      "title": "Section VII: Restricted Sums",
+      "startLine": 227,
+      "endLine": 292,
+      "summary": "smallPrimeDivisibleSum and largePrimeSum partition the sieve reciprocal sum by whether n - a_k has a prime factor ≤ a_k. Two proved private lemmas bound each restricted sum above by sieveReciprocalSum, and erdos_460_restricted_question proves the disjunctive sufficient condition: divergence of either restricted sum implies ErdosProblem460."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Section VIII: Additional Structural Properties",
+      "startLine": 293,
+      "endLine": 327,
+      "summary": "Auxiliary proved theorems: sieve_at_zero and sieve_at_one give the base values by rfl, smallPrimeDivisibleSum_nonneg and largePrimeSum_nonneg establish non-negativity of the restricted sums, and leastPrimeFactor_prime_eq shows P⁻(p) = p for prime p."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 460 asks whether the reciprocal sum of a greedy coprime sieve sequence diverges. The formalization captures the complete problem structure: axiomatic sieve definition, the known k^{2+o(1)} growth bound (which is too weak to resolve divergence), the conjectured k log k bound, a sufficient condition via least-prime-factor filtered sums, and Erdős's further question about restricted sum divergence.",
+    "summary": "Erdős Problem 460 asks whether the reciprocal sum of a greedy coprime sieve sequence diverges. The formalization captures the complete problem structure: a constructive recursive sieve definition with the greedy-selection properties proved (not axiomatized), the known k^{2+o(1)} growth bound as the single axiom (too weak to resolve divergence), the conjectured k log k bound as an open-conjecture def, a sufficient condition via least-prime-factor filtered sums (filtered_sum_implies_full, the lone sorry), and Erdős's further question about restricted sum divergence proved as a reduction.",
     "implications": "Resolution would connect greedy coprime selection with reciprocal sum divergence, bridging sieve theory, smooth number distribution, and additive combinatorics. The sufficient condition via P⁻(n-a) > a links the problem to the distribution of smooth numbers in arithmetic progressions.",
     "openQuestions": [
       "Does Σ_{0 < a_i < n} 1/a_i → ∞ as n → ∞?",


### PR DESCRIPTION
## Summary
`Erdos460Problem.lean` was rewritten from a dummy `fun _ => 0` sieve (with all behavior axiomatized) into a genuine well-founded recursive `greedyCoprimeSieve`, making `sieve_initial`/`sieve_greedy` proved theorems. The gallery `meta.json` and `annotations.json` still described the old axiomatic version and covered only lines 23–146 of the 327-line file.

- **Sections 7 → 8**, realigned to the file's `## Section I–VIII` banners and now covering lines **31–327 contiguously**. The old sections stopped at 146 with the last few mislabeled onto interior lines of the `sieve_greedy` proof (e.g. "Restricted Sums" was tagged 121–146 but the real Section VII is at 227–292). Restored hidden Sections **VI** (least-prime-factor connection), **VII** (restricted sums), **VIII** (structural properties).
- **Realigned all 15 annotation ranges**, which were 60–130 lines off the real declarations — e.g. `erdos_460_restricted_question` was tagged 143–146 but lives at 276–291; `largePrimeSum` was at 135–140 but is at 240–246.
- **Fixed stale "axiomatic" prose** across `proofStrategy`, `originalContributions`, `conclusion`, and the sieve annotations: the sieve is a constructive recursive def and `sieve_greedy` is proved (with an `hactive` guard for the n+1 sentinel); the conjectured `k log k` bound is a `def` (open conjecture), not an axiom; only `eggleton_erdos_selfridge` is an axiom and `filtered_sum_implies_full` is the single `sorry`.

Counts (15 thm / 9 def / 1 axiom / 1 sorry / 327 LC) were already correct.

## Test plan
- [x] `pnpm research:build` exits 0
- [x] `meta.json` and `annotations.json` parse as valid JSON
- [x] Sections cover the full file 31–327 with no overlaps or start>end
- [x] Every annotation range now matches its declaration in the Lean source
- [x] No open PR touches `src/data/proofs/erdos-460/`