### PR TITLE
research(stirling-formula-oq-02): realign drifted gallery sections to file (7→14)

### DIFF
--- a/src/data/proofs/stirling-formula-oq-02/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02/meta.json
@@ -101,60 +101,116 @@
   ],
   "sections": [
     {
-      "id": "gamma-factorial-bridge",
-      "title": "Part I: The Gamma-Factorial Bridge",
-      "startLine": 52,
-      "endLine": 77,
+      "id": "header-overview",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports (Mathlib Gamma/Beta/BohrMollerup, Stirling, Asymptotics, Pi bounds, Tactic) and module docstring: extends Stirling's formula from factorials to the Gamma function, Γ(x+1) ~ √(2πx)·(x/e)^x. Lists the approach, status checklist, and Mathlib dependencies, then opens the StirlingGamma namespace.",
+      "mathContext": "\\Gamma(x+1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x \\text{ as } x \\to \\infty, \\text{ generalizing } n! \\sim \\sqrt{2\\pi n}(n/e)^n \\text{ (Wiedijk #90)}"
+    },
+    {
+      "id": "part-1-gamma-factorial-bridge",
+      "title": "PART 1: The Gamma-Factorial Bridge",
+      "startLine": 51,
+      "endLine": 78,
       "summary": "gamma_eq_factorial (Γ(n+1)=n!), gamma_one (Γ(1)=1), gamma_nat_pos, gamma_pos_of_pos. The fundamental connection allowing all Stirling facts to transfer from n! to Γ.",
       "mathContext": "\\Gamma(n+1) = n! \\quad (\\text{Real.Gamma\\_nat\\_eq\\_factorial})\\\\ \\Gamma(s) > 0 \\text{ for } s > 0"
     },
     {
-      "id": "stirling-equivalence",
-      "title": "Parts II–III: Stirling Equivalence and Bounds",
-      "startLine": 80,
-      "endLine": 204,
-      "summary": "gammaStirlingApprox definition, gamma_isEquivalent_stirling (Γ(n+1)~√(2πn)·(n/e)^n), gamma_div_stirling_tendsto_one. Then gamma_stirling_seq_eq (=stirlingSeq), gamma_stirling_ratio_tendsto_sqrt_pi, gamma_lower_bound (√(2πn)·(n/e)^n ≤ Γ(n+1) via stirlingSeq antitonicity).",
-      "mathContext": "\\Gamma(n+1) \\sim \\sqrt{2\\pi n}(n/e)^n, \\quad \\frac{\\Gamma(n+1)}{\\sqrt{2\\pi n}(n/e)^n} \\to 1\\\\ \\text{stirlingSeq}(n) \\searrow \\sqrt{\\pi} \\Rightarrow n! \\geq \\sqrt{2\\pi n}(n/e)^n"
+      "id": "part-2-stirling-via-gamma",
+      "title": "PART 2: Stirling's Formula via Gamma at Integers",
+      "startLine": 79,
+      "endLine": 132,
+      "summary": "gammaStirlingApprox definition, gammaStirlingApprox_pos, gamma_isEquivalent_stirling (Γ(n+1)~√(2πn)·(n/e)^n via Γ(n+1)=n!), and gamma_div_stirling_tendsto_one.",
+      "mathContext": "\\Gamma(n+1) \\sim \\sqrt{2\\pi n}(n/e)^n, \\quad \\frac{\\Gamma(n+1)}{\\sqrt{2\\pi n}(n/e)^n} \\to 1"
     },
     {
-      "id": "log-gamma",
-      "title": "Part IV: Log-Gamma Approximation",
-      "startLine": 206,
-      "endLine": 257,
+      "id": "part-3-gamma-bounds",
+      "title": "PART 3: Bounds on Gamma from Stirling",
+      "startLine": 133,
+      "endLine": 204,
+      "summary": "gamma_stirling_seq_eq (the Gamma Stirling ratio equals stirlingSeq), gamma_stirling_ratio_tendsto_sqrt_pi, and gamma_lower_bound (√(2πn)·(n/e)^n ≤ Γ(n+1)) via antitonicity of stirlingSeq toward √π.",
+      "mathContext": "\\text{stirlingSeq}(n) \\searrow \\sqrt{\\pi} \\Rightarrow n! \\geq \\sqrt{2\\pi n}(n/e)^n"
+    },
+    {
+      "id": "part-4-log-gamma",
+      "title": "PART 4: Log-Gamma Approximation",
+      "startLine": 205,
+      "endLine": 258,
       "summary": "log_gamma_lower_bound: log√(2πn) + n·log(n/e) ≤ logΓ(n+1). log_gamma_stirling: expresses logΓ(n+1) = log(stirlingSeq n) + log√(2n) + n·log n - n.",
       "mathContext": "\\log\\Gamma(n+1) \\approx n\\log n - n + \\tfrac{1}{2}\\log(2\\pi n)\\\\ \\text{From: } n! = \\text{stirlingSeq}(n) \\cdot \\sqrt{2n} \\cdot (n/e)^n"
     },
     {
-      "id": "recurrence-ratios",
-      "title": "Parts V–VI: Gamma Recurrence and Ratios",
-      "startLine": 260,
+      "id": "part-5-recurrence",
+      "title": "PART 5: Gamma Recurrence and Stirling",
+      "startLine": 259,
+      "endLine": 293,
+      "summary": "gamma_succ_nat (Γ(n+2) = (n+1)·Γ(n+1)) and gamma_nat_le_pow_self (Γ(n+1) ≤ n^n via n! ≤ n^n by induction).",
+      "mathContext": "\\Gamma(n+2) = (n+1)\\cdot\\Gamma(n+1), \\quad \\Gamma(n+1) \\leq n^n"
+    },
+    {
+      "id": "part-6-ratios",
+      "title": "PART 6: Ratio of Gamma Values",
+      "startLine": 294,
       "endLine": 318,
-      "summary": "gamma_succ_nat (Γ(n+2) = (n+1)·Γ(n+1)), gamma_nat_le_pow_self (Γ(n+1) ≤ n^n), gamma_ratio_succ (Γ(n+1)/Γ(n)), gamma_ratio_exact (exact ratio formula).",
-      "mathContext": "\\Gamma(n+2) = (n+1)\\cdot\\Gamma(n+1)\\\\ \\Gamma(n+1)/\\Gamma(n) = n, \\quad \\Gamma(n+1) \\leq n^n"
+      "summary": "gamma_ratio_succ (Γ(n+2)/Γ(n+1) = n+1, exact from the recurrence) and gamma_ratio_exact (Γ((n+1)+1)/Γ(n+1) = n+1).",
+      "mathContext": "\\Gamma(n+2)/\\Gamma(n+1) = n+1"
     },
     {
-      "id": "gamma-half-integer",
-      "title": "Parts VII–VIII: Γ(1/2) = √π and Legendre Duplication",
-      "startLine": 320,
+      "id": "part-7-half-integer",
+      "title": "PART 7: Gamma at Half-Integer Points",
+      "startLine": 319,
+      "endLine": 347,
+      "summary": "gamma_one_half: Γ(1/2) = √π, transferred from Complex.Gamma_one_half_eq via Complex.Gamma_ofReal and ofReal injectivity.",
+      "mathContext": "\\Gamma(1/2) = \\sqrt{\\pi} \\quad (\\text{from the Gaussian integral } \\int_0^\\infty t^{-1/2}e^{-t}\\,dt)"
+    },
+    {
+      "id": "part-8-duplication",
+      "title": "PART 8: Duplication Formula",
+      "startLine": 348,
       "endLine": 385,
-      "summary": "gamma_one_half (Γ(1/2)=√π from reflection formula). duplication_at_nat: Γ(n)·Γ(n+1/2) = √π·Γ(2n)/4^{n-1} (Legendre duplication formula at integer points, via Real.Gamma_mul_Gamma_add_one).",
-      "mathContext": "\\Gamma(1/2) = \\sqrt{\\pi}\\\\ \\Gamma(n)\\Gamma(n+1/2) = \\frac{\\sqrt{\\pi}}{4^{n-1}}\\Gamma(2n)"
+      "summary": "duplication_at_nat: Γ(n)·Γ(n+1/2) = √π·(2n-1)!/2^(2n-1) (Legendre duplication formula at integer points, via Real.Gamma_mul_Gamma_add_half).",
+      "mathContext": "\\Gamma(n)\\Gamma(n+\\tfrac{1}{2}) = \\frac{\\sqrt{\\pi}}{2^{2n-1}}\\,(2n-1)!"
     },
     {
-      "id": "half-int-general",
-      "title": "Parts X–XI: Stirling Error and Half-Integer Formula",
-      "startLine": 402,
-      "endLine": 486,
-      "summary": "gamma_stirling_relative_error_tendsto (Γ(n+1)/approx - 1 → 0). gamma_three_halves (Γ(3/2)=√π/2), gamma_five_halves (Γ(5/2)=3√π/4). doubleFactorial definition. gamma_half_int_formula (Γ(n+1/2) = (2n-1)!!·√π/2^n by induction).",
-      "mathContext": "\\Gamma(n+\\tfrac{1}{2}) = \\frac{(2n-1)!!\\sqrt{\\pi}}{2^n}\\\\ \\Gamma(3/2)=\\frac{\\sqrt{\\pi}}{2}, \\quad \\Gamma(5/2)=\\frac{3\\sqrt{\\pi}}{4}"
+      "id": "part-9-continuous-statement",
+      "title": "PART 9: Continuous Stirling for Gamma (Statement)",
+      "startLine": 386,
+      "endLine": 400,
+      "summary": "Documentation block stating the full continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x for real x, noting it requires the Laplace method (~500 lines of integral analysis not yet in Mathlib).",
+      "mathContext": "\\Gamma(x+1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x \\text{ as } x \\to +\\infty,\\ x \\in \\mathbb{R}, \\text{ via the Laplace method on } \\int_0^\\infty t^x e^{-t}\\,dt"
     },
     {
-      "id": "central-binom",
-      "title": "Part XII: Central Binomial Coefficient via Gamma",
-      "startLine": 488,
-      "endLine": 598,
-      "summary": "centralBinom_via_gamma (C(2n,n)=Γ(2n+1)/Γ(n+1)²), factorial_double_mul ((2n)!=2^n·(2n-1)!!·n! by induction), centralBinom_gamma_half_int (C(2n,n)=4^nΓ(n+1/2)/(√πΓ(n+1))). Summary and #check exports.",
+      "id": "part-10-stirling-series",
+      "title": "PART 10: Stirling Series (First Correction Term)",
+      "startLine": 401,
+      "endLine": 417,
+      "summary": "gamma_stirling_relative_error_tendsto: the relative error Γ(n+1)/approx - 1 tends to 0, the leading consequence of the Stirling series 1 + 1/(12x) + ....",
+      "mathContext": "\\Gamma(x+1) = \\sqrt{2\\pi x}(x/e)^x\\left(1 + \\tfrac{1}{12x} + \\cdots\\right), \\quad \\frac{\\Gamma(n+1)}{\\text{approx}} - 1 \\to 0"
+    },
+    {
+      "id": "part-11-half-integer-recurrence",
+      "title": "PART 11: Gamma at Half-Integer Points via Recurrence",
+      "startLine": 418,
+      "endLine": 479,
+      "summary": "gamma_three_halves (Γ(3/2)=√π/2), gamma_five_halves (Γ(5/2)=3√π/4), gamma_half_int_pos, the doubleFactorial definition, and gamma_half_int_formula (Γ(n+1/2) = (2n-1)!!·√π/2^n by induction).",
+      "mathContext": "\\Gamma(n+\\tfrac{1}{2}) = \\frac{(2n-1)!!\\,\\sqrt{\\pi}}{2^n}, \\quad \\Gamma(3/2)=\\tfrac{\\sqrt{\\pi}}{2},\\ \\Gamma(5/2)=\\tfrac{3\\sqrt{\\pi}}{4}"
+    },
+    {
+      "id": "part-12-central-binom",
+      "title": "PART 12: Central Binomial Coefficient via Gamma",
+      "startLine": 480,
+      "endLine": 585,
+      "summary": "centralBinom_via_gamma (C(2n,n)=Γ(2n+1)/Γ(n+1)²), factorial_double_mul ((2n)!=2^n·(2n-1)!!·n! by induction), and centralBinom_gamma_half_int (C(2n,n)=4^nΓ(n+1/2)/(√πΓ(n+1))).",
       "mathContext": "\\binom{2n}{n} = \\frac{\\Gamma(2n+1)}{\\Gamma(n+1)^2} = \\frac{4^n\\,\\Gamma(n+\\frac{1}{2})}{\\sqrt{\\pi}\\,\\Gamma(n+1)} \\sim \\frac{4^n}{\\sqrt{\\pi n}}"
+    },
+    {
+      "id": "summary-exports",
+      "title": "Summary and Exports",
+      "startLine": 586,
+      "endLine": 601,
+      "summary": "`#check` commands listing the main results (gamma_eq_factorial, gamma_isEquivalent_stirling, gamma_lower_bound, log_gamma_lower_bound, gamma_one_half, gamma_half_int_formula, centralBinom_via_gamma, etc.) and the StirlingGamma namespace close.",
+      "mathContext": "Sanity checks that the Gamma-factorial bridge, Stirling equivalence/bounds, log-Gamma, half-integer formula, and central-binomial identities are all available at their stated types."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

The gallery meta for **stirling-formula-oq-02** (Stirling approximation for the Gamma function, `Proofs/StirlingFormulaOQ02.lean`, 601 lines) carried only **7 sections** drifted from an older revision, while the Lean file is organized into **12 `-- PART` box banners** plus a Summary block.

The drift:
- The module header (lines 1–50: imports, approach, status checklist, Mathlib dependencies) was uncovered.
- Several PARTs were lumped into combined sections ("Parts II–III", "Parts V–VI", "Parts VII–VIII", "Parts X–XI").
- **PART 9** (Continuous Stirling for Gamma — Statement, lines 386–400) fell entirely into an uncovered gap between the "Parts VII–VIII" section (…–385) and the "Parts X–XI" section (402–…).
- The tail (lines 599–601) was uncovered.

## Changes

- Rebuilt **14 contiguous sections** (header + 12 PARTs + Summary) tiling lines **1–601**, each aligned to its `-- PART N` box banner, preserving the per-section `mathContext` field.
- Counts were already correct and are **untouched**: 0 axioms, 26 theorems, 2 definitions, 0 sorries.

Build-free change (gallery metadata only).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Every section retains its `mathContext` field
- [x] Sections tile the file contiguously from line 1 to 601 with no gaps or overlaps
- [x] Section ranges verified against `-- PART` banner positions in the Lean source