### PR TITLE
research(erdos-1118-oq-02): truthful several-complex-variables formulation

### DIFF
--- a/proofs/Proofs/Erdos1118OQ02.lean
+++ b/proofs/Proofs/Erdos1118OQ02.lean
@@ -12,8 +12,12 @@ In one variable: for a non-constant entire function f : ℂ → ℂ,
 the superlevel set E(c) = {z : |f(z)| > c} can have finite
 planar Lebesgue measure for some c > 0.
 
-In several variables: f : ℂⁿ → ℂ, the superlevel set
-E(c) = {z ∈ ℂⁿ : |f(z)| > c} lives in ℝ^(2n).
+In several variables: this file works with scalar holomorphic
+f : ℂⁿ → ℂ, whose superlevel set E(c) = {z ∈ ℂⁿ : |f(z)| > c}
+lives in ℝ^(2n). The OQ's vector form f : ℂⁿ → ℂⁿ reduces to this
+via the norm: {z : ‖f(z)‖ > c} with log‖f‖ plurisubharmonic.
+Because all norms on ℂⁿ are equivalent, finiteness of the
+(2n)-measure of E(c) is independent of the chosen norm.
 
 Key differences:
 1. Growth is measured by the Nevanlinna characteristic T(r,f)
@@ -77,8 +81,12 @@ theorem superlevel_dimension (n : ℕ) :
     2 * n = 2 * n := rfl
 
 /-- The growth needed for finite measure increases with dimension.
-    Roughly: M(r) must grow faster than exp(r^(2n/(2n-1)))
-    for the superlevel set to have finite (2n)-measure. -/
+    The polar volume element scales from r dr (n = 1, planar area)
+    to r^(2n-1) dr in ℝ^(2n), so the natural candidate growth
+    integral is ∫₀^∞ r^(2n-1)/(log log M(r)) dr < ∞. The r^(2n-1)
+    volume factor is solid; the log log M(r) denominator is the
+    conjectural part and the precise threshold is OPEN — no specific
+    closed-form growth rate is established here. -/
 theorem growth_increases_with_dim :
     -- Higher dimension needs faster growth
     ∀ n₁ n₂ : ℕ, n₁ < n₂ → 2 * n₁ < 2 * n₂ := by

--- a/research/problems/erdos-1118-oq-02/knowledge.md
+++ b/research/problems/erdos-1118-oq-02/knowledge.md
@@ -6,16 +6,56 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent (erdos-1118) is the one-variable theory of entire $f:\mathbb{C}\to\mathbb{C}$
+whose superlevel set $E(c)=\{|f|>c\}$ has finite planar measure. Camera/Gol'dberg settled
+two questions: a double-logarithmic growth-integral characterizes when some finite-measure
+$E(c)$ exists (Q1), and the threshold set $T(f)=\{c>0:|E(c)|<\infty\}$ is an upper set that
+can have a gap above $0$ (Q2). This OQ asks for the $\mathbb{C}^n\to\mathbb{C}^n$ analogue.
+Its goal is to fix a *truthful formulation* first, not to prove the deep analytic results.
+
+In the parent Lean file `Erdos1118Problem.lean` the boundary is conservative: the deep
+analytic results (`camera_goldberg_theorem`, `goldberg_counterexample`,
+`goldberg_threshold_classification`) are **axioms**; the only Lean-proved facts are
+`superlevel_nested`, `finite_measure_monotone`, and `threshold_is_upper_set`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Dimension-free core.** The three proved parent lemmas use only set inclusion plus
+  monotonicity of measure. They hold verbatim for $E(c)=\{z\in\mathbb{C}^n:\|f(z)\|>c\}$
+  under $\lambda_{2n}$, with the identical proof skeleton (`measure_mono` +
+  `lt_of_le_of_lt`). So the order/measure scaffold is the cheap, reusable part of any SCV
+  formalization.
+
+- **Norm-independence.** All norms on $\mathbb{C}^n$ are equivalent, so whether
+  $\lambda_{2n}(E(c))<\infty$ does not depend on the chosen norm — a norm change only
+  rescales $c$ by a bounded factor. Therefore the *qualitative* SCV theory (existence of a
+  finite-measure level, order-type of $T(f)$) is norm-free; only quantitative growth
+  constants can depend on the norm.
+
+- **Monotone growth via plurisubharmonicity.** $\log\|f\|$ is plurisubharmonic for
+  holomorphic $f$, so $M(r)=\max_{\|z\|=r}\|f(z)\|$ is non-decreasing with a
+  three-spheres convexity bound — the SCV stand-in for the one-variable maximum modulus.
+
+- **Volume scaling of the Q1 kernel.** The one-variable kernel $r\,dr$ is the polar area
+  element; in $2n$ real dimensions the radial volume element is $r^{2n-1}\,dr$. So the
+  natural candidate growth integral is $\int_0^\infty r^{2n-1}/\log\log M(r)\,dr<\infty$.
+  The volume factor $r^{2n-1}$ is solid; the $\log\log M(r)$ denominator is the conjectural
+  part.
+
+- **Non-degeneracy is required.** "Non-constant" is too weak in SCV: maps with
+  positive-dimensional fibers (e.g. $(z_1,z_2)\mapsto(z_1,0)$) make $E(c)$ an
+  infinite-measure cylinder trivially. A dominance / generically-finite hypothesis
+  ($\det Df\not\equiv 0$) is the natural fix.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Inheriting the parent's SOLVED status for the SCV question — rejected. The parent's deep
+  results are axioms even in one variable; there is no SCV analogue of Camera/Gol'dberg in
+  the local material, so the higher-dimensional question must stay open.
+
+- Treating "non-constant" as the SCV non-degeneracy hypothesis — rejected (fiber
+  cylinders give trivial infinite measure; see Insights).

