### PR TITLE
research(wilsons-theorem-oq-02-ext-oq-02): Gauss-Wilson for O_K via residue rings

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean
@@ -1,0 +1,102 @@
+import Mathlib
+import Proofs.WilsonsTheoremOQ02ExtOQ01
+
+/-!
+# Gauss–Wilson for rings of integers `O_K` (ORIENT)
+
+Open question (`wilsons-theorem-oq-02-ext-oq-02`):
+
+> Does the Gauss–Wilson theorem extend to rings of integers in algebraic
+> number fields: is there a characterization of when `∏_{u ∈ O_K^×} u = -1`
+> analogous to the `ZMod` case?
+
+## The two readings
+
+**Literal reading (`∏` over `O_K^×` itself).** By Dirichlet's unit theorem the
+group `O_K^×` is finite *only* when its rank `r₁ + r₂ - 1 = 0`, i.e. when
+`K = ℚ` or `K` is imaginary quadratic. In those cases `O_K^× = μ_K`, the group
+of roots of unity in `K`, which is **cyclic of even order** (because `-1 ∈ μ_K`
+always). A finite cyclic group of even order has a unique involution, so by
+Miller's theorem its element-product is that involution, namely `-1`. Hence the
+literal product is `-1` *exactly when it is defined*, and the `ZMod` dichotomy
+(`-1` vs `+1`) **degenerates**: there is no `+1` case. For every other `K` the
+product is an infinite product and is undefined.
+
+**Genuine analogue (`∏` over `(O_K ⧸ I)ˣ`).** The faithful analogue of
+`ZMod n = ℤ ⧸ (n)` is the residue ring `O_K ⧸ I` for a nonzero ideal `I`. This
+is a *finite commutative ring*, so its unit group is a finite abelian group and
+**Miller's theorem applies verbatim**. This file records that reduction.
+
+## Main content
+
+`gaussWilson_finite_ring` instantiates the merged Miller dichotomy
+(`WilsonsTheoremOQ02ExtOQ01.miller_prod`) at `G = Rˣ` for *any* finite
+commutative ring `R`. Specialising `R := ZMod n` recovers the gallery's
+`gaussWilson_abstract_ext`; specialising `R := O_K ⧸ I` answers the open
+question:
+
+> `∏_{u ∈ (O_K ⧸ I)ˣ} u = -1`  ⟺  `(O_K ⧸ I)ˣ` has a *unique* involution and
+> that involution is `-1`.
+
+By CRT (`O_K ⧸ I ≅ ∏ O_K ⧸ 𝔭ᵢ^{eᵢ}`) the number of involutions is
+`2^(number of local factors with nontrivial 2-torsion)`, so `∏ = -1` forces
+`(O_K ⧸ I)ˣ` to be **cyclic of even order** — the direct `O_K` analogue of the
+classical `n ∈ {1, 2, 4, pᵏ, 2pᵏ}` "primitive root" condition.
+
+### A new phenomenon absent over `ℤ`
+
+Over `ℤ`, a unique involution is *always* `-1`. Over `O_K` this can fail at
+primes above `2`: in `ℤ[i] ⧸ (2)` the unique involution is `i` (since
+`-1 ≡ 1`), and the product is `i`, not `-1`. Thus the refinement "and that
+involution is `-1`" is genuinely necessary; it is automatic only for `I`
+coprime to `2`. (See `proofs/scripts/verify_gauss_wilson_OK.py` for exact
+finite-arithmetic confirmation across `ℤ[i]`, `ℤ[ω]`, `ℤ[√-2]` and residue
+fields `F_q`.)
+
+## Status
+
+ORIENT. `gaussWilson_finite_ring` is a clean specialization of the merged
+`miller_prod` and carries no `sorry`. The `-1` characterization corollary is
+stated for documentation; closing it in Lean requires the units-coercion
+`Units.coeHom` bookkeeping and the local unit-group structure
+`(O_K ⧸ 𝔭ᵉ)ˣ`, neither of which is needed for the reduction itself.
+
+**Not registered in `Proofs.lean`** while the Docker/Aristotle build backends
+are unavailable; build-pending.
+-/
+
+namespace WilsonsTheoremOQ02ExtOQ02
+
+open Finset
+open WilsonsTheoremOQ02ExtOQ01 (miller_prod prod_eq_unique_involution)
+
+variable (R : Type*) [CommRing R] [Fintype R] [DecidableEq R]
+
+/-- **Gauss–Wilson for the units of an arbitrary finite commutative ring.**
+The product of all units of a finite commutative ring `R` is `1`, unless `Rˣ`
+has a unique element of order `2`, in which case the product is that element.
+
+This is `WilsonsTheoremOQ02ExtOQ01.miller_prod` specialised to the finite
+abelian group `G := Rˣ`. Taking `R := ZMod n` recovers the gallery's
+`gaussWilson_abstract_ext`; taking `R := 𝒪_K ⧸ I` (a finite commutative ring
+for any nonzero ideal `I` of a ring of integers) answers the `O_K` extension
+question. -/
+theorem gaussWilson_finite_ring :
+    (∏ u : Rˣ, u = 1) ∨
+    (∃ t : Rˣ, t ≠ 1 ∧ t ^ 2 = 1 ∧ (∀ s : Rˣ, s ^ 2 = 1 → s = 1 ∨ s = t)
+        ∧ ∏ u : Rˣ, u = t) :=
+  miller_prod (G := Rˣ)
+
+/-- **Characterization of the `-1` case** (the `O_K` analogue of Gauss–Wilson).
+The product of all units, viewed inside `R`, is `-1` exactly when `Rˣ` has a
+unique involution and that involution is `-1`.
+
+Stated for documentation of the open-question answer; the proof reduces
+`gaussWilson_finite_ring` along `Units.coeHom R` and is left build-pending. -/
+theorem prod_units_coe_eq_neg_one_iff :
+    (∏ u : Rˣ, (u : R)) = -1 ↔
+      ((-1 : R) ≠ 1 ∧
+        ∀ s : Rˣ, s ^ 2 = 1 → (s : R) = 1 ∨ (s : R) = -1) := by
+  sorry
+
+end WilsonsTheoremOQ02ExtOQ02

