### PR TITLE
research(sqrt2+sqrt3+sqrt5-oq-01): S5 ACT — Strategy D Lean transcription (integral-closure descent)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2825,6 +2825,7 @@ import Proofs.Sqrt2PlusSqrt3Irrational
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03Aristotle
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
+import Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula

--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
@@ -52,8 +52,11 @@ polynomial `X² − C k`. -/
 theorem isIntegral_sqrt_natCast (k : ℕ) : IsIntegral ℤ (Real.sqrt (k : ℝ)) := by
   refine ⟨X ^ 2 - C (k : ℤ), monic_X_pow_sub_C (k : ℤ) (by norm_num), ?_⟩
   have hk : (0 : ℝ) ≤ (k : ℝ) := by positivity
-  simp only [map_sub, map_pow, aeval_X, aeval_C, algebraMap_int_eq, eq_intCast,
-    Int.cast_natCast]
+  -- The `IsIntegral` witness goal is an `eval₂` (via `RingHom.IsIntegralElem`);
+  -- include both `eval₂_*` and `aeval_*`/`map_*` rewrites so this is robust to
+  -- whichever normal form the goal is presented in.
+  simp only [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, map_sub, map_pow, aeval_X,
+    aeval_C, algebraMap_int_eq, eq_intCast, Int.cast_natCast]
   rw [Real.sq_sqrt hk]
   ring
 

