### PR TITLE
research(general-quartic-oq-02): reconcile top-level docstring to (y²+p+m) convention

### DIFF
--- a/proofs/Proofs/GeneralQuartic.lean
+++ b/proofs/Proofs/GeneralQuartic.lean
@@ -34,25 +34,31 @@ can be solved by radicals using Ferrari's method (1540).
 
 ## Mathematical Background
 
-Ferrari's brilliant insight (1540): Add m to both sides and complete the square.
+Ferrari's brilliant insight (1540): Add a parameter m and complete the square.
 
-Starting with y⁴ + py² + qy + r = 0, rearrange as:
-  (y² + p/2)² = (p²/4 - r) - qy
-            = (p/2)²y⁰ - qy - r + p²/4
+NOTE ON CONVENTION: this file uses a *non-standard* completion with constant
+`p + m` (not the textbook `p/2 + m`). The derivation below, the `resolventCubic`
+definition, and `ferrari_factorization_id` all share this `(y² + p + m)²`
+convention; the file's `m` differs from the textbook parameter by a shift of p/2.
 
-By adding a parameter m and completing the square on the right side, we can write:
-  (y² + p/2 + m)² = (2m + p)y² - qy + (m² + pm + p²/4 - r)
+Starting with y⁴ + py² + qy + r = 0, substitute y⁴ = -py² - qy - r into the
+expansion of (y² + p + m)² = y⁴ + 2(p + m)y² + (p + m)² to get:
+  (y² + p + m)² = (2m + p)y² - qy + (m² + 2pm + p² - r)
 
 The right side is a perfect square in y when its discriminant vanishes:
-  q² - 4(2m + p)(m² + pm + p²/4 - r) = 0
+  q² - 4(2m + p)((p + m)² - r) = 0
 
-This is the resolvent cubic in m. Once m is found, we have:
-  (y² + p/2 + m)² = (αy + β)²
+Expanding this gives the resolvent cubic in m (matching `resolventCubic`):
+  8m³ + 20pm² + (16p² - 8r)m + (4p³ - 4pr - q²) = 0
 
-for some α, β determined by m. Taking square roots:
-  y² + p/2 + m = ±(αy + β)
+Once m is found, we have:
+  (y² + p + m)² = (αy - β)²   with  α² = 2m + p,  2αβ = q,  β² = (p + m)² - r
 
-Each gives a quadratic, yielding four roots total.
+Taking square roots:
+  y² + p + m = ±(αy - β)
+
+Each gives a quadratic factor (see `ferrari_factorization_id`), yielding four
+roots total.
 
 Historical Note: Lodovico Ferrari (1522-1565), a student of Cardano, discovered
 this method at age 18. It was published in Cardano's Ars Magna (1545).

--- a/research/problems/general-quartic-oq-02/sessions/2026-06-14-s10-docstring-convention-reconcile.md
+++ b/research/problems/general-quartic-oq-02/sessions/2026-06-14-s10-docstring-convention-reconcile.md
@@ -1,0 +1,57 @@
+# S10 — Top-level docstring convention reconciliation (build-free)
+
+**Date**: 2026-06-14
+**Agent**: researcher-2
+**Phase**: ACT (documentation; S9 axiom-elimination remains Docker-blocked)
+**Type**: comment-only Lean edit (build-safe; Docker daemon down all session)
+
+## What
+
+The top-level module docstring of `proofs/Proofs/GeneralQuartic.lean`
+(the "Mathematical Background" section) described Ferrari's completion in
+the textbook `(y² + p/2 + m)²` convention, but every proved declaration in
+the file — `resolventCubic`, `ferrari_factorization_id`, the
+`ferrari_factorization_*_ne` theorems, `ferrari_roots_verify_ne` — uses the
+file's **non-standard `(y² + p + m)²` convention** (constant `p + m`, not
+`p/2 + m`). The inner docstrings (around `ferrari_factorization_id` and
+`ferrari_biquad_limit`) already flag this convention explicitly; only the
+top-level block was stale.
+
+The stale block was also **internally inconsistent**: its line
+`(y² + p/2 + m)² = (2m + p)y² − qy + (m² + pm + p²/4 − r)` pairs a
+textbook LHS (`p/2 + m`) with a file-convention RHS coefficient (`(2m+p)y²`),
+which do not match. In the textbook `p/2+m` convention the y²-coefficient is
+`2m`, not `2m+p`.
+
+## Fix
+
+Rewrote the Mathematical Background derivation entirely in the file's
+`(y² + p + m)²` convention, with an explicit NOTE that this is non-standard
+and that the file's `m` differs from the textbook parameter by a p/2 shift.
+The rewritten derivation is mathematically verified to match the code:
+
+- Completion: `(y² + p + m)² = (2m+p)y² − qy + (m² + 2pm + p² − r)`
+  (substitute `y⁴ = −py² − qy − r` into `y⁴ + 2(p+m)y² + (p+m)²`).
+- Perfect-square / discriminant-vanishing condition:
+  `q² − 4(2m+p)((p+m)² − r) = 0`.
+- Expanding that condition yields exactly the file's `resolventCubic`:
+  `8m³ + 20pm² + (16p² − 8r)m + (4p³ − 4pr − q²) = 0`
+  (expansion checked by hand: `4(2m+p)[(p+m)²−r] − q²`).
+- Factor relations: `α² = 2m+p`, `2αβ = q`, `β² = (p+m)² − r`, matching the
+  `hα / hβ1 / hβ2` hypotheses of `ferrari_factorization_id`; and the sign is
+  `(αy − β)` (the factors are `y² + p + m ∓ αy ± β`), corrected from the stale
+  `(αy + β)`.
+
+## Scope / safety
+
+- Comment-only: no declaration, statement, tactic, axiom, or import changed.
+- No effect on axiom count (still 3), sorry count (0), or line count semantics.
+- Gallery `general-quartic/meta.json` left untouched (it is a shared parent
+  entry and has concurrent audit branches; this fix is docstring-only and does
+  not change any meta-tracked count).
+
+## Still blocked
+
+S9 axiom-elimination (`biquadratic_forward/backward`, `quartic_has_four_roots`)
+remains Docker-gated; `docker info` still times out this session. Unblock
+condition unchanged: re-verify the S8 merge state builds, then resume Action 1.

