### PR TITLE
research(erdos-218): realign drifted gallery sections (11→12), fix theoremCount 28→30 + stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -59,92 +59,100 @@
   },
   "sections": [
     {
-      "id": "prime-enum",
-      "title": "Part 1: Prime Enumeration and Gaps",
-      "startLine": 43,
-      "endLine": 68,
-      "summary": "nthPrime via Nat.nth, nthPrime_prime, nthPrime_strictMono, specific values.",
-      "mathContext": "$p_n$ = $n$-th prime. $p_1 = 2, p_2 = 3, p_3 = 5, \\\\ldots$ Strictly increasing."
+      "id": "header",
+      "title": "Header: Statement and References",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "States Erdős Problem #218 (prime gap densities). With $d_n=p_{n+1}-p_n$, Erdős conjectured: (a) $\\{n:d_{n+1}\\geq d_n\\}$ has density $1/2$; (b) $\\{n:d_{n+1}\\leq d_n\\}$ has density $1/2$; (c) infinitely many $n$ with $d_{n+1}=d_n$ (equivalent to infinitely many 3-term APs of consecutive primes). Status OPEN (Tao: 'looks difficult'). Notes the Green–Tao connection. Imports `Nat.Prime.Nth`, liminf/limsup topology, reals.",
+      "mathContext": "$d_n=p_{n+1}-p_n$. Conjectures: density$(\\{d_{n+1}\\geq d_n\\})=$density$(\\{d_{n+1}\\leq d_n\\})=1/2$; $\\{d_{n+1}=d_n\\}$ infinite."
+    },
+    {
+      "id": "prime-enumeration",
+      "title": "Part I: Prime Enumeration and Gaps",
+      "startLine": 44,
+      "endLine": 93,
+      "summary": "Defines `nthPrime n = Nat.nth Nat.Prime n` and PROVES `nthPrime_prime`, `nthPrime_strictMono`, and the small values `nthPrime_zero/_one/_two` ($2,3,5$) — all derived from Mathlib's `Nat.nth` API (previously axiomatized). Private helpers `nthPrime_three`/`nthPrime_four` ($7,11$) via `Nat.count`/`decide`.",
+      "mathContext": "$p_0=2,p_1=3,p_2=5,p_3=7,p_4=11$; `nthPrime` strictly monotone and prime-valued (proved from `Nat.nth`)."
     },
     {
       "id": "prime-gaps",
-      "title": "Part 2: Prime Gaps",
-      "startLine": 69,
-      "endLine": 101,
-      "summary": "primeGap definition, primeGap_pos (proved), specific gap values.",
-      "mathContext": "$d_n = p_{n+1} - p_n$: consecutive prime gap. $d_1 = 1, d_2 = 2, d_3 = 2, d_4 = 4, \\\\ldots$"
+      "title": "Part II: Prime Gaps",
+      "startLine": 94,
+      "endLine": 134,
+      "summary": "Defines `primeGap n = nthPrime (n+1) - nthPrime n` and PROVES `primeGap_pos` ($d_n>0$ from strict monotonicity) and the small gaps `primeGap_zero/_one/_two/_three` ($1,2,2,4$) from the `nthPrime` values (previously axiomatized).",
+      "mathContext": "$d_0=1,d_1=2,d_2=2,d_3=4$; $d_n>0$ for all $n$."
     },
     {
-      "id": "density",
-      "title": "Part 3: Natural Density",
-      "startLine": 102,
-      "endLine": 127,
-      "summary": "HasDensity, upperDensity, lowerDensity definitions.",
-      "mathContext": "Natural density: $\\\\delta(S) = \\\\lim |S \\\\cap [1,N]|/N$. Upper density: $\\\\bar{\\\\delta}$, lower density: $\\\\underline{\\\\delta}$."
+      "id": "natural-density",
+      "title": "Part III: Natural Density",
+      "startLine": 135,
+      "endLine": 191,
+      "summary": "Defines `HasDensity S d` (the limit of $|S\\cap[0,N)|/N$ equals $d$), `upperDensity` (`limsup`) and `lowerDensity` (`liminf`), using `Classical.decPred` for arbitrary $S$. PROVES `hasDensity_iff_upper_lower`: $S$ has density $d$ iff upper and lower densities both equal $d$, via `tendsto_of_le_liminf_of_limsup_le` and the bounds $0\\leq\\text{count}/N\\leq1$.",
+      "mathContext": "$\\text{HasDensity}(S,d)\\Leftrightarrow\\overline{d}(S)=\\underline{d}(S)=d$, with $\\text{count}/N\\in[0,1]$."
     },
     {
-      "id": "key-sets",
-      "title": "Part 4: The Sets of Interest",
-      "startLine": 128,
-      "endLine": 172,
-      "summary": "gapIncreasingSet, gapDecreasingSet, gapEqualSet, gapEqualSet_eq_inter (proved).",
-      "mathContext": "$I = \\\\{n : d_{n+1} > d_n\\\\}$ (increasing gaps), $D = \\\\{n : d_{n+1} < d_n\\\\}$ (decreasing), $E = \\\\{n : d_{n+1} = d_n\\\\}$ (equal). These partition $\\\\mathbb{N}$."
+      "id": "sets-of-interest",
+      "title": "Part IV: The Sets of Interest",
+      "startLine": 192,
+      "endLine": 243,
+      "summary": "Defines `gapIncreasingSet` ($d_n\\leq d_{n+1}$), `gapDecreasingSet` ($d_{n+1}\\leq d_n$), `gapEqualSet` ($d_n=d_{n+1}$). PROVES `zero_mem_gapIncreasingSet`, `one_mem_gapEqualSet` (gaps at $n=1$ both $2$), and `gapEqualSet_eq_inter` (equal set = increasing $\\cap$ decreasing).",
+      "mathContext": "$\\text{gapEqual}=\\text{gapIncreasing}\\cap\\text{gapDecreasing}$; $0\\in$ increasing, $1\\in$ equal."
     },
     {
       "id": "conjectures",
-      "title": "Part 5: The Conjectures (OPEN)",
-      "startLine": 173,
-      "endLine": 203,
-      "summary": "erdos_218a, erdos_218b, erdos_218c axioms (all OPEN).",
-      "mathContext": "Three OPEN conjectures: (a) $\\\\delta(I) = \\\\delta(D) = 1/2$, $\\\\delta(E) = 0$; (b) $|I|, |D|$ infinite; (c) $E$ infinite."
+      "title": "Part V: The Conjectures (OPEN)",
+      "startLine": 244,
+      "endLine": 273,
+      "summary": "States the two density conjectures as AXIOMS: `erdos_218a` (gapIncreasingSet has density $1/2$) and `erdos_218b` (gapDecreasingSet has density $1/2$). A docstring records conjecture 218c (infinitely many equal gaps), equivalent to infinitely many 3-term APs of consecutive primes. All OPEN.",
+      "mathContext": "Axioms: density$(\\text{gapIncreasing})=$density$(\\text{gapDecreasing})=1/2$. 218c: $\\text{gapEqual}$ infinite."
     },
     {
       "id": "ap-connection",
-      "title": "Part 6: Connection to Arithmetic Progressions",
-      "startLine": 204,
-      "endLine": 225,
-      "summary": "threePrimesInAP, gapEqual_iff_ap axiom, infinitely_many_3ap_from_218c (proved).",
-      "mathContext": "Three primes in AP: $p, p+d, p+2d$ iff $d_n = d_{n+1}$. So $E$ infinite $\\\\iff$ infinitely many 3-term prime APs."
+      "title": "Part VI: Connection to Arithmetic Progressions",
+      "startLine": 274,
+      "endLine": 305,
+      "summary": "Defines `threePrimesInAP n` ($p_n+p_{n+2}=2p_{n+1}$). PROVES `gapEqual_iff_ap` (equal gaps iff three consecutive primes form an AP, via `omega` on ℕ subtraction) and `infinitely_many_3ap_from_218c` (if gapEqualSet is infinite, so is the set of AP triples).",
+      "mathContext": "$d_n=d_{n+1}\\Leftrightarrow p_n+p_{n+2}=2p_{n+1}$ (3-term AP of consecutive primes)."
     },
     {
-      "id": "examples",
-      "title": "Part 7: Known Examples of Equal Gaps",
-      "startLine": 226,
-      "endLine": 236,
-      "summary": "example_ap_1, apTriples definition, ap_357 axiom.",
-      "mathContext": "$p = 3, 5, 7$ is a 3-AP with $d = 2$. Primes 3, 7, 11 with $d = 4$."
+      "id": "known-examples",
+      "title": "Part VII: Known Examples of Equal Gaps",
+      "startLine": 306,
+      "endLine": 319,
+      "summary": "Concrete example. PROVES `example_ap_1` ($1\\in$ gapEqualSet: primes $3,5,7$). Defines `apTriples` and PROVES `ap_357` ($1\\in$ apTriples) from gap equality.",
+      "mathContext": "$(3,5,7)$ is a 3-term AP of consecutive primes (common difference $2$)."
     },
     {
       "id": "green-tao",
-      "title": "Part 8: Connection to Green-Tao",
-      "startLine": 237,
-      "endLine": 249,
-      "summary": "Green-Tao theorem axiom; does not directly imply conjecture 3.",
-      "mathContext": "Green-Tao (2008): primes contain $k$-APs for all $k$. But this gives $k \\\\geq 3$ APs, not necessarily $d_n = d_{n+1}$ (consecutive gaps)."
+      "title": "Part VIII: Connection to Green-Tao",
+      "startLine": 320,
+      "endLine": 330,
+      "summary": "A docstring discussing the Green–Tao theorem (2008): the primes contain arbitrarily long arithmetic progressions. Noted as much stronger than 218c but not directly implying that *consecutive* primes form APs. No declarations.",
+      "mathContext": "Green–Tao: arbitrarily long APs in primes; does not directly yield consecutive-prime APs."
     },
     {
-      "id": "partial",
-      "title": "Part 9: Partial Results",
-      "startLine": 250,
-      "endLine": 272,
-      "summary": "gapIncreasingSet_infinite, gapDecreasingSet_infinite axioms, average_gap_growth.",
-      "mathContext": "$I$ and $D$ are both infinite (gaps oscillate). Average gap: $d_n \\\\sim \\\\log n$ (PNT)."
+      "id": "partial-results",
+      "title": "Part IX: Partial Results",
+      "startLine": 331,
+      "endLine": 369,
+      "summary": "Declares the private AXIOM `infinite_of_hasDensity_pos` (a set of positive density is infinite — axiomatized due to Mathlib API drift around `Filter.Tendsto.div`). PROVES `gapIncreasingSet_infinite` and `gapDecreasingSet_infinite` by applying it to the density-$1/2$ axioms. A note discusses average gap growth ($\\sim\\log p$ by PNT).",
+      "mathContext": "Positive density $\\Rightarrow$ infinite (axiom); hence gapIncreasing and gapDecreasing are infinite."
     },
     {
       "id": "symmetry",
-      "title": "Part 10: Symmetry Argument (Heuristic)",
-      "startLine": 273,
-      "endLine": 301,
-      "summary": "Heuristic for density 1/2, partition theorem (proved).",
-      "mathContext": "Heuristic: gaps are roughly symmetric around the mean, suggesting $\\\\delta(I) \\\\approx \\\\delta(D) \\\\approx 1/2$."
+      "title": "Part X: Symmetry Argument (Heuristic)",
+      "startLine": 370,
+      "endLine": 453,
+      "summary": "A heuristic for why density $1/2$ is plausible, plus the full set-algebra. Defines `strictlyIncreasing`/`strictlyDecreasing`. PROVES: `partition` (strict$\\uparrow\\cup$strict$\\downarrow\\cup$equal $=$ univ), `gapIncreasingSet_union_gapDecreasingSet` ($=$ univ by totality of $\\leq$), the strict$\\subseteq$non-strict subset lemmas, the decompositions of increasing/decreasing into strict$\\cup$equal, and `strictlyIncreasing_disjoint_strictlyDecreasing`.",
+      "mathContext": "$\\text{strict}\\uparrow\\sqcup\\text{strict}\\downarrow\\sqcup\\text{equal}=\\mathbb{N}$; gapIncreasing$\\cup$gapDecreasing$=\\mathbb{N}$."
     },
     {
       "id": "summary",
-      "title": "Part 11: Summary",
-      "startLine": 302,
-      "endLine": 340,
-      "summary": "erdos_218_summary (proved from axioms), erdos_218_open.",
-      "mathContext": "Three OPEN conjectures on prime gap monotonicity. Partial: $I, D$ infinite. Unknown: densities, $E$ infinite."
+      "title": "Part XI: Summary",
+      "startLine": 454,
+      "endLine": 492,
+      "summary": "Recaps the three OPEN conjectures, what is known (both gap sets infinite; conjecture 3 $\\Leftrightarrow$ infinitely many 3-term consecutive-prime APs; Green–Tao gives long but not-necessarily-consecutive APs), and why it is hard. PROVES `erdos_218_summary`: (gapIncreasing and gapDecreasing infinite) $\\wedge$ (gapEqual infinite $\\Leftrightarrow$ apTriples infinite).",
+      "mathContext": "Summary theorem: both gap sets infinite; $\\text{gapEqual infinite}\\Leftrightarrow\\text{apTriples infinite}$."
     }
   ],
   "conclusion": {
@@ -176,7 +184,7 @@
     "namespace": "Erdos218",
     "lineCount": 492,
     "axiomCount": 3,
-    "theoremCount": 28,
+    "theoremCount": 30,
     "definitionCount": 12,
     "path": "Proofs/Erdos218Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
The Erdős #218 (prime gap densities) gallery `meta.json` had **section drift**, a **wrong theoremCount**, and **stale axiom prose**.

- Section ranges drifted progressively (Part IV labeled @128 but really @192; later Parts off by ~50-110 lines). Coverage stopped at line **340** of a **492**-line file — hiding most of Part X (the strict/non-strict gap set-algebra: `partition`, the union/subset/decomposition lemmas, disjointness) and Part XI (`erdos_218_summary`).
- **theoremCount was 28 but the file has 30** theorem/lemma declarations (verified by grep: 30 thm / 12 def / 3 axiom / 0 sorry).
- Stale "axiom" labels on now-proved theorems (the file underwent axiom-elimination, per its "Previously axiomatized; now proved" comments): `gapEqual_iff_ap`, `ap_357`, `gapIncreasingSet_infinite`, `gapDecreasingSet_infinite` are all **proved**; there is no Green-Tao axiom and no `erdos_218c` axiom (both are docstrings). The only **3** axioms are `erdos_218a`, `erdos_218b`, and the private `infinite_of_hasDensity_pos`.

## Changes
- Rebuilt **12 sections** (was 11) mapped to the file's real `## Part N` banners, full coverage **1-492**, with accurate `mathContext`.
- Fixed `leanFile.theoremCount` 28 → 30.
- Corrected the stale axiom prose.
- Other counts already correct: 12 definitions / 3 axioms / 0 sorries, lineCount 492.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-492 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-218
- [x] Declaration counts re-verified by grep against `Erdos218Problem.lean` (30/12/3/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)