### PR TITLE
research(erdos-1007-oq-01): realign drifted gallery sections to full file (11→25)

### DIFF
--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -80,92 +80,204 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 42,
+      "mathContext": "Erdős #1007: the graph dimension $\\dim(G)$ (least $n$ with a unit-distance embedding in $\\mathbb{R}^n$) and the minimum-edge function $\\mathrm{minEdges}(d)$.",
+      "summary": "Module header and imports for the formalization of Erdős problem #1007 on graph dimension and the minimum number of edges forcing a given dimension."
+    },
+    {
       "id": "graph-dimension",
-      "title": "Graph Dimension",
-      "summary": "Defines unit distance embeddings (structure `UnitDistanceEmbedding'`) with the condition $\\sqrt{\\sum_i (f(u)_i - f(v)_i)^2} = 1$ for all edges, and the graph dimension function (`graphDimension'`) as the minimum embedding dimension via `Nat.find`.",
-      "startLine": 41,
+      "title": "§1. Graph Dimension",
+      "startLine": 43,
       "endLine": 56,
-      "mathContext": "Defines unit distance embeddings (structure `UnitDistanceEmbedding'`) with the condition $\\sqrt{\\sum_i (f(u)_i - f(v)_i)^2} = 1$ for all edges, and the graph dimension function (`graphDimension'`) as the minimum embedding dimension via `Nat.find`."
-    },
-    {
-      "id": "min-edge-function",
-      "title": "Minimum Edge Function",
-      "summary": "Defines `minEdgesForDim` as a computable function with known values for d=0..5 and d as placeholder for d≥6. The lower bound `d ≤ minEdgesForDim d` and upper bound `minEdgesForDim d ≤ C(d+1,2)` are proved theorems (previously axioms, now proved by case analysis and arithmetic).",
-      "startLine": 172,
-      "endLine": 252,
-      "mathContext": "Defines `minEdgesForDim` concretely (was axiom in earlier versions). Lower and upper bound theorems proved by `decide` and `calc`; no `axiom` declarations remain."
-    },
-    {
-      "id": "known-values",
-      "title": "Known Values",
-      "summary": "Records $\\text{minEdges}(0..5) = (0, 1, 3, 6, 9, 15)$ as six definitional theorems proved by `rfl` (direct reduction from the `minEdgesForDim` definition). For $d \\le 3$ and $d=5$, these match $\\binom{d+1}{2}$; the $d=4$ value of 9 (from $K_{3,3}$) is the sole exception.",
-      "startLine": 188,
-      "endLine": 196,
-      "mathContext": "Known values proved by `rfl` from the `minEdgesForDim` definition — these are definitional equalities, not axioms."
-    },
-    {
-      "id": "structural-results",
-      "title": "Structural Results",
-      "summary": "Three theorems: $K_{d+1}$ optimality for $d \\le 3$ (via `interval_cases`), the $d=4$ surprise ($9 < \\binom{5}{2} = 10$), and $d=5$ matching ($15 = \\binom{6}{2}$).",
-      "startLine": 105,
-      "endLine": 123,
-      "mathContext": "Verified: Three theorems: $K_{d+1}$ optimality for $d \\le 3$ (via `interval_cases`), the $d=4$ surprise ($9 < \\binom{5}{2} = 10$), and $d=5$ matching ($15 = \\binom{6}{2}$)."
-    },
-    {
-      "id": "general-bounds",
-      "title": "General Bounds",
-      "summary": "Linear lower bound $d \\le \\text{minEdges}(d)$ (from rigidity) and quadratic upper bound $\\text{minEdges}(d) \\le \\binom{d+1}{2}$ (from complete graphs). Includes real-valued versions via `Nat.cast_le` and verified monotonicity for $d = 1..5$.",
-      "startLine": 128,
-      "endLine": 186,
-      "mathContext": "Linear lower bound $d \\le \\text{minEdges}(d)$ (from rigidity) and quadratic upper bound $\\text{minEdges}(d) \\le \\binom{d+1}{2}$ (from complete graphs). Includes real-valued versions via `Nat.cast_le` and verified monotonicity for $d = 1..5$."
-    },
-    {
-      "id": "conjectures",
-      "title": "Open Questions and Conjectures",
-      "summary": "Three Prop-valued definitions: monotonicity conjecture, quadratic growth conjecture (Θ(d²)), and complete graph optimality conjecture (K_{d+1} optimal for d ≠ 4).",
-      "startLine": 150,
-      "endLine": 166,
-      "mathContext": "Three Prop-valued definitions: monotonicity conjecture, quadratic growth conjecture (Θ(d²)), and complete graph optimality conjecture (K_{d+1} optimal for d $\\neq$ 4)."
+      "mathContext": "A unit-distance embedding realizes adjacent vertices at distance 1 in $\\mathbb{R}^n$; $\\dim(G)$ is the least such $n$.",
+      "summary": "§1. The notion of a unit-distance embedding `hasUnitEmbedding'` of a graph in $\\mathbb{R}^n$, inherited from the parent file."
     },
     {
       "id": "simplex-embedding",
-      "title": "Simplex Embedding Construction",
-      "summary": "Constructive proof that $K_n$ embeds as unit distances in $\\mathbb{R}^n$ via $v_i = \\frac{1}{\\sqrt{2}} e_i$. Key lemma: $(1/\\sqrt{2})^2 = 1/2$. Distance computation uses `Finset.add_sum_erase` to isolate the $i$-th and $j$-th terms. Corollary: $\\dim(K_n) \\le n$.",
-      "startLine": 190,
-      "endLine": 265,
-      "mathContext": "Constructive proof that $K_n$ embeds as unit distances in $\\mathbb{R}^n$ via $v_i = \\frac{1}{\\sqrt{2}} e_i$. Key lemma: $(1/\\sqrt{2})^2 = 1/2$. Distance computation uses `Finset.add_sum_erase` to isolate the $i$-th and $j$-th terms. Corollary: $\\dim(K_n) \\le n$."
+      "title": "§1b. Simplex Embedding Construction",
+      "startLine": 57,
+      "endLine": 131,
+      "mathContext": "Embed vertex $i$ as $\\tfrac1{\\sqrt2}e_i\\in\\mathbb{R}^n$; pairwise distances are all $1$, giving a unit embedding of $K_n$.",
+      "summary": "§1b. The key simplex embedding $i\\mapsto\\tfrac1{\\sqrt2}e_i$: its squared-distance computation, the resulting unit-distance embedding of $K_n$ in $\\mathbb{R}^n$ ($n\\ge2$), and inheritance by subgraphs."
     },
     {
-      "id": "irrefl-embedding",
-      "title": "Embedding Existence for Irreflexive Graphs",
-      "startLine": 272,
-      "endLine": 317,
-      "summary": "Constructive proof of `hasUnitEmbedding_exists_irrefl`: every finite irreflexive graph embeds in some $\\mathbb{R}^n$ via the simplex construction. Uses `Fintype.truncEquivFin` to reduce to `Fin |V|`.",
-      "mathContext": "Verified: Constructive proof of `hasUnitEmbedding_exists_irrefl`: every finite irreflexive graph embeds in some $\\mathbb{R}^n$ via the simplex construction. Uses `Fintype.truncEquivFin` to reduce to `Fin |V|`."
+      "id": "embedding-existence",
+      "title": "§1c. Embedding Existence (Proved)",
+      "startLine": 132,
+      "endLine": 161,
+      "mathContext": "Every irreflexive (loop-free) graph admits a unit embedding in some $\\mathbb{R}^n$; loops make it impossible.",
+      "summary": "§1c. Existence: every irreflexive graph admits a unit-distance embedding in some $\\mathbb{R}^n$ (via the complete-graph simplex embedding), while self-loops force non-existence."
+    },
+    {
+      "id": "graph-dimension-def",
+      "title": "§1d. Graph Dimension Definition",
+      "startLine": 162,
+      "endLine": 170,
+      "mathContext": "$\\mathrm{graphDimension}'(G)$ = least $n$ admitting a unit embedding, well-defined for irreflexive graphs.",
+      "summary": "§1d. The definition of `graphDimension'` as the least dimension admitting a unit-distance embedding, using the existence result of §1c."
+    },
+    {
+      "id": "min-edge-function",
+      "title": "§2. Minimum Edge Function",
+      "startLine": 171,
+      "endLine": 187,
+      "mathContext": "$\\mathrm{minEdges}(d)$ = fewest edges in a graph of dimension exactly $d$.",
+      "summary": "§2. The minimum-edge function `minEdgesForDim`, counting the fewest edges in a graph whose dimension equals $d$ — the central object of the problem."
+    },
+    {
+      "id": "known-values",
+      "title": "§3. Known Values",
+      "startLine": 188,
+      "endLine": 198,
+      "mathContext": "Small exact values of $\\mathrm{minEdges}(d)$ proved by `rfl`/`decide` from the definition.",
+      "summary": "§3. Machine-checked exact small values of `minEdgesForDim`, all proved by `rfl` directly from the definition."
+    },
+    {
+      "id": "structural-results",
+      "title": "§4. Structural Results",
+      "startLine": 199,
+      "endLine": 222,
+      "mathContext": "Basic structural lemmas relating dimension, edges, and embeddings.",
+      "summary": "§4. Structural results connecting graph dimension, edge counts, and the embedding machinery."
+    },
+    {
+      "id": "general-bounds",
+      "title": "§5. General Bounds",
+      "startLine": 223,
+      "endLine": 262,
+      "mathContext": "$d\\le\\mathrm{minEdges}(d)\\le\\binom{d+1}{2}$ — both formerly axioms, now proved.",
+      "summary": "§5. The general bounds $d\\le\\mathrm{minEdges}(d)\\le\\binom{d+1}{2}$, both upgraded from axioms to proved theorems."
+    },
+    {
+      "id": "conjectures",
+      "title": "§6. Open Questions and Conjectures",
+      "startLine": 263,
+      "endLine": 302,
+      "mathContext": "Is $\\mathrm{minEdges}(d)=\\Theta(d^2)$? Conjectures on optimality and monotonicity.",
+      "summary": "§6. The open questions: whether $\\mathrm{minEdges}(d)=\\Theta(d^2)$, the complete-graph-optimal conjecture, and the monotonicity conjecture, with the linear and quadratic growth corollaries."
+    },
+    {
+      "id": "complete-graph-dimension",
+      "title": "§7. Graph Dimension of Complete Graphs",
+      "startLine": 303,
+      "endLine": 314,
+      "mathContext": "$\\dim(K_n)\\le n$ for $n\\ge2$ from the simplex embedding; the optimal bound $n-1$ needs rigidity.",
+      "summary": "§7. The corollary $\\dim(K_n)\\le n$ for $n\\ge2$ from the simplex embedding, noting the optimal $n-1$ requires a harder rigidity argument (proved later)."
     },
     {
       "id": "conjecture-relationships",
-      "title": "Conjecture Relationships",
-      "summary": "Proves $K_{d+1}$ optimality implies monotonicity via 4-way case analysis on $d_1, d_2$ being 4. Building blocks: $\\binom{n}{2}$ monotonicity via `Nat.choose_le_choose` and the inequality $\\binom{d+1}{2} \\ge d$.",
-      "startLine": 318,
-      "endLine": 377,
-      "mathContext": "Proves $K_{d+1}$ optimality implies monotonicity via 4-way case analysis on $d_1, d_2$ being 4. Building blocks: $\\binom{n}{2}$ monotonicity via `Nat.choose_le_choose` and the inequality $\\binom{d+1}{2} \\ge d$."
+      "title": "§8. Conjecture Relationships",
+      "startLine": 315,
+      "endLine": 412,
+      "mathContext": "Implications among the optimality, quadratic-growth, and monotonicity conjectures.",
+      "summary": "§8. Relationships among the conjectures: how complete-graph optimality implies quadratic growth and other consequences, culminating in `optimal_implies_quadratic`."
     },
     {
       "id": "growth-rate",
-      "title": "Growth Rate Analysis",
-      "summary": "Successive differences $\\Delta(d) = \\text{minEdges}(d+1) - \\text{minEdges}(d)$ for $d=1..4$. The $d=3 \\to 4$ anomaly: $\\Delta(3) = 3 < 4$. Under the optimality conjecture, $\\Delta(d) = d+1$ (proved via $\\binom{d+2}{2} - \\binom{d+1}{2} = d+1$).",
-      "startLine": 330,
-      "endLine": 371,
-      "mathContext": "Successive differences $\\Delta(d) = \\text{minEdges}(d+1) - \\text{minEdges}(d)$ for $d=1..4$. The $d=3 \\to 4$ anomaly: $\\Delta(3) = 3 < 4$. Under the optimality conjecture, $\\Delta(d) = d+1$ (proved via $\\binom{d+2}{2} - \\binom{d+1}{2} = d+1$)."
+      "title": "§9. Growth Rate Analysis",
+      "startLine": 413,
+      "endLine": 457,
+      "mathContext": "Per-dimension growth ratios and successive differences of $\\mathrm{minEdges}$, including the anomaly at $d=4$.",
+      "summary": "§9. Growth-rate analysis: ratios $\\mathrm{minEdges}(d)/d$, successive differences, the $d=4$ difference anomaly, and the optimal-difference theorem under the optimality conjecture."
     },
     {
       "id": "deficiency",
-      "title": "Deficiency Function",
-      "summary": "Deficiency $\\delta(d) = \\binom{d+1}{2} - \\text{minEdges}(d)$. Computed: $\\delta = 0$ for $d \\in \\{1,2,3,5\\}$, $\\delta(4) = 1$. Proves the equivalence: optimality conjecture $\\iff$ $\\delta(d) = 0$ for all $d \\neq 4$. Confirms $d = 4$ is the unique anomaly for $d \\le 5$ via `interval_cases`.",
-      "startLine": 375,
+      "title": "§10. Deficiency Function",
+      "startLine": 458,
+      "endLine": 498,
+      "mathContext": "Deficiency measures the gap from the conjectured optimum; zero deficiency $\\iff$ optimal.",
+      "summary": "§10. The deficiency function with its small exact values, the equivalence `optimal_iff_zero_deficiency`, and the uniqueness of the small-dimension anomaly."
+    },
+    {
+      "id": "monotonicity-consequences",
+      "title": "§11. Monotonicity Consequences",
+      "startLine": 499,
+      "endLine": 523,
+      "mathContext": "Under the monotonicity conjecture, lower bounds on $\\mathrm{minEdges}(d)$ for $d\\ge4,5$.",
+      "summary": "§11. Consequences of the monotonicity conjecture: conditional lower bounds for $d\\ge4$ and $d\\ge5$ and the optimal chain under the optimality conjecture."
+    },
+    {
+      "id": "quadratic-bounds",
+      "title": "§13. Verified Quadratic Bounds for Known Values",
+      "startLine": 524,
+      "endLine": 538,
+      "mathContext": "Machine-checked quadratic bounds matching the known small values of $\\mathrm{minEdges}$.",
+      "summary": "§13. Verified quadratic bounds agreeing with the known small values of `minEdgesForDim`."
+    },
+    {
+      "id": "tighter-complete-bound",
+      "title": "§14. Tighter Complete Graph Dimension Bound",
+      "startLine": 539,
+      "endLine": 558,
+      "mathContext": "$\\dim(K_2)\\le1$ via an explicit unit embedding, tightening the general bound.",
+      "summary": "§14. A tighter complete-graph dimension bound starting from an explicit $K_2$ unit embedding in $\\mathbb{R}^1$."
+    },
+    {
+      "id": "k3-embedding",
+      "title": "§15. K₃ embeds in ℝ² (Equilateral Triangle)",
+      "startLine": 559,
+      "endLine": 595,
+      "mathContext": "The equilateral triangle gives a unit embedding of $K_3$ in $\\mathbb{R}^2$, so $\\dim(K_3)\\le2$.",
+      "summary": "§15. The equilateral-triangle unit embedding `K3_unit_embedding`, proving $\\dim(K_3)\\le2$."
+    },
+    {
+      "id": "k4-embedding",
+      "title": "§16. K₄ embeds in ℝ³ (Regular Tetrahedron)",
+      "startLine": 596,
+      "endLine": 658,
+      "mathContext": "The regular tetrahedron gives a unit embedding of $K_4$ in $\\mathbb{R}^3$, so $\\dim(K_4)\\le3$.",
+      "summary": "§16. The regular-tetrahedron unit embedding `K4_unit_embedding`, proving $\\dim(K_4)\\le3$."
+    },
+    {
+      "id": "k5-embedding",
+      "title": "§16b. K₅ embeds in ℝ⁴ (Regular 4-Simplex)",
+      "startLine": 659,
+      "endLine": 733,
+      "mathContext": "The regular 4-simplex gives a unit embedding of $K_5$ in $\\mathbb{R}^4$, so $\\dim(K_5)\\le4$.",
+      "summary": "§16b. The regular 4-simplex unit embedding `K5_unit_embedding`, proving $\\dim(K_5)\\le4$."
+    },
+    {
+      "id": "centered-simplex-upper",
+      "title": "§17. General dim(Kₙ) ≤ n−1 via Centered Simplex",
+      "startLine": 734,
+      "endLine": 757,
+      "mathContext": "The centered regular simplex gives the general upper bound $\\dim(K_n)\\le n-1$.",
+      "summary": "§17. The general upper bound $\\dim(K_n)\\le n-1$ via a centered regular-simplex construction."
+    },
+    {
+      "id": "regular-simplex-embedding",
+      "title": "§19. General Regular Simplex Embedding: Kₙ in ℝⁿ⁻¹",
+      "startLine": 758,
+      "endLine": 1135,
+      "mathContext": "Explicit regular-simplex embedding `regSimplexEmbed` of $K_n$ in $\\mathbb{R}^{n-1}$ with all pairwise distances 1.",
+      "summary": "§19. The full general regular-simplex embedding `regSimplexEmbed` of $K_n$ into $\\mathbb{R}^{n-1}$, with the detailed verification (`regSimplexEmbed_dist_sq`) that all pairwise distances equal 1."
+    },
+    {
+      "id": "lower-bound-dim-kn",
+      "title": "§20. Lower Bound: dim(Kₙ) ≥ n−1 (Proved)",
+      "startLine": 1136,
+      "endLine": 1257,
+      "mathContext": "A rigidity argument gives the matching lower bound $\\dim(K_n)\\ge n-1$, hence $\\dim(K_n)=n-1$.",
+      "summary": "§20. The matching lower bound $\\dim(K_n)\\ge n-1$ proved via rigidity, completing the exact value $\\dim(K_n)=n-1$."
+    },
+    {
+      "id": "summary-dimension-bounds",
+      "title": "§21. Summary of Dimension Bounds (Final)",
+      "startLine": 1258,
+      "endLine": 1272,
+      "mathContext": "Consolidated exact dimension results $\\dim(K_n)=n-1$.",
+      "summary": "§21. A consolidated summary of the dimension bounds, recording the exact value $\\dim(K_n)=n-1$."
+    },
+    {
+      "id": "known-values-summary",
+      "title": "§22. Known Values Summary",
+      "startLine": 1273,
       "endLine": 1337,
-      "mathContext": "Deficiency $\\delta(d) = \\binom{d+1}{2} - \\text{minEdges}(d)$. Computed: $\\delta = 0$ for $d \\in \\{1,2,3,5\\}$, $\\delta(4) = 1$. Proves the equivalence: optimality conjecture $\\iff$ $\\delta(d) = 0$ for all $d \\neq 4$. Confirms $d = 4$ is the unique anomaly for $d \\le 5$ via `interval_cases`."
+      "mathContext": "Final table of known $\\mathrm{minEdges}$ values and the problem's resolved/open status.",
+      "summary": "§22. The closing summary of known `minEdgesForDim` values and the overall resolved-versus-open status of the problem."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
- The gallery `sections` for **erdos-1007-oq-01** had drifted into a scrambled, overlapping, out-of-order state: **11 sections** with backward ranges (e.g. `structural-results` 105-123 listed after `min-edge-function` 172-252), nested overlaps, and a single `deficiency` section lumping lines **375-1337** (≈70% of the file) — hiding everything from the growth-rate analysis through the $K_n$ embedding constructions and the final dimension bounds.
- The Lean file is cleanly organized into **`-- § N` banners (§1–§22)**. Rebuilt `sections` into **25 contiguous parts** tiling lines 1-1337.
- Coverage now includes graph dimension and unit/simplex embeddings, the minimum-edge function and its known values, growth-rate and deficiency analysis, the explicit $K_3/K_4/K_5$ and general regular-simplex embeddings, and the matching $\dim(K_n)=n-1$ lower bound.

## Notes
- Content-only metadata change; **no Lean source modified**.
- Counts unchanged and verified: 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)