### PR TITLE
research(erdos-493-oq-01): exact image + τ(n+1) representation count of product-minus-sum

### DIFF
--- a/research/problems/erdos-493-oq-01/knowledge.md
+++ b/research/problems/erdos-493-oq-01/knowledge.md
@@ -1,0 +1,73 @@
+# Erdős #493 — OQ-01: Exact image and representation count of product-minus-sum
+
+**Parent**: Erdős Problem #493 (`proofs/Proofs/Erdos493Problem.lean`), SOLVED.
+Every `n ≥ 0` is `a*b - (a+b)` for some `a, b ≥ 2` (parent proves only
+`n ≥ 0 ⟹ representable`, via the witness `a = 2, b = n + 2`).
+
+**OQ-01 (this work)**: What is the *exact* image of `(a,b) ↦ a*b - (a+b)`
+over `a, b ≥ 2`, and how many representations does each value admit?
+
+## Central identity (the whole problem)
+
+    a*b - (a + b) = (a - 1)*(b - 1) - 1.
+
+Substituting `u = a - 1`, `v = b - 1` (so `a, b ≥ 2 ⟺ u, v ≥ 1`):
+
+    n = a*b - (a + b)   ⟺   n + 1 = u * v   with u, v ≥ 1.
+
+This is a bijection between representations of `n` and factorizations of `n+1`
+into two positive factors. Everything follows.
+
+## Results (all sympy-verified, `verify_prodminussum.py`, ALL CHECKS PASS)
+
+- **(C1) Image** `{ a*b - (a+b) : a,b ≥ 2 } = { n : n ≥ 0 }`.
+  The `⊇` direction is the parent theorem. The **converse** `representable ⟹ n ≥ 0`
+  is NEW (parent leaves it open, even flags the imprecision in its Part III):
+  from `u, v ≥ 1` we get `n + 1 = u*v ≥ 1`, so `n ≥ 0`. Every negative integer
+  is unrepresentable.
+
+- **(C2) Ordered count** `#{ (a,b) : a,b ≥ 2, a*b-(a+b)=n } = τ(n+1)`
+  (number of positive divisors of `n+1`). Each divisor `u | n+1` gives
+  `(a,b) = (u+1, (n+1)/u + 1)`. Cross-checked vs independent brute force.
+
+- **(C3) Unordered count** `= #{ u | n+1 : u ≤ √(n+1) } = ⌈τ(n+1)/2⌉`.
+
+- **(C4) Uniqueness**
+  - Exactly one *ordered* rep `⟺ τ(n+1)=1 ⟺ n=0`.
+  - Exactly one *unordered* rep `⟺ τ(n+1) ∈ {1,2} ⟺ n+1 is 1 or prime`.
+    (A prime square `n+1 = p²` already has two unordered reps `{1,p²}, {p,p}` —
+    a corrected guess; the verify-before-assert pass caught the wrong `{1,prime,p²}`
+    prediction.)
+
+## Lean status (Docker + Aristotle both DOWN this session — build-free only)
+
+ACT-ready, Docker-gated (NOT committed as unbuildable `.lean`). The converse —
+the new half of (C1) — is a few lines over `ℤ`:
+
+```lean
+theorem prodMinusSum2_iff_nonneg (n : ℤ) : Erdos493.HasProdMinusSum2 n ↔ n ≥ 0 := by
+  constructor
+  · rintro ⟨a, b, ha, hb, rfl⟩
+    -- a*b-(a+b) = (a-1)*(b-1) - 1 ≥ 1*1 - 1 = 0
+    have key : (a - 1) * (b - 1) ≥ 1 := by nlinarith [ha, hb]
+    nlinarith [key]
+  · intro hn; exact Erdos493.erdos_493_nonneg n hn
+```
+
+The counting formula (C2) needs the explicit bijection `Nat.divisors (n+1) ≃
+{ representations }`; `τ = Nat.ArithmeticFunction.sigma 0` / `(n+1).divisors.card`
+in Mathlib. Estimate ~120–180 LOC for the full counting theorem; the converse
+(C1) alone is < 20 LOC. Build when Docker returns.
+
+## Files
+- `research/problems/erdos-493-oq-01/verify_prodminussum.py` — durable cert (C1–C4).
+
+## Session log
+### 2026-06-14 (Session 1) — FRESH ORIENT
+- **Mode**: FRESH. **Outcome**: ORIENT + durable verification.
+- Defined OQ-01 (parent had no stated follow-up, empty research dir).
+- Found the `(a-1)(b-1)-1` bijection; proved the missing converse direction on
+  paper + sympy; derived ordered/unordered counts and uniqueness characterization.
+- Both proof backends down → shipped sympy cert, deferred Lean to ACT.
+- **Next**: build `prodMinusSum2_iff_nonneg` (converse, <20 LOC) and the τ(n+1)
+  counting theorem when Docker is available.

