### PR TITLE
research(platonic-solids-oq-02): de-lump gallery sections + fix phantom-axiom prose (5→8)

### DIFF
--- a/src/data/proofs/platonic-solids-oq-02/annotations.json
+++ b/src/data/proofs/platonic-solids-oq-02/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "platonic-solids-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 27
+      "endLine": 29
     },
     "type": "concept",
     "title": "The 13 Archimedean Solids: Vertex-Transitivity Beyond Platonic Symmetry",
-    "content": "Archimedean solids are convex polyhedra where: (a) all faces are regular polygons (possibly mixed types), (b) the same arrangement of faces meets at every vertex (vertex-transitive), (c) they are not Platonic solids, prisms, or antiprisms. There are exactly 13. First systematically catalogued by Archimedes (now lost), rediscovered by Kepler (1619), formally classified by Gr\u00fcnbaum (1967). The formalization verifies the angle defect constraint for all 13, establishes their V, E, F counts with Euler formula, and states the full classification as an axiom (geometric realizability and completeness require constructions beyond what is formalized). Zero sorries, one axiom.",
+    "content": "Archimedean solids are convex polyhedra where: (a) all faces are regular polygons (possibly mixed types), (b) the same arrangement of faces meets at every vertex (vertex-transitive), (c) they are not Platonic solids, prisms, or antiprisms. There are exactly 13. First systematically catalogued by Archimedes (now lost), rediscovered by Kepler (1619), formally classified by Gr\u00fcnbaum (1967). The formalization verifies the angle defect constraint for all 13, establishes their V, E, F counts with Euler formula, and states the full classification as a `True` placeholder (geometric realizability and completeness require constructions beyond what is formalized). Zero sorries, zero axioms.",
     "mathContext": "The **angle defect** condition: at each vertex of a convex polyhedron, the sum of face angles must be $< 2\\pi$ (otherwise the vertex 'lies flat' or creates a concavity). For a vertex type $(n_1, n_2, \\ldots, n_k)$: $\\sum_{i=1}^k \\frac{(n_i-2)\\pi}{n_i} < 2\\pi$, i.e., $\\sum (n_i-2)/n_i < 2$. By Descartes' theorem, the sum of all angle defects over all vertices of a convex polyhedron equals $4\\pi$ \u2014 this is equivalent to the Euler characteristic $V-E+F=2$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -28,8 +28,8 @@
     "id": "ann-archimedes-angle-defect",
     "proofId": "platonic-solids-oq-02",
     "range": {
-      "startLine": 28,
-      "endLine": 52
+      "startLine": 30,
+      "endLine": 51
     },
     "type": "concept",
     "title": "Angle Defect Computation: Integer Arithmetic via LCM Scaling",
@@ -53,7 +53,7 @@
     "id": "ann-archimedes-thirteen",
     "proofId": "platonic-solids-oq-02",
     "range": {
-      "startLine": 57,
+      "startLine": 52,
       "endLine": 115
     },
     "type": "concept",
@@ -78,8 +78,8 @@
     "id": "ann-archimedes-euler",
     "proofId": "platonic-solids-oq-02",
     "range": {
-      "startLine": 120,
-      "endLine": 165
+      "startLine": 116,
+      "endLine": 155
     },
     "type": "concept",
     "title": "ArchimedeanData: V, E, F Counts with Euler Formula Verification",
@@ -102,8 +102,8 @@
     "id": "ann-archimedes-extremes",
     "proofId": "platonic-solids-oq-02",
     "range": {
-      "startLine": 170,
-      "endLine": 210
+      "startLine": 167,
+      "endLine": 177
     },
     "type": "insight",
     "title": "Extreme Cases: Tightest and Loosest Angle Defects",
@@ -126,16 +126,16 @@
     "id": "ann-archimedes-classification",
     "proofId": "platonic-solids-oq-02",
     "range": {
-      "startLine": 170,
-      "endLine": 231
+      "startLine": 196,
+      "endLine": 232
     },
     "type": "insight",
