### PR TITLE
research(erdos-1001): realign drifted gallery sections to full file (9→11)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -87,44 +87,60 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the open question and answer (Hölder's inequality in eLpNorm form for an arbitrary NormedField 𝕜, 0 sorries / 0 axioms), opens `noncomputable section` and `namespace HolderELpNorm`.",
+      "mathContext": "$\\|fg\\|_1 \\le \\|f\\|_p\\,\\|g\\|_q$ for conjugate exponents $1/p+1/q=1$, formalized via Mathlib's `eLpNorm` API for NormedField-valued functions."
+    },
+    {
       "id": "bridge-lemma",
-      "title": "Bridge Lemma: eLpNorm ↔ lintegral",
+      "title": "Part 1: Bridge Lemma — eLpNorm ↔ lintegral",
+      "startLine": 45,
+      "endLine": 58,
       "summary": "eLpNorm_ofReal_eq converts eLpNorm f (ENNReal.ofReal p) μ to (∫⁻ ‖f‖ₑ^p)^(1/p) using eLpNorm_eq_lintegral_rpow_enorm.",
-      "startLine": 46,
-      "endLine": 56,
       "mathContext": "Bridge from eLpNorm API to lintegral form. Requires p > 0 as a real number."
     },
     {
       "id": "holder-elpnorm",
-      "title": "Hölder in eLpNorm Form for NormedField",
+      "title": "Part 2: Hölder in eLpNorm Form",
+      "startLine": 59,
+      "endLine": 87,
       "summary": "holder_normedField_eLpNorm: the main theorem. Applies bridge, nnnorm_mul factoring, and ENNReal Hölder.",
-      "startLine": 57,
-      "endLine": 85,
       "mathContext": "eLpNorm (f·g) 1 ≤ eLpNorm f p · eLpNorm g q for any NormedField 𝕜."
     },
     {
       "id": "product-membership",
-      "title": "Product Membership: fg ∈ L1",
+      "title": "Part 3: Product Membership in L1 — the Practical Consequence",
+      "startLine": 88,
+      "endLine": 108,
       "summary": "memLp_mul_of_memLp_ofReal: the practical Hölder consequence. f ∈ Lp and g ∈ Lq implies fg ∈ L1.",
-      "startLine": 86,
-      "endLine": 106,
       "mathContext": "The most useful form of Hölder's inequality for integration theory."
     },
     {
       "id": "specializations",
-      "title": "Real, Complex, and Cauchy-Schwarz Specializations",
+      "title": "Part 4: Real and Complex Specializations",
+      "startLine": 109,
+      "endLine": 138,
       "summary": "One-line corollaries: holder_real_eLpNorm, holder_complex_eLpNorm, cauchy_schwarz_complex_eLpNorm.",
-      "startLine": 107,
-      "endLine": 145,
       "mathContext": "Specializations to ℝ, ℂ, and the p=q=2 Cauchy-Schwarz case."
     },
     {
       "id": "verification",
-      "title": "Numerical Verification",
+      "title": "Part 5: Numerical Verification",
+      "startLine": 139,
+      "endLine": 151,
       "summary": "Checks: HolderConjugate 2 2 holds, ENNReal.ofReal 2 = 2.",
-      "startLine": 140,
-      "endLine": 145,
       "mathContext": "Quick sanity checks for the p=q=2 special case."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 152,
+      "endLine": 176,
+      "summary": "Closing docstring recapping the six results (bridge lemma, NormedField Hölder, L1 product membership, real/complex specializations, Cauchy-Schwarz at p=q=2) and the axiom-free / sorry-free status, then closes `namespace HolderELpNorm`.",
+      "mathContext": "Summary of the eLpNorm-form Hölder development; the $p=q=2$ case is the integral Cauchy-Schwarz inequality."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -94,76 +94,92 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring for Erdős Problem 1001 (limiting behavior of the counting function S(N,A,c) for Diophantine approximation by rationals with bounded denominator) and `namespace Erdos1001`.",
+      "mathContext": "Studies $\\lim_{N\\to\\infty} S(N,A,c)$, the density of reals approximable to order $A/y^c$ by fractions of denominator $\\le y$."
+    },
+    {
       "id": "approximation-set",
       "title": "The Approximation Set",
-      "summary": "Definition of isApproximable, approximationSet, and S(N,A,c)",
       "startLine": 32,
       "endLine": 50,
+      "summary": "Definition of isApproximable, approximationSet, and S(N,A,c)",
       "mathContext": "Formal definition: Definition of isApproximable, approximationSet, and S(N,A,c)"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "S bounds between 0 and 1, monotonicity in A and c",
       "startLine": 51,
-      "endLine": 71,
+      "endLine": 56,
+      "summary": "S bounds between 0 and 1, monotonicity in A and c",
       "mathContext": "Bound: S bounds between 0 and 1, monotonicity in A and c"
     },
     {
       "id": "limit-function",
       "title": "The Limit Function",
+      "startLine": 57,
+      "endLine": 96,
       "summary": "Definition of f(A,c) = 12A log(c)/π² and limitExists",
-      "startLine": 72,
-      "endLine": 85,
       "mathContext": "Formal definition: Definition of f(A,c) = 12A log(c)/π² and limitExists"
     },
     {
       "id": "est-result",
       "title": "Erdős-Szüsz-Turán Result (1958)",
+      "startLine": 97,
+      "endLine": 118,
       "summary": "Explicit formula in the EST regime",
-      "startLine": 86,
-      "endLine": 107,
       "mathContext": "Mathematical content: Explicit formula in the EST regime"
     },
     {
       "id": "boundedness",
       "title": "Boundedness Away from 0 and 1",
+      "startLine": 119,
+      "endLine": 124,
       "summary": "EST boundedness when min(A,c) > 10",
-      "startLine": 108,
-      "endLine": 117,
       "mathContext": "Bound: EST boundedness when min(A,c) > 10"
     },
     {
       "id": "kesten-sos",
       "title": "Kesten-Sós Result (1966)",
+      "startLine": 125,
+      "endLine": 147,
       "summary": "Limit exists for all valid A, c",
-      "startLine": 118,
-      "endLine": 140,
       "mathContext": "Mathematical content: Limit exists for all valid A, c"
     },
     {
       "id": "alternative-proofs",
       "title": "Alternative Proofs",
+      "startLine": 148,
+      "endLine": 162,
       "summary": "Boca (2008) and Xiong-Zaharescu (2006) approaches",
-      "startLine": 141,
-      "endLine": 158,
       "mathContext": "Mathematical content: Boca (2008) and Xiong-Zaharescu (2006) approaches"
     },
     {
       "id": "farey-connection",
       "title": "Connection to Farey Fractions",
-      "summary": "Why π² appears in the formula",
-      "startLine": 159,
+      "startLine": 163,
       "endLine": 177,
+      "summary": "Why π² appears in the formula",
       "mathContext": "Mathematical content: Why π² appears in the formula"
+    },
+    {
+      "id": "outside-est-regime",
+      "title": "Outside the EST Regime (Open Question oq-01)",
+      "startLine": 178,
+      "endLine": 219,
+      "summary": "The open-question content (oq-01): defines `estBoundary c = c/(1+c²)` with `estBoundary_pos`, the predicate `outsideESTRegime`, and `limit_in_est_regime` — characterizing where the Erdős-Szüsz-Turán explicit formula applies versus the regime that remains open.",
+      "mathContext": "Boundary $\\beta(c)=c/(1+c^2)$ separating the EST regime (explicit limit known) from the open regime for $\\lim S(N,A,c)$."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Problem status and main theorem erdos_1001",
-      "startLine": 176,
-      "endLine": 205,
-      "mathContext": "Verified: Problem status and main theorem erdos_1001"
+      "startLine": 220,
+      "endLine": 249,
+      "summary": "Closing docstring on problem status and the main theorem `erdos_1001`, which packages the established results; closes `namespace Erdos1001`.",
+      "mathContext": "Main statement $erdos\\_1001$ assembling the EST/Kesten-Sós results; the general off-regime limit is open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery `sections` for `Proofs/Erdos1001Problem.lean` (249 lines) had drifted:

- The **module header (lines 1–31) was uncovered**.
- The back half was shifted, and the **"Outside the EST Regime (Open Question oq-01)" section (178–219) was missing entirely** — it holds the oq-01 open-question content (`estBoundary`, `outsideESTRegime`, `limit_in_est_regime`).
- The **Summary range (176–205) was wrong**: the real Summary banner is at 221, so lines 206–249 were uncovered.

Rebuilt all sections **contiguously (1–249)**, aligned to the file's own `## ` doc-block banners: added a header section, the missing Outside-the-EST-Regime section, and snapped the Summary to its true range through end-of-file.

Counts (10 theorems / 12 defs / 2 axioms / 0 sorries / 249 lines) were already correct — **sections-only realignment**, no Lean changes. The two axioms (`erdos_szusz_turan`, `kesten_sos`) match `axiomCount = 2`.

## Test plan
- [x] Sections tile 1–249 contiguously with no gaps/overlaps and full coverage
- [x] Boundaries verified against the file's `## ` doc-block banners and declaration line numbers
- [x] `meta.json` re-parses as valid JSON; only the `sections` array changed