### PR TITLE
Enrich mean-value-theorem-oq-02: fix annotation range past EOF

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/annotations.json
@@ -108,8 +108,8 @@
     "id": "ann-mvt02-error-bounds",
     "proofId": "mean-value-theorem-oq-02",
     "range": {
-      "startLine": 129,
-      "endLine": 154
+      "startLine": 128,
+      "endLine": 153
     },
     "type": "insight",
     "title": "Error Bounds and Approximation Quality from Taylor's Theorem",


### PR DESCRIPTION
## Summary
Quality-98 entry `mean-value-theorem-oq-02` (Taylor's Theorem with Lagrange Remainder) was audited as fully enriched and accurate: rich meta, 5 complete annotations, and counts verified against source (4 theorems, 1 def, 1 axiom, 0 sorries, 153 lines).

The one genuine defect found: annotation `ann-mvt02-error-bounds` had `range` 129–154, exceeding the 153-line Lean file. Realigned to 128–153 (Part IV banner through EOF), matching the `second-order` section's start line.

No filler added — the rest of the entry is already complete and correct.

## Test plan
- [x] JSON parses (build enrichment phase loaded the entry cleanly)
- [x] Range now within file bounds (1–153) and aligned to Part IV banner