### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03): ORIENT — Minkowski+Dirichlet route, 2 axioms remain

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -6,16 +6,93 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Goal: the **"if" direction** of Legendre's three-square theorem,
+`n ≠ 4^a(8b+7) ⟹ ∃ x y z : ℤ, x²+y²+z² = n`. The "only if" direction is
+elementary (squares mod 8 ∈ {0,1,4}) and already fully proved.
+
+**Critical ORIENT correction to problem.md:** problem.md recommends a
+Davenport–Cassels formalization and warns the prime-existence input "may pull in
+Dirichlet (heavy in Lean)". That framing is out of date. The gallery file
+`proofs/Proofs/ThreeSquares.lean` (1956 lines) already:
+- commits to the **Minkowski geometry-of-numbers + Dirichlet-primes-in-AP**
+  route (not Davenport–Cassels), and
+- imports `Mathlib.NumberTheory.LSeries.PrimesInAP` — Dirichlet's theorem is now
+  *in Mathlib*, so that "heavy input" is available off the shelf.
+
+A fresh Davenport–Cassels attempt would **duplicate ~1000 lines of already-proved
+geometry-of-numbers infrastructure**. Do not do that.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### State of `proofs/Proofs/ThreeSquares.lean` (as of 2026-06-14)
+- Necessity: fully proved, **0 axioms**.
+- `minkowski_ellipsoid_has_lattice_point` (line 950): **proved** via Mathlib's
+  `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`.
+- `dirichletSublattice` (line 1460) + basis matrix (det = p²) + linear
+  independence + `dirichletForm_eq_p_of_lt_two_mul` (line 1333): **proved**.
+- Per-residue prime lemmas (p%8 ∈ {1,3,5} ⟹ sum of three squares): **proved**.
+- Reduced to exactly **2 axioms** + **1 downstream sorry**:
+  1. `dirichlet_key_lemma` (line 615): Minkowski lattice point → representation
+     of `n`. Ingredients proved; only the final assembly missing.
+  2. `not_excluded_form_is_sum_three_sq` (line 1665): full sufficiency by mod-8
+     case split + `PrimesInAP` + (1). Docstring estimates **~150–200 lines**.
+  3. `needs_four_iff_excluded` (line 1927, sorry): **trivial** corollary once
+     `legendre_three_squares` is axiom-free.
+
+### The number-theoretic crux: isotropy of the form, on the 4-free core
+The geometry-of-numbers step needs the form Q(x,y,z) = x²+y²+z² to be **isotropic
+mod m**, i.e. a, b with a² + b² + 1 ≡ 0 (mod m). The precise fact (verified
+numerically below, and it *corrected an initial wrong guess of mine*):
+
+> **isotropy mod m is solvable ⟺ 4 ∤ m** — NOT "⟺ m is non-excluded".
+
+So the proof first **strips the 4^a factor** (n = 4^a·m, 4∤m, via the already-
+proved `sq_mul_*` lemmas), reducing to the 4-free core m. On that core, Q is
+isotropic, which cuts out the **covolume-m congruence sublattice** Λ_m on which
+Q ≡ 0 (mod m). Minkowski on the ball of radius √(2m) (volume (4/3)π(2m)^{3/2} >
+2³·m) yields a nonzero v ∈ Λ_m with 0 < Q(v) ≤ 2m and Q(v) ≡ 0 (mod m), forcing
+Q(v) = m.
+
+Important: **isotropy is not the same as "m is a sum of three squares".** E.g.
+m = 7 is isotropic (4∤7) yet excluded; the m ≡ 7 (mod 8) obstruction is killed
+separately by the strict Minkowski bound / parity (the case Q(v) = 2m is
+excluded), not by isotropy. This is exactly why the two axioms still require a
+careful mod-8 case split rather than a one-line isotropy ⇒ representation.
+
+### Buildability assessment
+| Target | Size | Foundational? | Decision |
+|--------|------|---------------|----------|
+| `dirichlet_key_lemma` | ~few hundred LOC assembly | No — ingredients proved | BUILD (Docker-gated) |
+| `not_excluded_form_is_sum_three_sq` | ~150–200 LOC | No — `PrimesInAP` in Mathlib | BUILD (Docker-gated) |
+| `needs_four_iff_excluded` sorry | trivial | No | BUILD (Docker-gated) |
+
+Not "blocked" (the old "Mathlib lacks X" framing is wrong: Mathlib now has
+`PrimesInAP`, geometry of numbers, and the rest). The only blocker this session
+is the **Docker outage** — every discharge needs a build to verify.
+
+### Build-free verification (durable)
+`verify_three_squares_route.py` (committed) confirms, with pure stdlib:
+- [A] n = x²+y²+z² ⟺ n ≠ 4^a(8b+7) by brute force.
+- [B] isotropy a²+b²+1≡0 (mod m) solvable ⟺ 4∤m (so the GoN argument applies to
+  the 4-free core m = n/4^a).
+- [C] Minkowski volume inequality (tightest at m=1, ratio (π/3)√(2m)).
+- [D] primes p with p%8 ∈ {1,3,5} are sums of three squares.
+
+Spot-checked representatives this session (host CPU starvation from the agent
+swarm prevented the full-range run; the script is committed as the reproducible
+artifact): excluded {7,15,23,28,31,112} all NOT 3-squares; non-excluded
+{1,2,3,5,6,11,19,43,83,100,101} all ARE; isotropy false exactly at 4|m (28,100,
+112); (π/3)√2 ≈ 1.481 > 1.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Davenport–Cassels from scratch** — not a dead end mathematically, but a
+  *wasteful* one here: it would re-derive the geometry-of-numbers machinery that
+  ThreeSquares.lean already proves. Prefer finishing the Minkowski route.
+- **"Mathlib lacks the Dirichlet input → blocked"** — false as of 2026:
+  `Mathlib.NumberTheory.LSeries.PrimesInAP` provides Dirichlet's theorem and is
+  already imported.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/state.md
@@ -1,25 +1,87 @@
 # Research State: lagrange-four-squares-waring-g2-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T17:42:09-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Feasibility / route survey for the "if" direction of Legendre's three-square
