### PR TITLE
Enrich Moulton Plane counterexample: fix stale conjunction component count

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -86,7 +86,7 @@
         {
             "name": "moulton_counterexample",
             "type": "core",
-            "description": "The full Desargues-failure certificate as a single 21-component conjunction: three perspectivity-from-O facts (collinear_OAA', collinear_OBB', collinear_OCC'), eighteen incidence facts (P on AB/A'B', Q on BC/B'C', R on CA/C'A' with all six endpoint memberships), and desargues_fails. Term-mode anonymous-constructor proof. Packages the entire counterexample as one machine-checkable theorem statement asserting the negation of Desargues's theorem in the Moulton plane.",
+            "description": "The full Desargues-failure certificate as a single 22-component conjunction: three perspectivity-from-O facts (collinear_OAA', collinear_OBB', collinear_OCC'), eighteen incidence facts (P on AB/A'B', Q on BC/B'C', R on CA/C'A' with all six endpoint memberships), and desargues_fails. Term-mode anonymous-constructor proof. Packages the entire counterexample as one machine-checkable theorem statement asserting the negation of Desargues's theorem in the Moulton plane.",
             "leanType": "MoultonCollinear O_pt A_pt A'_pt ∧ MoultonCollinear O_pt B_pt B'_pt ∧ MoultonCollinear O_pt C_pt C'_pt ∧ … ∧ ¬ MoultonCollinear P_pt Q_pt R_pt",
             "line": 268,
             "endLine": 296


### PR DESCRIPTION
## Accuracy / enrichment pass — desargues-theorem-oq-01-oq-01

The entry is already deeply enriched (11 annotations, exhaustive historicalContext, deep keyInsights, detailed mainTheorems). One internal inconsistency remained.

### Problem
`mainTheorems[moulton_counterexample]` described it as a *"single 21-component conjunction"*, but its own breakdown — *three perspectivity facts + eighteen incidence facts + desargues_fails* — sums to **22**. Both `proofStrategy` (Stage 6) and the `sections` summary already say "22-component".

### Verification (`proofs/Proofs/DesarguesTheoremOQ01OQ01.lean`, lines 268-295)
The anonymous-constructor proof lists exactly 22 lemmas:
`collinear_OAA'`, `collinear_OBB'`, `collinear_OCC'` (3) + 18 incidence lemmas + `desargues_fails` (1) = **22**.

Also confirmed unchanged-and-correct: 297 lines, 0 axioms, 0 sorries, 30 theorems, 12 definitions (the apparent 13th `def` grep hit is the word "structure" inside a comment).

### Change
- `mainTheorems[moulton_counterexample]` description: "21-component" → "22-component".

No other content modified. JSON validates; data-pipeline prebuild parses cleanly.