### PR TITLE
research(roth-theorem-k3-oq-03): realign gallery sections to full file (8→11)

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -47,68 +47,92 @@
   },
   "sections": [
     {
-      "id": "kap-free",
-      "title": "Part I: k-AP-Free Sets and Equivalence with APFree",
+      "id": "header",
+      "title": "Module Header and Namespace",
+      "summary": "File header and `RothTheoremOQ03` namespace for the OQ-03 study of how Roth's $k=3$ theorem extends to $k$-term progressions (Szemerédi) via the Gowers-norm / density-increment framework.",
       "startLine": 1,
-      "endLine": 63,
-      "summary": "Defines `IsKAPFreeZMod A k` using Fin k as AP index. Proves `apFree_of_isKAPFreeZMod_three` and `isKAPFreeZMod_three_of_apFree` — the equivalence with Szemeredi.Roth.APFree for k=3 — using fin_cases on Fin 3.",
-      "mathContext": "`IsKAPFreeZMod A k`: $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ contains no $k$-term AP, i.e., $\\nexists x, d \\neq 0: \\{x, x+d, \\ldots, x+(k-1)d\\} \\subseteq A$. Encoded as $\\forall x\\, d \\neq 0,\\, \\lnot (\\forall i : \\text{Fin}\\, k,\\, x + i \\cdot d \\in A)$. The equivalence `apFree_of_isKAPFreeZMod_three`/`isKAPFreeZMod_three_of_apFree` bridges this to Mathlib's `Szemeredi.Roth.APFree` (which uses a different encoding), proved by `fin_cases` on `Fin 3` to handle all cases $i \\in \\{0, 1, 2\\}$."
+      "endLine": 32,
+      "mathContext": "Roth ($k=3$) vs Szemerédi ($k\\ge3$): both via density increment, but $k=3$ uses Fourier ($U^2$) while $k\\ge4$ needs Gowers $U^{k-1}$ norms."
     },
     {
-      "id": "structural-lemmas",
+      "id": "part1-kap-free",
+      "title": "Part I: k-AP-Free Sets in ZMod N",
+      "summary": "Defines `IsKAPFreeZMod A k` (no $k$-term arithmetic progression in $A\\subseteq\\mathbb{Z}/N$) and proves it agrees with the existing `APFree` predicate at $k=3$ (`apFree_of_isKAPFreeZMod_three`, `isKAPFreeZMod_three_of_apFree`).",
+      "startLine": 33,
+      "endLine": 64,
+      "mathContext": "`IsKAPFreeZMod A k`: $A$ contains no nontrivial $k$-AP; equivalent to `APFree` for $k=3$."
+    },
+    {
+      "id": "part1_5-structural-lemmas",
       "title": "Part I.5: Structural Lemmas for IsKAPFreeZMod",
+      "summary": "Basic closure properties: `isKAPFreeZMod_empty`, `isKAPFreeZMod_subset`, `isKAPFreeZMod_succ` (monotone in $k$), `isKAPFreeZMod_singleton`, and `isKAPFreeZMod_three_iff_apFree`.",
       "startLine": 65,
-      "endLine": 121,
-      "summary": "Routine structural facts about `IsKAPFreeZMod`: `isKAPFreeZMod_empty` (∅ is k-AP-free for k ≥ 1), `isKAPFreeZMod_subset` (downward closed under inclusion), `isKAPFreeZMod_succ` (k-AP-free → (k+1)-AP-free), `isKAPFreeZMod_singleton` (singleton is k-AP-free for k ≥ 2), and the convenience iff `isKAPFreeZMod_three_iff_apFree` bundling the two k=3 bridge directions. Mirrors the existing apFree_empty / apFree_subset / apFree_singleton trio in `Szemeredi.Roth` at the general-k level.",
-      "mathContext": "**Set-monotonicity** $B \\subseteq A,\\ A\\text{ is }k\\text{-AP-free} \\Rightarrow B\\text{ is }k\\text{-AP-free}$ is immediate by transporting the AP witness. **k-monotonicity** $A\\text{ is }k\\text{-AP-free} \\Rightarrow A\\text{ is }(k{+}1)\\text{-AP-free}$ follows because any $(k{+}1)$-AP $\\{a, a+d, \\ldots, a+kd\\}$ contains the initial $k$-AP $\\{a, \\ldots, a+(k-1)d\\}$ as a sub-AP — formalized via `Fin.castSucc : Fin k \\hookrightarrow Fin (k+1)`. **Singleton case** uses positions $0$ and $1$ to derive $a = x$ and $a + d = x$, so $d = 0$ via additive cancellation, contradicting $d \\neq 0$ — needs $k \\geq 2$ to access position $1$. The empty case requires $k \\geq 1$ to extract any AP element."
+      "endLine": 122,
+      "mathContext": "$k$-AP-freeness is hereditary (subsets) and monotone in $k$; singletons are $k$-AP-free for $k\\ge2$."
     },
     {
-      "id": "gowers-norms",
-      "title": "Parts II-III: Gowers Norms and k-AP Counting Operator",
+      "id": "part2-gowers-norms",
+      "title": "Part II: Gowers Uniformity Norms",
+      "summary": "Defines the Gowers $U^s$ norm machinery: `hypercubeShift`, `conjugateByWeight`, and `gowersNorm N s f` — the analytic measure of (non-)uniformity used to count progressions.",
       "startLine": 123,
-      "endLine": 180,
-      "summary": "Defines `hypercubeShift h ω = Σᵢ (if ω i then h i else 0)`, `conjugateByWeight ω z` (conjugates when Hamming weight is odd), `gowersNorm N s f` (U^s norm via hypercube average), and `kAPCount k f` (arithmetic progression counting operator as double average over (x,d)).",
-      "mathContext": "**Gowers $U^s$ norm**: $\\|f\\|_{U^s}^{2^s} = \\mathbb{E}_{x, h_1, \\ldots, h_s} \\prod_{\\omega \\in \\{0,1\\}^s} \\mathcal{C}^{|\\omega|} f(x + \\omega_1 h_1 + \\cdots + \\omega_s h_s)$ where $\\mathcal{C}$ is complex conjugation (applied when $|\\omega| = \\sum_i \\omega_i$ is odd). Lean encoding: `hypercubeShift h ω = Σ i, if ω i then h i else 0` gives the corner $x + \\omega \\cdot \\mathbf{h}$; `conjugateByWeight ω z = if Odd |ω| then conj z else z`. **k-AP counting operator**: `kAPCount k f = E_{x,d} ∏_{i<k} f_i(x + i·d)` — the normalized count of $k$-APs weighted by $f_0, \\ldots, f_{k-1}$."
+      "endLine": 161,
+      "mathContext": "$\\|f\\|_{U^s}$ measures correlation with degree-$(s-1)$ structure; $U^2$ reduces to the Fourier $L^4$ norm."
     },
     {
-      "id": "von-neumann-axiom",
-      "title": "Part IV: Generalized von Neumann Theorem (Axiom)",
+      "id": "part3-kap-counting",
+      "title": "Part III: k-AP Counting Operator",
+      "summary": "Defines `kAPCount`, the multilinear operator $\\Lambda_k(f_1,\\dots,f_k)$ counting $k$-term progressions, whose deviation from the expected value is controlled by Gowers norms.",
+      "startLine": 162,
+      "endLine": 181,
+      "mathContext": "$\\Lambda_k(f_1,\\dots,f_k)=\\mathbb{E}\\,f_1(x)f_2(x+d)\\cdots f_k(x+(k-1)d)$."
+    },
+    {
+      "id": "part4-von-neumann",
+      "title": "Part IV: Generalized von Neumann Theorem",
+      "summary": "Commentary on the generalized von Neumann theorem ($|\\Lambda_k(f_1,\\dots,f_k)-\\prod\\mathbb{E}f_i|\\le\\min_i\\|f_i\\|_{U^{k-1}}$), whose proof needs the Gowers–Cauchy–Schwarz inequality — described but not axiomatized (beyond current Mathlib scope).",
       "startLine": 182,
-      "endLine": 199,
-      "summary": "Axiom `generalized_von_neumann`: |kAPCount k f| ≤ gowersNorm N (k-1) (f 0) when each |f i x| ≤ 1. The docstring explains the Gowers-Cauchy-Schwarz inequality needed for the proof.",
-      "mathContext": "**Generalized von Neumann theorem**: $|\\Lambda_k(f_0, \\ldots, f_{k-1})| \\leq \\min_i \\|f_i\\|_{U^{k-1}}$ where $\\Lambda_k$ is the $k$-AP counting operator and $\\|\\cdot\\|_{U^{k-1}}$ is the Gowers $(k-1)$-norm. Proved via iterative Cauchy-Schwarz on the hypercube: each application squares one function while halving the number of free parameters, until only one function remains — giving control by the $U^{k-1}$ norm. For $k=3$ this is $|\\Lambda_3(f,g,h)| \\leq \\|f\\|_{U^2}$ (Fourier $L^4$ norm), the key step in Roth's theorem."
+      "endLine": 200,
+      "mathContext": "Generalized von Neumann: the $k$-AP count is controlled by the $U^{k-1}$ norm of any factor."
     },
     {
-      "id": "density-increment-axiom",
-      "title": "Parts V-VI: Inverse Theorem + Density Increment for k≥3 (Axiom)",
+      "id": "part5-inverse-theorem",
+      "title": "Part V: The Inverse Theorem",
+      "summary": "Commentary on the inverse theorem for Gowers norms (large $\\|f\\|_{U^s}$ implies correlation with a degree-$(s-1)$ nilsequence): the $s=2$ Fourier case underlies Roth, while $s\\ge3$ (Gowers 1998, Green–Tao–Ziegler 2012) needs nilmanifold infrastructure not yet in Mathlib — explicitly not axiomatized.",
       "startLine": 201,
-      "endLine": 258,
-      "summary": "Docstring for the inverse theorem (U^{k-1} large → nilsequence correlation). Axiom `density_increment_kAP`: k-AP-free A with density δ has a subprogression A' with higher density and still k-AP-free.",
-      "mathContext": "**Inverse theorem** (Green-Tao-Ziegler 2012): $\\|f\\|_{U^{k-1}} \\geq \\varepsilon$ implies $\\langle f, \\phi \\rangle \\geq \\delta(\\varepsilon)$ for some $(k-2)$-step nilsequence $\\phi$. This is the deep structure theorem converting Gowers norm control into correlation with algebraically structured functions. **Density increment** (axiom): if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ is $k$-AP-free with density $\\delta$, then $\\exists$ subprogression $P$ of length $M \\geq N^c$ with $\\delta(A \\cap P) \\geq \\delta + g(\\delta, k) > \\delta$. For $k \\geq 4$ the function $g$ is tower-type; for $k=3$, $g(\\delta,3) = \\delta^2/100$ (Roth)."
+      "endLine": 225,
+      "mathContext": "Inverse theorem: $\\|f\\|_{U^2}\\ge\\delta\\Rightarrow$ large Fourier coefficient ($k=3$); $U^3\\Rightarrow$ quadratic phase ($k=4$)."
     },
     {
-      "id": "szemeredi-sorry",
-      "title": "Part VII: Szemerédi from Density Increment",
+      "id": "part6-density-increment",
+      "title": "Part VI: Density Increment for k-APs",
+      "summary": "The single axiom `density_increment_kAP`: a $k$-AP-free set of density $\\delta$ has a subprogression where the (still $k$-AP-free) restriction has density $>\\delta$. The AP-free condition on the restriction is essential for iteration.",
+      "startLine": 226,
+      "endLine": 259,
+      "mathContext": "Density increment: $k$-AP-free density $\\delta$ on $[N]$ $\\Rightarrow$ density $>\\delta$ on a subprogression — the engine of the Szemerédi proof."
+    },
+    {
+      "id": "part7-szemeredi-connection",
+      "title": "Part VII: Connection to Szemerédi's Theorem",
+      "summary": "`szemeredi_from_density_increment`: iterating the density increment (density bounded by 1) forces a $k$-AP, yielding Szemerédi's theorem. Notes the remaining quantitative blocker — a lower bound $\\delta'\\ge\\delta+g(\\delta,k)$ with $g>0$.",
       "startLine": 260,
-      "endLine": 280,
-      "summary": "Theorem `szemeredi_from_density_increment` is proved (build pending) by ZMod transfer from the density_increment_kAP axiom — extracting the strictly-larger sub-density and applying the iteration termination bound. The earlier sorry concerned the missing quantitative lower bound δ' ≥ δ + g(δ,k); the resolved proof uses the qualitative axiom signature directly.",
-      "mathContext": "The density increment argument: start with $\\delta_0 = \\delta$; at step $i$, find a subprogression with $\\delta_{i+1} \\geq \\delta_i + g(\\delta_i)$. Since density $\\leq 1$, the iteration terminates after $\\leq 1/g(\\delta)$ steps. The sorry is at the **quantitative bound**: the axiom gives $\\delta' > \\delta$ but not $\\delta' \\geq \\delta + g(\\delta)$ for a specific explicit function $g$. Without $g$, one cannot bound the number of iterations and prove finiteness. For $k=3$: $g(\\delta) = \\delta^2/100$ gives termination in $\\leq 100/\\delta^2$ steps, giving Szemerédi's bound $r_3(N) \\leq N/(\\log\\log N)^c$."
+      "endLine": 365,
+      "mathContext": "Iterate density increment until density $>1$ is forced — a contradiction unless a $k$-AP appears."
     },
     {
-      "id": "k3-proved",
-      "title": "Part VIII: k=3 Case Proved from RothTheorem.lean",
-      "startLine": 282,
-      "endLine": 307,
-      "summary": "Theorem `density_increment_k3_explicit` (no axioms, no sorry): translates between k-AP notions, applies Szemeredi.Roth.density_increment_lemma, and produces A' with δ' ≥ δ + δ²/100 and still 3-AP-free.",
-      "mathContext": "`density_increment_k3_explicit`: for 3-AP-free $A$ with density $\\delta$, $\\exists$ subprogression $A' \\subseteq \\mathbb{Z}/M\\mathbb{Z}$ with $M \\geq N^c$ and density $\\delta' \\geq \\delta + \\delta^2/100$. Proved (0 axioms, 0 sorries) by translating `IsKAPFreeZMod A 3` to `Szemeredi.Roth.APFree` (via the Part I equivalence) and applying `Szemeredi.Roth.density_increment_lemma` from Mathlib. The explicit bound $\\delta^2/100$ enables the iteration to terminate in $\\leq 100/\\delta^2$ steps, giving Szemerédi's quantitative bound for $k=3$."
+      "id": "part8-k3-case",
+      "title": "Part VIII: k=3 Case (Proved from RothTheorem.lean)",
+      "summary": "`density_increment_k3_explicit`: for $k=3$ the increment is explicit, $\\delta'\\ge\\delta+\\delta^2/100$, proved via the Fourier-analytic density increment in the sibling `RothTheorem.lean` (`Szemeredi.Roth.density_increment_lemma`).",
+      "startLine": 366,
+      "endLine": 392,
+      "mathContext": "$k=3$: explicit Fourier increment $\\delta'\\ge\\delta+\\delta^2/100$ (Roth's quantitative bound)."
     },
     {
-      "id": "comparison",
-      "title": "Part IX: k=3 vs k≥4 Comparison",
-      "startLine": 309,
-      "endLine": 333,
-      "summary": "Markdown comparison table: k=3 uses U²=Fourier L⁴ with explicit δ²/100 increment; k≥4 uses U^{k-1} with tower-type c(δ,k). Documents proof length (~1400 lines for k=3 proved; ~5000+ estimated for k≥4).",
-      "mathContext": "$k=3$ (Roth): $\\|f\\|_{U^2} = \\|\\hat{f}\\|_{\\ell^4}^{1/2}$ (Fourier $L^4$ norm); inverse theorem is just 'large $U^2$ iff large Fourier coefficient'; density increment $\\delta^2/100$ is polynomial; total proof $\\approx 1400$ lines. $k \\geq 4$ (Szemerédi/Gowers): $\\|f\\|_{U^{k-1}}$ is not Fourier; inverse theorem requires $(k-2)$-step nilsequences (Green-Tao-Ziegler); density increment $c(\\delta,k)$ is tower-type ($k$-fold exponential in $1/\\delta$); estimated $5000+$ Lean lines. The table documents why $k=3$ is proved here while $k \\geq 4$ requires the two axioms."
+      "id": "part9-comparison",
+      "title": "Part IX: Comparison: k=3 (Fourier) vs k≥4 (Gowers)",
+      "summary": "A comparison table and discussion of why $k=3$ is special ($U^2=$ Fourier $L^4$, so direct Fourier analysis suffices) whereas $k\\ge4$ requires the deep inverse theorem for $U^{k-1}$ (nilsequences, hypergraph regularity, Gowers 2001).",
+      "startLine": 393,
+      "endLine": 419,
+      "mathContext": "$k=3$: Fourier (large coefficient). $k\\ge4$: Gowers $U^{k-1}$ inverse theorem (nilsequence correlation) — qualitatively harder."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-metadata realignment for **roth-theorem-k3-oq-03** (how Roth's $k=3$ theorem extends to Szemerédi via Gowers norms / density increment).

The `sections` array lumped parts ("Parts II-III", "Parts V-VI") and the back-half ranges had drifted badly: meta "Part VIII" at 282-307 but the real `-- PART VIII` banner is at **L367**, "Part IX" at 309-333 but real at **L394**. Coverage stopped at L333 while `Proofs/RothTheoremOQ03.lean` runs to 419.

### Changes
- Rebuilt all sections against the file's `-- PART N` banners for contiguous **full-file coverage 1-419**: Header + Parts I, I.5, II, III, IV, V, VI, VII, VIII, IX — **11** sections.
- Parts IV (generalized von Neumann) and V (inverse theorem) are commentary the file explicitly leaves un-axiomatized; the only `axiom` is `density_increment_kAP` (Part VI), so `axiomCount` stays 1.

### Counts (unchanged, verified accurate)
- axiomCount 1, sorries 0, theoremCount 9, definitionCount 5, lineCount 419 — all already correct.

## Test plan
- [x] `pnpm research:build` completes with no errors/warnings for this slug
- [x] JSON validates; 11 sections ordered, contiguous (no gaps/overlaps); final endLine 419 == lineCount
- [x] Section ranges cross-checked against the file's `-- PART N` banner lines; axiom count re-verified against the policy (1 real axiom, Parts IV/V intentionally un-axiomatized)