### PR TITLE
research(cayley-hamilton-reduction-oq-02-oq-01): realign drifted sections + annotations (6→7)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
@@ -73,12 +73,12 @@
     "id": "ann-sorry-theorems",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
     "range": {
-      "startLine": 170,
-      "endLine": 211
+      "startLine": 244,
+      "endLine": 340
     },
     "type": "insight",
-    "title": "Three Sorry Theorems: Annihilation, Charpoly, Minpoly",
-    "content": "Three key theorems are stated with `sorry`. (1) `aeval_companionMatrix`: p(C(p)) = 0, proved conceptually via the orbit: p(C(p))·e₀ = C(p)^d·e₀ + ∑ aₖ C(p)^k·e₀ = (−∑ aᵢeᵢ) + (∑ aₖeₖ) = 0, then commutativity gives p(C(p))·eⱼ = 0. (2) `charpoly_companionMatrix`: charpoly(C(p)) = p, deduced from minpoly = p since both are monic of degree d. (3) `minpoly_companionMatrix`: minpoly(C(p)) = p, using that the orbit implies no polynomial of degree < d annihilates C(p). All infrastructure for completing these proofs is already in place; only the formal argument assembly remains.",
+    "title": "Three Core Theorems: Annihilation, Charpoly, Minpoly",
+    "content": "Three key theorems are fully proved (0 sorries), supported by the private helper lemmas above (`aeval_eq_sum_pow`, `pow_d_mulVec_e0`, `aeval_commute_pow`). (1) `aeval_companionMatrix`: p(C(p)) = 0, proved via the orbit: p(C(p))·e₀ = C(p)^d·e₀ + ∑ aₖ C(p)^k·e₀ = (−∑ aᵢeᵢ) + (∑ aₖeₖ) = 0, then commutativity gives p(C(p))·eⱼ = 0. (2) `minpoly_companionMatrix`: minpoly(C(p)) = p, using that the orbit implies no polynomial of degree < d annihilates C(p). (3) `charpoly_companionMatrix`: charpoly(C(p)) = p, deduced from minpoly = p since both are monic of degree d. The orbit argument supplies a determinant-free proof of annihilation.",
     "mathContext": "$p(C(p)) = 0$; $\\mathrm{minpoly}(C(p)) = p$ (since orbit spans $\\Rightarrow$ no degree-$< d$ annihilator); $\\mathrm{charpoly}(C(p)) = p$ (monic, same degree)",
     "significance": "key",
     "relatedConcepts": [
@@ -98,8 +98,8 @@
     "id": "ann-linear-case",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
     "range": {
-      "startLine": 213,
-      "endLine": 225
+      "startLine": 341,
+      "endLine": 354
     },
     "type": "insight",
     "title": "Base Case: C(x − c) = [c]",
@@ -122,8 +122,8 @@
     "id": "ann-rcf-roadmap",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
     "range": {
-      "startLine": 226,
-      "endLine": 259
+      "startLine": 355,
+      "endLine": 396
     },
     "type": "concept",
     "title": "RCF Roadmap: ~1800 Lines of Missing Infrastructure",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "overview-imports",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Mathlib imports (charpoly, minpoly, polynomial division), the file docstring stating the companion-matrix / rational-canonical-form goal, and the namespace, opens, and `variable {F : Type*} [Field F]` setup.",
+      "mathContext": "Works over an arbitrary field $F$. The supporting Mathlib machinery is `Matrix.aeval_self_charpoly` (Cayley-Hamilton), the minimal-polynomial API, and polynomial coefficient access. The docstring frames the four targets: companion-matrix definition, orbit basis property, $p(C(p)) = 0$, and $\\mathrm{charpoly}(C(p)) = \\mathrm{minpoly}(C(p)) = p$."
+    },
+    {
       "id": "companion-definition",
       "title": "Part 1: Companion Matrix Definition",
       "startLine": 59,
@@ -74,7 +82,7 @@
       "id": "entry-lemmas",
       "title": "Part 2: Basic Entry Properties",
       "startLine": 82,
-      "endLine": 108,
+      "endLine": 109,
       "summary": "Three lemmas characterizing the three entry types: `companionMatrix_subdiag` (subdiagonal = 1), `companionMatrix_last_col` (last column = −coeff), `companionMatrix_zero` (elsewhere = 0).",
       "mathContext": "Each entry is a direct `if-then-else` on the indices. The proofs use `Matrix.ext` + `simp` with the definition. The `companion_col_action` lemma derives the column action: $C(p) \\cdot e_i = e_{i+1}$ for $i < d-1$ and $C(p) \\cdot e_{d-1} = -\\sum_{k<d} a_k e_k$. This is the key fact for the orbit argument."
     },
@@ -82,7 +90,7 @@
       "id": "orbit",
       "title": "Part 3: Orbit of Standard Basis Vectors",
       "startLine": 110,
