### PR TITLE
research(erdos-401): realign drifted sections/annotations (10→12) + de-phantom meta

### DIFF
--- a/src/data/proofs/erdos-401/annotations.json
+++ b/src/data/proofs/erdos-401/annotations.json
@@ -22,12 +22,12 @@
     "id": "ann-e401-primes",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 47,
-      "endLine": 52
+      "startLine": 60,
+      "endLine": 71
     },
     "type": "definition",
-    "title": "Prime Infrastructure",
-    "content": "**noncomputable def nthPrime (r : ℕ)**: ℕ\n  The r-th prime (0-indexed: p₀ = 2, p₁ = 3, ...)\n  Uses Nat.nth from Mathlib.\n\n**noncomputable def primorialPow (r n : ℕ)**: ℕ\n  ∏ i ∈ range r, (nthPrime i)^n\n  = 2ⁿ · 3ⁿ · 5ⁿ · ... · pᵣⁿ\n\nThis is the extra factor that distinguishes #401 from simpler factorial problems.",
+    "title": "Prime Infrastructure (Part I)",
+    "content": "**def nthPrime (r : ℕ) : ℕ** — the r-th prime (0-indexed: p₀ = 2, p₁ = 3, ...), via Mathlib's `Nat.nth Nat.Prime`.\n\n**def primorial (r : ℕ) : ℕ** — ∏ i ∈ range r, nthPrime i, the product of the first r primes.\n\n**def primorialPow (r n : ℕ) : ℕ** — ∏ i ∈ range r, (nthPrime i)^n = 2ⁿ · 3ⁿ · ... · pᵣⁿ.\n\nThis powered primorial is the extra factor that distinguishes #401 from simpler factorial problems.",
     "mathContext": "The primorial (product of first r primes) appears throughout number theory. Here we need the n-th power of each prime, giving massive additional divisibility.",
     "significance": "key",
     "relatedConcepts": [
@@ -41,12 +41,12 @@
     "id": "ann-e401-divides",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 57,
-      "endLine": 58
+      "startLine": 138,
+      "endLine": 177
     },
     "type": "definition",
-    "title": "Factorial Divisibility Predicate",
-    "content": "**def FactorialDivides (a₁ a₂ n r : ℕ)**: Prop\n  (a₁! · a₂!) ∣ (n! · primorialPow r n)\n\nThis is the central divisibility condition. We ask: given this condition, how large can a₁ + a₂ be relative to n?\n\nThe extra factor primorialPow(r,n) = 2ⁿ3ⁿ...pᵣⁿ provides additional prime powers that can satisfy divisibility for larger a₁, a₂.",
+    "title": "Factorial Divisibility Predicate (Part IV)",
+    "content": "**def FactorialDivides (a₁ a₂ n r : ℕ) : Prop** — (a₁! · a₂!) ∣ (n! · primorialPow r n).\n\nThe central divisibility condition: given it, how large can a₁ + a₂ be relative to n? The extra factor primorialPow(r,n) supplies additional prime powers.\n\nProved structural lemmas: classical divisibility implies it, symmetry in a₁,a₂, the trivial (a,0) case, reduction to classical divisibility at r=0 (`factorialDivides_zero_r`), and monotonicity in r (`factorialDivides_mono_r`).",
     "mathContext": "Factorial divisibility constraints are central to many Erdős problems. The divisibility a₁!a₂! | m determines which pairs (a₁, a₂) are valid.",
     "significance": "key",
     "relatedConcepts": [
@@ -60,12 +60,12 @@
     "id": "ann-e401-baseline",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 64,
-      "endLine": 67
+      "startLine": 183,
+      "endLine": 188
     },
     "type": "concept",
