### PR TITLE
Enrich spherical-law-of-cosines-oq-05: realign sections/annotations + de-stale S1 prose

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-05/annotations.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-05/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
       "startLine": 1,
-      "endLine": 82
+      "endLine": 95
     },
     "type": "concept",
     "title": "OQ-05: the haversine formula",
@@ -27,8 +27,8 @@
     "id": "ann-haversine-def",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 83,
-      "endLine": 119
+      "startLine": 96,
+      "endLine": 124
     },
     "type": "definition",
     "title": "haversine function and the half-angle identity",
@@ -49,8 +49,8 @@
     "id": "ann-haversine-range",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 120,
-      "endLine": 144
+      "startLine": 125,
+      "endLine": 149
     },
     "type": "definition",
     "title": "Elementary properties of the haversine",
@@ -72,8 +72,8 @@
     "id": "ann-haversine-algebraic",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 145,
-      "endLine": 198
+      "startLine": 150,
+      "endLine": 204
     },
     "type": "proof",
     "title": "Algebraic haversine formula (proved unconditionally)",
@@ -94,13 +94,13 @@
     "id": "ann-haversine-triangle-open",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 199,
-      "endLine": 244
+      "startLine": 205,
+      "endLine": 353
     },
     "type": "proof",
-    "title": "Haversine formula for SphericalTriangle (OPEN, deferred to S2)",
-    "content": "`haversine_formula` states $\\text{hav}(t.\\text{sideC}) = \\text{hav}(t.\\text{sideB} - t.\\text{sideA}) + \\sin(t.\\text{sideB}) \\cdot \\sin(t.\\text{sideA}) \\cdot \\text{hav}(t.\\text{angleC})$ for a parent-file `SphericalTriangle`. Recorded as `sorry`. The bridge to `haversine_formula_algebraic` requires converting the parent's `⟨projectPerp t.A t.C, projectPerp t.B t.C⟩` (from `spherical_law_of_cosines_trig`) into the trigonometric form `sin(t.sideB) · sin(t.sideA) · cos(t.angleC)`. On the non-degenerate branch (both projections nonzero) this follows from `norm_projectPerp_eq_sin` (parent file) plus the `cos = ⟨·,·⟩/(‖·‖·‖·‖)` identity. The degenerate branch coincides with $\\sin(t.\\text{sideA}) \\cdot \\sin(t.\\text{sideB}) = 0$, so the cross-term vanishes uniformly.",
-    "mathContext": "The open content is *only* the projection-to-trigonometric-angle conversion; the algebraic identity is already proved.",
+    "title": "Haversine formula for SphericalTriangle (closed at S2)",
+    "content": "`haversine_formula` proves $\\text{hav}(t.\\text{sideC}) = \\text{hav}(t.\\text{sideB} - t.\\text{sideA}) + \\sin(t.\\text{sideB}) \\cdot \\sin(t.\\text{sideA}) \\cdot \\text{hav}(t.\\text{angleC})$ for a parent-file `SphericalTriangle`. Closed at S2: the bridge to `haversine_formula_algebraic` converts the parent's `⟨projectPerp t.A t.C, projectPerp t.B t.C⟩` (from `spherical_law_of_cosines_trig`) into the trigonometric form `sin(t.sideB) · sin(t.sideA) · cos(t.angleC)` via `inner_projectPerp_eq_sin_sin_cos_angleC`. On the non-degenerate branch (both projections nonzero) this follows from `norm_projectPerp_eq_sin` (parent file) plus the `cos = ⟨·,·⟩/(‖·‖·‖·‖)` identity; the degenerate branch coincides with $\\sin(t.\\text{sideA}) \\cdot \\sin(t.\\text{sideB}) = 0$, so the cross-term vanishes uniformly.",
+    "mathContext": "The part deferred past S1 was *only* the projection-to-trigonometric-angle conversion; the algebraic identity was already proved unconditionally. Both are now closed, so the SphericalTriangle form holds with no hypothesis.",
     "significance": "key",
     "relatedConcepts": [
       "projectPerp (parent file)",
@@ -117,8 +117,8 @@
     "id": "ann-specialised",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 245,
-      "endLine": 270
+      "startLine": 354,
+      "endLine": 377
     },
     "type": "proof",
     "title": "Specialised corollaries",
