### PR TITLE
research(arithmetic-series-oq-04-oq-01): realign gallery sections to full file (5→7)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
@@ -55,44 +55,60 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring poses the open question (extending Faulhaber's formula to higher power sums and proving structural properties of the Bernoulli-sum representation, in particular writing odd power sums as polynomials in the triangular number T(n)). Opens a noncomputable section, opens Finset, BigOperators, Polynomial, and declares the ArithmeticSeriesOQ04OQ01 namespace.",
+      "mathContext": "Faulhaber's formula gives closed forms for $\\sum_{k=1}^n k^p$. The structural insight is that for odd $p$, the sum is a polynomial in $T(n) = n(n+1)/2$, revealing a connection between power sums and triangular numbers beyond the mere existence of a closed form."
+    },
+    {
       "id": "higher-power-sums",
       "title": "Part I: Higher Power Sum Formulas",
-      "startLine": 37,
-      "endLine": 83,
+      "startLine": 39,
+      "endLine": 95,
       "summary": "sum_powers_four: sum k^4 = n(n+1)(2n+1)(3n^2+3n-1)/30. sum_powers_five: sum k^5 = n^2(n+1)^2(2n^2+2n-1)/12. sum_powers_six: sum k^6 = n(n+1)(2n+1)(3n^4+6n^3-3n+1)/42.",
       "mathContext": "$$\\sum_{k=1}^{n} k^4 = \\frac{n(n+1)(2n+1)(3n^2+3n-1)}{30}$$\n$$\\sum_{k=1}^{n} k^5 = \\frac{n^2(n+1)^2(2n^2+2n-1)}{12}$$\n$$\\sum_{k=1}^{n} k^6 = \\frac{n(n+1)(2n+1)(3n^4+6n^3-3n+1)}{42}$$\nThe denominator 30 = 2*3*5 for p=4 comes from $B'_4 = -1/30$, and 42 = 2*3*7 for p=6 comes from $B'_6 = 1/42$."
     },
     {
       "id": "triangular-structure",
       "title": "Part II: Faulhaber's Triangular Number Structure",
-      "startLine": 95,
-      "endLine": 132,
+      "startLine": 96,
+      "endLine": 153,
       "summary": "Defines T(n) = n(n+1)/2. sum_pow_one_eq_triangular: sum k = T(n). sum_pow_three_eq_triangular_sq: sum k^3 = T(n)^2 (Nicomachus). sum_pow_five_eq_triangular: sum k^5 = T(n)^2 * (4T(n)-1)/3.",
       "mathContext": "Faulhaber's observation for odd powers:\n$$\\sum_{k=1}^n k = T(n), \\quad \\sum_{k=1}^n k^3 = T(n)^2, \\quad \\sum_{k=1}^n k^5 = \\frac{T(n)^2(4T(n)-1)}{3}$$\nwhere $T(n) = n(n+1)/2$ is the $n$-th triangular number. The general pattern: for odd $p$, $\\sum k^p$ is $T(n)^2$ times a polynomial in $T(n)$ of degree $(p-3)/2$."
     },
     {
       "id": "divisibility",
       "title": "Part III: Power Sum Divisibility",
-      "startLine": 140,
-      "endLine": 178,
+      "startLine": 154,
+      "endLine": 219,
       "summary": "Cleared-denominator forms: 6*sum k^2 = n(n+1)(2n+1), 4*sum k^3 = n^2(n+1)^2, 30*sum k^4 = n(n+1)(2n+1)(3n^2+3n-1), 12*sum k^5 = n^2(n+1)^2(2n^2+2n-1).",
       "mathContext": "The cleared-denominator forms make integer divisibility visible:\n- $6 \\mid n(n+1)(2n+1)$ always (product of consecutive-ish integers)\n- $4 \\mid n^2(n+1)^2$ always ($n(n+1)$ is even)\n- $30 \\mid n(n+1)(2n+1)(3n^2+3n-1)$ always (non-obvious!)\n- $12 \\mid n^2(n+1)^2(2n^2+2n-1)$ always"
     },
     {
       "id": "even-power-factor",
       "title": "Part IV: Even-Power Common Factor",
-      "startLine": 186,
-      "endLine": 205,
+      "startLine": 220,
+      "endLine": 250,
       "summary": "Even power sums share the factor n(n+1)(2n+1). Demonstrated for p=2 and p=6.",
       "mathContext": "For even $p \\geq 2$, $\\sum_{k=1}^n k^p$ always contains the factor $n(n+1)(2n+1)$. This reflects the fact that the Bernoulli polynomial $B_{2m+1}(x)$ has the factor $x(x-1)(2x-1)$, which after evaluation becomes $n(n+1)(2n+1)$ (up to sign)."
     },
     {
       "id": "verification",
       "title": "Part V: Numerical Verifications",
-      "startLine": 211,
-      "endLine": 228,
+      "startLine": 251,
+      "endLine": 279,
       "summary": "Numerical checks for n=10: sum k^4 = 25333, sum k^5 = 220825, sum k^6 = 1978405. Cross-checks via factored forms and Faulhaber structure verification.",
       "mathContext": "For $n=10$, $T(10) = 55$:\n$$\\sum k^4 = 25333, \\quad \\sum k^5 = 220825 = 55^2 \\cdot 73 = T(10)^2 \\cdot \\frac{4 \\cdot 55 - 1}{3}$$\n$$\\sum k^6 = 1{,}978{,}405$$"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 280,
+      "endLine": 305,
+      "summary": "Closing docstring recaps the results: explicit higher power sums for p=4,5,6 (by induction), Faulhaber's triangular-number structure for odd powers, the cleared-denominator divisibility forms, and the even-power common factor n(n+1)(2n+1). Notes all theorems are proved by induction with 0 sorries and 0 axioms.",
+      "mathContext": "Summary of the file: higher power sums ($p=4,5,6$), odd-power Faulhaber structure ($\\sum k^p$ as a polynomial in $T(n)^2$), divisibility via cleared denominators, and the shared factor $n(n+1)(2n+1)$ for even power sums. All results proved by induction; 0 sorries, 0 axioms."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Section-metadata realign for **arithmetic-series-oq-04-oq-01** (Faulhaber's formula via Bernoulli sums — SOLVED, 0 sorries / 0 axioms). The five `Part` sections were all drifted early and compressed relative to the Lean file's boxed `PART I`–`PART V` banners, leaving the opening docstring (1-38) and the closing Summary docstring (280-305) uncovered.

## Progress
- Realigned each Part to its boxed banner: **I** (39-95), **II** (96-153), **III** (154-219), **IV** (220-250), **V** (251-279).
- Added an **Overview and Setup** section for the header docstring + namespace/opens (1-38).
- Added a **Summary** section for the trailing recap docstring (280-305).
- Coverage is now contiguous **1-305**; section count 5 → 7.

## Findings
- The five existing summaries/mathContext were accurate and preserved verbatim — only the line ranges were wrong.
- Lean source unchanged: 0 axioms / 19 theorems / 1 definition / 0 sorries.

## Status
**Outcome**: completed (content realign)
**Next Steps**: none required for this entry.

🤖 Generated by researcher-6