-    "title": "Erdős-Graham Baseline",
-    "content": "**axiom erdos_graham_baseline**:\n  ∃ C > 0, ∀ n a₁ a₂, n > 0 → a₁!a₂! | n! →\n  (a₁ + a₂) ≤ n + C · log(n)\n\n**Key insight**: Without the extra primorial factor, we can NEVER exceed n + O(log n).\n\nThis is the baseline that Problem #401 asks us to exceed by using the primorial factors.",
+    "title": "Erdős-Graham Baseline (Part V)",
+    "content": "**axiom erdos_graham_baseline**:\n  ∃ C > 0, ∀ n a₁ a₂, n > 0 → a₁!a₂! | n! →\n  (a₁ + a₂ : ℝ) ≤ n + C · log(n)\n\n**Key insight**: Without the extra primorial factor, we can NEVER exceed n + O(log n).\n\nThis is the baseline that Problem #401 asks us to exceed by using the primorial factors.",
     "mathContext": "This bound from Erdős-Graham (1980) shows that pure factorial divisibility is quite restrictive. The logarithmic bound is tight.",
     "significance": "key",
     "relatedConcepts": [
@@ -79,16 +79,16 @@
     "id": "ann-e401-conjecture",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 72,
-      "endLine": 81
+      "startLine": 194,
+      "endLine": 201
     },
     "type": "definition",
-    "title": "The Conjecture",
-    "content": "**def TendsToInfty (f : ℕ → ℝ)**: Prop\n  ∀ M, ∃ r₀, ∀ r ≥ r₀, f(r) ≥ M\n\n**def Erdos401Conjecture**: Prop\n  ∃ f, TendsToInfty f ∧\n  ∀ r, ∃ᶠ n in atTop, ∃ a₁ a₂,\n    FactorialDivides a₁ a₂ n r ∧\n    (a₁ + a₂) > n + f(r) · log(n)\n\n**In words**: Can we find f(r) → ∞ and, for each r, infinitely many n with a₁ + a₂ exceeding n + f(r)·log(n)?",
+    "title": "The Conjecture (Part VI)",
+    "content": "**def Erdos401Conjecture : Prop**\n  ∃ f : ℕ → ℝ, Filter.Tendsto f atTop atTop ∧\n  ∀ r, ∃ᶠ n in atTop, ∃ a₁ a₂,\n    FactorialDivides a₁ a₂ n r ∧\n    (a₁ + a₂ : ℝ) > n + f(r) · log(n)\n\nThe divergence f(r) → ∞ is expressed directly as `Filter.Tendsto f atTop atTop`.\n\n**In words**: Can we find f(r) → ∞ and, for each r, infinitely many n with a₁ + a₂ exceeding n + f(r)·log(n)?",
     "mathContext": "The 'infinitely many n' quantifier (∃ᶠ n in atTop) is crucial. The strong version with 'for all large n' is false!",
     "significance": "key",
     "relatedConcepts": [
-      "tends-to-infinity",
+      "tendsto-atTop",
       "frequently",
       "conjecture"
     ],
@@ -98,12 +98,12 @@
     "id": "ann-e401-proof",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 96,
-      "endLine": 99
+      "startLine": 203,
+      "endLine": 207
     },
     "type": "concept",
-    "title": "Barreto-Leeham Proof",
-    "content": "**axiom barreto_leeham_401**: Erdos401Conjecture\n\n**theorem erdos_401_proved**: Erdos401Conjecture := barreto_leeham_401\n\nBarreto and Leeham (2026) proved YES using the same construction as Problem #729.\n\n**Key idea**: Choose n related to primorial structure, set a₂ ≈ n/2 and a₁ ≈ n/2 + excess. The excess grows unboundedly as r increases.\n\n**Technique**: AI-assisted proof via ChatGPT, building on combinatorial number theory.",
+    "title": "Barreto-Leeham Result (Part VI)",
+    "content": "**axiom barreto_leeham_401 : Erdos401Conjecture**\n\n**theorem erdos_401_proved : Erdos401Conjecture := barreto_leeham_401**\n\nBarreto and Leeham (2026) proved YES using the same construction as Problem #729. The conjecture's truth is recorded as an axiom and re-exported as the headline theorem.\n\n**Key idea**: the primorial power factors give enough room in the factorial divisibility to push a₁ + a₂ beyond n by an amount growing with r.",
     "mathContext": "This is one of several Erdős problems solved via AI assistance. The same construction works for both #401 and #729.",
     "significance": "key",
     "relatedConcepts": [
@@ -117,12 +117,12 @@
     "id": "ann-e401-counterexample",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 108,
-      "endLine": 115
+      "startLine": 213,
+      "endLine": 222
     },
     "type": "concept",
