### PR TITLE
research(erdos-521): realign drifted gallery sections to full file (7→8)

### DIFF
--- a/src/data/proofs/erdos-521/meta.json
+++ b/src/data/proofs/erdos-521/meta.json
@@ -82,45 +82,52 @@
   },
   "sections": [
     {
+      "id": "header-context",
+      "title": "Module Header and Random-Polynomial Roots Context",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring: Erdős #521 (real roots of random ±1 polynomials, Kac constant 2/π) statement and context"
+    },
+    {
       "id": "definitions",
       "title": "Basic Definitions",
       "startLine": 32,
-      "endLine": 61,
+      "endLine": 59,
       "summary": "Random polynomial, valid coefficients, root counts"
     },
     {
       "id": "kac-constant",
-      "title": "The Kac Constant 2/π",
-      "startLine": 62,
-      "endLine": 83,
+      "title": "The Kac-Erdős-Offord Constant",
+      "startLine": 60,
+      "endLine": 81,
       "summary": "kacConstant, halfKacConstant, positivity"
     },
     {
       "id": "erdos-offord",
       "title": "Erdős-Offord Theorem (1956)",
-      "startLine": 84,
-      "endLine": 117,
+      "startLine": 82,
+      "endLine": 109,
       "summary": "Expected number of real roots, variance bound"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 118,
-      "endLine": 132,
+      "startLine": 110,
+      "endLine": 122,
       "summary": "A.s. Rₙ/log n → 2/π (OPEN)"
     },
     {
       "id": "do-theorem",
       "title": "Do's Theorem (2024)",
-      "startLine": 133,
-      "endLine": 150,
+      "startLine": 123,
+      "endLine": 135,
       "summary": "A.s. result for roots in [-1,1]"
     },
     {
       "id": "kac-formula",
       "title": "Kac's Integral Formula",
-      "startLine": 151,
-      "endLine": 173,
+      "startLine": 136,
+      "endLine": 154,
       "summary": "Why 2/π appears, root bound"
     },
     {


### PR DESCRIPTION
## Summary
- The `erdos-521` gallery `meta.json` had **7 sections** with late drift and a real overlap: "Kac's Integral Formula" (151–173) and "Summary" (155–174) overlapped, the module header (lines 1–31) was uncovered, and Parts II–VII pointed at the wrong line ranges.
- Rebuilt **8 contiguous sections** (1→174) aligned one-per-`## Part` banner in `Erdos521Problem.lean`, plus a header section.
- Reused existing summaries by id; corrected the Part II title from "The Kac Constant 2/π" to the in-file banner "The Kac-Erdős-Offord Constant".

## Notes
- **No Lean changes** — pure gallery `meta.json` sections realign. All non-section keys identical; counts (1 thm / 5 ax / 4 def / 0 sorries) unchanged.
- Section boundaries computed from the `/-` docstring opener (banner − 1) of each `## Part` marker; coverage verified contiguous with no gaps/overlaps to file LOC 174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)