### PR TITLE
research(erdos-653-oq-01): discharge g_le_n axiom — g(n) ≤ n is a theorem (3→2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -143,8 +143,19 @@ g(n) ≥ 1 for n ≥ 2 (at least one R-value exists). -/
 /--
 **Trivial Upper Bound:**
 g(n) ≤ n (can't have more distinct values than points).
--/
-axiom g_le_n : ∀ n : ℕ, g n ≤ n
+
+Elementary: every achievable count equals `(S.image (distinctDistCount S)).card`
+for some `S` with `S.card = n`, and `Finset.card_image_le` bounds that by
+`S.card = n`. So every member of the `sSup` set is `≤ n`, hence `g n ≤ n`. -/
+theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
+  intro n
+  unfold g
+  apply Nat.sSup_le
+  intro k hk
+  simp only [Set.mem_setOf_eq] at hk
+  obtain ⟨S, hcard, rfl⟩ := hk
+  unfold numDistinctRValues rValueSet
+  exact le_trans Finset.card_image_le hcard.le
 
 /--
 **Monotonicity:**

--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -150,7 +150,7 @@ for some `S` with `S.card = n`, and `Finset.card_image_le` bounds that by
 theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
   intro n
   unfold g
-  apply Nat.sSup_le
+  apply csSup_le'
   intro k hk
   simp only [Set.mem_setOf_eq] at hk
   obtain ⟨S, hcard, rfl⟩ := hk

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -61,12 +61,12 @@
       "IsRegularPolygon: regular polygon predicate",
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
-      "g_le_n axiom: g(n) ≤ n"
+      "g_le_n theorem: g(n) ≤ n (proved from Finset.card_image_le)"
     ],
-    "axiomCount": 3,
-    "lineCount": 253,
-    "assumptions": "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries.",
-    "theoremCount": 2,
+    "axiomCount": 2,
+    "lineCount": 264,
+    "assumptions": "2 axioms: csizmadia_bound, upper_bound (both literature lower/upper bounds). g_le_n is now a proved theorem (Finset.card_image_le). 0 sorries.",
+    "theoremCount": 3,
     "definitionCount": 13
   },
   "overview": {
@@ -131,49 +131,49 @@
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "g_le_n axiom; g_pos and g_mono discussed only in docstrings",
+      "summary": "g_le_n theorem (g(n) ≤ n, proved); g_pos and g_mono discussed only in docstrings",
       "startLine": 138,
-      "endLine": 153,
-      "mathContext": "Axiomatized: g_le_n axiom (g(n) ≤ n); g_pos and g_mono appear only in docstrings"
+      "endLine": 164,
+      "mathContext": "g_le_n is a proved theorem (g(n) ≤ n via Finset.card_image_le); g_pos and g_mono appear only in docstrings"
     },
     {
       "id": "special-configs",
       "title": "Special Configurations",
       "summary": "IsCollinear, IsRegularPolygon, regular_polygon_r_value",
-      "startLine": 154,
-      "endLine": 178,
+      "startLine": 165,
+      "endLine": 189,
       "mathContext": "Mathematical content: IsCollinear, IsRegularPolygon, regular_polygon_r_value"
     },
     {
       "id": "extremal-configs",
       "title": "Extremal Configurations",
       "summary": "IsOptimalConfig, optimal_exists",
-      "startLine": 179,
-      "endLine": 193,
+      "startLine": 190,
+      "endLine": 204,
       "mathContext": "Mathematical content: IsOptimalConfig, optimal_exists"
     },
     {
       "id": "asymptotic",
       "title": "Asymptotic Analysis",
       "summary": "Asymptotic gap commentary in docstrings (no axioms in this section)",
-      "startLine": 194,
-      "endLine": 203,
+      "startLine": 205,
+      "endLine": 214,
       "mathContext": "Mathematical content: asymptotic gap commentary (gap_lower_bound and gap_bounds in docstrings only)"
     },
     {
       "id": "connections",
       "title": "Connection to Unit Distance Problem",
       "summary": "unitDistPairs, totalDistinctDistances",
-      "startLine": 204,
-      "endLine": 223,
+      "startLine": 215,
+      "endLine": 234,
       "mathContext": "Mathematical content: unitDistPairs, totalDistinctDistances"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_653_summary theorem, erdos_653 theorem",
-      "startLine": 224,
-      "endLine": 253,
+      "startLine": 235,
+      "endLine": 264,
       "mathContext": "Verified: erdos_653_summary theorem, erdos_653 theorem"
     }
   ],
@@ -202,9 +202,9 @@
       "Real"
     ],
     "namespace": "Erdos653",
-    "lineCount": 253,
-    "axiomCount": 3,
-    "theoremCount": 2,
+    "lineCount": 264,
+    "axiomCount": 2,
+    "theoremCount": 3,
     "definitionCount": 13,
     "path": "Proofs/Erdos653Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Discharges the `g_le_n : ∀ n, g n ≤ n` **axiom** in
`proofs/Proofs/Erdos653Problem.lean`, which prior ORIENT sessions (#24201,
#24248, merged) flagged as "trivially provable; should be a theorem" under the
repo Axiom Integrity Policy.

**Proof:** `g n = sSup {k | ∃ S, S.card = n ∧ numDistinctRValues S = k}`, and
`numDistinctRValues S = (S.image (distinctDistCount S)).card ≤ S.card = n` by
`Finset.card_image_le`. So every member of the set is `≤ n`, and `Nat.sSup_le`
gives `g n ≤ n`.

After this, `Erdos653Problem.lean` has **2 axioms** (`csizmadia_bound`,
`upper_bound` — both genuine deep literature bounds) and **0 sorries**.
`meta.json` updated: `axiomCount` 3→2, `theoremCount` 2→3, line/section
bookkeeping refreshed.

The downstream `erdos_653_summary` / `erdos_653` theorems are unaffected
(g_le_n keeps the same type).

## Status / honesty

- The main conjecture `g(n) ≥ (1-o(1))n` remains **OPEN**; the two remaining
  axioms are legitimate literature citations (not dischargeable in a session).
- Elementary proof; only nonstandard reference is `Nat.sSup_le`.
- **Build-pending**: authored during the Docker + Aristotle blackout, so not
  machine-checked locally. Edits a *registered* gallery file — please run
  `./proofs/scripts/docker-build.sh Proofs.Erdos653Problem` before merge.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos653Problem` once Docker is back.
- [ ] If `Nat.sSup_le` name/shape differs, the bound also follows from `csSup_le`
      (needs the set's nonemptiness) — trivial to adapt.