### PR TITLE
research(erdos-1068): realign drifted sections (9→10) + de-phantom annotations

### DIFF
--- a/src/data/proofs/erdos-1068/annotations.json
+++ b/src/data/proofs/erdos-1068/annotations.json
@@ -145,8 +145,8 @@
     "proofId": "erdos-1068",
     "type": "concept",
     "range": {
-      "startLine": 101,
-      "endLine": 104
+      "startLine": 97,
+      "endLine": 101
     },
     "title": "Erdős Problem 1068: The Main Conjecture",
     "content": "The central open question: does every graph with $\\chi(G) \\geq \\aleph_1$ contain a countable vertex set $S$ such that $G[S]$ is infinitely connected? This is a weakening of Problem 1067 (disproved by Soukup). The restriction to countable subgraphs makes this fundamentally different — Soukup's counterexample controls uncountable sets but says nothing about countable ones.",
@@ -168,8 +168,8 @@
     "proofId": "erdos-1068",
     "type": "concept",
     "range": {
-      "startLine": 112,
-      "endLine": 116
+      "startLine": 104,
+      "endLine": 107
     },
     "title": "Soukup's Counterexample (2015)",
     "content": "Soukup (2015, *Combinatorica*) constructed in ZFC a graph with $\\chi(G) \\geq \\aleph_1$ where every uncountable vertex set induces a graph that is NOT infinitely connected. The construction uses ladder systems on non-special trees: pairs of vertices from any uncountable set can be separated by a finite vertex cut. This makes the countable case (Problem 1068) the remaining open question.",
@@ -192,8 +192,8 @@
     "proofId": "erdos-1068",
     "type": "concept",
     "range": {
-      "startLine": 123,
-      "endLine": 127
+      "startLine": 108,
+      "endLine": 112
     },
     "title": "Problem 1067 Disproved",
     "content": "Problem 1067 asked whether every graph with $\\chi(G) \\geq \\aleph_1$ contains an infinitely connected subgraph with $\\chi \\geq \\aleph_1$. Soukup showed the answer is NO. Problem 1068 weakens this by dropping the chromatic number requirement and only asking for countability of the subgraph.",
@@ -214,8 +214,8 @@
     "proofId": "erdos-1068",
     "type": "concept",
     "range": {
-      "startLine": 134,
-      "endLine": 141
+      "startLine": 115,
+      "endLine": 187
     },
     "title": "No Finite Vertex Separator",
     "content": "In an infinitely connected graph, removing any finite set of vertices leaves any two remaining vertices connected. This is a consequence of the infinite Menger theorem (Aharoni-Berger, 2009, *Inventiones mathematicae*), which resolved the Erdős-Menger conjecture: in infinite graphs, the max number of disjoint $A$-$B$ paths equals the min size of an $A$-$B$ separator.",
@@ -238,11 +238,11 @@
     "proofId": "erdos-1068",
     "type": "insight",
     "range": {
-      "startLine": 148,
-      "endLine": 149
+      "startLine": 189,
+      "endLine": 195
     },
     "title": "Set-Theoretic Sensitivity",
-    "content": "Komjáth (2013, *Israel J. Math.*) showed that a related question (graphs of cardinality $\\aleph_1$ with $\\chi \\geq \\aleph_1$ and uncountable infinitely connected subgraphs) is independent of ZFC. Problem 1068 may also be sensitive to set-theoretic axioms, though independence has not been established for this specific variant. Axiomatized as `True` (placeholder).",
+    "content": "Komjáth (2013, *Israel J. Math.*) showed that a related question (graphs of cardinality $\\aleph_1$ with $\\chi \\geq \\aleph_1$ and uncountable infinitely connected subgraphs) is independent of ZFC. Problem 1068 may also be sensitive to set-theoretic axioms, though independence has not been established for this specific variant. Recorded here as documentation prose (no formal declaration).",
     "mathContext": "Komjáth's independence result uses forcing: in one model of ZFC the answer is yes, in another no. The ZFC-independence status of Problem 1068 specifically remains unknown.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -262,17 +262,17 @@
     "proofId": "erdos-1068",
     "type": "insight",
     "range": {
-      "startLine": 155,
-      "endLine": 156
+      "startLine": 197,
+      "endLine": 202
     },
-    "title": "Bowler-Pitz Simplification (2024)",
-    "content": "Bowler and Pitz (2024, *Electronic J. Combinatorics*) provided an elementary construction of an uncountably chromatic graph without uncountable infinitely connected subgraphs, simplifying Soukup's 2015 proof. Their tree-like \"ladder\" approach is more transparent. Axiomatized as `True` (placeholder for the simplification technique).",
+    "title": "Bowler-Pikhurko Simplification (2024)",
+    "content": "Bowler and Pikhurko (2024) provided a simplified construction of Soukup's counterexample for Problem #1067, illuminating the structure of the problem; their construction uses tree-like \"ladder\" graphs. Recorded here as documentation prose (no formal declaration).",
     "mathContext": "The simplified construction (arXiv:2402.05984) replaces Soukup's non-special tree technique with a more direct ladder-graph approach, preserving the key property that uncountable vertex sets have finite vertex cuts.",
     "significance": "supporting",
     "relatedConcepts": [
       "proof simplification",
-      "elementary constructions",
-      "ladder graphs"
+      "ladder graphs",
+      "infinite graph theory"
     ],
     "prerequisites": [
       "Soukup's counterexample",
@@ -284,8 +284,8 @@
     "proofId": "erdos-1068",
     "type": "concept",
     "range": {
-      "startLine": 165,
-      "endLine": 179
+      "startLine": 209,
+      "endLine": 238
     },
     "title": "Structural Implications of Infinite Connectivity",
     "content": "Two fully proved (non-axiomatized) theorems: (1) `inf_connected_implies_path`: infinite connectivity implies the existence of a path between any two distinct vertices (extracting one path from the infinite family), and (2) `inf_connected_subgraph_has_paths`: if $G[S]$ is infinitely connected, then any two vertices in $S$ are path-connected within $S$. These are verified by Lean's kernel.",

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -50,73 +50,81 @@
       "id": "preamble",
       "title": "Problem Statement and Context",
       "startLine": 1,
-      "endLine": 33,
-      "summary": "Detailed module docstring: the problem statement, its relationship to Problem 1067, Soukup's counterexample, Bowler–Pitz simplification, and key references. Explains the countable/uncountable distinction that makes Problem 1068 the remaining open case.",
-      "mathContext": "Detailed module docstring: the problem statement, its relationship to Problem 1067, Soukup's counterexample, Bowler–Pitz simplification, and key references. Explains the countable/uncountable distinction that makes Problem 1068 the remaining open case."
+      "endLine": 32,
+      "summary": "Docstring statement of Erdős Problem #1068 (Erdős–Hajnal): does every graph with chromatic number ℵ₁ contain a countable subgraph that is infinitely (vertex-)connected, i.e. with infinitely many pairwise internally disjoint paths between any two vertices? Notes the OPEN status, the relation to the DISPROVED Problem #1067 (Soukup 2015), the Bowler–Pikhurko (2024) simplification, possible dependence on axioms beyond ZFC, and references.",
+      "mathContext": "Problem statement, its place relative to Problem #1067, and the known partial results."
     },
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "startLine": 34,
-      "endLine": 44,
-      "summary": "Imports Mathlib's `SimpleGraph`, `Cardinal`, and `Set.Countable`. Opens `Cardinal` and `SimpleGraph` namespaces. Sets up universe-polymorphic vertex type variable.",
-      "mathContext": "Mathematical content: Imports Mathlib's `SimpleGraph`, `Cardinal`, and `Set.Countable`. Opens `Cardinal` and `SimpleGraph` namespaces. Sets up universe-polymorphic vertex type variable."
+      "startLine": 33,
+      "endLine": 45,
+      "summary": "Mathlib imports (`SimpleGraph.Basic`, `Cardinal.Basic`/`.Ordinal`, `Set.Countable`), `open Cardinal SimpleGraph`, `namespace Erdos1068`, and the ambient `variable {V : Type*}`.",
+      "mathContext": "Lean preamble: imports, opened namespaces, and the vertex-type variable."
     },
     {
       "id": "graph-infrastructure",
-      "title": "Graph Infrastructure: Paths and Disjointness",
-      "startLine": 45,
-      "endLine": 77,
-      "summary": "Defines `PathInGraph` (vertex-list paths), `InternallyDisjoint` (no shared internal vertices), `PairwiseInternallyDisjoint`, `InfinitelyManyDisjointPaths`, and `InfinitelyConnected`. These build toward Menger-style connectivity characterization.",
-      "mathContext": "Defines `PathInGraph` (vertex-list paths), `InternallyDisjoint` (no shared internal vertices), `PairwiseInternallyDisjoint`, `InfinitelyManyDisjointPaths`, and `InfinitelyConnected`. These build toward Menger-style connectivity characterization."
+      "title": "Part I — Graph Infrastructure",
+      "startLine": 46,
+      "endLine": 78,
+      "summary": "Path and connectivity definitions (reused from #1067): the `PathInGraph` structure (a vertex list with adjacent consecutive entries), `InternallyDisjoint` and `PairwiseInternallyDisjoint` (sharing no internal vertices), `InfinitelyManyDisjointPaths` (an infinite pairwise-internally-disjoint family between two vertices), and `InfinitelyConnected` (every distinct pair has such a family).",
+      "mathContext": "Definitions of paths, internal disjointness, and infinite vertex-connectivity over a `SimpleGraph V`."
     },
     {
       "id": "chromatic-infrastructure",
-      "title": "Chromatic Number and Induced Subgraphs",
-      "startLine": 78,
-      "endLine": 93,
-      "summary": "Defines `hasAleph1ChromaticNumber` ($\\chi(G) \\geq \\aleph_1$ via non-existence of countable proper coloring) and `inducedSubgraph` ($G[S]$ for a vertex set $S$). Together these set up the problem: find countable $S$ with $G[S]$ $\\infty$-connected.",
-      "mathContext": "Defines `hasAleph1ChromaticNumber` ($\\chi(G) \\geq \\aleph_1$ via non-existence of countable proper coloring) and `inducedSubgraph` ($G[S]$ for a vertex set $S$). Together these set up the problem: find countable $S$ with $G[S]$ $\\infty$-connected."
+      "title": "Part II — Chromatic Number Infrastructure",
+      "startLine": 79,
+      "endLine": 85,
+      "summary": "Definition `hasAleph1ChromaticNumber G`: G cannot be properly colored by any countable color type (every countable coloring has a monochromatic adjacent pair), encoding chromatic number ≥ ℵ₁.",
+      "mathContext": "Definition capturing uncountable (≥ ℵ₁) chromatic number via failure of countable colorings."
+    },
+    {
+      "id": "induced-subgraphs",
+      "title": "Part III — Induced Subgraphs on Vertex Subsets",
+      "startLine": 86,
+      "endLine": 94,
+      "summary": "Definition `inducedSubgraph G S`: the subgraph of G induced on a vertex set S (adjacency inherited from G, with `symm` and `loopless` proved), the construction used to speak of countable infinitely-connected subgraphs.",
+      "mathContext": "Definition of the induced subgraph on a `Set V` as a `SimpleGraph S`."
     },
     {
       "id": "main-conjecture",
-      "title": "The Main Conjecture (Problem 1068)",
-      "startLine": 94,
-      "endLine": 105,
-      "summary": "Documents in source comments the main conjecture: for all $G$ with $\\chi(G) \\geq \\aleph_1$, there exists a countable $S$ with $G[S]$ infinitely connected. No Lean axiom declaration exists for this statement (the file has 0 axioms).",
-      "mathContext": "The main conjecture is documented in a Lean docstring only; no axiom or theorem formalizes it. The file declares definitions (`InfinitelyConnected`, `hasAleph1ChromaticNumber`, etc.) and proved theorems but no axioms."
+      "title": "Part IV — Main Conjecture",
+      "startLine": 95,
+      "endLine": 101,
+      "summary": "The statement of Problem #1068 (as a docstring): is there a countable vertex set S such that the induced subgraph G[S] is infinitely connected, whenever G has chromatic number ℵ₁? Recorded as prose; the problem is open, so no formal claim is asserted.",
+      "mathContext": "Prose statement of the open main conjecture in terms of `inducedSubgraph` and `InfinitelyConnected`."
     },
     {
       "id": "known-results",
-      "title": "Known Results: Soukup and Problem 1067",
-      "startLine": 106,
-      "endLine": 128,
-      "summary": "Axiomatizes Soukup's (2015) counterexample (uncountable sets can fail) and the disproof of Problem 1067 (no uncountable $\\infty$-connected subgraph with $\\chi \\geq \\aleph_1$ is forced). These establish why the countable case is the key remaining question.",
-      "mathContext": "Axiomatizes Soukup's (2015) counterexample (uncountable sets can fail) and the disproof of Problem 1067 (no uncountable $\\infty$-connected subgraph with $\\chi \\geq \\aleph_1$ is forced)."
+      "title": "Part V — Known Results",
+      "startLine": 102,
+      "endLine": 112,
+      "summary": "Docstring summary of the literature: Soukup (2015) built a graph of uncountable chromatic number in which every uncountable vertex set induces a non-infinitely-connected subgraph (so #1068 genuinely needs a *countable* subgraph); and the connection to Problem #1067 (which demanded the subgraph also have χ = ℵ₁ and was disproved by Soukup).",
+      "mathContext": "Prose record of Soukup's construction and the relationship to the disproved Problem #1067."
     },
     {
       "id": "structural-observations",
-      "title": "Structural Observations",
-      "startLine": 129,
-      "endLine": 157,
-      "summary": "Axiomatizes the no-finite-separator property (consequence of Aharoni–Berger infinite Menger theorem), set-theoretic sensitivity (Komjáth 2013), and Bowler–Pitz (2024) simplified construction. The latter two are `True` placeholders.",
-      "mathContext": "Axiomatizes the no-finite-separator property (consequence of Aharoni–Berger infinite Menger theorem), set-theoretic sensitivity (Komjáth 2013), and Bowler–Pitz (2024) simplified construction. The latter two are `True` placeholders."
+      "title": "Part VI — Structural Observations",
+      "startLine": 113,
+      "endLine": 203,
+      "summary": "The main proved result `inf_connected_no_finite_separator`: in an infinitely connected graph, for any two non-separated vertices and any finite set S avoiding them, some u–v path avoids S entirely (each s ∈ S is internal to at most one path by pairwise disjointness, so the finitely many 'bad' paths cannot exhaust the infinite family). Also prose notes on set-theoretic sensitivity (Komjáth 2013) and the Bowler–Pikhurko construction.",
+      "mathContext": "A proved no-finite-separator theorem for infinitely connected graphs, via a finite-`biUnion`/subsingleton-fiber counting argument, plus contextual prose."
     },
     {
       "id": "proved-implications",
-      "title": "Proved Structural Implications",
-      "startLine": 158,
-      "endLine": 180,
-      "summary": "Two fully proved theorems: $\\infty$-connected implies path existence between any two vertices, and the same for induced subgraphs. These are the only non-axiomatized results in the file.",
-      "mathContext": "Verified: Two fully proved theorems: $\\infty$-connected implies path existence between any two vertices, and the same for induced subgraphs. These are the only non-axiomatized results in the file."
+      "title": "Part VII — Partial Implications",
+      "startLine": 204,
+      "endLine": 239,
+      "summary": "Proved structural relationships: `inf_connected_implies_path` (infinite connectivity gives at least one path between distinct vertices), `inf_connected_subgraph_has_paths` (paths within an infinitely connected induced subgraph), and `inf_connected_k_connected` (infinitely connected graphs are k-vertex-connected for every finite k, as a corollary of the no-finite-separator theorem).",
+      "mathContext": "Theorems deriving ordinary and finite-k connectivity consequences from infinite connectivity."
     },
     {
       "id": "summary",
-      "title": "Summary and Open Aspects",
-      "startLine": 181,
-      "endLine": 205,
-      "summary": "Closing comment summarizing the problem status: main question open, Soukup's counterexample for uncountable case, ZFC-independence not established for Problem 1068, and the intersection of infinite combinatorics and set theory.",
-      "mathContext": "Closing comment summarizing the problem status: main question open, Soukup's counterexample for uncountable case, ZFC-independence not established for Problem 1068, and the intersection of infinite combinatorics and set theory."
+      "title": "Summary",
+      "startLine": 240,
+      "endLine": 264,
+      "summary": "Closing docstring recap: the OPEN main question (does χ = ℵ₁ force a countable infinitely connected subgraph?), the known results (Soukup 2015; the disproved #1067; possible ZFC-independence), the unresolved open aspects, and a note on the problem's difficulty at the intersection of infinite combinatorics and set theory.",
+      "mathContext": "Narrative summary of the problem's status, known results, and open aspects."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-401/annotations.json
+++ b/src/data/proofs/erdos-401/annotations.json
@@ -22,12 +22,12 @@
     "id": "ann-e401-primes",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 47,
-      "endLine": 52
+      "startLine": 60,
+      "endLine": 71
     },
     "type": "definition",
