### PR TITLE
research(erdos-475): realign drifted gallery sections to file (9→9)

### DIFF
--- a/src/data/proofs/erdos-475/meta.json
+++ b/src/data/proofs/erdos-475/meta.json
@@ -92,72 +92,72 @@
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "startLine": 34,
-      "endLine": 42,
-      "summary": "Imports `ZMod.Basic`, `Finset.Basic`, `List.Basic`, `Nat.Prime.Basic`, and `Real.Basic`. Opens the `Erdos475` namespace and `Finset` for notation.",
-      "mathContext": "Mathematical content: Imports `ZMod.Basic`, `Finset.Basic`, `List.Basic`, `Nat.Prime.Basic`, and `Real.Basic`. Opens the `Erdos475` namespace and `Finset` for notation."
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File header documenting the problem statement, known results, and references, then imports `ZMod.Basic`, `Finset.Basic`, `List.Basic`, `Nat.Prime.Basic`, and `Real.Basic`. Opens the `Erdos475` namespace and `Finset` for notation.",
+      "mathContext": "Mathematical content: File header documenting the problem statement, known results, and references, then imports `ZMod.Basic`, `Finset.Basic`, `List.Basic`, `Nat.Prime.Basic`, and `Real.Basic`. Opens the `Erdos475` namespace and `Finset` for notation."
     },
     {
       "id": "valid-orderings",
       "title": "Valid Orderings",
-      "startLine": 47,
-      "endLine": 60,
+      "startLine": 44,
+      "endLine": 61,
       "summary": "Defines `partialSums` via `List.scanl (· + ·) 0`, `IsValidOrdering A ordering` requiring $\\text{ordering.toFinset} = A$, no duplicates in the ordering, and no duplicates in partial sums. `GrahamConjecture p` universally quantifies over all non-zero $A \\subseteq \\mathbb{F}_p$.",
       "mathContext": "Defines `partialSums` via `List.scanl (· + ·) 0`, `IsValidOrdering A ordering` requiring $\\text{ordering.toFinset} = A$, no duplicates in the ordering, and no duplicates in partial sums. `GrahamConjecture p` universally quantifies over all non-zero $A \\subseteq \\mathbb{F}_p$."
     },
     {
       "id": "small-cases",
       "title": "Small Cases (Costa-Pellegrini 2020)",
-      "startLine": 69,
-      "endLine": 78,
+      "startLine": 62,
+      "endLine": 79,
       "summary": "Axiomatizes `costa_pellegrini_2020` for $|A| \\leq 12$ with $p > 12$. The wrapper `small_sets_have_valid_orderings` directly applies the axiom. Costa and Pellegrini verified this via computation and theoretical reductions.",
       "mathContext": "Axiomatizes `costa_pellegrini_2020` for $|A| \\leq 12$ with $p > 12$. The wrapper `small_sets_have_valid_orderings` directly applies the axiom."
     },
     {
       "id": "large-cases",
       "title": "Large Cases (Hicks-Ollis-Schmitt 2019)",
-      "startLine": 87,
-      "endLine": 99,
+      "startLine": 80,
+      "endLine": 96,
       "summary": "Axiomatizes `hicks_ollis_schmitt_2019` for $p - 3 \\leq |A| \\leq p - 1$. (Graham's $|A|=p-1$ result mentioned in docstring only — no separate declaration.)",
       "mathContext": "Axiomatized: `hicks_ollis_schmitt_2019` for $p - 3 \\leq |A| \\leq p - 1$. Graham's full-set result is docstring-only, subsumed by this axiom."
     },
     {
       "id": "logarithmic",
       "title": "Logarithmic Range (Kravitz 2024)",
-      "startLine": 109,
-      "endLine": 113,
+      "startLine": 97,
+      "endLine": 104,
       "summary": "documents in source comments `kravitz_2024` (no Lean declaration exists) for $|A| \\leq \\log p / \\log \\log p$. This was the strongest small-side bound before the rectification barrier was broken, independently observed by Will Sawin.",
       "mathContext": "Axiomatized: documents in source comments `kravitz_2024` (no Lean declaration exists) for $|A| \\leq \\log p / \\log \\log p$. This was the strongest small-side bound before the rectification barrier was broken, independently observed by Will Sawin."
     },
     {
       "id": "rectification-barrier",
       "title": "Beyond the Rectification Barrier (Bedert-Kravitz 2024)",
-      "startLine": 128,
-      "endLine": 132,
+      "startLine": 105,
+      "endLine": 123,
       "summary": "Axiomatizes `bedert_kravitz_2024` for $|A| \\leq \\exp((\\log p)^{1/4})$. This breakthrough circumvents the rectification barrier that limited all previous methods to $\\log p / \\log \\log p$.",
       "mathContext": "Axiomatizes `bedert_kravitz_2024` for $|A| \\leq \\exp((\\log p)^{1/4})$. This breakthrough circumvents the rectification barrier that limited all previous methods to $\\log p / \\log \\log p$."
     },
     {
       "id": "alspach",
       "title": "Alspach's Conjecture",
-      "startLine": 141,
-      "endLine": 149,
+      "startLine": 124,
+      "endLine": 140,
       "summary": "Defines `AlspachConjecture G` for arbitrary finite abelian groups. Proves `graham_is_alspach_for_prime_field`: $\\text{GrahamConjecture}\\, p \\iff \\text{AlspachConjecture}\\, (\\mathbb{Z}/p\\mathbb{Z})$ by unfolding definitions.",
       "mathContext": "Defines `AlspachConjecture G` for arbitrary finite abelian groups. Proves `graham_is_alspach_for_prime_field`: $\\text{GrahamConjecture}\\, p \\iff \\text{AlspachConjecture}\\, (\\mathbb{Z}/p\\mathbb{Z})$ by unfolding definitions."
     },
     {
       "id": "constructive",
       "title": "Constructive vs Existential",
-      "startLine": 158,
-      "endLine": 170,
+      "startLine": 141,
+      "endLine": 157,
       "summary": "Defines `HasExplicitValidOrdering A` requiring a computable function producing a valid ordering. documents in source comments `graham_constructive` (no Lean declaration exists) for the full non-zero set, reflecting Graham's original constructive proof.",
       "mathContext": "Defines `HasExplicitValidOrdering A` requiring a computable function producing a valid ordering. documents in source comments `graham_constructive` (no Lean declaration exists) for the full non-zero set, reflecting Graham's original constructive proof."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 168,
-      "endLine": 193,
+      "startLine": 158,
+      "endLine": 195,
       "summary": "Proves `erdos_475_summary` combining small ($t \\leq 12$), large ($t \\geq p-3$), and medium ($t \\leq \\exp((\\log p)^{1/4})$) cases into a single conjunction. The general conjecture for arbitrary $t$ remains OPEN.",
       "mathContext": "Proves `erdos_475_summary` combining small ($t \\leq 12$), large ($t \\geq p-3$), and medium ($t \\leq \\exp((\\log p)^{1/4})$) cases into a single conjunction. The general conjecture for arbitrary $t$ remains OPEN."
     }


