### PR TITLE
research(erdos-234): realign drifted gallery sections to full file (11→12)

### DIFF
--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -47,40 +47,40 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Imports and Namespace",
-      "startLine": 15,
-      "endLine": 36,
-      "summary": "Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`.",
-      "mathContext": "Verified: Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`."
+      "title": "Overview, Imports and Namespace",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "File overview and references (Cramér, Gallagher, Erdős). Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`.",
+      "mathContext": "File overview and references. Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`."
     },
     {
       "id": "basic-definitions",
       "title": "Prime Gap Definitions",
-      "startLine": 37,
-      "endLine": 50,
+      "startLine": 32,
+      "endLine": 45,
       "summary": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\log n$ (with $0$ for $n \\leq 1$).",
-      "mathContext": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\$\\log n$$ (with $0$ for $n \\leq 1$)."
+      "mathContext": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\log n$ (with $0$ for $n \\leq 1$)."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions",
-      "startLine": 51,
-      "endLine": 62,
+      "startLine": 46,
+      "endLine": 57,
       "summary": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\log n < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$.",
-      "mathContext": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\$\\log n$ < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$."
+      "mathContext": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\log n < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
-      "startLine": 63,
-      "endLine": 82,
+      "startLine": 58,
+      "endLine": 77,
       "summary": "States ErdosProblem234: $\\forall c \\geq 0$, the density $f(c) = \\lim_{N} \\text{gapProportion}(N, c)$ exists and $f$ is continuous. Uses `Tendsto` with `atTop` and `nhds`.",
       "mathContext": "Mathematical content: States ErdosProblem234: $\\forall c \\geq 0$, the density $f(c) = \\lim_{N} \\text{gapProportion}(N, c)$ exists and $f$ is continuous. Uses `Tendsto` with `atTop` and `nhds`."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 83,
+      "startLine": 78,
       "endLine": 142,
       "summary": "Proves $f_N(0) = 0$, $0 \\leq f_N(c) \\leq 1$, monotonicity $c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$, and $f(0) = 0$.",
       "mathContext": "Verified: Proves $f_N(0) = 0$, $0 \\leq f_N(c) \\leq 1$, monotonicity $c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$, and $f(0) = 0$."
@@ -89,46 +89,54 @@
       "id": "markov-density",
       "title": "Proving density_at_infinity via Markov's Inequality",
       "startLine": 143,
-      "endLine": 263,
+      "endLine": 262,
       "summary": "**Key result**: Proves (previously axiom) density_at_infinity from average_normalized_gap via finite Markov inequality. For non-negative normalizedGap and $c > 0$: $|\\{n : \\text{gap}(n) \\geq c\\}| \\cdot c \\leq \\sum \\text{gap}(n)$, so gapProportion$(N,c) \\geq 1 - (\\text{avg gap})/c$. Choosing $c_0 = 2/\\varepsilon + 1$ gives the result. Reduces axiom count from 5 to 4.",
       "mathContext": "**Key result**: Proves (previously axiom) density_at_infinity from average_normalized_gap via finite Markov inequality. For non-negative normalizedGap and $c > 0$: $|\\{n : \\text{gap}(n) \\geq c\\}| \\cdot c \\leq \\sum \\text{gap}(n)$, so gapProportion$(N,c) \\geq 1 - (\\text{avg gap})/c$. Choosing $c_0 = 2/\\varepsilon + 1$ gives the result. Reduces axiom count from 5 to 4."
     },
     {
       "id": "cramer-model",
       "title": "Cramér's Exponential Model",
-      "startLine": 265,
-      "endLine": 303,
+      "startLine": 263,
+      "endLine": 295,
       "summary": "Defines cramerPrediction$(c) = 1 - e^{-c}$ for $c \\geq 0$. Proves continuity via `Continuous.if_lt` and validates CDF bounds $0 \\leq f(c) \\leq 1$.",
       "mathContext": "Formal definition: Defines cramerPrediction$(c) = 1 - e^{-c}$ for $c \\geq 0$. Proves continuity via `Continuous.if_lt` and validates CDF bounds $0 \\leq f(c) \\leq 1$."
     },
     {
       "id": "gallagher-result",
       "title": "Gallagher's Conditional Result",
-      "startLine": 304,
-      "endLine": 323,
+      "startLine": 296,
+      "endLine": 319,
       "summary": "Axiomatizes Gallagher (1976): RH $\\implies \\text{gapProportion}(N, c) \\to 1 - e^{-c}$. Proves gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234.",
       "mathContext": "Verified: Axiomatizes Gallagher (1976): RH $\\implies \\text{gapProportion}(N, c) \\to 1 - e^{-c}$. Proves gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234."
     },
     {
       "id": "partial-results",
       "title": "Partial Results on Gap Distribution",
-      "startLine": 324,
-      "endLine": 341,
-      "summary": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\log n$), (2) average $g_n/\\log n \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3.",
-      "mathContext": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\$\\log n$$), (2) average $g_n/\\$\\log n$ \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3."
+      "startLine": 320,
+      "endLine": 330,
+      "summary": "Axiomatizes the two remaining inputs: (1) large_gaps_exist (FGKT/Maynard: unbounded $g_n/\\log n$, stated as documentation), and (2) average_normalized_gap: $g_n/\\log n \\to 1$ on average by the Prime Number Theorem.",
+      "mathContext": "Axiomatizes the two remaining inputs: (1) large_gaps_exist (FGKT/Maynard: unbounded $g_n/\\log n$), and (2) average_normalized_gap: the Cesàro average of $g_n/\\log n$ tends to $1$ by PNT."
+    },
+    {
+      "id": "small-gaps",
+      "title": "Small Gaps from Average Gap (Axiom Elimination)",
+      "startLine": 331,
+      "endLine": 430,
+      "summary": "Proves (previously axiom) small_gaps_exist from average_normalized_gap via a Cesàro contrapositive: if only finitely many $n$ had normalizedGap $< 1+\\varepsilon$, the average would exceed $1$, contradicting PNT. Supporting lemmas: nthPrime_ge ($n \\leq p_n$), infinite_normalizedGap_lt, and primeGap_lt_of_normalizedGap_lt. Reduces axiom count from 4 to 3.",
+      "mathContext": "Proves small_gaps_exist from average_normalized_gap by contradiction: a finite small-gap set forces the Cesàro average above $1$. Uses nthPrime_ge, infinite_normalizedGap_lt, primeGap_lt_of_normalizedGap_lt, with `nlinarith` and an Archimedean bound to close the contradiction."
     },
     {
       "id": "cramer-properties",
-      "title": "Cramér Model Properties",
-      "startLine": 342,
-      "endLine": 363,
+      "title": "Additional Properties of Cramér's Model",
+      "startLine": 431,
+      "endLine": 457,
       "summary": "Proves $f(0) = 0$, $f(c) \\geq 0$, $f(c) \\leq 1$, and monotonicity $c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$ using $e^{-c_2} \\leq e^{-c_1}$.",
       "mathContext": "Verified: Proves $f(0) = 0$, $f(c) \\geq 0$, $f(c) \\leq 1$, and monotonicity $c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$ using $e^{-c_2} \\leq e^{-c_1}$."
     },
     {
       "id": "density-function-properties",
       "title": "Properties of the Density Function",
-      "startLine": 461,
+      "startLine": 458,
       "endLine": 510,
       "summary": "Conditional properties of the density $f(c)$ (if it exists): $f(c) \\in [0,1]$, $f$ is monotone non-decreasing, and $f(c) \\to 1$ as $c \\to \\infty$. The last result uses density_at_infinity and `tendsto_order`.",
       "mathContext": "Verified: If the density exists (the limit of gapProportion), it necessarily satisfies CDF properties. The limit approach uses `ge_of_tendsto` / `le_of_tendsto` for bounds and `tendsto_order` for the convergence $f(c) \\to 1$."


### PR DESCRIPTION
## Summary

Build-free gallery-integrity realign for **erdos-234** (Density of Normalized Prime Gaps). The `meta.json` section ranges had drifted out of sync with `Proofs/Erdos234Problem.lean`:

- The `cramer-properties` section was mis-ranged to lines **342–363**, which actually fall *inside* the Section VII' small-gaps proof (`infinite_normalizedGap_lt`), not the Cramér-model properties.
- A **97-line span (364–460)** was left completely uncovered — this contained the entire Section VII' axiom-elimination work (`small_gaps_exist` and its supporting lemmas) and the real **Section VIII: Additional Properties of Cramér's Model** (`cramer_at_zero`, `cramer_nonneg`, `cramer_le_one`, `cramer_monotone`, lines 431–457).
- The file-level overview docstring (lines 1–14) was uncovered.

## Changes

Rebuilt **12 contiguous sections covering lines 1–510**, matching the file's 12 banner units (overview + Sections I–IX, including IV' and VII'):

- Folded the overview docstring into the `imports` section (1–31).
- Added a new `small-gaps` section for **Section VII'** (331–430): `small_gaps_exist` proved from `average_normalized_gap` via a Cesàro contrapositive.
- Re-ranged `cramer-properties` to its true **Section VIII** location (431–457) and corrected its title.
- Narrowed `partial-results` to Section VII (320–330) and removed the small-gaps claim from its summary (now in the dedicated section).

No `.lean` changes; metric counts (axiomCount 2, lineCount 510, sorries 0) unchanged and accurate.

## Test plan
- [x] `jq empty meta.json` passes (valid JSON)
- [x] 12 sections are contiguous (each start = prev end + 1) and cover lines 1–510 (= leanFile.lineCount)
- [x] Section ranges verified against actual banner/declaration positions in the `.lean`