### PR TITLE
research(erdos-514): realign gallery sections (9→10) + fix phantom-theorem summary

### DIFF
--- a/src/data/proofs/erdos-514/meta.json
+++ b/src/data/proofs/erdos-514/meta.json
@@ -117,48 +117,56 @@
       "title": "Path Length Estimates",
       "summary": "pathLengthUpTo, path_length_bound_conjecture (Part 2 open problem)",
       "startLine": 154,
-      "endLine": 186,
+      "endLine": 183,
       "mathContext": "Bound: pathLengthUpTo, path_length_bound_conjecture (Part 2 open problem)"
     },
     {
       "id": "faster-growth",
       "title": "Faster Than M(r)^ε Growth",
       "summary": "DominatesMaxModulusPower, faster_than_max_modulus_conjecture (Part 3 open problem)",
-      "startLine": 187,
-      "endLine": 212,
+      "startLine": 184,
+      "endLine": 207,
       "mathContext": "Mathematical content: DominatesMaxModulusPower, faster_than_max_modulus_conjecture (Part 3 open problem)"
     },
     {
       "id": "examples",
       "title": "Examples of Entire Functions",
       "summary": "expFunction, sinFunction, maxModulus_exp",
-      "startLine": 213,
-      "endLine": 246,
+      "startLine": 208,
+      "endLine": 230,
       "mathContext": "Mathematical content: expFunction, sinFunction, maxModulus_exp"
     },
     {
       "id": "growth-orders",
       "title": "Growth Orders",
       "summary": "orderOfGrowth definition, exp_has_order_one",
-      "startLine": 247,
-      "endLine": 271,
+      "startLine": 231,
+      "endLine": 254,
       "mathContext": "Formal definition: orderOfGrowth definition, exp_has_order_one"
     },
     {
       "id": "wiman-valiron",
       "title": "Connection to Wiman-Valiron Theory",
       "summary": "centralIndex, wiman_valiron_intuition",
-      "startLine": 272,
-      "endLine": 300,
+      "startLine": 255,
+      "endLine": 280,
       "mathContext": "Mathematical content: centralIndex, wiman_valiron_intuition"
     },
     {
       "id": "max-modulus-props",
       "title": "Properties of Maximum Modulus",
-      "summary": "maxModulus_monotone, maxModulus_ge_origin, maxModulus_tendsto_infinity",
-      "startLine": 301,
+      "summary": "Docstring describing intended basic properties of the maximum modulus function M(r) (monotonicity, growth to infinity); descriptive only, no formal declarations in this part.",
+      "startLine": 281,
+      "endLine": 286,
+      "mathContext": "Mathematical content: prose on maximum-modulus properties (no theorems or definitions in this part)."
+    },
+    {
+      "id": "main-results-summary",
+      "title": "Main Results Summary",
+      "summary": "erdos_514_summary theorem (Part 1 resolved: every transcendental entire function admits a path to infinity with super-polynomial growth, via boas_existence), plus a status recap of Parts 1-3 and a closing key-insight docstring.",
+      "startLine": 287,
       "endLine": 318,
-      "mathContext": "Mathematical content: maxModulus_monotone, maxModulus_ge_origin, maxModulus_tendsto_infinity"
+      "mathContext": "Mathematical content: erdos_514_summary"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos514Problem.lean` has **10** `## Part` banners (I–X) but the gallery meta had only **9** sections, and the back-half section ranges had drifted out of alignment.

- Snapped all section `startLine`/`endLine` ranges to their `/-` banner openers (sections are now contiguous, 39–318). Examples of drift: Part V "Faster Than M(r)^ε Growth" is at line 184 (meta said 187); Part VII "Growth Orders" is at line 231 (meta said 247–271).
- Added the missing **Part X "Main Results Summary"** section (lines 287–318), which contains the `erdos_514_summary` theorem.
- Fixed the **Part IX "Properties of Maximum Modulus"** summary/mathContext: they listed `maxModulus_monotone`, `maxModulus_ge_origin`, `maxModulus_tendsto_infinity` — **none of which exist anywhere in the file**. Part IX is a docstring-only part with no declarations; reworded to reflect that.

## Scope / safety
- Metadata-only (`src/data/proofs/erdos-514/meta.json`); no `.lean` change, no build required.
- Section count 9 → 10 matches the 10 file banners; ranges verified contiguous to EOF.
- Theorem/axiom/sorry counts unchanged.

## Test plan
- [x] JSON validates; sections contiguous (39–318), each aligned to its `## Part` banner opener
- [x] Verified the 3 phantom `maxModulus_*` theorems are absent via `grep` of all declarations