### PR TITLE
research(de-moivre-oq-02-oq-02): realign gallery sections to full file (fix overlap, 6→6)

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
@@ -92,52 +92,52 @@
   },
   "sections": [
     {
-      "id": "preamble",
-      "title": "Preamble: Module Overview and Mathematical Context",
+      "id": "overview",
+      "title": "Overview and Proof Strategy",
       "startLine": 1,
-      "endLine": 30,
-      "summary": "Imports Mathlib, opens Polynomial/Chebyshev/Real namespaces, and introduces the open question: can the T×T product-to-sum formula extend to the T×U mixed setting? States the answer and proof strategy (paired integer induction).",
-      "mathContext": "$T_n(\\cos\\theta) = \\cos(n\\theta)$ and $U_n(\\cos\\theta)\\sin\\theta = \\sin((n+1)\\theta)$. The T×T formula $2T_m \\cdot T_n = T_{m+n} + T_{m-n}$ follows from $2\\cos(m\\theta)\\cos(n\\theta) = \\cos((m+n)\\theta) + \\cos((m-n)\\theta)$. The T×U formula $2T_m \\cdot U_n = U_{m+n} + U_{n-m}$ requires algebraic proof."
+      "endLine": 34,
+      "summary": "Module docstring posing the open question — does the Chebyshev T product-to-sum formula 2T_m·T_n = T_{m+n}+T_{m−n} extend to second-kind U_n? — and stating the YES answer with two identities (T·U cross product and U·U product-to-difference) plus the proof strategy: paired integer induction for the polynomial identity, direct trig for U·U.",
+      "mathContext": "Goal: extend $2T_m(\\cos\\theta)T_n(\\cos\\theta)=T_{m+n}+T_{m-n}$ to $U_n$, proving $2T_mU_n=U_{m+n}+U_{n-m}$ and $2(1-\\cos^2\\theta)U_mU_n=T_{m-n}-T_{m+n+2}$."
     },
     {
-      "id": "key-lemma",
-      "title": "Key Lemma: 2·X·U_k = U_{k+1} + U_{k-1}",
-      "startLine": 31,
-      "endLine": 64,
-      "summary": "Proves the engine lemma two_X_U: 2X·U_k = U_{k+1} + U_{k-1} by rearranging the U recurrence U_{k+2} = 2X·U_{k+1} - U_k. Also defines induction predicates P (the main identity at index m) and Q (paired conjunction P(m) ∧ P(m-1)), and proves the base case Q_zero covering P(0) and P(-1). The P(-1) base uses T_{-1} = X (itself derived from T_add_two at -1).",
-      "mathContext": "$2X \\cdot U_k = U_{k+1} + U_{k-1}$ follows from $U_{k+1} = 2X \\cdot U_k - U_{k-1}$. Base case $P(-1)$: $2T_{-1} \\cdot U_n = 2X \\cdot U_n = U_{n+1} + U_{n-1}$, since $T_{-1} = X$."
+      "id": "key-recurrence-helper",
+      "title": "Polynomial Identity: Key Recurrence Helper",
+      "startLine": 35,
+      "endLine": 45,
+      "summary": "Opens `section PolynomialIdentity` over a commutative ring R and proves the helper `two_X_U`: 2·X·U_k = U_{k+1} + U_{k-1}, a rearrangement of the Chebyshev U recurrence used twice in each induction step.",
+      "mathContext": "The rearranged $U$-recurrence $2X\\,U_k=U_{k+1}+U_{k-1}$ in $R[X]$ is the workhorse of the induction."
     },
     {
-      "id": "induction-steps",
-      "title": "Induction Steps: Q_succ and Q_pred",
-      "startLine": 65,
-      "endLine": 126,
-      "summary": "Q_succ proves Q(m+1) from Q(m): uses T_{m+1} = 2X·T_m - T_{m-1}, applies two_X_U twice (at m+n and n-m), then closes with linear_combination. Q_pred proves Q(m-1) from Q(m): symmetric argument with T_{m-2} = 2X·T_{m-1} - T_m and two_X_U twice (at m-1+n and n-m+1). Main theorem T_mul_U_product assembles all parts via Int.induction_on.",
-      "mathContext": "Successor step: $2T_{m+1} \\cdot U_n = 2(2X \\cdot T_m - T_{m-1}) \\cdot U_n = 2X(2T_m \\cdot U_n) - (2T_{m-1} \\cdot U_n)$. By $P(m)$ and $P(m-1)$, plus $2X \\cdot U_k = U_{k+1} + U_{k-1}$ twice: $= U_{m+n+1} + U_{n-m-1} = U_{(m+1)+n} + U_{n-(m+1)}$ ✓."
+      "id": "paired-induction",
+      "title": "Polynomial Identity: Paired Integer Induction",
+      "startLine": 46,
+      "endLine": 115,
+      "summary": "Defines the predicate `P m` (2·T_m·U_n = U_{m+n}+U_{n−m}) and the paired conjunction `Q m = P m ∧ P (m−1)`, proves the base case `Q_zero` and both step lemmas `Q_succ`/`Q_pred` via `linear_combination`, and concludes the main polynomial identity `T_mul_U_product` by `Int.induction_on`.",
+      "mathContext": "Carrying $P(m)$ and $P(m-1)$ together lets a single `Int.induction_on` establish $2T_m U_n=U_{m+n}+U_{n-m}$ in $R[X]$ for all $m\\in\\mathbb{Z}$."
     },
     {
-      "id": "real-evaluation-main",
-      "title": "Real Evaluation: chebyshev_T_U_product_to_sum and chebyshev_cos_U",
-      "startLine": 128,
-      "endLine": 154,
-      "summary": "Evaluates T_mul_U_product at x = cos θ to derive chebyshev_T_U_product_to_sum (the real form). Specializes to m=1 using T_1(cos θ) = cos θ to get chebyshev_cos_U: 2·cos θ·U_n(cos θ) = U_{n+1}(cos θ) + U_{n-1}(cos θ).",
-      "mathContext": "Polynomial evaluation: $\\mathrm{eval}(\\cos\\theta, 2T_m \\cdot U_n) = 2T_m(\\cos\\theta) \\cdot U_n(\\cos\\theta) = U_{m+n}(\\cos\\theta) + U_{n-m}(\\cos\\theta)$. The $m=1$ specialization uses $T_1(\\cos\\theta) = \\cos\\theta$."
-    },
-    {
-      "id": "trig-spreading",
-      "title": "Trig Identity: 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ)",
-      "startLine": 155,
-      "endLine": 182,
-      "summary": "Converts chebyshev_cos_U to pure trig form via sin_add/sin_sub (not U_real_cos, which has rewrite issues). Proves 2·cos θ·sin((n+1)θ) = sin((n+2)θ) + sin(nθ).",
-      "mathContext": "Uses $\\sin(A+B) + \\sin(A-B) = 2\\sin A \\cos B$ with $A = (n+1)\\theta$, $B = \\theta$."
+      "id": "real-evaluation",
+      "title": "Real Evaluation Form",
+      "startLine": 116,
+      "endLine": 157,
+      "summary": "`section RealEvaluation` specializes to cos θ: `chebyshev_T_U_product_to_sum` (the real cross product-to-sum, with no sin θ = 0 case analysis), the recurrence corollary `chebyshev_cos_U` (2cos θ·U_n = U_{n+1}+U_{n−1}), and the trig form `two_cos_sin_spreading` (2cos θ·sin((n+1)θ) = sin((n+2)θ)+sin(nθ)).",
+      "mathContext": "Evaluating the polynomial identity at $\\cos\\theta$ gives $2T_m(\\cos\\theta)U_n(\\cos\\theta)=U_{m+n}+U_{n-m}$ and the trig spreading identity for $\\cos\\theta\\sin((n+1)\\theta)$."
     },
     {
       "id": "uu-product",
-      "title": "U·U Product-to-Difference Formula",
-      "startLine": 140,
-      "endLine": 215,
-      "summary": "Proves 2·sin²θ·U_m(cosθ)·U_n(cosθ) = T_{m-n}(cosθ) − T_{m+n+2}(cosθ) via: (1) cos(A-B) − cos(A+B) = 2·sin(A)·sin(B); (2) U_n(cosθ)·sinθ = sin((n+1)θ). Also proves two_sin_sin_spreading: 2·sin((m+1)θ)·sin((n+1)θ) = cos((m−n)θ) − cos((m+n+2)θ). Summary theorem demoivre_oq02oq02_summary collects all main results.",
-      "mathContext": "$\\cos((m-n)\\theta) - \\cos((m+n+2)\\theta) = 2\\sin((m+1)\\theta)\\sin((n+1)\\theta) = 2 \\cdot U_m(\\cos\\theta)\\sin\\theta \\cdot U_n(\\cos\\theta)\\sin\\theta$. Dividing by $\\sin^2\\theta = 1 - \\cos^2\\theta$ (in the polynomial sense) gives the formula."
+      "title": "U·U Product-to-Difference",
+      "startLine": 158,
+      "endLine": 205,
+      "summary": "`section UUProduct` proves `chebyshev_U_U_product_to_diff`: 2(1−cos²θ)·U_m(cosθ)·U_n(cosθ) = T_{m−n}(cosθ) − T_{m+n+2}(cosθ), via U_n(cosθ)·sinθ = sin((n+1)θ) and cos(A−B)−cos(A+B) = 2sinA sinB, plus the companion trig form `two_sin_sin_spreading`. Completes the Chebyshev product table (T·T, T·U, U·U).",
+      "mathContext": "Using $U_n(\\cos\\theta)\\sin\\theta=\\sin((n+1)\\theta)$ and $\\cos(A-B)-\\cos(A+B)=2\\sin A\\sin B$ gives $2\\sin^2\\theta\\,U_mU_n=T_{m-n}-T_{m+n+2}$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 206,
+      "endLine": 216,
+      "summary": "`demoivre_oq02oq02_summary` bundles the three real-form results — the T·U cross product-to-sum, its recurrence corollary, and the U·U product-to-difference — into a single theorem, closing the namespace.",
+      "mathContext": "The three identities together answer the open question: the second-kind Chebyshev polynomials admit product-to-sum formulas paralleling the first-kind table."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `de-moivre-oq-02-oq-02` gallery entry's sections had drifted so the final "U·U Product-to-Difference Formula" range (140-215) overlapped the two preceding sections ("Real Evaluation" 128-154 and "Trig Identity" 155-182), leaving the section order scrambled against `DeMoivreOQ02OQ02.lean` (216 lines).

This retiles to 6 contiguous, correctly-ordered sections (1-216) matching the file's actual `section` structure:

1. Overview and Proof Strategy (1-34)
2. Polynomial Identity: Key Recurrence Helper (35-45) — `two_X_U`
3. Polynomial Identity: Paired Integer Induction (46-115) — `P`/`Q`/`Q_zero`/`Q_succ`/`Q_pred`/`T_mul_U_product`
4. Real Evaluation Form (116-157) — `chebyshev_T_U_product_to_sum`, `chebyshev_cos_U`, `two_cos_sin_spreading`
5. U·U Product-to-Difference (158-205) — `chebyshev_U_U_product_to_diff`, `two_sin_sin_spreading`
6. Summary (206-216) — `demoivre_oq02oq02_summary`

Each section gets an accurate `summary` and `mathContext`.

## Notes
- Build-free, gallery-metadata only: applied via a surgical splice of the `sections` array so the compact `imports`/`opens` arrays remain byte-identical.
- Counts verified and already correct: **0 axioms, 11 theorems, 2 definitions, 0 sorries, 216 lines**.
- No collision: no open PR touches this base-slug `meta.json`; the existing de-moivre branches/worktrees are stale (clean worktree, no remote diff).

## Test plan
- [x] `json.load` validates the edited meta.json
- [x] Section ranges contiguous 1→216 with no gaps/overlaps
- [x] Each `startLine` matches a real `section`/banner boundary in `DeMoivreOQ02OQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)