### PR TITLE
research(sperner-mathlib4-oq-02): S1 ORIENT — Tucker's lemma from abstract door-counting

### DIFF
--- a/research/problems/sperner-mathlib4-oq-02/scripts/verify_tucker.py
+++ b/research/problems/sperner-mathlib4-oq-02/scripts/verify_tucker.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+ORIENT verification for sperner-mathlib4-oq-02 (Tucker's lemma).
+
+Tucker's lemma: for an antipodally-symmetric triangulation of B^n with a labelling
+λ: V → {±1,...,±n} that is antipodal on the boundary (λ(-v) = -λ(v) for v ∈ ∂B^n),
+some edge {u,v} is COMPLEMENTARY: λ(u) = -λ(v).
+
+We verify by EXHAUSTIVE search over all admissible labellings that no labelling
+avoids a complementary edge, on two concrete antipodally-symmetric triangulations:
+  n = 1 : interval [-1,1] with 2m+1 vertices (antipodal endpoints).
+  n = 2 : hexagonal disk (6 boundary vertices in 3 antipodal pairs) + center.
+"""
+from itertools import product
+
+def has_complementary_edge(lab, edges):
+    return any(lab[u] == -lab[v] for (u,v) in edges)
+
+# ---------- n = 1 : path -m..m, boundary = {-m, m}, antipodal ----------
+def verify_n1(m):
+    verts = list(range(-m, m+1))            # 2m+1 vertices on the segment
+    edges = [(i, i+1) for i in range(-m, m)]
+    labels = [1, -1]                        # {±1}
+    interior = [v for v in verts if v not in (-m, m)]
+    total = checked = 0
+    # boundary antipodal: λ(m) = -λ(-m). choose λ(-m) freely.
+    for lneg in labels:
+        lpos = -lneg
+        for interior_vals in product(labels, repeat=len(interior)):
+            lab = {-m: lneg, m: lpos}
+            for v, val in zip(interior, interior_vals):
+                lab[v] = val
+            total += 1
+            if has_complementary_edge(lab, edges):
+                checked += 1
+    return total, checked
+
+# ---------- n = 2 : hexagon v0..v5 (v_{i+3} = -v_i) + center c ----------
+def verify_n2():
+    # boundary vertices 0..5, center = 6. antipodal pairing i <-> i+3.
+    hex_edges = [(i, (i+1)%6) for i in range(6)]      # boundary cycle
+    spokes    = [(6, i) for i in range(6)]            # center to each boundary
+    edges = hex_edges + spokes
+    labels = [1, -1, 2, -2]                           # {±1, ±2}
+    total = good = 0
+    bad_examples = []
+    # antipodal on boundary: λ(i+3) = -λ(i). choose λ(0),λ(1),λ(2) freely; center free.
+    for l0, l1, l2, lc in product(labels, repeat=4):
+        lab = {0:l0, 1:l1, 2:l2, 3:-l0, 4:-l1, 5:-l2, 6:lc}
+        total += 1
+        if has_complementary_edge(lab, edges):
+            good += 1
+        else:
+            bad_examples.append(dict(lab))
+    return total, good, bad_examples
+
+ok = True
+for m in (1, 2, 3, 5):
+    tot, chk = verify_n1(m)
+    status = "OK" if chk == tot else "FAIL"
+    if chk != tot: ok = False
+    print(f"n=1, segment 2m+1={2*m+1} verts: {chk}/{tot} labellings have a complementary edge  [{status}]")
+
+tot, good, bad = verify_n2()
+status = "OK" if good == tot else f"FAIL ({len(bad)} counterexamples)"
+if good != tot: ok = False
+print(f"n=2, hexagon+center (7 verts): {good}/{tot} labellings have a complementary edge  [{status}]")
+if bad:
+    print("  first counterexample labelling:", bad[0])
+
+print()
+print("ALL CHECKS PASSED — no admissible labelling avoids a complementary edge" if ok
+      else "FAILURES ABOVE (model too coarse or edge set wrong — investigate)")


### PR DESCRIPTION
## Summary

S1 ORIENT survey for the fresh OQ `sperner-mathlib4-oq-02` (was OBSERVE, 0
knowledge): can the parent's **abstract door-counting parity engine**
(`SpernerMathlib4.lean`) be extended from Sperner's lemma to **Tucker's lemma**
(the antipodal analogue, combinatorial heart of **Borsuk–Ulam**)? Docker is down,
so this is a **build-free, exhaustively-verified** survey.

## Results (reproducible; `ALL CHECKS PASSED`)

- **Tucker verified exhaustively** — no admissible labelling avoids a complementary
  edge:
  - n=1 segments (3/5/7/11 vertices): all labellings (1-D Tucker = discrete IVT).
  - n=2 hexagon+center: all **256** labellings, even on the coarsest symmetric
    triangulation.

## Answer to the OQ's premise: YES (strong evidence)

The antipodal extension **reuses the parent's existing engines** rather than
reinventing the parity argument:
- `door_count_parity` (SpernerMathlib4.lean:386) — the core parity lemma;
- `Finset.even_card_of_fpf_invol` (:60) — fixed-point-free involution lemma.

Add a ℤ/2 antipodal involution `σ`; the antipodal boundary condition makes boundary
complementary-doors σ-pair ⟹ **even** boundary count ⟹ an interior complementary
edge is forced. So the framework *is* general enough.

## Decomposition

- **Gate-free, buildable (T1–T3):** antipodal `CellComplex` + σ, antipodal door
  parity, Tucker's complementary-edge existence. Directly reuses the two parent
  lemmas. Recommended first deliverable (~180–350 LOC). First milestone: Tucker for
  a fixed antipodal triangulation.
- **Analytic gate (G1):** Tucker ⇒ Borsuk–Ulam (mesh→0 + compactness). Best wired
  to an existing `borsuk-ulam-*` gallery entry rather than reproved.

## What's in the PR (docs + script only, no Lean)

- `knowledge.md` — verification, the σ-involution route with parent line refs,
  T1–T3/G1 decomposition, dead ends (ℝPⁿ-quotient route rejected).
- `state.md` — OBSERVE → ORIENT, blockers, recommended ACT order.
- `scripts/verify_tucker.py` — reproducible host-`python3` exhaustive verification.

Released NOT completed — ACT (combinatorial Tucker, then the BU corollary) awaits a build host.

## Test plan
- [x] `python3 research/problems/sperner-mathlib4-oq-02/scripts/verify_tucker.py` → `ALL CHECKS PASSED`
- [ ] ACT: formalize T1–T3 reusing `door_count_parity` + `even_card_of_fpf_invol`; then G1 via existing Borsuk–Ulam (confirm exact names at build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)