--- a/research/problems/erdos-1118-oq-02/problem.md
+++ b/research/problems/erdos-1118-oq-02/problem.md
@@ -2,7 +2,11 @@
 
 ## Problem Statement
 
-What are the higher-dimensional analogues for holomorphic maps $f : \mathbb{C}^n \to \mathbb{C}^n$?
+What are the higher-dimensional analogues of Erdős Problem #1118 for holomorphic
+maps $f : \mathbb{C}^n \to \mathbb{C}^n$? Specifically, what is the right theory of
+finite-measure superlevel sets
+$$E(c) = \{\, z \in \mathbb{C}^n : \lVert f(z)\rVert > c \,\}, \qquad \lambda_{2n}(E(c)) < \infty,$$
+where $\lambda_{2n}$ is Lebesgue measure on $\mathbb{C}^n \cong \mathbb{R}^{2n}$?
 
 ## Source
 
@@ -12,12 +16,93 @@ What are the higher-dimensional analogues for holomorphic maps $f : \mathbb{C}^n
 
 ## Tags
 
-erdos, complex-analysis, entire-functions, measure-theory, growth-rate, solved
+erdos, complex-analysis, several-complex-variables, entire-functions, measure-theory, growth-rate, solved
 
 ## Related Gallery Proofs
 
 - erdos-1118
 
