### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): GATE-SYNC propagate BLOCKED to JSON + pool

### DIFF
--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03/state.md
@@ -4,8 +4,32 @@
 **Phase**: BLOCKED (S20 STATE-SYNC, 2026-06-14, researcher-6 — Docker still down: verification blackout; the long-pending `theoremCount: 18` gallery drift is **RESOLVED/STALE** — gallery `meta.json` now reads `theoremCount: 16`, which is correct under the public-only convention: the file has 16 public `theorem`s + 2 `private lemma`s (`standardNormalCDF_eq_zero_plus_intervalIntegral`, `piAntidiag_apply_le`). All other count/section fields re-verified CLEAN: lineCount 712, definitionCount 3, axiomCount 1, sorries 0; sections give full real-content coverage 141→712 aligned to the `/-! ##` banners post-#23526. No metadata action needed; clearing the 17-day mechanic mis-flag. Phase-4 D1 Lemma C ACT remains Docker-gated.)
 **Path**: full
 **Since**: 2026-06-02T17:00:00Z
-**Last Updated**: 2026-06-14 (Session 20, researcher-6)
-**Iteration**: 19
+**Last Updated**: 2026-06-14 (Session 21, researcher-1)
+**Iteration**: 20
+
+## Session 21 Focus (2026-06-14, researcher-1) — GATE-SYNC: propagate BLOCKED to research JSON + pool (stop re-serving an infra-blocked RICH slug)
+
+`claim-random` landed researcher-1 on this slug **again** during the Docker
+blackout — the fifth consecutive session (S18/S19/S20 all landed here too).
+Root cause: state.md correctly declares **BLOCKED**, but the gates that
+`claim-random` actually reads had drifted out of sync, so the high RICH
+knowledge score kept floating this Docker-gated slug to the top of the
+depth-first queue:
+
+- `src/data/research/problems/<slug>.json`: was `status: "active"`,
+  `phase: "PREP"` / `currentState.phase: "PREP"` → corrected to
+  `status: "blocked"`, `phase: "BLOCKED"`.
+- `.lean/state/candidate-pool.json`: was `status: "in-progress"` → set to
+  `"blocked"` (terminal, no longer claimable) via `claim-problem.sh update`.
+
+Re-confirmed the gallery is still CLEAN (no metadata change needed): meta
+`axiomCount 1`, `theoremCount 16`, `definitionCount 3`, `lineCount 712`,
+`sorries 0`; 7 sections + 8 annotations both cover 1→712 aligned to the
+`/-! ##` banners. The Phase-4 D1 Lemma C ACT and discharging the lone
+`binomial_clt_pointwise` axiom (classical de Moivre–Laplace) both require a
+Docker build and stay parked until INFRA recovers (`.lake` self-symlink +
+corrupted `lean4-arm64:v4.26.0` image, both host-side / outside worktree
+authority). When Docker is restored, un-block by reverting these gates.
 
 ## Session 20 Focus (2026-06-14, researcher-6) — STATE-SYNC: clear stale `theoremCount` mechanic mis-flag; gallery re-verified CLEAN; Docker still blocked
 

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
   "title": "Multinomial CLT in Lean: does (Xᵢ - npᵢ)/√(npᵢ(1-pᵢ)) converge in distribution to N(0,1) for each coordinate as n → ∞?",
-  "phase": "PREP",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -34,8 +34,8 @@
     "goal": "Phase-2: produce `Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` with (a) a precise Lean statement of the marginal CLT for the i-th coordinate of Multinomial(n, p₁,…,pₖ), (b) either a proof via Mathlib's `ProbabilityTheory.iid_central_limit_theorem` applied to the indicator variables Yⱼ = 𝟙[trial j → outcome i] (which are Bernoulli(pᵢ) i.i.d.), or an axiomatized statement with full proof sketch, and (c) a coordinate-free version using Cramér-Wold for the joint vector CLT."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-06-02T17:00:00Z",
+    "phase": "BLOCKED",
+    "since": "2026-06-14T18:30:00Z",
     "iteration": 18,
     "focus": "S19 STATE-SYNC (researcher-1, 2026-06-02T~17:00Z, doc-only) fires 17 days after S18. INFRA picture has shifted: 2 of 3 S18 RED blockers cleared (Docker daemon RED→GREEN: `docker info` returns Server Version 29.4.1 with 1 container running, was empty Server: section; host disk RED→GREEN: 19 Gi free / 39% used, was 3.8 Gi / 100%), `proofs/.lake` circular self-symlink RED unchanged (still `→ /Users/rwalters/GitHub/lean-genius/proofs/.lake` self-loop, propagates to all worktrees). NEW S19 RED #4: Docker image `lean4-arm64:v4.26.0` is corrupted — `docker image inspect lean4-arm64:v4.26.0` and `docker run --rm lean4-arm64:v4.26.0 echo ok` both fail with `blob sha256:9026c55995f444bfdc23dc2307ba058400286252a5c35e36e51358b05bb4719a expected at /var/lib/desktop-containerd/daemon/io.containerd.content.v1.content/blobs/sha256/...: input/output error`. Sibling container `lean-build-57602` (Up 6 h on same image, holding what little remains usable in-process) pre-dates the corruption. Gate A pre-flight still cannot run because `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ03` issues `docker run … lean4-arm64:v4.26.0 /bin/bash -c \"lake build …\"` which now errors on the corrupted blob. Mathlib pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) UNCHANGED per `proofs/lake-manifest.json`. Lean file UNCHANGED on origin/main since S16 ACT (#19402, 2026-05-16T03:51:56Z merge): 712 LOC / 16 theorems / 3 defs / 1 axiom / 0 sorries; BUILD-VERIFIED at 3209 jobs (S12) persists across S15→S19 because zero Lean edits since S12 + S16 ACT was comment-only. Gallery `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` `leanFile.theoremCount: 18` (stale; actual 16; drift -2) 17 days running with no mechanic action — re-flagged for next Mechanic cycle. Per S18 §4.3 and memory feedback _long_completed_slug_*_canonical_json_materially_contradicts_observe_findings_*, re-spotting Mathlib byte-stable bearers at unchanged SHA is busywork; B1/B1prime/B2/B3/B4/B5 carry forward + negative findings (CentralLimitTheorem.lean / iid_central_limit_theorem / Measure-form binomial all absent) carry forward. Phase-4 readiness gate refresh: A RED × 2 INFRA (different mix; was RED × 3); B/C/D/E remain GREEN. Content posture unchanged; INFRA posture partially recovered. Iteration JSON cs.iteration 17 → 18 catchup; since 2026-05-16T17:55Z → 2026-06-02T17:00Z bump; attemptCounts.total 17 → 18.",
     "blockers": [
@@ -173,7 +173,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.055Z",
-  "lastUpdate": "2026-06-02T17:00:00Z",
+  "lastUpdate": "2026-06-14T18:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Gate-sync for `binomial-theorem-oq-02-oq-01-oq-01-oq-03`. **No Lean source touched — build-safe.**

## Problem
`state.md` has correctly declared this slug **BLOCKED** (Docker infra outage — `.lake` self-symlink + corrupted `lean4-arm64:v4.26.0` image, both host-side) since S18. But the gates that `claim-random` actually reads had drifted out of sync, so the slug's high RICH knowledge score kept floating it to the top of the depth-first queue and re-serving it: **S18, S19, S20, and now S21 all landed here** and could do no build-free work.

## Changes
- **research JSON** (`src/data/research/problems/…json`): `status` `"active"`→`"blocked"`, `phase` / `currentState.phase` `"PREP"`→`"BLOCKED"`.
- **`.lean/state/candidate-pool.json`** (untracked local state): `"in-progress"`→`"blocked"` (terminal status; no longer claimable) via `claim-problem.sh update`.
- **state.md**: added S21 GATE-SYNC note.

## Verification (gallery re-confirmed CLEAN — no metadata change)
- meta: `axiomCount 1`, `theoremCount 16`, `definitionCount 3`, `lineCount 712`, `sorries 0` — all match source.
- 7 sections + 8 annotations both cover lines 1→712, aligned to the `/-! ##` banners.
- `git diff` touches 0 `.lean` files.

## Status
**Outcome**: state-sync / pool hygiene (stops repeated useless re-serving of a Docker-blocked RICH slug). No new mathematics.
**Next Steps**: When INFRA recovers, un-block by reverting these gates; remaining work (Phase-4 ACT, discharging the de Moivre–Laplace axiom) requires a Docker build.

🤖 Generated by researcher-1