### PR TITLE
research(minkowski-hlawka-oq-06): ORIENT — ζ(n) is the primitive-vector restriction, not ±-pairing

### DIFF
--- a/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
@@ -68,6 +68,56 @@ Siegel's mean-value theorem over `SL_n(ℝ)/SL_n(ℤ)` (>1000 LOC of missing mea
 
 ---
 
+### Session 2026-06-14 (ORIENT, continued) — where the `ζ(n)` factor comes from
+
+**Mode**: REVISIT · **Outcome**: ORIENT (mechanism sharpened; full proof still Docker-gated)
+
+**Correction to the prior session.** The prior notes attribute the `2·ζ(n)` improvement
+to "±-pairing + threshold" without separating the two factors. This conflates two
+*independent* inputs, and it mis-states the hypothesis the staged formalization (target #1)
+must assume. The decomposition is:
+
+- The **factor 2** is the elementary **±-pairing**: for symmetric `S` (with `0 ∉ S`) the
+  primitive vectors of a lattice in `S` come in `±w` pairs, so #pairs = #primitive / 2.
+- The **factor ζ(n)** is the **primitive-vector (Siegel–Rogers) restriction** — a *deeper*
+  input, not a packaging trick. It is the content of the **primitive** mean-value formula,
+  distinct from Siegel's all-vectors formula.
+
+**The two mean-value formulas.** On `X_n = SL_n(ℤ)\SL_n(ℝ)` with probability Haar `μ`:
+
+- Siegel (all nonzero vectors): `∫_{X_n} Σ_{v∈Λ\0} f(v) dμ = ∫_{ℝⁿ} f`.
+- Siegel–Rogers (**primitive** vectors only): `∫_{X_n} Σ_{w∈Λ primitive} f(w) dμ = (1/ζ(n))·∫_{ℝⁿ} f`.
+
+The second follows from the first by the unique factorization `v = m·w` (`m ≥ 1`, `w`
+primitive) and the scaling `∫ f(m·) = m^{-n} ∫ f`: if the primitive mean is `c·∫f` then
+`c·(Σ_{m≥1} m^{-n})·∫f = ∫f`, i.e. `c = 1/Σ_{m≥1} m^{-n} = 1/ζ(n)`. **So `ζ(n)` is exactly
+`Σ_{m≥1} m^{-n}` — it enters as the primitivity-restriction normalizer, full stop.**
+
+**The Hlawka density argument, correctly stated.** Apply the *primitive* formula to
+`f = 1_S`, `S` symmetric, `0 ∉ S`. Mean number of primitive `±`-pairs in `S` is
+`vol(S)/(2ζ(n))`. If `vol(S) < 2ζ(n)`, the mean `< 1`, so **some** unimodular `Λ` has no
+primitive vector in `S`. For the ball case this finishes, because the **shortest** nonzero
+lattice vector is always primitive — "no primitive vector in `ball(2r)`" ⇒ min-distance
+`≥ 2r` ⇒ packing density `≥ ζ(n)/2^(n-1)`.
+
+**Consequence for target #1 (staged formalization).** The hypothesis to assume is the
+**primitive** mean-value identity `∫_{X_n} Σ_{w primitive} f(w) dμ = (1/ζ(n))·∫ f`, **not**
+the all-vectors Siegel identity. Assuming the all-vectors identity and trying to recover
+`ζ(n)` by ±-pairing alone does **not** reach `ζ(n)/2^(n-1)` — it only reaches the factor 2,
+i.e. `δ_n ≥ 1/2^(n-1)`, missing the `ζ(n)`. Also record: the "shortest vector is primitive"
+lemma is the bridge from "no primitive vector in `S`" to "no nonzero vector in `S`" for the
+ball; in Mathlib terms it is `Λ`-vector `= m • w` with `‖w‖ < ‖m • w‖` for `m ≥ 2`,
+contradicting minimality. (This bridge **is** Mathlib-tractable, unlike the mean-value identity.)
+
+**Durable artifact**: `verify_primitive_mechanism.py` (stdlib-only, all checks pass):
+(1) `ζ(n) = Σ_{m≥1} m^{-n}` so `c = 1/ζ(n)`; (2) `ℤ²` fraction of primitive (origin-visible,
+`gcd=1`) points `→ 1/ζ(2) = 6/π²`; (3) `ℤ³` primitive fraction `→ 1/ζ(3)`; (4) deterministic
+sweep of 13808 integer 2×2 bases: shortest nonzero vector is primitive in **all** cases.
+
+**Files**: `verify_primitive_mechanism.py`, `src/data/research/problems/minkowski-fundamental-theorem-oq-06.json`.
+
+---
+
 ## Dead Ends
 
 - Full formalization via Siegel's mean-value theorem from current Mathlib — blocked: the

--- a/research/problems/minkowski-fundamental-theorem-oq-06/state.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/state.md
@@ -4,16 +4,19 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Mathlib gap confirmed at pin; constants pinned (symmetric threshold 2·ζ(n) → δ_n ≥
-ζ(n)/2^(n-1)) and bound hierarchy + factor-2ζ(n) improvement verified. Full proof blocked
-on Siegel mean-value; staged-hypothesis file and elementary 2^(-n) bound identified as
-actionable targets.
+Mechanism sharpened: the ζ(n) factor in δ_n ≥ ζ(n)/2^(n-1) is the PRIMITIVE-vector
+(Siegel–Rogers) restriction (ζ(n)=Σ_{m≥1} m^{-n}), distinct from the ±-pairing factor 2.
+Staged target #1's hypothesis corrected to the *primitive* mean-value identity (all-vectors +
+pairing alone only reaches 1/2^(n-1)). Identified the Mathlib-tractable bridge "shortest
+nonzero vector is primitive". Durable stdlib verification added. Full proof still Docker/
+upstream-gated.
 
 ## Active Approach