--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
@@ -1,0 +1,131 @@
+/-
+# Irrationality of √2 + √3 + √5 + √7 (OQ-01 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`)
+
+## Strategy D — algebraic integer in a bounded interval
+
+Let `α := √2 + √3 + √5 + √7`. This proof sidesteps the entire degree-16
+minimal-polynomial / iterated-squaring machinery (Strategies A–C) via a short
+integral-closure descent:
+
+1. Each `√k` (k ∈ {2,3,5,7}) is a root of the monic integer polynomial
+   `X² − C k`, hence `IsIntegral ℤ (√k)`. Algebraic integers are closed under
+   addition (`IsIntegral.add`), so `α` is integral over `ℤ`.
+2. Suppose `α` were rational, `α = (q : ℝ)` with `q : ℚ`. Integrality descends
+   along the injective `algebraMap ℚ ℝ` (`isIntegral_algebraMap_iff`), giving
+   `IsIntegral ℤ q`.
+3. `ℤ` is integrally closed in its fraction field `ℚ`
+   (`IsIntegrallyClosed.isIntegral_iff`), so `q = (n : ℤ)` for some integer `n`;
+   hence `α = (n : ℝ)`.
+4. But `8 < α < 9` (α ≈ 8.0281), so no integer can equal `α`. Contradiction,
+   so `α` is irrational. ∎
+
+This avoids surd isolation, the degree-16 minimal polynomial, and any new
+Mathlib theory — only the standard integral-closure API plus four `norm_num`
+radical bounds.
+
+## Provenance
+
+Bearer-confirmed at Mathlib pin `v4.26.0` over four build-free sessions; the
+load-bearing arithmetic (integrality of each `√k`, the bound `8 < α < 9`) is
+reproduced by `research/problems/.../verify_strategy_d.py`.
+
+## Status
+- [x] `isIntegral_sqrt_natCast` — √(k:ℕ) is integral over ℤ (root of monic X²−C k)
+- [x] `alpha_isIntegral`        — α is integral over ℤ (three `IsIntegral.add`)
+- [x] `sqrt_bounds`             — generic rational bracket lo < √x < hi from lo²<x<hi²
+- [x] `alpha_gt_eight`, `alpha_lt_nine` — `8 < α < 9` via the rational witnesses
+- [x] `irrational_sqrt2_plus_sqrt3_plus_sqrt5_plus_sqrt7` — main theorem
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 400000
+
+open Polynomial
+
+namespace Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
+
+noncomputable section
+
+/-- `√(k : ℕ)` is an algebraic integer: it is a root of the monic integer
+polynomial `X² − C k`. -/
+theorem isIntegral_sqrt_natCast (k : ℕ) : IsIntegral ℤ (Real.sqrt (k : ℝ)) := by
+  refine ⟨X ^ 2 - C (k : ℤ), monic_X_pow_sub_C (k : ℤ) (by norm_num), ?_⟩
+  have hk : (0 : ℝ) ≤ (k : ℝ) := by positivity
+  simp only [map_sub, map_pow, aeval_X, aeval_C, algebraMap_int_eq, eq_intCast,
+    Int.cast_natCast]
+  rw [Real.sq_sqrt hk]
+  ring
+
+/-- `α = √2 + √3 + √5 + √7` is integral over `ℤ` (sum of four algebraic
+integers). -/
+theorem alpha_isIntegral :
+    IsIntegral ℤ (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7) := by
+  have h2 : IsIntegral ℤ (Real.sqrt 2) := by simpa using isIntegral_sqrt_natCast 2
+  have h3 : IsIntegral ℤ (Real.sqrt 3) := by simpa using isIntegral_sqrt_natCast 3
+  have h5 : IsIntegral ℤ (Real.sqrt 5) := by simpa using isIntegral_sqrt_natCast 5
+  have h7 : IsIntegral ℤ (Real.sqrt 7) := by simpa using isIntegral_sqrt_natCast 7
+  exact ((h2.add h3).add h5).add h7
+
+/-- Generic rational bracket: a positive `lo` with `lo² < x` and a positive `hi`
+with `x < hi²` sandwich `√x`. Used to pin `8 < α < 9` from rational witnesses. -/
+theorem sqrt_bounds (x lo hi : ℝ) (hlo : 0 ≤ lo) (hhi : 0 ≤ hi)
+    (h1 : lo ^ 2 < x) (h2 : x < hi ^ 2) :
+    lo < Real.sqrt x ∧ Real.sqrt x < hi := by
+  have hx : 0 ≤ x := le_of_lt (lt_of_le_of_lt (sq_nonneg lo) h1)
+  refine ⟨?_, ?_⟩
+  · calc lo = Real.sqrt (lo ^ 2) := (Real.sqrt_sq hlo).symm
+      _ < Real.sqrt x := Real.sqrt_lt_sqrt (sq_nonneg lo) h1
+  · calc Real.sqrt x < Real.sqrt (hi ^ 2) := Real.sqrt_lt_sqrt hx h2
+      _ = hi := Real.sqrt_sq hhi
+
+/-- Lower bound: `8 < √2 + √3 + √5 + √7`. Witnesses
+`√2 > 1.41, √3 > 1.73, √5 > 2.23, √7 > 2.64` sum to `8.01 > 8`. -/
+theorem alpha_gt_eight :
+    (8 : ℝ) < Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7 := by
+  obtain ⟨l2, _⟩ := sqrt_bounds 2 1.41 1.42 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨l3, _⟩ := sqrt_bounds 3 1.73 1.74 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨l5, _⟩ := sqrt_bounds 5 2.23 2.24 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨l7, _⟩ := sqrt_bounds 7 2.64 2.65 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  linarith
+
+/-- Upper bound: `√2 + √3 + √5 + √7 < 9`. Witnesses
+`√2 < 1.42, √3 < 1.74, √5 < 2.24, √7 < 2.65` sum to `8.05 < 9`. -/
+theorem alpha_lt_nine :
+    Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7 < (9 : ℝ) := by
+  obtain ⟨_, u2⟩ := sqrt_bounds 2 1.41 1.42 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨_, u3⟩ := sqrt_bounds 3 1.73 1.74 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨_, u5⟩ := sqrt_bounds 5 2.23 2.24 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  obtain ⟨_, u7⟩ := sqrt_bounds 7 2.64 2.65 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  linarith
+
+/-- **Main theorem**: `√2 + √3 + √5 + √7` is irrational. -/
+theorem irrational_sqrt2_plus_sqrt3_plus_sqrt5_plus_sqrt7 :
+    Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7) := by
+  rintro ⟨q, hq⟩
+  -- hq : (q : ℝ) = √2 + √3 + √5 + √7
+  -- Step 1–2: α integral over ℤ; descend to q integral over ℤ.
+  have hα := alpha_isIntegral
+  have hq_int : IsIntegral ℤ q := by
+    rw [← isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective]
+    have hmap : (algebraMap ℚ ℝ) q
+        = Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7 := by
+      rw [eq_ratCast]; exact hq
+    rw [hmap]; exact hα
+  -- Step 3: ℤ integrally closed in ℚ ⇒ q is an integer.
+  obtain ⟨n, hn⟩ := IsIntegrallyClosed.isIntegral_iff.mp hq_int
+  -- hn : algebraMap ℤ ℚ n = q
+  have hqn : q = (n : ℚ) := hn.symm.trans (eq_intCast (algebraMap ℤ ℚ) n)
+  have hαn : Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7 = (n : ℝ) := by
+    rw [← hq, hqn]; push_cast; ring
+  -- Step 4: but 8 < α < 9, so no integer equals α.
+  have hlb := alpha_gt_eight
+  have hub := alpha_lt_nine
+  rw [hαn] at hlb hub
+  have h8 : (8 : ℤ) < n := by exact_mod_cast hlb
+  have h9 : n < (9 : ℤ) := by exact_mod_cast hub
+  omega
+
+end
+
+end Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -275,3 +275,59 @@ routine but are exactly why a real build (not an uncompilable `.lean`) is deferr
 
 ### Files modified
 - `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+
+---
+
+## Session 2026-06-15 (Session 5) — Strategy D ACT: Lean transcription (researcher-1)
+
+**Mode**: CONTINUE · **Outcome**: ORIENT (ACT-ready) → **ACT shipped (build-pending)**. Both
+backends still down (Docker `docker info` 20s timeout; Aristotle MCP `prove` → "Resource not
+found", re-probed). CI is ground truth per the project's established build-pending pattern.
+
+### What I did
+Transcribed Strategy D into `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean`
+(registered in `Proofs.lean`). **5 theorems, 0 sorries, 0 axioms.** The S4 "paste-port-ready"
+verdict had been carried for 4 sessions waiting on a backend; continuing to re-verify a stable
+verdict adds no information, so the proportionate move was the transcription itself.
+
+Proof structure (integral-closure descent):
+1. `isIntegral_sqrt_natCast (k)` — `√(k:ℕ)` is a root of monic `X²−C (k:ℤ)`
+   (`monic_X_pow_sub_C`, `Real.sq_sqrt`), so integral over ℤ.
+2. `alpha_isIntegral` — `((h2.add h3).add h5).add h7` (algebraic integers closed under +).
+3. `sqrt_bounds (x lo hi)` — `lo²<x ∧ x<hi² ⇒ lo<√x<hi` via `Real.sqrt_lt_sqrt`/`Real.sqrt_sq`.
+4. `alpha_gt_eight` / `alpha_lt_nine` — `8<α<9` from witnesses 1.41/1.42, 1.73/1.74, 2.23/2.24,
+   2.64/2.65 (all `norm_num`, sums 8.01 and 8.05).
+5. main — assume `α=(q:ℝ)`; `isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective` descends to
+   `IsIntegral ℤ q`; `IsIntegrallyClosed.isIntegral_iff` gives `q=(n:ℤ)`; then `8<(n:ℝ)<9` has
+   no integer solution (`exact_mod_cast` + `omega`).
+
+### Verification (build-free)
+- `verify_strategy_d.py` re-run → ALL CHECKS PASSED. Confirms integrality of each √k, the
+  degree-16 minimal poly, and the **exact** rational witnesses the Lean `norm_num` bounds use.
+- In-repo idiom cross-checks: `monic_X_pow_sub_C (·:ℤ) (·:n≠0)` is used in
+  `NthRootIrrationalOQ01.lean`; `isIntegral_algebraMap_iff (algebraMap _ _).injective` in
+  `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`. Descent + integrally-closed bearers are the
+  file:line-confirmed ones from S4 at pin v4.26.0.
+
+### Self-review fix (pre-commit)
+`sqrt_bounds` upper branch first wrote `Real.sqrt_lt_sqrt (le_of_lt (by positivity))` — but
+`positivity` cannot prove `0 ≤ x` for an abstract real `x`. Corrected to derive `0 ≤ x` from
+`lo² < x` via `lt_of_le_of_lt (sq_nonneg lo) h1`.
+
+### Residual risk (Lean-uncompiled — backends down)
+(i) the `simp only [map_sub, map_pow, aeval_X, aeval_C, algebraMap_int_eq, eq_intCast,
+Int.cast_natCast]` reduction in step 1; (ii) `IsIntegrallyClosed.isIntegral_iff`/`eq_ratCast`
+instance resolution (`IsScalarTower ℤ ℚ ℝ`, `IsFractionRing ℤ ℚ`). The math is verifier-confirmed;
+only Lean plumbing is at risk, isolated to single lines for any CI patch.
+
+### Files modified
+- `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (new)
+- `proofs/Proofs.lean` (import line)
+- `src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json`
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+- `research/problems/.../sessions/2026-06-15-s5-strategyd-act-lean-transcription.md` (new)
+
+### Next steps
+1. CI build of `Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01`. If green ⇒ OQ **SOLVED**
+   (0 sorries / 0 axioms) — promote to completed.
+2. If CI flags a name/cast/instance error, patch the offending line (see residual risk).

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -331,3 +331,16 @@ only Lean plumbing is at risk, isolated to single lines for any CI patch.
 1. CI build of `Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01`. If green ⇒ OQ **SOLVED**
    (0 sorries / 0 axioms) — promote to completed.
 2. If CI flags a name/cast/instance error, patch the offending line (see residual risk).
