### PR TITLE
Enrich erdos-1094: realign drifted sections + annotations to Part banners

### DIFF
--- a/src/data/proofs/erdos-1094/annotations.json
+++ b/src/data/proofs/erdos-1094/annotations.json
@@ -26,7 +26,7 @@
     "proofId": "erdos-1094",
     "type": "definition",
     "range": {
-      "startLine": 30,
+      "startLine": 28,
       "endLine": 36
     },
     "title": "LPF Bound and Exceptions",
@@ -50,8 +50,8 @@
     "proofId": "erdos-1094",
     "type": "concept",
     "range": {
-      "startLine": 43,
-      "endLine": 46
+      "startLine": 42,
+      "endLine": 44
     },
     "title": "Erdős Problem 1094",
     "content": "The main conjecture states that the set of exception pairs is finite. This is formalized using Set.Finite, making it a statement about the cardinality of a set of natural number pairs. Erdős, Lacampagne, and Selfridge posed this in 1988 as a strengthening of Problem 384.",
@@ -73,8 +73,8 @@
     "proofId": "erdos-1094",
     "type": "insight",
     "range": {
-      "startLine": 50,
-      "endLine": 81
+      "startLine": 48,
+      "endLine": 79
     },
     "title": "Computationally Verified Exceptions",
     "content": "Twelve of the 14 known exceptions are verified computationally using native_decide, which reduces the check to kernel evaluation. Each exception (n,k) satisfies k > 0, n ≥ 2k, and minFac(C(n,k)) > max(n/k, k). Notable cases include C(7,3) = 35 (the smallest exception, shared with Problem 384), C(62,6) (Selfridge's famous exception), and C(95,10) (the largest computationally verified).",
@@ -95,17 +95,17 @@
     "proofId": "erdos-1094",
     "type": "concept",
     "range": {
-      "startLine": 83,
-      "endLine": 86
+      "startLine": 82,
+      "endLine": 84
     },
