### PR TITLE
research(divisibility-truncation-general-oq-01-oq-01): combined osculator test for divisors sharing factors with 10

### DIFF
--- a/proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean
+++ b/proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean
@@ -1,0 +1,141 @@
+/-
+# Combined Osculator Test for Divisors Sharing Factors with 10
+
+Open Question (from `divisibility-truncation-general-oq-01`):
+  Can the osculator divisibility test be extended to divisors `d` that *share*
+  factors with 10 (e.g. d = 2, 4, 8, 5, 25, 6, 12, 14, ...) by combining it with
+  the "last-k-digits" framework?
+
+Answer: **YES**, via the Chinese Remainder Theorem.
+
+Write `d = D · m` where:
+  * `D` collects the 2- and 5-parts of `d`, so `D ∣ 10^k` for `k = max v₂(d) v₅(d)`;
+  * `m` is coprime to 10 (`gcd(m, 10) = 1`), the osculator-testable part.
+
+Since `gcd(D, m) = 1`, CRT gives `d ∣ n ↔ D ∣ n ∧ m ∣ n`. The first conjunct is
+decided by the last `k` digits (`D ∣ n ↔ D ∣ n % 10^k`, because `D ∣ 10^k`); the
+second by the Unified Osculator Theorem (`DivisibilityTruncationGeneralOQ01`)
+applied to `m`.
+
+That such a decomposition `d = D · m` exists for every `d > 0` is the fundamental
+theorem of arithmetic (take `D = 2^{v₂(d)} · 5^{v₅(d)}` and `m = d / D`). Here we
+formalize the *test itself* as a theorem parametrized by the decomposition, the
+two structural lemmas it rests on, and worked instances (d = 6, 12, 14).
+-/
+
+import Proofs.DivisibilityTruncationGeneralOQ01
+import Mathlib.Tactic
+
+open Nat
+
+namespace CombinedOsculator
+
+-- ============================================================================
+-- Part I: Last-k-digits test for the 2,5-part
+-- ============================================================================
+
+/-- **Last-k-digits test.** If `D ∣ 10^k`, then divisibility by `D` is decided by
+    the last `k` decimal digits of `n`, i.e. by `n % 10^k`.
+
+    This is the standard rule "a number is divisible by `2^a` (resp. `5^b`) iff its
+    last `max a b` digits are", stated for any `D` dividing a power of ten. -/
+theorem dvd_iff_dvd_mod_pow (D n k : ℕ) (hD : D ∣ 10 ^ k) :
+    D ∣ n ↔ D ∣ n % 10 ^ k := by
+  have hmterm : D ∣ 10 ^ k * (n / 10 ^ k) := hD.mul_right _
+  have hsplit : 10 ^ k * (n / 10 ^ k) + n % 10 ^ k = n := Nat.div_add_mod n (10 ^ k)
+  constructor
+  · intro h
+    have hsub : D ∣ n - 10 ^ k * (n / 10 ^ k) := Nat.dvd_sub' h hmterm
+    have heq : n - 10 ^ k * (n / 10 ^ k) = n % 10 ^ k := by omega
+    rwa [heq] at hsub
+  · intro h
+    have hsum := dvd_add hmterm h
+    rwa [hsplit] at hsum
+
+-- ============================================================================
+-- Part II: CRT split for coprime factors
+-- ============================================================================
+
+/-- **Chinese Remainder Theorem (divisibility form).** If `gcd(D, m) = 1`, then
+    `D · m ∣ n ↔ D ∣ n ∧ m ∣ n`. -/
+theorem dvd_mul_iff_of_coprime {D m : ℕ} (hcop : Nat.Coprime D m) (n : ℕ) :
+    D * m ∣ n ↔ D ∣ n ∧ m ∣ n := by
+  constructor
+  · intro h
+    exact ⟨(dvd_mul_right D m).trans h, (dvd_mul_left m D).trans h⟩
+  · rintro ⟨h1, h2⟩
+    exact hcop.mul_dvd_of_dvd_of_dvd h1 h2
+
+-- ============================================================================
+-- Part III: The Combined Osculator Theorem
+-- ============================================================================
+
+/-- **Combined Osculator Theorem.**
+
+    Let `d = D · m` with
+      * `D ∣ 10^k`           (D built from the 2- and 5-parts of d),
+      * `gcd(D, m) = 1`,
+      * `gcd(m, 10) = 1`     (m the osculator-testable part), and
+      * osculator `c` for `m`, i.e. `m ∣ 10c - 1`.
+
+    Then divisibility by `d` is decided by combining the last-`k`-digits test on
+    `D` with the osculator test on `m`:
+
+      `d ∣ n  ↔  (D ∣ n % 10^k)  ∧  ((m : ℤ) ∣ n/10 + c·(n%10))`.
+
+    This answers the open question: the osculator framework extends to **all**
+    divisors, not only those coprime to 10. -/
+theorem combined_osculator (D m k : ℕ) (c : ℤ) (n : ℕ)
+    (hD : D ∣ 10 ^ k)
+    (hcopDm : Nat.Coprime D m)
+    (hcop10 : IsCoprime (m : ℤ) 10)
+    (hc : (m : ℤ) ∣ 10 * c - 1) :
+    D * m ∣ n ↔
+      (D ∣ n % 10 ^ k) ∧ ((m : ℤ) ∣ (↑(n / 10) + c * ↑(n % 10))) := by
+  have hm : m ∣ n ↔ (m : ℤ) ∣ (↑(n / 10) + c * ↑(n % 10)) := by
+    rw [← Int.natCast_dvd_natCast]
+    exact UnifiedOsculator.unified_osculator m c n hcop10 hc
+  rw [dvd_mul_iff_of_coprime hcopDm n, dvd_iff_dvd_mod_pow D n k hD, hm]
+
+-- ============================================================================
+-- Part IV: Worked instances
+-- ============================================================================
+
+/-- d = 6 = 2 · 3. The 2-part needs the last digit (k = 1); the 3-part uses
+    osculator c = 1 (since 3 ∣ 10·1 - 1 = 9). -/
+theorem six_combined (n : ℕ) :
+    6 ∣ n ↔ (2 ∣ n % 10) ∧ ((3 : ℤ) ∣ (↑(n / 10) + ↑(n % 10))) := by
+  have h := combined_osculator 2 3 1 1 n (by norm_num) (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide)) ⟨3, by norm_num⟩
+  simpa using h
+
+/-- d = 12 = 4 · 3. The 4-part needs the last *two* digits (k = 2); the 3-part
+    uses osculator c = 1. -/
+theorem twelve_combined (n : ℕ) :
+    12 ∣ n ↔ (4 ∣ n % 100) ∧ ((3 : ℤ) ∣ (↑(n / 10) + ↑(n % 10))) := by
+  have h := combined_osculator 4 3 2 1 n (by norm_num) (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide)) ⟨3, by norm_num⟩
+  simpa using h
+
+/-- d = 14 = 2 · 7. The 2-part uses the last digit (k = 1); the 7-part uses
+    osculator c = 5 (since 7 ∣ 10·5 - 1 = 49). -/
+theorem fourteen_combined (n : ℕ) :
+    14 ∣ n ↔ (2 ∣ n % 10) ∧ ((7 : ℤ) ∣ (↑(n / 10) + 5 * ↑(n % 10))) := by
+  have h := combined_osculator 2 7 1 5 n (by norm_num) (by decide)
+    (Int.isCoprime_iff_gcd_eq_one.mpr (by decide)) ⟨7, by norm_num⟩
+  simpa using h
+
+-- ============================================================================
+-- Part V: Sanity checks
+-- ============================================================================
+
+example : 6 ∣ 312 := by native_decide
+example : 12 ∣ 144 := by native_decide
+example : 14 ∣ 98 := by native_decide
+example : ¬ (6 ∣ 100) := by native_decide
+
+#check @combined_osculator
+#check @dvd_iff_dvd_mod_pow
+#check @dvd_mul_iff_of_coprime
+
+end CombinedOsculator

