### PR TITLE
Enrich fermats-last-theorem: add mathContext to imports annotation (+ note FLT.Three)

### DIFF
--- a/src/data/proofs/fermats-last-theorem/annotations.json
+++ b/src/data/proofs/fermats-last-theorem/annotations.json
@@ -8,12 +8,15 @@
     },
     "type": "concept",
     "title": "Mathlib Imports",
-    "content": "We import from Mathlib's FLT modules: `FLT.Basic` for the theorem statement, `FLT.Four` for Fermat's descent proof of the n=4 case, and ring theory for integer properties.",
+    "content": "We import from Mathlib's FLT modules: `FLT.Basic` for the theorem statement, `FLT.Four` for Fermat's descent proof of the n=4 case, `FLT.Three` for Euler's n=3 case, and `EuclideanDomain.Basic` / `RingTheory.Int.Basic` for integer divisibility and unique factorization.",
+    "mathContext": "The imported Mathlib modules supply the verified small cases that this file wraps. `Mathlib.NumberTheory.FLT.Basic` defines `FermatLastTheoremFor n` — the statement that $a^n + b^n = c^n$ has no solution in positive integers $a,b,c$ — and the aggregate `FermatLastTheorem`. `FLT.Four` provides `fermatLastTheoremFour`, Fermat's own infinite-descent proof that $x^4 + y^4 = z^4$ has no nontrivial solution (the one case Fermat could actually prove). `FLT.Three` provides `fermatLastTheoremThree`, Euler's $n=3$ case via unique factorization in the Eisenstein integers $\\mathbb{Z}[\\omega]$, $\\omega = e^{2\\pi i/3}$. The general $n > 2$ theorem (Wiles–Taylor 1995, via the modularity of elliptic curves and Ribet's level-lowering) is not yet in Mathlib and is axiomatized in this file pending the Imperial College FLT project.",
     "significance": "supporting",
     "relatedConcepts": [
       "Mathlib",
       "Lean 4",
-      "formalization"
+      "formalization",
+      "fermatLastTheoremFour",
+      "fermatLastTheoremThree"
     ]
   },
   {


### PR DESCRIPTION
## Summary
Adds `mathContext` to the `ann-flt-imports` annotation — the last annotation in this marquee entry lacking it — and corrects a small content accuracy gap.

- **Substantive mathContext**: explains what each imported Mathlib FLT module provides:
  - `FLT.Basic` → `FermatLastTheoremFor n` ($a^n+b^n=c^n$ has no positive solution) + `FermatLastTheorem`
  - `FLT.Four` → `fermatLastTheoremFour`, Fermat's infinite-descent proof ($x^4+y^4=z^4$)
  - `FLT.Three` → `fermatLastTheoremThree`, Euler's $n=3$ case via unique factorization in $\mathbb{Z}[\omega]$, $\omega=e^{2\pi i/3}$
  - the general $n>2$ case (Wiles–Taylor, modularity + Ribet) remains axiomatized pending the Imperial College FLT project.
- **Accuracy fix**: the content listed only `FLT.Basic`/`FLT.Four`, but the file also imports `FLT.Three` (line 3) and `EuclideanDomain.Basic`/`RingTheory.Int.Basic`. Updated to match the actual imports.

Verified against the import block of `proofs/Proofs/FermatsLastTheorem.lean`. No status/count changes (entry remains axiomatized with sorries). Additive enrichment + one content correction.

## Test plan
- [x] JSON validates, 10 annotations, all fully-fielded
- [x] Module/theorem names match the file's import block (FLT.Basic/Four/Three)