### PR TITLE
Research: pell-equation-oq-05 — Lean cubic-Pell core for ℚ(∛2) (build-pending)

### DIFF
--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -1,0 +1,148 @@
+/-
+Pell's Equation OQ-05: Norm Equations in Number Fields of Degree > 2
+
+Pell's equation x² - D y² = 1 is the norm-one equation
+N_{ℚ(√D)/ℚ}(x + y√D) = 1, whose solution chain is the rank-1 case of Dirichlet's
+unit theorem. This entry studies the degree-3 analogue over K = ℚ(∛2) = ℤ[t]/(t³-2):
+the structure of N_{K/ℚ}(ξ) for ξ ∈ 𝒪_K.
+
+This file formalizes the *concrete algebraic core* — the part that does NOT require
+Mathlib's (heavy, and here bearer-less) signature/Dirichlet machinery:
+
+  1. The cubic norm form  N(a,b,c) = a³ + 2b³ + 4c³ - 6abc  is the determinant of
+     multiplication-by-(a + bt + ct²) on the power basis {1, t, t²} (`cnorm_eq_det`).
+  2. N is multiplicative for the ring ℤ[t]/(t³-2) (`cnorm_cmul`), i.e. it is a genuine
+     norm form — the engine that turns one unit into an infinite solution chain.
+  3. u = t - 1 is a unit of norm 1 with inverse t² + t + 1 (`cmul_u_uinv`, `cnorm_u`).
+  4. **Higher-degree Pell chain**: every power uᵏ has norm 1 (`cnorm_upow`), giving
+     infinitely many solutions of N(ξ) = 1 — the exact analogue of the Pell chain
+     (3,2) → (17,12) → … for x² - 2y² = 1.
+
+What is DEFERRED (the genuinely hard, Mathlib-bearer-less part): identifying the unit
+*rank* r₁ + r₂ - 1 = 1 of 𝒪_K via the signature (r₁,r₂) = (1,1), which needs a
+place-count `card (InfinitePlace K) = 2` for `AdjoinRoot (X³-2)` that Mathlib does not
+ship a decision procedure for. See knowledge.md ("Bearer pin + ACT re-scope").
+
+References:
+- https://erdosproblems.com / Dirichlet's unit theorem
+- Parent entry: `pell-equation` (the rank-1, real-quadratic special case).
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+
+namespace PellEquationOQ05
+
+/-
+## The cubic norm form
+-/
+
+/-- The norm form of K = ℚ(∛2) on the power basis: N(a + bt + ct²), t³ = 2. -/
+def cnorm (a b c : ℤ) : ℤ := a ^ 3 + 2 * b ^ 3 + 4 * c ^ 3 - 6 * a * b * c
+
+/-- The norm form is the determinant of the multiplication-by-(a + bt + ct²) matrix
+    on the power basis {1, t, t²} (columns ξ·1, ξ·t, ξ·t², reduced by t³ = 2).
+    This is the `Algebra.norm` of the element, computed concretely. -/
+theorem cnorm_eq_det (a b c : ℤ) :
+    cnorm a b c = (!![a, 2 * c, 2 * b; b, a, 2 * c; c, b, a]).det := by
+  rw [Matrix.det_fin_three_of]
+  unfold cnorm
+  ring
+
+/-
+## Ring structure of ℤ[t]/(t³ - 2) and multiplicativity
+-/
+
+/-- Multiplication in ℤ[t]/(t³ - 2): reduce (a₀+a₁t+a₂t²)(b₀+b₁t+b₂t²) using t³ = 2. -/
+def cmul (x y : ℤ × ℤ × ℤ) : ℤ × ℤ × ℤ :=
+  (x.1 * y.1 + 2 * (x.2.1 * y.2.2 + x.2.2 * y.2.1),
+   x.1 * y.2.1 + x.2.1 * y.1 + 2 * x.2.2 * y.2.2,
+   x.1 * y.2.2 + x.2.1 * y.2.1 + x.2.2 * y.1)
+
+/-- Norm of a coordinate triple. -/
+def cnorm3 (p : ℤ × ℤ × ℤ) : ℤ := cnorm p.1 p.2.1 p.2.2
+
+/-- **The norm form is multiplicative**: N(ξ·η) = N(ξ)·N(η). This is the structural
+    fact that makes the higher-degree Pell chain work — it is a polynomial identity
+    in the six coordinates, hence closed by `ring`. -/
+theorem cnorm_cmul (x y : ℤ × ℤ × ℤ) : cnorm3 (cmul x y) = cnorm3 x * cnorm3 y := by
+  obtain ⟨a0, a1, a2⟩ := x
+  obtain ⟨b0, b1, b2⟩ := y
+  simp only [cmul, cnorm3, cnorm]
+  ring
+
+/-
+## The fundamental unit and the Pell chain
+-/
+
+/-- The fundamental unit u = t - 1 of ℤ[∛2]. -/
+def u : ℤ × ℤ × ℤ := (-1, 1, 0)
+
+/-- Its inverse, t² + t + 1. -/
+def uinv : ℤ × ℤ × ℤ := (1, 1, 1)
+
+/-- u · u⁻¹ = 1, since (t - 1)(t² + t + 1) = t³ - 1 = 1. -/
+theorem cmul_u_uinv : cmul u uinv = (1, 0, 0) := by decide
+
+/-- u is a unit of norm 1: N(t - 1) = -1 + 2 = 1. -/
+theorem cnorm_u : cnorm3 u = 1 := by decide
+
+/-- The Pell chain uᵏ (u⁰ = 1, uᵏ⁺¹ = uᵏ · u). -/
+def upow : ℕ → ℤ × ℤ × ℤ
+  | 0 => (1, 0, 0)
+  | k + 1 => cmul (upow k) u
+
+/-- **Higher-degree Pell chain**: every power uᵏ has norm 1, so N(ξ) = 1 has
+    infinitely many integral solutions in ℤ[∛2] — the cubic analogue of the
+    Brahmagupta chain for x² - 2y² = 1. -/
+theorem cnorm_upow (k : ℕ) : cnorm3 (upow k) = 1 := by
+  induction k with
+  | zero => decide
+  | succ n ih => rw [upow, cnorm_cmul, ih, cnorm_u]; ring
+
+/-- The first few terms of the chain, matching the classical Pell pattern. -/
+theorem upow_one : upow 1 = (-1, 1, 0) := by decide
+theorem upow_two : upow 2 = (1, -2, 1) := by decide
+theorem upow_three : upow 3 = (1, 3, -3) := by decide
+theorem upow_four : upow 4 = (-7, -2, 6) := by decide
+
+/-
+## Recovering Pell (rank-1 special case)
+
+For comparison, the parent real-quadratic norm form N(p + q√2) = p² - 2q² with its
+fundamental solution (3, 2) and Brahmagupta chain (3,2) → (17,12) → (99,70) → …
+-/
+
+/-- The quadratic (Pell) norm form. -/
+def qnorm (p q : ℤ) : ℤ := p ^ 2 - 2 * q ^ 2
+
+/-- The classical fundamental Pell solution: 3² - 2·2² = 1. -/
+theorem qnorm_fundamental : qnorm 3 2 = 1 := by decide
+
+/-- One Brahmagupta composition step (3,2) ⊕ (3,2) = (17,12), all of norm 1. -/
+theorem qnorm_chain : qnorm 17 12 = 1 ∧ qnorm 99 70 = 1 ∧ qnorm 577 408 = 1 := by
+  refine ⟨?_, ?_, ?_⟩ <;> decide
+
+/-
+## Summary
+
+Pell's equation OQ-05 (norm equations in degree > 2), concrete-core formalization:
+
+1. The cubic norm form N(a,b,c) = a³ + 2b³ + 4c³ - 6abc = det of the multiplication
+   matrix (`cnorm_eq_det`) — the `Algebra.norm` of a + b∛2 + c∛4, computed.
+2. N is multiplicative (`cnorm_cmul`).
+3. u = ∛2 - 1 is a unit of norm 1 (`cnorm_u`, `cmul_u_uinv`).
+4. Every uᵏ has norm 1 (`cnorm_upow`): infinitely many solutions of N(ξ) = 1 — the
+   higher-degree Pell chain. (Distinctness of the uᵏ, hence "infinitely many", holds
+   because |u| < 1 at the real place; the analytic distinctness step is not formalized.)
+
+Deferred (Mathlib-bearer-less): the unit *rank* = 1 via signature (1,1) of ℚ(∛2),
+needing `card (InfinitePlace (AdjoinRoot (X³-2))) = 2`, for which Mathlib ships no
+signature-from-minpoly procedure.
+
+Axiom count: 0
+Sorry count: 0
+-/
+
+end PellEquationOQ05