--- a/research/problems/general-quartic-oq-02/state.md
+++ b/research/problems/general-quartic-oq-02/state.md
@@ -1,10 +1,28 @@
 # Current State
 
-**Phase**: ACT (S8 AXIOM ELIMINATION done; **S9 BLOCKED on Docker** — next axiom-eliminations are build-gated)
+**Phase**: ACT (S8 AXIOM ELIMINATION done; **S9 axiom-elimination BLOCKED on Docker**; S10 = build-free docstring reconciliation, this session)
 **Since**: 2026-06-04 (S6 AUDIT) → 2026-06-09 (S7 SOUND DISCHARGE) →
-2026-06-13 (S8 AXIOM ELIMINATION) → 2026-06-13 (S9 BLOCKED FLAG, this session)
-**Iteration**: 11 (S5a + S5b SCAFFOLD-1/-2/-3; S6 AUDIT + BUGFIX; S7
-SOUND DISCHARGE; S8 AXIOM ELIMINATION; S9 BLOCKED FLAG this session)
+2026-06-13 (S8 AXIOM ELIMINATION) → 2026-06-13 (S9 BLOCKED FLAG) →
+2026-06-14 (S10 DOCSTRING RECONCILE, this session)
+**Iteration**: 12 (S5a + S5b SCAFFOLD-1/-2/-3; S6 AUDIT + BUGFIX; S7
+SOUND DISCHARGE; S8 AXIOM ELIMINATION; S9 BLOCKED FLAG; S10 DOCSTRING
+RECONCILE this session)
+
+## S10 DOCSTRING RECONCILE (2026-06-14, researcher-2)
+
+**Build-free, comment-only.** The top-level module docstring described
+Ferrari's completion in the textbook `(y² + p/2 + m)²` convention while the
+entire proof body uses the file's non-standard `(y² + p + m)²` convention
+(constant `p + m`); the stale block was also internally inconsistent
+(textbook LHS paired with a file-convention `(2m+p)y²` RHS). Rewrote the
+"Mathematical Background" derivation in the `(y² + p + m)²` convention, with
+an explicit non-standard-convention note, sign fix `(αy − β)`, the
+`α²=2m+p / 2αβ=q / β²=(p+m)²−r` factor relations, and the discriminant
+condition `q² − 4(2m+p)((p+m)² − r) = 0` whose expansion matches
+`resolventCubic` exactly (verified by hand). No statement/tactic/axiom/import
+touched; axiom count 3, sorries 0 unchanged. See
+`sessions/2026-06-14-s10-docstring-convention-reconcile.md`. S9 axiom
+elimination remains Docker-gated.
 
 ## S9 BLOCKED FLAG (2026-06-13, researcher-2)
 


### PR DESCRIPTION
## Summary

The top-level module docstring of `proofs/Proofs/GeneralQuartic.lean` described Ferrari's square-completion in the textbook `(y² + p/2 + m)²` convention, but the entire proof body — `resolventCubic`, `ferrari_factorization_id`, the `ferrari_factorization_*_ne` theorems, `ferrari_roots_verify_ne` — uses the file's **non-standard `(y² + p + m)²` convention** (constant `p + m`). The inner docstrings already flag this; only the top-level block was stale.

The stale block was also **internally inconsistent**: it paired a textbook LHS `(y² + p/2 + m)²` with a file-convention RHS coefficient `(2m + p)y²` (in the textbook convention that coefficient is `2m`).

## Fix

Rewrote the "Mathematical Background" derivation entirely in the `(y² + p + m)²` convention, verified against the code:

- Completion: `(y² + p + m)² = (2m+p)y² − qy + (m² + 2pm + p² − r)`
- Discriminant-vanishing condition: `q² − 4(2m+p)((p+m)² − r) = 0`
- Expanding that condition reproduces the file's `resolventCubic` exactly: `8m³ + 20pm² + (16p² − 8r)m + (4p³ − 4pr − q²) = 0` (checked by hand)
- Factor relations `α²=2m+p`, `2αβ=q`, `β²=(p+m)²−r` matching the `hα/hβ1/hβ2` hypotheses of `ferrari_factorization_id`; sign corrected to `(αy − β)`
- Added an explicit note that the convention is non-standard (file `m` differs from the textbook parameter by a p/2 shift)

## Scope / safety

- **Comment-only**: no declaration, statement, tactic, axiom, or import changed.
- Axiom count (3), sorry count (0), and line-count semantics unchanged.
- Gallery `general-quartic/meta.json` left untouched (shared parent entry with concurrent audit branches).
- Build-free — Docker daemon is down this session; S9 axiom-elimination remains Docker-gated.

## Test plan
- [x] Verified no `axiom`/`theorem`/`def`/`import`/`sorry` lines changed (prose only)
- [ ] Lean build deferred until Docker is restored (comment-only change cannot affect compilation)