### PR TITLE
research(erdos-10-oq-02): S2 — odd cap of 2 is genuine (905), consecutive with even cap (906)

### DIFF
--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -81,6 +81,45 @@ extra power to fix parity before the prime can be odd.
 3. The conjecture itself is open and needs sieve/large-sieve machinery (Gallagher
    line); not within brute-force or near-term Lean reach.
 
+## Session 2 (2026-06-15) — sharpening the parity caps (build-free)
+
+Session 1 noted the +1 offset (odd ≤ 2, even ≤ 3 in range) but framed the odd side
+as *only trivially* in `S_3` and did not check whether **2 powers is ever necessary**
+on odds. `verify_min_powers_parity.py` (pure stdlib, exact sieve, `N = 10^6`) settles
+this and quantifies the offset across the *whole* distribution.
+
+**P1 — the odd cap is genuinely 2, first attained at 905.** The smallest odd `n`
+with `minPowers(n) = 2` is **905 = 5·181**, a *de Polignac number* (odd, composite,
+and not of the form `2^a + prime`). So `S_2` is **not** trivial on odds: there exist
+odd `n ∉ S_1`. Every odd `n ≤ 10^6` (and `≤ 3·10^6`, S1) has `minPowers ≤ 2`.
+
+**P2 — 905 and 906 are consecutive.** Smallest odd needing 2 powers = **905**;
+smallest even needing 3 powers = **906** (S1). The smallest forcing value for each
+parity sits back-to-back — a clean illustration of the +1 offset at the extreme.
+
+**P3 — the offset holds across the entire distribution (approximately).** The even
+`minPowers` distribution is the odd one shifted up by exactly 1, matching to within
+~0.02%:
+
+| k        | 0      | 1      | 2      | 3     |
+|----------|--------|--------|--------|-------|
+| odd  [k] | 78497  | 393538 | 27964  | 0     |
+| even [k] | 1      | 78511  | 393529 | 27959 |
+
+so `even[k] ≈ odd[k−1]` (diffs `+14, −9, −5`). **Mechanism (honest, not an exact
+identity):** `minPowers(2j) ≤ 1 + minPowers(2j−1)` — an even `n` spends one `2^0`
+to repair parity and is left with the odd subproblem on `n−1`. Equality holds
+*usually*; the small deviations come from even `n` that reach the prime `2` directly
+via the even offset `m = n−2`, occasionally beating the +1 route.
+
+**P4 — reading of GS.** The conjectured caps `3` (odd) / `4` (even) are exactly the
+in-range caps `2` / `3` **plus one**. The extra power is a safety margin beyond what
+is forced for `n ≤ 10^6`; the cases that actually force it (Crocker odd `∉ S_2`,
+Grechuk even `1117175146 ∉ S_3`) live far beyond brute force. This is consistent with
+GS but, as in S1, only weak evidence for it.
+
+**Files (S2):** `research/problems/erdos-10-oq-02/verify_min_powers_parity.py` (new).
+
 ## References
 
 - Granville, A.; Soundararajan, K. (1998). *A binary additive problem of Erdős and

