### PR TITLE
research(erdos-678): rebuild drifted gallery sections to full file (5→9) + fix stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -96,44 +96,76 @@
   },
   "sections": [
     {
-      "id": "interval-lcm-defs",
-      "title": "§1: Interval LCM Definitions and Basic Properties",
-      "startLine": 40,
-      "endLine": 95,
-      "summary": "Defines intervalLcm n k = lcm{n+1,...,n+k} and equivalent form intervalLcm'. Proves intervalLcm_eq_intervalLcm', intervalLcm_zero (lcm of empty = 1), intervalLcm_one, intervalLcm_mono_right (monotone in k), and dvd_intervalLcm (every element divides the lcm).",
-      "mathContext": "$\\text{lcm}(n+1, n+2, \\ldots, n+k) = \\prod_{p^a \\leq k} p^{\\lfloor \\log_p(n+k) \\rfloor - \\lfloor \\log_p n \\rfloor}$. The Chebyshev function gives $\\text{lcm}(1,\\ldots,n) \\approx e^n$ (prime number theorem). For shifted intervals, the lcm depends on which prime powers land in the interval — a number-theoretic question at the heart of this problem."
+      "id": "core-definitions",
+      "title": "§1: Core Definitions",
+      "startLine": 37,
+      "endLine": 63,
+      "summary": "Defines `intervalLcm n k` = lcm{n+1,...,n+k} (the M(n,k) of the problem) and an equivalent `Finset.Icc`-based form `intervalLcm'`, then proves `intervalLcm_eq_intervalLcm'` that the two agree for k ≥ 1.",
+      "mathContext": "$M(n,k) = \\operatorname{lcm}\\{n+1, n+2, \\ldots, n+k\\}$, defined both by folding `Nat.lcm` and via `Finset.Icc (n+1) (n+k)`."
     },
     {
-      "id": "selfridge-examples",
-      "title": "§2: Selfridge's Examples and the Comparison Predicate",
-      "startLine": 97,
-      "endLine": 128,
-      "summary": "Defines erdosLcmComparison n m k: lcm{n+1,...,n+k} > lcm{m+1,...,m+k+1}. Verifies Selfridge's two concrete examples: lcm(97,...,103) > lcm(105,...,112) and lcm(133,...,139) > lcm(140,...,147). Both by native_decide. States erdos_678_infinitely_many (infinitely many such n, m) as an axiom.",
-      "mathContext": "Selfridge observed that $\\text{lcm}(97,\\ldots,103) > \\text{lcm}(105,\\ldots,112)$ despite the second interval being longer — a $k$-element interval can have larger lcm than a $(k+1)$-element interval starting later. This counterintuitive comparison arises when the longer interval contains no additional prime powers beyond those in the shorter interval, but the shorter one includes a larger prime."
+      "id": "basic-properties",
+      "title": "§2: Basic Properties of Interval LCM",
+      "startLine": 64,
+      "endLine": 93,
+      "summary": "Establishes the elementary properties: `intervalLcm_zero` (empty interval has lcm 1), `intervalLcm_one` (singleton interval equals n+1), `intervalLcm_mono_right` (monotone as the interval extends), and `dvd_intervalLcm` (each element divides the interval lcm).",
+      "mathContext": "$M(n,0)=1$, $M(n,1)=n+1$, $M(n,k) \\mid M(n,k{+}1)$, and $(n+1+i) \\mid M(n,k)$ for $i < k$."
     },
     {
-      "id": "cambie-theorem",
-      "title": "§3: Cambie's Theorem and Technical Bounds",
-      "startLine": 129,
-      "endLine": 167,
-      "summary": "Axiomatizes cambie_2024: for all sufficiently large k, any k-element interval has smaller lcm than some (k+1)-element interval — the exact content of Erdős's 1978 question. Proves prime_power_divides_intervalLcm, interval_skip_prime_power, intervalLcm_growth (lcm grows at least exponentially), and intervalLcm_chebyshev_upper bound.",
-      "mathContext": "Cambie (2024) proved that for large $k$, there always exists $n$ with $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ for some $m$ — resolving Erdős's question. The key tool is the Chebyshev upper bound $\\text{lcm}(n+1,\\ldots,n+k) \\leq e^{2.000733k}$ and explicit prime power distribution in short intervals."
+      "id": "comparison-property",
+      "title": "§3: The Erdős Comparison Property and Selfridge's Examples",
+      "startLine": 94,
+      "endLine": 115,
+      "summary": "Defines the comparison predicate `erdosLcmComparison n m k` := M(n,k) > M(m,k+1), the central object of Erdős #678, and verifies Selfridge's two concrete witnesses `selfridge_example_1` (M(96,7) > M(104,8)) and `selfridge_example_2` (M(132,7) > M(139,8)).",
+      "mathContext": "$\\text{erdosLcmComparison}(n,m,k) :\\Leftrightarrow M(n,k) > M(m,k+1)$; Selfridge's witnesses are checked by `native_decide`."
     },
     {
-      "id": "growth-rate",
-      "title": "§4: Growth Rate and the Main Theorem",
-      "startLine": 169,
-      "endLine": 187,
-      "summary": "Defines minimalN k as the smallest n where the comparison holds for all k-element intervals. Axiomatizes erdos_growth_rate: minimalN k grows superlinearly. Proves erdos_678 (existence) from the Selfridge examples. Wraps up with the complete formalization of the LCM comparison problem.",
-      "mathContext": "The function $N(k) = \\min\\{n : \\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1) \\text{ for some } m\\}$ grows faster than any linear function of $k$. The first examples (Selfridge's $k=7$ cases at $n=96$ and $n=132$) show that $N(7) \\leq 96$."
+      "id": "computing-values",
+      "title": "§4: Computing Specific LCM Values",
+      "startLine": 116,
+      "endLine": 121,
+      "summary": "Records the raw value comparison `lcm_comparison_96_104` : intervalLcm 96 7 > intervalLcm 104 8, the unfolded numeric heart of Selfridge's first example.",
+      "mathContext": "Direct decidable check that $M(96,7) > M(104,8)$."
     },
     {
-      "id": "open-questions-678",
-      "title": "§5: Open Questions on Interval LCM Comparisons",
-      "startLine": 126,
-      "endLine": 187,
-      "summary": "The formalization captures the full state: Selfridge examples (verified), Cambie's theorem (axiomatized), growth rate (axiomatized). Open: what is the exact growth rate of N(k)? Can the first comparison be found for k=6 or smaller? What is the density of n where such comparisons occur?",
-      "mathContext": "Beyond Cambie's qualitative result, quantitative questions remain: How large must the starting index $n$ be? How often does the comparison $\\text{lcm}(n+1,\\ldots,n+k) > \\text{lcm}(m+1,\\ldots,m+k+1)$ hold for random $n,m$? These connect to the distribution of prime powers in short intervals — a topic at the frontier of analytic number theory."
+      "id": "main-theorem",
+      "title": "§5: The Main Theorem (Cambie 2024)",
+      "startLine": 122,
+      "endLine": 134,
+      "summary": "States the two infinitude results that resolve Erdős #678: `erdos_678_infinitely_many` (for every N there is a comparison with k > N) and `cambie_2024` (for all sufficiently large k a comparison exists). Both are stated as theorems with `sorry` — the Lean formalization records Cambie's 2024 result without re-deriving its analytic proof.",
+      "mathContext": "Cambie (2024): $\\exists K, \\forall k \\ge K, \\exists n,m,\\ M(n,k) > M(m,k+1)$. Stated as `sorry`-backed theorems (not axioms)."
+    },
+    {
+      "id": "why-occurs",
+      "title": "§6: Why This Phenomenon Occurs",
+      "startLine": 135,
+      "endLine": 176,
+      "summary": "Develops the prime-power mechanism behind the comparison: `prime_power_divides_intervalLcm` (an interval containing p^a has lcm divisible by p^a), `intervalLcm_pos` (positivity), and `padicValNat_intervalLcm` (the p-adic valuation of M(n,k) is the supremum of the elementwise p-adic valuations).",
+      "mathContext": "$v_p(M(n,k)) = \\max_{0 \\le i < k} v_p(n+1+i)$; a shorter interval can miss a large prime power that a longer, later interval must include."
+    },
+    {
+      "id": "bounds",
+      "title": "§7: Correct Bounds on Interval LCM",
+      "startLine": 177,
+      "endLine": 214,
+      "summary": "Proves upper bounds on the interval lcm: a helper `Nat.lcm a b ≤ a*b`, `intervalLcm_le_prod` (M(n,k) is at most the product of the k consecutive elements), and the polynomial bound `intervalLcm_poly_upper` : intervalLcm n k ≤ (n+k)^k.",
+      "mathContext": "$M(n,k) \\le \\prod_{i=1}^{k}(n+i) \\le (n+k)^k$."
+    },
+    {
+      "id": "observations",
+      "title": "§8: Erdős's Observations on Growth Rate",
+      "startLine": 215,
+      "endLine": 225,
+      "summary": "Defines `minimalN k`, the least n at which a comparison holds for k-element intervals, and states `erdos_growth_rate` (n_k / k → ∞, i.e. minimalN k > C·k eventually for every C). Stated as a `sorry`-backed theorem capturing Erdős's superlinear-growth observation.",
+      "mathContext": "$n_k = \\text{minimalN}(k)$; Erdős showed $n_k/k \\to \\infty$, formalized as $\\forall C,\\ \\exists K,\\ \\forall k \\ge K,\\ n_k > Ck$ (stated with `sorry`)."
+    },
+    {
+      "id": "summary",
+      "title": "§9: Main Result Summary",
+      "startLine": 226,
+      "endLine": 236,
+      "summary": "Closes with `erdos_678` : ∃ n m k, erdosLcmComparison n m k, proved unconditionally from `selfridge_example_1` — the existence statement of the problem, settled by an explicit Selfridge witness while the full infinitude (cambie_2024) remains `sorry`.",
+      "mathContext": "$\\exists n,m,k,\\ M(n,k) > M(m,k+1)$, discharged by the explicit witness $(96,104,7)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The 5 gallery sections for `erdos-678` had drifted to an older layout: ranges **overlapped** and were **out of order** (`open-questions-678` spanned 126-187 on top of other sections), and the **entire tail** (lines 188-236: the bounds, observations, and the closing `erdos_678` summary theorem) was uncovered.
- Rebuilt to **9 sections**, one per `/-! ## ` banner in `Erdos678Problem.lean`, tiling contiguously **37→236** in file order.
- **Fixed stale prose**: the old summaries claimed `cambie_2024` and `erdos_growth_rate` were *"axiomatized"*, but the file has **0 axioms** — both are `theorem ... := by sorry` (4 sorries total). New summaries say "stated with `sorry`".

## Verification
- Ground truth: `proofs/Proofs/Erdos678Problem.lean` @ origin/main — 236 lines, 0 axioms, 4 sorries, 18 theorems, 4 defs (matches `leanFile` metrics, unchanged).
- Banners confirmed via grep; section ranges tile the file with no overlaps. Build-free, data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)