### PR TITLE
research(erdos-102): realign gallery sections to file banners (8→6)

### DIFF
--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -73,68 +73,52 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "startLine": 19,
+      "id": "header",
+      "title": "Header, Imports and Setup",
+      "startLine": 1,
       "endLine": 22,
-      "summary": "Imports `Finset.Card` for finite set cardinality, `Data.Nat.Basic` for natural number arithmetic, and `Tactic` for general proof automation.",
-      "mathContext": "Verified: Imports `Finset.Card` for finite set cardinality, `Data.Nat.Basic` for natural number arithmetic, and `Tactic` for general proof automation."
+      "summary": "States Erdős Problem #102: given $n$ points in $\\mathbb{R}^2$ with $\\geq cn^2$ lines each containing $\\geq4$ points, let $h_c(n)$ be the max points on a line. Estimate $h_c(n)$; does $h_c(n)\\to\\infty$? Known: $h_c(n)\\ll_c\\sqrt n$; Erdős conjectured $\\gg_c\\sqrt n$ but Hunter disproved it ($\\ll n^{1/\\log(1/c)}$); $h_c\\to\\infty$ open (linked to #101). Imports `Finset`/`Nat`/tactics.",
+      "mathContext": "$cn^2$ 4-rich lines $\\Rightarrow$ max-collinear $h_c(n)$; is $h_c(n)\\to\\infty$? $h_c(n)\\ll_c\\sqrt n$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 23,
       "endLine": 45,
