### PR TITLE
research(erdos-858): realign drifted gallery sections to full file (5→13)

### DIFF
--- a/src/data/proofs/erdos-858/meta.json
+++ b/src/data/proofs/erdos-858/meta.json
@@ -48,39 +48,95 @@
   },
   "sections": [
     {
-      "id": "prime-factor",
-      "title": "Smallest Prime Factor",
+      "id": "header",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring (lines 1–31) stating Erdős Problem #858: for A ⊆ {1,…,N} with no solution to a·t = b (a,b ∈ A, smallest prime factor of t > a), the normalized reciprocal sum (1/log N)·Σ_{n∈A} 1/n is o(1) as N → ∞. Records the history (Alexander 1966; Erdős–Sárközi–Szemerédi 1968; Behrend's 1935 primitive-set bound O(1/√(log log N))) and references. Six Mathlib imports (lines 33–38) supply primes, factorization, finsets, and real-log, then `namespace Erdos858`."
+    },
+    {
+      "id": "part-1-smallest-prime-factor",
+      "title": "Part I: Smallest Prime Factor",
       "startLine": 44,
       "endLine": 78,
-      "summary": "Definition and properties of the smallest prime factor function"
+      "summary": "Defines `smallestPrimeFactor n` as `n.minFac` for n > 1 (else 0) and proves three basic facts: it divides n (`smallestPrimeFactor_dvd`), is prime (`smallestPrimeFactor_prime`), and is ≥ 2 (`smallestPrimeFactor_ge_two`), all by reduction to Mathlib's `Nat.minFac` lemmas."
     },
     {
-      "id": "condition",
-      "title": "The Multiplicative Condition",
+      "id": "part-2-multiplicative-condition",
+      "title": "Part II: The Multiplicative Condition",
       "startLine": 79,
-      "endLine": 105,
-      "summary": "Definition of sets avoiding at=b with spf(t) > a"
+      "endLine": 125,
+      "summary": "Defines the avoidance condition two ways: `SatisfiesCondition` (no a·t = b with spf(t) > a) and the divisibility form `SatisfiesCondition'` (a ∣ b, a < b ⇒ spf(b/a) ≤ a). `condition_equiv` proves them equivalent for sets of positive integers, noting the equivalence breaks at 0 ∈ A (one side vacuously false, the other vacuously true)."
     },
     {
-      "id": "primitive",
-      "title": "Primitive Sets",
-      "startLine": 106,
-      "endLine": 130,
-      "summary": "Definition and proof that primitive sets satisfy the condition"
+      "id": "part-3-primitive-sets",
+      "title": "Part III: Primitive Sets",
+      "startLine": 126,
+      "endLine": 150,
+      "summary": "Defines `IsPrimitive A` (no element divides another) and proves `primitive_satisfies_condition`: every primitive set satisfies the multiplicative condition, since a ∣ b in a primitive set forces a = b, hence t = 1, contradicting t > 1."
     },
     {
-      "id": "sums",
-      "title": "Weighted Reciprocal Sum",
-      "startLine": 131,
-      "endLine": 188,
-      "summary": "Definition of (1/log N) Σ 1/n and basic bounds"
+      "id": "part-4-weighted-reciprocal-sum",
+      "title": "Part IV: The Weighted Reciprocal Sum",
+      "startLine": 151,
+      "endLine": 191,
+      "summary": "Defines `reciprocalSum A = Σ_{n∈A, n>0} 1/n` and the normalized `weightedSum A N = reciprocalSum A / log N` (0 when N ≤ 1). Proves both are nonnegative (`reciprocalSum_nonneg` via `Finset.sum_nonneg`/positivity; `weightedSum_nonneg` for N ≥ 2 via `div_nonneg` and `Real.log_nonneg`)."
     },
     {
-      "id": "solution",
-      "title": "Solution: o(1) Bound",
-      "startLine": 189,
+      "id": "part-5-range-constraint",
+      "title": "Part V: The Range Constraint",
+      "startLine": 192,
+      "endLine": 205,
+      "summary": "Defines `InRange A N`: every n ∈ A satisfies 1 ≤ n ≤ N, encoding A ⊆ {1,…,N}. A docstring notes the reciprocal sum is then bounded by the harmonic number H_N."
+    },
+    {
+      "id": "part-6-alexander",
+      "title": "Part VI: Alexander's Result (1966)",
+      "startLine": 206,
+      "endLine": 228,
+      "summary": "States Alexander's 1966 theorem as the `axiom alexander_1966`: for every ε > 0 there is N₀ such that every in-range A satisfying the condition has weightedSum A N < ε for N ≥ N₀. The wrapper `max_weighted_sum_little_o` re-exposes it as the o(1) bound on the maximum."
+    },
+    {
+      "id": "part-7-esz-1968",
+      "title": "Part VII: Erdős-Sárközi-Szemerédi (1968)",
+      "startLine": 229,
+      "endLine": 237,
+      "summary": "Documentation block recording the independent 1968 proof of the same o(1) result by Erdős, Sárközi, and Szemerédi (J. London Math. Soc.), using different methods. No new Lean declaration."
+    },
+    {
+      "id": "part-8-behrend",
+      "title": "Part VIII: Behrend's Bound for Primitive Sets (1935)",
+      "startLine": 238,
+      "endLine": 248,
+      "summary": "Documentation block recording Behrend's 1935 sharper bound O(1/√(log log N)) for the reciprocal sum of primitive sets — a stronger conclusion under the stronger primitivity hypothesis. No new Lean declaration."
+    },
+    {
+      "id": "part-9-example-construction",
+      "title": "Part IX: Example Construction",
+      "startLine": 249,
+      "endLine": 282,
+      "summary": "Defines `exampleSet N` — integers in [√N, N] divisible by some prime p > √N — as a set achieving a relatively large weighted sum while satisfying the condition, and proves `exampleSet_in_range` that it lies in {1,…,N}."
+    },
+    {
+      "id": "part-10-solution",
+      "title": "Part X: Erdős Problem #858 Solution",
+      "startLine": 283,
+      "endLine": 305,
+      "summary": "States the main result `erdos_858_solution`: for in-range A satisfying the condition, weightedSum A N is eventually < ε, i.e. o(1) as N → ∞. Proved by invoking `alexander_1966`, attributing the result to Alexander (1966) and Erdős–Sárközi–Szemerédi (1968)."
+    },
+    {
+      "id": "part-11-relationship-143",
+      "title": "Part XI: Relationship to Problem #143",
+      "startLine": 306,
+      "endLine": 319,
+      "summary": "Records that #858 is a weaker variant of the primitive-set problem #143 — the condition permits some divisibility relations (small-prime-factor multipliers) — and proves `weaker_than_primitive` (primitivity ⇒ the condition) as the formal link."
+    },
+    {
+      "id": "part-12-summary",
+      "title": "Part XII: Summary",
+      "startLine": 320,
       "endLine": 348,
-      "summary": "Alexander (1966) axiom, historical context (docstrings only), example construction, main solution, and summary"
+      "summary": "Closing summary docstring and the theorem `erdos_858_summary`, which bundles the two headline facts — the condition is weaker than primitivity, and the weighted sum is o(1) — into a single conjunction, certifying the problem SOLVED. Closes `namespace Erdos858`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery `meta.json` for `erdos-858` had **5 sections** that lumped the Lean file's **12 `## Part` banners**. A single "Solution: o(1) Bound" section (lines 189–348) spanned Parts V–XII — the range constraint, Alexander (1966), Erdős–Sárközi–Szemerédi (1968), Behrend's bound, the example construction, the solution theorem, the #143 relationship, and the summary.

Realigned to **13 contiguous sections** covering the full file (lines 1–348): a header/overview section plus one per `## Part` banner (I–XII), each with an accurate summary of the declarations it contains.

- Documentation/metadata only — **no Lean source changed**.
- Verified contiguous coverage 1→348 and valid JSON.

## Test plan
- [x] `jq empty` parses the meta.json
- [x] Section ranges contiguous, ending at file EOF (348)
- [x] Section boundaries land on `## Part` banner blocks