### PR TITLE
research(erdos-735): realign gallery sections to full file (10→11)

### DIFF
--- a/src/data/proofs/erdos-735/meta.json
+++ b/src/data/proofs/erdos-735/meta.json
@@ -48,83 +48,91 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Part 0: Imports and Setup",
-      "startLine": 32,
-      "endLine": 38,
-      "summary": "Imports `InnerProductSpace.PiL2` for `EuclideanSpace ℝ (Fin 2)`, `AffineSubspace` for lines, `Finset` for finite point sets, and `Tactic` for proof automation.",
-      "mathContext": "Imports `InnerProductSpace.PiL2` for `EuclideanSpace $\\mathbb{R}$ (Fin 2)`, `AffineSubspace` for lines, `Finset` for finite point sets, and `Tactic` for proof automation."
+      "title": "Part 0: Overview, Imports and Setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Opening docstring states the problem (positive weights with equal line sums), the four-class answer, and the ABKPR08 reference. Imports `InnerProductSpace.PiL2` for `EuclideanSpace ℝ (Fin 2)`, `AffineSubspace` for lines, `Finset` for finite point sets, and `Tactic`; opens the `Erdos735` namespace under `open scoped Classical`.",
+      "mathContext": "Opening docstring states the problem (positive weights with equal line sums), the four-class answer, and the ABKPR08 reference. Imports `InnerProductSpace.PiL2` for `EuclideanSpace $\\mathbb{R}$ (Fin 2)`, `AffineSubspace` for lines, `Finset` for finite point sets, and `Tactic`; opens the `Erdos735` namespace under `open scoped Classical`."
     },
     {
       "id": "basic",
       "title": "Part I: Basic Setup",
-      "startLine": 39,
-      "endLine": 57,
+      "startLine": 42,
+      "endLine": 60,
       "summary": "Defines `PointConfig` (finite set of points in $\\mathbb{R}^2$), `Weighting` (positive real weights), `ConfigLine` (lines through $\\ge 2$ points via `AffineSubspace` with rank-1 direction), and `lineSum` (sum of weights on a line).",
       "mathContext": "Defines `PointConfig` (finite set of points in $\\mathbb{R}^2$), `Weighting` (positive real weights), `ConfigLine` (lines through $\\ge 2$ points via `AffineSubspace` with rank-1 direction), and `lineSum` (sum of weights on a line)."
     },
     {
       "id": "magic",
       "title": "Part II: Magic Configurations",
-      "startLine": 58,
-      "endLine": 67,
+      "startLine": 61,
+      "endLine": 70,
       "summary": "Defines `IsMagic P`: there exist positive weights $w$ and constant $c > 0$ such that every configuration line has weight sum $c$. Defines the `magicConstant` via `Classical.choose`.",
       "mathContext": "Defines `IsMagic P`: there exist positive weights $w$ and constant $c > 0$ such that every configuration line has weight sum $c$. Defines the `magicConstant` via `Classical.choose`."
     },
     {
       "id": "classes",
       "title": "Part III: The Four Magic Classes",
-      "startLine": 68,
-      "endLine": 108,
+      "startLine": 71,
+      "endLine": 113,
       "summary": "Defines the four classes: `IsCollinear`, `IsGeneralPosition`, `IsNearPencil`, `IsIncenterConfig`. Axiomatizes `collinear_is_magic` and `general_position_is_magic`; near-pencil and incenter classes are defined but not separately axiomatized in this file.",
       "mathContext": "Defines the four classes: `IsCollinear` (all points on one line), `IsGeneralPosition` (no 3 collinear), `IsNearPencil` ($n-1$ on a line), `IsIncenterConfig` (triangle + incenter + bisector points). Axiomatizes `collinear_is_magic` and `general_position_is_magic`; near-pencil and incenter classes are defined but not separately axiomatized in this file."
     },
     {
       "id": "projective",
       "title": "Part IV: Projective Equivalence",
-      "startLine": 109,
-      "endLine": 117,
+      "startLine": 114,
+      "endLine": 123,
       "summary": "Defines `ProjectivelyEquivalent` (bijective image). The preservation of magic under projective equivalence follows from `magic_classification` but is not separately axiomatized here.",
       "mathContext": "Formal definition: Defines `ProjectivelyEquivalent` (bijective image). The preservation of magic under projective equivalence follows from `magic_classification` but is not separately axiomatized here."
     },
     {
       "id": "classification",
       "title": "Part V: The Main Classification",
-      "startLine": 118,
-      "endLine": 131,
+      "startLine": 124,
+      "endLine": 137,
       "summary": "Defines `IsMagicClass` (disjunction of the four classes), `murty_conjecture` (magic $\\Leftrightarrow$ magic class for $|P| \\ge 3$), and axiomatizes `magic_classification`.",
       "mathContext": "Defines `IsMagicClass` (disjunction of the four classes), `murty_conjecture` (magic $\\Leftrightarrow$ magic class for $|P| \\ge 3$), and axiomatizes `magic_classification`."
     },
     {
       "id": "key-lemma",
       "title": "Part VI: Key Lemma: Lines Through a Point",
-      "startLine": 132,
-      "endLine": 140,
+      "startLine": 138,
+      "endLine": 147,
       "summary": "Defines `linesThrough` (number of lines through a given point). Docstring notes that in a magic configuration the weight of a point is determined by the number of lines through it and the magic constant.",
       "mathContext": "Defines `linesThrough` (number of lines through a given point in a configuration)."
     },
     {
       "id": "non-magic",
       "title": "Part VII: The Non-Magic Theorem",
-      "startLine": 141,
-      "endLine": 149,
+      "startLine": 148,
+      "endLine": 156,
       "summary": "Proves `not_magic_outside_classes`: configurations not in the four classes are not magic (contrapositive of `magic_classification`).",
       "mathContext": "Verified: Proves `not_magic_outside_classes`: configurations not in the four classes are not magic (contrapositive of `magic_classification`)."
     },
     {
       "id": "examples",
       "title": "Part VIII: Examples",
-      "startLine": 150,
-      "endLine": 171,
-      "summary": "Constructs `threeCollinear` $= \\{(0,0), (1,0), (2,0)\\}$ and `triangle` $= \\{(0,0), (1,0), (0,1)\\}$. Proves both are magic via the class axioms.",
-      "mathContext": "Verified: Constructs `threeCollinear` $= \\{(0,0), (1,0), (2,0)\\}$ and `triangle` $= \\{(0,0), (1,0), (0,1)\\}$. Proves both are magic via the class axioms."
+      "startLine": 157,
+      "endLine": 206,
+      "summary": "Constructs `threeCollinear` $= \\{(0,0), (1,0), (2,0)\\}$ and `triangle` $= \\{(0,0), (1,0), (0,1)\\}$. Proves both have $\\ge 2$ points (`three_collinear_card`, `triangle_card`) and are magic (`three_collinear_is_magic`, `triangle_is_magic`) via the class axioms.",
+      "mathContext": "Verified: Constructs `threeCollinear` $= \\{(0,0), (1,0), (2,0)\\}$ and `triangle` $= \\{(0,0), (1,0), (0,1)\\}$. Proves both have $\\ge 2$ points and are magic via the collinear and general-position class axioms."
     },
     {
-      "id": "linear",
-      "title": "Part IX: Linear Algebra Perspective",
-      "startLine": 172,
-      "endLine": 185,
-      "summary": "Defines the `incidenceMatrix` ($A_{L,p} = 1$ if $p \\in L$, else $0$) and sketches the dimension counting argument via docstrings: outside the four classes, the positive orthant misses the affine solution subspace. These claims are not formally axiomatized in this file.",
-      "mathContext": "Defines the `incidenceMatrix` ($A_{L,p} = 1$ if $p \\in L$, else $0$). The magic-iff-positive-solution equivalence and dimension bound are present as docstrings only."
+      "id": "incidence",
+      "title": "Part IX: Weighted Incidence Perspective",
+      "startLine": 207,
+      "endLine": 215,
+      "summary": "Defines the `incidenceMatrix` ($A_{L,p} = 1$ if $p \\in L$, else $0$). Docstring records that a configuration is magic iff the incidence linear system has a positive solution. This equivalence is present as a docstring only, not axiomatized in this file.",
+      "mathContext": "Defines the `incidenceMatrix` ($A_{L,p} = 1$ if $p \\in L$, else $0$). The magic-iff-positive-solution equivalence is present as a docstring only."
+    },
+    {
+      "id": "dimension",
+      "title": "Part X: Dimension Counting Argument and Summary",
+      "startLine": 216,
+      "endLine": 247,
+      "summary": "Closes the `Erdos735` namespace and sketches the dimension counting argument via docstrings: for configurations outside the four classes the valid-weighting space has negative dimension, so no positive solution exists. The trailing summary docstring restates the SOLVED status, the four-class answer, and the ABKPR08 method. These claims are not formally axiomatized in this file.",
+      "mathContext": "Sketches the dimension counting argument via docstrings: outside the four classes the positive orthant misses the affine solution subspace, so no positive weighting exists. The closing summary docstring restates the four-class characterization and the ABKPR08 method. Present as docstrings only."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section-metadata realign for **erdos-735** (Magic Configurations / Murty's conjecture, ABKPR08). The gallery section ranges had drifted early relative to the Lean file's `## ` banners, leaving the opening problem-statement docstring (lines 1-30) and the entire tail (lines 186-247) uncovered. The final section "Part IX: Linear Algebra Perspective" was a phantom title pointing into the middle of the Examples region.

## Progress
- Realigned every section range to the file's actual `## ` banner positions; coverage is now contiguous **1-247**.
- Folded the opening docstring + imports into Part 0 (`32-38` → `1-41`).
- Extended **Examples** to cover both worked examples (`threeCollinear`, `triangle`) at `157-206`.
- Replaced the phantom "Linear Algebra Perspective" section with the file's two real tail banners: **Weighted Incidence Perspective** (`207-215`) and **Dimension Counting Argument and Summary** (`216-247`).
- Section count 10 → 11.

## Findings
- Lean source is unchanged: 5 axioms / 5 theorems / 16 definitions / 0 sorries — all preserved. `axiomCount`/`status: axiomatized` already correct.
- No mathematical claims altered; this is a content-only metadata accuracy fix.

## Status
**Outcome**: completed (content realign)
**Next Steps**: none required for this entry.

🤖 Generated by researcher-6