+
+### S6 (researcher-1) — pre-merge robustness hardening (dual blackout persists)
+Static review of the build-pending file flagged one fragile proof. The `IsIntegral`
+witness goal is an `eval₂` (Mathlib `RingHom.IsIntegralElem` is defined via `eval₂`,
+not `aeval`), so `isIntegral_sqrt_natCast`'s original
+`simp only [map_sub, map_pow, aeval_X, aeval_C, …]` (all `aeval`/bundled-hom lemmas)
+likely makes no progress on a raw `eval₂` goal, leaving `rw [Real.sq_sqrt hk]` with
+nothing to rewrite ⇒ build failure. **Fix**: added the matching `eval₂_*` rewrites
+(`eval₂_sub, eval₂_pow, eval₂_X, eval₂_C`) alongside the existing set, so the proof
+is robust to whichever normal form the goal is presented in (`simp only` ignores the
+non-matching lemmas). The other four theorems (`alpha_isIntegral`, `sqrt_bounds`,
+`alpha_gt_eight/lt_nine`, main) were re-checked line-by-line against `v4.26.0` and
+look sound. Still unverified locally — Aristotle 404, `docker info` times out.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/sessions/2026-06-15-s5-strategyd-act-lean-transcription.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/sessions/2026-06-15-s5-strategyd-act-lean-transcription.md
@@ -1,0 +1,63 @@
+# Session 5 — Strategy D ACT: Lean transcription
+
+**Date**: 2026-06-15
+**Agent**: researcher-1
+**Mode**: CONTINUE (ORIENT ACT-ready → ACT shipped, build-pending)
+**Backends**: Docker `docker info` 20s timeout (DOWN); Aristotle MCP `prove` → "Resource not
+found" (DOWN). Dual blackout — file ships build-pending, CI is ground truth.
+
+## Decision
+
+Strategy D had been "paste-port-ready" since S4 (researcher-5), with every integral-closure
+bearer file:line-confirmed at Mathlib pin `v4.26.0` and the arithmetic durably verified by
+`verify_strategy_d.py` (S3). Four sessions deferred the transcription waiting for a backend.
+Re-confirming an already-stable verdict adds no information; the proportionate single-cycle move
+when the slug is reclaimed is the transcription itself. So I wrote the Lean file.
+
+## Artifact
+
+`proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` — 5 theorems, 0 sorries,
+0 axioms; registered in `proofs/Proofs.lean`.
+
+Integral-closure descent for `α = √2+√3+√5+√7`:
+
+1. `isIntegral_sqrt_natCast (k : ℕ) : IsIntegral ℤ (√(k:ℝ))` — witness `X²−C (k:ℤ)`, monic by
+   `monic_X_pow_sub_C`, `aeval` reduction by `simp only [...]` then `Real.sq_sqrt`.
+2. `alpha_isIntegral` — `(((h2.add h3).add h5).add h7)` with each `hk := simpa using
+   isIntegral_sqrt_natCast k`.
+3. `sqrt_bounds (x lo hi) (0≤lo) (0≤hi) (lo²<x) (x<hi²) : lo < √x ∧ √x < hi` — two `calc`s using
+   `Real.sqrt_sq` and `Real.sqrt_lt_sqrt`; `0≤x` derived from `lo²<x`.
+4. `alpha_gt_eight : 8 < α` and `alpha_lt_nine : α < 9` — instantiate `sqrt_bounds` at the
+   witnesses (1.41/1.42, 1.73/1.74, 2.23/2.24, 2.64/2.65), then `linarith`.
+5. `irrational_sqrt2_plus_sqrt3_plus_sqrt5_plus_sqrt7` — `rintro ⟨q,hq⟩`; descend via
+   `isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective` (uses `eq_ratCast` to identify
+   `algebraMap ℚ ℝ q` with `↑q`); `IsIntegrallyClosed.isIntegral_iff.mp` gives `q=(n:ℤ)`; then
+   `8<(n:ℝ)<9` ⇒ `exact_mod_cast` + `omega`.
+
+## Verification (build-free)
+
+- `verify_strategy_d.py` re-run: ALL CHECKS PASSED — integrality of each √k, degree-16 minimal
+  polynomial (resultant + `m(α)=0`), and the **exact** rational witnesses
+  `141/100 < √2 < 71/50`, …, `66/25 < √7 < 53/20` that the Lean `norm_num` obligations encode.
+- In-repo idiom confirmation: `monic_X_pow_sub_C` (NthRootIrrationalOQ01.lean:132,141),
+  `isIntegral_algebraMap_iff (… ).injective` (AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:171,414).
+
+## Self-review fix
+
+`sqrt_bounds` upper branch initially had `Real.sqrt_lt_sqrt (le_of_lt (by positivity)) h2`, but
+`positivity` cannot establish `0 ≤ x` for an abstract `x`. Replaced with a derived
+`hx : 0 ≤ x := le_of_lt (lt_of_le_of_lt (sq_nonneg lo) h1)`.
+
+## Residual risk
+
+Not Lean-checked (backends down). Two isolated plumbing risks if CI fails:
+1. The `simp only` aeval lemma set in `isIntegral_sqrt_natCast`.
+2. `IsIntegrallyClosed.isIntegral_iff` / `eq_ratCast` and the `IsScalarTower ℤ ℚ ℝ` /
+   `IsFractionRing ℤ ℚ` instances firing without manual `haveI`.
+
+The mathematics is verifier-confirmed; any failure is a one-line Lean fix, not a strategy change.
+
+## Next
+
+CI build. Green ⇒ OQ solved (0 sorries / 0 axioms), promote to completed. Red ⇒ patch the
+flagged line per residual-risk notes.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
@@ -1,10 +1,48 @@
 # Research State: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01
 
 ## Current State
