### PR TITLE
research(erdos-29): realign drifted gallery sections to full file (11→13)

### DIFF
--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -58,90 +58,106 @@
     {
       "id": "header",
       "title": "Problem Statement",
-      "summary": "Sidon's 1932 question to Erdős: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? JPSZ (2024) answered YES with explicit construction. The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE).",
       "startLine": 1,
       "endLine": 80,
-      "mathContext": "Sidon's 1932 question to Erdős: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE)."
+      "summary": "States Erdős Problem #29: does there exist an *explicit* economical additive basis — a set $A\\subseteq\\mathbb{N}$ with $A+A=\\mathbb{N}$ whose representation function $r_A(n)$ is $n^{o(1)}$? SOLVED (Jain–Pham–Sawhney–Zakharov 2024) via an explicit construction. The docstring surveys background, the probabilistic vs explicit history, and known bases.",
+      "mathContext": "Explicit economical additive basis: $A+A=\\mathbb{N}$ with $r_A(n)=n^{o(1)}$? SOLVED (JPSZ 2024)."
     },
     {
-      "id": "basic-definitions",
-      "title": "Sumsets and Representation",
-      "summary": "Core definitions: `Sumset A B = {a+b : a ∈ A, b ∈ B}` with notation `+ₛ`; `Doubling A = A +ₛ A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a ≤ b, a+b=n}|`. All `noncomputable` (use `Set.ncard`).",
+      "id": "basic-defs",
+      "title": "Basic Definitions",
       "startLine": 81,
       "endLine": 98,
-      "mathContext": "Core definitions: `Sumset A B = {a+b : a ∈ A, b ∈ B}` with notation `+ₛ`; `Doubling A = A +ₛ A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a ≤ b, a+b=n}|`. All `noncomputable` (use `Set.ncard`)."
+      "summary": "Defines `Sumset` (with `+ₛ` notation), `Doubling` ($A+A$), `representationCount` $r_A(n)$, and `orderedRepCount`.",
+      "mathContext": "$A+ₛB=\\{a+b\\}$; $\\text{Doubling}(A)=A+A$; $r_A(n)$ = representations of $n$ as a sum."
     },
     {
-      "id": "additive-basis",
-      "title": "Additive Basis",
-      "summary": "`IsAdditiveBasis A` := `Doubling A = Set.univ` ($A+A = \\mathbb{N}$); `CoversAll A` := $\\forall n, n \\in A+A$. `additive_basis_iff`: these are equivalent (Lean-verified by `ext n; simp; intro h n; rw [h]; trivial`).",
+      "id": "additive-bases",
+      "title": "Additive Bases",
       "startLine": 99,
       "endLine": 117,
-      "mathContext": "`IsAdditiveBasis A` := `Doubling A = Set.univ` ($A+A = \\mathbb{N}$); `CoversAll A` := $\\forall n, n \\in A+A$."
+      "summary": "Defines `IsAdditiveBasis` ($A+A=\\mathbb{N}$) and `CoversAll` ($\\forall n,\\ n\\in A+A$).",
+      "mathContext": "$\\text{IsAdditiveBasis}(A):\\ A+A=\\mathbb{N}$."
     },
     {
-      "id": "economical-condition",
+      "id": "economical",
       "title": "The Economical Condition",
-      "summary": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^ε) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$. `economical_equiv : IsEconomical ↔ IsEconomical'` (Aristotle-proved via filter limit theory).",
       "startLine": 118,
