### PR TITLE
research(platonic-solids-oq-01): realign drifted gallery sections to file (9→15)

### DIFF
--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -78,76 +78,124 @@
   },
   "sections": [
     {
-      "id": "zsqrt5-arithmetic",
-      "title": "Exact Arithmetic in Z[sqrt(5)]",
-      "startLine": 42,
-      "endLine": 84,
-      "summary": "Definition of Z[sqrt(5)] ring for exact computation of Schlaefli determinants involving the golden ratio.",
+      "id": "header-overview",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring extending the Platonic solids classification (Wiedijk #50) to 4D and higher: 6 regular polytopes in 4D, 3 in n >= 5. States the Schläfli-symbol / Coxeter-Schläfli determinant criterion, lists the 6 regular 4-polytopes and 3 infinite families, references, imports, and the RegularPolytopes namespace.",
+      "mathContext": "A regular n-polytope has a Schläfli symbol {p_1,...,p_{n-1}}; validity requires each consecutive pair to be a valid lower-dimensional symbol and the Coxeter-Schläfli determinant (angle-defect condition) to be positive."
+    },
+    {
+      "id": "part-1-zsqrt5-arithmetic",
+      "title": "PART 1: Exact Arithmetic in Z[sqrt(5)]",
+      "startLine": 44,
+      "endLine": 85,
+      "summary": "The QSqrt5 structure (a + b*sqrt(5), a,b in Z) with mul, sub, scale, and isPositive for exact computation of Schläfli determinants involving the golden ratio.",
       "mathContext": "The ring Z[sqrt(5)] = {a + b*sqrt(5) : a,b in Z} enables exact arithmetic with cos^2(pi/5) = (3+sqrt(5))/8. Positivity checking reduces to integer comparison: a + b*sqrt(5) > 0 iff a^2 > 5b^2 (when signs differ)."
     },
     {
-      "id": "trig-values",
-      "title": "Trigonometric Values",
+      "id": "part-2-trig-values",
+      "title": "PART 2: Trigonometric Values (Scaled by 8)",
       "startLine": 86,
-      "endLine": 123,
-      "summary": "Exact values of sin^2(pi/n) and cos^2(pi/n) for n in {3,4,5}, scaled by 8.",
+      "endLine": 124,
+      "summary": "sinSqScaled and cosSqScaled give 8*sin^2(pi/n) and 8*cos^2(pi/n) as QSqrt5 elements for n in {3,4,5}, with trig_identity_3/4/5 confirming the stored values.",
       "mathContext": "sin^2(pi/3) = 3/4, sin^2(pi/4) = 1/2, sin^2(pi/5) = (5-sqrt(5))/8. These are the only values needed since the Platonic solids have p,q in {3,4,5}."
     },
     {
-      "id": "3d-classification",
-      "title": "3D Classification (Recalled)",
+      "id": "part-3-3d-constraint",
+      "title": "PART 3: The 3D Constraint (Recalled)",
       "startLine": 125,
-      "endLine": 141,
-      "summary": "The 5 valid Schlaefli pairs for Platonic solids, used as building blocks for 4D.",
+      "endLine": 142,
+      "summary": "validPairs3D (the 5 Platonic pairs), the satisfies3D predicate with its Decidable instance, and validPairs3D_card = 5, used as building blocks for 4D.",
       "mathContext": "The 5 Platonic solids correspond to pairs (p,q) with p,q >= 3 and (p-2)(q-2) < 4."
     },
     {
-      "id": "schlaefli-determinant",
-      "title": "The 4D Schlaefli Determinant",
+      "id": "part-4-4d-determinant",
+      "title": "PART 4: The 4D Schläfli Determinant",
       "startLine": 143,
-      "endLine": 242,
-      "summary": "Definition and computation of the Coxeter-Schlaefli determinant for 4D symbols, with explicit verification of all 11 candidates.",
-      "mathContext": "Delta_4(p,q,r) = sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) is the Gram matrix determinant. Computed exactly in Z[sqrt(5)] for all candidates, yielding 6 positive (valid polytopes), 4 negative (hyperbolic), and 1 zero (Euclidean tiling {4,3,4})."
+      "endLine": 172,
+      "summary": "Defines schlaefliDet4 computing 64*Delta_4(p,q,r) in Z[sqrt(5)], and schlaefli4Positive testing its sign.",
+      "mathContext": "Delta_4(p,q,r) = sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) is the determinant of the 4x4 Coxeter Gram matrix; the regular 4-polytope exists iff Delta_4 > 0."
     },
     {
-      "id": "4d-polytopes",
-      "title": "The Six Regular 4-Polytopes",
+      "id": "part-5-4d-classification",
+      "title": "PART 5: The 4D Classification",
+      "startLine": 173,
+      "endLine": 243,
+      "summary": "combinatoriallyValid4D, the 11 candidates4D and 6 validTriples4D, the count/subset/positivity theorems (valid4D_count, valid4D_det_positive, invalid4D_det_nonpositive), and explicit det4 values for every candidate.",
+      "mathContext": "Computed exactly in Z[sqrt(5)] for all 11 candidates: 6 positive (valid polytopes), 4 negative (hyperbolic), and 1 zero (Euclidean tiling {4,3,4})."
+    },
+    {
+      "id": "part-6-six-4-polytopes",
+      "title": "PART 6: The Six Regular 4-Polytopes",
       "startLine": 244,
-      "endLine": 302,
-      "summary": "Combinatorial data (V,E,F,C) for all 6 regular 4-polytopes with Euler characteristic verification.",
-      "mathContext": "For 4-polytopes, the Euler relation is V - E + F - C = 0 (equivalently V + F = E + C in naturals). All six polytopes satisfy this relation."
+      "endLine": 281,
+      "summary": "The Polytope4Data structure (with the 4D Euler field) and the six instances: 5-cell, 8-cell, 16-cell, 24-cell, 120-cell, 600-cell, each with its V,E,F,C data.",
+      "mathContext": "Each regular 4-polytope is recorded by its Schläfli symbol and face counts (V,E,F,C); the structure enforces V + F = E + C at construction."
     },
     {
-      "id": "duality",
-      "title": "Duality of 4-Polytopes",
+      "id": "part-7-euler-verification",
+      "title": "PART 7: Euler Characteristic Verification",
+      "startLine": 282,
+      "endLine": 303,
+      "summary": "all_4polytopes_euler: all six 4-polytopes satisfy the 4D Euler relation V - E + F - C = 0.",
+      "mathContext": "For a convex 4-polytope the Euler characteristic is chi = V - E + F - C = 0 (the generalized Euler formula in even dimensions)."
+    },
+    {
+      "id": "part-8-duality",
+      "title": "PART 8: Duality of 4-Polytopes",
       "startLine": 304,
-      "endLine": 341,
-      "summary": "Duality relationships: dual of {p,q,r} is {r,q,p}. Self-dual: 5-cell, 24-cell. Dual pairs: 8-cell/16-cell, 120-cell/600-cell.",
+      "endLine": 342,
+      "summary": "dual4D reversing {p,q,r} to {r,q,p}, the self-dual/dual-pair theorems (5-cell, 24-cell self-dual; 8-cell/16-cell, 120-cell/600-cell pairs), involutivity, and dual4D_preserves_validity.",
       "mathContext": "The dual of a regular polytope {p,q,r} is {r,q,p}, which exchanges vertices with cells and edges with faces."
     },
     {
-      "id": "5d-classification",
-      "title": "The 5D Classification",
+      "id": "part-9-5d-classification",
+      "title": "PART 9: The 5D Classification",
       "startLine": 343,
-      "endLine": 416,
-      "summary": "Classification of regular 5-polytopes: exactly 3 (simplex, hypercube, cross-polytope). Uses tridiagonal determinant recurrence.",
-      "mathContext": "The 5D Schlaefli determinant Delta_5(p,q,r,s) = Delta_4(p,q,r) - cos^2(pi/s)*Delta_3(p,q) eliminates all exceptional 4D symbols. The 120-cell and 600-cell extensions fail because 64-32*sqrt(5) < 0."
+      "endLine": 417,
+      "summary": "det3Scaled, schlaefliDet5 (tridiagonal recurrence) and schlaefli5Positive, candidates5D, validQuads5D, the count/positivity theorems, and explicit det5 values; exactly 3 regular 5-polytopes.",
+      "mathContext": "Delta_5(p,q,r,s) = Delta_4(p,q,r) - cos^2(pi/s)*Delta_3(p,q) eliminates all exceptional 4D symbols; the 120-cell/600-cell extensions fail because 64 - 32*sqrt(5) < 0."
     },
     {
-      "id": "stabilization",
-      "title": "High-Dimensional Stabilization",
+      "id": "part-10-stabilization",
+      "title": "PART 10: High-Dimensional Stabilization",
       "startLine": 418,
-      "endLine": 505,
-      "summary": "The three infinite families (simplex, hypercube, cross-polytope) and verification that no other polytopes exist in dimensions 5 and 6.",
-      "mathContext": "The simplex {3,...,3} has determinant (n+1)/2^n > 0. The hypercube {4,3,...,3} and cross-polytope {3,...,3,4} have determinant 1/2^(n-1) > 0. The composite {4,3,...,3,4} always has determinant 0 (Euclidean). By combinatorial constraint, no other symbol survives beyond 4D."
+      "endLine": 466,
+      "summary": "The RegularFamily inductive (simplex, hypercube, crossPoly), familySymbol producing the Schläfli list per dimension, and the symbol theorems for n = 5,6.",
+      "mathContext": "The simplex {3,...,3} has determinant (n+1)/2^n > 0; the hypercube {4,3,...,3} and cross-polytope {3,...,3,4} have determinant 1/2^(n-1) > 0; the composite {4,3,...,3,4} always has determinant 0 (Euclidean)."
     },
     {
-      "id": "main-theorems",
-      "title": "Main Classification Theorems",
+      "id": "part-11-6d-verification",
+      "title": "PART 11: The 6D Verification (First Inductive Step)",
+      "startLine": 467,
+      "endLine": 506,
+      "summary": "schlaefliDet6 and schlaefli6Positive, with det6 positivity for {3,3,3,3,3}, {4,3,3,3,3}, {3,3,3,3,4} and zero for the Euclidean {4,3,3,3,4}, demonstrating the stabilization pattern.",
+      "mathContext": "For 6D {p,q,r,s,t}, both {p,q,r,s} and {q,r,s,t} must be valid 5D symbols; exhaustive enumeration yields only 4 candidates, of which 3 are valid and {4,3,3,3,4} is Euclidean."
+    },
+    {
+      "id": "part-12-main-theorems",
+      "title": "PART 12: Main Classification Theorems",
       "startLine": 507,
+      "endLine": 567,
+      "summary": "The headline results: regular_4polytope_classification (exactly 6), regular_5polytope_classification (exactly 3), and stabilization_from_5D (only simplex/hypercube/cross-polytope persist).",
+      "mathContext": "A triple (p,q,r) with (p,q),(q,r) valid Platonic symbols gives a regular 4-polytope iff the Coxeter-Schläfli determinant is positive; the exceptional 4D polytopes vanish in 5D because their determinant becomes 64 - 32*sqrt(5) < 0."
+    },
+    {
+      "id": "part-13-3d-connection",
+      "title": "PART 13: Connection to the 3D Classification",
+      "startLine": 568,
+      "endLine": 584,
+      "summary": "platonic_connection (validPairs3D are exactly the Platonic symbols) and dimension_count_pattern (5 in 3D, 6 in 4D, 3 in 5D).",
+      "mathContext": "Dimension 3 has 5 regular polytopes, dimension 4 has 6 (the maximum), and dimensions >= 5 have 3."
+    },
+    {
+      "id": "part-14-additional-properties",
+      "title": "PART 14: Additional Properties",
+      "startLine": 585,
       "endLine": 628,
-      "summary": "The three main results: 6 regular 4-polytopes, 3 regular 5-polytopes, and the stabilization pattern.",
-      "mathContext": "Dimension 3: 5 polytopes. Dimension 4: 6 polytopes (maximum across all dimensions). Dimension >= 5: exactly 3 polytopes. The 24-cell, 120-cell, and 600-cell are exclusive to dimension 4."
+      "summary": "twentyFourCell_is_4D_only, infinite_families_extend_to_5D, exceptional_4D_polytopes, and the dual face-count theorems (8-cell/16-cell, 120-cell/600-cell), plus the namespace close and exported #check results.",
+      "mathContext": "The 24-cell {3,4,3} is the only regular polytope unique to a single dimension; dual polytopes swap V<->C and E<->F."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery meta for **platonic-solids-oq-01** (Classification of Regular Polytopes in Higher Dimensions, `Proofs/PlatonicSolidsOQ01.lean`, 628 lines) carried only **9 sections**, while the Lean file is organized into **14 `-- PART` banners**.

The drift:
- The module header (lines 1–43: docstring, the 6/3 classification statement, references, imports) was uncovered.
- PARTs **5** (The 4D Classification), **7** (Euler Characteristic Verification), **11** (The 6D Verification), **13** (Connection to the 3D Classification), and **14** (Additional Properties) were lumped inside larger sections.

## Changes

- Rebuilt **15 contiguous sections** (header + 14 PARTs) tiling lines **1–628**, each aligned to its `-- PART N` box banner, with `summary` and `mathContext` reflecting the actual declarations in range.
- Counts were already correct and are **untouched**: 0 axioms, 53 theorems, 31 definitions, 0 sorries.

Build-free change (gallery metadata only).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Every section retains its `mathContext` field
- [x] Sections tile the file contiguously from line 1 to 628 with no gaps or overlaps
- [x] Section ranges verified against `-- PART` banner positions in the Lean source