### PR TITLE
research(erdos-szekeres-oq-02): GATE-SYNC propagate BLOCKED to JSON + pool

### DIFF
--- a/research/problems/erdos-szekeres-oq-02/state.md
+++ b/research/problems/erdos-szekeres-oq-02/state.md
@@ -4,7 +4,21 @@
 **Phase**: BLOCKED
 **Path**: full
 **Since**: 2026-06-13T00:00:00-07:00
-**Iteration**: 3
+**Iteration**: 4
+**Last Updated**: 2026-06-14 (S4 GATE-SYNC, researcher-1 — propagated the 2026-06-13 BLOCKED flag to the gates `claim-random` reads)
+
+## Session 4 (2026-06-14, researcher-1) — GATE-SYNC
+
+The 2026-06-13 BLOCKED flag lived in state.md only: the research JSON read
+`status: "surveyed"` / `phase: "ORIENT"` and `.lean/state/candidate-pool.json`
+read `"available"`, so `claim-random` kept re-serving this slug (it just
+re-served it again). Aligned both gates to BLOCKED (JSON
+`status`/`phase`/`currentState.phase` → `blocked`/`BLOCKED`; pool → `"blocked"`,
+terminal/unclaimable). **This block is Docker-transient, not a durable math
+wall**: Milestone 1 (`incDP` + `incDPcost n = n(n−1)/2`) is self-contained,
+oq-01-independent, and buildable as soon as a Lean build/verify route returns —
+un-block by reverting these gates the moment Docker (or Aristotle) is back.
+No metadata/Lean change.
 
 ## Current Focus
 Survey complete and accurate (researcher-9 2026-06-13). Flagged **blocked**

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-szekeres-oq-02",
   "title": "Complexity of finding the actual Erdos-Szekeres monotonic subsequence",
-  "phase": "ORIENT",
-  "status": "surveyed",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,7 +28,7 @@
     "goal": "Formalize a computable incDP : Fin n -> Nat proven equal to maxIncLen, a constructive witness extractor, and an exact Theta(n^2) comparison-count closed form n(n-1)/2; document the Theta(n log n) optimum as the cost-model-gated remainder."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "BLOCKED",
     "since": "2026-06-13T00:00:00-07:00",
     "iteration": 2,
     "focus": "First survey complete (researcher-9 2026-06-13, build-free during the Docker/Aristotle verification blackout). The OQ is resolved on paper and decomposed into a formalizable core (computable DP + correctness + constructive witness + exact comparison count) plus a cost-model-gated remainder (Theta(n log n) optimality).",
@@ -98,7 +98,7 @@
     ]
   },
   "started": "2026-06-10T11:02:48-07:00",
-  "lastUpdate": "2026-06-13T00:00:00-07:00",
+  "lastUpdate": "2026-06-14T19:00:00Z",
   "significance": 5,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Gate-sync for `erdos-szekeres-oq-02`. **No Lean source touched — build-safe** (slug has no gallery entry).

## Problem
A 2026-06-13 session flagged this slug **BLOCKED** with the explicit note "re-claiming this slug only produces churn," but the flag lived in `state.md` only. The research JSON read `status: "surveyed"` / `phase: "ORIENT"` and `.lean/state/candidate-pool.json` read `"available"`, so `claim-random` kept re-serving it (it did so again today).

## Changes
- **research JSON**: `status` `"surveyed"`→`"blocked"`, `phase` / `currentState.phase` `"ORIENT"`→`"BLOCKED"`.
- **`.lean/state/candidate-pool.json`** (untracked local state): `"available"`→`"blocked"` (terminal) via `claim-problem.sh update`.
- **state.md**: added S4 GATE-SYNC note.

## Status
**Outcome**: state-sync / pool hygiene. **The block is Docker-transient, not a durable math wall** — Milestone 1 (computable `incDP` DP + cost closed form `incDPcost n = n(n−1)/2`) is self-contained, oq-01-independent, and buildable as soon as a Lean build/verify route returns. No new mathematics.
**Next Steps**: Un-block by reverting these gates the moment Docker (or Aristotle) is back, then proceed with Milestone 1 ACT.

🤖 Generated by researcher-1