### PR TITLE
research(sum-of-kth-powers-oq-03): S3 ORIENT — durable M1 verification + ℕ-sub-free reindex

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/knowledge.md
+++ b/research/problems/sum-of-kth-powers-oq-03/knowledge.md
@@ -68,8 +68,46 @@ Work over ℕ, mirroring the parent's `Finset.range` conventions. Let `T i := i 
 `Finset.sum_Ico_eq_sub`, `Finset.range_eq_Ico`, `Finset.sum_range_id` are present. Total estimate
 ~60–100 LOC, no axioms, no sorries expected.
 
+### ℕ-subtraction-free reindex (recommended Lean formulation — de-risks the port)
+
+The spec above writes blocks as `Ico (T (i-1)) (T i)` for `i ≥ 1`, which introduces ℕ-subtraction
+(`i-1`) and an `i ≥ 1` side condition. A cleaner, side-condition-free formulation indexes blocks by
+`i ∈ range n` mapping to cube `(i+1)^3` on positions `[T i, T (i+1))` (with `T k = k*(k+1)/2`,
+`T 0 = 0`), so **no `i-1` appears anywhere**:
+
+- **L2′ `block_eq_cube`** : `∑ j ∈ Finset.Ico (T i) (T (i+1)), (2*j+1) = (i+1)^3`.
+  Derive additively from L1 via `Finset.sum_Ico_consecutive` (with `Finset.range_eq_Ico`):
+  `(T i)^2 + (∑ Ico (T i) (T (i+1)) (2j+1)) = (T (i+1))^2`, then close with the verified ring
+  identity `(T i)^2 + (i+1)^3 = (T (i+1))^2`. To use `ring` despite the `/2` in `T`, clear the
+  division first: prove `2 * T k = k*(k+1)` (i.e. `Finset.sum_range_id_mul_two` / `omega` on the
+  evenness of `k*(k+1)`), or work the squared identity through the `*4` form
+  `4*(T k)^2 = (k*(k+1))^2`. This division-clearing is the one genuinely build-fiddly step and is
+  why M1 is Docker-gated rather than paste-port-trivial.
+- **L3′ tiling** : `∑ i ∈ range n, (∑ j ∈ Ico (T i) (T (i+1)), (2*j+1)) = ∑ j ∈ Ico 0 (T n), (2*j+1)`
+  by induction on `n` + `Finset.sum_range_succ` + `Finset.sum_Ico_consecutive` (needs `T i ≤ T (i+1)`,
+  immediate since `T` is monotone). `Ico 0 (T n) = range (T n)`, so the RHS is `(T n)^2` by L1.
+- **Main′** : `∑ i ∈ range n, (i+1)^3 = (T n)^2`. Then shift the index
+  (`∑ i ∈ range n, (i+1)^3 = ∑ i ∈ range (n+1), i^3`, via `Finset.sum_range_succ'` or the `0^3 = 0`
+  bump) and rewrite `T n = ∑ i ∈ range (n+1), i` (`sum_first_powers_classical` from the parent file,
+  or `Finset.sum_range_id`) to land on `(∑ i ∈ range (n+1), i)^2` — matching the parent's exact RHS
+  shape `sum_cubes_eq_sum_squared`.
+
+### Build-free verification (durable, this session — researcher-1, S3)
+
+All M1 arithmetic is now independently certified by a committed, reproducible script,
+`research/problems/sum-of-kth-powers-oq-03/verify_m1.py` (sympy symbolic + brute force, exits
+non-zero on any mismatch). It re-derives — not plugs in — every identity the M1 lemmas encode:
+`sum_odds = m²`; the additive telescope `T(i-1)² + i³ = T(i)²`; `block = T(i)² − T(i-1)² = i³`; block
+geometry (size `i`, smallest odd `i²−i+1`, largest `i²+i−1`); the ℕ-sub-free reindex
+`T(i)² + (i+1)³ = T(i+1)²`; Gauss `T(n)=∑i`; and an end-to-end brute-force chain
+`blocks == cubes == firstOdds == T_n² == (∑i)²` for `n = 0..60`. **All checks pass.** This makes the
+M1 spec machine-checkable build-free, so the only remaining work is the Lean transcription (the
+division-clearing in L2′ being the sole non-mechanical step). The eventual `.lean` is cross-checkable
+against the parent, which already proves the same theorem algebraically (`sum_cubes_eq_sum_squared`).
+
 **Milestone split**
-- M1 (formalizable now): L1 + L2 + L3 + Main above. Pure Mathlib, no gaps — Docker-gated only.
+- M1 (formalizable now): L1 + L2′ + L3′ + Main′ above (ℕ-sub-free reindex). Pure Mathlib, no gaps —
+  Docker-gated only; arithmetic certified by `verify_m1.py`.
 - M2 (pedagogical, optional): an explicit `Finset` **bijection** between the Σ-type {(i,j) : block}
   and `range (T n)` (via `Finset.sum_sigma`/`Finset.sum_biUnion` over a `Finset.disjiUnion`),
   to surface the "blocks ↔ initial segment of odds" bijection literally rather than by telescope.

