### PR TITLE
research(erdos-202): realign drifted gallery sections to full file (9→10)

### DIFF
--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -81,73 +81,81 @@
       "id": "imports",
       "title": "Imports and Namespace",
       "startLine": 59,
-      "endLine": 68,
-      "summary": "Imports `Int.ModEq` for modular arithmetic, `Finset.Basic`, `Log.Basic`, `Pow.Real` for $L(N)$, and `Tactic`. Opens `Finset`, `Real` within `Erdos202`.",
-      "mathContext": "Mathematical content: Imports `Int.ModEq` for modular arithmetic, `Finset.Basic`, `Log.Basic`, `Pow.Real` for $L(N)$, and `Tactic`. Opens `Finset`, `Real` within `Erdos202`."
+      "endLine": 69,
+      "summary": "Imports `Int.ModEq` for modular arithmetic, `Finset.Basic`, `Log.Basic`, `Pow.Real` for $L(N)$, and `Tactic`. Opens `Finset`, `Real` within namespace `Erdos202`.",
+      "mathContext": "Mathematical content: Imports `Int.ModEq`, `Finset.Basic`, `Log.Basic`, `Pow.Real`, `Tactic`. Opens `Finset`, `Real` within namespace `Erdos202`."
     },
     {
       "id": "congruence-classes",
-      "title": "Congruence Classes and Disjointness",
-      "startLine": 73,
-      "endLine": 84,
+      "title": "Part I: Congruence Classes",
+      "startLine": 70,
+      "endLine": 85,
       "summary": "Defines CongruenceClass$(a, n)$ with $n > 0$, containment via $x \\equiv a \\pmod{n}$ (`Int.ModEq`), and AreDisjoint: no integer belongs to both classes.",
-      "mathContext": "Formal definition: Defines CongruenceClass$(a, n)$ with $n > 0$, containment via $x \\equiv a \\pmod{n}$ (`Int.ModEq`), and AreDisjoint: no integer belongs to both classes."
+      "mathContext": "Formal definition: CongruenceClass$(a, n)$ with $n > 0$, containment via `Int.ModEq`, and AreDisjoint predicate."
     },
     {
       "id": "disjoint-systems",
-      "title": "Disjoint System Structure",
-      "startLine": 89,
-      "endLine": 103,
-      "summary": "Defines DisjointSystem with `Finset CongruenceClass`, pairwise disjointness, `moduli` ($\\text{image}$ of modulus), `boundedBy(N)$ (all moduli $\\leq N$), and `size` ($|\\text{classes}|$).",
-      "mathContext": "Formal definition: Defines DisjointSystem with `Finset CongruenceClass`, pairwise disjointness, `moduli` ($\\text{image}$ of modulus), `boundedBy(N)$ (all moduli $\\leq N$), and `size` ($|\\text{classes}|$)."
+      "title": "Part II: Disjoint Systems",
+      "startLine": 86,
+      "endLine": 104,
+      "summary": "Defines DisjointSystem with `Finset CongruenceClass`, pairwise disjointness, `moduli` (image of modulus), `boundedBy(N)` (all moduli $\\leq N$), and `size` ($|\\text{classes}|$).",
+      "mathContext": "Formal definition: DisjointSystem with pairwise disjointness, `moduli`, `boundedBy(N)`, and `size`."
     },
     {
       "id": "f-function",
-      "title": "The Function $f(N)$",
-      "startLine": 108,
+      "title": "Part III: The Function $f(N)$",
+      "startLine": 105,
       "endLine": 152,
       "summary": "Defines $f(N) = \\text{sSup}\\{|S| : S$ bounded by $N\\}$. Proves `f_mono` ($N_1 \\leq N_2 \\implies f(N_1) \\leq f(N_2)$) via subset argument (Aristotle).",
-      "mathContext": "Formal definition: Defines $f(N) = \\text{sSup}\\{|S| : S$ bounded by $N\\}$. Proves `f_mono` ($N_1 \\leq N_2 \\implies f(N_1) \\leq f(N_2)$) via subset argument (Aristotle)."
+      "mathContext": "Formal definition: $f(N) = \\text{sSup}\\{|S| : S$ bounded by $N\\}$; `f_mono` proved by Aristotle."
     },
     {
       "id": "basic-bounds",
-      "title": "Basic Bounds and Density Constraint",
+      "title": "Part IV: Basic Bounds and Density Constraint",
       "startLine": 153,
       "endLine": 336,
       "summary": "Proves `sum_inv_moduli_le_one` ($\\sum 1/n_i \\leq 1$), `f_le_N` ($f(N) \\leq N$), `f_ge_N` ($f(N) \\geq N$ via full system), and `f_lower_trivial`. Multiple proofs by Aristotle.",
-      "mathContext": "Verified: Proves `sum_inv_moduli_le_one` ($\\sum 1/n_i \\leq 1$), `f_le_N` ($f(N) \\leq N$), `f_ge_N` ($f(N) \\geq N$ via full system), and `f_lower_trivial`. Multiple proofs by Aristotle."
+      "mathContext": "Verified: `sum_inv_moduli_le_one`, `f_le_N`, `f_ge_N`, `f_lower_trivial`. Multiple proofs by Aristotle."
     },
     {
       "id": "l-function",
-      "title": "The $L$ Function and Growth Properties",
-      "startLine": 340,
-      "endLine": 411,
-      "summary": "Defines $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$. Proves `L_mono` and `L_subpolynomial` ($L(N) < N^\\varepsilon$, Aristotle). States `L_superlogarithmic` (sorry).",
-      "mathContext": "Formal definition: Defines $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$. Proves `L_mono` and `L_subpolynomial` ($L(N) < N^\\varepsilon$, Aristotle). States `L_superlogarithmic` (sorry)."
+      "title": "Part V: The $L$ Function and Growth Properties",
+      "startLine": 337,
+      "endLine": 464,
+      "summary": "Defines $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$. Proves `L_mono`, `L_subpolynomial` ($L(N) < N^\\varepsilon$), and `L_superlogarithmic` ($(\\log N)^c < L(N)$) — all by Aristotle.",
+      "mathContext": "Formal definition: $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$; `L_mono`, `L_subpolynomial`, and `L_superlogarithmic` all proved by Aristotle."
     },
     {
       "id": "erdos-stein",
-      "title": "Erdős–Stein Conjecture and Szemerédi Bound",
-      "startLine": 420,
-      "endLine": 546,
-      "summary": "States erdos_stein_conjecture: $f(N) = o(N)$ (sorry). Proves `erdos_szemeredi_upper`: $f(N) < N/(\\log N)^c$ (Aristotle). Includes `trivialSystem` and `full_system` constructions.",
-      "mathContext": "Verified: States erdos_stein_conjecture: $f(N) = o(N)$ (sorry). Proves `erdos_szemeredi_upper`: $f(N) < N/(\\log N)^c$ (Aristotle). Includes `trivialSystem` and `full_system` constructions."
+      "title": "Part VI: The Erdős–Stein Conjecture (PROVED)",
+      "startLine": 465,
+      "endLine": 598,
+      "summary": "States `erdos_stein_conjecture`: $f(N) = o(N)$ (sorry). Proves `erdos_szemeredi_upper`: $f(N) < N/(\\log N)^c$ (Aristotle). Includes `trivialSystem` and `full_system` constructions.",
+      "mathContext": "Verified: `erdos_szemeredi_upper` ($f(N) < N/(\\log N)^c$) by Aristotle; `erdos_stein_conjecture` ($f(N)=o(N)$) remains a sorry. Includes `trivialSystem`, `full_system`."
     },
     {
       "id": "modern-bounds",
-      "title": "BFV Bounds and Exact Asymptotic Conjecture",
-      "startLine": 552,
-      "endLine": 760,
-      "summary": "States `upper_bound_BFV`: $f(N) < N/L(N)^{\\sqrt{3}/2-\\varepsilon}$ (sorry). Proves `lower_bound_BFV`: $f(N) > N/L(N)^{1+\\varepsilon}$ (Aristotle). Defines ExactAsymptoticConjecture: $f(N) = N/L(N)^{1+o(1)}$.",
-      "mathContext": "States `upper_bound_BFV`: $f(N) < N/L(N)^{\\sqrt{3}/2-\\varepsilon}$ (sorry). Proves `lower_bound_BFV`: $f(N) > N/L(N)^{1+\\varepsilon}$ (Aristotle). Defines ExactAsymptoticConjecture: $f(N) = N/L(N)^{1+o(1)}$."
+      "title": "Part VII: BFV Bounds and Exact Asymptotic Conjecture",
+      "startLine": 599,
+      "endLine": 813,
+      "summary": "States `upper_bound_BFV`: $f(N) < N/L(N)^{\\sqrt{3}/2-\\varepsilon}$ (sorry). Proves `lower_bound_BFV`: $f(N) > N/L(N)^{1+\\varepsilon}$ (Aristotle). Defines `ExactAsymptoticConjecture`: $f(N) = N/L(N)^{1+o(1)}$.",
+      "mathContext": "Bound: `lower_bound_BFV` ($f(N) > N/L(N)^{1+\\varepsilon}$) proved by Aristotle; `upper_bound_BFV` remains a sorry. Defines `ExactAsymptoticConjecture`."
+    },
+    {
+      "id": "historical-bounds",
+      "title": "Part VIII: Historical Bounds (Croot)",
+      "startLine": 814,
+      "endLine": 838,
+      "summary": "Croot (2003) bounds. Proves `croot_lower`: $f(N) > N/L(N)^{\\sqrt{2}+\\varepsilon}$ (Aristotle). States `croot_upper`: $f(N) < N/L(N)^{1/6-\\varepsilon}$ (sorry).",
+      "mathContext": "Bound: `croot_lower` ($f(N) > N/L(N)^{\\sqrt{2}+\\varepsilon}$) proved by Aristotle; `croot_upper` remains a sorry."
     },
     {
       "id": "examples",
-      "title": "Historical Bounds and Examples",
-      "startLine": 763,
-      "endLine": 809,
-      "summary": "States Croot bounds (sorry), `example_N6` ($f(6) \\geq 3$ via classes $0 \\bmod 2, 1 \\bmod 4, 3 \\bmod 6$), and `coveringDensity` with $\\sum 1/n_i \\leq 1$.",
-      "mathContext": "Bound: States Croot bounds (sorry), `example_N6` ($f(6) \\geq 3$ via classes $0 \\bmod 2, 1 \\bmod 4, 3 \\bmod 6$), and `coveringDensity` with $\\sum 1/n_i \\leq 1$."
+      "title": "Part IX: Examples",
+      "startLine": 839,
+      "endLine": 859,
+      "summary": "Proves `example_N6` ($f(6) \\geq 3$ via classes $0 \\bmod 2, 1 \\bmod 4, 3 \\bmod 6$). Defines `coveringDensity` and proves `covering_density_le_one` ($\\sum 1/n_i \\leq 1$, Aristotle).",
+      "mathContext": "Verified: `example_N6` ($f(6)\\geq 3$) and `covering_density_le_one` ($\\leq 1$) proved by Aristotle; defines `coveringDensity`."
     }
   ],
   "conclusion": {
@@ -157,7 +165,7 @@
       "Is $f(N) = N/L(N)^{1+o(1)}$ (matching the lower bound), or is the true exponent strictly between $1$ and $\\sqrt{3}/2$?",
       "Can the BFV upper bound exponent $\\sqrt{3}/2 \\approx 0.866$ be improved toward the conjectured $1$?",
       "What structural properties characterize extremal disjoint systems (those achieving $f(N)$)?",
-      "Can the remaining 7 sorries (including erdos_stein_conjecture and upper_bound_BFV) be proved by Aristotle with stronger Mathlib tactics?"
+      "Can the remaining 3 sorries (`erdos_stein_conjecture`, `upper_bound_BFV`, `croot_upper`) be proved by Aristotle with stronger Mathlib tactics?"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary
The 9 meta sections of erdos-202 had drifted off the Lean file's nine `## Part` banners. Most visibly, the final section (`Historical Bounds and Examples`, lines 763-809) ended **before** both the Part VIII banner (`Croot`, line 814) and Part IX banner (`Examples`, line 839) — so the entire 810-859 tail was uncovered. Part VII's span (599-813) was also incorrectly split across two sections.

Realigned to **10 banner-aligned, contiguous sections** covering lines 59-859 (imports + Parts I-IX), splitting the lumped tail into Part VIII (Historical Bounds / Croot) and Part IX (Examples).

## De-staled prose
- **Part V** summary: `L_superlogarithmic` is fully proved by Aristotle (line 412), not a sorry as the old summary claimed.
- **openQuestions**: "remaining 7 sorries" corrected to the actual **3** (`erdos_stein_conjecture` L473, `upper_bound_BFV` L606, `croot_upper` L836). The `sorries: 3` metric was already correct.

## Test plan
- [x] `python3 -c json.load` — meta.json parses
- [x] Sections contiguous 59→859, no gaps/overlaps, full-file coverage
- [x] Section ranges verified against `## Part` banner line numbers in the source
- [x] Build-free: `meta.json` only; no Lean source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)