+## Proposed Formulation (OBSERVE → ORIENT)
+
+The parent one-variable theory has two parts (Camera 1977, Gol'dberg 1979):
+
+- **Q1 (growth characterization).** A non-constant entire $f:\mathbb{C}\to\mathbb{C}$ has
+  some $c$ with $\lvert E(c)\rvert<\infty$ iff $\int_0^\infty \frac{r}{\log\log M(r)}\,dr<\infty$,
+  where $M(r)=\max_{|z|=r}\lvert f(z)\rvert$.
+- **Q2 (threshold classification).** The threshold set
+  $T(f)=\{c>0 : \lvert E(c)\rvert<\infty\}$ is always an upper set, but it need **not**
+  extend down to $0$: Gol'dberg realized $T(f)\in\{\varnothing,\ (0,\infty),\ [m,\infty),\ (m,\infty)\}$.
+
+The several-complex-variables analogue requires the following modelling choices. The
+ones below are reasoned from the parent material; items flagged **(open)** are genuine
+formulation gaps, not yet settled by the parent proof.
+
+### 1. Objects: holomorphic maps and a non-degeneracy hypothesis
+
+Take $f:\mathbb{C}^n\to\mathbb{C}^n$ holomorphic (each component $f_j$ entire in the SCV
+sense). The one-variable hypothesis "non-constant" is **too weak** here: a holomorphic
+map can be non-constant yet have positive-dimensional fibers (e.g.
+$f(z_1,z_2)=(z_1,0)$), making every superlevel set a cylinder of infinite $2n$-measure
+trivially. The right replacement is a **non-degeneracy / dominance** hypothesis — e.g.
+$f$ generically finite (Jacobian $\det Df \not\equiv 0$), so $f$ is open and proper onto
+its image off a thin set. **(open: the precise minimal hypothesis.)**
+
+### 2. Superlevel set and norm-independence
+
+$E(c)=\{z\in\mathbb{C}^n:\lVert f(z)\rVert>c\}$. Because all norms on the
+finite-dimensional space $\mathbb{C}^n$ are equivalent, **finiteness of $\lambda_{2n}(E(c))$
+is independent of the chosen norm** (a different norm only rescales the threshold $c$ by a
+bounded factor). So the *qualitative* theory (which $f$ admit some finite-measure $E(c)$,
+and the order-type of $T(f)$) is norm-free; only the *quantitative* growth constant can
+depend on the norm. This is a clean, true reduction.
+
+### 3. The growth invariant
+
+$M(r)=\max_{\lVert z\rVert=r}\lVert f(z)\rVert$. Since each $\lvert f_j\rvert$ is
+plurisubharmonic and $\max$/sums preserve plurisubharmonicity, $\log\lVert f\rVert$ is
+plurisubharmonic; hence $M(r)$ is non-decreasing in $r$ and obeys a Hadamard
+three-spheres convexity bound. This gives the reusable monotone growth profile the
+one-variable proof relies on.
+
+### 4. The growth-integral analogue (Q1 analogue)
+
+In one variable the kernel $r\,dr$ is exactly the planar area element in polar
+coordinates. In $2n$ real dimensions the radial volume element is
+$r^{2n-1}\,dr$ (up to the surface area of $S^{2n-1}$). The **natural candidate** is
+therefore
+$$\int_0^\infty \frac{r^{2n-1}}{\log\log M(r)}\,dr < \infty,$$
+replacing $r\,dr$ by $r^{2n-1}\,dr$. **(open)** Whether $\log\log M(r)$ is still the
+correct denominator in SCV — i.e. whether the level sets thin out at the same
+double-logarithmic rate — is **not** established by the parent material and is the central
+analytic open question. The dimensional volume scaling is solid; the denominator is the
+conjectural part.
+
+### 5. Threshold classification (Q2 analogue)
+
+$T(f)=\{c>0:\lambda_{2n}(E(c))<\infty\}$. The **order/measure facts transfer verbatim and
+are dimension-free**: $c_1<c_2\Rightarrow E(c_2)\subseteq E(c_1)$, finite measure is
+upward-monotone in $c$, and $T(f)$ is an upper set. These need only set inclusion and
+monotonicity of measure — no analysis, no dimension. **(open)** Whether the
+Gol'dberg pathologies (gaps in $T(f)$; the four order-types) persist for $n\ge 2$, or
+whether higher dimension forces extra rigidity, is unresolved.
+
+### Summary of the formulation split
+
+| Component | Status in SCV |
+|-----------|---------------|
+| Superlevel nesting, finite-measure upward monotonicity, $T(f)$ upper-set | **Dimension-free; directly reusable** |
+| Norm-independence of the finiteness question | **True (norm equivalence)** |
+| $M(r)$ monotone via plurisubharmonicity of $\log\lVert f\rVert$ | **True; reusable growth profile** |
+| Correct non-degeneracy hypothesis on $f$ | open |
+| Growth-integral kernel $r^{2n-1}/\log\log M(r)$ | volume factor solid; denominator conjectural |
+| Persistence of Gol'dberg threshold pathologies | open |
+
 ## Research Notes
 
-*To be filled during OBSERVE phase.*
+The goal for this OQ is explicitly to settle a *truthful formulation* before any
+formalization. The table above is the deliverable: it isolates what is genuinely new
+(the analytic Q1 kernel and the Q2 pathology question) from what is mechanical
+(the dimension-free order/measure scaffold). The parent file's
+`superlevel_nested`, `finite_measure_monotone`, and `threshold_is_upper_set` are the
+exact lemmas that lift to $\mathbb{C}^n$ unchanged and should anchor any future Lean
+development.

--- a/research/problems/erdos-1118-oq-02/state.md
+++ b/research/problems/erdos-1118-oq-02/state.md
@@ -1,25 +1,37 @@
 # Research State: erdos-1118-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-03-29T23:03:00-07:00
-**Iteration**: 1
+**Since**: 2026-06-14
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Truthful formulation of the several-complex-variables analogue is drafted in problem.md
+and knowledge.md. The formulation isolates the dimension-free reusable scaffold from the
+genuinely open analytic content.
 
 ## Active Approach
-None yet.
+Formulation-first: pin down the correct SCV statement before any Lean development, per the
+problem's stated goal. The order/measure facts (`superlevel_nested`,
+`finite_measure_monotone`, `threshold_is_upper_set`) lift to $\mathbb{C}^n$ verbatim and
+will anchor a future formalization; the Q1 growth kernel and Q2 threshold-pathology
+questions remain open.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- Docker build environment is down this session, so no Lean development was attempted
+  (consistent with the "formulate before formalizing" goal).
+- The deep analytic SCV results have no local Mathlib-ready statement; they remain
+  conjectural (Q1 denominator) or open (Q2 pathology persistence).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+1. ORIENT: survey SCV value-distribution / Nevanlinna theory for the correct growth
+   denominator replacing $\log\log M(r)$ and for the right non-degeneracy hypothesis.
+2. When Docker returns, draft `Erdos1118OQ02.lean` with the dimension-free order/measure
+   lemmas (mirroring the parent) plus the open SCV questions stated as `Prop`s, and build
+   it before shipping any Lean.

