### PR TITLE
Research: abel-ruffini-oq-06-galois-direction - S6 Step 5 corrected-signature soundness

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -121,10 +121,27 @@ theorem normalizer_iso_AGL1Z
     **Corrected signature** (to discharge in a future Docker-up session):
     thread the normal Sylow-p `P` and its `p`-cycle generator through, e.g.
     `(P : Sylow p H) (hPnorm : (P : Subgroup H).Normal)`
+    `(hσ_card : σ.support.card = p)`
     `(hgen : ∀ g : P, (H.subtype.comp (P : Subgroup H).subtype) g ∈`
     `  Subgroup.zpowers σ) (hσH : σ ∈ H) ⊢ H ≤ (Subgroup.zpowers σ).normalizer`,
     matching the outputs of Steps 2 (`sylow_p_normal`) and 3
-    (`sylow_p_is_pcycle`). See `knowledge.md` Risk R2. -/
+    (`sylow_p_is_pcycle`).
+
+    ⚠ **The `p`-cycle hypothesis `hσ_card : σ.support.card = p` is NOT
+    optional** (researcher-1, S6 OBSERVE 2026-06-14). `hgen` only states
+    `ι(P) ⊆ ⟨σ⟩` (where `ι = H.subtype.comp (P : Subgroup H).subtype`); the
+    normalizer argument needs the *equality* `ι(P) = ⟨σ⟩`. We have
+    `|ι(P)| = |P| = p` (faithful action; `|P| = p` because primitivity
+    forces `p ∣ |H|` while `p² ∤ p! ≥ |H|`), so `ι(P) = ⟨σ⟩` follows from
+    `ι(P) ⊆ ⟨σ⟩` **only when** `|⟨σ⟩| = ord σ = p`, i.e. `σ` is a `p`-cycle.
+    Drop `hσ_card` and the signature is still unsound: e.g. if `ord σ` were
+    composite, `ι(P)` (order `p`) could sit as a proper subgroup of `⟨σ⟩`
+    and `H`'s normalising `ι(P)` would not normalise the larger `⟨σ⟩`.
+    The S5 corrected-signature sketch (and `knowledge.md` Risk R2) omitted
+    this hypothesis. Discharge plan once threaded: from `hPnorm`, every
+    `h ∈ H` conjugates `ι(P)` to itself; rewrite `ι(P) = ⟨σ⟩` and close with
+    `Subgroup.le_normalizer`-style reasoning (~5–15 LOC). See `knowledge.md`
+    Risk R2. -/
 theorem H_le_normalizer
     (H : Subgroup (Equiv.Perm (ZMod p)))
     (_hPrim : MulAction.IsPreprimitive H (ZMod p))

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -77,6 +77,18 @@ Step-1 transitivity free); `MulAction.card_orbit_mul_card_stabilizer_eq_card_gro
   counterexample and corrected signature. No false proof was produced
   (Step 5 + the main theorem remain `sorry`), so this is a latent trap to
   fix before final assembly, not a soundness break in a closed proof.
+  **R2 refinement (researcher-1, S6 OBSERVE 2026-06-14): the corrected
+  signature above is itself still unsound — it must ALSO carry the
+  `p`-cycle hypothesis `(hσ_card : σ.support.card = p)`.** `hgen` gives only
+  `ι(P) ⊆ ⟨σ⟩`; the normaliser argument needs equality `ι(P) = ⟨σ⟩`. Since
+  `|ι(P)| = |P| = p` (faithful action; `|P| = p` as primitivity forces
+  `p ∣ |H|` and `p² ∤ p! ≥ |H|`), the inclusion upgrades to equality only
+  when `ord σ = |⟨σ⟩| = p`, i.e. `σ` is a `p`-cycle. Without `hσ_card`, a
+  `σ` of composite order could have `ι(P) ⊊ ⟨σ⟩`, and `H` normalising the
+  order-`p` `ι(P)` would not normalise the larger `⟨σ⟩`. The fully-sound
+  Step 5 therefore threads Step 3's COMPLETE output (`σ.IsCycle ∧
+  σ.support.card = p ∧ hgen`), not just `hgen`. The in-source `⚠` block was
+  updated to match.
 - **Risk R3** (medium): Build-pending qualifier extends across
   multiple sessions (matches the forward-direction's S3-S7 pattern).
   Plan for a final BUILD-VERIFY iteration.


### PR DESCRIPTION
## Summary
Research session for `abel-ruffini-galois-extensions-oq-06-galois-direction` (*every primitive solvable subgroup of S_p embeds into AGL(1,p)* — the Galois direction). The Lean scaffold has 5 sorries. The prior session (S5) found Step 5 `H_le_normalizer` **unsound** (`σ ∈ H` too weak) and proposed a corrected signature. This session (S6) is a **correctness refinement of that corrected signature**.

## Finding
S5's corrected signature threads the normal Sylow `P` and `hgen : ι(P) ⊆ ⟨σ⟩`. **It is itself still unsound**: `hgen` gives only the *inclusion* `ι(P) ⊆ ⟨σ⟩`, while the normaliser argument needs the *equality* `ι(P) = ⟨σ⟩`. Since `|ι(P)| = |P| = p` (faithful action; `|P| = p` because primitivity forces `p ∣ |H|` and `p² ∤ p! ≥ |H|`), the inclusion upgrades to equality **iff** `ord σ = |⟨σ⟩| = p`, i.e. `σ` is a `p`-cycle.

⇒ The fully-sound Step 5 must additionally carry `hσ_card : σ.support.card = p`, threading Step 3's **complete** output (`σ.IsCycle ∧ σ.support.card = p ∧ hgen`), not just `hgen`. Without it, a `σ` of composite order admits `ι(P) ⊊ ⟨σ⟩`, and `H` normalising the order-`p` `ι(P)` need not normalise the larger `⟨σ⟩`.

## Changes (all doc-only — build unaffected)
- `AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean`: updated the Step 5 `⚠` **docstring** with the `hσ_card` requirement + order-`p` argument. **Signatures and proof bodies are unchanged** (edit is entirely inside `/-- -/`), so the 5-sorry build state is untouched and no false proof exists.
- `knowledge.md` Risk R2, `state.md` (Iteration 6), JSON tracker (`phase`, insights, progressSummary).

## Status
**Outcome**: correctness refinement (no build). Docker is down (`docker info` times out) and Aristotle MCP is down (`prove()` → `Resource not found`), so no verification was possible — consistent with S5's doc-only approach.
**Next (Docker-up)**: discharge Step 1 (`sylow_p_unique`, the `|P| = p` order argument) and Step 3, then implement the sound `hσ_card`-threaded Step 5 with a `Subgroup.le_normalizer` closing argument.

🤖 Generated by researcher-1