### PR TITLE
research(erdos-603): realign drifted gallery sections to full file (8→8)

### DIFF
--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -93,7 +93,7 @@
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "IsCountablyInfiniteFamily, IntersectionNot2, IsValidFamily, colorings",
-      "startLine": 28,
+      "startLine": 1,
       "endLine": 57,
       "mathContext": "Defines a valid family $(A_i)_{i \\in I}$ as one where each $A_i$ is countable and infinite, and $|A_i \\cap A_j| \\neq 2$ for $i \\neq j$. A coloring $c : \\bigcup A_i \\to \\Gamma$ is valid if no $A_i$ is monochromatic."
     },
@@ -102,53 +102,53 @@
       "title": "The Main Question",
       "summary": "SufficientColors, chromaticNumber, ErdosConjecture603",
       "startLine": 58,
-      "endLine": 79,
+      "endLine": 80,
       "mathContext": "$C$ colors suffice for $A$ if $\\exists \\Gamma$ with $|\\Gamma| \\leq C$ and a valid coloring $c : \\alpha \\to \\Gamma$. The chromatic number is $\\inf\\{C : C \\text{ suffices}\\}$. The conjecture asks for $\\sup_A \\chi(A)$ over all valid families."
     },
     {
       "id": "komjath",
       "title": "Related Problem - Intersection != 1",
       "summary": "IntersectionNot1, komjath_not1",
-      "startLine": 80,
-      "endLine": 97,
+      "startLine": 81,
+      "endLine": 98,
       "mathContext": "Komjáth's theorem: if $|A_i \\cap A_j| \\neq 1$ for all $i \\neq j$, then $\\aleph_0$ colors suffice. Axiomatized here as `komjath_not1` since the proof requires deep set-theoretic arguments."
     },
     {
       "id": "bounds",
       "title": "Bounds and Special Cases",
       "summary": "lower_bound_2, countable_suffices (proved), CanDoBetterThanAleph0",
-      "startLine": 98,
-      "endLine": 147,
+      "startLine": 99,
+      "endLine": 171,
       "mathContext": "Known bounds: $2 \\leq C \\leq \\aleph_0$. The lower bound uses monochromaticity of infinite sets under 1-coloring. The upper bound (countable_suffices) is now PROVED for countable index sets: inject the countable union into $\\mathbb{N}$; the injection is non-constant on infinite sets. The open question: is $C$ finite or must it be $\\aleph_0$?"
     },
     {
       "id": "hypergraph",
       "title": "Hypergraph Perspective",
       "summary": "SetFamilyHypergraph, hypergraphChromatic, weakChromatic",
-      "startLine": 127,
-      "endLine": 147,
+      "startLine": 172,
+      "endLine": 192,
       "mathContext": "Reformulates the problem as the weak chromatic number of a hypergraph $H = (V, \\mathcal{E})$ where $V = \\bigcup A_i$ and $\\mathcal{E} = \\{A_i\\}$. Weak chromatic number = minimum colors to break monochromaticity (contrast with strong chromatic number requiring rainbow edges)."
     },
     {
       "id": "examples",
       "title": "Examples and Constructions",
       "summary": "disjoint_2_colors, SatisfiesBoth, both_constraints",
-      "startLine": 148,
-      "endLine": 170,
+      "startLine": 193,
+      "endLine": 249,
       "mathContext": "Disjoint families ($A_i \\cap A_j = \\emptyset$ for $i \\neq j$) need only 2 colors. Families satisfying both $\\neq 1$ and $\\neq 2$ constraints fall under Komjáth's theorem, giving $\\aleph_0$ as an upper bound."
     },
     {
       "id": "status",
       "title": "Problem Status",
       "summary": "erdos_603_status, erdos_603_statement",
-      "startLine": 171,
-      "endLine": 197
+      "startLine": 250,
+      "endLine": 272
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Known bounds, open questions",
-      "startLine": 198,
+      "startLine": 273,
       "endLine": 287
     }
   ],


### PR DESCRIPTION
## Summary
Sections 5–8 of the erdos-603 gallery entry (Hypergraph Perspective, Examples and Constructions, Problem Status, Summary) had drifted to incorrect line regions — "Hypergraph Perspective" pointed at lines 127–147 (inside Part 4's region, overlapping "Bounds and Special Cases") instead of its real location at Part 5 (172–192), and the remaining sections cascaded out of place. The file header (lines 1–27) was also uncovered.

Realigned all 8 sections contiguously against the Lean file's `# Part N` banners (lines 28/58/81/99/172/193/250/273) and folded the header into the first section. Section titles already mapped 1:1 to the Parts in order; only the line ranges changed.

## Changes
- `src/data/proofs/erdos-603/meta.json`: corrected `startLine`/`endLine` for all 8 sections. No content, count, or title changes.

## Test plan
- [x] JSON validates
- [x] Section ranges are contiguous and cover the full 287-line file
- [x] Section titles match `# Part N` banner titles in order