### PR TITLE
research(erdos-1179-oq-02): ORIENT — define additive-constant sharpening of Erdős–Hall + small-N experiment

### DIFF
--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -1,0 +1,31 @@
+# Knowledge: erdos-1179-oq-02
+
+## Question (defined from the parent 0-knowledge stub)
+
+Erdős #1179 (PROVED, main asymptotic): for `0<ε<1`, `g_ε(N)` = least `k` such that
+a uniformly random `k`-subset `A` of an abelian group `G`, `|G|=N`, has w.h.p. an
+ε-uniform subset-sum representation function
+`F_A(g)=#{S⊆A : Σ_{x∈S} x = g}`, i.e. `|F_A(g) − 2^k/N| ≤ ε·2^k/N` for all `g`.
+
+**oq-02 (OPEN):** can the Erdős–Hall `(1+o(1))` *multiplicative* factor be sharpened
+to a bounded *additive* error?  `g_ε(N) ≤ log₂N + O_ε(1)`.
+
+## Bound hierarchy
+
+| Result | Bound on g_ε(N) |
+|--------|-----------------|
+| Trivial lower bound | `≥ log₂N` (need `2^k ≥ N`) |
+| Erdős–Rényi (1965) | `≤ (2+o(1))log₂N + O_ε(1)` |
+| Erdős–Hall (1976) | `≤ (1 + O_ε(log log log N / log log N))·log₂N` |
+| **oq-02 (open)** | **`≤ log₂N + O_ε(1)`** ? |
+
+## Status
+
+ORIENT/DEFINE only (2026-06-14). The OQ is asymptotic/analytic — finite computation
+cannot decide it. `verify_uniform_subset_sums.py` (build-free, stdlib) confirms the
+parent identity `Σ_g F_A(g)=2^|A|`, the lower bound (no ε-uniform `k<log₂N`), and
+tabulates the exact empirical additive gap on `ℤ/N` (stays ~1–3.5 for the
+probabilistic proxy, `N=2..12`). Honest caveat: tiny `N`, single group — consistent
+with but not evidence for a bounded gap. Both backends (Docker + Aristotle) down.
+
+See `src/data/research/problems/erdos-1179-oq-02.json` for the full record.

