### PR TITLE
Fix: clamp trailing annotation range overshooting EOF (cauchy-schwarz-integral)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -133,7 +133,7 @@
     "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
     "range": {
       "startLine": 161,
-      "endLine": 218
+      "endLine": 208
     },
     "type": "insight",
     "title": "Main Theorem: Assembly via Density Extension (Step C)",
@@ -286,7 +286,7 @@
     "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
     "range": {
       "startLine": 161,
-      "endLine": 218
+      "endLine": 208
     },
     "type": "insight",
     "title": "Main Theorem and Sorries Summary: What Remains",


### PR DESCRIPTION
## Fix

The two `ann-main-theorem` annotations in `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` declared `range.endLine: 218`, but the source file `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean` is only 208 lines. The highlighted range overshot EOF by 10 lines. Clamped both to 208.

## Evidence

**Before**: `startLine: 161, endLine: 218` on a 208-line file (over-EOF by 10).
**After**: `startLine: 161, endLine: 208` (ends exactly at the file's last line, `end`).

The described content (the `riesz_lp_surjective_sigma_finite` theorem + sorries summary) lives at lines 161–208, so only the trailing boundary was wrong.

This is the straggler missed by the 15-proof batch in #24169 (same fix class). The remaining two over-EOF gallery entries (`ballot-problem-oq-03-oq-01-oq-02`, `ballot-problem-oq-01-oq-04`) are multi-file "gallery-face" cases tracked by auditor issue #24160 (enricher scope), not trailing clamps.

---
Automated fix by lean-mechanic agent.