@@ -136,34 +136,11 @@
     ]
   },
   {
-    "id": "ann-summary-tabular",
-    "proofId": "spherical-law-of-cosines-oq-05",
-    "range": {
-      "startLine": 272,
-      "endLine": 295
-    },
-    "type": "context",
-    "title": "Status Summary: 12 PROVED, 1 OPEN, 0 axioms",
-    "content": "Part VI is a tabular accounting of the file's contents, mirrored in `meta.json`'s `theoremCount: 12`, `definitionCount: 1`, `sorries: 1`, `axiomCount: 0`. The 12 proved theorems split into four groups: (i) the half-angle bridge (`haversine_eq_one_sub_cos_div_two`, `two_haversine_eq`, `cos_eq_one_sub_two_haversine`); (ii) range/sign/parity (`haversine_nonneg`, `haversine_le_one`, `haversine_zero`, `haversine_pi`, `haversine_neg`); (iii) the algebraic identity in both directions (`haversine_formula_algebraic`, `cos_form_of_haversine_formula`); (iv) corollaries (`haversine_formula_holds_when_sin_sideA_zero`, `haversine_sub_comm`). The single `sorry` is the `SphericalTriangle` form `haversine_formula`, blocked only on the projection-to-trigonometric-angle conversion in the parent file. The tabular form makes the S1→S2 boundary explicit for downstream automation (Aristotle/Mechanic) and for human auditors checking axiom-integrity claims.",
-    "mathContext": "Status field semantics (per axiom-integrity policy): $\\texttt{status: axiomatized}$, $\\texttt{sorries: 1}$, $\\texttt{axiomCount: 0}$, $\\texttt{badge: wip}$. The status will move to $\\texttt{verified}$ once the S2 conversion is closed and the lone $\\texttt{sorry}$ is discharged.",
-    "significance": "context",
-    "relatedConcepts": [
-      "gallery status taxonomy (verified vs axiomatized vs formalized)",
-      "axiom-integrity audit",
-      "S1 scaffold pattern",
-      "open-question slug bookkeeping"
-    ],
-    "prerequisites": [
-      "axiom-integrity policy (CLAUDE.md)",
-      "meta.json status/badge/axiomCount conventions"
-    ]
-  },
-  {
     "id": "ann-inverse-haversine-s3",
     "proofId": "spherical-law-of-cosines-oq-05",
     "range": {
-      "startLine": 385,
-      "endLine": 479
+      "startLine": 378,
+      "endLine": 473
     },
     "type": "theorem",
     "title": "Inverse haversine formula and great-circle distance (S3)",
@@ -183,6 +160,75 @@
       "Real.arcsin_sin",
       "Parent arcLength_nonneg, arcLength_le_pi",
       "S2 haversine_formula"
+    ]
+  },
+  {
+    "id": "ann-strict-mono-s4",
+    "proofId": "spherical-law-of-cosines-oq-05",
+    "range": {
+      "startLine": 474,
+      "endLine": 573
+    },
+    "type": "theorem",
+    "title": "Strict monotonicity, injectivity & navigation uniqueness (S4)",
+    "content": "Establishes that `haversine` is strictly monotone increasing on the principal arc-length range `[0, π]` (`haversine_strictMonoOn_Icc_zero_pi`), via `Real.strictAntiOn_cos` and the half-angle identity `haversine = (1 - cos)/2`. Strict monotonicity yields injectivity (`haversine_injOn_Icc_zero_pi`) and the order/equality iff-lemmas (`haversine_lt_haversine_iff_lt`, `haversine_eq_haversine_iff_eq`). These give *navigation uniqueness*: two spherical-triangle sides with equal haversine are equal (`sideC_eq_of_haversine_sideC_eq` and the `sideA`/`sideB` analogues), so the inverse recovery `c = 2·arcsin(√(hav c))` is well-defined as a function on `[0, π]`.",
+    "mathContext": "$\\text{hav}$ strictly increasing on $[0,\\pi]$ $\\Rightarrow$ injective $\\Rightarrow$ the navigation map $(a,b,C) \\mapsto c$ is single-valued.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.strictAntiOn_cos",
+      "StrictMonoOn / InjOn",
+      "well-definedness of inverse functions",
+      "great-circle distance recovery"
+    ],
+    "prerequisites": [
+      "haversine_eq_one_sub_cos_div_two",
+      "eq_two_arcsin_sqrt_haversine (S3 inverse)"
+    ]
+  },
+  {
+    "id": "ann-bijection-s5",
+    "proofId": "spherical-law-of-cosines-oq-05",
+    "range": {
+      "startLine": 574,
+      "endLine": 639
+    },
+    "type": "theorem",
+    "title": "The haversine bijection [0, π] ≃ [0, 1] (S5)",
+    "content": "Completes the bijection picture: S4 gave injectivity (via strict monotonicity); this part proves surjectivity onto `[0, 1]` (`haversine_surjOn`) and assembles the bijection (`haversine_bijOn`, `haversine_image_Icc`). Surjectivity is *constructive* and needs no intermediate-value argument: for any target `y ∈ [0, 1]`, the explicit preimage `2·arcsin(√y)` lies in `[0, π]` (`two_arcsin_sqrt_mem_Icc`) and maps to `y` (`haversine_two_arcsin_sqrt`), since `sin(arcsin(√y)) = √y` and `(√y)² = y`. So the forward haversine and the inverse `2·arcsin(√·)` are mutually inverse bijections between `[0, π]` and `[0, 1]` — the exact range statement underlying navigation recovery.",
+    "mathContext": "$\\text{hav} : [0,\\pi] \\xrightarrow{\\;\\sim\\;} [0,1]$ with explicit inverse $y \\mapsto 2\\arcsin(\\sqrt{y})$; $\\text{hav}(2\\arcsin\\sqrt{y}) = y$ for $y \\in [0,1]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "BijOn / SurjOn / MapsTo",
+      "constructive surjectivity (explicit preimage)",
+      "Real.arcsin / Real.sin_arcsin",
+      "principal range of arc length"
+    ],
+    "prerequisites": [
+      "ann-strict-mono-s4 (injectivity)",
+      "eq_two_arcsin_sqrt_haversine (S3)"
+    ]
+  },
+  {
+    "id": "ann-summary-tabular",
+    "proofId": "spherical-law-of-cosines-oq-05",
+    "range": {
+      "startLine": 640,
+      "endLine": 689
+    },
+    "type": "context",
+    "title": "Status Summary: 37 proved, 0 sorries, 0 axioms (verified)",
+    "content": "Part XI is a tabular accounting of the file's contents, mirrored in `meta.json`'s `theoremCount: 37`, `definitionCount: 1`, `sorries: 0`, `axiomCount: 0`. The proved results span: the half-angle bridge; range/sign/parity of `haversine`; the algebraic identity in both directions; the `SphericalTriangle` form (S2 bridge); the inverse formula and great-circle corollaries (S3); strict monotonicity / injectivity / navigation-uniqueness (S4); and the `[0, π] ≃ [0, 1]` bijection (S5). The table makes the S1→S5 development explicit for downstream automation (Aristotle/Mechanic) and for human auditors checking axiom-integrity claims — every row is PROVED, with no remaining `sorry`.",
+    "mathContext": "Status field semantics (per axiom-integrity policy): $\\texttt{status: verified}$, $\\texttt{sorries: 0}$, $\\texttt{axiomCount: 0}$, $\\texttt{badge: original}$. The lone S1 `sorry` (the SphericalTriangle conversion) was discharged at S2, and the file is Docker-verified end-to-end.",
+    "significance": "context",
+    "relatedConcepts": [
+      "gallery status taxonomy (verified vs axiomatized vs formalized)",
+      "axiom-integrity audit",
+      "end-to-end Docker verification",
+      "open-question slug bookkeeping"
+    ],
+    "prerequisites": [
+      "axiom-integrity policy (CLAUDE.md)",
+      "meta.json status/badge/axiomCount conventions"
     ]
   }
 ]

