### PR TITLE
research(erdos-27): realign gallery sections to file (9→11)

### DIFF
--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -97,8 +97,16 @@
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Problem Statement",
+      "summary": "File docstring stating Erdős Problem #27 (the $100 question, DISPROVED by Filaseta–Ford–Konyagin–Pomerance–Yu, JAMS 2007), the definition of an ε-almost covering system, and the `Erdos27` namespace.",
+      "startLine": 1,
+      "endLine": 44,
+      "mathContext": "An $\\varepsilon$-almost covering system is a finite set of congruences $a_i \\pmod{n_i}$ with distinct moduli whose set of uncovered integers has density $\\le \\varepsilon$. Problem #27 asked whether a single $C>1$ makes such systems possible with all moduli in $[N, CN]$, for every $\\varepsilon>0$ and $N$."
+    },
+    {
       "id": "congruence-systems",
-      "title": "Congruence Systems",
+      "title": "Part I — Congruence Systems",
       "summary": "Defines **Congruence** (residue/modulus), **CongruenceSystem** (finite set with distinct moduli), **covers** ($\\exists c, x \\equiv c.a \\pmod{c.n}$), and **uncovered** ($\\forall c, x \\not\\equiv c.a \\pmod{c.n}$).",
       "startLine": 45,
       "endLine": 70,
@@ -106,67 +114,75 @@
     },
     {
       "id": "density",
-      "title": "Uncovered Density",
+      "title": "Part II — Density of Uncovered Integers",
       "summary": "Defines **uncoveredCount** (integers in $[1,M]$ uncovered), **uncoveredDensity** (fraction), and **asymptoticUncoveredDensity** ($\\liminf$ as $M \\to \\infty$).",
       "startLine": 71,
       "endLine": 84,
-      "mathContext": "Formal definition: Defines **uncoveredCount** (integers in $[1,M]$ uncovered), **uncoveredDensity** (fraction), and **asymptoticUncoveredDensity** ($\\liminf$ as $M \\to \\infty$)."
+      "mathContext": "Defines **uncoveredCount** (integers in $[1,M]$ uncovered), **uncoveredDensity** (fraction), and **asymptoticUncoveredDensity** ($\\liminf$ as $M \\to \\infty$)."
     },
     {
       "id": "almost-covering",
-      "title": "Almost Covering Systems",
-      "summary": "Defines **IsAlmostCovering** ($\\delta(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$). Proves perfect $\\Rightarrow$ $0$-almost (sorry).",
+      "title": "Part III — Almost and Perfect Covering Systems",
+      "summary": "Defines **IsAlmostCovering** ($\\delta(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$), and proves **perfect_is_zero_almost**: every perfect covering is a $0$-almost covering.",
       "startLine": 85,
       "endLine": 112,
-      "mathContext": "Defines **IsAlmostCovering** ($\\$\\delta$(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$). Proves perfect $\\Rightarrow$ $0$-almost (sorry)."
+      "mathContext": "Defines **IsAlmostCovering** ($\\delta(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$); proves perfect $\\Rightarrow$ $0$-almost since a perfect system leaves no uncovered integers."
     },
     {
       "id": "bounded-moduli",
-      "title": "Bounded Moduli Systems",
+      "title": "Part IV — Bounded Moduli Systems",
       "summary": "Defines **HasModuliInRange** (moduli in $[N,M]$) and **HasModuliInCRange** (moduli in $[N, \\lfloor CN\\rfloor]$). The bounded-range constraint is what makes the problem nontrivial.",
       "startLine": 113,
-      "endLine": 121,
-      "mathContext": "Formal definition: Defines **HasModuliInRange** (moduli in $[N,M]$) and **HasModuliInCRange** (moduli in $[N, \\lfloor CN\\rfloor]$). The bounded-range constraint is what makes the problem nontrivial."
+      "endLine": 122,
+      "mathContext": "Defines **HasModuliInRange** (moduli in $[N,M]$) and **HasModuliInCRange** (moduli in $[N, \\lfloor CN\\rfloor]$). The bounded-range constraint is what makes the problem nontrivial."
     },
     {
       "id": "natural-density",
-      "title": "Natural Density Bound",
-      "summary": "Defines **naturalDensity** = $\\prod(1-1/n)$ over moduli range. States the averaging bound (exists system achieving this density) and that it vanishes as the range grows.",
+      "title": "Part V — The Natural Density Product",
+      "summary": "Defines **naturalDensity** $= \\prod_{n}(1-1/n)$ over a moduli range, proves the telescoping identity **naturalDensity_eq_inv** ($\\prod_{n=2}^{k}(1-1/n) = 1/k$), and proves **naturalDensity_vanishes** (the product → 0 as the range grows).",
       "startLine": 123,
-      "endLine": 177,
-      "mathContext": "Formal definition: Defines **naturalDensity** = $\\prod(1-1/n)$ over moduli range. States the averaging bound (exists system achieving this density) and that it vanishes as the range grows."
+      "endLine": 178,
+      "mathContext": "Telescoping: $\\prod_{n=2}^{k}\\left(1-\\frac1n\\right) = \\prod_{n=2}^{k}\\frac{n-1}{n} = \\frac1k \\to 0$, giving the heuristic for why bounded-modulus covering is hard."
     },
     {
       "id": "main-question",
-      "title": "The Main Question",
-      "summary": "States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail). Proves they are logical opposites (sorry).",
+      "title": "Part VI — The Main Question",
+      "summary": "States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail), and proves **conjecture_dichotomy**: the two are logical opposites.",
       "startLine": 179,
-      "endLine": 202,
-      "mathContext": "Verified: States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail). Proves they are logical opposites (sorry)."
+      "endLine": 203,
+      "mathContext": "States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail); the dichotomy $\\text{Conjecture} \\iff \\neg\\text{Negation}$ is proved."
     },
     {
-      "id": "disproof",
-      "title": "The FFKPY Disproof",
-      "summary": "Defines **criticalExponent** $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$. States **ffkpy_main_theorem** (density lower bound for $C \\leq N^{\\alpha(N)}$), **product_bounded_below** ($\\prod \\geq 1/C$), **erdos_27_disproved**, and **no_universal_constant**.",
+      "id": "critical-exponent",
+      "title": "Part VII — Critical Exponent and Growth Rates",
+      "summary": "Defines **criticalExponent** $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$, the sufficient growth rate **sufficientC** $= N^{1/\\log\\log N}$, and the explicit constant **perfectCoveringBound** $= 616000$.",
       "startLine": 204,
+      "endLine": 221,
+      "mathContext": "$\\alpha(N) = \\dfrac{\\log\\log\\log N}{4\\log\\log N}$ marks the threshold below which fixed $C \\le N^{\\alpha(N)}$ cannot achieve almost-covering; $C(N) = N^{1/\\log\\log N}$ grows just fast enough to succeed."
+    },
+    {
+      "id": "deep-results",
+      "title": "Part VIII — Deep Results (FFKPY 2007 and BBMST 2024)",
+      "summary": "States the four external results as axioms: **erdos_27_ffkpy** (the disproof, JAMS 2007), **growing_C_achieves** (a growing $C$ does achieve almost-covering), **averaging_bound_exists** (an averaging argument), and **bbmst_2024** (Bloom–Briggs–Maynard–Smith–Tao bound on the minimum modulus).",
+      "startLine": 222,
       "endLine": 270,
-      "mathContext": "Defines **criticalExponent** $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$. States **ffkpy_main_theorem** (density lower bound for $C \\leq N^{\\alpha(N)}$), **product_bounded_below** ($\\prod \\geq 1/C$), **erdos_27_disproved**, and **no_universal_constant**."
+      "mathContext": "These four `axiom` declarations import the deep number-theoretic results: FFKPY's disproof of the fixed-$C$ conjecture, the positive direction for growing $C$, the averaging existence bound, and the 2024 perfect-covering minimum-modulus bound ($< 616{,}000$)."
     },
     {
-      "id": "what-works",
-      "title": "What Does Work",
-      "summary": "Proves **growing_C_works** (growing $C(N)$ achieves almost-covering). Defines **sufficientC** = $N^{1/\\log\\log N}$ and states it suffices for any fixed $\\varepsilon$.",
-      "startLine": 243,
-      "endLine": 252,
-      "mathContext": "Formal definition: Proves **growing_C_works** (growing $C(N)$ achieves almost-covering). Defines **sufficientC** = $N^{1/\\log\\log N}$ and states it suffices for any fixed $\\varepsilon$."
+      "id": "main-theorems",
+      "title": "Part IX — Main Theorems",
+      "summary": "Derives the headline results from the axioms: **erdos_27_disproved** and **erdos_27_conjecture_false** (Problem #27 is DISPROVED), **no_universal_constant**, **growing_C_works**, **bbmst_bound** / **perfect_covering_min_modulus** (minimum modulus $< 616{,}000$), and the concrete instance **ffkpy_C_eq_2**.",
+      "startLine": 271,
+      "endLine": 318,
+      "mathContext": "The conjecture is false: $\\neg\\text{ErdosConjecture}$ follows from the dichotomy and the FFKPY axiom; every perfect covering has a modulus below the explicit bound $616{,}000$."
     },
     {
-      "id": "perfect-covering",
-      "title": "Perfect Covering Connection",
-      "summary": "States **perfect_covering_min_modulus** (some modulus is bounded) and **bbmst_bound** (minimum modulus $< 616{,}000$ by Bloom-Briggs-Maynard-Smith-Tao).",
-      "startLine": 267,
-      "endLine": 310,
-      "mathContext": "Bound: States **perfect_covering_min_modulus** (some modulus is bounded) and **bbmst_bound** (minimum modulus $< 616{,}000$ by Bloom-Briggs-Maynard-Smith-Tao)."
+      "id": "summary",
+      "title": "Summary",
+      "summary": "Closing comment block recapping the result ($100 problem, disproved by FFKPY 2007) and listing the eleven formalized items, including the final tally of 0 sorries and 4 axioms.",
+      "startLine": 319,
+      "endLine": 340,
+      "mathContext": "Final status: the file derives all main theorems from 4 axioms (the deep external results) with 0 sorries."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Realigns the drifted `sections` array in `src/data/proofs/erdos-27/meta.json` to match the actual 340-line `Proofs/Erdos27Problem.lean`.

- Rebuilds to **11 contiguous sections** tiling lines 1–340, aligned to the file's nine `## Part I–IX` banners plus an Imports/Problem-Statement header (1–44) and the trailing Summary block (319–340) — both previously uncovered.
- Fixes the scrambled back half: the old "The FFKPY Disproof" (204–270) lumped Parts VII+VIII, while "What Does Work" (243–252) and "Perfect Covering Connection" (267–310) overlapped it out of order and named theorems not present in the file. New sections split cleanly into **Part VII (Critical Exponent)**, **Part VIII (Deep Results / 4 axioms)**, and **Part IX (Main Theorems)**.
- Drops stale `(sorry)` annotations: `perfect_is_zero_almost` and `conjecture_dichotomy` are both fully proved (file has 0 sorries).

## Counts (verified, unchanged)
- 340 lines, **4 axioms**, **11 theorems**, **18 definitions**, **0 sorries** — all already correct in meta.

## Test plan
- [x] JSON validates; sections tile lines 1–340 contiguously with no gaps or overlaps
- [x] Section ranges verified against `## Part` banners in the Lean source
- [x] axiom/theorem/def/sorry counts re-derived from source and match meta
- [x] Diff limited to `erdos-27/meta.json`