### PR TITLE
research(erdos-353): realign drifted gallery sections to full file (10→11)

### DIFF
--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -81,82 +81,90 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "HasInfiniteMeasure, triangleArea, quadrilateralArea",
-      "startLine": 40,
-      "endLine": 68,
-      "mathContext": "Mathematical content: HasInfiniteMeasure, triangleArea, quadrilateralArea"
+      "summary": "Problem statement (isosceles trapezoid/triangle/right-triangle/cyclic-quadrilateral/congruent-sides of area 1 in infinite-measure sets); HasInfiniteMeasure, triangleArea, quadrilateralArea",
+      "startLine": 1,
+      "endLine": 69,
+      "mathContext": "Mathematical content: Problem statement (isosceles trapezoid/triangle/right-triangle/cyclic-quadrilateral/congruent-sides of area 1 in infinite-measure sets); HasInfiniteMeasure, triangleArea, quadrilateralArea"
     },
     {
       "id": "geometric-configurations",
       "title": "Geometric Configurations",
-      "summary": "Isosceles triangle, right triangle, trapezoid, parallelogram, cyclic quadrilateral",
-      "startLine": 69,
-      "endLine": 130,
-      "mathContext": "Mathematical content: Isosceles triangle, right triangle, trapezoid, parallelogram, cyclic quadrilateral"
+      "summary": "Predicates for the target shapes: IsIsoscelesTriangle, IsRightTriangle, IsIsoscelesTrapezoid, IsParallelogram, IsCyclicQuadrilateral, HasCongruentSides",
+      "startLine": 70,
+      "endLine": 131,
+      "mathContext": "Mathematical content: Predicates for the target shapes: IsIsoscelesTriangle, IsRightTriangle, IsIsoscelesTrapezoid, IsParallelogram, IsCyclicQuadrilateral, HasCongruentSides"
     },
     {
-      "id": "existence-predicates",
-      "title": "Configuration Existence",
-      "summary": "HasTriangleWithArea and related predicates",
-      "startLine": 131,
-      "endLine": 185,
-      "mathContext": "Mathematical content: HasTriangleWithArea and related predicates"
+      "id": "configuration-existence",
+      "title": "Configuration Existence in Sets",
+      "summary": "\"contains an area-t configuration with vertices in A\" predicates: HasTriangleWithArea, HasIsoscelesTriangleWithArea, HasRightTriangleWithArea, HasIsoscelesTrapezoidWithArea, HasCyclicQuadrilateralWithArea",
+      "startLine": 132,
+      "endLine": 186,
+      "mathContext": "Mathematical content: \"contains an area-t configuration with vertices in A\" predicates: HasTriangleWithArea, HasIsoscelesTriangleWithArea, HasRightTriangleWithArea, HasIsoscelesTrapezoidWithArea, HasCyclicQuadrilateralWithArea"
     },
     {
-      "id": "koizumi",
-      "title": "Koizumi's Theorems (2025)",
-      "summary": "Isosceles trapezoid, triangle, and right triangle existence",
-      "startLine": 186,
-      "endLine": 216,
-      "mathContext": "Mathematical content: Isosceles trapezoid, triangle, and right triangle existence"
+      "id": "koizumi-main-results",
+      "title": "Main Results — Koizumi (2025)",
+      "summary": "Koizumi's 2025 resolution as axioms: every infinite-measure set contains an isosceles trapezoid, isosceles triangle, and right triangle of area 1",
+      "startLine": 187,
+      "endLine": 217,
+      "mathContext": "Mathematical content: Koizumi's 2025 resolution as axioms: every infinite-measure set contains an isosceles trapezoid, isosceles triangle, and right triangle of area 1"
     },
     {
       "id": "kovac",
       "title": "Kovač Results (2023-2024)",
-      "summary": "Trapezoids, parallelogram counterexample, cyclic quadrilaterals",
-      "startLine": 217,
-      "endLine": 255,
-      "mathContext": "Mathematical content: Trapezoids, parallelogram counterexample, cyclic quadrilaterals"
+      "summary": "Kovač trapezoid theorem and parallelogram counterexample (prose); Kovač-Predojević cyclic quadrilateral axiom",
+      "startLine": 218,
+      "endLine": 242,
+      "mathContext": "Mathematical content: Kovač trapezoid theorem and parallelogram counterexample (prose); Kovač-Predojević cyclic quadrilateral axiom"
     },
     {
       "id": "congruent-sides",
       "title": "Congruent Sides Result",
-      "summary": "Counterexample for congruent-sided polygons",
-      "startLine": 256,
-      "endLine": 273,
-      "mathContext": "Mathematical content: Counterexample for congruent-sided polygons"
+      "summary": "Kovač-Predojević congruent-sided polygon counterexample: an infinite-measure set in which every congruent-sided convex polygon has area < 1",
+      "startLine": 243,
+      "endLine": 251,
+      "mathContext": "Mathematical content: Kovač-Predojević congruent-sided polygon counterexample: an infinite-measure set in which every congruent-sided convex polygon has area < 1"
     },
     {
-      "id": "infinite-measure",
+      "id": "why-infinite-measure",
       "title": "Why Infinite Measure Matters",
-      "summary": "Finite measure fails; density arguments",
-      "startLine": 274,
-      "endLine": 294,
-      "mathContext": "Mathematical content: Finite measure fails; density arguments"
+      "summary": "Why infinite measure is essential: finite-measure sets may contain no area-1 triangle; density argument behind the existence proofs",
+      "startLine": 252,
+      "endLine": 266,
+      "mathContext": "Mathematical content: Why infinite measure is essential: finite-measure sets may contain no area-1 triangle; density argument behind the existence proofs"
     },
     {
-      "id": "scaling",
-      "title": "Scaling Properties",
-      "summary": "Configurations of any positive area exist",
-      "startLine": 295,
-      "endLine": 319,
-      "mathContext": "Mathematical content: Configurations of any positive area exist"
+      "id": "scaling-infrastructure",
+      "title": "Scaling Properties — Infrastructure",
+      "summary": "Supporting lemmas: inv_smul_set_eq_preimage, hasInfiniteMeasure_inv_smul (Haar scaling preserves infinite measure), isIsoscelesTriangle_smul, triangleArea_smul_eq (area scales by c²)",
+      "startLine": 267,
+      "endLine": 325,
+      "mathContext": "Mathematical content: Supporting lemmas: inv_smul_set_eq_preimage, hasInfiniteMeasure_inv_smul (Haar scaling preserves infinite measure), isIsoscelesTriangle_smul, triangleArea_smul_eq (area scales by c²)"
+    },
+    {
+      "id": "scaling-main-result",
+      "title": "Scaling Properties — Main Result",
+      "summary": "scaling_property: infinite-measure sets contain isosceles triangles of every positive area t (scale by 1/√t, apply Koizumi, scale back); all_areas_isosceles corollary",
+      "startLine": 326,
+      "endLine": 373,
+      "mathContext": "Mathematical content: scaling_property: infinite-measure sets contain isosceles triangles of every positive area t (scale by 1/√t, apply Koizumi, scale back); all_areas_isosceles corollary"
     },
     {
       "id": "connections",
-      "title": "Connections",
-      "summary": "Erdős distance problem, Ramsey theory",
-      "startLine": 320,
-      "endLine": 337,
-      "mathContext": "Mathematical content: Erdős distance problem, Ramsey theory"
+      "title": "Connections to Other Problems",
+      "summary": "Links to the Erdős distinct-distances / unit-distance problems and Ramsey-theoretic flavor of finding configurations in large sets",
+      "startLine": 374,
+      "endLine": 389,
+      "mathContext": "Mathematical content: Links to the Erdős distinct-distances / unit-distance problems and Ramsey-theoretic flavor of finding configurations in large sets"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Main results and status theorem",
-      "startLine": 338,
-      "endLine": 362,
-      "mathContext": "Main results and status theorem (axiomatized)"
+      "summary": "erdos_353_summary and erdos_353_status collecting the resolved answers (trapezoid/triangle/right-triangle/cyclic YES, parallelogram NO, congruent-sided not always)",
+      "startLine": 390,
+      "endLine": 445,
+      "mathContext": "Mathematical content: erdos_353_summary and erdos_353_status collecting the resolved answers (trapezoid/triangle/right-triangle/cyclic YES, parallelogram NO, congruent-sided not always)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Realigns the gallery `sections` for Erdős Problem #353 (geometric configurations in infinite-measure planar sets) to the actual Lean source.
- The back half of the section list had drifted and the final section ended at line 362, leaving lines 363-445 (Connections, Summary, and `erdos_353_status`) uncovered.
- `Erdos353Problem.lean` has 11 `## Part` banners — Part VIII is a real two-way split (Scaling Infrastructure vs. Main Result). Rebuilt 11 contiguous sections covering lines 1-445, one per banner.

## Details
- Sections-only change; no proof, axiom, or count changes (8 theorems / 4 axioms / 14 defs / 0 sorries, all pre-correct and untouched).
- Build-free metadata realignment.

## Test plan
- [x] `jq` validates meta.json
- [x] Sections contiguous and cover full file (1-445)
- [x] No count/status fields modified