### PR TITLE
Enrich erdos-152-oq-01: remove duplicate section + reorder Setup

### DIFF
--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -47,41 +47,36 @@
   },
   "sections": [
     {
+      "id": "sidon-definition",
+      "title": "Setup: Sidon Sets and Sumsets over Finsets",
+      "startLine": 1,
+      "endLine": 17,
+      "summary": "File header and definitions: IsSidonFinset A states all pairwise sums a+b (a ≤ b) are distinct (the B₂ property). The sumset A+A is defined as {a+b : a,b ∈ A}. The minimal element and maximal element functions are used throughout. Imports the parent Erdos152Problem.lean.",
+      "mathContext": "A Finset $A \\subseteq \\mathbb{N}$ is Sidon if the sums $a + b$ for $a \\leq b$ are all distinct. This gives $|A+A| = \\binom{|A|}{2} + |A| = \\frac{|A|(|A|+1)}{2}$. For $|A| = n$, the sumset spans a range of roughly $2 \\max A$, leaving $\\sim 2\\max A - n^2/2$ gaps."
+    },
+    {
       "id": "endpoint-lemmas",
       "title": "Helper Lemmas: Endpoint Isolation Conditions",
       "startLine": 18,
       "endLine": 76,
-      "summary": "Four private lemmas prove when 2·min±1 and 2·max±1 are absent from A+A: min_sum_left_isolated (2·min−1 below minimum sum), min_sum_right_isolated (2·min+1 needs min+1∈A), max_sum_left_isolated (2·max−1 needs max−1∈A), max_sum_right_isolated (2·max+1 above maximum sum)."
+      "summary": "Four private lemmas prove when 2·min±1 and 2·max±1 are absent from A+A: min_sum_left_isolated (2·min−1 below minimum sum), min_sum_right_isolated (2·min+1 needs min+1∈A), max_sum_left_isolated (2·max−1 needs max−1∈A), max_sum_right_isolated (2·max+1 above maximum sum).",
+      "mathContext": "For $A$ with $\\min A = m,\\ \\max A = M$: $2m-1 \\notin A+A$ (below $2m$); $2m+1 \\notin A+A$ unless $m+1 \\in A$; $2M-1 \\notin A+A$ unless $M-1 \\in A$; $2M+1 \\notin A+A$ (above $2M$). These bound the four near-endpoint sums."
     },
     {
       "id": "no-consecutive-case",
       "title": "Easy Case: No Consecutive Pair",
       "startLine": 78,
-      "endLine": 131,
-      "summary": "two_isolated_no_consecutive: if min+1∉A and max−1∉A, both 2·min and 2·max are isolated, giving isolatedCount ≥ 2 via Finset.card_pair."
+      "endLine": 132,
+      "summary": "two_isolated_no_consecutive: if min+1∉A and max−1∉A, both 2·min and 2·max are isolated, giving isolatedCount ≥ 2 via Finset.card_pair.",
+      "mathContext": "If $m+1 \\notin A$ and $M-1 \\notin A$, then by the endpoint lemmas $2m$ and $2M$ are both isolated in $A+A$; since $2m < 2M$ they are distinct, so $\\mathrm{isolatedCount}(A) \\geq |\\{2m, 2M\\}| = 2$."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: gap_existence_two",
       "startLine": 133,
       "endLine": 319,
-      "summary": "gap_existence_two: for Sidon A with |A| ≥ 7 and min ≥ 1, proves isolatedCount ≥ 2 by case analysis: no consecutive pair (easy case), one pair at max (uses second-smallest s₂; Sidon prevents s₂+1∈A), one pair at min (symmetric), both pairs (contradiction for |A| ≥ 7)."
-    },
-    {
-      "id": "sidon-definition",
-      "title": "Setup: Sidon Sets and Sumsets over Finsets",
-      "startLine": 1,
-      "endLine": 17,
-      "summary": "File header and definitions: IsSidonFinset A states all pairwise sums a+b (a ≤ b) are distinct (the B₂ property). The sumset A+A is defined as {a+b : a,b ∈ A}. The minimal element and maximal element functions are used throughout.",
-      "mathContext": "A Finset $A \\subseteq \\mathbb{N}$ is Sidon if the sums $a + b$ for $a \\leq b$ are all distinct. This gives $|A+A| = \\binom{|A|}{2} + |A| = \\frac{|A|(|A|+1)}{2}$. For $|A| = n$, the sumset spans a range of roughly $2 \\max A$, leaving $\\sim 2\\max A - n^2/2$ gaps."
-    },
-    {
-      "id": "conclusion-open",
-      "title": "Open Question: From 2 to k Isolated Elements",
-      "startLine": 133,
-      "endLine": 319,
-      "summary": "The main theorem gap_existence_two proves ≥ 2 isolated elements for Sidon sets of size ≥ 7 with min ≥ 1, under a consecutive-pair condition. The full Erdős conjecture asks: does every Sidon set have ≥ 2 isolated elements in A+A without auxiliary conditions?",
-      "mathContext": "An element $s \\in A+A$ is isolated if $s-1 \\notin A+A$ and $s+1 \\notin A+A$. The theorem proves $|\\{\\text{isolated elements in } A+A\\}| \\geq 2$ under mild technical conditions. Erdős's full conjecture removes these conditions. The gap between the endpoint isolation lemmas (which give isolated boundary elements) and truly interior isolated elements is the key challenge."
+      "summary": "gap_existence_two: for Sidon A with |A| ≥ 7 and min ≥ 1, proves isolatedCount ≥ 2 by case analysis: no consecutive pair (easy case), one pair at max (uses second-smallest s₂; Sidon prevents s₂+1∈A), one pair at min (symmetric), both pairs (contradiction for |A| ≥ 7).",
+      "mathContext": "An element $s \\in A+A$ is isolated if $s\\pm1 \\notin A+A$. For Sidon $A$ with $|A| \\geq 7$ and $\\min A \\geq 1$: $\\mathrm{isolatedCount}(A) \\geq 2$. Sidon difference-injectivity allows at most one consecutive pair $\\{x, x+1\\} \\subseteq A$, splitting the proof into four cases that each exhibit two isolated sums."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-152-oq-01` (Two Isolated Elements in Sidon Sumsets). The `sections` array had a duplicate and a mis-ordered entry.

- **Removed a spurious duplicate section.** "Open Question: From 2 to k Isolated Elements" had the exact same range `[133-319]` as the `main-theorem` section. `Erdos152OQ01.lean` ends with `gap_existence_two` at line 319 — there is no separate open-question region in the file (that framing already lives in `conclusion.openQuestions`).
- **Reordered the Setup section.** "Setup: Sidon Sets and Sumsets" `[1-17]` had drifted to 4th position (after the main theorem); moved it to the front.
- Extended "Easy Case" `endLine` `131 → 132` to meet the main theorem at 133.
- Added `mathContext` to the `endpoint-lemmas` and `no-consecutive-case` sections, which previously had none.

Sections are now ordered and cover the file (`1-319`): Setup → Helper Lemmas → Easy Case → Main Theorem.

## Notes

- Only `meta.json` for this slug is modified.