### PR TITLE
research(quadratic-reciprocity-algorithm-oq-03): S8 — M2 sign value is a primality-free closed-form inversion count

### DIFF
--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -255,6 +255,50 @@ which there is still **no** upstream bearer. Net: M2's "~30–80 LOC" estimate s
 transport sub-step is now a known `simp` rather than an open sub-task. (Build-free, Docker still
 down; no Lean written. Minor ACT-readiness delta, not a new result.)
 
+### Session 2026-06-14 (S8, researcher-3) — the missing M2 sign value IS a primality-free closed-form inversion count
+
+**Mode:** CONTINUE. Both backends down (Docker `docker info` times out; Aristotle MCP previously
+`Resource not found`), so no Lean built — build-free durable-verify lane. This session **discharges
+the standing "no upstream bearer for the sign value" residual** flagged by S6/S7 by replacing the
+opaque "cycle/inversion count" target with an explicit, primality-free closed form, and ties it to
+how Mathlib actually *defines* `sign`.
+
+**Key observation (Mathlib mechanism).** `Equiv.Perm.sign` is defined upstream as the **parity of
+inversions**: `signAux a = ∏_{finPairsLT n} (if a x.1 ≤ a x.2 then -1 else 1)`
+(`Mathlib/GroupTheory/Perm/Sign.lean:174`, with `finPairsLT` :165). So the natural Lean target for
+the grid-transpose `σ` is **not** its cycle decomposition but its **number of inversions** — and
+that number has a clean closed form.
+
+**New certified result** (`verify_grid_inversions.py`, all asserts pass, pure stdlib + optional
+sympy cross-check; verify-before-assert — inversions are *counted* by brute pair-scan, then matched):
+
+- **(I) `inv(σ) = C(p,2)·C(q,2) = [p(p−1)/2]·[q(q−1)/2]` for ALL `p,q ≥ 1`** — **no primality
+  hypothesis** (checked over 144 grids `1 ≤ p,q < 13`, including even and composite dims). This is
+  strictly stronger/cleaner than S6/S7's odd-prime sign statement.
+- **(II) `sign(σ) = (−1)^{inv(σ)} = (−1)^{C(p,2)·C(q,2)}`**, with inversion-parity and cycle-parity
+  cross-checked equal on every grid (guards an off-by-parity slip in either route).
+- **(III) Elementary parity reduction** recovers the reciprocity exponent for odd `p,q`:
+  `C(p,2) = p(p−1)/2 ≡ (p−1)/2 (mod 2)` when `p` is odd (since `p` odd ⟹ parity is that of
+  `(p−1)/2`), hence `C(p,2)·C(q,2) ≡ (p−1)/2·(q−1)/2 (mod 2)`, so
+  `sign(σ) = (−1)^{(p−1)/2·(q−1)/2}` — matching S6/S7 exactly, now *derived* not asserted.
+- **(IV) cross-check** (sympy): `(−1)^{inv(σ)} = (p/q)(q/p)` on all 110 distinct odd-prime pairs
+  `< 40` — the inversion count carries the actual QR factor.
+
+**Effect on the M2 ACT — the residual is now a concrete, decomposable target.** The genuinely-new
+M2 content is reduced to:
+1. **`inv(σ) = C(p,2)·C(q,2)`** — a finite, primality-free combinatorial identity. State the M2
+   lemma for *arbitrary* `p,q` (no `Fact p.Prime`), which is easier to formalize. With Mathlib's
+   `signAux = ∏ finPairsLT …`, the inversion count is the directly-relevant quantity, not a
+   re-derivation.
+2. **`(−1)^{C(p,2)·C(q,2)} = (−1)^{(p−1)/2·(q−1)/2)}` for odd `p,q`** — pure `Nat`/parity arithmetic
+   (Step III), `omega`/`Nat.ParityYields`-level, **no** new bearer.
+The S7 `simp` transport lemmas still apply to move `σ` between `Perm (Fin (p*q))` and the product
+type. **Still no upstream lemma gives `inv(σ)` directly** (re-confirmed: `Sign.lean` has only the
+`signAux`/`finPairsLT` machinery, no closed inversion-count for a transpose), so (I) remains the new
+~20–60 LOC content — but it is now a *single closed-form count* rather than an opaque "cycle/inversion
+count," and it needs no primality. Net: M2 ACT target sharpened and de-risked; M1 still the
+prerequisite for the Zolotarev signs (A). (No Lean written; Docker still down.)
+
 ## Dead Ends
 
 - **Algorithm-confluence route** (prove the flip-and-reduce evaluator is order-independent and read

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Reproducible certification of the EXPLICIT INVERSION COUNT of the
+grid-transpose permutation for quadratic-reciprocity-algorithm-oq-03 (M2).
+
+Context.  S6/S7 numerically certified that the grid-transpose permutation
+
+    sigma = c o r^{-1}   on {0..pq-1},
+    r(i,j) = i*q + j  (row-major),   c(i,j) = j*p + i  (column-major),
+
+has sign  sign(sigma) = (-1)^((p-1)/2 * (q-1)/2)  for distinct odd primes p,q,
+and flagged that "there is still NO upstream bearer giving this sign value" --
+the Lean ACT must supply the missing combinatorial content itself.
+
+This script supplies and certifies that content as a CLOSED-FORM INVERSION COUNT.
+Mathlib already *defines* Equiv.Perm.sign via the parity of inversions
+(`signAux` as a product over `finPairsLT` in
+ Mathlib/GroupTheory/Perm/Sign.lean:174), so the natural Lean target is not the
+cycle structure of sigma but the number of inversions it has.  We prove that
+this count is a single product of binomials, with NO primality hypothesis:
+
+    (I)   inv(sigma)  =  C(p,2) * C(q,2)            for ALL p,q >= 1
+                       =  [p(p-1)/2] * [q(q-1)/2].
+
+    (II)  sign(sigma) = (-1)^(inv(sigma)) = (-1)^(C(p,2)*C(q,2))   (general).
+
+    (III) For ODD p,q the parity reduces to the reciprocity exponent:
+              C(p,2) = p(p-1)/2 ≡ (p-1)/2  (mod 2)   when p is odd,
+          hence  C(p,2)*C(q,2) ≡ (p-1)/2 * (q-1)/2  (mod 2),  recovering
+              sign(sigma) = (-1)^((p-1)/2 * (q-1)/2).
+
+(I) is strictly stronger and cleaner than the S6/S7 sign statement: it is a
+primality-free identity (verified here over even and composite p,q too), so the
+Lean lemma can be stated for arbitrary p,q and the odd-prime sign formula falls
+out by the elementary parity step (III).
+
+Verify-before-assert: inv(sigma) is COUNTED directly (brute pair scan) and only
+THEN compared to the binomial product; the cross-check sign(via inversions) ==
+sign(via cycles) guards against an off-by-parity error in either route.
+
+Run: python3 verify_grid_inversions.py    (pure stdlib; sympy optional). All
+asserts must pass.
+"""
+
+from math import comb
+
+
+# ---------------------------------------------------------------------------
+def grid_transpose_perm(p, q):
+    """sigma as a list: sigma[row-major index] = column-major index."""
+    N = p * q
+    sigma = [0] * N
+    for i in range(p):
+        for j in range(q):
+            sigma[i * q + j] = j * p + i
+    return sigma
+
+
+def count_inversions(perm):
+    """Number of pairs a<b with perm[a]>perm[b] (direct O(n^2) count)."""
+    n = len(perm)
+    inv = 0
+    for a in range(n):
+        pa = perm[a]
+        for b in range(a + 1, n):
+            if pa > perm[b]:
+                inv += 1
+    return inv
+
+
+def sign_via_inversions(perm):
+    return (-1) ** count_inversions(perm)
+
+
+def sign_via_cycles(perm):
+    n = len(perm)
+    seen = [False] * n
+    cycles = 0
+    for i in range(n):
+        if not seen[i]:
+            cycles += 1
+            j = i
+            while not seen[j]:
+                seen[j] = True
+                j = perm[j]
+    return (-1) ** (n - cycles)
+
+
+# ---------------------------------------------------------------------------
+def main():
+    # (I)+(II): general identity over ALL p,q (incl. even/composite), no primality.
+    n_general = 0
+    max_dim = 13
+    for p in range(1, max_dim):
+        for q in range(1, max_dim):
+            sigma = grid_transpose_perm(p, q)
+            inv = count_inversions(sigma)
+            formula = comb(p, 2) * comb(q, 2)
+            assert inv == formula, \
+                f"(I) inv(sigma)={inv} != C(p,2)C(q,2)={formula} at (p,q)=({p},{q})"
+            # (II) sign equals (-1)^inv, and the two sign routes agree.
+            si = sign_via_inversions(sigma)
+            sc = sign_via_cycles(sigma)
+            assert si == sc, f"(II) sign route mismatch at ({p},{q}): inv={si} cyc={sc}"
+            assert si == (-1) ** formula, \
+                f"(II) sign != (-1)^formula at ({p},{q})"
+            n_general += 1
+    print(f"(I)  inv(sigma) = C(p,2)*C(q,2)  -- primality-free, ALL 1<=p,q<{max_dim}: "
+          f"OK for {n_general} grids (incl. even & composite)")
+    print(f"(II) sign(sigma) = (-1)^inv = (-1)^(C(p,2)C(q,2)), and inversion- and "
+          f"cycle-parity agree: OK for {n_general} grids")
+
+    # (III): parity reduction for ODD p,q, and recovery of the reciprocity exponent.
+    odd_dims = [p for p in range(3, 40, 2)]  # odd p,q >= 3 (not necessarily prime)
+    n_odd = 0
+    for p in odd_dims:
+        # C(p,2) ≡ (p-1)/2 (mod 2) for odd p
+        assert comb(p, 2) % 2 == ((p - 1) // 2) % 2, \
+            f"(III) C(p,2) parity != (p-1)/2 parity at p={p}"
+        n_odd += 1
+    for p in odd_dims:
+        for q in odd_dims:
+            lhs = (comb(p, 2) * comb(q, 2)) % 2
+            rhs = (((p - 1) // 2) * ((q - 1) // 2)) % 2
+            assert lhs == rhs, \
+                f"(III) C(p,2)C(q,2) parity != (p-1)/2(q-1)/2 parity at ({p},{q})"
+            # full recovery of the S6/S7 sign value via the inversion count
+            sigma = grid_transpose_perm(p, q)
+            assert sign_via_inversions(sigma) == (-1) ** (((p - 1) // 2) * ((q - 1) // 2)), \
+                f"(III) recovered sign != reciprocity exponent at ({p},{q})"
+    print(f"(III) odd p,q: C(p,2) ≡ (p-1)/2 (mod 2) for {n_odd} odd dims, and "
+          f"C(p,2)C(q,2) ≡ (p-1)/2(q-1)/2 (mod 2); grid sign recovers "
+          f"(-1)^((p-1)/2 (q-1)/2): OK")
+
+    # Cross-check against the M1/M2 Legendre route on distinct odd PRIMES, if
+    # sympy is available (ties this inversion count back to actual reciprocity).
+    try:
+        from sympy import primerange
+        try:
+            from sympy.functions.combinatorial.numbers import legendre_symbol
+        except ImportError:
+            from sympy.ntheory.residue_ntheory import legendre_symbol
+        primes = list(primerange(3, 40))
+        n_pr = 0
+        for p in primes:
+            for q in primes:
+                if p == q:
+                    continue
+                sigma = grid_transpose_perm(p, q)
+                # inversion count carries the reciprocity factor = (p/q)(q/p)
+                assert sign_via_inversions(sigma) == legendre_symbol(p, q) * legendre_symbol(q, p), \
+                    f"(IV) inversion-sign != (p/q)(q/p) at primes ({p},{q})"
+                n_pr += 1
+        print(f"(IV) distinct odd primes: (-1)^inv(sigma) = (p/q)(q/p) [the QR law] "
+              f"via the closed-form inversion count: OK for {n_pr} pairs")
+    except ImportError:
+        print("(IV) skipped (sympy not installed) -- (I)-(III) stand on stdlib alone")
+
+    print("\nALL ASSERTS PASSED.  The grid-transpose sign reduces to a primality-free")
+    print("closed-form inversion count  inv(sigma) = C(p,2)*C(q,2),  matching Mathlib's")
+    print("inversion-based `signAux` definition; the odd-prime reciprocity exponent is")
+    print("the elementary parity (III).  This pins the missing M2 combinatorial content.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Build-free durable-verify session on the Zolotarev/permutation-sign route to quadratic
reciprocity. **Discharges the standing S6/S7 residual** — "there is still no upstream bearer giving
the grid-transpose sign value `(-1)^((p-1)/2·(q-1)/2)`" — by replacing the opaque "cycle/inversion
count" M2 target with an explicit **primality-free closed-form inversion count**, tied to how
Mathlib actually defines `sign`.

**Mechanism.** `Equiv.Perm.sign` is defined upstream as the parity of inversions (`signAux` as a
product over `finPairsLT`, `Mathlib/GroupTheory/Perm/Sign.lean:174`). So the natural M2 Lean target
for the grid-transpose `σ` is its **number of inversions**, which has a clean closed form.

**Certified (`verify_grid_inversions.py`, all asserts pass; verify-before-assert — inversions are
counted by brute pair-scan, then matched):**

- **(I)** `inv(σ) = C(p,2)·C(q,2) = [p(p−1)/2]·[q(q−1)/2]` for **all** `p,q ≥ 1` — **no primality**
  (144 grids `1 ≤ p,q < 13`, incl. even & composite). Strictly stronger/cleaner than the odd-prime
  sign statement.
- **(II)** `sign(σ) = (−1)^{inv(σ)} = (−1)^{C(p,2)·C(q,2)}`; inversion-parity and cycle-parity
  cross-checked equal on every grid.
- **(III)** Elementary parity reduction: for odd `p`, `C(p,2) ≡ (p−1)/2 (mod 2)`, hence
  `C(p,2)·C(q,2) ≡ (p−1)/2·(q−1)/2 (mod 2)` — *recovers* (not asserts) the reciprocity exponent.
- **(IV)** sympy cross-check: `(−1)^{inv(σ)} = (p/q)(q/p)` on all 110 distinct odd-prime pairs `< 40`.

**Effect on the M2 ACT.** The genuinely-new content reduces to (1) a finite, primality-free
identity `inv(σ) = C(p,2)·C(q,2)` — state the lemma for arbitrary `p,q`, no `Fact p.Prime` — and
(2) a pure `Nat`-parity step (III). S7's `@[simp]` transport lemmas still move `σ` between
`Perm (Fin (p*q))` and the product type. No upstream lemma gives `inv(σ)` directly (re-confirmed),
so (I) remains the new ~20–60 LOC content, now a single closed-form count rather than an opaque
cycle/inversion count.

Both backends down (Docker `docker info` times out; Aristotle previously `Resource not found`), so
no Lean built. M1 (Zolotarev signs) remains the prerequisite.

## Test plan

- [x] `python3 research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py` — all asserts pass (144 grids + 110 prime pairs)
- New file + knowledge.md only; path-disjoint from open PR #24079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)