### PR TITLE
Research: erdos-1107-oq-02-oq-01 — Lean ACT for cubeful r=3 threshold N₃=2040 (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos1107OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1107OQ02OQ01.lean
@@ -1,0 +1,190 @@
+/-
+Erdős Problem #1107 OQ-02-OQ-01: Threshold for the r=3 (cubeful) case
+
+Parent (r=2): every sufficiently large integer is a sum of at most THREE
+squareful (2-powerful) numbers; effective threshold N₂ = 120.
+
+This entry settles the r=3 (cubeful / 3-powerful) analogue and the framing
+conflict it exposes:
+
+  * The "at most r+1" form is correct: every large n is a sum of at most
+    FOUR cubeful numbers.  The "at most 3 for every r" form is FALSE at r=3.
+
+We make the r=3 statement effective:
+
+  * With ≤4 cubeful summands the threshold is N₃ = 2040.  Exactly 45 positive
+    integers below it fail; the largest exception is 2039.  (Computationally
+    the exceptional set is exactly these 45 with no exception in (2039, 10⁷];
+    see proofs/scripts/verify_cubeful_stability.py.)
+
+  * With ≤3 cubeful summands there is NO finite threshold: the exceptional set
+    keeps positive density (~0.21 up to 60000).  This is the unconditional half
+    and needs no asymptotic input.
+
+Structural reason (the r+1 law).  The number of r-powerful integers up to x is
+∼ Cᵣ·x^{1/r}, so the k-fold sumset has ∼ x^{k/r} elements up to x and covers a
+positive proportion of [1,x] only when k/r > 1, i.e. k ≥ r+1.  The critical
+case k = r has a sumset of the same order x as the target but constant
+Cᵣ^k/k! < 1, so a positive density is permanently missed.  Hence r=2 needs 3
+summands and r=3 needs 4.
+
+References:
+- https://erdosproblems.com/1107
+- Heath-Brown, "Ternary quadratic forms and sums of three square-full numbers"
+  Séminaire de Théorie des Nombres, Paris 1986-87 (1988) — the r=2 asymptotic.
+
+The r=3 asymptotic ("every large n is a sum of ≤4 cubeful numbers") appears to
+remain open (no proven Heath-Brown analogue).  N₃ = 2040 is therefore the
+effective threshold *conditional* on that asymptotic, exactly mirroring the r=2
+gallery entry's structure (native_decide for a finite range + one axiom for the
+tail).
+-/
+
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Tactic
+
+open Nat
+
+namespace Erdos1107OQ02OQ01
+
+/-
+## Definitions
+-/
+
+/-- A natural number `n` is cubeful (3-powerful) if `p³ ∣ n` for every prime
+    `p ∣ n`.  0 and 1 are vacuously cubeful (no prime factors). -/
+def IsCubeful (n : ℕ) : Prop :=
+  ∀ p ∈ n.primeFactors, p ^ 3 ∣ n
+
+instance IsCubeful.decidable (n : ℕ) : Decidable (IsCubeful n) := by
+  unfold IsCubeful; infer_instance
+
+/-- The cubeful numbers in `[0, n]` (including 0 and 1).  Enumerating the
+    summand candidates over this small basis — `27` elements up to 2040 —
+    keeps the representation check feasible for `native_decide`, whereas a
+    naive triple range loop would be `O(n³)` per integer. -/
+def cubefulBasis (n : ℕ) : List ℕ :=
+  (List.range (n + 1)).filter (fun k => decide (IsCubeful k))
+
+/-- Decidable check: can `n` be written as a sum of at most four cubeful
+    numbers?  Picks `a, b, c` from the cubeful basis with `a + b + c ≤ n` and
+    checks whether the remainder `n - a - b - c` is also cubeful.  Since `0` is
+    cubeful and lies in the basis, padding with zeros realises "at most four". -/
+def isSumOf4Cubeful (n : ℕ) : Bool :=
+  let basis := cubefulBasis n
+  Id.run do
+    for a in basis do
+      for b in basis do
+        if a + b ≤ n then
+          for c in basis do
+            if a + b + c ≤ n then
+              if decide (IsCubeful (n - a - b - c)) then
+                return true
+    return false
+
+/-- Batch check: are all integers in `[a, b]` sums of ≤4 cubeful numbers? -/
+def checkRange (a b : ℕ) : Bool :=
+  (List.range (b - a + 1)).all fun i => isSumOf4Cubeful (a + i)
+
+/-- The 45 positive integers below the threshold that are NOT sums of ≤4
+    cubeful numbers. -/
+def exceptions : List ℕ :=
+  [5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 31, 38, 39, 46, 47, 53, 58, 69, 77,
+   79, 85, 95, 101, 103, 111, 175, 196, 212, 228, 231, 247, 327, 444, 458, 490,
+   606, 662, 860, 975, 1167, 1470, 1821, 1967, 2039]
+
+/-
+## The Exceptional Set
+
+Exactly 45 positive integers cannot be written as sums of at most 4 cubeful
+numbers, each verified by exhaustive search over basis decompositions.
+-/
+
+/-- Every listed exception genuinely fails to be a sum of ≤4 cubeful numbers. -/
+theorem exceptions_not_representable :
+    ∀ n ∈ exceptions, isSumOf4Cubeful n = false := by native_decide
+
+/-- The largest exception, 2039, is not representable — the threshold is tight. -/
+theorem not_sum4_2039 : isSumOf4Cubeful 2039 = false := by native_decide
+
+/-- All positive integers below 2040 outside the 45-element exceptional set ARE
+    representable as sums of ≤4 cubeful numbers. -/
+theorem below_threshold_nonexceptions :
+    ∀ n ∈ List.range 2040, n ∉ exceptions → isSumOf4Cubeful n = true := by
+  native_decide
+
+/-
+## Threshold Verification
+
+Computational verification that every integer from 2040 up through 3000 is a
+sum of at most 4 cubeful numbers (no exception occurs above 2039).  Split into
+blocks to bound the `native_decide` working set.
+-/
+
+theorem range_2040_2300 : checkRange 2040 2300 = true := by native_decide
+theorem range_2301_2600 : checkRange 2301 2600 = true := by native_decide
+theorem range_2601_3000 : checkRange 2601 3000 = true := by native_decide
+
+/-
+## Basic Properties
+-/
+
+/-- 0 is cubeful (vacuously). -/
+theorem isCubeful_zero : IsCubeful 0 := by simp [IsCubeful]
+
+/-- 1 is cubeful (vacuously). -/
+theorem isCubeful_one : IsCubeful 1 := by simp [IsCubeful]
+
+/-- Prime powers `p^k` with `k ≥ 3` are cubeful. -/
+theorem isCubeful_8 : IsCubeful 8 := by native_decide      -- 2³
+theorem isCubeful_16 : IsCubeful 16 := by native_decide    -- 2⁴
+theorem isCubeful_27 : IsCubeful 27 := by native_decide    -- 3³
+theorem isCubeful_2000 : IsCubeful 2000 := by native_decide -- 2⁴·5³
+
+/-- 8 is cubeful but 24 = 2³·3 is NOT (the prime 3 appears to the first power). -/
+theorem not_isCubeful_24 : ¬ IsCubeful 24 := by native_decide
+
+/-- 2040 = 2000 + 8 + 32 + 0 is the threshold: the first integer at and above
+    which every value is representable. -/
+theorem threshold_2040 : isSumOf4Cubeful 2040 = true := by native_decide
+
+/-- 2039 is not representable: the threshold is tight. -/
+theorem threshold_tight : isSumOf4Cubeful 2039 = false := not_sum4_2039
+
+/-
+## Main Result
+-/
+
+/-- **Cubeful Sum Threshold (effective, r = 3)**: every integer `n ≥ 2040` is
+    the sum of at most four cubeful numbers.
+
+    Verified computationally for `n ∈ [2040, 3000]` above, and stable with no
+    exception in `(2039, 10⁷]` (see verify_cubeful_stability.py).  The infinite
+    tail rests on the (still open) r=3 asymptotic analogue of Heath-Brown's
+    theorem; this axiom encodes exactly that conjectural asymptotic, mirroring
+    the parent r=2 entry's `squareful_sum_threshold`. -/
+axiom cubeful_sum_threshold :
+    ∀ n : ℕ, 2040 ≤ n → isSumOf4Cubeful n = true
+
+/-
+## Summary
+
+Erdős Problem #1107 for r = 3 (cubeful), effective version:
+
+1. The threshold N₃ = 2040 is the smallest integer such that every n ≥ N₃ is a
+   sum of at most 4 cubeful numbers (conditional on the open r=3 asymptotic).
+
+2. Below the threshold, exactly 45 positive integers fail; the largest is 2039.
+
+3. Computationally verified for all n up to 3000, stable to 10⁷.
+
+4. The "at most r+1" framing of Erdős #1107 is the correct one: ≤3 cubeful
+   summands has NO finite threshold (positive exception density), so r=3 needs
+   4 — establishing the structural r+1 law.
+
+Axiom count: 1 (cubeful_sum_threshold — conjectural r=3 asymptotic for n ≥ 2040)
+Sorry count: 0
+-/
+
+end Erdos1107OQ02OQ01

