### PR TITLE
research(erdos-677): realign drifted gallery sections to full file (8→13)

### DIFF
--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -52,68 +52,108 @@
   },
   "sections": [
     {
-      "id": "lcm",
+      "id": "header",
+      "title": "Header: Statement and References",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "States Erdős Problem #677. With $M(n,k)=\\text{lcm}(n+1,\\dots,n+k)$, is $M(m,k)\\neq M(n,k)$ for all $m\\geq n+k$? Thue–Siegel implies only finitely many collisions for fixed $k$. Erdős knew two examples: $\\text{lcm}(5,6,7)=\\text{lcm}(14,15)$ and $\\text{lcm}(4,5,6,7)=\\text{lcm}(20,21)$. Stronger conjecture about shared prime factors. Imports GCD/factorization; opens `Finset`.",
+      "mathContext": "$M(n,k)=\\text{lcm}(n+1,\\dots,n+k)$; conjecture $M(m,k)\\neq M(n,k)$ for $m\\geq n+k$."
+    },
+    {
+      "id": "lcm-def",
       "title": "LCM of Consecutive Integers",
-      "startLine": 30,
-      "endLine": 36,
-      "summary": "Defines lcmInterval n k as the fold of Nat.lcm over range k.",
-      "mathContext": "$M(n, k) = \\text{lcm}(n+1, n+2, \\ldots, n+k) = \\text{Finset.fold}\\, \\text{Nat.lcm}\\, 1\\, (\\text{range}\\, k)\\, (\\lambda i, n + i + 1)$."
+      "startLine": 31,
+      "endLine": 37,
+      "summary": "Defines `lcmInterval n k` $=\\text{lcm}(n+1,\\dots,n+k)$ as a `Finset.fold` of `Nat.lcm`.",
+      "mathContext": "$\\text{lcmInterval}(n,k)=\\text{fold}\\,\\text{lcm}\\,1\\,(i\\mapsto n+i+1)$ over $\\text{range}\\,k$."
     },
     {
-      "id": "conjecture",
+      "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 37,
-      "endLine": 42,
-      "summary": "ErdosProblem677: M(m,k) ≠ M(n,k) for all m ≥ n+k.",
-      "mathContext": "$\\forall m, n, k > 0: m \\ge n + k \\implies M(m, k) \\neq M(n, k)$. The LCM function is injective on well-separated intervals of the same length."
+      "startLine": 38,
+      "endLine": 43,
+      "summary": "Defines `ErdosProblem677`: $\\forall m,n,k$ with $0<k$ and $n+k\\leq m$, $M(m,k)\\neq M(n,k)$.",
+      "mathContext": "$\\forall m\\geq n+k,\\ k>0:\\ \\text{lcmInterval}(m,k)\\neq\\text{lcmInterval}(n,k)$."
     },
     {
-      "id": "examples",
+      "id": "known-examples",
       "title": "Known Examples",
-      "startLine": 43,
-      "endLine": 49,
-      "summary": "The two known cross-parameter equalities: M(4,3) = M(13,2) and M(3,4) = M(19,2).",
-      "mathContext": "$\\text{lcm}(5,6,7) = \\text{lcm}(14,15) = 210$ and $\\text{lcm}(4,5,6,7) = \\text{lcm}(20,21) = 420$. Cross-parameter equalities ($k$ differs) that do not contradict the conjecture."
+      "startLine": 44,
+      "endLine": 51,
+      "summary": "PROVES the two known collisions by `native_decide`: `lcmInterval_example1` ($M(4,3)=M(13,2)=210$) and `lcmInterval_example2` ($M(3,4)=M(19,2)=420$).",
+      "mathContext": "$\\text{lcm}(5,6,7)=\\text{lcm}(14,15)=210$; $\\text{lcm}(4,5,6,7)=\\text{lcm}(20,21)=420$."
     },
     {
-      "id": "strong",
-      "title": "Stronger Conjecture and Thue–Siegel",
-      "startLine": 50,
-      "endLine": 73,
-      "summary": "Stronger prime-factor conjecture and Thue–Siegel finiteness theorem.",
-      "mathContext": "$\\forall k > 2: |\\{(m,n) : m \\ge n + k,\\, \\text{rad}(\\prod_{i=1}^k (n+i)) = \\text{rad}(\\prod_{i=1}^k (m+i))\\}| < \\infty$. Stronger than the LCM conjecture; same prime factors implies same LCM but not conversely. Thue-Siegel: for fixed $k$, only finitely many pairs with $M(m,k) = M(n,k)$."
+      "id": "stronger-conjecture",
+      "title": "Stronger Conjecture: Same Prime Factors",
+      "startLine": 52,
+      "endLine": 68,
+      "summary": "Defines `samePrimeFactors`, `consecutiveProduct n k` ($\\prod_{i<k}(n+i+1)$), and `ErdosProblem677_strong` (for $k>2$, only finitely many pairs whose consecutive products share the same prime factors).",
+      "mathContext": "Stronger: for $k>2$, $\\{(m,n):m\\geq n+k,\\ \\text{same prime factors of consecutive products}\\}$ finite."
     },
     {
-      "id": "basic",
+      "id": "thue-siegel",
+      "title": "Thue–Siegel Finiteness",
+      "startLine": 69,
+      "endLine": 75,
+      "summary": "States the AXIOM `thue_siegel_finiteness`: for fixed $k>0$, only finitely many pairs $(m,n)$ with $m\\geq n+k$ satisfy $M(m,k)=M(n,k)$ (a consequence of the Thue–Siegel theorem).",
+      "mathContext": "Axiom: $\\{(m,n):m\\geq n+k,\\ \\text{lcmInterval}(m,k)=\\text{lcmInterval}(n,k)\\}$ finite."
+    },
+    {
+      "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 74,
-      "endLine": 118,
-      "summary": "Proves lcmInterval_zero/one, consecutiveProduct_zero/one, divisibility, and positivity.",
-      "mathContext": "$M(n, 0) = 1$, $M(n, 1) = n + 1$, $\\prod_{i=1}^{0}(n+i) = 1$, $\\prod_{i=1}^{1}(n+i) = n + 1$. $M(n,k) \\mid \\prod_{i=1}^k (n+i)$ and $M(n,k) > 0$ for $k > 0$."
+      "startLine": 76,
+      "endLine": 120,
+      "summary": "PROVES `lcmInterval_zero`/`_one`, `consecutiveProduct_zero`/`_one`, `lcmInterval_dvd_product` ($M\\mid\\prod$, by induction) and `lcmInterval_pos` ($M>0$ for $k>0$).",
+      "mathContext": "$M(n,0)=1$, $M(n,1)=n+1$; $M(n,k)\\mid\\text{consecutiveProduct}(n,k)$; $M>0$."
     },
     {
       "id": "structural",
       "title": "Structural Properties",
-      "startLine": 120,
-      "endLine": 172,
-      "summary": "Recursion (lcmInterval_succ), element divisibility (dvd_lcmInterval), monotonicity in k (lcmInterval_dvd_succ/add), and consecutiveProduct recursion/positivity.",
-      "mathContext": "$M(n, k+1) = \\text{lcm}(n+k+1, M(n,k))$. For $i < k$: $(n+i+1) \\mid M(n,k)$. $M(n,k) \\mid M(n, k+j)$ for all $j$. $\\prod_{i=1}^{k+1}(n+i) = \\prod_{i=1}^k (n+i) \\cdot (n+k+1)$."
+      "startLine": 121,
+      "endLine": 173,
+      "summary": "PROVES recursion and divisibility: `lcmInterval_succ`, `dvd_lcmInterval` (each $n+i+1\\mid M$), `lcmInterval_dvd_succ`/`_dvd_add` (monotone in $k$), `last_dvd_lcmInterval` ($n+k\\mid M$), `consecutiveProduct_succ`/`_pos`.",
+      "mathContext": "$M(n,k+1)=\\text{lcm}(n+k+1,M(n,k))$; $M(n,k)\\mid M(n,k+j)$; $n+k\\mid M(n,k)$."
     },
     {
-      "id": "resolved-cases",
-      "title": "Conjecture Resolved for k = 1 and k = 2",
-      "startLine": 200,
-      "endLine": 230,
-      "summary": "PROVED: erdos677_k1 (k=1 case) and erdos677_k2 (k=2 case). Also: lcmInterval_ne_zero (M(n,k) ≠ 0), le_lcmInterval (n+k ≤ M(n,k)), lcmInterval_two (M(n,2) = (n+1)(n+2)).",
-      "mathContext": "For $k=1$: $M(n,1) = n+1$ is injective in $n$, so $M(m,1) \\neq M(n,1)$ when $m \\geq n+1$. For $k=2$: $\\gcd(n+1,n+2)=1$ implies $M(n,2) = (n+1)(n+2)$, which is strictly increasing in $n$, so $M(m,2) > M(n,2)$ when $m \\geq n+2$. Lower bound: $n+k \\mid M(n,k)$ implies $n+k \\leq M(n,k)$ for $k>0$."
+      "id": "prime-divisibility",
+      "title": "Prime Divisibility",
+      "startLine": 174,
+      "endLine": 197,
+      "summary": "PROVES `exists_dvd_in_range` (among $k$ consecutive integers, some is divisible by any $p\\leq k$) and `prime_le_dvd_lcmInterval` (every prime $p\\leq k$ divides $M(n,k)$).",
+      "mathContext": "Every prime $p\\leq k$ divides $\\text{lcmInterval}(n,k)$."
+    },
+    {
+      "id": "additional-structural",
+      "title": "Additional Structural Properties; k = 1, 2 Resolved",
+      "startLine": 198,
+      "endLine": 231,
+      "summary": "PROVES `lcmInterval_ne_zero`, `le_lcmInterval` ($n+k\\leq M$), `lcmInterval_two` ($M(n,2)=(n+1)(n+2)$ via coprimality), and the conjecture for small $k$: `erdos677_k1` ($M(\\cdot,1)=n+1$ injective) and `erdos677_k2` ($M(\\cdot,2)$ strictly increasing).",
+      "mathContext": "$n+k\\leq M(n,k)$; $M(n,2)=(n+1)(n+2)$; conjecture holds for $k=1,2$."
     },
     {
       "id": "factorization",
       "title": "Factorization Characterization",
-      "startLine": 230,
-      "endLine": 241,
-      "summary": "PROVED: factorization_lcmInterval — the Nat.factorization of M(n,k) equals the pointwise sup of the factorizations of n+1,...,n+k.",
-      "mathContext": "$(M(n,k))\\text{.factorization} = \\bigsqcup_{i=0}^{k-1} (n+i+1)\\text{.factorization}$, where $\\sqcup$ is the pointwise maximum of prime exponents. Equivalently: $v_p(M(n,k)) = \\max_{i<k} v_p(n+i+1)$ for every prime $p$. This characterizes when $M(n,k) = M(m,k)$: iff for every prime $p$, the maximum $p$-adic valuation in the two intervals coincide."
+      "startLine": 232,
+      "endLine": 246,
+      "summary": "PROVES `factorization_lcmInterval`: the factorization of $M(n,k)$ is the pointwise sup (max) of the factorizations of $n+1,\\dots,n+k$.",
+      "mathContext": "$(\\text{lcmInterval}(n,k)).\\text{factorization}=\\sup_{i<k}(n+i+1).\\text{factorization}$."
+    },
+    {
+      "id": "large-m",
+      "title": "General Large-m Distinctness Bound",
+      "startLine": 247,
+      "endLine": 278,
+      "summary": "PROVES `erdos677_large_m`: if $m+k>\\text{consecutiveProduct}(n,k)$ then $M(m,k)\\neq M(n,k)$ (sandwiching $M(n,k)\\leq\\prod$ against $M(m,k)\\geq m+k$). Corollary `erdos677_k3_large_m` and the closed form `consecutiveProduct_three` $=(n+1)(n+2)(n+3)$ — covers all large-$m$ cases without the Thue–Siegel axiom.",
+      "mathContext": "$m+k>\\prod_{i\\leq k}(n+i)\\Rightarrow M(m,k)\\neq M(n,k)$ (axiom-free large-$m$ bound)."
+    },
+    {
+      "id": "k3-small-n",
+      "title": "k = 3 Small-n Cases (Axiom-Free)",
+      "startLine": 279,
+      "endLine": 353,
+      "summary": "PROVES Erdős #677 for $k=3$ and each small $n$ axiom-free: `erdos677_k3_at_zero`/`_at_one`/`_at_two`/`_at_three` (using $m+3\\leq M(m,3)$ to bound $m$, then `interval_cases`+`native_decide`). Also `lcmInterval_two_three_collision` ($M(2,3)=M(3,3)=60$), a near-miss excluded precisely by the $m\\geq n+k$ constraint.",
+      "mathContext": "$k=3$, $n\\in\\{0,1,2,3\\}$ resolved by finite `native_decide` checks; near-miss $M(2,3)=M(3,3)=60$ excluded by $m\\geq n+k$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #677 (distinct LCM of consecutive integers) gallery `meta.json` had **section drift** with an internal gap and a large hidden tail.

- The "Prime Divisibility" section (lines 174-197: `exists_dvd_in_range`, `prime_le_dvd_lcmInterval`) was skipped entirely (gap between sections 6 and 7).
- Coverage stopped at line **241** of a **353**-line file — hiding the "General large-m distinctness bound" (`erdos677_large_m`, `erdos677_k3_large_m`, `consecutiveProduct_three`) and the "k = 3 small-n cases" (axiom-free proofs `erdos677_k3_at_zero`/`one`/`two`/`three` plus the near-miss `lcmInterval_two_three_collision`).

## Changes
- Rebuilt **13 sections** (was 8) mapped to the file's `## ` banners, full coverage **1-353**, with accurate `mathContext`.
- **Counts already correct**: 31 theorems / 5 definitions / 1 axiom / 0 sorries, lineCount 353.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-353 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-677
- [x] Section ranges re-verified against the `## ` banners in `Erdos677Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)