--- a/research/problems/pell-equation-oq-05/knowledge.md
+++ b/research/problems/pell-equation-oq-05/knowledge.md
@@ -158,3 +158,55 @@ verification de-risk the eventual ACT step.
 3. Recover-Pell lemma: real quadratic $\Rightarrow$ rank 1 (ties to parent).
 4. Cubic norm via `Algebra.norm` / det; verify $N(t-1)=1$.
 5. State finiteness of $N(\xi)=m$ classes via `ClassGroup` finiteness + `Units`.
+
+---
+
+## Session 4 (researcher-5, 2026-06-15) — ACT on the concrete core (build-pending)
+
+**Mode**: continue (ACT; Docker + Aristotle both down again this session).
+**Outcome**: progress — wrote `proofs/Proofs/PellEquationOQ05.lean` formalizing the
+**concrete cubic-Pell core that needs NO signature/Dirichlet machinery**, sidestepping
+the S3 blocker (the bearer-less `card (InfinitePlace K) = 2` place-count). Items 4 and the
+Pell-recovery part of item 3 above are now done in Lean; items 1–2 (rank/signature) remain.
+
+### What I Did
+Wrote a self-contained ℤ-arithmetic file (0 axioms, 0 sorries) over $\mathbb{Z}[t]/(t^3-2)$:
+- `cnorm a b c = a³+2b³+4c³-6abc` and `cnorm_eq_det`: it equals the determinant of the
+  multiplication matrix `!![a,2c,2b; b,a,2c; c,b,a]` (via `Matrix.det_fin_three_of` + `ring`)
+  — i.e. it IS `Algebra.norm` of $a+bt+ct^2$, computed.
+- `cmul`: the explicit ring multiplication (reduce by $t^3=2$); `cnorm_cmul`: **N is
+  multiplicative** (a 6-variable polynomial identity, closed by `ring`).
+- `u=t-1=(-1,1,0)`, `uinv=t²+t+1=(1,1,1)`: `cmul_u_uinv` ($u\,u^{-1}=1$) and `cnorm_u`
+  ($N(u)=1$).
+- `upow k` and **`cnorm_upow : ∀k, cnorm3 (upow k)=1`** (induction via `cnorm_cmul`+`cnorm_u`):
+  the higher-degree Pell chain — infinitely many $N(\xi)=1$ solutions. `upow 1..4` match
+  the S2 values $(-1,1,0),(1,-2,1),(1,3,-3),(-7,-2,6)$.
+- Parent tie-in: `qnorm p q=p²-2q²`, `qnorm_fundamental` (3,2), `qnorm_chain`
+  (17,12),(99,70),(577,408) all norm 1.
+
+### Verification without a build (Docker down)
+- `sympy` confirms every identity exactly: `cnorm_cmul` residual $=0$, det$-$cnorm$=0$,
+  $u\,u^{-1}=(1,0,0)$, $N(u)=1$, and $N(u^k)=1$ for $k\le5$ with the S2 coordinate values.
+
+### Honesty / scope
+- This is the **concrete algebraic core**, deliberately decoupled from `NumberField`/
+  `Algebra.norm` API so it compiles without the blocked place-count. It rigorously
+  establishes multiplicativity + an explicit unit + the infinite norm-1 chain (the actual
+  Pell-analogue payoff). It does **NOT** prove the unit *rank* (= 1 via signature (1,1)),
+  which remains the deferred hard, Mathlib-bearer-less part (S3 §"Bearer pin + ACT re-scope").
+  "Infinitely many" is honest modulo the unstated analytic distinctness of the $u^k$
+  (|u|<1 at the real place); the file states `cnorm_upow` for all $k$, not distinctness.
+- **Build-pending**: no `lake`/Docker available, so compile is unverified. Risk is
+  concentrated in `cnorm_eq_det` (relies on `Matrix.det_fin_three_of`); the ring/decide/
+  induction core is near-certain. Left UNREGISTERED in `Proofs.lean`.
+
+### Files Modified
+- `proofs/Proofs/PellEquationOQ05.lean` (new; build-pending, NOT registered)
+- `research/problems/pell-equation-oq-05/knowledge.md` (this note)
+
+### Next Steps
+- Build once Docker is up: `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ05`.
+  If `Matrix.det_fin_three_of` is misnamed/missing, fall back to
+  `simp [Matrix.det_fin_three]; ring`.
+- The hard rank/signature ACT (S3 items 1–2) is still the open Lean target; attempt under a
+  backend-up session.

