### PR TITLE
Enrich binomial-theorem-oq-02-oq-01-oq-01-oq-03: section coverage + annotation realign + fix stale opaque-CDF claim

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/annotations.json
@@ -1,8 +1,20 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 140 },
+    "type": "context",
+    "title": "Overview: Multinomial Marginal CLT and Honest Reporting",
+    "content": "The header docstring states the open question (binomial-theorem-oq-02-oq-01-oq-01-oq-03): does each standardized multinomial coordinate (X_i - np_i)/√(np_i(1-p_i)) converge in distribution to N(0,1) as n → ∞? It documents the strategy — reduce the multinomial marginal CLT to the classical de Moivre-Laplace (binomial) CLT via the proved marginal-PMF identity from the parent file — and is explicit in its honest reporting: the de Moivre-Laplace CLT is taken as an axiom because, at the lake-pinned Mathlib v4.26.0 SHA, no i.i.d. CLT symbol exists in Mathlib. After this file, the single mathematical assumption beyond Mathlib is the classical binomial CLT itself.",
+    "mathContext": "$(X_{i_0} - np_{i_0})/\\sqrt{np_{i_0}(1-p_{i_0})} \\Rightarrow \\mathcal{N}(0,1)$ for each coordinate $i_0$, reduced to $F_{n,p_{i_0}} \\to \\Phi$ (de Moivre-Laplace) via the exact identity $F_{X_{i_0}} = F_{n,p_{i_0}}$.",
+    "significance": "context",
+    "relatedConcepts": ["central limit theorem", "multinomial distribution", "de Moivre-Laplace theorem", "honest axiomatization"],
+    "prerequisites": ["convergence in distribution", "binomial and multinomial distributions"]
+  },
+  {
     "id": "ann-binomialcdf-def",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 88, "endLine": 95 },
+    "range": { "startLine": 148, "endLine": 154 },
     "type": "definition",
     "title": "Concrete CDF of Binomial(n, p)",
     "content": "binomialCDF n p x is defined as the finite sum ∑_{j=0}^n 𝟙_{[j ≤ x]} · C(n,j) · p^j · (1-p)^(n-j). The indicator is implemented as an `if (j : ℝ) ≤ x then ... else 0` guard. No constraints on p are enforced at the definition level — the de Moivre-Laplace axiom then requires 0 < p < 1.",
@@ -14,7 +26,7 @@
   {
     "id": "ann-multinomialmarginalcdf-def",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 96, "endLine": 103 },
+    "range": { "startLine": 155, "endLine": 162 },
     "type": "definition",
     "title": "Marginal CDF of Multinomial Coordinate i₀",
     "content": "multinomialMarginalCDF s p n i₀ x sums multinomialProb s p n k over all compositions k ∈ s.piAntidiag n, gated by the indicator 𝟙_{[k(i₀) ≤ x]}. This is the joint distribution's marginal CDF for coordinate i₀, defined directly without invoking convolution or measure-theoretic marginalization.",
@@ -26,19 +38,19 @@
   {
     "id": "ann-stdnormalcdf-opaque",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 105, "endLine": 112 },
+    "range": { "startLine": 163, "endLine": 364 },
     "type": "definition",
-    "title": "Standard Normal CDF (Opaque Marker)",
-    "content": "standardNormalCDF : ℝ → ℝ is declared `opaque`. Lean treats it as an unknown function with no available reductions; we only know its name. The semantic intent is Φ(x) = (1/√(2π)) ∫_{-∞}^x e^{-t²/2} dt, but bridging from Mathlib's measure-theoretic Gaussian to a CDF function is non-trivial and is left as a Phase-3 target. Note: `opaque` declarations count toward the axiom count.",
-    "mathContext": "$$\\Phi(x) = \\frac{1}{\\sqrt{2\\pi}} \\int_{-\\infty}^x e^{-t^2/2}\\, dt$$ The standard normal CDF; smooth, strictly increasing, with $\\Phi(-\\infty) = 0$, $\\Phi(0) = 1/2$, $\\Phi(+\\infty) = 1$.",
+    "title": "Standard Normal CDF (Concrete Gaussian Integral)",
+    "content": "standardNormalCDF x is a concrete `noncomputable def`: the integral of Mathlib's `ProbabilityTheory.gaussianPDFReal 0 1` (the N(0,1) density) over `Set.Iic x`. It is NOT opaque or axiomatic — the file proves its structural properties directly from the definition: `standardNormalCDF_nonneg`, `standardNormalCDF_le_one`, `standardNormalCDF_mono` (monotone), `standardNormalCDF_continuous`, and the boundary limits `standardNormalCDF_tendsto_atBot` (→ 0) and `standardNormalCDF_tendsto_atTop` (→ 1). The only axiom in the file is `binomial_clt_pointwise`; standardNormalCDF contributes nothing to the axiom count.",
+    "mathContext": "$$\\Phi(x) = \\int_{-\\infty}^x \\varphi(t)\\, dt = \\frac{1}{\\sqrt{2\\pi}} \\int_{-\\infty}^x e^{-t^2/2}\\, dt$$ Defined as $\\int_{\\mathrm{Iic}\\,x} \\mathrm{gaussianPDFReal}\\,0\\,1$; proved continuous and monotone with $\\Phi(-\\infty) = 0$, $\\Phi(+\\infty) = 1$.",
     "significance": "supporting",
