### PR TITLE
research(fair-games-theorem-oq-01): realign drifted gallery sections (6→11)

### DIFF
--- a/src/data/proofs/fair-games-theorem-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-01/meta.json
@@ -75,52 +75,92 @@
   },
   "sections": [
     {
-      "id": "setup",
-      "title": "Gambler's Ruin Setup",
-      "startLine": 47,
-      "endLine": 83,
-      "summary": "GamblersRuin structure with barriers at 0 and N, starting position k. Definitions of ruinProbWin, ruinProbLose, expectedRuinTime.",
-      "mathContext": "Parameters: $0 < k < N$ with $N \\geq 2$. $P(\\text{win}) = k/N$, $P(\\text{lose}) = (N-k)/N$, $E[T] = k(N-k)$."
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Imports, the module docstring stating the open question (quantitative gambler's-ruin / fair-games analysis via the Optional Stopping Theorem), the answer, improvements over the previous version, and the connection to the parent file.",
+      "mathContext": "Quantitative gambler's ruin: ruin probabilities, expected ruin time, variance, and the biased case, via Optional Stopping."
     },
     {
-      "id": "ruin-probability",
-      "title": "Ruin Probabilities (OST Application)",
-      "startLine": 84,
-      "endLine": 142,
-      "summary": "Proves ruin probabilities sum to 1 and are strictly between 0 and 1. Previously axiomized, now proved from definitions.",
-      "mathContext": "$k/N + (N-k)/N = 1$ proved by algebraic simplification. Strict bounds via $0 < k < N$."
+      "id": "part1-setup",
+      "title": "Part I: Setup — Symmetric Random Walk with Barriers",
+      "startLine": 45,
+      "endLine": 80,
+      "summary": "Defines the `GamblersRuin` structure (absorbing barriers at 0 and N, start position k) and the quantities `ruinProbWin` (k/N), `ruinProbLose` ((N−k)/N), and `expectedRuinTime` (k(N−k)).",
+      "mathContext": "Symmetric walk on $\\{0,\\dots,N\\}$ from k; $P_{win}=k/N$, $E[T]=k(N-k)$."
     },
     {
-      "id": "expected-ruin-time",
-      "title": "Expected Ruin Time (Quadratic Martingale)",
-      "startLine": 143,
-      "endLine": 184,
-      "summary": "E[T] = k(N-k) via the quadratic martingale X²-n. AM-GM bound: E[T] ≤ N²/4.",
-      "mathContext": "$E[X_T^2] = kN$ (from quadratic OST). $E[T] = kN - k^2 = k(N-k) \\leq N^2/4$ by AM-GM."
+      "id": "part2-ruin-prob-linear",
+      "title": "Part II: Ruin Probability via the Linear Martingale",
+      "startLine": 81,
+      "endLine": 140,
+      "summary": "Applies the Optional Stopping Theorem to the linear martingale: `ost_linear`, `ruin_probabilities_sum_one`, the closed forms `ruin_prob_win_eq`/`ruin_prob_lose_eq`, and positivity/strict-bound lemmas.",
+      "mathContext": "Optional Stopping on $X_n$ gives $P_{win}=k/N$, with $P_{win}+P_{lose}=1$ and $0<P_{win}<1$."
     },
     {
-      "id": "structural-properties",
-      "title": "Symmetry and Structural Properties",
-      "startLine": 220,
-      "endLine": 254,
-      "summary": "Symmetry E[T|k] = E[T|N-k], increment recurrence, and harmonic property.",
-      "mathContext": "Harmonic property: $E[T|k] = 1 + \\frac{E[T|k-1] + E[T|k+1]}{2}$ (discrete Laplacian)."
+      "id": "part3-expected-time-quadratic",
+      "title": "Part III: Expected Ruin Time via the Quadratic Martingale",
+      "startLine": 141,
+      "endLine": 182,
+      "summary": "Uses the quadratic martingale Xₙ²−n: `expected_squared_at_ruin`, `expected_ruin_time_eq` (E[T]=k(N−k)), positivity, and the AM-GM bound `expected_ruin_time_le_quarter_N_sq` (E[T] ≤ N²/4).",
+      "mathContext": "$E[T]=k(N-k) \\le N^2/4$ via the martingale $X_n^2-n$."
     },
     {
-      "id": "biased-walk",
-      "title": "Biased Random Walk (p ≠ 1/2)",
-      "startLine": 310,
-      "endLine": 416,
-      "summary": "BiasedGamblersRuin structure with odds ratio r = q/p. Ruin probability (1-r^k)/(1-r^N) when r ≠ 1. Proves sum-to-1, favorable (r<1) and unfavorable (r>1) cases.",
-      "mathContext": "$r = q/p$. $P(\\text{win}) = (1-r^k)/(1-r^N)$. When $p < 1/2$: $r > 1$ and $P(\\text{win}) < 1$."
+      "id": "part4-examples",
+      "title": "Part IV: Concrete Examples",
+      "startLine": 183,
+      "endLine": 212,
+      "summary": "Worked instances: `example_5_10` (win prob 1/2, E[T]=25), `example_1_10` (E[T]=9), and `example_1_100` (E[T]=99), each evaluated from the closed forms.",
+      "mathContext": "Numeric checks: $E[T]=25$ for (N,k)=(10,5), 9 for (10,1), 99 for (100,1)."
     },
     {
-      "id": "exponential-decay",
-      "title": "Exponential Decay of Ruin Time",
-      "startLine": 417,
+      "id": "part5-symmetry",
+      "title": "Part V: Symmetry and Structural Properties",
+      "startLine": 213,
+      "endLine": 240,
+      "summary": "Structural identities: `expected_ruin_time_symmetric` (E[T|k]=E[T|N−k]), the increment recurrence `expected_ruin_time_increment`, and the discrete `harmonic_property`.",
+      "mathContext": "$E[T|k]=E[T|N-k]$; expected time satisfies a discrete harmonic/recurrence relation."
+    },
+    {
+      "id": "part6-variance-bounds",
+      "title": "Part VI: Variance Bounds",
+      "startLine": 241,
+      "endLine": 272,
+      "summary": "Bounds on the squared/second-moment quantities: `expected_time_sq_upper_bound` and the worked values `expected_time_N2_k1`, `expected_time_N4_k2`.",
+      "mathContext": "Upper bounds on $E[T]^2$/second moments with concrete instances."
+    },
+    {
+      "id": "part7-asymptotic",
+      "title": "Part VII: Asymptotic Analysis",
+      "startLine": 273,
+      "endLine": 290,
+      "summary": "`expected_ruin_time_quadratic` (the quadratic growth of E[T] in N) and `poor_gambler_expected_time` (the k=1 'poor gambler' asymptotic E[T]=N−1).",
+      "mathContext": "Quadratic growth of $E[T]$; poor-gambler ($k=1$) gives $E[T]=N-1$."
+    },
+    {
+      "id": "part8-biased",
+      "title": "Part VIII: Biased Random Walk (p ≠ 1/2)",
+      "startLine": 291,
+      "endLine": 399,
+      "summary": "Introduces `BiasedGamblersRuin` with odds ratio r=q/p and proves the biased ruin probabilities `biasedRuinProbWin`/`biasedRuinProbLose` ((1−rᵏ)/(1−rᴺ)), the sum-to-one identity, the favorable (r<1) and unfavorable (r>1) cases, and `fair_limit_lhopital` recovering the symmetric formula as p→1/2.",
+      "mathContext": "Biased walk: $P_{win}=(1-r^k)/(1-r^N)$, $r=q/p$; L'Hôpital limit recovers the fair case."
+    },
+    {
+      "id": "part9-exponential-decay",
+      "title": "Part IX: Exponential Decay of Ruin Time Distribution",
+      "startLine": 400,
+      "endLine": 446,
+      "summary": "The dominant eigenvalue cos(π/N) governs the exponential tail: `ruin_time_decay_rate_pos` and `ruin_time_decay_rate_lt_one` (0 < cos(π/N) < 1 for N ≥ 3), plus `expected_time_from_pgf_agrees` reconciling the PGF derivation with E[T]=k(N−k).",
+      "mathContext": "Ruin-time tail decays like $\\cos(\\pi/N)^n$, $0<\\cos(\\pi/N)<1$ for $N\\ge 3$."
+    },
+    {
+      "id": "part10-second-moment-variance",
+      "title": "Part X: Second Moment and Variance of Ruin Time",
+      "startLine": 447,
       "endLine": 632,
-      "summary": "The dominant eigenvalue cos(π/N) governs exponential tail decay. Proved 0 < cos(π/N) < 1 for N ≥ 3.",
-      "mathContext": "$P(T > t) \\sim C \\cdot \\cos(\\pi/N)^t$. Proved $\\cos(\\pi/N) \\in (0,1)$ via trigonometric identities."
+      "summary": "Defines `expectedRuinTimeSq`/`varianceRuinTime`, proves `variance_eq_second_moment_minus_square`, the second-moment recurrence and boundary conditions, `variance_nonneg`, `variance_symmetric`, `variance_upper_bound`, the `coefficient_of_variation_sq`, and concrete variance values (N2_k1, N4_k2, N3_k1, N10_k5).",
+      "mathContext": "Variance of T: $\\mathrm{Var}(T)=E[T^2]-E[T]^2$ via a second-moment recurrence, with bounds and worked values."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
The gallery `meta.json` for **fair-games-theorem-oq-01** (quantitative gambler's ruin) had drifted: its 6 `sections` no longer matched the file's 10 `PART I`–`PART X` banners.

Uncovered / lumped in the old meta:
- Lines 1–44 — module header
- Lines 185–219 — **Part IV: Concrete Examples**
- Lines 255–309 — **Part VI: Variance Bounds** and **Part VII: Asymptotic Analysis**
- Parts **IX** and **X** were collapsed into one section

## Changes
- Rebuilt **11 contiguous sections** (header + Parts I–X) aligned to all 10 `PART N:` banners across the full 632 lines, no gaps or overlaps.
- Wrote accurate per-part summaries from each section's declarations: the `GamblersRuin` setup, linear- and quadratic-martingale ruin results, concrete examples, symmetry, variance bounds, asymptotics, the biased random walk, exponential ruin-time decay, and the second-moment/variance analysis.

Content-only change to gallery metadata; the Lean proof file is unchanged (0 sorries, 0 axioms, 49 theorems).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections are contiguous (1→632) and each aligns to a `PART N:` banner
- [x] Theorem/axiom counts unchanged