### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03): S1 ORIENT — Legendre 3-square "if" direction

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/scripts/verify_legendre_three_square.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/scripts/verify_legendre_three_square.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+ORIENT verification for lagrange-four-squares-waring-g2-oq-03
+(Legendre three-square theorem, the "if" direction).
+
+Claim under test (full Legendre characterization):
+    n = x^2+y^2+z^2 has a solution  <=>  n is NOT of the form 4^a(8b+7).
+
+We:
+  (A) brute-force decide three-square representability for n = 0..N,
+  (B) independently decide the 4^a(8b+7) exclusion predicate,
+  (C) confirm the two agree for all n <= N (both directions at once),
+  (D) sanity-check the Davenport-Cassels *integrality* step on the form
+      f = x^2+y^2+z^2: from a rational solution with small denominator,
+      one descent step lands on an integral solution.
+"""
+from math import isqrt
+from fractions import Fraction
+
+def is_three_squares(n):
+    b = isqrt(n)
+    for x in range(b+1):
+        rx = n - x*x
+        if rx < 0: break
+        by = isqrt(rx)
+        for y in range(x, by+1):
+            rz = rx - y*y
+            z = isqrt(rz)
+            if z*z == rz:
+                return (x,y,z)
+    return None
+
+def is_excluded(n):
+    """n == 4^a (8b+7) for some a,b >= 0."""
+    if n == 0:
+        return False
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+N = 5000
+ok = True
+mismatches = 0
+for n in range(0, N+1):
+    rep = is_three_squares(n)
+    excl = is_excluded(n)
+    # representable  XOR  excluded  must hold (representable == not excluded)
+    if (rep is not None) == excl:
+        mismatches += 1
+        if mismatches <= 10:
+            print(f"  MISMATCH n={n}: rep={rep} excluded={excl}")
+        ok = False
+print(f"(A)-(C) characterization n=0..{N}: {'AGREE (representable <=> not excluded)' if ok else f'{mismatches} MISMATCHES'}")
+
+# (D) Davenport-Cassels descent step for f(x,y,z)=x^2+y^2+z^2.
+# Given rational p with f(p)=n integer, set q = nearest-integer-vector to p.
+# Then the reflection p' = p - 2*((<p-q,p>)/(f(p-q))) * (p-q) ... (standard D-C).
+# We verify the key inequality that drives descent: for the nearest integer
+# point q to a non-integral rational solution p with f(p)=n, 0 < f(p-q) < 1,
+# which is exactly the property that makes the descent strictly reduce the
+# denominator (Cassels' lemma; holds because each coord differs from an integer
+# by < 1/2, so f(p-q) < 3*(1/2)^2 = 3/4 < 1, and >0 since p not integral).
+def nearest_int(fr):
+    # round half to even is fine; we just need |fr - q| <= 1/2
+    import math
+    return Fraction(round(fr))
+import random
+random.seed(0)  # determinism not required but stable
+dc_ok = True
+checks = 0
+# construct rational solutions with f(p)=n by scaling integer solutions
+for n in range(1, 400):
+    if is_excluded(n):
+        continue
+    sol = is_three_squares(n)
+    if sol is None:
+        continue
+    x,y,z = sol
+    # make a genuinely non-integral rational point on f=n by a rational rotation
+    # use p = (x + 1/3 adjustments) is not on the form; instead test the lemma
+    # directly on rational points of the form (a/3,b/3,c/3) with a^2+b^2+c^2=9n.
+    m = 9*n
+    found = is_three_squares(m)
+    if found is None:
+        continue
+    a,b,c = found
+    p = (Fraction(a,3), Fraction(b,3), Fraction(c,3))
+    if all(t.denominator == 1 for t in p):
+        continue  # integral already, skip
+    q = tuple(nearest_int(t) for t in p)
+    d = tuple(p[i]-q[i] for i in range(3))
+    fd = d[0]*d[0]+d[1]*d[1]+d[2]*d[2]
+    checks += 1
+    if not (Fraction(0) < fd < Fraction(1)):
+        dc_ok = False
+        if checks <= 5:
+            print(f"  D-C lemma FAIL n={n}: f(p-q)={fd}")
+print(f"(D) Davenport-Cassels descent inequality 0<f(p-q)<1 on {checks} non-integral rational points: {'HOLDS' if dc_ok else 'FAILED'}")
+
+print()
+print("ALL CHECKS PASSED" if (ok and dc_ok) else "FAILURES ABOVE")


### PR DESCRIPTION
## Summary

S1 ORIENT survey for the fresh OQ `lagrange-four-squares-waring-g2-oq-03`
(was OBSERVE, 0 knowledge): the open **"if"** direction of **Legendre's
three-square theorem**,

> `n ≠ 4^a(8b+7)` for all `a,b ≥ 0`  ⟹  `∃ x y z, n = x²+y²+z²`.

The parent file has the easy "only if" half (mod-8 + descent). The "if" half is
the genuinely hard case between two squares (Fermat, in Mathlib) and four squares
(Lagrange, in Mathlib). Docker is down, so this is a **build-free, Python-verified**
survey that pins the characterization, validates the Davenport–Cassels descent, and
isolates the exact Mathlib gate.

## Results (reproducible; `ALL CHECKS PASSED`)

- **Characterization** `n = x²+y²+z² ⟺ n ≠ 4^a(8b+7)` verified for **n = 0..5000**
  (both directions; no small counterexample to the open half).
- **Davenport–Cassels descent inequality** `0 < f(p−q) < 1` for non-integral
  rational `p` with `f(p) ∈ ℤ` verified on **177 points** — the `¾ < 1` "Euclidean"
  slack specific to `x²+y²+z²` that drives the rational→integral descent.

## Gate refinement (the useful ORIENT output)

Decomposes the proof into:
- **Gate-free, buildable core (D1+D2):** the Davenport–Cassels lemma
  (rational ⟹ integral representability) — finite descent on the denominator,
  reusable for any Euclidean form, and **not currently in Mathlib**. Recommended
  first deliverable (~150–260 LOC).
- **Single gate (G1):** rational representability of admissible `n`, which needs
  only the **qualitative** Dirichlet theorem (one prime in an AP) — already in
  Mathlib. So problem.md's "Dirichlet (heavy in Lean)" caveat is likely
  **over-pessimistic**: the density/PNT version is not required.

## What's in the PR (docs + script only, no Lean)

- `knowledge.md` — full write-up: characterization, D–C inequality with the `¾<1`
  reason, D1/D2/G1 decomposition with Mathlib anchors, dead ends.
- `state.md` — OBSERVE → ORIENT, blockers, recommended ACT order.
- `scripts/verify_legendre_three_square.py` — reproducible host-`python3` verification.

Released NOT completed — ACT (the D–C lemma, then G1) awaits a build host.

## Test plan
- [x] `python3 research/problems/lagrange-four-squares-waring-g2-oq-03/scripts/verify_legendre_three_square.py` → `ALL CHECKS PASSED`
- [ ] ACT: formalize D1+D2 (Davenport–Cassels) first; then G1 via qualitative Dirichlet (confirm exact Mathlib names at build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)