### PR TITLE
research(erdos-1206): rebuild stale stub-era sections to full file (5→4)

### DIFF
--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -37,44 +37,36 @@
   },
   "sections": [
     {
-      "id": "source-header",
-      "title": "Problem Source and Status",
+      "id": "header",
+      "title": "Header: Problem Statement and References",
       "startLine": 1,
-      "endLine": 6,
-      "summary": "Doc-comment header: source URL (erdosproblems.com/1206) and status SOLVED. The problem is solved by Gabdullin-Konyagin (2024) and Garaev-Garayev-Konyagin (2026).",
-      "mathContext": "Erdős Problem #1206: Does {1³, 2³, ..., N³} contain a Sidon set of size ≫ N? Status SOLVED — Gabdullin-Konyagin showed {n³ : N-cN^{1/2} ≤ n ≤ N} is Sidon."
+      "endLine": 28,
+      "summary": "States Erdős Problem #1206: does $\\{1^3,2^3,\\dots,N^3\\}$ contain a Sidon set of size $\\gg N$? Status SOLVED (Gabdullin–Konyagin 2024; Garaev–Garayev–Konyagin 2026): there is $c>0$ with $\\{n^3:N-cN^{1/2}\\leq n\\leq N\\}$ Sidon. A set is Sidon (B₂) if all pairwise sums are distinct. Imports `Finset`/`Nat`/`rpow`; opens `Finset`/`Nat`.",
+      "mathContext": "Does $\\{n^3:n\\leq N\\}$ contain a Sidon set of size $\\gg N^{1/2}$? SOLVED (yes)."
     },
     {
-      "id": "problem-statement",
-      "title": "Problem Statement: Sidon Sets in Cube Numbers",
-      "startLine": 7,
-      "endLine": 14,
-      "summary": "The problem text from erdosproblems.com. Asks two related questions: (1) does {1³,...,N³} have a Sidon subset of size ≫ N? (2) does a positive-density A ⊂ ℕ exist with {a³ : a ∈ A} Sidon? Also cites the Gabdullin-Konyagin and GGK results and the fifth-power conjecture.",
-      "mathContext": "Key results: {n³ : N - cN^{1/2} ≤ n ≤ N} is Sidon (size ≫ N^{1/2}), proved via n³ - m³ = (n-m)(n² + nm + m²). The exponent 1/2 improves to 4/7-o(1) for infinitely many N. Fifth powers {n⁵} may be Sidon (Diophantine conjecture a⁵+b⁵=c⁵+d⁵ has no non-trivial solutions)."
+      "id": "definitions",
+      "title": "Core Definitions",
+      "startLine": 29,
+      "endLine": 51,
+      "summary": "Defines `IsSidon S` (all pairwise sums distinct: $a+b=c+d$ with $a\\leq b,c\\leq d$ implies $\\{a,b\\}=\\{c,d\\}$), `cubeSet N` ($\\{1^3,\\dots,N^3\\}$), and `nearTopCubes N k` ($\\{n^3:N-k\\leq n\\leq N\\}$).",
+      "mathContext": "Sidon (B₂): pairwise sums distinct; `cubeSet`, `nearTopCubes` over $\\{n^3\\}$."
     },
     {
-      "id": "imports",
-      "title": "Mathlib Import",
-      "startLine": 16,
-      "endLine": 16,
-      "summary": "Imports all of Mathlib. A full formalization would use Mathlib's `IsSidon` predicate (if available) or define it as ∀ a b c d ∈ S, a + b = c + d → {a,b} = {c,d}, plus `Finset.image`, `Finset.Ico`, and integer arithmetic from `Mathlib.Data.Int.Order`.",
-      "mathContext": "Relevant Mathlib modules: `Mathlib.Combinatorics.Additive.SidonSet` (if it exists in 4.x), `Mathlib.Data.Int.Basic` (for integer arithmetic), `Mathlib.Data.Nat.GCD.Basic` (for gcd arguments in Sidon proofs)."
+      "id": "sidon-property",
+      "title": "Part I: The Sidon Property",
+      "startLine": 52,
+      "endLine": 64,
+      "summary": "States the AXIOM `sidon_upper_bound`: a Sidon set in $\\{1,\\dots,M\\}$ has size $\\leq2\\sqrt M+1$ (pigeonhole on pairwise sums).",
+      "mathContext": "Axiom: Sidon $S\\subseteq[1,M]\\Rightarrow|S|\\leq2\\sqrt M+1$."
     },
     {
-      "id": "placeholder-theorem",
-      "title": "Placeholder Theorem: Sidon Cubes (Sorry)",
-      "startLine": 18,
-      "endLine": 21,
-      "summary": "Stub `theorem erdos_1206 : True := by sorry`. The actual theorem to formalize: ∃ c > 0, ∀ N, IsSidon {n³ : N - c·N^(1/2) ≤ n ≤ N}, proved via the algebraic identity n³ - m³ = (n-m)(n²+nm+m²) showing all pairwise sums/differences are distinct in short intervals.",
-      "mathContext": "Target type: `∃ c : ℝ, 0 < c ∧ ∀ N : ℕ, 0 < N → (Finset.image (· ^ 3) (Finset.Ico (N - Nat.sqrt N) N)).card = (Finset.Ico (N - Nat.sqrt N) N).card`. The Sidon condition requires all pairwise sums $a^3 + b^3 = c^3 + d^3$ to imply $\\{a,b\\} = \\{c,d\\}$."
-    },
-    {
-      "id": "sorry-tracking",
-      "title": "Sorry Tracking via #check",
-      "startLine": 22,
-      "endLine": 23,
-      "summary": "Sorry marker comment and `#check erdos_1206` for Aristotle proof search system tracking. The sorry is tracked in the gallery's sorry count and awaits either manual proof or automated resolution.",
-      "mathContext": "`#check erdos_1206` outputs `erdos_1206 : True`, confirming the theorem is well-typed. `#print axioms erdos_1206` would show `axioms used: sorryAx`, indicating the sorry axiom dependency."
+      "id": "main-result",
+      "title": "Part II: Main Result",
+      "startLine": 65,
+      "endLine": 102,
+      "summary": "States the AXIOM `gabdullin_konyagin_2024` (there is $c>0$ with $\\{n^3:N-cN^{1/2}\\leq n\\leq N\\}$ Sidon) and PROVES `sidon_in_cubes` / `erdos_1206`: the cube set $\\{1^3,\\dots,N^3\\}$ contains Sidon subsets of size $\\geq c\\sqrt N$ for large $N$ — the SOLVED main result.",
+      "mathContext": "$\\exists c>0$: $\\text{cubeSet}(N)$ has a Sidon subset of size $\\geq c\\sqrt N$ (Gabdullin–Konyagin)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #1206 (Sidon sets in cubes) gallery `meta.json` described an **obsolete stub**: "Placeholder Theorem: Sidon Cubes (Sorry)", "Sorry Tracking via #check", with coverage stopping at line **23**.

- The current **102**-line file is SOLVED and sorry-free. Real content — `IsSidon`/`cubeSet`/`nearTopCubes` definitions, the `sidon_upper_bound` and `gabdullin_konyagin_2024` axioms, and the proved theorems `sidon_in_cubes` / `erdos_1206` (lines 24-102) — was entirely unrepresented.

## Changes
- Rebuilt **4 sections** mapped to the file's actual structure (header, core definitions, Part I Sidon property, Part II main result) with full coverage **1-102**.
- **Counts already correct**: 2 theorems / 3 definitions / 2 axioms / 0 sorries, lineCount 102.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-102 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-1206
- [x] Section ranges verified against `Erdos1206Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)