### PR TITLE
research(erdos-1001-oq-02): realign drifted gallery sections to full file (5→8)

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -87,44 +87,68 @@
   },
   "sections": [
     {
-      "id": "header-imports",
+      "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 74,
-      "summary": "Module header with imports, docstring, and namespace setup.",
-      "mathContext": "The open question: $S(N,A,c) = \\frac{1}{N}\\#\\{1 \\leq n \\leq N : \\{n\\alpha\\} \\in [0, A)\\}$ converges to $f(A,c) = A$ (or the ESP value) by Kesten-Sós; this file asks for the *rate* $|S(N,A,c) - f(A,c)|$. The EST regime ($0 < A < c/(1+c^2)$, approximation intervals disjoint) enables the reduction to a weighted Euler totient sum: $S(N,A,c) = 2A \\sum_{y=N}^{cN} \\varphi(y)/y^2 + O(A/N)$. By Mertens ($\\sum_{y \\leq x} \\varphi(y)/y^2 \\sim (6/\\pi^2)\\log x$) and Abel summation, the error is $O(A \\log N / N)$. Imports `Proofs.Erdos1001Problem` for the parent $S(N,A,c)$ infrastructure and `Mathlib` for `Nat.totient`, `Real.log`, and asymptotic analysis."
+      "endLine": 47,
+      "summary": "States Erdős #1001 OQ-02: the rate of convergence of $S(N,A,c)$ to $f(A,c)$. In the EST regime ($0<A<c/(1+c^2)$) the rate is $O(A\\log N/N)$, reducing (via Mertens + Abel summation) to $\\sum_{y=N}^{cN}\\varphi(y)/y^2=(6/\\pi^2)\\log c+O(\\log N/N)$. Status AXIOMATIZED (the totient partial-sum asymptotic is a Mathlib gap). Imports measure theory, Diophantine, asymptotics.",
+      "mathContext": "$|S(N,A,c)-f(A,c)|=O(A\\log N/N)$ in EST regime; reduces to $\\sum\\varphi(y)/y^2$ asymptotic."
     },
     {
-      "id": "weighted-totient-sum",
-      "title": "Weighted Totient Sum",
-      "summary": "Definitions: weightedTotientSum, rangeTotientSum, densityConst",
-      "startLine": 75,
-      "endLine": 100,
-      "mathContext": "Formal definition: T(n) = ∑_{y=1}^n φ(y)/y² and range variant"
+      "id": "parent-defs",
+      "title": "Core Definitions (from Parent Problem)",
+      "startLine": 48,
+      "endLine": 73,
+      "summary": "Defines `isApproximable` ($|\\alpha-x/y|<A/y^2$ for coprime $x$), `approximationSet`, `S` (its Lebesgue measure), `f A c` $=12A\\log c/\\pi^2$ (the EST formula), and `inESTRegime` ($0<A<c/(1+c^2)$).",
+      "mathContext": "$S(N,A,c)=\\text{vol}(\\text{approximationSet})$; $f(A,c)=12A\\log c/\\pi^2$; EST: $0<A<c/(1+c^2)$."
+    },
+    {
+      "id": "weighted-totient",
+      "title": "Weighted Totient Sum Asymptotics",
+      "startLine": 74,
+      "endLine": 93,
+      "summary": "Defines `weightedTotientSum` ($T(n)=\\sum_{y\\leq n}\\varphi(y)/y^2$), `logOverN` ($\\log N/N$), and `rangeTotientSum` ($\\sum_{y=N}^{\\lfloor cN\\rfloor}\\varphi(y)/y^2$) — the key quantity for the rate.",
+      "mathContext": "$\\text{rangeTotientSum}(N,c)=\\sum_{y=N}^{cN}\\varphi(y)/y^2$."
     },
     {
       "id": "asymptotic-analysis",
       "title": "Asymptotic Analysis",
-      "summary": "Axioms for qualitative and quantitative asymptotics of the range totient sum",
-      "startLine": 101,
-      "endLine": 135,
-      "mathContext": "Mathematical content: ∑_{y=N}^{cN} φ(y)/y² = (6/π²)log(c) + O(log N/N)"
+      "startLine": 94,
+      "endLine": 127,
+      "summary": "Defines `densityConst` $=6/\\pi^2$ and states the two AXIOMS encoding the deep analytic input: `rangeTotientSum_asymptotic` (converges to $(6/\\pi^2)\\log c$) and `rangeTotientSum_error` (error is $O(\\log N/N)$). Both reduce to the missing Mertens/totient partial-sum asymptotic in Mathlib.",
+      "mathContext": "Axioms: $\\sum_{y=N}^{cN}\\varphi(y)/y^2\\to(6/\\pi^2)\\log c$ with error $O(\\log N/N)$."
     },
     {
       "id": "main-rate",
       "title": "Main Rate Theorem",
-      "summary": "Axiom: |S(N,A,c) - f(A,c)| = O(A log N / N) in EST regime",
-      "startLine": 136,
-      "endLine": 160,
-      "mathContext": "Mathematical content: convergence_rate_est axiom with proof sketch"
+      "startLine": 128,
+      "endLine": 152,
+      "summary": "States the AXIOM `convergence_rate_est`: in the EST regime, $|S(N,A,c)-f(A,c)|=O(A\\log N/N)$ — the main result, reduced to the range totient sum error plus a disjointness/boundary argument.",
+      "mathContext": "Axiom: $|S(N,A,c)-f(A,c)|=O(A\\log N/N)$ (EST regime)."
     },
     {
       "id": "consequences",
-      "title": "Consequences",
-      "summary": "Rate better than 1/√N; effective bound; connection to three-distance theorem",
-      "startLine": 161,
-      "endLine": 200,
-      "mathContext": "Bound: rate implies convergence faster than O(1/√N)"
+      "title": "Consequences of the Rate",
+      "startLine": 153,
+      "endLine": 249,
+      "summary": "PROVES corollaries of the rate axiom: `convergence_faster_than_sqrtN` ($|S-f|=o(1/\\sqrt N)$, since $\\log N/N=o(1/\\sqrt N)$), `rate_is_nontrivial` ($|S-f|=o(1)$), and `convergence_effective` (for every $\\varepsilon$, eventually $|S-f|<\\varepsilon$).",
+      "mathContext": "$|S-f|=o(1/\\sqrt N)=o(1)$; effective $\\varepsilon$-bound."
+    },
+    {
+      "id": "three-distance",
+      "title": "Connection to Quantitative Metric Theory",
+      "startLine": 250,
+      "endLine": 266,
+      "summary": "Defines `three_distance_connection` (the rate restated) and PROVES `three_distance_connection_holds` — relating the $O(\\log N/N)$ rate to the three-distance theorem (the slower $\\log N/N$ reflects averaging over all $\\alpha$).",
+      "mathContext": "Rate $O(A\\log N/N)$ consistent with three-distance theorem (averaged over $\\alpha$)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 267,
+      "endLine": 315,
+      "summary": "A docstring documenting the formalization path (Mertens $\\to$ Abel summation $\\to$ EST measure formula) and the precise Mathlib gap (the totient partial-sum asymptotic $\\sum_{y\\leq N}\\varphi(y)=(3/\\pi^2)N^2+O(N\\log N)$, missing as of v4.26). PROVES `erdos_1001_oq_02_summary` (the headline rate, from `convergence_rate_est`).",
+      "mathContext": "Status AXIOMATIZED, blocked on Mathlib totient asymptotic $\\sum_{y\\leq N}\\varphi(y)=(3/\\pi^2)N^2+O(N\\log N)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #1001 OQ-02 (rate of convergence of S(N,A,c)) gallery `meta.json` had **section drift**.

- Sections covered only lines 1-200 of a **315**-line file. "Consequences" was tagged @161-200 but its content runs past 200 (`convergence_effective` @235), and the trailing sections were entirely hidden: "Connection to Quantitative Metric Theory" (@250-266) and "Summary" (@267-315: the headline theorem `erdos_1001_oq_02_summary` plus the detailed Mathlib-gap analysis).

## Changes
- Rebuilt **8 sections** (was 5) with full-file coverage **1-315** (splitting header from the parent-import definitions and adding the Connection and Summary sections).
- **Counts already correct**: 5 theorems / 10 definitions / 3 axioms / 0 sorries, lineCount 315. (A naive grep shows a 6th "theorem" but that is prose inside the Summary docstring — "Mertens' theorem with quantitative error".)

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-315 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-1001-oq-02
- [x] Declaration counts re-verified against `Erdos1001OQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)