### PR TITLE
research(divisibility-rules): cover Part IX verification examples in final section (range fix)

### DIFF
--- a/src/data/proofs/divisibility-rules/meta.json
+++ b/src/data/proofs/divisibility-rules/meta.json
@@ -111,9 +111,9 @@
     {
       "id": "section-verification",
       "title": "Parts IX–X: Verification Examples and Master Theorem",
-      "startLine": 384,
+      "startLine": 342,
       "endLine": 392,
-      "summary": "The rules_verification master theorem bundles 11 concrete divisibility facts in a single conjunction, all proved by native_decide, serving as a machine-checked sanity check for the entire formalization."
+      "summary": "Part IX exercises every rule on concrete numbers (divisibility by 2, 4, 5, 6, 8, 7, 3, 15, 12, 30), each discharged by rewriting with the corresponding `*_dvd_iff` lemma and `native_decide`; Part X's `rules_verification` master theorem then bundles 11 of these facts into a single conjunction, serving as a machine-checked sanity check for the entire formalization."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
In **divisibility-rules**, the final gallery section "Parts IX–X: Verification Examples and Master Theorem" began at line **384** — covering only Part X's `rules_verification` master theorem. Part IX's concrete verification examples (lines **343–378**, ~30 lines testing divisibility by 2, 4, 5, 6, 7, 8, 3, 15, 12, 30) fell **outside every section** and were invisible in the gallery nav, despite the section title explicitly naming Part IX.

## Change (meta-only, build-free)
- Move the section's `startLine` from 384 → **342** (the Part IX banner), so it now spans both Part IX (examples) and Part X (master theorem).
- Expand the summary to describe the example battery, not just the master theorem.

The section is now contiguous with Part VIII (319–341); all ranges remain in-bounds (file is 392 lines). No Lean source changed.

## Test plan
- [x] `jq empty` validates the edited meta.json
- [x] Part IX banner (343) and examples confirmed against source line numbers
- [x] Section keys unchanged (id, title, startLine, endLine, summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)