### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): ORIENT deepening — Strategy D + verified minimal polynomial

### DIFF
--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -44,8 +44,24 @@ polynomial of α has degree 16. Degree ≠ 1 ⇒ irrational.
   Strategy A needs no new Mathlib (`irrational_sqrt_natCast_iff`, `Real.sq_sqrt`, `Real.sqrt_mul`
   all present).
 
-- **Recommended path**: Strategy A — same toolkit as the parent, no infrastructure dependency,
-  BUILD-class. Reserve B/C if the A bookkeeping balloons.
+  - **(D) Algebraic-integer + bounded-interval** (NEW, 2026-06-14 Session 2; **now recommended**) —
+    α is a sum of four algebraic integers √2,√3,√5,√7 (each a root of the monic `X²−k`), so α is
+    integral over ℤ. A rational number that is integral over ℤ lies in ℤ (ℤ is integrally closed
+    in ℚ). But `8 < α < 9` (α ≈ 8.0281, verified), so α ∉ ℤ; hence α is irrational. This sidesteps
+    the entire degree-16 algebra: **no squaring chain, no minimal polynomial, no surd isolation.**
+    Estimated **~60–100 LOC**, no new Mathlib theory — just the integral-closure API.
+
+- **Recommended path**: **Strategy D** — far shorter than A and avoids the messy degree-16
+  bookkeeping that A and B/C require. Strategy A remains a valid fallback (no infrastructure
+  dependency) but is now superseded; reserve B/C only if the integral-closure lemmas are missing.
+
+- **Explicit minimal polynomial** (sympy-verified, `m(α)=0` exactly): α has degree-16 minimal
+  polynomial over ℚ (monic, integer coefficients, even):
+  `m(x) = x¹⁶ − 136x¹⁴ + 6476x¹² − 141912x¹⁰ + 1513334x⁸ − 7453176x⁶ + 13950764x⁴ − 5596840x² + 46225`
+  (constant term `46225 = 215²`). Equivalently `g(α²)=0` with the degree-8
+  `g(y)=y⁸−136y⁷+6476y⁶−141912y⁵+1513334y⁴−7453176y³+13950764y²−5596840y+46225`. This confirms
+  the degree-16 claim concretely and gives an alternative Lean target (`m(α)=0` is `ring`-provable
+  after `Real.sq_sqrt`, but the 16th-power expansion is heavy — Strategy D avoids needing it).
 
 ---
 
@@ -54,6 +70,13 @@ polynomial of α has degree 16. Degree ≠ 1 ⇒ irrational.
 - Naive reduction "√2+√3+√5 = q − √7 with both sides irrational" gives **no** contradiction
   (irrational − irrational can be rational). Squaring it yields √6+√10+√15+q√7 ∈ ℚ, i.e. four
   surds again — no shortcut around the degree-16 structure.
+- **Strategy-A single-surd reduction has ugly coefficients** (Session 2, numerically confirmed).
+  Expressing √210 (= √2·√3·√5·√7) in the power basis of α gives
+  `√210 = Σ cᵢ αⁱ` with only even powers but rational coefficients over a common denominator
+  `14 499 840` (e.g. `c₀ = 42047681/2899968`, `c₁₄ = −1/906240`). There is **no** clean
+  small-integer single-surd identity analogous to the parent's `α⁴−20α²−24 = 8α√30`. This is
+  concrete evidence that Strategy A's "isolate one surd" endgame is heavy, reinforcing the switch
+  to Strategy D.
 
 ---
 
@@ -85,3 +108,56 @@ polynomial of α has degree 16. Degree ≠ 1 ⇒ irrational.
 2. Fallback: narrow 4-prime Besicovitch lemma `LinearIndependent ℚ ![1,√2,√3,√5,√7]`.
 3. Surd-isolation identities are Aristotle-eligible (HARD-but-known) once stated — blocked by
    the Aristotle backend outage.
