### PR TITLE
Enrich Infinitely Many Primes ≡ 3 (mod 4): fix backwards cross-reference

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -129,8 +129,8 @@
     },
     {
       "targetId": "dirichlets-theorem-oq-02-oq-01",
-      "relationship": "parent",
-      "description": "Parent entry for the GRH sub-question about Dirichlet L-functions"
+      "relationship": "child",
+      "description": "A deeper sub-question nested under this entry: the Generalized Riemann Hypothesis for Dirichlet L-functions pursues the full analytic theory (L(s,χ) zeros, effective PNT for progressions, Linnik bounds) that this elementary special case deliberately bypasses"
     },
     {
       "targetId": "prime-number-theorem",


### PR DESCRIPTION
## Enrichment pass for `dirichlets-theorem-oq-02`

This entry is already saturated (quality score 98): all 6 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, the overview has a rich `historicalContext` and 5 `keyInsights`, and the conclusion has implications plus open questions. The Lean source is genuinely `verified` (0 sorries, 0 axioms, no structure-encoded assumptions) — confirmed against `Proofs/DirichletsTheoremOQ02.lean`.

### Fix
Cross-reference reconciliation found one genuine error. The cross-ref to `dirichlets-theorem-oq-02-oq-01` ("Generalized Riemann Hypothesis for Dirichlet L-functions") was labeled `relationship: "parent"`, but that slug is a **deeper sub-question nested under this entry** — a child, not a parent. The description ("Parent entry for the GRH sub-question…") was also muddled about the direction.

- `relationship`: `"parent"` → `"child"`
- Rewrote the description to accurately state that the GRH sub-question pursues the full analytic theory (L(s,χ) zeros, effective PNT for progressions, Linnik bounds) that this elementary special case deliberately bypasses.

All 5 cross-reference targets verified to exist in the gallery. `pnpm build` passes; JSON validated.