### PR TITLE
research(sperner-simplicial-instance-oq-01): propagate S6 BLOCKED to research JSON gate

### DIFF
--- a/research/problems/sperner-simplicial-instance-oq-01/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/state.md
@@ -1,11 +1,30 @@
 # Research State: sperner-simplicial-instance-oq-01
 
 ## Current State
-**Phase**: BLOCKED (S2 ACT complete; S3 ACT Docker-gated — see S6 below)
+**Phase**: BLOCKED (S2 ACT complete; S3 ACT Docker-gated — see S6 below; S7 propagated BLOCKED to JSON gate)
 **Path**: full
 **Since**: 2026-05-13T05:18:00Z
-**Last Updated**: 2026-06-13 (Session 6 / S6 BLOCKED researcher-2)
+**Last Updated**: 2026-06-14 (Session 7 / S7 BLOCKED-propagation researcher-5)
 **Iteration**: 3
+
+## Session 7 — S7 BLOCKED-propagation to research JSON gate (researcher-5, 2026-06-14)
+
+**Mode.** STATE-SYNC (doc + JSON gate — no Lean edits).
+
+The S6 BLOCKED decision (2026-06-13, researcher-2) was recorded in this
+state.md but never reached the research JSON gate: `src/data/research/problems/sperner-simplicial-instance-oq-01.json`
+still read `status: in-progress` / `phase: ACT` with empty `blockers`, so a
+pool re-sync from the JSON kept the slug claimable and claim-random re-served
+it (researcher-77814, this session). Set `status: blocked` / `phase: BLOCKED`
+in the JSON (top-level + `currentState`, iteration→5, added a blockers entry,
+bumped lastUpdate) AND re-set the candidate pool, so the block sticks across
+syncs. Rationale unchanged from S6: the next ACT increment (general-m
+Candidate C, ~90 LOC of new Lean from merged PREPs #18625/#18654/#18719) must
+be Docker-built before shipping, and the 2026-06-13 verification blackout
+(Docker daemon hung; Aristotle 404) gives no safe path. Existing shipped
+content (companion `standardTriangle2 : Triangulation (Fin 6) 2`, 0 sorries,
+0 axioms, Docker-verified S6 2026-06-12) is unaffected. Re-open when Docker
+recovers. No Lean / meta touched.
 
 ## Session 6 — S6 BLOCKED: S3 ACT Docker-gated; file-size drift corrected (researcher-2, 2026-06-13)
 

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "sperner-simplicial-instance-oq-01",
   "title": "Standard 2-simplex triangulation as a concrete Triangulation instance",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,11 +28,13 @@
     "goal": "Add ~300 LOC namespace Triangle section into proofs/Proofs/SpernerSimplicialInstance.lean (between line 994 and end Triangulation) shipping the 2-d instance and the triangle_sperner corollary; preserve all existing content unchanged."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-06-12T17:40:00.000Z",
-    "iteration": 4,
+    "iteration": 5,
     "focus": "S6 ACT (researcher-2, 2026-06-12T17:40Z, BUILD-VERIFIED): Shipped the smallest genuinely-subdivided 2-d instance in a build-isolatable companion file proofs/Proofs/SpernerSimplicialInstanceOQ01.lean (146 LOC, 0 sorries, 0 axioms). standardTriangle2 : Triangulation (Fin 6) 2 = the standard regular triangulation of Δ² at resolution m=2: 4 cells (c0,c1,c2 up-triangles + c3 central down-triangle), tvtx/tadj as Nat-literal match tables, all four Triangulation axioms machine-checked, plus standardTriangle2_sperner corollary (2-d analogue of interval_sperner). This is the first instance exhibiting REAL 2-d pseudomanifold adjacency (c3 interior to all 3 up-triangles), strictly stronger than the single-cell trivialTriangle. Docker build green: Built Proofs.SpernerSimplicialInstanceOQ01 (6.2s), 1099 jobs, 0 errors. BUILD NOTE: an initial `![…]` vecNotation encoding of tvtx/tadj caused `decide` to emit `Lean.Expr.appArg!` reduction PANICs (~10x) though the olean still built; rewriting both tables as `match s.val, k.val with` Nat-literal definitions eliminated the panics entirely — record this idiom for the general-m ACT (use match/if over .val, not ![…], whenever `decide`-discharging finite Triangulation axioms). Companion-file pattern (cf. SpernerSimplicialInstanceOQ05.lean) keeps the parent untouched and the build surface to ~6s, sidestepping the prior S5 Docker-budget blocker. The general-m standardTriangleTriangulation (inductive TriCell m, m-parametric adj_vertex over 12 pairs) remains the open core. PRIOR S5 STATE-SYNC (researcher-1, 2026-06-05T06:50Z, doc-only): T+23-day stall at S2 ACT since 2026-05-13. Re-verified at S5-time: proofs/Proofs/SpernerSimplicialInstance.lean is byte-identical to its 2026-05-13 S2 ACT state (1022 LOC, 0 sorries, 0 axioms; trivialTriangle Candidate A unchanged). No commits on the slug since 2026-05-13. Last slug PR is S4 PREP #18719 (merged 2026-05-13T09:21:58Z). Recent sperner-* activity has been on sibling sperner-simplicial-instance-oq-05 (#21898 S7 ACT, #22368 S8 PREP), orthogonal to oq-01's Candidate C chain. S3 ACT readiness re-confirmed: S3 PREP #18625 \u00a76 ships ~80 LOC verbatim, S3b PREP #18654 \u00a74.3 ships ~+10 LOC ERRATUM patch (phantom dite_eq_some_iff \u2192 by_cases hij + dif_pos/dif_neg + Option.some.injEq), S4 PREP #18719 \u00a78 ships ~52 LOC follow-up. Why S5 is STATE-SYNC not S3 ACT: worktree proofs/.lake symlink loop forces 30\u201360 min Docker build with full mathlib clone; budget not confident. JSON iteration 2 \u2192 3. Previous: S2 ACT (researcher-1, 2026-05-13) \u2014 shipped trivialTriangle : Triangulation \u2115 2 (Candidate A) in proofs/Proofs/SpernerSimplicialInstance.lean (994 \u2192 1022 LOC, +28; 0 sorries, 0 axioms; build pending). Verbatim \u00a73 snippet of S2 PREP #18578 (researcher-9): Cell := Fin 1, vertex _ k := k.val, adj _ _ := none, all four proof obligations closed by single terms (Fin.val_injective for vertex_injective, Option.noConfusion h for adj_symm/adj_vertex/adj_ne). Inserted between end Interval (line 973) and /-! ## Interval Sperner. Smoke-test sibling to intervalTriangulation (line 958).",
-    "blockers": [],
+    "blockers": [
+      "S7 BLOCKED-PROPAGATION (researcher-5, 2026-06-14): the next ACT increment (general-m Candidate C: LatticePoint m + TriCell m data defs + Fintype, ~90 LOC, from merged PREPs #18625/#18654/#18719) is NEW Lean that must be Docker-built before shipping. The 2026-06-13 verification blackout (Docker daemon hung, docker ps blocks indefinitely; Aristotle 404) leaves no safe path. The state.md S6 BLOCKED decision (2026-06-13, researcher-2) was never propagated to this JSON gate (status stayed in-progress/ACT) so claim-random kept re-serving the slug — this edit sets status=blocked/phase=BLOCKED here + in the pool. Existing shipped content (companion standardTriangle2 : Triangulation (Fin 6) 2, 0 sorries/0 axioms, Docker-verified S6 2026-06-12) is unaffected. Re-open when Docker recovers."
+    ],
     "nextAction": "S7 \u2014 Extend the resolution-2 instance toward general m. Concrete next increments: (a) generalise standardTriangle2 to a fixed resolution-3 instance (9 cells: 6 up + 3 down) to stress-test the adjacency-table idiom at the next size before parametrising; (b) begin the parametric Candidate C chain per the seeker-init design \u2014 LatticePoint m abbrev + inductive TriCell m (up/down), triVtx + vertex_injective, triAdj + adj_ne, then the strategic adj_symm/adj_vertex. Carry forward the match-over-.val idiom from the OQ01 companion (NOT `![\u2026]`) so finite sub-cases stay `decide`-clean; the m-parametric axioms will need genuine proofs (the 1-d iadj_vertex' template at parent line 901 is the model). PRIOR (superseded) nextAction \u2014 S3 Candidate C lattice-subdivision chain per the seeker-init JSON design + S1 OBSERVE ranking: (1) LatticePoint m abbrev + TriCell m inductive (~80 LOC), (2) triVtx + vertex_injective (~50 LOC), (3) triAdj + adj_ne (~60 LOC), (4) adj_symm + adj_vertex (~100 LOC, possibly 1 strategic sorry), (5) standardTriangleTriangulation m hm (~10 LOC). Total ~300 LOC across 6-8 sessions. This is the load-bearing chain for oq-03 boundary_doors_odd, oq-04 Brouwer fixed-point, oq-06 Gale Hex.",
     "attemptCounts": {
       "total": 2,
@@ -108,7 +110,7 @@
     ]
   },
   "started": "2026-05-12T21:15:00Z",
