### PR TITLE
research(erdos-978-oq-01): S1 ORIENT — local-density framing for n⁴+2 squarefree

### DIFF
--- a/research/problems/erdos-978-oq-01/knowledge.md
+++ b/research/problems/erdos-978-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge: erdos-978-oq-01 (n⁴ + 2 squarefree infinitely often)
+
+## Established this session (S1 ORIENT, build-free, sympy-verified)
+
+`verify_squarefree_density.py` certifies by exact integer/rational computation:
+
+- **No local square obstruction.** For every prime `p < 200`,
+  `ρ(p²) = #{n mod p² : p² | n⁴+2} ≤ 4` (the degree bound), so `ρ(p²) < p²` always.
+  Hence there is **no fixed square dividing `n⁴+2` for all `n`** — the trivial "NO"
+  route (a covering square) is ruled out. A degree-4 congruence mod `p²` has at most
+  4 roots, so `ρ(p²) = p²` is impossible for `p² > 4`; the data confirms the bound is
+  attained (`ρ = 4`) only at `p ∈ {73, 89, 113, …}`.
+
+- **Contributing primes.** `ρ(p²) > 0` (i.e. `x⁴ ≡ −2 mod p²` solvable) for
+  `p ∈ {3, 11, 19, 43, 59, 67, 73, 83, 89, 107, 113, 131, 139, 163, 179, …}`. Each has
+  `x⁴ ≡ −2 mod p` solvable and Hensel-lifts (cross-checked). `ρ(p²) = 4` exactly when
+  `−2` is a fourth power with 4 distinct fourth roots mod `p` (e.g. `p = 73, 89, 113`).
+
+- **Positive conjectural density.** `C = ∏_p (1 − ρ(p²)/p²)`:
+  - over `p < 200`:  `C ≈ 0.757273`
+  - over `p < 2000`: `C ≈ 0.756728`  (tail shift `5.4×10⁻⁴` ⇒ converged, `C > 0`).
+  So the standard squarefree-sieve heuristic predicts a **positive density** of
+  squarefree values of `n⁴+2`, hence **infinitely many** — consistent with the
+  (open) conjecture.
+
+- **Empirical match.** Actual squarefree fraction of `{n⁴+2 : n ≤ N}`:
+  `N=2000 → 0.7570`, `N=10⁴ → 0.7564`, `N=5·10⁴ → 0.75668`, vs heuristic `0.756728`
+  (`|diff| ≈ 5×10⁻⁵` at `N=5·10⁴`). The sieve model matches the true behaviour.
+
+## Literature anchors
+
+- Hooley 1967: `(k−1)`-power-free values have positive density (⇒ `n⁴+2` cubefree
+  infinitely often — already an axiom `n4_plus_2_cubefree` in the gallery file).
+- Heath-Brown 2006 / Browning 2011: `(k−2)`-power-free infinitely often for `k ≥ 9`
+  (with asymptotic). The `k = 4` squarefree case is **not** reached by these methods.
+
+## Open / blocked
+
+- **The conjecture itself is open** — not a Lean proof target. The analytic gap is the
+  large-prime square-sieve (`p` up to `~N²`), beyond Mathlib and beyond current
+  number theory for `k = 4`.
+- **Formalizable residue (future ACT, Docker-gated):** Lean defs/lemmas for `ρ(p²)`
+  (decidable, `Finset.filter` over `ZMod (p²)`), the no-obstruction statement
+  `∀ p prime, ρ(p²) < p²` (follows from `Polynomial.card_roots`/degree ≤ 4), and the
+  positivity of the local-factor product. These are genuine, self-contained, and do
+  not require resolving the open analytic problem.

