### PR TITLE
Fix: clamp trailing annotation ranges that overshoot EOF (15 proofs)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-03/annotations.json
@@ -258,7 +258,7 @@
     "proofId": "binary-gcd-oq-03",
     "range": {
       "startLine": 432,
-      "endLine": 490
+      "endLine": 488
     },
     "type": "insight",
     "title": "Step Count and Complexity Summary",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -172,7 +172,7 @@
   {
     "id": "ann-eqr-oq01x4-verifications",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02",
-    "range": { "startLine": 206, "endLine": 254 },
+    "range": { "startLine": 206, "endLine": 252 },
     "type": "context",
     "title": "Concrete Verifications via native_decide",
     "content": "Five private `Fact` instances make small primes 3, 5, 7, 11, 13 available, then four `example` declarations verify QR for the prime pairs $(3,5), (3,7), (5,7), (11,13)$ via `native_decide`. **Each example is a closed term of QR for two specific primes** — a strong validation that the formalization is operationally correct, not just propositionally derivable. The closing comment block summarizes the full assembly with a status table.",

--- a/src/data/proofs/erdos-1133/annotations.json
+++ b/src/data/proofs/erdos-1133/annotations.json
@@ -257,7 +257,7 @@
     "proofId": "erdos-1133",
     "range": {
       "startLine": 194,
-      "endLine": 195
+      "endLine": 194
     },
     "type": "concept",
     "title": "exact_interpolation_case (Fully Proved)",

--- a/src/data/proofs/erdos-114/annotations.json
+++ b/src/data/proofs/erdos-114/annotations.json
@@ -236,7 +236,7 @@
     "proofId": "erdos-114",
     "range": {
       "startLine": 43,
-      "endLine": 49
+      "endLine": 48
     },
     "type": "concept",
     "title": "Exact Length Formula via Gamma Function",

--- a/src/data/proofs/erdos-187/annotations.json
+++ b/src/data/proofs/erdos-187/annotations.json
@@ -101,7 +101,7 @@
     "type": "concept",
     "range": {
       "startLine": 56,
-      "endLine": 60
+      "endLine": 59
     },
     "title": "Main Open Conjecture: f(d) = Θ(log d)",
     "content": "**`erdos_187_conjecture`** formalizes the open question: does there exist $c > 0$ such that $f(d) \\geq c \\cdot \\lfloor \\log_2 d \\rfloor$ for all sufficiently large $d$?\n\nCombined with Beck's upper bound, this would give $f(d) = \\Theta(\\log d)$ — the exact answer to Problem #187.\n\n**Current gap:** The only known lower bound is $f(d) \\to \\infty$ (van der Waerden), which provides no rate at all. Even $f(d) \\geq \\log \\log d$ would be new. The conjectured $\\Theta(\\log d)$ lower bound seems plausible from probabilistic heuristics (a random 2-coloring has monochromatic APs of length $\\Theta(\\log d)$), but no proof technique is known.",

--- a/src/data/proofs/erdos-274/annotations.json
+++ b/src/data/proofs/erdos-274/annotations.json
@@ -167,7 +167,7 @@
     "proofId": "erdos-274",
     "range": {
       "startLine": 121,
-      "endLine": 130
+      "endLine": 127
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-275/annotations.json
+++ b/src/data/proofs/erdos-275/annotations.json
@@ -269,7 +269,7 @@
     "proofId": "erdos-275",
     "range": {
       "startLine": 169,
-      "endLine": 172
+      "endLine": 171
     },
     "type": "concept",
     "title": "Summary Theorem: Main Result and Tightness",

--- a/src/data/proofs/erdos-395/annotations.json
+++ b/src/data/proofs/erdos-395/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-395",
     "range": {
       "startLine": 158,
-      "endLine": 186
+      "endLine": 184
     },
     "type": "concept",
     "title": "Complete Resolution of Erdős #395",

--- a/src/data/proofs/erdos-582/annotations.json
+++ b/src/data/proofs/erdos-582/annotations.json
@@ -208,7 +208,7 @@
     "proofId": "erdos-582",
     "range": {
       "startLine": 307,
-      "endLine": 317
+      "endLine": 315
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/euler-identity-oq-01/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "euler-identity-oq-01",
     "range": {
       "startLine": 175,
-      "endLine": 211
+      "endLine": 210
     },
     "type": "concept",
     "title": "Axiom Elimination Roadmap: Three Approaches to a Fully Verified Proof",

--- a/src/data/proofs/friendship-theorem-oq-01/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-01/annotations.json
@@ -259,7 +259,7 @@
     "proofId": "friendship-theorem-oq-01",
     "range": {
       "startLine": 1870,
-      "endLine": 2276
+      "endLine": 2275
     },
     "type": "insight",
     "title": "Part XVIII-XIX: Matrix Symmetry and the Non-Regularity Step",

--- a/src/data/proofs/law-of-cosines-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-04/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "law-of-cosines-oq-01-oq-04",
     "range": {
       "startLine": 186,
-      "endLine": 191
+      "endLine": 190
     },
     "type": "example",
     "title": "Equilateral Triangle Case",

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -192,7 +192,7 @@
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
       "startLine": 108,
-      "endLine": 119
+      "endLine": 118
     },
     "type": "concept",
     "title": "Exports: Making the Toolkit Accessible",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/annotations.json
@@ -147,7 +147,7 @@
     "proofId": "shannon-channel-coding-oq-02-oq-03",
     "range": {
       "startLine": 121,
-      "endLine": 163
+      "endLine": 162
     },
     "type": "insight",
     "title": "Main Theorem: Explicit Threshold ⌈2/(R-C)⌉ with Quantitative Gap",

--- a/src/data/proofs/sperner-simplicial-bridge/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge/annotations.json
@@ -123,7 +123,7 @@
   {
     "id": "ann-main-theorem",
     "proofId": "sperner-simplicial-bridge",
-    "range": { "startLine": 564, "endLine": 612 },
+    "range": { "startLine": 564, "endLine": 611 },
     "type": "insight",
     "title": "Sperner's Lemma for Pseudomanifold Simplicial Complexes",
     "content": "`exists_panchromatic`: given `topCells` (a finite set of (d+1)-vertex simplices satisfying the pseudomanifold condition), a vertex coloring `c : E → Fin(d+1)`, and an odd number of boundary door-face pairs, there exists a panchromatic cell — one whose vertices collectively receive all d+1 colors.\n\nThe proof instantiates `Sperner.exists_panchromatic` from `SpernerMathlib` by providing:\n- `adjFn topCells hcard` as the adjacency function\n- The three verified axioms: `adjFn_vertex`, `adjFn_ne`, `adjFn_symm`\n\nThis is the bridge payoff: all the geometric machinery (vertex sorting, face construction, adjacency via containers) exists to satisfy the abstract axioms of the Sperner theorem in `SpernerMathlib`. Once the axioms are met, the combinatorial proof runs automatically.\n\nThe parity condition (odd boundary doors) is the discrete analog of Sperner's boundary condition: in the original Sperner's lemma, the boundary coloring must be 'Sperner-proper', which ensures an odd count of boundary simplices with d-1 distinct colors.",


### PR DESCRIPTION
## Fix

Fifteen gallery proofs had their final annotation's `endLine` pointing past the last line of the Lean source file. Each trailing annotation's `endLine` is clamped to the actual file line count.

## Evidence

For each slug, exactly one annotation (the trailing summary/closing section) had `endLine > LOC`, with its `startLine` still in range — the classic result of trailing source lines being removed after the annotation was authored.

| slug | endLine → LOC |
|------|---------------|
| erdos-274 | 130 → 127 |
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02 | 254 → 252 |
| erdos-395 | 186 → 184 |
| binary-gcd-oq-03 | 490 → 488 |
| erdos-582 | 317 → 315 |
| sperner-simplicial-bridge | 612 → 611 |
| friendship-theorem-oq-01 | 2276 → 2275 |
| euler-identity-oq-01 | 211 → 210 |
| erdos-114 | 49 → 48 |
| erdos-1133 | 195 → 194 |
| quadratic-reciprocity-oq-03 | 119 → 118 |
| erdos-275 | 172 → 171 |
| law-of-cosines-oq-01-oq-04 | 191 → 190 |
| erdos-187 | 60 → 59 |
| shannon-channel-coding-oq-02-oq-03 | 163 → 162 |

Each file ends at its LOC with a namespace `end`, docstring close, or final code line, so clamping to LOC keeps the annotation covering its real content. Diff is one line per file (15 files, 15 insertions, 15 deletions). Each annotations.json re-validated as parseable JSON.

Excluded from this pass (out of mechanic scope): `ballot-problem-oq-03-oq-01-oq-02` and `ballot-problem-oq-01-oq-04` (full-rewrite/multi-file ghost ranges — enricher scope), `cauchy-schwarz-integral-...` (duplicate annotation sets), `derangements-convergence` (in-flight PR #24156).

---
Automated fix by lean-mechanic agent.