### PR TITLE
research(pell-equation-oq-05): fix leanFiles misattribution (complements #24131)

### DIFF
--- a/src/data/research/problems/pell-equation-oq-05.json
+++ b/src/data/research/problems/pell-equation-oq-05.json
@@ -86,28 +86,5 @@
   "lastUpdate": "2026-06-14T21:05:00-07:00",
   "significance": 6,
   "tractability": 4,
-  "leanFiles": [
-    {
-      "path": "Proofs/PellEquation.lean",
-      "filename": "PellEquation.lean",
-      "lineCount": 299,
-      "theoremCount": 10,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PellEquation.lean"
-    },
-    {
-      "path": "Proofs/PellEquationOQ01.lean",
-      "filename": "PellEquationOQ01.lean",
-      "lineCount": 196,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 6,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PellEquationOQ01.lean"
-    }
-  ]
+  "leanFiles": []
 }


### PR DESCRIPTION
## Summary
Follow-up integrity fix complementing the merged ORIENT survey (#24131). That PR landed the survey but left the research JSON's `leanFiles` pointing at the **parent's** solved files (`PellEquation.lean`, `PellEquationOQ01.lean` — 0 sorries, 15 theorems), making this open, unstarted problem look formalized.

**Root cause:** the `-oq-05` suffix strips to base prefix `PellEquation`, which `startsWith`-matches both parent files in `enrich-research.ts`.

**Fix (build-free, 2 files):**
- Cleared JSON `leanFiles` to `[]` (the `knowledge`/survey fields from #24131 are untouched).
- Pinned `SPECIAL_CASES['pell-equation-oq-05'] = ['PellEquationOQ05']` in `scripts/research/enrich-research.ts` so regen matches only the (future) own file. Since `enrichProblem` only overwrites `leanFiles` on a **non-empty** match (never clears), `[]` stays durable until `PellEquationOQ05.lean` exists.

## Test plan
- [x] `jq empty` validates the JSON; `leanFiles=[]`, survey `knowledge` fields preserved
- [x] SPECIAL_CASES logic verified by code reading (special-case prefix → no current file match → leanFiles stays [])
- [x] Diff limited to the 2 files; no `.lean`, no clobber of #24131's merged docs