### PR TITLE
audit(hilbert-15-oq-02): correct verified→axiomatized overclaim (3 True-stub theorems)

### DIFF
--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert15OQ02.lean",
     "tags": [
       "algebraic-geometry",
@@ -16,11 +16,11 @@
       "schubert-calculus",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 533,
-    "assumptions": "Three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) prove `True` as explicit placeholders — the complexity theory formalism is not available in Lean/Mathlib. The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide.",
+    "assumptions": "axiomCount = 3 reflects three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) that assert `True` as explicit placeholders rather than proving their named statements — the complexity theory formalism is not available in Lean/Mathlib, so these are unproven assumptions (no `axiom` declarations appear in the source, but per the Axiom Integrity Policy these placeholder assertions are counted as assumptions). The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide; the entry is not status `verified` because the headline complexity results are not formally proved.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
     "theoremCount": 27,


### PR DESCRIPTION
## Gallery Integrity Issue

**Proof**: hilbert-15-oq-02 (Complexity of Littlewood-Richardson Coefficients)
**Severity**: HIGH (True-stub theorems under a `verified`/`original` claim)

## Problem

The Lean source (`Proofs/Hilbert15OQ02.lean`, Part VII "Complexity Results (Documentation)") honestly states that three famous complexity theorems assert `True` as explicit placeholders:

- `lr_saturation_theorem` (Knutson-Tao 1999) — line 352, `True := trivial`
- `lr_positivity_in_P` — line 364, body `True`
- `lr_counting_sharp_P_complete` (Narayanan 2006) — line 381, body `True`

The complexity-theory formalism is not available in Mathlib, so these are unproven placeholders, not proofs of their named statements.

However `meta.json` claimed the strongest possible status:

| Field | Was | Now |
|-------|-----|-----|
| `status` | `verified` | `axiomatized` |
| `badge` | `original` | `axiom` |
| `axiomCount` | `0` | `3` |

Per CLAUDE.md's **Axiom Integrity Policy**, `axiomCount` must reflect *all* assumptions, and a `theorem … : True := trivial` standing in for a famous result is an assumption-carrying assertion. Overclaiming `verified` damages credibility.

## What is genuinely verified (unchanged)

The 2-row LR coefficient computation (`lrCoeff2`), the Pieri/commutativity lemmas, and the full Gr(2,4) multiplication table — all via `native_decide`. Those claims remain accurate; only the headline `status`/`badge`/`axiomCount` and the `assumptions` wording changed.

## Fix

Meta-only (no Lean change — the source is already accurate and transparent). The `assumptions` field now explains that `axiomCount = 3` reflects the three `True` placeholders.

---
Discovered during gallery integrity audit.