### PR TITLE
research(minkowski-fundamental-theorem): realign gallery sections to full file (6→7)

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem/meta.json
@@ -74,51 +74,59 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Statement, Approach, and Mathlib Setup",
+      "summary": "Module imports and docstring: states Minkowski's Fundamental Theorem (Wiedijk #40) — a convex, centrally symmetric body of volume > 2ⁿ·det(L) contains a nonzero lattice point — and surveys the classical pigeonhole proof, applications, Mathlib dependencies, and the namespace/variable setup used throughout the file.",
+      "startLine": 1,
+      "endLine": 109,
+      "mathContext": "The header collects the geometry-of-numbers Mathlib imports (`MeasureTheory.Group.GeometryOfNumbers`, `Algebra.Module.ZLattice.Basic`, `NumberTheory.SumTwoSquares`) and a module docstring explaining the theorem statement, the classical pigeonhole argument, and downstream applications (Fermat's two squares, Dirichlet approximation, Lagrange four squares). It opens the `MinkowskiFundamentalTheorem` namespace and introduces the dimension parameter `variable (n : ℕ) [NeZero n]` shared by all subsequent definitions and theorems."
+    },
+    {
       "id": "custom-api",
       "title": "Part 1–4: Custom API (EuclideanN, Lattice, ConvexBody, HasVolume)",
       "summary": "Defines EuclideanN, CentrallySymmetric, Lattice (basis matrix + invertibility), covolume, latticePoints, ConvexBody structure, and HasVolume typeclass bridging abstract volume to ENNReal Lebesgue measure.",
-      "startLine": 106,
-      "endLine": 240,
+      "startLine": 110,
+      "endLine": 244,
       "mathContext": "The custom API models geometry-of-numbers at a high level of abstraction. `EuclideanN n = Fin n → ℝ` is the ambient space; using a function type (rather than `EuclideanSpace ℝ (Fin n)`) ensures direct compatibility with Mathlib's `ZSpan` API. `Lattice n` wraps an $n \\times n$ real `basis` matrix with a nonzero-determinant witness `basis_invertible : basis.det ≠ 0`, making it the Lean encoding of $GL_n(\\mathbb{R})$. The `covolume` of lattice $L$ is $|\\det(\\mathrm{basis})|$, the volume of its fundamental domain $[0,1)^n$ mapped through the basis matrix; `Lattice.covolume_pos` shows it is strictly positive. `isLatticeVector L x` asserts $x = \\sum_i c_i b_i$ for integers $c_i$ and basis rows $b_i$; `latticePoints L` is the $\\mathbb{Z}$-module of all such points. `ConvexBody n` bundles a set with proofs of `CentrallySymmetric`, `Convex`, and `Set.Nonempty`; central symmetry implies $0 \\in S$ by convexity (proved in `origin_mem_of_symmetric_nonempty`). `HasVolume n S` is a typeclass supplying `vol : ℝ` and `hv_eq : ENNReal.ofReal vol = MeasureTheory.volume ↑S`, bridging the real-valued volume condition to Mathlib's `ENNReal`-valued Lebesgue measure. `criticalVolume L = 2^n \\cdot \\mathrm{covolume}(L)$ is the threshold: any convex body with volume strictly exceeding this must contain a nonzero lattice point."
     },
     {
       "id": "bridge",
       "title": "Part 4.5: Bridge to Mathlib (toModuleBasis, latticePoints_eq_span)",
       "summary": "Lattice.toLinearEquiv, toModuleBasis, toModuleBasis_matrix_eq, basisVec_eq_toModuleBasis, and latticePoints_eq_span connect the custom Lattice type to Mathlib's Module.Basis and Submodule.span ℤ.",
-      "startLine": 241,
-      "endLine": 312,
+      "startLine": 245,
+      "endLine": 327,
       "mathContext": "The bridge section is the technical heart of the proof. `Lattice.toLinearEquiv L` constructs a `LinearEquiv (Fin n → ℝ) (Fin n → ℝ)` sending $v \\mapsto L.\\mathrm{basis}^\\top \\cdot v$ — i.e., the transpose of the basis matrix acts as a linear isomorphism (invertible by `basis_invertible`). `Lattice.toModuleBasis L` then pushes the standard `Pi.basisFun ℝ (Fin n)` through this equivalence to obtain a `Module.Basis (Fin n) ℝ (Fin n → ℝ)`, the Mathlib data structure for lattice bases. The crucial lemma `toModuleBasis_matrix_eq` proves `Matrix.of (L.toModuleBasis n) = L.basis`, showing the custom matrix and the Mathlib basis represent the same linear data. `basisVec_eq_toModuleBasis` gives the pointwise version: the $i$-th custom basis vector equals the $i$-th Mathlib basis vector. Finally, `latticePoints_eq_span L` identifies `latticePoints L` with `Submodule.span ℤ (Set.range (L.toModuleBasis n))` — the same set as the $\\mathbb{Z}$-span of the Mathlib basis vectors — via `Submodule.mem_span_range_iff_exists_fun` and `zsmul_eq_smul_cast`. This identification is what allows the main theorem to invoke Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`."
     },
     {
       "id": "main-theorem",
       "title": "Part 5: Minkowski's Fundamental Theorem",
       "summary": "minkowski_fundamental and minkowski_fundamental': proved via Mathlib's exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure with ENNReal arithmetic bridge and latticePoints_eq_span.",
-      "startLine": 313,
-      "endLine": 383,
+      "startLine": 328,
+      "endLine": 402,
       "mathContext": "The main theorem `minkowski_fundamental` states: if $L$ is a lattice with covolume $V$ and $S$ is a convex body with $\\mathrm{vol}(S) > 2^n \\cdot V$, then $S$ contains a nonzero lattice point. The proof calls Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`, which implements the classical pigeonhole argument: scale $S$ by $1/2$ (volume $\\mathrm{vol}(S)/2^n > V$), tile by the fundamental domain of $L$, two tiles must overlap, and their difference lies in $S$ by central symmetry and convexity. The technical bridge is an `ENNReal` arithmetic step converting the hypothesis `vol(S) > criticalVolume L` from `ℝ` to `ENNReal`, using `ENNReal.ofReal_lt_ofReal_iff` and the positivity of the covolume. `minkowski_fundamental'` is a variant with the `HasVolume` hypothesis in Prop form for ease of use. The Lean proof reduces to three steps: bridge the lattice representation (via `latticePoints_eq_span`), bridge the measure hypothesis (via `ENNReal` arithmetic), and invoke the Mathlib API."
     },
     {
       "id": "special-cases",
       "title": "Part 6–7: Integer Lattice and Fermat's Two Squares",
       "summary": "minkowski_integer_lattice (vol > 2^n for ℤⁿ), fermat_from_minkowski (every prime p ≡ 1 mod 4 is a sum of two squares, delegated to Nat.Prime.sq_add_sq), and application docstrings for Dirichlet and Lagrange.",
-      "startLine": 385,
-      "endLine": 470,
+      "startLine": 403,
+      "endLine": 489,
       "mathContext": "Two applications demonstrate the theorem. `minkowski_integer_lattice` specializes to the standard integer lattice $\\mathbb{Z}^n$ (covolume 1, critical volume $2^n$): any convex body with volume $> 2^n$ contains a nonzero integer point. This is the standard textbook statement. `fermat_from_minkowski` derives Fermat's two-squares theorem: every prime $p \\equiv 1 \\pmod{4}$ is a sum of two squares. The proof delegates entirely to Mathlib's `Nat.Prime.sq_add_sq`, which already uses geometry-of-numbers internally. The delegation is intentional — it shows the formalization connects to Mathlib's existing number theory infrastructure rather than being isolated. Application docstrings describe two more classical consequences: Dirichlet's theorem on simultaneous Diophantine approximation (given $n$ real numbers $\\alpha_i$, there exist integers $p_i, q$ with $q \\leq N^n$ such that $|q\\alpha_i - p_i| < 1/N$) and Lagrange's four-squares theorem (every positive integer is a sum of four squares)."
     },
     {
       "id": "variants",
       "title": "Part 8–9: Blichfeldt Generalization and Significance",
       "summary": "blichfeldt_statement (Prop-valued def for k+1 lattice points), discussion of Minkowski's second theorem (successive minima), and applications to algebraic number theory, cryptography, and coding theory.",
-      "startLine": 472,
-      "endLine": 545,
+      "startLine": 490,
+      "endLine": 564,
       "mathContext": "`blichfeldt_statement k` formalizes Blichfeldt's generalization as a `Prop`: if $\\mathrm{vol}(S) > k \\cdot 2^n \\cdot \\mathrm{covolume}(L)$, then $S$ contains $k+1$ distinct lattice points. The `Prop` (rather than proved `theorem`) form signals this is available as a statement for downstream use but is not proved in this file. The significance section discusses Minkowski's second theorem on successive minima: for each $\\lambda$, define the $i$-th successive minimum $\\lambda_i(L, S)$ as the smallest scaling factor such that $\\lambda_i \\cdot S$ contains $i$ linearly independent lattice points. Minkowski's second theorem states $\\lambda_1 \\cdots \\lambda_n \\cdot \\mathrm{covolume}(L) \\leq 2^n / \\mathrm{vol}(S)$. This finer result, not proved here, quantifies how lattice points are distributed relative to successive dilation of the body."
     },
     {
       "id": "proved-namespace",
       "title": "Part 10: MinkowskiProved — Direct Mathlib Proofs",
       "summary": "stdBasis, stdLattice, stdFundDomain, stdLattice_covolume (= 1), minkowski_integer_lattice_proved (integer lattice, ENNReal hypothesis), and minkowski_general_lattice_proved (arbitrary Module.Basis). Both are thin wrappers over Mathlib in 1–2 rewrites.",
-      "startLine": 547,
-      "endLine": 662,
+      "startLine": 565,
+      "endLine": 686,
       "mathContext": "The `MinkowskiProved` namespace provides direct Mathlib-style proofs without the custom API abstraction layer. `stdLattice` is the $\\mathbb{Z}^n$ lattice as a `Submodule ℤ (Fin n → ℝ)` (the $\\mathbb{Z}$-span of the standard basis); `stdFundDomain` is the unit cube $[0,1)^n$. `stdLattice_isAddFundamentalDomain` and `stdLattice_covolume` (= 1) are proved from Mathlib's `ZSpan.isAddFundamentalDomain` and `ZSpan.volume_fundamentalDomain`. `minkowski_integer_lattice_proved` and `minkowski_general_lattice_proved` are thin wrappers over Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`, requiring only 1–2 rewrites. The design philosophy: the custom API (Parts 1–9) provides user-friendly types (`Lattice n`, `ConvexBody n`) suitable for expressing mathematical theorems, while the `MinkowskiProved` namespace shows the same theorems follow directly from Mathlib in minimal code. Both routes have 0 sorries and 0 axioms, giving three independent proof paths to the fundamental theorem."
     }
   ],


### PR DESCRIPTION
## Summary
Gallery section ranges for `minkowski-fundamental-theorem` had drifted ~5 lines below their `-- PART N` source banners and left two regions uncovered:
- **Header (lines 1-109)**: module imports + docstring + namespace/`variable` setup
- **Tail (lines 663-686)**: the `MinkowskiProved` export block (`#check` summary)

## Changes
- Added an `overview` section (1-109) describing the statement, classical proof sketch, applications, and Mathlib setup.
- Re-ranged the six existing thematic sections to their banner boundaries, producing 7 fully contiguous sections covering the entire 686-line file with no gaps or overlaps.
- All existing `summary` and `mathContext` text preserved verbatim.

No Lean source changed; counts unaffected (19 theorems, 0 axioms, 0 sorries). Build-free metadata realignment.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections contiguous 1→686, zero gaps/overlaps
- [x] Section boundaries align to `-- PART N` banners