### PR TITLE
research(erdos-169): realign drifted gallery sections to full file (9→12)

### DIFF
--- a/src/data/proofs/erdos-169/meta.json
+++ b/src/data/proofs/erdos-169/meta.json
@@ -69,76 +69,100 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview, Imports and Namespace",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File header: states Erdős #169 (f(k) = sup harmonic sum over k-AP-free sets; the ratio question f(k)/log W(k) → ∞?), background, key results (Berlekamp, Gerver, Walker), imports, and the `Erdos169` namespace.",
+      "mathContext": "File header and imports for the Erdős #169 formalization, opening `Finset` and `BigOperators`."
+    },
+    {
       "id": "arithmetic-progressions",
-      "title": "Arithmetic Progressions",
+      "title": "Part I: Arithmetic Progressions",
       "startLine": 44,
       "endLine": 61,
-      "summary": "Definitions of k-term arithmetic progressions and AP-free sets",
-      "mathContext": "Formal definition: Definitions of k-term arithmetic progressions and AP-free sets"
+      "summary": "Definitions of k-term arithmetic progressions (IsArithmeticProgression) and AP-free sets (IsAPFree).",
+      "mathContext": "Formal definition: k-term arithmetic progressions and AP-free sets."
     },
     {
       "id": "harmonic-sum",
-      "title": "Harmonic Sum Function",
+      "title": "Part II: Harmonic Sum of a Set",
       "startLine": 62,
       "endLine": 79,
-      "summary": "Definition of f(k) as supremum of harmonic sums over AP-free sets",
-      "mathContext": "Formal definition: Definition of f(k) as supremum of harmonic sums over AP-free sets"
+      "summary": "Defines harmonicSum (sum of reciprocals) and f(k) as the supremum of harmonic sums over AP-free sets.",
+      "mathContext": "Formal definition: harmonicSum and f(k) as supremum of harmonic sums over AP-free sets."
     },
     {
       "id": "van-der-waerden",
-      "title": "Van der Waerden Numbers",
+      "title": "Part III: Van der Waerden Numbers",
       "startLine": 80,
-      "endLine": 100,
-      "summary": "Definition of W(k) and van der Waerden's theorem",
-      "mathContext": "Formal definition: Definition of W(k) and van der Waerden's theorem"
+      "endLine": 98,
+      "summary": "Definition of W(k) and statement of van der Waerden's theorem (W(k) finite for k ≥ 3).",
+      "mathContext": "Formal definition: Definition of W(k) and van der Waerden's theorem."
     },
     {
       "id": "berlekamp",
-      "title": "Berlekamp's Lower Bound",
-      "startLine": 101,
-      "endLine": 123,
-      "summary": "f(k) ≥ (log 2 / 2) · k from 1968",
-      "mathContext": "f(k) $\\geq$ (log 2 / 2) · k from 1968"
+      "title": "Part IV: Berlekamp's Lower Bound (1968)",
+      "startLine": 99,
+      "endLine": 118,
+      "summary": "Axiomatizes Berlekamp (1968): f(k) ≥ (log 2 / 2) · k, with its binary-representation construction.",
+      "mathContext": "f(k) $\\geq$ (log 2 / 2) · k from 1968 (axiomatized)."
     },
     {
       "id": "gerver",
-      "title": "Gerver's Improvement",
-      "startLine": 124,
-      "endLine": 145,
-      "summary": "f(k) ≥ (1-o(1)) k log k from 1977",
-      "mathContext": "f(k) $\\geq$ (1-o(1)) k log k from 1977"
+      "title": "Part V: Gerver's Improvement (1977)",
+      "startLine": 119,
+      "endLine": 136,
+      "summary": "Documents Gerver (1977): f(k) ≥ (1-o(1)) k log k, and his equivalence linking Problem #3 to finiteness of f(k).",
+      "mathContext": "f(k) $\\geq$ (1-o(1)) k log k from 1977."
     },
     {
       "id": "ratio-question",
-      "title": "The Ratio Question",
-      "startLine": 146,
-      "endLine": 165,
-      "summary": "Whether f(k)/log W(k) → ∞ remains open",
-      "mathContext": "Whether f(k)/log W(k) $\\to$ ∞ remains open"
+      "title": "Part VI: The Ratio Question",
+      "startLine": 137,
+      "endLine": 159,
+      "summary": "Axiomatizes the trivial bound f(k)/log W(k) ≥ 1/2 and states RatioQuestion (whether f(k)/log W(k) → ∞), which remains open.",
+      "mathContext": "Whether f(k)/log W(k) $\\to$ ∞ remains open; trivial bound ≥ 1/2 axiomatized."
     },
     {
       "id": "computational-records",
-      "title": "Computational Records",
-      "startLine": 166,
-      "endLine": 181,
-      "summary": "Best known values for f(3) and f(4)",
-      "mathContext": "Mathematical content: Best known values for f(3) and f(4)"
+      "title": "Part VII: Computational Records",
+      "startLine": 160,
+      "endLine": 173,
+      "summary": "Best known computational values: f(3) ≥ 3.00849 (Wróblewski 1984) and f(4) ≥ 4.43975 (Walker 2025).",
+      "mathContext": "Mathematical content: Best known values for f(3) and f(4)."
     },
     {
       "id": "walker-results",
-      "title": "Walker's Results",
-      "startLine": 182,
-      "endLine": 203,
-      "summary": "Kempner sets suffice for optimal AP-free harmonic sums",
-      "mathContext": "Mathematical content: Kempner sets suffice for optimal AP-free harmonic sums"
+      "title": "Part VIII: Walker's Results (2025)",
+      "startLine": 174,
+      "endLine": 193,
+      "summary": "Defines Kempner sets (digit-restricted integers) and documents Walker (2025): optimal AP-free sets for harmonic sum can be approximated by Kempner sets.",
+      "mathContext": "Mathematical content: Kempner sets suffice for optimal AP-free harmonic sums."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Part IX: Basic Properties",
+      "startLine": 194,
+      "endLine": 211,
+      "summary": "Documents basic properties of f: monotonic decrease in k, positivity f(k) > 0, and that the singleton {1} is k-AP-free for all k ≥ 2.",
+      "mathContext": "Mathematical content: monotonicity, positivity, and singleton AP-freeness of f."
+    },
+    {
+      "id": "related-problems",
+      "title": "Part X: Related Problems",
+      "startLine": 212,
+      "endLine": 232,
+      "summary": "Connections to related questions: Problem #3 (finiteness of f(k)), Problem #170, and OEIS A005346 (subsets of {1,...,n} with no 3-term AP).",
+      "mathContext": "Mathematical content: links to Problem #3, Problem #170, and OEIS A005346."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 253,
+      "title": "Part XI: Summary",
+      "startLine": 233,
       "endLine": 279,
-      "summary": "Complete summary of what's known and what's open",
-      "mathContext": "Mathematical content: Complete summary of what's known and what's open"
+      "summary": "Complete status summary of what is known and open, plus the proved theorems erdos_169_summary and erdos_169_open combining the Berlekamp and trivial-ratio bounds.",
+      "mathContext": "Mathematical content: Complete summary of what's known and what's open; proves erdos_169_summary / erdos_169_open."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -47,40 +47,40 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Imports and Namespace",
-      "startLine": 15,
-      "endLine": 36,
-      "summary": "Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`.",
-      "mathContext": "Verified: Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`."
+      "title": "Overview, Imports and Namespace",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "File overview and references (Cramér, Gallagher, Erdős). Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`.",
+      "mathContext": "File overview and references. Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`."
     },
     {
       "id": "basic-definitions",
       "title": "Prime Gap Definitions",
-      "startLine": 37,
-      "endLine": 50,
+      "startLine": 32,
+      "endLine": 45,
       "summary": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\log n$ (with $0$ for $n \\leq 1$).",
-      "mathContext": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\$\\log n$$ (with $0$ for $n \\leq 1$)."
+      "mathContext": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\log n$ (with $0$ for $n \\leq 1$)."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions",
-      "startLine": 51,
-      "endLine": 62,
+      "startLine": 46,
+      "endLine": 57,
       "summary": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\log n < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$.",
-      "mathContext": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\$\\log n$ < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$."
+      "mathContext": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\log n < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
-      "startLine": 63,
-      "endLine": 82,
+      "startLine": 58,
+      "endLine": 77,
       "summary": "States ErdosProblem234: $\\forall c \\geq 0$, the density $f(c) = \\lim_{N} \\text{gapProportion}(N, c)$ exists and $f$ is continuous. Uses `Tendsto` with `atTop` and `nhds`.",
       "mathContext": "Mathematical content: States ErdosProblem234: $\\forall c \\geq 0$, the density $f(c) = \\lim_{N} \\text{gapProportion}(N, c)$ exists and $f$ is continuous. Uses `Tendsto` with `atTop` and `nhds`."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 83,
+      "startLine": 78,
       "endLine": 142,
       "summary": "Proves $f_N(0) = 0$, $0 \\leq f_N(c) \\leq 1$, monotonicity $c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$, and $f(0) = 0$.",
       "mathContext": "Verified: Proves $f_N(0) = 0$, $0 \\leq f_N(c) \\leq 1$, monotonicity $c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$, and $f(0) = 0$."
@@ -89,46 +89,54 @@
       "id": "markov-density",
       "title": "Proving density_at_infinity via Markov's Inequality",
       "startLine": 143,
-      "endLine": 263,
+      "endLine": 262,
       "summary": "**Key result**: Proves (previously axiom) density_at_infinity from average_normalized_gap via finite Markov inequality. For non-negative normalizedGap and $c > 0$: $|\\{n : \\text{gap}(n) \\geq c\\}| \\cdot c \\leq \\sum \\text{gap}(n)$, so gapProportion$(N,c) \\geq 1 - (\\text{avg gap})/c$. Choosing $c_0 = 2/\\varepsilon + 1$ gives the result. Reduces axiom count from 5 to 4.",
       "mathContext": "**Key result**: Proves (previously axiom) density_at_infinity from average_normalized_gap via finite Markov inequality. For non-negative normalizedGap and $c > 0$: $|\\{n : \\text{gap}(n) \\geq c\\}| \\cdot c \\leq \\sum \\text{gap}(n)$, so gapProportion$(N,c) \\geq 1 - (\\text{avg gap})/c$. Choosing $c_0 = 2/\\varepsilon + 1$ gives the result. Reduces axiom count from 5 to 4."
     },
     {
       "id": "cramer-model",
       "title": "Cramér's Exponential Model",
-      "startLine": 265,
-      "endLine": 303,
+      "startLine": 263,
+      "endLine": 295,
       "summary": "Defines cramerPrediction$(c) = 1 - e^{-c}$ for $c \\geq 0$. Proves continuity via `Continuous.if_lt` and validates CDF bounds $0 \\leq f(c) \\leq 1$.",
       "mathContext": "Formal definition: Defines cramerPrediction$(c) = 1 - e^{-c}$ for $c \\geq 0$. Proves continuity via `Continuous.if_lt` and validates CDF bounds $0 \\leq f(c) \\leq 1$."
     },
     {
       "id": "gallagher-result",
       "title": "Gallagher's Conditional Result",
-      "startLine": 304,
-      "endLine": 323,
+      "startLine": 296,
+      "endLine": 319,
       "summary": "Axiomatizes Gallagher (1976): RH $\\implies \\text{gapProportion}(N, c) \\to 1 - e^{-c}$. Proves gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234.",
       "mathContext": "Verified: Axiomatizes Gallagher (1976): RH $\\implies \\text{gapProportion}(N, c) \\to 1 - e^{-c}$. Proves gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234."
     },
     {
       "id": "partial-results",
       "title": "Partial Results on Gap Distribution",
-      "startLine": 324,
-      "endLine": 341,
-      "summary": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\log n$), (2) average $g_n/\\log n \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3.",
-      "mathContext": "Axiomatizes: (1) large_gaps_exist (FGKT: unbounded $g_n/\\$\\log n$$), (2) average $g_n/\\$\\log n$ \\to 1$ by PNT. Then proves small_gaps_exist from average_normalized_gap via Cesàro contrapositive argument, reducing axiom count from 4 to 3."
+      "startLine": 320,
+      "endLine": 330,
+      "summary": "Axiomatizes the two remaining inputs: (1) large_gaps_exist (FGKT/Maynard: unbounded $g_n/\\log n$, stated as documentation), and (2) average_normalized_gap: $g_n/\\log n \\to 1$ on average by the Prime Number Theorem.",
+      "mathContext": "Axiomatizes the two remaining inputs: (1) large_gaps_exist (FGKT/Maynard: unbounded $g_n/\\log n$), and (2) average_normalized_gap: the Cesàro average of $g_n/\\log n$ tends to $1$ by PNT."
+    },
+    {
+      "id": "small-gaps",
+      "title": "Small Gaps from Average Gap (Axiom Elimination)",
+      "startLine": 331,
+      "endLine": 430,
+      "summary": "Proves (previously axiom) small_gaps_exist from average_normalized_gap via a Cesàro contrapositive: if only finitely many $n$ had normalizedGap $< 1+\\varepsilon$, the average would exceed $1$, contradicting PNT. Supporting lemmas: nthPrime_ge ($n \\leq p_n$), infinite_normalizedGap_lt, and primeGap_lt_of_normalizedGap_lt. Reduces axiom count from 4 to 3.",
+      "mathContext": "Proves small_gaps_exist from average_normalized_gap by contradiction: a finite small-gap set forces the Cesàro average above $1$. Uses nthPrime_ge, infinite_normalizedGap_lt, primeGap_lt_of_normalizedGap_lt, with `nlinarith` and an Archimedean bound to close the contradiction."
     },
     {
       "id": "cramer-properties",
-      "title": "Cramér Model Properties",
-      "startLine": 342,
-      "endLine": 363,
+      "title": "Additional Properties of Cramér's Model",
+      "startLine": 431,
+      "endLine": 457,
       "summary": "Proves $f(0) = 0$, $f(c) \\geq 0$, $f(c) \\leq 1$, and monotonicity $c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$ using $e^{-c_2} \\leq e^{-c_1}$.",
       "mathContext": "Verified: Proves $f(0) = 0$, $f(c) \\geq 0$, $f(c) \\leq 1$, and monotonicity $c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$ using $e^{-c_2} \\leq e^{-c_1}$."
     },
     {
       "id": "density-function-properties",
       "title": "Properties of the Density Function",
-      "startLine": 461,
+      "startLine": 458,
       "endLine": 510,
       "summary": "Conditional properties of the density $f(c)$ (if it exists): $f(c) \\in [0,1]$, $f$ is monotone non-decreasing, and $f(c) \\to 1$ as $c \\to \\infty$. The last result uses density_at_infinity and `tendsto_order`.",
       "mathContext": "Verified: If the density exists (the limit of gapProportion), it necessarily satisfies CDF properties. The limit approach uses `ge_of_tendsto` / `le_of_tendsto` for bounds and `tendsto_order` for the convergence $f(c) \\to 1$."

--- a/src/data/proofs/erdos-294/meta.json
+++ b/src/data/proofs/erdos-294/meta.json
@@ -80,46 +80,81 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview, Imports and Namespace",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File header: problem statement (t(N) for Egyptian fractions in [t,N]), background, known results (Erdős-Graham 1980, Liu-Sawhney 2024), imports, and the `Erdos294` namespace."
+    },
+    {
       "id": "sec-egyptian",
-      "title": "Egyptian Fractions",
+      "title": "Part I: Egyptian Fractions",
       "startLine": 44,
-      "endLine": 74,
-      "summary": "Defines unit fractions and Egyptian sums"
+      "endLine": 72,
+      "summary": "Defines unitFraction (1/n), egyptianSum, and isEgyptianRepresentationOf1 (a finite set of distinct positive integers whose reciprocals sum to 1)."
     },
     {
       "id": "sec-t-function",
-      "title": "The t(N) Function",
-      "startLine": 75,
-      "endLine": 107,
-      "summary": "Defines constrained representations and the t(N) function"
+      "title": "Part II: The t(N) Function",
+      "startLine": 73,
+      "endLine": 106,
+      "summary": "Defines hasConstrainedRepresentation (Egyptian rep of 1 with denominators in [t,N]), axiomatizes existence of a blocking t, and defines t_func via Nat.find."
     },
     {
       "id": "sec-small-values",
-      "title": "Small Values",
-      "startLine": 108,
-      "endLine": 140,
-      "summary": "Analyzes t(2), t(6), and harmonic sums"
+      "title": "Part III: Small Values",
+      "startLine": 107,
+      "endLine": 133,
+      "summary": "Documents small cases t(2), t(6) via the {2,3,6} representation, and defines the harmonic sum harmonicSum(N) with its log-asymptotic note."
     },
     {
       "id": "sec-erdos-graham",
-      "title": "Erdős-Graham Upper Bound",
-      "startLine": 141,
-      "endLine": 164,
-      "summary": "t(N) ≪ N/log N from 1980"
+      "title": "Part IV: Erdős-Graham Upper Bound",
+      "startLine": 134,
+      "endLine": 157,
+      "summary": "States erdosGrahamUpperBound (t(N) ≪ N/log N), axiomatizes erdos_graham_1980, and gives the interpretation that few starting points block representations."
     },
     {
       "id": "sec-liu-sawhney",
-      "title": "Liu-Sawhney Theorem",
-      "startLine": 165,
-      "endLine": 193,
-      "summary": "Lower bound from 2024 resolving the problem"
+      "title": "Part V: The Liu-Sawhney Theorem",
+      "startLine": 158,
+      "endLine": 186,
+      "summary": "States the Liu-Sawhney lower bound (2024), combines it with the upper bound into liuSawhneyTheorem, axiomatizes liu_sawhney_2024, and proves the main theorem erdos_294."
+    },
+    {
+      "id": "sec-implications",
+      "title": "Part VI: Implications",
+      "startLine": 187,
+      "endLine": 206,
+      "summary": "States the density interpretation (almost all starting points admit representations) and the harmonic-sum connection relating hasConstrainedRepresentation to partial harmonic sums."
+    },
+    {
+      "id": "sec-related-functions",
+      "title": "Part VII: Related Functions",
+      "startLine": 207,
+      "endLine": 228,
+      "summary": "Introduces the f(n) function (minimum number of distinct unit fractions summing to 1 with largest denominator n), axiomatizes its existence for n ≥ 6, and notes its relationship to t(N)."
     },
     {
       "id": "sec-greedy",
-      "title": "Greedy Algorithm",
-      "startLine": 239,
+      "title": "Part VIII: The Greedy Algorithm",
+      "startLine": 229,
+      "endLine": 255,
+      "summary": "Defines greedyStep (smallest n with 1/n ≤ q) and greedyRelation, describing the greedy Egyptian-fraction algorithm and its connection to constrained representations."
+    },
+    {
+      "id": "sec-computational",
+      "title": "Part IX: Computational Aspects",
+      "startLine": 256,
+      "endLine": 271,
+      "summary": "Notes that computing t(N) exactly is hard (no known efficient algorithm) and lists small known values via knownValues."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Part X: Main Results Summary",
+      "startLine": 272,
       "endLine": 306,
-      "summary": "Connection to greedy Egyptian fraction algorithms"
+      "summary": "Summarizes the resolution (Erdős-Graham upper bound + Liu-Sawhney lower bound), proves erdos_294_summary combining both bounds, and records the SOLVED status."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-integrity realign for **erdos-169** (Harmonic Sum of AP-Free Sets). The `meta.json` tracked **9 of the file's 11 `## Part` banners**, with systematic drift in `Proofs/Erdos169Problem.lean`:

- The file-level overview docstring (lines 1–43) was uncovered.
- **Parts IX (Basic Properties) and X (Related Problems) were missing entirely** — a 45-line gap at 204–252.
- Each of the 9 sections overran into the *following* Part's banner (e.g. `van-der-waerden` ran 80–100, swallowing the Part IV banner at line 100).

## Changes

Rebuilt **12 contiguous sections covering lines 1–279**, mapping the overview header plus each of Parts I–XI to its banner and declarations. Added `basic-properties` (Part IX) and `related-problems` (Part X), and corrected every range to stop before the next banner.

No `.lean` changes; metric counts (lineCount 279, axioms/defs unchanged) remain accurate.

## Test plan
- [x] `jq empty meta.json` passes (valid JSON)
- [x] 12 sections are contiguous (each start = prev end + 1) and cover lines 1–279 (= leanFile.lineCount)
- [x] Section ranges verified against actual `## Part` banner and declaration positions in the `.lean`