### PR TITLE
Enrich hurwitz-theorem: realign sections + fix stale axiom prose

### DIFF
--- a/src/data/proofs/hurwitz-theorem/annotations.json
+++ b/src/data/proofs/hurwitz-theorem/annotations.json
@@ -180,6 +180,29 @@
     ]
   },
   {
+    "id": "octonion-axiom",
+    "proofId": "hurwitz-theorem",
+    "range": {
+      "startLine": 302,
+      "endLine": 303
+    },
+    "type": "insight",
+    "title": "8-Square Identity (Degen's Identity)",
+    "content": "Constructs eight_square_identity_exists : NSquareIdentity 8 explicitly, eliminating the former axiom. The 8-square identity (Degen, 1818) has 8 output components, each a sum of 8 products of the 16 input variables; it is built here via Cayley-Dickson octonion multiplication and verified with the ring tactic. Corresponds to octonion multiplication.",
+    "mathContext": "Ferdinand Degen published the 8-square identity in 1818. John Graves discovered octonions independently in 1843, and Arthur Cayley rediscovered them in 1845. Octonions are the largest normed division algebra: they are non-associative but alternative (x(xy) = x^2 y). Their automorphism group is the exceptional Lie group G_2.",
+    "significance": "key",
+    "prerequisites": [
+      "NSquareIdentity"
+    ],
+    "relatedConcepts": [
+      "octonions",
+      "Degen's identity",
+      "Cayley numbers",
+      "G_2",
+      "alternative algebra"
+    ]
+  },
+  {
     "id": "no-three-setup",
     "proofId": "hurwitz-theorem",
     "range": {

--- a/src/data/proofs/hurwitz-theorem/annotations.source.json
+++ b/src/data/proofs/hurwitz-theorem/annotations.source.json
@@ -192,11 +192,11 @@
     "anchor": {
       "type": "declaration",
       "name": "eight_square_identity_exists",
-      "kind": "axiom"
+      "kind": "def"
     },
     "type": "insight",
     "title": "8-Square Identity (Degen's Identity)",
-    "content": "Axiomatizes eight_square_identity_exists : NSquareIdentity 8. The full formula (Degen's identity, 1818) has 8 output components, each a sum of 8 products of the 16 input variables -- too complex to write explicitly. Corresponds to octonion multiplication.",
+    "content": "Constructs eight_square_identity_exists : NSquareIdentity 8 explicitly, eliminating the former axiom. The 8-square identity (Degen, 1818) has 8 output components, each a sum of 8 products of the 16 input variables; it is built here via Cayley-Dickson octonion multiplication and verified with the ring tactic. Corresponds to octonion multiplication.",
     "mathContext": "Ferdinand Degen published the 8-square identity in 1818. John Graves discovered octonions independently in 1843, and Arthur Cayley rediscovered them in 1845. Octonions are the largest normed division algebra: they are non-associative but alternative (x(xy) = x^2 y). Their automorphism group is the exceptional Lie group G_2.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Summary
Enrichment pass for `hurwitz-theorem`, targeting section/Lean-file drift and stale-axiom prose (the quality scorer is saturated; these are defects it cannot see).

- **Sections realigned to the file (17 → 20, now tiling lines 1–2042).** The meta froze at an older 1679-line revision: the 363-line tail was uncovered (PART 8b odd-dimension impossibility & main theorem, PART 10 significance, final verification had no section), and PART 8/PART 9 ranges pointed ~130 lines *before* their actual `====` banners (1557/1594 vs real 1686/1957). Rebuilt the back portion against the file's PART banners; verified `admissibleDimensions`@1700, `hurwitz_only_if`@1904, `hurwitz_theorem`@1947, `DivisionAlgebra`@1981.
- **Restored a silently-dropped annotation (17 → 18).** `octonion-axiom` in `annotations.source.json` anchored to declaration `eight_square_identity_exists` with `kind: "axiom"`, but that declaration is now a `def` (the n=8 case was made constructive). The anchor failed to resolve, so the build dropped the annotation. Fixed `kind` → `def` (resolves to lines 302–303) and de-staled its "Axiomatizes…" content.
- **De-staled axiom prose** (integrity, consistent with `axiomCount: 0`): `overview.text` "Axiomatizes n=8" → constructively proved via Cayley–Dickson; `proofStrategy`/`conclusion.summary` "1679 lines" → 2042 with corrected line refs; `hurwitz_only_if` described as a theorem with one remaining `sorry` (line 1937, needs Clifford-algebra structure), not an axiom.

No Lean source changed. `axiomCount: 0`, `sorries: 1`, `status: formalized`, `badge: wip` all remain accurate.

## Test plan
- [x] `pnpm annotations:build` exits 0 with no `[hurwitz-theorem]` warnings (octonion-axiom anchor now resolves)
- [x] meta.json valid JSON; sections contiguously cover 1–2042
- [x] Build side-effect (unicode re-encode of ~36 other files) reverted; only `src/data/proofs/hurwitz-theorem/` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)