### PR TITLE
research(erdos-1056): realign drifted gallery sections to file (8→8)

### DIFF
--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -39,64 +39,64 @@
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "startLine": 22,
-      "endLine": 30,
+      "startLine": 1,
+      "endLine": 32,
       "summary": "Imports $\\texttt{Mathlib.Data.Nat.Prime.Basic}$, $\\texttt{Finset.Basic}$, and general tactics. Opens $\\texttt{Finset}$ namespace for $\\texttt{Ico}$ and $\\texttt{prod}$.",
       "mathContext": "Mathematical content: Imports $\\texttt{Mathlib.Data.Nat.Prime.Basic}$, $\\texttt{Finset.Basic}$, and general tactics. Opens $\\texttt{Finset}$ namespace for $\\texttt{Ico}$ and $\\texttt{prod}$."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 31,
-      "endLine": 53,
+      "startLine": 33,
+      "endLine": 55,
       "summary": "Defines $\\text{intervalProd}(a, b) = \\prod_{i=a}^{b-1} i$ via $\\texttt{Finset.Ico}$, validity of boundary sequences ($k+1$ strictly increasing points), the congruence condition $\\prod \\equiv 1 \\pmod{p}$ for all $k$ intervals, and $\\text{HasSolution}(k)$.",
       "mathContext": "Defines $\\text{intervalProd}(a, b) = \\prod_{i=a}^{b-1} i$ via $\\texttt{Finset.Ico}$, validity of boundary sequences ($k+1$ strictly increasing points), the congruence condition $\\prod \\equiv 1 \\pmod{p}$ for all $k$ intervals, and $\\text{HasSolution}(k)$."
     },
     {
       "id": "infrastructure",
       "title": "Infrastructure Lemmas",
-      "startLine": 54,
-      "endLine": 94,
+      "startLine": 56,
+      "endLine": 96,
       "summary": "Proves six supporting lemmas: empty interval product equals 1, boundary list properties (length, chain, count), interval product positivity for $a \\ge 1$, and closure of $\\equiv 1 \\pmod{p}$ under multiplication ($a \\equiv 1, b \\equiv 1 \\implies ab \\equiv 1$).",
       "mathContext": "Proves six supporting lemmas: empty interval product equals 1, boundary list properties (length, chain, count), interval product positivity for $a \\ge 1$, and closure of $\\equiv 1 \\pmod{p}$ under multiplication ($a \\equiv 1, b \\equiv 1 \\implies ab \\equiv 1$)."
     },
     {
       "id": "verified-solutions",
       "title": "Verified Solutions",
-      "startLine": 95,
-      "endLine": 151,
+      "startLine": 97,
+      "endLine": 153,
       "summary": "Computational verification via $\\texttt{native\\_decide}$: Erdős's $k=2$ ($p=11$, $3 \\cdot 4 \\equiv 5 \\cdot 6 \\cdot 7 \\equiv 1$), Makowski's $k=3$ ($p=17$, three intervals), combined result, non-triviality proof, and observation that both solutions use odd primes $p > 2$.",
       "mathContext": "Computational verification via $\\texttt{native\\_decide}$: Erdős's $k=2$ ($p=11$, $3 \\cdot 4 \\equiv 5 \\cdot 6 \\cdot 7 \\equiv 1$), Makowski's $k=3$ ($p=17$, three intervals), combined result, non-triviality proof, and observation that both solutions use odd primes $p > 2$."
     },
     {
       "id": "wilson-connection",
       "title": "Wilson's Theorem Connection",
-      "startLine": 152,
-      "endLine": 172,
+      "startLine": 154,
+      "endLine": 190,
       "summary": "Verifies Wilson's theorem for $p = 11$ and $p = 17$ computationally, then states the general constraint: $(p-1)! \\equiv -1 \\pmod{p}$ implies intervals with product $\\equiv 1$ cannot partition $\\{1, \\ldots, p-1\\}$.",
       "mathContext": "Verifies Wilson's theorem for $p = 11$ and $p = 17$ computationally, then states the general constraint: $(p-1)! \\equiv -1 \\pmod{p}$ implies intervals with product $\\equiv 1$ cannot partition $\\{1, \\ldots, p-1\\}$."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 173,
-      "endLine": 179,
+      "startLine": 191,
+      "endLine": 197,
       "summary": "Axiomatizes the open conjecture: $\\forall k \\ge 2$, $\\text{HasSolution}(k)$. Only $k = 2$ and $k = 3$ are verified; no $k = 4$ solution is known.",
       "mathContext": "Axiomatized: Axiomatizes the open conjecture: $\\forall k \\ge 2$, $\\text{HasSolution}(k)$. Only $k = 2$ and $k = 3$ are verified; no $k = 4$ solution is known."
     },
     {
       "id": "noll-simmons",
       "title": "Noll–Simmons Generalization",
-      "startLine": 180,
-      "endLine": 193,
-      "summary": "Axiomatizes the Noll–Simmons conjecture: $\\forall k, \\exists p$ prime with $k$ values $q_1 < \\cdots < q_k < p$ satisfying $q_1! \\equiv \\cdots \\equiv q_k! \\pmod{p}$. Weaker than the interval product conjecture since it drops consecutiveness.",
-      "mathContext": "Axiomatizes the Noll–Simmons conjecture: $\\forall k, \\exists p$ prime with $k$ values $q_1 < \\cdots < q_k < p$ satisfying $q_1! \\pmod{p}$."
+      "startLine": 198,
+      "endLine": 206,
+      "summary": "States the Noll–Simmons question (prose, not formalized): $\\forall k, \\exists p$ prime with $k$ values $q_1 < \\cdots < q_k < p$ satisfying $q_1! \\equiv \\cdots \\equiv q_k! \\pmod{p}$. Weaker than the interval-product formulation; recorded as motivation, not as an axiom.",
+      "mathContext": "States the Noll–Simmons question (prose, not formalized): $\\forall k, \\exists p$ prime with $k$ values $q_1 < \\cdots < q_k < p$ satisfying $q_1! \\equiv \\cdots \\equiv q_k! \\pmod{p}$."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 194,
-      "endLine": 204,
+      "startLine": 207,
+      "endLine": 217,
       "summary": "Packages all verified results: $\\text{HasSolution}(2) \\land \\text{HasSolution}(3) \\land (10! \\equiv 10 \\pmod{11}) \\land (16! \\equiv 16 \\pmod{17})$.",
       "mathContext": "Mathematical content: Packages all verified results: $\\text{HasSolution}(2) \\land \\text{HasSolution}(3) \\land (10! \\equiv 10 \\pmod{11}) \\land (16! \\equiv 16 \\pmod{17})$."
     }


