### PR TITLE
research(solution-of-cubic-oq-03-oq-03-oq-01): ORIENT — reframe to 3 residual axioms + durable verification

### DIFF
--- a/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/knowledge.md
+++ b/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/knowledge.md
@@ -1,0 +1,117 @@
+# Knowledge Base: solution-of-cubic-oq-03-oq-03-oq-01
+
+Discharging the three remaining axioms of `proofs/Proofs/GeneralQuartic.lean`.
+
+---
+
+## Problem Understanding
+
+The OQ ("prove the Ferrari factorization axioms") is **stale**: the Ferrari
+factorization declarations are already proven theorems (lines 167/183/207/232/323).
+The file has **3 axioms, 0 sorries**. The real target is those 3 axioms — see
+`problem.md` for the table.
+
+All three are **routine, classical facts** (FTA for a quartic; the quadratic
+formula for a biquadratic). None is open mathematics. This is an axiom-discharge
+de-risking ORIENT, build-gated by Docker being down this session.
+
+---
+
+## Per-axiom buildability assessment
+
+### (A1) `quartic_has_four_roots` — MEDIUM, ~80 LOC
+`quarticPoly a b c d = X⁴ + C a·X³ + C b·X² + C c·X + C d` is **monic of degree 4**
+(GeneralQuartic.lean:74), so for all coefficients it splits over ℂ.
+
+**Confirmed bearers @ Mathlib v4.26.0:**
+- `IsAlgClosed.splits` (`FieldTheory/IsAlgClosed/Basic.lean:64`) — every ℂ-poly splits.
+- `Polynomial.Splits.eq_prod_roots_of_monic` (alias `eq_prod_roots_of_monic_of_splits_id`,
+  `Algebra/Polynomial/Splits.lean:203`) — monic + splits ⇒ `p = ∏ (X − rᵢ)`.
+- `Polynomial.Splits.natDegree_eq_card_roots` (`Splits.lean:176`) — `card (roots p) = 4`.
+- `Polynomial.mem_roots` — for `p ≠ 0`, `x ∈ roots p ↔ IsRoot p x`.
+
+**Route:** monicity ⇒ `p ≠ 0`; `mem_roots` gives `eval x = 0 ↔ x ∈ roots p`; the
+roots multiset has card 4 (`natDegree_eq_card_roots`); destructure it into
+`r₁,r₂,r₃,r₄` (repeats allowed) so multiset-membership becomes the 4-fold
+disjunction. The only finicky bit is enumerating a card-4 `Multiset` into four
+named elements (no `Multiset.card_eq_four` helper at the pin — do it stepwise from
+`card_eq_three` analogue or via `roots.toList` length-4 pattern match).
+
+### (A2) `biquadratic_forward` — MEDIUM, ~60 LOC
+With `q = 0`, set `w = y²`; then `y⁴ + p y² + r = w² + p w + r`. Let
+`s = Complex.cpow (p²−4r) (1/2)`. The **only** non-elementary fact needed is
+`s² = p²−4r`, supplied by:
+- **`Complex.cpow_nat_inv_pow`** (`Analysis/SpecialFunctions/Pow/Complex.lean:137`,
+  v4.26.0): `(x ^ (n⁻¹ : ℂ)) ^ n = x` for `n ≠ 0`; with `n = 2` and `1/2 = 2⁻¹`
+  (`one_div`) this is exactly `s² = p²−4r`. (Also `Complex.cpow_ofNat_inv_pow`, line 142.)
+
+Given `s² = p²−4r`, the resolvent quadratic factors as `w² + p w + r = (w−z₁)(w−z₂)`
+with `z₁,₂ = (-p ± s)/2` (verified symbolically, see script). A root of the LHS
+makes a factor vanish; ℂ is an integral domain ⇒ `w = z₁ ∨ w = z₂`.
+
+### (A3) `biquadratic_backward` — EASY, ~40 LOC
+Converse: substitute `y² = z₁` (or `z₂`) and reduce `z² + p z + r` to 0 using the
+same factorization + `s² = p²−4r`. Pure `ring`/substitution once `s²` is rewritten.
+
+**Total estimate: ~150–200 LOC, all bearers present at the pin. Docker-gated only.**
+
+---
+
+## Durable verification (build-free)
+
+`verify_quartic_axioms.py` (sympy + cmath) checks, with all assertions passing:
+- **A2/A3 core:** `z² + p z + r ≡ (z−z₁)(z−z₂)` under `s² = p²−4r`; Vieta sum/product.
+- **A3 backward:** `y² ∈ {z₁,z₂} ⇒ y⁴ + p y² + r = 0`.
+- **A2 forward:** `w² + p w + r = 0 ⇒ (w−z₁)(w−z₂) = 0 ⇒ w = z₁ ∨ w = z₂`.
+- **cpow branch:** principal `√` (Python `**0.5` = `Complex.cpow · (1/2)`) satisfies
+  `s² = D` over 2000 random complex `(p,r)` and on the negative-real branch cut —
+  grounding the one branch-sensitive Lean fact.
+- **A1:** `X⁴+aX³+bX²+cX+d ≡ ∏(X−rᵢ)` under Vieta; `eval(rᵢ)=0 ∀i` and non-roots ≠ 0
+  over 3000 random root tuples (including repeated roots).
+
+This grounds the math behind all three axioms so the Lean discharge is a
+transcription task, not a discovery task.
+
+---
+
+## Dead Ends / Cautions
+
+- **Do not** re-attempt the Ferrari *factorization* declarations — they are already
+  theorems. Target only A1/A2/A3.
+- The `cpow(·, 1/2)` square is the **only** subtle step; it is NOT `ring`-provable —
+  it needs `Complex.cpow_nat_inv_pow` + a `one_div`/`2⁻¹` normalization. A naive
+  `field_simp; ring` will fail on the biquadratic axioms.
+- A1's multiset-of-4 enumeration into a disjunction is where blind Lean is risky;
+  this is why the discharge is Docker-gated rather than written blind this session.
+
+---
+
+## Next Steps (ACT, build-gated)
+
+1. **A3** first (easiest): rewrite `s²`, then `ring`. Confirms the cpow pattern.
+2. **A2**: reuse the `(w−z₁)(w−z₂)` factorization; `mul_eq_zero`.
+3. **A1**: `IsAlgClosed.splits` → `eq_prod_roots_of_monic` → `natDegree_eq_card_roots`
+   → destructure card-4 multiset → `mem_roots`. Candidate for Aristotle once the
+   surrounding scaffolding compiles.
+4. Update `meta.json` `axiomCount` 3 → 0 and `status` once all three land green.
+
+---
+
+## Session Log
+
+### 2026-06-14 (Session 1) — ORIENT
+
+**Mode**: FRESH · **Outcome**: progress (ORIENT, no .lean; both backends down)
+
+- Claimed fresh available OQ (knowledge 0). Docker hangs; Aristotle backend
+  "Resource not found" — build-free session.
+- Read `GeneralQuartic.lean`: found OQ framing stale (Ferrari factorization already
+  theorems); isolated the **3** genuine remaining axioms A1/A2/A3.
+- Confirmed every needed Mathlib bearer **present at pin v4.26.0** via `gh api`
+  (`Complex.cpow_nat_inv_pow`, `IsAlgClosed.splits`, `Splits.eq_prod_roots_of_monic`,
+  `Splits.natDegree_eq_card_roots`, `Polynomial.mem_roots`).
+- Wrote `verify_quartic_axioms.py`; all assertions pass (quadratic-formula
+  factorization, biquadratic forward/backward, principal-branch `s²=D`, quartic
+  root-set split).
+- Verdict: all 3 axioms buildable, ~150–200 LOC, Docker-gated. Phase OBSERVE→ORIENT.
+- **Next**: ACT — discharge A3, A2, A1 in that order.

