### PR TITLE
Enrich erdos-1071: rebuild sections 9→12 + de-stale ℚ²/axiomatized-disjointness prose

### DIFF
--- a/src/data/proofs/erdos-1071/annotations.json
+++ b/src/data/proofs/erdos-1071/annotations.json
@@ -8,12 +8,12 @@
     },
     "type": "concept",
     "title": "Imports and Dependencies",
-    "content": "The formalization imports basic Mathlib modules for natural numbers, sets, finite sets, and rationals. Notably, it uses $\\mathbb{Q} \\times \\mathbb{Q}$ rather than $\\mathbb{R}^2$ for segment endpoints — this is an abstraction choice that avoids the complexities of real-number computation while preserving the combinatorial structure of the packing problem. The `Mathlib.Tactic` import provides the standard tactic library.",
-    "mathContext": "Working with $\\mathbb{Q} \\times \\mathbb{Q}$ as an abstraction of $\\mathbb{R}^2$, using `Set` and `Finset` for packing collections.",
+    "content": "The file does a single `import Mathlib`, opens the `Set` namespace, and works inside `namespace Erdos1071`. Segment endpoints live in $\\mathbb{R} \\times \\mathbb{R}$ (genuine real geometry), with `Set`, `Disjoint`, and `Real.sqrt` providing the packing and metric machinery, and `zorn_subset` (Zorn's lemma) used later for the existence proof.",
+    "mathContext": "Working over $\\mathbb{R} \\times \\mathbb{R}$ with `Set`/`Disjoint` for packing collections and `Real.sqrt` for Euclidean distance.",
     "significance": "supporting",
     "relatedConcepts": [
-      "rational approximation",
-      "combinatorial abstraction",
+      "Euclidean geometry",
+      "Zorn's lemma",
       "Mathlib foundations"
     ],
     "prerequisites": [
@@ -26,43 +26,42 @@
     "proofId": "erdos-1071",
     "type": "definition",
     "title": "Unit Segment Structure",
-    "content": "A unit segment is represented by its two endpoints in $\\mathbb{Q} \\times \\mathbb{Q}$, with a `unit_length` field abstracting the constraint that endpoints are at Euclidean distance 1. The field is typed as `True` — a deliberate simplification that focuses the formalization on the combinatorial packing structure rather than metric geometry. In a fully rigorous treatment, one would require $\\|x_1 - x_2\\| = 1$ using the Euclidean norm on $\\mathbb{R}^2$.",
-    "mathContext": "A unit segment $s = [p, q]$ with $p, q \\in \\mathbb{Q}^2$ and $\\|p - q\\|_2 = 1$ (abstracted). The segment is the convex hull $\\{(1-t)p + tq : 0 \\leq t \\leq 1\\}$.",
+    "content": "A unit segment is represented by its two endpoints in $\\mathbb{R} \\times \\mathbb{R}$, with a real proof field `unit_length : euclidDist x1 x2 = 1` — the metric constraint is genuinely enforced (not abstracted to `True`). `euclidDist` is the ordinary Euclidean distance $\\sqrt{(p_1-q_1)^2 + (p_2-q_2)^2}$, and `segmentSet p q` is the set of convex combinations $(1-t)p + tq$ for $t \\in [0,1]$.",
+    "mathContext": "A unit segment $s = [p, q]$ with $p, q \\in \\mathbb{R}^2$ and $\\|p - q\\|_2 = 1$ (proved as a structure field). The segment is the convex hull $\\{(1-t)p + tq : 0 \\leq t \\leq 1\\}$.",
     "significance": "key",
     "relatedConcepts": [
       "convex hull",
       "line segments",
-      "Euclidean distance",
-      "geometric abstraction"
+      "Euclidean distance"
     ],
     "prerequisites": [
       "structure types in Lean",
-      "rational numbers"
+      "Euclidean norm"
     ],
     "range": {
-      "startLine": 26,
-      "endLine": 31
+      "startLine": 30,
+      "endLine": 43
     }
   },
   {
     "id": "ann-1071-unit-square",
     "proofId": "erdos-1071",
     "range": {
-      "startLine": 33,
-      "endLine": 39
+      "startLine": 45,
+      "endLine": 51
     },
     "type": "definition",
     "title": "Unit Square and Segment Containment",
-    "content": "`InUnitSquare` checks that a point $(x, y)$ satisfies $0 \\leq x \\leq 1$ and $0 \\leq y \\leq 1$. `SegmentInSquare` requires both endpoints to lie in $[0,1]^2$. Note that this does not guarantee the entire segment lies within the square (a segment could have both endpoints in $[0,1]^2$ but pass through points outside it in general, though for unit segments in $[0,1]^2$ this is less of an issue since the segment length is 1 and the square has side length 1).",
-    "mathContext": "$\\text{InUnitSquare}(p) \\iff p \\in [0,1]^2 = \\{(x,y) : 0 \\leq x \\leq 1,\\; 0 \\leq y \\leq 1\\}$. $\\text{SegmentInSquare}(s) \\iff s.x_1, s.x_2 \\in [0,1]^2$.",
+    "content": "`InUnitSquare` checks that a point $(x, y)$ satisfies $0 \\leq x \\leq 1$ and $0 \\leq y \\leq 1$. `SegmentInSquare` requires both endpoints to lie in $[0,1]^2$. Because the square is convex, the endpoint check actually suffices: Part 4c proves `segment_in_square_all_points`, so every point of a segment whose endpoints are in $[0,1]^2$ also lies in $[0,1]^2$.",
+    "mathContext": "$\\text{InUnitSquare}(p) \\iff p \\in [0,1]^2 = \\{(x,y) : 0 \\leq x \\leq 1,\\; 0 \\leq y \\leq 1\\}$. $\\text{SegmentInSquare}(s) \\iff s.x_1, s.x_2 \\in [0,1]^2$ (and then the whole segment is in $[0,1]^2$ by convexity).",
     "significance": "supporting",
     "relatedConcepts": [
       "unit square",
-      "containment predicates",
-      "boundary conditions"
+      "convexity",
+      "containment predicates"
     ],
     "prerequisites": [
-      "rational inequalities",
+      "real inequalities",
       "product types"
     ]
   },