### PR DESCRIPTION
## Summary
- The back-half sections of `erdos-1056` (Erdős #1056, factorial-interval products ≡ 1 mod p) had drifted ~18 lines early: **Main Conjecture**, **Noll–Simmons Generalization**, and **Summary Theorem** all pointed before their actual `## Part` banners.
- This left the file **tail 205–217 uncovered** (including the `erdos_1056_summary` theorem) and the **header 1–21 uncovered**.
- Re-snapped all 8 section ranges to the `Part I–VII` banners for full 1–217 coverage.
- Corrected the Noll–Simmons summary, which wrongly claimed the question was *axiomatized* — `axiomCount=1` (only `erdos_1056_conjecture`); Noll–Simmons is stated as prose, not formalized.

## Details
| Section | Old range | New range |
|---|---|---|
| Imports and Setup | 22–30 | 1–32 |
| Core Definitions | 31–53 | 33–55 |
| Infrastructure Lemmas | 54–94 | 56–96 |
| Verified Solutions | 95–151 | 97–153 |
| Wilson's Theorem Connection | 152–172 | 154–190 |
| Main Conjecture | 173–179 | 191–197 |
| Noll–Simmons Generalization | 180–193 | 198–206 |
| Summary Theorem | 194–204 | 207–217 |

Counts unchanged and pre-correct (1ax/15thm/4def/0sry, 217 lines). Build-free metadata-only change; titles and summary content preserved except the Noll–Simmons accuracy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)