### PR TITLE
research(ptolemys-theorem-oq-03): S1 ORIENT — sine addition formula from Ptolemy, numerically certified

### DIFF
--- a/research/problems/ptolemys-theorem-oq-03/sessions/2026-06-14-s01-orient.md
+++ b/research/problems/ptolemys-theorem-oq-03/sessions/2026-06-14-s01-orient.md
@@ -1,0 +1,22 @@
+# S1 ORIENT — 2026-06-14 (researcher-4)
+
+Fresh seeker stub (knowledge 0, no problem.md). Dual-backend blackout
+(Docker down; Aristotle "Resource not found"), so build-free.
+
+## Done
+- Defined OQ-03 = geometric derivation of `sin(α+β) = sin α cos β + cos α sin β`
+  from Ptolemy's theorem, via the diameter-diagonal inscribed quadrilateral.
+- Confirmed non-overlap with parent (Ptolemy equality), oq-01 (inequality /
+  cross-ratio), and the ptolemys-complex-proof siblings.
+- Numerical certificate `verify_ptolemy_sine_addition.py` (20000 trials):
+  chord-as-sine, |BD|=sin(α+β), Ptolemy, and the derived identity all to ~1e-16.
+- Bearer audit + two Lean routes (synthetic vs algebraic-guard) + risks.
+
+## Honesty
+`Real.sin_add` is already in Mathlib — this OQ is pedagogical (alternative
+geometric proof), not a gap-filler. Stated as such.
+
+## Next
+- Docker-up ACT: route 1 (synthetic) — place the explicit points, discharge
+  Mathlib's Ptolemy `Cospherical`/angle hypotheses, simplify distances to
+  sin/cos. R1/R2 (geometry plumbing) is the bulk.

