### PR TITLE
research(sum-of-kth-powers-oq-03): S4 — close the L2' /2 ℕ-division hazard

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -4,7 +4,7 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T20:00:16-07:00
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 OQ resolved on paper (odd-number partition of cubes). Formalizable core pinned to existing
@@ -14,8 +14,13 @@ is empty (=0³), so `Main` over `range (n+1)` needs no `i=0` special case — no
 **S3 (researcher-1):** that verification is now **durable + reproducible** — committed as
 `verify_m1.py` (sympy symbolic + brute force n=0..60, exits non-zero on mismatch) — and the M1
 spec sharpened to a **ℕ-subtraction-free reindex** (block `i∈range n` ↦ cube `(i+1)³` on
-`[T i, T(i+1))`, no `i-1`, no `i≥1` side condition) that removes the last build-fiddly hazard
-except the `/2` division-clearing in L2′. Ready to ACT (transcription only) once backends return.
+`[T i, T(i+1))`, no `i-1`, no `i≥1` side condition).
+**S4 (researcher-5):** closed the last documented hazard — the `/2` division-clearing in L2′.
+`verify_m1.py` now certifies the **division-free** ring identities (multiply through by 4 using
+`2·T k = k(k+1)`): `((i-1)i)² + 4i³ = (i(i+1))²` and the reindex form
+`(i(i+1))² + 4(i+1)³ = ((i+1)(i+2))²`, plus that the ℕ-division is **exact**
+(`2·(k(k+1)//2)=k(k+1)`, `k(k+1)` even = `Nat.even_mul_succ_self`). The Lean ring steps can now
+avoid `/2` entirely. Spec fully de-hazarded; ready to ACT (transcription only) once backends return.
 
 ## Active Approach
 Telescoping odd-partition: i³ = T_i² − T_{i−1}², then `Finset.sum_Ico_consecutive` tiles the
@@ -35,7 +40,8 @@ odd-position ranges and `sum_odds (m) = m²` closes it to T_n² = (∑ i)². See
 When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, type M1 using the
 **ℕ-sub-free reindex** in knowledge.md ("ℕ-subtraction-free reindex"): L1 `sum_odds`, L2′
 `block_eq_cube` (`∑ Ico (T i) (T (i+1)) (2j+1) = (i+1)³` via `Finset.sum_Ico_consecutive` +
-ring identity `(T i)²+(i+1)³=(T(i+1))²`, clearing `/2` by `2*T k = k*(k+1)`), L3′ tiling, Main′,
+the **division-free** ring identity `(i(i+1))²+4(i+1)³=((i+1)(i+2))²`, clearing `/2` by
+`2*T k = k*(k+1)` with `Nat.even_mul_succ_self`), L3′ tiling, Main′,
 then index-shift to the parent's RHS shape. Build via
 `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`; cross-check arithmetic against
 `verify_m1.py` if any ring step misbehaves. Then add the gallery entry under

--- a/research/problems/sum-of-kth-powers-oq-03/verify_m1.py
+++ b/research/problems/sum-of-kth-powers-oq-03/verify_m1.py
@@ -60,6 +60,27 @@ check("reindex: T(i)^2 + (i+1)^3 = T(i+1)^2 (no nat-sub)",
 check("Gauss T(n) = sum_{i<=n} i",
       sp.simplify(sp.summation(i, (i, 0, n)) - n * (n + 1) / 2) == 0)
 
+# --- ℕ-DIVISION HAZARD (L2′ "/2" clearing) -------------------------------------
+# In Lean `T i = i*(i+1)/2` is *truncated* Nat division. The only build-fiddly
+# step left is clearing it. The clean route is `2 * T k = k*(k+1)` (division-free),
+# valid because `k*(k+1)` is always even (Mathlib: `Nat.even_mul_succ_self`).
+# Multiplying the additive telescope identities through by 4 then removes every
+# `/2`, giving the exact ring identities the Lean proof should `ring`/`omega` on:
+#   (2 T(i-1))^2 + 4 i^3     = (2 T(i))^2      with 2 T k = k(k+1)
+#   ((i-1) i)^2 + 4 i^3      = (i (i+1))^2
+#   (i (i+1))^2 + 4 (i+1)^3  = ((i+1)(i+2))^2  (nat-sub-free reindex form)
+check("clear /2: 2 T(i) = i(i+1) (division-free)",
+      sp.simplify(2 * Ti - i * (i + 1)) == 0)
+check("L2 cleared (x4, no /2): ((i-1)i)^2 + 4 i^3 = (i(i+1))^2",
+      sp.simplify(((i - 1) * i)**2 + 4 * i**3 - (i * (i + 1))**2) == 0)
+check("reindex cleared (x4, no /2): (i(i+1))^2 + 4 (i+1)^3 = ((i+1)(i+2))^2",
+      sp.simplify((i * (i + 1))**2 + 4 * (i + 1)**3 - ((i + 1) * (i + 2))**2) == 0)
+# ℕ-division is EXACT here (no truncation): 2*(i*(i+1)//2) == i*(i+1) for all i,
+# i.e. i*(i+1) is even — the content of `Nat.even_mul_succ_self`.
+check("Nat-division exact: 2*(k*(k+1)//2) == k*(k+1) and k*(k+1) even, k=0..200",
+      all(2 * ((k * (k + 1)) // 2) == k * (k + 1) and (k * (k + 1)) % 2 == 0
+          for k in range(0, 201)))
+
 
 def T(k):
     return k * (k + 1) // 2


### PR DESCRIPTION
## Summary

Build-free S4 continuation (Docker + Aristotle down). Closes the **one remaining documented build hazard** in the spec-complete M1 proof of Nicomachus's theorem (`∑ i³ = (∑ i)²` via the odd-number partition).

The M1 spec was already durable and reproducible (`verify_m1.py`), but state.md flagged a residual: clearing the **truncated ℕ-division** in `T i = i*(i+1)/2` (the L2′ `/2` step). This PR removes that hazard by certifying the **division-free** formulation:

- `2·T k = k(k+1)` (division-free), valid since `k(k+1)` is even — Mathlib `Nat.even_mul_succ_self`.
- Multiplying the additive telescope identities through by 4 then eliminates every `/2`:
  - `((i-1)i)² + 4i³ = (i(i+1))²`
  - reindex form: `(i(i+1))² + 4(i+1)³ = ((i+1)(i+2))²`
- ℕ-division is **exact** here: `2·(k(k+1)//2) = k(k+1)` and `k(k+1)` even, verified k=0..200.

The eventual Lean `ring` steps can now avoid `/2` entirely, so the ACT is pure transcription once backends return. No `.lean` changes (build-gated). Phase stays ORIENT.

## Files

- `research/problems/sum-of-kth-powers-oq-03/verify_m1.py` — three new passing checks (division-free clearing + ℕ-division exactness); still exits non-zero on any mismatch.
- `research/problems/sum-of-kth-powers-oq-03/state.md` — marks the `/2` hazard closed; pins `Nat.even_mul_succ_self` and the division-free ring identity for the ACT.

## Test plan

- [x] `python3 research/problems/sum-of-kth-powers-oq-03/verify_m1.py` — all identities verified (RC=0).
- [ ] Lean ACT (`SumOfKthPowersOQ03.lean`) — deferred, Docker-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)