### PR TITLE
research(friendship-theorem-oq-04): ACT — locally-finite friendship graphs are finite (spectral-free)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2024-2025 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import Proofs.FriendshipTheorem
+
+/-
+# Friendship Theorem OQ-04: The Infinite Case
+
+## Open Question (friendship-theorem-oq-04)
+
+The finite Friendship Theorem (Erdős–Rényi–Sós 1966) says: if every two distinct
+vertices of a *finite* graph have exactly one common neighbour, then some vertex is
+adjacent to all others (a "universal friend" / politician). The graph is a windmill.
+
+For **infinite** graphs the theorem is **false**: the C₅ free-amalgamation
+construction (Chvátal–Kotzig–Rosenberg–Davies 1976) gives a countable friendship
+graph with no universal vertex; every vertex there has infinite degree.
+
+This file formalizes the *positive* boundary result that pins down exactly which
+extra hypothesis restores the conclusion, **without using the spectral argument**
+that has no infinite analogue:
+
+* `friendship_diameter_two` — every friendship graph (finite **or** infinite) has
+  diameter ≤ 2: any vertex `u ≠ v` is either adjacent to `v` or has a common
+  neighbour with `v`. This is purely local — no finiteness is used.
+
+* `locally_finite_is_finite` — if a friendship graph is **locally finite** (every
+  neighbourhood is finite) then the vertex type is finite. The diameter-2 covering
+  exhibits `V` as a finite union of finite sets. So local finiteness is the *sharp*
+  restoring condition: the sole obstruction to finiteness is an infinite-degree
+  vertex.
+
+* `locally_finite_friendship_has_universal` — combining the above with the finite
+  gallery theorem `FriendshipTheorem.friendship_theorem` recovers a universal
+  vertex for any locally finite friendship graph with at least three vertices.
+
+Where the finite proof breaks: the spectral step
+`FriendshipTheorem.friendship_regular_implies_universal` is entirely finite-matrix
+algebra (trace, finite eigenvalue multiplicities, integrality) and has no infinite
+analogue. The covering argument below bypasses it entirely.
+-/
+
+namespace FriendshipTheoremOQ04
+
+open SimpleGraph
+
+variable {V : Type*} {G : SimpleGraph V}
+
+/-- The (Fintype-free) **friendship property**: every pair of distinct vertices
+has exactly one common neighbour. Definitionally identical to
+`FriendshipTheorem.IsFriendshipGraph`, but stated without a `[Fintype V]`
+assumption so it applies to infinite vertex types. -/
+def IsFriendshipGraph (G : SimpleGraph V) : Prop :=
+  ∀ u v : V, u ≠ v → (G.commonNeighbors u v).ncard = 1
+
+/-- In a friendship graph, any two distinct vertices have at least one common
+neighbour. -/
+theorem exists_common_neighbor (hF : IsFriendshipGraph G) {a b : V} (hab : a ≠ b) :
+    ∃ x, G.Adj a x ∧ G.Adj b x := by
+  obtain ⟨x, hx⟩ := Set.ncard_eq_one.mp (hF a b hab)
+  have hmem : x ∈ G.commonNeighbors a b := by
+    rw [hx]; exact Set.mem_singleton_iff.mpr rfl
+  rw [SimpleGraph.mem_commonNeighbors] at hmem
+  exact ⟨x, hmem.1, hmem.2⟩
+
+/-- **Diameter ≤ 2 (survives infinity).** For any base vertex `v` and any other
+vertex `u`, either `u` is a neighbour of `v`, or `u` and `v` share a common
+neighbour `x` (so `u` is at distance ≤ 2 from `v`). No finiteness is used. -/
+theorem friendship_diameter_two (hF : IsFriendshipGraph G) (v u : V) (huv : u ≠ v) :
+    G.Adj v u ∨ ∃ x, G.Adj v x ∧ G.Adj x u := by
+  by_cases hadj : G.Adj v u
+  · exact Or.inl hadj
+  · obtain ⟨x, hvx, hux⟩ := exists_common_neighbor hF (Ne.symm huv)
+    exact Or.inr ⟨x, hvx, hux.symm⟩
+
+/-- The diameter-2 covering of the vertex set by a base vertex's 2-ball. -/
+theorem univ_subset_two_ball (hF : IsFriendshipGraph G) (v : V) :
+    (Set.univ : Set V) ⊆
+      {v} ∪ G.neighborSet v ∪ (⋃ x ∈ G.neighborSet v, G.neighborSet x) := by
+  intro u _
+  by_cases huv : u = v
+  · exact Or.inl (Or.inl (Set.mem_singleton_iff.mpr huv))
+  · by_cases hadj : G.Adj v u
+    · exact Or.inl (Or.inr ((G.mem_neighborSet v u).mpr hadj))
+    · obtain ⟨x, hvx, hux⟩ := exists_common_neighbor hF (Ne.symm huv)
+      refine Or.inr (Set.mem_biUnion ?_ ?_)
+      · exact (G.mem_neighborSet v x).mpr hvx
+      · exact (G.mem_neighborSet x u).mpr hux.symm
+
+/-- **Local finiteness restores finiteness.** If every neighbourhood of a friendship
+graph is finite, the whole vertex set is finite: the 2-ball covering exhibits it as
+a finite union of finite sets. This is the sharp restoring condition — the only
+obstruction to the infinite theorem is an infinite-degree vertex. -/
+theorem univ_finite_of_locallyFinite (hF : IsFriendshipGraph G)
+    (hfin : ∀ w : V, (G.neighborSet w).Finite) :
+    (Set.univ : Set V).Finite := by
+  rcases isEmpty_or_nonempty V with he | hne
+  · rw [Set.univ_eq_empty_iff.mpr he]; exact Set.finite_empty
+  · obtain ⟨v⟩ := hne
+    have hcover : ({v} ∪ G.neighborSet v ∪
+        (⋃ x ∈ G.neighborSet v, G.neighborSet x)).Finite := by
+      refine Set.Finite.union (Set.Finite.union (Set.finite_singleton v) (hfin v)) ?_
+      exact Set.Finite.biUnion (hfin v) (fun x _ => hfin x)
+    exact hcover.subset (univ_subset_two_ball hF v)
+
+/-- A locally finite friendship graph has a finite vertex type. -/
+theorem locally_finite_is_finite (hF : IsFriendshipGraph G)
+    (hfin : ∀ w : V, (G.neighborSet w).Finite) :
+    Finite V :=
+  Set.finite_univ_iff.mp (univ_finite_of_locallyFinite hF hfin)
+
+/-- **Conclusion restored.** A locally finite friendship graph with at least three
+vertices has a universal vertex — recovered from the finite gallery theorem via the
+finiteness above, with no spectral input on the infinite side. -/
+theorem locally_finite_friendship_has_universal (hF : IsFriendshipGraph G)
+    (hfin : ∀ w : V, (G.neighborSet w).Finite)
+    (a b c : V) (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
+    ∃ z : V, FriendshipTheorem.IsUniversalVertex G z := by
+  haveI : Finite V := locally_finite_is_finite hF hfin
+  classical
+  letI : Fintype V := Fintype.ofFinite V
+  have h3 : 3 ≤ Fintype.card V := by
+    have hcard : ({a, b, c} : Finset V).card = 3 := by
+      rw [Finset.card_eq_three]; exact ⟨a, b, c, hab, hac, hbc, rfl⟩
+    calc 3 = ({a, b, c} : Finset V).card := hcard.symm
+      _ ≤ Fintype.card V := Finset.card_le_univ _
+  exact FriendshipTheorem.friendship_theorem G (fun u v h => hF u v h) h3
+
+end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -1,21 +1,153 @@
 # Knowledge Base: friendship-theorem-oq-04
 
-Insights accumulated during research on this problem.
+**Friendship Theorem for infinite graphs** — where does the finite proof break,
+and what extra condition restores the conclusion?
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Finite Friendship Theorem (Erdős–Rényi–Sós 1966): in a *finite* simple graph in
+which every two distinct vertices have **exactly one** common neighbor, some
+vertex is adjacent to all others (a "politician"); the graph is a windmill
+`W_k` (k triangles sharing a center, `2k+1` vertices).
+
+OQ-04 asks the infinite analogue: pin down (i) that the theorem **fails** for
+infinite graphs, (ii) *exactly which step* of the finite proof breaks, and
+(iii) what extra hypothesis brings the conclusion back.
+
+The gallery's finite proof (`proofs/Proofs/FriendshipTheorem.lean`) is a clean
+two-step reduction:
+- `friendship_has_universal_or_regular` (FriendshipTheorem.lean:179) — dichotomy:
+  universal vertex **or** the graph is `k`-regular. (A³-commutativity gives
+  "non-adjacent ⟹ equal degree"; complement-connectivity propagates it.)
+- `friendship_regular_implies_universal` (FriendshipTheorem.lean:193) — the
+  **spectral / eigenvalue-integrality** argument forcing `k = 2`.
 
 ---
 
-## Insights
+## Insights (Session 1, 2026-06-15 — ORIENT)
 
-[Insights from research attempts will be accumulated here]
+### 1. Counterexample exists (theorem fails for infinite graphs)
+Chvátal–Kotzig–Rosenberg–Davies (Canad. Math. Bull. 19(4), 1976: *"There are
+2^ℵ_α friendship graphs of cardinal ℵ_α"*). Standard construction = **C₅ free
+amalgamation**: start from the 5-cycle; repeatedly add a brand-new private
+common neighbor to every pair that currently has none. The countable limit is a
+friendship graph with **no universal vertex**.
+
+I verified the construction's correctness invariant myself (not just cited):
+adding a fresh `w` adjacent to exactly a zero-common-neighbor pair `{u,v}`
+**preserves** the "linear" property (no pair has ≥2 common neighbors), because
+any other vertex `x` is adjacent to at most one of `{u,v}` (else `x` would
+already be a common neighbor of `u,v`, contradicting zero). So every new pair
+`{w,x}` gets ≤1. Hence the closure converges to a genuine friendship graph.
+`verify_infinite_friendship.py` confirms max-common-neighbors stays = 1 across 4
+rounds (|V| up to 3695), the original C₅ vertices reach exactly-one pairwise, and
+**max degree strictly grows** `[4,5,13,83]` ⟹ the limit is **locally infinite**.
+
+### 2. Diameter ≤ 2 — the lemma that SURVIVES infinity
+For **every** friendship graph (finite or infinite) and any vertex `v`:
+
+    V = {v} ∪ N(v) ∪ ⋃_{x ∈ N(v)} N(x).
+
+Reason: any non-neighbor `u ≠ v` has a unique common neighbor `x` with `v`;
+`x ∈ N(v)` and `u ∈ N(x)`. This is purely local — no finiteness used. Verified
+on windmills `W_1..W_8` and on the amalgamation graph.
+
+### 3. RESTORING CONDITION = local finiteness (sharp)
+From the diameter-2 covering: if **every degree is finite**, then `V` is a finite
+union (`N(v)` finite, each `N(x)` finite) of finite sets ⟹ `V` finite ⟹ (by ERS)
+windmill ⟹ universal vertex. So:
+
+> **A locally finite friendship graph is finite (a windmill); the obstruction to
+> the infinite theorem is *precisely* the existence of an infinite-degree
+> vertex.** Every infinite friendship graph has all (or at least one — in fact,
+> by the covering, infinitely many) vertices of infinite degree.
+
+This is a *more elementary* route than the spectral argument: it bypasses
+eigenvalues entirely (a 2-ball covering bound). Verified the bound
+`|V| ≤ 1 + deg(v) + Σ_{x∈N(v)} deg(x)` on `W_1..W_13`.
+
+### 4. WHERE the finite proof breaks (bearer-pinned)
+- **Dichotomy** `friendship_has_universal_or_regular`
+  (FriendshipTheorem.lean:179): the "non-adjacent ⟹ equal degree" bijection
+  survives only as a **cardinality** statement. When degrees are infinite all
+  are equal (= ℵ₀), so the dichotomy's "regular" branch becomes *vacuous* — it
+  carries no finite arithmetic content. (The C₅-amalgam counterexample is
+  neither universal nor regular, so the dichotomy itself is *false* infinitely.)
+- **Spectral step** `friendship_regular_implies_universal`
+  (FriendshipTheorem.lean:193) — the **hard break**. Its OQ01 engine is entirely
+  finite-matrix algebra:
+  - `adjMatrix_sq_eq`: `A² = (k-1)I + J` (FriendshipTheoremOQ01.lean:363)
+  - `adjMatrix_trace_zero`: `tr A = 0` (OQ01:362)
+  - `trace_adjMatrix_sq`: `tr A² = nk` (OQ01:367) — uses finite `n`
+  - `k_sub_one_is_perfect_square` (OQ01:328) and `k_eq_two_no_axiom` (OQ01:330):
+    integer eigenvalue multiplicities `m₊,m₋` with `k + (m₊−m₋)s = 0` force
+    `k−1 = s²` then `k = 2`.
+  None of trace, finite multiplicities, or eigenvalue integrality has an infinite
+  analogue. This is the irreducible finiteness in the ERS proof.
 
 ---
 
-## Dead Ends
+## Lean target (for a future ACT session, build-gated)
 
-[Approaches known not to work will be documented here]
+The cleanly formalizable infinite-side results, in order of tractability:
+
+1. `friendship_diameter_two`: `∀ v u, u ≠ v → u ∈ N(v) ∨ ∃ x ∈ N(v), u ∈ N(x)`
+   — no `[Fintype V]` needed; pure unfolding of `IsFriendshipGraph` + `ncard=1`.
+2. `locally_finite_friendship_is_finite`: with `[LocallyFinite G]` (each
+   `neighborSet` finite), `Set.Finite (univ : Set V)` via the covering of (1) as
+   a finite union of finite sets (`Set.Finite.biUnion`).
+3. Corollary: combine (2) with the existing finite `friendship_theorem`
+   (needs bridging `Set.Finite` → `Fintype`) to get a universal vertex under
+   local finiteness — the "conclusion restored" statement.
+
+(1)+(2) are `< 150` lines and **finiteness-light**; good Aristotle/ACT targets
+once the build backend is available.
+
+---
+
+## Session 2 (2026-06-15 — ACT, build-pending)
+
+Transcribed the ORIENT plan into Lean: **`proofs/Proofs/FriendshipTheoremOQ04.lean`**
+(new file, namespace `FriendshipTheoremOQ04`, unregistered in `Proofs.lean` while
+the build backend is down — registering a possibly-erroring file into the
+auto-merged aggregator would break `main` for everyone).
+
+Contents (all spectral-free, finiteness-light):
+- `IsFriendshipGraph` — the `ncard (commonNeighbors) = 1` property *without*
+  `[Fintype V]`; definitionally equal to `FriendshipTheorem.IsFriendshipGraph`.
+- `exists_common_neighbor` — `ncard = 1 ⟹` a witness via `Set.ncard_eq_one`.
+- `friendship_diameter_two` — `u ≠ v ⟹ G.Adj v u ∨ ∃ x, G.Adj v x ∧ G.Adj x u`.
+- `univ_subset_two_ball` — `univ ⊆ {v} ∪ N(v) ∪ ⋃_{x∈N(v)} N(x)`.
+- `univ_finite_of_locallyFinite` / `locally_finite_is_finite` — local finiteness
+  `⟹ (univ).Finite ⟹ Finite V`, via `Set.Finite.biUnion` over the covering.
+- `locally_finite_friendship_has_universal` — capstone: bridge `Finite → Fintype`
+  (`Fintype.ofFinite`), card `≥ 3` from three distinct vertices
+  (`Finset.card_eq_three` + `Finset.card_le_univ`), then apply the finite
+  `FriendshipTheorem.friendship_theorem`. Coercion of the friendship hypothesis is
+  the identity lambda (definitional equality of the two `IsFriendshipGraph`s).
+
+**Verification status**: NOT machine-checked — Docker build host and Aristotle
+backend both unavailable this session (Aristotle `prove` returns 404; `docker info`
+times out). Proofs were written for high static compile-confidence and audited by
+hand against in-repo lemma usages. Names to re-confirm at build time:
+`Set.finite_univ_iff`, `Set.univ_eq_empty_iff`, `Set.Finite.biUnion` arity.
+
+This is the **positive half** of OQ-04 (sharp restoring condition). The negative
+half (formalizing the C₅-amalgamation infinite counterexample) remains open.
+
+## Dead Ends / Non-starters
+- Trying to recover the theorem via *regularity* alone fails: infinite degrees
+  are all "equal" as cardinals, so regularity is vacuously satisfiable without a
+  universal vertex (the amalgam is a witness).
+- The spectral argument has no salvageable infinite generalization (no trace).
+
+---
+
+## References
+- P. Erdős, A. Rényi, V. T. Sós, *On a problem of graph theory*, Studia Sci.
+  Math. Hungar. 1 (1966).
+- V. Chvátal, A. Kotzig, I. G. Rosenberg, R. O. Davies, *There are 2^ℵ_α
+  friendship graphs of cardinal ℵ_α*, Canad. Math. Bull. 19(4) (1976) 431–433.
+- *Degrees of vertices in a friendship graph*, Canad. Math. Bull. (1976).

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -1,0 +1,126 @@
+{
+  "slug": "friendship-theorem-oq-04",
+  "title": "The Friendship Theorem for Infinite Graphs",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Does } \\forall\\, u \\neq v,\\ |N(u)\\cap N(v)| = 1 \\ \\text{force a universal vertex when } V(G) \\text{ is infinite?}",
+    "plain": "The friendship theorem says: in a finite \"everyone-shares-exactly-one-mutual-friend\" social network, there must be one person who is friends with everybody (a politician). For infinite networks this *fails* — you can build endless friend-of-a-friend structures with no universal politician. The task is to pin down, in Lean, exactly where the finite proof breaks and what extra conditions bring the conclusion back.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-14T22:54:16-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ACT (build-pending): wrote FriendshipTheoremOQ04.lean — diameter-2 covering + locally-finite=>finite + universal-vertex capstone, the spectral-free positive result. Unregistered until a build backend confirms (dual blackout). Counterexample direction still open.",
+    "builtItems": [
+      "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
+      "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
+      "friendship_diameter_two (FriendshipTheoremOQ04.lean:71): every friendship graph has diameter <=2 (G.Adj v u OR common neighbor x), no Fintype.",
+      "univ_subset_two_ball (:79): univ subset {v} U N(v) U bigUnion_{x in N(v)} N(x) via exists_common_neighbor.",
+      "univ_finite_of_locallyFinite (:96) + locally_finite_is_finite (:109): local finiteness => Finite V via Set.Finite.biUnion of the 2-ball covering.",
+      "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices."
+    ],
+    "insights": [
+      "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
+      "Adding a private common neighbor to a zero-common-neighbor pair {u,v} preserves the linear invariant (<=1 common neighbor per pair): any other x is adjacent to at most one of u,v, else x would already be a common neighbor of u,v.",
+      "Diameter<=2 holds for EVERY friendship graph (finite or infinite): V = {v} U N(v) U union_{x in N(v)} N(x). Purely local, survives infinity.",
+      "RESTORING CONDITION = local finiteness: the diameter-2 covering makes V a finite union of finite sets => finite => windmill => universal vertex. Obstruction is precisely an infinite-degree vertex.",
+      "WHERE finite proof breaks: spectral step friendship_regular_implies_universal (FriendshipTheorem.lean:193) is entirely finite-matrix (trace, finite eigenvalue multiplicities, integrality) with no infinite analogue. The regularity dichotomy degrades to vacuous (all infinite degrees equal as cardinals).",
+      "ACT: the positive OQ-04 result is finiteness-light and spectral-free — the diameter-2 covering (purely local) plus local finiteness gives Finite V directly, bypassing the trace/eigenvalue step that has no infinite analogue.",
+      "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting."
+    ],
+    "mathlibGaps": [
+      "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."
+    ],
+    "nextSteps": [
+      "BUILD VERIFY (gated): once Docker/Aristotle backend is up, ./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04, then register import in proofs/Proofs.lean after line 2322.",
+      "Lower-confidence lemma names to confirm at build: Set.finite_univ_iff, Set.univ_eq_empty_iff, Set.Finite.biUnion arity, Set.mem_biUnion.",
+      "Optional: formalize the C5-free-amalgamation infinite counterexample (the negative direction) — harder, needs an inductive/colimit construction of the vertex type."
+    ],
+    "markdown": "# Knowledge Base: friendship-theorem-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "graph-theory",
+    "combinatorics",
+    "friendship-theorem",
+    "infinite-graphs",
+    "spectral-methods"
+  ],
+  "relatedProofs": [
+    "friendship-theorem",
+    "friendship-theorem-oq-01",
+    "friendship-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-14T22:54:16-07:00",
+  "significance": 6,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/FriendshipTheorem.lean",
+      "filename": "FriendshipTheorem.lean",
+      "lineCount": 374,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheorem.lean"
+    },
+    {
+      "path": "Proofs/FriendshipTheoremOQ01.lean",
+      "filename": "FriendshipTheoremOQ01.lean",
+      "lineCount": 2276,
+      "theoremCount": 74,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/FriendshipTheoremOQ02.lean",
+      "filename": "FriendshipTheoremOQ02.lean",
+      "lineCount": 378,
+      "theoremCount": 11,
+      "axiomCount": 1,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FriendshipTheoremOQ03.lean",
+      "filename": "FriendshipTheoremOQ03.lean",
+      "lineCount": 308,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **positive half** of the infinite Friendship Theorem question (`friendship-theorem-oq-04`) in a new file `proofs/Proofs/FriendshipTheoremOQ04.lean`. The finite Erdős–Rényi–Sós theorem is **false** for infinite graphs (C₅ free-amalgamation counterexample); this PR pins down the **sharp restoring condition** — local finiteness — *without* the spectral argument that has no infinite analogue.

New file, namespace `FriendshipTheoremOQ04`, with a Fintype-free `IsFriendshipGraph` (definitionally equal to the finite `FriendshipTheorem.IsFriendshipGraph`):

- `friendship_diameter_two` — every friendship graph (finite **or** infinite) has diameter ≤ 2. Purely local; no finiteness used.
- `univ_subset_two_ball` — `univ ⊆ {v} ∪ N(v) ∪ ⋃_{x∈N(v)} N(x)` (the 2-ball covering).
- `univ_finite_of_locallyFinite` / `locally_finite_is_finite` — **local finiteness ⟹ `Finite V`**, via `Set.Finite.biUnion` over the covering. Bypasses the trace/eigenvalue step entirely.
- `locally_finite_friendship_has_universal` — capstone: restores a universal vertex by bridging `Finite → Fintype` (`Fintype.ofFinite`) and applying the finite gallery theorem `FriendshipTheorem.friendship_theorem`.

**Math takeaway:** the sole obstruction to the infinite theorem is an infinite-degree vertex. A *locally finite* friendship graph is forced to be a finite windmill.

## Verification status (build-pending)

Docker build host and the Aristotle backend were both unavailable this session (`docker info` times out; Aristotle `prove` returns 404). The proofs were written for high static compile-confidence and hand-audited against in-repo lemma usages.

**Intentionally NOT registered in `proofs/Proofs.lean`** — registering a not-yet-built file into the auto-merged aggregator could break `main` for everyone. Once a build backend is available:
1. `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04`
2. add `import Proofs.FriendshipTheoremOQ04` to `proofs/Proofs.lean` (after the OQ03 import).

Lemma names to re-confirm at build: `Set.finite_univ_iff`, `Set.univ_eq_empty_iff`, `Set.Finite.biUnion` arity.

## Still open

The **negative direction** (formalizing the C₅-amalgamation infinite counterexample as a concrete `SimpleGraph`) remains open — it needs an inductive/colimit construction of the vertex type.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` (blocked: backend down)
- [ ] Register import in `proofs/Proofs.lean` once the build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)