### PR TITLE
research(erdos-940): realign drifted gallery sections to full file (11→11)

### DIFF
--- a/src/data/proofs/erdos-940/meta.json
+++ b/src/data/proofs/erdos-940/meta.json
@@ -89,7 +89,7 @@
       "id": "powerful-numbers",
       "title": "r-Powerful Numbers",
       "summary": "Defines `isPowerful r n` ($n \\neq 0$ and $\\forall p$ prime, $p \\mid n \\Rightarrow p^r \\mid n$). Proves `one_isPowerful`, `zero_not_isPowerful`, and `power_isPowerful` ($n^r$ is $r$-powerful via `Nat.Prime.dvd_of_dvd_pow`).",
-      "startLine": 39,
+      "startLine": 1,
       "endLine": 77,
       "mathContext": "Defines `isPowerful r n` ($n \\neq 0$ and $\\forall p$ prime, $p \\mid n \\Rightarrow p^r \\mid n$). Proves `one_isPowerful`, `zero_not_isPowerful`, and `power_isPowerful` ($n^r$ is $r$-powerful via `Nat.Prime.dvd_of_dvd_pow`)."
     },
@@ -114,63 +114,63 @@
       "title": "The Main Conjecture (OPEN)",
       "summary": "States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (1 sorry).",
       "startLine": 119,
-      "endLine": 143,
+      "endLine": 187,
       "mathContext": "Mathematical content: States `erdos_940_conjecture`: $\\forall r \\ge 3$, $\\text{DiagonalSums}(r)$ has density 0. Also `erdos_940_infinitely_many` (complement is infinite) and `conjecture_implies_infinite` (1 sorry)."
     },
     {
       "id": "squarefull",
       "title": "The Squarefull Case (r = 2)",
       "summary": "Axiomatizes `baker_brudern_theorem`: $\\text{SumsOfPowerful}(2, 2)$ has density 0. Baker-Brüdern (1994) proved this 18 years after Erdős called it 'easy'.",
-      "startLine": 144,
-      "endLine": 160,
+      "startLine": 188,
+      "endLine": 204,
       "mathContext": "Verified: Axiomatizes `baker_brudern_theorem`: $\\text{SumsOfPowerful}(2, 2)$ has density 0. Baker-Brüdern (1994) proved this 18 years after Erdős called it 'easy'."
     },
     {
       "id": "heath-brown",
       "title": "Heath-Brown's Representation Theorem",
       "summary": "Axiomatizes `heath_brown_theorem`: $\\forall^\\infty n$, $n \\in \\text{SumsOfPowerful}(2, 3)$. All large integers are sums of $\\le 3$ squarefull numbers (1988, ternary quadratic forms).",
-      "startLine": 161,
-      "endLine": 181,
+      "startLine": 205,
+      "endLine": 234,
       "mathContext": "Verified: Axiomatizes `heath_brown_theorem`: $\\forall^\\infty n$, $n \\in \\text{SumsOfPowerful}(2, 3)$. All large integers are sums of $\\le 3$ squarefull numbers (1988, ternary quadratic forms)."
     },
     {
       "id": "cubefull",
       "title": "The Cubefull Case and Three Cubes",
       "summary": "States `three_cubes_conjecture` (OPEN). Proves `cubes_subset_cubefull` ($n^3$ is 3-powerful). Defines `cubefull_conjecture` ($r = 3$ case).",
-      "startLine": 182,
-      "endLine": 204,
+      "startLine": 235,
+      "endLine": 257,
       "mathContext": "States `three_cubes_conjecture` (OPEN). Proves `cubes_subset_cubefull` ($$n^{3}$$ is 3-powerful). Defines `cubefull_conjecture` ($r = 3$ case)."
     },
     {
       "id": "universal",
       "title": "The Large Integer Representation Question",
       "summary": "States `universal_representation_conjecture`: $\\forall r \\ge 2$, $\\forall^\\infty n$, $n \\in \\text{DiagonalSums}(r)$. OPEN even for $r = 2$ (diagonal case).",
-      "startLine": 205,
-      "endLine": 224,
+      "startLine": 258,
+      "endLine": 277,
       "mathContext": "Mathematical content: States `universal_representation_conjecture`: $\\forall r \\ge 2$, $\\forall^\\infty n$, $n \\in \\text{DiagonalSums}(r)$. OPEN even for $r = 2$ (diagonal case)."
     },
     {
       "id": "relationship",
       "title": "Relationship Between the Questions",
       "summary": "Proves `status_summary`: Baker-Brüdern $\\wedge$ Heath-Brown in one line. Summarizes known vs open cases.",
-      "startLine": 225,
-      "endLine": 248,
+      "startLine": 278,
+      "endLine": 301,
       "mathContext": "Verified: Proves `status_summary`: Baker-Brüdern $\\wedge$ Heath-Brown in one line. Summarizes known vs open cases."
     },
     {
       "id": "examples",
       "title": "Examples and Computations",
       "summary": "Concrete proofs: $4 = 2^2$ is squarefull, $8 = 2^3$ is cubefull, $72 = 2^3 \\cdot 3^2$ is squarefull. All use `interval_cases` and `simp_all`.",
-      "startLine": 249,
-      "endLine": 281,
+      "startLine": 302,
+      "endLine": 334,
       "mathContext": "Concrete proofs: $4 = $2^{2}$$ is squarefull, $8 = $2^{3}$$ is cubefull, $72 = $2^{3}$ \\cdot $3^{2}$$ is squarefull. All use `interval_cases` and `simp_all`."
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Defines connections to Erdős #941 (Heath-Brown's theorem), #1081 (refined $r=2$), and #1107 ($r+1$ summands, off-diagonal).",
-      "startLine": 282,
-      "endLine": 339,
+      "startLine": 335,
+      "endLine": 392,
       "mathContext": "Formal definition: Defines connections to Erdős #941 (Heath-Brown's theorem), #1081 (refined $r=2$), and #1107 ($r+1$ summands, off-diagonal)."
     }
   ],


