### PR TITLE
Enrich Eulerian Paths in Directed Graphs: correct stale theorem count

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "konigsberg-oq-01-oq-02",
   "title": "Eulerian Paths in Directed Graphs",
   "slug": "konigsberg-oq-01-oq-02",
-  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s)=indeg(s)+1, indeg(t)=outdeg(t)+1, and all other vertices are balanced. The directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg) and necessity direction (Eulerian circuit → balanced) are proved from first principles. 12 theorems proved, 2 axioms (Hierholzer sufficiency and path characterization).",
+  "description": "Extends the Eulerian circuit characterization to directed graphs. A weakly connected digraph has an Eulerian circuit iff every vertex has equal in-degree and out-degree; it has an Eulerian path from s to t iff outdeg(s)=indeg(s)+1, indeg(t)=outdeg(t)+1, and all other vertices are balanced. The directed handshaking lemma (∑ outDeg = |E| = ∑ inDeg), the necessity direction (Eulerian circuit → balanced), and the Hierholzer infrastructure (greedy maximal trail, its closure in a balanced graph, circuit existence, and Eulerian-path necessity) are proved from first principles. 25 of 26 theorems are proved from first principles (1 sorry remains in remove_circuit_balanced, blocked on a Finset.sdiff distributivity step); 2 axioms (Hierholzer sufficiency and the full Eulerian path characterization) remain.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",


### PR DESCRIPTION
## Enrichment / accuracy pass — konigsberg-oq-01-oq-02

The entry is already deeply enriched (18 annotations covering lines 1–1198, full references, cross-references, conclusion). The one genuine defect was a **stale theorem count in the `description`**.

### Problem
`description` claimed *"12 theorems proved, 2 axioms"*. That count predates the Hierholzer infrastructure (greedy maximal trail, trail closure, circuit existence, Eulerian-path necessity — ~13 theorems at lines 390–1198) added in later sessions.

### Verification (against `proofs/Proofs/KonigsbergOQ01OQ02.lean`)
- 26 theorems/lemmas (25 proved from first principles, **1 sorry** in `remove_circuit_balanced`)
- 2 axioms (`directed_eulerian_iff`, `directed_euler_path_iff`)
- 1202 lines, 15 definitions

These match `meta.theoremCount` (26), `axiomCount` (2), `sorries` (1), and the existing `conclusion` text ("25 of 26 theorems proved"). Only the `description` was out of sync.

### Change
- Updated `description` to state "25 of 26 theorems proved from first principles (1 sorry in remove_circuit_balanced), 2 axioms" and to name the Hierholzer infrastructure now proved.

No other content modified. JSON validates; data-pipeline prebuild parses cleanly.