### PR TITLE
Enrich erdos-501: realign drifted sections (8) + annotations to full file

### DIFF
--- a/src/data/proofs/erdos-501/annotations.json
+++ b/src/data/proofs/erdos-501/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-501-setfamily",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 38,
-      "endLine": 39
+      "startLine": 40,
+      "endLine": 40
     },
     "type": "definition",
     "title": "Set Family",
@@ -223,8 +223,8 @@
     "id": "ann-501-ch",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 92,
-      "endLine": 92
+      "startLine": 133,
+      "endLine": 136
     },
     "type": "concept",
     "title": "Continuum Hypothesis",
@@ -246,8 +246,8 @@
     "id": "ann-501-hechler",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 94,
-      "endLine": 96
+      "startLine": 138,
+      "endLine": 140
     },
     "type": "concept",
     "title": "Hechler's Theorem (1972)",
@@ -266,33 +266,11 @@
     ]
   },
   {
-    "id": "ann-501-gladysz",
-    "proofId": "erdos-501",
-    "range": {
-      "startLine": 101,
-      "endLine": 103
-    },
-    "type": "concept",
-    "title": "Gladysz's Theorem (1962)",
-    "content": "For closed measure families, size-2 independent sets always exist. Closedness provides the topological structure the general case lacks.",
-    "mathContext": "Gladysz: If $A_x$ is closed, $\\mu(A_x) < 1$ $\\forall x$, then $\\exists x \\neq y$ with $x \\notin A_y \\land y \\notin A_x$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "closed sets in ℝ",
-      "topological regularity",
-      "Baire property"
-    ],
-    "prerequisites": [
-      "ClosedMeasureFamily",
-      "IsIndependentOfSize"
-    ]
-  },
-  {
     "id": "ann-501-nps",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 107,
-      "endLine": 109
+      "startLine": 144,
+      "endLine": 148
     },
     "type": "concept",
     "title": "NPS Theorem (1987)",
@@ -310,11 +288,33 @@
     ]
   },
   {
+    "id": "ann-501-gladysz",
+    "proofId": "erdos-501",
+    "range": {
+      "startLine": 150,
+      "endLine": 168
+    },
+    "type": "concept",
+    "title": "Gladysz's Theorem (1962)",
+    "content": "For closed measure families, size-2 independent sets always exist. Closedness provides the topological structure the general case lacks.",
+    "mathContext": "Gladysz: If $A_x$ is closed, $\\mu(A_x) < 1$ $\\forall x$, then $\\exists x \\neq y$ with $x \\notin A_y \\land y \\notin A_x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "closed sets in ℝ",
+      "topological regularity",
+      "Baire property"
+    ],
+    "prerequisites": [
+      "ClosedMeasureFamily",
+      "IsIndependentOfSize"
+    ]
+  },
+  {
     "id": "ann-501-q1",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 121,
-      "endLine": 122
+      "startLine": 172,
+      "endLine": 181
     },
     "type": "definition",
     "title": "Question 1: Infinite Independence",
@@ -335,8 +335,8 @@
     "id": "ann-501-zfc",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 132,
-      "endLine": 139
+      "startLine": 190,
+      "endLine": 198
     },
     "type": "concept",
     "title": "ZFC Independence of Question 1",
@@ -358,8 +358,8 @@
     "id": "ann-501-hereditary",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 144,
-      "endLine": 147
+      "startLine": 202,
+      "endLine": 206
     },
     "type": "concept",
     "title": "Hereditary Property",
@@ -380,8 +380,8 @@
     "id": "ann-501-insert",
     "proofId": "erdos-501",
     "range": {
-      "startLine": 150,
-      "endLine": 161
+      "startLine": 208,
+      "endLine": 220
     },
     "type": "concept",
     "title": "Insertion Lemma",


### PR DESCRIPTION
## Enrichment: full-file section + annotation realignment

`Erdos501Problem.lean` (278 lines, Erdős #501 — independent sets for bounded outer measure families) had `sections` and `annotations` frozen at an old revision.

### Sections (8, realigned)
The back-half sections were scrambled and mislabeled: Parts IV–VII pointed at lines 86–206 (overlapping the Erdős-Hajnal proof) instead of their real banner positions (`Part IV` @124, `Part V` @142, `Part VI` @170, `Part VII` @200), and the closing summary docstring (206–278) was uncovered. Rebuilt to **8 contiguous sections** (header + Parts I–VII) covering the full file (1–278), with summaries naming the actual declarations and flagging the 3 sorries (Erdős-Hajnal n≥2 Fubini step, Hechler/CH, NPS/closed).

### Annotations (9 realigned, 4 build errors fixed)
The CH / Hechler / NPS / Gladysz / Question-1 / ZFC-independence / hereditary / insert annotations (plus `setfamily`) pointed at stale line numbers, producing build errors ("No Lean construct found", "definition but found theorem"). Realigned each to its correct current range and re-sorted by start line. Content was already correct (only line ranges drifted).

### Counts
Unchanged — 10 theorems / 12 defs / 0 axioms / 3 sorries were already accurate. Only `sections`/`annotations` metadata changed.

Validated: `annotations/build.ts` reports no errors for this slug.