-    "title": "Large Axiomatized Exceptions",
-    "content": "C(241,16) and C(284,28) are too large for native_decide within reasonable time and memory, so they are axiomatized. These are the two largest known exceptions from the Erdős-Lacampagne-Selfridge list of 14.",
-    "mathContext": "$\\binom{241}{16} \\approx 1.6 \\times 10^{27}$ and $\\binom{284}{28} \\approx 2.4 \\times 10^{38}$; their primality factorizations exceed Lean's kernel computation budget.",
+    "title": "Large Exceptions: C(241,16) and C(284,28) (Now Proved)",
+    "content": "C(241,16) ≈ 1.6×10²⁷ and C(284,28) ≈ 2.4×10³⁸ are the two largest known exceptions from the Erdős-Lacampagne-Selfridge list of 14. They were previously axiomatized (too large for the kernel), but are now fully proved by native_decide (exception_241_16, exception_284_28), so the file is axiom-free.",
+    "mathContext": "$\\binom{241}{16} \\approx 1.6 \\times 10^{27}$ and $\\binom{284}{28} \\approx 2.4 \\times 10^{38}$; native_decide now discharges both within the kernel budget, removing the former axioms.",
     "significance": "supporting",
     "relatedConcepts": [
-      "computational limits",
-      "axiom",
-      "large binomial coefficients"
+      "native_decide",
+      "large binomial coefficients",
+      "axiom-free verification"
     ],
     "prerequisites": [
       "native_decide limitations",
@@ -117,8 +117,8 @@
     "proofId": "erdos-1094",
     "type": "insight",
     "range": {
-      "startLine": 88,
-      "endLine": 114
+      "startLine": 90,
+      "endLine": 111
     },
     "title": "Verified Non-Exceptions",
     "content": "Eight pairs are verified to satisfy the LPF bound, demonstrating that the bound holds generically. C(12,4) = 495 is a near-miss: minFac(495) = 3 just meets max(3,4) = 4. The even binomial C(20,10) = 184756 trivially satisfies the bound since minFac = 2. C(100,2) = 4950 illustrates that large n/k makes the bound easy to satisfy.",
@@ -138,8 +138,8 @@
     "proofId": "erdos-1094",
     "type": "concept",
     "range": {
-      "startLine": 118,
-      "endLine": 128
+      "startLine": 116,
+      "endLine": 126
     },
     "title": "Bound Simplification Theorems",
     "content": "Two iff-rewriting lemmas decompose the bound by the relative size of n/k and k. When k ≤ n/k (equivalently n ≥ k²), max(n/k, k) = n/k, reducing to the weaker Erdős-Selfridge bound from Problem 384. When n/k < k (n < k²), the bound becomes lpf(C(n,k)) ≤ k. These use max_eq_left and max_eq_right from Mathlib.",
@@ -160,8 +160,8 @@
     "proofId": "erdos-1094",
     "type": "insight",
     "range": {
-      "startLine": 130,
-      "endLine": 152
+      "startLine": 129,
+      "endLine": 150
     },
     "title": "Trivial Cases: k = 0 and k = 1",
     "content": "The cases k = 0 and k = 1 are ruled out as exceptions. For k = 0, the IsException definition requires k > 0, giving immediate contradiction via omega. For k = 1, C(n,1) = n and n/1 = n, so minFac(n) ≤ n = max(n, 1) holds for n ≥ 2 by Nat.minFac_le. Six explicit n = 2k cases are also verified computationally.",
@@ -182,7 +182,7 @@
     "type": "definition",
     "range": {
       "startLine": 156,
-      "endLine": 160
+      "endLine": 159
     },
     "title": "Selfridge's Refinement",
     "content": "John Selfridge conjectured (1977) that the LPF bound holds for all n ≥ k² − 1, with C(62,6) as the sole exception. This is much stronger than the original conjecture, effectively predicting that all 14 exceptions have n < k² − 1 except C(62,6) (since 62 ≥ 36 − 1 = 35).",
@@ -203,7 +203,7 @@
     "type": "definition",
     "range": {
       "startLine": 164,
-      "endLine": 177
+      "endLine": 176
     },
     "title": "Stronger Bound Conjectures",
     "content": "Two progressively stronger conjectures replace k in the bound. StrongerBoundSqrt replaces k with √k, asserting lpf(C(n,k)) ≤ max(n/k, √k) with finitely many exceptions. StrongestBound13 replaces k with the constant 13, asserting at most 12 exceptions—remarkably, one fewer than the 13 exceptions with k > 13 in the original list.",
@@ -225,10 +225,10 @@
     "type": "definition",
     "range": {
       "startLine": 181,
-      "endLine": 187
+      "endLine": 206
     },
     "title": "Connection to Problem 384",
-    "content": "Problem 384 asks whether C(n,k) always has a prime factor ≤ n/k for n ≥ 2k. Problem 1094 is strictly stronger: if lpf(C(n,k)) ≤ max(n/k, k) with finitely many exceptions, then for large enough n the lpf is ≤ n/k (since n/k eventually dominates k), implying Problem 384 asymptotically. The implication is axiomatized since the formal proof would require handling the finite exception set.",
+    "content": "Problem 384 asks whether C(n,k) always has a prime factor ≤ n/k for n ≥ 2k. Problem 1094 is strictly stronger: if lpf(C(n,k)) ≤ max(n/k, k) with finitely many exceptions, then for large enough n the lpf is ≤ n/k (since n/k eventually dominates k), implying Problem 384 asymptotically. This implication is left as an informal comment (not a formal lemma); a previously-present axiom asserting #1094 ⇒ naive #384 was removed (it was incorrect, since the naive #384 is false), leaving the file axiom-free.",
     "mathContext": "Problem 384: $\\forall\\, n \\geq 2k,\\; \\exists\\, p \\leq n/k$ with $p \\mid \\binom{n}{k}$ and $p$ prime. Since $\\operatorname{lpf}\\binom{n}{k}$ divides $\\binom{n}{k}$ and $\\operatorname{lpf} \\leq \\max(n/k, k)$, the finite exceptions do not affect the asymptotic claim.",
     "significance": "key",
     "relatedConcepts": [
@@ -246,8 +246,8 @@
     "proofId": "erdos-1094",
     "type": "concept",
     "range": {
-      "startLine": 191,
-      "endLine": 195
+      "startLine": 216,
+      "endLine": 219
     },
     "title": "Binomial Coefficient Lower Bounds",
     "content": "Four specific instances of C(n,k) > 1 are verified computationally, confirming that these binomial coefficients are composite or prime (not trivial). This ensures minFac returns a genuine prime factor rather than 1.",

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -49,81 +49,81 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 27,
-      "summary": "Header documentation, Mathlib imports for primes, binomial coefficients, and tactics, and namespace declaration.",
-      "mathContext": "Mathematical content: Header documentation, Mathlib imports for primes, binomial coefficients, and tactics, and namespace declaration."
+      "endLine": 24,
+      "summary": "Header documentation stating Erdős Problem #1094 (least prime factor of binomial coefficients), known results from Erdős-Lacampagne-Selfridge, OPEN status, and references. `import Mathlib` and `namespace Erdos1094`.",
+      "mathContext": "Conjecture: for all $n \\geq 2k$, the least prime factor $\\mathrm{lpf}(\\binom{n}{k}) \\leq \\max(n/k, k)$ with only finitely many exceptions. Strengthens Erdős Problem #384."
     },
     {
       "id": "lpf-bound",
-      "title": "Core Definitions",
-      "startLine": 28,
-      "endLine": 40,
-      "summary": "Defines LPFBound (minFac ≤ max(n/k, k)) and IsException for pairs with k > 0, n ≥ 2k where the bound fails.",
-      "mathContext": "Defines LPFBound (minFac $\\leq$ max(n/k, k)) and IsException for pairs with k > 0, n $\\geq$ 2k where the bound fails."
+      "title": "Part 1: Core Definitions",
+      "startLine": 25,
+      "endLine": 37,
+      "summary": "Defines `LPFBound n k` ((n.choose k).minFac ≤ max(n/k, k)) and `IsException n k` (0 < k, 2k ≤ n, and the bound fails), with `Decidable` instances for both enabling native_decide verification.",
+      "mathContext": "$\\mathrm{LPFBound}(n,k) \\equiv (\\binom{n}{k}).\\mathrm{minFac} \\leq \\max(\\lfloor n/k \\rfloor, k)$. An exception requires $0 < k$, $2k \\leq n$, and $\\neg\\mathrm{LPFBound}$."
     },
     {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "startLine": 41,
-      "endLine": 47,
-      "summary": "States ErdosProblem1094 as Set.Finite of the exception set: finitely many pairs violate the LPF bound.",
-      "mathContext": "Bound: States ErdosProblem1094 as Set.Finite of the exception set: finitely many pairs violate the LPF bound."
+      "title": "Part 2: The Main Conjecture",
+      "startLine": 38,
+      "endLine": 44,
+      "summary": "States `ErdosProblem1094` as `Set.Finite { p | IsException p.1 p.2 }`: the set of exception pairs is finite.",
+      "mathContext": "$\\mathrm{ErdosProblem1094} \\equiv \\mathrm{Set.Finite}\\,\\{(n,k) : \\mathrm{IsException}(n,k)\\}$ — finitely many pairs violate the LPF bound."
     },
     {
       "id": "verified-exceptions",
-      "title": "Verified Exceptions",
-      "startLine": 48,
-      "endLine": 83,
-      "summary": "All 14 known exceptions verified by native_decide, including the large C(241,16) and C(284,28).",
-      "mathContext": "All 14 known exceptions verified computationally by native_decide."
+      "title": "Part 3: Verified Exceptions",
+      "startLine": 45,
+      "endLine": 84,
+      "summary": "All 14 known exceptions verified by native_decide — from C(7,3)=35 up to the large C(241,16)≈1.6×10²⁷ and C(284,28)≈2.4×10³⁸ (the latter two previously axioms, now machine-checked). Includes Selfridge's famous C(62,6).",
+      "mathContext": "Each `exception_n_k : IsException n k` is closed by native_decide. E.g. C(7,3)=35 has minFac 5 > max(⌊7/3⌋,3)=3; C(62,6) is Selfridge's celebrated exception."
     },
     {
       "id": "non-exceptions",
-      "title": "Verified Non-Exceptions",
-      "startLine": 88,
-      "endLine": 115,
-      "summary": "Eight pairs verified to satisfy the bound, including near-miss C(12,4) and large C(100,2).",
-      "mathContext": "Bound: Eight pairs verified to satisfy the bound, including near-miss C(12,4) and large C(100,2)."
+      "title": "Part 4: Verified Non-Exceptions",
+      "startLine": 85,
+      "endLine": 112,
+      "summary": "Eight pairs verified to satisfy the bound via native_decide, including the near-miss C(12,4)=495 (minFac 3 ≤ 4, just barely) and the large C(100,2).",
+      "mathContext": "Each `non_exception_n_k : LPFBound n k`. C(12,4)=495 has minFac 3 ≤ max(3,4)=4 (tight); C(20,10) has minFac 2 ≤ 10 (even-row case)."
     },
     {
       "id": "properties",
-      "title": "Structural Properties",
-      "startLine": 116,
-      "endLine": 153,
-      "summary": "Bound simplification for n ≥ k² and n < k², plus proofs that k = 0 and k = 1 never produce exceptions. Verified n = 2k boundary cases.",
-      "mathContext": "Bound simplification for n $\\geq$ k² and n < k², plus proofs that k = 0 and k = 1 never produce exceptions. Verified n = 2k boundary cases."
+      "title": "Part 5: Basic Properties",
+      "startLine": 113,
+      "endLine": 151,
+      "summary": "Structural lemmas: `bound_simplifies_large` (n/k ≥ k reduces the bound to minFac ≤ n/k) and `bound_simplifies_small` (n/k < k reduces it to minFac ≤ k); `not_exception_k_zero` and `not_exception_k_one`/`bound_k_one` (k=0 and k=1 never give exceptions). Plus verified n=2k boundary cases.",
+      "mathContext": "The max splits on whether $n \\geq k^2$: $\\lfloor n/k \\rfloor \\geq k \\Rightarrow$ bound is $\\mathrm{minFac} \\leq n/k$, else $\\mathrm{minFac} \\leq k$. $k=1$: $\\binom{n}{1}=n$ and $\\mathrm{minFac}(n) \\leq n$."
     },
     {
       "id": "selfridge",
-      "title": "Selfridge's Refinement",
-      "startLine": 154,
-      "endLine": 161,
-      "summary": "Selfridge's stronger conjecture: bound holds for n ≥ k² − 1 with sole exception C(62,6).",
-      "mathContext": "Selfridge's stronger conjecture: bound holds for n $\\geq$ k² − 1 with sole exception C(62,6)."
+      "title": "Part 6: Selfridge's Refinement",
+      "startLine": 152,
+      "endLine": 159,
+      "summary": "Defines `SelfridgeConjecture`: the bound holds for all n ≥ k² − 1 with the sole exception of C(62,6).",
+      "mathContext": "Selfridge: $\\forall n, k,\\; 0 < k \\land n \\geq k^2 - 1 \\land (n,k) \\neq (62,6) \\Rightarrow \\mathrm{LPFBound}(n,k)$."
     },
     {
       "id": "stronger-bounds",
-      "title": "Stronger Bound Conjectures",
-      "startLine": 162,
-      "endLine": 178,
-      "summary": "Two progressively stronger conjectures replacing k with √k (finitely many exceptions) and the constant 13 (at most 12 exceptions).",
-      "mathContext": "Mathematical content: Two progressively stronger conjectures replacing k with √k (finitely many exceptions) and the constant 13 (at most 12 exceptions)."
+      "title": "Part 7: Stronger Bound Conjectures",
+      "startLine": 160,
+      "endLine": 176,
+      "summary": "Two progressively stronger conjectures: `StrongerBoundSqrt` replaces k with √k (finitely many exceptions), and `StrongestBound13` replaces it with the constant 13 (at most 12 exceptions, witnessed by a Finset S).",
+      "mathContext": "$\\mathrm{StrongerBoundSqrt}$: finitely many $(n,k)$ with $\\mathrm{minFac} > \\max(n/k, \\sqrt{k})$. $\\mathrm{StrongestBound13}$: $\\exists S,\\, |S| \\leq 12$, all others satisfy $\\mathrm{minFac} \\leq \\max(n/k, 13)$."
     },
     {
       "id": "problem384",
-      "title": "Connection to Problem 384",
+      "title": "Part 8: Connection to Problem 384",
       "startLine": 177,
-      "endLine": 211,
-      "summary": "Proves the naive formulation of Problem 384 is false via the C(7,3) counterexample (no prime ≤ 2 divides 35). Provides corrected formulation with sufficiently-large-n condition.",
-      "mathContext": "The naive statement '∀ n ≥ 2k, ∃ prime ≤ n/k dividing C(n,k)' is proved false. Corrected to: for each k, ∃ N(k) such that for n ≥ N(k), lpf(C(n,k)) ≤ n/k."
+      "endLine": 212,
+      "summary": "Proves the naive formulation of Problem 384 is FALSE (`erdos384_naive_false`) via the C(7,3)=35 counterexample (only prime ≤ ⌊7/3⌋=2 is 2, and 2 ∤ 35). Provides the corrected `ErdosProblem384` with a sufficiently-large-n threshold N(k), and notes #1094 ⇒ #384 informally.",
+      "mathContext": "Naive #384: $\\forall n \\geq 2k,\\, \\exists$ prime $p \\leq n/k,\\, p \\mid \\binom{n}{k}$ — FALSE at $(7,3)$. Corrected #384: $\\forall k > 0,\\, \\exists N(k),\\, \\forall n \\geq N(k),\\, \\mathrm{minFac}(\\binom{n}{k}) \\leq n/k$."
     },
     {
       "id": "binomial-props",
-      "title": "Binomial Coefficient Properties and Summary",
-      "startLine": 189,
-      "endLine": 219,
-      "summary": "Verified C(n,k) > 1 for small cases ensuring minFac is a genuine prime. Closing summary of proved and open results.",
-      "mathContext": "Mathematical content: Verified C(n,k) > 1 for small cases ensuring minFac is a genuine prime. Closing summary of proved and open results."
+      "title": "Part 9: Binomial Coefficient Properties & Summary",
+      "startLine": 213,
+      "endLine": 248,
+      "summary": "Verifies C(n,k) > 1 for small specific cases (ensuring minFac is a genuine prime, not the minFac(1)=1 degenerate case), then the closing summary docstring recapping what is proved (14 exceptions, 8 non-exceptions, structural results, naive #384 falsity) and what remains open (the finiteness conjecture, Selfridge, stronger bounds), noting 0 axioms (a previously-incorrect #1094⇒naive-#384 axiom was removed).",
+      "mathContext": "`choose_gt_one_*` lemmas confirm $\\binom{n}{k} > 1$ so $\\mathrm{minFac}$ is a true prime factor. Summary: status OPEN, 0 axioms, 0 sorries — the conjecture itself is stated as a `Prop`, not proved."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: section + annotation realignment

`Erdos1094Problem.lean` (248 lines, Erdős #1094 — least prime factor of binomial coefficients) had `sections` and `annotations` drifted off the file's `-- ## Part N` banners.

### Sections (10, realigned)
Back-half sections overlapped (Connection-to-384 `177-211` overlapped Binomial-Props `189-219`) and the Part 9/10 summary tail (`219-248`) was uncovered. Realigned all 10 to the actual Part boundaries (header + Parts 1–9/10), contiguous over the full file (1–248), with summaries naming the actual declarations.

### Annotations (realigned + stale-prose fixes)
- Realigned ranges that pointed at comment lines / wrong sections (`lpfbound`, `verified-exceptions`, `non-exceptions`, `binomial-props`), fixing 3 build errors.
- **Stale prose fixed:** the "Large Axiomatized Exceptions" annotation still described `C(241,16)`/`C(284,28)` as axiomatized, but the file now proves both via `native_decide`. The Problem-384 annotation still called the #1094⇒#384 implication "axiomatized", but that (incorrect) axiom was removed. The file is now **axiom-free (0 axioms, 0 sorries)**.

### Counts
Unchanged — 38 theorems / 8 defs / 0 axioms / 0 sorries were already accurate. Only `sections`/`annotations` metadata changed.

Validated: `annotations/build.ts` reports no errors for this slug.