### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): realign drifted gallery sections to full file (5→8)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof by redesigning IsConstructible (removing IsConstructible \u03b2 precondition from sqrt_ext). Proves isConstructible_sqrt2, isConstructible_map, and all three impossibility results (angle trisection, cube doubling, regular 7-gon). 0 sorries, 0 axioms.",
+  "description": "Completes the parent Wantzel-Galois proof by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext). Proves isConstructible_sqrt2, isConstructible_map, and all three impossibility results (angle trisection, cube doubling, regular 7-gon). 0 sorries, 0 axioms.",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -28,17 +28,17 @@
       },
       {
         "theorem": "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
-        "description": "Gauss's lemma: \u2124-irreducibility implies \u211a-irreducibility for primitive polynomials",
+        "description": "Gauss's lemma: ℤ-irreducibility implies ℚ-irreducibility for primitive polynomials",
         "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Basic"
       },
       {
         "theorem": "minpoly.eq_X_sub_C",
-        "description": "minpoly \u211a (algebraMap \u211a \u2102 q) = X - C q for rational q",
+        "description": "minpoly ℚ (algebraMap ℚ ℂ q) = X - C q for rational q",
         "module": "Mathlib.FieldTheory.Minpoly.Field"
       },
       {
         "theorem": "minpoly.dvd",
-        "description": "If p(\u03b1) = 0 then minpoly \u211a \u03b1 \u2223 p",
+        "description": "If p(α) = 0 then minpoly ℚ α ∣ p",
         "module": "Mathlib.FieldTheory.Minpoly.Field"
       },
       {
@@ -55,71 +55,92 @@
   "parent": "angle-trisection-oq-02-oq-01-oq-02",
   "openQuestion": "How can the not_constructible_of_bad_degree sorry in the parent Wantzel-Galois formalization be proved?",
   "overview": {
-    "historicalContext": "The three classical problems of antiquity \u2014 trisecting an angle, doubling the cube, and constructing the regular heptagon \u2014 were posed by Greek geometers and remained open for over 2000 years. Pierre Laurent Wantzel proved their impossibility in 1837 using nascent field theory, predating the full development of Galois theory by a decade. Wantzel's key insight was that any ruler-and-compass construction amounts to a tower of quadratic field extensions, so constructible lengths must have degree over \u211a that is a power of 2. Since cos(20\u00b0), \u221b2, and cos(2\u03c0/7) each satisfy irreducible cubics over \u211a \u2014 and 3 is not a power of 2 \u2014 none can be constructed.\n\nThis file is the completion of a two-part Lean 4 formalization. The parent file (AngleTrisectionOQ02OQ01OQ02.lean) set up the overall framework but left five theorems as sorry. The root cause was a subtle design flaw: the `sqrt_ext` constructor required `IsConstructible \u03b2` as a precondition, making structural induction produce induction hypotheses for both `a` and `b` but not for the square root \u03b2 itself \u2014 blocking the tower-degree argument.\n\nThis file fixes `IsConstructible` by removing the `IsConstructible \u03b2` precondition from `sqrt_ext`. Under the fixed definition, \u221a2 IS constructible (\u03b2 = \u221a2, \u03b2\u00b2 = 2 \u2208 \u211a). The key theorem `isConstructible_algebraic_degree` then shows every constructible \u03b1 is algebraic over \u211a with `finrank \u211a \u211a\u27ee\u03b1\u27ef \u2223 2^n`, which is exactly what is needed to prove the three impossibility results.",
-    "problemStatement": "Prove not_constructible_of_bad_degree: if p is irreducible over \u211a with degree not a power of 2, then no root of p in \u2102 is constructible. Also prove cube_root_2_minpoly_irred, cos20_minpoly_degree, and regular_7gon_impossible_degree which were sorried in the parent.",
-    "proofStrategy": "Key insight: removing the `IsConstructible \u03b2` precondition from `sqrt_ext` gives the mathematically correct definition where \u221a2 is constructible. The tower-degree theorem `isConstructible_algebraic_degree` is then proved by structural induction: for constructible \u03b1, \u03b1 is algebraic over \u211a and `finrank \u211a \u211a\u27ee\u03b1\u27ef \u2223 2^n`. The `hjoin_dvd` tower step (bounding `finrank \u211a (\u211a\u27eeb\u27ef \u2294 \u211a\u27ee\u03b2\u27ef)`) is proved by strengthening the IH over arbitrary base fields via `isConstructible_sup_degree`. Then `not_constructible_of_bad_degree`: \u03b1 constructible \u2192 `finrank \u211a \u211a\u27ee\u03b1\u27ef \u2223 2^n` \u2192 `deg(minpoly \u211a \u03b1) \u2223 2^n` \u2192 p irreducible + minpoly \u2223 p \u2192 `deg(p) \u2223 2^n` \u2192 contradiction since deg(p) is not a power of 2. For irreducibility of X\u00b3-2: use Eisenstein at p=2 over \u2124 then lift to \u211a via Gauss's lemma.",
+    "historicalContext": "The three classical problems of antiquity — trisecting an angle, doubling the cube, and constructing the regular heptagon — were posed by Greek geometers and remained open for over 2000 years. Pierre Laurent Wantzel proved their impossibility in 1837 using nascent field theory, predating the full development of Galois theory by a decade. Wantzel's key insight was that any ruler-and-compass construction amounts to a tower of quadratic field extensions, so constructible lengths must have degree over ℚ that is a power of 2. Since cos(20°), ∛2, and cos(2π/7) each satisfy irreducible cubics over ℚ — and 3 is not a power of 2 — none can be constructed.\n\nThis file is the completion of a two-part Lean 4 formalization. The parent file (AngleTrisectionOQ02OQ01OQ02.lean) set up the overall framework but left five theorems as sorry. The root cause was a subtle design flaw: the `sqrt_ext` constructor required `IsConstructible β` as a precondition, making structural induction produce induction hypotheses for both `a` and `b` but not for the square root β itself — blocking the tower-degree argument.\n\nThis file fixes `IsConstructible` by removing the `IsConstructible β` precondition from `sqrt_ext`. Under the fixed definition, √2 IS constructible (β = √2, β² = 2 ∈ ℚ). The key theorem `isConstructible_algebraic_degree` then shows every constructible α is algebraic over ℚ with `finrank ℚ ℚ⟮α⟯ ∣ 2^n`, which is exactly what is needed to prove the three impossibility results.",
+    "problemStatement": "Prove not_constructible_of_bad_degree: if p is irreducible over ℚ with degree not a power of 2, then no root of p in ℂ is constructible. Also prove cube_root_2_minpoly_irred, cos20_minpoly_degree, and regular_7gon_impossible_degree which were sorried in the parent.",
+    "proofStrategy": "Key insight: removing the `IsConstructible β` precondition from `sqrt_ext` gives the mathematically correct definition where √2 is constructible. The tower-degree theorem `isConstructible_algebraic_degree` is then proved by structural induction: for constructible α, α is algebraic over ℚ and `finrank ℚ ℚ⟮α⟯ ∣ 2^n`. The `hjoin_dvd` tower step (bounding `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯)`) is proved by strengthening the IH over arbitrary base fields via `isConstructible_sup_degree`. Then `not_constructible_of_bad_degree`: α constructible → `finrank ℚ ℚ⟮α⟯ ∣ 2^n` → `deg(minpoly ℚ α) ∣ 2^n` → p irreducible + minpoly ∣ p → `deg(p) ∣ 2^n` → contradiction since deg(p) is not a power of 2. For irreducibility of X³-2: use Eisenstein at p=2 over ℤ then lift to ℚ via Gauss's lemma.",
     "keyInsights": [
-      "Removing `IsConstructible \u03b2` from the `sqrt_ext` precondition gives the mathematically correct definition: square roots of constructibles are constructible, so \u221a2 IS constructible under the fixed definition",
-      "Under the fixed definition, `isConstructible_algebraic_degree` (structural induction giving `finrank \u211a \u211a\u27ee\u03b1\u27ef \u2223 2^n`) is the key tool for `not_constructible_of_bad_degree` \u2014 not a rationality collapse",
-      "minpoly.eq_X_sub_C is the key bridge: for q \u2208 \u211a, minpoly \u211a (algebraMap \u211a \u2102 q) = X - C q",
-      "interval_cases k requires an explicit upper bound; establish k \u2264 1 from 3 = 2^k via Nat.pow_le_pow_right",
+      "Removing `IsConstructible β` from the `sqrt_ext` precondition gives the mathematically correct definition: square roots of constructibles are constructible, so √2 IS constructible under the fixed definition",
+      "Under the fixed definition, `isConstructible_algebraic_degree` (structural induction giving `finrank ℚ ℚ⟮α⟯ ∣ 2^n`) is the key tool for `not_constructible_of_bad_degree` — not a rationality collapse",
+      "minpoly.eq_X_sub_C is the key bridge: for q ∈ ℚ, minpoly ℚ (algebraMap ℚ ℂ q) = X - C q",
+      "interval_cases k requires an explicit upper bound; establish k ≤ 1 from 3 = 2^k via Nat.pow_le_pow_right",
       "In Lean 4 induction with | caseName ... =>, IHs come AFTER all constructor arguments, not interleaved",
-      "Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) bridges \u2124-irreducibility and \u211a-irreducibility: it suffices to apply the Eisenstein criterion over \u2124, then lift. This is a standard and powerful technique for proving rational polynomial irreducibility.",
-      "The wantzel_galois_iff sorry exposes the gap between the proof-of-impossibility (degree 3 \u2260 power of 2) and the full characterization (constructible \u2194 Galois group is 2-group). The former is elementary; the latter requires FTGT and hundreds of lines of Galois infrastructure not yet bridged in Mathlib to custom constructibility predicates."
+      "Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) bridges ℤ-irreducibility and ℚ-irreducibility: it suffices to apply the Eisenstein criterion over ℤ, then lift. This is a standard and powerful technique for proving rational polynomial irreducibility.",
+      "The wantzel_galois_iff sorry exposes the gap between the proof-of-impossibility (degree 3 ≠ power of 2) and the full characterization (constructible ↔ Galois group is 2-group). The former is elementary; the latter requires FTGT and hundreds of lines of Galois infrastructure not yet bridged in Mathlib to custom constructibility predicates."
     ]
   },
   "sections": [
     {
-      "id": "constructible-redesign",
-      "title": "Redesigned IsConstructible with Explicit Parameters",
-      "startLine": 54,
-      "endLine": 96,
-      "summary": "IsConstructible redefined with explicit \u03b2, a, b in sqrt_ext (not existential). Proves isConstructible_rat, isConstructible_sqrt2. Key design change: removing IsConstructible \u03b2 precondition from sqrt_ext to enable induction."
+      "id": "overview",
+      "title": "Overview, History, and Status",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Module header: the explicit-parameter redesign of IsConstructible (Session 26/29), proof history, the list of remaining sorries, new lemmas added in Sessions 36–37, and the current status (0 sorries, 0 axioms — all three impossibility results proved)."
     },
     {
-      "id": "eisenstein",
-      "title": "Eisenstein Criterion \u2014 X\u00b3 - 2 is Irreducible",
-      "startLine": 445,
-      "endLine": 476,
-      "summary": "Proves X\u00b3 - 2 irreducible over \u2124 via Eisenstein at p=2, then lifts to \u211a using Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast)."
+      "id": "part1-constructible-framework",
+      "title": "Part 1: Constructible Number Framework (Fixed Definition)",
+      "startLine": 66,
+      "endLine": 108,
+      "summary": "IsConstructible redefined with explicit β, a, b in sqrt_ext (not existential). Proves isConstructible_rat, isConstructible_zero, isConstructible_one, isConstructible_sqrt2. Key design change: removing the IsConstructible β precondition from sqrt_ext to enable induction."
     },
     {
-      "id": "degree-computations",
-      "title": "Degree Computations",
-      "startLine": 477,
-      "endLine": 530,
-      "summary": "Computes natDegree = 3 for 8x\u00b3-6x-1 (cos(20\u00b0)), x\u00b3-2, and 8x\u00b3+4x\u00b2-4x-1 (cos(2\u03c0/7)). Proves 3 \u2260 2^k via Nat.pow_le_pow_right bound + interval_cases."
+      "id": "part2-tower-degree",
+      "title": "Part 2: Key Structural Lemmas (Tower Degree Property)",
+      "startLine": 109,
+      "endLine": 489,
+      "summary": "The core structural results: isConstructible_map (closure under ℚ-algebra maps), isConstructible_algebraic (every constructible number is algebraic over ℚ), finrank_sup_quadratic_dvd_two (a quadratic extension multiplies the degree of a compositum by a divisor of 2), and the tower-degree theorems isConstructible_sup_degree and isConstructible_algebraic_degree showing [ℚ(α):ℚ] is a power of two for constructible α."
     },
     {
-      "id": "impossibilities",
-      "title": "Concrete Impossibility Results",
-      "startLine": 581,
-      "endLine": 611,
-      "summary": "Derives not_constructible_of_bad_degree via tower degree theorem. Applies to prove angle_trisection_impossible_degree, doubling_cube_impossible_degree, regular_7gon_construction_impossible."
+      "id": "part3-eisenstein",
+      "title": "Part 3: Eisenstein Criterion — X³ - 2 is Irreducible",
+      "startLine": 490,
+      "endLine": 521,
+      "summary": "Proves X³ - 2 irreducible over ℤ via Eisenstein at p=2, then lifts to ℚ using Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast)."
     },
     {
-      "id": "concrete-impossibilities",
-      "title": "Concrete Impossibility Results (PROVED)",
-      "startLine": 627,
+      "id": "part4-degree-computations",
+      "title": "Part 4: Degree Computations",
+      "startLine": 522,
+      "endLine": 537,
+      "summary": "Computes natDegree = 3 for the minimal polynomials 8x³-6x-1 (cos 20°), x³-2 (doubling the cube), and the regular 7-gon polynomial."
+    },
+    {
+      "id": "part5-degree-not-pow-two",
+      "title": "Part 5: Degree Not a Power of Two",
+      "startLine": 538,
+      "endLine": 574,
+      "summary": "Defines DegreePowerOfTwo and proves 3 ≠ 2^k (three_ne_two_pow via a Nat.pow bound + interval_cases), hence the degree-3 minimal polynomials for cos 20°, X³-2, and the regular 7-gon have degree that is not a power of two."
+    },
+    {
+      "id": "part6-non-constructibility",
+      "title": "Part 6: Non-constructibility (Degree Obstruction)",
+      "startLine": 575,
+      "endLine": 622,
+      "summary": "Derives not_constructible_of_bad_degree from the tower-degree theorem: if the minimal polynomial of α is irreducible with degree not a power of two, then α is not constructible."
+    },
+    {
+      "id": "part7-impossibility-proved",
+      "title": "Part 7: Concrete Impossibility Results (PROVED)",
+      "startLine": 623,
       "endLine": 639,
-      "summary": "Three fully proved impossibility theorems: angle_trisection_impossible_degree, doubling_cube_impossible_degree, regular_7gon_construction_impossible. Each applies not_constructible_of_bad_degree to the respective irreducible polynomial."
+      "summary": "Three fully proved impossibility theorems — angle_trisection_impossible_degree, doubling_cube_impossible_degree, regular_7gon_construction_impossible — each applying not_constructible_of_bad_degree to the respective irreducible degree-3 polynomial."
     }
   ],
   "conclusion": {
     "summary": "Reduces the parent's 5 sorries to 0 in this file. The wantzel_galois_iff theorem (requiring 500+ lines of FTGT) is out of scope and not declared. The three impossibility results are fully proved via not_constructible_of_bad_degree + isConstructible_algebraic_degree. 0 sorries, 0 axioms.",
-    "implications": "The three classical impossibility results \u2014 angle trisection, cube doubling, regular 7-gon \u2014 are now fully proved (0 axioms) in this file. The proof demonstrates that the IsConstructible definition choice is critical: existential vs explicit constructors has dramatic consequences for what can be proved by induction.",
+    "implications": "The three classical impossibility results — angle trisection, cube doubling, regular 7-gon — are now fully proved (0 axioms) in this file. The proof demonstrates that the IsConstructible definition choice is critical: existential vs explicit constructors has dramatic consequences for what can be proved by induction.",
     "openQuestions": [
       "Can wantzel_galois_iff be proved using Mathlib's IntermediateField.orderIsoOfGal and Sylow theory for 2-groups?",
-      "Can the fixed IsConstructible definition (allowing \u221a2, \u221b(1+\u221a2), etc.) be extended to give the full tower characterization: \u03b1 constructible \u2194 [\u211a(\u03b1):\u211a] is a power of 2?",
-      "Can the standard tower-degree definition of IsConstructible (allowing \u221a2, \u221b(1+\u221a2), etc.) be formalized in Lean 4 with a proof that still avoids the existential-parameter pitfall?",
-      "Is the regular 17-gon (cos(2\u03c0/17) constructible since [\u211a(cos(2\u03c0/17)):\u211a] = 8 = 2\u00b3) provable under a strengthened IsConstructible definition?"
+      "Can the fixed IsConstructible definition (allowing √2, ∛(1+√2), etc.) be extended to give the full tower characterization: α constructible ↔ [ℚ(α):ℚ] is a power of 2?",
+      "Can the standard tower-degree definition of IsConstructible (allowing √2, ∛(1+√2), etc.) be formalized in Lean 4 with a proof that still avoids the existential-parameter pitfall?",
+      "Is the regular 17-gon (cos(2π/17) constructible since [ℚ(cos(2π/17)):ℚ] = 8 = 2³) provable under a strengthened IsConstructible definition?"
     ]
   },
   "crossReferences": [
     {
       "targetId": "angle-trisection-oq-02-oq-01-oq-02",
       "relationship": "completes",
-      "description": "This file completes 3 of the 5 sorries from the parent proof by fixing the IsConstructible definition (removing the `IsConstructible \u03b2` precondition from `sqrt_ext`). The fixed definition enables the tower-degree induction (`isConstructible_algebraic_degree`), which is used to prove `not_constructible_of_bad_degree` and the three concrete impossibility results."
+      "description": "This file completes 3 of the 5 sorries from the parent proof by fixing the IsConstructible definition (removing the `IsConstructible β` precondition from `sqrt_ext`). The fixed definition enables the tower-degree induction (`isConstructible_algebraic_degree`), which is used to prove `not_constructible_of_bad_degree` and the three concrete impossibility results."
     },
     {
       "targetId": "abel-ruffini",
@@ -129,7 +150,7 @@
     {
       "targetId": "abel-ruffini-galois-extensions",
       "relationship": "related",
-      "description": "The Galois characterization in wantzel_galois_iff (\u03b1 constructible \u2194 Gal(minpoly(\u211a,\u03b1)) is a 2-group) is the constructibility analog of the Abel-Ruffini solvability criterion (a polynomial is solvable by radicals \u2194 its Galois group is solvable). Both connect geometric/arithmetic properties to Galois group structure."
+      "description": "The Galois characterization in wantzel_galois_iff (α constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group) is the constructibility analog of the Abel-Ruffini solvability criterion (a polynomial is solvable by radicals ↔ its Galois group is solvable). Both connect geometric/arithmetic properties to Galois group structure."
     },
     {
       "targetId": "hilbert-10",


### PR DESCRIPTION
## Summary
- Realigns `meta.json` sections of `angle-trisection-oq-02-oq-01-oq-02-incomplete-01` to the actual `-- PART N` banner structure of `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` (639 lines).
- Prior meta had 5 badly drifted sections with a **~380-line hole**: the entire **PART 2 "Key Structural Lemmas (tower degree property)" (lines 109–489)** — `isConstructible_map`, `isConstructible_algebraic`, `finrank_sup_quadratic_dvd_two`, `isConstructible_sup_degree`, `isConstructible_algebraic_degree` — was uncovered, **PART 5 "Degree Not a Power of Two"** was missing, the module header (1–65) was uncovered, and the remaining sections were misaligned to their banners.
- Rebuilt as **8 contiguous sections** (1–639): header + PART 1 Constructible Framework, PART 2 Tower Degree Property, PART 3 Eisenstein Criterion, PART 4 Degree Computations, PART 5 Degree Not a Power of Two, PART 6 Non-constructibility, PART 7 Concrete Impossibility Results (PROVED).
- Existing summaries reused for unchanged sections; new summaries written for the header, PART 2, and PART 5.

## Notes
- Build-free change: `meta.json` only, no Lean source touched. Section ranges now match banner openers exactly.
- No `loom:review-requested` (math content PR — deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)