-      "endLine": 150,
-      "mathContext": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^ε) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$."
+      "endLine": 144,
+      "summary": "Defines `IsEconomical` and `IsEconomical'` ($r_A(n)=n^{o(1)}$, i.e. $r_A(n)/n^\\varepsilon\\to0$ for all $\\varepsilon>0$).",
+      "mathContext": "Economical: $r_A(n)=o(n^\\varepsilon)$ for all $\\varepsilon>0$."
     },
     {
-      "id": "probabilistic-existence",
-      "title": "Erdős's Probabilistic Existence",
-      "summary": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erdős's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it.",
-      "startLine": 151,
-      "endLine": 159,
-      "mathContext": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erdős's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it."
+      "id": "original-problem",
+      "title": "Erdős's Original Problem",
+      "startLine": 145,
+      "endLine": 150,
+      "summary": "Defines `Erdos29Statement`: $\\exists A,\\ \\text{IsAdditiveBasis}\\,A\\wedge\\text{IsEconomical}\\,A$.",
+      "mathContext": "$\\text{Erdos29Statement}:\\ \\exists A,\\ A+A=\\mathbb{N}\\wedge r_A(n)=n^{o(1)}$."
     },
     {
       "id": "jpsz-construction",
-      "title": "JPSZ Explicit Construction (2024)",
-      "summary": "`axiom JPSZ_set : Set ℕ` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `⟨JPSZ_set, JPSZ_is_basis, JPSZ_is_economical⟩`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$.",
-      "startLine": 160,
-      "endLine": 204,
-      "mathContext": "`axiom JPSZ_set : Set ℕ` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `⟨JPSZ_set, JPSZ_is_basis, JPSZ_is_economical⟩`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$."
+      "title": "The Explicit Construction (JPSZ 2024)",
+      "startLine": 151,
+      "endLine": 230,
+      "summary": "The Jain–Pham–Sawhney–Zakharov construction as AXIOMS `JPSZ_set` and `JPSZ_is_basis`, with `JPSZ_is_economical` PROVED from the representation bound (a detailed squeeze argument: $\\exp(C\\sqrt{\\log n})/n^\\varepsilon\\to0$). `erdos_29_solved` concludes Erdős #29 holds.",
+      "mathContext": "JPSZ set: explicit additive basis with $r_A(n)\\leq\\exp(C\\sqrt{\\log n})=n^{o(1)}$, solving #29."
     },
     {
-      "id": "comparisons",
+      "id": "jpsz-properties",
+      "title": "Properties of the JPSZ Construction",
+      "startLine": 231,
+      "endLine": 284,
+      "summary": "Defines `HasDensityZero` and PROVES `JPSZ_density_zero` (the JPSZ set has density 0, via $|A\\cap[1,N]|\\leq C\\sqrt N\\sqrt{\\log N}$ and a squeeze). States the AXIOM `JPSZ_representation_bound` ($r_A(n)\\leq\\exp(C\\sqrt{\\log n})$).",
+      "mathContext": "JPSZ density 0; $r_A(n)\\leq\\exp(C\\sqrt{\\log n})$ (axiom)."
+    },
+    {
+      "id": "comparison",
       "title": "Comparison with Other Bases",
-      "summary": "`univ_is_basis`: $\\mathbb{N}+\\mathbb{N} = \\mathbb{N}$ (trivial, $n = 0+n$). `univ_not_economical`: $r_\\mathbb{N}(n) = n+1$, and $(n+1)/n^{1/2} \\to \\infty$ (Aristotle-proved). `squares_not_basis`: 3 is not a sum of two squares (`interval_cases`). All Aristotle-verified.",
-      "startLine": 205,
-      "endLine": 245,
-      "mathContext": "`univ_is_basis`: $\\mathbb{N}+\\mathbb{N} = \\mathbb{N}$ (trivial, $n = 0+n$). `univ_not_economical`: $r_\\mathbb{N}(n) = n+1$, and $(n+1)/n^{1/2} \\to \\infty$ (Aristotle-proved)."
+      "startLine": 285,
+      "endLine": 325,
+      "summary": "PROVES `univ_is_basis` ($\\mathbb{N}$ is a basis) but `univ_not_economical` ($r_\\mathbb{N}(n)=n+1$), and `squares_not_basis` (the squares are not a basis — $3$ is not a sum of two squares).",
+      "mathContext": "$\\mathbb{N}$ basis but not economical ($r=n+1$); squares not a basis."
     },
     {
-      "id": "sidon-sets",
-      "title": "Sidon Sets Cannot Be Bases",
-      "summary": "`IsSidon A`: `orderedRepCount A n ≤ 1`. `sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 ≥ 2` — contradiction. Aristotle-verified. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis.",
-      "startLine": 246,
-      "endLine": 323,
-      "mathContext": "`sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 ≥ 2` — contradiction. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis."
+      "id": "sidon",
+      "title": "Thin Bases and Sidon Sets",
+      "startLine": 326,
+      "endLine": 408,
+      "summary": "Defines `IsSidon` ($r_A\\leq1$ ordered) and PROVES `sidon_not_basis` (a Sidon set is too thin to be an additive basis: $|A\\cap[1,N]|\\leq\\sqrt N+O(1)$ so $A+A\\neq\\mathbb{N}$).",
+      "mathContext": "Sidon sets ($r_A\\leq1$) cannot be additive bases (too thin)."
     },
     {
-      "id": "explicit-class",
+      "id": "explicit-vs-prob",
       "title": "Explicit vs Probabilistic",
-      "summary": "`class ExplicitSet (A : Set ℕ)` with `membership_decidable : DecidablePred (· ∈ A)`. `JPSZ_explicit : ExplicitSet JPSZ_set`. Erdős's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership — key distinction formalizing 'constructive'.",
-      "startLine": 329,
-      "endLine": 357,
-      "mathContext": "Erdős's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership — key distinction formalizing 'constructive'."
+      "startLine": 409,
+      "endLine": 424,
+      "summary": "Contrasts explicit and probabilistic constructions; states the AXIOM `JPSZ_explicit` (the JPSZ set is explicit, via `ExplicitSet`) — the key advance over Erdős's probabilistic existence proof.",
+      "mathContext": "JPSZ set is explicit (not merely a probabilistic existence proof)."
+    },
+    {
+      "id": "history",
+      "title": "Historical Context",
+      "startLine": 425,
+      "endLine": 437,
+      "summary": "A documentation note on the history: Erdős's probabilistic existence (1956), the long-open explicit-construction question, and its 2024 resolution.",
+      "mathContext": "History: probabilistic existence (Erdős 1956) → explicit construction (JPSZ 2024)."
     },
     {
       "id": "lower-bounds",
-      "title": "Size Lower Bounds",
-      "summary": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** — Aristotle built counterexample `CounterexampleA = {0,1} ∪ {n ≥ 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$.",
-      "startLine": 358,
-      "endLine": 422,
-      "mathContext": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** — Aristotle built counterexample `CounterexampleA = {0,1} ∪ {n ≥ 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$."
+      "title": "Lower Bounds",
+      "startLine": 438,
+      "endLine": 492,
+      "summary": "Defines `CounterexampleA` and PROVES `counterexample_to_lower_bound` and `basis_size_lower_bound_false` (a naive size lower bound fails) and `erdos_probabilistic_from_jpsz` (the probabilistic existence now follows from JPSZ, formerly a separate axiom). States the AXIOM `JPSZ_size_optimal` ($|A\\cap[1,N]|\\leq C\\sqrt N\\sqrt{\\log N}$).",
+      "mathContext": "Size lower bound refuted by a counterexample; JPSZ size optimal $|A\\cap[1,N]|\\leq C\\sqrt{N\\log N}$ (axiom)."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "1932: Sidon asks; ~1950s: Erdős proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound).",
-      "startLine": 423,
-      "endLine": 454,
-      "mathContext": "1932: Sidon asks; ~1950s: Erdős proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound)."
+      "startLine": 493,
+      "endLine": 523,
+      "summary": "Closing docstring recapping the resolution of Erdős #29 (JPSZ 2024 explicit economical additive basis), the density-zero and representation-bound properties, and the axioms used (JPSZ_set/is_basis/representation_bound/explicit/size_optimal).",
+      "mathContext": "Recap: #29 SOLVED by JPSZ 2024; 5 axioms encode the construction's properties."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #29 (explicit economical additive basis) gallery `meta.json` had **section drift**.

- Sections 1-4 were aligned, but the back half drifted: "Erdős's Probabilistic Existence" labeled @151 (that banner is "The Explicit Construction (JPSZ 2024)"); "Comparison with Other Bases" @205 but @285; "Explicit vs Probabilistic" @329 but @409; "Size Lower Bounds" @358 but @438; "Summary" @423 but @493.
- Coverage stopped at line **454** of a **523**-line file, hiding the rest of Lower Bounds (`basis_size_lower_bound_false`, `erdos_probabilistic_from_jpsz`, `JPSZ_size_optimal`) and the Summary. The "Historical Context" and "Erdős's Original Problem" banners were also missing.

## Changes
- Rebuilt **13 sections** (was 11) mapped to the file's `## ` banners (plus header) with full coverage **1-523**.
- **Counts unchanged**: 12 theorems / 13 definitions / 5 axioms / 0 sorries, lineCount 523 (`definitionCount` 13 includes the `+ₛ` notation; left as-is).

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-523 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-29
- [x] Section ranges re-verified against the `## ` banners in `Erdos29Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)