### PR TITLE
research(erdos-101-oq-01): realign drifted annotations to full file (6→11)

### DIFF
--- a/src/data/proofs/erdos-101-oq-01/annotations.json
+++ b/src/data/proofs/erdos-101-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-101-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 56
+      "endLine": 67
     },
     "type": "concept",
     "title": "OQ-01: the $o(n^2)$ open question",
@@ -26,12 +26,12 @@
     "id": "ann-asymptotic-vocab",
     "proofId": "erdos-101-oq-01",
     "range": {
-      "startLine": 57,
+      "startLine": 68,
       "endLine": 80
     },
     "type": "concept",
     "title": "Asymptotic vocabulary: `IsLittleOh_n_squared` and `BoundsAtRate`",
-    "content": "`IsLittleOh_n_squared (f : ℕ → ℕ)` is the standard ε–N formulation of $f(n) = o(n^2)$, with $f(n)$ cast to ℝ and compared against $\\varepsilon \\cdot n^2$. The explicit ε–N form is preferred over `Mathlib.Analysis.Asymptotics.IsLittleO` for first-iteration readability; the equivalence is left to S3.\n\n`BoundsAtRate (g : ℕ → ℝ)` packages the predicate \"`fourPointLineCount P ≤ g |P|` for every no-five-collinear `P`.\" It abstracts away the quantification over planar point sets so that known elementary rates (e.g., $n^2$, $n^2/12$) and the conjectured $o(n^2)$ rate can be stated uniformly.",
+    "content": "`IsLittleOh_n_squared (f : ℕ → ℕ)` is the standard ε–N formulation of $f(n) = o(n^2)$, with $f(n)$ cast to ℝ and compared against $\\varepsilon \\cdot n^2$. The explicit ε–N form is preferred over `Mathlib.Analysis.Asymptotics.IsLittleO` for first-iteration readability; the equivalence is established later in the file by `isLittleOh_n_squared_iff_isLittleO`.\n\n`BoundsAtRate (g : ℕ → ℝ)` packages the predicate \"`fourPointLineCount P ≤ g |P|` for every no-five-collinear `P`.\" It abstracts away the quantification over planar point sets so that known elementary rates (e.g., $n^2$, $n^2/12$) and the conjectured $o(n^2)$ rate can be stated uniformly.",
     "mathContext": "$\\text{IsLittleOh}_{n^2}(f) \\iff \\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall n \\geq N,\\ f(n) < \\varepsilon n^2$. The choice to use ℕ rather than ℝ for the count `f` reflects that `fourPointLineCount` is integer-valued, while the bound itself is taken in ℝ to allow non-integer rates.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -47,16 +47,15 @@
     "proofId": "erdos-101-oq-01",
     "range": {
       "startLine": 81,
-      "endLine": 119
+      "endLine": 115
     },
     "type": "concept",
     "title": "Two equivalent formal forms of OQ-01",
