### PR TITLE
audit(cevas-theorem-oq-04): clean — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2009,9 +2009,9 @@
       "result": "clean"
     },
     "cevas-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:20:48Z",
+      "lastAudited": "2026-06-14T23:53:04Z",
       "result": "clean"
     },
     "chebyshev-bounds": {


### PR DESCRIPTION
## Gallery Integrity Audit: clean

**Proof**: cevas-theorem-oq-04 (Ceva's Theorem via Mass Point Geometry)

Verified meta.json claims against Lean source (main + OQ01 companion):

| Check | meta | source | OK |
|-------|------|--------|----|
| sorries | 0 | 0 (both files) | ✓ |
| axiomCount | 0 | 0 (both files) | ✓ |
| theoremCount | 22 / 11 | 22 / 11 | ✓ |
| definitionCount | 4 / 4 | 4 / 4 (1 structure + 3 noncomputable def each) | ✓ |
| True stubs | — | none | ✓ |

No overclaim: top-level status/badge are null; description is honestly scoped to a constructive mass-point certificate, no famous-theorem inflation.

Tracker bump only (auditCount 3→4).

---
Discovered during gallery integrity audit loop.