### PR TITLE
research(erdos-299): realign drifted gallery sections to full file (8→9)

### DIFF
--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -80,68 +80,76 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Mathlib imports, the Erdos299 namespace, and the statement of Problem #299: does an infinite bounded-gap sequence exist whose reciprocals never sum to 1 over any finite subset? The answer is NO.",
+      "mathContext": "Setup: imports, namespace, and the problem statement."
+    },
+    {
       "id": "definitions",
       "title": "Definitions",
-      "startLine": 49,
-      "endLine": 66,
-      "summary": "Key definitions: bounded gaps, unit fraction sums, and avoiding unit fractions.",
-      "mathContext": "Formal definition: Key definitions: bounded gaps, unit fraction sums, and avoiding unit fractions."
+      "startLine": 61,
+      "endLine": 85,
+      "summary": "Formal definitions: HasBoundedGaps (O(1) consecutive differences), HasUniformBoundedGaps (gaps bounded by a constant C), HasUnitFractionSum, and AvoidsUnitFractionSum.",
+      "mathContext": "Formal definitions of bounded-gap sequences and unit-fraction sums."
     },
     {
       "id": "density",
       "title": "Upper Density",
-      "startLine": 73,
-      "endLine": 85,
-      "summary": "Definition of counting function, upper density, and positive density for sets of natural numbers.",
-      "mathContext": "Formal definition: Definition of counting function, upper density, and positive density for sets of natural numbers."
+      "startLine": 86,
+      "endLine": 104,
+      "summary": "Definitions of the counting function, upper density of a set A ⊆ ℕ, and HasPositiveUpperDensity.",
+      "mathContext": "Formal definitions of counting function, upper density, and positive density."
     },
     {
       "id": "key-lemma",
       "title": "Bounded Gaps Imply Positive Density",
-      "startLine": 93,
-      "endLine": 101,
-      "summary": "The crucial connection: sequences with bounded gaps have positive density.",
-      "mathContext": "Bound: The crucial connection: sequences with bounded gaps have positive density."
+      "startLine": 105,
+      "endLine": 174,
+      "summary": "The structural lemma bounded_gaps_growth (a strictly increasing C-bounded-gap sequence satisfies a_k ≤ a_0 + k·C) and the theorem boundedGaps_implies_positiveDensity, giving density ≥ 1/C.",
+      "mathContext": "Bound: bounded gaps force density at least 1/C."
     },
     {
       "id": "bloom",
       "title": "Bloom's Theorem",
-      "startLine": 109,
-      "endLine": 117,
-      "summary": "Axiom encoding Bloom's 2021 result: positive density sets contain unit fraction sums.",
-      "mathContext": "Axiomatized: Axiom encoding Bloom's 2021 result: positive density sets contain unit fraction sums."
+      "startLine": 175,
+      "endLine": 193,
+      "summary": "The axiom bloom_theorem encoding Bloom's 2021 result (Erdős Problem #298): every set of positive upper density contains a finite subset whose reciprocals sum to 1.",
+      "mathContext": "Axiomatized: positive density sets contain a unit-fraction sum (Bloom 2021)."
     },
     {
       "id": "main-result",
-      "title": "Main Result",
-      "startLine": 123,
-      "endLine": 155,
-      "summary": "The main theorem: no bounded-gap sequence avoids unit fraction sums.",
-      "mathContext": "Verified: The main theorem: no bounded-gap sequence avoids unit fraction sums."
+      "title": "The Main Result",
+      "startLine": 194,
+      "endLine": 294,
+      "summary": "The main theorems erdos_299_no_such_sequence and erdos_299: combining bounded-gaps→positive-density with Bloom's theorem shows no bounded-gap sequence can avoid unit-fraction sums.",
+      "mathContext": "Verified: no bounded-gap sequence avoids unit-fraction sums."
     },
     {
       "id": "density-variant",
-      "title": "Density Variant",
-      "startLine": 164,
-      "endLine": 173,
-      "summary": "Restatement showing positive density alone suffices.",
-      "mathContext": "Mathematical content: Restatement showing positive density alone suffices."
+      "title": "The Density Variant",
+      "startLine": 295,
+      "endLine": 311,
+      "summary": "The theorem erdos_299_density_variant restating the result directly in terms of positive upper density, isolating the density hypothesis that does the work.",
+      "mathContext": "Verified: positive upper density alone forces a unit-fraction sum."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "startLine": 181,
-      "endLine": 201,
-      "summary": "Verified examples: arithmetic sequence gaps and Egyptian fractions {2,3,6} and {2,4,6,12}.",
-      "mathContext": "Mathematical content: Verified examples: arithmetic sequence gaps and Egyptian fractions {2,3,6} and {2,4,6,12}."
+      "startLine": 312,
+      "endLine": 340,
+      "summary": "Verified examples: arith_seq_bounded_gaps (the sequence n+2 has uniform gaps of 1) and the Egyptian fractions egyptian_236 ({2,3,6}) and egyptian_2_4_6_12 ({2,4,6,12}).",
+      "mathContext": "Verified: arithmetic-sequence gaps and Egyptian-fraction witnesses."
     },
     {
       "id": "sparse",
       "title": "Why Bounded Gaps Matter",
-      "startLine": 209,
-      "endLine": 325,
-      "summary": "Proof that powers of 2 have unbounded gaps, showing the condition is necessary.",
-      "mathContext": "Verified: Proof that powers of 2 have unbounded gaps, showing the condition is necessary."
+      "startLine": 341,
+      "endLine": 386,
+      "summary": "The theorem powers_of_two_gaps_unbounded shows that the sparse sequence 2^n has unbounded gaps (so the bounded-gap hypothesis is essential), and erdos_299_summary collects the main results.",
+      "mathContext": "Verified: powers of 2 have unbounded gaps; summary of the resolution."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Gallery section metadata for **erdos-299** (Bounded Gap Sequences and Unit Fractions, 386-line `Erdos299Problem.lean`) had drifted badly: the 8 sections were compressed into the first half of the file and no longer matched the `## Part I–VIII` banners.

- The **Bloom** section pointed to lines 109-117, but the `bloom_theorem` axiom is actually at L191 (under the Part IV banner @176).
- The final section stopped at line 325, leaving **326-386 uncovered** (the `powers_of_two_gaps_unbounded` proof and `erdos_299_summary`).
- Parts VI (Density Variant @296) and VII (Concrete Examples @313) were mapped to ranges in the 160-200 region.

Rebuilt **9 contiguous sections** (header + Parts I–VIII) spanning lines 1-386, one per banner block, with accurate summaries.

## Verification
- Counts unchanged and confirmed against the source: **1 axiom** (`bloom_theorem` @L191), **10 theorems**, **7 definitions**, **0 sorries**.
- Sections are contiguous (1→386), non-overlapping, valid JSON.
- Sections-only metadata change — no Lean source touched, build-free.

## Test plan
- [x] `json.load` validates meta.json
- [x] Section boundaries verified against banner `/-`/`##` lines in the source
- [x] Axiom/theorem/def/sorry counts re-derived from the file