### PR TITLE
research(erdos-269): realign drifted gallery sections to file (11→12)

### DIFF
--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -95,92 +95,100 @@
   },
   "sections": [
     {
-      "id": "psmooth",
-      "title": "P-smooth Numbers",
-      "summary": "IsPSmooth definition, basic properties",
-      "startLine": 34,
-      "endLine": 73,
-      "mathContext": "$n$ is $P$-smooth if all prime factors of $n$ are in $P$. Example: $P = \\\\{2,3\\\\}$, smooth numbers are $\\\\{1, 2, 3, 4, 6, 8, 9, \\\\ldots\\\\}$."
+      "id": "header",
+      "title": "Header and Problem Statement",
+      "summary": "Docstring stating Erdős Problem #269: for a finite set P of ≥ 2 primes and {a_n} the P-smooth integers, is Σ_{n≥1} 1/[a_1,…,a_n] irrational? Records the status (OPEN for finite P, SOLVED for infinite P), `import Mathlib`, and the `Erdos269` namespace.",
+      "startLine": 1,
+      "endLine": 35,
+      "mathContext": "Source erdosproblems.com/269; Erdős (1974) Fibonacci Quarterly. The sum over partial LCMs converges (Lₙ grows exponentially); irrationality for finite P is the open question."
     },
     {
-      "id": "sequence",
-      "title": "The P-smooth Sequence",
-      "summary": "smoothSeq enumeration and properties",
-      "startLine": 74,
-      "endLine": 93,
-      "mathContext": "$(a_n)$: the $P$-smooth numbers in increasing order. $a_0 = 1, a_1 = \\\\min P, \\\\ldots$"
+      "id": "part-1-psmooth-numbers",
+      "title": "Part I: P-smooth Numbers",
+      "summary": "Defines `IsPSmooth P n` (n>0 with every prime divisor in P) and proves its closure properties: `one_isPSmooth`, `prime_isPSmooth`, `isPSmooth_mul`, and `pow_isPSmooth` (prime powers stay smooth).",
+      "startLine": 36,
+      "endLine": 92,
+      "mathContext": "P-smooth (P-friable) numbers form a multiplicative monoid; prime-power closure underlies the 'P infinite ⇒ sequence infinite' argument."
     },
     {
-      "id": "partial-lcm",
-      "title": "Partial LCM",
-      "summary": "L_n = [a_0,...,a_{n-1}] definition and properties",
-      "startLine": 94,
-      "endLine": 129,
-      "mathContext": "$L_n = \\\\text{lcm}(a_0, a_1, \\\\ldots, a_{n-1})$: partial LCM of the first $n$ smooth numbers."
+      "id": "part-2-smooth-sequence",
+      "title": "Part II: The Sequence of P-smooth Numbers",
+      "summary": "Defines `smoothSeq P := Nat.nth (IsPSmooth P)`, the strictly increasing enumeration of P-smooth integers, and proves `smoothSeq_zero` (the 0-th term is 1).",
+      "startLine": 93,
+      "endLine": 120,
+      "mathContext": "Uses Mathlib's `Nat.nth`/`Nat.count` machinery to enumerate the smooth set; a₀ = 1 since 1 is vacuously smooth and 0 is excluded."
     },
     {
-      "id": "series",
-      "title": "The Series",
-      "summary": "lcmSeries definition, convergence, positivity",
-      "startLine": 130,
-      "endLine": 152,
-      "mathContext": "$\\\\sum_{n=0}^\\\\infty 1/L_n$: converges (since $L_n$ grows super-exponentially). The sum is a well-defined positive real."
+      "id": "part-3-partial-lcm",
+      "title": "Part III: Partial LCM",
+      "summary": "Defines `partialLcm P n` = lcm of the first n smooth numbers and proves `partialLcm_zero`, `partialLcm_one`, `partialLcm_succ`, `partialLcm_dvd_succ` (divisibility-monotone), and `smoothSeq_dvd_partialLcm`.",
+      "startLine": 121,
+      "endLine": 158,
+      "mathContext": "Lₙ = [a₀,…,a_{n-1}] is a divisibility-increasing chain; each smooth term divides every later partial LCM."
     },
     {
-      "id": "main-conjecture",
-      "title": "The Main Conjecture (OPEN)",
-      "summary": "erdos_269 axiom for finite P",
-      "startLine": 153,
-      "endLine": 176,
-      "mathContext": "OPEN: $\\\\sum 1/L_n$ is irrational for all finite $P$ with $|P| \\\\geq 2$. Connects smooth number LCMs to irrationality."
+      "id": "part-4-the-series",
+      "title": "Part IV: The Series",
+      "summary": "Defines `lcmSeries P := ∑' n, 1/(partialLcm P n)`, the real-valued LCM series whose irrationality is in question.",
+      "startLine": 159,
+      "endLine": 170,
+      "mathContext": "S(P) = Σ_{n} 1/Lₙ converges absolutely because Lₙ grows at least exponentially."
     },
     {
-      "id": "infinite-case",
-      "title": "The Infinite Case (SOLVED)",
-      "summary": "erdos_269_infinite axiom",
-      "startLine": 177,
+      "id": "part-5-main-conjecture",
+      "title": "Part V: The Main Conjecture (OPEN)",
+      "summary": "States the open conjecture as `axiom erdos_269` (irrationality of lcmSeries for finite P with |P|≥2), defines the rationality predicate `isSeriesRational`, and proves the equivalence `erdos_269_equivalent`.",
+      "startLine": 171,
       "endLine": 193,
-      "mathContext": "When $P$ is the set of all primes: $L_n = \\\\text{lcm}(1,\\\\ldots,n)$ and $\\\\sum 1/\\\\text{lcm}(1,\\\\ldots,n)$ is known to be irrational."
+      "mathContext": "OPEN: Σ 1/Lₙ is irrational for every finite P with |P| ≥ 2. Encoded as an axiom; ¬rational ⇔ Irrational is definitional."
     },
     {
-      "id": "examples",
+      "id": "part-6-infinite-case",
+      "title": "Part VI: The Infinite Case (SOLVED)",
+      "summary": "States the solved infinite-P case as `axiom erdos_269_infinite`: when P is infinite the series is always irrational (Erdős's 'simple exercise').",
+      "startLine": 194,
+      "endLine": 207,
+      "mathContext": "Infinite P yields infinitely many distinct p-adic contribution levels, forcing irrationality; recorded here as a stated assumption."
+    },
+    {
+      "id": "part-7-examples",
       "title": "Part VII: Examples",
-      "summary": "P = {2,3} worked examples",
-      "startLine": 180,
-      "endLine": 195,
-      "mathContext": "$P = \\\\{2,3\\\\}$: smooth numbers 1,2,3,4,6,8,9,12,... LCMs: 1,2,6,12,12,24,..."
-    },
-    {
-      "id": "padic",
-      "title": "Part VIII: Structural Properties",
-      "summary": "P-adic valuation analysis",
-      "startLine": 196,
-      "endLine": 209,
-      "mathContext": "$p$-adic valuation $v_p(L_n) = \\\\max v_p(a_i)$ for $i < n$. Controls the growth of $L_n$."
-    },
-    {
-      "id": "difficulty",
-      "title": "Part IX: Why It's Hard",
-      "summary": "Analysis of the finite P difficulty",
-      "startLine": 210,
+      "summary": "Worked example P = {2,3}: defines `twoThreeSmooth` and verifies `twoThreeSmooth_card` (two primes) and `twoThreeSmooth_prime` (2 and 3 are prime).",
+      "startLine": 208,
       "endLine": 223,
-      "mathContext": "For finite $P$: the structure of $L_n$ depends on how primes in $P$ interleave. Harder than the all-primes case."
+      "mathContext": "{2,3} generates the 3-smooth numbers 1,2,3,4,6,8,9,…; a concrete instance satisfying the |P|≥2 hypothesis."
     },
     {
-      "id": "partial-result",
-      "title": "Part X: Known Partial Result",
-      "summary": "Distinct terms case is solved (distinctLcmTerms, erdos_269_distinct axiom)",
+      "id": "part-8-structural-properties",
+      "title": "Part VIII: Structural Properties",
+      "summary": "Introduces the p-adic valuation viewpoint and defines `lcmPadicVal p n P := padicValNat p (partialLcm P n)`.",
       "startLine": 224,
-      "endLine": 241,
-      "mathContext": "Distinct terms case solved: when all $L_n$ are distinct, irrationality follows from standard criteria."
+      "endLine": 237,
+      "mathContext": "v_p(Lₙ) increases in discrete jumps as new powers of p enter the smooth sequence, the structure governing the series' growth."
     },
     {
-      "id": "summary",
+      "id": "part-9-why-its-hard",
+      "title": "Part IX: Why It's Hard",
+      "summary": "Expository comment on the difficulty: for finite P the partial LCMs eventually stabilize their prime structure, and irrationality hinges on the exact pattern of when Lₙ increases versus repeats.",
+      "startLine": 238,
+      "endLine": 251,
+      "mathContext": "The obstruction is showing the per-prime contributions never conspire into a rational sum, requiring control of the Lₙ = L_{n-1} repetition pattern."
+    },
+    {
+      "id": "part-10-known-partial-result",
+      "title": "Part X: Known Partial Result",
+      "summary": "The duplicates-removed result: defines `distinctLcmTerms` and `distinctLcmSeries`, and states `axiom erdos_269_distinct` that the series over distinct LCM values is irrational for finite P.",
+      "startLine": 252,
+      "endLine": 269,
+      "mathContext": "Erdős's known result: dropping terms where Lₙ = L_{n-1} (the duplicate summands) yields a provably irrational series."
+    },
+    {
+      "id": "part-11-summary",
       "title": "Part XI: Summary",
-      "summary": "erdos_269_summary theorem, erdos_269_conjecture restating the main open problem",
-      "startLine": 242,
-      "endLine": 275,
-      "mathContext": "OPEN for finite $P$ with $|P| \\\\geq 2$. Solved for $P$ = all primes. Partial: distinct-LCM case."
+      "summary": "Summary docstring of the known/open status, `erdos_269_summary` packaging the infinite and distinct-case results, and `erdos_269_conjecture` restating the open finite-P irrationality from the axiom.",
+      "startLine": 270,
+      "endLine": 303,
+      "mathContext": "Infinite P and finite-P-with-duplicates-removed are solved; finite P with duplicates remains open. The repetition of LCM values is the central challenge."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Realigns the gallery section ranges for **erdos-269** (LCM Series Irrationality) to the current Lean source `Proofs/Erdos269Problem.lean` (303 lines).

The 11 stored section ranges had drifted early by 2–30 lines:
- "P-smooth Numbers" mapped to 34–73, but the `Part I` banner is at line 36
- The drift left the **header (1–35)** and **tail (276–303)** entirely uncovered
- It produced a real **overlap**: "The Infinite Case" (177–193) vs "Part VII: Examples" (180–195)

## Changes
- Rebuilt **12 contiguous sections** (11→12) snapped to the file's 11 `/- ## Part N -/` banners, plus a dedicated **Header** section.
- Refreshed each section's summary/mathContext to match the actual declarations in range.
- **No count changes** — counts were already correct and are untouched: 3 axioms, 15 theorems, 9 definitions, 0 sorries.

## Verification
- New ranges are contiguous and complete: 1–35, 36–92, 93–120, 121–158, 159–170, 171–193, 194–207, 208–223, 224–237, 238–251, 252–269, 270–303.
- Diff is scoped to the `sections` array only; `leanFile` counts untouched.
- Build-free metadata change (no Lean rebuild required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)