--- a/research/problems/erdos-493-oq-01/verify_prodminussum.py
+++ b/research/problems/erdos-493-oq-01/verify_prodminussum.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Erdős Problem #493, follow-up OQ-01: exact characterization and representation
+count of the product-minus-sum image.
+
+Parent result (Erdos493Problem.lean): k = 2 suffices, i.e. every n >= 0 is
+representable as  n = a*b - (a + b)  with a, b >= 2  (one direction only:
+n >= 0  =>  representable, via a = 2, b = n + 2).
+
+OQ-01 asks for the EXACT image and the number of representations.
+
+Central identity (the missing converse + the counting bijection):
+
+    a*b - (a + b) = (a - 1)*(b - 1) - 1.
+
+Write u = a - 1, v = b - 1.  Then a, b >= 2  <=>  u, v >= 1, and
+
+    n = a*b - (a + b)   <=>   n + 1 = u * v    with u, v >= 1.
+
+Consequences proved here by exhaustive check:
+
+  (C1) IMAGE.  { a*b - (a+b) : a,b >= 2 } = { n in Z : n >= 0 }.
+       In particular every negative integer has NO representation
+       (the parent file leaves this converse direction unproved).
+
+  (C2) COUNT.  The number of ORDERED pairs (a, b) with a,b >= 2 and
+       a*b - (a+b) = n  equals  tau(n + 1)  = number of positive divisors
+       of n + 1  (each divisor u | n+1 gives u = a-1, v = (n+1)/u = b-1).
+
+  (C3) UNORDERED COUNT.  The number of UNORDERED representations {a,b}
+       equals ceil(tau(n+1)/2) = number of divisors u of n+1 with
+       u <= sqrt(n+1)  (i.e. divisor pairs up to order).
+
+  (C4) UNIQUE-REPRESENTATION CHARACTERIZATION.  n has exactly one ordered
+       representation  <=>  tau(n+1) = 1  <=>  n + 1 = 1  <=>  n = 0.
+       n has exactly one unordered representation <=> tau(n+1) in {1, 2}
+       <=>  n + 1 is 1 or prime.  (A prime square n+1 = p^2 already has TWO
+       unordered reps: {1, p^2} from u=1 and {p, p} from u=v=p.)
+
+All assertions below pass (pure arithmetic, no external proof backend).
+"""
+
+from math import isqrt
+from sympy import divisor_count, isprime
+
+
+def reps_ordered(n, cap=None):
+    """All ordered (a,b), a,b>=2, with a*b-(a+b)=n. Bounded since a-1 | n+1."""
+    if n + 1 <= 0:
+        # u*v = n+1 <= 0 impossible with u,v >= 1
+        return []
+    out = []
+    m = n + 1
+    for u in range(1, m + 1):
+        if m % u == 0:
+            v = m // u
+            out.append((u + 1, v + 1))  # (a, b)
+    return out
+
+
+def brute_reps_ordered(n, bound):
+    """Independent brute force over a,b in [2,bound] (no factorization)."""
+    return [(a, b) for a in range(2, bound + 1) for b in range(2, bound + 1)
+            if a * b - (a + b) == n]
+
+
+def main():
+    ok = True
+
+    # (C1) image is exactly {n >= 0}; negatives unrepresentable
+    for n in range(-50, 0):
+        if brute_reps_ordered(n, 60):
+            print(f"FAIL C1: negative n={n} is representable"); ok = False
+    for n in range(0, 60):
+        if not brute_reps_ordered(n, n + 4):
+            print(f"FAIL C1: nonneg n={n} not representable"); ok = False
+
+    # (C2) ordered count == tau(n+1); cross-check divisor enum vs brute force
+    for n in range(0, 300):
+        via_div = reps_ordered(n)
+        via_brute = brute_reps_ordered(n, n + 4)
+        tau = divisor_count(n + 1)
+        if len(via_div) != tau:
+            print(f"FAIL C2a: n={n} divisor-count {len(via_div)} != tau {tau}"); ok = False
+        if sorted(via_div) != sorted(via_brute):
+            print(f"FAIL C2b: n={n} divisor enum != brute force"); ok = False
+
+    # (C3) unordered count == #divisors u of n+1 with u <= sqrt(n+1)
+    for n in range(0, 300):
+        m = n + 1
+        small = sum(1 for u in range(1, isqrt(m) + 1) if m % u == 0)
+        unordered = {tuple(sorted(p)) for p in reps_ordered(n)}
+        if len(unordered) != small:
+            print(f"FAIL C3: n={n} unordered {len(unordered)} != small-div {small}")
+            ok = False
+
+    # (C4) unique ordered rep <=> n == 0
+    uniq_ordered = [n for n in range(0, 300) if len(reps_ordered(n)) == 1]
+    if uniq_ordered != [0]:
+        print(f"FAIL C4a: unique-ordered set = {uniq_ordered}, expected [0]"); ok = False
+    # unique unordered rep <=> n+1 is 1 or prime  (tau in {1,2})
+    for n in range(0, 300):
+        m = n + 1
+        unordered = {tuple(sorted(p)) for p in reps_ordered(n)}
+        is_unique = (len(unordered) == 1)
+        pred = (m == 1) or isprime(m)
+        if is_unique != pred:
+            print(f"FAIL C4b: n={n} m={m} uniqueUnordered={is_unique} pred={pred}")
+            ok = False
+
+    # spot identity (a-1)(b-1)-1 == ab-(a+b)
+    for a in range(2, 40):
+        for b in range(2, 40):
+            if (a - 1) * (b - 1) - 1 != a * b - (a + b):
+                print(f"FAIL identity a={a} b={b}"); ok = False
+
+    print("ALL CHECKS PASS" if ok else "SOME CHECKS FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-up OQ-01 to Erdős Problem #493 (product-minus-sum, parent SOLVED). The parent file proves only one direction — every `n ≥ 0` is `a*b - (a+b)` for some `a,b ≥ 2`. This PR settles the **exact image** and **counts representations**.

**Central identity:** `a*b - (a+b) = (a-1)(b-1) - 1`. With `u=a-1, v=b-1 ≥ 1`, a representation of `n` is exactly a factorization `n+1 = u*v` (`u,v ≥ 1`). Everything follows:

- **(C1) Image** = exactly `{n ≥ 0}`. The converse `representable ⟹ n ≥ 0` is **new** (parent leaves it open; negatives are unrepresentable since `n+1 = u*v ≥ 1`).
- **(C2) Ordered count** `= τ(n+1)` (positive divisors of `n+1`).
- **(C3) Unordered count** `= ⌈τ(n+1)/2⌉`.
- **(C4)** Unique ordered rep `⟺ n = 0`; unique unordered rep `⟺ n+1` is `1` or prime.

All four verified in `verify_prodminussum.py` (sympy + independent brute-force cross-check, **ALL CHECKS PASS**).

## Why build-free this session
Docker and the Aristotle backend were both down. The new converse half of (C1) is a `< 20` LOC Lean proof (sketch in `knowledge.md`); the τ(n+1) counting theorem ~120–180 LOC. Both are ACT-ready and deferred to a build session rather than committed as unbuildable `.lean`.

## Files
- `research/problems/erdos-493-oq-01/verify_prodminussum.py` — durable certificate (C1–C4)
- `research/problems/erdos-493-oq-01/knowledge.md` — ORIENT write-up + ACT-ready Lean sketch

## Test plan
- [x] `python3 research/problems/erdos-493-oq-01/verify_prodminussum.py` → `ALL CHECKS PASS`
- [ ] Build `prodMinusSum2_iff_nonneg` + counting theorem when Docker returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)