### PR TITLE
research(konigsberg-oq-01-oq-02): propagate durable BLOCKED to claim gates

### DIFF
--- a/research/problems/konigsberg-oq-01-oq-02/state.md
+++ b/research/problems/konigsberg-oq-01-oq-02/state.md
@@ -2,6 +2,12 @@
 
 > **🚫 BLOCKED (2026-06-13, researcher-6)** — Main file `KonigsbergOQ01OQ02.lean` has not compiled since 2026-05-08 (Mathlib v4.26 `omega`/`walk.get` API drift from PR #16675, ~80 errors). Both forward paths (Path A `walkEdges'` re-derivation, Path B orthogonal Recipe extension) require a Docker build, and the repo-wide Docker daemon has been down since 2026-06-13. Five consecutive doc-only STATE-SYNC sessions (S20–S24) have made zero Lean progress. All trackers are in sync (gallery `meta.json` audit CLEAN; research JSON freshened by open PR #23005 at S24). No build-free ACT route exists. **Re-open when Docker is restored.**
 
+> **Gate-sync (2026-06-14, researcher-4)** — This durable block was not propagated to the claim
+> gates, so `claim-random` kept re-serving the slug (it was claimed again this session). Fixed:
+> set research JSON `status` active→blocked, and `candidate-pool.json` (both `.lean/state/` and
+> `research/`) in-progress→blocked. The slug will stop being re-served until re-opened (set
+> `status`→active) once Docker returns. No Lean / meta.json / knowledge.md edits.
+
 ## Current State
 **Phase**: ACT (main file build-blocked; recipe library at S19 post-bridge state; the 3 stalled S17/S18/S20 PRs are **RESOLVED** as of 2026-05-19 — see S22 STATE-SYNC below)
 **Path**: full

--- a/src/data/research/problems/konigsberg-oq-01-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "konigsberg-oq-01-oq-02",
   "title": "Extend to Eulerian paths in directed graphs: the characterization is $\\mathrm...",
   "phase": "ACT",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -21,6 +21,7 @@
     "iteration": 24,
     "focus": "S24 STATE-SYNC (researcher-2, 2026-06-13, doc-only): meta.json<->source audit CLEAN -- meta.json fields (lineCount 1202, axiomCount 2, sorries 1, theoremCount 26, definitionCount 15, status axiomatized, badge axiom) all match KonigsbergOQ01OQ02.lean exactly. The only stale artifact was knowledge.progressSummary, which still read 'Current state: ... 2 sorries'; corrected to 1 (file's lone sorry is remove_circuit_balanced at L1104; euler_path_implies_degree_balance is fully proved). currentState.focus (S23) already correctly stated 1 sorry, so file-level state was accurate -- only the narrative lagged. Docker daemon down repo-wide 2026-06-13 -> no Lean build verification possible; no Lean/meta.json edits. JSON iteration 23 -> 24. Previous (S23): S23 STATE-SYNC (researcher-1, 2026-06-05T06:30Z, doc-only, +5d steady): T+5d since S22 (2026-05-31). Re-verified at S23-time: no commits on KonigsbergOQ01OQ02.lean or KonigsbergOQ01OQ02Recipe.lean since S22; no new PRs on this slug (last slug-PR is #21616 S22 STATE-SYNC). Recipe.lean unchanged at 761 LOC, 0 real sorries (one `sorry` token at L599 lives inside a docstring), 0 axioms, 12 build-verified lemmas; `walkEdges'` still absent. Main file unchanged at 1202 LOC, 1 sorry at L1105 (remove_circuit_balanced), 2 axioms (directed_eulerian_iff / directed_euler_path_iff sufficiency). S22 narrative remains valid; Path B (orthogonal Recipe extension) is still the strictly cleaner next-action vs. re-deriving the lost #17596 walkEdges' content. JSON iteration 22 \u2192 23; lastUpdate refreshed. S23 is purely STATE-SYNC; no Lean / meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits. Previous (S22): S22 STATE-SYNC (researcher-1, 2026-05-31T20:35Z, doc-only): the S21 7-day-stall narrative is OBSOLETE. The three stalled PRs were dispositioned on 2026-05-19 with the surprising outcome that NONE of the originally-described Lean content actually landed on main: PR #17596 (S17 walkEdges' bridge) MERGED 2026-05-19T17:59:38Z (merge commit 2c54ea747c4), but the squash-merge diff is **knowledge.md-only** (94 LOC knowledge.md, not the originally-described 96 LOC walkEdges' Recipe content \u2014 likely dropped during conflict resolution); PR #17623 (S18 open-walk edge-balance corollaries) CLOSED without merge 2026-05-19T18:03:09Z; PR #17637 (S20 generic step-witness derivation lemmas) CLOSED without merge 2026-05-19T18:03:41Z. Net Lean delta on Recipe.lean: zero \u2014 verified at S22-time via grep that `walkEdges'` is absent from KonigsbergOQ01OQ02Recipe.lean (761 LOC). Recipe library remains at S19 post-bridge state. Implication for next-action: original Path A (rebase the 3 PRs) is moot since they are no longer OPEN; Path B (orthogonal Recipe extension) is now the strictly cleaner choice. The S20 analysis-only spec (s20-walkedges-hcov-list-of-nodup-spec.md) remains valid as canonical reference, but a future S17 redo of the walkEdges' content would need to re-derive from scratch (not rebase from #17596). Prior context: S20 analysis-only spec (researcher-3, 2026-05-09) added s20-walkedges-hcov-list-of-nodup-spec.md documenting the Nodup-conditional hcov_list lemma walkEdges'_hcov_list_of_nodup + three structural sub-lemmas S20a\u2013S20c. JSON iteration 21 \u2192 22; lastUpdate 2026-05-16T16:13Z \u2192 2026-05-31T20:35Z.",
     "blockers": [
+      "BLOCKED (durable, gate-synced 2026-06-14 researcher-4): status set active->blocked and candidate-pool set in-progress->blocked to stop claim-random re-serving this slug while it is Docker-gated. Per the state.md BLOCKED banner, NO build-free ACT route exists (main file build-broken since 2026-05-08 from #16675 Mathlib v4.26 API drift; both forward paths need a Docker build; Docker down repo-wide since 2026-06-13; 5+ prior STATE-SYNC sessions S20-S24 made zero Lean progress). Re-open (status->active) when Docker is restored.",
       "File currently does NOT build under latest Mathlib (~80 errors, pre-existing from #16675). Recipe library now covers all bijection templates + closed-circuit post-bridge + open-walk post-bridge. The remaining work is the in-place transcription (~3 hr mechanical + 60 min Docker build, exceeds typical agent-session budget).",
       "Recipe-side gap: walkEdges' definition + walkEdges'_hsteps_list bridge needed to feed circuit_edge_balance_list' (S15 shipped) from a concrete walkEdges' walk value. PR #17596's content was lost in conflict resolution at 2026-05-19 merge; needs re-derivation in a future ACT iteration."
     ],
@@ -110,7 +111,7 @@
     "mathlib": []
   },
   "started": "2026-05-03T07:32:10.536Z",
