### PR TITLE
research(mean-value-theorem-oq-02-oq-02): discharge taylor_lagrange_remainder axiom

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ02.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02.lean
@@ -31,9 +31,11 @@ for some c between a and b.
 - `taylorPolynomial`: The n-th Taylor polynomial of f centered at a
 - `taylorPolynomial_zero`: The 0th Taylor polynomial is the constant f(a)
 - `taylorPolynomial_one`: The 1st Taylor polynomial is f(a) + f'(a)(x-a)
+- `taylor_lagrange_remainder`: Taylor's theorem with the Lagrange remainder,
+  proved (not axiomatized) by bridging Mathlib's `taylorWithinEval` form
 - `mvt_is_first_order_taylor`: MVT is Taylor's theorem with n=0
 
-Theorems: 4, Axioms: 1, Sorries: 0
+Theorems: 5, Axioms: 0, Sorries: 0
 -/
 
 noncomputable section
@@ -78,23 +80,45 @@ then there exists c between a and b such that:
 This is the higher-order generalization of the MVT (which is the n=0 case).
 -/
 
-/-- **Taylor's Theorem with Lagrange Remainder** (axiomatized).
+/-- **Taylor's Theorem with Lagrange Remainder**.
 
-    If f is (n+1)-times differentiable on [a,b], then there exists
+    If f is (n+1)-times continuously differentiable, then there exists
     c ∈ (a,b) such that:
       f(b) - taylorPolynomial f a n b = iteratedDeriv (n+1) f c / (n+1)! · (b-a)^{n+1}
 
-    This is axiomatized because converting between Mathlib's integral
-    remainder form and the classical Lagrange form requires the
-    generalized MVT for integrals, which involves substantial infrastructure.
+    Discharged from Mathlib's `taylor_mean_remainder_lagrange_iteratedDeriv`,
+    which already states the Lagrange remainder with the *global* iterated
+    derivative. The only gap is a formulation bridge: Mathlib's `taylorWithinEval`
+    (built from `iteratedDerivWithin` on `Set.Icc a b`) agrees term-by-term with
+    this file's `taylorPolynomial` (built from the global `iteratedDeriv`),
+    because on the unique-differentiability set `Icc a b` the within-derivative
+    equals the global one (`iteratedDerivWithin_eq_iteratedDeriv`). No integral
+    remainder or MVT-for-integrals machinery is needed.
 
     Reference: Rudin "Principles of Mathematical Analysis" Theorem 5.15. -/
-axiom taylor_lagrange_remainder
+theorem taylor_lagrange_remainder
     (f : ℝ → ℝ) (a b : ℝ) (hab : a < b) (n : ℕ)
     (hf : ContDiff ℝ (n + 1) f) :
     ∃ c ∈ Set.Ioo a b,
       f b - taylorPolynomial f a n b =
