### PR TITLE
audit(central-limit-theorem-oq-01): correct overclaimed Gnedenko-Kolmogorov contribution

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/meta.json
@@ -51,7 +51,7 @@
       "Proved Gaussian (α=2) and Cauchy (α=1) are special stable cases with correct normalizations",
       "Proved Lévy distribution (α=1/2) is 1/2-stable with normalization n²",
       "Proved that non-Gaussian stable laws (α < 2) have different characteristic functions from Gaussian",
-      "Formal statement of Gnedenko-Kolmogorov domain of attraction theorem"
+      "Precise prose statement of the Gnedenko-Kolmogorov domain of attraction theorem (documented, not formalized — requires deep measure theory)"
     ],
     "dateAdded": "2026-02-23",
     "axiomCount": 0,


### PR DESCRIPTION
## Integrity Issue

**Proof**: central-limit-theorem-oq-01
**Problem**: `originalContributions` overstates a prose docstring as a formalization.

## Evidence

**meta.json claimed**: `"Formal statement of Gnedenko-Kolmogorov domain of attraction theorem"`

**Lean file shows** (`Proofs/CentralLimitTheoremOQ01.lean`, Part V, lines 230-236): the Gnedenko-Kolmogorov domain-of-attraction theorem appears only in a prose docstring, which explicitly states it *"cannot be proved from first principles here (requires deep measure theory)"*. There is no Lean `theorem` of the domain-of-attraction result — `grep` for `gnedenko|domain|attraction` matches only comments/docstrings.

## Fix

Reworded the contribution to: *"Precise prose statement of the Gnedenko-Kolmogorov domain of attraction theorem (documented, not formalized — requires deep measure theory)"*.

## Everything else verified clean

- lineCount 313 ✓, sorries 0 ✓, axiomCount 0 ✓, theoremCount 12 ✓, definitionCount 1 ✓
- No `True` stubs; the 12 theorems are substantive algebraic identities (stability property, normalization identity, distinctness via log-injectivity), genuinely proved.
- Badge `mathlib` and status `verified` are appropriate (conservative).

---
Discovered during gallery integrity audit. Severity: LOW.