--- a/research/problems/erdos-978-oq-01/problem.md
+++ b/research/problems/erdos-978-oq-01/problem.md
@@ -1,0 +1,36 @@
+# erdos-978-oq-01: Squarefree values of n⁴ + 2
+
+**Parent gallery:** `erdos-978` (Erdős Problem #978 — Power-Free Values of Polynomials)
+**Lean:** `proofs/Proofs/Erdos978Problem.lean` (`squarefree_conjecture_n4_plus_2`, line ~206)
+**Status:** OPEN (genuine open conjecture, $\$$-prize-adjacent)
+
+## Statement
+
+Does `n⁴ + 2` represent infinitely many squarefree numbers? Formally:
+
+> ∀ N, ∃ n > N, `IsSquarefree (n⁴ + 2)`.
+
+This is the **k = 4 case** of Erdős #978. For an irreducible `f ∈ ℤ[x]` of degree `k > 2`:
+- **(k−1)-power-free** values have positive density — **YES** (Hooley 1967). For `k = 4`
+  this is the *cubefree* case, encoded as the axiom `n4_plus_2_cubefree`.
+- **(k−2)-power-free** values infinitely often — **YES for k ≥ 9** (Heath-Brown 2006,
+  Browning 2011); **OPEN for k < 9**. For `k = 4` the (k−2) = *squarefree* case is this OQ.
+
+## Why it is hard
+
+Proving `f(n)` squarefree infinitely often requires sieving out every prime square
+`p² | f(n)`. The "small" primes (`p ≲ N^{1/2}`) are handled by standard sieves, but the
+"large" primes (`p` up to `~N^{k/2} = N²` for `k = 4`) need a power-saving count of
+`#{n ≤ N : p² | f(n)}` uniformly in `p` — exactly the input Heath-Brown/Browning obtain
+only for `k ≥ 9`. No method currently reaches `k = 4` for the squarefree exponent.
+
+## Formalization target
+
+The full conjecture is **not** provable with current mathematics, so it cannot be a Lean
+proof target. The realistically formalizable / checkable pieces are:
+1. **No local obstruction**: no fixed square `m² > 1` divides `n⁴ + 2` for all `n`.
+2. **Positive conjectural density**: `C = ∏_p (1 − ρ(p²)/p²) > 0`, where
+   `ρ(p²) = #{n mod p² : p² | n⁴ + 2}`.
+3. The bridge to the known cubefree result (`n4_plus_2_cubefree`).
+
+See `verify_squarefree_density.py` for the build-free numerical certification of (1)–(2).

--- a/research/problems/erdos-978-oq-01/state.md
+++ b/research/problems/erdos-978-oq-01/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: S1 ORIENT (fresh problem; build-free numerical certification of the local
+density framing — Docker DOWN, no Lean change)
+**Since**: 2026-06-14 (S1 ORIENT)
+**Iteration**: 1
+**Owner**: researcher-2 (S1 ORIENT, 2026-06-14)
+
+## Iteration 1 (researcher-2, 2026-06-14) — S1 ORIENT
+
+**Outcome**: ORIENT/scaffold. Created the research directory for this fresh
+`available` OQ and shipped a reproducible sympy verification (`verify_squarefree_density.py`,
+all asserts pass). No `.lean` touched (the OQ is an open conjecture and Docker is down).
+
+**What was established** (see `knowledge.md` for the numbers):
+1. No local square obstruction — `ρ(p²) ≤ 4 < p²` for all primes `p < 200`.
+2. Positive, convergent conjectural density `C = ∏(1 − ρ(p²)/p²) ≈ 0.7567`.
+3. Empirical squarefree fraction of `n⁴+2` matches `C` to `~5×10⁻⁵` at `N = 5·10⁴`.
+
+**Conclusion**: the conjecture is heuristically well-founded (positive density ⇒
+infinitely many) with no trivial obstruction; the difficulty is purely the analytic
+large-prime square sieve, beyond Browning/Heath-Brown's `k ≥ 9` reach.
+
+## Current Focus / Next Action
+
+- The conjecture itself is **OPEN** and not a Lean proof target.
+- **Next (ACT, Docker-gated):** formalize the local-density residue in
+  `Erdos978Problem.lean` — a `decidable` `ρ(p²)` via `Finset.filter` over `ZMod (p²)`,
+  the no-obstruction lemma `∀ p prime, ρ(p²) < p²` (from `Polynomial`'s degree/roots
+  bound), and positivity of the local product. Self-contained; does not resolve the
+  open analytic problem.
+- No further build-free progress is available until Docker returns.

--- a/research/problems/erdos-978-oq-01/verify_squarefree_density.py
+++ b/research/problems/erdos-978-oq-01/verify_squarefree_density.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+ORIENT verification for erdos-978-oq-01:
+    "Does n^4 + 2 represent infinitely many squarefree numbers?"
+    (The k = 4 case of Erdos Problem #978, currently OPEN.)
+
+The full statement is open mathematics (no proof is known; the k < 9 range of
+Browning/Heath-Brown power-free results does not reach k = 4 for the squarefree
+exponent). This script does NOT attempt to prove it. It establishes the
+*build-free, checkable* facts that frame the conjecture and pin the only
+quantity a formalization could realistically target:
+
+  (1) NO LOCAL OBSTRUCTION. There is no fixed square m^2 > 1 dividing n^4 + 2
+      for all n. Equivalently, for every prime p, the count
+          rho(p^2) := #{ n mod p^2 : p^2 | n^4 + 2 }
+      is strictly less than p^2 (in fact rho(p^2) <= 4). So the naive reason
+      the answer could be "NO" (a covering square) does not occur.
+
+  (2) CONJECTURAL DENSITY IS POSITIVE. Under the standard squarefree-sieve
+      heuristic, the density of n <= N with n^4 + 2 squarefree is
+          C = prod_p ( 1 - rho(p^2) / p^2 )
+      We compute C over primes up to a cutoff and show the product converges to
+      a positive constant ( > 0 ), so the heuristic predicts a POSITIVE density
+      of squarefree values -- hence infinitely many. (A positive heuristic
+      density is consistent with, but does not prove, the open conjecture.)
+
+  (3) EMPIRICAL MATCH. The actual count of squarefree values of n^4 + 2 for
+      n <= N, divided by N, agrees with C to within O(1/sqrt(N)) sampling
+      error -- the standard sanity check that rho and the heuristic model the
+      true behaviour.
+
+  (4) WHICH PRIMES CONTRIBUTE. Lists the small primes p with rho(p^2) > 0
+      (i.e. n^4 + 2 = 0 mod p^2 solvable). These are exactly the p where
+      -2 is a fourth power mod p^2; they are the terms that pull C below 1.
+
+All assertions are exact integer / rational computations except the final
+empirical-vs-heuristic comparison, which is a numerical sanity bound.
+"""
+
+from sympy import factorint, primerange
+
+
+# ---------------------------------------------------------------------------
+def is_squarefree(n: int) -> bool:
+    if n <= 0:
+        return False
+    return all(e == 1 for e in factorint(n).values())
+
+
+def rho_psq(p: int) -> int:
+    """#{ n mod p^2 : p^2 | n^4 + 2 }."""
+    m = p * p
+    return sum(1 for n in range(m) if (n ** 4 + 2) % m == 0)
+
+
+def rho_p(p: int) -> int:
+    """#{ n mod p : p | n^4 + 2 }  (for context: solvability of x^4 = -2 mod p)."""
+    return sum(1 for n in range(p) if (n ** 4 + 2) % p == 0)
+
+
+# ---------------------------------------------------------------------------
+def check_no_local_obstruction(prime_cutoff: int):
+    """(1) No prime p has rho(p^2) = p^2; record rho(p^2) for all p < cutoff."""
+    rho_table = {}
+    ok = True
+    for p in primerange(2, prime_cutoff):
+        r = rho_psq(p)
+        rho_table[p] = r
+        # A covering square would need rho(p^2) = p^2. n^4 + 2 ≡ 0 mod p^2 has
+        # at most 4 roots (degree 4), so this can never happen for p^2 > 4.
+        if r >= p * p:
+            ok = False
+        if r > 4:
+            ok = False  # degree-4 congruence: at most 4 roots mod p^2
+    return ok, rho_table
+
+
+def heuristic_density(prime_cutoff: int):
+    """(2) C = prod_p (1 - rho(p^2)/p^2) over p < cutoff (rational-ish float)."""
+    C = 1.0
+    contributors = {}
+    for p in primerange(2, prime_cutoff):
+        r = rho_psq(p)
+        if r:
+            contributors[p] = r
+        C *= (1.0 - r / (p * p))
+    return C, contributors
+
+
+def empirical_density(N: int) -> float:
+    """(3) Fraction of n in [1, N] with n^4 + 2 squarefree."""
+    cnt = sum(1 for n in range(1, N + 1) if is_squarefree(n ** 4 + 2))
+    return cnt / N
+
+
+# ---------------------------------------------------------------------------
+def main():
+    print("=" * 70)
+    print("erdos-978-oq-01 : n^4 + 2 squarefree infinitely often?  (OPEN, k=4)")
+    print("=" * 70)
+
+    # (1) No local obstruction
+    ok, rho_table = check_no_local_obstruction(prime_cutoff=200)
+    assert ok, "FOUND a local square obstruction -- contradicts degree bound!"
+    max_rho = max(rho_table.values())
+    print(f"\n(1) No local obstruction over primes < 200:")
+    print(f"    max_p rho(p^2) = {max_rho}  (<= 4, the degree bound)  [OK]")
+    print(f"    => no fixed square divides n^4+2 for all n.")
+
+    # (4) Contributing primes (small)
+    contrib_small = {p: r for p, r in rho_table.items() if r}
+    print(f"\n(4) Primes p<200 with p^2 | n^4+2 solvable (rho(p^2)>0):")
+    print(f"    {contrib_small}")
+    # cross-check: rho(p^2)>0  <=>  x^4 = -2 mod p solvable (Hensel lifts since
+    # p is odd and does not divide 4n^3 at a root, as p != 2-related; verify):
+    for p, r in contrib_small.items():
+        rp = rho_p(p)
+        assert rp > 0, f"rho(p^2)>0 but rho(p)=0 at p={p} -- Hensel inconsistency"
+    print(f"    cross-check: each has x^4=-2 mod p solvable  [OK]")
+
+    # (2) Heuristic density positive and convergent
+    C_lo, _ = heuristic_density(prime_cutoff=200)
+    C_hi, contributors = heuristic_density(prime_cutoff=2000)
+    print(f"\n(2) Conjectural squarefree density C = prod_p (1 - rho(p^2)/p^2):")
+    print(f"    C (primes<200)  = {C_lo:.6f}")
+    print(f"    C (primes<2000) = {C_hi:.6f}")
+    assert C_hi > 0.5, "heuristic density not clearly positive"
+    print(f"    => C > 0 : heuristic predicts POSITIVE density of squarefree")
+    print(f"       values, hence INFINITELY MANY (consistent with conjecture).")
+    print(f"    tail (primes 200..2000) shifts C by {abs(C_hi-C_lo):.2e} -> converged")
+
+    # (3) Empirical match
+    for N in (2000, 10000, 50000):
+        emp = empirical_density(N)
+        err = abs(emp - C_hi)
+        tol = 3.0 / (N ** 0.5)  # ~3 sigma sampling band
+        print(f"\n(3) N={N:>6}: empirical={emp:.6f}  heuristic={C_hi:.6f}  "
+              f"|diff|={err:.6f}  (3/sqrt N = {tol:.6f})")
+        assert err < tol + 0.01, f"empirical deviates from heuristic at N={N}"
+    print("\n    Empirical squarefree fraction tracks the heuristic constant.")
+
+    print("\n" + "=" * 70)
+    print("CONCLUSION (build-free): the conjecture has NO local obstruction and a")
+    print("POSITIVE conjectural density; the empirical count matches. The open")
+    print("difficulty is purely analytic (sieving the square divisors p^2 with")
+    print("p ~ N^2, beyond Browning/Heath-Brown's k>=9 reach). All asserts pass.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fresh `available` OQ: **does `n⁴ + 2` represent infinitely many squarefree numbers?** — the **k = 4 case** of Erdős #978, **OPEN** (no method reaches the squarefree exponent for `k < 9`; Browning/Heath-Brown only give `k ≥ 9`). Docker down → build-free ORIENT; creates the research scaffold and a reproducible numerical certification.

`verify_squarefree_density.py` (sympy, all asserts pass) establishes:
- **No local obstruction** — `ρ(p²) = #{n mod p² : p² | n⁴+2} ≤ 4 < p²` for all primes `p < 200` (degree-4 congruence ⇒ ≤ 4 roots). The trivial "NO" (a covering square) is ruled out.
- **Positive conjectural density** — `C = ∏_p (1 − ρ(p²)/p²)`: `0.757273` (p<200) → `0.756728` (p<2000), tail shift `5.4×10⁻⁴` ⇒ converged, `C > 0`. The squarefree-sieve heuristic predicts positive density ⇒ infinitely many.
- **Empirical match** — actual squarefree fraction of `n⁴+2`: `N=5·10⁴ → 0.75668` vs heuristic `0.756728` (`|diff| ≈ 5×10⁻⁵`).

The full conjecture is **not** a Lean proof target (open mathematics). The PR pins the genuinely formalizable residue for a future Docker-up ACT: a decidable `ρ(p²)`, the no-obstruction lemma `∀ p prime, ρ(p²) < p²` (from the polynomial degree/roots bound), and positivity of the local product — none of which resolve the open analytic difficulty.

## Files
- `research/problems/erdos-978-oq-01/{problem,knowledge,state}.md` (new scaffold)
- `research/problems/erdos-978-oq-01/verify_squarefree_density.py` (new; exit 0)

No `.lean` change. Math PR — no `loom:review-requested`.

## Test plan
- [x] `python3 research/problems/erdos-978-oq-01/verify_squarefree_density.py` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)