### PR TITLE
research(erdos-453-oq-02): realign sections + recover missing Part IV/V (5→6)

### DIFF
--- a/src/data/proofs/erdos-453-oq-02/meta.json
+++ b/src/data/proofs/erdos-453-oq-02/meta.json
@@ -63,7 +63,7 @@
       "convexity_implies_product_bound: re-derived using proved (not axiomatized) prime facts"
     ],
     "axiomCount": 2,
-    "lineCount": 226,
+    "lineCount": 254,
     "assumptions": "2 axioms remain: logPrime_ratio_tendsto_zero (PNT consequence), pomerance_convex_hull_lemma (convex hull theory). Reduced from 4 axioms + 1 sorry in parent.",
     "theoremCount": 7,
     "definitionCount": 3
@@ -81,7 +81,7 @@
       "Real"
     ],
     "namespace": "Erdos453OQ02",
-    "lineCount": 226,
+    "lineCount": 254,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 3,
@@ -118,15 +118,15 @@
       "id": "imports-setup",
       "title": "Imports, Namespace, and Axiom Elimination Goal",
       "startLine": 1,
-      "endLine": 35,
+      "endLine": 37,
       "summary": "Documents the axiom elimination goal: reduce from 4 axioms + 1 sorry (parent) to 2 axioms + 0 sorries. Imports Mathlib.Data.Nat.Prime.Nth (for nth_mem_of_infinite, nth_strictMono, nth_count), Mathlib.Analysis.SpecialFunctions.Log.Basic (for Real.log), and Mathlib.Analysis.Convex.Basic. Opens Nat, Real, and Finset.BigOperators for concise notation.",
       "mathContext": "Key imports: Nat.nth_mem_of_infinite, Nat.nth_strictMono ∈ Nat.Prime.Nth; axiom count: 4+1sorry (parent) → 2+0sorry (this file)"
     },
     {
       "id": "prime-sequence",
       "title": "Part I: The Prime Sequence (Axiom-Free)",
-      "startLine": 36,
-      "endLine": 104,
+      "startLine": 38,
+      "endLine": 105,
       "summary": "Defines nthPrime (1-indexed via Nat.nth Nat.Prime (n-1)) and proves three facts that were axioms/sorry in the parent. nthPrime_is_prime: Nat.nth_mem_of_infinite Nat.infinite_setOf_prime. nthPrime_strictMono: shifted form + Nat.nth_strictMono. nthPrime_values: Mathlib constants for p_1,p_2,p_3 and Nat.count+decide for p_4=7.",
       "mathContext": "\\text{nthPrime}(n) = \\text{Nat.nth Nat.Prime}(n-1) \\quad (n \\geq 1)\\\\ \\text{nthPrime\\_is\\_prime: Nat.nth\\_mem\\_of\\_infinite}\\\\ \\text{nthPrime\\_strictMono: Nat.nth\\_strictMono}\\\\ p_1=2,\\; p_2=3,\\; p_3=5,\\; p_4=7\\; (\\text{Nat.nth\\_count})"
     },
@@ -142,16 +142,25 @@
       "id": "main-results",
       "title": "Part III: Re-derived Main Results (2 Axioms)",
       "startLine": 148,
