### PR TITLE
research(erdos-863): realign drifted gallery sections to file (8→8)

### DIFF
--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -49,60 +49,60 @@
   },
   "sections": [
     {
-      "id": "sec-863-imports",
+      "id": "problem-statement",
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 24,
       "summary": "Module documentation describing Problem 863 and its context, with imports for Data.Nat.Basic, Data.Finset.Basic, Data.Finset.Card, Order.Filter.Basic (for eventually/atTop), and Tactic."
     },
     {
-      "id": "sec-863-b2r-definitions",
+      "id": "b2r-definitions",
       "title": "B₂[r] Set Definitions",
       "startLine": 25,
       "endLine": 43,
       "summary": "Four core definitions: sumRepCount (ordered sum pairs a ≤ b with a+b = n), IsB2r (at most r sum representations), diffRepCount (difference pairs a-b = n over Z), and IsDiffB2r (at most r nonzero difference representations)."
     },
     {
-      "id": "sec-863-inrange",
+      "id": "containment-predicate",
       "title": "Containment Predicate",
       "startLine": 44,
       "endLine": 49,
       "summary": "Defines InRange A N asserting A ⊆ {1,...,N}, restricting to the standard finite interval for Sidon-type extremal problems."
     },
     {
-      "id": "sec-863-max-sizes",
+      "id": "maximum-set-sizes",
       "title": "Maximum Set Sizes",
       "startLine": 50,
       "endLine": 63,
       "summary": "Defines maxB2rSize and maxDiffB2rSize as maxima over powerset of {0,...,N} filtered by the B₂[r] and InRange conditions, using Finset.sup with Finset.card as the objective."
     },
     {
-      "id": "sec-863-sidon-case",
+      "id": "classical-sidon-case",
       "title": "Classical Sidon Case (r = 1)",
       "startLine": 64,
-      "endLine": 75,
-      "summary": "Comment section stating the classical r=1 baseline: both sum and difference B₂[1] (Sidon) set sizes grow as ~√N with equal constants c₁ = c'₁ = 1. Not formalized as a theorem (open asymptotic problem); documented as background."
+      "endLine": 67,
+      "summary": "Comment stating the classical r=1 baseline: both the sum and difference B₂[1] (Sidon) extremal sizes grow as ~√N with equal constants c₁ = c'₁ = 1. Documented as background; not formalized as a theorem (the asymptotic is classical)."
     },
     {
-      "id": "sec-863-main-conjecture",
-      "title": "Main Conjecture: c'ᵣ < cᵣ",
-      "startLine": 76,
-      "endLine": 88,
-      "summary": "Comment section stating the main open conjecture (Erdős Problem 863): for all r ≥ 2, the asymptotic density constants cᵣ (sums) and c'ᵣ (differences) are unequal, with c'ᵣ < cᵣ. Not formalized as a theorem or axiom (problem is open); documented as background context."
+      "id": "erdos-problem",
+      "title": "The Erdős Problem (Main and Weak Conjectures)",
+      "startLine": 68,
+      "endLine": 73,
+      "summary": "Comment section stating Erdős Problem 863. Main conjecture: for r ≥ 2 the asymptotic constants cᵣ (sums) and c'ᵣ (differences) satisfy c'ᵣ < cᵣ, so difference sets are strictly smaller. Weak conjecture: there exists r ≥ 2 with cᵣ ≠ c'ᵣ. Both are open and documented as background, not formalized as theorems or axioms."
     },
     {
-      "id": "sec-863-weak-conjecture",
-      "title": "Weak Conjecture: cᵣ ≠ c'ᵣ",
-      "startLine": 89,
-      "endLine": 97,
-      "summary": "Comment section stating the weak open conjecture: there exists r ≥ 2 with cᵣ ≠ c'ᵣ. Not formalized as a theorem or axiom; documented as a stepping stone toward the full conjecture."
+      "id": "basic-properties",
+      "title": "Part II: Basic Properties of B₂[r] Sets",
+      "startLine": 74,
+      "endLine": 140,
+      "summary": "Eight proved theorems: monotonicity of IsB2r and IsDiffB2r in r (isB2r_mono, isDiffB2r_mono), monotonicity of InRange in N (inRange_mono), empty-set lemmas (inRange_empty, isB2r_empty, isDiffB2r_empty), crude cardinality bounds sumRepCount/diffRepCount ≤ |A|² (sumRepCount_le_card_sq, diffRepCount_le_card_sq), and downward closure under subsets (isB2r_subset, isDiffB2r_subset)."
     },
     {
-      "id": "sec-863-basic-properties",
-      "title": "Basic Properties of B₂[r] Sets",
-      "startLine": 99,
-      "endLine": 138,
-      "summary": "Eight proved theorems: monotonicity of B₂[r] and IsDiffB2r in r (isB2r_mono, isDiffB2r_mono), monotonicity of InRange in N (inRange_mono), empty set lemmas (inRange_empty, isB2r_empty, isDiffB2r_empty), and crude cardinality bounds (sumRepCount_le_card_sq, diffRepCount_le_card_sq)."
+      "id": "connection-sidon",
+      "title": "Connection to Sidon Sets (Erdős #340)",
+      "startLine": 141,
+      "endLine": 201,
+      "summary": "Links the r=1 case to Sidon sets. Defines IsSidonSetLocal (all ordered sums a+b with a ≤ b are distinct, matching IsSidonSet from Erdos340Problem.lean) and proves the equivalence isB2r_one_iff_sidon: a set is B₂[1] iff it is Sidon. Also proves singleton sets are both B₂[r] and difference B₂[r] for r ≥ 1 (isB2r_singleton, isDiffB2r_singleton)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery `meta.json` sections for **erdos-863** (B₂[r] sum sets vs difference sets) had drifted from `Proofs/Erdos863Problem.lean`:

- "Main Conjecture" (76-88) and "Weak Conjecture" (89-97) pointed at ranges that actually contain the **Part II theorems**, not the conjecture doc-comments.
- The final `## Connection to Sidon Sets (Erdős #340)` banner (lines **141-201**, holding `isB2r_one_iff_sidon` and the singleton lemmas) was **uncovered entirely**.

Rebuilt to **8 contiguous sections**, one per `## ` banner, covering the full 201-line file. The two open conjectures are merged into a single "The Erdős Problem" section that matches the banner, and the missing Sidon-set connection section is restored.

Counts unchanged and pre-correct: **0 axioms, 13 theorems, 8 definitions, 0 sorries**. Sections-only change — no Lean source touched, no build required.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] 8 sections contiguous 1→201, matching the `## ` banners
- [x] Counts verified against the Lean source (13 theorems incl. the restored Sidon section)
- [x] Diff scoped to `src/data/proofs/erdos-863/meta.json` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)