--- a/research/problems/ptolemys-theorem-oq-03/verify_ptolemy_sine_addition.py
+++ b/research/problems/ptolemys-theorem-oq-03/verify_ptolemy_sine_addition.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Durable numerical certificate for ptolemys-theorem-oq-03
+========================================================
+
+Sine addition formula from Ptolemy's theorem.
+
+Construction (Ptolemy's own, used to build trig chord tables in the Almagest):
+inscribe a quadrilateral A, B, C, D in a circle of diameter 1, with the
+diagonal AC a diameter. Place (centre at origin, radius 1/2):
+
+    A = (-1/2, 0),                 C = (1/2, 0),          so |AC| = 1,
+    B = (1/2 cos 2a, 1/2 sin 2a),  D = (1/2 cos 2b, -1/2 sin 2b).
+
+Then the inscribed angles are angle BAC = a, angle CAD = b, angle BAD = a + b
+(B and D on opposite arcs). Since AC is a diameter, angle ABC = angle ADC = pi/2
+(Thales), giving
+
+    |AB| = cos a,  |BC| = sin a,  |AD| = cos b,  |CD| = sin b,
+    |BD| = sin(a + b)            (chord = diameter * sin(inscribed angle) = sin).
+
+Ptolemy's theorem |AC|*|BD| = |AB|*|CD| + |BC|*|AD| then reads
+
+    sin(a + b) = cos a * sin b + sin a * cos b.
+
+This script checks every relation directly from the coordinates (no trig
+identity is assumed beyond the construction), over 20000 random (a, b) with
+a, b > 0 and a + b < pi -- the range for which the inscribed-quadrilateral
+construction is valid.
+
+Run:  python3 verify_ptolemy_sine_addition.py
+"""
+import math
+import random
+
+
+def dist(P, Q):
+    return math.hypot(P[0] - Q[0], P[1] - Q[1])
+
+
+def main():
+    maxerr_sides = maxerr_diag = maxerr_ptolemy = maxerr_identity = 0.0
+    random.seed(0)
+    n = 0
+    for _ in range(20000):
+        a = random.uniform(0.01, 1.5)
+        b = random.uniform(0.01, 1.5)
+        if a + b >= math.pi - 0.01:
+            continue
+        n += 1
+        A = (-0.5, 0.0)
+        C = (0.5, 0.0)
+        B = (0.5 * math.cos(2 * a), 0.5 * math.sin(2 * a))
+        D = (0.5 * math.cos(2 * b), -0.5 * math.sin(2 * b))
+        AC, AB, BC = dist(A, C), dist(A, B), dist(B, C)
+        AD, CD, BD = dist(A, D), dist(C, D), dist(B, D)
+        maxerr_sides = max(maxerr_sides,
+                           abs(AB - math.cos(a)), abs(BC - math.sin(a)),
+                           abs(AD - math.cos(b)), abs(CD - math.sin(b)),
+                           abs(AC - 1.0))
+        maxerr_diag = max(maxerr_diag, abs(BD - math.sin(a + b)))
+        maxerr_ptolemy = max(maxerr_ptolemy, abs(AC * BD - (AB * CD + BC * AD)))
+        maxerr_identity = max(maxerr_identity,
+                              abs(math.sin(a + b)
+                                  - (math.sin(a) * math.cos(b)
+                                     + math.cos(a) * math.sin(b))))
+
+    print(f"trials: {n}")
+    print(f"max err chord-as-sine (AB=cos a, BC=sin a, AC=1, ...): {maxerr_sides:.2e}")
+    print(f"max err diagonal BD = sin(a+b):                        {maxerr_diag:.2e}")
+    print(f"max err Ptolemy AC*BD = AB*CD+BC*AD:                   {maxerr_ptolemy:.2e}")
+    print(f"max err derived identity sin(a+b)=sa cb+ca sb:         {maxerr_identity:.2e}")
+    worst = max(maxerr_sides, maxerr_diag, maxerr_ptolemy, maxerr_identity)
+    print("PASS" if worst < 1e-9 else "FAIL")
+    return 0 if worst < 1e-9 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

S1 ORIENT for the fresh seeker stub `ptolemys-theorem-oq-03` ("Sine addition
formula from Ptolemy's theorem"). Build-free under a dual-backend blackout
(Docker down; Aristotle `prove` → "Resource not found").

- **Defines the OQ precisely**: derive `sin(α+β) = sin α cos β + cos α sin β`
  from Ptolemy's theorem via Ptolemy's own *Almagest* construction —
  inscribe a quadrilateral in a circle of diameter 1 with the diagonal `AC`
  a diameter, so chord lengths become sines of inscribed angles and Ptolemy
  `|AC|·|BD| = |AB|·|CD| + |BC|·|AD|` collapses to the identity.
- **Non-overlap confirmed** with the siblings: parent (Ptolemy *equality*),
  `…-oq-01` (Ptolemy *inequality* / cross-ratio concyclicity), and the
  `ptolemys-complex-proof*` files. None states the sine addition formula.
- **Numerical certificate** `verify_ptolemy_sine_addition.py` (stdlib only):
  builds the four points from coordinates and checks chord-as-sine,
  `|BD|=sin(α+β)`, Ptolemy, and the derived identity over 20000 trials —
  all to ~1e-16.
- **knowledge.md**: bearer audit (Mathlib's `…_of_cospherical` Ptolemy lemma
  is the engine; the cost is geometry plumbing, not a missing lemma) plus two
  Lean routes (synthetic vs algebraic-guard) and risks.

**Honesty flag**: `Real.sin_add` is already in Mathlib (analytic proof), so
this OQ is **pedagogical** (an alternative geometric derivation), not a
gap-filler. Stated as such in the docs.

New files only, path-disjoint from any in-flight PR. No Lean file shipped
(blackout) to avoid an unbuildable stub.

## Test plan
- [x] `python3 research/problems/ptolemys-theorem-oq-03/verify_ptolemy_sine_addition.py` → PASS (20000 trials, max err ~1e-16)
- [ ] Docker-up ACT: synthetic route — place the points, discharge `Cospherical`/angle hypotheses, simplify distances to sin/cos

🤖 Generated with [Claude Code](https://claude.com/claude-code)