### PR TITLE
research(motivic-flag-maps): realign drifted gallery sections (8→16)

### DIFF
--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -98,68 +98,132 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring stating the main result, historical context (Bryan–Elek–Manners–Salafatinos–Vakil 2025, arXiv:2601.07222, AI-assisted), formalization approach, status checklist, and namespace setup.",
+      "mathContext": "Establishes the goal: for the space $\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})$ of based genus-0 maps $\\mathbb{P}^1 \\to \\mathrm{Fl}_{n+1}$ in homology class $\\beta$, under a positivity condition, $[\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})] = [\\mathrm{GL}_n \\times \\mathbb{A}^a]$ in $K_0(\\mathrm{Var})$ with $a$ determined by $\\beta$. Opens `Polynomial` and `BigOperators` scopes."
+    },
+    {
       "id": "grothendieck-ring",
-      "title": "Grothendieck Ring of Varieties",
+      "title": "Part I: The Grothendieck Ring of Varieties",
       "startLine": 57,
       "endLine": 101,
-      "summary": "K_0(Var) as CommRing with Lefschetz motive L, affine and projective class formulas with geometric series proof.",
-      "mathContext": "The Grothendieck ring $K_0(\\mathrm{Var})$ is defined as a $\\mathrm{CommRing}$ with Lefschetz motive $\\mathbb{L} = [\\mathbb{A}^1]$. Affine space has class $[\\mathbb{A}^n] = \\mathbb{L}^n$ and projective space $[\\mathbb{P}^n] = 1 + \\mathbb{L} + \\cdots + \\mathbb{L}^n = \\frac{\\mathbb{L}^{n+1}-1}{\\mathbb{L}-1}$."
+      "summary": "K_0(Var) as a CommRing with Lefschetz motive L, affine and projective class definitions, and the geometric series formula (L-1)·[P^n] = L^{n+1}-1 proved via mul_geom_sum.",
+      "mathContext": "The Grothendieck ring $K_0(\\mathrm{Var})$ is modeled as a $\\mathrm{CommRing}$ with distinguished Lefschetz motive $\\mathbb{L} = [\\mathbb{A}^1]$. Affine space has class $[\\mathbb{A}^n] = \\mathbb{L}^n$ and projective space $[\\mathbb{P}^n] = 1 + \\mathbb{L} + \\cdots + \\mathbb{L}^n$, satisfying $(\\mathbb{L}-1)[\\mathbb{P}^n] = \\mathbb{L}^{n+1}-1$."
     },
     {
       "id": "gln-class",
-      "title": "GL_n Motivic Class",
+      "title": "Part II: The General Linear Group GL_n",
       "startLine": 102,
-      "endLine": 150,
-      "summary": "Explicit GL_n formula via Bruhat decomposition with GL_1 through GL_4 theorems proved.",
-      "mathContext": "The motivic class of $\\mathrm{GL}_n$ is $[\\mathrm{GL}_n] = \\prod_{i=0}^{n-1}(\\mathbb{L}^n - \\mathbb{L}^i) = \\mathbb{L}^{n(n-1)/2} \\prod_{i=1}^{n}(\\mathbb{L}^i - 1)$, derived from the Bruhat decomposition. Explicit values: $[\\mathrm{GL}_1] = \\mathbb{L} - 1$, $[\\mathrm{GL}_2] = \\mathbb{L}(\\mathbb{L}-1)(\\mathbb{L}^2-1)$."
+      "endLine": 149,
+      "summary": "Explicit GL_n motivic class via Bruhat decomposition, with the GL_1 through GL_4 class theorems proved by ring normalization.",
+      "mathContext": "The motivic class of $\\mathrm{GL}_n$ is $[\\mathrm{GL}_n] = \\left(\\prod_{i=1}^{n}(\\mathbb{L}^i - 1)\\right) \\mathbb{L}^{n(n-1)/2}$, derived from the Bruhat cell decomposition. Explicit values: $[\\mathrm{GL}_1] = \\mathbb{L} - 1$, $[\\mathrm{GL}_2] = (\\mathbb{L}-1)(\\mathbb{L}^2-1)\\mathbb{L}$, up through $[\\mathrm{GL}_4]$."
     },
     {
       "id": "flag-varieties",
-      "title": "Flag Varieties",
-      "startLine": 151,
-      "endLine": 196,
-      "summary": "Complete flag definition and flag variety motivic class formula with Fl_1 through Fl_4 proved.",
-      "mathContext": "The complete flag variety $\\mathrm{Fl}_{n+1}$ parametrizes chains $0 = V_0 \\subset V_1 \\subset \\cdots \\subset V_{n+1} = \\mathbb{A}^{n+1}$ with $\\dim V_i = i$. Its motivic class is $[\\mathrm{Fl}_{n+1}] = \\prod_{i=1}^{n} [\\mathbb{P}^i] = \\prod_{i=1}^{n} \\frac{\\mathbb{L}^{i+1}-1}{\\mathbb{L}-1}$."
+      "title": "Part III: Flag Varieties",
+      "startLine": 150,
+      "endLine": 195,
+      "summary": "Complete flag structure definition with nested subspaces, the flag variety motivic class as a product of projective classes, and Fl_1 through Fl_4 proved.",
+      "mathContext": "The complete flag variety $\\mathrm{Fl}_{n}$ parametrizes chains $0 = V_0 \\subset V_1 \\subset \\cdots \\subset V_{n}$ with $\\dim V_i = i$. Its motivic class is $[\\mathrm{Fl}_{n}] = \\prod_{i=0}^{n-1} [\\mathbb{P}^i]$, e.g. $[\\mathrm{Fl}_2] = 1 + \\mathbb{L}$ and $[\\mathrm{Fl}_3] = (1+\\mathbb{L})(1+\\mathbb{L}+\\mathbb{L}^2)$."
     },
     {
       "id": "homology-classes",
-      "title": "Homology Classes",
-      "startLine": 197,
+      "title": "Part IV: Homology Classes",
+      "startLine": 196,
       "endLine": 232,
-      "summary": "Homology class representation, positivity condition, and dimension formula computeA with n=1,2 cases.",
-      "mathContext": "A homology class $\\beta = (d_1, \\ldots, d_n) \\in \\mathbb{Z}^n$ is positive if all $d_i > 0$. The dimension formula is $a(\\beta) = \\sum_{i=1}^{n} \\frac{d_i(d_i+1)}{2} + (n-1)\\sum_{i=1}^{n} d_i$, giving the exponent in $[\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})] = [\\mathrm{GL}_n \\times \\mathbb{A}^{a(\\beta)}]$."
+      "summary": "Homology class representation as Fin n → ℤ, the positivity condition, and the dimension formula computeA with the n=1, n=2 cases and specific β=(1,1), (2,1) values proved.",
+      "mathContext": "A homology class $\\beta = (d_1, \\ldots, d_n) \\in \\mathbb{Z}^n$ is positive if all $d_i > 0$. The dimension formula is $a(\\beta) = \\sum_{i=1}^{n} \\frac{d_i(d_i+1)}{2} + (n-1)\\sum_{i=1}^{n} d_i$; verified $a(1,1)=4$ and $a(2,1)=7$."
+    },
+    {
+      "id": "based-maps",
+      "title": "Part V: Space of Based Maps",
+      "startLine": 233,
+      "endLine": 243,
+      "summary": "The BasedRationalMaps structure for the space of based rational maps to the flag variety, and the AffineSpace definition.",
+      "mathContext": "Introduces $\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})$, the space of based rational maps $(\\mathbb{P}^1, 0, \\infty) \\to (\\mathrm{Fl}_{n+1}, *, *)$ in homology class $\\beta$, abstractly carried as a type, together with affine $n$-space $\\mathbb{A}^n = (\\mathrm{Fin}\\,n \\to k)$."
     },
     {
       "id": "tower-decomposition",
-      "title": "Tower Decomposition",
+      "title": "Part V-B: Tower Decomposition Structure",
       "startLine": 244,
+      "endLine": 276,
+      "summary": "Tower decomposition of the moduli space with the fiber class formula (Corollary 2.5 of the paper), verified for k=1 and k=2.",
+      "mathContext": "The moduli space decomposes as a tower $\\Omega^2_{d_n,\\ldots,d_1}(\\mathrm{Fl}_{n+1}) \\to \\cdots \\to \\Omega^2_{d_n}(\\mathbb{P}^n)$. Each projection $\\pi_k$ has fiber class $[\\mathrm{fiber}(\\pi_k)] = \\mathbb{L}^{(k+1)d_k - k\\,d_{k+1} - k} (\\mathbb{L}^k - 1)$, independent of the fiber point by compensation of splitting type and basepoint depth."
+    },
+    {
+      "id": "cell-decomposition",
+      "title": "Part V-C: Cell Decomposition Infrastructure",
+      "startLine": 277,
       "endLine": 303,
-      "summary": "Fiber class formula from Corollary 2.5: [fiber] = L^{exponent} · (L^k - 1), verified for k=1,2,3. Cell decomposition infrastructure.",
-      "mathContext": "The tower $\\Omega^2_\\beta(\\mathrm{Fl}_{n+1}) \\xrightarrow{\\pi_k} \\Omega^2_{\\beta'}(\\mathrm{Fl}_k)$ has fiber class $[\\mathrm{fiber}(\\pi_k)] = \\mathbb{L}^{(k+1)d_k - k\\cdot d_{k+1} - k} \\cdot (\\mathbb{L}^k - 1)$. This fiber class is independent of the base point, enabling inductive computation of the total motivic class."
+      "summary": "CellDecomposition structure and the motivic class of a cell-decomposed variety as a sum of L-powers, with the GL_1 cell example verifying the Bruhat formula.",
+      "mathContext": "A cell decomposition stratifies a variety by affine cells, giving motivic class $\\sum_d \\mathrm{mult}(d)\\,\\mathbb{L}^d$. This is the foundation for computing $[\\mathrm{GL}_n]$ via the Bruhat decomposition; the $\\mathrm{GL}_1$ cell structure reproduces $[\\mathrm{GL}_1] = \\mathbb{L} - 1$."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
+      "title": "Part VI: The Main Theorem",
       "startLine": 304,
       "endLine": 347,
-      "summary": "Main theorem axiom with n=1, n=2 special cases derived and L-expansion formula.",
-      "mathContext": "The main theorem states $[\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})] = [\\mathrm{GL}_n] \\cdot \\mathbb{L}^{a(\\beta)}$ in $K_0(\\mathrm{Var})$. For $n=1$: $[\\Omega^2_d(\\mathbb{P}^1)] = (\\mathbb{L}-1)\\cdot\\mathbb{L}^{d(d+1)/2}$. For $n=2$: $[\\Omega^2_{(d_1,d_2)}(\\mathrm{Fl}_3)] = [\\mathrm{GL}_2]\\cdot\\mathbb{L}^{a(d_1,d_2)}$."
+      "summary": "The two axioms (moduli space class and the BEMSV main identity), with n=1 and n=2 special cases derived and the L-expansion of the class proved.",
+      "mathContext": "The main theorem states $[\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})] = [\\mathrm{GL}_n] \\cdot \\mathbb{L}^{a(\\beta)}$ in $K_0(\\mathrm{Var})$. Expanded: $[\\Omega^2_\\beta] = \\left(\\prod_{i=1}^{n}(\\mathbb{L}^i-1)\\right)\\mathbb{L}^{\\,n(n-1)/2 + a(\\beta)}$. Special cases $n=1$ (maps to $\\mathbb{P}^1$) and $n=2$ (maps to $\\mathrm{Fl}_3$) are derived from the axiom."
+    },
+    {
+      "id": "divisibility-consequences",
+      "title": "Part VI-B: Divisibility Consequences",
+      "startLine": 348,
+      "endLine": 410,
+      "summary": "Four divisibility lemmas (S2-C/S2-D for OQ-03) extracted from the expanded main theorem: the Bruhat L-power, the affine L-power, their combination, and (L-1) all divide the based-maps class.",
+      "mathContext": "From $[\\Omega^2_\\beta] = \\left(\\prod_i(\\mathbb{L}^i-1)\\right)\\mathbb{L}^{\\,\\mathrm{tri}(n)+a}$ one reads off divisibilities: $\\mathbb{L}^{\\mathrm{tri}(n)} \\mid$, $\\mathbb{L}^{a} \\mid$, $\\mathbb{L}^{\\mathrm{tri}(n)+a} \\mid$, and $(\\mathbb{L}-1) \\mid [\\Omega^2_\\beta]$. The last is the algebraic skeleton of Euler-characteristic vanishing: any ring hom $\\mu$ with $\\mu\\mathbb{L}=1$ annihilates the class."
+    },
+    {
+      "id": "additional-structure",
+      "title": "Part VII: Additional Structure",
+      "startLine": 411,
+      "endLine": 420,
+      "summary": "The Lefschetz motive element and the identity L^n = [A^n] relating powers of L to affine classes.",
+      "mathContext": "Records the Lefschetz motive $\\mathbb{L} \\in K_0(\\mathrm{Var})$ and the definitional identity $\\mathbb{L}^n = [\\mathbb{A}^n]$, tying the ring element to its geometric meaning as affine $n$-space."
     },
     {
       "id": "mathlib-connection",
-      "title": "Mathlib Connection & Dimension Formulas",
-      "startLine": 358,
-      "endLine": 410,
-      "summary": "Connection to Mathlib's GL_n, explicit fiber class computations, and dimension formula verification via Gauss sums.",
-      "mathContext": "Links the abstract $\\mathrm{GL}_n$ motivic class to Mathlib's $\\mathrm{Matrix.GeneralLinearGroup}$. Verifies dimension formulas using the Gauss sum identity $\\sum_{i=0}^{n-1} i = \\frac{n(n-1)}{2}$ and computes explicit fiber classes for $k = 1, 2, 3$."
+      "title": "Part VIII: Connection to Mathlib's GL_n",
+      "startLine": 421,
+      "endLine": 431,
+      "summary": "Maps the file's GLn type to Mathlib matrices via GLn_to_matrix, with the determinant-nonzero property derived from the subtype.",
+      "mathContext": "Relates the directly-defined $\\mathrm{GLn}\\,n = \\{M : \\mathrm{Matrix}\\,(\\mathrm{Fin}\\,n)\\,(\\mathrm{Fin}\\,n)\\,k \\mid \\det M \\ne 0\\}$ to Mathlib's matrix infrastructure, recovering $\\det(M) \\ne 0$ for every element."
+    },
+    {
+      "id": "fiber-class-computations",
+      "title": "Part VIII-B: Explicit Fiber Class Computations",
+      "startLine": 432,
+      "endLine": 454,
+      "summary": "Verification of the fiber class formula (Corollary 2.5) for k=3 and the minimal case k=1, d=(1,1), plus a total-exponent check for degree (1,1) in n=2.",
+      "mathContext": "Confirms $[\\mathrm{fiber}(\\pi_3)] = \\mathbb{L}^{4d_3 - 3d_4 - 3}(\\mathbb{L}^3-1)$ and $[\\mathrm{fiber}(\\pi_1)]_{(1,1)} = \\mathbb{L}^0(\\mathbb{L}-1)$, with the fiber exponents summing to the expected affine dimension for $\\beta=(1,1)$."
+    },
+    {
+      "id": "dimension-formula-verification",
+      "title": "Part VIII-C: Verification of Dimension Formula",
+      "startLine": 455,
+      "endLine": 472,
+      "summary": "Gauss sum and shifted Gauss sum identities (via Finset.sum_range_id) underpinning the dimension formula a = ∑ d_i(d_i+1)/2 + (n-1)∑ d_i.",
+      "mathContext": "Proves $\\sum_{i=0}^{d-1} i = \\frac{d(d-1)}{2}$ and $\\sum_{i=0}^{d-1}(i+1) = d + \\frac{d(d-1)}{2}$, the combinatorial identities matching the dimension of degree-$d$ based maps $\\mathbb{P}^1 \\to \\mathbb{P}^1$ and verifying the $a(\\beta)$ formula."
+    },
+    {
+      "id": "ai-collaboration",
+      "title": "Part VIII-D: Remarks on AI Collaboration",
+      "startLine": 473,
+      "endLine": 481,
+      "summary": "Documentation note on the result being one of the first major theorems to explicitly credit AI (Google Gemini) assistance.",
+      "mathContext": "A docstring milestone marker: the source result of Bryan–Elek–Manners–Salafatinos–Vakil credits AI tooling in its proof, recorded here as historical context within the formalization."
     },
     {
       "id": "further-formalization",
-      "title": "Paths to Further Formalization",
-      "startLine": 420,
-      "endLine": 438,
-      "summary": "Roadmap for short, medium, and long-term formalization goals (most short-term goals now complete).",
-      "mathContext": "Remaining formalization targets: constructing $\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})$ as a scheme in Mathlib (requires moduli space theory), and proving the main identity from Birkhoff-Grothendieck stratification of vector bundles on $\\mathbb{P}^1$."
+      "title": "Part IX: Paths to Further Formalization",
+      "startLine": 482,
+      "endLine": 501,
+      "summary": "Roadmap of short-, medium-, and long-term formalization goals; most short-term items are now complete, leaving moduli-space construction and the full identity proof.",
+      "mathContext": "Remaining targets: constructing $\\Omega^2_\\beta(\\mathrm{Fl}_{n+1})$ as a scheme in Mathlib (moduli space theory), computing individual strata classes, and proving the main identity from the Birkhoff–Grothendieck stratification of vector bundles on $\\mathbb{P}^1$ — the work that would remove the two remaining axioms."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Gallery section ranges for `motivic-flag-maps` had drifted off the Lean source structure. Realigned to the actual `/-! ## Part N -/` banners in `proofs/Proofs/MotivicFlagMaps.lean` (501 lines).

### Problems fixed
- **Uncovered header**: lines 1-56 (module docstring, imports, namespace setup) had no section.
- **Missing Part V**: "Space of Based Maps" (233-243) fell into a gap between Part IV and the Tower Decomposition section.
- **Uncovered tail**: the entire back of the file — Part VIII-B (Explicit Fiber Class Computations), VIII-C (Dimension Formula), VIII-D (AI Collaboration), and IX (Paths to Further Formalization), lines 438-501 — had no coverage.
- **Mislabeled sections**: "Mathlib Connection & Dimension Formulas" pointed at 358-410, which is actually the Part VI-B divisibility lemmas; "Paths to Further Formalization" pointed at 420-438 (Parts VII/VIII).

### Result
Rebuilt **16 contiguous sections** (1-501), one per banner plus the module header, with corrected titles and accurate summaries/mathContext.

## Scope
- Only `src/data/proofs/motivic-flag-maps/meta.json` changed (sections array).
- No Lean source edits. Counts (2 axioms / 30 theorems / 17 definitions / 0 sorries) were already correct and are untouched.

## Test plan
- [x] JSON validates (round-trip parse)
- [x] Sections are contiguous 1→501 with no gaps or overlaps
- [x] Section titles/ranges match the `## Part N` banners in the Lean source