### PR TITLE
research(four-square-distribution): realign gallery sections to full file (5→12)

### DIFF
--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -52,44 +52,100 @@
   },
   "sections": [
     {
-      "id": "intro-docstring",
-      "title": "Imports and Open-Question Framing",
+      "id": "overview",
+      "title": "Overview and Open-Question Framing",
       "startLine": 1,
-      "endLine": 35,
-      "summary": "Imports `Mathlib.NumberTheory.SumFourSquares`, `Finset.Basic`/`Card`, `Multiset.Basic`, `List.Sort`, `Mathlib.Tactic`. The module docstring states the gallery open question OQ-02 ('How do representations distribute among the possible orderings?'), summarizes the four contributions of the file (computable representation types, symmetry multipliers, small-n enumeration, structural properties), and records the key insight that Jacobi's factor of 8 arises from the signed-permutation symmetry group acting on 4-tuples.",
-      "mathContext": "$r_4(n) = \\sum_{\\text{types } t \\text{ for } n} \\text{contribution}(t)$, where $\\text{contribution}(t) = \\binom{4}{m_1, m_2, \\ldots}^{\\!*}\\cdot 2^{\\text{nz}(t)}$ — the multinomial coefficient over multiplicities times $2^k$ for $k$ nonzero positions. The factor of 8 in Jacobi's formula $r_4(n) = 8\\sigma^*(n)$ is the GCD of all type contributions."
+      "endLine": 40,
+      "summary": "Imports (Mathlib SumFourSquares, Finset, Multiset) and the module docstring framing gallery OQ-02: how do the representations n=a²+b²+c²+d² distribute among orderings? Introduces the central formula contribution(type) = multinomial(positions) × 2^(nonzero count) and the insight that Jacobi's factor of 8 in r₄(n)=8σ*(n) is the weighted average of per-type symmetries.",
+      "mathContext": "Representations $n=a^2+b^2+c^2+d^2$ are grouped by the sorted multiset of $|a|,|b|,|c|,|d|$; each type contributes $\\binom{4}{\\text{mult}}\\cdot2^{k}$ (permutations × sign choices) to $r_4(n)$, totalling Jacobi's $8\\sigma^*(n)$."
     },
     {
-      "id": "rep-types",
-      "title": "Part 1: Representation Types and Symmetry",
-      "startLine": 36,
-      "endLine": 165,
-      "summary": "Defines RepType n, nonzeroCount, signFactor, permutations, contribution. Base structure for the distribution analysis.",
-      "mathContext": "$\\text{contribution}(t) = 2^{k} \\cdot \\frac{4!}{\\prod m_i!}$ where $k$ = nonzero count and $m_i$ = multiplicity of value $i$."
+      "id": "part-1-rep-types",
+      "title": "Part 1: Representation Types",
+      "startLine": 41,
+      "endLine": 72,
+      "summary": "`RepType n`: a structure for a sorted 4-tuple a₁≤a₂≤a₃≤a₄ with a₁²+a₂²+a₃²+a₄²=n (DecidableEq derived), plus the computable accessors `nonzeroCount`, `distinctValues`, and `toList`.",
+      "mathContext": "A representation type is the unordered multiset of absolute values, encoded as a sorted tuple whose squares sum to $n$."
     },
     {
-      "id": "concrete-contributions",
-      "title": "Parts 2–3: Concrete Type Contributions",
-      "startLine": 164,
-      "endLine": 260,
-      "summary": "Verifies contributions for specific types: type_1 (8), type_2 (24), type_3 (32), type_4 (8+16=24), type_5 (48), type_6 (96), type_7 (64). Bounds: nonzeroCount ≤ 4, signFactor ≤ 16, permutations ≤ 24, contribution ≤ 384.",
-      "mathContext": "Type $(1,1,1,1)$: contribution $= 2^4 = 8$. Type $(1,2,3,4)$: contribution $= 2^4 \\cdot 4! = 384$."
+      "id": "part-2-symmetry-multiplier",
+      "title": "Part 2: Symmetry Multiplier",
+      "startLine": 73,
+      "endLine": 102,
+      "summary": "Computable symmetry components: `multiplicity` (occurrences of a value), `permutations` (multinomial 24/∏ mᵢ!), `signFactor` (2^nonzeroCount), and `contribution = permutations × signFactor`.",
+      "mathContext": "The number of ordered signed representations of a type is $\\dfrac{4!}{\\prod_i m_i!}\\cdot 2^{k}$, where $m_i$ are value multiplicities and $k$ the count of nonzero entries."
     },
     {
-      "id": "distribution-complete",
-      "title": "Parts 4–7: Complete Distribution Verification and Structural Bounds",
+      "id": "part-3-enumeration",
+      "title": "Part 3: Enumeration of Types for Small n",
+      "startLine": 103,
+      "endLine": 154,
+      "summary": "The `private def mkType` helper plus explicit type definitions for n = 1,2,3,4,5,6,7,9,10,30 (e.g. `type_4_a`=(0,0,0,2), `type_4_b`=(1,1,1,1), `type_30_a`=(1,2,3,4)).",
+      "mathContext": "Concrete representation types for small $n$, each a sorted tuple $(a_1,a_2,a_3,a_4)$ with $\\sum a_i^2=n$."
+    },
+    {
+      "id": "part-4-verification",
+      "title": "Part 4: Verification of Contributions",
+      "startLine": 155,
+      "endLine": 227,
+      "summary": "`native_decide` checks that each type's contribution matches Jacobi (e.g. type_1=8, type_2=24, type_3=32) and that multi-type totals match: `r₄_4_distribution` (8+16=24), `r₄_9_distribution` (8+96=104), `r₄_10_distribution` (48+96=144), plus type_30_a=384.",
+      "mathContext": "For each enumerated $n$ the type contributions sum to $r_4(n)=8\\sigma^*(n)$, e.g. $r_4(9)=8+96=104=8\\cdot13$."
+    },
+    {
+      "id": "part-5-structural",
+      "title": "Part 5: Structural Theorems about the Distribution",
       "startLine": 228,
-      "endLine": 293,
-      "summary": "Structural bounds: nonzeroCount ≤ 4, signFactor ≤ 16, permutations ≤ 24, contribution ≤ 384. Sharpness: type (1,2,3,4) achieves 384. n4_type_weights: 33%/66% split for n=4.",
-      "mathContext": "$\\text{contribution}(t) \\leq 24 \\times 16 = 384$, sharp at $(1,2,3,4)$. Proof: $\\text{Nat.mul\\_le\\_mul}$ on the two sub-bounds."
+      "endLine": 258,
+      "summary": "General bounds: `nonzeroCount_le_four`, `signFactor_le_sixteen` (2^k ≤ 16), `permutations_le_twentyfour` (≤ 4!), and `contribution_le_384` (the maximum single-type contribution 24×16).",
+      "mathContext": "Every type satisfies $k\\le4$, sign factor $\\le2^4=16$, permutations $\\le4!=24$, so contribution $\\le384$."
     },
     {
-      "id": "trivial-types-patterns",
-      "title": "Parts 8–10: Perfect Squares, Completeness, and S₄ Symmetry",
-      "startLine": 294,
+      "id": "part-6-type-classification",
+      "title": "Part 6: Type Classification",
+      "startLine": 259,
+      "endLine": 272,
+      "summary": "`n4_type_weights`: the first multi-type case n=4 splits unevenly — (0,0,0,2) is 33% and (1,1,1,1) is 67% of r₄(4).",
+      "mathContext": "At $n=4$ the weight splits $8:16$ (33%/67%) between the two types — an early instance of the uneven multi-type distribution."
+    },
+    {
+      "id": "part-7-jacobi-relationship",
+      "title": "Part 7: The Relationship Between Types and Jacobi's Formula",
+      "startLine": 273,
+      "endLine": 295,
+      "summary": "Interprets the factor 8: `all_distinct_nonzero_contribution` (=384), `all_equal_nonzero_contribution` (=16), and `symmetry_ratio` (384/16=24), showing the per-type symmetry spans a 24:1 = 4! range whose weighted average yields 8σ*(n).",
+      "mathContext": "The most asymmetric type $(1,2,3,4)$ contributes $384$ and the most symmetric $(1,1,1,1)$ contributes $16$; the ratio $384/16=24=|S_4|$."
+    },
+    {
+      "id": "part-8-perfect-square-types",
+      "title": "Part 8: Perfect Square Types",
+      "startLine": 296,
+      "endLine": 316,
+      "summary": "`trivial_type k`: the canonical (0,0,0,k) type for n=k², with `trivial_type_1..5` verifying its contribution is always exactly 8.",
+      "mathContext": "Every perfect square $n=k^2$ has the trivial type $(0,0,0,k)$ contributing $4\\cdot2=8$ representations."
+    },
+    {
+      "id": "part-9-completeness",
+      "title": "Part 9: Completeness Verification via Summation",
+      "startLine": 317,
+      "endLine": 349,
+      "summary": "`distribution_complete_1..10`: a consolidated record that the enumerated type contributions reproduce r₄(n) for every n ≤ 10 (single-type and multi-type cases alike), all via `native_decide`.",
+      "mathContext": "For each $n\\le10$ the full set of types accounts for exactly $r_4(n)$, confirming completeness of the enumeration."
+    },
+    {
+      "id": "part-10-patterns",
+      "title": "Part 10: Patterns in the Distribution",
+      "startLine": 350,
+      "endLine": 373,
+      "summary": "Prose synthesis of the empirical patterns: single-type vs multi-type numbers, the always-present perfect-square trivial type, the 16–384 symmetry range, and the linear-on-average growth of the number of types since each is bounded by 384 while r₄(n) ~ (π²/2)n.",
+      "mathContext": "Since per-type contributions are bounded by $384$ while $r_4(n)\\sim\\tfrac{\\pi^2}{2}n$, the number of types must grow linearly on average."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 374,
       "endLine": 400,
-      "summary": "trivial_type(k) = (0,0,0,k) for n=k² always contributes 8 (verified k=1..5). distribution_complete_1..10 aliases all results. symmetry_ratio = 384/16 = 24 = |S₄|. Growth r₄(n) ~ (π²/2)n implies average linear growth in type count.",
-      "mathContext": "Trivial type: $\\frac{4!}{3!1!} \\cdot 2^1 = 8$. Symmetry ratio: $384/16 = 24 = |S_4|$. Average types per $n$: $r_4(n)/(384) \\sim \\frac{\\pi^2 n}{768}$."
+      "summary": "Tabulated inventory of the proved results (RepType and its symmetry components, the n=1..10 verifications, the structural bounds, symmetry_ratio, and the trivial-type family) — all with 0 axioms and 0 sorries — and the closing statement of the distribution's complete answer via Jacobi's formula.",
+      "mathContext": "The distribution-among-orderings question is fully answered: $r_4(n)=8\\sigma^*(n)$ splits across types by $\\text{multinomial}\\times2^k$, with symmetry multiplier ranging over $[16,384]$ (ratio $4!$)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `four-square-distribution` gallery entry stored 5 sections whose line ranges had drifted into overlaps against `FourSquareDistribution.lean` (400 lines). For example, "Parts 2–3: Concrete Type Contributions" (164-260) overlapped "Parts 4–7" (228-293) by 32 lines, lumping several distinct parts together.

This realigns the `sections` array 1:1 to the 11 `## Part`/`## Summary` banners plus the overview, contiguous over lines 1-400:

1. Overview and Open-Question Framing (1-40)
2. Part 1: Representation Types (41-72)
3. Part 2: Symmetry Multiplier (73-102)
4. Part 3: Enumeration of Types for Small n (103-154)
5. Part 4: Verification of Contributions (155-227)
6. Part 5: Structural Theorems about the Distribution (228-258)
7. Part 6: Type Classification (259-272)
8. Part 7: The Relationship Between Types and Jacobi's Formula (273-295)
9. Part 8: Perfect Square Types (296-316)
10. Part 9: Completeness Verification via Summation (317-349)
11. Part 10: Patterns in the Distribution (350-373)
12. Summary (374-400)

Each section gets an accurate `summary` and `mathContext`.

## Notes
- Build-free, gallery-metadata only: `sections` array is the sole change.
- Counts verified and already correct: **0 axioms, 38 theorems, 23 definitions** (22 `def` + 1 `structure`), **0 sorries, 400 lines**.
- No collision: the open four-square branches all target the deeper `-oq-01` slug; none modifies this base-slug `meta.json`.

## Test plan
- [x] `json.load` validates the edited meta.json
- [x] Section ranges contiguous 1→400 with no gaps/overlaps
- [x] Each `startLine` matches a real `## Part`/`## Summary` banner in `FourSquareDistribution.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)