### PR TITLE
research(picks-theorem-oq-03-product): realign drifted gallery sections to full file (5→14)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03-product/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-product/meta.json
@@ -50,41 +50,113 @@
       "id": "module-header",
       "title": "Module Header: Ehrhart Extensions and References",
       "startLine": 1,
-      "endLine": 26,
+      "endLine": 25,
       "summary": "Module docstring outlining the three open questions addressed (product formula, quasipolynomials, valuation), references (Beck-Robins, Barvinok, Stanley), import of Mathlib, set_option linter.unusedVariables false, namespace EhrhartProductQuasi, and open Finset.",
       "mathContext": "The three extension directions: (1) $L(P \\times Q, n) = L(P,n) \\cdot L(Q,n)$; (2) quasipolynomials for rational polytopes; (3) $L(P \\cup Q) + L(P \\cap Q) = L(P) + L(Q)$ (valuation property)."
     },
     {
       "id": "product-formula",
-      "title": "Parts 1–2: Product Formula and Volume Multiplicativity",
-      "startLine": 27,
-      "endLine": 120,
-      "summary": "ehrhart_product: L(P×Q, n) = L(P,n)·L(Q,n). volume_product: vol(P×Q) = vol(P)·vol(Q). Concrete verification for small polytopes.",
+      "title": "Part 1: Product Formula for Ehrhart Polynomials",
+      "startLine": 26,
+      "endLine": 82,
+      "summary": "cube_ehrhart definition and the product formula cube_product: L([0,1]^(a+b),n) = L([0,1]^a,n)·L([0,1]^b,n). Special cases line_times_line, square_times_line, line_cubed, simplex2_times_line, segment_product_is_square.",
       "mathContext": "$L(P \\times Q, n) = L(P, n) \\cdot L(Q, n)$ because lattice points of $n(P \\times Q) = nP \\times nQ$ biject with pairs from $nP \\cap \\mathbb{Z}^d$ and $nQ \\cap \\mathbb{Z}^d$."
+    },
+    {
+      "id": "volume-multiplicativity",
+      "title": "Part 2: Volume Multiplicativity",
+      "startLine": 83,
+      "endLine": 119,
+      "summary": "simplex_volume definition and volume_product_simplices: Vol(Δ_a × Δ_b) = Vol(Δ_a)·Vol(Δ_b). Concrete volumes volume_simplex2_squared (1/4), volume_simplex2_times_simplex3 (1/12), volume_cube.",
+      "mathContext": "$\\mathrm{Vol}(P \\times Q) = \\mathrm{Vol}(P) \\cdot \\mathrm{Vol}(Q)$. The volume is the leading Ehrhart coefficient, so multiplicativity of volume is the leading-term shadow of the product formula."
     },
     {
       "id": "quasipolynomials",
       "title": "Part 3: Quasipolynomials for Rational Polytopes",
-      "startLine": 121,
-      "endLine": 186,
-      "summary": "Defines quasi_poly structure. Examples: half-integer interval [0,1/2] has L(n) = ⌊n/2⌋+1. Period-2 quasipolynomial example.",
-      "mathContext": "For rational polytope with denominator $q$: $L(P, n)$ is quasiperiodic with period $q$ in $n$. The interval $[0, 1/2]$: $L(n) = \\lfloor n/2 \\rfloor + 1$, period 2."
+      "startLine": 120,
+      "endLine": 185,
+      "summary": "Defines the QuasiPoly structure (period, period_pos, eval) and poly_as_quasi. half_segment_quasi example with period 2; verifications half_segment_at_0/2/4. lattice_segment_is_poly and unit_segment_period_1 for period-1 polytopes.",
+      "mathContext": "For a rational polytope with denominator $q$: $L(P, n)$ is quasiperiodic with period $q$ in $n$. The interval $[0, 1/2]$: $L(n) = \\lfloor n/2 \\rfloor + 1$, period 2."
     },
     {
       "id": "valuation",
-      "title": "Parts 4–5: Valuation Property and Degree",
-      "startLine": 187,
-      "endLine": 304,
-      "summary": "ehrhart_valuation: L(P∪Q)+L(P∩Q)=L(P)+L(Q) (inclusion-exclusion). Degree analysis: deg(L) = dim(P).",
-      "mathContext": "$L(P \\cup Q, n) + L(P \\cap Q, n) = L(P, n) + L(Q, n)$ — Ehrhart is a valuation on the lattice of polytopes. Proved for interval unions."
+      "title": "Part 4: Ehrhart as a Valuation",
+      "startLine": 186,
+      "endLine": 235,
+      "summary": "interval_count and the valuation/inclusion-exclusion theorems: interval_valuation, interval_disjoint_union, plus cube_boundary_3d and cube_total_minus_interior relating total, interior and boundary lattice counts.",
+      "mathContext": "$L(P \\cup Q, n) + L(P \\cap Q, n) = L(P, n) + L(Q, n)$ — Ehrhart is a valuation on the lattice of polytopes. Proved for integer intervals via inclusion-exclusion."
     },
     {
-      "id": "concrete-zonotopes",
-      "title": "Parts 6–12: Concrete Verifications, Zonotopes, Products, h*-Vectors",
-      "startLine": 305,
+      "id": "degree-dimension",
+      "title": "Part 5: Degree and Dimension",
+      "startLine": 236,
+      "endLine": 262,
+      "summary": "Degree-dimension relationship: cube_leading_term, product_degree_additive, product_dimension. The Ehrhart polynomial of a d-dimensional polytope has degree exactly d, and degrees add under products.",
+      "mathContext": "$\\deg L(P \\times Q) = \\deg L(P) + \\deg L(Q) = \\dim P + \\dim Q$, a direct consequence of the product formula $L(P)\\cdot L(Q)$."
+    },
+    {
+      "id": "reciprocity",
+      "title": "Part 6: Reciprocity for Products",
+      "startLine": 263,
+      "endLine": 303,
+      "summary": "cube_interior_ehrhart definition and Ehrhart-Macdonald reciprocity: cube_reciprocity (L*(n) = (-1)^d·L(-n)), cube_interior_product, and reciprocity_multiplicative showing reciprocity is compatible with products.",
+      "mathContext": "Ehrhart-Macdonald reciprocity $L^*(P, n) = (-1)^{\\dim P} L(P, -n)$ is multiplicative: $L^*(P \\times Q, n) = L^*(P, n) \\cdot L^*(Q, n)$."
+    },
+    {
+      "id": "concrete-verifications",
+      "title": "Part 7: Concrete Product Verifications",
+      "startLine": 304,
+      "endLine": 343,
+      "summary": "Numeric verifications of the product formula at specific dilates: square_at_3 (16), segment_at_3 (4), product_at_3, cube3_at_2 (27), product_cube3_at_2, and interior counts cube3_interior_at_2 (1), cube3_interior_at_3 (8).",
+      "mathContext": "Spot-checks: $L([0,1]^2,3)=16=4^2$, $L([0,1]^3,2)=27=9\\cdot 3$, and interior counts $L^*([0,1]^3,n)=(n-1)^3$."
+    },
+    {
+      "id": "zonotopes",
+      "title": "Part 8: Zonotope Ehrhart Theory",
+      "startLine": 344,
+      "endLine": 401,
+      "summary": "Zonotopes as Minkowski sums of segments. centered_segment_ehrhart, centered_cube_ehrhart, centered_cube_product (product formula), centered_square/cube expansions, centered_square_at_1 (9), and centered_cube_from_standard.",
+      "mathContext": "A zonotope is a Minkowski sum of line segments; the centered cube $[-1,1]^d$ has $L(n) = (2n+1)^d = L_{[0,1]^d}(2n)$, and the product formula holds for centered cubes."
+    },
+    {
+      "id": "simplex-products",
+      "title": "Part 9: Higher-Dimensional Simplex Products",
+      "startLine": 402,
+      "endLine": 428,
+      "summary": "Simplex products and binomial identities: simplex1_squared (Δ₁×Δ₁ is a square (n+1)²), simplex1_times_simplex2, volume_simplex1_times_simplex2.",
+      "mathContext": "The Ehrhart polynomial of $\\Delta_a \\times \\Delta_b$ is $\\binom{n+a}{a}\\binom{n+b}{b}$; note $\\Delta_1 \\times \\Delta_1$ is the unit square with $L(n)=(n+1)^2$, not a simplex."
+    },
+    {
+      "id": "derivatives",
+      "title": "Part 10: Ehrhart Polynomial Derivatives",
+      "startLine": 429,
+      "endLine": 459,
+      "summary": "Derivatives of the cube Ehrhart polynomial: cube_ehrhart_deriv_3, cube_ehrhart_deriv2_3, cube3_deriv_at_0 (3), and cube3_second_coeff identifying the second coefficient with C(3,2)=3.",
+      "mathContext": "$L'(n) \\sim d\\,\\mathrm{Vol}(P)\\,n^{d-1}$ captures boundary growth; for the cube $(n+1)^d$ the second coefficient is $\\binom{d}{1}=d$."
+    },
+    {
+      "id": "picks-product",
+      "title": "Part 11: Pick's Theorem from Product Perspective",
+      "startLine": 460,
+      "endLine": 502,
+      "summary": "rectangle_ehrhart and its expansion abn²+(a+b)n+1, unit_square_ehrhart, picks_for_rectangle (Pick's formula proved algebraically), rectangle_total_points relating L(1) to interior + boundary.",
+      "mathContext": "For $[0,a]\\times[0,b]$: $L(n)=(an+1)(bn+1)=abn^2+(a+b)n+1$, recovering Pick's relation area $=$ interior $+$ boundary$/2 - 1$."
+    },
+    {
+      "id": "hstar-vectors",
+      "title": "Part 12: h*-Vector under Products",
+      "startLine": 503,
+      "endLine": 557,
+      "summary": "eulerian number recurrence and small-case verifications (eulerian_1_0, eulerian_2_0/2_1, eulerian_3_0), eulerian_sum identities, and hstar_cube_sum_is_factorial showing the h*-vector sum of a d-cube equals d!.",
+      "mathContext": "The $h^*$-polynomial of the cube $[0,1]^d$ is the Eulerian polynomial $A_d(z)$; the $h^*$-vector sums to $d!$ (total permutations of $\\{1,\\dots,d\\}$)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Results",
+      "startLine": 558,
       "endLine": 604,
-      "summary": "Concrete product verifications (interval × interval = square). Zonotope Ehrhart (cube as Minkowski sum). Higher-dim simplex products. Polynomial derivatives. Pick's theorem from product perspective. h*-vectors under products.",
-      "mathContext": "Cube $[0,1]^d$ as zonotope (Minkowski sum of $d$ unit segments): $L(n) = (n+1)^d$. h*-vector convolution: $h^*(P \\times Q) = h^*(P) * h^*(Q)$ (generating function product)."
+      "summary": "Summary docstring grouping the results by theme (product formula, volume multiplicativity, quasipolynomials, valuation, zonotopes, Pick's revisited, h*-vectors) followed by #check commands and the closing of namespace EhrhartProductQuasi.",
+      "mathContext": "Consolidates the 57 theorems: product formula and its reciprocity/interior variants, valuation, quasipolynomial examples, zonotope and simplex-product identities, and the Eulerian $h^*$-vector computations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Split the five lumped gallery sections of `picks-theorem-oq-03-product` into one section per `-- PART N` banner in `PicksTheoremOQ03Product.lean`, plus the module header and Summary block (5 → 14 sections).
- The old sections grouped "Parts 1–2", "Parts 4–5", and "Parts 6–12" into single entries; ranges now snap to the 12 banner dividers (box-tops at lines 26, 83, 120, 186, 236, 263, 304, 344, 402, 429, 460, 503, 558) and cover lines 1–604 contiguously.
- Each new section's summary lists its actual declarations and the mathContext is split to match.

## Notes
- No Lean source changes — pure gallery metadata realignment. `lineCount`, `theoremCount` (57), `axiomCount` (0), `sorries` (0) unchanged.
- Section schema keys (id/title/startLine/endLine/summary/mathContext) preserved; ranges verified contiguous and ending at lineCount 604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)