-**Phase**: ORIENT (ACT-ready)
+**Phase**: ACT (build-pending)
 **Path**: full
-**Since**: 2026-06-14
-**Iteration**: 5
+**Since**: 2026-06-15
+**Iteration**: 6
+
+## Session 5 — Strategy D ACT: Lean transcription (researcher-1, 2026-06-15)
+
+**Goal**: Convert the 4-session ORIENT (Strategy D "paste-port-ready" since S4) into the
+actual Lean file. Both backends still down (Docker `docker info` 20s timeout; Aristotle MCP
+`prove` → "Resource not found"), so this ships **build-pending** — CI is the ground truth per
+the project's established pattern. Continuing to defer would only re-confirm an already-stable
+verdict, so the proportionate move is the transcription itself.
+
+**What shipped**: new file `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean`
+(registered in `Proofs.lean`), implementing the full integral-closure descent — **0 sorries,
+0 axioms**:
+
+| Theorem | Role |
+|---|---|
+| `isIntegral_sqrt_natCast` | `√(k:ℕ)` integral over ℤ (root of monic `X²−C k`; `monic_X_pow_sub_C` + `Real.sq_sqrt`) |
+| `alpha_isIntegral` | α integral over ℤ via three `IsIntegral.add` |
+| `sqrt_bounds` | generic bracket `lo<√x<hi` from `lo²<x<hi²` (`Real.sqrt_lt_sqrt`/`Real.sqrt_sq`) |
+| `alpha_gt_eight`, `alpha_lt_nine` | `8<α<9` from the rational witnesses (1.41…2.65) |
+| `irrational_…_plus_sqrt7` | main: descend along `isIntegral_algebraMap_iff`, `IsIntegrallyClosed.isIntegral_iff` ⇒ `q∈ℤ`, contradicted by bounds + `omega` |
+
+**Verification done (build-free)**: re-ran `verify_strategy_d.py` → ALL CHECKS PASSED (integrality
+of each √k, degree-16 minimal poly, and the exact radical witnesses 141/100…53/20 that the Lean
+`norm_num` bounds rely on). In-repo cross-checks: `monic_X_pow_sub_C (k:ℤ) (h:n≠0)` and
+`isIntegral_algebraMap_iff (algebraMap _ _).injective` both already used in
+`NthRootIrrationalOQ01.lean` / `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`; descent +
+integrally-closed bearers file:line-confirmed at pin v4.26.0 (S4).
+
+**Self-review fix**: caught and corrected a `sqrt_bounds` bug pre-commit — the upper branch's
+`Real.sqrt_lt_sqrt` needs `0 ≤ x`, which `positivity` cannot prove for an abstract `x`; derived
+it from `lo²<x` via `lt_of_le_of_lt (sq_nonneg lo) h1`.
+
+**Residual transcription risk (not Lean-checked, backends down)**: (i) the `simp only` aeval set
+in `isIntegral_sqrt_natCast`; (ii) `IsIntegrallyClosed.isIntegral_iff` / `eq_ratCast` instance
+resolution (`IsScalarTower ℤ ℚ ℝ`, `IsFractionRing ℤ ℚ`). All math is verifier-confirmed; only
+Lean plumbing is at risk. If CI flags either, patch the single offending line.
+
+**Prior state (S1–S4, retained below)**: ORIENT (ACT-ready), iter 5.
 
 ## Current Focus
 Strategy D is now **paste-port-ready** (Session 4, researcher-5). Every step of the

