### PR TITLE
research(erdos-469): realign drifted gallery sections to full file (5→13)

### DIFF
--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -28,39 +28,108 @@
   },
   "sections": [
     {
-      "id": "imports",
+      "id": "header",
       "title": "Imports and Setup",
       "startLine": 1,
       "endLine": 21,
-      "summary": "Module imports and problem context for primitive pseudoperfect numbers."
+      "summary": "States Erdős Problem #469 (primitive pseudoperfect numbers). $n$ is pseudoperfect (semiperfect) if it is a sum of distinct proper divisors; primitive pseudoperfect if additionally no proper divisor is pseudoperfect. Let $A$ = primitive pseudoperfect numbers (OEIS A006036: $6,20,28,88,\\dots$). Does $\\sum_{n\\in A}1/n$ converge? Status OPEN. Imports Mathlib.",
+      "mathContext": "Primitive pseudoperfect $A$ (OEIS A006036); does $\\sum_{n\\in A}1/n$ converge?"
     },
     {
       "id": "definitions",
-      "title": "Core Definitions",
+      "title": "Definitions",
       "startLine": 22,
       "endLine": 38,
-      "summary": "IsPseudoperfect, IsPrimitivePseudoperfect, primitivePseudoperfectSet."
+      "summary": "Defines `IsPseudoperfect` (a subset of proper divisors sums to $n$), `IsPrimitivePseudoperfect` (pseudoperfect with no pseudoperfect proper divisor), and the set `primitivePseudoperfectSet`.",
+      "mathContext": "$\\text{IsPseudoperfect}(n):\\exists S\\subseteq\\text{properDivisors}(n),\\ \\sum S=n$; primitive if no proper divisor is pseudoperfect."
     },
     {
-      "id": "known-results",
-      "title": "Known Results",
+      "id": "perfect-pseudoperfect",
+      "title": "Perfect Numbers are Pseudoperfect",
       "startLine": 39,
+      "endLine": 46,
+      "summary": "PROVES `perfect_is_pseudoperfect`: a perfect number (proper divisors sum to $n$) is pseudoperfect, witnessed by all of its proper divisors.",
+      "mathContext": "Perfect $\\Rightarrow$ pseudoperfect (take all proper divisors)."
+    },
+    {
+      "id": "verified-pseudoperfect",
+      "title": "Verified Pseudoperfect Numbers (Witnesses)",
+      "startLine": 47,
       "endLine": 60,
-      "summary": "6 is primitive pseudoperfect, perfect numbers are pseudoperfect, infinitely many exist, multiples inherit property."
+      "summary": "PROVES explicit examples by `decide`: `pseudoperfect_6` ($6=1+2+3$), `pseudoperfect_12` ($12=1+2+3+6$), `pseudoperfect_20` ($20=1+4+5+10$).",
+      "mathContext": "$6,12,20$ pseudoperfect via explicit divisor subsets."
     },
     {
-      "id": "open-question",
-      "title": "The Open Question",
+      "id": "deficiency-argument",
+      "title": "Non-pseudoperfect: Deficiency Argument",
       "startLine": 61,
-      "endLine": 70,
-      "summary": "Does the sum of reciprocals of primitive pseudoperfect numbers converge?"
+      "endLine": 109,
+      "summary": "The private helper `subset_sum_le_total` (subset sum $\\leq$ total proper-divisor sum) drives PROVED non-pseudoperfectness of $0,1,2,3,4,5$ (their proper divisors sum below themselves). Also `pseudoperfect_28` ($28=1+2+4+7+14$, perfect).",
+      "mathContext": "$n\\leq5$: $\\sum\\text{properDivisors}<n$, so not pseudoperfect. $28$ pseudoperfect (perfect)."
     },
     {
-      "id": "implications",
-      "title": "Implications and Context",
-      "startLine": 71,
-      "endLine": 227,
-      "summary": "Connection to analytic number theory, density questions, and OEIS A006036."
+      "id": "additional-nonpseudoperfect",
+      "title": "Non-pseudoperfect: Additional Cases",
+      "startLine": 110,
+      "endLine": 129,
+      "summary": "PROVES `not_pseudoperfect_7`, `_10`, `_14` (proper-divisor sums $1,8,10$ all below the number) — needed for the primitivity proofs of $20$ and $28$.",
+      "mathContext": "$7,10,14$ deficient, hence not pseudoperfect."
+    },
+    {
+      "id": "divisors-of-88",
+      "title": "Non-pseudoperfect: Divisors of 88",
+      "startLine": 130,
+      "endLine": 155,
+      "summary": "PROVES `not_pseudoperfect_8`, `_11`, `_22`, `_44` (all deficient) — needed for the primitivity proof of $88$.",
+      "mathContext": "$8,11,22,44$ deficient, hence not pseudoperfect."
+    },
+    {
+      "id": "key-structural",
+      "title": "Key Structural Results",
+      "startLine": 156,
+      "endLine": 169,
+      "summary": "PROVES `pseudoperfect_ge_six`: the smallest pseudoperfect number is $6$ (by `interval_cases` over $n<6$ using the non-pseudoperfect lemmas).",
+      "mathContext": "Pseudoperfect $\\Rightarrow n\\geq6$."
+    },
+    {
+      "id": "verified-primitive",
+      "title": "Verified Primitive Pseudoperfect Numbers (A006036)",
+      "startLine": 170,
+      "endLine": 228,
+      "summary": "PROVES the first members of $A$: `primitive_pseudoperfect_6`, `_20`, `_28`, and (after `pseudoperfect_88`) `primitive_pseudoperfect_88` — each by checking no proper divisor is pseudoperfect (via $n\\geq6$ plus the deficiency lemmas and `interval_cases`).",
+      "mathContext": "$6,20,28,88\\in A$ (primitive pseudoperfect, OEIS A006036)."
+    },
+    {
+      "id": "structural-theorems",
+      "title": "Structural Theorems",
+      "startLine": 229,
+      "endLine": 254,
+      "summary": "PROVES the unfolding/projection lemmas: `isPseudoperfect_iff`, `primitive_pos`, `primitive_is_pseudoperfect`, `primitive_no_divisor_pseudoperfect`, and `primitive_pseudoperfect_ge_six`.",
+      "mathContext": "Primitive pseudoperfect $\\Rightarrow$ pseudoperfect, $>0$, $\\geq6$, no pseudoperfect proper divisor."
+    },
+    {
+      "id": "abundance",
+      "title": "Abundance and Pseudoperfection",
+      "startLine": 255,
+      "endLine": 280,
+      "summary": "Defines `sigma0` (proper-divisor sum), `IsAbundant`, `IsDeficient`, `IsPerfect'`, and PROVES `deficient_not_pseudoperfect` (a deficient number cannot be pseudoperfect).",
+      "mathContext": "Deficient ($\\sigma_0(n)<n$) $\\Rightarrow$ not pseudoperfect."
+    },
+    {
+      "id": "weird-numbers",
+      "title": "Weird Numbers",
+      "startLine": 281,
+      "endLine": 288,
+      "summary": "Defines `IsWeird` (abundant but not pseudoperfect; smallest is $70$).",
+      "mathContext": "Weird = abundant $\\wedge$ not pseudoperfect (smallest $70$)."
+    },
+    {
+      "id": "open-questions",
+      "title": "The Open Questions (OPEN)",
+      "startLine": 289,
+      "endLine": 327,
+      "summary": "Defines (as `Prop`s, NOT axioms) the open questions: `erdos469_conjecture` (convergence of $\\sum_{n\\in A}1/n$) and `infinitely_many_primitive` ($A$ is infinite). PROVES `multiple_of_pseudoperfect` (every positive multiple of a pseudoperfect number is pseudoperfect, by scaling the divisor witness).",
+      "mathContext": "Open: $\\sum_{n\\in A}1/n$ summable? $A$ infinite? Proved: $n$ pseudoperfect $\\Rightarrow nm$ pseudoperfect."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
The Erdős #469 (primitive pseudoperfect numbers) gallery `meta.json` had only **5 sections**, heavily lumped and mislabeled.

- "The Open Question" was labeled @61-70 (actually the deficiency argument), and a single "Implications and Context" section spanned lines **71-227** covering many distinct file sections.
- Coverage stopped at line **227** of a **327**-line file, hiding the Abundance/Deficiency definitions, Weird Numbers, and the actual Open Questions section (`erdos469_conjecture`, `infinitely_many_primitive`, and the proved `multiple_of_pseudoperfect`).

## Changes
- Rebuilt **13 sections** (was 5) mapped to the file's `-- ## ` banners with full coverage **1-327**, with accurate `mathContext`.
- **Counts already correct**: 32 theorems / 10 definitions / 0 axioms / 0 sorries, lineCount 327.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-327 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-469
- [x] Section ranges re-verified against the `-- ## ` banners in `Erdos469Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)