### PR TITLE
research(synthesis-curvature-ptolemy-oq-01): curvatureSin satisfies the curvature ODE y''+K·y=0

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2847,6 +2847,7 @@ import Proofs.SylowTheoremOQ03
 import Proofs.SylowTheoremOQ03B
 import Proofs.SylowTheoremOQ04
 import Proofs.SynthesisCurvaturePtolemy
+import Proofs.SynthesisCurvaturePtolemyOQ01
 import Proofs.SzemerediCore
 import Proofs.SzemerediCoreOQ01
 import Proofs.SzemerediCoreOQ01Aristotle

--- a/proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean
+++ b/proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean
@@ -1,0 +1,216 @@
+import Proofs.SynthesisCurvaturePtolemy
+import Mathlib.Tactic
+
+/-!
+# Synthesis: curvatureSin satisfies the curvature ODE  y'' + K·y = 0  (OQ-01)
+
+Building on `SynthesisCurvaturePtolemy.lean`, which defines the
+curvature-parametrized function
+
+  curvatureSin K t =
+    | t                          (K = 0,  Euclidean)
+    | sin (√K · t) / √K          (K > 0,  spherical)
+    | sinh (√(-K) · t) / √(-K)   (K < 0,  hyperbolic)
+
+and already establishes the initial conditions
+
+  curvatureSin K 0 = 0       (`curvatureSin_zero_right`)
+  (curvatureSin K)'(0) = 1   (`curvatureSin_hasDerivAt_zero`),
+
+this file proves the **defining second-order ODE**
+
+  y'' + K · y = 0       where  y = curvatureSin K.
+
+Together with the two initial conditions, this is the unique-solution
+characterization referenced in the parent file's docstring: `curvatureSin K`
+is THE solution of `y'' + K·y = 0` with `y(0) = 0`, `y'(0) = 1`. This unifies
+the three constant-curvature model geometries under a single linear ODE.
+
+## Structure
+
+1. `curvatureCos K t` — the first derivative ("curvature cosine"):
+   1 (K=0), cos(√K t) (K>0), cosh(√(-K) t) (K<0).
+2. `curvatureSin_hasDerivAt`   :  (curvatureSin K)' t = curvatureCos K t
+3. `curvatureCos_hasDerivAt`   :  (curvatureCos K)' t = -K · curvatureSin K t
+4. `curvatureSin_deriv_eq`     :  deriv (curvatureSin K) = curvatureCos K
+5. `curvatureSin_second_deriv` :  (curvatureSin K)'' t = -K · curvatureSin K t
+6. `curvatureSin_satisfies_ode`:  (curvatureSin K)'' t + K · curvatureSin K t = 0
+
+The first-derivative closed forms and the y''+K·y=0 identity are verified
+symbolically (exact, no floating point) for all three cases in
+`research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py`.
+-/
+
+namespace SynthesisCurvaturePtolemyOQ01
+
+open Real
+
+/-- Auxiliary: derivative of `Real.sinh` is `Real.cosh` (re-derived from `exp`,
+since the parent file's version is `private`). -/
+private theorem hasDerivAt_sinh (x : ℝ) : HasDerivAt Real.sinh (Real.cosh x) x := by
+  have h1 := Real.hasDerivAt_exp x
+  have h2 := (Real.hasDerivAt_exp (-x)).comp x (hasDerivAt_neg x)
+  have hsinhDef : Real.sinh = fun y => (Real.exp y - Real.exp (-y)) / 2 := by
+    ext y; exact Real.sinh_eq y
+  rw [hsinhDef]
+  have hcoshEq : Real.cosh x = (Real.exp x + Real.exp (-x)) / 2 := Real.cosh_eq x
+  rw [hcoshEq]
+  convert (h1.sub h2).div_const 2 using 1
+  ring
+
+/-- Auxiliary: derivative of `Real.cosh` is `Real.sinh` (re-derived from `exp`). -/
+private theorem hasDerivAt_cosh (x : ℝ) : HasDerivAt Real.cosh (Real.sinh x) x := by
+  have h1 := Real.hasDerivAt_exp x
+  have h2 := (Real.hasDerivAt_exp (-x)).comp x (hasDerivAt_neg x)
+  have hcoshDef : Real.cosh = fun y => (Real.exp y + Real.exp (-y)) / 2 := by
+    ext y; exact Real.cosh_eq y
+  rw [hcoshDef]
+  have hsinhEq : Real.sinh x = (Real.exp x - Real.exp (-x)) / 2 := Real.sinh_eq x
+  rw [hsinhEq]
+  convert (h1.add h2).div_const 2 using 1
+  ring
+
+/-- The **curvatureCos K** function: the first derivative of `curvatureSin K`.
+
+- K = 0 (Euclidean):   curvatureCos 0 t = 1
+- K > 0 (spherical):   curvatureCos K t = cos (√K · t)
+- K < 0 (hyperbolic):  curvatureCos K t = cosh (√(-K) · t) -/
+noncomputable def curvatureCos (K t : ℝ) : ℝ :=
+  if K = 0 then 1
+  else if 0 < K then Real.cos (Real.sqrt K * t)
+  else Real.cosh (Real.sqrt (-K) * t)
+
+@[simp]
+lemma curvatureCos_zero (t : ℝ) : curvatureCos 0 t = 1 := by
+  simp [curvatureCos]
+
+lemma curvatureCos_pos {K : ℝ} (hK : 0 < K) (t : ℝ) :
+    curvatureCos K t = Real.cos (Real.sqrt K * t) := by
+  simp only [curvatureCos, if_neg (ne_of_gt hK), if_pos hK]
+
+lemma curvatureCos_neg {K : ℝ} (hK : K < 0) (t : ℝ) :
+    curvatureCos K t = Real.cosh (Real.sqrt (-K) * t) := by
+  simp only [curvatureCos, if_neg (ne_of_lt hK), if_neg (not_lt.mpr (le_of_lt hK))]
+
+/-- **First derivative**: `(curvatureSin K)' t = curvatureCos K t` for every `t`.
+
+This generalizes the parent file's `curvatureSin_hasDerivAt_zero` (the `t = 0`
+case) to all of `ℝ`. -/
+theorem curvatureSin_hasDerivAt (K t : ℝ) :
+    HasDerivAt (curvatureSin K) (curvatureCos K t) t := by
+  by_cases hK0 : K = 0
+  · -- Euclidean: curvatureSin 0 = id, curvatureCos 0 = 1.
+    subst hK0
+    have hfun : curvatureSin 0 = id := by ext s; simp [curvatureSin]
+    rw [hfun, curvatureCos_zero]
+    exact hasDerivAt_id t
+  · by_cases hKpos : 0 < K
+    · -- Spherical: d/dt [sin(√K t)/√K] = cos(√K t)·√K/√K = cos(√K t).
+      have hS : (Real.sqrt K : ℝ) ≠ 0 := Real.sqrt_ne_zero'.mpr hKpos
+      have hfun : curvatureSin K = fun s => Real.sin (Real.sqrt K * s) / Real.sqrt K := by
+        ext s; simp [curvatureSin, if_neg hK0, if_pos hKpos]
+      rw [hfun, curvatureCos_pos hKpos]
+      have h1 : HasDerivAt (fun s => Real.sqrt K * s) (Real.sqrt K) t :=
+        (hasDerivAt_id t).const_mul (Real.sqrt K)
+      have h2 : HasDerivAt Real.sin (Real.cos (Real.sqrt K * t)) (Real.sqrt K * t) :=
+        Real.hasDerivAt_sin (Real.sqrt K * t)
+      have h3 : HasDerivAt (fun s => Real.sin (Real.sqrt K * s))
+          (Real.cos (Real.sqrt K * t) * Real.sqrt K) t := h2.comp t h1
+      have h4 := h3.div_const (Real.sqrt K)
+      rwa [mul_div_assoc, div_self hS, mul_one] at h4
+    · -- Hyperbolic: d/dt [sinh(√(-K) t)/√(-K)] = cosh(√(-K) t)·√(-K)/√(-K).
+      have hKneg : K < 0 := lt_of_le_of_ne (not_lt.mp hKpos) hK0
+      have hNK : (0 : ℝ) < -K := neg_pos.mpr hKneg
+      have hS : (Real.sqrt (-K) : ℝ) ≠ 0 := Real.sqrt_ne_zero'.mpr hNK
+      have hfun : curvatureSin K = fun s => Real.sinh (Real.sqrt (-K) * s) / Real.sqrt (-K) := by
+        ext s; simp [curvatureSin, if_neg hK0, if_neg (not_lt.mpr (le_of_lt hKneg))]
+      rw [hfun, curvatureCos_neg hKneg]
+      have h1 : HasDerivAt (fun s => Real.sqrt (-K) * s) (Real.sqrt (-K)) t :=
+        (hasDerivAt_id t).const_mul (Real.sqrt (-K))
+      have h2 : HasDerivAt Real.sinh (Real.cosh (Real.sqrt (-K) * t)) (Real.sqrt (-K) * t) :=
+        hasDerivAt_sinh (Real.sqrt (-K) * t)
+      have h3 : HasDerivAt (fun s => Real.sinh (Real.sqrt (-K) * s))
+          (Real.cosh (Real.sqrt (-K) * t) * Real.sqrt (-K)) t := h2.comp t h1
+      have h4 := h3.div_const (Real.sqrt (-K))
+      rwa [mul_div_assoc, div_self hS, mul_one] at h4
+
+/-- **Second derivative**: `(curvatureCos K)' t = -K · curvatureSin K t`.
+
+This is the heart of the ODE: differentiating the curvature cosine returns
+`-K` times the curvature sine, in all three geometries. -/
+theorem curvatureCos_hasDerivAt (K t : ℝ) :
+    HasDerivAt (curvatureCos K) (-K * curvatureSin K t) t := by
+  by_cases hK0 : K = 0
+  · -- Euclidean: curvatureCos 0 = const 1, derivative 0 = -0 · t.
+    subst hK0
+    have hfun : curvatureCos 0 = fun _ => (1 : ℝ) := by ext s; simp [curvatureCos]
+    rw [hfun]
+    have : (-(0 : ℝ)) * curvatureSin 0 t = 0 := by simp
+    rw [this]
+    exact hasDerivAt_const t 1
+  · by_cases hKpos : 0 < K
+    · -- Spherical: d/dt cos(√K t) = -sin(√K t)·√K = -K·sin(√K t)/√K.
+      have hS : (Real.sqrt K : ℝ) ≠ 0 := Real.sqrt_ne_zero'.mpr hKpos
+      have hKK : Real.sqrt K * Real.sqrt K = K := Real.mul_self_sqrt (le_of_lt hKpos)
+      have hfun : curvatureCos K = fun s => Real.cos (Real.sqrt K * s) := by
+        ext s; rw [curvatureCos_pos hKpos]
+      rw [hfun]
+      have h1 : HasDerivAt (fun s => Real.sqrt K * s) (Real.sqrt K) t :=
+        (hasDerivAt_id t).const_mul (Real.sqrt K)
+      have h2 : HasDerivAt Real.cos (-Real.sin (Real.sqrt K * t)) (Real.sqrt K * t) :=
+        Real.hasDerivAt_cos (Real.sqrt K * t)
+      have h3 : HasDerivAt (fun s => Real.cos (Real.sqrt K * s))
+          (-Real.sin (Real.sqrt K * t) * Real.sqrt K) t := h2.comp t h1
+      convert h3 using 1
+      rw [curvatureSin_pos hKpos, ← mul_div_assoc, div_eq_iff hS]
+      linear_combination Real.sin (Real.sqrt K * t) * hKK
+    · -- Hyperbolic: d/dt cosh(√(-K) t) = sinh(√(-K) t)·√(-K) = -K·sinh(√(-K) t)/√(-K).
+      have hKneg : K < 0 := lt_of_le_of_ne (not_lt.mp hKpos) hK0
+      have hNK : (0 : ℝ) < -K := neg_pos.mpr hKneg
+      have hS : (Real.sqrt (-K) : ℝ) ≠ 0 := Real.sqrt_ne_zero'.mpr hNK
+      have hKK : Real.sqrt (-K) * Real.sqrt (-K) = -K := Real.mul_self_sqrt (le_of_lt hNK)
+      have hfun : curvatureCos K = fun s => Real.cosh (Real.sqrt (-K) * s) := by
+        ext s; rw [curvatureCos_neg hKneg]
+      rw [hfun]
+      have h1 : HasDerivAt (fun s => Real.sqrt (-K) * s) (Real.sqrt (-K)) t :=
+        (hasDerivAt_id t).const_mul (Real.sqrt (-K))
+      have h2 : HasDerivAt Real.cosh (Real.sinh (Real.sqrt (-K) * t)) (Real.sqrt (-K) * t) :=
+        hasDerivAt_cosh (Real.sqrt (-K) * t)
+      have h3 : HasDerivAt (fun s => Real.cosh (Real.sqrt (-K) * s))
+          (Real.sinh (Real.sqrt (-K) * t) * Real.sqrt (-K)) t := h2.comp t h1
+      convert h3 using 1
+      rw [curvatureSin_neg hKneg, ← mul_div_assoc, div_eq_iff hS]
+      linear_combination (-Real.sinh (Real.sqrt (-K) * t)) * hKK
+
+/-- `deriv (curvatureSin K) = curvatureCos K` as functions. -/
+theorem curvatureSin_deriv_eq (K : ℝ) : deriv (curvatureSin K) = curvatureCos K := by
+  ext t
+  exact (curvatureSin_hasDerivAt K t).deriv
+
+/-- The second derivative of `curvatureSin K` is `-K · curvatureSin K`. -/
+theorem curvatureSin_second_deriv (K t : ℝ) :
+    deriv (deriv (curvatureSin K)) t = -K * curvatureSin K t := by
+  rw [curvatureSin_deriv_eq]
+  exact (curvatureCos_hasDerivAt K t).deriv
+
+/-- **Main result (OQ-01)**: `curvatureSin K` satisfies the curvature ODE
+
+  y'' + K · y = 0
+
+for every curvature `K ∈ ℝ` and every `t ∈ ℝ`. Combined with the parent file's
+initial conditions `curvatureSin K 0 = 0` and `(curvatureSin K)'(0) = 1`, this
+characterizes `curvatureSin K` as the unique solution of the constant-curvature
+oscillator equation — unifying the Euclidean, spherical and hyperbolic models. -/
+theorem curvatureSin_satisfies_ode (K t : ℝ) :
+    deriv (deriv (curvatureSin K)) t + K * curvatureSin K t = 0 := by
+  rw [curvatureSin_second_deriv]
+  ring
+
+/-- The initial conditions, restated for convenience: `y(0) = 0` and `y'(0) = 1`.
+(Both are proved in the parent file; collected here as the IVP companion to the
+ODE above.) -/
+theorem curvatureSin_initial_conditions (K : ℝ) :
+    curvatureSin K 0 = 0 ∧ deriv (curvatureSin K) 0 = 1 :=
+  ⟨curvatureSin_zero_right K, curvatureSin_deriv_zero K⟩
+
+end SynthesisCurvaturePtolemyOQ01

