### PR TITLE
research(cayley-hamilton-minpoly-oq-05-oq-01-oq-02): realign gallery sections to SECTION banners (6→6)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -109,49 +109,49 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Definitions",
-      "startLine": 35,
-      "endLine": 39,
-      "summary": "Defines IsCyclicVector and IsNonderogatory for real matrices, consistent with the parent proof.",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring states the goal (cyclic vectors of a nonderogatory real matrix have full Lebesgue measure) and the three-step strategy, followed by the namespace setup and the SECTION I definitions IsCyclicVector and IsNonderogatory for real matrices, consistent with the parent proof.",
       "mathContext": "IsCyclicVector M v: no nonzero polynomial of degree < n annihilates v under M. IsNonderogatory M: minpoly = charpoly."
     },
     {
       "id": "cofactor-kernels",
       "title": "Cofactor Kernels and Properness",
-      "startLine": 44,
-      "endLine": 107,
+      "startLine": 41,
+      "endLine": 108,
       "summary": "Defines cofactorKernel M q = ker((mu/q)(M)) and proves each is a proper submodule when q is an irreducible factor of the minimal polynomial.",
       "mathContext": "For irreducible $q | \\mu$, the cofactor $\\mu/q$ has degree $< n = \\deg(\\mu)$, so $(\\mu/q)(M) \\neq 0$ by minimality, hence $\\ker((\\mu/q)(M)) \\subsetneq \\mathbb{R}^n$."
     },
     {
       "id": "gcd-annihilation",
       "title": "GCD Annihilation via Bezout",
-      "startLine": 112,
-      "endLine": 136,
+      "startLine": 109,
+      "endLine": 137,
       "summary": "If p(M)v = 0, then gcd(p, minpoly)(M)v = 0 via Bezout's identity.",
       "mathContext": "$d = \\gcd(p, \\mu) = ap + b\\mu$, so $d(M)v = a(M)p(M)v + b(M)\\mu(M)v = 0$."
     },
     {
       "id": "non-cyclic-containment",
       "title": "Non-Cyclic Vectors Lie in Cofactor Kernels",
-      "startLine": 141,
-      "endLine": 211,
+      "startLine": 138,
+      "endLine": 212,
       "summary": "Proves the structural heart: if v is not cyclic, there exists an irreducible factor q of mu such that v lies in cofactorKernel M q.",
       "mathContext": "If $v$ is not cyclic, $\\exists p \\neq 0$ with $\\deg(p) < n$ and $p(M)v = 0$. Then $d = \\gcd(p,\\mu)$ properly divides $\\mu$, $\\mu = ds$, $s$ has an irreducible factor $q$, and $(\\mu/q)(M)v = 0$."
     },
     {
       "id": "measure-theory",
       "title": "Proper Subspaces Have Measure Zero",
-      "startLine": 216,
-      "endLine": 223,
+      "startLine": 213,
+      "endLine": 224,
       "summary": "Applies Mathlib's addHaar_submodule: proper submodules of finite-dimensional real vector spaces have Lebesgue measure (volume) zero.",
       "mathContext": "The Lebesgue measure on $\\mathbb{R}^n$ is an additive Haar measure. Proper submodules (= proper linear subspaces) are closed sets of lower dimension, hence have Haar measure zero."
     },
     {
       "id": "main-theorems",
       "title": "Main Theorems: Measure Zero and Almost Everywhere",
-      "startLine": 228,
-      "endLine": 266,
+      "startLine": 225,
+      "endLine": 270,
       "summary": "Assembles the pieces: non_cyclic_measure_zero shows the non-cyclic set has measure zero via subset monotonicity + finite subadditivity. cyclic_vectors_ae gives the ae formulation.",
       "mathContext": "$\\mu(\\{v : \\neg \\text{cyclic}\\}) \\leq \\mu(\\bigcup_q \\ker((\\mu/q)(M))) \\leq \\sum_q \\mu(\\ker((\\mu/q)(M))) = 0$."
     }


### PR DESCRIPTION
## Summary

Build-free gallery metadata fix for **cayley-hamilton-minpoly-oq-05-oq-01-oq-02** (Cyclic Vectors Have Full Lebesgue Measure). The `sections` ranges in `meta.json` had drifted off the `-- SECTION N` banner boxes in `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean`.

Each section started a few lines *after* its SECTION banner box, stranding all six boxes in inter-section gaps. The module docstring + namespace setup (lines 1-34) and the file tail (267-270) were not covered by any section.

Snapped each section to its `-- SECTION N` box opener and extended coverage to the whole file:

| Section | Before | After |
|---|---|---|
| Module Header and Definitions (was "Definitions") | 35-39 | 1-40 |
| Cofactor Kernels and Properness | 44-107 | 41-108 |
| GCD Annihilation via Bezout | 112-136 | 109-137 |
| Non-Cyclic Vectors Lie in Cofactor Kernels | 141-211 | 138-212 |
| Proper Subspaces Have Measure Zero | 216-223 | 213-224 |
| Main Theorems: Measure Zero and Almost Everywhere | 228-266 | 225-270 |

The first section was retitled "Module Header and Definitions" (and its summary extended) to reflect that it now also covers the overview docstring and namespace setup. Ranges are now contiguous over the full file (1-270); each `-- SECTION N` box and each named theorem falls within its own section. Counts (status `verified`, 0 axioms, 0 sorries) and the other summaries were already accurate and are left unchanged.

## Scope

- Meta-only (`src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json`); no Lean source touched, no build required.

## Test plan

- [x] Section ranges are contiguous and cover 1-270.
- [x] Each `-- SECTION N` banner line falls within its own `[startLine, endLine]`.
- [x] Each section's named theorems/defs lie within its range.
- [x] JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)