--- a/src/data/research/problems/erdos-1118-oq-02.json
+++ b/src/data/research/problems/erdos-1118-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1118-oq-02",
   "title": "Higher-Dimensional Analogues of Erdős Problem #1118",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -28,29 +28,35 @@
     "goal": "Determine a truthful formulation of the several-complex-variables analogue before attempting formalization."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-29T23:03:00-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "phase": "ORIENT",
+    "since": "2026-06-14",
+    "iteration": 2,
+    "focus": "Truthful several-complex-variables formulation drafted: dimension-free order/measure scaffold separated from the genuinely open analytic content (Q1 growth kernel, Q2 threshold pathology).",
+    "blockers": [
+      "Docker build environment down this session; no Lean development attempted, consistent with the formulate-before-formalizing goal.",
+      "No local Mathlib-ready statement of the SCV growth criterion; the Q1 denominator stays conjectural and Q2 pathology persistence stays open."
+    ],
+    "nextAction": "ORIENT: survey SCV value-distribution/Nevanlinna theory for the correct growth denominator and non-degeneracy hypothesis; when Docker returns, add the dimension-free order/measure lemmas (mirroring the parent) and build before shipping any Lean.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Backfilled from local evidence: the OQ-02 research files contain only the OBSERVE scaffold plus the question asking for higher-dimensional analogues of the parent entire-function result. The parent proof metadata and Lean source show a conservative proof boundary: Camera-Gol'dberg/Gol'dberg analytic results are axioms; the set-nesting, finite-measure monotonicity, and threshold upper-set facts are Lean-proved.",
+    "progressSummary": "ORIENT iteration: drafted a truthful several-complex-variables formulation (problem.md, knowledge.md). The deliverable is a split between the dimension-free reusable scaffold and the genuinely open analytic content. Dimension-free/true: superlevel nesting, finite-measure upward monotonicity, and the threshold upper-set property lift to C^n verbatim (same measure_mono proofs); the finiteness question is norm-independent (norm equivalence on C^n); M(r) is monotone because log||f|| is plurisubharmonic. Open/conjectural: the correct non-degeneracy hypothesis on f (non-constant is too weak — fiber cylinders give trivial infinite measure), the Q1 growth kernel (volume factor r^(2n-1) dr is solid, the log log M(r) denominator is conjectural), and whether Gol'dberg's threshold pathologies persist for n >= 2. Corrected a misleading docstring in Erdos1118OQ02.lean that asserted an unfounded closed-form growth rate exp(r^(2n/(2n-1))).",
     "builtItems": [
       "research/problems/erdos-1118-oq-02/problem.md records the open question and links it to parent proof erdos-1118.",
       "proofs/Proofs/Erdos1118Problem.lean contains the parent one-variable definitions and theorems.",
       "src/data/proofs/erdos-1118/meta.json records the parent proof as status axiomatized with 3 axioms, 7 theorems, 13 definitions, and 0 sorries."
     ],
     "insights": [
-      "The higher-dimensional question should not inherit the parent solved status automatically; the local OQ file records a challenging generalization question.",
-      "The parent formalization separates reusable order/measure reasoning from deep analytic content: superlevel nesting, finite-measure monotonicity, and upward closure are proved, while Hayman's growth criterion and Gol'dberg threshold classification are axioms.",
-      "A future formulation needs choices absent from the local notes: scalar versus vector-valued norm, Lebesgue measure on C^n, and the correct maximum-modulus or plurisubharmonic growth invariant."
+      "Dimension-free core: the three parent-proved lemmas (superlevel_nested, finite_measure_monotone, threshold_is_upper_set) use only set inclusion plus monotonicity of measure, so they lift to E(c) = {z in C^n : ||f(z)|| > c} under lambda_2n with the identical proof skeleton (measure_mono + lt_of_le_of_lt).",
+      "Norm-independence: all norms on C^n are equivalent, so whether lambda_2n(E(c)) is finite does not depend on the norm (a norm change only rescales c by a bounded factor). Thus the qualitative SCV theory is norm-free; only quantitative growth constants can depend on the norm.",
+      "Monotone growth via plurisubharmonicity: log||f|| is plurisubharmonic for holomorphic f, so M(r) = max_{||z||=r} ||f(z)|| is non-decreasing with a three-spheres convexity bound — the SCV stand-in for the one-variable maximum modulus.",
+      "Q1 kernel volume scaling: the one-variable kernel r dr is the polar area element; in 2n real dimensions the radial volume element is r^(2n-1) dr, so the natural candidate growth integral is integral of r^(2n-1)/(log log M(r)) dr. The r^(2n-1) factor is solid; the log log M(r) denominator is conjectural.",
+      "Non-degeneracy required: non-constant is too weak in SCV — maps with positive-dimensional fibers, e.g. (z1,z2) -> (z1,0), make E(c) an infinite-measure cylinder trivially. A dominance / generically-finite hypothesis (det Df not identically 0) is the natural fix.",
+      "The higher-dimensional question should not inherit the parent solved status; the parent's deep analytic results are axioms even in one variable, and there is no SCV analogue of Camera/Gol'dberg in the local material."
     ],
     "mathlibGaps": [
       "No local evidence shows a Mathlib-ready statement of the Camera-Gol'dberg theorem in one variable.",
@@ -58,11 +64,11 @@
       "The parent proof currently axiomatizes camera_goldberg_theorem, goldberg_counterexample, and goldberg_threshold_classification."
     ],
     "nextSteps": [
-      "Define the candidate higher-dimensional superlevel set for f : C^n -> C^n and choose a norm on the target.",
-      "Check whether the one-variable monotonicity lemmas generalize to the selected measurable space and measure.",
-      "Survey literature before asserting any Camera-Gol'dberg-style growth criterion in several complex variables."
+      "ORIENT: survey SCV value-distribution / Nevanlinna theory to pin the correct growth denominator replacing log log M(r) and the minimal non-degeneracy hypothesis on f.",
+      "When Docker returns, extend Erdos1118OQ02.lean with the dimension-free order/measure lemmas (superlevel_nested / finite_measure_monotone / threshold_is_upper_set generalized to ||.|| on C^n) and build before shipping any Lean.",
+      "Investigate whether Gol'dberg-style threshold pathologies (gaps in T(f); the four order-types) persist for n >= 2 or whether higher dimension forces extra rigidity."
     ],
