### PR TITLE
Enrich Sperner Simplicial Instance (OQ-05): scope/header annotation (5→6)

### DIFF
--- a/src/data/proofs/sperner-simplicial-instance-oq-05/annotations.json
+++ b/src/data/proofs/sperner-simplicial-instance-oq-05/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "oq05-header-scope",
+    "proofId": "sperner-simplicial-instance-oq-05",
+    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 85
+    },
+    "title": "Scope: Brute-Force Candidate C1, Not Scarf's Algorithm",
+    "content": "The header sets the honest scope of this file. It is Candidate C1 of the `sperner-simplicial-instance-oq-05` dossier: a `Decidable`-driven brute-force witness extractor for a panchromatic cell. Two caveats are essential for a reader: (1) this is **not** Scarf's algorithm — it enumerates all cells in $O(|T.\\text{Cell}|)$ rather than walking door-paths in $O(\\text{path length})$; the Scarf pivot is the separate Candidate C2; (2) it does **not** yet replace the `axiom scarf_approx_fixed_point` in `BrouwerFixedPointOQ04OQ04.lean`. The mathematical content is deliberately shallow: every step is forced by pre-existing `Triangulation.cellFintype` and `CellComplex.decidableIsPanchromatic` instances. The value is naming a computable witness `def` plus a totality theorem grounded in `Triangulation.sperner`. Imports `Proofs.SpernerSimplicialInstance`; opens `CellComplex Triangulation Finset`.",
+    "mathContext": "Sperner's lemma guarantees a panchromatic (fully-coloured) cell exists for any Sperner colouring; this file *extracts* one computably. Brute force $O(|T.\\text{Cell}|)$ vs. Scarf pivot $O(\\text{door-path length})$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "Scarf's algorithm",
+      "panchromatic cell",
+      "computable witness extraction",
+      "Brouwer fixed point"
+    ],
+    "prerequisites": [
+      "simplicial complexes",
+      "Sperner colouring",
+      "decidability in Lean"
+    ]
+  },
+  {
     "id": "oq05-def-finder",
     "proofId": "sperner-simplicial-instance-oq-05",
     "type": "definition",


### PR DESCRIPTION
## Enrichment: sperner-simplicial-instance-oq-05

Closes the only annotation coverage gap. The existing 5 annotations covered lines 86–185 (the code); lines 1–85 (copyright header, module docstring, imports, namespace) were unannotated.

### Change
- Added \`oq05-header-scope\` (lines 1–85, type \`context\`). Beyond describing the header, it surfaces the file's two essential honesty caveats inline for gallery readers:
  1. This is Candidate **C1**, a brute-force $O(|T.\text{Cell}|)$ extractor — **not** Scarf's $O(\text{door-path})$ pivot algorithm (that is C2).
  2. It does **not** yet replace \`axiom scarf_approx_fixed_point\` in \`BrouwerFixedPointOQ04OQ04.lean\`.

Counts unchanged; this is annotation-coverage only. Verified the uncovered region 1–85 is entirely docstring/imports (first \`def\` begins at line 86).