### PR TITLE
research(abel-ruffini-oq-04-oq-07): realign sections + split lumped Parts (5→8)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -62,19 +62,28 @@
   },
   "sections": [
     {
+      "id": "overview-imports",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 84,
+      "summary": "Mathlib imports (polynomial, analysis/IVT, monotonicity), the file docstring on the Bring-Jerrard reduction and Bring radical, and the namespace setup.",
+      "mathContext": "Sets up the reduction chain quintic → depressed quintic → Bring-Jerrard form $x^5 + px + q$, and the Bring radical BR$(t)$ as the unique real root of $x^5 + x + t = 0$. Existence uses the intermediate value theorem; uniqueness uses strict monotonicity of $x \\mapsto x^5 + x$.",
+      "theorems": []
+    },
+    {
       "id": "poly-defs",
-      "title": "Polynomial Type Definitions",
+      "title": "Part 1: Polynomial Type Definitions",
       "startLine": 85,
-      "endLine": 102,
+      "endLine": 103,
       "summary": "Defines quinticPoly (5 free parameters), depressedQuintic (4 free parameters, no x⁴ term), and bringJerrardPoly (2 free parameters, Bring-Jerrard normal form x⁵+px+q).",
       "mathContext": "Three polynomial types over $\\mathbb{C}$ representing the three normal forms in the reduction chain: quintic → depressed quintic → Bring-Jerrard form.",
       "theorems": []
     },
     {
       "id": "tschirnhaus",
-      "title": "Linear Tschirnhaus Transform (Proved)",
+      "title": "Part 2: Linear Tschirnhaus Transform (Proved)",
       "startLine": 104,
-      "endLine": 170,
+      "endLine": 171,
       "summary": "Proves the forward (depressed_quintic_forward), backward (depressed_quintic_backward), and biconditional (depressed_quintic_iff) forms of the linear Tschirnhaus transform y = x + a₄/5 that eliminates the x⁴ term. All proved by linear_combination.",
       "mathContext": "The substitution $y = x + a_4/5$ gives $b_4 = -5(a_4/5) + a_4 = 0$, with explicit formulas for $b_3, b_2, b_1, b_0$. Proved by `linear_combination h`.",
       "theorems": [
@@ -85,9 +94,9 @@
     },
     {
       "id": "bring-jerrard",
-      "title": "Full Bring-Jerrard Reduction (Axiomatized)",
+      "title": "Part 3: Full Bring-Jerrard Reduction (Axiomatized)",
       "startLine": 172,
-      "endLine": 222,
+      "endLine": 223,
       "summary": "Axiomatizes the full Bring-Jerrard reduction (quadratic and cubic Tschirnhaus steps). Proves quintic_to_bringJerrard by chaining the linear transform with the axiom.",
       "mathContext": "The axiom $\\exists\\, p, q, \\varphi,\\ \\forall y.\\ y^5 + b_3 y^3 + \\cdots = 0 \\Rightarrow (\\varphi(y))^5 + p(\\varphi(y)) + q = 0$ requires polynomial resultant theory not in Mathlib.",
       "theorems": [
@@ -97,29 +106,52 @@
     },
     {
       "id": "strict-mono",
-      "title": "Strict Monotonicity and IVT Existence",
+      "title": "Part 4: The Bring Radical — Strict Monotonicity",
       "startLine": 224,
-      "endLine": 294,
-      "summary": "Proves bringRad_strictMono (x↦x⁵+x is strictly increasing) and bringRad_exists (x⁵+x+t=0 has a real root for every t) via IVT with bounds ±(|t|+1).",
-      "mathContext": "$f(x) = x^5 + x$ is strictly monotone (Odd.strictMono_pow + linarith) and continuous, with $f(-(|t|+1)) < 0 < f(|t|+1)$ for all $t$.",
+      "endLine": 249,
+      "summary": "Proves bringRad_strictMono: x↦x⁵+x is strictly increasing on ℝ. This guarantees uniqueness of the root of x⁵+x+t=0 for each t.",
+      "mathContext": "Since 5 is odd, $x^5$ is strictly monotone (`Odd.strictMono_pow`), and adding the identity preserves strict monotonicity (`linarith`). Strict monotonicity of $f(x) = x^5 + x$ underwrites both uniqueness of the Bring radical and its anti-monotonicity in $t$.",
       "theorems": [
-        "bringRad_strictMono",
+        "bringRad_strictMono"
+      ]
+    },
+    {
+      "id": "existence-ivt",
+      "title": "Part 5: The Bring Radical — Existence via IVT",
+      "startLine": 250,
+      "endLine": 295,
+      "summary": "Proves bringRad_exists: x⁵+x+t=0 has a real root for every t, via the intermediate value theorem on [−(|t|+1), |t|+1], using the sign-change lemmas bringRad_pos_at_upper and bringRad_neg_at_lower.",
+      "mathContext": "$f(x) = x^5 + x + t$ is continuous and coercive. The explicit bounds give $f(-(|t|+1)) < 0 < f(|t|+1)$ for all $t$ (since $(|t|+1)^5 \\ge 0$ dominates $|t|$), so `intermediate_value_Icc` yields a root.",
+      "theorems": [
+        "bringRad_pos_at_upper",
+        "bringRad_neg_at_lower",
         "bringRad_exists"
       ]
     },
     {
       "id": "bring-radical",
-      "title": "Bring Radical: Definition and Properties",
+      "title": "Part 6: The Bring Radical — Definition and Properties",
       "startLine": 296,
-      "endLine": 377,
-      "summary": "Defines bringRadical t = the unique real root of x⁵+x+t=0. Proves: bringRadical_spec (satisfies equation), bringRadical_unique, bringRadical_anti_mono, bringRadical_zero, bringRadical_neg (odd function). Axiomatizes bringRadical_not_in_radicals. Summary theorem packages the main results.",
-      "mathContext": "BR$(t)$ satisfies BR$(t)^5 + \\mathrm{BR}(t) + t = 0$, is strictly anti-monotone, odd, and BR$(0) = 0$. Not expressible by nested radicals (axiom).",
+      "endLine": 343,
+      "summary": "Defines bringRadical t = the unique real root of x⁵+x+t=0. Proves: bringRadical_spec (satisfies equation), bringRadical_unique, bringRadical_anti_mono, bringRadical_zero, bringRadical_neg (odd function).",
+      "mathContext": "BR$(t)$ satisfies BR$(t)^5 + \\mathrm{BR}(t) + t = 0$ (`choose_spec`), is strictly anti-monotone, odd (BR$(-t) = -\\mathrm{BR}(t)$), and BR$(0) = 0$. Uniqueness comes from injectivity of the strictly monotone $x \\mapsto x^5 + x$.",
       "theorems": [
         "bringRadical_spec",
         "bringRadical_unique",
         "bringRadical_anti_mono",
         "bringRadical_zero",
-        "bringRadical_neg",
+        "bringRadical_neg"
+      ]
+    },
+    {
+      "id": "algebraic-significance",
+      "title": "Part 7: Algebraic Significance",
+      "startLine": 344,
+      "endLine": 377,
+      "summary": "Axiomatizes bringRadical_not_in_radicals (the Bring radical is not expressible in radicals, via Abel-Ruffini and the non-solvability of S₅). Proves bringJerrard_summary, packaging the unique-root, defining-equation, and anti-monotonicity results.",
+      "mathContext": "The generic Bring-Jerrard quintic $y^5 + y + t$ has Galois group $S_5$ over $\\mathbb{Q}(t)$, which is not solvable, so its roots (the Bring radicals) are not radical expressions. A full proof would need the $S_5$ Galois computation; the connection is axiomatized.",
+      "theorems": [
+        "bringRadical_not_in_radicals",
         "bringJerrard_summary"
       ]
     }


### PR DESCRIPTION
## Summary

The gallery metadata for `abel-ruffini-oq-04-oq-07` (Bring-Jerrard Reduction & Bring Radical) listed only 5 sections, but the 377-line Lean source is organized into seven `-- PART N` banners plus a header.

### What was wrong
- **Header uncovered**: lines 1-84 (imports, docstring, namespace) had no section.
- **Parts 4 & 5 lumped**: "Strict Monotonicity" (PART 4 @224) and "Existence via IVT" (PART 5 @250) were combined into a single section (224-294).
- **Parts 6 & 7 lumped**: "Definition and Properties" (PART 6 @296) and "Algebraic Significance" (PART 7 @344) were combined (296-377).
- Section endLines were off-by-one from their banner spans.

### Changes
- Add `Overview and Imports` section (1-84)
- Split the monotonicity/existence section into Part 4 (224-249, `bringRad_strictMono`) and Part 5 (250-295, `bringRad_exists` + sign-change lemmas)
- Split the Bring-radical section into Part 6 (296-343, definition + properties) and Part 7 (344-377, the `bringRadical_not_in_radicals` axiom + summary theorem)
- Distribute the per-section `theorems` arrays to match the split
- Result: 8 contiguous sections covering 1-377

No Lean source changes; content-only metadata fix. Annotations already match the file structure and are left unchanged.

## Test plan
- [x] meta.json parses as valid JSON
- [x] Sections are contiguous 1-377 with no gaps or overlaps
- [x] Section ranges match the `-- PART N` banner positions and the theorems they contain