--- a/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "spherical-law-of-cosines-oq-05",
   "title": "Spherical Law of Cosines OQ-05: the Haversine Formula",
   "slug": "spherical-law-of-cosines-oq-05",
-  "description": "Formal scaffold for OQ-05 of the parent gallery entry `spherical-law-of-cosines`: the haversine formula $\\text{hav}(c) = \\text{hav}(a-b) + \\sin(a)\\sin(b)\\,\\text{hav}(C)$ — the numerically stable version of the spherical law of cosines used in navigation and GPS great-circle distance computations. S1 establishes the haversine function and proves the pure algebraic identity (from the planar SLC hypothesis); the `SphericalTriangle` version is recorded as `sorry` pending the conversion of the parent file's projection-inner-product form into the trigonometric `sin(a)sin(b)cos(C)` form (deferred to S2).",
+  "description": "Formal entry for OQ-05 of the parent gallery entry `spherical-law-of-cosines`: the haversine formula $\\text{hav}(c) = \\text{hav}(a-b) + \\sin(a)\\sin(b)\\,\\text{hav}(C)$ — the numerically stable version of the spherical law of cosines used in navigation and GPS great-circle distance computations. Establishes the haversine function, proves the pure algebraic identity (from the planar SLC hypothesis) and the `SphericalTriangle` version (closed at S2 via the projection-inner-product bridge), then develops the inverse haversine formula, strict monotonicity/injectivity, and the $[0,\\pi] \\simeq [0,1]$ bijection. Fully Docker-verified end-to-end: 37 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Todhunter, Sigl",
     "status": "verified",
