### PR TITLE
Research: arithmetic-series multiset Vandermonde — S2 close-out (already verified)

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/knowledge.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/knowledge.md
@@ -28,3 +28,29 @@
 - Verify build succeeds
 - If build fails, fix errors and rebuild
 - Commit, push, create PR
+
+## Session 2026-06-15 (Session 2) — verification + close-out
+
+**Mode**: REVISIT
+**Outcome**: COMPLETED (no churn to the proof — already shipped and verified)
+
+### What I Did
+- The Session 1 "next step: verify build" was stale. The Lean file
+  `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean` is **already merged to `main`** and was
+  audited clean in #22746 (commit d8284214ed0), so it builds. It is registered in
+  `Proofs.lean` (line 147).
+- Re-audited the proof logic by hand. The engine lemma `sum_succ_left` is correct:
+  peel j=0 from both range(r+2) sums (each j=0 term is `mc n (r+1)`, a shared atom),
+  align indices via `r+1-(j+1) = r-j`, expand `mc(m+1)(j+1) = mc m (j+1) + mc(m+1) j`
+  via `multichoose_succ_succ`, distribute with `sum_add_distrib`, close by `ring`.
+  Main theorem's double induction wiring is sound.
+- Confirmed all Mathlib lemma names (`multichoose_succ_succ`, `multichoose_zero_right`,
+  `multichoose_zero_succ`, `multichoose_eq`) are valid at our pin — the audit-passed
+  sibling `…OQ03.lean` uses the identical names.
+- Confirmed gallery `meta.json` is complete: `status: verified`, `badge: original`,
+  `axiomCount: 0`, `sorries: 0`, `theoremCount: 3` (2 lemmas + 1 theorem).
+  `annotations.json` present.
+
+### Conclusion
+Problem is fully solved, verified, and in the gallery. No genuine residual work.
+Marked COMPLETED to stop the pool from re-serving a finished entry.

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-21T12:53:48.289Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-06-15
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+None — problem is solved and shipped.
 
 ## Active Approach
 
-None yet.
+Double induction on m (generalizing r) and r. Complete.
 
 ## Blockers
 
@@ -18,10 +18,11 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+None. The proof is merged to `main` (audit-clean #22746), 0 axioms / 0 sorries,
+and the gallery entry is fully populated (status `verified`, badge `original`).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1


### PR DESCRIPTION
## Summary
Close-out session for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02` (Multiset Vandermonde Identity). The proof was already complete and shipped — this PR only updates the stale research tracker so the candidate pool stops re-serving a finished problem.

## Findings
- The Lean proof `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean` (multiset Vandermonde: `multichoose(m+n,r) = Σ_j multichoose(m,j)·multichoose(n,r-j)`) is **already merged to `main`**, audit-clean (#22746), registered in `Proofs.lean:147`, with **0 axioms / 0 sorries**.
- Gallery `meta.json` is fully populated: `status: verified`, `badge: original`, `axiomCount: 0`, `theoremCount: 3` (2 lemmas + 1 theorem). `annotations.json` present.
- Re-audited the proof by hand: the `sum_succ_left` decomposition (peel j=0, align `r+1-(j+1)=r-j`, expand via `multichoose_succ_succ`, distribute, close by `ring`) and the double-induction wiring of `multiset_vandermonde` are sound.
- Confirmed the Mathlib lemma names (`multichoose_succ_succ`, `multichoose_zero_right`, `multichoose_zero_succ`) are valid at our pin — the audit-passed sibling `…OQ03.lean` uses the identical names.

## Status
**Outcome**: completed — no churn to the proof; tracker (state.md/knowledge.md) marked COMPLETED.
**Next Steps**: none.

🤖 Generated by researcher-2