-    "relatedConcepts": ["standard normal distribution", "Gaussian", "opaque declarations"],
-    "prerequisites": ["measure theory", "Lebesgue integration"]
+    "relatedConcepts": ["standard normal distribution", "Gaussian", "gaussianPDFReal", "cumulative distribution function"],
+    "prerequisites": ["measure theory", "Lebesgue integration", "dominated convergence"]
   },
   {
     "id": "ann-binomial-clt-axiom",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 114, "endLine": 131 },
+    "range": { "startLine": 365, "endLine": 385 },
     "type": "insight",
     "title": "Axiom: de Moivre-Laplace Theorem",
     "content": "binomial_clt_pointwise axiomatizes the classical de Moivre-Laplace CLT in CDF form: for 0 < p < 1, the standardized binomial CDF binomialCDF n p (np + x √(np(1-p))) converges pointwise to standardNormalCDF x as n → ∞. Choosing the CDF formulation rather than measure-weak-convergence avoids the measure-theoretic setup needed to use Mathlib's `ProbabilityTheory.iid_central_limit_theorem`. Bridging the two formulations is a Phase-3 task; doing so would discharge this axiom.",
@@ -50,7 +62,7 @@
   {
     "id": "ann-reduction-lemma",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 138, "endLine": 210 },
+    "range": { "startLine": 386, "endLine": 467 },
     "type": "technique",
     "title": "Reduction Lemma: Marginal CDF = Binomial CDF (proved)",
     "content": "multinomialMarginalCDF_eq_binomialCDF asserts that the marginal CDF of the multinomial *equals* (not just approximates) the binomial CDF with parameter p(i₀). Now fully proved: the proof uses Finset.sum_fiberwise_of_maps_to to regroup the sum over k ∈ s.piAntidiag n into fibres indexed by j = k(i₀) ∈ Finset.range (n+1); the if-condition ((k i₀ : ℕ) : ℝ) ≤ x simplifies to (j : ℝ) ≤ x on each fibre (so it factors out as a uniform indicator), and on the resulting all-true fibre BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf collapses the inner sum to C(n,j) · p(i₀)^j · (1 - p(i₀))^(n-j).",
