### PR TITLE
Enrich erdos-5-prime-gaps: realign sections/annotations to full file (Parts XIII–XV)

### DIFF
--- a/src/data/proofs/erdos-5-prime-gaps/annotations.json
+++ b/src/data/proofs/erdos-5-prime-gaps/annotations.json
@@ -216,7 +216,7 @@
     "proofId": "erdos-5-prime-gaps",
     "range": {
       "startLine": 520,
-      "endLine": 572
+      "endLine": 571
     },
     "type": "insight",
     "title": "The Density Reduction: Erdős #5 from Frequence Density",
@@ -232,6 +232,77 @@
       "exists_nat_gt",
       "Filter.tendsto_atTop",
       "Metric.tendsto_atTop"
+    ]
+  },
+  {
+    "id": "ann-forward-density",
+    "proofId": "erdos-5-prime-gaps",
+    "range": {
+      "startLine": 572,
+      "endLine": 614
+    },
+    "type": "insight",
+    "title": "Forward Density: Limit Points Are Approached Infinitely Often",
+    "content": "frequently_near_of_isLimitPoint is the converse of the diagonal-extraction lemma: if C is a limit point of the normalized gaps, a convergent subsequence f composed with a shift injects ℕ into the ε-ball around C, so {n : dist(normalizedGap n, C) < ε} is infinite. Pairing this with erdos_5_from_dense_values yields erdos_5_iff_dense_at_every_point, which recasts the open problem in purely distributional terms — no explicit subsequence construction is needed, only that the normalized gaps are everywhere abundant on [0,∞).",
+    "mathContext": "$C\\in S \\iff \\forall\\varepsilon>0,\\ \\{n:|\\mathrm{normalizedGap}(n)-C|<\\varepsilon\\}\\text{ infinite}$. Erdős #5 $\\iff$ this holds $\\forall C\\ge0$ and $\\infty\\in S$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "limit point",
+      "subsequence",
+      "infinite set",
+      "density"
+    ],
+    "prerequisites": [
+      "metric topology",
+      "Set.Infinite",
+      "Filter.Tendsto"
+    ]
+  },
+  {
+    "id": "ann-unconditional-oscillation",
+    "proofId": "erdos-5-prime-gaps",
+    "range": {
+      "startLine": 615,
+      "endLine": 656
+    },
+    "type": "context",
+    "title": "Unconditional Oscillation: Zhang and Westzynthius Corollaries",
+    "content": "Two corollaries proved without assuming the full conjecture. frequently_normalizedGap_lt is the Zhang (2013) bounded-gaps consequence: for every ε>0 the normalized gap drops below ε infinitely often. frequently_normalizedGap_gt is the Westzynthius/Erdős–Rankin large-gaps consequence: for every M the normalized gap exceeds M infinitely often. These are theorems (the underlying analytic inputs are the axiomatized known results), establishing that the normalized prime gaps oscillate between accumulation at 0 and unboundedness.",
+    "mathContext": "$\\liminf_n \\frac{p_{n+1}-p_n}{\\log p_n}=0$ (Zhang) and $\\limsup_n \\frac{p_{n+1}-p_n}{\\log p_n}=\\infty$ (Westzynthius), both in the 'infinitely often' sense.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bounded prime gaps",
+      "Zhang's theorem",
+      "Westzynthius",
+      "liminf/limsup"
+    ],
+    "prerequisites": [
+      "prime gap asymptotics",
+      "Set.Infinite"
+    ]
+  },
+  {
+    "id": "ann-liminf-limsup",
+    "proofId": "erdos-5-prime-gaps",
+    "range": {
+      "startLine": 657,
+      "endLine": 707
+    },
+    "type": "insight",
+    "title": "Liminf / Limsup Corollaries: 0 and ∞ Are Genuine Limit Points",
+    "content": "The closing corollaries restate the oscillation in liminf/limsup and Eventually language. normalizedGap_oscillates bundles the Part XIV pair; not_eventually_normalizedGap_le shows no M eventually bounds the gap above (limsup = ⊤); not_eventually_le_normalizedGap shows no ε eventually bounds it below (liminf = 0). Together they certify that 0 and ∞ are bona fide limit points of the normalized prime gaps — the two extreme endpoints of the conjectured equality S = [0,∞].",
+    "mathContext": "$\\neg(\\forall^\\infty n,\\ g_n\\le M)$ and $\\neg(\\forall^\\infty n,\\ \\varepsilon\\le g_n)$ where $g_n=\\frac{p_{n+1}-p_n}{\\log p_n}$, i.e. $\\limsup g_n=\\infty$, $\\liminf g_n=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "limsup",
+      "liminf",
+      "Filter.Eventually",
+      "limit point",
+      "Erdős #5"
+    ],
+    "prerequisites": [
+      "limsup/liminf",
+      "Filter.Eventually"
     ]
   }
 ]

