### PR TITLE
research(cantor-diagonalization-oq-01-oq-02): sync stale leanFiles metrics (build-free)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-09T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "S3 ACT (researcher-4, 2026-06-09): contrapositive corollaries (PART IX) — +5 theorems (14→19), +55 LOC (306→361), 0 new axioms, 0 new defs, 0 sorries. New: ch_implies_not_mm, ch_implies_not_ma, gch_implies_not_mm, gch_implies_not_ma (four-corner {CH,¬CH}×{MM/MA,¬MM/¬MA} structure) + mm_continuum_gt_aleph_one (MM → ℵ₁ < 2^ℵ₀ quantitative refinement). Docker-verified 3061/3061 jobs both pre- and post-edit. File is buildable under Mathlib v4.26.0; all 7 axioms retained (deep set-theoretic results requiring forcing / inner model theory not in Mathlib).",
+    "iteration": 4,
+    "focus": "S4 build-free leanFiles sync (researcher-2, 2026-06-14): Docker down, no build. Corrected the stale leanFiles[CantorDiagonalizationOQ01OQ02.lean] metrics — lineCount 307→362 and theoremCount 14→19 — which were never updated after researcher-4's PART IX work (the prose in focus/progressSummary already recorded 14→19 / 306→361, but the leanFiles array lagged). Verified against the actual file: wc -l 361 (lineCount convention = wc+1 = 362, matching sibling entries), 19 theorem/lemma decls, 7 axioms, 10 defs, 0 sorries, identical to origin/main HEAD. Metrics-only; no Lean change. PRIOR: S3 ACT (researcher-4, 2026-06-09): contrapositive corollaries (PART IX) — +5 theorems (14→19), +55 LOC (306→361), 0 new axioms, 0 new defs, 0 sorries. New: ch_implies_not_mm, ch_implies_not_ma, gch_implies_not_mm, gch_implies_not_ma (four-corner {CH,¬CH}×{MM/MA,¬MM/¬MA} structure) + mm_continuum_gt_aleph_one (MM → ℵ₁ < 2^ℵ₀ quantitative refinement). Docker-verified 3061/3061 jobs both pre- and post-edit. File is buildable under Mathlib v4.26.0; all 7 axioms retained (deep set-theoretic results requiring forcing / inner model theory not in Mathlib).",
     "blockers": [],
     "nextAction": "Doc-only (lower priority): gallery meta.json enrichment with explicit citations to Lévy-Solovay (1967), Foreman-Magidor-Shelah (1988), Woodin Ultimate-L program; cross-reference sibling cantor-diagonalization gallery entries. Axiom elimination is BLOCKED until Mathlib has forcing theory / inner model theory infrastructure (multi-year projects).",
     "attemptCounts": {
@@ -95,7 +95,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.651Z",
-  "lastUpdate": "2026-06-09T00:00:00.000Z",
+  "lastUpdate": "2026-06-14T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ01OQ02.lean",
       "filename": "CantorDiagonalizationOQ01OQ02.lean",
-      "lineCount": 307,
-      "theoremCount": 14,
+      "lineCount": 362,
+      "theoremCount": 19,
       "axiomCount": 7,
       "defCount": 10,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Build-free tracker fix for `cantor-diagonalization-oq-01-oq-02` ("Is the Continuum Hypothesis decided by large cardinal axioms"). Docker is down, and axiom elimination here is blocked on forcing / inner-model-theory infrastructure not in Mathlib (multi-year), so no Lean work was attempted.

The `leanFiles[CantorDiagonalizationOQ01OQ02.lean]` metrics were stale — never updated after researcher-4's PART IX work on 2026-06-09. The record's own `focus`/`progressSummary` prose already documents the change (14→19 theorems, 306→361 LOC), but the `leanFiles` array still showed the pre-PART-IX numbers.

## Changes

- `lineCount` 307 → 362
- `theoremCount` 14 → 19
- iteration 3 → 4; `lastUpdate` → 2026-06-14

`axiomCount` (7), `defCount` (10), `sorryCount` (0) were already correct.

## Verification

Cross-checked against the actual file (identical to origin/main HEAD):
- `wc -l` = 361 → `lineCount` = 362 (repo convention `wc -l + 1`, confirmed against sibling entries CantorDiagonalization 175→176, OQ01 442→443, OQ01OQ01 303→304)
- 19 `theorem`/`lemma` decls, 7 axioms, 10 defs, 0 sorries

## Test plan

- [x] JSON validates (`JSON.parse`)
- [x] Metrics cross-checked against the Lean file and origin/main
- [ ] No build attempted (Docker down); no Lean changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)