### PR TITLE
research(konigsberg-oq-01-oq-02): realign section+annotation, fix stale sorry prose

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
@@ -220,12 +220,12 @@
     "id": "ann-koe02-circuit-exists",
     "proofId": "konigsberg-oq-01-oq-02",
     "range": {
-      "startLine": 737,
-      "endLine": 848
+      "startLine": 1044,
+      "endLine": 1198
     },
     "type": "concept",
     "title": "Circuit Existence, Balance Preservation, and Path Necessity",
-    "content": "`circuit_exists` applies `maxTrail_closed` directly: start from any vertex with an outgoing edge, run the greedy trail, which is closed by balance, giving a `DirectedCircuit` structure. `remove_circuit_balanced` (sorry'd) would prove that removing a circuit's edges preserves balance — the circuit passes through each vertex equally often as source and target (by `closed_walk_balance`), so both degrees decrease by the same amount. `euler_path_implies_degree_balance` (sorry'd) proves necessity for Eulerian paths: in an open walk from $s$ to $t$, applying `open_walk_first_source_excess` to $s$ and `open_walk_last_target_excess` to $t$ yields the asymmetric degree conditions; closed-walk balance handles interior vertices. These two sorries are the remaining obstacles to eliminating the `directed_eulerian_iff` axiom.",
+    "content": "`circuit_exists` applies `maxTrail_closed` directly: start from any vertex with an outgoing edge, run the greedy trail, which is closed by balance, giving a `DirectedCircuit` structure. `remove_circuit_balanced` (sorry'd) would prove that removing a circuit's edges preserves balance — the circuit passes through each vertex equally often as source and target (by `closed_walk_balance`), so both degrees decrease by the same amount. `euler_path_implies_degree_balance` (fully proved) establishes necessity for Eulerian paths: in an open walk from $s$ to $t$, applying `open_walk_first_source_excess` to $s$ and `open_walk_last_target_excess` to $t$ yields the asymmetric degree conditions; closed-walk balance handles interior vertices. The single remaining sorry (`remove_circuit_balanced`) is the last obstacle to eliminating the `directed_eulerian_iff` axiom.",
     "mathContext": "Circuit existence: $G$ balanced, $|E| \\geq 1 \\Rightarrow \\exists$ directed circuit in $G$. Remove circuit: for each $v$, circuit passes through $v$ equally as source ($s_v$ times) and target ($t_v = s_v$ times by closed-walk balance), so $\\text{outDeg}_{G'}(v) = \\text{outDeg}_G(v) - s_v = \\text{inDeg}_G(v) - s_v = \\text{inDeg}_{G'}(v)$. Path necessity: $s$ has $\\text{outDeg}(s) = \\text{inDeg}(s)+1$ (extra source at start); $t$ has $\\text{inDeg}(t) = \\text{outDeg}(t)+1$ (extra target at end).",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -99,7 +99,7 @@
       "id": "characterization",
       "title": "Directed Eulerian Theorem and Path Characterization",
       "startLine": 314,
-      "endLine": 341,
+      "endLine": 347,
       "summary": "Defines IsWeaklyConnected and HasEulerianPath. Axiomatizes directed_eulerian_iff (Hierholzer) and directed_euler_path_iff.",
       "mathContext": "$G$ has an Eulerian circuit $\\iff$ $\\text{IsEulerianBalanced}(G)$ (weak connectivity required). $G$ has Eulerian path $s \\to t$ $\\iff$ $\\text{outDeg}(s) = \\text{inDeg}(s)+1$, $\\text{inDeg}(t) = \\text{outDeg}(t)+1$, and all others balanced."
     },


### PR DESCRIPTION
## Summary

Build-free accuracy/realignment pass on `konigsberg-oq-01-oq-02` (Eulerian Paths in Directed Graphs). Verified against `proofs/Proofs/KonigsbergOQ01OQ02.lean` (1202 lines, 2 axioms, 1 sorry @1105).

- **Section drift**: `characterization` ended at line 341, but the axiom `directed_euler_path_iff` (lines 342–346) — which the section summary *explicitly* says it axiomatizes — fell in an uncovered gap before the PART V banner (348). Extended `endLine` 341→347 so the section covers the axiom and `characterization`→`examples` is contiguous.
- **Annotation drift**: `ann-koe02-circuit-exists` had range 737–848 (the `maxTrail` support-lemma region), but its content describes `circuit_exists` (1060), `remove_circuit_balanced` (1103), and `euler_path_implies_degree_balance` (1125). Re-anchored to 1044–1198.
- **Stale prose**: the same annotation called `euler_path_implies_degree_balance` "(sorry'd)" and referred to "two sorries". The file has a *single* sorry (`remove_circuit_balanced` @1105); `euler_path_implies_degree_balance` is fully proved. Corrected.

Distinct from open PR #23908 (which only fixes the `description` theorem count in meta.json) — no overlapping lines.

## Test plan
- [x] Both JSON files parse (`python3 -c json.load`)
- [x] Section/annotation ranges verified against actual declaration line numbers
- [x] No overlap with PR #23908

Build-free (JSON only); no Lean rebuild required.