### PR TITLE
research(abel-ruffini-galois-extensions-oq-06-galois-direction): S10 ORIENT — char-in-normal bridge bearer found (corrects S8)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -65,18 +65,29 @@ variable {p : ℕ} [Fact p.Prime]
        `A` nontrivial + faithful (`H ≤ S_p`) moves some point, so that orbit
        is univ ⟹ **`A` is transitive** (`isPretransitive_iff_orbit_eq_univ`).
     3. `A` transitive on a `p`-set ⟹ `p ∣ |A|` (orbit–stabilizer).
-    4. `A` abelian ⟹ its Sylow-`p` `Q` is **normal** in `A` ⟹ characteristic
-       in `A` (`Sylow.characteristic_of_normal`, Sylow.lean:728); `Q` char in
-       `A` char in `H` ⟹ **`Q ⊴ H`**.
+    4. `A` abelian ⟹ its Sylow-`p` `Q` is **normal** in `↥A` ⟹ characteristic
+       in `↥A` (`Sylow.characteristic_of_normal`, Sylow.lean:728); with `A ⊴ ↥H`
+       (from `A` characteristic in `↥H`) the transported subgroup
+       `Q.map A.subtype` is then **normal in `↥H`** by the *instance*
+       `Subgroup.normal_of_characteristic_of_normal`
+       (`Mathlib/GroupTheory/GroupAction/ConjAct.lean:260` at pin `2df2f015`:
+       `{H : Subgroup G} [H.Normal] {K : Subgroup H} [K.Characteristic] :
+       (K.map H.subtype).Normal`). Instantiated with `G := ↥H`, lemma-`H := A`,
+       lemma-`K := Q`, this fires by typeclass resolution — **0 LOC**, not the
+       ~10–30 LOC ad-hoc bridge the S8 audit budgeted (see knowledge.md R4 §S10).
     5. `v_p(|H|) ≤ v_p(p!) = 1` (Legendre, `Nat.Prime.factorization_factorial`
        / `padicValNat_factorial`), and `p ∣ |A| ∣ |H|` ⟹ `v_p(|A|) = 1` ⟹
        `|Q| = p`, so `Q` is a Sylow-`p` of `H` too (`Sylow.ofCard`,
        Sylow.lean:102). `Q ⊴ H` Sylow ⟹ **unique**
        (`Sylow.unique_of_normal`, Sylow.lean:710) ⟹ `Subsingleton (Sylow p H)`.
 
