### PR TITLE
research(continuum-hypothesis-oq-02): realign gallery sections to full file (7→8)

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -99,58 +99,66 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: What ZFC Can and Cannot Decide About the Continuum",
+      "summary": "Module docstring and namespace setup: frames the continuum problem beyond Cohen's independence result — ZFC does constrain 2^ℵ₀ (it must be an uncountable regular cardinal, by König's theorem) — and previews Easton's theorem, Shelah's pcf theory, the cardinal characteristics of the continuum, and Martin's Axiom.",
+      "startLine": 1,
+      "endLine": 68,
+      "mathContext": "The header imports Mathlib's cardinal/ordinal/cofinality APIs and opens the `Cardinal` and `ContinuumHypothesis` namespaces. The docstring explains that while Cohen proved CH independent of ZFC, the value of the continuum 2^ℵ₀ is not arbitrary: by König's theorem its cofinality must exceed ℵ₀, so it cannot equal ℵ_ω. Easton's theorem (1970) shows exponentiation at regular cardinals is otherwise unconstrained, while Shelah's pcf theory imposes bounds at singular cardinals. The file formalizes these constraints and the cardinal characteristics (bounding/dominating numbers, Martin's Axiom) that further pin down the continuum's behavior."
+    },
+    {
       "id": "regular-singular",
       "title": "Regular and Singular Cardinals",
-      "startLine": 57,
-      "endLine": 119,
+      "startLine": 69,
+      "endLine": 133,
       "summary": "Establishes the regular/singular dichotomy using Mathlib. aleph_1 is regular (successor), aleph_omega is singular (countable cofinality).",
       "mathContext": "A cardinal $\\kappa$ is **regular** if $\\text{cf}(\\kappa) = \\kappa$. All successor cardinals $\\aleph_{\\alpha+1}$ are regular. $\\aleph_\\omega = \\sup\\{\\aleph_n : n < \\omega\\}$ is the first singular infinite cardinal."
     },
     {
       "id": "konig-constraint",
       "title": "Konig's Cofinality Constraint",
-      "startLine": 121,
-      "endLine": 166,
+      "startLine": 134,
+      "endLine": 184,
       "summary": "Konig's theorem constrains the continuum: cf(2^aleph_0) > aleph_0. This rules out 2^aleph_0 = aleph_omega and all singular values.",
       "mathContext": "**Konig's Theorem**: If $\\kappa_i < \\lambda_i$ for all $i \\in I$, then $\\sum_{i \\in I} \\kappa_i < \\prod_{i \\in I} \\lambda_i$. Corollary: $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$, so $2^{\\aleph_0} \\neq \\aleph_\\omega$."
     },
     {
       "id": "easton-spectrum",
       "title": "Easton's Theorem: The Spectrum of Possible Values",
-      "startLine": 168,
-      "endLine": 236,
+      "startLine": 185,
+      "endLine": 262,
       "summary": "IsPossibleContinuumValue characterizes the spectrum. Easton: any regular kappa >= aleph_1 is consistent. Successor alephs are all possible; aleph_omega is not.",
       "mathContext": "**Easton's Theorem** (1970): For any function $F$ from regular cardinals to cardinals satisfying $\\kappa \\leq \\text{cf}(F(\\kappa))$ and $\\kappa < \\lambda \\Rightarrow F(\\kappa) \\leq F(\\lambda)$, there is a model of ZFC where $2^\\kappa = F(\\kappa)$. For $\\kappa = \\aleph_0$, this means any regular $\\lambda \\geq \\aleph_1$ is achievable."
     },
     {
       "id": "cardinal-characteristics",
       "title": "Cardinal Characteristics of the Continuum",
-      "startLine": 238,
-      "endLine": 330,
+      "startLine": 263,
+      "endLine": 405,
       "summary": "Defines bounding number b and dominating number d. Proves the chain aleph_1 <= b <= d <= 2^aleph_0 and that CH collapses all to aleph_1.",
       "mathContext": "The **bounding number** $\\mathfrak{b}$ and **dominating number** $\\mathfrak{d}$ are defined via the eventual domination preorder $\\leq^*$ on $\\omega^\\omega$. ZFC proves $\\aleph_1 \\leq \\mathfrak{b} \\leq \\mathfrak{d} \\leq 2^{\\aleph_0}$. Under CH, $\\mathfrak{b} = \\mathfrak{d} = \\aleph_1$."
     },
     {
       "id": "martins-axiom",
       "title": "Martin's Axiom and the Continuum",
-      "startLine": 332,
-      "endLine": 382,
+      "startLine": 406,
+      "endLine": 460,
       "summary": "Martin's Axiom collapses b and d to 2^aleph_0. Under MA + not-CH, all characteristics are maximal.",
       "mathContext": "**Martin's Axiom**: For any ccc poset $P$ and $< 2^{\\aleph_0}$ dense sets, a generic filter exists. MA + $\\neg$CH implies $\\mathfrak{b} = \\mathfrak{d} = 2^{\\aleph_0}$. MA + $2^{\\aleph_0} = \\aleph_2$ is equiconsistent with ZFC."
     },
     {
       "id": "three-scenarios",
       "title": "Three Scenarios for the Continuum",
-      "startLine": 384,
-      "endLine": 425,
+      "startLine": 461,
+      "endLine": 498,
       "summary": "CH gives aleph_1, PFA gives aleph_2, Easton allows aleph_3 and beyond. All are regular (Konig-consistent).",
       "mathContext": "Three scenarios: (1) $2^{\\aleph_0} = \\aleph_1$ (CH, V=L), (2) $2^{\\aleph_0} = \\aleph_2$ (PFA, MM), (3) $2^{\\aleph_0} > \\aleph_2$ (exotic, no known natural axiom). Most set theorists favor scenario (2)."
     },
     {
       "id": "complete-picture",
       "title": "The Complete Picture",
-      "startLine": 427,
-      "endLine": 526,
+      "startLine": 499,
+      "endLine": 584,
       "summary": "Easton-Konig characterization: the possible continuum values are exactly the regular uncountable cardinals. The 'true' value remains the deepest open question in foundations.",
       "mathContext": "The ZFC constraints are: $\\aleph_1 \\leq 2^{\\aleph_0}$ and $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$. These are sharp: Easton showed any regular uncountable cardinal is achievable. Between $\\aleph_1$ and $2^{\\aleph_0}$, cardinal characteristics provide intermediate invariants."
     }


### PR DESCRIPTION
## Summary
The seven section titles for `continuum-hypothesis-oq-02` map 1:1 to the file's `-- PART N` divider boxes, but their line ranges had drifted early and compressed. This left two regions uncovered:
- **Header (1-68)**: module docstring + imports + namespace setup
- **Tail (527-584)**: PART 7's `the_open_question` theorem, the exported `#check`s, and the closing `end` namespace

Several middle sections also stopped well before their PART's next divider (e.g. "Cardinal Characteristics" ended at 330 although PART 4 runs to 405).

## Changes
- Added an `overview` section (1-68).
- Re-ranged the seven existing sections to their `-- ===` divider boundaries (69, 134, 185, 263, 406, 461, 499) and extended PART 7 to file end, giving 8 fully contiguous sections covering the entire 584-line file with no gaps or overlaps.
- All existing `summary`/`mathContext` text preserved verbatim.

No Lean source changed; counts unaffected. Build-free metadata realignment.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections contiguous 1→584, zero gaps/overlaps
- [x] Each section's range matches the `-- PART N` divider its title describes