### PR TITLE
Enrich Erdős #100 family: complete cross-reference graph

### DIFF
--- a/src/data/proofs/erdos-100-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01/meta.json
@@ -117,6 +117,11 @@
       "targetId": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey Theory \u2014 shares the theme of forced structure in large combinatorial configurations. Both Ramsey theory (monochromatic cliques in colorings) and integer distance sets (large diameter forced by integer arithmetic) ask: what structure is unavoidable in large configurations? The Anning-Erd\u0151s theorem (no infinite non-collinear integer distance sets) is a Ramsey-type finiteness result for planar geometry."
+    },
+    {
+      "proofId": "erdos-100-oq-01-wip-01",
+      "relationship": "extended-by",
+      "description": "Implements the Anning-Erdos finiteness theorem (1945) that this entry invokes: any non-collinear planar point set with all pairwise distances integers and bounded by d is finite, via the circle-intersection argument (two fixed points admit only finitely many integer-distance loci, whose pairwise intersections are finite). The WIP entry supplies the rigorous formal proof of the finiteness fact OQ-01 uses qualitatively in its gap analysis."
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -101,8 +101,19 @@
   },
   "crossReferences": [
     {
-      "relationship": "Open question derived from parent problem",
-      "targetId": "erdos-100"
+      "relationship": "extends",
+      "targetId": "erdos-100",
+      "description": "Open question derived from the parent Erdős #100: whether the minimum diameter of an n-point integer distance set grows linearly (Θ(n)) or only as Θ(n/log n)."
+    },
+    {
+      "proofId": "erdos-100-oq-01",
+      "relationship": "sibling",
+      "description": "Reciprocal sibling. OQ-01 frames the same distance-set diameter problem as the explicit Ω(n/log n) vs Ω(n) gap (Guth–Katz lower bound vs the linear conjecture) and develops the Anning–Erdős / Piepmeyer structure; OQ-02 frames it as the Θ(n) vs Θ(n/log n) growth-rate dichotomy. Two phrasings of the one open question."
+    },
+    {
+      "proofId": "erdos-100-oq-02-oq-02",
+      "relationship": "extended-by",
+      "description": "OQ-02-OQ-02 derives Kanold's bound (diam ≥ c·n^{3/4}) as a corollary of the Guth–Katz-derived bound (diam ≥ c·n/log n) established in this chain, eliminating the need for a separate proof of the weaker Kanold estimate. It is the concrete downstream consequence of the growth-rate analysis posed here."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -262,6 +262,16 @@
       "relationship": "related",
       "description": "Erdős #1007 (graph dimension and unit distance embedding) connects to the geometric embedding questions underlying restricted distance sets.",
       "targetId": "erdos-1007"
+    },
+    {
+      "proofId": "erdos-100-oq-01",
+      "relationship": "extended-by",
+      "description": "OQ-01 isolates the central quantitative gap: the known Guth–Katz lower bound on the minimum diameter of an n-point integer distance set is Ω(n/log n), while the conjecture asks for the linear Ω(n). OQ-01 formalizes this log n gap and the surrounding structure (Anning–Erdős finiteness, Piepmeyer constructions), making precise exactly how much remains between the proven bound and the parent problem's conjectured answer."
+    },
+    {
+      "proofId": "erdos-100-oq-02",
+      "relationship": "extended-by",
+      "description": "OQ-02 poses the growth-rate dichotomy directly: is the minimum diameter of n-point integer distance sets Θ(n) (linear, conjectured) or Θ(n/log n) (the current upper barrier)? It is the question-form companion to this parent problem and the root of the sub-chain that derives Kanold's cn^{3/4} bound as a corollary of the Guth–Katz cn/log n bound (OQ-02-OQ-02)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
Completes the cross-reference graph for the Erdős #100 (integer distance sets / restricted distances) family. The parent linked only outward to sibling Erdős problems, sub-entries linked non-reciprocally, and one parent link used a sentence as its `relationship` value. Adds/normalizes links across three entries:

- **`erdos-100` → `erdos-100-oq-01`, `erdos-100-oq-02`** (`extended-by`).
- **`erdos-100-oq-01` → `erdos-100-oq-01-wip-01`** (`extended-by`) — the Anning–Erdős finiteness implementation OQ-01 invokes.
- **`erdos-100-oq-02` → `erdos-100-oq-01`** (reciprocal `sibling`) and **→ `erdos-100-oq-02-oq-02`** (`extended-by`, the Kanold-from-Guth–Katz corollary). Also normalized OQ-02's parent link from the free-text `relationship` `"Open question derived from parent problem"` to `"extends"` + a proper `description`.

Qualitative cross-references the `find-targets.ts` scorer cannot measure.

## Validation
- `jq empty` valid on all three (xref counts: parent 5→7, oq-01 4→5, oq-02 1→3).
- Data-generation prebuild ran and wrote every new link to `public/data/proofs/.../meta.json` (verified). The downstream `tsc` step fails only on missing `node_modules` in the fresh worktree — known tooling issue, unrelated to the data change.
- Staged only the three edited `meta.json` files.