### PR TITLE
Enrich erdos-335: fix duplicate annotation ID

### DIFF
--- a/src/data/proofs/erdos-335/annotations.json
+++ b/src/data/proofs/erdos-335/annotations.json
@@ -93,7 +93,7 @@
     ]
   },
   {
-    "id": "erdos-335-ann-density",
+    "id": "erdos-335-ann-asymptotic-density",
     "proofId": "erdos-335",
     "range": {
       "startLine": 34,


### PR DESCRIPTION
## Summary

Two distinct annotations on `erdos-335` — "Counting Function" and "Asymptotic Density" — shared the same ID `erdos-335-ann-density`, causing a React render-key collision (one can mask the other).

- Renamed the second to `erdos-335-ann-asymptotic-density`. Both annotations retained; only the duplicate ID was changed.

## Verification
- `pnpm annotations:build` exits 0; all annotation IDs in this proof now unique.
- Data-only change.