### PR TITLE
research(basel-problem-oq-04-oq-03): realign sections, add header coverage (10→11)

### DIFF
--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -77,6 +77,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and Limit Infrastructure",
+      "startLine": 1,
+      "endLine": 101,
+      "summary": "Proof architecture (Mobius decomposition of the coprime-pair count, the Mobius Dirichlet series identity, and the density limit), imports, namespace, and the private helper lemma nat_div_div_tendsto establishing that the floor ratio (N/d)/N converges to 1/d as N to infinity for any fixed d.",
+      "mathContext": "For fixed $d$, $\\lfloor N/d\\rfloor / N \\to 1/d$ as $N\\to\\infty$. This elementary limit is the analytic workhorse behind the density convergence: it is proved via an explicit $\\varepsilon$-$N$ bound using $N = \\lfloor N/d\\rfloor\\, d + (N \\bmod d)$ with $N\\bmod d < d$."
+    },
+    {
       "id": "definitions",
       "title": "The Coprime Pair Count",
       "startLine": 102,


### PR DESCRIPTION
## Summary
Build-free gallery section realignment for `basel-problem-oq-04-oq-03` (Coprime Pair Density, 558-line file, 0 sorries / 0 axioms).

The 10 existing sections were correctly aligned to the in-file `-- SECTION` dividers, but **lines 1–101 were entirely uncovered**: the proof-architecture docstring, imports/opens, and the substantive private helper lemma `nat_div_div_tendsto` (proving ⌊N/d⌋/N → 1/d via an explicit ε–N bound — the analytic workhorse behind density convergence).

This PR adds an `overview` section spanning 1–101, so the 11 sections now cover the full file contiguously (1–558).

## Changes
- `src/data/proofs/basel-problem-oq-04-oq-03/meta.json`: insert `overview` section (1–101); 10 → 11 sections.

## Test plan
- [x] JSON validates (`jq empty`)
- [x] Sections contiguous 1–558, no overlaps/gaps
- [x] No Lean source changed (content-only meta edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)