### PR TITLE
Enrich Taylor's Theorem with Lagrange Remainder (mean-value-theorem-oq-02)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/annotations.json
@@ -30,10 +30,10 @@
     "type": "definition",
     "range": {
       "startLine": 52,
-      "endLine": 68
+      "endLine": 69
     },
     "title": "Taylor Polynomial via Finset.sum and iteratedDeriv",
-    "content": "Defines `taylorPolynomial f a n x = Σ_{k ∈ Finset.range (n+1)} iteratedDeriv k f a / k! · (x-a)^k`. The sum runs from k=0 to n using Lean's `Finset.range (n+1)`. The `iteratedDeriv k f a` computes the k-th iterated derivative of f at a using Mathlib's Fréchet derivative infrastructure. The `noncomputable section` wrapping the entire file reflects that `iteratedDeriv` uses `Classical.choice`. The n=0 and n=1 cases are verified by simp lemmas.",
+    "content": "Defines `taylorPolynomial f a n x = Σ_{k ∈ Finset.range (n+1)} iteratedDeriv k f a / k! · (x-a)^k`. The sum runs from k=0 to n using Lean's `Finset.range (n+1)`. The `iteratedDeriv k f a` computes the k-th iterated derivative of f at a using Mathlib's Fréchet derivative infrastructure. The `noncomputable section` wrapping the entire file reflects that `iteratedDeriv` uses `Classical.choice`. The n=0 case (`taylorPolynomial_zero`) closes by `simp [taylorPolynomial, iteratedDeriv_zero]`, while the n=1 case (`taylorPolynomial_one`) needs `Finset.sum_range_succ` to unfold the two-term sum before `iteratedDeriv_zero`/`iteratedDeriv_one` collapse it to `f a + deriv f a · (x-a)`.",
     "mathContext": "$T_n(x) = \\sum_{k=0}^{n} \\frac{f^{(k)}(a)}{k!}(x-a)^k$. `taylorPolynomial_zero`: $T_0 = f(a)$ (zeroth derivative is the function itself; `iteratedDeriv_zero` gives `iteratedDeriv 0 f = f`). `taylorPolynomial_one`: $T_1 = f(a) + f'(a)(x-a)$ (the tangent line at $a$; `iteratedDeriv_one` gives `iteratedDeriv 1 f = deriv f`).",
     "significance": "key",
     "relatedConcepts": [
@@ -108,7 +108,7 @@
     "proofId": "mean-value-theorem-oq-02",
     "type": "concept",
     "range": {
-      "startLine": 141,
+      "startLine": 137,
       "endLine": 152
     },
     "title": "Second-Order Taylor Expansion",

--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -96,7 +96,7 @@
       "Can the axiom `taylor_lagrange_remainder` be proved from Mathlib's integral form? The key missing lemma is the MVT for integrals applied to $h(t) = (b-t)^n / n!$ and $g(t) = f^{(n+1)}(t)$ on $[a,b]$.",
       "Is there a formalized version of Taylor's theorem for functions $f : \\mathbb{R}^n \\to \\mathbb{R}$? The multivariate Lagrange remainder involves the Hessian and higher-order derivatives, and Mathlib's `HasFDerivAt` infrastructure could support this.",
       "Can the Taylor polynomial definition be connected to Mathlib's `taylorWithinEval`? Mathlib's Taylor module defines polynomials differently (using `taylorWithinEval`); reconciling the two definitions would allow direct use of Mathlib's existing Taylor remainder bounds.",
-      "Is there a uniform error bound formalization: for all $x \\in [a-r, a+r]$ and $f$ analytic on the disk of radius $R > r$, $|f(x) - T_n f(a)(x)| \\leq M r^{n+1} / (R-r)$? This uniform version is used in complex analysis and approximation theory."
+      "Can a *uniform* error bound be transferred from the complex disk back to the real interval? The naive real-line claim $\\sup_{x \\in [a-r,a+r]} |f(x) - T_n f(a)(x)| \\leq M r^{n+1}/(R-r)$ (with $M = \\sup |f^{(n+1)}|$) is **false** — the gallery child entry `mean-value-theorem-oq-02-oq-04` refutes it via the Runge function $f(x) = 1/(1+x^2)$ ($a=0$, $R=100$, $r=1$, $n=0$: $|f(1)-f(0)| = 1/2 > 1/99$). The correct statement requires analyticity on a *complex* disk and Cauchy's integral estimates (`analytic_taylor_remainder_uniform_bound_complex`). The open question is whether this complex-disk bound yields a sharp, *correct* real-interval remainder estimate."
     ]
   },
   "crossReferences": [
@@ -114,6 +114,16 @@
       "targetId": "intermediate-value-theorem",
       "relationship": "foundational",
       "description": "The intermediate value theorem underlies the MVT (via Rolle's theorem), and the MVT underlies Taylor's theorem. The existence of the intermediate point c in the Lagrange remainder is a continuity argument analogous to the IVT."
+    },
+    {
+      "targetId": "mean-value-theorem-oq-02-oq-04",
+      "relationship": "extended-by",
+      "description": "Child entry that pursues this file's open question on a *uniform* Taylor remainder bound. It shows the naive real-line uniform estimate is false (Runge counterexample $f(x)=1/(1+x^2)$ at $a=0$ gives $|f(1)-T_0(1)| = 1/2 > M r/(R-r) = 1/99$) and instead formalizes the correct complex-disk Cauchy estimate `analytic_taylor_remainder_uniform_bound_complex`. This directly sharpens open question 5 below."
+    },
+    {
+      "targetId": "mean-value-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry generalizing the n=0 case (the ordinary MVT proved here as `mvt_is_first_order_taylor`) from scalar functions to vector-valued maps. The equality $f(b)-f(a)=f'(c)(b-a)$ has no vector analogue, so it relaxes to the mean value *inequality* $\\|f(b)-f(a)\\| \\leq \\sup_{c}\\|f'(c)\\|\\,(b-a)$."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass: mean-value-theorem-oq-02

This entry was already high-quality (rich historical context, 5 mathContext annotations, full conclusion). This pass grounds its open questions in actual gallery work and tightens annotation coverage. **No Lean source changed; meta/annotation only.**

### Changes
- **Cross-references (2 new):**
  - `mean-value-theorem-oq-02-oq-04` (`extended-by`) — the child entry that pursues this file's open question on a *uniform* Taylor remainder bound, refutes the naive real-line estimate via the Runge counterexample $1/(1+x^2)$, and formalizes the correct complex-disk Cauchy bound instead.
  - `mean-value-theorem-oq-03` (`sibling`) — generalizes the n=0 case (the MVT proved here) to vector-valued maps, relaxing the equality to the mean value *inequality*.
- **Open question 5 rewritten** to reflect the gallery's actual resolution (real-line claim is false; complex-disk version correct) rather than restating an already-explored question.
- **Annotation hygiene:** closed the line-69 coverage gap; aligned the second-order annotation range to the theorem's docstring (137) instead of starting mid-statement (141).
- **Deepened** the Taylor-polynomial annotation to explain why the n=1 case needs `Finset.sum_range_succ`.

### Verification
- `pnpm build` passes.
- Cross-ref targets `mean-value-theorem-oq-02-oq-04` and `mean-value-theorem-oq-03` both exist in the gallery.
- Axiom integrity unchanged: `axiomCount: 1` (`taylor_lagrange_remainder`), `status: axiomatized`, `badge: axiom` — accurate vs. the Lean source.