### PR TITLE
research(erdos-741): realign sections (7→10) + fix theoremCount 160→27, definitionCount 35→8

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -115,53 +115,84 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "States Erdős Problem #741 on density, sumsets, basis order 2, and syndetic sets: two conjectures relating positive upper density / additive-basis structure to syndeticity of complements. Both OPEN. Imports and overview.",
+      "mathContext": "Erdős #741: positive-density / basis-order-2 sets and syndetic complements (two open conjectures)."
+    },
+    {
       "id": "definitions",
       "title": "Density and Sumset Definitions",
-      "startLine": 27,
-      "endLine": 52,
-      "summary": "upperDensity via atTop.limsup of Set.ncard ratios; HasPosDensity as 0 < upperDensity; sumset as explicit existential {n | exists a, b}; IsBasisOrder2 via Filter.Eventually; IsSyndetic with bounded gap condition."
+      "startLine": 42,
+      "endLine": 67,
+      "summary": "Defines `upperDensity`, `HasPosDensity`, `sumset` ($A+B$), `IsBasisOrder2` ($A+A=\\mathbb{N}$), and `IsSyndetic` (bounded gaps).",
+      "mathContext": "`upperDensity`, `sumset A B`, `IsBasisOrder2` ($A+A=\\mathbb{N}$), `IsSyndetic`."
     },
     {
       "id": "conjectures",
-      "title": "Main Conjectures (Both OPEN)",
-      "startLine": 53,
-      "endLine": 70,
-      "summary": "ErdosProblem741_density (Part 1): positive density sumset splitting. ErdosProblem741_basis (Part 2): existence of non-splittable basis. Both stated as Prop definitions."
+      "title": "Main Conjectures (OPEN)",
+      "startLine": 68,
+      "endLine": 85,
+      "summary": "Defines `ErdosProblem741_density` and `ErdosProblem741_basis` — the two open conjectures of the problem.",
+      "mathContext": "Two OPEN conjectures: density form and basis-order-2 form."
     },
     {
       "id": "sumset-algebra",
       "title": "Sumset Algebraic Properties",
-      "startLine": 71,
-      "endLine": 122,
-      "summary": "10 proved theorems: sumset_comm (A+B=B+A), empty cases, sumset_mono (monotonicity), zero_mem_sumset_self, double_mem_sumset (a in A implies 2a in A+A), sumset_union_contains_left/right."
+      "startLine": 86,
+      "endLine": 137,
+      "summary": "PROVES algebraic facts about sumsets: `sumset_comm`, `empty_sumset`, `sumset_empty_left`/`_right`, `sumset_mono`/`_mono_left`, `zero_mem_sumset_self`, `double_mem_sumset`, `sumset_union_contains_left`/`_right`.",
+      "mathContext": "Sumset is commutative, monotone, empty-absorbing; $0\\in A\\Rightarrow0\\in A+A$."
     },
     {
       "id": "partition",
       "title": "Partition Properties",
-      "startLine": 123,
-      "endLine": 148,
-      "summary": "3 proved theorems: trivial_partition (A = A union empty), complement_partition (A = A_1 union (A \\ A_1)), partition_membership (disjoint implies exclusive)."
+      "startLine": 138,
+      "endLine": 163,
+      "summary": "PROVES `trivial_partition`, `complement_partition`, and `partition_membership`.",
+      "mathContext": "Basic set-partition lemmas (complement, disjoint membership)."
     },
     {
       "id": "syndetic",
       "title": "Syndetic Set Properties",
-      "startLine": 149,
-      "endLine": 181,
-      "summary": "5 proved theorems: nat_syndetic (gap 0), empty_not_syndetic, syndetic_nonempty, syndetic_mono (superset), syndetic_infinite (via Set.infinite_iff_exists_gt)."
+      "startLine": 164,
+      "endLine": 196,
+      "summary": "PROVES `nat_syndetic` ($\\mathbb{N}$ is syndetic), `empty_not_syndetic`, `syndetic_nonempty`, `syndetic_mono`, and `syndetic_infinite`.",
+      "mathContext": "$\\mathbb{N}$ syndetic; syndetic sets are nonempty, infinite, upward-closed."
     },
     {
-      "id": "density",
+      "id": "density-props",
       "title": "Density Properties",
-      "startLine": 182,
-      "endLine": 214,
-      "summary": "4 proved theorems: density_empty (d(∅)=0), density_univ (d(ℕ)=1), density_mono (monotone), density_le_one (≤1) — all derived from limsup. No density_finite exists in the file."
+      "startLine": 197,
+      "endLine": 233,
+      "summary": "PROVES (no axioms, despite the banner's '(Axiomatized)' label) `density_empty` ($\\bar d(\\emptyset)=0$), `density_univ` ($\\bar d(\\mathbb{N})=1$), `density_mono`, and `density_le_one`.",
+      "mathContext": "$\\bar d(\\emptyset)=0$, $\\bar d(\\mathbb{N})=1$, monotone, $\\leq1$ (all proved)."
     },
     {
-      "id": "basis",
-      "title": "Basis Properties and Connections",
-      "startLine": 215,
-      "endLine": 284,
-      "summary": "basis_infinite (PROVED by contradiction: bounded A implies bounded A+A). basis_has_pos_density_sumset (PROVED via cofinite density). part2_gives_non_syndetic and part2_contradicts_part1_for_basis (PROVED): formal tension between Parts 1 and 2."
+      "id": "basis-props",
+      "title": "Basis Properties",
+      "startLine": 234,
+      "endLine": 322,
+      "summary": "PROVES `basis_infinite` (a basis of order 2 is infinite), `cofinite_density_one` (cofinite sets have density 1), and `basis_has_pos_density_sumset` (the sumset of a basis has positive density).",
+      "mathContext": "Basis order 2 $\\Rightarrow$ infinite; cofinite $\\Rightarrow$ density 1; basis sumset has positive density."
+    },
+    {
+      "id": "connections",
+      "title": "Connections Between Parts",
+      "startLine": 323,
+      "endLine": 347,
+      "summary": "PROVES `part2_gives_non_syndetic` and `part2_contradicts_part1_for_basis` — relating the two conjectures (the basis form would force a non-syndetic complement, in tension with the density form).",
+      "mathContext": "The basis conjecture implies a non-syndetic complement, linking the two forms."
+    },
+    {
+      "id": "status",
+      "title": "Problem Status",
+      "startLine": 348,
+      "endLine": 351,
+      "summary": "Defines `erdos_741_status = \"OPEN\"` — both conjectures remain unresolved.",
+      "mathContext": "Status: OPEN."
     }
   ],
   "conclusion": {
@@ -191,8 +222,8 @@
     "namespace": null,
     "lineCount": 351,
     "axiomCount": 0,
-    "theoremCount": 160,
-    "definitionCount": 35,
+    "theoremCount": 27,
+    "definitionCount": 8,
     "path": "Proofs/Erdos741Problem.lean",
     "companionPaths": [
       "Proofs/Erdos741ProblemAPNPartI.lean",


### PR DESCRIPTION
## Summary
The Erdős #741 (density, sumsets, syndetic sets) gallery `meta.json` had **badly wrong counts** and **section drift**.

- `theoremCount` was **160** (actual **27**) and `definitionCount` was **35** — which is the *total* declaration count, conflating the 27 theorems into the def count (actual def count is **8**). Verified by grep: 27 theorem/lemma, 8 def, 0 axioms, 0 sorries.
- Sections drifted ~15-30 lines and stopped at line **284** of a **351**-line file, hiding the tail of Basis Properties, "Connections Between Parts", and "Problem Status".

## Changes
- Rebuilt **10 sections** (was 7) mapped to the file's `## ` banners with full coverage **1-351**.
- Fixed `theoremCount` 160 → 27 and `definitionCount` 35 → 8.
- (The "Density Properties (Axiomatized)" banner is a stale label — those theorems are proved; the file has 0 axioms.)

No Lean source changed — metadata only.

## Test plan
- [x] `meta.json` is valid JSON; sections cover lines 1-351 contiguously
- [x] `tsx scripts/research/build.ts` exits 0 with no errors for erdos-741
- [x] Declaration counts re-verified by grep (27 thm / 8 def / 0 ax / 0 sorry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)