### PR TITLE
research(erdos-100): realign drifted gallery sections to full file (10→12)

### DIFF
--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -95,7 +95,7 @@
       "title": "The Plane and Distance",
       "summary": "Euclidean distance in ℝ² and its basic metric-space lemmas: dist_symm, dist_nonneg, dist_self, dist_pos (positivity for distinct points), dist_triangle",
       "startLine": 31,
-      "endLine": 77,
+      "endLine": 76,
       "mathContext": "Euclidean distance in $\\mathbb{R}^2$ with the standard metric-space lemmas (symmetry, non-negativity, self-distance zero, positivity for distinct points, triangle inequality)."
     },
     {
@@ -103,7 +103,7 @@
       "title": "Restricted Distance Sets",
       "summary": "hasIntegerDistances predicate (every pairwise distance is a positive integer), pairwiseDistances (Finset of positive distances), numDistinctDistances",
       "startLine": 77,
-      "endLine": 103,
+      "endLine": 102,
       "mathContext": "hasIntegerDistances predicate, pairwiseDistances Finset, numDistinctDistances cardinality."
     },
     {
@@ -111,7 +111,7 @@
       "title": "Diameter",
       "summary": "Diameter as maximum pairwise distance (defined via Finset.max' on pairwiseDistances, with 0 fallback when empty); diam_nonneg and diam_is_integer (proved: for ≥ 2 points the diameter is a positive integer)",
       "startLine": 103,
-      "endLine": 161,
+      "endLine": 160,
       "mathContext": "Diameter $\\mathrm{diam}(S) := \\max \\{\\mathrm{dist}(p,q) : p,q \\in S, p \\neq q\\}$ when nonempty, $0$ otherwise. Proved: $\\mathrm{diam}(S) \\geq 0$, and for integer-distance sets with $|S| \\geq 2$ the diameter is a positive integer."
     },
     {
@@ -119,7 +119,7 @@
       "title": "The Main Conjecture",
       "summary": "minDiameterRestrictedSets (infimum of diameters over n-point integer-distance sets), Erdos100Conjecture (∃ c > 0, eventually minDiameterRestrictedSets n ≥ c·n), Erdos100StrongConjecture (eventually minDiameterRestrictedSets n ≥ n−1)",
       "startLine": 161,
-      "endLine": 195,
+      "endLine": 194,
       "mathContext": "Erdős #100 main conjecture: $\\exists c>0$ such that eventually $\\mathrm{diam}(A) \\geq c \\cdot |A|$ for any integer-distance $A \\subset \\mathbb{R}^2$. Strong form: eventually $\\mathrm{diam}(A) \\geq |A|-1$."
     },
     {
@@ -127,7 +127,7 @@
       "title": "Key Connection: Distinct Distances ≤ Diameter",
       "summary": "Bridge lemma distinctDistances_le_diam: for integer-distance sets, the number of distinct pairwise distances is at most ⌊diam⌋. Proved by injecting pairwiseDistances → Finset.Icc 1 ⌊diam⌋ via Nat.floor.",
       "startLine": 195,
-      "endLine": 266,
+      "endLine": 265,
       "mathContext": "Bridge lemma: $|\\Delta(A)| \\leq \\lfloor \\mathrm{diam}(A) \\rfloor$ via the injection $d \\mapsto \\lfloor d \\rfloor$, valid because every $d \\in \\Delta(A)$ is a positive integer."
     },
     {
@@ -135,7 +135,7 @@
       "title": "Known Lower Bounds",
       "summary": "diam_ge_one (proved), guthKatz_distinct_distances (axiom: ≥ cn/log n distinct distances), diam_ge_n_over_log_n (proved from axiom + bridge lemma); Kanold's n^(3/4) bound is referenced in commentary only",
       "startLine": 266,
-      "endLine": 348,
+      "endLine": 347,
       "mathContext": "Axiomatized: guthKatz_distinct_distances (axiom: $\\geq cn/\\log n$ distinct distances). Proved: diam_ge_one, diam_ge_n_over_log_n. Kanold's $n^{3/4}$ bound discussed in comments but not declared."
     },
     {
@@ -143,7 +143,7 @@
       "title": "Known Upper Bounds",
       "summary": "piepmeyer_construction (axiom: 9-point integer-distance set with diam < 5), piepmeyer_ratio_bound (proved: ∃ S of size 9 with diam/|S| < 5/9), strong_conjecture_fails_at_9 (proved: the strong form diam ≥ n−1 fails at n = 9)",
       "startLine": 348,
-      "endLine": 386,
+      "endLine": 385,
       "mathContext": "Axiomatized: piepmeyer_construction. Proved: piepmeyer_ratio_bound, strong_conjecture_fails_at_9 — both deduced from the axiom by direct unpacking."
     },
     {
@@ -151,16 +151,32 @@
       "title": "The Erdős-Anning Theorem",
       "summary": "IsCollinear definition + motivational discussion: any infinite integer-distance set in ℝ² must be collinear (Erdős–Anning 1945). The theorem is referenced as background context — only the IsCollinear predicate is formally defined here, not a Lean declaration of the theorem itself.",
       "startLine": 386,
-      "endLine": 407,
+      "endLine": 406,
       "mathContext": "Formal definition: IsCollinear (a Set is collinear iff all points lie on a single line). The Erdős–Anning theorem is described in commentary as motivation for restricting to finite point sets; no formal statement is declared."
     },
     {
-      "id": "implications",
-      "title": "Implications and Sublinearity",
-      "summary": "conjecture_implies_kanold (proved: the linear conjecture implies a Kanold-style sublinear bound c·n^(3/4)) and n_over_log_sublinear (proved: ∀ ε > 0, eventually n/log n < ε·n, confirming the Guth-Katz bound is genuinely o(n))",
+      "id": "conjecture-implies-kanold",
+      "title": "The Conjecture Implies Kanold",
+      "summary": "conjecture_implies_kanold (proved): if the linear conjecture holds, then Kanold's sublinear bound c·n^(3/4) follows, since for large n the linear bound c·n dominates c·n^(3/4).",
       "startLine": 407,
-      "endLine": 470,
-      "mathContext": "conjecture_implies_kanold: linear conjecture $\\Rightarrow$ $c \\cdot n^{3/4}$ sublinear bound; n_over_log_sublinear: $n/\\log n = o(n)$ via filter convergence (Real.tendsto_log_atTop)."
+      "endLine": 432,
+      "mathContext": "conjecture_implies_kanold: $\\text{Erdos100Conjecture} \\Rightarrow \\exists c>0,\\ \\text{eventually } c \\cdot n^{3/4} \\leq \\mathrm{minDiam}(n)$. Proof uses Real.rpow_le_rpow_of_exponent_le with $3/4 \\leq 1$, so the linear conjecture is the stronger statement."
+    },
+    {
+      "id": "guth-katz-sublinear",
+      "title": "The Guth-Katz Lower Bound Is Sublinear",
+      "summary": "n_over_log_sublinear (proved): for every ε > 0, eventually n/log n < ε·n, showing the current best lower bound cn/log n is genuinely o(n) and the gap to the conjectured linear bound remains open.",
+      "startLine": 433,
+      "endLine": 469,
+      "mathContext": "n_over_log_sublinear: $\\forall \\varepsilon>0,\\ \\text{eventually } n/\\log n < \\varepsilon n$, i.e. $n/\\log n = o(n)$. Proof via Real.tendsto_log_atTop (log n → ∞) and div_lt_iff₀, witnessing the gap between the known $cn/\\log n$ bound and the conjectured $cn$."
+    },
+    {
+      "id": "historical-development",
+      "title": "Historical Development",
+      "summary": "Chronological commentary on Erdős Problem #100: the 1945 Erdős–Anning infinite/collinear result, Erdős posing the problem (~1990), Kanold's n^(3/4) bound, Piepmeyer's 2004 nine-point construction (diam < 5), and the 2015 Guth–Katz distinct-distances theorem yielding diam ≥ cn/log n.",
+      "startLine": 470,
+      "endLine": 482,
+      "mathContext": "Historical timeline of Erdős #100: Erdős–Anning (1945), Erdős's problem (~1990), Kanold's $n^{3/4}$ bound, Piepmeyer's 9-point set with $\\mathrm{diam}<5$ (2004), and Guth–Katz distinct distances $\\geq cn/\\log n$ (2015) implying $\\mathrm{diam} \\geq cn/\\log n$. Open: closing the gap between $n/\\log n$ and $n$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery `meta.json` for **erdos-100** (Point Sets with Restricted Distances) had drifted from the Lean source `Proofs/Erdos100Problem.lean` (482 lines, 12 banner blocks).

The final section, **"Implications and Sublinearity" (407-470)**, was an invented title that lumped together three distinct `/-` banner blocks of the source and stopped at line 470 while the file runs to 482 — hiding the last two sections entirely.

## Changes

- Split the lumped tail section into the three **real** banner sections:
  - **The Conjecture Implies Kanold** (407-432) — `conjecture_implies_kanold`
  - **The Guth-Katz Lower Bound Is Sublinear** (433-469) — `n_over_log_sublinear`
  - **Historical Development** (470-482) — chronological commentary
- Tightened the eight cosmetic shared-boundary overlaps (`endLine == next.startLine`) in sections 2-9 so all ranges are contiguous.
- Result: **10 → 12 sections**, contiguous and covering the file 1-482 in source order.

Sections 1-9 already matched their banners (titles unchanged); only endLines were adjusted. Counts (2 axioms, 14 theorems, 9 defs, 0 sorries) were already correct and are untouched. Only the `sections` field of `meta.json` changed.

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] Non-section fields byte-identical to base
- [x] All 12 section ranges contiguous, in-order, covering lines 1-482
- [x] Section start lines match `/-` banner positions in the Lean source