### PR TITLE
Enrich Combinations Formula: realign mislabeled mega-section (5→13 sections)

### DIFF
--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -39,7 +39,8 @@
       "Pedagogical wrapper theorems with explicit documentation",
       "Symmetry, boundary cases, and Pascal's identity as corollaries",
       "Connection to subset counting via Finset.powersetCard",
-      "Concrete verification examples"
+      "Concrete verification examples",
+      "A self-contained development of generalized (real-argument) binomial coefficients genBinom α k = α(α−1)…(α−k+1)/k!, proved consistent with Nat.choose on ℕ (genBinom_nat_eq_choose) and equipped with the upper-negation formula C(−α,k) = (−1)^k C(α+k−1,k) and the absorption identity (k+1)C(α,k+1) = α C(α−1,k)"
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 58,
@@ -60,7 +61,8 @@
       "Pascal's identity C(n+1, k+1) = C(n, k) + C(n, k+1) enables efficient computation",
       "Symmetry C(n,k) = C(n, n-k) reflects that choosing k is equivalent to choosing n-k to exclude",
       "The binomial coefficient is always a natural number despite involving division",
-      "The generating function (1+x)^n = ∑_k C(n,k) x^k connects binomial coefficients to polynomial algebra, and Vandermonde's identity ∑_j C(m,j)C(n,k-j) = C(m+n,k) encodes convolution of subset counts — making C(n,k) a bridge between combinatorics and generating function calculus"
+      "The generating function (1+x)^n = ∑_k C(n,k) x^k connects binomial coefficients to polynomial algebra, and Vandermonde's identity ∑_j C(m,j)C(n,k-j) = C(m+n,k) encodes convolution of subset counts — making C(n,k) a bridge between combinatorics and generating function calculus",
+      "The falling-product form C(α,k) = α(α−1)…(α−k+1)/k! extends the coefficient to any real α while still agreeing with C(n,k) on the naturals; this single definition simultaneously yields Pascal-type recurrences, the upper-negation formula relating C(−α,k) to a positive argument, and the multiset/stars-and-bars count C(−n,k) = (−1)^k C(n+k−1,k)"
     ],
     "prerequisites": [
       "Factorial function and its basic properties",
@@ -69,6 +71,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "header-overview",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Mathlib imports (Nat.Choose, Nat.Factorial, Tactic), the module docstring framing the result as Wiedijk's 100 Theorems #58, and the historical/pedagogical notes (Pascal's 1654 treatise, the permutations-to-combinations derivation). Opens the CombinationsFormula namespace.",
+      "mathContext": "Goal: $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$ counts $k$-element subsets of an $n$-set. The header records the approach — a Mathlib-backed core (`Nat.choose_eq_factorial_div_factorial`) wrapped in pedagogical corollaries — and the divide-by-$k!$/$(n-k)!$ intuition (remove orderings of chosen and unchosen items)."
+    },
     {
       "id": "main-theorem",
       "title": "The Main Theorem",
@@ -102,19 +112,75 @@
       "mathContext": "$P(n,k) = n^{\\underline{k}} = n!/(n-k)!$ counts ordered selections (permutations). Since $P(n,k) = k! \\cdot \\binom{n}{k}$ (each $k$-subset has $k!$ orderings), $\\binom{n}{k} = P(n,k)/k! = n^{\\underline{k}}/k!$."
     },
     {
-      "id": "examples",
+      "id": "verification-examples",
       "title": "Verification Examples",
       "startLine": 130,
+      "endLine": 152,
+      "summary": "native_decide checks of concrete values: C(5,2)=10, C(10,3)=120, C(6,3)=20, the matching factorial quotients 5!/(2!·3!)=10 and 10!/(3!·7!)=120, a symmetry instance C(7,2)=C(7,5), and a Pascal instance C(5,3)=C(4,2)+C(4,3).",
+      "mathContext": "Decidable evaluation confirms the formula on specific inputs: $\\binom{5}{2}=10$, $\\binom{10}{3}=120$, $\\binom{6}{3}=20$, and that $\\frac{5!}{2!\\,3!}=10$, $\\frac{10!}{3!\\,7!}=120$ agree with `Nat.choose`. These ground the abstract theorems in computable arithmetic via `native_decide`."
+    },
+    {
+      "id": "subset-counting",
+      "title": "Connection to Subset Counting",
+      "startLine": 153,
+      "endLine": 163,
+      "summary": "card_subsets_of_size: the number of k-element subsets of a Finset s equals C(|s|, k), via Finset.card_powersetCard. This is the combinatorial meaning of the binomial coefficient — the bridge from the algebraic formula to actual subset enumeration.",
+      "mathContext": "$|\\{S \\subseteq s : |S| = k\\}| = \\binom{|s|}{k}$ (`Finset.card_powersetCard`). This realizes the binomial coefficient as the count of $k$-subsets, the interpretation underlying its appearance in probability and counting arguments."
+    },
+    {
+      "id": "generalized-binomial",
+      "title": "Part VII: Generalized Binomial Coefficients",
+      "startLine": 164,
+      "endLine": 232,
+      "summary": "Defines genBinom α k = α(α−1)…(α−k+1)/k! for real α via primitive recursion, extending C(n,k) beyond natural-number upper arguments. Proves the base/recursion (genBinom_zero, genBinom_succ), the low-order values genBinom_one = α and genBinom_two = α(α−1)/2, the vanishing genBinom 0 k = 0 for k ≥ 1, agreement at k=0, and concrete real evaluations including C(1/2, 2) = −1/8 and C(−1, 3) = −1.",
+      "mathContext": "$\\binom{\\alpha}{k} = \\frac{\\alpha(\\alpha-1)\\cdots(\\alpha-k+1)}{k!}$ for $\\alpha \\in \\mathbb{R}$, defined recursively by $\\binom{\\alpha}{0}=1$, $\\binom{\\alpha}{k+1} = \\binom{\\alpha}{k}\\cdot\\frac{\\alpha-k}{k+1}$. Examples: $\\binom{1/2}{2} = -\\tfrac18$, $\\binom{-1}{3} = -1$ — values impossible for the natural-number definition, showing the genuine extension."
+    },
+    {
+      "id": "falling-product-representation",
+      "title": "Part VIII: Falling Product Representation",
+      "startLine": 233,
+      "endLine": 267,
+      "summary": "Defines fallingProd α k = α(α−1)…(α−k+1) (the real falling factorial) and proves genBinom_eq_fallingProd_div: genBinom α k = fallingProd α k / k!, separating the numerator product from the factorial denominator. Includes the base case and recursion for fallingProd.",
+      "mathContext": "$\\alpha^{\\underline{k}} = \\prod_{i=0}^{k-1}(\\alpha - i)$, and $\\binom{\\alpha}{k} = \\frac{\\alpha^{\\underline{k}}}{k!}$. The proof is an induction using `field_simp` to clear the factorial denominators; isolating the falling product makes the subsequent identities (negation, absorption) cleaner to state and prove."
+    },
+    {
+      "id": "nat-agreement",
+      "title": "Part IX: Agreement with Natural-Number Binomial Coefficients",
+      "startLine": 268,
+      "endLine": 303,
+      "summary": "The consistency theorem. fallingProd_nat: for natural n, fallingProd n k = descFactorial n k (handling both m ≤ n and the m > n vanishing case). genBinom_nat_eq_choose: genBinom (↑n) k = ↑(C(n,k)), confirming the real-valued generalization restricts to the classical binomial coefficient on ℕ.",
+      "mathContext": "$\\binom{(n:\\mathbb{R})}{k} = \\binom{n}{k}$ for $n,k \\in \\mathbb{N}$ — the key validation that `genBinom` extends rather than redefines. The proof composes $\\binom{\\alpha}{k} = \\alpha^{\\underline{k}}/k!$ with $n^{\\underline{k}} = $ `Nat.descFactorial n k` and `Nat.choose_eq_descFactorial_div_factorial`, casting ℕ-division to ℝ via the exact divisibility $k! \\mid n^{\\underline{k}}$."
+    },
+    {
+      "id": "falling-product-identities",
+      "title": "Part X: Falling Product Identities",
+      "startLine": 304,
+      "endLine": 318,
+      "summary": "fallingProd_succ_eq_mul: fallingProd α (k+1) = α · fallingProd (α−1) k — a (k+1)-term falling product from α equals α times a k-term falling product from α−1. This shift identity is the workhorse for the negation and absorption formulas that follow.",
+      "mathContext": "$\\alpha^{\\underline{k+1}} = \\alpha \\cdot (\\alpha-1)^{\\underline{k}}$. Proved by induction with `ring`; it lets later proofs re-index a falling product by peeling the leading factor and decrementing the base, which is exactly the manipulation the negation identity needs."
+    },
+    {
+      "id": "negation-formula",
+      "title": "Part XI: The Negation Formula",
+      "startLine": 319,
+      "endLine": 369,
+      "summary": "The upper-negation identity. fallingProd_neg gives fallingProd(−α) k = (−1)^k · fallingProd(α+k−1) k, lifted to genBinom_neg: C(−α, k) = (−1)^k · C(α+k−1, k). Specializations: genBinom_neg_one (C(−1,k) = (−1)^k) and genBinom_neg_nat (C(−n,k) = (−1)^k·C(n+k−1,k) for natural n).",
+      "mathContext": "$\\binom{-\\alpha}{k} = (-1)^k\\binom{\\alpha+k-1}{k}$, the 'upper negation' rule relating negative to positive arguments. In particular $\\binom{-1}{k} = (-1)^k$ and $\\binom{-n}{k} = (-1)^k\\binom{n+k-1}{k}$ — the latter recovering the signed count of multisets (negative binomial / stars-and-bars) from the generalized coefficient."
+    },
+    {
+      "id": "additional-identities",
+      "title": "Part XII: Additional Identities",
+      "startLine": 370,
       "endLine": 400,
-      "summary": "Concrete examples verifying the formula and properties for specific values.",
-      "mathContext": "Verification: $\\binom{4}{2} = 6$, $\\binom{5}{3} = 10$, $\\binom{10}{5} = 252$. Row sums: $\\sum_k \\binom{n}{k} = 2^n$ (total subsets). Connection to `Finset.powersetCard`: $|\\{S \\subseteq \\text{Fin}(n) : |S| = k\\}| = \\binom{n}{k}$."
+      "summary": "genBinom_absorption: (k+1)·C(α, k+1) = α·C(α−1, k), the absorption/committee identity connecting adjacent generalized coefficients, proved via the falling-product shift. Closes with concrete real-argument checks (C(−1/2, 3) = −5/16, C(4,3) = 4, C(−3,2) = 6) and the namespace end.",
+      "mathContext": "$(k+1)\\binom{\\alpha}{k+1} = \\alpha\\binom{\\alpha-1}{k}$ (absorption), the real-argument analogue of $k\\binom{n}{k} = n\\binom{n-1}{k-1}$. Verifications such as $\\binom{-1/2}{3} = -\\tfrac{5}{16}$ and the negation check $\\binom{-3}{2} = (-1)^2\\binom{4}{2} = 6$ confirm the identities hold on non-integer and negative inputs."
     }
   ],
   "conclusion": {
     "summary": "The combinations formula is one of the most fundamental results in combinatorics, connecting the abstract concept of subset counting to the concrete factorial formula. The formalization demonstrates the elegance of the relationship between permutations and combinations.",
     "implications": "**Theoretical Significance:**\n\n**1. Foundation of combinatorics**\nThe binomial coefficient appears throughout mathematics, from probability to algebra.\n\n**2. Binomial theorem**\nThe coefficients in (x+y)^n are precisely C(n,k).\n\n**3. Pascal's triangle**\nProvides an efficient recursive computation method.\n\n**Practical Applications:**\n\n- Probability calculations (choosing outcomes)\n- Counting problems in computer science\n- Polynomial expansion\n- Statistical sampling",
     "openQuestions": [
-      "How do generalized binomial coefficients extend to non-integer arguments?",
+      "This file already extends binomial coefficients to real arguments (genBinom over ℝ, with the upper-negation and absorption identities); can the same falling-product development be pushed to complex α, recovering Newton's generalized binomial series (1+x)^α = ∑ C(α,k) x^k with its radius of convergence?",
       "What are the connections to Catalan numbers and other combinatorial sequences?",
       "How does the q-analog of binomial coefficients arise in quantum groups?"
     ]


### PR DESCRIPTION
## Summary
The `sections` array for `combinations-formula` described an earlier, smaller version of `CombinationsFormula.lean`. Two defects:

1. **Header uncovered** — lines 1–54 (module docstring, Wiedijk #58 framing, historical notes) had no section.
2. **Mislabeled mega-section** — a single "Verification Examples" section (130–400, 270 lines) actually lumped the file's entire **generalized binomial coefficient** development (Parts VII–XII): `genBinom` over ℝ, the falling-product representation, agreement with `Nat.choose`, the upper-negation formula `C(−α,k) = (−1)^k C(α+k−1,k)`, and the absorption identity. None of this is "examples."

Rebuilt **13 contiguous sections** covering lines 1–400, aligned to the file's `##` banners (overview, main theorem, properties, Pascal, factorial interpretation, verification examples, subset counting, then one section per Part VII–XII). Each carries a `mathContext`.

**Stale framing fixed:** the conclusion listed *"How do generalized binomial coefficients extend to non-integer arguments?"* as an open question — but the file **proves** exactly that. Replaced it with a genuine follow-up (extension to complex α / Newton's generalized binomial series), and surfaced the generalized development in `originalContributions` and `keyInsights`.

`annotations.json` was already aligned (7/7 valid, 0 misaligned) and is unchanged. Counts (26 thm / 2 def / 0 axiom / 0 sorry) were already accurate.

## Test plan
- [x] meta.json parses; 13 sections contiguous over lines 1–400
- [x] `resolver.ts validate` on annotations → 7/7 valid (unchanged)
- [x] Only `src/data/proofs/combinations-formula/meta.json` staged