-    "title": "Sothanaphan Counterexample",
-    "content": "**def Erdos401Strong**: Prop\n  Same as Erdos401Conjecture but with '∀ n ≥ N₀' instead of '∃ᶠ n'\n\n**axiom sothanaphan_counterexample**: ¬Erdos401Strong\n\n**Counterexample**: Take n = p_{r+1}^k - 1 (one less than a prime power).\n\nFor such n, the divisibility constraint forces a₁ + a₂ ≤ n + 2·p_{r+1}, which is bounded independent of how large k is.\n\nThis shows the quantifier matters: 'infinitely many n' vs 'all large n' give different answers!",
+    "title": "Sothanaphan Counterexample (Part VII)",
+    "content": "**def Erdos401Strong : Prop** — as Erdos401Conjecture but with '∀ n ≥ N₀' replacing '∃ᶠ n'.\n\n**axiom sothanaphan_counterexample : ¬Erdos401Strong**\n\n**Counterexample**: take n = p_{r+1}^k − 1 (one less than a prime power); such n force bounded excess, independent of k.\n\nThis shows the quantifier matters: 'infinitely many n' vs 'all large n' give different answers!",
     "mathContext": "This is a subtle point about quantifiers. The 'for all large n' version fails because some n have special structure that limits the excess.",
     "significance": "key",
     "relatedConcepts": [
@@ -133,15 +133,53 @@
     "prerequisites": []
   },
   {
+    "id": "ann-e401-consequences",
+    "proofId": "erdos-401",
+    "range": {
+      "startLine": 228,
+      "endLine": 248
+    },
+    "type": "concept",
+    "title": "Consequences: Unbounded Excess (Part VIII)",
+    "content": "Theorems proved from the axioms above:\n\n**theorem unbounded_excess** — for every bound C there is an r with a₁ + a₂ > n + C·log(n) for infinitely many n; obtained by choosing r where f(r) ≥ max(C,0) using `Filter.tendsto_atTop` and `Real.log_natCast_nonneg`.\n\n**theorem erdos_401_complete** — the full resolution: `Erdos401Conjecture ∧ ¬Erdos401Strong`, i.e. YES for infinitely many n but NO for all large n.",
+    "mathContext": "These corollaries combine the Barreto-Leeham result with the Sothanaphan counterexample to give the complete, quantifier-sensitive answer.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unbounded-excess",
+      "tendsto",
+      "complete-resolution"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e401-legendre",
+    "proofId": "erdos-401",
+    "range": {
+      "startLine": 254,
+      "endLine": 276
+    },
+    "type": "concept",
+    "title": "Legendre's Formula Connection (Part IX)",
+    "content": "The tool underlying the Erdős-Graham baseline is Legendre's formula ν_p(n!) = (n − s_p(n))/(p−1):\n\n**theorem legendre_formula** — (p−1)·ν_p(n!) = n − (digits p n).sum, proved from Mathlib's `Nat.Prime.sub_one_mul_multiplicity_factorial`.\n\n**theorem padic_valuation_factorial_bound** — there exists v with p^v | n! and v ≤ n/(p−1).",
+    "mathContext": "Legendre's formula controls the p-adic valuation of factorials via base-p digit sums; it is what makes the Erdős-Graham logarithmic bound provable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "legendre-formula",
+      "p-adic-valuation",
+      "digit-sum"
+    ],
+    "prerequisites": []
+  },
+  {
     "id": "ann-e401-g2",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 121,
-      "endLine": 130
+      "startLine": 281,
+      "endLine": 292
     },
