### PR TITLE
research(erdos-1016): realign gallery sections to full file (9→5)

### DIFF
--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -49,76 +49,44 @@
   },
   "sections": [
     {
-      "id": "header-imports",
+      "id": "header",
       "title": "Header and Imports",
+      "summary": "File header for Erdős #1016: $h(n)$ is the minimum excess edges (beyond $n$) for an $n$-vertex graph to be pancyclic (contain cycles of every length $3,\\dots,n$); estimate $h(n)$ and decide whether $h(n)\\ge\\log_2 n+\\log^* n-O(1)$. Lists the known bounds (Bondy/Griffin 2013 lower, George–Khodkar–Wallis 2016 upper) and references; imports Mathlib graph/log libraries.",
       "startLine": 1,
       "endLine": 28,
-      "summary": "Module documentation for Erdos Problem #1016 on pancyclic excess edges, listing key results by Bondy, Griffin, and George-Khodkar-Wallis. Imports Mathlib's SimpleGraph, Nat.Log, Real, and Tactic modules.",
-      "mathContext": "Four Mathlib imports provide the foundation: `SimpleGraph.Basic` for graph definitions, `Nat.Log` for $\\lfloor\\log_2 n\\rfloor$ in the BES bounds, `Real.Basic` for real-valued analysis, and `Tactic` for the `omega` and `linarith` proof automation."
+      "mathContext": "$h(n)=\\min\\{|E(G)|-n\\}$ over pancyclic $G$ on $n$ vertices. Open: does $h(n)-\\log_2 n\\to\\infty$?"
     },
     {
-      "id": "pancyclic-definition",
-      "title": "Pancyclic Graph Definition",
+      "id": "core-definitions",
+      "title": "Core Definitions",
+      "summary": "Defines `IsPancyclic` (contains a cycle of every length $3\\le k\\le n$), `pancyclicExcess n` ($h(n)$ as an `sSup` of edge-lower-bound witnesses), and the iterated logarithm `iteratedLog` ($\\log^* n$) with its termination proof.",
       "startLine": 29,
-      "endLine": 35,
-      "summary": "Defines `IsPancyclic`: a graph on $n$ vertices containing cycles of every length $k$ for $3 \\leq k \\leq n$. This is the central structural property whose edge cost the problem studies.",
-      "mathContext": "$\\text{IsPancyclic}(n, e, C) :\\equiv \\forall k,\\, 3 \\leq k \\leq n \\Rightarrow C(k)$, where $C(k)$ asserts the existence of a $k$-cycle. Pancyclic $\\Rightarrow$ Hamiltonian, but $C_n$ (Hamiltonian but not pancyclic for $n \\geq 4$) shows the converse fails."
+      "endLine": 62,
+      "mathContext": "$\\log^* n$ = number of $\\log_2$ iterations to reach $\\le 1$; $h(n)$ defined via the supremum of valid excess lower bounds."
     },
     {
-      "id": "excess-function",
-      "title": "Excess Function h(n) and Iterated Logarithm",
-      "startLine": 36,
-      "endLine": 49,
-      "summary": "Defines `pancyclicExcess` $h(n) = \\min\\{|E(G)| - n\\}$ over pancyclic $G$ on $n$ vertices, and `iteratedLog` $\\log^* n$ as the number of $\\log_2$ applications to reach $\\leq 1$. These are the two key quantities in the problem's bounds.",
-      "mathContext": "$h(n) = \\sup\\{h : \\forall G \\text{ pancyclic on } n \\text{ vertices},\\, |E(G)| \\geq n + h\\}$. The Lean definition uses `sSup` over $\\mathbb{N}$.\n\n$\\log^*(n) = \\begin{cases} 0 & n \\leq 1 \\\\ 1 + \\log^*(\\lfloor\\log_2 n\\rfloor) & n \\geq 2 \\end{cases}$. Values: $\\log^*(2) = 1$, $\\log^*(4) = 2$, $\\log^*(16) = 3$, $\\log^*(65536) = 4$, $\\log^*(2^{65536}) = 5$."
+      "id": "iterated-log-properties",
+      "title": "Iterated Logarithm Properties",
+      "summary": "Basic lemmas about $\\log^*$: `iteratedLog_zero`/`iteratedLog_one` (`@[simp]`), `iteratedLog_add_two`, `iteratedLog_eq_zero_iff` ($\\log^* n=0\\iff n\\le 1$), and `iteratedLog_pos` ($\\log^* n\\ge 1$ for $n\\ge 2$).",
+      "startLine": 63,
+      "endLine": 100,
+      "mathContext": "$\\log^* n=0\\iff n\\le 1$; $\\log^* n\\ge 1$ for $n\\ge 2$."
     },
     {
-      "id": "main-conjecture",
-      "title": "Main Conjecture and Weaker Question",
-      "startLine": 50,
-      "endLine": 64,
-      "summary": "States Erdos's conjecture $h(n) \\geq \\lfloor\\log_2 n\\rfloor + \\log^* n - O(1)$ and the weaker open question $h(n) - \\lfloor\\log_2 n\\rfloor \\to \\infty$. The weaker question asks whether the correction to the logarithmic term diverges.",
-      "mathContext": "Conjecture: $\\exists C,\\, \\forall n \\geq 3,\\, h(n) + C \\geq \\lfloor\\log_2 n\\rfloor + \\log^* n$. Combined with GKW upper bound, this gives $h(n) = \\lfloor\\log_2 n\\rfloor + \\log^* n + \\Theta(1)$.\n\nWeaker: $\\forall M,\\, \\exists N,\\, \\forall n \\geq N,\\, h(n) \\geq \\lfloor\\log_2 n\\rfloor + M$."
-    },
-    {
-      "id": "lower-bound",
-      "title": "Bondy's Lower Bound (Griffin 2013)",
-      "startLine": 65,
-      "endLine": 72,
-      "summary": "The lower bound $h(n) \\geq \\lfloor\\log_2(n-1)\\rfloor - 1$ from a doubling argument: each extra edge at most doubles achievable cycle lengths, so $2^h \\geq n - 2$.",
-      "mathContext": "Axiom: $\\forall n \\geq 3,\\, h(n) + 1 \\geq \\lfloor\\log_2(n-1)\\rfloor$. Proof idea (Griffin 2013): starting from a Hamiltonian cycle $C_n$, each chord can create cycles of at most twice as many distinct lengths, so $h$ chords give at most $2^h$ cycle lengths out of $n - 2$ needed."
-    },
-    {
-      "id": "upper-bound",
-      "title": "George-Khodkar-Wallis Upper Bound (2016)",
-      "startLine": 73,
-      "endLine": 79,
-      "summary": "The upper bound $h(n) \\leq \\lfloor\\log_2 n\\rfloor + \\log^* n + O(1)$ via explicit hierarchical construction: $\\log_2 n$ doubling stages plus $\\log^* n$ correction stages.",
-      "mathContext": "Axiom: $\\exists C,\\, \\forall n \\geq 3,\\, h(n) \\leq \\lfloor\\log_2 n\\rfloor + \\log^* n + C$. The construction: start with $C_n$, add $\\lfloor\\log_2 n\\rfloor$ chords at geometrically spaced positions to achieve cycle lengths in $\\{n/2^k \\pm O(1) : 0 \\leq k \\leq \\log_2 n\\}$, then $\\log^* n$ correction chords to fill gaps at each tower level."
+      "id": "model-flaw",
+      "title": "Model Flaw and Consequences",
+      "summary": "Honestly documents a modeling flaw: because `IsPancyclic` takes `hasCycleOfLength` as a parameter disconnected from `edgeCount`, the witness $(\\text{edgeCount}=0,\\text{hasCycle}=\\top)$ collapses the defining set, so `pancyclicExcess_eq_zero` ($h(n)=0$ for all $n\\ge1$) and `gkw_upper_bound` hold trivially. The genuine Bondy/Griffin/GKW lower bounds are FALSE under this abstract encoding (preserved as comments) and would need ~200 lines of `SimpleGraph`/`Walk.IsCycle` infrastructure to formalize properly.",
+      "startLine": 101,
+      "endLine": 156,
+      "mathContext": "Abstract model degenerate: $\\text{pancyclicExcess}(n)=0$; the real mathematics (Bondy 1971, Griffin 2013, GKW 2016) is correct but needs a graph-theoretic encoding."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
-      "startLine": 80,
-      "endLine": 96,
-      "summary": "Hamiltonian baseline ($h(n) \\geq 0$), Bondy's quadratic threshold ($n^2/4$ edges suffice for pancyclicity or bipartiteness), and monotonicity of pancyclicity under edge addition.",
-      "mathContext": "Three results: (1) $h(n) \\geq 0$ (trivial for $\\mathbb{N}$, but the non-trivial content is that pancyclic $\\Rightarrow$ Hamiltonian $\\Rightarrow |E| \\geq n$). (2) Bondy's theorem: $|E(G)| \\geq n^2/4 \\Rightarrow G$ pancyclic or bipartite (axiomatized for $n \\geq 7$). (3) Monotonicity: pancyclicity is an upward-closed property under edge addition."
-    },
-    {
-      "id": "small-cases",
-      "title": "Small Cases",
-      "startLine": 97,
-      "endLine": 106,
-      "summary": "Computed values: $h(3) = 0$ ($K_3$), $h(4) = 1$ ($C_4$ plus diagonal). OEIS A105206 gives further terms.",
-      "mathContext": "$h(3) = 0$: $K_3$ has 3 edges = $n$ edges, pancyclic (only needs $C_3$). $h(4) = 1$: need $C_3$ and $C_4$, achieved by $C_4 + $ one diagonal with 5 = $4 + 1$ edges. The BES-style lower bound gives $h(4) \\geq \\lfloor\\log_2 3\\rfloor - 1 = 0$, so the truth $h(4) = 1$ exceeds the lower bound by 1."
-    },
-    {
-      "id": "bounds-gap",
-      "title": "Bounds Gap",
-      "startLine": 107,
-      "endLine": 110,
-      "summary": "The gap between upper and lower bounds is at most $\\log^* n + O(1)$, making this one of the tightest known gaps for an open extremal graph theory problem.",
-      "mathContext": "Upper $-$ lower $\\leq (\\lfloor\\log_2 n\\rfloor + \\log^* n + C) - (\\lfloor\\log_2(n-1)\\rfloor - 1) = \\log^* n + O(1)$. Since $\\log^* n \\leq 5$ for $n < 2^{65536}$, the bounds differ by at most $\\approx 6$ for any practical graph."
+      "summary": "Remaining results: `hamiltonian_edge_count` (non-negativity), `bondy_quadratic_threshold` (for $n\\ge7$, $n^2/4\\ge n+\\log_2 n$, via `interval_cases`/`nlinarith`), `pancyclic_monotone`, `triangle_pancyclic` ($h(3)=0$, proved from the empty defining set), and `bounds_gap`.",
+      "startLine": 157,
+      "endLine": 209,
+      "mathContext": "$n^2/4\\ge n+\\log_2 n$ for $n\\ge 7$ (Bondy's quadratic threshold is far from the $\\log$-scale truth); $h(3)=0$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-metadata realignment for **erdos-1016** (Erdős #1016: pancyclic excess edges $h(n)$).

The `sections` array was from an older layout (titles like "Bondy's Lower Bound", "Small Cases", "Bounds Gap" that no longer match the file) and coverage stopped at L110 while `Proofs/Erdos1016Problem.lean` runs to 209 — nearly half the file (the "Model Flaw and Consequences" and "Structural Properties" content) was hidden.

### Changes
- Rebuilt all sections against the file's `## ` banners for contiguous **full-file coverage 1-209**: Header and Imports, Core Definitions, Iterated Logarithm Properties, Model Flaw and Consequences (which honestly documents that the abstract `IsPancyclic` model is degenerate — `pancyclicExcess n = 0` for all `n`), and Structural Properties — **5** sections.

### Counts (unchanged, verified accurate)
- axiomCount 0, sorries 0, theoremCount 12 (including two `@[simp]` theorems), definitionCount 3, lineCount 209 — all already correct.

## Test plan
- [x] `pnpm research:build` completes with no errors/warnings for this slug
- [x] JSON validates; 5 sections ordered, contiguous (no gaps/overlaps); final endLine 209 == lineCount
- [x] Section ranges cross-checked against the file's `## ` banner lines