### PR TITLE
Enrich Two Isolated Elements in Sidon Sumsets: section coverage (4→7)

### DIFF
--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -71,12 +71,36 @@
       "mathContext": "If $m+1 \\notin A$ and $M-1 \\notin A$, then by the endpoint lemmas $2m$ and $2M$ are both isolated in $A+A$; since $2m < 2M$ they are distinct, so $\\mathrm{isolatedCount}(A) \\geq |\\{2m, 2M\\}| = 2$."
     },
     {
-      "id": "main-theorem",
-      "title": "Main Theorem: gap_existence_two",
+      "id": "main-theorem-dispatch",
+      "title": "Main Theorem: Statement, Case Dispatch, and the Two-Pairs Contradiction",
       "startLine": 133,
+      "endLine": 158,
+      "summary": "gap_existence_two: for Sidon A with |A| ≥ 7 and min ≥ 1, isolatedCount ≥ 2. After fixing m = min(A), M = max(A), the proof branches on the 2×2 case split (M−1 ∈ A?) × (m+1 ∈ A?). The first branch handled here is the both-consecutive-pairs case: if both (m, m+1) and (M−1, M) lie in A, sidon_diff_injective collapses A into {m, m+1}, forcing |A| ≤ 2 and contradicting |A| ≥ 7.",
+      "mathContext": "An element $s \\in A+A$ is isolated if $s\\pm1 \\notin A+A$. The proof opens `by_cases hM1 : M-1 ∈ A` then `by_cases hm1 : m+1 ∈ A`, producing four branches. The both-pairs branch derives the contradiction from $m + M = (m+1) + (M-1)$: Sidon injectivity forces $\\{m, M\\} = \\{m+1, M-1\\}$, so $M - m \\leq 1$ and $A \\subseteq \\{m, m+1\\}$, giving $|A| \\leq 2 < 7$."
+    },
+    {
+      "id": "one-pair-at-max",
+      "title": "Case: One Consecutive Pair at the Maximum (Second-Smallest Element)",
+      "startLine": 159,
+      "endLine": 233,
+      "summary": "Branch M−1 ∈ A, m+1 ∉ A. Here 2·min is isolated, and a second isolated element is built from s₂ = min(A \\ {m}), the second-smallest element. Since m+1 ∉ A we get s₂ ≥ m+2; the Sidon property forces s₂+1 ∉ A (else (s₂+1)+(M−1) = s₂+M gives a forbidden second representation, collapsing A to ≤ 3 elements). Then m+s₂ is isolated, and {2m, m+s₂} gives isolatedCount ≥ 2.",
+      "mathContext": "With $s_2 = \\min(A \\setminus \\{m\\})$: from $m+1 \\notin A$, $s_2 \\geq m+2$. Sidon gives $s_2 + 1 \\notin A$ because $s_2 + M = (s_2+1) + (M-1)$ would be a second representation, forcing $\\{s_2, M\\} = \\{s_2+1, M-1\\}$ — impossible. Hence both $m + s_2 \\pm 1 \\notin A+A$ (the gap $s_2 \\geq m+2$ kills the left neighbour, $s_2+1 \\notin A$ kills the right), so $m+s_2$ joins $2m$ as a second isolated element."
+    },
+    {
+      "id": "one-pair-at-min",
+      "title": "Case: One Consecutive Pair at the Minimum (Second-Largest Element)",
+      "startLine": 234,
+      "endLine": 317,
+      "summary": "Mirror branch M−1 ∉ A, m+1 ∈ A. Now 2·max is isolated, and the second isolated element comes from sL = max(A \\ {M}), the second-largest element. Since M−1 ∉ A, sL ≤ M−2; Sidon forces sL−1 ∉ A (else sL+m = (sL−1)+(m+1) collapses A to ≤ 3 elements), and sL+1 ∉ A since sL is the largest element below M. Then M+sL is isolated, and {2M, M+sL} gives isolatedCount ≥ 2.",
+      "mathContext": "With $s_L = \\max(A \\setminus \\{M\\})$: from $M-1 \\notin A$, $s_L \\leq M-2$. Sidon gives $s_L - 1 \\notin A$ because $s_L + m = (s_L-1) + (m+1)$ would be a second representation of the same sum. Both neighbours of $M + s_L$ are absent: $M + s_L + 1 = (M+1) + s_L$ exceeds $\\max A$, and $M + s_L - 1 = M + (s_L-1)$ needs $s_L-1 \\in A$. So $M+s_L$ joins $2M$ as a second isolated element — the exact reflection of the second-smallest argument."
+    },
+    {
+      "id": "final-no-pair-delegate",
+      "title": "Case: No Consecutive Pair (Delegation to the Easy Case)",
+      "startLine": 318,
       "endLine": 319,
-      "summary": "gap_existence_two: for Sidon A with |A| ≥ 7 and min ≥ 1, proves isolatedCount ≥ 2 by case analysis: no consecutive pair (easy case), one pair at max (uses second-smallest s₂; Sidon prevents s₂+1∈A), one pair at min (symmetric), both pairs (contradiction for |A| ≥ 7).",
-      "mathContext": "An element $s \\in A+A$ is isolated if $s\\pm1 \\notin A+A$. For Sidon $A$ with $|A| \\geq 7$ and $\\min A \\geq 1$: $\\mathrm{isolatedCount}(A) \\geq 2$. Sidon difference-injectivity allows at most one consecutive pair $\\{x, x+1\\} \\subseteq A$, splitting the proof into four cases that each exhibit two isolated sums."
+      "summary": "Final branch M−1 ∉ A, m+1 ∉ A. With no consecutive pair at either endpoint, both 2·min and 2·max are isolated, so the goal reduces directly to two_isolated_no_consecutive, completing the 2×2 case analysis.",
+      "mathContext": "When neither $\\min(A)+1$ nor $\\max(A)-1$ lies in $A$, all four endpoint conditions hold and $\\mathrm{isolatedCount}(A) \\geq 2$ follows from `two_isolated_no_consecutive`. This closes the last of the four branches of `by_cases hM1` / `by_cases hm1`, so the four exhaustive cases together establish $\\mathrm{isolatedCount}(A) \\geq 2$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-152-oq-01` (quality 98, already deeply annotated). The one remaining gap was a 187-line mega-section: `main-theorem` covered lines 133–319 (the entire 2×2 case analysis) as a single block.

This PR splits it into four case-aligned sections, mirroring the structure the annotations already recognize:
- **main-theorem-dispatch** (133–158): theorem statement, `by_cases` dispatch, and the both-consecutive-pairs contradiction
- **one-pair-at-max** (159–233): M−1 ∈ A, m+1 ∉ A — second-smallest element technique (s₂)
- **one-pair-at-min** (234–317): M−1 ∉ A, m+1 ∈ A — second-largest element technique (sₗ)
- **final-no-pair-delegate** (318–319): delegation to `two_isolated_no_consecutive`

Sections now cover the full file (1→319) with no mega-section; each new section carries a `mathContext`. No counts, claims, or other content changed; `axiomCount`/`status`/`sorries` already accurate.

## Test plan
- [x] meta.json parses (build enrichment/JSON-validation stage passed)
- [x] Sections are contiguous and cover lines 1–319
- [x] Only `src/data/proofs/erdos-152-oq-01/meta.json` staged