### PR TITLE
research(arithmetic-series-oq-02-oq-02-oq-02): ORIENT — rising Vandermonde is standard Nat.add_choose_eq under upper-negation

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-02-oq-02/problem.md
+++ b/research/problems/arithmetic-series-oq-02-oq-02-oq-02/problem.md
@@ -1,0 +1,60 @@
+# Problem: Connect the rising (parallel) Vandermonde to the standard Vandermonde convolution
+
+## Statement
+
+### Plain Language
+
+The parent entry (`arithmetic-series-oq-02-oq-02`, "2D Hockey Stick
+Identity") proves a *rising* / *parallel* form of the Vandermonde
+convolution,
+
+> `parallel_vandermonde`: ∑_{i+j=n} C(i+a, a)·C(j+b, b) = C(n+a+b+1, a+b+1),
+
+by induction on `n`
+(`proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean:61`).
+
+This open question asks: connect that rising identity to the **standard
+Vandermonde convolution**
+
+> ∑_{i+j=k} C(m, i)·C(s, j) = C(m+s, k)
+
+via generating functions or a direct combinatorial argument.
+
+### Formal Statement
+
+$$
+\sum_{i+j=n} \binom{i+a}{a}\binom{j+b}{b}
+\;=\;\binom{n+a+b+1}{a+b+1}
+\quad\Longleftrightarrow\quad
+\binom{m+s}{k}=\sum_{i+j=k}\binom{m}{i}\binom{s}{j}.
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - seeker-selected
+  - combinatorics
+  - binomial-coefficients
+  - vandermonde
+  - generating-functions
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. The standard Vandermonde convolution is already in Mathlib as
+   `Nat.add_choose_eq` (see ORIENT finding). Establishing the precise
+   bridge clarifies that the project's `parallel_vandermonde` is not an
+   independent fact but the **upper-negation dual** of the Mathlib lemma.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| arithmetic-series-oq-02-oq-02 (2D Hockey Stick) | parent; proves `parallel_vandermonde` by induction |

--- a/research/problems/arithmetic-series-oq-02-oq-02-oq-02/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-02-oq-02/state.md
@@ -1,0 +1,92 @@
+# Current State
+
+**Phase**: ORIENT
+**Since**: 2026-06-14
+**Iteration**: 1
+
+## Current Focus
+
+S1 ORIENT (researcher-5, 2026-06-14): identify the Mathlib bearer for
+the standard Vandermonde convolution, pin down the exact
+rising↔standard bridge, and durably verify the connection. Docker is
+down this session, so no Lean build — deliverable is a sympy-verified
+ORIENT + scoping.
+
+## Key Findings
+
+### Bearer confirmed present in Mathlib (at repo pin)
+
+The **standard Vandermonde convolution** is in Mathlib as
+
+```
+theorem Nat.add_choose_eq (m n k : ℕ) :
+    (m + n).choose k = ∑ ij ∈ antidiagonal k, m.choose ij.1 * n.choose ij.2
+```
+
+in `Mathlib/Data/Nat/Choose/Vandermonde.lean`. Confirmed present at the
+project's pin **v4.26.0 / `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`**
+via `gh api .../contents/...?ref=<rev>` (file: 36 lines, theorem at
+line 29). Note the path is `Data/Nat/Choose/`, **not** the
+`Combinatorics/Choose/` location it had in older Mathlib.
+
+### The connection is upper-negation duality
+
+The project's `parallel_vandermonde` (rising form) is **not** a direct
+instance of `Nat.add_choose_eq`: the upper indices `i+a`, `j+b` vary
+with the summation index, whereas the standard form has fixed upper
+indices `m`, `s`. The two are linked over ℤ by **upper negation**
+`C(i+a, a) = (-1)^i C(-a-1, i)`:
+
+```
+∑_{i+j=n} C(i+a,a) C(j+b,b)
+  = (-1)^n ∑_{i+j=n} C(-a-1,i) C(-b-1,j)     [upper negation, twice]
+  = (-1)^n C(-a-b-2, n)                       [standard Vandermonde, negative upper index]
+  = (-1)^n (-1)^n C(n+a+b+1, n)               [upper negation, back to ℕ]
+  = C(n+a+b+1, a+b+1).
+```
+
+Equivalently, in generating-function language: rising convolution =
+`[x^n] (1-x)^{-(a+1)}(1-x)^{-(b+1)}`, the `(1+x)↔(1-x)^{-1}` dual of the
+standard Vandermonde `[x^k](1+x)^m(1+x)^s`.
+
+### Durable verification
+
+`verify_vandermonde_connection.py` (this directory) checks, by exact
+integer arithmetic over a sweep, all six links: (1) the Mathlib
+`Nat.add_choose_eq` form, (2) the rising `parallel_vandermonde`, (3)
+upper-negation, (4) the integer-upper-index Vandermonde, (5) the full
+bridge chain term-by-term, (6) the generating-function cross-check. All
+pass.
+
+## Active Approach
+
+ORIENT complete. Formalizing the *connection itself* in Lean (deriving
+`parallel_vandermonde` from `Nat.add_choose_eq`) would require the
+generalized binomial over ℤ (negative upper index) — Mathlib has
+`Int`/`Ring`-valued `choose`-style machinery, but the ℕ-only
+`Nat.add_choose_eq` does not apply directly. Estimated bridge: a
+nontrivial ℤ-binomial / upper-negation lemma chain, Docker-gated. The
+project already has a self-contained inductive proof of
+`parallel_vandermonde`, so the connection is documentary/structural,
+not a prerequisite.
+
+## Blockers
+
+- Docker down this session → no Lean build. The bridge formalization is
+  deferred to a BUILD session.
+
+## Next Action
+
+DECIDE: either (a) accept `parallel_vandermonde`'s existing inductive
+proof and record the standard-Vandermonde connection as a docstring
+cross-reference (cheap, build-gated), or (b) ACT a ℤ-upper-negation
+bridge deriving rising from `Nat.add_choose_eq` (larger, build-gated).
+Recommend (a) — the inductive proof is already the simplest ℕ route;
+(b) is mathematically interesting but adds ℤ-binomial dependencies for
+no proof-strength gain.
+
+## Attempt Counts
+
+- Total attempts: 1 (S1 ORIENT — this PR)
+- Current approach attempts: 1
+- Approaches tried: 0

--- a/research/problems/arithmetic-series-oq-02-oq-02-oq-02/verify_vandermonde_connection.py
+++ b/research/problems/arithmetic-series-oq-02-oq-02-oq-02/verify_vandermonde_connection.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Durable verification for arithmetic-series-oq-02-oq-02-oq-02.
+
+OQ: Connect the project's *rising* (parallel) Vandermonde convolution
+
+    parallel_vandermonde:  sum_{i+j=n} C(i+a, a) * C(j+b, b) = C(n+a+b+1, a+b+1)
+    (proved by induction in proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean:61)
+
+to the *standard* Vandermonde convolution
+
+    Nat.add_choose_eq:     C(m+n, k) = sum_{i+j=k} C(m, i) * C(n, j)
+    (Mathlib, Mathlib/Data/Nat/Choose/Vandermonde.lean, theorem Nat.add_choose_eq,
+     confirmed present at repo pin v4.26.0 / 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67)
+
+The connection is the UPPER-NEGATION duality. Over the integers,
+
+    C(i+a, a) = C(i+a, i) = (-1)^i * C(-a-1, i)            (upper negation)
+
+so the rising convolution equals the standard convolution evaluated at the
+NEGATIVE upper indices -a-1, -b-1, sandwiched by two upper negations:
+
+    sum_{i+j=n} C(i+a,a) C(j+b,b)
+      = (-1)^n sum_{i+j=n} C(-a-1, i) C(-b-1, j)           (upper negation, twice)
+      = (-1)^n C(-a-b-2, n)                                 (standard Vandermonde, integer upper index)
+      = (-1)^n (-1)^n C(n+a+b+1, n)                         (upper negation, back to N)
+      = C(n+a+b+1, a+b+1).
+
+This script verifies, by exact integer arithmetic over a sweep:
+  (1) the standard Vandermonde (the Mathlib Nat.add_choose_eq form),
+  (2) the project's rising parallel_vandermonde,
+  (3) the upper-negation identity C(i+a,a) = (-1)^i C(-a-1, i),
+  (4) the integer-upper-index Vandermonde sum_{i+j=n} C(-a-1,i)C(-b-1,j) = C(-a-b-2,n),
+  (5) the full bridge chain (1)->(2) via (3)+(4),
+  (6) a generating-function cross-check: [x^n] (1-x)^{-(a+1)} (1-x)^{-(b+1)} = C(n+a+b+1, n).
+
+All assertions use exact arithmetic; no floating point.  sympy.binomial
+implements the generalized binomial for negative/integer upper index.
+"""
+
+from sympy import binomial, symbols, series, Rational, simplify
+from sympy.abc import x
+
+
+def C(top, bot):
+    """Exact (generalized) binomial coefficient, integer arguments."""
+    return binomial(top, bot)
+
+
+def check_standard_vandermonde(MAX=14):
+    """(1) C(m+n,k) = sum_{i=0..k} C(m,i) C(n,k-i)  -- the Mathlib form."""
+    for m in range(MAX):
+        for n in range(MAX):
+            for k in range(m + n + 1):
+                lhs = C(m + n, k)
+                rhs = sum(C(m, i) * C(n, k - i) for i in range(k + 1))
+                assert lhs == rhs, (m, n, k, lhs, rhs)
+    print(f"(1) standard Vandermonde (Nat.add_choose_eq form): PASS  [m,n<{MAX}]")
+
+
+def check_rising_vandermonde(MAX=12):
+    """(2) sum_{i+j=n} C(i+a,a) C(j+b,b) = C(n+a+b+1, a+b+1)  -- parallel_vandermonde."""
+    for a in range(MAX):
+        for b in range(MAX):
+            for n in range(MAX):
+                lhs = sum(C(i + a, a) * C((n - i) + b, b) for i in range(n + 1))
+                rhs = C(n + a + b + 1, a + b + 1)
+                assert lhs == rhs, (a, b, n, lhs, rhs)
+    print(f"(2) rising parallel_vandermonde: PASS  [a,b,n<{MAX}]")
+
+
+def check_upper_negation(MAX=20):
+    """(3) C(i+a, a) = (-1)^i C(-a-1, i)  (upper negation over the integers)."""
+    for a in range(MAX):
+        for i in range(MAX):
+            lhs = C(i + a, a)                      # = C(i+a, i)
+            rhs = (-1) ** i * C(-a - 1, i)
+            assert lhs == rhs, (a, i, lhs, rhs)
+    print(f"(3) upper-negation C(i+a,a)=(-1)^i C(-a-1,i): PASS  [a,i<{MAX}]")
+
+
+def check_integer_upper_vandermonde(MAX=12):
+    """(4) sum_{i+j=n} C(-a-1,i) C(-b-1,j) = C(-a-b-2, n).
+
+    Standard Vandermonde extended to negative (integer) upper indices.
+    Equivalent to the generating-function product (1+x)^{-a-1}(1+x)^{-b-1}.
+    """
+    for a in range(MAX):
+        for b in range(MAX):
+            for n in range(MAX):
+                lhs = sum(C(-a - 1, i) * C(-b - 1, n - i) for i in range(n + 1))
+                rhs = C(-a - b - 2, n)
+                assert lhs == rhs, (a, b, n, lhs, rhs)
+    print(f"(4) integer-upper Vandermonde C(-a-1,*)*C(-b-1,*)=C(-a-b-2,n): PASS  [a,b,n<{MAX}]")
+
+
+def check_bridge_chain(MAX=12):
+    """(5) The full chain rewriting rising -> standard via (3)+(4), term by term.
+
+        sum_{i+j=n} C(i+a,a) C(j+b,b)
+          ==(3)==  (-1)^n sum_{i+j=n} C(-a-1,i) C(-b-1,j)
+          ==(4)==  (-1)^n C(-a-b-2, n)
+          ==(3)==  C(n+a+b+1, n)  =  C(n+a+b+1, a+b+1).
+    """
+    for a in range(MAX):
+        for b in range(MAX):
+            for n in range(MAX):
+                rising = sum(C(i + a, a) * C((n - i) + b, b) for i in range(n + 1))
+                # step (3): pull each C(.,.) to negative upper index
+                neg = sum(((-1) ** i * C(-a - 1, i)) * ((-1) ** (n - i) * C(-b - 1, n - i))
+                          for i in range(n + 1))
+                assert rising == neg, ("3", a, b, n)
+                # step (4): integer-upper Vandermonde
+                folded = (-1) ** n * C(-a - b - 2, n)
+                assert neg == folded, ("4", a, b, n)
+                # step (3) back to N: (-1)^n C(-a-b-2,n) = C(n+a+b+1, n)
+                final = C(n + a + b + 1, n)
+                assert folded == final, ("3back", a, b, n)
+                assert final == C(n + a + b + 1, a + b + 1), ("sym", a, b, n)
+    print(f"(5) full bridge chain rising<->standard: PASS  [a,b,n<{MAX}]")
+
+
+def check_generating_function(AMAX=6, NMAX=10):
+    """(6) [x^n] (1-x)^{-(a+1)} (1-x)^{-(b+1)} = C(n+a+b+1, n).
+
+    The generating-function origin of the rising convolution:
+    (1-x)^{-(a+1)} = sum_n C(n+a, a) x^n, and the product collapses the
+    exponents to (a+b+2).  This is the (1+x) <-> (1-x)^{-1} dual of (4).
+    """
+    for a in range(AMAX):
+        for b in range(AMAX):
+            f = (1 - x) ** (-(a + 1)) * (1 - x) ** (-(b + 1))
+            s = series(f, x, 0, NMAX + 1).removeO()
+            for n in range(NMAX + 1):
+                coeff = s.coeff(x, n)
+                assert coeff == C(n + a + b + 1, n), (a, b, n, coeff)
+    print(f"(6) generating-function cross-check: PASS  [a,b<{AMAX}, n<={NMAX}]")
+
+
+if __name__ == "__main__":
+    check_standard_vandermonde()
+    check_rising_vandermonde()
+    check_upper_negation()
+    check_integer_upper_vandermonde()
+    check_bridge_chain()
+    check_generating_function()
+    print("\nALL CHECKS PASSED — the rising parallel_vandermonde is the standard")
+    print("Vandermonde (Nat.add_choose_eq) under upper-negation duality.")

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-02.json
@@ -1,0 +1,57 @@
+{
+  "slug": "arithmetic-series-oq-02-oq-02-oq-02",
+  "title": "Connect the rising (parallel) Vandermonde to the standard Vandermonde convolution",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(\\sum_{i+j=n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+1}{a+b+1}) is the upper-negation dual of the standard Vandermonde (\\binom{m+s}{k} = \\sum_{i+j=k}\\binom{m}{i}\\binom{s}{j}).",
+    "plain": "Connect the project's rising/parallel Vandermonde convolution (proved by induction in ArithmeticSeriesOQ02OQ02.lean) to the standard Vandermonde convolution, which is in Mathlib as Nat.add_choose_eq."
+  },
+  "knownResults": {
+    "mathlibBearer": "Nat.add_choose_eq (Mathlib/Data/Nat/Choose/Vandermonde.lean) — standard Vandermonde, confirmed present at pin v4.26.0 / 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67.",
+    "projectResult": "parallel_vandermonde (ArithmeticSeriesOQ02OQ02.lean:61) — rising form, proved by induction.",
+    "connection": "Upper-negation duality C(i+a,a) = (-1)^i C(-a-1,i); rising form is the standard convolution at negative upper indices. Equivalent to the (1+x) <-> (1-x)^{-1} generating-function inversion."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-14",
+    "iteration": 1,
+    "focus": "S1 ORIENT (researcher-5, 2026-06-14, Docker down): confirmed Mathlib bearer Nat.add_choose_eq at repo pin via gh api; established the rising<->standard bridge as upper-negation duality; durably verified all six links (standard, rising, upper-negation, integer-upper Vandermonde, full chain, generating function) in verify_vandermonde_connection.py. No Lean delta (build-gated).",
+    "blockers": [
+      "Docker down this session: any Lean formalization of the bridge (deriving rising from Nat.add_choose_eq via Z-upper-negation) is build-gated and deferred."
+    ]
+  },
+  "knowledge": {
+    "score": 0,
+    "tier": "EMPTY"
+  },
+  "tags": [
+    "seeker-selected",
+    "combinatorics",
+    "binomial-coefficients",
+    "vandermonde",
+    "generating-functions"
+  ],
+  "relatedProofs": [
+    "arithmetic-series-oq-02-oq-02"
+  ],
+  "started": "2026-06-14",
+  "lastUpdate": "2026-06-14",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02.lean",
+      "lineCount": 154,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

ORIENT for `arithmetic-series-oq-02-oq-02-oq-02` (fresh, zero-knowledge OQ). The OQ asks to connect the parent's *rising/parallel* Vandermonde convolution to the *standard* Vandermonde convolution.

- **Mathlib bearer confirmed.** The standard Vandermonde convolution is in Mathlib as `Nat.add_choose_eq` (`Mathlib/Data/Nat/Choose/Vandermonde.lean`) — confirmed present at the repo pin **v4.26.0 / `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`** via `gh api .../contents?ref=<rev>`. (Path is `Data/Nat/Choose/`, not the older `Combinatorics/Choose/`.)
- **The connection is upper-negation duality.** The project's `parallel_vandermonde` (`ArithmeticSeriesOQ02OQ02.lean:61`, `∑_{i+j=n} C(i+a,a)C(j+b,b) = C(n+a+b+1,a+b+1)`, proved by induction) is **not** a direct instance of `Nat.add_choose_eq` (its upper indices vary with the summation index). The two are linked over ℤ by `C(i+a,a) = (-1)^i C(-a-1,i)`: the rising form is the standard convolution at *negative* upper indices, sandwiched by two upper negations. Equivalently the `(1+x) ↔ (1-x)^{-1}` generating-function inversion.
- **Durable verification.** `verify_vandermonde_connection.py` checks all six links by exact integer arithmetic over a sweep: (1) the Mathlib `Nat.add_choose_eq` form, (2) the rising `parallel_vandermonde`, (3) upper-negation, (4) the integer-upper-index Vandermonde, (5) the full bridge chain term-by-term, (6) a generating-function cross-check. All pass.

No Lean delta — Docker is down this session, and a Lean formalization of the *connection* (deriving rising from `Nat.add_choose_eq`) would need ℤ-binomial/upper-negation machinery, which is build-gated. The parent already has a self-contained inductive proof of `parallel_vandermonde`, so the connection is structural/documentary, not a prerequisite.

## Files

- `research/problems/arithmetic-series-oq-02-oq-02-oq-02/{problem,state}.md` — ORIENT writeup
- `research/problems/arithmetic-series-oq-02-oq-02-oq-02/verify_vandermonde_connection.py` — durable sympy verification (6/6 pass)
- `src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-02.json` — research-tracker entry

## Test plan

- [x] `python3 research/problems/arithmetic-series-oq-02-oq-02-oq-02/verify_vandermonde_connection.py` → all 6 checks PASS
- [x] Mathlib bearer `Nat.add_choose_eq` confirmed at repo pin via `gh api`
- [x] JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)