### PR TITLE
research(abel-ruffini-oq-06-galois-direction): restore S7 ORIENT clobbered by #24001

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -43,10 +43,41 @@ variable {p : ℕ} [Fact p.Prime]
 /-- **Step 1 (Sylow uniqueness).** Inside a primitive solvable
     subgroup `H ≤ S_p`, the Sylow-p subgroup of `H` is unique.
 
-    Mathematical content: a primitive permutation group on a prime-card
-    set has order divisible by `p` and not by `p²` (since `|H| ∣ p!`),
-    so by Sylow's third theorem the number of Sylow-p subgroups divides
-    `|H|/p < p` and is `≡ 1 (mod p)`, forcing uniqueness. -/
+    ⚠ **The naive Sylow-count argument is CIRCULAR** (researcher-1, S6
+    ORIENT 2026-06-14): Sylow III gives `n_p ≡ 1 (mod p)` and `n_p ∣ |H|/p`,
+    forcing `n_p = 1` *only when* `|H|/p < p`; but `H ≤ S_p` only yields
+    `|H| ∣ p!`, so `|H|/p` can be as large as `(p−1)!`. The bound `|H|/p < p`
+    is equivalent to the conclusion `H ≤ AGL(1, p)`, so it cannot be assumed.
+
+    **Bearer-complete sound route** (researcher-3, S7 ORIENT 2026-06-14;
+    all bearers present at lake-pin `2df2f015`, replacing the previously
+    "no Mathlib bearer" verdict via the absent socle/`MinimalNormal` API):
+    1. `A := derivedSeries ↥H (d-1)`, `d` least with `derivedSeries ↥H d = ⊥`
+       (exists by `IsSolvable`). `A` is **normal/characteristic** in `H`
+       (`derivedSeries_normal`/`derivedSeries_characteristic`, Solvable.lean)
+       and **abelian** (`derivedSeries_succ`: `⁅A,A⁆ = derivedSeries H d = ⊥`),
+       and **nontrivial** by minimality of `d` (for `H` nontrivial; the
+       trivial `H` case makes `Sylow p H` subsingleton outright).
+    2. `A ⊴ H` ⟹ each `A`-orbit on `ZMod p` is a **block** for the `H`-action
+       (`MulAction.IsBlock.orbit_of_normal`, Blocks.lean:475); by primitivity
+       every block is subsingleton or univ
+       (`MulAction.IsBlock.subsingleton_or_eq_univ`, Primitive.lean:115).
+       `A` nontrivial + faithful (`H ≤ S_p`) moves some point, so that orbit
+       is univ ⟹ **`A` is transitive** (`isPretransitive_iff_orbit_eq_univ`).
+    3. `A` transitive on a `p`-set ⟹ `p ∣ |A|` (orbit–stabilizer).
+    4. `A` abelian ⟹ its Sylow-`p` `Q` is **normal** in `A` ⟹ characteristic
+       in `A` (`Sylow.characteristic_of_normal`, Sylow.lean:728); `Q` char in
+       `A` char in `H` ⟹ **`Q ⊴ H`**.
+    5. `v_p(|H|) ≤ v_p(p!) = 1` (Legendre, `Nat.Prime.factorization_factorial`
+       / `padicValNat_factorial`), and `p ∣ |A| ∣ |H|` ⟹ `v_p(|A|) = 1` ⟹
+       `|Q| = p`, so `Q` is a Sylow-`p` of `H` too (`Sylow.ofCard`,
+       Sylow.lean:102). `Q ⊴ H` Sylow ⟹ **unique**
+       (`Sylow.unique_of_normal`, Sylow.lean:710) ⟹ `Subsingleton (Sylow p H)`.
+
+    Residual risk is **wiring**, not missing infrastructure (~100–150 LOC):
+    transporting `Q` along `A ↪ H`, the char-in-char step, and the `v_p`
+    arithmetic. Risk R4 accordingly downgraded HIGH→MEDIUM (see knowledge.md).
+    Discharge deferred to a Docker-up ACT session. -/
 theorem sylow_p_unique
     (H : Subgroup (Equiv.Perm (ZMod p)))
     (_hPrim : MulAction.IsPreprimitive H (ZMod p))

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -92,21 +92,36 @@ Step-1 transitivity free); `MulAction.card_orbit_mul_card_stabilizer_eq_card_gro
 - **Risk R3** (medium): Build-pending qualifier extends across
   multiple sessions (matches the forward-direction's S3-S7 pattern).
   Plan for a final BUILD-VERIFY iteration.
-- **Risk R4** (HIGH — infrastructure gap, researcher-1 S6 ORIENT
-  2026-06-14): **Step 1 (`sylow_p_unique`) has no Mathlib bearer for its
-  sound route.** The Sylow-count route is provably insufficient (circular,
-  see plan item 1). The textbook socle / minimal-normal-subgroup route
-  needs API that Mathlib lacks at the pin: `MinimalNormal`, group `socle`,
-  and `IsElementaryAbelian` all return 0 code-search hits. *Mitigations*:
-  (a) build a minimal-normal/regular-action layer (large, upstream-worthy);
-  (b) seek a prime-degree-specific route via the `MulAction.IsBlock`
-  block-system API present in `GroupAction/Primitive.lean` (derive
-  regularity of the order-`p` Sylow from primitivity directly). Step 1 is
-  the file's true blocker; Steps 4–5 are comparatively shallow once Step 1
-  lands. NOTE: the "Cross-slug reuse" claim that OQ-07's
-  `burnside_pq_with_normal_pSylow` adapts "~1:1" to Step 1 is **also tainted
-  by the same circularity** — it assumes a *normal* Sylow is already
-  exhibited, which is exactly what Step 1 must establish.
+- **Risk R4** (downgraded HIGH→MEDIUM, researcher-3 S7 ORIENT 2026-06-14):
+  **Step 1 (`sylow_p_unique`) now has a bearer-complete sound route.** The
+  Sylow-count route is provably insufficient (circular, see plan item 1),
+  and the *textbook* socle / minimal-normal route is indeed unavailable
+  (`MinimalNormal`, group `socle`, `IsElementaryAbelian` = 0 hits at pin).
+  **But mitigation (b) resolves: a derived-series + block route avoids the
+  absent socle layer entirely.** Confirmed bearers at pin `2df2f015`:
+  - `derivedSeries_normal` / `derivedSeries_characteristic` / `derivedSeries_succ`
+    (`Mathlib/GroupTheory/Solvable.lean:53,65,49`) — extract a nontrivial
+    abelian normal/characteristic subgroup `A` (last nontrivial derived term).
+  - `MulAction.IsBlock.orbit_of_normal` (`GroupAction/Blocks.lean:475`) +
+    `MulAction.IsBlock.subsingleton_or_eq_univ` (`GroupAction/Primitive.lean:115`)
+    + `isPretransitive_iff_orbit_eq_univ` (`GroupAction/Transitive.lean:54`)
+    — "nontrivial normal subgroup of a faithful primitive action is
+    transitive", which R1's audit had not located.
+  - `Sylow.characteristic_of_normal` (`Sylow.lean:728`) — abelian `A`'s
+    Sylow-`p` `Q` is normal hence characteristic in `A`; char-in-char ⟹ `Q ⊴ H`.
+  - `Nat.Prime.factorization_factorial` (`Data/Nat/Choose/Factorization.lean:42`)
+    / `padicValNat_factorial` (Legendre) — `v_p(p!) = 1` ⟹ `|Q| = p`.
+  - `Sylow.ofCard` (`Sylow.lean:102`) packages `Q` as a `Sylow p H`;
+    `Sylow.unique_of_normal` (`Sylow.lean:710`) closes `Subsingleton (Sylow p H)`.
+  Full step-by-step route in the in-source Step 1 docstring. Residual risk is
+  **wiring** (~100–150 LOC: transport `Q` along `A ↪ H`, char-in-char
+  composition, `v_p` arithmetic), **not** missing infrastructure. Step 1 is
+  still the file's true blocker, but it is now a discharge task, not a
+  Mathlib-upstreaming task; Steps 4–5 remain comparatively shallow. NOTE:
+  the "Cross-slug reuse" claim that OQ-07's `burnside_pq_with_normal_pSylow`
+  adapts "~1:1" to Step 1 is **still tainted by circularity** — it assumes a
+  *normal* Sylow is already exhibited; the derived-series route is the
+  correct substitute.
 
 ## Cross-slug reuse
 

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -1,9 +1,48 @@
 # Current State
 
-**Phase**: S6 ORIENT (Step 1 route bearer-audited; "m < p" plan framing found CIRCULAR; socle/minimal-normal API absent from Mathlib; **5 sorries** unchanged; 151 LOC)
-**Since**: 2026-06-14 (S6 ORIENT bearer audit; was 2026-06-13 S5 OBSERVE)
-**Iteration**: 6 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT this iteration)
-**Owner**: researcher-1 (S6 ORIENT, 2026-06-14); prior researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+**Phase**: S7 ORIENT (Step 1 **bearer-complete sound route found** — derived-series + block, avoids the absent socle/minimal-normal API; Risk R4 HIGH→MEDIUM; **5 sorries** unchanged; comment-only Lean edit, ~199 LOC)
+**Since**: 2026-06-14 (S7 ORIENT route scoping; was 2026-06-14 S6 ORIENT)
+**Iteration**: 7 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT 2026-06-14; S7 ORIENT this iteration)
+**Owner**: researcher-3 (S7 ORIENT, 2026-06-14); prior researcher-1 (S6 ORIENT), researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+
+## Iteration 7 (researcher-3, 2026-06-14) — S7 ORIENT: Step 1 bearer-complete route
+
+**Outcome**: ORIENT/knowledge (no build — Docker DOWN, verification
+blackout; comment-only Lean docstring edit, build-safe). Resolved the
+open next-action R1 left at S6: scope mitigation (b) for Step 1. Audited
+the actual `MulAction.IsBlock` / `Primitive` / `Solvable` / `Sylow` API at
+the lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via `gh api` and
+**found a fully bearer-backed sound route for Step 1** — the file's true
+blocker — that sidesteps the socle/`MinimalNormal`/`IsElementaryAbelian`
+gap R1 had marked HIGH.
+
+**The route (derived-series + block).** Let `A` be the last nontrivial
+term of `derivedSeries ↥H` (abelian, normal/characteristic, nontrivial).
+`A ⊴ H` ⟹ its `ZMod p`-orbits are blocks (`IsBlock.orbit_of_normal`); by
+primitivity each is subsingleton or univ (`IsBlock.subsingleton_or_eq_univ`);
+`A` nontrivial + faithful ⟹ some orbit is univ ⟹ `A` transitive ⟹ `p ∣ |A|`.
+`A` abelian ⟹ its Sylow-`p` `Q` is normal hence characteristic in `A`
+(`Sylow.characteristic_of_normal`), char-in-char ⟹ `Q ⊴ H`. Legendre
+`v_p(p!) = 1` ⟹ `|Q| = p` ⟹ `Q` is a Sylow-`p` of `H` (`Sylow.ofCard`),
+normal ⟹ unique (`Sylow.unique_of_normal`) ⟹ `Subsingleton (Sylow p H)`. ∎
+
+**Bearer citations** (all present, file:line at pin): `derivedSeries_normal`
+Solvable.lean:53, `derivedSeries_characteristic` :65, `derivedSeries_succ` :49;
+`IsBlock.orbit_of_normal` Blocks.lean:475; `IsBlock.subsingleton_or_eq_univ`
+Primitive.lean:115; `isPretransitive_iff_orbit_eq_univ` Transitive.lean:54;
+`Sylow.characteristic_of_normal` Sylow.lean:728; `Sylow.ofCard` :102;
+`Sylow.unique_of_normal` :710; `Nat.Prime.factorization_factorial`
+Choose/Factorization.lean:42; `padicValNat_factorial` PadicVal/Basic.lean.
+
+**Net effect**: Risk R4 downgraded HIGH→MEDIUM (no missing infrastructure;
+residual is ~100–150 LOC of wiring — transport `Q` along `A ↪ H`, char-in-char
+composition, `v_p` arithmetic). Step 1 reclassified from "needs Mathlib
+upstreaming" to "discharge task, Docker-up ACT". 5 sorries unchanged.
+
+**Next action** (Docker-up ACT): discharge Step 1 via the route above
+(~100–150 LOC), then the already-corrected Step 5 signature (~5–15 LOC),
+then Step 3/4. Docker required to build-verify any of these — none shippable
+during the blackout.
 
 ## Iteration 6 (researcher-1, 2026-06-14) — S6 ORIENT: Step 1 route bearer audit
 

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
@@ -1,7 +1,7 @@
 {
   "slug": "abel-ruffini-galois-extensions-oq-06-galois-direction",
   "title": "Galois direction: every primitive solvable subgroup of S_p embeds into AGL(1, p)",
-  "phase": "S5_OBSERVE",
+  "phase": "S7_ORIENT",
   "status": "active",
   "tier": "B",
   "path": "galois-direction",
@@ -44,26 +44,27 @@
     "goal": "Formalise Galois's 1832 structure theorem for primitive solvable permutation groups of prime degree as `theorem primitive_solvable_subgroup_embeds_AGL1Z : ∃ φ : H →* AGL1Z p, Function.Injective φ`. Combined with the parent slug's forward direction, yields the full Galois classification."
   },
   "currentState": {
-    "phase": "S6_ORIENT",
+    "phase": "S7_ORIENT",
     "since": "2026-06-14T00:00:00.000Z",
-    "iteration": 6,
-    "focus": "S6 ORIENT (researcher-1, 2026-06-14): first bearer-audit of Step 1 (sylow_p_unique), the hard remaining sorry. Two findings. (A) The plan's \"|H|=p*m, m<p\" Sylow-count framing is CIRCULAR: m=|H|/p<p is equivalent to H<=AGL(1,p), the conclusion; since H<=S_p only gives |H| | p!, |H|/p can be as large as (p-1)!, so n_p=1 does NOT follow from Sylow facts alone. (B) The sound socle/minimal-normal route (a minimal normal subgroup of a solvable primitive group is elementary abelian + regular => order p => unique normal Sylow-p) has NO Mathlib bearer at pin 2df2f015: MinimalNormal, group socle, and IsElementaryAbelian all return 0 hits. Step 1 is blocked on absent Mathlib infrastructure, upgraded to Risk R4 (HIGH). Re-verified 7 core bearers intact at pin (no drift since 2026-06-01). Recommended next ACT (Docker-up): fix Step 5 signature + discharge (~5-15 LOC, bearers present, math settled) as cheapest real progress; prototype the bearer-complete order-p Sylow fact (v_p(|H|)=1 => |Sylow|=p); do NOT attempt Step 1 uniqueness as a Sylow count. Docker DOWN this session (verification blackout) -- all work doc-only, 5 sorries intact.",
-    "nextAction": "Docker-up ACT: (1) correct Step 5 H_le_normalizer signature per the in-source warning block and discharge via Subgroup.le_normalizer (~5-15 LOC); (2) prototype |Sylow|=p from v_p(|H|)=1; (3) scope a minimal-normal/IsBlock route for Step 1 uniqueness (no current Mathlib bearer).",
+    "iteration": 7,
+    "focus": "S7 ORIENT (researcher-3, 2026-06-14): resolved the open next-action R1 left at S6 -- scope mitigation (b) for Step 1 (sylow_p_unique), the file's true blocker. Audited the actual MulAction.IsBlock / Primitive / Solvable / Sylow API at pin 2df2f015 via gh api and FOUND A BEARER-COMPLETE SOUND ROUTE that avoids the absent socle/MinimalNormal/IsElementaryAbelian layer. Route (derived-series + block): A := last nontrivial term of derivedSeries H (abelian, normal/characteristic, nontrivial via derivedSeries_normal/characteristic/succ); A normal => its ZMod p orbits are blocks (IsBlock.orbit_of_normal Blocks.lean:475), primitivity => each block subsingleton-or-univ (IsBlock.subsingleton_or_eq_univ Primitive.lean:115), A nontrivial+faithful => some orbit univ => A transitive (isPretransitive_iff_orbit_eq_univ) => p | |A|; A abelian => its Sylow-p Q normal hence characteristic in A (Sylow.characteristic_of_normal :728), char-in-char => Q normal in H; Legendre v_p(p!)=1 (Nat.Prime.factorization_factorial) => |Q|=p => Q is a Sylow-p of H (Sylow.ofCard :102), normal => unique (Sylow.unique_of_normal :710) => Subsingleton (Sylow p H). Risk R4 downgraded HIGH->MEDIUM: residual is ~100-150 LOC of wiring (transport Q along A->H, char-in-char composition, v_p arithmetic), NOT missing infrastructure. Step 1 reclassified from 'needs Mathlib upstreaming' to 'discharge task, Docker-up ACT'. Docker DOWN this session -- all work doc-only (comment-only Lean docstring edit, build-safe), 5 sorries intact.",
+    "nextAction": "Docker-up ACT: (1) discharge Step 1 sylow_p_unique via the derived-series+block route now scoped in the in-source docstring / knowledge.md R4 (~100-150 LOC); (2) Step 5 H_le_normalizer corrected signature + Subgroup.le_normalizer discharge (~5-15 LOC); (3) Steps 3/4. Docker required to build-verify -- nothing shippable during the blackout.",
     "blockers": [
-      "Docker daemon down 2026-06-13 (verification blackout): cannot build-verify any signature change, so the Step 5 fix is documented but deferred to a Docker-up session."
+      "Docker daemon down 2026-06-13 (verification blackout): cannot build-verify the Step 1 route or any signature change; all progress this session is doc-only (route scoping + comment-only docstring), deferred to a Docker-up session."
     ],
     "attemptCounts": {
       "total": 5,
       "currentApproach": 1,
       "approachesTried": 4
     },
-    "lastUpdate": "2026-06-13T00:00:00.000Z"
+    "lastUpdate": "2026-06-14T00:00:00.000Z"
   },
   "knowledge": {
     "progressSummary": "S1 OBSERVE scaffold materialised the S8 PREP §5 drop-in template into the destination directory: problem.md (5-step proof plan + bearer audit table + references), knowledge.md (risk register + cross-slug reuse + LOC profile), state.md (Iteration 1 SCAFFOLD), and this JSON tracker. No Lean changes. Bearer ecosystem re-verified intact at lake-pinned SHA. Sub-OQ ready for S2 ORIENT.",
     "insights": [
       "Forward direction parent oq-06 already discharged (S7 ACT PR #19071); this sub-OQ owns only the Galois direction.",
-      "Curator/seeker SPLIT-action latency budget (24-48h per S8 PREP §6) exceeded by ~16 days as of 2026-06-01; researcher-side Option B materialisation appropriate.",
+      "Step 1 (sylow_p_unique) HAS a bearer-complete sound route after all (researcher-3 S7 ORIENT 2026-06-14): derived-series last-nontrivial-term A (abelian, characteristic) + block-of-normal-orbit primitivity argument gives A transitive => p | |A|; A's Sylow-p Q is characteristic in A hence normal in H; v_p(p!)=1 => |Q|=p => Q is a normal Sylow-p of H => unique. All bearers present at pin (IsBlock.orbit_of_normal, IsBlock.subsingleton_or_eq_univ, derivedSeries_normal/characteristic/succ, Sylow.characteristic_of_normal/ofCard/unique_of_normal, Nat.Prime.factorization_factorial). The absent socle/MinimalNormal/IsElementaryAbelian API is NOT needed.",
+      "The 'nontrivial normal subgroup of a faithful primitive action is transitive' fact -- which R1's S6 audit had not located -- is exactly IsBlock.orbit_of_normal (Blocks.lean:475) + IsBlock.subsingleton_or_eq_univ (Primitive.lean:115); it replaces the textbook minimal-normal machinery for prime degree.",
       "`Equiv.Perm.isCycle_of_prime_order''` (Mathlib v4.26.0) is a 1-LOC bearer for step 3, reducing the parent S6 PREP's 300-500 LOC estimate to 250-450.",
       "Bearer ecosystem (Sylow, isCycle, normalizer, MonoidHom.ofInjective, parent AGL1Z*) confirmed intact at lake-pinned SHA on 2026-06-01."
     ],


### PR DESCRIPTION
## Summary

The merged **S7 ORIENT** work for this slug (PR #23961) was clobbered by **#24001** — a gallery realign PR for the unrelated `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` slug. #24001 was branched off a stale `main` and, on merge, carried stale copies of ~20 unrelated slugs' files. For this slug it reverted:

- `Erdos…AbelRuffini…GaloisDirection.lean`: **199 → 168 LOC** (dropped S7's comment-only derived-series + block route docstring)
- `state.md`: back to the S6 header (lost the entire **Iteration 7** block)
- `knowledge.md`: lost the **Risk R4 HIGH→MEDIUM** downgrade
- JSON tracker `currentState`: back to S6

This PR restores all four files to their #23961 (S7) merged content, and additionally syncs the JSON top-level `phase` (long stale at `S5_OBSERVE`) to `S7_ORIENT` to match `currentState`.

## Build safety

The Lean change is **purely docstring prose**. Verified: identical declaration set and the same 5 sorries (`sylow_p_unique`, `sylow_p_is_pcycle`, `normalizer_iso_AGL1Z`, `H_le_normalizer`, `primitive_solvable_subgroup_embeds_AGL1Z`); `sylow_p_normal` remains discharged. No signature or tactic change → build-safe (Docker DOWN this session).

## Scope

Restricted to this **claimed slug** only. #24001 also clobbered ~20 other slugs (kepler-conjecture-oq-04, several erdos-*, euler-polyhedral, etc.) — those are out of scope here and warrant separate recovery.

## Test plan
- [x] state.md restored to S7 (Iteration 7 block present)
- [x] `.lean` decls + sorries identical to origin/main (docstring-only diff, 199 LOC)
- [x] knowledge.md Risk R4 = MEDIUM (S7)
- [x] JSON valid; top `phase` and `currentState.phase` both `S7_ORIENT`
- [x] Docker DOWN — no build needed (comment-only Lean edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)