@@ -60,9 +72,21 @@
     "prerequisites": ["BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf", "Finset.piAntidiag", "Finset.sum_fiberwise_of_maps_to"]
   },
   {
+    "id": "ann-binomialcdf-structural",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 468, "endLine": 680 },
+    "type": "technique",
+    "title": "Structural Properties of binomialCDF (Phase-4 Prep)",
+    "content": "Nine proved lemmas establishing that binomialCDF behaves like a genuine cumulative distribution function: `binomialCDF_neg` (= 0 for x < 0), `binomialCDF_mono` (monotone in x), `binomialCDF_zero_le` and `binomialCDF_le_one` (range bounded in [0,1]), `binomialCDF_zero` (value at the bottom), `binomialCDF_eq_one` (= 1 once x ≥ n), and the boundary limits `binomialCDF_tendsto_one_atTop` (→ 1) and `binomialCDF_tendsto_zero_atBot` (→ 0). These supply the analytic scaffolding a future Portmanteau-style bridge from the de Moivre-Laplace axiom to measure-weak convergence would require.",
+    "mathContext": "$0 \\le F_{n,p}(x) \\le 1$, monotone, with $F_{n,p}(x) = 0$ for $x < 0$ and $F_{n,p}(x) = 1$ for $x \\ge n$; and $F_{n,p}(x) \\to 1$ as $x \\to +\\infty$, $F_{n,p}(x) \\to 0$ as $x \\to -\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cumulative distribution function", "monotone convergence", "Tendsto"],
+    "prerequisites": ["finite sums over Nat.choose", "monotonicity of finite sums"]
+  },
+  {
     "id": "ann-main-clt-derived",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
-    "range": { "startLine": 212, "endLine": 239 },
+    "range": { "startLine": 681, "endLine": 712 },
     "type": "insight",
     "title": "Main Theorem: Multinomial Marginal CLT (Derived, No New Axiom)",
     "content": "multinomial_marginal_clt is *derived*, not axiomatized. The proof builds a pointwise equality `key : ∀ n, multinomialMarginalCDF (...) = binomialCDF (...)` from the reduction lemma, then applies `Filter.Tendsto.congr` to convert binomial_clt_pointwise into the marginal-CLT statement. Because the reduction is an *equality* (not asymptotic), Tendsto.congr — which only requires pointwise equality of two sequences — is exactly the right tool: it is strictly stronger than needed.",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -89,6 +89,14 @@
   ],
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Multinomial Marginal CLT (Statement, Strategy, Honest Reporting)",
+      "startLine": 1,
+      "endLine": 140,
+      "summary": "File docstring (problem statement, status, what the file provides, mathematical content, honest reporting, why the CDF formulation, dependencies), imports, and namespace. The open question asks whether each standardized multinomial coordinate (X_i - np_i)/√(np_i(1-p_i)) converges to N(0,1). The file reduces the multinomial marginal CLT to the classical de Moivre-Laplace binomial CLT — taken as the single axiom binomial_clt_pointwise, since no i.i.d. CLT symbol exists in the lake-pinned Mathlib v4.26.0 — composed with the proved marginal-PMF identity from the parent file BinomialTheoremOQ02OQ01OQ02.",
+      "mathContext": "$(X_{i_0}-np_{i_0})/\\sqrt{np_{i_0}(1-p_{i_0})} \\Rightarrow \\mathcal{N}(0,1)$ for each coordinate $i_0$; reduced to $F_{n,p_{i_0}} \\to \\Phi$ (de Moivre-Laplace) via the exact equality $F_{X_{i_0}} = F_{n,p_{i_0}}$."
+    },
+    {
       "id": "sec-cdf-defs",
       "title": "CDF Definitions: Binomial and Multinomial Marginal",
       "range": null,


### PR DESCRIPTION
## Summary
Enrichment pass for `binomial-theorem-oq-02-oq-01-oq-01-oq-03` (multinomial marginal CLT, reduced to de Moivre-Laplace).

**Sections (6 → 7):** added an "Overview" section covering the 140-line header docstring (problem statement, status, honest reporting on the single CLT axiom, dependencies), which was uncovered. Sections are now contiguous over the full file (1–712).

**Annotations (6 → 8, fully realigned):** all six existing annotations had drifted to a pre-growth revision of the file — e.g. the de Moivre-Laplace axiom annotation pointed at 114–131 but the axiom is at line 379; the main-theorem annotation pointed at 212–239 but it is at 690–712. Every annotation is re-anchored to its current construct. Added a header annotation (1–140) and an annotation for the previously uncovered "Structural properties of binomialCDF" block (468–680, 9 lemmas). Annotations now align 1:1 with the sections.

**Integrity fix:** the "Standard Normal CDF" annotation claimed `standardNormalCDF` is declared `opaque` and "counts toward the axiom count." That is stale: `standardNormalCDF` is a concrete `noncomputable def` integrating `ProbabilityTheory.gaussianPDFReal 0 1` over `Set.Iic x`, with six proved structural lemmas (nonneg, le_one, mono, continuous, tendsto atBot/atTop). The only axiom is `binomial_clt_pointwise` (axiomCount = 1). Rewrote the annotation to match.

No Lean source changes. JSON validated; meta.json round-trips with indent=2 + trailing newline; annotations.json edited surgically to preserve its compact inline-array style.