### PR TITLE
research(sqrt2-from-axioms-oq-01): realign drifted gallery sections to PART banners

### DIFF
--- a/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
@@ -70,14 +70,14 @@
       "id": "divisibility",
       "title": "Divisibility (Built from Scratch)",
       "startLine": 48,
-      "endLine": 83,
+      "endLine": 81,
       "summary": "Defines `Divides p n` as $\\exists k, n = p \\cdot k$ with basic lemmas: every number divides 0 and itself, divisibility through multiplication, and small numbers less than $p$ are not divisible by $p$",
       "mathContext": "Custom divisibility: $p \\mid n \\;\\Leftrightarrow\\; \\exists k,\\, n = p \\cdot k$. Lemmas: $p \\mid 0$, $p \\mid p$, $p \\mid n \\implies p \\mid mn$, and $0 < n < p \\implies p \\nmid n$."
     },
     {
       "id": "primality",
       "title": "Primality via Euclid's Criterion",
-      "startLine": 84,
+      "startLine": 82,
       "endLine": 97,
       "summary": "Defines `EuclidPrime p` as $p > 1$ and $p \\mid ab \\Rightarrow p \\mid a \\lor p \\mid b$. This is the exact property needed for irrationality proofs, equivalent to classical primality via Bezout's identity",
       "mathContext": "Euclid's criterion as definition of primality: $\\text{EuclidPrime}(p) \\;:\\Leftrightarrow\\; p > 1 \\,\\wedge\\, (p \\mid ab \\Rightarrow p \\mid a \\lor p \\mid b)$. Equivalent to the classical definition via B\\u00e9zout's identity $\\gcd(a,p)=1 \\implies \\exists x,y,\\, ax+py=1$."
@@ -86,49 +86,41 @@
       "id": "small-primes",
       "title": "Verifying Small Primes",
       "startLine": 98,
-      "endLine": 153,
+      "endLine": 152,
       "summary": "Proves 2, 3, and 5 satisfy Euclid's criterion using modular arithmetic (`Nat.mul_mod`). For prime $p$, the verification reduces to checking that $\\mathbb{Z}/p\\mathbb{Z}$ has no zero divisors",
       "mathContext": "Verification that $p \\in \\{2,3,5\\}$ satisfies Euclid's criterion by exhaustive case analysis on residues: for $a,b \\in \\mathbb{Z}/p\\mathbb{Z}$, $ab \\equiv 0 \\pmod{p} \\implies a \\equiv 0$ or $b \\equiv 0$."
     },
     {
       "id": "bridge",
       "title": "Bridge to Mathlib",
-      "startLine": 154,
-      "endLine": 173,
+      "startLine": 153,
+      "endLine": 172,
       "summary": "Proves every `Nat.Prime` is an `EuclidPrime`, connecting our from-axioms development to Mathlib's library for users who need the classical definition",
       "mathContext": "Bridge theorem: $\\text{Nat.Prime}(p) \\implies \\text{EuclidPrime}(p)$, using Mathlib's `Nat.Prime.dvd_mul` to show the classical definition implies the multiplicative property."
     },
     {
       "id": "key-lemma",
       "title": "Key Lemma: Prime Divides Square Implies Divides Base",
-      "startLine": 174,
-      "endLine": 195,
+      "startLine": 173,
+      "endLine": 188,
       "summary": "Proves $p$ prime and $p \\mid n^2 \\Rightarrow p \\mid n$. With Euclid's criterion as definition, this is a two-line proof: $p \\mid n \\cdot n$ gives $p \\mid n \\lor p \\mid n$, so $p \\mid n$",
       "mathContext": "Key lemma: $p \\mid n^2 \\implies p \\mid n$ for $\\text{EuclidPrime}(p)$. Proof: $n^2 = n \\cdot n$, so $p \\mid n \\cdot n \\implies p \\mid n \\lor p \\mid n$, hence $p \\mid n$."
     },
     {
       "id": "coprimality",
       "title": "Coprimality Modulo p",
-      "startLine": 192,
-      "endLine": 199,
+      "startLine": 189,
+      "endLine": 200,
       "summary": "Defines \\ as ¬(p | a ∧ p | b)—a weaker form of coprimality that generalizes \"not both even\" from the √2 proof. Full coprimality (gcd = 1) would require building GCD from scratch",
       "mathContext": "Coprimality modulo $p$: $\\text{CoprimeMod}(p, a, b) \\;:\\Leftrightarrow\\; \\neg(p \\mid a \\,\\wedge\\, p \\mid b)$. Generalizes \"not both even\" ($p=2$) to arbitrary primes. Weaker than $\\gcd(a,b) = 1$ but sufficient for the descent argument."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: √p is Irrational",
-      "startLine": 197,
-      "endLine": 261,
+      "startLine": 201,
+      "endLine": 257,
       "summary": "Proves that for any Euclid prime $p$, if $a^2 = p \\cdot b^2$ with $b > 0$, then $p$ divides both $a$ and $b$. Includes helper lemmas for the arithmetic cancellation step ($p^2k^2 = pb^2 \\Rightarrow pk^2 = b^2$)",
       "mathContext": "Main theorem: $\\text{EuclidPrime}(p) \\,\\wedge\\, a^2 = p \\cdot b^2 \\,\\wedge\\, b > 0 \\implies p \\mid a \\,\\wedge\\, p \\mid b$. Descent: from $a^2 = pb^2$, get $p \\mid a$, write $a = pk$, then $(pk)^2 = pb^2 \\implies p k^2 = b^2 \\implies p \\mid b$."
-    },
-    {
-      "id": "instances",
-      "title": "Concrete Instances and Applications",
-      "startLine": 262,
-      "endLine": 300,
-      "summary": "Derives $\\sqrt{2}$, $\\sqrt{3}$, $\\sqrt{5}$ irrationality as immediate corollaries, plus a general bridge theorem for any Mathlib-certified prime",
-      "mathContext": "Corollaries: $\\nexists\\, a,b \\in \\mathbb{N},\\; b > 0 \\,\\wedge\\, \\text{CoprimeMod}(p,a,b) \\,\\wedge\\, a^2 = p b^2$ for $p \\in \\{2, 3, 5\\}$, i.e., $\\sqrt{2}, \\sqrt{3}, \\sqrt{5} \\notin \\mathbb{Q}$. General bridge: $\\text{Nat.Prime}(p) \\implies \\sqrt{p} \\notin \\mathbb{Q}$."
     },
     {
       "id": "alt-formulation",
@@ -139,9 +131,17 @@
       "mathContext": "Contrapositive form: $a^2 = p b^2 \\implies b = 0 \\;\\lor\\; (p \\mid a \\,\\wedge\\, p \\mid b)$. No coprimality hypothesis needed; the conclusion directly says the fraction $a/b$ is not in lowest terms."
     },
     {
+      "id": "instances",
+      "title": "Concrete Instances and Applications",
+      "startLine": 278,
+      "endLine": 301,
+      "summary": "Derives $\\sqrt{2}$, $\\sqrt{3}$, $\\sqrt{5}$ irrationality as immediate corollaries, plus a general bridge theorem for any Mathlib-certified prime",
+      "mathContext": "Corollaries: $\\nexists\\, a,b \\in \\mathbb{N},\\; b > 0 \\,\\wedge\\, \\text{CoprimeMod}(p,a,b) \\,\\wedge\\, a^2 = p b^2$ for $p \\in \\{2, 3, 5\\}$, i.e., $\\sqrt{2}, \\sqrt{3}, \\sqrt{5} \\notin \\mathbb{Q}$. General bridge: $\\text{Nat.Prime}(p) \\implies \\sqrt{p} \\notin \\mathbb{Q}$."
+    },
+    {
       "id": "educational-notes",
       "title": "Educational Notes and Extensions",
-      "startLine": 304,
+      "startLine": 302,
       "endLine": 365,
       "summary": "Documents the correspondence between the √2 and √p proofs, explains the relationship between Euclid's criterion and the classical prime definition via Bézout's identity, and discusses limitations for non-prime radicands like √6",
       "mathContext": "Documents the correspondence between the √2 and √p proofs, explains the relationship between Euclid's criterion and the classical prime definition via Bézout's identity, and discusses limitations for non-prime radicands like √6"


### PR DESCRIPTION
## Summary
- The 10 gallery sections for `sqrt2-from-axioms-oq-01` had drifted to an older file layout: section ranges **overlapped** (`key-lemma` 174-195 vs `coprimality` 192-199; `main-theorem` 197-261 vs `alt-formulation` 258-277) and were **out of order** (`alt-formulation` listed *after* `instances`).
- Realigned all 10 sections to the Lean file's `PART 1`–`PART 10` banners, tiling contiguously **48→365** in file order with no overlaps.
- Summaries and `mathContext` left unchanged — they were already accurate, only the line ranges and ordering had drifted.

## Verification
- Ground truth: `proofs/Proofs/Sqrt2FromAxiomsOQ01.lean` @ origin/main, 365 lines, banners confirmed via grep.
- No Lean change; metrics in `leanFile` already correct (365 LOC). Build-free, data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)