### PR TITLE
research(cevas-theorem-oq-02-oq-02): realign drifted gallery sections to full file (7→12)

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
@@ -81,60 +81,100 @@
   },
   "sections": [
     {
-      "id": "polygon-config",
-      "title": "Polygon Ceva Configuration",
+      "id": "module-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring introducing Ceva's theorem for spherical polygons (cevas-theorem-oq-02-oq-02), import Mathlib, namespace CevasPolygon, and open Finset BigOperators Real.",
+      "mathContext": "Generalizes Ceva's concurrency criterion from triangles to $n$-sided spherical polygons via a weight-product balance condition."
+    },
+    {
+      "id": "part1-ceva-product",
+      "title": "Part 1: Polygon Ceva Product (Algebraic Framework)",
       "startLine": 49,
-      "endLine": 73,
-      "summary": "PolygonCevaConfig structure with weight parameters (αᵢ, βᵢ) for Fin n. cevaProduct and weightBalance definitions.",
-      "mathContext": "PolygonCevaConfig: a structure with weight parameters $(\\alpha_i, \\beta_i)$ for $i \\in \\text{Fin}\\,n$. The Ceva product $\\prod_{i=0}^{n-1} \\beta_i/\\alpha_i$ and weight product $\\prod \\alpha_i$ generalize the classical triangle Ceva condition to $n$-gons."
+      "endLine": 69,
+      "summary": "PolygonCevaConfig structure (weight parameters αᵢ, βᵢ for an n-gon), cevaProduct = ∏ᵢ(βᵢ/αᵢ), and the weightBalance predicate ∏αᵢ = ∏βᵢ.",
+      "mathContext": "For an $n$-gon configuration the Ceva product is $\\prod_i \\beta_i/\\alpha_i$, and weight balance is $\\prod_i \\alpha_i = \\prod_i \\beta_i$."
     },
     {
-      "id": "main-theorem",
-      "title": "Main Theorem: Weight Balance Criterion",
-      "startLine": 78,
-      "endLine": 128,
-      "summary": "polygon_ceva_weight_balance: ∏(βᵢ/αᵢ) = 1 ↔ ∏αᵢ = ∏βᵢ. Uses prod_div_distrib and div_eq_one_iff_eq.",
-      "mathContext": "The polygon Ceva balance: $\\prod(\\beta_i/\\alpha_i) = 1 \\iff \\prod \\alpha_i = \\prod \\beta_i$. Proved using `Finset.prod_div_distrib` and `div_eq_one_iff_eq`. This is the algebraic content of the generalized Ceva theorem."
+      "id": "part2-weight-balance",
+      "title": "Part 2: Main Theorem - Weight Balance Criterion",
+      "startLine": 70,
+      "endLine": 124,
+      "summary": "Positivity/nonvanishing helpers (α_ne_zero, prod_α_pos, prod_α_ne_zero, prod_β_pos), ceva_product_eq_ratio (cevaProduct = ∏β/∏α), and the main theorem polygon_ceva_weight_balance (cevaProduct = 1 ↔ weight balance).",
+      "mathContext": "Main criterion: $\\prod_i \\beta_i/\\alpha_i = 1 \\iff \\prod_i \\alpha_i = \\prod_i \\beta_i$, since $\\prod(\\beta_i/\\alpha_i) = (\\prod\\beta_i)/(\\prod\\alpha_i)$."
     },
     {
-      "id": "triangle-specialization",
-      "title": "Triangle Specialization (n=3)",
-      "startLine": 133,
-      "endLine": 149,
-      "summary": "triangle_ceva_specialization: n=3 recovers α₀·α₁·α₂ = β₀·β₁·β₂ via Fin.prod_univ_three.",
-      "mathContext": "For $n = 3$: recovers $\\alpha_0 \\alpha_1 \\alpha_2 = \\beta_0 \\beta_1 \\beta_2$, the classical Ceva's theorem condition for concurrent cevians in a triangle. Uses `Fin.prod_univ_three` for the 3-element product."
+      "id": "part3-triangle",
+      "title": "Part 3: Triangle Specialization (n = 3)",
+      "startLine": 125,
+      "endLine": 140,
+      "summary": "triangle_ceva_specialization: the classical triangle Ceva theorem recovered as the n = 3 case of the polygon weight-balance criterion.",
+      "mathContext": "For $n=3$ the criterion reduces to the classical Ceva condition on the three cevian ratios."
     },
     {
-      "id": "quadrilateral-ceva",
-      "title": "Quadrilateral Ceva (n=4)",
-      "startLine": 154,
-      "endLine": 175,
-      "summary": "quadrilateral_ceva: n=4 gives α₀·α₁·α₂·α₃ = β₀·β₁·β₂·β₃ via Fin.prod_univ_four.",
-      "mathContext": "For $n = 4$: the quadrilateral Ceva condition $\\alpha_0 \\alpha_1 \\alpha_2 \\alpha_3 = \\beta_0 \\beta_1 \\beta_2 \\beta_3$. Uses `Fin.prod_univ_four`. This extends the classical concurrence condition to quadrilaterals."
+      "id": "part4-quadrilateral",
+      "title": "Part 4: Quadrilateral Ceva (n = 4)",
+      "startLine": 141,
+      "endLine": 162,
+      "summary": "quadrilateral_ceva: the n = 4 spherical Ceva theorem as a specialization of the polygon criterion.",
+      "mathContext": "For $n=4$ the four weight ratios multiply to one under the concurrency/balance condition."
     },
     {
-      "id": "equal-weight",
-      "title": "Equal-Weight (Medial) Case",
-      "startLine": 180,
-      "endLine": 200,
-      "summary": "equal_weight_polygon_ceva: when αᵢ = βᵢ for all i, the Ceva product is 1.",
-      "mathContext": "When $\\alpha_i = \\beta_i$ for all $i$, the Ceva product is trivially 1. This corresponds to the case where all cevians are medians (equal division of sides)."
+      "id": "part5-equal-weight",
+      "title": "Part 5: Equal-Weight (Medial) Case",
+      "startLine": 163,
+      "endLine": 183,
+      "summary": "equal_weight_polygon_ceva: cevians with equal weights (αᵢ = βᵢ = wᵢ) always satisfy the Ceva condition, the medial/centroid-type case.",
+      "mathContext": "When $\\alpha_i = \\beta_i$ for all $i$, the Ceva product is identically $1$ — equal-weight cevians are always concurrent."
     },
     {
-      "id": "polygon-menelaus",
-      "title": "Polygon Menelaus and Duality",
-      "startLine": 205,
-      "endLine": 245,
-      "summary": "menelausCondition for n-gons, negate_one_ratio_flips_sign, triangle and quadrilateral Menelaus sign results.",
-      "mathContext": "The Menelaus dual: `menelausCondition` for $n$-gons, where negating one ratio flips the overall sign. Triangle and quadrilateral specializations recover the classical Menelaus theorem conditions."
+      "id": "part6-menelaus",
+      "title": "Part 6: Polygon Menelaus (Signed Product)",
+      "startLine": 184,
+      "endLine": 207,
+      "summary": "menelausCondition predicate on signed ratios, with triangle_menelaus_sign (signed product = −1) and quad_menelaus_sign (signed product = +1).",
+      "mathContext": "Menelaus' collinearity uses the signed product $\\prod_i r_i = (-1)^n$: $-1$ for triangles, $+1$ for quadrilaterals."
     },
     {
-      "id": "scaling-and-angles",
-      "title": "Scaling Invariance and Angle Connection",
-      "startLine": 250,
+      "id": "part7-duality",
+      "title": "Part 7: Ceva-Menelaus Duality for Polygons",
+      "startLine": 208,
+      "endLine": 234,
+      "summary": "negate_one_ratio_flips_sign expressing the Ceva-Menelaus duality: negating a single ratio flips the signed product, dualizing concurrency and collinearity.",
+      "mathContext": "Ceva (product $+1$) and Menelaus (product $\\pm 1$) are dual: flipping the sign of one ratio interchanges the two conditions."
+    },
+    {
+      "id": "part8-scaling",
+      "title": "Part 8: Scaling Invariance",
+      "startLine": 235,
+      "endLine": 259,
+      "summary": "ceva_product_scale_invariant: scaling all weights by a positive constant c leaves the Ceva product unchanged.",
+      "mathContext": "$\\prod_i (c\\beta_i)/(c\\alpha_i) = \\prod_i \\beta_i/\\alpha_i$ for $c>0$ — the Ceva product is scale-invariant."
+    },
+    {
+      "id": "part9-positivity",
+      "title": "Part 9: Product Positivity",
+      "startLine": 260,
+      "endLine": 274,
+      "summary": "ceva_product_pos: the Ceva product of any valid (positive-weight) configuration is strictly positive.",
+      "mathContext": "With $\\alpha_i, \\beta_i > 0$ the product $\\prod_i \\beta_i/\\alpha_i > 0$."
+    },
+    {
+      "id": "part10-numerical",
+      "title": "Part 10: Numerical Examples",
+      "startLine": 275,
+      "endLine": 292,
+      "summary": "Concrete equal-weight verifications: pentagon_equal_weight_ceva (n=5) and hexagon_equal_weight_ceva (n=6).",
+      "mathContext": "Worked instances for the pentagon ($n=5$) and hexagon ($n=6$) confirming the equal-weight Ceva condition."
+    },
+    {
+      "id": "part11-angle-connection",
+      "title": "Part 11: Connection to Angle-Based Formulation",
+      "startLine": 293,
       "endLine": 320,
-      "summary": "ceva_product_scale_invariant, ceva_product_pos, angle_product_from_weight_ratios connecting to the formal problem statement.",
-      "mathContext": "Scale invariance: the Ceva product $\\prod \\beta_i/\\alpha_i$ is unchanged by uniform scaling of all weights. Positivity: if all weights are positive, the product is positive. Angle interpretation: weight ratios correspond to ratios of subtended angles."
+      "summary": "angle_product_from_weight_ratios linking the algebraic weight ratios to the angle-based (spherical-trigonometric) formulation of polygon Ceva.",
+      "mathContext": "Translates the weight ratios $\\beta_i/\\alpha_i$ into products of trigonometric angle ratios, recovering the spherical Ceva formulation."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Rebuild the gallery sections of `cevas-theorem-oq-02-oq-02` to match the eleven `-- PART N` banner boxes in `CevasTheoremOQ02OQ02.lean` and add the previously-uncovered module header (lines 1–48), 7 → 12 sections.
- The old seven sections began at line 49 (no header section) and lumped Parts 6–7 ("Polygon Menelaus and Duality") and Parts 8–11 ("Scaling Invariance and Angle Connection"). Ranges now snap to the banner box-tops (49, 70, 125, 141, 163, 184, 208, 235, 260, 275, 293) and cover lines 1–320 contiguously, each summary naming its real declarations.

## Notes
- No Lean source changes — pure gallery metadata realignment. `axiomCount` (0), `theoremCount` (17), `lineCount` (320), `sorries` (0) unchanged; entry stays verified/original.
- Section schema keys (id/title/startLine/endLine/summary/mathContext) preserved; ranges verified contiguous and ending at lineCount 320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)