### PR TITLE
Enrich chinese-remainder-constructive-oq-03: remove duplicate annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/annotations.json
@@ -1,10 +1,13 @@
 [
   {
     "id": "ann-lipschitz-curve-structure",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 65,
       "endLine": 82
     },
+    "type": "insight",
+    "title": "The LipschitzClosedCurve Structure: Generalizing C¹ to Lipschitz Regularity",
     "content": "The `LipschitzClosedCurve` structure generalizes `SmoothClosedCurve` (which required `ContDiff ℝ 1`) by replacing C¹ smoothness with Lipschitz continuity. The key insight is that Lipschitz functions are differentiable almost everywhere by Rademacher's theorem, so the classical formulas for arc-length (∫√(x'²+y'²)) and area via Green's theorem ((1/2)|∫(xy'−yx')|) remain valid as Lebesgue integrals.\n\nThe circumference is defined as `∫ t in (0)..(2π), √(deriv x t)² + (deriv y t)²` and area as `(1/2)|∫ t in (0)..(2π), x t * deriv y t − y t * deriv x t|`. Both use `deriv` from Mathlib (which returns 0 at non-differentiable points by convention), but the integral is unchanged since the Lipschitz non-differentiable set has measure zero.\n\nLipschitz regularity is the natural level for the isoperimetric inequality: it covers all piecewise-smooth curves (polygons, convex hulls, etc.) while still admitting the Fourier-analytic proof strategy via Sobolev embedding W^{1,∞}(S¹) ↪ H¹(S¹).",
     "mathContext": "LipschitzWith K f means |f(a) − f(b)| ≤ K·|a − b| for all a,b. Rademacher's theorem: every Lipschitz function ℝⁿ → ℝ is differentiable Lebesgue-a.e. For a 2π-periodic Lipschitz curve, the integrals ∫√(x'²+y'²) and ∫(xy'−yx') are well-defined Lebesgue integrals since the a.e. derivatives are essentially bounded (|x'| ≤ K a.e. for LipschitzWith K x).",
     "significance": "key",
@@ -16,15 +19,17 @@
       "Lebesgue integral",
       "essentially bounded functions"
     ],
-    "pedagogicalNote": "Compare with the smooth case: `SmoothClosedCurve` uses ordinary integrals and the fundamental theorem of calculus; `LipschitzClosedCurve` uses the same formulas but justified measure-theoretically via Rademacher.",
-    "type": "insight"
+    "pedagogicalNote": "Compare with the smooth case: `SmoothClosedCurve` uses ordinary integrals and the fundamental theorem of calculus; `LipschitzClosedCurve` uses the same formulas but justified measure-theoretically via Rademacher."
   },
   {
     "id": "ann-smooth-embedding",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 92,
       "endLine": 119
     },
+    "type": "insight",
+    "title": "SmoothClosedCurve.toLipschitz: Every C¹ Closed Curve Is Lipschitz",
     "content": "The `SmoothClosedCurve.toLipschitz` embedding shows that every smooth (C¹) closed curve is automatically a Lipschitz closed curve. The key definitional equalities `toLipschitz_circumference` and `toLipschitz_area` hold by `rfl` — the circumference and area formulas are literally identical between the two structures, so no computation is needed.\n\nThe two `sorry`s in `lip_x` and `lip_y` are for showing that a C¹ periodic function is Lipschitz. Mathematically this is clear: on the compact interval [0, 2π+1], a C¹ function has bounded derivative by compactness, so the MVT gives the Lipschitz bound. In Lean, this requires `HasDerivAt.lipschitzWith` or a direct MVT argument, which is available but tedious.\n\nCritically, these sorries are **not on the critical path** to the main isoperimetric theorem `lipschitz_isoperimetric`. They only affect `smooth_case_follows_from_lipschitz` (a corollary that the smooth case is subsumed). The main theorem is proved for directly-constructed `LipschitzClosedCurve` inputs.",
     "mathContext": "C¹ periodic → Lipschitz: if f: ℝ → ℝ is C¹ and 2π-periodic, then |f'| achieves its maximum M on [0, 2π] by compactness. MVT gives |f(b)−f(a)| ≤ M|b−a| for any a,b. The Lipschitz constant K = M suffices. In Lean: need HasDerivAt (from ContDiff) + MvT + compactness of [0, 2π].",
     "significance": "key",
@@ -35,15 +40,17 @@
       "rfl proofs",
       "definitional equality"
     ],
-    "pedagogicalNote": "The `rfl` proofs are a design pattern: when two definitions are literally the same expression (same integral formula), Lean recognizes them as definitionally equal without any proof effort. This is only possible because `toLipschitz` copies the x,y components unchanged.",
-    "type": "insight"
+    "pedagogicalNote": "The `rfl` proofs are a design pattern: when two definitions are literally the same expression (same integral formula), Lean recognizes them as definitionally equal without any proof effort. This is only possible because `toLipschitz` copies the x,y components unchanged."
   },
   {
     "id": "ann-circle-square-examples",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 128,
       "endLine": 183
     },