--- a/src/data/research/problems/divisibility-truncation-general-oq-01-oq-01.json
+++ b/src/data/research/problems/divisibility-truncation-general-oq-01-oq-01.json
@@ -1,0 +1,76 @@
+{
+  "slug": "divisibility-truncation-general-oq-01-oq-01",
+  "title": "Combined Osculator Test for Divisors Sharing Factors with 10",
+  "status": "in-progress",
+  "phase": "ACT",
+  "significance": 4,
+  "tier": "B",
+  "tractability": 8,
+  "tags": [
+    "seeker-selected",
+    "algebra",
+    "divisibility",
+    "number-theory"
+  ],
+  "path": "fast",
+  "problemStatement": {
+    "formal": "theorem combined_osculator (D m k : ℕ) (c : ℤ) (n : ℕ) (hD : D ∣ 10 ^ k) (hcopDm : Nat.Coprime D m) (hcop10 : IsCoprime (m : ℤ) 10) (hc : (m : ℤ) ∣ 10 * c - 1) : D * m ∣ n ↔ (D ∣ n % 10 ^ k) ∧ ((m : ℤ) ∣ (↑(n / 10) + c * ↑(n % 10)))",
+    "plain": "Can the osculator divisibility test be extended to divisors d that share factors with 10 (e.g. 2, 4, 8, 5, 25, 6, 12, 14) by combining it with the last-k-digits framework? YES, via CRT: write d = D*m with D | 10^k (the 2,5-part) and gcd(m,10)=1 (the osculator part); test D by the last k digits and m by the osculator rule.",
+    "whyMatters": [
+      "Extends the osculator framework from divisors coprime to 10 to ALL positive divisors",
+      "Shows the last-k-digits rule and the osculator rule are CRT-orthogonal components of one test",
+      "Provides a reusable Lean recipe: dvd_iff_dvd_mod_pow (last-k-digits) + dvd_mul_iff_of_coprime (CRT split)"
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean",
+      "filename": "DivisibilityTruncationGeneralOQ01OQ01.lean",
+      "lineCount": 142,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "divisibility-truncation-general",
+    "divisibility-truncation-general-oq-01",
+    "divisibility-truncation-general-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Divisibility_rule"
+    ],
+    "mathlib": [
+      "Int.natCast_dvd_natCast",
+      "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+      "Int.isCoprime_iff_gcd_eq_one",
+      "Nat.dvd_sub'",
+      "Nat.div_add_mod"
+    ]
+  },
+  "started": "2026-06-15T00:00:00.000Z",
+  "lastUpdate": "2026-06-15T00:00:00.000Z",
+  "knowledge": {
+    "progressSummary": "ACT (build-pending, docker blackout): answered YES via CRT. New file proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean (namespace CombinedOsculator) ships 3 structural theorems + 3 worked instances, 0 axioms / 0 sorries. Core: combined_osculator decomposes d = D*m and proves d|n iff (D | n % 10^k) and the osculator test on m, by chaining dvd_mul_iff_of_coprime (CRT divisibility split) and dvd_iff_dvd_mod_pow (last-k-digits test, D | 10^k) with the parent UnifiedOsculator.unified_osculator on the coprime-to-10 part m. Instances: six_combined (6=2*3), twelve_combined (12=4*3, k=2), fourteen_combined (14=2*7, c=5). All three iff-statements numerically verified over n<20000 (Python). NOT registered in Proofs.lean and NOT build-verified (docker-build.sh host hangs / docker info times out this cycle) - needs a build + registration pass before claiming verified.",
+    "builtItems": [
+      "dvd_iff_dvd_mod_pow (D n k : ℕ) (hD : D ∣ 10^k) : D ∣ n ↔ D ∣ n % 10^k  -- last-k-digits test",
+      "dvd_mul_iff_of_coprime (hcop : Nat.Coprime D m) (n) : D*m ∣ n ↔ D ∣ n ∧ m ∣ n  -- CRT divisibility form",
+      "combined_osculator (D m k c n ...) : D*m ∣ n ↔ (D ∣ n % 10^k) ∧ ((m:ℤ) ∣ ↑(n/10)+c*↑(n%10))  -- main",
+      "six_combined / twelve_combined / fourteen_combined  -- worked instances for 6, 12, 14"
+    ],
+    "mathlibGaps": [
+      "None needed for the test mechanism: all lemmas are standard (CRT divisibility, Nat.div_add_mod, cast-dvd).",
+      "The general decomposition 'every d>0 = D*m with D|10^k, gcd(m,10)=1' is FTA (Nat.factorization at primes 2,5); left documented rather than formalized this cycle to keep the build-pending file high-confidence."
+    ],
+    "nextSteps": [
+      "Build via ./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneralOQ01OQ01 once docker is back, then register in proofs/Proofs.lean.",
+      "Optional follow-up: formalize the existence of the d = D*m decomposition for every d>0 via Nat.factorization, turning combined_osculator into a self-contained per-d test.",
+      "Optional: generalize to an arbitrary base b in place of 10 (osculator part coprime to b, prime-power part dividing b^k)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Answers the open question from `divisibility-truncation-general-oq-01`: **can the osculator divisibility test be extended to divisors `d` that share factors with 10?** Yes — via the Chinese Remainder Theorem.

Write `d = D · m` where `D` collects the 2- and 5-parts (`D ∣ 10^k`) and `m` is coprime to 10. Then:

`d ∣ n  ↔  (D ∣ n % 10^k)  ∧  ((m : ℤ) ∣ n/10 + c·(n%10))`

— the `D`-part by the last-`k`-digits rule, the `m`-part by the existing Unified Osculator Theorem.

## Files
- **New** `proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean` (namespace `CombinedOsculator`), 6 theorems, **0 axioms / 0 sorries**:
  - `dvd_iff_dvd_mod_pow` — last-`k`-digits test (`D ∣ 10^k ⟹ (D ∣ n ↔ D ∣ n % 10^k)`)
  - `dvd_mul_iff_of_coprime` — CRT divisibility split
  - `combined_osculator` — the main combined test
  - `six_combined` (6=2·3), `twelve_combined` (12=4·3, k=2), `fourteen_combined` (14=2·7, c=5)
- **New** `src/data/research/problems/divisibility-truncation-general-oq-01-oq-01.json` — knowledge tracking.

## Findings
- The last-`k`-digits rule and the osculator rule are **CRT-orthogonal components** of one divisibility test; combining them covers every positive divisor, not just those coprime to 10.
- The required machinery is all standard Mathlib (`Int.natCast_dvd_natCast`, `Nat.Coprime.mul_dvd_of_dvd_of_dvd`, `Nat.div_add_mod`, `Nat.dvd_sub'`).
- The existence of the decomposition `d = D·m` for every `d>0` is FTA (factor at primes 2,5); documented rather than formalized this cycle to keep the file high-confidence under the build blackout.
- All three instance iff-statements numerically verified over `n < 20000`.

## Status
**Outcome**: progress (ACT) — **build-pending**. `./proofs/scripts/docker-build.sh` could not run this cycle (docker host hangs / `docker info` times out). The file is **not yet registered** in `proofs/Proofs.lean`; it should be built and registered before being marked verified.

**Next Steps**: build + register once docker is back; optionally formalize the `d = D·m` existence via `Nat.factorization`, and generalize to an arbitrary base `b`.

🤖 Generated by researcher-5