+
+---
+
+## Session 2026-06-14 (Session 2) — Build-free strategy deepening (researcher-4)
+
+**Mode**: CONTINUE · **Outcome**: ORIENT deepened (new recommended strategy + verified
+artifacts). Both backends still down (Docker `docker info` timeout; Aristotle `prove` →
+"Resource not found"), so build-free only — all results checked with sympy/mpmath, not Lean.
+
+### What I found (all numerically/symbolically verified)
+1. **Explicit minimal polynomial** of α (sympy `minimal_polynomial`, then `m(α)=0` confirmed
+   exactly): degree 16, monic, integer, even — see Insights above. Independently re-derivable
+   from `p=√2+√3 ⇒ p⁴−10p²+1=0` and `q=√5+√7 ⇒ q⁴−24q²+4=0` via the resultant
+   `Res_y(y⁴−10y²+1, (α−y)⁴−24(α−y)²+4)`.
+2. **New Strategy D (algebraic integer + bound)** — now the recommended path; ~60–100 LOC,
+   avoids all degree-16 algebra. The key arithmetic fact `8 < α < 9` (α ≈ 8.0281) is verified.
+3. **Strategy A's single-surd endgame is ugly** (denominator 14 499 840) — see Dead Ends.
+
+### Strategy D — concrete Lean skeleton (for ACT when Docker returns)
+```lean
+import Mathlib
+open Real
+-- √k is integral over ℤ: root of monic X^2 - C k.
+lemma isIntegral_sqrt (k : ℕ) : IsIntegral ℤ (Real.sqrt k) := by
+  refine ⟨Polynomial.X ^ 2 - Polynomial.C (k : ℤ), ?_, ?_⟩
+  · -- monic (leading coeff 1)
+    monicity?  -- Polynomial.monic_X_pow_sub_C-style; degree-2 monic
+  · -- aeval (√k) (X^2 - C k) = 0, i.e. (√k)^2 - k = 0
+    simp [Real.sq_sqrt (by positivity : (0:ℝ) ≤ k)]
+theorem irrational_sum :
+    Irrational (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7) := by
+  have hα : IsIntegral ℤ (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7) :=
+    (((isIntegral_sqrt 2).add (isIntegral_sqrt 3)).add (isIntegral_sqrt 5)).add (isIntegral_sqrt 7)
+  rintro ⟨r, hr⟩                       -- r : ℚ, (r:ℝ) = α
+  -- (r:ℝ) integral over ℤ  ⇒  r integral over ℤ  (ℚ↪ℝ injective)  ⇒  r ∈ ℤ (ℤ integrally closed)
+  -- then 8 < (r:ℝ)=α < 9 forces a non-integer integer. Contradiction.
+  sorry
+```
+Open Lean items to confirm at build time (lemma names, not math):
+- `IsIntegral.add` (algebraic integers closed under +) — standard, in `Mathlib.RingTheory.IntegralClosure`.
+- Descent of integrality along the injective `algebraMap ℚ ℝ` (so `(r:ℝ)` integral ⇒ `r` integral).
+- `IsIntegrallyClosed ℤ` ⇒ a rational integral over ℤ equals some `(n:ℤ)` (`IsIntegrallyClosed.isIntegral_iff`).
+- Bounds `8 < √2+√3+√5+√7 < 9` via `Real.sqrt_lt_sqrt`/`Real.lt_sqrt` + `norm_num`.
+
+### Files modified
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+- `src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json`
+
+### Next steps
+1. When Docker returns: implement **Strategy D** (above) — much smaller than A; verify the four
+   Lean lemma names resolve, fill the `sorry`. If `IsIntegrallyClosed` descent is awkward, fall
+   back to Strategy A or prove `m(α)=0` and apply the rational-root theorem (α∉ℤ ⇒ irrational).
+2. Strategy A remains the no-infrastructure fallback (3-squaring chain; ugly but elementary).

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
@@ -4,16 +4,19 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Feasibility survey complete. Resolved on paper (α has degree 16 ⇒ irrational). Three
-formalization strategies assessed; Strategy A (elementary iterated squaring) is the
-recommended no-new-Mathlib path, currently Docker-gated.
+Survey deepened (Session 2, researcher-4). Found a NEW recommended strategy (D:
+algebraic-integer + bounded-interval) that is ~60–100 LOC and avoids ALL degree-16 algebra,
+superseding Strategy A. Computed and verified the explicit degree-16 minimal polynomial and
+the decisive bound `8 < α < 9` (sympy/mpmath). Still Docker-gated for the final Lean build.
 
 ## Active Approach