-    "title": "Prime Infrastructure",
-    "content": "**noncomputable def nthPrime (r : ℕ)**: ℕ\n  The r-th prime (0-indexed: p₀ = 2, p₁ = 3, ...)\n  Uses Nat.nth from Mathlib.\n\n**noncomputable def primorialPow (r n : ℕ)**: ℕ\n  ∏ i ∈ range r, (nthPrime i)^n\n  = 2ⁿ · 3ⁿ · 5ⁿ · ... · pᵣⁿ\n\nThis is the extra factor that distinguishes #401 from simpler factorial problems.",
+    "title": "Prime Infrastructure (Part I)",
+    "content": "**def nthPrime (r : ℕ) : ℕ** — the r-th prime (0-indexed: p₀ = 2, p₁ = 3, ...), via Mathlib's `Nat.nth Nat.Prime`.\n\n**def primorial (r : ℕ) : ℕ** — ∏ i ∈ range r, nthPrime i, the product of the first r primes.\n\n**def primorialPow (r n : ℕ) : ℕ** — ∏ i ∈ range r, (nthPrime i)^n = 2ⁿ · 3ⁿ · ... · pᵣⁿ.\n\nThis powered primorial is the extra factor that distinguishes #401 from simpler factorial problems.",
     "mathContext": "The primorial (product of first r primes) appears throughout number theory. Here we need the n-th power of each prime, giving massive additional divisibility.",
     "significance": "key",
     "relatedConcepts": [
@@ -41,12 +41,12 @@
     "id": "ann-e401-divides",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 57,
-      "endLine": 58
+      "startLine": 138,
+      "endLine": 177
     },
     "type": "definition",
-    "title": "Factorial Divisibility Predicate",
-    "content": "**def FactorialDivides (a₁ a₂ n r : ℕ)**: Prop\n  (a₁! · a₂!) ∣ (n! · primorialPow r n)\n\nThis is the central divisibility condition. We ask: given this condition, how large can a₁ + a₂ be relative to n?\n\nThe extra factor primorialPow(r,n) = 2ⁿ3ⁿ...pᵣⁿ provides additional prime powers that can satisfy divisibility for larger a₁, a₂.",
+    "title": "Factorial Divisibility Predicate (Part IV)",
+    "content": "**def FactorialDivides (a₁ a₂ n r : ℕ) : Prop** — (a₁! · a₂!) ∣ (n! · primorialPow r n).\n\nThe central divisibility condition: given it, how large can a₁ + a₂ be relative to n? The extra factor primorialPow(r,n) supplies additional prime powers.\n\nProved structural lemmas: classical divisibility implies it, symmetry in a₁,a₂, the trivial (a,0) case, reduction to classical divisibility at r=0 (`factorialDivides_zero_r`), and monotonicity in r (`factorialDivides_mono_r`).",
     "mathContext": "Factorial divisibility constraints are central to many Erdős problems. The divisibility a₁!a₂! | m determines which pairs (a₁, a₂) are valid.",
     "significance": "key",
     "relatedConcepts": [
@@ -60,12 +60,12 @@
     "id": "ann-e401-baseline",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 64,
-      "endLine": 67
+      "startLine": 183,
+      "endLine": 188
     },
     "type": "concept",
-    "title": "Erdős-Graham Baseline",
-    "content": "**axiom erdos_graham_baseline**:\n  ∃ C > 0, ∀ n a₁ a₂, n > 0 → a₁!a₂! | n! →\n  (a₁ + a₂) ≤ n + C · log(n)\n\n**Key insight**: Without the extra primorial factor, we can NEVER exceed n + O(log n).\n\nThis is the baseline that Problem #401 asks us to exceed by using the primorial factors.",
+    "title": "Erdős-Graham Baseline (Part V)",
+    "content": "**axiom erdos_graham_baseline**:\n  ∃ C > 0, ∀ n a₁ a₂, n > 0 → a₁!a₂! | n! →\n  (a₁ + a₂ : ℝ) ≤ n + C · log(n)\n\n**Key insight**: Without the extra primorial factor, we can NEVER exceed n + O(log n).\n\nThis is the baseline that Problem #401 asks us to exceed by using the primorial factors.",
     "mathContext": "This bound from Erdős-Graham (1980) shows that pure factorial divisibility is quite restrictive. The logarithmic bound is tight.",
     "significance": "key",
     "relatedConcepts": [
@@ -79,16 +79,16 @@
     "id": "ann-e401-conjecture",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 72,
-      "endLine": 81
+      "startLine": 194,
+      "endLine": 201
     },
     "type": "definition",
-    "title": "The Conjecture",
-    "content": "**def TendsToInfty (f : ℕ → ℝ)**: Prop\n  ∀ M, ∃ r₀, ∀ r ≥ r₀, f(r) ≥ M\n\n**def Erdos401Conjecture**: Prop\n  ∃ f, TendsToInfty f ∧\n  ∀ r, ∃ᶠ n in atTop, ∃ a₁ a₂,\n    FactorialDivides a₁ a₂ n r ∧\n    (a₁ + a₂) > n + f(r) · log(n)\n\n**In words**: Can we find f(r) → ∞ and, for each r, infinitely many n with a₁ + a₂ exceeding n + f(r)·log(n)?",
+    "title": "The Conjecture (Part VI)",
+    "content": "**def Erdos401Conjecture : Prop**\n  ∃ f : ℕ → ℝ, Filter.Tendsto f atTop atTop ∧\n  ∀ r, ∃ᶠ n in atTop, ∃ a₁ a₂,\n    FactorialDivides a₁ a₂ n r ∧\n    (a₁ + a₂ : ℝ) > n + f(r) · log(n)\n\nThe divergence f(r) → ∞ is expressed directly as `Filter.Tendsto f atTop atTop`.\n\n**In words**: Can we find f(r) → ∞ and, for each r, infinitely many n with a₁ + a₂ exceeding n + f(r)·log(n)?",
     "mathContext": "The 'infinitely many n' quantifier (∃ᶠ n in atTop) is crucial. The strong version with 'for all large n' is false!",
     "significance": "key",
     "relatedConcepts": [
-      "tends-to-infinity",
+      "tendsto-atTop",
       "frequently",
       "conjecture"
     ],
