### PR TITLE
research(wilsons-theorem-oq-02-ext-oq-01): general two-involution trick for finite abelian groups

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean
@@ -1,0 +1,206 @@
+import Mathlib.Tactic
+import Proofs.WilsonsTheoremOQ02Ext
+
+/-
+# Gauss-Wilson Theorem: General Finite Abelian Group (OQ-02-ext OQ-01)
+
+**Open question (`wilsons-theorem-oq-02-ext-oq-01`):** Can the two-involution
+trick be formalized as a *general* theorem about finite abelian groups, rather
+than only the unit group `(ZMod n)ˣ`?
+
+**Answer: yes.** The companion file `WilsonsTheoremOQ02Ext.lean` already proves
+the two-involution trick for `(ZMod n)ˣ` (`prod_units_one_of_not_cyclic_ext`).
+Inspecting that proof, every step from `prod_eq_prod_sq_eq_one` onward is stated
+for an arbitrary `[CommGroup G] [Fintype G] [DecidableEq G]`. The *only*
+`(ZMod n)`-specific ingredient is the derivation of `3 ≤ |{x | x² = 1}|` from
+`¬ IsCyclic (ZMod n)ˣ` (via `GaussWilsonNonCyclic`, CRT and the `2^k` case
+analysis). The general theorem simply takes that cardinality bound as a
+*hypothesis*, and is therefore strictly more elementary than the specialization.
+
+## Main results
+
+* `prod_eq_one_of_three_le_card_sqrt_one` — **the general two-involution
+  theorem**: if `G` has at least three square roots of `1`, then `∏ x = 1`.
+* `prod_eq_one_of_no_involution` — if `G` has no element of order two,
+  `∏ x = 1`.
+* `prod_eq_unique_involution` — if `G` has a unique element `t` of order two,
+  `∏ x = t`.
+* `prod_eq_one_or_unique_involution` — **full Gauss-Wilson characterization**:
+  the product of all elements of a finite abelian group is the unique element
+  of order two if one exists, and `1` otherwise.
+
+The cardinality `|{x | x² = 1}|` is always a power of two (the square-roots of
+`1` form an elementary abelian 2-group), so the case `|S| = 3` never occurs;
+nonetheless the `3 ≤ |S|` hypothesis is all the two-involution trick needs.
+-/
+
+namespace WilsonsTheoremOQ02ExtOQ01
+
+open Finset
+
+/-- **Involution helper** (general `CommGroup` form, copied from the private
+    helper in `WilsonsTheoremOQ02Ext`). For `c` with `c² = 1` and `c ≠ 1`, the
+    map `x ↦ c * x` is a fixed-point-free involution on `S = {x | x² = 1}` with
+    constant pair product `c`. -/
+theorem mul_involution_on_sq_eq_one {G : Type*} [CommGroup G] [DecidableEq G]
+    {c : G} (hc_sq : c ^ 2 = 1) (hc_ne : c ≠ 1) :
+    let S := Finset.univ.filter (fun x : G => x ^ 2 = 1)
+    (∀ x ∈ S, c * x ∈ S) ∧
+    (∀ x ∈ S, c * (c * x) = x) ∧
+    (∀ x ∈ S, c * x ≠ x) ∧
+    (∀ x ∈ S, x * (c * x) = c) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro x hx
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx ⊢
+    exact WilsonsTheoremOQ02Ext.mul_sq_eq_one hc_sq hx
+  · intro x _; rw [← mul_assoc, ← sq, hc_sq, one_mul]
+  · intro x _ h; exact hc_ne (mul_right_cancel h)
+  · intro x hx
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx
+    rw [mul_comm x (c * x), mul_assoc, ← sq, hx, mul_one]
+
+/-- **General two-involution theorem.** In a finite abelian group with at least
+    three square roots of `1`, the product of all elements is `1`.
+
+    This is the abstract content of the two-involution trick: the proof body is
+    the `(ZMod n)ˣ` proof `prod_units_one_of_not_cyclic_ext`, with the
+    cardinality bound supplied as a hypothesis instead of derived from
+    non-cyclicity. -/
+theorem prod_eq_one_of_three_le_card_sqrt_one
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G]
+    (hS_card : 3 ≤ (Finset.univ.filter (fun x : G => x ^ 2 = 1)).card) :
+    ∏ x : G, x = 1 := by
+  rw [WilsonsTheoremOQ02Ext.prod_eq_prod_sq_eq_one]
+  set S := Finset.univ.filter (fun x : G => x ^ 2 = 1)
+  have hS_mem_sq : ∀ x ∈ S, x ^ 2 = 1 := fun x hx => by
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx; exact hx
+  -- Pick c ∈ S \ {1}
+  have hS_sub1_nonempty : (S \ {1}).Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]; intro hempty
+    have hsub : S ⊆ {1} := by
+      intro x hx; by_contra hxne
+      exact Finset.not_mem_empty x (hempty ▸ Finset.mem_sdiff.mpr ⟨hx, hxne⟩)
+    have := Finset.card_le_card hsub; simp at this; omega
+  obtain ⟨c, hc_mem⟩ := hS_sub1_nonempty
+  have hc_in_S : c ∈ S := (Finset.mem_sdiff.mp hc_mem).1
+  have hc_ne_1 : c ≠ 1 := by intro h; exact (Finset.mem_sdiff.mp hc_mem).2 (by simp [h])
+  have hc_sq : c ^ 2 = 1 := hS_mem_sq c hc_in_S
+  -- Pick d ∈ S \ {1, c}
+  have hS_sub2_nonempty : (S \ {1, c}).Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]; intro hempty
+    have hsub : S ⊆ {1, c} := by
+      intro x hx; by_contra hxne
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hxne; push_neg at hxne
+      exact Finset.not_mem_empty x (hempty ▸ Finset.mem_sdiff.mpr ⟨hx, by
+        simp only [Finset.mem_insert, Finset.mem_singleton]; push_neg; exact hxne⟩)
+    have h1 := Finset.card_le_card hsub
+    have h2 : ({1, c} : Finset G).card ≤ 2 := Finset.card_insert_le _ _
+    omega
+  obtain ⟨d, hd_mem⟩ := hS_sub2_nonempty
+  have hd_in_S : d ∈ S := (Finset.mem_sdiff.mp hd_mem).1
+  have hd_ne_1 : d ≠ 1 := by intro h; exact (Finset.mem_sdiff.mp hd_mem).2 (by simp [h])
+  have hd_ne_c : d ≠ c := by intro h; exact (Finset.mem_sdiff.mp hd_mem).2 (by simp [h])
+  have hd_sq : d ^ 2 = 1 := hS_mem_sq d hd_in_S
+  -- c * d ≠ 1
+  have hcd_sq : (c * d) ^ 2 = 1 := WilsonsTheoremOQ02Ext.mul_sq_eq_one hc_sq hd_sq
+  have hcd_ne_1 : c * d ≠ 1 := by
+    intro h
+    have hdc : d = c⁻¹ := by rwa [mul_eq_one_iff_eq_inv] at h
+    have : d = c := by
+      rw [hdc, inv_eq_of_mul_eq_one_right]; rw [← sq]; exact hc_sq
+    exact hd_ne_c this
+  -- Involution data for c, d, cd
+  obtain ⟨hσc_mem, hσc_inv, hσc_ne, hσc_prod⟩ := mul_involution_on_sq_eq_one hc_sq hc_ne_1
+  obtain ⟨hσd_mem, hσd_inv, hσd_ne, hσd_prod⟩ := mul_involution_on_sq_eq_one hd_sq hd_ne_1
+  obtain ⟨hσcd_mem, hσcd_inv, hσcd_ne, hσcd_prod⟩ :=
+    mul_involution_on_sq_eq_one hcd_sq hcd_ne_1
+  -- ∏ S equals c^k, d^k and (cd)^k where k = |S|/2
+  have hP_eq_c : ∏ x ∈ S, x = c ^ (S.card / 2) :=
+    WilsonsTheoremOQ02Ext.prod_involution_const hσc_mem hσc_inv hσc_ne hσc_prod
+  have hP_eq_d : ∏ x ∈ S, x = d ^ (S.card / 2) :=
+    WilsonsTheoremOQ02Ext.prod_involution_const hσd_mem hσd_inv hσd_ne hσd_prod
+  have hP_eq_cd : ∏ x ∈ S, x = (c * d) ^ (S.card / 2) :=
+    WilsonsTheoremOQ02Ext.prod_involution_const hσcd_mem hσcd_inv hσcd_ne hσcd_prod
+  -- Two-involution trick: c^k = (cd)^k ⟹ d^k = 1 ⟹ c^k = 1
+  have hd_pow : d ^ (S.card / 2) = 1 := by
+    have h : c ^ (S.card / 2) = (c * d) ^ (S.card / 2) := by rw [← hP_eq_c, hP_eq_cd]
+    rw [mul_pow] at h
+    exact mul_left_cancel (a := c ^ (S.card / 2)) (by rwa [mul_one])
+  have hc_pow : c ^ (S.card / 2) = 1 := by rw [hP_eq_c, hP_eq_d, hd_pow]
+  rw [hP_eq_c, hc_pow]
+
+/-- If a finite abelian group has no element of order two, the product of all
+    its elements is `1`. -/
+theorem prod_eq_one_of_no_involution
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G]
+    (h : ∀ s : G, s ^ 2 = 1 → s = 1) :
+    ∏ x : G, x = 1 := by
+  rw [WilsonsTheoremOQ02Ext.prod_eq_prod_sq_eq_one]
+  have hS : Finset.univ.filter (fun x : G => x ^ 2 = 1) = {1} := by
+    apply Finset.eq_singleton_iff_unique_mem.mpr
+    refine ⟨by simp only [Finset.mem_filter, Finset.mem_univ, true_and, one_pow], ?_⟩
+    intro x hx
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx
+    exact h x hx
+  rw [hS, Finset.prod_singleton]
+
+/-- If a finite abelian group has a unique element `t` of order two, the product
+    of all its elements is `t`. -/
+theorem prod_eq_unique_involution
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G]
+    {t : G} (ht_ne : t ≠ 1) (ht_sq : t ^ 2 = 1)
+    (huniq : ∀ s : G, s ^ 2 = 1 → s = 1 ∨ s = t) :
+    ∏ x : G, x = t := by
+  rw [WilsonsTheoremOQ02Ext.prod_eq_prod_sq_eq_one]
+  have hS : Finset.univ.filter (fun x : G => x ^ 2 = 1) = {1, t} := by
+    apply Finset.ext
+    intro x
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert,
+      Finset.mem_singleton]
+    refine ⟨fun hx => huniq x hx, ?_⟩
+    rintro (rfl | rfl)
+    · simp
+    · exact ht_sq
+  rw [hS, Finset.prod_pair (Ne.symm ht_ne), one_mul]
+
+/-- **Full Gauss-Wilson characterization for finite abelian groups.** The
+    product of all elements of a finite abelian group is the unique element of
+    order two if such an element exists, and `1` otherwise. -/
+theorem prod_eq_one_or_unique_involution
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G] :
+    (∏ x : G, x = 1) ∨
+      (∃ t : G, t ≠ 1 ∧ t ^ 2 = 1 ∧
+        (∀ s : G, s ^ 2 = 1 → s = 1 ∨ s = t) ∧ ∏ x : G, x = t) := by
+  by_cases h1 : ∀ s : G, s ^ 2 = 1 → s = 1
+  · exact Or.inl (prod_eq_one_of_no_involution h1)
+  · push_neg at h1
+    obtain ⟨t, ht_sq, ht_ne⟩ := h1
+    by_cases huniq : ∀ s : G, s ^ 2 = 1 → s = 1 ∨ s = t
+    · exact Or.inr ⟨t, ht_ne, ht_sq, huniq, prod_eq_unique_involution ht_ne ht_sq huniq⟩
+    · -- A second non-identity involution `u` exists ⟹ |{x | x²=1}| ≥ 3
+      push_neg at huniq
+      obtain ⟨u, hu_sq, hu_ne1, hu_net⟩ := huniq
+      have hcard : 3 ≤ (Finset.univ.filter (fun x : G => x ^ 2 = 1)).card := by
+        have h1m : (1 : G) ∈ Finset.univ.filter (fun x : G => x ^ 2 = 1) := by
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and, one_pow]
+        have htm : t ∈ Finset.univ.filter (fun x : G => x ^ 2 = 1) := by
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact ht_sq
+        have hum : u ∈ Finset.univ.filter (fun x : G => x ^ 2 = 1) := by
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact hu_sq
+        have hsub : ({1, t, u} : Finset G) ⊆
+            Finset.univ.filter (fun x : G => x ^ 2 = 1) := by
+          intro y hy
+          simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+          rcases hy with rfl | rfl | rfl
+          · exact h1m
+          · exact htm
+          · exact hum
+        have hcard3 : ({1, t, u} : Finset G).card = 3 := by
+          rw [Finset.card_insert_of_not_mem (by simp [Ne.symm ht_ne, Ne.symm hu_ne1])]
+          rw [Finset.card_insert_of_not_mem (by simp [Ne.symm hu_net])]
+          simp
+        have hle := Finset.card_le_card hsub
+        omega
+      exact Or.inl (prod_eq_one_of_three_le_card_sqrt_one hcard)
+
+end WilsonsTheoremOQ02ExtOQ01

