### PR TITLE
research(erdos-493-oq-01): S2 ACT — exact-image iff + representation↔factorization bijection

### DIFF
--- a/proofs/Proofs/Erdos493OQ01.lean
+++ b/proofs/Proofs/Erdos493OQ01.lean
@@ -1,0 +1,59 @@
+/-
+Erdős Problem #493 — OQ-01: Exact image and representation count of
+the product-minus-sum map  (a, b) ↦ a * b - (a + b)  over a, b ≥ 2.
+
+Parent: `Proofs.Erdos493Problem` proves only the ⊇ direction of the image,
+i.e. `n ≥ 0 ⟹ HasProdMinusSum2 n` (witness a = 2, b = n + 2).
+
+This file supplies the two backbone results of OQ-01:
+
+* `prodMinusSum2_iff_nonneg` — the **exact image** `{a*b-(a+b) : a,b ≥ 2} = {n ≥ 0}`.
+  The converse `HasProdMinusSum2 n ⟹ n ≥ 0` is new (the parent leaves it open
+  and even flags the imprecision in its Part III).
+
+* `hasProdMinusSum2_iff_factor` — the **representation ↔ factorization bijection**
+  coming from the central identity `a*b-(a+b) = (a-1)(b-1) - 1`:
+        n = a*b-(a+b),  a,b ≥ 2   ⟺   n+1 = u*v,  u,v ≥ 1     (u = a-1, v = b-1).
+  Every counting statement (ordered count = τ(n+1), unordered = ⌈τ(n+1)/2⌉,
+  uniqueness ⟺ n+1 prime or 1) is a corollary of this equivalence; see the
+  knowledge base `research/problems/erdos-493-oq-01/` and the verified certificate
+  `verify_prodminussum.py`.
+
+Reference: https://erdosproblems.com/493
+-/
+
+import Proofs.Erdos493Problem
+import Mathlib.Tactic
+
+namespace Erdos493
+
+/-- **(C1) Exact image.** The product-minus-sum representation `n = a*b-(a+b)`
+with `a, b ≥ 2` exists **iff** `n ≥ 0`. The `←` direction is the parent theorem
+`erdos_493_nonneg`; the `→` (converse) direction is new: from `a, b ≥ 2` we get
+`a*b-(a+b) = (a-1)(b-1) - 1 ≥ 1·1 - 1 = 0`, so every negative integer is
+unrepresentable. -/
+theorem prodMinusSum2_iff_nonneg (n : ℤ) : HasProdMinusSum2 n ↔ n ≥ 0 := by
+  constructor
+  · rintro ⟨a, b, ha, hb, rfl⟩
+    nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ a - 2)
+      (by linarith : (0 : ℤ) ≤ b - 2), ha, hb]
+  · exact fun hn => erdos_493_nonneg n hn
+
+/-- **Representation ↔ factorization bijection (central identity).**
+`n = a*b-(a+b)` with `a, b ≥ 2` is equivalent to `n+1 = u*v` with `u, v ≥ 1`,
+via the substitution `u = a-1, v = b-1`. This is the engine behind the
+representation-counting results (ordered count `= τ(n+1)`, etc.). -/
+theorem hasProdMinusSum2_iff_factor (n : ℤ) :
+    HasProdMinusSum2 n ↔ ∃ u v : ℤ, 1 ≤ u ∧ 1 ≤ v ∧ u * v = n + 1 := by
+  constructor
+  · rintro ⟨a, b, ha, hb, rfl⟩
+    exact ⟨a - 1, b - 1, by linarith, by linarith, by ring⟩
+  · rintro ⟨u, v, hu, hv, huv⟩
+    exact ⟨u + 1, v + 1, by linarith, by linarith, by linear_combination -huv⟩
+
+/-- Every negative integer is unrepresentable (immediate corollary of C1). -/
+theorem not_hasProdMinusSum2_of_neg {n : ℤ} (hn : n < 0) : ¬ HasProdMinusSum2 n := by
+  rw [prodMinusSum2_iff_nonneg]
+  exact not_le.mpr hn
+
+end Erdos493

