### PR TITLE
research(erdos-671): realign drifted gallery sections to full file (5→14)

### DIFF
--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -100,44 +100,116 @@
   },
   "sections": [
     {
-      "id": "lagrange-setup",
-      "title": "§I-II: Interpolation Points and Lagrange Basis",
-      "startLine": 34,
-      "endLine": 75,
-      "summary": "Defines InterpolationPoints (n points in [-1,1], distinct), PointSequence, and the Lagrange basis polynomial lagrangeBasis. Proves lagrangeBasis_self (p_i(a_i)=1) and lagrangeBasis_other (p_i(a_j)=0 for i≠j). Defines lagrangeInterp as the weighted sum and proves it reproduces function values at nodes.",
-      "mathContext": "The Lagrange basis polynomial $p_i^n(x) = \\prod_{j \\neq i} \\frac{x - a_j^n}{a_i^n - a_j^n}$ has degree $n-1$ and satisfies $p_i^n(a_j^n) = \\delta_{ij}$ (Kronecker delta). The interpolation operator $L^n f(x) = \\sum_{i=1}^n f(a_i^n) p_i^n(x)$ is the unique degree-$(n-1)$ polynomial agreeing with $f$ at all $n$ nodes."
+      "id": "header",
+      "title": "Header: Statement and Questions",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "States Erdős Problem #671 (Lagrange interpolation convergence, OPEN, $250 prize). For nodes $a_i^n\\in[-1,1]$ define Lagrange basis polynomials $p_i^n$, the interpolation operator $L^n$, and the Lebesgue function $\\lambda_n(x)=\\sum_i|p_i^n(x)|$. Q1: is there a node sequence where for every continuous $f$ some $x$ has $\\limsup\\lambda_n(x)=\\infty$ yet $L^nf(x)\\to f(x)$? Q2: same with $\\limsup\\lambda_n(x)=\\infty$ for ALL $x$. Known: Bernstein (1931), Erdős–Vértesi (1980). Imports Mathlib.",
+      "mathContext": "$\\lambda_n(x)=\\sum_i|p_i^n(x)|$ (Lebesgue function); $L^nf(x)=\\sum_i f(a_i)p_i^n(x)$. Both questions OPEN."
+    },
+    {
+      "id": "basic-defs",
+      "title": "Part I: Basic Definitions",
+      "startLine": 31,
+      "endLine": 68,
+      "summary": "Defines the `InterpolationPoints n` structure (distinct nodes in $[-1,1]$), `PointSequence`, and the Lagrange basis `lagrangeBasis pts i` $=\\prod_{j\\neq i}\\frac{X-a_j}{a_i-a_j}$. PROVES the defining interpolation properties `lagrangeBasis_self` ($p_i(a_i)=1$) and `lagrangeBasis_other` ($p_i(a_j)=0$ for $j\\neq i$).",
+      "mathContext": "$p_i^n(x)=\\prod_{j\\neq i}\\frac{x-a_j}{a_i-a_j}$; $p_i(a_i)=1$, $p_i(a_j)=0$."
+    },
+    {
+      "id": "interpolation",
+      "title": "Part II: Lagrange Interpolation",
+      "startLine": 69,
+      "endLine": 114,
+      "summary": "Defines the interpolation operator `lagrangeInterp pts f x` $=\\sum_i f(a_i)p_i(x)$. PROVES `lagrangeInterp_at_node` ($L^nf(a_i)=f(a_i)$) and `lagrangeInterp_degree` ($L^nf$ agrees with a polynomial of degree $\\leq n-1$, via natDegree bounds on the basis product).",
+      "mathContext": "$L^nf(x)=\\sum_i f(a_i)p_i(x)$; interpolates at nodes; degree $\\leq n-1$."
     },
     {
       "id": "lebesgue-function",
-      "title": "§III: The Lebesgue Function and Constant",
-      "startLine": 77,
-      "endLine": 96,
-      "summary": "Defines lebesgueFunction λ_n(x) = Σ|p_i^n(x)| and lebesgueConstant Λ_n = sup_x λ_n(x). Proves lebesgueFunction_ge_one (λ_n(x) ≥ 1 whenever x is a node). These measure the worst-case amplification of interpolation errors.",
-      "mathContext": "The Lebesgue constant $\\Lambda_n = \\sup_{x \\in [-1,1]} \\sum_{i=1}^n |p_i^n(x)|$ controls interpolation error: $\\|f - L^n f\\|_\\infty \\leq (1 + \\Lambda_n) \\inf_p \\|f - p\\|_\\infty$ over degree-$(n-1)$ polynomials $p$. Chebyshev nodes minimize $\\Lambda_n$, giving $\\Lambda_n \\sim \\frac{2}{\\pi} \\ln n$; equidistant nodes give $\\Lambda_n \\sim \\frac{2^n}{en \\ln n}$ (exponential growth)."
+      "title": "Part III: The Lebesgue Function",
+      "startLine": 115,
+      "endLine": 190,
+      "summary": "Defines `lebesgueFunction pts x` $=\\sum_i|p_i(x)|$ and `lebesgueConstant` $=\\sup_{x\\in[-1,1]}\\lambda_n(x)$. PROVES the private partition-of-unity lemma `lagrangeBasis_sum_one` ($\\sum_i p_i(x)=1$, via a degree-$\\leq n-1$ polynomial with $n$ roots being zero) and `lebesgueFunction_ge_one` ($\\lambda_n(x)\\geq1$, from $|\\sum p_i|\\leq\\sum|p_i|$). A note records the error bound $|L^nf-f|\\leq(1+\\Lambda_n)\\cdot E_n(f)$.",
+      "mathContext": "$\\sum_i p_i(x)=1$ (partition of unity) $\\Rightarrow\\lambda_n(x)\\geq1$; $\\Lambda_n=\\max_{[-1,1]}\\lambda_n$."
     },
     {
-      "id": "bernstein-erdos-vertesi",
-      "title": "§IV-V: Bernstein's Theorem and Erdős–Vértesi",
-      "startLine": 97,
-      "endLine": 122,
-      "summary": "Axiomatizes bernstein (1931): for ANY point sequence, there exists x₀ ∈ [-1,1] with limsup λ_n(x₀) = ∞. Axiomatizes erdos_vertesi (1980): for any sequence, there exists a continuous f such that limsup |L^n f(x)| = ∞ for almost every x ∈ [-1,1]. Also proves lebesgueConstant_growth: Λ_n ≥ (2/π)ln(n) - 2 for n ≥ 2.",
-      "mathContext": "Bernstein (1931) showed $\\Lambda_n \\to \\infty$ for ANY point sequence — no optimal nodes exist in the pointwise sense. Erdős and Vértesi (1980) strengthened this: divergence occurs for measure-1 set of $x$. The growth bound $\\Lambda_n \\geq \\frac{2}{\\pi} \\ln n - 2$ is universal; it holds with equality (up to $O(1)$) for Chebyshev nodes."
+      "id": "bernstein",
+      "title": "Part IV: Bernstein's Theorem",
+      "startLine": 191,
+      "endLine": 208,
+      "summary": "Defines `LebesgueUnbounded` ($\\limsup\\lambda_n(x)=\\infty$). States Bernstein's 1931 theorem `bernstein` (some $x_0$ has unbounded Lebesgue function — `sorry`) and `lebesgueConstant_growth` ($\\Lambda_n\\geq(2/\\pi)\\log n - 1$ — `sorry`). A note records that Chebyshev nodes attain the optimal $\\sim(2/\\pi)\\log n$ growth.",
+      "mathContext": "Bernstein: $\\exists x_0,\\ \\limsup_n\\lambda_n(x_0)=\\infty$. $\\Lambda_n\\geq(2/\\pi)\\log n - 1$."
     },
     {
-      "id": "open-questions",
-      "title": "§VI-VII: Question 1 and Question 2",
-      "startLine": 123,
-      "endLine": 155,
-      "summary": "States Question1 (does there exist a sequence where limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for every continuous f at some x?) and Question2 (same with limsup λ_n(x) = ∞ for ALL x). Both axiomatized as open. Proves q2_implies_q1: Question2 is strictly stronger than Question1.",
-      "mathContext": "Question 1 asks: can the Lebesgue function be unbounded pointwise yet interpolation still converge? Question 2 is the global version. The implication $Q_2 \\Rightarrow Q_1$ is immediate. Both questions probe the boundary between pointwise Lebesgue function growth and interpolation convergence — asking whether $\\limsup \\lambda_n(x) = \\infty$ is compatible with $L^n f(x) \\to f(x)$."
+      "id": "erdos-vertesi",
+      "title": "Part V: Erdős-Vértesi Theorem",
+      "startLine": 209,
+      "endLine": 223,
+      "summary": "Defines `InterpUnbounded` ($|L^nf(x)|\\to\\infty$ frequently). States the Erdős–Vértesi 1980 theorem `erdos_vertesi`: for any nodes there is a continuous $f$ with $|L^nf(x)|\\to\\infty$ for a.e. $x$ (`sorry`). A note: divergence is generic (Baire category).",
+      "mathContext": "Erdős–Vértesi: $\\exists f\\in C[-1,1]$ with $|L^nf(x)|\\to\\infty$ for a.e. $x$."
     },
     {
-      "id": "special-sequences-conjecture",
-      "title": "§VIII-XII: Special Sequences and Main Conjecture",
-      "startLine": 153,
-      "endLine": 249,
-      "summary": "Defines chebyshevNodes (optimal: $x_k = \\cos((2k+1)π/2n)$) and equidistantNodes (divergent: $x_k = -1 + 2k/(n-1)$). Axiomatizes equidistant_diverges, faber (Faber's theorem: no universal convergent sequence), and measure-theoretic results. States MainConjecture about pointwise convergence for Chebyshev nodes.",
-      "mathContext": "Chebyshev nodes $x_k = \\cos\\frac{(2k-1)\\pi}{2n}$ minimize $\\|\\omega_n\\|_\\infty$ where $\\omega_n(x) = \\prod_{i=1}^n (x-x_i)$, giving the smallest possible max interpolation error for polynomials. Faber's theorem (1914): there is NO point sequence for which $L^n f \\to f$ uniformly for every continuous $f$ — universal convergent interpolation is impossible."
+      "id": "question1",
+      "title": "Part VI: Question 1",
+      "startLine": 224,
+      "endLine": 235,
+      "summary": "Formalizes `Question1`: there is a node sequence such that for every continuous $f$ some $x$ has $\\limsup\\lambda_n(x)=\\infty$ yet $L^nf(x)\\to f(x)$. Declared OPEN via the axiom `question1_open`.",
+      "mathContext": "Q1: $\\exists$ seq, $\\forall f\\,\\exists x$: $\\lambda_n(x)$ unbounded $\\wedge\\ L^nf(x)\\to f(x)$."
+    },
+    {
+      "id": "question2",
+      "title": "Part VII: Question 2",
+      "startLine": 236,
+      "endLine": 255,
+      "summary": "Formalizes `Question2`: a node sequence with $\\limsup\\lambda_n(x)=\\infty$ for ALL $x\\in[-1,1]$, yet for every continuous $f$ some $x$ has $L^nf(x)\\to f(x)$. Declared OPEN via the axiom `question2_open`. PROVES `q2_implies_q1` (Question 2 is strictly stronger).",
+      "mathContext": "Q2 (all-$x$ unboundedness) $\\Rightarrow$ Q1."
+    },
+    {
+      "id": "special-sequences",
+      "title": "Part VIII: Special Point Sequences",
+      "startLine": 256,
+      "endLine": 318,
+      "summary": "Concrete node families. Defines `chebyshevNodes` ($x_k=\\cos\\frac{(2k+1)\\pi}{2n}$) and `equidistantNodes` ($x_k=-1+2k/(n-1)$), each with the distinctness obligation FULLY PROVED (via injectivity of $\\cos$ on $[0,\\pi]$ / linear node spacing). States `equidistant_diverges` ($\\Lambda_n\\geq2^{n-1}/n^2$ for equidistant nodes — `sorry`).",
+      "mathContext": "Chebyshev $x_k=\\cos\\frac{(2k+1)\\pi}{2n}$; equidistant $x_k=-1+\\frac{2k}{n-1}$ with $\\Lambda_n\\geq2^{n-1}/n^2$."
+    },
+    {
+      "id": "convergence-conditions",
+      "title": "Part IX: Convergence Conditions",
+      "startLine": 319,
+      "endLine": 327,
+      "summary": "A docstring summarizing classical convergence criteria: uniform convergence iff $\\Lambda_n\\cdot\\omega(f,1/n)\\to0$; Lipschitz functions converge when $\\Lambda_n=O(\\log n)$; analytic functions converge for any node sequence. No declarations.",
+      "mathContext": "Uniform $L^nf\\to f$ iff $\\Lambda_n\\,\\omega(f,1/n)\\to0$; analytic $f$ always converge."
+    },
+    {
+      "id": "pointwise-uniform",
+      "title": "Part X: Pointwise vs Uniform Convergence",
+      "startLine": 328,
+      "endLine": 338,
+      "summary": "States Faber's theorem `faber`: no node sequence yields convergence for all continuous $f$ (`sorry`). A note contrasts pointwise vs uniform convergence.",
+      "mathContext": "Faber: no node sequence gives convergence for every $f\\in C[-1,1]$."
+    },
+    {
+      "id": "measure-theoretic",
+      "title": "Part XI: Measure-Theoretic Aspects",
+      "startLine": 339,
+      "endLine": 354,
+      "summary": "States two measure-theoretic results (both `sorry`): `positive_measure_divergence` (for some $f$, the divergence set has positive measure) and `full_measure_convergence` (for some sequence and $f$, the convergence set has full measure).",
+      "mathContext": "Divergence on positive-measure sets vs convergence on full-measure sets (both stated, sorry)."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Part XII: The Main Conjecture",
+      "startLine": 355,
+      "endLine": 377,
+      "summary": "Defines `MainConjecture` ($\\text{Question1}\\leftrightarrow\\text{Question2}$), declared OPEN via the axiom `main_conjecture_open`. PROVES `q2_fails_implies`: if Question 2 fails, then every all-$x$-unbounded sequence admits a continuous $f$ with no convergence point.",
+      "mathContext": "Main conjecture: Q1 $\\leftrightarrow$ Q2 (open). $\\neg$Q2 $\\Rightarrow$ full divergence for some $f$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 378,
+      "endLine": 397,
+      "summary": "Closing docstring recapping the problem (OPEN, $250 prize), the two questions, the known Bernstein/Erdős–Vértesi results, and the key remaining sorries (`bernstein`, `erdos_vertesi`) and open-question axioms (`question1_open`, `question2_open`).",
+      "mathContext": "Recap: 7 sorries (classical/measure results) + 3 axioms (the open questions/conjecture)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #671 (Lagrange interpolation convergence) gallery `meta.json` had heavy **section drift**.

- Sections used a compressed older grouping (§I-II, §III, §IV-V, §VI-VII, §VIII-XII) whose ranges had drifted: §III labeled @77 but really @115; the §VIII-XII group started @153 but Part VIII really @256.
- Coverage stopped at line **249** of a **397**-line file — hiding Parts VIII (tail), IX (convergence conditions), X (Faber's theorem), XI (measure-theoretic results), XII (main conjecture), and the closing Summary.

## Changes
- Rebuilt **14 sections** (was 5) mapped one-to-one to the file's `## Part N` banners plus header and summary, full coverage **1-397**, with accurate `mathContext`.
- Each section's prose matches the real proof state — which lemmas are proved vs the **7 genuine sorries** (`bernstein`, `lebesgueConstant_growth`, `erdos_vertesi`, `equidistant_diverges`, `faber`, `positive_measure_divergence`, `full_measure_convergence`) and **3 open-question axioms** (`question1_open`, `question2_open`, `main_conjecture_open`).
- **Counts already correct**: 15 theorems / 13 definitions (includes the `InterpolationPoints` structure) / 3 axioms / 7 sorries, lineCount 397.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-397 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-671
- [x] Section ranges re-verified against the `## Part N` banners in `Erdos671Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)