### PR TITLE
research(mean-value-theorem-oq-03): realign sections, restore header + Summary (10→12)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-03/meta.json
@@ -99,6 +99,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview — Vector-Valued Mean Value Inequality",
+      "summary": "Imports, file docstring, and namespace setup: states what the file proves (the mean value inequality for vector- and Banach-space-valued functions), explains why the classical equality form of the MVT fails for vectors, and gives status and references.",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "For $f : \\mathbb{R} \\to E$ (or $E \\to F$) the equality form of the MVT fails — there need be no $c$ with $f(b)-f(a) = f'(c)(b-a)$ — but the inequality $\\|f(b)-f(a)\\| \\leq \\sup\\|f'\\|\\cdot(b-a)$ survives and is what this file develops."
+    },
+    {
       "id": "core-inequality",
       "title": "The Mean Value Inequality",
       "summary": "The central theorem: for $f : \\mathbb{R} \\to E$ with $\\|f'(x)\\| \\leq C$ on $[a,b]$, $\\|f(x) - f(a)\\| \\leq C \\cdot (x-a)$ for all $x \\in [a,b]$. One-line proof delegating to Mathlib's `norm_image_sub_le_of_norm_deriv_le_segment'`.",
@@ -167,8 +175,16 @@
       "title": "Scalar vs Vector: Strict Monotonicity and Antiderivatives",
       "summary": "Strict monotonicity ($f' > 0 \\Rightarrow f(a) < f(b)$) requires the scalar MVT equality. Antiderivative uniqueness ($f' = g' \\Rightarrow f - g$ constant) uses the vector inequality with $C = 0$.",
       "startLine": 307,
-      "endLine": 363,
+      "endLine": 364,
       "mathContext": "Strict monotonicity ($f > 0 \\Rightarrow f(a) < f(b)$) requires the ordering of $\\mathbb{R}$. In $\\mathbb{R}^n$ or Banach spaces, only the norm inequality $\\|\\Delta f\\| \\leq \\sup\\|f\\| \\cdot \\Delta t$ survives."
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Results",
+      "summary": "Recap of the twelve results — the mean value inequality, its scalar special case, the circular-motion counterexample, Lipschitz and contraction bounds, the displacement/Gronwall estimate, the Banach-space MVT, ODE uniqueness, strict monotonicity, and antiderivative uniqueness — framed as the answer to MVT gallery Open Question #3.",
+      "startLine": 365,
+      "endLine": 388,
+      "mathContext": "Answers Open Question #3 from the MVT gallery: the vector-valued generalization of the mean value theorem is the mean value inequality $\\|f(b)-f(a)\\| \\leq \\sup\\|f'\\|\\cdot(b-a)$, which holds in any normed space even though the equality form does not."
     },
     {
       "id": "banach-extensions",


### PR DESCRIPTION
## Summary
The 10 gallery sections for `mean-value-theorem-oq-03` left two regions uncovered:
- **Header docstring (lines 1-48)** — imports, the file docstring, and the namespace open.
- **"Summary of Results" block (lines 365-388)** — a 12-point recap answering MVT gallery Open Question #3 — was dropped entirely, leaving a 25-line gap between PART 9 and PART 10.

## Changes
- Added an **Overview** section (1-48) for the header.
- Restored the **Summary of Results** section (365-388).
- Extended **PART 9** (Scalar vs Vector) to close at the Summary banner (307-364).
- Result: 12 contiguous sections covering the full file (1-461). No Lean source, theorem/axiom/def counts, or prose claims changed — section ranges only.

## Verification
- `meta.json` parses as valid JSON.
- Sections verified contiguous (no gaps/overlaps) and covering exactly 1-461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)