### PR TITLE
Enrich derangements-convergence-oq-01: realign sections (5→6) + fix stale-sorry prose

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-dcoq01-overview",
+    "proofId": "derangements-convergence-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Problem Setup: Fixed-Point Count Converges to Poisson(1)",
+    "content": "The header docstring states the open question and its full resolution. For a uniformly random permutation of Fin n, X_n counts fixed points. The probability of exactly k fixed points factors as P(X_n=k) = C(n,k)·D(n-k)/n! = (1/k!)·D(n-k)/(n-k)!, where D(m) = numDerangements m. Because D(m)/m! → e⁻¹ (Mathlib's numDerangements_tendsto_inv_e), each marginal converges to the Poisson(1) mass e⁻¹/k!. The file also proves the finite-n rate bound |P(X_n=k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!); the underlying alternating-series estimate |D(m)/m! - e⁻¹| ≤ 1/(m+1)! is supplied by derangements_convergence_rate imported from the parent DerangementsConvergence module, so the result is fully machine-checked with no sorries or axioms.",
+    "mathContext": "$P(X_n=k)=\\binom{n}{k}D(n-k)/n!=\\tfrac{1}{k!}\\cdot D(n-k)/(n-k)! \\xrightarrow{n\\to\\infty} e^{-1}/k! = \\mathrm{Pois}(1)(k)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Poisson approximation",
+      "derangements",
+      "fixed points of permutations",
+      "weak convergence of measures"
+    ],
+    "prerequisites": [
+      "probability on finite symmetric groups",
+      "limits of real sequences",
+      "Taylor series of e⁻¹"
+    ]
+  },
+  {
     "id": "ann-dcoq01-probkfixed",
     "proofId": "derangements-convergence-oq-01",
     "range": {
@@ -28,7 +52,7 @@
     "proofId": "derangements-convergence-oq-01",
     "range": {
       "startLine": 60,
-      "endLine": 84
+      "endLine": 81
     },
     "type": "concept",
     "title": "Algebraic Identity: Factoring Out 1/k! via linear_combination",
@@ -50,8 +74,8 @@
     "id": "ann-dcoq01-rate",
     "proofId": "derangements-convergence-oq-01",
     "range": {
-      "startLine": 83,
-      "endLine": 114
+      "startLine": 85,
+      "endLine": 111
     },
     "type": "concept",
     "title": "Rate Bound via Alternating Series Delegation",

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -31,7 +31,7 @@
       "probKFixed_eq (PROVED): P(X_n = k) = (1/k!)·D(n-k)/(n-k)! via Nat.choose_mul_factorial_mul_factorial",
       "probKFixed_succ_eq (PROVED): P(X_{n+k} = k) = (1/k!)·D(n)/n! (reparametrization)",
       "kFixed_tendsto (PROVED): P(X_{n+k} = k) → e⁻¹/k! using numDerangements_tendsto_inv_e",
-      "kFixed_convergence_rate (PROVED modulo sorry): |P(X_n = k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!)",
+      "kFixed_convergence_rate (PROVED): |P(X_n = k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!)",
       "kFixed_zero_tendsto (PROVED): k=0 case recovers derangement convergence P(X_n = 0) → e⁻¹",
       "kFixed_rate_tighter (PROVED): for k≥1, the k-fixed rate is tighter by factor k!"
     ]
@@ -39,13 +39,13 @@
   "overview": {
     "historicalContext": "The birthday problem in probability asks: how are fixed points of a random permutation distributed? For a uniformly random permutation of n elements, the number of fixed points X_n converges in distribution to a Poisson(1) random variable as n → ∞. Specifically, P(X_n = k) → e⁻¹/k! for each k ≥ 0.\n\nThe k=0 case P(X_n = 0) = D(n)/n! → e⁻¹ is the classical derangement result (Montmort 1708, Euler 1751), proved in the parent file derangements-convergence. This file extends to all k ≥ 0.\n\nThe convergence P(X_n = k) → Pois(1)(k) is a special case of the general Poisson approximation theorem for sums of dependent indicator random variables (Arratia-Goldstein-Gordon 1989). For fixed points, the dependence structure is particularly nice: the indicators 1[σ(i)=i] are negatively correlated, making the approximation sharp.",
     "problemStatement": "**OQ-01 of derangements-convergence**\n\nFor a uniformly random permutation σ of Fin n, let X_n = |{i : σ(i) = i}| be the number of fixed points. Prove:\n\n1. P(X_n = k) = C(n,k)·D(n-k)/n! for all k ≤ n\n2. This equals (1/k!)·D(n-k)/(n-k)!\n3. As n → ∞ (k fixed): P(X_n = k) → e⁻¹/k!\n4. Rate bound: |P(X_n = k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!)",
-    "proofStrategy": "The proof has four steps:\n\n1. **Algebraic identity**: P(X_n = k) = C(n,k)·D(n-k)/n!. This is immediate from the parent derangements-oq-02, which proves |{σ : Perm(Fin n) | |Fix(σ)| = k}| = C(n,k)·D(n-k).\n\n2. **Factoring**: C(n,k)·D(n-k)/n! = D(n-k)/(k!·(n-k)!) = (1/k!)·D(n-k)/(n-k)!. This uses C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial) and is proved by `field_simp; linear_combination`.\n\n3. **Convergence**: P(X_{n+k} = k) = (1/k!)·D(n)/n! → (1/k!)·e⁻¹ = e⁻¹/k!. Factor out the constant 1/k! and apply Mathlib's `numDerangements_tendsto_inv_e`.\n\n4. **Rate bound**: |P(X_n = k) - e⁻¹/k!| = (1/k!)·|D(n-k)/(n-k)! - e⁻¹| ≤ (1/k!)·1/(n-k+1)! = 1/(k!·(n-k+1)!). Uses the alternating series bound (sorry).",
+    "proofStrategy": "The proof has four steps:\n\n1. **Algebraic identity**: P(X_n = k) = C(n,k)·D(n-k)/n!. This is immediate from the parent derangements-oq-02, which proves |{σ : Perm(Fin n) | |Fix(σ)| = k}| = C(n,k)·D(n-k).\n\n2. **Factoring**: C(n,k)·D(n-k)/n! = D(n-k)/(k!·(n-k)!) = (1/k!)·D(n-k)/(n-k)!. This uses C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial) and is proved by `field_simp; linear_combination`.\n\n3. **Convergence**: P(X_{n+k} = k) = (1/k!)·D(n)/n! → (1/k!)·e⁻¹ = e⁻¹/k!. Factor out the constant 1/k! and apply Mathlib's `numDerangements_tendsto_inv_e`.\n\n4. **Rate bound**: |P(X_n = k) - e⁻¹/k!| = (1/k!)·|D(n-k)/(n-k)! - e⁻¹| ≤ (1/k!)·1/(n-k+1)! = 1/(k!·(n-k+1)!). Uses the alternating series bound |D(m)/m! - e⁻¹| ≤ 1/(m+1)!, supplied by `derangements_convergence_rate` imported from the parent `DerangementsConvergence` module — so the bound is fully machine-checked (no sorry).",
     "keyInsights": [
       "The key algebraic identity P(X_n = k) = (1/k!)·D(n-k)/(n-k)! decouples the 1/k! factor from the derangement ratio, reducing to the k=0 case",
       "Mathlib's numDerangements_tendsto_inv_e provides the foundational limit D(n)/n! → e⁻¹ that drives all k≥0 cases",
       "The proof uses linear_combination to handle the algebraic manipulation involving Nat.choose_mul_factorial_mul_factorial — a clean way to bridge the ℕ identity with ℝ arithmetic",
       "The rate bound 1/(k!·(n-k+1)!) is sharper than 1/(n-k+1)! by a factor of k! — larger k gives better approximation at any fixed n",
-      "The convergence proof avoids the parent file DerangementsConvergence.lean (which has pre-existing Mathlib syntax issues) by importing numDerangements_tendsto_inv_e directly from Mathlib"
+      "The convergence limit comes from Mathlib's `numDerangements_tendsto_inv_e`, while the finite-n rate bound is supplied by `derangements_convergence_rate` imported from the parent `DerangementsConvergence` module — so the entire result, limit and rate, is machine-checked with no sorry and no axioms"
     ],
     "prerequisites": [
       "Proofs.DerangementsOQ02: card_perms_with_kfixed giving |{σ : fixed k}| = C(n,k)·D(n-k)",
@@ -55,10 +55,10 @@
     ]
   },
   "conclusion": {
-    "summary": "This file proves that P(X_n = k) → e⁻¹/k! as n → ∞ for uniformly random permutations, where X_n is the fixed-point count. The proof factors P(X_n = k) = (1/k!)·D(n-k)/(n-k)! and applies Mathlib's derangement convergence theorem. The rate bound 1/(k!·(n-k+1)!) holds modulo one sorry (the alternating series estimation applied to D(n)/n!).",
-    "implications": "**Connection to Poisson(1)**: This proves that X_n converges in distribution to Pois(1), in the sense that all marginal probabilities converge. The stronger total variation convergence is proved in derangements-oq-03-oq-02, which gives TV(X_n, Pois(1)) → 0.\\n\\n**Rate improvement**: The bound 1/(k!·(n-k+1)!) improves on the raw derangements rate 1/(n-k+1)! by a factor of k!. For k=2 and n=5: rate = 1/(2·4!) = 1/48 vs 1/4! = 1/24 — exactly twice as good.\\n\\n**Resolving the sorry**: The derangements_rate sorry is exactly derangements_convergence_rate from DerangementsConvergence.lean. That file proves it via the alternating series estimation theorem but has a Mathlib syntax issue (∑ k in vs ∑ k ∈). Fixing DerangementsConvergence.lean (a mechanical find-and-replace) would remove this sorry.",
+    "summary": "This file proves that P(X_n = k) → e⁻¹/k! as n → ∞ for uniformly random permutations, where X_n is the fixed-point count. The proof factors P(X_n = k) = (1/k!)·D(n-k)/(n-k)! and applies Mathlib's derangement convergence theorem. The rate bound 1/(k!·(n-k+1)!) is fully proved: the alternating series estimation applied to D(n)/n! is supplied by `derangements_convergence_rate` from the parent `DerangementsConvergence` module, so the file has no sorries and no axioms.",
+    "implications": "**Connection to Poisson(1)**: This proves that X_n converges in distribution to Pois(1), in the sense that all marginal probabilities converge. The stronger total variation convergence is proved in derangements-oq-03-oq-02, which gives TV(X_n, Pois(1)) → 0.\\n\\n**Rate improvement**: The bound 1/(k!·(n-k+1)!) improves on the raw derangements rate 1/(n-k+1)! by a factor of k!. For k=2 and n=5: rate = 1/(2·4!) = 1/48 vs 1/4! = 1/24 — exactly twice as good.\\n\\n**Fully machine-checked**: `derangements_rate` delegates to `derangements_convergence_rate` from DerangementsConvergence.lean, which proves the alternating series bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem. The result therefore has no sorries and no axioms (status: verified).",
     "openQuestions": [
-      "Fix DerangementsConvergence.lean (replace ∑ k in with ∑ k ∈ throughout) to enable importing derangements_convergence_rate and removing the sorry",
+      "Establish a matching lower bound showing the rate 1/(k!·(n-k+1)!) is order-optimal — i.e. that no asymptotically faster decay holds for fixed k",
       "Prove the analogous result for k-cycles in permutations: P(σ has exactly m k-cycles) → Pois(1/k)^m",
       "Quantify the total variation convergence rate: TV(X_n, Pois(1)) ≤ C/n for some constant C (Chen-Stein method)"
     ]
@@ -87,42 +87,50 @@
   ],
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Fixed-Point Count and Poisson(1) Convergence",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "File docstring, imports, and namespace. States the open question (derangements-convergence-oq-01): for a uniformly random permutation of Fin n, the number of fixed points X_n has P(X_n = k) → e⁻¹/k!, the Poisson(1) mass function. Lists the main results and notes that the alternating-series rate bound is supplied by the imported derangements_convergence_rate.",
+      "mathContext": "$P(X_n=k)=\\binom{n}{k}D(n-k)/n!=\\tfrac{1}{k!}\\cdot D(n-k)/(n-k)! \\xrightarrow{n\\to\\infty} e^{-1}/k!=\\mathrm{Pois}(1)(k)$."
+    },
+    {
       "id": "definition",
       "title": "§1. Probability of Exactly k Fixed Points",
-      "startLine": 52,
-      "endLine": 58,
+      "startLine": 47,
+      "endLine": 55,
       "summary": "probKFixed n k = C(n,k)·D(n-k)/n!. Noncomputable definition using Real division.",
       "mathContext": "$P(X_n = k) = \\binom{n}{k} \\cdot D(n-k) / n!$, where $D(m)$ is the number of derangements of $m$ elements."
     },
     {
       "id": "algebraic",
       "title": "§2. Algebraic Identities",
-      "startLine": 60,
-      "endLine": 84,
+      "startLine": 56,
+      "endLine": 81,
       "summary": "probKFixed_eq: P(X_n=k) = (1/k!)·D(n-k)/(n-k)! via choose_mul_factorial_mul_factorial and linear_combination. probKFixed_succ_eq: reparametrization P(X_{n+k}=k) = (1/k!)·D(n)/n!.",
       "mathContext": "$P(X_n=k) = (1/k!) \\cdot D(n-k)/(n-k)!$. Key: $\\binom{n}{k} \\cdot k! \\cdot (n-k)! = n!$ (choose_mul_factorial_mul_factorial)."
     },
     {
       "id": "rate",
       "title": "§3. Rate Bound",
-      "startLine": 83,
-      "endLine": 114,
-      "summary": "derangements_rate: |D(n)/n! - e⁻¹| ≤ 1/(n+1)! — delegates to DerangementsConvergence.derangements_convergence_rate (alternating series bound). kFixed_convergence_rate: |P(X_n=k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!).",
+      "startLine": 82,
+      "endLine": 111,
+      "summary": "derangements_rate: |D(n)/n! - e⁻¹| ≤ 1/(n+1)! — proved by delegating to DerangementsConvergence.derangements_convergence_rate (alternating series estimation). kFixed_convergence_rate: |P(X_n=k) - e⁻¹/k!| ≤ 1/(k!·(n-k+1)!), via abs_mul / mul_le_mul_of_nonneg_left.",
       "mathContext": "$|P(X_n=k) - e^{-1}/k!| = (1/k!) \\cdot |D(n-k)/(n-k)! - e^{-1}| \\leq 1/(k! \\cdot (n-k+1)!)$."
     },
     {
       "id": "convergence",
       "title": "§4. Convergence to Poisson(1) Mass",
-      "startLine": 116,
-      "endLine": 136,
+      "startLine": 112,
+      "endLine": 134,
       "summary": "kFixed_tendsto: P(X_{n+k}=k) → e⁻¹/k! using numDerangements_tendsto_inv_e. kFixed_zero_tendsto: k=0 case recovers P(X_n=0) → e⁻¹.",
       "mathContext": "$P(X_n=k) \\to \\text{Pois}(1)(k) = e^{-1}/k!$ as $n \\to \\infty$ for each fixed $k \\geq 0$."
     },
     {
       "id": "comparison",
       "title": "§5. Rate Comparison",
-      "startLine": 138,
-      "endLine": 151,
+      "startLine": 135,
+      "endLine": 152,
       "summary": "kFixed_rate_tighter: for k≥1, bound 1/(k!·(n-k+1)!) ≤ 1/(n-k+1)! — rate is tighter by factor k!.",
       "mathContext": "$1/(k! \\cdot (n-k+1)!) \\leq 1/(n-k+1)!$ since $k! \\geq 1$ for $k \\geq 0$."
     }


