### PR TITLE
research(erdos-733-oq-01): ORIENT — explicit lower bound λ ≥ π√(2/3) on lim log f(n)/√n

### DIFF
--- a/research/problems/erdos-733-oq-01/knowledge.md
+++ b/research/problems/erdos-733-oq-01/knowledge.md
@@ -1,0 +1,79 @@
+# Erdős #733 OQ-01 — The limiting constant λ = lim log f(n)/√n
+
+## Problem
+
+For an $n$-point configuration in $\mathbb{R}^2$, a *line-compatible sequence* is the
+sorted multiset of point-counts over its **rich lines** (lines containing $\ge 2$
+points). Let $f(n)$ be the number of distinct line-compatible sequences.
+Szemerédi–Trotter (1983) proved $f(n) = \exp(\Theta(\sqrt n))$. Erdős's follow-up,
+recorded as this OQ, asks:
+
+> Does $\lambda = \lim_{n\to\infty}\dfrac{\log f(n)}{\sqrt n}$ exist, and what is its value?
+
+This is **OPEN**. The gallery file `proofs/Proofs/Erdos733Problem.lean` encodes only
+`lower_bound : ∃ c>0, f(n) ≥ exp(c√n)` and `upper_bound : ∃ C>0, f(n) ≤ exp(C√n)`
+as axioms — no explicit constants.
+
+## Session 2026-06-14 (Session 1) — ORIENT
+
+**Mode**: FRESH · **Outcome**: progress (explicit lower bound on the constant)
+
+### Result: an explicit, rigorously-verified lower bound on λ
+
+**Claim.** $\displaystyle \liminf_{n\to\infty}\frac{\log f(n)}{\sqrt n}\ \ge\ \pi\sqrt{2/3}\approx 2.5651.$
+
+**Construction.** Take any multiset of integers $\ge 3$ with sum $s\le n$ ("parts").
+Realize each part $a$ as its own *generic* line carrying exactly $a$ points, and place
+the remaining $n-s$ points in general position. Generically the only lines with $\ge 3$
+points are the chosen ones; every other rich line carries exactly $2$ points. The
+realized sequence is therefore
+$$[\text{parts}\ge 3]\ \cup\ \big[\,2\text{ repeated } \tbinom n2-\textstyle\sum_i\binom{a_i}{2}\text{ times}\,\big],$$
+which is **determined by and determines** the multiset of parts $\ge 3$. Distinct
+multisets give distinct line-compatible sequences, so
+$$f(n)\ \ge\ Q(n):=\#\{\text{partitions of any }s\le n\text{ into parts}\ge 3\}.$$
+Excluding parts $1,2$ only multiplies the partition generating function by the
+polynomial $(1-x)(1-x^2)$, leaving the Hardy–Ramanujan exponential rate unchanged:
+$\log Q(n)\sim \pi\sqrt{2n/3}$. Hence $\lambda \ge \pi\sqrt{2/3}$ (as a liminf).
+
+### Verification (durable, exact arithmetic)
+
+`verify_lower_constant.py` (committed):
+- For $n=4,\dots,12$: realizes **every** parts-$\ge 3$ construction with exact $\mathbb{Q}$
+  coordinates, recomputes the rich-line multiset from scratch, and confirms (i) each
+  construction realizes its predicted sequence and (ii) the realized sequences are
+  pairwise distinct. The distinct count equals $Q(n)$ exactly (3,4,6,8,11,15,20,26,35),
+  with **0 mismatches, 0 collisions** — so the construction is valid and injective.
+- Hardy–Ramanujan check: $\log Q(n)/\sqrt n$ rises toward $\pi\sqrt{2/3}=2.5651$
+  (1.55 at $n{=}50$ → 2.35 at $n{=}4000$; convergence is slow, governed by the
+  $O(\log n/\sqrt n)$ correction in $\log p(n)=\pi\sqrt{2n/3}-\tfrac34\log n+O(1)$).
+
+### Key Findings
+- The constant problem is genuinely open; only the $\Theta$ (not the constant) is known.
+- $\pi\sqrt{2/3}\approx 2.5651$ is a clean, elementary, rigorous **lower** bound on
+  $\lambda$ — sharper than the gallery's "$\exists c>0$". It need not be tight: the
+  $\sqrt n\times\sqrt n$ grid (Erdős's original construction) may yield a larger constant
+  by also using rich lines of intermediate multiplicity; pinning the grid constant is
+  harder and was not attempted.
+- **Upper side is the hard direction**: a naïve count of $(m_2,m_3,\dots)$ tuples
+  satisfying the pairs constraint $\sum_k \binom k2 m_k\le\binom n2$ vastly overshoots
+  $\exp(\Theta(\sqrt n))$, so the Szemerédi–Trotter upper constant requires the full
+  realizability structure, not a counting bound. No explicit $C$ extracted.
+- **Formalization note (integrity)**: in `Erdos733Problem.lean` the definition
+  `countLineCompatible n` (L103–105) is a placeholder equal to $2^n-1$
+  (`(range n).powerset.filter (·.card>0)).card`), *not* $f(n)$. The `lower_bound`/
+  `upper_bound` axioms are thus stated about a stand-in count. Correcting this needs a
+  genuine (noncomputable) definition of line-compatibility over $\mathbb{R}^2$; flagged,
+  not fixed (out of scope for this OQ, and unbuildable under the current Docker blackout).
+
+### Files Modified
+- `research/problems/erdos-733-oq-01/verify_lower_constant.py` (new)
+- `research/problems/erdos-733-oq-01/knowledge.md` (new)
+- `src/data/research/problems/erdos-733-oq-01.json` (new)
+
+### Next Steps
+- Compute the $\sqrt n\times\sqrt n$ grid's sequence-count constant for a possibly
+  larger lower bound (Erdős's "easy" construction may beat $\pi\sqrt{2/3}$).
+- Extract an explicit upper constant $C$ from the quantitative Szemerédi–Trotter
+  rich-lines bound (the genuinely hard half).
+- If pursuing Lean: replace the placeholder `countLineCompatible` with a real
+  definition, then state `lower_bound` with the explicit $c=\pi\sqrt{2/3}-\varepsilon$.

--- a/research/problems/erdos-733-oq-01/verify_lower_constant.py
+++ b/research/problems/erdos-733-oq-01/verify_lower_constant.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Erdős Problem #733 — OQ-01: the limiting constant  λ = lim_{n→∞} log f(n) / √n.
+
+f(n) = number of "line-compatible" sequences for n points: the distinct sorted
+multisets of point-counts over the rich lines (lines with ≥ 2 points) of an
+n-point configuration in the plane.  Szemerédi–Trotter (1983) gives
+f(n) = exp(Θ(√n)); the exact constant λ (if the limit exists) is OPEN.
+
+This script makes the lower side of the constant EXPLICIT and rigorously
+checks the underlying construction in exact rational arithmetic.
+
+CLAIM (constructive lower bound):
+    f(n)  ≥  Q(n) := #{ partitions of any s ≤ n into parts ≥ 3 }
+and hence, by Hardy–Ramanujan,
+    liminf log f(n)/√n  ≥  π·√(2/3) ≈ 2.5651.
+
+Why parts ≥ 3:  place each part a (≥3) as a generic line carrying exactly a
+points, and the remaining n−Σa points in general position.  Generically the
+ONLY lines with ≥3 points are the chosen ones; every other rich line has
+exactly 2 points.  The realized sequence is therefore
+    [the parts ≥ 3]  ++  [2 repeated  C(n,2) − Σ C(a_i,2)  times],
+which is determined by — and determines — the multiset of parts ≥ 3.
+Distinct such multisets ⇒ distinct line-compatible sequences ⇒ f(n) ≥ Q(n).
+
+We VERIFY this for small n by actually placing the points (exact ℚ
+coordinates), recomputing the rich-line multiset from scratch, and confirming
+(1) each construction realizes its predicted sequence and (2) the realized
+sequences are pairwise distinct, so the count equals Q(n).
+
+No external assumptions; pure exact arithmetic.  Run:  python3 verify_lower_constant.py
+"""
+
+from fractions import Fraction as Fr
+from itertools import combinations
+from math import comb, pi, sqrt, log
+
+# ---------------------------------------------------------------------------
+# Exact geometry helpers
+# ---------------------------------------------------------------------------
+
+def collinear(p, q, r):
+    """Exact test: are points p,q,r collinear?  (cross product == 0)."""
+    return (q[0]-p[0])*(r[1]-p[1]) - (q[1]-p[1])*(r[0]-p[0]) == 0
+
+def line_key(p, q):
+    """Canonical exact key (A,B,C) for the line through distinct p,q: A x + B y = C."""
+    A = q[1] - p[1]
+    B = p[0] - q[0]
+    C = A*p[0] + B*p[1]
+    # normalize sign and scale so the key is canonical
+    # divide by gcd-like normalization using Fractions: make leading nonzero entry 1
+    if A != 0:
+        B, C, A = B/A, C/A, Fr(1)
+    elif B != 0:
+        C, B = C/B, Fr(1)
+    return (A, B, C)
+
+def rich_line_sequence(points):
+    """Sorted list of point-counts over all lines containing ≥ 2 points."""
+    counts = {}
+    for i, j in combinations(range(len(points)), 2):
+        k = line_key(points[i], points[j])
+        counts.setdefault(k, set()).update((i, j))
+    seq = sorted(len(s) for s in counts.values() if len(s) >= 2)
+    return tuple(seq)
+
+# ---------------------------------------------------------------------------
+# Partition enumeration (parts ≥ 3) and Q(n)
+# ---------------------------------------------------------------------------
+
+def partitions_min_part(s, m):
+    """All partitions of s into parts ≥ m, as sorted ascending tuples."""
+    if s == 0:
+        yield ()
+        return
+    def rec(remaining, least):
+        if remaining == 0:
+            yield ()
+            return
+        for part in range(least, remaining + 1):
+            for tail in rec(remaining - part, part):
+                yield (part,) + tail
+    yield from rec(s, m)
+
+def Q(n):
+    """#{ partitions of any s in 0..n into parts ≥ 3 }."""
+    total = 0
+    for s in range(0, n + 1):
+        total += sum(1 for _ in partitions_min_part(s, 3))
+    return total
+
+# ---------------------------------------------------------------------------
+# Realize a construction in exact arithmetic
+# ---------------------------------------------------------------------------
+
+def realize(parts_ge3, n):
+    """
+    Place n points: the i-th part a_i (≥3) on its own generic line with a_i
+    points; remaining n - Σ a_i points in general position.  Deterministic
+    generic coordinates chosen on the parabola y = x^2 PLUS controlled
+    collinear blocks, with a verified-genericity fallback search.
+
+    Returns the list of exact-rational points, or raises if it cannot place
+    a clean generic configuration (should not happen for the small sizes used).
+    """
+    s = sum(parts_ge3)
+    assert s <= n
+    filler = n - s
+
+    # Strategy: pick distinct generic slopes/intercepts for the part-lines and
+    # generic x-positions, scanning small integer parameters until the realized
+    # incidence structure has NO unintended ≥3-collinearity.
+    # We parametrize attempts by an integer "spread" to perturb coordinates.
+    for spread in range(1, 60):
+        pts = []
+        ok = True
+        # part lines: line i has slope = prime-ish distinct value, intercept distinct
+        slopes = [Fr(2*i + 1, 1) for i in range(len(parts_ge3))]
+        intercepts = [Fr(7*i + 3, 1) for i in range(len(parts_ge3))]
+        for i, a in enumerate(parts_ge3):
+            m, b = slopes[i], intercepts[i]
+            for t in range(a):
+                x = Fr(spread*(i + 1) + t*(len(parts_ge3) + 1) + 1, 1)
+                y = m * x + b
+                pts.append((x, y))
+        # filler points on the parabola y = x^2 shifted far away (parabola: no 3 collinear)
+        base = 1000 + spread
+        for t in range(filler):
+            x = Fr(base + t, 1)
+            y = x * x          # parabola guarantees no 3 filler collinear
+            pts.append((x, y))
+        # verify: the ONLY ≥3-point lines are exactly the intended part-lines
+        counts = {}
+        for ii, jj in combinations(range(len(pts)), 2):
+            k = line_key(pts[ii], pts[jj])
+            counts.setdefault(k, set()).update((ii, jj))
+        big = sorted(len(v) for v in counts.values() if len(v) >= 3)
+        if big == sorted(parts_ge3):
+            return pts
+        # else accidental collinearity; retry with different spread
+    raise RuntimeError(f"could not realize {parts_ge3} with n={n}")
+
+# ---------------------------------------------------------------------------
+# Verification driver
+# ---------------------------------------------------------------------------
+
+def predicted_sequence(parts_ge3, n):
+    twos = comb(n, 2) - sum(comb(a, 2) for a in parts_ge3)
+    return tuple(sorted(list(parts_ge3) + [2] * twos))
+
+def verify_small(n):
+    """Realize every parts≥3 construction with sum ≤ n; confirm each matches its
+       prediction and that all realized sequences are distinct => count == Q(n)."""
+    realized = {}
+    constructions = []
+    for s in range(0, n + 1):
+        for parts in partitions_min_part(s, 3):
+            constructions.append(parts)
+    bad = 0
+    for parts in constructions:
+        pts = realize(parts, n)
+        seq = rich_line_sequence(pts)
+        pred = predicted_sequence(parts, n)
+        match = (seq == pred)
+        if not match:
+            bad += 1
+            print(f"   MISMATCH parts={parts}: realized {seq} != predicted {pred}")
+        realized.setdefault(seq, []).append(parts)
+    distinct = len(realized)
+    collisions = {k: v for k, v in realized.items() if len(v) > 1}
+    q = Q(n)
+    print(f"  n={n:2d}: constructions={len(constructions):3d}  distinct_realized={distinct:3d}  Q(n)={q:3d}"
+          f"  mismatches={bad}  collisions={len(collisions)}")
+    if collisions:
+        for k, v in collisions.items():
+            print(f"     COLLISION seq={k} from {v}")
+    ok = (bad == 0 and distinct == q and len(collisions) == 0)
+    return ok, q
+
+def asymptotics(nmax=4000):
+    print("\n[2] Hardy–Ramanujan asymptotic check  log Q(n)/√n  ->  π√(2/3) ≈ "
+          f"{pi*sqrt(2/3):.6f}")
+    # Q(n) via DP on partitions into parts >= 3, then cumulative.
+    # p3[s] = # partitions of s into parts >= 3
+    p3 = [0]*(nmax+1); p3[0] = 1
+    for part in range(3, nmax+1):
+        for s in range(part, nmax+1):
+            p3[s] += p3[s-part]
+    cum = 0
+    targets = [50, 100, 250, 500, 1000, 2000, 4000]
+    for n in range(1, nmax+1):
+        cum += p3[n]
+        if n in targets:
+            print(f"   n={n:5d}:  log Q(n)/√n = {log(cum)/sqrt(n):.5f}")
+    print(f"   limit  π√(2/3) = {pi*sqrt(2/3):.5f}")
+
+def main():
+    print("=" * 70)
+    print("Erdős #733 OQ-01: explicit lower bound on  λ = lim log f(n)/√n")
+    print("=" * 70)
+    print("\n[1] Exact-arithmetic verification: f(n) >= Q(n) and the")
+    print("    parts-≥3 construction realizes Q(n) distinct sequences.")
+    all_ok = True
+    for n in range(4, 13):
+        ok, _ = verify_small(n)
+        all_ok = all_ok and ok
+    print(f"\n  [1] {'ALL CHECKS PASSED' if all_ok else 'FAILURES PRESENT'}: "
+          "construction is valid and injective (=> f(n) >= Q(n)).")
+    asymptotics()
+    print("\n[3] CONCLUSION")
+    print("    f(n) >= Q(n) = exp((π√(2/3)+o(1))√n)  =>  liminf log f(n)/√n >= π√(2/3) ≈ 2.5651.")
+    print("    This sharpens the gallery's 'lower_bound : ∃ c>0' to an EXPLICIT c.")
+    print("    The matching upper constant (from Szemerédi–Trotter) remains OPEN.")
+    return 0 if all_ok else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/erdos-733-oq-01.json
+++ b/src/data/research/problems/erdos-733-oq-01.json
@@ -1,0 +1,29 @@
+{
+  "id": "erdos-733-oq-01",
+  "status": "active",
+  "phase": "ORIENT",
+  "title": "Erdős #733 OQ-01: the limiting constant lim log f(n)/sqrt(n)",
+  "knowledge": {
+    "progressSummary": "PROGRESS: explicit, exact-arithmetic-verified lower bound liminf log f(n)/sqrt(n) >= pi*sqrt(2/3) ~ 2.5651 via realizing all partitions into parts >= 3 as generic line configs. Upper constant remains open.",
+    "builtItems": [
+      "verify_lower_constant.py: exact-Q geometry checker; for n=4..12 realizes every parts>=3 construction, recomputes rich-line multiset, confirms 0 mismatches / 0 collisions => f(n) >= Q(n) (3,4,6,8,11,15,20,26,35).",
+      "Hardy-Ramanujan asymptotic check: log Q(n)/sqrt(n) -> pi*sqrt(2/3) = 2.5651 (DP up to n=4000)."
+    ],
+    "insights": [
+      "Lower bound construction: each part a>=3 is a generic line with a points; remaining points in general position; generically only the chosen lines are >=3-rich, all other rich lines carry exactly 2 points. Realized sequence is determined by the multiset of parts >=3, so distinct multisets => distinct line-compatible sequences.",
+      "f(n) >= Q(n) := #{partitions of any s<=n into parts >=3}; excluding parts 1,2 only multiplies the partition GF by (1-x)(1-x^2), preserving the Hardy-Ramanujan rate => log Q(n) ~ pi*sqrt(2n/3) => lambda >= pi*sqrt(2/3) ~ 2.5651.",
+      "The bound need not be tight: the sqrt(n) x sqrt(n) grid (Erdos's original) may give a larger constant via intermediate-multiplicity rich lines.",
+      "Upper side is hard: naive counting of (m_2,m_3,...) under the pairs constraint sum_k C(k,2) m_k <= C(n,2) overshoots exp(Theta(sqrt n)); Szemeredi-Trotter upper constant needs realizability structure.",
+      "INTEGRITY: gallery countLineCompatible (Erdos733Problem.lean L103-105) is a placeholder = 2^n - 1, not f(n); the lower/upper axioms are stated about a stand-in count."
+    ],
+    "mathlibGaps": [
+      "No Szemeredi-Trotter incidence theorem in Mathlib v4.26.0; the gallery encodes its consequences as axioms.",
+      "A genuine (noncomputable) Lean definition of line-compatibility over R^2 is absent (placeholder countLineCompatible used instead)."
+    ],
+    "nextSteps": [
+      "Compute the sqrt(n) x sqrt(n) grid sequence-count constant for a possibly larger lower bound.",
+      "Extract an explicit upper constant C from quantitative Szemeredi-Trotter rich-lines bound (the hard half).",
+      "If formalizing: replace placeholder countLineCompatible with a real definition and state lower_bound with explicit c = pi*sqrt(2/3) - eps."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Erdős Problem **#733** (line-compatible sequences) is solved at the $\Theta(\sqrt n)$ level (Szemerédi–Trotter 1983), but OQ-01 — the *exact* constant $\lambda=\lim_{n\to\infty}\log f(n)/\sqrt n$ — is open. This PR contributes a build-free **ORIENT** with an explicit, rigorously-verified lower bound on that constant.

**Result.** $\displaystyle \liminf_{n\to\infty}\frac{\log f(n)}{\sqrt n}\ \ge\ \pi\sqrt{2/3}\approx 2.5651.$

**Construction.** Realize every multiset of parts $\ge 3$ (sum $\le n$) as generic lines — part $a$ becomes a line carrying exactly $a$ points; remaining points in general position. Generically the only $\ge 3$-rich lines are the chosen ones, so the sequence is determined by the multiset of parts $\ge 3$. Distinct multisets ⇒ distinct line-compatible sequences, giving
$$f(n)\ \ge\ Q(n):=\#\{\text{partitions of any }s\le n\text{ into parts}\ge 3\}.$$
Excluding parts $1,2$ only multiplies the partition GF by $(1-x)(1-x^2)$, preserving the Hardy–Ramanujan rate $\log Q(n)\sim\pi\sqrt{2n/3}$. This sharpens the gallery's `lower_bound : ∃ c>0` to an explicit $c=\pi\sqrt{2/3}-\varepsilon$.

## Verification (`verify_lower_constant.py`, exact ℚ arithmetic)

- $n=4..12$: realizes **every** parts-$\ge 3$ construction, recomputes the rich-line multiset from scratch, confirms each matches its prediction and all are pairwise distinct → count $= Q(n)$ (3,4,6,8,11,15,20,26,35), **0 mismatches / 0 collisions**.
- Hardy–Ramanujan: $\log Q(n)/\sqrt n \to \pi\sqrt{2/3}=2.5651$ (slow, as the $-\tfrac34\log n$ correction predicts).

## Notes
- **Upper constant stays open** (the hard half): naïve counting under $\sum_k\binom k2 m_k\le\binom n2$ overshoots $\exp(\Theta(\sqrt n))$; the ST upper constant needs realizability structure.
- **Integrity flag**: `Erdos733Problem.lean` `countLineCompatible` (L103) is a placeholder $=2^n-1$, not $f(n)$. Flagged, not fixed (needs a real noncomputable definition; out of scope, Docker blackout).
- No Lean changes; research artifacts only.

## Test plan
- [x] `python3 research/problems/erdos-733-oq-01/verify_lower_constant.py` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)