### PR TITLE
research(sperner-mathlib4-oq-02): ORIENT — Tucker engine-reusability assessment

### DIFF
--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -1,21 +1,122 @@
 # Knowledge Base: sperner-mathlib4-oq-02
 
-Insights accumulated during research on this problem.
+Tucker's lemma (and Borsuk–Ulam) from the parent's abstract door-counting engine.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Parent `sperner-mathlib4` (`proofs/Proofs/SpernerMathlib4.lean`, 732 LOC, GREEN)
+proves Sperner's lemma abstractly:
+
+- `CellComplex V d`: `Cell` type, `vertex : Cell → Fin (d+1) → V`,
+  `adj : Cell → Fin (d+1) → Option (Cell × Fin (d+1))` with symmetry /
+  shared-face / distinctness axioms.
+- `IsPanchromatic c K s`  := `c ∘ vertex s` surjective onto `Fin (d+1)`.
+- `IsDoor c K s k`        := dropping vertex `k`, the other `d` vertices realize
+  all colors `{0,…,d-1}`.
+- `door_count_parity`: a coloring `f : Fin (d+1) → Fin (d+1)` has door count ≡ 1
+  (mod 2) iff `f` is surjective, else 0.
+- `sperner_parity`: `#panchromatic ≡ #boundary-doors (mod 2)`.
+- `sperner`: odd boundary doors ⟹ a panchromatic cell exists.
+
+The OQ asks: does this engine extend to **Tucker's lemma** — antipodally
+symmetric triangulation of `Bⁿ`, labelling `λ : V → {±1,…,±n}` antipodal on the
+boundary (`λ(-v) = -λ(v)`), conclusion: some edge is **complementary**
+(`λ(u) = -λ(v)`)? Tucker ⟹ Borsuk–Ulam.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Insight 1 — the parent engine is hard-wired to the Sperner target
+`door_count_parity`, `IsPanchromatic`, `IsDoor` are all stated over an *unsigned*
+color alphabet `Fin (d+1)` with the conclusion "a `d`-cell sees all `d+1` colors".
+Tucker's alphabet is *signed* with `2n` labels `{±1,…,±n}` and its conclusion is a
+**1-dimensional** object (a complementary edge), not a full-dimensional
+panchromatic cell. There is no black-box specialization of `CellComplex.sperner`
+that yields Tucker — the *target object has the wrong arity and the wrong
+algebraic structure*. (Engine-divergence probe, n=2 hexagon: 40 antipodal
+labellings have a complementary edge but no "rainbow-signed" triangle — the two
+conclusions are not interchangeable.)
+
+### Insight 2 — n=1 Tucker IS a direct door-count corollary (PORTABLE)
+Exhaustive check of `B¹ = [-m,m]` (3,5,7 vertices; labels `{+1,-1}`; antipodal
+endpoints `λ(m) = -λ(-m)`, interior free): the **complementary-edge count is
+ALWAYS ODD** (distributions `{1:4}`, `{1:8,3:8}`, `{1:12,3:40,5:12}`). This is
+exactly a door-counting parity over a 2-label alphabet: complementary edges are
+the "doors", antipodal boundary forces an odd boundary contribution, interior
+pairing gives the rest. So **n=1 Tucker (= 1-D Borsuk–Ulam) is a near-mechanical
+port of the parent engine** restricted to `d=1` with a signed 2-symbol alphabet.
+
+### Insight 3 — n≥2 Tucker is NOT a one-step parity (needs path-following)
+Exhaustive check of `B²` (hexagon + center, antipodally symmetric, 6 triangles,
+labels `{±1,±2}`, 256 antipodal labellings): Tucker holds (0 labellings without a
+complementary edge) BUT the complementary-edge count is **not** a parity invariant
+— distribution `{1:48, 2:72, 3:48, 4:48, 5:24, 6:8, 9:8}`, only 128/256 odd.
+Hence the parent's "count the target object, show it's odd" strategy does NOT lift
+to `n≥2`. The standard remedy is **Freund–Todd (1981) / Prescott–Su
+path-following on *almost-complementary* simplices**: paths run between
+complementary simplices and the boundary; the antipodal boundary condition pairs
+boundary path-endpoints, forcing an interior complementary simplex. This is a
+genuinely different parity engine (parity of path endpoints, not of the target
+set itself).
+
+### Insight 4 — buildability split
+- **n=1 milestone**: small, self-contained `CellComplex`-style parity over
+  `{+1,-1}`. Estimated < 200 LOC. BUILD when Docker is up.
+- **General Tucker**: the Freund–Todd path-following engine + antipodal pairing of
+  boundary endpoints is substantial (≈ 500–1000+ LOC) and is the real content;
+  alternatively a Tucker-via-Sperner "doubling/quotient" reduction (problem.md
+  approach 2) trades the path-following for orientation bookkeeping on `ℝPⁿ`.
+- **Tucker ⟹ Borsuk–Ulam** (continuous, mesh→0 + compactness) is a separate
+  analytic phase, out of scope for the combinatorial engine.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **"Adapt `door_count_parity` to complementary edges and show the boundary count
+  is odd"** — fails for `n≥2`: the complementary-edge count is not odd in general
+  (verified, B² distribution above). Only works for `n=1`.
+
+---
+
+## Verification Artifact
+
+`verify_tucker.py` (this dir) — Docker-free, exhaustive. Confirms Tucker on
+`B¹` (3/5/7 vtx) and `B²` (hexagon+center), prints the complementary-edge-count
+distributions (the parity evidence), and runs the engine-divergence probe. All
+assertions pass: every antipodal labelling on every enumerated triangulation has
+a complementary edge.
+
+---
+
+## Session Log
+
+## Session 2026-06-14 (Session 2) — ORIENT: engine reusability assessment
+
+**Mode**: FRESH
+**Outcome**: progress (ORIENT) — Docker DOWN, no Lean written
+
+### What I Did
+- Read the full parent engine `SpernerMathlib4.lean` (abstract `CellComplex`
+  door-counting; `sperner_parity`, `sperner`).
+- Built `verify_tucker.py`: exhaustive Tucker check on `B¹`/`B²` + parity probe +
+  engine-divergence probe. All assertions pass.
+
+### Key Findings
+- Parent engine is specialized to the unsigned `Fin (d+1)` panchromatic target;
+  no black-box reduction yields Tucker (Insight 1).
+- n=1 Tucker = direct door-count parity (complementary edges always ODD) →
+  portable first milestone (Insight 2).
+- n≥2 Tucker complementary-edge count is NOT a parity invariant → needs
+  Freund–Todd path-following, a different engine (Insight 3).
+
+### Files Modified
+- research/problems/sperner-mathlib4-oq-02/{knowledge.md, state.md}
+- research/problems/sperner-mathlib4-oq-02/verify_tucker.py (new)
+
+### Next Steps
+- Docker up → port n=1 Tucker as a `CellComplex`-style parity lemma over `{±1}`.
+- Scope Freund–Todd path-following engine for n≥2 (BUILD vs Sperner-doubling).

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -1,25 +1,41 @@
 # Research State: sperner-mathlib4-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-14T17:42:10-07:00