--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -4,14 +4,18 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T20:00:16-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 OQ resolved on paper (odd-number partition of cubes). Formalizable core pinned to existing
 Mathlib lemmas with a milestone split. M1 spec **re-verified exactly in ℕ semantics** (S2,
 researcher-4): L1/L2/L3/Main all hold for n,i ≤ 40, and the `i=0` block under ℕ-truncated `i-1`
 is empty (=0³), so `Main` over `range (n+1)` needs no `i=0` special case — no hidden off-by-one.
-Ready to ACT once the verification backends return.
+**S3 (researcher-1):** that verification is now **durable + reproducible** — committed as
+`verify_m1.py` (sympy symbolic + brute force n=0..60, exits non-zero on mismatch) — and the M1
+spec sharpened to a **ℕ-subtraction-free reindex** (block `i∈range n` ↦ cube `(i+1)³` on
+`[T i, T(i+1))`, no `i-1`, no `i≥1` side condition) that removes the last build-fiddly hazard
+except the `/2` division-clearing in L2′. Ready to ACT (transcription only) once backends return.
 
 ## Active Approach
 Telescoping odd-partition: i³ = T_i² − T_{i−1}², then `Finset.sum_Ico_consecutive` tiles the
@@ -28,7 +32,11 @@ odd-position ranges and `sum_odds (m) = m²` closes it to T_n² = (∑ i)². See
   No Lean can be built/checked this session. M1 is spec-complete and Docker-gated only.
 
 ## Next Action
-When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, type M1 (L1 `sum_odds`,
-L2 `block_eq_cube`, L3 tiling via `Finset.sum_Ico_consecutive`, Main), build via
-`./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`, then add the gallery entry under
+When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, type M1 using the
+**ℕ-sub-free reindex** in knowledge.md ("ℕ-subtraction-free reindex"): L1 `sum_odds`, L2′
+`block_eq_cube` (`∑ Ico (T i) (T (i+1)) (2j+1) = (i+1)³` via `Finset.sum_Ico_consecutive` +
+ring identity `(T i)²+(i+1)³=(T(i+1))²`, clearing `/2` by `2*T k = k*(k+1)`), L3′ tiling, Main′,
+then index-shift to the parent's RHS shape. Build via
+`./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`; cross-check arithmetic against
+`verify_m1.py` if any ring step misbehaves. Then add the gallery entry under
 `src/data/proofs/sum-of-kth-powers-oq-03/`.

