### PR TITLE
research(erdos-409): realign drifted gallery sections to full file (10→8)

### DIFF
--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -45,86 +45,62 @@
       "Number theory (primes, divisibility)"
     ]
   },
-  "sections": [
+  "sections":   [
     {
-      "id": "imports",
-      "title": "Imports and Dependencies",
-      "startLine": 24,
-      "endLine": 30,
-      "summary": "Imports Mathlib's Euler totient $\\varphi(n) = |\\{k \\leq n : \\gcd(k,n) = 1\\}|$, primality, and the filter framework for $o(\\cdot)$ asymptotics.",
-      "mathContext": "Mathematical content: Imports Mathlib's Euler totient $\\varphi(n) = |\\{k \\leq n : \\gcd(k,n) = 1\\}|$, primality, and the filter framework for $o(\\cdot)$ asymptotics."
+      "id": "header",
+      "title": "Header, Context, and Imports",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Module docstring for Erdős Problem #409 (iterating $n \\mapsto \\varphi(n)+1$, the number of steps $F(n)$ to reach a prime fixed point), key context, references, and imports."
     },
     {
       "id": "core-defs",
       "title": "Core Definitions",
-      "startLine": 32,
-      "endLine": 44,
-      "summary": "Defines the totient-plus-one map $T(n) = \\varphi(n) + 1$, its $k$-th iterate $T^k(n)$ via $\\texttt{Nat.iterate}$, and the stopping time $F(n) = \\min\\{k : T^k(n) \\text{ is prime}\\}$ using $\\texttt{sSup}$.",
-      "mathContext": "Defines the totient-plus-one map $T(n) = \\varphi(n) + 1$, its $k$-th iterate $T^k(n)$ via $\\texttt{Nat.iterate}$, and the stopping time $F(n) = \\min\\{k : T^k(n) \\text{ is prime}\\}$ using $\\texttt{sSup}$."
+      "startLine": 29,
+      "endLine": 42,
+      "summary": "`totientPlusOne` ($n \\mapsto \\varphi(n)+1$), `totientIterate` (its $k$-fold iterate), and `iterationsToFirst` (the step count $F(n)$ to the first prime)."
     },
     {
       "id": "termination",
       "title": "Termination and Descent",
-      "startLine": 46,
-      "endLine": 131,
-      "summary": "Proves that every orbit reaches a prime: $\\forall n > 0,\\; \\exists k,\\; T^k(n)$ is prime. The key lemma `iterate_decreasing` shows $T(n) < n$ for composite $n > 1$ via Finset reasoning (0 and minFac are non-coprime elements in range $n$, giving $\\varphi(n) \\leq n - 2$). Termination follows by strong induction on $n$.",
-      "mathContext": "Proves that every orbit reaches a prime: $\\forall n > 0,\\; \\exists k,\\; T^k(n)$ is prime. The key lemma `iterate_decreasing` shows $T(n) < n$ for composite $n > 1$ via Finset reasoning (0 and minFac are non-coprime elements in range $n$, giving $\\varphi(n) \\leq n - 2$). Termination follows by strong induction on $n$."
+      "startLine": 43,
+      "endLine": 129,
+      "summary": "`iterate_decreasing` and `iteration_terminates`: the iteration strictly descends until it reaches a prime, so $F(n)$ is well-defined."
     },
     {
-      "id": "part-i",
-      "title": "Part (i): Asymptotic Bound $F(n) = o(n)$",
-      "startLine": 133,
-      "endLine": 140,
-      "summary": "The trivial bound $F(n) = o(n)$ follows from the fact that each iteration reduces $n$ by at least 1 for composites. The open question is whether $F(n) = O(\\log n)$ or even $O(\\log \\log n)$.",
-      "mathContext": "The trivial bound $F(n) = o(n)$ follows from the fact that each iteration reduces $n$ by at least 1 for composites. The open question is whether $F(n) = $O(\\$\\log n$)$$ or even $$O(\\log \\$\\log n$)$$."
-    },
-    {
-      "id": "part-ii",
-      "title": "Part (ii): Infinite Basins of Attraction",
-      "startLine": 142,
-      "endLine": 147,
-      "summary": "Asks whether some prime $p$ has $|\\{n : \\exists k,\\; T^k(n) = p\\}| = \\infty$. The basin of attraction of $p$ under $T$ --- likely infinite for small primes like 2 and 3.",
-      "mathContext": "Mathematical content: Asks whether some prime $p$ has $|\\{n : \\exists k,\\; T^k(n) = p\\}| = \\infty$. The basin of attraction of $p$ under $T$ --- likely infinite for small primes like 2 and 3."
-    },
-    {
-      "id": "part-iii",
-      "title": "Part (iii): Natural Density of Basins",
-      "startLine": 149,
-      "endLine": 153,
-      "summary": "For each prime $p$, asks whether $\\alpha(p) = \\lim_{N \\to \\infty} |\\{n \\leq N : \\exists k,\\; T^k(n) = p\\}|/N$ exists and what its value is.",
-      "mathContext": "For each prime $p$, asks whether $\\$\\alpha$(p) = \\lim_{N \\to \\infty} |\\{n \\leq N : \\exists k,\\; T^k(n) = p\\}|/N$ exists and what its value is."
+      "id": "main-questions",
+      "title": "Main Questions",
+      "startLine": 130,
+      "endLine": 145,
+      "summary": "States the three open questions as docstrings on the density theorem `erdos_409_density`: Part (i) estimate $F(n)$ (asymptotically $o(n)$), Part (ii) infinitely many $n$ reaching the same prime, Part (iii) the natural density of basins reaching a fixed prime $p$."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 155,
-      "endLine": 174,
-      "summary": "Establishes $F(p) = 0$ for primes, the criterion $F(n) = 1 \\iff \\varphi(n) + 1$ is prime, and the parity result that $\\varphi(n) + 1$ is odd for $n \\geq 3$ (since $\\varphi(n)$ is even).",
-      "mathContext": "Mathematical content: Establishes $F(p) = 0$ for primes, the criterion $F(n) = 1 \\iff \\varphi(n) + 1$ is prime, and the parity result that $\\varphi(n) + 1$ is odd for $n \\geq 3$ (since $\\varphi(n)$ is even)."
-    },
-    {
-      "id": "quantitative-bound",
-      "title": "Quantitative Bound: $F(n) \\leq n - 2$",
-      "startLine": 270,
-      "endLine": 311,
-      "summary": "Proves $F(n) \\leq n - 2$ for all $n > 1$ by strong induction: primes need 0 steps, composites $n \\geq 4$ satisfy $T(n) < n$ and $T(n) > 1$ (since $\\varphi(n) \\geq 2$), so by IH the iterate reaches a prime in $\\leq T(n) - 2 \\leq n - 3$ additional steps. Helper lemma: $\\varphi(n) \\geq 2$ for $n \\geq 3$ via evenness and positivity of the totient.",
-      "mathContext": "Proves $F(n) \\leq n - 2$ for all $n > 1$ by strong induction. The key helper is $\\varphi(n) \\geq 2$ for $n \\geq 3$, which follows from $\\varphi(n)$ being even (Nat.totient_even) and positive (Nat.totient_pos)."
+      "startLine": 146,
+      "endLine": 226,
+      "summary": "Fixed-point characterization `totientPlusOne_eq_self_iff_prime` (fixed points are exactly the primes), iterate base cases (`totientIterate_zero/_one`), `prime_zero_iterations`, `one_iteration_criterion`, and parity (`totient_plus_one_odd`)."
     },
     {
       "id": "sigma-variant",
-      "title": "Sigma Variant: $n \\mapsto \\sigma(n) - 1$",
-      "startLine": 235,
-      "endLine": 268,
-      "summary": "The companion problem using $\\sigma(n)$ instead of $\\varphi(n)$. Since $\\sigma(n) \\geq 1 + n$ for composites, $\\sigma(n) - 1 \\geq n$, so the sigma iteration is non-decreasing --- a fundamentally different dynamical regime.",
-      "mathContext": "The companion problem using $\\sigma(n)$ instead of $\\varphi(n)$. Since $\\sigma(n) \\geq 1 + n$ for composites, $\\sigma(n) - 1 \\geq n$, so the sigma iteration is non-decreasing --- a fundamentally different dynamical regime."
+      "title": "Sigma Variant: n ↦ σ(n) − 1",
+      "startLine": 227,
+      "endLine": 312,
+      "summary": "The $\\sigma$-variant of the iteration: `sigma_growing`, `sigma_prime_fixed` (primes are fixed), and `sigma_composite_growth`."
+    },
+    {
+      "id": "quantitative-bound",
+      "title": "Quantitative Bound: F(n) ≤ n − 2",
+      "startLine": 313,
+      "endLine": 389,
+      "summary": "`totient_ge_two`, `iteration_reaches_prime_in`, and `iteration_reaches_prime_half`: explicit upper bounds on the number of iterations to reach a prime."
     },
     {
       "id": "small-cases",
       "title": "Small Cases and Fixed Points",
-      "startLine": 313,
-      "endLine": 339,
-      "summary": "Concrete computations: $T(2) = 2$ (fixed point), $T(4) = 3$ (one-step example), and \\textbf{\\texttt{one\\_iteration\\_infinite}}: $F(n) = 1$ infinitely often --- proved by showing that for every odd prime $p$, $\\varphi(2p) + 1 = p$ via Euler totient multiplicativity.",
-      "mathContext": "Concrete computations: $T(2) = 2$ (fixed point, proved by $\\texttt{simp}$), $T(4) = 3$ (one-step example), and $F(n) = 1$ infinitely often since $\\{n > 1 : \\varphi(n) + 1 \\text{ is prime}\\}$ is infinite."
+      "startLine": 390,
+      "endLine": 424,
+      "summary": "Concrete small cases: `two_fixed_point`, `four_to_three`, and `one_iteration_infinite` (infinitely many $n$ reach a prime in a single step)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section metadata for **erdos-409** (iterating $n \mapsto \varphi(n)+1$ and the step count $F(n)$ to reach a prime) had drifted to a scrambled, incomplete layout:
- Ranges line-shifted off the file's `/- ## -/` banners
- `sigma-variant` and `quantitative-bound` out of order and **overlapping**
- Three spurious `part-i`/`part-ii`/`part-iii` sub-sections duplicating a single `## Main Questions` banner (the Parts are docstrings on one density theorem)
- The entire **tail (340-424) uncovered** — sections stopped at line 339

Rebuilt to the file's 8 actual banners, giving contiguous full-file coverage **1-424**.

## Note on section count (10 → 8)
The count drops because the spurious `part-i/ii/iii` split is consolidated into the real `Main Questions` section. Net effect is *more* coverage: the previously hidden `Quantitative Bound` (313-389) and `Small Cases` (390-424) are now correctly placed, and the overlapping sigma/quantitative ordering is fixed.

## Verification
- Metadata-only; Lean source untouched
- Counts already correct and unchanged: **0 axioms / 18 theorems / 3 defs / 0 sorries**
- Sections verified contiguous (1-424, no gaps/overlaps), valid JSON; diff scoped to the `sections` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)