@@ -34,71 +34,63 @@
       "id": "header-setup",
       "title": "File Header and Setup",
       "startLine": 1,
-      "endLine": 82,
+      "endLine": 95,
       "summary": "Documentation header describing OQ-05 (the haversine formula), its applications (navigation, GPS, numerical stability), the S1 scaffold contents, and the proof strategy for the deferred `SphericalTriangle` version. Imports the parent `SphericalLawOfCosines`.",
       "mathContext": "$\\text{hav}(\\theta) := \\sin^2(\\theta/2) = (1 - \\cos\\theta)/2$. The haversine formula $\\text{hav}(c) = \\text{hav}(a-b) + \\sin(a)\\sin(b)\\text{hav}(C)$ is equivalent to the spherical law of cosines but avoids catastrophic cancellation for small great-circle distances."
     },
     {
       "id": "haversine-def",
       "title": "Part I: The haversine function",
-      "startLine": 83,
-      "endLine": 119,
+      "startLine": 96,
+      "endLine": 124,
       "summary": "Defines `haversine θ := sin²(θ/2)` and proves the half-angle identity `haversine θ = (1 − cos θ) / 2` using `Real.cos_two_mul` and `Real.sin_sq_add_cos_sq`. Records the equivalent `2 · haversine` and `cos = 1 − 2 · haversine` reformulations.",
       "mathContext": "The half-angle identity is the algebraic bridge between the haversine form and the standard cosine form. Mathlib derivation goes through `cos(2x) = 1 - 2sin²(x)`."
     },
     {
       "id": "haversine-range",
       "title": "Part II: Range and elementary properties",
-      "startLine": 120,
-      "endLine": 144,
+      "startLine": 125,
+      "endLine": 149,
       "summary": "Proves `0 ≤ haversine θ ≤ 1`, `haversine 0 = 0`, `haversine π = 1`, and the even-function property `haversine (−θ) = haversine θ`. All unconditional.",
       "mathContext": "The haversine maps $[0, \\pi]$ to $[0, 1]$ bijectively (on the principal branch), with $\\text{hav}(0) = 0$ at antipodal-coincident points and $\\text{hav}(\\pi) = 1$ at antipodal points."
     },
     {
       "id": "haversine-algebraic",
       "title": "Part III: The algebraic haversine formula",
-      "startLine": 145,
-      "endLine": 198,
+      "startLine": 150,
+      "endLine": 204,
       "summary": "Proves `haversine_formula_algebraic`: given the planar identity `cos(a-b) = cos a · cos b + sin a · sin b` (via `Real.cos_sub`) and a hypothesis that the spherical law of cosines holds for `(a, b, c, C)`, the haversine identity follows by linear arithmetic. The converse `cos_form_of_haversine_formula` is also recorded.",
       "mathContext": "The identity is purely algebraic; no spherical geometry is required. The proof is `rw` + `linarith` once the half-angle and subtraction formulas are unfolded."
     },
     {
       "id": "haversine-triangle",
-      "title": "Part IV: The SphericalTriangle version (OPEN)",
-      "startLine": 199,
-      "endLine": 244,
-      "summary": "States `haversine_formula` for a `SphericalTriangle` from the parent file, using `sideA`, `sideB`, `sideC`, `angleC`. Recorded as `sorry`. The bridge to `haversine_formula_algebraic` requires converting the parent's `⟨projectPerp t.A t.C, projectPerp t.B t.C⟩` into `sin(sideB) · sin(sideA) · cos(angleC)`, which case-splits on the degenerate-projection branch of `angleC`'s definition.",
+      "title": "Part IV: The SphericalTriangle version (closed at S2)",
+      "startLine": 205,
+      "endLine": 353,
+      "summary": "Proves `haversine_formula` for a `SphericalTriangle` from the parent file, using `sideA`, `sideB`, `sideC`, `angleC`. Closed at S2: the bridge from the parent's `⟨projectPerp t.A t.C, projectPerp t.B t.C⟩` to `sin(sideB) · sin(sideA) · cos(angleC)` is supplied by `inner_projectPerp_eq_sin_sin_cos_angleC`, which case-splits on the degenerate-projection branch of `angleC`'s definition.",
       "mathContext": "On the non-degenerate branch (both projections nonzero), the identity follows from `norm_projectPerp_eq_sin` and `cos = ⟨·,·⟩/(‖·‖·‖·‖)`. On the degenerate branch, both `sin(sideA) · sin(sideB) = 0` and `‖projectPerp‖ = 0`, so the cross-term vanishes uniformly."
     },
     {
       "id": "specialised-corollaries",
       "title": "Part V: Specialised consequences",
-      "startLine": 245,
-      "endLine": 270,
+      "startLine": 354,
+      "endLine": 377,
       "summary": "Records `haversine_formula_holds_when_sin_sideA_zero` (degenerate case via the algebraic version) and `haversine_sub_comm` (haversine of difference is symmetric: `hav(a−b) = hav(b−a)`).",
       "mathContext": "These witness that the small-case content is already captured by the algebraic identity; the open content lies entirely in the projection-to-angle conversion."
     },
     {
-      "id": "summary",
-      "title": "Part VI: Summary",
-      "startLine": 271,
-      "endLine": 297,
-      "summary": "Tabular summary of the file's contents: 12 proved theorems + 1 sorry, 0 axioms, 1 definition.",
-      "mathContext": "Status accounting for the gallery: this file is `axiomatized` (1 sorry on `haversine_formula`), with no axioms or assumption-bearing structures."
-    },
-    {
       "id": "inverse-haversine",
       "title": "Part VII: Inverse haversine formula (S3)",
-      "startLine": 385,
-      "endLine": 479,
+      "startLine": 378,
+      "endLine": 473,
       "summary": "Adds the inverse to the forward `haversine_formula`. Proves the general identity `θ = 2·arcsin(√(haversine θ))` for `θ ∈ [0, π]` (the principal range of arc-lengths on the sphere), then specialises it to the three sides of a `SphericalTriangle` using the parent's `arcLength_nonneg` and `arcLength_le_pi`. Finally composes the forward and inverse formulas into `sideC_eq_great_circle_haversine`, the canonical navigation identity `c = 2·arcsin(√(hav(a−b) + sin(a)·sin(b)·hav(C)))`.",
       "mathContext": "The inverse uses two facts: (1) `sin(θ/2) ≥ 0` on `[0, π/2]`, so `√(sin²(θ/2)) = sin(θ/2)`; (2) `arcsin(sin x) = x` on `[-π/2, π/2]`, and `θ/2 ∈ [0, π/2] ⊆ [-π/2, π/2]` when `θ ∈ [0, π]`. Both branches use only standard Mathlib API (`Real.sin_nonneg_of_nonneg_of_le_pi`, `Real.sqrt_sq`, `Real.arcsin_sin`). The great-circle distance corollary closes the navigation pipeline: given latitudes/longitude-difference, the haversine of the great-circle distance can be computed without going through `arccos` near 1, and the inverse `arcsin(√·)` is well-conditioned because `arcsin` near 0 is well-behaved."
     },
     {
       "id": "strict-mono-injOn",
       "title": "Part IX: Strict monotonicity, injectivity, and navigation uniqueness (S4)",
-      "startLine": 481,
-      "endLine": 580,
+      "startLine": 474,
+      "endLine": 573,
       "summary": "Establishes strict monotonicity of `haversine` on the principal arc-length range `[0, π]` via `Real.strictAntiOn_cos`, deduces injectivity as a corollary, and records the resulting two-triangle uniqueness statements. Nine new theorems: `haversine_strictMonoOn_Icc_zero_pi`, `haversine_injOn_Icc_zero_pi`, `haversine_lt_haversine_iff_lt`, `haversine_eq_haversine_iff_eq`, the generic-Vec3 corollary `arcLength_eq_of_haversine_eq` (lifting injectivity from real numbers to parent-gallery arc-lengths), the three `sideA/B/C_eq_of_haversine_sideA/B/C_eq` uniqueness statements, and the vanishing characterisation `haversine_eq_zero_iff_of_mem_Icc`.",
       "mathContext": "Strict monotonicity formalises the navigation pipeline's well-definedness: the forward `haversine_formula` (S2) plus the inverse `eq_two_arcsin_sqrt_haversine` (S3) compute a great-circle distance, and injectivity confirms this distance is uniquely recoverable from its haversine. Mathematically: $\\text{hav}(\\theta) = (1 - \\cos\\theta)/2$, and `cos` is strictly antitone on $[0, \\pi]$, so `haversine` is strictly monotone there. The corollary `arcLength_eq_of_haversine_eq` makes the injectivity directly applicable to arc-lengths between unit vectors, which always lie in $[0, \\pi]$ by `arcLength_nonneg`/`arcLength_le_pi` from the parent file."
     },
