### PR TITLE
research(erdos-1054-oq-01): realign gallery sections to full file (Parts I-VIII)

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01/meta.json
@@ -88,50 +88,81 @@
       "id": "header",
       "title": "Background and Sigma Bound Approach",
       "startLine": 1,
-      "endLine": 30,
-      "summary": "Problem statement, sigma bound approach, and Gronwall-Mertens connection."
+      "endLine": 37,
+      "summary": "States Erdős #1054 OQ-01: the density-theoretic version asserting $f(n)=o(n)$ for almost all $n$, where $f(n)$ is the least number of distinct divisors summing to $n$. Overview of the $\\sigma$-bound approach.",
+      "mathContext": "$f(n)=o(n)$ for almost all $n$; $\\sigma$-bound approach."
     },
     {
-      "id": "definitions",
-      "title": "Core Definitions",
+      "id": "part1",
+      "title": "Part I: Core Definitions (standalone)",
       "startLine": 38,
-      "endLine": 57,
-      "summary": "sortedDivisors, partialDivisorSums, IsRepresentable, sigma function."
+      "endLine": 56,
+      "summary": "Defines `sortedDivisors`, `partialDivisorSums`, `IsRepresentable`, and `sigma` (the sum-of-divisors function).",
+      "mathContext": "$\\sigma(m)=\\sum_{d\\mid m}d$; partial divisor sums."
     },
     {
-      "id": "conjecture",
-      "title": "The Open Conjecture",
-      "startLine": 62,
-      "endLine": 80,
-      "summary": "Formal statement of density-0 conjecture and Tao's counterexample axiom."
+      "id": "part2",
+      "title": "Part II: The Open Conjecture (formal statement)",
+      "startLine": 57,
+      "endLine": 79,
+      "summary": "States the conjecture as AXIOMS: `erdos_1054_almost_all` ($f(n)=o(n)$ a.a.) and `tao_counterexample_1054` (Tao's potential counterexample density).",
+      "mathContext": "Axioms: a.a. bound vs. Tao counterexample density."
     },
     {
-      "id": "sigma-bound",
-      "title": "Sigma Bound Connection",
-      "startLine": 84,
-      "endLine": 108,
-      "summary": "sigma_in_partial_sums and f_sigma_witness: the key structural result."
+      "id": "part3",
+      "title": "Part III: Sigma Bound Connection (key structural results)",
+      "startLine": 80,
+      "endLine": 146,
+      "summary": "Proves the structural link: helpers `scanl_add_ne_nil`, `getLast_scanl_add`, `sort_sum_eq`, then `sigma_in_partial_sums` ($\\sigma(m)$ is a partial divisor sum) and `f_sigma_witness`.",
+      "mathContext": "$\\sigma(m)\\in$ partialDivisorSums$(m)$: $f$-witness."
     },
     {
-      "id": "computations",
-      "title": "Concrete Computations",
-      "startLine": 112,
-      "endLine": 160,
-      "summary": "Six native_decide theorems showing σ-witnesses for m = 6, 12, 24, 120, 720, 5040."
+      "id": "part4",
+      "title": "Part IV: Explicit small-m computations (0 sorries)",
+      "startLine": 147,
+      "endLine": 175,
+      "summary": "Proves concrete values `f_12_le_6`, `f_28_le_12`, `f_60_le_24`, `f_360_le_120`, `f_2418_le_720`, `f_19344_le_5040` by `decide`/computation.",
+      "mathContext": "$\\sigma(6)=12,\\ \\sigma(12)=28,\\dots,\\sigma(5040)=19344$."
     },
     {
-      "id": "ratios",
-      "title": "Ratio Bounds",
-      "startLine": 164,
-      "endLine": 205,
-      "summary": "Decreasing ratios and explicit bounds: ratio < 1/3 for n = 360."
+      "id": "part5",
+      "title": "Part V: Ratio bounds going to zero",
+      "startLine": 176,
+      "endLine": 198,
+      "summary": "Proves `sigma_ratio_decreasing` and `abundant_ratio_le_half` — bounds on $f(n)/n$ toward $0$.",
+      "mathContext": "$f(n)/n$ bounds; abundant-number ratio $\\leq\\tfrac12$."
     },
     {
-      "id": "sigma-props",
-      "title": "Sigma Function Properties and File Summary",
-      "startLine": 166,
-      "endLine": 234,
-      "summary": "Parts VII-VIII: sigma_prime (σ(p)=p+1 via Nat.Prime.divisors + Finset.sum_pair), sigma_ge_succ (σ(m)≥m+1 via subset bound on {1,m}), sigma_ratio_2a_3b formula and bound (proven via ArithmeticFunction bridge, multiplicativity of σ, and geometric sum identities). All theorems fully proved, 0 sorries."
+      "id": "part6",
+      "title": "Part VI: Infinitely many n with f(n)/n bounded",
+      "startLine": 199,
+      "endLine": 214,
+      "summary": "Proves `inf_many_small_ratio_one_third` and `f_ratio_lt_third`: infinitely many $n$ with $f(n)/n$ small.",
+      "mathContext": "Infinitely many $n$ with $f(n)/n<\\tfrac13$."
+    },
+    {
+      "id": "part7",
+      "title": "Part VII: Sigma function properties",
+      "startLine": 215,
+      "endLine": 239,
+      "summary": "Proves `sigma_prime` ($\\sigma(p)=p+1$) and `sigma_ge_succ` ($\\sigma(m)\\geq m+1$ for $m\\geq2$).",
+      "mathContext": "$\\sigma(p)=p+1$; $\\sigma(m)\\geq m+1$."
+    },
+    {
+      "id": "part8",
+      "title": "Part VIII: Sigma ratio for 2^a · 3^b (proven via multiplicativity)",
+      "startLine": 240,
+      "endLine": 324,
+      "summary": "Proves the multiplicative ratio: helpers `sigma_eq_arith_sigma1`, `coprime_pow2_pow3`, geometric-sum lemmas, `sigma1_prime_pow_eq`, then `sigma_ratio_2a_3b` and `sigma_ratio_2a_3b_bound`.",
+      "mathContext": "$\\sigma(2^a3^b)/(2^a3^b)$ via multiplicativity + geom. sums."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 325,
+      "endLine": 352,
+      "summary": "Recaps: $\\sigma$-bound witness for $f$, explicit small values, ratio decay, and the $2^a3^b$ multiplicative computation; the almost-all conjecture remains axiomatized.",
+      "mathContext": "Summary of results; conjecture remains open (axiom)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Realigns the gallery `sections` for **erdos-1054-oq-01** ($f(n)=o(n)$ for almost all $n$, `Erdos1054AlmostAllOQ01.lean`, 352 lines).

The meta sections **overlapped** (164–205 and 166–234) and stopped at line 234, hiding Parts VI–VIII and the Summary.

## Changes
- Rebuilt 10 sections (Header + Parts I–VIII + Summary) mapped to the `Part N` banners, covering lines 1–352 contiguously.
- Refreshed summaries/mathContext (definitions, conjecture axioms, $\sigma$-bound witness, explicit small values, ratio decay, $2^a3^b$ multiplicative computation).
- Counts already correct: 24 theorems / 4 defs / 2 axioms / 0 sorries, lineCount 352.

## Validation
- `npx tsx scripts/research/build.ts` exits 0.