-    "content": "`erdos_101_oq_01_conjecture` is the primary ε–N form. `erdos_101_oq_01_rate_form` is the witness-function form: there exists a function $g : \\mathbb{N} \\to \\mathbb{N}$ which is $o(n^2)$ and bounds the four-point line count for every no-five-collinear `P`. The two forms are mutually convertible by the standard Cauchy-criterion bridge; we record the primary form as the OPEN theorem `erdos_101_oq_01` and use the rate form to express equivalent statements about specific witness rates.",
+    "content": "`erdos_101_oq_01_conjecture` is the primary ε–N form. `erdos_101_oq_01_rate_form` is the witness-function form: there exists a function $g : \\mathbb{N} \\to \\mathbb{N}$ which is $o(n^2)$ and bounds the four-point line count for every no-five-collinear `P`. The two forms are mutually convertible by the standard witness bridge (proved later as `erdos_101_oq_01_conjecture_iff_rate_form`); we record the primary form as the OPEN theorem `erdos_101_oq_01` and use the rate form to express equivalent statements about specific witness rates.",
     "mathContext": "**Primary form (Σ₂)**: $\\forall \\varepsilon > 0,\\ \\exists N,\\ \\forall P,\\ (\\text{NoFiveCollinear}\\ P \\land N \\leq |P|) \\Rightarrow \\text{fourPointLineCount}(P) < \\varepsilon |P|^2$. **Rate form**: $\\exists g : \\mathbb{N} \\to \\mathbb{N},\\ \\text{IsLittleOh}_{n^2}(g) \\land \\forall P, \\text{NoFiveCollinear}\\ P \\Rightarrow \\text{fourPointLineCount}(P) \\leq g(|P|)$.",
     "significance": "key",
     "relatedConcepts": [
       "Σ₂ quantifier complexity",
-      "Cauchy criterion",
       "witness-function representation"
     ],
     "prerequisites": [
@@ -67,12 +66,12 @@
     "id": "ann-small-cases",
     "proofId": "erdos-101-oq-01",
     "range": {
-      "startLine": 120,
-      "endLine": 175
+      "startLine": 116,
+      "endLine": 173
     },
     "type": "proof-step",
     "title": "Small-case lemmas the conjecture subsumes",
-    "content": "Three unconditional lemmas witness the regime in which OQ-01 is meaningful:\n\n1. `fourPointLineCount_zero_of_small`: for every `P` with $|P| < 4$, `fourPointLineCount P = 0`. Restatement of `fourPointLineCount_lt_four` from the parent file (no 4-element subset exists).\n2. `fourPointLineCount_o_n_squared_holds_below_four`: the OQ-01 ε–N statement holds vacuously for every $|P| \\leq 3$. Pure positivity (`0 < ε \\cdot n^2` whenever $n \\geq 1$).\n3. `fourPointLineCount_le_quadratic`: the real-valued $\\text{fourPointLineCount}(P) \\leq |P|^2$ trivial upper bound. Lifted from `improved_upper_bound`'s ℕ statement via `Nat.div_le_self` and `n(n-1) \\leq n^2$.\n\nTogether, these show that OQ-01's content is genuinely in the regime $|P| \\to \\infty$ with a sub-quadratic refinement of an already-known $O(n^2)$ bound.",
+    "content": "Three unconditional lemmas witness the regime in which OQ-01 is meaningful:\n\n1. `fourPointLineCount_zero_of_small`: for every `P` with $|P| < 4$, `fourPointLineCount P = 0`. Restatement of `fourPointLineCount_lt_four` from the parent file (no 4-element subset exists).\n2. `fourPointLineCount_o_n_squared_holds_below_four`: the OQ-01 ε–N statement holds vacuously for every $|P| \\leq 3$. Pure positivity (`0 < ε \\cdot n^2` whenever $n \\geq 1$).\n3. `fourPointLineCount_le_quadratic`: the real-valued $\\text{fourPointLineCount}(P) \\leq |P|^2$ trivial upper bound. Lifted from `improved_upper_bound`'s ℕ statement via `Nat.div_le_self` and $n(n-1) \\leq n^2$.\n\nTogether, these show that OQ-01's content is genuinely in the regime $|P| \\to \\infty$ with a sub-quadratic refinement of an already-known $O(n^2)$ bound.",
     "mathContext": "Trivially $|P| < 4 \\Rightarrow \\text{count} = 0$, and the elementary bound $\\text{count} \\leq |P|(|P|-1)/12 \\leq |P|^2/12 \\leq |P|^2$ holds. The gap between $|P|^2$ and $\\varepsilon |P|^2$ for *every* $\\varepsilon > 0$ is the open content.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -90,8 +89,8 @@
     "id": "ann-rate-bounds",
     "proofId": "erdos-101-oq-01",
     "range": {
-      "startLine": 176,
-      "endLine": 217
+      "startLine": 174,
+      "endLine": 208
     },
     "type": "proof-step",
     "title": "Known rates as `BoundsAtRate` instances",
@@ -110,15 +109,85 @@
     ]
   },
   {
+    "id": "ann-isbigo-bridge",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 209,
+      "endLine": 334
+    },
+    "type": "concept",
+    "title": "IsBigO / IsLittleO bridge to the Mathlib idiom",
+    "content": "Bridges the slug-local asymptotic vocabulary to Mathlib's `Asymptotics` predicates on `Filter.atTop`, so OQ-01 can be cited and consumed downstream in canonical form without abandoning the elementary ε–N statements. Three artifacts:\n\n1. `maxFourPointLines n := n*(n-1)/12` (noncomputable aggregator) with its certificate `maxFourPointLines_isBigO_n_squared : IsBigO atTop (↑maxFourPointLines) (·^2)`, plus the `NoFiveCollinear`-gated per-`P` corollary `fourPointLineCount_le_max`. The hypothesis is load-bearing: 9 collinear points give `C(9,4) = 126 > 6 = maxFourPointLines 9`.\n2. `isLittleOh_n_squared_iff_isLittleO`: the slug-local strict-`<` predicate equals `Asymptotics.IsLittleO atTop (↑g) (·^2)`, using the standard `c := ε/2` lift in the `←` direction.\n3. `erdos_101_oq_01_isLittleO_form` and `erdos_101_oq_01_rate_form_iff_isLittleO`: the Mathlib-idiom existential restatement of OQ-01 and its equivalence with `erdos_101_oq_01_rate_form`.",
+    "mathContext": "`IsBigO.of_norm_le` needs a single-norm hypothesis $\\|f\\,x\\| \\le g\\,x$ (RHS bare), discharged by `Real.norm_of_nonneg (by positivity)`. The bridge keeps both vocabularies available: elementary ε–N for readability, Mathlib `IsBigO`/`IsLittleO` for downstream consumption.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Asymptotics.IsBigO",
+      "Asymptotics.IsLittleO",
+      "Filter.atTop",
+      "load-bearing NoFiveCollinear hypothesis"
+    ],
+    "prerequisites": [
+      "Mathlib.Analysis.Asymptotics.Defs",
+      "Real.norm_of_nonneg",
+      "improved_upper_bound (parent)"
+    ]
+  },
+  {
+    "id": "ann-conjecture-iff-rate",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 335,
+      "endLine": 398
+    },
+    "type": "concept",
+    "title": "Size-indexed supremum `maxCountAtSize`: the witness for conjecture ↔ rate_form",
+    "content": "Introduces the genuine size-indexed extremal quantity `maxCountAtSize n := sSup {fourPointLineCount Q | |Q| = n, NoFiveCollinear Q}` — the precise quantity OQ-01 asks about — together with the machinery needed to prove `conjecture ↔ rate_form`:\n\n- `maxCountAtSize_bddAbove`: the underlying set is bounded above by `n(n-1)/12` via `improved_upper_bound`, so the `sSup` is a genuine natural number.\n- `le_maxCountAtSize`: every no-five-collinear set's count is `≤ maxCountAtSize |P|` (`le_csSup`).\n- `maxCountAtSize_lt_of_forall`: if every size-`n` set's count is below a positive real `X`, so is the supremum — the empty case (`sSup ∅ = 0`) is covered by positivity of `X`.\n\nThese are the `→`-direction witness used by `erdos_101_oq_01_conjecture_iff_rate_form` (proved in the next section): the conjecture forces every count below `ε·n²`, hence the supremum, supplying the `o(n²)` witness.",
+    "mathContext": "$\\text{maxCountAtSize}(n) = \\sup\\{\\,\\text{fourPointLineCount}(Q) : |Q| = n,\\ \\text{NoFiveCollinear}\\ Q\\,\\}$, well-defined in ℕ because `improved_upper_bound` bounds the set above by $n(n-1)/12$. The empty-set case uses `csSup_empty : sSup (∅ : Set ℕ) = 0`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conditionally complete lattice sSup",
+      "BddAbove",
+      "extremal supremum"
+    ],
+    "prerequisites": [
+      "le_csSup / Nat.sSup_mem",
+      "csSup_empty",
+      "improved_upper_bound (parent)"
+    ]
+  },
+  {
+    "id": "ann-surrogate-truesup",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 399,
+      "endLine": 496
+    },
+    "type": "proof-step",
+    "title": "Surrogate ↔ true-sup unification; the derived OPEN main theorem",
+    "content": "Unifies the elementary surrogate `maxFourPointLines = n(n-1)/12` with the genuine sup `maxCountAtSize` and assembles the equivalence chain:\n\n1. `maxCountAtSize_le_maxFourPointLines`: a uniform lift of `improved_upper_bound` — every size-`n` candidate is bounded by the same surrogate value, so their supremum is too (empty case via `sSup ∅ = 0`).\n2. `maxCountAtSize_isBigO_n_squared`: the true sup inherits the surrogate's `O(n²)` certificate through that pointwise bound, with no duplicated cast bookkeeping.\n3. `erdos_101_oq_01_conjecture_iff_rate_form`: the missing link; `→` takes the `maxCountAtSize` witness, `←` reads the `o(n²)` decay directly.\n4. `erdos_101_oq_01_isLittleO`: the Mathlib-idiom OPEN main theorem, now **derived** from `erdos_101_oq_01` via `conjecture ↔ rate_form ↔ isLittleO_form` rather than carried as an independent `sorry`.",
+    "mathContext": "Because $\\text{maxCountAtSize}(n) \\le \\text{maxFourPointLines}(n)$ pointwise and the surrogate is $O(n^2)$, the genuine extremal function is $O(n^2)$ too. Chaining the two equivalences collapses the file's open content to the single primary conjecture (plus the deferred Solymosi–Stojaković construction).",
+    "significance": "key",
+    "relatedConcepts": [
+      "pointwise bound transfer",
+      "IsBigO.trans",
+      "equivalence-chain derivation"
+    ],
+    "prerequisites": [
+      "maxCountAtSize_bddAbove",
+      "maxFourPointLines_isBigO_n_squared",
+      "csSup_le / csSup_empty"
+    ]
+  },
+  {
     "id": "ann-obstructions",
     "proofId": "erdos-101-oq-01",
     "range": {
-      "startLine": 218,
-      "endLine": 253
+      "startLine": 497,
+      "endLine": 557
     },
     "type": "concept",
-    "title": "Obstructions and Solymosi–Stojaković lower bound",
-    "content": "The OPEN content arises from two obstructions:\n\n1. **Szemerédi–Trotter is too coarse**. The incidence bound $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$, applied to lines of multiplicity-4, gives at most $O(|P|^2)$ four-point lines — same regime as the elementary $n(n-1)/12$ bound. A multiplicity-aware refinement would be needed.\n2. **Pure double counting is tight**. The improved upper bound $n(n-1)/12$ is the best one can extract from packing 6 disjoint pairs per 4-collinear subset; no further elementary counting reduces it.\n\nOn the lower-bound side, **Solymosi–Stojaković (2013)** constructed $n$-point sets with no five collinear and $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ four-point lines — disproving Erdős's earlier $\\Theta(n^{3/2})$ conjecture. The construction uses number-theoretic sum–product ideas. This file does not formalise the construction; S2 will record the existence statement.",
+    "title": "Obstructions and the Solymosi–Stojaković lower bound",
+    "content": "The OPEN content arises from two obstructions:\n\n1. **Szemerédi–Trotter is too coarse**. The incidence bound $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$, applied to lines of multiplicity-4, gives at most $O(|P|^2)$ four-point lines — same regime as the elementary $n(n-1)/12$ bound. A multiplicity-aware refinement would be needed.\n2. **Pure double counting is tight**. The improved upper bound $n(n-1)/12$ is the best one can extract from packing 6 disjoint pairs per 4-collinear subset; no further elementary counting reduces it.\n\nOn the lower-bound side, **Solymosi–Stojaković (2013)** constructed $n$-point sets with no five collinear and $\\Omega(n^{2-O(1/\\sqrt{\\log n})})$ four-point lines — disproving Erdős's earlier $\\Theta(n^{3/2})$ conjecture. The construction uses number-theoretic sum–product ideas. This prose block frames the existence statement and refutation that the following theorems record.",
     "mathContext": "Upper bound: $O(n^2)$ (elementary). Lower bound: $\\Omega(n^{2 - O(1/\\sqrt{\\log n})}) = n^{2 - o(1)}$ (Solymosi–Stojaković). Gap: the entire polylog correction.",
     "significance": "key",
     "relatedConcepts": [
@@ -130,6 +199,51 @@
     "prerequisites": [
       "Szemerédi–Trotter incidence theorem (statement)",
       "Solymosi–Stojaković (2013) paper"
+    ]
+  },
+  {
+    "id": "ann-solymosi-stojakovic",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 558,
+      "endLine": 674
+    },
+    "type": "proof-step",
+    "title": "Solymosi–Stojaković lower bound and refutation of $\\Theta(n^{3/2})$",
+    "content": "Two theorems:\n\n1. `solymosi_stojakovic_lower_bound`: for every $C > 0$, all sufficiently large $n$ admit a no-five-collinear set of size $n$ with at least $n^{2 - C/\\sqrt{\\log n}}$ four-point lines. Recorded as `theorem ... := by sorry` (the algebraic-geometry construction over finite fields is deferred), keeping the file axiom-free — a deferred *proof obligation*, not a permanent `axiom`.\n2. `erdos_three_halves_conjecture_refuted`: there is no global $O(n^{3/2})$ upper bound. **Fully discharged** (no sorry) from the lower bound: specialise $C = 1/2$; for $m \\geq 3$, $\\exp 1 < 3 \\le m$ gives $\\log m > 1$, hence $\\sqrt{\\log m} > 1$, hence $2 - \\tfrac{1/2}{\\sqrt{\\log m}} > 3/2$; then `Real.rpow_lt_rpow_of_exponent_lt` yields $m^{2-1/(2\\sqrt{\\log m})} > m^{3/2}$, contradicting the hypothesised bound.",
+    "mathContext": "$\\Omega(n^{2-O(1/\\sqrt{\\log n})}) > \\Omega(n^{3/2})$ for large $n$. The lower bound is recorded as a deferred `sorry`; the refutation corollary is proved unconditionally from it by elementary real-analysis arithmetic (`Real.exp_one_lt_d9`, `Real.rpow_lt_rpow_of_exponent_lt`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Solymosi–Stojaković 2013 lower bound",
+      "Real.rpow strict monotonicity",
+      "deferred proof obligation vs axiom"
+    ],
+    "prerequisites": [
+      "Real.exp_one_lt_d9",
+      "Real.rpow_lt_rpow_of_exponent_lt",
+      "Real.log / Real.sqrt monotonicity"
+    ]
+  },
+  {
+    "id": "ann-s4-constructive",
+    "proofId": "erdos-101-oq-01",
+    "range": {
+      "startLine": 675,
+      "endLine": 762
+    },
+    "type": "proof-step",
+    "title": "Constructive refutation of the $\\Theta(n^{3/2})$ conjecture",
+    "content": "`erdos_three_halves_conjecture_refuted_constructive` is the positive form of the S3 negated-existence refutation: for every threshold `N` there exists a no-five-collinear planar point set `P` with `|P| ≥ N` and *strictly more* than $|P|^{3/2}$ four-point lines. The proof reuses the same chain verbatim through `Real.rpow_lt_rpow_of_exponent_lt` (specialise `solymosi_stojakovic_lower_bound` at $C = 1/2$, then $m \\geq 3 \\Rightarrow \\log m > 1 \\Rightarrow \\sqrt{\\log m} > 1 \\Rightarrow 2 - \\tfrac{1/2}{\\sqrt{\\log m}} > 3/2$); only the final assembly changes — it delivers the witness directly instead of deriving a contradiction. Sorry-free and axiom-free; depends only on the deferred `solymosi_stojakovic_lower_bound`.",
+    "mathContext": "The constructive form is more useful downstream than the negated-existence S3 refutation: it produces explicit witnesses rather than contradicting a hypothetical bound. Both forms share the single deferred proof obligation; the file's sorry count stays 2 and axiom count stays 0.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "constructive vs negated-existence form",
+      "explicit witness extraction",
+      "Real.rpow_lt_rpow_of_exponent_lt"
+    ],
+    "prerequisites": [
+      "solymosi_stojakovic_lower_bound",
+      "Real.rpow strict monotonicity"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

`annotations.json` for erdos-101-oq-01 had drifted: it was written for a ~253-line version of `Erdos101OQ01.lean`, but the file is now **762 lines**. The S11–S14 additions (IsBigO/IsLittleO bridge, conjecture↔rate_form witness `maxCountAtSize`, surrogate↔true-sup unification — roughly 280 inserted lines) shifted all later content down without updating the annotations.

Concretely:
- `ann-obstructions` (range 218-253) sat on the **S11 IsBigO bridge**, not the obstructions prose. The real obstructions/Solymosi discussion is at lines 497-557.
- Lines **254-762** (over half the file — including the actual `solymosi_stojakovic_lower_bound` theorem and both `erdos_three_halves_conjecture_refuted` / `_constructive` refutations) had **no annotations at all**.

## Changes

- Realigned `ann-obstructions` → 497-557 (its true content location).
- Added 5 annotations covering the previously un-annotated regions:
  - `ann-isbigo-bridge` (209-334)
  - `ann-conjecture-iff-rate` (335-398)
  - `ann-surrogate-truesup` (399-496)
  - `ann-solymosi-stojakovic` (558-674)
  - `ann-s4-constructive` (675-762)
- Tidied the first 5 ranges to meta-section boundaries.

Result: **11 annotations, contiguous 1→762, one-to-one with the 11 `meta.json` sections.**

`annotations.json` only — no Lean, `meta.json`, or count change. Path-disjoint from in-flight #23389 (which touches `.lean`/`state.md`/`meta.json`), so no conflict.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` validates
- [x] Annotation ranges contiguous 1→762, no gaps/overlaps
- [x] Ranges verified against actual decl line numbers (`grep -nE '^(theorem|lemma|def)'`)
- [x] Docker DOWN — build-free metadata change, no Lean compilation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)