-    Residual risk is **wiring**, not missing infrastructure (~100–150 LOC):
-    transporting `Q` along `A ↪ H`, the char-in-char step, and the `v_p`
-    arithmetic. Risk R4 accordingly downgraded HIGH→MEDIUM (see knowledge.md).
+    Residual risk is **wiring**, not missing infrastructure (now ~70–110 LOC,
+    revised down from ~100–150): transporting `Q` along `A ↪ ↥H`, the `v_p`
+    arithmetic, and the orbit–stabilizer transitivity. The char-in-normal step
+    that S8 flagged as the single hardest residual ("no upstream bearer",
+    ~10–30 LOC) is **resolved** — it is the 0-LOC instance
+    `Subgroup.normal_of_characteristic_of_normal` cited in step 4. Risk R4
+    accordingly stays MEDIUM but the budget shrinks (see knowledge.md R4 §S10).
     Discharge deferred to a Docker-up ACT session. -/
 theorem sylow_p_unique
     (H : Subgroup (Equiv.Perm (ZMod p)))

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -155,6 +155,29 @@ Step-1 transitivity free); `MulAction.card_orbit_mul_card_stabilizer_eq_card_gro
   adapts "~1:1" to Step 1 is **still tainted by circularity** — it assumes a
   *normal* Sylow is already exhibited; the derived-series route is the
   correct substitute.
+  **R4 §S10 — char-in-normal bridge bearer FOUND (researcher-7, 2026-06-14;
+  CORRECTS the S8 "no direct bearer" verdict).** S8 budgeted ~10–30 LOC for an
+  ad-hoc bridge to get `Q.map A.subtype` normal in `↥H`, on the grounds that
+  `Subgroup.Characteristic` ships no transitivity lemma. But the step does not
+  need char-in-char (characteristic in `↥H`) — it needs only **normal** in `↥H`,
+  and that is exactly the *instance*
+  `Subgroup.normal_of_characteristic_of_normal`, present at the lake-pin
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) in
+  `Mathlib/GroupTheory/GroupAction/ConjAct.lean:260`:
+  `instance normal_of_characteristic_of_normal {H : Subgroup G} [hH : H.Normal]`
+  `{K : Subgroup H} [h : K.Characteristic] : (K.map H.subtype).Normal`
+  (verified by `gh api .../contents/...?ref=<pin>`; namespace `ConjAct`, but
+  being an `instance` it fires by typeclass resolution regardless of name).
+  Instantiate with `G := ↥H`, lemma-`H := A` (the abelian characteristic ⟹
+  normal `derivedSeries ↥H (d-1)`), lemma-`K := Q` (`Q` characteristic in `↥A`
+  via `Sylow.characteristic_of_normal`, abelian ⟹ Sylow normal). Then
+  `(Q.map A.subtype).Normal` holds automatically — **0 LOC**. This removes S8's
+  "single hardest residual" and obviates the offered abelian-primary-component
+  reroute. Step 1's wiring budget drops ~100–150 → ~70–110 LOC; Risk R4 stays
+  MEDIUM (the `v_p` arithmetic + `Sylow.ofCard` transport remain the bulk).
+  Build still pending (Docker + Aristotle both DOWN this session — Aristotle
+  `prove` returns "Resource not found"), so this is bearer-confirmation, not a
+  discharge; no `.lean` proof produced, 5 sorries intact.
 
 ## Cross-slug reuse
 

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/sessions/2026-06-14-s10-orient-charbridge-bearer.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/sessions/2026-06-14-s10-orient-charbridge-bearer.md
@@ -1,0 +1,67 @@
+# S10 ORIENT — char-in-normal bridge bearer FOUND (corrects S8)
+
+**Researcher**: researcher-7
+**Date**: 2026-06-14
+**Phase**: ORIENT (no build — Docker DOWN; Aristotle `prove` → "Resource not found")
+**Lean change**: docstring only (Step 1); **5 sorries intact, 0 proof produced**
+
+## Premise
+
+S8 (researcher-2, 2026-06-14) flagged the "char-in-char composition" as Step 1's
+*single hardest residual*: getting the Sylow-p `Q` of the abelian normal subgroup
+`A` to be normal in `↥H`. Its verdict: "**no direct bearer**" — `Subgroup.Characteristic`
+ships only `characteristic_iff_{map,comap}_{eq,le}` + `bot`/`top`, with no
+`Characteristic.trans` or transitivity-through-subtype lemma — so the ACT session
+"must build a ~10–30 LOC bridge OR reroute via an abelian primary-component
+construction". Budgeted accordingly.
+
+## Finding
+
+The verdict is wrong. The step does **not** need `Q.map A.subtype` characteristic
+in `↥H` — it needs only **normal**, and that is a Mathlib *instance*:
+
+```
+-- Mathlib/GroupTheory/GroupAction/ConjAct.lean:260  (namespace ConjAct)
+instance normal_of_characteristic_of_normal {H : Subgroup G} [hH : H.Normal]
+    {K : Subgroup H} [h : K.Characteristic] : (K.map H.subtype).Normal
+```
+
+Confirmed present at the exact lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+(v4.26.0):
+
+```
+gh api repos/leanprover-community/mathlib4/contents/\
+  Mathlib/GroupTheory/GroupAction/ConjAct.lean?ref=2df2f015... | jq -r .content | base64 -d
+# → 293 lines; instance at line 260
+gh search code --repo leanprover-community/mathlib4 "Characteristic" "map" "Normal"
+# → ConjAct.lean: normal_of_characteristic_of_normal ... (K.map H.subtype).Normal
+```
+
+## Instantiation in this proof
+
+- `G := ↥H`.
+- lemma-`H := A := derivedSeries ↥H (d-1)` — abelian, characteristic in `↥H`
+  (`derivedSeries_characteristic`), hence `A.Normal` (characteristic ⟹ normal).
+- lemma-`K := Q`, the Sylow-p of `↥A` — abelian ⟹ Sylow normal ⟹ characteristic
+  in `↥A` (`Sylow.characteristic_of_normal`, Sylow.lean:728), so `Q.Characteristic`.
+
+Both instance hypotheses (`A.Normal`, `Q.Characteristic`) are satisfied, so
+`(Q.map A.subtype).Normal` holds **by typeclass resolution — 0 LOC**. Being an
+`instance` (not a named lemma), it does not even need to be invoked explicitly.
+
+## Net effect
+
+- S8's "single hardest residual" collapses to a 0-LOC automatic instance.
+- The offered abelian-primary-component reroute is unnecessary.
+- Step 1 wiring budget revised ~100–150 → ~70–110 LOC. Risk R4 stays MEDIUM,
+  now dominated by `v_p(|H|)=1` Legendre arithmetic + `Sylow.ofCard` transport,
+  not by missing infrastructure.
+- All five sorries remain; discharge still gated on a Docker-up (or
+  Aristotle-up) ACT session.
+
+## Files touched
+
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean` — Step 1
+  docstring step-4 line + residual note (docstring only, no code/sorry change).
+- `research/problems/.../knowledge.md` — R4 §S10.
+- `research/problems/.../state.md` — iteration 10 header + entry.

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -1,9 +1,42 @@
 # Current State
 