### PR DESCRIPTION
## Summary

The 9 gallery sections for **Erdős #475 (Graham's Rearrangement Conjecture)** had drifted out of alignment with `proofs/Proofs/Erdos475Problem.lean`, badly in the back half:

- **"Alspach's Conjecture"** pointed at lines 141-149 — but those are Part VII (Constructive vs Existential). Its real `## Part VI` banner is at line 124.
- **"Constructive vs Existential"** at 158-170 was actually Part VIII (Summary).
- **"Summary Theorem"** at 168-193 then **overlapped** the previous section (168 < 170).
- The file-header docstring (lines 1-32, problem statement / known results / references) and several interior gaps were left **uncovered**.

## Fix

Remapped all 9 sections 1:1 to the file's `## Part I–VIII` banners (plus the header), contiguous `1 → 195`:

| Section | New range |
|---|---|
| Imports and Setup | 1–43 |
| Valid Orderings | 44–61 |
| Small Cases (Costa-Pellegrini 2020) | 62–79 |
| Large Cases (Hicks-Ollis-Schmitt 2019) | 80–96 |
| Logarithmic Range (Kravitz 2024) | 97–104 |
| Beyond the Rectification Barrier (Bedert-Kravitz 2024) | 105–123 |
| Alspach's Conjecture | 124–140 |
| Constructive vs Existential | 141–157 |
| Summary Theorem | 158–195 |

The header section's summary was broadened to note it now covers the problem statement. The existing rich LaTeX summaries for all other sections are preserved verbatim.

Counts are unchanged and pre-correct (3 axioms / 3 theorems / 5 definitions). Section-metadata only — no Lean source changed, no rebuild required.

## Test plan

- [x] JSON validates (`json.load` after edit)
- [x] Sections contiguous and within file bounds (1–195), no overlaps
- [x] Section ranges verified against `## Part` banner positions in the Lean file