### PR TITLE
research(erdos-363): realign drifted gallery sections to file (11→12)

### DIFF
--- a/src/data/proofs/erdos-363/meta.json
+++ b/src/data/proofs/erdos-363/meta.json
@@ -88,10 +88,10 @@
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "summary": "ConsecutiveInterval, DisjointIntervalCollection structures",
-      "startLine": 30,
+      "summary": "File header (problem statement and history) and Part I: ConsecutiveInterval and DisjointIntervalCollection structures with element/product/size helpers.",
+      "startLine": 1,
       "endLine": 70,
-      "mathContext": "Disjoint intervals $I_1,\\\\ldots,I_n \\\\subset \\\\mathbb{R}$ with $|I_k| = n/k$ (length proportional to $1/k$)."
+      "mathContext": "Formal definition: File header (problem statement and history) and Part I: ConsecutiveInterval and DisjointIntervalCollection structures with element/product/size helpers."
     },
     {
       "id": "perfect-squares",
@@ -130,14 +130,14 @@
       "title": "Bauer-Bennett Theorem (2007)",
       "summary": "Infinitely many solutions for n=3 or n=5",
       "startLine": 141,
-      "endLine": 156,
+      "endLine": 149,
       "mathContext": "Infinitely many solutions for n=3 or n=5"
     },
     {
       "id": "bennett-van-luijk",
       "title": "Bennett-Van Luijk Theorem (2012)",
       "summary": "Statement of Bennett-Van Luijk theorem in docstring (not axiomatized)",
-      "startLine": 151,
+      "startLine": 150,
       "endLine": 158,
       "mathContext": "Infinitely many solutions with size-5 intervals"
     },
@@ -145,32 +145,40 @@
       "id": "disproof",
       "title": "The Conjecture is FALSE",
       "summary": "Combining results to disprove the conjecture",
-      "startLine": 160,
+      "startLine": 159,
       "endLine": 192,
       "mathContext": "Combining results to disprove the conjecture"
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem",
+      "summary": "The erdos_363 main theorem restating that Erdős #363's finiteness conjecture is FALSE (via erdosConjecture363_false).",
+      "startLine": 193,
+      "endLine": 203,
+      "mathContext": "Verified: The erdos_363 main theorem restating that Erdős #363's finiteness conjecture is FALSE (via erdosConjecture363_false)."
     },
     {
       "id": "ulas-conjecture",
       "title": "Ulas's Conjecture",
       "summary": "Generalization to arbitrary interval sizes",
-      "startLine": 205,
-      "endLine": 219,
+      "startLine": 204,
+      "endLine": 220,
       "mathContext": "Generalization to arbitrary interval sizes"
     },
     {
       "id": "erdos-selfridge",
       "title": "Connection to Erdős-Selfridge",
       "summary": "Single blocks vs disjoint blocks",
-      "startLine": 222,
-      "endLine": 272,
+      "startLine": 221,
+      "endLine": 273,
       "mathContext": "Single blocks vs disjoint blocks"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Complete summary of results",
-      "startLine": 275,
-      "endLine": 292,
+      "startLine": 274,
+      "endLine": 293,
       "mathContext": "OPEN: whether only finitely many valid collections exist. A curious geometric-number-theoretic question."
     }
   ],


### PR DESCRIPTION
## Summary

The gallery sections for **Erdős #363 (Square Products from Disjoint Intervals)** had drifted out of alignment with `proofs/Proofs/Erdos363Problem.lean`:

- **Part IX "Main Theorem"** (`## Part IX` banner at line 194, holding `theorem erdos_363`) had **no section at all** — the listing jumped from "The Conjecture is FALSE" (ending 192) straight to "Ulas's Conjecture" at 205, leaving lines 193-204 uncovered.
- **"Bauer-Bennett" (141-156)** overlapped **"Bennett-Van Luijk" (151-158)** (151 < 156).
- The file-header docstring (lines 1-29, problem statement and history) was uncovered.

## Fix

Added the missing Part IX section and remapped all sections 1:1 to the file's `## Part I–XII` banners, contiguous `1 → 293`:

| Section | New range |
|---|---|
| Basic Definitions | 1–70 |
| Perfect Squares | 71–87 |
| The Erdős Conjecture | 88–99 |
| Why \|Iᵢ\| ≥ 4? | 100–124 |
| Ulas's Theorem (2005) | 125–140 |
| Bauer-Bennett Theorem (2007) | 141–149 |
| Bennett-Van Luijk Theorem (2012) | 150–158 |
| The Conjecture is FALSE | 159–192 |
| **Main Theorem** (new) | 193–203 |
| Ulas's Conjecture | 204–220 |
| Connection to Erdős-Selfridge | 221–273 |
| Summary | 274–293 |

Counts are unchanged and pre-correct (3 axioms / 5 theorems / 12 definitions). Section-metadata only — no Lean source changed, no rebuild required.

## Test plan

- [x] JSON validates (`json.load` after edit)
- [x] Sections contiguous and within file bounds (1–293), no overlaps
- [x] Section ranges verified against `## Part` banner positions in the Lean file