### PR TITLE
research(erdos-782): realign drifted gallery sections to Part banners (10→10)

### DIFF
--- a/src/data/proofs/erdos-782/meta.json
+++ b/src/data/proofs/erdos-782/meta.json
@@ -97,70 +97,70 @@
       "title": "Arithmetic Progressions",
       "summary": "ArithProg, ContainsAP, squares_contain_3AP, no_4AP_in_squares",
       "startLine": 54,
-      "endLine": 78,
+      "endLine": 83,
       "mathContext": "Mathematical content: ArithProg, ContainsAP, squares_contain_3AP, no_4AP_in_squares"
     },
     {
       "id": "quasi-prog",
       "title": "Quasi-Progressions",
       "summary": "IsQuasiProg, ContainsQuasiProg, Question1, Question1Weak",
-      "startLine": 79,
-      "endLine": 104,
+      "startLine": 84,
+      "endLine": 131,
       "mathContext": "Mathematical content: IsQuasiProg, ContainsQuasiProg, Question1, Question1Weak"
     },
     {
       "id": "cubes",
       "title": "Combinatorial Cubes",
       "summary": "CubeVertices, IsNontrivialCube, ContainsCube, Question2",
-      "startLine": 105,
-      "endLine": 131,
+      "startLine": 132,
+      "endLine": 158,
       "mathContext": "Mathematical content: CubeVertices, IsNontrivialCube, ContainsCube, Question2"
     },
     {
       "id": "relationship",
       "title": "Relationship Between Questions",
       "summary": "question1_implies_question2, no_cubes_implies_no_quasiprog",
-      "startLine": 132,
-      "endLine": 146,
+      "startLine": 159,
+      "endLine": 173,
       "mathContext": "Mathematical content: question1_implies_question2, no_cubes_implies_no_quasiprog"
     },
     {
       "id": "solymosi",
       "title": "Solymosi's Conjecture",
       "summary": "SolymosiConjecture, SolymosiConjectureAlt, solymosi_equiv",
-      "startLine": 147,
-      "endLine": 169,
+      "startLine": 174,
+      "endLine": 196,
       "mathContext": "Mathematical content: SolymosiConjecture, SolymosiConjectureAlt, solymosi_equiv"
     },
     {
       "id": "bombieri-lang",
       "title": "Conditional Result",
       "summary": "BombieriLangConjecture, cilleruelo_granville, conditional_q2_negative",
-      "startLine": 170,
-      "endLine": 189,
+      "startLine": 197,
+      "endLine": 221,
       "mathContext": "Mathematical content: BombieriLangConjecture, cilleruelo_granville, conditional_q2_negative"
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "Has2Cube, Has3Cube",
-      "startLine": 190,
-      "endLine": 208
+      "startLine": 222,
+      "endLine": 255
     },
     {
       "id": "density",
       "title": "Density Considerations",
       "summary": "numSquaresUpTo, sparsity analysis",
-      "startLine": 209,
-      "endLine": 225,
+      "startLine": 256,
+      "endLine": 272,
       "mathContext": "Mathematical content: numSquaresUpTo, sparsity analysis"
     },
     {
       "id": "status",
       "title": "Problem Status",
       "summary": "erdos_782_status, erdos_782_question1, erdos_782_question2",
-      "startLine": 226,
-      "endLine": 271,
+      "startLine": 273,
+      "endLine": 328,
       "mathContext": "Mathematical content: erdos_782_status, erdos_782_question1, erdos_782_question2"
     }
   ],


### PR DESCRIPTION
## Summary
Gallery sections for erdos-782 (Quasi-Progressions and Cubes in the Squares) had drifted early relative to the `# Part N` banners in `Proofs/Erdos782Problem.lean`.

- Sections 2–10 started before their banners, leaving banner lines stranded in inter-section gaps.
- The trailing Part 10 region (lines 272–328) — containing `erdos_782_question1` and `erdos_782_question2` — was uncovered by any section.

Snapped each section's `startLine`/`endLine` to its banner opener (`/-` at banner−1). The 10 sections now contiguously cover lines 33–328 with a 1:1 mapping to the 10 Part banners.

## Scope
- Meta-only, build-free: ranges only. Section summaries were already content-accurate (each lists the decls under its banner) and were left unchanged.
- No count changes — `leanFile` counts (3 axioms, 10 theorems, 18 defs, 0 sorries, 328 lines) verified accurate against source.

## Test plan
- [x] Sections contiguous 33→328, no gaps/overlaps
- [x] Valid JSON
- [x] Diff touches only startLine/endLine