### PR TITLE
Enrich kroneckers-jugendtraum: realign drifted tail sections & annotations

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum/annotations.json
+++ b/src/data/proofs/kroneckers-jugendtraum/annotations.json
@@ -173,7 +173,7 @@
     "proofId": "kroneckers-jugendtraum",
     "range": {
       "startLine": 272,
-      "endLine": 299
+      "endLine": 285
     },
     "type": "concept",
     "title": "Open Cases and General Statement",
@@ -196,8 +196,8 @@
     "id": "ann-examples",
     "proofId": "kroneckers-jugendtraum",
     "range": {
-      "startLine": 306,
-      "endLine": 323
+      "startLine": 291,
+      "endLine": 303
     },
     "type": "concept",
     "title": "Concrete Examples and Irreducibility",
@@ -219,8 +219,8 @@
     "id": "ann-stark",
     "proofId": "kroneckers-jugendtraum",
     "range": {
-      "startLine": 342,
-      "endLine": 350
+      "startLine": 308,
+      "endLine": 329
     },
     "type": "concept",
     "title": "Stark Conjectures",
@@ -243,8 +243,8 @@
     "id": "ann-summary",
     "proofId": "kroneckers-jugendtraum",
     "range": {
-      "startLine": 356,
-      "endLine": 387
+      "startLine": 335,
+      "endLine": 371
     },
     "type": "concept",
     "title": "Problem Status Summary",

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -118,30 +118,30 @@
       "id": "open-cases",
       "title": "Open Cases",
       "startLine": 255,
-      "endLine": 300,
+      "endLine": 286,
       "summary": "States Hilberts12thProblem for general K as a placeholder proposition (the deep statement is not formalizable without specifying \"explicit analytic function\").",
       "mathContext": "The general `Hilberts12thProblem` asks for a set of generators in $\\mathbb{C}$ that are special values of explicit analytic functions and generate all abelian extensions of any number field $K$. The file proves `hilbert12_solved_for_rationals` (reducing to `KroneckerWeberTheorem \\to \\mathrm{True}$) and `hilbert12_solved_for_imaginary_quadratic` (reducing via `CMSolution`). Both proofs are trivial since the deep content is in the axiomatized premises. For real quadratic fields $\\mathbb{Q}(\\sqrt{d})$, no analogue of CM exists; the Stark conjectures and the Langlands program represent the main avenues of current research."
     },
     {
       "id": "examples",
       "title": "Partial Results and Examples",
-      "startLine": 301,
-      "endLine": 324,
+      "startLine": 287,
+      "endLine": 303,
       "summary": "Proves cyclotomic_irreducible via cyclotomic.irreducible_rat. Demonstrates CyclotomicField 4 ℚ and CyclotomicField 3 ℚ as IsCyclotomicExtension instances.",
       "mathContext": "The irreducibility of $\\Phi_n(x) \\in \\mathbb{Z}[x]$ is proved via `cyclotomic.irreducible_rat n`, which ultimately rests on Gauss's lemma (irreducible over $\\mathbb{Z}$ implies irreducible over $\\mathbb{Q}$). Two concrete examples instantiate `IsCyclotomicExtension`: $\\mathbb{Q}(\\zeta_4) = \\mathbb{Q}(i)$ (the Gaussian integers adjoin the 4th root of unity) and $\\mathbb{Q}(\\zeta_3) = \\mathbb{Q}(\\omega)$ where $\\omega = e^{2\\pi i/3}$ (equivalently $\\mathbb{Q}(\\sqrt{-3})$). These demonstrate the base case of Kronecker-Weber with small, explicit cyclotomic fields."
     },
     {
       "id": "stark-conjectures",
       "title": "Stark Conjectures",
-      "startLine": 325,
-      "endLine": 351,
+      "startLine": 304,
+      "endLine": 330,
       "summary": "States StarkConjecture as a placeholder Prop. Discusses L-function special values and Stark units as conjectural generators for real quadratic abelian extensions.",
       "mathContext": "Stark's conjecture (1970s--80s) predicts that for a number field $K$, character $\\chi$ of $\\mathrm{Gal}(L/K)$, and a set $S$ of places containing all archimedean ones, the leading Taylor coefficient of $L_S(s, \\chi)$ at $s = 0$ equals $\\pm\\,\\mathrm{Reg}_S(\\epsilon)/w$ where $\\epsilon$ is a 'Stark unit' in $L$ and $w$ is the number of roots of unity. For real quadratic fields, these Stark units would provide the explicit generators that CM theory provides for imaginary quadratic fields. The conjecture has been proved for abelian extensions of $\\mathbb{Q}$ (recovering the analytic class number formula) and for imaginary quadratic fields, but remains open in general."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 352,
+      "startLine": 331,
       "endLine": 371,
       "summary": "Documentation block recapping solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
       "mathContext": "The file's genuine Lean content comprises three machine-checked results: (1) `cyclotomic_galois_comm` proving $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ is abelian via the `autEquivPow` isomorphism to $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, (2) `cyclotomic_degree` proving $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ via `IsCyclotomicExtension.finrank`, and (3) `cyclotomic_irreducible` proving $\\Phi_n$ is irreducible over $\\mathbb{Z}$. All other results -- Kronecker-Weber, CM theory, Artin reciprocity, Stark conjectures, and the general Hilbert 12th problem -- are formulated as `Prop := True` placeholders whose deep proofs lie beyond current Mathlib infrastructure."


### PR DESCRIPTION
## Summary

Tail **co-drift** fix for the Kronecker's Jugendtraum (Hilbert's 12th problem) gallery entry. The annotations and meta sections for PARTs VI–VIII had each drifted roughly one section late as the Lean file evolved:

- `ann-summary` had range `356-387` — past the **371-line** EOF, so it was orphaned and never rendered.
- `ann-stark` (342-350) pointed into the PART VIII *Summary* docstring instead of the PART VII `StarkConjecture` definition.
- `ann-examples` (306-323) sat in the PART VII *Stark* region instead of the PART VI cyclotomic examples.
- `ann-open` (272-299) overran PART V into the PART VI examples.

## Changes

Realigned to the actual `PART V–VIII` banner regions:

| Annotation / Section | old → new |
|---|---|
| `ann-open` | 272-299 → 272-285 |
| `ann-examples` | 306-323 → 291-303 |
| `ann-stark` | 342-350 → 308-329 |
| `ann-summary` | 356-387 → 335-371 |
| section `open-cases` | 255-300 → 255-286 |
| section `examples` | 301-324 → 287-303 |
| section `stark-conjectures` | 325-351 → 304-330 |
| section `summary` | 352-371 → 331-371 |

Sections now contiguously tile lines 82–371; annotation starts land on their PART's leading construct.

## Verification

- Schema-defect scan: this slug no longer reports any out-of-bounds annotation.
- `pnpm annotations:build` passes with **no** warnings for this entry.
- Diff is range-only.