### PR TITLE
research(erdos-10-oq-02): ORIENT — popcount reduction + S_3 experiment for Granville–Soundararajan (k=3 odd)

### DIFF
--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -1,0 +1,92 @@
+# erdos-10-oq-02 — Granville–Soundararajan (k = 3 for odd integers)
+
+**Parent:** Erdős Problem #10 — sums of a prime and powers of 2.
+**Question (open):** Is the Granville–Soundararajan conjecture true, i.e. is every
+odd integer `n > 1` a sum of a prime and **at most 3** powers of 2?
+
+  `n = p + 2^{a_1} + ... + 2^{a_j}`, `p` prime, `0 ≤ j ≤ 3`.   (GS-odd)
+
+Companion even part: every even `n ≥ 2` needs at most 4 (GS-even). Both open
+(Granville–Soundararajan 1998).
+
+Status this session: **ORIENT** (build-free — Docker + Lean unavailable). No proof
+attempted; the conjecture is open. Contribution = a precise combinatorial reduction
++ a reproducible numerical experiment that is honest about what small-N data can and
+cannot show.
+
+## Reduction lemma (the cleanest formalizable fact here)
+
+For `m ∈ ℕ` and `k ∈ ℕ`:
+
+  `m` is a sum of **at most `k`** powers of 2 (multiset of exponents of size ≤ k,
+  repetitions allowed)  **⟺**  `popcount(m) ≤ k`.
+
+- (⟸) `popcount(m) = t ≤ k` ⟹ `m` is the sum of its `t` distinct set bits.
+- (⟹) `2^a + 2^a = 2^{a+1}` merges equal powers, only shrinking the multiset;
+  iterate to ≤ k **distinct** powers, so `popcount(m) ≤ k`.
+
+Hence, with `S_k = { n : n = p + (≤ k powers of 2), p prime }`,
+
+  `n ∈ S_k  ⟺  ∃ m ≥ 0, popcount(m) ≤ k, n − m ≥ 2, (n − m) prime`.   (*)
+
+`(*)` turns membership and the *minimal number of powers* into a cheap finite
+search (offsets `m` with `popcount ≤ k` number only `~ C(b,≤k) ~ b^k/k!`,
+`b = #bits(n)`). This is the natural target for a future ACT (Lean) iteration:
+it is elementary, self-contained, and converts the existing `sumPrimeAndTwoPows`
+definition into a decidable predicate.
+
+## Numerical evidence (verify_granville_soundararajan_odd.py)
+
+Verified with `N = 10^6` (odd and even), plus a separate odd `S_2` sweep to
+`3·10^6`. All reproducible with stdlib + sympy.
+
+**E1 — odd side (GS-odd).** Every odd `n ∈ [3, 10^6]` is in `S_3`. Minimal-#powers
+distribution: 0→15.70%, 1→78.71%, 2→5.59%, **3→0.00%**. I.e. ≤ 2 powers always
+suffice in range; up to `3·10^6` *no* odd `n` even leaves `S_2`.
+
+  ⚠️ **Honest caveat.** A direct odd sweep therefore confirms GS-odd only
+  *trivially* — it never exercises the third power. The conjecture is stated with
+  `k = 3` (not `k = 2`) because of **Crocker (1971)**: there are infinitely many
+  odd `n ∉ S_2`. But Crocker's witnesses come from covering systems and are
+  astronomically large, far beyond brute force. So small-N data is genuine but
+  **weak** evidence for GS-odd.
+
+**E2 — even side (where `S_3` is genuinely exercised).** Every even `n ∈ [2, 10^6]`
+is in `S_3`. Distribution: 0→0.00%, 1→15.70%, 2→78.71%, **3→5.59%**. The third
+power is genuinely required for ~5.6% of even `n`; the **smallest even `n` needing
+exactly 3 powers is `906`**. No even `n ≤ 10^6` needs more than 3.
+
+**E3 — Grechuk's counterexample.** `1117175146` (even, popcount 16) is **not** in
+`S_3` but **is** in `S_4` — confirming both Grechuk's observation (`k = 3` fails on
+the even side) and the even part of GS (`k = 4` suffices there in this instance).
+It is the first known even failure of `S_3`, well beyond the `10^6` sweep.
+
+## Parity structure (the heart of the conjecture)
+
+The odd/even split is the +1-power offset, visible directly in the data:
+in range, **odd** `n` need at most **2** powers, **even** `n` need at most **3** —
+exactly the `k = 3` (odd) vs `k = 4` (even) gap GS conjectures. Mechanism: for odd
+`n`, subtracting one even power `2^a` (`a ≥ 1`) leaves an odd number `n − 2^a`,
+which has a Goldbach/Romanoff-dense chance of being prime; even `n` must spend an
+extra power to fix parity before the prime can be odd.
+
+## Next steps
+
+1. **ACT (Lean, Docker-gated):** formalize the reduction lemma `(*)` and turn
+   `sumPrimeAndTwoPows`/`IsPrimePlusKPowers` (already in `Erdos10Problem.lean` /
+   `Erdos10OQ01.lean`) into a `Decidable` membership via `popcount`; discharge the
+   `906`/Grechuk witnesses by `decide`/`native_decide`.
+2. Cite Crocker (1971) in the gallery as the reason `k = 3` (not 2) for odd —
+   the gallery currently lists it only obliquely.
+3. The conjecture itself is open and needs sieve/large-sieve machinery (Gallagher
+   line); not within brute-force or near-term Lean reach.
+
+## References
+
+- Granville, A.; Soundararajan, K. (1998). *A binary additive problem of Erdős and
+  the order of `2 mod p²`.* Ramanujan J. 2, 283–298.
+- Crocker, R. (1971). *On the sum of a prime and of two powers of two.* Pacific J.
+  Math. 36, 103–107. (Infinitely many odd `n ∉ S_2`.)
+- Gallagher, P.X. (1975). *Primes and powers of 2.* Invent. Math. 29, 125–142.
+- Erdős, P.; Graham, R. (1980). *Old and New Problems and Results in Combinatorial
+  Number Theory.*