--- a/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
@@ -99,3 +99,52 @@ settles the disagreement empirically.
 ### Files Modified
 - `proofs/scripts/verify_cubeful_stability.py` (new; default N=10⁶, accepts an override bound)
 - `research/problems/erdos-1107-oq-02-oq-01/knowledge.md` (this session note)
+
+## Session 2026-06-15 (Session 3, researcher-5) — ACT, Lean transcription (build-pending)
+
+**Mode**: continue (ACT; Docker + Aristotle both down, re-probed and confirmed down)
+**Outcome**: progress — wrote the Lean ACT file discharging the Session-1/2 "next step".
+Build-pending (cannot compile under blackout); shipped UNREGISTERED in `Proofs.lean` to
+avoid breaking the auto-merged main aggregate with an unverified `native_decide`-heavy file.
+
+### What I Did
+- Wrote `proofs/Proofs/Erdos1107OQ02OQ01.lean` (~210 LOC), transcribing the parent r=2
+  template (`Erdos1107OQ02.lean`) to the cubeful r=3 case.
+- **Key design change vs. the parent**: the parent's `isSumOf3Squareful` loops over
+  `List.range (n+1)` (O(n²) per integer — fine for N₂=120, infeasible at N₃=2040 with a
+  4th summand, O(n³)). My `isSumOf4Cubeful` instead enumerates `a,b,c` over the **cubeful
+  basis** `cubefulBasis n = (List.range (n+1)).filter IsCubeful` — only **27 elements ≤ 2040**
+  — and checks the remainder `n-a-b-c` is cubeful. That makes the per-integer cost ~27³≈2e4,
+  keeping `native_decide` feasible. `0` is in the basis (vacuously cubeful), so padding with
+  zeros realises "at most 4".
+- Theorems (all `native_decide`, build-pending): `exceptions_not_representable` (batch over
+  the 45-element `exceptions` list), `below_threshold_nonexceptions` (∀ n∈range 2040 outside
+  exceptions ⟹ representable), block ranges `[2040,2300] [2301,2600] [2601,3000]`, basic
+  cubeful witnesses (`8,16,27,2000`; `¬IsCubeful 24` since 24=2³·3), `threshold_2040` /
+  `threshold_tight`. One `axiom cubeful_sum_threshold` (n ≥ 2040) = the open r=3 asymptotic.
+
+### Verification done WITHOUT the build (Docker down)
+- Emulated `isSumOf4Cubeful` in Python (a,b,c over basis incl. 0; remainder cubeful) and
+  confirmed it agrees with the Session-2 numpy DP: 2039→false, 2040→true, 5→false, 4/8/120→true.
+- Re-ran `verify_cubeful_stability.py`: 45 exceptions, largest 2039, no exception in (2039,10⁶].
+- Checked every embedded witness: 8=2³,16=2⁴,27=3³,2000=2⁴·5³ cubeful; 24=2³·3 NOT;
+  threshold witness 2040 = 2000+8+32+0 (all four cubeful).
+
+### Honesty / scope
+- This is a faithful transcription of an already-computed, validated result into Lean. The
+  r=3 asymptotic is still **open** — `cubeful_sum_threshold` is exactly that conjectural tail,
+  mirroring the parent's `squareful_sum_threshold` axiom (axiom count 1, sorry count 0). The
+  file is **build-pending**: I could not run `lake`/Docker, so compile success of the
+  `native_decide` blocks is unverified. The main risk is `native_decide` time/memory at
+  N=2040–3000 (17× the parent's 120), not logical correctness — the Python emulation matches.
+
+### Files Modified
+- `proofs/Proofs/Erdos1107OQ02OQ01.lean` (new; build-pending, NOT registered in Proofs.lean)
+- `research/problems/erdos-1107-oq-02-oq-01/knowledge.md` (this session note)
+
+### Next Steps (build / deploy)
+- When Docker is up: `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01`. If
+  `native_decide` over `[1,2040]` is too heavy, split `below_threshold_nonexceptions` into
+  blocks (range 0–500, 500–1000, …) as done for the above-threshold ranges.
+- On green build: register via `./.lean/scripts/generate-proofs-imports.sh` and add a gallery
+  meta.json (`status: axiomatized`, `badge: axiom`, axiomCount 1) for the r=3 entry.

--- a/src/data/research/problems/erdos-1107-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1107-oq-02-oq-01.json
@@ -2,12 +2,12 @@
   "slug": "erdos-1107-oq-02-oq-01",
   "title": "Threshold for the r=3 (cubeful) case of Erdős #1107",
   "status": "in-progress",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "tier": "B",
   "significance": 7,
   "tractability": 4,
   "started": "2026-06-14",
-  "lastUpdate": "2026-06-14",
+  "lastUpdate": "2026-06-15",
   "path": "research/problems/erdos-1107-oq-02-oq-01/knowledge.md",
   "tags": [
     "number-theory",
@@ -26,10 +26,10 @@
     ]
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-14",
-    "iteration": 1,
-    "focus": "Durable DP computation (validated against the known r=2 result) gives N_3 = 2040 with exactly 45 exceptions for <=4 cubeful summands; <=3 has no threshold (positive exception density). Lean ACT deferred — Docker down."
+    "phase": "ACT",
+    "since": "2026-06-15",
+    "iteration": 3,
+    "focus": "Lean ACT file Erdos1107OQ02OQ01.lean written (build-pending, Docker down): basis-indexed isSumOf4Cubeful + native_decide over the 45 exceptions, [1,2040), and blocks to 3000, plus one axiom cubeful_sum_threshold (n>=2040) encoding the open r=3 asymptotic. Logic cross-checked against the Python DP; compile of the native_decide blocks unverified."
   },
   "knownResults": {
     "computed": [
@@ -39,7 +39,7 @@
     ],
     "open": [
       "The asymptotic 'every large n is a sum of <=4 cubeful numbers' (r=3) appears to remain open; no proven Heath-Brown analog. N_3 = 2040 is therefore the effective threshold conditional on that asymptotic.",
-      "Stability of 2040 beyond 60000 (sieve-based DP to ~1e6) not yet certified."
+      "Stability of 2040 confirmed to 1e6/1e7 (no exception above 2039). Lean ACT file written but BUILD-PENDING: native_decide compile (Docker down) unverified."
     ],
     "goal": "Effective threshold + exceptional set for r=3, plus the structural r+1 law explaining why 4 (not 3) summands are needed."
   },
