### PR TITLE
research(cauchy-schwarz-oq-03-oq-02-oq-01): FRESH ORIENT — reverse Minkowski (0<p<1)

### DIFF
--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/knowledge.md
@@ -1,0 +1,145 @@
+# Knowledge Base: cauchy-schwarz-oq-03-oq-02-oq-01
+
+**Goal**: formalize the **reverse Minkowski inequality** for `0 < p < 1`:
+`(∑ (a_i+b_i)^p)^(1/p) ≥ (∑ a_i^p)^(1/p) + (∑ b_i^p)^(1/p)` for nonneg `a,b`.
+
+**Parent**: `cauchy-schwarz-oq-03-oq-02` (`Proofs/CauchySchwarzOQ03OQ02.lean`,
+`MinkowskiFromHolder`) — forward Minkowski `p ≥ 1` via `NNReal.Lp_add_le`.
+
+---
+
+## Problem Understanding
+
+For `p ≥ 1`, `‖v‖_p = (∑ v_i^p)^(1/p)` is a norm (triangle inequality `≤`).
+For `0 < p < 1` it is a **quasi-norm**: still positively homogeneous of degree 1,
+but **concave** on the nonnegative orthant, hence **super**additive — the
+triangle inequality reverses to `≥`. That reversal is the entire content of (RM).
+
+Concavity + homogeneity ⇒ superadditivity directly:
+`‖a+b‖_p = 2·‖(a+b)/2‖_p ≥ 2·(½‖a‖_p + ½‖b‖_p) = ‖a‖_p + ‖b‖_p`.
+So (RM) ⟺ concavity of `‖·‖_p` for `0 < p < 1`.
+
+---
+
+## Numerical certification (durable)
+
+`verify_reverse_minkowski.py` (pure stdlib, exits 0 on "ALL CHECKS PASSED")
+checks from first principles:
+
+- **(C1)** (RM) holds: **0 violations over 70 000 random trials**, `p ∈
+  {0.05,…,0.99}`, `n ∈ {1,2,3,5,8}`.
+- **(C2)** equality **iff** `a,b` proportional (or one is `0`); disjoint-support
+  pairs are **strict** (a large gap, the opposite extreme from forward
+  Minkowski).
+- **(C3)** the proof engine — **reverse Hölder** — holds: for `0 < p < 1`,
+  `q = p/(p-1) < 0` (so `1/p + 1/q = 1`, `v > 0`),
+  `∑ u_i v_i ≥ (∑ u_i^p)^(1/p) · (∑ v_i^q)^(1/q)`. 0 violations.
+- **(C4)** the term-level bound Mathlib **does** have,
+  `rpow_add_le_add_rpow` ((a+b)^p ≤ a^p+b^p, 0≤p≤1), proves only the **outer**
+  sandwich `X^(1/p)+Y^(1/p) ≤ LHS ≤ (X+Y)^(1/p)` (upper bound on LHS) — it does
+  **not** give (RM), which is the lower bound. Documented to forestall a wrong
+  "just use `rpow_add_le_add_rpow`" attempt.
+
+---
+
+## Mathlib survey (at repo pin `v4.26.0`, rev `2df2f01`, read via `gh api`)
+
+**Present (forward / building blocks):**
+- `NNReal.Lp_add_le` — forward Minkowski, `1 ≤ p`
+  (`Mathlib/Analysis/MeanInequalities.lean:613`). Used by the parent.
+- `NNReal.inner_le_Lp_mul_Lq` — forward Hölder, `p.HolderConjugate q`
+  (`MeanInequalities.lean:480`).
+- `NNReal.rpow_add_le_add_rpow` `(hp : 0 ≤ p) (hp1 : p ≤ 1) : (a+b)^p ≤ a^p+b^p`
+  (`Mathlib/Analysis/MeanInequalitiesPow.lean:179`; Real `:211`; ENNReal `:313`).
+  This is the **only** `p ≤ 1` direction lemma — and per (C4) it bounds the
+  wrong way for (RM).
+- `Real.rpow_natCast`, `NNReal.rpow_le_rpow`, `Real.rpow_le_rpow_left_iff`, the
+  `young_inequality` family — all gated on `HolderConjugate` (⇒ `p > 1`).
+
+**Absent (the gap):**
+- **No reverse Hölder** for `0 < p < 1` (negative conjugate exponent). Every
+  Hölder lemma requires `Real.HolderConjugate p q`, whose field `one_lt`/
+  `inv_add_inv` forces `p, q > 1`. Web + `gh search code` for "reverse"+"Holder"
+  hit only the linter/docs, no lemma.
+- **No reverse Minkowski / quasi-norm superadditivity** for `0 < p < 1`.
+- **No concavity** of `v ↦ (∑ v_i^p)^(1/p)` on the orthant for `0 < p < 1`.
+
+So this is genuinely "Mathlib lacks the reverse direction", not a wiring task.
+
+---
+
+## Recommended formal target (ACT plan, Docker-gated)
+
+New file `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`, namespace
+`ReverseMinkowski`, mirroring the parent's `NNReal`/`Finset` style. Two viable
+routes; **Route 1 (reverse Hölder) is primary**, matching the parent's
+"Minkowski from Hölder" architecture.
+
+**Route 1 — reverse Hölder (≈150–250 LOC):**
+1. `reverse_holder` : for `0 < p < 1`, `q = p/(p-1)`, `v i > 0`,
+   `(∑ u_i^p)^(1/p) · (∑ v_i^q)^(1/q) ≤ ∑ u_i v_i`.
+   Derive from forward Hölder by the standard exponent substitution: set
+   `P = 1/p > 1`, apply `NNReal.inner_le_Lp_mul_Lq` to the pair
+   `(u_i v_i)^p, v_i^{-p}` with `HolderConjugate P P'` and unwind. (The negative
+   exponent appears only through `v_i^q = v_i^{-p/(1-p)}`; keep `v_i > 0` to
+   avoid `0^{neg}`.)
+2. `reverse_minkowski` : split `∑(a+b)^p = ∑(a+b)^{p-1}·a + ∑(a+b)^{p-1}·b`,
+   apply `reverse_holder` to each summand with `u = a` (resp. `b`),
+   `v = (a+b)^{p-1}`, note `v^q = (a+b)^p`, factor `(∑(a+b)^p)^{1/q}`, and divide
+   (here `1/q < 0`, division flips — track the direction carefully).
+3. Corollaries: `p = 1/2` instance; signed-real version via `‖·‖₊`; equality
+   characterization (proportional) — optional, defer like the parent deferred
+   its converse.
+
+**Route 2 — concavity (≈120–200 LOC, more analytic):** prove `‖·‖_p` concave on
+the orthant for `0 < p < 1` (via `Real.inner_le_nnorm`-style or
+`Real.add_pow_le_pow_mul_pow_of_sq_le_sq` analogues + `rpow` concavity), then
+superadditivity from homogeneity. Heavier on real-analysis API; Route 1 reuses
+the parent's exact toolchain, so prefer it.
+
+**Open Lean obligations (confirm names at build):** the negative-exponent
+bookkeeping in step 1 (cast `v_i^{p/(p-1)}`, keep strict positivity), and the
+direction flip in step 2's division by `(∑(a+b)^p)^{1/q}` with `1/q < 0`. These
+are the genuinely fiddly parts and the reason the file is Docker-gated rather
+than shipped here uncompiled.
+
+---
+
+## Dead Ends
+
+- **`rpow_add_le_add_rpow` does NOT prove (RM)** — see (C4); it gives the outer
+  upper bound `LHS ≤ (X+Y)^(1/p)`, the wrong direction. A future session must
+  not "close" (RM) by citing it.
+- **Instantiating `NNReal.Lp_add_le` with `p < 1`** is impossible — its
+  hypothesis is `1 ≤ p`. There is no `p ≤ 1` companion in Mathlib.
+
+---
+
+## Session 2026-06-14 (Session 1) — FRESH ORIENT (researcher-4)
+
+**Mode**: FRESH (knowledge 0, no prior dir) · **Outcome**: OBSERVE → ORIENT.
+Both backends down (Docker `docker info` 15s timeout; Aristotle MCP `prove` →
+"Resource not found", probed), so build-free only.
+
+### What I did
+- Fixed the precise statement and **equality locus** (proportional) of reverse
+  Minkowski; related it to concavity of the `0<p<1` quasi-norm.
+- Read the parent `CauchySchwarzOQ03OQ02.lean` — confirmed it is forward-only
+  (`NNReal.Lp_add_le`, `hp : 1 ≤ p`), so the child genuinely needs new material.
+- Surveyed Mathlib at the exact pin `v4.26.0` (`gh api .../contents?ref=…`):
+  forward Hölder/Minkowski + `rpow_add_le_add_rpow` present; **reverse
+  Hölder/Minkowski/quasi-norm-concavity absent** (the gap).
+- Committed `verify_reverse_minkowski.py` (70 000-trial, 0-violation cert of
+  RM + equality case + reverse-Hölder route + the (C4) wrong-direction caveat).
+- Wrote the ACT plan: Route 1 (reverse Hölder, mirrors the parent) primary,
+  Route 2 (concavity) fallback; ≈150–250 LOC, Docker-gated.
+
+### Files modified
+- `research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/{problem.md, knowledge.md,
+  state.md, verify_reverse_minkowski.py}` (all new).
+
+### Next steps
+1. When Docker returns: implement Route 1 in
+   `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`; the only genuinely-open obligations
+   are the negative-exponent casts and the `1/q < 0` division flip.
+2. Re-run `verify_reverse_minkowski.py` to re-confirm all artifacts.

