### PR TITLE
research(schauder-fixed-point): realign drifted gallery sections to file (9→10)

### DIFF
--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -85,72 +85,80 @@
     {
       "id": "framework",
       "title": "Fixed Point Framework",
-      "startLine": 68,
-      "endLine": 77,
+      "startLine": 74,
+      "endLine": 84,
       "summary": "Basic definitions of fixed points and the HasFixedPtIn predicate.",
       "mathContext": "Defines $x$ is a fixed point of $f$ iff $f(x) = x$, and the predicate $\\texttt{HasFixedPtIn}(f, K)$ iff $\\exists\\, x \\in K,\\; f(x) = x$."
     },
     {
       "id": "foundational-axioms",
       "title": "Foundational Axioms",
-      "startLine": 79,
-      "endLine": 148,
+      "startLine": 85,
+      "endLine": 135,
       "summary": "The axioms: Schauder projection lemma, Brouwer FPT, Brouwer for finite-dim subsets, and Mazur's theorem.",
       "mathContext": "Axiomatizes: (1) Schauder projection: $\\forall\\, \\varepsilon > 0,\\; \\exists\\, \\pi_\\varepsilon : K \\to \\operatorname{conv}(S)$ with $\\dim(S) < \\infty$ and $\\|\\pi_\\varepsilon(x) - x\\| < \\varepsilon$; (2) Brouwer: continuous $f : B^n \\to B^n$ has a fixed point; (3) Mazur: $\\overline{\\operatorname{conv}(C)}$ is convex in a Banach space."
     },
     {
       "id": "schauder-normed",
       "title": "Schauder Fixed Point Theorem (PROVED)",
-      "startLine": 150,
-      "endLine": 330,
-      "summary": "The main theorem proved from projection lemma + Brouwer via finite-dimensional approximation and sequential compactness. 1 sorry for closedness of convex hull in finite-dim subspace.",
+      "startLine": 136,
+      "endLine": 344,
+      "summary": "The main theorem proved from projection lemma + Brouwer via finite-dimensional approximation and sequential compactness. No sorry.",
       "mathContext": "Proves the Schauder FPT: if $K \\subseteq E$ is nonempty, compact, and convex in a normed space, and $f : K \\to K$ is continuous, then $\\exists\\, x \\in K,\\; f(x) = x$. The proof constructs $\\varepsilon$-approximate fixed points $x_\\varepsilon$ with $\\|f(x_\\varepsilon) - x_\\varepsilon\\| < \\varepsilon$, then extracts a convergent subsequence by compactness."
     },
     {
       "id": "compact-operator",
       "title": "Compact Operator Version (PROVED)",
-      "startLine": 332,
-      "endLine": 350,
+      "startLine": 345,
+      "endLine": 409,
       "summary": "Extension to non-compact domains with compact operators, proved from Schauder + Mazur's theorem. No sorry.",
       "mathContext": "Proves: if $C$ is closed, bounded, convex in a Banach space and $T : C \\to C$ is continuous with $\\overline{T(C)}$ compact, then $\\exists\\, x \\in C,\\; T(x) = x$. Uses Mazur's theorem to show $\\overline{\\operatorname{conv}(T(C))}$ is compact and convex, then applies Schauder."
     },
     {
       "id": "tychonoff",
       "title": "Tychonoff Fixed Point Theorem (PROVED)",
-      "startLine": 352,
-      "endLine": 374,
+      "startLine": 410,
+      "endLine": 433,
       "summary": "Normed space case proved directly from Schauder. No sorry.",
       "mathContext": "Proves Tychonoff's generalization: if $K$ is nonempty, compact, convex in a locally convex TVS $E$ and $f : K \\to K$ is continuous, then $\\exists\\, x \\in K,\\; f(x) = x$. Derived from Schauder since every normed space is locally convex."
     },
     {
       "id": "hierarchy",
       "title": "Theorem Hierarchy",
-      "startLine": 376,
-      "endLine": 410,
+      "startLine": 434,
+      "endLine": 466,
       "summary": "The implication chain: interval FPT (fully proved), Brouwer from Schauder, Schauder from Tychonoff.",
       "mathContext": "Establishes the hierarchy: IVT $\\implies$ $f : [a,b] \\to [a,b]$ has a fixed point (proved via Mathlib), Brouwer $\\implies$ Schauder (compact convex in normed spaces) $\\implies$ Tychonoff (compact convex in locally convex TVS). Each level strictly generalizes the previous."
     },
     {
       "id": "peano",
       "title": "Application: Peano Existence Theorem",
-      "startLine": 412,
-      "endLine": 435,
+      "startLine": 467,
+      "endLine": 492,
       "summary": "How Schauder proves existence of ODE solutions where Brouwer cannot reach.",
       "mathContext": "Applies Schauder to the Peano existence theorem: the ODE $y' = f(t, y)$ with $f$ continuous on $[t_0 - a, t_0 + a] \\times \\overline{B}(y_0, b)$ has a solution. The integral operator $T(y)(t) = y_0 + \\int_{t_0}^{t} f(s, y(s))\\, ds$ maps a compact convex subset of $C([t_0-a, t_0+a])$ to itself."
     },
     {
       "id": "banach",
       "title": "Banach Contraction Mapping (PROVED)",
-      "startLine": 437,
-      "endLine": 475,
+      "startLine": 493,
+      "endLine": 528,
       "summary": "Contractions as a special case, with uniqueness proved via Mathlib's ContractingWith API.",
       "mathContext": "Proves the Banach contraction mapping theorem: if $(X, d)$ is a complete metric space and $T : X \\to X$ satisfies $d(Tx, Ty) \\leq q \\cdot d(x,y)$ with $q < 1$, then $T$ has a unique fixed point $x^* = \\lim_{n \\to \\infty} T^n(x_0)$, using Mathlib's $\\texttt{ContractingWith}$ API."
     },
     {
+      "id": "hierarchy-diagram",
+      "title": "The Hierarchy Diagram",
+      "startLine": 529,
+      "endLine": 574,
+      "summary": "An ASCII diagram of the fixed point theorem hierarchy (Tychonoff → Schauder → Brouwer → IVT, plus Kakutani → Nash) and an explanation of why compactness, not finite-dimensionality, is the essential hypothesis.",
+      "mathContext": "Summarizes the implication structure relating Tychonoff (1935), Schauder (1930), Schauder for compact operators, Peano existence, Brouwer (1911), the interval FPT/IVT, and the Kakutani (1941) → Nash (1950) branch. Emphasizes that Brouwer fails in infinite dimensions because the unit ball of $\\ell^2$ is not compact (Riesz's lemma), so compactness of the domain or image is what restores the fixed point property."
+    },
+    {
       "id": "counterexample",
       "title": "Infinite-Dimensional Counterexample",
-      "startLine": 520,
-      "endLine": 537,
+      "startLine": 575,
+      "endLine": 601,
       "summary": "Brouwer fails without compactness: continuous fixed-point-free self-maps of the unit ball exist in infinite dimensions.",
       "mathContext": "Shows that compactness is necessary: in $\\ell^2$, the shift map $T(x_1, x_2, \\ldots) = (\\sqrt{1 - \\|x\\|^2}, x_1, x_2, \\ldots)$ is a continuous self-map of the closed unit ball $\\overline{B}(0,1)$ with no fixed point, since the ball is not compact in infinite dimensions."
     }


