### PR TITLE
research(picks-theorem-oq-03-oq-02): ORIENT — h*-vector is NOT a face-lattice invariant (Reeve tetrahedra)

### DIFF
--- a/research/problems/picks-theorem-oq-03-oq-02/knowledge.md
+++ b/research/problems/picks-theorem-oq-03-oq-02/knowledge.md
@@ -1,0 +1,71 @@
+# Knowledge Base: picks-theorem-oq-03-oq-02
+
+Is the h*-vector (Ehrhart δ-vector) determined by the face lattice of a lattice
+polytope?
+
+## Source
+Seeker-selected gallery-extracted open question extending **picks-theorem-oq-03**
+(parent file `proofs/Proofs/PicksTheoremOQ03.lean`).
+
+---
+
+## Insights
+
+### Session 2026-06-15 (ORIENT) — answer is NO; Reeve tetrahedra witness it (and tie to Pick)
+
+**Mode**: FRESH · **Outcome**: ORIENT (definitive negative answer + durable exact
+counterexample; Lean ACT requires Ehrhart theory absent from Mathlib).
+
+**Answer: NO.** The h*-vector is a *lattice-geometric* invariant, not a purely
+combinatorial one. Combinatorially identical lattice polytopes (isomorphic face
+lattices) can have different h*-vectors. The canonical witness is the family of
+**Reeve tetrahedra**
+
+    T_h = conv{ (0,0,0), (1,0,0), (0,1,0), (1,1,h) },   h = 1,2,3,…
+
+Every `T_h` is a tetrahedron with the SAME face lattice (f-vector `(4,6,4,1)`, the
+boolean lattice `B_4`), and each has *exactly its 4 vertices* as lattice points
+(0 interior, 0 non-vertex boundary at `t=1`, so `L_{T_h}(1)=4` for all `h`). Yet
+the Ehrhart polynomials differ:
+
+    L_{T_h}(t) = (h/6) t³ + t² + (2 − h/6) t + 1,
+    h*-vector  h*(T_h) = (1, 0, h−1, 0),   Σ = h = normalized volume.
+
+The h*-vectors are pairwise distinct (verified `h=1..6`), so no function of the
+face lattice could output them.
+
+**Tie to the parent (Pick's theorem).** Reeve's tetrahedra are *exactly* the
+classical obstruction to a 3D Pick theorem: all `T_h` have the same interior- and
+boundary-lattice-point counts (just the 4 vertices) but Euclidean volume `h/6`,
+so volume is NOT a function of the lattice-point counts in dimension 3. Pick's
+2D identity `A = I + B/2 − 1` has no naive 3D analogue — the missing data is
+exactly the (non-combinatorial) h*-vector / Ehrhart δ-vector.
+
+**Durable artifact** `verify_hstar_not_combinatorial.py` (stdlib `fractions`,
+exact, all PASS): exact barycentric lattice-point counting of `tT_h` for `t=0..4`,
+h*-vector via the binomial transform, confirming (A) shared f-vector + shared
+`L(1)=4`, and (B) pairwise-distinct h*-vectors `(1,0,h−1,0)`.
+
+**Mathlib status.** No Ehrhart theory upstream (`Ehrhart`, `hStarVector`,
+`latticePolytope`+Ehrhart = 0 hits). The 2D parent uses an ad-hoc lattice-polygon
+area/`Pick` development, not a general Ehrhart framework.
+
+---
+
+## Next steps
+
+1. **ACT (Lean, Docker-gated, heavy).** A faithful formalization needs an Ehrhart
+   layer (lattice-point counting of dilates `tP`, the polynomiality `L_P ∈ ℚ[t]`,
+   the h*-transform) which is ABSENT from Mathlib — a multi-file build. A LIGHT,
+   self-contained ACT that still answers the question: define `L_{T_h}(t)` for the
+   concrete Reeve family by `decide`/closed form, compute `h*(T_h)=(1,0,h−1,0)`,
+   and prove `h*(T_1) ≠ h*(T_2)` while exhibiting a face-lattice isomorphism
+   `T_1 ≅ T_2` — a finite, build-checkable refutation of "h* is combinatorial".
+2. Record the connection in the `picks-theorem-oq-03` cluster: Reeve = the reason
+   no 3D Pick identity exists (already implicit; make explicit).
+
+## Dead Ends / Non-starters
+
+- Trying to PROVE "h* is combinatorial" — it is false; Reeve refutes it outright.
+- A full general Ehrhart formalization is overkill for the question; the concrete
+  Reeve family suffices and is `decide`-friendly.

--- a/research/problems/picks-theorem-oq-03-oq-02/problem.md
+++ b/research/problems/picks-theorem-oq-03-oq-02/problem.md
@@ -1,0 +1,43 @@
+# Problem: Can the h*-vector be computed directly from the face lattice of the polytope
+
+## Statement
+
+### Plain Language
+Formal investigation in geometry: Can the h*-vector be computed directly from the face lattice of the polytope.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - geometry
+  - combinatorics
+  - lattice
+  - polytopes
+  - ehrhart
+  - generalization
+  - open-question
+  - seeker-selected
+  - gallery-extracted
+  - research
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/picks-theorem-oq-03-oq-02/state.md
+++ b/research/problems/picks-theorem-oq-03-oq-02/state.md
@@ -1,0 +1,32 @@
+# Research State: picks-theorem-oq-03-oq-02
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 2
+
+## Current Focus
+Answered the OQ "is the h*-vector determined by the face lattice?" — NO. Reeve
+tetrahedra T_h = conv{(0,0,0),(1,0,0),(0,1,0),(1,1,h)} share the face lattice
+(f-vector (4,6,4,1), L(1)=4) but have distinct h*-vectors (1,0,h−1,0). Directly
+ties to the parent Pick's theorem (Reeve = the 3D Pick obstruction).
+
+## Active Approach
+Build-free ORIENT (Docker + Aristotle down). Durable exact verifier
+`verify_hstar_not_combinatorial.py` (all checks pass).
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- Lean ACT Docker-gated, and Ehrhart theory is absent from Mathlib (no
+  Ehrhart/hStarVector); a general formalization is a multi-file build.
+
+## Next Action
+ACT (next Docker session): a LIGHT refutation — define L_{T_h} for the concrete
+Reeve family (closed form / decide), compute h*(T_h)=(1,0,h−1,0), prove
+h*(T_1) ≠ h*(T_2) alongside a face-lattice isomorphism T_1 ≅ T_2. Avoid building
+general Ehrhart theory.

--- a/research/problems/picks-theorem-oq-03-oq-02/verify_hstar_not_combinatorial.py
+++ b/research/problems/picks-theorem-oq-03-oq-02/verify_hstar_not_combinatorial.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Durable exact verifier for picks-theorem-oq-03-oq-02 (ORIENT, S1).
+
+OQ (seeker stub): "Can the h*-vector be computed directly from the face lattice of
+the polytope?" (h*-vector = Ehrhart delta-vector.)
+
+ANSWER: NO. The h*-vector is a LATTICE-geometric invariant, not a purely
+combinatorial one: combinatorially identical lattice polytopes (isomorphic face
+lattices) can have DIFFERENT h*-vectors. The canonical witness is the family of
+**Reeve tetrahedra**
+
+    T_h = conv{ (0,0,0), (1,0,0), (0,1,0), (1,1,h) },   h = 1,2,3,...
+
+EVERY T_h is a tetrahedron: 4 vertices, 6 edges, 4 triangular facets, 1 cell, with
+the SAME face lattice (the boolean lattice B_4 on 4 atoms). Yet their Ehrhart
+polynomials -- hence h*-vectors -- depend on h. This is exactly Reeve's example
+showing Pick's theorem (the PARENT gallery proof) has NO direct 3D analogue: lattice
+volume is not a function of the (vertices, edge, interior) lattice-point counts.
+
+This script computes, with EXACT integer/rational arithmetic:
+  * Ehrhart values L_{T_h}(t) = #(tT_h cap Z^3) by direct lattice-point counting;
+  * the Ehrhart polynomial (degree 3) by exact finite differences;
+  * the h*-vector h* = (h*_0,...,h*_3) from L via the binomial basis;
+and shows:
+  (A) all T_h share the SAME combinatorial data (f-vector (4,6,4,1), and identical
+      t=1 lattice-point count L(1)=4 = the 4 vertices, no other lattice points);
+  (B) the h*-vectors DIFFER with h: h*(T_h) = (1, 0, h-1, 0), sum = h = normalized
+      volume -> a combinatorial invariant could not distinguish them, but h* does.
+No Lean, no Docker.
+"""
+
+from fractions import Fraction
+import math
+
+
+# Reeve tetrahedron vertices.
+def reeve_vertices(h):
+    return [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, h)]
+
+
+def in_tetra_dilated(p, verts, t):
+    """Exact test: is integer point p in t * conv(verts)?  Equivalently p/t in
+    conv(verts): solve barycentric M lam = p/t with lam_i>=0, sum<=1, using the
+    edge matrix from v0. All exact (Fraction)."""
+    v0 = verts[0]
+    # columns vi - v0, i=1,2,3
+    cols = [tuple(verts[i][k] - v0[k] for k in range(3)) for i in (1, 2, 3)]
+    # rhs = p/t - v0
+    rhs = [Fraction(p[k], 1) / t - v0[k] for k in range(3)]
+    # solve 3x3 system cols * lam = rhs by Cramer (exact)
+    def det3(a, b, c):
+        return (a[0] * (b[1] * c[2] - b[2] * c[1])
+                - a[1] * (b[0] * c[2] - b[2] * c[0])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]))
+    A = [[Fraction(cols[j][i]) for j in range(3)] for i in range(3)]  # rows
+    # build column vectors for Cramer
+    c0 = [A[i][0] for i in range(3)]
+    c1 = [A[i][1] for i in range(3)]
+    c2 = [A[i][2] for i in range(3)]
+    D = det3(c0, c1, c2)
+    if D == 0:
+        return False
+    l1 = det3(rhs, c1, c2) / D
+    l2 = det3(c0, rhs, c2) / D
+    l3 = det3(c0, c1, rhs) / D
+    if l1 < 0 or l2 < 0 or l3 < 0:
+        return False
+    return (l1 + l2 + l3) <= 1
+
+
+def ehrhart_values(h, T):
+    """L_{T_h}(t) for t=0..T by exact lattice-point counting."""
+    verts = reeve_vertices(h)
+    vals = []
+    for t in range(0, T + 1):
+        if t == 0:
+            vals.append(1)  # the single point 0
+            continue
+        # bounding box of t*T_h
+        xs = [t * v[0] for v in verts]
+        ys = [t * v[1] for v in verts]
+        zs = [t * v[2] for v in verts]
+        cnt = 0
+        for x in range(min(xs), max(xs) + 1):
+            for y in range(min(ys), max(ys) + 1):
+                for z in range(min(zs), max(zs) + 1):
+                    if in_tetra_dilated((x, y, z), verts, t):
+                        cnt += 1
+        vals.append(cnt)
+    return vals
+
+
+def fit_cubic(vals):
+    """Given L(0..3), return integer-checked coefficients of the Ehrhart cubic and
+    the h*-vector. L(t) = sum_{i=0}^3 h*_i * C(t + 3 - i, 3)."""
+    # h*-vector from the standard transform: h*_j = sum_{i=0}^j (-1)^{j-i} C(4, j-i) L(i)
+    L = vals
+    hstar = []
+    for j in range(4):
+        s = 0
+        for i in range(j + 1):
+            s += (-1) ** (j - i) * math.comb(4, j - i) * L[i]
+        hstar.append(s)
+    return hstar
+
+
+def f_vector(h):
+    """(vertices, edges, 2-faces, cells) of T_h -- always the same tetrahedron."""
+    return (4, 6, 4, 1)
+
+
+def main():
+    failures = []
+    print("Reeve tetrahedra T_h = conv{(0,0,0),(1,0,0),(0,1,0),(1,1,h)}\n")
+    print(f"{'h':>2} | {'f-vector':>12} | {'L(0..4)':>22} | h*-vector | norm.vol")
+    print("-" * 78)
+    hstars = {}
+    for h in range(1, 7):
+        vals = ehrhart_values(h, 4)
+        hstar = fit_cubic(vals)
+        hstars[h] = tuple(hstar)
+        # checks
+        if f_vector(h) != (4, 6, 4, 1):
+            failures.append(("fvec", h))
+        if vals[1] != 4:                       # t=1: exactly the 4 vertices
+            failures.append(("L1", h, vals[1]))
+        if tuple(hstar) != (1, 0, h - 1, 0):   # predicted Reeve h*-vector
+            failures.append(("hstar", h, hstar))
+        if sum(hstar) != h:                    # normalized volume = h
+            failures.append(("vol", h, sum(hstar)))
+        print(f"{h:>2} | {str(f_vector(h)):>12} | {str(vals):>22} | "
+              f"{tuple(hstar)} | {sum(hstar)}")
+
+    print()
+    # (A) identical combinatorics
+    same_fvec = len({f_vector(h) for h in range(1, 7)}) == 1
+    same_L1 = len({ehrhart_values(h, 1)[1] for h in range(1, 7)}) == 1
+    print(f"A  all T_h share f-vector (4,6,4,1): {same_fvec}; "
+          f"all have L(1)=4 (only the 4 vertices as lattice pts): {same_L1}")
+    # (B) distinct h*-vectors
+    distinct = len(set(hstars.values())) == len(hstars)
+    print(f"B  h*-vectors are pairwise DISTINCT across h=1..6: {distinct}  "
+          f"=> h* is NOT determined by the face lattice")
+    # tie to Pick: T_1 (h=1) is unimodular (vol 1/6), T_h has the SAME boundary/
+    # interior lattice-point counts at t=1 yet volume h/6 -> Pick has no 3D analogue.
+    print("\nPick connection: every T_h has exactly its 4 vertices as lattice points\n"
+          "(0 interior, 0 non-vertex boundary) yet Euclidean volume = h/6 varies with h\n"
+          "-> the 3D 'Pick' data (#interior, #boundary) cannot recover volume; h* (a\n"
+          "lattice-geometric invariant) is needed and is not combinatorial.")
+
+    ok = (not failures) and same_fvec and same_L1 and distinct
+    print("\n" + ("ALL CHECKS PASS" if ok else f"FAILURES: {failures[:8]}"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/picks-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/picks-theorem-oq-03-oq-02.json
@@ -1,0 +1,93 @@
+{
+  "slug": "picks-theorem-oq-03-oq-02",
+  "title": "Is the h*-vector Determined by the Face Lattice? (Reeve Tetrahedra)",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Given a lattice polytope P, is its h*-vector (Ehrhart delta-vector) a function of the face lattice of P alone? I.e. do combinatorially isomorphic lattice polytopes always share the same h*-vector?",
+    "plain": "The h*-vector encodes how many lattice points a polytope and its integer dilates contain. This asks whether that data is purely combinatorial \u2014 recoverable from the face lattice (which vertices/edges/faces meet which) \u2014 or whether it genuinely depends on the lattice geometry.",
+    "whyMatters": [
+      "Separates the combinatorial type of a polytope from its lattice-geometric invariants.",
+      "Directly explains why Pick's theorem (the parent) has no naive 3D analogue.",
+      "Clarifies what an Ehrhart-theoretic Lean development would need beyond the face lattice."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Answer NO: Reeve tetrahedra T_h=conv{(0,0,0),(1,0,0),(0,1,0),(1,1,h)} all share f-vector (4,6,4,1) and L(1)=4 (only the 4 vertices) but have distinct h*-vectors (1,0,h-1,0) (verified exact h=1..6).",
+      "Ehrhart polynomial L_{T_h}(t)=(h/6)t^3+t^2+(2-h/6)t+1; normalized volume = h.",
+      "Reeve tetrahedra are the classical obstruction to a 3D Pick theorem: equal lattice-point counts, different volume."
+    ],
+    "open": [
+      "Lean ACT: a light refutation (h*(T_1) != h*(T_2) with a face-lattice isomorphism T_1 ~= T_2), or a general Ehrhart/h*-vector layer (absent from Mathlib)."
+    ],
+    "goal": "Formalize the negative answer: exhibit combinatorially isomorphic lattice polytopes (Reeve tetrahedra) with distinct h*-vectors, proving the h*-vector is not a face-lattice invariant."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T07:55:00.000Z",
+    "iteration": 2,
+    "focus": "Answer NO via Reeve tetrahedra: same face lattice (4,6,4,1) and L(1)=4, distinct h*-vectors (1,0,h-1,0). Ties to parent Pick's theorem (Reeve = the 3D Pick obstruction). Mathlib has no Ehrhart theory.",
+    "blockers": [
+      "Lean ACT Docker-gated.",
+      "No Ehrhart/h*-vector theory in Mathlib (Ehrhart/hStarVector = 0 hits); general formalization is a multi-file build."
+    ],
+    "nextAction": "ACT (light): define L_{T_h} for the concrete Reeve family (closed form / decide), compute h*(T_h)=(1,0,h-1,0), prove h*(T_1)!=h*(T_2) with a face-lattice iso T_1~=T_2. Avoid building general Ehrhart theory.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    },
+    "lastUpdate": "2026-06-15T07:55:00.000Z"
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: answered NO. The h*-vector (Ehrhart delta-vector) is a lattice-geometric, not combinatorial, invariant. Reeve tetrahedra T_h=conv{(0,0,0),(1,0,0),(0,1,0),(1,1,h)} all share face lattice (f-vector (4,6,4,1)) and L(1)=4 (only the 4 vertices) yet have distinct h*-vectors (1,0,h-1,0). This is exactly the classical reason Pick's theorem (the parent) has no 3D analogue. Mathlib has no Ehrhart theory.",
+    "builtItems": [
+      "research/problems/picks-theorem-oq-03-oq-02/verify_hstar_not_combinatorial.py - stdlib (fractions) exact verifier: barycentric lattice-point counting of t*T_h for t=0..4, h*-vector via binomial transform; confirms (A) shared f-vector + L(1)=4, (B) pairwise-distinct h*-vectors (1,0,h-1,0). All PASS."
+    ],
+    "insights": [
+      "The h*-vector is NOT a face-lattice invariant. Reeve tetrahedra are combinatorially identical (same boolean lattice B_4) but h*(T_h)=(1,0,h-1,0) varies, so no function of the face lattice yields h*.",
+      "Each T_h has exactly its 4 vertices as lattice points (0 interior, 0 non-vertex boundary), so L(1)=4 for ALL h, yet Euclidean volume = h/6: this is precisely why a 3D Pick identity (volume from lattice-point counts) is impossible. The missing datum is the h*-vector itself.",
+      "L_{T_h}(t)=(h/6)t^3+t^2+(2-h/6)t+1; T_1 is unimodular (h*=(1,0,0,0), Ehrhart = tetrahedral numbers)."
+    ],
+    "mathlibGaps": [
+      "No Ehrhart theory in Mathlib (Ehrhart, hStarVector, latticePolytope+Ehrhart = 0 hits). The gallery Pick development is ad-hoc 2D area, not a general Ehrhart framework.",
+      "A faithful ACT needs lattice-point counting of dilates, Ehrhart polynomiality, and the h*-transform \u2014 all absent upstream."
+    ],
+    "nextSteps": [
+      "ACT (light, Docker-gated): formalize the concrete Reeve family refutation \u2014 L_{T_h} closed form via decide, h*(T_h)=(1,0,h-1,0), h*(T_1)!=h*(T_2) + a face-lattice iso. Avoids building general Ehrhart theory.",
+      "Make explicit in the picks-theorem-oq-03 cluster that Reeve tetrahedra are the obstruction to a 3D Pick theorem."
+    ],
+    "markdown": "See research/problems/picks-theorem-oq-03-oq-02/knowledge.md"
+  },
+  "tags": [
+    "geometry",
+    "combinatorics",
+    "lattice-polytopes",
+    "ehrhart",
+    "h-star-vector",
+    "reeve-tetrahedra",
+    "research"
+  ],
+  "relatedProofs": [
+    "picks-theorem-oq-03",
+    "picks-theorem",
+    "picks-theorem-oq-03-ext"
+  ],
+  "references": {
+    "papers": [
+      "J. E. Reeve, On the volume of lattice polyhedra, Proc. LMS (1957).",
+      "Beck & Robins, Computing the Continuous Discretely (Ehrhart theory)."
+    ],
+    "urls": [],
+    "mathlib": [
+      "(absent) Ehrhart theory / h*-vector"
+    ]
+  },
+  "started": "2026-06-15T07:55:00.000Z",
+  "lastUpdate": "2026-06-15T07:55:00.000Z",
+  "significance": 6,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary

Build-free **ORIENT** answering the seeker stub *"Can the h\*-vector be computed directly from the face lattice of the polytope?"*: **No.** The h\*-vector (Ehrhart δ-vector) is a *lattice-geometric*, not combinatorial, invariant.

**Witness — Reeve tetrahedra.** `T_h = conv{(0,0,0),(1,0,0),(0,1,0),(1,1,h)}`, `h = 1,2,3,…`:
- all share the **same face lattice** (f-vector `(4,6,4,1)`; each has *exactly its 4 vertices* as lattice points, so `L_{T_h}(1)=4` for every `h`);
- yet have **distinct h\*-vectors** `(1, 0, h−1, 0)`, with `L_{T_h}(t) = (h/6)t³ + t² + (2−h/6)t + 1`, normalized volume `h`.

**Tie to the parent (Pick's theorem).** Reeve's tetrahedra are precisely why Pick's 2D identity has no 3D analogue: equal lattice-point counts, different volume, so volume is not a function of the lattice-point data — the missing datum is the non-combinatorial h\*-vector.

## Verification (durable, exact, no Docker)

`research/problems/picks-theorem-oq-03-oq-02/verify_hstar_not_combinatorial.py` (stdlib `fractions`, exact, **all PASS**): barycentric lattice-point counting of `t·T_h` for `t=0..4`, h\*-vector via the binomial transform; confirms (A) shared f-vector + `L(1)=4`, (B) pairwise-distinct h\*-vectors.

## ACT scope (Docker-gated; both backends down)

Mathlib has **no** Ehrhart theory (`Ehrhart`/`hStarVector` = 0 hits). A faithful formalization is a multi-file build; a **light** refutation is `decide`-friendly: closed-form `L_{T_h}`, `h*(T_h)=(1,0,h−1,0)`, prove `h*(T_1) ≠ h*(T_2)` alongside a face-lattice isomorphism `T_1 ≅ T_2`. No Lean changed.

## Test plan
- [x] `python3 research/problems/picks-theorem-oq-03-oq-02/verify_hstar_not_combinatorial.py` → ALL CHECKS PASS
- [ ] Lean light-refutation deferred to a Docker session

🤖 Generated with [Claude Code](https://claude.com/claude-code)