--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/problem.md
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/problem.md
@@ -1,0 +1,32 @@
+# Reverse Minkowski Inequality for 0 < p < 1
+
+**Slug**: `cauchy-schwarz-oq-03-oq-02-oq-01`
+**Parent**: `cauchy-schwarz-oq-03-oq-02` — "Minkowski's Inequality from Hölder"
+(`Proofs/CauchySchwarzOQ03OQ02.lean`, namespace `MinkowskiFromHolder`, 257 LOC,
+0 sorries, 0 axioms; proves the **forward** Minkowski for `p ≥ 1`).
+
+## Statement
+
+For nonnegative reals `a_i, b_i` (i ∈ s, a finite index set) and exponent
+`0 < p < 1`, the Minkowski inequality reverses:
+
+    (∑ (a_i + b_i)^p)^(1/p)  ≥  (∑ a_i^p)^(1/p) + (∑ b_i^p)^(1/p)        (RM)
+
+This contrasts with the parent's forward case `p ≥ 1`, where the same
+expression holds with `≤`. The functional `‖v‖_p := (∑ v_i^p)^(1/p)` is a
+genuine norm only for `p ≥ 1`; for `0 < p < 1` it is a *quasi-norm* that is
+**super**additive (concave + positively homogeneous), which is exactly (RM).
+
+## Equality
+
+Equality in (RM) holds **iff** `a` and `b` are proportional (`b = c·a` for some
+`c ≥ 0`) or one of them is the zero vector — the same equality locus as forward
+Minkowski. (Numerically verified; see `verify_reverse_minkowski.py`.)
+
+## Why it is open here
+
+The parent proves forward Minkowski by quoting Mathlib `NNReal.Lp_add_le`
+(`hp : 1 ≤ p`). Mathlib has **no** reverse (`0 < p < 1`) Hölder or Minkowski
+lemma — every Hölder statement is gated on `Real.HolderConjugate p q`, which
+forces `p, q > 1`. So (RM) cannot be obtained by instantiating an existing
+Mathlib lemma; the reverse direction must be built.

