### PR TITLE
Fix: realign derangements-convergence annotation ranges to source

### DIFF
--- a/src/data/proofs/derangements-convergence/annotations.json
+++ b/src/data/proofs/derangements-convergence/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-derang-conv-identity",
     "proofId": "derangements-convergence",
-    "range": { "startLine": 56, "endLine": 75 },
+    "range": { "startLine": 54, "endLine": 77 },
     "type": "insight",
     "title": "The Bridge Theorem: D(n) = n! · altFactPartialSum(n) via Strong Induction",
     "content": "The theorem `numDerangements_eq_factorial_mul_altSum` is the crucial algebraic bridge connecting combinatorics and analysis. It proves D(n) = n! · ∑_{k=0}^n (-1)^k/k! by strong induction, matching the recurrence `numDerangements_add_two : D(n+2) = (n+1)(D(n+1) + D(n))` to the telescoping recurrence `altFactPartialSum_succ`.\n\nThe three-case structure in the induction: base cases n=0 (D(0)=1=0!·1, proved by simp) and n=1 (D(1)=0=1!·(1-1), proved by simp + ring) are trivial. The inductive step n+2 applies both IHs at n and n+1, uses `numDerangements_add_two` and `altFactPartialSum_succ` twice, then closes with `push_cast` (to lift ℕ casts to ℝ) followed by `ring` — the recurrence identity is purely algebraic once the IHs are substituted.\n\nThe companion theorem `derangements_div_factorial` divides by n! via `field_simp` to give D(n)/n! = altFactPartialSum(n), the form directly used in the convergence proof.",
