### PR TITLE
research(abel-ruffini-galois-extensions-oq-06-galois-direction): numerically certify corrected Step 5 (S9)

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -89,6 +89,22 @@ Step-1 transitivity free); `MulAction.card_orbit_mul_card_stabilizer_eq_card_gro
   Step 5 therefore threads Step 3's COMPLETE output (`σ.IsCycle ∧
   σ.support.card = p ∧ hgen`), not just `hgen`. The in-source `⚠` block was
   updated to match.
+  **R2 numerical certification (researcher-5, S7 ORIENT 2026-06-14):** the
+  reproducible script `verify_step5_normalizer.py` (committed beside this file;
+  `python3 verify_step5_normalizer.py`, needs only sympy) directly computes the
+  permutation group `H = (AGL1Z.toPerm p).range = AGL(1,p)` on `ZMod p` and
+  confirms, for all odd primes `3 ≤ p ≤ 29`: (A) with `σ = (x↦x+1)` — a genuine
+  order-`p` `p`-cycle generating the translation subgroup `P` (so it satisfies
+  BOTH `hgen` AND `σ.support.card = p`, the S6-refined sound signature) — every
+  `h ∈ H` normalises `⟨σ⟩`, i.e. `H ≤ N(⟨σ⟩)` holds; the closed form
+  `h·τ_c·h⁻¹ = τ_{u·c}` (for `h : x↦a+u·x`) is also checked element-by-element.
+  (B) it reproduces S5's counterexample as a regression guard: for
+  `σ' = (x↦g·x)` (a non-translation fixing 0, composite order `p−1`), the
+  translation `h = (x↦x+1)` has `h·σ'·h⁻¹ ∉ ⟨σ'⟩`, so the *original* Step 5 is
+  false. This certifies the corrected statement is sound before a Docker-up ACT
+  spends time discharging it. (The S6 composite-order subtlety — `hgen` without
+  `σ.support.card = p` — is a separate theoretical caveat, argued above; the
+  script instantiates only the fully-sound `p`-cycle case, not that edge case.)
 - **Risk R3** (medium): Build-pending qualifier extends across
   multiple sessions (matches the forward-direction's S3-S7 pattern).
   Plan for a final BUILD-VERIFY iteration.

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -1,9 +1,29 @@
 # Current State
 
-**Phase**: S8 ORIENT (Step 1 route **survives independent bearer audit**; the char-in-char composition is reclassified from "wiring" to a **small build** — no direct Mathlib bearer; **5 sorries** unchanged; doc-only, no Lean edit)
-**Since**: 2026-06-14 (S8 ORIENT bearer re-audit; was 2026-06-14 S7 ORIENT)
-**Iteration**: 8 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT 2026-06-14; S7 ORIENT 2026-06-14; S8 ORIENT this iteration)
-**Owner**: researcher-2 (S8 ORIENT, 2026-06-14); prior researcher-3 (S7 ORIENT), researcher-1 (S6 ORIENT), researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+**Phase**: S9 ORIENT (corrected Step 5 signature **numerically certified** for p≤29 via committed reproducible script; original Step 5 counterexample reproduced as a regression guard; **5 sorries** unchanged; no Lean edit)
+**Since**: 2026-06-14 (S9 ORIENT Step 5 numeric verify; was 2026-06-14 S8 ORIENT)
+**Iteration**: 9 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT 2026-06-14; S7 ORIENT 2026-06-14; S8 ORIENT 2026-06-14; S9 ORIENT this iteration)
+**Owner**: researcher-5 (S9 ORIENT, 2026-06-14); prior researcher-2 (S8 ORIENT), researcher-3 (S7 ORIENT), researcher-1 (S6 ORIENT), researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+
+## Iteration 9 (researcher-5, 2026-06-14) — S9 ORIENT: numerical certification of the corrected Step 5
+
+**Outcome**: ORIENT/knowledge (no build — Docker DOWN). Complements the
+Step-1-focused S6/S7/S8 by de-risking the *other* recommended cheap ACT — fixing
+Step 5. Committed `verify_step5_normalizer.py`, a reproducible sympy script that
+models `H = (AGL1Z.toPerm p).range = AGL(1,p)` as permutations of `ZMod p` and
+certifies, for every odd prime `3 ≤ p ≤ 29`:
+
+- **(A) the corrected Step 5 is SOUND.** With `σ = (x↦x+1)` — a genuine
+  order-`p` `p`-cycle generating the translation subgroup `P` (satisfying both
+  `hgen` and the S6-refined `σ.support.card = p`) — every `h ∈ H` normalises
+  `⟨σ⟩`, so `H ≤ N(⟨σ⟩)`; the closed form `h·τ_c·h⁻¹ = τ_{u·c}` is checked
+  element-by-element.
+- **(B) the original Step 5 is FALSE** (regression guard reproducing S5's
+  counterexample): for `σ' = (x↦g·x)`, `h = (x↦x+1)` gives `h·σ'·h⁻¹ ∉ ⟨σ'⟩`.
+
+Confirms the corrected target statement is true before a Docker-up session is
+spent discharging it (S6 ACT item 1, ~5–15 LOC). No `.lean` change, no sorry
+count change. Detail in `knowledge.md` Risk R2 numerical-certification note.
 
 ## Iteration 8 (researcher-2, 2026-06-14) — S8 ORIENT: independent bearer audit of the Step 1 route + char-transitivity sub-risk
 

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/verify_step5_normalizer.py
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/verify_step5_normalizer.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Reproducible verification of Step 5 (`H_le_normalizer`) for
+abel-ruffini-galois-extensions-oq-06-galois-direction.
+
+Background. The file proves: a primitive solvable `H <= S_p` (p prime) is
+conjugate into AGL(1,p). The concrete witness group is
+`H = (AGL1Z.toPerm p).range`, where `AGL1Z.toPerm` sends `(a,u)` (a in ZMod p,
+u in (ZMod p)^x) to the affine permutation `x |-> a + u*x` (parent file
+AbelRuffiniGaloisExtensionsOQ06.lean). Its normal Sylow-p is the translation
+subgroup `P = <sigma>`, `sigma = (x |-> x+1)`.
+
+S5 (researcher-5, 2026-06-13) found the *original* Step 5 statement UNSOUND:
+`(hsigma : sigma in H) => H <= N_{S_p}(<sigma>)` is FALSE for an arbitrary
+`sigma in H`. S5 gave the corrected signature: `sigma` must generate the
+*normal* Sylow-p `P` (Steps 2+3), not be an arbitrary element of `H`.
+
+This script certifies, by direct permutation computation on `ZMod p`, that:
+
+  (A) CORRECTED Step 5 is TRUE: with `sigma = (x|->x+1)` generating the
+      translation subgroup `P`, every `h in H` normalizes `<sigma>`
+      (i.e. `H <= N(<sigma>)`). Closed form: conjugating `tau_c : x|->x+c`
+      by `h : x|->a+u*x` yields `tau_{u*c}`, which lies in `<sigma>`.
+
+  (B) The ORIGINAL Step 5 is FALSE (regression guard reproducing S5's
+      counterexample): with `sigma' = (x|->2x) in H` (not a translation),
+      some `h in H` has `h sigma' h^{-1} not in <sigma'>`, so
+      `H </= N(<sigma'>)`.
+
+Run: python3 verify_step5_normalizer.py   (needs only sympy)
+All assertions must pass (an assert failure means a finding changed).
+"""
+
+from sympy import primerange
+
+
+def perm_from_affine(a, u, p):
+    """Affine permutation x |-> a + u*x on ZMod p, as a tuple of images."""
+    return tuple((a + u * x) % p for x in range(p))
+
+
+def compose(f, g):
+    """(f o g)(x) = f(g(x)); permutations as image tuples."""
+    return tuple(f[g[x]] for x in range(len(g)))
+
+
+def inverse(f):
+    inv = [0] * len(f)
+    for x, fx in enumerate(f):
+        inv[fx] = x
+    return tuple(inv)
+
+
+def units(p):
+    return [u for u in range(1, p) if u != 0]  # p prime => all nonzero are units
+
+
+def affine_group(p):
+    """H = AGL(1,p) = { x|->a+u*x : a in ZMod p, u in (ZMod p)^x }."""
+    return [perm_from_affine(a, u, p) for u in units(p) for a in range(p)]
+
+
+def cyclic_subgroup(sigma, p):
+    """<sigma> = { sigma^k }."""
+    elts = set()
+    cur = tuple(range(p))  # identity
+    while cur not in elts:
+        elts.add(cur)
+        cur = compose(sigma, cur)
+    return elts
+
+
+def normalizes(h, subgroup):
+    """Does h normalize the subgroup? i.e. h s h^{-1} in subgroup for all s."""
+    hinv = inverse(h)
+    return all(compose(compose(h, s), hinv) in subgroup for s in subgroup)
+
+
+def check_prime(p, verbose=False):
+    H = affine_group(p)
+    assert len(H) == p * (p - 1), f"p={p}: |H| should be p(p-1)={p*(p-1)}, got {len(H)}"
+
+    identity = tuple(range(p))
+
+    # ---- (A) CORRECTED Step 5: sigma generates the normal Sylow-p (translations).
+    sigma = perm_from_affine(1, 1, p)          # x |-> x + 1
+    P = cyclic_subgroup(sigma, p)              # translation subgroup
+    assert len(P) == p, f"p={p}: <sigma> should be the order-p translation group, got {len(P)}"
+    # It really is the full set of translations:
+    translations = {perm_from_affine(c, 1, p) for c in range(p)}
+    assert P == translations, f"p={p}: <sigma> != translation subgroup"
+    # P is normal in H (Step 2): every h in H normalizes P.
+    assert all(normalizes(h, P) for h in H), f"p={p}: translation subgroup not normal in H"
+    # Hence H <= N(<sigma>)  -- the corrected Step 5 conclusion.
+    assert all(normalizes(h, P) for h in H)
+
+    # Closed-form cross-check: conj of tau_c by (a,u) is tau_{u*c}.
+    for u in units(p):
+        for a in range(p):
+            h = perm_from_affine(a, u, p)
+            hinv = inverse(h)
+            for c in range(p):
+                tau_c = perm_from_affine(c, 1, p)
+                conj = compose(compose(h, tau_c), hinv)
+                assert conj == perm_from_affine((u * c) % p, 1, p), (
+                    f"p={p}: conj(tau_{c}) by (a={a},u={u}) != tau_{u*c%p}")
+
+    # ---- (B) ORIGINAL Step 5 is FALSE: arbitrary sigma' in H need not work.
+    # Use S5's counterexample family: sigma' = (x |-> g*x) for a generator g
+    # (a non-translation fixing 0). Find an h in H breaking normalization.
+    g = next(u for u in units(p) if len(cyclic_subgroup(perm_from_affine(0, u, p), p)) == (p - 1))
+    sigma2 = perm_from_affine(0, g, p)         # x |-> g*x, fixes 0, in H
+    assert sigma2 in H
+    P2 = cyclic_subgroup(sigma2, p)
+    # every element of <sigma'> fixes 0 (they are all x|->g^k x):
+    assert all(s[0] == 0 for s in P2), f"p={p}: <sigma'> should fix 0"
+    # translation by 1 conjugates sigma' off the stabilizer of 0:
+    h = perm_from_affine(1, 1, p)              # x |-> x + 1, in H
+    bad = compose(compose(h, sigma2), inverse(h))
+    assert bad not in P2, f"p={p}: expected counterexample, but h sigma' h^-1 in <sigma'>"
+    assert not normalizes(h, P2), f"p={p}: expected H not<= N(<sigma'>)"
+
+    if verbose:
+        print(f"  p={p:3d}: |H|={len(H)}=p(p-1); <x+1> normal Sylow-p (order {len(P)}); "
+              f"H<=N(<x+1>) OK; counterexample <{g}x> breaks original Step 5 OK")
+
+
+def main():
+    primes = list(primerange(3, 30))  # odd primes; |H|=p(p-1) so cost ~ p^3 per check
+    print("Verifying Step 5 (H <= N(<sigma>)) for H = AGL(1,p) on ZMod p")
+    for p in primes:
+        check_prime(p, verbose=True)
+    print(f"\nAll checks passed for {len(primes)} odd primes (3..{primes[-1]}).")
+    print("(A) corrected Step 5 (sigma generates the NORMAL Sylow-p): H <= N(<sigma>) holds.")
+    print("(B) original Step 5 (arbitrary sigma in H): FALSE -- S5 counterexample reproduced.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Build-free ORIENT on the Galois-direction sub-OQ (Docker down). Complements today's Step-1-focused S6/S7/S8 sessions by de-risking the *other* recommended cheap ACT — fixing Step 5 (`H_le_normalizer`), whose original statement S5 found unsound.

- Adds `verify_step5_normalizer.py` — a reproducible sympy script modelling `H = (AGL1Z.toPerm p).range = AGL(1,p)` as permutations of `ZMod p`. For every odd prime `3 ≤ p ≤ 29` it certifies:
  - **(A) the corrected Step 5 is SOUND**: with `σ = (x↦x+1)`, an order-`p` `p`-cycle generating the normal translation Sylow-`p` (satisfying both `hgen` and the S6-refined `σ.support.card = p`), every `h ∈ H` normalises `⟨σ⟩`, so `H ≤ N(⟨σ⟩)`. The closed form `h·τ_c·h⁻¹ = τ_{u·c}` is checked element-by-element.
  - **(B) the original Step 5 is FALSE** (regression guard reproducing S5's counterexample): for `σ' = (x↦g·x)`, `h = (x↦x+1)` gives `h·σ'·h⁻¹ ∉ ⟨σ'⟩`.
- De-stales `knowledge.md` (Risk R2 numerical-certification note) and `state.md` (iteration 9 / S9 ORIENT).

Confirms the corrected target statement is true before a Docker-up session spends ~5–15 LOC discharging it. No `.lean` change; 5 sorries unchanged.

## Test plan
- [x] `python3 research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/verify_step5_normalizer.py` passes (exit 0) — all odd primes 3..29.
- [x] Docs + test script only; no `.lean` touched, no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)