-    "type": "concept",
-    "title": "The g₂ Function",
-    "content": "**noncomputable def g₂ (n : ℕ)**: ℝ\n  sSup { a₁ + a₂ - n | a₁!a₂! | n! }\n\nThe maximum excess when factorials divide n! (no extra factors).\n\n**axiom g2_log_bound**: ∃ C > 0, ∀ n > 1, g₂(n) ≤ C · log(n)\n\n**noncomputable def g₂_modified (n r : ℕ)**: ℝ\n  sSup { a₁ + a₂ - n | FactorialDivides a₁ a₂ n r }\n\nThe modified version with primorial factors - this can exceed C·log(n) by f(r)·log(n).",
+    "type": "definition",
+    "title": "The g₂ Functions (Part X)",
+    "content": "Definitions linking #401 to Problem #400:\n\n**def g₂ (n : ℕ) : ℝ** — sSup { a₁ + a₂ − n | a₁!a₂! | n! }, the maximum excess under classical divisibility.\n\n**def g₂_modified (n r : ℕ) : ℝ** — sSup { a₁ + a₂ − n | FactorialDivides a₁ a₂ n r }, the same excess with the enhanced primorial-factor constraint.\n\nProblem #401 concerns how much faster g₂_modified can grow than the O(log n)-bounded g₂.",
     "mathContext": "The g_k functions from Problem #400 measure the 'excess' possible in factorial divisibility. Problem #401 asks how the modified g₂ behaves.",
     "significance": "key",
     "relatedConcepts": [
@@ -152,59 +190,21 @@
     "prerequisites": []
   },
   {
-    "id": "ann-e401-reformulation",
-    "proofId": "erdos-401",
-    "range": {
-      "startLine": 137,
-      "endLine": 140
-    },
-    "type": "concept",
-    "title": "Reformulation via g₂",
-    "content": "**axiom erdos_401_reformulation**:\n  Erdos401Conjecture ↔\n  ∃ f, TendsToInfty f ∧\n  ∀ r, ∃ᶠ n in atTop, g₂_modified(n,r) > f(r) · log(n)\n\nThis shows #401 asks: can g₂_modified exceed f(r)·log(n) for unbounded f(r)?\n\nThe answer is YES, while for the unmodified g₂, we always have g₂(n) ≤ C·log(n).",
-    "mathContext": "This reformulation makes clear what the primorial factors accomplish: they allow the g-function to grow faster than logarithmically.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "reformulation",
-      "equivalence",
-      "g-function"
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "ann-e401-729",
-    "proofId": "erdos-401",
-    "range": {
-      "startLine": 146,
-      "endLine": 151
-    },
-    "type": "concept",
-    "title": "Connection to Problem #729",
-    "content": "**axiom erdos_729_connection**:\n  Erdos401Conjecture ↔ [equivalent statement for #729]\n\nThe same Barreto-Leeham construction proves both #401 and #729.\n\n**Problem #729** has a slightly different formulation but the underlying mathematics is the same.\n\nBoth problems ask about exceeding logarithmic bounds via careful factorial constructions.",
-    "mathContext": "This connection shows the Erdős problems form a web of related questions. Solving one often illuminates others.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "erdos-729",
-      "connection",
-      "same-construction"
-    ],
-    "prerequisites": []
-  },
-  {
     "id": "ann-e401-summary",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 153,
-      "endLine": 175
+      "startLine": 296,
+      "endLine": 312
     },
     "type": "concept",
-    "title": "Summary and Status",
-    "content": "**Erdős Problem #401: PROVED** (Barreto-Leeham 2026)\n\n**Answer**: YES - such f(r) → ∞ exists.\n\n**Key Results**:\n1. Without extra factors: a₁ + a₂ ≤ n + O(log n) (Erdős-Graham)\n2. With primorial factors: can exceed n + f(r)·log(n) for f(r) → ∞\n3. But NOT for ALL large n - only INFINITELY MANY (Sothanaphan)\n\n**Connections**:\n- Related to Problem #400 (g_k function)\n- Same construction as Problem #729\n- AI-assisted proof via ChatGPT\n\n**Technique**: Careful choice of n exploiting primorial structure.",
+    "title": "Summary and Status (Part XI)",
+    "content": "**Erdős Problem #401: PROVED** (Barreto-Leeham 2026)\n\n**Answer**: YES — such f(r) → ∞ exists.\n\n**Key Results**:\n1. Without extra factors: a₁ + a₂ ≤ n + O(log n) (Erdős-Graham)\n2. With primorial factors: can exceed n + f(r)·log(n) for f(r) → ∞\n3. But NOT for ALL large n — only INFINITELY MANY (Sothanaphan)\n\n**Connections**: related to Problem #400 (g_k function); same construction as Problem #729.\n\n**Axiom budget**: 3 (erdos_graham_baseline, barreto_leeham_401, sothanaphan_counterexample).",
     "mathContext": "This problem illustrates how additional prime power factors can fundamentally change divisibility constraints, and the importance of exact quantifier formulations.",
     "significance": "key",
     "relatedConcepts": [
       "problem-status",
       "proved",
-      "ai-assisted"
+      "axiom-budget"
     ],
     "prerequisites": []
   }

