### PR TITLE
Enrich shannon-channel-coding-oq-02-oq-01: surface hidden discharge section + de-stale blocked narrative

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Bridge Architecture: Two Definitions, One Theorem",
-    "content": "This file resolves a modular tension in the information theory formalization: OQ-03 proved Fano's inequality using its own private `conditionalEntropy` definition to avoid importing a broken dependency, while the rest of the project uses `InformationTheory.conditionalEntropy` from ShannonEntropy.lean. The bridge confirms these are the same, allowing OQ-03's result to flow into the broader framework.\n\nThe architectural lesson: when a dependency has a known bug, it can be productive to duplicate the minimal interface (here, just the conditional entropy definition) and prove the main theorem self-contained, then bridge back later. This 'islands of correctness' approach allows progress without waiting for upstream fixes.",
+    "content": "This file resolves a modular tension in the information theory formalization: OQ-03 proved Fano's inequality using its own private `conditionalEntropy` definition to avoid importing a then-broken dependency, while the rest of the project uses `InformationTheory.conditionalEntropy` from ShannonEntropy.lean. The bridge confirms these are the same, letting OQ-03's result flow into the broader framework — and, now that the dependency is fixed (PR #16334), letting Section 5 discharge the parent `fano_inequality` axiom outright.\n\nThe architectural lesson: when a dependency has a known bug, it can be productive to duplicate the minimal interface (here, just the conditional entropy definition) and prove the main theorem self-contained, then bridge back once the upstream fix lands. This 'islands of correctness' approach let OQ-03 make progress before the blocker was resolved.",
     "mathContext": "Two definitions:\n$H_1(X|Y) = -\\sum_x\\sum_y [\\text{if } p=0 \\text{ then } 0 \\text{ else } p \\log(p/p_Y)]$ (OQ-03)\n$H_2(X|Y) = -\\sum_x\\sum_y [\\text{if } p=0 \\text{ then } 0 \\text{ else } p \\log(p/p_Y)]$ (standard)\nSame formula → definitional equality.",
     "significance": "key",
     "relatedConcepts": [
@@ -25,8 +25,8 @@
     "id": "ann-def-compat",
     "proofId": "shannon-channel-coding-oq-02-oq-01",
     "range": {
-      "startLine": 39,
-      "endLine": 50
+      "startLine": 45,
+      "endLine": 56
     },
     "type": "concept",
     "title": "Definitional Equality via rfl",
@@ -47,8 +47,8 @@
     "id": "ann-fano-corollary",
     "proofId": "shannon-channel-coding-oq-02-oq-01",
     "range": {
-      "startLine": 56,
-      "endLine": 69
+      "startLine": 62,
+      "endLine": 76
     },
     "type": "concept",
     "title": "One-Line Proof via OQ-03",
@@ -70,14 +70,14 @@
     "id": "ann-shannon-entropy-bug",
     "proofId": "shannon-channel-coding-oq-02-oq-01",
     "range": {
-      "startLine": 73,
-      "endLine": 107
+      "startLine": 77,
+      "endLine": 136
     },
     "type": "insight",
-    "title": "Root Cause: Sum Order Mismatch in strong_subadditivity",
-    "content": "ShannonEntropy.lean's `strong_subadditivity` proof fails at line 811 with `linarith [h_cmi]`. The root cause is a sum order mismatch: after the `simp_rw [hYZ]` rewrite, the YZ marginal sum has order `∑ y : β, ∑ z : γ, ∑ x : α, f x y z`, but after `simp_rw [hterm]`, the same quantity from the hterm expansion has order `∑ x : α, ∑ y : β, ∑ z : γ, f x y z`.\n\nLean's `linarith` tactic works syntactically — it cannot see that these sums are definitionally equal (by Finset.sum_comm), so the cancellation that should make the inequality obvious doesn't happen.\n\nThe fix: add a `simp_rw [Finset.sum_comm (s := Finset.univ)]` rewrite before `linarith [h_cmi]` to normalize the sum order. This is a routine commutativity rewrite that would complete the proof.",
-    "mathContext": "Blocked step: `linarith [h_cmi]` where `h_cmi ≥ 0` should cancel a term. Mismatch: one copy of $\\sum_y\\sum_z\\sum_x f$ vs $\\sum_x\\sum_y\\sum_z f$. Fix: `Finset.sum_comm` normalizes to $\\sum_x\\sum_y\\sum_z f$.",
-    "significance": "key",
+    "title": "Historical Blocker: Sum Order Mismatch in strong_subadditivity (Resolved)",
+    "content": "This comment block records a blocker that has since been resolved. ShannonEntropy.lean's `strong_subadditivity` proof originally failed at line 811 with `linarith [h_cmi]`. The root cause was a sum order mismatch: after the `simp_rw [hYZ]` rewrite, the YZ marginal sum had order `∑ y : β, ∑ z : γ, ∑ x : α, f x y z`, but the same quantity from the hterm expansion had order `∑ x : α, ∑ y : β, ∑ z : γ, f x y z`. Lean's `linarith` works syntactically and could not see these as equal (they differ by `Finset.sum_comm`), so the cancellation never fired.\n\nThe diagnosed fix — inserting a `Finset.sum_comm` normalization before `linarith [h_cmi]` — was applied in PR #16334, which made `strong_subadditivity` a genuine theorem. That is why this file can now `import Proofs.ShannonEntropy` (line 34) and complete the axiom discharge in Section 5. The block is retained as documentation of the original obstruction and the 'islands of correctness' strategy that let OQ-03 progress while it stood.",
+    "mathContext": "Originally-blocked step: `linarith [h_cmi]` where `h_cmi ≥ 0` should cancel a term. Mismatch: one copy of $\\sum_y\\sum_z\\sum_x f$ vs $\\sum_x\\sum_y\\sum_z f$. Resolved by `Finset.sum_comm` normalization (PR #16334).",
+    "significance": "supporting",
     "relatedConcepts": [
       "strong subadditivity",
       "sum commutativity",
@@ -94,23 +94,48 @@
     "id": "ann-trivial-case",
     "proofId": "shannon-channel-coding-oq-02-oq-01",
     "range": {
-      "startLine": 126,
-      "endLine": 141
+      "startLine": 137,
+      "endLine": 188
     },
     "type": "concept",
     "title": "Edge Case: |X| = 1",
-    "content": "For the degenerate case where X takes only one value (Unit type), Fano's inequality is trivially satisfied. Both sides equal 0: H(X|Y) = 0 because X is deterministic (knowing or not knowing Y gives no information about a fixed value), and the RHS collapses to h(p)·0 because log(|X|-1) = log(0) = 0.\n\nThis case is mathematically transparent but has a Lean simp challenge: simplifying `∑ x : Unit, f x` to `f ()` via `Fintype.sum_unique` interacts poorly with the surrounding `if pXY(x,y) = 0 then 0 else ...` structure. The proof is marked sorry pending a cleaner tactic approach.",
-    "mathContext": "For $|\\mathcal{X}|=1$: $H(X|Y) = 0$ (deterministic X) and $(|\\mathcal{X}|-1)\\log = 0\\cdot\\log(0) = 0$.",
+    "content": "For the degenerate case where X takes only one value (Unit type), Fano's inequality is trivially satisfied. Both sides equal 0: H(X|Y) = 0 because X is deterministic (knowing or not knowing Y gives no information about a fixed value), and the RHS collapses because log(|X|-1) = log(0) = 0 annihilates the second term while P_e = 0 by hsum.\n\nThe case is mathematically transparent but takes real work in Lean: `fano_trivial_singleton` must push `∑ x : Unit, f x = f ()` collapses through both the P_e expression and the conditional-entropy `if pXY(x,y)=0 then 0 else ...` structure, using `div_self` to reduce each surviving log argument to 1. The theorem is fully proved (no sorry); `fano_singleton_card_one` in Section 5 generalizes it to any `Fintype.card α = 1` via `Subsingleton`.",
+    "mathContext": "For $|\\mathcal{X}|=1$: $H(X|Y) = 0$ (deterministic X), $P_e = 0$, and $(|\\mathcal{X}|-1)\\log = 0\\cdot\\log(0) = 0$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Unit type in Lean",
       "Fintype.sum_unique",
+      "Subsingleton collapse",
       "degenerate distributions"
     ],
     "prerequisites": [
       "Fintype.card_unit = 1",
       "Real.log_zero = 0",
       "Finset.sum over Unit"
+    ]
+  },
+  {
+    "id": "ann-axiom-discharge",
+    "proofId": "shannon-channel-coding-oq-02-oq-01",
+    "range": {
+      "startLine": 189,
+      "endLine": 318
+    },
+    "type": "insight",
+    "title": "Discharging the fano_inequality Axiom",
+    "content": "Section 5 is where the bridge pays off. With the strong_subadditivity blocker resolved (PR #16334), `fano_from_oq03_std` restates the |α|≥2 bound against the project-standard `InformationTheory.conditionalEntropy` and is proved by `:=` — supplying the OQ-03 proof term directly, since the two conditional-entropy definitions are definitionally equal. `fano_singleton_card_one` covers the general one-element domain via a `Subsingleton` collapse. `fano_inequality_proved` then assembles a hypothesis-free dispatcher: it first derives `Nonempty α` (an empty domain makes ∑ pXY = 0, contradicting hsum = 1), then case-splits on `Fintype.card α` — card 1 routes to the singleton lemma, card ≥ 2 to the OQ-03 route. Its statement is a literal match for the `fano_inequality` axiom signature, so the parent `ShannonChannelCoding.lean` defines `theorem fano_inequality := FanoFromConditionalEntropy.fano_inequality_proved ...`, reducing the parent's axiom count from 4 to 3.",
+    "mathContext": "Dispatcher: $|\\mathcal{X}| = 0 \\Rightarrow$ contradiction with $\\sum pXY = 1$; $|\\mathcal{X}| = 1 \\Rightarrow$ singleton case; $|\\mathcal{X}| \\geq 2 \\Rightarrow$ OQ-03 route. Conclusion: $H(X|Y) \\leq h(P_e) + P_e\\log(|\\mathcal{X}|-1)$ for the standard definition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "axiom discharge",
+      "definitional equality",
+      "case analysis on Fintype.card",
+      "modular proof reuse"
+    ],
+    "prerequisites": [
+      "fano_theorem from OQ-03",
+      "Fintype.card case analysis",
+      "Subsingleton / Nonempty reasoning"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
This gallery entry's `meta.json` was internally inconsistent. The `description`/`assumptions` had been updated to say the `fano_inequality` axiom is now **discharged** (parent `axiomCount` 4 → 3), but the `sections`, `proofStrategy`, `keyInsights`, and `conclusion` still described the OLD "blocked, pending ShannonEntropy.lean fix" state. The `sections` and `annotations` stopped at line 181, hiding **Section 5** (lines 189–318) — which contains the actual discharge theorems.

**Verified against source** before rewriting: parent `ShannonChannelCoding.lean` line 200 is now `theorem fano_inequality := FanoFromConditionalEntropy.fano_inequality_proved ...`, `strong_subadditivity` is a proved theorem, and the parent has exactly 3 axioms remaining.

- **Sections 5 → 6**, now covering the full file 1–318 (was 1–181). Added Section 5 "Discharge of the fano_inequality Axiom" (`fano_from_oq03_std`, `fano_singleton_card_one`, `fano_inequality_proved`) and retitled the Section 3 doc block to "Historical Blocker (Resolved)".
- **Fixed `lineCount` 312 → 318** (both `meta.meta` and `leanFile`).
- **De-staled the narrative**: `proofStrategy` layer 3 ("blocked" → "axiom discharge done"); `keyInsights` (dropped the dead line-811 fix-recipe insights, added the dispatcher + definitional-reuse insights); `conclusion` (the axiom is eliminated, not pending); `originalContributions` (added the 4 discharge theorems); one crossReference.
- **Annotations**: realigned ranges, reframed the `strong_subadditivity` bug note as resolved-by-PR-#16334, corrected the |X|=1 note (`fano_trivial_singleton` is fully proved, not "marked sorry"), and added an annotation for the discharge section.

Counts (6 thm / 0 def / 0 axiom / 0 sorry) were already correct.

## Test plan
- [x] `pnpm research:build` exits 0
- [x] `meta.json` and `annotations.json` parse as valid JSON
- [x] Sections cover the full file 1–318 with no overlaps
- [x] Parent-file discharge claim verified against `ShannonChannelCoding.lean`
- [x] No open PR touches `src/data/proofs/shannon-channel-coding-oq-02-oq-01/`