### PR TITLE
research(descartes-rule-of-signs-oq-02-oq-03): S1 ORIENT — pin the real budan_parity route + certify decomposition

### DIFF
--- a/research/problems/descartes-rule-of-signs-oq-02-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-03/knowledge.md
@@ -1,0 +1,110 @@
+# Knowledge Base: descartes-rule-of-signs-oq-02-oq-03
+
+Seeker task: **"Close the `budan_parity` axiom via Mathlib's FTA."**
+
+---
+
+## Problem Understanding
+
+`proofs/Proofs/DescartesRuleOfSignsOQ02.lean` formalizes **Budan's theorem** with a 3-axiom
+budget (`budan_upper_bound`, `budan_parity`, `budanCount_large`). The target axiom
+(`DescartesRuleOfSignsOQ02.lean:244`):
+
+```
+axiom budan_parity_axiom (p : ℝ[X]) (hp : p ≠ 0) (a b : ℝ) (hab : a < b) :
+    Even (budanCount p a - budanCount p b - rootsInInterval p a b)   -- ℕ-subtraction
+```
+
+where (file defs):
+- `budanCount p x := signChangesInList (budanSequence p p.natDegree x)` — sign changes (zeros
+  dropped) in the derivative-evaluation sequence `[p(x), p'(x), …, p⁽ⁿ⁾(x)]` (`:181`).
+- `rootsInInterval p a b` — `#{real roots in (a,b]}` with multiplicity (`:203`).
+The truncated subtraction is well-defined because `budan_upper_bound` gives
+`rootsInInterval ≤ budanCount a − budanCount b`.
+
+---
+
+## Session 2026-06-15 (S1, researcher-2) — ORIENT: correct route pinned, seeker framing refined
+
+**Mode:** FRESH (knowledge score 0). **Both backends down** (Docker `docker info` times out;
+Aristotle MCP `prove` → `"Resource not found"` on a trivial ping). Build-free: numerical
+verify-before-assert + Mathlib bearer audit at the repo pin (`lean-toolchain` v4.26.0,
+mathlib rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).
+
+### The big finding: Mathlib HAS Descartes' rule — but only the BOUND, not the parity
+
+`Mathlib/Algebra/Polynomial/RuleOfSigns.lean` exists at the pin and proves
+**`Polynomial.roots_countP_pos_le_signVariations`** (`:382`): `P.roots.countP (0 < ·) ≤
+signVariations P` — the Descartes **upper bound**, with `signVariations P :=
+(nonzero_signs.destutter (· ≠ ·)).length - 1` (`:50`). A grep of that file for
+`even`/`odd`/`parity` returns **nothing** — Mathlib does **not** prove the parity refinement.
+This exactly mirrors the in-file split: Mathlib's `roots_countP_pos_le_signVariations` ↔ this
+file's `budan_upper_bound`; the parity half is unformalized **both** upstream and here. So
+`budan_parity` is a genuine gap, not duplicable from Mathlib.
+
+### The seeker's "via FTA / complex conjugate pairs" is the GLOBAL intuition; the local interval
+### parity has a cleaner, formalizable route (numerically certified, 288/288 — `verify_budan_parity.py`)
+
+The "non-real roots come in conjugate pairs" picture is the standard hand-wave for the *global*
+Descartes count. The *local* `(a,b]` parity decomposes more cleanly:
+
+- **(A) Mathlib bridge.** `budanCount p x = signVariations (taylor x p)`. The Taylor coefficients
+  of `p(X+x)` are `p⁽ᵏ⁾(x)/k!` — same **signs** as `p⁽ᵏ⁾(x)`, so the two sign-change counts
+  coincide. (`Polynomial.taylor` ∈ `Mathlib/Algebra/Polynomial/Taylor.lean`.) This is optional —
+  one may instead reprove parity directly on the in-file `signChangesInList` (see P1 below),
+  avoiding the bridge entirely.
+- **(B) Parity-of-sign-variations is an ENDPOINT fact.** `signVariations` is `destutter`-length−1;
+  a destuttered ±1 list `[s₀,…,s_m]` is strictly alternating, so `s_m = s₀·(−1)^m`, hence
+  `parity(length−1) = parity(m) = [s₀ ≠ s_m]` = (first nonzero sign ≠ last nonzero sign). For the
+  derivative sequence: first entry `= p(x)`; last entry `= p⁽ⁿ⁾(x) = n!·leadingCoeff p` (degree
+  `n`), which is **sign-constant in x**. Therefore
+  **`parity(budanCount p x) = [sign(p(x)) ≠ sign(leadingCoeff p)]`** (when `p(x) ≠ 0`).
+- **(C)** Cancelling the common `sign(leadingCoeff p)`:
+  **`parity(budanCount p a) ⊕ parity(budanCount p b) = [sign p(a) ≠ sign p(b)]`**.
+- **(D) The genuine FTA content.** `[sign p(a) ≠ sign p(b)] ⟺ Odd(rootsInInterval p a b)`. Via
+  the real factorization `p = leadingCoeff · ∏_{real rᵢ}(X−rᵢ) · ∏(positive-definite quadratics)`:
+  `sign p(a)·sign p(b) = ∏_{real r} sign((a−r)(b−r)) = (−1)^{#real roots in (a,b) w/ mult}`
+  (complex pairs are positive on ℝ; even multiplicities don't flip parity). With `p(a),p(b) ≠ 0`
+  the half-open `(a,b]` count has the same parity as `(a,b)`.
+
+(A)+(B)+(C)+(D) ⇒ `budanCount p a − budanCount p b ≡ rootsInInterval p a b (mod 2)`, i.e. the
+axiom. Certificate `verify_budan_parity.py` (numpy; 288 cases over real-root multisets ×
+complex pairs × leading signs × endpoints) asserts (A),(B),(C),(D) **and** the axiom
+`Even(V_a−V_b−N)` directly, plus reconfirms the upper bound `N ≤ V_a−V_b`. All pass.
+
+### Formalization plan (the honest difficulty split)
+
+| Step | Statement | Difficulty | Mathlib support |
+|------|-----------|-----------|-----------------|
+| **P1** | `parity(signChangesInList l) = (firstNonzeroSign l ≠ lastNonzeroSign l)` | elementary list induction on `countAdjacentDiffs` (~40–70 LOC) | none needed (self-contained); `List.destutter` analogue if going through Mathlib |
+| **P2** | last Budan entry `= n!·leadingCoeff` (sign-constant); first `= p(x)` ⇒ `parity(budanCount p x) = [sign p(x) ≠ sign lead]` | moderate (~30–50 LOC) | `iterDeriv` (in-file), `Polynomial.iterate_derivative_eq_factorial…`/`leadingCoeff` |
+| **P3** | `[sign p(a) ≠ sign p(b)] ⟺ Odd(rootsInInterval p a b)` | **the real work** (~100–150 LOC) | `Polynomial.roots`, `Polynomial.eval`-as-product, `Multiset.countP`, sign-of-product over roots |
+
+**P1, P2 are routine and Mathlib-light; P3 is where the FTA/factorization content lives.**
+`budan_parity` is therefore **NOT** a one-liner corollary of Mathlib's RuleOfSigns (which only
+gives the bound), but it IS reducible to P1+P2+P3, with P3 the genuine theorem. This refutes the
+optimistic "close via Mathlib's FTA" reading — Mathlib's FTA helps **P3 only**, and even there
+it is the factorization machinery (not a packaged parity lemma) that carries it.
+
+**Build status:** no Lean written (dual blackout; P1/P2 are blind-authorable with moderate
+confidence but P3's `roots`-product sign argument needs a live build to iterate). The remaining
+two axioms (`budan_upper_bound`, `budanCount_large`) are out of scope for this OQ; note
+`budan_upper_bound` ↔ Mathlib's `roots_countP_pos_le_signVariations` is itself a candidate
+reduction for a sibling session.
+
+### Mathlib bearers pinned @ rev `2df2f01` / v4.26.0
+- `Polynomial.signVariations` + `Polynomial.roots_countP_pos_le_signVariations` —
+  `Mathlib/Algebra/Polynomial/RuleOfSigns.lean:50,382` (the BOUND; parity absent).
+- `Polynomial.taylor` — `Mathlib/Algebra/Polynomial/Taylor.lean` (the (A) bridge).
+- `List.destutter` — `Mathlib/Data/List/Destutter.lean` (the (B) parity engine, if going via Mathlib).
+- `Polynomial.roots` / `Multiset.countP` / eval-as-product — for P3.
+
+## Dead Ends / Refuted
+
+- **"`budan_parity` is a direct corollary of Mathlib's Descartes (`RuleOfSigns.lean`)."** No —
+  Mathlib proves only the inequality `countP_pos ≤ signVariations`, never the parity. (S1, by
+  reading the file at the pin.)
+- **"Parity follows from complex-conjugate-pair counting (FTA)."** This is the *global* picture
+  and obscures the cleaner endpoint route (B)+(C). The interval parity needs (D)'s real-root
+  factorization sign argument, for which conjugate pairs are simply *irrelevant* (they never
+  change `sign p` on ℝ). (S1.)

--- a/research/problems/descartes-rule-of-signs-oq-02-oq-03/verify_budan_parity.py
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-03/verify_budan_parity.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+S1 ORIENT (researcher-2) for descartes-rule-of-signs-oq-02-oq-03:
+"Close the `budan_parity` axiom".
+
+The axiom (DescartesRuleOfSignsOQ02.lean:244) states, for p ≠ 0 and a < b:
+    Even (budanCount p a - budanCount p b - rootsInInterval p a b)   [ℕ-subtraction]
+where budanCount p x = #sign-changes in [p(x), p'(x), …, p⁽ⁿ⁾(x)]
+and   rootsInInterval p a b = #real roots in (a,b] with multiplicity.
+
+The seeker named this "close via Mathlib's FTA / complex-conjugate pairs".
+That intuition is for the GLOBAL Descartes count; the LOCAL interval parity has a
+cleaner route, which this script certifies (verify-before-assert) before any Lean:
+
+  (A) budanCount p x = signVariations(taylor x p)   [the Mathlib bridge:
+      taylor coeffs are p⁽ᵏ⁾(x)/k!, same signs as p⁽ᵏ⁾(x)].
+  (B) PARITY of a sign-variation count = (sign of leading coeff ≠ sign of the
+      lowest-degree nonzero coeff).  For Q = taylor x p: leadingCoeff Q =
+      leadingCoeff p (shift-invariant) and constant term Q.coeff 0 = p(x).
+      ⇒ parity(budanCount p x) = [sign(p(x)) ≠ sign(leadingCoeff p)].
+  (C) ⇒ parity(budanCount p a) ⊕ parity(budanCount p b) = [sign p(a) ≠ sign p(b)].
+  (D) [sign p(a) ≠ sign p(b)] ⟺ Odd(rootsInInterval p a b)   [the FTA content:
+      real factorization p = lead·∏(x−rᵢ)·(pos. quadratics); each real root in
+      (a,b) flips the sign, complex pairs and even multiplicities don't change parity].
+  ⇒ (A–D) give  V_p(a) − V_p(b) ≡ N (mod 2), i.e. the axiom.
+
+Requires numpy (uses numpy.polynomial). Pure-deterministic seeds (no RNG state
+leakage). Exits non-zero on any mismatch.
+Run:  python3 verify_budan_parity.py
+"""
+
+import itertools
+import numpy as np
+from numpy.polynomial import polynomial as P
+
+
+def sign(x, tol=1e-9):
+    if x > tol:
+        return 1
+    if x < -tol:
+        return -1
+    return 0
+
+
+def sign_changes(vals, tol=1e-9):
+    s = [sign(v, tol) for v in vals if abs(v) > tol]
+    return sum(1 for i in range(len(s) - 1) if s[i] != s[i + 1])
+
+
+def coeffs_low_to_high(roots, lead, extra_complex_pairs):
+    """Build a real polynomial from given real roots (with multiplicity), a
+    leading coefficient sign, and some conjugate complex pairs (irreducible
+    positive-definite quadratics x^2 - 2*Re*x + |z|^2 with no real root)."""
+    # start from lead
+    c = np.array([float(lead)])
+    for r in roots:
+        c = P.polymul(c, [-r, 1.0])  # (x - r)
+    for (re, im) in extra_complex_pairs:
+        # (x-(re+i*im))(x-(re-i*im)) = x^2 - 2 re x + (re^2+im^2)
+        c = P.polymul(c, [re * re + im * im, -2 * re, 1.0])
+    return c  # low-to-high
+
+
+def iter_deriv_evals(c_low_high, x):
+    """[p(x), p'(x), ..., p^(n)(x)] via repeated polyder."""
+    out = []
+    c = c_low_high.copy()
+    while len(c) >= 1 and not (len(c) == 1 and abs(c[0]) == 0):
+        out.append(float(P.polyval(x, c)))
+        if len(c) == 1:
+            break
+        c = P.polyder(c)
+    # ensure we include the final constant derivative even if loop ended early
+    return out
+
+
+def budan_count(c_low_high, x):
+    n = len(c_low_high) - 1
+    vals = [float(P.polyval(x, P.polyder(c_low_high, k))) for k in range(n + 1)]
+    return sign_changes(vals)
+
+
+def taylor_shift(c_low_high, x):
+    """coeffs (low->high) of p(X + x)."""
+    n = len(c_low_high) - 1
+    # taylor coeff k = p^(k)(x)/k!
+    out = []
+    fk = 1.0
+    for k in range(n + 1):
+        if k > 0:
+            fk *= k
+        out.append(float(P.polyval(x, P.polyder(c_low_high, k))) / fk)
+    return np.array(out)
+
+
+def signVariations(c_low_high):
+    # Mathlib's signVariations = sign changes in the coefficient list (zeros dropped)
+    return sign_changes(list(c_low_high))
+
+
+def roots_in_interval(real_roots, a, b):
+    # half-open (a, b], with multiplicity
+    return sum(1 for r in real_roots if a < r <= b)
+
+
+def main():
+    checks = 0
+    # deterministic catalogue of real-root multisets + complex pairs + leads
+    real_root_sets = [
+        [], [0.5], [-1.0, 2.0], [1.0, 1.0], [0.3, 0.3, 0.3],
+        [-2.0, -0.5, 1.5, 3.0], [0.7, 0.7, 2.2], [-1.5, -1.5, -1.5, 4.0],
+        [0.1, 0.9, 1.1, 2.5, 2.5], [-3.0, -1.0, 0.0, 2.0, 4.0],
+    ]
+    complex_sets = [[], [(0.5, 1.0)], [(-1.0, 0.7), (2.0, 0.3)]]
+    leads = [1.0, -2.5]
+    # endpoints chosen to avoid sitting on roots
+    endpoints = [(-2.7, 0.45), (-0.6, 1.05), (0.05, 2.45), (-4.0, 4.0), (0.65, 2.15)]
+
+    for rr, cs, lead in itertools.product(real_root_sets, complex_sets, leads):
+        c = coeffs_low_to_high(rr, lead, cs)
+        for (a, b) in endpoints:
+            pa, pb = float(P.polyval(a, c)), float(P.polyval(b, c))
+            if abs(pa) < 1e-7 or abs(pb) < 1e-7:
+                continue  # endpoint on a root: classical Budan excludes this
+            Va, Vb = budan_count(c, a), budan_count(c, b)
+            N = roots_in_interval(rr, a, b)
+
+            # (A) budanCount = signVariations(taylor)
+            assert Va == signVariations(taylor_shift(c, a)), f"(A) fail a: {rr},{cs},{lead},{a}"
+            assert Vb == signVariations(taylor_shift(c, b)), f"(A) fail b"
+
+            # (B) parity(budanCount p x) = [sign p(x) != sign lead]
+            lead_sign = sign(c[-1])
+            assert (Va % 2 == 1) == (sign(pa) != lead_sign), f"(B) fail a: {rr},{cs},{lead},{a}"
+            assert (Vb % 2 == 1) == (sign(pb) != lead_sign), f"(B) fail b"
+
+            # (C) parity(Va) xor parity(Vb) = [sign pa != sign pb]
+            assert ((Va % 2) ^ (Vb % 2) == 1) == (sign(pa) != sign(pb)), "(C) fail"
+
+            # (D) [sign pa != sign pb] <-> Odd(N)
+            assert (sign(pa) != sign(pb)) == (N % 2 == 1), f"(D) fail: {rr},{a},{b},N={N}"
+
+            # MAIN: the axiom itself — Even(Va - Vb - N) with TRUNCATED nat subtraction,
+            # matching the Lean statement (and the proven upper bound Va >= Vb,
+            # rootsInInterval <= Va - Vb).
+            nat_sub = max(Va - Vb, 0)
+            nat_sub2 = max(nat_sub - N, 0)
+            # the upper bound guarantees N <= Va - Vb, so nat-sub == true difference here:
+            assert Vb <= Va, f"upper-bound violated?! Va={Va} Vb={Vb}"
+            assert N <= Va - Vb, f"bound violated N={N} Va-Vb={Va-Vb}"
+            assert nat_sub2 % 2 == 0, f"AXIOM fail Even(Va-Vb-N): Va={Va},Vb={Vb},N={N}"
+            checks += 1
+
+    print(f"All {checks} checks passed.")
+    print("Certified the budan_parity decomposition (verify-before-assert):")
+    print("  (A) budanCount p x = signVariations(taylor x p)   [Mathlib bridge via Polynomial.taylor]")
+    print("  (B) parity(budanCount p x) = [sign p(x) != sign(leadingCoeff p)]")
+    print("  (C) parity(V_a) xor parity(V_b) = [sign p(a) != sign p(b)]")
+    print("  (D) [sign p(a) != sign p(b)] <-> Odd(rootsInInterval p a b)   [real-factorization/FTA]")
+    print("  => Even(V_a - V_b - N): the budan_parity axiom. Also reconfirmed N <= V_a - V_b.")
+    print("Mathlib has signVariations + roots_countP_pos_le_signVariations (the BOUND) but NOT parity.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

S1 ORIENT on the axiom-elimination task **"Close the `budan_parity` axiom"**
(`DescartesRuleOfSignsOQ02.lean:244`). Build-free (dual backend blackout: Docker
`docker info` times out; Aristotle MCP `prove` → `Resource not found`).

**Key findings:**

- **Mathlib has Descartes' rule — but only the BOUND, not the parity.**
  `Mathlib/Algebra/Polynomial/RuleOfSigns.lean` proves
  `roots_countP_pos_le_signVariations` (the inequality) and contains **no**
  `even`/`odd`/`parity` lemma. So `budan_parity` is a genuine gap, not duplicable
  upstream — mirroring the in-file split (`budan_upper_bound` ↔ Mathlib's bound;
  parity unformalized both places).

- **The seeker's "via FTA / conjugate pairs" is the *global* intuition.** The
  local `(a,b]` parity has a cleaner, formalizable route, certified numerically
  (288/288, `verify_budan_parity.py`):
  - (A) `budanCount p x = signVariations(taylor x p)` [Mathlib bridge via `Polynomial.taylor`];
  - (B) `parity(signVariations) = [first nonzero sign ≠ last nonzero sign]`, and the
    last Budan entry is `n!·leadingCoeff` (sign-constant) ⇒
    `parity(budanCount p x) = [sign p(x) ≠ sign(leadingCoeff p)]`;
  - (C) ⇒ `parity(V_a) ⊕ parity(V_b) = [sign p(a) ≠ sign p(b)]`;
  - (D) `[sign p(a) ≠ sign p(b)] ⟺ Odd(rootsInInterval p a b)` [the real-root
    factorization — the genuine FTA content; conjugate pairs are *irrelevant*].

- **Formalization split (honest difficulty):** P1 (parity-of-sign-changes list
  lemma) and P2 (last-entry sign) are routine/Mathlib-light; **P3** (the
  `[sign p(a)≠sign p(b)] ⟺ Odd(N)` factorization) is the real ~100–150 LOC work.
  So `budan_parity` is **not** a one-line corollary of Mathlib's RuleOfSigns;
  Mathlib's FTA helps P3 only, and there as factorization machinery, not a
  packaged parity lemma.

Bearers pinned @ rev `2df2f01` / v4.26.0 in `knowledge.md`. No Lean written
(blackout; P3 needs a live build to iterate the `roots`-product sign argument).

## Test plan
- [x] `python3 verify_budan_parity.py` exits 0 (288 cases: A, B, C, D + the axiom `Even(V_a−V_b−N)` + bound `N ≤ V_a−V_b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)