### PR TITLE
research(erdos-210): realign drifted gallery sections to full file (10→11)

### DIFF
--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -79,6 +79,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview & Problem Statement",
+      "summary": "Module docstring for Erdős Problem #210 (ordinary lines): f(n) is minimal such that any n points in ℝ², not all collinear, determine at least f(n) ordinary lines (lines through exactly two points). SOLVED by Green-Tao (2013). Includes the statement and Mathlib imports.",
+      "startLine": 1,
+      "endLine": 41,
+      "mathContext": null
+    },
+    {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "Point, PointSet, Collinear, InGeneralPosition, NotAllCollinear",
@@ -107,7 +115,7 @@
       "title": "Sylvester-Gallai Theorem",
       "summary": "f(n) ≥ 1 for any non-collinear configuration",
       "startLine": 89,
-      "endLine": 105,
+      "endLine": 103,
       "mathContext": "f(n) $\\geq$ 1 for any non-collinear configuration"
     },
     {


### PR DESCRIPTION
## Summary
Section-realign for the **erdos-210** gallery entry (Erdős Problem #210 — ordinary lines, SOLVED by Green-Tao 2013). Build-free; meta.json sections only.

- The 41-line module-docstring header (problem statement) was **uncovered**.
- **Sylvester-Gallai** overran into Motzkin's Theorem — ended at 105 while the next `/- ## -/` banner is at 104.

Rebuilt **11 contiguous sections** (overview + the 10 file banners) covering lines **1–196** with no gaps or overlaps.

## Test plan
- [x] `json.load` validates; sections contiguous and cover 1–196 (file is 196 lines)
- [x] Diff is sections-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)