### PR TITLE
research(erdos-573): realign drifted gallery sections to file

### DIFF
--- a/src/data/proofs/erdos-573/meta.json
+++ b/src/data/proofs/erdos-573/meta.json
@@ -101,54 +101,54 @@
       "id": "kst-theorem",
       "title": "Kővári-Sós-Turán Theorem",
       "startLine": 95,
-      "endLine": 109,
+      "endLine": 102,
       "summary": "KST bound `ex(n; C₄) ≤ (1/2)n^(3/2) + O(n)` documented in docstring commentary only; the bound is NOT declared as an axiom or theorem. This section also contains `axiom exC4C5 : ℕ → ℕ` (the extremal function for {C₄, C₅}-free graphs).",
       "mathContext": "KST bound (commentary only); `axiom exC4C5 : ℕ → ℕ` declared here"
     },
     {
       "id": "erdos-simonovits",
       "title": "Erdős-Simonovits Result",
-      "startLine": 110,
-      "endLine": 121,
+      "startLine": 103,
+      "endLine": 110,
       "summary": "The Erdős-Simonovits equality `ex(n; {C₄, C₅}) = (n/2)^(3/2) + O(n)` is documented in docstring commentary only; no axiom or theorem is declared in this section.",
       "mathContext": "Docstring commentary only; no Lean declaration in this section"
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
-      "startLine": 122,
-      "endLine": 132,
+      "startLine": 111,
+      "endLine": 121,
       "summary": "Formal statement: ex(n; {C₃, C₄}) ~ (n/2)^(3/2)",
       "mathContext": "Mathematical content: Formal statement: ex(n; {C₃, C₄}) ~ (n/2)^(3/2)"
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "startLine": 133,
-      "endLine": 145,
+      "startLine": 122,
+      "endLine": 131,
       "summary": "Upper and lower bounds on ex(n; {C₃, C₄})",
       "mathContext": "Bound: Upper and lower bounds on ex(n; {C₃, C₄})"
     },
     {
       "id": "constructions",
       "title": "Special Constructions",
-      "startLine": 146,
-      "endLine": 161,
+      "startLine": 132,
+      "endLine": 143,
       "summary": "Polarity graphs and projective plane constructions",
       "mathContext": "Mathematical content: Polarity graphs and projective plane constructions"
     },
     {
       "id": "asymptotic-gap",
       "title": "The Asymptotic Gap",
-      "startLine": 162,
-      "endLine": 173,
+      "startLine": 144,
+      "endLine": 152,
       "summary": "Gap between C₄-free and {C₃,C₄}-free leading constants",
       "mathContext": "Mathematical content: Gap between C₄-free and {C₃,C₄}-free leading constants"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 168,
+      "startLine": 153,
       "endLine": 177,
       "summary": "Main theorems: erdos_573 and erdos_573_summary",
       "mathContext": "Verified: Main theorems: erdos_573 and erdos_573_summary"


### PR DESCRIPTION
## Summary

The 10-section gallery meta for `erdos-573` had section ranges drifted ~10–15 lines ahead of the file's `/- ## Part N` banners from Part V onward, with **Part IX (Asymptotic Gap) overlapping Part X (Summary)** (162–173 vs 168–177).

Rebuilt to contiguous, banner-aligned ranges over the 177-line file (banners at 45/71/77/95/103/111/122/132/144/153):

| Part | Range |
|------|-------|
| I Basic Definitions | 45–70 |
| II Edge Counting | 71–76 |
| III Extremal Function | 77–94 |
| IV Kővári–Sós–Turán | 95–102 |
| V Erdős–Simonovits | 103–110 |
| VI The Conjecture | 111–121 |
| VII Known Bounds | 122–131 |
| VIII Special Constructions | 132–143 |
| IX The Asymptotic Gap | 144–152 |
| X Summary | 153–177 |

## Verification
- Counts unchanged and pre-verified (comment-stripped): **2 theorems, 5 axioms, 7 defs, 0 sorries, 177 lines**.
- Sections contiguous 45→177; diff scoped to `sections` array (+12/−12).
- No remote branch / open PR touches this meta (checked at commit gate).

## Test plan
- [x] JSON validates
- [x] Section ranges contiguous, 1:1 with `/- ## Part N` banners
- [x] Counts re-verified with block-comment stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)