### PR TITLE
Enrich Erdős #114 family: complete cross-reference graph

### DIFF
--- a/src/data/proofs/erdos-114-oq-01/meta.json
+++ b/src/data/proofs/erdos-114-oq-01/meta.json
@@ -180,6 +180,11 @@
       "targetId": "erdos-114",
       "relationship": "extends",
       "description": "Extends the main Erdős #114 formalization by defining Tao's threshold and proving finite reduction"
+    },
+    {
+      "proofId": "erdos-114-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling formalization sub-problem of Erdős #114, addressing the complementary axis. OQ-01 (this entry) handles the quantitative side — making Tao's threshold N₀ explicit and reducing the conjecture to finitely many cases — while OQ-04 handles the foundational side, de-axiomatizing the lemniscate set definitions via Mathlib's `Polynomial.eval` and complex norm. Read together they cover both 'how large is the threshold' and 'how few axioms does the formalization need.'"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-114-oq-04/meta.json
+++ b/src/data/proofs/erdos-114-oq-04/meta.json
@@ -117,6 +117,11 @@
       "targetId": "erdos-114",
       "relationship": "extends",
       "description": "Parent proof with axiomatized lemniscate definitions"
+    },
+    {
+      "proofId": "erdos-114-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling formalization sub-problem of Erdős #114, addressing the complementary axis. OQ-04 (this entry) handles the foundational side — discharging the parent's axioms using Mathlib complex analysis and redefining the lemniscate sets via `Polynomial.eval` and the complex norm ‖·‖ — while OQ-01 handles the quantitative side, making Tao's (2025) threshold N₀ explicit and reducing the full conjecture to finitely many cases. Together they pair a stronger formal foundation with a sharper mathematical statement."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -150,6 +150,16 @@
       "targetId": "isoperimetric-theorem",
       "relationship": "isoperimetric-analogy",
       "description": "The classical isoperimetric theorem (circle maximizes area for fixed perimeter) provides the philosophical template for #114. Both problems find a symmetric extremizer—circle for the classical case, z^n-1 (with D_n symmetry) for the polynomial lemniscate case."
+    },
+    {
+      "proofId": "erdos-114-oq-01",
+      "relationship": "extended-by",
+      "description": "OQ-01 attacks the quantitative residue left open by Tao (2025): Tao proved z^n-1 uniquely maximizes lemniscate length for all n above some threshold N₀, but the proof gives no explicit value. OQ-01 formalizes the threshold via `Nat.find` and proves the finite-reduction principle — that the full conjecture for all n reduces to verifying the remaining finitely many cases n < N₀ — turning the open problem into a (still hard but) finite computation."
+    },
+    {
+      "proofId": "erdos-114-oq-04",
+      "relationship": "extended-by",
+      "description": "OQ-04 is the foundational/de-axiomatization companion: it audits which axioms used in this parent formalization can be discharged using Mathlib's complex-analysis library, redefining lemniscate sets rigorously via `Polynomial.eval` and the complex norm ‖·‖ and proving the basic set-theoretic properties from first principles. Where OQ-01 sharpens the mathematical statement, OQ-04 strengthens the formal foundation beneath it."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
Completes the cross-reference graph for the Erdős #114 (lemniscate length maximization) family. Previously the parent linked only to sibling lemniscate problems and each child linked only upward to the parent. Adds the missing reciprocal links across three entries:

- **`erdos-114` → `erdos-114-oq-01`, `erdos-114-oq-04`** (`extended-by`).
- **`erdos-114-oq-01` ↔ `erdos-114-oq-04`** (`sibling`) — the two formalization sub-problems address complementary axes: OQ-01 makes Tao's (2025) threshold N₀ explicit and reduces the conjecture to finitely many cases; OQ-04 de-axiomatizes the lemniscate definitions using Mathlib complex analysis.

Bundled into one PR (3 files) since the links are a single atomic cluster completion. Qualitative cross-references the `find-targets.ts` scorer cannot measure.

## Validation
- `jq empty` valid on all three meta.json (xref counts: parent 6→8, oq-01 1→2, oq-04 1→2).
- Data-generation prebuild ran and wrote every new link to `public/data/proofs/.../meta.json` (verified). The downstream `tsc` step fails only on missing `node_modules` in the fresh worktree — known tooling issue, unrelated to the data change.
- Staged only the three edited `meta.json` files; no artifact churn committed.