### PR TITLE
research(lagrange-theorem-oq-02-oq-02-oq-01): realign gallery sections to Part banners (5→5)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json
@@ -197,7 +197,7 @@
     {
       "id": "burnside-sum-form",
       "title": "Burnside's Lemma (Sum Form)",
-      "startLine": 72,
+      "startLine": 69,
       "endLine": 90,
       "summary": "burnside_lemma_sum_form: Σ_g |Fix(g)| = |X/G| · |G|. One-line restatement of `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` in the file's namespace.",
       "mathContext": "$\\sum_{g \\in G} |\\mathrm{Fix}(g)| = |X/G| \\cdot |G|$ — the symmetric multiplicative form, no division. The decisive Mathlib invocation."
@@ -205,15 +205,15 @@
     {
       "id": "burnside-average-form",
       "title": "Burnside's Lemma (Average Form)",
-      "startLine": 94,
-      "endLine": 116,
+      "startLine": 91,
+      "endLine": 114,
       "summary": "burnside_lemma_average_form: |X/G| = (Σ_g |Fix(g)|) / |G|. Derived from the sum form by `Nat.mul_div_cancel` under the hypothesis `0 < |G|`.",
       "mathContext": "$|X/G| = \\frac{1}{|G|} \\sum_{g \\in G} |\\mathrm{Fix}(g)|$ — the classical Burnside formulation. Recovered as an `ℕ`-division corollary of the sum form."
     },
     {
       "id": "conjugation-specialisation",
       "title": "Conjugation-Action Specialisation",
-      "startLine": 120,
+      "startLine": 115,
       "endLine": 138,
       "summary": "conjugation_burnside_form: Σ_c |Fix(c)| = |G/∼| · |ConjAct G|, the application of Burnside to the action `ConjAct G ↷ G`. This exhibits the conceptual parallel with the parent's class equation — the same identity applied to two different actions.",
       "mathContext": "Instantiate Burnside at $G := \\mathrm{ConjAct}\\,G$, $X := G$. The fixed points of $c = \\mathrm{ConjAct.toConjAct}\\,g$ acting on $G$ are precisely the elements of $G$ commuting with $g$, i.e. $C_G(g)$. Summing over $c \\in \\mathrm{ConjAct}\\,G$ is dual to summing over conjugacy classes — the form used by the parent file."
@@ -221,8 +221,8 @@
     {
       "id": "oq01-resolution",
       "title": "OQ-01 Resolution",
-      "startLine": 142,
-      "endLine": 175,
+      "startLine": 139,
+      "endLine": 195,
       "summary": "oq01_resolution: bundled conjunction of `burnside_lemma_sum_form` and `conjugation_burnside_form` as a single statement attesting the affirmative answer to OQ-01. The Lean proof is the trivial conjunction.",
       "mathContext": "The two-part packaging: (1) Burnside in general (Σ_g |Fix(g)| = |X/G| · |G| for any G ↷ X), and (2) the conjugation specialisation (the parent's setting recovered as a Burnside instance). Together they answer the OQ-01 affirmatively."
     }


### PR DESCRIPTION
## Summary

Build-free gallery metadata fix for **lagrange-theorem-oq-02-oq-02-oq-01** (Burnside's Lemma from the Conjugation-Action Class Equation). The `sections` ranges in `meta.json` had drifted off the `-- Part N` banner boxes in `proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01.lean`.

The header section (1-68) was correctly aligned to end exactly at the Part I banner (@69), but sections 2-5 each started ~3 lines *after* their Part banner box, stranding every `-- Part N` banner in the preceding gap. The final section also ended at 175 while the file runs to 195, dropping the `#check` block and the Results Summary table.

Snapped each section to its Part banner box:

| Section | Before | After |
|---|---|---|
| Header and Conceptual Setup | 1-68 | 1-68 |
| Burnside's Lemma (Sum Form) — Part I | 72-90 | 69-90 |
| Burnside's Lemma (Average Form) — Part II | 94-116 | 91-114 |
| Conjugation-Action Specialisation — Part III | 120-138 | 115-138 |
| OQ-01 Resolution — Part IV | 142-175 | 139-195 |

Ranges are now contiguous over the full file (1-195) and each `-- Part N` banner falls within its own section. Summaries, `mathContext`, and all counts (4 theorems, 0 defs, 0 axioms, status `verified`) were already accurate and are left unchanged.

## Scope

- Meta-only (`src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01/meta.json`); no Lean source touched, no build required.

## Test plan

- [x] Section ranges are contiguous and cover 1-195.
- [x] Each `-- Part N` banner line falls within its own `[startLine, endLine]`.
- [x] Each section's named theorem lies within its range.
- [x] JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)