### PR TITLE
research(erdos-681): realign drifted gallery sections to full file (7→8)

### DIFF
--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -83,7 +83,7 @@
     {
       "id": "least-prime-factor",
       "title": "Least Prime Factor Infrastructure",
-      "startLine": 19,
+      "startLine": 1,
       "endLine": 97,
       "summary": "Defines leastPrimeFactor via Nat.minFac and IsLeastPrimeFactor. Proves minFac_is_lpf, composite_has_lpf, prime_lpf_self, lpf_le_sqrt, lpf_unique, leastPrimeFactor_eq_minFac, leastPrimeFactor_prime, lpf_dvd, lpf_prime — 10 proved theorems."
     },
@@ -105,28 +105,35 @@
       "id": "structural",
       "title": "Structural Observations",
       "startLine": 125,
-      "endLine": 185,
+      "endLine": 186,
       "summary": "Proves prime_offset_gives_large_lpf, composite_constraint (k⁴ < n+k), d1_k1_trivial, general_d0_trivial (fully proved), and general_monotone."
+    },
+    {
+      "id": "k1-resolution",
+      "title": "The k = 1 Resolution",
+      "startLine": 187,
+      "endLine": 250,
+      "summary": "Proves the k = 1 case resolves every exponent d: `k1_resolves_all_d`, `general_d1_at_composite_succ` and `general_d1_odd` (the d = 1 generalisation holds whenever n+1 is composite), `conjecture_at_composite_succ` (the original conjecture holds at composite n+1), and `hard_case_constraint` (constraints on the remaining k ≥ 2 hard case)."
     },
     {
       "id": "witness-parity",
       "title": "Witness Parity Constraints",
-      "startLine": 249,
-      "endLine": 298,
+      "startLine": 251,
+      "endLine": 316,
       "summary": "Proves that when n+1 is an odd prime, any witness k ≥ 2 must be odd. Even offsets produce even composites with minFac = 2, but k^d ≥ 2 for d ≥ 1. Includes minFac_of_even, even_of_prime_succ, even_offset_excluded, and witness_must_be_odd."
     },
     {
       "id": "d1-residue-class",
       "title": "d=1 Residue Class Resolution",
-      "startLine": 316,
+      "startLine": 317,
       "endLine": 348,
       "summary": "Proves d1_at_2_mod_3: for primes p ≡ 2 (mod 3) with p+2 composite, k=3 witnesses the d=1 case via minFac(n+3) ≥ 5 > 3."
     },
     {
       "id": "connection-680",
       "title": "Connection to Problem #680",
-      "startLine": 350,
-      "endLine": 360,
+      "startLine": 349,
+      "endLine": 362,
       "summary": "Proves lpf_condition_equiv: IsLeastPrimeFactor bound ↔ Nat.minFac bound, connecting Problems #680 and #681."
     }
   ],


### PR DESCRIPTION
## Summary
Gallery section ranges for `erdos-681` had drifted from `Proofs/Erdos681Problem.lean`, dropping a whole section and leaving several ranges misaligned.

- **Surface missing section**: the file's `## The k = 1 resolution` block (banner @187; `k1_resolves_all_d`, `general_d1_at_composite_succ`, `general_d1_odd`, `conjecture_at_composite_succ`, `hard_case_constraint`) had no gallery section. Added it as `187–250`.
- **Cover the header/imports**: "Least Prime Factor Infrastructure" `19 → 1`.
- **Snap drifted ranges onto banners**: Structural Observations end `185 → 186`; Witness Parity Constraints `249–298 → 251–316`; d=1 Residue Class Resolution start `316 → 317`; Connection to Problem #680 `350–360 → 349–362`.

Sections now tile the file `1–362` contiguously (7 → 8). Meta-only change; no Lean source touched.

## Test plan
- [x] JSON parses; sections contiguous, no gaps/overlap, last end = lineCount (362)
- [x] Each range verified against `/- ## ... -/` banners and declaration positions