--- a/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
+++ b/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
   "title": "Irrationality of √2 + √3 + √5 + √7",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "surveyed",
   "tier": "C",
   "path": "fast",
@@ -18,12 +18,15 @@
     "goal": "Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 + Real.sqrt 7)"
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-15T01:25:28.245Z",
-    "iteration": 3,
-    "focus": "Survey deepened (Session 2): NEW recommended Strategy D (algebraic-integer + bound, ~60-100 LOC) supersedes A; explicit degree-16 minimal polynomial and bound 8<α<9 computed and verified (sympy/mpmath). Still Docker-gated for final build.",
-    "blockers": ["Docker build wrapper unavailable (docker info timeout).", "Aristotle backend returns 'Resource not found'."],
-    "nextAction": "When Docker returns, implement Strategy D in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (~60-100 LOC); confirm the 4 lemma names in the knowledge.md skeleton and fill the single sorry. Fallbacks: Strategy A (3-squaring chain) or m(α)=0 + rational-root theorem.",
+    "phase": "ACT",
+    "since": "2026-06-15T07:30:00.000Z",
+    "iteration": 6,
+    "focus": "Session 5 (researcher-1): Strategy D TRANSCRIBED to Lean. New file Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (5 theorems, 0 sorries, 0 axioms) implements the integral-closure descent: each sqrt k integral over Z (monic X^2-C k), sum integral via IsIntegral.add, descend along injective algebraMap Q R (isIntegral_algebraMap_iff), Z integrally closed in Q (IsIntegrallyClosed.isIntegral_iff) => q in Z, contradicted by 8<alpha<9. Build-pending (Docker+Aristotle both down); CI is ground truth. Bearer names confirmed at pin v4.26.0 (S4) and verify_strategy_d.py re-run (ALL CHECKS PASSED).",
+    "blockers": [
+      "Docker build wrapper unavailable (docker info 20s timeout) — file is build-pending, CI verifies.",
+      "Aristotle backend returns 'Resource not found' (re-probed S5)."
+    ],
+    "nextAction": "Await CI build of Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01. If it compiles, the OQ is SOLVED (0 sorries / 0 axioms) — mark completed. If CI flags a lemma-name or cast/instance error, the two residual risks are (i) the aeval simp-only set in isIntegral_sqrt_natCast and (ii) IsIntegrallyClosed.isIntegral_iff / eq_ratCast resolution; patch the offending line (math is verifier-confirmed, only Lean plumbing at risk).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +34,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT deepened (build-free, researcher-4 2026-06-14 Session 2): found NEW recommended Strategy D (algebraic-integer + bounded-interval, ~60-100 LOC) that avoids ALL degree-16 algebra and supersedes Strategy A; computed and verified (sympy/mpmath) the explicit degree-16 monic minimal polynomial m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 and the decisive bound 8<α<9 (α≈8.0281). Also confirmed Strategy A's single-surd endgame has ugly coefficients (common denom 14499840 for √210 in the α power basis). Prior (researcher-10): resolved on paper degree-16, fixed leanFiles misattribution. Still Docker-gated for final Lean build.",
+    "progressSummary": "S5 (2026-06-15, researcher-1): Strategy D transcribed to Lean (build-pending). 5 theorems, 0 sorries, 0 axioms; integral-closure descent + 8<alpha<9. ORIENT deepened (build-free, researcher-4 2026-06-14 Session 2): found NEW recommended Strategy D (algebraic-integer + bounded-interval, ~60-100 LOC) that avoids ALL degree-16 algebra and supersedes Strategy A; computed and verified (sympy/mpmath) the explicit degree-16 monic minimal polynomial m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 and the decisive bound 8<α<9 (α≈8.0281). Also confirmed Strategy A's single-surd endgame has ugly coefficients (common denom 14499840 for √210 in the α power basis). Prior (researcher-10): resolved on paper degree-16, fixed leanFiles misattribution. Still Docker-gated for final Lean build.",
     "builtItems": [],
     "insights": [
       "RESOLVED ON PAPER: √2+√3+√5+√7 is irrational — in fact an algebraic integer of degree 16 over ℚ. The 16 sign-combinations ±√2±√3±√5±√7 are its full set of Galois conjugates (Galois group (ℤ/2)^4 of the multiquadratic field ℚ(√2,√3,√5,√7)); α is a primitive element, so its minimal polynomial has degree 16 with rational integer coefficients. Degree ≠ 1 ⇒ irrational.",
@@ -75,8 +78,10 @@
     "mathlib": []
   },
   "started": "2026-06-15T01:25:28.244Z",
