### PR TITLE
research(erdos-1126-oq-01): realign drifted gallery sections (7→8) + fix axiom/line counts

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,10 +64,10 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 7,
-    "lineCount": 472,
-    "assumptions": "7 axioms: volume_preimage_double_null (measure-theoretic helper), ae_double_of_almost_jensen (Fubini section extraction), almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries.",
-    "theoremCount": 15,
+    "axiomCount": 6,
+    "lineCount": 489,
+    "assumptions": "6 axioms: ae_double_of_almost_jensen (Fubini section extraction), almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. The measure-theoretic helper volume_preimage_double_null is now fully proved (no longer an axiom). 0 sorries.",
+    "theoremCount": 16,
     "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos1126OQ01Aristotle.lean"
@@ -77,7 +77,7 @@
     "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
     "problemStatement": "**Open Question (from Erdős Problem #1126)**\n\nCan the de Bruijn-Jurkat theorem be extended to other functional equations, such as:\n- $f(xy) = f(x)f(y)$ (multiplicative/Cauchy exponential)\n- $f((x+y)/2) = (f(x)+f(y))/2$ (Jensen's equation)\n- $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ (Leibniz/derivation rule)\n\nThe answer is **YES** for all three, making a.e. stability a universal phenomenon for algebraic functional equations.",
     "text": "Extends the de Bruijn-Jurkat stability theorem to multiplicative, Jensen, and derivation functional equations. Jensen's equation is proved equivalent to additivity modulo constants. The multiplicative case reduces via logarithms. Derivation stability follows from Ger's 1979 work.",