@@ -70,30 +69,30 @@
     "id": "ann-1071-disjointness",
     "proofId": "erdos-1071",
     "range": {
-      "startLine": 41,
-      "endLine": 45
+      "startLine": 59,
+      "endLine": 69
     },
     "type": "definition",
-    "title": "Interior-Disjointness Axiom",
-    "content": "The `AreDisjoint` predicate is axiomatized rather than defined — checking whether two line segments in $\\mathbb{R}^2$ have disjoint interiors requires computational geometry (segment intersection tests). The companion axiom `disjoint_symm` ensures the relation is symmetric, which is a basic geometric property: if $s$ doesn't intersect $t$, then $t$ doesn't intersect $s$. In a full formalization, this would be defined via the relative interiors of the segments: $\\text{relint}(s) \\cap \\text{relint}(t) = \\emptyset$.",
-    "mathContext": "$\\text{AreDisjoint}(s, t) \\iff \\text{relint}(s) \\cap \\text{relint}(t) = \\emptyset$, where $\\text{relint}([p,q]) = \\{(1-\\lambda)p + \\lambda q : 0 < \\lambda < 1\\}$. Axiomatized with symmetry: $\\text{AreDisjoint}(s,t) \\Rightarrow \\text{AreDisjoint}(t,s)$.",
+    "title": "Disjointness (Defined) and Endpoint-Disjointness",
+    "content": "`AreDisjoint s t` is *defined* (not axiomatized) as `Disjoint (segmentSet s.x1 s.x2) (segmentSet t.x1 t.x2)` — the two segments' point sets have empty intersection. Symmetry, `disjoint_symm`, is then *proved* in one line from `Disjoint.symm` (it was previously an axiom). The file also defines `EndpointDisjoint s t`, a strictly weaker relation allowing the segments to meet only at their four endpoints; `disjoint_implies_endpoint_disjoint` proves AreDisjoint ⇒ EndpointDisjoint.",
+    "mathContext": "$\\text{AreDisjoint}(s,t) \\iff \\text{segmentSet}(s) \\cap \\text{segmentSet}(t) = \\emptyset$. Proved symmetric. $\\text{EndpointDisjoint}(s,t)$: $\\text{segmentSet}(s) \\cap \\text{segmentSet}(t) \\subseteq \\{s.x_1, s.x_2\\} \\cup \\{t.x_1, t.x_2\\}$.",
     "significance": "key",
     "relatedConcepts": [
       "segment intersection",
-      "relative interior",
-      "computational geometry"
+      "Disjoint.symm",
+      "endpoint contact"
     ],
     "prerequisites": [
-      "convexity",
-      "axiomatization patterns"
+      "Set.Disjoint",
+      "convex combinations"
     ]
   },
   {
     "id": "ann-1071-packing",
     "proofId": "erdos-1071",
     "range": {
-      "startLine": 49,
-      "endLine": 52
+      "startLine": 75,
+      "endLine": 78
     },
     "type": "definition",
     "title": "Packing Definition",
@@ -129,16 +128,16 @@
       "SegmentInSquare"
     ],
     "range": {
-      "startLine": 54,
-      "endLine": 58
+      "startLine": 80,
+      "endLine": 84
     }
   },
   {
     "id": "ann-1071-finite-countable",
     "proofId": "erdos-1071",
     "range": {
-      "startLine": 60,
-      "endLine": 66
+      "startLine": 86,
+      "endLine": 92
     },
     "type": "definition",
     "title": "Finite and Countably Infinite Packings",
@@ -175,8 +174,8 @@
       "IsMaximalPacking"
     ],
     "range": {
-      "startLine": 70,
-      "endLine": 73
+      "startLine": 291,
+      "endLine": 296
     }
   },
   {
@@ -184,8 +183,8 @@
     "proofId": "erdos-1071",
     "type": "definition",
     "title": "Region Packings and Maximality in Arbitrary Regions",
-    "content": "To handle part (b), the formalization generalizes from $[0,1]^2$ to an arbitrary region $R \\subseteq \\mathbb{Q}^2$. `IsRegionPacking` requires both endpoints of every segment to lie in $R$ and pairwise disjointness. `IsMaximalRegionPacking` adds the blocking condition: every new segment with both endpoints in $R$ must intersect some existing segment. The key motivation is that $[0,1]^2$ can only hold finitely many disjoint unit segments, so a countably infinite packing requires a larger (potentially unbounded) region.",
-    "mathContext": "A region $R \\subseteq \\mathbb{Q}^2$; a packing $S$ in $R$ has $\\forall s \\in S,\\; s.x_1, s.x_2 \\in R$ and pairwise disjointness. Maximality: $\\forall s'$ with endpoints in $R$, $s' \\notin S \\Rightarrow \\exists t \\in S,\\; s' \\cap t \\neq \\emptyset$.",
+    "content": "To handle part (b), the formalization generalizes from $[0,1]^2$ to an arbitrary region `Region := Set (ℝ × ℝ)`. `IsRegionPacking` requires both endpoints of every segment to lie in $R$ and pairwise disjointness. `IsMaximalRegionPacking` adds the blocking condition: every new segment with both endpoints in $R$ must intersect some existing segment. The key motivation is that $[0,1]^2$ can only hold finitely many disjoint unit segments, so a countably infinite packing requires a larger (potentially unbounded) region.",
+    "mathContext": "A region $R \\subseteq \\mathbb{R}^2$; a packing $S$ in $R$ has $\\forall s \\in S,\\; s.x_1, s.x_2 \\in R$ and pairwise disjointness. Maximality: $\\forall s'$ with endpoints in $R$, $s' \\notin S \\Rightarrow \\exists t \\in S,\\; s' \\cap t \\neq \\emptyset$.",
     "significance": "key",
     "relatedConcepts": [
       "domain extension",
@@ -197,8 +196,8 @@
       "Region type"
     ],
     "range": {
-      "startLine": 77,
-      "endLine": 89
+      "startLine": 302,
+      "endLine": 314
     }
   },
   {
@@ -206,8 +205,8 @@
     "proofId": "erdos-1071",
     "type": "concept",
     "title": "Open Problem: Countably Infinite Maximal Packing (Part b)",
-    "content": "This axiom captures the open part of Erdős Problem 1071: does there exist a region $R$ and a countably infinite set $S$ of unit segments forming a maximal packing in $R$? The axiom asserts this positively, but the problem is **open** — it is not known whether such a configuration exists. The difficulty lies in simultaneously achieving: (1) infinitely many disjoint unit segments, (2) blocking every possible additional segment, and (3) the blocking being achieved by the existing segments alone (not by the region boundary). An unbounded region like a strip or half-plane might work, but the blocking condition is hard to verify.",
-    "mathContext": "$\\exists R \\subseteq \\mathbb{Q}^2,\\; \\exists S$ with $|S| = \\aleph_0$, $S$ a maximal packing in $R$. Status: **OPEN**.",
+    "content": "The open part of Erdős Problem 1071 is stated here as a comment (deliberately NOT an axiom — the file does not assert it): does there exist a region $R$ and a countably infinite set $S$ of unit segments forming a maximal packing in $R$? The difficulty lies in simultaneously achieving: (1) infinitely many disjoint unit segments, (2) blocking every possible additional segment, and (3) the blocking being achieved by the existing segments alone (not by the region boundary). Because $[0,1]^2$ admits only finitely many disjoint unit segments (area/compactness), any witness $R$ must be unbounded — a strip or half-plane might work, but neither direction is known.",
+    "mathContext": "Open question (a comment, not an axiom): $\\exists R \\subseteq \\mathbb{R}^2,\\; \\exists S$ with $|S| = \\aleph_0$, $S$ a maximal packing in $R$. Status: **OPEN**.",
     "significance": "key",
     "relatedConcepts": [
       "Erdős open problems",
@@ -220,31 +219,32 @@
       "Set.Infinite"
     ],
     "range": {
-      "startLine": 91,
-      "endLine": 95
+      "startLine": 316,
+      "endLine": 321
     }
   },
   {
-    "id": "endpoint-variant",
+    "id": "zorn-existence",
     "proofId": "erdos-1071",
-    "type": "concept",
-    "title": "Endpoint-Intersection Variant",
-    "content": "This variant relaxes the disjointness condition: segments may share endpoints but not cross in their interiors. `EndpointDisjoint` is axiomatized as a weaker condition than `AreDisjoint`. The question asks whether a finite maximal configuration exists under this relaxed rule. Allowing endpoint touching means more segments can coexist (e.g., segments radiating from a common point), potentially making it easier to block all placements — or harder, since new segments can also touch at endpoints. The interplay between these effects is subtle.",
-    "mathContext": "$\\text{EndpointDisjoint}(s, t)$ allows $s \\cap t \\subseteq \\{\\text{endpoints}\\}$. Question: $\\exists S$ finite, endpoint-disjoint, maximal in $[0,1]^2$?",
+    "type": "technique",
+    "title": "Existence of a Maximal Packing via Zorn's Lemma",
+    "content": "Part 5 proves — unconditionally, no axiom — that a maximal packing exists. `IsExtendable S` says some in-square unit segment can be inserted while staying disjoint, and `maximal_iff_not_extendable` proves maximality is exactly non-extendability. The crux is `packing_chain_union`: the union of a ⊆-chain of packings is again a packing (pairwise disjointness is checked by comparing the two members' source sets along the chain). With this chain-condition in hand, `exists_maximal_packing` applies `zorn_subset` to the set of all packings; the Zorn-maximal element `m` is then shown maximal by contradiction — if some segment were disjoint from all of `m`, `insert s m` would be a strictly larger packing, violating Zorn-maximality. This is the abstract counterpart to Danzer's axiom: existence is free, but Zorn gives no control over cardinality, which is why Danzer's *finite* construction is still needed.",
+    "mathContext": "`zorn_subset {S | IsPacking S}` with upper bound $\\bigcup \\text{chain}$ (a packing by `packing_chain_union`). Maximal element blocks every insertable segment ⇒ `IsMaximalPacking`.",
     "significance": "key",
     "relatedConcepts": [
-      "touching configurations",
-      "endpoint contact",
-      "relaxed disjointness",
-      "noncrossing partitions"
+      "Zorn's lemma",
+      "chain condition",
+      "maximal independent set",
+      "non-constructive existence"
     ],
     "prerequisites": [
-      "UnitSegment",
-      "SegmentInSquare"
+      "zorn_subset",
+      "IsChain",
+      "IsPacking"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 109
+      "startLine": 221,
+      "endLine": 286
     }
   }
 ]

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -39,30 +39,30 @@
         "module": "Mathlib.Data.Finset.Basic"
       },
       {
-        "theorem": "Rat.Basic",
-        "description": "Rational number type for coordinate abstraction",
-        "module": "Mathlib.Data.Rat.Basic"
+        "theorem": "Real.sqrt",
+        "description": "Square root for the Euclidean distance euclidDist on ℝ²",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRat"
+      },
+      {
+        "theorem": "zorn_subset",
+        "description": "Zorn's lemma over set inclusion, used to prove exists_maximal_packing",
+        "module": "Mathlib.Order.Zorn"
       }
     ],
     "originalContributions": [
-      "UnitSegment: structure with rational endpoints and unit_length",
-      "InUnitSquare: point in [0,1]² predicate",
-      "SegmentInSquare: both endpoints in unit square",
-      "AreDisjoint: axiomatized interior-disjointness with symmetry",
-      "IsPacking: all in square + pairwise disjoint",
-      "IsMaximalPacking: packing + blocking condition",
-      "IsFinitePacking: packing + finite",
-      "IsCountablyInfinitePacking: packing + countable + infinite",
-      "danzer_finite_maximal: axiom for Danzer's solution",
-      "IsRegionPacking: packing restricted to a region",
-      "IsMaximalRegionPacking: maximal packing in a region",
-      "ErdosProblem1071b: countably infinite maximal packing existence",
-      "ErdosProblem1071_endpoint_variant: endpoint-intersection variant",
-      "IsExtendable: packing extendability predicate",
-      "maximal_iff_not_extendable: maximality iff non-extendability",
-      "packing_chain_union: chain union is a packing (for Zorn)",
-      "exists_maximal_packing: existence via Zorn's lemma",
-      "danzer_finite_maximal_packing: axiom for Danzer's finite construction"
+      "euclidDist + UnitSegment: ℝ² Euclidean distance and a unit-segment structure with a real unit_length proof field",
+      "segmentSet: convex-combination point set of a segment; InUnitSquare / SegmentInSquare predicates",
+      "AreDisjoint: DEFINED interior-disjointness (Disjoint of point sets); disjoint_symm PROVED; EndpointDisjoint defined",
+      "IsPacking / IsMaximalPacking / IsFinitePacking / IsCountablyInfinitePacking: the packing hierarchy",
+      "Structural lemmas (proved): packing_empty, packing_subset, finite_packing_countable, disjoint_implies_endpoint_disjoint, segmentSet_nonempty, not_areDisjoint_self",
+      "Euclidean-distance lemmas (proved): euclidDist_symm/nonneg/self, UnitSegment.endpoints_ne",
+      "Convexity (proved): unitSquare_convex, segment_in_square_all_points, packing_segment_all_in_square",
+      "Concrete constructions (proved): horizontalMidSegment + in-square, packing_singleton, exists_nonempty_packing, maximal_packing_nonempty",
+      "IsExtendable + maximal_iff_not_extendable (proved): maximality iff non-extendability",
+      "packing_chain_union (proved): the union of a chain of packings is a packing",
+      "exists_maximal_packing (proved): existence of a maximal packing via Zorn's lemma (zorn_subset)",
+      "danzer_finite_maximal_packing: the single axiom — existence of a FINITE maximal packing (Danzer's $10-prize result)",
+      "Region / IsRegionPacking / IsMaximalRegionPacking: region-restricted packings for part (b), with the open question left as a comment"
     ],
     "relatedProblems": [
       {
@@ -80,12 +80,12 @@
     "historicalContext": "**Maximal Segment Packings: Danzer's Construction and Beyond**\n\nThis problem originates from the collaboration of Paul Erdős and Géza Tóth on extremal problems in combinatorial geometry. A **packing** of unit segments in a region is a collection of non-intersecting (interior-disjoint) unit line segments; it is **maximal** if no additional unit segment can be placed without intersecting an existing one — every possible placement is blocked.\n\n**Part (a) — Solved by Danzer**: Erdős asked whether a *finite* maximal packing exists in the unit square $[0,1]^2$. This is non-trivial because a unit segment can be oriented in any direction $\\theta \\in [0, \\pi)$ and positioned at any point, creating an uncountable family of potential placements that must all be blocked by finitely many segments. Ludwig Danzer (1921–2011), a German mathematician known for his work on discrete and convex geometry (including the Danzer set problem), constructed an explicit finite configuration achieving this. Erdős paid him \\$10 for the solution. Danzer's construction carefully places segments at multiple orientations to ensure that every possible unit segment in the square intersects at least one existing segment.\n\n**Part (b) — Open**: Does there exist *any* region $R \\subseteq \\mathbb{R}^2$ with a countably infinite maximal packing of disjoint unit segments? A key observation is that the unit square $[0,1]^2$ can contain at most finitely many disjoint unit segments (by a compactness argument: each segment has a positive-area 'exclusion zone', and $[0,1]^2$ has finite area). So the question necessarily requires working in a larger, potentially unbounded region. The difficulty is that in an unbounded region, one must block all possible orientations and positions with countably many segments — a much harder blocking condition than in the bounded case.\n\n**Endpoint variant**: A natural relaxation allows segments to touch at their endpoints (but not cross). Whether a finite maximal configuration exists under this weaker disjointness condition is also open.\n\nThe problem connects to several threads in combinatorial geometry: maximal independent sets in geometric intersection graphs, the theory of blocking sets, and the study of packing density and saturation.",
     "problemStatement": "Two questions: (a) Is there a finite maximal set of pairwise non-intersecting unit segments in $[0,1]^2$? (**Solved**: yes, by Danzer, \\$10 prize) (b) Is there a region $R$ with a countably infinite maximal set of disjoint unit segments? (**Open**)",
     "text": "Can finitely many non-intersecting unit segments in [0,1]² be maximal? Yes (Danzer). Can a countably infinite maximal packing exist in some region? Open.",
-    "proofStrategy": "**Formalization via Combinatorial Abstraction**\n\nThe formalization models the problem using rational-coordinate endpoints ($\\mathbb{Q} \\times \\mathbb{Q}$) rather than $\\mathbb{R}^2$, focusing on the combinatorial structure of packings. Key design decisions:\n\n1. **UnitSegment**: A structure with two $\\mathbb{Q}^2$ endpoints and an abstracted `unit_length : True` field (the metric constraint is not computationally verified).\n\n2. **Disjointness**: `AreDisjoint` is axiomatized rather than defined, since computing segment intersections in $\\mathbb{Q}^2$ is nontrivial. Symmetry (`disjoint_symm`) is provided as a companion axiom.\n\n3. **Packing hierarchy**: `IsPacking` $\\to$ `IsMaximalPacking` $\\to$ `IsFinitePacking` / `IsCountablyInfinitePacking`, building up from basic containment and disjointness to the blocking condition and cardinality constraints.\n\n4. **Danzer's result**: Axiomatized as an existential — $\\exists S$ that is both a finite packing and a maximal packing.\n\n5. **Region generalization**: For part (b), `Region` is defined as `Set (ℚ × ℚ)`, with `IsRegionPacking` and `IsMaximalRegionPacking` generalizing the unit-square definitions.\n\n6. **Endpoint variant**: A separate `EndpointDisjoint` axiom and the variant problem statement.",
+    "proofStrategy": "**Real-geometry formalization with one residual axiom**\n\nThe formalization models the problem over $\\mathbb{R}^2$ with genuine Euclidean geometry, axiomatizing only Danzer's deep finiteness result. Key design decisions:\n\n1. **UnitSegment**: A structure with two $\\mathbb{R}^2$ endpoints and a real proof field `unit_length : euclidDist x1 x2 = 1` (the metric constraint is genuinely enforced, not abstracted to `True`).\n\n2. **Disjointness (defined, not axiomatized)**: `AreDisjoint s t` is *defined* as `Disjoint (segmentSet ...) (segmentSet ...)` — empty intersection of the convex-combination point sets. Symmetry (`disjoint_symm`) is *proved* from `Disjoint.symm`; `EndpointDisjoint` is likewise a definition.\n\n3. **Packing hierarchy**: `IsPacking` $\\to$ `IsMaximalPacking` $\\to$ `IsFinitePacking` / `IsCountablyInfinitePacking`, with a substantial layer of proved structural lemmas (subset-closure, convexity of the square, an explicit `horizontalMidSegment` witness, non-emptiness of maximal packings).\n\n4. **Existence via Zorn (proved)**: `exists_maximal_packing` is *proved* by applying `zorn_subset` to the set of all packings, with `packing_chain_union` supplying the chain-union upper bound and `maximal_iff_not_extendable` characterizing maximality. So a maximal packing exists unconditionally.\n\n5. **Danzer's result (the only axiom)**: `danzer_finite_maximal_packing` axiomatizes the strictly stronger claim that a *finite* maximal packing exists — Danzer's \\$10-prize construction.\n\n6. **Region generalization**: For part (b), `Region := Set (ℝ × ℝ)`, with `IsRegionPacking` and `IsMaximalRegionPacking`; the open question itself is left as a comment rather than asserted as an axiom.",
     "keyInsights": [
       "**Maximality as a blocking condition**: A packing is maximal when every possible new unit segment intersects some existing one — a geometric analogue of a **maximal independent set** in the intersection graph of all possible unit segments. The 'graph' has uncountably many vertices, making the finite blocking condition remarkable.",
       "**Danzer's construction requires multi-angle blocking**: A finite set of parallel segments cannot be maximal (perpendicular segments would avoid all of them). Danzer's construction must use segments at sufficiently many orientations to block every angle $\\theta \\in [0, \\pi)$, while keeping the segments non-intersecting. This is a delicate balancing act between diversity of orientations and mutual avoidance.",
       "**Compactness forces finiteness in $[0,1]^2$**: Any packing of unit segments in $[0,1]^2$ is finite because each segment has a positive-radius exclusion zone (any nearby segment of any orientation must intersect it). By compactness of $[0,1]^2$, only finitely many such exclusion zones fit. This is why part (b) requires an unbounded region.",
-      "**Abstraction via rational coordinates**: Using $\\mathbb{Q} \\times \\mathbb{Q}$ instead of $\\mathbb{R}^2$ and axiomatizing the unit-length constraint is a pragmatic choice that avoids the computational complexity of real arithmetic while preserving the logical structure of the packing problem.",
+      "**Existence is cheap, finiteness is the hard part**: A maximal packing exists unconditionally — `exists_maximal_packing` proves it directly by Zorn's lemma over the inclusion order on packings, since the union of any chain of packings is again a packing. What Danzer's axiomatized result adds is that a maximal packing can be *finite*, which is the genuinely difficult geometric content (an uncountable family of orientations and positions blocked by finitely many segments).",
       "**The endpoint-touching variant changes the blocking game**: Allowing segments to share endpoints means fan-like configurations (segments radiating from one point) become valid, potentially enabling more efficient blocking. But new segments can also touch existing ones at endpoints, so the blocking condition is subtly different."
     ],
     "prerequisites": [
@@ -138,37 +138,61 @@
       "id": "structural-lemmas",
       "title": "Part 4: Structural Lemmas",
       "startLine": 94,
-      "endLine": 127,
+      "endLine": 137,
       "summary": "Proves foundational properties of segments and packings.",
-      "mathContext": "PROVED `left_endpoint_mem_segment` and `right_endpoint_mem_segment`: endpoints $p, q \\in \\text{segmentSet}(p,q)$ (at $t=0$ and $t=1$). PROVED `packing_empty`: $\\emptyset$ is a packing. PROVED `packing_subset`: subsets of packings are packings. PROVED `finite_packing_countable`: finite packings are countable (via `Set.Finite.countable`). PROVED `disjoint_implies_endpoint_disjoint`: strict disjointness implies endpoint-disjointness."
+      "mathContext": "PROVED `left_endpoint_mem_segment` / `right_endpoint_mem_segment`: endpoints $p, q \\in \\text{segmentSet}(p,q)$ (at $t=0$ and $t=1$). PROVED `packing_empty`, `packing_subset`, `finite_packing_countable` (via `Set.Finite.countable`), `disjoint_implies_endpoint_disjoint`, `segmentSet_nonempty`, and `not_areDisjoint_self`."
+    },
+    {
+      "id": "euclid-distance-properties",
+      "title": "Part 4b: Euclidean Distance Properties",
+      "startLine": 138,
+      "endLine": 157,
+      "summary": "Proves basic metric facts about euclidDist used to validate unit segments.",
+      "mathContext": "PROVED `euclidDist_symm`, `euclidDist_nonneg` (via `Real.sqrt_nonneg`), `euclidDist_self` $= 0$, and `UnitSegment.endpoints_ne`: a unit segment's endpoints are distinct (else `euclidDist = 0 \\neq 1`)."
+    },
+    {
+      "id": "unit-square-convexity",
+      "title": "Part 4c: Convexity of the Unit Square",
+      "startLine": 158,
+      "endLine": 178,
+      "summary": "Proves the unit square is convex, so whole segments (not just endpoints) stay inside.",
+      "mathContext": "PROVED `unitSquare_convex`: $(1-t)p + tq \\in [0,1]^2$ for $p,q \\in [0,1]^2$, $t \\in [0,1]$ (via `nlinarith`). PROVED `segment_in_square_all_points` and `packing_segment_all_in_square`."
+    },
+    {
+      "id": "concrete-constructions",
+      "title": "Part 4d: Concrete Constructions",
+      "startLine": 179,
+      "endLine": 220,
+      "summary": "Builds an explicit witness segment and proves non-emptiness facts about packings.",
+      "mathContext": "Defines `horizontalMidSegment` from $(0,\\tfrac12)$ to $(1,\\tfrac12)$ (unit length proved). PROVED `horizontalMidSegment_in_square`, `packing_singleton`, `exists_nonempty_packing`, and `maximal_packing_nonempty`: a maximal packing in $[0,1]^2$ is nonempty."
+    },
+    {
+      "id": "zorn-existence",
+      "title": "Part 5: Existence of Maximal Packings via Zorn's Lemma",
+      "startLine": 221,
+      "endLine": 286,
+      "summary": "Proves — not axiomatizes — that a maximal packing exists, via Zorn's lemma.",
+      "mathContext": "Defines `IsExtendable`. PROVED `maximal_iff_not_extendable`, `packing_chain_union` (the union of a chain of packings is a packing), and `exists_maximal_packing`: applies `zorn_subset` to $\\{S : \\text{IsPacking}\\,S\\}$ with the chain-union upper bound, then shows the Zorn-maximal element blocks every insertable segment. A genuine machine-checked existence result."
     },
     {
       "id": "danzer",
-      "title": "Part 5: Danzer's Result (SOLVED)",
-      "startLine": 128,
-      "endLine": 135,
-      "summary": "Axiomatizes the solved part (a): existence of a finite maximal packing.",
-      "mathContext": "Axiom `danzer_finite_maximal`: $\\exists S$, `IsFinitePacking(S)` $\\wedge$ `IsMaximalPacking(S)`. Ludwig Danzer constructed an explicit finite configuration of unit segments at multiple orientations that blocks every possible placement in $[0,1]^2$, earning Erdős's \\$10 prize."
+      "title": "Part 6: Danzer's Result (Solved, $10 Prize)",
+      "startLine": 287,
+      "endLine": 297,
+      "summary": "Axiomatizes the solved part (a): existence of a FINITE maximal packing (the only axiom in the file).",
+      "mathContext": "Axiom `danzer_finite_maximal_packing`: $\\exists S$, `IsMaximalPacking(S)` $\\wedge$ $S$ finite. Ludwig Danzer constructed an explicit finite configuration of unit segments at multiple orientations that blocks every possible placement in $[0,1]^2$, earning Erdős's \\$10 prize. Part 5 already gives a maximal packing unconditionally; Danzer's contribution is that one can be finite."
     },
     {
       "id": "open-problem",
-      "title": "Part 6: The Open Problem",
-      "startLine": 137,
-      "endLine": 159,
-      "summary": "Generalizes to region packings and states the open problem on countably infinite maximal packings.",
-      "mathContext": "Defines `Region := \\text{Set}(\\mathbb{R}^2)$. `IsRegionPacking(R, S)`: endpoints in $R$ and pairwise disjoint. `IsMaximalRegionPacking(R, S)`: region packing $+$ blocking in $R$. Axiom `ErdosProblem1071b`: $\\exists R, S$ with $S$ countable, infinite, and maximal in $R$. Key insight: $[0,1]^2$ forces finite packings by compactness, so part (b) requires an unbounded region."
-    },
-    {
-      "id": "endpoint-variant",
-      "title": "Part 7: Endpoint-Intersection Variant",
-      "startLine": 161,
-      "endLine": 174,
-      "summary": "States the open variant allowing segments to touch at endpoints.",
-      "mathContext": "Axiom `ErdosProblem1071_endpoint_variant`: $\\exists S$ finite with all segments in $[0,1]^2$, pairwise `EndpointDisjoint`, and maximal under this weaker condition. Fan-like configurations (segments radiating from one point) become valid, potentially enabling more efficient blocking."
+      "title": "Part 7: The Open Problem — Countably Infinite Maximal Packing",
+      "startLine": 298,
+      "endLine": 323,
+      "summary": "Generalizes to region packings and states the open part (b) as a comment, not an axiom.",
+      "mathContext": "Defines `Region := \\text{Set}(\\mathbb{R} \\times \\mathbb{R})`, `IsRegionPacking(R, S)` (endpoints in $R$, pairwise disjoint), and `IsMaximalRegionPacking(R, S)`. The open problem is stated as a comment, not an axiom: is there a region $R$ with a countably infinite maximal packing? Since $[0,1]^2$ forces finite packings by area/compactness, any witness $R$ must be unbounded; neither direction is known."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 1071 explores maximal packings of unit segments — configurations where no additional segment can be placed without intersection. Part (a) was resolved by Ludwig Danzer, who constructed a finite maximal packing in $[0,1]^2$ (earning \\$10 from Erdős). Part (b) remains open: whether any region admits a countably infinite maximal packing. The formalization captures the full problem structure using rational-coordinate abstractions, axiomatized disjointness, and a clean hierarchy from basic packings through maximality to the open problems. 0 sorries.",
+    "summary": "Erdős Problem 1071 explores maximal packings of unit segments — configurations where no additional segment can be placed without intersection. Part (a) was resolved by Ludwig Danzer, who constructed a finite maximal packing in $[0,1]^2$ (earning \\$10 from Erdős). Part (b) remains open: whether any region admits a countably infinite maximal packing. The formalization captures the full problem structure over ℝ² with genuine Euclidean geometry: disjointness is defined (not axiomatized), the existence of a maximal packing is proved via Zorn's lemma, and a clean hierarchy runs from basic packings through maximality to the open problem. The sole axiom is Danzer's finite-maximal-packing result. 0 sorries.",
     "implications": "1. **Geometric maximal independent sets**: The problem connects packing theory to graph theory — a maximal packing is a maximal independent set in the (uncountable) intersection graph of unit segments. Understanding when finite vs. infinite maximal independent sets exist in geometric intersection graphs is a fundamental question.\n\n**2. Blocking and covering duality**: A maximal packing simultaneously serves as a 'blocking set' for all possible unit-segment placements. This duality between packing (non-overlapping) and blocking (covering all placements) is a recurring theme in combinatorial geometry.\n\n3. **Compactness and cardinality**: The proof that $[0,1]^2$ forces finite packings illustrates how compactness constrains combinatorial structure. The open question about infinite packings in unbounded regions probes the limits of this compactness phenomenon.\n\n4. **Orientation diversity**: Danzer's construction highlights the importance of angular diversity in blocking — a theme that also appears in problems about piercing sets, transversals, and geometric set cover.",
     "openQuestions": [
       "Is there a region $R \\subseteq \\mathbb{R}^2$ with a countably infinite maximal packing of unit segments? (Part b — the main open question)",
@@ -295,14 +319,12 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Set.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Rat.Basic",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
-    "opens": [],
-    "namespace": null,
+    "opens": [
+      "Set"
+    ],
+    "namespace": "Erdos1071",
     "lineCount": 323,
     "axiomCount": 1,
     "theoremCount": 23,


### PR DESCRIPTION
## Summary
`Erdos1071Problem.lean` was rewritten from an early ℚ²/axiomatized-disjointness draft into genuine ℝ² Euclidean geometry, but the gallery entry still described the old draft and covered only lines 1–174 of the now 323-line file.

What actually changed in the source (and was NOT reflected in the meta):
- Endpoints are `ℝ × ℝ` with a real `unit_length : euclidDist x1 x2 = 1` proof field (was ℚ² with `unit_length : True`).
- `AreDisjoint` is **defined** (`Disjoint` of the segment point sets); `disjoint_symm` is **proved** (both were axioms).
- A 65-line **Zorn's-lemma proof** `exists_maximal_packing` (Part 5) was added — entirely hidden by the old sections.
- The phantom axioms `ErdosProblem1071b` and `ErdosProblem1071_endpoint_variant` referenced throughout the meta **do not exist** in the file.

Fixes:
- **Sections 9 → 12**, realigned to the file's `# Part 1–7` (+ `4b/4c/4d`) banners covering 1–323. The old back-half sections were badly mislabeled — "Part 5: Danzer" pointed at lines 128–135 (structural lemmas) while the real Danzer axiom is at 287–296. Restored the hidden Part 5 (Zorn), Parts 4b/4c/4d.
- **De-staled** `proofStrategy`, `originalContributions`, `keyInsights`, `conclusion`: ℚ²→ℝ², "axiomatized disjointness"→defined+proved, removed the two phantom axioms, added the proved Zorn existence + structural/convexity/construction lemmas, and clarified the single remaining axiom is `danzer_finite_maximal_packing`.
- Fixed `leanFile` (`imports: [Mathlib]`, `opens: [Set]`, `namespace: Erdos1071`) and the stale `Rat.Basic` dependency (→ `Real.sqrt` + `zorn_subset`).
- **Annotations**: realigned all ranges (off by up to ~200 lines), rewrote the disjointness/imports/unit-segment/region/open-problem notes from ℚ²/axiom to ℝ²/defined, and repurposed the phantom endpoint-variant annotation into one for the Zorn existence proof.

Counts (23 thm / 16 def / 1 axiom / 0 sorry / 323 LC) were already correct.

## Test plan
- [x] `pnpm research:build` exits 0
- [x] `meta.json` and `annotations.json` parse as valid JSON
- [x] Sections cover the full file 1–323; each Part banner matched to source
- [x] No remaining ℚ-coordinate / phantom-axiom / `: True` prose
- [x] No open PR touches `src/data/proofs/erdos-1071/`