### PR TITLE
Enrich desargues-theorem-oq-01-oq-01: fix stale 21→22 component count

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
@@ -250,7 +250,7 @@
     },
     "type": "insight",
     "title": "moulton_counterexample: Full Desargues Failure Certificate",
-    "content": "`moulton_counterexample` is a single large conjunction packaging the complete certificate: (1) three perspectivity facts (collinear_OAA', collinear_OBB', collinear_OCC'), (2) eighteen incidence facts (each of P, Q, R on both corresponding sides of both triangles), and (3) the non-collinearity fact `desargues_fails`. The proof is a term-mode anonymous constructor \u27e8..., ...\u27e9 listing all 21 components. This makes the counterexample machine-checkable and self-contained \u2014 a single theorem whose type is the negation of Desargues's theorem in the Moulton plane.",
+    "content": "`moulton_counterexample` is a single large conjunction packaging the complete certificate: (1) three perspectivity facts (collinear_OAA', collinear_OBB', collinear_OCC'), (2) eighteen incidence facts (each of P, Q, R on both corresponding sides of both triangles), and (3) the non-collinearity fact `desargues_fails`. The proof is a term-mode anonymous constructor \u27e8..., ...\u27e9 listing all 22 components. This makes the counterexample machine-checkable and self-contained \u2014 a single theorem whose type is the negation of Desargues's theorem in the Moulton plane.",
     "mathContext": "Desargues's theorem asserts: if two triangles $ABC$, $A'B'C'$ are in perspective from a point (i.e., $O,A,A'$; $O,B,B'$; $O,C,C'$ collinear), then their side-intersection points $P = AB \\cap A'B'$, $Q = BC \\cap B'C'$, $R = CA \\cap C'A'$ are collinear. `moulton_counterexample` exhibits all hypotheses \u2713 and conclusion \u2717, formally refuting Desargues in the Moulton affine plane.",
     "significance": "key",
     "prerequisites": [

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -86,10 +86,10 @@
         {
             "name": "moulton_counterexample",
             "type": "core",
-            "description": "The full Desargues-failure certificate as a single 21-component conjunction: three perspectivity-from-O facts (collinear_OAA', collinear_OBB', collinear_OCC'), eighteen incidence facts (P on AB/A'B', Q on BC/B'C', R on CA/C'A' with all six endpoint memberships), and desargues_fails. Term-mode anonymous-constructor proof. Packages the entire counterexample as one machine-checkable theorem statement asserting the negation of Desargues's theorem in the Moulton plane.",
+            "description": "The full Desargues-failure certificate as a single 22-component conjunction: three perspectivity-from-O facts (collinear_OAA', collinear_OBB', collinear_OCC'), eighteen incidence facts (P on AB/A'B', Q on BC/B'C', R on CA/C'A' with all six endpoint memberships), and desargues_fails. Term-mode anonymous-constructor proof. Packages the entire counterexample as one machine-checkable theorem statement asserting the negation of Desargues's theorem in the Moulton plane.",
             "leanType": "MoultonCollinear O_pt A_pt A'_pt ∧ MoultonCollinear O_pt B_pt B'_pt ∧ MoultonCollinear O_pt C_pt C'_pt ∧ … ∧ ¬ MoultonCollinear P_pt Q_pt R_pt",
             "line": 268,
-            "endLine": 296
+            "endLine": 295
         },
         {
             "name": "onMoultonLine",


### PR DESCRIPTION
## Accuracy fix

`moulton_counterexample` in `DesarguesTheoremOQ01OQ01.lean` is a **22-component** conjunction:
- 3 perspectivity facts (`collinear_OAA'`, `collinear_OBB'`, `collinear_OCC'`)
- 18 incidence facts (P, Q, R each on both corresponding sides of both triangles)
- 1 `desargues_fails`

3 + 18 + 1 = 22, verified against the anonymous-constructor term in the Lean source (lines 288–295).

Two places in the gallery data still said "21", contradicting `meta.proofStrategy` and the section summary (which already say 22):
- `meta.json` `mainTheorems[moulton_counterexample].description`: "21-component" → "22-component"
- `annotations.json` (line 253): "all 21 components" → "all 22 components"

Also corrected `mainTheorems[moulton_counterexample].endLine` from 296 (a blank line) to 295 (the last line of the declaration, `desargues_fails⟩`).

No mathematical content changed; this is an internal-consistency/accuracy pass.