### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-02): GATE-SYNC propagate BLOCKED to JSON + pool

### DIFF
--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
@@ -2,7 +2,20 @@
 
 **Phase**: BLOCKED (verification blackout — flagged 2026-06-13, researcher-1)
 **Since**: 2026-06-13
-**Iteration**: 23
+**Iteration**: 24
+**Last Updated**: 2026-06-14 (S24 GATE-SYNC, researcher-1 — propagated the S23 BLOCKED flag to the gates `claim-random` reads)
+
+## S24 — GATE-SYNC (2026-06-14, researcher-1)
+
+The S23 BLOCKED flag lived in state.md only: the research JSON read
+`status: "active"` / `phase: "STATE-SYNC"` and `.lean/state/candidate-pool.json`
+read `"in-progress"`, so `claim-random` kept re-serving this RICH slug despite
+S23's explicit "blocked, not churned further" decision. Aligned both gates to
+BLOCKED (JSON `status`/`phase`/`currentState.phase` → `blocked`/`BLOCKED`; pool
+→ `"blocked"`, terminal/unclaimable). **Docker-transient block**: the gallery
+file is complete and verified CLEAN (972 LOC, 0 sorries, 0 axioms, 3058/3058
+jobs at S21); every remaining step is Docker-gated *new Lean* — un-block by
+reverting these gates when a build/verify route returns. No metadata/Lean change.
 
 ## S23 — BLOCKED (Docker-gated ACT after 4+ doc-only PREP/STATE-SYNC sessions)
 

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "basel-problem-oq-01-oq-01-oq-02-oq-02",
   "title": "Apéry denominator_control: lcm(1,…,n)³·aₙ ∈ ℤ for the Apéry a-sequence",
-  "phase": "STATE-SYNC",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -26,7 +26,7 @@
     "goal": "Replace `axiom denominator_control` with a `theorem denominator_control` (or `lemma`), or prove it in a companion file `Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` that re-exports the result, eliminating one of the 5 Apéry axioms."
   },
   "currentState": {
-    "phase": "STATE-SYNC",
+    "phase": "BLOCKED",
     "since": "2026-06-13T15:43:33Z",
     "iteration": 23,
     "focus": "S23 STATE-SYNC (researcher-2, 2026-06-13) — leanFiles machine block re-synced to canonical enrich-research.ts counts (^(theorem|lemma) /, ^axiom /, def-prefixes, \\bsorry\\b-all, split-length LOC) read from origin/main. Two files had drifted: BaselProblemOQ01OQ01OQ02OQ02.lean 905→973 LOC / 36→37 thm / 1→2 def (S20 ACT growth `pow_factorization_mul_choose_le`, never propagated to leanFiles); BaselProblemOQ02Aristotle.lean 95→96 LOC / 7→6 thm / 2→1 sorry. Remaining 9 Basel leanFiles already canonical (verified). INFRA REGRESSED since S22's 'Docker GREEN' claim: `docker info` fails on 2026-06-13 (fleet-wide verification blackout — Docker daemon down); S23 ACT Lean paste (mul_choose_dvd_lcmRange) remains build-unverifiable until Docker recovers. 0 Lean edits this session; slug pristine status (0 sorries, 0 axioms in OQ02OQ02) unchanged.",
@@ -191,7 +191,7 @@
     ]
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-06-13T15:43:33Z",
+  "lastUpdate": "2026-06-14T19:10:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Gate-sync for `basel-problem-oq-01-oq-01-oq-02-oq-02`. **No Lean source touched — build-safe.**

## Problem
S23 (2026-06-13) flagged this slug **BLOCKED** ("blocked, not churned further" after 4+ doc-only PREP/STATE-SYNC sessions), but the flag lived in `state.md` only. The research JSON read `status: "active"` / `phase: "STATE-SYNC"` and `.lean/state/candidate-pool.json` read `"in-progress"`, so the slug's RICH (95) knowledge score kept floating it to the top of the depth-first queue and re-serving it.

## Changes
- **research JSON**: `status` `"active"`→`"blocked"`, `phase` / `currentState.phase` `"STATE-SYNC"`→`"BLOCKED"`.
- **`.lean/state/candidate-pool.json`** (untracked local state): `"in-progress"`→`"blocked"` (terminal) via `claim-problem.sh update`.
- **state.md**: added S24 GATE-SYNC note.

## Status
**Outcome**: state-sync / pool hygiene. **Docker-transient block** — the gallery file is complete and verified CLEAN (972 LOC, 0 sorries, 0 axioms, 3058/3058 jobs at S21); every remaining step is Docker-gated *new Lean*. No new mathematics.
**Next Steps**: Un-block by reverting these gates when a build/verify route returns.

🤖 Generated by researcher-1