### PR TITLE
research(erdos-75): realign drifted gallery sections + de-stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -48,45 +48,45 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Mathlib Imports",
-      "startLine": 17,
-      "endLine": 21,
-      "summary": "Imports Nat.Basic, Finset, Rat.Basic, and tactics."
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Module docstring states the Erdős–Hajnal–Szemerédi question (a graph of chromatic number ℵ₁ whose large finite subgraphs all have independent sets of size > n^{1−ε}, a $1000 prize problem). Imports Nat.Basic, Finset, Rat.Defs, and tactics; opens the Erdos75 namespace under open Classical."
     },
     {
       "id": "graph-infrastructure",
       "title": "Graph Infrastructure",
-      "startLine": 23,
-      "endLine": 57,
-      "summary": "Defines UGraph structure (symmetric, loopless adjacency), bundled Graph, Colorable predicate, chromaticNum definition, and proves monotonicity. Replaces 4 axioms with concrete definitions."
+      "startLine": 27,
+      "endLine": 64,
+      "summary": "Defines UGraph (symmetric, loopless adjacency), bundled Graph, the Colorable predicate, chromaticNum, and HasUncountableChromaticNum, and proves chromaticNum_mono. Uses concrete Lean 4 structures and proved theorems rather than axioms."
     },
     {
       "id": "finite-subgraphs",
       "title": "Finite Subgraphs and Independence",
-      "startLine": 59,
-      "endLine": 86,
-      "summary": "Defines FiniteSubgraph (injective embedding from Fin n), IsIndepSet, indepNumber via Finset.sup, and proves indepNumber ≤ n. Replaces 3 axioms with definitions and proved theorems."
+      "startLine": 65,
+      "endLine": 100,
+      "summary": "Defines FiniteSubgraph (injective embedding from Fin n), IsIndepSet, and indepNumber via Finset.sup; proves empty_IsIndepSet and indepNumber_le (α(H) ≤ n). All definitions and proved theorems, no axioms."
     },
     {
       "id": "known-context",
       "title": "Known Context",
-      "startLine": 88,
-      "endLine": 99,
-      "summary": "Axiomatizes the pigeonhole-based chromatic-independence bound. Placeholder for Erdős-Hajnal connection."
+      "startLine": 101,
+      "endLine": 172,
+      "summary": "Proves indepNumber_ge_of_exists (an independent set of size m witnesses indepNumber ≥ m) and finite_chromatic_independence: for a k-colorable graph, every n-vertex subgraph satisfies indepNumber·k ≥ n, proved by partitioning into color classes, bounding each, and summing. Includes a docstring noting the related Erdős–Hajnal conjecture. Proved theorems, not axioms."
     },
     {
       "id": "independence-properties",
-      "title": "Independence Ratio Properties",
-      "startLine": 101,
-      "endLine": 117,
-      "summary": "Defines HasLargeIndepSets (n^{1-ε} approximation) and HasLinearIndepSets (c·n) properties."
+      "title": "The Independence Ratio Property",
+      "startLine": 173,
+      "endLine": 191,
+      "summary": "Defines HasLargeIndepSets (the n^{1−ε} property, approximated as positive independence number) and HasLinearIndepSets (independence number ≥ c·n) as Lean propositions."
     },
     {
       "id": "conjectures",
       "title": "The Erdős Problem",
-      "startLine": 119,
-      "endLine": 140,
-      "summary": "Proves linear → large implication, states both forms of Problem 75 as axioms."
+      "startLine": 192,
+      "endLine": 214,
+      "summary": "Proves linear_implies_large (the linear property implies the basic property) and strong_implies_basic (the strong conjecture implies the basic conjecture). Both forms of Problem 75 are stated as docstrings rather than axioms; the file contains no axiom declarations. Closes the Erdos75 namespace."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section-metadata realign for **erdos-75** (Uncountable Chromatic Number and Large Independent Sets — a \$1000 Erdős prize problem, OPEN). The back-half section ranges had drifted ~70 lines early relative to the Lean file's `## ` banners, leaving the opening problem-statement docstring (1-15) and the entire tail (141-214) uncovered. Several section summaries also still described **axioms the file no longer contains** (`axiomCount` is 0).

## Progress
- Realigned every section range to the file's actual `## ` banner positions; coverage is now contiguous **1-214**.
- Folded the problem-statement docstring + imports into the first section (`17-21` → `1-26`).
- Fixed **Known Context** to cover the proved pigeonhole bound `finite_chromatic_independence` (`88-99` → `101-172`).
- Fixed **The Independence Ratio Property** (`101-117` → `173-191`) and **The Erdős Problem** (`119-140` → `192-214`) to their real banner positions.

## Findings
- De-staled summaries: the pigeonhole chromatic-independence bound is a **proved theorem**, not an axiom, and both conjecture forms are stated as **docstrings**, not axioms. The file has **0 axiom declarations**.
- Lean source unchanged: 0 axioms / 7 theorems / 10 definitions / 0 sorries — all preserved.

## Status
**Outcome**: completed (content realign + accuracy fix)
**Next Steps**: none required for this entry.

🤖 Generated by researcher-6