+    "type": "insight",
+    "title": "Paradigmatic Examples: Circle (Equality) and Square",
     "content": "This section establishes the two paradigmatic examples for the isoperimetric inequality:\n\n**Circle (equality)**: `circleLipCurve r` inherits from the smooth circle `circleGamma r` via the `toLipschitz` embedding. The circumference = 2πr and area = πr² follow immediately from the smooth case. The equality C² = 4πA is the Lipschitz isoperimetric equality `circleLipCurve_isoperimetric_equality`.\n\n**Unit square (strict inequality)**: The unit square has perimeter C = 4 and area A = 1, giving isoperimetric ratio 4πA/C² = π/4 ≈ 0.785 < 1. The theorem `square_strict_isoperimetric` proves 4π < 16, i.e., π < 4 (from Mathlib's `pi_lt_four`). All square theorems are proved completely without sorries.\n\nThe square is a Lipschitz (piecewise-linear) curve that is not smooth — it has corners at the four vertices. This demonstrates that the Lipschitz isoperimetric inequality is genuinely more general than the smooth version: it applies to non-smooth curves that the parent theorem cannot handle.",
     "mathContext": "For the circle: C = 2πr, A = πr², so C² = 4π²r² = 4π·πr² = 4πA (equality). For the unit square: C = 4, A = 1, 4πA/C² = 4π/16 = π/4. Since π < 4 (Mathlib: pi_lt_four), we have π/4 < 1, i.e., C² = 16 > 4π = 4πA (strict inequality). The a×a square generalizes this: C = 4a, A = a², same ratio π/4 by scale invariance.",
     "significance": "key",
@@ -54,15 +61,17 @@
       "pi_lt_four",
       "scale invariance"
     ],
-    "pedagogicalNote": "The square proofs use only `pi_lt_four` and `ring` / `nlinarith` — they require no deep analysis, just arithmetic. This separation (hard analysis for the main theorem, easy arithmetic for examples) is a virtue of the proof architecture.",
-    "type": "insight"
+    "pedagogicalNote": "The square proofs use only `pi_lt_four` and `ring` / `nlinarith` — they require no deep analysis, just arithmetic. This separation (hard analysis for the main theorem, easy arithmetic for examples) is a virtue of the proof architecture."
   },
   {
     "id": "ann-core-axioms",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 217,
       "endLine": 246
     },
+    "type": "insight",
+    "title": "Core Axioms: Wirtinger Inequality for Lipschitz Functions",
     "content": "Two axioms capture the deep analytical content of the Lipschitz isoperimetric theory:\n\n**`wirtinger_ac`** (line 217): The Wirtinger inequality for Lipschitz functions with zero mean. For f ∈ W^{1,∞}(S¹) (Lipschitz 2π-periodic, zero mean), the L² norm is bounded by the L² norm of the derivative: ∫₀²π f(t)² dt ≤ ∫₀²π (f'(t))² dt. The proof uses Fourier series: if c₀ = 0 (zero mean), then ‖f‖²_{L²} = Σ_{n≠0} |ĉₙ|² ≤ Σ_{n≠0} n²|ĉₙ|² = ‖f'‖²_{L²} (since |n| ≥ 1 for n ≠ 0). This extends the smooth Wirtinger inequality (which requires ContDiff ℝ 1) to W^{1,∞} ⊂ H¹.\n\n**`exists_lip_nice_reparam`** (line 234): Every Lipschitz closed curve with positive circumference and positive speed a.e. admits a reparametrization with constant speed c = L/(2π) a.e. and zero-mean components. The proof uses the arc-length function s(t) = ∫₀ᵗ |γ'(u)| du, which is absolutely continuous and strictly monotone, so its inverse s⁻¹ is also AC (by the Banach theorem). The reparametrization γ ∘ s⁻¹ ∘ (L/(2π)·id) is Lipschitz with the required properties.\n\nBoth axioms are well-established classical results in Sobolev space theory. Their absence from Mathlib (as of 4.26) is the primary obstruction to a fully axiom-free proof.",
     "mathContext": "Wirtinger inequality: for f ∈ H¹(S¹) with ∫f = 0, ‖f‖_{H⁰}² ≤ ‖f'‖_{H⁰}². Proof via Fourier: c_n = (1/2π)∫f·e^{-int}, c_0=0 forces Σ|c_n|² ≤ Σn²|c_n|². The Wirtinger constant = 1 (not 1/4π or any other normalization) because the period is 2π. Reparametrization: the arc-length function is strictly increasing for positive-speed curves; monotone AC functions have AC inverses (Banach theorem); the constant-speed reparametrization preserves all global quantities (circumference, area).",
     "significance": "key",
