### PR TITLE
Enrich Infinitely Many Primes ≡ 3 (mod 4): add section mathContext

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -81,14 +81,16 @@
       "title": "Key Lemma: Prime Factor ≡ 3 (mod 4)",
       "startLine": 17,
       "endLine": 54,
-      "summary": "Any n > 1 with n ≡ 3 (mod 4) has a prime factor p with p ≡ 3 (mod 4). Proved by strong induction: if every prime factor were ≡ 1 (mod 4), their product would be ≡ 1 (mod 4)."
+      "summary": "Any n > 1 with n ≡ 3 (mod 4) has a prime factor p with p ≡ 3 (mod 4). Proved by strong induction: if every prime factor were ≡ 1 (mod 4), their product would be ≡ 1 (mod 4).",
+      "mathContext": "$n > 1,\\ n \\equiv 3 \\pmod 4 \\implies \\exists p\\text{ prime},\\ p \\mid n,\\ p \\equiv 3 \\pmod 4$. Strong induction via `termination_by n` with decreasing measure $k = n/p < n$: take any prime factor $p$; if $p \\equiv 3$ we are done, otherwise $p$ is odd so $p \\equiv 1 \\pmod 4$, and $\\bar 1 \\cdot \\bar k = \\bar 3$ in $(\\mathbb{Z}/4\\mathbb{Z})^\\times$ forces $k = n/p \\equiv 3 \\pmod 4$, so the recursive call on $k$ yields the required factor of $n$."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Infinitely Many Primes ≡ 3 (mod 4)",
       "startLine": 55,
       "endLine": 96,
-      "summary": "Constructs N = 4·(n+1)! - 1 (which is ≡ 3 mod 4) to find a prime ≡ 3 (mod 4) larger than any given bound, via a Euclid-style argument without L-functions."
+      "summary": "Constructs N = 4·(n+1)! - 1 (which is ≡ 3 mod 4) to find a prime ≡ 3 (mod 4) larger than any given bound, via a Euclid-style argument without L-functions.",
+      "mathContext": "Reduces $\\{p : p\\text{ prime},\\ p \\equiv 3 \\pmod 4\\}$ being infinite to `Set.infinite_iff_exists_gt`: for each bound $n$, the witness $N = 4(n+1)! - 1 \\equiv 3 \\pmod 4$ has a prime factor $p \\equiv 3 \\pmod 4$ by the key lemma. If $p \\le n+1$ then $p \\mid (n+1)! \\mid 4(n+1)! = N+1$ while also $p \\mid N$, so $p \\mid \\gcd(N, N+1) = 1$ — impossible for $p \\ge 2$. Hence $p > n$, giving arbitrarily large such primes."
     },
     {
       "id": "existence-witness",


### PR DESCRIPTION
Enrichment pass for `dirichlets-theorem-oq-02`.

The entry was already well-developed (6 full annotations, accurate counts, 5 resolving crossReferences), so this is a focused consistency fix rather than padding.

## Change
Two of the four `sections` (`key-lemma`, `main-theorem`) lacked a `mathContext` field while the other two (`setup`, `existence-witness`) had one. Added accurate LaTeX `mathContext` to both:
- **key-lemma**: states the lemma, the `termination_by n` strong induction with decreasing measure $k = n/p < n$, and the mod-4 multiplicativity ($\bar 1\cdot\bar k=\bar 3$ in $(\mathbb{Z}/4\mathbb{Z})^\times$) that drives it.
- **main-theorem**: the reduction via `Set.infinite_iff_exists_gt`, the $N = 4(n+1)!-1 \equiv 3 \pmod 4$ witness, and the $p \mid \gcd(N,N+1)=1$ contradiction forcing $p > n$.

Verified against `proofs/Proofs/DirichletsTheoremOQ02.lean` (3 theorems, 0 sorries, 0 axioms — matches meta). `pnpm build` passes.