### PR TITLE
research(isosceles-triangle): fix overlapping header/setup gallery sections

### DIFF
--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -73,15 +73,15 @@
       "title": "Module Documentation and Historical Context",
       "startLine": 1,
       "endLine": 49,
-      "summary": "Docstring covering the isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65). States forward ($AB = AC \\Rightarrow \\angle ABC = \\angle ACB$) and converse directions. Documents Mathlib dependencies: `angle_eq_angle_of_dist_eq`, `dist_eq_of_angle_eq_angle_of_angle_ne_pi`, `angle_sub_eq_angle_sub_rev_of_norm_eq`. Historical note on medieval naming and Pappus's simplified proof.",
+      "summary": "Imports (`Mathlib.Geometry.Euclidean.Triangle`, `Mathlib.Tactic`) and module docstring: the isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65) with approach, status, and historical note.",
       "mathContext": "The isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #1): if $|AB| = |AC|$ in triangle $ABC$, then $\\angle ABC = \\angle ACB$. One of the oldest theorems in mathematics, first proved rigorously by Euclid circa 300 BCE."
     },
     {
       "id": "setup",
       "title": "Imports and Type Variables",
-      "startLine": 1,
+      "startLine": 50,
       "endLine": 57,
-      "summary": "Imports `Mathlib.Geometry.Euclidean.Triangle` and `Mathlib.Tactic`. Opens `EuclideanGeometry` namespace. Declares type variables $V$ (normed inner product space over $\\mathbb{R}$) and $P$ (metric space with $V$-torsor structure), enabling the theorem in arbitrary-dimensional Euclidean spaces.",
+      "summary": "Opens `EuclideanGeometry`, declares `namespace IsoscelesTriangle`, and the type variables `V` (real inner product space) and `P` (metric torsor over `V`).",
       "mathContext": "Imports for Euclidean geometry: inner product spaces, metric spaces, and norm definitions. Sets up the framework for proving that equal sides imply equal base angles in a triangle."
     },
     {


### PR DESCRIPTION
## Summary
- The `isosceles-triangle` gallery `meta.json` had two sections both starting at line 1: "Module Documentation and Historical Context" (1–49) and "Imports and Type Variables" (1–57), overlapping the entire module docstring.
- Repointed "Imports and Type Variables" to **50–57** (the `open`/`namespace`/`variable` block) and folded the imports into the header section, so all 7 sections now cover the file contiguously (1→129) with no overlap.

## Notes
- **No Lean changes** — pure gallery `meta.json` sections fix. All non-section keys identical; counts (4 thm / 0 ax / 0 def / 0 sorries) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)