### PR TITLE
research(dissection-of-cubes-oq-01-oq-01): realign drifted gallery sections to full file (7→11)

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -72,53 +72,81 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring for Dissection of Cubes OQ01 sub-question 01, plus Mathlib imports and the parent import `Proofs.DissectionOfCubesOQ01`."
+    },
+    {
       "id": "concrete-cubes",
       "title": "Concrete Cube Definitions",
-      "startLine": 50,
-      "endLine": 90,
+      "startLine": 53,
+      "endLine": 81,
       "summary": "Defines cubeA (0,0,0, side=1/4), cubeB (1/2,0,0, side=1/4), cubeC (0,0,1/2, side=1/3) with size lemmas."
     },
     {
       "id": "distinctness",
       "title": "Cube Distinctness",
-      "startLine": 91,
-      "endLine": 115,
+      "startLine": 82,
+      "endLine": 106,
       "summary": "Proves A≠B (different x), A≠C and B≠C (different sides)."
     },
     {
       "id": "containment",
       "title": "Containment in Unit Cube",
-      "startLine": 116,
-      "endLine": 135,
+      "startLine": 107,
+      "endLine": 125,
       "summary": "All three cubes lie in [0,1]³ by norm_num."
     },
     {
       "id": "disjointness",
       "title": "Pairwise Interior Disjointness",
-      "startLine": 136,
-      "endLine": 185,
+      "startLine": 126,
+      "endLine": 163,
       "summary": "All 6 ordered pairs are disjoint via coordinate separation."
     },
     {
       "id": "dissection",
       "title": "The Example Dissection",
-      "startLine": 186,
-      "endLine": 220,
+      "startLine": 164,
+      "endLine": 199,
       "summary": "Constructs exampleDissection from {cubeA, cubeB, cubeC} satisfying all CubeDissection fields."
+    },
+    {
+      "id": "membership-facts",
+      "title": "Membership Facts",
+      "startLine": 200,
+      "endLine": 225,
+      "summary": "cubeA_mem, cubeB_mem, cubeC_mem (each example cube belongs to the dissection) and mem_collidingCubes_iff (membership characterization of the colliding set)."
     },
     {
       "id": "collision-analysis",
       "title": "Which Cubes Collide",
-      "startLine": 221,
-      "endLine": 260,
+      "startLine": 226,
+      "endLine": 256,
       "summary": "cubeA and cubeB collide; cubeC does not (unique size 1/3)."
+    },
+    {
+      "id": "colliding-eq-pair",
+      "title": "Colliding Cubes = {A, B}",
+      "startLine": 257,
+      "endLine": 280,
+      "summary": "colliding_eq_pair: the set of colliding cubes of the example dissection is exactly {A, B}."
     },
     {
       "id": "main-result",
       "title": "Main Results",
-      "startLine": 261,
-      "endLine": 285,
-      "summary": "HasMinimalCollision for the example; existential achievability; lower bound tightness."
+      "startLine": 281,
+      "endLine": 300,
+      "summary": "example_has_minimal_collision (the example attains a minimal collision) and minimal_collision_achievable (existential achievability of a minimal-collision dissection)."
+    },
+    {
+      "id": "lower-bound-connection",
+      "title": "Connection to the Lower Bound",
+      "startLine": 301,
+      "endLine": 328,
+      "summary": "lower_bound_tight: the example dissection achieves the lower bound, establishing that the minimal collision count is tight."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
`Proofs/DissectionOfCubesOQ01OQ01.lean` has ten `-- SECTION N` banner boxes plus a header, but the gallery had only 7 drifted sections covering `50–285`, leaving the header and tail uncovered and three interior sections missing.

- **Surface 4 missing sections**: Module Header & Imports (`1–52`), **"Membership Facts"** (SECTION 6: `cubeX_mem`, `mem_collidingCubes_iff`), **"Colliding Cubes = {A, B}"** (SECTION 8: `colliding_eq_pair`), and **"Connection to the Lower Bound"** (SECTION 10: `lower_bound_tight`).
- Re-mapped the 7 existing sections to their `-- ===` banner boxes and trimmed the over-broad "Main Results" summary (lower-bound content moved to SECTION 10).

Sections now tile the file `1–328` contiguously (7 → 11). Meta-only change; no Lean source touched.

## Test plan
- [x] JSON parses; sections contiguous, no gaps/overlap, last end = lineCount (328)
- [x] Each range verified against `-- SECTION N` banner boxes and declaration positions