### PR TITLE
research(qr-zolotarev-oq03): ORIENT survey — Mathlib API map + milestone plan

### DIFF
--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/literature/README.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/literature/README.md
@@ -7,8 +7,29 @@ This directory contains:
 
 ## Related Gallery Proofs
 
-[List proofs from src/data/proofs/ that relate to this problem]
+- `quadratic-reciprocity-algorithm` — direct parent; algorithmic (flip-and-reduce) presentation.
+  Lean file `Proofs/QuadraticReciprocityOQ03.lean`.
+- `QuadraticReciprocityAlgorithmOQ01.lean` — sibling answering the recursive-function form
+  (`jacobiAlgo`, `jacobiAlgo_eq_jacobiSym`); the permutation-sign route here is disjoint from it.
+- `quadratic-reciprocity` (gallery) — Gauss-sum / Eisenstein proof; cross-check for the statement.
+- `primitive-roots` — cyclic structure of `(ZMod p)ˣ` used in the Zolotarev sign computation.
 
 ## External References
 
-[Papers, books, online resources]
+- Zolotarev, E. I. (1872). "Nouvelle démonstration de la loi de réciprocité de Legendre."
+  *Nouvelles Annales de Mathématiques.* — original permutation-sign proof.
+- Rousseau, G. (1994). "On the quadratic reciprocity law." *J. Austral. Math. Soc.* — modern
+  permutation-sign exposition.
+- Frobenius / Lerch — the row-vs-column shuffle reduction used for the reciprocity step (M2).
+
+## Mathlib Documentation
+
+- `Mathlib.NumberTheory.LegendreSymbol.Basic` — `legendreSym`, `legendreSym.eq_pow` (Euler's
+  criterion link).
+- `Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity` — existing `ZMod.quadratic_reciprocity`
+  (statement reference / cross-check only).
+- `Mathlib.GroupTheory.Perm.Sign` — `Equiv.Perm.sign`, `Equiv.Perm.sign_mul`, cycle-sign machinery.
+- `Mathlib.GroupTheory.SpecificGroups.Cyclic` — `IsCyclic (ZMod p)ˣ`, generators.
+
+Note: a string search for "Zolotarev" across the pinned Mathlib returns nothing — the bridging
+lemma `legendreSym p a = sign πₐ` is not yet in Mathlib and is the core deliverable (M1).


### PR DESCRIPTION
## Summary

Advances `quadratic-reciprocity-algorithm-oq-03` (rederiving quadratic reciprocity via **Zolotarev's lemma** — Legendre symbol = sign of the multiplication permutation) from **OBSERVE → ORIENT**.

Docker is down, so the build milestones cannot be compiled this iteration. This is a **build-free research-state advance** (documentation only) — **not** a proof and **not** a Lean file. No gallery data or counts touched.

## What changed (docs only, under `research/problems/quadratic-reciprocity-algorithm-oq-03/`)

- **knowledge.md** — concrete ORIENT findings:
  - Mathlib supplies the *endpoints* (`legendreSym`, `Equiv.Perm.sign`, `IsCyclic (ZMod p)ˣ`, and `ZMod.quadratic_reciprocity` for cross-check) but **not** Zolotarev's bridging lemma — confirmed by a "Zolotarev" string search returning nothing. That gap is the deliverable.
  - Sign-computation skeleton (generator → single `(p−1)`-cycle → `sign(πₐ) = (-1)^k = legendreSym p a` via Euler's criterion).
  - Milestone decomposition: **M1** Zolotarev lemma (buildable when Docker up, the reusable artifact); **M2** reciprocity from M1 via the shuffle-sign / CRT route (gated).
- **state.md** — phase OBSERVE → ORIENT; records the Docker-down blocker and the exact next action (file/lemma to formalize).
- **literature/README.md** — Zolotarev (1872), Rousseau (1994), and the precise Mathlib modules.

## Notes

- Distinct from the sibling `QuadraticReciprocityAlgorithmOQ01.lean`, which already answers the *recursive-function* form; this is the *permutation-sign* route.
- Status stays pre-`verified` (problem unsolved). Per the axiom-integrity policy, M1 landing with M2 stubbed would be `axiomatized`/`formalized`, never `verified`.

## Test plan

- [ ] Docs-only change; no build required. When Docker is restored, formalize M1 in `proofs/Proofs/QuadraticReciprocityZolotarevOQ03.lean` and build via `./proofs/scripts/docker-build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)