### PR TITLE
research(erdos-1210): realign gallery sections to banner boundaries (6→6)

### DIFF
--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -58,22 +58,22 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 54,
-      "endLine": 73,
+      "endLine": 74,
       "summary": "Defines primesBelow, PairwiseCoprime, ValidSubset, and primeReciprocalSum (the corrected right-hand side ∑_{p<n} 1/p).",
       "mathContext": "$\\text{primesBelow}(n) = \\{p < n : p \\text{ prime}\\}$; $\\text{primeReciprocalSum}(n) = \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{p}$."
     },
     {
       "id": "prime-properties",
       "title": "Properties of Primes and Coprimality",
-      "startLine": 74,
-      "endLine": 116,
+      "startLine": 75,
+      "endLine": 113,
       "summary": "Proves distinct primes are coprime, primesBelow is valid and nonempty for n≥3, and pairwise coprime sets have ≤1 even element.",
       "mathContext": "Distinct primes are coprime. $|\\text{primesBelow}(n)| \\geq 1$ for $n \\geq 3$. $|\\{a \\in A : 2 \\mid a\\}| \\leq 1$ for pairwise coprime $A$."
     },
     {
       "id": "rhs-bounds",
       "title": "The Corrected Right-Hand Side",
-      "startLine": 117,
+      "startLine": 114,
       "endLine": 132,
       "summary": "Proves the prime-reciprocal sum ∑_{p<n} 1/p is nonneg and strictly positive for n≥3.",
       "mathContext": "$0 < \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{p}$ for $n \\geq 3$."
@@ -82,14 +82,14 @@
       "id": "conjecture",
       "title": "Main Conjecture and Consequences",
       "startLine": 133,
-      "endLine": 170,
+      "endLine": 169,
       "summary": "States the erdos_1210 axiom with an explicit existential O(1) constant, re-exposes it as a uniform bound, and records the unconditional empty-set bound.",
       "mathContext": "$\\exists C,\\ \\forall n \\geq 3,\\ \\forall \\text{ pairwise coprime } A,\\ \\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p<n} \\frac{1}{p} + C$."
     },
     {
       "id": "o1-essential",
       "title": "Why the O(1) Term Is Essential",
-      "startLine": 171,
+      "startLine": 170,
       "endLine": 230,
       "summary": "Machine-checked: primesBelow 5 = {2,3}, primeReciprocalSum 5 = 5/6, {4} is valid at n=5, the constant-free statement fails there (1 > 5/6), and any C ≥ 1/6 restores consistency with the conjecture.",
       "mathContext": "At $n=5$, $A=\\{4\\}$: $\\sum 1/(5-a) = 1 > 5/6 = \\sum_{p<5} 1/p$, so the $C=0$ statement fails; any $C \\geq 1/6$ suffices."


### PR DESCRIPTION
## Summary

Build-free gallery metadata fix for **erdos-1210** (Pairwise Coprime Weighted Harmonic Sum). The six `sections` ranges in `meta.json` had drifted off the `## ...` banner blocks in `proofs/Proofs/Erdos1210Problem.lean`.

The clearest symptom: the **"The Corrected Right-Hand Side"** banner (lines 114-116) sat inside the *prime-properties* section (74-116) while section 4 started at 117 — so the section whose title names that banner did not contain it. Likewise the **"Why the O(1) Term Is Essential"** banner (line 170) sat at the tail of section 5.

Snapped each section to `[banner, next_banner-1]`:

| Section | Before | After |
|---|---|---|
| Problem Statement and Module Header | 1-53 | 1-53 |
| Core Definitions | 54-73 | 54-74 |
| Properties of Primes and Coprimality | 74-116 | 75-113 |
| The Corrected Right-Hand Side | 117-132 | 114-132 |
| Main Conjecture and Consequences | 133-170 | 133-169 |
| Why the O(1) Term Is Essential | 171-230 | 170-230 |

Each section now owns its own banner; ranges stay contiguous over the full file (1-230). Summaries, `mathContext`, and all counts (14 theorems, 4 defs, 1 axiom, 230 lines) were already accurate and are left unchanged.

## Scope

- Meta-only (`src/data/proofs/erdos-1210/meta.json`); no Lean source touched, no build required.
- Status `axiomatized` / badge `axiom` unchanged (open conjecture).

## Test plan

- [x] Section ranges are contiguous and cover 1-230.
- [x] Each section's `## ` banner line falls within its own `[startLine, endLine]`.
- [x] JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)