--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/state.md
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/state.md
@@ -1,0 +1,49 @@
+# Research State: cauchy-schwarz-oq-03-oq-02-oq-01
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-14
+**Iteration**: 1
+
+## Current Focus
+Reverse Minkowski inequality for `0 < p < 1`:
+`(∑(a_i+b_i)^p)^(1/p) ≥ (∑a_i^p)^(1/p) + (∑b_i^p)^(1/p)` (nonneg a,b). Statement,
+equality locus (proportional), and proof route pinned and numerically certified.
+
+## Active Approach
+**Route 1 — reverse Hölder** (mirrors the parent's "Minkowski from Hölder"):
+prove `reverse_holder` (negative conjugate `q=p/(p-1)<0`, `v>0`) from forward
+`NNReal.inner_le_Lp_mul_Lq` by exponent substitution, then derive
+`reverse_minkowski` via the two-Hölder split + division by `(∑(a+b)^p)^{1/q}`.
+~150–250 LOC, Docker-gated. Route 2 (quasi-norm concavity) is the fallback.
+
+## Attempt Count
+- Total attempts: 0 (survey only; no Lean built)
+- Current approach attempts: 0
+- Approaches tried: 1 (reverse-Hölder route — viable, numerically validated)
+
+## Blockers
+- **Verification blackout (2026-06-14)**: Docker daemon down (`docker info` 15s
+  timeout) and Aristotle MCP `prove` → "Resource not found" (probed). No Lean
+  build possible, so the ~150–250 LOC formalisation is build-gated. The ORIENT
+  (statement, Mathlib survey at pin v4.26.0, numerical cert, ACT plan) is
+  build-free and complete.
+- **Mathlib gap (genuine, not wiring)**: no reverse Hölder / reverse Minkowski /
+  `0<p<1` quasi-norm concavity in Mathlib; every Hölder lemma is gated on
+  `HolderConjugate` (⇒ p,q>1). The reverse direction must be built.
+
+## Next Action (when Docker recovers)
+1. Implement Route 1 in `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`
+   (namespace `ReverseMinkowski`): `reverse_holder` → `reverse_minkowski`,
+   `p=1/2` instance, signed-real corollary. Confirm at build: negative-exponent
+   casts (`v_i^{p/(p-1)}`, keep `v_i>0`) and the `1/q<0` division flip.
+2. Build: `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ03OQ02OQ01`.
+3. Add gallery entry `src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/`.
+4. Re-run `verify_reverse_minkowski.py` to re-confirm artifacts.
+
+## Dead Ends
+- `rpow_add_le_add_rpow` ((a+b)^p≤a^p+b^p, 0≤p≤1) does **not** prove reverse
+  Minkowski — it gives the outer **upper** bound `LHS ≤ (X+Y)^(1/p)`, wrong
+  direction (see knowledge.md (C4)).
+- Instantiating `NNReal.Lp_add_le` with `p<1` is impossible (`hp : 1 ≤ p`).

--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/verify_reverse_minkowski.py
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/verify_reverse_minkowski.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Durable verification for cauchy-schwarz-oq-03-oq-02-oq-01.
+
+Open question: formalize the REVERSE Minkowski inequality for 0 < p < 1.
+
+Forward Minkowski (p >= 1, already formalized in the parent
+Proofs/CauchySchwarzOQ03OQ02.lean via Mathlib `NNReal.Lp_add_le`):
+
+    (sum (a_i + b_i)^p)^(1/p)  <=  (sum a_i^p)^(1/p) + (sum b_i^p)^(1/p)
+
+For 0 < p < 1 the inequality REVERSES (for nonnegative a_i, b_i):
+
+    (sum (a_i + b_i)^p)^(1/p)  >=  (sum a_i^p)^(1/p) + (sum b_i^p)^(1/p)   (RM)
+
+This script independently checks, from first principles (no Lean):
+  (C1) RM holds across many random nonnegative vectors and many p in (0,1);
+  (C2) equality holds iff a, b are proportional (or one is 0);
+  (C3) the proof route is sound: REVERSE Holder (0<p<1, negative conjugate
+       exponent q = p/(p-1) < 0, v > 0):
+           sum u_i v_i  >=  (sum u_i^p)^(1/p) * (sum v_i^q)^(1/q);
+  (C4) the term-level bound Mathlib DOES have, `rpow_add_le_add_rpow`
+       ((a+b)^p <= a^p + b^p for 0<=p<=1), goes the WRONG way for RM:
+       it yields an UPPER bound (LHS <= (X+Y)^(1/p)), not the RM lower bound.
+
+Exit code 0 prints "ALL CHECKS PASSED".  Pure stdlib; no dependencies.
+"""
+
+import random
+import sys
+
+EPS = 1e-9
+
+
+def Lp(v, p):
+    """The p-functional (sum v_i^p)^(1/p) for nonnegative v (a quasi-norm when 0<p<1)."""
+    return sum(x ** p for x in v) ** (1.0 / p)
+
+
+def check_reverse_minkowski():
+    """(C1) RM lower bound holds for all tested 0<p<1, all n; 0 violations."""
+    random.seed(11)
+    violations = 0
+    total = 0
+    for p in [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99]:
+        for n in [1, 2, 3, 5, 8]:
+            for _ in range(2000):
+                a = [random.random() * 3 for _ in range(n)]
+                b = [random.random() * 3 for _ in range(n)]
+                lhs = Lp([a[i] + b[i] for i in range(n)], p)
+                rhs = Lp(a, p) + Lp(b, p)
+                total += 1
+                if lhs < rhs - EPS:
+                    violations += 1
+    assert violations == 0, f"RM violated in {violations}/{total} trials"
+    return total
+
+
+def check_equality_iff_proportional():
+    """(C2) equality iff proportional (b = c*a) or one vector is 0; else strict."""
+    random.seed(12)
+    for p in [0.2, 0.4, 0.6, 0.8]:
+        # proportional => equality
+        a = [random.random() * 3 + 0.1 for _ in range(4)]
+        c = random.random() * 5 + 0.1
+        b = [c * x for x in a]
+        gap = Lp([a[i] + b[i] for i in range(4)], p) - (Lp(a, p) + Lp(b, p))
+        assert abs(gap) < 1e-7, f"proportional not equality at p={p}: gap={gap}"
+        # one zero => equality (Lp(0)=0)
+        z = [0.0, 0.0, 0.0, 0.0]
+        gap0 = Lp([a[i] + z[i] for i in range(4)], p) - (Lp(a, p) + Lp(z, p))
+        assert abs(gap0) < 1e-7, f"one-zero not equality at p={p}: gap={gap0}"
+        # disjoint support (non-proportional, both nonzero) => STRICT
+        u = [1.0, 0.0]
+        v = [0.0, 1.0]
+        gapd = Lp([u[i] + v[i] for i in range(2)], p) - (Lp(u, p) + Lp(v, p))
+        assert gapd > 1e-6, f"disjoint support not strict at p={p}: gap={gapd}"
+    return True
+
+
+def check_reverse_holder():
+    """(C3) reverse Holder (the proof engine for RM) holds, >= direction, v>0."""
+    random.seed(13)
+    violations = 0
+    for p in [0.2, 0.3, 0.5, 0.7, 0.9]:
+        q = p / (p - 1.0)  # negative conjugate: 1/p + 1/q = 1, q < 0
+        assert abs(1.0 / p + 1.0 / q - 1.0) < 1e-12
+        assert q < 0
+        for n in [2, 3, 5]:
+            for _ in range(2000):
+                u = [random.random() * 2 + 0.01 for _ in range(n)]
+                v = [random.random() * 2 + 0.05 for _ in range(n)]  # strictly > 0
+                lhs = sum(u[i] * v[i] for i in range(n))
+                rhs = Lp(u, p) * (sum(x ** q for x in v) ** (1.0 / q))
+                if lhs < rhs - 1e-7:
+                    violations += 1
+    assert violations == 0, f"reverse Holder violated {violations} times"
+    return True
+
+
+def check_term_subadditivity_wrong_direction():
+    """(C4) `rpow_add_le_add_rpow` ((a+b)^p<=a^p+b^p, 0<=p<=1) is present in
+    Mathlib but yields only an UPPER bound on the RM LHS, not the RM lower
+    bound -- so it does NOT by itself prove reverse Minkowski.
+
+        sum (a_i+b_i)^p <= sum a_i^p + sum b_i^p = X + Y          [term subadd]
+        => (sum (a_i+b_i)^p)^(1/p) <= (X+Y)^(1/p)                 [1/p > 0 incr]
+
+    while RM needs   (...)^(1/p) >= X^(1/p) + Y^(1/p).
+    Both are consistent because (X+Y)^(1/p) >= X^(1/p)+Y^(1/p) for 1/p>=1;
+    the term bound is the OUTER inequality, strictly weaker than RM.
+    """
+    random.seed(14)
+    for p in [0.3, 0.5, 0.7]:
+        for _ in range(3000):
+            n = 4
+            a = [random.random() * 3 for _ in range(n)]
+            b = [random.random() * 3 for _ in range(n)]
+            X = sum(x ** p for x in a)
+            Y = sum(x ** p for x in b)
+            inner = sum((a[i] + b[i]) ** p for i in range(n))
+            # term subadditivity: inner <= X + Y
+            assert inner <= X + Y + EPS
+            lhs = inner ** (1.0 / p)
+            upper = (X + Y) ** (1.0 / p)
+            rm_lower = X ** (1.0 / p) + Y ** (1.0 / p)
+            # the Mathlib-available bound is the OUTER sandwich:
+            #   rm_lower <= lhs <= upper
+            assert rm_lower - EPS <= lhs <= upper + EPS
+            # and `upper` is NOT a proof of `rm_lower <= lhs` (it bounds above)
+            assert upper >= rm_lower - EPS
+    return True
+
+
+def main():
+    n = check_reverse_minkowski()
+    check_equality_iff_proportional()
+    check_reverse_holder()
+    check_term_subadditivity_wrong_direction()
+    print(f"(C1) reverse Minkowski: 0 violations over {n} random trials")
+    print("(C2) equality iff proportional / one-zero; disjoint support strict")
+    print("(C3) reverse Holder route (q=p/(p-1)<0) holds, 0 violations")
+    print("(C4) Mathlib `rpow_add_le_add_rpow` gives outer UPPER bound only")
+    print("ALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fresh ORIENT (knowledge 0) on the open question **"can the reverse Minkowski inequality for `0 < p < 1` be formalized?"** — the super-additive reversal of the parent `cauchy-schwarz-oq-03-oq-02` (forward Minkowski, `p ≥ 1`, via `NNReal.Lp_add_le`).

Both backends down this session (Docker `docker info` 15s timeout; Aristotle MCP `prove` → "Resource not found", probed), so build-free only.

**Target (RM):** for nonneg `a_i, b_i`, `0 < p < 1`:
`(∑(a_i+b_i)^p)^(1/p) ≥ (∑a_i^p)^(1/p) + (∑b_i^p)^(1/p)`.

## What this PR establishes

- **Precise statement + equality locus**: equality iff `a,b` proportional (or one is `0`) — same locus as forward Minkowski. (RM) ⟺ concavity of the `0<p<1` quasi-norm.
- **Mathlib survey at the exact repo pin `v4.26.0`** (read via `gh api .../contents?ref=…`):
  - *Present:* `NNReal.Lp_add_le` (MeanInequalities.lean:613), `NNReal.inner_le_Lp_mul_Lq` (:480), `NNReal.rpow_add_le_add_rpow` ((a+b)^p≤a^p+b^p, 0≤p≤1; MeanInequalitiesPow.lean:179).
  - *Absent (the genuine gap):* reverse Hölder / reverse Minkowski / quasi-norm concavity for `0<p<1`. Every Hölder lemma is gated on `HolderConjugate` ⇒ `p,q>1`.
- **Durable `verify_reverse_minkowski.py`** (pure stdlib, exits 0): 70 000-trial 0-violation cert of (RM), the equality case, the **reverse-Hölder proof route** (negative conjugate `q=p/(p-1)<0`), and the **(C4) caveat** that `rpow_add_le_add_rpow` bounds the *wrong* direction (outer upper bound, not (RM)).
- **ACT plan**: Route 1 reverse-Hölder (mirrors the parent's "Minkowski from Hölder"), Route 2 quasi-norm concavity fallback; ~150–250 LOC, Docker-gated.

## Changes
- `research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/{problem,knowledge,state}.md` (new)
- `research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/verify_reverse_minkowski.py` (new, durable)

Docs-only; 0 `.lean`. No `loom:review-requested` (math PR).

## Test plan
- [x] `python3 research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/verify_reverse_minkowski.py` → "ALL CHECKS PASSED" (exit 0)
- [ ] (deferred, Docker-gated) implement Route 1 in `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`