@@ -123,12 +115,12 @@
     "historicalContext": "The haversine formula was first published by James Inman in 1835 for navigational use. The half-angle reformulation avoids the catastrophic cancellation that plagues the standard $\\arccos(\\cos a \\cos b + \\sin a \\sin b \\cos C)$ form when the great-circle distance is small: for example, at a great-circle distance of $1$ kilometre on Earth (radius $\\approx 6371$ km), the argument of $\\arccos$ is $1 - 1.23 \\times 10^{-8}$, well beyond double-precision resolution near the boundary. The haversine form computes $\\sin^2(\\text{distance}/2)$ directly and remains well-conditioned. Modern GPS and great-circle distance libraries use this formulation; its formalisation here connects spherical trigonometry to applied numerical geometry.",
     "problemStatement": "**OQ-05**: Formalise the haversine formula $\\text{hav}(c) = \\text{hav}(a - b) + \\sin(a) \\sin(b) \\text{hav}(C)$, where $\\text{hav}(\\theta) = \\sin^2(\\theta/2)$, as the numerically stable formulation of the spherical law of cosines for great-circle distance computations.",
     "text": "Formalise the haversine formula $\\text{hav}(c) = \\text{hav}(a-b) + \\sin(a)\\sin(b)\\text{hav}(C)$, where $\\text{hav}(\\theta) = \\sin^2(\\theta/2)$, which is the numerically stable version of the spherical law of cosines for computing great-circle distances. Applications to navigation and GPS coordinate systems make this a practically important variant to formalize.",
