### PR TITLE
research(cramers-rule-oq-04-oq-01): OQ already answered by CramersRuleOQ01.lean

### DIFF
--- a/research/problems/cramers-rule-oq-04-oq-01/problem.md
+++ b/research/problems/cramers-rule-oq-04-oq-01/problem.md
@@ -1,0 +1,24 @@
+# cramers-rule-oq-04-oq-01
+
+**Parent:** cramers-rule-oq-04 (the adjugate as a generalized inverse — reflexive properties)
+**Tier:** B  ·  **Significance:** 6  ·  **Tractability:** 7
+**Tags:** gallery-extracted, linear-algebra, seeker-selected
+
+## Open Question (verbatim)
+
+> Formalize the algebraic Cayley-Hamilton proof via adj(xI−A)·(xI−A) = charpoly(A)·I —
+> the adjugate reflexive properties here are the key building block.
+
+## Restatement
+
+Give an explicit Lean formalization of the *algebraic* proof of the Cayley–Hamilton
+theorem (as opposed to citing `Matrix.aeval_self_charpoly` as a black box). The proof
+should route through the adjugate identity applied to the characteristic matrix
+`charmatrix M = X•1 − C M`:
+
+```
+adjugate(charmatrix M) · charmatrix M = det(charmatrix M) • 1 = charpoly(M) • 1
+```
+
+and then transfer to `(Matrix n n R)[X]` and evaluate at `X = M` to obtain
+`aeval M (charpoly M) = 0`.


### PR DESCRIPTION
## Summary

FRESH/ORIENT on `cramers-rule-oq-04-oq-01`. The OQ asks to **formalize the algebraic Cayley–Hamilton proof via `adj(xI−A)·(xI−A) = charpoly(A)·I`**. A pre-work grep of the gallery shows this deliverable **already exists**, fully formalized (0 sorries, 0 axioms), in `proofs/Proofs/CramersRuleOQ01.lean`:

| OQ ask | Existing theorem | Location |
|--------|------------------|----------|
| `adj(charmatrix M)·charmatrix M = charpoly(M)·I` | `cramer_applied_to_charmatrix` | CramersRuleOQ01.lean:108–113 |
| explicit algebraic CH derivation (non-black-box) | `cayley_hamilton_proof_via_cramer` | :192–208 |
| conditional "Cramer ⟹ CH" | `cramer_implies_cayley_hamilton` | :264–280 |

`cayley_hamilton_proof_via_cramer` spells out every step (adjugate identity → `matPolyEquiv` → evaluate at `M` via `eval_mul_X_sub_C`) rather than invoking `Matrix.aeval_self_charpoly` — exactly the "algebraic proof" requested.

## What this PR contains

Documentation only (no `.lean` churn): `research/problems/cramers-rule-oq-04-oq-01/{problem,knowledge,state}.md` recording the finding with exact bearer citations, so future agents don't re-attempt an already-solved OQ.

## Framing correction

The OQ says the *reflexive* adjugate properties are "the key building block." This is imprecise: the actual building block is the **plain** adjugate identity `adjugate_mul` (`adj(A)·A = det(A)•1`), which `CramersRuleOQ01` correctly uses. The reflexive forms are corollaries that add no proof power toward CH. The only genuinely-new fragment specific to this slug is a trivial reflexive-at-charmatrix corollary (mirrors `CramersRuleOQ04.adjugate_reflexive_sym`), left for an optional future build-enabled session.

## Notes

- Pool status → `surveyed` (answered). Docker was down this session; finding is source-grep based and durable (no build needed).
- Label `research` only — no Judge review requested.