### PR TITLE
research(brouwer-fixed-point-oq-04-oq-01): build-free tracker sync (iteration 3)

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -26,9 +26,9 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-02T21:57:15-07:00",
-    "lastUpdated": "2026-06-12T00:00:00.000Z",
-    "iteration": 2,
-    "focus": "S2 ACT — DRIFT REPAIR (researcher-2, 2026-06-12, this PR). Correcting a badly stale record: the prior 'OBSERVE iteration 1, formal statement not specified' was wrong — Proofs/BrouwerFixedPointOQ04OQ01.lean is a complete 297-line Nash-equilibrium-via-Kakutani development (8 theorems, 2 axioms, 0 sorries as recorded). First actual Docker build revealed the file was SILENTLY RED from Mathlib v4.26.0 drift (pin 2df2f015): 11 errors across bestResponse_convex (132: Convex now presents the segment as `a • x + b • y` not `fun k => a*x k + b*y k`), fixed_point_is_nash (204: needed `Function.update_eq_self` to collapse `update σ i (σ i) = σ`), matching_pennies (250: simp left `2⁻¹+2⁻¹=1`), and prisoners_dilemma_nash (271/275-289: `prisonersDilemmaGame.strategies i` no longer reduces to 2, breaking `OfNat (Fin (strategies i))` numerals and `Fin.sum_univ_two` rewrites). Repaired ALL to green at [2366/2366], 0 new axioms, 0 sorries: added a smul→pointwise conversion + explicit convexity inequality; `Function.update_eq_self`; `norm_num` finishers; made `prisonersDilemmaGame` `@[reducible]` and inlined the strategy profile so numerals elaborate. The two pre-existing axioms (bestResponse_uhc = Berge's theorem; kakutani_product_simplex) are unchanged — they remain stated assumptions.",
+    "lastUpdated": "2026-06-14T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "ACT — BUILD-FREE TRACKER SYNC (researcher-2, 2026-06-14, this PR). Docker daemon down, so no build/axiom-discharge attempted this iteration. Verified Proofs/BrouwerFixedPointOQ04OQ01.lean against the record: still 8 theorems / 2 axioms (bestResponse_uhc, kakutani_product_simplex) / 6 defs / 0 sorries, but the file is now 305 lines (record said 297 — fixed in leanFiles). Main repair: the record was internally self-contradictory — top-level fields described the complete ACT development, while knowledge.markdown, knowledge.builtItems, knowledge.nextSteps, and three knowledge.insights lines were still the original OBSERVE-iteration-1 stub ('formal statement not specified', 'Move to ORIENT', 'no substantive notes'). Synced all of those stale sub-fields to the actual ACT state and replaced the placeholder mathlibGaps with the real, known gaps (Kakutani fixed point and Berge's maximum theorem are both absent from Mathlib). No Lean changes. PRIOR: S2 ACT — DRIFT REPAIR (researcher-2, 2026-06-12). Correcting a badly stale record: the prior 'OBSERVE iteration 1, formal statement not specified' was wrong — Proofs/BrouwerFixedPointOQ04OQ01.lean is a complete 297-line Nash-equilibrium-via-Kakutani development (8 theorems, 2 axioms, 0 sorries as recorded). First actual Docker build revealed the file was SILENTLY RED from Mathlib v4.26.0 drift (pin 2df2f015): 11 errors across bestResponse_convex (132: Convex now presents the segment as `a • x + b • y` not `fun k => a*x k + b*y k`), fixed_point_is_nash (204: needed `Function.update_eq_self` to collapse `update σ i (σ i) = σ`), matching_pennies (250: simp left `2⁻¹+2⁻¹=1`), and prisoners_dilemma_nash (271/275-289: `prisonersDilemmaGame.strategies i` no longer reduces to 2, breaking `OfNat (Fin (strategies i))` numerals and `Fin.sum_univ_two` rewrites). Repaired ALL to green at [2366/2366], 0 new axioms, 0 sorries: added a smul→pointwise conversion + explicit convexity inequality; `Function.update_eq_self`; `norm_num` finishers; made `prisonersDilemmaGame` `@[reducible]` and inlined the strategy profile so numerals elaborate. The two pre-existing axioms (bestResponse_uhc = Berge's theorem; kakutani_product_simplex) are unchanged — they remain stated assumptions.",
     "blockers": [
       "The slug's nominal target ('prove Kakutani from Brouwer') is NOT yet discharged: Kakutani is the axiom `kakutani_finite_dim` in Proofs/BrouwerFixedPointOQ04OQ03.lean:69, on which this file's `kakutani_product_simplex` axiom rests. Proving it from Brouwer is a large (multi-hundred-line) formalization (simplicial approximation / partition-of-unity), out of scope for a single iteration.",
       "`bestResponse_uhc` (Berge's maximum theorem) is axiomatized; discharging it is a separate substantial deliverable."
@@ -41,29 +41,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (iteration 2). Proofs/BrouwerFixedPointOQ04OQ01.lean is a complete 297-line Nash-equilibrium-via-Kakutani development: 8 theorems, 0 sorries, 2 stated axioms (bestResponse_uhc = Berge's maximum theorem; kakutani_product_simplex = Kakutani fixed point on the product simplex). The best-response correspondence is proved nonempty/convex/closed and nash_existence is derived from a Kakutani fixed point of the joint best response. Drift-repaired to green at [2366/2366] under Mathlib v4.26.0 pin 2df2f015 by researcher-2 (2026-06-12). Remaining work is axiom elimination of the two deep assumptions, both non-trivial results not currently in Mathlib. THIS ITER (researcher-1, 2026-06-13): build-free tracker drift repair only — synced stale top-level phase/title/problemStatement/progressSummary (previously 'OBSERVE iteration 1, formal statement not specified, target=Kakutani from Brouwer') to match the actual file + currentState.focus. No Lean changes; Docker down 2026-06-13 so no build attempted.",
+    "progressSummary": "ACT (iteration 3). Proofs/BrouwerFixedPointOQ04OQ01.lean is a complete 305-line Nash-equilibrium-via-Kakutani development: 8 theorems, 0 sorries, 2 stated axioms (bestResponse_uhc = Berge's maximum theorem; kakutani_product_simplex = Kakutani fixed point on the product simplex). The best-response correspondence is proved nonempty/convex/closed and nash_existence is derived from a Kakutani fixed point of the joint best response. Drift-repaired to green at [2366/2366] under Mathlib v4.26.0 pin 2df2f015 by researcher-2 (2026-06-12). Remaining work is axiom elimination of the two deep assumptions, both non-trivial results not currently in Mathlib. THIS ITER (researcher-2, 2026-06-14): build-free tracker sync only — Docker down so no build. Fixed stale lineCount (297→305) and resolved an internal contradiction in the record by syncing the leftover OBSERVE-era knowledge.markdown / builtItems / nextSteps / insights / mathlibGaps to the actual ACT state. No Lean changes. PRIOR (researcher-1, 2026-06-13): build-free top-level field sync.",
     "builtItems": [
-      "Research record initialized for slug brouwer-fixed-point-oq-04-oq-01.",
-      "State file records OBSERVE phase, full path, iteration 1, no active approach, and zero attempts."
+      "Proofs/BrouwerFixedPointOQ04OQ01.lean (305 lines): complete Nash-equilibrium-via-Kakutani development, 8 theorems / 6 defs / 2 axioms / 0 sorries.",
+      "Definitions: purePayoff, expectedUtility, IsLinearInStrategy, bestResponse, jointBestResponse, prisonersDilemmaGame.",
+      "Best-response correspondence proved nonempty (EVT on compact simplex), convex (multilinearity hypothesis), and closed (level set of continuous EU).",
+      "nash_existence derived from a Kakutani fixed point of the joint best response; fixed_point_is_nash bridges fixed-point to Nash-equilibrium.",
+      "Worked examples: matching_pennies_uniform_is_mixed and prisoners_dilemma_nash (mutual defection is a Nash equilibrium)."
     ],
     "insights": [
       "S2 ACT (researcher-2, 2026-06-12): BrouwerFixedPointOQ04OQ01.lean was silently drift-broken (11 errors) under Mathlib v4.26.0 despite being recorded as 0-sorry/compiling — confirming the gallery-wide 'builds silently red' risk. Key drift signatures for this family: (a) `Convex`'s segment is now `a • x + b • y` (pointwise Pi smul), so proofs that `rw` a `fun k => a*x k + b*y k` lemma must first convert via `funext k; simp [Pi.add_apply, Pi.smul_apply, smul_eq_mul]`; (b) numerals `0`/`1 : Fin (G.strategies i)` fail `OfNat` synthesis when `G` is a plain `def` whose `strategies` projection no longer reduces — mark such game defs `@[reducible]` and inline strategy profiles so the literals elaborate; (c) `Function.update σ i (σ i)` must be collapsed with `Function.update_eq_self`.",
       "The whole Brouwer→Kakutani→Nash chain here is axiomatized at the Kakutani level: `kakutani_finite_dim` (OQ04OQ03:69) and `fan_glicksberg` (OQ04OQ03:85) are axioms, and this file's `kakutani_product_simplex` + `bestResponse_uhc` (Berge) are axioms. So Nash existence is proved *conditional on* Kakutani; the slug's nominal 'prove Kakutani from Brouwer' is exactly the undischarged `kakutani_finite_dim`.",
-      "The intended route is explicitly from Brouwer via Mathlib topology.",
-      "The formal theorem statement is absent from the allowed research notes, so the target must be specified before proof work starts.",
-      "No active approach, completed attempts, dead ends, or literature references are recorded for this child problem."
+      "The intended route is explicitly from Brouwer via Mathlib topology: discharging kakutani_product_simplex reduces (via kakutani_finite_dim in OQ04OQ03) to Kakutani⇐Brouwer, which is the slug's nominal target.",
+      "Convexity of bestResponse relies on a multilinearity hypothesis (IsLinearInStrategy) stated as a Prop rather than derived from FiniteGame, since FiniteGame carries no multilinearity axiom — a deliberate encoding choice, not a hidden assumption baked into the headline nash_existence (which takes only continuity)."
     ],
     "mathlibGaps": [
-      "Documentation gap: exact Mathlib modules and theorem names for the Brouwer/topology prerequisites are not recorded yet.",
-      "Documentation gap: the Lean encoding of the set-valued correspondence and its compactness, convexity, and continuity hypotheses is not recorded yet."
+      "Kakutani fixed point theorem is not in Mathlib — kept here as the axiom kakutani_finite_dim (Proofs/BrouwerFixedPointOQ04OQ03.lean:69), on which this file's kakutani_product_simplex rests.",
+      "Berge's maximum theorem (upper hemicontinuity of the argmax correspondence) is not in Mathlib — kept here as the axiom bestResponse_uhc.",
+      "Embedding of the product simplex Πᵢ Δᵢ into EuclideanSpace ℝ (Fin (∑ i, strategies i)) as a convexity/homeomorphism-preserving map is the routine-but-unwritten topological step folded into kakutani_product_simplex."
     ],
     "nextSteps": [
-      "Write a precise Lean and LaTeX target statement for Kakutani fixed point theorem.",
-      "Identify the specific Brouwer fixed point theorem and topology/convexity declarations that should be reused.",
-      "Populate literature and Mathlib references from source files before claiming known results.",
-      "Only after ORIENT evidence exists, record an approach and update attempt counts if proof work begins."
+      "Discharge kakutani_finite_dim (Kakutani ⇐ Brouwer) — the slug's true target; large formalization (simplicial approximation / partition of unity). Requires Docker build.",
+      "Discharge bestResponse_uhc (Berge's maximum theorem) as a separate deliverable.",
+      "After either, re-run ./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ04OQ01 — this family drifts silently red on Mathlib bumps."
     ],
-    "markdown": "# Knowledge Base: brouwer-fixed-point-oq-04-oq-01\n\n## Evidence Summary\n\n- problem.md records the target title: Prove Kakutani Fixed Point Theorem from Brouwer via Mathlib topology.\n- state.md records phase OBSERVE, path full, iteration 1, no active approach, and zero attempts.\n- knowledge.md contains no substantive notes beyond the initialized knowledge-base heading.\n\n## Current Understanding\n\nThe problem is a user-requested Brouwer-family follow-up whose intended route is to derive a Kakutani fixed point result using Brouwer and Mathlib topology. The formal theorem statement, exact hypotheses, and supporting modules are still unspecified in the research notes.\n\n## Open Gaps\n\n- Choose the precise Lean statement and mathematical hypotheses.\n- Identify the relevant Brouwer fixed point result and topology/convexity declarations.\n- Add literature and Mathlib references from concrete source evidence.\n\n## Next Steps\n\n1. Move to ORIENT by drafting the exact theorem statement.\n2. Survey available local Brouwer/Kakutani-related proofs and Mathlib topology support.\n3. Record known results only after source evidence identifies them.\n"
+    "markdown": "# Knowledge Base: brouwer-fixed-point-oq-04-oq-01\n\n## Status (ACT, iteration 3)\n\nProofs/BrouwerFixedPointOQ04OQ01.lean is a complete 305-line Nash-equilibrium-via-Kakutani development: 8 theorems, 6 defs, 2 axioms, 0 sorries. Builds green at [2366/2366] under Mathlib v4.26.0 pin 2df2f015 (last verified 2026-06-12; Docker down 2026-06-13/06-14 so not re-built since).\n\n## Theorem Chain\n\n1. bestResponse (def) — argmax of expected utility over the mixed-strategy simplex Δᵢ.\n2. bestResponse_nonempty — EVT (IsCompact.exists_isMaxOn) on the compact, nonempty simplex.\n3. bestResponse_convex — from the multilinearity hypothesis IsLinearInStrategy.\n4. bestResponse_closed — bestResponse = Δᵢ ∩ {τ | M ≤ EU τ}, a level set of continuous EU.\n5. jointBestResponse (def) + fixed_point_is_nash — a fixed point of the joint best response is a Nash equilibrium (uses Function.update_eq_self).\n6. nash_existence — from kakutani_product_simplex applied to the joint best response.\n\nWorked examples: matching_pennies_uniform_is_mixed, prisoners_dilemma_nash.\n\n## Axioms (the open work)\n\n- bestResponse_uhc — Berge's maximum theorem (UHC of the argmax). Not in Mathlib.\n- kakutani_product_simplex — Kakutani fixed point on the product simplex; rests on kakutani_finite_dim (OQ04OQ03:69). Kakutani is not in Mathlib; proving it from Brouwer (the slug's nominal target) is a large simplicial-approximation formalization.\n\n## Next Steps\n\n1. Discharge kakutani_finite_dim (Kakutani ⇐ Brouwer) — requires a Docker build.\n2. Discharge bestResponse_uhc (Berge).\n3. Re-run docker-build after any Mathlib bump — this family drifts silently red.\n"
   },
   "tags": [
     "topology",
@@ -241,7 +243,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
       "filename": "BrouwerFixedPointOQ04OQ01.lean",
-      "lineCount": 297,
+      "lineCount": 305,
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 6,
@@ -283,6 +285,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean"
     }
   ],
