### PR TITLE
research(fermat-defect-one-oq-02): n=3 both signs are infinite Mahler families; n≥4 empty

### DIFF
--- a/proofs/Proofs/FermatDefectOneFamilies.lean
+++ b/proofs/Proofs/FermatDefectOneFamilies.lean
@@ -1,0 +1,115 @@
+/-
+  Parametric families for the Fermat Defect-One Conjecture (n = 3)
+
+  See `FermatDefectOne.lean` for the main formalization and the open headline
+  conjecture `fermat_defect_one_exists` (∀ n ≥ 3, a primitive defect-one
+  witness exists). This file addresses open question OQ-02:
+
+      "Are both signs of the defect realised for every n ≥ 3?"
+
+  ## Result for n = 3: both signs come from one parametrization
+
+  Both defect signs at n = 3 are not merely witnessed by two hand-picked
+  triples — each lies on an explicit infinite polynomial family, and both
+  families descend from Mahler's parametrization of the cubic surface
+  $x^3 + y^3 + z^3 = 1$ evaluated at the parameter and its negation:
+
+      x = 9t⁴,   y = 3t − 9t⁴,   z = 1 − 9t³,    x³ + y³ + z³ = 1.
+
+  * **Negative defect** (t ≥ 1, signs (+,−,−)): rearranging gives
+        (9t⁴ − 3t)³ + (9t³ − 1)³ + 1 = (9t⁴)³.
+    t = 1 ↦ (6, 8, 9)  [the gallery benchmark `fermat_defect_three_neg`],
+    t = 2 ↦ (71, 138, 144), t = 3 ↦ (242, 720, 729), …
+
+  * **Positive defect** (parameter −s, s ≥ 1, signs (+,+,−)): rearranging gives
+        (9s⁴)³ + (9s³ + 1)³ = (9s⁴ + 3s)³ + 1.
+    s = 1 ↦ (9, 10, 12)  [the gallery benchmark `fermat_defect_three_pos`,
+    the taxicab number 1729 shifted by one], s = 2 ↦ (73, 144, 150), …
+
+  Both identities are polynomial identities, closed by `ring`. Because the
+  parameter ranges over all naturals/integers ≥ 1 and the value of `c`
+  (`9t⁴` resp. `9s⁴ + 3s`) is strictly increasing, **each sign of the defect
+  at n = 3 has infinitely many primitive witnesses.** OQ-02 is therefore
+  fully settled in the affirmative *at n = 3*, and with explicit families
+  rather than sporadic examples.
+
+  ## Contrast at n ≥ 4 (see also `FermatDefectOneAristotle.lean`)
+
+  An exact integer search (see
+  `research/problems/fermat-defect-one-oq-02/verify_defect_search.py`) finds
+  NO primitive defect-one witness of either sign for 4 ≤ n ≤ 7 within large
+  bounds (n = 4 up to a, b ≤ 6000; n = 5 ≤ 4000; n = 6 ≤ 2500; n = 7 ≤ 2000).
+  The standard heuristic count of primitive solutions up to height X scales
+  like X^(3−n): n = 3 is the critical exponent (X⁰, log-divergent ⟹ infinitely
+  many, matching the families above), while n ≥ 4 is convergent (⟹ heuristically
+  finitely many, plausibly zero). So the n = 3 abundance is a critical-exponent
+  phenomenon, and demanding *both signs at every n ≥ 4* is, under standard
+  heuristics, expected to be hard or false — not a routine extension of n = 3.
+-/
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne
+
+/-! ## Parametric identities (the mathematical heart, closed by `ring`) -/
+
+/-- **Negative-defect family at n = 3.** For every integer `t`,
+`(9t⁴ − 3t)³ + (9t³ − 1)³ + 1 = (9t⁴)³`. Stated over `ℤ` so that the
+truncated subtraction of `ℕ` does not interfere. For `t ≥ 1` the three base
+terms are positive and give a primitive negative-defect witness `a³+b³+1=c³`
+(after ordering `a ≤ b`); `t = 1` recovers `(6,8,9)`. -/
+theorem defect_neg_family (t : ℤ) :
+    (9 * t ^ 4 - 3 * t) ^ 3 + (9 * t ^ 3 - 1) ^ 3 + 1 = (9 * t ^ 4) ^ 3 := by
+  ring
+
+/-- **Positive-defect family at n = 3.** For every natural `s`,
+`(9s⁴)³ + (9s³ + 1)³ = (9s⁴ + 3s)³ + 1`. This family is subtraction-free, so
+it holds over `ℕ` directly. For `s ≥ 1` it gives a primitive positive-defect
+witness `a³+b³=c³+1` (after ordering `a ≤ b`); `s = 1` recovers `(9,10,12)`,
+the taxicab number `1729 = 9³ + 10³ = 12³ + 1`. -/
+theorem defect_pos_family (s : ℕ) :
+    (9 * s ^ 4) ^ 3 + (9 * s ^ 3 + 1) ^ 3 = (9 * s ^ 4 + 3 * s) ^ 3 + 1 := by
+  ring
+
+/-! ## New verified primitive witnesses beyond the gallery's `t = s = 1` pair
+
+The gallery's `FermatDefectOne.lean` verifies only the first member of each
+family. These are the next members (`t = 2`, `s = 2`), confirming that the
+families produce genuine *primitive* defect-one witnesses, not just solutions
+to the equation. Discharged by `native_decide`. -/
+
+/-- Negative-defect family at `t = 2`: `71³ + 138³ + 1 = 144³`, primitive,
+`2 ≤ 71 ≤ 138 < 144`. (From `defect_neg_family 2`, ordered.) -/
+theorem fermat_defect_three_neg_t2 : FermatDefectWitness 3 71 138 144 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · left; native_decide
+
+/-- Positive-defect family at `s = 2`: `73³ + 144³ = 150³ + 1`, primitive,
+`2 ≤ 73 ≤ 144 < 150`. (From `defect_pos_family 2`, ordered.) -/
+theorem fermat_defect_three_pos_s2 : FermatDefectWitness 3 73 144 150 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · right; native_decide
+
+/-! ## Existence packaging at n = 3 (both signs), from the families
+
+These re-derive `FermatDefectExists 3` along each family member, witnessing
+that the *family* — not just the gallery benchmark — settles n = 3 for each
+sign. -/
+
+/-- Negative sign realised at n = 3 (family member `t = 2`). -/
+theorem defect_exists_three_neg : FermatDefectExists 3 :=
+  ⟨71, 138, 144, fermat_defect_three_neg_t2⟩
+
+/-- Positive sign realised at n = 3 (family member `s = 2`). -/
+theorem defect_exists_three_pos : FermatDefectExists 3 :=
+  ⟨73, 144, 150, fermat_defect_three_pos_s2⟩
+
+end FermatDefectOne

