### PR TITLE
research(erdos-10-oq-01): realign gallery sections to full file (6→9)

### DIFF
--- a/src/data/proofs/erdos-10-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-oq-01/meta.json
@@ -49,52 +49,76 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Core Definitions",
-      "startLine": 36,
-      "endLine": 55,
-      "summary": "Defines `IsPrimePlusKPowers k n` (prime plus at most k powers of 2 using a Multiset of exponents) and `RepSet k = {n | IsPrimePlusKPowers k n}`. Also defines `OQ01` (the existence question) and `Erdos10Main` (the stronger all-integers question).",
-      "mathContext": "$S_k = \\{n : n = p + \\sum_{i \\leq j} 2^{a_i},\\; p \\text{ prime},\\; j \\leq k\\}$. OQ-01: $\\exists k, N: \\{n \\geq N\\} \\subseteq S_k$."
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "File header for Erdős #10 OQ-01: the original problem asks for a constant $k$ such that every integer is a prime plus at most $k$ powers of $2$; OQ-01 is the 'sufficiently large' variant $\\exists k,N,\\ \\forall n\\ge N,\\ n=p+\\sum 2^{a_i}$. Status OPEN (conjectured FALSE by Erdős–Graham); Gallagher's density-1 theorem is the best unconditional result. Imports Mathlib, opens `Filter`/`Set`/`Classical`, enters the namespace.",
+      "startLine": 1,
+      "endLine": 47,
+      "mathContext": "OQ-01: $\\exists k,N\\ \\forall n\\ge N$, $n$ is a prime plus $\\le k$ powers of 2. Conjectured FALSE (Erdős–Graham)."
     },
     {
-      "id": "monotonicity",
-      "title": "Monotonicity Lemmas",
-      "startLine": 56,
-      "endLine": 85,
-      "summary": "Proves RepSet is monotone (RepSet k ⊆ RepSet (k+1)), RepSet 0 = {primes}, and that OQ-01 is inherited by larger k.",
-      "mathContext": "$S_{k_1} \\subseteq S_{k_2}$ for $k_1 \\leq k_2$. $S_0 = \\text{Primes}$."
+      "id": "part1-core-definitions",
+      "title": "Part I: Core Definitions",
+      "summary": "Defines `IsPrimePlusKPowers k n` ($n=p+\\sum_{i} 2^{a_i}$ for a prime $p$ and a multiset of $\\le k$ exponents) and `RepSet k` (the representable set).",
+      "startLine": 48,
+      "endLine": 58,
+      "mathContext": "$n\\in\\mathrm{RepSet}(k)\\iff n=p+\\sum_{i\\le k}2^{a_i}$, $p$ prime (repeated exponents allowed)."
     },
     {
-      "id": "crocker",
-      "title": "Crocker's Lower Bound",
-      "startLine": 86,
-      "endLine": 115,
-      "summary": "Axiomatizes Crocker's theorem (infinitely many odd integers not in RepSet 2). Derives that k=2 fails OQ-01: for every N, there exists n ≥ N not representable with ≤2 powers.",
-      "mathContext": "$|\\{n \\text{ odd} : n \\notin S_2\\}| = \\infty$ (Crocker 1971). Corollary: $\\neg \\exists N: \\{n \\geq N\\} \\subseteq S_2$."
+      "id": "part2-oq01-question",
+      "title": "Part II: The OQ-01 Question",
+      "summary": "States `OQ01` (some finite $k$ works for all large $n$) and the stronger parent `Erdos10Main` (some $k$ works for all $n\\ge2$), with `main_implies_oq01` showing the parent conjecture implies OQ-01.",
+      "startLine": 59,
+      "endLine": 78,
+      "mathContext": "$\\mathrm{Erdos10Main}\\Rightarrow\\mathrm{OQ01}$: OQ-01 is the strictly weaker 'sufficiently large' form."
     },
     {
-      "id": "granville-soundararajan",
-      "title": "Granville-Soundararajan Implies OQ-01",
-      "startLine": 116,
-      "endLine": 155,
-      "summary": "Defines G-S conjectures for odd (k=3) and even (k=4) integers. Proves: if both G-S conjectures hold, then OQ-01 is true with k=4 and N=3.",
-      "mathContext": "G-S: $k=3$ for odd $n \\geq 3$; $k=4$ for even $n \\geq 2$. Together: $\\{n \\geq 3\\} \\subseteq S_4$, so OQ-01 holds with $k=4, N=3$."
+      "id": "part3-monotonicity",
+      "title": "Part III: Monotonicity Lemmas",
+      "summary": "Structural monotonicity: `repSet_mono`/`repSet_mono_le` ($\\mathrm{RepSet}$ grows with $k$), `repSet_zero_eq_primes` ($\\mathrm{RepSet}(0)=$ primes), and `oq01_mono` (OQ-01 is monotone in $k$).",
+      "startLine": 79,
+      "endLine": 108,
+      "mathContext": "$\\mathrm{RepSet}(k_1)\\subseteq\\mathrm{RepSet}(k_2)$ for $k_1\\le k_2$; $\\mathrm{RepSet}(0)=\\{\\text{primes}\\}$."
     },
     {
-      "id": "gallagher-gap",
-      "title": "Gallagher Density Gap",
-      "startLine": 156,
-      "endLine": 195,
-      "summary": "Axiomatizes Gallagher's density result. Proves by counterexample (non-squares) that density approaching 1 does not imply universal coverage for large n. This shows the gap between Gallagher's result and OQ-01.",
-      "mathContext": "Gallagher: $\\underline{d}(S_k) \\to 1$. Gap: $\\underline{d}(\\mathbb{N} \\setminus \\{m^2\\}) = 1$ but $\\{n \\geq N\\} \\not\\subseteq \\mathbb{N} \\setminus \\{m^2\\}$ for any $N$."
+      "id": "part4-k2-insufficient",
+      "title": "Part IV: k=2 is Insufficient for Large Integers",
+      "summary": "Crocker's lower bound: axiom `crocker_theorem` and `k_two_not_sufficient_large`/`k_two_fails_oq01` showing $k=2$ fails OQ-01 — infinitely many large integers are not a prime plus two powers of 2.",
+      "startLine": 109,
+      "endLine": 133,
+      "mathContext": "Crocker (1971): $k=2$ is insufficient — infinitely many integers are not $p+2^a+2^b$."
     },
     {
-      "id": "erdos-graham",
-      "title": "Erdős-Graham Conjecture",
-      "startLine": 196,
-      "endLine": 215,
-      "summary": "Axiomatizes the Erdős-Graham conjecture (for every k, infinitely many large integers are not in RepSet k). Derives ¬OQ-01 as a formal consequence.",
-      "mathContext": "E-G: $\\forall k: \\{n : n \\notin S_k\\}$ is infinite. Implies $\\neg \\exists k, N: \\{n \\geq N\\} \\subseteq S_k$."
+      "id": "part5-granville-soundararajan",
+      "title": "Part V: Connection to Granville-Soundararajan Conjecture",
+      "summary": "Defines the parity-split `GranvilleSoundararajanOdd`/`GranvilleSoundararajanEven` and proves `granville_soundararajan_implies_oq01`: if the G–S conjecture holds, then $k=4$ works for all sufficiently large integers.",
+      "startLine": 134,
+      "endLine": 163,
+      "mathContext": "Granville–Soundararajan (1998) $\\Rightarrow$ OQ-01 with $k=4$."
+    },
+    {
+      "id": "part6-gallagher",
+      "title": "Part VI: Gallagher's Density Result (Does Not Imply OQ-01)",
+      "summary": "Axiom `gallagher_density_approach` (Gallagher 1975: the representable set has density $\\to1$) and `gallagher_does_not_imply_oq01_in_principle`, showing density 1 is consistent with OQ-01 failing — a sparse exceptional set can persist.",
+      "startLine": 164,
+      "endLine": 284,
+      "mathContext": "Gallagher (1975): density $\\to 1$, but density 1 does not give universal coverage for large $n$."
+    },
+    {
+      "id": "part7-erdos-graham",
+      "title": "Part VII: The Erdős-Graham Conjecture (Formalized)",
+      "summary": "Axiom `erdos_graham_conjecture` (Erdős–Graham predicted OQ-01 is FALSE) and `oq01_false_from_conjecture` deriving the negative answer from it.",
+      "startLine": 285,
+      "endLine": 301,
+      "mathContext": "Erdős–Graham (1980) conjectured OQ-01 is FALSE: no finite $k$ covers all large integers."
+    },
+    {
+      "id": "part8-logical-hierarchy",
+      "title": "Part VIII: The Logical Hierarchy Summary",
+      "summary": "Summarizes the logical hierarchy: parent conjecture $\\Rightarrow$ OQ-01; G–S $\\Rightarrow$ OQ-01 ($k=4$); Crocker rules out $k=2$; Gallagher's density-1 result does not settle it; Erdős–Graham conjecture OQ-01 false.",
+      "startLine": 302,
+      "endLine": 316,
+      "mathContext": "Hierarchy: Main $\\Rightarrow$ OQ-01 $\\Leftarrow$ G–S; Crocker ($k\\ne2$); Gallagher (density only); Erdős–Graham (conjectured false)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-metadata realignment for **erdos-10-oq-01** (Erdős #10 OQ-01: does a finite $k$ suffice for all sufficiently large integers — prime plus $k$ powers of 2?).

The meta had 6 mislabeled sections covering only L36-215, while `Proofs/Erdos10OQ01.lean` (316 lines) is organized into 8 `/-! ## Part N` banners. **Two whole parts were missing** from the metadata (Part II "The OQ-01 Question" and Part VIII "The Logical Hierarchy Summary"), and the tail (L216-316, Parts VI-VIII) was hidden.

### Changes
- Rebuilt all sections against the file's banners for contiguous **full-file coverage 1-316**: Header + Parts I-VIII (Core Definitions, The OQ-01 Question, Monotonicity, k=2 Insufficient/Crocker, Granville-Soundararajan, Gallagher Density, Erdős-Graham Conjecture, Logical Hierarchy Summary) — **9** sections.

### Counts (unchanged, verified accurate)
- axiomCount 3, sorries 0, theoremCount 10, definitionCount 6, lineCount 316 — all already correct (the meta count was right; a naive grep over-counts via prose/docstrings).

## Test plan
- [x] `pnpm research:build` completes with no errors/warnings for this slug
- [x] JSON validates; 9 sections ordered, contiguous (no gaps/overlaps); final endLine 316 == lineCount
- [x] Section ranges cross-checked against the file's `/-! ## Part N` banner lines