@@ -98,12 +98,12 @@
     "id": "ann-e401-proof",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 96,
-      "endLine": 99
+      "startLine": 203,
+      "endLine": 207
     },
     "type": "concept",
-    "title": "Barreto-Leeham Proof",
-    "content": "**axiom barreto_leeham_401**: Erdos401Conjecture\n\n**theorem erdos_401_proved**: Erdos401Conjecture := barreto_leeham_401\n\nBarreto and Leeham (2026) proved YES using the same construction as Problem #729.\n\n**Key idea**: Choose n related to primorial structure, set a₂ ≈ n/2 and a₁ ≈ n/2 + excess. The excess grows unboundedly as r increases.\n\n**Technique**: AI-assisted proof via ChatGPT, building on combinatorial number theory.",
+    "title": "Barreto-Leeham Result (Part VI)",
+    "content": "**axiom barreto_leeham_401 : Erdos401Conjecture**\n\n**theorem erdos_401_proved : Erdos401Conjecture := barreto_leeham_401**\n\nBarreto and Leeham (2026) proved YES using the same construction as Problem #729. The conjecture's truth is recorded as an axiom and re-exported as the headline theorem.\n\n**Key idea**: the primorial power factors give enough room in the factorial divisibility to push a₁ + a₂ beyond n by an amount growing with r.",
     "mathContext": "This is one of several Erdős problems solved via AI assistance. The same construction works for both #401 and #729.",
     "significance": "key",
     "relatedConcepts": [
@@ -117,12 +117,12 @@
     "id": "ann-e401-counterexample",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 108,
-      "endLine": 115
+      "startLine": 213,
+      "endLine": 222
     },
     "type": "concept",
-    "title": "Sothanaphan Counterexample",
-    "content": "**def Erdos401Strong**: Prop\n  Same as Erdos401Conjecture but with '∀ n ≥ N₀' instead of '∃ᶠ n'\n\n**axiom sothanaphan_counterexample**: ¬Erdos401Strong\n\n**Counterexample**: Take n = p_{r+1}^k - 1 (one less than a prime power).\n\nFor such n, the divisibility constraint forces a₁ + a₂ ≤ n + 2·p_{r+1}, which is bounded independent of how large k is.\n\nThis shows the quantifier matters: 'infinitely many n' vs 'all large n' give different answers!",
+    "title": "Sothanaphan Counterexample (Part VII)",
+    "content": "**def Erdos401Strong : Prop** — as Erdos401Conjecture but with '∀ n ≥ N₀' replacing '∃ᶠ n'.\n\n**axiom sothanaphan_counterexample : ¬Erdos401Strong**\n\n**Counterexample**: take n = p_{r+1}^k − 1 (one less than a prime power); such n force bounded excess, independent of k.\n\nThis shows the quantifier matters: 'infinitely many n' vs 'all large n' give different answers!",
     "mathContext": "This is a subtle point about quantifiers. The 'for all large n' version fails because some n have special structure that limits the excess.",
     "significance": "key",
     "relatedConcepts": [
@@ -133,15 +133,53 @@
     "prerequisites": []
   },
   {
+    "id": "ann-e401-consequences",
+    "proofId": "erdos-401",
+    "range": {
+      "startLine": 228,
+      "endLine": 248
+    },
+    "type": "concept",
+    "title": "Consequences: Unbounded Excess (Part VIII)",
+    "content": "Theorems proved from the axioms above:\n\n**theorem unbounded_excess** — for every bound C there is an r with a₁ + a₂ > n + C·log(n) for infinitely many n; obtained by choosing r where f(r) ≥ max(C,0) using `Filter.tendsto_atTop` and `Real.log_natCast_nonneg`.\n\n**theorem erdos_401_complete** — the full resolution: `Erdos401Conjecture ∧ ¬Erdos401Strong`, i.e. YES for infinitely many n but NO for all large n.",
+    "mathContext": "These corollaries combine the Barreto-Leeham result with the Sothanaphan counterexample to give the complete, quantifier-sensitive answer.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unbounded-excess",
+      "tendsto",
+      "complete-resolution"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e401-legendre",
+    "proofId": "erdos-401",
+    "range": {
+      "startLine": 254,
+      "endLine": 276
+    },
+    "type": "concept",
+    "title": "Legendre's Formula Connection (Part IX)",
+    "content": "The tool underlying the Erdős-Graham baseline is Legendre's formula ν_p(n!) = (n − s_p(n))/(p−1):\n\n**theorem legendre_formula** — (p−1)·ν_p(n!) = n − (digits p n).sum, proved from Mathlib's `Nat.Prime.sub_one_mul_multiplicity_factorial`.\n\n**theorem padic_valuation_factorial_bound** — there exists v with p^v | n! and v ≤ n/(p−1).",
+    "mathContext": "Legendre's formula controls the p-adic valuation of factorials via base-p digit sums; it is what makes the Erdős-Graham logarithmic bound provable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "legendre-formula",
+      "p-adic-valuation",
+      "digit-sum"
+    ],
+    "prerequisites": []
+  },
+  {
     "id": "ann-e401-g2",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 121,
-      "endLine": 130
+      "startLine": 281,
+      "endLine": 292
     },
-    "type": "concept",
-    "title": "The g₂ Function",
-    "content": "**noncomputable def g₂ (n : ℕ)**: ℝ\n  sSup { a₁ + a₂ - n | a₁!a₂! | n! }\n\nThe maximum excess when factorials divide n! (no extra factors).\n\n**axiom g2_log_bound**: ∃ C > 0, ∀ n > 1, g₂(n) ≤ C · log(n)\n\n**noncomputable def g₂_modified (n r : ℕ)**: ℝ\n  sSup { a₁ + a₂ - n | FactorialDivides a₁ a₂ n r }\n\nThe modified version with primorial factors - this can exceed C·log(n) by f(r)·log(n).",
+    "type": "definition",
+    "title": "The g₂ Functions (Part X)",
+    "content": "Definitions linking #401 to Problem #400:\n\n**def g₂ (n : ℕ) : ℝ** — sSup { a₁ + a₂ − n | a₁!a₂! | n! }, the maximum excess under classical divisibility.\n\n**def g₂_modified (n r : ℕ) : ℝ** — sSup { a₁ + a₂ − n | FactorialDivides a₁ a₂ n r }, the same excess with the enhanced primorial-factor constraint.\n\nProblem #401 concerns how much faster g₂_modified can grow than the O(log n)-bounded g₂.",
     "mathContext": "The g_k functions from Problem #400 measure the 'excess' possible in factorial divisibility. Problem #401 asks how the modified g₂ behaves.",
     "significance": "key",
     "relatedConcepts": [
@@ -152,59 +190,21 @@
     "prerequisites": []
   },
   {
-    "id": "ann-e401-reformulation",
-    "proofId": "erdos-401",
-    "range": {
-      "startLine": 137,
-      "endLine": 140
-    },
-    "type": "concept",
-    "title": "Reformulation via g₂",
-    "content": "**axiom erdos_401_reformulation**:\n  Erdos401Conjecture ↔\n  ∃ f, TendsToInfty f ∧\n  ∀ r, ∃ᶠ n in atTop, g₂_modified(n,r) > f(r) · log(n)\n\nThis shows #401 asks: can g₂_modified exceed f(r)·log(n) for unbounded f(r)?\n\nThe answer is YES, while for the unmodified g₂, we always have g₂(n) ≤ C·log(n).",
-    "mathContext": "This reformulation makes clear what the primorial factors accomplish: they allow the g-function to grow faster than logarithmically.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "reformulation",
-      "equivalence",
-      "g-function"
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "ann-e401-729",
-    "proofId": "erdos-401",
-    "range": {
-      "startLine": 146,
-      "endLine": 151
-    },
-    "type": "concept",
-    "title": "Connection to Problem #729",
-    "content": "**axiom erdos_729_connection**:\n  Erdos401Conjecture ↔ [equivalent statement for #729]\n\nThe same Barreto-Leeham construction proves both #401 and #729.\n\n**Problem #729** has a slightly different formulation but the underlying mathematics is the same.\n\nBoth problems ask about exceeding logarithmic bounds via careful factorial constructions.",
-    "mathContext": "This connection shows the Erdős problems form a web of related questions. Solving one often illuminates others.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "erdos-729",
-      "connection",
-      "same-construction"
-    ],
-    "prerequisites": []
-  },
-  {
     "id": "ann-e401-summary",
     "proofId": "erdos-401",
     "range": {
-      "startLine": 153,
-      "endLine": 175
+      "startLine": 296,
+      "endLine": 312
     },
     "type": "concept",
-    "title": "Summary and Status",
-    "content": "**Erdős Problem #401: PROVED** (Barreto-Leeham 2026)\n\n**Answer**: YES - such f(r) → ∞ exists.\n\n**Key Results**:\n1. Without extra factors: a₁ + a₂ ≤ n + O(log n) (Erdős-Graham)\n2. With primorial factors: can exceed n + f(r)·log(n) for f(r) → ∞\n3. But NOT for ALL large n - only INFINITELY MANY (Sothanaphan)\n\n**Connections**:\n- Related to Problem #400 (g_k function)\n- Same construction as Problem #729\n- AI-assisted proof via ChatGPT\n\n**Technique**: Careful choice of n exploiting primorial structure.",
+    "title": "Summary and Status (Part XI)",
+    "content": "**Erdős Problem #401: PROVED** (Barreto-Leeham 2026)\n\n**Answer**: YES — such f(r) → ∞ exists.\n\n**Key Results**:\n1. Without extra factors: a₁ + a₂ ≤ n + O(log n) (Erdős-Graham)\n2. With primorial factors: can exceed n + f(r)·log(n) for f(r) → ∞\n3. But NOT for ALL large n — only INFINITELY MANY (Sothanaphan)\n\n**Connections**: related to Problem #400 (g_k function); same construction as Problem #729.\n\n**Axiom budget**: 3 (erdos_graham_baseline, barreto_leeham_401, sothanaphan_counterexample).",
     "mathContext": "This problem illustrates how additional prime power factors can fundamentally change divisibility constraints, and the importance of exact quantifier formulations.",
     "significance": "key",
     "relatedConcepts": [
       "problem-status",
       "proved",
-      "ai-assisted"
+      "axiom-budget"
     ],
     "prerequisites": []
   }

--- a/src/data/proofs/erdos-401/meta.json
+++ b/src/data/proofs/erdos-401/meta.json
@@ -56,13 +56,13 @@
       "Definition of FactorialDivides predicate",
       "Axiom erdos_graham_baseline (a₁ + a₂ ≤ n + O(log n) bound)",
       "Theorem legendre_formula (proved from Mathlib via pow_multiplicity_dvd + sub_one_mul_multiplicity_factorial)",
-      "Definition of TendsToInfty for functions",
-      "Definition of Erdos401Conjecture using Filter.Frequently",
+      "Definition of Erdos401Conjecture using Filter.Tendsto (for f(r) → ∞) and Filter.Frequently",
+      "Theorems unbounded_excess and erdos_401_complete (proved consequences of the axioms)",
       "Axiom barreto_leeham_401 (main proof)",
       "Definition and axiom for Erdos401Strong (the false version)",
       "Axiom sothanaphan_counterexample",
-      "Definition of g₂ and g₂_modified functions",
-      "Connection to Problem #729"
+      "Theorem padic_valuation_factorial_bound (p-adic valuation of n! via Legendre's formula)",
+      "Definition of g₂ and g₂_modified functions"
     ],
     "axiomCount": 3,
     "lineCount": 319,
