### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): S25 — durable witness verification (k=3..9)

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
@@ -2,7 +2,20 @@
 
 **Phase**: ACT (lower-bound coverage `k ∈ {3,4,5,6,7}` shipped; S8 now ACT-ready — params verified; S4 / S6 remain Docker-gated)
 **Since**: 2026-06-14 (S24 ORIENT-depth — S8 ACT-readiness, Python-verified witness `6399 = 24·256 + 255`, miss-by-1)
-**Iteration**: 24 (S24 — de-risk S8 paste-port ; researcher-1)
+**Iteration**: 25 (S25 — durable witness verification ; researcher-1)
+
+## S25 ORIENT-depth 2026-06-14 (researcher-1) — durable witness verification
+
+**Focus**: make the S24 (and earlier) Python witness arithmetic durable. Until now the
+witness checks (`N_k = 2^k·⌊(3/2)^k⌋−1`, the miss-by-1 calibration, `f_i ≤ 2` soundness
+via `3^k > N_k`) lived only in session transcripts. Committed runnable
+`verify_witnesses.py` (stdlib only, exits 0 on "ALL CHECKS PASSED") that re-derives every
+constant from the Mahler formula and checks, by the exact counting argument the Lean proofs
+use, that `N_k` is **infeasible with g(k)−1 summands** but **feasible (tight) with g(k)** —
+for `k = 3..9`. This covers all five shipped lower-bound files (k=3..7), the paste-port-ready
+S8 (k=8), and the k=9 look-ahead, and cross-checks each `g(k)` against the literature value.
+Build-free, both backends down (Docker `docker ps` timeout; Aristotle MCP loads but `prove`
+→ "Resource not found"). **No Lean built, no ACT shipped** — durable verification only.
 
 ## S24 ORIENT-depth 2026-06-14 (researcher-1)
 

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/verify_witnesses.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/verify_witnesses.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Reproducible verification of the Waring g(k) lower-bound witnesses behind
+
+    lagrange-four-squares-waring-g2-oq-01
+
+This slug ships, for each k, a Lean theorem of the shape
+
+    ¬ IsSumOfKthPowers (g(k) - 1) N_k          (the "miss by 1" lower bound)
+
+establishing g(k) ≥ <known value>, via the counting+omega template
+(bound f_i ≤ 2 → lift to Fin 3 → fiber-count → omega). The same witness
+arithmetic underpins all five shipped lower-bound files
+(Counting, CountingG4..G7 for k = 3..7), the paste-port-ready S8 (k = 8),
+and the k = 9 look-ahead.
+
+Until now those numbers were only verified inside session transcripts
+(ephemeral). This script makes them reproducible: it re-derives every
+constant from the Mahler formula and checks, by the exact counting argument
+the Lean proof uses, that N_k is infeasible with g(k)-1 summands but feasible
+with g(k). Run:
+
+    python3 verify_witnesses.py
+
+Exits 0 with "ALL CHECKS PASSED" iff every assertion holds.
+Pure standard library (no dependencies).
+
+Definitions
+-----------
+  q_k  = floor((3/2)^k)
+  N_k  = q_k * 2^k - 1            (the hardest number < 3^k to represent)
+  g(k) = 2^k + q_k - 2           (Mahler value; = known g(k) for k here)
+  s_k  = g(k) - 1                 (the term count the Lean theorem refutes)
+
+Soundness of "f_i ≤ 2": since N_k < 3^k, every k-th power summand is one of
+0^k, 1^k, 2^k. So a representation of N_k by s summands is exactly a triple
+(n0, n1, n2) of fiber sizes with
+
+  n0 + n1 + n2 = s        and        n1 + 2^k * n2 = N_k.
+
+The lower bound is the claim that this system is INFEASIBLE for s = s_k and
+FEASIBLE (tight) for s = g(k).
+"""
+
+from fractions import Fraction
+
+# Known values of g(k) (Niven 1936; Dickson/Pillai/Chen/etc.), for cross-check.
+KNOWN_G = {3: 9, 4: 19, 5: 37, 6: 73, 7: 143, 8: 279, 9: 548}
+
+
+def floor_three_halves_pow(k: int) -> int:
+    """Exact floor((3/2)^k) via integer arithmetic (3^k // 2^k)."""
+    return (3 ** k) // (2 ** k)
+
+
+def counting_feasible(s: int, k: int, N: int) -> bool:
+    """
+    True iff N is a sum of s k-th powers using bases in {0,1,2}, i.e. there
+    exist n0,n1,n2 >= 0 with n0+n1+n2 = s and n1 + 2^k*n2 = N.
+    This mirrors exactly the Lean `IsSumOfKthPowers s N` reduction (since
+    N < 3^k forces bases <= 2). Finite scan over n2.
+    """
+    twok = 2 ** k
+    for n2 in range(0, N // twok + 1):
+        rem = N - twok * n2          # must be covered by n1 ones
+        n1 = rem                     # one base-1 summand per unit
+        n0 = s - n1 - n2
+        if n1 >= 0 and n0 >= 0:
+            return True
+    return False
+
+
+def check(name, cond):
+    print(f"  [{'ok  ' if cond else 'FAIL'}] {name}")
+    assert cond, f"CHECK FAILED: {name}"
+
+
+def main():
+    for k in range(3, 10):
+        q = floor_three_halves_pow(k)
+        N = q * (2 ** k) - 1
+        g = (2 ** k) + q - 2
+        s = g - 1
+        print(f"== k = {k}:  q={q}  N={N}  g(k)={g}  s=g-1={s} ==")
+
+        # q_k is the floor, and STRICTLY below (3/2)^k (S6b audit: (3/2)^k is
+        # never an integer for k >= 1, so q < (3/2)^k strictly, which is what
+        # guarantees N_k = q·2^k + (2^k - 1) < 3^k).
+        check(f"q < (3/2)^{k} strictly", q < Fraction(3, 2) ** k)
+        check(f"q is the floor: q <= (3/2)^{k} < q+1",
+              q <= Fraction(3, 2) ** k < q + 1)
+
+        # Cross-check the Mahler value against the literature value.
+        if k in KNOWN_G:
+            check(f"g({k}) = {KNOWN_G[k]} (known)", g == KNOWN_G[k])
+
+        # Soundness of the f_i <= 2 reduction: N < 3^k.
+        check(f"N < 3^{k} (forces bases <= 2)", N < 3 ** k)
+
+        # The decisive pair: infeasible at s = g-1, feasible (tight) at s = g.
+        check(f"N NOT a sum of {s} = g-1 k-th powers (lower bound)",
+              not counting_feasible(s, k, N))
+        check(f"N IS a sum of {g} = g k-th powers (tightness)",
+              counting_feasible(g, k, N))
+
+        # Witness shape recorded in the session ledger: the optimal
+        # representation uses (q-1) twos and (2^k - 1) ones.
+        twos, ones = q - 1, (2 ** k) - 1
+        check(f"witness (q-1)·2^{k} + (2^{k}-1)·1 = N",
+              twos * (2 ** k) + ones * 1 == N)
+        check(f"witness term count (q-1)+(2^{k}-1) = g({k})",
+              twos + ones == g)
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Build-free ORIENT depth (both backends down: Docker `docker ps` timeout; Aristotle MCP loads but `prove` → "Resource not found"). No Lean built.

The Waring `g(k)` lower-bound witness arithmetic — `N_k = 2^k·⌊(3/2)^k⌋−1`, the "miss by 1" calibration, and the `f_i ≤ 2` soundness fact `3^k > N_k` — underpins all five shipped lower-bound Lean files (`Counting`, `CountingG4..G7` for k=3..7), the paste-port-ready S8 (k=8), and the k=9 look-ahead. Until now those numbers were only verified inside session transcripts (ephemeral).

This commits a runnable **`verify_witnesses.py`** (Python stdlib only, runs instantly, exits 0 on "ALL CHECKS PASSED") that, for `k = 3..9`:
- re-derives `q_k`, `N_k`, `g(k)`, `s_k = g(k)−1` from the Mahler formula;
- checks `q_k < (3/2)^k` strictly and `N_k < 3^k` (the bases-≤-2 soundness);
- runs the **exact counting argument the Lean proofs use** (fiber sizes `n0+n1+n2 = s`, `n1 + 2^k·n2 = N_k`) to confirm `N_k` is **infeasible with g(k)−1 summands** but **feasible (tight) with g(k)**;
- cross-checks each `g(k)` against the literature value.

Path-disjoint from the open cross-slug PR #22889 (which touches `CountingG7.lean` + the fourier slug, not this slug's research dir).

## Test plan
- [x] `python3 research/problems/lagrange-four-squares-waring-g2-oq-01/verify_witnesses.py` → "ALL CHECKS PASSED" (k=3..9)
- [ ] S8 ACT (`g(8) ≥ 279`) paste-port awaits Docker; S4/S6 await the Mechanic parent fix (B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)