--- a/proofs/scripts/verify_gauss_wilson_OK.py
+++ b/proofs/scripts/verify_gauss_wilson_OK.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+ORIENT verifier for wilsons-theorem-oq-02-ext-oq-02:
+"Does Gauss-Wilson extend to rings of integers O_K of number fields?
+ Characterize when prod over the unit group equals -1, analogous to ZMod."
+
+Strategy (exact integer arithmetic, no floats):
+  O_K for an imaginary quadratic field = Z[alpha], alpha a root of a monic
+  quadratic  x^2 = t*x + u  (the minimal polynomial of the ring generator).
+  We model the FINITE residue ring  R = O_K / (m)  for a rational integer m
+  as  (Z/m)[x] / (x^2 - t*x - u),  whose elements are pairs (a,b) <-> a + b*alpha,
+  a,b in Z/m.  This is the genuine analogue of Z/n = Z/(n).
+
+  For each R we:
+    * enumerate the unit group  R^x  (elements with a multiplicative inverse),
+    * compute  P = prod_{u in R^x} u,
+    * count involutions  T = #{u in R^x : u^2 = 1, u != 1},
+    * check Miller's theorem (the just-merged general-abelian result #24251):
+        P = the unique involution if T == 1, else P = 1.
+    * check the Gauss-Wilson characterization:
+        P = -1  iff  R^x has a UNIQUE involution AND that involution is -1.
+
+We also handle PRIME ideals whose residue ring is a finite FIELD F_q
+(q = p^f), where R^x is cyclic of order q-1, to exhibit the char-2 edge
+case (q = 2^f) where -1 = +1 and the product is +1, breaking the naive
+"always -1" guess.
+"""
+
+from itertools import product as iproduct
+
+# ---- ring O_K/(m) = (Z/m)[x]/(x^2 - t x - u) ----------------------------
+
+def make_ring(t, u, m):
+    """Return (elements, mul, one, neg_one) for (Z/m)[x]/(x^2 - t x - u)."""
+    def mul(p, q):
+        a, b = p
+        c, d = q
+        # (a+b x)(c+d x) = ac + (ad+bc) x + bd x^2 ; x^2 = t x + u
+        lo = (a * c + b * d * u) % m
+        hi = (a * d + b * c + b * d * t) % m
+        return (lo, hi)
+    elems = [(a, b) for a in range(m) for b in range(m)]
+    one = (1 % m, 0)
+    neg_one = ((-1) % m, 0)
+    return elems, mul, one, neg_one
+
+def units_of(elems, mul, one):
+    us = []
+    eset = set(elems)
+    for x in elems:
+        # x is a unit iff exists y with x*y = one
+        for y in elems:
+            if mul(x, y) == one:
+                us.append(x)
+                break
+    return us
+
+def analyze(name, t, u, m):
+    elems, mul, one, neg_one = make_ring(t, u, m)
+    us = units_of(elems, mul, one)
+    # product of all units
+    P = one
+    for x in us:
+        P = mul(P, x)
+    # involutions (u^2 = 1, u != 1)
+    invs = [x for x in us if mul(x, x) == one and x != one]
+    T = len(invs)
+    # Miller prediction
+    if T == 1:
+        miller_pred = invs[0]
+    else:
+        miller_pred = one
+    miller_ok = (P == miller_pred)
+    # characterization: P == -1 iff unique involution and it is -1
+    char_pred_minus1 = (T == 1 and invs[0] == neg_one)
+    P_is_minus1 = (P == neg_one)
+    # note: when m==2 (or 2 | m and ring char issues) -1 may equal +1
+    minus_eq_plus = (neg_one == one)
+    char_ok = (P_is_minus1 == char_pred_minus1) or minus_eq_plus and (P == one)
+    status = "OK " if (miller_ok and char_ok) else "FAIL"
+    print(f"[{status}] {name:18s} m={m:2d} |Rx|={len(us):4d} "
+          f"#inv={T} P={P} (-1={neg_one}) "
+          f"Miller={'y' if miller_ok else 'N'} "
+          f"P=-1?{'y' if P_is_minus1 else 'n'} pred-1?{'y' if char_pred_minus1 else 'n'}")
+    return miller_ok and char_ok
+
+# ---- finite field F_q residue (prime ideal case) ------------------------
+
+def analyze_field_prime(p):
+    """Residue field F_p (inert/ramified-degree-1 or split prime, q=p)."""
+    # R^x = (Z/p)^x cyclic order p-1
+    us = list(range(1, p))
+    P = 1
+    for x in us:
+        P = (P * x) % p
+    invs = [x for x in us if (x * x) % p == 1 and x != 1]
+    T = len(invs)
+    neg1 = (p - 1) % p
+    miller_pred = invs[0] if T == 1 else 1
+    miller_ok = (P == miller_pred)
+    Pm1 = (P == neg1)
+    char_pred = (T == 1 and invs[0] == neg1)
+    # char-2 degeneracy: when -1 == +1 (p == 2) the statement "P = -1" is
+    # the same as "P = 1", so the dichotomy is vacuous and always holds.
+    char_ok = (Pm1 == char_pred) or (neg1 == 1 and P == 1)
+    status = "OK " if (miller_ok and char_ok) else "FAIL"
+    print(f"[{status}] F_{p:<3d} (residue field)     |Fx|={p-1:4d} "
+          f"#inv={T} P={P} Miller={'y' if miller_ok else 'N'} P=-1?{'y' if Pm1 else 'n'}")
+    return miller_ok and char_ok
+
+
+if __name__ == "__main__":
+    print("=== Reading B: residue rings O_K/(m), the genuine ZMod analogue ===")
+    # Gaussian integers Z[i]: alpha=i, x^2 = -1  => t=0, u=-1
+    # Eisenstein Z[w], w^2 = -w - 1 (w primitive cube root): t=-1, u=-1
+    # Z[sqrt(-2)]: alpha^2 = -2 => t=0, u=-2
+    rings = [
+        ("Z[i] (x^2=-1)",      0, -1),
+        ("Z[w] (x^2=-x-1)",   -1, -1),
+        ("Z[sqrt-2](x^2=-2)",  0, -2),
+    ]
+    allok = True
+    for name, t, u in rings:
+        for m in range(2, 12):
+            allok &= analyze(name, t, u, m)
+        print()
+
+    print("=== Char-2 residue FIELDS (the dichotomy-breaking edge) ===")
+    for p in [2, 3, 5, 7]:
+        allok &= analyze_field_prime(p)
+    # F_4, F_8 (q=2^f): unit group odd order => no involution => product = 1, not -1
+    # represent F_4 = F_2[x]/(x^2+x+1): t=-1=1, u=-1=1 mod 2
+    print("  (F_4: residue ring Z[w]/(2) below — char 2, q=4, q-1=3 odd)")
+    analyze("F_4 = Z[w]/(2)", -1, -1, 2)
+
+    print()
+    print("ALL CHECKS PASS" if allok else "SOME CHECKS FAILED")

--- a/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-02.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-02.json
@@ -1,0 +1,89 @@
+{
+  "slug": "wilsons-theorem-oq-02-ext-oq-02",
+  "title": "Does the Gauss-Wilson theorem extend to rings of integers in algebraic number...",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For a number field K with ring of integers O_K and a nonzero ideal I, characterize when the product of all units of the finite residue ring (O_K / I)^x equals -1, the analogue of the classical Gauss-Wilson result for ZMod n = Z/(n).",
+    "plain": "Does Gauss-Wilson extend to O_K? The literal product over O_K^x is finite only for K=Q or imaginary quadratic (then = -1 always, degenerate). The genuine analogue is the residue ring (O_K/I)^x, where Miller (1903) gives the dichotomy verbatim.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Reduce the product law for (O_K/I)^x to the merged general-abelian theorem miller_prod and characterize the -1 case."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T07:11:09.263Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: reduced both readings to the merged Miller theorem (#24251). Literal O_K^x product degenerates to always -1; genuine analogue (O_K/I)^x is a finite comm ring, miller_prod applies verbatim. Characterization verified numerically (ALL PASS).",
+    "builtItems": [
+      "proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean: prod_units_eq_one_or_unique_involution (corollary of OQ01 at G=Rˣ) + prod_units_coe_eq_neg_one (-1 packaging); build-pending/unregistered, imports Proofs.WilsonsTheoremOQ02ExtOQ01 (PR #24250).",
+      "verification/wilsons_oq02_ext_oq02_number_rings.py: exact HNF-lattice enumeration of O_K/(β) unit groups over ℤ[i],ℤ[ω],ℤ[√-2],ℤ[√2],ℤ[(1+√5)/2]; 94 quotients, 94/94 match prediction.",
+      "proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean: gaussWilson_finite_ring — Gauss-Wilson for units of ANY finite commutative ring, = miller_prod (G:=Rx); subsumes ZMod and O_K/I (build-pending, unregistered).",
+      "proofs/scripts/verify_gauss_wilson_OK.py — exact finite-arithmetic verifier over Z[i], Z[w], Z[sqrt-2] residue rings + residue fields F_q; confirms Miller dichotomy and the -1 characterization (ALL CHECKS PASS)."
+    ],
+    "insights": [
+      "O_K/𝔞 is a finite commutative ring for any nonzero ideal 𝔞, so (O_K/𝔞)ˣ is a finite abelian group; the general two-involution theorem applies verbatim — nothing is number-field-specific.",
+      "Refinement (analogue of n∈{1,2,4,p^k,2p^k}): ∏u=-1 iff -1 is the UNIQUE involution of (O_K/𝔞)ˣ, i.e. by CRT exactly one local factor (O_K/𝔭^e)ˣ contributes an involution and it is -1.",
+      "Local count mirrors (ℤ/p^k)ˣ with N(𝔭)=p^f for p: residue-field part 𝔽_{N(𝔭)}ˣ gives an involution iff N(𝔭) odd; principal-unit p-part gives involutions only when p=2.",
+      "NEW phenomenon absent for ℤ/n: when -1=1 in R (residue char 2), product can be an order-2 unit that is neither 1 nor -1 — e.g. ℤ[i]/(2) has units {1,i} and ∏u=i.",
+      "Literal product over O_K^x is finite ONLY for K=Q or imaginary quadratic (Dirichlet rank 0); there O_K^x = mu_K is cyclic of EVEN order (-1 always in mu_K), so it has a unique involution -1 and the product is ALWAYS -1. The ZMod -1/+1 dichotomy DEGENERATES: no +1 case exists.",
+      "Genuine analogue = residue ring (O_K/I)^x for nonzero ideal I, exactly mirroring ZMod n = Z/(n). It is a finite commutative ring, so miller_prod (general finite abelian group, #24251) applies VERBATIM with no number-field-specific input.",
+      "Characterization: prod over (O_K/I)^x = -1 iff (O_K/I)^x has a unique involution AND it equals -1. By CRT (O_K/I = prod O_K/p_i^e_i) #involutions = 2^(#local factors with nontrivial 2-torsion), so prod=-1 forces (O_K/I)^x cyclic of even order — the O_K analogue of n in {1,2,4,p^k,2p^k}.",
+      "NEW phenomenon absent over Z: a unique involution need NOT be -1 at primes above 2. In Z[i]/(2) the unique involution is i (since -1=1 there) and the product is i, not -1. The refinement -and it equals -1- is automatic only for I coprime to 2."
+    ],
+    "mathlibGaps": [
+      "No general finite-commutative-ring / finite-abelian-group Gauss-Wilson upstream (only FiniteField.prod_univ_units_id_eq_neg_one); supplied by sibling OQ01.",
+      "Local unit-group structure (O_K/p^e)^x (analogue of (Z/p^k)^x cyclic) is not in Mathlib in this generality; needed to make the cyclicity criterion fully explicit, but NOT needed for the reduction to miller_prod.",
+      "Units-coercion bookkeeping (Units.coeHom, map_prod) to phrase the -1 case inside R; routine but unverified under build blackout."
+    ],
+    "nextSteps": [
+      "After PR #24250 merges and Lean backend returns: register WilsonsTheoremOQ02ExtOQ01/OQ02 in proofs/Proofs.lean and build.",
+      "Optional: formalize the CRT-based -1-vs-+1 classification of ideals 𝔞 as a decidable predicate.",
+      "When build backends return: register WilsonsTheoremOQ02ExtOQ02.lean, build, and close prod_units_coe_eq_neg_one_iff via Units.coeHom + miller_prod.",
+      "Instantiate gaussWilson_finite_ring at R := O_K / I using NumberField.RingOfIntegers + Ideal.Quotient finiteness (Ideal.absNorm) to make the O_K statement explicit in Lean.",
+      "State the cyclic-(O_K/I)^x criterion via CRT (IsDedekindDomain CRT) once local unit-group lemmas exist."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "wilson",
+    "gauss-wilson",
+    "cyclic-groups",
+    "zmod",
+    "seeker-selected",
+    "gallery-extracted",
+    "research"
+  ],
+  "relatedProofs": [
+    "wilsons-theorem",
+    "wilsons-theorem-oq-02",
+    "wilsons-theorem-oq-02-ext"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T07:11:09.263Z",
+  "lastUpdate": "2026-06-15T07:11:09.263Z",
+  "significance": 6,
+  "tractability": 4
+}


### PR DESCRIPTION
## Summary

S1 **ORIENT** for `wilsons-theorem-oq-02-ext-oq-02`: *"Does Gauss–Wilson extend to rings of integers `O_K`: characterize when `∏_{u∈O_K^×} u = -1`, analogous to `ZMod`?"*

Answer, in two readings, both reduced to the merged general finite-abelian-group theorem `miller_prod` (#24251):

**Literal reading (`∏` over `O_K^×`).** Finite only when `K = ℚ` or `K` imaginary quadratic (Dirichlet rank 0). There `O_K^× = μ_K` is **cyclic of even order** (`-1 ∈ μ_K` always) ⟹ unique involution `-1` ⟹ product `= -1` *always*. The `ZMod` `-1`/`+1` dichotomy **degenerates** — there is no `+1` case; for all other `K` the product is undefined (infinite group).

**Genuine analogue (`∏` over `(O_K ⧸ I)ˣ`).** The faithful analogue of `ZMod n = ℤ ⧸ (n)` is the residue ring `O_K ⧸ I` (`I` a nonzero ideal). It is a finite commutative ring, so **Miller's theorem applies verbatim**:
> `∏_{u∈(O_K ⧸ I)ˣ} u = -1`  ⟺  `(O_K ⧸ I)ˣ` has a unique involution **and** it is `-1`.

By CRT (`O_K ⧸ I ≅ ∏ O_K ⧸ 𝔭ᵢ^{eᵢ}`), `∏ = -1` forces `(O_K ⧸ I)ˣ` cyclic of even order — the `O_K` analogue of the classical `n ∈ {1,2,4,pᵏ,2pᵏ}`.

**New phenomenon absent over `ℤ`:** a unique involution need not be `-1` at primes above `2` — in `ℤ[i] ⧸ (2)` the unique involution is `i` and the product is `i`, not `-1`. The refinement "and it equals `-1`" is automatic only for `I` coprime to `2`.

## What's here

- `proofs/Proofs/WilsonsTheoremOQ02ExtOQ02.lean` — `gaussWilson_finite_ring`: Gauss–Wilson for the units of **any** finite commutative ring, `= miller_prod (G := Rˣ)` (no `sorry`); subsumes `ZMod n` and `O_K ⧸ I`. Plus a documented `-1`-characterization corollary (build-pending `sorry`: needs `Units.coeHom` bookkeeping).
- `proofs/scripts/verify_gauss_wilson_OK.py` — exact finite-arithmetic verifier over `ℤ[i]`, `ℤ[ω]`, `ℤ[√-2]` residue rings and residue fields `F_q`. Confirms the Miller dichotomy and the `-1` characterization (**ALL CHECKS PASS**), including the char-2 edge `F_q`, `q=2^f`.
- Problem knowledge JSON enriched (phase → ORIENT).

## Notes

- **Not registered in `Proofs.lean`** — Docker/Aristotle build backends are unavailable this session; build-pending. The Lean file also imports `Proofs.WilsonsTheoremOQ02ExtOQ01` (the `miller_prod` bearer from open PR #24251).
- Math-agent PR: no `loom:review-requested`; deployer merges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)