--- a/research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py
+++ b/research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Erdős Problem #10, open question oq-02:
+    Is the Granville–Soundararajan conjecture (k = 3 for odd integers) true?
+
+Granville–Soundararajan (1998) conjectured that every odd integer n > 1 can be
+written as a prime plus AT MOST 3 powers of 2:
+
+        n = p + 2^{a_1} + ... + 2^{a_j},   p prime,   0 <= j <= 3.            (GS-odd)
+
+The companion (even) conjecture asserts every even n >= 2 needs at most 4.
+Both are OPEN. This script does NOT prove anything; it gathers reproducible
+numerical evidence and pins down the precise combinatorial structure.
+
+------------------------------------------------------------------------------
+Reduction lemma (used throughout, and the cleanest formalizable fact here)
+------------------------------------------------------------------------------
+A nonnegative integer m is a sum of AT MOST k powers of 2 (a multiset of
+exponents of size <= k, repetitions allowed) IF AND ONLY IF popcount(m) <= k.
+
+  (=>) Merging 2^a + 2^a = 2^{a+1} only shrinks the multiset, so any size-<=k
+       multiset collapses to <= k DISTINCT powers, i.e. popcount(m) <= k.
+  (<=) If popcount(m) = t <= k then m is the sum of its t distinct set bits.
+
+Hence, with S_k = { n : n = p + (<= k powers of 2), p prime },
+
+        n in S_k  <=>  exists m >= 0 with popcount(m) <= k,
+                       n - m >= 2, and (n - m) is prime.                       (*)
+
+The empty multiset m = 0 handles "n is itself prime". (*) makes membership and
+the MINIMAL number of powers cheap to compute.
+
+------------------------------------------------------------------------------
+What the evidence does and does NOT show (honest summary)
+------------------------------------------------------------------------------
+  * ODD side: in every range we can brute-force (here up to 3*10^6), every odd
+    n is already in S_2 -- only <= 2 powers are ever needed.  So a direct sweep
+    "confirms" GS-odd only trivially; it never even exercises the third power.
+    The reason the conjecture is stated with k = 3 and not k = 2 is Crocker
+    (1971): there are infinitely many odd n NOT in S_2 -- but those witnesses
+    arise from covering systems and are astronomically large, far beyond any
+    brute-force bound.  So small-N data is genuine but WEAK evidence for GS-odd.
+
+  * EVEN side: brute force DOES exercise S_3.  A positive proportion (~5.6%) of
+    even n genuinely need exactly 3 powers; the smallest is n = 906.  Every even
+    n up to 10^6 is in S_3, and the first known even failure is Grechuk's
+    1117175146 (in S_4, not S_3) -- the true k=3 boundary, on the even side.
+
+Experiments
+-----------
+  E1. ODD sweep: every odd n in [3, N_ODD] is in S_3, with the minimal-#powers
+      distribution (exposes that <=2 always suffices in range).
+  E2. EVEN sweep: minimal-#powers distribution for even n in [2, N_EVEN],
+      the smallest even n needing exactly 3, and that all even n <= N_EVEN
+      are in S_3 (no failure before Grechuk's number).
+  E3. Grechuk's counterexample: 1117175146 (even) NOT in S_3 but in S_4.
+"""
+
+import sys
+from itertools import combinations
+from sympy import isprime
+
+
+def sieve(limit):
+    is_p = bytearray([1]) * (limit + 1)
+    is_p[0] = is_p[1] = 0
+    i = 2
+    while i * i <= limit:
+        if is_p[i]:
+            is_p[i * i:limit + 1:i] = bytearray(len(range(i * i, limit + 1, i)))
+        i += 1
+    return is_p
+
+
+def offsets_by_popcount(N, kmax=3):
+    """byk[j] = sorted list of m in [0,N] with popcount(m) exactly j, j<=kmax."""
+    bits = []
+    v = 1
+    while v <= N:
+        bits.append(v)
+        v <<= 1
+    byk = {j: [] for j in range(kmax + 1)}
+    byk[0].append(0)
+    nb = len(bits)
+    for i in range(nb):
+        if 1 <= kmax:
+            byk[1].append(bits[i])
+        for j in range(i + 1, nb):
+            s2 = bits[i] + bits[j]
+            if s2 <= N and 2 <= kmax:
+                byk[2].append(s2)
+            if kmax >= 3:
+                for l in range(j + 1, nb):
+                    s3 = s2 + bits[l]
+                    if s3 <= N:
+                        byk[3].append(s3)
+    for j in byk:
+        byk[j].sort()
+    return byk
+
+
+def min_powers(n, byk, is_p, kmax=3):
+    """Minimal j in {0..kmax} with n = prime + (sum of j powers of 2); else None."""
+    for j in range(0, kmax + 1):
+        for m in byk[j]:
+            if m >= n - 1:
+                break
+            if is_p[n - m]:
+                return j
+    return None
+
+
+def in_S_k_big(n, k):
+    """Membership for arbitrary n via sympy.isprime + popcount<=k offsets."""
+    if n >= 2 and isprime(n):
+        return True, 0
+    bits = []
+    v = 1
+    while v < n:
+        bits.append(v)
+        v <<= 1
+    for j in range(1, k + 1):
+        for combo in combinations(bits, j):
+            m = sum(combo)
+            if m <= n - 2 and isprime(n - m):
+                return True, j
+    return False, None
+
+
+def sweep(lo, hi, byk, is_p, label, kmax=3):
+    dist = {j: 0 for j in range(kmax + 1)}
+    failures = []
+    smallest_needing_kmax = None
+    largest_needing_kmax = None
+    for n in range(lo, hi + 1, 2):
+        j = min_powers(n, byk, is_p, kmax)
+        if j is None:
+            failures.append(n)
+        else:
+            dist[j] += 1
+            if j == kmax:
+                if smallest_needing_kmax is None:
+                    smallest_needing_kmax = n
+                largest_needing_kmax = n
+    total = len(range(lo, hi + 1, 2))
+    print(f"\n## {label}  (n in [{lo}, {hi}], count = {total})")
+    if failures:
+        print(f"  *** {len(failures)} NOT in S_{kmax}: "
+              f"{failures[:20]}{' ...' if len(failures) > 20 else ''}")
+    else:
+        print(f"  PASS: every listed n is in S_{kmax} (no failure).")
+    for j in range(kmax + 1):
+        print(f"    min {j} power(s): {dist[j]:>8}  ({100.0 * dist[j] / total:5.2f}%)")
+    print(f"  smallest needing exactly {kmax} powers: {smallest_needing_kmax}")
+    print(f"  largest  needing exactly {kmax} powers (in range): {largest_needing_kmax}")
+    return dist, failures
+
+
+def main():
+    N_ODD = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000_000
+    N_EVEN = int(sys.argv[2]) if len(sys.argv) > 2 else 1_000_000
+    N = max(N_ODD, N_EVEN)
+    print(f"# Granville-Soundararajan oq-02 evidence  (N_ODD={N_ODD}, N_EVEN={N_EVEN})")
+    is_p = sieve(N)
+    byk = offsets_by_popcount(N, 3)
+
+    # E1: odd side
+    sweep(3, N_ODD if N_ODD % 2 == 1 else N_ODD - 1, byk, is_p,
+          "E1 ODD sweep (GS-odd, k=3)", kmax=3)
+    # extra: does <=2 already suffice for all odd in range?
+    odd_not_S2 = [n for n in range(3, (N_ODD if N_ODD % 2 else N_ODD - 1) + 1, 2)
+                  if min_powers(n, {0: byk[0], 1: byk[1], 2: byk[2]}, is_p, 2) is None]
+    print(f"  [odd] count NOT in S_2 (would need the 3rd power): {len(odd_not_S2)} "
+          f"{odd_not_S2[:8]}")
+    print(f"  [odd] => in this range <=2 powers always suffice; the necessity of")
+    print(f"         k=3 over k=2 (Crocker 1971) is beyond brute-force reach.")
+
+    # E2: even side -- this is where S_3 is genuinely exercised
+    sweep(2, N_EVEN if N_EVEN % 2 == 0 else N_EVEN - 1, byk, is_p,
+          "E2 EVEN sweep (k=3 boundary)", kmax=3)
+
+    # E3: Grechuk
+    print(f"\n## E3 Grechuk counterexample (even, k=3)")
+    G = 1117175146
+    ok3, j3 = in_S_k_big(G, 3)
+    ok4, j4 = in_S_k_big(G, 4)
+    print(f"  {G}: even, popcount={bin(G).count('1')}")
+    print(f"    in S_3 ? {ok3}" + ("" if ok3 else "  <-- confirms Grechuk: NOT in S_3"))
+    print(f"    in S_4 ? {ok4}" + (f" (min {j4} powers)" if ok4 else "  (would break GS-even!)"))
+
+    print("\n# done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -1,0 +1,59 @@
+{
+  "slug": "erdos-10-oq-02",
+  "title": "Granville–Soundararajan conjecture (k = 3 for odd integers)",
+  "status": "in-progress",
+  "phase": "ORIENT",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 4,
+  "started": "2026-06-15T06:02:35Z",
+  "lastUpdate": "2026-06-15T06:02:35Z",
+  "path": "research/problems/erdos-10-oq-02",
+  "tags": [
+    "number-theory",
+    "additive-combinatorics",
+    "primes",
+    "powers-of-2",
+    "open-conjecture",
+    "gallery-extracted",
+    "seeker-selected"
+  ],
+  "problemStatement": "Is the Granville–Soundararajan conjecture true: is every odd integer n > 1 a sum of a prime and at most 3 powers of 2 (n = p + 2^{a_1} + ... + 2^{a_j}, p prime, j ≤ 3)? The companion even part conjectures at most 4 powers suffice for even n. Both open (Granville–Soundararajan 1998).",
+  "knownResults": {
+    "proven": [
+      "Reduction lemma: m is a sum of at most k powers of 2 (multiset of exponents, size ≤ k) iff popcount(m) ≤ k; hence n ∈ S_k ⟺ ∃ m, popcount(m) ≤ k ∧ n−m ≥ 2 ∧ (n−m) prime.",
+      "Gallagher (1975): for any ε>0 there is k(ε) with lowerDensity(S_k) ≥ 1−ε (best unconditional result).",
+      "Crocker (1971): infinitely many odd n are NOT in S_2 — the reason k=3 (not 2) is needed on the odd side; witnesses are very large (covering systems).",
+      "Grechuk: 1117175146 (even) ∉ S_3 — k=3 cannot extend to all integers."
+    ],
+    "open": [
+      "GS-odd: every odd n > 1 is in S_3 (this question).",
+      "GS-even: every even n ≥ 2 is in S_4.",
+      "Erdős–Graham: no finite k makes {n>1} ⊆ S_k."
+    ],
+    "goal": "Decide GS-odd. Near-term realistic target: formalize the popcount reduction lemma and a Decidable membership for sumPrimeAndTwoPows in Lean, enabling decide/native_decide on concrete witnesses."
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (build-free; Docker + Lean unavailable). Established the popcount≤k reduction characterizing S_k membership, and ran a reproducible experiment. ODD side: every odd n ≤ 10^6 ∈ S_3, but only trivially — ≤2 powers always suffice in range (no odd n leaves S_2 up to 3·10^6), so direct small-N data is weak evidence for GS-odd; the k=3-over-k=2 necessity (Crocker) lives at scales beyond brute force. EVEN side genuinely exercises S_3: ~5.6% of even n need exactly 3 powers (smallest = 906), all even n ≤ 10^6 ∈ S_3, first known even failure is Grechuk's 1117175146 (∈ S_4, ∉ S_3). The +1-power parity offset between odd and even is visible directly in the data, matching the conjecture's k=3 (odd) vs k=4 (even) structure.",
+    "builtItems": [
+      "research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py — stdlib+sympy experiment (odd/even sweeps via the popcount reduction, minimal-#powers distributions, Grechuk check)."
+    ],
+    "insights": [
+      "S_k membership reduces to popcount(m) ≤ k offsets: n ∈ S_k ⟺ ∃ m with popcount(m) ≤ k and (n−m) prime, n−m ≥ 2.",
+      "Brute force confirms GS-odd only trivially: every odd n ≤ 3·10^6 is already in S_2, so the third power is never needed in range. Crocker's odd ∉ S_2 witnesses are astronomically large.",
+      "The even side is where S_3 is genuinely tested: smallest even n needing exactly 3 powers is 906; ~5.6% of even n need exactly 3; all even n ≤ 10^6 ∈ S_3.",
+      "Parity offset is explicit: in range, odd n need ≤2 powers and even n need ≤3 — the same +1 gap GS conjectures (k=3 odd vs k=4 even). Subtracting one even power from odd n leaves an odd candidate for primality; even n must first spend a power to fix parity.",
+      "Grechuk's 1117175146 confirmed ∉ S_3 and ∈ S_4 (popcount 16)."
+    ],
+    "mathlibGaps": [
+      "No Decidable instance wired for sumPrimeAndTwoPows / IsPrimePlusKPowers; the popcount reduction would supply one.",
+      "Crocker (1971) and Gallagher (1975) results are documented in source comments only, not formalized."
+    ],
+    "nextSteps": [
+      "ACT (Docker-gated): formalize the popcount≤k reduction lemma and a Decidable membership for sumPrimeAndTwoPows; discharge the 906 / Grechuk witnesses by decide/native_decide.",
+      "Add Crocker (1971) citation to the gallery as the precise reason k=3 (not 2) is required on the odd side.",
+      "GS-odd itself needs sieve/large-sieve machinery (Gallagher line) — out of brute-force and near-term Lean reach."
+    ],
+    "markdown": "See research/problems/erdos-10-oq-02/knowledge.md for the full write-up (reduction lemma, experiment results, parity structure, references)."
+  }
+}


### PR DESCRIPTION
## Summary

Opens the seeker stub **erdos-10-oq-02** (child of Erdős #10, *sums of a prime and
powers of 2*): *Is the Granville–Soundararajan conjecture (k = 3 for odd n > 1) true?*
The conjecture is **open**; this is an honest ORIENT, not a proof.

Build-free (Docker + Lean unavailable this session). Three new files, no overlap with
existing gallery/research files.

## Contributions

- **Reduction lemma.** `m` is a sum of ≤ `k` powers of 2 **⟺** `popcount(m) ≤ k`.
  Hence `n ∈ S_k ⟺ ∃ m, popcount(m) ≤ k ∧ (n−m) ≥ 2 ∧ (n−m) prime`. Elementary,
  self-contained, and the natural ACT target — it gives a `Decidable` membership for
  the existing `sumPrimeAndTwoPows` / `IsPrimePlusKPowers` definitions.

- **Reproducible experiment** (`verify_granville_soundararajan_odd.py`, stdlib + sympy):
  - **Odd:** every odd `n ≤ 10⁶` ∈ `S_3` — but only *trivially*: ≤ 2 powers always
    suffice in range (no odd `n` leaves `S_2` up to `3·10⁶`).
    ⚠️ Honest caveat: this is **weak** evidence for GS-odd. The reason `k = 3` (not 2)
    is conjectured is **Crocker (1971)** — infinitely many odd `n ∉ S_2` — whose
    witnesses arise from covering systems and are far beyond brute force.
  - **Even:** genuinely exercises `S_3`: ~5.6% of even `n` need exactly 3 powers
    (smallest = **906**); all even `n ≤ 10⁶` ∈ `S_3`.
  - **Grechuk's** `1117175146` confirmed ∉ `S_3`, ∈ `S_4`.

- **Parity structure** visible directly in the data: odd `n` need ≤ 2 powers, even
  `n` need ≤ 3 in range — exactly the `k = 3` (odd) vs `k = 4` (even) offset GS
  conjectures.

## What this does NOT claim

The conjecture remains open. Small-N data confirms GS-odd only in a regime where the
third power is never required, so it does not stress the conjecture's content. No Lean
file is added (Docker unavailable → unverifiable); the popcount reduction is documented
as the next-step ACT target.

## Test plan

- [x] `python3 research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py 1000000 1000000` — odd/even sweeps pass, Grechuk confirmed
- [x] `jq empty src/data/research/problems/erdos-10-oq-02.json` — valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)