### PR TITLE
research(burnside-counting): realign drifted gallery sections to file (5→5)

### DIFF
--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -227,13 +227,13 @@
       "id": "sec-burnside-header",
       "title": "Imports, Docstring, and Namespace",
       "startLine": 1,
-      "endLine": 37,
+      "endLine": 40,
       "summary": "Imports Mathlib group action quotient, cyclic groups, ZMod, and Fintype cardinality. Docstring outlines the three goals: Burnside's lemma, ZMod n action on colorings, binary 4-necklace count. Opens BurnsideCounting namespace."
     },
     {
       "id": "sec-burnside-lemma",
       "title": "Part I: Burnside's Lemma from Mathlib",
-      "startLine": 38,
+      "startLine": 41,
       "endLine": 53,
       "summary": "States burnside_lemma as a one-line delegation to MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group. The multiplicative form Σ|Fix(g)| = |X/G| × |G| avoids division. Requires Fintype instances for G, fixedBy X g, and orbitRel.Quotient G X."
     },
@@ -241,14 +241,14 @@
       "id": "sec-burnside-action",
       "title": "Part II: Cyclic Group Action on Finite Colorings",
       "startLine": 54,
-      "endLine": 109,
+      "endLine": 225,
       "summary": "Defines Coloring n k (Fin n → Fin k), rotateColoring and rotatedIndex. Proves rotatedIndex_zero and rotatedIndex_add (both fully verified theorems — composition law via ZMod.val_add + Nat.mod_mod + 8-leaf sign-case enumeration with three private Nat-mod auxiliaries: mod_eq_sub, mod_of_shift, mod_of_eq). Establishes cyclicAddActionOnColorings: AddAction (ZMod n) (Coloring n k) instance with verified zero_vadd and add_vadd."
     },
     {
       "id": "sec-burnside-concrete",
-      "title": "Part III: Concrete Fixed-Point Counts",
-      "startLine": 110,
-      "endLine": 193,
+      "title": "Part III: Concrete Example - Binary 4-Necklaces",
+      "startLine": 226,
+      "endLine": 305,
       "summary": "binary_4_colorings_count: |Coloring 4 2| = 16 via norm_num. Defines IsConstant, proves constant_coloring_count (bijection with Fin k, fully verified). Derives constant_4_2. Defines HasPeriod2, proves period2_count = 4 via bijection with Fin 2 × Fin 2 using vector literals and fin_cases."
     },
     {


### PR DESCRIPTION
## Summary
- The two middle sections of `burnside-counting` (Burnside/Cauchy-Frobenius necklace counting) had drifted: **Part II** (54–109) and a mislabeled **"Part III: Concrete Fixed-Point Counts"** (110–193) both fell inside the file's actual Part II region.
- This left a **112-line gap (194–305)** that swallowed the real `## Part III: Concrete Example - Binary 4-Necklaces` banner at line 226.
- The section *summaries* were already accurate (the "concrete" summary describes the binary-4-necklace content at 226–305) — only the **ranges** and one **title** were wrong.

## Details
| Section | Old range | New range |
|---|---|---|
| Imports, Docstring, and Namespace | 1–37 | 1–40 |
| Part I: Burnside's Lemma from Mathlib | 38–53 | 41–53 |
| Part II: Cyclic Group Action on Finite Colorings | 54–109 | 54–225 |
| Part III: Concrete Example – Binary 4-Necklaces | 110–193 | 226–305 |
| Part IV: Summary, Decidable Predicates, Necklace Count | 306–404 | 306–404 |

Re-snapped to the file's four `## Part` banners (I@41, II@54, III@226, IV@306) for full 1–404 coverage; aligned the Part III title to the file banner ("Concrete Fixed-Point Counts" → "Concrete Example - Binary 4-Necklaces").

Counts unchanged and pre-correct (0ax/9thm/9def/0sry, 404 lines). Build-free metadata-only change; summaries preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)