### PR TITLE
research(borsuk-ulam-oq-03): realign drifted gallery sections to full file (6→20)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -97,46 +97,164 @@
   },
   "sections": [
     {
-      "id": "interval-bu",
-      "title": "1D Borsuk-Ulam on [-1,1]",
-      "summary": "Proves borsuk_ulam_interval: for continuous f, there exists x in [-1,1] with f(x)=f(-x). Uses IVT on g(x)=f(x)-f(-x) with antisymmetry g(-1)=-g(1).",
-      "startLine": 66,
-      "endLine": 106
+      "id": "foundations-1d-interval-circle",
+      "title": "Foundations: 1D Borsuk-Ulam on the Interval and Circle",
+      "startLine": 49,
+      "endLine": 261,
+      "mathContext": "For $n=1$, $f:S^1\\to\\mathbb{R}$ has an antipodal pair via IVT on $g(x)=f(x)-f(-x)$, which is antisymmetric.",
+      "summary": "Sections I-VI. The constructive core: 1D Borsuk-Ulam on $[-1,1]$ proved via the Intermediate Value Theorem applied to the antisymmetric difference $g(x)=f(x)-f(-x)$; the equivalence \"BU $\\iff$ every continuous odd function has a zero\"; the parametric $S^1$ version via $\\theta\\mapsto(\\cos\\theta,\\sin\\theta)$; non-existence of odd-valued continuous maps to $\\{+1,-1\\}$; and structural properties of antipodal pairs."
     },
     {
-      "id": "odd-zero",
-      "title": "Odd Functions and Equivalences",
-      "summary": "Proves odd continuous functions have zeros in [-1,1] as a corollary. Establishes logical equivalence: BU <-> odd functions vanish. Proves no odd continuous map to {+/-1} exists.",
-      "startLine": 107,
-      "endLine": 229
+      "id": "higher-dim-axiom-status",
+      "title": "Higher-Dimensional BU Axiom and Structural Summaries",
+      "startLine": 262,
+      "endLine": 390,
+      "mathContext": "General BU for $n\\ge1$ is axiomatized (`borsuk_ulam_general`); classical $n\\ge2$ proof needs Brouwer degree, absent from Mathlib.",
+      "summary": "Sections VII-X. The general Borsuk-Ulam theorem stated as the single independent axiom `borsuk_ulam_general`, with the sphere and antipodal-map definitions; a consequence that every continuous $f:S^n\\to\\mathbb{R}^n$ is non-injective; a summary of the constructive status; the trivial witness $x=0$ for the interval version; and the closedness/compactness of the coincidence set $\\{x:f(x)=f(-x)\\}$."
     },
     {
-      "id": "circle-bu",
-      "title": "Circle S^1 Borsuk-Ulam",
-      "summary": "Proves borsuk_ulam_circle_param: for continuous f: R^2 -> R, there exists theta in [0,pi] with f(cos t,sin t)=f(-cos t,-sin t). Uses IVT.",
-      "startLine": 150,
-      "endLine": 211
+      "id": "brouwer-fp-symmetric-intervals",
+      "title": "1D Brouwer Fixed-Point and Symmetric Intervals",
+      "startLine": 391,
+      "endLine": 453,
+      "mathContext": "1D Brouwer: continuous $g:[-1,1]\\to[-1,1]$ has a fixed point, proved independently of BU via IVT on $g(x)-x$.",
+      "summary": "Sections XI-XII. The 1D Brouwer Fixed-Point Theorem proved independently of Borsuk-Ulam via IVT on $g(x)-x$, and the generalization of all interval results to arbitrary symmetric intervals $[-a,a]$ with $a>0$."
     },
     {
-      "id": "axiom-reduction",
-      "title": "Axiom Reduction Chain (0 sorries)",
-      "summary": "Complete proof chain: BU -> no_retraction (hemisphere folding), no_retraction -> Brouwer FP (ray-sphere retraction with ball projection), BU -> LS (infDist technique). Reduces 4 axioms to 1 independent axiom.",
-      "startLine": 3302,
-      "endLine": 4400
+      "id": "tucker-ls-ham-sandwich-1d",
+      "title": "Tucker, Lusternik-Schnirelman and Ham-Sandwich (1D Combinatorial)",
+      "startLine": 454,
+      "endLine": 686,
+      "mathContext": "Tucker's 1D lemma: any signed labeling with complementary boundary has a sign-change edge — the discrete foundation of BU.",
+      "summary": "Sections XIII-XIX. The combinatorial backbone: Tucker's 1D lemma (Boolean and signed integer-label forms), the Lusternik-Schnirelman 1D covering theorem, the 1D Ham-Sandwich theorem, BU for odd polynomial functions, the existence of approximate antipodal pairs (constructive content), and the Tucker-to-BU reduction."
     },
     {
-      "id": "applications",
-      "title": "Applications of Borsuk-Ulam",
-      "summary": "Ham Sandwich theorem, Necklace Splitting, Kneser's conjecture (chromatic number formula verified), BU consequence web (5 equivalents + 5 implications).",
-      "startLine": 4415,
-      "endLine": 4672
+      "id": "degree-parity-dimension-consequences",
+      "title": "Degree Parity and Dimension-Reduction Consequences",
+      "startLine": 687,
+      "endLine": 927,
+      "mathContext": "From BU: no continuous injective map reduces dimension; antipodal degree has parity $(-1)^{n+1}$.",
+      "summary": "Sections XX-XXIV. Parity of the antipodal degree; BU implies dimension-reducing continuous maps cannot be injective (via the padding map $\\mathbb{R}^m\\hookrightarrow\\mathbb{R}^n$); BU implies the no-retraction and Brouwer fixed-point consequence chain; Lusternik-Schnirelmann for $S^n$ from the BU axiom; and topological dimension consequences."
     },
     {
-      "id": "no-odd-map",
-      "title": "No Odd Map Between Spheres",
-      "summary": "Proves no continuous odd map S^n -> S^{n-1} exists (from BU). Establishes equivariant map hierarchy: existence iff source_dim <= target_dim. Proves isobarycentric point theorem for odd functions.",
-      "startLine": 4830,
-      "endLine": 5139
+      "id": "general-form-bu-status",
+      "title": "General-Form BU and Constructive Status",
+      "startLine": 928,
+      "endLine": 1042,
+      "mathContext": "Constructive proof of $n=1$ BU in the general $f:S^1\\to\\mathbb{R}$ form; full inventory of what is constructive vs axiomatized.",
+      "summary": "Sections XXV-XXVI. The $n=1$ Borsuk-Ulam theorem in general form proved constructively via IVT, together with the complete constructive-status summary distinguishing the constructively proved results from the single axiomatized general case."
+    },
+    {
+      "id": "tucker-parity-ls-s1-antipodal",
+      "title": "Tucker Parity, LS on the Circle and Antipodal Pairing",
+      "startLine": 1043,
+      "endLine": 1448,
+      "mathContext": "Refined parity and pairing results on $S^1$: Tucker's parity lemma, non-trivial LS covers, antipodal zero pairing.",
+      "summary": "Sections XXVII-XXXV. Tucker's parity lemma; a non-trivial Lusternik-Schnirelman result for $S^1$; antipodal zero pairing on the circle; BU for compositions and products; Tucker's lemma for integer-valued functions; the 1D Borsuk number; connections to topological connectivity; and metric consequences of BU on $S^1$."
+    },
+    {
+      "id": "even-odd-decomposition-quantitative-bisection",
+      "title": "Even-Odd Decomposition and Quantitative Bisection",
+      "startLine": 1449,
+      "endLine": 1769,
+      "mathContext": "$f=\\mathrm{evenPart}(f)+\\mathrm{oddPart}(f)$; antipodal pairs are exactly zeros of the odd part; bisection gives effective witnesses.",
+      "summary": "Sections XXXVII-XLI. The even-odd decomposition $f(x)=\\tfrac12(f(x)+f(-x))+\\tfrac12(f(x)-f(-x))$ with $f(x)=f(-x)\\iff\\mathrm{oddPart}(f)(x)=0$; continuity of both parts; effective bisection producing antipodal witnesses; quantitative BU via bisection; and the constructive-content summaries."
+    },
+    {
+      "id": "tucker-2d-sperner-kkm",
+      "title": "Tucker 2D, Sperner and KKM Combinatorial Bridges",
+      "startLine": 1770,
+      "endLine": 2462,
+      "mathContext": "Higher combinatorial lemmas: Tucker 2D (octahedral), Sperner 1D/2D, KKM 1D — finite analogues bridging to BU and Brouwer.",
+      "summary": "Sections XLII-XLIX. Tucker's 2D lemma on the octahedral triangulation; Sperner's 1D lemma (combinatorial Brouwer FP) and 2D lemma on a minimal triangulation; the formal equivalence chain in 1D; the Tucker-BU bridge; the KKM lemma in 1D via `infDist`; and the equivalence web summarizing how these results interrelate."
+    },
+    {
+      "id": "equivalence-chain-combinatorial-degree",
+      "title": "The 1D Equivalence Chain and Combinatorial Degree",
+      "startLine": 2463,
+      "endLine": 2669,
+      "mathContext": "Formal composition KKM $\\to$ no-retraction $\\to$ Brouwer FP, plus a combinatorial degree (sign-change count) for 1D functions.",
+      "summary": "Sections L-LI. The complete 1D equivalence chain assembled by formal composition (e.g. KKM $\\to$ no-retraction $\\to$ Brouwer FP), and a combinatorial degree for 1D functions defined via counted sign changes."
+    },
+    {
+      "id": "quantitative-lipschitz-circle-degree",
+      "title": "Quantitative, Lipschitz and Circle-Degree Borsuk-Ulam",
+      "startLine": 2670,
+      "endLine": 2903,
+      "mathContext": "Quantitative BU via modulus of continuity; specialization to Lipschitz maps; circle-map degree and its link to BU.",
+      "summary": "Sections LII-LV. Quantitative Borsuk-Ulam bounds via the modulus of continuity; the Lipschitz specialization; the degree of circle maps and its connection to BU; and an updated summary of the quantitative results."
+    },
+    {
+      "id": "lusternik-schnirelmann-covering",
+      "title": "Lusternik-Schnirelmann Covering Theory",
+      "startLine": 2904,
+      "endLine": 3100,
+      "mathContext": "LS covering theorem (1D) and its equivalence with BU: an LS cover forces a set containing an antipodal pair.",
+      "summary": "Sections LVI-LIX. The Lusternik-Schnirelmann covering theorem in 1D; the LS $\\iff$ BU equivalence; LS implies no nonvanishing odd function; and the updated equivalence web placing LS among the BU-equivalent statements."
+    },
+    {
+      "id": "bu-to-ls-general-axiom-reduction",
+      "title": "BU → LS General (Axiom Reduction)",
+      "startLine": 3101,
+      "endLine": 3312,
+      "mathContext": "Deriving the general LS covering property from the single BU axiom, eliminating LS as an independent assumption.",
+      "summary": "Sections LX-LXII. Deriving the general Lusternik-Schnirelmann covering property (open and closed-set forms) from the `borsuk_ulam_general` axiom, reducing the independent axiom count, with an updated axiom-status inventory."
+    },
+    {
+      "id": "no-retraction-brouwer-construction",
+      "title": "No-Retraction → Brouwer FP Construction",
+      "startLine": 3313,
+      "endLine": 3745,
+      "mathContext": "Explicit no-retraction $\\Rightarrow$ Brouwer FP: ray-sphere intersection, ball projection $x/\\max(1,|x|)$, and the retraction construction.",
+      "summary": "Sections LXIII-LXVII. The constructive No-Retraction $\\to$ Brouwer Fixed-Point argument: ray-sphere intersection via the quadratic formula with a perfect-square discriminant; ball-projection and continuity infrastructure ($x/\\max(1,|x|)$ avoiding piecewise continuity); the retraction construction; and BU $\\to$ no-retraction reducing the system to a single axiom."
+    },
+    {
+      "id": "radial-extension-axiom-elimination",
+      "title": "Radial Extension Infrastructure and Axiom Elimination",
+      "startLine": 3746,
+      "endLine": 4377,
+      "mathContext": "Hemisphere-fold construction and 4-case radial-extension continuity proving BU $\\to$ no-retraction with 0 sorries.",
+      "summary": "Sections LXVIII (and LXVIII-A). Radial extension continuity infrastructure — the hemisphere-fold construction $g$ with the projection $\\pi$, oddness by sign case-analysis on the last coordinate, and a four-branch `ContinuousAt` decomposition — completing the axiom-elimination so that all reductions hold with 0 sorries (effective independent axiom count 1)."
+    },
+    {
+      "id": "classical-applications",
+      "title": "Classical Applications of Borsuk-Ulam",
+      "startLine": 4378,
+      "endLine": 4641,
+      "mathContext": "Ham Sandwich, Necklace Splitting and Kneser's conjecture as consequences of BU; `ham_sandwich_general` proved from BU.",
+      "summary": "Section LXIX. Classical applications: the Ham Sandwich theorem (`ham_sandwich_general`) derived from BU via an explicit chain, plus catalogued applications to Necklace Splitting and Kneser's conjecture with worked example data."
+    },
+    {
+      "id": "degree-theory-higher-bu",
+      "title": "Degree Theory and Higher BU Structure",
+      "startLine": 4642,
+      "endLine": 4779,
+      "mathContext": "Antipodal degree $\\deg=(-1)^{n+1}$; odd continuous self-maps of $S^n$ have odd degree; degree-theoretic form of BU.",
+      "summary": "Section LXX. Degree theory for sphere maps: the antipodal degree $(-1)^{n+1}$ with computed small cases, the classification of $S^n\\to S^n$ maps by degree, the fact that odd maps have odd degree, and the degree-theoretic formulation of Borsuk-Ulam."
+    },
+    {
+      "id": "no-odd-map-between-spheres",
+      "title": "No Continuous Odd Map S^n → S^{n-1}",
+      "startLine": 4780,
+      "endLine": 4889,
+      "mathContext": "Borsuk (1933): no continuous odd map $S^n\\to S^{n-1}$ exists; equivalent to BU.",
+      "summary": "Section LXXI. The sphere-to-sphere obstruction `no_odd_map_between_spheres`: there is no continuous odd (antipode-preserving) map $S^n\\to S^{n-1}$, shown equivalent to the Borsuk-Ulam theorem."
+    },
+    {
+      "id": "isobarycentric-point-theorem",
+      "title": "Isobarycentric Point Theorem",
+      "startLine": 4890,
+      "endLine": 4946,
+      "mathContext": "From BU: every odd continuous $f$ admits an isobarycentric point where the coordinate values balance.",
+      "summary": "Section LXXII. The Isobarycentric Point Theorem for odd functions, derived from Borsuk-Ulam: existence of a point at which the components of an odd continuous map balance."
+    },
+    {
+      "id": "topological-tverberg",
+      "title": "Topological Tverberg Theorem",
+      "startLine": 4947,
+      "endLine": 5139,
+      "mathContext": "Tverberg generalizes BU: $r$ disjoint faces of $\\Delta^N$ with a common image — true for $r$ a prime power, false for $r=6$.",
+      "summary": "Section LXXIII. The Topological Tverberg Theorem as a higher generalization of Borsuk-Ulam, including the dependence on the arithmetic of $r$ (true for prime powers by Barany-Shlosman-Szucs / Volovikov, false for $r=6$ by Mabillard-Wagner) and the $r=2$ reduction back to BU, with the closing axiom-hierarchy summary."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The gallery `sections` for **borsuk-ulam-oq-03** had drifted to an old revision: only **6 sections** covering a fraction of the **5139-line** Lean file, with a ~3000-line internal gap (lines 229→3302 uncovered) and overlapping front ranges.
- The actual file contains **73 internal "Section I–LXXIII" units**: constructive 1D Borsuk-Ulam (IVT on the antisymmetric difference), Tucker/Sperner/KKM combinatorial bridges, the No-Retraction → Brouwer FP construction, the full axiom-reduction chain (BU → no-retraction/LS/Brouwer, 0 sorries), and applications (Ham Sandwich, degree theory, no-odd-map, isobarycentric point, Tverberg).
- Rebuilt `sections` into **20 contiguous thematic groups** tiling lines 49–5139 with accurate titles, `mathContext`, and summaries.

## Notes
- Content-only metadata change; **no Lean source modified**.
- Counts unchanged and verified: 0 sorries, effective independent `axiomCount` 1 (`borsuk_ulam_general`), `lineCount` 5139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)