### PR TITLE
research(erdos-1061): realign drifted gallery sections to Part banners (10->14)

### DIFF
--- a/src/data/proofs/erdos-1061/meta.json
+++ b/src/data/proofs/erdos-1061/meta.json
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 380,
-    "assumptions": "No axioms. 0 sorries. The main open conjecture (asymptotic count ~ cx) is not asserted \u2014 the file proves structural results: the infinite sigma(a)+sigma(2a)=sigma(3a) family for a coprime to 6, and consequences.",
+    "assumptions": "No axioms. 0 sorries. The main open conjecture (asymptotic count ~ cx) is not asserted — the file proves structural results: the infinite sigma(a)+sigma(2a)=sigma(3a) family for a coprime to 6, and consequences.",
     "theoremCount": 48,
     "definitionCount": 5
   },
@@ -66,7 +66,7 @@
     "historicalContext": "**Erdos Problem #1061**\n\nThis problem appears as Problem B15 in Richard Guy's celebrated collection \"Unsolved Problems in Number Theory\" (2004 edition), attributed to Erdos.\n\n**The Question:**\nThe sum of divisors function sigma(n) is one of the most studied arithmetic functions. This problem explores when the additive equation sigma(a) + sigma(b) = sigma(a + b) holds.\n\n**Mathematical Context:**\nUnlike many arithmetic functions, sigma is neither subadditive nor superadditive in general. The equation sigma(a) + sigma(b) = sigma(a + b) represents a delicate balance where the divisor structure of a + b relates precisely to the divisors of a and b.\n\n**Current Status:**\nThis problem remains OPEN. The question of whether the count of solutions grows linearly (with density c > 0) or has some other asymptotic behavior has not been resolved.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet S(x) count the number of ordered pairs (a, b) of positive integers with:\n1. a + b <= x\n2. sigma(a) + sigma(b) = sigma(a + b)\n\nwhere sigma is the sum of divisors function.\n\n**Question:** Is S(x) ~ c * x for some constant c > 0?\n\nIn other words, does the number of solutions grow linearly with x, suggesting a positive density of solutions among all pairs?\n\n**Known Solutions:**\n- (1, 2): sigma(1) + sigma(2) = 1 + 3 = 4 = sigma(3)\n- (2, 1): by symmetry\n\n**Related OEIS:** A110177 lists n for which such a decomposition exists.",
     "text": "How many ordered pairs (a,b) satisfy sigma(a)+sigma(b)=sigma(a+b) with a+b<=x? Is this count asymptotic to cx for some c>0?",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Functions:** Define sigma(n) as the sum over n.divisors\n\n2. **Solution Predicate:** isAdditiveDivisorPair a b captures when the equation holds\n\n3. **Counting Function:** S(x) counts pairs via Finset.filter\n\n4. **Verified Examples:** Use native_decide to check small cases\n\n5. **Asymptotic Question:** Formalize hasLinearGrowth using Filter.Tendsto\n\n6. **Open Problem:** Mark erdos_1061_open as an axiom placeholder\n\nSince this is an open problem, we cannot prove the main conjecture, but we establish the framework and verify known facts.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Functions:** Define sigma(n) as the sum over n.divisors\n\n2. **Solution Predicate:** isAdditiveDivisorPair a b captures when the equation holds\n\n3. **Counting Function:** S(x) counts pairs via Finset.filter\n\n4. **Verified Examples:** Use native_decide to check small cases\n\n5. **Asymptotic Question:** Formalize hasLinearGrowth using Filter.Tendsto\n\n6. **Open Problem:** State the asymptotic dichotomy hasLinearGrowth via excluded middle (linear_growth_or_not); the conjecture itself is left unresolved.\n\nSince this is an open problem, we cannot prove the asymptotic conjecture, but we establish the framework, prove the coprime-to-6 and prime solution families, and verify known facts -- with 0 axioms and 0 sorries.",
     "keyInsights": [
       "**Solution Structure:** The equation sigma(a) + sigma(b) = sigma(a + b) probes how divisibility interacts with addition",
       "**Known Solutions:** (1, 2) and (2, 1) give S(x) >= 2 for x >= 3",
@@ -81,84 +81,116 @@
   },
   "sections": [
     {
-      "id": "sum-of-divisors",
-      "title": "Sum of Divisors Function",
-      "summary": "Definition of sigma(n) and basic values",
-      "startLine": 36,
-      "endLine": 67,
-      "mathContext": "Formal definition: Definition of sigma(n) and basic values"
+      "id": "overview",
+      "title": "Overview: Erdős Problem #1061",
+      "summary": "Problem statement: how many ordered solutions to σ(a)+σ(b)=σ(a+b) with a+b≤x, and is the count asymptotic to c·x? Lists the key results proved in the file (general coprime-to-6 family, prime specialization, infinitude, symmetry, non-solution criterion) and the unformalized computational data.",
+      "startLine": 1,
+      "endLine": 43,
+      "mathContext": "Problem context: Erdős #1061 (Guy B15), status OPEN; file proves several structural facts with 0 axioms, 0 sorries."
     },
     {
-      "id": "additive-equation",
-      "title": "The Additive Divisor Equation",
-      "summary": "Definition of isAdditiveDivisorPair and additiveDivisorPairs set",
-      "startLine": 68,
-      "endLine": 88,
-      "mathContext": "Formal definition: Definition of isAdditiveDivisorPair and additiveDivisorPairs set"
+      "id": "part-i-sigma",
+      "title": "Part I: The Sum of Divisors Function",
+      "summary": "Concrete values of σ via native_decide (σ1=1, σ2=3, σ3=4, …) and sigma_prime': σ(p)=p+1 for prime p.",
+      "startLine": 44,
+      "endLine": 66,
+      "mathContext": "Mathematical content: basic σ values and the prime formula σ(p)=p+1."
     },
     {
-      "id": "counting-function",
-      "title": "The Counting Function S(x)",
-      "summary": "Definition of S(x) and base cases S(0)=0, S(1)=0",
-      "startLine": 89,
-      "endLine": 114,
-      "mathContext": "Formal definition: Definition of S(x) and base cases S(0)=0, S(1)=0"
+      "id": "part-ii-equation",
+      "title": "Part II: The Additive Divisor Equation",
+      "summary": "Definitions IsAdditiveDivisorPair a b (σ(a)+σ(b)=σ(a+b)) and the solution set additiveDivisorPairs.",
+      "startLine": 67,
+      "endLine": 78,
+      "mathContext": "Formal definition: IsAdditiveDivisorPair and additiveDivisorPairs."
     },
     {
-      "id": "known-solutions",
-      "title": "Known Solutions",
-      "summary": "Verified examples: (1,2), (2,1) are solutions; many pairs are not",
-      "startLine": 115,
-      "endLine": 176,
-      "mathContext": "Mathematical content: Verified examples: (1,2), (2,1) are solutions; many pairs are not"
+      "id": "part-iii-known-solutions",
+      "title": "Part III: Known Solutions",
+      "summary": "Verified concrete solutions ((1,2),(2,1),(4,5),(5,10),(7,14),(2,6),(2,8),(11,22)) and non-solutions ((1,1),(2,2)); σ is neither subadditive nor superadditive.",
+      "startLine": 79,
+      "endLine": 120,
+      "mathContext": "Mathematical content: explicit solution and non-solution examples; σ_not_subadditive / σ_not_superadditive."
     },
     {
-      "id": "structure-theorems",
-      "title": "Structure Theorems",
-      "summary": "Non-subadditivity and non-superadditivity of sigma",
-      "startLine": 177,
-      "endLine": 201,
-      "mathContext": "Mathematical content: Non-subadditivity and non-superadditivity of sigma"
+      "id": "part-iv-general-family",
+      "title": "Part IV: General Structural Theorem",
+      "summary": "sigma_add_eq_coprime6: σ(a)+σ(2a)=σ(3a) for every a coprime to 6 (via σ(2a)=3σ(a), σ(3a)=4σ(a)); hence (a,2a) and its mirror (2a,a) are solutions.",
+      "startLine": 121,
+      "endLine": 172,
+      "mathContext": "Mathematical content: the coprime-to-6 family solution_coprime6 and its symmetric form."
     },
     {
-      "id": "asymptotic-question",
-      "title": "Asymptotic Question",
-      "summary": "hasLinearGrowth and isAsymptoticToLinear formulations",
-      "startLine": 202,
-      "endLine": 227,
-      "mathContext": "Mathematical content: hasLinearGrowth and isAsymptoticToLinear formulations"
+      "id": "part-iv-b-prime",
+      "title": "Part IV-b: Prime Specialization",
+      "summary": "sigma_add_eq_of_prime and solution_prime_2p: (p,2p) is a solution for every prime p≥5; infinitely_many_solutions follows.",
+      "startLine": 173,
+      "endLine": 209,
+      "mathContext": "Mathematical content: prime specialization of the general family and infinitude of solutions."
     },
     {
-      "id": "bounds",
-      "title": "Bounds and Estimates",
-      "summary": "Lower bound S(x)>=2 for x>=3, upper bound S(x)<=x^2/4",
-      "startLine": 228,
-      "endLine": 251,
-      "mathContext": "Bound: Lower bound S(x)>=2 for x>=3, upper bound S(x)<=x^2/4"
+      "id": "part-iv-c-applications",
+      "title": "Part IV-c: Concrete Applications of the General Family",
+      "summary": "Worked instances from the general family: (25,50), (35,70), (49,98) are solutions.",
+      "startLine": 210,
+      "endLine": 226,
+      "mathContext": "Mathematical content: concrete applications solution_25_50, solution_35_70, solution_49_98."
     },
     {
-      "id": "open-problem",
-      "title": "The Open Problem",
-      "summary": "Erdos 1061 statement as an axiom placeholder",
-      "startLine": 252,
-      "endLine": 279,
-      "mathContext": "Axiomatized: Erdos 1061 statement as an axiom placeholder"
+      "id": "part-v-counting",
+      "title": "Part V: The Counting Function S(x)",
+      "summary": "noncomputable definition of S(x) counting ordered pairs (a,b) with a+b≤x that solve the equation; S_zero (S 0 = 0) and S_monotone (x≤y ⟹ S x ≤ S y).",
+      "startLine": 227,
+      "endLine": 249,
+      "mathContext": "Formal definition: S(x) and its monotonicity; S(0)=0."
     },
     {
-      "id": "oeis",
-      "title": "Related OEIS Sequence",
-      "summary": "A110177: sums n with sigma(n) = sigma(a) + sigma(n-a)",
-      "startLine": 280,
-      "endLine": 305,
-      "mathContext": "Mathematical content: A110177: sums n with sigma(n) = sigma(a) + sigma(n-a)"
+      "id": "part-vi-oeis",
+      "title": "Part VI: OEIS A110177",
+      "summary": "Definition of A110177 (n with σ(n)=σ(a)+σ(n−a) for some 0<a<n); membership of 3,8,9,10,15,21; three_p_in_A110177 and three_a_in_A110177 give whole families in the sequence.",
+      "startLine": 250,
+      "endLine": 289,
+      "mathContext": "Mathematical content: A110177 set and its membership theorems."
+    },
+    {
+      "id": "part-vi-a-symmetry",
+      "title": "Part VI-a: Symmetry",
+      "summary": "solution_symmetric: if (a,b) is an additive divisor pair then so is (b,a).",
+      "startLine": 290,
+      "endLine": 301,
+      "mathContext": "Mathematical content: symmetry of the solution relation."
+    },
+    {
+      "id": "part-vi-b-non-solutions",
+      "title": "Part VI-b: Non-Solution Families",
+      "summary": "not_solution_of_sum_prime / not_additive_pair_of_sum_prime: if p, q, and p+q are all prime then (p,q) is not a solution.",
+      "startLine": 302,
+      "endLine": 326,
+      "mathContext": "Mathematical content: a non-solution criterion for prime pairs with prime sum."
+    },
+    {
+      "id": "part-vi-c-lower-bound",
+      "title": "Part VI-c: Lower Bound from Prime Family",
+      "summary": "prime_solution_counted: each prime p in [5, x/3] yields a pair (p,2p) counted by S(x), giving a lower bound on the counting function.",
+      "startLine": 327,
+      "endLine": 347,
+      "mathContext": "Mathematical content: prime family contributes a counted lower bound to S(x)."
+    },
+    {
+      "id": "part-vii-open-problem",
+      "title": "Part VII: The Open Problem",
+      "summary": "hasLinearGrowth: ∃ c>0 with S(x)/x → c; linear_growth_or_not states the dichotomy via excluded middle — the asymptotic question itself remains open.",
+      "startLine": 348,
+      "endLine": 358,
+      "mathContext": "Open problem: the linear-growth asymptotic for S(x); stated, not resolved."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_1061_summary combining verified facts",
-      "startLine": 306,
+      "summary": "erdos_1061_summary bundles the proved facts: (1,2) and (2,1) are solutions, 3 ∈ A110177, and there are infinitely many solutions.",
+      "startLine": 359,
       "endLine": 380,
-      "mathContext": "Mathematical content: erdos_1061_summary combining verified facts"
+      "mathContext": "Mathematical content: erdos_1061_summary combining the verified results."
     }
   ],
   "conclusion": {
@@ -167,7 +199,7 @@
     "openQuestions": [
       "Does S(x) grow linearly, i.e., is there c > 0 with S(x) ~ cx?",
       "What is the density of solutions among pairs with a + b = n for fixed n?",
-      "Are there infinitely many solutions beyond (1,2) and (2,1)?",
+      "Beyond the proved (a,2a) family for a coprime to 6, what other infinite families of solutions exist?",
       "Can the equation hold for coprime a, b?",
       "What is the relationship to perfect numbers and amicable numbers?"
     ]
@@ -175,27 +207,27 @@
   "crossReferences": [
     {
       "relationship": "sibling",
-      "description": "Both problems study equations involving \u03c3(k) and counting solution pairs; #1060 asks how many k satisfy k\u00b7\u03c3(k) = n while #1061 asks about pairs with \u03c3(a)+\u03c3(b) = \u03c3(a+b)",
+      "description": "Both problems study equations involving σ(k) and counting solution pairs; #1060 asks how many k satisfy k·σ(k) = n while #1061 asks about pairs with σ(a)+σ(b) = σ(a+b)",
       "targetId": "erdos-1060"
     },
     {
       "relationship": "related",
-      "description": "Unitary perfect numbers satisfy \u03c3*(n) = 2n; the additive divisor equation \u03c3(a)+\u03c3(b) = \u03c3(a+b) belongs to the same family of problems probing when \u03c3 achieves prescribed values",
+      "description": "Unitary perfect numbers satisfy σ*(n) = 2n; the additive divisor equation σ(a)+σ(b) = σ(a+b) belongs to the same family of problems probing when σ achieves prescribed values",
       "targetId": "erdos-1052"
     },
     {
       "relationship": "related",
-      "description": "k-perfect numbers satisfy \u03c3(n) = k\u00b7n; both problems ask about density and growth rates of sets defined by divisor-sum equalities",
+      "description": "k-perfect numbers satisfy σ(n) = k·n; both problems ask about density and growth rates of sets defined by divisor-sum equalities",
       "targetId": "erdos-1053"
     },
     {
       "relationship": "related",
-      "description": "Abundancy (\u03c3(n)/n) is central to both problems; #277 connects covering systems to \u03c3-values while #1061 probes additive identities of \u03c3",
+      "description": "Abundancy (σ(n)/n) is central to both problems; #277 connects covering systems to σ-values while #1061 probes additive identities of σ",
       "targetId": "erdos-277"
     },
     {
       "relationship": "related",
-      "description": "Both involve analytic properties of the sigma function; #250 studies irrationality of \u03a3 \u03c3(n)/n^s while #1061 studies additive identities of \u03c3 at consecutive integers",
+      "description": "Both involve analytic properties of the sigma function; #250 studies irrationality of Σ σ(n)/n^s while #1061 studies additive identities of σ at consecutive integers",
       "targetId": "erdos-250"
     },
     {
@@ -212,14 +244,14 @@
       "title": "Unsolved Problems in Number Theory, 3rd ed., Problem B15",
       "venue": "Springer",
       "year": "2004",
-      "description": "Original source recording the problem: how many ordered pairs (a,b) satisfy \u03c3(a)+\u03c3(b)=\u03c3(a+b) with a+b \u2264 x?"
+      "description": "Original source recording the problem: how many ordered pairs (a,b) satisfy σ(a)+σ(b)=σ(a+b) with a+b ≤ x?"
     },
     {
       "authors": [
-        "Paul Erd\u0151s",
+        "Paul Erdős",
         "Carl Pomerance"
       ],
-      "title": "On the normal number of prime factors of \u03c6(n)",
+      "title": "On the normal number of prime factors of φ(n)",
       "venue": "Rocky Mountain Journal of Mathematics",
       "year": "1985",
       "description": "Establishes analytic techniques for counting solutions to arithmetic-function equations that underpin the linear-growth question in #1061"
@@ -232,7 +264,7 @@
       "title": "On additive properties of the sum-of-divisors function",
       "venue": "Acta Arithmetica",
       "year": "1975",
-      "description": "Early study of when \u03c3(a)+\u03c3(b) can equal \u03c3(n) for various n; context for the Erd\u0151s problem"
+      "description": "Early study of when σ(a)+σ(b) can equal σ(n) for various n; context for the Erdős problem"
     },
     {
       "authors": [
@@ -242,7 +274,7 @@
       "venue": "OEIS Foundation",
       "year": "2005",
       "url": "https://oeis.org/A110177",
-      "description": "Catalogs integers n = a+b for which \u03c3(a)+\u03c3(b) = \u03c3(a+b); the OEIS sequence directly referenced in the Lean formalization"
+      "description": "Catalogs integers n = a+b for which σ(a)+σ(b) = σ(a+b); the OEIS sequence directly referenced in the Lean formalization"
     },
     {
       "authors": [


### PR DESCRIPTION
Build-free gallery metadata realign. Rebuilt 10 drifted/mislabeled sections into 14 contiguous sections aligned to the file's `## Part` banners (Overview + Parts I-VII incl. IV-b/c and VI-a/b/c + Summary), lines 1-380. Summaries/mathContext rewritten from actual declarations (prior titles wrong: 'Counting Function S(x)' sat on Part III, 'Bounds and Estimates' on Part V, 'Asymptotic Question' cited nonexistent isAsymptoticToLinear). De-staled proofStrategy (claimed an erdos_1061_open axiom placeholder though file has 0 axioms / verified) and an openQuestion the file already proves (infinitely_many_solutions). No Lean source touched; lineCount 380, 0 sorries, 0 axioms confirmed.