-      "endLine": 168,
+      "endLine": 169,
       "summary": "Proves C(p)ᵏ·e₀ = eₖ for k < d by induction using the column action lemmas. The orbit {e₀, ..., e_{d-1}} equals the standard basis.",
       "mathContext": "The induction: base case $C^0 e_0 = e_0$; step $C^{k+1} e_0 = C \\cdot (C^k e_0) = C \\cdot e_k = e_{k+1}$ (using the subdiagonal action for $k < d-1$). This confirms the isomorphism $F^d \\cong F[X]/(p)$ as $F[X]$-modules, with $e_k \\leftrightarrow X^k \\bmod p$."
     },
@@ -90,23 +98,23 @@
       "id": "key-theorems",
       "title": "Part 3b: Annihilation, Charpoly, Minpoly",
       "startLine": 170,
-      "endLine": 211,
+      "endLine": 340,
       "summary": "Three core theorems: p(C(p)) = 0 (orbit annihilation), charpoly(C(p)) = p (from minpoly = p), minpoly(C(p)) = p (orbit independence). All proved with 0 sorries.",
       "mathContext": "Annihilation ($p(C) = 0$): using the orbit, $p(C) \\cdot e_0 = (C^d + a_{d-1}C^{d-1} + \\cdots + a_0) \\cdot e_0 = e_d + \\sum a_k e_k$. The last-column action gives $e_d = C^{d-1} \\cdot e_{d-1} = -\\sum a_k e_k$ (the last column entry), so $p(C) \\cdot e_0 = 0$. Since $e_0$ generates all of $F^d$ under $C$, $p(C) = 0$."
     },
     {
       "id": "linear-case",
       "title": "Part 4: Linear Polynomial Base Case",
-      "startLine": 213,
-      "endLine": 225,
+      "startLine": 341,
+      "endLine": 354,
       "summary": "Proves C(x−c) = [c] for the 1×1 companion matrix, connecting companion blocks to eigenvalues.",
       "mathContext": "For $p = X - c$ (degree 1), $C(p)$ is the $1 \\times 1$ matrix $[c]$. The companion matrix of a linear factor is thus exactly the eigenvalue, confirming that the Jordan block with eigenvalue $c$ is $C(X-c) = [c]$ in the degree-1 case."
     },
     {
       "id": "rcf-roadmap",
       "title": "Part 5: Full RCF Roadmap",
-      "startLine": 226,
-      "endLine": 259,
+      "startLine": 355,
+      "endLine": 396,
       "summary": "Documents the ~1800-line gap to a complete Lean formalization of the rational canonical form: SNF (~800), companion (~200), block assembly (~300), uniqueness (~200).",
       "mathContext": "The complete RCF theorem requires: (1) Smith Normal Form for $F[X]$-matrices (Euclidean domain algorithm, ~800 lines); (2) companion block diagonalization from SNF invariant factors (~200 lines); (3) similarity proof assembling the block structure (~300 lines); (4) uniqueness of invariant factors (~200 lines). Completed formalizations exist in Coq (Cano-Dénès 2012) and Isabelle (Divasón-Thiemann 2016)."
     }


### PR DESCRIPTION
## Summary

The gallery meta sections and annotations for `cayley-hamilton-reduction-oq-02-oq-01` (Rational Canonical Form: Companion Matrix) had drifted out of alignment with the 396-line Lean source. This realigns both to the file's six `## Part N` banners plus a header section.

### What was wrong
- **Part 3b truncated**: covered only 170-211 (the private helper lemmas), missing the three core theorems `aeval_companionMatrix`, `minpoly_companionMatrix`, `charpoly_companionMatrix` at lines 244-340.
- **Parts 4 & 5 mislabeled**: pointed at earlier regions (213-225, 226-259) that fall inside Part 3b; their real banners are at 341 and 355.
- **Header uncovered**: lines 1-58 (imports, docstring, namespace setup) had no section.
- **Stale annotation prose**: the "Three Sorry Theorems" annotation claimed the theorems were stated with `sorry`, but all three are fully proved (0 sorries).

### Changes
- Add `Overview and Imports` section (1-58)
- Expand Part 3b to its real span 170-340
- Relocate Part 4 (341-354) and Part 5 (355-396) to their actual banners
- Re-anchor three drifted annotations to match the current source
- Rename/de-stale the core-theorems annotation (no longer "sorry")
- Result: 7 contiguous sections covering 1-396; resolver reports all 6 annotations valid, 0 misaligned

No Lean source changes; content-only metadata fix.

## Test plan
- [x] meta.json and annotations.json parse as valid JSON
- [x] Sections are contiguous 1-396 with no gaps or overlaps
- [x] `resolver.ts validate` → 6 valid, 0 misaligned