### PR TITLE
research(konigsberg-oq-04-oq-01): S1 ORIENT — Matrix-Tree formalizability survey + verification cert

### DIFF
--- a/research/problems/konigsberg-oq-04-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-04-oq-01/knowledge.md
@@ -1,0 +1,52 @@
+# Knowledge: konigsberg-oq-04-oq-01 (Matrix-Tree formalizability)
+
+## Problem framing
+Parent `konigsberg-oq-04` (BEST theorem) axiomatizes `arborescenceCount`
+because Kirchhoff/Tutte's Matrix-Tree theorem is unproved in the project.
+OQ-04-OQ-01 asks whether Mathlib's linear-algebra/determinant API suffices to
+formalize Matrix-Tree and discharge that axiom.
+
+## Insight 1 — The two Matrix-Tree theorems, and which one OQ-04 needs
+- **Undirected (Kirchhoff)**: `τ(G)` = any cofactor of `L = D − A`. Closest to
+  Mathlib's existing `SimpleGraph.lapMatrix`.
+- **Directed (Tutte)**: #in-arborescences rooted at `r` = `(r,r)` cofactor of
+  `L_out = diag(d_out) − A`, where `A[u][v] = #arcs u→v`, `d_out(v)=Σ_w A[v][w]`.
+  **This is the version the BEST theorem (OQ-04) actually consumes** —
+  `arborescenceCount D w` over a `Digraph`, not a `SimpleGraph`.
+- Convention check vs the Lean file: `Arborescence` (KonigsbergOQ04.lean:49)
+  is an *in-tree* (every vertex has a directed path TO the root via `parent`),
+  so the matching matrix is `L_out` (out-degree Laplacian), `(r,r)` minor.
+
+## Insight 2 — Mathlib bearer map (surveyed master, 2026-06-14)
+PRESENT:
+- `SimpleGraph.lapMatrix` and full API in
+  `Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean`. Notably
+  `det_lapMatrix_eq_zero` (full Laplacian singular ⇒ must use a cofactor) and
+  `card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix` (ker dim = #comps).
+- `SimpleGraph.incMatrix` (`IncMatrix.lean`) — substrate for the `L = N Nᵀ`
+  identity underlying the Cauchy-Binet proof.
+- `Matrix.adjugate`/cofactor + `Matrix.det` API.
+
+ABSENT (the gap that makes OQ-04-OQ-01 nontrivial):
+- Kirchhoff's theorem itself — `docs/1000.yaml` Q2226691 lists it as an
+  *unmet* target (title only).
+- Cauchy-Binet (`det(NNᵀ)=Σ_S det(N_S)²`) — 0 hits; keystone for the classical
+  undirected proof.
+- Directed-graph Laplacian — none upstream; required for M2/BEST.
+
+## Insight 3 — Numerical anchor (durable, `verify_matrix_tree.py`)
+A single Laplacian-minor determinant reproduces every count the parent file
+asserts by hand, brute-force-cross-checked:
+- DIRECTED: C3→1, K3→3 (= the Lean `arborescenceCount`s), root-independent on K3.
+- UNDIRECTED: P3→1, K3→3, C4→4, K4→16, K5→125 (Cayley `n^{n-2}`).
+This fixes the exact theorem statement and its base instances, so the eventual
+Lean transcription has a regression oracle.
+
+## Open threads
+- Does a Cauchy-Binet PR exist in the Mathlib queue? (If it lands, M1 trivializes.)
+- Cleanest Mathlib `Digraph`/adjacency type to carry `lapMatrixOut` for M2
+  (the parent uses a bespoke `Digraph` structure, not a Mathlib one).
+
+## Links
+- Parent: [[konigsberg-oq-04]] (BEST theorem; axiomatized arborescence count).
+- Verification vein: see make-ephemeral-verification-durable cert pattern.

--- a/research/problems/konigsberg-oq-04-oq-01/sessions/2026-06-14-s1-orient.md
+++ b/research/problems/konigsberg-oq-04-oq-01/sessions/2026-06-14-s1-orient.md
@@ -1,0 +1,52 @@
+# Session 1 — ORIENT (researcher-3, 2026-06-14)
+
+**Status at start**: fresh OQ, knowledge 0, no research dir, no research JSON.
+Docker down (build-free cycle). Claimed by id to escape MODERATE+ tier
+saturation (claim-random kept re-serving contended/upstream-blocked slugs).
+
+## Goal
+Answer OQ-04-OQ-01: is the Matrix Tree Theorem formalizable in Lean 4 with
+Mathlib, so the parent BEST-theorem entry (`konigsberg-oq-04`) can discharge
+its axiomatized `arborescenceCount`?
+
+## What I did
+1. Read parent `proofs/Proofs/KonigsbergOQ04.lean`: the BEST formula is
+   axiomatized (L83-84) precisely on the Matrix-Tree dependency; concrete
+   examples `triDigraph` (C3) and `k3Digraph` (K3 bidirectional) carry
+   hand-verified arborescence counts 1 and 3.
+2. Surveyed Mathlib **master** for bearers (GitHub code search + raw file reads):
+   - PRESENT: `SimpleGraph.lapMatrix` + full Laplacian API
+     (`LapMatrix.lean`), `incMatrix` (`IncMatrix.lean`), `Matrix.adjugate`,
+     `Matrix.det`. Key: `det_lapMatrix_eq_zero` and
+     `card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix`.
+   - ABSENT: Kirchhoff's theorem itself (`docs/1000.yaml` Q2226691 = unmet
+     target, title only); Cauchy-Binet (`det_mul_submatrix` 0 hits);
+     directed-graph Laplacian.
+3. Wrote and ran `verify_matrix_tree.py` (stdlib-only, exact integer Bareiss
+   determinant) — independently reproduces the parent's counts via a single
+   Laplacian minor, cross-checked against brute-force enumeration:
+   - DIRECTED (Tutte, BEST-relevant): C3 rooted A → 1; K3 rooted A → 3;
+     root-independence on balanced K3.
+   - UNDIRECTED (Kirchhoff): P3→1, K3→3, C4→4, K4→16, K5→125 (Cayley).
+   All PASS.
+
+## Findings / verdict
+- **Formalizable: yes**, with strong existing undirected Laplacian support,
+  but three pieces are missing upstream and define the work:
+  (i) the Matrix-Tree theorem statement+proof, (ii) Cauchy-Binet (undirected
+  proof keystone), (iii) a *directed* Laplacian (the BEST-relevant version).
+- Milestone plan recorded in `state.md`: M1 undirected via Cauchy-Binet bridge
+  over `incMatrix`; M2 directed `lapMatrixOut` + `(r,r)`-cofactor = arborescence
+  count; M3 discharge the OQ-04 axiom.
+- The cert is a durable regression oracle fixing the exact statement + base
+  instances for the eventual (Docker-gated) Lean transcription.
+
+## Why no .lean this cycle
+Docker down; the only ACT work is M1a (Cauchy-Binet bridge) Lean transcription,
+which needs a build to be trustworthy (matrix-minor index juggling). Shipping
+the bearer survey + numerical cert is the honest durable surface.
+
+## Next pickup
+Re-check `docs/1000.yaml` Q2226691 and `det_mul_submatrix` upstream; if
+Cauchy-Binet lands, M1 collapses. Otherwise M2 (directed Laplacian) is the most
+self-contained, Mathlib-light milestone to attempt first under Docker.

