### PR TITLE
Enrich erdos-1006-oq-04: realign drifted sections + annotations (6→8)

### DIFF
--- a/src/data/proofs/erdos-1006-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1006-oq-04/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-1006-oq-04",
     "range": {
       "startLine": 1,
-      "endLine": 30
+      "endLine": 31
     },
     "type": "concept",
     "title": "Module Setup — Building on OQ03",
@@ -27,8 +27,8 @@
     "id": "ann-rank-strict",
     "proofId": "erdos-1006-oq-04",
     "range": {
-      "startLine": 31,
-      "endLine": 50
+      "startLine": 32,
+      "endLine": 51
     },
     "type": "insight",
     "title": "Graded DAG: Color as Strict Rank Function",
@@ -52,8 +52,8 @@
     "id": "ann-source-sink",
     "proofId": "erdos-1006-oq-04",
     "range": {
-      "startLine": 51,
-      "endLine": 71
+      "startLine": 52,
+      "endLine": 72
     },
     "type": "insight",
     "title": "Color-0 Sources and Color-(k-1) Sinks",
@@ -77,8 +77,8 @@
     "id": "ann-arc-iff",
     "proofId": "erdos-1006-oq-04",
     "range": {
-      "startLine": 72,
-      "endLine": 101
+      "startLine": 73,
+      "endLine": 102
     },
     "type": "insight",
     "title": "Arc Characterization — Orientation Fully Determined by Color",
@@ -102,8 +102,8 @@
     "id": "ann-different-colors",
     "proofId": "erdos-1006-oq-04",
     "range": {
-      "startLine": 102,
-      "endLine": 115
+      "startLine": 103,
+      "endLine": 116
     },
     "type": "concept",
     "title": "No Horizontal Arcs — All Arcs Cross Color Levels",
@@ -125,8 +125,8 @@
     "id": "ann-oq03-consistency",
     "proofId": "erdos-1006-oq-04",
     "range": {
-      "startLine": 116,
-      "endLine": 163
+      "startLine": 117,
+      "endLine": 130
     },
     "type": "concept",
     "title": "Consistency with OQ03 — Acyclicity Follows from Rank",
@@ -143,6 +143,51 @@
       "Proofs.Erdos1006OQ03 results",
       "DAG acyclicity",
       "robust orientation theory"