-**Phase**: S9 ORIENT (corrected Step 5 signature **numerically certified** for p≤29 via committed reproducible script; original Step 5 counterexample reproduced as a regression guard; **5 sorries** unchanged; no Lean edit)
-**Since**: 2026-06-14 (S9 ORIENT Step 5 numeric verify; was 2026-06-14 S8 ORIENT)
-**Iteration**: 9 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT 2026-06-14; S7 ORIENT 2026-06-14; S8 ORIENT 2026-06-14; S9 ORIENT this iteration)
-**Owner**: researcher-5 (S9 ORIENT, 2026-06-14); prior researcher-2 (S8 ORIENT), researcher-3 (S7 ORIENT), researcher-1 (S6 ORIENT), researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+**Phase**: S10 ORIENT (char-in-normal bridge bearer **found** — `Subgroup.normal_of_characteristic_of_normal` instance, ConjAct.lean:260 at pin; corrects S8's "no direct bearer" verdict; Step 1 hardest residual → 0 LOC; **5 sorries** unchanged; docstring + knowledge edit only, no proof)
+**Since**: 2026-06-14 (S10 ORIENT bearer find; was 2026-06-14 S9 ORIENT)
+**Iteration**: 10 (S1 scaffold merged via #22031 on 2026-06-02; S2 ORIENT 2026-06-04; S3 STATE-SYNC 2026-06-10; S4 ACT 2026-06-12; S5 OBSERVE 2026-06-13; S6 ORIENT 2026-06-14; S7 ORIENT 2026-06-14; S8 ORIENT 2026-06-14; S9 ORIENT 2026-06-14; S10 ORIENT this iteration)
+**Owner**: researcher-7 (S10 ORIENT, 2026-06-14); prior researcher-5 (S9 ORIENT), researcher-2 (S8 ORIENT), researcher-3 (S7 ORIENT), researcher-1 (S6 ORIENT), researcher-5 (S5 OBSERVE), researcher-2 (S4 ACT), researcher-1 (S1–S3)
+
+## Iteration 10 (researcher-7, 2026-06-14) — S10 ORIENT: char-in-normal bridge bearer FOUND (corrects S8)
+
+**Outcome**: ORIENT/knowledge (no build — Docker DOWN, Aristotle `prove`
+returns "Resource not found"; both backends in blackout). Doc-only: the
+in-source Step 1 docstring + `knowledge.md` R4 were corrected; **0 Lean proof
+changes, 5 sorries intact**.
+
+**What I did.** S8 named the "char-in-char composition" (`Q` char in `↥A`,
+`A` char in `↥H` ⟹ `Q.map A.subtype` normal in `↥H`) as Step 1's *single
+hardest residual* — "no direct bearer", budget ~10–30 LOC for an ad-hoc bridge,
+with an abelian-primary-component reroute offered as fallback. That verdict is
+**wrong**. The step needs only `Q.map A.subtype` **normal** (not characteristic)
+in `↥H`, and Mathlib supplies exactly that as an *instance*:
+
+`Subgroup.normal_of_characteristic_of_normal`
+(`Mathlib/GroupTheory/GroupAction/ConjAct.lean:260`, namespace `ConjAct`):
+`{H : Subgroup G} [H.Normal] {K : Subgroup H} [K.Characteristic] :`
+`(K.map H.subtype).Normal`
+
+Verified present at the exact lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+(v4.26.0) via `gh api .../contents/Mathlib/GroupTheory/GroupAction/ConjAct.lean?ref=<pin>`
+(file is 293 lines; instance at 260; `gh search code` also surfaced it). Being
+an `instance`, it fires by typeclass resolution — instantiate `G := ↥H`,
+lemma-`H := A` (= abelian, characteristic ⟹ normal `derivedSeries ↥H (d-1)`),
+lemma-`K := Q` (Sylow-p of `↥A`, characteristic via `Sylow.characteristic_of_normal`),
+and `(Q.map A.subtype).Normal` holds with **0 LOC**.
+
+**Net effect.** Step 1's hardest sub-step collapses from "build a bridge" to
+"the instance is already there". The abelian-primary-component reroute is
+unnecessary. Step 1 wiring budget revised ~100–150 → ~70–110 LOC; Risk R4 stays
+MEDIUM, now dominated by the `v_p(|H|)=1` Legendre arithmetic + `Sylow.ofCard`
+transport rather than a missing-infrastructure concern. No new soundness defect.
 
 ## Iteration 9 (researcher-5, 2026-06-14) — S9 ORIENT: numerical certification of the corrected Step 5
 


### PR DESCRIPTION
## Summary

S10 ORIENT on the Galois-direction sub-OQ (every primitive solvable subgroup of S_p embeds in AGL(1,p)). **Doc-only: 5 sorries intact, no build** (Docker down; Aristotle `prove` returns "Resource not found").

**Finding — corrects the S8 bearer audit.** S8 (#24134 lineage) named the "char-in-char composition" — getting the Sylow-p `Q` of the abelian normal subgroup `A` to be normal in `↥H` — as Step 1's *single hardest residual*, with verdict "no direct bearer" and a ~10–30 LOC ad-hoc bridge budgeted (plus an abelian-primary-component reroute as fallback).

That verdict is wrong. The step needs only `Q.map A.subtype` **normal** (not characteristic) in `↥H`, and Mathlib supplies exactly that as an **instance**:

```
-- Mathlib/GroupTheory/GroupAction/ConjAct.lean:260  (namespace ConjAct)
instance normal_of_characteristic_of_normal {H : Subgroup G} [H.Normal]
    {K : Subgroup H} [K.Characteristic] : (K.map H.subtype).Normal
```

Confirmed at the exact lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) via `gh api .../contents/...?ref=<pin>` (file 293 lines, instance at 260). Instantiated with `G := ↥H`, lemma-`H := A` (abelian char ⟹ normal `derivedSeries ↥H (d-1)`), lemma-`K := Q` (Sylow-p of `↥A`, characteristic via `Sylow.characteristic_of_normal`), it fires by typeclass resolution — **0 LOC**.

**Net effect.** Step 1's hardest sub-step collapses to an automatic instance; the reroute is unnecessary. Step 1 wiring budget revised ~100–150 → ~70–110 LOC. Risk R4 stays MEDIUM, now dominated by the `v_p(|H|)=1` Legendre arithmetic + `Sylow.ofCard` transport.

## Changes

- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean` — Step 1 docstring (step-4 line + residual note); **docstring only, no code/sorry change**.
- `research/problems/.../knowledge.md` — R4 §S10.
- `research/problems/.../state.md` — iteration 10 entry.
- `research/problems/.../sessions/2026-06-14-s10-orient-charbridge-bearer.md` — session log.

## Test plan

- [ ] No build required (ORIENT; 5 sorries unchanged). Bearer existence verified by `gh api`/`gh search code` against the lake-pinned mathlib SHA.