### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): durable Strategy D verification + bound recipe

### DIFF
--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -161,3 +161,57 @@ Open Lean items to confirm at build time (lemma names, not math):
    Lean lemma names resolve, fill the `sorry`. If `IsIntegrallyClosed` descent is awkward, fall
    back to Strategy A or prove `m(α)=0` and apply the rational-root theorem (α∉ℤ ⇒ irrational).
 2. Strategy A remains the no-infrastructure fallback (3-squaring chain; ugly but elementary).
+
+---
+
+## Session 2026-06-14 (Session 3) — Make Strategy D verification durable + bound recipe (researcher-1)
+
+**Mode**: CONTINUE · **Outcome**: ORIENT deepened (ephemeral verification made
+reproducible; explicit ACT recipe for the bounds). Both backends still down: Docker
+`docker ps` timeout; **Aristotle MCP tools now load but `prove` returns "Resource not
+found"** (backend still unavailable) — so still build-free only.
+
+### What I did
+1. **Made Session 2's sympy verification durable and reproducible.** Committed
+   `verify_strategy_d.py` (sympy 1.14 / mpmath, runs in seconds, exits 0 on
+   "ALL CHECKS PASSED"). It re-derives every load-bearing fact *from first
+   principles*, not by trusting the numbers already in this file:
+   - **(F1) integrality**: each `√k` is a root of the monic integer `x²−k`
+     (leading coeff 1, integer coeffs, `(√k)²−k=0`) — exactly `IsIntegral ℤ (√k)`.
+   - **(F3) minimal polynomial**: re-derived `m(x)` independently as
+     `Res_y(y⁴−10y²+1, (x−y)⁴−24(x−y)²+4)` (from `p=√2+√3 ⇒ p⁴−10p²+1=0` and
+     `q=√5+√7 ⇒ q⁴−24q²+4=0`, both re-checked), confirmed it is **degree 16,
+     monic, integer**, equals the value recorded above, has constant term
+     `215²=46225`, and satisfies `m(α)=0` symbolically.
+   - **(F2) the bound**: `8 < α < 9` (α ≈ 8.0281, 60-digit mpmath).
+2. **Extracted the explicit ACT recipe for the bound lemmas** (de-risks the
+   `8 < α < 9` step that Strategy D rests on). Rational witnesses, each verified
+   to bound its radical by squaring (`lo² < k < hi²`):
+   - `√2 ∈ (1.41, 1.42)`, `√3 ∈ (1.73, 1.74)`, `√5 ∈ (2.23, 2.24)`, `√7 ∈ (2.64, 2.65)`.
+   - Lower sum `1.41+1.73+2.23+2.64 = 8.01 > 8`; upper sum
+     `1.42+1.74+2.24+2.65 = 8.05 < 9`.
+   - **Lean shape**: for each radical use `Real.lt_sqrt`/`Real.sqrt_lt'` (or
+     `Real.le_sqrt`) with `norm_num` on `lo² < k` and `k < hi²`, then `linarith`
+     to combine the four into `8 < α` and `α < 9`. No new Mathlib.
+
+### Why this is forward progress (not re-ORIENT churn)
+- Session 2's verification lived only in that session's transcript; the *numbers*
+  were copied into knowledge.md but nothing here could be **re-checked**. The
+  script makes them reproducible by anyone, and would catch a future transcription
+  error in `m(x)` or the bound.
+- The rational-witness recipe converts the hand-wavy "bounds via
+  `Real.sqrt_lt_sqrt`" note into concrete, `norm_num`-ready inequalities — the
+  single remaining non-API step in Strategy D's `sorry`.
+
+### Files modified
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/verify_strategy_d.py` (new)
+
+### Next steps (unchanged target, now lower-risk)
+1. When Docker **or** Aristotle returns: implement Strategy D (~60–100 LOC). The
+   only two genuinely-open Lean obligations are (a) the integral-closure descent
+   `(r:ℝ) integral / ℤ ⇒ r ∈ ℤ` (lemma names to confirm: `IsIntegral.add`,
+   integrality descent along injective `algebraMap ℚ ℝ`, `IsIntegrallyClosed ℤ`
+   ⇒ `IsIntegrallyClosed.isIntegral_iff`) and (b) the bounds — now fully specced
+   by the witness recipe above.
+2. Fallbacks unchanged (Strategy A 3-squaring chain; or `m(α)=0` + rational-root).

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
@@ -4,13 +4,15 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Survey deepened (Session 2, researcher-4). Found a NEW recommended strategy (D:
-algebraic-integer + bounded-interval) that is ~60–100 LOC and avoids ALL degree-16 algebra,
-superseding Strategy A. Computed and verified the explicit degree-16 minimal polynomial and
-the decisive bound `8 < α < 9` (sympy/mpmath). Still Docker-gated for the final Lean build.
+Strategy D verification made durable (Session 3, researcher-1). Committed
+`verify_strategy_d.py` that independently re-derives the degree-16 minimal polynomial (via
+resultant), certifies integrality of each `√k`, and confirms `8 < α < 9` — all reproducible,
+exits 0 on "ALL CHECKS PASSED". Extracted the explicit rational-witness recipe for the bound
+lemmas (the one non-API `sorry` step). Still build-gated: Docker down AND Aristotle MCP loads
+but `prove` returns "Resource not found".
 
 ## Active Approach
 Strategy D — α = √2+√3+√5+√7 is a sum of algebraic integers ⇒ integral over ℤ; a rational
@@ -24,13 +26,15 @@ Fallback: Strategy A (elementary 3-squaring chain) or `m(α)=0` + rational-root 
 - Approaches tried: 0
 
 ## Blockers
-- Docker build wrapper unavailable (`docker info` timeout) — cannot verify Lean.
-- Aristotle backend returns "Resource not found" — cannot delegate the mechanical identities.
+- Docker build wrapper unavailable (`docker ps` timeout) — cannot verify Lean locally.
+- Aristotle MCP tools now load but `prove` returns "Resource not found" — backend still down,
+  cannot delegate the proof.
 
 ## Next Action
-When Docker returns, implement **Strategy D** in
-`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~60–100 LOC). Confirm the four
-Mathlib lemma names in the knowledge.md skeleton (`IsIntegral.add`, integrality descent along
-`algebraMap ℚ ℝ`, `IsIntegrallyClosed ℤ`, sqrt bounds), then fill the single `sorry`. If the
-integral-closure descent is awkward, fall back to Strategy A (3-squaring chain) or prove
-`m(α)=0` and apply the rational-root theorem. See knowledge.md for the full assessment.
+When Docker **or** Aristotle returns, implement **Strategy D** in
+`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~60–100 LOC). The bound step is
+now fully specced (rational-witness recipe in knowledge.md Session 3); the only genuinely-open
+Lean obligation is the integral-closure descent `(r:ℝ) integral / ℤ ⇒ r ∈ ℤ` (confirm lemma
+names `IsIntegral.add`, integrality descent along `algebraMap ℚ ℝ`,
+`IsIntegrallyClosed.isIntegral_iff`). Fallbacks: Strategy A (3-squaring chain) or `m(α)=0` +
+rational-root theorem. Re-run `verify_strategy_d.py` to re-confirm all math artifacts.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/verify_strategy_d.py
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/verify_strategy_d.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Reproducible verification of the load-bearing facts behind Strategy D for
+
+    sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01
+    Goal:  Irrational (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7)
+
+Strategy D (algebraic integer + bounded interval):
+  alpha = sqrt2 + sqrt3 + sqrt5 + sqrt7 is a sum of four algebraic integers,
+  hence integral over Z. A rational number integral over Z is an integer
+  (Z is integrally closed in Q). But 8 < alpha < 9, so alpha is not an
+  integer, hence alpha is irrational.
+
+This script independently re-derives and checks, with NO appeal to the
+numbers pre-written in knowledge.md, the three facts the Lean proof rests on:
+
+  (F1) integrality:   each sqrt(k) is a root of the MONIC INTEGER poly x^2 - k,
+                      so alpha is integral over Z. We also exhibit alpha's
+                      monic integer minimal polynomial m(x) (degree 16) and
+                      check m(alpha) = 0, certifying integrality concretely.
+  (F2) the bound:     8 < alpha < 9, verified to high precision (mpmath).
+  (F3) minimal poly:  m(x) is re-derived from first principles via a resultant
+                      of two quartics (NOT copied from the knowledge base),
+                      then cross-checked against the value recorded in
+                      knowledge.md. Confirms degree 16 and constant term 215^2.
+
+Run:  python3 verify_strategy_d.py
+Exits 0 with "ALL CHECKS PASSED" iff every assertion holds.
+
+Dependencies: sympy >= 1.14, mpmath (bundled with sympy).
+"""
+
+import sympy as sp
+import mpmath as mp
+
+
+def check(name, cond):
+    status = "ok  " if cond else "FAIL"
+    print(f"  [{status}] {name}")
+    assert cond, f"CHECK FAILED: {name}"
+
+
+def main():
+    x, y = sp.symbols("x y")
+
+    print("== (F1) Each sqrt(k) is integral over Z (root of monic x^2 - k) ==")
+    # sqrt(k) is a root of the monic integer polynomial x^2 - k; the leading
+    # coefficient is 1 (monic) and all coefficients are integers, which is
+    # exactly what `IsIntegral Z (sqrt k)` requires.
+    for k in (2, 3, 5, 7):
+        poly = sp.Poly(x**2 - k, x)
+        check(f"x^2 - {k} is monic", poly.LC() == 1)
+        check(f"x^2 - {k} has integer coeffs", all(c.is_integer for c in poly.all_coeffs()))
+        check(f"(sqrt {k})^2 - {k} == 0", sp.simplify(sp.sqrt(k)**2 - k) == 0)
+
+    print("== (F3) Re-derive alpha's minimal polynomial via a resultant ==")
+    # p = sqrt2 + sqrt3 satisfies p^4 - 10 p^2 + 1 = 0.
+    # q = sqrt5 + sqrt7 satisfies q^4 - 24 q^2 + 4 = 0.
+    # Confirm those two quartics from scratch:
+    p_val = sp.sqrt(2) + sp.sqrt(3)
+    q_val = sp.sqrt(5) + sp.sqrt(7)
+    check("p=sqrt2+sqrt3 root of y^4-10y^2+1",
+          sp.simplify(p_val**4 - 10 * p_val**2 + 1) == 0)
+    check("q=sqrt5+sqrt7 root of y^4-24y^2+4",
+          sp.simplify(q_val**4 - 24 * q_val**2 + 4) == 0)
+
+    # alpha = p + q. Eliminate y between p's minimal poly (in y) and
+    # q's minimal poly written for q = x - y. The resultant in y is a
+    # polynomial in x having alpha as a root.
+    p_poly = y**4 - 10 * y**2 + 1
+    q_poly = (x - y) ** 4 - 24 * (x - y) ** 2 + 4
+    res = sp.resultant(p_poly, q_poly, y)
+    m_derived = sp.Poly(sp.expand(res), x)
+
+    check("resultant is degree 16", m_derived.degree() == 16)
+    check("resultant is monic", m_derived.LC() == 1)
+    check("resultant has integer coeffs",
+          all(c.is_integer for c in m_derived.all_coeffs()))
+
+    # The value recorded in knowledge.md (independent transcription):
+    m_recorded = sp.Poly(
+        x**16 - 136 * x**14 + 6476 * x**12 - 141912 * x**10
+        + 1513334 * x**8 - 7453176 * x**6 + 13950764 * x**4
+        - 5596840 * x**2 + 46225,
+        x,
+    )
+    check("derived minimal poly == value in knowledge.md",
+          m_derived == m_recorded)
+    check("constant term is 215^2 = 46225",
+          m_derived.all_coeffs()[-1] == 215**2 == 46225)
+
+    # m(alpha) = 0 exactly (certifies alpha integral over Z via this monic m).
+    alpha_sym = sp.sqrt(2) + sp.sqrt(3) + sp.sqrt(5) + sp.sqrt(7)
+    m_at_alpha = sp.expand(m_derived.as_expr().subs(x, alpha_sym))
+    check("m(alpha) == 0 (symbolic)", sp.simplify(m_at_alpha) == 0)
+
+    print("== (F2) Decisive bound 8 < alpha < 9 (high precision) ==")
+    mp.mp.dps = 60
+    alpha_num = mp.sqrt(2) + mp.sqrt(3) + mp.sqrt(5) + mp.sqrt(7)
+    print(f"       alpha ~= {alpha_num}")
+    check("8 < alpha", alpha_num > 8)
+    check("alpha < 9", alpha_num < 9)
+    # Margins are comfortable (alpha ~ 8.0281), so floating error is irrelevant;
+    # the strict inequalities also follow rigorously from, e.g.,
+    #   sqrt2>1.41, sqrt3>1.73, sqrt5>2.23, sqrt7>2.64  => sum > 8.01 > 8
+    #   sqrt2<1.42, sqrt3<1.74, sqrt5<2.24, sqrt7<2.65  => sum < 8.05 < 9
+    check("rational lower witnesses sum > 8",
+          sp.Rational(141, 100) + sp.Rational(173, 100)
+          + sp.Rational(223, 100) + sp.Rational(264, 100) > 8)
+    check("rational upper witnesses sum < 9",
+          sp.Rational(142, 100) + sp.Rational(174, 100)
+          + sp.Rational(224, 100) + sp.Rational(265, 100) < 9)
+    # And each witness genuinely bounds its radical:
+    for lo, hi, k in [(sp.Rational(141, 100), sp.Rational(142, 100), 2),
+                      (sp.Rational(173, 100), sp.Rational(174, 100), 3),
+                      (sp.Rational(223, 100), sp.Rational(224, 100), 5),
+                      (sp.Rational(264, 100), sp.Rational(265, 100), 7)]:
+        check(f"{lo} < sqrt {k}: lo^2 < {k}", lo**2 < k)
+        check(f"sqrt {k} < {hi}: {k} < hi^2", k < hi**2)
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Build-free ORIENT deepening for `Irrational (√2 + √3 + √5 + √7)` while both backends are down (Docker `docker ps` timeout; Aristotle MCP tools now load but `prove` returns "Resource not found").

- **Made Session 2's ephemeral sympy verification durable**: committed `verify_strategy_d.py` (sympy 1.14 / mpmath, runs in seconds, exits 0 on "ALL CHECKS PASSED"). It independently re-derives every load-bearing fact of Strategy D — *not* by trusting the numbers already in knowledge.md:
  - **(F1)** each `√k` is a root of the monic integer `x²−k` ⇒ `IsIntegral ℤ (√k)`;
  - **(F3)** re-derives α's degree-16 minimal polynomial as a resultant of two quartics, confirms it is monic/integer, matches the recorded value, has constant term `215²=46225`, and satisfies `m(α)=0`;
  - **(F2)** confirms the decisive bound `8 < α < 9` (α ≈ 8.0281, 60-digit).
- **Extracted the explicit ACT recipe for the bound lemmas** (the one non-API `sorry` step in Strategy D): rational witnesses `√2∈(1.41,1.42)`, `√3∈(1.73,1.74)`, `√5∈(2.23,2.24)`, `√7∈(2.64,2.65)`, each verified by squaring; Lean shape is `Real.lt_sqrt`/`Real.sqrt_lt'` + `norm_num` + `linarith`.
- Synced `state.md` to iteration 4 and recorded that Aristotle MCP loads but its backend is still unavailable.

No Lean file is committed: Strategy D is still build-gated, and committing an uncompilable `sorry`-skeleton would risk landing a broken file. The full skeleton lives in `knowledge.md`.

## Test plan
- [x] `python3 research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/verify_strategy_d.py` → "ALL CHECKS PASSED"
- [ ] When Docker/Aristotle returns: implement Strategy D (~60–100 LOC) per the now-de-risked skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)