### PR TITLE
Enrich Erdős #530 (Sidon finite sets): link structured special cases

### DIFF
--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -178,6 +178,16 @@
       "targetId": "erdos-53",
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: additive combinatorics, number theory"
+    },
+    {
+      "proofId": "erdos-773",
+      "relationship": "specialized-by",
+      "description": "A concrete special case: Erdős #773 asks for the maximum Sidon subset of the perfect squares {1²,…,N²}. Where #530 establishes ℓ(N) ∼ N^{1/2} for an arbitrary N-element set, restricting the ambient set to squares lifts the extremal size well above √N — to between N^{2/3} (Lefmann–Thiele) and N/(log N)^{1/4} (Alon–Erdős) — showing how additive structure of the ground set can break the generic bound."
+    },
+    {
+      "proofId": "erdos-1206",
+      "relationship": "specialized-by",
+      "description": "Another special case over a structured ground set: Erdős #1206 concerns Sidon subsets of the cubes {1³,…,N³}. As with #773 (squares), the arithmetic of the ambient set governs the answer; the cube case was solved in the short-interval regime (Gabdullin–Konyagin 2024, size ≫N^{1/2}), again exceeding what the generic #530 bound predicts for an unstructured N-element set."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-530` (Maximum Sidon Subsets of Finite Sets), quality-100 but with generic auto-generated cross-references. Adds reciprocal links to the two structured-ground-set special cases that were previously unlinked, completing the Sidon-family cross-link cluster (#530 ↔ #773 ↔ #1206):

- **erdos-773** (`specialized-by`) — Sidon subsets of perfect squares {1²,…,N²}. Restricting #530's arbitrary ground set to squares lifts the extremal size from the generic ℓ(N)∼√N to between N^{2/3} and N/(log N)^{1/4}.
- **erdos-1206** (`specialized-by`) — Sidon subsets of cubes {1³,…,N³}, solved in the short-interval regime (Gabdullin–Konyagin 2024).

Both targets exist in the gallery and are direct specializations of the general #530 problem.

## Verification
- JSON validated (`node` parse); crossReferences now 5, all targets confirmed present in gallery.
- meta.json only; no Lean/axiom changes (status `axiomatized`, axiomCount 2 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)