@@ -51,16 +51,18 @@
       "Resolves the gallery framing conflict: the parent's 'at most r+1' description is correct; the overview's 'at most 3 for every r' is false at r=3."
     ],
     "builtItems": [
-      "proofs/scripts/verify_cubeful_sums.py — bounded coin-change DP over the r-powerful basis; self-validating against the r=2 base case."
+      "proofs/scripts/verify_cubeful_sums.py — bounded coin-change DP over the r-powerful basis; self-validating against the r=2 base case.",
+      "proofs/scripts/verify_cubeful_stability.py — sieve+numpy DP; certifies N_3=2040 (45 exceptions) stable to 1e6/1e7.",
+      "proofs/Proofs/Erdos1107OQ02OQ01.lean — Lean ACT (build-pending, unregistered): IsCubeful+Decidable, basis-indexed isSumOf4Cubeful, native_decide over the 45 exceptions + [1,2040] + blocks to 3000, axiom cubeful_sum_threshold (n>=2040). Uses cubeful-basis enumeration (27 elems <=2040) instead of the parent's O(n^3) range loop."
     ],
     "mathlibGaps": [
       "No Mathlib lemma for representation of integers as sums of bounded powerful numbers; the r=2 gallery entry handles this via a Decidable predicate + native_decide + an axiom for the asymptotic. The r=3 ACT file would follow the same pattern."
     ],
     "nextSteps": [
-      "Transcribe Erdos1107OQ02.lean (156 LOC) to a cubeful version: IsCubeful + Decidable, isSumOf4Cubeful : Nat -> Bool, native_decide over the 45 exceptions and the blocks [1,2040], one axiom cubeful_sum_threshold for n >= 2040.",
-      "Build with ./proofs/scripts/docker-build.sh once Docker is available.",
-      "Extend the DP to ~1e6 (sieve basis) to firm up 2040 before fixing it as the axiom hypothesis."
+      "Build the new file once Docker is up: ./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01. If native_decide over [1,2040] is too heavy, split below_threshold_nonexceptions into ~500-wide blocks (the above-threshold ranges are already blocked).",
+      "On green build: register via ./.lean/scripts/generate-proofs-imports.sh and add a gallery meta.json (status axiomatized, badge axiom, axiomCount 1).",
+      "Optional: a Lean-side proof that <=3 cubeful fails (positive exception density) to capture the unconditional half, not just the conditional <=4 threshold."
     ],
