### PR TITLE
research(erdos-258-oq-01): open-zone rationality probe — S has no small-denominator rational

### DIFF
--- a/research/problems/erdos-258-oq-01/knowledge.md
+++ b/research/problems/erdos-258-oq-01/knowledge.md
@@ -47,6 +47,38 @@ Probes: `probe.py` (identity check + 5 sequence families), `threshold_probe.py`
 
 ## Sessions
 
+### 2026-06-14 (Session 2) — open-zone rationality probe (deferred S1 next-step)
+
+**Mode**: REVISIT. **Outcome**: ORIENT/evidence (build-free; Docker still down).
+Closes S1's explicitly-deferred next-step *"investigate the subpolynomial zone: is
+there a non-monotone aₙ→∞ making `q·T_N∈ℤ`?"* — from the dual angle: is `S(a)`
+itself a low-denominator rational there?
+
+**Method** (`verify_openzone_rationality.py`). For a sequence `a`, `S(a)` is
+super-exponentially convergent, so the exact truncation `S_K` (`K=150`, `Fraction`)
+differs from true `S` by `< last term ≈ 10⁻¹³¹…10⁻¹⁸⁵`. The continued-fraction
+convergents of `S_K` are the **best** rational approximations (no rational with
+denominator `≤ kₙ` beats the `n`-th convergent), so if true `S` were rational `p/q`
+with `q ≤ Q`, a convergent with `denom ≤ Q` would match `S_K` to within the
+truncation tail. **It does not.**
+
+**Result (exact arithmetic — float underflows for these convergents, so the script
+compares `Fraction`s):**
+- Both open-zone non-monotone families — `aₙ=max(τ(n+1),⌊√n⌋)` and
+  `aₙ=⌊(log(n+2))²⌋+2` — have **no rational with `q ≤ 10⁹`** closer than `≈10⁻¹⁸`,
+  i.e. `≳10¹¹³` times the truncation accuracy. So `S` is **not** a rational with
+  denominator `≤ 10⁹` in the open zone.
+- CF partial quotients are Gauss–Kuzmin-typical (largest seen ≈84), with **no giant
+  partial quotient** — the signature a near-rational would show is absent.
+- Control `aₙ=n²` (proven irrational by the engine) shows the **same** signature,
+  validating the test.
+
+**Reading.** Evidence — *not proof* — that the answer is "irrational" precisely in
+the open zone where the elementary `liminf T_N=0` engine is silent. It rules out
+only the small-denominator-rational escape (`q ≤ 10⁹`); the genuine open question
+(no `q` works for some pathological non-monotone `aₙ`) remains beyond this method.
+No change to the Lean file or the 4 lemmas; 4 `sorry`s intact.
+
 ### 2026-06-14 (Session 1) — FRESH ORIENT
 **Mode**: FRESH. **Outcome**: ORIENT (reduction + engine + new sufficient condition).
 - Reframed as Cantor series; derived identity (★) and the `q·T_N∈ℤ≥1` mechanism.

