### PR TITLE
Enrich Erdős #1022: add scannable cross-reference descriptions

### DIFF
--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -174,27 +174,33 @@
   "crossReferences": [
     {
       "relationship": "The Lovász Local Lemma (1975) is the direct probabilistic successor to the sparseness condition in Problem #1022. The LLL proves property B when each hyperedge shares elements with few others; Problem #1022 asks whether a global subset-density bound (sparseness) likewise guarantees property B. The two conditions are formally related: sparseness bounds the expected number of 'bad' monochromatic events, while the LLL handles dependent bad events explicitly.",
-      "targetId": "prob-method-lovasz-local"
+      "targetId": "prob-method-lovasz-local",
+      "description": "The Lovász Local Lemma (1975), the probabilistic successor to #1022's sparseness condition: LLL proves property B when each hyperedge shares elements with few others, while #1022 asks whether a global subset-density bound does the same."
     },
     {
       "relationship": "This library demonstrates the classical applications of the probabilistic method, including the Erdős (1963) first-moment proof that families of t-sets with fewer than 2^{t-1} members have property B — the global-size predecessor to Problem #1022's local-density (sparseness) condition. Property B is one of the canonical showcases for the probabilistic method.",
-      "targetId": "prob-method-applications"
+      "targetId": "prob-method-applications",
+      "description": "Classical probabilistic-method applications, including Erdős's 1963 first-moment proof that $t$-set families with fewer than $2^{t-1}$ members have property B — the global-size predecessor to #1022's local-density condition."
     },
     {
       "relationship": "Erdős Problem #836 studies intersecting hypergraphs with chromatic number 3, citing the Erdős-Lovász (1975) paper that established the Lovász Local Lemma. The bound ≫ r/log r on edge intersections comes from an early LLL application. Problem #1022 was posed in the same 1968–1975 period by Erdős and Lovász and sits in the same circle of hypergraph coloring questions.",
-      "targetId": "erdos-836"
+      "targetId": "erdos-836",
+      "description": "Erdős #836 on intersecting hypergraphs with chromatic number 3 (bound $\\gg r/\\log r$ from an early LLL application); posed in the same 1968–1975 Erdős–Lovász circle of hypergraph-coloring questions as #1022."
     },
     {
       "relationship": "The Erdős Matching Conjecture (Problem #1020) is a parallel r-uniform hypergraph extremal problem: bounding the maximum number of edges in a hypergraph with no k independent edges. Both problems impose structural constraints on set families — matching-freeness versus sparseness — and both are open for r ≥ 4, reflecting the difficulty of r-uniform hypergraph combinatorics.",
-      "targetId": "erdos-1020"
+      "targetId": "erdos-1020",
+      "description": "The Erdős Matching Conjecture — a parallel $r$-uniform extremal problem (max edges with no $k$ independent edges); like #1022 it constrains set families and is open for $r \\ge 4$."
     },
     {
       "relationship": "Problem #1023 on union-free families is complementary: it asks how large a set family can be if no member is the union of others (a 'union-free' condition). Both problems constrain set families via inclusion/union structure. Problem #1022's sparseness bounds the number of sub-family members inside any superset; #1023 forbids unions entirely. The solved answer F(n) = C(n,n/2) for #1023 contrasts with the open status of #1022.",
-      "targetId": "erdos-1023"
+      "targetId": "erdos-1023",
+      "description": "Union-free families: how large a family can be if no member is the union of others. Complementary to #1022's sparseness; #1023 is solved ($F(n) = \\binom{n}{n/2}$) while #1022 is open."
     },
     {
       "relationship": "Problem #562 on hypergraph Ramsey tower growth concerns r-uniform hypergraph Ramsey numbers, where r-colorings of complete hypergraphs are forced to contain monochromatic cliques. The tower-growth phenomenon arises from the difficulty of r-uniform hypergraph coloring, the same difficulty underlying Problem #1022's open cases for t ≥ 3.",
-      "targetId": "erdos-562"
+      "targetId": "erdos-562",
+      "description": "Hypergraph Ramsey tower growth for $r$-uniform Ramsey numbers; the tower phenomenon stems from the same difficulty of $r$-uniform coloring underlying #1022's open cases for $t \\ge 3$."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass for `erdos-1022`

### Problem
All 6 cross-references stored a 337–459 char essay in `relationship` with no `description`. The Related Proofs UI renders `ref.description ?? ref.relationship`, so each linked proof rendered as a full paragraph instead of a scannable label.

### Fix
Added a concise one-sentence `description` to each of the 6 cross-references, condensed faithfully from the existing essays. The detailed `relationship` text is **preserved unchanged**. Surgical diff: +12 / −6.

### Integrity checks
- **Axiom integrity verified**: 1 `axiom` (`erdos_1022_conjecture`) in `Proofs/Erdos1022Problem.lean`, `axiomCount: 1` matches, 0 sorries, `status: "axiomatized"` / `badge: "axiom"` correct.
- All 6 cross-reference targets exist (no dead links).
- `pnpm build` passes; JSON validated.