### PR TITLE
research(erdos-1017): realign drifted gallery sections (5→11)

### DIFF
--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -54,44 +54,92 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Core Definitions: Clique Partition and Turan Bound",
-      "startLine": 65,
-      "endLine": 140,
-      "summary": "Defines the clique partition number cp(G), usesOnlyEdgesAndTriangles, and the Turan bound floor(n²/4). Proves turanBound is monotone, has explicit small values (0,0,1,2,4 for n=0..4), and equals (n/2)·(n-n/2).",
-      "mathContext": "cp(G) = min\\{|P| : P is an edge-clique partition of G\\}. Turan bound: $\\lfloor n^2/4 \\rfloor = (n/2)(n - n/2)$. The EGP theorem states cp(G) ≤ ⌊n²/4⌋ for every n-vertex graph G."
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports (Mathlib SimpleGraph, Fintype, Tactic), the module docstring stating Erdős Problem #1017 (minimum number of cliques needed to partition a graph's edge set) and the axiom-reduction history (9 axioms reduced to 2), and the ambient graph variable context (V a finite type with decidable equality).",
+      "mathContext": "Erdős Problem #1017: determine $f(n,k)$, the minimum number of cliques to partition the edges of any $n$-vertex, $k$-edge graph. EGP (1966): $f \\leq \\lfloor n^2/4\\rfloor$."
     },
     {
-      "id": "egp-theorem",
-      "title": "Erdős-Goodman-Pósa Theorem and Tight Example",
-      "startLine": 142,
-      "endLine": 260,
-      "summary": "Axiomatizes egp_theorem (cp(G) ≤ ⌊n²/4⌋), proves cliquePartitionNum_le_turan as a corollary, constructs the extremal complete bipartite graph K_{k,k} (proved triangle-free with exactly k² edges), and proves egp_tight_example (cp(K_{k,k}) = k² = ⌊(2k)²/4⌋).",
-      "mathContext": "EGP (1966): $cp(G) \\leq \\lfloor n^2/4 \\rfloor$ for every graph. Extremal: $K_{k,k}$ achieves equality ($cp(K_{k,k}) = k^2 = \\lfloor(2k)^2/4\\rfloor$). The bipartite graph is triangle-free, so every clique has $\\leq 2$ vertices, forcing one clique per edge."
+      "id": "part1-framework",
+      "title": "Part I: Edge Clique Partition Framework",
+      "startLine": 61,
+      "endLine": 88,
+      "summary": "Defines the `EdgeCliquePartition` structure (a collection of cliques whose edges partition G's edge set, each edge in exactly one clique), the clique partition number `cliquePartitionNum` cp(G), and the predicate `usesOnlyEdgesAndTriangles`.",
+      "mathContext": "cp(G) = min\\{|P| : P is an edge-clique partition of G\\}."
     },
     {
-      "id": "triangle-free",
-      "title": "Triangle-Free Graphs: cp(G) = |E|",
-      "startLine": 296,
-      "endLine": 460,
-      "summary": "Proves that triangle-free graphs satisfy cp(G) = |E|: every clique has ≤ 2 vertices, so each clique covers exactly one edge. Key proof: constructs an edge-by-edge partition (one 2-vertex clique per edge) showing cp ≤ |E|, and the lower bound cp ≥ |E| via clique counting.",
-      "mathContext": "For triangle-free G: cp(G) = |E(G)|. Upper bound: partition into singleton edges. Lower bound: each clique covers $\\leq 1$ edge (since any 2-vertex clique is just an edge, and 3-vertex cliques are triangles which are excluded). Turan's theorem: dense graphs (|E| > ⌊n²/4⌋) must contain a triangle."
+      "id": "part2-turan-bound",
+      "title": "Part II: Turán Number and ⌊n²/4⌋",
+      "startLine": 89,
+      "endLine": 137,
+      "summary": "Defines `turanBound n = ⌊n²/4⌋` and proves its basic arithmetic: explicit small values (0,0,1,2,4 for n=0..4), monotonicity (`turanBound_mono`), the product form `turanBound_eq_product` (⌊n²/4⌋ = (n/2)(n − n/2)), and positivity `turanBound_pos` for n ≥ 2.",
+      "mathContext": "Turán bound: $\\lfloor n^2/4 \\rfloor = (n/2)(n - n/2)$, the EGP upper bound on cp(G)."
     },
     {
-      "id": "k4-free-improvement",
-      "title": "K₄-Free Graphs and Gyori-Keszegh Improvement",
-      "startLine": 462,
-      "endLine": 600,
-      "summary": "States the open question erdos1017_question, proves savings formulas for larger cliques (K_r saves r(r-1)/2 - 1 over individual edges), and axiomatizes the Gyori-Keszegh theorem (2017): K₄-free graphs with ⌊n²/4⌋ + m edges have m edge-disjoint triangles, giving cp(G) = ⌊n²/4⌋ - m.",
-      "mathContext": "Savings: $K_r$ reduces the partition count by $\\binom{r}{2} - 1$ vs using $\\binom{r}{2}$ individual edges. $K_4$ saves 5, $K_5$ saves 9. Gyori-Keszegh (2017): $K_4$-free dense graphs satisfy $cp(G) = \\lfloor n^2/4\\rfloor - m$ where $m$ = edge surplus above $\\lfloor n^2/4\\rfloor$."
+      "id": "part3-egp",
+      "title": "Part III: Erdős-Goodman-Pósa Theorem (1966)",
+      "startLine": 138,
+      "endLine": 162,
+      "summary": "Axiomatizes `egp_theorem` (every graph satisfies cp(G) ≤ ⌊n²/4⌋) and derives the corollary `cliquePartitionNum_le_turan`.",
+      "mathContext": "EGP (1966): $cp(G) \\leq \\lfloor n^2/4 \\rfloor$ for every graph G on n vertices."
     },
     {
-      "id": "remaining-bounds",
-      "title": "Open Question Formalization and Trivial Bounds",
-      "startLine": 601,
+      "id": "part4-extremal-bipartite",
+      "title": "Part IV: Extremal Example — Complete Bipartite Graph",
+      "startLine": 163,
+      "endLine": 457,
+      "summary": "Constructs the extremal complete bipartite graph K_{a,b} (`completeBipartite` with its decidable adjacency instance), proves it is triangle-free (`completeBipartite_cliqueFree`) with exactly a·b edges (`completeBipartite_edgeCount`), establishes `triangleFree_cliquePartition_eq_edges` (cp(G) = |E| for triangle-free G, via one 2-vertex clique per edge for the upper bound and clique counting for the lower bound), and concludes `egp_tight_example`/`egp_tight_matches_turan`: K_{k,k} attains cp = k² = ⌊(2k)²/4⌋, so the EGP bound is tight.",
+      "mathContext": "Extremal: $K_{k,k}$ achieves equality $cp(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor$. For triangle-free G, $cp(G) = |E(G)|$."
+    },
+    {
+      "id": "part5-open-question",
+      "title": "Part V: The Open Question — Dense Graphs with Large Cliques",
+      "startLine": 458,
+      "endLine": 513,
+      "summary": "Defines `isDense` and proves `dense_contains_triangle`; formalizes the open question `erdos1017_question` (is there c ∈ (0,1) with cp(G) ≤ c·⌊n²/4⌋ for all sufficiently dense graphs?) and proves the clique-savings arithmetic (`triangle_saves` = 2, `k4_saves` = 5, `k5_saves` = 9, `k4_saves_more_than_triangle`, `clique_savings`, `savings_growth`), quantifying how a K_r saves ⌊r(r−1)/2⌋ − 1 over using individual edges.",
+      "mathContext": "Open question: can $\\lfloor n^2/4\\rfloor$ be improved to $c\\lfloor n^2/4\\rfloor$, $c<1$, for dense graphs? A $K_r$ saves $\\binom{r}{2}-1$ cliques."
+    },
+    {
+      "id": "part6-k4free",
+      "title": "Part VI: K₄-Free Case — Győri-Keszegh (2017)",
+      "startLine": 514,
+      "endLine": 563,
+      "summary": "Axiomatizes `k4free_partition_number` (Győri-Keszegh 2017: a K₄-free graph with ⌊n²/4⌋ + m edges has m edge-disjoint triangles, so cp(G) = ⌊n²/4⌋ − m) and derives `k4free_improves` and `k4free_savings_linear` — the resolved K₄-free instance of the open question.",
+      "mathContext": "Győri-Keszegh (2017): for K₄-free G with $\\lfloor n^2/4\\rfloor + m$ edges, $cp(G) = \\lfloor n^2/4\\rfloor - m$."
+    },
+    {
+      "id": "part7-lovasz",
+      "title": "Part VII: Lovász Covering Bound (1968)",
+      "startLine": 564,
+      "endLine": 579,
+      "summary": "Proves `lovasz_covering`, the Lovász (1968) edge-covering bound for clique partitions.",
+      "mathContext": "Lovász (1968) covering bound for edge clique partitions."
+    },
+    {
+      "id": "part8-connections",
+      "title": "Part VIII: Connections and Consequences",
+      "startLine": 580,
+      "endLine": 609,
+      "summary": "Proves `cliquePartition_le_vertices` (cp(G) ≤ |V|) and `supersaturation_triangles`, linking edge surplus over the Turán threshold to forced triangles.",
+      "mathContext": "cp(G) $\\leq$ |V|; supersaturation forces triangles past the Turán edge count."
+    },
+    {
+      "id": "part9-additional",
+      "title": "Part IX: Additional Proved Results",
+      "startLine": 610,
+      "endLine": 647,
+      "summary": "Further lemmas: `k4free_double_savings`, `turanBound_succ_diff` (the increment ⌊(n+1)²/4⌋ − ⌊n²/4⌋), `turanBound_le_choose_two` (⌊n²/4⌋ ≤ C(n,2)), and `triangle_free_not_dense`.",
+      "mathContext": "Auxiliary bounds: Turán increments, $\\lfloor n^2/4\\rfloor \\leq \\binom{n}{2}$, triangle-free graphs are not dense."
+    },
+    {
+      "id": "part10-verification",
+      "title": "Part X: Verification",
+      "startLine": 648,
       "endLine": 696,
-      "summary": "Proves trivial bounds (lovasz_covering, supersaturation_triangles, cliquePartition_le_vertices) and formalizes the open question: is there c ∈ (0,1) such that cp(G) ≤ c·⌊n²/4⌋ for all sufficiently dense graphs? The 3 remaining axioms (egp_theorem, gyori_keszegh_triangles, k4free_partition_number) are listed.",
-      "mathContext": "The open question asks whether the EGP bound $\\lfloor n^2/4\\rfloor$ can be improved to $c\\lfloor n^2/4\\rfloor$ for $c < 1$ when the graph is sufficiently dense (contains large cliques). Gyori-Keszegh shows $c$ can be improved for $K_4$-free dense graphs; the general case is open."
+      "summary": "`#check` commands confirming all main definitions, theorems, and the two remaining axioms (`egp_theorem`, `k4free_partition_number`) type-check; closes the namespace.",
+      "mathContext": "Type-check verification of all definitions, theorems, and the 2 remaining axioms."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery `meta.json` for **erdos-1017** (Erdős Problem #1017, clique partition of graphs) had drifted: its 5 `sections` no longer matched the Lean file's `PART I`–`PART X` banner structure.

Problems in the old meta:
- A section started at line 296 with **no corresponding banner**.
- Parts **VII (Lovász Covering Bound)**, **VIII (Connections)**, **IX (Additional Results)**, and **X (Verification)** were lumped together or omitted.
- The module header (lines 1–60) and a **35-line interior gap (261–295)** were uncovered.

## Changes
- Rebuilt **11 contiguous sections** (header + Parts I–X) aligned to the file's 10 `PART N:` banners, covering all 696 lines with no gaps or overlaps.
- Wrote accurate per-part summaries drawn from each section's actual declarations (e.g. `EdgeCliquePartition`, `turanBound`, `egp_theorem`, `completeBipartite`, `k4free_partition_number`, `lovasz_covering`).

Content-only change to gallery metadata; the Lean proof file is unchanged (0 sorries, 2 axioms, 37 theorems).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections are contiguous (1→696) and each aligns to a `PART N:` banner
- [x] Axiom/theorem counts unchanged