### PR TITLE
Enrich e-transcendental: realign meta/annotations to refactored axiom architecture

### DIFF
--- a/src/data/proofs/e-transcendental/annotations.json
+++ b/src/data/proofs/e-transcendental/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Transcendence of e: Wiedijk #67",
-    "content": "**Main Result**:\n\nEuler's number $e = 2.71828...$ is **transcendental**: it is not the root of any non-zero polynomial with integer coefficients.\n\n$$\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\}: P(e) = 0$$\n\n**Historical Significance**: Hermite (1873) - first proof that a \"naturally occurring\" number is transcendental.\n\n**Status**: Axiomatized pending Lindemann-Weierstrass formalization.",
+    "content": "**Main Result**:\n\nEuler's number $e = 2.71828...$ is **transcendental**: it is not the root of any non-zero polynomial with integer coefficients.\n\n$$\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\}: P(e) = 0$$\n\n**Historical Significance**: Hermite (1873) - first proof that a \"naturally occurring\" number is transcendental.\n\n**Status**: Axiomatized — the main theorem is proved from a single imported `hermite_lindemann` axiom (Lindemann-Weierstrass is not yet in Mathlib), with no axiom declared in this file.",
     "mathContext": "$\\text{Transcendental}\\; \\mathbb{Z}\\; (\\exp 1)$ — the statement that $e$ is not a root of any nonzero integer polynomial. This is Wiedijk's 100 theorems list entry #67.",
     "significance": "key",
     "relatedConcepts": [
@@ -25,8 +25,8 @@
     "id": "ann-definitions",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 50,
-      "endLine": 65
+      "startLine": 52,
+      "endLine": 68
     },
     "type": "definition",
     "title": "Transcendental Numbers",
@@ -47,8 +47,8 @@
     "id": "ann-properties",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 71,
-      "endLine": 83
+      "startLine": 73,
+      "endLine": 85
     },
     "type": "concept",
     "title": "Properties of e",
@@ -69,8 +69,8 @@
     "id": "ann-hermite-proof",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 88,
-      "endLine": 128
+      "startLine": 90,
+      "endLine": 131
     },
     "type": "concept",
     "title": "Hermite's Proof Strategy",
@@ -92,18 +92,18 @@
     "id": "ann-main-axiom",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 134,
-      "endLine": 156
+      "startLine": 136,
+      "endLine": 152
     },
     "type": "concept",
-    "title": "Main Theorem (Axiomatized)",
-    "content": "**Main Axiom**:\n$$\\text{Transcendental } \\mathbb{Z} \\ (\\exp 1)$$\n\n**Requirements for full proof**:\n1. Polynomial arithmetic over $\\mathbb{Z}$\n2. Integration by parts for polynomial $\\times$ exponential\n3. Divisibility analysis mod $p$\n4. Asymptotic estimates\n\n**Equivalence**:\n$$\\text{Transcendental } \\mathbb{Z} \\ e \\Leftrightarrow \\text{Transcendental } \\mathbb{Q} \\ e$$\n(Clear denominators to convert $\\mathbb{Q}$-polynomial to $\\mathbb{Z}$-polynomial)",
-    "mathContext": "`Transcendental ℤ (Real.exp 1)` — axiomatized because the Lindemann-Weierstrass theorem (the standard generalization) is not yet in Mathlib. The $\\mathbb{Z} \\leftrightarrow \\mathbb{Q}$ equivalence follows from clearing denominators.",
+    "title": "Main Theorem (Derived from Hermite-Lindemann)",
+    "content": "**Main Theorem** (`e_transcendental`):\n$$\\text{Transcendental } \\mathbb{Z} \\ (\\exp 1)$$\n\nProved as `HermiteLindemann.e_transcendental_int` — the imported `hermite_lindemann` axiom specialized to $\\alpha = 1$. This file declares no axiom of its own; the single assumption lives in `Proofs.HermiteLindemann`.\n\n**Why an axiom is still needed**: a from-scratch Hermite proof requires (1) polynomial arithmetic over $\\mathbb{Z}$, (2) integration by parts for polynomial $\\times$ exponential, (3) divisibility analysis mod $p$, and (4) asymptotic estimates — machinery (Lindemann-Weierstrass) not yet in Mathlib.\n\n**Over $\\mathbb{Q}$**:\n$$\\text{Transcendental } \\mathbb{Z} \\ e \\Leftrightarrow \\text{Transcendental } \\mathbb{Q} \\ e$$\nvia `IsFractionRing.isAlgebraic_iff` for $\\mathbb{Z} \\subset \\mathbb{Q}$.",
+    "mathContext": "`e_transcendental : Transcendental ℤ (Real.exp 1) := HermiteLindemann.e_transcendental_int`. The proof is conditional on the imported `hermite_lindemann` axiom, because the Lindemann-Weierstrass theorem is not yet in Mathlib. The $\\mathbb{Z} \\leftrightarrow \\mathbb{Q}$ equivalence follows from `IsFractionRing.isAlgebraic_iff`.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
+      "Hermite-Lindemann",
       "Lindemann-Weierstrass",