### PR DESCRIPTION
## Summary
Section-coverage realign for the **Erdős #940** gallery entry (`Proofs/Erdos940Problem.lean`, 392 lines). The 11 section titles correctly matched the file's 11 `## Part I–XI` banners in order, but the `startLine`/`endLine` ranges drifted from Part IV onward:

- Sections pointed at earlier regions — e.g. `squarefull` (Part V) was at 144-160, missing its own declarations `baker_brudern_theorem`@198 and `squarefull_case`@202, which live in Part V (188-204).
- The 38-line module-docstring header (1-38) was uncovered.
- A 53-line tail (340-392) was uncovered.

Snapped all boundaries onto the `/- ## Part -/` banner lines (39, 78, 106, 119, 188, 205, 235, 258, 278, 302, 335) so the file is contiguously covered **1-392**. Titles and summaries are unchanged — verified each summary's named declarations fall inside its corrected range.

No Lean source changes. Counts unchanged (392 lines, 2 axioms, 0 sorries, 10 theorems, 15 defs).

## Section map (after)
| lines | id |
|------|-----|
| 1-77 | powerful-numbers (Part I + header) |
| 78-105 | sums-set (Part II) |
| 106-118 | density (Part III) |
| 119-187 | main-conjecture (Part IV) |
| 188-204 | squarefull (Part V) |
| 205-234 | heath-brown (Part VI) |
| 235-257 | cubefull (Part VII) |
| 258-277 | universal (Part VIII) |
| 278-301 | relationship (Part IX) |
| 302-334 | examples (Part X) |
| 335-392 | related (Part XI) |

## Test plan
- [x] `meta.json` is valid JSON
- [x] sections contiguous, last endLine (392) == lineCount (392)
- [x] each section summary's decls verified inside its new range
- [x] no contention: slug has no open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)