### PR TITLE
research(fourier-series-oq-02): realign drifted gallery sections to full file (11→10)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -135,92 +135,84 @@
   },
   "sections": [
     {
-      "id": "holder-setup",
-      "title": "Hölder Continuity on the Circle",
-      "startLine": 48,
-      "endLine": 72,
-      "summary": "Defines `IsHolderOnCircle` using Mathlib's `HolderWith`. Proves Hölder ⟹ continuous and Lipschitz ⟹ Hölder(1).",
-      "mathContext": "A function $f$ is $(C, \\alpha)$-Hölder iff $|f(x) - f(y)| \\leq C \\cdot d(x,y)^\\alpha$. Lipschitz = Hölder(1)."
+      "id": "overview-setup",
+      "title": "Overview & Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring stating the research question (OQ-02: optimal Fourier coefficient decay under Hölder continuity), the main result, and the half-period translation proof technique. Imports Mathlib's Fourier/Hölder infrastructure plus the two companion files (Incomplete01, OQ04), sets maxHeartbeats, opens the relevant namespaces, and opens `noncomputable section FourierHolderDecay`.",
+      "mathContext": "Goal: for $\\alpha$-Hölder $f$ on $\\mathbb{R}/T\\mathbb{Z}$, $\\|\\hat{c}_n(f)\\| \\leq \\tfrac{C}{2}(T/2|n|)^\\alpha$, proved via translating by the half-period $T/(2n)$."
+    },
+    {
+      "id": "holder-circle",
+      "title": "Part I — Hölder Continuity on the Circle",
+      "startLine": 50,
+      "endLine": 74,
+      "summary": "Defines `IsHolderOnCircle C α f` via Mathlib's `HolderWith`. Proves `holder_continuous` (Hölder ⟹ continuous) and `lipschitz_is_holder_one` (Lipschitz is exactly the α = 1 case).",
+      "mathContext": "A function $f$ is $(C,\\alpha)$-Hölder iff $|f(x)-f(y)| \\leq C\\,d(x,y)^\\alpha$; Lipschitz = Hölder(1)."
     },
     {
       "id": "translation-infrastructure",
-      "title": "Translation Infrastructure",
-      "startLine": 74,
-      "endLine": 95,
-      "summary": "Defines `circleTranslate` (translation on AddCircle) and `halfPeriod` (T/(2n)). Proves `fourier_norm_one`: ‖e_n(x)‖ = 1 via Mathlib's fourier_apply and toCircle.",
-      "mathContext": "The half-period $h = T/(2n)$ satisfies $e_{-n}(x + h) = -e_{-n}(x)$ because $e^{-\\pi i} = -1$."
+      "title": "Part II — Translation Infrastructure",
+      "startLine": 75,
+      "endLine": 93,
+      "summary": "Defines `circleTranslate s x = x + ↑s` and `halfPeriod T n = T/(2n)` (0 when n = 0). Proves `fourier_norm_one`: ‖e_n(x)‖ = 1 for all x, since `fourier n x` lands on the unit circle (`fourier_apply`).",
+      "mathContext": "The half-period $h = T/(2n)$ is chosen so that $e_{-n}(x+h) = -e_{-n}(x)$, since $e^{-\\pi i} = -1$."
     },
     {
-      "id": "axiomatized-analysis",
-      "title": "Axiomatized Analysis Infrastructure",
-      "startLine": 97,
-      "endLine": 148,
-      "summary": "Axiomatizes the core analytical tools: half-period identity (e_{-n} sign flip), difference formula (2ĉ_n as integral), Hölder translation bound, and integral product bound.",
-      "mathContext": "Key identity: $2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n))) e_{-n}(x)\\, d\\mu$, bounded by $C(T/(2|n|))^\\alpha$ via Hölder."
+      "id": "analysis-infrastructure",
+      "title": "Part III — Analysis Infrastructure (Proved)",
+      "startLine": 94,
+      "endLine": 226,
+      "summary": "Four fully-proved analytical lemmas (no axioms): `fourier_translate_halfperiod` (half-period sign flip via `fourier_add_half_inv_index` and `fourier_neg`), `fourierCoeff_difference_formula` (2ĉ_n as a translated difference integral via Haar invariance and `integral_add_right_eq_self`), `holder_translation_bound` (‖f(x)−f(x+h)‖ ≤ C(T/2|n|)^α from `HolderWith.dist_le_of_le` and the quotient-norm bound), and `integral_product_bound` (the product integral bounded via `norm_integral_le_integral_norm`, unit-norm monomials, and probability-measure total mass 1).",
+      "mathContext": "Key identity: $2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n)))\\, e_{-n}(x)\\, d\\mu$, bounded by $C(T/2|n|)^\\alpha$. The banner labels this 'PARTIALLY PROVED', but all four lemmas are complete with no axioms or sorries."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem: Fourier Coefficient Decay",
-      "startLine": 150,
-      "endLine": 177,
-      "summary": "**PROVED**: ‖ĉ_n(f)‖ ≤ (C/2)(T/2|n|)^α. Uses difference formula, integral bound, and norm arithmetic.",
-      "mathContext": "$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2} \\left(\\frac{T}{2|n|}\\right)^\\alpha$ for $\\alpha$-Hölder $f$ with constant $C$."
+      "title": "Part IV — Main Theorem: Fourier Coefficient Decay",
+      "startLine": 227,
+      "endLine": 252,
+      "summary": "**PROVED** `fourierCoeff_holder_decay`: ‖ĉ_n(f)‖ ≤ (C/2)(T/2|n|)^α for α-Hölder f. Combines the difference formula, the integral product bound, and `norm_mul`/`norm_ofNat` arithmetic to divide by 2.",
+      "mathContext": "$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2}\\left(\\frac{T}{2|n|}\\right)^\\alpha$ for $\\alpha$-Hölder $f$ with constant $C$ and $n \\neq 0$."
     },
     {
       "id": "corollaries",
-      "title": "Corollaries",
-      "startLine": 179,
-      "endLine": 205,
-      "summary": "Proves Lipschitz decay (α=1). Axiomatizes square-summability for α > 1/2 and Riemann-Lebesgue from Hölder.",
-      "mathContext": "Lipschitz: $\\|\\hat{c}_n\\| \\leq CT/(4|n|)$. For $\\alpha > 1/2$: $\\sum |\\hat{c}_n|^2 < \\infty$."
+      "title": "Part V — Corollaries",
+      "startLine": 253,
+      "endLine": 357,
+      "summary": "Three proved corollaries: `fourierCoeff_lipschitz_decay` (α = 1 case, ‖ĉ_n‖ ≤ CT/(4|n|)); `fourierCoeff_sq_summable_of_holder` (α > 1/2 ⟹ Σ‖ĉ_n‖² < ∞, via continuity on the compact circle ⟹ MemLp 2 ⟹ Parseval/Bessel `hasSum_sq_fourierCoeff`); and `riemannLebesgue_of_holder` (ĉ_n → 0 in the cofinite filter, by showing each bad set {n : ‖ĉ_n‖ ≥ ε} is finite via `Filter.Tendsto.div_atTop` and threshold extraction). All proved — no axioms.",
+      "mathContext": "Lipschitz: $\\|\\hat{c}_n\\| = O(1/|n|)$. Square-summability for $\\alpha > 1/2$ (since $2\\alpha > 1$). Riemann–Lebesgue: $\\hat{c}_n \\to 0$."
     },
     {
       "id": "optimality",
-      "title": "Optimality",
-      "startLine": 207,
-      "endLine": 232,
-      "summary": "Axiomatizes optimality (Weierstrass function construction) and partial converse (decay ⟹ regularity via Sobolev embedding).",
-      "mathContext": "For each $\\alpha \\in (0,1)$, $\\exists$ $\\alpha$-Hölder $f$ with $|\\hat{c}_n| \\geq c/|n|^\\alpha$. Converse: $O(1/|n|^\\beta)$ with $\\beta > \\alpha + 1/2$ gives Hölder($\\alpha$)."
+      "title": "Part VI — Optimality",
+      "startLine": 358,
+      "endLine": 408,
+      "summary": "`holder_decay_is_optimal_seq`: for each α ∈ (0,1) a Weierstrass lacunary series f(x) = Σ 2^{-kα} e_{2^k}(x) is α-Hölder with |ĉ_{2^k}| = (2^k)^{-α} along n_k = 2^k → ∞ (sequential — the original 'cofinite' axiom was FALSE since most coefficients vanish). `decay_implies_regularity`: O(|n|^{-β}) decay with β > α+1 implies α-Hölder (corrected from the incorrect β > α+1/2). Both discharged via the companion files `FourierSeriesOQ02OQ04` (`WeierstrassOptimality`) and `FourierDecayInfra`.",
+      "mathContext": "Optimality witness $f(x) = \\sum_k 2^{-k\\alpha} e_{2^k}(x)$ achieves $|\\hat{c}_{2^k}| = (2^k)^{-\\alpha}$. Converse: $O(|n|^{-\\beta})$ with $\\beta > \\alpha+1$ gives Hölder($\\alpha$)."
     },
     {
-      "id": "hierarchy",
-      "title": "Regularity-Decay Hierarchy (Part 1)",
-      "startLine": 234,
-      "endLine": 258,
-      "summary": "Axiomatizes C^k, C^∞ (rapid), and analytic (exponential) decay. Proves arithmetic consequences for the α = 1/2 threshold.",
-      "mathContext": "$C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow$ rapid decay, analytic $\\Rightarrow O(e^{-c|n|})$. Complete regularity $\\leftrightarrow$ decay correspondence."
+      "id": "regularity-hierarchy",
+      "title": "Part VII — The Full Regularity-Decay Hierarchy",
+      "startLine": 409,
+      "endLine": 455,
+      "summary": "Proves the smoothness→decay ladder: `fourierCoeff_smooth_decay` (C^k ⟹ O(1/|n|^k)), `fourierCoeff_Cinfty_rapid_decay` (C^∞ ⟹ faster than any polynomial, by applying the C^k case for every k), and `fourierCoeff_analytic_decay` (holomorphic on a strip of width δ ⟹ O(e^{-2πδ|n|/T})). The C^k and analytic constants are stated non-uniformly (Ck may depend on n); uniform versions are noted as requiring integration-by-parts / contour integration.",
+      "mathContext": "Hierarchy: $C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow$ rapid decay, analytic $\\Rightarrow O(e^{-c|n|})$ — each level refines the previous."
     },
     {
-      "id": "lipschitz-sq-summability",
-      "title": "Lipschitz Corollary and Square-Summability",
-      "startLine": 256,
-      "endLine": 276,
-      "summary": "Proves `fourierCoeff_lipschitz_decay`: the Lipschitz case ($\\alpha = 1$) recovers $\\|\\hat{c}_n\\| \\leq CT/(4|n|)$. Proves `fourierCoeff_sq_summable_of_holder` ($\\alpha > 1/2 \\Rightarrow$ square-summable via Parseval/Bessel inequality).",
-      "mathContext": "Lipschitz: $\\|\\hat{c}_n\\| = O(1/|n|)$, from $\\alpha = 1$ in the main theorem. Square-summability: $\\|\\hat{c}_n\\|^2 = O(1/|n|^{2\\alpha})$, and $\\sum 1/|n|^{2\\alpha} < \\infty$ when $2\\alpha > 1$."
+      "id": "arithmetic-consequences",
+      "title": "Part VIII — Arithmetic Consequences",
+      "startLine": 456,
+      "endLine": 476,
+      "summary": "Threshold arithmetic for square-summability: `holder_half_critical` (α > 1/2 ⟹ 2α > 1) and `holder_parseval_range` (α ∈ (1/2,1] ⟹ 2α ∈ (1,2]). `quantitative_riemannLebesgue` restates the main decay bound as the explicit-rate Riemann–Lebesgue estimate.",
+      "mathContext": "The critical exponent $\\alpha = 1/2$ governs square-summability: $\\sum |\\hat{c}_n|^2 < \\infty$ exactly when $2\\alpha > 1$."
     },
     {
-      "id": "riemann-lebesgue-holder",
-      "title": "Riemann-Lebesgue for Hölder Functions (Proved)",
-      "startLine": 278,
-      "endLine": 336,
-      "summary": "Proves `riemannLebesgue_of_holder`: $\\alpha$-Hölder decay $\\Rightarrow$ $\\hat{c}_n \\to 0$ (Riemann-Lebesgue). The 58-line proof shows the bad set $\\{n : \\|\\hat{c}_n\\| \\geq \\varepsilon\\}$ is finite by: (1) showing the decay bound tends to 0 via `Filter.Tendsto.div_atTop` and `rpow_const`, (2) extracting $N_0$ from `Filter.eventually_atTop`, (3) proving the bad set is contained in $[-N_0-1, N_0+1]$.",
-      "mathContext": "The Riemann-Lebesgue lemma for Hölder functions: $\\hat{c}_n(f) \\to 0$ as $|n| \\to \\infty$ in the cofinite filter topology. The quantitative rate $O(1/|n|^\\alpha)$ gives the explicit bound. The proof handles $C = 0$ (trivial) and $C > 0$ (extract threshold $N_0$) separately."
-    },
-    {
-      "id": "optimality-converse",
-      "title": "Optimality and Partial Converse (Axioms)",
-      "startLine": 338,
-      "endLine": 360,
-      "summary": "documents in source comments `holder_decay_is_optimal` (no Lean declaration exists): for each $\\alpha \\in (0,1)$, a Weierstrass-type lacunary series achieves exactly $O(1/|n|^\\alpha)$ decay. Axiomatizes `decay_implies_regularity`: $O(1/|n|^\\beta)$ decay with $\\beta > \\alpha + 1/2$ implies $\\alpha$-Hölder (Sobolev embedding on the circle).",
-      "mathContext": "Optimality: $f(x) = \\sum_{k \\geq 0} b^{-k\\alpha} e^{ib^k x}$ is $\\alpha$-Hölder with $|\\hat{c}_{b^k}| = b^{-k\\alpha} = 1/|n|^\\alpha$. Converse gap: the Sobolev embedding $H^{\\alpha+1/2}(\\mathbb{T}) \\hookrightarrow C^\\alpha(\\mathbb{T})$ creates the $1/2$ loss."
-    },
-    {
-      "id": "hierarchy-extended",
-      "title": "Full Regularity-Decay Hierarchy (Extended)",
-      "startLine": 362,
-      "endLine": 430,
-      "summary": "Axioms for $C^k$ decay ($O(1/|n|^k)$ by iterated integration by parts) and analytic decay ($O(e^{-c|n|})$). Proves `fourierCoeff_Cinfty_rapid_decay` ($C^\\infty \\Rightarrow$ rapid decay for all $k$). Arithmetic consequences: $\\alpha > 1/2$ threshold for square-summability. Verification `#check` commands for all main results.",
-      "mathContext": "The complete hierarchy: $\\text{Hölder}(\\alpha) \\Rightarrow O(1/|n|^\\alpha)$, $C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow O(1/|n|^k)$ for all $k$, analytic $\\Rightarrow O(e^{-c|n|})$. Each level strictly refines the previous."
+      "id": "verification",
+      "title": "Part IX — Verification",
+      "startLine": 477,
+      "endLine": 495,
+      "summary": "`#check` commands confirming the type signatures of all twelve main results — the decay theorem, Lipschitz case, Riemann–Lebesgue, optimality (sequential), partial converse, unit-norm monomials, the Hölder/Lipschitz/continuity lemmas, quantitative R–L, and the C^k / C^∞ / analytic hierarchy — then closes the `FourierHolderDecay` section.",
+      "mathContext": "Final sanity layer: every headline declaration is re-checked so the gallery entry's claims are pinned to live Lean signatures."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

The gallery section ranges for `fourier-series-oq-02` had drifted from the Lean source (`Proofs/FourierSeriesOQ02.lean`, 495 lines, 0 axioms / 0 sorries / verified):

- **Tail content hidden**: the old sections stopped at line 430, completely omitting **PART VIII: Arithmetic Consequences** (456-476) and **PART IX: Verification** (477-495).
- **Overlaps**: e.g. "Regularity-Decay Hierarchy (Part 1)" (234-258) overlapped "Lipschitz Corollary and Square-Summability" (256-276).
- **Stale "axiomatized" prose**: several titles/summaries labeled content as *"Axiomatized Analysis Infrastructure"*, *"Axiomatizes…"*, and *"(Axioms)"*, but the file has **0 axioms and 0 sorries** — every PART is fully proved (the optimality/converse lemmas are discharged via the companion files `FourierSeriesOQ02OQ04` and `FourierDecayInfra`).

## Changes

Rebuilt to **10 contiguous sections** tiling lines 1-495, aligned 1:1 to the file's `PART I–IX` box-rule banners plus a leading Overview & Setup section:

| Lines | Section |
|------|---------|
| 1-49 | Overview & Setup |
| 50-74 | Part I — Hölder Continuity on the Circle |
| 75-93 | Part II — Translation Infrastructure |
| 94-226 | Part III — Analysis Infrastructure (Proved) |
| 227-252 | Part IV — Main Theorem: Fourier Coefficient Decay |
| 253-357 | Part V — Corollaries |
| 358-408 | Part VI — Optimality |
| 409-455 | Part VII — The Full Regularity-Decay Hierarchy |
| 456-476 | Part VIII — Arithmetic Consequences |
| 477-495 | Part IX — Verification |

Summaries corrected to reflect the proved status of each part. Counts (0 axioms, 0 sorries, 19 theorems, 3 defs, 495 lines) were already correct and are unchanged. Metadata-only change; no Lean source touched.

## Test plan
- [x] `meta.json` validates as JSON
- [x] Sections tile the full file contiguously (1-495) with no gaps or overlaps
- [x] Section ranges verified against the `PART` banners in the Lean source
- [x] Diff scoped to the `sections` block only

🤖 Generated with [Claude Code](https://claude.com/claude-code)