--- a/research/problems/erdos-10-oq-02/verify_min_powers_parity.py
+++ b/research/problems/erdos-10-oq-02/verify_min_powers_parity.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Erdős #10 / OQ-02 — Granville–Soundararajan conjecture (k = 3 for odd n).
+
+GS conjecture: every odd n > 1 is a sum of a prime and AT MOST 3 powers of 2
+(n = p + 2^{a_1} + ... + 2^{a_j}, j ≤ 3); the even companion needs ≤ 4. Open.
+
+Reduction lemma (Session 1):  with  minPowers(n) := min number of powers of two
+(repetition allowed) needed so that n − (that sum) is prime, we have
+    n ∈ S_k  ⟺  minPowers(n) ≤ k  ⟺  ∃ m, popcount(m) ≤ k and (n−m) prime,
+because the minimum number of powers of two summing to a fixed m equals popcount(m)
+(carrying 2^a+2^a → 2^{a+1} never increases below the binary representation).
+
+----------------------------------------------------------------------------
+WHAT THIS SESSION ADDS (Session 2 refinement)
+----------------------------------------------------------------------------
+Session 1 observed "every odd n ≤ 3·10^6 ∈ S_2, so S_3 is only TRIVIALLY satisfied
+on the odd side" — but did not check whether 2 powers is ever NECESSARY on odds.
+It is.  This script computes minPowers exactly over both parities and pins the
+in-range CAPS:
+
+  * smallest odd  n with minPowers(n) = 2  is  905  (= 5·181, a *de Polignac
+    number*: odd, composite, and not of the form 2^a + prime).
+  * smallest even n with minPowers(n) = 3  is  906  (Session 1).
+
+So 905 and 906 are CONSECUTIVE: the smallest odd that genuinely needs 2 powers is
+immediately followed by the smallest even that genuinely needs 3.  In range the
+caps are minPowers ≤ 2 (odd) and ≤ 3 (even) — a clean +1 parity offset — and the
+GS conjecture proposes the *true* caps are exactly one larger: 3 (odd) and 4 (even).
+The extra power is the "safety margin" beyond the empirically observed in-range cap,
+and the offset's mechanism is parity: subtracting an even power 2^a (a≥1) from an
+odd n leaves an odd primality candidate, whereas an even n must first spend a power
+to repair parity, costing one extra throughout.
+
+Pure stdlib (sieve of Eratosthenes; no sympy in the hot loop).
+Run:  python3 verify_min_powers_parity.py
+"""
+
+from math import isqrt
+
+# ---------------------------------------------------------------------------
+N = 1_000_000           # sweep bound (Session 1 used 3·10^6 for the odd S_2 claim)
+# ---------------------------------------------------------------------------
+
+def sieve(limit):
+    is_p = bytearray([1]) * (limit + 1)
+    is_p[0] = is_p[1] = 0
+    for i in range(2, isqrt(limit) + 1):
+        if is_p[i]:
+            is_p[i*i::i] = bytearray(len(is_p[i*i::i]))
+    return is_p
+
+print(f"sieving primes up to {N} ...")
+IS_P = sieve(N)
+POWERS = []
+p = 1
+while p <= N:
+    POWERS.append(p)
+    p <<= 1
+# index helpers for popcount-2/3 offsets
+NP = len(POWERS)
+
+def min_powers(n):
+    """minPowers(n): fewest powers of two (popcount of the offset m) with n−m prime,
+    n−m ≥ 2.  Returns 0,1,2,3 or 4+ (4+ means 'needs ≥4 in this search')."""
+    if n >= 2 and IS_P[n]:
+        return 0
+    # k = 1 : offset m = 2^a
+    for m in POWERS:
+        r = n - m
+        if r < 2:
+            break
+        if IS_P[r]:
+            return 1
+    # k = 2 : m = 2^a + 2^b  (a ≥ b)
+    for i in range(NP):
+        pa = POWERS[i]
+        if n - pa < 2:
+            break
+        for j in range(i + 1):
+            r = n - pa - POWERS[j]
+            if r < 2:
+                break
+            if IS_P[r]:
+                return 2
+    # k = 3 : m = 2^a + 2^b + 2^c
+    for i in range(NP):
+        pa = POWERS[i]
+        if n - pa < 2:
+            break
+        for j in range(i + 1):
+            pb = pa + POWERS[j]
+            if n - pb < 2:
+                break
+            for l in range(j + 1):
+                r = n - pb - POWERS[l]
+                if r < 2:
+                    break
+                if IS_P[r]:
+                    return 3
+    return 4  # needs ≥ 4 powers within this search window
+
+def is_de_polignac(n):
+    """odd n that is NOT prime and NOT of the form 2^a + prime  (needs ≥2 powers)."""
+    if n < 2 or n % 2 == 0:
+        return False
+    if IS_P[n]:
+        return False
+    for m in POWERS:
+        r = n - m
+        if r < 2:
+            break
+        if IS_P[r]:
+            return False
+    return True
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("="*74)
+    print("Erdős #10 OQ-02 — minPowers parity caps for Granville–Soundararajan")
+    print("="*74)
+
+    odd_dist = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+    even_dist = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0}
+    first_odd = {}
+    first_even = {}
+
+    print(f"sweeping n = 2 .. {N} (exact minPowers) ...")
+    for n in range(2, N + 1):
+        k = min_powers(n)
+        if n & 1:
+            odd_dist[k] = odd_dist.get(k, 0) + 1
+            if k not in first_odd:
+                first_odd[k] = n
+        else:
+            even_dist[k] = even_dist.get(k, 0) + 1
+            if k not in first_even:
+                first_even[k] = n
+
+    def pct(d):
+        tot = sum(d.values())
+        return {k: f"{100*v/tot:5.2f}%" for k, v in d.items()}
+
+    print()
+    print("ODD  minPowers distribution:", dict(odd_dist))
+    print("       as fractions        :", pct(odd_dist))
+    print("EVEN minPowers distribution:", dict(even_dist))
+    print("       as fractions        :", pct(even_dist))
+    print()
+    print("smallest n by minPowers value:")
+    for k in range(0, 5):
+        print(f"   k={k}:  odd → {first_odd.get(k, '— none in range')}"
+              f"      even → {first_even.get(k, '— none in range')}")
+
+    # ----- headline checks -----
+    print()
+    print("-"*74)
+    print("Headline facts")
+    print("-"*74)
+    odd_cap = max(k for k, v in odd_dist.items() if v > 0)
+    even_cap = max(k for k, v in even_dist.items() if v > 0)
+    print(f"in-range cap:  odd minPowers ≤ {odd_cap}   even minPowers ≤ {even_cap}"
+          f"   (+1 parity offset {'CONFIRMED' if even_cap == odd_cap + 1 else 'NOT seen'})")
+    print(f"smallest odd needing exactly 2 powers : {first_odd.get(2)}"
+          f"   (expected 905; de Polignac = {is_de_polignac(905)}, 905 = 5·181)")
+    print(f"smallest even needing exactly 3 powers: {first_even.get(3)}"
+          f"   (expected 906, Session 1)")
+    print(f"905 & 906 consecutive, caps (2 odd, 3 even) attained back-to-back: "
+          f"{first_odd.get(2) == 905 and first_even.get(3) == 906}")
+
+    # distribution shift: even ≈ odd shifted +1, but only APPROXIMATELY
+    print()
+    print("distribution shift  even[k] vs odd[k-1]  (approximate, NOT an identity):")
+    for k in (1, 2, 3):
+        e = even_dist.get(k, 0); o = odd_dist.get(k - 1, 0)
+        print(f"   even[{k}]={e:>7}  odd[{k-1}]={o:>7}  diff={e-o:+d}")
+    print("   minPowers(2j) ≤ 1 + minPowers(2j-1) (spend 2^0 to fix parity, then the"
+          " odd subproblem), with EQUALITY usually but not always: an even n can also")
+    print("   reach the prime 2 directly via m = n-2 (an even offset), occasionally")
+    print("   beating the +1 route — this is the source of the small count deviations.")
+    # GS conjecture margin
+    print()
+    print(f"GS conjecture caps: 3 (odd) / 4 (even) = in-range caps ({odd_cap}/{even_cap}) + 1"
+          f"   ⇒ the conjectured bound is exactly one power beyond what is forced in range.")
+    print(f"No odd n ≤ {N} needs 3 powers; no even n ≤ {N} needs 4 — "
+          f"consistent with (but far weaker than) GS, whose hard cases (Crocker odd ∉ S_2,")
+    print(f"Grechuk even 1117175146 ∉ S_3) live well beyond brute force.")

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -34,15 +34,17 @@
     "goal": "Decide GS-odd. Near-term realistic target: formalize the popcount reduction lemma and a Decidable membership for sumPrimeAndTwoPows in Lean, enabling decide/native_decide on concrete witnesses."
   },
   "knowledge": {
-    "progressSummary": "ORIENT (build-free; Docker + Lean unavailable). Established the popcount≤k reduction characterizing S_k membership, and ran a reproducible experiment. ODD side: every odd n ≤ 10^6 ∈ S_3, but only trivially — ≤2 powers always suffice in range (no odd n leaves S_2 up to 3·10^6), so direct small-N data is weak evidence for GS-odd; the k=3-over-k=2 necessity (Crocker) lives at scales beyond brute force. EVEN side genuinely exercises S_3: ~5.6% of even n need exactly 3 powers (smallest = 906), all even n ≤ 10^6 ∈ S_3, first known even failure is Grechuk's 1117175146 (∈ S_4, ∉ S_3). The +1-power parity offset between odd and even is visible directly in the data, matching the conjecture's k=3 (odd) vs k=4 (even) structure.",
+    "progressSummary": "ORIENT (build-free; Docker + Lean down). S1: popcount≤k reduction for S_k membership + sweeps. S2 (this session) sharpens the parity caps: the odd cap is GENUINELY 2 (not trivial) — smallest odd needing exactly 2 powers is 905 = 5·181, a de Polignac number (odd composite, not 2^a+prime), and it is CONSECUTIVE with 906 (smallest even needing 3, S1). Moreover the even minPowers distribution is the odd one shifted up by exactly 1, matching to ~0.02% (even[k]≈odd[k-1]); deviations come from even n reaching prime 2 via the even offset m=n-2. GS caps 3(odd)/4(even) = in-range caps 2/3 plus one. The forcing cases (Crocker odd ∉ S_2, Grechuk even 1117175146 ∉ S_3) lie far beyond brute force.",
     "builtItems": [
-      "research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py — stdlib+sympy experiment (odd/even sweeps via the popcount reduction, minimal-#powers distributions, Grechuk check)."
+      "research/problems/erdos-10-oq-02/verify_min_powers_parity.py (S2) — exact stdlib sieve, minPowers over both parities to 10^6; pins smallest n by minPowers value, confirms 905/906 consecutive caps and the approximate +1 distribution shift.",
+      "research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py (S1) — stdlib+sympy experiment (odd/even sweeps, distributions, Grechuk check)."
     ],
     "insights": [
       "S_k membership reduces to popcount(m) ≤ k offsets: n ∈ S_k ⟺ ∃ m with popcount(m) ≤ k and (n−m) prime, n−m ≥ 2.",
-      "Brute force confirms GS-odd only trivially: every odd n ≤ 3·10^6 is already in S_2, so the third power is never needed in range. Crocker's odd ∉ S_2 witnesses are astronomically large.",
-      "The even side is where S_3 is genuinely tested: smallest even n needing exactly 3 powers is 906; ~5.6% of even n need exactly 3; all even n ≤ 10^6 ∈ S_3.",
-      "Parity offset is explicit: in range, odd n need ≤2 powers and even n need ≤3 — the same +1 gap GS conjectures (k=3 odd vs k=4 even). Subtracting one even power from odd n leaves an odd candidate for primality; even n must first spend a power to fix parity.",
+      "S2: the odd cap of 2 is NECESSARY, not trivial — smallest odd needing exactly 2 powers is 905 = 5·181 (a de Polignac number: odd composite, not 2^a+prime). So odd n ∉ S_1 exist.",
+      "S2: 905 (smallest odd needing 2) and 906 (smallest even needing 3) are CONSECUTIVE — the +1 parity offset realized back-to-back at the forcing extremes.",
+      "S2: the even minPowers distribution ≈ the odd one shifted +1 (even[k]≈odd[k-1], match to ~0.02%): minPowers(2j) ≤ 1 + minPowers(2j-1) (spend 2^0 to fix parity, then the odd subproblem); equality usually but not always — even n can reach prime 2 via m=n-2, causing small deviations.",
+      "GS caps 3 (odd) / 4 (even) = in-range caps 2 / 3, plus one safety power; the forcing cases live beyond brute force.",
       "Grechuk's 1117175146 confirmed ∉ S_3 and ∈ S_4 (popcount 16)."
     ],
     "mathlibGaps": [


### PR DESCRIPTION
## Summary

Erdős #10 / OQ-02 = the **Granville–Soundararajan** conjecture (every odd $n>1$ is a prime + at most 3 powers of 2; even companion ≤ 4). **Open.** Session 1 (#24212) gave the popcount reduction and parity sweeps but framed the odd side as *only trivially* in $S_3$. This session sharpens the parity structure with an exact stdlib sieve over both parities to $10^6$.

### Findings
- **The odd cap of 2 is genuine, not trivial.** Smallest odd $n$ with $\mathrm{minPowers}(n)=2$ is $\mathbf{905}=5\cdot181$ — a *de Polignac number* (odd, composite, not $2^a+\text{prime}$). So odd $n\notin S_1$ exist.
- **905 and 906 are consecutive.** Smallest odd needing 2 powers ($905$) is immediately followed by the smallest even needing 3 powers ($906$, S1) — the $+1$ parity offset realized back-to-back at the forcing extremes.
- **The offset holds across the whole distribution (approximately).** The even $\mathrm{minPowers}$ distribution is the odd one shifted up by 1, matching to ~0.02%:

  | k | 0 | 1 | 2 | 3 |
  |---|---|---|---|---|
  | odd[k] | 78497 | 393538 | 27964 | 0 |
  | even[k] | 1 | 78511 | 393529 | 27959 |

  i.e. $\mathrm{even}[k]\approx\mathrm{odd}[k-1]$. **Mechanism (honest, not an exact identity):** $\mathrm{minPowers}(2j)\le 1+\mathrm{minPowers}(2j-1)$ — an even $n$ spends a $2^0$ to fix parity, then solves the odd subproblem on $n-1$; equality usually but not always (even $n$ can reach the prime $2$ via the even offset $m=n-2$, the source of the small deviations $+14,-9,-5$).
- **Reading of GS:** the conjectured caps $3$ (odd) / $4$ (even) are exactly the in-range caps $2/3$ **plus one safety power**; the cases that force the extra power (Crocker odd $\notin S_2$, Grechuk even $1117175146\notin S_3$) live far beyond brute force.

### Honesty
Build-free (Docker/Lean blackout); this is sharper *evidence*, not progress on the open conjecture. The ACT target (Lean: formalize the popcount reduction + `Decidable` membership, discharge 905/906/Grechuk by `decide`) remains backend-gated.

## Files
- `research/problems/erdos-10-oq-02/verify_min_powers_parity.py` (new)
- `research/problems/erdos-10-oq-02/knowledge.md`, `src/data/research/problems/erdos-10-oq-02.json` (S2 section)

## Test plan
- [x] `python3 research/problems/erdos-10-oq-02/verify_min_powers_parity.py` → EXIT 0, reproduces 905/906, distributions, de Polignac check
- [x] JSON validates