### PR DESCRIPTION
## Summary
- Gallery `meta.json` section ranges for **schauder-fixed-point** were anchored to an earlier revision of `proofs/Proofs/SchauderFixedPoint.lean`: every range was off by 40–65 lines, `banach` (437–475) overflowed its real PART 8 end, and a 45-line interior gap (475→520) plus a 64-line tail (537→601) were left uncovered.
- The Lean file now has **10** `-- PART N` banners but meta listed only **9** sections — **PART 9 "The Hierarchy Diagram"** was missing entirely.
- Retiled all sections contiguously (**74–601**) to the actual PART banners and added the missing `hierarchy-diagram` section.
- De-staled the `schauder-normed` summary: it claimed "1 sorry for closedness of convex hull…", but the file has **0 sorries** (the projection-lemma sorry was discharged).

## New section tiling (10, contiguous)
| Range | Section |
|-------|---------|
| 74–84 | framework (PART 1) |
| 85–135 | foundational-axioms (PART 2) |
| 136–344 | schauder-normed (PART 3) |
| 345–409 | compact-operator (PART 4) |
| 410–433 | tychonoff (PART 5) |
| 434–466 | hierarchy (PART 6) |
| 467–492 | peano (PART 7) |
| 493–528 | banach (PART 8) |
| 529–574 | hierarchy-diagram (PART 9, **new**) |
| 575–601 | counterexample (PART 10) |

## Notes
- Counts (5 axioms, 9 theorems, 2 defs, 0 sorries) are unchanged and already correct — this is a ranges + one-section-added + one-summary-de-staled change only.
- No Lean source changes; no build required.

## Test plan
- [x] `jq -e .` validates the JSON
- [x] Sections are perfectly contiguous (no gaps/overlaps) from 74 to EOF (601)
- [x] Each range aligns to its `-- PART N` box banner in the Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)