-      "endLine": 186,
-      "summary": "Re-derives convexity_implies_product_bound (log convexity → p_n² > p_{n+i}p_{n-i}) and pomerance_1979 (infinitely many such n) using the proved prime facts. The log→product conversion: Real.log_mul, Real.log_lt_log_iff, exact_mod_cast to ℤ. axiom_elimination_summary documents the 4→2 axiom reduction.",
+      "endLine": 199,
+      "summary": "Re-derives convexity_implies_product_bound (log convexity → p_n² > p_{n+i}p_{n-i}) and pomerance_1979 (infinitely many such n) using the proved prime facts. The log→product conversion: Real.log_mul, Real.log_lt_log_iff, exact_mod_cast to ℤ.",
       "mathContext": "\\text{convexity\\_implies\\_product\\_bound: }\\\\ 2\\log p_n > \\log p_{n-i}+\\log p_{n+i} \\Rightarrow p_n^2 > p_{n+i}p_{n-i}\\\\ \\text{pomerance\\_1979: } \\forall N,\\; \\exists n\\geq N,\\; \\forall 0<i<n:\\; p_n^2 > p_{n+i}p_{n-i}\\\\ \\text{Axiom count: 4 (parent)} \\to \\text{2 (this file)}"
     },
     {
-      "id": "section-187",
-      "title": "Part III: Re-derived Main Results (2 Axioms) (continued)",
-      "startLine": 187,
-      "endLine": 224,
-      "summary": "Continuation: remaining proofs and definitions in this section."
+      "id": "consecutive-primes-corollary",
+      "title": "Part IV: Consecutive Primes Corollary (i = 1 specialization)",
+      "startLine": 200,
+      "endLine": 227,
+      "summary": "Specializes pomerance_1979 to i = 1 (theorem pomerance_consecutive_primes): infinitely many n ≥ 2 satisfy p_n² > p_{n-1}·p_{n+1}. This is the smallest non-trivial case and the headline form often quoted from Pomerance's 1979 paper, obtained by instantiating the universally quantified i to 1 and requiring n ≥ 2 (so that 0 < 1 < n).",
+      "mathContext": "\\text{pomerance\\_consecutive\\_primes: } \\forall N,\\; \\exists n \\geq \\max(N,2),\\; p_n^2 > p_{n-1} p_{n+1}\\\\ \\text{(i = 1 specialization of pomerance\\_1979)}"
+    },
+    {
+      "id": "axiom-elimination-summary",
+      "title": "Part V: Summary of Axiom Elimination",
+      "startLine": 228,
+      "endLine": 254,
+      "summary": "axiom_elimination_summary restates the main bound (infinitely many n with p_n² > p_{n+i}·p_{n-i} for all 0 < i < n) as a direct alias of pomerance_1979, documenting the reduction from 4 axioms + 1 sorry (parent) to 2 axioms + 0 sorries: nthPrime_is_prime, nthPrime_strictMono, and nthPrime_values were eliminated, while logPrime_ratio_tendsto_zero (PNT consequence) and pomerance_convex_hull_lemma (discrete convex hull theory) remain.",
+      "mathContext": "\\text{Parent: 4 axioms + 1 sorry} \\;\\to\\; \\text{this file: 2 axioms + 0 sorries}\\\\ \\text{Eliminated: nthPrime\\_is\\_prime, nthPrime\\_strictMono, nthPrime\\_values}\\\\ \\text{Remaining: logPrime\\_ratio\\_tendsto\\_zero, pomerance\\_convex\\_hull\\_lemma}"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Metadata-only realign of the `erdos-453-oq-02` gallery entry. `Proofs/Erdos453OQ02.lean` grew from 226 → 254 lines when **Part IV (Consecutive Primes Corollary)** and **Part V (Summary of Axiom Elimination)** were added, but `meta.json` was never updated.

Before this fix the `sections[]` had 5 entries ending in a spurious generic **"Part III: Re-derived Main Results (2 Axioms) (continued)"** (`id: section-187`, lines 187–224, summary "Continuation: remaining proofs and definitions in this section"), and **Part IV and Part V were entirely missing**.

Changes:
- **Relabeled** the generic `section-187` → **Part IV "Consecutive Primes Corollary (i = 1 specialization)"** (`pomerance_consecutive_primes`, lines 200–227) with an accurate summary + mathContext.
- **Added** the missing **Part V "Summary of Axiom Elimination"** (`axiom_elimination_summary`, lines 228–254).
- **Realigned** Part I (38–105) and Part III (148–199); header now includes the namespace (1–37). Sections tile 1→254 contiguously, matching the file's `## Part I–V` banners.
- **Fixed stale `lineCount` 226 → 254** in both the `meta` and `leanFile` blocks (`wc -l` = 254).
- Dropped a stale mention of `axiom_elimination_summary` from the Part III summary (it now lives in Part V).

No Lean source changes. Counts unchanged and verified against the file: 7 theorems, 2 axioms, 3 definitions, 0 sorries.

## Verification
- `wc -l Proofs/Erdos453OQ02.lean` = 254; each section range matches its `## Part N` banner (banners at 39/107/149/201/229).
- `python3 -m json.tool` parses cleanly; sections contiguous, last `endLine` = 254.
- Build-free metadata change (Docker + Aristotle backends down this session).