### PR TITLE
research(prime-gap-bounds-oq-01): realign sections, add Summary section (6→7)

### DIFF
--- a/src/data/proofs/prime-gap-bounds-oq-01/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-01/meta.json
@@ -93,49 +93,57 @@
       "id": "setup",
       "title": "Setup and Utilities",
       "startLine": 1,
-      "endLine": 55,
+      "endLine": 61,
       "summary": "Module docstring, imports, and basic lemmas about the nth prime (it is prime, it is at least 2).",
       "mathContext": "The nth prime $p_n$ is the $n$-th element of the infinite set of primes, 0-indexed. $p_0 = 2$, $p_1 = 3$, etc."
     },
     {
       "id": "pnt-asymptotic",
       "title": "PNT Asymptotic (Axiom 1)",
-      "startLine": 56,
-      "endLine": 73,
+      "startLine": 62,
+      "endLine": 78,
       "summary": "States the PNT asymptotic $p_n/(n \\ln n) \\to 1$ as an axiom, citing PrimeNumberTheorem.lean.",
       "mathContext": "The Prime Number Theorem implies $p_n \\sim n \\ln n$: the ratio $p_n/(n \\ln n)$ tends to 1 as $n \\to \\infty$."
     },
     {
       "id": "asymptotic-bounds",
       "title": "Asymptotic Bounds (Proved from PNT)",
-      "startLine": 74,
-      "endLine": 117,
+      "startLine": 79,
+      "endLine": 116,
       "summary": "Proves that for any $\\varepsilon > 0$, eventually $p_n < (1+\\varepsilon) \\cdot n \\ln n$ and $p_n > (1-\\varepsilon) \\cdot n \\ln n$. Uses filter convergence machinery: `Iio_mem_nhds`, `Ioi_mem_nhds`, and `div_lt_iff`.",
       "mathContext": "From $p_n/(n \\ln n) \\to 1$: for any $\\varepsilon > 0$, $\\exists N$ such that $\\forall n \\geq N$, $(1-\\varepsilon) n \\ln n < p_n < (1+\\varepsilon) n \\ln n$."
     },
     {
       "id": "subexponential",
       "title": "Subexponential Comparison",
-      "startLine": 118,
-      "endLine": 147,
+      "startLine": 117,
+      "endLine": 171,
       "summary": "States that the PNT bound $2 \\cdot n \\ln n$ is eventually less than $2^{n+1}$, witnessing the exponential improvement over the Bertrand bound.",
       "mathContext": "For large $n$: $2n \\ln n < 2^{n+1}$. This shows $p_n \\lesssim n \\ln n$ is exponentially better than $p_n \\leq 2^{n+1}$."
     },
     {
       "id": "dusart-axioms",
       "title": "Dusart's Explicit Bounds (Axioms 2-3)",
-      "startLine": 148,
-      "endLine": 180,
+      "startLine": 172,
+      "endLine": 205,
       "summary": "Axiomatizes Dusart's upper bound $p_n \\leq n(\\ln n + \\ln\\ln n)$ and lower bound $p_n \\geq n(\\ln n + \\ln\\ln n - 1)$ for $n \\geq 6$, with historical citations.",
       "mathContext": "Rosser (1941) proved the upper bound; Dusart (2010) proved the matching lower bound. Together: $n(\\ln n + \\ln\\ln n - 1) \\leq p_n \\leq n(\\ln n + \\ln\\ln n)$ for $n \\geq 6$."
     },
     {
       "id": "consequences",
       "title": "Consequences of Dusart Bounds (All Proved)",
-      "startLine": 181,
-      "endLine": 211,
+      "startLine": 206,
+      "endLine": 253,
       "summary": "Derives the sandwich theorem, computes the gap width (exactly $n$), instantiates at $n = 6$, and shows the Dusart bound implies a PNT-type ratio bound.",
       "mathContext": "The Dusart bounds sandwich $p_n$ in $[n(\\ln n + \\ln\\ln n - 1),\\, n(\\ln n + \\ln\\ln n)]$. The ratio $p_n/(n \\ln n) \\leq 1 + \\ln\\ln n / \\ln n \\to 1$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 254,
+      "endLine": 288,
+      "summary": "Documentation footer (## Summary): lists the 3 axioms (nth_prime_asymptotic, dusart_upper_bound, dusart_lower_bound), the 7 proved theorems, the improvement chain Bertrand -> PNT -> Dusart, and confirms the axiom count of 3.",
+      "mathContext": "No new declarations; a prose recap of the axiom/theorem inventory and the bound-improvement chain $p_n \\le 2^{n+1}$ (Bertrand) $\\to p_n \\sim n\\ln n$ (PNT) $\\to$ explicit Dusart sandwich."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
- `prime-gap-bounds-oq-01` (PNT/Dusart explicit prime-gap bounds). Every section after "Setup" had drifted ~5–30 lines early relative to its `## Part` banner.
- The final "Consequences" section stopped at line **211**, leaving the file's `## Summary` documentation block (axiom/theorem inventory, Bertrand→PNT→Dusart improvement chain) at **212–288 uncovered**.

## Details
| Section | Old range | New range |
|---|---|---|
| Setup and Utilities | 1–55 | 1–61 |
| PNT Asymptotic (Axiom 1) | 56–73 | 62–78 |
| Asymptotic Bounds (Proved from PNT) | 74–117 | 79–116 |
| Subexponential Comparison | 118–147 | 117–171 |
| Dusart's Explicit Bounds (Axioms 2-3) | 148–180 | 172–205 |
| Consequences of Dusart Bounds (All Proved) | 181–211 | 206–253 |
| **Summary** *(new)* | — | 254–288 |

Re-snapped to the `/-`-opened `## Part I–V` banners (the Part III editorial split at `pnt_bound_subexponential` is preserved) and added a Summary section for full **1–288** coverage. Counts unchanged and pre-correct (3ax/7thm, 288 lines). Build-free metadata-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)