### PR TITLE
research(cantor-diagonalization-oq-03-oq-01-oq-02): realign gallery sections + add missing Section VI (5→6)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -62,38 +62,45 @@
   "sections": [
     {
       "id": "section-eval-framework",
-      "title": "Section I: Evaluation Structure Framework",
-      "startLine": 59,
-      "endLine": 74,
-      "summary": "Defines EvalStructure (Ob, Val, eval triple), IsPointSurjective (universal representation), and proves lawvere_fpt: in a point-surjective structure, every endomorphism has a fixed point (the abstract diagonal argument)."
+      "title": "Module Header and Evaluation Structure Framework",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Module docstring framing Rice's theorem as a Lawvere fixed-point instance, namespace setup, and the SECTION I framework: defines EvalStructure (Ob, Val, eval triple), IsPointSurjective (universal representation), and proves lawvere_fpt: in a point-surjective structure, every endomorphism has a fixed point (the abstract diagonal argument)."
     },
     {
       "id": "section-abstract-rice",
       "title": "Section II: Abstract Rice Theorem",
-      "startLine": 91,
-      "endLine": 120,
+      "startLine": 76,
+      "endLine": 121,
       "summary": "abstract_rice: no Bool evaluation is point-surjective (Bool.not has no fixed point). rice_induced_obstruction: even a universal V-computation cannot be Bool-universal. rice_undecidable_witness: for any eval, an undecidable Boolean function exists."
     },
     {
       "id": "section-semantic-flip",
       "title": "Section III: Semantic Properties and Flip Programs",
-      "startLine": 130,
-      "endLine": 164,
+      "startLine": 122,
+      "endLine": 165,
       "summary": "SemanticProperty (P depends only on behavior) and HasFlipProgram (transformer that flips P). semantic_rice_flip: semantics-preserving flip + semantic property → direct contradiction, no Lawvere needed."
     },
     {
       "id": "section-halting",
       "title": "Section IV: Halting Problem as a Rice Instance",
-      "startLine": 173,
-      "endLine": 188,
+      "startLine": 166,
+      "endLine": 189,
       "summary": "HaltingModel (Prog, halts, evaluate, universal). no_halting_model: a decidable universal halting predicate is a Bool point-surjective structure — forbidden by abstract_rice. Turing's undecidability in one line."
     },
     {
       "id": "section-classical-rice",
       "title": "Section V: Classical Rice Theorem via Kleene Recursion",
-      "startLine": 210,
-      "endLine": 262,
+      "startLine": 190,
+      "endLine": 263,
       "summary": "ClassicalRiceModel axiomatizes Kleene's recursion theorem. classical_rice_abstract proves: semantic + non-trivial P leads to contradiction via the flipper code transformer and Kleene's semantic fixed point."
+    },
+    {
+      "id": "section-summary-checks",
+      "title": "Section VI: Summary Checks",
+      "startLine": 264,
+      "endLine": 275,
+      "summary": "Closing #check commands confirming the type signatures of the six main results (abstract_rice, rice_induced_obstruction, rice_undecidable_witness, semantic_rice_flip, no_halting_model, classical_rice_abstract) and the namespace end."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

Build-free gallery metadata fix for **cantor-diagonalization-oq-03-oq-01-oq-02** (Rice's Theorem as a Lawvere Instance). The `sections` ranges in `meta.json` had drifted off the `-- Section N` banner boxes in `proofs/Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean`, and one whole section was missing.

Each section started a few lines *after* its `-- Section N` box, stranding every box in an inter-section gap. The module docstring + namespace setup (lines 1-58) and the entire **Section VI: Summary Checks** block (the closing `#check` commands, lines 264-275) were not covered by any section.

Snapped each section to its box opener and restored full coverage:

| Section | Before | After |
|---|---|---|
| Module Header and Evaluation Structure Framework (was "Section I: …") | 59-74 | 1-75 |
| Section II: Abstract Rice Theorem | 91-120 | 76-121 |
| Section III: Semantic Properties and Flip Programs | 130-164 | 122-165 |
| Section IV: Halting Problem as a Rice Instance | 173-188 | 166-189 |
| Section V: Classical Rice Theorem via Kleene Recursion | 210-262 | 190-263 |
| **Section VI: Summary Checks** (new) | — | 264-275 |

The first section was retitled and extended to cover the overview docstring + namespace setup; the previously absent Section VI was added for the `#check` block. Ranges are now contiguous over the full file (1-275) and each `-- Section N` box and named declaration falls within its own section. Counts (status `axiomatized`, 2 structure-encoded assumptions — the `kleene_rec`/`h_compile`/halting-model hypothesis fields — 275 lines) and the other summaries were already accurate and are left unchanged.

## Scope

- Meta-only (`src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json`); no Lean source touched, no build required.

## Test plan

- [x] Section ranges are contiguous and cover 1-275.
- [x] Each `-- Section N` banner line falls within its own `[startLine, endLine]`.
- [x] Each section's named declarations lie within its range.
- [x] JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)