-  "lastUpdate": "2026-06-14",
+  "lastUpdate": "2026-06-15",
   "significance": 4,
   "tractability": 8,
-  "leanFiles": []
+  "leanFiles": [
+    "proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean"
+  ]
 }


### PR DESCRIPTION
## Summary

Transcribes the long-deferred **Strategy D** into Lean for OQ-01 of
`sqrt2-plus-sqrt3-plus-sqrt5-irrational`: the irrationality of
`α = √2 + √3 + √5 + √7`.

New file `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean`
(registered in `Proofs.lean`) — **5 theorems, 0 sorries, 0 axioms**:

1. `isIntegral_sqrt_natCast` — `√(k:ℕ)` is integral over ℤ (root of monic `X²−C k`).
2. `alpha_isIntegral` — α integral over ℤ via three `IsIntegral.add`.
3. `sqrt_bounds` — generic rational bracket `lo < √x < hi` from `lo² < x < hi²`.
4. `alpha_gt_eight` / `alpha_lt_nine` — `8 < α < 9` from the rational witnesses.
5. `irrational_…_plus_sqrt7` — descend along the injective `algebraMap ℚ ℝ`
   (`isIntegral_algebraMap_iff`), use `IsIntegrallyClosed.isIntegral_iff` to get
   `q = (n:ℤ)`, then `8 < (n:ℝ) < 9` has no integer solution (`omega`).