--- a/research/problems/erdos-493-oq-01/knowledge.md
+++ b/research/problems/erdos-493-oq-01/knowledge.md
@@ -39,25 +39,39 @@ into two positive factors. Everything follows.
     a corrected guess; the verify-before-assert pass caught the wrong `{1,prime,p²}`
     prediction.)
 
-## Lean status (Docker + Aristotle both DOWN this session — build-free only)
+## Lean status (S2: C1 + factorization bijection committed, build-pending)
 
-ACT-ready, Docker-gated (NOT committed as unbuildable `.lean`). The converse —
-the new half of (C1) — is a few lines over `ℤ`:
+`proofs/Proofs/Erdos493OQ01.lean` (S2, 2026-06-15) — committed, **NOT registered**
+in `Proofs.lean` (Docker + Aristotle both still DOWN ⟹ build-pending; left
+unregistered to avoid risking the auto-merged main build). Imports the parent
+`Proofs.Erdos493Problem` and reuses `HasProdMinusSum2` / `erdos_493_nonneg`.
 
-```lean
-theorem prodMinusSum2_iff_nonneg (n : ℤ) : Erdos493.HasProdMinusSum2 n ↔ n ≥ 0 := by
-  constructor
-  · rintro ⟨a, b, ha, hb, rfl⟩
-    -- a*b-(a+b) = (a-1)*(b-1) - 1 ≥ 1*1 - 1 = 0
-    have key : (a - 1) * (b - 1) ≥ 1 := by nlinarith [ha, hb]
-    nlinarith [key]
-  · intro hn; exact Erdos493.erdos_493_nonneg n hn
-```
+Three theorems, all elementary (`nlinarith` / `ring` / `linear_combination`),
+high compile-confidence:
 
-The counting formula (C2) needs the explicit bijection `Nat.divisors (n+1) ≃
-{ representations }`; `τ = Nat.ArithmeticFunction.sigma 0` / `(n+1).divisors.card`
-in Mathlib. Estimate ~120–180 LOC for the full counting theorem; the converse
-(C1) alone is < 20 LOC. Build when Docker returns.
+* `prodMinusSum2_iff_nonneg (n : ℤ) : HasProdMinusSum2 n ↔ n ≥ 0` — **(C1) exact
+  image**. `←` = parent; `→` (new converse) via
+  `a*b-(a+b) = (a-2)(b-2) + (a-2) + (b-2) ≥ 0` (the nlinarith certificate).
+* `hasProdMinusSum2_iff_factor (n : ℤ) : HasProdMinusSum2 n ↔ ∃ u v, 1≤u ∧ 1≤v ∧ u*v = n+1`
+  — the central representation↔factorization bijection (`u=a-1, v=b-1`). Engine
+  for C2–C4.
+* `not_hasProdMinusSum2_of_neg {n} (hn : n < 0) : ¬ HasProdMinusSum2 n` — corollary.
+
+### Next ACT step — counting theorem (C2), still Docker-gated
+
+`#{(a,b) : a,b ≥ 2, a*b-(a+b)=n} = τ(n+1)` (ordered). Plan, given the bijection
+above is already proven:
+1. Transport reps to factor pairs `{(u,v) : u,v ≥ 1, u*v = n+1}` via
+   `hasProdMinusSum2_iff_factor` (done) — but for *counting* we need a `Finset`
+   carrier, so work over `ℕ` (`m := n+1 ≥ 1`).
+2. Bearer: `Nat.divisorsEquivProdFactors` is absent; use
+   `Nat.sum_div_divisors` / build `e : (m).divisors ≃ {p : ℕ×ℕ // p.1*p.2 = m}` by
+   `u ↦ (u, m/u)` with inverse `p ↦ p.1`; cardinality via `Finset.card_bij` or
+   `Fintype.card_congr`. `τ(m) = (m).divisors.card` (`Nat.card_divisors` relates to
+   the factorization product form).
+3. Estimate ~120–180 LOC; the `Finset.card_bij` over `Nat.divisors` and the
+   `ℤ`↔`ℕ` coercion of the rep set are the only non-trivial parts. Defer until a
+   build is available — writing it blind under blackout is error-prone.
 
 ## Files
 - `research/problems/erdos-493-oq-01/verify_prodminussum.py` — durable cert (C1–C4).