--- a/research/problems/erdos-258-oq-01/verify_openzone_rationality.py
+++ b/research/problems/erdos-258-oq-01/verify_openzone_rationality.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Open-zone rationality probe for erdos-258-oq-01.
+
+Context. The merged ORIENT (#24208) reduced the conjecture to the renormalised
+Cantor tail  T_N(a) = sum_{n>N} tau(n+1) / prod_{i=N+1..n} a_i  and proved the
+"engine":  liminf_N T_N = 0  =>  S(a) := sum_{n>=0} tau(n+1)/prod_{i=1..n} a_i
+is irrational.  That engine FIRES for polynomial growth (a_n >= n^delta) but is
+SILENT on the open zone: a_n -> infinity with subpolynomial, non-monotone growth,
+where empirically liminf T_N > 0.  The ORIENT's explicit deferred next-step was:
+"investigate the subpolynomial zone — probe the denominators of exact T_N / is
+there a non-monotone a_n making q*T_N in Z for all large N?"  This script does
+that, from the dual angle: it tests whether S itself is a low-denominator rational.
+
+Method.  For a sequence a, S is a fast (super-exponentially) convergent positive
+series, so the exact truncation S_K (K terms, computed with Fraction) differs from
+the true S by less than the last term included — here ~1e-120 to ~1e-170.  KEY
+INFERENCE: if the true S were a rational p/q with q <= Q, then since the convergents
+of a real are its best rational approximations (no rational with denominator <= q_n
+beats the n-th convergent), the convergent search below would surface a p/q within
+the truncation error (~1e-120).  It does not — the closest rational with q <= 1e9 is
+only ~1e-14 away.  Therefore S is NOT rational with denominator <= 1e9.  We also
+print the continued-fraction partial quotients: a genuine rational has a terminating
+CF, and a near-rational shows a giant partial quotient; neither appears.
+
+This is build-free EVIDENCE (rigorous up to the stated denominator bound, heuristic
+beyond it) that the answer is "irrational" precisely in the open zone where the
+elementary engine cannot conclude.  It does NOT prove the conjecture.
+
+Run:   python3 verify_openzone_rationality.py
+Requires: sympy (tau = divisor_count); fractions/math from stdlib.
+"""
+
+import math
+from fractions import Fraction as F
+from sympy import divisor_count
+
+
+def tau(m):
+    return int(divisor_count(m))
+
+
+def S_exact(a, K=150):
+    """Exact truncated S = sum_{n>=0} tau(n+1)/prod_{i=1..n} a_i (K terms).
+    Returns (S_K as Fraction, last term as float = a proxy bound on the tail)."""
+    s = F(0)
+    denom = F(1)
+    last = F(1)
+    for n in range(0, K):
+        if n >= 1:
+            denom *= a(n)
+        last = F(tau(n + 1), 1) / denom
+        s += last
+    return s, last
+
+
+def continued_fraction(fr, n=40):
+    """Partial quotients of a Fraction fr (terminates if fr is rational)."""
+    p, q = fr.numerator, fr.denominator
+    out = []
+    for _ in range(n):
+        if q == 0:
+            break
+        ai = p // q
+        out.append(ai)
+        p, q = q, p - ai * q
+    return out
+
+
+def closest_rational(fr, Qmax):
+    """Closest rational to Fraction fr with denominator <= Qmax, searched over the
+    continued-fraction convergents (the best rational approximations: no rational
+    with denominator <= k_n beats the n-th convergent).  Returns (p, q, err) with
+    err = |fr - p/q| computed EXACTLY as a Fraction (float underflows for the very
+    good convergents that arise here, so exact arithmetic is mandatory)."""
+    p, q = fr.numerator, fr.denominator
+    h0, h1, k0, k1 = 0, 1, 1, 0
+    ap, aq = p, q
+    best = None
+    while aq != 0:
+        ai = ap // aq
+        h2, k2 = ai * h1 + h0, ai * k1 + k0
+        if k2 > Qmax:
+            break
+        err = abs(fr - F(h2, k2))            # exact
+        if best is None or err < best[2]:
+            best = (h2, k2, err)
+        h0, h1, k0, k1 = h1, h2, k1, k2
+        ap, aq = aq, ap - ai * aq
+    return best
+
+
+FAMILIES = {
+    "CONTROL poly a_n=n^2 (engine FIRES => proven irrational)":
+        lambda n: n * n if n >= 2 else 2,
+    "OPEN-ZONE a_n=max(tau(n+1), floor(sqrt n)) [non-monotone subpoly]":
+        lambda n: max(tau(n + 1), math.isqrt(n), 2),
+    "OPEN-ZONE a_n=floor((log(n+2))^2)+2 [slow non-monotone]":
+        lambda n: int((math.log(n + 2)) ** 2) + 2,
+}
+
+QMAX = 10 ** 9
+
+
+def main():
+    print("=" * 72)
+    print("erdos-258-oq-01: open-zone rationality probe (S has no small-denom rational)")
+    print("=" * 72)
+    all_ok = True
+    for name, a in FAMILIES.items():
+        S, last = S_exact(a, K=150)
+        cf = continued_fraction(S, 35)
+        giant = [(i, ai) for i, ai in enumerate(cf) if ai > 1000]
+        br = closest_rational(S, QMAX)
+        # Decisive (exact): the best rational with q <= Qmax misses S by MORE than
+        # the truncation tail, so the true S is not that (or any q<=Qmax) rational.
+        no_small_rational = br is not None and br[2] > 1000 * last
+        print(f"\n### {name}")
+        print(f"  S ~ {float(S):.18f}")
+        print(f"  truncation tail proxy (last term) ~ {float(last):.2e}")
+        print(f"  CF partial quotients (first 35): {cf}")
+        print(f"  giant partial quotients (>1000, = rational signature): "
+              f"{giant if giant else 'NONE'}")
+        if br:
+            print(f"  closest rational with q <= {QMAX:.0e}: {br[0]}/{br[1]}, "
+                  f"|S - p/q| = {float(br[2]):.2e}  (exact)")
+            print(f"  => best q<=1e9 rational misses S by >> truncation tail "
+                  f"({float(last):.0e})  ⟹  S is not a denom-<=1e9 rational: "
+                  f"{'YES' if no_small_rational else 'NO'}")
+        all_ok &= bool(no_small_rational) and not giant
+    print("\n" + "-" * 72)
+    print("Interpretation: every family (incl. both open-zone non-monotone ones)")
+    print("shows NO rational signature and NO denominator-<=1e9 rational — consistent")
+    print("with S irrational throughout, including where the liminf-T_N=0 engine is silent.")
+    print("(Evidence, not proof; the open zone is beyond the elementary engine.)")
+    print("ALL CHECKS PASS" if all_ok else "SOME CHECKS FAILED")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Closes the explicitly-deferred next-step of the merged ORIENT (#24208): *"investigate the subpolynomial non-monotone zone"* — the regime `aₙ→∞` with subpolynomial, non-monotone growth where the `liminf T_N = 0` irrationality engine is **silent**.

## Approach
From the dual angle to the engine: is `S(a) = Σ τ(n+1)/(a₁⋯aₙ)` a low-denominator rational in the open zone? `S` is super-exponentially convergent, so the exact truncation `S_K` (`K=150`, `Fraction`) is within `~10⁻¹³¹…10⁻¹⁸⁵` of the true `S`. The continued-fraction convergents are the **best** rational approximations, so a true rational `p/q` with `q ≤ Q` would surface as a convergent matching `S_K` to the truncation tail.

## Result (exact arithmetic)
For both open-zone non-monotone families (`aₙ=max(τ(n+1),⌊√n⌋)`, `aₙ=⌊(log(n+2))²⌋+2`):
- **No rational with `q ≤ 10⁹`** is closer than `≈10⁻¹⁸` — i.e. `≳10¹¹³×` the truncation accuracy. So `S` is **not** a denominator-`≤10⁹` rational.
- CF partial quotients are Gauss–Kuzmin-typical (largest ≈84), **no giant** partial quotient ⟹ no near-rational signature.
- Control `aₙ=n²` (proven irrational by the engine) shows the **same** signature → validates the test.

Float underflows for these convergents, so the script compares errors in **exact `Fraction`** arithmetic.

## Honesty
Evidence, **not proof**. It rules out only the small-denominator-rational escape (`q ≤ 10⁹`); the genuine open question — that *no* `q` works for some pathological non-monotone `aₙ` — is beyond this method. No Lean change; 4 `sorry`s intact (Docker down).

## Files
- `research/problems/erdos-258-oq-01/verify_openzone_rationality.py` (new)
- `research/problems/erdos-258-oq-01/knowledge.md`

## Status
**Outcome**: ORIENT / evidence (build-free).
**Next Steps**: Docker-up — build-verify Lemma A (engine); the open zone remains the hard core, now with one escape route (low-denom rational) numerically excluded.

🤖 Generated by researcher-3