### PR TITLE
research(erdos-246): realign drifted gallery sections to full file (8→13)

### DIFF
--- a/src/data/proofs/erdos-246/meta.json
+++ b/src/data/proofs/erdos-246/meta.json
@@ -82,64 +82,108 @@
   },
   "sections": [
     {
-      "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "summary": "Power sets and completeness property",
+      "id": "module-header",
+      "title": "Problem Overview and Imports",
+      "summary": "Module docstring stating Erdős Problem #246 (for coprime a,b the set {a^k b^l : k,l ≥ 0} is complete — SOLVED by Birch 1959), the history (Cassels, Davenport, Hegyvári, Fang-Chen, Yu), references and tags, the Nat/Finset/Set imports, and namespace Erdos246.",
+      "startLine": 1,
+      "endLine": 44,
+      "mathContext": "A set $S \\subseteq \\mathbb{N}$ is complete if every sufficiently large integer is a sum of distinct elements of $S$. Question: is $\\{a^k b^l : k,l \\ge 0\\}$ complete for coprime $a,b$?"
+    },
+    {
+      "id": "part1-definitions",
+      "title": "Part 1: Basic Definitions",
+      "summary": "powerSet a b = {a^k·b^l}, example membership checks for {2^k·3^l}, isComplete (every large n is a sum of distinct elements of S), and isCompleteFrom with an explicit threshold N₀.",
       "startLine": 45,
       "endLine": 71,
-      "mathContext": "$P(a,b) = \\{a^k b^l : k, l \\geq 0\\}$. Complete: $\\forall n \\geq N_0,\\, \\exists S \\subseteq P(a,b)$ distinct, $n = \\sum_{s \\in S} s$."
+      "mathContext": "$\\mathrm{powerSet}(a,b) = \\{a^k b^l : k,l \\ge 0\\}$; completeness means $\\exists N_0,\\ \\forall n \\ge N_0,\\ n = \\sum_{x \\in T} x$ for a finite $T \\subseteq S$ of distinct elements."
     },
     {
-      "id": "birch-theorem",
-      "title": "Birch's Theorem (1959)",
-      "summary": "Main result: coprime power sets are complete",
+      "id": "part2-birch",
+      "title": "Part 2: The Main Theorem (Birch 1959)",
+      "summary": "birch_theorem axiom (for coprime a,b ≥ 2 the power set is complete) and two_three_complete deriving completeness of {2^k·3^l} from it.",
       "startLine": 72,
-      "endLine": 92,
-      "mathContext": "$\\gcd(a,b) = 1,\\, a,b \\geq 2 \\Rightarrow P(a,b)$ is complete (Birch 1959)."
+      "endLine": 87,
+      "mathContext": "Birch (1959): for $\\gcd(a,b)=1$, $a,b \\ge 2$, the set $\\{a^k b^l\\}$ is complete — the positive answer to Erdős #246."
     },
     {
-      "id": "cassels-generalization",
-      "title": "Cassels' Generalization",
-      "summary": "Logarithmic density criterion",
-      "startLine": 93,
-      "endLine": 106,
-      "mathContext": "Cassels criterion: if $|S \\cap [1,N]| \\gg (\\log N)^{1+\\epsilon}$, then $S$ is complete."
+      "id": "part3-cassels",
+      "title": "Part 3: Cassels' Generalization",
+      "summary": "Docstring marker for Cassels' (1960) more general representation result that subsumes the Erdős-Birch case (no Lean declarations in this part).",
+      "startLine": 88,
+      "endLine": 91,
+      "mathContext": "Cassels (1960) proved a broader completeness criterion covering $\\{a^k b^l\\}$ as a special case."
     },
     {
-      "id": "davenport-observation",
-      "title": "Davenport's Observation",
-      "summary": "Bounded l suffices",
-      "startLine": 107,
-      "endLine": 124
+      "id": "part4-davenport",
+      "title": "Part 4: Davenport's Observation",
+      "summary": "powerSetBoundedL a b L = {a^k·b^l : l ≤ L}, formalizing Davenport's observation that completeness still holds with the exponent l bounded by a constant.",
+      "startLine": 92,
+      "endLine": 99,
+      "mathContext": "Davenport: completeness persists for $\\{a^k b^l : l \\le C(a,b)\\}$ — the second exponent can be bounded by a constant."
     },
     {
-      "id": "quantitative-bounds",
-      "title": "Quantitative Bounds",
-      "summary": "Hegyvári and Fang-Chen bounds",
-      "startLine": 125,
-      "endLine": 140,
-      "mathContext": "Hegyvári (2000): $l \\leq 2^{2^{2^{2^{\\max(a,b)}}}}$. Fang-Chen (2017): $l \\leq 2^{2^{2^{\\max(a,b)}}}$."
+      "id": "part5-quantitative",
+      "title": "Part 5: Quantitative Bounds (Hegyvári, Fang-Chen)",
+      "summary": "Docstring marker for the explicit completeness-threshold bounds: Hegyvári (2000, quadruple-exponential) and Fang-Chen (2017, triply-exponential) (no Lean declarations in this part).",
+      "startLine": 100,
+      "endLine": 103,
+      "mathContext": "Effective thresholds $N_0(a,b)$: Hegyvári's quadruple-exponential bound, improved to triply-exponential by Fang-Chen."
     },
     {
-      "id": "yu-result",
-      "title": "Yu's Result (2024)",
-      "summary": "Large summands suffice",
-      "startLine": 141,
-      "endLine": 152
+      "id": "part6-yu",
+      "title": "Part 6: Yu's Result on Large Summands",
+      "summary": "Docstring marker for Yu's (2024) result that representing large n uses summands greater than n/(log n)^{1+o(1)} (no Lean declarations in this part).",
+      "startLine": 104,
+      "endLine": 107,
+      "mathContext": "Yu (2024): representations of large $n$ require summands exceeding $n/(\\log n)^{1+o(1)}$."
     },
     {
-      "id": "related-sequences",
-      "title": "Related Complete Sequences",
-      "summary": "Fibonacci, powers of 2, general criterion",
-      "startLine": 153,
-      "endLine": 177
+      "id": "part7-related-complete",
+      "title": "Part 7: Related Complete Sequences",
+      "summary": "Other complete sequences: the Fibonacci sequence and fibonacciSet (Zeckendorf completeness) and powersOfTwo (binary representation).",
+      "startLine": 108,
+      "endLine": 122,
+      "mathContext": "Examples of complete sequences: the Fibonacci numbers (Zeckendorf) and the powers of two (binary expansion)."
     },
     {
-      "id": "non-complete",
-      "title": "Non-Complete Sequences",
-      "summary": "Single-base powers not complete",
-      "startLine": 178,
-      "endLine": 186
+      "id": "part8-non-complete",
+      "title": "Part 8: Non-Complete Sequences",
+      "summary": "powersOf a = {a^k} and the single_powers_not_complete axiom: powers of a single base a ≥ 3 are not complete, contrasting with the two-base case.",
+      "startLine": 123,
+      "endLine": 133,
+      "mathContext": "A single geometric sequence $\\{a^k\\}$ ($a \\ge 3$) is not complete — coprimality of two bases is essential."
+    },
+    {
+      "id": "part9-structure",
+      "title": "Part 9: Structure of Power Sets",
+      "summary": "powerSetUpTo a b N: the finite set of power-set elements not exceeding N, used to reason about representations of bounded integers.",
+      "startLine": 134,
+      "endLine": 141,
+      "mathContext": "$\\mathrm{powerSet}(a,b) \\cap [0,N]$ as a finite set, the search space for representing $n \\le N$."
+    },
+    {
+      "id": "part10-unique-representations",
+      "title": "Part 10: Unique Representations",
+      "summary": "numRepresentations a b n: the number of distinct-element subsets of powerSetUpTo summing to n, formalizing the count of representations.",
+      "startLine": 142,
+      "endLine": 151,
+      "mathContext": "$r(n)$ counts subsets $T \\subseteq \\mathrm{powerSet}(a,b)$ of distinct elements with $\\sum_{x\\in T} x = n$."
+    },
+    {
+      "id": "part11-algorithmic",
+      "title": "Part 11: Algorithmic Aspects",
+      "summary": "Greedy representation: the axiomatized greedyRepresentation function and greedy_eventually_works (for coprime a,b ≥ 2 the greedy algorithm eventually produces a valid distinct-element representation).",
+      "startLine": 152,
+      "endLine": 168,
+      "mathContext": "A greedy algorithm (take the largest power $\\le$ remaining sum, repeat) eventually yields a valid distinct representation for all large $n$."
+    },
+    {
+      "id": "part12-summary",
+      "title": "Part 12: Summary",
+      "summary": "erdos_246 (the main result = birch_theorem) and erdos_246_summary bundling completeness of the two-base power set with non-completeness of single-base powers; closes namespace Erdos246.",
+      "startLine": 169,
+      "endLine": 186,
+      "mathContext": "Erdős #246 is SOLVED: $\\{a^k b^l\\}$ is complete for coprime $a,b\\ge 2$, while $\\{a^k\\}$ alone ($a\\ge3$) is not."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Rebuild the gallery sections of `erdos-246` to match the twelve `## Part N` docstring banners in `Erdos246Problem.lean` and add the previously-uncovered module header (lines 1–44), 8 → 13 sections.
- The old eight sections began at line 45 (no header section) and were drifted/lumped: "Birch's Theorem (1959)" was ranged 72-92 but spans Parts 2 and 3; "Cassels' Generalization" (93-106) actually covers Parts 4–6; the tail labels (Yu's Result, Related/Non-Complete Sequences) pointed past their real banners. Parts 11 (Algorithmic) and 12 (Summary) were entirely uncovered.
- Ranges now snap to the `/-` docstring openers (banner−1) and cover lines 1–186 contiguously, each summary naming its real declarations (powerSet, birch_theorem, powerSetBoundedL, the single_powers_not_complete / greedy axioms, erdos_246, etc.).

## Notes
- No Lean source changes — pure gallery metadata realignment. `axiomCount` (4), `theoremCount` (3), `lineCount` (186), `sorries` (0) unchanged.
- Section schema key order (id/title/summary/startLine/endLine/mathContext) preserved; ranges verified contiguous and ending at lineCount 186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)