+    ]
+  },
+  {
+    "id": "ann-1006oq04-transitivity",
+    "proofId": "erdos-1006-oq-04",
+    "range": {
+      "startLine": 131,
+      "endLine": 160
+    },
+    "type": "technique",
+    "title": "Part VI: Transitivity and Non-Reflexivity — a Strict Partial Order",
+    "content": "Four theorems give the order-theoretic shape of the coloring orientation: coloringOrientation_trans (transitive — u→v and v→w yield u→w, since color strictly increases along arcs), coloringOrientation_arc_irrefl (irreflexive — no vertex has an arc to itself), coloringOrientation_arc_ne (arcs connect distinct vertices), and coloring_same_color_not_adj (vertices sharing a color are non-adjacent, the contrapositive of proper coloring). Combined with rank-strictness, these show the orientation is a strict partial order refining the coloring.",
+    "mathContext": "$u \\to v \\to w \\Rightarrow u \\to w$ (transitive, via $\\text{col}(u) < \\text{col}(v) < \\text{col}(w)$); $\\neg(v \\to v)$ (irreflexive); $u \\to v \\Rightarrow u \\neq v$. The relation is therefore a strict partial order.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict partial order",
+      "transitivity",
+      "irreflexivity",
+      "graph orientation"
+    ],
+    "prerequisites": [
+      "proper graph coloring",
+      "strict orders"
+    ]
+  },
+  {
+    "id": "ann-1006oq04-summary",
+    "proofId": "erdos-1006-oq-04",
+    "range": {
+      "startLine": 161,
+      "endLine": 193
+    },
+    "type": "context",
+    "title": "Summary: Structural Properties of the Coloring Orientation",
+    "content": "The closing docstring inventories the verified results: the coloring orientation u→v ⟺ col(u)<col(v) (for adjacent vertices) yields rank structure, color-0 sources and color-(k-1) sinks, full arc-direction determination, no horizontal arcs, acyclicity/consistency with OQ03, and a transitive irreflexive order. All theorems are machine-checked with 0 sorries and 0 axioms.",
+    "mathContext": "A proper k-coloring induces a strict partial order (graded DAG) on the graph; the construction is fully formalized with 0 sorries and 0 axioms.",
+    "significance": "context",
+    "relatedConcepts": [
+      "graded DAG",
+      "graph coloring",
+      "acyclic orientation"
+    ],
+    "prerequisites": [
+      "proper coloring",
+      "directed acyclic graphs"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1006-oq-04/meta.json
+++ b/src/data/proofs/erdos-1006-oq-04/meta.json
@@ -62,49 +62,65 @@
       "id": "header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 33,
+      "endLine": 31,
       "summary": "Docstring describing the coloring orientation construction and the 5 structural properties to be proved. Imports Erdos1006OQ03 for the coloringOrientation definition and related results.",
       "mathContext": "The coloring orientation: given proper $k$-coloring $\\text{col}: V \\to \\text{Fin}(k)$, orient $u \\to v$ when $\\text{col}(u) < \\text{col}(v)$. Properties: rank strictness, source/sink structure, arc characterization, no back-arcs."
     },
     {
       "id": "level-structure",
       "title": "Part I: Level Structure",
-      "startLine": 31,
-      "endLine": 50,
+      "startLine": 32,
+      "endLine": 51,
       "summary": "Three theorems: `coloringOrientation_rank_strict` (arcs go from lower to higher color), `coloringOrientation_has_rank` (color value is an explicit rank witness), `coloringOrientation_rank_lt_k` (all ranks < k). All proved directly from the arc definition and Fin.isLt.",
       "mathContext": "If $(u \\to v)$ is an arc, then $\\text{col}(u) < \\text{col}(v)$ (rank strict). The function $v \\mapsto \\text{col}(v).\\text{val}$ is an explicit rank witness. All values are in $\\{0, \\ldots, k-1\\}$."
     },
     {
       "id": "source-sink",
       "title": "Part II: Source and Sink Structure",
-      "startLine": 51,
-      "endLine": 71,
+      "startLine": 52,
+      "endLine": 72,
       "summary": "`color_zero_no_in_arc`: vertices with color 0 have no in-arcs (proved by `omega` — an in-arc would require color < 0). `color_max_no_out_arc`: vertices with color k-1 have no out-arcs (proved by `omega` — an out-arc would require color > k-1).",
       "mathContext": "Color-0 vertices: $\\text{col}(v) = 0$ and $(u \\to v)$ would imply $\\text{col}(u) < 0$, contradiction. Color-$(k-1)$ vertices: $\\text{col}(v) = k-1$ and $(v \\to u)$ would imply $\\text{col}(u) > k-1 \\geq \\text{col}(u)$, contradicting Fin bound."
     },
     {
       "id": "arc-direction",
       "title": "Part III: Arc Direction Characterization",
-      "startLine": 72,
-      "endLine": 101,
+      "startLine": 73,
+      "endLine": 102,
       "summary": "Three theorems: `coloringOrientation_arc_iff` (arc iff color ordering, for adjacent vertices), `coloringOrientation_no_back_arc` (no 2-cycles — omega contradiction from rank strict applied twice), `coloringOrientation_exactly_one_arc` (exactly one arc direction per edge, via covers from OQ03).",
       "mathContext": "$(u \\to v) \\iff \\text{col}(u) < \\text{col}(v)$ for $u \\sim v$. For adjacent $u, v$: exactly one of $\\text{col}(u) < \\text{col}(v)$ or $\\text{col}(v) < \\text{col}(u)$ holds (since $\\text{col}(u) \\neq \\text{col}(v)$ by properness)."
     },
     {
       "id": "no-same-level",
       "title": "Part IV: No Same-Level Arcs",
-      "startLine": 102,
-      "endLine": 115,
+      "startLine": 103,
+      "endLine": 116,
       "summary": "`coloringOrientation_different_colors`: arcs only exist between differently-colored vertices (col(u) ≠ col(v)). Proved from rank strictness via Nat.lt_irrefl.",
       "mathContext": "$(u \\to v) \\Rightarrow \\text{col}(u) < \\text{col}(v) \\Rightarrow \\text{col}(u) \\neq \\text{col}(v)$. Equivalently, there are no 'horizontal' arcs between vertices at the same color level."
     },
     {
       "id": "consistency-oq03",
       "title": "Part V: Consistency with OQ03 Results",
-      "startLine": 116,
-      "endLine": 163,
+      "startLine": 117,
+      "endLine": 130,
       "summary": "`coloringOrientation_acyclic_via_rank`: restates OQ03's acyclicity result through the rank lens. `every_graph_has_robust`: restates OQ03's main theorem. Both delegate to OQ03 directly.",
       "mathContext": "Acyclicity follows from rank strictness: any directed path $v_0 \\to v_1 \\to \\cdots \\to v_n$ satisfies $\\text{col}(v_0) < \\text{col}(v_1) < \\cdots < \\text{col}(v_n)$, preventing cycles."
+    },
+    {
+      "id": "transitivity",
+      "title": "Part VI: Transitivity and Non-Reflexivity",
+      "startLine": 131,
+      "endLine": 160,
+      "summary": "Four theorems on the order structure of the orientation: coloringOrientation_trans (the arc relation is transitive — u→v and v→w give u→w via col(u)<col(v)<col(w)), coloringOrientation_arc_irrefl (irreflexive — no self-arcs), coloringOrientation_arc_ne (arcs join distinct vertices), and coloring_same_color_not_adj (same-colored vertices are non-adjacent, the contrapositive of properness). With rank-strictness these make the orientation a strict partial order refining the coloring.",
+      "mathContext": "$u \\to v \\to w \\Rightarrow u \\to w$ (transitive, via $\\text{col}(u) < \\text{col}(v) < \\text{col}(w)$); $\\neg(v \\to v)$ (irreflexive); $u \\to v \\Rightarrow u \\neq v$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 161,
+      "endLine": 193,
+      "summary": "Closing summary docstring recapping the coloring-orientation construction and its proved structural properties — level/rank structure, source/sink vertices, arc-direction characterization, no horizontal arcs, consistency with OQ03, and transitivity/non-reflexivity — all verified with 0 sorries and 0 axioms.",
+      "mathContext": "The coloring orientation $u \\to v \\iff \\text{col}(u) < \\text{col}(v)$ (for adjacent $u \\sim v$) is a strict partial order refining the proper coloring; fully machine-checked, 0 sorries, 0 axioms."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-1006-oq-04` (coloring-orientation structural properties; verified, 0 axioms / 0 sorries).

**Sections (6 → 8):** the final section "Part V: Consistency with OQ03" (116–163) lumped together Part V, Part VI ("Transitivity and Non-Reflexivity"), and the closing `## Summary` banner, while the tail (164–193) was uncovered and §1 "Module Header" (1–33) overlapped §2 "Part I" (31–50). Split out dedicated "Part VI" and "Summary" sections, fixed the header/Part-I overlap, and aligned every section to the `## Part` banners. Sections are now contiguous over 1–193.

**Annotations (6 → 8):** the same co-drift — the "Consistency with OQ03" annotation spanned 116–163. Trimmed it to Part V and added annotations for Part VI (the four transitivity / irreflexivity / arc_ne / same-color-not-adjacent theorems, previously undescribed) and the Summary, plus minor range realignments to the banners. Annotations now align 1:1 with sections.

No Lean source changes. Meta is accurate (verified, 0 axioms, 0 sorries). JSON validated; meta indent=2 + trailing newline, annotations indent=2 no trailing newline.