### PR TITLE
research(sum-of-kth-powers-oq-03): verify M1 spec exactly in ℕ semantics

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/knowledge.md
+++ b/research/problems/sum-of-kth-powers-oq-03/knowledge.md
@@ -108,3 +108,24 @@ blackout (Docker down + Aristotle "Resource not found"). A Docker-up session can
 ## Dead Ends
 
 - (none yet — no proof attempt could run during the backend blackout)
+
+---
+
+## Session 2026-06-14 (S2, researcher-4) — build-free ℕ-spec verification
+
+Still backend blackout (Docker `docker info` timeout; Aristotle `prove` → "Resource not found").
+Re-verified the **entire formalizable core exactly as Lean would evaluate it in ℕ** (emulating
+truncated subtraction `i-1` and `T i = i*(i+1)/2`), to catch off-by-one / ℕ-truncation hazards in
+the spec *before* it is typed:
+
+- **L1** `∑_{j<m}(2j+1)=m²` holds for all `m ≤ 50`.
+- **L2** `∑_{j∈Ico(T(i-1),T i)}(2j+1)=i³` holds for all `1 ≤ i ≤ 40`.
+- **i=0 edge (the subtle one):** in `Main` the sum runs over `range (n+1)`, which *includes* `i=0`.
+  With ℕ-truncated `i-1`, the `i=0` block is `Ico (T 0) (T 0) = Ico 0 0 = ∅`, summing to `0 = 0³`.
+  So including `i=0` is harmless and L2 need only be proved for `i ≥ 1` — **confirmed**, no special
+  casing of `i=0` is required in `Main`.
+- **L3 tiling + Main** `∑_{i<n+1} i³ = ∑_{i<n+1}(block i) = ∑_{j<T n}(2j+1) = T n² = (∑_{i<n+1} i)²`
+  holds as a 5-way exact equality for all `n ≤ 40`; `T i − T(i-1) = i` confirmed (ranges tile `[0,T n)`).
+
+Conclusion: the spec is ℕ-sound as written; M1 carries no hidden off-by-one. No spec changes needed
+— this only raises confidence for the Docker-up ACT. (Verified with `python3` emulating ℕ semantics.)

--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -4,11 +4,14 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T20:00:16-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
 OQ resolved on paper (odd-number partition of cubes). Formalizable core pinned to existing
-Mathlib lemmas with a milestone split. Ready to ACT once the verification backends return.
+Mathlib lemmas with a milestone split. M1 spec **re-verified exactly in ℕ semantics** (S2,
+researcher-4): L1/L2/L3/Main all hold for n,i ≤ 40, and the `i=0` block under ℕ-truncated `i-1`
+is empty (=0³), so `Main` over `range (n+1)` needs no `i=0` special case — no hidden off-by-one.
+Ready to ACT once the verification backends return.
 
 ## Active Approach
 Telescoping odd-partition: i³ = T_i² − T_{i−1}², then `Finset.sum_Ico_consecutive` tiles the


### PR DESCRIPTION
## Summary

Build-free ORIENT iteration on the odd-partition (Nicomachus) proof of ∑i³=(∑i)². Both backends
down (Docker `docker info` timeout; Aristotle `prove` → "Resource not found"). The proof spec was
already pinned in #24076; this iteration **re-verifies the entire formalizable core exactly as
Lean would evaluate it in ℕ** (truncated subtraction for `i-1`, `T i = i*(i+1)/2`), catching
off-by-one / ℕ-truncation hazards before the proof is typed.

- **L1** `∑_{j<m}(2j+1)=m²`, **L2** `∑_{j∈Ico(T(i-1),T i)}(2j+1)=i³` (i≥1), **L3** tiling, and
  **Main** all hold as exact ℕ equalities for `n,i ≤ 40`.
- **Subtle `i=0` edge confirmed:** `Main` sums over `range (n+1)` which includes `i=0`; under
  ℕ-truncated `i-1` the `i=0` block is `Ico (T 0) (T 0)=∅` summing to `0=0³`, so including `i=0`
  is harmless and `Main` needs **no** `i=0` special case. This is exactly the kind of ℕ edge that
  breaks Lean proofs, and it's clean.
- `T i − T(i-1)=i` confirmed (blocks tile `[0, T n)`).

Conclusion: the M1 spec is ℕ-sound as written; no hidden off-by-one. Raises ACT confidence; no
spec change required.

## Files
- `research/problems/sum-of-kth-powers-oq-03/{knowledge.md, state.md}` — Session 2 ℕ-verification entry; phase stays ORIENT (iter 2).

Docs only; **no `.lean` touched**. Remains Docker-gated for the M1 build.

## Test plan
- [x] L1/L2/L3/Main exact ℕ equalities, n,i ≤ 40 (python3 emulating ℕ semantics)
- [x] i=0 edge: empty block = 0 = 0³ under ℕ-truncated i-1
- [x] block ranges tile [0, T n)
- [ ] Milestone 1 Lean proof (deferred to ACT — Docker-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)