-**Iteration**: 1
+**Since**: 2026-06-14T21:34:31-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Assessed whether the parent's abstract `CellComplex` door-counting engine
+(`proofs/Proofs/SpernerMathlib4.lean`) generalizes to Tucker's lemma.
+Verdict: it ports cleanly to the n=1 case (where complementary-edge parity is
+an exact invariant) but NOT to n>=2 Tucker, which needs a path-following
+(Freund-Todd) engine because the complementary-edge count is no longer a
+parity invariant.
 
 ## Active Approach
-None yet.
+1. **n=1 (immediate, build-gated)**: Tucker on B^1 IS a direct corollary of a
+   door-count parity over the 2-label set {+1,-1}. Brute force confirms the
+   complementary-edge count is ALWAYS ODD. This is a near-mechanical port of
+   the parent engine restricted to d=1 with a signed 2-label alphabet.
+2. **n>=2 (open infrastructure)**: requires a NEW combinatorial engine
+   (almost-complementary simplex path-following / Freund-Todd 1981), since
+   the direct complementary-edge count is not odd in general (verified n=2).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (direct-parity-port assessment)
 
 ## Blockers
-None.
+- Docker DOWN this session -> no `lake build`; no Lean written (avoid shipping
+  uncompilable .lean). Verification done in Python instead.
+- n>=2 Tucker engine is substantial (~500-1000+ LOC: path-following on
+  almost-complementary simplices, antipodal pairing of boundary path-endpoints).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+- When Docker is up: attempt the n=1 Tucker port as a `CellComplex`-style
+  parity lemma over a 2-label alphabet (small, self-contained first milestone).
+- For n>=2: scope the Freund-Todd path-following engine; decide BUILD vs the
+  Tucker-via-Sperner-doubling reduction. Until then this is ORIENT, not ACT.

