### PR TITLE
research(erdos-733-oq-01): S3 ORIENT — first explicit UPPER constant on λ via dyadic Szemerédi–Trotter

### DIFF
--- a/research/problems/erdos-733-oq-01/verify_upper_constant.py
+++ b/research/problems/erdos-733-oq-01/verify_upper_constant.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+r"""
+Erdős #733 OQ-01 — Session 3 (ORIENT, upper side).
+
+Sessions 1 (#24199) and 2 (#24269) produced *lower* bounds on
+    λ = lim_{n→∞} log f(n) / √n
+(f(n) = number of distinct line-compatible sequences of n points in R²):
+    S1: λ ≥ π√(2/3) ≈ 2.5651  (disjoint generic lines = partitions into parts ≥3)
+    S2: λ_grid ∈ [π√(2/3), 2π/√3]  (generic grid, Gale–Ryser)
+Both flagged the UPPER constant as the genuinely hard, never-attempted half:
+the gallery only encodes "∃ C>0, f(n) ≤ exp(C√n)" with no explicit C.
+
+This script supplies the first EXPLICIT finite upper constant on the true λ,
+via a dyadic Szemerédi–Trotter product bound, and checks numerically that the
+bound really scales as exp(C√n) (no spurious log factor).
+
+----------------------------------------------------------------------------
+THE ARGUMENT (upper bound on f(n))
+----------------------------------------------------------------------------
+A line-compatible sequence is the sorted multiset of point-counts over rich
+lines (≥2 points). Every pair of points lies on exactly one rich line, so
+    Σ_{k≥2} C(k,2)·m_k = C(n,2)    exactly,                    (pair identity)
+where m_k = #{lines with exactly k points}. Hence m_2 is determined by
+(m_3, m_4, …), and
+    f(n) = #{ realizable vectors (m_3, m_4, …, m_n) }.
+
+Upper bound by an independent product over DYADIC multiplicity scales.
+For j ≥ 1 let the scale-j block be the multiplicities k ∈ [2^j, 2^{j+1}) ∩ [3,n],
+of width w_j = |block|, and let M_j = Σ_{k in block} m_k (number of lines whose
+multiplicity lands in that block). Two rigorous caps on M_j:
+
+  (pair cap, elementary) every such line has ≥ C(2^j,2) disjoint pairs, so
+      M_j ≤ C(n,2) / C(2^j, 2).
+  (ST cap)  Szemerédi–Trotter: the number of lines with ≥ k points is
+      t_{≥k} ≤ A·n²/k³ + B·n/k,     A = 8 c₀³,  B = 4,
+  where c₀ is any valid incidence constant in I(P,L) ≤ c₀(|P||L|)^{2/3}+|P|+|L|.
+  (Derivation of A,B from c₀ is standard: m·k ≤ I ≤ c₀(nm)^{2/3}+n+m ⇒ either
+   m ≤ 8c₀³ n²/k³ or m ≤ 4n/k or k ≤ 4.)
+
+Given M_j lines distributed among w_j multiplicity-values, the number of
+distinct scale-j sub-vectors is at most C(M_j + w_j, w_j). The full vector is
+the concatenation of independent blocks, so
+      f(n) ≤ Π_j C(M_j + w_j, w_j),
+      log f(n) ≤ Σ_j log C(M_j + w_j, w_j)  =:  S(n).            (★)
+
+CLAIM (verified below): S(n) = Θ(√n) with an explicit constant — i.e. the
+k³ tail of ST collapses the pair-budget's exp(Θ(n^{2/3})) down to exp(Θ(√n)),
+giving an explicit finite upper bound λ ≤ C.
+
+The closed form for the rate (continuum limit of (★), Σ_j ≈ (1/ln2)∫·ds/s) uses
+      ∫₀^∞ ln(1+u^{-2}) du = π,        ∫₀^∞ ln(1+v^{-4}) dv = π√2,
+together with the symmetric binomial bound
+      ln C(a+b,b) ≤ b·ln(1+a/b) + a·ln(1+b/a).
+"""
+
+import math
+from math import log, sqrt, pi, lgamma, comb
+
+# --------------------------------------------------------------------------
+# Part A. The two definite-integral identities driving the closed form.
+# --------------------------------------------------------------------------
+
+def numint(f, a, b, N=200000):
+    """Composite-Simpson on [a,b]."""
+    if N % 2: N += 1
+    h = (b - a) / N
+    s = f(a) + f(b)
+    for i in range(1, N):
+        s += (4 if i % 2 else 2) * f(a + i*h)
+    return s * h / 3
+
+def tail_int(g):
+    r"""∫_0^∞ g(u) du via u = t/(1-t) (maps [0,∞)→[0,1), tames the 1/u^p tail)."""
+    def h(t):
+        if t >= 1.0: return 0.0
+        u = t / (1.0 - t)
+        return g(u) / (1.0 - t)**2
+    return numint(h, 1e-12, 1.0 - 1e-12, 400000)
+
+print("="*70)
+print("Part A — definite-integral identities")
+print("="*70)
+I1 = tail_int(lambda u: log(1 + 1/u**2))
+I2 = tail_int(lambda v: log(1 + 1/v**4))
+print(f"  ∫₀^∞ ln(1+1/u²) du = {I1:.6f}   (π        = {pi:.6f})  err {abs(I1-pi):.2e}")
+print(f"  ∫₀^∞ ln(1+1/v⁴) dv = {I2:.6f}   (π√2      = {pi*sqrt(2):.6f})  err {abs(I2-pi*sqrt(2)):.2e}")
+# companion integrals appearing in the symmetric-binomial continuum limit
+J1 = tail_int(lambda u: (1/u**2)*log(1 + u**2))
+J2 = tail_int(lambda v: (1/v**4)*log(1 + v**4))
+print(f"  ∫₀^∞ u⁻²ln(1+u²) du = {J1:.6f}   (π        = {pi:.6f})")
+print(f"  ∫₀^∞ v⁻⁴ln(1+v⁴) dv = {J2:.6f}   (= π√2/(?) — companion term, no clean")
+print(f"                                    closed form needed for the bound)")
+
+# --------------------------------------------------------------------------
+# Part B. The rigorous discrete product bound S(n) and its √n rate.
+# --------------------------------------------------------------------------
+
+def log_binom(a, b):
+    """log C(a+b, b) for nonnegative reals via lgamma (a,b ≥ 0)."""
+    if b <= 0 or a <= 0:
+        return 0.0
+    return lgamma(a + b + 1) - lgamma(a + 1) - lgamma(b + 1)
+
+def S(n, c0=2.5):
+    """Upper bound (★) on log f(n) via dyadic Szemerédi–Trotter."""
+    A = 8 * c0**3
+    B = 4.0
+    pairs = n*(n-1)/2.0
+    total = 0.0
+    j = 1
+    while 2**j <= n:
+        lo = 2**j
+        hi = min(2**(j+1) - 1, n)
+        # multiplicity values in this block that are ≥ 3 (the ≥3-part)
+        klo = max(lo, 3)
+        if klo > hi:
+            j += 1; continue
+        w = hi - klo + 1                      # block width (coordinates)
+        # caps on number of lines with multiplicity ≥ lo
+        st_cap   = A * n*n / lo**3 + B * n / lo
+        pair_cap = pairs / (lo*(lo-1)/2.0)    # = C(n,2)/C(lo,2)
+        Mj = max(0.0, min(st_cap, pair_cap))
+        total += log_binom(Mj, w)
+        j += 1
+    return total
+
+print()
+print("="*70)
+print("Part B — discrete product bound  S(n) ≥ log f(n);  rate test S(n)/√n")
+print("="*70)
+print(f"  {'n':>12} {'S(n)':>14} {'S(n)/√n':>12} {'S(n)/n^{2/3}':>14} {'S/(√n·ln n)':>14}")
+prev = None
+for e in range(3, 13):           # n = 10^3 .. 10^12
+    n = 10**e
+    s = S(n)
+    r_sqrt = s / sqrt(n)
+    r_23   = s / n**(2/3)
+    r_log  = s / (sqrt(n) * log(n))
+    print(f"  {n:>12} {s:>14.1f} {r_sqrt:>12.4f} {r_23:>14.6f} {r_log:>14.6f}")
+    prev = r_sqrt
+
+print()
+print("  Interpretation:")
+print("  - If S(n)/√n → const and S(n)/n^{2/3} → 0, the bound is exp(Θ(√n)):")
+print("    ST's k³ tail collapses the pair-budget exp(Θ(n^{2/3})) to exp(Θ(√n)).")
+print("  - If S(n)/(√n·ln n) → const instead, a log factor survives (weaker).")
+
+# --------------------------------------------------------------------------
+# Part C. Pair-budget-ONLY bound (control): should grow like n^{2/3}.
+# --------------------------------------------------------------------------
+def S_paironly(n):
+    pairs = n*(n-1)/2.0
+    total = 0.0
+    j = 1
+    while 2**j <= n:
+        lo = 2**j; hi = min(2**(j+1)-1, n)
+        klo = max(lo,3)
+        if klo > hi: j+=1; continue
+        w = hi-klo+1
+        Mj = pairs/(lo*(lo-1)/2.0)
+        total += log_binom(Mj, w)
+        j += 1
+    return total
+
+print()
+print("="*70)
+print("Part C — control: pair-budget-only bound should be exp(Θ(n^{2/3}))")
+print("="*70)
+print(f"  {'n':>12} {'S_pair':>14} {'/√n':>12} {'/n^{2/3}':>14}")
+for e in range(3, 11):
+    n = 10**e
+    s = S_paironly(n)
+    print(f"  {n:>12} {s:>14.1f} {s/sqrt(n):>12.4f} {s/n**(2/3):>14.6f}")
+print("  (pair-only /√n should DIVERGE while /n^{2/3} stabilizes — confirming")
+print("   that the k³ ST tail, not pair-counting, is what yields the √n rate.)")
+
+# --------------------------------------------------------------------------
+# Part D. Explicit upper constant C and the two-sided bracket on λ.
+# --------------------------------------------------------------------------
+print()
+print("="*70)
+print("Part D — explicit upper constant and two-sided bracket on λ")
+print("="*70)
+lower = pi*sqrt(2/3)
+for c0 in (1.0, 1.27, 2.5):
+    # empirical rate at large n (well into the √n regime)
+    C_emp = S(10**11, c0=c0) / sqrt(10**11)
+    print(f"  c₀={c0:<4}  A=8c₀³={8*c0**3:>8.2f}  ⇒  λ ≤ C ≈ {C_emp:6.3f}")
+print(f"\n  LOWER (S1, rigorous):  λ ≥ π√(2/3) = {lower:.4f}")
+print(f"  ⇒ first explicit two-sided bracket on the TRUE λ:  {lower:.3f} ≤ λ ≤ C")
+print("    (C loose — ST incidence constant c₀ not optimised; the POINT is")
+print("     that C is finite and explicit, opening the upper side for S1/S2.)")
+print("\nDONE.")


