### PR TITLE
audit(erdos-463): honest wording for even_composites_insufficient contribution

### DIFF
--- a/src/data/proofs/erdos-463/meta.json
+++ b/src/data/proofs/erdos-463/meta.json
@@ -53,7 +53,7 @@
       "odd_composite_minFac_ge_three: p(m) ≥ 3 for odd composites (proved)",
       "odd_composite_ge_nine: m ≥ 9 for odd composites (proved via minFac_sq_le_self)",
       "composite_above_exists: ∃ composite m > n (proved constructively)",
-      "even_composites_insufficient: even composites cannot satisfy the conjecture (proved)",
+      "even_composites_insufficient: the n+2 < m < n+2 sandwich is empty for p(m)=2 (proved)",
       "conjecture_needs_large_minFac: structural requirement p(m) > f(n) (proved)",
       "leastPrimeGap_pos: positive gap for composites (proved)"
     ],


### PR DESCRIPTION
## Integrity Issue (LOW severity)

**Proof**: erdos-463 (Composites Near Their Least Prime Factor)

During gallery integrity audit, all numeric metadata verified correct (0 sorries, 0 axioms, 9 theorems, 1 definition, 118 lines; sections aligned; status `axiomatized`/badge `wip` appropriate for an open conjecture). One contribution bullet overstated a degenerate theorem.

## Evidence

`originalContributions` claimed:
> even_composites_insufficient: even composites cannot satisfy the conjecture (proved)

But the theorem (`Erdos463Problem.lean` L94-97) proves:
```lean
theorem even_composites_insufficient (n : ℕ) :
    ¬(∃ m : ℕ, m.minFac = 2 ∧ n + 2 < m ∧ m < n + 2) := by
  intro ⟨_, _, h1, h2⟩
  omega
```
This is a **vacuously empty interval** (`n+2 < m < n+2` is impossible); the `m.minFac = 2` hypothesis is unused. The section summary already honestly describes it as an "empty interval," so only the contribution bullet was out of step.

## Fix

Reword the bullet to match what the kernel actually verifies:
> even_composites_insufficient: the n+2 < m < n+2 sandwich is empty for p(m)=2 (proved)

---
Discovered during gallery integrity audit.