### PR TITLE
research(geometric-series-oq-01-oq-02): ORIENT — Cesàro (C,1) regularity reduces to Mathlib Filter.Tendsto.cesaro

### DIFF
--- a/research/problems/geometric-series-oq-01-oq-02/knowledge.md
+++ b/research/problems/geometric-series-oq-01-oq-02/knowledge.md
@@ -1,0 +1,90 @@
+# Knowledge: geometric-series-oq-01-oq-02
+
+## Summary
+
+**Problem**: Formalize the general Cesàro (C,1) regularity theorem — if a series
+`∑ aₙ` converges to `s`, then its Cesàro mean converges to the same `s`.
+
+**Status**: ORIENT (S1, 2026-06-14). OQ resolved on paper; reduces to Mathlib's
+`Filter.Tendsto.cesaro`. Buildable (< 80 LOC), no Mathlib gap. ACT deferred —
+Docker verification host down this session.
+
+**Progress summary**: ORIENT — formalizable core pinned to existing Mathlib API;
+two-milestone plan (M1 regularity, M2 converse-failure via Grandi). No Lean
+written yet.
+
+## Key insights
+
+- The OQ is the **regularity / consistency** property of (C,1) summation:
+  ordinary convergence ⟹ Cesàro summability to the *same* limit. It is a
+  near-immediate corollary of `Filter.Tendsto.cesaro`, applied to the
+  **partial-sum sequence** `S N = ∑ i ∈ range N, a i` (not to the terms `aₙ`).
+- The correct object to average is the sequence of partial sums `S`, not the
+  terms `aₙ`. Averaging the terms gives `→ 0` whenever `∑ aₙ` converges (terms
+  vanish) and is *not* the (C,1) mean of the series.
+- Mathlib's `Filter.Tendsto.cesaro` divides by `N` over `range N` (includes the
+  empty partial sum `S 0 = 0`); the indexing offset / inclusion of `S 0` does not
+  affect the limit, so it matches the standard (C,1) definition.
+- The parent entry `geometric-series-oq-01` already proves the **concrete** Grandi
+  instance by hand (`grandiCesaro_tendsto`, via `|σₙ − 1/2| ≤ 1/(2n)`). OQ-02's
+  general theorem subsumes that bespoke bound — the value-add is generality, plus
+  the converse-failure illustration that (C,1) **strictly** extends convergence.
+- Regularity and its converse are distinct facts: regularity is
+  convergent ⟹ (C,1)-summable; Grandi's series witnesses that the converse
+  fails ((C,1)-summable to 1/2, yet divergent / not `Summable`).
+
+## Built items
+
+- (none — ORIENT only; no Lean written this session)
+
+## Mathlib gaps
+
+- No named series-level `CesaroSummable` predicate in Mathlib (trivial to define
+  locally; not a fundamental gap).
+- The sequence-average limit transfer **is** present: `Filter.Tendsto.cesaro`
+  and `Filter.Tendsto.cesaro_smul` in
+  `Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean`.
+
+## Next steps
+
+1. (ACT, Docker) Create `proofs/Proofs/GeometricSeriesOQ01OQ02.lean`.
+2. Define `cesaroMean S N := (N⁻¹:ℝ) * ∑ k ∈ range N, S k` and a
+   `CesaroSummable` predicate.
+3. M1: regularity via `exact h.cesaro` on the partial-sum sequence.
+4. M2: Grandi converse-failure using parent `grandiCesaro_tendsto` +
+   `not_summable_grandi`.
+5. Add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` and build-verify.
+
+## Sessions
+
+### Session 2026-06-14 (S1) — ORIENT feasibility survey
+
+**Mode**: FRESH
+**Outcome**: scouted / ORIENT (no proof attempt — Docker down)
+
+#### What I did
+- Selected from the available pool by knowledge-tier triage (RICH slugs
+  `nth-root-irrational-oq-03` = active passive-watch, `mean-value-theorem-oq-02-oq-04`
+  = already resolved/retracted; chose this high-tractability fresh OQ for a
+  paper ORIENT).
+- Resolved the OQ on paper: regularity of (C,1) summation reduces to
+  `Filter.Tendsto.cesaro` applied to the partial-sum sequence.
+- Verified the exact Mathlib signatures against `master` (2026-06-14) in
+  `Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean`.
+- Inspected the parent Lean file `proofs/Proofs/GeometricSeriesOQ01.lean`:
+  found reusable `grandiCesaro_tendsto`, `not_summable_grandi`, `grandi_even`,
+  `grandi_odd` for M2.
+- Split into M1 (regularity) and M2 (converse-failure) milestones; both
+  buildable (< 80 LOC), no Mathlib gap.
+
+#### Key findings
+- OQ is a near-immediate corollary of existing Mathlib — main work is packaging
+  + the converse illustration, not new mathematics.
+- Average the partial sums, not the terms.
+
+#### Files modified
+- `research/problems/geometric-series-oq-01-oq-02/state.md` (new)
+- `research/problems/geometric-series-oq-01-oq-02/knowledge.md` (new)
+
+#### Next steps
+- ACT when Docker returns (see Next steps above).

--- a/research/problems/geometric-series-oq-01-oq-02/state.md
+++ b/research/problems/geometric-series-oq-01-oq-02/state.md
@@ -1,0 +1,103 @@
+# Research State: geometric-series-oq-01-oq-02
+
+## Current State
+
+**Phase**: ORIENT — S1 feasibility survey (researcher-6, 2026-06-14). OQ resolved
+on paper: the general Cesàro (C,1) regularity theorem reduces to Mathlib's
+existing `Filter.Tendsto.cesaro`. Formalizable core pinned to real Mathlib API;
+milestones split. No Lean written this session (verification blackout — Docker
+down); ACT deferred until build host returns.
+
+**Path**: full
+**Since**: 2026-06-14 (S1 ORIENT, researcher-6)
+**Last Updated**: 2026-06-14 (Iteration 1, S1 ORIENT, researcher-6)
+**Iteration**: 1
+
+## Problem statement
+
+OQ-02 of the follow-up chain rooted at the gallery entry `geometric-series-oq-01`
+("Geometric Series at the Boundary: |r| = 1"):
+
+> The general Cesàro summability theorem states that if `∑ aₙ` converges to `s`,
+> then its Cesàro mean also converges (to `s`).
+
+This is the **regularity** (a.k.a. consistency) property of (C,1) summation:
+ordinary convergence of a series implies Cesàro summability to the **same** sum.
+The parent entry `geometric-series-oq-01` already proves the *concrete* Grandi
+instance by hand (`grandiCesaro_tendsto : Tendsto grandiCesaro atTop (𝓝 (1/2))`,
+via an explicit `|σₙ − 1/2| ≤ 1/(2n)` bound). OQ-02 asks for the **general**
+theorem that subsumes such bespoke computations.
+
+## Mathematical resolution (paper)
+
+Let `a : ℕ → ℝ`, partial sums `S N := ∑ i ∈ range N, a i`.
+
+- **Series converges to `s`**  ⟺  `Tendsto S atTop (𝓝 s)`.
+- **(C,1)-summable to `σ`**  ⟺  the Cesàro means
+  `M N := (N⁻¹ : ℝ) * ∑ k ∈ range N, S k`  satisfy  `Tendsto M atTop (𝓝 σ)`.
+
+**Regularity theorem.** `Tendsto S atTop (𝓝 s)  →  Tendsto M atTop (𝓝 s)`.
+
+**Proof.** Apply Mathlib's `Filter.Tendsto.cesaro` to the sequence `u := S`,
+`l := s`. Its conclusion is verbatim
+`Tendsto (fun N => (N⁻¹ : ℝ) * ∑ i ∈ range N, S i) atTop (𝓝 s)`,
+i.e. `Tendsto M atTop (𝓝 s)`. ∎
+
+So the OQ is a **near-immediate corollary** of existing Mathlib infrastructure —
+the only original content is (i) packaging the `CesaroSummable` predicate and the
+series→partial-sum bridge, and (ii) wiring the converse-failure illustration.
+
+### Pinned Mathlib API (verified against master 2026-06-14)
+
+`Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean`:
+
+```
+/-- The Cesaro average of a converging sequence converges to the same limit. -/
+theorem Filter.Tendsto.cesaro_smul {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {u : ℕ → E} {l : E} (h : Tendsto u atTop (𝓝 l)) :
+    Tendsto (fun n : ℕ => (n⁻¹ : ℝ) • ∑ i ∈ range n, u i) atTop (𝓝 l)
+
+theorem Filter.Tendsto.cesaro {u : ℕ → ℝ} {l : ℝ} (h : Tendsto u atTop (𝓝 l)) :
+    Tendsto (fun n : ℕ => (n⁻¹ : ℝ) * ∑ i ∈ range n, u i) atTop (𝓝 l)
+```
+
+## Milestones
+
+| ID | Statement | Mathlib hook | Est. LOC | Gate |
+|----|-----------|--------------|----------|------|
+| **M1** | Regularity: `Tendsto S atTop (𝓝 s) → Tendsto (cesaroMean S) atTop (𝓝 s)`, where `cesaroMean S N = (N⁻¹:ℝ) * ∑ k ∈ range N, S k`. Includes `CesaroSummable` def + series-converges⇒(C,1)-summable corollary. | `Filter.Tendsto.cesaro` (direct) | 15–40 | buildable now (Docker) |
+| **M2** | Converse fails: Grandi's series `(fun n => (-1)^n)` is (C,1)-summable to `1/2` (reuse parent `grandiCesaro_tendsto`) yet `¬ Summable` / partial sums divergent (reuse parent `not_summable_grandi`). Demonstrates (C,1) **strictly** extends convergence. | parent `geometric-series-oq-01` lemmas | 20–50 | buildable now (Docker) |
+
+Both milestones are Docker-gated only for *verification*; neither needs missing
+Mathlib infrastructure.
+
+## Infrastructure Assessment: Cesàro summability
+
+**Needed**: a named `CesaroSummable` predicate + the regularity bridge from
+series convergence (partial-sum `Tendsto`) to the (C,1) mean.
+**Mathlib status**: `Filter.Tendsto.cesaro` provides the sequence-average limit
+transfer; Mathlib has **no** named series-level `CesaroSummable` predicate.
+**Size estimate**: < 80 LOC total (M1 + M2).
+**Decision**: BUILD (when Docker returns). No fundamental gap.
+
+## Blockers
+
+- **Verification blackout**: Docker host down this session → cannot run
+  `docker-build.sh`. ORIENT (paper + API pinning) complete; ACT deferred.
+
+## Next Action (ACT, when Docker returns)
+
+1. Create `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` importing
+   `Mathlib` + `Proofs.GeometricSeriesOQ01`.
+2. Define `cesaroMean (S : ℕ → ℝ) (N : ℕ) : ℝ := (N⁻¹ : ℝ) * ∑ k ∈ range N, S k`
+   and `CesaroSummable (a : ℕ → ℝ) (σ : ℝ) : Prop`.
+3. M1: prove regularity by `exact h.cesaro` after unfolding `cesaroMean`.
+4. M2: instantiate Grandi via parent lemmas; state strictness (C,1) ⊋ convergence.
+5. Add gallery entry `src/data/proofs/geometric-series-oq-01-oq-02/`
+   (meta.json + annotations.json) and build-verify.
+
+## Iteration log
+
+* **S1** (2026-06-14, researcher-6, ORIENT): paper resolution + Mathlib API
+  pin (`Filter.Tendsto.cesaro`) + milestone split. No Lean written
+  (Docker down). Doc-only ORIENT PR.


### PR DESCRIPTION
## Summary

FRESH-ORIENT (OBSERVE→ORIENT) for the open question **geometric-series-oq-01-oq-02**:

> The general Cesàro summability theorem states that if `∑ aₙ` converges to `s`, then its Cesàro mean also converges (to `s`).

This is the **regularity / consistency** property of (C,1) summation. Resolved on paper and pinned to existing Mathlib:

- Average the **partial sums** `S N = ∑ i ∈ range N, a i`, not the terms.
- The regularity theorem `Tendsto S atTop (𝓝 s) → Tendsto (cesaroMean S) atTop (𝓝 s)` is a **near-immediate corollary** of `Filter.Tendsto.cesaro` (in `Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean`, signatures verified against master 2026-06-14).
- The parent entry `geometric-series-oq-01` already proves the concrete Grandi case by hand (`grandiCesaro_tendsto`); OQ-02's general theorem subsumes it.

### Milestones (both buildable, no Mathlib gap)
- **M1** Regularity via `exact h.cesaro` on the partial-sum sequence (+ `CesaroSummable` predicate). ~15–40 LOC.
- **M2** Converse-failure: Grandi's series is (C,1)-summable to 1/2 yet divergent — reuses parent `grandiCesaro_tendsto` / `not_summable_grandi`. ~20–50 LOC.

### Scope of this PR
Doc-only ORIENT (tracked `research/problems/geometric-series-oq-01-oq-02/{state,knowledge}.md`). **No Lean written** — ACT deferred because the Docker verification host is down this session. Pool status advanced to `in-progress` locally (untracked).

## Test plan
- [ ] (Deferred to ACT, requires Docker) `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02`
- [x] Mathlib API signatures verified against mathlib4 master
- [x] No contention (no open PRs on this slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)