-Strategy A — extend the parent's iterated-squaring chain from two to three squarings to
-isolate a single non-square residual surd. Deferred to ACT until Docker returns.
+Strategy D — α = √2+√3+√5+√7 is a sum of algebraic integers ⇒ integral over ℤ; a rational
+integral over ℤ lies in ℤ; but 8 < α < 9 ⇒ not an integer ⇒ irrational. Lean skeleton drafted
+in knowledge.md (4 lemma names to confirm at build). Deferred to ACT until Docker returns.
+Fallback: Strategy A (elementary 3-squaring chain) or `m(α)=0` + rational-root theorem.
 
 ## Attempt Count
 - Total attempts: 0
@@ -25,6 +28,9 @@ isolate a single non-square residual surd. Deferred to ACT until Docker returns.
 - Aristotle backend returns "Resource not found" — cannot delegate the mechanical identities.
 
 ## Next Action
-When Docker returns, draft Strategy A in
-`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~300–600 LOC, elementary,
-no new Mathlib). See knowledge.md for the full strategy assessment.
+When Docker returns, implement **Strategy D** in
+`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~60–100 LOC). Confirm the four
+Mathlib lemma names in the knowledge.md skeleton (`IsIntegral.add`, integrality descent along
+`algebraMap ℚ ℝ`, `IsIntegrallyClosed ℤ`, sqrt bounds), then fill the single `sorry`. If the
+integral-closure descent is awkward, fall back to Strategy A (3-squaring chain) or prove
+`m(α)=0` and apply the rational-root theorem. See knowledge.md for the full assessment.

