### PR TITLE
research(puiseux-theorem): realign drifted gallery sections to full file (7→9)

### DIFF
--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview — Puiseux's Theorem (Wiedijk #41)",
+      "startLine": 1,
+      "endLine": 100,
+      "summary": "Imports, file docstring, and namespace setup: states Puiseux's theorem (the field of Puiseux series is algebraically closed in characteristic 0), summarizes what the file contains, and opens the PuiseuxTheorem namespace.",
+      "mathContext": "Puiseux's theorem (Wiedijk #41) states that the field of Puiseux series $K\\{\\{x\\}\\}$ — formal series in fractional powers of $x$ — is algebraically closed whenever $K$ is algebraically closed of characteristic 0. This file surveys the conceptual definition, the closure theorem, the Newton-Puiseux algorithm, Galois theory, applications, and worked examples."
+    },
+    {
       "id": "puiseux-series",
       "title": "Puiseux Series via Hahn Series",
       "startLine": 101,
@@ -86,50 +94,58 @@
     {
       "id": "algebraic-closure",
       "title": "Algebraic Closure Theorem",
-      "startLine": 160,
-      "endLine": 204,
+      "startLine": 144,
+      "endLine": 206,
       "summary": "Main theorem axiomatized: K{{x}} is algebraically closed when K is algebraically closed of characteristic 0.",
       "mathContext": "The main theorem (Puiseux, 1850): the field of Puiseux series $K\\{\\{x\\}\\}$ is algebraically closed when $K$ is algebraically closed of characteristic 0. Equivalently, every polynomial over $K((x))$ (Laurent series) splits in $K\\{\\{x\\}\\}$. This is the function-field analogue of the fundamental theorem of algebra."
     },
     {
       "id": "newton-polygon",
       "title": "Newton-Puiseux Algorithm",
-      "startLine": 205,
-      "endLine": 261,
+      "startLine": 207,
+      "endLine": 264,
       "summary": "The constructive root-finding algorithm: Newton polygon → edge slopes → characteristic polynomial → substitution → recurse.",
       "mathContext": "Newton's polygon method: given $f(x, y) = \\sum a_{ij} x^i y^j$, plot the support $\\{(i,j) : a_{ij} \\neq 0\\}$ and take the lower convex hull. Each edge of slope $-p/q$ yields a term $y \\sim c \\cdot x^{p/q}$ in the Puiseux expansion. Iterating gives the full series."
     },
     {
       "id": "applications",
       "title": "Applications: Singularities and Tropical Geometry",
-      "startLine": 269,
-      "endLine": 314,
+      "startLine": 265,
+      "endLine": 317,
       "summary": "Resolution of curve singularities via Puiseux parameterization; connection to tropical geometry through Newton polygon slopes.",
       "mathContext": "Applications: resolution of algebraic curve singularities via Puiseux parameterization ($y = \\sum a_n t^{n/d}$, $x = t^e$), tropical geometry (Newton polygons as tropical curves), and ramification theory in algebraic geometry."
     },
     {
       "id": "galois-theory",
       "title": "Galois Group: Profinite Integers",
-      "startLine": 322,
-      "endLine": 344,
+      "startLine": 318,
+      "endLine": 347,
       "summary": "Gal(K{{x}}/K((x))) ≅ Ẑ acts by x^{1/n} ↦ ζₙ · x^{1/n}; key example in infinite Galois theory.",
       "mathContext": "The Galois group $\\text{Gal}(K\\{\\{x\\}\\}/K((x))) \\cong \\hat{\\mathbb{Z}}$ acts by $x^{1/n} \\mapsto \\zeta_n \\cdot x^{1/n}$, where $\\hat{\\mathbb{Z}} = \\varprojlim \\mathbb{Z}/n\\mathbb{Z}$ is the profinite completion of $\\mathbb{Z}$. This is a key example in infinite Galois theory."
     },
     {
       "id": "calculations",
       "title": "Concrete Calculations",
-      "startLine": 352,
-      "endLine": 398,
+      "startLine": 348,
+      "endLine": 400,
       "summary": "Worked examples: Y² = x (square root), Y² = x³ (cusp), Y³ = x (cube root) with Newton polygon analysis.",
       "mathContext": "Worked examples: $y^2 = x$ gives $y = x^{1/2}$ (Newton polygon has slope $-1/2$); $y^2 = x^3$ (cusp) gives $y = x^{3/2}$; $y^3 = x$ gives $y = x^{1/3}$. Each demonstrates the Newton polygon algorithm and the fractional power expansion."
     },
     {
       "id": "connections",
       "title": "Connections: Hensel's Lemma and Characteristic Zero",
-      "startLine": 399,
-      "endLine": 469,
+      "startLine": 401,
+      "endLine": 448,
       "summary": "p-adic analogy via Hensel's lemma; failure in characteristic p demonstrated by Artin-Schreier counterexample.",
       "mathContext": "The $p$-adic analogy: Hensel's lemma plays the same role for $p$-adic completions $\\mathbb{Q}_p$ that Puiseux's theorem plays for $K((x))$ — both lift approximate roots to exact roots. In characteristic $p > 0$, Puiseux's theorem fails: the Artin-Schreier equation $y^p - y = x^{-1}$ has no solution in $\\overline{\\mathbb{F}_p}\\{\\{x\\}\\}$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 449,
+      "endLine": 471,
+      "summary": "Recap of the key results — Puiseux's theorem, the Newton-Puiseux algorithm, the Galois group Ẑ, and applications — and the theorem's significance bridging algebra, analysis, and geometry.",
+      "mathContext": "Puiseux's theorem bridges algebra (algebraic closure, Galois theory with $\\text{Gal} \\cong \\hat{\\mathbb{Z}}$), analysis (convergent local expansions), and geometry (resolution of singularities, branch points), making it a foundational result for the local study of algebraic curves."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The 7 gallery sections for `puiseux-theorem` had drifted ~15 lines past their `PART` banners, leaving two regions uncovered and one section over-broad:
- **Header docstring (lines 1-100)** — imports, the Wiedijk #41 docstring, and the namespace open — was uncovered.
- **PART VIII: SUMMARY (lines 449-471)** was uncovered.
- The last section lumped **PART VII (Connections)** and **PART VIII (Summary)** together.

## Changes
- Realigned all section `startLine`/`endLine` to the file's 8 `PART` banners.
- Added an **Overview** section (1-100) for the header.
- Split the over-broad **Connections** section into **Connections** (401-448) and a new **Summary** (449-471).
- Result: 9 contiguous sections covering the full file (1-471). No Lean source, theorem/axiom/def counts, or prose claims changed — section ranges only.

## Verification
- `meta.json` parses as valid JSON.
- Sections verified contiguous (no gaps/overlaps) and covering exactly 1-471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)