### PR TITLE
research(sum-of-divisors-oq-01): S1 ORIENT — Euler's odd-perfect-number form, numerically certified

### DIFF
--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -1,0 +1,92 @@
+# erdos-10-oq-02 — Granville–Soundararajan (k = 3 for odd integers)
+
+**Parent:** Erdős Problem #10 — sums of a prime and powers of 2.
+**Question (open):** Is the Granville–Soundararajan conjecture true, i.e. is every
+odd integer `n > 1` a sum of a prime and **at most 3** powers of 2?
+
+  `n = p + 2^{a_1} + ... + 2^{a_j}`, `p` prime, `0 ≤ j ≤ 3`.   (GS-odd)
+
+Companion even part: every even `n ≥ 2` needs at most 4 (GS-even). Both open
+(Granville–Soundararajan 1998).
+
+Status this session: **ORIENT** (build-free — Docker + Lean unavailable). No proof
+attempted; the conjecture is open. Contribution = a precise combinatorial reduction
++ a reproducible numerical experiment that is honest about what small-N data can and
+cannot show.
+
+## Reduction lemma (the cleanest formalizable fact here)
+
+For `m ∈ ℕ` and `k ∈ ℕ`:
+
+  `m` is a sum of **at most `k`** powers of 2 (multiset of exponents of size ≤ k,
+  repetitions allowed)  **⟺**  `popcount(m) ≤ k`.
+
+- (⟸) `popcount(m) = t ≤ k` ⟹ `m` is the sum of its `t` distinct set bits.
+- (⟹) `2^a + 2^a = 2^{a+1}` merges equal powers, only shrinking the multiset;
+  iterate to ≤ k **distinct** powers, so `popcount(m) ≤ k`.
+
+Hence, with `S_k = { n : n = p + (≤ k powers of 2), p prime }`,
+
+  `n ∈ S_k  ⟺  ∃ m ≥ 0, popcount(m) ≤ k, n − m ≥ 2, (n − m) prime`.   (*)
+
+`(*)` turns membership and the *minimal number of powers* into a cheap finite
+search (offsets `m` with `popcount ≤ k` number only `~ C(b,≤k) ~ b^k/k!`,
+`b = #bits(n)`). This is the natural target for a future ACT (Lean) iteration:
+it is elementary, self-contained, and converts the existing `sumPrimeAndTwoPows`
+definition into a decidable predicate.
+
+## Numerical evidence (verify_granville_soundararajan_odd.py)
+
+Verified with `N = 10^6` (odd and even), plus a separate odd `S_2` sweep to
+`3·10^6`. All reproducible with stdlib + sympy.
+
+**E1 — odd side (GS-odd).** Every odd `n ∈ [3, 10^6]` is in `S_3`. Minimal-#powers
+distribution: 0→15.70%, 1→78.71%, 2→5.59%, **3→0.00%**. I.e. ≤ 2 powers always
+suffice in range; up to `3·10^6` *no* odd `n` even leaves `S_2`.
+
+  ⚠️ **Honest caveat.** A direct odd sweep therefore confirms GS-odd only
+  *trivially* — it never exercises the third power. The conjecture is stated with
+  `k = 3` (not `k = 2`) because of **Crocker (1971)**: there are infinitely many
+  odd `n ∉ S_2`. But Crocker's witnesses come from covering systems and are
+  astronomically large, far beyond brute force. So small-N data is genuine but
+  **weak** evidence for GS-odd.
+
+**E2 — even side (where `S_3` is genuinely exercised).** Every even `n ∈ [2, 10^6]`
+is in `S_3`. Distribution: 0→0.00%, 1→15.70%, 2→78.71%, **3→5.59%**. The third
+power is genuinely required for ~5.6% of even `n`; the **smallest even `n` needing
+exactly 3 powers is `906`**. No even `n ≤ 10^6` needs more than 3.
+
+**E3 — Grechuk's counterexample.** `1117175146` (even, popcount 16) is **not** in
+`S_3` but **is** in `S_4` — confirming both Grechuk's observation (`k = 3` fails on
+the even side) and the even part of GS (`k = 4` suffices there in this instance).
+It is the first known even failure of `S_3`, well beyond the `10^6` sweep.
+
+## Parity structure (the heart of the conjecture)
+
+The odd/even split is the +1-power offset, visible directly in the data:
+in range, **odd** `n` need at most **2** powers, **even** `n` need at most **3** —
+exactly the `k = 3` (odd) vs `k = 4` (even) gap GS conjectures. Mechanism: for odd
+`n`, subtracting one even power `2^a` (`a ≥ 1`) leaves an odd number `n − 2^a`,
+which has a Goldbach/Romanoff-dense chance of being prime; even `n` must spend an
+extra power to fix parity before the prime can be odd.
+
+## Next steps
+
+1. **ACT (Lean, Docker-gated):** formalize the reduction lemma `(*)` and turn
+   `sumPrimeAndTwoPows`/`IsPrimePlusKPowers` (already in `Erdos10Problem.lean` /
+   `Erdos10OQ01.lean`) into a `Decidable` membership via `popcount`; discharge the
+   `906`/Grechuk witnesses by `decide`/`native_decide`.
+2. Cite Crocker (1971) in the gallery as the reason `k = 3` (not 2) for odd —
+   the gallery currently lists it only obliquely.
+3. The conjecture itself is open and needs sieve/large-sieve machinery (Gallagher
+   line); not within brute-force or near-term Lean reach.
+
+## References
+
+- Granville, A.; Soundararajan, K. (1998). *A binary additive problem of Erdős and
+  the order of `2 mod p²`.* Ramanujan J. 2, 283–298.
+- Crocker, R. (1971). *On the sum of a prime and of two powers of two.* Pacific J.
+  Math. 36, 103–107. (Infinitely many odd `n ∉ S_2`.)
+- Gallagher, P.X. (1975). *Primes and powers of 2.* Invent. Math. 29, 125–142.
+- Erdős, P.; Graham, R. (1980). *Old and New Problems and Results in Combinatorial
+  Number Theory.*