-    "proofStrategy": "S1 (this scaffold) records the haversine function `sin²(θ/2)`, proves the half-angle identity `hav θ = (1 − cos θ)/2` from `Real.cos_two_mul` + `Real.sin_sq_add_cos_sq`, and proves the pure **algebraic** haversine formula `haversine_formula_algebraic` by linear arithmetic from the planar subtraction formula `Real.cos_sub` and the hypothesis that the spherical law of cosines holds. The `SphericalTriangle` version `haversine_formula` is recorded as the open `sorry`; closing it (deferred to S2) requires the conversion of the parent's projection-inner-product form `⟨projectPerp A C, projectPerp B C⟩` into the trigonometric form `sin(sideB) · sin(sideA) · cos(angleC)` via a case split on degenerate projections (where `norm_projectPerp_eq_sin` from the parent supplies the non-degenerate branch and the degenerate branch is handled by the vanishing of `sin(sideA) · sin(sideB)`).",
+    "proofStrategy": "S1 (this scaffold) records the haversine function `sin²(θ/2)`, proves the half-angle identity `hav θ = (1 − cos θ)/2` from `Real.cos_two_mul` + `Real.sin_sq_add_cos_sq`, and proves the pure **algebraic** haversine formula `haversine_formula_algebraic` by linear arithmetic from the planar subtraction formula `Real.cos_sub` and the hypothesis that the spherical law of cosines holds. The `SphericalTriangle` version `haversine_formula` is closed at S2: the conversion of the parent's projection-inner-product form `⟨projectPerp A C, projectPerp B C⟩` into the trigonometric form `sin(sideB) · sin(sideA) · cos(angleC)` via a case split on degenerate projections (where `norm_projectPerp_eq_sin` from the parent supplies the non-degenerate branch and the degenerate branch is handled by the vanishing of `sin(sideA) · sin(sideB)`).",
     "keyInsights": [
       "The haversine identity is algebraically equivalent to the standard spherical law of cosines; the conversion is a pure half-angle calculation.",
       "The half-angle identity $\\sin^2(\\theta/2) = (1 - \\cos\\theta)/2$ underlies the entire scaffold; in Mathlib it is derived from `Real.cos_two_mul` + `Real.sin_sq_add_cos_sq`.",
       "The numerical advantage is content-free at the symbolic level — both forms compute the same real number — but is crucial for floating-point evaluation.",
-      "The `SphericalTriangle` version is open at S1 only because the parent's `spherical_law_of_cosines_trig` uses the projection-inner-product form `⟨projectPerp A C, projectPerp B C⟩`, not the `sin · sin · cos C` form; bridging requires a case split on degenerate projections.",
+      "The `SphericalTriangle` version was the one part deferred past S1, because the parent's `spherical_law_of_cosines_trig` uses the projection-inner-product form `⟨projectPerp A C, projectPerp B C⟩`, not the `sin · sin · cos C` form; the S2 bridge `inner_projectPerp_eq_sin_sin_cos_angleC` closes it via a case split on degenerate projections.",
       "On the degenerate-projection branch of `angleC`'s definition, both the cross-term and `sin(sideA) · sin(sideB)` vanish uniformly, so the haversine formula reduces to `hav(c) = hav(a − b)` — which holds automatically when one side has length 0 or π."
     ],
     "prerequisites": [
@@ -139,7 +131,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Complete after S4: the forward haversine formula `hav(c) = hav(a−b) + sin(a)·sin(b)·hav(C)` is proved both as an algebraic identity (S1) and for a `SphericalTriangle` (S2 bridge); the inverse `c = 2·arcsin(√(hav c))` is proved on the principal arc-length range `[0, π]` (S3); the composed corollary `sideC_eq_great_circle_haversine` is the canonical navigation identity (S3); and strict monotonicity / injectivity of `haversine` on `[0, π]` (S4) formalises the well-definedness of the inverse step. 31 theorems, 0 sorries, 0 axioms. File is now Docker-verified end-to-end — S4 also fixed pre-existing S2 build issues (orphan docstring, split_ifs on let-wrapped if, le_div_iff → le_div_iff₀) that had silently blocked CI verification.",
+    "summary": "Complete after S5: the forward haversine formula `hav(c) = hav(a−b) + sin(a)·sin(b)·hav(C)` is proved both as an algebraic identity (S1) and for a `SphericalTriangle` (S2 bridge); the inverse `c = 2·arcsin(√(hav c))` is proved on the principal arc-length range `[0, π]` (S3); the composed corollary `sideC_eq_great_circle_haversine` is the canonical navigation identity (S3); strict monotonicity / injectivity of `haversine` on `[0, π]` (S4) formalises the well-definedness of the inverse step; and S5 completes the picture with the haversine bijection `[0, π] ≃ [0, 1]` (injectivity from S4 plus surjectivity via the intermediate value theorem). 37 theorems, 0 sorries, 0 axioms. File is Docker-verified end-to-end — S4 also fixed pre-existing S2 build issues (orphan docstring, split_ifs on let-wrapped if, le_div_iff → le_div_iff₀) that had silently blocked CI verification.",
     "implications": "The haversine form is the only stable way to compute small great-circle distances in floating-point: at 1 km on Earth's surface ($R \\approx 6371$ km), the standard SLC argument $\\cos a \\cos b + \\sin a \\sin b \\cos C$ differs from 1 by $\\sim 10^{-8}$ — below the resolution of `Real.arccos` near 1 — while $\\text{hav}(c) = \\sin^2(c/2)$ stays well-conditioned because $\\sin^2$ vanishes quadratically rather than $\\cos$ saturating. Formalising the algebraic equivalence (S1's `haversine_formula_algebraic` + `cos_form_of_haversine_formula`) means any Mathlib-formalised algorithm built on the cosine form can be refactored into the haversine form without re-proving correctness. With S3's inverse formula closing the pipeline (`sideC_eq_great_circle_haversine`) and S4's injectivity confirming uniqueness, the file is now self-contained: a verified end-to-end great-circle distance routine can be written against this file's API without ever calling `Real.arccos`, with formal guarantees that the recovered distance is the unique value matching its haversine. Methodologically, the file demonstrates a clean four-stage pattern: (S1) algebraic identity (no geometry), (S2) project geometry-to-trigonometry bridge, (S3) numerically stable inverse, (S4) injectivity + well-definedness — isolating the analytic, geometric, computational, and order-theoretic content into separate sessions for independent review.",
     "openQuestions": [
       "Lift `haversine`, `haversine_formula_algebraic`, `eq_two_arcsin_sqrt_haversine`, `haversine_strictMonoOn_Icc_zero_pi` to `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` as a potential upstream contribution (no `Real.haversine` exists at v4.26.0).",


### PR DESCRIPTION
## Summary
Enrichment pass for `spherical-law-of-cosines-oq-05`. The `meta.json` counts (37 theorems, 0 sorries, 0 axioms, `status: verified`) are current, but the **sections, annotations, and narrative prose froze at the S1/S2/S4 revisions** while the file advanced through S5.

- **Sections realigned to the file banners (11 → 10, tiling 1–689).** Front sections (Parts I–V) pointed at pre-S2 line numbers; a phantom "Part VI Summary" section pointed at mid-Part-IV proof content (`inner_projectPerp_eq_sin_sin_cos_angleC`) and carried stale "12 theorems + 1 sorry"; the S4/S5 sections overlapped (481–580 / 574–639). Rebuilt against the real banners (I@96, II@125, III@150, IV@205, V@354, VII@378, IX@474, X@574, XI@640).
- **Annotations realigned + coverage added (8 → 10).** All 8 ranges were stale; added `ann-strict-mono-s4` (474–573) and `ann-bijection-s5` (574–639) for the previously uncovered region. Annotations now tile 1–689.
- **De-staled prose.** The `SphericalTriangle` form `haversine_formula` is **closed at S2** (the lean docstring says "Status: CLOSED at S2"; 0 sorries), not an "open sorry deferred to S2" — fixed in `description`, `overview.proofStrategy`, `overview.keyInsights`, and the Part IV section/annotation (which still said "(OPEN)"). `conclusion.summary` updated from S4/"31 theorems" → S5/"37 theorems" with the bijection. The tabular-summary annotation "12 PROVED, 1 OPEN" → "37 proved, 0 sorries, 0 axioms (verified)".

No Lean source changed; all meta counts already match the file.

## Test plan
- [x] `pnpm annotations:build` exits 0 with no `[spherical-law-of-cosines-oq-05]` warnings (the prior "type proof but found theorem at line 199" range-drift warning is resolved)
- [x] meta.json + annotations.json valid JSON; sections and annotations each contiguously cover 1–689
- [x] Build unicode side-effects on other files reverted; only `src/data/proofs/spherical-law-of-cosines-oq-05/` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)