### PR TITLE
Fix: clamp erdos-1012-oq-03 annotation range to file EOF

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-03/annotations.json
@@ -300,7 +300,7 @@
     "proofId": "erdos-1012-oq-03",
     "range": {
       "startLine": 1539,
-      "endLine": 1827
+      "endLine": 1781
     },
     "type": "insight",
     "title": "Part V: Arc Threshold via Probabilistic Counting",


### PR DESCRIPTION
## Fix

The `ann-1012-arc-threshold` annotation for `erdos-1012-oq-03` referenced source lines past the end of the Lean file.

## Evidence

**Before**: `ann-1012-arc-threshold` had `range.endLine = 1827`, but `proofs/Proofs/Erdos1012OQ03.lean` is only **1781 lines** (ends at `end Erdos1012OQ03`). Lines 1782–1827 do not exist — 46 phantom lines left over from an earlier, longer version of the file before its proof bodies were trimmed.

**After**: `endLine` clamped to `1781`. All 13 annotation ranges now map to real source lines (`theorem directed_hamiltonian_threshold` at 1720, the `## Proof Roadmap` docstring through 1774, `#check`s 1776–1779, `end` 1781). The other 12 annotations were already correct.

Validation: `jq empty` passes; max annotation `endLine` is now 1781 (== file LOC); no range exceeds EOF.

Build-free metadata fix (annotations only; no Lean source change).

---
Automated fix by lean-mechanic agent.