--- a/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/problem.md
+++ b/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/problem.md
@@ -1,0 +1,41 @@
+# Problem: solution-of-cubic-oq-03-oq-03-oq-01
+
+**Name (pool):** Can the Ferrari factorization axioms in `GeneralQuartic.lean` be proved?
+
+**Tier:** B · **Significance:** 6 · **Tractability:** 7 · **Tags:** algebra, gallery-extracted
+
+## Statement (as posed)
+
+The open question asks whether the *Ferrari factorization axioms* used in
+`proofs/Proofs/GeneralQuartic.lean` (the gallery's formalization of the solution
+of the general quartic by radicals) can be discharged to theorems.
+
+## Reframing (ORIENT, 2026-06-14)
+
+The posed framing is **stale**. Reading the current source, every
+Ferrari-*factorization* declaration is **already a proven `theorem`**, not an
+`axiom`:
+
+| Declaration | Line | Status |
+|---|---|---|
+| `ferrari_factorization_id` | 167 | theorem (proved) |
+| `ferrari_hβ2_of_resolvent` | 183 | theorem (proved) |
+| `ferrari_factorization_backward_ne` | 207 | theorem (proved) |
+| `ferrari_factorization_forward_ne` | 232 | theorem (proved) |
+| `ferrari_factorization` | 323 | theorem (proved) |
+
+`grep -c '^axiom ' GeneralQuartic.lean` → **3**, `grep -c sorry` → **0**.
+
+So the **genuine residual** is exactly the three axioms that remain, none of which
+is a "Ferrari factorization" axiom per se:
+
+- **(A1) `quartic_has_four_roots`** (line 268) — Fundamental Theorem of Algebra
+  instance: the monic degree-4 `quarticPoly a b c d` has a 4-element root set,
+  `∃ r₁..r₄, ∀ x, eval x = 0 ↔ x ∈ {r₁,r₂,r₃,r₄}`.
+- **(A2) `biquadratic_forward`** (line 275) — when `q = 0`, a root of
+  `y⁴ + p y² + r` has `y²` equal to one of `(-p ± √(p²−4r))/2`
+  (`√` = `Complex.cpow · (1/2)`).
+- **(A3) `biquadratic_backward`** (line 283) — the converse of A2.
+
+This problem is therefore an **axiom-discharge** task on an otherwise complete,
+0-sorry file, not new mathematics.

