### PR TITLE
research(hilbert-21): realign drifted gallery sections to full file (5→11)

### DIFF
--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -64,39 +64,81 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Singular Points and Monodromy",
+      "id": "module-header",
+      "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 100,
-      "summary": "Basic definitions of singular points, punctured planes, and monodromy representations."
+      "endLine": 73,
+      "summary": "Module docstring stating the Riemann-Hilbert problem and its nuanced resolution (Plemelj 1908 positive for irreducible, Bolibrukh 1989 negative in general), imports (Mathlib.Tactic, Complex.Basic, GeneralLinearGroup, Topology), and the namespace Hilbert21."
+    },
+    {
+      "id": "definitions",
+      "title": "Part 1: Basic Definitions",
+      "startLine": 74,
+      "endLine": 95,
+      "summary": "SingularPoints structure (a nonempty Finset ℂ of singularities) and puncturedPlane, the complement ℂ \\ {singular points} on which monodromy is defined."
+    },
+    {
+      "id": "monodromy",
+      "title": "Part 2: Monodromy Representations",
+      "startLine": 96,
+      "endLine": 132,
+      "summary": "MonodromyRep structure assigning a GL(Fin n, ℂ) matrix to each singular point (a homomorphism from the free fundamental group π₁(ℂ \\ {zᵢ})), and MonodromyRep.isIrreducible (no proper invariant subspaces)."
     },
     {
       "id": "fuchsian",
-      "title": "Fuchsian Systems",
-      "startLine": 101,
-      "endLine": 150,
-      "summary": "Definition of Fuchsian systems with simple pole singularities."
+      "title": "Part 3: Fuchsian Systems",
+      "startLine": 133,
+      "endLine": 165,
+      "summary": "FuchsianSystem structure given by residue matrices with residue_sum_zero (the relation at infinity), and the coefficientMatrix A(z) = Σ Aᵢ/(z−zᵢ). A docstring notes that regular-singularity (polynomial growth) is not yet formalized."
     },
     {
-      "id": "positive",
-      "title": "Plemelj's Theorem",
-      "startLine": 151,
-      "endLine": 200,
-      "summary": "The positive result: irreducible representations are always realizable."
+      "id": "rh-correspondence",
+      "title": "Part 4: The Riemann-Hilbert Correspondence",
+      "startLine": 166,
+      "endLine": 188,
+      "summary": "The computeMonodromy axiom (analytic continuation of a fundamental solution matrix around each singularity) and the realizes predicate: a Fuchsian system realizes ρ iff its computed monodromy equals ρ."
     },
     {
-      "id": "negative",
-      "title": "Bolibrukh's Counterexamples",
-      "startLine": 201,
-      "endLine": 250,
-      "summary": "The negative result: some reducible representations have no Fuchsian realization."
+      "id": "plemelj",
+      "title": "Part 5: The Main Theorems (Plemelj, Irreducible Case)",
+      "startLine": 189,
+      "endLine": 220,
+      "summary": "plemelj_theorem_irreducible axiom — every irreducible monodromy representation is realized by some Fuchsian system — and riemann_hilbert_irreducible deriving the positive answer to Hilbert's 21st in the irreducible case."
+    },
+    {
+      "id": "bolibrukh",
+      "title": "Part 6: Bolibrukh's Counterexamples",
+      "startLine": 221,
+      "endLine": 255,
+      "summary": "bolibrukh_counterexample axiom (a reducible representation with 4 singular points and dimension 3 realizable by no Fuchsian system) and hilbert21_negative_in_general, showing the original 'always exists' claim is false."
+    },
+    {
+      "id": "birkhoff",
+      "title": "Part 7: Regular Singular Systems (Birkhoff)",
+      "startLine": 256,
+      "endLine": 286,
+      "summary": "RegularSingularSystem structure (higher-order poles with polynomial-growth solutions) and birkhoff_theorem: every monodromy representation is realizable once the Fuchsian (simple-pole) constraint is relaxed to regular singular."
     },
     {
       "id": "characterization",
-      "title": "Complete Characterization and RH Correspondence",
-      "startLine": 251,
+      "title": "Part 8: Characterization Theorem",
+      "startLine": 287,
+      "endLine": 319,
+      "summary": "hasFuchsianRealization predicate and the realization_criterion axiom (Deligne 1970, Bolibrukh 1989): Fuchsian realizability is determined by the splitting type of an associated vector bundle over ℂP¹."
+    },
+    {
+      "id": "rh-correspondence-modern",
+      "title": "Part 9: The Riemann-Hilbert Correspondence (Modern)",
+      "startLine": 320,
+      "endLine": 342,
+      "summary": "Prose section on the modern categorical Riemann-Hilbert correspondence — equivalence between local systems, regular-singular D-modules, and connections (Kashiwara-Mebkhout) — a cornerstone of geometric Langlands. Formalization awaits derived-category machinery."
+    },
+    {
+      "id": "summary",
+      "title": "Part 10: Summary",
+      "startLine": 343,
       "endLine": 386,
-      "summary": "Birkhoff's theorem (regular singular systems always work), complete realizability criterion via cohomological conditions, and the modern Riemann-Hilbert correspondence between D-modules and local systems."
+      "summary": "Summary docstring of the four-part answer (positive irreducible, negative general, positive regular-singular, complete characterization) and the hilbert21_summary theorem bundling the irreducible-positive and general-negative results, followed by #check exports."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Split the five lumped gallery sections of `hilbert-21` into one section per `-- PART N` banner in `Hilbert21RiemannHilbert.lean` (module header + Parts 1–10), 5 → 11 sections.
- The old sections used uniform 50-line guesses (1-100, 101-150, 151-200, 201-250, 251-386) that no longer matched the actual banner dividers at lines 74, 96, 133, 166, 189, 221, 256, 287, 320, 343. Ranges now snap to those boxes and cover lines 1–386 contiguously.
- Each section summary names its actual declarations (SingularPoints, MonodromyRep, FuchsianSystem, the computeMonodromy / plemelj / bolibrukh / realization_criterion axioms, birkhoff_theorem, hilbert21_summary).

## Notes
- No Lean source changes — pure gallery metadata realignment. `axiomCount` (4), `theoremCount` (4), `lineCount` (386), `sorries` (0) unchanged; entry stays `axiomatized`.
- Section schema keys (id/title/startLine/endLine/summary) preserved; ranges verified contiguous and ending at lineCount 386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)