### PR TITLE
research(erdos-852): realign drifted gallery sections (8→8) + fix stale "axioms" title

### DIFF
--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -50,65 +50,65 @@
       "id": "header",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 25,
-      "summary": "Header documenting Erdős Problem #852 on maximal distinct prime gap runs. Imports `Nat.Prime.Basic`, `Finset.Basic`, `Real.log`, `Real.rpow`, `Asymptotics.Defs`, and `Filter.Basic` for the formalization.",
-      "mathContext": "Header documenting Erdős Problem #852 on maximal distinct prime gap runs. Imports `Nat.Prime.Basic`, `Finset.Basic`, `Real.log`, `Real.rpow`, `Asymptotics.Defs`, and `Filter.Basic` for the formalization."
+      "endLine": 26,
+      "summary": "States Erdős Problem #852: with $d_n=p_{n+1}-p_n$, $h(x)$ is the maximal run length such that consecutive gaps $d_n,\\dots,d_{n+h-1}$ (for some $p_n<x$) are all distinct. Erdős asked: (1) is $h(x)>(\\log x)^c$? (2) is $h(x)=o(\\log x)$? Brun's sieve gives $h(x)\\to\\infty$. Status OPEN. Imports prime/asymptotics; opens `Filter`/`Asymptotics`/`Real`.",
+      "mathContext": "$h(x)=$ max run of distinct consecutive prime gaps below $x$. Open: $(\\log x)^c<h(x)=o(\\log x)$?"
     },
     {
-      "id": "primes",
-      "title": "Prime Sequence Axioms",
-      "startLine": 26,
-      "endLine": 33,
-      "summary": "Axiomatizes `nthPrime : ℕ → ℕ` with four properties: $p_n$ is prime, $n \\mapsto p_n$ is strictly monotone, $p_0 = 2$, and $p_1 = 3$. These encode the fundamental enumeration of primes.",
-      "mathContext": "Axiomatizes `nthPrime : $\\mathbb{N}$ $\\to$ $\\mathbb{N}$` with four properties: $p_n$ is prime, $n \\mapsto p_n$ is strictly monotone, $p_0 = 2$, and $p_1 = 3$. These encode the fundamental enumeration of primes."
-    },
-    {
-      "id": "gaps",
-      "title": "Prime Gap Definition and Properties",
-      "startLine": 34,
-      "endLine": 56,
-      "summary": "Defines `primeGap n = nthPrime (n+1) - nthPrime n` and proves four results: $d_n > 0$ (from strict monotonicity), `nthPrime` is monotone, $p_n \\geq 2$ (from primality), and $d_0 = 1$ (from $p_0 = 2, p_1 = 3$). All are genuine Lean proofs.",
-      "mathContext": "Defines `primeGap n = nthPrime (n+1) - nthPrime n` and proves four results: $d_n > 0$ (from strict monotonicity), `nthPrime` is monotone, $p_n \\geq 2$ (from primality), and $d_0 = 1$ (from $p_0 = 2, p_1 = 3$)."
+      "id": "prime-sequence",
+      "title": "Prime Sequence and Gaps (Proved from Mathlib)",
+      "startLine": 27,
+      "endLine": 65,
+      "summary": "Defines `nthPrime` (via `Nat.nth`) and `primeGap` and PROVES (no axioms — formerly axiomatized) their properties: `nthPrime_prime`, `nthPrime_strictMono`, `nthPrime_initial` ($p_0=2,p_1=3$), `primeGap_pos`, `nthPrime_mono`, `nthPrime_ge_two`, `primeGap_zero` ($d_0=1$).",
+      "mathContext": "$p_n=$ Nat.nth prime, $d_n=p_{n+1}-p_n>0$; $p_0=2,p_1=3,d_0=1$ (all proved)."
     },
     {
       "id": "distinct-runs",
       "title": "Distinct Gap Runs",
-      "startLine": 57,
-      "endLine": 81,
-      "summary": "Defines `IsDistinctRun n k` requiring all $k$ gaps $d_n, \\ldots, d_{n+k-1}$ to be pairwise distinct. Proves: empty and single runs are distinct (`omega` tactic), and distinct runs are downward-closed in $k$ (prefix property).",
-      "mathContext": "Defines `IsDistinctRun n k` requiring all $k$ gaps $d_n, \\ldots, d_{n+k-1}$ to be pairwise distinct. Proves: empty and single runs are distinct (`omega` tactic), and distinct runs are downward-closed in $k$ (prefix property)."
+      "startLine": 66,
+      "endLine": 90,
+      "summary": "Defines `IsDistinctRun n k` (gaps $d_n,\\dots,d_{n+k-1}$ pairwise distinct) and PROVES `isDistinctRun_zero`/`_one` and downward-closure `isDistinctRun_prefix`/`_le`.",
+      "mathContext": "`IsDistinctRun n k`: the $k$ gaps from index $n$ are pairwise distinct; downward-closed in $k$."
     },
     {
       "id": "h-function",
-      "title": "The Function $h(x)$",
-      "startLine": 82,
-      "endLine": 112,
-      "summary": "Defines `maxDistinctRun : ��� → ℕ` as `sSup` of valid run lengths (previously 4 axioms, now fully proved). Proves witness, optimality, $h(x) \\geq 1$ for $x \\geq 3$, and monotonicity $h(x) \\leq h(y)$ for $x \\leq y$.",
-      "mathContext": "Defines `maxDistinctRun : ℕ → ℕ` as `sSup` of valid run lengths (previously 4 axioms, now fully proved). Proves witness, optimality, $h(x) \\geq 1$ for $x \\geq 3$, and monotonicity $h(x) \\leq h(y)$ for $x \\leq y$."
+      "title": "h(x): Maximal Distinct Run Length (Defined)",
+      "startLine": 91,
+      "endLine": 147,
+      "summary": "Defines `maxDistinctRun x` $=h(x)=\\sup$ of achievable distinct run lengths $\\leq x$ (formerly 4 axioms, now defined). Private `validRunLengths` infrastructure (bddAbove, nonempty, monotone, the ℕ-sSup-membership lemma) feeds `maxDistinctRun_witness` (the sup is achieved) and `maxDistinctRun_optimal` (maximality).",
+      "mathContext": "$h(x)=\\sup\\{k\\leq x:\\exists n,p_n<x,\\ \\text{IsDistinctRun }n\\,k\\}$ (defined, with witness + optimality proved)."
     },
     {
-      "id": "brun-sieve",
-      "title": "Brun's Sieve Divergence",
-      "startLine": 113,
-      "endLine": 128,
-      "summary": "Axiomatizes Brun's result: $\\forall C,\\, \\exists X,\\, \\forall x \\geq X,\\, h(x) \\geq C$. Proves the `Filter.Tendsto` reformulation: $h \\to +\\infty$ as $x \\to \\infty$, using `tendsto_atTop_atTop` and `Nat.cast_le`.",
-      "mathContext": "Axiomatizes Brun's result: $\\forall C,\\, \\exists X,\\, \\forall x \\geq X,\\, h(x) \\geq C$. Proves the `Filter.Tendsto` reformulation: $h \\to +\\infty$ as $x \\to \\infty$, using `tendsto_atTop_atTop` and `Nat.cast_le`."
+      "id": "properties",
+      "title": "Properties of h(x)",
+      "startLine": 148,
+      "endLine": 166,
+      "summary": "PROVES `maxDistinctRun_ge_one` ($h(x)\\geq1$ for $x\\geq3$) and `maxDistinctRun_mono` ($x\\leq y\\Rightarrow h(x)\\leq h(y)$).",
+      "mathContext": "$h(x)\\geq1$ ($x\\geq3$); $h$ non-decreasing."
+    },
+    {
+      "id": "brun",
+      "title": "Brun's Sieve Result",
+      "startLine": 167,
+      "endLine": 182,
+      "summary": "States the AXIOM `brun_sieve_divergence` ($h(x)\\to\\infty$: for any $C$, eventually $h(x)\\geq C$) and PROVES `maxDistinctRun_tendsto_atTop` (the filter form $h(x)\\to\\infty$).",
+      "mathContext": "Axiom (Brun): $h(x)\\to\\infty$ as $x\\to\\infty$."
     },
     {
       "id": "conjectures",
       "title": "Erdős Conjectures (OPEN)",
-      "startLine": 129,
-      "endLine": 156,
-      "summary": "Axiomatizes both open questions: (1) $\\exists c > 0,\\, \\forall^\\infty x,\\, (\\log x)^c < h(x)$ using `Real.log` and `rpow`; (2) $h = o(\\log)$ using `Asymptotics.IsLittleO`. Derives $\\varepsilon$-bound consequence and combined growth rate statement.",
-      "mathContext": "Axiomatizes both open questions: (1) $\\exists c > 0,\\, \\forall^\\infty x,\\, (\\log x)^c < h(x)$ using `Real.log` and `rpow`; (2) $h = o(\\log)$ using `Asymptotics.IsLittleO`. Derives $\\varepsilon$-bound consequence and combined growth rate statement."
+      "startLine": 183,
+      "endLine": 210,
+      "summary": "States the two OPEN conjectures as AXIOMS: `erdos852_lower_bound` ($\\exists c>0,\\ (\\log x)^c<h(x)$ eventually) and `erdos852_upper_bound` ($h(x)=o(\\log x)$). PROVES `erdos852_upper_eventually` (the $\\varepsilon\\log x$ form) and `erdos852_growth_rate` (the combined statement).",
+      "mathContext": "Axioms (open): $(\\log x)^c<h(x)$ and $h(x)=o(\\log x)$ — growth strictly between."
     },
     {
-      "id": "pigeonhole",
-      "title": "Pigeonhole Upper Bound",
-      "startLine": 157,
-      "endLine": 170,
-      "summary": "Proves $h(x) \\leq x$ (from sSup definition) and the pigeonhole principle: $k$ distinct positive values all $\\leq M$ implies $k \\leq M$ (via `Finset.card_image_of_injOn`).",
-      "mathContext": "Proves $h(x) \\leq x$ (from sSup definition) and the pigeonhole principle: $k$ distinct positive values all $\\leq M$ implies $k \\leq M$ (via `Finset.card_image_of_injOn`)."
+      "id": "upper-bound",
+      "title": "Upper Bound",
+      "startLine": 211,
+      "endLine": 247,
+      "summary": "PROVES `maxDistinctRun_le_x` ($h(x)\\leq x$, from the definition) and `distinct_run_bounded_by_max_gap` (a distinct run of length $k$ with all gaps $\\leq M$ has $k\\leq M$, by pigeonhole via `Finset.card_image_of_injOn`).",
+      "mathContext": "$h(x)\\leq x$; a distinct run with gaps $\\leq M$ has length $\\leq M$ (pigeonhole)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #852 (maximal runs of distinct consecutive prime gaps) gallery `meta.json` had **section drift** and a **stale title**.

- Sections drifted heavily from the middle: "Brun's Sieve Divergence" labeled @113 but the banner is @167, "Erdős Conjectures" @129 but @183, "Pigeonhole Upper Bound" @157 but @211; the "Properties of h(x)" banner (@148) was missing entirely.
- Coverage stopped at line **170** of a **247**-line file, hiding the Erdős-conjecture axioms/theorems and the Upper Bound theorems (`maxDistinctRun_le_x`, `distinct_run_bounded_by_max_gap`).
- Stale title: "Prime Sequence Axioms" — the `nthPrime` facts are now **proved** from Mathlib (not axioms), as the file's banner states.

## Changes
- Realigned all **8 sections** to the file's `-- ## ` banners with full coverage **1-247**, with accurate `mathContext`.
- **Counts already correct**: 25 theorems / 5 definitions / 3 axioms / 0 sorries, lineCount 247.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-247 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-852
- [x] Section ranges/titles re-verified against the `-- ## ` banners in `Erdos852Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)