--- a/research/problems/fermat-defect-one-oq-02/verify_defect_search.py
+++ b/research/problems/fermat-defect-one-oq-02/verify_defect_search.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Exact integer search for primitive Fermat defect-one witnesses, both signs.
+
+OQ-02 (Level 3): for every n >= 3 and every epsilon in {-1,+1}, does there
+exist a primitive nontrivial triple (a,b,c) with
+
+    2 <= a <= b < c,  gcd(a,b,c) = 1,  a^n + b^n - c^n = epsilon ?
+
+On Nat this splits into
+    negative defect (eps = -1):  a^n + b^n + 1 = c^n   (c^n = s + 1)
+    positive defect (eps = +1):  a^n + b^n     = c^n + 1 (c^n = s - 1)
+with s = a^n + b^n.
+
+The arithmetic is exact (Python big ints). For each (a,b) with 2 <= a <= b,
+we test whether s+1 and s-1 are perfect n-th powers c^n with c > b, then
+check primitivity. No floating point: integer n-th root by bisection with
+exact verification.
+
+This pins down which (n, sign) rows of the conjecture's table are realised by
+*small* witnesses, and -- equally informative -- which rows have NO witness
+below the searched bound (evidence that any witness, if it exists, is
+astronomically large, consistent with abc-style sparsity heuristics).
+
+Usage:  python3 verify_defect_search.py [--bmax B] [--nmax N]
+"""
+
+import argparse
+from math import gcd
+
+
+def iroot(x, n):
+    """Exact integer n-th root: largest r with r**n <= x (x >= 0)."""
+    if x < 0:
+        return -1
+    if x == 0:
+        return 0
+    # initial bracket
+    hi = 1
+    while hi ** n <= x:
+        hi <<= 1
+    lo = hi >> 1
+    while lo < hi:
+        mid = (lo + hi + 1) >> 1
+        if mid ** n <= x:
+            lo = mid
+        else:
+            hi = mid - 1
+    return lo
+
+
+def is_perfect_power(x, n):
+    """Return c if x == c**n with c >= 0, else None."""
+    if x < 0:
+        return None
+    r = iroot(x, n)
+    if r ** n == x:
+        return r
+    return None
+
+
+def search(n, bmax):
+    """Return lists of primitive witnesses (a,b,c) for neg and pos defect."""
+    neg = []  # a^n + b^n + 1 = c^n
+    pos = []  # a^n + b^n     = c^n + 1
+    # precompute powers
+    powr = [k ** n for k in range(bmax + 2)]
+    for a in range(2, bmax + 1):
+        an = powr[a]
+        for b in range(a, bmax + 1):
+            s = an + powr[b]
+            # negative defect: c^n = s + 1
+            c = is_perfect_power(s + 1, n)
+            if c is not None and c > b:
+                if gcd(gcd(a, b), c) == 1:
+                    neg.append((a, b, c))
+            # positive defect: c^n = s - 1
+            c = is_perfect_power(s - 1, n)
+            if c is not None and c > b:
+                if gcd(gcd(a, b), c) == 1:
+                    pos.append((a, b, c))
+    return neg, pos
+
+
+def verify_families(tmax=200):
+    """Verify the two parametric n=3 families that settle OQ-02 at n=3.
+
+    These are the Lean `ring`-identities in
+    proofs/Proofs/FermatDefectOneFamilies.lean.
+
+      negative defect: (9t^4 - 3t)^3 + (9t^3 - 1)^3 + 1 = (9t^4)^3
+      positive defect: (9s^4)^3   + (9s^3 + 1)^3       = (9s^4 + 3s)^3 + 1
+
+    Both descend from Mahler's parametrization of x^3+y^3+z^3=1 at t and -t.
+    We check the identity AND primitivity (gcd of the ordered triple = 1) AND
+    the witness bounds 2 <= a <= b < c, for every parameter 1..tmax.
+    """
+    neg_c, pos_c = set(), set()
+    for t in range(1, tmax + 1):
+        # negative: a3+b3+1=c3
+        A, B, c = 9 * t ** 4 - 3 * t, 9 * t ** 3 - 1, 9 * t ** 4
+        a, b = sorted((A, B))
+        assert a ** 3 + b ** 3 + 1 == c ** 3, f"neg identity fails at t={t}"
+        assert gcd(gcd(a, b), c) == 1, f"neg not primitive at t={t}: {(a,b,c)}"
+        assert 2 <= a <= b < c, f"neg bounds fail at t={t}: {(a,b,c)}"
+        neg_c.add(c)
+    for s in range(1, tmax + 1):
+        A, B, c = 9 * s ** 4, 9 * s ** 3 + 1, 9 * s ** 4 + 3 * s
+        a, b = sorted((A, B))
+        assert a ** 3 + b ** 3 == c ** 3 + 1, f"pos identity fails at s={s}"
+        assert gcd(gcd(a, b), c) == 1, f"pos not primitive at s={s}: {(a,b,c)}"
+        assert 2 <= a <= b < c, f"pos bounds fail at s={s}: {(a,b,c)}"
+        pos_c.add(c)
+    # strictly increasing c => infinitely many distinct primitive witnesses
+    assert len(neg_c) == tmax and len(pos_c) == tmax
+    print(f"[families] OK: both n=3 families primitive & in-bounds for "
+          f"t,s = 1..{tmax}; {tmax} distinct c each (=> infinitely many).")
+
+
+def self_test():
+    """Confirm the two known n=3 benchmarks are found and families hold."""
+    neg, pos = search(3, 12)
+    assert (6, 8, 9) in neg, f"missing neg n=3 witness; got {neg}"
+    assert (9, 10, 12) in pos, f"missing pos n=3 witness; got {pos}"
+    # sanity on iroot
+    assert iroot(729, 3) == 9 and iroot(728, 3) == 8
+    assert is_perfect_power(1729 - 1, 3) == 12
+    print("[self-test] OK: n=3 benchmarks (6,8,9) neg and (9,10,12) pos recovered.")
+    verify_families()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bmax", type=int, default=3000,
+                    help="search a,b up to this bound (default 3000)")
+    ap.add_argument("--nmax", type=int, default=8,
+                    help="search exponents 3..nmax (default 8)")
+    args = ap.parse_args()
+
+    self_test()
+    print(f"\nSearching primitive defect-one witnesses, 2<=a<=b<={args.bmax}, "
+          f"n=3..{args.nmax}\n")
+    print(f"{'n':>3} {'#neg(-1)':>9} {'#pos(+1)':>9}  smallest witnesses")
+    for n in range(3, args.nmax + 1):
+        neg, pos = search(n, args.bmax)
+        # smallest by c
+        neg_s = sorted(neg, key=lambda t: (t[2], t[0], t[1]))[:2]
+        pos_s = sorted(pos, key=lambda t: (t[2], t[0], t[1]))[:2]
+        def fmt(lst):
+            return ", ".join(f"({a},{b},{c})" for a, b, c in lst) or "NONE"
+        print(f"{n:>3} {len(neg):>9} {len(pos):>9}  "
+              f"neg=[{fmt(neg_s)}]  pos=[{fmt(pos_s)}]")
+    print("\nNote: 'NONE' at the searched bound is evidence of absence of SMALL "
+          "witnesses,\nnot a proof of non-existence (abc heuristics permit rare "
+          "large witnesses).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/fermat-defect-one-oq-02.json
+++ b/src/data/research/problems/fermat-defect-one-oq-02.json
@@ -1,0 +1,96 @@
+{
+  "slug": "fermat-defect-one-oq-02",
+  "title": "Fermat Defect-One: are both signs realised for every n ≥ 3?",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall n \\ge 3:\\quad \\Big(\\exists x,y,z \\in \\mathbb{Z}_{>0},\\ x^n + y^n - z^n = +1\\Big)\\ \\wedge\\ \\Big(\\exists x,y,z \\in \\mathbb{Z}_{>0},\\ x^n + y^n - z^n = -1\\Big)\\ ?",
+    "plain": "The Fermat defect-one question asks, for each exponent n ≥ 3, whether the Diophantine equation |xⁿ + yⁿ − zⁿ| = 1 has solutions in positive integers realising BOTH the +1 and the −1 sign (\"Level 3\"). At n = 3 both signs occur; for general n a modular (congruence) obstruction might rule out one sign at specific exponents. The goal is to decide whether both signs are realised for every n ≥ 3, or to exhibit an exponent n where one sign is provably impossible.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-15T06:15:07.078468+00:00",
+    "iteration": 2,
+    "focus": "n=3 fully characterised (both signs, infinite families); n>=4 reframed via heuristic + empty search.",
+    "blockers": [],
+    "nextAction": "Build FermatDefectOneFamilies.lean; optionally formalize infinitude; tackle bounded-nonexistence at n=4.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: n=3 settled for BOTH signs via explicit infinite parametric families (Mahler x^3+y^3+z^3=1 at +/-t); n>=4 empty in large exact searches; X^(3-n) heuristic reframes 'every n>=3' as Fermat-Catalan-finiteness for n>=4.",
+    "builtItems": [
+      "defect_neg_family (t:Z): (9t^4-3t)^3+(9t^3-1)^3+1=(9t^4)^3 [ring] in proofs/Proofs/FermatDefectOneFamilies.lean",
+      "defect_pos_family (s:N): (9s^4)^3+(9s^3+1)^3=(9s^4+3s)^3+1 [ring, subtraction-free over N]",
+      "fermat_defect_three_neg_t2 : FermatDefectWitness 3 71 138 144 [native_decide]",
+      "fermat_defect_three_pos_s2 : FermatDefectWitness 3 73 144 150 [native_decide]",
+      "research/problems/fermat-defect-one-oq-02/verify_defect_search.py: exact both-sign search + family verifier (identity+primitivity+bounds, t,s=1..200)"
+    ],
+    "insights": [
+      "Both n=3 defect signs lie on infinite polynomial families, both descending from Mahler's parametrization of x^3+y^3+z^3=1 at parameter t (neg) and -t (pos); t=1/s=1 recover the gallery benchmarks (6,8,9) and (9,10,12).",
+      "Each family is primitive (gcd=1) and in-bounds (2<=a<=b<c) for all parameters >=1 with strictly increasing c => infinitely many primitive witnesses of EACH sign at n=3.",
+      "Exact search finds NO primitive defect-one witness of either sign for 4<=n<=7 (n=4 up to a,b<=6000; n=5<=4000; n=6<=2500; n=7<=2000).",
+      "Expected count of primitive defect-one solutions up to height X scales like X^(3-n): n=3 is the critical exponent (X^0, log-divergent => infinitely many) while n>=4 is convergent (=> finitely many, plausibly zero).",
+      "Reframing: 'both signs for every n>=3' is heuristically hard/false for n>=4; the n=3 abundance is a critical-exponent artifact, and n>=4 is governed by Fermat-Catalan-type finiteness. Confirms the existing no_witness_n_eq_4_below_20 target is TRUE.",
+      "The families are not exhaustive: positive witness (64,94,103) is off-family (other rational curves on the same cubic surface)."
+    ],
+    "mathlibGaps": [
+      "No abc-conjecture / Fermat-Catalan finiteness machinery in Mathlib to attack the n>=4 case (the open part).",
+      "n=3 result needs nothing beyond ring + native_decide."
+    ],
+    "nextSteps": [
+      "Build & ship FermatDefectOneFamilies.lean once Docker is back (identities are ring-trivial; build is the only gate).",
+      "Optional: upgrade to a Lean infinitude theorem (inject N->witnesses; c=9s^4+3s strictly monotone) -- routine but needs generic bounds/primitivity packaging (Nat-subtraction care on neg family).",
+      "Discharge no_witness_n_eq_4_below_20 via decide/native_decide or Aristotle (confirmed TRUE by search)."
+    ],
+    "markdown": "# Knowledge Base: fermat-defect-one-oq-02\n\n## Source\nSeeker-selected gallery-extracted open question extending **fermat-defect-one**.\n\n## Progress Summary\nStub created by Seeker. No research progress yet.\n\n## Mathlib Notes\n[To be filled by the Researcher during OBSERVE/ORIENT.]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "fermat-defect-one"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T06:29:35.219Z",
+  "lastUpdate": "2026-06-15T06:29:35.257Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/FermatDefectOne.lean",
+      "filename": "FermatDefectOne.lean",
+      "lineCount": 147,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FermatDefectOne.lean"
+    },
+    {
+      "path": "Proofs/FermatDefectOneAristotle.lean",
+      "filename": "FermatDefectOneAristotle.lean",
+      "lineCount": 77,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FermatDefectOneAristotle.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Open question **OQ-02** of `fermat-defect-one` asks: *are both signs of the defect `|aⁿ+bⁿ−cⁿ|=1` realised for every n ≥ 3?* This session settles **n = 3** and reframes **n ≥ 4**.

- **n = 3, both signs — explicit infinite families** (both descend from Mahler's parametrization of `x³+y³+z³=1` at parameter `±t`):
  - negative: `(9t⁴−3t)³ + (9t³−1)³ + 1 = (9t⁴)³`  (`ring`, over ℤ)
  - positive: `(9s⁴)³ + (9s³+1)³ = (9s⁴+3s)³ + 1`  (`ring`, subtraction-free over ℕ)
  - `t=1`/`s=1` recover the gallery benchmarks `(6,8,9)` and `(9,10,12)` (taxicab 1729 + 1). Both families are primitive (`gcd=1`) and satisfy `2≤a≤b<c` for every parameter ≥ 1, with strictly increasing `c` ⟹ **infinitely many primitive witnesses of each sign at n = 3**.
- **n ≥ 4 — empty** in large exact searches: no primitive witness of either sign for `4≤n≤7` (n=4 to a,b≤6000; n=5≤4000; n=6≤2500; n=7≤2000).
- **Heuristic reframe**: expected primitive-solution count up to height `X` scales like `X^(3−n)`. n = 3 is the critical exponent (`X⁰`, log-divergent ⟹ infinite — matching the families); n ≥ 4 is convergent (⟹ finitely many, plausibly zero). So "both signs for every n ≥ 3" is, under standard abc/Fermat–Catalan heuristics, hard or false for n ≥ 4 — the n = 3 abundance is a critical-exponent phenomenon. Corroborates the existing `no_witness_n_eq_4_below_20` target.

## Changes

- `proofs/Proofs/FermatDefectOneFamilies.lean` — new companion: two parametric identities (`ring`), two new verified primitive witnesses at `t=2`/`s=2` (`native_decide`), and `FermatDefectExists 3` along each family.
- `research/problems/fermat-defect-one-oq-02/verify_defect_search.py` — exact both-sign integer search + family verifier (identity + primitivity + bounds for `t,s = 1..200`; self-test recovers both benchmarks).
- `research/problems/fermat-defect-one-oq-02/knowledge.md`, problem JSON (phase → ACT).

## Verification status

- Identities and concrete witnesses verified **exactly in Python** (big-int arithmetic); the Lean is `ring` + `native_decide` only.
- **Build-gated**: Docker was down this session, so `FermatDefectOneFamilies.lean` is not yet `lake`-built. The identities are `ring`-trivial; the build is the only remaining gate.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneFamilies`
- [x] `python3 research/problems/fermat-defect-one-oq-02/verify_defect_search.py` (self-test + family checks pass)