### PR TITLE
research(waring-g2-oq-01): S26 — verify ideal-Waring upper-bound condition (k=1..200)

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/knowledge.md
@@ -1,5 +1,62 @@
 # Knowledge — lagrange-four-squares-waring-g2-oq-01
 
+## S26 (researcher-2, 2026-06-14) — ORIENT-depth: upper-bound condition + review of #24228
+
+**Mode**: FRESH (RICH, score 37) · **Outcome**: durable verification (no Lean
+built — Docker daemon down, Aristotle `Resource not found`) · **Phase**: ORIENT
+
+### Context
+
+The lower bound `g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2` is now fully covered:
+parametrically by open PR **#24228** (`…OQ01General.lean`, build-pending) and
+per-`k` (k=3..7) by the merged Counting files. Every committed artifact
+(`verify_witnesses.py`, `verify_general_lower.py`) certifies only the **lower**
+half. Nothing checked the matching **upper** half. This session fills that gap
+on the verification side and independently reviews the in-flight #24228 proof.
+
+### Independent math review of #24228 (Step 6 `nlinarith`, the only new logic)
+
+Confirmed the parametric proof's final discharge is **mathematically sound**.
+Over `ℤ` with `M=2^k`, `Q=⌊(3/2)^k⌋`, fiber counts `c₀,c₁,c₂≥0`:
+`hZeqn: c₁ + M·c₂ + 1 = Q·M` ⟹ `c₁ = M(Q−c₂) − 1`. The product hint
+`(M−1)(Q−1−c₂) ≥ 0` expands to `M(Q−c₂) + c₂ ≥ M + Q − 1`, while
+`hZpart` + `c₀≥0` gives `c₁ + c₂ = M(Q−c₂) − 1 + c₂ ≤ M + Q − 3`, i.e.
+`M(Q−c₂) + c₂ ≤ M + Q − 2`. The two bounds (`≥ M+Q−1` vs `≤ M+Q−2`) are
+contradictory — exactly what `nlinarith` needs. Residual build risk is only
+v4.26.0 lemma-name drift, not the logic. (Posted as a confirming comment on
+the PR.)
+
+### New durable artifact — `verify_ideal_condition.py` (the UPPER-bound side)
+
+Exact big-integer certificate for the **ideal-Waring** value
+`g(k) = 2^k + ⌊(3/2)^k⌋ − 2`. With `q = ⌊(3/2)^k⌋`, `r = 3^k mod 2^k`:
+
+- **Dickson–Pillai condition (*)** `r + q ≤ 2^k` — *necessary and sufficient*
+  for the ideal value. Checked to hold for **all k = 1..200**.
+- **Mahler condition (M)** `{(3/2)^k} ≤ 1 − (3/4)^k` ⟺ exact-integer
+  `r·2^k ≤ 4^k − 3^k`; strictly stronger sufficient condition (M ⟹ *). Fails
+  only at the trivial edge `k=1` in range; holds for every `k ≥ 2..200`.
+- Formula `2^k + q − 2` cross-checked against **OEIS A002804** for k=1..12.
+
+### Honesty boundary (which step is which)
+
+| Step | Status |
+|---|---|
+| Lower bound `g(k) ≥ 2^k+q−2` | ELEMENTARY — formalised (#24228, build-pending) |
+| Checking (*)/(M) for given k | ELEMENTARY — this script, exact arithmetic |
+| Implication `(*) ⟹ upper bound` | **DEEP THEOREM** (Dickson–Pillai–Niven 1936–44), NOT formalised, Mathlib gap |
+
+So the certificate establishes: for every checked `k`, the *hypothesis* of the
+ideal-Waring theorem holds, hence `g(k)` equals the formula **modulo the
+unformalised Dickson–Pillai–Niven implication**. It does NOT prove that
+implication. The upper bound remains the deep open half of the slug.
+
+### Files
+
+- `research/problems/.../verify_ideal_condition.py` (new — upper-bound condition)
+
+---
+
 ## S1 (researcher-3, 2026-05-12) — OBSERVE survey
 
 ### Historical values of $g(k)$

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
@@ -1,8 +1,22 @@
 # Current State
 
-**Phase**: ACT (lower-bound coverage `k ∈ {3,4,5,6,7}` shipped; S8 now ACT-ready — params verified; S4 / S6 remain Docker-gated)
-**Since**: 2026-06-14 (S24 ORIENT-depth — S8 ACT-readiness, Python-verified witness `6399 = 24·256 + 255`, miss-by-1)
-**Iteration**: 25 (S25 — durable witness verification ; researcher-1)
+**Phase**: ORIENT (lower bound DONE — parametric all-`k` in open PR #24228, build-pending; upper-bound condition now durably verified; remaining open half = deep Dickson–Pillai–Niven implication, Mathlib gap)
+**Since**: 2026-06-14 (S26 — upper-bound ideal-condition verified k=1..200 + independent review of #24228 Step-6 nlinarith)
+**Iteration**: 26 (S26 — ideal-Waring condition verification ; researcher-2)
+
+## S26 ORIENT-depth 2026-06-14 (researcher-2) — upper-bound condition + #24228 review
+
+**Focus**: cover the **upper**-bound half (no committed artifact did). Shipped
+`verify_ideal_condition.py` (stdlib, exact big-int): the Dickson–Pillai condition
+`(*) r+q ≤ 2^k` (necessary & sufficient for `g(k)=2^k+⌊(3/2)^k⌋−2`) holds for ALL
+`k=1..200`; Mahler condition `(M) r·2^k ≤ 4^k−3^k` (stronger, ⟹*) holds for all
+`k≥2..200` (fails only trivial `k=1`); formula matches OEIS A002804 k=1..12.
+Independently reviewed open PR #24228's parametric lower bound: Step-6 `nlinarith`
+certificate is mathematically sound (the `(M−1)(Q−1−c₂)≥0` hint yields
+`M(Q−c₂)+c₂ ≥ M+Q−1`, contradicting the `≤ M+Q−2` from `c₀≥0`); posted confirming
+comment. HONESTY: the implication `(*) ⟹ upper bound` is the DEEP unformalised
+theorem — this verifies the *hypothesis*, not the implication. Both backends down
+(Docker `docker info` timeout; Aristotle `Resource not found`) — no Lean built.
 
 ## S25 ORIENT-depth 2026-06-14 (researcher-1) — durable witness verification
 

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/verify_ideal_condition.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/verify_ideal_condition.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Exact-integer verification of the *upper-bound* side of Waring's problem for
+
+    lagrange-four-squares-waring-g2-oq-01
+
+Companion to `verify_witnesses.py` / `verify_general_lower.py`, which certify
+the **lower** bound g(k) >= 2^k + floor((3/2)^k) - 2 (the unconditional,
+elementary half, formalised parametrically in PR #24228). Those artifacts say
+nothing about the matching **upper** bound. This script fills that gap.
+
+Background
+----------
+The full "ideal Waring" value is
+
+    g(k) = 2^k + floor((3/2)^k) - 2
+
+PROVIDED a number-theoretic side condition holds. The lower bound (this value
+is necessary) is elementary. The upper bound (this value SUFFICES) is the deep
+Dickson-Pillai-Rubugunday-Niven theorem (1936-1944): it is conditional on the
+exactly-checkable
+
+    Dickson-Pillai condition  (*):   r + q <= 2^k
+
+where  q = floor((3/2)^k)  and  r = 3^k mod 2^k = 3^k - q * 2^k  (so that
+{(3/2)^k} = r / 2^k). Condition (*) is *necessary and sufficient* for the
+ideal value g(k) = 2^k + q - 2. When (*) fails, g(k) picks up an extra
+floor((4/3)^k) term.
+
+Mahler (1957) proved the strictly stronger sufficient condition
+
+    Mahler condition  (M):   {(3/2)^k} <= 1 - (3/4)^k
+                       <=>   r * 2^k <= 4^k - 3^k        (exact-integer form)
+
+holds for all but finitely many k; Kubina-Wunderlich (1990) verified (*) for
+all k <= 4.716e8. NO k is known where (*) fails, so the formula is believed to
+hold for every k -- but this is open, contingent on an irrationality-measure
+improvement for (3/2). (M) => (*), so verifying (M) also verifies (*).
+
+What is elementary vs deep (HONEST boundary)
+--------------------------------------------
+  * Lower bound  g(k) >= 2^k + q - 2          : ELEMENTARY (counting argument,
+                                                 formalised in #24228).
+  * Checking (*) / (M) for a given k          : ELEMENTARY (this script; pure
+                                                 big-integer arithmetic).
+  * Implication  (*) ==> upper bound          : DEEP THEOREM (Dickson-Pillai-
+                                                 Niven), NOT formalised, Mathlib
+                                                 gap. This script does NOT prove
+                                                 it -- it verifies the hypothesis.
+
+So this certificate establishes: "for every k in the checked range the
+hypothesis of the ideal-Waring theorem holds, hence g(k) = 2^k + floor((3/2)^k)
+- 2 exactly, *modulo* the unformalised Dickson-Pillai-Niven implication."
+
+Run:
+    python3 verify_ideal_condition.py
+Exits 0 with "ALL CHECKS PASSED" iff every assertion holds. Pure stdlib.
+"""
+
+# OEIS A002804 -- Waring's problem g(k), the literature values.
+OEIS_A002804 = {
+    1: 1, 2: 4, 3: 9, 4: 19, 5: 37, 6: 73, 7: 143, 8: 279,
+    9: 548, 10: 1079, 11: 2132, 12: 4223,
+}
+
+K_MAX = 200  # exact big-integer arithmetic stays fast well beyond this
+
+
+def data(k):
+    """Return (M, q, r) with M=2^k, q=floor((3/2)^k), r=3^k mod 2^k."""
+    M = 2 ** k
+    P = 3 ** k
+    q = P // M          # floor((3/2)^k)
+    r = P - q * M       # 3^k mod 2^k  (= 2^k * frac((3/2)^k))
+    return M, q, r
+
+
+def main():
+    failures = []
+    mahler_fails = []
+
+    for k in range(1, K_MAX + 1):
+        M, q, r = data(k)
+
+        # sanity: 0 <= r < M, and q*M + r == 3^k
+        if not (0 <= r < M and q * M + r == 3 ** k):
+            failures.append((k, "decomposition 3^k = q*2^k + r failed"))
+            continue
+
+        formula = M + q - 2  # conjectural ideal value 2^k + floor((3/2)^k) - 2
+
+        # (*) Dickson-Pillai necessary&sufficient condition for g(k)=formula.
+        ideal_star = (r + q <= M)
+
+        # (M) Mahler's stronger sufficient condition, exact-integer form:
+        #     {(3/2)^k} <= 1 - (3/4)^k  <=>  r * 2^k <= 4^k - 3^k.
+        mahler = (r * M <= 4 ** k - 3 ** k)
+
+        # (M) => (*): the Mahler condition must imply Dickson-Pillai.
+        if mahler and not ideal_star:
+            failures.append((k, "Mahler (M) held but Dickson-Pillai (*) failed"))
+
+        # No exceptional k is known: (*) must hold throughout the checked range.
+        if not ideal_star:
+            failures.append((k, f"Dickson-Pillai (*) FAILS: r+q={r+q} > 2^k={M}"))
+
+        if not mahler:
+            mahler_fails.append(k)
+
+        # Cross-check the formula against the literature where known.
+        if k in OEIS_A002804 and formula != OEIS_A002804[k]:
+            failures.append(
+                (k, f"formula {formula} != OEIS A002804 {OEIS_A002804[k]}")
+            )
+
+    # Report a small table for the documented range.
+    print("Waring ideal-condition verification (exact integer arithmetic)")
+    print(f"  q = floor((3/2)^k),  r = 3^k mod 2^k,  formula = 2^k + q - 2")
+    print()
+    print(f"  {'k':>3} {'2^k':>8} {'q':>6} {'r':>8} {'r+q<=2^k':>9}"
+          f" {'Mahler':>7} {'formula':>9} {'g(k)':>6}")
+    for k in range(1, 13):
+        M, q, r = data(k)
+        formula = M + q - 2
+        star = "yes" if r + q <= M else "NO"
+        mah = "yes" if r * M <= 4 ** k - 3 ** k else "no"
+        g = OEIS_A002804.get(k, "-")
+        print(f"  {k:>3} {M:>8} {q:>6} {r:>8} {star:>9} {mah:>7}"
+              f" {formula:>9} {str(g):>6}")
+    print()
+    print(f"  Dickson-Pillai (*) holds for ALL k = 1..{K_MAX}")
+    print(f"  Mahler (M) fails only at k in {mahler_fails or 'none'}"
+          f"  (small-k edges; (M) holds for every larger k in range)")
+    print(f"  formula matched OEIS A002804 for k = 1..12")
+    print()
+
+    if failures:
+        print("FAILURES:")
+        for k, msg in failures:
+            print(f"  k={k}: {msg}")
+        raise SystemExit(1)
+
+    print("ALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Slug `lagrange-four-squares-waring-g2-oq-01`, **S26 ORIENT-depth**. Adds the
first committed artifact covering the **upper-bound** half of Waring's ideal
value. Prior verifiers (`verify_witnesses.py`, `verify_general_lower.py`) and
the parametric Lean proof (open #24228) certify only the *lower* bound
`g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2`.

`verify_ideal_condition.py` (stdlib, exact big-integer arithmetic) checks, with
`q = ⌊(3/2)^k⌋`, `r = 3^k mod 2^k`:

- **Dickson–Pillai condition (\*)** `r + q ≤ 2^k` — *necessary and sufficient*
  for the ideal value `g(k) = 2^k + ⌊(3/2)^k⌋ − 2` — holds for **all k = 1..200**.
- **Mahler condition (M)** `{(3/2)^k} ≤ 1 − (3/4)^k` ⟺ exact-integer
  `r·2^k ≤ 4^k − 3^k` (strictly stronger, M ⟹ \*) — holds for all `k ≥ 2..200`
  (fails only the trivial `k = 1` edge).
- Formula `2^k + q − 2` cross-checked vs **OEIS A002804** for k=1..12.

## Honesty boundary

| Step | Status |
|---|---|
| Lower bound `g(k) ≥ 2^k+q−2` | ELEMENTARY — formalised parametrically in open #24228 (build-pending) |
| Checking (\*)/(M) for given k | ELEMENTARY — this script |
| Implication `(*) ⟹ upper bound` | **DEEP THEOREM** (Dickson–Pillai–Niven 1936–44), NOT formalised, Mathlib gap |

The certificate verifies the *hypothesis* of the ideal-Waring theorem for every
checked `k`; it does **not** prove the deep `(*) ⟹ upper bound` implication,
which remains the open half of this slug.

No Lean built — written during a Docker/Aristotle blackout; pure-Python
documentation/verification artifact, no library-build impact.

## Test plan
- [x] `python3 research/problems/lagrange-four-squares-waring-g2-oq-01/verify_ideal_condition.py` exits 0, prints `ALL CHECKS PASSED`
- [x] Independent review of #24228 Step-6 `nlinarith` cert (math sound; posted as PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)