### PR TITLE
research(erdos-653-oq-01): S2 — ⌈n/2⌉ is the 1D optimum; the lower-bound frontier is intrinsically 2D

### DIFF
--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -91,3 +91,41 @@ The OQ itself is open and untouched. This session's value is modest: an accurate
 axiom-status map, one elementary sharpening (`g(n) ≤ n−1`) the file misses, an
 elementary lower-bound construction, and a durable structural verifier. No Lean
 was changed (build-verification unavailable this session).
+
+## Session 2026-06-14 (Session 2, researcher-3, ORIENT — elementary lower-bound frontier)
+
+**Mode:** CONTINUE (build-free; Docker `docker info` times out, Aristotle previously
+`Resource not found`). The S1 ACT plan (discharge `g_le_n`, add `g(n) ≤ n−1` and `g(n) ≥ ⌈n/2⌉`)
+is fully specified but build-gated. This session sharpens the **lower-bound** picture S1 left as a
+"candidate first Lean lower bound," answering: *is ⌈n/2⌉ the best elementary construction, and is
+it worth trying to push the collinear idea further?* (extends `verify_g_structure.py`, all asserts
+pass, exact integer squared-distance arithmetic).
+
+**Finding (4a) — ⌈n/2⌉ is the 1D optimum.** Exhaustive search over ALL collinear integer configs
+with positions in `[0, 2n+6]` gives `max D = ⌈n/2⌉` for n=3..7 — equal spacing is optimal on a
+line, and **no collinear (1D) configuration beats ⌈n/2⌉**. So the S1 elementary lower bound is the
+*ceiling* of the 1D approach: a 1D Lean lower bound tops out at ⌈n/2⌉ = 0.5n and cannot be nudged
+toward the 0.7n literature bound by re-spacing points on a line. (Empirical over a wide position
+range, not a proof; robust enough to direct strategy.)
+
+**Finding (4b) — 2D strictly beats it (exact witnesses).** The collinear bound is **not tight**;
+two-dimensional configs achieve `D > ⌈n/2⌉` already at small n (verified from scratch, integer
+grid, exact squared distances):
+- `n=4`: pts `(0,0),(0,1),(0,2),(1,1)` — R-vec `[3,1,3,2]`, **D=3 > ⌈4/2⌉=2**.
+- `n=6`: pts `(0,0),(0,1),(0,2),(1,1),(2,0),(2,1)` — R-vec `[4,3,5,2,5,3]`, **D=4 > ⌈6/2⌉=3**.
+
+**Strategic consequence for the ACT.** The elementary lower-bound frontier is **intrinsically
+2-dimensional**: the clean, Lean-friendly `g(n) ≥ ⌈n/2⌉` collinear construction (S1) is the best a
+1D argument can give, and any improvement toward Csizmadia's 0.7n must use genuinely 2D point sets.
+This reframes the lower-bound ACT: formalize `g(n) ≥ ⌈n/2⌉` as the *complete* elementary 1D result
+(not a way-station to be improved on a line), and treat ">0.5n" as a separate, 2D, harder target.
+**Honesty:** this session does **not** exhibit a closed-form 2D family with `D > ⌈n/2⌉` for all `n`
+(the witnesses are small-n, brute-force) — finding one is the genuine open elementary question and
+is NOT claimed here. No Lean written (Docker down); the three axioms (`csizmadia_bound`,
+`upper_bound` legit literature; `g_le_n` still the dischargeable one) are unchanged.
+
+### Files Touched (Session 2)
+
+- `research/problems/erdos-653-oq-01/verify_g_structure.py`: +2 checks (4a 1D-optimality,
+  4b 2D-beats witnesses), +summary lines.
+- `research/problems/erdos-653-oq-01/knowledge.md`: this Session 2 entry.

--- a/research/problems/erdos-653-oq-01/verify_g_structure.py
+++ b/research/problems/erdos-653-oq-01/verify_g_structure.py
@@ -159,6 +159,50 @@ def brute_force_g(max_n=6, grid=4):
         print(f"  n={n}: best D found = {best}  (elementary ceiling n-1 = {n-1})")
 
 