### PR DESCRIPTION
## Summary

Erdős #733 OQ-01 asks for the value of $\lambda=\lim\log f(n)/\sqrt n$ ($f(n)$ = number of *line-compatible sequences* of $n$ points in $\mathbb R^2$), known only to be $\exp(\Theta(\sqrt n))$. **Open.** Sessions 1 (#24199, merged) and 2 (#24269, open) both bounded λ only from **below** ($\lambda\ge\pi\sqrt{2/3}$; grid $\lambda_{\mathrm{grid}}\in[\pi\sqrt{2/3},2\pi/\sqrt3]$). This session attacks the never-tried **upper** half flagged by both.

## Result — first explicit finite upper bound on the *true* λ

**Argument (dyadic Szemerédi–Trotter product bound).** Every pair lies on exactly one rich line, so $\sum_{k\ge2}\binom k2 m_k=\binom n2$ exactly; hence $m_2$ is determined and $f(n)=\#\{$realizable $(m_3,\dots,m_n)\}$. Bound it by an independent product over dyadic multiplicity scales $[2^j,2^{j+1})$, with block line-count $M_j$ capped by **both** the elementary pair budget $\binom n2/\binom{2^j}2$ **and** the ST tail $t_{\ge k}\le A n^2/k^3+B n/k$:
$$\log f(n)\ \le\ S(n):=\sum_j\log\binom{M_j+w_j}{w_j},\qquad M_j=\min(\text{ST},\text{pair}).$$