-      "summary": "Defines `PointConfig` (a finset of $\\mathbb{R}^2$ points with positive cardinality), `collinear₃` via the cross-product determinant, `richLineCount` counting 4-element collinear subsets, and `maxCollinear` as the supremum of collinear subset sizes.",
-      "mathContext": "Defines `PointConfig` (a finset of $\\mathbb{R}^2$ points with positive cardinality), `collinear₃` via the cross-product determinant, `richLineCount` counting 4-element collinear subsets, and `maxCollinear` as the supremum of collinear subset sizes."
+      "summary": "Defines `PointConfig` (a nonempty finite planar point set), `collinear₃` (three-point collinearity via the cross-product), `richLineCount` (number of 4-point collinear lines), and `maxCollinear` (max collinear subset size).",
+      "mathContext": "`collinear₃ p q r`: $(q_1-p_1)(r_2-p_2)=(r_1-p_1)(q_2-p_2)$; `richLineCount`, `maxCollinear`."
     },
     {
       "id": "main-problem",
-      "title": "Main Problem: Divergence of $h_c(n)$",
+      "title": "Main Problem",
       "startLine": 46,
-      "endLine": 55,
-      "summary": "Documents in source comments the central open question: for fixed $c > 0$, given $cn^2$ rich lines, $\\max$-collinear $\\to \\infty$ with $n$. No Lean axiom declaration exists for this statement; the only axiom in the file is `connection_101`.",
-      "mathContext": "Documents in source comments `erdos_102_divergence` (no Lean declaration exists): for fixed $c > 0$, given $cn^2$ rich lines, $\\max$-collinear $\\to \\infty$ with $n$. This is the central open question. The only axiom in the file is `connection_101`."
+      "endLine": 49,
+      "summary": "States the open question (as documentation): $h_c(n)\\to\\infty$ — if $cn^2$ lines contain $\\geq4$ points, some line must contain many (growing) points.",
+      "mathContext": "Open: $h_c(n)\\to\\infty$ for fixed $c>0$."
     },
     {
-      "id": "upper-bound",
-      "title": "Upper Bound: $h_c(n) \\le C\\sqrt{n}$",
-      "startLine": 56,
-      "endLine": 64,
-      "summary": "Axiomatizes the $O(\\sqrt{n})$ upper bound on maximum collinear count, derived from the Szemerédi–Trotter incidence theorem.",
-      "mathContext": "Axiomatizes the $$O(\\sqrt{n})$$ upper bound on maximum collinear count, derived from the Szemerédi–Trotter incidence theorem."
+      "id": "collinearity",
+      "title": "Collinearity Properties",
+      "startLine": 50,
+      "endLine": 75,
+      "summary": "PROVES the symmetry/degeneracy lemmas for `collinear₃`: `collinear₃_comm`, `collinear₃_perm12`, `collinear₃_cycle` (the $S_3$ permutation invariances) and the degenerate cases `collinear₃_self_left`/`_self_right`/`_self_mid`.",
+      "mathContext": "`collinear₃` is invariant under all argument permutations; degenerate triples are collinear."
     },
     {
-      "id": "hunter",
-      "title": "Hunter's Counterexample",
-      "startLine": 65,
-      "endLine": 74,
-      "summary": "Axiomatizes Hunter's construction disproving Erdős's $\\sqrt{n}$ lower conjecture: lattice-point configurations achieve $h_c(n) \\ll n^{1/\\log(1/c)}$.",
-      "mathContext": "Axiomatized: Axiomatizes Hunter's construction disproving Erdős's $\\sqrt{n}$ lower conjecture: lattice-point configurations achieve $h_c(n) \\ll n^{1/\\log(1/c)}$."
+      "id": "known-results",
+      "title": "Known Results",
+      "startLine": 76,
+      "endLine": 141,
+      "summary": "Documents the upper bound ($h_c\\ll_c\\sqrt n$), Hunter's counterexample, and the #101 connection. States the AXIOM `connection_101` and PROVES `connection_101_for_same_c` (divergence $\\Rightarrow$ $<cn^2$ rich lines when max-collinear $\\leq4$), `connection_101_for_larger_eps` (extends to $\\varepsilon\\geq c$), and `connection_101_from_full_divergence` (the axiom follows from the full $\\forall c$ conjecture).",
+      "mathContext": "$h_c\\to\\infty\\Rightarrow$ max-collinear $\\leq4$ configs have $<cn^2$ rich lines; axiom derivable from full divergence."
     },
     {
-      "id": "connection-101",
-      "title": "Connection to Problem #101",
-      "startLine": 75,
-      "endLine": 87,
-      "summary": "Axiomatizes the logical implication: if $h_c(n) \\to \\infty$ (Problem #102), then the four-point line count is $o(n^2)$ for no-five-collinear configurations (Problem #101).",
-      "mathContext": "Axiomatizes the logical implication: if $h_c(n) \\to \\infty$ (Problem #102), then the four-point line count is $o($n^{2}$)$ for no-five-collinear configurations (Problem #101)."
-    },
-    {
-      "id": "szemeredi-trotter",
-      "title": "Szemerédi–Trotter Context",
-      "startLine": 88,
-      "endLine": 96,
-      "summary": "Axiomatizes the Szemerédi–Trotter incidence bound $I(P,L) \\le C(n^{2/3}m^{2/3} + n + m)$, the foundational tool constraining rich-line configurations.",
-      "mathContext": "Axiomatized: Axiomatizes the Szemerédi–Trotter incidence bound $I(P,L) \\le C(n^{2/3}m^{2/3} + n + m)$, the foundational tool constraining rich-line configurations."
-    },
-    {
-      "id": "erdos-purdy",
-      "title": "Erdős–Purdy Origin",
-      "startLine": 97,
-      "endLine": 103,
-      "summary": "Axiomatizes the elementary observation that $cn^2$ four-point lines force $\\max$-collinear $\\ge 4$, connecting to the Erdős–Purdy survey origin.",
-      "mathContext": "Axiomatized: Axiomatizes the elementary observation that $cn^2$ four-point lines force $\\max$-collinear $\\ge 4$, connecting to the Erdős–Purdy survey origin."
+      "id": "observations",
+      "title": "Observations",
+      "startLine": 142,
+      "endLine": 173,
+      "summary": "Documents the Szemerédi–Trotter incidence context and PROVES `erdos_purdy_connection`: if $cn^2$ rich lines exist then some line has $\\geq4$ collinear points (extract a 4-element collinear subset and apply `Finset.le_sup`).",
+      "mathContext": "$cn^2$ rich lines $\\Rightarrow$ max-collinear $\\geq4$ (Erdős–Purdy); Szemerédi–Trotter bounds incidences."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #102 (maximum collinear points forced by many rich lines) gallery `meta.json` had **section drift**.

- The 8 sections used fine titles ("Upper Bound", "Hunter's Counterexample", "Szemerédi-Trotter Context", "Erdős-Purdy Origin") that are actually inline comments, not the file's `## ` section banners, and the "Collinearity Properties" section (6 proved lemmas) was missing entirely.
- From section 4 onward the ranges drifted, and coverage stopped at line **103** of a **173**-line file, hiding the Known-Results theorems (`connection_101_for_larger_eps`, `connection_101_from_full_divergence`) and all of Observations (`erdos_purdy_connection`).

## Changes
- Rebuilt **6 sections** (was 8) mapped to the file's actual `## ` banners (Definitions, Main Problem, Collinearity Properties, Known Results, Observations) with full coverage **1-173**.
- **Counts already correct**: 10 theorems / 4 definitions / 1 axiom / 0 sorries, lineCount 173.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-173 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-102
- [x] Section ranges re-verified against the `## ` banners in `Erdos102Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)