--- a/research/problems/synthesis-curvature-ptolemy-oq-01/knowledge.md
+++ b/research/problems/synthesis-curvature-ptolemy-oq-01/knowledge.md
@@ -1,27 +1,71 @@
-# Knowledge Base: synthesis-curvature-ptolemy-oq-01
+# synthesis-curvature-ptolemy-oq-01
 
-Insights accumulated during research on this problem.
+**Question**: Prove `curvatureSin K` satisfies the second-order ODE `y'' + K·y = 0`.
 
----
+## Summary
 
-## Problem Understanding
+`curvatureSin K t` (defined in `proofs/Proofs/SynthesisCurvaturePtolemy.lean`) is the
+curvature-parametrized "sine" unifying the three constant-curvature model geometries:
 
-(Initial observations from OBSERVE phase will be recorded here.)
+| regime | curvatureSin K t |
+|--------|------------------|
+| K = 0 (Euclidean)  | `t` |
+| K > 0 (spherical)  | `sin(√K · t) / √K` |
+| K < 0 (hyperbolic) | `sinh(√(-K) · t) / √(-K)` |
 
----
+The parent file already proves the initial conditions: `curvatureSin K 0 = 0`
+(`curvatureSin_zero_right`) and `(curvatureSin K)'(0) = 1`
+(`curvatureSin_hasDerivAt_zero`). OQ-01 asks for the **defining ODE** that, together
+with those two initial conditions, uniquely characterizes the function:
 