--- a/src/data/proofs/erdos-401/meta.json
+++ b/src/data/proofs/erdos-401/meta.json
@@ -56,13 +56,13 @@
       "Definition of FactorialDivides predicate",
       "Axiom erdos_graham_baseline (a₁ + a₂ ≤ n + O(log n) bound)",
       "Theorem legendre_formula (proved from Mathlib via pow_multiplicity_dvd + sub_one_mul_multiplicity_factorial)",
-      "Definition of TendsToInfty for functions",
-      "Definition of Erdos401Conjecture using Filter.Frequently",
+      "Definition of Erdos401Conjecture using Filter.Tendsto (for f(r) → ∞) and Filter.Frequently",
+      "Theorems unbounded_excess and erdos_401_complete (proved consequences of the axioms)",
       "Axiom barreto_leeham_401 (main proof)",
       "Definition and axiom for Erdos401Strong (the false version)",
       "Axiom sothanaphan_counterexample",
-      "Definition of g₂ and g₂_modified functions",
-      "Connection to Problem #729"
+      "Theorem padic_valuation_factorial_bound (p-adic valuation of n! via Legendre's formula)",
+      "Definition of g₂ and g₂_modified functions"
     ],
     "axiomCount": 3,
     "lineCount": 319,
@@ -74,7 +74,7 @@
     "historicalContext": "This problem comes from Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory'. It is closely related to Problems #400 and #729.\n\n**The g_k Function**: Problem #400 introduced g_k(n), the maximum of (a₁ + ... + a_k) - n subject to a₁!...a_k! | n!. Erdős-Graham showed g_k(n) ≪ log(n).\n\n**The Extra Factors**: Problem #401 asks what happens when we multiply n! by prime powers 2ⁿ3ⁿ...p_rⁿ. These extra factors provide additional 'room' for the factorial divisibility.\n\n**Resolution**: In 2026, Barreto and Leeham proved the answer is YES using AI-assisted methods. Interestingly, Sothanaphan showed that the stronger version (for ALL large n) is FALSE, using the counterexample n = p_{r+1}^k - 1.",
     "problemStatement": "**Erdős Problem #401**: Is there some function $f(r)$ such that $f(r) \\to \\infty$ as $r \\to \\infty$, such that for infinitely many $n$, there exist $a_1, a_2$ with\n$$a_1 + a_2 > n + f(r) \\log n$$\nsuch that $a_1! a_2! \\mid n! \\cdot 2^n \\cdot 3^n \\cdots p_r^n$?\n\n**Answer**: YES (Barreto-Leeham 2026)\n\n**Key Subtlety**: The quantifier 'for infinitely many n' is essential. The version with 'for all large n' is FALSE.\n\n**Counterexample to Strong Version**: Sothanaphan showed that taking $n = p_{r+1}^k - 1$ forces $a_1 + a_2 \\leq n + 2p_{r+1}$, which is bounded.",
     "text": "Does there exist f(r) → ∞ such that for infinitely many n, there exist a₁, a₂ with a₁ + a₂ > n + f(r)·log(n) where a₁!·a₂! | n!·2ⁿ·3ⁿ·...·pᵣⁿ? YES (Barreto-Leeham 2026). The 'for all large n' version is FALSE (Sothanaphan).",
