### PR TITLE
research(erdos-574-oq-01): ORIENT — unconditional k=2 lower bound + durable verifier

### DIFF
--- a/research/erdos-574-oq-01/knowledge.md
+++ b/research/erdos-574-oq-01/knowledge.md
@@ -1,0 +1,93 @@
+# Erdős Problem #574 (OQ-01) — Turán Number for Consecutive Cycle Pairs
+
+**Question.** For `k ≥ 2`, is
+`ex(n; {C_{2k-1}, C_{2k}}) = (1 + o(1)) · (n/2)^{1+1/k}` ?
+I.e. does additionally forbidding the odd cycle `C_{2k-1}` cost nothing
+asymptotically beyond forbidding `C_{2k}` alone?
+
+**Status:** OPEN. Gallery entry is a statement-level stub (custom
+`SimpleGraph'`, placeholder `exConsecutiveCycles`, 0 theorems, 0 sorries,
+0 axioms).
+
+---
+
+## Session 2026-06-14 (Session 1) — ORIENT
+
+**Mode:** FRESH
+**Outcome:** progress (ORIENT — durable lower-bound verification, framing sharpened)
+
+### Key structural observation: the LOWER bound is unconditional
+
+The conjecture is an asymptotic *equality*. It splits cleanly:
+
+- **Upper bound** `ex(n;{C_{2k-1},C_{2k}}) ≤ (1+o(1))(n/2)^{1+1/k}`:
+  trivially `≤ ex(n; C_{2k})` (more forbidden subgraphs ⟹ fewer edges).
+  This is the GENUINELY OPEN half — and is in fact *at least as hard* as
+  determining the leading constant of `ex(n; C_{2k})`, which is itself
+  open for general `k` (known only for `k = 2, 3, 5`).
+
+- **Lower bound** `ex(n;{C_{2k-1},C_{2k}}) ≥ (1-o(1))(n/2)^{1+1/k}`:
+  **UNCONDITIONAL for the values where the even-cycle construction is
+  known** (`k = 2, 3, 5`). Reason: the dense `C_{2k}`-free graphs from
+  incidence geometry (projective planes / generalized polygons; Wenger
+  1991, Lazebnik–Ustimenko–Woldar 1995) are **bipartite**. A bipartite
+  graph has *no odd cycle whatsoever*, so it is automatically
+  `C_{2k-1}`-free. Forbidding the odd cycle is therefore "free" on the
+  lower-bound side — not conjecturally, but as a theorem.
+
+So the open content of #574 is purely an **upper-bound** matching
+question, inheriting the open even-cycle-constant problem. The "free"
+phenomenon on the lower side is already a proof, not evidence.
+
+### Durable verification (k = 2): exact leading constant
+
+For `k = 2` (forbid `C_3` and `C_4`) the incidence graph of the
+projective plane `PG(2,q)` (`q` prime) is bipartite, `(q+1)`-regular,
+girth 6, with `q²+q+1` points and the same number of lines. Computed
+directly (`verify_lower_bound.py`, all checks pass for `q = 2,3,5,7`):
+
+| q | n   | edges | bipartite | C₃-free | C₄-free | edges/(n/2)^{3/2} |
+|---|-----|-------|-----------|---------|---------|-------------------|
+| 2 | 14  | 21    | ✓         | ✓       | ✓       | 1.1339            |
+| 3 | 26  | 52    | ✓         | ✓       | ✓       | 1.1094            |
+| 5 | 62  | 186   | ✓         | ✓       | ✓       | 1.0776            |
+| 7 | 114 | 456   | ✓         | ✓       | ✓       | 1.0596            |
+
+The ratio is **exact in closed form**:
+```
+edges        (q+1)(q²+q+1)        q+1
+--------- = ------------------ = ---------------  ⟶ 1   (from above)
+(n/2)^1.5   (q²+q+1)^{3/2}       √(q²+q+1)
+```
+because `(q+1)/√(q²+q+1) = √(1 + q/(q²+q+1)) → 1`. So the construction
+attains the conjectured **leading constant** `(1/2)^{1+1/k}` exactly in
+the limit (not merely the order `n^{3/2}`), confirming the `k = 2` lower
+bound `ex(n;{C_3,C_4}) ≥ (1-o(1))(n/2)^{3/2}`.
+
+### Why this is not just enumeration theater
+Small-`q` numbers alone would be weak (the `o(1)` dominates), but here
+they back a *closed-form* limit, so the verification certifies the
+asymptotic constant, not just a few data points.
+
+### Mathlib gaps (for an eventual Lean lower-bound proof)
+- Mathlib has `SimpleGraph.isBipartite` / 2-colorings and the
+  no-odd-closed-walk fact, which would give `C_{2k-1}`-freeness of a
+  bipartite witness essentially for free.
+- Mathlib does **not** have: projective-plane / generalized-polygon
+  incidence graphs as a packaged construction, the Bondy–Simonovits
+  even-cycle upper bound, or extremal-number (`ex`) machinery for graphs.
+  Building the `PG(2,q)` witness + its girth-6 proof is a few-hundred-line
+  finite-geometry project; the upper bound is research-level (OPEN).
+
+### Next steps
+- ACT (lower bound, `k = 2`): formalize the `PG(2,q)` incidence graph in
+  Mathlib's `SimpleGraph`, prove bipartite ⟹ `C_3`-free and girth ≥ 6 ⟹
+  `C_4`-free, and the edge count `(q+1)(q²+q+1)`. This is a buildable,
+  unconditional lower-bound theorem (Docker required; currently down).
+- Generalize the "bipartite ⟹ `C_{2k-1}`-free" lemma to all `k` — this is
+  the reusable core and is `O(50)` LOC against Mathlib's bipartite API.
+- Upper bound stays OPEN; do not submit to Aristotle.
+
+### Files
+- `research/erdos-574-oq-01/verify_lower_bound.py` (new, runs clean)
+- `research/erdos-574-oq-01/knowledge.md` (this file)