-## Insights
+    y'' + K · y = 0.
 
-(Insights from research attempts will be accumulated here.)
+## Mathematical content (settled / known)
 
----
+This is a known constant-coefficient linear ODE. The point of formalizing it is to
+confirm that a single function `curvatureSin K` solves it uniformly across all three
+geometries (the "synthesis" claim of the parent file). First derivative ("curvatureCos"):
 
-## Mathlib Coverage Audit
+| regime | (curvatureSin K)' t |
+|--------|---------------------|
+| K = 0  | `1` |
+| K > 0  | `cos(√K · t)` |
+| K < 0  | `cosh(√(-K) · t)` |
 
-(After ORIENT phase: list of relevant Mathlib lemmas / APIs and their applicability.)
+The ODE then follows because differentiating curvatureCos returns `-K · curvatureSin`:
+the spherical/hyperbolic cases use `√K·√K = K` (resp. `√(-K)·√(-K) = -K`) to convert
+`∓ sin/sinh · √K` into `-K · (sin/sinh)/√K`. Verified exactly (symbolic, no float) for
+all three regimes in `verify_ode.py` (curvatureCos closed form, ODE, initial conditions).
 
----
+## Built this session (proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean)
 
-## Anti-Goals
+- `curvatureCos K t` — first-derivative function (1 / cos / cosh by regime).
+- `curvatureSin_hasDerivAt (K t)` : `HasDerivAt (curvatureSin K) (curvatureCos K t) t`
+  — generalizes parent's `curvatureSin_hasDerivAt_zero` from t=0 to all t.
+- `curvatureCos_hasDerivAt (K t)` : `HasDerivAt (curvatureCos K) (-K · curvatureSin K t) t`
+  — the second-derivative step (heart of the ODE).
+- `curvatureSin_deriv_eq (K)` : `deriv (curvatureSin K) = curvatureCos K`.
+- `curvatureSin_second_deriv (K t)` : `deriv (deriv (curvatureSin K)) t = -K · curvatureSin K t`.
+- `curvatureSin_satisfies_ode (K t)` : `deriv (deriv (curvatureSin K)) t + K · curvatureSin K t = 0`.
+- `curvatureSin_initial_conditions (K)` : `curvatureSin K 0 = 0 ∧ deriv (curvatureSin K) 0 = 1`.
 