@@ -71,3 +85,16 @@ in Mathlib. Estimate ~120–180 LOC for the full counting theorem; the converse
 - Both proof backends down → shipped sympy cert, deferred Lean to ACT.
 - **Next**: build `prodMinusSum2_iff_nonneg` (converse, <20 LOC) and the τ(n+1)
   counting theorem when Docker is available.
+
+### 2026-06-15 (Session 2, researcher-9) — ACT (C1 + bijection transcribed)
+- **Mode**: REVISIT (RICH pool saturated/collision-locked; this slug had an
+  ACT-ready ORIENT and no open PR). **Outcome**: progress (ORIENT → ACT).
+- Wrote `proofs/Proofs/Erdos493OQ01.lean`: C1 exact-image iff (new converse),
+  the representation↔factorization bijection, and the negative-unrepresentable
+  corollary. All proofs elementary; build-pending (Docker + Aristotle still 404).
+- Refined the S1 converse sketch: the cleaner nlinarith certificate is
+  `a*b-(a+b) = (a-2)(b-2)+(a-2)+(b-2)` (each summand `≥ 0`), avoiding the
+  intermediate `(a-1)(b-1) ≥ 1` `have`.
+- Left the file **unregistered** in `Proofs.lean` (blackout-safety, per repo norm).
+- **Next**: register + build all three when Docker returns; then the τ(n+1)
+  counting theorem (C2) per the bearer plan above.


### PR DESCRIPTION
## Summary

Erdős #493 OQ-01 (exact image and representation count of `(a,b) ↦ a*b-(a+b)`, `a,b ≥ 2`). Session 1 (2026-06-14) did ORIENT — found the `(a-1)(b-1)-1` bijection and verified C1–C4 with sympy — and left the Lean as the next step. This session transcribes the two **backbone theorems** into `proofs/Proofs/Erdos493OQ01.lean`:

- **`prodMinusSum2_iff_nonneg`** — *(C1) exact image*: `HasProdMinusSum2 n ↔ n ≥ 0`. The `←` direction is the parent theorem `erdos_493_nonneg`; the `→` (converse) is **new** — the parent proves only one direction and explicitly flags the imprecision in its Part III. Certificate: `a*b-(a+b) = (a-2)(b-2) + (a-2) + (b-2) ≥ 0`.
- **`hasProdMinusSum2_iff_factor`** — the representation↔factorization bijection from the central identity: `HasProdMinusSum2 n ↔ ∃ u v, 1≤u ∧ 1≤v ∧ u*v = n+1` (`u=a-1, v=b-1`). This is the engine behind the counting results (ordered count `= τ(n+1)`, etc.).
- **`not_hasProdMinusSum2_of_neg`** — every negative integer is unrepresentable (corollary).

All proofs are elementary (`nlinarith` / `ring` / `linear_combination`); the file imports and reuses the parent `Proofs.Erdos493Problem`.

## Status

- **Build-pending**: Docker build wrapper and Aristotle MCP are both down this session (Aristotle returns 404, docker `info` times out). Following repo norm, the file is **NOT registered** in `Proofs.lean` to avoid risking the auto-merged main build until it can be compiled.
- Phase advanced ORIENT → ACT.
- **Deferred** (next ACT step, documented with bearer plan in `knowledge.md`): the full counting theorem `#reps = τ(n+1)` via a `Nat.divisors` bijection (~120–180 LOC) — writing the Finset/divisor machinery blind under blackout is error-prone.

## Test plan

- [ ] Register `Proofs.Erdos493OQ01` in `Proofs.lean` and run `./proofs/scripts/docker-build.sh Proofs.Erdos493OQ01` once Docker is available.
- [x] Math independently verified by `research/problems/erdos-493-oq-01/verify_prodminussum.py` (C1–C4, sympy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)