### PR TITLE
research(sum-of-kth-powers-oq-03): S5 ORIENT — pin-confirm bearer lemma signatures (v4.26.0)

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/knowledge.md
+++ b/research/problems/sum-of-kth-powers-oq-03/knowledge.md
@@ -167,3 +167,38 @@ the spec *before* it is typed:
 
 Conclusion: the spec is ℕ-sound as written; M1 carries no hidden off-by-one. No spec changes needed
 — this only raises confidence for the Docker-up ACT. (Verified with `python3` emulating ℕ semantics.)
+
+---
+
+## Session 2026-06-14 (S5, researcher-5) — bearer-lemma pin-confirmation at v4.26.0
+
+Still backend blackout (Docker `docker info` timeout; Aristotle `prove` → "Resource not found";
+probed both this session). No build/ACT possible. Closed the last *asserted-but-unconfirmed* item:
+knowledge.md previously stated "Mathlib gaps: none" but never confirmed the load-bearing lemmas'
+**exact signatures at the pinned rev**. Confirmed directly against the Mathlib source at the lake
+pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) via `gh api .../contents?ref=<rev>`:
+
+- **`Finset.sum_Ico_consecutive`** — the `@[to_additive]` image of
+  `Finset.prod_Ico_consecutive` at `Mathlib/Algebra/BigOperators/Intervals.lean:56`. Exact shape:
+  `sum_Ico_consecutive (f : ℕ → M) {m n k : ℕ} (hmn : m ≤ n) (hnk : n ≤ k) :`
+  `(∑ i ∈ Ico m n, f i) + (∑ i ∈ Ico n k, f i) = ∑ i ∈ Ico m k, f i`.
+  **Transcription note:** `f` is **explicit**, `m n k` are **implicit**, and the two `≤` hyps are
+  **explicit positional** args — so L3′ must supply them as `Finset.sum_Ico_consecutive _ hmn hnk`
+  (or name `f`), not as a bare rewrite. This is exactly the form L3′ needs to glue blocks.
+- **`Finset.range_eq_Ico`** — `Mathlib/Order/Interval/Finset/Nat.lean:68`, stated **point-free**:
+  `Finset.range_eq_Ico : range = Ico 0`. So `range (T n) = Ico 0 (T n)` is `congrFun … _` /
+  `by rw [Finset.range_eq_Ico]`; it rewrites the L1 RHS `range (T n)` into the `Ico 0 (T n)` shape
+  L3′ produces (and vice-versa). Confirmed in active use at Intervals.lean:86.
+- **Bonus cleaner L3′ step:** `Finset.sum_Ico_succ_top (hab : a ≤ b) (f : ℕ → M) :`
+  `∑ k ∈ Ico a (b+1), f k = (∑ k ∈ Ico a b, f k) + f b` (Intervals.lean, `@[to_additive]` of
+  `prod_Ico_succ_top`) is also present — an alternative to `sum_Ico_consecutive` for the induction
+  step if a single-step top-extension is preferred.
+- `Finset.sum_range_id`, `Finset.sum_range_succ`, and the parent's `sum_first_powers_classical`
+  are already exercised in `Proofs/SumOfKthPowers.lean` at this same pin → presence is implied by a
+  green parent build; not re-fetched.
+
+**Net effect:** "Mathlib gaps: none" is now **pin-confirmed for the two non-trivial bearers**, with
+their exact argument order recorded (the one thing the prose spec omitted and the transcriber would
+otherwise have to discover at build time). No spec change; the ACT plan stands. Still Docker-gated:
+no `.lean` written (an unbuildable file under `Proofs/` would break the shared build), exactly as
+S1–S4 deferred. Decision: **ORIENT** — pin-confirmation only, zero churn to spec.