-(Things explicitly NOT to attempt — discovered duplicates, scope creep risks, etc.)
+Re-derived `hasDerivAt_sinh` / `hasDerivAt_cosh` from `Real.hasDerivAt_exp` (parent's
+`hasDerivAt_sinh` is `private`). All HasDerivAt chains mirror the parent's proven
+`curvatureSin_hasDerivAt_zero` pattern (`comp` + `div_const`, with the √-cancellation
+done via `mul_div_assoc`/`div_eq_iff` + `linear_combination ... * (√·√ = ·)`).
+
+## Status
+
+- **Phase**: ACT (Lean written; no sorries). **Build-pending**: Docker was DOWN this
+  session, so the file is not yet machine-checked locally. Math is exact-verified by
+  `verify_ode.py`.
+
+## Next steps
+
+1. Build `Proofs.SynthesisCurvaturePtolemyOQ01` via docker-build when Docker is back;
+   fix any tactic-level mismatches (most fragile: the two `linear_combination` √-cancel
+   steps — coefficients are `sin(√K·t)` and `-sinh(√(-K)·t)`).
+2. If a `linear_combination` step fails, fall back to `field_simp; ring_nf` then
+   `rw [Real.sq_sqrt]` / `Real.mul_self_sqrt`.
+3. Possible follow-up OQ: uniqueness — any `y` with `y''+K·y=0`, `y(0)=0`, `y'(0)=1`
+   equals `curvatureSin K` (would use Mathlib ODE/Picard–Lindelöf or Wronskian).

