### PR TITLE
research(konigsberg-oq-03-oq-02): realign drifted gallery section ranges

### DIFF
--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -58,42 +58,42 @@
     {
       "id": "sec-infinite-graph",
       "title": "Part 0: Infinite Graph Definition",
-      "startLine": 35,
+      "startLine": 34,
       "endLine": 44,
       "summary": "Self-contained InfiniteGraph: adj predicate, symmetry, loopless."
     },
     {
       "id": "sec-walk",
       "title": "Part 1: One-Way Infinite Walks",
-      "startLine": 46,
-      "endLine": 76,
+      "startLine": 45,
+      "endLine": 69,
       "summary": "InfiniteWalk structure: vertex : ℕ → V, step_adj. stepPair, sameEdge (undirected edge equality)."
     },
     {
       "id": "sec-euler",
       "title": "Part 2: Euler Walk Conditions",
-      "startLine": 78,
-      "endLine": 108,
+      "startLine": 70,
+      "endLine": 98,
       "summary": "IsEdgeInjective (at-most-once), CoversDirArc, CoversEdge (at-least-once), IsEulerWalk, HasOneWayInfiniteEulerPath."
     },
     {
       "id": "sec-biinfinite",
       "title": "Part 3: Bi-Infinite Walks",
-      "startLine": 100,
-      "endLine": 125,
+      "startLine": 99,
+      "endLine": 120,
       "summary": "BiInfiniteWalk (ℤ-indexed), CoversEdge, IsBiInfiniteEulerWalk."
     },
     {
       "id": "sec-properties",
       "title": "Part 4: Basic Properties",
-      "startLine": 127,
-      "endLine": 155,
+      "startLine": 121,
+      "endLine": 150,
       "summary": "step_is_adj, step_ne (endpoints distinct), covers/injective projections, ofStream (Stream' equivalence)."
     },
     {
       "id": "sec-summary",
       "title": "Part 5: Summary and API Surface",
-      "startLine": 150,
+      "startLine": 151,
       "endLine": 184,
       "summary": "Module summary comment recapping design choices. #check commands documenting the public API: InfiniteWalk, IsEulerWalk, HasOneWayInfiniteEulerPath, BiInfiniteWalk, step_ne."
     }


### PR DESCRIPTION
## Summary
Realigns the 6 gallery section ranges for `konigsberg-oq-03-oq-02` to the current Lean file. The ranges were anchored to an earlier revision, producing overlaps:
- `sec-euler` (78-108) overlapped `sec-biinfinite` (100-125)
- `sec-properties` (127-155) overlapped `sec-summary` (150-184)
- plus off-by-one starts (e.g. sec-infinite-graph began at 35, after the `## Part 0` banner at 34)

Retiled all sections contiguously over 34-184, aligned to the `## Part 0` … `## Summary` banners:
| section | new range |
|---|---|
| sec-infinite-graph | 34-44 |
| sec-walk | 45-69 |
| sec-euler | 70-98 |
| sec-biinfinite | 99-120 |
| sec-properties | 121-150 |
| sec-summary | 151-184 |

Summaries and counts (0 sorries, 0 axioms, 4 theorems, 13 defs) are unchanged and already accurate — this is a ranges-only fix. Annotations already point to the correct constructs and were left untouched.

## Test plan
- [x] meta.json is valid JSON; sections contiguous, ordered, in-bounds (file is 184 lines)
- [x] each section range maps to its `## Part N` banner in `Proofs/KonigsbergOQ03OQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)