### PR TITLE
Enrich Erdős #285 (Egyptian Fractions): realign drifted sections (5→10) + fix annotations

### DIFF
--- a/src/data/proofs/erdos-285/annotations.json
+++ b/src/data/proofs/erdos-285/annotations.json
@@ -41,8 +41,8 @@
     "id": "ann-e285-representation",
     "proofId": "erdos-285",
     "range": {
-      "startLine": 27,
-      "endLine": 37
+      "startLine": 31,
+      "endLine": 39
     },
     "type": "definition",
     "title": "Egyptian Fraction Representation",
@@ -212,8 +212,8 @@
     "id": "ann-e285-examples",
     "proofId": "erdos-285",
     "range": {
-      "startLine": 116,
-      "endLine": 127
+      "startLine": 205,
+      "endLine": 212
     },
     "type": "concept",
     "title": "Concrete Examples",

--- a/src/data/proofs/erdos-285/meta.json
+++ b/src/data/proofs/erdos-285/meta.json
@@ -41,10 +41,11 @@
       }
     ],
     "originalContributions": [
-      "Formal definition of Egyptian fraction representations",
-      "Definition of f(k) as minimal largest denominator",
-      "Statement of Martin's asymptotic result",
-      "Statement of the trivial lower bound"
+      "Formal definition of Egyptian fraction representations and f(k) as minimal largest denominator",
+      "Statement of Martin's asymptotic result as the single axiom, with the asymptotic lower bound derived as a theorem",
+      "Fully verified bounds on the constant e/(e-1): 3/2 < e/(e-1) < 2, e/(e-1) > 79/50, plus the identities 1 + 1/(e-1) and inverse 1 - 1/e",
+      "An unconditional elementary lower bound f(k) ≥ k+1 (via strict_mono_last_ge_succ), proved without the Martin axiom",
+      "Concrete valid-length witnesses for k = 0, 2, 3, 4, 5 and a proof that k = 1 is impossible (a+b = ab forces a = b = 2)"
     ],
     "axiomCount": 1,
     "lineCount": 374,
@@ -56,7 +57,7 @@
     "historicalContext": "Egyptian fractions — sums of distinct unit fractions — date to ancient Egypt (the Rhind papyrus, ~1650 BCE). Every positive rational has infinitely many Egyptian fraction representations, but the question of how 'efficient' these can be remained open.\n\nErdős asked: if we want 1 = 1/n₁ + ··· + 1/nₖ with the smallest possible largest denominator nₖ, what is f(k)? The trivial lower bound f(k) ≥ (1+o(1))·e/(e-1)·k follows from the harmonic series.\n\nGreg Martin (2000) proved this bound is tight: f(k) = (1+o(1))·e/(e-1)·k. His paper 'Denser Egyptian Fractions' constructs explicit representations achieving this asymptotic.",
     "problemStatement": "**Definition**: Let $f(k)$ be the minimal value of the largest denominator $n_k$ such that there exist positive integers $n_1 < n_2 < \\cdots < n_k$ with\n$$1 = \\frac{1}{n_1} + \\frac{1}{n_2} + \\cdots + \\frac{1}{n_k}$$\n\n**Question**: Is $f(k) = (1 + o(1)) \\cdot \\frac{e}{e-1} \\cdot k$?\n\n**Answer**: YES (Martin 2000)\n\nThe constant $e/(e-1) \\approx 1.5819$ is optimal.",
     "text": "Let f(k) be the minimal largest denominator in a k-term Egyptian fraction representation of 1. Is f(k) = (1+o(1))·e/(e-1)·k? YES — proved by Martin (2000). The constant e/(e-1) ≈ 1.582 comes from harmonic series structure.",
