### PR TITLE
research(kepler-conjecture-oq-04): fix grep-based axiom over-count (docstring hygiene)

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ04.lean
+++ b/proofs/Proofs/KeplerConjectureOQ04.lean
@@ -189,8 +189,8 @@ single-variable bounds are in scope.
 The Chen–Engel–Glotzer (2010) tetrahedral dimer density strictly
 exceeds the Kepler-Hales FCC sphere density.
 
-**Mathematical content.** The parent gallery's `kepler_conjecture`
-axiom states `δ ≤ π/(3√2)` for packings of *congruent spheres*. This
+**Mathematical content.** The parent gallery's `kepler_conjecture` axiom
+asserts `δ ≤ π/(3√2)` for packings of *congruent spheres*. This
 theorem shows that the abstract `PackingDensity` type in
 `Proofs.KeplerConjecture` admits values *strictly above* `fccDensity`,
 witnessed by the tetrahedral dimer construction. Hence the Kepler

--- a/research/problems/kepler-conjecture-oq-04/knowledge.md
+++ b/research/problems/kepler-conjecture-oq-04/knowledge.md
@@ -421,3 +421,18 @@ across shape classes, in both directions.
 Torquato (2004) axiom δ ≈ 0.7707 at aspect ratio α ≈ √2 (+1 axiom).
 Fills the non-lattice ellipsoid cell of the matrix; does not change the
 hierarchy bound. Lower priority than the closed S7 aggregation.
+
+## S8 (researcher-1, 2026-06-15) — axiom-count hygiene (build-free)
+
+The OQ-04 work (S1–S7) is complete: density hierarchy formalised, 0 sorries, 2
+legitimately-deep axioms (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`,
+`ulam_conjecture` — OPEN since 1972), meta.json accurate. No build-free math value
+remains (the deferred S8 Donev non-lattice bound would *add* an axiom and is
+Docker-gated; not pursued under the persisting blackout).
+
+One hygiene defect fixed: the docstring at line ~192 wrapped so that "axiom states …"
+began at **column 0** inside a `/-- -/` comment, making `grep -c "^axiom "` report **3**
+while the file has only **2** real axiom declarations (meta.json correctly says 2).
+Reworded to "`kepler_conjecture` axiom / asserts …" so the prose no longer starts a
+line with `axiom` — removes a false positive for grep-based axiom-count auditors.
+Line count held at 456 (no annotation drift); no Lean declaration changed.


### PR DESCRIPTION
## Summary
Doc-hygiene fix on the OQ-04 file. A docstring line wrapped so that `axiom states …` began at **column 0** inside a `/-- -/` comment, making `grep -c "^axiom "` report **3** axioms while the file actually has only **2** declarations (`bezdek_kuperberg_ellipsoid_lattice_upper_bound`, `ulam_conjecture`). `meta.json` already correctly records `axiomCount: 2`, so the grep was a false positive for the project's axiom-integrity auditors.

## Progress
- Reworded the docstring (`KeplerConjectureOQ04.lean` ~line 192) from `…kepler_conjecture` / `axiom states …` to `…kepler_conjecture` axiom` / `asserts …`, so no comment line begins with `axiom`. `grep -c "^axiom "` now returns 2, matching meta.json.
- **Line count held at 456** → no gallery annotation ranges drift. No Lean declaration changed.

## Findings
- The OQ-04 formalization (S1–S7) is complete: 0 sorries, 2 legitimately-deep axioms (Bezdek–Kuperberg ellipsoid-lattice bound; Ulam 1972, open 50+ years). No build-free mathematical value remains; the deferred Donev non-lattice ellipsoid bound would *add* an axiom and is Docker-gated.

## Status
**Outcome**: progress (axiom-integrity hygiene; build-safe under the Docker + Aristotle blackout)
**Next Steps**: none build-free; S8 Donev bound remains Docker-gated and is low priority (adds an axiom).

🤖 Generated by researcher-1