### PR TITLE
research(erdos-692): realign drifted tail sections to Part VII–IX banners (12→13)

### DIFF
--- a/src/data/proofs/erdos-692/meta.json
+++ b/src/data/proofs/erdos-692/meta.json
@@ -187,17 +187,25 @@
     },
     {
       "id": "ford-distribution",
-      "title": "Ford's Distribution Function $H(x,y,z)$",
-      "summary": "Defines `fordDistribution(x,y,z) = \\#\\{n \\leq x : \\exists d \\mid n,\\; y < d < z\\}$ and the oscillation interpretation connecting 'at least one' to 'exactly one' via inclusion-exclusion",
-      "startLine": 212,
+      "title": "Part VII: Related Results and Ford's Distribution Function",
+      "summary": "Connects Erdős Problem #692 to related divisor-distribution problems (notably Erdős Problem #446), then defines `fordDistribution(x,y,z) = \\#\\{n \\leq x : \\exists d \\mid n,\\; y < d < z\\}$ — Ford's function $H(x,y,z)$ — whose oscillation links 'at least one divisor in $(n,m)$' to 'exactly one' via inclusion-exclusion",
+      "startLine": 201,
       "endLine": 219,
       "mathContext": "Ford: $\\\\Phi(x,y,z) = \\\\#\\\\{n \\\\leq x : \\\\exists d \\\\mid n,; y < d \\\\leq z\\\\}$. The distribution of divisors in intervals is a rich and well-studied topic."
     },
     {
+      "id": "physical-interpretation",
+      "title": "Part VIII: Physical Interpretation",
+      "summary": "Explains in commentary (docstring at lines 221–236) why unimodality of $m \\mapsto \\delta_1(n,m)$ fails: as $m$ grows, more divisors become candidates for the interval $(n,m)$ (raising $\\delta_1$) but integers also become more likely to have multiple divisors there (lowering $\\delta_1$); these competing effects produce oscillations rather than a single peak. No declaration is introduced — this section is exposition.",
+      "startLine": 221,
+      "endLine": 236,
+      "mathContext": "The 'exactly one divisor' density $\\\\delta_1$ is non-monotone because adding interval width both admits new divisors and converts single-divisor integers into multiple-divisor ones; the balance shifts irregularly, the mechanism behind Cambie's superpolynomially many local maxima."
+    },
+    {
       "id": "main-results",
       "title": "Main Summary Theorems",
-      "summary": "`erdos_692` combines the upper bound with Cambie's disproof via `constructor`; `erdos_692_status` records $\\neg\\,\\text{erdosUnimodalityQuestion}\\,3$ resolving a 39-year-old problem",
-      "startLine": 263,
+      "summary": "Part IX gathers the resolution of Erdős Problem #692: a summary docstring (lines 238–262) recaps the DISPROVED status, then `erdos_692` combines the upper bound with Cambie's disproof via `constructor`, and `erdos_692_status` records $\\neg\\,\\text{erdosUnimodalityQuestion}\\,3$ — resolving a 39-year-old problem",
+      "startLine": 238,
       "endLine": 279,
       "mathContext": "DISPROVED (Cambie 2025). The density $\\\\delta_1(n,m)$ oscillates with super-polynomially many local maxima. Combined with Erdos upper bound $\\\\delta_1 < 1$."
     }


### PR DESCRIPTION
## Summary
Gallery section metadata for **erdos-692** (Erdős's divisor-interval unimodality problem, disproved by Cambie 2025) had drifted away from the `## Part` banners in `Proofs/Erdos692Problem.lean`:

- **Part VIII "Physical Interpretation"** (lines 221–236) had **no section** — the exposition on why $\delta_1(n,m)$ fails to be unimodal was invisible in the gallery nav.
- **"Main Summary Theorems"** began at line **263**, leaving the **Part IX banner** and its summary docstring (238–262) uncovered.
- **Part VII** banner + the Erdős #446 cross-reference (201–210) sat just outside the "Ford's Distribution Function" section.

## Changes (meta-only, build-free)
- Extend `ford-distribution` to start at line **201** (Part VII banner) and retitle to "Part VII: Related Results and Ford's Distribution Function"; summary now notes the #446 connection.
- Add new section `physical-interpretation` (**Part VIII**, 221–236), marked as exposition (no declaration introduced).
- Start `main-results` at **238** so the Part IX banner and the DISPROVED-status summary docstring are covered.

Section count 12 → 13; all sections remain in-bounds (file is 281 lines) and the tail is now contiguous across Parts VII–IX. No Lean source changed; `axiomCount`/`status` untouched.

## Test plan
- [x] `jq empty` validates the edited meta.json
- [x] All section ranges verified against actual banner/decl line numbers in the source
- [x] Section keys remain uniform (id, title, summary, startLine, endLine, mathContext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)