### PR TITLE
audit(central-limit-theorem-oq-01): correct section summaries claiming axiomatized content

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/meta.json
@@ -117,7 +117,7 @@
       "title": "Why Infinite Variance: Distinctness from Gaussian",
       "startLine": 186,
       "endLine": 245,
-      "summary": "Proof that α-stable (α<2) differs from Gaussian via log-injectivity argument. Formal statement of domain of attraction theorem.",
+      "summary": "Theorem stable_infinite_variance: α-stable (α<2) differs from Gaussian via a log-injectivity argument. The domain of attraction theorem is described in prose only, not formalized.",
       "mathContext": "For $\\alpha < 2$, the $\\alpha$-stable distribution has infinite variance. Proof: if it had finite variance, the CLT would give Gaussian convergence with $\\sqrt{n}$ normalization, contradicting the $n^{1/\\alpha}$ normalization ($\\alpha < 2 \\Rightarrow 1/\\alpha > 1/2$)."
     },
     {
@@ -125,7 +125,7 @@
       "title": "The Generalized CLT and Lévy-Khintchine",
       "startLine": 246,
       "endLine": 295,
-      "summary": "Axiomatized Lévy-Khintchine representation and Gnedenko-Kolmogorov domain of attraction theorem.",
+      "summary": "Theorems nongaussian_stable_infinite_variance and levy_is_half_stable (Lévy is 1/2-stable). The Lévy-Khintchine representation and Gnedenko-Kolmogorov domain of attraction theorem are described in prose only — not axiomatized (this file has 0 axioms).",
       "mathContext": "The Gnedenko-Kolmogorov generalized CLT: the domain of attraction of an $\\alpha$-stable law consists of distributions with regularly varying tails $P(|X| > x) \\sim x^{-\\alpha} L(x)$ where $L$ is slowly varying. The Lévy-Khintchine representation characterizes all infinitely divisible distributions."
     },
     {


### PR DESCRIPTION
## Integrity Issue

**Proof**: central-limit-theorem-oq-01
**Severity**: LOW (stale section-summary overclaim; top-level claims are correct)

Two `sections[].summary` fields overstated what the Lean source contains.

## Evidence

`proofs/Proofs/CentralLimitTheoremOQ01.lean` has **0 axioms**, 0 sorries, 12 theorems, 1 def (matches `axiomCount`/`sorries`/`theoremCount`/`definitionCount`). `grep` confirms "Lévy-Khintchine" appears **nowhere** in the file, and "domain of attraction" appears only inside prose docstrings.

- **`infinite-variance` section claimed**: "...Formal statement of domain of attraction theorem." → no formal statement exists, only prose.
- **`generalized-clt` section claimed**: "Axiomatized Lévy-Khintchine representation and Gnedenko-Kolmogorov domain of attraction theorem." → nothing is axiomatized; the region actually holds theorems `nongaussian_stable_infinite_variance` and `levy_is_half_stable`.

## Fix

Reworded both summaries to name the actual theorems and state that the generalized CLT / Lévy-Khintchine material is described in prose only, not formalized/axiomatized. No change to top-level `status` (`verified`), `badge` (`mathlib`), `axiomCount` (0), or `originalContributions` — all verified accurate.

---
Discovered during gallery integrity audit.