### PR TITLE
research(erdos-640): realign drifted/mislabeled gallery sections to Part banners (7→12)

### DIFF
--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -51,60 +51,100 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "summary": "Imports Mathlib's `SimpleGraph.Basic`, `SimpleGraph.Subgraph`, `WalkCounting` for connectivity, `Nat.Basic`, `Finset.Basic`, and `Tactic`. Opens the `SimpleGraph` namespace.",
-      "startLine": 31,
-      "endLine": 41,
-      "mathContext": "Mathlib's `SimpleGraph V` type: symmetric irreflexive relation on vertex type $V$. Subgraph API for induced subgraphs. WalkCounting for cycle detection."
-    },
-    {
-      "id": "chromatic-number",
-      "title": "Part I: Chromatic Number",
-      "summary": "Defines `IsKColorable G k` (existence of a proper $k$-coloring $c: V \\to \\mathrm{Fin}\\, k$ with $G.\\mathrm{Adj}(v,w) \\implies c(v) \\ne c(w)$) and `chromaticNumber` $= \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$ via `Nat.find`.",
-      "startLine": 42,
-      "endLine": 59,
-      "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ has a proper } k\\text{-coloring}\\}$. Bipartite $\\iff \\chi(G) \\leq 2 \\iff$ no odd cycles. Non-bipartite $\\iff \\chi(G) \\geq 3$."
+      "id": "header",
+      "title": "Module Documentation, Imports, and Setup",
+      "summary": "Module docstring stating Erdős #640 (Erdős–Hajnal): for $k \\ge 3$, is there $f(k)$ with $\\chi(G) \\ge f(k)$ forcing an odd cycle whose vertices span $\\chi \\ge k$? Imports Mathlib `SimpleGraph.Basic`/`Subgraph`/`WalkCounting`, `Nat.Basic`, `Finset.Basic`, `Tactic`, and the local `Proofs.GraphCore`. Opens `GraphCore` and `SimpleGraph` (hiding `chromaticNumber`); declares `namespace Erdos640`.",
+      "startLine": 1,
+      "endLine": 43,
+      "mathContext": "`chromaticNumber` and `IsKColorable` are supplied by the imported `GraphCore` module, not defined here. Bipartite $\\iff \\chi(G) \\leq 2 \\iff$ no odd cycles; non-bipartite $\\iff \\chi(G) \\geq 3$."
     },
     {
       "id": "odd-cycles",
       "title": "Part II: Odd Cycles",
-      "summary": "Defines `HasOddCycleWithVertices G S`: $|S| \\ge 3$, $|S|$ odd, vertices pairwise reachable, and $\\exists$ a cyclic ordering $\\sigma: \\mathrm{Fin}\\, |S| \\to V$ with consecutive vertices adjacent. This captures odd cycles as vertex-labeled closed walks.",
-      "startLine": 60,
-      "endLine": 76,
+      "summary": "Defines `HasOddCycleWithVertices G S`: $|S| \\ge 3$, $|S|$ odd, vertices of $S$ pairwise adjacent-or-reachable, and $\\exists$ a cyclic ordering $\\sigma: \\mathrm{Fin}\\, |S| \\to V$ (injective, into $S$) with each $\\sigma(i)$ adjacent to $\\sigma(i+1 \\bmod |S|)$. This captures odd cycles as vertex-labeled closed walks.",
+      "startLine": 44,
+      "endLine": 60,
       "mathContext": "An odd cycle $C_{2m+1}$ has $\\chi = 3$. The set $S$ identifies the vertex set of the cycle. The conjecture asks: can we find odd cycles whose *neighborhoods* (induced subgraphs) have high $\\chi$?"
     },
     {
       "id": "induced-chromatic",
       "title": "Part III: Induced Subgraph Chromatic Number",
-      "summary": "Defines `inducedSubgraph G S` (restricts adjacency to vertex set $S$) and `InducedChromaticAtLeast G S k` ($\\neg\\mathrm{IsKColorable}(G[S], k-1)$, i.e., $\\chi(G[S]) \\ge k$).",
-      "startLine": 77,
-      "endLine": 94,
+      "summary": "Defines `InducedChromaticAtLeast G S k` as $\\neg\\mathrm{IsKColorable}(\\mathrm{inducedSubgraph}\\, G\\, S, k-1)$, i.e. the subgraph induced on $S$ admits no proper $(k-1)$-coloring, equivalently $\\chi(G[S]) \\ge k$.",
+      "startLine": 61,
+      "endLine": 70,
       "mathContext": "$G[S]$: the induced subgraph on vertex set $S$, where $u \\sim v$ in $G[S]$ iff $u, v \\in S$ and $u \\sim v$ in $G$. The condition $\\chi(G[S]) \\geq k$ means no proper $(k-1)$-coloring of $G[S]$ exists."
     },
     {
       "id": "conjecture",
-      "title": "Part IV: The Erdős-Hajnal Conjecture",
-      "summary": "States `ErdosHajnalConjecture640`: $\\forall k \\ge 3,\\, \\exists f(k)$ such that $\\chi(G) \\ge f(k) \\implies \\exists$ odd cycle $S$ with $\\chi(G[S]) \\ge k$. Also states `SteinerPathVariant` (same with paths) and axiomatizes their equivalence.",
-      "startLine": 95,
-      "endLine": 134,
+      "title": "Part IV: The Erdős–Hajnal Conjecture",
+      "summary": "States `ErdosHajnalConjecture640`: $\\forall k \\ge 3,\\, \\exists f(k)$ such that any finite graph with $\\chi(G) \\ge f(k)$ has an odd cycle $S$ with $\\chi(G[S]) \\ge k$. States `SteinerPathVariant` (identical but with a path in place of the odd cycle). Axiomatizes `steiner_equivalence`: the two formulations are equivalent.",
+      "startLine": 71,
+      "endLine": 110,
       "mathContext": "The conjecture: $\\forall k \\geq 3$, $\\exists f(k)$ s.t. $\\chi(G) \\geq f(k) \\Rightarrow \\exists$ odd cycle $C$ in $G$ with $\\chi(G[V(C)]) \\geq k$. Steiner equivalence: paths can replace cycles. Open for $k \\geq 4$."
     },
     {
       "id": "trivial-case",
       "title": "Part V: The Trivial Case $k = 3$",
-      "summary": "Axiomatizes the $k = 3$ case: $\\chi(G) \\ge 3 \\implies \\exists$ odd cycle $S$ with $\\chi(G[S]) \\ge 3$. This follows because non-bipartite graphs contain odd cycles, and odd cycles have $\\chi = 3$.",
-      "startLine": 135,
-      "endLine": 149,
+      "summary": "Axiomatizes `trivial_case_k3`: $\\chi(G) \\ge 3 \\implies \\exists$ odd cycle $S$ with $\\chi(G[S]) \\ge 3$, witnessing $f(3) = 3$. Holds because non-bipartite graphs contain an odd cycle and every odd cycle has $\\chi = 3$.",
+      "startLine": 111,
+      "endLine": 125,
       "mathContext": "$k = 3$: $\\chi(G) \\geq 3$ means $G$ is non-bipartite, so $G$ contains an odd cycle $C_{2m+1}$. Since $\\chi(C_{2m+1}) = 3$, the induced subgraph on the cycle vertices has $\\chi \\geq 3$. So $f(3) = 3$."
     },
     {
       "id": "summary",
-      "title": "Part VI: Summary Theorem",
-      "summary": "Proves `erdos_640_summary`: the conjecture is equivalent to Steiner's path variant, directly applying the `steiner_equivalence` axiom.",
-      "startLine": 150,
-      "endLine": 259,
-      "mathContext": "Summary: Erdős-Hajnal conjecture $\\iff$ Steiner path variant. Known: $f(3) = 3$. Open: $f(k)$ for $k \\geq 4$."
+      "title": "Part VI: Summary",
+      "summary": "Proves `erdos_640_summary`: the conjecture is equivalent to Steiner's path variant, discharged directly by the `steiner_equivalence` axiom.",
+      "startLine": 126,
+      "endLine": 137,
+      "mathContext": "Summary: Erdős–Hajnal conjecture $\\iff$ Steiner path variant. Known: $f(3) = 3$. Open: $f(k)$ for $k \\geq 4$."
+    },
+    {
+      "id": "structural-lemmas",
+      "title": "Part VII: Structural Lemmas on Colorability",
+      "summary": "Four proved colorability lemmas: `isKColorable_succ` ($k$-colorable $\\Rightarrow (k+1)$-colorable), `isKColorable_mono` (monotone in the color count), `isKColorable_one_of_no_edges` (edge-free graphs are $1$-colorable), and `isKColorable_zero_of_isEmpty` (the empty type is $0$-colorable).",
+      "startLine": 138,
+      "endLine": 167,
+      "mathContext": "Colorability is upward-closed in $k$: a proper $k$-coloring composes with the inclusion $\\mathrm{Fin}\\,k \\hookrightarrow \\mathrm{Fin}\\,k'$ for $k \\le k'$. These elementary monotonicity facts underpin reasoning about $\\chi$ as a minimum."
+    },
+    {
+      "id": "induced-inheritance",
+      "title": "Part VIII: Induced Subgraph Coloring Inheritance",
+      "summary": "Proves `inducedSubgraph_isKColorable` (a $k$-coloring of $G$ restricts to any induced subgraph) and `inducedChromaticAtLeast_of_not_colorable` (if $G[S]$ is not $(k-1)$-colorable then neither is $G$), the contrapositive linking induced-subgraph chromatic lower bounds back to $G$.",
+      "startLine": 168,
+      "endLine": 183,
+      "mathContext": "Induced subgraphs inherit proper colorings by restriction, so $\\chi(G[S]) \\le \\chi(G)$. Contrapositive: $\\chi(G[S]) \\ge k \\Rightarrow \\chi(G) \\ge k$, i.e. high span chromatic number forces high global chromatic number."
+    },
+    {
+      "id": "odd-cycle-not-one-colorable",
+      "title": "Part IX: Odd Cycle Chromatic Number",
+      "summary": "Proves `oddCycle_not_one_colorable`: the subgraph induced on the vertices of an odd cycle is not $1$-colorable, since any adjacent pair on the cycle forces two distinct colors.",
+      "startLine": 184,
+      "endLine": 201,
+      "mathContext": "A $1$-coloring makes every vertex the same color, contradicting properness on a single edge of the cycle. This is the base step toward $\\chi \\ge 3$ for odd cycles."
+    },
+    {
+      "id": "every-graph-colorable",
+      "title": "Part X: Every Graph is Colorable",
+      "summary": "Proves `exists_colorable`: every graph on a finite vertex type admits some proper coloring, using $\\mathrm{card}\\,V$ colors via the equivalence $V \\simeq \\mathrm{Fin}(\\mathrm{card}\\,V)$ (distinct color per vertex), with the empty case handled separately.",
+      "startLine": 202,
+      "endLine": 215,
+      "mathContext": "The trivial upper bound $\\chi(G) \\le |V|$: coloring each vertex with its own index is always proper. Guarantees `chromaticNumber` is well-defined (the colorability set is nonempty)."
+    },
+    {
+      "id": "bipartite",
+      "title": "Part XI: Bipartite and 2-Colorability",
+      "summary": "Defines `IsBipartiteColoring G := IsKColorable G 2` and proves the key lemma `oddCycle_chromatic_at_least_3`: an odd cycle's induced subgraph is not $2$-colorable, so $\\chi(G[S]) \\ge 3$. The proof maps a hypothetical $2$-coloring to `Fin 2`, shows colors flip along the cycle (`hflip`), derives a closed-form parity `hparity` by induction, and obtains a contradiction with $|S|$ odd at cycle closure.",
+      "startLine": 216,
+      "endLine": 280,
+      "mathContext": "Bipartite $\\iff 2$-colorable $\\iff$ no odd cycle. Walking around an odd cycle, a proper $2$-coloring forces the color to alternate; after an odd number of steps the parity fails to close, contradicting properness on the final edge."
+    },
+    {
+      "id": "structural-summary",
+      "title": "Part XII: Structural Summary",
+      "summary": "Proves `k3_odd_cycle_span`: any odd cycle on vertex set $S$ both is an odd cycle and spans an induced subgraph with $\\chi \\ge 3$ — the unconditional $k=3$ structural fact, assembled from `oddCycle_chromatic_at_least_3`.",
+      "startLine": 281,
+      "endLine": 291,
+      "mathContext": "Packages the $k=3$ result: existence of an odd cycle already yields a span of chromatic number $\\ge 3$, the elementary endpoint of the conjecture spectrum that becomes open for $k \\ge 4$."
     }
   ],
   "conclusion": {
@@ -127,9 +167,8 @@
       "Mathlib.Tactic"
     ],
     "opens": [
-      "SimpleGraph",
-      "Classical",
-      "in"
+      "GraphCore",
+      "SimpleGraph"
     ],
     "namespace": "Erdos640",
     "lineCount": 291,


