### PR TITLE
research(zsqrtd-neg-two-oq-02): ORIENT — three-square theorem is axiomatized; ℤ[√−2] covers only the prime sub-cases

### DIFF
--- a/research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py
+++ b/research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Durable exact verifier for zsqrtd-neg-two-oq-02 (ORIENT, S1).
+
+The slug asks to formalize the Legendre-Gauss three-square theorem
+    n = a^2 + b^2 + c^2  (a,b,c in Z)   <=>   n is NOT of the form 4^a (8b+7)
+"via the gallery's Z[sqrt(-2)] infrastructure" (norm form x^2 + 2 y^2).
+
+GALLERY STATE (audited): proofs/Proofs/ThreeSquares.lean proves the theorem
+`legendre_three_squares` (line 1672), but its converse half is the bare AXIOM
+`not_excluded_form_is_sum_three_sq` (line 1665). The forward obstruction and all
+descent lemmas (4^a descent `sum_three_sq_iff_four_mul`, square-factor descent
+`sum_three_sq_of_sq_mul`) are fully PROVEN. The real deliverable for this slug is
+therefore: ELIMINATE that axiom. The parent ZsqrtdNegTwo.lean contributes the
+prime case p == 3 (mod 8): p = a^2 + 2 b^2  (split in Z[sqrt(-2)]).
+
+This script verifies, with EXACT integer arithmetic:
+  C1  the full iff  (3-squares <=> not excluded), n <= N;
+  C2  the Z[sqrt(-2)] BRIDGE: x^2+2y^2 = x^2+y^2+y^2, so any n = x^2+2y^2 is a
+      sum of three squares; and the prime mechanism that the parent + Fermat give:
+        - p == 1 (mod 4):  p = a^2 + b^2          (Fermat) -> a^2+b^2+0^2;
+        - p == 3 (mod 8):  p = a^2 + 2 b^2        (parent) -> a^2+b^2+b^2;
+        - p == 7 (mod 8):  excluded (a=0), not needed;
+      so EVERY prime that is not excluded is a sum of three squares;
+  C3  the CRITICAL LIMITATION (verify-before-assert): three-squares is NOT
+      multiplicative, and the binary norm form x^2+2y^2 does NOT represent every
+      non-excluded n. There exist squarefree, non-excluded, COMPOSITE n that are
+      sums of three squares but are NOT of the form x^2+2y^2 -- so the Z[sqrt(-2)]
+      route handles only the prime sub-cases; the full converse for composite
+      squarefree n needs the deeper Dirichlet / ternary-form input.
+  C4  the descent reductions used by ThreeSquares.lean are sound:
+      n is 3-squares  <=>  4n is;  and  k^2 * m 3-squares if m is.
+
+No Lean, no Docker; all checks exact.
+"""
+
+import math
+from sympy import isprime, factorint
+
+
+def is_excluded(n: int) -> bool:
+    """n = 4^a (8b+7) for some a>=0, b>=0."""
+    if n <= 0:
+        return False
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+
+def three_squares(n: int):
+    """Return (a,b,c) with a^2+b^2+c^2=n if it exists, else None. Exact."""
+    a = 0
+    while a * a <= n:
+        r = n - a * a
+        b = a
+        while b * b <= r:
+            c2 = r - b * b
+            c = math.isqrt(c2)
+            if c >= b and c * c == c2:
+                return (a, b, c)
+            b += 1
+        a += 1
+    return None
+
+
+def is_three_squares(n: int) -> bool:
+    return three_squares(n) is not None
+
+
+def two_squares(n: int):
+    """(a,b) with a^2+b^2=n if exists, else None."""
+    a = 0
+    while a * a <= n:
+        r = n - a * a
+        b = math.isqrt(r)
+        if b >= a and b * b == r:
+            return (a, b)
+        a += 1
+    return None
+
+
+def repr_x2_2y2(n: int):
+    """(x,y) with x^2+2y^2=n if exists, else None."""
+    y = 0
+    while 2 * y * y <= n:
+        r = n - 2 * y * y
+        x = math.isqrt(r)
+        if x * x == r:
+            return (x, y)
+        y += 1
+    return None
+
+
+def squarefree(n: int) -> bool:
+    return all(e == 1 for e in factorint(n).values()) if n > 1 else (n == 1)
+
+
+def main():
+    N = 20000
+    fails = []
+
+    # C1: the full iff.
+    bad = 0
+    for n in range(1, N + 1):
+        if is_three_squares(n) == is_excluded(n):
+            bad += 1
+            if len(fails) < 20:
+                fails.append(("C1", n, is_three_squares(n), is_excluded(n)))
+    print(f"C1  3-squares(n) <=> not excluded(n), n in [1,{N}]: "
+          f"{'PASS' if bad == 0 else f'FAIL ({bad})'}")
+
+    # C2: Z[sqrt(-2)] bridge + prime mechanism.
+    # (a) algebraic bridge x^2+2y^2 = x^2+y^2+y^2 for all x,y.
+    bridge = all((x * x + 2 * y * y) == (x * x + y * y + y * y)
+                 for x in range(0, 60) for y in range(0, 60))
+    # (b) every non-excluded prime is a sum of three squares, via the stated route.
+    c2_route = True
+    for p in range(2, N + 1):
+        if not isprime(p) or is_excluded(p):
+            continue
+        if p % 4 == 1:                      # Fermat two-square -> three squares
+            ok = two_squares(p) is not None
+        elif p % 8 == 3:                    # parent: p = x^2 + 2y^2 -> three squares
+            ok = repr_x2_2y2(p) is not None
+        elif p == 2:
+            ok = is_three_squares(p)
+        else:                               # p % 8 == 7 would be excluded; p%8 in {?}
+            ok = is_three_squares(p)        # any leftover class: must still hold
+        if not (ok and is_three_squares(p)):
+            c2_route = False
+            fails.append(("C2", p, p % 8))
+    print(f"C2  bridge x^2+2y^2=x^2+y^2+y^2: {bridge}; "
+          f"every non-excluded prime is 3-squares via stated route: "
+          f"{'PASS' if c2_route else 'FAIL'}")
+
+    # C3: the limitation -- composite squarefree non-excluded n NOT of form x^2+2y^2.
+    witnesses = []
+    for n in range(2, 2000):
+        if (squarefree(n) and not is_excluded(n) and not isprime(n)
+                and is_three_squares(n) and repr_x2_2y2(n) is None):
+            witnesses.append(n)
+    print(f"C3  composite squarefree non-excluded n that ARE 3-squares but NOT "
+          f"x^2+2y^2 (so the binary norm form alone is insufficient): "
+          f"{len(witnesses)} found; first 12: {witnesses[:12]}")
+    # also: fraction of non-excluded n in range that are x^2+2y^2 representable
+    ne = [n for n in range(1, 2000) if not is_excluded(n)]
+    covered = [n for n in ne if repr_x2_2y2(n) is not None]
+    print(f"    only {len(covered)}/{len(ne)} = {len(covered)/len(ne):.1%} of "
+          f"non-excluded n<2000 are x^2+2y^2 -> norm form covers a minority")
+
+    # C4: descent reductions (as used in ThreeSquares.lean) are sound.
+    c4 = True
+    for n in range(1, 4000):
+        if is_three_squares(n) != is_three_squares(4 * n):       # 4n iff n
+            c4 = False; fails.append(("C4-4n", n))
+        for k in (2, 3):                                          # k^2 m => m direction
+            if is_three_squares(n) and not is_three_squares(k * k * n):
+                c4 = False; fails.append(("C4-k2", n, k))
+    print(f"C4  descent: 3-squares(4n) <=> 3-squares(n) and k^2*n keeps it: "
+          f"{'PASS' if c4 else 'FAIL'}")
+
+    ok = (bad == 0) and bridge and c2_route and len(witnesses) > 0 and c4
+    print("\n" + ("ALL CHECKS PASS" if ok else f"FAILURES: {fails[:8]}"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/zsqrtd-neg-two-oq-02.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-02.json
@@ -1,0 +1,98 @@
+{
+  "slug": "zsqrtd-neg-two-oq-02",
+  "title": "Legendre\u2013Gauss Three-Square Theorem via the \u2124[\u221a\u22122] Infrastructure",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For all n in N: (exists a b c in Z, n = a^2+b^2+c^2) iff NOT (exists a b in N, n = 4^a (8b+7)). Formalize the full iff, eliminating the gallery axiom not_excluded_form_is_sum_three_sq, ideally routing the converse via the ZsqrtdNegTwo (x^2+2y^2) infrastructure.",
+    "plain": "A natural number is a sum of three integer squares iff it is NOT of the form 4^a(8b+7). The forward (obstruction) direction is an elementary mod-8 argument and is fully proven in the gallery; the converse is the deep direction and is currently a bare axiom.",
+    "whyMatters": [
+      "Completes the classical sums-of-squares trilogy (two, three, four squares).",
+      "Exercises the quadratic-form / algebraic-number-theory machinery already present for x^2+2y^2.",
+      "Eliminating the converse axiom upgrades the gallery three-square theorem from axiomatized to verified."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Forward obstruction excluded_form_not_sum_three_sq + all descent lemmas (sum_three_sq_iff_four_mul, sum_three_sq_of_sq_mul) are sorry-free in ThreeSquares.lean.",
+      "Parent ZsqrtdNegTwo.lean: p \u2261 3 (mod 8) \u21d2 p = a^2+2b^2 (split in Euclidean \u2124[\u221a\u22122]) \u21d2 p = sum of three squares.",
+      "\u2124[\u221a\u22122] bridge x^2+2y^2 = x^2+y^2+y^2; every non-excluded PRIME is a sum of three squares via p\u22611(mod4)\u2192Fermat two-square and p\u22613(mod8)\u2192x^2+2y^2 (verified exact)."
+    ],
+    "open": [
+      "Eliminate the axiom not_excluded_form_is_sum_three_sq (ThreeSquares.lean:1665): the deep converse for squarefree-composite primitives.",
+      "\u2124[\u221a\u22122] alone is insufficient (x^2+2y^2 covers only 42.5% of non-excluded n; three-squares is non-multiplicative): the deep step needs Dirichlet primes-in-AP + a ternary-form reduction (the latter absent from Mathlib and the gallery)."
+    ],
+    "goal": "Upgrade legendre_three_squares from axiomatized to verified by discharging not_excluded_form_is_sum_three_sq; as a first step prove the prime cases via \u2124[\u221a\u22122] + Fermat and isolate a smaller squarefree-primitive hypothesis."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T07:35:00.000Z",
+    "iteration": 2,
+    "focus": "Gallery three-square theorem is AXIOMATIZED (single converse axiom line 1665); forward+descent proven. \u2124[\u221a\u22122] (x^2+2y^2=x^2+y^2+y^2) dispatches every non-excluded prime but covers only 42.5% of non-excluded n \u2014 cannot close the converse for squarefree composites (non-multiplicativity).",
+    "blockers": [
+      "Lean ACT Docker-gated (Docker + Aristotle both down).",
+      "Ternary-form reduction absent from Mathlib and gallery; only the Dirichlet engine forall_exists_prime_gt_and_modEq is available upstream."
+    ],
+    "nextAction": "ACT: shrink the axiom by proving prime cases (parent prime_three_mod_eight_is_sum_three_sq + Fermat two-square), leaving a smaller squarefree-primitive hypothesis. Coordinate with ThreeSquares.lean / lagrange-...-g2-oq-03.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    },
+    "lastUpdate": "2026-06-15T07:35:00.000Z"
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: gallery three-square theorem is axiomatized via the single converse axiom not_excluded_form_is_sum_three_sq (ThreeSquares.lean:1665); forward + descent fully proven. \u2124[\u221a\u22122] bridge x^2+2y^2=x^2+y^2+y^2 dispatches every non-excluded PRIME (p\u22611 mod4 via Fermat, p\u22613 mod8 via the parent's split). VERIFY-BEFORE-ASSERT: \u2124[\u221a\u22122] CANNOT close the full converse \u2014 x^2+2y^2 covers only 42.5% of non-excluded n and three-squares is non-multiplicative; 553 composite squarefree non-excluded witnesses are 3-squares but not x^2+2y^2. Deep step needs Dirichlet primes-in-AP (in Mathlib) + ternary-form reduction (absent).",
+    "builtItems": [
+      "research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py - sympy exact verifier: C1 full iff n<=20000; C2 \u2124[\u221a\u22122] bridge + every non-excluded prime 3-squares via the route; C3 the limitation (553 composite witnesses, 42.5% norm-form coverage); C4 descent reductions 4n<=>n and k^2*n. All PASS."
+    ],
+    "insights": [
+      "The gallery three-square theorem legendre_three_squares (ThreeSquares.lean:1672) is PROVEN modulo the bare axiom not_excluded_form_is_sum_three_sq (line 1665) = the entire deep converse. Forward obstruction + 4^a descent + square-factor descent are sorry-free. The slug's real target is eliminating this one axiom.",
+      "\u2124[\u221a\u22122] route works because x^2+2y^2 = x^2+y^2+y^2: any n=x^2+2y^2 is a sum of three squares. Parent gives p\u22613(mod8)\u21d2p=a^2+2b^2; Fermat gives p\u22611(mod4)\u21d2a^2+b^2\u21d2+0^2. So every non-excluded PRIME is handled.",
+      "But three-squares is NON-multiplicative and x^2+2y^2 represents only ~42.5% of non-excluded n (553 composite squarefree counterexamples like 10,14,21,26). So \u2124[\u221a\u22122] cannot deliver the composite converse \u2014 the seeker's 'via \u2124[\u221a\u22122]' premise is incomplete; the deep input is unavoidable."
+    ],
+    "mathlibGaps": [
+      "No three-square theorem in Mathlib (sum_three_squares / isSumThreeSquares / exists_sq_add_sq_add_sq etc. = 0 hits across 5 query forms; a known unmet docs/1000.yaml target).",
+      "The ternary-form reduction 'auxiliary prime in the right AP \u21d2 n is a sum of three squares' is absent from Mathlib AND the gallery.",
+      "Available: Dirichlet primes-in-AP forall_exists_prime_gt_and_modEq (Mathlib/NumberTheory/LSeries/PrimesInAP.lean); Fermat two-square; the parent \u2124[\u221a\u22122] split."
+    ],
+    "nextSteps": [
+      "ACT (Docker-gated): prove the prime cases outright (parent prime_three_mod_eight_is_sum_three_sq + Fermat two-square Nat.Prime.sq_add_sq) and replace the monolithic axiom by a smaller squarefree-primitive hypothesis \u2014 honest axiomatized progress.",
+      "ACT (deep): build the Dirichlet/ternary route (have forall_exists_prime_gt_and_modEq; need a Lean ternary-form reduction) \u2014 the true multi-hundred-LOC obstruction.",
+      "Coordinate with ThreeSquares.lean and lagrange-...-g2-oq-03 (same three-square target) to avoid duplicated axiom-discharge attempts."
+    ],
+    "markdown": "See research/problems/zsqrtd-neg-two-oq-02/knowledge.md"
+  },
+  "tags": [
+    "number-theory",
+    "sums-of-squares",
+    "quadratic-forms",
+    "zsqrtd",
+    "three-squares",
+    "axiom-elimination",
+    "research"
+  ],
+  "relatedProofs": [
+    "zsqrtd-neg-two",
+    "lagrange-four-squares-waring-g2",
+    "fermat-two-squares"
+  ],
+  "references": {
+    "papers": [
+      "Legendre/Gauss three-square theorem (classical).",
+      "Grosswald, Representations of Integers as Sums of Squares."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.LSeries.PrimesInAP (forall_exists_prime_gt_and_modEq) \u2014 Dirichlet primes in AP",
+      "Nat.Prime.sq_add_sq \u2014 Fermat two-square",
+      "(absent) three-square theorem / ternary-form reduction"
+    ]
+  },
+  "started": "2026-06-15T07:35:00.000Z",
+  "lastUpdate": "2026-06-15T07:35:00.000Z",
+  "significance": 7,
+  "tractability": 4
+}


### PR DESCRIPTION
## Summary

Build-free **ORIENT** on the Legendre–Gauss three-square theorem (`n = a²+b²+c² ⟺ n ≠ 4ᵃ(8b+7)`) routed "via ℤ[√−2]".

**Gallery audit — the real target is axiom elimination.** `ThreeSquares.lean` states `legendre_three_squares` (line 1672), but its converse half is the bare **axiom** `not_excluded_form_is_sum_three_sq` (line 1665). The forward obstruction and the full descent toolkit (`4ᵃ` and square-factor reductions) are proven sorry-free. So this slug = discharge that one axiom.

**What ℤ[√−2] buys.** Via the identity `x²+2y² = x²+y²+y²`, any `n = x²+2y²` is a sum of three squares. The parent gives `p≡3 (mod 8) ⇒ p = a²+2b²` and Fermat gives `p≡1 (mod 4) ⇒ a²+b²`, so **every non-excluded prime** is a sum of three squares.

**Verify-before-assert — the "via ℤ[√−2]" premise is incomplete for the full converse.** Three-squares is *non-multiplicative*, and `x²+2y²` represents only **42.5%** of non-excluded `n` (`708/1667` for `n<2000`); there are **553** squarefree *composite* non-excluded `n` that are sums of three squares but not `x²+2y²` (10, 14, 21, 26, 30, …). The composite converse needs Dirichlet primes-in-AP (Mathlib: `forall_exists_prime_gt_and_modEq`) **plus** a ternary-form reduction that is absent from both Mathlib and the gallery.

## Verification (durable, exact, no Docker)

`research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py` (sympy, exact, **all PASS**):
- **C1** full iff for `n ≤ 20000`;
- **C2** ℤ[√−2] bridge + every non-excluded prime is 3-squares via the route;
- **C3** the limitation (553 composite witnesses; 42.5% norm-form coverage);
- **C4** descent reductions `3sq(4n) ⟺ 3sq(n)` and `k²·n`.

## ACT scope (Docker-gated; both backends down this session)

Realistic first step: prove the prime cases outright (parent `prime_three_mod_eight_is_sum_three_sq` + Fermat `Nat.Prime.sq_add_sq`) and replace the monolithic axiom with a smaller squarefree-primitive hypothesis. Coordinate with `ThreeSquares.lean` / `lagrange-…-g2-oq-03` (same target) to avoid duplicate axiom-discharge work. No Lean changed.

## Test plan
- [x] `python3 research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py` → ALL CHECKS PASS
- [ ] Lean axiom-reduction deferred to a Docker session

🤖 Generated with [Claude Code](https://claude.com/claude-code)