### PR TITLE
research(erdos-893): realign drifted gallery sections to file (9→9)

### DIFF
--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -113,23 +113,23 @@
       "id": "sec-893-tau",
       "title": "Divisor Counting Function $\\tau$",
       "startLine": 31,
-      "endLine": 71,
+      "endLine": 85,
       "summary": "Defines `tau n` as `n.divisors.card`. Verifies $\\tau(2^k-1)$ for $k = 1, \\ldots, 8$ via `native_decide`. Proves `tau_prime_eq_two`: primes have exactly 2 divisors.",
       "mathContext": "Defines `tau n` as `n.divisors.card`. Verifies $\\tau($2^{k}$-1)$ for $k = 1, \\ldots, 8$ via `native_decide`. Proves `tau_prime_eq_two`: primes have exactly 2 divisors."
     },
     {
       "id": "sec-893-f",
       "title": "Cumulative Sum $f(n)$",
-      "startLine": 72,
-      "endLine": 110,
+      "startLine": 86,
+      "endLine": 133,
       "summary": "Defines `f n` as $\\sum_{k=1}^n \\tau(2^k-1)$ via `Finset.Icc` and `Finset.sum`. Verifies $f(1), \\ldots, f(8)$ via `native_decide` and collects into `f_initial_values`.",
       "mathContext": "Defines `f n` as $\\sum_{k=1}^n \\tau($2^{k}$-1)$ via `Finset.Icc` and `Finset.sum`. Verifies $f(1), \\ldots, f(8)$ via `native_decide` and collects into `f_initial_values`."
     },
     {
       "id": "sec-893-mono",
       "title": "Monotonicity and Positivity",
-      "startLine": 111,
-      "endLine": 125,
+      "startLine": 134,
+      "endLine": 206,
       "summary": "Proves `f_mono` ($m \\le n \\implies f(m) \\le f(n)$) via `Finset.sum_le_sum_of_subset` and `f_pos` ($n \\ge 1 \\implies f(n) > 0$) via chaining with $f(1) = 1$.",
       "mathContext": "Verified: Proves `f_mono` ($m \\le n \\implies f(m) \\le f(n)$) via `Finset.sum_le_sum_of_subset` and `f_pos` ($n \\ge 1 \\implies f(n) > 0$) via chaining with $f(1) = 1$."
     },
@@ -137,7 +137,7 @@
       "id": "sec-893-mersenne",
       "title": "Mersenne Divisibility and Tau Bounds",
       "startLine": 207,
-      "endLine": 269,
+      "endLine": 270,
       "summary": "Proves `mersenne_dvd` ($a \\mid b \\Rightarrow (2^a-1) \\mid (2^b-1)$) by induction on the quotient, `mersenne_injective` ($2^a-1 = 2^b-1 \\Rightarrow a = b$) by strict monotonicity, `tau_mersenne_ge_tau` ($\\tau(2^k-1) \\geq \\tau(k)$) via injection of divisors, and `f_divisor_sum_lower` ($f(n) \\geq \\sum_{k=1}^n \\tau(k)$) connecting $f$ to the divisor summatory function.",
       "mathContext": "Key structural chain: Mersenne divisibility provides an injection from divisors of $k$ to divisors of $2^k-1$, giving $\\tau(2^k-1) \\geq \\tau(k)$. Summing yields $f(n) \\geq \\sum_{k=1}^n \\tau(k) \\sim n \\log n$ (by Dirichlet's divisor estimate)."
     },
@@ -145,7 +145,7 @@
       "id": "sec-893-ratio",
       "title": "The Ratio $f(2n)/f(n)$",
       "startLine": 271,
-      "endLine": 284,
+      "endLine": 285,
       "summary": "Defines `ratio n` as $(f(2n) : \\mathbb{R}) / (f(n) : \\mathbb{R})$. Proves `ratio_ge_one`: the ratio is at least 1 for $n \\ge 1$.",
       "mathContext": "Formal definition: Defines `ratio n` as $(f(2n) : \\mathbb{R}) / (f(n) : \\mathbb{R})$. Proves `ratio_ge_one`: the ratio is at least 1 for $n \\ge 1$."
     },
@@ -153,7 +153,7 @@
       "id": "sec-893-known",
       "title": "Known Results: Kovac-Luca",
       "startLine": 286,
-      "endLine": 300,
+      "endLine": 301,
       "summary": "Axiomatizes `kovac_luca_limsup_infinite`: $\\forall M > 0,\\, \\exists n,\\, \\text{ratio}(n) > M$. Proves `ratio_unbounded` by contradiction.",
       "mathContext": "Verified: Axiomatizes `kovac_luca_limsup_infinite`: $\\forall M > 0,\\, \\exists n,\\, \\text{ratio}(n) > M$. Proves `ratio_unbounded` by contradiction."
     },
@@ -168,7 +168,7 @@
     {
       "id": "sec-893-summary",
       "title": "Summary Theorem",
-      "startLine": 320,
+      "startLine": 319,
       "endLine": 332,
       "summary": "Collects verified results into `erdos893_summary`: positivity, monotonicity, and ratio unboundedness.",
       "mathContext": "Bound: Collects verified results into `erdos893_summary`: positivity, monotonicity, and ratio unboundedness."


### PR DESCRIPTION
## Summary
- `erdos-893` (growth of f(n) = Σ τ(2ᵏ−1); is f(2n)/f(n) → ∞?). The "Monotonicity and Positivity" section ended at line **125**, before its `## Part IV: Monotonicity` banner at **135**, so the entire Part IV body fell into an **81-line uncovered gap (126–206)**.
- The back-half sections were each a few lines short of their `## Part` banners.
- Re-snapped all nine sections to the `/-`-opened `## Part` banners (openers at 31/86/134/207/271/286/302/319) for full **1–332** coverage.

## Details
| Section | Old range | New range |
|---|---|---|
| Problem Statement and Imports | 1–30 | 1–30 |
| Divisor Counting Function τ | 31–71 | 31–85 |
| Cumulative Sum f(n) | 72–110 | 86–133 |
| Monotonicity and Positivity | 111–125 | 134–206 |
| Mersenne Divisibility and Tau Bounds | 207–269 | 207–270 |
| The Ratio f(2n)/f(n) | 271–284 | 271–285 |
| Known Results: Kovac-Luca | 286–300 | 286–301 |
| Main Question: f(2n)/f(n)→∞ | 302–318 | 302–318 |
| Summary Theorem | 320–332 | 319–332 |

Counts unchanged and pre-correct (332 lines). Summaries preserved (the τ section already documents both Part I and the Part II small-value checks, an intentional merge). Build-free metadata-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)