### PR TITLE
research(four-square-distribution-oq-02): S1 ORIENT — verified B4 orbit-size law + numTypes ≤ r4/8 bound

### DIFF
--- a/research/problems/four-square-distribution-oq-02/knowledge.md
+++ b/research/problems/four-square-distribution-oq-02/knowledge.md
@@ -6,16 +6,130 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+We count **representation types** of `n` as four squares. The hyperoctahedral
+group `B₄ = (ℤ/2)⁴ ⋊ S₄` (order `2⁴·4! = 384`) acts on the solution set
+
+```
+Sol(n) = { (x₁,x₂,x₃,x₄) ∈ ℤ⁴ : x₁²+x₂²+x₃²+x₄² = n }
+```
+
+by permuting coordinates (the `S₄` factor) and flipping signs independently (the
+`(ℤ/2)⁴` factor). A **type** is a `B₄`-orbit; `numTypes(n) := #(B₄-orbits on Sol(n))`.
+Jacobi pins the total `|Sol(n)| = r₄(n)`. The OQ asks for a bound on `numTypes(n)`
+in terms of `r₄(n)` / divisor data of `n`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### ORIENT (S1, 2026-06-14, researcher-3) — verified orbit-size law + clean type bound
+
+All three results below are checked by brute force for `n = 1..50` in the
+reproducible script `scripts/verify_orbit_bound.py` (host `python3`, no Docker).
+`ALL CHECKS PASSED`.
+
+**Action convention.** An element `g = (s, σ) ∈ (ℤ/2)⁴ ⋊ S₄` (with `s ∈ {±1}⁴`,
+`σ ∈ S₄`) acts by `(g·v)_i = s_i · v_{σ⁻¹(i)}`. The 384 elements were enumerated
+explicitly and orbits computed directly.
+
+**(A) Jacobi total (input, classical).**
+`r₄(n) = 8·σ*(n)` where `σ*(n) = Σ_{d∣n, 4∤d} d`. Confirmed `r₄ = 8σ*` for all
+`n ≤ 50` against brute-force ordered-signed counts. This is the *weighted total*
+the OQ takes as given (existence is Mathlib `Nat.sum_four_squares`; the exact
+count is the assumed/parent input — see Gaps).
+
+**(B) Orbit-size law (the core lemma).** For a solution `v` with
+- `z` = number of zero coordinates, and
+- nonzero absolute values occurring with multiplicities `m₁,…,m_k`
+  (`z + Σ mⱼ = 4`),
+
+the stabilizer is exactly
+
+```
+|Stab_{B₄}(v)| = 2^z · z! · ∏ⱼ (mⱼ!)
+|orbit(v)|     = 384 / |Stab_{B₄}(v)|.
+```
+
+Reason: a stabilizing `(s,σ)` needs `σ` to preserve both the zero-set and each
+equal-|value| class (`z!·∏mⱼ!` choices); given `σ`, signs are *forced* on the
+nonzero coordinates and *free* on the `z` zero coordinates (`2^z` choices). The
+formula matched the brute-force orbit cardinality for every orbit, every `n ≤ 50`.
+
+Degeneracy table (illustrative, n>0):
+
+| type | `\|Stab\|` | `\|orbit\|` |
+|------|-----:|------:|
+| `(a,b,c,d)` distinct nonzero | 1 | 384 |
+| `(a,a,a,a)` | 24 | 16 |
+| `(a,a,0,0)` | 16 | 24 |
+| `(a,0,0,0)` | 48 | **8** |
+
+**(C) Clean type bound (the deliverable).** For every `n > 0`,
+
+```
+numTypes(n) ≤ r₄(n) / 8 = σ*(n) = Σ_{d∣n, 4∤d} d.
+```
+
+Proof skeleton: by orbit–stabilizer `Σ_{orbits} |orbit| = r₄(n)`. By (B), for
+`n > 0` at least one coordinate is nonzero, so `z ≤ 3` and the stabilizer is
+maximised at the `(a,0,0,0)` type, `|Stab| = 2³·3!·1! = 48`; hence **every orbit
+has size ≥ 384/48 = 8**. Therefore `numTypes(n) = Σ_{orbits} 1 ≤ Σ |orbit|/8 =
+r₄(n)/8`. Substituting Jacobi gives `numTypes(n) ≤ σ*(n)`. Verified: bound holds
+and `minorb ≥ 8` for all `n ≤ 50`.
+
+This is a self-contained, finite, fully-formalizable bound with **no open
+analytic dependencies** (matching the OQ's stated character). Equality
+`numTypes = σ*` requires every orbit to have size exactly 8 — i.e. all reps of
+the `(a,0,0,0)` type — which forces `n` a perfect square `a²` with `r₄ = 8`
+(`σ*(a²) = 1`, e.g. `n = 1`). So the bound is tight only at `n = 1` among `n ≤ 50`
+(`numTypes(1) = 1 = σ*(1)`); for larger `n` it is a genuine (often loose) upper bound.
+
+---
+
+## Lean Formalization Plan (ORIENT decomposition)
+
+Target Lean statement (clean form, Jacobi taken as a hypothesis):
+
+```lean
+-- numTypes n := Nat.card (orbits of B₄ on Sol n)
+theorem numTypes_le_sigmaStar (n : ℕ) (hn : 0 < n) :
+    numTypes n ≤ sigmaStar n := ...
+```
+
+**Buildable now (no analytic input):**
+1. `B₄` as `SemidirectProduct (Fin 4 → ZMod 2) (Equiv.Perm (Fin 4)) φ`, or
+   pragmatically as the signed-permutation subgroup of `Equiv.Perm (Fin 4 → ...)`.
+   Order `384` via `Fintype.card` of the semidirect product
+   (`card = 2⁴ · 4!`). **M1.**
+2. The `MulAction` of `B₄` on `Sol n ⊆ (Fin 4 → ℤ)`. **M2.**
+3. Orbit–stabilizer: `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`
+   (orbit size = `|G| / |Stab|`), giving `Σ |orbit| = r₄(n)` over orbit reps. **M3.**
+4. The orbit-size law (B): stabilizer computation by zero-count + abs-value
+   multiplicities. This is the **main labor** — case analysis on degeneracy. **M4.**
+5. The bound (C): `|orbit| ≥ 8` for `n > 0` ⟹ `numTypes ≤ r₄/8`. **M5.**
+
+**Gated / assumed (Jacobi exact count):**
+- `r₄(n) = 8·σ*(n)` — Mathlib has Lagrange existence (`Nat.sum_four_squares`) but
+  (as of pin `2df2f01…`) **not** the exact Jacobi count. Take `r₄ = 8σ*` as a
+  hypothesis / parent input, OR prove only the orbit-side `numTypes ≤ r₄(n)/8`
+  (which needs NO Jacobi) and state the `σ*` corollary conditionally.
+  → **The orbit-side bound `numTypes(n) ≤ r₄(n)/8` is fully self-contained and
+     does not depend on Jacobi at all.** Recommend shipping that as the verified
+     core, with `≤ σ*(n)` as a Jacobi-conditional corollary.
+
+**Mathlib anchors (modules; exact lemma names to confirm at build time):**
+- `Mathlib.GroupTheory.GroupAction.Basic` / `…/Quotient` — `orbit`, `stabilizer`,
+  `orbitEquivQuotientStabilizer`, orbit–stabilizer cardinality.
+- `Mathlib.GroupTheory.SemidirectProduct` — `B₄` construction.
+- `Mathlib.GroupTheory.Perm.*`, `Fintype.card_perm` (`= 4! = 24`).
+- `Mathlib.NumberTheory.SumFourSquares` — Lagrange baseline.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Direct divisor bound alone** (approach 2 in problem.md): bounding
+  `numTypes ≤ r₄ / (min orbit)` is exactly the route taken, but the value of
+  `min orbit` must come from the stabilizer law (B) — without (B) one cannot
+  justify `min orbit = 8`. So (B) is not optional; it is the crux. Not a dead end,
+  but the "crude" framing in problem.md understates that (B) is required.

--- a/research/problems/four-square-distribution-oq-02/scripts/verify_orbit_bound.py
+++ b/research/problems/four-square-distribution-oq-02/scripts/verify_orbit_bound.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+ORIENT verification for four-square-distribution-oq-02.
+
+B4 = (Z/2)^4 semidirect S4, |B4| = 2^4 * 4! = 384, acts on integer vectors
+(x1,x2,x3,x4) by coordinate permutation (S4) and independent sign flips ((Z/2)^4).
+
+We verify, by brute force for small n, three claims that form the ORIENT plan:
+
+  (A) Jacobi:        r4(n) = 8 * sigma*(n),  sigma*(n) = sum_{d|n, 4 not| d} d.
+  (B) Orbit-size:    for a solution v with z zero-coords and nonzero |values|
+                     occurring with multiplicities m_1,...,m_k,
+                        |Stab(v)| = 2^z * z! * prod_j m_j!,
+                        |orbit(v)| = 384 / |Stab(v)|.
+  (C) Type bound:    numTypes(n) := #(B4-orbits) satisfies, for n > 0,
+                        numTypes(n) <= r4(n)/8 = sigma*(n),
+                     because every orbit of a nonzero vector has size >= 8
+                     (max stabilizer for n>0 is 48, at the (a,0,0,0) type).
+"""
+from itertools import product, permutations
+from math import isqrt, factorial
+from collections import Counter
+
+def r4_bruteforce(n):
+    """Ordered signed reps; count solutions and return the solution set."""
+    b = isqrt(n)
+    sols = []
+    for x in product(range(-b, b+1), repeat=4):
+        if x[0]*x[0]+x[1]*x[1]+x[2]*x[2]+x[3]*x[3] == n:
+            sols.append(x)
+    return sols
+
+def sigma_star(n):
+    return sum(d for d in range(1, n+1) if n % d == 0 and d % 4 != 0)
+
+def b4_group():
+    """All 384 elements as (signs, perm) with action w_i = signs[i]*v[perm[i]]."""
+    elems = []
+    for signs in product((1,-1), repeat=4):
+        for perm in permutations(range(4)):
+            elems.append((signs, perm))
+    return elems
+
+B4 = b4_group()
+assert len(B4) == 384
+
+def act(g, v):
+    signs, perm = g
+    return tuple(signs[i]*v[perm[i]] for i in range(4))
+
+def orbit(v):
+    return {act(g, v) for g in B4}
+
+def stab_size_formula(v):
+    z = sum(1 for c in v if c == 0)
+    nz = [abs(c) for c in v if c != 0]
+    mult = Counter(nz)
+    prod = 1
+    for m in mult.values():
+        prod *= factorial(m)
+    return (2**z) * factorial(z) * prod
+
+ok = True
+print(f"{'n':>3} {'r4':>5} {'8sig*':>6} {'numTypes':>8} {'sig*':>5} {'bound ok':>8} {'minorb':>6}")
+for n in range(1, 51):
+    sols = r4_bruteforce(n)
+    r4 = len(sols)
+    jac = 8*sigma_star(n)
+    if r4 != jac:
+        print(f"  JACOBI MISMATCH n={n}: r4={r4} 8sig*={jac}"); ok=False
+    # orbits
+    seen = set()
+    orbits = []
+    for v in sols:
+        if v in seen: continue
+        o = orbit(v)
+        seen |= o
+        orbits.append(o)
+    numTypes = len(orbits)
+    # verify orbit-stabilizer + sum = r4, and formula matches brute-force orbit size
+    total = 0
+    minorb = 384
+    for o in orbits:
+        rep = next(iter(o))
+        formula = 384 // stab_size_formula(rep)
+        if formula != len(o):
+            print(f"  ORBIT-SIZE MISMATCH n={n} rep={rep}: formula={formula} actual={len(o)}"); ok=False
+        total += len(o)
+        minorb = min(minorb, len(o))
+    if total != r4:
+        print(f"  ORBIT-SUM MISMATCH n={n}: sum={total} r4={r4}"); ok=False
+    bound_ok = numTypes <= sigma_star(n)
+    if not bound_ok:
+        print(f"  BOUND VIOLATION n={n}: numTypes={numTypes} sig*={sigma_star(n)}"); ok=False
+    if minorb < 8:
+        print(f"  MIN-ORBIT < 8 at n={n}: minorb={minorb}"); ok=False
+    if n <= 20 or not bound_ok:
+        print(f"{n:>3} {r4:>5} {jac:>6} {numTypes:>8} {sigma_star(n):>5} {str(bound_ok):>8} {minorb:>6}")
+
+print()
+print("ALL CHECKS PASSED" if ok else "FAILURES ABOVE")
+# Spot demonstration of the four largest-stabilizer (smallest-orbit) types for n>0:
+print("\nStabilizer/orbit by degeneracy type (illustrative):")
+for label, v in [("(a,b,c,d) distinct nonzero", (1,2,3,4)),
+                 ("(a,a,a,a)", (1,1,1,1)),
+                 ("(a,a,0,0)", (1,1,0,0)),
+                 ("(a,0,0,0)", (1,0,0,0))]:
+    s = stab_size_formula(v)
+    print(f"  {label:28} |Stab|={s:3}  |orbit|={384//s:3}")

--- a/research/problems/four-square-distribution-oq-02/state.md
+++ b/research/problems/four-square-distribution-oq-02/state.md
@@ -1,25 +1,51 @@
 # Research State: four-square-distribution-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-14T17:42:10-07:00
+**Since**: 2026-06-14 (S1 ORIENT — researcher-3)
 **Iteration**: 1
+**Owner**: researcher-3 (S1 ORIENT, 2026-06-14)
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## S1 ORIENT 2026-06-14 (researcher-3)
+
+**Mode**: ORIENT survey, build-free (Docker DOWN — verification blackout).
+Brute-force + orbit-counting checks done on host `python3`; no Lean built.
+
+**Outcome**: Identified and numerically verified the core lemma and a clean,
+self-contained deliverable bound. Advanced OBSERVE → ORIENT with a concrete
+Mathlib-grounded formalization decomposition. See `knowledge.md` for the full
+write-up and `scripts/verify_orbit_bound.py` for the reproducible verification
+(`ALL CHECKS PASSED`, n = 1..50).
+
+**Key results (all Python-verified for n ≤ 50):**
+- Orbit-size law: `|Stab_{B₄}(v)| = 2^z · z! · ∏ⱼ mⱼ!`, `|orbit| = 384/|Stab|`,
+  where `z` = #zero coords, `mⱼ` = multiplicities of nonzero absolute values.
+- Deliverable bound (no Jacobi needed): `numTypes(n) ≤ r₄(n)/8` for `n > 0`,
+  since every nonzero orbit has size ≥ 8 (max stabilizer 48 at type `(a,0,0,0)`).
+- Jacobi corollary: `numTypes(n) ≤ σ*(n) = Σ_{d∣n, 4∤d} d` (Jacobi `r₄ = 8σ*`
+  re-verified n ≤ 50; taken as parent input since exact count is not yet in Mathlib).
 
 ## Active Approach
-None yet.
+Orbit–stabilizer + degeneracy case analysis (problem.md approach 1). The crude
+divisor bound (approach 2) is subsumed: its `min orbit` constant (= 8) is exactly
+what the stabilizer law supplies.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only; no Lean built)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (orbit-stabilizer + Burnside — viable, core lemma verified)
 
 ## Blockers
-None.
+- **Verification blackout (2026-06-14)**: Docker daemon down, so the Lean
+  formalization (M1–M5 in knowledge.md, est. ~150–250 LOC) cannot be built/checked.
+  ORIENT artifacts (formula, bound, plan, reproducible script) are build-free.
+- **Jacobi exact count not in Mathlib** (pin `2df2f01…`): `Nat.sum_four_squares`
+  gives existence only. Mitigation: ship the orbit-side bound `numTypes ≤ r₄/8`
+  (Jacobi-free) as the core; `≤ σ*(n)` as a conditional corollary.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+ACT (once Docker returns): formalize M1–M5. Recommended first deliverable is the
+**Jacobi-free** `numTypes(n) ≤ r₄(n)/8` — it needs only the orbit-size law +
+orbit–stabilizer, no analytic input. Confirm exact Mathlib lemma names for
+`SemidirectProduct` cardinality and orbit–stabilizer at build time.


### PR DESCRIPTION
## Summary

S1 ORIENT survey for the fresh OQ `four-square-distribution-oq-02` (was OBSERVE,
0 knowledge). Docker is down, so this is a **build-free, Python-verified** survey
that advances the problem with a concrete core lemma, a clean deliverable bound,
and a Mathlib-grounded formalization plan.

The problem: count **representation types** of `n` as four squares = orbits of the
hyperoctahedral group `B₄ = (ℤ/2)⁴ ⋊ S₄` (order 384) acting on `{x : ∑xᵢ² = n}`
by coordinate permutation + sign flips.

## Results (all brute-force verified for n = 1..50; `ALL CHECKS PASSED`)

- **Orbit-size law** (the crux lemma): for a solution `v` with `z` zero
  coordinates and nonzero absolute values of multiplicities `m₁,…,mₖ`,
  `|Stab_{B₄}(v)| = 2^z · z! · ∏ⱼ mⱼ!` and `|orbit(v)| = 384/|Stab|`.
- **Deliverable bound (Jacobi-free):** `numTypes(n) ≤ r₄(n)/8` for `n > 0`,
  because every nonzero orbit has size ≥ 8 (max stabilizer 48, at type `(a,0,0,0)`).
- **Corollary:** `numTypes(n) ≤ σ*(n) = Σ_{d∣n, 4∤d} d` via Jacobi `r₄ = 8σ*`
  (re-verified n ≤ 50; taken as parent input since the exact count is not yet in Mathlib).

## What's in the PR (docs + script only, no Lean)

- `knowledge.md` — full write-up: action convention, orbit-size law with proof,
  degeneracy table, the bound, equality analysis, and an M1–M5 Lean decomposition
  with Mathlib anchors. Flags the Jacobi-free core vs. the Jacobi-conditional corollary.
- `state.md` — OBSERVE → ORIENT, blockers (Docker; Jacobi count absent from Mathlib),
  recommended ACT first deliverable.
- `scripts/verify_orbit_bound.py` — reproducible host-`python3` verification.

Released NOT completed — ACT (the ~150–250 LOC Lean formalization) awaits a build host.

## Test plan
- [x] `python3 research/problems/four-square-distribution-oq-02/scripts/verify_orbit_bound.py` → `ALL CHECKS PASSED`
- [ ] ACT: formalize M1–M5 once Docker returns (confirm exact Mathlib lemma names at build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)