### PR TITLE
research(law-of-cosines-oq-01-oq-05): realign scrambled gallery sections to file (10→12)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -56,79 +56,100 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Imports and module docstring. Poses the research problem (can the Euclidean, spherical, and hyperbolic laws of cosines be unified?), introduces the curvature-parametrized $cs_K, sn_K$ and the unified law $cs_K(c) = cs_K(a)\\,cs_K(b) + K\\,sn_K(a)\\,sn_K(b)\\cos C$, and notes status (0 sorries; `UnifiedTriangle.law` is a structure-encoded assumption). Opens namespace `UnifiedLawOfCosines`.",
+      "mathContext": "Statement of the three classical laws ($K=0,\\pm1$), the unified framework, and references (Ratcliffe, Todhunter, Thurston, CFKP)."
+    },
+    {
       "id": "definitions",
-      "title": "Curvature-Parametrized Trig Functions",
-      "startLine": 62,
-      "endLine": 86,
-      "summary": "Defines curvatureCos K r = cos(√K·r) for K>0, cosh(√(-K)·r) for K<0, 1 for K=0; and curvatureSin K r = sin(√K·r)/√K for K>0, sinh(√(-K)·r)/√(-K) for K<0, r for K=0.",
-      "mathContext": "The definitions use Lean's if-then-else: $\\text{curvatureCos}(K,r) = \\text{if } K>0 \\text{ then } \\cos(\\sqrt{K}\\cdot r) \\text{ else if } K<0 \\text{ then } \\cosh(\\sqrt{-K}\\cdot r) \\text{ else } 1$. These recover the standard functions at K=±1 via simp lemmas using $\\sqrt{1}=1$."
+      "title": "Part I: Curvature-Parametrized Trigonometric Functions",
+      "startLine": 67,
+      "endLine": 88,
+      "summary": "Defines **curvatureCos** $cs_K$ ($\\cos(\\sqrt K r)$ for $K>0$, $\\cosh(\\sqrt{-K}r)$ for $K<0$, $1$ for $K=0$) and **curvatureSin** $sn_K$ ($\\sin(\\sqrt K r)/\\sqrt K$, $\\sinh(\\sqrt{-K}r)/\\sqrt{-K}$, or $r$).",
+      "mathContext": "The two piecewise (noncomputable) definitions parametrizing trigonometry by curvature $K\\in\\mathbb R$."
     },
     {
-      "id": "pythagorean",
-      "title": "Unified Pythagorean Identity",
-      "startLine": 183,
-      "endLine": 217,
-      "summary": "curvaturePythagorean: cs_K(r)² + K·sn_K(r)² = 1 for all K, r ∈ ℝ. Proved by case analysis on sign of K.",
-      "mathContext": "For $K<0$: $\\cosh^2(\\sqrt{-K}\\cdot r) + K\\cdot(\\sinh(\\sqrt{-K}\\cdot r)/\\sqrt{-K})^2 = \\cosh^2-\\sinh^2=1$ since $K/(\\sqrt{-K})^2 = -1$. For $K>0$: $\\cos^2(\\sqrt{K}\\cdot r) + K\\cdot(\\sin(\\sqrt{K}\\cdot r)/\\sqrt{K})^2 = \\cos^2+\\sin^2=1$ since $K/K=1$. For $K=0$: $1+0=1$."
+      "id": "standard-values",
+      "title": "Part II: Values at Standard Curvatures",
+      "startLine": 89,
+      "endLine": 130,
+      "summary": "Evaluates $cs_K, sn_K$ at $K = 1, -1, 0$: **curvatureCos_one** $=\\cos$, **curvatureSin_one** $=\\sin$, **curvatureCos_neg_one** $=\\cosh$, **curvatureSin_neg_one** $=\\sinh$, the $K=0$ cases, and the at-zero values $cs_K(0)=1$, $sn_K(0)=0$.",
+      "mathContext": "`@[simp]` recovery lemmas pinning the parametrized functions to the classical ones at $K=0,\\pm1$."
     },
     {
-      "id": "triangle-structure",
-      "title": "Unified Triangle Structure",
-      "startLine": 222,
-      "endLine": 241,
-      "summary": "UnifiedTriangle K encodes a triangle in constant-curvature-K space satisfying the unified law. Fields: sides a, b, c > 0 and angle C ∈ (0, π).",
-      "mathContext": "The structure UnifiedTriangle K packages a triangle with the law $\\text{cs}_K(c) = \\text{cs}_K(a)\\cdot\\text{cs}_K(b) + K\\cdot\\text{sn}_K(a)\\cdot\\text{sn}_K(b)\\cdot\\cos(C)$ as a field. This axiomatizes K-geometry triangles without building the full Riemannian geometry machinery."
-    },
-    {
-      "id": "recovery",
-      "title": "Recovery of Classical Laws",
-      "startLine": 244,
-      "endLine": 275,
-      "summary": "Recovers spherical law (K=1) and hyperbolic law (K=-1) from the unified structure. Also provides the reverse direction: classical hypothesis implies K-formula.",
-      "mathContext": "For $K=-1$: simp_only [curvatureCos_neg_one, curvatureSin_neg_one] unfolds cs_{-1}=cosh and sn_{-1}=sinh; then the law field reads cosh(c)=cosh(a)cosh(b)+(-1)sinh(a)sinh(b)cos(C)=cosh(a)cosh(b)-sinh(a)sinh(b)cos(C). linarith closes."
-    },
-    {
-      "id": "equivalences",
-      "title": "Algebraic Equivalences",
-      "startLine": 278,
-      "endLine": 314,
-      "summary": "Proves the unified formula for K>0 is equivalent to the spherical law at sides √K·a, √K·b, √K·c, and for K<0 is equivalent to the hyperbolic law at sides √(-K)·a, etc.",
-      "mathContext": "For $K>0$: $K\\cdot(\\sin(\\sqrt{K}\\cdot a)/\\sqrt{K})\\cdot(\\sin(\\sqrt{K}\\cdot b)/\\sqrt{K}) = \\sin(\\sqrt{K}\\cdot a)\\cdot\\sin(\\sqrt{K}\\cdot b)$ by the algebra lemma $K\\cdot(x/\\sqrt{K})\\cdot(y/\\sqrt{K})=x\\cdot y$. Then linear_combination h * cos(C) closes the iff. This gives the geometric interpretation: the unified law on a sphere of curvature K is the spherical law at angle-distance coordinates."
-    },
-    {
-      "id": "special-values-parity",
-      "title": "Special Values and Parity Properties",
-      "startLine": 87,
+      "id": "parity",
+      "title": "Part III: Parity Properties",
+      "startLine": 131,
       "endLine": 148,
-      "summary": "simp lemmas compute cs_K and sn_K at K=0,±1 using explicit norm_num conditions. Parity theorems: curvatureCos_neg (even) and curvatureSin_neg (odd) follow from cos/cosh even and sin/sinh odd. All proved by simp/split_ifs/ring."
+      "summary": "Proves **curvatureCos_neg** ($cs_K$ is even) and **curvatureSin_neg** ($sn_K$ is odd), uniformly across the three curvature branches.",
+      "mathContext": "Parity of the curvature-parametrized functions via `split_ifs` and the parities of $\\cos/\\cosh$ and $\\sin/\\sinh$."
     },
     {
-      "id": "algebra-lemmas",
-      "title": "Key Algebra Lemmas: K·(x/√K)·(y/√K) = ±x·y",
+      "id": "key-algebra",
+      "title": "Part IV: Key Algebraic Lemmas",
       "startLine": 149,
-      "endLine": 181,
-      "summary": "Two private lemmas K_mul_div_sqrt_sq_pos (K>0) and K_mul_div_sqrt_sq_neg (K<0) prove the algebraic identity that makes equivalence proofs work. The sign difference (xy vs -xy) is the algebraic origin of the minus sign in the hyperbolic law. Both proved by field_simp + rw + calc."
+      "endLine": 175,
+      "summary": "Private lemmas **K_mul_div_sqrt_sq_pos** ($K\\cdot(x/\\sqrt K)(y/\\sqrt K)=xy$ for $K>0$) and **K_mul_div_sqrt_sq_neg** ($=-(xy)$ for $K<0$) — the sign-tracking identities behind the unified formula.",
+      "mathContext": "Algebraic simplifications of the $K\\cdot sn_K\\cdot sn_K$ term, supplying the $\\pm$ sign that distinguishes spherical from hyperbolic."
     },
     {
-      "id": "triangle-structure",
-      "title": "UnifiedTriangle Structure",
-      "startLine": 218,
-      "endLine": 260,
-      "summary": "UnifiedTriangle K packages sides a,b,c > 0, angle C ∈ (0,π), and the law field. Recovery theorems (K=±1 ↔ classical laws) are simp + linarith. unified_law_of_cosines extracts the structure's law field."
+      "id": "pythagorean-identity",
+      "title": "Part V: The Unified Pythagorean Identity",
+      "startLine": 176,
+      "endLine": 216,
+      "summary": "Proves **curvaturePythagorean**: $cs_K(r)^2 + K\\,sn_K(r)^2 = 1$ for all $K, r$, simultaneously encoding $\\cos^2+\\sin^2=1$ ($K=1$), $\\cosh^2-\\sinh^2=1$ ($K=-1$), and $1+0=1$ ($K=0$).",
+      "mathContext": "Trichotomy on $K$ reducing to `Real.sin_sq_add_cos_sq` and `Real.cosh_sq_sub_sinh_sq`."
     },
     {
-      "id": "scaling-euclidean-setup",
-      "title": "Scaling Consistency and Euclidean Limit Helpers",
+      "id": "unified-triangle",
+      "title": "Part VI: The Unified Triangle Structure",
+      "startLine": 217,
+      "endLine": 243,
+      "summary": "Defines the **UnifiedTriangle K** structure (sides $a,b,c$, angle $C$, positivity, and the field **law** encoding the unified law of cosines) and proves **unified_law_of_cosines** restating that field. The `law` field is the structure-encoded assumption.",
+      "mathContext": "A triangle in constant-curvature space; the `law` field carries the unified cosine identity as a hypothesis (not derived)."
+    },
+    {
+      "id": "classical-recovery",
+      "title": "Part VII: Recovery of Classical Laws",
+      "startLine": 244,
+      "endLine": 277,
+      "summary": "Proves the classical laws follow from the unified one: **spherical_recovery_K1**, **hyperbolic_recovery_Kneg1**, and that a unified triangle at $K=1$ / $K=-1$ yields the spherical (**unified_K1_gives_spherical**) and hyperbolic (**unified_K_neg1_gives_hyperbolic**) laws.",
+      "mathContext": "Specialization theorems instantiating the unified law at $K=\\pm1$ via the `@[simp]` value lemmas."
+    },
+    {
+      "id": "algebraic-equivalences",
+      "title": "Part VIII: Algebraic Equivalences",
+      "startLine": 278,
+      "endLine": 316,
+      "summary": "Proves **unified_to_spherical_K_pos** ($K>0$ form $\\iff$ spherical law at scaled sides $\\sqrt K\\cdot a$, etc.) and **unified_to_hyperbolic_K_neg** ($K<0$ form $\\iff$ hyperbolic law at $\\sqrt{-K}$-scaled sides), using the Part IV lemmas.",
+      "mathContext": "Iff-equivalences showing the unified formula is a rescaling of the classical spherical/hyperbolic laws."
+    },
+    {
+      "id": "scaling-consistency",
+      "title": "Part IX: Scaling Consistency",
       "startLine": 317,
-      "endLine": 391,
-      "summary": "Scaling: cs_K(r) = cs_1(√K·r) for K>0 by direct simp. Euclidean limit helpers: exp_sub_one_le_mul_exp, cosh_sub_one_le, cosh_K_bound, cosh_double_K_bound bound error terms via Real.cosh_le_exp_half_sq and exponential monotonicity."
+      "endLine": 330,
+      "summary": "Proves **curvature_family_consistency_pos** ($cs_K(r)=cs_1(\\sqrt K r)$) and **curvature_sin_family_consistency_pos** ($sn_K(r)=sn_1(\\sqrt K r)/\\sqrt K$): $K$-geometry is unit geometry at scale $1/\\sqrt K$.",
+      "mathContext": "Self-similarity of the curvature family under rescaling for $K>0$."
     },
     {
-      "id": "euclidean-limit-proof",
-      "title": "euclidean_limit_holds: Full Taylor Bound Proof",
-      "startLine": 392,
+      "id": "euclidean-limit",
+      "title": "Part X: Euclidean Limit (K → 0)",
+      "startLine": 331,
+      "endLine": 671,
+      "summary": "The technical core: helper bounds (**exp_sub_one_le_mul_exp**, **cosh_sub_one_le**, **one_le_cosh**, **cosh_K_bound**, **cosh_double_K_bound**) and the main **euclidean_limit_holds** — an $\\varepsilon$–$\\delta$ proof that the unified formula converges to $c^2=a^2+b^2-2ab\\cos C$ as $K\\to0$, with explicit Taylor/exponential bounds for $K>0$, $K<0$, and $K=0$.",
+      "mathContext": "Full quantitative limit argument using $1-\\cos x\\le x^2/2$, $|\\sin x|\\le|x|$, $\\cosh x-1\\le \\tfrac{x^2}{2}e^{x^2/2}$, and AM–GM; `maxHeartbeats 4000000`."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 672,
       "endLine": 693,
-      "summary": "Fully proved (0 sorries) 280-line proof of K→0 limit. For K>0: |sin(√K·r)| ≤ √K·|r| and 1-cos(√K·r) ≤ K·r²/2 give |expr| ≤ K·M_pos. For K<0: cosh/sinh bounds from helper lemmas give |expr| ≤ -K·M_neg. For K=0: exact zero. Combined: δ=min(1,ε/M) with M=M_pos+M_neg."
+      "summary": "Closing table of $cs_K/sn_K$ across the five geometries, the unified law, and the list of proved results (Pythagorean identity, classical recoveries, and the two algebraic equivalences) at 0 sorries. Closes namespace `UnifiedLawOfCosines`.",
+      "mathContext": "File-closing summary table and proved-results checklist."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery `sections` for **law-of-cosines-oq-01-oq-05** had drifted from an older revision: they were **out of order and overlapping**. Section start lines ran `62 → 183 → 222 → 244 → 278 → 87 → 149 → 218 → 317 → 392`, and the range `218-260` overlapped both `222-241` and `244-275`. Several titles no longer matched the file content, the module header (1-66) was uncovered, and the closing Summary was missing.

This PR rebuilds the sections to **12 contiguous, in-order entries tiling lines 1-693**, aligned to the file's `## Part I`–`## Part X` banners plus a Module Header section and the Summary block:

| Lines | Section |
|------|---------|
| 1-66 | Module Header and Setup |
| 67-88 | Part I: Curvature-Parametrized Trigonometric Functions |
| 89-130 | Part II: Values at Standard Curvatures |
| 131-148 | Part III: Parity Properties |
| 149-175 | Part IV: Key Algebraic Lemmas |
| 176-216 | Part V: The Unified Pythagorean Identity |
| 217-243 | Part VI: The Unified Triangle Structure |
| 244-277 | Part VII: Recovery of Classical Laws |
| 278-316 | Part VIII: Algebraic Equivalences |
| 317-330 | Part IX: Scaling Consistency |
| 331-671 | Part X: Euclidean Limit (K → 0) |
| 672-693 | Summary |

Titles and summaries were rewritten to match the actual declarations in each region.

## Scope
- Only `src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json` `sections` array changed (text-spliced; rest of the file byte-identical).
- **No** change to counts or status — proof remains 0 sorries with `UnifiedTriangle.law` as a structure-encoded assumption.

## Test plan
- [x] Sections validate as JSON and tile lines 1-693 with no gaps or overlaps
- [x] Each section's range matches the corresponding `## Part` banner / header / summary in `Proofs/LawOfCosinesOQ05.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)