### PR TITLE
research(erdos-203): realign drifted gallery sections to full file (8→11)

### DIFF
--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -79,70 +79,83 @@
       "Number theory (primes, divisibility)"
     ]
   },
-  "sections": [
+  "sections":   [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Module docstring for Erdős Problem #203 (the Sierpiński/covering-system question: which $k$ make $k\\cdot2^n+1$ composite for all $n$) and imports."
+    },
     {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "candidateNumber, AvoidsPrimes, AvoidingSet",
+      "title": "Part 1: Basic Definitions",
       "startLine": 27,
-      "endLine": 42,
-      "mathContext": "Mathematical content: candidateNumber, AvoidsPrimes, AvoidingSet"
+      "endLine": 38,
+      "summary": "Core definitions: `candidateNumber`, `AvoidsPrimes`, and `AvoidingSet`."
     },
     {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "summary": "ErdosConjecture203, conjecture_equiv",
-      "startLine": 43,
-      "endLine": 62,
-      "mathContext": "Mathematical content: ErdosConjecture203, conjecture_equiv"
+      "title": "Part 2: The Main Conjecture",
+      "startLine": 39,
+      "endLine": 54,
+      "summary": "`ErdosConjecture203` (the main statement) and `conjecture_equiv` (an equivalent formulation)."
     },
     {
       "id": "sierpinski",
-      "title": "Sierpinski Numbers",
-      "summary": "IsSierpinskiNumber, selfridge_sierpinski, sierpinski_exists",
-      "startLine": 63,
-      "endLine": 89,
-      "mathContext": "Mathematical content: IsSierpinskiNumber, selfridge_sierpinski, sierpinski_exists"
+      "title": "Part 3: Sierpinski Numbers",
+      "startLine": 55,
+      "endLine": 128,
+      "summary": "`IsSierpinskiNumber`, `SierpinskiSet`, and the Selfridge result: 78557 is a Sierpiński number (`selfridge_sierpinski`, `selfridge_sierpinski_is_sierpinski`) proved via the covering system $\\{3,5,7,13,19,37,73\\}$ of period 36, with power-periodicity and modular divisibility-transfer lemmas. Also `sierpinski_exists` and `sierpinski_necessary_not_sufficient`."
     },
     {
       "id": "covering",
-      "title": "Covering Systems",
-      "summary": "IsCoveringSystem, PrimeCovering, covering_implies_sierpinski",
-      "startLine": 90,
-      "endLine": 109,
-      "mathContext": "Mathematical content: IsCoveringSystem, PrimeCovering, covering_implies_sierpinski"
+      "title": "Part 4: Covering Systems",
+      "startLine": 129,
+      "endLine": 140,
+      "summary": "`IsCoveringSystem` and `PrimeCovering`: the covering-system framework underlying Sierpiński numbers."
     },
     {
       "id": "extended",
-      "title": "Extended Problem",
-      "summary": "IsExtendedAvoiding, ExtendedDivisibility, ord2, ord3",
-      "startLine": 110,
-      "endLine": 137,
-      "mathContext": "Mathematical content: IsExtendedAvoiding, ExtendedDivisibility, ord2, ord3"
+      "title": "Part 5: The Extended Problem — 2D Covering Systems",
+      "startLine": 141,
+      "endLine": 155,
+      "summary": "`ExtendedDivisibility`, `Covers2D`, and `IsCoveringSystem2D`: the two-dimensional generalization."
     },
     {
-      "id": "constraints",
-      "title": "Constraints and Small Cases",
-      "summary": "coprime_6_equiv, base_case, one_fails, five_fails",
-      "startLine": 138,
-      "endLine": 179,
-      "mathContext": "Mathematical content: coprime_6_equiv, base_case, one_fails, five_fails"
+      "id": "small-cases",
+      "title": "Part 6: Small Cases and Constraints",
+      "startLine": 156,
+      "endLine": 304,
+      "summary": "Small-case analysis and constraints: `coprime_6_equiv`, `base_case`, candidate positivity/recurrence (`candidate_pos/_base/_k1/_l1`), and concrete elimination lemmas (`one_fails`, `five_fails`, `seven_fails`, …) — the bulk of the proved content, previously partly hidden by section drift."
+    },
+    {
+      "id": "relationship",
+      "title": "Part 7: Relationship between Sierpinski and Problem 203",
+      "startLine": 305,
+      "endLine": 343,
+      "summary": "Links the avoiding-set problem to Sierpiński numbers: `avoiding_implies_sierpinski_like`, `avoiding_implies_base3_like`, `coprime6_implies_odd`, `avoiding_is_sierpinski`, and `problem203_stronger_than_sierpinski`."
+    },
+    {
+      "id": "candidate-growth",
+      "title": "Part 8: Candidate Growth",
+      "startLine": 344,
+      "endLine": 353,
+      "summary": "`candidate_ge_succ`: monotone growth of the candidate numbers."
     },
     {
       "id": "generalizations",
-      "title": "Generalized Problems",
-      "summary": "IsGeneralizedAvoiding, QuadraticProductAvoiding",
-      "startLine": 180,
-      "endLine": 199,
-      "mathContext": "Mathematical content: IsGeneralizedAvoiding, QuadraticProductAvoiding"
+      "title": "Part 9: Generalized Problems",
+      "startLine": 354,
+      "endLine": 375,
+      "summary": "`IsGeneralizedAvoiding` and monotonicity lemmas `candidate_mono_k`, `candidate_mono_l`."
     },
     {
       "id": "status",
-      "title": "Problem Status",
-      "summary": "erdos_203_status, erdos_203_statement",
-      "startLine": 200,
-      "endLine": 255,
-      "mathContext": "Mathematical content: erdos_203_status, erdos_203_statement"
+      "title": "Part 10: Problem Status",
+      "startLine": 376,
+      "endLine": 390,
+      "summary": "`erdos_203_statement`: the formal problem-status statement summarizing what is proved and what remains open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section metadata for **erdos-203** (the Sierpiński / covering-system problem: which $k$ make $k\cdot2^n+1$ composite for all $n$) had drifted to an older layout:
- **Missing header** (lines 1-26 uncovered)
- Every range line-shifted off the file's `/- Part N -/` banners
- The Sierpiński section lumped away the Selfridge covering-system proof
- The entire **tail (256-390) was uncovered** — sections stopped at line 255 of 390

Rebuilt to the file's 11 actual banners (header + Parts 1-10), giving contiguous full-file coverage **1-390**.

## Highlights (8 → 11 sections)
- `small-cases` (Part 6, 156-304): the bulk of the proved content (`base_case`, candidate recurrences, `one_fails`/`five_fails`/`seven_fails`, …)
- `relationship` (Part 7): Sierpiński ↔ Problem-203 links (`avoiding_is_sierpinski`, `problem203_stronger_than_sierpinski`)
- `candidate-growth` (Part 8), `generalizations` (Part 9), `status` (Part 10) — all previously uncovered

## Verification
- Metadata-only; Lean source untouched
- Counts already correct and unchanged: **0 axioms / 44 theorems / 13 defs / 0 sorries**
- Sections verified contiguous (1-390, no gaps/overlaps), valid JSON; diff scoped to the `sections` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)