### PR TITLE
research(erdos-256): realign file-growth-drifted sections + annotations, fix phantom-decl prose (9→10)

### DIFF
--- a/src/data/proofs/erdos-256/annotations.json
+++ b/src/data/proofs/erdos-256/annotations.json
@@ -148,13 +148,13 @@
     "id": "ann-e256-distinct",
     "proofId": "erdos-256",
     "range": {
-      "startLine": 141,
-      "endLine": 158
+      "startLine": 194,
+      "endLine": 209
     },
     "type": "definition",
     "title": "The Distinct Exponents Variant",
     "content": "**A natural variant:**\n\nWhat if we require a₁ < a₂ < ... < aₙ (strictly increasing) instead of a₁ ≤ ... ≤ aₙ?\n\nDefine f*(n) for this distinct case. Bourgain and Chang (2018) proved:\n\nlog f*(n) ≪ (n log n)^{1/2} · log log n\n\nThis is worse than (log n)⁴ but still subpolynomial in n.",
-    "mathContext": "fDistinct(n) := sInf {maxOnUnitCircle a | a : Fin n → ℕ, Injective a}\n\nbourgain_chang_bound : log f*(n) ≤ C·(n·log n)^{1/2}·log log n",
+    "mathContext": "fDistinct(n) := sInf {maxOnUnitCircle a | a : Fin n → ℕ, Injective a}\n\nThe Bourgain-Chang (2018) bound log f*(n) ≤ C·(n·log n)^{1/2}·log log n is recorded as a docstring note, not a Lean declaration.",
     "significance": "key",
     "relatedConcepts": [
       "distinct-exponents",
@@ -171,13 +171,13 @@
     "id": "ann-e256-chowla",
     "proofId": "erdos-256",
     "range": {
-      "startLine": 160,
-      "endLine": 178
+      "startLine": 210,
+      "endLine": 226
     },
     "type": "concept",
     "title": "Connection to Chowla Cosine Problem (#510)",
     "content": "**Hidden connections:**\n\nThe Chowla cosine problem asks: for a set A of n integers, find θ minimizing Σ_{a∈A} cos(aθ).\n\nAtkinson observed: if such θ exists with sum < -M, then log f*(n) ≪ M·log n.\n\nThis connects two seemingly different problems about oscillatory behavior on the unit circle.",
-    "mathContext": "chowlaMinimum(A) := sInf {Σ_{a∈A} cos(aθ) | θ : ℝ}\n\natkinson_chowla_connection : (∀ A with |A|=n, chowlaMinimum(A) < -M) → log f*(n) ≤ C·M·log n",
+    "mathContext": "chowlaMinimum(A) := sInf {Σ_{a∈A} cos(aθ) | θ : ℝ}\n\nAtkinson's observation — (∀ A with |A|=n, chowlaMinimum(A) < -M) → log f*(n) ≤ C·M·log n — is recorded as a docstring note, not a Lean declaration.",
     "significance": "supporting",
     "relatedConcepts": [
       "cosine-sum",
@@ -195,13 +195,13 @@
     "id": "ann-e256-roots-unity",
     "proofId": "erdos-256",
     "range": {
-      "startLine": 180,
-      "endLine": 200
+      "startLine": 227,
+      "endLine": 250
     },
     "type": "concept",
     "title": "Behavior at Roots of Unity",
     "content": "**Key evaluation points:**\n\nWhen z is a k-th root of unity (z^k = 1), the product simplifies:\n- z^{aᵢ} = z^{aᵢ mod k}\n- The product depends only on residues mod k\n\nPrimitive roots provide lower bounds: there always exists a root where |product| ≥ 1.",
-    "mathContext": "product_at_root_of_unity : z^k = 1 → productPoly a z = ∏ᵢ(1-z^{aᵢ mod k})\n\nprimitive_root_lower_bound : ∃ k, ∃ ζ with ζ^k = 1, |productPoly a ζ| ≥ 1",
+    "mathContext": "product_at_root_of_unity (the one proved theorem here) evaluates the product at primitive k-th roots of unity.\n\nThe lower-bound idea — ∃ k, ∃ ζ with ζ^k = 1 and |productPoly a ζ| ≥ 1 — is documented in source comments only (no Lean declaration).",
     "significance": "key",
     "relatedConcepts": [
       "roots-of-unity",
@@ -218,13 +218,13 @@
     "id": "ann-e256-bounds-summary",
     "proofId": "erdos-256",
     "range": {
-      "startLine": 202,
-      "endLine": 225
+      "startLine": 251,
+      "endLine": 272
     },
     "type": "concept",
     "title": "Timeline and Gap Between Bounds",
     "content": "**What we know:**\n\n- **Lower**: log f(n) ≥ (1/2) log(2n) ≈ (1/2) log n\n- **Upper**: log f(n) ≤ C(log n)⁴\n\n**The gap**: The true growth is between log n and (log n)⁴. Pinning down the exact power remains open.\n\n**Timeline**:\n1959: √(2n) lower\n1961: n^{1/2}·log n upper\n1982: n^{1/3}·(log n)^{4/3} upper  \n1996: (log n)⁴ upper [final answer]",
-    "mathContext": "bounds_summary : (1/2)·log n ≤ log f(n) ≤ C·(log n)⁴\n\nThe gap between exponents 1 and 4 on log n is the remaining open question.",
+    "mathContext": "This part is a prose summary: (1/2)·log n ≤ log f(n) ≤ C·(log n)⁴, combining the erdos_szekeres_lower and belov_konyagin_bound axioms from earlier parts. The gap between exponents 1 and 4 on log n is the remaining open question. (No declaration in this part; erdos_256_summary in Part IX packages the two bounds.)",
     "significance": "key",
     "relatedConcepts": [
       "timeline",
@@ -242,8 +242,8 @@
     "id": "ann-e256-main-result",
     "proofId": "erdos-256",
     "range": {
-      "startLine": 227,
-      "endLine": 262
+      "startLine": 273,
+      "endLine": 308
     },
     "type": "insight",
     "title": "Main Result: Erdős #256 SOLVED",

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -98,76 +98,84 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Problem Statement",
+      "summary": "Module docstring stating Erdős Problem #256 — estimate $f(n)$, the minimax $\\inf_a \\max_{|z|=1} |\\prod_i(1 - z^{a_i})|$ — its SOLVED status (Belov-Konyagin 1996: $\\log f(n) \\ll (\\log n)^4$), and the historical bounds timeline; imports, opens, and namespace.",
+      "startLine": 1,
+      "endLine": 38,
+      "mathContext": "Erdős asked whether $\\log f(n) \\gg n^c$ for some $c > 0$. The answer is NO (Belov-Konyagin 1996). Header records the Erdős-Szekeres, Atkinson, Odlyzko, and Bourgain-Chang bounds as background."
+    },
+    {
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "Defines `productPoly` ($\\prod_i(1 - z^{a_i})$), `maxOnUnitCircle` ($\\max_{|z|=1} |P(z)|$), and $f(n) = \\inf_a \\max_{|z|=1} |P(z;a)|$. The inf-max structure captures the minimax optimization.",
       "startLine": 39,
       "endLine": 65,
-      "mathContext": "Formal definition: Defines `productPoly` ($\\prod_i(1 - z^{a_i})$), `maxOnUnitCircle` ($\\max_{|z|=1} |P(z)|$), and $f(n) = \\inf_a \\max_{|z|=1} |P(z;a)|$. The inf-max structure captures the minimax optimization."
+      "mathContext": "Defines `productPoly` ($\\prod_i(1 - z^{a_i})$), `maxOnUnitCircle` ($\\max_{|z|=1} |P(z)|$), and $f(n) = \\inf_a \\max_{|z|=1} |P(z;a)|$. The inf-max structure captures the minimax optimization."
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
-      "summary": "Axiomatizes the historical bounds: Erdős-Szekeres $f(n) > \\sqrt{2n}$ (1959), Atkinson $\\log f(n) \\ll n^{1/2} \\log n$ (1961), Odlyzko $\\log f(n) \\ll n^{1/3}(\\log n)^{4/3}$ (1982). Also proves $\\lim f(n)^{1/n} = 1$.",
+      "summary": "Axiomatizes the Erdős-Szekeres (1959) lower bound $f(n) > \\sqrt{2n}$ (`erdos_szekeres_lower`). The Erdős-Szekeres limit $f(n)^{1/n} \\to 1$, the Erdős probabilistic bound, Atkinson (1961), and Odlyzko (1982) are recorded as docstring notes only — no Lean declarations.",
       "startLine": 66,
-      "endLine": 104,
-      "mathContext": "Axiomatizes the historical bounds: Erdős-Szekeres $f(n) > \\sqrt{2n}$ (1959), Atkinson $\\log f(n) \\ll n^{1/2} \\log n$ (1961), Odlyzko $\\log f(n) \\ll n^{1/3}(\\log n)^{4/3}$ (1982). Also proves $\\lim f(n)^{1/n} = 1$."
+      "endLine": 96,
+      "mathContext": "Only `erdos_szekeres_lower : f n > √(2n)` is an axiom here. Atkinson $\\log f(n) \\ll n^{1/2}\\log n$, Odlyzko $\\log f(n) \\ll n^{1/3}(\\log n)^{4/3}$, and $\\lim f(n)^{1/n} = 1$ appear as background docstrings without declarations."
     },
     {
       "id": "question",
       "title": "The Main Question",
       "summary": "Defines `ErdosQuestion256`: $\\exists c > 0,\\, \\exists C > 0,\\, \\forall n \\geq 2,\\, \\log f(n) \\geq C \\cdot n^c$. Asks whether $\\log f(n)$ grows at least as a power of $n$.",
-      "startLine": 105,
-      "endLine": 117,
-      "mathContext": "Formal definition: Defines `ErdosQuestion256`: $\\exists c > 0,\\, \\exists C > 0,\\, \\forall n \\geq 2,\\, \\log f(n) \\geq C \\cdot n^c$. Asks whether $\\log f(n)$ grows at least as a power of $n$."
+      "startLine": 97,
+      "endLine": 109,
+      "mathContext": "Defines `ErdosQuestion256`: $\\exists c > 0,\\, \\exists C > 0,\\, \\forall n \\geq 2,\\, \\log f(n) \\geq C \\cdot n^c$. Asks whether $\\log f(n)$ grows at least as a power of $n$."
     },
     {
       "id": "answer",
       "title": "The Answer",
-      "summary": "Axiomatizes the Belov-Konyagin bound $\\log f(n) \\leq C(\\log n)^4$ and proves `erdos_256_answer : ¬ErdosQuestion256` — the answer is NO, since $(\\log n)^4$ grows slower than $n^c$ for any $c > 0$.",
-      "startLine": 118,
-      "endLine": 140,
-      "mathContext": "Axiomatizes the Belov-Konyagin bound $\\log f(n) \\leq C(\\$\\log n$)^4$ and proves `erdos_256_answer : ¬ErdosQuestion256` — the answer is NO, since $(\\$\\log n$)^4$ grows slower than $n^c$ for any $c > 0$."
+      "summary": "Axiomatizes the Belov-Konyagin bound $\\log f(n) \\leq C(\\log n)^4$ (`belov_konyagin_bound`) and proves `erdos_256_answer : ¬ErdosQuestion256` — the answer is NO, since $(\\log n)^4$ grows slower than $n^c$ for any $c > 0$.",
+      "startLine": 110,
+      "endLine": 193,
+      "mathContext": "Axiomatizes the Belov-Konyagin bound $\\log f(n) \\leq C(\\log n)^4$ and proves `erdos_256_answer : ¬ErdosQuestion256` — the answer is NO, since $(\\log n)^4$ grows slower than $n^c$ for any $c > 0$."
     },
     {
       "id": "distinct",
       "title": "The Distinct Case",
-      "summary": "Defines `fDistinct(n)` for the variant with distinct exponents. Axiomatizes the Bourgain-Chang (2018) bound for this case, which has different (potentially better) growth behavior.",
-      "startLine": 141,
-      "endLine": 159,
-      "mathContext": "Formal definition: Defines `fDistinct(n)` for the variant with distinct exponents. Axiomatizes the Bourgain-Chang (2018) bound for this case, which has different (potentially better) growth behavior."
+      "summary": "Defines `fDistinct(n)`, the minimax for strictly increasing (distinct) exponents. The Bourgain-Chang (2018) bound $\\log f^*(n) \\ll (n \\log n)^{1/2} \\log\\log n$ is recorded as a docstring note (no Lean declaration).",
+      "startLine": 194,
+      "endLine": 209,
+      "mathContext": "`fDistinct n = sInf {maxOnUnitCircle a | a injective}`. The Bourgain-Chang (2018) bound for the distinct case is background prose, not a declaration."
     },
     {
       "id": "chowla",
       "title": "Connection to Chowla Problem",
-      "summary": "Connects to Erdős Problem #510 via `chowlaMinimum`: the minimum of $|\\sum \\cos(a_i \\theta)|$ over $\\theta$. Atkinson observed these two minimax problems are related through the logarithm of the product.",
-      "startLine": 160,
-      "endLine": 179,
-      "mathContext": "Connects to Erdős Problem #510 via `chowlaMinimum`: the minimum of $|\\sum \\cos(a_i \\theta)|$ over $\\theta$."
+      "summary": "Connects to Erdős Problem #510 via `chowlaMinimum`: the minimum of $\\sum_{a \\in A} \\cos(a\\theta)$ over $\\theta$. Atkinson's observation relating the two minimax problems is recorded as a docstring note.",
+      "startLine": 210,
+      "endLine": 226,
+      "mathContext": "`chowlaMinimum A = sInf {∑_{a∈A} cos(aθ) | θ}`. Atkinson: if $\\sum \\cos(a\\theta) < -M_n$ is achievable then $\\log f^*(n) \\ll M_n \\log n$."
     },
     {
       "id": "properties",
       "title": "Properties of the Product",
-      "summary": "Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. documents in source comments `primitive_root_lower_bound` (no Lean declaration exists): these evaluation points provide key lower bounds on $f(n)$.",
-      "startLine": 180,
-      "endLine": 201,
-      "mathContext": "Verified: Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. documents in source comments `primitive_root_lower_bound` (no Lean declaration exists): these evaluation points provide key lower bounds on $f(n)$."
+      "summary": "Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. (`primitive_root_lower_bound` is documented in source comments only — no Lean declaration exists.)",
+      "startLine": 227,
+      "endLine": 250,
+      "mathContext": "`product_at_root_of_unity` evaluates the product at primitive roots of unity; these evaluation points provide key lower bounds on $f(n)$."
     },
     {
       "id": "summary-bounds",
       "title": "Summary of Bounds",
-      "summary": "Axiomatizes the complete bounds timeline in one theorem: $\\sqrt{2n} \\leq f(n)$ (1959) and $\\log f(n) \\leq C(\\log n)^4$ (1996). The gap between $\\frac{1}{2}\\log n$ and $(\\log n)^4$ remains open.",
-      "startLine": 202,
-      "endLine": 226,
-      "mathContext": "Axiomatizes the complete bounds timeline in one theorem: $\\sqrt{2n} \\leq f(n)$ (1959) and $\\log f(n) \\leq C(\\$\\log n$)^4$ (1996). The gap between $\\frac{1}{2}\\$\\log n$$ and $(\\$\\log n$)^4$ remains open."
+      "summary": "Documents the complete bounds timeline (1959 Erdős-Szekeres through 1996 Belov-Konyagin) and the remaining gap between $\\frac{1}{2}\\log n$ and $(\\log n)^4$ as prose docstrings; no Lean declarations in this part (the bounds are the axioms in Parts II and IV).",
+      "startLine": 251,
+      "endLine": 272,
+      "mathContext": "Lower: $\\log f(n) \\geq \\frac{1}{2}\\log n$ (from $f(n) > \\sqrt{2n}$). Upper: $\\log f(n) \\ll (\\log n)^4$. The true growth lies between. Prose-only summary."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Packages the final result: `erdos_256` aliases `erdos_256_answer` (¬ErdosQuestion256), and `erdos_256_summary` combines the Belov-Konyagin upper bound with the Erdős-Szekeres lower bound into a single conjunction, providing a self-contained statement of what is known about $f(n)$.",
-      "startLine": 227,
-      "endLine": 262,
-      "mathContext": "Packages the final result: `erdos_256` aliases `erdos_256_answer` (¬ErdosQuestion256), and `erdos_256_summary` combines the Belov-Konyagin upper bound with the Erdős-Szekeres lower bound into a single conjunction, providing a self-contained statement of what is known about $f(n)$."
+      "startLine": 273,
+      "endLine": 308,
+      "mathContext": "`erdos_256` aliases `erdos_256_answer` (¬ErdosQuestion256); `erdos_256_summary` proves $(\\exists C>0, \\forall n\\geq2, \\log f(n) \\leq C(\\log n)^4) \\wedge (\\forall n\\geq1, f(n) > \\sqrt{2n})$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery doc-integrity fix for `erdos-256` (Docker/Aristotle backends down).

The long `erdos_256_answer` proof (lines 110-193) pushed Parts V-IX down, so the meta sections for the distinct case, Chowla, product properties, bounds summary, and final summary sat **~50 lines before** their `## Part` banners. This left the header (1-38) and the Part IX declarations (`erdos_256` @295, `erdos_256_summary` @300; file ends at 308) uncovered.

## Changes

- Snapped every section to its `## Part` opener + added a "Module Header and Problem Statement" section → full contiguous coverage 1-308 (9→10 sections)
- Realigned the 5 later annotations, which had co-drifted (the earlier ones still pointed correctly, since pre-proof content didn't shift)
- **Fixed phantom-decl prose**: meta summaries claimed Part II "axiomatizes Atkinson/Odlyzko" + "proves lim f(n)^{1/n}=1", Part V "axiomatizes Bourgain-Chang", and Part VIII has a "theorem" — but those are `/-- -/` docstring notes, **not declarations**. Annotation `mathContext` referenced nonexistent decls `bourgain_chang_bound`, `atkinson_chowla_connection`, `primitive_root_lower_bound`, `bounds_summary`. The only axioms are `erdos_szekeres_lower` (@74) and `belov_konyagin_bound` (@121); summaries now reflect this.

## Integrity

- Counts unchanged: **2 axioms**, 0 sorries, status `axiomatized` — verified against source
- **No Lean source modified** (diff is JSON-only)

## Test plan
- [x] Both JSON files parse
- [x] Sections contiguous 1-308, every `## Part` banner covered by exactly one section
- [x] No phantom declaration names remain in annotations
- [x] `git diff --name-only` shows no `.lean` files