### PR TITLE
Enrich Erdős #101 (Four-Point Lines): realign drifted sections (6→13) + annotations

### DIFF
--- a/src/data/proofs/erdos-101/annotations.json
+++ b/src/data/proofs/erdos-101/annotations.json
@@ -72,7 +72,7 @@
     "id": "four-point-count",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 42,
+      "startLine": 43,
       "endLine": 48
     },
     "type": "definition",
@@ -95,12 +95,12 @@
     "id": "main-conjecture",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 51,
-      "endLine": 57
+      "startLine": 285,
+      "endLine": 286
     },
     "type": "concept",
     "title": "Erdős Problem #101: The Main Conjecture",
-    "content": "The central open problem: the four-point line count is $o(n^2)$, formalized as for every $\\varepsilon > 0$, there exists $N_0$ such that for all no-five-collinear point sets $P$ with $|P| \\geq N_0$, we have $f_4(P) < \\varepsilon \\cdot |P|^2$. This is stated as an axiom since the problem is open, carrying a $100 Erdős prize.",
+    "content": "The central open problem: the four-point line count is $o(n^2)$, formalized as for every $\\varepsilon > 0$, there exists $N_0$ such that for all no-five-collinear point sets $P$ with $|P| \\geq N_0$, we have $f_4(P) < \\varepsilon \\cdot |P|^2$. This is recorded as a documentation comment, not an axiom — the file declares zero axioms. The conjecture remains open (carrying a $100 Erdős prize), while the surrounding theorems prove unconditional partial bounds ($f_4 \\leq n^2$, $\\leq n(n-1)/2$, $\\leq n(n-1)/12$, and $\\leq (n-1)/3$ per point).",
     "mathContext": "The conjecture is $f_4(n) = o(n^2)$: $\\forall \\varepsilon > 0, \\exists N_0 \\in \\mathbb{N}, \\forall P$ with $\\text{NoFiveCollinear}(P)$ and $|P| \\geq N_0$: $f_4(P) < \\varepsilon \\cdot |P|^2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -118,8 +118,8 @@
     "id": "grunbaum-lower",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 61,
-      "endLine": 67
+      "startLine": 289,
+      "endLine": 290
     },
     "type": "concept",
     "title": "Grünbaum's Lower Bound Construction",
@@ -140,8 +140,8 @@
     "id": "solymosi-stojakovic",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 69,
-      "endLine": 75
+      "startLine": 291,
+      "endLine": 292
     },
     "type": "insight",
     "title": "Solymosi–Stojaković: Nearly Quadratic Lower Bound",
@@ -164,8 +164,8 @@
     "id": "trivial-upper",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 77,
-      "endLine": 81
+      "startLine": 293,
+      "endLine": 501
     },
     "type": "concept",
     "title": "Trivial Quadratic Upper Bound",
@@ -185,8 +185,8 @@
     "id": "collinear-triples",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 85,
-      "endLine": 91
+      "startLine": 593,
+      "endLine": 594
     },
     "type": "concept",
     "title": "Collinear Triples Without Four-Point Lines",
