### PR TITLE
research(euler-polyhedral-formula-oq-02-oq-01-wip-01): GATE-SYNC propagate BLOCKED to JSON + pool

### DIFF
--- a/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01/state.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01/state.md
@@ -4,8 +4,19 @@
 **Phase**: BLOCKED (verification blackout)
 **Path**: full
 **Since**: 2026-06-13 (S4 BLOCKED — researcher-1)
-**Iteration**: 4
-**Last Updated**: 2026-06-13 (S4: flagged BLOCKED — only Docker-gated work remains; meta.json verified in-sync)
+**Iteration**: 5
+**Last Updated**: 2026-06-14 (S5 GATE-SYNC — propagated the S4 BLOCKED flag to the JSON + pool gates; researcher-1)
+
+## S5 GATE-SYNC (2026-06-14, researcher-1)
+
+The S4 BLOCKED flag lived in state.md only: the research JSON read
+`status: "active"` / `phase: "ACT"` and `.lean/state/candidate-pool.json`
+read `"in-progress"`, so `claim-random` kept re-serving this RICH slug.
+Aligned both gates to BLOCKED (JSON `status`/`phase`/`currentState.phase`
+→ `blocked`/`BLOCKED`; pool → `"blocked"`, terminal). Docker-transient block —
+only Docker-gated work remains (meta.json already verified in-sync at S4).
+Un-block by reverting these gates when a build/verify route returns. No
+metadata/Lean change.
 
 ## S4 BLOCKED (2026-06-13, researcher-1)
 

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "euler-polyhedral-formula-oq-02-oq-01-wip-01",
   "title": "Complete smooth Gauss-Bonnet formalization beyond structure axioms",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -29,7 +29,7 @@
     "goal": "Turn the WIP completion task into a concrete de-axiomatization plan: start from `CompactRiemannianSurface.gauss_bonnet`, audit current Mathlib support for Riemannian surfaces and integration on manifolds, and either discharge a narrow assumption or document the precise blocker without claiming unsupported Lean progress. (S3 ACT 2026-06-10: Reduction D discharged → axiomCount 10 → 9. Next: Reductions B, C.)"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-06-10T09:00:00.000Z",
     "iteration": 3,
     "focus": "S3 ACT (researcher-1, 2026-06-10): Reduction D landed and docker-verified. Restructured VectorFieldOnSurface from a 5-field shape (surface, totalIndex, noZeros, poincare_hopf, nonvanishing_index) to a 4-field shape with an explicit finite zero set (surface, zeros : Finset ℕ, indexAt : ℕ → ℤ, poincare_hopf : (∑ i ∈ zeros, indexAt i) = surface.chi). totalIndex and noZeros are now defined functions (totalIndex := ∑ ..., noZeros := zeros = ∅); nonvanishing_index is now a theorem derived from Finset.sum_empty. Docker build (Proofs.EulerPolyhedralOQ02OQ01) succeeded with no new sorries/axioms and all 5 downstream theorems (hairy_ball, sphere_no_nonvanishing_field, positive_chi_has_zeros, negative_chi_has_zeros, nonvanishing_iff_chi_zero) intact. Net: parent axiomCount 10 → 9; lineCount 786 → 810; theoremCount 60 → 61; definitionCount 13 → 15.",
@@ -89,5 +89,5 @@
     "mathlib": []
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-06-10T09:00:00.000Z"
+  "lastUpdate": "2026-06-14T19:40:00Z"
 }


### PR DESCRIPTION
## Summary
Gate-sync for `euler-polyhedral-formula-oq-02-oq-01-wip-01`. **No Lean source touched — build-safe** (research-only slug).

## Problem
S4 (2026-06-13) flagged this slug **BLOCKED** ("only Docker-gated work remains; meta.json verified in-sync"), but the flag lived in `state.md` only. The research JSON read `status: "active"` / `phase: "ACT"` and `.lean/state/candidate-pool.json` read `"in-progress"`, so the RICH knowledge score kept re-serving it via depth-first `claim-random`.

## Changes
- **research JSON**: `status` `"active"`→`"blocked"`, `phase` / `currentState.phase` `"ACT"`→`"BLOCKED"`.
- **`.lean/state/candidate-pool.json`** (untracked local state): `"in-progress"`→`"blocked"` (terminal).
- **state.md**: added S5 GATE-SYNC note.

## Status
**Outcome**: state-sync / pool hygiene. Docker-transient block — only Docker-gated work remains. No new mathematics.
**Next Steps**: Un-block by reverting these gates when a build/verify route returns.

🤖 Generated by researcher-1