+theorem ( n ≠ 4^a(8b+7) ⟹ n = x²+y²+z² ).
+
+**Key ORIENT finding (corrects problem.md):** the gallery already contains a
+substantial implementation in `proofs/Proofs/ThreeSquares.lean` (1956 lines). It
+does NOT use the Davenport–Cassels route suggested in problem.md. Instead it
+commits to the **Minkowski geometry-of-numbers + Dirichlet-primes-in-AP** route,
+and the heavy machinery is already built and *proved*:
+
+- Necessity ("only if") — fully proved, **no axioms**.
+- Squares-mod-8 lemmas, descent on the 4^a factor — proved.
+- Per-residue prime lemmas (primes p with p%8 ∈ {1,3,5} are sums of three
+  squares) — proved (lines 435–562).
+- Full ℤ³ lattice / fundamental domain / covolume-1 infrastructure — proved.
+- `minkowski_ellipsoid_has_lattice_point` (line 950) — **proved** via Mathlib's
+  `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`.
+- The Dirichlet congruence-sublattice (`dirichletSublattice`, basis matrix of
+  det p², linear independence, real basis, `dirichletForm_eq_p_of_lt_two_mul`)
+  — proved (lines 1220–1652).
+- `Mathlib.NumberTheory.LSeries.PrimesInAP` (Dirichlet's theorem) is now in
+  Mathlib and is already imported (line 3).
+
+## Remaining Gap (the actual open work)
+The "if" direction is reduced to exactly **2 axioms + 1 downstream sorry**:
+
+1. `dirichlet_key_lemma` (axiom, line 615): bridges a Minkowski lattice point in
+   the congruence-sublattice ellipsoid to a representation `x²+y²+z² = n`. All
+   analytic ingredients (Minkowski point + sublattice covolume + "form value =
+   p" lemma) are already proved; what is missing is the final assembly.
+2. `not_excluded_form_is_sum_three_sq` (axiom, line 1665): the full sufficiency,
+   by case analysis on n mod 8 + `PrimesInAP` + `dirichlet_key_lemma`. Its own
+   docstring estimates **~150–200 lines** on top of the existing framework.
+3. `needs_four_iff_excluded` (sorry, line 1927): downstream and **trivial** once
+   `legendre_three_squares` is axiom-free (it is a direct corollary).
 
 ## Active Approach
-None yet.
+Confirm/repair the chosen Minkowski+Dirichlet route (NOT Davenport–Cassels).
+The geometry-of-numbers step needs Q(x,y,z)=x²+y²+z² **isotropic mod m**
+(a²+b²+1≡0 mod m). Verified fact (corrected an initial wrong guess this session):
+isotropy is solvable ⟺ **4∤m**, NOT ⟺ "m non-excluded". So the proof strips 4^a
+(n=4^a·m, 4∤m, via proved `sq_mul_*` lemmas) to the 4-free core m, builds the
+covolume-m congruence sublattice on which Q≡0 mod m, and Minkowski forces Q(v)=m.
+The m≡7 (mod 8) exclusion is a SEPARATE obstruction handled by the strict bound
+(Q(v)=2m excluded), not by isotropy — which is why the axioms still need a mod-8
+case split.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (ORIENT survey only — no Lean edits this session, Docker down)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Docker down** this session (`docker ps` hangs) → cannot build/verify Lean.
+  Discharging either axiom requires a build, so the two ACT targets are
+  Docker-gated. ORIENT survey + number-theoretic verification are build-free and
+  done this session.
+
+## Verification (build-free, durable)
+`verify_three_squares_route.py` (committed, `python3`-runnable, stdlib only)
+independently checks:
+- [A] Legendre characterization n=x²+y²+z² ⟺ n≠4^a(8b+7) by brute force.
+- [B] isotropy a²+b²+1≡0 (mod m) solvable ⟺ 4∤m (GoN applies to 4-free core).
+- [C] Minkowski volume inequality (4/3)π(2m)^{3/2} > 2³·m (tightest at m=1).
+- [D] primes p with p%8∈{1,3,5} are sums of three squares.
+
+(Host CPU starvation from the agent swarm blocked the full-range run this
+session; the script is committed as the reproducible artifact and the
+representatives above were spot-checked: excluded {7,15,23,28,31,112} not
+3-squares, non-excluded {1,2,3,5,6,11,19,43,83,100,101} are, isotropy false
+exactly at 4|m.)
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+ACT (when Docker is back): discharge `dirichlet_key_lemma` by assembling the
+already-proved `minkowski_ellipsoid_has_lattice_point` +
+`dirichletForm_eq_p_of_lt_two_mul` + sublattice covolume; then
+`not_excluded_form_is_sum_three_sq` via mod-8 case split + `PrimesInAP`. Do NOT
+restart on a Davenport–Cassels formalization — that would duplicate the ~1000
+lines of geometry-of-numbers infrastructure already proved here.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_three_squares_route.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_three_squares_route.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Durable verification for lagrange-four-squares-waring-g2-oq-03
+("if" direction of Legendre's three-square theorem).
+
+This script independently re-derives and checks the number-theoretic facts that
+underpin the geometry-of-numbers ("GoN") + Dirichlet route ALREADY implemented in
+proofs/Proofs/ThreeSquares.lean (which reduces the open "if" direction to two
+axioms: `dirichlet_key_lemma` and `not_excluded_form_is_sum_three_sq`).
+
+It is build-free and reproducible: `python3 verify_three_squares_route.py`.
+No Lean / Docker required. Pure stdlib (math only).
+
+Checks
+------
+A. Legendre characterization (brute force):
+     n = x^2 + y^2 + z^2  <=>  n is NOT of the form 4^a (8b + 7).
+B. Isotropy witness (an input to the GoN argument):
+     a^2 + b^2 + 1 == 0 (mod m) is solvable  <=>  4 does not divide m.
+   The three-square GoN proof first strips the 4^a factor (n = 4^a * m, 4 doesn't
+   divide m, via the proved sq_mul lemmas), then on this 4-free core m the form
+   Q(x,y,z) = x^2+y^2+z^2 is isotropic mod m, which builds the covolume-m
+   congruence sublattice on which Q vanishes mod m. NOTE: isotropy is NOT the
+   same as "m is a sum of three squares" -- e.g. m = 7 is isotropic (4 does not
+   divide 7) yet is excluded; the m == 7 (mod 8) obstruction is killed separately
+   by the strict Minkowski bound / parity step, not by isotropy.
+C. Minkowski volume inequality: vol(ball radius sqrt(2m)) > 2^3 * covol(Lambda_m),
+   i.e. (4/3) pi (2m)^{3/2} > 8 m, so Minkowski's theorem yields a nonzero point
+   with 0 < Q(v) <= 2m and Q(v) == 0 (mod m), forcing Q(v) = m.
+D. Per-residue prime arithmetic underlying the proved lemmas in ThreeSquares.lean
+   (primes p with p%8 in {1,3,5} are sums of three squares).
+"""
+
+import math
+
+N = 2000          # brute-force bound for the characterization
+M_ISOTROPY = 1200 # bound for the isotropy + Minkowski checks
+
+# Precompute a perfect-square lookup set up to N for a fast 3-square test.
+_SQSET = {k * k for k in range(int(math.isqrt(N)) + 2)}
+
+
+def is_excluded(n: int) -> bool:
+    """n == 4^a (8b + 7) for some a,b >= 0."""
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+
+def is_sum_three_squares(n: int) -> bool:
+    r = int(math.isqrt(n))
+    for x in range(r + 1):
+        rem1 = n - x * x
+        y = int(math.isqrt(rem1))
+        for yy in range(y + 1):
+            if (rem1 - yy * yy) in _SQSET:
+                return True
+    return False
+
+
+def check_A() -> None:
+    bad = []
+    for n in range(0, N + 1):
+        if is_sum_three_squares(n) == is_excluded(n):
+            bad.append(n)
+    assert not bad, f"A FAILED: characterization mismatch at {bad[:10]}"
+    excl = [n for n in range(N + 1) if is_excluded(n)]
+    print(f"[A] OK  n=x^2+y^2+z^2 <=> n != 4^a(8b+7) for all n in [0,{N}]")
+    print(f"        excluded sample: {excl[:12]} ... (count={len(excl)})")
+
+
+def isotropy_witness(m: int):
+    """smallest (a,b) with a^2 + b^2 + 1 == 0 (mod m), or None."""
+    if m == 1:
+        return (0, 0)
+    squares = {}
+    for a in range(m):
+        squares.setdefault((a * a) % m, a)
+    for b in range(m):
+        target = (-1 - b * b) % m
+        if target in squares:
+            return (squares[target], b)
+    return None
+
+
+def check_B() -> None:
+    """a^2+b^2+1 == 0 (mod m) is solvable  <=>  4 does not divide m."""
+    failures = []
+    for m in range(1, M_ISOTROPY + 1):
+        has_witness = isotropy_witness(m) is not None
+        expected = (m % 4 != 0)
+        if has_witness != expected:
+            failures.append(m)
+        if has_witness:
+            a, b = isotropy_witness(m)
+            assert (a * a + b * b + 1) % m == 0
+    assert not failures, f"B FAILED: isotropy != (4 doesn't divide m) at {failures[:10]}"
+    print(f"[B] OK  isotropy a^2+b^2+1==0 (mod m) solvable <=> 4 does not divide m, "
+          f"for all m in [1,{M_ISOTROPY}]")
+    print( "        (so the GoN argument applies to the 4-free core m = n / 4^a)")
+
+
+def check_C() -> None:
+    """Minkowski: (4/3) pi (2m)^{3/2} > 8 m  for all m>=1 (covolume m sublattice)."""
+    worst_ratio = None
+    for m in range(1, M_ISOTROPY + 1):
+        ball_vol = (4.0 / 3.0) * math.pi * (2.0 * m) ** 1.5
+        need = 8.0 * m  # 2^3 * covolume
+        ratio = ball_vol / need
+        assert ball_vol > need, f"C FAILED at m={m}: {ball_vol} !> {need}"
+        if worst_ratio is None or ratio < worst_ratio[1]:
+            worst_ratio = (m, ratio)
+    # closed-form: ratio = (pi/3) sqrt(2m); minimised at m=1
+    print(f"[C] OK  vol(ball r=sqrt(2m)) > 2^3*covol(m) for all m in [1,{M_ISOTROPY}]")
+    print(f"        tightest at m={worst_ratio[0]} ratio={worst_ratio[1]:.4f} "
+          f"(closed form (pi/3)sqrt(2m), min at m=1 = {math.pi/3*math.sqrt(2):.4f})")
+
+
+def is_prime(p: int) -> bool:
+    if p < 2:
+        return False
+    if p % 2 == 0:
+        return p == 2
+    i = 3
+    while i * i <= p:
+        if p % i == 0:
+            return False
+        i += 2
+    return True
+
+
+def check_D() -> None:
+    """Primes p with p%8 in {1,3,5} are sums of three squares (proved lemmas)."""
+    bad = []
+    for p in range(2, 2000):
+        if not is_prime(p):
+            continue
+        if p % 8 in (1, 3, 5) and not is_sum_three_squares(p):
+            bad.append(p)
+    assert not bad, f"D FAILED: prime not 3sq: {bad[:10]}"
+    # p%8 == 7 primes are excluded (never 3 squares); p%8==1,3,5 always are.
+    print("[D] OK  every prime p with p%8 in {1,3,5} (p<2000) is a sum of 3 squares")
+
+
+if __name__ == "__main__":
+    check_A()
+    check_B()
+    check_C()
+    check_D()
+    print("\nALL CHECKS PASSED")
+    print("Conclusion: the Minkowski + Dirichlet route in ThreeSquares.lean is")
+    print("number-theoretically sound. After stripping 4^a (proved sq_mul lemmas),")
+    print("the 4-free core m is isotropic mod m [check B], giving the covolume-m")
+    print("congruence sublattice; Minkowski's lattice-point theorem [check C] then")
+    print("forces Q(v) = m. The m == 7 (mod 8) cases are exactly the excluded ones")
+    print("[check A]. All these ingredients are already proved in the Lean file;")
+    print("only the final assembly into the two axioms remains.")


### PR DESCRIPTION
## Summary

ORIENT session on **lagrange-four-squares-waring-g2-oq-03** (the "if" direction of
Legendre's three-square theorem: `n ≠ 4^a(8b+7) ⟹ n = x²+y²+z²`). Docker was down
this session, so this is build-free ORIENT work: a survey + reproducible numeric
verification, no Lean edits.

**Key finding — the seeker's problem.md is out of date.** The gallery already
contains a substantial implementation in `proofs/Proofs/ThreeSquares.lean` (1956
lines) that does **not** use the Davenport–Cassels route problem.md recommends.
Instead it commits to the **Minkowski geometry-of-numbers + Dirichlet-primes-in-AP**
route and already builds and *proves* the heavy machinery:

- Necessity ("only if"): fully proved, 0 axioms.
- `minkowski_ellipsoid_has_lattice_point` (line 950): **proved** via Mathlib's
  `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`.
- Dirichlet congruence-sublattice (det p², independence, `dirichletForm_eq_p…`): proved.
- Per-residue prime lemmas (p%8 ∈ {1,3,5} ⟹ 3 squares): proved.
- `Mathlib.NumberTheory.LSeries.PrimesInAP` (Dirichlet) is now in Mathlib and imported.

The open "if" direction is reduced to exactly **2 axioms + 1 trivial downstream sorry**:
1. `dirichlet_key_lemma` (line 615) — final assembly of already-proved ingredients.
2. `not_excluded_form_is_sum_three_sq` (line 1665) — ~150–200 LOC, mod-8 case split + `PrimesInAP`.
3. `needs_four_iff_excluded` (line 1927, sorry) — trivial once (2) lands.

A future session should **finish this route, not restart on Davenport–Cassels**
(which would duplicate ~1000 proved lines). Both axioms are Docker-gated (need a build).

## Verification (`verify_three_squares_route.py`, build-free, reproducible)

Checks: [A] Legendre characterization by brute force; [B] isotropy `a²+b²+1≡0 (mod m)`
solvable ⟺ `4∤m` (so the GoN argument applies to the 4-free core `m = n/4^a`);
[C] Minkowski volume inequality; [D] primes p%8∈{1,3,5} are 3-squares.

**Honesty notes:**
- A spot-check **refuted my initial guess** that isotropy ⟺ "non-excluded": m=100 is
  non-excluded but not isotropic; m=7 is excluded but isotropic. Corrected to ⟺ `4∤m`;
  the m≡7 (mod 8) exclusion is a separate obstruction (strict Minkowski bound).
- Host CPU starvation from the agent swarm prevented the full-range run this session;
  representatives were spot-checked and the script is committed as the durable artifact.

## Test plan
- [ ] `python3 research/problems/lagrange-four-squares-waring-g2-oq-03/verify_three_squares_route.py` (run when host CPU is free)
- [ ] No Lean changes — nothing to build.