-    "proofStrategy": "We formalize:\n\n1. **Egyptian fraction representations**: Strictly increasing sequences of positive integers whose reciprocals sum to 1\n\n2. **The function f(k)**: Minimum of the largest denominator over all k-term representations\n\n3. **The Egyptian constant**: e/(e-1) ≈ 1.5819...\n\n4. **Martin's result as an axiom**: f(k) = (1+o(1))·e/(e-1)·k\n\n5. **The trivial lower bound**: Also stated as an axiom, though it follows from harmonic series analysis",
+    "proofStrategy": "We formalize:\n\n1. **Egyptian fraction representations**: Strictly increasing sequences of positive integers whose reciprocals sum to 1\n\n2. **The function f(k)**: Minimum of the largest denominator over all k-term representations\n\n3. **The Egyptian constant**: e/(e-1) ≈ 1.5819..., with verified bounds 3/2 < e/(e-1) < 2 and the identities e/(e-1) = 1 + 1/(e-1) and (e/(e-1))⁻¹ = 1 - 1/e\n\n4. **Martin's result as the single axiom**: f(k) = (1+o(1))·e/(e-1)·(k+1). This is the file's only assumption (axiomCount 1)\n\n5. **The asymptotic lower bound**: derived as a *theorem* (egyptian_lower_bound) from the Martin axiom, not assumed separately\n\n6. **An unconditional elementary bound**: f(k) ≥ k+1 is proved outright (f_ge_succ, via strict_mono_last_ge_succ), independent of the axiom; together with concrete valid-length witnesses (k = 0, 2, 3, 4, 5) and the proof that k = 1 is impossible",
     "keyInsights": [
       "**The constant e/(e-1)**: Arises because ∑_{e ≤ n ≤ eu} 1/n ≈ 1 for any u. The interval [e, eu] contains about (e-1)u integers, each contributing ~1/eu on average.",
       "**Lower bound reasoning**: If nₖ ≈ eu, we need (e-1)u terms from [e, eu] to sum to ~1. So k ≤ (e-1)u = (e-1)/e · nₖ, giving f(k) ≥ e/(e-1) · k.",
@@ -74,36 +75,81 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 26,
-      "summary": "Module documentation and Mathlib imports for exponentials, asymptotics, and sums."
+      "endLine": 28,
+      "summary": "Module docstring stating the problem (minimal largest denominator f(k) in a k+1-term Egyptian fraction representation of 1, and Martin's 2000 answer f(k) = (1+o(1))·e/(e−1)·k), Mathlib imports for the real exponential, little-o asymptotics, and finite sums, and the Erdos285 namespace with its opens.",
+      "mathContext": "Target: $f(k) = (1+o(1))\\cdot\\frac{e}{e-1}\\cdot k$ with $\\frac{e}{e-1} \\approx 1.5819$. Imports `Real.rexp`, `Asymptotics.IsLittleO`, and `Finset` big-operators; the constant's value flows from `Real.exp_one_gt_d9` / `Real.exp_one_lt_d9` bounds used later."
     },
     {
       "id": "background",
       "title": "Egyptian Fraction Definitions",
-      "startLine": 27,
-      "endLine": 52,
-      "summary": "Definitions of Egyptian fraction representations, valid lengths, and the function f(k)."
+      "startLine": 29,
+      "endLine": 54,
+      "summary": "Core definitions: IsEgyptianRepresentation (a strictly increasing, nonzero sequence n : Fin (k+1) → ℕ with ∑ 1/nᵢ = 1), ValidLengths (the set of k admitting such a representation), and f(k) as the infimum of achievable largest denominators n(last k).",
+      "mathContext": "$\\text{IsEgyptianRepresentation}(k,n) \\equiv \\text{StrictMono}(n) \\wedge 0 \\notin \\text{range}(n) \\wedge \\sum_i \\tfrac{1}{n_i} = 1$. $f(k) = \\inf\\{m : \\exists n,\\ \\text{IsEgyptianRepresentation}(k,n) \\wedge n(\\text{last }k) = m\\}$, indexing over `Fin k.succ` so a 'k-term' problem uses $k+1$ denominators."
     },
     {
       "id": "main-result",
       "title": "Martin's Asymptotic Result",
-      "startLine": 53,
-      "endLine": 76,
-      "summary": "The constant e/(e-1) and Martin's theorem that f(k) achieves this asymptotic."
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "Defines the Egyptian constant e/(e−1), states Martin's theorem as the single axiom martin_egyptian_fractions (f(k) = (1+o(1))·e/(e−1)·(k+1) on valid lengths), and packages it as erdos_285.",
+      "mathContext": "$\\text{egyptianConstant} = \\frac{e}{e-1}$. The axiom asserts $\\exists o = o(1)$ with $f(k) = (1 + o(k))\\cdot\\frac{e}{e-1}\\cdot(k+1)$ for all $k \\in \\text{ValidLengths}$; `erdos_285` simply re-exposes it. This is the one assumption in the file (axiomCount 1) — Martin's full construction is not formalized."
     },
     {
       "id": "lower-bound",
-      "title": "The Trivial Lower Bound",
-      "startLine": 77,
+      "title": "The Lower Bound (from the Asymptotic)",
+      "startLine": 79,
       "endLine": 90,
-      "summary": "The lower bound f(k) ≥ (1+o(1))·e/(e-1)·k from harmonic series analysis."
+      "summary": "egyptian_lower_bound: f(k) ≥ (1+o(1))·e/(e−1)·(k+1). Derived as a theorem from the Martin axiom (equality implies ≥), not assumed separately.",
+      "mathContext": "$(1+o(k))\\cdot\\frac{e}{e-1}\\cdot(k+1) \\leq f(k)$ follows from the equality in `martin_egyptian_fractions` via `le_of_eq`. It is a corollary, not an independent axiom — the file's only assumption remains the Martin asymptotic."
+    },
+    {
+      "id": "understanding-constant",
+      "title": "Understanding the Constant e/(e−1)",
+      "startLine": 91,
+      "endLine": 155,
+      "summary": "Bounds and identities pinning down e/(e−1) ≈ 1.5819: egyptianConstant_gt_one, _lt_two, _gt_three_halves, _pos, the decomposition _eq (= 1 + 1/(e−1)), and _inv (1/c = 1 − 1/e, the 'density of usable denominators'). Uses Mathlib's exp_one bounds.",
+      "mathContext": "$1 < \\frac{e}{e-1} < 2$, in fact $\\frac{3}{2} < \\frac{e}{e-1}$, giving $k < f(k) < 2k$ asymptotically. Decomposition: $\\frac{e}{e-1} = 1 + \\frac{1}{e-1}$, and $\\left(\\frac{e}{e-1}\\right)^{-1} = 1 - \\frac1e = \\frac{e-1}{e}$ — the fraction of integers in any range $[a, ea]$ that contribute useful unit fractions."
+    },
+    {
+      "id": "concrete-valid-lengths",
+      "title": "Concrete Valid Lengths",
+      "startLine": 156,
+      "endLine": 202,
+      "summary": "Explicit witnesses proving small k are valid lengths: k=2 (1/2+1/3+1/6), k=3 (1/2+1/4+1/5+1/20), k=4 (1/3+1/4+1/5+1/6+1/20), each verified by exhibiting the denominator vector and checking StrictMono, nonzero, and the reciprocal sum. Also a tighter constant bound egyptianConstant_gt_79_over_50.",
+      "mathContext": "Membership $k \\in \\text{ValidLengths}$ is shown by a concrete $n : \\text{Fin}(k{+}1) \\to \\mathbb{N}$, e.g. $1 = \\tfrac12+\\tfrac13+\\tfrac16$ (k=2). The bound $\\frac{e}{e-1} > \\frac{79}{50} = 1.58$ sharpens the constant using $e < 2.7182818286$."
     },
     {
       "id": "examples",
-      "title": "Examples",
-      "startLine": 116,
+      "title": "Worked Examples",
+      "startLine": 203,
+      "endLine": 213,
+      "summary": "Three norm_num-checked identities exhibiting Egyptian fraction representations of 1: the classic 1/2+1/3+1/6, then 1/2+1/4+1/5+1/20 and 1/3+1/4+1/5+1/6+1/20.",
+      "mathContext": "$1 = \\tfrac12+\\tfrac13+\\tfrac16 = \\tfrac12+\\tfrac14+\\tfrac15+\\tfrac1{20} = \\tfrac13+\\tfrac14+\\tfrac15+\\tfrac16+\\tfrac1{20}$, each a distinct-denominator decomposition realizing a small valid length."
+    },
+    {
+      "id": "additional-valid-lengths",
+      "title": "Additional Valid Lengths",
+      "startLine": 214,
+      "endLine": 223,
+      "summary": "zero_mem_validLengths: k=0 is valid via the single-term representation 1 = 1/1, the degenerate base case of ValidLengths.",
+      "mathContext": "$0 \\in \\text{ValidLengths}$ via $n = [1]$: the one-term sum $\\tfrac11 = 1$ trivially satisfies StrictMono (vacuously) and nonzero."
+    },
+    {
+      "id": "additional-properties",
+      "title": "Additional Properties",
+      "startLine": 224,
+      "endLine": 286,
+      "summary": "one_not_mem_validLengths: k=1 is NOT valid — 1 = 1/a + 1/b with a < b forces a = b = 2 (clearing denominators gives ab = a+b), a contradiction. Also five_mem_validLengths via the splitting 1/20 = 1/21 + 1/420 applied to the k=4 witness, with a matching norm_num example.",
+      "mathContext": "$1 \\notin \\text{ValidLengths}$: $\\tfrac1a + \\tfrac1b = 1$ with $a<b$ gives $ab = a+b$, whose only positive solution is $a=b=2$. The splitting $\\tfrac1{20} = \\tfrac1{21} + \\tfrac1{420}$ (since $\\tfrac1n = \\tfrac1{n+1} + \\tfrac1{n(n+1)}$) promotes the k=4 witness to k=5."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties of f",
+      "startLine": 287,
       "endLine": 374,
-      "summary": "Concrete Egyptian fraction representations of 1."
+      "summary": "The verified backbone behind the trivial lower bound: strict_mono_last_ge_succ (a strictly increasing positive sequence has n(last k) ≥ k+1), f_set_nonempty (the denominator set is nonempty on valid lengths), f_ge_succ (hence f(k) ≥ k+1), and the constant-interval summaries egyptianConstant_in_interval, _eq_one_plus_inv, _well_defined.",
+      "mathContext": "$f(k) \\geq k+1$: any strictly increasing $n : \\text{Fin}(k{+}1)\\to\\mathbb{N}_{>0}$ has $n(\\text{last }k) \\geq k+1$ (induction: $n_i \\geq i+1$), and `le_csInf` lifts this to the infimum $f(k)$. This is the elementary unconditional bound, complementing the (axiomatic) sharp constant $\\frac{e}{e-1}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `sections` array for `erdos-285` described an earlier version of `Erdos285Problem.lean`. Two defects:

1. **Gap** — the "Understanding the Constant" block (lines 91–115: the bounds `1 < e/(e−1) < 2`, `> 3/2`, and the decomposition identities) had no section.
2. **Mislabeled mega-section** — a single "Examples" section (116–374, 258 lines) lumped five banners: the constant bounds, concrete valid-length witnesses, worked examples, the proof that k=1 is impossible, and the structural properties of `f`.

Rebuilt **10 contiguous sections** aligned to the file's `##` banners, covering lines 1–374, each with a `mathContext`.

**Stale axiom framing fixed:** `proofStrategy` claimed "The trivial lower bound: Also stated as an axiom," but `egyptian_lower_bound` is a *theorem* derived from the single Martin axiom (`axiomCount` is 1). Also surfaced the genuinely-verified content the old meta undersold — the unconditional `f(k) ≥ k+1` bound, the verified constant bounds, and the valid-length witnesses — in `proofStrategy` and `originalContributions`.

**Annotations:** fixed one dropped anchor (`ann-e285-representation` landed on an `open` line → repointed to the `IsEgyptianRepresentation` def) and one mislabel (`ann-e285-examples` sat on the constant-bound theorems → repointed to the actual `norm_num` examples at 205–212). Resolver now reports **12/12 valid, 0 misaligned**.

Counts (21 thm / 4 def / 1 axiom / 0 sorry) were already accurate.

## Test plan
- [x] meta.json + annotations.json parse; 10 sections contiguous over 1–374
- [x] `resolver.ts validate` → 12/12 annotations valid, 0 misaligned
- [x] Only `src/data/proofs/erdos-285/` staged