### PR TITLE
Enrich cayley-hamilton-minpoly-oq-03-oq-02: section coverage (5→7) + annotation co-drift realign

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/annotations.json
@@ -175,13 +175,13 @@
     "id": "ann-layer-2-5-factor-count",
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-02",
     "range": {
-      "startLine": 181,
-      "endLine": 219
+      "startLine": 182,
+      "endLine": 267
     },
     "type": "insight",
-    "title": "Layer 2.5: popcount(j) ≤ j — The Factor-Count Bound",
-    "content": "The quantitative bound `squareKrylovProd_factor_count_le`: the number of squared-Krylov factors needed to assemble $M^j$ is at most $j$. The proof packages `Nat.twoPowSum_bitIndices` (sum of $2^i$ over bit-indices is $j$) with the elementary helper `length_le_twoPow_sum` (each term in the sum is at least $1$, so the count of terms bounds the sum) and finishes with `omega`. This bound is *loose* for large $j$ — the asymptotically sharp version is $\\mathrm{popcount}(j) \\leq \\mathrm{Nat.size}(j) \\approx \\lceil \\log_2(j+1) \\rceil$ — but it is the immediately verifiable elementary version, and combined with the $\\lceil \\log_2 j \\rceil + 1$ squaring count of Layer 1 it gives the structural source of the $O(\\log j)$ matrix-multiplication count of Keller-Gehrig's assembly step.",
-    "mathContext": "$\\mathrm{popcount}(j) = |\\mathrm{bitIndices}(j)| \\leq \\sum_{i \\in \\mathrm{bitIndices}(j)} 2^i = j$. The asymptotically correct bound is $\\mathrm{popcount}(j) \\leq \\lceil \\log_2(j+1) \\rceil$, but the elementary $\\leq j$ bound suffices to certify $O(\\log j)$ when combined with the Layer 1 squaring count.",
+    "title": "Layer 2.5: Matrix-Multiplication Factor-Count Bounds (popcount(j) ≤ j and ≤ Nat.size j)",
+    "content": "Two quantitative bounds on the number of squared-Krylov factors needed to assemble $M^j$. The elementary `squareKrylovProd_factor_count_le` gives $\\mathrm{popcount}(j) \\leq j$: package `Nat.twoPowSum_bitIndices` (sum of $2^i$ over bit-indices is $j$) with the helper `length_le_twoPow_sum` (each term is at least $1$, so the count of terms bounds the sum) and finish with `omega`. The sharper `squareKrylovProd_factor_count_le_size` (an S8 addition) gives the asymptotically tight $\\mathrm{popcount}(j) \\leq \\mathrm{Nat.size}(j) \\approx \\lceil \\log_2(j+1) \\rceil$: every set-bit index $i$ satisfies $2^i \\leq j$ (so $i < \\mathrm{Nat.size}\\,j$ via `Nat.lt_size`), and the `Nodup` bit-index list therefore embeds into `Finset.range (Nat.size j)`, bounding its length by that range's cardinality. Both are proved; combined with the $\\lceil \\log_2 j \\rceil + 1$ squaring count of Layer 1 they give the genuinely $O(\\log j)$ matrix-multiplication count of Keller-Gehrig's assembly step.",
+    "mathContext": "$\\mathrm{popcount}(j) = |\\mathrm{bitIndices}(j)| \\leq \\sum_{i \\in \\mathrm{bitIndices}(j)} 2^i = j$ (elementary), and the asymptotically tight $\\mathrm{popcount}(j) \\leq \\mathrm{Nat.size}(j) \\approx \\lceil \\log_2(j+1) \\rceil$ (via the Nodup bit-index list embedding into $\\mathrm{Finset.range}(\\mathrm{Nat.size}\\,j)$). Both certify the $O(\\log j)$ matrix-product count.",
     "significance": "supporting",
     "relatedConcepts": [
       "popcount (Hamming weight)",
@@ -201,8 +201,8 @@
     "id": "ann-layer-3-omega-axiomatized",
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-02",
     "range": {
-      "startLine": 221,
-      "endLine": 259
+      "startLine": 268,
+      "endLine": 307
     },
     "type": "context",
     "title": "Layer 3 Axiomatized: The Matrix-Multiplication Exponent ω",
@@ -228,13 +228,13 @@
     "id": "ann-end-summary",
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-02",
     "range": {
-      "startLine": 262,
-      "endLine": 333
+      "startLine": 309,
+      "endLine": 383
     },
     "type": "context",
-    "title": "Closing Summary: 11 Theorems, 0 Sorries, 3 Axioms",
-    "content": "The closing docstring inventories the file's contents: 11 theorems (3 Layer 1 + 4 Layer 2 matrix + 2 Layer 2 vector + 1 Layer 2.5 + 1 Layer 3 sanity), 0 sorries, 3 axioms (the Layer 3 $\\omega$ block). The structural / quantitative split is explicit: Layers 1, 2, 2.5 are unconditionally proved; the operation count is deferred. The end-of-file commentary also gives the Layer 2 proof sketch in plain English — `squareKrylov_eq_pow_two`, `prod_pow_of_list`, `Nat.twoPowSum_bitIndices` — which a reader can map onto the proof of `squareKrylovProd_eq_pow` to see how the three rewrites compose. This separation cleanly delineates Lean-formalisable structural mathematics (Layers 1+2), Lean-formalisable elementary quantitative bounds (Layer 2.5), and genuinely axiomatic mathematical constants (Layer 3 ω).",
-    "mathContext": "Inventory: $11$ theorems, $0$ sorries, $3$ axioms. The three axioms are all in the Layer 3 placeholder block; Layers 1, 2, and 2.5 are unconditional. The asymptotic Keller-Gehrig claim ($O(n^\\omega)$ field operations) is *deferred*, not asserted — the file ships only what current Mathlib infrastructure supports.",
+    "title": "Closing Summary: 12 Theorems, 0 Sorries, 3 Axioms",
+    "content": "The closing docstring inventories the file's contents: 12 theorems (3 Layer 1 + 4 Layer 2 matrix + 2 Layer 2 vector + 2 Layer 2.5 + 1 Layer 3 sanity), 0 sorries, 3 axioms (the Layer 3 $\\omega$ block). The structural / quantitative split is explicit: Layers 1, 2, 2.5 are unconditionally proved; the operation count is deferred. The end-of-file commentary also gives the Layer 2 proof sketch in plain English — `squareKrylov_eq_pow_two`, `prod_pow_of_list`, `Nat.twoPowSum_bitIndices` — which a reader can map onto the proof of `squareKrylovProd_eq_pow` to see how the three rewrites compose. This separation cleanly delineates Lean-formalisable structural mathematics (Layers 1+2), Lean-formalisable elementary quantitative bounds (Layer 2.5), and genuinely axiomatic mathematical constants (Layer 3 ω).",
+    "mathContext": "Inventory: $12$ theorems, $0$ sorries, $3$ axioms. The three axioms are all in the Layer 3 placeholder block; Layers 1, 2, and 2.5 are unconditional. The asymptotic Keller-Gehrig claim ($O(n^\\omega)$ field operations) is *deferred*, not asserted — the file ships only what current Mathlib infrastructure supports.",
     "significance": "context",
     "relatedConcepts": [
       "axiom integrity",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json
@@ -81,34 +81,42 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Keller-Gehrig and the Three-Layer Decomposition",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "File docstring, imports, and namespace setup. States the open question — can the O(n^ω) Keller-Gehrig (1985) characteristic-polynomial algorithm be formalised in Lean 4, extending the naive O(n³) Krylov framework (CayleyHamiltonMinpolyOQ03) to subcubic complexity? Lays out the three-layer decomposition: Layer 1 (structural squared-Krylov sequence T_k := M^(2^k)), Layer 2 (binary-expansion correctness M^j = ∏ T_i), and Layer 3 (the O(n^ω) operation count, out of scope and axiomatic pending a Mathlib complexity monad). Cites Keller-Gehrig, Giesbrecht-Storjohann, and Mathlib's Nat.bitIndices (Peter Nelson).",
+      "mathContext": "$T_k := M^{2^k}$ via repeated squaring; $M^j = \\prod_{i \\in \\mathrm{bitIndices}(j)} T_i$, so $\\lceil\\log_2 j\\rceil$ squarings plus $\\mathrm{popcount}(j)$ multiplications recover any Krylov power $M^j$."
+    },
+    {
       "id": "layer-1-squared-krylov",
       "title": "Layer 1: Squared-Krylov Sequence (Structural)",
       "startLine": 57,
-      "endLine": 89,
+      "endLine": 91,
       "summary": "Defines `squareKrylov M k` by repeated squaring (T_0 = M, T_{k+1} = T_k · T_k) and proves the bridge `squareKrylov M k = M^(2^k)`. The proof is a one-line induction using `congr 1 + ring` on the exponent identity 2^k + 2^k = 2^(k+1).",
       "mathContext": "$T_k := M^{2^k}$, $T_0 = M$, $T_{k+1} = T_k \\cdot T_k$. The bridge $T_k = M^{2^k}$ is the algebraic content of repeated squaring."
     },
     {
       "id": "layer-2-correctness-matrix",
       "title": "Layer 2: Correctness — Matrix-Level Binary Expansion",
-      "startLine": 91,
-      "endLine": 155,
+      "startLine": 92,
+      "endLine": 156,
       "summary": "Defines `squareKrylovProd M j` as the product of T_i over the set bits of j (the matrix the Keller-Gehrig outer loop assembles after `popcount(j)` multiplications) and proves the correctness bridge `M^j = ∏ T_i`. The proof factors through Mathlib's `Nat.twoPowSum_bitIndices`, the Layer 1 bridge, and the elementary fact that powers of a single matrix commute. Sanity checks at j = 0, 1, 2^k confirm the empty product, single-factor, and pure-power cases.",
       "mathContext": "$M^j = \\prod_{i \\in \\mathrm{bitIndices}(j)} T_i$. Combining `Nat.twoPowSum_bitIndices` ($\\sum_{i \\in \\mathrm{bitIndices}(j)} 2^i = j$) with Layer 1 gives $\\prod M^{2^i} = M^{\\sum 2^i} = M^j$."
     },
     {
       "id": "layer-2-correctness-vector",
       "title": "Layer 2 (Vector Form): Krylov Vectors via Squared-Krylov",
-      "startLine": 156,
-      "endLine": 179,
+      "startLine": 157,
+      "endLine": 181,
       "summary": "Lifts the matrix-level Layer 2 bridge to vectors: `(squareKrylovProd M j).mulVec v = (M^j).mulVec v`. Provides the reachability corollary `krylov_in_squareKrylov_range` showing every Krylov vector $M^j v$ lies in the image of the squared-Krylov product matrix-vector map. These bridge the Keller-Gehrig matrix arithmetic into the OQ-03 matvec ladder.",
       "mathContext": "$(\\prod_{i \\in \\mathrm{bitIndices}(j)} T_i) \\cdot v = M^j v$. The Keller-Gehrig pass produces each Krylov vector by a single matrix-vector product against the squared-Krylov product matrix (assembled from $\\mathrm{popcount}(j)$ matrix multiplications)."
     },
     {
       "id": "layer-2-5-factor-count",
       "title": "Layer 2.5: Matrix-Multiplication Factor-Count Bound",
-      "startLine": 181,
-      "endLine": 266,
+      "startLine": 182,
+      "endLine": 267,
       "summary": "Two bounds on the number of squared-Krylov factors needed to assemble M^j. The elementary `squareKrylovProd_factor_count_le` gives `popcount(j) ≤ j` via `Nat.twoPowSum_bitIndices` + the lemma `length(L) ≤ ∑ 2^L`. The sharper `squareKrylovProd_factor_count_le_size` gives the asymptotically tight `popcount(j) ≤ Nat.size(j) ≈ ⌈log₂(j+1)⌉`: every set-bit index i satisfies 2^i ≤ j (so i < Nat.size j by `Nat.lt_size`), and the Nodup bit-index list therefore embeds into `Finset.range (Nat.size j)`, bounding its length by that range's cardinality. This is the genuinely logarithmic factor count promised by the Keller-Gehrig analysis.",
       "mathContext": "$\\mathrm{popcount}(j) = |\\mathrm{bitIndices}(j)| \\leq j$. Combined with Layer 1's $\\lceil \\log_2 j \\rceil + 1$ squarings, the total matrix-multiplication count for $M^j$ is $O(\\log j)$ — the structural source of the Keller-Gehrig speed-up."
     },
@@ -116,9 +124,17 @@
       "id": "layer-3-omega-axiomatized",
       "title": "Layer 3 (Axiomatized): The Matrix-Multiplication Exponent ω",
       "startLine": 268,
-      "endLine": 306,
+      "endLine": 308,
       "summary": "Three axioms declare the matrix-multiplication exponent ω with its known bounds: `omegaMM : ℝ` (the exponent itself), `omegaMM_two_le : 2 ≤ ω` (folklore lower bound), and `omegaMM_lt_three : ω < 3` (Strassen 1969 upper bound). The corollary `omegaMM_mem_Ico` packages the two-sided bound for convenient chaining. The full O(n^ω) operation-count theorem is deferred pending Mathlib growing a complexity monad and a fast-matmul oracle — neither of which exists today.",
       "mathContext": "$\\omega \\in [2, 3)$ is the matrix-multiplication exponent: the infimum of $\\alpha$ such that two $n \\times n$ matrices can be multiplied in $O(n^\\alpha)$ field operations. Currently $2 \\leq \\omega < 2.371552$ (Williams-Xu-Xu-Zhou 2024); $\\omega = 2$ is unknown."
+    },
+    {
+      "id": "closing-summary",
+      "title": "Closing Summary: Per-Layer Theorem Inventory",
+      "startLine": 309,
+      "endLine": 383,
+      "summary": "Closing summary docstring. Recaps the problem (Layers 1 + 2 of cayley-hamilton-minpoly-oq-03-oq-02), the completion status (12 theorems, 0 sorries, 3 axioms), and a per-layer theorem inventory: Layer 1 (squareKrylov_zero/succ/eq_pow_two), Layer 2 matrix-level (squareKrylovProd + the eq_pow bridge + three sanity checks), Layer 2 vector form (mulVec corollary + krylov reachability), Layer 2.5 factor-count bounds (the elementary ≤ j and the asymptotically tight ≤ Nat.size j), and the Layer 3 axiomatized ω placeholder (3 axioms + the two-sided sanity corollary). Closes with the structural-speedup key insight and a plain-English Layer 2 proof sketch.",
+      "mathContext": "Inventory: 12 theorems, 0 sorries, 3 axioms. Factor count $\\mathrm{popcount}(j) = |\\mathrm{bitIndices}(j)| \\leq \\mathrm{Nat.size}(j) \\approx \\lceil \\log_2(j+1) \\rceil$ — the logarithmic matrix-multiplication count behind the Keller-Gehrig speed-up."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
Enrichment pass for `cayley-hamilton-minpoly-oq-03-oq-02` (squared-Krylov / Keller-Gehrig subcubic characteristic-polynomial algorithm).

The meta and annotation prose are already high quality and accurate (axiomatized; 3 ω axioms; 0 sorries). This pass fixes coverage drift introduced as the file grew (S5/S8 additions):

**Sections (5 → 7):** the section ranges left the header docstring (lines 1–56) and the closing `## Summary` docstring (309–383) uncovered, and had 1-line gaps at the `-- ===` banner boundaries. Added an "Overview" section and a "Closing Summary" section, and realigned all boundaries so sections are contiguous over the full file (1–383) with no gaps or overlaps.

**Annotations (co-drift):** the last three annotations had drifted off their constructs after the file grew:
- *Layer 2.5* (181–219 → 182–267): now covers both factor-count theorems, including the S8 `squareKrylovProd_factor_count_le_size` (the asymptotically tight `popcount(j) ≤ Nat.size j` bound); content updated to state both bounds are proved (it previously read as if only the loose `≤ j` bound existed).
- *Layer 3 ω* (221–259 → 268–307): realigned to the actual Layer 3 banner block.
- *Closing Summary* (262–333 → 309–383): realigned, and the stale "11 theorems / 1 Layer 2.5" inventory corrected to "12 theorems / 2 Layer 2.5" to match `meta.theoremCount`.

No Lean source changes. JSON validated; both files round-trip byte-clean (indent=2 + trailing newline).