-    "proofStrategy": "The formalization captures both the positive result and the counterexample:\n\n1. **Infrastructure**:\n   - `nthPrime`: The r-th prime via Nat.nth\n   - `primorialPow`: Product 2ⁿ·3ⁿ·...·p_rⁿ\n   - `FactorialDivides`: The central divisibility condition\n\n2. **Baseline**:\n   - `erdos_graham_baseline`: Without extra factors, a₁ + a₂ ≤ n + O(log n)\n\n3. **The Conjecture**:\n   - `TendsToInfty`: f(r) → ∞ as r → ∞\n   - `Erdos401Conjecture`: Existence of such f with infinitely many n\n\n4. **Resolution**:\n   - `barreto_leeham_401`: The main YES result (axiom)\n   - `erdos_401_proved`: The theorem statement\n\n5. **Counterexample**:\n   - `Erdos401Strong`: The false 'for all large n' version\n   - `sothanaphan_counterexample`: Proof it's false",
+    "proofStrategy": "The formalization captures both the positive result and the counterexample:\n\n1. **Infrastructure**:\n   - `nthPrime`: The r-th prime via Nat.nth\n   - `primorialPow`: Product 2ⁿ·3ⁿ·...·p_rⁿ\n   - `FactorialDivides`: The central divisibility condition\n\n2. **Baseline**:\n   - `erdos_graham_baseline`: Without extra factors, a₁ + a₂ ≤ n + O(log n)\n\n3. **The Conjecture**:\n   - `Erdos401Conjecture`: existence of f with `Filter.Tendsto f atTop atTop` (f(r) → ∞) and infinitely many n\n\n4. **Resolution**:\n   - `barreto_leeham_401`: The main YES result (axiom)\n   - `erdos_401_proved`: The theorem statement\n   - `unbounded_excess`, `erdos_401_complete`: proved consequences\n\n5. **Counterexample**:\n   - `Erdos401Strong`: The false 'for all large n' version\n   - `sothanaphan_counterexample`: Proof it's false",
     "keyInsights": [
       "**Quantifier sensitivity**: The problem has different answers depending on 'infinitely many n' vs 'all large n'. This subtlety was clarified through the counterexample.",
       "**Prime power factors matter**: The primorial factors 2ⁿ3ⁿ...p_rⁿ fundamentally change the divisibility landscape, allowing larger a₁ + a₂ values.",
@@ -90,83 +90,99 @@
   "sections": [
     {
       "id": "header",
-      "title": "Problem Overview",
+      "title": "File Header and Problem Statement",
       "startLine": 1,
-      "endLine": 37,
-      "summary": "Problem statement, background, and solution summary.",
-      "mathContext": "Mathematical content: Problem statement, background, and solution summary."
+      "endLine": 56,
+      "summary": "Docstring statement of Erdős Problem #401 (does some f(r)→∞ allow a₁+a₂ > n + f(r)·log n with a₁!·a₂! | n!·2ⁿ3ⁿ⋯pᵣⁿ for infinitely many n?), background tying it to Problem #400's g_k, the YES answer (Barreto–Leeham 2026), the Sothanaphan counterexample to the 'all large n' variant, and references; followed by Mathlib imports, opened namespaces, and the `noncomputable section`/`namespace Erdos401` setup.",
+      "mathContext": "Problem statement, historical background, and the Lean preamble (imports, `open Nat Real BigOperators Finset Filter`, namespace)."
     },
     {
       "id": "primes",
-      "title": "Prime Infrastructure",
-      "startLine": 45,
-      "endLine": 53,
-      "summary": "nthPrime and primorialPow definitions.",
-      "mathContext": "Formal definition: nthPrime and primorialPow definitions."
+      "title": "Part I — Prime Infrastructure",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "Core definitions: `nthPrime r` (the r-th prime via `Nat.nth Nat.Prime`, 0-indexed), `primorial r` (product of the first r primes), and `primorialPow r n` (product of the first r primes each raised to the n-th power, i.e. 2ⁿ3ⁿ⋯pᵣⁿ).",
+      "mathContext": "Definitions of `nthPrime`, `primorial`, and `primorialPow` over `Finset.range`."
+    },
+    {
+      "id": "prime-properties",
+      "title": "Part II — Prime Properties",
+      "startLine": 72,
+      "endLine": 91,
+      "summary": "Basic facts about `nthPrime`, all proved: each value is prime (`nthPrime_prime`), is ≥ 2 (`nthPrime_ge_two`), is positive (`nthPrime_pos`), and the sequence is strictly monotone (`nthPrime_strictMono`).",
+      "mathContext": "Theorems establishing primality, positivity, and strict monotonicity of the prime sequence, derived from `Nat.nth` lemmas on the infinite set of primes."
+    },
+    {
+      "id": "primorial-properties",
+      "title": "Part III — Primorial Properties",
+      "startLine": 92,
+      "endLine": 133,
+      "summary": "Proved properties of the primorial and its powered form: `primorial_zero` (empty product = 1), `primorial_succ` (recursion), `primorial_pos`, `primorial_mono` (monotone), `primorialPow_zero`, and `primorialPow_pos`.",
+      "mathContext": "Positivity, monotonicity, and recursion lemmas for `primorial` and `primorialPow`, proved via `Finset.prod_range_succ` and `Finset.prod_pos`."
     },
     {
       "id": "divides",
-      "title": "Divisibility Predicate",
-      "startLine": 54,
-      "endLine": 59,
-      "summary": "FactorialDivides definition.",
-      "mathContext": "Formal definition: FactorialDivides definition."
+      "title": "Part IV — Divisibility Predicate and Properties",
+      "startLine": 134,
+      "endLine": 178,
+      "summary": "The factorial-divisibility predicate `FactorialDivides a₁ a₂ n r` ((a₁!·a₂!) | (n!·primorialPow r n)) and its proved properties: classical divisibility implies it (`classical_implies_factorialDivides`), symmetry in a₁,a₂, the trivial (a,0) case, reduction to classical divisibility at r=0 (`factorialDivides_zero_r`), and monotonicity in r (`factorialDivides_mono_r`).",
+      "mathContext": "Definition of `FactorialDivides` and structural lemmas (symmetry, r=0 reduction, monotonicity in r) via divisibility transitivity and `Finset.prod_dvd_prod_of_subset`."
     },
     {
       "id": "baseline",
-      "title": "Erdős-Graham Baseline",
-      "startLine": 60,
-      "endLine": 68,
-      "summary": "The O(log n) bound without extra factors.",
-      "mathContext": "The $O($\\log n$)$ bound without extra factors."
+      "title": "Part V — The Erdős–Graham Baseline",
+      "startLine": 179,
+      "endLine": 189,
+      "summary": "The `erdos_graham_baseline` axiom: without the extra prime-power factors, a₁!·a₂! | n! forces a₁+a₂ ≤ n + C·log n for some constant C>0. This O(log n) bound is the baseline that Problem #401 asks whether one can exceed.",
+      "mathContext": "Axiom recording the Erdős–Graham O(log n) excess bound for classical factorial divisibility."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 69,
-      "endLine": 82,
-      "summary": "TendsToInfty and Erdos401Conjecture definitions.",
-      "mathContext": "Formal definition: TendsToInfty and Erdos401Conjecture definitions."
-    },
-    {
-      "id": "proof",
-      "title": "Main Proof",
-      "startLine": 83,
-      "endLine": 100,
-      "summary": "Barreto-Leeham axiom and erdos_401_proved theorem.",
-      "mathContext": "Verified: Barreto-Leeham axiom and erdos_401_proved theorem."
+      "title": "Part VI — The Conjecture and Main Results",
+      "startLine": 190,
+      "endLine": 208,
+      "summary": "The formal conjecture `Erdos401Conjecture` (∃ f→∞ such that for every r, infinitely often there exist a₁,a₂ with FactorialDivides and a₁+a₂ > n + f(r)·log n), the `barreto_leeham_401` axiom asserting its truth, and `erdos_401_proved` discharging the conjecture from that axiom.",
+      "mathContext": "Definition of `Erdos401Conjecture` using `Filter.Tendsto … atTop` and `∃ᶠ … in atTop`; the Barreto–Leeham result recorded as an axiom and re-exported as a theorem."
     },
     {
       "id": "counterexample",
-      "title": "Sothanaphan Counterexample",
-      "startLine": 101,
-      "endLine": 116,
-      "summary": "Erdos401Strong definition and sothanaphan_counterexample.",
-      "mathContext": "Formal definition: Erdos401Strong definition and sothanaphan_counterexample."
+      "title": "Part VII — The Sothanaphan Counterexample",
+      "startLine": 209,
+      "endLine": 223,
+      "summary": "The strengthened 'for all large n' variant `Erdos401Strong` and the `sothanaphan_counterexample` axiom showing it is FALSE — the witness n = p_{r+1}^k − 1 (one less than a prime power) forces bounded excess.",
+      "mathContext": "Definition of `Erdos401Strong` and the axiom `¬Erdos401Strong` recording Sothanaphan's refutation of the uniform variant."
+    },
+    {
+      "id": "consequences",
+      "title": "Part VIII — Consequences",
+      "startLine": 224,
+      "endLine": 249,
+      "summary": "Theorems proved from the axioms above: `unbounded_excess` (for every bound C some r makes a₁+a₂ > n + C·log n infinitely often, via tendsto of f) and `erdos_401_complete` (the full resolution: the conjecture holds while its uniform strengthening fails).",
+      "mathContext": "Proved corollaries combining `erdos_401_proved` and `sothanaphan_counterexample`; uses `Filter.tendsto_atTop` and `Real.log_natCast_nonneg`."
+    },
+    {
+      "id": "legendre",
+      "title": "Part IX — Legendre's Formula Connection",
+      "startLine": 250,
+      "endLine": 276,
+      "summary": "Legendre's formula as the tool underlying the baseline: `legendre_formula` ((p−1)·ν_p(n!) = n − s_p(n), the base-p digit sum) proved from Mathlib's `Nat.Prime.sub_one_mul_multiplicity_factorial`, and `padic_valuation_factorial_bound` giving v ≤ n/(p−1) with p^v | n!.",
+      "mathContext": "Theorems expressing the p-adic valuation of n! via the digit-sum form of Legendre's formula, using `multiplicity` and `pow_multiplicity_dvd`."
     },
     {
       "id": "g-functions",
-      "title": "The g₂ Functions",
-      "startLine": 117,
-      "endLine": 141,
-      "summary": "g₂, g₂_modified, and reformulation.",
-      "mathContext": "Mathematical content: g₂, g₂_modified, and reformulation."
-    },
-    {
-      "id": "connections",
-      "title": "Connection to #729",
-      "startLine": 142,
-      "endLine": 152,
-      "summary": "erdos_729_connection axiom.",
-      "mathContext": "Axiomatized: erdos_729_connection axiom."
+      "title": "Part X — Connection to Problem #400 (g₂ function)",
+      "startLine": 277,
+      "endLine": 293,
+      "summary": "Definitions linking to Problem #400: `g₂ n` (the supremum of a₁+a₂−n over classical divisibility) and `g₂_modified n r` (the same with the enhanced `FactorialDivides` constraint), formalizing the excess functions whose growth the problem concerns.",
+      "mathContext": "Definitions of the excess functions `g₂` and `g₂_modified` as suprema (`sSup`) over factorial-divisibility witness sets."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 153,
+      "title": "Part XI — Summary",
+      "startLine": 294,
       "endLine": 319,
-      "summary": "Problem status and key results.",
-      "mathContext": "Mathematical content: Problem status and key results."
+      "summary": "Closing prose recap: the answer is YES (Barreto–Leeham 2026), the primorial factors supply the extra room, the same construction handles Problem #729, and the uniform variant is false (Sothanaphan); notes the 3-axiom budget and the `#check` verification commands.",
+      "mathContext": "Narrative summary of the result, axiom budget, and key points; final `#check` statements verifying the exported declarations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Build-free gallery-integrity fix for `erdos-401` (Erdős Problem #401, factorial divisibility with prime products).

The `meta.json` sections and `annotations.json` were stale from a much shorter earlier version of `Proofs/Erdos401Problem.lean`:
- Section ranges ended at line **152** with a single `153–319` "Summary" lump, while the file's **11 boxed Parts** now extend to line 295.
- Realigned the 10 sections → **12 contiguous sections (1–319)** matching the file header + Parts I–XI.
- Snapped all **11 annotation ranges** to their current declarations.

## De-phantoming
Removed references to declarations that do **not** exist in the current source:
- `TendsToInfty` — the conjecture uses `Filter.Tendsto f atTop atTop` directly.
- `axiom g2_log_bound`, `axiom erdos_401_reformulation`, `axiom erdos_729_connection` — never present in the current file.

The two phantom-axiom annotations were repurposed to cover the previously uncovered **Part VIII (Consequences: `unbounded_excess`, `erdos_401_complete`)** and **Part IX (Legendre's Formula: `legendre_formula`, `padic_valuation_factorial_bound`)**.

## Unchanged (verified correct)
- Counts: 3 axioms, 20 theorems, 8 defs, 0 sorries, lineCount 319.
- `status: axiomatized`, `badge: axiom`.

## Test plan
- [x] `meta.json` + `annotations.json` valid JSON
- [x] Sections contiguous 1–319, aligned to `-- === Part N ===` banners
- [x] No phantom declarations remain (grep clean)
- [x] Data-only; no Lean source touched (build-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)