### PR TITLE
Enrich hermite-lindemann: realign drifted sections & annotations

### DIFF
--- a/src/data/proofs/hermite-lindemann/annotations.json
+++ b/src/data/proofs/hermite-lindemann/annotations.json
@@ -52,7 +52,7 @@
     "proofId": "hermite-lindemann",
     "range": {
       "startLine": 131,
-      "endLine": 158
+      "endLine": 156
     },
     "type": "concept",
     "title": "Hermite-Lindemann Theorem (Axiomatized)",
@@ -75,8 +75,8 @@
     "id": "ann-lindemann-weierstrass",
     "proofId": "hermite-lindemann",
     "range": {
-      "startLine": 164,
-      "endLine": 205
+      "startLine": 161,
+      "endLine": 186
     },
     "type": "concept",
     "title": "Lindemann-Weierstrass Theorem (Two Forms)",
@@ -99,8 +99,8 @@
     "id": "ann-corollaries",
     "proofId": "hermite-lindemann",
     "range": {
-      "startLine": 213,
-      "endLine": 281
+      "startLine": 191,
+      "endLine": 271
     },
     "type": "concept",
     "title": "Fundamental Corollaries",
@@ -123,8 +123,8 @@
     "id": "ann-applications",
     "proofId": "hermite-lindemann",
     "range": {
-      "startLine": 289,
-      "endLine": 317
+      "startLine": 276,
+      "endLine": 295
     },
     "type": "concept",
     "title": "Applications: Circle Squaring and Irrationality",
@@ -147,8 +147,8 @@
     "id": "ann-connections",
     "proofId": "hermite-lindemann",
     "range": {
-      "startLine": 325,
-      "endLine": 352
+      "startLine": 300,
+      "endLine": 330
     },
     "type": "concept",
     "title": "Generalizations and Open Problems",
@@ -171,8 +171,8 @@
     "id": "ann-proof-technique",
     "proofId": "hermite-lindemann",
     "range": {
-      "startLine": 360,
-      "endLine": 390
+      "startLine": 335,
+      "endLine": 373
     },
     "type": "concept",
     "title": "Auxiliary Polynomial Method (Pedagogical)",

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -84,46 +84,46 @@
       "id": "hermite-lindemann-theorem",
       "title": "Part II: The Hermite-Lindemann Theorem",
       "startLine": 127,