-    "markdown": "# Knowledge Base: erdos-1118-oq-02\n\n## Problem Understanding\n\nThis open question asks for higher-dimensional analogues of Erdős Problem #1118 for holomorphic maps `f : C^n -> C^n`. The parent problem concerns one-variable entire functions whose superlevel sets `E(c) = {z : |f z| > c}` have finite planar measure.\n\n## Evidence From Parent Formalization\n\n`proofs/Proofs/Erdos1118Problem.lean` defines the one-variable objects: entire functions, superlevel sets, finite-measure predicates, maximum modulus, threshold sets, and Hayman's growth-integral conjecture.\n\nThe analytic results are not fully proved in Lean. The file axiomatizes `camera_goldberg_theorem`, `goldberg_counterexample`, and `goldberg_threshold_classification`.\n\nThe constructive Lean-proved core consists of `superlevel_nested`, `finite_measure_monotone`, and `threshold_is_upper_set`. The negative answer to the parent threshold question is then derived from the Gol'dberg counterexample axiom with explicit witnesses `m + 1` and `m / 2`.\n\n## Current Research Boundary\n\nNo local evidence provides a specific several-variable theorem statement, growth integral, or Lean development for OQ-02. The next real work is formulation: choose the target norm, the ambient measure on `C^n`, and the correct higher-dimensional growth invariant before attempting proof work.\n"
+    "markdown": "# Knowledge Base: erdos-1118-oq-02\n\n## Problem Understanding\n\nThis open question asks for higher-dimensional analogues of Erdős Problem #1118 for holomorphic maps `f : C^n -> C^n`, with the finite-measure superlevel condition `lambda_2n {z in C^n : ||f(z)|| > c} < infinity`. The parent (erdos-1118) is the one-variable theory; its deep analytic results (Camera-Gol'dberg) are axioms even there, so the SCV question stays genuinely open. The goal is a truthful formulation before formalization.\n\n## Formulation Split (the deliverable)\n\n**Dimension-free / reusable scaffold:**\n- Superlevel nesting `c1 < c2 => E(c2) subset E(c1)`, finite-measure upward monotonicity, and `T(f)` being an upper set all lift to C^n verbatim (only set inclusion + `measure_mono`).\n- Finiteness of `lambda_2n(E(c))` is norm-independent (all norms on C^n are equivalent; a norm change only rescales c by a bounded factor).\n- `M(r) = max_{||z||=r} ||f(z)||` is non-decreasing because `log||f||` is plurisubharmonic (three-spheres convexity).\n\n**Genuinely open / conjectural:**\n- The minimal non-degeneracy hypothesis on f. `Non-constant` is too weak: maps with positive-dimensional fibers (e.g. `(z1,z2) -> (z1,0)`) give infinite-measure cylinders. Candidate: dominance / generically finite (`det Df` not identically 0).\n- The Q1 growth kernel. The volume factor `r^(2n-1) dr` (replacing the planar `r dr`) is solid; the `log log M(r)` denominator is conjectural and there is NO established closed-form threshold.\n- Whether Gol'dberg's threshold pathologies (gaps in `T(f)`; the four order-types) persist for `n >= 2`.\n\n## Lean Status\n\n`proofs/Proofs/Erdos1118OQ02.lean` holds an exploratory scaffold (scalar `f : C^n -> C` framing, 3 theorems, 1 def, 0 axioms, 0 sorries). This iteration corrected a misleading docstring there that asserted an unfounded closed-form growth rate `exp(r^(2n/(2n-1)))`. Adding the dimension-free order/measure lemmas is deferred until the Docker build environment is available, to avoid shipping unverified Lean.\n"
   },
   "tags": [
     "erdos",
@@ -92,12 +98,12 @@
     ]
   },
   "started": "2026-03-30T06:03:08.389Z",