--- a/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/state.md
+++ b/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/state.md
@@ -1,0 +1,30 @@
+# Research State: solution-of-cubic-oq-03-oq-03-oq-01
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Iteration**: 1
+
+## Current Focus
+Reframed the OQ. The "Ferrari factorization axioms" it names are ALREADY proven
+theorems in `GeneralQuartic.lean` (lines 167/183/207/232/323). The file has
+**3 axioms, 0 sorries**. The genuine residual is exactly:
+- A1 `quartic_has_four_roots` (FTA root-set, line 268)
+- A2 `biquadratic_forward` (quadratic formula, line 275)
+- A3 `biquadratic_backward` (converse, line 283)
+
+## Active Approach
+Discharge A3 → A2 → A1. All bearers confirmed present at Mathlib v4.26.0:
+`Complex.cpow_nat_inv_pow` (s²=p²−4r), `IsAlgClosed.splits`,
+`Splits.eq_prod_roots_of_monic`, `Splits.natDegree_eq_card_roots`,
+`Polynomial.mem_roots`. Math verified build-free via `verify_quartic_axioms.py`
+(all assertions pass).
+
+## Blockers
+- Docker hangs this session → no Lean build, ACT deferred.
+- Aristotle backend down ("Resource not found") → no async submit.
+
+## Next Action
+ACT (build-gated): write the 3 discharges (~150–200 LOC total). A3 easiest
+(rewrite `s²`, `ring`); A2 via `(w−z₁)(w−z₂)` + `mul_eq_zero`; A1 via alg-closed
+splitting + card-4 multiset enumeration. Then `meta.json` axiomCount 3 → 0.

