### PR TITLE
Enrich Erdős #1134: add scannable cross-reference descriptions

### DIFF
--- a/src/data/proofs/erdos-1134/meta.json
+++ b/src/data/proofs/erdos-1134/meta.json
@@ -167,27 +167,33 @@
   "crossReferences": [
     {
       "relationship": "Klarner's 1982 theorem on affine sequence iteration: for maps {x ↦ aᵢx + bᵢ} with Σ(1/aᵢ) > 1, iterating from {1} must produce repeated elements. Problem #1134 sits at the critical threshold Σ(1/mᵢ) = 1/2 + 1/3 + 1/6 = 1 where Klarner's semigroup theory yields only trivial density bounds, motivating the Crampin-Hilton refinement.",
-      "targetId": "erdos-481"
+      "targetId": "erdos-481",
+      "description": "Klarner's 1982 theorem on affine sequence iteration ($\\sum 1/a_i > 1$ forces repeats); #1134 sits at the critical threshold $\\sum 1/m_i = 1$ where Klarner's bounds go trivial, motivating the Crampin–Hilton refinement."
     },
     {
       "relationship": "The Collatz conjecture studies the orbit of every n under the deterministic map f(n) = n/2 or (3n+1)/2. Lagarias observed that Klarner's problems (including #1134) are structurally related: both concern iteration of piecewise affine maps on ℕ, with the key difference that Klarner's maps are applied non-deterministically (any map may be used), while Collatz applies maps based on parity.",
-      "targetId": "erdos-1135"
+      "targetId": "erdos-1135",
+      "description": "Collatz conjecture — Lagarias noted Klarner's problems (incl. #1134) are structurally related as iteration of piecewise-affine maps on ℕ, differing by non-deterministic (Klarner) vs. parity-driven (Collatz) map choice."
     },
     {
       "relationship": "Concerns representability as sums of p^k q^l with p=2, q=3 — the same two primes that appear as primary multipliers in #1134 (maps x↦2x+1 and x↦3x+1). The 3-smooth structure and the factorization 6 = 2×3 underlie both problems: in #1134 the coincidence 6 = 2×3 enables the Crampin-Hilton trick, while in #1110 the interaction of powers of 2 and 3 governs which integers can be represented.",
-      "targetId": "erdos-1110"
+      "targetId": "erdos-1110",
+      "description": "Representability as sums of $2^k 3^l$ — the same primes 2, 3 as #1134's multipliers; the factorization $6 = 2\\times 3$ underlies both (the Crampin–Hilton trick here, representability there)."
     },
     {
       "relationship": "Asks whether a set defined by digit restrictions (base-3 digits ∈ {0,1} summed with base-4 digits ∈ {0,1}) has positive density. Known lower bound |A+B ∩ [1,x]| ≫ x^{0.9777} is qualitatively similar to #1134's exponent τ ≈ 0.9006 < 1. Both problems feature sets with sub-linear but super-polynomial growth where the density question turns on fine analytic estimates.",
-      "targetId": "erdos-125"
+      "targetId": "erdos-125",
+      "description": "Density of a digit-restricted set; its lower-bound exponent $\\approx 0.978$ parallels #1134's $\\tau \\approx 0.9006$ — both sets show sub-linear, super-polynomial growth where density hinges on fine analytic estimates."
     },
     {
       "relationship": "Asks whether the 3-smooth numbers B = {2^m · 3^n} form an essential component (a set that boosts Schnirelmann density when added to any positive-density set). The counting function |B ∩ [1,N]| ~ C(log N)² places B exactly at Ruzsa's threshold. Problem #1134 uses the multiplicative structure of 2 and 3 in a complementary way: the factorization 6 = 2×3 among generating multipliers produces a sharp growth exponent, linking both problems to the arithmetic of 3-smooth numbers.",
-      "targetId": "erdos-1146"
+      "targetId": "erdos-1146",
+      "description": "Whether the 3-smooth numbers $\\{2^m 3^n\\}$ form an essential component (at Ruzsa's threshold); #1134 uses the same $6 = 2\\times 3$ multiplicative structure to produce its sharp growth exponent."
     },
     {
       "relationship": "Studies sums of 3-smooth numbers b₁ < ... < bₜ with bounded ratio bₜ/b₁ ≤ C. The 3-smooth numbers {2^m · 3^n} are exactly the values reachable by iterating multiplication by 2 and 3 — a multiplicative analogue of the additive iteration in #1134. Disproval of #845 (all integers representable with C = 6) contrasts with #1134's result that the additive-affine orbit has density zero.",
-      "targetId": "erdos-845"
+      "targetId": "erdos-845",
+      "description": "Sums of 3-smooth numbers with bounded ratio; their multiplicative iteration by 2 and 3 is the analogue of #1134's additive-affine orbit, and #845's disproof contrasts with #1134's density-zero result."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass for `erdos-1134`

### Problem
All 6 cross-references stored a 330–476 char essay in the `relationship` field with no `description`. The Related Proofs UI (`ProofOverview.tsx` / `ProofConclusion.tsx`) renders `ref.description ?? ref.relationship`, so each linked proof rendered as a full paragraph rather than a scannable label.

### Fix
Added a concise one-sentence `description` to each of the 6 cross-references, condensed faithfully from the existing essays. The detailed `relationship` text is **preserved unchanged** — only short summaries were added. Surgical diff: +12 / −6.

### Integrity checks
- **Axiom integrity verified**: 4 `axiom` declarations in `Proofs/Erdos1134Problem.lean`, `axiomCount: 4` matches, 0 sorries, `status: "axiomatized"` / `badge: "axiom"` correct.
- All 6 cross-reference targets exist in the gallery (no dead links).
- `pnpm build` passes; JSON validated.