### PR TITLE
research(erdos-1100): realign drifted gallery sections to file (9→9)

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -72,55 +72,55 @@
       "id": "coprime-consecutive-divisors",
       "title": "Coprime Consecutive Divisors",
       "startLine": 59,
-      "endLine": 85,
+      "endLine": 163,
       "summary": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p)).",
       "mathContext": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p))."
     },
     {
       "id": "question-1-almost-all-growth",
       "title": "Question 1: Almost All Growth",
-      "startLine": 86,
-      "endLine": 107,
+      "startLine": 164,
+      "endLine": 183,
       "summary": "Formalizes Question 1 as a natural density statement: for every M > 0, the density of n with τ⊥(n)/ω(n) < M tends to zero.",
       "mathContext": "Mathematical content: Formalizes Question 1 as a natural density statement: for every M > 0, the density of n with τ⊥(n)/ω(n) < M tends to zero."
     },
     {
       "id": "question-2-upper-bound",
       "title": "Question 2: Upper Bound",
-      "startLine": 108,
-      "endLine": 134,
+      "startLine": 184,
+      "endLine": 209,
       "summary": "Formalizes Question 2 (sub-polylogarithmic growth of τ⊥) and axiomatizes the Erdős–Hall lower bound on max_{n<x} τ⊥(n).",
       "mathContext": "Axiomatized: Formalizes Question 2 (sub-polylogarithmic growth of τ⊥) and axiomatizes the Erdős–Hall lower bound on max_{n<x} τ⊥(n)."
     },
     {
       "id": "question-3-growth-of-g-k",
       "title": "Question 3: Growth of g(k)",
-      "startLine": 135,
-      "endLine": 178,
+      "startLine": 210,
+      "endLine": 254,
       "summary": "Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments).",
       "mathContext": "Formal definition: Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments)."
     },
     {
       "id": "examples",
       "title": "Worked Examples",
-      "startLine": 179,
-      "endLine": 204,
+      "startLine": 255,
+      "endLine": 280,
       "summary": "Concrete examples for n = 6 (τ⊥ = 2 = ω, equality case) and n = 12 (τ⊥ = 3 > ω = 2, strict inequality), with ω verified by native_decide.",
       "mathContext": "Bound: Concrete examples for n = 6 (τ⊥ = 2 = ω, equality case) and n = 12 (τ⊥ = 3 > ω = 2, strict inequality), with ω verified by native_decide."
     },
     {
       "id": "why-this-problem-is-hard",
       "title": "Structural Difficulty",
-      "startLine": 205,
-      "endLine": 219,
+      "startLine": 281,
+      "endLine": 295,
       "summary": "Commentary on why the problem is hard: coprimality of consecutive divisors depends delicately on the factorization of n, creating intricate combinatorial constraints on the divisor lattice.",
       "mathContext": "Mathematical content: Commentary on why the problem is hard: coprimality of consecutive divisors depends delicately on the factorization of n, creating intricate combinatorial constraints on the divisor lattice."
     },
     {
       "id": "summary",
       "title": "Problem Summary Theorem",
-      "startLine": 220,
-      "endLine": 255,
+      "startLine": 296,
+      "endLine": 331,
       "summary": "The erdos_1100_summary theorem combines the three known results (lower bound, equality infinitely often, Erdős–Hall extremal bound) into a single conjunction, proved directly from the axioms.",
       "mathContext": "Verified: The erdos_1100_summary theorem combines the three known results (lower bound, equality infinitely often, Erdős–Hall extremal bound) into a single conjunction, proved directly from the axioms."
     }


### PR DESCRIPTION
## Summary
- `erdos-1100` (coprime-consecutive-divisors growth questions). Sections III–IX ("Question 1" onward) had drifted **early by 60–90 lines**, pointing well before their `## Part` banners.
- "Coprime Consecutive Divisors" stopped at line **85** instead of running to its Part III banner at **164**, and the whole back half left the file tail (**256–331** — examples, difficulty, summary) uncovered.
- The section titles already match the file's `## Part I–VIII` banners 1:1; only the line ranges were wrong.

## Details
| Section | Old range | New range |
|---|---|---|
| Header, References, and Imports | 1–37 | 1–37 |
| Divisor Functions | 38–58 | 38–58 |
| Coprime Consecutive Divisors | 59–85 | 59–163 |
| Question 1: Almost All Growth | 86–107 | 164–183 |
| Question 2: Upper Bound | 108–134 | 184–209 |
| Question 3: Growth of g(k) | 135–178 | 210–254 |
| Worked Examples | 179–204 | 255–280 |
| Structural Difficulty | 205–219 | 281–295 |
| Problem Summary Theorem | 220–255 | 296–331 |

Re-snapped to the `/-`-opened `## Part` banners for full **1–331** coverage. Counts unchanged and pre-correct (331 lines). Build-free metadata-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)