### PR TITLE
research(lhopital-oq-02): realign drifted gallery sections to file (5→6)

### DIFF
--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -59,42 +59,50 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring stating the ∞/∞ goal, proof-strategy outline, status checklist (all 4 variants proved), and Mathlib dependencies. Imports LHopital, MeanValue, Deriv.Basic, SpecificLimits.Normed, Filter.Basic, Topology.Order.Basic; opens the `LHopitalInfty` namespace with `Set Filter Topology Real`.",
+      "mathContext": "Mathlib's 26 L'Hôpital variants (as of v4.26.0) cover only the 0/0 form. This file adds the logically independent ∞/∞ form, whose 0/0 strategy ($f(a)=g(a)=0$ with Cauchy MVT on $[a,x]$) does not apply when both functions diverge."
+    },
+    {
       "id": "zero-case",
       "title": "Private Lemma: c = 0 Case (Core Engine)",
-      "startLine": 64,
-      "endLine": 224,
-      "summary": "Private theorem proving g→∞, f'/g'→0 ⟹ f/g→0 via three-δ construction + Cauchy MVT on [x, x₀] + algebraic identity.",
+      "startLine": 62,
+      "endLine": 233,
+      "summary": "PART I banner plus the private theorem proving g→∞, f'/g'→0 ⟹ f/g→0 via three-δ construction + Cauchy MVT on [x, x₀] + algebraic identity.",
       "mathContext": "Three-δ: fix $x_0$ near $a$ with $|f'/g'|<\\varepsilon/2$ for $\\xi < x_0$, then ensure $g(x) \\ge M = \\max(g(x_0)+1, 2|f(x_0)|/\\varepsilon+1)$. Key identity: $f/g = (f'/g')\\cdot(1-g(x_0)/g) + f(x_0)/g$."
     },
     {
       "id": "right-approach",
       "title": "Main Theorem: ∞/∞ L'Hôpital, Right Approach",
-      "startLine": 226,
-      "endLine": 275,
+      "startLine": 234,
+      "endLine": 284,
       "summary": "Public theorem for general c: reduce to c=0 via h(x)=f(x)-c·g(x), then apply the private lemma and add c back.",
       "mathContext": "$f/g \\to c$ iff $h/g = (f-c\\cdot g)/g \\to 0$, where $h'/g' = f'/g' - c \\to 0$."
     },
     {
       "id": "variants",
       "title": "Additional Variants (All Proved)",
-      "startLine": 277,
-      "endLine": 373,
-      "summary": "Left approach (negation), atTop (inversion), and atBot (negation of atTop) — all fully proved following Mathlib's 0/0 reduction pattern.",
+      "startLine": 285,
+      "endLine": 378,
+      "summary": "PART II banner plus left approach (negation), atTop (inversion), and atBot (negation of atTop) — all fully proved following Mathlib's 0/0 reduction pattern.",
       "mathContext": "Each reduces to the right approach via a substitution that maps the limit direction to $\\mathcal{N}^+[a]$. Left: $u=-x$ with $\\text{neg\\_Ioo}$; atTop: $u=x^{-1}$ with $\\text{hasDerivAt\\_inv}$; atBot: $u=-x$ composed with atTop."
     },
     {
       "id": "examples",
       "title": "Classic Examples: x/eˣ and ln(x)/cot(x)",
-      "startLine": 315,
-      "endLine": 333,
-      "summary": "Two canonical ∞/∞ examples as commentary. x/eˣ → 0 (x→∞), ln(x)/cot(x) → 0 (x→0⁺)."
+      "startLine": 379,
+      "endLine": 398,
+      "summary": "PART III banner plus two canonical ∞/∞ examples as commentary. x/eˣ → 0 (x→∞), ln(x)/cot(x) → 0 (x→0⁺)."
     },
     {
       "id": "comparison",
       "title": "Why ∞/∞ Needs a Different Proof from 0/0",
-      "startLine": 335,
-      "endLine": 357,
-      "summary": "Explains why the 0/0 Cauchy MVT at the limit point fails for ∞/∞, and why the two-variable argument is necessary.",
+      "startLine": 399,
+      "endLine": 428,
+      "summary": "PART IV banner explaining why the 0/0 Cauchy MVT at the limit point fails for ∞/∞ and why the two-variable argument is necessary, followed by `#check` sanity checks for all four variants and the namespace close.",
       "mathContext": "For $0/0$: MVT on $[a,x]$ gives $f(x)/g(x) = (f(x)-f(a))/(g(x)-g(a)) = f'(\\xi)/g'(\\xi)$ directly. For $\\infty/\\infty$: $f(a), g(a)$ don't exist; must use MVT on $[x, x_0]$ with $x_0 > a$ as anchor."
     }
   ],
