### PR TITLE
research(erdos-1-oq-02): realign drifted gallery sections to full file (5→5)

### DIFF
--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -84,41 +84,41 @@
       "id": "header",
       "title": "Header and Strategy",
       "startLine": 1,
-      "endLine": 55,
-      "summary": "Imports Erdos1Problem and Mathlib. Module docstring describes the DFX 2021 framework: view subset sums as random variables, use variance (Berry-Esseen) anticoncentration to bound the number of distinct values, derive N ≥ √(2/π)·2ⁿ/√n.",
-      "mathContext": "The file imports `Proofs.Erdos1Problem` (which defines `HasDistinctSubsetSums`) and `Mathlib` (for `Real.sqrt`, `Finset.induction_on`, and `nlinarith`). The strategy: convert the discrete counting problem into a continuous probability argument by viewing $X = \\sum \\varepsilon_i a_i$ as a random variable approximated by $\\mathcal{N}(S/2, V)$."
+      "endLine": 49,
+      "summary": "States Erdős #1 OQ-02: a refined lower bound on the largest element of a distinct-subset-sums set, via the DFX (Dubroff–Fox–Xu 2021) anticoncentration approach. Documents what is proved, the proof strategy, connection to prior work, and references.",
+      "mathContext": "Distinct-subset-sums sets: DFX (2021) anticoncentration lower bound on $\\max A$ given $|A|=k$."
     },
     {
-      "id": "part-i-variance-upper",
-      "title": "Part I: Variance Upper Bounds (Σa² and Σa)",
-      "startLine": 56,
-      "endLine": 88,
-      "summary": "Two crude upper bounds: sum_sq_le_card_mul_max_sq (Σa² ≤ n·N², term-by-term using Finset.sum_le_sum) and sum_sq_cauchy_schwarz (Σa² ≥ (Σa)²/n, Cauchy-Schwarz proved by ℤ lifting + Finset.induction_on).",
-      "mathContext": "`sum_sq_le_card_mul_max_sq`: $\\sum a^2 \\leq n \\cdot N^2$ since each $a \\leq N$. `sum_sq_cauchy_schwarz`: $(\\sum a)^2 \\leq n \\cdot \\sum a^2$ — this is $\\langle \\mathbf{a}, \\mathbf{1} \\rangle^2 \\leq \\|\\mathbf{a}\\|^2 \\cdot \\|\\mathbf{1}\\|^2$. Proved by `Finset.induction_on` in $\\mathbb{Z}$ using $\\sum_{b \\in s}(a-b)^2 \\geq 0$ expanded via `ring` and closed by `nlinarith`."
+      "id": "part1",
+      "title": "Part I: Variance Bounds",
+      "startLine": 50,
+      "endLine": 97,
+      "summary": "PROVES the variance/second-moment infrastructure: `sum_sq_le_card_mul_max_sq` ($\\sum a^2\\leq|A|N^2$), `sum_sq_cauchy_schwarz` (Cauchy–Schwarz on the elements), and `sum_le_card_mul_max` ($\\sum a\\leq|A|N$).",
+      "mathContext": "$\\sum_{a\\in A}a^2\\leq|A|N^2$, $\\sum a\\leq|A|N$ (variance bounds for $A\\subseteq[0,N]$)."
     },
     {
-      "id": "part-i-variance-sum",
-      "title": "Part I: Sum Bound and Part II Header",
-      "startLine": 89,
-      "endLine": 120,
-      "summary": "sum_le_card_mul_max (Σa ≤ n·max(A)): bounds the total sum by n times the maximum element. Followed by the Part II section header documenting the anticoncentration strategy and the namespace opening for the Berry-Esseen step.",
-      "mathContext": "`sum_le_card_mul_max`: $\\sum_{a \\in A} a \\leq |A| \\cdot N$ since each $a \\leq N = \\max(A)$. This gives $S \\leq nN$, so $N \\geq S/n$. The Berry-Esseen step then provides a lower bound on $S$ in terms of $2^n$ and $\\sqrt{\\sum a^2}$, which combines with Cauchy-Schwarz to eliminate $\\sum a^2$ and give a bound purely in $n$ and $N$."
+      "id": "part2",
+      "title": "Part II: The DFX Anticoncentration Step",
+      "startLine": 98,
+      "endLine": 216,
+      "summary": "States the AXIOM `anticoncentration_bound` (the DFX anticoncentration estimate for distinct-subset-sum sets) and PROVES the main `dfx_lower_bound` (the refined lower bound on $\\max A$ in terms of $|A|$, combining the variance bounds with anticoncentration).",
+      "mathContext": "DFX anticoncentration (axiom) + variance bounds $\\Rightarrow$ refined lower bound on $\\max A$."
     },
     {
-      "id": "part-ii-anticonc",
-      "title": "Part II: Anticoncentration Axiom and DFX Main Bound",
-      "startLine": 121,
-      "endLine": 160,
-      "summary": "Axiom anticoncentration_bound (Berry-Esseen step). Theorem dfx_lower_bound (1 sorry): assembles the variance bounds and anticoncentration axiom to derive N ≥ √(2/π)·2ⁿ/√n. Theorem dfx_improves_counting: the DFX bound is asymptotically better than the basic counting bound.",
-      "mathContext": "`anticoncentration_bound` axiom: $2^n \\leq \\sqrt{2/\\pi} \\cdot 2(S+1)/\\sqrt{\\sum a^2}$. This axiomatizes the normal anticoncentration: $\\mathcal{N}(S/2, V)$ has density $\\leq 1/\\sqrt{2\\pi V}$, so at most $S/\\sqrt{2\\pi V} = S\\sqrt{2/\\pi}/\\sqrt{\\sum a^2/2}$ distinct values can each receive probability mass $\\geq 1/\\sqrt{2\\pi V}$. The `sorry` in `dfx_lower_bound` is at the real-arithmetic assembly: combining $2^n \\lesssim S\\sqrt{n}/S = \\sqrt{n}$ and $S \\leq nN$ to isolate $N$."
+      "id": "part3",
+      "title": "Part III: Comparison with Basic Bound",
+      "startLine": 217,
+      "endLine": 235,
+      "summary": "PROVES `dfx_improves_counting` (the DFX bound improves the basic counting bound) and `improvement_factor` ($n<n^2$, quantifying the gain).",
+      "mathContext": "DFX bound strictly improves the basic $2^k$ counting bound."
     },
     {
-      "id": "part-iii-concrete",
-      "title": "Part III: Concrete Cases and Improvement Factor",
-      "startLine": 161,
-      "endLine": 194,
-      "summary": "Concrete verification: f_one (DSS set with 1 element, max = 1), f_two_max (DSS set with 2 elements, max = 2). Also improvement_factor (n < n² for n ≥ 2) as a technical lemma.",
-      "mathContext": "`f_one`: $\\{1\\}$ has all $2^1 = 2$ subset sums distinct ($0$ and $1$); $\\max = 1$. `f_two_max`: $\\{1,2\\}$ has $\\max = 2$ (can be verified by `simp`). `improvement_factor`: $n < n^2$ for $n \\geq 2$ (in $\\mathbb{N}$, proved by `omega`) — the algebraic core of the asymptotic comparison DFX $\\sim 2^n/\\sqrt{n}$ vs counting $\\sim 2^n/n$."
+      "id": "part4",
+      "title": "Part IV: Small Cases",
+      "startLine": 236,
+      "endLine": 268,
+      "summary": "PROVES concrete small cases: `f_one` (a 1-element distinct-subset-sums set with max $1$) and `f_two_max` (a 2-element set with max $2$).",
+      "mathContext": "Small cases: $|A|=1$ gives $\\max=1$; $|A|=2$ gives $\\max=2$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The Erdős #1 OQ-02 (DFX anticoncentration lower bound for distinct-subset-sums) gallery `meta.json` had **section drift**.

- The middle/back sections were mislabeled: a "Part I: Sum Bound and Part II Header" section straddled the Part I/II boundary, and "Part III: Concrete Cases and Improvement Factor" was tagged @161 although Part III begins @217 (and Part IV @236).
- Coverage stopped at line **194** of a **268**-line file, hiding the rest of Part II, all of Part III (`dfx_improves_counting`, `improvement_factor`), and Part IV (`f_one`, `f_two_max`).

## Changes
- Realigned all **5 sections** to the file's `/-! ## Part I-IV` banners with full coverage **1-268**.
- **Counts already correct**: 8 theorems / 0 definitions / 1 axiom / 0 sorries, lineCount 268.

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-268 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-1-oq-02
- [x] Section ranges re-verified against the `## Part I-IV` banners in `Erdos1OQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)