--- a/research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py
+++ b/research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Durable EXACT (symbolic) verification for synthesis-curvature-ptolemy-oq-01.
+
+Claim (OQ-01): the curvature-parametrized function
+
+    curvatureSin K t =
+        | t                         (K = 0,  Euclidean)
+        | sin(sqrt(K)  * t)/sqrt(K)   (K > 0,  spherical)
+        | sinh(sqrt(-K)* t)/sqrt(-K)  (K < 0,  hyperbolic)
+
+satisfies the second-order linear ODE
+
+    y'' + K * y = 0
+
+for all K and t, with initial conditions y(0)=0, y'(0)=1.
+
+This script confirms, by exact symbolic differentiation (no floating point):
+  1. the first-derivative closed form ("curvatureCos"),
+  2. the ODE  y'' + K*y == 0,
+  3. the initial conditions y(0)=0, y'(0)=1,
+in each of the three curvature regimes.
+
+These are exactly the statements formalized in
+proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean
+(curvatureSin_hasDerivAt, curvatureCos_hasDerivAt, curvatureSin_satisfies_ode,
+curvatureSin_initial_conditions).
+"""
+import sympy as sp
+
+t = sp.symbols('t', real=True)
+
+cases = []
+
+# K > 0 (spherical): K = Kp > 0
+Kp = sp.symbols('Kp', positive=True)
+cases.append(("K>0  (spherical)",
+              sp.sin(sp.sqrt(Kp) * t) / sp.sqrt(Kp),  # y
+              Kp,                                       # K value
+              sp.cos(sp.sqrt(Kp) * t)))                # expected curvatureCos
+
+# K = 0 (Euclidean)
+cases.append(("K=0  (Euclidean)",
+              t,
+              sp.Integer(0),
+              sp.Integer(1)))
+
+# K < 0 (hyperbolic): K = -m, m > 0
+m = sp.symbols('m', positive=True)
+cases.append(("K<0  (hyperbolic)",
+              sp.sinh(sp.sqrt(m) * t) / sp.sqrt(m),
+              -m,
+              sp.cosh(sp.sqrt(m) * t)))
+
+all_ok = True
+for name, y, K, expected_cos in cases:
+    yp = sp.simplify(sp.diff(y, t))
+    ypp = sp.diff(y, t, 2)
+    ode = sp.simplify(ypp + K * y)
+    cos_ok = sp.simplify(yp - expected_cos) == 0
+    ode_ok = (ode == 0)
+    y0 = sp.simplify(y.subs(t, 0))
+    yp0 = sp.simplify(yp.subs(t, 0))
+    ic_ok = (y0 == 0) and (yp0 == 1)
+    ok = cos_ok and ode_ok and ic_ok
+    all_ok = all_ok and ok
+    print(f"[{ 'PASS' if ok else 'FAIL'}] {name}")
+    print(f"        y'            = {yp}        (curvatureCos match: {cos_ok})")
+    print(f"        y'' + K*y     = {ode}        (ODE holds: {ode_ok})")
+    print(f"        y(0), y'(0)   = {y0}, {yp0}  (initial conditions: {ic_ok})")
+
+print()
+print("ALL EXACT CHECKS PASS" if all_ok else "SOME CHECK FAILED")
+import sys
+sys.exit(0 if all_ok else 1)

--- a/src/data/research/problems/synthesis-curvature-ptolemy-oq-01.json
+++ b/src/data/research/problems/synthesis-curvature-ptolemy-oq-01.json
@@ -1,0 +1,40 @@
+{
+  "slug": "synthesis-curvature-ptolemy-oq-01",
+  "title": "curvatureSin K satisfies the curvature ODE y'' + K·y = 0",
+  "problemStatement": "Prove that the curvature-parametrized function curvatureSin K (defined in SynthesisCurvaturePtolemy.lean: t for K=0, sin(√K·t)/√K for K>0, sinh(√(-K)·t)/√(-K) for K<0) satisfies the second-order linear ODE y'' + K·y = 0. Together with the parent file's initial conditions y(0)=0 and y'(0)=1, this characterizes curvatureSin K as the unique solution of the constant-curvature oscillator equation, unifying the Euclidean, spherical and hyperbolic models.",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "C",
+  "tractability": 8,
+  "tags": ["differential-equations", "curvature", "trigonometry", "synthesis", "ptolemy"],
+  "started": "2026-06-14",
+  "lastUpdate": "2026-06-14",
+  "path": "proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean",
+  "currentState": "Lean file written (no sorries) proving the global ODE and both initial conditions across all three curvature regimes. Build-pending: Docker was down this session, so not yet machine-checked locally; math exact-verified symbolically (verify_ode.py).",
+  "knowledge": {
+    "insights": [
+      "curvatureSin K solves y''+K·y=0 in all three regimes; first derivative ('curvatureCos K') is 1 (K=0), cos(√K·t) (K>0), cosh(√(-K)·t) (K<0).",
+      "The second-derivative step is the heart of the ODE: differentiating curvatureCos returns -K·curvatureSin, using √K·√K=K (resp. √(-K)·√(-K)=-K) to convert ∓sin/sinh·√K into -K·(sin/sinh)/√K.",
+      "Generalizes the parent file's existing t=0 derivative lemma (curvatureSin_hasDerivAt_zero) to all t via the same HasDerivAt comp+div_const chain.",
+      "Exact symbolic verification (sympy, no floating point) confirms curvatureCos closed form, y''+K·y=0, and y(0)=0/y'(0)=1 in each regime."
+    ],
+    "builtItems": [
+      "curvatureCos K t — first-derivative function (SynthesisCurvaturePtolemyOQ01.lean)",
+      "curvatureSin_hasDerivAt (K t): HasDerivAt (curvatureSin K) (curvatureCos K t) t",
+      "curvatureCos_hasDerivAt (K t): HasDerivAt (curvatureCos K) (-K·curvatureSin K t) t",
+      "curvatureSin_deriv_eq, curvatureSin_second_deriv",
+      "curvatureSin_satisfies_ode (K t): deriv(deriv(curvatureSin K)) t + K·curvatureSin K t = 0",
+      "curvatureSin_initial_conditions (K): curvatureSin K 0 = 0 ∧ deriv (curvatureSin K) 0 = 1",
+      "research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py — exact symbolic certificate"
+    ],
+    "mathlibGaps": [
+      "Real.hasDerivAt_sinh / Real.hasDerivAt_cosh not used directly (re-derived from Real.hasDerivAt_exp; parent's hasDerivAt_sinh is private)."
+    ],
+    "nextSteps": [
+      "Build Proofs.SynthesisCurvaturePtolemyOQ01 via docker-build when Docker returns; fix any tactic mismatch in the two linear_combination √-cancel steps.",
+      "Fallback if linear_combination fails: field_simp; ring_nf; rw [Real.sq_sqrt]/Real.mul_self_sqrt.",
+      "Possible follow-up OQ: uniqueness of the IVP solution (any y with y''+K·y=0, y(0)=0, y'(0)=1 equals curvatureSin K)."
+    ],
+    "progressSummary": "PROGRESS (build-pending): full Lean proof of the curvature ODE + initial conditions written across all three regimes; math exact-verified symbolically. Not yet machine-checked (Docker down)."
+  }
+}


### PR DESCRIPTION
## Summary

Resolves OQ-01 for `synthesis-curvature-ptolemy`: proves the curvature-parametrized
function `curvatureSin K` (from `SynthesisCurvaturePtolemy.lean`) satisfies the
**defining second-order linear ODE**

```
y'' + K · y = 0
```

across all three constant-curvature geometries (K=0 Euclidean, K>0 spherical,
K<0 hyperbolic). Combined with the parent file's existing initial conditions
`y(0)=0` and `y'(0)=1`, this characterizes `curvatureSin K` as the unique solution
of the constant-curvature oscillator — the synthesis claim the parent file sets up.

## What's added (`proofs/Proofs/SynthesisCurvaturePtolemyOQ01.lean`)

- `curvatureCos K t` — first derivative (`1` / `cos(√K·t)` / `cosh(√(-K)·t)`).
- `curvatureSin_hasDerivAt` — generalizes parent's `curvatureSin_hasDerivAt_zero` from t=0 to all t.
- `curvatureCos_hasDerivAt` — second-derivative step: `(curvatureCos K)' t = -K·curvatureSin K t`.
- `curvatureSin_second_deriv`, `curvatureSin_satisfies_ode` — the assembled ODE.
- `curvatureSin_initial_conditions` — IVP companion (`y(0)=0 ∧ y'(0)=1`).

No sorries. Proof structure mirrors the parent file's proven `HasDerivAt` chains
(`comp` + `div_const`; √-cancellation via `mul_div_assoc`/`div_eq_iff` +
`linear_combination`).

## Verification

- **Exact symbolic** (sympy, no floating point):
  `research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py` confirms the
  curvatureCos closed form, `y''+K·y=0`, and the initial conditions in each regime
  (ALL EXACT CHECKS PASS). The two `linear_combination` coefficients were also
  residual-checked to 0.
- **Build status: PENDING.** Docker was unavailable this session, so the Lean file
  is not yet machine-checked locally. Flagged honestly in the problem JSON / knowledge.md.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.SynthesisCurvaturePtolemyOQ01` when Docker is back
- [x] `python3 research/problems/synthesis-curvature-ptolemy-oq-01/verify_ode.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)