### PR TITLE
research(erdos-1071): realign drifted gallery sections to full file (9→12)

### DIFF
--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -95,76 +95,100 @@
   },
   "sections": [
     {
-      "id": "docstring",
+      "id": "module-docstring",
       "title": "Module Docstring",
       "startLine": 1,
       "endLine": 16,
-      "summary": "Problem statement for Erdős Problem #1071 on maximal packings of unit segments in the unit square.",
-      "mathContext": "States the two questions: (a) SOLVED by Danzer — existence of a finite maximal set of pairwise non-intersecting unit segments in $[0,1]^2$. (b) OPEN — existence of a region $R$ with a countably infinite maximal packing."
+      "summary": "Module docstring framing Erdős Problem #1071 (Erdős–Tóth): two questions on unit segments in [0,1]² — (a) SOLVED by Danzer ($10 prize): a finite maximal set of pairwise non-intersecting unit segments exists; (b) OPEN: a region with a countably infinite maximal disjoint set. Defines maximality (no further segment addable).",
+      "mathContext": "Erdős #1071: (a) finite maximal packing of unit segments in $[0,1]^2$ exists (Danzer, solved); (b) does a region admit a countably infinite maximal packing? (open). Ref: erdosproblems.com/1071."
     },
     {
       "id": "imports-namespace",
       "title": "Imports and Namespace",
-      "startLine": 18,
-      "endLine": 22,
-      "summary": "Imports Mathlib and opens the Set namespace.",
-      "mathContext": "Imports full Mathlib for `Set`, `Disjoint`, `Real.sqrt`, real arithmetic. Opens `Set` for set operations."
+      "startLine": 17,
+      "endLine": 23,
+      "summary": "Imports Mathlib, opens the `Set` namespace, and enters namespace `Erdos1071`.",
+      "mathContext": "`import Mathlib`; `open Set`; `namespace Erdos1071`."
     },
     {
       "id": "geometric-foundations",
       "title": "Part 1: Geometric Foundations",
       "startLine": 24,
-      "endLine": 51,
-      "summary": "Defines the geometric primitives: Euclidean distance, unit segments, line segment point sets, and containment in the unit square.",
-      "mathContext": "Defines `euclidDist(p,q) = \\sqrt{(p_1 - q_1)^2 + (p_2 - q_2)^2}$. `UnitSegment` structure with $\\mathbb{R}^2$ endpoints and proof `euclidDist = 1$. `segmentSet(p,q) = \\{(1-t)p + tq : t \\in [0,1]\\}$ (convex combinations). `InUnitSquare(p) \\iff p \\in [0,1]^2$. `SegmentInSquare(s)` requires both endpoints in the unit square."
+      "endLine": 52,
+      "summary": "Real-valued planar geometry: Euclidean distance in ℝ², the UnitSegment structure (two endpoints at distance 1), the point set of a segment as convex combinations of its endpoints, membership in the unit square [0,1]², and a segment's containment in the unit square via an endpoint check.",
+      "mathContext": "Euclidean distance on $\\mathbb{R}^2$; `UnitSegment` = endpoints with $\\|p-q\\|=1$; `segmentSet` = convex hull of endpoints; `InUnitSquare`, `SegmentInSquare`."
     },
     {
       "id": "disjointness",
       "title": "Part 2: Disjointness",
       "startLine": 53,
-      "endLine": 69,
-      "summary": "Defines segment disjointness and endpoint-disjointness, with a proved symmetry lemma.",
-      "mathContext": "Defines `AreDisjoint(s,t) \\iff \\text{Disjoint}(\\text{segmentSet}(s), \\text{segmentSet}(t))$ (empty intersection of point sets). PROVED `disjoint_symm` via `Disjoint.symm`. Defines `EndpointDisjoint(s,t)`: intersection $\\subseteq \\{s.x_1, s.x_2\\} \\cup \\{t.x_1, t.x_2\\}$ (segments may touch only at their endpoints)."
+      "endLine": 70,
+      "summary": "Defines segment disjointness (empty intersection of point sets) and endpoint-disjointness (segments may meet only at endpoints), with a proved symmetry lemma. These were previously axioms, now definitions.",
+      "mathContext": "`AreDisjoint(s,t) \\iff \\text{Disjoint}(\\text{segmentSet}(s),\\text{segmentSet}(t))$; `EndpointDisjoint`; `disjoint_symm` proved via `Disjoint.symm`."
     },
     {
-      "id": "packing-defs",
+      "id": "packing-definitions",
       "title": "Part 3: Packing Definitions",
       "startLine": 71,
-      "endLine": 92,
-      "summary": "Builds the hierarchy of packing predicates from basic to maximal to cardinality-constrained.",
-      "mathContext": "Defines `IsPacking(S)`: all segments in $[0,1]^2$ and pairwise disjoint. `IsMaximalPacking(S)`: packing $+$ blocking condition ($\\forall s \\notin S$, $\\exists t \\in S$ with $\\neg\\text{AreDisjoint}(s,t)$). `IsFinitePacking(S)`: packing $\\wedge$ $S$ finite. `IsCountablyInfinitePacking(S)`: packing $\\wedge$ $S$ countable $\\wedge$ $S$ infinite."
+      "endLine": 93,
+      "summary": "Defines a packing (a set of pairwise disjoint unit segments in the unit square), maximality (no addable segment), and finite/countably-infinite packings.",
+      "mathContext": "`IsPacking S`: pairwise `AreDisjoint`, all `SegmentInSquare`; `IsMaximal`; finite and countably-infinite packing predicates."
     },
     {
       "id": "structural-lemmas",
       "title": "Part 4: Structural Lemmas",
       "startLine": 94,
-      "endLine": 127,
-      "summary": "Proves foundational properties of segments and packings.",
-      "mathContext": "PROVED `left_endpoint_mem_segment` and `right_endpoint_mem_segment`: endpoints $p, q \\in \\text{segmentSet}(p,q)$ (at $t=0$ and $t=1$). PROVED `packing_empty`: $\\emptyset$ is a packing. PROVED `packing_subset`: subsets of packings are packings. PROVED `finite_packing_countable`: finite packings are countable (via `Set.Finite.countable`). PROVED `disjoint_implies_endpoint_disjoint`: strict disjointness implies endpoint-disjointness."
+      "endLine": 137,
+      "summary": "Structural lemmas: endpoints lie on their segment, the empty set is a packing, subsets of packings are packings, finite packings are countable, strict disjointness implies endpoint-disjointness, the segment point set is nonempty, and a segment is not disjoint from itself.",
+      "mathContext": "Endpoint membership; `∅` is a packing; subset-closed; finite ⟹ countable; `AreDisjoint ⟹ EndpointDisjoint`; `segmentSet` nonempty; a segment intersects itself."
     },
     {
-      "id": "danzer",
-      "title": "Part 5: Danzer's Result (SOLVED)",
-      "startLine": 128,
-      "endLine": 135,
-      "summary": "Axiomatizes the solved part (a): existence of a finite maximal packing.",
-      "mathContext": "Axiom `danzer_finite_maximal`: $\\exists S$, `IsFinitePacking(S)` $\\wedge$ `IsMaximalPacking(S)`. Ludwig Danzer constructed an explicit finite configuration of unit segments at multiple orientations that blocks every possible placement in $[0,1]^2$, earning Erdős's \\$10 prize."
+      "id": "distance-properties",
+      "title": "Part 4b: Euclidean Distance Properties",
+      "startLine": 138,
+      "endLine": 157,
+      "summary": "Basic metric properties of the Euclidean distance: symmetry, non-negativity, vanishing on the diagonal, and distinctness of a unit segment's endpoints.",
+      "mathContext": "`dist` symmetric, $\\ge 0$, $=0$ iff equal points; a unit segment's endpoints are distinct (distance 1)."
+    },
+    {
+      "id": "convexity-unit-square",
+      "title": "Part 4c: Convexity of the Unit Square",
+      "startLine": 158,
+      "endLine": 178,
+      "summary": "Convexity of the unit square [0,1]²: convex combinations of unit-square points stay inside, hence every point on a segment between two unit-square points (and a SegmentInSquare segment) lies in the square.",
+      "mathContext": "$[0,1]^2$ convex: convex combinations stay inside; `SegmentInSquare` ⟹ all segment points in the square."
+    },
+    {
+      "id": "concrete-constructions",
+      "title": "Part 4d: Concrete Constructions",
+      "startLine": 179,
+      "endLine": 220,
+      "summary": "Concrete witnesses: the horizontal mid-segment from (0,1/2) to (1,1/2), a proof it lies in the unit square, that a singleton is a valid packing, existence of a non-empty packing, and that a maximal packing in the unit square must be nonempty.",
+      "mathContext": "Horizontal mid-segment $(0,\\tfrac12)\\to(1,\\tfrac12)$ in the square; singletons are packings; a non-empty packing exists; maximal packings are nonempty."
+    },
+    {
+      "id": "zorn-existence",
+      "title": "Part 5: Existence of Maximal Packings via Zorn's Lemma",
+      "startLine": 221,
+      "endLine": 286,
+      "summary": "Existence of maximal packings via Zorn's lemma: defines extendability (some unit segment is insertable), proves maximal ⟺ not extendable, that the union of a chain of packings is a packing, and concludes existence of a maximal packing.",
+      "mathContext": "Maximal ⟺ not extendable; unions of chains of packings are packings; Zorn ⟹ a maximal packing exists in $[0,1]^2$."
+    },
+    {
+      "id": "danzer-result",
+      "title": "Part 6: Danzer's Result (Solved, $10 Prize)",
+      "startLine": 287,
+      "endLine": 297,
+      "summary": "Danzer's theorem (Erdős $10 prize), part (a): there exists a finite maximal packing of unit segments in the unit square. Stated as the single axiom of the file (the deep geometric construction is taken as a hypothesis).",
+      "mathContext": "Danzer (solved): a finite maximal packing exists in $[0,1]^2$ — the file's one axiom `danzer_finite_maximal_packing`."
     },
     {
       "id": "open-problem",
-      "title": "Part 6: The Open Problem",
-      "startLine": 137,
-      "endLine": 159,
-      "summary": "Generalizes to region packings and states the open problem on countably infinite maximal packings.",
-      "mathContext": "Defines `Region := \\text{Set}(\\mathbb{R}^2)$. `IsRegionPacking(R, S)`: endpoints in $R$ and pairwise disjoint. `IsMaximalRegionPacking(R, S)`: region packing $+$ blocking in $R$. Axiom `ErdosProblem1071b`: $\\exists R, S$ with $S$ countable, infinite, and maximal in $R$. Key insight: $[0,1]^2$ forces finite packings by compactness, so part (b) requires an unbounded region."
-    },
-    {
-      "id": "endpoint-variant",
-      "title": "Part 7: Endpoint-Intersection Variant",
-      "startLine": 161,
-      "endLine": 174,
-      "summary": "States the open variant allowing segments to touch at endpoints.",
-      "mathContext": "Axiom `ErdosProblem1071_endpoint_variant`: $\\exists S$ finite with all segments in $[0,1]^2$, pairwise `EndpointDisjoint`, and maximal under this weaker condition. Fan-like configurations (segments radiating from one point) become valid, potentially enabling more efficient blocking."
+      "title": "Part 7: The Open Problem — Countably Infinite Maximal Packing",
+      "startLine": 298,
+      "endLine": 323,
+      "summary": "Part (b), the OPEN problem: defines a Region in ℝ², packings restricted to a region, and maximal region-packings, framing the unresolved question of whether some region admits a countably infinite maximal disjoint set of unit segments.",
+      "mathContext": "Open question (b): does a `Region` admit a *countably infinite* maximal packing? Defines `IsRegionPacking`, `IsMaximalRegionPacking`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `erdos-1071` gallery sections had drifted: after Part 4, sections were mislabeled (regions 128-174 carried stale "Danzer/Open-Problem/Endpoint-Variant" titles) and coverage stopped at line 174, leaving lines 175-323 (out of 323) with no section — Part 4b/4c/4d (distance, convexity, concrete constructions), Part 5 (Zorn existence), Part 6 (Danzer axiom), and Part 7 (the open problem) were entirely uncovered.

Rebuilt as 12 contiguous sections (1-323) aligned one-per-`# Part` banner in `Proofs/Erdos1071Problem.lean`, reusing the accurate early summaries and writing correct summaries/mathContext for the recovered parts.

- Content-only metadata change; no Lean source touched.
- Counts unchanged and pre-correct (1 axiom = `danzer_finite_maximal_packing`, 0 sorries).

## Test plan
- [x] `jq empty` validates JSON
- [x] Sections verified contiguous and covering lines 1-323
- [x] Section titles/ranges match the file's `# Part` banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)