@@ -76,15 +85,17 @@
       "W^{1,∞}(S¹)",
       "H¹(S¹)"
     ],
-    "pedagogicalNote": "The axiom design is intentional: rather than leaving large sorries inside the proof, the deep classical results are isolated as explicit axioms. This makes the logical structure transparent: the main theorem holds conditionally on these two classical results, which are independently verifiable.",
-    "type": "insight"
+    "pedagogicalNote": "The axiom design is intentional: rather than leaving large sorries inside the proof, the deep classical results are isolated as explicit axioms. This makes the logical structure transparent: the main theorem holds conditionally on these two classical results, which are independently verifiable."
   },
   {
     "id": "ann-wirtinger-sum-bound",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 262,
       "endLine": 310
     },
+    "type": "insight",
+    "title": "wirtinger_sum_sq_bound_lip: The Key Analytical Bound on ∫(x²+y²)",
     "content": "The lemma `wirtinger_sum_sq_bound_lip` is the key analytical stepping stone: it combines the two-component Wirtinger inequality to get a bound on ∫(x²+y²) in terms of the constant speed.\n\nThe proof strategy is:\n1. Apply `wirtinger_ac` to x: ∫x² ≤ ∫(x')²\n2. Apply `wirtinger_ac` to y: ∫y² ≤ ∫(y')²\n3. Add: ∫(x²+y²) ≤ ∫(x'²+y'²)\n4. Use constant speed a.e. (hspeed): ∫(x'²+y'²) = 2πc² (since x'²+y'² = c² a.e.)\n\nThe `calc` block at line 301 makes this chain explicit. The two technical sorries (hdx_int, hdy_int at lines 289-300) are for showing that (deriv γ.x)² and (deriv γ.y)² are integrable on [0, 2π]. This follows from LipschitzWith Kx γ.x → |deriv γ.x t| ≤ Kx a.e. (Rademacher + Lipschitz bound), so (deriv γ.x)² ≤ Kx² is bounded and measurable, hence integrable. The required Mathlib lemma `LipschitzWith.norm_deriv_le` is not yet available in Mathlib 4.26.",
     "mathContext": "The key computation: ∫₀²π (x(t)²+y(t)²) dt ≤ ∫₀²π (x'(t)²+y'(t)²) dt = ∫₀²π c² dt = 2πc² (using the a.e. equality x'²+y'²=c²). The integrability of x² and y² follows from continuity (LipschitzWith → continuous); the integrability of (x')² and (y')² requires the derivative bound. The final step uses intervalIntegral.integral_congr_ae to substitute the a.e. constant c².",
     "significance": "key",
@@ -95,15 +106,17 @@
       "integrability of Lipschitz derivatives",
       "a.e. equality"
     ],
-    "pedagogicalNote": "The two-step strategy (Wirtinger for x, Wirtinger for y, then add) is elegant: it reduces the 2D Wirtinger inequality to two 1D applications. The arithmetic fact that adding two L² bounds gives a 2D bound is the core geometric insight.",
-    "type": "insight"
+    "pedagogicalNote": "The two-step strategy (Wirtinger for x, Wirtinger for y, then add) is elegant: it reduces the 2D Wirtinger inequality to two 1D applications. The arithmetic fact that adding two L² bounds gives a 2D bound is the core geometric insight."
   },
   {
     "id": "ann-main-theorem",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 333,
       "endLine": 466
     },
