### PR TITLE
research(erdos-660): realign drifted gallery sections to file (5→6)

### DIFF
--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -89,8 +89,8 @@
     {
       "id": "definitions",
       "title": "Convex Polyhedra and Distance Definitions",
-      "startLine": 39,
-      "endLine": 70,
+      "startLine": 41,
+      "endLine": 64,
       "summary": "Defines Point3D (ℝ³ points), distances, and IsConvexPolyhedronVertices (a finite set of points in convex position in 3D). The distinct distances problem asks for the minimum number of distinct pairwise distances among n points in convex position.",
       "mathContext": "Given $n$ points $P \\subset \\mathbb{R}^3$ in convex position, let $D(P) = \\{|x-y| : x,y \\in P, x\\neq y\\}$. Erdős #660 asks: what is $\\min |D(P)|$ over all convex $n$-point sets?"
     },
@@ -98,7 +98,7 @@
       "id": "altman-2d",
       "title": "2D Analogue: Altman's Result for Convex Polygons",
       "startLine": 65,
-      "endLine": 95,
+      "endLine": 93,
       "summary": "States altman_convex_polygon_distances: an n-point convex polygon has ≥ ⌊n/2⌋ distinct distances (Altman 1963). This 2D result is the motivation for the 3D problem.",
       "mathContext": "Altman (1963): for $n$ points in convex position in $\\mathbb{R}^2$, the number of distinct distances is $\\geq \\lfloor n/2 \\rfloor$. This is tight: the regular $n$-gon achieves $\\lfloor n/2 \\rfloor$ distinct distances."
     },
@@ -106,25 +106,33 @@
       "id": "main-conjecture",
       "title": "3D Conjecture and Open Problem",
       "startLine": 94,
-      "endLine": 130,
+      "endLine": 113,
       "summary": "Axiomatizes erdos_660_conjecture: an n-point convex polyhedron has ≥ (1/2 - o(1))n distinct distances. This generalizes the 2D floor(n/2) result. The o(1) term is the main open question.",
       "mathContext": "Conjecture (Erdős): $|D(P)| \\geq (1/2 - o(1))n$ for $n$ points in convex position in $\\mathbb{R}^3$. The \\lfloor n/2\\rfloor bound from 2D may extend to 3D, but the proof requires different geometric tools. The current best lower bound is $\\Omega(n^{1/2})$."
     },
     {
       "id": "lower-bounds",
       "title": "Trivial and Conjectural Lower Bounds",
-      "startLine": 117,
-      "endLine": 160,
+      "startLine": 114,
+      "endLine": 131,
       "summary": "Proves trivial_lower_bound: ≥ 1 distinct distance (trivially, for n ≥ 2). States linear_lower_bound_conjecture: ≥ cn for some c > 0. The gap between Ω(n^{1/2}) and the conjectured Ω(n) is the main challenge.",
       "mathContext": "Known: $|D(P)| = \\Omega(n^{1/2})$ for any $n$ points (not necessarily convex). Conjectured: $|D(P)| = \\Omega(n)$ for convex position. The Guth-Katz theorem (2015) proves $|D| = \\Omega(n/\\log n)$ for arbitrary point sets in $\\mathbb{R}^2$."
     },
     {
-      "id": "3d-geometry",
-      "title": "3D Geometric Constraints",
-      "startLine": 160,
+      "id": "special-cases",
+      "title": "Special Cases and Constructions",
+      "startLine": 132,
+      "endLine": 167,
+      "summary": "Computes the distinct-distance counts for the Platonic solids: regular tetrahedron (1 distinct distance), cube (3), regular octahedron (2), regular dodecahedron (20 vertices), and regular icosahedron (12 vertices). These small symmetric examples illustrate how high symmetry minimizes the number of distinct distances.",
+      "mathContext": "Regular tetrahedron: 4 vertices, 1 distinct distance. Cube: 8 vertices, 3 distinct distances. Regular octahedron: 6 vertices, 2 distinct distances. High symmetry collapses many pairwise distances to a common value, giving the extremal small cases."
+    },
+    {
+      "id": "related-distances",
+      "title": "Related: General Distinct Distances Problem",
+      "startLine": 168,
       "endLine": 179,
-      "summary": "Discusses the additional geometric constraints in 3D: convex polyhedra have faces, edges, vertices (Euler's formula V-E+F=2), and the combinatorial structure limits coincidences among distances.",
-      "mathContext": "In $\\mathbb{R}^3$, convex polyhedra satisfy Euler's formula $V - E + F = 2$. For $n = V$ vertices, the number of edges is $E \\leq 3n - 6$ (Euler), giving at most $3n-6$ distinct edge lengths. Whether the number of diagonal distances is $\\Omega(n)$ remains open."
+      "summary": "States the Guth-Katz Theorem (2015): any n points in ℝ² determine Ω(n/log n) distinct distances, resolving the Erdős distinct distances problem in the plane up to the logarithmic factor. Provides context for the harder convex-position and 3D variants.",
+      "mathContext": "Guth-Katz (2015): $n$ points in $\\mathbb{R}^2$ determine $\\Omega(n/\\log n)$ distinct distances. This nearly resolves the general (non-convex) planar distinct distances problem; the convex-position refinement (#660) seeks a sharper $(1/2-o(1))n$ bound in 3D."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Gallery sections for `erdos-660` (Distinct distances of convex polyhedra in ℝ³) had drifted from an older revision of `Erdos660Problem.lean`. The section ranges no longer matched the six `/-! ## ` banners in the file.

### What was wrong
- Missing **Special Cases and Constructions** section (Platonic-solid distinct-distance counts, lines 132–167)
- Missing **Related: General Distinct Distances Problem** section (Guth-Katz 2015, lines 168–179)
- Phantom **3D Geometric Constraints** section (Euler V−E+F=2) describing content that does not appear in the file
- The four real sections pointed at stale, overlapping ranges

### Fix
- Realigned the four genuine sections to their banner boundaries
- Dropped the phantom section; added the two missing real sections
- Sections now tile lines 41–179 contiguously (5 → 6 sections)
- Lean counts (0 axiom / 10 theorem / 10 def / 10 sorry / 179 lines) were already correct — no count changes needed

## Test plan
- [x] `jq empty` validates meta.json
- [x] Section ranges verified against `/-! ## ` banners in the Lean source
- [x] Each section title matches the declarations in its range