### PR DESCRIPTION
## Summary

The gallery sections for **erdos-640** (Chromatic Number of Odd Cycle Spans) had drifted and become mislabeled relative to `proofs/Proofs/Erdos640Problem.lean` (291 lines):

- `"Part I: Chromatic Number"` (42–59) sat on the **Part II** banner and its summary described `IsKColorable` / `chromaticNumber` — definitions that live in the imported `GraphCore` module, **not in this file**.
- Every subsequent title was shifted one Part behind the source banners.
- The final `"Part VI: Summary Theorem"` spanned **150–259**, lumping the entire structural block (Parts VII–XI: colorability lemmas, induced-subgraph inheritance, the odd-cycle parity argument).
- **Part XII** (281–291, `k3_odd_cycle_span`) was **not covered by any section**.

## Changes

- Realign to **12 contiguous sections** (1–291), one per `/- ## Part N -/` banner, with summaries rewritten from the actual declarations in each range.
- Fix stale `leanFile.opens`: `["SimpleGraph", "Classical", "in"]` → the file's actual `["GraphCore", "SimpleGraph"]`.
- Counts left unchanged (11 theorems / 5 definitions / 2 axioms — all verified against source).

Meta-only (gallery JSON); no Lean source touched, no build required.

## Test plan
- [x] `jq empty` validates JSON
- [x] Sections contiguous with no gaps/overlaps, covering lines 1–291
- [x] Each section title matches its source Part banner; summaries reflect in-range decls

🤖 Generated with [Claude Code](https://claude.com/claude-code)