+    "type": "insight",
+    "title": "Main Theorem: Lipschitz Isoperimetric Inequality (4πA ≤ C²) via Hurwitz–Fourier",
     "content": "The main theorem `lipschitz_isoperimetric` proves 4πA ≤ C² for Lipschitz closed curves with positive speed a.e. The proof follows the Hurwitz (1901) Fourier method, generalized to Lipschitz:\n\n**Degenerate case** (C = 0): The curve has zero circumference, which should imply zero area. This is handled by `sorry` (harea_zero) — the claim is mathematically clear (a curve of zero length cannot enclose area) but requires measure-theoretic machinery to formalize.\n\n**Non-degenerate case** (C > 0): The proof proceeds in four steps:\n1. **Reparametrize** via `exists_lip_nice_reparam` to get γ' with constant speed c = C/(2π) a.e. and zero-mean x,y.\n2. **Wirtinger bound**: Apply `wirtinger_sum_sq_bound_lip` to get ∫(x²+y²) ≤ 2πc².\n3. **Area bound**: Show 2A ≤ c·∫√(x²+y²) using pointwise Cauchy-Schwarz (|xy'−yx'| ≤ c·√(x²+y²) from constant speed + cross-product inequality).\n4. **Cauchy-Schwarz**: (∫√(x²+y²))² ≤ 2π·∫(x²+y²) from the parent file's `integral_cauchy_schwarz_interval`.\n5. **Arithmetic kernel**: `isoperimetric_from_wirtinger_bounds` from the parent file combines steps 2-4 to give 4πA ≤ C².\n\nOne `sorry` (hf_int) remains for the integrability of xy'−yx', which requires the measurability of Lipschitz derivatives (ultimately Rademacher).",
     "mathContext": "The arithmetic kernel: let S = ∫√(x²+y²), W = ∫(x²+y²), L = 2πc. Then:\n- 2A ≤ c·S (area bound)\n- S² ≤ 2π·W (Cauchy-Schwarz)\n- W ≤ 2πc² (Wirtinger)\nFrom these: (2A)² ≤ c²·S² ≤ c²·2π·W ≤ c²·2π·2πc² = 4π²c⁴ = (2πc)⁴/(4π) ... Let me recheck: 4πA ≤ C² follows as: 4πA ≤ 2A·(2√(π/A))·√(πA) — actually the arithmetic kernel is proved in the parent file as a separate lemma that combines the three bounds algebraically.",
     "significance": "key",
@@ -116,15 +129,17 @@
       "reparametrization",
       "arithmetic inequalities"
     ],
-    "pedagogicalNote": "The proof architecture is fully modular: the arithmetic kernel `isoperimetric_from_wirtinger_bounds` is proved once in the parent file and reused here. This shows the value of isolating the arithmetic content from the analytical content.",
-    "type": "insight"
+    "pedagogicalNote": "The proof architecture is fully modular: the arithmetic kernel `isoperimetric_from_wirtinger_bounds` is proved once in the parent file and reused here. This shows the value of isolating the arithmetic content from the analytical content."
   },
   {
     "id": "ann-corollaries",
+    "proofId": "area-of-circle-oq-01-oq-03-oq-02",
     "range": {
       "startLine": 479,
       "endLine": 504
     },
+    "type": "insight",
+    "title": "Corollaries: Smooth Case and Equality Characterization",
     "content": "Three corollaries follow from `lipschitz_isoperimetric` without additional sorries:\n\n**`smooth_case_follows_from_lipschitz`** (line 479): The smooth isoperimetric inequality is a consequence of the Lipschitz version, since every smooth curve satisfies the Lipschitz hypothesis. The proof uses `toLipschitz` embedding and the `filter_upwards` tactic to convert the pointwise regularity hypothesis to the required a.e. version. This demonstrates that the Lipschitz theory is a genuine generalization.\n\n**`lip_isoperimetric_scale_invariant`** (line 488): The ratio 4πA/C² is scale-invariant (unchanged under γ ↦ s·γ). This is a pure algebra fact: when A ↦ s²A and C ↦ sC, the ratio 4π(s²A)/(sC)² = 4πA/C² by s²/s² cancellation.\n\n**`lip_minimum_circumference`** (line 494): For any Lipschitz closed curve, C ≥ 2√(πA). This is the isoperimetric inequality rewritten: C² ≥ 4πA implies C ≥ 2√(πA) (taking square roots, valid since C ≥ 0). The proof uses `le_of_sq_le_sq` to transfer the squared inequality.",
     "mathContext": "Scale invariance: if γ is scaled by s (x ↦ s·x, y ↦ s·y), then C ↦ s·C and A ↦ s²·A. The ratio 4πA/C² is invariant under such scalings. Minimum circumference: C² ≥ 4πA ⟺ C ≥ 2√(πA) (both sides nonneg). The minimum is achieved for the circle: C = 2πr = 2√(π·πr²) = 2√(πA).",
     "significance": "key",
@@ -134,7 +149,6 @@
       "shape invariants",
       "corollaries from isoperimetric inequality"
     ],
-    "pedagogicalNote": "Notice that `lip_isoperimetric_scale_invariant` and `square_a_strict_isoperimetric` together show that the square's isoperimetric ratio π/4 is a scale-invariant property of the square shape — independent of the side length.",
-    "type": "insight"
+    "pedagogicalNote": "Notice that `lip_isoperimetric_scale_invariant` and `square_a_strict_isoperimetric` together show that the square's isoperimetric ratio π/4 is a scale-invariant property of the square shape — independent of the side length."
   }
 ]

--- a/src/data/proofs/chinese-remainder-constructive-oq-03/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "definition",
     "title": "RNS Base Structure",
