### PR TITLE
Enrich dissection-of-cubes-oq-01-oq-03: annotate module setup region

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-03/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-module-setup",
+    "proofId": "dissection-of-cubes-oq-01-oq-03",
+    "range": {
+      "startLine": 46,
+      "endLine": 56
+    },
+    "type": "technique",
+    "title": "Namespace, Opens, and the Classical DecidableEq Instance",
+    "content": "Enters `namespace DissectionOfCubesOQ01OQ03`, opens the parent namespaces `DissectionOfCubes` and `DissectionOfCubesOQ01` (bringing `Cube`, `CubeDissection`, `IsCollisionPair`, and `every_dissection_has_collision` into scope) plus `BigOperators` (for `∑` notation), and opens a `noncomputable section`. The line `noncomputable instance : DecidableEq Cube := Classical.decEq _` installs a classical decidable-equality instance on `Cube`.",
+    "mathContext": "`Cube` is a structure over the reals, so equality on it is not decidable by computation; `Classical.decEq` supplies a `DecidableEq Cube` instance non-constructively (via the law of excluded middle). This instance is a prerequisite for `Finset.sum_insert`, which must discriminate the case `c ∈ s` from `c ∉ s` to state how `∑` changes — hence `volumeSum_insert` and the pair-sum manipulations in `cube_volume_lt_one_of_card_ge_two` and `collision_volume_bound` all depend on it. The `noncomputable section` is required because the resulting definitions carry real-valued, non-algorithmic data.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "DecidableEq",
+      "Classical.decEq",
+      "noncomputable",
+      "BigOperators"
+    ],
+    "prerequisites": [
+      "Classical logic (excluded middle)",
+      "Finset.sum_insert"
+    ]
+  },
+  {
     "id": "ann-volume-sum-def",
     "proofId": "dissection-of-cubes-oq-01-oq-03",
     "range": {


### PR DESCRIPTION
## Summary
Enrichment pass for `dissection-of-cubes-oq-01-oq-03` (Volume Constraint for Cube Dissections, Wiedijk #82 track).

- Added `ann-module-setup` (lines 46-56), the one previously-unannotated code region — explains why `Classical.decEq` supplies the `DecidableEq Cube` instance that `Finset.sum_insert` (and thus `volumeSum_insert`, `cube_volume_lt_one_of_card_ge_two`, `collision_volume_bound`) depends on, plus the role of the `noncomputable section`. Annotation coverage 9 → 10.
- Audited the entry against the Lean source: theoremCount (14), definitionCount (2 = `def volumeSum` + `structure VolumeDissection`), axiomCount (0), lineCount (256), all section ranges, and all annotation ranges verified accurate. No drift or count corrections needed.

## Notes
- JSON validated via `python3 json.load`; `pnpm build` prebuild parsed all gallery JSON successfully (fails only at `tsc: command not found` — node_modules not installed in this env).