@@ -14,7 +14,7 @@
   {
     "id": "ann-derang-conv-tsum",
     "proofId": "derangements-convergence",
-    "range": { "startLine": 86, "endLine": 116 },
+    "range": { "startLine": 78, "endLine": 104 },
     "type": "insight",
     "title": "Linking e⁻¹ to the Alternating Series via NormedSpace.exp_eq_tsum",
     "content": "The theorem `exp_neg_one_eq_tsum_alt` proves that e⁻¹ (represented as `rexp (-1)` in Mathlib) equals the infinite alternating series ∑' k, altFactTerm k. The proof uses two steps: (1) identify `rexp (-1)` with `NormedSpace.exp ℝ (-1 : ℝ)` via `Real.exp_eq_exp_ℝ`, then (2) apply `NormedSpace.exp_eq_tsum` which states exp x = ∑' k, x^k/k!. At x = -1, this gives ∑' k, (-1)^k/k! = ∑' k, altFactTerm k (after a `ring` normalization).\n\nThe companion `tsum_eq_partial_sum_add_tail` is the key technical infrastructure for the error bound. It splits the infinite series into the partial sum plus a tail: ∑' k, altFactTerm k = altFactPartialSum n + ∑' k, altFactTerm (n+1+k). The proof uses `hasSum_compl_iff` (which expresses the sum over the complement of `range(n+1)`) combined with an injection from ℕ into that complement via k ↦ n+1+k. The injection is surjective onto the complement by the omega tactic.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-derang-conv-nonneg",
     "proofId": "derangements-convergence",
-    "range": { "startLine": 120, "endLine": 208 },
+    "range": { "startLine": 105, "endLine": 198 },
     "type": "insight",
     "title": "Parity-Splitting Strong Induction: The Alternating Series Auxiliary Lemmas",
     "content": "The two auxiliary lemmas `alt_partial_sum_nonneg` and `alt_partial_sum_le_first` prove that finite alternating sums ∑_{k<N} (-1)^k/(m+k)! are bounded: 0 ≤ ∑ ≤ 1/m!. Both use strong induction with three cases: N=0, N=1, N'+2.\n\nThe N'+2 case requires parity analysis on N'. When N' is even (N'=2k): the pair of terms at positions 2k and 2k+1 contributes non-negatively (since 1/(m+2k)! ≥ 1/(m+2k+1)!), so the sum is ≥ 0 by the inductive hypothesis for N'. When N' is odd (N'=2k+1): the pair at 2k and 2k+1 is still non-negative, and there's an additional non-negative term at 2k+2, giving non-negativity.\n\nFor `alt_partial_sum_le_first`, the structure is similar but mirrored: when N' is even, the N'+1 term (which is negative) pushes the sum below the inductive bound; when N' is odd, the pair at 2k+1 and 2k+2 is non-positive, so the sum is ≤ the bound from the IH at 2k+1.\n\nThe factorial monotonicity `Nat.factorial_le (by omega)` is the key arithmetic lemma used in both inductive steps to compare adjacent terms.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-derang-conv-tail",
     "proofId": "derangements-convergence",
-    "range": { "startLine": 210, "endLine": 242 },
+    "range": { "startLine": 199, "endLine": 232 },
     "type": "insight",
     "title": "Alternating Tail Bound: Passing from Finite Partial Sums to the Infinite Series",
     "content": "The theorem `alternating_tail_bound` proves |∑' k, altFactTerm (n+1+k)| ≤ 1/(n+1)! by passing the finite partial sum bounds through the limit.\n\nKey steps: (1) Set m = n+1, factor out (-1)^m via `tsum_mul_left`: ∑' k, altFactTerm(m+k) = (-1)^m · ∑' k, c k where c k = (-1)^k/(m+k)!. (2) Simplify |(-1)^m| = 1 via `abs_pow, abs_neg, abs_one`. (3) Prove c summable by comparison to 1/(m+k)! using `Summable.comp_injective`. (4) The lower bound 0 ≤ ∑' k, c k follows by `le_of_tendsto_of_tendsto`: the partial sums of c are ≥ 0 (by `alt_partial_sum_nonneg`), and the partial sums converge to ∑' c by `Summable.hasSum.tendsto_sum_nat`. (5) The upper bound ∑' k, c k ≤ 1/m! follows by `le_of_tendsto`: partial sums are ≤ 1/m! (by `alt_partial_sum_le_first`), and again the partial sums converge to ∑' c. (6) Combine: 0 ≤ ∑' c ≤ 1/m!, so |∑' c| = ∑' c ≤ 1/m!.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-derang-conv-main",
     "proofId": "derangements-convergence",
-    "range": { "startLine": 246, "endLine": 283 },
+    "range": { "startLine": 233, "endLine": 272 },
     "type": "insight",
     "title": "Convergence Rate and Tendency: Composing the Full Proof Chain",
     "content": "The theorem `derangements_convergence_rate` is proved in 4 lines by composing all preceding results: rw [derangements_div_factorial] (replace D(n)/n! by altFactPartialSum), rw [exp_neg_one_eq_tsum_alt] (replace e⁻¹ by ∑' altFactTerm), rw [tsum_eq_partial_sum_add_tail] (split into partial sum + tail), then algebraic simplification (the difference is exactly the tail) and abs_neg closes with alternating_tail_bound.\n\nThe theorem `derangements_tendsto_inv_e` proves convergence via `Metric.tendsto_atTop`: given ε > 0, find N such that 1/(N+1)! < ε. This uses the fact that |altFactTerm(n+1)| = 1/(n+1)! → 0 (as a term of the convergent series altFactTerm), and `summable_altFactTerm.tendsto_atTop_zero.comp (tendsto_add_atTop_nat 1)` extracts this convergence. The existential N is then used: for n ≥ N, the bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! ≤ 1/(N+1)! < ε via factorial monotonicity.\n\nThe calc block in derangements_tendsto_inv_e is the cleanest expression of the full argument: bound by convergence_rate, bound by factorial monotonicity, bound by the ε-neighborhood.",


### PR DESCRIPTION
## Fix

The 5 annotations in `derangements-convergence` were uniformly drifted downward (content was deleted above them), leaving the final annotation's range pointing past end-of-file.

## Evidence

**Before** (file is 272 lines):
- `ann-derang-conv-identity` 56-75
- `ann-derang-conv-tsum` 86-116
- `ann-derang-conv-nonneg` 120-208
- `ann-derang-conv-tail` 210-242
- `ann-derang-conv-main` 246-**283** ← overshoots EOF by 11 lines

**After** — realigned to declaration/section boundaries (`/- ## ... -/` headers at 54/78/105/233), contiguous with no gaps, final range ends exactly at file EOF (272):
- `ann-derang-conv-identity` 54-77 (derangement-factorial identity block)
- `ann-derang-conv-tsum` 78-104 (summability + exponential series)
- `ann-derang-conv-nonneg` 105-198 (alternating-series auxiliary lemmas)
- `ann-derang-conv-tail` 199-232 (`alternating_tail_bound`)
- `ann-derang-conv-main` 233-272 (`derangements_convergence_rate`, `derangements_tendsto_inv_e`)

Annotation titles continue to match the content at their new ranges. No Lean source changed.

---
Automated fix by lean-mechanic agent.