### PR TITLE
research(erdos-910): realign drifted gallery sections to file (7→7)

### DIFF
--- a/src/data/proofs/erdos-910/meta.json
+++ b/src/data/proofs/erdos-910/meta.json
@@ -86,53 +86,53 @@
   },
   "sections": [
     {
-      "id": "connected-subsets",
-      "title": "Connected Sets and Subsets",
-      "startLine": 49,
-      "endLine": 63,
-      "summary": "Defines `connectedSubsets X` (all connected subsets of $X$) and `connectedSubsetsOf S` (connected subsets within $S$), using Mathlib's `IsConnected`."
+      "id": "problem-statement",
+      "title": "Problem Statement and Overview",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Erdős Problem #910: two questions about connected sets in $\\mathbb{R}^n$ — (1) does every connected set contain a connected subset that is neither a point nor homeomorphic to the whole, and (2) for $n \\ge 2$, does it contain more than $2^{\\aleph_0}$ connected subsets? Both answered NO by Mary Ellen Rudin (1958) under CH."
     },
     {
-      "id": "homeomorphism",
-      "title": "Homeomorphism Between Subsets",
-      "startLine": 44,
-      "endLine": 69,
-      "summary": "Defines `AreHomeomorphic S T := Nonempty (S ≃ₜ T)` as topological equivalence via continuous bijection with continuous inverse. Proves reflexivity via `Homeomorph.refl` and symmetry via `Homeomorph.symm`, establishing two of the three equivalence relation properties."
+      "id": "definitions",
+      "title": "Definitions: Connected Subsets and Rudin Sets",
+      "startLine": 38,
+      "endLine": 61,
+      "summary": "Defines `connectedSubsetsOf S` (connected subsets within $S$ via Mathlib's `IsConnected`), `AreHomeomorphic` (subspace homeomorphism), `HasDiverseConnectedSubset` (a proper connected subset that is neither a singleton nor homeomorphic to the whole), and `IsRudinSet` (a connected set with no diverse connected subset)."
     },
     {
-      "id": "first-question",
-      "title": "Erdős's First Question",
-      "startLine": 85,
-      "endLine": 103,
-      "summary": "Defines `HasDiverseConnectedSubset` (proper connected non-singleton non-homeomorphic subset) and `erdosFirstConjecture` (all connected sets have diverse subsets)."
+      "id": "homeomorphism-basics",
+      "title": "Homeomorphism Basics",
+      "startLine": 62,
+      "endLine": 70,
+      "summary": "Proves `areHomeomorphic_refl` (via `Homeomorph.refl`) and `areHomeomorphic_symm` (via `Homeomorph.symm`), establishing reflexivity and symmetry of the homeomorphism relation."
     },
     {
-      "id": "second-question",
-      "title": "Erdős's Second Question",
-      "startLine": 104,
-      "endLine": 122,
-      "summary": "Defines `connectedSubsetCardinality`, `continuum := \\#\\mathbb{R}$, and `erdosSecondConjecture` (connected sets in $\\mathbb{R}^n$ have $> 2^{\\aleph_0}$ connected subsets)."
+      "id": "erdos-conjectures",
+      "title": "Erdős's Conjectures Formalized",
+      "startLine": 71,
+      "endLine": 86,
+      "summary": "Specializes to $\\mathbb{R} \\times \\mathbb{R}$ to avoid universe issues: `erdosFirstConjecture` (every connected set has a diverse subset), `connectedSubsetCardinality` (cardinality of connected subsets), and `erdosSecondConjecture` (connected sets have $> 2^{\\aleph_0}$ connected subsets)."
     },
     {
-      "id": "rudin-set",
-      "title": "The Rudin Set",
-      "startLine": 123,
-      "endLine": 142,
-      "summary": "Defines `ContinuumHypothesis`, `IsRudinSet` (every proper connected subset is a point or homeomorphic to the whole), and `HasExactlyContinuumConnectedSubsets`."
+      "id": "rudin-axiom",
+      "title": "Rudin's Axiom (under CH)",
+      "startLine": 87,
+      "endLine": 99,
+      "summary": "Encodes Rudin's deep 1958 construction as `rudin_theorem_ch`: under CH ($\\mathfrak{c} = \\aleph_1$) there exists a connected planar Rudin set with exactly continuum-many connected subsets, including nontriviality. This is the sole axiom of the file."
     },
     {
-      "id": "rudin-theorem",
-      "title": "Rudin's Theorem",
-      "startLine": 143,
+      "id": "main-theorems",
+      "title": "Main Theorems: Both Conjectures False under CH",
+      "startLine": 100,
+      "endLine": 140,
+      "summary": "Proves `rudin_set_no_diverse_subset` (Rudin sets have no diverse connected subset), then `erdos_first_conjecture_false` and `erdos_second_conjecture_false`, each deriving a contradiction from the Rudin set supplied by the axiom under CH. All proved with 0 sorries."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Combined Disproof",
+      "startLine": 141,
       "endLine": 155,
-      "summary": "Axiomatizes the existence of a Rudin set in $\\mathbb{R}^2$ under CH with exactly $2^{\\aleph_0}$ connected subsets."
-    },
-    {
-      "id": "disproving",
-      "title": "Disproving Erdős's Conjectures",
-      "startLine": 155,
-      "endLine": 155,
-      "summary": "All three theorems fully proved (0 sorries): `rudin_set_no_diverse_subset`, `erdos_first_conjecture_false`, and `erdos_second_conjecture_false`. Combined in `erdos_910_both_false`."
+      "summary": "Combines the two disproofs into `erdos_910_both_false`: under CH, both of Erdős's conjectures about connected subsets of Euclidean space are false, via Rudin's 1958 construction."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `meta.json` gallery sections for `erdos-910` (Erdős Problem #910, connected subsets of Euclidean space) had drifted badly from the Lean source (`Proofs/Erdos910OQ01.lean`, 155 lines):

- **Overlapping / out-of-order ranges**: section 1 was 49-63, section 2 was 44-69 (overlaps and precedes section 1).
- **Uncovered header**: lines 1-43 (problem statement + definitions banner) were not covered by any section.
- **Degenerate tail**: the final section was 155-155 (a single line).
- **Stale summaries**: several referenced constructs that no longer exist in the file (`connectedSubsets X`, `ContinuumHypothesis`, `HasExactlyContinuumConnectedSubsets`, `continuum := #ℝ`).

## Changes

Rebuilt to **7 contiguous sections** tiling the full file (1-155), aligned to the `-- ## ` banners and declaration boundaries:

| Range | Section |
|-------|---------|
| 1-37 | Problem Statement and Overview |
| 38-61 | Definitions: Connected Subsets and Rudin Sets |
| 62-70 | Homeomorphism Basics |
| 71-86 | Erdős's Conjectures Formalized |
| 87-99 | Rudin's Axiom (under CH) |
| 100-140 | Main Theorems: Both Conjectures False under CH |
| 141-155 | Summary: Combined Disproof |

Summaries rewritten to describe the actual definitions, the single `rudin_theorem_ch` axiom, and the disproofs of both Erdős conjectures under CH. Counts (6 theorems, 7 defs, 1 axiom, 0 sorry) were already correct and are unchanged.

Meta-only, build-free change.

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] Sections tile 1-155 contiguously, in order, no overlaps/gaps
- [x] Diff scoped to the `sections` block only