### PR TITLE
research(roth-theorem-oq-01): ORIENT survey + fix leanFiles misattribution

### DIFF
--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -6,16 +6,112 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Target: a **quantitative** upper bound on the Roth number `r₃(N)` (largest 3-AP-free subset
+of `{1,…,N}`), of Bourgain's strength, rather than the qualitative `r₃(N) = o(N)` already in
+the parent gallery proof `roth-theorem`.
+
+**Correct quantitative landscape** (the original problem.md misstated Bourgain's bound as
+`N/(log log N)^{1/2}`, which is weaker than even Roth's rate — see Insights):
+
+| Author (year) | Bound on `r₃(N)` |
+|---|---|
+| Roth (1953) | `≪ N / log log N` |
+| **Bourgain (1999)** | `≪ N (log log N / log N)^{1/2}` |
+| Bourgain (2008) | `≪ N (log log N)² / log N` |
+| Sanders (2011) | `≪ N (log log N)^{O(1)} / log N` |
+| Bloom (2016) | `≪ N (log log N)⁴ / log N` |
+| Bloom–Sisask (2020) | `≪ N / (log N)^{1+c}` |
+| Kelley–Meka (2023) | `≪ N · exp(-c (log N)^β)` |
+
+The "saving" in Bourgain 1999 is a **power of log** (`(log N)^{1/2}` up to a `loglog`
+factor), not a `loglog` saving. The companion problem `roth-theorem-oq-02` targets the
+Bloom–Sisask bound; this problem (oq-01) is the strictly weaker Bourgain bound, so it is
+**implied by** oq-02.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Session 2026-06-14 (Session 1, ORIENT) — Mode: FRESH
+
+- **Mathlib anchor.** Mathlib already provides `rothNumberNat : ℕ → ℕ`
+  (`Mathlib.Combinatorics.Additive.AP.Three`) and the qualitative
+  `rothNumberNat_isLittleO_id : (fun N => (rothNumberNat N : ℝ)) =o[atTop] (fun N => (N:ℝ))`.
+  Any quantitative statement for this problem should be phrased at the **Mathlib
+  `rothNumberNat`** level, NOT the project-local `Szemeredi.Roth.rothNumber` over `ZMod N`
+  used in `RothTheorem.lean`. The sibling `RothTheoremOQ02.lean` already does exactly this.
+
+- **Sibling precedent (oq-02 = Bloom–Sisask).** `proofs/Proofs/RothTheoremOQ02.lean` states
+  the Bloom–Sisask bound as
+  `axiom rothNumberNat_bloom_sisask : ∃ c > 0, ∀ N ≥ 3, (rothNumberNat N : ℝ) ≤ N / (log N)^(1+c)`
+  and builds a stable downstream API (`blasiConst`, `blasiConst_pos`, `rothNumberNat_le_blasi`).
+  This is the established gallery pattern for these out-of-reach quantitative bounds: state the
+  bound as an `axiom` (status `axiomatized`, NOT `verified`), then derive consequences.
+
+- **Bound-statement error in the seed problem.md.** The auto-generated formal statement gave
+  Bourgain (1999) as `O(N/(log log N)^{1/2})`, and the "Initial Thoughts" section described the
+  Bohr-set refinement as a `1/√(log log N)` improvement. Both confuse `log` with `log log`. The
+  actual Bourgain 1999 bound is `N (log log N / log N)^{1/2}`. Corrected in problem.md this
+  session.
+
+- **leanFiles misattribution (fixed).** The research JSON `leanFiles` listed 6 sibling
+  `RothTheorem*` files (base proof, OQ02, OQ03, Quantitative, Aristotle variants) even though no
+  `RothTheoremOQ01*.lean` exists — making this open problem look formalized. Root cause:
+  `scripts/research/enrich-research.ts` `getPascalCasePrefixes` falls back to the bare root
+  `RothTheorem` for `-oq-NN` slugs, whose `startsWith` match greedily grabs every sibling.
+  Pinned `SPECIAL_CASES['roth-theorem-oq-01'] = ['RothTheoremOQ01']` so the match is `[]` now
+  and links only the real file if one is ever added. Verified via `enrich-research.ts --dry-run`.
+  (Systemic note below.)
+
+---
+
+## Buildability Assessment
+
+**Genuine from-scratch proof (density increment / Fourier):**
+- Needs discrete Fourier analysis on `ZMod N` at strength: AP-counting via the third moment
+  `∑_r f̂(r)² f̂(-2r)`, large-spectrum extraction, ℓ² control, and a single-step density
+  increment on a sub-progression (Roth) or Bohr set (Bourgain), then the iteration with explicit
+  constant tracking.
+- Mathlib has `AddChar` / discrete convolution / Cauchy–Schwarz but **not** the
+  large-spectrum + Bohr-set packaging needed for a rate.
+- Estimate: even Roth's original `1/log log N` rate is **> 1000 LOC** of new additive-combinatorics
+  infrastructure; Bourgain's improvement adds Bohr-set geometry on top. **BLOCKED** as a
+  from-scratch proof; not attemptable in a single session (and Docker is currently down).
+
+**Build-free / short routes:**
+- **M1 (small, ~30–60 LOC, Docker to verify):** state `axiom rothNumberNat_bourgain :
+  ∃ C > 0, ∀ N ≥ 3, (rothNumberNat N : ℝ) ≤ C * N * (Real.log (Real.log N) / Real.log N)^(1/2)`
+  and PROVE the bridge `rothNumberNat_bourgain → rothNumberNat_isLittleO_id` (an explicit
+  `(log log N / log N)^{1/2}` bound ⟹ `o(N)`, since the ratio → 0). This is a *real* provable
+  lemma connecting an axiomatized quantitative bound to Mathlib's qualitative result — the honest
+  unit of progress here. Status would be `axiomatized`.
+- Since oq-02's `rothNumberNat_bloom_sisask` axiom implies the Bourgain bound, an alternative is
+  to DERIVE `rothNumberNat_bourgain` from the oq-02 axiom rather than re-axiomatize. Cleaner
+  dependency, but both remain assumptions.
+
+**Decision: SURVEY / ORIENT.** Statement is clear and anchored; a genuine proof is blocked on
+missing Mathlib infrastructure (>1000 LOC). Realistic next deliverable is M1 once Docker is up.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Working at the project-local `ZMod N` `rothNumber` level (as in `RothTheorem.lean`) for the
+  quantitative statement: diverges from the Mathlib `rothNumberNat` API that oq-02 and the
+  qualitative `_isLittleO_id` result use. Stay at the Mathlib level.
+
+---
+
+## Systemic Note (for a builder, not this session)
+
+`scripts/research/enrich-research.ts` has a systemic dual bug affecting all `-oq-NN` slugs:
+1. `slugToPascalCase` emits `Oq` (lowercase `q`) for the `oq` token, so the correctly-cased
+   own-prefix (`RothTheoremOQ01`) is never generated and never matches real `*OQ##*.lean` files.
+2. The bare-root `-oq-NN` fallback (`RothTheorem`) `startsWith`-matches every sibling.
+
+A measured probe (`oq`→`OQ` casing + dropping the bare-root fallback for `-oq` slugs) changes
+attribution for **1431 / 2158** slugs: 9 are pure gains (`-incomplete-01` mid-slug OQs that
+currently match nothing due to casing) and the rest only shed misattributed siblings. This is the
+real root fix but has a large blast radius and cannot be render-verified during the Docker
+blackout — left as a recommendation rather than shipped. Per-slug `SPECIAL_CASES` remains the
+safe interim patch.

--- a/research/problems/roth-theorem-oq-01/problem.md
+++ b/research/problems/roth-theorem-oq-01/problem.md
@@ -2,7 +2,7 @@
 
 **Slug**: roth-theorem-oq-01
 **Created**: 2026-06-14
-**Status**: Active (OBSERVE)
+**Status**: Active (ORIENT)
 **Source**: gallery-gap (parent: `roth-theorem`)
 
 ## Problem Statement
@@ -15,19 +15,20 @@ qualitative density-$o(1)$ statement. This problem targets a **quantitative** bo
 Bourgain's strength:
 
 $$
-r_3(N) = O\!\left(\frac{N}{(\log\log N)^{1/2}}\right)
-\quad\text{(Bourgain 1999; later improved to } N(\log\log N/\log N)\ \text{and beyond)} .
+r_3(N) = O\!\left(N\left(\frac{\log\log N}{\log N}\right)^{1/2}\right)
+\quad\text{(Bourgain 1999; later improved by Bourgain 2008, Sanders, Bloom, Bloom–Sisask, Kelley–Meka).}
 $$
 
-The aim is a formalized explicit decay rate via the density-increment / Fourier-analytic argument,
-rather than the qualitative limit alone.
+Note this is a **power-of-log** saving over the trivial bound, strictly stronger than Roth's
+original $O(N/\log\log N)$. The aim is a formalized explicit decay rate via the
+density-increment / Fourier-analytic argument, rather than the qualitative limit alone.
 
 ### Plain Language
 
 Roth's theorem says a set of integers with no 3-term arithmetic progression must be "thin"
 (vanishing density). The parent proof gives only the vanishing. This problem asks for a *rate*:
 how fast does the maximum density shrink? Bourgain's Fourier-analytic density-increment argument
-gives a concrete $1/\sqrt{\log\log N}$-type bound, which is what we want to formalize.
+gives a concrete $\sqrt{\log\log N/\log N}$-type density bound, which is what we want to formalize.
 
 ### Why This Matters
 
@@ -75,7 +76,7 @@ $1/\sqrt{\log\log N}$ if the Bohr-set machinery is tractable.
    - Risk: handling sub-progressions and the Fourier coefficient extraction in `ZMod N` is intricate.
 
 2. **Bourgain's Bohr-set refinement**: replace sub-progressions by Bohr sets to improve the rate.
-   - Why it might work: gives the stated $1/\sqrt{\log\log N}$ bound.
+   - Why it might work: upgrades Roth's $\log\log$ saving to the power-of-log bound $N(\log\log N/\log N)^{1/2}$.
    - Risk: Bohr-set geometry is heavy; likely a later phase.
 
 ### Key Difficulties
@@ -114,8 +115,18 @@ $1/\sqrt{\log\log N}$ if the Bohr-set machinery is tractable.
 - Parent gallery entry `roth-theorem`.
 
 ### Mathlib
+- `Mathlib.Combinatorics.Additive.AP.Three` — `rothNumberNat : ℕ → ℕ` and the qualitative
+  `rothNumberNat_isLittleO_id` (`r₃(N) = o(N)`). **Phrase the quantitative statement at this
+  level**, as `roth-theorem-oq-02` (`RothTheoremOQ02.lean`) does, not the project-local
+  `ZMod N` `rothNumber`.
 - `Mathlib.Combinatorics.Additive` — additive-combinatorics lemmas.
-- `Mathlib.Analysis.Fourier` / `AddChar` — discrete Fourier analysis.
+- `Mathlib.Analysis.Fourier` / `AddChar` — discrete Fourier analysis (present, but lacks the
+  large-spectrum / Bohr-set packaging a from-scratch rate requires).
+
+### Sibling problem
+- `roth-theorem-oq-02` — targets the stronger Bloom–Sisask bound `N/(log N)^{1+c}`, stated as
+  `axiom rothNumberNat_bloom_sisask`. Since it implies the Bourgain bound, this problem (oq-01)
+  could be derived from it, or axiomatized independently following the same pattern.
 
 ## Metadata
 

--- a/research/problems/roth-theorem-oq-01/state.md
+++ b/research/problems/roth-theorem-oq-01/state.md
@@ -1,16 +1,20 @@
 # Research State: roth-theorem-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T17:42:10-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Feasibility and approach identified (Session 1, ORIENT). Statement anchored to Mathlib
+`rothNumberNat`; sibling `roth-theorem-oq-02` precedent (axiomatized Bloom–Sisask bound) noted.
 
 ## Active Approach
-None yet.
+SURVEY/axiomatized route. The genuine Fourier/density-increment proof is blocked on missing
+Mathlib infrastructure (>1000 LOC: large-spectrum estimates, Bohr sets). Realistic next unit:
+M1 — state `rothNumberNat_bourgain` (`N (loglog N/log N)^{1/2}`) and prove the bridge to the
+qualitative `rothNumberNat_isLittleO_id`. Requires Docker (currently down) to verify.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +22,11 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Docker build environment down (cannot compile/verify Lean this session).
+- A from-scratch quantitative proof needs additive-combinatorics infrastructure (large spectrum,
+  Bohr sets) not in Mathlib — out of single-session scope.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker is up: create `proofs/Proofs/RothTheoremOQ01.lean` with the M1 deliverable —
+`axiom rothNumberNat_bourgain` + proved bridge lemma `… → rothNumberNat_isLittleO_id`
+(mirroring the `RothTheoremOQ02.lean` axiomatized pattern). Status `axiomatized`.

--- a/scripts/research/enrich-research.ts
+++ b/scripts/research/enrich-research.ts
@@ -68,6 +68,13 @@ const SPECIAL_CASES: Record<string, string[]> = {
   // discrete EulerPolyhedralFormula.lean and the unrelated OQ01OQ02 sibling,
   // making this open problem look solved. Empty list = no leanFiles match.
   'euler-polyhedral-formula-oq-02-oq-01-oq-01': [],
+  // Open problem (Bourgain's quantitative Roth bound) with no Lean file of its
+  // own. The `-oq-01` fallback strips to the bare root `RothTheorem`, whose
+  // `startsWith` match greedily grabs every `RothTheorem*` sibling (base proof,
+  // OQ02, OQ03, Quantitative, …), making this open problem look formalized.
+  // No `RothTheoremOQ01*.lean` exists; pin the exact own-prefix so the match is
+  // [] now and links only the real file if one is ever added.
+  'roth-theorem-oq-01': ['RothTheoremOQ01'],
 }
 
 /**


### PR DESCRIPTION
## Summary
Build-free ORIENT iteration on **roth-theorem-oq-01** (Bourgain's quantitative Roth bound), a freshly-seeded open problem. Docker build environment is down, so this is docs + enrichment-script only (**0 `.lean` files**).

## Changes
- **leanFiles misattribution fix.** The research JSON listed 6 sibling `RothTheorem*` files (base proof, OQ02, OQ03, Quantitative, Aristotle variants) even though no `RothTheoremOQ01*.lean` exists — making this open problem look formalized. Root cause: `enrich-research.ts` `getPascalCasePrefixes` falls back to the bare root `RothTheorem` for `-oq-NN` slugs, whose `startsWith` match greedily grabs every sibling. Pinned `SPECIAL_CASES['roth-theorem-oq-01'] = ['RothTheoremOQ01']`; verified `[]` via `enrich-research.ts --dry-run`.
- **ORIENT survey** (`knowledge.md`, `state.md`, `problem.md`): anchored the statement to Mathlib `rothNumberNat` + `rothNumberNat_isLittleO_id`; documented the sibling `roth-theorem-oq-02` Bloom–Sisask axiomatized precedent; buildability assessment (genuine Fourier/density-increment proof >1000 LOC → BLOCKED; build-free M1 route = `axiom rothNumberNat_bourgain` + proved bridge to qualitative `o(N)`). Phase **OBSERVE → ORIENT**.
- **Math correction.** The seed `problem.md` misstated Bourgain (1999) as `N/(loglog N)^{1/2}` (weaker than Roth's own rate). Corrected to `N(loglog N/log N)^{1/2}`, a power-of-log saving, with the full bound landscape table in `knowledge.md`.

## Systemic note (not shipped)
The same prefix-fallback bug affects ~1431/2158 slugs (measured: 9 pure gains, rest shed misattributed siblings). The root fix (`oq`→`OQ` casing + drop the bare-root fallback for `-oq` slugs) is recommended for a builder with render verification; per-slug `SPECIAL_CASES` is the safe interim patch here. Details in `knowledge.md`.

## Test plan
- [x] `enrich-research.ts --dry-run` reports `roth-theorem-oq-01`: 0 lean files (was 6)
- [x] sibling `roth-theorem-oq-02` still enriches correctly (unaffected)
- [x] No `.lean` files touched; no build required