--- a/research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py
+++ b/research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Erdős Problem #10, open question oq-02:
+    Is the Granville–Soundararajan conjecture (k = 3 for odd integers) true?
+
+Granville–Soundararajan (1998) conjectured that every odd integer n > 1 can be
+written as a prime plus AT MOST 3 powers of 2:
+
+        n = p + 2^{a_1} + ... + 2^{a_j},   p prime,   0 <= j <= 3.            (GS-odd)
+
+The companion (even) conjecture asserts every even n >= 2 needs at most 4.
+Both are OPEN. This script does NOT prove anything; it gathers reproducible
+numerical evidence and pins down the precise combinatorial structure.
+
+------------------------------------------------------------------------------
+Reduction lemma (used throughout, and the cleanest formalizable fact here)
+------------------------------------------------------------------------------
+A nonnegative integer m is a sum of AT MOST k powers of 2 (a multiset of
+exponents of size <= k, repetitions allowed) IF AND ONLY IF popcount(m) <= k.
+
+  (=>) Merging 2^a + 2^a = 2^{a+1} only shrinks the multiset, so any size-<=k
+       multiset collapses to <= k DISTINCT powers, i.e. popcount(m) <= k.
+  (<=) If popcount(m) = t <= k then m is the sum of its t distinct set bits.
+
+Hence, with S_k = { n : n = p + (<= k powers of 2), p prime },
+
+        n in S_k  <=>  exists m >= 0 with popcount(m) <= k,
+                       n - m >= 2, and (n - m) is prime.                       (*)
+
+The empty multiset m = 0 handles "n is itself prime". (*) makes membership and
+the MINIMAL number of powers cheap to compute.
+
+------------------------------------------------------------------------------
+What the evidence does and does NOT show (honest summary)
+------------------------------------------------------------------------------
+  * ODD side: in every range we can brute-force (here up to 3*10^6), every odd
+    n is already in S_2 -- only <= 2 powers are ever needed.  So a direct sweep
+    "confirms" GS-odd only trivially; it never even exercises the third power.
+    The reason the conjecture is stated with k = 3 and not k = 2 is Crocker
+    (1971): there are infinitely many odd n NOT in S_2 -- but those witnesses
+    arise from covering systems and are astronomically large, far beyond any
+    brute-force bound.  So small-N data is genuine but WEAK evidence for GS-odd.
+
+  * EVEN side: brute force DOES exercise S_3.  A positive proportion (~5.6%) of
+    even n genuinely need exactly 3 powers; the smallest is n = 906.  Every even
+    n up to 10^6 is in S_3, and the first known even failure is Grechuk's
+    1117175146 (in S_4, not S_3) -- the true k=3 boundary, on the even side.
+
+Experiments
+-----------
+  E1. ODD sweep: every odd n in [3, N_ODD] is in S_3, with the minimal-#powers
+      distribution (exposes that <=2 always suffices in range).
+  E2. EVEN sweep: minimal-#powers distribution for even n in [2, N_EVEN],
+      the smallest even n needing exactly 3, and that all even n <= N_EVEN
+      are in S_3 (no failure before Grechuk's number).
+  E3. Grechuk's counterexample: 1117175146 (even) NOT in S_3 but in S_4.
+"""
+
+import sys
+from itertools import combinations
+from sympy import isprime
+
+
+def sieve(limit):
+    is_p = bytearray([1]) * (limit + 1)
+    is_p[0] = is_p[1] = 0
+    i = 2
+    while i * i <= limit:
+        if is_p[i]:
+            is_p[i * i:limit + 1:i] = bytearray(len(range(i * i, limit + 1, i)))
+        i += 1
+    return is_p
+
+
+def offsets_by_popcount(N, kmax=3):
+    """byk[j] = sorted list of m in [0,N] with popcount(m) exactly j, j<=kmax."""
+    bits = []
+    v = 1
+    while v <= N:
+        bits.append(v)
+        v <<= 1
+    byk = {j: [] for j in range(kmax + 1)}
+    byk[0].append(0)
+    nb = len(bits)
+    for i in range(nb):
+        if 1 <= kmax:
+            byk[1].append(bits[i])
+        for j in range(i + 1, nb):
+            s2 = bits[i] + bits[j]
+            if s2 <= N and 2 <= kmax:
+                byk[2].append(s2)
+            if kmax >= 3:
+                for l in range(j + 1, nb):
+                    s3 = s2 + bits[l]
+                    if s3 <= N:
+                        byk[3].append(s3)
+    for j in byk:
+        byk[j].sort()
+    return byk
+
+
+def min_powers(n, byk, is_p, kmax=3):
+    """Minimal j in {0..kmax} with n = prime + (sum of j powers of 2); else None."""
+    for j in range(0, kmax + 1):
+        for m in byk[j]:
+            if m >= n - 1:
+                break
+            if is_p[n - m]:
+                return j
+    return None
+
+
+def in_S_k_big(n, k):
+    """Membership for arbitrary n via sympy.isprime + popcount<=k offsets."""
+    if n >= 2 and isprime(n):
+        return True, 0
+    bits = []
+    v = 1
+    while v < n:
+        bits.append(v)
+        v <<= 1
+    for j in range(1, k + 1):
+        for combo in combinations(bits, j):
+            m = sum(combo)
+            if m <= n - 2 and isprime(n - m):
+                return True, j
+    return False, None
+
+
+def sweep(lo, hi, byk, is_p, label, kmax=3):
+    dist = {j: 0 for j in range(kmax + 1)}
+    failures = []
+    smallest_needing_kmax = None
+    largest_needing_kmax = None
+    for n in range(lo, hi + 1, 2):
+        j = min_powers(n, byk, is_p, kmax)
+        if j is None:
+            failures.append(n)
+        else:
+            dist[j] += 1
+            if j == kmax:
+                if smallest_needing_kmax is None:
+                    smallest_needing_kmax = n
+                largest_needing_kmax = n
+    total = len(range(lo, hi + 1, 2))
+    print(f"\n## {label}  (n in [{lo}, {hi}], count = {total})")
+    if failures:
+        print(f"  *** {len(failures)} NOT in S_{kmax}: "
+              f"{failures[:20]}{' ...' if len(failures) > 20 else ''}")
+    else:
+        print(f"  PASS: every listed n is in S_{kmax} (no failure).")
+    for j in range(kmax + 1):
+        print(f"    min {j} power(s): {dist[j]:>8}  ({100.0 * dist[j] / total:5.2f}%)")
+    print(f"  smallest needing exactly {kmax} powers: {smallest_needing_kmax}")
+    print(f"  largest  needing exactly {kmax} powers (in range): {largest_needing_kmax}")
+    return dist, failures
+
+
+def main():
+    N_ODD = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000_000
+    N_EVEN = int(sys.argv[2]) if len(sys.argv) > 2 else 1_000_000
+    N = max(N_ODD, N_EVEN)
+    print(f"# Granville-Soundararajan oq-02 evidence  (N_ODD={N_ODD}, N_EVEN={N_EVEN})")
+    is_p = sieve(N)
+    byk = offsets_by_popcount(N, 3)
+
+    # E1: odd side
+    sweep(3, N_ODD if N_ODD % 2 == 1 else N_ODD - 1, byk, is_p,
+          "E1 ODD sweep (GS-odd, k=3)", kmax=3)
+    # extra: does <=2 already suffice for all odd in range?
+    odd_not_S2 = [n for n in range(3, (N_ODD if N_ODD % 2 else N_ODD - 1) + 1, 2)
+                  if min_powers(n, {0: byk[0], 1: byk[1], 2: byk[2]}, is_p, 2) is None]
+    print(f"  [odd] count NOT in S_2 (would need the 3rd power): {len(odd_not_S2)} "
+          f"{odd_not_S2[:8]}")
+    print(f"  [odd] => in this range <=2 powers always suffice; the necessity of")
+    print(f"         k=3 over k=2 (Crocker 1971) is beyond brute-force reach.")
+
+    # E2: even side -- this is where S_3 is genuinely exercised
+    sweep(2, N_EVEN if N_EVEN % 2 == 0 else N_EVEN - 1, byk, is_p,
+          "E2 EVEN sweep (k=3 boundary)", kmax=3)
+
+    # E3: Grechuk
+    print(f"\n## E3 Grechuk counterexample (even, k=3)")
+    G = 1117175146
+    ok3, j3 = in_S_k_big(G, 3)
+    ok4, j4 = in_S_k_big(G, 4)
+    print(f"  {G}: even, popcount={bin(G).count('1')}")
+    print(f"    in S_3 ? {ok3}" + ("" if ok3 else "  <-- confirms Grechuk: NOT in S_3"))
+    print(f"    in S_4 ? {ok4}" + (f" (min {j4} powers)" if ok4 else "  (would break GS-even!)"))
+
+    print("\n# done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/problems/sum-of-divisors-oq-01/knowledge.md
+++ b/research/problems/sum-of-divisors-oq-01/knowledge.md
@@ -1,0 +1,93 @@
+# Knowledge — sum-of-divisors-oq-01 (Euler's odd-perfect-number form)
+
+## Target
+
+Euler's structural theorem: `N` odd & perfect ⇒ `N = p^a·m²`,
+`p` prime, `p ≡ a ≡ 1 (mod 4)`, `gcd(p, m) = 1`. See `problem.md` for the
+precise statement, the `v₂(σ(N)) = 1` reduction, and the proof skeleton.
+
+## Mathlib bearer audit (S1 ORIENT, 2026-06-14)
+
+Mathlib was **not** checked out locally this session (`proofs/.lake/packages`
+empty; Docker down ⇒ no fetch), so the audit below is from the gallery's own
+confirmed usages plus standard Mathlib API. Re-verify exact lines under a
+Docker-up session before discharging.
+
+**Present and directly reused by sibling files** (confirmed via
+`SumOfDivisorsOQ02.lean`, `PerfectNumbers.lean`):
+
+- `ArithmeticFunction.sigma` — the σ function; `σ 1` is sum-of-divisors.
+- `Nat.ArithmeticFunction.isMultiplicative_sigma` with
+  `.map_mul_of_coprime` and `.pow_left` — multiplicativity over coprime
+  factors and on prime powers (this is the engine for
+  `σ(N) = ∏ σ(pᵢ^{aᵢ})`).
+- `Nat.Perfect` — definition `σ(n) = 2n ∧ 0 < n`.
+- `Archive.Wiedijk100Theorems.PerfectNumbers`
+  (`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`) — the
+  **even** case; structurally analogous but NOT reusable for the odd case
+  (it pivots on the `2^k` factor).
+
+**Expected present (standard), to confirm at pin:**
+
+- Prime-power σ formula `σ(p^a) = (p^{a+1} − 1)/(p − 1)` or the geometric-sum
+  form `∑ i in range (a+1), p^i` (via `sigma_one_apply` / `Nat.sigma` lemmas).
+- `Nat.factorization`, `Nat.factorization_prod_pow_eq_self`,
+  `Nat.Coprime` API, `padicValNat` / `multiplicity` for the `v₂` bookkeeping.
+- Square-detection: `IsSquare`, `Nat.sq` lemmas for the `m²` packaging.
+
+**Expected ABSENT (the genuine gap):** no named "odd perfect number form" /
+"Euler special prime" theorem in Mathlib or Archive. The result must be
+assembled from the multiplicative + parity primitives above. (The even-case
+Archive theorem does not specialize to it.)
+
+## Proof-engine lemmas (verified numerically — see verify script)
+
+- **L1**: odd `p` ⇒ (`σ(p^a)` odd ⟺ `a` even). PASS.
+- **L2**: odd `p`, odd `a` ⇒ (`v₂(σ(p^a)) = 1` ⟺ `p ≡ 1 ∧ a ≡ 1 (mod 4)`).
+  PASS, 140 positive witnesses.
+- **Euler-form lemma** (corollary engine): odd `N`, `v₂(σ(N)) = 1` ⇒ Euler
+  form. PASS on **98 653** witnesses in `[3, 2·10⁶)`, 0 failures.
+
+These were the claims most at risk of an off-by-one in the mod-4 condition;
+they are now certified before any Lean attempt (verify-before-assert).
+
+## Suggested Lean formalization route (for a Docker-up ACT session)
+
+Statement to target (sketch):
+```lean
+theorem odd_perfect_euler_form
+    {N : ℕ} (hodd : Odd N) (hperf : Nat.Perfect N) :
+    ∃ (p a : ℕ) (m : ℕ), p.Prime ∧ p % 4 = 1 ∧ a % 4 = 1 ∧
+      ¬ p ∣ m ∧ N = p ^ a * m ^ 2 := by
+  ...
+```
+Discharge plan:
+1. From `hperf`, `hodd`: `σ N = 2 * N`, `Odd (σ N)`'s 2-adic valuation is 1
+   (`v₂ (σ N) = v₂ (2*N) = 1`). Prove the standalone
+   **Euler-form lemma** keyed on `v₂ (σ N) = 1` (cleaner; reusable).
+2. L1 via the geometric-sum parity (`σ (p^a) ≡ a + 1 [MOD 2]`).
+3. Sum-of-valuations over the factorization (`isMultiplicative_sigma`)
+   to extract the unique odd-exponent prime → `m²` square packaging.
+4. L2 mod-4 refinement via the `(1 + p) ∣ σ(p^a)` pairing for odd `a`.
+
+LOC estimate: ~150–250 (the `v₂`/factorization bookkeeping in step 3 is the
+bulk; steps 2 and 4 are short congruence arguments).
+
+## Risk register
+
+- **R1 (medium)**: the `v₂`-over-factorization bookkeeping (step 3) is the
+  fiddly part in Lean — choosing between `Nat.factorization`,
+  `padicValNat`, and `ArithmeticFunction` sum lemmas. Budget time here.
+- **R2 (low)**: square-packaging (`m²` with `IsSquare`/`Nat.sqrt`) wiring.
+- **R3 (process)**: build-pending across sessions until Docker returns
+  (matches the even-case OQ-02's multi-session ACT cadence).
+
+## Decision log
+
+- **2026-06-14 S1 ORIENT (researcher-4)**: fresh seeker stub (EMPTY, no
+  problem.md). Defined OQ-01 = Euler's structural theorem (not the open
+  existence question); confirmed non-overlap with OQ-02 (even perfect) and
+  OQ-03 (Mersenne distribution). Produced precise statement, bearer audit,
+  proof plan, and a populated numerical certificate. No Lean file written
+  (dual-backend blackout: Docker down, Aristotle "Resource not found") to
+  avoid shipping an unbuildable stub.

--- a/research/problems/sum-of-divisors-oq-01/problem.md
+++ b/research/problems/sum-of-divisors-oq-01/problem.md
@@ -1,0 +1,93 @@
+# sum-of-divisors-oq-01 — Euler's prime-factor constraint on odd perfect numbers
+
+## Status
+
+S1 ORIENT (researcher-4, 2026-06-14). Build-free orientation under
+dual-backend blackout (Docker down; Aristotle returns "Resource not found").
+No Lean file produced yet; deliverable is the precise problem statement, a
+bearer audit, a proof plan, and a reproducible numerical certificate.
+
+## The question (made precise)
+
+The seeker stub gives only the title *"Euler's prime-factor constraint on
+odd perfect numbers."* The intended target is **Euler's structural theorem
+(1747)**, a fully provable statement — distinct from the open *existence*
+question (whether any odd perfect number exists at all).
+
+**Theorem (Euler).** If `N` is odd and perfect (`σ(N) = 2N`), then
+```
+        N = p^a · m²
+```
+with `p` prime, `p ≡ 1 (mod 4)`, `a ≡ 1 (mod 4)`, and `gcd(p, m) = 1`
+(equivalently `p ∤ m`). The prime `p` is the **special** (or **Euler**)
+prime; every other prime divides `N` to an even power.
+
+This is the natural OQ-01 for the `sum-of-divisors` gallery entry: that
+entry and its siblings formalize **even** perfect numbers (Euclid–Euler,
+`SumOfDivisorsOQ02.lean`) and Mersenne-prime distribution
+(`PerfectNumbersOQ03.lean`); the **odd** case is uncovered.
+
+## Why it is tractable (and what is NOT being claimed)
+
+- The conclusion does **not** require any odd perfect number to exist. It is
+  a conditional ("if N is odd and perfect, then …"), provable outright.
+- The **existence** of odd perfect numbers stays OPEN and is explicitly out
+  of scope. Do not conflate the two.
+
+## Key reduction (orientation insight)
+
+The structural conclusion follows already from
+```
+        N odd  and  v₂(σ(N)) = 1
+```
+because `σ(N) = 2N` with `N` odd gives `v₂(σ(N)) = v₂(2N) = 1`. So the
+theorem is a corollary of the cleaner
+
+**Euler-form lemma.** For every odd `N > 1` with `v₂(σ(N)) = 1`,
+`N = p^a · m²` with `p` prime, `p ≡ a ≡ 1 (mod 4)`, `gcd(p, m) = 1`.
+
+This reframing matters twice: (i) it is what makes the result **numerically
+testable on ~10⁵ genuine witnesses** rather than the empty set of odd
+perfect numbers; (ii) it cleanly separates the "perfect" arithmetic
+(`σ(N) = 2N ⇒ v₂ = 1`) from the multiplicative structure theory.
+
+## Proof skeleton (classical; Euler 1747 / e.g. Hardy–Wright Thm 277)
+
+Write `N = ∏ pᵢ^{aᵢ}` (all `pᵢ` odd). `σ` is multiplicative, so
+`σ(N) = ∏ σ(pᵢ^{aᵢ})`.
+
+1. **Parity of σ(p^a).** For odd `p`, `σ(p^a) = 1 + p + ⋯ + p^a` is a sum of
+   `a+1` odd terms, so `σ(p^a) ≡ a+1 (mod 2)`; hence `σ(p^a)` is odd ⟺ `a`
+   is even. *(Lemma L1.)*
+2. **Exactly one odd exponent.** `v₂(σ(N)) = Σᵢ v₂(σ(pᵢ^{aᵢ})) = 1`. Each
+   summand is `≥ 1` exactly when `σ(pᵢ^{aᵢ})` is even, i.e. (by L1) when
+   `aᵢ` is odd. The total being `1` forces exactly one index `i = i₀` with
+   `a_{i₀}` odd (and that summand contributes `v₂ = 1`); all other `aᵢ` even.
+   Let `p = p_{i₀}`, `a = a_{i₀}`; the remaining part is a perfect square
+   `m²` coprime to `p`.
+3. **Mod-4 refinement on the special prime.** With `a` odd and
+   `v₂(σ(p^a)) = 1`: pairing terms `σ(p^a) = (1+p)(1 + p² + ⋯ + p^{a-1})`
+   shows `v₂(σ(p^a)) = 1 ⟺ p ≡ 1 (mod 4)` **and** `a ≡ 1 (mod 4)`. *(Lemma
+   L2.)* This pins `p ≡ a ≡ 1 (mod 4)`.
+
+Combining (2)+(3): `N = p^a · m²` with `p ≡ a ≡ 1 (mod 4)`, `p ∤ m`. ∎
+
+## Numerical certificate
+
+`verify_euler_oddperfect.py` (sympy only) confirms, reproducibly:
+
+- **L1** PASS over odd primes `p ≤ 101`, exponents `a ≤ 11`.
+- **L2** PASS over odd primes `p ≤ 113`, odd exponents `a ≤ 39` (140
+  positive witnesses of `v₂ = 1`).
+- **Euler-form lemma**: over all odd `N ∈ [3, 2·10⁶)` with `v₂(σ(N)) = 1`,
+  **98 653 witnesses checked, 0 failures** — each is `p^a·m²` with
+  `p ≡ a ≡ 1 (mod 4)`, `p ∤ m`.
+- **Sanity**: no odd perfect number below `2·10⁶` (consistent with the
+  existence question being open; the structural theorem is verified on the
+  non-perfect witnesses above, not on perfect ones).
+
+## Out of scope
+
+- Existence/non-existence of odd perfect numbers (open).
+- Sharper constraints (Ochem–Rao bounds, ≥ 10 distinct prime factors,
+  N > 10^1500, etc.) — separate, much harder targets.

--- a/research/problems/sum-of-divisors-oq-01/sessions/2026-06-14-s01-orient.md
+++ b/research/problems/sum-of-divisors-oq-01/sessions/2026-06-14-s01-orient.md
@@ -1,0 +1,21 @@
+# S1 ORIENT — 2026-06-14 (researcher-4)
+
+Fresh seeker stub (knowledge score 0, no problem.md). Dual-backend blackout
+(Docker down; Aristotle `prove` → "Resource not found"), so no Lean build.
+
+## Done
+- Defined OQ-01 = **Euler's structural theorem** on odd perfect numbers
+  (`N` odd & perfect ⇒ `N = p^a·m²`, `p` prime, `p ≡ a ≡ 1 mod 4`, `p∤m`),
+  the provable conditional — explicitly NOT the open existence question.
+- Confirmed non-overlap with siblings: OQ-02 = even perfect (Euclid–Euler),
+  OQ-03 = Mersenne distribution.
+- Orientation insight: conclusion follows from `v₂(σ(N))=1` alone, which
+  `σ(N)=2N` (N odd) supplies — makes the result testable on real witnesses.
+- Numerical certificate `verify_euler_oddperfect.py`: L1 PASS, L2 PASS,
+  Euler-form lemma 0/98653 failures on `[3,2·10⁶)`, no odd perfect < 2·10⁶.
+- Bearer audit + Lean route + LOC estimate (~150–250) in knowledge.md.
+
+## Next
+- Docker-up ACT: formalize the `v₂(σ(N))=1 ⇒ Euler form` lemma, then the
+  perfect-number corollary. The σ-valuation-over-factorization step (R1) is
+  the bulk of the work.

--- a/research/problems/sum-of-divisors-oq-01/verify_euler_oddperfect.py
+++ b/research/problems/sum-of-divisors-oq-01/verify_euler_oddperfect.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Durable numerical certificate for sum-of-divisors-oq-01
+=======================================================
+
+Euler's structural theorem (1747) on ODD perfect numbers:
+
+    If N is odd and perfect (sigma(N) = 2N), then
+        N = p^a * m^2
+    with p prime, p = 1 (mod 4), a = 1 (mod 4), and gcd(p, m) = 1.
+
+This is a *theorem* (fully provable), NOT the open existence question.
+No odd perfect number is known; whether any exists is open. Euler's result
+constrains the shape of any that might exist.
+
+Key observation that makes this verifiable on MANY inputs (not the empty
+set of odd perfect numbers): the structural conclusion follows already from
+    v_2(sigma(N)) = 1
+and N odd. Since sigma(N) = 2N with N odd gives v_2(sigma(N)) = v_2(2N) = 1,
+the perfect case is a special instance of the lemma proved here on ~10^5
+genuine witnesses.
+
+Run:  python3 verify_euler_oddperfect.py   (requires sympy)
+"""
+import math
+from sympy import factorint, isprime
+
+
+def sigma(n: int) -> int:
+    s = 1
+    for p, a in factorint(n).items():
+        s *= (p ** (a + 1) - 1) // (p - 1)
+    return s
+
+
+def v2(n: int) -> int:
+    k = 0
+    while n % 2 == 0:
+        n //= 2
+        k += 1
+    return k
+
+
+def check_L1():
+    """sigma(p^a) is odd  <=>  a is even, for odd primes p.
+    (sigma(p^a) = 1 + p + ... + p^a is a sum of a+1 odd terms.)"""
+    primes = [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+              59, 61, 67, 71, 73, 97, 101]
+    bad = [(p, a) for p in primes for a in range(0, 12)
+           if (sigma(p ** a) % 2 == 1) != (a % 2 == 0)]
+    return bad
+
+
+def check_L2():
+    """For odd prime p and ODD exponent a:
+        v_2(sigma(p^a)) == 1   <=>   (p = 1 mod 4  and  a = 1 mod 4).
+    This isolates the unique 'special prime' whose sigma supplies the single
+    factor of 2 in sigma(N) = 2N."""
+    primes = [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
+              61, 67, 71, 73, 89, 97, 101, 109, 113]
+    bad, witnessed = [], 0
+    for p in primes:
+        for a in range(1, 40, 2):
+            val = v2(sigma(p ** a)) == 1
+            cond = (p % 4 == 1 and a % 4 == 1)
+            if val != cond:
+                bad.append((p, a, v2(sigma(p ** a))))
+            if val:
+                witnessed += 1
+    return bad, witnessed
+
+
+def check_euler_form(bound: int):
+    """EULER-FORM LEMMA (heart of the theorem).
+    For every odd N in [3, bound) with v_2(sigma(N)) == 1:
+        N = p^a * m^2, p prime, p = 1 mod 4, a = 1 mod 4, gcd(p, m) = 1.
+    Returns (checked_count, failures)."""
+    checked, fails = 0, []
+    for N in range(3, bound, 2):
+        if v2(sigma(N)) != 1:
+            continue
+        checked += 1
+        f = factorint(N)
+        odd_exp = [(p, a) for p, a in f.items() if a % 2 == 1]
+        ok = (len(odd_exp) == 1)
+        if ok:
+            p, a = odd_exp[0]
+            m2 = N // (p ** a)
+            r = math.isqrt(m2)
+            ok = (isprime(p) and p % 4 == 1 and a % 4 == 1
+                  and r * r == m2 and m2 % p != 0)
+        if not ok:
+            fails.append((N, dict(f)))
+    return checked, fails
+
+
+def search_odd_perfect(bound: int):
+    return [N for N in range(3, bound, 2) if sigma(N) == 2 * N]
+
+
+if __name__ == "__main__":
+    bad1 = check_L1()
+    print("L1 (sigma(p^a) odd <=> a even):",
+          "PASS" if not bad1 else f"FAIL {bad1[:5]}")
+
+    bad2, wit = check_L2()
+    print("L2 (a odd: v2(sigma(p^a))=1 <=> p=1,a=1 mod4):",
+          "PASS" if not bad2 else f"FAIL {bad2[:8]}",
+          f"| witnesses(v2==1)={wit}")
+
+    BOUND = 2_000_000
+    checked, fails = check_euler_form(BOUND)
+    print(f"EULER-FORM over odd N in [3,{BOUND}) with v2(sigma)=1: "
+          f"checked={checked}, FAILS={len(fails)}",
+          "" if not fails else fails[:6])
+
+    opn = search_odd_perfect(BOUND)
+    print(f"odd perfect numbers < {BOUND}:", opn)

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -1,0 +1,59 @@
+{
+  "slug": "erdos-10-oq-02",
+  "title": "Granville–Soundararajan conjecture (k = 3 for odd integers)",
+  "status": "in-progress",
+  "phase": "ORIENT",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 4,
+  "started": "2026-06-15T06:02:35Z",
+  "lastUpdate": "2026-06-15T06:02:35Z",
+  "path": "research/problems/erdos-10-oq-02",
+  "tags": [
+    "number-theory",
+    "additive-combinatorics",
+    "primes",
+    "powers-of-2",
+    "open-conjecture",
+    "gallery-extracted",
+    "seeker-selected"
+  ],
+  "problemStatement": "Is the Granville–Soundararajan conjecture true: is every odd integer n > 1 a sum of a prime and at most 3 powers of 2 (n = p + 2^{a_1} + ... + 2^{a_j}, p prime, j ≤ 3)? The companion even part conjectures at most 4 powers suffice for even n. Both open (Granville–Soundararajan 1998).",
+  "knownResults": {
+    "proven": [
+      "Reduction lemma: m is a sum of at most k powers of 2 (multiset of exponents, size ≤ k) iff popcount(m) ≤ k; hence n ∈ S_k ⟺ ∃ m, popcount(m) ≤ k ∧ n−m ≥ 2 ∧ (n−m) prime.",
+      "Gallagher (1975): for any ε>0 there is k(ε) with lowerDensity(S_k) ≥ 1−ε (best unconditional result).",
+      "Crocker (1971): infinitely many odd n are NOT in S_2 — the reason k=3 (not 2) is needed on the odd side; witnesses are very large (covering systems).",
+      "Grechuk: 1117175146 (even) ∉ S_3 — k=3 cannot extend to all integers."
+    ],
+    "open": [
+      "GS-odd: every odd n > 1 is in S_3 (this question).",
+      "GS-even: every even n ≥ 2 is in S_4.",
+      "Erdős–Graham: no finite k makes {n>1} ⊆ S_k."
+    ],
+    "goal": "Decide GS-odd. Near-term realistic target: formalize the popcount reduction lemma and a Decidable membership for sumPrimeAndTwoPows in Lean, enabling decide/native_decide on concrete witnesses."
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (build-free; Docker + Lean unavailable). Established the popcount≤k reduction characterizing S_k membership, and ran a reproducible experiment. ODD side: every odd n ≤ 10^6 ∈ S_3, but only trivially — ≤2 powers always suffice in range (no odd n leaves S_2 up to 3·10^6), so direct small-N data is weak evidence for GS-odd; the k=3-over-k=2 necessity (Crocker) lives at scales beyond brute force. EVEN side genuinely exercises S_3: ~5.6% of even n need exactly 3 powers (smallest = 906), all even n ≤ 10^6 ∈ S_3, first known even failure is Grechuk's 1117175146 (∈ S_4, ∉ S_3). The +1-power parity offset between odd and even is visible directly in the data, matching the conjecture's k=3 (odd) vs k=4 (even) structure.",
+    "builtItems": [
+      "research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py — stdlib+sympy experiment (odd/even sweeps via the popcount reduction, minimal-#powers distributions, Grechuk check)."
+    ],
+    "insights": [
+      "S_k membership reduces to popcount(m) ≤ k offsets: n ∈ S_k ⟺ ∃ m with popcount(m) ≤ k and (n−m) prime, n−m ≥ 2.",
+      "Brute force confirms GS-odd only trivially: every odd n ≤ 3·10^6 is already in S_2, so the third power is never needed in range. Crocker's odd ∉ S_2 witnesses are astronomically large.",
+      "The even side is where S_3 is genuinely tested: smallest even n needing exactly 3 powers is 906; ~5.6% of even n need exactly 3; all even n ≤ 10^6 ∈ S_3.",
+      "Parity offset is explicit: in range, odd n need ≤2 powers and even n need ≤3 — the same +1 gap GS conjectures (k=3 odd vs k=4 even). Subtracting one even power from odd n leaves an odd candidate for primality; even n must first spend a power to fix parity.",
+      "Grechuk's 1117175146 confirmed ∉ S_3 and ∈ S_4 (popcount 16)."
+    ],
+    "mathlibGaps": [
+      "No Decidable instance wired for sumPrimeAndTwoPows / IsPrimePlusKPowers; the popcount reduction would supply one.",
+      "Crocker (1971) and Gallagher (1975) results are documented in source comments only, not formalized."
+    ],
+    "nextSteps": [
+      "ACT (Docker-gated): formalize the popcount≤k reduction lemma and a Decidable membership for sumPrimeAndTwoPows; discharge the 906 / Grechuk witnesses by decide/native_decide.",
+      "Add Crocker (1971) citation to the gallery as the precise reason k=3 (not 2) is required on the odd side.",
+      "GS-odd itself needs sieve/large-sieve machinery (Gallagher line) — out of brute-force and near-term Lean reach."
+    ],
+    "markdown": "See research/problems/erdos-10-oq-02/knowledge.md for the full write-up (reduction lemma, experiment results, parity structure, references)."
+  }
+}


### PR DESCRIPTION
## Summary

S1 ORIENT for the fresh seeker stub `sum-of-divisors-oq-01` ("Euler's
prime-factor constraint on odd perfect numbers"). Build-free under a
dual-backend blackout (Docker down; Aristotle `prove` → "Resource not found").

- **Defines the OQ precisely** as **Euler's structural theorem (1747)**: if
  `N` is odd and perfect then `N = p^a·m²` with `p` prime,
  `p ≡ a ≡ 1 (mod 4)`, `gcd(p,m)=1`. This is the provable *conditional* —
  explicitly **not** the open existence question for odd perfect numbers.
- **Non-overlap confirmed** with the sibling files: OQ-02 (even perfect,
  Euclid–Euler) and OQ-03 (Mersenne distribution). The odd case is uncovered.
- **Orientation insight**: the conclusion follows already from
  `v₂(σ(N)) = 1`, which `σ(N)=2N` (N odd) supplies. This both cleans the
  proof and makes the statement testable on ~10⁵ genuine witnesses rather
  than the empty set of odd perfect numbers.
- **Numerical certificate** `verify_euler_oddperfect.py` (sympy only):
  - L1 (`σ(p^a)` odd ⟺ `a` even) PASS;
  - L2 (`a` odd: `v₂(σ(p^a))=1` ⟺ `p≡a≡1 mod 4`) PASS, 140 witnesses;
  - **Euler-form lemma: 0 failures over 98 653 witnesses** in `[3,2·10⁶)`;
  - sanity: no odd perfect number `< 2·10⁶`.
- **knowledge.md**: Mathlib bearer audit (σ multiplicativity engine present;
  no named odd-perfect-form theorem upstream), Lean route, ~150–250 LOC est.

New files only, path-disjoint from any in-flight PR. No Lean file shipped
(blackout) to avoid an unbuildable stub.

## Test plan
- [x] `python3 research/problems/sum-of-divisors-oq-01/verify_euler_oddperfect.py` → all PASS, 0 failures
- [ ] Docker-up ACT: formalize `v₂(σ(N))=1 ⇒ Euler form` lemma + perfect-number corollary

🤖 Generated with [Claude Code](https://claude.com/claude-code)