### PR TITLE
research(erdos-1047-oq-02): lemniscate convexity via boundary curvature — multiplicity-driven pre-merge necking

### DIFF
--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -1,0 +1,119 @@
+# erdos-1047-oq-02: Characterize which polynomials have all convex lemniscate components
+
+Parent: Erdős #1047 (Grunsky / Erdős–Herzog–Piranian). Solved = NO: not all
+components of {z : |f(z)| ≤ c} need be convex, even in the regime where the
+sublevel set has exactly m = (#distinct roots) connected components. Counter-
+examples: Pommerenke (1961) f = zᵏ(z−a) for large k; Goodman (1966)
+f = (z²+1)(z−2)²; a referee's f = z(z⁵−1).
+
+OQ-02 asks for a **characterization** of the polynomials all of whose lemniscate
+components are convex (open in full generality).
+
+---
+
+## Session 2026-06-14 (Session 1) — FRESH, ORIENT
+
+**Mode:** FRESH. **Outcome:** progress (durable numerical results + tooling).
+
+### The right tool: boundary signed curvature, not area defect
+
+A prior session (R4, erdos-1047 parent) used a convex-hull **area-defect** grid
+metric and got inconclusive results — that metric is blind to sub-grid concavity.
+The correct, sensitive test is the **signed curvature of the boundary curve**.
+
+For g(x,y) = |f(x+iy)|² (real, smooth, with ∇g ≠ 0 on the boundary since |f|=c>0
+there), the component boundary is the level set {g = c}, and the curvature,
+calibrated so that a sublevel *disk* {g ≤ c} has κ > 0, is
+
+    κ = ( gₓ² g_yy − 2 gₓ g_y g_xy + g_y² gₓₓ ) / (gₓ² + g_y²)^{3/2}.
+
+A component K of {g ≤ c} is **convex ⟺ κ ≥ 0 on all of ∂K**. Calibration check:
+for g = x²+y² the numerator = 8(x²+y²) > 0 (disk is convex). Verified: the unit
+circle gives κ = +1.000 exactly.
+
+Two **independent** implementations were built and cross-validated:
+1. grid marching-squares contour + Newton-projection onto {g=c} + analytic κ
+   (complex form: gₓ = 2 Re(f̄ f′), g_y = −2 Im(f̄ f′), etc.);
+2. grid-free / contour-free **polar trace** r(θ) by 1-D root finding of
+   |f(r e^{iθ})| = c, then the exact polar-convexity test r² + 2r′² − r r″ ≥ 0.
+Both methods agree on every case tested.
+
+### Key findings
+
+**(A) Low-degree / simple-root polynomials: all components convex up to merge.**
+- deg 2 Cassini f = z²−1 (roots ±1): both separate components convex for all
+  c < c* = 1 (the merge value); κ_min → 0⁺ as c → c*⁻, never negative.
+- deg 3 f = z³−z (three simple roots): all three components convex throughout the
+  3-component regime, κ_min → 0⁺ at merge.
+⇒ Strong evidence: simple-root configurations of low degree are all-convex.
+
+**(B) The non-convexity is a PRE-MERGE NECKING driven by root multiplicity.**
+For Pommerenke f = zᵏ(z−a) the component around the multiplicity-k root at 0
+develops a non-convex dimple **on the side facing a** (dimple angle ≈ 0), inside
+a c-window (c_nc, c*) just below the merge threshold c*. While in this window the
+sublevel set still has m = 2 separate components, so this is a genuine
+counterexample to Grunsky in the m-component regime.
+
+The **relative width** W(k) = (c* − c_nc)/c* of the non-convex window grows
+monotonically with multiplicity k and is — strikingly — **essentially
+independent of the inter-root distance a** (identical to 3 decimals at a=1.0
+and a=1.3), so W(k) is an *intrinsic function of the multiplicity*:
+
+| k (mult)      | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 |
+|---------------|---|---|---|---|---|---|---|----|
+| W(k) (a=1.0)  | 0.000% | 0.048% | 0.341% | 0.926% | 1.754% | 2.767% | 5.168% | 7.854% |
+| W(k) (a=1.3)  | 0.000% | 0.048% | 0.341% | 0.926% | 1.754% | 2.767% | 5.168% | 7.854% |
+
+- k = 1 (simple root): W = 0 — convex through the entire separated regime up to merge.
+- k = 2 (double root): W ≈ 0.05% — only at the instant of merging (matches Goodman, see (C)).
+- k = 3, 4: thin sliver (W ≈ 0.3–0.9%) right below c*.
+- k ≥ 5–6: a robust window (W ≳ 1.8%; component non-convex at, e.g., 0.97 c*),
+  matching Pommerenke's original "large k" statement. Dimple depth also grows
+  monotonically: worst κ ≈ −0.7 (k=5), ≈ −1.3 (k=7), ≈ −5.6 (k=10) near merge.
+
+(Window widths W(k) = (c*−c_nc)/c* computed by bisection in `window_width.py`;
+c* = max_{0<r<a} rᵏ|r−a| is the on-axis barrier height = merge threshold.)
+
+**(C) The gallery's Goodman example needs scrutiny.**
+For f = (z²+1)(z−2)² at the stated c = 5^{3/2}/4 ≈ 2.795, the sensitive curvature
+test finds **all three components convex** (κ_min ≈ 1.25 around the double root
+z=2, κ_min ≈ 5.2 around ±i). Note 5^{3/2}/4 sits essentially at the component-
+merge threshold (components merge to one just above it), and the only multiple
+root of Goodman's polynomial is a **double** root (k=2) — exactly the regime where
+finding (B) predicts at most a razor-thin necking window. The referee example
+f = z(z⁵−1) (all simple roots, deg 6) likewise tests all-convex at the stated c.
+⇒ The classical counterexamples are real (Pommerenke, large k), but the gallery's
+specific Goodman/referee (f, c) pairs do **not** exhibit a non-convex *separate*
+component under a sensitive boundary-curvature test. This corroborates the prior
+session's suspicion that those specific values are mis-stated or at-merge. The
+clean, reproducible counterexample is Pommerenke zᵏ(z−a) with k ≥ 5.
+
+### Toward the characterization (partial)
+
+Evidence points to: a component around a root of multiplicity k is convex
+throughout the separated regime **iff** k is small relative to the geometry; the
+mechanism is a dimple facing the nearest other root that sharpens as c → c* and
+as k grows. A precise characterization likely combines (i) per-root multiplicity
+and (ii) inter-root distances controlling how close c can get to merge while
+components stay separate. Simple-root, well-separated configurations are
+all-convex; high-multiplicity roots force non-convex necking before merge.
+
+### Files
+
+- `research/problems/erdos-1047-oq-02/verify_lemniscate_curvature.py` — grid+contour curvature test (calibrated, Newton-projected).
+- `research/problems/erdos-1047-oq-02/pommerenke_scan.py` — analytic complex-curvature, merge-threshold bisection, Pommerenke sweep.
+- `research/problems/erdos-1047-oq-02/onset_refine.py` — full c-scan, dimple location.
+- `research/problems/erdos-1047-oq-02/robustness_check.py` — independent grid-free polar-trace cross-check.
+- `research/problems/erdos-1047-oq-02/window_width.py` — non-convex window width W(k).
+
+### Next steps
+
+- Derive analytically the leading harmonic of r(θ) near 0 for zᵏ(z−a) and the
+  convexity threshold |aₙ|(n²+2) > 1 to predict W(k) (the limaçon b ≤ 1/2 bound
+  is the n=1 analogue).
+- Audit the gallery's Goodman/referee (f, c): check against Goodman (1966)
+  primary source; the gallery may need a corrected c or a switch to a clean
+  Pommerenke k ≥ 5 example with a computed κ < 0 (addresses the gallery's own
+  open question "make counterexamples explicit with computed convexity violations").
+- Lean: convexity of level sets is heavy real analysis; defer. The decidable,
+  checkable artifact here is the curvature certificate, not a Lean proof.

--- a/research/problems/erdos-1047-oq-02/onset_refine.py
+++ b/research/problems/erdos-1047-oq-02/onset_refine.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Pin down the ONSET multiplicity k for non-convex separate components in
+Pommerenke's family f(z)=z^k(z-a), and locate the dimple.
+
+For each k, scan c across the ENTIRE 2-component regime (0, c*) and report the
+most-negative convex-calibrated curvature found on the component around 0, plus
+the argument (angle) of the dimple point. Uses the analytic complex-curvature
+machinery from pommerenke_scan.py.
+"""
+import numpy as np
+from scipy import ndimage
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from pommerenke_scan import make_g, curvature_on_curve, newton, find_merge
+
+
+def worst_curv_around_zero(roots, mult, c, R, res=900):
+    f, fp, fpp = make_g(roots, mult)
+    xs = np.linspace(-R, R, res); ys = np.linspace(-R, R, res)
+    X, Y = np.meshgrid(xs, ys); Z = X + 1j * Y
+    G = np.abs(f(Z)) ** 2
+    cs = plt.contour(X, Y, G, levels=[c])
+    a = roots[1]
+    best = (np.inf, None, None)
+    ncomp = ndimage.label(G <= c)[1]
+    for seg in cs.allsegs[0]:
+        if len(seg) < 10:
+            continue
+        pts = seg[:, 0] + 1j * seg[:, 1]
+        # is this the loop around 0? check it encircles 0 not a
+        cen = pts.mean()
+        if abs(cen - 0) > abs(cen - a):
+            continue
+        pts = newton(pts, f, fp, c)
+        k = curvature_on_curve(pts, f, fp, fpp)
+        i = np.nanargmin(k)
+        if k[i] < best[0]:
+            best = (float(k[i]), float(np.angle(pts[i])), float(abs(pts[i])))
+    plt.close("all")
+    return ncomp, best
+
+
+def onset(k, a=1.0):
+    roots = [0.0, a]; mult = [k, 1]
+    R = max(1.6 * a, 1.3)
+    cstar = find_merge(roots, mult, R, 2, 1e-10, (a ** k) * a * 0.95, res=600)
+    worst = (np.inf, None, None)
+    cw = None
+    for frac in np.linspace(0.10, 0.995, 24):
+        c = cstar * frac
+        nc, b = worst_curv_around_zero(roots, mult, c, R)
+        if nc < 2:
+            continue
+        if b[0] < worst[0]:
+            worst = b; cw = c
+    return cstar, cw, worst
+
+
+if __name__ == "__main__":
+    print("Pommerenke f(z)=z^k(z-a), a=1.0 : onset of non-convex SEPARATE component around 0")
+    print("k = root multiplicity ; degree = k+1 ; dimple angle in units of pi (pi = far side from a)")
+    for k in [3, 4, 5, 6, 7]:
+        cstar, cw, (kmin, ang, rad) = onset(k, a=1.0)
+        deg = k + 1
+        verdict = "NON-CONVEX" if kmin < -1e-2 else "convex"
+        angpi = ang / np.pi if ang is not None else None
+        print(f"  k={k} (deg {deg}): c*={cstar:.5f}  worst_kappa={kmin:+.4f} at c={cw} "
+              f"angle={angpi:.3f}*pi rad={rad:.4f}  -> {verdict}" if ang is not None
+              else f"  k={k} (deg {deg}): c*={cstar:.5f} worst_kappa={kmin:+.4f} -> {verdict}")

--- a/research/problems/erdos-1047-oq-02/pommerenke_scan.py
+++ b/research/problems/erdos-1047-oq-02/pommerenke_scan.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Hunt for a curvature-verified non-convex SEPARATE lemniscate component.
+
+Two questions:
+ (Q1) For low-degree examples (deg 2 Cassini, deg 3 z^3-z), do separate
+      components stay convex right up to the merge threshold? (-> supports a
+      partial characterization)
+ (Q2) Pommerenke's family f(z)=z^k(z-a): for which k,a,c does the component
+      around the multiple root 0 become NON-CONVEX while still separate from
+      the component around a?  This is the canonical Erdos #1047 counterexample;
+      exhibiting it with a computed kappa<0 answers the gallery's open question
+      "make counterexamples explicit with computed convexity violations."
+
+Method: numerically (no symbolics). g=|f|^2 sampled on a grid; components via
+ndimage.label; boundary curvature via finite differences of g, calibrated so a
+disk has kappa>0. We scan c upward, locate the largest c with the desired number
+of separate components (just below merge), and report min curvature per component.
+"""
+import numpy as np
+from scipy import ndimage
+
+
+def make_g(roots, mult):
+    """f(z)=prod (z-r)^m ; return g(x,y)=|f|^2 and its needed partials by AUTODIFF-free
+    finite differences are avoided -- instead use exact complex evaluation + analytic
+    derivative of g via f and f'."""
+    roots = np.array(roots, dtype=complex)
+    mult = np.array(mult, dtype=int)
+
+    def f(z):
+        out = np.ones_like(z, dtype=complex)
+        for r, m in zip(roots, mult):
+            out = out * (z - r) ** m
+        return out
+
+    def fp(z):
+        # f'(z) = f(z) * sum m_i/(z-r_i)
+        s = np.zeros_like(z, dtype=complex)
+        for r, m in zip(roots, mult):
+            s = s + m / (z - r)
+        return f(z) * s
+
+    def fpp(z):
+        # f'' = f * [ (sum m/(z-r))^2 - sum m/(z-r)^2 ]
+        s1 = np.zeros_like(z, dtype=complex)
+        s2 = np.zeros_like(z, dtype=complex)
+        for r, m in zip(roots, mult):
+            s1 = s1 + m / (z - r)
+            s2 = s2 + m / (z - r) ** 2
+        return f(z) * (s1 ** 2 - s2)
+
+    return f, fp, fpp
+
+
+def curvature_on_curve(pts, f, fp, fpp):
+    """Convex-calibrated signed curvature of {g=c} at complex points pts, where g=|f|^2.
+    Using g = f*conj(f). With w=x+iy:
+      g_x = 2 Re(conj(f) f'),  g_y = 2 Re(conj(f) (i f')) = -2 Im(conj(f) f')
+    Let A=conj(f)*f'. g_x=2 Re A, g_y=-2 Im A.
+    Second derivatives (df/dx=f', df/dy=i f'):
+      g_xx = 2 Re(conj(f) f'') + 2 |f'|^2
+      g_yy = 2 Re(conj(f)(i^2 f'')) + 2 |i f'|^2 = -2 Re(conj(f) f'') + 2|f'|^2
+      g_xy = 2 Re(conj(f)(i f'')) + 2 Re(conj(f') (i f')) = -2 Im(conj(f) f'') + 2 Re(i |f'|^2... )
+    Compute carefully numerically instead:
+    """
+    z = pts
+    F = f(z); Fp = fp(z); Fpp = fpp(z)
+    A = np.conj(F) * Fp
+    gx = 2 * A.real
+    gy = -2 * A.imag
+    # df/dx = f', df/dy = i f'
+    # g = F conj(F).  g_xx = 2 Re( conj(F) F_xx + |F_x|^2 ), F_xx=f''
+    gxx = 2 * (np.conj(F) * Fpp).real + 2 * (np.abs(Fp) ** 2)
+    # F_y = i f', F_yy = i^2 f'' = -f''
+    gyy = 2 * (np.conj(F) * (-Fpp)).real + 2 * (np.abs(1j * Fp) ** 2)
+    # g_xy = 2 Re( conj(F) F_xy + conj(F_x) F_y ), F_xy = i f''
+    gxy = 2 * (np.conj(F) * (1j * Fpp)).real + 2 * (np.conj(Fp) * (1j * Fp)).real
+    num = gx ** 2 * gyy - 2 * gx * gy * gxy + gy ** 2 * gxx
+    den = (gx ** 2 + gy ** 2)
+    good = den > 1e-12
+    k = np.full(z.shape, np.nan)
+    k[good] = num[good] / den[good] ** 1.5
+    return k
+
+
+def newton(pts, f, fp, c, steps=5):
+    z = pts.copy()
+    for _ in range(steps):
+        F = f(z)
+        g = (F.real ** 2 + F.imag ** 2) - c
+        A = np.conj(F) * fp(z)
+        gx = 2 * A.real
+        gy = -2 * A.imag
+        n2 = gx ** 2 + gy ** 2
+        n2[n2 < 1e-14] = 1e-14
+        z = z - g * (gx + 1j * gy) / n2
+    return z
+
+
+def components_and_curv(roots, mult, c, R, res=700):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    f, fp, fpp = make_g(roots, mult)
+    xs = np.linspace(-R, R, res); ys = np.linspace(-R, R, res)
+    X, Y = np.meshgrid(xs, ys)
+    Z = X + 1j * Y
+    G = np.abs(f(Z)) ** 2
+    ncomp = ndimage.label(G <= c)[1]
+    cs = plt.contour(X, Y, G, levels=[c])
+    loops = []
+    for seg in cs.allsegs[0]:
+        if len(seg) < 10:
+            continue
+        pts = seg[:, 0] + 1j * seg[:, 1]
+        pts = newton(pts, f, fp, c)
+        k = curvature_on_curve(pts, f, fp, fpp)
+        k = k[np.isfinite(k)]
+        if len(k):
+            loops.append((float(np.min(k)), float(np.max(k)), len(k)))
+    plt.close("all")
+    return ncomp, loops
+
+
+def find_merge(roots, mult, R, target_comps, clo, chi, res=500):
+    """Bisect to find threshold where #components drops below target."""
+    f, _, _ = make_g(roots, mult)
+    xs = np.linspace(-R, R, res); ys = np.linspace(-R, R, res)
+    X, Y = np.meshgrid(xs, ys); Z = X + 1j * Y
+    G = np.abs(f(Z)) ** 2
+    def nc(c):
+        return ndimage.label(G <= c)[1]
+    for _ in range(40):
+        cm = 0.5 * (clo + chi)
+        if nc(cm) >= target_comps:
+            clo = cm
+        else:
+            chi = cm
+    return clo  # largest c with >= target components
+
+
+def scan_just_below_merge(name, roots, mult, R, target, cmax_guess):
+    cstar = find_merge(roots, mult, R, target, 1e-6, cmax_guess)
+    print(f"\n### {name}  roots={roots} mult={mult}")
+    print(f"  merge threshold c* (>= {target} comps below this) ~ {cstar:.6f}")
+    for frac in [0.5, 0.8, 0.95, 0.99, 0.999]:
+        c = cstar * frac
+        ncomp, loops = components_and_curv(roots, mult, c, R)
+        mins = [round(l[0], 4) for l in loops]
+        worst = min((l[0] for l in loops), default=None)
+        tag = "  <<< NON-CONVEX SEPARATE COMPONENT" if (worst is not None and worst < -1e-2) else ""
+        print(f"  c={c:.6f} (={frac} c*) grid_comps={ncomp} loop_min_kappas={mins} worst={worst}{tag}")
+
+
+if __name__ == "__main__":
+    # Q1: low-degree, do separate comps stay convex up to merge?
+    scan_just_below_merge("Cassini z^2-1", [-1, 1], [1, 1], 2.0, 2, 1.5)
+    scan_just_below_merge("z^3-z", [0, 1, -1], [1, 1, 1], 2.0, 3, 0.5)
+
+    # Q2: Pommerenke z^k(z-a). Sweep k and a; look for non-convex comp around 0.
+    print("\n========== POMMERENKE z^k(z-a) SWEEP ==========")
+    for k in [2, 3, 4, 5, 6, 8, 10]:
+        for a in [0.6, 0.8, 1.0, 1.3]:
+            roots = [0.0, a]; mult = [k, 1]
+            R = max(1.6 * a, 1.5)
+            try:
+                cstar = find_merge(roots, mult, R, 2, 1e-9, (a ** k) * a * 0.9)
+                # test just below merge
+                c = cstar * 0.97
+                ncomp, loops = components_and_curv(roots, mult, c, R, res=800)
+                worst = min((l[0] for l in loops), default=None)
+                mins = [round(l[0], 4) for l in loops]
+                tag = "  <<< NON-CONVEX!" if (worst is not None and worst < -1e-2) else ""
+                print(f"  k={k} a={a}: c*~{cstar:.5f} c={c:.5f} comps={ncomp} mins={mins}{tag}")
+            except Exception as e:
+                print(f"  k={k} a={a}: ERR {e}")

--- a/research/problems/erdos-1047-oq-02/robustness_check.py
+++ b/research/problems/erdos-1047-oq-02/robustness_check.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Robustness / resolution check for the curvature-verified non-convex Pommerenke
+component, to rule out saddle-point numerical noise.
+
+Strategy:
+ - Pick a ROBUST case far from numerical danger: large k, large a, so the
+   working c and the curve radius are O(0.1-1), grad g not tiny.
+ - Re-evaluate worst curvature at several grid resolutions; a genuine geometric
+   non-convexity is resolution-stable, saddle noise is not.
+ - Also verify the marginal k=3,4 onset and report whether they survive.
+ - Independent cross-check: parametrize the component-around-0 boundary directly
+   by tracing r(theta) via 1-D root finding of |f(r e^{i theta})|=c (no grid, no
+   contour), then test polar-curve convexity  r^2 + 2 r'^2 - r r'' >= 0.
+"""
+import numpy as np
+from scipy.optimize import brentq
+
+def f_abs(z, k, a):
+    return abs(z)**k * abs(z - a)
+
+def radius_at(theta, c, k, a, rmax):
+    # solve |f(r e^{i th})| = c for the inner (component-around-0) branch
+    g = lambda r: f_abs(r*np.exp(1j*theta), k, a) - c
+    # f_abs(0)=0 < c ; increase r until exceeds c (first crossing = component-around-0 boundary)
+    rs = np.linspace(1e-6, rmax, 4000)
+    vals = np.array([g(r) for r in rs])
+    sign = np.sign(vals)
+    idx = np.where(np.diff(sign) > 0)[0]  # - to +
+    if len(idx) == 0:
+        return None
+    i = idx[0]
+    return brentq(g, rs[i], rs[i+1])
+
+def polar_convexity(c, k, a, rmax, N=2000):
+    th = np.linspace(0, 2*np.pi, N, endpoint=False)
+    r = np.array([radius_at(t, c, k, a, rmax) for t in th])
+    if any(v is None for v in r):
+        return None, None, None
+    r = np.array(r, dtype=float)
+    dt = th[1]-th[0]
+    rp = np.gradient(r, dt)
+    rpp = np.gradient(rp, dt)
+    conv = r**2 + 2*rp**2 - r*rpp     # >=0 everywhere  <=>  convex
+    i = np.argmin(conv)
+    return float(conv.min()), float(th[i]/np.pi), float(r.max()/r.min())
+
+def find_cstar(k, a, rmax):
+    # merge when component-around-0 reaches the saddle on segment (0,a): real axis dip
+    # saddle value: max over r in (0,a) of f_abs(r,k,a) along positive real axis is a local
+    # min of |f| between roots -> that's the saddle barrier height.
+    rs = np.linspace(1e-4, a-1e-4, 20000)
+    vals = rs**k * np.abs(rs - a)
+    return vals.max()  # peak between the two roots = barrier = merge threshold c*
+
+if __name__ == "__main__":
+    print("INDEPENDENT POLAR-TRACE convexity test (no grid / no contour):")
+    print("  conv_min < 0  <=>  component-around-0 is NON-CONVEX")
+    print(f"{'k':>2} {'a':>4} {'c/c*':>6} {'c*':>10} {'c':>10} {'conv_min':>11} {'dimple/pi':>9} {'r_ratio':>7}")
+    for (k, a) in [(3,1.0),(4,1.0),(5,1.0),(6,1.3),(8,1.3),(10,1.3)]:
+        cstar = find_cstar(k, a, 1.6*a)
+        for frac in [0.90, 0.97, 0.999]:
+            c = cstar*frac
+            cm, dimp, rr = polar_convexity(c, k, a, 1.7*a)
+            if cm is None:
+                print(f"{k:>2} {a:>4} {frac:>6} {cstar:>10.5f} {c:>10.5f}   (open/merged)")
+            else:
+                flag = " NON-CONVEX" if cm < -1e-4 else ""
+                print(f"{k:>2} {a:>4} {frac:>6} {cstar:>10.5f} {c:>10.5f} {cm:>11.5f} {dimp:>9.3f} {rr:>7.3f}{flag}")

--- a/research/problems/erdos-1047-oq-02/verify_lemniscate_curvature.py
+++ b/research/problems/erdos-1047-oq-02/verify_lemniscate_curvature.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Boundary signed-curvature test for convexity of polynomial lemniscate components.
+
+Erdős #1047 / OQ-02: characterize which polynomials f have ALL components of
+{z : |f(z)| <= c} convex, in the regime where the sublevel set has exactly
+m = (number of distinct roots) connected components (one per root).
+
+WHY CURVATURE, NOT AREA-DEFECT:
+A previous session used a convex-hull area-defect grid metric. That metric is
+blind to sub-grid concavity (a slightly dented oval can have ~0 hull defect).
+The correct, sensitive tool is the SIGNED CURVATURE of the boundary curve.
+
+For g(x,y) = |f(x+iy)|^2 (a real polynomial, smooth, with grad g != 0 on the
+boundary because |f|=c>0 there), the boundary of a component is the level set
+{g = c}. The signed curvature, calibrated so a sublevel disk {g<=c} is convex
+iff kappa >= 0 everywhere, is
+
+    kappa = ( g_x^2 g_yy - 2 g_x g_y g_xy + g_y^2 g_xx ) / (g_x^2 + g_y^2)^{3/2}
+
+Calibration check: for g = x^2+y^2 (a disk) the numerator = 8(x^2+y^2) > 0, so
+kappa > 0 -- correct, a disk is convex.
+
+A connected component K of {g<=c} is convex  <=>  kappa >= 0 on all of dK.
+Equivalently min over dK of kappa is >= 0 (up to numerical tolerance).
+
+The contour vertices produced by marching squares are pushed exactly onto
+{g=c} by a few Newton steps along grad g before curvature is evaluated, so the
+reported curvature is the EXACT analytic curvature at points that genuinely lie
+on the level set -- no grid noise in the curvature value itself.
+"""
+import sys
+import numpy as np
+import sympy as sp
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy import ndimage
+
+x, y = sp.symbols("x y", real=True)
+
+
+def build_g(coeffs):
+    """coeffs = real coefficients of f, highest degree first. Returns g=|f|^2 and lambdified derivatives."""
+    z = x + sp.I * y
+    f = sum(sp.Rational(c) * z**(len(coeffs) - 1 - k) for k, c in enumerate(coeffs))
+    f = sp.expand(f)
+    g = sp.expand(sp.re(f) ** 2 + sp.im(f) ** 2)
+    gx = sp.diff(g, x)
+    gy = sp.diff(g, y)
+    gxx = sp.diff(g, x, 2)
+    gyy = sp.diff(g, y, 2)
+    gxy = sp.diff(g, x, y)
+    num = gx**2 * gyy - 2 * gx * gy * gxy + gy**2 * gxx
+    den = (gx**2 + gy**2)
+    funcs = {
+        "g": sp.lambdify((x, y), g, "numpy"),
+        "gx": sp.lambdify((x, y), gx, "numpy"),
+        "gy": sp.lambdify((x, y), gy, "numpy"),
+        "num": sp.lambdify((x, y), num, "numpy"),
+        "den": sp.lambdify((x, y), den, "numpy"),
+    }
+    return funcs
+
+
+def newton_to_level(funcs, px, py, c, steps=4):
+    """Push (px,py) onto {g=c} along grad g."""
+    for _ in range(steps):
+        gv = funcs["g"](px, py) - c
+        gx = funcs["gx"](px, py)
+        gy = funcs["gy"](px, py)
+        nrm2 = gx * gx + gy * gy
+        if nrm2 < 1e-14:
+            break
+        px = px - gv * gx / nrm2
+        py = py - gv * gy / nrm2
+    return px, py
+
+
+def kappa(funcs, px, py):
+    den = funcs["den"](px, py)
+    if den < 1e-14:
+        return None
+    return funcs["num"](px, py) / den ** 1.5
+
+
+def count_components(funcs, c, R, res=600):
+    """Number of connected components of {g<=c} on [-R,R]^2."""
+    xs = np.linspace(-R, R, res)
+    ys = np.linspace(-R, R, res)
+    X, Y = np.meshgrid(xs, ys)
+    G = funcs["g"](X, Y)
+    mask = G <= c
+    _, n = ndimage.label(mask)
+    return n
+
+
+def min_curvature(funcs, c, R, res=900):
+    """Extract level set {g=c}, return per-loop minimum convex-calibrated curvature."""
+    xs = np.linspace(-R, R, res)
+    ys = np.linspace(-R, R, res)
+    X, Y = np.meshgrid(xs, ys)
+    G = funcs["g"](X, Y)
+    cs = plt.contour(X, Y, G, levels=[c])
+    loops = []
+    # matplotlib >=3.8: allsegs
+    segs = cs.allsegs[0]
+    for seg in segs:
+        if len(seg) < 8:
+            continue
+        ks = []
+        for (px, py) in seg:
+            rx, ry = newton_to_level(funcs, px, py, c)
+            k = kappa(funcs, rx, ry)
+            if k is not None:
+                ks.append(k)
+        if ks:
+            loops.append((min(ks), max(ks), len(ks)))
+    plt.close("all")
+    return loops
+
+
+def analyze(name, coeffs, c, R, expect):
+    funcs = build_g(coeffs)
+    ncomp = count_components(funcs, c, R)
+    loops = min_curvature(funcs, c, R)
+    print(f"\n=== {name} ===")
+    print(f"  coeffs={coeffs}  c={c:.6f}  region components(grid)={ncomp}")
+    overall_min = None
+    for i, (kmin, kmax, npts) in enumerate(loops):
+        flag = "NON-CONVEX" if kmin < -1e-3 else "convex"
+        print(f"  loop {i}: min_kappa={kmin:+.5f}  max_kappa={kmax:+.5f}  pts={npts}  -> {flag}")
+        overall_min = kmin if overall_min is None else min(overall_min, kmin)
+    verdict = "ALL CONVEX" if (overall_min is not None and overall_min >= -1e-3) else "HAS NON-CONVEX COMPONENT"
+    print(f"  VERDICT: {verdict}   (expected: {expect})")
+    return verdict
+
+
+def calibrate():
+    # circle g=x^2+y^2, c=1 -> single convex loop, kappa ~ +1
+    funcs = build_g([1, 0, 0])  # f=z^2? no. Use f=z: coeffs=[1,0]-> g=x^2+y^2
+    funcs = build_g([1, 0])  # f(z)=z, g=|z|^2=x^2+y^2
+    loops = min_curvature(funcs, 1.0, 2.0)
+    print("CALIBRATION (unit circle, expect kappa ~ +1.0):")
+    for (kmin, kmax, n) in loops:
+        print(f"  min={kmin:+.5f} max={kmax:+.5f} pts={n}")
+
+
+if __name__ == "__main__":
+    calibrate()
+
+    # Degree 2 Cassini: f=z^2-1, roots +-1. Separated regime c<1 -> expect ALL CONVEX.
+    analyze("Cassini deg2 z^2-1, c=0.5 (separated)", [1, 0, -1], 0.5, 2.0, "ALL CONVEX")
+    analyze("Cassini deg2 z^2-1, c=0.9 (near merge)", [1, 0, -1], 0.9, 2.0, "ALL CONVEX")
+
+    # Goodman (z^2+1)(z-2)^2 = (z^2+1)(z^2-4z+4). Expand:
+    # = z^4 -4z^3 +4z^2 + z^2 -4z +4 = z^4 -4z^3 +5z^2 -4z +4
+    cgood = 5 ** 1.5 / 4
+    for cc in [2.5, 2.7, 2.75, 2.78, cgood, 2.80]:
+        analyze(f"Goodman (z^2+1)(z-2)^2, c={cc:.4f}", [1, -4, 5, -4, 4], cc, 4.0, "HAS NON-CONVEX (around z=2)")
+
+    # Referee z(z^5-1)=z^6-z, c=5.6^{-6/5}
+    cref = 5.6 ** (-6 / 5)
+    analyze(f"Referee z(z^5-1), c={cref:.5f}", [1, 0, 0, 0, 0, -1, 0], cref, 1.5, "HAS NON-CONVEX")
+
+    # Degree 3 all simple roots, symmetric: f=z^3-z=z(z-1)(z+1). Scan c in 3-comp regime.
+    print("\n### Degree-3 all-simple-root scan f=z^3-z (probing Goodman 'min degree, simple roots') ###")
+    funcs3 = build_g([1, 0, -1, 0])
+    for cc in [0.1, 0.2, 0.3, 0.35, 0.38]:
+        n = count_components(funcs3, cc, 2.0)
+        loops = min_curvature(funcs3, cc, 2.0)
+        mk = min((l[0] for l in loops), default=None)
+        print(f"  c={cc:.3f} comps={n} min_kappa={mk:+.5f}" if mk is not None else f"  c={cc:.3f} comps={n} (no loops)")

--- a/research/problems/erdos-1047-oq-02/window_width.py
+++ b/research/problems/erdos-1047-oq-02/window_width.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Map the NON-CONVEX WINDOW width vs root multiplicity for Pommerenke f=z^k(z-a).
+
+For each k, find c_nc = smallest c at which the component-around-0 first becomes
+non-convex (polar-trace convexity test), and report the relative window width
+W(k) = (c* - c_nc)/c*  where c* is the merge threshold.
+
+W(k) ~ 0  => non-convexity only at the instant of merging (not a robust separate
+             counterexample)
+W(k) >> 0 => a robust band of c with a non-convex SEPARATE component (genuine
+             Erdos #1047 counterexample in the m-component regime).
+"""
+import numpy as np
+from scipy.optimize import brentq
+
+def f_abs(z, k, a):
+    return abs(z)**k * abs(z - a)
+
+def radius_at(theta, c, k, a, rmax):
+    g = lambda r: f_abs(r*np.exp(1j*theta), k, a) - c
+    rs = np.linspace(1e-7, rmax, 5000)
+    vals = rs**k * np.abs(rs*np.exp(1j*theta) - a) - c
+    sign = np.sign(vals)
+    idx = np.where(np.diff(sign) > 0)[0]
+    if len(idx) == 0:
+        return None
+    i = idx[0]
+    return brentq(g, rs[i], rs[i+1])
+
+def conv_min(c, k, a, rmax, N=1500):
+    th = np.linspace(0, 2*np.pi, N, endpoint=False)
+    r = []
+    for t in th:
+        v = radius_at(t, c, k, a, rmax)
+        if v is None:
+            return None
+        r.append(v)
+    r = np.array(r)
+    dt = th[1]-th[0]
+    rp = np.gradient(r, dt); rpp = np.gradient(rp, dt)
+    return float((r**2 + 2*rp**2 - r*rpp).min())
+
+def cstar(k, a):
+    rs = np.linspace(1e-5, a-1e-5, 50000)
+    return float((rs**k * np.abs(rs - a)).max())
+
+def window(k, a):
+    cs = cstar(k, a)
+    rmax = 1.8*a
+    # bisect for c_nc in (lo, cs): convex below, nonconvex near cs
+    lo, hi = 0.3*cs, cs*(1-1e-7)
+    # ensure hi is nonconvex
+    if conv_min(hi, k, a, rmax) >= 0:
+        return cs, None, 0.0   # never nonconvex even at merge
+    # ensure lo is convex
+    if conv_min(lo, k, a, rmax) < 0:
+        lo = 0.05*cs
+    for _ in range(28):
+        mid = 0.5*(lo+hi)
+        cm = conv_min(mid, k, a, rmax)
+        if cm is None or cm >= 0:
+            lo = mid
+        else:
+            hi = mid
+    c_nc = hi
+    return cs, c_nc, (cs - c_nc)/cs
+
+if __name__ == "__main__":
+    print("Pommerenke z^k(z-a): non-convex window of the component around the mult-k root")
+    print(f"{'k':>2} {'a':>4} {'c*':>10} {'c_nc':>10} {'W=(c*-c_nc)/c*':>15}")
+    for a in [1.0, 1.3]:
+        for k in [1, 2, 3, 4, 5, 6, 8, 10]:
+            cs, c_nc, W = window(k, a)
+            cncs = f"{c_nc:.6f}" if c_nc is not None else "   --   "
+            print(f"{k:>2} {a:>4} {cs:>10.6f} {cncs:>10} {W*100:>13.3f}%")
+        print()

--- a/src/data/research/problems/erdos-1047-oq-02.json
+++ b/src/data/research/problems/erdos-1047-oq-02.json
@@ -1,0 +1,50 @@
+{
+  "slug": "erdos-1047-oq-02",
+  "title": "Characterize which polynomials have all convex lemniscate components",
+  "problemStatement": "Erdős #1047 (Grunsky / Erdős–Herzog–Piranian) asks whether every connected component of {z : |f(z)| ≤ c} is convex in the regime where there are m = (#distinct roots) components. The answer is NO (Pommerenke 1961, Goodman 1966). OQ-02 asks to characterize the polynomials all of whose lemniscate components are convex.",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 5,
+  "status": "in-progress",
+  "phase": "ORIENT",
+  "path": "research",
+  "tags": ["complex-analysis", "lemniscates", "convexity", "gallery-extracted", "seeker-selected"],
+  "started": "2026-06-14T00:00:00Z",
+  "lastUpdate": "2026-06-14T00:00:00Z",
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-14T00:00:00Z",
+    "iteration": 1,
+    "focus": "Built a boundary signed-curvature convexity test (two independent implementations). Found the non-convexity is a pre-merge necking on the side facing the nearest other root, in a window (c_nc, c*) below the merge threshold; window width W(k) grows monotonically with root multiplicity and is independent of inter-root distance. Simple-root low-degree configs are all-convex through merge. Gallery's Goodman/referee (f,c) pairs test all-convex; clean counterexample is Pommerenke z^k(z-a), k≥5."
+  },
+  "knownResults": [
+    "Grunsky conjecture (all components convex) is FALSE — Pommerenke (1961), Goodman (1966).",
+    "Near a root of multiplicity k, |f| ≈ const·|z−root|^k, locally a circle (convex) for small enough c."
+  ],
+  "knowledge": {
+    "insights": [
+      "Correct convexity test is boundary SIGNED CURVATURE κ = (gₓ²g_yy − 2gₓg_y g_xy + g_y²gₓₓ)/(gₓ²+g_y²)^{3/2} for g=|f|², calibrated so a disk has κ>0 (κ=+1 on the unit circle); a component {g≤c} is convex ⟺ κ≥0 on its boundary. The convex-hull area-defect metric used previously is blind to sub-grid concavity.",
+      "Non-convexity of a lemniscate component is a PRE-MERGE NECKING: as c→c*⁻ (merge threshold) the component around a root stretches toward the nearest other root and dimples on the side facing it. The dimple angle is ≈0 (toward the other root).",
+      "For Pommerenke f=z^k(z−a), the non-convex window W(k)=(c*−c_nc)/c* grows monotonically with multiplicity k and is essentially INDEPENDENT of inter-root distance a: W = 0% (k=1), 0.05% (k=2), 0.34% (k=3), 0.93% (k=4), 1.75% (k=5), 2.77% (k=6), 5.17% (k=8), 7.85% (k=10). So W(k) is an intrinsic function of multiplicity.",
+      "Simple-root low-degree configs (deg-2 Cassini z²−1, deg-3 z³−z) keep ALL components convex through the entire separated regime (κ_min→0⁺ at merge, never negative).",
+      "The merge threshold for z^k(z−a) is c* = max_{0<r<a} r^k|r−a| (the on-axis barrier height between the two roots).",
+      "The gallery's stated Goodman example (z²+1)(z−2)² at c=5^{3/2}/4 tests ALL CONVEX under the sensitive curvature test (κ_min≈1.25 around the double root); 5^{3/2}/4 sits at the merge threshold and the only multiple root is double (k=2, W≈0.05%). The referee example z(z⁵−1) (all simple roots) also tests all-convex. The clean reproducible counterexample is Pommerenke z^k(z−a) with k≥5."
+    ],
+    "builtItems": [
+      "research/problems/erdos-1047-oq-02/verify_lemniscate_curvature.py — grid+contour curvature test, Newton-projected onto {g=c}, calibrated on the unit circle.",
+      "research/problems/erdos-1047-oq-02/pommerenke_scan.py — analytic complex-curvature, merge-threshold bisection, Pommerenke k×a sweep.",
+      "research/problems/erdos-1047-oq-02/onset_refine.py — full c-scan and dimple localization.",
+      "research/problems/erdos-1047-oq-02/robustness_check.py — independent grid-free polar-trace cross-check (r(θ) root-finding + r²+2r′²−rr″≥0).",
+      "research/problems/erdos-1047-oq-02/window_width.py — bisection map of non-convex window W(k)."
+    ],
+    "mathlibGaps": [
+      "Convexity of polynomial level sets / lemniscate components is heavy real analysis (curvature of implicit curves); no direct Mathlib support. A Lean formalization is deferred — the checkable artifact here is the numerical curvature certificate, not a Lean proof."
+    ],
+    "nextSteps": [
+      "Derive analytically the leading harmonic of r(θ) near a multiplicity-k root for z^k(z−a) and the convexity threshold |aₙ|(n²+2)>1 (limaçon b≤1/2 is the n=1 analogue) to predict W(k).",
+      "Audit the gallery's Goodman/referee (f,c) against Goodman (1966); consider a corrected c or switching to a clean Pommerenke k≥5 example with a computed κ<0 (answers the gallery's open question 'make counterexamples explicit with computed convexity violations').",
+      "Extend to general multiplicity profiles + inter-root distances to sharpen the characterization (simple+separated ⇒ all-convex; high-multiplicity ⇒ pre-merge necking)."
+    ],
+    "progressSummary": "PROGRESS: built a sensitive boundary-curvature convexity test (2 independent methods, cross-validated); characterized non-convexity as pre-merge necking with multiplicity-controlled window W(k) (a-independent); flagged the gallery's Goodman/referee (f,c) as testing all-convex, with Pommerenke z^k(z−a) k≥5 the clean counterexample."
+  }
+}


### PR DESCRIPTION
## Summary

ORIENT session on **erdos-1047-oq-02** ("Characterize which polynomials have all
convex lemniscate components"; parent Erdős #1047 / Grunsky, solved = NO).

Builds the **correct convexity tool** — boundary **signed curvature** of the level
set {g=c}, g=|f|² (a prior session used a convex-hull area-defect metric that is
blind to sub-grid concavity). Two **independent** implementations, cross-validated:
1. grid marching-squares contour + Newton projection onto {g=c} + analytic κ;
2. grid-free **polar trace** r(θ) by 1-D root finding + exact r²+2r′²−rr″ ≥ 0.
Both calibrated to κ = +1.000 on the unit circle.

## Findings

- **Non-convexity = pre-merge necking.** A component dimples on the side facing
  the nearest other root, in a window (c_nc, c*) just below the merge threshold
  c*. While in this window the sublevel set still has m separate components, so it
  is a genuine Grunsky counterexample in the m-component regime.
- **Window width W(k) = (c*−c_nc)/c* is monotonic in root multiplicity k and
  independent of inter-root distance a** (identical to 3 decimals at a=1.0, 1.3):

  | k | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 |
  |---|---|---|---|---|---|---|---|----|
  | W(k) | 0% | 0.05% | 0.34% | 0.93% | 1.75% | 2.77% | 5.17% | 7.85% |

  So W(k) is an intrinsic function of multiplicity. k=1 (simple): convex through
  merge. k≥5: robust window (non-convex at 0.97 c*), matching Pommerenke's "large k".
- **Gallery audit:** the stated Goodman example (z²+1)(z−2)² at c=5^{3/2}/4 and the
  referee z(z⁵−1) both test **all convex** (κ_min≈1.25 around Goodman's double
  root). 5^{3/2}/4 sits at the merge threshold and the only multiple root is double
  (k=2, W≈0.05%). The clean, reproducible counterexample is Pommerenke z^k(z−a),
  k≥5 — with a computed κ<0, which also answers the gallery's open question
  "make counterexamples explicit with computed convexity violations."

No Lean changes (level-set convexity is heavy real analysis, deferred); the
checkable artifact is the numerical curvature certificate. New files only — no
collision with existing PRs.

## Test plan
- [x] Curvature test calibrated: κ=+1.000 on unit circle.
- [x] Two independent methods (contour-curvature and polar-trace) agree on all cases.
- [x] W(k) table reproducible via `window_width.py`; a-independence verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)