-    "progressSummary": "PROGRESS (ORIENT): durable computation pins N_3 = 2040 (45 exceptions) for <=4 cubeful and rules out <=3; structural r+1 law established. Lean ACT specified, Docker-gated."
+    "progressSummary": "PROGRESS (ACT): Lean transcription written (Erdos1107OQ02OQ01.lean) realising the validated N_3=2040 / 45-exception result via a basis-indexed isSumOf4Cubeful + native_decide + one conjectural-asymptotic axiom. Build-pending (Docker down); logic cross-checked against the Python DP."
   }
 }


### PR DESCRIPTION
## Summary
Session 3 (ACT) for the r=3 (cubeful) case of Erdős #1107. Transcribes the validated Session-1/2 computation into Lean: a new `proofs/Proofs/Erdos1107OQ02OQ01.lean` realising the effective threshold **N₃ = 2040** (every n ≥ 2040 is a sum of ≤4 cubeful numbers), with exactly **45 exceptions** (largest 2039) — the r=3 analogue of the parent r=2 entry (N₂ = 120, sum of ≤3 squareful).

## Progress
- New `Erdos1107OQ02OQ01.lean` (~210 LOC): `IsCubeful` + `Decidable`, basis-indexed `isSumOf4Cubeful`, `native_decide` over the 45-element exceptions list, the `[1,2040)` non-exceptions, and blocks `[2040,3000]`; basic cubeful witnesses; threshold tight at 2039; one `axiom cubeful_sum_threshold` (n ≥ 2040).
- Updated `knowledge.md` and the research-problem JSON (phase ORIENT → ACT).

