### PR TITLE
research(erdos-837-oq-05): realign drifted gallery sections to file

### DIFF
--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -54,35 +54,35 @@
     {
       "id": "strengthened-def",
       "title": "Section I: Strengthened Definition",
-      "startLine": 39,
-      "endLine": 72,
+      "startLine": 40,
+      "endLine": 71,
       "summary": "Defines IsDensityJumpLiminf using Filter.liminf and Filter.Tendsto, and the corresponding densityJumpSetLiminf."
     },
     {
       "id": "relationship",
       "title": "Section II: Relationship to Original",
-      "startLine": 74,
-      "endLine": 84,
+      "startLine": 72,
+      "endLine": 83,
       "summary": "Shows the strengthened definition implies the original placeholder."
     },
     {
       "id": "ess-theorem",
       "title": "Section III: A_2 Characterization",
-      "startLine": 86,
-      "endLine": 112,
+      "startLine": 84,
+      "endLine": 105,
       "summary": "Defines Turán densities 1-1/m, proves they're in [0,1), axiomatizes A_2 = {1-1/m}."
     },
     {
       "id": "properties",
       "title": "Section IV: Properties",
-      "startLine": 110,
-      "endLine": 121,
+      "startLine": 106,
+      "endLine": 122,
       "summary": "States 0 ∈ A_k (sorry: needs supersaturation) and A_k ⊆ [0,1)."
     },
     {
       "id": "open-problem",
       "title": "Section V: The Open Problem and Verification",
-      "startLine": 127,
+      "startLine": 123,
       "endLine": 149,
       "summary": "Marks the characterization of A_3 as open and lists #check verification commands.",
       "mathContext": "The open problem: characterize densityJumpSetLiminf 3, i.e., determine which values α ∈ [0,1) are density jump values for 3-uniform hypergraphs."


### PR DESCRIPTION
## Summary

The 5-section gallery meta for `erdos-837-oq-05` had ranges drifted off the file's `-- ═══` box-rule section banners (Sections I–V with top rules at 40/72/84/106/123), and **Section III (86–112) overlapped Section IV (110–121)**.

Rebuilt to contiguous, box-rule-aligned ranges over the 149-line file:

| Section | Range |
|---------|-------|
| I Strengthened Definition | 40–71 |
| II Relationship to Original | 72–83 |
| III A₂ Characterization | 84–105 |
| IV Properties | 106–122 |
| V The Open Problem and Verification | 123–149 |

## Verification
- Counts unchanged and pre-verified (comment-stripped): **5 theorems, 1 axiom, 3 defs, 1 sorry, 149 lines**.
- Sections contiguous 40→149, aligned to `-- ═══` box-rule banners.
- No remote branch / open PR touches this meta (checked at commit gate).

## Test plan
- [x] JSON validates
- [x] Section ranges contiguous and banner-aligned
- [x] Counts re-verified with block-comment stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)