### PR TITLE
research(erdos-1001-oq-02-oq-01): realign sections to full file

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -124,44 +124,68 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Core Definitions",
-      "startLine": 45,
-      "endLine": 90,
-      "summary": "Reuse of S, f, inESTRegime, densityConst, rangeTotientSum from OQ-02, plus new partialTotientSum.",
-      "mathContext": "The setup mirrors OQ-02: $S(N,A,c)$ measures the density of $\\alpha \\in (0,1)$ approximable by $x/y$ with $y \\in [N,cN]$; $f(A,c) = 12A\\log(c)/\\pi^2$ is the EST formula; $T(N,c) = \\sum_{y=N}^{cN} \\varphi(y)/y^2$ is the range totient sum. New: $\\Phi(n) = \\sum_{y \\leq n} \\varphi(y)$ is the partial totient sum whose error term $E(n) = \\Phi(n) - (3/\\pi^2)n^2$ is the subject of both Mertens' and Walfisz's bounds."
+      "id": "header",
+      "title": "Module Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "States Erdős #1001 OQ-02-OQ-01: whether the $O(\\log N/N)$ convergence rate for the totient-sum density is sharp. Overview of the Mertens vs. Walfisz comparison.",
+      "mathContext": "Sharpness of the $O(\\log N/N)$ totient-sum convergence rate."
     },
     {
-      "id": "error-bounds",
-      "title": "Mertens vs. Walfisz Error Bounds",
-      "startLine": 95,
-      "endLine": 135,
-      "summary": "Axioms for both the elementary O(N log N) error (Mertens) and the sharp O(N (log N)^(2/3) (log log N)^(4/3)) error (Walfisz).",
-      "mathContext": "The Mertens bound $E(N) = O(N \\log N)$ is elementary (1874). The Walfisz bound $E(N) = O(N (\\log N)^{2/3} (\\log \\log N)^{4/3})$ (1963) requires the Vinogradov–Korobov zero-free region for $\\zeta(s)$. Both are axiomatized as neither appears in Mathlib v4.26."
+      "id": "part1",
+      "title": "Core Definitions (from Erdos1001OQ02)",
+      "startLine": 55,
+      "endLine": 89,
+      "summary": "Defines `isApproximable`, `S`, `f`, `inESTRegime`, `densityConst` ($6/\\pi^2$), `rangeTotientSum`, `partialTotientSum`.",
+      "mathContext": "Totient-sum density constant $6/\\pi^2$; range/partial sums."
     },
     {
-      "id": "rate-comparison",
-      "title": "Comparison of Error Rates",
-      "startLine": 140,
-      "endLine": 175,
-      "summary": "Proves (log N)^(2/3)/N = o(log N/N) — the core comparison showing Walfisz rate is strictly better.",
-      "mathContext": "The comparison reduces to $1/(\\log N)^{1/3} \\to 0$, proved from $\\operatorname{Real.tendsto\\_log\\_div\\_rpow\\_atTop}$ with exponent $p = 1/3$. Two sorries remain for the formal manipulation of $\\text{rpow}$ inequalities — these are Aristotle candidates."
+      "id": "part2",
+      "title": "The Elementary vs. Walfisz Error Bounds",
+      "startLine": 90,
+      "endLine": 123,
+      "summary": "States the AXIOMS `totient_sum_mertens_error` (elementary Mertens error) and `totient_sum_walfisz_error` (Walfisz's sharper error).",
+      "mathContext": "Axioms: Mertens vs. Walfisz error terms for $\\sum\\varphi$."
     },
     {
-      "id": "range-sum-improvement",
-      "title": "Improved Range Sum Error",
-      "startLine": 178,
-      "endLine": 215,
-      "summary": "Axiom: Walfisz bound propagates via Abel summation to range totient sum.",
-      "mathContext": "The Abel summation argument follows the same template as OQ-02's $\\texttt{rangeTotientSum\\_error}$ but uses the Walfisz input $E(N) = O(N(\\log N)^{2/3}(\\log\\log N)^{4/3})$ rather than Mertens' $O(N \\log N)$. The result: $T(N,c) - (6/\\pi^2)\\log c = O((\\log N)^{2/3}(\\log\\log N)^{4/3}/N)$. Axiomatized pending the Abel summation implementation."
+      "id": "part3",
+      "title": "Comparison: Walfisz rate vs. Mertens rate",
+      "startLine": 124,
+      "endLine": 164,
+      "summary": "Proves `walfisz_rate_isLittleO_mertens_rate` and `walfisz_full_rate_isLittleO_mertens_rate` (2 `sorry`): the Walfisz rate is $o(\\cdot)$ of Mertens.",
+      "mathContext": "Walfisz error $=o(\\text{Mertens error})$ (2 sorries)."
     },
     {
-      "id": "main-result",
-      "title": "Main Result: Rate Not Sharp",
-      "startLine": 218,
-      "endLine": 248,
-      "summary": "Proves oq02_rate_not_sharp: |S(N,A,c) - f(A,c)| = o(A log N / N).",
-      "mathContext": "The main theorem combines: (1) the sharp rate axiom $|S-f| = O(A(\\log N)^{2/3}(\\log\\log N)^{4/3}/N)$, and (2) the comparison $(\\log N)^{2/3}(\\log\\log N)^{4/3}/N = o(\\log N/N)$, via $\\texttt{IsBigO.trans\\_isLittleO}$. This yields $|S-f| = o(A \\log N/N)$ — strictly better convergence than OQ-02's O bound."
+      "id": "part4",
+      "title": "Sharp Range Totient Sum Error via Abel Summation",
+      "startLine": 165,
+      "endLine": 198,
+      "summary": "States the AXIOM `rangeTotientSum_walfisz_error`: the improved range-sum error obtained by Abel summation.",
+      "mathContext": "Axiom: improved range-sum error via Abel summation."
+    },
+    {
+      "id": "part5",
+      "title": "Main Result: O(log N / N) Is NOT the Tight Rate",
+      "startLine": 199,
+      "endLine": 264,
+      "summary": "States the AXIOM `convergence_rate_sharp` and proves `sharp_rate_isLittleO_oq02_rate` and `oq02_rate_not_sharp` (1 `sorry`): the OQ-02 rate is not sharp.",
+      "mathContext": "$O(\\log N/N)$ is not the tight rate (1 sorry)."
+    },
+    {
+      "id": "part6",
+      "title": "Quantitative Comparison: How Much Better?",
+      "startLine": 265,
+      "endLine": 282,
+      "summary": "Proves `improvement_factor_tends_to_zero` (1 `sorry`): the improvement factor $\\to0$.",
+      "mathContext": "Improvement factor $\\to0$ (1 sorry)."
+    },
+    {
+      "id": "part7",
+      "title": "Historical Context and Summary",
+      "startLine": 283,
+      "endLine": 313,
+      "summary": "Gives historical context and proves `erdos_1001_oq02_oq01_summary` packaging the result.",
+      "mathContext": "Summary: OQ-02 rate improvable; 4 axioms, 4 sorries remain."
     }
   ],
   "sorries": 4


### PR DESCRIPTION
## Summary
Realigns the gallery `sections` for **erdos-1001-oq-02-oq-01** (sharpness of the $O(\log N/N)$ totient-sum convergence rate, `Erdos1001OQ02OQ01.lean`, 313 lines).

The meta sections had drifted from the `## ` banners and stopped at line 248, hiding "Quantitative Comparison" (@265) and "Historical Context" (@283–313).

## Changes
- Rebuilt 8 sections mapped to the real banners, covering lines 1–313 contiguously.
- Refreshed summaries/mathContext (core definitions, Mertens/Walfisz error axioms, rate comparison, Abel-summation axiom, main not-sharp result, quantitative improvement, summary).
- Counts already correct: 6 theorems / 7 defs / 4 axioms / 4 sorries (real sorries @148/162/248/280; lines 29/142 are prose mentions), lineCount 313.

## Validation
- `npx tsx scripts/research/build.ts` exits 0.