-    "proofStrategy": "**Formalization Strategy**\n\nThe 388-line Lean file covers three extensions:\n\n1. **Jensen ↔ Additive** (Parts I-II): The central proved result. `jensen_implies_shifted_additive` shows that if $f$ satisfies Jensen's equation, then $g(x) = f(x) - f(0)$ is additive. The converse `additive_plus_const_is_jensen` shows additive + constant satisfies Jensen. Combined in `jensen_iff_additive_shifted`.\n\n2. **Multiplicative Functions** (Part III): Defines `IsMultiplicative` and proves basic properties: $f(1) = 1$ (when $f$ is nonzero), $f(x^2) = f(x)^2$, and the logarithmic reduction to additivity.\n\n3. **Derivation Equation** (Part V): Defines `IsDerivation` and proves the key structural theorems: $d(1) = 0$, $d(x^2) = 2x \\cdot d(x)$, and the power rule $d(x^n) = n x^{n-1} d(x)$ by induction — showing derivations generalize differentiation.\n\n4. **Stability Axioms** (Part IV): The deep extension theorems are axiomatized: almost multiplicative → multiplicative, almost Jensen → Jensen, almost derivation → derivation.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe 489-line Lean file covers three extensions:\n\n1. **Jensen ↔ Additive** (Parts I-II): The central proved result. `jensen_implies_shifted_additive` shows that if $f$ satisfies Jensen's equation, then $g(x) = f(x) - f(0)$ is additive. The converse `additive_plus_const_is_jensen` shows additive + constant satisfies Jensen. Combined in `jensen_iff_additive_shifted`.\n\n2. **Multiplicative Functions** (Part III): Defines `IsMultiplicative` and proves basic properties: $f(1) = 1$ (when $f$ is nonzero), $f(x^2) = f(x)^2$, and the logarithmic reduction to additivity.\n\n3. **Derivation Equation** (Part V): Defines `IsDerivation` and proves the key structural theorems: $d(1) = 0$, $d(x^2) = 2x \\cdot d(x)$, and the power rule $d(x^n) = n x^{n-1} d(x)$ by induction — showing derivations generalize differentiation.\n\n4. **Stability Axioms** (Part IV): The deep extension theorems are axiomatized: almost multiplicative → multiplicative, almost Jensen → Jensen, almost derivation → derivation.",
     "keyInsights": [
       "**Jensen = Additive + Constant:** Jensen's equation $f((x+y)/2) = (f(x)+f(y))/2$ is exactly equivalent to saying $f(x) - f(0)$ is additive. This is proved constructively in Lean.",
       "**Logarithmic Reduction:** For positive multiplicative functions, $\\log \\circ f \\circ \\exp$ is additive. This reduces multiplicative stability to additive stability (de Bruijn-Jurkat).",
@@ -95,58 +95,66 @@
     {
       "id": "parent-defs",
       "title": "Definitions from Parent Problem",
-      "startLine": 31,
-      "endLine": 58,
+      "startLine": 43,
+      "endLine": 65,
       "summary": "Redefines `IsAdditive`, `ae_holds`, `ae_pairs`, `ae_eq`, and `IsAlmostAdditive` from the parent Erdős #1126 formalization for self-containment.",
       "mathContext": "$f(x+y) = f(x) + f(y)$ (Cauchy); $P$ holds a.e. means $P$ fails only on a Lebesgue null set."
     },
     {
       "id": "jensen",
-      "title": "Jensen's Functional Equation",
-      "startLine": 60,
-      "endLine": 130,
-      "summary": "Defines `IsJensen` and proves the key equivalence: Jensen ↔ additive modulo constant. Three theorems: `jensen_implies_shifted_additive` (forward), `additive_plus_const_is_jensen` (backward), `jensen_iff_additive_shifted` (iff).",
+      "title": "Part I: Jensen's Functional Equation",
+      "startLine": 66,
+      "endLine": 179,
+      "summary": "Defines `IsJensen` and `IsAlmostJensen` and proves the key equivalence: Jensen ↔ additive modulo constant. Theorems `jensen_implies_shifted_additive` (forward), `additive_plus_const_is_jensen` (backward), and `jensen_iff_additive_shifted` (iff).",
       "mathContext": "$f\\bigl(\\tfrac{x+y}{2}\\bigr) = \\tfrac{f(x)+f(y)}{2} \\iff f - f(0)$ is additive. Proved via the doubling formula $f(2z) = 2f(z) - f(0)$."
     },
     {
       "id": "almost-jensen",
-      "title": "Almost Jensen → Almost Additive",
-      "startLine": 170,
-      "endLine": 190,
-      "summary": "States that almost Jensen reduces to almost additive for the shifted function. This reduces Jensen stability to de Bruijn-Jurkat.",
-      "mathContext": "Almost Jensen for $f$ $\\Rightarrow$ almost additive for $g(x) = f(x) - f(0)$. Contains one of the two remaining sorries."
+      "title": "Part II: Almost Jensen → Almost Additive Reduction",
+      "startLine": 180,
+      "endLine": 281,
+      "summary": "Proves `almost_jensen_implies_almost_additive_shifted`: if $f$ is almost Jensen then $g(x) = f(x) - f(0)$ is almost additive, reducing Jensen stability to de Bruijn-Jurkat. The null-set helpers `volume_preimage_double_null`, `volume_preimage_fst_null`, `volume_preimage_snd_null` are now fully proved from Mathlib's quasi-measure-preserving API; only the Fubini section-extraction step `ae_double_of_almost_jensen` remains an axiom. 0 sorries.",
+      "mathContext": "Almost Jensen for $f$ $\\Rightarrow$ almost additive for $g(x) = f(x) - f(0)$. Proof unions three null sets: Jensen at $(2x,2y)$ plus two projection preimages of the doubling null set."
     },
     {
       "id": "multiplicative",
-      "title": "Multiplicative Functional Equation",
-      "startLine": 192,
-      "endLine": 250,
-      "summary": "Defines `IsMultiplicative` and `IsAlmostMultiplicative`. Proves `mul_func_one` ($f(1) = 1$), `mul_func_sq` ($f(x^2) = f(x)^2$), and states the logarithmic reduction to additivity.",
+      "title": "Part III: Multiplicative Functional Equation",
+      "startLine": 282,
+      "endLine": 346,
+      "summary": "Defines `IsMultiplicative` and `IsAlmostMultiplicative`. Proves `mul_func_one` ($f(1) = 1$), `mul_func_sq` ($f(x^2) = f(x)^2$), positivity on squares, and the logarithmic reduction to additivity for positive multiplicative functions.",
       "mathContext": "$f(xy) = f(x)f(y)$ on $\\mathbb{R} \\setminus \\{0\\}$. Key reduction: $\\log \\circ f \\circ \\exp$ is additive for positive $f$."
     },
     {
       "id": "stability",
-      "title": "Extension Theorems (Axiomatized)",
-      "startLine": 252,
-      "endLine": 280,
-      "summary": "Three stability axioms: `almost_multiplicative_stability`, `almost_jensen_stability`, `almost_derivation_stability` — the deep extension theorems.",
-      "mathContext": "Almost $E$ $\\Rightarrow$ $\\exists$ exact $E$-solution agreeing a.e., for $E \\in \\{$multiplicative, Jensen, derivation$\\}$."
+      "title": "Part IV: Extension Theorems (Axiomatized)",
+      "startLine": 347,
+      "endLine": 374,
+      "summary": "Two stability axioms: `almost_multiplicative_stability` (almost multiplicative → exact multiplicative a.e., via log/exp conjugation) and `almost_jensen_stability` (almost Jensen → exact Jensen a.e., via the Part II reduction to de Bruijn-Jurkat).",
+      "mathContext": "Almost $E$ $\\Rightarrow$ $\\exists$ exact $E$-solution agreeing a.e., for $E \\in \\{$multiplicative, Jensen$\\}$."
     },
     {
       "id": "derivation",
-      "title": "Derivation Equation",
-      "startLine": 282,
-      "endLine": 350,
-      "summary": "Defines `IsDerivation` and proves structural theorems: `derivation_at_one` ($d(1) = 0$), `derivation_sq` ($d(x^2) = 2x d(x)$), `derivation_pow` (power rule by induction). Also axiomatizes that continuous derivations are zero and almost-derivation stability.",
-      "mathContext": "$d(xy) = xd(y) + yd(x)$. Power rule: $d(x^n) = nx^{n-1}d(x)$ by induction. Continuous $\\Rightarrow$ $d = 0$."
+      "title": "Part V: Derivation Equation",
+      "startLine": 375,
+      "endLine": 439,
+      "summary": "Defines `IsDerivation` and `IsAlmostDerivation` and proves structural theorems: `derivation_at_one` ($d(1) = 0$), `derivation_sq` ($d(x^2) = 2x\\,d(x)$), and `derivation_pow` (power rule $d(x^n) = n x^{n-1} d(x)$ by induction). The stability statement `almost_derivation_stability` (Ger 1979) is axiomatized.",
+      "mathContext": "$d(xy) = x\\,d(y) + y\\,d(x)$. Power rule: $d(x^n) = nx^{n-1}d(x)$ by induction — derivations generalize differentiation."
+    },
+    {
+      "id": "general-pattern",
+      "title": "Part VI: The General Pattern",
+      "startLine": 440,
+      "endLine": 464,
+      "summary": "States the unifying stability paradigm across additive, Jensen, multiplicative, and derivation equations, and proves `stability_paradigm_summary` combining the Jensen and derivation stability results into a single statement.",
+      "mathContext": "All four equations define algebraic homomorphisms; a.e. homomorphisms can be repaired to exact ones — generalizing to locally compact groups (Járai 2005)."
     },
     {
       "id": "regularity",
-      "title": "Regularity Theorems",
-      "startLine": 360,
-      "endLine": 388,
-      "summary": "Axiomatizes regularity results: `measurable_multiplicative_is_power` (measurable multiplicative → power function) and `measurable_derivation_is_zero` (measurable derivation → zero).",
-      "mathContext": "Measurable $f(xy) = f(x)f(y)$ with $f > 0$: $f(x) = x^c$. Measurable derivation: $d = 0$. Tame vs. wild dichotomy."
+      "title": "Part VII: Regularity Theorems",
+      "startLine": 465,
+      "endLine": 489,
+      "summary": "Axiomatizes the regularity results `measurable_multiplicative_is_power` (measurable multiplicative → power function) and `measurable_derivation_is_zero` (measurable derivation → zero), then proves `continuous_derivation_is_zero` as a corollary since continuous functions are measurable.",
+      "mathContext": "Measurable $f(xy) = f(x)f(y)$ with $f > 0$: $f(x) = x^c$. Measurable (hence continuous) derivation: $d = 0$. Tame vs. wild dichotomy."
     }
   ],
   "crossReferences": [
@@ -188,11 +196,11 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos1126OQ01Problem.lean",
-    "lineCount": 472,
-    "axiomCount": 7,
+    "lineCount": 489,
+    "axiomCount": 6,
     "sorries": 0,
     "definitionCount": 11,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "additionalFiles": [
       "Proofs/Erdos1126OQ01Aristotle.lean"
     ]


### PR DESCRIPTION
## Summary
Gallery `sections` for **erdos-1126-oq-01** ("Extending de Bruijn-Jurkat to Other Functional Equations") had drifted to an older revision of `Proofs/Erdos1126OQ01Problem.lean`. All line ranges were off, **Part VI ("The General Pattern") was missing entirely**, and the tail (Part VII regularity, lines 465-489) was uncovered. Rebuilt all 8 sections from the file's `## Part N` banners (7 → 8).

Also corrected metadata that lagged the source:
- **axiomCount 7 → 6** — `volume_preimage_double_null` is now a fully proved `private lemma` (PR #22339 eliminated the axiom but the meta count was never updated). 6 genuine `axiom` declarations remain; no structure-encoded assumptions.
- **lineCount 472 → 489**, **theoremCount 15 → 16**
- `assumptions` field updated to list 6 axioms (dropped `volume_preimage_double_null`)
- Removed stale prose: "388-line file" → 489, and the almost-jensen section's "Contains one of the two remaining sorries" (file is 0-sorry)
- Fixed Part IV summary (lists 2 axioms, not 3 — derivation stability lives in Part V) and Part VII (clarifies `continuous_derivation_is_zero` is proved, not axiomatized)

Counts verified: 6 axioms, 0 sorries, 16 theorems/lemmas, 11 defs, 489 lines.

## Test plan
- [x] `JSON.parse` of meta.json succeeds
- [x] Section line ranges match `## Part N` banners and are contiguous over the file
- [x] Axiom count cross-checked against `grep '^.*axiom '` (6) and structure scan (none)
- [ ] Gallery `pnpm build` (meta-only change; no Lean rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)