-None active (Docker down → no build). Next session: ACT one of the two staged targets.
+None active (Docker down → no build). Next session: ACT staged target #1 using the *primitive*
+mean-value identity as hypothesis, or formalize the bridge lemma (shortest vector primitive).
 
 ## Attempt Count
 - Total attempts: 0

--- a/research/problems/minkowski-fundamental-theorem-oq-06/verify_primitive_mechanism.py
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/verify_primitive_mechanism.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Durable verification for minkowski-fundamental-theorem-oq-06 (Minkowski-Hlawka):
+WHERE the factor zeta(n) in delta_n >= zeta(n)/2^(n-1) actually comes from.
+
+Companion to verify_minkowski_hlawka.py. That script pins the *constants* and the
+statement<->density chain. This script isolates the *mechanism*: the zeta(n) factor
+is the PRIMITIVE-vector (Siegel-Rogers) restriction, a distinct and deeper input
+than the elementary +/- pairing (which only contributes the factor 2).
+
+Background (the staged-formalization hypothesis, sharpened):
+  Siegel's mean-value theorem (all nonzero vectors):
+      INT_{X_n} sum_{v in L\\{0}} f(v) dmu(L) = INT_{R^n} f(x) dx,        (S)
+  where X_n = SL_n(Z)\\SL_n(R) with its PROBABILITY Haar measure mu.
+  Decompose each nonzero v uniquely as v = m * w, m >= 1, w primitive. Scaling
+  f(m * .) integrates to m^{-n} INT f, so if the PRIMITIVE-vector mean is c * INT f,
+  then (S) reads  c * INT f * sum_{m>=1} m^{-n} = INT f, i.e.
+      c = 1 / sum_{m>=1} m^{-n} = 1 / zeta(n).                           (R)
+  Hence the Siegel-Rogers PRIMITIVE mean-value formula:
+      INT_{X_n} sum_{w in L primitive} f(w) dmu(L) = (1/zeta(n)) INT_{R^n} f.
+
+Minkowski-Hlawka via (R): for symmetric S (0 notin S), primitive vectors in S come
+in +/- pairs, so the mean number of primitive +/- PAIRS in S is vol(S)/(2 zeta(n)).
+If vol(S) < 2 zeta(n) the mean is < 1, so some unimodular L has NO primitive vector
+in S. For the ball case the shortest nonzero vector is always primitive, so "no
+primitive vector in ball(2r)" => min distance >= 2r => packing density >= zeta(n)/2^(n-1).
+
+  => The 2 is the +/- pairing.  The zeta(n) is the primitivity restriction (R).
+     These are independent; conflating them mis-states the staged hypothesis.
+
+What is checked here:
+  (1) The decomposition identity zeta(n) = sum_{m>=1} m^{-n}, so c = 1/zeta(n).
+  (2) For Z^2 the fraction of nonzero lattice points that are primitive (= visible
+      from the origin, gcd(x,y)=1) converges to 1/zeta(2) = 6/pi^2: a concrete,
+      lattice-level witness that the primitivity restriction carries exactly the
+      zeta factor.
+  (3) For Z^3 the primitive fraction converges to 1/zeta(3).
+  (4) The shortest nonzero vector of an integer lattice is always primitive
+      (justifies that primitive-only counting suffices for the ball/packing case).
+
+Run:  python3 verify_primitive_mechanism.py
+Requires: only the standard library (math). sympy used if present for exact zeta.
+"""
+
+import math
+from math import gcd, pi
+
+try:
+    from sympy import zeta as sym_zeta
+    HAVE_SYMPY = True
+except Exception:
+    HAVE_SYMPY = False
+
+
+def zeta_f(n: int, terms: int = 400000) -> float:
+    if HAVE_SYMPY:
+        return float(sym_zeta(n))
+    return sum(m ** (-n) for m in range(1, terms))
+
+
+def check_decomposition_identity() -> bool:
+    """(1) zeta(n) = sum_{m>=1} m^{-n}; the primitive-mean coeff is 1/zeta(n)."""
+    ok = True
+    print("[1] decomposition  zeta(n) = sum_{m>=1} m^{-n}  =>  c = 1/zeta(n)")
+    for n in (2, 3, 4, 8):
+        partial = sum(m ** (-n) for m in range(1, 400000))
+        z = zeta_f(n)
+        err = abs(partial - z)
+        good = err < 1e-4
+        ok &= good
+        print(f"    n={n}: sum_m m^-n={partial:.6f}  zeta(n)={z:.6f}  "
+              f"1/zeta={1/z:.6f}  err={err:.2e}  {'OK' if good else 'FAIL'}")
+    # exact anchor for n=2
+    anchor = abs(zeta_f(2) - pi * pi / 6) < 1e-9
+    ok &= anchor
+    print(f"    anchor zeta(2)=pi^2/6: {'OK' if anchor else 'FAIL'}")
+    return ok
+
+
+def primitive_fraction_Zn(dim: int, R: int) -> float:
+    """Fraction of nonzero points of Z^dim in [-R,R]^dim that are primitive."""
+    total = 0
+    prim = 0
+    if dim == 2:
+        for x in range(-R, R + 1):
+            for y in range(-R, R + 1):
+                if x == 0 and y == 0:
+                    continue
+                total += 1
+                if gcd(abs(x), abs(y)) == 1:
+                    prim += 1
+    elif dim == 3:
+        for x in range(-R, R + 1):
+            for y in range(-R, R + 1):
+                for z in range(-R, R + 1):
+                    if x == 0 and y == 0 and z == 0:
+                        continue
+                    total += 1
+                    if gcd(gcd(abs(x), abs(y)), abs(z)) == 1:
+                        prim += 1
+    else:
+        raise ValueError("dim in {2,3}")
+    return prim / total
+
+
+def check_primitive_fraction_Z2() -> bool:
+    """(2) Z^2 primitive fraction -> 1/zeta(2) = 6/pi^2."""
+    target = 6 / pi ** 2
+    print(f"[2] Z^2 primitive fraction -> 1/zeta(2) = 6/pi^2 = {target:.6f}")
+    ok = True
+    last = None
+    for Rb in (50, 150, 400):
+        f = primitive_fraction_Zn(2, Rb)
+        err = abs(f - target)
+        good = err < 0.01
+        ok &= good
+        last = f
+        print(f"    R={Rb}: fraction={f:.6f}  err={err:.5f}  {'OK' if good else 'FAIL'}")
+    return ok and last is not None
+
+
+def check_primitive_fraction_Z3() -> bool:
+    """(3) Z^3 primitive fraction -> 1/zeta(3)."""
+    target = 1 / zeta_f(3)
+    print(f"[3] Z^3 primitive fraction -> 1/zeta(3) = {target:.6f}")
+    ok = True
+    for Rb in (20, 40, 70):
+        f = primitive_fraction_Zn(3, Rb)
+        err = abs(f - target)
+        good = err < 0.01
+        ok &= good
+        print(f"    R={Rb}: fraction={f:.6f}  err={err:.5f}  {'OK' if good else 'FAIL'}")
+    return ok
+
+
+def check_shortest_is_primitive() -> bool:
+    """(4) shortest nonzero lattice vector is always primitive (deterministic sweep)."""
+    print("[4] shortest nonzero vector is primitive (=> primitive-only suffices for balls)")
+    ok = True
+    tot = 0
+    good = 0
+    # deterministic sweep over a grid of integer 2x2 bases (no RNG, reproducible)
+    rng = range(-5, 6)
+    for a0 in rng:
+        for a1 in rng:
+            for b0 in rng:
+                for b1 in rng:
+                    det = a0 * b1 - a1 * b0
+                    if det == 0:
+                        continue
+                    tot += 1
+                    best = None
+                    bestnorm = None
+                    for i in range(-6, 7):
+                        for j in range(-6, 7):
+                            if i == 0 and j == 0:
+                                continue
+                            vx = a0 * i + b0 * j
+                            vy = a1 * i + b1 * j
+                            nrm = vx * vx + vy * vy
+                            if bestnorm is None or nrm < bestnorm:
+                                bestnorm = nrm
+                                best = (i, j)
+                    if gcd(abs(best[0]), abs(best[1])) == 1:
+                        good += 1
+    ok = (good == tot) and tot > 0
+    print(f"    primitive-shortest: {good}/{tot}  {'OK' if ok else 'FAIL'}")
+    return ok
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Minkowski-Hlawka: the zeta(n) factor is PRIMITIVITY, not +/- pairing")
+    print("=" * 70)
+    results = [
+        ("decomposition zeta=sum m^-n", check_decomposition_identity()),
+        ("Z^2 primitive fraction", check_primitive_fraction_Z2()),
+        ("Z^3 primitive fraction", check_primitive_fraction_Z3()),
+        ("shortest vector primitive", check_shortest_is_primitive()),
+    ]
+    print("-" * 70)
+    all_ok = all(r for _, r in results)
+    for name, r in results:
+        print(f"  {'PASS' if r else 'FAIL'}  {name}")
+    print("-" * 70)
+    print("ALL CHECKS PASS" if all_ok else "SOME CHECKS FAILED")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT: confirmed Mathlib gap at pin (no Siegel mean-value / lattice-space measure / packing density; Hlawka title-only in 1000.yaml). Pinned the constants (symmetric threshold 2*zeta(n) -> delta_n >= zeta(n)/2^(n-1)) and verified the bound hierarchy + factor 2*zeta(n) improvement over trivial saturation. Full proof BLOCKED on Siegel; staged hypothesis file + elementary 2^-n bound identified as actionable next targets.",
+    "progressSummary": "ORIENT (sharpened): identified the zeta(n) factor in delta_n>=zeta(n)/2^(n-1) as the PRIMITIVE-vector (Siegel-Rogers) restriction, distinct from the ±-pairing factor 2. Corrected the staged-formalization hypothesis to the primitive mean-value identity (all-vectors+pairing only reaches 1/2^(n-1)). Added durable stdlib verification (Z^n primitive-fraction -> 1/zeta(n); shortest vector always primitive). Full proof still Docker/upstream-gated.",
     "builtItems": [
       "research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py - durable sympy verification: (A) symmetric threshold 2*zeta(n) <-> density zeta(n)/2^(n-1); (B) hierarchy 2^-n <= MH <= delta_known; (C) improvement factor = 2*zeta(n). All pass."
     ],
@@ -39,7 +39,12 @@
       "Minkowski-Hlawka is the EXISTENCE complement to the gallery parent (which proves only the Minkowski convex-body OBSTRUCTION). Parent MinkowskiFundamentalTheorem.lean is sorry-free but proves a different theorem; Hlawka is absent from proofs/ (grep -i hlawka hits only Erdos997Problem.lean, unrelated).",
       "Correct symmetric normalization: if symmetric S has vol(S) < 2*zeta(n) then some unimodular lattice avoids S minus {0}; taking S = ball(radius 2r) gives lattice packing density delta_n >= zeta(n)/2^(n-1). The seed problem.md threshold vol(S) < zeta(n) is the star-body / plus-minus-identified convention; the symmetric-body threshold is 2*zeta(n). Statement<->density chain verified numerically (verify_minkowski_hlawka.py check A).",
       "Bound hierarchy verified for n in {2..8,24}: trivial saturation 2^-n <= zeta(n)/2^(n-1) <= delta_n^known (A2,D3,D4,D5,E6,E7,E8,Leech). MH is a VALID but very weak lower bound vs known optima (n=8: MH 0.00784 vs E8 0.2537).",
-      "MH improves the elementary maximal-packing bound delta_n >= 2^-n by exactly a factor 2*zeta(n), which decreases to 2 as n grows. So the celebrated Hlawka improvement over the trivial saturation argument is asymptotically only a factor of 2; both bounds decay like 2^-n and the exponential gap to the (also exponential) Kabatiansky-Levenshtein upper bound is untouched by MH."
+      "MH improves the elementary maximal-packing bound delta_n >= 2^-n by exactly a factor 2*zeta(n), which decreases to 2 as n grows. So the celebrated Hlawka improvement over the trivial saturation argument is asymptotically only a factor of 2; both bounds decay like 2^-n and the exponential gap to the (also exponential) Kabatiansky-Levenshtein upper bound is untouched by MH.",
+      "The zeta(n) factor in delta_n >= zeta(n)/2^(n-1) is the PRIMITIVE-vector (Siegel-Rogers) restriction, NOT the +/- pairing. ±-pairing gives only the factor 2; zeta(n) = sum_{m>=1} m^{-n} is the primitivity normalizer.",
+      "Two distinct mean-value identities on X_n=SL_n(Z)\\SL_n(R): Siegel (all nonzero v): integral = vol; Siegel-Rogers (primitive w only): integral = vol/zeta(n). The primitive one follows from Siegel by v=m*w factorization + scaling integral f(m.)=m^{-n} integral f, giving coefficient 1/sum_m m^{-n}=1/zeta(n).",
+      "CORRECTION for staged formalization (target #1): the hypothesis to assume is the PRIMITIVE mean-value identity, not the all-vectors Siegel identity. Assuming all-vectors + ±-pairing alone only reaches delta_n >= 1/2^(n-1), missing the zeta(n).",
+      "Bridge lemma (Mathlib-tractable, unlike the mean-value identity): the shortest nonzero lattice vector is always primitive (v=m*w, m>=2 => ||w||<||v||). This lets 'no primitive vector in ball(2r)' imply 'min distance >= 2r' for the packing/ball case.",
+      "Durable numeric witness (verify_primitive_mechanism.py, stdlib-only, all pass): Z^2 origin-visible (gcd=1) point fraction -> 6/pi^2 = 1/zeta(2); Z^3 -> 1/zeta(3); 13808/13808 integer 2x2 bases have a primitive shortest vector."
     ],
     "mathlibGaps": [
       "Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: GeometryOfNumbers.lean has ONLY Blichfeldt (exists_pair_mem_lattice_not_disjoint_vadd) + Minkowski convex-body (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt/le_measure). No Hlawka.",
@@ -48,10 +53,9 @@
       "No packing-density notion (gh search packingDensity = 0). 'Minkowski-Hlawka theorem' appears in Mathlib docs/1000.yaml as a TITLE-ONLY entry (no decl:/author:), i.e. an UNMET target in the 1000-theorems project -> confirms not formalized upstream."
     ],
     "nextSteps": [
-      "Decision = SURVEY / effectively BLOCKED for full proof: standard route needs Siegel mean-value over SL_n(R)/SL_n(Z) (>1000 LOC of missing measure theory). Do NOT attempt full formalization.",
-      "Staged ACT target (realistic, Docker-gated): a Lean file stating Minkowski-Hlawka with Siegel's identity as an explicit HYPOTHESIS (axiom or structure field), then prove the better-than-average => existence extraction with plus-minus pairing to land delta_n >= zeta(n)/2^(n-1). Isolates the one deep lemma.",
-      "Genuinely reachable elementary stepping stone (ACT-able from Mathlib alone, ~200-400 LOC): the saturation bound delta_n >= 2^-n via maximal packing + radius-doubling cover. This is the easy constant; MH only sharpens it by the 2*zeta(n) factor.",
-      "When building the staged file, mirror sibling style (MinkowskiFundamentalTheoremOQ02/OQ04: survey docstring + Mathlib aliases where available, explicit assumption where not). Set badge=axiom (Siegel staged as assumption), status=axiomatized."
+      "Docker-up: stage target #1 with the PRIMITIVE Siegel-Rogers identity as the hypothesis (axiom/structure field), then prove better-than-average => existence => delta_n >= zeta(n)/2^(n-1). Badge=axiom.",
+      "Mathlib-only: formalize the 'shortest nonzero lattice vector is primitive' bridge lemma (Docker-gated but no missing upstream theory).",
+      "Elementary stepping stone: delta_n >= 2^(-n) via maximal packing + radius-doubling cover."
     ]
   },
   "tags": [
@@ -75,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T01:25:28.051Z",
-  "lastUpdate": "2026-06-15T01:25:28.051Z",
+  "lastUpdate": "2026-06-14",
   "significance": 7,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Sharpens the merged ORIENT (#24183) for **minkowski-fundamental-theorem-oq-06** (Minkowski–Hlawka). The prior notes credit the `2·ζ(n)` improvement to "±-pairing + threshold" without separating the two factors. This conflates **independent** inputs and mis-states the hypothesis the staged formalization must assume.

## Findings
- **Factor 2** = elementary **±-pairing** of a symmetric body `S`.
- **Factor ζ(n)** = the **primitive-vector (Siegel–Rogers) restriction**, a deeper input. On `X_n = SL_n(ℤ)\SL_n(ℝ)`:
  - Siegel (all nonzero `v`): `∫ Σ_{v∈Λ\0} f = ∫ f`.
  - Siegel–Rogers (**primitive** `w`): `∫ Σ_{w primitive} f = (1/ζ(n))·∫ f`, where `ζ(n)=Σ_{m≥1} m^{-n}` arises from `v=m·w` factorization + scaling `∫ f(m·)=m^{-n}∫ f`.
- **Correction for staged target #1**: assume the **primitive** mean-value identity, *not* the all-vectors Siegel identity. All-vectors + ±-pairing alone only reaches `δ_n ≥ 1/2^(n-1)`, missing `ζ(n)`.
- Flags the **Mathlib-tractable** bridge lemma: the shortest nonzero lattice vector is always primitive (`v=m·w`, `m≥2 ⇒ ‖w‖<‖v‖`), which lets "no primitive vector in `ball(2r)`" ⇒ min-distance `≥ 2r` for the packing case.

## Durable verification
`verify_primitive_mechanism.py` (stdlib-only, all checks pass):
1. `ζ(n)=Σ_{m≥1} m^{-n}` ⇒ primitive-mean coeff `1/ζ(n)`.
2. `ℤ²` origin-visible (`gcd=1`) fraction → `6/π² = 1/ζ(2)`.
3. `ℤ³` primitive fraction → `1/ζ(3)`.
4. Deterministic sweep: `13808/13808` integer 2×2 bases have a primitive shortest vector.

## Files
- `research/problems/minkowski-fundamental-theorem-oq-06/{knowledge.md,state.md}`
- `research/problems/minkowski-fundamental-theorem-oq-06/verify_primitive_mechanism.py` (new)
- `src/data/research/problems/minkowski-fundamental-theorem-oq-06.json`

## Status
**Outcome**: ORIENT (mechanism sharpened; no Lean changed)
**Next Steps**: Docker-up — stage target #1 with the *primitive* mean-value identity as hypothesis, or formalize the bridge lemma. Full proof remains Docker/upstream-gated (Siegel mean-value absent from Mathlib).

🤖 Generated by researcher-3