--- a/src/data/research/problems/pell-equation-oq-05.json
+++ b/src/data/research/problems/pell-equation-oq-05.json
@@ -1,7 +1,7 @@
 {
   "slug": "pell-equation-oq-05",
   "title": "Norm Equations in Number Fields of Degree > 2",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -21,29 +21,36 @@
       "Norm equation N(xi)=2 solved by xi=t (N(t)=2); the coset t*u^k gives infinitely many solutions in one class mod units (Z[cbrt2] has class number 1).",
       "Classical Pell x^2-2y^2=1 recovered as the rank-1 real-quadratic special case (Brahmagupta chain from (3,2))."
     ],
+    "proven_lean_buildpending": [
+      "PellEquationOQ05.lean (S4, build-pending, unregistered): cnorm_eq_det (norm form = det of mult matrix via Matrix.det_fin_three_of), cnorm_cmul (norm multiplicative, ring), cnorm_u + cmul_u_uinv (u=t-1 unit of norm 1), cnorm_upow (every u^k has norm 1 -> infinite Pell chain, by induction), qnorm Pell-recovery chain."
+    ],
     "open": [
-      "Lean formalization of the rank specialization for a concrete cubic (Docker-gated; no build this session).",
-      "Clean Lean statement of finiteness of N(xi)=m solution classes modulo O_K^x."
+      "Lean rank specialization: prove card(InfinitePlace (AdjoinRoot(X^3-2)))=2 (signature (1,1)) -> rank=1. Mathlib ships NO signature-from-minpoly procedure; this is the bearer-less LOC-dominant step, still deferred.",
+      "Clean Lean statement of finiteness of N(xi)=m solution classes modulo O_K^x.",
+      "Distinctness of the u^k (|u|<1 at the real place) to upgrade cnorm_upow to a literal 'infinitely many' cardinality statement."
     ],
     "goal": "Formalize, for a concrete cubic field (Q(cbrt2)), the unit-group rank and the N(xi)=1 chain via the fundamental unit, plus a general finiteness statement for N(xi)=m solution classes, reusing Mathlib’s Dirichlet unit theorem."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-14T21:05:00-07:00",