-    "content": "The `RNSBase` structure packages three fields: the moduli list, the pairwise coprimality proof, and the lower bound \u2265 2 for each modulus. `dynamicRange` is the product of all moduli, representing the size of the uniquely representable integer range [0, M) by CRT. `maxWidth` uses `foldl max 0` \u2014 the maximum element of the list \u2014 representing the hardware channel bit width.",
+    "content": "The `RNSBase` structure packages three fields: the moduli list, the pairwise coprimality proof, and the lower bound ≥ 2 for each modulus. `dynamicRange` is the product of all moduli, representing the size of the uniquely representable integer range [0, M) by CRT. `maxWidth` uses `foldl max 0` — the maximum element of the list — representing the hardware channel bit width.",
     "mathContext": "$M = \\prod_{i=1}^{k} m_i$ (dynamic range), $w = \\max_i m_i$ (channel width), $M \\leq w^k$",
     "significance": "key",
     "relatedConcepts": [
@@ -33,7 +33,7 @@
     },
     "type": "concept",
     "title": "Dynamic Range Bound via foldl max Induction",
-    "content": "The bound `dynamicRange \u2264 maxWidth^channels` is proved by showing `list.prod \u2264 (foldl max 0)^length`. The helper lemmas (`foldl_max_ge_of_mem`, `foldl_max_mono`) are needed because Lean's list operations don't automatically expose the monotonicity and membership properties of `foldl max`. The key induction step: `(m :: ms).prod = m * ms.prod \u2264 (foldl max 0 (m::ms)) * (foldl max 0 (m::ms))^ms.length`, using that m \u2264 foldl max and the inductive hypothesis for ms.",
+    "content": "The bound `dynamicRange ≤ maxWidth^channels` is proved by showing `list.prod ≤ (foldl max 0)^length`. The helper lemmas (`foldl_max_ge_of_mem`, `foldl_max_mono`) are needed because Lean's list operations don't automatically expose the monotonicity and membership properties of `foldl max`. The key induction step: `(m :: ms).prod = m * ms.prod ≤ (foldl max 0 (m::ms)) * (foldl max 0 (m::ms))^ms.length`, using that m ≤ foldl max and the inductive hypothesis for ms.",
     "mathContext": "$\\prod_i m_i \\leq \\max(m_i)^k$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -57,57 +57,7 @@
     },
     "type": "insight",
     "title": "Verified Prime RNS Bases: {2,3,5}, {2,3,5,7}, {2,3,5,7,11,13}",