### PR DESCRIPTION
## Summary
Enrichment pass for `derangements-convergence-oq-01` (P(X_n = k) → e⁻¹/k!, Poisson(1) convergence of permutation fixed-point counts).

**Section realignment (5 → 6):** the section ranges had drifted off the `-- ===` banner blocks and left the file header (lines 1–46) uncovered, with a §2/§3 overlap (84 vs 83). Added an "Overview" section for the header docstring and realigned §1–§5 to the banner boundaries. Sections are now contiguous over the full file (1–152) with no gaps or overlaps.

**Annotation coverage (5 → 6):** added a header annotation framing the problem statement with Poisson(1) `mathContext`, and fixed the matching §2/§3 annotation overlap.

**Integrity (stale-sorry prose):** the structured fields are correct (`status: verified`, `sorries: 0`, `axiomCount: 0`, and the `assumptions` field already documents that `derangements_rate` delegates to the proved `derangements_convergence_rate`). But several prose fields still claimed a leftover `sorry` / "Mathlib syntax issues preventing import." Removed these stale claims from `originalContributions`, `overview.proofStrategy`, `overview.keyInsights`, `conclusion.summary`, `conclusion.implications`, and replaced the now-obsolete `openQuestions[0]` ("fix DerangementsConvergence.lean to remove the sorry") with a genuine open question (order-optimality of the rate bound).

No Lean source changes. JSON validated; meta uses indent=2 + trailing newline, annotations indent=2 with no trailing newline (byte-clean round-trip).