--- a/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
+++ b/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-06-15T01:25:28.245Z",
-    "iteration": 2,
-    "focus": "Feasibility survey complete: resolved on paper, 3 strategies assessed.",
-    "blockers": [],
-    "nextAction": "When Docker returns, draft Strategy A (iterated-squaring extension) in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean.",
+    "iteration": 3,
+    "focus": "Survey deepened (Session 2): NEW recommended Strategy D (algebraic-integer + bound, ~60-100 LOC) supersedes A; explicit degree-16 minimal polynomial and bound 8<α<9 computed and verified (sympy/mpmath). Still Docker-gated for final build.",
+    "blockers": ["Docker build wrapper unavailable (docker info timeout).", "Aristotle backend returns 'Resource not found'."],
+    "nextAction": "When Docker returns, implement Strategy D in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (~60-100 LOC); confirm the 4 lemma names in the knowledge.md skeleton and fill the single sorry. Fallbacks: Strategy A (3-squaring chain) or m(α)=0 + rational-root theorem.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,24 +31,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (build-free survey, researcher-10 2026-06-14): resolved on paper (degree-16 algebraic integer ⇒ irrational); 3 formalization strategies assessed; elementary iterated-squaring (A) is the only no-new-Mathlib path, BUILD-class and Docker-gated. Fixed leanFiles misattribution (JSON pointed at the parent √2+√3+√5 proof, falsely showing 0 sorries/solved) and added the real problem statement.",
+    "progressSummary": "ORIENT deepened (build-free, researcher-4 2026-06-14 Session 2): found NEW recommended Strategy D (algebraic-integer + bounded-interval, ~60-100 LOC) that avoids ALL degree-16 algebra and supersedes Strategy A; computed and verified (sympy/mpmath) the explicit degree-16 monic minimal polynomial m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 and the decisive bound 8<α<9 (α≈8.0281). Also confirmed Strategy A's single-surd endgame has ugly coefficients (common denom 14499840 for √210 in the α power basis). Prior (researcher-10): resolved on paper degree-16, fixed leanFiles misattribution. Still Docker-gated for final Lean build.",
     "builtItems": [],
     "insights": [
       "RESOLVED ON PAPER: √2+√3+√5+√7 is irrational — in fact an algebraic integer of degree 16 over ℚ. The 16 sign-combinations ±√2±√3±√5±√7 are its full set of Galois conjugates (Galois group (ℤ/2)^4 of the multiquadratic field ℚ(√2,√3,√5,√7)); α is a primitive element, so its minimal polynomial has degree 16 with rational integer coefficients. Degree ≠ 1 ⇒ irrational.",
       "Three formalization strategies, in increasing Mathlib-infrastructure cost: (A) elementary iterated squaring; (B) ℚ-linear independence of {1,√2,√3,√5,√7} (Besicovitch); (C) field degree [ℚ(√2,√3,√5,√7):ℚ]=16.",
       "Strategy A generalizes the existing 145-line √2+√3+√5 proof (Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean) but does NOT collapse to a single surd: after subtracting √7 and squaring once, three independent surds √6,√10,√15 appear alongside √7, so the contradiction requires unwinding the full degree-16 relation. Honest LOC estimate 300-600, all elementary (ring/linarith/Real.sq_sqrt/irrational_sqrt_natCast_iff), NO new Mathlib. Upper end of BUILD range; Docker-gated.",
       "Strategy B is mathematically cleanest (α rational ⇒ a nontrivial ℚ-linear relation among 1,√2,√3,√5,√7, contradicting Besicovitch independence of √ of distinct squarefree integers) but Mathlib has NO ready lemma for linear independence of square roots of squarefree integers (web-confirmed 2026-06); building the general theorem is >500 LOC.",
-      "Strategy C parallels the sibling gallery proof Sqrt2PlusSqrt3IrrationalOQ03 (minimal polynomial of √2+√3 = X⁴-10X²+1 via minpoly/IntermediateField), scaled to the degree-16 multiquadratic field; needs linear-disjointness / degree-of-multiquadratic infrastructure not assembled in Mathlib (>500 LOC)."
+      "Strategy C parallels the sibling gallery proof Sqrt2PlusSqrt3IrrationalOQ03 (minimal polynomial of √2+√3 = X⁴-10X²+1 via minpoly/IntermediateField), scaled to the degree-16 multiquadratic field; needs linear-disjointness / degree-of-multiquadratic infrastructure not assembled in Mathlib (>500 LOC).",
+      "NEW Strategy D (RECOMMENDED, Session 2): α = √2+√3+√5+√7 is a sum of four algebraic integers (each √k a root of monic X²-k), hence integral over ℤ (IsIntegral.add). A rational number integral over ℤ lies in ℤ (ℤ integrally closed in ℚ, IsIntegrallyClosed). But 8 < α < 9 (α≈8.0281, verified), so α ∉ ℤ ⇒ irrational. This sidesteps the ENTIRE degree-16 algebra: no squaring chain, no minimal-polynomial expansion, no surd isolation. ~60-100 LOC, no new Mathlib theory (just the integral-closure API). Lean skeleton drafted in knowledge.md with 4 lemma names to confirm at build.",
+      "Explicit minimal polynomial (sympy-verified m(α)=0 exactly): m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 (monic, integer, even; constant 46225=215²); equivalently g(α²)=0 with g(y)=y^8-136y^7+6476y^6-141912y^5+1513334y^4-7453176y^3+13950764y^2-5596840y+46225. Confirms the degree-16 claim concretely; alternative Lean target (m(α)=0 then rational-root theorem), though the 16th-power expansion is heavy vs Strategy D.",
+      "Strategy A's single-surd endgame is NOT clean (numerically confirmed Session 2): √210=Σcᵢαⁱ in the α power basis has only even powers but rational coefficients over common denominator 14499840 (e.g. c₀=42047681/2899968). No small-integer analog of the parent's α⁴-20α²-24=8α√30 — reinforces switching to Strategy D."
     ],
     "mathlibGaps": [
       "No usable Mathlib lemma for ℚ-linear independence of {√d : d squarefree} (Besicovitch); needed for Strategy B.",
       "No assembled multiquadratic-field degree result [ℚ(√p₁,…,√pₖ):ℚ]=2^k / linear disjointness of ℚ(√pᵢ); needed for Strategy C.",
-      "Sufficient for Strategy A and already present: irrational_sqrt_natCast_iff, Real.sq_sqrt, Real.sqrt_mul — no gap."
+      "Sufficient for Strategy A and already present: irrational_sqrt_natCast_iff, Real.sq_sqrt, Real.sqrt_mul — no gap.",
+      "Strategy D (recommended) needs only the integral-closure API expected to be present: IsIntegral.add, IsIntegrallyClosed ℤ / IsIntegrallyClosed.isIntegral_iff, and integrality descent along algebraMap ℚ ℝ — to be confirmed at build, no known gap."
     ],
     "nextSteps": [
-      "When Docker returns: draft Strategy A — extend the 2-squaring chain of Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean to a 3-squaring chain isolating one non-square surd; target new file Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean. Elementary, no new Mathlib, ~300-600 LOC. BUILD-class, Docker-gated.",
-      "Fallback if Strategy A algebra is unwieldy: build the specific 4-prime Besicovitch lemma (LinearIndependent ℚ ![1,√2,√3,√5,√7]) as standalone infrastructure (~200-400 LOC), narrower than the general theorem.",
-      "Aristotle-eligible once a clean surd-isolation lemma statement exists (the identities are HARD-but-known mechanical algebra, not OPEN). Currently blocked: Aristotle backend returns 'Resource not found' (2026-06-14)."
+      "When Docker returns: implement Strategy D (RECOMMENDED) in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (~60-100 LOC). Confirm the 4 Mathlib lemma names in the knowledge.md skeleton (IsIntegral.add; integrality descent along the injective algebraMap ℚ ℝ; IsIntegrallyClosed ℤ ⇒ rational integral element is an integer; sqrt bounds for 8<α<9), then fill the single sorry.",
+      "Fallback 1: Strategy A (3-squaring chain) — no infrastructure dependency but ~300-600 LOC and ugly single-surd endgame. Fallback 2: prove m(α)=0 (explicit poly recorded) and apply the rational-root theorem (monic ℤ-poly ⇒ rational roots are integers; α∈(8,9) ⇒ none).",
+      "Aristotle-eligible once the backend returns: submit the Strategy D theorem (or m(α)=0) directly. As of 2026-06-14 Aristotle 'prove' still returns 'Resource not found' (re-confirmed Session 2)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Build-free ORIENT iteration on the irrationality of √2 + √3 + √5 + √7 (both
Docker and Aristotle backends down). All results verified with sympy/mpmath
— no Lean build was available, so the Lean side is recorded as a skeleton for
ACT, not committed code.

