### PR TITLE
seeker: replenish candidate pool with 5 fresh research problems

### DIFF
--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: four-square-distribution-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/four-square-distribution-oq-04/literature/README.md
+++ b/research/problems/four-square-distribution-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for four-square-distribution-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/four-square-distribution-oq-04/problem.md
+++ b/research/problems/four-square-distribution-oq-04/problem.md
@@ -1,0 +1,120 @@
+# Problem: Type-Decomposition of Sums of 2k Squares via the Hyperoctahedral Group
+
+**Slug**: four-square-distribution-oq-04
+**Created**: 2026-06-14
+**Status**: Active
+**Source**: gallery-gap <!-- open question extending four-square-distribution -->
+
+## Problem Statement
+
+### Formal Statement
+
+The gallery proof `four-square-distribution` decomposes the count $r_4(n)$ of representations $n = x_1^2+x_2^2+x_3^2+x_4^2$ by "ordering type", using the hyperoctahedral group $B_4 = S_4 \ltimes (\mathbb{Z}/2)^4$ (signed permutations) acting on representations, with each unordered solution of "shape" contributing an orbit whose size is
+
+$$
+2^{\#\{\text{nonzero parts}\}} \cdot \frac{(2k)!}{\prod_i m_i!}\quad(k=2 \text{ here}),
+$$
+
+where $m_i$ are the multiplicities of the distinct absolute values. **Open question:** does this orbit–stabilizer type-decomposition framework generalize to $r_{2k}(n)$, the number of representations as a sum of $2k$ squares, with the hyperoctahedral group $B_{2k} = S_{2k} \ltimes (\mathbb{Z}/2)^{2k}$ of order $(2k)!\,2^{2k}$?
+
+For example, for $k=4$ (eight squares), $B_8 = S_8 \ltimes (\mathbb{Z}/2)^8$ has order $8!\cdot 2^8 = 10{,}321{,}920$.
+
+### Plain Language
+
+If you count the ways to write a number as a sum of four squares, many of those ways are just sign-changes and reorderings of each other. The gallery proof organizes them into neat families (orbits) using the group of "signed shuffles" of 4 coordinates. This question asks whether the *exact same bookkeeping* works for sums of 6, 8, 10, ... squares, where the relevant group is the signed-shuffle group on $2k$ coordinates.
+
+### Why This Matters
+
+Sums-of-squares counts $r_{2k}(n)$ are governed by Jacobi-type formulas and modular forms (e.g. $r_4(n) = 8\sum_{d\mid n,\,4\nmid d} d$). A clean, *group-theoretic* orbit decomposition that separates the "combinatorial multiplicity" (how many orderings/signs each shape has) from the "arithmetic content" (how many shapes there are) is a reusable lens: it isolates exactly the hyperoctahedral combinatorial factor and lets the arithmetic part be supplied by Jacobi's formula. Formalizing it for general $2k$ turns a single worked example into a parametric library.
+
+## Known Results
+
+### What's Already Proven
+
+- The $k=2$ (four squares) type-decomposition — gallery proof `four-square-distribution`
+- Lagrange's four-square theorem (existence) — Mathlib `Nat.sum_four_squares`
+- Jacobi's four-square formula $r_4(n) = 8\sigma(n) - 32\sigma(n/4)$ — classical (not necessarily in Mathlib)
+- $B_m = S_m \ltimes (\mathbb{Z}/2)^m$, the hyperoctahedral / signed-permutation group of order $m!\,2^m$ — standard group theory
+
+### What's Still Open (in Lean)
+
+- The general $2k$ orbit–stabilizer statement: orbit size $= 2^{\#\text{nonzero}}\cdot (2k)!/\prod m_i!$
+- A parametric definition of the $B_{2k}$ action on representation tuples and a proof that orbits are exactly the "shape classes"
+- The clean separation: $r_{2k}(n) = \sum_{\text{shapes } s \text{ of } n} (\text{orbit size of } s)$
+
+### Our Goal
+
+Formalize the orbit–stabilizer decomposition for general $2k$ (or at least for $2k \in \{4,6,8\}$): define the signed-permutation action of $B_{2k}$ on the set of representations of $n$ as an ordered sum of $2k$ squares, prove the orbit-size formula via orbit–stabilizer, and recover the total count as a sum over shapes. The arithmetic value of the total (Jacobi) can be taken as input.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| four-square-distribution | The $k=2$ case being generalized | Orbit–stabilizer, signed permutations |
+| lagrange-four-squares-* | Existence of four-square representations | Descent / Minkowski |
+| jacobi-two-square / sums-of-squares cluster | Arithmetic count formulas | Modular forms / divisor sums |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Orbit–stabilizer via `MulAction`** (recommended): model representations as `Fin (2k) → ℤ` tuples summing-of-squares to $n$; define the `B_{2k}` action (permute coordinates + flip signs); show the stabilizer of a tuple has order $\prod m_i! \cdot 2^{\#\text{zeros}}$, giving the orbit-size formula by `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`.
+   - Why it might work: Mathlib has solid `MulAction`, `Equiv.Perm`, and orbit–stabilizer (`Fintype` cardinalities). The group $B_{2k}$ is `Equiv.Perm (Fin (2k)) ` combined with `(ZMod 2)^(2k)` sign flips.
+   - Risk: defining $B_{2k}$ and its action with the right stabilizer computation; handling zero parts (which have trivial sign orbit) carefully.
+
+2. **Generating-function / direct combinatorial count**: bypass the group action and count orderings directly via multinomials.
+   - Risk: loses the conceptual orbit picture that is the point of the question.
+
+### Key Difficulties
+
+- Correctly accounting for zero coordinates (sign flip acts trivially on $0$) in the stabilizer.
+- Assembling the semidirect product $S_{2k} \ltimes (\mathbb{Z}/2)^{2k}$ and its action cleanly in Mathlib.
+
+### What Would a Proof Need?
+
+- Key lemma 1: definition of the $B_{2k}$ action on $2k$-square representation tuples.
+- Key lemma 2: stabilizer order $= 2^{\#\text{zeros}} \prod_i m_i!$ for a tuple of given shape.
+- Key lemma 3: orbit size $= |B_{2k}| / |\text{stab}| = 2^{\#\text{nonzero}}\,(2k)!/\prod m_i!$.
+- Technical requirements: `Mathlib.GroupTheory.GroupAction.*`, `Equiv.Perm`, `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`, `Fintype`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The hard arithmetic (how many representations exist) is *not* required — Jacobi's value can be an input; the open contribution is the purely group-theoretic orbit counting, which Mathlib supports well.
+- The $k=2$ case is already done in the gallery, giving a concrete template to generalize.
+
+**Estimated Effort**:
+- Exploration: 1–2 days (study the existing four-square-distribution proof and Mathlib orbit–stabilizer)
+- If tractable: 1–2 weeks for the general $2k$ orbit-size formula
+
+## References
+
+### Papers / Texts
+- C. G. J. Jacobi, sums-of-squares formulas (classical).
+- Grosswald, *Representations of Integers as Sums of Squares*.
+- Any standard reference on the hyperoctahedral group $B_n$ (signed permutations).
+
+### Mathlib
+- `Mathlib.GroupTheory.GroupAction.Basic` — `MulAction`, orbits, stabilizers
+- `Mathlib.GroupTheory.OrbitStabilizer` (or current location) — `card_orbit_mul_card_stabilizer_eq_card_group`
+- `Mathlib.GroupTheory.Perm.*` — `Equiv.Perm`
+- `Nat.sum_four_squares` — Lagrange's theorem
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - sums-of-squares
+  - hyperoctahedral-group
+  - representations
+  - group-actions
+related_proofs:
+  - four-square-distribution
+  - lagrange-four-squares-waring-g2
+difficulty: medium
+source: gallery-gap
+created: 2026-06-14
+```

--- a/research/problems/four-square-distribution-oq-04/state.md
+++ b/research/problems/four-square-distribution-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: four-square-distribution-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-14T22:54:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: friendship-theorem-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/friendship-theorem-oq-04/literature/README.md
+++ b/research/problems/friendship-theorem-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for friendship-theorem-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/friendship-theorem-oq-04/problem.md
+++ b/research/problems/friendship-theorem-oq-04/problem.md
@@ -1,0 +1,115 @@
+# Problem: The Friendship Theorem for Infinite Graphs
+
+**Slug**: friendship-theorem-oq-04
+**Created**: 2026-06-14
+**Status**: Active
+**Source**: gallery-gap <!-- open question extending friendship-theorem -->
+
+## Problem Statement
+
+### Formal Statement
+
+Finite case (the gallery theorem): if a finite graph $G$ has the property that every two distinct vertices have **exactly one** common neighbour, then $G$ has a "universal friend" — a vertex adjacent to all others (a windmill/friendship graph).
+
+Infinite extension (this problem):
+
+$$
+\text{Does } \forall\, u \neq v,\ |N(u)\cap N(v)| = 1 \ \text{force a universal vertex when } V(G) \text{ is infinite?}
+$$
+
+The known answer is **no** without extra hypotheses: there exist infinite graphs satisfying the unique-common-neighbour condition with no universal friend (constructed by Erdős–Rényi–Sós and others). The research question is to formalize a precise statement: characterize which additional structural assumptions (e.g. local finiteness, bounded degree, regularity) restore the windmill conclusion, and formalize at least one counterexample and one positive result.
+
+### Plain Language
+
+The friendship theorem says: in a finite "everyone-shares-exactly-one-mutual-friend" social network, there must be one person who is friends with everybody (a politician). For infinite networks this *fails* — you can build endless friend-of-a-friend structures with no universal politician. The task is to pin down, in Lean, exactly where the finite proof breaks and what extra conditions bring the conclusion back.
+
+### Why This Matters
+
+The finite proof is a beautiful mix of double counting and **spectral** (eigenvalue) methods — and both ingredients fail for infinite graphs. Formalizing the boundary between the finite and infinite regimes clarifies *why* the spectral argument is essential and gives the gallery a worked example of "a theorem that does not generalize, and the precise reason." It also exercises Mathlib's `SimpleGraph` API on infinite vertex types.
+
+## Known Results
+
+### What's Already Proven
+
+- Friendship theorem (finite) — gallery proof `friendship-theorem`; classical Erdős–Rényi–Sós (1966)
+- Infinite counterexamples exist: there are infinite friendship graphs with no universal vertex (Erdős–Rényi–Sós; later Chvátal–Kotzig–and others)
+- The finite proof's spectral step: the adjacency matrix eigenvalue/regularity argument — relies on finite-dimensional linear algebra
+
+### What's Still Open (in Lean)
+
+- A formal statement separating the finite theorem from the infinite case
+- A formalized infinite counterexample (graph + verification of the unique-common-neighbour property + absence of universal vertex)
+- A positive result under an explicit extra hypothesis (e.g. local finiteness or bounded degree), if one is cleanly provable
+
+### Our Goal
+
+Formalize: (1) the negative result — exhibit/define an infinite graph satisfying the hypothesis with no universal vertex; and (2) identify and state (ideally prove) a structural hypothesis under which the windmill conclusion is recovered. Document precisely which step of the finite gallery proof fails in the infinite setting.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| friendship-theorem | The finite theorem being extended | Double counting + spectral / eigenvalue |
+| graph-theory cluster (e.g. konigsberg, ramsey) | Shared `SimpleGraph` infrastructure | Combinatorial graph arguments |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Counterexample first** (recommended): define a concrete infinite friendship graph (e.g. a suitable algebraic/geometric incidence structure, or a directed-tree-based construction) and prove in Lean it satisfies $|N(u)\cap N(v)|=1$ for all $u\ne v$ yet has no universal vertex.
+   - Why it might work: it is a construction + verification, no spectral theory needed.
+   - Risk: choosing a construction whose unique-common-neighbour property is *cleanly* provable in Lean.
+
+2. **Positive result under bounded degree/regularity**: try to show the windmill conclusion holds for infinite *locally finite* friendship graphs (if true), reusing a localized version of the counting argument.
+   - Risk: the truth and the cleanest hypothesis need literature confirmation; the spectral step does not localize.
+
+### Key Difficulties
+
+- The eigenvalue argument is intrinsically finite-dimensional; there is no drop-in infinite analogue.
+- Verifying the unique-common-neighbour property for an explicitly defined infinite graph can be combinatorially fiddly.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a concrete infinite `SimpleGraph` with decidable adjacency and a proof of the unique-common-neighbour property.
+- Key lemma 2: proof that no vertex is universal in that graph.
+- (Optional positive) Key lemma 3: under local finiteness, recover a universal vertex or show counterexamples persist.
+- Technical requirements: `Mathlib.Combinatorics.SimpleGraph.*`, `Set`/`Finset` neighbourhood lemmas, infinite vertex types.
+
+## Tractability Assessment
+
+**Difficulty**: Medium–Hard
+
+**Justification**:
+- The counterexample direction is a self-contained construction-and-verification task (medium).
+- A clean *positive* theorem under extra hypotheses is more open-ended and depends on literature (harder).
+
+**Estimated Effort**:
+- Exploration: 1–2 days (survey infinite-friendship-graph constructions)
+- If tractable (counterexample): ~1 week; positive result: unknown
+
+## References
+
+### Papers
+- P. Erdős, A. Rényi, V. T. Sós, "On a problem of graph theory", Studia Sci. Math. Hungar. 1 (1966), 215–235.
+- J. Q. Longyear, T. D. Parsons, "The friendship theorem", Indag. Math. (infinite remarks).
+- H. S. M. Coxeter / later surveys on infinite friendship graphs.
+
+### Mathlib
+- `Mathlib.Combinatorics.SimpleGraph.Basic` — graphs, neighbourhoods, adjacency
+- `Mathlib.Combinatorics.SimpleGraph.Finite` — common-neighbour cardinalities (finite case)
+
+## Metadata
+
+```yaml
+tags:
+  - graph-theory
+  - combinatorics
+  - friendship-theorem
+  - infinite-graphs
+  - spectral-methods
+related_proofs:
+  - friendship-theorem
+difficulty: hard
+source: gallery-gap
+created: 2026-06-14
+```

--- a/research/problems/friendship-theorem-oq-04/state.md
+++ b/research/problems/friendship-theorem-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: friendship-theorem-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-14T22:54:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/inverse-galois-a5-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-a5-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: inverse-galois-a5-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/inverse-galois-a5-oq-02/literature/README.md
+++ b/research/problems/inverse-galois-a5-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for inverse-galois-a5-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/inverse-galois-a5-oq-02/problem.md
+++ b/research/problems/inverse-galois-a5-oq-02/problem.md
@@ -1,0 +1,114 @@
+# Problem: Realize PSL(2,7) (order 168) as a Galois Group over ℚ
+
+**Slug**: inverse-galois-a5-oq-02
+**Created**: 2026-06-14
+**Status**: Active
+**Source**: gallery-gap <!-- open question extending inverse-galois-a5 -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\exists\, f \in \mathbb{Q}[x]\ \text{(explicit)}\ \text{with}\ \operatorname{Gal}(f/\mathbb{Q}) \cong \mathrm{PSL}(2,7) \cong \mathrm{GL}(3,2),\ |\mathrm{PSL}(2,7)| = 168.
+$$
+
+Extend the gallery's realization of $A_5$ (the first non-solvable Galois group) to the next simple non-solvable group, $\mathrm{PSL}(2,7)$, by exhibiting and verifying a concrete polynomial over $\mathbb{Q}$.
+
+### Plain Language
+
+The gallery proof `inverse-galois-a5` writes down an explicit degree-5 polynomial whose "symmetry group" (Galois group) is $A_5$ — the smallest non-solvable group, which is *why* the general quintic has no radical formula. This open question asks for the next landmark: produce a concrete polynomial over the rationals whose symmetry group is $\mathrm{PSL}(2,7)$, the simple group of order 168 (the second-smallest non-abelian simple group, famous as the automorphism group of the Klein quartic and of the Fano plane).
+
+### Why This Matters
+
+It is a concrete data point on the Inverse Galois Problem (which groups arise as $\operatorname{Gal}(\,\cdot\,/\mathbb{Q})$?), extending the gallery beyond $A_5$ to a second simple non-solvable group. $\mathrm{PSL}(2,7)$ is well understood and known to be realizable (it is a Galois group over $\mathbb{Q}$), so this is a *formalize-a-known-construction* task: choose an explicit septic (degree-7) polynomial with Galois group $\mathrm{PSL}(2,7)$ acting on the Fano-plane points and verify the group via resolvents / discriminant / cycle-type evidence.
+
+## Known Results
+
+### What's Already Proven
+
+- $A_5$ realized over $\mathbb{Q}$ by an explicit quintic — gallery proof `inverse-galois-a5`
+- Every solvable group is a Galois group over $\mathbb{Q}$ (Shafarevich) — classical, not in Mathlib
+- $\mathrm{PSL}(2,7) \cong \mathrm{GL}(3,2)$ is simple of order 168 — classical; Mathlib has finite-group / `Equiv.Perm` machinery
+- Standard explicit septics with group $\mathrm{PSL}(2,7)$ exist in the number-theory literature (e.g. Trinks' polynomial $x^7 - 7x + 3$)
+
+### What's Still Open (in Lean)
+
+- Any formalized realization beyond $A_5$ in this gallery
+- Lean verification that a specific septic has Galois group exactly $\mathrm{PSL}(2,7)$ (order 168, transitive, contained in $A_7$ via square discriminant)
+
+### Our Goal
+
+Pick the standard polynomial $f(x) = x^7 - 7x + 3$ (Trinks, 1968; $\operatorname{Gal} = \mathrm{PSL}(2,7)$). Establish in Lean: (1) irreducibility over $\mathbb{Q}$ (transitivity, group order divisible by 7); (2) the discriminant is a perfect square (so $\operatorname{Gal} \le A_7$); (3) factorization cycle types modulo several primes pin the group to the order-168 subgroup $\mathrm{PSL}(2,7) \le A_7$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| inverse-galois-a5 | Template: explicit polynomial → non-solvable Galois group | Irreducibility, discriminant, cycle types |
+| abel-ruffini-* | Non-solvability and Galois-group obstructions | Galois theory of the symmetric/alternating groups |
+| solution-of-cubic / quartic | Resolvent technique for small-degree Galois groups | Resolvents |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Mod-p factorization (Dedekind) + discriminant** (recommended): irreducibility gives transitivity ($7 \mid |G|$); square discriminant gives $G \le A_7$; Frobenius cycle types from factorizations mod small primes force $G = \mathrm{PSL}(2,7)$ (the unique transitive order-168 subgroup of $A_7$).
+   - Why it might work: each ingredient is computational and matches Mathlib's `Polynomial.Monic`, `ZMod` factorization, and discriminant tooling.
+   - Risk: identifying the group from cycle-type data requires a transitive-subgroup classification argument that may need to be axiomatized or done by explicit group reasoning.
+
+2. **Direct Galois-group computation via splitting field**: heavy; likely infeasible to fully mechanize without large group-theory development.
+
+### Key Difficulties
+
+- Pinning the group to exactly 168 (not all of $A_7$, order 2520) needs either a resolvent or a classification of transitive subgroups of $A_7$ of order 168.
+- Computing discriminants and mod-$p$ factorizations cleanly in Lean.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $x^7-7x+3$ irreducible over $\mathbb{Q}$ (e.g. mod-2 factorization or rational-root + further argument).
+- Key lemma 2: $\operatorname{disc}(f)$ is a perfect square in $\mathbb{Q}$.
+- Key lemma 3: enough Frobenius cycle types to exclude all transitive subgroups of $A_7$ except $\mathrm{PSL}(2,7)$.
+- Technical requirements: `Mathlib.FieldTheory.Galois`, `Polynomial` discriminant, `ZMod` factorization, finite-group order facts.
+
+## Tractability Assessment
+
+**Difficulty**: Hard
+
+**Justification**:
+- The polynomial and its group are classical and well-documented, so the target is unambiguous.
+- But fully certifying "Galois group = exactly PSL(2,7)" in Lean is substantial — the subgroup-pinning step is the main obstacle and may require a partial axiomatization of the transitive-subgroup classification (in line with the gallery's `axiomatized` policy for hard realizations).
+
+**Estimated Effort**:
+- Exploration: 2–3 days
+- If tractable: several weeks; a staged result (irreducibility + square discriminant, with the order-168 pinning axiomatized) is a reasonable first deliverable.
+
+## References
+
+### Papers
+- W. Trinks (1968), polynomial $x^7-7x+3$ with Galois group $\mathrm{PSL}(2,7)$.
+- LMFDB, number field / Galois group tables for degree-7 fields.
+- Serre, *Topics in Galois Theory* — realization of $\mathrm{PSL}(2,7)$ and rigidity.
+
+### Mathlib
+- `Mathlib.FieldTheory.Galois` — Galois group API
+- `Mathlib.RingTheory.Polynomial.Discriminant` (or equivalent) — discriminant
+- `ZMod` polynomial factorization — Dedekind / Frobenius cycle types
+
+## Metadata
+
+```yaml
+tags:
+  - galois-theory
+  - inverse-galois-problem
+  - psl27
+  - non-solvable
+  - polynomial-irreducibility
+  - discriminant
+related_proofs:
+  - inverse-galois-a5
+  - abel-ruffini-galois-extensions
+difficulty: hard
+source: gallery-gap
+created: 2026-06-14
+```

--- a/research/problems/inverse-galois-a5-oq-02/state.md
+++ b/research/problems/inverse-galois-a5-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: inverse-galois-a5-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-14T22:54:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/pythagorean-triples-oq-03/knowledge.md
+++ b/research/problems/pythagorean-triples-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: pythagorean-triples-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/pythagorean-triples-oq-03/literature/README.md
+++ b/research/problems/pythagorean-triples-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for pythagorean-triples-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/pythagorean-triples-oq-03/problem.md
+++ b/research/problems/pythagorean-triples-oq-03/problem.md
@@ -1,0 +1,109 @@
+# Problem: Rational Circle Parametrization for x² + y² = p (primes p ≡ 1 mod 4)
+
+**Slug**: pythagorean-triples-oq-03
+**Created**: 2026-06-14
+**Status**: Active
+**Source**: gallery-gap <!-- open question extending pythagorean-triples -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\, p \text{ prime},\ p \equiv 1 \pmod 4 \ \Longrightarrow\ \exists\, x,y \in \mathbb{Z},\ x^2 + y^2 = p,
+$$
+
+to be formalized along the **rational-parametrization** line: the rational points on the unit circle $u^2+v^2=1$ are exactly $\left(\tfrac{1-t^2}{1+t^2}, \tfrac{2t}{1+t^2}\right)$ for $t\in\mathbb{Q}\cup\{\infty\}$, the same parametrization that generates Pythagorean triples in the gallery proof.
+
+### Plain Language
+
+The gallery proof `pythagorean-triples` derives all integer right-triangle side lengths by drawing rational-slope lines through $(-1,0)$ on the unit circle. This open question asks: can that *same geometric parametrization technique* be turned into a Lean proof of Fermat's two-square theorem — that every prime that is one more than a multiple of four is a sum of two squares (e.g. $5=1+4$, $13=4+9$, $17=16+1$)?
+
+### Why This Matters
+
+It connects two classical results (Pythagorean triples and Fermat's two-square theorem) through one reusable method, and tests whether the rational-circle technique generalizes from the *parametrize-all-solutions* setting to an *existence* statement that genuinely uses arithmetic of $\mathbb{Z}[i]$. Mathlib already has `Nat.Prime.sq_add_sq` (existence) via Gaussian integers; the open contribution is the explicit constructive/parametric route and the bridge to the gallery's geometric method.
+
+## Known Results
+
+### What's Already Proven
+
+- `Nat.Prime.sq_add_sq` : `p % 4 = 1 → ∃ a b, a^2 + b^2 = p` — Mathlib (descent / `ZMod`, Gaussian integers)
+- All Pythagorean triples via rational parametrization — gallery proof `pythagorean-triples`
+- `ZMod.exists_sq_eq_neg_one_iff` : $-1$ is a QR mod $p$ iff $p \not\equiv 3 \pmod 4$ — Mathlib
+
+### What's Still Open (in Lean)
+
+- A formalization that *derives* the two-square representation through the rational-circle / descent-on-the-circle geometry, rather than the abstract Gaussian-integer norm argument
+- Extension of the parametrization toolkit to other conics $x^2 + y^2 = n$ and $x^2 + 2y^2 = p$, $x^2+3y^2=p$
+
+### Our Goal
+
+Build a small reusable Lean library: (1) the rational-point parametrization of $u^2+v^2=1$, (2) a clearing-denominators lemma converting a rational point of given "height" into an integer solution, (3) apply it (with $-1$ being a QR mod $p$) to obtain $x^2+y^2=p$. Relate the result to `Nat.Prime.sq_add_sq`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| pythagorean-triples | Source of the rational-parametrization method | Rational lines through a conic point |
+| sum-of-two-squares (if present) / number-theory cluster | Same theorem, different route | Gaussian integers / descent |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Geometry-of-numbers / Thue descent on the circle** (recommended): use $-1 \equiv r^2 \pmod p$ to get a rational point of bounded height on the circle, then Minkowski/pigeonhole (Thue's lemma) to extract a genuine integer solution with $x^2+y^2 = p$.
+   - Why it might work: Mathlib has `ZMod.exists_sq_eq_neg_one_iff` and pigeonhole infrastructure; mirrors the gallery's "rational point → integer triple" clearing step.
+   - Risk: the Minkowski/Thue bound step is the technical core.
+
+2. **Direct parametrization + denominator analysis**: parametrize, then control the denominator $1+t^2$ to land on $p$ exactly.
+   - Risk: harder to force the value to be a *prime* $p$ rather than an arbitrary sum of two squares.
+
+### Key Difficulties
+
+- Going from "there is a rational point" to "there is an integer point summing to exactly $p$" needs a height/descent or Thue-lemma argument.
+- Cleanly connecting the geometric construction to the existing `Nat.Prime.sq_add_sq` so the work is recognized as a proof, not a restatement.
+
+### What Would a Proof Need?
+
+- Key lemma 1: rational parametrization of $u^2+v^2=1$ (constructive bijection with $\mathbb{Q}\cup\{\infty\}$).
+- Key lemma 2: Thue's lemma / pigeonhole to produce a small integer solution of $x \equiv ry \pmod p$.
+- Technical requirements: `Mathlib.NumberTheory.SumTwoSquares`, `ZMod`, `Mathlib.NumberTheory.Pythagorean` (if present), pigeonhole.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The target theorem already exists in Mathlib, so correctness is anchored; the novelty is the *method*.
+- Thue's lemma and QR(-1) are available; the parametrization is elementary.
+
+**Estimated Effort**:
+- Exploration: 1 day (locate Thue/pigeonhole and the circle parametrization status in Mathlib)
+- If tractable: several days to ~1 week
+
+## References
+
+### Papers / Texts
+- Hardy & Wright, *An Introduction to the Theory of Numbers*, two-square theorem.
+- Aigner & Ziegler, *Proofs from THE BOOK*, "Representing numbers as sums of two squares".
+
+### Mathlib
+- `Mathlib.NumberTheory.SumTwoSquares` — `Nat.Prime.sq_add_sq`
+- `ZMod.exists_sq_eq_neg_one_iff` — $-1$ as a quadratic residue
+- Pigeonhole / `Finset` cardinality lemmas for Thue's lemma
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - diophantine
+  - two-squares
+  - rational-parametrization
+  - fermat
+related_proofs:
+  - pythagorean-triples
+difficulty: medium
+source: gallery-gap
+created: 2026-06-14
+```

--- a/research/problems/pythagorean-triples-oq-03/state.md
+++ b/research/problems/pythagorean-triples-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: pythagorean-triples-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-14T22:54:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/literature/README.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/problem.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/problem.md
@@ -1,0 +1,112 @@
+# Problem: Besicovitch's Theorem — ℚ-Linear Independence of Square Roots of Squarefree Integers
+
+**Slug**: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02
+**Created**: 2026-06-14
+**Status**: Active
+**Source**: gallery-gap <!-- open question extending sqrt2-plus-sqrt3-plus-sqrt5-irrational -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{For distinct squarefree integers } a_1,\dots,a_n > 1,\ \{1, \sqrt{a_1}, \dots, \sqrt{a_n}\} \text{ is linearly independent over } \mathbb{Q}.
+$$
+
+Besicovitch (1940): if $a_1,\dots,a_n$ are distinct squarefree positive integers then $\sqrt{a_1},\dots,\sqrt{a_n}$ are linearly independent over $\mathbb{Q}$; more strongly, the family of squarefree-product radicals forms a $\mathbb{Q}$-basis of the multiquadratic field they generate.
+
+### Plain Language
+
+The gallery proof shows the specific number $\sqrt2 + \sqrt3 + \sqrt5$ is irrational. This open question asks for the general structural theorem behind it: there is never a nontrivial rational relation among the square roots of distinct squarefree integers. So $\sqrt2,\sqrt3,\sqrt5,\sqrt6,\sqrt7,\dots$ are "independent" over $\mathbb{Q}$ — no rational combination collapses to a rational number unless every coefficient is zero.
+
+### Why This Matters
+
+This is the reusable engine behind a whole family of irrationality results. It generalizes the ad-hoc $\sqrt2+\sqrt3+\sqrt5$ argument to arbitrary finite sets and characterizes the structure of the multiquadratic field $\mathbb{Q}(\sqrt{a_1},\dots,\sqrt{a_n})$, which has degree $2^n$ over $\mathbb{Q}$ with Galois group $(\mathbb{Z}/2)^n$. It is **not** currently in Mathlib v4.26.0.
+
+## Known Results
+
+### What's Already Proven
+
+- Irrationality of $\sqrt2 + \sqrt3 + \sqrt5$ — gallery proof `sqrt2-plus-sqrt3-plus-sqrt5-irrational`
+- `Nat.Prime.irrational_sqrt`, `irrational_nrt_of_notint_nrt` — Mathlib (single square roots)
+- Multiquadratic field has degree $2^n$, Galois group $(\mathbb{Z}/2)^n$ — classical
+
+### What's Still Open (in Lean)
+
+- A structured induction on $n$ proving full $\mathbb{Q}$-linear independence
+- Key step: $\sqrt{a_{n+1}} \notin \mathbb{Q}(\sqrt{a_1},\dots,\sqrt{a_n})$ for $a_{n+1}$ squarefree, not a square-class product of earlier radicals
+
+### Our Goal
+
+Formalize Besicovitch's general theorem. A clean intermediate target is the prime case ($a_i$ distinct primes), where the field-degree argument is sharpest, then extend to general squarefree integers via prime factorizations.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| sqrt2-plus-sqrt3-plus-sqrt5-irrational | Direct $n=3$, $\{2,3,5\}$ instance | Conjugation / minimal polynomial |
+| nth-root-irrational | Single-radical irrationality | Rational-root / valuation |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Field-theoretic induction on the quadratic tower** (recommended): show $[\mathbb{Q}(\sqrt{a_1},\dots,\sqrt{a_n}):\mathbb{Q}] = 2^n$ by proving each $\sqrt{a_{k+1}}$ has degree 2 over the previous field. Independence of the $2^n$ squarefree-product monomials follows from the basis structure.
+   - Why it might work: matches Mathlib's `IntermediateField.adjoin` / `FiniteDimensional` API.
+   - Risk: the "genuinely new radical" step needs a clean valuation or parity argument.
+
+2. **Galois-action / conjugation**: the group $(\mathbb{Z}/2)^n$ acts by independent sign flips $\sqrt{a_i} \mapsto \pm\sqrt{a_i}$; a nontrivial rational relation fixed by all sign flips forces every coefficient to vanish.
+   - Why it might work: conceptual, mirrors the $n=3$ gallery proof.
+   - Risk: constructing and proving well-definedness of the automorphisms in Lean.
+
+### Key Difficulties
+
+- The inductive step (a new radical is not in the previous field) requires 2-adic valuation reasoning or multiplicativity of field degrees.
+- General squarefree (vs. prime) integers add bookkeeping over shared prime factors.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $\sqrt{m} \notin \mathbb{Q}(\sqrt{a_1},\dots,\sqrt{a_n})$ when $m$ is squarefree and not a square-class product of the $a_i$.
+- Key lemma 2: degree multiplicativity in the quadratic tower (`IntermediateField.adjoin` + degrees).
+- Technical requirements: `Mathlib.FieldTheory.*`, `Irrational`, `Nat.Squarefree`, `Nat.factorization`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Classical theorem with several elementary proofs.
+- Mathlib has strong field-theory and squarefree-number support, but this theorem is absent.
+- The induction is conceptually clear; the labor is the Lean-mechanical "new radical" step.
+
+**Estimated Effort**:
+- Exploration: 1–2 days (survey Mathlib field-tower API)
+- If tractable: 1–2 weeks for the prime case; more for general squarefree
+
+## References
+
+### Papers
+- A. S. Besicovitch, "On the linear independence of fractional powers of integers", J. London Math. Soc. 15 (1940), 3–6.
+- I. Richards, "An application of Galois theory to elementary arithmetic", Adv. Math. 13 (1974).
+
+### Mathlib
+- `Mathlib.FieldTheory.Adjoin` — `IntermediateField.adjoin`, degrees of adjoined elements
+- `Nat.Squarefree`, `Nat.factorization` — squarefree structure
+- `Irrational` — irrationality primitives
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - field-theory
+  - linear-independence
+  - irrationality
+  - besicovitch
+related_proofs:
+  - sqrt2-plus-sqrt3-plus-sqrt5-irrational
+  - nth-root-irrational
+difficulty: medium
+source: gallery-gap
+created: 2026-06-14
+```

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-14T22:54:15-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -21834,6 +21834,41 @@
       "started": "2026-06-15T02:22:23.647Z",
       "status": "active",
       "lastUpdate": "2026-06-15T02:22:23.824Z"
+    },
+    {
+      "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-06-14T22:54:15-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "pythagorean-triples-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-06-14T22:54:16-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "inverse-galois-a5-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-06-14T22:54:16-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "friendship-theorem-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-06-14T22:54:16-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "four-square-distribution-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-06-14T22:54:17-07:00",
+      "status": "active"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary

The live candidate pool (`.lean/state/candidate-pool.json`) dropped below the 15-available threshold under active researcher draw-down. This adds 5 vetted, well-defined open questions across distinct mathematical domains, each with a fully filled-in `problem.md` (no template placeholders).

| Slug | Domain | Statement |
|------|--------|-----------|
| `sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02` | Field theory | Besicovitch (1940): ℚ-linear independence of √(distinct squarefree integers) |
| `pythagorean-triples-oq-03` | Number theory | Rational-circle parametrization route to x²+y²=p for p≡1 (mod 4) |
| `inverse-galois-a5-oq-02` | Galois theory | Realize PSL(2,7) (order 168) as a Galois group over ℚ |
| `friendship-theorem-oq-04` | Graph theory | Friendship theorem in the infinite setting (counterexample + structural hypotheses) |
| `four-square-distribution-oq-04` | Additive number theory | Orbit–stabilizer type-decomposition of sums of 2k squares via the hyperoctahedral group |

## Selection notes

- Sourced from un-pooled gallery open questions (8054 candidates not yet in the live pool).
- Excludes saturated / collision-prone families (erdos-*, abel-ruffini, sperner, etc.).
- Diverse domains, all with a concrete formalization target and Mathlib bearer notes.
- The live pool + `knowledge.db` were updated out-of-band (gitignored); this PR carries the tracked workspace stubs and `registry.json`.

## Test plan

- [x] `validate-seeker-stubs.ts` passes for all 5 slugs (no template placeholders)
- [x] `registry.json` diff is exactly the 5 new entries
- [x] Live pool back to 18 available