@@ -74,7 +74,7 @@
     "historicalContext": "This problem comes from Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory'. It is closely related to Problems #400 and #729.\n\n**The g_k Function**: Problem #400 introduced g_k(n), the maximum of (a₁ + ... + a_k) - n subject to a₁!...a_k! | n!. Erdős-Graham showed g_k(n) ≪ log(n).\n\n**The Extra Factors**: Problem #401 asks what happens when we multiply n! by prime powers 2ⁿ3ⁿ...p_rⁿ. These extra factors provide additional 'room' for the factorial divisibility.\n\n**Resolution**: In 2026, Barreto and Leeham proved the answer is YES using AI-assisted methods. Interestingly, Sothanaphan showed that the stronger version (for ALL large n) is FALSE, using the counterexample n = p_{r+1}^k - 1.",
     "problemStatement": "**Erdős Problem #401**: Is there some function $f(r)$ such that $f(r) \\to \\infty$ as $r \\to \\infty$, such that for infinitely many $n$, there exist $a_1, a_2$ with\n$$a_1 + a_2 > n + f(r) \\log n$$\nsuch that $a_1! a_2! \\mid n! \\cdot 2^n \\cdot 3^n \\cdots p_r^n$?\n\n**Answer**: YES (Barreto-Leeham 2026)\n\n**Key Subtlety**: The quantifier 'for infinitely many n' is essential. The version with 'for all large n' is FALSE.\n\n**Counterexample to Strong Version**: Sothanaphan showed that taking $n = p_{r+1}^k - 1$ forces $a_1 + a_2 \\leq n + 2p_{r+1}$, which is bounded.",
     "text": "Does there exist f(r) → ∞ such that for infinitely many n, there exist a₁, a₂ with a₁ + a₂ > n + f(r)·log(n) where a₁!·a₂! | n!·2ⁿ·3ⁿ·...·pᵣⁿ? YES (Barreto-Leeham 2026). The 'for all large n' version is FALSE (Sothanaphan).",
