### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01): realign drifted gallery sections to full file (8→11)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -55,68 +55,92 @@
   },
   "sections": [
     {
+      "id": "header-docs",
+      "title": "Problem Documentation and Imports",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Module docstring (the open question on a Mathlib multinomial PMF, the affirmative answer, and dependencies), Mathlib imports, and namespace `BinomialTheoremOQ02OQ01OQ01`.",
+      "mathContext": "Open question: can the multinomial distribution be packaged as a Mathlib `PMF`? Answer: yes, via a Composition support type, ENNReal normalization from the multinomial theorem, and `PMF.mk`."
+    },
+    {
       "id": "sec-composition-type",
       "title": "Composition: Support Type of Multinomial",
-      "startLine": 36,
-      "endLine": 53,
+      "startLine": 38,
+      "endLine": 73,
       "summary": "Defines Composition as a structure bundling a count function, a sum constraint, and zero-outside condition. Fintype instance left sorry.",
       "mathContext": "The support of the multinomial$(n, p)$ on alphabet $s$ is $\\{k : s \\to \\mathbb{N} \\mid \\sum_{i\\in s} k(i) = n\\} = \\text{piAntidiag}(s,n)$. The `Composition` structure wraps this as a `Fintype` required by Lean's `PMF` typeclass."
     },
     {
       "id": "sec-pmf-val",
       "title": "Multinomial PMF Value Function",
-      "startLine": 55,
-      "endLine": 66,
+      "startLine": 74,
+      "endLine": 87,
       "summary": "Defines multinomialPMFVal in ENNReal: the multinomial coefficient times the product of probability powers.",
       "mathContext": "$\\text{multinomialPMFVal}(k) = \\binom{n}{k_1,\\ldots,k_r} \\cdot \\prod_{i\\in s} p_i^{k_i} \\in \\mathbb{R}_{\\geq 0}^\\infty$. The `Nat.multinomial s k.counts` is the multinomial coefficient $\\frac{n!}{\\prod k_i!}$."
     },
     {
       "id": "sec-normalization",
       "title": "Normalization from the Multinomial Theorem",
-      "startLine": 68,
-      "endLine": 99,
+      "startLine": 88,
+      "endLine": 128,
       "summary": "Proves sum of multinomial PMF values equals 1 (sorry). Constructs multinomialPMF via PMF.mk using normalization proof.",
       "mathContext": "$\\sum_{k \\in \\text{Composition}(s,n)} \\binom{n}{k} \\prod_{i} p_i^{k_i} = \\left(\\sum_{i\\in s} p_i\\right)^n = 1$ when $\\sum p_i = 1$. This is the multinomial theorem in $\\mathbb{R}_{\\geq 0}^\\infty$, lifted from `Finset.sum_pow_eq_sum_piAntidiag`."
     },
     {
+      "id": "pmf-instance",
+      "title": "The PMF Instance",
+      "startLine": 129,
+      "endLine": 145,
+      "summary": "Defines `multinomialPMF` as a genuine `PMF` via `PMF.mk`, packaging the value function with the ENNReal normalization established in Part 3 (the Fintype-instance obligation is recorded as a sorry).",
+      "mathContext": "The probability mass function $P(X = k) = \\binom{n}{k_1,\\dots,k_m}\\prod_i p_i^{k_i}$ assembled into Mathlib's `PMF` type, whose `tsum`-based normalization is discharged by the multinomial theorem."
+    },
+    {
       "id": "sec-pmf-properties",
       "title": "PMF Properties: Apply and Support",
-      "startLine": 101,
-      "endLine": 119,
+      "startLine": 146,
+      "endLine": 165,
       "summary": "multinomialPMF_apply (proved by rfl) and multinomialPMF_support (sorry: product nonzero iff factors nonzero).",
       "mathContext": "`multinomialPMF_apply` holds by `rfl` since `PMF.instFunLike` makes `P k` definitionally equal to `P.1 k`. Support: $P(X=k) \\neq 0 \\iff \\forall i\\in s, k_i \\neq 0 \\Rightarrow p_i \\neq 0$."
     },
     {
       "id": "sec-marginal-binomial",
       "title": "Marginal Distribution: Multinomial → Binomial",
-      "startLine": 121,
-      "endLine": 142,
+      "startLine": 166,
+      "endLine": 187,
       "summary": "multinomial_marginal_binomial (sorry): fixing k(i) = m and summing over remaining components gives the binomial PMF formula C(n,m)·p(i)^m·(1-p(i))^(n-m).",
       "mathContext": "$P(X_i = m) = \\binom{n}{m} p_i^m (1-p_i)^{n-m}$. The inner sum over remaining categories equals $(1-p_i)^{n-m}$ by the $(|s|-1)$-dimensional multinomial theorem applied to $\\{p_j : j\\neq i\\}$, which sum to $1-p_i$."
     },
     {
       "id": "sec-moments",
       "title": "Mean and Covariance",
-      "startLine": 144,
-      "endLine": 168,
+      "startLine": 188,
+      "endLine": 214,
       "summary": "multinomial_mean (E[Xᵢ] = n·pᵢ, sorry) and multinomial_covariance (Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ, sorry). Both use piAntidiag sum manipulation.",
       "mathContext": "$E[X_i] = np_i$. $\\text{Cov}(X_i, X_j) = E[X_iX_j] - E[X_i]E[X_j] = n(n-1)p_ip_j - n^2p_ip_j = -np_ip_j < 0$. Negative covariance reflects the constraint $\\sum X_i = n$: components cannot fluctuate independently."
     },
     {
       "id": "sec-feasibility",
       "title": "Feasibility Analysis for Mathlib Contribution",
-      "startLine": 170,
-      "endLine": 202,
+      "startLine": 215,
+      "endLine": 248,
       "summary": "Documents what is available in Mathlib and what needs to be built. Estimates ~200-300 lines for complete contribution. Answer: YES, integration is feasible.",
       "mathContext": "Mathlib already has `PMF` (tsum normalization), `Nat.multinomial`, `Finset.sum_pow_eq_sum_piAntidiag` (multinomial theorem), and `ENNReal` arithmetic. The gap is the `Fintype` instance for `Composition` (~50 lines) and the ENNReal lift of the multinomial theorem (~30 lines)."
     },
     {
       "id": "sec-concrete-example",
       "title": "Concrete Example: Dice Roll",
-      "startLine": 204,
-      "endLine": 215,
+      "startLine": 249,
+      "endLine": 260,
       "summary": "Example: rolling a fair die 6 times, probability of seeing each face exactly once = 6!/(1!^6) · (1/6)^6 = 720/46656.",
       "mathContext": "$P(\\text{all distinct in 6 rolls}) = \\frac{6!}{1!^6}\\cdot\\left(\\frac{1}{6}\\right)^6 = \\frac{720}{46656} = \\frac{5}{324} \\approx 1.54\\%$. The theorem checks $\\text{multinomial}(\\{0,\\ldots,5\\}, \\mathbf{1}) = 6!$ (multinomial with all counts 1 equals $n!$)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 261,
+      "endLine": 292,
+      "summary": "Module summary docstring: enumerates the proved results (`multinomialPMF_apply`, the Composition structure) and the seven remaining sorries (Fintype instance, normalization, support, marginal, mean, covariance, dice example), and outlines the Mathlib-integration contribution path. Ends with `#check`s.",
+      "mathContext": "Concluding overview: 0 axioms, 7 sorries, and an estimated ~200-300 lines for a complete Mathlib contribution of the multinomial PMF."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
The Lean file `Proofs/BinomialTheoremOQ02OQ01OQ01.lean` grew to ten `-- PART` banners, but the gallery had only 8 drifted sections covering `36–215`, leaving a 77-line tail and several Parts unrepresented.

- **Surface 3 missing sections**: the header/imports (`1–37`), **"The PMF Instance"** (Part 4, the `multinomialPMF` definition), and **"Summary"** (Part 10, the results/sorries overview).
- Re-mapped all 8 existing sections to their `-- ===` banner boxes (the file had grown, so every range was stale).

Sections now tile the file `1–292` contiguously (8 → 11). Meta-only change; no Lean source touched.

## Test plan
- [x] JSON parses; sections contiguous, no gaps/overlap, last end = lineCount (292)
- [x] Each range verified against `-- PART N` banner boxes and declaration positions