### PR TITLE
research(erdos-1129): realign drifted gallery sections to file (8→8)

### DIFF
--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -91,66 +91,66 @@
     {
       "id": "lagrange-basics",
       "title": "Lagrange Interpolation Fundamentals",
-      "summary": "LagrangeBasis definition, DistinctNodes, NodesInInterval predicates",
-      "startLine": 43,
-      "endLine": 76,
-      "mathContext": "Formal definition: LagrangeBasis definition, DistinctNodes, NodesInInterval predicates"
+      "summary": "File header and Part I: LagrangeBasis definition, DistinctNodes and NodesInInterval predicates",
+      "startLine": 1,
+      "endLine": 71,
+      "mathContext": "Formal definition: File header and Part I: LagrangeBasis definition, DistinctNodes and NodesInInterval predicates"
     },
     {
       "id": "lebesgue-constant",
       "title": "The Lebesgue Constant",
       "summary": "LebesgueFunction and LebesgueConstant definitions measuring interpolation conditioning",
-      "startLine": 77,
-      "endLine": 100,
+      "startLine": 72,
+      "endLine": 95,
       "mathContext": "Formal definition: LebesgueFunction and LebesgueConstant definitions measuring interpolation conditioning"
     },
     {
       "id": "chebyshev-nodes",
       "title": "Chebyshev Nodes",
-      "summary": "ChebyshevNodes definition using cosine formula, chebyshev_nodes_in_interval theorem",
-      "startLine": 101,
-      "endLine": 128,
-      "mathContext": "Formal definition: ChebyshevNodes definition using cosine formula, chebyshev_nodes_in_interval theorem"
+      "summary": "ChebyshevNodes definition using the cosine formula and chebyshev_nodes_in_interval theorem",
+      "startLine": 96,
+      "endLine": 119,
+      "mathContext": "Formal definition: ChebyshevNodes definition using the cosine formula and chebyshev_nodes_in_interval theorem"
     },
     {
       "id": "lower-bounds",
       "title": "Fundamental Lower Bounds",
-      "summary": "faber_lower_bound, erdos_lower_bound, chebyshev_upper_bound axioms establishing (2/π) log n",
-      "startLine": 129,
-      "endLine": 169,
-      "mathContext": "faber_lower_bound, erdos_lower_bound, chebyshev_upper_bound axioms establishing (2/π) $\\log n$"
+      "summary": "erdos_lower_bound and chebyshev_upper_bound axioms establishing the sharp (2/π) log n asymptotic",
+      "startLine": 120,
+      "endLine": 150,
+      "mathContext": "erdos_lower_bound and chebyshev_upper_bound axioms establishing the sharp (2/π) log n asymptotic"
     },
     {
       "id": "equal-height",
       "title": "The Equal-Height Characterization",
-      "summary": "SubintervalMax, EqualHeightProperty definitions; Kilgore-Cheney and de Boor-Pinkus theorems",
-      "startLine": 170,
-      "endLine": 225,
-      "mathContext": "Formal definition: SubintervalMax, EqualHeightProperty definitions; Kilgore-Cheney and de Boor-Pinkus theorems"
+      "summary": "SubintervalMax and EqualHeightProperty definitions; kilgore_cheney_existence axiom; Kilgore and de Boor-Pinkus characterization notes",
+      "startLine": 151,
+      "endLine": 187,
+      "mathContext": "Formal definition: SubintervalMax and EqualHeightProperty definitions; kilgore_cheney_existence axiom; Kilgore and de Boor-Pinkus characterization notes"
     },
     {
       "id": "exact-solutions",
       "title": "Known Exact Solutions",
-      "summary": "optimal_n2, optimal_n3, optimal_n4_exists for small cases",
-      "startLine": 226,
-      "endLine": 267,
-      "mathContext": "Mathematical content: optimal_n2, optimal_n3, optimal_n4_exists for small cases"
+      "summary": "Explicit optimal nodes for small cases: optimal_n2 ({-1,1}, Λ=1) and optimal_n3 ({-1,0,1}, Λ=5/4) with supporting Lagrange/Lebesgue lemmas",
+      "startLine": 188,
+      "endLine": 353,
+      "mathContext": "Mathematical content: Explicit optimal nodes for small cases: optimal_n2 ({-1,1}, Λ=1) and optimal_n3 ({-1,0,1}, Λ=5/4) with supporting Lagrange/Lebesgue lemmas"
     },
     {
       "id": "complex-variant",
       "title": "Complex Variant",
-      "summary": "ComplexLebesgueConstant, RootsOfUnity, Brutman's theorems for unit circle",
-      "startLine": 268,
-      "endLine": 317,
-      "mathContext": "Verified: ComplexLebesgueConstant, RootsOfUnity, Brutman's theorems for unit circle"
+      "summary": "ComplexLebesgueConstant, RootsOfUnity definitions; Brutman and Brutman-Pinkus theorems; erdos_complex_conjecture for nodes on the unit circle",
+      "startLine": 354,
+      "endLine": 403,
+      "mathContext": "Verified: ComplexLebesgueConstant, RootsOfUnity definitions; Brutman and Brutman-Pinkus theorems; erdos_complex_conjecture for nodes on the unit circle"
     },
     {
       "id": "main-results",
       "title": "Main Results",
-      "summary": "erdos_1129 and erdos_1129_summary theorems combining all results",
-      "startLine": 318,
-      "endLine": 374,
-      "mathContext": "Verified: erdos_1129 and erdos_1129_summary theorems combining all results"
+      "summary": "erdos_1129 and erdos_1129_summary theorems combining existence, asymptotic bounds, and the complex variant",
+      "startLine": 404,
+      "endLine": 454,
+      "mathContext": "Verified: erdos_1129 and erdos_1129_summary theorems combining existence, asymptotic bounds, and the complex variant"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The 8 gallery sections for **Erdős #1129 (Optimal Lagrange Interpolation Nodes)** had drifted out of alignment with `proofs/Proofs/Erdos1129Problem.lean`, badly in the back half:

- **"Complex Variant"** was mapped to lines 268-317 — but those lines hold the Part VI exact-solution lemmas (`optimal_n3` supporting lemmas). Its real `## Part VII: Complex Variant` banner is at line 355.
- **"Main Results"** pointed at 318-374, though `## Part VIII: Main Results` begins at line 405.
- This left the file header (lines 1-37) and the entire tail (375-454, the complex-variant + main theorems) **uncovered**.

## Fix

Remapped all 8 sections 1:1 to the file's `## Part I–VIII` banners, contiguous `1 → 454`:

| Section | New range |
|---|---|
| Lagrange Interpolation Fundamentals | 1–71 |
| The Lebesgue Constant | 72–95 |
| Chebyshev Nodes | 96–119 |
| Fundamental Lower Bounds | 120–150 |
| The Equal-Height Characterization | 151–187 |
| Known Exact Solutions | 188–353 |
| Complex Variant | 354–403 |
| Main Results | 404–454 |

Also de-staled two summaries: `faber_lower_bound` (now a comment, not an axiom) and `optimal_n4_exists` (the n=4 case is a comment, not a theorem).

Counts are unchanged and pre-correct (5 axioms / 30 theorem+lemma / 10 definitions). Section-metadata only — no Lean source changed, no rebuild required.

## Test plan

- [x] JSON validates (`json.load` after edit)
- [x] Sections contiguous and within file bounds (1–454)
- [x] Section ranges verified against `## Part` banner positions in the Lean file