### PR TITLE
research(prob-method-lovasz-local-oq-01): realign drifted annotations + de-stale prose

### DIFF
--- a/src/data/proofs/prob-method-lovasz-local/annotations.json
+++ b/src/data/proofs/prob-method-lovasz-local/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "prob-method-lovasz-local",
     "range": {
       "startLine": 1,
-      "endLine": 13
+      "endLine": 16
     },
     "type": "concept",
     "title": "The Lovász Local Lemma: Crown Jewel of the Probabilistic Method",
@@ -27,12 +27,12 @@
     "id": "ann-symmetric-lll",
     "proofId": "prob-method-lovasz-local",
     "range": {
-      "startLine": 24,
-      "endLine": 28
+      "startLine": 25,
+      "endLine": 34
     },
     "type": "concept",
     "title": "Symmetric LLL (Simplified Criterion)",
-    "content": "The symmetric LLL states that if each of $n$ bad events has probability $\\leq p$ and depends on at most $d$ other events, and a criterion involving $p$, $d$ is met, then all bad events can be avoided. The formalization uses $p(d+1) \\leq 1/3$ as a simplified criterion (the exact bound is $ep(d+1) \\leq 1$ where $e \\approx 2.718$). The constant $1/3$ is a safe approximation since $1/e \\approx 0.368 > 1/3$. The theorem currently proves `True` as a placeholder because the full statement requires formalizing events, probability measures, and dependency graphs.",
+    "content": "The symmetric LLL states that if each of $n$ bad events has probability $\\leq p$ and depends on at most $d$ other events, and a criterion involving $p$, $d$ is met, then all bad events can be avoided. The formalization uses $p(d+1) \\leq 1/3$ as a simplified criterion (the exact bound is $ep(d+1) \\leq 1$ where $e \\approx 2.718$). The constant $1/3$ is a safe approximation since $1/e \\approx 0.368 > 1/3$. The formalization proves the algebraic core `symmetric_lll_bound`: given $0 \\leq p$ and $p(d+1) \\leq 1/3$, the avoidance factor $(1-p)^n > 0$. This captures the positivity heart of the symmetric LLL; the full probabilistic statement $\\Pr[\\bigcap \\overline{A_i}] \\geq (1-p)^n > 0$ additionally requires formalizing events, probability measures, and dependency graphs.",
     "mathContext": "Simplified: $p(d+1) \\leq 1/3$. Exact: $ep(d+1) \\leq 1$, i.e., $p \\leq \\frac{1}{e(d+1)}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -50,8 +50,8 @@
     "id": "ann-general-lll",
     "proofId": "prob-method-lovasz-local",
     "range": {
-      "startLine": 33,
-      "endLine": 37
+      "startLine": 40,
+      "endLine": 48
     },
     "type": "concept",
     "title": "General (Asymmetric) Lovász Local Lemma",
@@ -74,8 +74,8 @@
     "id": "ann-ksat",
     "proofId": "prob-method-lovasz-local",
     "range": {
-      "startLine": 41,
-      "endLine": 44
+      "startLine": 96,
+      "endLine": 115
     },
     "type": "concept",
     "title": "k-SAT Satisfiability via LLL",
@@ -97,12 +97,12 @@
     "id": "ann-moser-tardos",
     "proofId": "prob-method-lovasz-local",
     "range": {
-      "startLine": 48,
-      "endLine": 52
+      "startLine": 119,
+      "endLine": 129
     },
     "type": "concept",
     "title": "Moser-Tardos Constructive LLL (2010)",
-    "content": "Robin Moser and Gábor Tardos (2010) gave a constructive proof of the LLL via a simple resampling algorithm: while any bad event $A_i$ occurs, pick one and resample its random variables. They proved that the expected number of resampling steps is at most $\\sum_i x_i/(1-x_i)$, which is polynomial in $n$ under the LLL conditions. This resolved a major open problem: Erdős and Lovász's original proof was purely existential and gave no algorithm. The formalization currently only states that this sum is non-negative (a weak bound), with a sorry on a simplified version of the witness condition.",
+    "content": "Robin Moser and Gábor Tardos (2010) gave a constructive proof of the LLL via a simple resampling algorithm: while any bad event $A_i$ occurs, pick one and resample its random variables. They proved that the expected number of resampling steps is at most $\\sum_i x_i/(1-x_i)$, which is polynomial in $n$ under the LLL conditions. This resolved a major open problem: Erdős and Lovász's original proof was purely existential and gave no algorithm. The formalization proves `moser_tardos_termination`: the resampling-bound sum $\\sum_i x_i/(1-x_i)$ is non-negative (a weak but fully verified bound) via `Finset.sum_nonneg`. The full quantitative expectation bound and the witness-tree termination argument are not yet formalized.",
     "mathContext": "Moser-Tardos: expected resampling steps $\\leq \\sum_{i=1}^n \\frac{x_i}{1-x_i}$",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -170,7 +170,7 @@
     },
     {
       "id": "complete-theorem",
-      "title": "Part X: Complete Symmetric LLL (Capstone)",
+      "title": "Part XI: Complete Symmetric LLL (Capstone)",
       "startLine": 348,
       "endLine": 364,
       "summary": "Proves `symmetric_lll_complete`: given $\\Pr[A_i] \\leq T(d)$ and dependency degree $\\leq d$, both the general LLL condition and the avoidance positivity hold. Combines `threshold_satisfies_lll` and `symmetric_lll_avoidance`.",


### PR DESCRIPTION
## Summary

Build-free gallery-integrity fix for `prob-method-lovasz-local` (forward research on OQ-01 is Docker-gated; this is the available build-free win this session).

The five **concept** annotations in `annotations.json` were authored for an earlier, shorter layout of `LovaszLocalLemma.lean`. The eight **detail** annotations (L54+) are correctly placed, but four concept annotations pointed tens of lines off their actual decls, and two carried prose that is now factually false against the verified (0 sorry, 0 axiom) file.

### Range realignments (verified against current decl lines)
| annotation | old range | new range | decl |
|---|---|---|---|
| `ann-symmetric-lll` | 24–28 | 25–34 | `symmetric_lll_bound` |
| `ann-general-lll` | 33–37 | 40–48 | `general_lll` |
| `ann-ksat` | 41–44 | 96–115 | `ksat_lll` |
| `ann-moser-tardos` | 48–52 | 119–129 | `moser_tardos_termination` |
| `ann-lll-docstring` | 1–13 | 1–16 | module docstring (runs to L16) |

### Stale-prose de-stale
- `ann-symmetric-lll` claimed the theorem "proves \`True\` as a placeholder." The current `symmetric_lll_bound` proves `(1-p)^n > 0` given `p(d+1) ≤ 1/3`. Rewritten to describe the real algebraic core.
- `ann-moser-tardos` claimed "a sorry on a simplified version of the witness condition." `moser_tardos_termination` proves the sum `Σ xᵢ/(1-xᵢ)` is non-negative with **no** sorry (via `Finset.sum_nonneg`). Rewritten; notes the full expectation bound / witness-tree argument are not yet formalized.

### meta.json
- Fixed a duplicate Part number: the capstone section was a second "Part X" → "Part XI".

Data-only (annotations.json, meta.json); no Lean source touched — build-safe. Disjoint from open PR #23465 (which touches only `MoserTardos.lean` + `state.md`).

## Test plan
- [x] Both JSON files validate (`python3 -m json.tool`).
- [x] Each new range verified against `grep -n` decl lines in `LovaszLocalLemma.lean`.
- [x] Confirmed file has 0 real code sorries (sole `sorry` token is in a docstring).