### PR TITLE
research(erdos-73): realign drifted gallery sections to full file (10→12)

### DIFF
--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -101,84 +101,100 @@
   },
   "sections": [
     {
+      "id": "problem-statement",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "File header for Erdős Problem #73 (SOLVED, Reed 1999): if every n-vertex subgraph of G has an independent set of size ≥ (n−k)/2, must G be a bipartite graph plus O_k(1) vertices? Records the answer (YES), the k=0 odd-cycle argument, Reed's \"Mangoes and Blueberries\" reference, and imports SimpleGraph machinery.",
+      "mathContext": "The k-independence condition $\\alpha(H)\\ge \\frac{|V(H)|-k}{2}$ for all subgraphs $H$ is a near-bipartiteness hypothesis. Reed (Combinatorica 1999) proved it forces $G$ to be bipartite after deleting at most $f(k)$ vertices, with $f(k)$ independent of $|V(G)|$."
+    },
+    {
       "id": "independent-sets",
-      "title": "Independent Sets and $\\alpha(G)$",
+      "title": "Part I: Independent Sets",
       "startLine": 39,
       "endLine": 59,
-      "summary": "Defines `IsIndependentSet` and `independenceNumber` $\\alpha(G)$. Proves basic properties: empty set and singletons are independent.",
-      "mathContext": "Defines `IsIndependentSet` and `independenceNumber` $\\$\\alpha$(G)$. Proves basic properties: empty set and singletons are independent."
+      "summary": "Defines IsIndependentSet (no edges inside S) and the independence number α(G). Proves exists_independent_set (∅ is independent) and singleton_independent.",
+      "mathContext": "$\\alpha(G)=\\max\\{|S| : S \\text{ independent}\\}$ is the size of the largest edge-free vertex subset; trivially $\\alpha(G)\\ge 1$ for nonempty $G$."
     },
     {
       "id": "independence-condition",
-      "title": "The $k$-Independence Condition",
+      "title": "Part II: The Independence Condition",
       "startLine": 60,
       "endLine": 71,
-      "summary": "Defines `satisfiesIndependenceCondition G k`: $\\alpha(G[S]) \\ge (|S| - k)/2$ for all $S$. The $k = 0$ case is `satisfiesStrictCondition`.",
-      "mathContext": "Defines `satisfiesIndependenceCondition G k`: $\\$\\alpha$(G[S]) \\ge (|S| - k)/2$ for all $S$. The $k = 0$ case is `satisfiesStrictCondition`."
+      "summary": "Defines satisfiesIndependenceCondition (every induced subgraph on |S| vertices has an independent set I with 2|I| ≥ |S| − k) and the k=0 specialization satisfiesStrictCondition.",
+      "mathContext": "The hypothesis $\\forall S\\,\\exists I\\subseteq S$ independent with $2|I|\\ge |S|-k$ is the formal version of \"every subgraph has independence number at least $(n-k)/2$\"."
     },
     {
-      "id": "bipartite",
-      "title": "Bipartite Graphs and Odd Cycles",
+      "id": "bipartite-graphs",
+      "title": "Part III: Bipartite Graphs",
       "startLine": 72,
-      "endLine": 87,
-      "summary": "Defines `IsBipartite` via vertex partition and `hasNoOddCycle`. Axiomatizes the classical equivalence $G$ bipartite $\\iff$ no odd cycles.",
-      "mathContext": "Formal definition: Defines `IsBipartite` via vertex partition and `hasNoOddCycle`. Axiomatizes the classical equivalence $G$ bipartite $\\iff$ no odd cycles."
+      "endLine": 84,
+      "summary": "Defines IsBipartite (vertex set splits into two independent sets) and hasNoOddCycle, noting the classical characterization that bipartite ⇔ no odd cycle.",
+      "mathContext": "A graph is bipartite iff it contains no odd cycle; bipartiteness is the $k=0$, deletion-free target of the structural theorem."
     },
     {
-      "id": "trivial-case",
-      "title": "The Trivial $k = 0$ Case",
-      "startLine": 88,
-      "endLine": 114,
-      "summary": "Proves $2m < 2m+1$ (odd cycles violate strict condition). `trivial_case` is proved later via delegation to `strict_implies_bipartite`.",
-      "mathContext": "Proves $2m < 2m+1$ (odd cycles violate strict condition). `trivial_case` is proved later via delegation to `strict_implies_bipartite`."
+      "id": "trivial-k0-case",
+      "title": "Part IV: The Trivial k=0 Case",
+      "startLine": 85,
+      "endLine": 92,
+      "summary": "States odd_cycle_violates_strict: an odd cycle on 2m+1 vertices has independence number m, so 2m < 2m+1, violating the k=0 condition (the combinatorial heart of the trivial case).",
+      "mathContext": "An odd cycle $C_{2m+1}$ has $\\alpha=m<\\frac{2m+1}{2}$, so it cannot satisfy the strict ($k=0$) condition — hence a strict-condition graph is odd-cycle-free, i.e. bipartite."
     },
     {
       "id": "almost-bipartite",
-      "title": "Almost Bipartite Structure",
-      "startLine": 115,
-      "endLine": 130,
-      "summary": "Defines `isAlmostBipartite G bound` (remove $\\le$ bound vertices for bipartiteness) and `bipartiteDeficiency` (minimum such bound).",
-      "mathContext": "Formal definition: Defines `isAlmostBipartite G bound` (remove $\\le$ bound vertices for bipartiteness) and `bipartiteDeficiency` (minimum such bound)."
+      "title": "Part V: Almost Bipartite Structure",
+      "startLine": 93,
+      "endLine": 132,
+      "summary": "Defines isAlmostBipartite (bipartite after deleting ≤ bound vertices) and bipartiteDeficiency (the minimum such deletion). Proves bipartite_deficiency_zero by transferring a bipartition through the induced-subgraph-on-univ identification.",
+      "mathContext": "$G$ is $b$-almost-bipartite if deleting some $S$ with $|S|\\le b$ yields a bipartite graph; the bipartite deficiency is the least such $b$, equal to $0$ exactly when $G$ is already bipartite."
     },
     {
       "id": "reed-theorem",
-      "title": "Reed's Theorem: $k$-Independence $\\Rightarrow$ Almost Bipartite",
-      "startLine": 131,
-      "endLine": 152,
-      "summary": "Axiomatizes `reed_bound` and `reed_theorem`. Proves `erdos_73_solved` by unpacking the axiom into existential form.",
-      "mathContext": "Verified: Axiomatizes `reed_bound` and `reed_theorem`. Proves `erdos_73_solved` by unpacking the axiom into existential form."
+      "title": "Part VI: Reed's Theorem",
+      "startLine": 133,
+      "endLine": 154,
+      "summary": "States Reed's theorem (1999) as axioms reed_bound : ℕ → ℕ and reed_theorem (the k-independence condition implies f(k)-almost-bipartite). Derives erdos_73_solved as the explicit conclusion.",
+      "mathContext": "Reed's theorem: there is $f:\\mathbb{N}\\to\\mathbb{N}$ with the k-independence condition $\\Rightarrow$ deleting $\\le f(k)$ vertices makes $G$ bipartite, $f(k)$ depending only on $k$ — the affirmative answer to #73."
     },
     {
       "id": "special-cases",
-      "title": "Special Case $k = 0$",
-      "startLine": 153,
-      "endLine": 169,
-      "summary": "Axiomatizes $f(0) = 0$ and fully proves `strict_implies_bipartite` and `trivial_case` via Reed's theorem for $k=0$.",
-      "mathContext": "Verified: Axiomatizes $f(0) = 0$ and fully proves `strict_implies_bipartite` and `trivial_case` — no sorries remain."
+      "title": "Part VII: Special Cases",
+      "startLine": 155,
+      "endLine": 207,
+      "summary": "Records reed_bound_zero (f(0)=0) and derives strict_implies_bipartite and trivial_case: the strict (k=0) condition forces exact bipartiteness, with the bipartition transferred back from the univ-induced subgraph.",
+      "mathContext": "Specializing to $k=0$ gives $f(0)=0$, so the strict condition yields $0$-almost-bipartite, i.e. $G$ itself bipartite — the clean trivial case of Reed's theorem."
     },
     {
       "id": "examples",
-      "title": "Triangle Example: $K_3$",
-      "startLine": 170,
-      "endLine": 185,
-      "summary": "Defines `triangleGraph` on `Fin 3`. Proves that $K_3$ violates the strict condition and is 1-almost-bipartite.",
-      "mathContext": "Verified: Defines `triangleGraph` on `Fin 3`. Fully proves `K3_violates_strict` and `K3_almost_bipartite`."
+      "title": "Part VIII: Examples",
+      "startLine": 208,
+      "endLine": 264,
+      "summary": "Builds the triangle graph K₃ and proves K3_violates_strict (its independence number 1 fails the k=0 bound) and K3_almost_bipartite (deleting one vertex leaves bipartite K₂).",
+      "mathContext": "$K_3$ has $\\alpha=1<\\tfrac32$, violating the strict condition, yet becomes bipartite after one deletion — the minimal example separating the $k=0$ and general regimes."
     },
     {
-      "id": "bounds",
-      "title": "Explicit Bounds: $f(k) \\le 2^k$",
-      "startLine": 186,
-      "endLine": 197,
-      "summary": "Axiomatizes $f(k) \\le 2^k$ from Reed's proof. Defines the open question of optimal $f(k)$.",
-      "mathContext": "Axiomatizes $f(k) \\le $2^{k}$$ from Reed's proof. Defines the open question of optimal $f(k)$."
+      "id": "bounds-on-fk",
+      "title": "Part IX: Bounds on f(k)",
+      "startLine": 265,
+      "endLine": 274,
+      "summary": "Frames the open quantitative question openQuestion_optimal_bound: characterizing the optimal (least) deletion function f(k) that still guarantees almost-bipartiteness for all such graphs.",
+      "mathContext": "Reed's proof gives some explicit but non-optimal $f(k)$; determining the least valid $f$ (a pointwise-minimal deletion function) remains open."
     },
     {
-      "id": "chromatic",
-      "title": "Chromatic Number: $\\chi(G) \\le f(k) + 2$",
-      "startLine": 198,
-      "endLine": 226,
-      "summary": "Axiomatizes bipartite $\\iff$ 2-colorable and $k$-almost-bipartite $\\Rightarrow$ $\\chi(G) \\le k + 2$.",
-      "mathContext": "Axiomatized: Axiomatizes bipartite $\\iff$ 2-colorable and $k$-almost-bipartite $\\Rightarrow$ $\\chi(G) \\le k + 2$."
+      "id": "chromatic-connection",
+      "title": "Part X: Connection to Chromatic Number",
+      "startLine": 275,
+      "endLine": 280,
+      "summary": "Documents the chromatic consequence: bipartite graphs are 2-colorable, so an f(k)-almost-bipartite graph has chromatic number at most 2 + f(k).",
+      "mathContext": "Deleting $f(k)$ vertices to reach bipartiteness gives $\\chi(G)\\le 2 + f(k)$: each removed vertex needs at most one extra color beyond the 2-coloring of the bipartite remainder."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 281,
+      "endLine": 314,
+      "summary": "Closing documentation recapping Erdős Problem #73, Reed's affirmative answer, what the file formalizes (independent sets, the condition, bipartiteness, the trivial case, almost-bipartite structure, Reed's theorem as axiom, K₃ examples), the origin of the \"Mangoes and Blueberries\" name, and remaining open questions (optimal bounds, complexity, hypergraph extensions).",
+      "mathContext": "Status: SOLVED. The formalization captures the structural theorem and the trivial $k=0$ case constructively, axiomatizing only Reed's deep general bound; open directions concern the optimal $f(k)$ and algorithmic/hypergraph generalizations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery `meta.json` for **erdos-73** (Almost Bipartite Graphs / Reed's "Mangoes and Blueberries" theorem) had 10 section ranges using stale line numbers from an earlier revision of `Proofs/Erdos73Problem.lean`:

- Sections spanned only **39–226**, while the 314-line file's `/- ## Part N -/` banners run to line **275**.
- The **header (1–38)**, **Part IX: Bounds on f(k)** and **Part X: Connection to Chromatic Number** (265–280), and the **Summary (281–314)** were entirely uncovered.
- Interior ranges had drifted off their banners (e.g. "Almost Bipartite Structure" listed at 115–130 vs. the actual banner at line 93).

Rebuilt to **12 contiguous sections** aligned 1:1 with the file's `## Part` banners (plus a header section and the closing Summary), covering lines **1–314** with no gaps or overlaps.

## Verification

- JSON validates; top-level key order preserved; diff localized to the `sections` block.
- Counts left unchanged because they were already correct: **3 axioms** (`reed_bound`, `reed_theorem`, `reed_bound_zero`), **9 theorems**, **10 defs**, **0 sorries**, lineCount 314.
- Build-free change (gallery metadata only).

## Test plan
- [x] `json.load` of meta.json succeeds
- [x] Sections contiguous, cover 1–314
- [x] No count drift introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)