### PR TITLE
research(minkowski-fundamental-theorem-oq-06): ORIENT — Minkowski–Hlawka gap audit + durable bound verification

### DIFF
--- a/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
@@ -6,16 +6,70 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The **Minkowski–Hlawka theorem** is the non-constructive *existence* counterpart to the
+gallery's parent (Minkowski's convex-body *obstruction* theorem). It asserts the densest
+lattice packing in dimension `n ≥ 2` has density
+
+    δ_n ≥ ζ(n) / 2^(n-1)
+
+equivalently: every symmetric bounded measurable `S` with `vol(S) < 2·ζ(n)` is avoided
+(off the origin) by some unimodular lattice. The standard proof averages
+`#(Λ ∩ S \ {0})` over the space of unimodular lattices `X_n = SL_n(ℤ)\SL_n(ℝ)` via
+**Siegel's mean-value theorem** and extracts a better-than-average lattice — without
+exhibiting one.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Session 2026-06-14 (ORIENT) — gap audit + constants pinned
+
+**Mode**: FRESH · **Outcome**: ORIENT (survey, effectively blocked for full proof)
+
+**What I did**
+- Confirmed Hlawka is *not* in the gallery: only the obstruction parent exists
+  (`MinkowskiFundamentalTheorem.lean`, sorry-free, proves a different theorem). `grep -i
+  hlawka proofs/` hits only `Erdos997Problem.lean` (unrelated).
+- Audited Mathlib at pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:
+  `MeasureTheory/Group/GeometryOfNumbers.lean` contains only **Blichfeldt**
+  (`exists_pair_mem_lattice_not_disjoint_vadd`) and **Minkowski convex-body**
+  (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_{lt,le}_measure`). No Siegel
+  mean-value (`gh search` = 0), no packing density (`gh search packingDensity` = 0).
+  "Minkowski–Hlawka theorem" is a **title-only** entry in Mathlib `docs/1000.yaml` (no
+  `decl:`/`author:`) → an *unmet* target upstream.
+- Wrote a durable numerical artifact `verify_minkowski_hlawka.py` (all checks pass).
+
+**Key findings**
+- **Normalization (correction to seed).** For *symmetric* `S` the threshold is
+  `vol(S) < 2·ζ(n)`, not `< ζ(n)`. Chain: take `S = ball(2r)`; an avoiding unimodular
+  lattice has min distance `≥ 2r`, so radius-`r` balls pack with density
+  `vol(ball r) = vol(S)/2^n = 2ζ(n)/2^n = ζ(n)/2^(n-1)`. The seed's `< ζ(n)` is the
+  star-body / ±-identified convention.
+- **Bound hierarchy** (verified n ∈ {2..8, 24}): `2^(-n) ≤ ζ(n)/2^(n-1) ≤ δ_n^known`
+  (A2, D3, D4, D5, E6, E7, E8, Leech). MH is a valid but very weak lower bound vs known
+  optima (e.g. n=8: MH `0.00784` vs E8 `0.2537`).
+- **Improvement factor.** `MH / trivial = 2ζ(n) → 2` as `n→∞`. So Hlawka beats the
+  elementary maximal-packing bound `δ_n ≥ 2^(-n)` by only ~a factor of 2; both decay like
+  `2^(-n)` and the exponential gap to the (also exponential) Kabatiansky–Levenshtein
+  *upper* bound is untouched.
+
+**Decision: SURVEY / effectively BLOCKED for full proof.** The standard route requires
+Siegel's mean-value theorem over `SL_n(ℝ)/SL_n(ℤ)` (>1000 LOC of missing measure theory).
+
+**Actionable next targets** (both Docker-gated):
+1. *Staged*: state Hlawka with Siegel's identity as an explicit hypothesis
+   (axiom/structure field), then prove "better-than-average ⇒ existence" with ±-pairing →
+   `δ_n ≥ ζ(n)/2^(n-1)`. Isolates the one deep lemma; badge=axiom, status=axiomatized.
+2. *Elementary stepping stone* (~200–400 LOC, Mathlib-only): the saturation bound
+   `δ_n ≥ 2^(-n)` via maximal packing + radius-doubling cover. The "easy constant" that MH
+   sharpens by `2ζ(n)`.
+
+**Files**: `verify_minkowski_hlawka.py`, `src/data/research/problems/minkowski-fundamental-theorem-oq-06.json`.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Full formalization via Siegel's mean-value theorem from current Mathlib — blocked: the
+  homogeneous space `SL_n(ℤ)\SL_n(ℝ)`, its finite invariant measure, and Siegel's identity
+  are all absent upstream.

--- a/research/problems/minkowski-fundamental-theorem-oq-06/state.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/state.md
@@ -1,16 +1,19 @@
 # Research State: minkowski-fundamental-theorem-oq-06
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-14T17:42:10-07:00
-**Iteration**: 1
+**Since**: 2026-06-14
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Mathlib gap confirmed at pin; constants pinned (symmetric threshold 2·ζ(n) → δ_n ≥
+ζ(n)/2^(n-1)) and bound hierarchy + factor-2ζ(n) improvement verified. Full proof blocked
+on Siegel mean-value; staged-hypothesis file and elementary 2^(-n) bound identified as
+actionable targets.
 
 ## Active Approach
-None yet.
+None active (Docker down → no build). Next session: ACT one of the two staged targets.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +21,11 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Full proof: Siegel's mean-value theorem over SL_n(ℝ)/SL_n(ℤ) absent from Mathlib
+  (>1000 LOC of missing measure theory on the space of unimodular lattices).
+- Build: Docker unavailable this session (build-free ORIENT only).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Either (1) stage Siegel as an explicit hypothesis and prove the better-than-average ⇒
+existence extraction (badge=axiom), or (2) ACT the elementary δ_n ≥ 2^(-n) saturation
+bound from Mathlib alone. Both are Docker-gated.

--- a/research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Durable verification for minkowski-fundamental-theorem-oq-06 (Minkowski-Hlawka).
+
+The full theorem is NON-CONSTRUCTIVE and not formalizable from current Mathlib
+(needs Siegel's mean-value theorem over SL_n(R)/SL_n(Z); see ORIENT notes). This
+script does NOT prove the theorem. It pins down the *numerical content* of the
+statement so the Lean target and its constants are unambiguous, and sanity-checks
+the claimed lower bound against the classical densest-lattice-packing data.
+
+What is checked:
+  (A) Statement<->density derivation. The symmetric Minkowski-Hlawka statement
+      "any symmetric S with vol(S) < 2*zeta(n) is avoided (nonzero) by some
+      unimodular lattice" yields, with S a ball of radius 2r, the lattice
+      packing-density lower bound
+            delta_n >= zeta(n) / 2^(n-1).
+      We verify vol(ball r) / vol(unit cell=1) = vol(S)/2^n = 2*zeta(n)/2^n
+                                              = zeta(n)/2^(n-1).
+  (B) Bound hierarchy: trivial saturation bound  2^(-n)  <=  MH bound
+      <=  known densest lattice density delta_n^known,  for n where delta_n is known.
+  (C) Improvement factor: MH / trivial = 2*zeta(n)  (-> 2 as n->infty since
+      zeta(n) -> 1). MH improves the elementary maximal-packing bound by ~2x.
+
+Run:  python3 verify_minkowski_hlawka.py
+Requires: sympy (exact zeta/pi); falls back to float zeta via mpmath/math if absent.
+"""
+
+import math
+
+try:
+    from sympy import zeta, Rational, pi, factorial, nsimplify, simplify, N
+    HAVE_SYMPY = True
+except Exception:
+    HAVE_SYMPY = False
+
+
+def zeta_f(n: int) -> float:
+    if HAVE_SYMPY:
+        return float(zeta(n))
+    # Euler-Maclaurin-free crude sum; n>=2 converges fast enough for a sanity check.
+    s = 0.0
+    for k in range(1, 200000):
+        s += k ** (-n)
+    return s
+
+
+def mh_bound(n: int) -> float:
+    """Minkowski-Hlawka lower bound on the densest LATTICE packing density, n>=2."""
+    return zeta_f(n) / 2 ** (n - 1)
+
+
+def trivial_bound(n: int) -> float:
+    """Elementary maximal-packing (saturation) lower bound delta_n >= 2^-n."""
+    return 2.0 ** (-n)
+
+
+# Classical densest known LATTICE packing densities (fraction of space covered).
+KNOWN = {
+    1: 1.0,                                  # Z
+    2: math.pi / math.sqrt(12),              # A2 hexagonal  ~0.90690
+    3: math.pi / (3 * math.sqrt(2)),         # D3 / fcc      ~0.74048
+    4: math.pi ** 2 / 16,                    # D4            ~0.61685
+    5: math.pi ** 2 / (15 * math.sqrt(2)),   # D5            ~0.46526
+    6: math.pi ** 3 / (48 * math.sqrt(3)),   # E6            ~0.37295
+    7: math.pi ** 3 / 105,                   # E7            ~0.29530
+    8: math.pi ** 4 / 384,                   # E8            ~0.25367
+    24: math.pi ** 12 / math.factorial(12),  # Leech         ~0.0019296
+}
+
+EPS = 1e-12
+
+
+def check_A_statement_density() -> bool:
+    """vol(S)=2*zeta(n), S=ball(2r): density = vol(ball r) = vol(S)/2^n = zeta/2^(n-1)."""
+    ok = True
+    for n in range(2, 13):
+        volS = 2.0 * zeta_f(n)               # symmetric threshold
+        density_from_S = volS / 2 ** n       # ball radius r is ball(2r) scaled by 1/2
+        target = mh_bound(n)
+        if abs(density_from_S - target) > EPS * max(1.0, target):
+            print(f"  [A] n={n}: derivation mismatch {density_from_S} vs {target}")
+            ok = False
+    return ok
+
+
+def check_B_hierarchy() -> bool:
+    ok = True
+    for n in sorted(KNOWN):
+        if n == 1:
+            continue  # zeta(1) diverges; n=1 density is trivially 1
+        triv, mh, kd = trivial_bound(n), mh_bound(n), KNOWN[n]
+        if not (triv <= mh + EPS):
+            print(f"  [B] n={n}: trivial {triv} !<= MH {mh}")
+            ok = False
+        if not (mh <= kd + EPS):
+            print(f"  [B] n={n}: MH {mh} !<= known {kd}")
+            ok = False
+    return ok
+
+
+def check_C_improvement() -> bool:
+    ok = True
+    for n in range(2, 25):
+        ratio = mh_bound(n) / trivial_bound(n)
+        if abs(ratio - 2.0 * zeta_f(n)) > 1e-9 * ratio:
+            print(f"  [C] n={n}: ratio {ratio} != 2*zeta {2*zeta_f(n)}")
+            ok = False
+    # monotone approach to 2 from above as n grows
+    if not (mh_bound(24) / trivial_bound(24) < mh_bound(2) / trivial_bound(2)):
+        print("  [C] improvement factor not decreasing toward 2")
+        ok = False
+    return ok
+
+
+def table():
+    print(f"{'n':>3} {'2^-n (triv)':>13} {'zeta(n)/2^(n-1) (MH)':>22} "
+          f"{'delta_n known':>14} {'MH/triv=2zeta(n)':>18}")
+    for n in sorted(KNOWN):
+        if n == 1:
+            print(f"{n:>3} {trivial_bound(n):13.6g} {'(zeta diverges)':>22} "
+                  f"{KNOWN[n]:14.6g} {'-':>18}")
+            continue
+        print(f"{n:>3} {trivial_bound(n):13.6g} {mh_bound(n):22.8g} "
+              f"{KNOWN[n]:14.6g} {2*zeta_f(n):18.6g}")
+
+
+if __name__ == "__main__":
+    print(f"sympy available: {HAVE_SYMPY}\n")
+    table()
+    print()
+    results = {
+        "A statement<->density (delta=zeta/2^(n-1))": check_A_statement_density(),
+        "B hierarchy 2^-n <= MH <= delta_known": check_B_hierarchy(),
+        "C improvement factor MH/triv = 2*zeta(n)": check_C_improvement(),
+    }
+    print()
+    allok = True
+    for name, ok in results.items():
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}")
+        allok = allok and ok
+    print()
+    print("ALL CHECKS PASSED" if allok else "SOME CHECKS FAILED")
+    raise SystemExit(0 if allok else 1)

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
@@ -1,0 +1,116 @@
+{
+  "slug": "minkowski-fundamental-theorem-oq-06",
+  "title": "The Minkowski–Hlawka Theorem",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: The Minkowski–Hlawka Theorem.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T01:25:28.051Z",
+    "iteration": 2,
+    "focus": "Confirmed Mathlib gap and pinned constants; full proof blocked on Siegel mean-value, staged/elementary targets identified.",
+    "blockers": [],
+    "nextAction": "Either stage Siegel as a hypothesis and prove the extraction, or ACT the elementary 2^-n saturation bound (both Docker-gated).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: confirmed Mathlib gap at pin (no Siegel mean-value / lattice-space measure / packing density; Hlawka title-only in 1000.yaml). Pinned the constants (symmetric threshold 2*zeta(n) -> delta_n >= zeta(n)/2^(n-1)) and verified the bound hierarchy + factor 2*zeta(n) improvement over trivial saturation. Full proof BLOCKED on Siegel; staged hypothesis file + elementary 2^-n bound identified as actionable next targets.",
+    "builtItems": [
+      "research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py - durable sympy verification: (A) symmetric threshold 2*zeta(n) <-> density zeta(n)/2^(n-1); (B) hierarchy 2^-n <= MH <= delta_known; (C) improvement factor = 2*zeta(n). All pass."
+    ],
+    "insights": [
+      "Minkowski-Hlawka is the EXISTENCE complement to the gallery parent (which proves only the Minkowski convex-body OBSTRUCTION). Parent MinkowskiFundamentalTheorem.lean is sorry-free but proves a different theorem; Hlawka is absent from proofs/ (grep -i hlawka hits only Erdos997Problem.lean, unrelated).",
+      "Correct symmetric normalization: if symmetric S has vol(S) < 2*zeta(n) then some unimodular lattice avoids S minus {0}; taking S = ball(radius 2r) gives lattice packing density delta_n >= zeta(n)/2^(n-1). The seed problem.md threshold vol(S) < zeta(n) is the star-body / plus-minus-identified convention; the symmetric-body threshold is 2*zeta(n). Statement<->density chain verified numerically (verify_minkowski_hlawka.py check A).",
+      "Bound hierarchy verified for n in {2..8,24}: trivial saturation 2^-n <= zeta(n)/2^(n-1) <= delta_n^known (A2,D3,D4,D5,E6,E7,E8,Leech). MH is a VALID but very weak lower bound vs known optima (n=8: MH 0.00784 vs E8 0.2537).",
+      "MH improves the elementary maximal-packing bound delta_n >= 2^-n by exactly a factor 2*zeta(n), which decreases to 2 as n grows. So the celebrated Hlawka improvement over the trivial saturation argument is asymptotically only a factor of 2; both bounds decay like 2^-n and the exponential gap to the (also exponential) Kabatiansky-Levenshtein upper bound is untouched by MH."
+    ],
+    "mathlibGaps": [
+      "Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: GeometryOfNumbers.lean has ONLY Blichfeldt (exists_pair_mem_lattice_not_disjoint_vadd) + Minkowski convex-body (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt/le_measure). No Hlawka.",
+      "No Siegel mean-value theorem in Mathlib (gh search SiegelMeanValue/siegel_mean = 0 hits). The identity int_{X_n} sum_{v in L minus 0} f(v) dmu = int_{R^n} f is THE engine of the standard proof and is absent.",
+      "No space of unimodular lattices X_n = SL_n(Z)\\SL_n(R) with its finite SL_n(R)-invariant probability measure. Mathlib has Haar on locally compact groups and ZLattice/Zspan covolume, but not this homogeneous space / its finite measure.",
+      "No packing-density notion (gh search packingDensity = 0). 'Minkowski-Hlawka theorem' appears in Mathlib docs/1000.yaml as a TITLE-ONLY entry (no decl:/author:), i.e. an UNMET target in the 1000-theorems project -> confirms not formalized upstream."
+    ],
+    "nextSteps": [
+      "Decision = SURVEY / effectively BLOCKED for full proof: standard route needs Siegel mean-value over SL_n(R)/SL_n(Z) (>1000 LOC of missing measure theory). Do NOT attempt full formalization.",
+      "Staged ACT target (realistic, Docker-gated): a Lean file stating Minkowski-Hlawka with Siegel's identity as an explicit HYPOTHESIS (axiom or structure field), then prove the better-than-average => existence extraction with plus-minus pairing to land delta_n >= zeta(n)/2^(n-1). Isolates the one deep lemma.",
+      "Genuinely reachable elementary stepping stone (ACT-able from Mathlib alone, ~200-400 LOC): the saturation bound delta_n >= 2^-n via maximal packing + radius-doubling cover. This is the easy constant; MH only sharpens it by the 2*zeta(n) factor.",
+      "When building the staged file, mirror sibling style (MinkowskiFundamentalTheoremOQ02/OQ04: survey docstring + Mathlib aliases where available, explicit assumption where not). Set badge=axiom (Siegel staged as assumption), status=axiomatized."
+    ]
+  },
+  "tags": [
+    "geometry-of-numbers",
+    "lattices",
+    "packing-density",
+    "minkowski-hlawka",
+    "seeker-selected",
+    "gallery-extracted",
+    "research"
+  ],
+  "relatedProofs": [
+    "minkowski-fundamental-theorem",
+    "minkowski-fundamental-theorem-oq-02",
+    "minkowski-fundamental-theorem-oq-04",
+    "minkowski-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T01:25:28.051Z",
+  "lastUpdate": "2026-06-15T01:25:28.051Z",
+  "significance": 7,
+  "tractability": 3,
+  "leanFiles": [
+    {
+      "path": "Proofs/MinkowskiFundamentalTheorem.lean",
+      "filename": "MinkowskiFundamentalTheorem.lean",
+      "lineCount": 687,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheorem.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ02.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ02.lean",
+      "lineCount": 131,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ04.lean",
+      "lineCount": 193,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fresh seeker OQ: **The Minkowski–Hlawka theorem** — the non-constructive *existence*/density complement to the gallery's already-formalized Minkowski convex-body **obstruction** parent. This is a build-free ORIENT (Docker unavailable this session).

## What this PR does

- **Mathlib gap audit at pin `2df2f01`** (grounded, not assumed):
  - `MeasureTheory/Group/GeometryOfNumbers.lean` contains only **Blichfeldt** + **Minkowski convex-body**; no Hlawka.
  - No Siegel mean-value theorem, no packing-density notion (`gh search` = 0 each).
  - "Minkowski–Hlawka theorem" is a **title-only** (unmet) target in Mathlib `docs/1000.yaml`.
  - ⟹ full proof **BLOCKED**: standard route needs Siegel's mean-value over `SL_n(ℝ)/SL_n(ℤ)` (>1000 LOC of absent measure theory on the space of unimodular lattices).
- **Constants pinned + corrected.** Symmetric threshold is `vol(S) < 2·ζ(n)` (not the seed's `ζ(n)`), which yields `δ_n ≥ ζ(n)/2^(n-1)` via `S = ball(2r)`.
- **Durable numerical artifact** `verify_minkowski_hlawka.py` (sympy, all checks pass):
  - (A) statement↔density chain `2ζ(n)/2^n = ζ(n)/2^(n-1)`;
  - (B) hierarchy `2^(-n) ≤ ζ(n)/2^(n-1) ≤ δ_n^known` for n ∈ {2..8, 24} (A2, D3, D4, D5, E6, E7, E8, Leech);
  - (C) improvement factor `MH/trivial = 2ζ(n) → 2`, i.e. Hlawka beats the elementary saturation bound by only ~2×.
- **Actionable next targets** documented: (1) staged Siegel-as-hypothesis extraction → `δ_n ≥ ζ(n)/2^(n-1)`; (2) the elementary `δ_n ≥ 2^(-n)` saturation bound (Mathlib-only, ~200–400 LOC).
- Rescue-committed the untracked seeker JSON; advanced phase OBSERVE→ORIENT.

No Lean changes (full proof is blocked upstream); no gallery `meta.json` changes.

## Test plan
- [x] `python3 research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py` → ALL CHECKS PASSED
- [x] Mathlib gap claims checked via `gh api`/`gh search` at the repo's pinned rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)