### PR TITLE
research(divisibility-by-3-oq-01): realign drifted gallery sections to full file (11→11)

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01/meta.json
@@ -79,15 +79,15 @@
     {
       "id": "last-k-digits",
       "title": "General Last-k-Digits Framework",
-      "startLine": 28,
-      "endLine": 96,
+      "startLine": 1,
+      "endLine": 95,
       "summary": "Unified theorem for last-digit rules (2, 4, 8, 16, 32, 5, 25, 125) including binary and hexadecimal bases.",
       "mathContext": "$d \\mid 10^k \\Rightarrow d \\mid n \\iff d \\mid (n \\bmod 10^k)$. Covers $d \\in \\{2, 4, 5, 8, 16, 25, 32, 125\\}$ with appropriate $k$."
     },
     {
       "id": "power-generalizations",
       "title": "Power-of-2 and Power-of-5 Theorems",
-      "startLine": 97,
+      "startLine": 96,
       "endLine": 119,
       "summary": "General theorems: 2^k | n ↔ 2^k | (n mod 10^k), and similarly for 5^k.",
       "mathContext": "$2^k \\mid n \\iff 2^k \\mid (n \\bmod 10^k)$. Similarly $5^k \\mid n \\iff 5^k \\mid (n \\bmod 10^k)$. Both follow from $\\gcd(2^k, 10^k/2^k) = 1$ and $10^k = 2^k \\cdot 5^k$."
@@ -104,14 +104,14 @@
       "id": "digit-sum-rules",
       "title": "Digit-Sum Rules in Various Bases",
       "startLine": 155,
-      "endLine": 268,
+      "endLine": 217,
       "summary": "Instantiations of the general digit-sum rule for 37 (base 1000), 99 (base 100), 999, 27, and rules in hex, octal, and other bases.",
       "mathContext": "$d \\mid (b-1) \\Rightarrow d \\mid n \\iff d \\mid S_b(n)$ where $S_b(n)$ is the digit sum in base $b$. Examples: $37 \\mid n \\iff 37 \\mid S_{1000}(n)$, $99 \\mid n \\iff 99 \\mid S_{100}(n)$."
     },
     {
       "id": "casting-out",
       "title": "Casting Out Nines and Threes",
-      "startLine": 220,
+      "startLine": 218,
       "endLine": 269,
       "summary": "Casting out nines/threes preserves addition and multiplication modulo 9/3.",
       "mathContext": "$n \\equiv S_{10}(n) \\pmod{9}$ (casting out nines). Preserves arithmetic: $S(a+b) \\equiv S(a) + S(b) \\pmod{9}$, $S(ab) \\equiv S(a) \\cdot S(b) \\pmod{9}$."
@@ -120,15 +120,15 @@
       "id": "digital-root",
       "title": "Digital Root Theory",
       "startLine": 270,
-      "endLine": 332,
+      "endLine": 331,
       "summary": "Digital root definition, bound ≤ 9, positivity, divisibility-by-9 characterization, and mod-3 property.",
       "mathContext": "$\\text{dr}(n) = 1 + ((n-1) \\bmod 9)$ for $n > 0$. Properties: $1 \\leq \\text{dr}(n) \\leq 9$, $9 \\mid n \\iff \\text{dr}(n) = 9$, $3 \\mid n \\iff \\text{dr}(n) \\in \\{3, 6, 9\\}$."
     },
     {
       "id": "coprime-factorization",
       "title": "Coprime Factorization Rules",
-      "startLine": 333,
-      "endLine": 375,
+      "startLine": 332,
+      "endLine": 374,
       "summary": "Rules for 6, 12, 15, 18, 36, 45, 60, 90 via coprime factor decomposition.",
       "mathContext": "$\\gcd(a,b) = 1 \\Rightarrow (ab \\mid n \\iff a \\mid n \\wedge b \\mid n)$. Applied: $6 = 2 \\cdot 3$, $12 = 4 \\cdot 3$, $36 = 4 \\cdot 9$, $45 = 5 \\cdot 9$, etc."
     },
@@ -136,30 +136,30 @@
       "id": "truncation-7-11",
       "title": "Truncation Methods for 7 and 11",
       "startLine": 375,
-      "endLine": 441,
+      "endLine": 437,
       "summary": "Divisibility by 7 via subtract-2x-last-digit and divisibility by 11 via subtract-last-digit, both proved via integer arithmetic and coprimality.",
       "mathContext": "$7 \\mid n \\iff 7 \\mid (\\lfloor n/10 \\rfloor - 2(n \\bmod 10))$. $11 \\mid n \\iff 11 \\mid (\\lfloor n/10 \\rfloor - (n \\bmod 10))$. From $7 \\mid 21$ and $11 \\mid 11$."
     },
     {
       "id": "truncation-17-19",
       "title": "Truncation Methods for 17 and 19",
-      "startLine": 442,
-      "endLine": 511,
+      "startLine": 438,
+      "endLine": 495,
       "summary": "Divisibility by 17 via subtract-5x-last-digit and divisibility by 19 via add-2x-last-digit.",
       "mathContext": "$17 \\mid n \\iff 17 \\mid (\\lfloor n/10 \\rfloor - 5(n \\bmod 10))$. $19 \\mid n \\iff 19 \\mid (\\lfloor n/10 \\rfloor + 2(n \\bmod 10))$. From $17 \\mid 51$ and $19 \\mid 19$."
     },
     {
       "id": "alternating-grouping",
       "title": "Alternating Digit Grouping",
-      "startLine": 512,
-      "endLine": 539,
+      "startLine": 496,
+      "endLine": 516,
       "summary": "Observations about alternating 3-digit groups: 1001 = 7·11·13 implies 1000 ≡ -1 (mod 7, 11, 13).",
       "mathContext": "$1001 = 7 \\cdot 11 \\cdot 13$, so $1000 \\equiv -1 \\pmod{7}$, $1000 \\equiv -1 \\pmod{11}$, $1000 \\equiv -1 \\pmod{13}$. Alternating 3-digit group sum tests divisibility by 7, 11, and 13."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 540,
+      "startLine": 517,
       "endLine": 550,
       "summary": "Master summary combining digit-sum, last-digit, and power generalization rules.",
       "mathContext": "Unified framework: digit-sum rules ($d \\mid b-1$), last-$k$-digit rules ($d \\mid b^k$), and truncation rules ($d \\mid mb \\pm 1$). All derive from $n = qb + r$ and modular arithmetic."


### PR DESCRIPTION
## Summary
Gallery section ranges for `divisibility-by-3-oq-01` had drifted from `Proofs/DivisibilityByThreeOQ01.lean`, causing a 49-line overlap between "Digit-Sum Rules in Various Bases" (155–268) and "Casting Out Nines and Threes" (220–269).

- All eleven section titles map 1:1 to the file's eleven `-- Part N` banners in order — pure **range realign**, no sections added or removed.
- Snapped every section to its `-- ===` banner box (banner−1) and covered the module header.

Sections now tile the file `1–550` contiguously, no overlaps or gaps. Meta-only change; no Lean source touched.

## Test plan
- [x] JSON parses; sections contiguous, no gaps/overlap, last end = lineCount (550)
- [x] Each range verified against `-- Part N` banner boxes and declaration positions