### PR TITLE
research(fermat-two-squares): realign gallery sections to full file (5→6)

### DIFF
--- a/src/data/proofs/fermat-two-squares/meta.json
+++ b/src/data/proofs/fermat-two-squares/meta.json
@@ -79,41 +79,49 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Statement and Approach",
+      "summary": "Module docstring: states Fermat's two-squares theorem (Wiedijk #20) — an odd prime p is a sum of two squares iff p ≡ 1 (mod 4) — and outlines the historical context, Zagier's one-sentence involution proof, the proof status, and the Mathlib dependencies used.",
+      "startLine": 1,
+      "endLine": 52,
+      "mathContext": "The header collects imports and a module docstring covering the classical statement of Fermat's theorem on sums of two squares, its history (Fermat 1640, Euler's first proof, Zagier's 1990 one-sentence involution proof), and the fact that the formalization wraps Mathlib's `Nat.Prime.sq_add_sq`. It situates the file within the Wiedijk 100 Theorems list (#20)."
+    },
+    {
       "id": "main-theorem",
       "title": "The Main Theorem",
-      "startLine": 47,
-      "endLine": 66,
+      "startLine": 53,
+      "endLine": 88,
       "summary": "The complete characterization: a prime p is a sum of two squares if and only if p % 4 is not 3.",
       "mathContext": "The main theorem is a direct wrapper around Mathlib's `Nat.Prime.sq_add_sq`, which states: for a prime $p$, $\\exists\\, a\\, b,\\, p = a^2 + b^2 \\iff p\\,\\%\\,4 \\neq 3$. This covers all three cases simultaneously: $p = 2$ (since $2\\,\\%\\,4 = 2 \\neq 3$, and $2 = 1^2+1^2$), $p \\equiv 1 \\pmod{4}$ (representable), and $p \\equiv 3 \\pmod{4}$ (not representable, since squares mod 4 are 0 or 1 so $a^2+b^2 \\in \\{0,1,2\\} \\pmod{4}$)."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 67,
-      "endLine": 94,
+      "startLine": 89,
+      "endLine": 135,
       "summary": "Explicit statements for primes congruent to 1 (mod 4), the prime 2, and primes congruent to 3 (mod 4).",
       "mathContext": "This section splits the main theorem into pedagogically clearer cases: (1) `prime_one_mod_four_sum_two_squares`: if $p$ is prime and $p \\equiv 1 \\pmod{4}$ then $p = a^2+b^2$; (2) `two_sum_two_squares`: $2 = 1^2+1^2$; (3) `prime_three_mod_four_not_sum_two_squares`: if $p \\equiv 3 \\pmod{4}$ then $p \\neq a^2+b^2$ for any $a,b$. Each case is a consequence of the main theorem plus modular arithmetic, often discharged with `omega` or `decide` for the residue computations."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "startLine": 95,
-      "endLine": 114,
+      "startLine": 136,
+      "endLine": 155,
       "summary": "Verification of small cases: 5 = 1^2 + 2^2, 13 = 2^2 + 3^2, 17 = 1^2 + 4^2, etc.",
       "mathContext": "Concrete verifications serve as executable witnesses: $5 = 1^2+2^2$, $13 = 2^2+3^2$, $17 = 1^2+4^2$, $29 = 2^2+5^2$, $37 = 1^2+6^2$, $41 = 4^2+5^2$. Each is proved by `norm_num` or `decide`, which reduces the goal to arithmetic. These examples also illustrate uniqueness: primes $\\equiv 1 \\pmod{4}$ have essentially unique representations (up to order and signs), a consequence of unique factorization in $\\mathbb{Z}[i]$ — though uniqueness is not formally proved here."
     },
     {
       "id": "classification",
       "title": "Prime Classification",
-      "startLine": 115,
-      "endLine": 160,
+      "startLine": 156,
+      "endLine": 181,
       "summary": "Complete classification of all primes into three categories based on their residue mod 4.",
       "mathContext": "Every prime $p$ has residue mod 4 in $\\{0,1,2,3\\}$, but primes $\\geq 3$ cannot be $\\equiv 0 \\pmod{4}$ (divisible by 4) or $\\equiv 2 \\pmod{4}$ (even, unless $p = 2$). So odd primes $\\geq 3$ fall into exactly two classes: $p \\equiv 1 \\pmod{4}$ (sum of two squares, infinitely many by Dirichlet's theorem) and $p \\equiv 3 \\pmod{4}$ (not a sum of two squares, also infinitely many). This trichotomy — $p=2$, $p \\equiv 1$, $p \\equiv 3$ — exhausts all primes and is proved by case analysis on `p % 4`."
     },
     {
       "id": "classification-corollary",
       "title": "Classification Corollary",
-      "startLine": 156,
+      "startLine": 182,
       "endLine": 201,
       "summary": "Restates the main theorem in the natural form: p = a² + b² iff p = 2 or p ≡ 1 (mod 4). Combines all three cases into a single equivalence.",
       "mathContext": "This corollary presents the theorem in its most natural formulation: $p = a^2+b^2 \\iff p = 2 \\lor p \\equiv 1 \\pmod{4}$. The forward direction (representable implies $p=2$ or $p \\equiv 1$) uses the mod-4 obstruction: if $p \\equiv 3 \\pmod{4}$ then $a^2+b^2 \\equiv 0,1,2 \\pmod{4}$, never 3. The backward direction uses the existence proof from `Nat.Prime.sq_add_sq`. Combining both directions into a clean `↔` statement makes this the most useful form for downstream applications."


### PR DESCRIPTION
## Summary
Two genuine defects in `fermat-two-squares` gallery sections:
- **Mis-ranged section**: "Concrete Examples" (whose summary lists `5=1²+2²`, `13=2²+3²`, …) was ranged at lines 95-114, which covers `two_is_sum_of_squares`, not the `## Examples` rfl block at lines 136-155 it actually describes.
- **Overlap**: "Prime Classification" (115-160) overlapped "Classification Corollary" (156-201).
- **Uncovered header**: the module docstring (lines 1-52).

## Changes
- Added an `overview` section (1-52) for the docstring/imports.
- Re-ranged the five existing sections to their true declaration positions, producing 6 fully contiguous sections covering the entire 201-line file with no gaps or overlaps:
  - main-theorem 53-88, special-cases 89-135, examples 136-155, classification 156-181, classification-corollary 182-201.
- All existing `summary`/`mathContext` text preserved verbatim.

No Lean source changed. Build-free metadata realignment.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections contiguous 1→201, zero gaps/overlaps
- [x] Each section's range matches the theorem/banner its summary describes