--- a/research/problems/wilsons-theorem-oq-02-ext-oq-01/knowledge.md
+++ b/research/problems/wilsons-theorem-oq-02-ext-oq-01/knowledge.md
@@ -1,0 +1,107 @@
+# wilsons-theorem-oq-02-ext-oq-01 — Two-Involution Trick for General Finite Abelian Groups
+
+## Problem
+
+OQ-01 of `wilsons-theorem-oq-02-ext`:
+
+> Can the two-involution trick be formalized as a **general theorem about finite
+> abelian groups**, rather than only the unit group `(ZMod n)ˣ`?
+
+**Answer: yes**, and the general statement is strictly more elementary than the
+already-proven `(ZMod n)ˣ` specialization.
+
+## The general Gauss-Wilson theorem
+
+Let `G` be a finite abelian group and `S = {x ∈ G : x² = 1}`. Then:
+
+1. **Pairing.** `∏_{x∈G} x = ∏_{x∈S} x`. (Pair each `x ∉ S` with `x⁻¹ ≠ x`;
+   already proven generally as `WilsonsTheoremOQ02Ext.prod_eq_prod_sq_eq_one`.)
+2. **Structure.** `S = ker(x ↦ x²)` is an elementary abelian 2-group, so
+   `|S| = 2^r` for `r =` the 2-rank. In particular `|S| ∈ {1,2,4,8,…}`,
+   never `3`.
+3. **Trichotomy.**
+   - `|S| = 1` (`r = 0`): `∏ G = 1`.
+   - `|S| = 2` (`r = 1`): `S = {1, t}`, `∏ G = t` (the unique involution).
+   - `|S| ≥ 4` (`r ≥ 2`): `∏ G = 1`, by the **two-involution trick**.
+
+Equivalently: **the product of all elements of a finite abelian group is the
+unique element of order two if one exists, and `1` otherwise.**
+
+## Key ORIENT insight (why this is the right generalization)
+
+The companion file proves the `(ZMod n)ˣ` case in
+`prod_units_one_of_not_cyclic_ext` (`WilsonsTheoremOQ02Ext.lean:362-436`).
+Reading that proof line-by-line:
+
+- Line **373** is the *only* `(ZMod n)`-specific step: it derives
+  `3 ≤ |S|` from `¬ IsCyclic (ZMod n)ˣ` via `GaussWilsonNonCyclic`
+  (CRT splitting + the `n = 2^k` explicit `2^{k-1}+1` construction).
+- **Every line from `prod_eq_prod_sq_eq_one` (line 370) onward** is already
+  written for an arbitrary `[CommGroup G] [Fintype G] [DecidableEq G]`:
+  picking `c, d ∈ S \ {1}` distinct, building the FPF involutions
+  `x ↦ cx`, `x ↦ cdx`, applying `prod_involution_const`, and concluding
+  `c^{|S|/2} = (cd)^{|S|/2} ⟹ d^{|S|/2} = 1 ⟹ ∏S = c^{|S|/2} = 1`.
+
+So the general theorem is obtained by **taking `3 ≤ |S|` as a hypothesis** and
+copying the proven proof body. It *sheds* all of `GaussWilsonNonCyclic`
+(the CRT and `2^k` case analysis) — the hardest part of the original — because
+that machinery only existed to translate `¬IsCyclic` into the cardinality bound.
+
+## Mathlib gap (honesty check)
+
+Mathlib v4.26.0 has only the **field-units** case:
+`FiniteField.prod_univ_units_id_eq_neg_one` (the engine behind
+`ZMod.wilsons_lemma`). There is **no** general finite-abelian-group
+"product = unique involution, else 1" theorem. The OQ is genuine.
+(Classical reference: P. L. Clark, *Wilson's Theorem: An Algebraic Approach*.)
+
+## Deliverables this session (ACT, build-pending)
+
+New file `proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean` (0 sorries, 0 axioms):
+
+| theorem | statement |
+|---|---|
+| `prod_eq_one_of_three_le_card_sqrt_one` | `3 ≤ \|{x:x²=1}\|` ⇒ `∏ G = 1` (heart) |
+| `prod_eq_one_of_no_involution` | no element of order 2 ⇒ `∏ G = 1` |
+| `prod_eq_unique_involution` | unique `t` of order 2 ⇒ `∏ G = t` |
+| `prod_eq_one_or_unique_involution` | full characterization |
+
+The heart theorem reuses the public `WilsonsTheoremOQ02Ext` lemmas
+(`prod_eq_prod_sq_eq_one`, `prod_involution_const`, `mul_sq_eq_one`) and a local
+copy of the (private) `mul_involution_on_sq_eq_one` helper. Its proof body is a
+near-verbatim transcription of the proven `(ZMod n)ˣ` proof with `(ZMod n)ˣ → G`
+and the cardinality bound as a hypothesis.
+
+## Exact verification
+
+`research/verification/wilsons_oq02_ext_oq01_abelian.py` checks the full
+trichotomy, the pairing lemma, and `|S|` being a power of two, exactly (integer
+group arithmetic, no floats) over **1311 finite abelian groups**:
+cyclic `ℤ/n` (`n ≤ 200`), products `ℤ/a × ℤ/b` (`a,b ≤ 30`), selected
+higher-rank products (incl. 2-rank 2 and 3), and the unit groups `(ℤ/n)ˣ`
+(`n ≤ 200`). **0 mismatches.**
+
+## Blackout note
+
+Docker build and Aristotle were both unavailable this session (Docker
+hangs; Aristotle returns 404). The Lean file is therefore **build-pending** and
+**not yet registered** in `proofs/Proofs.lean` — registering an unverified file
+into the import-based aggregator risks breaking the auto-merged `main` build.
+
+## Next steps
+
+1. On a Docker-up session: build `Proofs.WilsonsTheoremOQ02ExtOQ01`, then add
+   `import Proofs.WilsonsTheoremOQ02ExtOQ01` to `proofs/Proofs.lean`.
+2. Optionally upstream the general two-involution theorem to Mathlib
+   (self-contained, fills a clear gap).
+3. Optionally re-derive `gaussWilson_abstract_ext` for `(ZMod n)ˣ` as a
+   corollary of the new general theorem.
+
+## Session log
+
+### 2026-06-15 (Session 1, FRESH) — ACT, build-pending
+- **Mode**: FRESH. **Outcome**: progress (general theorems written, math verified, build deferred).
+- Found Mathlib lacks the general theorem; confirmed the proven `(ZMod n)ˣ` proof is general except for one cardinality-bound step.
+- Wrote 4 general `CommGroup` theorems + 1 combined characterization.
+- Verified the trichotomy exactly on 1311 groups.
+- Did not register in the aggregator (dual-backend blackout).

--- a/research/verification/wilsons_oq02_ext_oq01_abelian.py
+++ b/research/verification/wilsons_oq02_ext_oq01_abelian.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Exact verification for wilsons-theorem-oq-02-ext-oq-01.
+
+OPEN QUESTION (OQ-01 of wilsons-theorem-oq-02-ext):
+    Can the two-involution trick be formalized as a GENERAL theorem about
+    finite abelian groups (not just the unit group (ZMod n)^x)?
+
+GENERAL GAUSS-WILSON THEOREM (claim to verify):
+    Let G be a finite abelian group and S = {x in G : x^2 = 1}.
+      (1)  prod_{x in G} x = prod_{x in S} x          [pairing of x with x^{-1}]
+      (2)  S is an elementary abelian 2-subgroup, so |S| = 2^r (a power of 2).
+      (3)  The product of all elements of G is:
+              - 1                      if S = {1}                 (|S| = 1)
+              - t  (unique involution) if S = {1, t}              (|S| = 2)
+              - 1                      if |S| >= 4 (2-rank >= 2)   two-involution trick
+           Equivalently:  prod_{x in G} x = (the unique element of order 2 if one
+           exists), otherwise 1.
+
+This file checks the claim EXACTLY (integer/group arithmetic, no floats) over a
+large family of finite abelian groups represented as products of cyclic groups
+Z/n1 x Z/n2 x ... , covering:
+  - all cyclic groups Z/n, n <= 200
+  - all products Z/a x Z/b with a,b <= 30
+  - selected triple/quad products including the 2-rank >= 2 and 2-rank = 3 cases
+  - the classic (ZMod n)^x unit groups (the already-proven specialization) for n <= 200
+
+For each group it independently:
+  * computes P  = product of ALL elements,
+  * computes S  = involutions+identity {x : 2x = 0},
+  * computes PS = product over S,
+  * checks P == PS,                                 (lemma 1)
+  * checks |S| is a power of 2,                     (lemma 2)
+  * predicts P by the trichotomy and checks it.     (main theorem)
+"""
+
+from itertools import product
+from math import gcd
+
+
+# ---- finite abelian group as additive Z/n1 x ... x Z/nk -------------------
+
+def elements(mods):
+    return list(product(*[range(m) for m in mods]))
+
+def add(a, b, mods):
+    return tuple((x + y) % m for x, y, m in zip(a, b, mods))
+
+def double(a, mods):
+    return tuple((2 * x) % m for x, m in zip(a, mods))
+
+def group_product(mods):
+    """Sum (additive 'product') of all elements of Z/n1 x ... x Z/nk."""
+    acc = tuple(0 for _ in mods)
+    for e in elements(mods):
+        acc = add(acc, e, mods)
+    return acc
+
+def involutions(mods):
+    """S = {x : 2x = 0}, includes identity."""
+    zero = tuple(0 for _ in mods)
+    return [e for e in elements(mods) if double(e, mods) == zero]
+
+def product_over(subset, mods):
+    acc = tuple(0 for _ in mods)
+    for e in subset:
+        acc = add(acc, e, mods)
+    return acc
+
+def is_power_of_two(n):
+    return n >= 1 and (n & (n - 1)) == 0
+
+
+def predict(mods):
+    """Trichotomy prediction of prod of all elements."""
+    zero = tuple(0 for _ in mods)
+    S = involutions(mods)
+    nontrivial = [x for x in S if x != zero]
+    if len(nontrivial) == 0:
+        return zero                  # |S| = 1
+    if len(nontrivial) == 1:
+        return nontrivial[0]         # |S| = 2: unique involution
+    return zero                      # |S| >= 4: two-involution trick -> identity
+
+
+def check_group(mods, fails):
+    zero = tuple(0 for _ in mods)
+    S = involutions(mods)
+    P = group_product(mods)
+    PS = product_over(S, mods)
+    # lemma 1: P == PS
+    if P != PS:
+        fails.append((mods, "P != prod(S)", P, PS))
+    # lemma 2: |S| is a power of two
+    if not is_power_of_two(len(S)):
+        fails.append((mods, "|S| not power of 2", len(S), None))
+    # main theorem: trichotomy prediction
+    pred = predict(mods)
+    if P != pred:
+        fails.append((mods, "trichotomy mismatch", P, pred))
+
+
+# ---- (ZMod n)^x as a MULTIPLICATIVE group (the proven specialization) -----
+
+def unit_group_product(n):
+    """prod over (Z/n)^x, returned as element of Z/n. Also returns S, P_S."""
+    units = [a for a in range(1, n) if gcd(a, n) == 1]
+    P = 1
+    for a in units:
+        P = (P * a) % n
+    S = [a for a in units if (a * a) % n == 1]
+    PS = 1
+    for a in S:
+        PS = (PS * a) % n
+    return P, S, PS
+
+def check_unit_group(n, fails):
+    if n < 2:
+        return
+    P, S, PS = unit_group_product(n)
+    if P != PS % n:
+        fails.append((("U", n), "P != prod(S)", P, PS % n))
+    if not is_power_of_two(len(S)):
+        fails.append((("U", n), "|S| not power of 2", len(S), None))
+    nontrivial = [a for a in S if a != 1]
+    if len(nontrivial) == 0:
+        pred = 1
+    elif len(nontrivial) == 1:
+        pred = nontrivial[0]
+    else:
+        pred = 1
+    if P != pred:
+        fails.append((("U", n), "trichotomy mismatch", P, pred))
+
+
+def main():
+    fails = []
+    tested = 0
+
+    # cyclic Z/n, n <= 200
+    for n in range(1, 201):
+        check_group((n,), fails)
+        tested += 1
+
+    # products Z/a x Z/b, a,b <= 30
+    for a in range(1, 31):
+        for b in range(1, 31):
+            check_group((a, b), fails)
+            tested += 1
+
+    # selected triples / quads, emphasizing 2-rank structure
+    triples = [
+        (2, 2, 2), (2, 2, 4), (2, 4, 8), (4, 4, 4), (2, 2, 3),
+        (2, 6, 6), (3, 3, 3), (6, 10, 15), (2, 2, 2, 2), (2, 4, 6, 8),
+        (12, 18, 30), (2, 2, 2, 3, 5),
+    ]
+    for t in triples:
+        check_group(t, fails)
+        tested += 1
+
+    # unit groups (Z/n)^x, n <= 200  (the already-proven case)
+    for n in range(2, 201):
+        check_unit_group(n, fails)
+        tested += 1
+
+    print(f"Groups tested: {tested}")
+    if fails:
+        print(f"FAILURES: {len(fails)}")
+        for f in fails[:40]:
+            print("  ", f)
+        raise SystemExit(1)
+    print("ALL CHECKS PASSED")
+    print("  - prod(G) == prod{x : x^2=1}            (pairing lemma)")
+    print("  - |{x : x^2=1}| is always a power of 2  (elementary abelian 2-group)")
+    print("  - trichotomy: prod(G) = unique involution if one exists, else 1")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-01.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-01.json
@@ -1,0 +1,106 @@
+{
+  "slug": "wilsons-theorem-oq-02-ext-oq-01",
+  "title": "Two-Involution Trick as a General Theorem on Finite Abelian Groups",
+  "phase": "ACT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "standard",
+  "problemStatement": {
+    "formal": "\\forall \\text{ finite abelian } G,\\ \\prod_{x \\in G} x = t \\text{ if } G \\text{ has a unique } t \\text{ with } t^2=1, t\\neq 1; \\text{ else } \\prod_{x \\in G} x = 1.",
+    "plain": "Can the two-involution trick (used to prove the Gauss-Wilson theorem for the unit group (ZMod n)ˣ) be formalized as a general theorem about arbitrary finite abelian groups?",
+    "whyMatters": [
+      "Separates the genuinely group-theoretic content of Gauss-Wilson from the (ZMod n)-specific cyclicity case analysis.",
+      "The general statement is strictly more elementary than the proven specialization: it takes the cardinality bound on square roots of 1 as a hypothesis instead of deriving it via CRT and the 2^k case split."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Gauss-Wilson for (ZMod n)ˣ (WilsonsTheoremOQ02Ext.gaussWilson_abstract_ext): product of units = -1 iff (ZMod n)ˣ is cyclic.",
+      "Abstract pairing lemma prod_eq_prod_sq_eq_one for any finite CommGroup (already in WilsonsTheoremOQ02Ext).",
+      "Abstract prod_involution_const and even_card_of_fpf_involution for any finite CommGroup."
+    ],
+    "open": [],
+    "goal": "State and prove the general finite-abelian-group Gauss-Wilson theorem and its constituent two-involution lemma."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-15T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Generalized two-involution trick from (ZMod n)ˣ to arbitrary finite abelian groups.",
+    "blockers": [
+      "Docker build unavailable this session (dual-backend blackout); Lean file is build-pending and not yet registered in proofs/Proofs.lean."
+    ],
+    "nextAction": "On a Docker-up session: build Proofs.WilsonsTheoremOQ02ExtOQ01, then register it in proofs/Proofs.lean.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ACT (build-pending): wrote general CommGroup theorems generalizing the proven (ZMod n)ˣ two-involution trick. Heart theorem is a near-verbatim copy of prod_units_one_of_not_cyclic_ext with the 3 ≤ |{x:x²=1}| cardinality bound taken as a hypothesis.",
+    "builtItems": [
+      "WilsonsTheoremOQ02ExtOQ01.prod_eq_one_of_three_le_card_sqrt_one: finite CommGroup with ≥3 square roots of 1 ⇒ product of all elements = 1 (the general two-involution trick).",
+      "WilsonsTheoremOQ02ExtOQ01.prod_eq_one_of_no_involution: no element of order 2 ⇒ product = 1.",
+      "WilsonsTheoremOQ02ExtOQ01.prod_eq_unique_involution: unique element t of order 2 ⇒ product = t.",
+      "WilsonsTheoremOQ02ExtOQ01.prod_eq_one_or_unique_involution: full characterization (product = unique involution if one exists, else 1).",
+      "research/verification/wilsons_oq02_ext_oq01_abelian.py: exact check over 1311 finite abelian groups (cyclic n≤200, products a,b≤30, selected higher-rank products, and unit groups (ZMod n)ˣ n≤200)."
+    ],
+    "insights": [
+      "Inspecting prod_units_one_of_not_cyclic_ext (WilsonsTheoremOQ02Ext.lean:362-436): the ONLY (ZMod n)-specific step is line 373 deriving 3 ≤ |S| from ¬IsCyclic via GaussWilsonNonCyclic; everything from prod_eq_prod_sq_eq_one onward is already stated for an arbitrary finite CommGroup.",
+      "The general theorem is therefore MORE elementary than the proven specialization — it sheds the entire CRT / 2^k case analysis of GaussWilsonNonCyclic by taking the cardinality bound as a hypothesis.",
+      "S = {x : x²=1} is the kernel of x↦x², an elementary abelian 2-group, so |S| is always a power of 2; the value |S|=3 never occurs, but 3 ≤ |S| is exactly what the two-involution trick needs (it implies |S| ≥ 4).",
+      "Mathlib (as of v4.26.0) has only the field-units case FiniteField.prod_univ_units_id_eq_neg_one (underlying ZMod.wilsons_lemma); there is no general finite-abelian-group 'product = unique involution or 1' theorem.",
+      "Python verification confirmed the trichotomy exactly on 1311 groups (0 mismatches), including the pairing lemma prod(G)=prod(S) and |S| being a power of 2."
+    ],
+    "mathlibGaps": [
+      "No general theorem 'product of all elements of a finite abelian group = unique element of order 2 if one exists, else 1' in Mathlib v4.26.0 (only the field-units/Wilson specialization exists)."
+    ],
+    "nextSteps": [
+      "Build Proofs.WilsonsTheoremOQ02ExtOQ01 under Docker and register it in proofs/Proofs.lean (deferred due to blackout).",
+      "Optionally upstream the general two-involution theorem to Mathlib (self-contained, ~150 LOC, fills a clear gap).",
+      "Optionally restate gaussWilson_abstract_ext for (ZMod n)ˣ as a corollary of the new general theorem to de-duplicate."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "group-theory",
+    "number-theory",
+    "extension"
+  ],
+  "relatedProofs": [
+    "wilsons-theorem",
+    "wilsons-theorem-oq-02",
+    "wilsons-theorem-oq-02-ext",
+    "gauss-wilson-non-cyclic-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "P. L. Clark, Wilson's Theorem: An Algebraic Approach (generalization to finite commutative groups)."
+    ],
+    "urls": [],
+    "mathlib": [
+      "FiniteField.prod_univ_units_id_eq_neg_one",
+      "ZMod.wilsons_lemma"
+    ]
+  },
+  "started": "2026-06-15T00:00:00.000Z",
+  "lastUpdate": "2026-06-15T00:00:00.000Z",
+  "completed": null,
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/WilsonsTheoremOQ02ExtOQ01.lean",
+      "filename": "WilsonsTheoremOQ02ExtOQ01.lean",
+      "lineCount": 220,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "buildStatus": "pending-docker",
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers OQ-01 of `wilsons-theorem-oq-02-ext`: **yes**, the two-involution trick generalizes from `(ZMod n)ˣ` to arbitrary finite abelian groups — and the general statement is *more elementary* than the proven specialization.

**General Gauss-Wilson theorem.** For a finite abelian group `G` with `S = {x : x²=1}`: `∏_{x∈G} x` equals the unique element of order two if one exists, and `1` otherwise.

## Key ORIENT insight

In the proven `(ZMod n)ˣ` proof `prod_units_one_of_not_cyclic_ext` (`WilsonsTheoremOQ02Ext.lean:362-436`), the **only** ZMod-specific step is line 373, which derives `3 ≤ |S|` from `¬IsCyclic` via `GaussWilsonNonCyclic` (CRT + the `2^k` case split). Everything from `prod_eq_prod_sq_eq_one` onward is already stated for an arbitrary finite `CommGroup`. Taking `3 ≤ |S|` as a hypothesis sheds that entire machinery.

## New file `proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean` (0 sorries, 0 axioms)

- `prod_eq_one_of_three_le_card_sqrt_one` — `3 ≤ |{x:x²=1}|` ⇒ `∏ G = 1` (the general two-involution trick)
- `prod_eq_one_of_no_involution` — no element of order 2 ⇒ `∏ G = 1`
- `prod_eq_unique_involution` — unique `t` of order 2 ⇒ `∏ G = t`
- `prod_eq_one_or_unique_involution` — full characterization

Reuses the public `WilsonsTheoremOQ02Ext` lemmas; the heart theorem is a near-verbatim transcription of the proven proof.

## Honesty / Mathlib gap

Mathlib v4.26.0 has only the field-units case (`FiniteField.prod_univ_units_id_eq_neg_one`, behind `ZMod.wilsons_lemma`). No general finite-abelian-group version exists.

## Verification

`research/verification/wilsons_oq02_ext_oq01_abelian.py` checks the trichotomy, the pairing lemma, and `|S|` being a power of two — exactly (integer group arithmetic) over **1311 finite abelian groups** (cyclic `ℤ/n` n≤200, products `ℤ/a×ℤ/b` a,b≤30, selected higher-rank products, unit groups `(ℤ/n)ˣ` n≤200). 0 mismatches.

## Build status

⚠️ **Build-pending.** Docker and Aristotle were both unavailable this session, so the Lean file is **not yet registered** in `proofs/Proofs.lean` (registering an unbuilt file into the import-based aggregator risks breaking the auto-merged `main` build). A Docker-up session should build it and add the import.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.WilsonsTheoremOQ02ExtOQ01`
- [ ] Add `import Proofs.WilsonsTheoremOQ02ExtOQ01` to `proofs/Proofs.lean`
- [x] `python3 research/verification/wilsons_oq02_ext_oq01_abelian.py` → ALL CHECKS PASSED (1311 groups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)