### PR TITLE
research(erdos-232): realign drifted gallery section ranges to file (12→13)

### DIFF
--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -91,99 +91,107 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and Problem Statement",
+      "summary": "File header and problem statement for Erdős #232: estimating $m_1 = \\sup \\overline{\\delta}(A)$ over measurable unit-distance-free sets $A \\subseteq \\mathbb{R}^2$, where $\\overline{\\delta}$ is asymptotic upper density. Records the affirmative answer to \"is $m_1 \\leq 1/4$?\" — Ambrus–Csiszárik–Matolcsi–Varga–Zsámboki (2023) proved $m_1 \\leq 0.247$ — the historical bounds (Moser, hexagonal lattice, Croft 1967), imports, and the `Erdos232` namespace.",
+      "startLine": 1,
+      "endLine": 47,
+      "mathContext": "File header and problem statement for Erdős #232: estimating $m_1 = \\sup \\overline{\\delta}(A)$ over measurable unit-distance-free sets $A \\subseteq \\mathbb{R}^2$, where $\\overline{\\delta}$ is asymptotic upper density. Records the affirmative answer to \"is $m_1 \\leq 1/4$?\" — Ambrus–Csiszárik–Matolcsi–Varga–Zsámboki (2023) proved $m_1 \\leq 0.247$ — the historical bounds (Moser, hexagonal lattice, Croft 1967), imports, and the `Erdos232` namespace."
+    },
+    {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "Defines `euclideanDist` as a wrapper around Mathlib's `dist` for $\\mathbb{R}^2$, and `IsUnitDistance` as the predicate that two points have distance exactly 1.",
-      "startLine": 46,
-      "endLine": 63,
+      "startLine": 48,
+      "endLine": 65,
       "mathContext": "Formal definition: Defines `euclideanDist` as a wrapper around Mathlib's `dist` for $\\mathbb{R}^2$, and `IsUnitDistance` as the predicate that two points have distance exactly 1."
     },
     {
       "id": "unit-distance-free",
       "title": "Unit-Distance Avoiding Sets",
       "summary": "Introduces two equivalent definitions of unit-distance-free sets (`IsUnitDistanceFree` and `IsUnitDistanceFree'`) and proves their equivalence via `unitDistanceFree_iff` using contraposition.",
-      "startLine": 64,
-      "endLine": 92,
+      "startLine": 66,
+      "endLine": 94,
       "mathContext": "Formal definition: Introduces two equivalent definitions of unit-distance-free sets (`IsUnitDistanceFree` and `IsUnitDistanceFree'`) and proves their equivalence via `unitDistanceFree_iff` using contraposition."
     },
     {
       "id": "balls-measure",
       "title": "Balls and Lebesgue Measure",
       "summary": "Defines `ballR R` as the closed ball of radius $R$ at the origin and axiomatizes the area formula $\\lambda(B_R) = \\pi R^2$.",
-      "startLine": 93,
-      "endLine": 110,
+      "startLine": 95,
+      "endLine": 120,
       "mathContext": "Defines `ballR R` as the closed ball of radius $R$ at the origin and axiomatizes the area formula $\\lambda(B_R) = \\$\\pi$ R^2$."
     },
     {
       "id": "upper-density",
       "title": "Upper Density",
       "summary": "Defines the asymptotic upper density $\\overline{\\delta}(A) = \\limsup_{R \\to \\infty} \\lambda(A \\cap B_R)/\\lambda(B_R)$ with a placeholder implementation, and axiomatizes its boundedness ($[0,1]$) and monotonicity.",
-      "startLine": 111,
-      "endLine": 136,
+      "startLine": 121,
+      "endLine": 141,
       "mathContext": "Defines the asymptotic upper density $\\overline{\\delta}(A) = \\limsup_{R \\to \\infty} \\lambda(A \\cap B_R)/\\lambda(B_R)$ with a placeholder implementation, and axiomatizes its boundedness ($[0,1]$) and monotonicity."
     },
     {
       "id": "max-density",
       "title": "Maximum Density m_1",
       "summary": "Defines $m_1 = \\sup\\{\\overline{\\delta}(A) : A \\text{ unit-distance-free}\\}$ using Mathlib's `sSup` and axiomatizes $0 \\leq m_1 \\leq 1$.",
-      "startLine": 137,
-      "endLine": 152,
+      "startLine": 142,
+      "endLine": 155,
       "mathContext": "Defines $m_1 = \\sup\\{\\overline{\\$\\delta$}(A) : A \\text{ unit-distance-free}\\}$ using Mathlib's `sSup` and axiomatizes $0 \\leq m_1 \\leq 1$."
     },
     {
       "id": "trivial-bound",
       "title": "Trivial Upper Bound",
       "summary": "Axiomatizes the translation argument giving $m_1 \\leq 1/2$ and formalizes the key lemma `translation_disjoint`: $A \\cap (A + u) = \\emptyset$ for unit $u$.",
-      "startLine": 153,
-      "endLine": 175,
+      "startLine": 156,
+      "endLine": 183,
       "mathContext": "Axiomatized: Axiomatizes the translation argument giving $m_1 \\leq 1/2$ and formalizes the key lemma `translation_disjoint`: $A \\cap (A + u) = \\emptyset$ for unit $u$."
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds (Constructions)",
       "summary": "Axiomatizes the hexagonal lattice lower bound $m_1 \\geq \\pi/(8\\sqrt{3}) \\approx 0.2267$ and Croft's refinement $m_1 \\geq 0.22936$ from 1967.",
-      "startLine": 176,
-      "endLine": 194,
+      "startLine": 184,
+      "endLine": 199,
       "mathContext": "Axiomatizes the hexagonal lattice lower bound $m_1 \\geq \\$\\pi$/(8\\sqrt{3}) \\approx 0.2267$ and Croft's refinement $m_1 \\geq 0.22936$ from 1967."
     },
     {
       "id": "solution",
       "title": "The Solution",
       "summary": "Axiomatizes the Ambrus et al. (2023) upper bound $m_1 \\leq 0.247$ and derives the main result $m_1 < 1/4$ via `calc` with `norm_num`, plus the weak bound $m_1 \\leq 1/4$ via `linarith`.",
-      "startLine": 195,
-      "endLine": 228,
+      "startLine": 200,
+      "endLine": 233,
       "mathContext": "Axiomatized: Axiomatizes the Ambrus et al. (2023) upper bound $m_1 \\leq 0.247$ and derives the main result $m_1 < 1/4$ via `calc` with `norm_num`, plus the weak bound $m_1 \\leq 1/4$ via `linarith`."
     },
     {
       "id": "bounds-summary",
       "title": "Current Bounds Summary",
       "summary": "Combines the lower and upper bounds into `current_bounds`: $0.22936 \\leq m_1 \\leq 0.247$, and computes the explicit gap $0.247 - 0.22936 = 0.01764$ via `norm_num`.",
-      "startLine": 229,
-      "endLine": 245,
+      "startLine": 234,
+      "endLine": 250,
       "mathContext": "Bound: Combines the lower and upper bounds into `current_bounds`: $0.22936 \\leq m_1 \\leq 0.247$, and computes the explicit gap $0.247 - 0.22936 = 0.01764$ via `norm_num`."
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality).",
-      "startLine": 246,
-      "endLine": 293,
+      "startLine": 251,
+      "endLine": 291,
       "mathContext": "Verified: Proves the empty set and singletons are unit-distance-free (by vacuity and uniqueness) and that open balls of radius $1/2$ are unit-distance-free (via the triangle inequality)."
     },
     {
       "id": "chromatic-connection",
       "title": "Connection to Chromatic Number",
       "summary": "Defines the unit distance graph adjacency and proves unit-distance-free sets are independent sets. Axiomatizes $4 \\leq \\chi(\\mathbb{R}^2) \\leq 7$ with $m_1 \\leq 1/\\chi$, connecting the density problem to the Hadwiger-Nelson problem.",
-      "startLine": 276,
-      "endLine": 306,
+      "startLine": 292,
+      "endLine": 319,
       "mathContext": "Defines the unit distance graph adjacency and proves unit-distance-free sets are independent sets. Axiomatizes $4 \\leq \\chi(\\mathbb{R}^2) \\leq 7$ with $m_1 \\leq 1/\\chi$, connecting the density problem to the Hadwiger-Nelson problem."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Packages all main results into `erdos_232_summary`: the affirmative answer $m_1 \\leq 1/4$ together with the precise bounds $0.22936 \\leq m_1 \\leq 0.247$.",
-      "startLine": 307,
-      "endLine": 333,
+      "startLine": 320,
+      "endLine": 346,
       "mathContext": "Bound: Packages all main results into `erdos_232_summary`: the affirmative answer $m_1 \\leq 1/4$ together with the precise bounds $0.22936 \\leq m_1 \\leq 0.247$."
     }
   ],


### PR DESCRIPTION
## Summary
- The `erdos-232` gallery section ranges had drifted from `Proofs/Erdos232Problem.lean`: the file header / problem statement (lines 1-47) was uncovered, the **Examples** (246-293) and **Connection to Chromatic Number** (276-306) sections overlapped, and several ranges were offset from their `## Part` banners.
- Realigned all 12 section ranges to their `## Part` banner boundaries and added an **Overview and Problem Statement** section, yielding **13 contiguous sections** covering the full 346-line file 1:1.

## Verification
- Section titles, summaries, and `mathContext` preserved verbatim — only `startLine`/`endLine` changed (plus the new overview).
- Counts unchanged and pre-correct: 12 theorems, 8 definitions, 2 axioms, 0 sorries, 346 lines.
- Sections validated contiguous (1..346, no gaps or overlaps).
- Build-free change (gallery metadata only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)