-    "proofStrategy": "The formalization captures both the positive result and the counterexample:\n\n1. **Infrastructure**:\n   - `nthPrime`: The r-th prime via Nat.nth\n   - `primorialPow`: Product 2ⁿ·3ⁿ·...·p_rⁿ\n   - `FactorialDivides`: The central divisibility condition\n\n2. **Baseline**:\n   - `erdos_graham_baseline`: Without extra factors, a₁ + a₂ ≤ n + O(log n)\n\n3. **The Conjecture**:\n   - `TendsToInfty`: f(r) → ∞ as r → ∞\n   - `Erdos401Conjecture`: Existence of such f with infinitely many n\n\n4. **Resolution**:\n   - `barreto_leeham_401`: The main YES result (axiom)\n   - `erdos_401_proved`: The theorem statement\n\n5. **Counterexample**:\n   - `Erdos401Strong`: The false 'for all large n' version\n   - `sothanaphan_counterexample`: Proof it's false",
+    "proofStrategy": "The formalization captures both the positive result and the counterexample:\n\n1. **Infrastructure**:\n   - `nthPrime`: The r-th prime via Nat.nth\n   - `primorialPow`: Product 2ⁿ·3ⁿ·...·p_rⁿ\n   - `FactorialDivides`: The central divisibility condition\n\n2. **Baseline**:\n   - `erdos_graham_baseline`: Without extra factors, a₁ + a₂ ≤ n + O(log n)\n\n3. **The Conjecture**:\n   - `Erdos401Conjecture`: existence of f with `Filter.Tendsto f atTop atTop` (f(r) → ∞) and infinitely many n\n\n4. **Resolution**:\n   - `barreto_leeham_401`: The main YES result (axiom)\n   - `erdos_401_proved`: The theorem statement\n   - `unbounded_excess`, `erdos_401_complete`: proved consequences\n\n5. **Counterexample**:\n   - `Erdos401Strong`: The false 'for all large n' version\n   - `sothanaphan_counterexample`: Proof it's false",
     "keyInsights": [
       "**Quantifier sensitivity**: The problem has different answers depending on 'infinitely many n' vs 'all large n'. This subtlety was clarified through the counterexample.",
       "**Prime power factors matter**: The primorial factors 2ⁿ3ⁿ...p_rⁿ fundamentally change the divisibility landscape, allowing larger a₁ + a₂ values.",
@@ -90,83 +90,99 @@
   "sections": [
     {
       "id": "header",
-      "title": "Problem Overview",
+      "title": "File Header and Problem Statement",
       "startLine": 1,
-      "endLine": 37,
-      "summary": "Problem statement, background, and solution summary.",
-      "mathContext": "Mathematical content: Problem statement, background, and solution summary."
+      "endLine": 56,
+      "summary": "Docstring statement of Erdős Problem #401 (does some f(r)→∞ allow a₁+a₂ > n + f(r)·log n with a₁!·a₂! | n!·2ⁿ3ⁿ⋯pᵣⁿ for infinitely many n?), background tying it to Problem #400's g_k, the YES answer (Barreto–Leeham 2026), the Sothanaphan counterexample to the 'all large n' variant, and references; followed by Mathlib imports, opened namespaces, and the `noncomputable section`/`namespace Erdos401` setup.",
+      "mathContext": "Problem statement, historical background, and the Lean preamble (imports, `open Nat Real BigOperators Finset Filter`, namespace)."
     },
     {
       "id": "primes",
-      "title": "Prime Infrastructure",
-      "startLine": 45,
-      "endLine": 53,
-      "summary": "nthPrime and primorialPow definitions.",
-      "mathContext": "Formal definition: nthPrime and primorialPow definitions."
+      "title": "Part I — Prime Infrastructure",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "Core definitions: `nthPrime r` (the r-th prime via `Nat.nth Nat.Prime`, 0-indexed), `primorial r` (product of the first r primes), and `primorialPow r n` (product of the first r primes each raised to the n-th power, i.e. 2ⁿ3ⁿ⋯pᵣⁿ).",
+      "mathContext": "Definitions of `nthPrime`, `primorial`, and `primorialPow` over `Finset.range`."
+    },
+    {
+      "id": "prime-properties",
+      "title": "Part II — Prime Properties",
+      "startLine": 72,
+      "endLine": 91,
+      "summary": "Basic facts about `nthPrime`, all proved: each value is prime (`nthPrime_prime`), is ≥ 2 (`nthPrime_ge_two`), is positive (`nthPrime_pos`), and the sequence is strictly monotone (`nthPrime_strictMono`).",
+      "mathContext": "Theorems establishing primality, positivity, and strict monotonicity of the prime sequence, derived from `Nat.nth` lemmas on the infinite set of primes."
+    },
+    {
+      "id": "primorial-properties",
+      "title": "Part III — Primorial Properties",
+      "startLine": 92,
+      "endLine": 133,
+      "summary": "Proved properties of the primorial and its powered form: `primorial_zero` (empty product = 1), `primorial_succ` (recursion), `primorial_pos`, `primorial_mono` (monotone), `primorialPow_zero`, and `primorialPow_pos`.",
+      "mathContext": "Positivity, monotonicity, and recursion lemmas for `primorial` and `primorialPow`, proved via `Finset.prod_range_succ` and `Finset.prod_pos`."
     },
     {
       "id": "divides",
-      "title": "Divisibility Predicate",
-      "startLine": 54,
-      "endLine": 59,
-      "summary": "FactorialDivides definition.",
-      "mathContext": "Formal definition: FactorialDivides definition."
+      "title": "Part IV — Divisibility Predicate and Properties",
+      "startLine": 134,
+      "endLine": 178,
+      "summary": "The factorial-divisibility predicate `FactorialDivides a₁ a₂ n r` ((a₁!·a₂!) | (n!·primorialPow r n)) and its proved properties: classical divisibility implies it (`classical_implies_factorialDivides`), symmetry in a₁,a₂, the trivial (a,0) case, reduction to classical divisibility at r=0 (`factorialDivides_zero_r`), and monotonicity in r (`factorialDivides_mono_r`).",
+      "mathContext": "Definition of `FactorialDivides` and structural lemmas (symmetry, r=0 reduction, monotonicity in r) via divisibility transitivity and `Finset.prod_dvd_prod_of_subset`."
     },
     {
       "id": "baseline",
-      "title": "Erdős-Graham Baseline",
-      "startLine": 60,
-      "endLine": 68,
-      "summary": "The O(log n) bound without extra factors.",
-      "mathContext": "The $O($\\log n$)$ bound without extra factors."
+      "title": "Part V — The Erdős–Graham Baseline",
+      "startLine": 179,
+      "endLine": 189,
+      "summary": "The `erdos_graham_baseline` axiom: without the extra prime-power factors, a₁!·a₂! | n! forces a₁+a₂ ≤ n + C·log n for some constant C>0. This O(log n) bound is the baseline that Problem #401 asks whether one can exceed.",
+      "mathContext": "Axiom recording the Erdős–Graham O(log n) excess bound for classical factorial divisibility."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 69,
-      "endLine": 82,
-      "summary": "TendsToInfty and Erdos401Conjecture definitions.",
-      "mathContext": "Formal definition: TendsToInfty and Erdos401Conjecture definitions."
-    },
-    {
-      "id": "proof",
-      "title": "Main Proof",
-      "startLine": 83,
-      "endLine": 100,
-      "summary": "Barreto-Leeham axiom and erdos_401_proved theorem.",
-      "mathContext": "Verified: Barreto-Leeham axiom and erdos_401_proved theorem."
+      "title": "Part VI — The Conjecture and Main Results",
+      "startLine": 190,
+      "endLine": 208,
+      "summary": "The formal conjecture `Erdos401Conjecture` (∃ f→∞ such that for every r, infinitely often there exist a₁,a₂ with FactorialDivides and a₁+a₂ > n + f(r)·log n), the `barreto_leeham_401` axiom asserting its truth, and `erdos_401_proved` discharging the conjecture from that axiom.",
+      "mathContext": "Definition of `Erdos401Conjecture` using `Filter.Tendsto … atTop` and `∃ᶠ … in atTop`; the Barreto–Leeham result recorded as an axiom and re-exported as a theorem."
     },
     {
       "id": "counterexample",
-      "title": "Sothanaphan Counterexample",
-      "startLine": 101,
-      "endLine": 116,
-      "summary": "Erdos401Strong definition and sothanaphan_counterexample.",
-      "mathContext": "Formal definition: Erdos401Strong definition and sothanaphan_counterexample."
+      "title": "Part VII — The Sothanaphan Counterexample",
+      "startLine": 209,
+      "endLine": 223,
+      "summary": "The strengthened 'for all large n' variant `Erdos401Strong` and the `sothanaphan_counterexample` axiom showing it is FALSE — the witness n = p_{r+1}^k − 1 (one less than a prime power) forces bounded excess.",
+      "mathContext": "Definition of `Erdos401Strong` and the axiom `¬Erdos401Strong` recording Sothanaphan's refutation of the uniform variant."
+    },
+    {
+      "id": "consequences",
+      "title": "Part VIII — Consequences",
+      "startLine": 224,
+      "endLine": 249,
+      "summary": "Theorems proved from the axioms above: `unbounded_excess` (for every bound C some r makes a₁+a₂ > n + C·log n infinitely often, via tendsto of f) and `erdos_401_complete` (the full resolution: the conjecture holds while its uniform strengthening fails).",
+      "mathContext": "Proved corollaries combining `erdos_401_proved` and `sothanaphan_counterexample`; uses `Filter.tendsto_atTop` and `Real.log_natCast_nonneg`."
+    },
+    {
+      "id": "legendre",
+      "title": "Part IX — Legendre's Formula Connection",
+      "startLine": 250,
+      "endLine": 276,
+      "summary": "Legendre's formula as the tool underlying the baseline: `legendre_formula` ((p−1)·ν_p(n!) = n − s_p(n), the base-p digit sum) proved from Mathlib's `Nat.Prime.sub_one_mul_multiplicity_factorial`, and `padic_valuation_factorial_bound` giving v ≤ n/(p−1) with p^v | n!.",
+      "mathContext": "Theorems expressing the p-adic valuation of n! via the digit-sum form of Legendre's formula, using `multiplicity` and `pow_multiplicity_dvd`."
     },
     {
       "id": "g-functions",
-      "title": "The g₂ Functions",
-      "startLine": 117,
-      "endLine": 141,
-      "summary": "g₂, g₂_modified, and reformulation.",
-      "mathContext": "Mathematical content: g₂, g₂_modified, and reformulation."
-    },
-    {
-      "id": "connections",
-      "title": "Connection to #729",
-      "startLine": 142,
-      "endLine": 152,
-      "summary": "erdos_729_connection axiom.",
-      "mathContext": "Axiomatized: erdos_729_connection axiom."
+      "title": "Part X — Connection to Problem #400 (g₂ function)",
+      "startLine": 277,
+      "endLine": 293,
+      "summary": "Definitions linking to Problem #400: `g₂ n` (the supremum of a₁+a₂−n over classical divisibility) and `g₂_modified n r` (the same with the enhanced `FactorialDivides` constraint), formalizing the excess functions whose growth the problem concerns.",
+      "mathContext": "Definitions of the excess functions `g₂` and `g₂_modified` as suprema (`sSup`) over factorial-divisibility witness sets."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 153,
+      "title": "Part XI — Summary",
+      "startLine": 294,
       "endLine": 319,
-      "summary": "Problem status and key results.",
-      "mathContext": "Mathematical content: Problem status and key results."
+      "summary": "Closing prose recap: the answer is YES (Barreto–Leeham 2026), the primorial factors supply the extra room, the same construction handles Problem #729, and the uniform variant is false (Sothanaphan); notes the 3-axiom budget and the `#check` verification commands.",
+      "mathContext": "Narrative summary of the result, axiom budget, and key points; final `#check` statements verifying the exported declarations."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-436/annotations.json
+++ b/src/data/proofs/erdos-436/annotations.json
@@ -27,18 +27,18 @@
     "proofId": "erdos-436",
     "type": "concept",
     "range": {
-      "startLine": 404,
-      "endLine": 556
+      "startLine": 417,
+      "endLine": 583
     },
-    "title": "Fermat's Little Theorem, QR Multiplicativity, and Power Residue Arithmetic",
-    "content": "A large block of proved theorems and axioms building the number-theoretic infrastructure. Key proved results: `fermat_little_theorem` ($r^{p-1} \\equiv 1 \\pmod{p}$ for $\\gcd(r,p)=1$), `kth_residue_fermat_little` (applies Fermat to power residues), `euler_criterion_forward` ($a$ is QR $\\Rightarrow a^{(p-1)/2} \\equiv 1$). Axiomatized: `qr_product_non_residues` (product of two non-residues is a residue via Legendre symbol multiplicativity), `consecutive_qr_existence_k2` (Hildebrand: consecutive pairs of $k$th power residues start bounded). The `even_k_m3_infinite` and `lambda_finite_small_m` theorems establish the parity dichotomy.",
+    "title": "Part XI — Power Residue Arithmetic, Fermat's Little Theorem, and QR Multiplicativity",
+    "content": "A block of proved supporting theorems. Key results, all proved: `kth_residue_mul` (product of kth power residues is one), `fermat_little_theorem` ($r^{p-1} \\equiv 1 \\pmod p$ for $\\gcd(r,p)=1$, via Mathlib's `ZMod.pow_card_sub_one_eq_one`), `kth_residue_fermat_little`, the `ZMod`/`IsSquare` bridge lemmas, and `qr_product_non_residues` (the product of two quadratic non-residues mod an odd prime is a residue, proved via Legendre-symbol multiplicativity `legendreSym.mul`). Also `count_kth_residues`, `half_are_qr`, and the observed $\\Lambda(k,2)$ data lemmas (`lambda_2_monotone_observed`, `all_lambda_2_values_known`, `lambda_2_gaps`, `lambda_8_2_finite`, `lambda_up_to_100_finite`, `m_2_complete_picture`, `lambda_values_positive`).",
     "mathContext": "Fermat: $r^{p-1} \\equiv 1 \\pmod{p}$ for $p \\nmid r$. Euler: $a$ is QR mod $p$ $\\iff a^{(p-1)/2} \\equiv 1 \\pmod{p}$. Legendre: $(ab/p) = (a/p)(b/p)$, so non-residue $\\times$ non-residue = residue.",
     "significance": "key",
     "relatedConcepts": [
       "Fermat's Little Theorem",
-      "Euler's criterion",
       "Legendre symbol",
-      "quadratic residues"
+      "quadratic residues",
+      "ZMod"
     ],
     "prerequisites": [
       "Nat.Prime",
@@ -51,17 +51,17 @@
     "proofId": "erdos-436",
     "type": "concept",
     "range": {
-      "startLine": 580,
-      "endLine": 634
+      "startLine": 584,
+      "endLine": 686
     },
-    "title": "Euler's Criterion and Quadratic Reciprocity Applications",
-    "content": "The closing section proves and axiomatizes the full Euler criterion ($a$ is QR mod $p$ $\\iff a^{(p-1)/2} \\equiv 1$) and applies it to specific computations. The forward direction is proved via direct computation; the backward direction (`euler_criterion_backward`) is axiomatized as it requires deeper `ZMod` machinery. The combined `euler_criterion` iff statement wraps both. Additional axioms encode specific computational results for small power residues and lambda values.",
+    "title": "Part XII — Euler's Criterion and ZMod Connections",
+    "content": "The closing part proves Euler's criterion in full. `euler_criterion_forward` ($a$ a QR $\\Rightarrow a^{(p-1)/2} \\equiv 1$) is proved via Fermat's Little Theorem; `euler_criterion_backward` is proved using Mathlib's `ZMod.euler_criterion` together with the $\\mathbb{N} \\leftrightarrow \\mathrm{ZMod}\\,p$ bridge lemmas; and `euler_criterion` wraps both as an iff. Also proved here: Legendre-symbol multiplicativity (`legendre_sym_mul`), the power lemma `pow_multiple_p_minus_one`, and the quadratic-residue counting facts `prime_sub_one_even`, `count_qr_exact`, and `qr_nonqr_equal_count`. All declarations in this part are proved theorems (no axioms).",
     "mathContext": "Euler's criterion: $a \\in (\\mathbb{Z}/p\\mathbb{Z})^{\\times 2} \\iff a^{(p-1)/2} \\equiv 1 \\pmod{p}$. Forward: if $a = b^2$, then $a^{(p-1)/2} = b^{p-1} = 1$ by Fermat. Backward: requires that $x^{(p-1)/2} = 1$ has exactly $(p-1)/2$ solutions, which are exactly the QRs.",
     "significance": "key",
     "relatedConcepts": [
       "Euler's criterion",
-      "quadratic residue computation",
-      "ZMod machinery"
+      "Legendre symbol",
+      "ZMod"
     ],
     "prerequisites": [
       "fermat_little_theorem",
@@ -373,7 +373,7 @@
     "significance": "key",
     "relatedConcepts": [
       "Legendre symbol multiplicativity",
-      "quadratic reciprocity",
+      "non-residue product rule",
       "case analysis"
     ],
     "prerequisites": [

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -49,99 +49,115 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Header and Imports",
+      "title": "File Header and Imports",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Module docstring documenting the problem statement, background, and references; 6 Mathlib imports covering required modules; `open` declarations (Nat Classical)",
-      "mathContext": "Module docstring documenting the problem statement, background, and references; 6 Mathlib imports covering required modules; `open` declarations (Nat Classical)"
+      "endLine": 46,
+      "summary": "Docstring statement of Erdős Problem #436: for prime p and k,m ≥ 2, r(k,m,p) is the minimal r with r,…,r+m−1 all kth power residues mod p, and Λ(k,m) = limsup_{p→∞} r(k,m,p). Lists the three questions (Λ(k,2) finite ∀k — SOLVED Hildebrand 1991; Λ(k,3) finite ∀ odd k — OPEN; growth rates — PARTIAL), the known exact values, and references; followed by Mathlib imports, `open Nat Classical`, and `namespace Erdos436`.",
+      "mathContext": "Problem statement, known-value table, and Lean preamble (imports including `ZMod.Basic`, `FieldTheory.Finite.Basic`, `LegendreSymbol.Basic`)."
     },
     {
       "id": "definitions",
-      "title": "Power Residue Definitions",
-      "startLine": 45,
+      "title": "Part I — Power Residue Definitions",
+      "startLine": 47,
       "endLine": 70,
-      "summary": "Defines $\\texttt{IsKthPowerResidue}(r, k, p) \\iff \\exists x,\\; x^k \\bmod p = r \\bmod p$, consecutive runs $\\texttt{AreConsecutiveKthResidues}$, and the quadratic residue specialization $k = 2$.",
-      "mathContext": "Formal definition: Defines $\\texttt{IsKthPowerResidue}(r, k, p) \\iff \\exists x,\\; x^k \\bmod p = r \\bmod p$, consecutive runs $\\texttt{AreConsecutiveKthResidues}$, and the quadratic residue specialization $k = 2$."
+      "summary": "Core definitions: `IsKthPowerResidue r k p` (∃ x, xᵏ ≡ r mod p), `AreConsecutiveKthResidues r k m p` (r,…,r+m−1 all kth power residues), and `IsQuadraticResidue r p` (the k=2 specialization).",
+      "mathContext": "Definitions of kth power residues, consecutive runs, and the quadratic-residue special case over ℕ with `% p`."
     },
     {
       "id": "structural",
-      "title": "Structural Properties",
+      "title": "Part Ib — Structural Properties of Power Residues",
       "startLine": 71,
       "endLine": 156,
-      "summary": "Proved lemmas: $0, 1$, and perfect powers are always $k$th power residues; $k = 1$ is trivial; runs can be extended, shortened, shifted, and verified at individual positions.",
-      "mathContext": "Mathematical content: Proved lemmas: $0, 1$, and perfect powers are always $k$th power residues; $k = 1$ is trivial; runs can be extended, shortened, shifted, and verified at individual positions."
+      "summary": "Proved structural lemmas: 0, 1, perfect kth powers, and (for k=1) every integer are kth power residues; reduction mod p preserves the property (`kth_residue_mod`); and run-manipulation lemmas `consecutive_single`/`_at`/`_extend`/`_shorten`/`_shift`/`_max_element`, plus `all_are_first_power_residues`.",
+      "mathContext": "Theorems establishing closure and monotonicity properties of (consecutive) kth power residues via elementary modular arithmetic."
     },
     {
       "id": "r-function",
-      "title": "The $r(k,m,p)$ Function",
+      "title": "Part II — The r(k,m,p) Function",
       "startLine": 157,
-      "endLine": 176,
-      "summary": "Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. A docstring at lines 170–173 notes existence for large primes informally; no axiom or theorem formalizes this claim.",
-      "mathContext": "Formal definition: Defines $r(k,m,p) = \\min\\{r \\geq 1 : r, \\ldots, r+m-1$ are $k$th power residues$\\}$ via $\\texttt{Nat.find}$. Existence for large primes is mentioned in a docstring only; no formal declaration."
+      "endLine": 173,
+      "summary": "Definition `minConsecKthResidues k m p` — the minimal r ≥ 1 starting a length-m run of consecutive kth power residues mod p (via `Nat.find` when such r exists, else 0).",
+      "mathContext": "`noncomputable def` using `Nat.find` over the decidable existence of a consecutive run."
     },
     {
       "id": "lambda-function",
-      "title": "The $\\Lambda(k,m)$ Function",
-      "startLine": 177,
-      "endLine": 196,
-      "summary": "Defines $\\texttt{LambdaFinite}(k, m)$ (existence of uniform bound) and $\\Lambda(k, m) = \\min\\{N : \\forall p > N,\\; r(k,m,p) \\leq N\\}$ via $\\texttt{Nat.find}$.",
-      "mathContext": "Formal definition: Defines $\\texttt{LambdaFinite}(k, m)$ (existence of uniform bound) and $\\Lambda(k, m) = \\min\\{N : \\forall p > N,\\; r(k,m,p) \\leq N\\}$ via $\\texttt{Nat.find}$."
+      "title": "Part III — The Λ(k,m) Function",
+      "startLine": 174,
+      "endLine": 193,
+      "summary": "Definitions `LambdaFinite k m` (a uniform bound N exists so r(k,m,p) ≤ N for all large primes p) and `Lambda k m` (the exact value via `Nat.find` when finite, else 0), formalizing the limsup quantity Λ(k,m).",
+      "mathContext": "Definitions of finiteness and exact value of Λ(k,m) using a uniform-bound predicate and `Nat.find`."
     },
     {
       "id": "known-values",
-      "title": "Known Exact Values",
-      "startLine": 197,
-      "endLine": 238,
-      "summary": "Axiomatized: $\\Lambda(2,2) = 9$, $\\Lambda(3,2) = 77$, $\\Lambda(4,2) = 1224$, $\\Lambda(5,2) = 7888$, $\\Lambda(6,2) = 202124$, $\\Lambda(7,2) = 1649375$ from 1960s computations.",
-      "mathContext": "Axiomatized: Axiomatized: $\\Lambda(2,2) = 9$, $\\Lambda(3,2) = 77$, $\\Lambda(4,2) = 1224$, $\\Lambda(5,2) = 7888$, $\\Lambda(6,2) = 202124$, $\\Lambda(7,2) = 1649375$ from 1960s computations."
+      "title": "Part IV — Known Exact Values for m = 2",
+      "startLine": 194,
+      "endLine": 235,
+      "summary": "The six computed values of Λ(k,2), recorded as axioms: Λ(2,2)=9 (Lehmer-Lehmer 1962), Λ(3,2)=77 (Dunton 1965), Λ(4,2)=1224 (Bierstedt-Mills 1963), Λ(5,2)=7888 and Λ(6,2)=202124 (Lehmer-Lehmer-Mills 1963), Λ(7,2)=1649375 (Brillhart-Lehmer-Lehmer 1964).",
+      "mathContext": "Axioms recording the literature's exact Λ(k,2) values for k = 2..7."
     },
     {
       "id": "hildebrand",
-      "title": "Hildebrand's Theorem (1991)",
-      "startLine": 239,
-      "endLine": 258,
-      "summary": "Resolves Question 1: $\\forall k \\geq 2,\\; \\Lambda(k, 2) < \\infty$. Uses character sum estimates and the large sieve inequality. The theorem $\\texttt{erdos\\_436\\_question1}$ follows directly.",
-      "mathContext": "Resolves Question 1: $\\forall k \\geq 2,\\; \\Lambda(k, 2) < \\infty$. The theorem $\\texttt{erdos\\_436\\_question1}$ follows directly."
+      "title": "Part V — Hildebrand's Theorem (1991)",
+      "startLine": 236,
+      "endLine": 255,
+      "summary": "The `hildebrand_theorem` axiom: Λ(k,2) is finite for all k ≥ 2 (proved by Hildebrand 1991 via character-sum estimates and the large sieve), and `erdos_436_question1` re-exporting it as the resolution of Question 1.",
+      "mathContext": "Axiom + corollary recording the affirmative answer to the m=2 finiteness question."
     },
     {
       "id": "m3-case",
-      "title": "The $m = 3$ Case and Parity Dichotomy",
-      "startLine": 259,
-      "endLine": 286,
-      "summary": "$\\Lambda(3,3) = 23532$ (Lehmer-Lehmer-Mills-Selfridge). $\\Lambda(k,3) = \\infty$ for even $k$ (Lehmer-Lehmer parity obstruction). Open question: is $\\Lambda(k,3) < \\infty$ for odd $k \\geq 5$?",
-      "mathContext": "Mathematical content: $\\Lambda(3,3) = 23532$ (Lehmer-Lehmer-Mills-Selfridge). $\\Lambda(k,3) = \\infty$ for even $k$ (Lehmer-Lehmer parity obstruction). Open question: is $\\Lambda(k,3) < \\infty$ for odd $k \\geq 5$?"
+      "title": "Part VI — The m = 3 Case",
+      "startLine": 256,
+      "endLine": 281,
+      "summary": "The m=3 dichotomy: `lambda_even_3_infinite` axiom (Λ(k,3)=∞ for even k, Lehmer-Lehmer 1962), the noted value Λ(3,3)=23532, and the predicate `erdos436Question2` capturing the OPEN question of whether Λ(k,3) is finite for all odd k ≥ 3.",
+      "mathContext": "Axiom for the even-k infinitude and a `Prop` stating the open odd-k finiteness question."
     },
     {
       "id": "graham",
-      "title": "Graham's Theorem (1964)",
-      "startLine": 287,
-      "endLine": 311,
-      "summary": "$\\Lambda(k, m) = \\infty$ for all $k \\geq 2, m \\geq 4$. Corollary: $\\texttt{LambdaFinite}(k, m) \\Rightarrow m \\leq 3$, proved by contradiction.",
-      "mathContext": "Mathematical content: $\\Lambda(k, m) = \\infty$ for all $k \\geq 2, m \\geq 4$. Corollary: $\\texttt{LambdaFinite}(k, m) \\Rightarrow m \\leq 3$, proved by contradiction."
+      "title": "Part VII — Graham's Theorem (1964)",
+      "startLine": 282,
+      "endLine": 306,
+      "summary": "The `graham_theorem` axiom: Λ(k,m)=∞ for all k ≥ 2 and m ≥ 4 (Graham 1964), and the corollary `only_small_m_matters` deducing that finiteness forces m ≤ 3.",
+      "mathContext": "Axiom for m ≥ 4 infinitude plus a contrapositive corollary via `by_contra`/`push_neg`."
     },
     {
       "id": "quadratic",
-      "title": "Quadratic Residue Case: $\\Lambda(2,2) \\leq 9$",
-      "startLine": 312,
-      "endLine": 335,
-      "summary": "The Lehmer-Lehmer argument via Legendre symbol multiplicativity: $(10/p) = (2/p)(5/p)$ forces a consecutive QR pair among $\\{1,2\\}$, $\\{4,5\\}$, or $\\{9,10\\}$. Also: $\\{9,10\\}$ is achieved infinitely often.",
-      "mathContext": "The Lehmer-Lehmer argument via Legendre symbol multiplicativity: $(10/p) = (2/p)(5/p)$ forces a consecutive QR pair among $\\{1,2\\}$, $\\{4,5\\}$, or $\\{9,10\\}$. Also: $\\{9,10\\}$ is achieved infinitely often."
+      "title": "Part VIII — The Quadratic Residue Case",
+      "startLine": 307,
+      "endLine": 327,
+      "summary": "The proved bound `lambda_2_2_bound : Lambda 2 2 ≤ 9`, with the elegant argument that 9=3² is a QR and, if 10 is not, the factorization 10=2·5 into non-QRs forces one of {1,2}, {4,5}, {9,10} to be a consecutive QR pair.",
+      "mathContext": "Theorem discharging the Λ(2,2) ≤ 9 bound by rewriting with the `lambda_2_2` value."
     },
     {
       "id": "growth",
-      "title": "Growth Rate Analysis",
-      "startLine": 336,
-      "endLine": 540,
-      "summary": "Super-polynomial growth axiomatized. Monotonicity and gaps proved via $\\texttt{native\\_decide}$: $68, 1147, 6664, 194236, 1447251$. Also: $\\Lambda(8,2)$ finite (Hildebrand), all values positive.",
-      "mathContext": "Axiomatized: Super-polynomial growth axiomatized. Monotonicity and gaps proved via $\\texttt{native\\_decide}$: $68, 1147, 6664, 194236, 1447251$. Also: $\\Lambda(8,2)$ finite (Hildebrand), all values positive."
+      "title": "Part IX — Growth Rate Questions",
+      "startLine": 328,
+      "endLine": 347,
+      "summary": "The predicate `growthRatePolynomial` expressing polynomial-boundedness of Λ(k,2) over ℕ (∃ f bounding Λ with f(k) ≤ k^d for some d), framing the open question of how fast the rapidly-growing sequence 9, 77, 1224, 7888, 202124, 1649375 increases with k.",
+      "mathContext": "Definition encoding polynomial growth of Λ(k,2); the exact growth rate remains open."
     },
     {
-      "id": "flt-euler",
-      "title": "Fermat's Little Theorem and Euler's Criterion",
-      "startLine": 541,
-      "endLine": 634,
-      "summary": "FLT $r^{p-1} \\equiv 1 \\pmod{p}$ proved from $\\texttt{ZMod.pow\\_card\\_sub\\_one\\_eq\\_one}$. Euler's criterion forward ($r = x^2 \\Rightarrow r^{(p-1)/2} = 1$) proved via calc chain; backward axiomatized. Legendre symbol multiplicativity from Mathlib.",
-      "mathContext": "FLT: $r^{p-1} \\equiv 1 \\pmod{p}$ via ZMod.pow_card_sub_one_eq_one. Euler criterion: $r = x^2 \\Rightarrow r^{(p-1)/2} = 1$ proved forward; backward axiomatized. Legendre symbol multiplicativity from Mathlib."
+      "id": "summary",
+      "title": "Part X — Summary",
+      "startLine": 348,
+      "endLine": 416,
+      "summary": "Summary theorems aggregating the results: `erdos_436_summary` and `erdos_436_partially_solved` (Hildebrand finiteness + Graham m≥4 infinitude + Lehmer-Lehmer even-k m=3 infinitude), plus consequences `even_k_m3_infinite`, `lambda_finite_small_m`, `quadratic_case_complete`, `no_four_consecutive_qr`, and `no_five_consecutive`.",
+      "mathContext": "Theorems combining the axiomatized results into the overall partial-resolution statement and its immediate corollaries."
+    },
+    {
+      "id": "additional-structural",
+      "title": "Part XI — Additional Structural Results",
+      "startLine": 417,
+      "endLine": 583,
+      "summary": "Further proved structure: multiplicativity of kth residues (`kth_residue_mul`), Fermat's Little Theorem (`fermat_little_theorem`, via `ZMod.pow_card_sub_one_eq_one`), ZMod/IsSquare bridge lemmas, the product-of-two-non-residues-is-a-residue fact (`qr_product_non_residues`, via Legendre-symbol multiplicativity), residue counts (`count_kth_residues`, `half_are_qr`), and observed Λ(k,2) value/gap/positivity/finiteness lemmas (`lambda_2_monotone_observed`, `all_lambda_2_values_known`, `lambda_2_gaps`, `lambda_8_2_finite`, `lambda_up_to_100_finite`, `m_2_complete_picture`, `lambda_values_positive`).",
+      "mathContext": "Proved number-theoretic lemmas bridging the ℕ definitions to Mathlib's `ZMod`/Legendre-symbol API and recording the known Λ(k,2) data."
+    },
+    {
+      "id": "euler-criterion",
+      "title": "Part XII — Euler's Criterion and ZMod Connections",
+      "startLine": 584,
+      "endLine": 686,
+      "summary": "Euler's criterion in both directions and as an iff (`euler_criterion_forward`/`_backward`/`euler_criterion`, via `ZMod.euler_criterion` and Fermat's Little Theorem), Legendre-symbol multiplicativity (`legendre_sym_mul`), the power lemma `pow_multiple_p_minus_one`, and quadratic-residue counting facts (`prime_sub_one_even`, `count_qr_exact`, `qr_nonqr_equal_count`).",
+      "mathContext": "Theorems connecting the file's residue definitions to Euler's criterion and exact QR counts over `ZMod p` for odd primes."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-454/annotations.json
+++ b/src/data/proofs/erdos-454/annotations.json
@@ -125,8 +125,8 @@
     "proofId": "erdos-454",
     "type": "definition",
     "range": {
-      "startLine": 92,
-      "endLine": 93
+      "startLine": 102,
+      "endLine": 108
     },
     "title": "The Deviation",
     "content": "`deviation n` $= f(n) - 2p_n$ over $\\mathbb{Z}$. This measures the signed distance between the minimum symmetric sum and twice the central prime. Positive deviation means ALL symmetric sums exceed $2p_n$; negative means some fall below.",
@@ -148,8 +148,8 @@
     "proofId": "erdos-454",
     "type": "definition",
     "range": {
-      "startLine": 96,
-      "endLine": 99
+      "startLine": 110,
+      "endLine": 114
     },
     "title": "Extended Natural Deviation",
     "content": "`deviationENat n` casts non-negative deviations to $\\mathbb{N}_\\infty$ and maps negative deviations to $0$. This allows the $\\limsup$ to take values in $\\mathbb{N}_\\infty = \\mathbb{N} \\cup \\{\\infty\\}$, where the conjecture asks whether $\\limsup = \\infty = \\top$.",
@@ -174,8 +174,8 @@
     "proofId": "erdos-454",
     "type": "concept",
     "range": {
-      "startLine": 104,
-      "endLine": 106
+      "startLine": 118,
+      "endLine": 121
     },
     "title": "The $i = 0$ Case",
     "content": "Proves `symmetric_sum_at_zero`: $p_{n+0} + p_{n-0} = 2p_n$ by `simp [mul_comm]`. This is the anchor point — the $i = 0$ term always contributes exactly $2p_n$ to the infimum, establishing $f(n) \\le 2p_n$.",
@@ -197,8 +197,8 @@
     "proofId": "erdos-454",
     "type": "concept",
     "range": {
-      "startLine": 114,
-      "endLine": 118
+      "startLine": 135,
+      "endLine": 141
     },
     "title": "Asymmetric Behavior",
     "content": "Proves `asymmetric_behavior`: for $i > 0$ and $i < n$, $p_{n+i} > p_n$ and $p_{n-i} < p_n$. Both follow from `nthPrime_strictMono` applied to $n + i > n$ and $n - i < n$. Whether $p_{n+i} + p_{n-i}$ exceeds or falls below $2p_n$ depends on which gap is larger.",
@@ -221,8 +221,8 @@
     "proofId": "erdos-454",
     "type": "concept",
     "range": {
-      "startLine": 126,
-      "endLine": 126
+      "startLine": 145,
+      "endLine": 149
     },
     "title": "Pomerance's Lower Bound (1979)",
     "content": "`pomerance_1979` (axiom): $2 \\le \\limsup$ `deviationENat atTop`. Infinitely many $n$ have $f(n) - 2p_n \\ge 2$, meaning ALL symmetric sums at those positions exceed $2p_n + 2$. The proof uses the chromatic number of Pomerance's Prime Number Graph.",
@@ -245,8 +245,8 @@
     "proofId": "erdos-454",
     "type": "definition",
     "range": {
-      "startLine": 147,
-      "endLine": 148
+      "startLine": 183,
+      "endLine": 190
     },
     "title": "Main Conjecture: $\\limsup = \\infty$",
     "content": "`Erdos454Conjecture` $:=$ $\\limsup$ `deviationENat atTop` $= \\top$. In $\\mathbb{N}_\\infty$, $\\top = \\infty$, so this asks: for every $M$, there exists $n$ with `deviationENat n` $\\ge M$. Equivalently, deviations are unbounded.",
@@ -269,8 +269,8 @@
     "proofId": "erdos-454",
     "type": "concept",
     "range": {
-      "startLine": 168,
-      "endLine": 169
+      "startLine": 227,
+      "endLine": 229
     },
     "title": "Large Prime Gaps Exist",
     "content": "`large_prime_gaps_exist` (axiom): $\\forall G,\\, \\exists k,\\, p_{k+1} - p_k \\ge G$. Arbitrarily large prime gaps exist — classically proved via the construction $n! + 2, n! + 3, \\ldots, n! + n$ (all composite). Large gaps are necessary but not sufficient for large deviations.",
@@ -292,8 +292,8 @@
     "proofId": "erdos-454",
     "type": "definition",
     "range": {
-      "startLine": 227,
-      "endLine": 234
+      "startLine": 284,
+      "endLine": 295
     },
     "title": "The Prime Number Graph",
     "content": "`primeNumberGraph` is a `SimpleGraph ℕ` where $n \\sim m$ iff $n \\ne m$ and $p_n + p_m = p_k$ for some $k$. Symmetry is proved by commutativity of addition ($p_n + p_m = p_m + p_n$). Looplessness follows from $n \\ne n$ being false. This is Pomerance's central construction.",
@@ -318,8 +318,8 @@
     "proofId": "erdos-454",
     "type": "definition",
     "range": {
-      "startLine": 238,
-      "endLine": 240
+      "startLine": 297,
+      "endLine": 301
     },
     "title": "Symmetric Goldbach Property",
     "content": "`goldbachSymmetric`: every even $m > 4$ can be written as $p_{n+i} + p_{n-i}$ for some $n, i$ with $i < n$. This strengthens Goldbach's conjecture by requiring the two primes to be at symmetric positions in the prime sequence.",

--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -131,100 +131,108 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Namespace",
-      "startLine": 25,
+      "id": "header",
+      "title": "File Header and Setup",
+      "startLine": 1,
       "endLine": 34,
-      "summary": "Imports `PrimeCounting` for `Nat.nth Prime`, `Filter.Basic` and `LiminfLimsup` for $\\limsup$ via filters, `ENat` for extended naturals $\\mathbb{N}_\\infty$, and `Tactic` for proof automation. Opens `Nat` and `Filter` namespaces.",
-      "mathContext": "Imports `PrimeCounting` for `Nat.nth Prime`, `Filter.Basic` and `LiminfLimsup` for $\\limsup$ via filters, `ENat` for extended naturals $\\mathbb{N}_\\infty$, and `Tactic` for proof automation."
+      "summary": "Docstring statement of Erdős Problem #454: with p_k the k-th prime and f(n) = min_{i<n}(p_{n+i}+p_{n−i}), is limsup_{n→∞}(f(n)−2p_n) = ∞? Notes the OPEN status, Pomerance's (1979) limsup ≥ 2 lower bound, the even-spacing intuition (f(n) ≈ 2p_n if primes were regular), and references; followed by Mathlib imports (`PrimeCounting`, `LiminfLimsup`, `Instances.ENat`), `namespace Erdos454`, and `open Nat Filter`.",
+      "mathContext": "Problem statement, known partial result, and the Lean preamble."
     },
     {
       "id": "nth-prime",
-      "title": "The $n$th Prime Function",
+      "title": "Part I — The nth Prime Function",
       "startLine": 35,
       "endLine": 58,
-      "summary": "Defines `nthPrime k` $= k$-th prime via `Nat.nth Prime`. Proves specific values: $p_0 = 2$, $p_1 = 3$, $p_2 = 5$ (using `native_decide`). Establishes `nthPrime_prime` (all values are prime) and `nthPrime_strictMono` (strict monotonicity).",
-      "mathContext": "Defines `nthPrime k` $= k$-th prime via `Nat.nth Prime`. Proves specific values: $p_0 = 2$, $p_1 = 3$, $p_2 = 5$ (using `native_decide`)."
+      "summary": "Definition `nthPrime k = k.nth Prime` (0-indexed: p₀=2, p₁=3, p₂=5, …) with proved facts: the first three values (`nthPrime_zero/one/two`), primality (`nthPrime_prime` via `Nat.prime_nth_prime`), and strict monotonicity (`nthPrime_strictMono`).",
+      "mathContext": "Definition of the indexed prime sequence via `Nat.nth Prime`, plus basic value and monotonicity lemmas."
     },
     {
       "id": "function-f",
-      "title": "The Function $f(n)$",
+      "title": "Part II — The Function f(n)",
       "startLine": 59,
-      "endLine": 84,
-      "summary": "Defines `symmetricPrimeSum n i` $= p_{n+i} + p_{n-i}$ and $f(n) = \\inf_{i \\in \\text{Fin}\\,n}(p_{n+i} + p_{n-i})$ with $f(0) = 0$. Provides alternative `f'` using `Finset.inf'` and states their equivalence (`f_eq_f'`, sorry).",
-      "mathContext": "Defines `symmetricPrimeSum n i` $= p_{n+i} + p_{n-i}$ and $f(n) = \\inf_{i \\in \\text{Fin}\\,n}(p_{n+i} + p_{n-i})$ with $f(0) = 0$."
+      "endLine": 99,
+      "summary": "Definitions of the symmetric prime sum `symmetricPrimeSum n i = p_{n+i}+p_{n−i}`, the central quantity `f n` (the ⨅ over `Fin n` of these sums, with f 0 = 0), the alternative `f'` using `Finset.inf'`, and the equivalence theorem `f_eq_f'` (proved via `ciInf_le`/`le_ciInf` and `Finset.le_inf'`).",
+      "mathContext": "Definitions of f(n) as an indexed infimum, an equivalent `Finset.inf'` form, and their equality over a `BddBelow` range."
     },
     {
       "id": "deviation",
-      "title": "The Deviation from $2p_n$",
-      "startLine": 85,
-      "endLine": 100,
-      "summary": "Defines `deviation n` $= f(n) - 2p_n$ over $\\mathbb{Z}$ and `deviationENat n` casting non-negative deviations to $\\mathbb{N}_\\infty$ for $\\limsup$ computation. The $\\mathbb{N}_\\infty$ version allows the $\\limsup$ to equal $\\top = \\infty$.",
-      "mathContext": "Defines `deviation n` $= f(n) - 2p_n$ over $\\mathbb{Z}$ and `deviationENat n` casting non-negative deviations to $\\mathbb{N}_\\infty$ for $\\limsup$ computation. The $\\mathbb{N}_\\infty$ version allows the $\\limsup$ to equal $\\top = \\infty$."
+      "title": "Part III — The Deviation from 2p_n",
+      "startLine": 100,
+      "endLine": 115,
+      "summary": "Definitions of the key quantity `deviation n = f n − 2·p_n` (over ℤ) and its extended-natural truncation `deviationENat n` (the ℕ∞ value used for the limsup, set to 0 when f n < 2p_n).",
+      "mathContext": "Definitions of the signed deviation and its `ℕ∞`-valued truncation for limsup computation."
     },
     {
       "id": "symmetric-analysis",
-      "title": "Understanding Symmetric Sums",
-      "startLine": 101,
-      "endLine": 119,
-      "summary": "Proves `symmetric_sum_at_zero`: $p_{n+0} + p_{n-0} = 2p_n$. Proves `f_le_twice_nthPrime`: $f(n) \\le 2p_n$ via `ciInf_le` at $i=0$. Proves `asymmetric_behavior`: for $i > 0$, $p_{n+i} > p_n$ and $p_{n-i} < p_n$ by strict monotonicity.",
-      "mathContext": "Proves `symmetric_sum_at_zero`: $p_{n+0} + p_{n-0} = 2p_n$. Proves `f_le_twice_nthPrime`: $f(n) \\le 2p_n$ via `ciInf_le` at $i=0$. Proves `asymmetric_behavior`: for $i > 0$, $p_{n+i} > p_n$ and $p_{n-i} < p_n$ by strict monotonicity."
+      "title": "Part IV — Understanding Symmetric Prime Sums",
+      "startLine": 116,
+      "endLine": 142,
+      "summary": "Proved structural facts: at i=0 the symmetric sum equals 2p_n (`symmetric_sum_at_zero`); hence f(n) ≤ 2p_n (`f_le_twice_nthPrime`, the minimum is attained at i=0); and for i>0 strict monotonicity gives p_{n+i} > p_n and p_{n−i} < p_n (`asymmetric_behavior`).",
+      "mathContext": "Theorems establishing the i=0 baseline, the upper bound f(n) ≤ 2p_n, and the asymmetry for i>0 via `nthPrime_strictMono`."
     },
     {
       "id": "pomerance",
-      "title": "Pomerance's Lower Bound",
-      "startLine": 120,
-      "endLine": 138,
-      "summary": "Axiomatizes `pomerance_1979`: $2 \\le \\limsup$ `deviationENat atTop`. Derives `limsup_pos` ($\\limsup > 0$) and `infinitely_many_deviation_ge_2` (the set $\\{n : \\text{deviation}(n) \\ge 2\\}$ is infinite, sorry).",
-      "mathContext": "Axiomatizes `pomerance_1979`: $2 \\le \\limsup$ `deviationENat atTop`. Derives `limsup_pos` ($\\limsup > 0$) and `infinitely_many_deviation_ge_2` (the set $\\{n : \\text{deviation}(n) \\ge 2\\}$ is infinite, sorry)."
+      "title": "Part V — Pomerance's Lower Bound",
+      "startLine": 143,
+      "endLine": 180,
+      "summary": "Pomerance's (1979) result `pomerance_1979 : 2 ≤ limsup deviationENat atTop` (axiom) and its proved corollaries: `limsup_pos` (the limsup is positive) and `infinitely_many_deviation_ge_2` (the set {n : deviationENat n ≥ 2} is infinite, by a contradiction with the eventual bound forcing limsup ≤ 1).",
+      "mathContext": "Axiom for the limsup ≥ 2 lower bound plus corollaries derived via `limsup_le_of_le` and eventual-bound reasoning."
     },
     {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "startLine": 139,
-      "endLine": 158,
-      "summary": "Defines `Erdos454Conjecture`: $\\limsup = \\top$ ($= \\infty$). Defines `Erdos454Negation`: $\\exists M,\\, \\limsup \\le M$. States `conjecture_iff_not_negation` (sorry): the two are complementary.",
-      "mathContext": "Formal definition: Defines `Erdos454Conjecture`: $\\limsup = \\top$ ($= \\infty$). Defines `Erdos454Negation`: $\\exists M,\\, \\limsup \\le M$. States `conjecture_iff_not_negation` (sorry): the two are complementary."
+      "title": "Part VI — The Main Conjecture",
+      "startLine": 181,
+      "endLine": 218,
+      "summary": "The conjecture `Erdos454Conjecture : limsup deviationENat atTop = ⊤`, its negation `Erdos454Negation` (a finite bound M exists), and the equivalence `conjecture_iff_not_negation` proving the two are complementary (⊤ is not ≤ any finite value; a non-⊤ limsup is some finite m).",
+      "mathContext": "Definitions of the conjecture and its negation in `ℕ∞`, with a proved iff via case analysis on `WithTop`."
     },
     {
       "id": "heuristics",
-      "title": "Heuristic Analysis",
-      "startLine": 159,
-      "endLine": 175,
-      "summary": "Defines `primeGapHeuristic`: gaps $\\approx \\log p$ implies symmetric sums $\\approx 2p_n$. Axiomatizes `large_prime_gaps_exist`: $\\forall G,\\, \\exists k,\\, p_{k+1} - p_k \\ge G$. States `gap_deviation_connection` linking gaps to deviations (sorry).",
-      "mathContext": "Defines `primeGapHeuristic`: gaps $\\approx \\log p$ implies symmetric sums $\\approx 2p_n$. Axiomatizes `large_prime_gaps_exist`: $\\forall G,\\, \\exists k,\\, p_{k+1} - p_k \\ge G$."
+      "title": "Part VII — Heuristic Analysis",
+      "startLine": 219,
+      "endLine": 235,
+      "summary": "Heuristic material: the predicate `primeGapHeuristic` (prime gaps stay within C of log p), the axiom `large_prime_gaps_exist` (arbitrarily large gaps occur), and `gap_deviation_connection` relating non-positive deviations to bounded gaps (currently a `sorry`).",
+      "mathContext": "A heuristic predicate, an axiom on large prime gaps, and a connecting theorem (one open `sorry`)."
     },
     {
       "id": "examples",
-      "title": "Examples",
-      "startLine": 176,
-      "endLine": 192,
-      "summary": "Computes $f(3) = \\min(14, 16, 16) = 14 = 2p_3$ (sorry). Proves $2p_3 = 14$ via `native_decide` (0-indexed: $p_3 = 7$). States $\\text{deviation}(3) = 0$ (sorry).",
-      "mathContext": "Computes $f(3) = \\min(14, 16, 16) = 14 = 2p_3$ (sorry). Proves $2p_3 = 14$ via `native_decide` (0-indexed: $p_3 = 7$). States $\\text{deviation}(3) = 0$ (sorry)."
+      "title": "Part VIII — Examples",
+      "startLine": 236,
+      "endLine": 253,
+      "summary": "Worked numerical examples around n=3 (0-indexed primes p₀..p₅): `example_f_3 : f 3 = 14` (sorry), `example_twice_p3 : 2·p₃ = 14` (proved by `native_decide`), and `example_deviation_3 : deviation 3 = 0` (sorry).",
+      "mathContext": "Concrete evaluations of f, 2p_n, and the deviation at n=3 (two `sorry`s, one `native_decide` computation)."
     },
     {
       "id": "related",
-      "title": "Related Problems",
-      "startLine": 193,
-      "endLine": 204,
-      "summary": "Notes connection to Problem #458 (consecutive prime sums). Axiomatizes `prime_number_theorem_asymptotic`: $p_n / (n \\log n) \\to 1$, providing context for average gap size.",
-      "mathContext": "Notes connection to Problem #458 (consecutive prime sums). Axiomatizes `prime_number_theorem_asymptotic`: $p_n / (n \\$\\log n$) \\to 1$, providing context for average gap size."
+      "title": "Part IX — Related Problems",
+      "startLine": 254,
+      "endLine": 265,
+      "summary": "Connections to neighboring problems: `relatedToErdos458` (a documentation placeholder, `True`) and the axiom `prime_number_theorem_asymptotic` (p_n ~ n log n, recorded as a `Tendsto` statement).",
+      "mathContext": "A placeholder relation to Problem #458 and the PNT asymptotic recorded as an axiom."
     },
     {
       "id": "resolution",
-      "title": "What Would Resolve the Conjecture",
-      "startLine": 205,
-      "endLine": 220,
-      "summary": "Defines `witnessForConjecture M`: $\\exists n$ with all symmetric sums $> 2p_n + M$. Defines `witnessForNegation M`: eventually $f(n) \\le 2p_n + M$. These formalize what a proof or disproof would require.",
-      "mathContext": "Defines `witnessForConjecture M`: $\\exists n$ with all symmetric sums $> 2p_n + M$. Defines `witnessForNegation M`: eventually $f(n) \\le 2p_n + M$."
+      "title": "Part X — What Would Resolve the Conjecture",
+      "startLine": 266,
+      "endLine": 281,
+      "summary": "Predicates capturing what a proof or disproof would require: `witnessForConjecture M` (some n with every symmetric sum exceeding 2p_n + M) and `witnessForNegation M` (eventually f n ≤ 2p_n + M).",
+      "mathContext": "Definitions formalizing the witness conditions for proving (limsup = ∞) or disproving (limsup ≤ M) the conjecture."
     },
     {
       "id": "prime-graph",
-      "title": "The Prime Number Graph",
-      "startLine": 221,
-      "endLine": 274,
-      "summary": "Formalizes `primeNumberGraph` as a `SimpleGraph ℕ` with edge $n$-$m$ iff $p_n + p_m = p_k$ for some $k$. Proves symmetry and looplessness. Defines `goldbachSymmetric`: can every even $m > 4$ be expressed as $p_{n+i} + p_{n-i}$?",
-      "mathContext": "Formalizes `primeNumberGraph` as a `SimpleGraph ℕ` with edge $n$-$m$ iff $p_n + p_m = p_k$ for some $k$. Proves symmetry and looplessness. Defines `goldbachSymmetric`: can every even $m > 4$ be expressed as $p_{n+i} + p_{n-i}$?"
+      "title": "Part XI — The Prime Number Graph",
+      "startLine": 282,
+      "endLine": 304,
+      "summary": "Definition of Pomerance's `primeNumberGraph` (a `SimpleGraph ℕ` with n adjacent to m iff n≠m and p_n+p_m = p_k for some k, with `symm`/`loopless` proved) and the related `goldbachSymmetric` predicate (every even m>4 is a symmetric prime sum), closing the namespace.",
+      "mathContext": "A `SimpleGraph` encoding Pomerance's prime number graph and a Goldbach-style symmetric-sum predicate."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 305,
+      "endLine": 335,
+      "summary": "Closing docstring recap: the problem (f(n) = min symmetric prime sum; is limsup(f(n)−2p_n)=∞?), OPEN status with Pomerance's limsup ≥ 2, the seven formalized components, the three key axioms (`pomerance_1979`, `large_prime_gaps_exist`, `prime_number_theorem_asymptotic`), and the even-spacing intuition.",
+      "mathContext": "Narrative summary of the formalization, its axiom budget, and the underlying intuition."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Build-free gallery-integrity fix for `erdos-1068` (Erdős Problem #1068, countable infinitely-connected subgraphs).

`Proofs/Erdos1068Problem.lean` has a header + **7 `/- ## Part N -/` banners** + a Summary banner, but `meta.json`:
- **Lumped** Parts II+III into one section and Parts IV+V into another.
- Left a **~59-line tail gap**: sections ended at line 205 while Part VII runs to 239 and the Summary docstring spans **240–264**.

Realigned to **10 contiguous sections (1–264)**, each Part/Summary snapped to its banner line.

## Annotations
Realigned 7 co-drifted annotation ranges (`soukup`, `problem1067`, `separator`, `set-theory`, `bowler`, `proved-theorems`, `conjecture`) to their actual source locations — e.g. `proved-theorems` pointed at 165–179 (inside the separator proof) while the Part VII theorems are at 209–238. Also corrected inaccuracies:
- **"Bowler-Pitz" → "Bowler-Pikhurko"** to match the Lean source (and dropped a fabricated journal citation).
- Removed **"Axiomatized as `True`"** claims on the Bowler and set-theory annotations — those regions are documentation prose, not declarations.

## Unchanged (verified correct)
- Counts: 0 axioms, 4 theorems, 7 definitions (incl. the `PathInGraph` structure), 0 sorries, lineCount 264.
- `status`/`badge` unchanged.

## Test plan
- [x] `meta.json` + `annotations.json` valid JSON
- [x] Sections contiguous 1–264, each Part start = its `/- ## Part -/` banner
- [x] Annotation ranges aligned to real source locations; no phantom decl claims
- [x] Data-only; no Lean source touched (build-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)