### PR TITLE
Enrich Erdős Problem #1206: fix broken card description

### DIFF
--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1206",
   "title": "Erdős Problem #1206",
   "slug": "erdos-1206",
-  "description": "Does ... contain a Sidon set of size ...? Is there an infinite set ... of positive density such that ... is a Sidon set? This question may also be asked for higher powers, and [324] suggests that f...",
+  "description": "Does the cube set {1³, 2³, …, N³} contain a Sidon set (a B₂ set in which all pairwise sums are distinct) of size ≫ N? Marked solved: Gabdullin–Konyagin (2024) proved the short-interval cubes {n³ : N − cN^{1/2} ≤ n ≤ N} form a Sidon set of size ≫ N^{1/2}, and Garaev–Garayev–Konyagin (2026) raised the exponent to 4/7 − o(1). Formalized in axiomatized form (3 definitions, 2 axioms, 2 theorems, 0 sorries).",
   "meta": {
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1206",


### PR DESCRIPTION
## Enrichment pass: erdos-1206

The gallery card description for Erdős Problem #1206 contained literal `...` placeholders left over from the original problem scrape:

> Does ... contain a Sidon set of size ...? Is there an infinite set ... of positive density such that ... is a Sidon set? ...

Replaced with an accurate, self-contained summary that states the question (Sidon set of size ≫ N in the cubes), the proven results (Gabdullin–Konyagin 2024 → size ≫ N^{1/2}; Garaev–Garayev–Konyagin 2026 → exponent 4/7 − o(1)), and the formalization shape (3 definitions, 2 axioms, 2 theorems, 0 sorries).

### Notes
- The rest of the entry (meta overview, 8 annotations with mathContext/significance/relatedConcepts, conclusion, cross-references) was already high quality (score 98) and is unchanged.
- Verified all three cross-reference targets (`erdos-340-greedy-sidon`, `erdos-1202`, `fundamental-arithmetic`) exist in the gallery.
- `pnpm annotations:build` regenerates listings cleanly with no warnings for erdos-1206; the new description propagates to the gallery card.
- `axiomCount: 2` / `status: axiomatized` accurately reflect the Lean source (2 `axiom` declarations, 0 structure-encoded assumptions).