### PR TITLE
research(wilsons-theorem-oq-01): realign drifted gallery sections to file (11→14)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -97,92 +97,116 @@
   ],
   "sections": [
     {
-      "id": "sec-wq01-infra",
-      "title": "Factorial Infrastructure",
-      "startLine": 58,
-      "endLine": 80,
+      "id": "overview",
+      "title": "Overview: Wilson's Theorem for Non-Prime Moduli",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring and imports. States the program: Wilson's theorem ((p-1)! ≡ -1 mod p iff p prime) and its generalizations to composite moduli — composite factorial vanishing, the n=4 exception, the complete trichotomy, the Wilson quotient and Wilson primes, and Gauss's classification of when the product of units mod n is -1.",
+      "mathContext": "Wilson's theorem: $(p-1)! \\equiv -1 \\pmod{p} \\iff p$ prime. This file develops the composite-modulus picture: for composite $n>4$, $(n-1)! \\equiv 0$; the unique exception $n=4$ gives $3! \\equiv 2$; and Gauss's generalization $\\prod (\\mathbb{Z}/n\\mathbb{Z})^* \\equiv -1 \\iff n \\in \\{1,2,4,p^k,2p^k\\}$ (odd prime $p$). Imports include Mathlib's Wilson theory and the companion `Proofs.WilsonsTheoremOQ02`."
+    },
+    {
+      "id": "infrastructure",
+      "title": "Infrastructure: Factorial as Finset Product",
+      "startLine": 53,
+      "endLine": 81,
       "summary": "factorial_eq_Icc_prod expresses n! as a Finset.Icc product; distinct_factors_dvd_factorial proves a·b | n! when a,b are distinct elements of {1,...,n}.",
       "mathContext": "$n! = \\prod_{k \\in \\{1,\\ldots,n\\}} k = \\mathrm{Finset.Icc}\\,1\\,n$ product. Key lemma $\\texttt{distinct\\_factors\\_dvd\\_factorial}$: if $a,b \\in \\{1,\\ldots,n\\}$ with $a \\neq b$, then $a \\cdot b \\mid n!$ — both factors appear with distinct indices in the product, so their product divides the overall product."
     },
     {
-      "id": "sec-wq01-composite",
-      "title": "Composite Factorial Vanishing",
-      "startLine": 88,
-      "endLine": 131,
+      "id": "composite-factorial-vanishing",
+      "title": "Part 1: Composite Factorial Vanishing",
+      "startLine": 82,
+      "endLine": 132,
       "summary": "composite_factorial_dvd: for composite n > 4, n | (n-1)!. Case split on n = p² vs n = p·q (p≠q). composite_factorial_zero: ZMod formulation.",
       "mathContext": "$\\texttt{composite\\_factorial\\_dvd}$: $n$ composite, $n > 4 \\Rightarrow n \\mid (n-1)!$. Two cases: (1) $n = p^2$ ($p \\geq 3$ prime): $p$ and $2p$ are distinct elements of $\\{1,\\ldots,n-1\\}$ (since $2p \\leq p^2 - 1$ for $p \\geq 3$), so $p \\cdot 2p = 2p^2 \\equiv 0 \\pmod{p^2}$. (2) $n = ab$ with $a \\neq b$ ($a,b > 1$): $a,b \\in \\{1,\\ldots,n-1\\}$ distinct, so $ab = n \\mid (n-1)!$ by $\\texttt{distinct\\_factors\\_dvd\\_factorial}$."
     },
     {
-      "id": "sec-wq01-classification",
-      "title": "Special Cases and Complete Trichotomy",
-      "startLine": 138,
-      "endLine": 187,
+      "id": "special-cases-classification",
+      "title": "Part 2: Special Cases and Complete Classification",
+      "startLine": 133,
+      "endLine": 188,
       "summary": "factorial_mod_four (n=4: 3!≡2), small prime/composite verifications, wilson_complete_classification (trichotomy for n≥2), prime_iff_factorial_neg_one (biconditional primality test).",
       "mathContext": "$\\texttt{wilson\\_complete\\_classification}$: for $n \\geq 2$, $(n-1)! \\bmod n \\in \\{-1, 2, 0\\}$ according to: $-1$ if $n$ is prime, $2$ if $n = 4$, $0$ if $n$ is composite and $n > 4$. Special case: $3! = 6 \\equiv 2 \\pmod{4}$ — the unique exception where neither Wilson's formula nor divisibility holds. Biconditional: $n$ prime $\\iff (n-1)! \\equiv -1 \\pmod{n}$."
     },
     {
-      "id": "sec-wq01-quotient",
-      "title": "Wilson Quotient",
-      "startLine": 193,
-      "endLine": 224,
+      "id": "wilson-quotient",
+      "title": "Part 3: Wilson Quotient",
+      "startLine": 189,
+      "endLine": 225,
       "summary": "wilsonQuotient definition, prime_dvd_factorial_succ (p | (p-1)!+1), wilsonQuotient_mul, wilsonQuotient_pos. Computed values for p = 2,3,5,7,11,13.",
       "mathContext": "Wilson quotient $W_p = ((p-1)! + 1) / p \\in \\mathbb{N}$ — an integer since $p \\mid (p-1)! + 1$ by Wilson's theorem. $\\texttt{wilsonQuotient\\_pos}$: $W_p \\geq 1$ (since $(p-1)! + 1 \\geq p$). A prime $p$ is a Wilson prime iff $p \\mid W_p$. Values: $W_2 = 1$, $W_3 = 1$, $W_5 = 5$, $W_7 = 103$, $W_{11} = 329891$, $W_{13} = 428731$."
     },
     {
-      "id": "sec-wq01-wilson-primes",
-      "title": "Wilson Primes",
-      "startLine": 230,
-      "endLine": 269,
+      "id": "wilson-primes",
+      "title": "Part 4: Wilson Primes",
+      "startLine": 226,
+      "endLine": 270,
       "summary": "IsWilsonPrime definition (p² | (p-1)!+1), isWilsonPrime_iff_quotient, five_is_wilson_prime, thirteen_is_wilson_prime, and non-Wilson primes (2,3,7,11).",
       "mathContext": "$\\texttt{IsWilsonPrime}\\,p$: $p^2 \\mid (p-1)! + 1$, equivalently $p \\mid W_p$. Verified: $5^2 = 25 \\mid 4! + 1 = 25$ ✓; $13^2 = 169 \\mid 12! + 1$ ✓. Non-Wilson: $2^2 = 4 \\nmid 1 + 1 = 2$, $7^2 = 49 \\nmid 720 + 1 = 721$. Known Wilson primes: 5, 13, 563 (Goldberg 1953); no fourth found below $2 \\times 10^{13}$."
     },
     {
-      "id": "sec-wq01-units-product",
-      "title": "Units Product and Gauss-Wilson Form",
-      "startLine": 280,
-      "endLine": 372,
-      "summary": "unitsProduct definition, hasGaussWilsonForm decidable check, gaussWilsonCheck verification procedure, gaussWilson_verified_le_50 and extended computational checks.",
-      "mathContext": "$\\texttt{unitsProduct}\\,n = \\prod_{a \\in (\\mathbb{Z}/n\\mathbb{Z})^*} a \\in \\mathbb{Z}/n\\mathbb{Z}$. Gauss-Wilson form: $n \\in \\{1, 2, 4, p^k, 2p^k\\}$ for odd prime $p$. The decidable predicate $\\texttt{hasGaussWilsonForm}\\,n$ checks this form. Computationally verified for $n \\leq 50$: $\\texttt{unitsProduct}\\,n \\equiv -1 \\pmod{n}$ iff $n$ is in the Gauss-Wilson family."
+      "id": "gauss-units-product",
+      "title": "Part 5: Gauss's Generalization (Product of Units)",
+      "startLine": 271,
+      "endLine": 302,
+      "summary": "Defines `unitsProduct n` as the product of all residues in {0,...,n-1} coprime to n. `native_decide` examples confirm the dichotomy: unitsProduct n ≡ n-1 (i.e. -1) mod n for n ∈ {2,3,4,5,6,7,9,10,11,13,25} and ≡ 1 for n ∈ {8,12,15,16,24}.",
+      "mathContext": "$\\texttt{unitsProduct}\\,n = \\prod_{\\substack{0 \\le a < n \\\\ \\gcd(a,n)=1}} a$. Gauss's generalization: $\\texttt{unitsProduct}\\,n \\equiv -1 \\pmod n$ when $n \\in \\{1,2,4,p^k,2p^k\\}$ (odd prime $p$), and $\\equiv 1$ otherwise. The `native_decide` examples exhibit both regimes (e.g. $\\texttt{unitsProduct}\\,9 \\equiv 8 \\equiv -1$, while $\\texttt{unitsProduct}\\,8 \\equiv 1$)."
     },
     {
-      "id": "sec-wq01-bridge-factorial",
-      "title": "Bridge: Units Product ↔ Factorial for Primes",
-      "startLine": 383,
-      "endLine": 440,
+      "id": "gauss-wilson-classification-decidable",
+      "title": "Part 6: The Gauss-Wilson Classification (Decidable Form)",
+      "startLine": 303,
+      "endLine": 373,
+      "summary": "Decidable machinery for the classification: `isPowerOfAux` (is x a power of base), `hasGaussWilsonForm n` (Bool test for n ∈ {≤2, 4, p^k, 2p^k}), and `gaussWilsonCheck n` comparing unitsProduct n % n == n-1 against the form. `gaussWilson_verified_le_50` proves the two sides agree for all 3 ≤ n ≤ 50 by native_decide, with worked examples (27, 49, 14, 18, 50 give -1; 20, 21, 30, 32, 36, 40, 48 give 1).",
+      "mathContext": "Decidable predicate $\\texttt{hasGaussWilsonForm}\\,n$ recognizes $n \\in \\{1,2,4\\} \\cup \\{p^k, 2p^k : p\\text{ odd prime}\\}$ via $\\texttt{minFac}$ and a structural power check $\\texttt{isPowerOfAux}$ (with explicit `termination_by`/`decreasing_by`). $\\texttt{gaussWilson\\_verified\\_le\\_50}$: $\\forall\\, 3 \\le n \\le 50,\\ (\\texttt{unitsProduct}\\,n \\bmod n = n-1) \\Leftrightarrow \\texttt{hasGaussWilsonForm}\\,n$, established by `native_decide`."
+    },
+    {
+      "id": "bridge-units-factorial",
+      "title": "Part 7: Bridge Between unitsProduct and Factorial",
+      "startLine": 374,
+      "endLine": 441,
       "summary": "prime_coprime_iff_pos, unitsProduct_eq_factorial (for primes, unitsProduct = (p-1)!), unitsProduct_prime (Wilson's theorem via unitsProduct), wilson_product_form (Mathlib ZMod.prod_Ico_one_prime).",
       "mathContext": "For prime $p$: $(\\mathbb{Z}/p\\mathbb{Z})^* = \\{1, 2, \\ldots, p-1\\}$ (every nonzero residue is a unit), so $\\texttt{unitsProduct}\\,p = (p-1)! \\bmod p$. The bridge $\\texttt{unitsProduct\\_eq\\_factorial}$ uses Mathlib's $\\texttt{ZMod.prod\\_Ico\\_one\\_prime}$ to give $(p-1)! \\equiv \\prod_{a \\in (\\mathbb{Z}/p\\mathbb{Z})^*} a \\equiv -1 \\pmod{p}$."
     },
     {
-      "id": "sec-wq01-sqrt-unity",
-      "title": "Square Roots of Unity Analysis",
-      "startLine": 454,
-      "endLine": 494,
+      "id": "square-roots-of-unity",
+      "title": "Part 8: Square Roots of Unity Analysis",
+      "startLine": 442,
+      "endLine": 495,
       "summary": "sqRootsOfUnity definition, sqRootsOfUnity_prime_card (primes have 2 sq roots), examples for odd prime powers and 2p^k, sqRoot_gaussWilson_le_100 classification.",
       "mathContext": "$\\texttt{sqRootsOfUnity}\\,n = \\{a \\in (\\mathbb{Z}/n\\mathbb{Z})^* : a^2 = 1\\}$. For prime $p$: $|\\texttt{sqRootsOfUnity}\\,p| = 2$ (only $\\pm 1$, since $X^2 - 1$ has at most 2 roots mod $p$). For Gauss-Wilson $n$ (cyclic unit group): also exactly 2 square roots of unity. For other $n$: more than 2 (e.g., $n = 8$: $\\{1, 3, 5, 7\\}$ all satisfy $a^2 \\equiv 1$), so $\\prod (\\mathbb{Z}/n\\mathbb{Z})^* \\neq -1$."
     },
     {
-      "id": "sec-wq01-involution",
-      "title": "Involution-Product Structure",
-      "startLine": 504,
-      "endLine": 513,
+      "id": "involution-product",
+      "title": "Part 9: Involution-Product Connection",
+      "startLine": 496,
+      "endLine": 514,
       "summary": "selfInverseProductCheck verifies ∏units = ∏{self-inverse} (mod n) — the pairing argument. selfInverse_product_le_100 computational verification.",
       "mathContext": "Pairing argument: for $a \\in (\\mathbb{Z}/n\\mathbb{Z})^*$ with $a \\neq a^{-1}$, pair $a$ with $a^{-1}$ — they cancel in $\\prod$. Only self-inverse elements $\\{a : a^2 = 1\\}$ contribute. So $\\prod_{(\\mathbb{Z}/n\\mathbb{Z})^*} a = \\prod_{a^2 = 1} a$. When $(\\mathbb{Z}/n\\mathbb{Z})^*$ is cyclic: self-inverse elements are only $\\pm 1$, so $\\prod = (-1)(1) = -1$."
     },
     {
-      "id": "sec-wq01-gauss-wilson-abstract",
-      "title": "Abstract Gauss-Wilson Classification",
-      "startLine": 576,
-      "endLine": 591,
-      "summary": "isCyclic_units_iff_gaussWilson: restates Mathlib's ZMod.isCyclic_units_iff as (ℤ/nℤ)* cyclic iff n ∈ {1,2,4,p^k,2p^k} (odd prime p). Case analysis over Mathlib output.",
-      "mathContext": "$\\texttt{isCyclic\\_units\\_iff\\_gaussWilson}$: $(\\mathbb{Z}/n\\mathbb{Z})^*$ is cyclic $\\iff n \\in \\{1, 2, 4, p^k, 2p^k\\}$ (odd prime $p$, $k \\geq 1$). This restates Mathlib's $\\texttt{ZMod.isCyclic\\_units\\_iff}$ via case analysis on the Mathlib classification output. Cyclic group $\\Leftrightarrow$ primitive root exists $\\Leftrightarrow$ exactly 2 square roots of unity $\\Leftrightarrow$ product of units $= -1$."
+      "id": "extended-computational-verification",
+      "title": "Part 10: Extended Computational Verification",
+      "startLine": 515,
+      "endLine": 532,
+      "summary": "Pushes the computational confirmation of the Gauss-Wilson classification to larger ranges: `gaussWilson_verified_le_100`, `gaussWilson_verified_le_150`, and `gaussWilson_verified_le_200`, each proving (unitsProduct n % n = n-1) ↔ hasGaussWilsonForm n for all 3 ≤ n below the bound via native_decide.",
+      "mathContext": "Strengthens $\\texttt{gaussWilson\\_verified\\_le\\_50}$ to $n \\le 100, 150, 200$: $\\forall\\, 3 \\le n \\le N,\\ (\\texttt{unitsProduct}\\,n \\bmod n = n-1) \\Leftrightarrow \\texttt{hasGaussWilsonForm}\\,n$. Pure `native_decide` evidence accumulating support for the general theorem proved abstractly in Parts 11-12."
     },
     {
-      "id": "sec-wq01-gauss-wilson-main",
-      "title": "Main Theorem: Gauss-Wilson Classification",
-      "startLine": 639,
-      "endLine": 687,
-      "summary": "natCast_sub_one_eq_neg_one' bridge, unitsProduct_eq_neg_one_iff_cyclic (concrete ↔ abstract via OQ02), prime_odd_iff_ne_two, gaussWilson_classification: the complete main theorem.",
-      "mathContext": "$\\texttt{gaussWilson\\_classification}$: $\\prod_{a \\in (\\mathbb{Z}/n\\mathbb{Z})^*} a \\equiv -1 \\pmod{n} \\iff n \\in \\{1, 2, 4, p^k, 2p^k\\}$ (odd prime $p$). Chain: $\\prod = -1 \\iff$ exactly 2 self-inverse elements $\\iff (\\mathbb{Z}/n\\mathbb{Z})^*$ cyclic $\\iff n \\in \\{1,2,4,p^k,2p^k\\}$. The bridge $\\texttt{unitsProduct\\_eq\\_neg\\_one\\_iff\\_cyclic}$ connects the concrete factorial product to the abstract cyclicity via OQ02's framework."
+      "id": "proof-architecture",
+      "title": "Part 11: Proof Architecture (Three-Lemma Decomposition)",
+      "startLine": 533,
+      "endLine": 561,
+      "summary": "Documentation section laying out the mathematical proof of Gauss's theorem as three lemmas: (1) the involution ∏units = ∏{self-inverse units}; (2) n has Gauss-Wilson form ↔ exactly 2 square roots of unity (via X²-1 factoring in integral domains, Hensel lifting, and CRT); (3) product evaluation — 2 self-inverse units give -1, ≥4 give 1. Notes that Mathlib's `ZMod.isCyclic_units_iff` now supplies the classification used in Part 12.",
+      "mathContext": "Three-lemma architecture for $\\prod (\\mathbb{Z}/n\\mathbb{Z})^* \\equiv -1 \\iff n \\in \\{4, p^k, 2p^k\\}$: (1) involution $a \\mapsto n-a$ collapses the product to self-inverse units; (2) $|\\{a : a^2 \\equiv 1\\}| = 2 \\iff (\\mathbb{Z}/n\\mathbb{Z})^*$ cyclic — forward by $X^2-1=(X-1)(X+1)$ in $\\mathbb{Z}/p^k$ plus CRT, backward by root-doubling; (3) product $= n-1$ when the self-inverse set is $\\{1,n-1\\}$, else the $(\\mathbb{Z}/2)^k$ subgroup gives $1$. The general statement is obtained from Mathlib's $\\texttt{ZMod.isCyclic\\_units\\_iff}$."
+    },
+    {
+      "id": "abstract-gauss-wilson-main",
+      "title": "Part 12: Abstract Gauss-Wilson via Mathlib (Main Theorem)",
+      "startLine": 562,
+      "endLine": 688,
+      "summary": "Completes the proof using Mathlib. `isCyclic_units_iff_gaussWilson` restates `ZMod.isCyclic_units_iff` as: for n ≥ 3, (ℤ/nℤ)* cyclic ↔ n = 4 ∨ ∃ p k, p odd prime ∧ (n = p^k ∨ n = 2p^k). The bridge `unitsProduct_eq_neg_one_iff_cyclic` connects the concrete unitsProduct n % n = n-1 to abstract cyclicity through OQ02's `unitsProduct_cast_eq_abstract` and `gaussWilson_abstract`. The main theorem `gaussWilson_classification` then states unitsProduct n % n = n-1 ↔ (∃ p k, p ≠ 2 prime ∧ n = p^k ∨ n = 2p^k) ∨ n = 4 — the complete Gauss-Wilson classification, sorry-free.",
+      "mathContext": "$\\texttt{gaussWilson\\_classification}$ (for $n \\ge 3$): $\\texttt{unitsProduct}\\,n \\bmod n = n-1 \\iff (\\exists\\, p\\,k,\\ p\\text{ prime},\\ p \\ne 2,\\ k \\ge 1,\\ n = p^k \\lor n = 2p^k) \\lor n = 4$. Proof chain: bridge lemma $\\texttt{unitsProduct\\_eq\\_neg\\_one\\_iff\\_cyclic}$ (concrete $\\leftrightarrow$ $\\texttt{IsCyclic}\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times$ via OQ02's $\\texttt{gaussWilson\\_abstract}$ and the cast $\\texttt{unitsProduct\\_cast\\_eq\\_abstract}$), composed with $\\texttt{isCyclic\\_units\\_iff\\_gaussWilson}$ (Mathlib's $\\texttt{ZMod.isCyclic\\_units\\_iff}$). The helper $\\texttt{natCast\\_sub\\_one\\_eq\\_neg\\_one'}$ gives $\\uparrow(n-1) = -1$ in $\\mathbb{Z}/n\\mathbb{Z}$."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
The gallery `meta.json` sections for **wilsons-theorem-oq-01** (generalizations of Wilson's theorem to non-prime moduli) had drifted from `Proofs/WilsonsTheoremOQ01.lean`:

- The **module header** (lines 1-52) was uncovered.
- "Units Product and Gauss-Wilson Form" **lumped Part 5 and Part 6** into a single section.
- **Parts 10** (Extended Computational Verification) and **11** (Proof Architecture) were missing entirely, and Part 12 was compressed — leaving ~120 lines across two interior gaps (514-575, 592-638) uncovered.

Rebuilt to **14 contiguous sections** — an Overview, the Infrastructure block, and one per `## Part` banner (Parts 1-12) — covering the full 688-line file with no gaps or overlaps. Existing summaries and LaTeX `mathContext` are preserved for the unchanged parts; new summaries were written for Parts 5, 6, 10, 11, the merged Part 12, and the header.

Counts unchanged and pre-correct: **0 axioms, 35 theorems, 9 definitions, 0 sorries**. Sections-only change — no Lean source touched, no build required.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] 14 sections contiguous 1→688, matching the 12 `## Part` banners + Infrastructure + header
- [x] Counts verified against the Lean source
- [x] Diff scoped to `src/data/proofs/wilsons-theorem-oq-01/meta.json` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)