### PR TITLE
research(prime-number-theorem): realign drifted gallery sections to file (7→9)

### DIFF
--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -88,58 +88,74 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "startLine": 66,
-      "endLine": 91,
+      "startLine": 1,
+      "endLine": 89,
       "summary": "Defines primePi (via Mathlib's Nat.primeCounting), primeApprox (x/ln x), and logIntegral Li(x) = ∫₂ˣ dt/ln t.",
       "mathContext": "\\(\\pi(x) = \\#\\{p \\leq x : p \\text{ prime}\\}\\), \\(\\text{primeApprox}(x) = x/\\ln x\\), \\(\\text{Li}(x) = \\int_2^x \\frac{dt}{\\ln t}\\)"
     },
     {
       "id": "main-theorem",
       "title": "The Prime Number Theorem",
-      "startLine": 92,
-      "endLine": 130,
+      "startLine": 90,
+      "endLine": 128,
       "summary": "Four equivalent formulations: ratio (π·ln x/x → 1), asymptotic (π ~ x/ln x), error (π − x/ln x = o(x/ln x)), and Li form (π ~ Li).",
       "mathContext": "\\(\\lim_{x\\to\\infty}\\frac{\\pi(x)\\ln x}{x} = 1\\); equivalently \\(\\pi(x) \\sim x/\\ln x\\), \\(\\pi(x) - x/\\ln x = o(x/\\ln x)\\), and \\(\\pi(x) \\sim \\mathrm{Li}(x)\\)"
     },
     {
       "id": "equivalences",
       "title": "Equivalence of Formulations",
-      "startLine": 127,
-      "endLine": 189,
+      "startLine": 129,
+      "endLine": 199,
       "summary": "Proved equivalences between all four PNT formulations (3 axioms eliminated). Only Li(x) ~ x/ln(x) remains axiomatized.",
       "mathContext": "\\(f \\sim g \\iff f - g = o(g)\\); transitivity: \\(\\pi \\sim x/\\ln x \\sim \\mathrm{Li}(x)\\) because \\(\\mathrm{Li}(x) = x/\\ln x + x/\\ln^2 x + \\cdots\\)"
     },
     {
       "id": "main-axiom",
       "title": "The Main Theorem (Axiomatized)",
-      "startLine": 190,
-      "endLine": 217,
+      "startLine": 200,
+      "endLine": 227,
       "summary": "PNT axiomatized based on PrimeNumberTheoremAnd project; corollaries derive asymptotic and Li forms.",
       "mathContext": "\\(\\texttt{axiom primeNumberTheorem}\\colon \\text{Tendsto}(\\lambda x,\\, \\pi(x)\\ln x/x)\\;\\texttt{atTop}\\;(\\mathcal{N}\\,1)\\); key step: \\(\\zeta(1+it)\\neq 0\\) via \\(3+4\\cos\\theta+\\cos 2\\theta\\geq 0\\)"
     },
     {
       "id": "consequences",
       "title": "Consequences of PNT",
-      "startLine": 218,
-      "endLine": 310,
+      "startLine": 228,
+      "endLine": 317,
       "summary": "Prime density → 0, nth prime ~ n ln n, Mertens' sum of reciprocals ~ ln ln x, and prime gaps are sublinear.",
       "mathContext": "\\(\\pi(x)/x \\to 0\\); \\(p_n \\sim n\\ln n\\); \\(\\sum_{p\\leq x}1/p = \\ln\\ln x + M + o(1)\\) where \\(M\\approx 0.2615\\); prime gaps \\(= o(x)\\)"
     },
     {
       "id": "rh-connection",
       "title": "Stronger Versions (Conditional on RH)",
-      "startLine": 308,
-      "endLine": 352,
+      "startLine": 318,
+      "endLine": 362,
       "summary": "Riemann Hypothesis stated; von Koch's theorem gives |π(x)−Li(x)| = O(√x ln x) conditionally.",
       "mathContext": "RH: all non-trivial zeros of \\(\\zeta(s)\\) satisfy \\(\\operatorname{Re}(s)=1/2\\). Von Koch (1901): RH \\(\\Rightarrow |\\pi(x)-\\mathrm{Li}(x)| = O(\\sqrt{x}\\ln x)\\)"
     },
     {
       "id": "elementary-bounds",
       "title": "Elementary Bounds",
-      "startLine": 353,
-      "endLine": 460,
+      "startLine": 363,
+      "endLine": 408,
       "summary": "Chebyshev's pre-PNT bounds (0.92 < π·ln x/x < 1.11), infinitude of primes, and Euler product connection.",
       "mathContext": "Chebyshev (1852): \\(0.92 < \\pi(x)\\ln x/x < 1.11\\) for large \\(x\\). Euler product: \\(\\zeta(s) = \\prod_p (1-p^{-s})^{-1}\\) for \\(\\operatorname{Re}(s)>1\\)"
+    },
+    {
+      "id": "numerical-evidence",
+      "title": "Numerical Evidence",
+      "startLine": 409,
+      "endLine": 426,
+      "summary": "Tabulated values of π(x), x/ln x, and Li(x) for x up to 10¹², illustrating that Li(x) is consistently the sharper approximation.",
+      "mathContext": "\\(\\pi(10^9)=50{,}847{,}534\\) vs \\(\\mathrm{Li}(10^9)\\approx 50{,}849{,}235\\) and \\(10^9/\\ln 10^9\\approx 48{,}254{,}942\\); relative error of \\(\\mathrm{Li}\\) decays faster"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 427,
+      "endLine": 460,
+      "summary": "Recap of the statement π(x) ~ x/ln x, the sharper Li(x) form, unconditional and RH error terms, the analytic proof techniques (ζ(s), zero-free region, Tauberian theorems), and historical context (Gauss/Legendre → Hadamard/de la Vallée Poussin 1896).",
+      "mathContext": "Unconditional: \\(\\pi(x)=\\mathrm{Li}(x)+O\\!\\left(x\\,e^{-c\\sqrt{\\ln x}}\\right)\\); under RH: \\(\\pi(x)=\\mathrm{Li}(x)+O(\\sqrt{x}\\ln x)\\)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Gallery `meta.json` for **prime-number-theorem** carried 7 sections from an older revision, drifted against the current 460-line `PrimeNumberTheorem.lean`.
- The Lean file is organized into 9 banner-delimited parts (`PART I` … `PART IX`). The stale meta sections pointed a few lines *before* each banner and lumped **PART VIII (Numerical Evidence)** and **PART IX (Summary)** into the final "Elementary Bounds" section. The header (imports + module docstring, lines 1–65) was uncovered.
- Rebuilt **9 contiguous sections** tiling lines 1–460, aligned to the actual `PART` banners, and added dedicated **Numerical Evidence** and **Summary** sections.

## Section map (new)
| Lines | Title |
|-------|-------|
| 1–89 | Basic Definitions (incl. header/imports) |
| 90–128 | The Prime Number Theorem |
| 129–199 | Equivalence of Formulations |
| 200–227 | The Main Theorem (Axiomatized) |
| 228–317 | Consequences of PNT |
| 318–362 | Stronger Versions (Conditional on RH) |
| 363–408 | Elementary Bounds |
| 409–426 | Numerical Evidence *(new)* |
| 427–460 | Summary *(new)* |

## Notes
- Sections-only change; proof counts and Lean source untouched. Build-free.
- Existing section summaries/mathContext preserved verbatim; only line ranges corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)