### PR TITLE
Enrich Taylor's Theorem (mvt-oq-02): de-overlap error-bounds annotation

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/annotations.json
@@ -135,7 +135,7 @@
     "proofId": "mean-value-theorem-oq-02",
     "range": {
       "startLine": 128,
-      "endLine": 153
+      "endLine": 136
     },
     "type": "insight",
     "title": "Error Bounds and Approximation Quality from Taylor's Theorem",


### PR DESCRIPTION
## Enrichment pass for `mean-value-theorem-oq-02`

This entry is already high-quality (6 fully-fielded annotations, deep `overview`/`conclusion`, 8 cross-references). This pass fixes one genuine structural defect rather than padding content.

### Problem
`ann-mvt02-error-bounds` was assigned source range **128–153**, which entirely overlaps `ann-mvt02-second-order` (137–152). Two annotations highlighting the same `taylor_second_order` block collide in the source viewer. Separately, lines **128–136** (the Part IV docstring) had no annotation coverage.

### Fix
Re-scope `ann-mvt02-error-bounds` to **128–136** (the Part IV docstring on the exact-remainder quadratic approximation — a natural home for the error-bound insight). Annotation coverage is now contiguous and non-overlapping across lines 1–152:

| Annotation | Range |
|---|---|
| setup | 1–51 |
| taylor-poly | 52–69 |
| lagrange-axiom | 70–98 |
| mvt-recovery | 99–127 |
| error-bounds | 128–136 |
| second-order | 137–152 |

No content was deleted; only the one range changed. Data-build JSON validation passes (the `tsc` step fails only because `node_modules` is absent in this worktree — environmental, not content).