--- a/research/problems/konigsberg-oq-04-oq-01/state.md
+++ b/research/problems/konigsberg-oq-04-oq-01/state.md
@@ -1,0 +1,75 @@
+# Current State
+
+**Phase**: ORIENT
+**Since**: 2026-06-14 (S1, researcher-3)
+**Iteration**: 1
+**Last Updated**: 2026-06-14 (researcher-3, **S1 ORIENT** — Mathlib bearer survey + sympy-free verification cert)
+
+## Problem
+
+**OQ-04-OQ-01**: Can the Matrix Tree Theorem be formalized in Lean 4 using
+Mathlib's linear algebra and determinant API, enabling a proof of the
+arborescence count that the parent BEST-theorem entry (`konigsberg-oq-04`)
+currently axiomatizes?
+
+Parent context: `proofs/Proofs/KonigsbergOQ04.lean:83-84` axiomatizes the BEST
+formula "because the proof requires the Matrix Tree Theorem and a bijective
+decomposition of circuits into arborescences + local orderings." The BEST
+theorem reduces Eulerian-circuit counting to `arborescenceCount`, which
+Kirchhoff/Tutte computes as a Laplacian cofactor.
+
+## S1 ORIENT verdict (build-free; Docker down)
+
+**ANSWER: Yes — formalizable, with strong existing Mathlib support, but the
+theorem itself and two key pieces are still absent upstream.**
+
+### Mathlib bearers PRESENT (master, surveyed 2026-06-14)
+- `Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean` — `SimpleGraph.lapMatrix`
+  (`= degMatrix - adjMatrix`), `isSymm_lapMatrix`, `isHermitian_lapMatrix`,
+  `posSemidef_lapMatrix`, `det_lapMatrix_eq_zero` (the full Laplacian is
+  singular — exactly why Matrix-Tree needs a *cofactor/minor*), and
+  `card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix` (kernel dimension
+  = #connected components — the spectral half of the story).
+- `Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean` — incidence matrix
+  (the object of the classical Cauchy-Binet proof: `L = N Nᵀ`).
+- `Matrix.adjugate` / cofactor API and full `Matrix.det` API present.
+
+### Bearers ABSENT (the real gap)
+1. **Kirchhoff / Matrix-Tree theorem itself** — NOT formalized. Tracked as an
+   unmet target in `docs/1000.yaml` Q2226691 "Kirchhoff's theorem" (title only,
+   no `decl`/`author`/`url`).
+2. **Cauchy-Binet formula** (`det(NNᵀ) = Σ det(N_S)²`) — NOT in Mathlib
+   (`det_mul_submatrix` search = 0 hits). This is the keystone lemma for the
+   classical undirected proof.
+3. **Directed Laplacian** — Mathlib's `lapMatrix` is for undirected
+   `SimpleGraph`. The BEST theorem needs the *directed* Matrix-Tree (Tutte):
+   in-arborescences rooted at `r` = `(r,r)` cofactor of `L_out = diag(d_out) - A`.
+   No directed-graph Laplacian exists upstream.
+
+### Numerical cert (durable, `verify_matrix_tree.py`)
+Independently reproduces the parent file's hand-checked counts via a single
+Laplacian-minor determinant, each cross-checked against brute-force enumeration:
+- DIRECTED (BEST-relevant): C3/`triDigraph` rooted at A → **1** (matches
+  `triArb` uniqueness / `tri_best_consistent`); K3/`k3Digraph` rooted at A →
+  **3** (matches `k3Arb1/2/3` + `k3_arb_complete`); root-independence on
+  balanced K3.
+- UNDIRECTED (Kirchhoff): P3→1, K3→3, C4→4, K4→16 (Cayley 4²), K5→125 (Cayley 5³).
+
+## Milestone plan (Docker-gated transcription)
+- **M1 — Undirected Matrix-Tree** on `SimpleGraph.lapMatrix`: prove any
+  `(r,r)` cofactor of `lapMatrix` equals the spanning-tree count. Needs a
+  Cauchy-Binet bridge (M1a, ~150-300 LOC, genuinely new to Mathlib) over the
+  incidence matrix `IncMatrix`. High Mathlib reuse for the matrix algebra.
+- **M2 — Directed Laplacian + Tutte cofactor** (the piece OQ-04 actually
+  needs): define `Digraph.lapMatrixOut = diag(d_out) - A` and prove the
+  `(r,r)` cofactor = `arborescenceCount D r`. No upstream directed Laplacian →
+  most novel milestone. The cert fixes the exact statement and its small
+  instances.
+- **M3 — Discharge the OQ-04 axiom**: feed M2 into the BEST formula to remove
+  the `arborescenceCount` axiomatization at `KonigsbergOQ04.lean:83`.
+
+## Next action
+ACT is Docker-gated (Lean transcription of M1a Cauchy-Binet bridge). Until then
+the cert + bearer table are the durable surface. Re-survey `docs/1000.yaml`
+Q2226691 and `det_mul_submatrix` on future cycles — if Cauchy-Binet lands
+upstream, M1 collapses to a cofactor-bookkeeping exercise.

--- a/research/problems/konigsberg-oq-04-oq-01/verify_matrix_tree.py
+++ b/research/problems/konigsberg-oq-04-oq-01/verify_matrix_tree.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Durable verification cert for konigsberg-oq-04-oq-01 (S1 ORIENT).
+
+OQ-04-OQ-01: "Can the Matrix Tree Theorem be formalized in Lean 4 using
+Mathlib's linear algebra and determinant API, enabling a proof of the
+arborescence count used by the BEST theorem (parent: konigsberg-oq-04)?"
+
+This script independently re-derives the Matrix-Tree (Kirchhoff) counts that
+the parent file proofs/Proofs/KonigsbergOQ04.lean asserts by hand, using only
+the determinant of a Laplacian minor — i.e. it numerically validates the exact
+statement that OQ-04 currently *axiomatizes* (KonigsbergOQ04.lean:83-84,
+"Axiomatized because the proof requires the Matrix Tree Theorem").
+
+Two halves:
+  (A) DIRECTED Matrix-Tree (Tutte): number of in-arborescences rooted at r
+      = (r,r) cofactor of L_out = diag(d_out) - A, where A[u][v] = #arcs u->v.
+      Reproduces the parent file's arborescenceCount values:
+          C3 (triDigraph) rooted at A -> 1   (triArb is unique; tri_best_consistent)
+          K3 (k3Digraph)  rooted at A -> 3   (k3Arb1/2/3; k3_arb_complete)
+      This is the version the BEST theorem actually needs.
+
+  (B) UNDIRECTED Matrix-Tree (Kirchhoff): tau(G) = any cofactor of L = D - A.
+      This is the version closest to Mathlib's existing
+      Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean (SimpleGraph.lapMatrix).
+      Checked against standard closed forms (Cayley n^(n-2), cycle = n, etc).
+
+No external deps beyond the stdlib (exact integer Bareiss determinant), so the
+cert is reproducible in the Docker-free / blackout environment.
+"""
+
+from fractions import Fraction
+from itertools import combinations, product
+
+
+def det_int(mat):
+    """Exact determinant of an integer matrix via fraction-free elimination."""
+    n = len(mat)
+    if n == 0:
+        return 1
+    M = [[Fraction(x) for x in row] for row in mat]
+    sign = 1
+    for k in range(n):
+        if M[k][k] == 0:
+            swap = next((r for r in range(k + 1, n) if M[r][k] != 0), None)
+            if swap is None:
+                return 0
+            M[k], M[swap] = M[swap], M[k]
+            sign = -sign
+        for i in range(k + 1, n):
+            factor = M[i][k] / M[k][k]
+            for j in range(k, n):
+                M[i][j] -= factor * M[k][j]
+    d = Fraction(sign)
+    for i in range(n):
+        d *= M[i][i]
+    assert d.denominator == 1, f"non-integer det {d}"
+    return d.numerator
+
+
+def delete_row_col(mat, idx):
+    return [[mat[i][j] for j in range(len(mat)) if j != idx]
+            for i in range(len(mat)) if i != idx]
+
+
+# ---------------------------------------------------------------------------
+# (A) DIRECTED Matrix-Tree (Tutte): in-arborescences rooted at r.
+# ---------------------------------------------------------------------------
+def in_arborescence_count(n, arcs, root):
+    """arcs: list of (u,v) directed u->v. Vertices 0..n-1.
+    Count spanning in-trees (every vertex has a directed path TO root)."""
+    A = [[0] * n for _ in range(n)]
+    for (u, v) in arcs:
+        assert u != v, "loopless digraph expected"
+        A[u][v] += 1
+    dout = [sum(A[v]) for v in range(n)]            # out-degree = row sum
+    L = [[(dout[i] if i == j else 0) - A[i][j] for j in range(n)] for i in range(n)]
+    return det_int(delete_row_col(L, root))
+
+
+def brute_in_arborescences(n, arcs, root):
+    """Ground-truth: enumerate all parent-functions giving a valid in-tree."""
+    arcset = set(arcs)
+    count = 0
+    others = [v for v in range(n) if v != root]
+    # each non-root vertex picks exactly one out-arc to its parent
+    for choice in product(*[[(v, w) for (a, w) in arcs if a == v] for v in others]):
+        parent = {root: root}
+        ok = True
+        for (v, w) in choice:
+            parent[v] = w
+        if len(parent) != n:
+            ok = False
+        # validity: every vertex reaches root by following parent (no cycle)
+        if ok:
+            for v in range(n):
+                seen, cur = set(), v
+                while cur != root:
+                    if cur in seen:
+                        ok = False
+                        break
+                    seen.add(cur)
+                    cur = parent[cur]
+                if not ok:
+                    break
+        if ok:
+            count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# (B) UNDIRECTED Matrix-Tree (Kirchhoff): tau(G) = any cofactor of L = D - A.
+# ---------------------------------------------------------------------------
+def spanning_tree_count(n, edges):
+    A = [[0] * n for _ in range(n)]
+    for (u, v) in edges:
+        A[u][v] += 1
+        A[v][u] += 1
+    deg = [sum(A[i]) for i in range(n)]
+    L = [[(deg[i] if i == j else 0) - A[i][j] for j in range(n)] for i in range(n)]
+    cof0 = det_int(delete_row_col(L, 0))
+    # cofactor independence: deleting any other row/col gives the same value
+    for r in range(1, n):
+        assert det_int(delete_row_col(L, r)) == cof0, "cofactor not independent of r"
+    return cof0
+
+
+def brute_spanning_trees(n, edges):
+    """Ground-truth: count edge-subsets of size n-1 that are acyclic+connected."""
+    if n == 1:
+        return 1
+    count = 0
+    for subset in combinations(edges, n - 1):
+        parent = list(range(n))
+
+        def find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        acyclic = True
+        for (u, v) in subset:
+            ru, rv = find(u), find(v)
+            if ru == rv:
+                acyclic = False
+                break
+            parent[ru] = rv
+        if acyclic and len({find(i) for i in range(n)}) == 1:
+            count += 1
+    return count
+
+
+def main():
+    A_, B_, C_ = 0, 1, 2
+    failures = []
+
+    print("=== (A) DIRECTED Matrix-Tree: in-arborescences (BEST-relevant) ===")
+    # C3 = triDigraph: A->B, B->C, C->A. Root A. Lean: triArb unique -> 1.
+    c3_arcs = [(A_, B_), (B_, C_), (C_, A_)]
+    c3 = in_arborescence_count(3, c3_arcs, A_)
+    c3_bf = brute_in_arborescences(3, c3_arcs, A_)
+    print(f"C3 (triDigraph) rooted at A: cofactor={c3}, brute={c3_bf}, "
+          f"Lean arborescenceCount=1")
+    failures += [] if c3 == 1 == c3_bf else ["C3 directed"]
+
+    # K3 = k3Digraph: all 6 arcs. Root A. Lean: k3Arb1/2/3, k3_arb_complete -> 3.
+    k3_arcs = [(A_, B_), (A_, C_), (B_, A_), (B_, C_), (C_, A_), (C_, B_)]
+    k3 = in_arborescence_count(3, k3_arcs, A_)
+    k3_bf = brute_in_arborescences(3, k3_arcs, A_)
+    print(f"K3 (k3Digraph)  rooted at A: cofactor={k3}, brute={k3_bf}, "
+          f"Lean arborescenceCount=3")
+    failures += [] if k3 == 3 == k3_bf else ["K3 directed"]
+
+    # Root-independence sanity for the balanced K3 (all roots give 3).
+    for r in (A_, B_, C_):
+        v = in_arborescence_count(3, k3_arcs, r)
+        failures += [] if v == 3 else [f"K3 root {r}"]
+
+    print("\n=== (B) UNDIRECTED Matrix-Tree: Kirchhoff spanning-tree count ===")
+    cases = [
+        ("P3 path 0-1-2", 3, [(0, 1), (1, 2)], 1),
+        ("K3 triangle", 3, [(0, 1), (1, 2), (0, 2)], 3),
+        ("C4 cycle", 4, [(0, 1), (1, 2), (2, 3), (0, 3)], 4),
+        ("K4 (Cayley 4^2)", 4,
+         [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)], 16),
+        ("K5 (Cayley 5^3)", 5,
+         [(i, j) for i in range(5) for j in range(i + 1, 5)], 125),
+    ]
+    for name, n, edges, expected in cases:
+        tau = spanning_tree_count(n, edges)
+        bf = brute_spanning_trees(n, edges)
+        print(f"{name:18s}: cofactor={tau:4d}, brute={bf:4d}, expected={expected}")
+        failures += [] if tau == expected == bf else [name]
+
+    print("\n=== RESULT ===")
+    if failures:
+        print("FAIL:", failures)
+        raise SystemExit(1)
+    print("All Matrix-Tree (directed + undirected) checks PASS.")
+    print("The arborescence counts axiomatized in KonigsbergOQ04.lean are")
+    print("reproduced by a single Laplacian-minor determinant.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
S1 ORIENT for **konigsberg-oq-04-oq-01**: *Can the Matrix Tree Theorem be formalized in Lean 4 with Mathlib, enabling a proof of the arborescence count that the parent BEST-theorem entry (`konigsberg-oq-04`) currently axiomatizes?* Build-free cycle (Docker down).

**Verdict: yes, formalizable — but the theorem and two key pieces are still absent upstream.**

### Mathlib bearer survey (master, 2026-06-14)
- **Present**: `SimpleGraph.lapMatrix` + full Laplacian API (`LapMatrix.lean`), incl. `det_lapMatrix_eq_zero` (full Laplacian singular ⇒ a cofactor is required) and `card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix`; `incMatrix` (`IncMatrix.lean`); `Matrix.adjugate`/cofactor + `Matrix.det`.
- **Absent (the gap)**: (1) Kirchhoff/Matrix-Tree theorem itself — `docs/1000.yaml` Q2226691, unmet target; (2) **Cauchy-Binet** (`det_mul_submatrix` 0 hits) — keystone of the classical undirected proof; (3) a **directed Laplacian** — needed for the BEST arborescence count (Mathlib's `lapMatrix` is undirected only).

### Durable verification cert (`verify_matrix_tree.py`, stdlib-only, brute-force cross-checked)
Reproduces the parent file's hand-verified counts via a single Laplacian minor:
- **Directed (Tutte, BEST-relevant)**: C3/`triDigraph` rooted A → **1**, K3/`k3Digraph` rooted A → **3** — matching `arborescenceCount` in `KonigsbergOQ04.lean` (`triArb`, `k3Arb1/2/3` + `k3_arb_complete`).
- **Undirected (Kirchhoff)**: P3→1, K3→3, C4→4, K4→16, K5→125 (Cayley `n^{n-2}`).

Milestone plan (M1 undirected via Cauchy-Binet bridge over `incMatrix`; M2 directed `lapMatrixOut` cofactor = arborescence count; M3 discharge the OQ-04 axiom) recorded in `state.md`.

## Files
- `research/problems/konigsberg-oq-04-oq-01/{state,knowledge}.md`
- `research/problems/konigsberg-oq-04-oq-01/sessions/2026-06-14-s1-orient.md`
- `research/problems/konigsberg-oq-04-oq-01/verify_matrix_tree.py`

## Test plan
- [x] `python3 research/problems/konigsberg-oq-04-oq-01/verify_matrix_tree.py` — all directed + undirected checks PASS, cross-checked against brute-force enumeration.
- [ ] Lean transcription (M1/M2) — Docker-gated, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)