### PR TITLE
research(erdos-875): rebuild stale axiomatized-era sections to full file (10→7)

### DIFF
--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -48,84 +48,60 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "startLine": 20,
+      "id": "header",
+      "title": "Header and Imports",
+      "startLine": 1,
       "endLine": 26,
-      "summary": "Imports tactics, Finset.Basic, Finset.Powerset, and Nat.Bitwise for popcount.",
-      "mathContext": "Mathematical content: Imports tactics, Finset.Basic, Finset.Powerset, and Nat.Bitwise for popcount."
+      "summary": "States Erdős Problem #875: an infinite $A=\\{a_1<a_2<\\cdots\\}$ is *admissible* if its $r$-fold sumsets $S_r$ (sums of $r$ distinct elements) are pairwise disjoint for distinct $r\\geq1$. Questions: how fast must such a sequence grow, and how small can $a_{n+1}-a_n$ be (e.g. $\\leq n^c$)? An infinite variant of #874 (Deshouillers–Erdős). Status OPEN. Imports `Finset`/`Nat.Bitwise`.",
+      "mathContext": "Admissible: $r$-fold sumsets pairwise disjoint. Open: growth rate / minimal gaps $a_{n+1}-a_n$?"
     },
     {
-      "id": "r-fold-sumset",
-      "title": "r-Fold Sumset Definition",
+      "id": "core-defs",
+      "title": "Core Definitions",
       "startLine": 27,
-      "endLine": 32,
-      "summary": "Defines rFoldSumset as the image of r-element subsets under summation.",
-      "mathContext": "Formal definition: Defines rFoldSumset as the image of r-element subsets under summation."
-    },
-    {
-      "id": "sequence-defs",
-      "title": "Sequence Properties",
-      "startLine": 33,
       "endLine": 52,
-      "summary": "Defines StrictlyIncreasing, seqRSumset, DisjointSumsets, and IsAdmissible.",
-      "mathContext": "Formal definition: Defines StrictlyIncreasing, seqRSumset, DisjointSumsets, and IsAdmissible."
+      "summary": "Defines `rFoldSumset` (sums of $r$ distinct elements), `StrictlyIncreasing`, `seqRSumset` (the $r$-fold sumset of the first $N$ sequence terms), `DisjointSumsets`, and `IsAdmissible` (strictly increasing + disjoint sumsets).",
+      "mathContext": "$S_r(A)=\\{\\sum_{i\\in T}a_i:|T|=r\\}$; admissible $=$ strictly increasing $\\wedge$ all $S_r$ disjoint."
     },
     {
       "id": "main-questions",
       "title": "Main Questions (OPEN)",
       "startLine": 53,
-      "endLine": 76,
-      "summary": "Defines HasPolynomialGaps, HasRatioOne, and states the gap threshold and ratio-one axioms.",
-      "mathContext": "Formal definition: Defines HasPolynomialGaps, HasRatioOne, and states the gap threshold and ratio-one axioms."
+      "endLine": 68,
+      "summary": "Defines the open-question predicates: `HasPolynomialGaps` ($a_{n+1}-a_n\\leq n^c$ eventually) and `HasRatioOne` ($a_{n+1}/a_n\\to1$, which Erdős noted is 'not completely trivial').",
+      "mathContext": "Open: for which $c$ can $a_{n+1}-a_n\\leq n^c$? Can $a_{n+1}/a_n\\to1$?"
     },
     {
-      "id": "pow2-increasing",
-      "title": "Powers of 2 Strictly Increasing (Fully Proved)",
-      "startLine": 77,
-      "endLine": 83,
-      "summary": "Proves 2^n < 2^(n+1) using Nat.pow_lt_pow_right.",
-      "mathContext": "Proves $2^{n}$ < 2^(n+1) using Nat.pow_lt_pow_right."
-    },
-    {
-      "id": "popcount",
-      "title": "Popcount Lemma (Axiomatized)",
-      "startLine": 84,
-      "endLine": 92,
-      "summary": "Axiomatizes that the popcount of a sum of distinct powers of 2 equals the number of terms.",
-      "mathContext": "Axiomatized: Axiomatizes that the popcount of a sum of distinct powers of 2 equals the number of terms."
-    },
-    {
-      "id": "pow2-admissible",
-      "title": "Powers of 2 Admissible (Partially Proved)",
-      "startLine": 93,
-      "endLine": 104,
-      "summary": "Strict increase proved; disjoint sumsets uses sorry (depends on popcount argument).",
-      "mathContext": "Mathematical content: Strict increase proved; disjoint sumsets uses sorry (depends on popcount argument)."
+      "id": "powers-of-two",
+      "title": "Powers of 2 are Admissible",
+      "startLine": 69,
+      "endLine": 175,
+      "summary": "PROVES that powers of $2$ form an admissible sequence. `pow2_strictly_increasing`; the private `sum_range_two_pow` ($\\sum_{i<N}2^i=2^N-1$) and the binary-uniqueness lemma `pow2_subset_sum_inj` (distinct-power subsets with equal sums are equal — replacing a former popcount axiom); then `powers_of_two_admissible` (disjoint sumsets, since a sum of distinct powers of $2$ determines the subset). Axiom-free.",
+      "mathContext": "Sums of distinct powers of $2$ are unique $\\Rightarrow$ $\\{2^n\\}$ admissible (proved, no axioms)."
     },
     {
       "id": "growth-lower",
-      "title": "Growth Lower Bound (Fully Proved)",
-      "startLine": 105,
-      "endLine": 116,
-      "summary": "Proves a(n) ≥ n+1 for admissible sequences by induction.",
-      "mathContext": "Proves a(n) $\\geq$ n+1 for admissible sequences by induction."
+      "title": "Admissible Growth Lower Bound",
+      "startLine": 176,
+      "endLine": 187,
+      "summary": "PROVES `admissible_growth_lower`: every admissible sequence with $a_0\\geq1$ satisfies $a_n\\geq n+1$ (by strict monotonicity).",
+      "mathContext": "Admissible, $a_0\\geq1\\Rightarrow a_n\\geq n+1$."
     },
     {
       "id": "small-examples",
       "title": "Small Examples",
-      "startLine": 117,
-      "endLine": 124,
-      "summary": "The set {1, 2, 4} has disjoint 1-fold and 2-fold sumsets (sorry).",
-      "mathContext": "Mathematical content: The set {1, 2, 4} has disjoint 1-fold and 2-fold sumsets (sorry)."
+      "startLine": 188,
+      "endLine": 195,
+      "summary": "PROVES `pow2_small_example`: $\\{1,2,4\\}$ has disjoint $1$-fold and $2$-fold sumsets ($S_1=\\{1,2,4\\}$, $S_2=\\{3,5,6\\}$), by `native_decide`.",
+      "mathContext": "$\\{1,2,4\\}$: $S_1=\\{1,2,4\\}$, $S_2=\\{3,5,6\\}$ disjoint."
     },
     {
-      "id": "finite-connection",
+      "id": "connection-874",
       "title": "Connection to Problem #874",
-      "startLine": 125,
-      "endLine": 135,
-      "summary": "Axiomatizes the finite version: maximum admissible subset size of {1,...,n}.",
-      "mathContext": "Axiomatized: Axiomatizes the finite version: maximum admissible subset size of {1,...,n}."
+      "startLine": 196,
+      "endLine": 212,
+      "summary": "PROVES `finite_version_connection`: the finite #874 variant (max $|A|$ for $A\\subseteq\\{0,\\dots,n\\}$ with disjoint sumsets) has the trivial upper bound $|A|\\leq n+1$. The infinite #875 asks instead about growth rates.",
+      "mathContext": "#874 (finite): $A\\subseteq\\{0,\\dots,n\\}\\Rightarrow|A|\\leq n+1$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #875 (admissible sequences with disjoint sumsets) gallery `meta.json` described an **obsolete axiomatized layout**.

- The 10 sections included "Popcount Lemma (Axiomatized)" and "Powers of 2 Admissible (Partially Proved)", but the current file has **no popcount lemma and 0 axioms**: the former axiom was replaced by the proved binary-uniqueness lemma `pow2_subset_sum_inj`, and `powers_of_two_admissible` is fully proved.
- Coverage stopped at line **135** of a **212**-line file, hiding the admissible growth lower bound, small examples, and the #874 connection.

## Changes
- Rebuilt **7 sections** (was 10) mapped to the file's current `-- ## ` banners with full coverage **1-212**.
- **Counts already correct**: 7 theorems / 7 definitions / 0 axioms / 0 sorries, lineCount 212.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-212 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-875
- [x] Section ranges re-verified against `Erdos875Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)