### PR TITLE
Enrich Primes ≡ 3 (mod 4) (dirichlets-theorem-oq-02): Schur–Murty characterization

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -60,7 +60,8 @@
       "The construction N = 4·(n+1)! - 1 ensures N ≡ 3 (mod 4) AND that any small prime divides N+1 but not N",
       "Unlike the general Dirichlet theorem, this special case needs no analytic number theory — pure number theory and induction suffice",
       "The proof uses strong induction (well-founded recursion on n) for the key lemma, with termination from n/p < n",
-      "The proof avoids L-functions and Dirichlet characters entirely — the special structure of ≡ 3 (mod 4) primes allows a purely elementary argument that doesn't generalize to other arithmetic progressions."
+      "The proof avoids L-functions and Dirichlet characters entirely — the special structure of ≡ 3 (mod 4) primes allows a purely elementary argument that doesn't generalize to other arithmetic progressions.",
+      "**When does Euclid's method suffice?** A Euclidean-style (polynomial) proof of infinitely many primes ≡ a (mod q) exists *if and only if* a² ≡ 1 (mod q): Schur (1912) constructed such proofs whenever a² ≡ 1, and Murty (1988) proved the converse. Here a = 3, q = 4, and 3² = 9 ≡ 1 (mod 4) — which is exactly why this file's elementary argument exists. It also explains the obstruction: no analogous Euclidean proof exists for, e.g., primes ≡ 2 (mod 5), since 2² = 4 ≢ 1 (mod 5)."
     ],
     "prerequisites": [
       "Elementary number theory (primes, divisibility, modular arithmetic)",
@@ -101,10 +102,11 @@
   ],
   "conclusion": {
     "summary": "A fully verified, axiom-free elementary proof that infinitely many primes are congruent to 3 modulo 4. The proof uses only basic number theory and well-founded induction — no L-functions, characters, or analytic techniques.",
-    "implications": "This is a special case of Dirichlet's theorem (which Mathlib proves in full generality using L-functions). The elementary approach here demonstrates that certain arithmetic progression results can be obtained without heavy analytic machinery.\n\nSimilar elementary arguments work for primes ≡ 2 (mod 3), but most residue classes require L-functions.",
+    "implications": "This is a special case of Dirichlet's theorem (which Mathlib proves in full generality using L-functions). The elementary approach here demonstrates that certain arithmetic progression results can be obtained without heavy analytic machinery.\n\nSimilar elementary arguments work for primes ≡ 2 (mod 3) — and, more precisely, the Schur–Murty theorem pins down the exact boundary: a Euclidean-style proof of infinitude for the class a (mod q) exists if and only if a² ≡ 1 (mod q). The class 3 (mod 4) satisfies 3² ≡ 1, so it lies inside the Euclidean regime; classes like 2 (mod 5) do not, and provably admit no such elementary Euclidean proof.",
     "openQuestions": [
-      "Which residue classes admit elementary (non-L-function) proofs of infinitude?",
-      "Can the construction be made effective — what is the smallest prime ≡ 3 (mod 4) exceeding n?"
+      "For Euclidean-style (polynomial) proofs the answer is settled by Schur (1912) and Murty (1988): infinitude of primes ≡ a (mod q) admits such a proof iff a² ≡ 1 (mod q). Do the remaining residue classes (e.g. 2 mod 5) admit *any* elementary, non-analytic proof, or is some analytic input provably necessary?",
+      "Can the construction be made effective — what is the smallest prime ≡ 3 (mod 4) exceeding n?",
+      "The factorial construction N = 4·(n+1)! − 1 certifies a prime ≡ 3 (mod 4) above n, as does the simpler product variant N = 4·p₁⋯p_k − 1 over the known such primes. How does the lower bound on the k-th prime ≡ 3 (mod 4) that these elementary constructions certify compare with the true asymptotic growth ~2k·ln k from the prime number theorem for arithmetic progressions?"
     ]
   },
   "crossReferences": [
@@ -148,6 +150,13 @@
       "year": "1977",
       "venue": "Springer-Verlag, Universitext",
       "note": "Chapter 4 discusses primes in arithmetic progressions and the special cases admitting elementary proofs, including primes ≡ 3 (mod 4)"
+    },
+    {
+      "authors": "M. Ram Murty",
+      "title": "Primes in certain arithmetic progressions",
+      "year": "1988",
+      "venue": "Journal of the Madras University, Section B 51, 161–169",
+      "note": "Proves the converse of Schur's 1912 result: a Euclidean-style proof of the infinitude of primes ≡ a (mod q) exists if and only if a² ≡ 1 (mod q). The class 3 (mod 4) satisfies this, explaining why the elementary argument formalized here works."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass: dirichlets-theorem-oq-02 (Infinitely Many Primes ≡ 3 mod 4)

This entry was already high quality (score 98, well-aligned sections/annotations, valid cross-refs). This pass adds genuine mathematical depth that directly answers the entry's own open question.

### Change (meta.json only)
- **New keyInsight — the Schur–Murty characterization.** A Euclidean-style (polynomial) proof of infinitely many primes ≡ a (mod q) exists **iff** `a² ≡ 1 (mod q)`: Schur (1912) built such proofs when `a² ≡ 1`, and Murty (1988) proved the converse. Here `a = 3, q = 4`, and `3² = 9 ≡ 1 (mod 4)` — precisely why this file's elementary argument exists. It also names the obstruction: no analogous proof for primes ≡ 2 (mod 5), since `2² = 4 ≢ 1 (mod 5)`.
- **Reframed open question #1** around this now-known characterization (the Euclidean case is settled; the broader "any elementary method" question for the remaining classes stays open), and **added a third, quantitative open question** comparing the lower bound the factorial/product constructions certify against the true `~2k·ln k` growth from the PNT for arithmetic progressions.
- **Expanded conclusion implications** with the exact Euclidean-regime boundary.
- **Added the Murty (1988) reference.**

keyInsights 5 → 6; openQuestions 2 → 3; references 2 → 3.

### Verification notes
- JSON validated (parses). `status: verified` / `axiomCount: 0` confirmed accurate: the Lean file (`Proofs/DirichletsTheoremOQ02.lean`, 101 lines, 3 theorems) has no `axiom` declarations and no assumption-carrying structures.
- Schur–Murty result cross-checked against Keith Conrad's "Euclidean Proofs of Dirichlet's Theorem" and standard references.
- Source-only `meta.json` change; no Lean code touched. (`tsc` step of `pnpm build` cannot run here — `node_modules` absent in this fresh worktree — but the data-enrichment prebuild validates all proof JSON.)