### PR TITLE
research(erdos-277): realign drifted gallery sections to full file (12->12)

### DIFF
--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -125,54 +125,54 @@
       "id": "trivial-covering",
       "title": "Trivial Covering Analysis",
       "startLine": 123,
-      "endLine": 172,
+      "endLine": 153,
       "summary": "Defines and proves properties of the trivial covering $\\{0 \\pmod{1}\\}$: it covers all integers (proved), $1 \\mid n$ for all $n \\geq 1$ (proved), so every $n \\geq 1$ has some covering with divisor moduli (proved). Motivates the non-trivial refinement.",
       "mathContext": "Defines and proves properties of the trivial covering $\\{0 \\pmod{1}\\}$: it covers all integers (proved), $1 \\mid n$ for all $n \\geq 1$ (proved), so every $n \\geq 1$ has some covering with divisor moduli (proved)."
     },
     {
       "id": "nontrivial-refinement",
       "title": "Non-Trivial Covering Refinement",
-      "startLine": 173,
-      "endLine": 191,
+      "startLine": 154,
+      "endLine": 166,
       "summary": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. documents in source comments `haight_strong_theorem` (no Lean declaration exists): the stronger result excluding non-trivial coverings.",
       "mathContext": "Defines `HasDistinctModuli`, `IsNonTrivialCovering` ($\\geq 2$ distinct moduli), and `HasNonTrivialCoveringWithDivisorModuli`. documents in source comments `haight_strong_theorem` (no Lean declaration exists): the stronger result excluding non-trivial coverings."
     },
     {
       "id": "covering-properties",
       "title": "Key Properties of Covering Systems",
-      "startLine": 192,
-      "endLine": 214,
+      "startLine": 167,
+      "endLine": 183,
       "summary": "Defines the reciprocal sum $\\sum_{c \\in S} 1/m_c$ and states the bound $\\sum 1/m_i \\geq 1$ in a docstring (no Lean declaration). Proves `covering_crt_connection` via `Finset.mem_image`: every modulus in a covering system has at least one congruence.",
       "mathContext": "Defines the reciprocal sum $\\sum_{c \\in S} 1/m_c$ and states the bound $\\sum 1/m_i \\geq 1$ in a docstring (no Lean declaration). Proves `covering_crt_connection` via `Finset.mem_image`: every modulus in a covering system has at least one congruence."
     },
     {
       "id": "haight-construction",
       "title": "Haight's Construction Insight",
-      "startLine": 215,
-      "endLine": 243,
+      "startLine": 184,
+      "endLine": 198,
       "summary": "Source comments outline Haight's strategy: primorial-like products $n = p_1 \\cdots p_k$ achieve high $\\sigma(n)/n$ via $\\prod (1 + 1/p_i)$ while having divisor reciprocal sums too small for covering. No Lean definitions are introduced in this section.",
       "mathContext": "Source comments outline Haight's strategy: primorial-like products $n = p_1 \\cdots p_k$ achieve high $\\sigma(n)/n$ via $\\prod (1 + 1/p_i)$ while having divisor reciprocal sums too small for covering. No Lean definitions are introduced in this section."
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
-      "startLine": 244,
-      "endLine": 263,
+      "startLine": 199,
+      "endLine": 221,
       "summary": "Defines `coveringLCM` (period of covering system), `IsHighlyComposite` ($n$ maximizes $d(n)$ up to $n$), `IsSuperabundant` ($n$ maximizes $\\sigma(n)/n$ up to $n$). Proves `lcm_divides_of_all_divide` and `haight_superabundance_connection`.",
       "mathContext": "Defines `coveringLCM` (period of covering system), `IsHighlyComposite` ($n$ maximizes $d(n)$ up to $n$), `IsSuperabundant` ($n$ maximizes $\\sigma(n)/n$ up to $n$)."
     },
     {
       "id": "connections",
       "title": "Connections to Other Problems",
-      "startLine": 244,
-      "endLine": 263,
+      "startLine": 222,
+      "endLine": 241,
       "summary": "Links to Problem #276 (distinct-moduli covering existence), #278 (covering density), and Egyptian fractions ($\\sum 1/m_i$ as unit fraction decomposition). Part of Erdős's covering system cluster #273-#279.",
       "mathContext": "Links to Problem #276 (distinct-moduli covering existence), #278 (covering density), and Egyptian fractions ($\\sum 1/m_i$ as unit fraction decomposition)."
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
-      "startLine": 264,
+      "startLine": 242,
       "endLine": 275,
       "summary": "Three restatements of the main result: `erdos_277` (abstract), `erdos_277_main` (explicit $\\sigma(n) > cn$ formulation), and `erdos_277_summary`. All derive from the axiomatized `haight_theorem`.",
       "mathContext": "Verified: Three restatements of the main result: `erdos_277` (abstract), `erdos_277_main` (explicit $\\sigma(n) > cn$ formulation), and `erdos_277_summary`. All derive from the axiomatized `haight_theorem`."


### PR DESCRIPTION
## Summary
The `erdos-277` gallery entry's back-half sections (Parts V–X) had drifted off the Lean file's `## Part N` banners (`Erdos277Problem.lean`, 275 lines):
- "Trivial Covering Analysis" (123–172) spilled past Part V into the Part VI region.
- "Related Concepts" and "Connections to Other Problems" shared an identical, incorrect range (244–263).
- The tail (264–275) was uncovered, while "Summary" (Part X) actually begins at line 242.

Realigned all 12 sections contiguously to the banner boundaries (Part openers at lines 38/68/99/111/123/167/184/199/222/242, plus the header). The intentional split of Part V into "Trivial Covering Analysis" (123–153) and "Non-Trivial Covering Refinement" (154–166) is preserved. The front 5 sections were already aligned and are unchanged.

## Changes
- `src/data/proofs/erdos-277/meta.json`: corrected `startLine`/`endLine` for the 7 drifted sections. No Lean source, count, or title changes.

## Test plan
- [x] JSON validates
- [x] 12 sections contiguous, covering the full 275-line file
- [x] Section titles match their `## Part N` banner content in order
- [x] Duplicate 244–263 range resolved