### PR TITLE
Enrich euler-identity-oq-01: fix duplicate annotation IDs and out-of-bounds range

### DIFF
--- a/src/data/proofs/euler-identity-oq-01/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01/annotations.json
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "id": "ann-algebraic-identities",
+    "id": "ann-i-powers-term-matching",
     "proofId": "euler-identity-oq-01",
     "range": {
       "startLine": 57,
@@ -47,34 +47,6 @@
       "complex number arithmetic",
       "Lean 4 induction tactic",
       "pow_add lemma",
-      "Mathlib Complex.I_sq"
-    ]
-  },
-  {
-    "id": "ann-algebraic-identities",
-    "proofId": "euler-identity-oq-01",
-    "range": {
-      "startLine": 57,
-      "endLine": 87
-    },
-    "type": "concept",
-    "title": "Powers of i: Four Algebraic Identities Proved by Induction",
-    "content": "The algebraic core of the proof: four theorems establishing how powers of i simplify. I_pow_even (k : ℕ) : I^{2k} = (-1)^k — proved by induction, with base case I^0 = 1 (trivial) and inductive step using I^{2(k+1)} = I^{2k} · I^2 = (-1)^k · (-1) = (-1)^{k+1}. I_pow_odd (k : ℕ) : I^{2k+1} = I · (-1)^k — a one-liner from I_pow_even and pow_succ. expTerm_even (x k) : expTerm(ix)(2k) = evenTerm(x)(k) — rewrites (ix)^{2k}/(2k)! = i^{2k} · x^{2k}/(2k)! = (-1)^k · x^{2k}/(2k)! using I_pow_even. expTerm_odd (x k) : expTerm(ix)(2k+1) = oddTerm(x)(k) — similarly converts odd-indexed terms using I_pow_odd. These four results are the only purely algebraic (non-analytic) content of the proof: they require no topology, no limits, only ring arithmetic and induction.",
-    "mathContext": "$i^{2k} = (-1)^k$ (induction from $i^2 = -1$: $i^{2(k+1)} = i^{2k} \\cdot i^2 = (-1)^k \\cdot (-1) = (-1)^{k+1}$); $i^{2k+1} = i \\cdot (-1)^k$ (from $i^{2k+1} = i^{2k} \\cdot i$). These imply $(ix)^{2k} = i^{2k} x^{2k} = (-1)^k x^{2k}$ and $(ix)^{2k+1} = i^{2k+1} x^{2k+1} = i(-1)^k x^{2k+1}$, converting general exponential series terms into recognizable cos/sin series terms.",
-    "significance": "key",
-    "relatedConcepts": [
-      "I_pow_even",
-      "I_pow_odd",
-      "expTerm_even",
-      "expTerm_odd",
-      "imaginary unit",
-      "de Moivre's formula",
-      "Complex.I_sq"
-    ],
-    "prerequisites": [
-      "complex numbers",
-      "mathematical induction",
-      "Lean ring tactic",
       "Mathlib Complex.I_sq"
     ]
   },
@@ -165,7 +137,7 @@
     "proofId": "euler-identity-oq-01",
     "range": {
       "startLine": 175,
-      "endLine": 213
+      "endLine": 211
     },
     "type": "concept",
     "title": "Axiom Elimination Roadmap: Three Approaches to a Fully Verified Proof",


### PR DESCRIPTION
## Summary

`euler-identity-oq-01` had two annotation schema defects:

- **Duplicate IDs:** `ann-algebraic-identities` appeared three times — two byte-identical copies (one removed) and one with distinct content ("Powers of i: I_pow_even, I_pow_odd, and Term Matching"), which was renamed to `ann-i-powers-term-matching`.
- **Out-of-bounds range:** `ann-independence` ended at line 213 in a 211-line file; clamped to 211.

7 → 6 annotations, all IDs unique and all ranges in-bounds.

## Verification
- `pnpm annotations:build` exits 0; no duplicate IDs, no out-of-bounds ranges.
- Data-only change.