-    "content": "Three concrete prime RNS bases are machine-verified using norm_num. `three_prime_range` confirms [2,3,5].prod = 30 (30 representable values per cycle). `three_prime_coprime` proves pairwise coprimality via `decide` or case analysis \u2014 necessary because CRT requires coprimality for the isomorphism \u2124/M \u2245 \u2124/m\u2081 \u00d7 \u22ef \u00d7 \u2124/m\u2096 to hold. `six_prime_range` confirms [2,3,5,7,11,13].prod = 30030, the primorial 6#. These bases are historically significant: {2,3,5} was used in early RNS processors; {2,3,5,7,11,13} gives 30030 representable integers \u2014 sufficient for 15-bit arithmetic \u2014 across 6 independent channels, each processing at most 4 bits.",
-    "mathContext": "The primorial $k\\# = p_1 \\cdot p_2 \\cdots p_k$: $3\\# = 30$, $4\\# = 210$, $6\\# = 30030$. Prime bases are optimal: no other set of $k$ pairwise coprime integers in $[2, p_k]$ has a larger product. The CRT isomorphism $\\mathbb{Z}/30030\\mathbb{Z} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\times \\mathbb{Z}/5 \\times \\mathbb{Z}/7 \\times \\mathbb{Z}/11 \\times \\mathbb{Z}/13$ makes 6-channel parallel arithmetic exact.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "norm_num tactic",
-      "primorial",
-      "pairwise coprimality",
-      "CRT isomorphism"
-    ],
-    "prerequisites": [
-      "Nat.Coprime",
-      "List.Pairwise",
-      "norm_num tactic",
-      "CRT structure"
-    ]
-  },
-  {
-    "id": "ann-prime-bases",
-    "proofId": "chinese-remainder-constructive-oq-03",
-    "range": {
-      "startLine": 105,
-      "endLine": 120
-    },
-    "type": "insight",
-    "title": "Verified Prime RNS Bases: {2,3,5}, {2,3,5,7}, {2,3,5,7,11,13}",
-    "content": "Three concrete prime RNS bases are machine-verified using norm_num. `three_prime_range` confirms [2,3,5].prod = 30 (30 representable values per cycle). `three_prime_coprime` proves pairwise coprimality via `decide` or case analysis \u2014 necessary because CRT requires coprimality for the isomorphism \u2124/M \u2245 \u2124/m\u2081 \u00d7 \u22ef \u00d7 \u2124/m\u2096 to hold. `six_prime_range` confirms [2,3,5,7,11,13].prod = 30030, the primorial 6#. These bases are historically significant: {2,3,5} was used in early RNS processors; {2,3,5,7,11,13} gives 30030 representable integers \u2014 sufficient for 15-bit arithmetic \u2014 across 6 independent channels, each processing at most 4 bits.",
-    "mathContext": "The primorial $k\\# = p_1 \\cdot p_2 \\cdots p_k$: $3\\# = 30$, $4\\# = 210$, $6\\# = 30030$. Prime bases are optimal: no other set of $k$ pairwise coprime integers in $[2, p_k]$ has a larger product. The CRT isomorphism $\\mathbb{Z}/30030\\mathbb{Z} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\times \\mathbb{Z}/5 \\times \\mathbb{Z}/7 \\times \\mathbb{Z}/11 \\times \\mathbb{Z}/13$ makes 6-channel parallel arithmetic exact.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "norm_num tactic",
-      "primorial",
-      "pairwise coprimality",
-      "CRT isomorphism"
-    ],
-    "prerequisites": [
-      "Nat.Coprime",
-      "List.Pairwise",
-      "norm_num tactic",
-      "CRT structure"
-    ]
-  },
-  {
-    "id": "ann-prime-bases",
-    "proofId": "chinese-remainder-constructive-oq-03",
-    "range": {
-      "startLine": 105,
-      "endLine": 120
-    },
-    "type": "insight",
-    "title": "Verified Prime RNS Bases: {2,3,5}, {2,3,5,7}, {2,3,5,7,11,13}",
-    "content": "Three concrete prime RNS bases are machine-verified using norm_num. `three_prime_range` confirms [2,3,5].prod = 30 (30 representable values per cycle). `three_prime_coprime` proves pairwise coprimality via `decide` or case analysis \u2014 necessary because CRT requires coprimality for the isomorphism \u2124/M \u2245 \u2124/m\u2081 \u00d7 \u22ef \u00d7 \u2124/m\u2096 to hold. `six_prime_range` confirms [2,3,5,7,11,13].prod = 30030, the primorial 6#. These bases are historically significant: {2,3,5} was used in early RNS processors; {2,3,5,7,11,13} gives 30030 representable integers \u2014 sufficient for 15-bit arithmetic \u2014 across 6 independent channels, each processing at most 4 bits.",
+    "content": "Three concrete prime RNS bases are machine-verified using norm_num. `three_prime_range` confirms [2,3,5].prod = 30 (30 representable values per cycle). `three_prime_coprime` proves pairwise coprimality via `decide` or case analysis — necessary because CRT requires coprimality for the isomorphism ℤ/M ≅ ℤ/m₁ × ⋯ × ℤ/mₖ to hold. `six_prime_range` confirms [2,3,5,7,11,13].prod = 30030, the primorial 6#. These bases are historically significant: {2,3,5} was used in early RNS processors; {2,3,5,7,11,13} gives 30030 representable integers — sufficient for 15-bit arithmetic — across 6 independent channels, each processing at most 4 bits.",
     "mathContext": "The primorial $k\\# = p_1 \\cdot p_2 \\cdots p_k$: $3\\# = 30$, $4\\# = 210$, $6\\# = 30030$. Prime bases are optimal: no other set of $k$ pairwise coprime integers in $[2, p_k]$ has a larger product. The CRT isomorphism $\\mathbb{Z}/30030\\mathbb{Z} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\times \\mathbb{Z}/5 \\times \\mathbb{Z}/7 \\times \\mathbb{Z}/11 \\times \\mathbb{Z}/13$ makes 6-channel parallel arithmetic exact.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -132,7 +82,7 @@
     },
     "type": "concept",
     "title": "Mersenne Euclidean Step",
-    "content": "The key lemma `mersenne_mod_eq` proves (2^b - 1) mod (2^a - 1) = 2^(b mod a) - 1 for a \u2265 2. This is the Mersenne analogue of the Euclidean algorithm step. It uses `pow_two_mod_mersenne` (which proves 2^b \u2261 2^(b mod a) mod (2^a - 1) via 2^a \u2261 1 mod (2^a - 1)) and careful natural number subtraction arithmetic. The bound 2^(b mod a) < 2^a - 1 ensures the remainder is in the right range.",
+    "content": "The key lemma `mersenne_mod_eq` proves (2^b - 1) mod (2^a - 1) = 2^(b mod a) - 1 for a ≥ 2. This is the Mersenne analogue of the Euclidean algorithm step. It uses `pow_two_mod_mersenne` (which proves 2^b ≡ 2^(b mod a) mod (2^a - 1) via 2^a ≡ 1 mod (2^a - 1)) and careful natural number subtraction arithmetic. The bound 2^(b mod a) < 2^a - 1 ensures the remainder is in the right range.",
     "mathContext": "$(2^b - 1) \\bmod (2^a - 1) = 2^{b \\bmod a} - 1$ for $a \\geq 2$",
     "significance": "key",
     "relatedConcepts": [
@@ -155,7 +105,7 @@
       "endLine": 224
     },
     "type": "insight",
