### PR TITLE
Fix: puiseux-theorem-oq-02 badge original->infrastructure

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/PuiseuxTheoremOQ02.lean",
-    "badge": "original",
+    "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All 6 theorems and 4 definitions fully verified with 0 sorries and 0 axioms. The main algebraic closure theorem (MultiHahnSeries n K is algebraically closed when K is) requires HahnSeries ℚ K to be algebraically closed — open in Mathlib — so it is described in comments rather than formalized as a theorem.",


### PR DESCRIPTION
## Fix

Change `puiseux-theorem-oq-02` badge from `original` to `infrastructure` to match what the Lean file actually formalizes.

## Evidence

**Before**: `badge: "original"` on an entry whose headline result `multivariate_puiseux_theorem` (and `double_puiseux_redundant`) is **commented out** in `proofs/Proofs/PuiseuxTheoremOQ02.lean` (lines ~211–235), blocked by a Mathlib gap (`IsAlgClosed` for `HahnSeries ℚ K`).

**After**: `badge: "infrastructure"` (🧱). The file genuinely provides the `MultiHahnSeries` definition + 6 verified support theorems (0 sorries, 0 axioms) — Tier-D infrastructure, not an independent proof of the named theorem.

Scope: badge-only. `status`, `sorries`, `axiomCount`, `description`, and `conclusion` are already accurate (the Mathlib gap is openly disclosed) and are left unchanged.

Closes #24249

---
Automated fix by lean-mechanic agent.