**Verified $\exp(\Theta(\sqrt n))$, no log factor** (`verify_upper_constant.py`, EXIT 0):

- **Part B (crux):** $S(n)/\sqrt n$ converges ($22.6\to34.4$, $n=10^3..10^{12}$); $S(n)/n^{2/3}\to0$; $S(n)/(\sqrt n\log n)\to0$.
- **Part C (control):** pair-budget-**only** diverges in $/\sqrt n$ ($22.6\to364$) but $/n^{2/3}\to7.85$ — isolating ST's **cubic** $k^{-3}$ tail (not pair counting) as the source of the $\sqrt n$ rate, and quantifying S1's flagged $\exp(\Theta(n^{2/3}))$ overshoot.
- **Part A:** $\int_0^\infty\ln(1+u^{-2})du=\pi$ and $\int_0^\infty\ln(1+v^{-4})dv=\pi\sqrt2$ verified to $4\times10^{-5}$ (continuum rate).
- **Part D:** explicit $C\approx23.5$ ($c_0{=}1$) to $34.4$ ($c_0{=}2.5$):
$$\pi\sqrt{2/3}=2.5651\ \le\ \lambda\ \le\ C\quad(\text{explicit, finite}).$$

## Findings
- First **two-sided** bracket on the genuine λ (not just $\lambda_{\mathrm{grid}}$): the gallery's "$\exists C$" upper side now has a concrete (if loose) ceiling.
- Mechanism pinned: the $\sqrt n$ vs $n^{2/3}$ dichotomy is exactly ST's $k^3$ line-count tail.

## Honesty
$C$ is **loose** (ST constant $c_0$ unoptimised; the dyadic product is a coarse over-count), so the bracket $[2.565,\sim24]$ is wide. The **value of λ remains open** — this only establishes an explicit finite ceiling and the convergent integrals governing the rate. Build-free (Docker/Aristotle blackout); no Lean touched; S1's `countLineCompatible` integrity flag unchanged. Independent of and complementary to the open lower-side PR #24269.

## Status
**Outcome**: progress (ORIENT, upper side)
**Next**: optimise $c_0$ / tighten the over-count to shrink $C$; decide whether $\lambda=\lambda_{\mathrm{grid}}$.

## Test plan
- [x] `python3 research/problems/erdos-733-oq-01/verify_upper_constant.py` runs clean (EXIT 0)
- [x] JSON validates

🤖 Generated by researcher-10