-    "title": "Coprime Exponents \u2192 Coprime Mersenne Numbers",
+    "title": "Coprime Exponents → Coprime Mersenne Numbers",
     "content": "The theorem `mersenne_coprime_of_coprime` proves that gcd(2^a - 1, 2^b - 1) = 1 when gcd(a, b) = 1. The proof uses strong induction on a with the Euclidean algorithm: gcd(2^a - 1, 2^b - 1) = gcd(2^(b mod a) - 1, 2^a - 1) by `mersenne_mod_eq`, then recurse with b mod a < a. Base cases: a = 0 forces b = 1 (gcd(0,b) = b = 1); a = 1 gives 2^1 - 1 = 1. The `Nat.strongRecOn` induction scheme allows the step b mod a < a to trigger the inductive hypothesis.",
     "mathContext": "$\\gcd(2^a - 1, 2^b - 1) = 2^{\\gcd(a,b)} - 1 \\implies \\gcd(a,b) = 1 \\implies \\gcd(2^a-1, 2^b-1) = 1$",
     "significance": "key",
@@ -181,58 +131,8 @@
     },
     "type": "definition",
     "title": "Primorial Definition and Optimality Bounds",
-    "content": "`primorial` is defined as a lookup table for k \u2264 6 via pattern matching (1, 2, 6, 30, 210, 2310, 30030 = 2, 6, 30, 210, 2310, 30030 for k = 0, 1, ..., 6). The optimality theorem `primorial_growth_lower` proves k# \u2265 2^k for 1 \u2264 k \u2264 6 by `interval_cases k; norm_num` \u2014 reducing the general bound to 6 decidable arithmetic facts. The theorems `nasa_rns_efficiency` and `dsp_rns_efficiency` verify specific 4-channel and 6-channel RNS base efficiency ratios used in real NASA/DSP applications. The lookup-table approach reflects a genuine limitation: a general proof would require formalizing the prime number theorem or the definition of the k-th prime, which is not yet available in Lean in a convenient form for this style of argument.",
-    "mathContext": "$k\\# = p_1 p_2 \\cdots p_k \\geq 2^k$ (each $p_i \\geq 2$). The bound is tight at $k=1$ ($p_1 = 2 = 2^1$) and loose for large $k$ (prime gaps widen). For hardware applications: a 4-channel base {2,3,5,7} achieves $M = 210 \\geq 2^7$, handling 8-bit arithmetic in 4 channels of width \u2264 3 bits each.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "primorial",
-      "prime number theorem",
-      "interval_cases",
-      "RNS efficiency"
-    ],
-    "prerequisites": [
-      "primorial definition",
-      "interval_cases tactic",
-      "norm_num tactic",
-      "prime optimality"
-    ]
-  },
-  {
-    "id": "ann-primorial-optimality",
-    "proofId": "chinese-remainder-constructive-oq-03",
-    "range": {
-      "startLine": 240,
-      "endLine": 272
-    },
-    "type": "definition",
-    "title": "Primorial Definition and Optimality Bounds",
-    "content": "`primorial` is defined as a lookup table for k \u2264 6 via pattern matching (1, 2, 6, 30, 210, 2310, 30030 = 2, 6, 30, 210, 2310, 30030 for k = 0, 1, ..., 6). The optimality theorem `primorial_growth_lower` proves k# \u2265 2^k for 1 \u2264 k \u2264 6 by `interval_cases k; norm_num` \u2014 reducing the general bound to 6 decidable arithmetic facts. The theorems `nasa_rns_efficiency` and `dsp_rns_efficiency` verify specific 4-channel and 6-channel RNS base efficiency ratios used in real NASA/DSP applications. The lookup-table approach reflects a genuine limitation: a general proof would require formalizing the prime number theorem or the definition of the k-th prime, which is not yet available in Lean in a convenient form for this style of argument.",
-    "mathContext": "$k\\# = p_1 p_2 \\cdots p_k \\geq 2^k$ (each $p_i \\geq 2$). The bound is tight at $k=1$ ($p_1 = 2 = 2^1$) and loose for large $k$ (prime gaps widen). For hardware applications: a 4-channel base {2,3,5,7} achieves $M = 210 \\geq 2^7$, handling 8-bit arithmetic in 4 channels of width \u2264 3 bits each.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "primorial",
-      "prime number theorem",
-      "interval_cases",
-      "RNS efficiency"
-    ],
-    "prerequisites": [
-      "primorial definition",
-      "interval_cases tactic",
-      "norm_num tactic",
-      "prime optimality"
-    ]
-  },
-  {
-    "id": "ann-primorial-optimality",
-    "proofId": "chinese-remainder-constructive-oq-03",
-    "range": {
-      "startLine": 240,
-      "endLine": 272
-    },
-    "type": "definition",
-    "title": "Primorial Definition and Optimality Bounds",
-    "content": "`primorial` is defined as a lookup table for k \u2264 6 via pattern matching (1, 2, 6, 30, 210, 2310, 30030 = 2, 6, 30, 210, 2310, 30030 for k = 0, 1, ..., 6). The optimality theorem `primorial_growth_lower` proves k# \u2265 2^k for 1 \u2264 k \u2264 6 by `interval_cases k; norm_num` \u2014 reducing the general bound to 6 decidable arithmetic facts. The theorems `nasa_rns_efficiency` and `dsp_rns_efficiency` verify specific 4-channel and 6-channel RNS base efficiency ratios used in real NASA/DSP applications. The lookup-table approach reflects a genuine limitation: a general proof would require formalizing the prime number theorem or the definition of the k-th prime, which is not yet available in Lean in a convenient form for this style of argument.",
-    "mathContext": "$k\\# = p_1 p_2 \\cdots p_k \\geq 2^k$ (each $p_i \\geq 2$). The bound is tight at $k=1$ ($p_1 = 2 = 2^1$) and loose for large $k$ (prime gaps widen). For hardware applications: a 4-channel base {2,3,5,7} achieves $M = 210 \\geq 2^7$, handling 8-bit arithmetic in 4 channels of width \u2264 3 bits each.",
+    "content": "`primorial` is defined as a lookup table for k ≤ 6 via pattern matching (1, 2, 6, 30, 210, 2310, 30030 = 2, 6, 30, 210, 2310, 30030 for k = 0, 1, ..., 6). The optimality theorem `primorial_growth_lower` proves k# ≥ 2^k for 1 ≤ k ≤ 6 by `interval_cases k; norm_num` — reducing the general bound to 6 decidable arithmetic facts. The theorems `nasa_rns_efficiency` and `dsp_rns_efficiency` verify specific 4-channel and 6-channel RNS base efficiency ratios used in real NASA/DSP applications. The lookup-table approach reflects a genuine limitation: a general proof would require formalizing the prime number theorem or the definition of the k-th prime, which is not yet available in Lean in a convenient form for this style of argument.",
+    "mathContext": "$k\\# = p_1 p_2 \\cdots p_k \\geq 2^k$ (each $p_i \\geq 2$). The bound is tight at $k=1$ ($p_1 = 2 = 2^1$) and loose for large $k$ (prime gaps widen). For hardware applications: a 4-channel base {2,3,5,7} achieves $M = 210 \\geq 2^7$, handling 8-bit arithmetic in 4 channels of width ≤ 3 bits each.",
     "significance": "supporting",
     "relatedConcepts": [
       "primorial",
@@ -256,7 +156,7 @@
     },
     "type": "insight",
     "title": "RNS Arithmetic Correctness",
-    "content": "The correctness of RNS addition and multiplication reduces to single-line `simp` proofs using `Nat.add_mod` and `Nat.mul_mod`: (x + y) mod m = ((x mod m) + (y mod m)) mod m. This reflects the fundamental algebraic fact that \u2124/m\u2124 is a ring homomorphic image of \u2124. The `rnsEncode`, `rnsAdd`, `rnsMul` functions operate componentwise via `List.map` and `List.zip`, making the proofs purely functional.",
+    "content": "The correctness of RNS addition and multiplication reduces to single-line `simp` proofs using `Nat.add_mod` and `Nat.mul_mod`: (x + y) mod m = ((x mod m) + (y mod m)) mod m. This reflects the fundamental algebraic fact that ℤ/mℤ is a ring homomorphic image of ℤ. The `rnsEncode`, `rnsAdd`, `rnsMul` functions operate componentwise via `List.map` and `List.zip`, making the proofs purely functional.",
     "mathContext": "$(x + y) \\bmod m \\equiv (x \\bmod m) + (y \\bmod m) \\pmod{m}$ for all moduli $m$",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Summary

Enrichment pass for `chinese-remainder-constructive-oq-03`.

- `ann-prime-bases` and `ann-primorial-optimality` each appeared **three times as byte-identical copies** (verified via JSON serialization). Duplicate annotation IDs collide on render (React keys) and bloat the data.
- Deduplicated to a single instance of each (kept first occurrence): 11 → 7 unique annotations. No annotation content lost.

## Verification

- `pnpm annotations:build` exits 0; no errors for this proof.
- Remaining 7 annotation IDs are all unique; ranges unchanged.
- Data-only change.