-    "title": "Classification Theorem: Axiom for Completeness, Soccer Ball Corollary",
-    "content": "The `archimedean_classification` axiom states the completeness direction: any convex vertex-transitive polyhedron with regular faces that is not Platonic/prism/antiprism must be one of the 13. This is axiomatized (not proved) because the formal proof requires geometric realizability arguments \u2014 showing that each vertex type actually closes into a valid polyhedron \u2014 and completeness arguments \u2014 showing no other vertex type works geometrically. The computational verification (`hasPositiveDefect` for all 13) gives the necessary condition; the axiom adds sufficiency. Corollaries: `soccerBall_is_archimedean` (the soccer ball is Archimedean), `archimedean_not_platonic` (none of the 13 are Platonic).",
+    "title": "Classification Theorem: True Placeholder for Completeness, Soccer Ball Corollary",
+    "content": "The `archimedean_classification` theorem states the completeness direction: any convex vertex-transitive polyhedron with regular faces that is not Platonic/prism/antiprism must be one of the 13. It is currently a `True` placeholder (not proved) because the formal proof requires geometric realizability arguments \u2014 showing that each vertex type actually closes into a valid polyhedron \u2014 and completeness arguments \u2014 showing no other vertex type works geometrically. The computational verification (`hasPositiveDefect` for all 13) gives the necessary condition; a full proof would add sufficiency. Corollaries: `soccerBall_is_archimedean` (the soccer ball is Archimedean), `soccerBall_data` (its 60/90/32 V/E/F counts); relatedly `archimedean_not_platonic` (none of the 13 are Platonic).",
     "mathContext": "The completeness proof (for humans): the angle defect constraint $\\sum (n_i-2)/n_i < 2$ limits the possible vertex types. With $k$ faces meeting at a vertex (each $\\geq 3$-gon), we get $k < 6$ (since each triangle contributes $\\geq 1/3$ to the angle ratio). For $k=3$: the constraint gives $(p-2)(q-2)(r-2) > 8$ \u2014 equivalent to the 3D Platonic solid constraint, yielding only 5 families. For $k=4,5$: finite enumeration gives the remaining Archimedean types. Geometric realizability (that a valid vertex type actually closes into a polyhedron) is proved by explicit construction via truncation, cantellation, or snubification.",
     "significance": "key",
     "relatedConcepts": [
-      "archimedean_classification axiom",
+      "archimedean_classification (True placeholder)",
       "soccerBall_is_archimedean",
       "archimedean_not_platonic",
       "geometric realizability",

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -70,44 +70,68 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Module Overview and Setup",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module docstring defining Archimedean solids and listing all 13 vertex types; imports and namespace.",
+      "mathContext": "An Archimedean solid is convex, vertex-transitive, regular-faced, and not a prism/antiprism. The 13 types range from the truncated tetrahedron (3,6,6) to the snub dodecahedron (3,3,3,3,5)."
+    },
+    {
       "id": "vertex-types",
       "title": "Vertex Types and Angle Computation",
-      "startLine": 28,
-      "endLine": 52,
-      "summary": "LCM-based angle defect computation for vertex types.",
+      "startLine": 30,
+      "endLine": 51,
+      "summary": "LCM-based angle defect computation for vertex types (faceLcm, angleNumerator, hasPositiveDefect).",
       "mathContext": "Angle sum = Σ (nᵢ-2)/nᵢ in units of π. Positive defect: sum < 2. Integer check: Σ(nᵢ-2)(L/nᵢ) < 2L."
     },
     {
       "id": "thirteen-types",
       "title": "The 13 Archimedean Vertex Types",
-      "startLine": 57,
-      "endLine": 74,
-      "summary": "All 13 vertex types defined as concrete List ℕ values.",
+      "startLine": 52,
+      "endLine": 76,
+      "summary": "All 13 vertex types defined as concrete List ℕ values, plus the archimedeanTypes list.",
       "mathContext": "From truncated tetrahedron (3,6,6) to snub dodecahedron (3,3,3,3,5)."
     },
     {
       "id": "verification",
       "title": "Angle Defect Verification",
-      "startLine": 79,
+      "startLine": 77,
       "endLine": 115,
-      "summary": "All 13 types verified by native_decide to have positive angle defect.",
+      "summary": "All 13 types verified by native_decide to have positive angle defect (all_archimedean_valid).",
       "mathContext": "Each hasPositiveDefect check reduces to a ℕ comparison, decided by native compilation."
     },
     {
       "id": "euler-data",
       "title": "Face Counts and Euler's Formula",
-      "startLine": 120,
-      "endLine": 165,
+      "startLine": 116,
+      "endLine": 155,
       "summary": "ArchimedeanData records with V, E, F values; Euler formula verified by omega.",
       "mathContext": "V - E + F = 2 for all 13 solids. E.g., truncated icosahedron: 60 - 90 + 32 = 2."
     },
     {
+      "id": "exactly-thirteen",
+      "title": "There Are Exactly 13",
+      "startLine": 156,
+      "endLine": 177,
+      "summary": "The archimedeanTypes list has length 13 and all entries are distinct; tightness and largest-defect lemmas.",
+      "mathContext": "archimedean_count: archimedeanTypes.length = 13 (native_decide). archimedean_distinct establishes pairwise distinctness."
+    },
+    {
+      "id": "platonic-connection",
+      "title": "Connection to Platonic Solids",
+      "startLine": 178,
+      "endLine": 195,
+      "summary": "The isPlatonic predicate and a proof that no Archimedean vertex type is Platonic.",
+      "mathContext": "isPlatonic singles out the regular (single-face-type) vertex configurations; archimedean_not_platonic shows the 13 Archimedean types are all non-Platonic."
+    },
+    {
       "id": "classification",
       "title": "The Classification Theorem",
-      "startLine": 170,
-      "endLine": 210,
-      "summary": "Exactly 13 types, all distinct, none Platonic; classification axiom.",
-      "mathContext": "The full classification (Kepler 1619, Grünbaum 1967) is axiomatized. Geometric realizability is beyond the scope of the current formalization."
+      "startLine": 196,
+      "endLine": 232,
+      "summary": "The classification theorem (stated as a True placeholder pending geometric formalization), plus the soccer-ball (truncated icosahedron) corollaries.",
+      "mathContext": "The full classification (Kepler 1619, Grünbaum 1967, Cromwell 1997) requires geometric realizability and completeness arguments beyond combinatorics, so archimedean_classification is currently a True placeholder. soccerBall_is_archimedean and soccerBall_data verify the truncated icosahedron (60 V, 90 E, 32 F)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery doc-integrity fix for `platonic-solids-oq-02` (Docker/Aristotle backends down).

The `.lean` file has **7** `-- Section N` banners plus a substantial header docstring, but meta had only **5** sections:
- "Face Counts and Euler's Formula" lumped in Section 5 ("There Are Exactly 13")
- "The Classification Theorem" lumped in Section 6 ("Connection to Platonic Solids") and left the tail uncovered (`soccerBall_is_archimedean` @224, `soccerBall_data` @228; file ends at 232, meta stopped at 210)

## Changes

- Split into one section per banner + a "Module Overview and Setup" section for the docstring → full contiguous coverage 1-232 (5→8 sections)
- Realigned the 6 annotations, which had co-drifted
- **Fixed phantom-axiom prose**: annotations called `archimedean_classification` "an axiom" and "one axiom", but the file has **0 axiom declarations** — it is a `theorem ... True := fun _ => trivial` placeholder. The corrected prose now matches the meta `assumptions` field, which already states this accurately.

## Integrity

- Counts/status/badge **unchanged**: 0 axioms, 0 sorries, badge `wip`, status `axiomatized` — all verified against source
- **No Lean source modified** (diff is JSON-only)

## Test plan
- [x] Both JSON files parse
- [x] Sections contiguous 1-232, every banner covered by exactly one section
- [x] No remaining "axiom" claims about the True-placeholder in annotations
- [x] `git diff --name-only` shows no `.lean` files