### PR TITLE
Enrich Taylor's Theorem (mean-value-theorem-oq-02): add setup annotation

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-mvt02-setup",
+    "proofId": "mean-value-theorem-oq-02",
+    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "title": "Imports, Setup, and the Open Question Being Resolved",
+    "content": "The file imports `Mathlib.Analysis.Calculus.Taylor` (which provides `taylor_mean_remainder` in integral form), `Mathlib.Analysis.Calculus.MeanValue`, and the iterated-derivative infrastructure from `Deriv.Basic`. The open question, inherited from the base `MeanValueTheorem.lean`, asks whether the higher-order MVT (Taylor's theorem with Lagrange remainder) admits a Mathlib-compatible formalization. The answer is yes: Mathlib supplies the integral remainder, and this file repackages it in the classical pedagogical Lagrange form. The `noncomputable section` is required because `iteratedDeriv` is built on the Fréchet derivative, which uses `Classical.choice`; `open Real MeasureTheory Set` brings `Set.Ioo` and integral notation into scope.",
+    "mathContext": "Target identity: $f(b) = \\sum_{k=0}^{n} \\frac{f^{(k)}(a)}{k!}(b-a)^k + R_n(a,b)$ with Lagrange remainder $R_n(a,b) = \\frac{f^{(n+1)}(c)}{(n+1)!}(b-a)^{n+1}$ for some $c \\in (a,b)$. Mathlib's native `taylor_mean_remainder` instead expresses $R_n$ in the Cauchy/integral form $\\int_a^b \\frac{(b-t)^n}{n!}f^{(n+1)}(t)\\,dt$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Taylor's theorem",
+      "Lagrange remainder",
+      "Mathlib.Analysis.Calculus.Taylor",
+      "noncomputable section",
+      "Classical.choice"
+    ],
+    "prerequisites": [
+      "Mathlib.Analysis.Calculus.Taylor",
+      "iteratedDeriv",
+      "ContDiff"
+    ]
+  },
+  {
     "id": "ann-mvt02-taylor-poly",
     "proofId": "mean-value-theorem-oq-02",
     "type": "definition",


### PR DESCRIPTION
## Enrichment pass: mean-value-theorem-oq-02 (Taylor's Theorem with Lagrange Remainder)

This entry was already high quality (score 98). This pass adds the one genuine coverage gap.

### Change
- **New annotation `ann-mvt02-setup`** (lines 1–51, the previously un-annotated header/imports/setup region). It explains:
  - the Mathlib modules being wrapped (`Mathlib.Analysis.Calculus.Taylor` providing `taylor_mean_remainder` in integral form, plus `MeanValue` and `Deriv.Basic`),
  - the open question inherited from the base `MeanValueTheorem.lean` and its resolution (repackaging Mathlib's integral remainder into classical Lagrange form),
  - why the file is `noncomputable` (`iteratedDeriv` → Fréchet derivative → `Classical.choice`) and what `open Real MeasureTheory Set` brings into scope.
  - Includes `mathContext` contrasting the target Lagrange identity with Mathlib's native Cauchy/integral remainder form.

Annotation count: 5 → 6. All annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Verification notes
- JSON validated (parses; all annotation ranges within the 153-line file).
- Section ranges and meta counts confirmed accurate against `Proofs/MeanValueTheoremOQ02.lean` (1 def, 4 theorems, 1 axiom, 153 lines); axiom/badge/status (`axiomatized`/`axiom`) correctly reflect the `taylor_lagrange_remainder` assumption.
- The error-bounds annotation's out-of-bounds `endLine` (154 → 153) was already fixed upstream; rebase preserved that.
- `pnpm build`'s data-enrichment prebuild validated all proof JSON (including this entry). The full `tsc` step could not run because `node_modules` is absent in this fresh worktree — an environment issue, unrelated to this JSON-only change.