### PR TITLE
Enrich Infinitely Many Primes ≡ 3 (mod 4): annotation coverage + termination note

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/annotations.json
@@ -27,11 +27,11 @@
     "proofId": "dirichlets-theorem-oq-02",
     "range": {
       "startLine": 17,
-      "endLine": 53
+      "endLine": 54
     },
     "type": "concept",
     "title": "Key Lemma: Prime Factor 3 mod 4",
-    "content": "The key lemma proves that any $n > 1$ with $n \\equiv 3 \\pmod{4}$ has a prime factor $p \\equiv 3 \\pmod{4}$. The proof uses strong induction (`termination_by n`): take any prime factor $p$ of $n$. If $p \\equiv 3$, done. Otherwise $p$ must be odd (since $n$ is odd) and $p \\equiv 1 \\pmod{4}$. Then $n/p \\equiv 3 \\pmod{4}$ (since $1 \\cdot k \\equiv 3$ forces $k \\equiv 3$) and $n/p < n$, so induction applies. The multiplicativity of residues mod 4 is the engine driving the argument.",
+    "content": "The key lemma proves that any $n > 1$ with $n \\equiv 3 \\pmod{4}$ has a prime factor $p \\equiv 3 \\pmod{4}$. The proof uses strong induction (`termination_by n`): take any prime factor $p$ of $n$. If $p \\equiv 3$, done. Otherwise $p$ must be odd (since $n$ is odd) and $p \\equiv 1 \\pmod{4}$. Then $n/p \\equiv 3 \\pmod{4}$ (since $1 \\cdot k \\equiv 3$ forces $k \\equiv 3$) and $n/p < n$, so induction applies. The recursion's well-foundedness obligation is discharged explicitly by `decreasing_by exact hk_lt`, supplying the strict measure $k = n/p < n$ (itself obtained from $p > 1$ via `nlinarith`). The multiplicativity of residues mod 4 is the engine driving the argument.",
     "mathContext": "$n > 1,\\; n \\equiv 3 \\pmod{4} \\implies \\exists p \\mid n,\\; p \\text{ prime},\\; p \\equiv 3 \\pmod{4}$",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -129,8 +129,8 @@
     },
     {
       "targetId": "dirichlets-theorem-oq-02-oq-01",
-      "relationship": "parent",
-      "description": "Parent entry for the GRH sub-question about Dirichlet L-functions"
+      "relationship": "extended-by",
+      "description": "Child sub-question spawned from this entry: it leaves the elementary, L-function-free regime and formalizes the Generalized Riemann Hypothesis for Dirichlet L-functions — the analytic machinery this 3 (mod 4) special case was specifically constructed to avoid."
     },
     {
       "targetId": "prime-number-theorem",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -129,8 +129,8 @@
     },
     {
       "targetId": "dirichlets-theorem-oq-02-oq-01",
-      "relationship": "extended-by",
-      "description": "Child sub-question spawned from this entry: it leaves the elementary, L-function-free regime and formalizes the Generalized Riemann Hypothesis for Dirichlet L-functions — the analytic machinery this 3 (mod 4) special case was specifically constructed to avoid."
+      "relationship": "parent",
+      "description": "Parent entry for the GRH sub-question about Dirichlet L-functions"
     },
     {
       "targetId": "prime-number-theorem",


### PR DESCRIPTION
## Enrichment pass: dirichlets-theorem-oq-02 (annotation-only)

Scoped to changes that **don't overlap** with the in-flight #24155 (which already fixes the inverted `dirichlets-theorem-oq-02-oq-01` cross-reference). I dropped my own cross-ref edit to avoid conflicting with that PR.

### Changes (annotations.json only)
- **Closed the line-54 annotation coverage gap** in the key lemma so the `termination_by`/`decreasing_by` block is covered (range 17-53 → 17-54).
- **Added a teaching note** on how Lean discharges the well-founded recursion obligation: `decreasing_by exact hk_lt`, supplying the strict measure $k = n/p < n$ (obtained from $p > 1$ via `nlinarith`).

### Verification
- `pnpm build` passes.
- Net diff vs main is annotations.json only (2 lines) — complementary to #24155.