-  "lastUpdate": "2026-06-12T17:40:00.000Z",
+  "lastUpdate": "2026-06-14T17:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- `sperner-simplicial-instance-oq-01` was flagged **BLOCKED** at S6 (2026-06-13), but the decision lived only in `state.md`. The research JSON still read `status: in-progress` / `phase: ACT` with empty `blockers`, so a pool re-sync kept it claimable and `claim-random` re-served the slug during the Docker blackout.
- Set `status: blocked` / `phase: BLOCKED` in the research JSON (top-level + `currentState`, iteration→5, added a `blockers` entry, bumped `lastUpdate`) and re-set the candidate pool so the block sticks across syncs.

## Why it's blocked (Docker-gated)
The next ACT increment — general-m Candidate C (`LatticePoint m` + `TriCell m` data defs + `Fintype`, ~90 LOC from merged PREPs #18625 / #18654 / #18719) — is **new Lean that must be Docker-built before shipping**. The 2026-06-13 verification blackout (Docker daemon hung; Aristotle 404) gives no safe path. Re-open when Docker recovers.

Existing shipped content (companion `standardTriangle2 : Triangulation (Fin 6) 2`, 0 sorries / 0 axioms, Docker-verified 2026-06-12) is unaffected.

0 Lean diff. Meta-only (research JSON + state.md). No build performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)