### PR TITLE
Enrich Kepler Conjecture OQ-04: fix non-rendering cross-references

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -157,24 +157,28 @@
   },
   "crossReferences": [
     {
-      "id": "kepler-conjecture",
+      "proofId": "kepler-conjecture",
       "title": "Kepler Conjecture: Sphere Packing (parent)",
-      "relationship": "Parent gallery entry. Provides `fccDensity = π/(3√2)`, the `PackingDensity` structure, and the Kepler-Hales theorem axiomatization. OQ-04 instantiates `PackingDensity` with a concrete value strictly above `fccDensity`, formally demonstrating shape-specificity."
+      "relationship": "Parent gallery entry. Provides `fccDensity = π/(3√2)`, the `PackingDensity` structure, and the Kepler-Hales theorem axiomatization. OQ-04 instantiates `PackingDensity` with a concrete value strictly above `fccDensity`, formally demonstrating shape-specificity.",
+      "description": "Parent entry: supplies `fccDensity = π/(3√2)`, the `PackingDensity` structure, and the Kepler–Hales axiomatization; OQ-04 instantiates `PackingDensity` with a value strictly above `fccDensity` to demonstrate shape-specificity."
     },
     {
-      "id": "minkowski-fundamental-theorem",
+      "proofId": "minkowski-fundamental-theorem",
       "title": "Minkowski's Fundamental Theorem (lattice / convex body)",
-      "relationship": "Cousin result in lattice convex geometry. Minkowski's theorem gives a sufficient *volume* condition for a centrally symmetric convex body to contain a non-zero lattice point — a foundational tool for *lattice* packings. Bezdek–Kuperberg (2007), cited in this file's docstring, prove that the optimal *lattice* ellipsoid density in ℝ³ equals π/(3√2) exactly, leveraging the same lattice-symmetry framework. OQ-04 highlights the gap between lattice-constrained density (which preserves the FCC bound for ellipsoids) and unconstrained density (where Donev et al. achieve 0.7707 and Chen-Engel-Glotzer achieve 4000/4671 with dimer crystals)."
+      "relationship": "Cousin result in lattice convex geometry. Minkowski's theorem gives a sufficient *volume* condition for a centrally symmetric convex body to contain a non-zero lattice point — a foundational tool for *lattice* packings. Bezdek–Kuperberg (2007), cited in this file's docstring, prove that the optimal *lattice* ellipsoid density in ℝ³ equals π/(3√2) exactly, leveraging the same lattice-symmetry framework. OQ-04 highlights the gap between lattice-constrained density (which preserves the FCC bound for ellipsoids) and unconstrained density (where Donev et al. achieve 0.7707 and Chen-Engel-Glotzer achieve 4000/4671 with dimer crystals).",
+      "description": "Cousin in lattice convex geometry: a volume condition for a centrally symmetric convex body to contain a nonzero lattice point. Bezdek–Kuperberg (2007) use this framework to prove the optimal lattice ellipsoid density in ℝ³ is exactly π/(3√2)."
     },
     {
-      "id": "minkowski-theorem",
+      "proofId": "minkowski-theorem",
       "title": "Minkowski's Theorem on Successive Minima",
-      "relationship": "Provides the asymptotic counting tool for *lattice* point estimates on convex bodies — the prerequisite framework for any density argument in the lattice-packing literature (Bezdek–Kuperberg 2007 belongs to this tradition). The strict separation between Minkowski-type lattice bounds and Chen–Engel–Glotzer's non-lattice 4000/4671 record motivates OQ-04's central observation: the FCC bound is rigid under lattice symmetry but breaks under non-lattice crystalline arrangements."
+      "relationship": "Provides the asymptotic counting tool for *lattice* point estimates on convex bodies — the prerequisite framework for any density argument in the lattice-packing literature (Bezdek–Kuperberg 2007 belongs to this tradition). The strict separation between Minkowski-type lattice bounds and Chen–Engel–Glotzer's non-lattice 4000/4671 record motivates OQ-04's central observation: the FCC bound is rigid under lattice symmetry but breaks under non-lattice crystalline arrangements.",
+      "description": "Minkowski's successive-minima theorem — the asymptotic lattice-point counting tool underpinning lattice-packing density arguments (the Bezdek–Kuperberg tradition); contrasts with the non-lattice 4000/4671 record motivating OQ-04."
     },
     {
-      "id": "ehrhart-cube-proven",
+      "proofId": "ehrhart-cube-proven",
       "title": "Ehrhart Theory: Lattice-Point Counting in the Cube",
-      "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques."
+      "relationship": "Adjacent discrete-geometric machinery. Ehrhart theory counts lattice points in dilations of a convex polytope, complementing the *volumetric* density theory of Kepler/Hales. Both frameworks share the convex-body-in-ℝᵈ setting, and Ehrhart's `tDilateLatticePoints` polynomial encodes (in the limit) the same kind of asymptotic density information that packing arguments exploit. The 4000/4671 dimer construction is itself a polytopal arrangement — its unit cell counts naturally interface with Ehrhart-style techniques.",
+      "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
   "theoremCount": 8,


### PR DESCRIPTION
## Enrichment pass for `kepler-conjecture-oq-04`

### Problem (rendering bug, not just style)
All 4 cross-references used a non-standard schema — `{id, title, relationship}` — instead of `{proofId|targetId, relationship, description}`. The Related Proofs UI (`ProofOverview.tsx` L364, `ProofConclusion.tsx`) computes `const refSlug = ref.proofId ?? ref.targetId` and does `if (!refSlug) return null`. Since these used `id`, **all 4 cross-references silently failed to render** on the live proof page.

### Fix
- Renamed `id` → `proofId` (the preferred field per `src/types/proof.ts`) on all 4 cross-references, so they now render and link.
- Added a concise `description` to each (UI renders `description ?? relationship`), so the list is scannable. The detailed `relationship` essays are **preserved unchanged**.

Surgical diff: +12 / −8.

### Integrity checks
- **Axiom integrity verified**: 2 `axiom` declarations (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`), `axiomCount: 2` matches. The two `PackingDensity`-extending structures (`EllipsoidLatticePacking`, `SymmetricConvexBody3DPacking`) add no assumption-carrying fields. 0 sorries. `status: "axiomatized"` correct.
- All 4 cross-reference targets exist (no dead links).
- `pnpm build` passes; JSON validated.

### ⚠️ Systemic issue (recommend a builder follow-up)
This `id`-keyed cross-reference schema is **not unique to this entry — 42 gallery entries** have `crossReferences` using `id` with no `proofId`/`targetId`, so all of their cross-refs are invisible on the site. Rather than editing 42 data files, a one-line UI fallback would fix them all at once:

```ts
const refSlug = ref.proofId ?? ref.targetId ?? ref.id
```

in both `ProofOverview.tsx` and `ProofConclusion.tsx` (and adding `id?: string` to the `CrossReference` type). This data fix is forward-compatible with that change (`proofId` takes precedence). Flagging for a builder since it's a code change outside the enrichment lane.