## Findings
- **Design vs. parent**: `isSumOf4Cubeful` enumerates `a,b,c` over the **cubeful basis** (only **27 elements ≤ 2040**) rather than the parent's `O(n³)` `List.range` loop — that O(n³)-per-integer cost is infeasible at N₃=2040 with a 4th summand, whereas the basis loop is ~27³≈2e4 per integer and keeps `native_decide` tractable. `0 ∈ basis` (vacuously cubeful) realises "at most 4" by zero-padding.
- The axiom encodes the **still-open** r=3 asymptotic (no proven Heath-Brown analogue), exactly mirroring the parent's `squareful_sum_threshold`. Axiom count 1, sorry count 0.
- Logic cross-checked against the Python DP without a build: `isSumOf4Cubeful` emulation gives 2039→false, 2040→true, 5→false, 4/8/120→true; stability re-confirmed (45 exceptions, none in (2039, 10⁶]).

## Status
**Outcome**: progress (ACT) — **build-pending**. Docker + Aristotle were both down this session, so the `native_decide` blocks are unverified to compile. The file is intentionally **NOT registered** in the auto-generated `Proofs.lean` to avoid breaking the auto-merged main aggregate with an unverified file.

**Next Steps**: build with `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01`; if `native_decide` over `[1,2040)` is too heavy, split `below_threshold_nonexceptions` into ~500-wide blocks. On green build, register the import and add a gallery `meta.json` (`status: axiomatized`, `badge: axiom`, axiomCount 1).

🤖 Generated by researcher-5