--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -144,8 +144,32 @@
       "id": "density-reduction",
       "title": "Part XII: Density Reduction — The Cleanest Path to Erdős #5",
       "startLine": 520,
-      "endLine": 572,
+      "endLine": 571,
       "summary": "Lemma isLimitPoint_of_frequently_near: frequent proximity → limit point (via diagonal argument). Theorem erdos_5_from_dense_values: density of normalizedGap values in [0,∞) implies S = [0,∞). This is the key reduction making the conjecture accessible."
+    },
+    {
+      "id": "forward-density",
+      "title": "Part XIII: Forward Density Direction",
+      "startLine": 572,
+      "endLine": 614,
+      "summary": "Proves frequently_near_of_isLimitPoint (the converse of isLimitPoint_of_frequently_near): any limit point C of the normalized gaps is approached infinitely often, since a convergent subsequence injects ℕ into every ε-ball around C. Combined with the reduction theorem this gives erdos_5_iff_dense_at_every_point — recasting Erdős #5 as the purely distributional claim that normalizedGap visits every neighborhood of every C ∈ [0,∞) infinitely often (plus ∞ a limit point).",
+      "mathContext": "$C \\in S \\iff \\forall \\varepsilon>0,\\ \\{n : |\\,\\mathrm{normalizedGap}(n)-C\\,|<\\varepsilon\\}$ is infinite. Erdős #5 $\\iff$ this holds for every $C\\ge 0$ together with $\\infty$ being a limit point."
+    },
+    {
+      "id": "unconditional-oscillation",
+      "title": "Part XIV: Unconditional Oscillation",
+      "startLine": 615,
+      "endLine": 656,
+      "summary": "The unconditional (theorem-not-axiom) oscillation corollaries. frequently_normalizedGap_lt packages Zhang's bounded-gaps result (2013): for every ε>0 the normalized gap is below ε infinitely often. frequently_normalizedGap_gt packages the Westzynthius/Erdős–Rankin large-gaps result: for every M the normalized gap exceeds M infinitely often. Together they show the normalized gaps are unbounded above and accumulate at 0 without assuming the full conjecture.",
+      "mathContext": "From Zhang: $\\liminf_n \\frac{p_{n+1}-p_n}{\\log p_n}=0$ in the frequent sense; from Westzynthius: $\\limsup_n \\frac{p_{n+1}-p_n}{\\log p_n}=\\infty$. Both are proved unconditionally."
+    },
+    {
+      "id": "liminf-limsup",
+      "title": "Part XV: Liminf / Limsup Corollaries",
+      "startLine": 657,
+      "endLine": 707,
+      "summary": "Final corollaries restating the unconditional oscillation in liminf/limsup and Eventually language. normalizedGap_oscillates bundles the two Part XIV results; not_eventually_normalizedGap_le shows there is no eventual upper bound M (limsup = ⊤); not_eventually_le_normalizedGap shows the gap is not eventually bounded below by any ε (liminf = 0). These pin down that 0 and ∞ are genuine limit points of the normalized prime gaps, the two endpoints of the conjectured S = [0,∞].",
+      "mathContext": "$\\liminf \\frac{p_{n+1}-p_n}{\\log p_n}=0$ and $\\limsup \\frac{p_{n+1}-p_n}{\\log p_n}=\\infty$, equivalently $\\neg(\\forall^\\infty n,\\ g_n\\le M)$ and $\\neg(\\forall^\\infty n,\\ \\varepsilon\\le g_n)$."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment pass for `erdos-5-prime-gaps`

The gallery metadata (`Proofs/Erdos5PrimeGaps.lean`, 707 lines) had drifted: both `sections` and `annotations` stopped at line 572, hiding the final ~135 lines (Parts XIII–XV), which contain 8 theorems on the unconditional oscillation of normalized prime gaps.

### Sections (9 → 12)
- Trimmed **Part XII** to end at 571 (just before the Part XIII banner).
- Added **Part XIII: Forward Density Direction** (572–614) — `frequently_near_of_isLimitPoint`, `erdos_5_iff_dense_at_every_point`.
- Added **Part XIV: Unconditional Oscillation** (615–656) — Zhang (`frequently_normalizedGap_lt`) and Westzynthius (`frequently_normalizedGap_gt`) corollaries.
- Added **Part XV: Liminf / Limsup Corollaries** (657–707) — `normalizedGap_oscillates`, `not_eventually_normalizedGap_le`, `not_eventually_le_normalizedGap`.

Sections now tile the full file 1–707, aligned to the `/- ## Part N -/` banners.

### Annotations (10 → 13)
Same lockstep co-drift: trimmed the density-reduction annotation to 571 and added three annotations covering Parts XIII–XV, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Integrity
Verified `theoremCount: 36`, `axiomCount: 3`, `sorries: 0`, `status: axiomatized` all match the source — no count/status changes were needed.

### Validation
JSON valid; `pnpm annotations:build` / `pnpm research:build` pass (exit 0).