### PR TITLE
research(minpoly-charpoly): realign drifted gallery sections (5→11)

### DIFF
--- a/src/data/proofs/minpoly-charpoly/meta.json
+++ b/src/data/proofs/minpoly-charpoly/meta.json
@@ -51,44 +51,92 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring stating what is proved (relationships between the minimal and characteristic polynomials of a matrix), key results, mathematical context, status, and Mathlib dependencies; opens the MinpolyCharpoly namespace with Matrix/Polynomial scopes and the matrix index variables.",
+      "mathContext": "Sets up the study of $m_M = \\mathrm{minpoly}_K M$ and $p_M = M.\\mathrm{charpoly}$ for an $n \\times n$ matrix $M$ over a field $K$, with $n$ a `Fintype` with `DecidableEq`."
+    },
+    {
       "id": "core-relationship",
-      "title": "Parts 1–2: Integrality and Divisibility",
-      "startLine": 49,
-      "endLine": 92,
-      "summary": "matrix_is_integral: every matrix is integral over its base ring (prerequisite for minpoly). minpoly_dvd_charpoly: minpoly K M | M.charpoly — the core divisibility theorem. minpoly_monic: minpoly is monic. minpoly_degree_pos: degree ≥ 1 for nontrivial matrix rings.",
-      "mathContext": "$\\text{minpoly}(M) \\mid \\text{charpoly}(M)$; minpoly is monic; $\\deg(\\text{minpoly}) \\geq 1$."
+      "title": "Part 1: Core Relationship",
+      "startLine": 55,
+      "endLine": 74,
+      "summary": "Establishes that every matrix is integral over its base ring (matrix_is_integral) and the core divisibility minpoly_dvd_charpoly: the minimal polynomial divides the characteristic polynomial.",
+      "mathContext": "$M$ is integral over $K$, so $m_M$ is defined, and $m_M \\mid p_M$ in $K[X]$ — the fundamental relationship between the two polynomials."
+    },
+    {
+      "id": "minpoly-properties",
+      "title": "Part 2: Properties of the Minimal Polynomial",
+      "startLine": 75,
+      "endLine": 93,
+      "summary": "Records that the minimal polynomial is monic (minpoly_monic) and has positive degree for a nontrivial matrix ring (minpoly_degree_pos).",
+      "mathContext": "$m_M$ is monic and $\\deg(m_M) \\ge 1$ whenever $\\mathrm{Matrix}\\,n\\,n\\,K$ is nontrivial."
     },
     {
       "id": "degree-bounds",
       "title": "Part 3: Degree Bounds",
       "startLine": 94,
       "endLine": 116,
-      "summary": "minpoly_degree_le_charpoly_degree: deg(minpoly) ≤ deg(charpoly) via Polynomial.natDegree_le_of_dvd. minpoly_degree_le_dim: deg(minpoly) ≤ n via Matrix.charpoly_natDegree_eq_dim. Both use charpoly_monic.ne_zero to ensure the divisor is nonzero.",
-      "mathContext": "$1 \\leq \\deg(m_M) \\leq \\deg(p_M) = n$ where $n = \\text{Fintype.card}\\,\\mathtt{n}$."
+      "summary": "Bounds the minimal polynomial degree: minpoly_degree_le_charpoly_degree (≤ deg charpoly via natDegree_le_of_dvd) and minpoly_degree_le_dim (≤ n via charpoly_natDegree_eq_dim).",
+      "mathContext": "$1 \\le \\deg(m_M) \\le \\deg(p_M) = n$, where $n = \\mathrm{Fintype.card}\\,n$, using that $p_M$ is monic hence nonzero."
     },
     {
-      "id": "annihilation-universal",
-      "title": "Parts 4–5: Annihilation, Universal Property, Monicness",
-      "startLine": 118,
-      "endLine": 151,
-      "summary": "charpoly_annihilates: aeval M M.charpoly = 0 (Cayley-Hamilton from Mathlib). minpoly_annihilates: aeval M (minpoly K M) = 0 (defining property). minpoly_divides_annihilator: universal property (minpoly.dvd). both_monic: both polynomials are monic.",
-      "mathContext": "$\\text{Ann}(M) = (m_M)$ as a principal ideal in $K[X]$. $p(M) = 0 \\Leftrightarrow m_M \\mid p$."
+      "id": "annihilation",
+      "title": "Part 4: Annihilation Properties",
+      "startLine": 117,
+      "endLine": 138,
+      "summary": "Both polynomials annihilate the matrix: charpoly_annihilates (Cayley-Hamilton, from Mathlib) and minpoly_annihilates (defining property), plus the universal property minpoly_divides_annihilator that minpoly divides any annihilating polynomial.",
+      "mathContext": "$p_M(M) = 0$ (Cayley–Hamilton) and $m_M(M) = 0$; moreover $p(M) = 0 \\Leftrightarrow m_M \\mid p$, so the annihilator ideal is $(m_M)$."
     },
     {
-      "id": "roots-linmap",
-      "title": "Parts 6–7: Root Relationship and Linear Map Connection",
+      "id": "monicness",
+      "title": "Part 5: Both Polynomials are Monic",
+      "startLine": 139,
+      "endLine": 152,
+      "summary": "Proves both_monic: the minimal and characteristic polynomials are each monic.",
+      "mathContext": "Both $m_M$ and $p_M$ are monic, a prerequisite for the degree and divisibility arguments."
+    },
+    {
+      "id": "root-relationship",
+      "title": "Part 6: Root Relationship",
       "startLine": 153,
-      "endLine": 179,
-      "summary": "minpoly_root_is_charpoly_root: every root of minpoly is a root of charpoly. minpoly_eq_linmap_minpoly: minpoly of matrix = minpoly of corresponding linear map (Matrix.minpoly_toLin'). Establishes basis-independence of the minimal polynomial.",
-      "mathContext": "$\\alpha$ root of $m_M \\Rightarrow$ $\\alpha$ root of $p_M$. $m_M = m_\\phi$ where $\\phi$ is the linear map represented by $M$."
+      "endLine": 167,
+      "summary": "Proves minpoly_root_is_charpoly_root: every root of the minimal polynomial is also a root of the characteristic polynomial (the two share their root set / eigenvalues).",
+      "mathContext": "If $\\alpha$ is a root of $m_M$ then $\\alpha$ is a root of $p_M$, since $m_M \\mid p_M$; the roots are exactly the eigenvalues of $M$."
     },
     {
-      "id": "examples-uniqueness",
-      "title": "Parts 8–9: Concrete Examples and Uniqueness",
-      "startLine": 181,
-      "endLine": 213,
-      "summary": "identity_annihilated: aeval I (minpoly K I) = 0 (minpoly = X − 1). zero_annihilated: aeval 0 (minpoly K 0) = 0 (minpoly = X). zero_matrix_minpoly_dvd_charpoly: minpoly(0) | charpoly(0). minpoly_dvd_annihilating_monic: universal property restated. Identity and zero are the extremal cases with maximum degree gap n−1.",
-      "mathContext": "Identity: $m_I = X-1$, $p_I = (X-1)^n$. Zero: $m_0 = X$, $p_0 = X^n$. Both have degree gap $n-1$."
+      "id": "linmap-connection",
+      "title": "Part 7: The Linear Map Connection",
+      "startLine": 168,
+      "endLine": 179,
+      "summary": "Proves minpoly_eq_linmap_minpoly: the minimal polynomial of a matrix equals that of its associated linear map (via Matrix.minpoly_toLin'), establishing basis-independence.",
+      "mathContext": "$m_M = m_\\phi$ where $\\phi$ is the endomorphism represented by $M$, so the minimal polynomial is independent of the chosen basis."
+    },
+    {
+      "id": "concrete-examples",
+      "title": "Part 8: Concrete Examples",
+      "startLine": 180,
+      "endLine": 200,
+      "summary": "Works the extremal examples: the identity matrix (minpoly = X − 1) and the zero matrix (minpoly = X), with their annihilation and divisibility checks — the cases of maximal degree gap n − 1.",
+      "mathContext": "Identity: $m_I = X-1$, $p_I = (X-1)^n$. Zero: $m_0 = X$, $p_0 = X^n$. Both realize the maximal degree gap $\\deg(p) - \\deg(m) = n-1$."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Part 9: Uniqueness of Minimal Polynomial",
+      "startLine": 201,
+      "endLine": 211,
+      "summary": "Proves minpoly_dvd_annihilating_monic: the minimal polynomial divides any monic annihilating polynomial — the universal property uniquely characterizing it.",
+      "mathContext": "For any monic $p$ with $p(M) = 0$, $m_M \\mid p$; together with monicity this determines $m_M$ uniquely."
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Results",
+      "startLine": 212,
+      "endLine": 246,
+      "summary": "Closing documentation block grouping all 17 results by theme — divisibility, degree bounds, annihilation, structure, and the linear-map connection — giving the complete picture of the minpoly/charpoly relationship.",
+      "mathContext": "Synthesizes the file: $m_M \\mid p_M$, $\\deg(m_M) \\le n$, both annihilate $M$ and are monic, share roots, and the matrix minpoly agrees with the linear-map minpoly."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Gallery sections for `minpoly-charpoly` (minimal vs. characteristic polynomial of a matrix) lumped the file's nine `-- PART N` banners into five paired sections and left both ends of `proofs/Proofs/MinpolyCharpoly.lean` (246 lines) uncovered.

### Problems fixed
- **Uncovered header**: lines 1-54 (module docstring, imports, namespace, variable setup) had no section.
- **Uncovered tail**: lines 214-246 — the `Summary` banner and the `## Summary of Results` documentation block — had no coverage.
- **Lumped parts**: old sections paired Parts 1-2, 4-5, 6-7, and 8-9 into single entries.

### Result
Rebuilt **11 contiguous sections** (1-246): a module-header section, one section per `-- PART N` banner (Parts 1-9), and a Summary section, each with a focused summary and mathContext.

## Scope
- Only `src/data/proofs/minpoly-charpoly/meta.json` changed (sections array).
- No Lean source edits. Counts (0 axioms / 17 theorems / 0 definitions / 0 sorries) were already correct and are untouched.

## Test plan
- [x] JSON validates (round-trip parse)
- [x] Sections are contiguous 1→246 with no gaps or overlaps
- [x] Section ranges match the `-- PART N` banners in the Lean source