### PR TITLE
research(erdos-319): realign drifted gallery sections to full file (5→5)

### DIFF
--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -76,39 +76,44 @@
   },
   "sections": [
     {
-      "id": "preamble",
+      "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 25,
-      "summary": "Module docstring describing the Erdős problem, its open status, and known partial results. Imports Mathlib for number theory and combinatorics infrastructure."
+      "summary": "States Erdős Problem #319: find the maximum size $c(N)$ of $A\\subseteq\\{1,\\dots,N\\}$ admitting a signing $\\delta:A\\to\\{\\pm1\\}$ with $\\sum_{n\\in A}\\delta(n)/n=0$ but no nonempty proper subset summing to $0$ (irreducible signed zero-sum). Known: Croot (2001) on unit-fraction sums; Adenwalla $|A|\\geq(1-1/e+o(1))N$. Status OPEN. Imports `Finset`/`Rat`/tactics.",
+      "mathContext": "$c(N)=\\max|A|$ with $\\sum_{n\\in A}\\delta(n)/n=0$ irreducibly; conjectured $\\geq(1-1/e)N$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 26,
       "endLine": 47,
-      "summary": "Defines `IsSigning A δ` ($\\delta(n) \\in \\{\\pm 1\\}$ for $n \\in A$), `signedSum A δ = \\sum_{n \\in A} \\delta(n)/n \\in \\mathbb{Q}$, `IsIrreducibleZeroSum A δ` (signing + zero sum + no proper nonempty zero-sum subset), and `maxIrreducibleSize N` as the supremum of $|A|$ over the powerset of $\\{1,\\ldots,N\\}$ filtered by existence of an irreducible zero sum."
-    },
-    {
-      "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 48,
-      "endLine": 56,
-      "summary": "Axiomatizes `erdos_319_conjecture`: for every $\\varepsilon > 0$, for large enough $N$, $c(N) \\geq (1 - 1/e - \\varepsilon)N$, using `Real.exp 1` for Euler's number $e$. This is the strongest known lower bound."
+      "summary": "Defines `IsSigning` ($\\delta$ takes values $\\pm1$ on $A$), `signedSum` ($\\sum_{n\\in A}\\delta(n)/n\\in\\mathbb{Q}$), `IsIrreducibleZeroSum` (signing with zero sum and no nonempty proper subset summing to zero), and `maxIrreducibleSize N` $=c(N)$ (the sup of $|A|$ over admissible subsets of $\\{1,\\dots,N\\}$).",
+      "mathContext": "`IsIrreducibleZeroSum`: $\\sum_A\\delta/n=0$, $\\forall\\emptyset\\neq A'\\subsetneq A,\\ \\sum_{A'}\\delta/n\\neq0$."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 57,
-      "endLine": 78,
-      "summary": "Axiomatizes `adenwalla_lower_bound` ($c(N) \\geq (1 - 1/e + o(1))N$ via the $B \\cup \\{1\\}$ construction), `trivial_upper_bound` ($c(N) \\leq N$), and `croot_unit_fraction_theorem` (every positive integer $k \\leq N$ is a sum of distinct unit fractions $1/n$ with $n \\in \\{1,\\ldots,N\\}$ for large $N$)."
+      "startLine": 48,
+      "endLine": 57,
+      "summary": "States the AXIOM `adenwalla_lower_bound` (Adenwalla): $c(N)\\geq(1-1/e-\\varepsilon)N$ for large $N$, via the construction $A=B\\cup\\{1\\}$ with $B\\subseteq[(1/e-o(1))N,N]$, $\\sum_{b\\in B}1/b=1$.",
+      "mathContext": "Axiom (Adenwalla): $c(N)\\geq(1-1/e-\\varepsilon)N$."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Main Conjecture",
+      "startLine": 58,
+      "endLine": 86,
+      "summary": "States the conjecture `erdos_319_conjecture` ($c(N)\\geq(1-1/e+o(1))N$), PROVED here directly from `adenwalla_lower_bound`. PROVES the `trivial_upper_bound` ($c(N)\\leq N$). Also states the AXIOM `croot_unit_fraction_theorem` (every $k\\leq N$ is a sum of distinct unit fractions with denominators in $\\{1,\\dots,N\\}$, used in constructions).",
+      "mathContext": "$(1-1/e-\\varepsilon)N\\leq c(N)\\leq N$; Croot's unit-fraction theorem (axiom)."
     },
     {
       "id": "observations",
       "title": "Observations",
-      "startLine": 79,
-      "endLine": 89,
-      "summary": "Axiomatizes `small_example`: there exists an irreducible zero sum in $\\{1,\\ldots,6\\}$. Notes the connection to Egyptian fraction theory and the Erdős-Graham program on unit-fraction decompositions."
+      "startLine": 87,
+      "endLine": 191,
+      "summary": "PROVES `small_example` (was an axiom): $A=\\{2,3,6\\}$ with $\\delta(2)=-1$, $\\delta(3)=\\delta(6)=1$ gives $-1/2+1/3+1/6=0$, and every nonempty proper subset sums to $\\pm1/6,\\pm1/3,\\pm1/2\\neq0$ — verified by exhaustive subset case analysis. A closing comment connects the problem to Egyptian/signed unit-fraction decompositions (Erdős–Graham 1980).",
+      "mathContext": "$\\{2,3,6\\}$ with signs $(-,+,+)$: $-1/2+1/3+1/6=0$, irreducible (all proper subsets nonzero)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #319 (maximum irreducible signed unit-fraction sum) gallery `meta.json` had **swapped/mislabeled sections** and a hidden tail.

- "Main Conjecture" was tagged @48-56 (actually the Adenwalla lower-bound axiom), while "Known Results" was tagged @57-78 (actually `erdos_319_conjecture` + `trivial_upper_bound`).
- Coverage stopped at line **89** of a **191**-line file, hiding the entire `small_example` proof (lines 90-188: the {2,3,6} irreducible signed zero-sum with its exhaustive subset verification).

## Changes
- Realigned all **5 sections** to the file's `## ` banners with full coverage **1-191**, with accurate `mathContext`.
- **Counts already correct**: 3 theorems / 4 definitions / 2 axioms / 0 sorries, lineCount 191.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-191 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-319
- [x] Section ranges re-verified against the `## ` banners in `Erdos319Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)