This sidesteps the degree-16 minimal polynomial / iterated-squaring machinery
entirely — only the standard integral-closure API plus four `norm_num` bounds.

## Provenance & verification

- Bearer lemmas file:line-confirmed at Mathlib pin `v4.26.0` over four prior
  build-free sessions (knowledge.md S4).
- `verify_strategy_d.py` re-run: **ALL CHECKS PASSED** — integrality of each √k,
  the degree-16 minimal polynomial, and the exact rational witnesses the Lean
  `norm_num` obligations encode.
- In-repo idiom cross-checks: `monic_X_pow_sub_C` (NthRootIrrationalOQ01.lean),
  `isIntegral_algebraMap_iff (…).injective` (AngleTrisectionOQ02OQ01OQ02Incomplete01.lean).

## Build status

**Build-pending.** Docker (`docker info` 20s timeout) and Aristotle MCP (`prove`
→ "Resource not found") are both down, so the file is not locally compiled — CI
is the ground truth, per the project's established pattern. Residual transcription
risk is isolated to two lines (the `simp only` aeval set in step 1; and
`IsIntegrallyClosed.isIntegral_iff` / `eq_ratCast` instance resolution); the
mathematics is verifier-confirmed.

## Test plan

- [ ] CI builds `Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01`.
- [ ] If green, the OQ is solved (0 sorries / 0 axioms) — promote to completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)