### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): confirm Strategy D descent bearers at pin v4.26.0

### DIFF
--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -215,3 +215,63 @@ found"** (backend still unavailable) — so still build-free only.
    ⇒ `IsIntegrallyClosed.isIntegral_iff`) and (b) the bounds — now fully specced
    by the witness recipe above.
 2. Fallbacks unchanged (Strategy A 3-squaring chain; or `m(α)=0` + rational-root).
+
+---
+
+## Session 2026-06-14 (Session 4) — Strategy D descent bearers confirmed at pin (researcher-5)
+
+**Mode**: CONTINUE · **Outcome**: ORIENT → ACT-ready (de-risk). Both backends still down
+(Docker `docker info` 15s timeout; Aristotle MCP `prove` → "Resource not found", probed this
+session). Build-free only. **This discharges the single hedged item in the prior Next Action**:
+"the integral-closure descent `(r:ℝ) integral / ℤ ⇒ r ∈ ℤ` (lemma names *to confirm*: ...,
+integrality descent along injective `algebraMap ℚ ℝ`, ...)". Those names are now confirmed —
+and the previously-**unnamed** descent step is identified — against the repo's exact Mathlib pin
+`v4.26.0` (read via `gh api .../contents/...?ref=v4.26.0`, not the moving HEAD).
+
+### Strategy D descent chain — every step now has a confirmed Mathlib bearer @ v4.26.0
+
+Let `α := √2+√3+√5+√7`. Assume `α = algebraMap ℚ ℝ q` for some `q : ℚ` (i.e. `α` rational).
+
+1. **`IsIntegral ℤ α`** — `IsIntegral.add` (×3) over the four `IsIntegral ℤ (√k)`. Each `√k`
+   (k ∈ {2,3,5,7}) is a root of the monic integer `X² − C k`: leading coeff 1, integer coeffs,
+   `(√k)² − k = 0` via `Real.sq_sqrt (by positivity)`. (Monic witness: `monic_X_pow_sub_C`.)
+2. **descent ℝ → ℚ** (the step the prior sessions left *unnamed* as "integrality descent along
+   `algebraMap ℚ ℝ`"): it is
+   **`isIntegral_algebraMap_iff`** — `Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean:179`
+   ```
+   theorem isIntegral_algebraMap_iff [Algebra A B] [IsScalarTower R A B] {x : A}
+       (hAB : Function.Injective (algebraMap A B)) :
+       IsIntegral R (algebraMap A B x) ↔ IsIntegral R x
+   ```
+   Apply with `R = ℤ`, `A = ℚ`, `B = ℝ`, `x = q`. Needs `[IsScalarTower ℤ ℚ ℝ]` (standard
+   instance) and `Function.Injective (algebraMap ℚ ℝ)` = `(algebraMap ℚ ℝ).injective`
+   (`RingHom.injective`, since ℚ is a field). `.mp` turns `IsIntegral ℤ (algebraMap ℚ ℝ q)`
+   (= `IsIntegral ℤ α` by the rationality hypothesis) into **`IsIntegral ℤ q`**.
+3. **q is an integer** — **`IsIntegrallyClosed.isIntegral_iff`**
+   `Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean:210`
+   ```
+   theorem isIntegral_iff [IsIntegrallyClosed R] {x : K} :
+       IsIntegral R x ↔ ∃ y : R, algebraMap R K y = x
+   ```
+   with `R = ℤ`, `K = ℚ`. `IsIntegrallyClosed ℤ` resolves by instance (ℤ is a PID/UFD; the
+   `UniqueFactorizationMonoid` integrally-closed instance, same file/region — search hit
+   `IntegrallyClosed.lean` & `RationalRoot.lean`); `[IsFractionRing ℤ ℚ]` is a standard instance.
+   `.mp` gives `∃ n : ℤ, algebraMap ℤ ℚ n = q`, i.e. **`q ∈ ℤ`** ⇒ `α = (n : ℝ)`.
+4. **contradiction** — bounds `8 < α < 9` (witness recipe, Session 3) ⇒ `α ∉ ℤ`. So no integer
+   `n` with `α = n`; the rationality assumption is false. `Irrational α` ∎.
+
+### Net effect
+Strategy D is now **paste-port-ready**: steps 1–4 are pure transcription against named,
+pin-verified lemmas; the only non-API work left is the four `norm_num` radical bounds (already
+specced by Session 3's witness recipe). No genuinely-open Mathlib gap remains for Strategy D.
+This is *not* re-ORIENT churn — it converts the prior "lemma names to confirm" TODO into
+confirmed `file:line` bearers and resolves the one step that had no name.
+
+### Caveat (kept honest)
+Not Lean-checked — Docker/Aristotle down. The two residual transcription risks are (i) the cast
+plumbing `√(2:ℕ)` vs `√(2:ℝ)` when assembling step 1 from `IsIntegral ℤ (√(k:ℕ))`, and (ii) that
+`IsScalarTower ℤ ℚ ℝ` + `IsFractionRing ℤ ℚ` instances fire without manual `haveI`. Both are
+routine but are exactly why a real build (not an uncompilable `.lean`) is deferred to ACT.
+
+### Files modified
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
@@ -1,23 +1,26 @@
 # Research State: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ORIENT (ACT-ready)
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
-Strategy D verification made durable (Session 3, researcher-1). Committed
-`verify_strategy_d.py` that independently re-derives the degree-16 minimal polynomial (via
-resultant), certifies integrality of each `√k`, and confirms `8 < α < 9` — all reproducible,
-exits 0 on "ALL CHECKS PASSED". Extracted the explicit rational-witness recipe for the bound
-lemmas (the one non-API `sorry` step). Still build-gated: Docker down AND Aristotle MCP loads
-but `prove` returns "Resource not found".
+Strategy D is now **paste-port-ready** (Session 4, researcher-5). Every step of the
+integral-closure descent has a Mathlib bearer **confirmed at the repo pin `v4.26.0`**: the
+previously-unnamed "descent along `algebraMap ℚ ℝ`" is `isIntegral_algebraMap_iff`
+(`Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean:179`) and the ℤ-step is
+`IsIntegrallyClosed.isIntegral_iff`
+(`Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean:210`). Combined with Session 3's
+durable `verify_strategy_d.py` and the bound-witness recipe, no genuinely-open Mathlib gap
+remains for Strategy D — only transcription. Still build-gated: Docker down (`docker info` 15s
+timeout) AND Aristotle MCP `prove` returns "Resource not found" (probed this session).
 
 ## Active Approach
 Strategy D — α = √2+√3+√5+√7 is a sum of algebraic integers ⇒ integral over ℤ; a rational
-integral over ℤ lies in ℤ; but 8 < α < 9 ⇒ not an integer ⇒ irrational. Lean skeleton drafted
-in knowledge.md (4 lemma names to confirm at build). Deferred to ACT until Docker returns.
+integral over ℤ lies in ℤ; but 8 < α < 9 ⇒ not an integer ⇒ irrational. Full bearer-confirmed
+descent chain in knowledge.md Session 4. Deferred to ACT until Docker/Aristotle returns.
 Fallback: Strategy A (elementary 3-squaring chain) or `m(α)=0` + rational-root theorem.
 
 ## Attempt Count
@@ -31,10 +34,14 @@ Fallback: Strategy A (elementary 3-squaring chain) or `m(α)=0` + rational-root 
   cannot delegate the proof.
 
 ## Next Action
-When Docker **or** Aristotle returns, implement **Strategy D** in
-`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~60–100 LOC). The bound step is
-now fully specced (rational-witness recipe in knowledge.md Session 3); the only genuinely-open
-Lean obligation is the integral-closure descent `(r:ℝ) integral / ℤ ⇒ r ∈ ℤ` (confirm lemma
-names `IsIntegral.add`, integrality descent along `algebraMap ℚ ℝ`,
-`IsIntegrallyClosed.isIntegral_iff`). Fallbacks: Strategy A (3-squaring chain) or `m(α)=0` +
-rational-root theorem. Re-run `verify_strategy_d.py` to re-confirm all math artifacts.
+When Docker **or** Aristotle returns, **transcribe** Strategy D into
+`Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~60–100 LOC). All lemma names are
+now confirmed at pin `v4.26.0` (knowledge.md Session 4): step 1 `IsIntegral.add` ×3 over
+`IsIntegral ℤ (√k)` (monic `X²−C k`, `Real.sq_sqrt`); step 2 descent
+`isIntegral_algebraMap_iff` (`IsIntegral/Basic.lean:179`, needs `[IsScalarTower ℤ ℚ ℝ]` +
+`(algebraMap ℚ ℝ).injective`); step 3 `IsIntegrallyClosed.isIntegral_iff`
+(`IntegrallyClosed.lean:210`, ℤ integrally closed by instance); step 4 bounds `8<α<9` via the
+Session-3 `norm_num` witness recipe ⇒ contradiction. Residual transcription risks: cast plumbing
+`√(2:ℕ)` vs `√(2:ℝ)` in step 1, and instance firing for `IsScalarTower ℤ ℚ ℝ`/`IsFractionRing ℤ ℚ`.
+Fallbacks: Strategy A (3-squaring chain) or `m(α)=0` + rational-root theorem. Re-run
+`verify_strategy_d.py` to re-confirm all math artifacts.


### PR DESCRIPTION
## Summary

Build-free ACT-readiness de-risk for Strategy D on `Irrational (√2+√3+√5+√7)`. Both backends down this session (Docker `docker info` 15s timeout; Aristotle MCP `prove` → "Resource not found", probed), so no Lean build.

The prior Next Action hedged the proof's one open obligation: *"the integral-closure descent `(r:ℝ) integral / ℤ ⇒ r ∈ ℤ` (confirm lemma names: integrality descent along `algebraMap ℚ ℝ`, `IsIntegrallyClosed.isIntegral_iff`)"*. This PR discharges that TODO by confirming every descent step against the repo's **exact Mathlib pin `v4.26.0`** (read via `gh api .../contents/...?ref=v4.26.0`, not moving HEAD):

- **step 2 (the previously *unnamed* ℝ→ℚ descent)** = `isIntegral_algebraMap_iff` — `Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean:179` (needs `[IsScalarTower ℤ ℚ ℝ]` + `(algebraMap ℚ ℝ).injective`)
- **step 3 (ℚ-integer)** = `IsIntegrallyClosed.isIntegral_iff` — `Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean:210` (`IsIntegrallyClosed ℤ` by instance)
- step 1 (`IsIntegral ℤ α`) via `IsIntegral.add` over `IsIntegral ℤ (√k)`; step 4 bounds `8<α<9` via Session-3 `norm_num` witness recipe.

Net: Strategy D is now **paste-port-ready** — steps 1–4 are pure transcription against named, pin-verified lemmas; no genuinely-open Mathlib gap remains. Not Lean-checked (backends down); residual transcription risks (cast plumbing `√(2:ℕ)` vs `√(2:ℝ)`; instance firing) are documented and are why a real build is deferred rather than shipping an uncompilable `.lean`.

## Changes
- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md` — Session 4: bearer-confirmed descent chain with `file:line` at pin
- `.../state.md` — de-hedged Next Action (transcription, not "confirm names"); iteration 4→5

Docs-only; 0 `.lean`. No `loom:review-requested` (math PR).