### PR TITLE
research(erdos-1201): realign drifted gallery sections to full file (18→33)

### DIFF
--- a/src/data/proofs/erdos-1201/meta.json
+++ b/src/data/proofs/erdos-1201/meta.json
@@ -45,150 +45,237 @@
       "Number theory (primes, divisibility)"
     ]
   },
-  "sections": [
+  "sections":   [
     {
-      "id": "definitions",
-      "title": "Core Definitions",
-      "startLine": 27,
-      "endLine": 48,
-      "summary": "Defines greatestPrimeFactor, consecutiveProduct, gpfConsecutive, and upperDensity.",
-      "mathContext": "$P(n) = \\max(n.\\text{primeFactors})$, $P(n,k) = P(n(n+1)\\cdots(n+k))$, upper density via $\\limsup_{N\\to\\infty} |S \\cap [1,N]|/N$."
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 19,
+      "summary": "Module docstring: P(m) = greatest prime divisor of m (P(1)=0), P(n,k) = P(n(n+1)···(n+k)). States the **main conjecture** (for all $\\varepsilon,\\eta>0$ some $k$ makes the upper density of $\\{n : P(n,k) > n^{1-\\varepsilon}\\}$ at least $1-\\eta$), Erdős's $\\varepsilon=1/2$ partial result, and the reference erdosproblems.com/1201. Imports `Mathlib`; opens `namespace Erdos1201`."
     },
     {
-      "id": "conjecture",
-      "title": "Main Conjecture and Partial Result",
-      "startLine": 54,
-      "endLine": 69,
-      "summary": "ErdosProblem1201 (open) and erdos_1201_half_case axiom (ε=1/2 proved by Erdős).",
-      "mathContext": "$\\forall\\varepsilon,\\eta>0\\,\\exists k: \\overline{d}(\\{n : P(n,k)>n^{1-\\varepsilon}\\})\\geq 1-\\eta$. Axiomatized: $\\forall\\eta>0\\,\\exists k: \\overline{d}(\\{n : P(n,k)>\\sqrt{n}\\})\\geq 1-\\eta$."
+      "id": "greatest-prime-factor",
+      "title": "Greatest Prime Factor",
+      "startLine": 20,
+      "endLine": 35,
+      "summary": "Core definitions: `greatestPrimeFactor n` (the `max'` of `n.primeFactors`, 0 when none), `consecutiveProduct n k` $= \\prod_{i<k+1}(n+i)$, and `gpfConsecutive n k` $= $ gpf of the consecutive product."
     },
     {
-      "id": "gpf-properties",
-      "title": "Properties of Greatest Prime Factor",
-      "startLine": 74,
+      "id": "upper-density",
+      "title": "Upper Density",
+      "startLine": 36,
+      "endLine": 46,
+      "summary": "Defines `upperDensity S` as the `limsup` of $|S \\cap [1,N]| / N$ over `atTop`, the asymptotic density notion the conjecture is stated against."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Main Conjecture (Open)",
+      "startLine": 47,
+      "endLine": 57,
+      "summary": "`ErdosProblem1201`: for all $\\varepsilon\\in(0,1)$, $\\eta>0$ there exists $k$ with `upperDensity` $\\{n \\mid n^{1-\\varepsilon} < P(n,k)\\} \\ge 1-\\eta$. The full open conjecture, stated as a `Prop` (not an axiom)."
+    },
+    {
+      "id": "partial-result",
+      "title": "Partial Result (Erdős, ε = 1/2)",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "Introduces the one **axiom** `erdos_1201_half_case`: Erdős's proved $\\varepsilon=1/2$ result, that for every $\\eta>0$ some $k$ gives `upperDensity` $\\{n \\mid \\sqrt n < P(n,k)\\} \\ge 1-\\eta$. This is the sole assumption; all downstream theorems either are unconditional or reduce to it."
+    },
+    {
+      "id": "gpf-basic",
+      "title": "Basic Properties of Greatest Prime Factor",
+      "startLine": 69,
       "endLine": 114,
-      "summary": "Primality, divisibility, maximality, and bounds for greatestPrimeFactor.",
-      "mathContext": "$P(n)$ is prime, $P(n) \\mid n$, $P(n) \\leq n$, $P(n) \\geq 2$ for $n \\geq 2$. Any prime divisor $p \\mid n$ satisfies $p \\leq P(n)$."
+      "summary": "Foundational lemmas on `greatestPrimeFactor` for $n\\ge2$: it is prime (`gpf_prime`), lies in `primeFactors` (`gpf_mem_primeFactors`), divides $n$ (`gpf_dvd`), satisfies $2 \\le \\mathrm{gpf}(n) \\le n$ (`gpf_le`, `gpf_ge_two`), and dominates every prime factor (`gpf_max`, `gpf_ge_prime_dvd`)."
     },
     {
-      "id": "consecutive-properties",
-      "title": "Properties of Consecutive Products",
-      "startLine": 118,
-      "endLine": 166,
-      "summary": "Recursion, positivity, divisibility, and monotonicity of consecutiveProduct. consecutiveProduct_one: n*(n+1) formula.",
-      "mathContext": "$\\prod_{i=0}^{k+1}(n+i) = n \\cdot \\prod_{i=0}^{k}(n+1+i)$. $\\text{consecutiveProduct}(n,1) = n(n+1)$. Both $n$ and $n+k$ divide the product. The product is positive for $n \\geq 1$."
+      "id": "consecutive-basic",
+      "title": "Basic Properties of Consecutive Products",
+      "startLine": 115,
+      "endLine": 163,
+      "summary": "Basic identities for `consecutiveProduct`: $P(n,0)=n$, $P(n,1)=n(n+1)$, positivity for $n\\ge1$, left/right divisibility ($n$ and $n+k$ both divide the product), and the recursion $P(n,k+1) = n \\cdot P(n+1,k)$ (`consecutiveProduct_succ`)."
     },
     {
-      "id": "monotonicity",
-      "title": "Monotonicity and Growth",
-      "startLine": 161,
-      "endLine": 229,
-      "summary": "gpfConsecutive_mono and gpfConsecutive_large_of_prime_dvd: the key structural theorems.",
-      "mathContext": "$P(n,k) \\leq P(n,k+1)$. If $p$ is prime with $p \\mid n+i$ for some $i \\leq k$ and $p > n^{1-\\varepsilon}$, then $P(n,k) > n^{1-\\varepsilon}$."
+      "id": "monotonicity-k",
+      "title": "Monotonicity of gpfConsecutive in k",
+      "startLine": 164,
+      "endLine": 188,
+      "summary": "Proves divisibility persists when widening the window (`dvd_consecutiveProduct_of_dvd_lt`) and the one-step monotonicity `gpfConsecutive_mono`: for $n\\ge2$, $P(n,k) \\le P(n,k+1)$."
     },
     {
-      "id": "half-case",
-      "title": "The ε=1/2 Case",
+      "id": "large-prime-criterion",
+      "title": "Large Prime Factor Criterion",
+      "startLine": 189,
+      "endLine": 210,
+      "summary": "`gpfConsecutive_large_of_prime_dvd`: if a prime $p \\le n+k$ divides some window term and $p > n^{1-\\varepsilon}$, then $P(n,k) > n^{1-\\varepsilon}$. The structural link from a large prime in the window to a large window GPF."
+    },
+    {
+      "id": "asymptotic-growth",
+      "title": "Asymptotic Growth",
+      "startLine": 211,
+      "endLine": 230,
+      "summary": "Lower bounds: `consecutiveProduct_ge_n` ($P(n,k) \\ge n$ as a product) and `gpfConsecutive_ge_two` ($P(n,k) \\ge 2$ for $n\\ge2$)."
+    },
+    {
+      "id": "comparison-half",
+      "title": "Comparison with ε = 1/2 case",
       "startLine": 231,
-      "endLine": 266,
-      "summary": "Equivalence of sqrt condition and squared GPF condition; specialization of partial result.",
-      "mathContext": "$P(n,k) > \\sqrt{n} \\iff P(n,k)^2 > n$. The ε=1/2 axiom specializes to: $\\forall\\eta>0\\,\\exists k: \\overline{d}(\\{n: n < P(n,k)^2\\}) \\geq 1-\\eta$."
+      "endLine": 265,
+      "summary": "Recasts the $\\varepsilon=1/2$ condition: `gpfConsecutive_half_iff` shows $\\sqrt n < P(n,k) \\iff n < P(n,k)^2$, and `erdos_1201_half_squared` transfers the half-case axiom to the squared form."
     },
     {
-      "id": "bounds",
+      "id": "bertrand-consequences",
+      "title": "Bertrand's Postulate Consequences",
+      "startLine": 266,
+      "endLine": 295,
+      "summary": "Via Bertrand's postulate: `gpfConsecutive_self_gt` ($n < P(n,n)$, the window $[n,2n]$ contains a prime $>n$) and `gpfConsecutive_gt_n_of_large_window` ($n < P(n,k)$ whenever $k \\ge n \\ge 2$)."
+    },
+    {
+      "id": "prime-start",
+      "title": "Prime Start Lower Bound",
+      "startLine": 296,
+      "endLine": 308,
+      "summary": "`gpfConsecutive_ge_self_of_prime`: for prime $n$ and any $k$, $P(n,k) \\ge n$, since the prime first term $n$ is itself a prime factor of the product."
+    },
+    {
+      "id": "term-divisibility",
+      "title": "Term Divisibility",
+      "startLine": 309,
+      "endLine": 319,
+      "summary": "`dvd_consecutiveProduct_term`: every term $n+i$ with $i\\le k$ divides the consecutive product (generalizing the right-endpoint case)."
+    },
+    {
+      "id": "sylvester-schur",
+      "title": "Sylvester-Schur: Prime Factor Exceeds Window Size",
+      "startLine": 320,
+      "endLine": 383,
+      "summary": "Sylvester–Schur-type results that $P(n,k) > k$. The general criterion `gpfConsecutive_gt_k_of_prime_in_window` plus the diagonal/near-diagonal cases $n=k+1,k+2,k+3$ (`gpfConsecutive_succ_gt_k` etc., each via a Bertrand prime in the window, the $k+3$ case ruling out the even endpoint $2(k+2)$) and the prime-start case `gpfConsecutive_prime_gt_k`."
+    },
+    {
+      "id": "infinitely-many",
+      "title": "Infinitely Many n with Large GPF",
+      "startLine": 384,
+      "endLine": 402,
+      "summary": "`erdos_1201_infinitely_many`: for any fixed $k$ and $\\varepsilon\\in(0,1)$, infinitely many $n$ satisfy $P(n,k) > n^{1-\\varepsilon}$ — the good set contains every prime $n$."
+    },
+    {
+      "id": "monotonicity-window",
+      "title": "Monotonicity in Window Width",
+      "startLine": 403,
+      "endLine": 484,
+      "summary": "Good-set monotonicity in $k$: pointwise (`erdos_1201_good_implies_good_succ`) and as set containment (`erdos_1201_good_set_mono_k`). Builds the `densityFun` machinery (nonneg, $\\le1$, monotone, bounded/cobounded, complement-sum) and proves `upperDensity_mono` and `erdos_1201_density_mono_k` (good-set density is non-decreasing in $k$)."
+    },
+    {
+      "id": "epsilon-monotonicity",
+      "title": "Epsilon-Monotonicity and Partial Conjecture Proof",
+      "startLine": 485,
+      "endLine": 546,
+      "summary": "Monotonicity in $\\varepsilon$ and the first conditional result. Shows $n^{1-\\varepsilon} \\le \\sqrt n$ for $\\varepsilon\\ge1/2$, the good set grows with $\\varepsilon$ (pointwise/containment/density), and proves `erdos_1201_partial_conjecture`: **ErdosProblem1201 holds for all $\\varepsilon\\ge1/2$**, deduced from the half-case axiom via $\\varepsilon$-monotonicity."
+    },
+    {
+      "id": "upper-bounds-tight",
       "title": "Upper Bounds and Tight Estimates",
-      "startLine": 342,
-      "endLine": 395,
-      "summary": "gpfConsecutive_zero (base case), prime_dvd_consecutive_range (induction helper), gpfConsecutive_upper_bound (P(n,k) ≤ n+k), le_gpfConsecutive_of_prime_dvd_term (lower bound from divisibility), gpfConsecutive_between (Bertrand tight bound n < P(n,n) ≤ 2n).",
-      "mathContext": "$P(n,0) = \\mathrm{gpf}(n)$. $P(n,k) \\leq n+k$ (every prime factor of any term $n+i$ is $\\leq n+i \\leq n+k$). If prime $p \\mid n+i$ for $i \\leq k$, then $p \\leq P(n,k)$. By Bertrand: $n < P(n,n) \\leq 2n$."
+      "startLine": 547,
+      "endLine": 624,
+      "summary": "Upper and tight bounds: $P(n,0) = \\mathrm{gpf}(n)$, $P(n,k) \\le n+k$ (`gpfConsecutive_upper_bound`), prime-window-size Sylvester–Schur ($k+1$ prime $\\Rightarrow P(n,k) \\ge k+1$ via a complete residue system), and the Bertrand sandwich $n < P(n,n) \\le 2n$ (`gpfConsecutive_between`)."
+    },
+    {
+      "id": "upper-bounds-bertrand",
+      "title": "Upper Bounds and Bertrand Structure",
+      "startLine": 625,
+      "endLine": 668,
+      "summary": "Refines the upper bound `gpfConsecutive_le_right` ($P(n,k)\\le n+k$), the exact value when the right endpoint is prime (`gpfConsecutive_eq_of_prime_right`: $P(n,k)=n+k$), and `gpfConsecutive_bertrand`: every $n$ has a window $k\\le n$ with $n+k$ prime achieving $P(n,k)=n+k$."
     },
     {
       "id": "max-formula",
-      "title": "Max Formula and Smooth-Window Reformulation",
-      "startLine": 472,
-      "endLine": 514,
-      "summary": "gpfConsecutive_eq_sup_range: P(n,k) = sup of individual GPFs. gpfConsecutive_le_iff: P(n,k) ≤ t iff all terms in window are t-smooth.",
-      "mathContext": "$P(n,k) = \\sup_{0 \\leq i \\leq k} P(n+i)$. Equivalently, $P(n,k) \\leq t \\iff \\forall i \\leq k,\\, P(n+i) \\leq t$ (all terms are $t$-smooth). This connects the Erdős conjecture to Dickman's $\\rho$ function: density of $t$-smooth numbers in $[n, n+k]$."
+      "title": "Max Formula and Smooth-Number Reformulation",
+      "startLine": 669,
+      "endLine": 711,
+      "summary": "Key reformulation `gpfConsecutive_eq_sup_range`: $P(n,k)$ equals the max of the individual term GPFs $\\mathrm{gpf}(n+i)$. Yields the smooth-window duality `gpfConsecutive_le_iff`: $P(n,k)\\le t \\iff$ every term $n+i$ is $t$-smooth — connecting the conjecture to smooth-number density."
     },
     {
-      "id": "prime-gpf",
-      "title": "GPF for Primes and Short Windows",
-      "startLine": 515,
-      "endLine": 575,
-      "summary": "greatestPrimeFactor_prime: P(n)=n for prime n. gpfConsecutive_prime_start: P(n,0)=n for prime n. gpfConsecutive_one_eq_max: P(n,1)=max(P(n),P(n+1)). gpfConsecutive_one_coprime: gpf(n) and gpf(n+1) are coprime. gpfConsecutive_one_ne: gpf(n) ≠ gpf(n+1). gpfConsecutive_ge_left/right: window GPF bounds from endpoints.",
-      "mathContext": "For prime $n$: $P(n) = n$. Length-2 window: $P(n,1) = \\max(P(n), P(n+1))$. Coprimality: $\\gcd(P(n), P(n+1)) = 1$ (since $\\gcd(n, n+1)=1$ and both gpfs divide their respective terms). Distinctness: $P(n) \\neq P(n+1)$."
+      "id": "gpf-primes-short",
+      "title": "Greatest Prime Factor for Primes and Short Windows",
+      "startLine": 712,
+      "endLine": 772,
+      "summary": "GPF for primes and small windows: $\\mathrm{gpf}(p)=p$, $P(p,0)=p$, $P(n,1)=\\max(\\mathrm{gpf}(n),\\mathrm{gpf}(n+1))$ with the two GPFs coprime and distinct (consecutive integers coprime), and the endpoint bounds $\\mathrm{gpf}(n), \\mathrm{gpf}(n+k) \\le P(n,k)$."
     },
     {
-      "id": "gpf-product-and-recursion",
-      "title": "GPF Product Formula and Recursive Window Formulas",
-      "startLine": 561,
-      "endLine": 598,
-      "summary": "greatestPrimeFactor_mul: gpf(a*b)=max(gpf(a),gpf(b)). gpfConsecutive_le_of_le_k: general k-monotonicity via Finset.sup subset. gpfConsecutive_succ_right: P(n,k+1)=max(P(n,k),gpf(n+k+1)) one-step recursion.",
-      "mathContext": "For $a,b \\geq 2$: $P(ab) = \\max(P(a), P(b))$ (prime divisor of product divides a factor). General monotonicity: $k_1 \\leq k_2 \\Rightarrow P(n,k_1) \\leq P(n,k_2)$ (sup over larger range). One-step recursion: $P(n,k+1) = \\max(P(n,k), P(n+k+1))$ from inserting last range element."
+      "id": "gpf-of-products",
+      "title": "GPF of Products",
+      "startLine": 773,
+      "endLine": 793,
+      "summary": "`greatestPrimeFactor_mul`: $\\mathrm{gpf}(ab) = \\max(\\mathrm{gpf}(a),\\mathrm{gpf}(b))$ for $a,b\\ge2$, the multiplicative backbone of the max formula."
+    },
+    {
+      "id": "general-monotonicity-recursive",
+      "title": "General Monotonicity and Recursive Formula",
+      "startLine": 794,
+      "endLine": 819,
+      "summary": "General $k$-monotonicity `gpfConsecutive_le_of_le_k` ($k_1\\le k_2 \\Rightarrow P(n,k_1)\\le P(n,k_2)$) and the recursion `gpfConsecutive_succ_right`: $P(n,k+1) = \\max(P(n,k), \\mathrm{gpf}(n+k+1))$."
     },
     {
       "id": "right-endpoint-biconditional",
       "title": "Right-Endpoint Biconditional and Infinite Sets",
-      "startLine": 606,
-      "endLine": 648,
-      "summary": "gpfConsecutive_eq_right_iff: P(n,k) = n+k ↔ (n+k).Prime (sharp biconditional). erdos_1201_prime_right_infinite: {n | (n+k).Prime} is infinite. erdos_1201_eq_right_infinite: {n | P(n,k)=n+k} is infinite for k≥1.",
-      "mathContext": "The upper bound $P(n,k) \\leq n+k$ is achieved exactly at prime right endpoints. $\\{n : P(n,k) = n+k\\}$ is infinite by Dirichlet/Euclid: for any $N$, find prime $p \\geq N+k$ and set $n = p-k$. Complements the prime-start infinite-set result from earlier sessions."
+      "startLine": 820,
+      "endLine": 862,
+      "summary": "`gpfConsecutive_eq_right_iff`: $P(n,k)=n+k \\iff (n+k)$ prime — the upper bound is hit exactly at prime right endpoints. Plus infinitude: $\\{n \\mid n+k \\text{ prime}\\}$ and $\\{n \\mid P(n,k)=n+k\\}$ are both infinite."
     },
     {
-      "id": "window-extension-and-prime-terms",
-      "title": "Window Extension, Concatenation, and Prime Term Bounds",
-      "startLine": 649,
-      "endLine": 762,
-      "summary": "gpfConsecutive_succ_left: left-endpoint extension P(n,k+1)=max(gpf(n),P(n+1,k)). gpfConsecutive_window_concat: window splitting P(n,j+k+1)=max(P(n,j),P(n+j+1,k)). gpfConsecutive_ge_prime_term: prime term gives lower bound n+i ≤ P(n,k). erdos_1201_good_of_prime_in_window: sufficient condition for good n. gpfConsecutive_eq_term_gpf: GPF localization when k < P(n,k).",
-      "mathContext": "Left extension: $P(n,k+1) = \\max(P(n), P(n+1,k))$ (symmetric to succ_right). Window concat: $P(n,j+k+1) = \\max(P(n,j), P(n+j+1,k))$ (split at position $j$). Prime term: if $(n+i)$ prime and $i \\leq k$ then $n+i \\leq P(n,k)$ (since $P(n+i) = n+i$ and $P(n+i) \\leq P(n,k)$). Good n: if $\\exists i \\leq k$ with $n+i$ prime and $n+i > n^{1-\\varepsilon}$, then $P(n,k) > n^{1-\\varepsilon}$."
+      "id": "window-extension",
+      "title": "Window Extension and Concatenation Formulas",
+      "startLine": 863,
+      "endLine": 970,
+      "summary": "Left-endpoint extension `gpfConsecutive_succ_left` and window concatenation `gpfConsecutive_window_concat` ($P(n,j+k+1) = \\max(P(n,j), P(n+j+1,k))$). Prime-term lower bound, the sufficient goodness condition `erdos_1201_good_of_prime_in_window`, and GPF localization `gpfConsecutive_eq_term_gpf` (when $P(n,k)>k$ the GPF comes from a single term)."
     },
     {
-      "id": "smooth-window-and-conditional",
-      "title": "Smooth-Window Duality and Conditional Reduction",
-      "startLine": 1097,
+      "id": "factorial-divisibility",
+      "title": "Factorial Divisibility and Universal Lower Bound",
+      "startLine": 971,
+      "endLine": 1109,
+      "summary": "Factorial structure: the product equals a descending factorial, so $(k+1)! \\mid$ product (`factorial_dvd_consecutiveProduct`). Gives the **universal** lower bounds $\\mathrm{gpf}((k+1)!) \\le P(n,k)$ and $k < 2 P(n,k)$ for ALL $n\\ge1$ (via Bertrand, no $n>k$ needed), the threshold bound, trivial goodness for large $\\varepsilon$, the reduction `erdos_1201_conjecture_large_eps` to $\\varepsilon=1/2$, individual thresholds, and the equivalence `erdos_1201_equiv_small_eps` (the conjecture reduces to $\\varepsilon<1/2$)."
+    },
+    {
+      "id": "smooth-window-characterization",
+      "title": "Smooth-Window Characterization and Conditional Reduction",
+      "startLine": 1110,
       "endLine": 1168,
-      "summary": "erdos_1201_not_good_smooth_window: n bad ↔ window is n^(1-ε)-smooth (all gpf(n+i) ≤ n^(1-ε)). erdos_1201_good_iff_rough_term: n good ↔ ∃ rough term in window. erdos_1201_conditional_proof: formal reduction to Cramér-type prime gap hypothesis.",
-      "mathContext": "Duality: $\\neg(P(n,k) > n^{1-\\varepsilon}) \\iff \\forall i \\leq k,\\, P(n+i) \\leq n^{1-\\varepsilon}$ (uses gpfConsecutive_le_iff + Nat.floor bound). Rough-term: $P(n,k) > n^{1-\\varepsilon} \\iff \\exists i \\leq k,\\, P(n+i) > n^{1-\\varepsilon}$ (negation of smooth-window). Conditional: if $\\forall \\varepsilon,\\eta>0\\,\\exists k$: $\\overline{d}(\\{n : \\exists i\\leq k, (n+i)\\text{ prime}, n+i>n^{1-\\varepsilon}\\}) \\geq 1-\\eta$, then $\\text{ErdosProblem1201}$ holds."
+      "summary": "Smooth-window duality: $n$ is bad $\\iff$ the window $[n,n+k]$ is $n^{1-\\varepsilon}$-smooth (`erdos_1201_not_good_smooth_window`), equivalently good $\\iff$ some term is rough (`erdos_1201_good_iff_rough_term`). Proves the prime-gap conditional `erdos_1201_conditional_proof`: a Cramér-type density hypothesis on primes in short windows implies ErdosProblem1201."
     },
     {
       "id": "density-complement",
-      "title": "Density Complement and Smooth-Decay Reduction",
+      "title": "Density Complement and Smooth-Density Conditional",
       "startLine": 1169,
       "endLine": 1286,
-      "summary": "erdos_1201_good_prime_k0: primes are good for k=0. upperDensity_compl_ge: 1 - uD(S) ≤ uD(Sᶜ) (complement density lower bound). upperDensity_mono: density is monotone under inclusion up to finite sets. erdos_1201_from_bad_density_bound: density(bad) ≤ η → density(good) ≥ 1-η. erdos_1201_smooth_decay_implies_conjecture: ErdosProblem1201 follows from smooth-window density decaying to 0.",
-      "mathContext": "Complement bound: $\\overline{d}(S) + \\overline{d}(S^c) \\geq 1$ (via limsup sub-additivity; both densities are in $[0,1]$). Smooth-decay reduction: if for every $\\varepsilon,\\eta>0$ there exists $k$ with $\\overline{d}(\\{n \\geq 2 : \\forall i \\leq k,\\, P(n+i) \\leq n^{1-\\varepsilon}\\}) \\leq \\eta$, then ErdosProblem1201 holds. This makes the connection to Dickman $\\rho$ density estimates precise."
+      "summary": "Density complement machinery: primes are good at $k=0$, `upperDensity_compl_ge` ($1 - d(S) \\le d(S^c)$), monotonicity up to a finite set, and `erdos_1201_from_bad_density_bound`. Culminates in `erdos_1201_smooth_decay_implies_conjecture`: ErdosProblem1201 follows if the smooth-window (bad-set) density decays to 0 as $k\\to\\infty$ — the Dickman-function form of Erdős's heuristic."
     },
     {
       "id": "upper-density-basic",
       "title": "Upper Density Basic Facts",
       "startLine": 1287,
       "endLine": 1332,
-      "summary": "upperDensity_empty: uD(∅)=0. upperDensity_le_one: uD(S) ≤ 1. upperDensity_ge_zero: 0 ≤ uD(S). upperDensity_univ: uD(ℕ)=1.",
-      "mathContext": "$\\overline{d}(\\emptyset) = 0$ (limsup of 0), $\\overline{d}(\\mathbb{N}) = 1$ (limsup of 1), $0 \\leq \\overline{d}(S) \\leq 1$ for all $S$. These are the density analogs of measure-theoretic normalization and monotonicity."
+      "summary": "Basic density facts: $|[1,N]| = N$, `upperDensity_empty` $=0$, `upperDensity_le_one`, `upperDensity_ge_zero`, and `upperDensity_univ` $=1$."
     },
     {
-      "id": "asymptotic-and-convergence",
+      "id": "asymptotic-window",
       "title": "Asymptotic Behavior as Window Grows",
       "startLine": 1333,
       "endLine": 1399,
-      "summary": "gpfConsecutive_atTop: for fixed n ≥ 2, P(n,k) → +∞ as k → ∞. erdos_1201_eventually_good: fixed n ≥ 2 is eventually good for all large k. erdos_1201_density_eventually_large: assuming ErdosProblem1201, density of good set ≥ 1-η for ALL k ≥ K (not just one k).",
-      "mathContext": "$P(n,k) \\to +\\infty$ as $k \\to \\infty$ for fixed $n \\geq 2$: for any bound $M$, find prime $p > \\max(n, M)$ by Euclid; then $p \\in [n+1, n+(p-n)]$, so $P(n, p-n) \\geq p > M$. Individual goodness: for any $n \\geq 2$, $\\varepsilon \\in (0,1)$, eventually $P(n,k) > n^{1-\\varepsilon}$. Density: ErdosProblem1201 $\\Rightarrow$ $\\exists K$: $\\forall k \\geq K$, $\\overline{d}(\\text{good}_k) \\geq 1-\\eta$."
+      "summary": "For fixed $n\\ge2$, $P(n,k) \\to \\infty$ as $k\\to\\infty$ (`gpfConsecutive_atTop`, via infinitude of primes). Each $n$ is eventually good (`erdos_1201_eventually_good`), and assuming the conjecture the good density stays $\\ge 1-\\eta$ for all large $k$ (`erdos_1201_density_eventually_large`)."
     },
     {
       "id": "lower-density",
-      "title": "Lower Density and Complement Duality",
+      "title": "Lower Density",
       "startLine": 1400,
-      "endLine": 1486,
-      "summary": "lowerDensity (def via Filter.liminf). lowerDensity_nonneg: lD(S) ≥ 0. lowerDensity_le_upperDensity: lD(S) ≤ uD(S). lowerDensity_compl: lD(Sᶜ) = 1 - uD(S) (exact duality). upperDensity_compl_eq: uD(Sᶜ) = 1 - lD(S).",
-      "mathContext": "$\\underline{d}(S) = \\liminf_{N\\to\\infty} |S\\cap[1,N]|/N$. Exact duality: $\\underline{d}(S^c) = 1 - \\overline{d}(S)$ (uses Filter.liminf_const_sub for $\\liminf(1-f) = 1 - \\limsup f$). Ordering: $\\underline{d}(S) \\leq \\overline{d}(S)$ (liminf ≤ limsup). These are the density analogs of inner/outer measure relations."
+      "endLine": 1614,
+      "summary": "Defines `lowerDensity` (liminf), proves nonnegativity, $\\mathrm{lower} \\le \\mathrm{upper}$, and the complement dualities $d_*(S^c) = 1 - d^*(S)$ and $d^*(S^c) = 1 - d_*(S)$. States the **strong conjecture** `ErdosProblem1201Strong` (lower density form), shows strong $\\Rightarrow$ weak, and proves `erdos_1201_strong_iff_smooth_decay`: the strong conjecture is exactly equivalent to the smooth-window density decaying to 0."
     },
     {
-      "id": "strong-conjecture",
-      "title": "Strong Conjecture and Equivalence",
-      "startLine": 1487,
-      "endLine": 1615,
-      "summary": "ErdosProblem1201Strong (def via lowerDensity): strong form uses lD ≥ 1-η. erdos_1201_strong_implies_weak: Strong → ErdosProblem1201 (lD ≥ 1-η ⟹ uD ≥ 1-η). erdos_1201_strong_iff_smooth_decay: ErdosProblem1201Strong ↔ smooth-window density decays to 0.",
-      "mathContext": "Strong conjecture: $\\forall\\varepsilon,\\eta>0\\,\\exists k: \\underline{d}(\\{n : P(n,k)>n^{1-\\varepsilon}\\}) \\geq 1-\\eta$ (holds for ALL large $N$, not just $\\limsup$). Strong implies weak via $\\underline{d} \\leq \\overline{d}$. Equivalence: Strong $\\iff$ $\\forall\\varepsilon,\\eta>0\\,\\exists k$: $\\overline{d}(\\{n\\geq 2: \\forall i\\leq k, P(n+i) \\leq n^{1-\\varepsilon}\\}) \\leq \\eta$. Forward uses lowerDensity_compl; backward uses limsup sub-additivity + the $1/N \\to 0$ correction."
+      "id": "prime-window-automatic",
+      "title": "Prime-Window Automatic Goodness",
+      "startLine": 1615,
+      "endLine": 1651,
+      "summary": "Automatic goodness: any prime in the window makes $n$ good with no size condition (`erdos_1201_good_of_any_prime_in_window`), specializing to prime start (`erdos_1201_good_prime_any_k`) and prime right endpoint (`erdos_1201_good_prime_endpoint`)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section metadata for **erdos-1201** (Greatest Prime Factor of Consecutive Products) had drifted badly to an older layout:
- **Missing header** section (lines 1-26 uncovered)
- Several **overlapping / mis-ranged** sections
- A **333-line internal gap** (jumped 763 → 1097), hiding the factorial-divisibility and conditional-reduction machinery
- A **36-line tail gap** (stopped at 1615 of 1651)

Rebuilt to the file's 33 actual `## ` banners (header + 32 sections), giving contiguous full-file coverage **1-1651**.

## Changes (18 → 33 sections)
Among the newly surfaced / realigned sections:
- `factorial-divisibility` (971-1109) — $(k+1)!$ divides the product, universal lower bound $k < 2P(n,k)$, reduction to $\varepsilon=1/2$
- `smooth-window-characterization` (1110-1168) — smooth-window duality + Cramér-type prime-gap conditional
- `density-complement` (1169-1286) — `erdos_1201_smooth_decay_implies_conjecture` (Dickman-function heuristic)
- `upper-density-basic`, `asymptotic-window`, `lower-density` (1400-1614, strong-conjecture equivalence)
- Plus header, max-formula, window-extension, right-endpoint-biconditional, and others realigned to the true banner ranges.

## Verification
- Metadata-only; Lean source untouched
- Counts already correct and unchanged: **1 axiom** (`erdos_1201_half_case`, Erdős's proved $\varepsilon=1/2$ result) / 116 theorems / 8 defs / 0 sorries
- Sections verified contiguous (1-1651, no gaps/overlaps), valid JSON; diff scoped to the `sections` block only

🤖 Generated with [Claude Code](https://claude.com/claude-code)