@@ -208,8 +208,8 @@
     "id": "szemeredi-trotter",
     "proofId": "erdos-101",
     "range": {
-      "startLine": 93,
-      "endLine": 99
+      "startLine": 595,
+      "endLine": 598
     },
     "type": "concept",
     "title": "Szemerédi–Trotter Incidence Theorem",

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -38,48 +38,104 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 22,
-      "endLine": 48,
+      "endLine": 49,
       "summary": "Defines PlanarPointSet as a positive-cardinality Finset of ℝ × ℝ, collinearity via the signed area determinant, the NoFiveCollinear condition (at most four points per line), and fourPointLineCount by filtering collinear 4-subsets of the powerset.",
       "mathContext": "Collinearity: three points $(x_1,y_1), (x_2,y_2), (x_3,y_3)$ are collinear iff the signed area determinant $\\det \\begin{pmatrix} x_1-x_3 & y_1-y_3 \\\\ x_2-x_3 & y_2-y_3 \\end{pmatrix} = 0$. `NoFiveCollinear P` asserts no 5-element subset is collinear. `fourPointLineCount` filters for collinear 4-subsets."
     },
     {
+      "id": "properties-collinearity",
+      "title": "Properties of Collinearity",
+      "startLine": 50,
+      "endLine": 127,
+      "summary": "Eleven theorems establishing that the determinant collinearity predicate behaves like a genuine line relation: reflexivity (collinear_self, collinear_refl, collinear_self_right), the permutation symmetries (collinear_swap23, collinear_swap12, collinear_rotate, collinear_cycle), and the transitivity results collinear_trans, collinear_four, and collinear_any_triple. The last shows that once two distinct points p, q fix a line, every other point on it is collinear with every triple — the algebraic backbone for treating four-collinear subsets as subsets of a single line.",
+      "mathContext": "The signed-area predicate $\\mathrm{collinear}(p,q,r) \\equiv (q_1-p_1)(r_2-p_2) = (r_1-p_1)(q_2-p_2)$ is symmetric in all three arguments and transitive along a fixed line. `collinear_trans` uses a case split on $q_1 = p_1$ and `mul_left_cancel₀` to derive $\\mathrm{collinear}(p,r,s)$ from $\\mathrm{collinear}(p,q,r)$ and $\\mathrm{collinear}(p,q,s)$ when $p \\neq q$; `collinear_any_triple` upgrades this to: any three of $\\{r,s,t\\}$ lying on the line through distinct $p,q$ are mutually collinear."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties and the Line Bound",
+      "startLine": 128,
+      "endLine": 217,
+      "summary": "Three structural theorems. noFiveCollinear_small: the no-five-collinear hypothesis holds vacuously for |P| ≤ 4 (a 5-subset would have card 5 > |P|). fourPointLineCount_lt_four: the count is 0 when |P| < 4. noFiveCollinear_line_bound: the key extremal lemma — under NoFiveCollinear, any line (the points collinear with a fixed distinct pair a, b) contains at most 4 points, proved by extracting a hypothetical 5th point via repeated Finset.erase and contradicting the hypothesis.",
+      "mathContext": "`noFiveCollinear_line_bound` is the heart of the upper-bound machinery: for distinct $a,b \\in P$, $|\\{p \\in P : \\mathrm{collinear}(a,b,p)\\}| \\leq 4$. The proof assumes $\\geq 5$, peels off $a, b$ and three further points $c, d, e$ by erasing, establishes all $\\binom{5}{2}$ distinctness obligations, and feeds them to `NoFiveCollinear` to reach a contradiction. This caps every line at 4 points, the precise threshold the problem is built around."
+    },
+    {
+      "id": "uniqueness-four-collinear",
+      "title": "Uniqueness of Four-Collinear Subsets",
+      "startLine": 218,
+      "endLine": 282,
+      "summary": "two theorems turning the line bound into a combinatorial injection. four_collinear_unique: two 4-element collinear subsets sharing a distinct pair a, b must be equal (both equal the ≤4-element line through a, b). four_collinear_overlap_small: two distinct 4-element collinear subsets share at most one point — if they shared two points x ≠ y, collinear_any_triple would force both subsets onto the line through x, y, and uniqueness would collapse them.",
+      "mathContext": "From $|\\text{line through } a,b| \\leq 4$ and $|S_i| = 4$ with $S_i \\subseteq \\text{line}$, equality $S_i = \\text{line}$ follows by `Finset.eq_of_subset_of_card_le`; hence two such subsets through the same pair coincide. The overlap bound $|S_1 \\cap S_2| \\leq 1$ for $S_1 \\neq S_2$ is the disjointness engine for the packing arguments: it says distinct four-point lines meet in at most one point."
+    },
+    {
       "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 49,
-      "endLine": 58,
-      "summary": "The open conjecture: for any ε > 0 and sufficiently large no-five-collinear point sets P, the four-point line count is less than ε·|P|². Stated as an axiom since the problem is unresolved.",
-      "mathContext": "Conjecture: $\\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall P$ with $|P| \\geq N$ and `NoFiveCollinear P`: $f_4(P) < \\varepsilon |P|^2$. Equivalently, $f_4(n) = o(n^2)$ as $n \\to \\infty$."
+      "title": "Main Conjecture (Statement)",
+      "startLine": 283,
+      "endLine": 286,
+      "summary": "A documentation comment stating Erdős #101: the number of four-point lines is o(n²), i.e. for any ε > 0 eventually fourPointLineCount(P) < ε·n². This is recorded as prose only — it is NOT an axiom (the file declares zero axioms); the conjecture remains open while the surrounding theorems prove unconditional partial bounds.",
+      "mathContext": "Conjecture: $\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P$ with $|P| \\geq N$ and `NoFiveCollinear P`: $f_4(P) < \\varepsilon |P|^2$. Equivalently $f_4(n) = o(n^2)$. Stated in a `/- … -/` comment, carrying no logical force — the verified content of the file is the chain of upper bounds below."
     },
     {
-      "id": "known-lower-bounds",
-      "title": "Known Lower Bounds",
-      "startLine": 59,
-      "endLine": 76,
-      "summary": "Two lower bound results: Grünbaum's Ω(n^{3/2}) construction and Solymosi–Stojaković's nearly quadratic n^{2−O(1/√log n)} construction that disproved Erdős's original Θ(n^{3/2}) conjecture.",
-      "mathContext": "Grünbaum: $\\Omega(n^{3/2})$ four-point lines from $\\sqrt{n}$ families of $\\sqrt{n}$ points on carefully chosen lines. Solymosi-Stojaković (2013): $n^{2 - O(1/\\sqrt{\\log n})}$ via sum-product type constructions, disproving the $\\Theta(n^{3/2})$ conjecture."
+      "id": "known-results",
+      "title": "Known Results and Trivial Upper Bounds",
+      "startLine": 287,
+      "endLine": 502,
+      "summary": "Prose comments recording Grünbaum's ≫ n^{3/2} lower bound and the Solymosi–Stojaković n^{2−O(1/√log n)} construction (which disproved Erdős's Θ(n^{3/2}) conjecture), followed by two fully proved upper bounds. trivial_upper_bound_sq: fourPointLineCount ≤ n² via an injective witness map from each 4-subset to an ordered pair of points. trivial_upper_bound: the sharper ≤ n(n-1)/2, mapping each 4-subset to the unordered pair {witness₁, witness₂} ∈ powersetCard 2, injective by four_collinear_unique.",
+      "mathContext": "Each four-collinear $S$ admits a witnessing distinct pair $(a,b)$ with all of $S$ on line $ab$; `four_collinear_unique` makes $S \\mapsto (a,b)$ injective. Counting ordered pairs gives $f_4 \\leq n^2$; counting unordered pairs in `powersetCard 2` gives $f_4 \\leq \\binom{n}{2} = n(n-1)/2$. The lower-bound results (Grünbaum, Solymosi–Stojaković) are cited as comments, not formalized constructions."
     },
     {
-      "id": "trivial-upper",
-      "title": "Trivial Upper Bound",
-      "startLine": 77,
-      "endLine": 82,
-      "summary": "The elementary observation that at most C(n,2) lines are determined by n points, giving O(n²) as the trivial upper bound on four-point lines.",
-      "mathContext": "$f_4(n) \\leq \\binom{n}{2} = O(n^2)$ since each line is determined by any two of its points. The gap between $O(n^2)$ and the conjectured $o(n^2)$ is the content of the open problem."
+      "id": "improved-upper-bound",
+      "title": "Improved Upper Bound n(n-1)/12",
+      "startLine": 503,
+      "endLine": 590,
+      "summary": "The sharpest bound in the file. powersetCard2_disjoint: if two sets meet in ≤1 element their 2-element subsets are disjoint. improved_upper_bound: fourPointLineCount ≤ n(n-1)/12 — each 4-collinear subset contributes C(4,2)=6 pairs, distinct subsets share ≤1 point (four_collinear_overlap_small) so their pair-sets are disjoint, and packing 6·|F| disjoint pairs into the C(n,2) total gives 6|F| ≤ n(n-1)/2.",
+      "mathContext": "Pair-packing: the map $S \\mapsto \\binom{S}{2}$ sends each four-point line to 6 distinct 2-subsets of $P$, and overlap $\\leq 1$ makes these 6-element blocks pairwise disjoint. `Finset.card_biUnion` over the disjoint blocks yields $6|F| = |\\bigcup_S \\binom{S}{2}| \\leq \\binom{n}{2}$, hence $f_4(P) \\leq n(n-1)/12$ — the best bound obtainable from pure incidence combinatorics for $k=4$."
     },
     {
       "id": "related-observations",
       "title": "Related Observations",
-      "startLine": 83,
-      "endLine": 757,
-      "summary": "Burr–Grünbaum–Sloane/Füredi–Palásti constructions with Θ(n²) collinear triples but no four-point lines, and the Szemerédi–Trotter incidence theorem as the key tool for bounding collinearity configurations.",
-      "mathContext": "Szemerédi-Trotter incidence theorem: $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$. Applied to lines with $\\geq 4$ points: $4|L_4| \\leq I(P, L_4)$, giving $|L_4| = O(n^2)$ — matching the trivial bound. The Burr-Grünbaum-Sloane construction shows $\\Theta(n^2)$ collinear triples can exist with zero four-point lines, illustrating a phase transition."
+      "startLine": 591,
+      "endLine": 598,
+      "summary": "Documentation comments on context: the Burr–Grünbaum–Sloane and Füredi–Palásti constructions yield ~n²/6 collinear triples with no four-point line, and the Szemerédi–Trotter incidence theorem bounds point-line incidences. Prose only, no declarations.",
+      "mathContext": "Szemerédi–Trotter: $I(P,L) \\leq C(|P|^{2/3}|L|^{2/3} + |P| + |L|)$. Applied to four-rich lines it recovers only $O(n^2)$, no better than the trivial bound — illustrating why closing the gap to $o(n^2)$ needs new ideas. The $\\Theta(n^2)$-collinear-triples-with-zero-four-lines constructions mark a sharp 3-to-4 phase transition."
+    },
+    {
+      "id": "f-family",
+      "title": "The F Family (Reusable Definitions)",
+      "startLine": 599,
+      "endLine": 614,
+      "summary": "Packages the filtered powerset as a named object for reuse: fourCollinearFamily P is the Finset of all 4-element collinear subsets, and fourPointLineCount_eq_family proves fourPointLineCount equals its cardinality (definitional unfolding).",
+      "mathContext": "$\\mathcal{F}(P) = \\{S \\subseteq P : |S| = 4,\\ \\exists a \\neq b \\in S,\\ \\forall p \\in S,\\ \\mathrm{collinear}(a,b,p)\\}$, with $f_4(P) = |\\mathcal{F}(P)|$ by `rfl`. Naming the family lets the per-point and double-counting results refer to it directly rather than re-deriving the filter."
+    },
+    {
+      "id": "per-point-bound",
+      "title": "Per-Point Bound (n-1)/3",
+      "startLine": 615,
+      "endLine": 716,
+      "summary": "Defines fourCollinearThrough P p (four-collinear subsets containing a fixed point p) and proves fourCollinearThrough_bound: at most (n-1)/3 four-point lines pass through any single point. Each such subset contributes 3 points other than p; by four_collinear_overlap_small distinct subsets share only p, so the erased 3-element parts are pairwise disjoint inside P \\ {p}, giving 3·|FP| ≤ n-1.",
+      "mathContext": "For fixed $p$, the map $S \\mapsto S \\setminus \\{p\\}$ sends each four-point line through $p$ to a 3-element subset of $P \\setminus \\{p\\}$. Two distinct such lines share only $p$ (overlap $\\leq 1$), so the images are disjoint; `Finset.card_biUnion` gives $3 \\cdot |\\{$lines through $p\\}| \\leq |P \\setminus \\{p\\}| = n-1$, i.e. $\\leq (n-1)/3$ four-point lines per point."
+    },
+    {
+      "id": "structural-lemmas-through",
+      "title": "Structural Lemmas for fourCollinearThrough",
+      "startLine": 717,
+      "endLine": 738,
+      "summary": "Two bridging lemmas relating the per-point family to the global family: fourCollinearThrough_sub_family (every subset through p is in the global family) and mem_fourCollinearThrough_of_mem_family (every family member belongs to fourCollinearThrough p for each of its points). Together they set up the incidence (S, p) double counting.",
+      "mathContext": "These establish the incidence correspondence $S \\in \\mathcal{F}(P) \\iff S \\in \\mathrm{through}(p)$ for each $p \\in S$. Since $|S| = 4$, every four-point line is counted exactly 4 times across $\\sum_{p} |\\mathrm{through}(p)|$ — the combinatorial identity feeding the double-counting reproof of the global bound."
+    },
+    {
+      "id": "double-counting-connection",
+      "title": "Double-Counting Connection",
+      "startLine": 739,
+      "endLine": 758,
+      "summary": "A closing documentation block explaining how the per-point bound (n-1)/3 and the global bound n(n-1)/12 are linked by double counting: each 4-subset appears in fourCollinearThrough(p) for exactly its 4 points, so Σ_p |through(p)| = 4|F|; combining with 3|through(p)| ≤ n-1 reproves 12|F| ≤ n(n-1). Notes that both routes give the same tight n(n-1)/12, which is optimal for purely combinatorial methods, and that closing the O(n²)→o(n²) gap needs genuinely new ideas.",
+      "mathContext": "Double counting: $\\sum_{p \\in P} |\\mathrm{through}(p)| = \\sum_{S \\in \\mathcal{F}} |S| = 4|\\mathcal{F}|$. With $3|\\mathrm{through}(p)| \\leq n-1$ summed over $p$: $12|\\mathcal{F}| = 3\\sum_p |\\mathrm{through}(p)| \\leq n(n-1)$, recovering $|\\mathcal{F}| \\leq n(n-1)/12$. The bound is tight for incidence-only arguments; the conjectured $o(n^2)$ lies strictly beyond Szemerédi–Trotter and double counting for $k=4$."
     }
   ],
   "overview": {
     "historicalContext": "Erdős posed this problem across several papers from 1984 to 1997, asking whether the maximum number of lines through exactly four points of an $n$-point planar set (with no five collinear) is $o(n^2)$. He initially conjectured the answer was $\\Theta(n^{3/2})$, based on a construction by Grünbaum that achieves $\\Omega(n^{3/2})$ four-point lines using carefully arranged points on families of lines. This conjecture stood for decades until Solymosi and Stojaković (2013) disproved it with a stunning construction achieving $n^{2 - O(1/\\sqrt{\\log n})}$ four-point lines—nearly quadratic growth. Their approach uses number-theoretic ideas related to sum-product estimates. The gap between this lower bound and the conjectured $o(n^2)$ upper bound remains one of the central open problems in combinatorial geometry, carrying a $\\$100$ Erdős prize. The problem connects deeply to the Szemerédi–Trotter incidence theorem and the broader program of understanding collinearity patterns in finite point sets.",
     "problemStatement": "Given $n$ points in $\\mathbb{R}^2$ with no five collinear, prove that the number of lines containing exactly four of the points is $o(n^2)$.",
     "text": "Given n points in ℝ² with no five collinear, is the number of lines containing exactly four points o(n²)? Grünbaum: ≫ n^{3/2}. Solymosi–Stojaković: n^{2−O(1/√log n)}. Open.",
-    "proofStrategy": "The formalization defines a `PlanarPointSet` as a positive-cardinality finite subset of $\\mathbb{R}^2$, introduces collinearity via the signed area determinant, and defines `NoFiveCollinear` (at most four points per line). The four-point line count is computed by filtering the powerset for collinear 4-subsets. Since the problem is open, the main conjecture and all known partial results (Grünbaum's lower bound, Solymosi–Stojaković's near-quadratic construction, trivial upper bound, Szemerédi–Trotter) are stated as axioms.",
+    "proofStrategy": "The formalization defines a `PlanarPointSet` as a positive-cardinality finite subset of $\\mathbb{R}^2$, introduces collinearity via the signed area determinant, and defines `NoFiveCollinear` (at most four points per line). The four-point line count is computed by filtering the powerset for collinear 4-subsets. The file is axiom-free (`axiomCount` 0): the open conjecture $o(n^2)$ and the historical lower bounds (Grünbaum, Solymosi–Stojaković, Szemerédi–Trotter) are recorded only as documentation comments, while every numerical claim that is asserted is fully proved. The proved core is a ladder of unconditional upper bounds — $f_4 \\leq n^2$ (`trivial_upper_bound_sq`), $f_4 \\leq n(n-1)/2$ (`trivial_upper_bound`), $f_4 \\leq n(n-1)/12$ (`improved_upper_bound`), and a per-point bound $\\leq (n-1)/3$ (`fourCollinearThrough_bound`) — all resting on the line bound (`noFiveCollinear_line_bound`: every line has $\\leq 4$ points) and the overlap lemma (distinct four-point lines meet in $\\leq 1$ point), packed via disjoint pair-sets and reconciled by a double-counting identity.",
     "keyInsights": [
       "The no-five-collinear condition is the precise threshold: with five points on a line, one can trivially arrange $\\Theta(n)$ points on each of $\\Theta(n)$ lines to get $\\Omega(n^2)$ four-point lines",
       "Grünbaum's $\\Omega(n^{3/2})$ construction uses grid-like arrangements that balance collinear quadruples against the five-point restriction",


### PR DESCRIPTION
## Summary
Both the `sections` array and `annotations.json` for `erdos-101` had drifted badly — they described an earlier ~100-line version of `Erdos101Problem.lean`, which has since grown to 758 lines of fully-proved content.

**Sections (6 → 13):** the old array mislabeled mid-file ranges (e.g. `main-conjecture` pointed at lines 49–58, but the real Main Conjecture banner is at line 283) and dumped 600+ lines into a single `related-observations` mega-section (83–757). Rebuilt 13 contiguous sections aligned to the file's `##` banners, now covering lines 1–758: collinearity properties, structural/line bound, uniqueness, main conjecture, known results + trivial bounds, the improved n(n−1)/12 bound, related observations, F family, per-point bound, structural lemmas, and the double-counting connection. Each carries a `mathContext`.

**Annotations (all 10 realigned):** 2 were silently dropped (anchored on `open Classical in` and a blank-line gap) and 5 more overlaid the wrong code (e.g. the Szemerédi–Trotter note sat on a collinearity reflexivity lemma). Repointed each annotation to its current-file location. The resolver now reports **10/10 valid, 0 misaligned** (was 8 valid + 2 dropped + 5 mis-anchored).

**De-staled axiom prose:** `proofStrategy` and the main-conjecture annotation claimed results were "stated as axioms", but `axiomCount` is 0 — the conjecture and historical lower bounds are documentation comments, and the upper bounds (`trivial_upper_bound_sq`, `trivial_upper_bound`, `improved_upper_bound`, `fourCollinearThrough_bound`) are fully proved theorems. Corrected to reflect the axiom-free reality.

No Lean source changed; counts (23 thm / 5 def / 0 axiom / 0 sorry) were already accurate.

## Test plan
- [x] meta.json + annotations.json parse (build JSON-validation stage passes)
- [x] Sections contiguous, cover lines 1–758
- [x] `resolver.ts validate` → 10/10 annotations valid, 0 misaligned
- [x] Only `src/data/proofs/erdos-101/` staged