### PR TITLE
research(erdos-101-oq-01): S17 durable Docker-free verification of pair-packing bound + Θ(n²) arithmetic

### DIFF
--- a/research/problems/erdos-101-oq-01/sessions/2026-06-14-s17-durable-bound-verification.md
+++ b/research/problems/erdos-101-oq-01/sessions/2026-06-14-s17-durable-bound-verification.md
@@ -1,0 +1,57 @@
+# S17 — Durable (Docker-free) verification of the unconditional bounds
+
+**Date**: 2026-06-14
+**Agent**: researcher-3
+**Mode**: DURABLE-VERIFY (build-free; new files only — path-disjoint from
+in-flight PR #23389 which edits `Erdos101OQ01.lean` + `state.md` + `meta.json`)
+
+## Context
+
+Erdős #101 OQ-01 is a saturated formalization (S1–S16). The two remaining
+`sorry`s are **genuinely open mathematics** and not closable by routine ACT:
+
+1. `erdos_101_oq_01` — the $100 *four-point lines are o(n²)* conjecture.
+2. `solymosi_stojakovic_lower_bound` — the Ω(n^{2−C/√log n}) lower bound via an
+   explicit finite-field construction (deferred; AG over 𝔽_q).
+
+Docker was **DOWN** this session, so no Lean ACT was possible, and the only
+in-flight Lean work (PR #23389, S16 reverse-IsBigO for Θ(n²)) is build-pending.
+There were no durable verification artifacts in the slug.
+
+## What this session adds
+
+`research/problems/erdos-101-oq-01/verify_bounds.py` — a self-contained,
+deterministic (seed 101), Docker-free numerical check of the **proved,
+unconditional** facts the gallery file relies on, plus the surrogate arithmetic
+underlying #23389. It does **not** touch the two open sorries.
+
+- **(A)** `improved_upper_bound` pair-packing: `6·(#4-point collinear subsets)
+  ≤ C(n,2)`, hence `fourPointLineCount ≤ ⌊n(n−1)/12⌋`. Brute-forced over 360
+  random rational/integer no-five-collinear configs (n=4..12, 29 with ≥1
+  four-point line) **and** the 2×2/3×3/4×4 grids. All satisfy the bound.
+- **(B)** Surrogate Θ(n²) for `maxFourPointLines n = n(n−1)//12` — the function
+  behind #23389's reverse IsBigO. Verifies forward `≤ n²` (const 1), the ℕ-floor
+  lemma `a ≤ 12·⌊a/12⌋+11`, reverse `n² ≤ 24·maxFourPointLines n` for n≥6
+  (PR #23389's constant 24), the residual `n²≤2n²−2n−22`, and the factor
+  `(n−6)(n+4)≥0`. Confirms the const-24 bound **genuinely needs n≥6** (fails at
+  n∈{1,2,3,5}), independently de-risking #23389's `nlinarith` step.
+- **(C)** Concrete ℝ² witness: the 4×4 integer grid has max collinearity 4 (no 5
+  collinear) and exactly **10** four-point lines (4 rows + 4 cols + 2 diagonals)
+  vs the bound ⌊16·15/12⌋ = 20 — a Θ(1) fraction realised in the real plane, so
+  the elementary bound is non-vacuous. (A super-linear ℝ² construction is the SS
+  lower bound, deferred.)
+
+Run: `python3 research/problems/erdos-101-oq-01/verify_bounds.py` → exit 0.
+
+## Why build-free / new-files-only
+
+`improved_upper_bound` is proved in `Erdos101Problem.lean:523`; its pair-packing
+combinatorics had no independent numerical cross-check. #23389's Θ(n²) reverse
+bound was build-pending with an un-exercised `nlinarith`. This artifact grounds
+both without recompiling Lean and **without editing any file #23389 touches**, so
+the two PRs are mergeable in either order.
+
+## Not attempted
+
+- The two open sorries (open math / deep construction).
+- Any edit to `Erdos101OQ01.lean`, `state.md`, or `meta.json` (contended by #23389).

--- a/research/problems/erdos-101-oq-01/verify_bounds.py
+++ b/research/problems/erdos-101-oq-01/verify_bounds.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Durable numerical verification for Erdős #101 OQ-01 (four-point lines are o(n²)?).
+
+This script grounds — independently of the Lean build (Docker) — the two
+*proved, unconditional* arithmetic/combinatorial facts that the gallery file
+`proofs/Proofs/Erdos101OQ01.lean` (and its parent `Erdos101Problem.lean`) rely
+on, plus the surrogate Θ(n²) arithmetic underlying the in-flight reverse-IsBigO
+work (PR #23389).
+
+It does NOT attempt the two genuinely OPEN sorries:
+  * `erdos_101_oq_01`              — the $100 o(n²) conjecture itself
+  * `solymosi_stojakovic_lower_bound` — the Ω(n^{2−C/√log n}) finite-field construction
+
+What is verified here:
+
+  (A) `improved_upper_bound` pair-packing inequality
+        6 · (#4-point collinear subsets) ≤ C(n,2)
+      hence   fourPointLineCount(P) ≤ ⌊n(n-1)/12⌋
+      brute-forced over random rational-coordinate no-five-collinear point sets
+      AND structured grids.
+
+  (B) The surrogate Θ(n²) arithmetic for `maxFourPointLines n = n(n-1)//12`:
+        forward  maxFourPointLines n ≤ n²          (constant 1, all n)
+        reverse  n² ≤ 24 · maxFourPointLines n     (constant 24, n ≥ 6)
+      via the two ℕ-floor lemmas the Lean proof leans on:
+        floor lower bound      a ≤ 12·(a//12) + 11
+        residual (n≥6)         n² ≤ 2n² − 2n − 22   ⇔ (n−6)(n+4) ≥ 22−24 ... see below
+
+  (C) A concrete real-plane lower-bound *witness*: the 4×4 integer grid has
+      exactly 10 lines of exactly four points and NO five collinear, so the
+      four-point-line count is genuinely positive and the elementary bound is
+      not vacuous. (This is a witness, not the SS construction.)
+
+Run:  python3 verify_bounds.py
+Exit code 0 ⇔ all checks pass.
+"""
+
+from __future__ import annotations
+import itertools
+import math
+import random
+from fractions import Fraction
+from collections import defaultdict
+
+random.seed(101)  # deterministic
+
+
+# ---------------------------------------------------------------------------
+# Geometry primitives over exact rationals (no floating point).
+# ---------------------------------------------------------------------------
+
+def collinear(a, b, c):
+    """Exact collinearity test via the cross product of (b−a) and (c−a)."""
+    (ax, ay), (bx, by), (cx, cy) = a, b, c
+    return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax) == 0
+
+
+def maximal_collinear_lines(points):
+    """Return the set of maximal collinear subsets (as frozensets of indices).
+
+    Two points determine a line; we group all points by the line they span,
+    using an exact normalized line key, then return the point-index sets.
+    """
+    n = len(points)
+    line_members = defaultdict(set)
+    for i, j in itertools.combinations(range(n), 2):
+        line_members[_line_key(points[i], points[j])].update((i, j))
+    # Dedup: distinct (i,j) on the same line produce the same key, so the
+    # members sets already coincide. Collect unique frozensets.
+    seen = set()
+    out = []
+    for members in line_members.values():
+        fs = frozenset(members)
+        if fs not in seen:
+            seen.add(fs)
+            out.append(fs)
+    return out
+
+
+def _line_key(p, q):
+    """Exact canonical key for the line through distinct points p, q.
+
+    Line: A x + B y + C = 0 with (A,B,C) = (qy−py, px−qx, qx·py − px·qy),
+    normalized by dividing by gcd and fixing a sign convention.
+    """
+    (px, py), (qx, qy) = p, q
+    A = qy - py
+    B = px - qx
+    C = qx * py - px * qy
+    # Work over integers if possible; otherwise clear denominators.
+    A, B, C = _clear_denoms(A, B, C)
+    g = math.gcd(math.gcd(abs(A), abs(B)), abs(C))
+    if g:
+        A, B, C = A // g, B // g, C // g
+    # sign convention: first nonzero of (A,B,C) positive
+    for v in (A, B, C):
+        if v != 0:
+            if v < 0:
+                A, B, C = -A, -B, -C
+            break
+    return (A, B, C)
+
+
+def _clear_denoms(*vals):
+    fracs = [Fraction(v) for v in vals]
+    lcm = 1
+    for f in fracs:
+        lcm = lcm * f.denominator // math.gcd(lcm, f.denominator)
+    return tuple(int(f * lcm) for f in fracs)
+
+
+def four_point_line_count(points):
+    """Number of 4-element collinear subsets = #lines with exactly 4 points
+    (under the no-five-collinear regime, each contributes exactly one)."""
+    count = 0
+    for members in maximal_collinear_lines(points):
+        k = len(members)
+        # number of 4-subsets that are collinear on this maximal line
+        if k >= 4:
+            count += math.comb(k, 4)
+    return count
+
+
+def max_line_multiplicity(points):
+    return max((len(m) for m in maximal_collinear_lines(points)), default=0)
+
+
+# ---------------------------------------------------------------------------
+# (A) improved_upper_bound : 6·count ≤ C(n,2)  and  count ≤ ⌊n(n-1)/12⌋
+# ---------------------------------------------------------------------------
+
+def check_improved_upper_bound_on(points, label):
+    n = len(points)
+    mult = max_line_multiplicity(points)
+    if mult >= 5:
+        return None  # not a no-five-collinear configuration; bound doesn't apply
+    count = four_point_line_count(points)
+    pairs = math.comb(n, 2)
+    floor_bound = n * (n - 1) // 12
+    ok_pack = 6 * count <= pairs
+    ok_floor = count <= floor_bound
+    assert ok_pack, f"PAIR-PACK VIOLATED [{label}] n={n}: 6*{count}={6*count} > C(n,2)={pairs}"
+    assert ok_floor, f"FLOOR BOUND VIOLATED [{label}] n={n}: {count} > {floor_bound}"
+    return (n, count, floor_bound, mult)
+
+
+def random_no5_pointset(n, lo=0, hi=12, tries=2000):
+    """Random integer-coordinate set of n points with no five collinear."""
+    for _ in range(tries):
+        pts = set()
+        while len(pts) < n:
+            pts.add((random.randint(lo, hi), random.randint(lo, hi)))
+        pts = list(pts)
+        if max_line_multiplicity(pts) < 5:
+            return pts
+    return None
+
+
+def part_A():
+    print("== (A) improved_upper_bound pair-packing  6·count ≤ C(n,2) ⟹ count ≤ ⌊n(n-1)/12⌋ ==")
+    checked = 0
+    witnesses_with_4lines = 0
+    # random configurations
+    for n in range(4, 13):
+        for _ in range(40):
+            pts = random_no5_pointset(n)
+            if pts is None:
+                continue
+            res = check_improved_upper_bound_on(pts, f"rand n={n}")
+            if res:
+                checked += 1
+                if res[1] > 0:
+                    witnesses_with_4lines += 1
+    print(f"   random no-5-collinear configs checked: {checked} "
+          f"(of which {witnesses_with_4lines} had ≥1 four-point line); all satisfy the bound")
+    # structured grids 2x2 .. 4x4 (k=4 is the largest grid with no 5 collinear)
+    for k in (2, 3, 4):
+        pts = [(x, y) for x in range(k) for y in range(k)]
+        res = check_improved_upper_bound_on(pts, f"{k}x{k} grid")
+        if res:
+            n, count, fb, mult = res
+            print(f"   {k}x{k} grid: n={n}, four-point-line count={count}, "
+                  f"⌊n(n-1)/12⌋={fb}, max collinear={mult}  ✓")
+    print("   PASS\n")
+    return checked
+
+
+# ---------------------------------------------------------------------------
+# (B) surrogate Θ(n²) arithmetic for maxFourPointLines n = n(n-1)//12
+#     (the function behind PR #23389's reverse IsBigO)
+# ---------------------------------------------------------------------------
+
+def max_four_point_lines(n):
+    return n * (n - 1) // 12
+
+
+def part_B():
+    print("== (B) surrogate Θ(n²): maxFourPointLines n = n(n-1)//12 ==")
+    N = 5000
+    # forward: maxFourPointLines n ≤ n²  (so it is O(n²) with constant 1)
+    for n in range(0, N):
+        assert max_four_point_lines(n) <= n * n, f"forward fail n={n}"
+    # the ℕ-floor lower bound the Lean proof uses: a ≤ 12·(a//12) + 11
+    for a in range(0, 100000):
+        assert a <= 12 * (a // 12) + 11, f"floor lemma fail a={a}"
+    # reverse: n² ≤ 24 · maxFourPointLines n  for n ≥ 6 (PR #23389 constant 24)
+    bad = [n for n in range(6, N) if n * n > 24 * max_four_point_lines(n)]
+    assert not bad, f"reverse (const 24, n≥6) fails at {bad[:5]}"
+    # show it genuinely needs n ≥ 6: list small n where it would fail
+    small_fail = [n for n in range(0, 6) if n * n > 24 * max_four_point_lines(n)]
+    # residual identity used in the nlinarith step:  with a = n²−n (= n(n-1)),
+    #   12·(a//12) ≥ a − 11, and  n² ≤ 2(n²−n) − 22  ⇔  (n−6)(n+4) ≥ 2  for the
+    #   threshold; verify the clean factored form (n−6)(n+4) ≥ 0 ⟹ n²≥2n+24-... :
+    for n in range(6, N):
+        a = n * n - n
+        assert 2 * a - 22 >= n * n, f"residual n²≤2n²−2n−22 fails n={n}"
+        assert (n - 6) * (n + 4) >= 0, f"factor (n-6)(n+4)≥0 fails n={n}"
+    print(f"   forward maxFourPointLines n ≤ n²: PASS for n<{N}")
+    print(f"   floor lemma a ≤ 12·⌊a/12⌋+11: PASS for a<100000")
+    print(f"   reverse n² ≤ 24·maxFourPointLines n (n≥6): PASS for n<{N}")
+    print(f"   threshold confirmed: const-24 reverse bound fails for n∈{small_fail} (needs n≥6)")
+    print(f"   residual n²≤2n²−2n−22 and factor (n−6)(n+4)≥0: PASS for 6≤n<{N}")
+    print("   ⟹ maxFourPointLines is Θ(n²): the *elementary* bound is NOT o(n²);")
+    print("     the open content of OQ-01 is a genuinely sub-quadratic refinement.\n")
+
+
+# ---------------------------------------------------------------------------
+# (C) concrete real-plane lower-bound witness: the 4x4 grid
+# ---------------------------------------------------------------------------
+
+def part_C():
+    print("== (C) real-plane witness: 4×4 integer grid ==")
+    pts = [(x, y) for x in range(4) for y in range(4)]
+    n = len(pts)
+    mult = max_line_multiplicity(pts)
+    # enumerate maximal lines with exactly 4 points
+    exactly4 = [m for m in maximal_collinear_lines(pts) if len(m) == 4]
+    count = four_point_line_count(pts)
+    assert mult == 4, f"grid should have max multiplicity 4, got {mult}"
+    assert len(exactly4) == count, "all 4-lines are exactly-4 (no 5 collinear)"
+    print(f"   n={n}, max collinear={mult} (no 5 collinear ✓)")
+    print(f"   lines of exactly 4 points = {len(exactly4)}  (4 rows + 4 cols + 2 diagonals)")
+    print(f"   four_point_line_count = {count}, elementary bound ⌊n(n-1)/12⌋ = {n*(n-1)//12}")
+    # the bound is tight up to a constant here: 10 vs 20
+    assert count == 10, f"expected 10 four-point lines on 4x4 grid, got {count}"
+    print("   ⟹ positive Θ(1)-fraction of the upper bound is realised in ℝ²; the\n"
+          "     elementary bound is non-vacuous.  (A super-linear ℝ² construction is\n"
+          "     the SS lower bound, deferred — see solymosi_stojakovic_lower_bound.)\n")
+
+
+def main():
+    print("Erdős #101 OQ-01 — durable bound verification (Docker-free)\n")
+    part_A()
+    part_B()
+    part_C()
+    print("ALL CHECKS PASSED.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Erdős #101 OQ-01 (the \$100 *four-point lines are o(n²)* open question) is a
saturated formalization (S1–S16). Its two remaining `sorry`s are **genuinely
open mathematics**: the o(n²) conjecture itself and the Solymosi–Stojaković
Ω(n^{2−C/√log n}) lower-bound construction. Docker was down this session, so no
Lean ACT was possible.

This PR adds a **durable, Docker-free numerical verification artifact** that
grounds the *proved, unconditional* facts the gallery file relies on — plus the
surrogate arithmetic underlying the in-flight reverse-IsBigO PR #23389. It is
**new-files-only and path-disjoint** from #23389 (no edit to `Erdos101OQ01.lean`,
`state.md`, or `meta.json`), so the two PRs are mergeable in either order.

`research/problems/erdos-101-oq-01/verify_bounds.py` (deterministic, seed 101):

- **(A) `improved_upper_bound` pair-packing** — `6·(#4-point collinear subsets)
  ≤ C(n,2)`, hence `fourPointLineCount ≤ ⌊n(n−1)/12⌋`. Brute-forced over 360
  random no-5-collinear configs (n=4..12; 29 with ≥1 four-point line) and the
  2×2/3×3/4×4 grids. The combinatorics of `Erdos101Problem.lean:523` had no prior
  independent cross-check.
- **(B) surrogate Θ(n²)** for `maxFourPointLines n = n(n−1)//12` — forward `≤ n²`,
  the ℕ-floor lemma `a ≤ 12·⌊a/12⌋+11`, reverse `n² ≤ 24·maxFourPointLines n`
  for n≥6 (PR #23389's constant 24), the residual `n²≤2n²−2n−22`, and factor
  `(n−6)(n+4)≥0`. Confirms the const-24 bound **genuinely needs n≥6** (fails at
  n∈{1,2,3,5}) — independently de-risks #23389's `nlinarith` step.
- **(C) ℝ² witness** — the 4×4 integer grid: max collinearity 4 (no 5 collinear),
  exactly **10** four-point lines vs the bound 20. Shows the elementary bound is
  non-vacuous.

Run: `python3 research/problems/erdos-101-oq-01/verify_bounds.py` → exit 0
(`ALL CHECKS PASSED`).

## Not attempted

The two OPEN sorries (open math / deep finite-field construction) are untouched.

## Test plan

- [x] `python3 research/problems/erdos-101-oq-01/verify_bounds.py` exits 0
- [x] No changes to any file touched by in-flight PR #23389
- [x] No `.lean` / `meta.json` changes (no Lean build required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)