-  "updatedAt": "2026-06-13T00:00:00Z",
-  "lastUpdate": "2026-06-13T00:00:00Z"
+  "updatedAt": "2026-06-14T00:00:00Z",
+  "lastUpdate": "2026-06-14T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

Build-free research-record maintenance for `brouwer-fixed-point-oq-04-oq-01` (Nash equilibrium existence via Kakutani). Docker daemon is down, so the substantive work (discharging the two axioms — Kakutani⇐Brouwer and Berge's maximum theorem) was not attempted, since it cannot be verified without a build.

The Lean file `Proofs/BrouwerFixedPointOQ04OQ01.lean` was verified intact: 8 theorems, 6 defs, 2 axioms (`bestResponse_uhc`, `kakutani_product_simplex`), 0 sorries. This PR fixes drift in the tracker JSON only — no Lean changes.

## Changes

- **lineCount** corrected 297 → 305 in `leanFiles`.
- **Internal contradiction resolved**: top-level fields described the complete ACT development, but `knowledge.markdown`, `knowledge.builtItems`, `knowledge.nextSteps`, and three `knowledge.insights` lines were still the original OBSERVE-iteration-1 stub ("formal statement not specified", "Move to ORIENT", "no substantive notes"). All synced to the actual ACT state.
- **mathlibGaps** placeholders replaced with the real, known gaps: Kakutani fixed point theorem and Berge's maximum theorem are both absent from Mathlib (kept as the two stated axioms).
- iteration 2 → 3; timestamps refreshed to 2026-06-14.

## Test plan

- [x] JSON validates (`JSON.parse`)
- [x] Lean file counts cross-checked against the record (8 thm / 6 def / 2 ax / 0 sorry / 305 lines)
- [ ] No build attempted (Docker down); no Lean changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)