--- a/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/verify_quartic_axioms.py
+++ b/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/verify_quartic_axioms.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Durable, reproducible verification of the THREE remaining axioms in
+`proofs/Proofs/GeneralQuartic.lean`, the genuine residual of the open question
+`solution-of-cubic-oq-03-oq-03-oq-01`
+("Can the Ferrari factorization axioms in GeneralQuartic.lean be proved?").
+
+KEY REFRAMING (build-free ORIENT, 2026-06-14)
+---------------------------------------------
+The OQ names "the Ferrari factorization axioms", but every Ferrari-factorization
+declaration in the file is ALREADY a proven `theorem`, not an `axiom`:
+    ferrari_factorization_id, ferrari_hβ2_of_resolvent,
+    ferrari_factorization_forward_ne, ferrari_factorization_backward_ne,
+    ferrari_factorization      (GeneralQuartic.lean lines 167, 183, 207, 232, 323)
+`grep -c '^axiom ' GeneralQuartic.lean` == 3 and `grep -c sorry` == 0.
+
+The actual residual is exactly these three axioms:
+  (A1) quartic_has_four_roots  (line 268) -- FTA: a monic deg-4 ℂ-poly's root set
+  (A2) biquadratic_forward     (line 275) -- q=0 ⇒ y² solves the resolvent quadratic
+  (A3) biquadratic_backward    (line 283) -- converse of A2
+
+This script verifies the MATHEMATICAL CONTENT of all three so that the (Docker-gated)
+Lean discharge is de-risked. It uses exact symbolic algebra (sympy) plus a numeric
+principal-branch check (cmath) for the one branch-sensitive fact behind A2/A3.
+
+Run:  python3 verify_quartic_axioms.py     (needs: sympy)
+All assertions must pass.
+"""
+
+import cmath
+import sympy as sp
+
+print("=" * 72)
+print("Verification: 3 remaining axioms of GeneralQuartic.lean")
+print("=" * 72)
+
+# ---------------------------------------------------------------------------
+# Symbols. We treat the discriminant square-root `s` as an INDEPENDENT symbol
+# constrained by s^2 = D (= p^2 - 4r). This mirrors the Lean situation: the only
+# fact we know about `Complex.cpow (p^2-4r) (1/2)` is that its square is p^2-4r,
+# delivered by `Complex.cpow_nat_inv_pow` (Mathlib v4.26.0, Pow/Complex.lean:137).
+# We never assume a particular branch; only s^2 = D.
+# ---------------------------------------------------------------------------
+p, q, r, y, z, s = sp.symbols('p q r y z s')
+D = p**2 - 4*r                      # quadratic discriminant of z^2 + p z + r
+z1 = (-p + s) / 2                   # (-p + sqrt(D))/2  with s = sqrt(D)
+z2 = (-p - s) / 2                   # (-p - sqrt(D))/2
+
+def reduce_s2(expr):
+    """Rewrite using the ONLY known fact about s: s^2 = D = p^2 - 4r."""
+    return sp.simplify(sp.expand(expr).subs(s**2, D).subs(s**4, D**2))
+
+# ===========================================================================
+# (A2)/(A3) CORE IDENTITY: the resolvent quadratic factors as (z-z1)(z-z2).
+#   Over any field: z^2 + p z + r == (z - z1)(z - z2)  PROVIDED s^2 = p^2 - 4r.
+# This single identity is the substrate of BOTH biquadratic axioms.
+# ===========================================================================
+factor_form = sp.expand((z - z1) * (z - z2))            # = z^2 + ((z1+z2)??) ...
+target_form = z**2 + p*z + r
+diff_quad = reduce_s2(factor_form - target_form)
+assert diff_quad == 0, f"quadratic factorization FAILED: residue {diff_quad}"
+print("[A2/A3 core] z^2 + p z + r == (z - z1)(z - z2)  given s^2 = p^2-4r   OK")
+
+# Vieta cross-checks (both must hold given s^2 = D):
+assert reduce_s2(z1 + z2 - (-p)) == 0, "Vieta sum failed"
+assert reduce_s2(z1 * z2 - r) == 0,   "Vieta product failed"
+print("[A2/A3 core] Vieta: z1+z2 = -p, z1*z2 = r                            OK")
+
+# ===========================================================================
+# (A3) biquadratic_backward:
+#   if y^2 = z1 OR y^2 = z2  then  y^4 + p y^2 + 0*y + r = 0.
+#   Equivalently z1, z2 each satisfy the resolvent quadratic z^2+pz+r = 0.
+# ===========================================================================
+for name, root in [("z1", z1), ("z2", z2)]:
+    val = reduce_s2(root**2 + p*root + r)
+    assert val == 0, f"backward: {name} not a root of z^2+pz+r (got {val})"
+    # full biquadratic with the substitution y^2 = root:
+    biq = reduce_s2((root)**2 + p*(root) + r)   # = (y^2)^2 + p(y^2)+r with y^2=root
+    assert biq == 0
+print("[A3 backward] y^2 ∈ {z1,z2}  ⇒  y^4 + p y^2 + r = 0                  OK")
+
+# ===========================================================================
+# (A2) biquadratic_forward:
+#   if y^4 + p y^2 + r = 0  then  y^2 = z1  OR  y^2 = z2.
+#   With w := y^2 we have w^2 + p w + r = 0; by the core factorization
+#   (w - z1)(w - z2) = 0, hence w = z1 or w = z2 (ℂ is an integral domain).
+# We verify the logical reduction symbolically: assuming w^2+pw+r=0, the product
+# (w-z1)(w-z2) reduces to 0, so at least one factor vanishes.
+# ===========================================================================
+w = sp.symbols('w')
+prod_wz = reduce_s2((w - z1) * (w - z2) - (w**2 + p*w + r))
+assert prod_wz == 0, "forward: (w-z1)(w-z2) != w^2+pw+r"
+print("[A2 forward ] w^2+pw+r = 0 ⇒ (w-z1)(w-z2)=0 ⇒ w=z1 ∨ w=z2           OK")
+
+# ===========================================================================
+# PRINCIPAL-BRANCH GROUNDING for s = Complex.cpow(D, 1/2):
+#   The Lean axioms pick s as the PRINCIPAL square root cpow(D,1/2). The only
+#   fact the proof needs is s^2 = D, supplied by Complex.cpow_nat_inv_pow.
+#   We confirm numerically that the principal branch indeed satisfies s^2 = D
+#   across many random complex (p, r), including negative-real D (branch cut).
+# ===========================================================================
+import random
+random.seed(0)
+maxerr = 0.0
+for _ in range(2000):
+    pp = complex(random.uniform(-5, 5), random.uniform(-5, 5))
+    rr = complex(random.uniform(-5, 5), random.uniform(-5, 5))
+    Dn = pp*pp - 4*rr
+    sn = Dn ** 0.5                     # Python principal sqrt == Complex.cpow(.,1/2)
+    maxerr = max(maxerr, abs(sn*sn - Dn))
+    # check both candidate z solve the quadratic numerically
+    for zc in ((-pp + sn)/2, (-pp - sn)/2):
+        maxerr = max(maxerr, abs(zc*zc + pp*zc + rr))
+assert maxerr < 1e-9, f"principal-branch s^2=D / quadratic check err={maxerr}"
+print(f"[cpow branch] principal sqrt: max|s^2-D| & |z^2+pz+r| = {maxerr:.2e}  OK")
+
+# also confirm the branch cut on negative real D (the only worry):
+for Dn in (-1.0, -4.0, -9.0+0j, complex(-3, 0)):
+    sn = complex(Dn) ** 0.5
+    assert abs(sn*sn - complex(Dn)) < 1e-12
+print("[cpow branch] s^2 = D holds on negative-real branch cut             OK")
+
+# ===========================================================================
+# (A1) quartic_has_four_roots:
+#   ∃ r1..r4, ∀ x: (x^4 + a x^3 + b x^2 + c x + d) = 0  ⇔  x ∈ {r1,r2,r3,r4}.
+#   quarticPoly is MONIC of degree 4 (GeneralQuartic.lean:74), so over ℂ
+#   (algebraically closed) it splits: poly = ∏ (X - r_i). We verify the
+#   eval ⇔ membership equivalence and the splitting identity (Vieta) symbolically
+#   and numerically over random root tuples (incl. repeated roots).
+# ===========================================================================
+a, b, c, d = sp.symbols('a b c d')
+r1, r2, r3, r4 = sp.symbols('r1 r2 r3 r4')
+x = sp.symbols('x')
+
+# Splitting identity: matching coefficients via Vieta gives the monic quartic.
+prod_quartic = sp.expand((x - r1)*(x - r2)*(x - r3)*(x - r4))
+vieta = {
+    a: -(r1 + r2 + r3 + r4),
+    b:  (r1*r2 + r1*r3 + r1*r4 + r2*r3 + r2*r4 + r3*r4),
+    c: -(r1*r2*r3 + r1*r2*r4 + r1*r3*r4 + r2*r3*r4),
+    d:  (r1*r2*r3*r4),
+}
+monic = x**4 + a*x**3 + b*x**2 + c*x + d
+assert sp.expand(monic.subs(vieta) - prod_quartic) == 0, "quartic split failed"
+print("[A1 roots   ] X^4+aX^3+bX^2+cX+d == ∏(X-r_i) under Vieta            OK")
+
+# eval ⇔ membership, numerically over random (possibly repeated) roots:
+random.seed(1)
+maxres = 0.0
+for _ in range(3000):
+    roots = [complex(random.uniform(-3, 3), random.uniform(-3, 3)) for _ in range(4)]
+    if random.random() < 0.3:            # force a repeated root sometimes
+        roots[1] = roots[0]
+    def f(t):
+        return (t-roots[0])*(t-roots[1])*(t-roots[2])*(t-roots[3])
+    # forward: each root evaluates to 0
+    for rt in roots:
+        maxres = max(maxres, abs(f(rt)))
+    # backward: a generic non-root evaluates to nonzero (sanity, not an assert
+    # on exact 0 — just that membership ⇔ zero is the right shape)
+    t = complex(random.uniform(-3, 3), random.uniform(-3, 3))
+    if min(abs(t - rt) for rt in roots) > 1e-3:
+        assert abs(f(t)) > 1e-9
+assert maxres < 1e-9, f"A1 root eval residue {maxres}"
+print(f"[A1 roots   ] eval(r_i)=0 ∀i; non-roots ≠ 0  (max residue {maxres:.2e})  OK")
+
+print("=" * 72)
+print("ALL CHECKS PASSED — all three remaining axioms are mathematically sound.")
+print("Buildability: A1 (FTA split) MEDIUM ~80LOC; A2 forward MEDIUM ~60LOC;")
+print("A3 backward EASY ~40LOC. Key bearer Complex.cpow_nat_inv_pow present @v4.26.0.")
+print("=" * 72)


### PR DESCRIPTION
## Summary

ORIENT on the open question *"Can the Ferrari factorization axioms in `GeneralQuartic.lean` be proved?"* (`solution-of-cubic-oq-03-oq-03-oq-01`). Both backends down this session (Docker hangs, Aristotle "Resource not found"), so this is a build-free ORIENT.

**The OQ framing is stale.** Every Ferrari-*factorization* declaration is already a proven `theorem`, not an `axiom` (`GeneralQuartic.lean` lines 167/183/207/232/323). The file has **3 axioms, 0 sorries**. The genuine residual is exactly:

| Axiom | Line | Content | Difficulty |
|---|---|---|---|
| `quartic_has_four_roots` (A1) | 268 | FTA: monic deg-4 ℂ-poly root set | MEDIUM ~80 LOC |
| `biquadratic_forward` (A2) | 275 | `q=0` ⇒ `y²` solves resolvent quadratic | MEDIUM ~60 LOC |
| `biquadratic_backward` (A3) | 283 | converse of A2 | EASY ~40 LOC |

**All three are buildable** — bearers confirmed present at Mathlib **v4.26.0** via `gh api`:
- `Complex.cpow_nat_inv_pow` (`Pow/Complex.lean:137`) gives `s² = p²−4r` for `s = cpow(·,1/2)` — the one branch-sensitive step.
- `IsAlgClosed.splits`, `Splits.eq_prod_roots_of_monic`, `Splits.natDegree_eq_card_roots`, `Polynomial.mem_roots` for A1.

**Durable artifact** `verify_quartic_axioms.py` (sympy + cmath, all assertions pass): the biquadratic quadratic-formula factorization `z²+pz+r ≡ (z−z₁)(z−z₂)` under `s²=p²−4r`, forward/backward directions, principal-branch `s²=D` over 2000 random complex `(p,r)` incl. the negative-real branch cut, and the quartic root-set split. This de-risks the Lean discharge to a transcription task.

Gallery `general-quartic/meta.json` already accurately reports `axiomCount: 3`, status `axiomatized` — no integrity change needed.

## Files
- `research/problems/solution-of-cubic-oq-03-oq-03-oq-01/{problem.md,knowledge.md,state.md}`
- `research/problems/solution-of-cubic-oq-03-oq-03-oq-01/verify_quartic_axioms.py`

## Next (ACT, build-gated)
Discharge A3 → A2 → A1 (~150–200 LOC) once Docker is back; A1's card-4 multiset enumeration is the only finicky bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)