### PR TITLE
research(fodor-pressing-down-oq-04): GATE-SYNC propagate BLOCKED to JSON + pool

### DIFF
--- a/research/problems/fodor-pressing-down-oq-04/state.md
+++ b/research/problems/fodor-pressing-down-oq-04/state.md
@@ -3,7 +3,19 @@
 ## Phase: BLOCKED (S2-β-γ packaging landed; next ACT `fodor_anti_constant` is Docker-gated + design-incomplete) — verification blackout 2026-06-13
 
 > **Iteration**: 11 (unchanged; this is a status flag, not a new ACT).
-> **Last Updated**: 2026-06-14 (S2-β-δ PREP — `cofSecond` bearer confirmed; BLOCKED root cause unchanged, researcher-1).
+> **Last Updated**: 2026-06-14 (S2-β-ε GATE-SYNC — propagated BLOCKED to the JSON + pool gates; researcher-1).
+
+### S2-β-ε GATE-SYNC (researcher-1, 2026-06-14)
+
+The BLOCKED flag lived in state.md only: the research JSON read `status:
+"in-progress"` / `phase: "ACT"` and `.lean/state/candidate-pool.json` read
+`"in-progress"`, so `claim-random` kept re-serving this RICH slug. Aligned
+both gates to BLOCKED (JSON `status`/`phase`/`currentState.phase` →
+`blocked`/`BLOCKED`; pool → `"blocked"`, terminal). Block has two causes:
+the next ACT (`fodor_anti_constant`) is **Docker-gated** AND
+**design-incomplete** (not paste-ready even with a build route). Un-block by
+reverting these gates once Docker returns AND the `fodor_anti_constant`
+design is settled. No metadata/Lean change.
 
 ### S2-β-δ PREP update (researcher-1, 2026-06-14) — design front advanced, BLOCKED unchanged
 

--- a/src/data/research/problems/fodor-pressing-down-oq-04.json
+++ b/src/data/research/problems/fodor-pressing-down-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "fodor-pressing-down-oq-04",
   "title": "Solovay splitting: every stationary subset of a regular uncountable κ admits a partition into κ pairwise-disjoint stationary subsets",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -30,7 +30,7 @@
     "goal": "Reach a build-verified Lean 4 proof of Solovay splitting in the FodorPressingDown.lean framework. Decompose into three milestones: limit-reduction lemma (S2-α, DONE), binary splitting (S2-β/S3), full κ-splitting (S2-γ/S4+)."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-06-12T00:00:00Z",
     "iteration": 11,
     "focus": "S2-β-γ ACT (researcher-2, 2026-06-12): binary-split packaging shipped in new §Part X (+73 LOC, 654→727; 0 sorries, 0 axioms; Docker 3062 jobs CLEAN). Two reducers from S3b §4.4: (1) `stationary_splits_of_fiber_compl` — a stationary fiber {α ∈ S | P α} plus a stationary complement {α ∈ S | ¬ P α} yield two disjoint stationary subsets of S (the canonical consumer of a fodor_anti_constant two-conjunct output); (2) `stationary_splits_of_two_fibers` — two stationary fibers of one f at distinct values c₁ ≠ c₂ yield two disjoint stationary subsets (the two-Fodor route packaging). Both proved from Set.disjoint_left / inter_subset_left / mem_preimage / mem_singleton_iff. Scope honesty: these PACKAGE a split once two complementary/distinct-value stationary pieces exist; they do NOT produce them. The production step (fodor_anti_constant, index-of-first-disagreement) remains open and was under-specified in the S3b design (h_pair_distinct carried a True placeholder). Current FodorPressingDown.lean counts (post oq-01 S4 trim #22948, which moved the club/stationary infra to Proofs.Club.Basic): 653 LOC, 14 theorems, 1 noncomputable def (cofHead), 0 sorries, 0 axioms — §Part X intact. The 727/22/4 figures in the §Part X delta above describe the file at the moment Part X landed, before the trim.",
@@ -114,7 +114,7 @@
     ]
   },
   "started": "2026-05-12T14:35:20.231Z",
-  "lastUpdate": "2026-06-14T23:55:00Z",
+  "lastUpdate": "2026-06-14T19:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Gate-sync for `fodor-pressing-down-oq-04`. **No Lean source touched — build-safe** (research-only slug, no gallery entry).

## Problem
state.md correctly flagged this slug **BLOCKED**, but the flag lived there only. The research JSON read `status: "in-progress"` / `phase: "ACT"` and `.lean/state/candidate-pool.json` read `"in-progress"`, so the RICH knowledge score kept re-serving it via depth-first `claim-random`.

## Changes
- **research JSON**: `status` `"in-progress"`→`"blocked"`, `phase` / `currentState.phase` `"ACT"`→`"BLOCKED"`.
- **`.lean/state/candidate-pool.json`** (untracked local state): `"in-progress"`→`"blocked"` (terminal).
- **state.md**: added S2-β-ε GATE-SYNC note.

## Status
**Outcome**: state-sync / pool hygiene. Block has two causes — the next ACT (`fodor_anti_constant`) is **Docker-gated** AND **design-incomplete** (not paste-ready even with a build route). No new mathematics.
**Next Steps**: Un-block by reverting these gates once Docker returns AND the `fodor_anti_constant` design is settled.

🤖 Generated by researcher-1