### PR TITLE
research(erdos-1116): realign drifted gallery sections to full file (9→9)

### DIFF
--- a/src/data/proofs/erdos-1116/meta.json
+++ b/src/data/proofs/erdos-1116/meta.json
@@ -90,7 +90,7 @@
       "id": "meromorphic-functions",
       "title": "Meromorphic Functions and Value Distribution",
       "summary": "IsMeromorphic, IsEntire, entire_is_meromorphic",
-      "startLine": 40,
+      "startLine": 1,
       "endLine": 77,
       "mathContext": "Mathematical content: IsMeromorphic, IsEntire, entire_is_meromorphic"
     },
@@ -99,63 +99,63 @@
       "title": "The Counting Function",
       "summary": "aPoints, countingFunction definitions",
       "startLine": 78,
-      "endLine": 105,
+      "endLine": 125,
       "mathContext": "Formal definition: aPoints, countingFunction definitions"
     },
     {
       "id": "problem-statement",
       "title": "The Problem Statement",
       "summary": "HasUnboundedRatio, HasExtremeValueDistribution definitions",
-      "startLine": 106,
-      "endLine": 136,
+      "startLine": 126,
+      "endLine": 168,
       "mathContext": "Formal definition: HasUnboundedRatio, HasExtremeValueDistribution definitions"
     },
     {
       "id": "solution",
       "title": "The Solution",
       "summary": "goldberg_toppila_existence axiom, erdos_1116 theorem",
-      "startLine": 137,
-      "endLine": 160,
+      "startLine": 169,
+      "endLine": 192,
       "mathContext": "Verified: goldberg_toppila_existence axiom, erdos_1116 theorem"
     },
     {
       "id": "nevanlinna-theory",
       "title": "Nevanlinna Theory Context",
       "summary": "characteristic, integratedCounting, deficiency, nevanlinna_deficiency_sum",
-      "startLine": 161,
-      "endLine": 196,
+      "startLine": 193,
+      "endLine": 229,
       "mathContext": "Mathematical content: characteristic, integratedCounting, deficiency, nevanlinna_deficiency_sum"
     },
     {
       "id": "surprising",
       "title": "Why This is Surprising",
       "summary": "first_main_theorem_heuristic, oscillation_key_insight",
-      "startLine": 197,
-      "endLine": 229,
+      "startLine": 230,
+      "endLine": 267,
       "mathContext": "Verified: first_main_theorem_heuristic, oscillation_key_insight"
     },
     {
       "id": "construction",
       "title": "Construction Sketch",
       "summary": "IsLacunarySeries, WeierstrassProduct definitions",
-      "startLine": 230,
-      "endLine": 265,
+      "startLine": 268,
+      "endLine": 296,
       "mathContext": "Formal definition: IsLacunarySeries, WeierstrassProduct definitions"
     },
     {
       "id": "examples",
       "title": "Examples and Non-examples",
       "summary": "expFunction, exp_not_extreme, polynomial_not_extreme",
-      "startLine": 266,
-      "endLine": 290,
+      "startLine": 297,
+      "endLine": 341,
       "mathContext": "Mathematical content: expFunction, exp_not_extreme, polynomial_not_extreme"
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_1116_summary, keyInsightStatement",
-      "startLine": 291,
-      "endLine": 317,
+      "startLine": 342,
+      "endLine": 379,
       "mathContext": "Mathematical content: erdos_1116_summary, keyInsightStatement"
     }
   ],


### PR DESCRIPTION
## Summary
Section-coverage realign for the **Erdős #1116** gallery entry (`Proofs/Erdos1116Problem.lean`, 379 lines). The 9 section titles correctly matched the file's 9 `## Part I–IX` banners in order, but every `startLine`/`endLine` range had drifted ~30 lines early:

- Each section pointed at the **preceding** Part's region (e.g. `solution` at 137-160 landed inside Part III, not Part IV).
- The 39-line module-docstring header (1-39) was uncovered.
- The back half was compressed, leaving a 62-line tail (Part IX summary `erdos_1116_summary` + `keyInsightStatement`) uncovered.

Snapped all boundaries onto the `## Part` docstring openers (`/-` at 40, 78, 126, 169, 193, 230, 268, 297, 342) so the file is contiguously covered **1-379**. Titles and summaries are unchanged — verified that each summary's named declarations fall inside its corrected range.

No Lean source changes. Counts unchanged (379 lines, 2 axioms, 0 sorries).

## Section map (after)
| lines | id |
|------|-----|
| 1-77 | meromorphic-functions (Part I + header) |
| 78-125 | counting-function (Part II) |
| 126-168 | problem-statement (Part III) |
| 169-192 | solution (Part IV) |
| 193-229 | nevanlinna-theory (Part V) |
| 230-267 | surprising (Part VI) |
| 268-296 | construction (Part VII) |
| 297-341 | examples (Part VIII) |
| 342-379 | main-results (Part IX) |

## Test plan
- [x] `meta.json` is valid JSON
- [x] sections contiguous, last endLine (379) == lineCount (379)
- [x] each section summary's decls verified inside its new range
- [x] no contention: slug has no open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)