### PR TITLE
Enrich erdos-315: repair orphaned summary annotation range

### DIFF
--- a/src/data/proofs/erdos-315/annotations.json
+++ b/src/data/proofs/erdos-315/annotations.json
@@ -424,8 +424,8 @@
     "id": "ann-e315-summary",
     "proofId": "erdos-315",
     "range": {
-      "startLine": 255,
-      "endLine": 258
+      "startLine": 245,
+      "endLine": 250
     },
     "type": "concept",
     "title": "Summary Theorem",


### PR DESCRIPTION
## Summary

The `ann-e315-summary` annotation in the erdos-315 entry had `range` `255-258`, but `Proofs/Erdos315Problem.lean` is only **252 lines**. The annotation was entirely past EOF — fully orphaned, bound to no source, never rendered.

Its content ("Summary Theorem … combines the main result with the Vardi constant bounds") describes the `erdos_315_summary` theorem, which lives at **lines 245-250**. Repointed the range there.

## Verification

- Schema-defect scan: erdos-315 no longer reports any out-of-bounds annotation.
- `pnpm annotations:build` passes; no new warnings for this entry.
- Single range-only change; meta sections were already correct and untouched.