-      iteratedDeriv (n + 1) f c / ((n + 1).factorial : ℝ) * (b - a) ^ (n + 1)
+      iteratedDeriv (n + 1) f c / ((n + 1).factorial : ℝ) * (b - a) ^ (n + 1) := by
+  have hu : UniqueDiffOn ℝ (Set.Icc a b) := uniqueDiffOn_Icc hab
+  have hmem : a ∈ Set.Icc a b := ⟨le_refl a, le_of_lt hab⟩
+  -- The within-Taylor polynomial on `Icc a b` matches `taylorPolynomial`.
+  have hpoly : taylorWithinEval f n (Set.Icc a b) a b = taylorPolynomial f a n b := by
+    rw [taylor_within_apply]
+    simp only [taylorPolynomial]
+    refine Finset.sum_congr rfl (fun k hk => ?_)
+    have hk' : k ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+    have hcda : ContDiffAt ℝ k f a :=
+      hf.contDiffAt.of_le (by exact_mod_cast Nat.le_succ_of_le hk')
+    rw [iteratedDerivWithin_eq_iteratedDeriv hu hcda hmem, smul_eq_mul]
+    ring
+  obtain ⟨c, hc, heq⟩ :=
+    taylor_mean_remainder_lagrange_iteratedDeriv hab hf.contDiffOn
+  refine ⟨c, hc, ?_⟩
+  rw [hpoly] at heq
+  rw [heq]; ring
 
 /-!
 ## Part III: MVT as First-Order Taylor

--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Taylor, Lagrange (classical)",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MeanValueTheoremOQ02.lean",
     "tags": [
       "calculus",
@@ -15,11 +15,11 @@
       "analysis",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 153,
-    "assumptions": "1 axiom: taylor_lagrange_remainder (converting Mathlib's integral remainder to Lagrange form). 0 sorries.",
+    "axiomCount": 0,
+    "lineCount": 177,
+    "assumptions": "None. taylor_lagrange_remainder is now proved (not axiomatized) by bridging Mathlib's taylor_mean_remainder_lagrange_iteratedDeriv to this file's taylorPolynomial. 0 axioms, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -59,7 +59,7 @@
       "MVT as first-order Taylor (n=0 specialization)",
       "Second-order Taylor with explicit remainder"
     ],
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1
   },
   "overview": {
@@ -213,9 +213,9 @@
       "Set"
     ],
     "namespace": "MeanValueTheoremOQ02",
-    "lineCount": 153,
-    "axiomCount": 1,
-    "theoremCount": 4,
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/MeanValueTheoremOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Discharges the gallery axiom `taylor_lagrange_remainder` in `proofs/Proofs/MeanValueTheoremOQ02.lean`, converting it from an `axiom` into a proved `theorem` with an **identical signature** (so the downstream `mvt_is_first_order_taylor` and `taylor_second_order` corollaries are untouched).

**This file goes from 1 axiom → 0 axioms, 0 sorries.**

## The insight

The axiom's old docstring justified it by claiming the discharge "requires the generalized MVT for integrals / substantial infrastructure." That is **outdated**. Mathlib v4.26.0 already ships:

```lean
lemma taylor_mean_remainder_lagrange_iteratedDeriv {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ}
    (hx : x₀ < x) (hf : ContDiffOn ℝ (n + 1) f (Icc x₀ x)) :
    ∃ x' ∈ Ioo x₀ x, f x - taylorWithinEval f n (Icc x₀ x) x₀ x =
      iteratedDeriv (n + 1) f x' * (x - x₀) ^ (n + 1) / (n + 1)!
```

which already states the Lagrange remainder with the **global** `iteratedDeriv`. No integral form or MVT-for-integrals is needed.

The only remaining gap is a formulation bridge between Mathlib's set-relative Taylor polynomial and this file's global one:

- `taylorWithinEval f n (Icc a b) a b` (built from `iteratedDerivWithin`)  =  `taylorPolynomial f a n b` (built from global `iteratedDeriv`)

proved term-by-term with `taylor_within_apply` + `iteratedDerivWithin_eq_iteratedDeriv`, using `UniqueDiffOn ℝ (Icc a b)` (`uniqueDiffOn_Icc hab`). The gallery's hypothesis is the **global** `ContDiff ℝ (n+1) f`, strictly stronger than Mathlib's `ContDiffOn`, so `hf.contDiffOn` / `hf.contDiffAt` supply every Mathlib hypothesis directly.

## meta.json

- status: `axiomatized` → `verified`
- badge: `axiom` → `mathlib`
- axiomCount: 1 → 0, theoremCount: 4 → 5, lineCount: 153 → 177

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02` — **build-pending**: the Docker build wrapper was unavailable this session, so CI must confirm before merge. Every Mathlib lemma name/signature used was read verbatim from the `v4.26.0` tag of `Mathlib/Analysis/Calculus/Taylor.lean` and `.../IteratedDeriv/Defs.lean`.
- [ ] `pnpm build` (gallery JSON validation: badge `mathlib` and status `verified` are both in the type unions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)