+# ---------------------------------------------------------------------------
+# (4) Is the collinear bound ceil(n/2) the best ELEMENTARY lower bound?
+#     (4a) 1D (collinear) optimality: search ALL integer positions in [0,M] and
+#          confirm max D over collinear configs equals ceil(n/2) -- i.e. equal
+#          spacing is optimal in 1D and the bound CANNOT be improved on a line.
+#     (4b) 2D strictly beats it: exhibit exact-arithmetic witnesses with
+#          D > ceil(n/2), proving the lower-bound frontier is intrinsically
+#          two-dimensional (a 1D Lean lower bound tops out at ceil(n/2)).
+# ---------------------------------------------------------------------------
+def check_1d_optimality(max_n=7):
+    print("\n(4a) 1D optimality: max D over ALL collinear integer configs in [0,M]")
+    print("     equals ceil(n/2) (equal spacing is optimal on a line):")
+    ok = True
+    for n in range(3, max_n + 1):
+        M = 2 * n + 6
+        best = 0
+        for combo in combinations(range(M + 1), n):
+            best = max(best, D_config([(x, 0) for x in combo]))
+        ok &= assert_eq(f"1D max D (n={n}, M={M})", best, ceil(n / 2))
+    print(f"  => ceil(n/2) is the best any collinear config achieves: {ok}")
+    return ok
+
+
+def check_2d_beats_collinear():
+    """Exact-arithmetic witnesses with D > ceil(n/2): the elementary collinear
+    bound is NOT tight; improving it requires genuinely 2D constructions.
+    Witnesses found by integer-grid brute force; verified here from scratch."""
+    print("\n(4b) 2D strictly beats ceil(n/2) -- exact witnesses (D > ceil(n/2)):")
+    witnesses = {
+        4: [(0, 0), (0, 1), (0, 2), (1, 1)],                          # D=3 > 2
+        6: [(0, 0), (0, 1), (0, 2), (1, 1), (2, 0), (2, 1)],          # D=4 > 3
+    }
+    ok = True
+    for n, pts in witnesses.items():
+        d = D_config(pts)
+        Rvec = [R_value(pts, i) for i in range(n)]
+        beats = d > ceil(n / 2)
+        status = "OK " if beats else "FAIL"
+        print(f"  [{status}] n={n}: pts={pts} R-vec={Rvec} D={d} > ceil(n/2)={ceil(n / 2)}")
+        ok &= beats
+    print(f"  => the elementary lower-bound frontier is intrinsically 2D: {ok}")
+    return ok
+
+
 if __name__ == "__main__":
     print("=" * 70)
     print("Erdős #653 OQ-01 — structural / bound verification (ORIENT, not a proof)")
@@ -167,8 +211,13 @@ if __name__ == "__main__":
     r2 = check_regular_polygon()
     r3 = check_collinear()
     brute_force_g()
+    r4a = check_1d_optimality()
+    r4b = check_2d_beats_collinear()
     print("\nSummary:")
     print(f"  elementary n-1 bound empirically valid : {r1}")
     print(f"  regular-polygon structure confirmed    : {r2}")
     print(f"  collinear ceil(n/2) construction valid : {r3}")
+    print(f"  ceil(n/2) is the 1D optimum            : {r4a}")
+    print(f"  2D strictly beats ceil(n/2) (witnessed): {r4b}")
     print("\nNOTE: the OQ (g(n) >= (1-o(1))n) is OPEN and is NOT addressed here.")
+    print("A closed-form 2D family with D > ceil(n/2) for all n is NOT claimed.")


### PR DESCRIPTION
## Summary

Build-free ORIENT on Erdős #653 OQ-01 (`g(n)` = max over n-point configs of the number of distinct
`R`-values, `R(x)` = # distinct distances from `x`). S1 (#24201) gave the elementary lower bound
`g(n) ≥ ⌈n/2⌉` via equally-spaced collinear points and flagged it a "candidate first Lean lower
bound." This session answers whether that bound can be pushed further on a line, and where the real
frontier lives. Extends `verify_g_structure.py` (exact integer squared-distance arithmetic, all
asserts pass):

- **(4a) ⌈n/2⌉ is the 1D optimum.** Exhaustive search over ALL collinear integer configs with
  positions in `[0, 2n+6]` (n=3..7) gives `max D = ⌈n/2⌉`: equal spacing is optimal on a line, and
  **no 1D configuration beats ⌈n/2⌉**. A 1D Lean lower bound therefore tops out at `0.5n` and cannot
  be nudged toward Csizmadia's `0.7n` by re-spacing collinear points.
- **(4b) 2D strictly beats it (exact witnesses).** The collinear bound is **not tight**:
  - `n=4`: `(0,0),(0,1),(0,2),(1,1)` → R-vec `[3,1,3,2]`, **D=3 > 2**.
  - `n=6`: `(0,0),(0,1),(0,2),(1,1),(2,0),(2,1)` → R-vec `[4,3,5,2,5,3]`, **D=4 > 3**.

**Strategic consequence.** The elementary lower-bound frontier is **intrinsically 2-dimensional**:
formalize `g(n) ≥ ⌈n/2⌉` as the *complete* elementary 1D result (not a way-station to be improved on
a line); any improvement toward `0.7n` must use genuinely 2D point sets.

**Honesty:** no closed-form 2D family with `D > ⌈n/2⌉` for all `n` is claimed — the witnesses are
small-n brute force; finding such a family is the genuine open elementary question. Docker down; no
Lean changed; the three axioms unchanged (`g_le_n` still the dischargeable one when a build returns).

## Test plan

- [x] `python3 research/problems/erdos-653-oq-01/verify_g_structure.py` — all checks pass (incl. new 4a/4b)
- Verifier + knowledge.md only; no open PRs on this slug to conflict with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)