-      "endLine": 159,
+      "endLine": 156,
       "summary": "Axiomatizes the main theorem: $\\alpha \\neq 0$ algebraic $\\Rightarrow e^\\alpha$ transcendental. Also states the contrapositive: $e^\\alpha$ algebraic $\\Rightarrow \\alpha$ transcendental.",
       "mathContext": "Axiomatizes the main theorem: $\\$\\alpha$ \\neq 0$ algebraic $\\Rightarrow e^\\$\\alpha$$ transcendental. Also states the contrapositive: $e^\\$\\alpha$$ algebraic $\\Rightarrow \\$\\alpha$$ transcendental."
     },
     {
       "id": "lindemann-weierstrass",
       "title": "Part III: The Lindemann-Weierstrass Theorem",
-      "startLine": 160,
-      "endLine": 206,
+      "startLine": 157,
+      "endLine": 186,
       "summary": "Defines `AlgebraicallyIndependent` using `MvPolynomial` and axiomatizes two forms: classical (distinct algebraics $\\Rightarrow$ linearly independent exponentials) and strong ($\\mathbb{Q}$-linearly independent algebraics $\\Rightarrow$ algebraically independent exponentials).",
       "mathContext": "Defines `AlgebraicallyIndependent` using `MvPolynomial` and axiomatizes two forms: classical (distinct algebraics $\\Rightarrow$ linearly independent exponentials) and strong ($\\mathbb{Q}$-linearly independent algebraics $\\Rightarrow$ algebraically independent exponentials)."
     },
     {
       "id": "fundamental-corollaries",
       "title": "Part IV: Fundamental Corollaries",
-      "startLine": 207,
-      "endLine": 282,
+      "startLine": 187,
+      "endLine": 271,
       "summary": "Derives transcendence of $e$ (Wiedijk #67), $\\pi$ (Wiedijk #53), $e^n$ for nonzero $n \\in \\mathbb{Z}$ (proved via `hermite_lindemann` + `isAlgebraic_int`), and $e^{n\\alpha}$ for algebraic $\\alpha$.",
       "mathContext": "Derives transcendence of $e$ (Wiedijk #67), $\\$\\pi$$ (Wiedijk #53), $e^n$ for nonzero $n \\in \\mathbb{Z}$ (proved via `hermite_lindemann` + `isAlgebraic_int`), and $e^{n\\$\\alpha$}$ for algebraic $\\$\\alpha$$."
     },
     {
       "id": "applications",
       "title": "Part V: Applications",
-      "startLine": 283,
-      "endLine": 318,
+      "startLine": 272,
+      "endLine": 295,
       "summary": "Axiomatizes $\\sqrt{\\pi}$ transcendental (impossibility of squaring the circle) and $e$ irrational (non-periodic decimal expansion). Both follow from transcendence via algebraic closure properties.",
       "mathContext": "Axiomatizes $\\sqrt{\\$\\pi$}$ transcendental (impossibility of squaring the circle) and $e$ irrational (non-periodic decimal expansion). Both follow from transcendence via algebraic closure properties."
     },
     {
       "id": "connections",
       "title": "Part VI: Connections to Other Results",
-      "startLine": 319,
-      "endLine": 353,
+      "startLine": 296,
+      "endLine": 330,
       "summary": "Documents generalizations: Gelfond-Schneider (1934, $\\alpha^\\beta$ transcendental, Hilbert #7), Baker's theorem (1966, linear forms in logarithms). Lists open problems: is $e + \\pi$ transcendental? Describes Schanuel's conjecture.",
       "mathContext": "Documents generalizations: Gelfond-Schneider (1934, $\\alpha^\\beta$ transcendental, Hilbert #7), Baker's theorem (1966, linear forms in logarithms). Lists open problems: is $e + \\pi$ transcendental?"
     },
     {
       "id": "proof-techniques",
       "title": "Part VII: Proof Techniques (Pedagogical)",
-      "startLine": 354,
+      "startLine": 331,
       "endLine": 373,
       "summary": "Detailed pedagogical exposition of Hermite's auxiliary polynomial method: construction of $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, the sum $F(x) = \\sum f^{(k)}(x)$, integration by parts yielding $I_k = e^k F(0) - F(k)$, and the integer-vs-small contradiction.",
       "mathContext": "Detailed pedagogical exposition of Hermite's auxiliary polynomial method: construction of $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, the sum $F(x) = \\sum f^{(k)}(x)$, integration by parts yielding $I_k = e^k F(0) - F(k)$, and the integer-vs-small contradiction."


### PR DESCRIPTION
## Summary

Annotation/section **co-drift** fix for the Hermite–Lindemann gallery entry. As the Lean file (`Proofs/HermiteLindemann.lean`, 373 lines) evolved, the meta `sections` for Parts III–VII and the parallel annotations drifted progressively late. The worst case: annotation `ann-proof-technique` pointed at lines **360–390** — 17 lines past the end of a 373-line file, so it bound to nothing and never rendered.

## Changes

Realigned every section and annotation range to the actual `PART I–VII` banner boundaries:

| Part | Section (old → new) | Banner |
|------|--------------------|--------|
| II   | 127-159 → 127-156  | 127 |
| III  | 160-206 → 157-186  | 157 |
| IV   | 207-282 → 187-271  | 187 |
| V    | 283-318 → 272-295  | 272 |
| VI   | 319-353 → 296-330  | 296 |
| VII  | 354-373 → 331-373  | 331 |

Annotation starts were nudged onto the corresponding `/--`/`/-!`/`section` construct lines. Sections now contiguously tile lines 1–373 and all annotation ranges are in-bounds.

## Verification

- `pnpm annotations:build` passes; the previous "No Lean construct" warnings for this entry's drifted annotations are gone.
- Schema-defect scan: `hermite-lindemann` no longer reports any out-of-bounds annotation.
- Diff is range-only; no prose or content changed.