### PR TITLE
research(erdos-933): realign overlapping gallery section ranges (10→10)

### DIFF
--- a/src/data/proofs/erdos-933/meta.json
+++ b/src/data/proofs/erdos-933/meta.json
@@ -112,7 +112,7 @@
       "id": "mahler-s-upper-bound",
       "title": "Mahler's Upper Bound",
       "startLine": 69,
-      "endLine": 82,
+      "endLine": 79,
       "summary": "Contains `mahlerSUnitConnection` placeholder (def returning True) noting Mahler's S-unit theorem. No `mahler_upper_bound` axiom — Mahler's bound is mentioned in comments but not formalized as an axiom. The equation x + 1 = y in {2,3}-smooth integers has finitely many solutions by Baker-Evertse theory.",
       "mathContext": "Contains `mahlerSUnitConnection` placeholder (def returning True) noting Mahler's S-unit theorem. No axiom for the bound — only a notational placeholder."
     },
@@ -120,15 +120,15 @@
       "id": "erd-s-s-lower-bound",
       "title": "Erdős's Lower Bound",
       "startLine": 80,
-      "endLine": 88,
+      "endLine": 85,
       "summary": "Header section only; contains a docstring describing Erdős's lower bound claim but no `erdos_lower_bound` axiom. Steinerberger's construction (Part V) directly proves ErdosQuestion933 without separately axiomatizing Erdős's claim.",
       "mathContext": "Header section only. No `erdos_lower_bound` axiom — the bound is referenced in comments but not formalized as an axiom in this file."
     },
     {
       "id": "steinerberger-s-construction",
       "title": "Steinerberger's Construction",
-      "startLine": 87,
-      "endLine": 113,
+      "startLine": 86,
+      "endLine": 114,
       "summary": "Defines `steinerbergerN r = 2^(3^r)`. Proves `steinerberger_n_plus_1` (rfl). States `steinerberger_gives_large_smooth` (sorry — needs LTE computation to show 3^{r+1} | 2^{3^r}+1). Axiomatizes `steinerberger_proof : ErdosQuestion933` (the file's only axiom). Proves `limsup_infinite` as an alias. No `steinerberger_divisibility` axiom.",
       "mathContext": "Defines `steinerbergerN r = 2^(3^r)`. Proves `steinerberger_n_plus_1` by rfl. The file's only axiom is `steinerberger_proof : ErdosQuestion933`; `steinerberger_gives_large_smooth` has a sorry. No `steinerberger_divisibility` axiom exists."
     },
@@ -144,7 +144,7 @@
       "id": "properties-of-n-n-1",
       "title": "Properties of n(n+1)",
       "startLine": 128,
-      "endLine": 146,
+      "endLine": 147,
       "summary": "Proves `consecutive_coprime` (one-line: `Nat.coprime_self_add_one n`). States `power2_consecutive` and `power3_consecutive` (factorization additivity for coprime products, both sorry) showing v_p(n(n+1)) = v_p(n) + v_p(n+1).",
       "mathContext": "Proves `consecutive_coprime` (one-line: `Nat.coprime_self_add_one n`). States `power2_consecutive` and `power3_consecutive` (factorization additivity for coprime products, both sorry) showing v_p(n(n+1)) = v_p(n) + v_p(n+1)."
     },
@@ -152,7 +152,7 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 148,
-      "endLine": 164,
+      "endLine": 165,
       "summary": "Two concrete examples verified by `native_decide`: steinerbergerN 1 = 8 (8·9=72=2³·3², ratio≈4.33), steinerbergerN 2 = 512 (512·513=2⁹·3³·19, smooth=13824). Defines `exampleSequence := steinerbergerN`.",
       "mathContext": "Two concrete examples verified by `native_decide`: steinerbergerN 1 = 8 (8·9=72=2³·3², ratio≈4.33), steinerbergerN 2 = 512 (512·513=2⁹·3³·19, smooth=13824). Defines `exampleSequence := steinerbergerN`."
     },


### PR DESCRIPTION
## Summary

The `meta.json` gallery section ranges for `erdos-933` (smooth part of consecutive products) had drifted and overlapped:

- **Mahler's Upper Bound** (69-82) and **Erdős's Lower Bound** (80-88) overlapped at lines 80-82.
- **Steinerberger's Construction** (87-113) overlapped the lower-bound range.
- Several boundaries left small gaps.

## Changes

Realigned all 10 sections to contiguous, non-overlapping ranges tiling the full file (1-197), aligned to the `## Part I`..`## Part IX` banners:

| Range | Section |
|-------|---------|
| 1-33 | Erdős Problem #933 (header) |
| 34-60 | Basic Definitions |
| 61-68 | The Erdős Question |
| 69-79 | Mahler's Upper Bound |
| 80-85 | Erdős's Lower Bound |
| 86-114 | Steinerberger's Construction |
| 115-127 | Why the Construction Works |
| 128-147 | Properties of n(n+1) |
| 148-165 | Examples |
| 166-197 | Summary |

Section titles and summaries were already correct and are unchanged; only the line ranges moved.

Meta-only, build-free change.

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] Sections tile 1-197 contiguously, in order, no overlaps/gaps
- [x] Diff scoped to 6 range edits only