-  "lastUpdate": "2026-03-30T06:03:08.397Z",
+  "lastUpdate": "2026-06-14T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos1118OQ02.lean",
       "filename": "Erdos1118OQ02.lean",
-      "lineCount": 104,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Summary

Advances **erdos-1118-oq-02** (higher-dimensional analogue of Erdős #1118) from OBSERVE to ORIENT by settling a **truthful formulation** — the problem's stated goal ("determine a truthful formulation before attempting formalization").

The deliverable is a clean split between what is mechanical and what is genuinely new:

**Dimension-free / directly reusable (true):**
- Superlevel nesting `c₁<c₂ ⇒ E(c₂)⊆E(c₁)`, finite-measure upward monotonicity, and `T(f)` upper-set — these use only set inclusion + `measure_mono`, so the parent's verified lemmas lift to `E(c)={z∈ℂⁿ:‖f(z)‖>c}` under `λ₂ₙ` verbatim.
- Finiteness of `λ₂ₙ(E(c))` is **norm-independent** (all norms on ℂⁿ equivalent).
- `M(r)` is monotone because `log‖f‖` is plurisubharmonic (three-spheres convexity).

**Genuinely open / conjectural (flagged as such):**
- Minimal non-degeneracy hypothesis on `f` — "non-constant" is too weak (fiber cylinders give trivial infinite measure); candidate is dominance / generically finite.
- Q1 growth kernel `∫ r^(2n-1)/(log log M(r)) dr`: the volume factor is solid, the denominator is conjectural — no closed-form threshold is established.
- Whether Gol'dberg's threshold pathologies persist for `n≥2`.

Also **corrects a misleading docstring** in `Erdos1118OQ02.lean` that asserted an unfounded closed-form growth rate `exp(r^(2n/(2n-1)))`.

## Changes
- `research/problems/erdos-1118-oq-02/{problem,knowledge,state}.md` — formulation, insights, ORIENT state.
- `src/data/research/problems/erdos-1118-oq-02.json` — phase OBSERVE→ORIENT, knowledge fields, lineCount sync.
- `proofs/Proofs/Erdos1118OQ02.lean` — **comment-only** edits (no code changed).

## Notes
- Docker build env was down this session, so no new Lean lemmas were shipped — only comment-only edits, keeping the build status unchanged. Adding the dimension-free order/measure lemmas is deferred until a build is available (recorded as next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)