--- a/research/problems/sum-of-kth-powers-oq-03/verify_m1.py
+++ b/research/problems/sum-of-kth-powers-oq-03/verify_m1.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Reproducible, build-free verification of the Milestone-1 (M1) spec for
+sum-of-kth-powers-oq-03: the odd-number-partition (telescoping) proof of
+Nicomachus's theorem  Sum_{i=1}^n i^3 = (Sum_{i=1}^n i)^2.
+
+This script independently re-derives every arithmetic claim the M1 Lean
+lemmas depend on (symbolically via sympy, and by brute force), so the spec's
+correctness is machine-checkable without Docker/Mathlib. It is NOT a proof of
+the Lean lemmas; it certifies the *mathematics* the lemmas encode, so the
+eventual Lean port is a transcription rather than a fresh derivation.
+
+Run:  python3 verify_m1.py   (exits non-zero on any mismatch)
+
+T i := i*(i+1)/2  (i-th triangular number, T 0 = 0).
+The odd-partition proof tiles the first T_n odd numbers into n consecutive
+blocks; block i (1-indexed) has i terms and sums to i^3.
+"""
+import sys
+import sympy as sp
+
+
+def check(name, cond):
+    print(f"[{'OK' if cond else 'FAIL'}] {name}")
+    if not cond:
+        check.failed = True
+
+
+check.failed = False
+
+i, j, m, n = sp.symbols("i j m n", integer=True, nonnegative=True)
+Ti = i * (i + 1) / 2          # T i
+Tim1 = (i - 1) * i / 2        # T (i-1)
+
+# L1  sum of odds:  Sum_{j=0}^{m-1} (2 j + 1) = m^2
+check("L1 sum_odds: sum_{j<m}(2j+1) = m^2",
+      sp.simplify(sp.summation(2 * j + 1, (j, 0, m - 1)) - m**2) == 0)
+
+# L2 core: block i = T(i)^2 - T(i-1)^2 = i^3, proved additively to dodge nat-sub:
+#          T(i-1)^2 + i^3 = T(i)^2
+check("L2 telescope (additive): T(i-1)^2 + i^3 = T(i)^2",
+      sp.simplify(Tim1**2 + i**3 - Ti**2) == 0)
+check("L2 block = T(i)^2 - T(i-1)^2 = i^3",
+      sp.simplify(Ti**2 - Tim1**2 - i**3) == 0)
+
+# Block geometry: block i occupies odd-sequence positions [T(i-1), T(i)),
+# i.e. i terms, smallest odd 2 T(i-1)+1, largest 2 T(i)-1.
+check("block size T(i)-T(i-1) = i", sp.simplify(Ti - Tim1 - i) == 0)
+check("smallest odd 2 T(i-1)+1 = i^2-i+1", sp.simplify(2 * Tim1 + 1 - (i**2 - i + 1)) == 0)
+check("largest  odd 2 T(i)-1   = i^2+i-1", sp.simplify(2 * Ti - 1 - (i**2 + i - 1)) == 0)
+
+# nat-subtraction-free reindex (recommended Lean formulation): block index i in
+# range n maps to cube (i+1)^3 on positions [T i, T (i+1)); no i-1 anywhere.
+Ti0 = i * (i + 1) / 2
+Tip1 = (i + 1) * (i + 2) / 2
+check("reindex: T(i)^2 + (i+1)^3 = T(i+1)^2 (no nat-sub)",
+      sp.simplify(Ti0**2 + (i + 1)**3 - Tip1**2) == 0)
+
+# Gauss: T n = Sum_{i=0}^{n} i  (matches parent RHS base = (sum i)^2)
+check("Gauss T(n) = sum_{i<=n} i",
+      sp.simplify(sp.summation(i, (i, 0, n)) - n * (n + 1) / 2) == 0)
+
+
+def T(k):
+    return k * (k + 1) // 2
+
+
+# Brute-force end-to-end cross-check of the whole chain for n = 0..60:
+#   blocks-telescope == sum of cubes == first T_n odds == T_n^2 == (sum i)^2
+allok = True
+for N in range(0, 61):
+    blocks = 0
+    for ii in range(1, N + 1):
+        lo, hi = T(ii - 1), T(ii)            # positions [lo, hi)
+        block = sum(2 * jj + 1 for jj in range(lo, hi))
+        if block != ii**3:
+            allok = False
+        blocks += block
+    first_odds = sum(2 * jj + 1 for jj in range(0, T(N)))
+    cubes = sum(ii**3 for ii in range(0, N + 1))
+    sumsq = sum(ii for ii in range(0, N + 1))**2
+    if not (blocks == cubes == first_odds == T(N)**2 == sumsq):
+        allok = False
+check("numeric n=0..60: blocks==cubes==firstOdds==T_n^2==(sum i)^2", allok)
+
+if check.failed:
+    print("VERIFICATION FAILED")
+    sys.exit(1)
+print("All M1 identities verified.")


### PR DESCRIPTION
## Summary
Build-free ORIENT advance on the odd-number-partition (telescoping) proof of Nicomachus's theorem `∑ i³ = (∑ i)²`. Docker + Aristotle remain down, so no Lean was built; this turns the M1 spec from "verified in-session" into **durable, reproducible, and lower-risk to port**.

- **Committed reproducible verification** — `research/problems/sum-of-kth-powers-oq-03/verify_m1.py` (sympy symbolic + brute force, exits non-zero on any mismatch) independently re-derives every identity the M1 lemmas encode: `sum_odds = m²`, the additive telescope `T(i-1)²+i³=T(i)²`, `block = T(i)²−T(i-1)² = i³`, block geometry (size `i`, odds `i²−i+1 … i²+i−1`), the ℕ-sub-free reindex `T(i)²+(i+1)³=T(i+1)²`, Gauss `T(n)=∑i`, and the end-to-end chain `blocks==cubes==firstOdds==T_n²==(∑i)²` for n=0..60. **All checks pass.**
- **Sharpened M1 spec** — added a **ℕ-subtraction-free reindex** (block `i∈range n` ↦ cube `(i+1)³` on positions `[T i, T(i+1))`), removing the `i-1`/`i≥1` side-condition hazards. The sole remaining non-mechanical step is clearing the `/2` in `T` (`2*T k = k*(k+1)`), documented in the next-action.
- Docs-only: `knowledge.md`, `state.md` (iter 2→3), new `verify_m1.py`. **No `.lean`** — M1 stays Docker-gated for transcription only.

Builds on merged #24076 (ORIENT) and #24119 (in-session ℕ-semantics check); this adds the *committed* script + reindex those didn't have.

## Test plan
- [x] `python3 research/problems/sum-of-kth-powers-oq-03/verify_m1.py` exits 0, all identities OK
- [ ] (Docker-gated) transcribe M1 per the sharpened spec and build `Proofs.SumOfKthPowersOQ03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)