### PR TITLE
Enrich arithmetic-series q-multichoose: fix out-of-bounds annotation range

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "ann-vandermonde-link",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
-    "range": { "startLine": 222, "endLine": 240 },
+    "range": { "startLine": 222, "endLine": 228 },
     "type": "context",
     "title": "Link to Multiset Vandermonde and Classical q-Vandermonde",
     "content": "The consistency theorem qMultichoose_recovers_classical_int instantiates qMultichoose_eq_multichoose at R=ℤ, confirming the classical identity in the integer ring. This closes the connection to the parent entry (ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02), where the multiset Vandermonde identity ∑ multichoose n k = multichoose (n+r) k was proved. The q-analog of this Vandermonde identity (using qMultichoose) would be a q-deformed Vandermonde convolution.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -140,7 +140,7 @@
       "id": "vandermonde",
       "title": "VIII. Consistency with Classical q-Vandermonde",
       "startLine": 222,
-      "endLine": 226,
+      "endLine": 228,
       "summary": "qMultichoose_recovers_classical_int: instantiates the main theorem at R=ℤ, confirming qMultichoose (1:ℤ) n k = Nat.multichoose n k. Closes the connection to the parent multiset Vandermonde entry.",
       "mathContext": "At $R = \\mathbb{Z}$: $\\text{qMultichoose}(1, n, k) = \\text{multichoose}(n, k) \\in \\mathbb{Z}$."
     }


### PR DESCRIPTION
## Summary

Fixes a dead annotation in the `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` (q-multichoose / q-Vandermonde) gallery entry.

The `ann-vandermonde-link` annotation had `range.endLine: 240`, but the Lean source (`Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean`) is only **228 lines**. An annotation whose range runs past EOF binds to no source lines and never renders on the proof page.

## Changes

- `annotations.json`: `ann-vandermonde-link` range `222-240` → `222-228` (clamped to the closing `end QMultichooseCoefficients` at line 228; its content describes the final q-Vandermonde docstring block).
- `meta.json`: the matching `vandermonde` section `222-226` → `222-228`, so the sections tile to the end of the file.

## Verification

- Schema-defect scan: this slug no longer reports any out-of-bounds annotation.
- `pnpm annotations:build` passes; no new warnings introduced for this entry.
- Diff is range-only.