@@ -108,7 +116,7 @@
       "The key algebraic identity $f/g = [f'/g'] \\cdot [1-g(x_0)/g] + f(x_0)/g$ decomposes the ratio into an MVT term (close to $c$) and two correction terms (that vanish as $g \\to \\infty$) — this is the central insight of the two-variable argument",
       "The bound $|1 - g(x_0)/g(x)| \\le 1$ (since $0 < g(x_0) < g(x)$) is crucial: it ensures the MVT term contributes at most $|f'/g'|$, even without knowing the bracket is small",
       "The reduction to $c=0$ via $h = f - c \\cdot g$ is a bookkeeping simplification that transforms 'ratio tends to $c$' into 'ratio tends to 0', making the epsilon argument cleaner",
-      "The three pending sorry variants (left, atTop, atBot) are proof-structure exercises — they contain the substitution strategy in comments and should be closable by Aristotle or by direct filter manipulation"
+      "The three directional variants (left, atTop, atBot) each reduce to the right approach by a single substitution rather than a fresh epsilon argument: left via reflection $u=-x$ (neg_Ioo), atTop via inversion $u=x^{-1}$ (hasDerivAt_inv), atBot via negation composed with atTop"
     ],
     "prerequisites": [
       "Cauchy's Mean Value Theorem",
@@ -123,7 +131,6 @@
     "summary": "All four variants of the ∞/∞ L'Hôpital's rule are fully proved (0 sorries, 0 axioms): right approach via two-variable Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop. Docker-verified with Lean 4.26.0.",
     "implications": "This formalization fills a genuine gap in Mathlib's calculus library: as of v4.26.0, all 26 L'Hôpital variants handle only the 0/0 form. All four directional variants are now complete and could be contributed to Mathlib. The two-variable argument with explicit delta construction is a template applicable to other limit theorems where direct MVT application at the limit point fails.",
     "openQuestions": [
-      "Can the three pending sorry variants be closed by Aristotle proof search? The substitution strategy is spelled out in comments (reflection for left approach, inversion for atTop, negation for atBot) — these may be straightforward filter manipulations.",
       "The 0/0 form can sometimes be reduced to the ∞/∞ form via $u = 1/f(x)$. Is there a clean formal proof that the two forms are logically equivalent (derivable from each other), or does each require its own independent epsilon-delta argument?",
       "Mathlib's 26 L'Hôpital variants include different derivative hypotheses (HasDerivAt, HasStrictDerivAt, DifferentiableOn). Should the ∞/∞ variants be stated for each hypothesis style to match the existing API surface?"
     ]


### PR DESCRIPTION
## Summary
- Realigned `src/data/proofs/lhopital-oq-02/meta.json` sections to the current `LHopitalOQ02.lean`. The `examples` (315-333) and `comparison` (335-357) sections pointed **inside the atTop/atBot variant theorems** rather than the actual PART III/IV comment blocks at 379-428; the file header (1-61) was uncovered and the variant ranges were shifted.
- Rebuilt to **6 sections tiling 1-428 contiguously** against the file's four `═══` PART banners, adding a header section. Section titles/content were already correct — only line ranges were stale.
- Fixed stale prose: `keyInsights` and `conclusion.openQuestions` referenced "three pending sorry variants" (left/atTop/atBot), but all four variants are **fully proved (0 sorries, 0 axioms)**. Updated to describe the substitution reductions.

## Counts (unchanged, pre-correct)
428 lines · 0 axioms · 5 theorems · 0 defs · 0 sorries.

## Test plan
- [x] `jq empty` validates JSON
- [x] Sections tile 1-428 contiguously, no overlaps
- [x] `grep` confirms 0 sorries / 0 axiom decls / 5 theorems in the Lean file
- [x] Diff scoped to the single meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)