### PR TITLE
research(erdos-413): realign drifted gallery sections to full file (14→24)

### DIFF
--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -88,116 +88,196 @@
   },
   "sections": [
     {
-      "id": "header-imports",
+      "id": "header",
       "title": "Header and Imports",
       "startLine": 1,
       "endLine": 22,
-      "summary": "Module docstring describing barriers for ω, Erdős's conjecture, known results (expProd density, Selfridge's computation, OEIS A005236), and Mathlib import.",
-      "mathContext": "Erdős #413: Are there infinitely many barriers for $\\omega(n)$? A barrier $n$ satisfies $m + \\omega(m) \\leq n$ for all $m < n$."
+      "summary": "Module docstring describing barriers for ω, Erdős's conjecture, known results (expProd density, Selfridge's computation, OEIS A005236), and the Mathlib import.",
+      "mathContext": "A barrier for $f$ is $n$ with $m + f(m) \\leq n$ for all $m < n$. Erdős asks whether there are infinitely many barriers for $\\omega$."
     },
     {
-      "id": "arithmetic-functions",
-      "title": "Arithmetic Functions",
+      "id": "arithmetic-functions-barriers",
+      "title": "Arithmetic Functions and Barrier Definitions",
       "startLine": 23,
-      "endLine": 41,
-      "summary": "Defines three noncomputable arithmetic functions: ω(n) = number of distinct prime divisors, Ω(n) = prime factors with multiplicity, and expProd(n) = product of prime exponents.",
-      "mathContext": "$\\omega(n) = |\\{p \\text{ prime} : p \\mid n\\}|$ (number of distinct prime divisors), $\\Omega(n) = \\sum_{p^k \\| n} k$ (with multiplicity), $\\text{expProd}(n) = \\prod_{p \\mid n} p$."
-    },
-    {
-      "id": "barrier-definitions",
-      "title": "Barrier Definitions",
-      "startLine": 42,
       "endLine": 62,
-      "summary": "Defines IsBarrier for ℕ → ℕ functions, IsBarrierReal for ℝ-valued functions (ε-variant), and the set of barriers.",
-      "mathContext": "$n$ is a barrier for $f$ if $\\forall m < n, m + f(m) \\leq n$. Real variant: $\\forall m < n, m + f(m) < n + \\varepsilon$."
+      "summary": "Defines ω (distinct prime divisors), Ω (prime factors with multiplicity), expProd(n)=∏kᵢ; and IsBarrier (ℕ→ℕ), IsBarrierReal (ε-variant), and the barrier set.",
+      "mathContext": "$\\omega(n)=|\\{p\\,\\text{prime}:p\\mid n\\}|$, $\\Omega(n)=\\sum_p v_p(n)$, $F(n)=\\prod_i k_i$. $n$ is a barrier for $f$ iff $\\forall m<n,\\ m+f(m)\\leq n$."
     },
     {
-      "id": "basic-properties",
-      "title": "Basic Barrier Properties",
+      "id": "basic-barrier-properties",
+      "title": "Basic Properties of Barriers",
       "startLine": 63,
-      "endLine": 100,
-      "summary": "Proves 0 and 1 are always barriers, characterizes when 2 is a barrier, and shows barrier monotonicity in the function argument.",
-      "mathContext": "0 and 1 are always barriers. 2 is a barrier iff $f(1) \\leq 1$. Each barrier is $\\leq$ the next."
+      "endLine": 101,
+      "summary": "Proves 0 and 1 are always barriers, characterizes when 2 is a barrier (f(1)≤1 given f(0)=0), the at-barrier inequality m+f(m)≤n, and barrier monotonicity in the function argument (g≤f).",
+      "mathContext": "$0$ is vacuously a barrier; $1$ is a barrier when $f(0)\\leq 1$; if $g\\leq f$ pointwise and $n$ is a barrier for $f$ then $n$ is a barrier for $g$."
     },
     {
-      "id": "omega-values-bounds",
-      "title": "ω Values and Upper Bound",
-      "startLine": 101,
+      "id": "omega-values-upper-bound",
+      "title": "ω Values and Upper Bound ω(n) ≤ log₂ n",
+      "startLine": 102,
       "endLine": 159,
-      "summary": "Computes ω for small inputs, proves ω(p) = 1 for primes, and establishes the key bound 2^ω(n) ≤ n (equivalently ω(n) ≤ log₂ n) via prime factorization.",
-      "mathContext": "$\\omega(1) = 0, \\omega(p) = 1, \\omega(p^k) = 1, \\omega(pq) = 2$. Key bound: $\\omega(n) \\leq \\log_2(n)$ since $2^{\\omega(n)} \\leq n$."
+      "summary": "Computes ω for small inputs (ω(n)=0 ⟺ n≤1), proves the radical divides n, and establishes 2^ω(n) ≤ n, i.e. ω(n) ≤ log₂ n for n ≥ 2.",
+      "mathContext": "$\\prod_{p\\mid n}p \\mid n$, hence $2^{\\omega(n)} \\leq n$ and $\\omega(n) \\leq \\log_2 n$ for $n \\geq 2$ — the basic growth ceiling on ω."
     },
     {
-      "id": "phi-sigma-no-barriers",
-      "title": "φ and σ₁ Have No Barriers",
+      "id": "barrier-no-large-jumps",
+      "title": "Barrier Implies No Large Jumps",
       "startLine": 160,
-      "endLine": 218,
-      "summary": "Proves φ has no barriers beyond 3 (since φ(n) ≥ 2 for n ≥ 3) and σ₁ has no barriers beyond 2 (since σ₁(n) ≥ n+1 for n ≥ 2). Also proves ω ≤ Ω.",
-      "mathContext": "$\\varphi$ has no barriers beyond 3 (since $\\varphi(n) \\geq 2$ for $n \\geq 3$, making $n + \\varphi(n) > n+1$). Similarly $\\sigma_1$ has no barriers beyond 2."
+      "endLine": 173,
+      "summary": "At a barrier n>0, f(n-1) ≤ 1; and at a barrier, f(m) ≤ n - m for all m < n.",
+      "mathContext": "The barrier condition $m+f(m)\\leq n$ rearranges to $f(m)\\leq n-m$; in particular $f(n-1)\\leq 1$."
     },
     {
-      "id": "decidable-omega-barriers",
-      "title": "Machine-Verified ω-Barriers",
-      "startLine": 244,
-      "endLine": 402,
-      "summary": "Computable barrier checking via isBarrierBool with soundness/completeness proofs. Machine-verifies ω-barriers at 0-128 and non-barriers at 3,5,7-10,15,16,20 via native_decide. Counts barriers at thresholds.",
-      "mathContext": "Computable barrier checking via `isBarrierBool` with decidable arithmetic. Sound and complete: `isBarrierBool n = true ↔ IsBarrier omega n`."
+      "id": "phi-no-barriers",
+      "title": "Why φ Has No Barriers",
+      "startLine": 174,
+      "endLine": 202,
+      "summary": "For prime p, p+φ(p)=2p-1; φ(n)≥2 for n≥3; hence φ has no barriers beyond 3 ((n-1)+φ(n-1) > n for n ≥ 4).",
+      "mathContext": "$\\varphi(n)\\geq 2$ for $n\\geq 3$, so $(n-1)+\\varphi(n-1) > n$ for all $n\\geq 4$ — φ grows too fast to admit large barriers."
     },
     {
-      "id": "structural-theorems",
-      "title": "Barrier Structural Theorems",
-      "startLine": 403,
-      "endLine": 480,
-      "summary": "Not-barrier witness extraction, proof that barrier predecessors are prime powers, barrier spacing (gap-two, consecutive barriers, offset bounds), and barrier downward closure.",
-      "mathContext": "Witness extraction: if $n$ is not a barrier, $\\exists m < n, m + \\omega(m) > n$. Barrier predecessors are prime powers."
+      "id": "omega-le-Omega-prime-powers",
+      "title": "Relationship ω ≤ Ω and ω of Prime Powers",
+      "startLine": 203,
+      "endLine": 241,
+      "summary": "ω(n) ≤ Ω(n); an Ω-barrier is also an ω-barrier; ω(p^k)=1; at any barrier n>0, ω(n-1) ≤ 1.",
+      "mathContext": "$\\omega(n)\\leq\\Omega(n)$ (distinct ≤ with-multiplicity), so barriers for $\\Omega$ are barriers for $\\omega$; $\\omega(p^k)=1$; barrier predecessors satisfy $\\omega(n-1)\\leq 1$."
+    },
+    {
+      "id": "decidable-barrier-checking",
+      "title": "Decidable Barrier Checking",
+      "startLine": 242,
+      "endLine": 275,
+      "summary": "section DecidableBarriers: computable ωC, isBarrierBool with soundness (true ⟹ IsBarrier) and completeness (IsBarrier ⟹ true), and a barrier-counting function up to N.",
+      "mathContext": "isBarrierBool reduces $\\forall m<n,\\ m+f(m)\\leq n$ to a finite Bool check, sound and complete against IsBarrier — enabling native_decide verification."
+    },
+    {
+      "id": "verified-omega-barriers",
+      "title": "Machine-Verified ω-Barriers and Non-Barriers",
+      "startLine": 276,
+      "endLine": 355,
+      "summary": "Machine-verifies ω-barriers (OEIS A005236) at 0–128 and non-barriers (3,5,7–10,15,16,20) via native_decide, and counts barriers at thresholds.",
+      "mathContext": "OEIS A005236 lists barriers for ω; their finite prefixes are verified by reflection (native_decide), giving concrete data toward the infinitude question."
+    },
+    {
+      "id": "barrier-structural-spacing",
+      "title": "Barrier Structural and Spacing Theorems",
+      "startLine": 356,
+      "endLine": 433,
+      "summary": "Not-barrier witness extraction (∃ m<n, m+f(m)>n), barrier predecessors are prime powers, downward closure (barrier for constant 0), and spacing: gap-two barriers force ω(n),ω(n+1) ≤ 1, and barrier-to-successor conditions.",
+      "mathContext": "Every barrier $n\\geq 2$ for ω has $n-1\\in\\{1\\}\\cup\\{p^k\\}$. If $n$ and $n+2$ are both barriers then $\\omega(n),\\omega(n+1)\\leq 1$ — barriers cannot cluster around composite-rich predecessors."
+    },
+    {
+      "id": "sigma-no-barriers",
+      "title": "Why σ₁ Has No Barriers",
+      "startLine": 434,
+      "endLine": 471,
+      "summary": "σ₁(n) (sum of divisors); σ₁(n) ≥ n+1 for n ≥ 2 (1 and n divide n); hence σ₁ has no barriers beyond 2 ((n-1)+σ₁(n-1) > n for n ≥ 3).",
+      "mathContext": "$\\sigma_1(n)\\geq n+1$ for $n\\geq 2$, so $(n-1)+\\sigma_1(n-1) > n$ — like φ, σ₁ admits no large barriers, isolating ω as the interesting slow-growing case."
     },
     {
       "id": "general-barrier-theory",
-      "title": "General Barrier Theory",
-      "startLine": 519,
-      "endLine": 584,
-      "summary": "Barriers for zero function = all of ℕ, constant function characterization, bounded-by-one implies universal barrier, barrier sum decomposition, and inter-barrier witness theorem.",
-      "mathContext": "Zero function: all $n$ are barriers. Constant $c$: barriers are exactly $\\{0, \\ldots, c\\}$. Bounded $f$: barrier set is cofinite."
+      "title": "General Barrier Theory and Density Analysis",
+      "startLine": 472,
+      "endLine": 557,
+      "summary": "Barriers for g≤f, finitely-many-barriers when f eventually dominates identity, downward closure, barriers of the zero function = all of ℕ, and density: at most one of n,n+1,n+2 is a barrier when n ≥ 6.",
+      "mathContext": "If $f$ eventually exceeds the identity, $f$ has only finitely many barriers; the zero function's barrier set is all of $\\mathbb{N}$. For $n\\geq 6$, barriers for ω are spaced apart (not three-in-a-row)."
     },
     {
       "id": "iterated-dynamics",
-      "title": "Iterated Dynamics",
-      "startLine": 605,
-      "endLine": 709,
-      "summary": "Defines iterOmega, iterOmegaPow, eventuallyMeet, and orbit. Proves orbits are strictly increasing for n ≥ 2, barriers trap orbits, and orbits respect barrier ordering.",
-      "mathContext": "iterOmega: $\\omega^{(k)}(n)$. orbits are strictly decreasing until reaching 0 or 1. eventuallyMeet: do all orbits merge?"
+      "title": "Connection to Iterated Dynamics",
+      "startLine": 558,
+      "endLine": 644,
+      "summary": "Defines iterOmega, iterOmegaPow, eventuallyMeet, orbit. The map x↦x+ω(x) is strictly increasing for n≥2; orbits are monotone; a barrier traps any orbit started below it; for squarefree n, ω(n)=Ω(n).",
+      "mathContext": "Orbit of $n$: iterates of $x\\mapsto x+\\omega(x)$. Strictly increasing for $n\\geq 2$; a barrier $b$ is passed through by every orbit started at $m<b$ — linking barriers to the trajectory-merging question (#412)."
     },
     {
-      "id": "decidable-bigomega-expprod",
-      "title": "Verified Ω and expProd Barriers",
-      "startLine": 710,
-      "endLine": 855,
-      "summary": "Computable Ω and expProd, machine-verified barriers for each, barrier counts, and computational comparison hierarchy: F >> ω >> Ω.",
-      "mathContext": "Machine-verified: $\\Omega$-barriers are $\\{0,1,2,3,4,8\\}$. expProd-barriers are $\\{0,1,2\\}$."
+      "id": "orbit-barrier-interaction",
+      "title": "Orbit and Barrier Interaction",
+      "startLine": 645,
+      "endLine": 662,
+      "summary": "An orbit starting below a barrier reaches/passes it in finitely many steps; with two consecutive barriers, orbits started below the first coalesce.",
+      "mathContext": "Barriers act as funnels: any orbit from $m<b$ meets $b$ in finite time, so consecutive barriers force trajectory coalescence."
     },
     {
-      "id": "omega-multiplicativity",
-      "title": "ω Multiplicativity and Subadditivity",
-      "startLine": 1025,
-      "endLine": 1047,
-      "summary": "Proves ω(mn) = ω(m) + ω(n) for coprime m,n, derives ω(6) = 2 and ω(30) = 3, and proves the subadditive bound ω(mn) ≤ ω(m) + ω(n) for general products.",
-      "mathContext": "$\\omega(mn) = \\omega(m) + \\omega(n)$ for $\\gcd(m,n) = 1$. Derives $\\omega(6) = 2$, $\\omega(30) = 3$."
+      "id": "computable-Omega-barriers",
+      "title": "Computable Ω and Verified Ω-Barriers",
+      "startLine": 663,
+      "endLine": 707,
+      "summary": "Computable bigOmega (ΩC) with transfer to Ω, and machine-verified Ω-barriers via native_decide.",
+      "mathContext": "ΩC matches Ω, so reflected barrier checks for ΩC transfer to Ω; verified Ω-barriers give the second arm of the F ≫ ω ≫ Ω comparison."
+    },
+    {
+      "id": "computable-expProd-barriers",
+      "title": "Computable expProd and Verified F-Barriers",
+      "startLine": 708,
+      "endLine": 767,
+      "summary": "Computable expProd (F) and barrier verification, plus machine-verified F-barriers (expProd).",
+      "mathContext": "$F(n)=\\prod_i k_i$ is the slowest of the three functions; its verified barriers are the densest, anchoring the hierarchy F ≫ ω ≫ Ω."
+    },
+    {
+      "id": "extended-comparison",
+      "title": "Extended ω-Barrier Verification and Function Comparison",
+      "startLine": 768,
+      "endLine": 801,
+      "summary": "Extended native_decide ω-barrier checks and the comparison ω-barriers are more common than Ω-barriers up to 5 — the computational hierarchy F ≫ ω ≫ Ω.",
+      "mathContext": "Counts of barriers up to small thresholds confirm $F \\gg \\omega \\gg \\Omega$ in barrier density, matching the heuristic that slower-growing functions admit more barriers."
+    },
+    {
+      "id": "consecutive-offset-bounds",
+      "title": "Consecutive Barriers, Transfer and Offset Bounds",
+      "startLine": 802,
+      "endLine": 866,
+      "summary": "Consecutive barriers n,n+1 force ω(n)≤1; ω(n)≥2 ⟹ n+1 not a barrier; numbers with ω(m)≥2 must sit ≥2 below a barrier; omegaC=omega transfer; offset bound ω(n-j) ≤ j at a barrier.",
+      "mathContext": "At a barrier $n$, $\\omega(n-j)\\leq j$ for $1\\leq j<n$; consecutive barriers force $\\omega(n)\\leq 1$, so prime-rich numbers repel nearby barriers."
+    },
+    {
+      "id": "predecessor-structure",
+      "title": "Barrier Non-Existence and Predecessor Structure",
+      "startLine": 867,
+      "endLine": 904,
+      "summary": "f(n-1)≥2 ⟹ n not a barrier; if a+f(a)=n for some a<n then n-1 is not a barrier; between consecutive barriers b₁<b₂ every n has a function lower bound.",
+      "mathContext": "A barrier $n$ forces $f(n-1)\\leq 1$, so any predecessor with $f\\geq 2$ rules $n$ out; consecutive barriers impose lower bounds on $f$ across the gap."
+    },
+    {
+      "id": "squarefree-orbit-coalescence",
+      "title": "Squarefree Equivalence and Orbit Coalescence",
+      "startLine": 905,
+      "endLine": 970,
+      "summary": "If all numbers below n are squarefree (or 0) then ω-barrier ⟺ Ω-barrier at n; orbit notations agree (orbit=iterOmegaPow), orbit shift law, and every orbit from m∈[2,b) reaches barrier b exactly.",
+      "mathContext": "Under squarefreeness ω=Ω, so the two barrier notions coincide; the shift law $\\text{orbit}\\,n\\,(k+j)=\\text{orbit}(\\text{orbit}\\,n\\,k)\\,j$ and exact-reaching prove trajectory coalescence at barriers."
     },
     {
       "id": "main-conjectures",
-      "title": "Main Conjectures and Open Problem",
-      "startLine": 974,
-      "endLine": 1024,
-      "summary": "States the main conjecture (ω-barriers infinite), ε-variant, trajectory merging conjecture (related to #412), Erdős's expProd density result, Selfridge's computation, and the combined open problem.",
-      "mathContext": "Main conjecture: $|\\{n : \\text{IsBarrier}(\\omega, n)\\}| = \\infty$. Trajectory merging: do all $\\omega$-orbits eventually meet?"
+      "title": "The Main Conjectures (OPEN)",
+      "startLine": 971,
+      "endLine": 1007,
+      "summary": "States the main conjecture (ω-barriers infinite), its ε-variant, and the trajectory-merging conjecture related to Erdős #412.",
+      "mathContext": "Main open question: $\\{n : n\\ \\text{is a barrier for}\\ \\omega\\}$ is infinite. The ε-variant uses IsBarrierReal; trajectory-merging links to problem #412."
     },
     {
-      "id": "strong-prime-power",
-      "title": "Strong Prime Power Predecessor",
-      "startLine": 1024,
-      "endLine": 1047,
-      "summary": "Proves the strong form: at any barrier n ≥ 3, n-1 is necessarily a prime power p^k with k ≥ 1, using the fact that ω(n-1) = 1 for n ≥ 3 at a barrier.",
-      "mathContext": "At any barrier $n \\geq 3$: $n - 1$ is a prime power $p^k$. Proof: if $n-1 = ab$ with $a,b > 1$ coprime, then $\\omega(n-1) \\geq 2$, violating the barrier condition."
+      "id": "known-results-axioms",
+      "title": "Known Results (Axioms) and Main Open Problem",
+      "startLine": 1008,
+      "endLine": 1034,
+      "summary": "Erdős's expProd density result and Selfridge's computation, stated as axioms (deep but known), and the combined main open problem statement.",
+      "mathContext": "Cited as axioms: expProd-barriers have density results (Erdős) and Selfridge's explicit barrier computations — the single axiom in the file encodes such a known-but-deep input."
+    },
+    {
+      "id": "omega-multiplicativity-subadditivity",
+      "title": "ω Multiplicativity and Subadditivity",
+      "startLine": 1035,
+      "endLine": 1087,
+      "summary": "ω(mn)=ω(m)+ω(n) for coprime m,n (deriving ω(6)=2, ω(30)=3) and the subadditive bound ω(mn) ≤ ω(m)+ω(n) for general products.",
+      "mathContext": "$\\omega$ is additive on coprimes and subadditive in general: $\\omega(mn)\\leq\\omega(m)+\\omega(n)$ — the arithmetic backbone for predecessor-structure arguments."
+    },
+    {
+      "id": "strong-prime-power-predecessor",
+      "title": "Barrier Predecessor Must Be Prime Power (Strong Form)",
+      "startLine": 1088,
+      "endLine": 1115,
+      "summary": "Strong form: at any barrier n ≥ 3, n-1 is necessarily a prime power p^k (k ≥ 1), since ω(n-1)=1 there.",
+      "mathContext": "At a barrier $n\\geq 3$, $\\omega(n-1)=1$ forces $n-1=p^k$ — a sharp structural constraint linking barriers to the distribution of prime powers."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Gallery section metadata for **erdos-413** (barriers for ω — *are there infinitely many n with m + ω(m) ≤ n for all m < n?*) had drifted from an older revision of `Erdos413Problem.lean`:

- A **119-line internal region (lines 856–973)** was completely hidden (orbit coalescence, squarefree barrier-equivalence, all-squarefree-below results).
- Several mid-file banners were uncovered or mislabeled (barrier density analysis, iterated dynamics, orbit/barrier interaction, computable Ω/expProd verification, ω-vs-Ω-vs-F comparison, consecutive-barrier & offset bounds, predecessor structure).
- The final sections were **out of order** with a 68-line tail gap; coverage stopped short of the 1115-line file.

Rebuilt the section list to follow the file's 41 `-- ##` banners as **24 contiguous sections spanning lines 1–1115**, grouping related banners and writing accurate titles/summaries/mathContext for the previously-hidden content.

## Verification

- `pnpm research:build` passes (exit 0); JSON valid.
- Sections are fully contiguous (1 → 1115, final endLine == lineCount).
- Declaration counts unchanged and already correct: **1 axiom, 109 theorems, 19 defs, 0 sorries, lineCount 1115**. Metadata-only change; no Lean source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)