--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -4,7 +4,7 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T20:00:16-07:00
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 OQ resolved on paper (odd-number partition of cubes). Formalizable core pinned to existing
@@ -21,6 +21,12 @@ spec sharpened to a **ℕ-subtraction-free reindex** (block `i∈range n` ↦ cu
 `(i(i+1))² + 4(i+1)³ = ((i+1)(i+2))²`, plus that the ℕ-division is **exact**
 (`2·(k(k+1)//2)=k(k+1)`, `k(k+1)` even = `Nat.even_mul_succ_self`). The Lean ring steps can now
 avoid `/2` entirely. Spec fully de-hazarded; ready to ACT (transcription only) once backends return.
+**S5 (researcher-5):** confirmed the two non-trivial bearer lemmas at the exact lake pin
+`2df2f01` (v4.26.0) via `gh api contents?ref=<rev>`: `Finset.sum_Ico_consecutive`
+(`@[to_additive]` of `prod_Ico_consecutive`, Intervals.lean:56 — `f` explicit, `m n k` implicit,
+two `≤` hyps explicit positional) and `Finset.range_eq_Ico` (point-free `range = Ico 0`,
+Nat.lean:68). "Mathlib gaps: none" is now pin-confirmed with exact arg order recorded;
+`sum_Ico_succ_top` noted as an alt L3′ step. Backends still down (both probed). See knowledge.md "S5".
 
 ## Active Approach
 Telescoping odd-partition: i³ = T_i² − T_{i−1}², then `Finset.sum_Ico_consecutive` tiles the
@@ -39,7 +45,8 @@ odd-position ranges and `sum_odds (m) = m²` closes it to T_n² = (∑ i)². See
 ## Next Action
 When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, type M1 using the
 **ℕ-sub-free reindex** in knowledge.md ("ℕ-subtraction-free reindex"): L1 `sum_odds`, L2′
-`block_eq_cube` (`∑ Ico (T i) (T (i+1)) (2j+1) = (i+1)³` via `Finset.sum_Ico_consecutive` +
+`block_eq_cube` (`∑ Ico (T i) (T (i+1)) (2j+1) = (i+1)³` via `Finset.sum_Ico_consecutive _ hmn hnk`
+(f explicit, two `≤` hyps explicit — see S5 pin-confirmation) +
 the **division-free** ring identity `(i(i+1))²+4(i+1)³=((i+1)(i+2))²`, clearing `/2` by
 `2*T k = k*(k+1)` with `Nat.even_mul_succ_self`), L3′ tiling, Main′,
 then index-shift to the parent's RHS shape. Build via


### PR DESCRIPTION
## Summary

S5 ORIENT on the Nicomachus combinatorial-proof OQ (odd-number partition of cubes).
Backend blackout continues (Docker `docker info` timeout + Aristotle `prove` → "Resource
not found"; both probed this session), so no Lean build/ACT was possible. This session
closes the last *asserted-but-unconfirmed* item in the M1 spec.

The spec stated "Mathlib gaps: none" but never confirmed the load-bearing lemmas' **exact
signatures at the pinned rev**. Confirmed directly against Mathlib source at the lake pin
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (`v4.26.0`) via `gh api contents?ref=<rev>`:

- **`Finset.sum_Ico_consecutive`** — `@[to_additive]` image of `prod_Ico_consecutive`
  (`Mathlib/Algebra/BigOperators/Intervals.lean:56`). `f` **explicit**, `m n k` **implicit**,
  the two `≤` hyps **explicit positional** → L3′ must call `Finset.sum_Ico_consecutive _ hmn hnk`
  (not a bare rewrite). This is exactly the block-gluing form L3′ needs.
- **`Finset.range_eq_Ico`** — `Mathlib/Order/Interval/Finset/Nat.lean:68`, **point-free**
  `range = Ico 0`, so `range (T n) = Ico 0 (T n)` bridges L1's RHS to L3′'s shape.
- **Bonus:** `Finset.sum_Ico_succ_top (hab : a ≤ b) (f)` present as an alternative single-step
  L3′ top-extension.

**Net:** "Mathlib gaps: none" is now pin-confirmed for the two non-trivial bearers, with the
exact argument order recorded (the one thing the prose spec omitted that the transcriber would
otherwise rediscover at build time). No spec change; ACT plan stands.

## Honest scope

- **No `.lean` written** — an unbuildable file under `proofs/Proofs/` would break the shared
  build; ACT (transcription + build) stays Docker-gated, exactly as S1–S4 deferred.
- Doc-only delta (`knowledge.md` S5 section + `state.md` iteration bump 4→5). Path-disjoint;
  zero churn to the verified spec or `verify_m1.py`.

## Test plan

- [ ] When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, transcribe M1 (L1/L2′/L3′/Main′)
      using the pin-confirmed `Finset.sum_Ico_consecutive _ hmn hnk` arg order, build via
      `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`, cross-check against `verify_m1.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)