### PR TITLE
Enrich schroeder-bernstein-oq-02: add mathContext to surjectivity annotation

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-02/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02/annotations.json
@@ -134,6 +134,7 @@
     "type": "insight",
     "title": "Surjectivity and the Full Knaster-Tarski Schroeder-Bernstein Theorem",
     "content": "Surjectivity `ktBij_surjective` proceeds by cases on `b \u2208 f '' fixedSet f g`. If b = f(a) for a \u2208 S*: then h(a) = f(a) = b, done. If b \u2209 f(S*): then g(b) \u2209 S* (by `gb_not_fixedSet`) and h(g(b)) = g\u207b\u00b9(g(b)) = b by injectivity of g. The `knasterTarski_equiv` function packages the bijection as an `Equiv` using `Equiv.ofBijective`. The `fixedSet_characterization` theorem restates T(S*) = S* as an explicit set equation for inspection \u2014 the 'explicit and inspectable' fixed point mentioned in the file header.",
+    "mathContext": "Surjectivity of $h$ (where $h(a) = f(a)$ on $S^*$ and $h(a) = g^{-1}(a)$ off $S^*$): fix $b \\in \\beta$ and split on $b \\in f(S^*)$. **Case $b = f(a)$ with $a \\in S^*$:** then $h(a) = f(a) = b$, so $b$ is hit by the left branch. **Case $b \\notin f(S^*)$:** the lemma `gb_not_fixedSet` (using $g$ injective) gives $g(b) \\notin S^*$, so $h$ acts on $g(b)$ via the right branch as $g^{-1}$, yielding $h(g(b)) = g^{-1}(g(b)) = b$. Together with `ktBij_injective`, this makes $h$ bijective, and `Equiv.ofBijective` packages it as $\\alpha \\simeq \\beta$. The witnessing fixed point is fully explicit: $S^* = (\\text{range}\\,g)^c \\cup g(f(S^*))$ (`fixedSet_characterization`), so the bijection is constructed, not merely shown to exist.",
     "significance": "supporting",
     "relatedConcepts": [
       "ktBij_surjective",


### PR DESCRIPTION
## Summary
Adds the one missing `mathContext` field to the `schroeder-bernstein-oq-02` annotation set, bringing it to full gallery-wide annotation completeness (every annotation now carries `mathContext` + `significance` + `relatedConcepts`).

The `ann-kt-surjectivity` annotation (lines 174–207, `ktBij_surjective`) was the sole annotation in this entry — and one of only 4 across all 2447 gallery entries — lacking `mathContext`. Added LaTeX describing the surjectivity case split for the piecewise bijection $h$ ($f$ on $S^*$, $g^{-1}$ off $S^*$):
- $b \in f(S^*)$: hit by the $f$-branch, $h(a) = f(a) = b$.
- $b \notin f(S^*)$: `gb_not_fixedSet` gives $g(b) \notin S^*$, so $h(g(b)) = g^{-1}(g(b)) = b$.
- `Equiv.ofBijective` packages the explicit bijection; the fixed point $S^* = (\text{range}\,g)^c \cup g(f(S^*))$ is fully inspectable.

Content verified against `proofs/Proofs/SchroederBernsteinOQ02.lean`. No counts, status, or other fields changed. Pure additive enrichment.

## Test plan
- [x] JSON validates (`json.load`), 6 annotations, all fully-fielded
- [x] mathContext matches the actual `ktBij_surjective` proof in the Lean source