--- a/research/problems/sperner-mathlib4-oq-02/verify_tucker.py
+++ b/research/problems/sperner-mathlib4-oq-02/verify_tucker.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Brute-force verification of Tucker's lemma on small antipodally-symmetric
+triangulations, and an empirical probe of the parity invariant that any
+door-counting-style Lean proof would have to track.
+
+Context (sperner-mathlib4-oq-02): the parent gallery proof
+`proofs/Proofs/SpernerMathlib4.lean` proves Sperner's lemma via an abstract
+`CellComplex` door-counting parity engine. The open question asks whether the
+SAME engine yields Tucker's lemma (the antipodal analogue / combinatorial heart
+of Borsuk-Ulam). This script does NOT need Docker or Lean -- it independently
+checks the combinatorial statement we would formalize, on cases small enough to
+enumerate exhaustively.
+
+Tucker's lemma (combinatorial form): for an antipodally symmetric triangulation
+T of the n-ball and a labelling lam: vertices -> {+-1,...,+-n} that is antipodal
+on the boundary (lam(-v) = -lam(v)), some edge {u,w} of T is COMPLEMENTARY:
+lam(u) = -lam(w).
+
+Run: python3 verify_tucker.py
+"""
+
+from itertools import product
+
+LABELS = None  # set per dimension: [+-1,...,+-n]
+
+
+def is_complementary(a, b):
+    """Edge labels a,b are complementary iff a = -b (i.e. {+k,-k})."""
+    return a == -b
+
+
+# ---------------------------------------------------------------------------
+# Case n = 1 : B^1 = [-1, 1], symmetric triangulation with an odd number of
+# interior vertices. Vertices indexed -m..m; antipodal map i |-> -i.
+# Edges are consecutive pairs. Boundary = {-m, m}.
+# ---------------------------------------------------------------------------
+def verify_n1(m):
+    """B^1 with vertices -m..m (2m+1 vertices), labels in {+1,-1}."""
+    verts = list(range(-m, m + 1))
+    edges = [(i, i + 1) for i in range(-m, m)]
+    labels = [1, -1]
+    free = [v for v in verts if v < 0] + [0]  # determine v<=0, mirror v>0
+    total = 0
+    bad = 0
+    comp_counts = []
+    for assign in product(labels, repeat=len(free)):
+        lam = {}
+        for v, val in zip(free, assign):
+            lam[v] = val
+        # antipodal on boundary: here whole structure is antipodal-symmetric,
+        # but Tucker only REQUIRES antipodality on the boundary. We impose the
+        # minimal hypothesis: only boundary vertices -m, m are constrained.
+        lam[m] = -lam[-m]
+        # interior positive vertices are FREE -> enumerate them too
+        # (so re-do with all interior free). Handled by full enumeration below.
+        total += 1
+    # Full correct enumeration: free = boundary rep {-m} (mirror to m) + all
+    # interior vertices -m+1..m-1 free.
+    total = 0
+    bad = 0
+    comp_counts = []
+    interior = list(range(-m + 1, m))
+    for bval in labels:                      # lam[-m]; lam[m] = -bval
+        for iv in product(labels, repeat=len(interior)):
+            lam = {-m: bval, m: -bval}
+            for v, val in zip(interior, iv):
+                lam[v] = val
+            c = sum(1 for (a, b) in edges if is_complementary(lam[a], lam[b]))
+            comp_counts.append(c)
+            total += 1
+            if c == 0:
+                bad += 1
+    return total, bad, comp_counts
+
+
+# ---------------------------------------------------------------------------
+# Case n = 2 : B^2 disk, antipodally symmetric "hexagon + center"
+# triangulation. Boundary vertices v0..v5 (hexagon), center c (interior).
+# Antipodal map sigma: v_i |-> v_{(i+3)%6}, c |-> c.
+# Triangles T_i = (c, v_i, v_{i+1}); edges = 6 boundary edges + 6 spokes.
+# Labels in {+-1, +-2}. Boundary antipodal: lam(v_{i+3}) = -lam(v_i).
+# Free choices: lam(v0),lam(v1),lam(v2),lam(c).
+# ---------------------------------------------------------------------------
+def verify_n2():
+    labels = [1, -1, 2, -2]
+    V = ["c"] + [f"v{i}" for i in range(6)]
+    boundary_edges = [(f"v{i}", f"v{(i + 1) % 6}") for i in range(6)]
+    spokes = [("c", f"v{i}") for i in range(6)]
+    edges = boundary_edges + spokes
+
+    total = 0
+    bad = 0
+    comp_counts = []
+    examples_min = None
+    for l0, l1, l2, lc in product(labels, repeat=4):
+        lam = {
+            "v0": l0, "v1": l1, "v2": l2,
+            "v3": -l0, "v4": -l1, "v5": -l2,  # boundary antipodal
+            "c": lc,
+        }
+        c = sum(1 for (a, b) in edges if is_complementary(lam[a], lam[b]))
+        comp_counts.append(c)
+        total += 1
+        if c == 0:
+            bad += 1
+        if c >= 1 and (examples_min is None or c < examples_min[0]):
+            examples_min = (c, dict(lam))
+    return total, bad, comp_counts, examples_min
+
+
+# ---------------------------------------------------------------------------
+# Probe: does the parent's Sperner engine apply DIRECTLY?
+# The parent concludes a PANCHROMATIC cell (coloring surjective onto Fin(d+1),
+# i.e. d+1 distinct colors on a d-cell). Tucker concludes a COMPLEMENTARY EDGE.
+# We check on n=2 whether "panchromatic triangle" and "complementary edge"
+# coincide, to show they are genuinely different targets.
+# ---------------------------------------------------------------------------
+def probe_panchromatic_vs_complementary():
+    labels = [1, -1, 2, -2]
+    triangles = [("c", f"v{i}", f"v{(i + 1) % 6}") for i in range(6)]
+    boundary_edges = [(f"v{i}", f"v{(i + 1) % 6}") for i in range(6)]
+    spokes = [("c", f"v{i}") for i in range(6)]
+    edges = boundary_edges + spokes
+
+    has_comp_no_panchro = 0
+    has_panchro_no_comp = 0
+    for l0, l1, l2, lc in product(labels, repeat=4):
+        lam = {"v0": l0, "v1": l1, "v2": l2,
+               "v3": -l0, "v4": -l1, "v5": -l2, "c": lc}
+        comp = any(is_complementary(lam[a], lam[b]) for (a, b) in edges)
+        # "panchromatic" in the 3-color sense is ill-typed for 4 signed labels;
+        # use the natural antipodal analogue: a triangle is "rainbow-signed" if
+        # its 3 vertex labels are pairwise non-complementary AND use >=2 axes.
+        panchro = any(
+            len({abs(lam[a]), abs(lam[b]), abs(lam[cc])}) == 2
+            and not any(is_complementary(lam[x], lam[y])
+                        for x, y in [(a, b), (b, cc), (a, cc)])
+            for (a, b, cc) in triangles)
+        if comp and not panchro:
+            has_comp_no_panchro += 1
+        if panchro and not comp:
+            has_panchro_no_comp += 1
+    return has_comp_no_panchro, has_panchro_no_comp
+
+
+def summarize(name, total, bad, counts):
+    from collections import Counter
+    dist = dict(sorted(Counter(counts).items()))
+    odd = sum(1 for c in counts if c % 2 == 1)
+    print(f"[{name}] labelings={total}  no-complementary-edge={bad}  "
+          f"(Tucker holds iff this is 0)")
+    print(f"    complementary-edge-count distribution: {dist}")
+    print(f"    labelings with ODD complementary-edge count: {odd}/{total}")
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("Tucker's lemma -- exhaustive verification on small triangulations")
+    print("=" * 70)
+
+    for m in (1, 2, 3):
+        t, b, cc = verify_n1(m)
+        summarize(f"n=1, B^1 with {2*m+1} vertices", t, b, cc)
+    print()
+
+    t, b, cc, ex = verify_n2()
+    summarize("n=2, B^2 hexagon+center (6 triangles)", t, b, cc)
+    print(f"    min complementary-edge example (count={ex[0]}): {ex[1]}")
+    print()
+
+    hcnp, hpnc = probe_panchromatic_vs_complementary()
+    print("[engine-divergence probe] n=2 hexagon")
+    print(f"    labelings with complementary edge but NO rainbow-signed "
+          f"triangle: {hcnp}")
+    print(f"    labelings with rainbow-signed triangle but NO complementary "
+          f"edge: {hpnc}")
+    print("    (nonzero on either side => the Sperner 'panchromatic cell'")
+    print("     target and the Tucker 'complementary edge' target are NOT")
+    print("     interchangeable; the parent engine's conclusion is the wrong")
+    print("     shape for Tucker.)")
+
+    print()
+    print("RESULT: assertions below must all pass.")
+    # Tucker holds on every enumerated case:
+    for m in (1, 2, 3):
+        t, b, cc = verify_n1(m)
+        assert b == 0, f"n=1 m={m}: found labeling with no complementary edge!"
+    t, b, cc, ex = verify_n2()
+    assert b == 0, "n=2: found labeling with no complementary edge!"
+    print("OK: every antipodal labeling on every test triangulation has a "
+          "complementary edge (Tucker confirmed).")


### PR DESCRIPTION
## Summary

ORIENT session on `sperner-mathlib4-oq-02` (does the parent's abstract
door-counting engine extend to **Tucker's lemma** / Borsuk–Ulam?). Docker was
DOWN, so all verification is in Python — **no Lean written** (avoids shipping
uncompilable `.lean`).

## Key findings

- **Parent engine is specialized.** `SpernerMathlib4.lean`'s `door_count_parity`
  / `IsPanchromatic` / `IsDoor` are hard-wired to the unsigned `Fin (d+1)`
  alphabet with a *full-cell* panchromatic conclusion. Tucker's alphabet is
  *signed* (`{±1,…,±n}`) and its target is a *1-D* complementary edge — there is
  no black-box specialization of `CellComplex.sperner` that yields Tucker.
- **n=1 Tucker is a direct door-count corollary (portable).** Exhaustive check
  of `B¹` (3/5/7 vertices): the complementary-edge count is **always odd** — a
  clean parity over the 2-label set `{±1}`. Estimated < 200 LOC port when Docker
  is up.
- **n≥2 Tucker is NOT a one-step parity.** Exhaustive check of `B²`
  (hexagon+center, 256 antipodal labellings): Tucker holds, but the
  complementary-edge count is *not* a parity invariant (distribution
  `{1:48,2:72,3:48,4:48,5:24,6:8,9:8}`, only 128/256 odd). The standard remedy
  is the **Freund–Todd path-following** engine on almost-complementary
  simplices — a genuinely different parity argument (≈500–1000+ LOC).

## Artifact

`research/problems/sperner-mathlib4-oq-02/verify_tucker.py` — Docker-free,
exhaustive; all assertions pass (every antipodal labelling on every enumerated
triangulation has a complementary edge).

## Files
- `research/problems/sperner-mathlib4-oq-02/knowledge.md` (ORIENT findings)
- `research/problems/sperner-mathlib4-oq-02/state.md` (OBSERVE→ORIENT)
- `research/problems/sperner-mathlib4-oq-02/verify_tucker.py` (new)

## Test plan
- [x] `python3 research/problems/sperner-mathlib4-oq-02/verify_tucker.py` passes
- [ ] (future, Docker up) port n=1 Tucker as a `CellComplex`-style parity lemma

🤖 Generated with [Claude Code](https://claude.com/claude-code)