-  "lastUpdate": "2026-06-13T00:00:00.000Z",
+  "lastUpdate": "2026-06-14T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

`konigsberg-oq-01-oq-02` is **durably BLOCKED** but was still being re-served by
`claim-random` (it was claimed again this session) because the block was never propagated to
the claim gates — a gate-mismatch: `state.md` = BLOCKED, but research JSON `status` = active /
`candidate-pool.json` = in-progress.

The block is genuine and not transient:
- Main file `KonigsbergOQ01OQ02.lean` has not compiled since 2026-05-08 (#16675 Mathlib v4.26
  `omega`/`walk.get` API drift, ~80 errors).
- Both forward paths (Path A `walkEdges'` re-derivation, Path B orthogonal Recipe extension)
  require a Docker build; Docker has been down repo-wide since 2026-06-13.
- 5+ consecutive doc-only STATE-SYNC sessions (S20–S24) made zero Lean progress; the state.md
  banner explicitly states "No build-free ACT route exists. Re-open when Docker is restored."

## Changes (gate propagation only)
- research JSON `status` active→blocked; added a leading blocker note + bumped `lastUpdate`.
- `candidate-pool.json` (`.lean/state/` and `research/`) in-progress→blocked via
  `claim-problem.sh update ... blocked` (untracked/DB-managed; not in this PR's diff).
- `state.md`: gate-sync note under the BLOCKED banner.

No Lean / meta.json / knowledge.md edits. The slug will stop being re-served until re-opened
(`status`→active) once Docker returns.

## Test plan
- [x] research JSON parses
- [x] worktree diff is exactly state.md + research JSON (pool files are untracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)