--- a/research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py
+++ b/research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Build-free ORIENT experiment for erdos-1179-oq-02.
+
+Erdős Problem #1179 (PROVED for the main asymptotic): for 0<ε<1 let g_ε(N) be
+the minimal k such that a uniformly random k-subset A of an abelian group G of
+size N has, w.h.p. as N→∞, an ε-uniform subset-sum representation function
+    F_A(g) = #{S ⊆ A : Σ_{x∈S} x = g},   |F_A(g) − 2^k/N| ≤ ε·2^k/N  ∀g.
+Known: g_ε(N) ≥ log₂N (trivial); Erdős–Rényi (1965) g_ε ≤ (2+o(1))log₂N;
+Erdős–Hall (1976) g_ε ≤ (1 + O_ε(log log log N / log log N))·log₂N.
+
+oq-02 (this OQ): can the (1+o(1)) FACTOR be sharpened to an additive constant,
+    g_ε(N) ≤ log₂N + O_ε(1)  ?
+This is OPEN and analytic — this script does NOT resolve it. It gives an honest,
+reproducible small-N computation that (a) grounds the Lean definitions in the
+parent file (the identity Σ_g F_A(g) = 2^|A|), (b) confirms the trivial lower
+bound g_ε(N) ≥ ⌈log₂N⌉ empirically, and (c) tabulates the EXACT empirical
+additive gap  g_ε(N) − log₂N  for the cyclic group G = ℤ/N over small N, as
+data informing whether the gap looks bounded.
+
+We use G = ℤ/N (one canonical abelian group; the OQ is over all abelian G —
+documented caveat). "w.h.p." is rendered finitely as: the EXACT fraction of
+k-subsets A ⊆ G that are ε-uniform, and g_ε^p(N) := least k with that fraction
+≥ p (we report p ∈ {1.0, 0.9}).
+"""
+import math
+from itertools import combinations
+
+
+def repr_counts(A, N):
+    """F_A(g) for all g in Z/N, via all 2^|A| subset sums. Returns list length N."""
+    F = [0] * N
+    # iterate subsets of A by bitmask
+    k = len(A)
+    for mask in range(1 << k):
+        s = 0
+        m = mask
+        idx = 0
+        while m:
+            if m & 1:
+                s += A[idx]
+            m >>= 1
+            idx += 1
+        F[s % N] += 1
+    return F
+
+
+def is_eps_uniform(F, k, N, eps):
+    exp = (2.0 ** k) / N
+    tol = eps * exp
+    return all(abs(f - exp) <= tol + 1e-12 for f in F)
+
+
+def check_total_identity(N_max=10):
+    """Sanity: Σ_g F_A(g) = 2^|A| for every subset (grounds the parent Lean defs)."""
+    bad = []
+    for N in range(2, N_max + 1):
+        elems = list(range(N))
+        for k in range(0, N + 1):
+            for A in combinations(elems, k):
+                F = repr_counts(list(A), N)
+                if sum(F) != (1 << k):
+                    bad.append((N, A))
+                    break
+    assert not bad, f"identity Σ_g F_A(g)=2^|A| FAILED at {bad[:5]}"
+    print(f"[ID] OK  Σ_g F_A(g) = 2^|A| for every subset of Z/N, N≤{N_max}")
+
+
+def g_eps(N, eps, p):
+    """Least k such that fraction of ε-uniform k-subsets of Z/N is ≥ p.
+    Returns (k, fraction_at_k). p=1.0 means ALL k-subsets uniform."""
+    elems = list(range(N))
+    for k in range(0, N + 1):
+        subsets = list(combinations(elems, k))
+        if not subsets:
+            continue
+        good = sum(1 for A in subsets if is_eps_uniform(repr_counts(list(A), N), k, N, eps))
+        frac = good / len(subsets)
+        if frac >= p - 1e-12:
+            return k, frac
+    return None, 0.0
+
+
+def main():
+    check_total_identity(N_max=9)
+
+    print("\n[LB] Trivial lower bound g_ε(N) ≥ ⌈log₂N⌉ (no k<log₂N is ε-uniform):")
+    eps_lb = 0.5
+    for N in range(2, 13):
+        elems = list(range(N))
+        kmax_below = math.floor(math.log2(N) - 1e-9)  # largest k with 2^k < N
+        any_uniform_below = False
+        for k in range(0, kmax_below + 1):
+            if any(is_eps_uniform(repr_counts(list(A), N), k, N, eps_lb)
+                   for A in combinations(elems, k)):
+                any_uniform_below = True
+                break
+        flag = "OK" if not any_uniform_below else "VIOLATED"
+        print(f"   N={N:2d}  log₂N={math.log2(N):5.2f}  ⌈log₂N⌉={math.ceil(math.log2(N)):d}  "
+              f"no ε-uniform k<log₂N: {flag}")
+
+    print("\n[GAP] Empirical additive gap g_ε(N) − log₂N on G=ℤ/N (p = required fraction):")
+    for eps in (0.5, 0.9):
+        print(f"  ε={eps}:")
+        print(f"    {'N':>3} {'log2N':>6} | {'g(p=1.0)':>9} {'gap':>6} | {'g(p=0.9)':>9} {'gap':>6}")
+        for N in range(2, 13):
+            l2 = math.log2(N)
+            k1, f1 = g_eps(N, eps, 1.0)
+            k9, f9 = g_eps(N, eps, 0.9)
+            gap1 = (k1 - l2) if k1 is not None else float('nan')
+            gap9 = (k9 - l2) if k9 is not None else float('nan')
+            s1 = f"{k1}" if k1 is not None else "—"
+            s9 = f"{k9}" if k9 is not None else "—"
+            print(f"    {N:>3} {l2:>6.2f} | {s1:>9} {gap1:>6.2f} | {s9:>9} {gap9:>6.2f}")
+
+    print("\nNotes:")
+    print(" - Data is for the single group ℤ/N; the OQ ranges over all abelian G")
+    print("   (an elementary-abelian 2-group can behave differently — caveat).")
+    print(" - p=1.0 (every k-subset uniform) is a conservative finite proxy for")
+    print("   'w.h.p.'; p=0.9 is closer to the probabilistic statement.")
+    print(" - This computation cannot decide the asymptotic O_ε(1) question; it only")
+    print("   exhibits the exact small-N gap and confirms the structural bounds.")
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/erdos-1179-oq-02.json
+++ b/src/data/research/problems/erdos-1179-oq-02.json
@@ -1,0 +1,98 @@
+{
+  "slug": "erdos-1179-oq-02",
+  "title": "Erdős #1179 oq-02: can the Erdős–Hall bound be sharpened to an additive constant, g_ε(N) ≤ log₂N + O_ε(1)?",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For 0<ε<1 and an abelian group G of size N, let g_ε(N) be the minimal k such that a uniformly random k-subset A⊆G has, with probability →1 as N→∞, an ε-uniform subset-sum representation function F_A(g)=#{S⊆A : Σ_{x∈S}x=g}, i.e. |F_A(g) − 2^k/N| ≤ ε·2^k/N for all g∈G. The main asymptotic g_ε(N)=(1+o_ε(1))log₂N is PROVED (Erdős–Hall 1976). OPEN (this OQ): is the (1+o(1)) FACTOR improvable to a bounded ADDITIVE error, g_ε(N) ≤ log₂N + O_ε(1)?",
+    "plain": "Problem #1179 (proved) says you need about log₂N random group elements so that every group element is hit by roughly the same number of subset-sums. The known upper bound (Erdős–Hall 1976) is (1 + O(log log log N / log log N))·log₂N — the slack above log₂N grows slowly with N. This open question asks whether the slack is actually BOUNDED: g_ε(N) ≤ log₂N + (a constant depending only on ε). The trivial lower bound is g_ε(N) ≥ log₂N.",
+    "whyMatters": [
+      "Sharpens the headline result of a solved Erdős problem from a multiplicative (1+o(1)) factor to the strongest possible additive form, matching the trivial lower bound up to O_ε(1).",
+      "The Erdős–Hall error term O(log log log N / log log N) is the kind of slowly-growing factor that resists improvement; deciding O_ε(1) probes the true second-order behaviour.",
+      "Builds directly on the parent gallery infrastructure (Erdos1179Problem.lean: reprCount, IsEpsUniform, the identity Σ_g F_A(g)=2^|A|)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Trivial lower bound g_ε(N) ≥ log₂N: ε-uniformity with ε<1 forces F_A(g)>0 for all g, hence 2^k = Σ_g F_A(g) ≥ N (parent file's reprCount/IsEpsUniform). Confirmed empirically for ℤ/N, N≤12: no k<log₂N admits any ε-uniform subset (verify_uniform_subset_sums.py [LB]).",
+      "Erdős–Rényi (1965): g_ε(N) ≤ (2+o(1))log₂N + O_ε(1).",
+      "Erdős–Hall (1976): g_ε(N) ≤ (1 + O_ε(log log log N / log log N))·log₂N — the current best, still a (1+o(1)) multiplicative factor, NOT an additive constant.",
+      "Parent identity Σ_g F_A(g) = 2^|A| verified by brute force for every subset of ℤ/N, N≤9 (grounds the Lean definitions in Erdos1179Problem.lean)."
+    ],
+    "open": [
+      "S1 (2026-06-14, ORIENT): the question g_ε(N) ≤ log₂N + O_ε(1) is genuinely open and analytic — no finite computation can decide an asymptotic O_ε(1) claim. Empirical small-N data for G=ℤ/N (verify_uniform_subset_sums.py [GAP]) shows the additive gap g_ε(N)−log₂N staying in a narrow band (~1–3.5 for the probabilistic proxy p=0.9, ε∈{0.5,0.9}, N=2..12) — CONSISTENT WITH but NOT evidence for a bounded gap (small N, single group; an elementary-abelian 2-group may behave differently).",
+      "A Lean formalization target is not yet identified; the parent file states the problem and axiomatizes the Erdős–Hall bound. An oq-02 formalization would most plausibly state the conjectured additive bound as an axiom/target, not prove it."
+    ],
+    "goal": "ORIENT/DEFINE this 0-knowledge seeker stub: pin the precise additive-gap question, record the bound hierarchy (LB log₂N / Erdős–Rényi 2+o(1) / Erdős–Hall 1+o(1)), and commit a reproducible small-N experiment grounding the definitions and the lower bound."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "DEFINE the bare seeker stub. Read parent Erdos1179Problem.lean (problem PROVED for the main asymptotic; reprCount, IsEpsUniform, Σ_g F_A(g)=2^|A|). Pinned oq-02 = the additive-constant sharpening g_ε(N) ≤ log₂N + O_ε(1) of the Erdős–Hall (1+o(1)) factor. Wrote verify_uniform_subset_sums.py: confirms the identity Σ_g F_A(g)=2^|A| (N≤9), the lower bound g_ε≥⌈log₂N⌉ (no ε-uniform k<log₂N, N≤12), and tabulates the exact empirical additive gap on ℤ/N. ALL CHECKS PASSED.",
+    "blockers": [
+      "The OQ is asymptotic/analytic — not decidable by finite computation; this session is ORIENT/DEFINE only.",
+      "Verification infra (Docker + Aristotle) down this session — no Lean build; the contribution is build-free (problem definition + reproducible Python experiment)."
+    ],
+    "nextAction": "DECOMPOSE: survey whether the Erdős–Hall error term log log log N / log log N is known to be improvable, and whether any class of abelian groups (e.g. ℤ/N vs elementary-abelian 2-groups) is conjectured to achieve g_ε(N) = log₂N + O_ε(1). If a Lean target is wanted, state the conjectured additive bound as an axiomatized target alongside the parent. Extend verify_uniform_subset_sums.py to compare ℤ/N against (ℤ/2)^m at matched N to test the single-group caveat.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (2026-06-14, S1): this slug was a 0-knowledge seeker stub (no problem.md, no tracked JSON). Defined it from the parent: Erdős #1179 (PROVED) establishes g_ε(N)=(1+o_ε(1))log₂N for uniform subset-sum representations in abelian groups; oq-02 asks whether the (1+o(1)) multiplicative factor can be sharpened to a bounded additive error g_ε(N) ≤ log₂N + O_ε(1), matching the trivial lower bound g_ε(N) ≥ log₂N up to O_ε(1). Recorded the bound hierarchy (Erdős–Rényi 1965: 2+o(1); Erdős–Hall 1976: 1 + O(log log log N / log log N)). Committed verify_uniform_subset_sums.py (build-free, stdlib): verifies the parent identity Σ_g F_A(g)=2^|A| (every subset of ℤ/N, N≤9), confirms no ε-uniform k below log₂N (N≤12), and tabulates the EXACT empirical additive gap g_ε(N)−log₂N on ℤ/N (stays ~1–3.5 for p=0.9, ε∈{0.5,0.9}). Honest caveats: tiny N and a single group cannot decide the asymptotic O_ε(1) question. Both backends down → ORIENT/DEFINE only.",
+    "builtItems": [
+      "research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py — reproducible small-N experiment (identity check + lower-bound check + additive-gap table), ALL CHECKS PASSED."
+    ],
+    "insights": [
+      "ε-uniformity with ε<1 forces every F_A(g)>0, so 2^k=Σ_g F_A(g)≥N gives the trivial lower bound g_ε(N)≥log₂N for free from the parent definitions.",
+      "The open gap is between Erdős–Hall's MULTIPLICATIVE (1+o(1)) factor and a conjectured ADDITIVE O_ε(1) constant; the slowly-growing log log log N / log log N error is exactly the kind that resists being shown bounded or unbounded.",
+      "Small-N data on ℤ/N is consistent with a bounded additive gap but is not evidence: N≤12 is far from asymptotic, and the OQ ranges over ALL abelian G (elementary-abelian 2-groups, where subset sums are XORs, can differ structurally)."
+    ],
+    "mathlibGaps": [
+      "No probabilistic 'with high probability over random subsets' framework targeted here; the parent axiomatizes the Erdős–Hall bound rather than proving it.",
+      "Second-moment / Fourier-analytic estimates on representation-function uniformity in finite abelian groups are not readily available in Mathlib."
+    ],
+    "nextSteps": [
+      "Literature: check whether the Erdős–Hall log log log N / log log N term is known to be improvable, and whether the additive-constant form is explicitly conjectured.",
+      "Experiment: extend the script to (ℤ/2)^m vs ℤ/N at matched N to probe the single-group caveat.",
+      "Formalization (Docker-gated): if pursued, state g_ε(N) ≤ log₂N + O_ε(1) as an axiomatized target alongside the parent, since proving it is out of reach."
+    ]
+  },
+  "tags": [
+    "erdos",
+    "combinatorics",
+    "probability",
+    "analysis",
+    "additive-combinatorics",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-1179",
+    "erdos-1179-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "Erdős, P. & Rényi, A. (1965), 'Probabilistic methods in group theory', J. Analyse Math. 14:127–138.",
+      "Erdős, P. & Hall, R.R. (1976), on uniform subset-sum representations in abelian groups.",
+      "Erdős Problem #1179, https://erdosproblems.com/1179 (status: solved for the main asymptotic)."
+    ],
+    "urls": [
+      "https://erdosproblems.com/1179"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Algebra.BigOperators.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+    ]
+  },
+  "started": "2026-06-14T00:00:00Z",
+  "lastUpdate": "2026-06-14T00:00:00.000Z",
+  "significance": 6,
+  "tractability": 4,
+  "leanFiles": []
+}


### PR DESCRIPTION
## Summary

Defines and ORIENTs the previously **0-knowledge seeker stub** `erdos-1179-oq-02` (no problem.md, no tracked JSON before this PR). Build-free during the Docker + Aristotle blackout.

**Parent** Erdős #1179 (proved): `g_ε(N) = (1 + o_ε(1)) log₂N` for ε-uniform subset-sum representations `F_A(g)=#{S⊆A : Σx=g}` in an abelian group of size `N`.

**oq-02 (OPEN, this entry):** can the Erdős–Hall `(1+o(1))` *multiplicative* factor be sharpened to a bounded *additive* error?
```
g_ε(N) ≤ log₂N + O_ε(1)   ?      (trivial lower bound: g_ε(N) ≥ log₂N)
```

## What's in this PR
- **`research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py`** — reproducible, stdlib-only experiment (ALL CHECKS PASSED):
  - `[ID]` parent identity `Σ_g F_A(g) = 2^|A|` for every subset of `ℤ/N`, `N≤9` (grounds the Lean defs in `Erdos1179Problem.lean`).
  - `[LB]` no ε-uniform `k < log₂N` for `N≤12` → confirms `g_ε(N) ≥ ⌈log₂N⌉`.
  - `[GAP]` exact empirical additive gap `g_ε(N) − log₂N` on `ℤ/N`: stays in a **narrow ~1–3.5 band** for the probabilistic proxy (p=0.9), `ε∈{0.5,0.9}`, `N=2..12`.
- **`src/data/research/problems/erdos-1179-oq-02.json`** + **`knowledge.md`** — full ORIENT record: the bound hierarchy (Erdős–Rényi 1965 `2+o(1)`; Erdős–Hall 1976 `1 + O(logloglogN/loglogN)`), the pinned question, and next steps.

## Honest caveats
- The OQ is asymptotic/analytic — **no finite computation can decide an `O_ε(1)` claim**. The small-N data is *consistent with* but **not evidence for** a bounded gap (tiny `N`; only `ℤ/N`, whereas the OQ ranges over all abelian `G` — elementary-abelian 2-groups may differ).
- No Lean target proved; a formalization would most plausibly state the conjectured additive bound as an axiomatized target alongside the parent.

## Test plan
- [x] `python3 research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py` → ALL CHECKS PASSED
- [x] JSON validates
- [ ] Lean — N/A this PR (ORIENT only; backends down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)