### PR TITLE
research(erdos-512): realign drifted gallery sections to full file (12→12)

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -97,100 +97,100 @@
   },
   "sections": [
     {
-      "id": "header-imports",
+      "id": "header",
       "title": "Problem Statement and Imports",
-      "summary": "Littlewood's conjecture statement, references to Konyagin 1981 and MPS 1981; imports Complex.Exponential, Bochner integration, Complex.Log",
       "startLine": 1,
       "endLine": 36,
-      "mathContext": "Littlewood conjecture: for $A \\\\subset \\\\mathbb{Z}$ with $|A|=N$, is $\\\\int_0^1 |\\\\sum_{n \\\\in A} e(n\\\\theta)| d\\\\theta \\\\gg \\\\log N$? SOLVED: YES (1981)."
+      "summary": "States Erdős Problem #512 (Littlewood's conjecture on exponential sums): for finite $A\\subset\\mathbb{Z}$ with $|A|=N$, is $\\int_0^1|\\sum_{n\\in A}e(n\\theta)|\\,d\\theta\\gg\\log N$ (where $e(x)=e^{2\\pi ix}$)? Status SOLVED (Konyagin 1981; McGehee–Pigno–Smith 1981 via Hardy's inequality); the $\\log N$ bound is optimal. Imports complex exp, Bochner integral; opens `Real`/`Complex`/`MeasureTheory`.",
+      "mathContext": "Littlewood: $\\int_0^1|\\sum_{n\\in A}e(n\\theta)|\\,d\\theta\\geq c\\log N$. SOLVED 1981."
     },
     {
-      "id": "exponential-functions",
-      "title": "Exponential Functions",
-      "summary": "expTwoPiI definition e(x) = e^{2πix}; proved: periodicity (e(x+1) = e(x)), unit norm (|e(x)| = 1), multiplicativity (e(x+y) = e(x)e(y))",
+      "id": "part1",
+      "title": "Part I: Exponential Functions",
       "startLine": 37,
       "endLine": 60,
-      "mathContext": "$e(x) = e^{2\\\\pi ix}$: periodic ($e(x+1)=e(x)$), unit modulus ($|e(x)|=1$), multiplicative ($e(x+y)=e(x)e(y)$). Foundation for Fourier analysis on $\\\\mathbb{T}$."
+      "summary": "Defines `expTwoPiI x` $=e^{2\\pi ix}$ and PROVES its key properties: `expTwoPiI_periodic` (period 1), `expTwoPiI_norm` ($|e(x)|=1$), and `expTwoPiI_add` ($e(x+y)=e(x)e(y)$).",
+      "mathContext": "$e(x)=e^{2\\pi ix}$: period 1, $|e(x)|=1$, $e(x+y)=e(x)e(y)$."
     },
     {
-      "id": "exponential-sums",
-      "title": "Exponential Sums",
-      "summary": "expSum for ℤ and ℕ, expSumNorm modulus, expSum_bound (proved: triangle inequality |S_A| ≤ N)",
+      "id": "part2",
+      "title": "Part II: Exponential Sums",
       "startLine": 61,
       "endLine": 85,
-      "mathContext": "$S_A(\\\\theta) = \\\\sum_{n \\\\in A} e(n\\\\theta)$. Triangle inequality: $|S_A(\\\\theta)| \\\\leq N$. Equality iff all $e(n\\\\theta)$ are aligned (e.g. $\\\\theta=0$)."
+      "summary": "Defines `expSum` ($\\sum_{n\\in A}e(n\\theta)$), `expSumNat`, `expSumNorm` (its modulus), and PROVES `expSum_bound` ($|\\text{expSum}|\\leq|A|$ by the triangle inequality).",
+      "mathContext": "$\\text{expSum}(A,\\theta)=\\sum_{n\\in A}e(n\\theta)$; $|\\text{expSum}|\\leq|A|$."
     },
     {
-      "id": "l1-norm",
-      "title": "The L¹ Norm",
-      "summary": "L1norm via Bochner integral on [0,1]; proved: nonnegativity; proved: upper bound L¹ ≤ N",
+      "id": "part3",
+      "title": "Part III: The L¹ Norm",
       "startLine": 86,
-      "endLine": 105,
-      "mathContext": "$\\\\|S_A\\\\|_1 = \\\\int_0^1 |\\\\sum_{n \\\\in A} e(n\\\\theta)| d\\\\theta$. The $L^1$ norm measures average cancellation. Non-negative, bounded above by $N$."
+      "endLine": 132,
+      "summary": "Defines `L1norm A` $=\\int_0^1|\\text{expSum}\\,A\\,\\theta|\\,d\\theta$ and PROVES `L1norm_nonneg` and `L1norm_upper_bound` ($\\leq|A|$, via continuity/integrability and monotone integration).",
+      "mathContext": "$\\|S_A\\|_1=\\int_0^1|\\text{expSum}|\\,d\\theta\\in[0,|A|]$."
     },
     {
-      "id": "littlewood-conjecture",
-      "title": "Littlewood's Conjecture",
-      "summary": "LittlewoodConjecture (∃c > 0, L¹ ≥ c log N) and asymptotic variant LittlewoodConjecture'",
-      "startLine": 106,
-      "endLine": 122,
-      "mathContext": "Conjecture: $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ for all $A$ with $|A|=N$. The logarithmic lower bound quantifies how much cancellation is inevitable."
+      "id": "part4",
+      "title": "Part IV: Littlewood's Conjecture",
+      "startLine": 133,
+      "endLine": 149,
+      "summary": "States the conjecture two ways: `LittlewoodConjecture` ($\\exists c>0,\\ \\|S_A\\|_1\\geq c\\log|A|$ for $|A|\\geq2$) and the asymptotic `LittlewoodConjecture'` ($\\|S_A\\|_1\\geq(1-\\varepsilon)\\log|A|$ eventually).",
+      "mathContext": "$\\exists c>0,\\ \\|S_A\\|_1\\geq c\\log N$ (and asymptotically $(1-\\varepsilon)\\log N$)."
     },
     {
-      "id": "solution",
-      "title": "The Solution (1981)",
-      "summary": "konyagin_theorem and mcgehee_pigno_smith_theorem axioms; littlewoodConstant = 1/(4π) explicit constant",
-      "startLine": 123,
-      "endLine": 141,
-      "mathContext": "Konyagin (1981) and McGehee-Pigno-Smith (1981): $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ with $c = 1/(8\\\\pi^2)$. Two independent proofs in the same year."
+      "id": "part5",
+      "title": "Part V: The Solution",
+      "startLine": 150,
+      "endLine": 165,
+      "summary": "The 1981 resolution as two AXIOMS: `konyagin_theorem` (Konyagin's proof) and `mcgehee_pigno_smith_theorem` (independent proof via Hardy's inequality), both asserting `LittlewoodConjecture`. Defines `littlewoodConstant` $=1/(4\\pi)$.",
+      "mathContext": "Axioms (1981): Littlewood's conjecture holds (Konyagin; McGehee–Pigno–Smith)."
     },
     {
-      "id": "sharpness",
-      "title": "Sharpness: log N is Optimal",
-      "summary": "geometricProgression = {0,...,N-1}; L¹ ≍ log N for arithmetic progressions (Lebesgue constant)",
-      "startLine": 142,
-      "endLine": 160,
-      "mathContext": "Sharp: geometric progressions $A = \\\\{0,1,\\\\ldots,N-1\\\\}$ achieve $\\\\|S_A\\\\|_1 = \\\\Theta(\\\\log N)$. The Dirichlet kernel $\\\\sum_{n=0}^{N-1} e(n\\\\theta)$ has $L^1$ norm $\\\\sim (4/\\\\pi^2)\\\\log N$."
-    },
-    {
-      "id": "hardy-connection",
-      "title": "Hardy's Inequality Connection",
-      "summary": "Discrete Hardy inequality axiom with constant 4; hardyConnection noting MPS proof technique",
-      "startLine": 161,
+      "id": "part6",
+      "title": "Part VI: Sharpness",
+      "startLine": 166,
       "endLine": 175,
-      "mathContext": "Hardy inequality: $\\\\sum |\\\\hat{f}(n)|/n \\\\leq 4\\\\|f\\\\|_1$. The MPS proof proceeds through this discrete Hardy inequality, connecting $L^1$ norms to coefficient decay."
+      "summary": "Defines `geometricProgression N` ($\\{0,1,\\dots,N-1\\}$ as integers); arithmetic/geometric progressions achieve the $\\log N$ lower bound, showing it is essentially optimal.",
+      "mathContext": "Progressions $\\{0,\\dots,N-1\\}$ attain $\\|S_A\\|_1\\asymp\\log N$ (optimality)."
     },
     {
-      "id": "related-results",
-      "title": "Related Results: Parseval, Flat Polynomials",
-      "summary": "L2_norm = √N (Parseval, proved via character orthogonality); L1 vs L2 comparison; flat polynomial problem connection",
+      "id": "part7",
+      "title": "Part VII: Hardy's Inequality Connection",
       "startLine": 176,
-      "endLine": 196,
-      "mathContext": "$\\\\|S_A\\\\|_2 = \\\\sqrt{N}$ (Parseval). So $L^1 = \\\\Theta(\\\\log N) \\\\ll L^2 = \\\\sqrt{N}$: exponential sums have much more $L^1$ cancellation than $L^2$ suggests."
+      "endLine": 186,
+      "summary": "Defines `hardyConnection` (a `Prop` placeholder) recording that McGehee–Pigno–Smith derived the $L^1$ lower bound from Hardy's discrete inequality.",
+      "mathContext": "MPS proof route: Hardy's inequality $\\Rightarrow$ the $L^1$ lower bound."
     },
     {
-      "id": "generalizations",
-      "title": "Generalizations",
-      "summary": "weightedExpSum with unit weights; same log N lower bound holds for unit-weight generalizations",
-      "startLine": 197,
-      "endLine": 215,
-      "mathContext": "Weighted version: $\\\\int |\\\\sum w_n e(n\\\\theta)| d\\\\theta \\\\geq c\\\\log N$ for $|w_n|=1$. Same $\\\\log N$ bound with unit weights."
+      "id": "part8",
+      "title": "Part VIII: Related Results (Parseval / L² Norm)",
+      "startLine": 187,
+      "endLine": 308,
+      "summary": "The $L^2$ theory. Private lemmas `expTwoPiI_conj` (conjugation negates the exponent), `expSumNorm_sq_double` (Parseval algebraic identity: $|S|^2=\\sum_{m,n}\\cos(2\\pi(m-n)\\theta)$), and `integral_cos_character` (character orthogonality $\\int_0^1\\cos(2\\pi k\\theta)\\,d\\theta=[k=0]$) combine to PROVE `L2_norm`: $\\int_0^1|S_A|^2\\,d\\theta=|A|$ (Parseval). Also the `Prop` placeholders `L1_vs_L2_comparison` ($\\log N$ vs $\\sqrt N$) and `flatPolynomialProblem`.",
+      "mathContext": "Parseval: $\\int_0^1|S_A|^2\\,d\\theta=|A|$ (via character orthogonality). $L^1\\asymp\\log N\\ll\\sqrt N=L^2$."
     },
     {
-      "id": "applications",
-      "title": "Applications",
-      "summary": "Connections to Diophantine approximation (Weyl's criterion) and analytic number theory (character sums)",
-      "startLine": 216,
-      "endLine": 231,
-      "mathContext": "Weyl criterion: $S_A(\\\\theta) \\\\to 0$ for irrational $\\\\theta$ iff $A$ is equidistributed. The $L^1$ bound constrains how equidistributed finite sets can be."
+      "id": "part9",
+      "title": "Part IX: Generalizations",
+      "startLine": 309,
+      "endLine": 322,
+      "summary": "Defines `weightedExpSum` (sums with complex weights) and the `Prop` placeholder `higherDimensionalGeneralization` (analogous bounds over $\\mathbb{Z}^d$).",
+      "mathContext": "Weighted sums $\\sum_n w_n e(n\\theta)$; generalizations to $\\mathbb{Z}^d$."
     },
     {
-      "id": "summary",
-      "title": "Summary and Main Theorems",
-      "summary": "erdos_512 = konyagin_theorem; erdos_512_solved packages both proofs; konyagin_equals_mps shows logical equivalence",
-      "startLine": 232,
-      "endLine": 267,
-      "mathContext": "SOLVED (1981). $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ with $c = 1/(8\\\\pi^2)$. Sharp: arithmetic progressions achieve $\\\\Theta(\\\\log N)$."
+      "id": "part10",
+      "title": "Part X: Applications",
+      "startLine": 323,
+      "endLine": 338,
+      "summary": "`Prop` placeholders recording applications: `diophantineApplication` (distribution mod 1) and `numberTheoreticApplication` (error terms in prime counting).",
+      "mathContext": "Applications: Diophantine approximation, analytic number theory error terms."
+    },
+    {
+      "id": "part11",
+      "title": "Part XI: Summary",
+      "startLine": 339,
+      "endLine": 368,
+      "summary": "Closing summary (SOLVED) and the headline theorems: `erdos_512` and `erdos_512_main` (Littlewood's conjecture holds, from `konyagin_theorem`), `erdos_512_solved` (the conjunction), and `konyagin_equals_mps` (both axioms establish the same result).",
+      "mathContext": "$\\text{erdos\\_512}:\\text{LittlewoodConjecture}$ (SOLVED, two independent 1981 proofs)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #512 (Littlewood's conjecture on exponential sums) gallery `meta.json` had **section drift**.

- Sections drifted from Part IV onward (Littlewood's Conjecture labeled @106 but really @133; later Parts shifted 10-90 lines).
- Coverage stopped at line **267** of a **368**-line file — hiding most of Part VIII (the substantial L²-norm Parseval proof `L2_norm` with its character-orthogonality and Parseval-identity lemmas), Part IX (`weightedExpSum`, generalizations), Part X (applications), and the Part XI summary theorems (`erdos_512`, `erdos_512_main`, `erdos_512_solved`, `konyagin_equals_mps`).

## Changes
- Realigned all **12 sections** to the file's `## Part N` banners with full coverage **1-368**, with accurate `mathContext`.
- **Counts already correct**: 14 theorems / 16 definitions / 2 axioms / 0 sorries, lineCount 368.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-368 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-512
- [x] Section ranges re-verified against the `## Part N` banners in `Erdos512Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)