--- a/research/erdos-574-oq-01/verify_lower_bound.py
+++ b/research/erdos-574-oq-01/verify_lower_bound.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Durable verification for Erdős Problem #574 (OQ-01), case k = 2.
+
+Conjecture:  ex(n; {C_{2k-1}, C_{2k}}) = (1 + o(1)) * (n/2)^{1+1/k}  for k >= 2.
+
+The genuinely OPEN part of the conjecture is the upper bound (and even
+ex(n; C_{2k})'s exact constant is open for general k). The LOWER bound,
+however, transfers for free from the C_{2k}-alone extremal construction
+for one structural reason:
+
+    The standard extremal C_{2k}-free graphs (incidence graphs of
+    generalized k-gons / projective planes) are BIPARTITE, hence have NO
+    odd cycles at all, hence are automatically C_{2k-1}-free.
+
+So the lower bound ex(n; {C_{2k-1}, C_{2k}}) >= (bipartite construction
+count) is UNCONDITIONAL — "forbidding C_{2k-1} is free" on the lower-bound
+side.
+
+This script demonstrates that fact concretely for k = 2 (forbid C_3 and
+C_4) using the point-line incidence graph of the projective plane PG(2,q)
+over GF(q), q prime. For each q it checks:
+
+  1. The graph is bipartite (points vs lines)  => no odd cycle  => C_3-free.
+  2. The graph is genuinely C_3-free (direct triangle search).
+  3. The graph is C_4-free (direct 4-cycle search; girth = 6).
+  4. Edge count e ~ (n/2)^{3/2} = (n/2)^{1+1/2}, matching the conjecture.
+
+A graph that is simultaneously C_3-free AND C_4-free with ~(n/2)^{3/2}
+edges is exactly a lower-bound witness for ex(n; {C_3, C_4}).
+"""
+
+from itertools import combinations
+
+
+def projective_points(q):
+    """Representatives of 1-dim subspaces of GF(q)^3 (q prime), i.e. the
+    points of PG(2,q). Normalize so the first nonzero coordinate is 1."""
+    pts = []
+    for x in range(q):
+        for y in range(q):
+            for z in range(q):
+                if (x, y, z) == (0, 0, 0):
+                    continue
+                # find first nonzero coordinate, require it == 1 (canonical rep)
+                v = (x, y, z)
+                lead = next(c for c in v if c != 0)
+                inv = pow(lead, q - 2, q)  # inverse in GF(q), q prime
+                canon = tuple((c * inv) % q for c in v)
+                if canon == v:
+                    pts.append(v)
+    return pts
+
+
+def incidence_graph(q):
+    """Bipartite point-line incidence graph of PG(2,q).
+    Points and lines are the same set of representatives (duality);
+    point p is incident to line L iff the dot product p.L == 0 mod q."""
+    reps = projective_points(q)
+    # vertices: ('P', i) for points, ('L', j) for lines
+    points = [('P', i) for i in range(len(reps))]
+    lines = [('L', j) for j in range(len(reps))]
+    adj = {v: set() for v in points + lines}
+    for i, p in enumerate(reps):
+        for j, L in enumerate(reps):
+            dot = (p[0] * L[0] + p[1] * L[1] + p[2] * L[2]) % q
+            if dot == 0:
+                adj[('P', i)].add(('L', j))
+                adj[('L', j)].add(('P', i))
+    return adj, reps
+
+
+def is_bipartite_PL(adj):
+    """The construction is bipartite by design (P-side vs L-side). Verify
+    no edge stays within a side."""
+    for u, nbrs in adj.items():
+        for v in nbrs:
+            if u[0] == v[0]:
+                return False
+    return True
+
+
+def has_triangle(adj):
+    verts = list(adj)
+    for a, b, c in combinations(verts, 3):
+        if b in adj[a] and c in adj[b] and a in adj[c]:
+            return True
+    return False
+
+
+def has_c4(adj):
+    """C_4 exists iff some pair of vertices has >= 2 common neighbours."""
+    verts = list(adj)
+    for u, w in combinations(verts, 2):
+        common = adj[u] & adj[w]
+        if len(common) >= 2:
+            return True
+    return False
+
+
+def edge_count(adj):
+    return sum(len(n) for n in adj.values()) // 2
+
+
+def run():
+    print(f"{'q':>3} {'n':>5} {'edges':>6} {'bipart':>7} {'C3free':>7} "
+          f"{'C4free':>7} {'(n/2)^1.5':>10} {'ratio':>7}")
+    print("-" * 62)
+    all_ok = True
+    for q in (2, 3, 5, 7):
+        adj, reps = incidence_graph(q)
+        n = len(adj)
+        e = edge_count(adj)
+        bip = is_bipartite_PL(adj)
+        c3free = not has_triangle(adj)
+        c4free = not has_c4(adj)
+        target = (n / 2) ** 1.5
+        ratio = e / target
+        # sanity: PG(2,q) has q^2+q+1 points & lines, each (q+1)-regular,
+        # edges = (q+1)(q^2+q+1).
+        npts = q * q + q + 1
+        assert len(reps) == npts, (len(reps), npts)
+        assert n == 2 * npts
+        assert e == (q + 1) * npts
+        ok = bip and c3free and c4free
+        all_ok = all_ok and ok
+        print(f"{q:>3} {n:>5} {e:>6} {str(bip):>7} {str(c3free):>7} "
+              f"{str(c4free):>7} {target:>10.2f} {ratio:>7.4f}")
+
+    print("-" * 62)
+    print("Structural facts confirmed for k = 2:")
+    print("  * incidence graph of PG(2,q) is bipartite -> no odd cycle")
+    print("    -> C_3-free WITHOUT any extra work (this is the 'free' part)")
+    print("  * also C_4-free (girth 6), so {C_3,C_4}-free")
+    print("  * edges = (q+1)(q^2+q+1) ~ (n/2)^{3/2}, ratio -> 1 as q grows")
+    print("  => unconditional lower bound ex(n;{C_3,C_4}) >= ~(n/2)^{3/2}")
+    print()
+    print("ALL CHECKS PASSED" if all_ok else "FAILURE")
+    return all_ok
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## Summary

ORIENT pass on **Erdős #574** (OQ-01): is `ex(n; {C_{2k-1}, C_{2k}}) = (1+o(1))·(n/2)^{1+1/k}` for `k ≥ 2`? The gallery entry was a statement-level stub (0 theorems, 0 axioms). This PR adds a durable verification artifact and sharpens the framing of what is actually open.

## Key finding: the lower bound is unconditional

The conjecture is an asymptotic *equality* that splits cleanly:

- **Upper bound** is the genuinely OPEN half (`≤ ex(n; C_{2k})`, whose leading constant is open for general `k`).
- **Lower bound** is already a **theorem** for `k = 2, 3, 5`: the dense `C_{2k}`-free incidence-geometry constructions (projective planes / generalized polygons) are **bipartite**, hence have no odd cycle, hence are automatically `C_{2k-1}`-free. Forbidding the odd cycle is "free" on the lower side — not conjecturally.

## Durable verification (k = 2)

`research/erdos-574-oq-01/verify_lower_bound.py` builds the `PG(2,q)` point–line incidence graph for `q = 2,3,5,7` and confirms each is bipartite (⟹ `C_3`-free), `C_4`-free (girth 6), with `edges = (q+1)(q²+q+1)`. The ratio to the conjectured value is exact in closed form:

```
edges / (n/2)^{3/2} = (q+1)/√(q²+q+1) → 1   (from above: 1.134, 1.109, 1.078, 1.060)
```

so the construction attains the conjectured **leading constant** `(1/2)^{1+1/k}`, not merely the order — certifying `ex(n;{C_3,C_4}) ≥ (1−o(1))(n/2)^{3/2}`.

## Scope / honesty

- No Lean code changed (Docker build backend is down; the existing stub builds and is left untouched to avoid unverifiable churn).
- This is an ORIENT/durable-verify contribution, not a Lean proof. The upper bound remains OPEN and was not submitted to Aristotle.
- Next step (when Docker is up): formalize the `PG(2,q)` witness in Mathlib's `SimpleGraph` for an unconditional `k=2` lower-bound theorem.

## Test plan
- [x] `python3 research/erdos-574-oq-01/verify_lower_bound.py` → all checks pass, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)