- **New recommended Strategy D (algebraic-integer + bounded-interval).** α is a
  sum of four algebraic integers (each √k is a root of the monic `X²−k`), hence
  integral over ℤ. A rational number integral over ℤ lies in ℤ (ℤ is integrally
  closed in ℚ). But `8 < α < 9` (α ≈ 8.0281, verified), so α ∉ ℤ ⇒ irrational.
  This **sidesteps the entire degree-16 algebra** — no squaring chain, no
  minimal-polynomial expansion, no surd isolation — and is ~60–100 LOC vs
  Strategy A's 300–600. A concrete Lean skeleton with the four lemma names to
  confirm at build time is in `knowledge.md`.
- **Explicit minimal polynomial** computed and `m(α)=0` confirmed exactly:
  `x¹⁶ − 136x¹⁴ + 6476x¹² − 141912x¹⁰ + 1513334x⁸ − 7453176x⁶ + 13950764x⁴ − 5596840x² + 46225`
  (monic, integer, even; constant `46225 = 215²`).
- **Strategy A's single-surd endgame is not clean** (numerically confirmed):
  √210 in the α power basis has common denominator `14 499 840`, so there is no
  small-integer analog of the parent's `α⁴−20α²−24 = 8α√30`.

## Files

- `research/problems/.../knowledge.md` — Strategy D, minimal polynomial, Lean skeleton, Session 2 log
- `research/problems/.../state.md` — phase ORIENT (iter 3), Strategy D as active approach
- `src/data/research/problems/...json` — registry insights/nextSteps/focus updated

Docs only; **no `.lean` files touched** (build-safe). Problem remains
Docker-gated for the final build/verification of Strategy D.

## Test plan
- [x] `m(α) = 0` verified exactly (sympy)
- [x] `8 < α < 9` verified (mpmath)
- [x] minimal polynomial degree 16, monic, even (sympy)
- [x] registry JSON parses
- [ ] Strategy D Lean proof (deferred to ACT — Docker-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)