### PR TITLE
audit(cantors-theorem-oq-01): fix stale "König's constraint axiom" prose

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01/meta.json
@@ -139,7 +139,7 @@
       "title": "Part 7-8: König's Constraint and Summary",
       "startLine": 213,
       "endLine": 272,
-      "summary": "König's constraint axiom: cf(|𝒫(ℝ)|) > 𝔠. cantors_theorem_oq01_summary bundles all four ZFC facts. #check exports confirm all key theorems.",
+      "summary": "Part 7 is a docstring that cross-references König's cofinality constraint cf(|𝒫(ℝ)|) > 𝔠 — proved as a theorem (not an axiom) in the child file CantorsTheoremOQ01OQ03; this file contains no axiom for it. cantors_theorem_oq01_summary bundles all four ZFC facts. #check exports confirm all key theorems.",
       "mathContext": "König's cofinality bound: $\\operatorname{cf}(2^{\\mathfrak{c}}) > \\mathfrak{c}$. This rules out values like $\\aleph_\\omega$ (since $\\operatorname{cf}(\\aleph_\\omega) = \\omega \\leq \\mathfrak{c}$). Summary structure bundles four ZFC facts: (1) $|\\mathcal{P}(\\mathbb{R})| = 2^{\\mathfrak{c}}$, (2) $|\\mathbb{R}| < |\\mathcal{P}(\\mathbb{R})|$, (3) $|\\mathcal{P}(\\mathbb{R})| = \\beth_2$, (4) $\\aleph_1 < |\\mathcal{P}(\\mathbb{R})|$."
     }
   ],


### PR DESCRIPTION
## Integrity Issue

**Proof**: cantors-theorem-oq-01
**Severity**: LOW (stale prose / internal inconsistency)
**Problem**: The Part 7-8 `sections` summary claims the file contains a "König's constraint axiom: cf(|𝒫(ℝ)|) > 𝔠". The Lean file `CantorsTheoremOQ01.lean` contains **zero axioms** (status `verified`, `axiomCount: 0`, badge `mathlib`).

## Evidence

**meta.json claimed** (sections → "Part 7-8: König's Constraint and Summary"):
> "König's constraint axiom: cf(|𝒫(ℝ)|) > 𝔠. ..."

**Lean file shows**: `grep -c '^axiom '` → 0; no occurrence of `axiom` anywhere. Part 7 (lines 215–245) is a docstring that explicitly cross-references the child file `CantorsTheoremOQ01OQ03.lean`, where König's cofinality bound is proved as a **theorem** (`konig_general`, `cf_powerSet_real_gt_continuum`) via Mathlib's `Cardinal.lt_cof_power`.

The entry's own `crossReferences` and `openQuestions[2]` already note this was resolved as a theorem in the child file — so the "axiom" wording was internally inconsistent.

## Fix

Reword the section summary to state that Part 7 is a docstring cross-referencing the constraint (proved as a theorem in the child file, no axiom in this file).

All numeric fields verified correct: 295 lines, 17 theorems, 2 defs, 0 axioms, 0 sorries.

---
Discovered during gallery integrity audit.