-      "pending formalization"
+      "imported axiom"
     ],
     "prerequisites": [
       "Transcendental definition",
@@ -114,8 +114,8 @@
     "id": "ann-corollaries",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 162,
-      "endLine": 200
+      "startLine": 157,
+      "endLine": 232
     },
     "type": "concept",
     "title": "Corollaries: Irrationality and Closure Properties",
@@ -136,8 +136,8 @@
     "id": "ann-connections",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 205,
-      "endLine": 231
+      "startLine": 237,
+      "endLine": 264
     },
     "type": "concept",
     "title": "Related Theorems and Open Problems",
@@ -159,8 +159,8 @@
     "id": "ann-significance",
     "proofId": "e-transcendental",
     "range": {
-      "startLine": 237,
-      "endLine": 269
+      "startLine": 269,
+      "endLine": 304
     },
     "type": "concept",
     "title": "Historical and Mathematical Significance",

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -39,8 +39,8 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "assumptions": "1 axiom: e_transcendental (Hermite 1873: e is transcendental). Corollaries e_irrational_axiom, exp_nat_transcendental_axiom, e_inv_transcendental_axiom, e_plus_one_transcendental_axiom formerly axiomatized; now proved from e_transcendental.",
-    "lineCount": 305,
+    "assumptions": "1 axiom, imported: `hermite_lindemann` in `Proofs.HermiteLindemann` (the Hermite-Lindemann theorem; Hermite 1873). This file declares no axiom of its own — the main theorem `e_transcendental` is proved as `HermiteLindemann.e_transcendental_int` (Hermite-Lindemann at α = 1), and all corollaries (`e_irrational`, `exp_nat_transcendental`, `e_inv_transcendental`, `e_plus_one_transcendental`) are then proved from it. The proof remains conditional on the single imported axiom, so the status is axiomatized.",
+    "lineCount": 304,
     "relatedProblems": [
       {
         "id": "e-transcendental-oq-01",
@@ -52,9 +52,9 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",
+    "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is proved from an explicit `hermite_lindemann` axiom (declared once in `Proofs.HermiteLindemann` and shared across the $e$- and $\\pi$-transcendence entries) rather than from a self-contained Lean derivation.",
     "problemStatement": "**Theorem**: e is transcendental, i.e., there is no nonzero polynomial P with integer coefficients such that P(e) = 0.\n\nThis is stronger than irrationality (proved by Euler) and even algebraic irrationality.",
-    "text": "A 267-line axiomatized formalization of $e$'s transcendence (Wiedijk #67) with 12 declarations, 0 sorries. The main theorem `e_transcendental` states $\\neg \\text{IsAlgebraic}\\,\\mathbb{Z}\\,e$ and is axiomatized (Hermite's 1873 proof requires auxiliary polynomial integral estimates not yet in Mathlib). Proves `e_irrational` from transcendence via `Transcendental.irrational`, and `e_not_integer` / `e_bounds` ($2 < e < 3$) from Mathlib's `Real.exp_one_gt_d9` and `Real.exp_one_lt_d9`. Includes `e_power_transcendental` ($e^n$ transcendental for $n \\neq 0$) via the Lindemann-Weierstrass axiom, and `e_algebraic_independence` for $\\{e, e^2\\}$. Commentary traces Hermite's method and the path to Lindemann's transcendence of $\\pi$.",
+    "text": "A 304-line formalization of $e$'s transcendence (Wiedijk #67) with 13 theorems, 0 sorries, and no axiom of its own. The main theorem `e_transcendental` states $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp 1)$ and is proved as `HermiteLindemann.e_transcendental_int` — the imported Hermite-Lindemann axiom specialized to $\\alpha = 1$ — so the page is conditional on that single imported assumption. Establishes the bounds $e \\in (1,3)$ via Mathlib's `exp_pos`, `one_lt_exp_iff`, and `exp_one_lt_d9`; derives `e_irrational` from transcendence; and proves `exp_nat_transcendental` ($e^n$ transcendental for $n \\neq 0$), `e_inv_transcendental` ($1/e$), and `e_plus_one_transcendental` ($e+1$) from the main result. Commentary traces Hermite's auxiliary-polynomial method and the path to Lindemann's transcendence of $\\pi$.",
     "proofStrategy": "Hermite's proof uses contour integration. Assume e is algebraic with minimal polynomial P. Construct an auxiliary integral that is simultaneously a non-zero integer and arbitrarily small (using factorial growth vs exponential), yielding a contradiction.",
     "keyInsights": [
       "**Factorial vs. Exponential:** Hermite's proof exploits $\\int_0^n f(t)e^{-t}dt$ where $f$ has $(p{-}1)!$ in the denominator. For large prime $p$, the integral is a nonzero integer (by divisibility) yet arbitrarily small (since $p! \\gg e^n$) — contradiction.",
@@ -102,63 +102,63 @@
       "id": "imports-docstring",
       "title": "Imports and Module Documentation",
       "startLine": 1,
-      "endLine": 45,
+      "endLine": 47,
       "summary": "Imports Mathlib's algebraic and analytic infrastructure: `Transcendental` from ring theory, `Real.exp` and exponential bounds, `Irrational` definition, and `Complex.Analytic` for the exponential function's analytic theory.",
-      "mathContext": "Wiedijk #67: $e$ is transcendental, i.e., $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp(1))$. Hermite (1873) was first to prove this. The main theorem is axiomatized pending Lindemann-Weierstrass in Mathlib."
+      "mathContext": "Wiedijk #67: $e$ is transcendental, i.e., $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp(1))$. Hermite (1873) was first to prove this. The main theorem is proved from the imported `hermite_lindemann` axiom in `Proofs.HermiteLindemann` (the full Lindemann-Weierstrass theorem is not yet in Mathlib)."
     },
     {
       "id": "definitions-background",
       "title": "Definitions and Background",
-      "startLine": 46,
-      "endLine": 66,
+      "startLine": 48,
+      "endLine": 68,
       "summary": "Reviews the definition of transcendental numbers ($\\nexists P \\in R[X] \\setminus \\{0\\}: P(x) = 0$), the distinction from irrationality, and Cantor's result that most reals are transcendental. Uses `#check` to verify Mathlib provides `Transcendental` and `Real.exp 1`.",
       "mathContext": "$x$ is transcendental over $R$ iff $\\nexists P \\in R[X] \\setminus \\{0\\},\\ P(x) = 0$. Equivalently, $x$ is not algebraic: $\\neg\\text{IsAlgebraic}\\ R\\ x$. Transcendental $\\implies$ irrational (since $p/q$ satisfies $qX - p = 0$), but not conversely ($\\sqrt{2}$ is irrational but algebraic)."
     },
     {
       "id": "e-properties",
       "title": "Key Properties of e from Mathlib",
-      "startLine": 67,
-      "endLine": 83,
+      "startLine": 69,
+      "endLine": 85,
       "summary": "Establishes $e > 0$, $e > 1$, and $e < 3$ using Mathlib's `exp_pos`, `one_lt_exp_iff`, and `exp_one_lt_d9`. These bounds verify the exponential constant lies in $(1, 3)$.",
       "mathContext": "$e = \\exp(1) \\in (1, 3)$. Verified via Mathlib: `exp_pos` gives $e > 0$, `one_lt_exp_iff` and positivity gives $e > 1$, and `exp_one_lt_d9` bounds $e < 2.7182818286$ which implies $e < 3$."
     },
     {
       "id": "hermite-proof",
       "title": "Hermite's Proof Strategy (1873)",
-      "startLine": 84,
-      "endLine": 129,
+      "startLine": 86,
+      "endLine": 131,
       "summary": "Detailed exposition of Hermite's proof outline: (1) assume $\\sum a_i e^i = 0$, (2) construct auxiliary polynomial $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, (3) define key integrals $I_k = \\int_0^k f(x)e^x dx$, (4) show the sum $S = \\sum a_k I_k$ is simultaneously small and a nonzero multiple of $p$—contradiction.",
       "mathContext": "Hermite's auxiliary polynomial: $f(x) = \\frac{x^{p-1}(x-1)^p \\cdots (x-n)^p}{(p-1)!}$ for large prime $p$. The integral $I_k = \\int_0^k f(t)e^{k-t} dt$ satisfies: (1) $\\sum a_k I_k \\equiv a_0 \\cdot (-1)^n n!^p \\pmod{p}$ (nonzero for $p > \\max(|a_0|, n)$), and (2) $|\\sum a_k I_k| \\to 0$ as $p \\to \\infty$ (factorial denominator dominates). Contradiction."
     },
     {
-      "id": "main-axioms",
-      "title": "Main Theorem (Axiomatized)",
-      "startLine": 130,
-      "endLine": 157,
-      "summary": "Axiomatizes `Transcendental ℤ (Real.exp 1)` and the equivalent `Transcendental ℚ (Real.exp 1)`, pending formalization of the Lindemann-Weierstrass theorem in Mathlib. Notes that clearing denominators converts $\\mathbb{Q}$-algebraicity to $\\mathbb{Z}$-algebraicity.",
-      "mathContext": "Axiom: $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp(1))$, i.e., $\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\},\\ P(e) = 0$. Equivalently $\\text{Transcendental}\\ \\mathbb{Q}\\ (\\exp(1))$, since any $\\mathbb{Q}$-polynomial can be cleared to a $\\mathbb{Z}$-polynomial by multiplying by the LCM of denominators."
+      "id": "main-theorem",
+      "title": "Main Theorem (Derived from Hermite-Lindemann)",
+      "startLine": 132,
+      "endLine": 152,
+      "summary": "Proves `e_transcendental : Transcendental ℤ (Real.exp 1)` as `HermiteLindemann.e_transcendental_int` — the imported Hermite-Lindemann axiom at $\\alpha = 1$ — and derives `e_transcendental_over_rationals` over $\\mathbb{Q}$ via `IsFractionRing.isAlgebraic_iff`. This file carries no axiom of its own; the assumption lives once in `Proofs.HermiteLindemann`.",
+      "mathContext": "Theorem (conditional on the imported axiom): $\\text{Transcendental}\\ \\mathbb{Z}\\ (\\exp(1))$, i.e., $\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\},\\ P(e) = 0$. Equivalent to $\\text{Transcendental}\\ \\mathbb{Q}\\ (\\exp(1))$ via $\\text{IsAlgebraic}\\ \\mathbb{Q}\\ x \\leftrightarrow \\text{IsAlgebraic}\\ \\mathbb{Z}\\ x$ for the fraction ring $\\mathbb{Z} \\subset \\mathbb{Q}$."
     },
     {
       "id": "corollaries",
       "title": "Corollaries: Irrationality and Closure Properties",
-      "startLine": 158,
-      "endLine": 200,
-      "summary": "Derives (via axioms) that $e$ is irrational, $e^n$ is transcendental for $n \\neq 0$, $1/e$ is transcendental, and $e+1$ is transcendental. Each follows from the closure of transcendental numbers under polynomial substitutions.",
+      "startLine": 153,
+      "endLine": 232,
+      "summary": "Proves, as theorems from the single imported axiom, that $e$ is irrational (`e_irrational`), $e^n$ is transcendental for $n \\neq 0$ (`exp_nat_transcendental`), $1/e$ is transcendental (`e_inv_transcendental`), and $e+1$ is transcendental (`e_plus_one_transcendental`). Each follows from the closure of transcendental numbers under polynomial substitutions.",
       "mathContext": "Corollaries: (1) $e$ irrational (transcendental $\\implies$ irrational). (2) $e^n$ transcendental for $n \\geq 1$ (Lindemann-Weierstrass: $e^\\alpha$ transcendental for algebraic $\\alpha \\neq 0$). (3) $1/e = e^{-1}$ transcendental. (4) $e + 1$ transcendental (if $e + 1$ were algebraic, then $e$ would be algebraic)."
     },
     {
       "id": "connections",
       "title": "Connections to Other Results",
-      "startLine": 201,
-      "endLine": 232,
+      "startLine": 233,
+      "endLine": 264,
       "summary": "Surveys generalizations: Lindemann-Weierstrass (1882), Gelfond-Schneider (1934, Hilbert's 7th problem), Baker's theorem (1966), and the open Schanuel's conjecture. Notes that $e + \\pi$ and $e^e$ transcendence remain open.",
       "mathContext": "Generalization hierarchy: Hermite ($e$ transcendental) $\\subset$ Lindemann ($e^\\alpha$ for algebraic $\\alpha \\neq 0$) $\\subset$ Gelfond-Schneider ($\\alpha^\\beta$ for algebraic $\\alpha \\neq 0,1$, irrational algebraic $\\beta$) $\\subset$ Baker (linear forms in logarithms). Schanuel's conjecture would subsume all of these."
     },
     {
       "id": "significance",
       "title": "Historical and Mathematical Significance",
-      "startLine": 233,
-      "endLine": 267,
+      "startLine": 265,
+      "endLine": 304,
       "summary": "Discusses the revolutionary impact of Hermite's 1873 proof, its implications for constructibility and algebraic relations, and open problems including whether $e + \\pi$ is transcendental, whether $e$ is normal, and the irrationality of the Euler-Mascheroni constant $\\gamma$.",
       "mathContext": "Open problems: Is $e + \\pi$ transcendental? Is $e \\cdot \\pi$? (At least one must be transcendental, but we don't know which.) Is $e^e$ transcendental? Is $e$ normal (each digit sequence equally frequent in every base)? The continued fraction $e = [2; 1, 2, 1, 1, 4, 1, 1, 6, \\ldots]$ has the striking pattern $[2; 1, 2k, 1]_{k=1}^\\infty$."
     }
@@ -219,8 +219,8 @@
     {
       "name": "e_transcendental",
       "type": "core",
-      "description": "Euler's number e is transcendental over Q",
-      "leanType": "Transcendental Q (Real.exp 1)"
+      "description": "Euler's number e is transcendental over ℤ (and hence over ℚ); proved from the imported Hermite-Lindemann axiom",
+      "leanType": "Transcendental ℤ (Real.exp 1)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment pass for e-transcendental (accuracy / axiom-integrity fix)

The `Proofs/eTranscendental.lean` file was refactored: the main theorem `e_transcendental` and all corollaries are now **proved** from a single *imported* `hermite_lindemann` axiom in `Proofs.HermiteLindemann` (specialized to α = 1), and this file declares **no axiom of its own**. The gallery meta still described the old architecture (a local `axiom e_transcendental` plus corollaries "derived via axioms") and its section/annotation ranges had drifted.

### Stale / inaccurate prose fixed
- **`assumptions`**: named `e_transcendental` as the axiom — it is now a theorem. Rewritten to name the imported `hermite_lindemann` axiom and note this file has no axiom of its own.
- **`overview.text`**: referenced four theorems that do not exist in the file (`e_not_integer`, `e_bounds`, `e_power_transcendental`, `e_algebraic_independence`) and stale "267-line / 12 declarations" counts. Rewritten to match the actual 13 theorems / 304 lines and the real declarations (`e_pos`/`e_gt_one`/`e_lt_three`, `e_irrational`, `exp_nat_transcendental`, `e_inv_transcendental`, `e_plus_one_transcendental`).
- **`historicalContext`** closing sentence and the `imports-docstring` / `main-theorem` / `corollaries` section prose: updated "axiomatized / Main Axiom / derived via axioms" wording to reflect the single imported axiom.
- **`main-theorem`** section + `ann-main-axiom` annotation: retitled "Main Theorem (Axiomatized)" → "(Derived from Hermite-Lindemann)".
- **`mainTheorems[0].leanType`**: `Transcendental Q ...` → `Transcendental ℤ ...` (the theorem is over ℤ).

### Drift realignment
- All **8 sections** realigned to the 7 `-- PART` banners (the last section ended at line 267; the file is 304 lines — lines 268–304 were uncovered).
- All **7 drifted annotation ranges** realigned (resolves the "No Lean construct found" validator errors for this entry).
- `lineCount` 305 → 304.

### Axiom integrity (unchanged, and correct)
`status: axiomatized`, `badge: axiom`, `axiomCount: 1` are **kept** — the proof remains conditional on the imported `hermite_lindemann` axiom. Verified `axiom hermite_lindemann` exists at `Proofs/HermiteLindemann.lean:147` and `e_transcendental := HermiteLindemann.e_transcendental_int`. Content-only edit; no Lean changes. All cross-reference targets verified to exist.