### PR TITLE
Enrich Infinitely Many Primes ≡ 3 (mod 4): header annotation (5→6)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-setup-context",
+    "proofId": "dirichlets-theorem-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 16
+    },
+    "type": "context",
+    "title": "Setup: Elementary Dirichlet via Euclid's Argument",
+    "content": "The header frames the result as the special case $q=4,\\, a=3$ of Dirichlet's theorem on primes in arithmetic progressions. The general theorem (1837) requires analytic machinery — Dirichlet $L$-functions and the nonvanishing $L(1,\\chi) \\neq 0$ — but the residue class $3 \\pmod 4$ admits a purely elementary proof because the units mod 4 form the two-element group $\\{1,3\\}$, so a number $\\equiv 3$ cannot factor entirely into primes $\\equiv 1$. The single `import Mathlib` pulls in `Nat.exists_prime_and_dvd`, `Nat.Prime.dvd_factorial`, and `Set.infinite_iff_exists_gt`; `open Finset Nat` brings factorial and primality lemmas into scope, and everything lives in the `DirichletsTheoremOQ02` namespace.",
+    "mathContext": "Special case of $\\{a + nq : n \\in \\mathbb{N}\\}$ with $\\gcd(a,q)=1$: here $q=4,\\, a=3$, provable without $L(s,\\chi)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet's theorem",
+      "arithmetic progressions",
+      "Euclid's argument",
+      "units mod 4"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "infinitude of primes"
+    ]
+  },
+  {
     "id": "ann-key-lemma",
     "proofId": "dirichlets-theorem-oq-02",
     "range": {


### PR DESCRIPTION
## Enrichment: dirichlets-theorem-oq-02

Closes the only annotation coverage gap on this entry. The existing 5 annotations covered lines 17–101; lines 1–16 (file header, \`import Mathlib\`, \`open Finset Nat\`, namespace) were unannotated.

### Change
- Added \`ann-setup-context\` (lines 1–16, type \`context\`): frames the result as the special case $q=4, a=3$ of Dirichlet's theorem, explains why $3 \pmod 4$ admits an elementary (non-$L$-function) proof via the two-element unit group $\{1,3\}$ mod 4, and identifies the three Mathlib lemmas the single \`import Mathlib\` provides.

Sections were already realigned in #23792; meta.json overview/conclusion/cross-references already deep. This pass only adds the missing header annotation for full-file coverage. Counts verified against source (3 theorems, 0 def, 0 axioms, 0 sorries).