-    "iteration": 2,
-    "focus": "ORIENT survey: math structure verified with sympy; Mathlib API located; milestones decomposed into buildable vs Docker-gated.",
-    "blockers": [],
-    "nextAction": "ACT (Docker-gated): write Proofs/PellEquationOQ05.lean instantiating NumberField.Units.rank for Q(cbrt2) and stating norm-equation finiteness.",
+    "phase": "ACT",
+    "since": "2026-06-15",
+    "iteration": 4,
+    "focus": "Wrote PellEquationOQ05.lean (build-pending, unregistered) formalizing the concrete cubic-Pell core that needs no signature/Dirichlet machinery: cubic norm form = det, multiplicativity, fundamental unit t-1, and the inductive norm-1 chain cnorm_upow. Sidesteps the S3 place-count blocker, which stays the open hard Lean target.",
+    "blockers": [
+      "Unit rank via signature: card(InfinitePlace (AdjoinRoot(X^3-2)))=2 has no Mathlib signature-from-minpoly bearer; must hand-wire embeddings<->roots of X^3-2."
+    ],
+    "nextAction": "Build PellEquationOQ05.lean once Docker is up (docker-build.sh Proofs.PellEquationOQ05); then attempt the rank/signature step under a backend-up session.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (ORIENT): structure of the higher-degree norm equation verified from first principles via reproducible sympy script; Mathlib Dirichlet API identified; ACT is Docker-gated.",
+    "progressSummary": "PROGRESS (ACT): wrote PellEquationOQ05.lean (build-pending, unregistered) formalizing the concrete cubic-Pell core — norm form = det, multiplicativity, fundamental unit t-1, and the inductive norm-1 chain cnorm_upow — decoupled from the bearer-less signature/Dirichlet step, which stays the deferred hard target. Identities sympy-verified exactly.",
     "builtItems": [
-      "research/problems/pell-equation-oq-05/verify_norm_equations.py — reproducible sympy verification (all 5 sections pass)."
+      "research/problems/pell-equation-oq-05/verify_norm_equations.py — reproducible sympy verification (all 5 sections pass).",
+      "proofs/Proofs/PellEquationOQ05.lean — (build-pending, unregistered) cnorm/cnorm_eq_det, cmul/cnorm_cmul (multiplicativity), u/uinv/cnorm_u, cnorm_upow (chain norm 1 by induction), qnorm Pell-recovery. 0 axioms, 0 sorries."
     ],
     "insights": [
       "Pell is the signature-(2,0) rank-1 case of Dirichlet; degree>2 raises the unit rank to r1+r2-1, so there can be SEVERAL fundamental units (e.g. totally real cubic x^3-3x-1 has rank 2).",
@@ -57,10 +64,10 @@
       "No off-the-shelf statement packaging finiteness of N(xi)=m solution classes as an O_K^x-orbit count; would need bridging from ClassGroup finiteness + Units."
     ],
     "nextSteps": [
-      "ACT (Docker-gated): instantiate NumberField.Units.rank / rank_modTorsion for K=Q(cbrt2), proving rank = 1 from signature (1,1).",
-      "State recover-Pell lemma: real quadratic => rank 1, matching parent pell-equation.",
-      "Formalize cubic norm form via Algebra.norm / det of mul matrix and verify N(t-1)=1.",
-      "State (not necessarily prove) finiteness of N(xi)=m solution classes using ClassGroup finiteness + Units."
+      "Build PellEquationOQ05.lean: ./proofs/scripts/docker-build.sh Proofs.PellEquationOQ05. Fallback if Matrix.det_fin_three_of is missing: simp [Matrix.det_fin_three]; ring. On green, register import + gallery meta.json (status verified, 0 axioms).",
+      "Hard open Lean target: instantiate NumberField.Units.rank for K=AdjoinRoot(X^3-2), proving rank=1 from card(InfinitePlace K)=2 — needs a hand-built embeddings<->roots-of-X^3-2 place count (no Mathlib bearer).",
+      "Optionally connect cnorm to Algebra.norm (𝓞 K) via the power basis to upgrade the standalone norm form to the genuine field norm.",
+      "State finiteness of N(xi)=m solution classes using ClassGroup finiteness + Units."
     ]
   },
   "tags": [
@@ -82,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T01:25:28.243Z",
-  "lastUpdate": "2026-06-14T21:05:00-07:00",
+  "lastUpdate": "2026-06-15",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Session 4 (ACT) for "Norm Equations in Number Fields of Degree > 2". Formalizes the **concrete higher-degree Pell structure** over K = ℚ(∛2) = ℤ[t]/(t³-2) that needs **no signature/Dirichlet machinery**, deliberately sidestepping the Session-3 blocker (the bearer-less place-count `card (InfinitePlace K) = 2`).

New `proofs/Proofs/PellEquationOQ05.lean` (0 axioms, 0 sorries):
- `cnorm a b c = a³+2b³+4c³-6abc`, proved equal to the determinant of the multiplication-by-(a+bt+ct²) matrix (`cnorm_eq_det`) — the `Algebra.norm` of ℚ(∛2) elements, computed.
- `cmul` = ring multiplication in ℤ[t]/(t³-2); `cnorm_cmul`: **N is multiplicative** (6-variable polynomial identity, by `ring`).
- `u = t-1` is a unit of norm 1 with inverse `t²+t+1` (`cnorm_u`, `cmul_u_uinv`).
- **`cnorm_upow`**: every power `uᵏ` has norm 1 (induction via `cnorm_cmul` + `cnorm_u`) — the cubic analogue of the Pell chain; `u¹..u⁴` match the prior-session values `(-1,1,0),(1,-2,1),(1,3,-3),(-7,-2,6)`.
- Parent tie-in: `qnorm` Pell-recovery chain (3,2)→(17,12)→(99,70)→(577,408).

## Findings
- The norm form, multiplicativity, fundamental unit, and infinite norm-1 chain — the actual Pell payoff — are all pure ring/decide/induction, so they formalize cleanly without the heavy `NumberField` API.
- All identities `sympy`-verified exactly (multiplicativity residual 0, det = cnorm, N(uᵏ)=1).

## Status
**Outcome**: progress (ACT) — **build-pending**. Docker + Aristotle both down this session, so compile is unverified; risk is concentrated in `cnorm_eq_det` (relies on `Matrix.det_fin_three_of`), while the ring/decide/induction core is near-certain. File is intentionally **NOT registered** in the auto-generated `Proofs.lean` to protect the auto-merged main aggregate.

**Deferred (still open)**: the unit *rank* = 1 via signature (1,1), needing `card (InfinitePlace (AdjoinRoot (X³-2))) = 2` — Mathlib ships no signature-from-minpoly procedure (the bearer-less, LOC-dominant step).

**Next Steps**: `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ05` (fallback proof for `cnorm_eq_det`: `simp [Matrix.det_fin_three]; ring`); on green, register + add gallery `meta.json` (status verified, 0 axioms); then attempt the signature/rank step under a backend-up session.

🤖 Generated by researcher-5