### PR TITLE
Research: pell-equation-oq-05 S5 — N(ξ)=1 is infinite via real-embedding distinctness (supersedes #24277)

### DIFF
--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -1,0 +1,241 @@
+/-
+Pell's Equation OQ-05: Norm Equations in Number Fields of Degree > 2
+
+Pell's equation x² - D y² = 1 is the norm-one equation
+N_{ℚ(√D)/ℚ}(x + y√D) = 1, whose solution chain is the rank-1 case of Dirichlet's
+unit theorem. This entry studies the degree-3 analogue over K = ℚ(∛2) = ℤ[t]/(t³-2):
+the structure of N_{K/ℚ}(ξ) for ξ ∈ 𝒪_K.
+
+This file formalizes the *concrete algebraic core* — the part that does NOT require
+Mathlib's (heavy, and here bearer-less) signature/Dirichlet machinery:
+
+  1. The cubic norm form  N(a,b,c) = a³ + 2b³ + 4c³ - 6abc  is the determinant of
+     multiplication-by-(a + bt + ct²) on the power basis {1, t, t²} (`cnorm_eq_det`).
+  2. N is multiplicative for the ring ℤ[t]/(t³-2) (`cnorm_cmul`), i.e. it is a genuine
+     norm form — the engine that turns one unit into an infinite solution chain.
+  3. u = t - 1 is a unit of norm 1 with inverse t² + t + 1 (`cmul_u_uinv`, `cnorm_u`).
+  4. **Higher-degree Pell chain**: every power uᵏ has norm 1 (`cnorm_upow`), giving
+     solutions of N(ξ) = 1 — the analogue of the Pell chain (3,2) → (17,12) → …
+
+  5. **(Session 5, new) Distinctness ⟹ infinitely many solutions.** Via the real
+     embedding φ : ξ ↦ a + bτ + cτ² with τ = ∛2, which is a ring homomorphism
+     (`phi_cmul`), one has φ(uᵏ) = φ(u)ᵏ with 0 < φ(u) = τ-1 < 1, so the chain values
+     are *strictly decreasing*, hence pairwise distinct (`upow_injective`). Therefore
+     the integral solution set of N(ξ) = 1 is **infinite** (`norm_one_solutions_infinite`).
+     This closes the gap S4 explicitly left open ("the analytic distinctness step is
+     not formalized") — and does so with no signature/Dirichlet machinery.
+
+What remains DEFERRED (the genuinely hard, Mathlib-bearer-less part): identifying the
+unit *rank* r₁ + r₂ - 1 = 1 of 𝒪_K via the signature (r₁,r₂) = (1,1), which needs a
+place-count `card (InfinitePlace K) = 2` for `AdjoinRoot (X³-2)` that Mathlib does not
+ship a decision procedure for. See knowledge.md ("Bearer pin + ACT re-scope").
+
+References:
+- https://erdosproblems.com / Dirichlet's unit theorem
+- Parent entry: `pell-equation` (the rank-1, real-quadratic special case).
+
+NOTE: This supersedes and extends the S4 file in PR #24277 (which contained items
+1–4 only). All identities are verified exactly by
+`research/problems/pell-equation-oq-05/verify_distinctness.py`.
+-/
+
+import Mathlib
+
+namespace PellEquationOQ05
+
+/-
+## The cubic norm form
+-/
+
+/-- The norm form of K = ℚ(∛2) on the power basis: N(a + bt + ct²), t³ = 2. -/
+def cnorm (a b c : ℤ) : ℤ := a ^ 3 + 2 * b ^ 3 + 4 * c ^ 3 - 6 * a * b * c
+
+/-- The norm form is the determinant of the multiplication-by-(a + bt + ct²) matrix
+    on the power basis {1, t, t²} (columns ξ·1, ξ·t, ξ·t², reduced by t³ = 2).
+    This is the `Algebra.norm` of the element, computed concretely. -/
+theorem cnorm_eq_det (a b c : ℤ) :
+    cnorm a b c = (!![a, 2 * c, 2 * b; b, a, 2 * c; c, b, a]).det := by
+  rw [Matrix.det_fin_three_of]
+  unfold cnorm
+  ring
+
+/-
+## Ring structure of ℤ[t]/(t³ - 2) and multiplicativity
+-/
+
+/-- Multiplication in ℤ[t]/(t³ - 2): reduce (a₀+a₁t+a₂t²)(b₀+b₁t+b₂t²) using t³ = 2. -/
+def cmul (x y : ℤ × ℤ × ℤ) : ℤ × ℤ × ℤ :=
+  (x.1 * y.1 + 2 * (x.2.1 * y.2.2 + x.2.2 * y.2.1),
+   x.1 * y.2.1 + x.2.1 * y.1 + 2 * x.2.2 * y.2.2,
+   x.1 * y.2.2 + x.2.1 * y.2.1 + x.2.2 * y.1)
+
+/-- Norm of a coordinate triple. -/
+def cnorm3 (p : ℤ × ℤ × ℤ) : ℤ := cnorm p.1 p.2.1 p.2.2
+
+/-- **The norm form is multiplicative**: N(ξ·η) = N(ξ)·N(η). This is the structural
+    fact that makes the higher-degree Pell chain work — it is a polynomial identity
+    in the six coordinates, hence closed by `ring`. -/
+theorem cnorm_cmul (x y : ℤ × ℤ × ℤ) : cnorm3 (cmul x y) = cnorm3 x * cnorm3 y := by
+  obtain ⟨a0, a1, a2⟩ := x
+  obtain ⟨b0, b1, b2⟩ := y
+  simp only [cmul, cnorm3, cnorm]
+  ring
+
+/-
+## The fundamental unit and the Pell chain
+-/
+
+/-- The fundamental unit u = t - 1 of ℤ[∛2]. -/
+def u : ℤ × ℤ × ℤ := (-1, 1, 0)
+
+/-- Its inverse, t² + t + 1. -/
+def uinv : ℤ × ℤ × ℤ := (1, 1, 1)
+
+/-- u · u⁻¹ = 1, since (t - 1)(t² + t + 1) = t³ - 1 = 1. -/
+theorem cmul_u_uinv : cmul u uinv = (1, 0, 0) := by decide
+
+/-- u is a unit of norm 1: N(t - 1) = -1 + 2 = 1. -/
+theorem cnorm_u : cnorm3 u = 1 := by decide
+
+/-- The Pell chain uᵏ (u⁰ = 1, uᵏ⁺¹ = uᵏ · u). -/
+def upow : ℕ → ℤ × ℤ × ℤ
+  | 0 => (1, 0, 0)
+  | k + 1 => cmul (upow k) u
+
+/-- **Higher-degree Pell chain**: every power uᵏ has norm 1, so N(ξ) = 1 has
+    integral solutions in ℤ[∛2] — the cubic analogue of the Brahmagupta chain
+    for x² - 2y² = 1. -/
+theorem cnorm_upow (k : ℕ) : cnorm3 (upow k) = 1 := by
+  induction k with
+  | zero => decide
+  | succ n ih => rw [upow, cnorm_cmul, ih, cnorm_u]; ring
+
+/-- The first few terms of the chain, matching the classical Pell pattern. -/
+theorem upow_one : upow 1 = (-1, 1, 0) := by decide
+theorem upow_two : upow 2 = (1, -2, 1) := by decide
+theorem upow_three : upow 3 = (1, 3, -3) := by decide
+theorem upow_four : upow 4 = (-7, -2, 6) := by decide
+
+/-
+## The real embedding and distinctness of the chain (Session 5)
+
+φ(a + bt + ct²) := a + bτ + cτ², where τ ∈ ℝ is the real cube root of 2 (τ³ = 2).
+This is the real archimedean embedding of K = ℚ(∛2). It is a ring homomorphism
+(`phi_cmul`), so φ(uᵏ) = φ(u)ᵏ. Since 0 < φ(u) = τ - 1 < 1, the chain values are
+strictly decreasing, hence pairwise distinct — giving infinitely many solutions of
+N(ξ) = 1 without invoking the signature/Dirichlet machinery.
+-/
+
+/-- The real embedding evaluation a + bτ + cτ² (the real place of ℚ(∛2) when τ³ = 2). -/
+noncomputable def phi (τ : ℝ) (p : ℤ × ℤ × ℤ) : ℝ :=
+  (p.1 : ℝ) + (p.2.1 : ℝ) * τ + (p.2.2 : ℝ) * τ ^ 2
+
+/-- φ respects multiplication: φ(ξ·η) = φ(ξ)·φ(η), since τ³ = 2 reduces the products
+    of the power basis exactly as `cmul` does. The residual is a multiple of (τ³ - 2),
+    cleared by `linear_combination` (coefficient verified by `verify_distinctness.py`). -/
+theorem phi_cmul (τ : ℝ) (hτ : τ ^ 3 = 2) (x y : ℤ × ℤ × ℤ) :
+    phi τ (cmul x y) = phi τ x * phi τ y := by
+  obtain ⟨a0, a1, a2⟩ := x
+  obtain ⟨b0, b1, b2⟩ := y
+  simp only [phi, cmul]
+  push_cast
+  linear_combination (-((a1 : ℝ) * (b2 : ℝ) + (a2 : ℝ) * (b1 : ℝ) + (a2 : ℝ) * (b2 : ℝ) * τ)) * hτ
+
+/-- φ(uᵏ) = φ(u)ᵏ — the chain is a geometric progression at the real place. -/
+theorem phi_upow (τ : ℝ) (hτ : τ ^ 3 = 2) (k : ℕ) :
+    phi τ (upow k) = (phi τ u) ^ k := by
+  induction k with
+  | zero => simp [upow, phi]
+  | succ n ih => rw [upow, phi_cmul τ hτ, ih, pow_succ]
+
+/-- The real cube root of 2 lies strictly between 1 and 2. -/
+theorem tau_bounds (τ : ℝ) (hτ : τ ^ 3 = 2) (hpos : 0 < τ) : 1 < τ ∧ τ < 2 := by
+  constructor
+  · nlinarith [hτ, hpos, sq_nonneg (τ - 1), sq_nonneg (τ + 1), mul_pos hpos hpos]
+  · nlinarith [hτ, hpos, sq_nonneg (τ - 2), sq_nonneg (τ + 2), mul_pos hpos hpos]
+
+/-- φ(u) = τ - 1 lies strictly in (0, 1). -/
+theorem phi_u_mem (τ : ℝ) (hτ : τ ^ 3 = 2) (hpos : 0 < τ) :
+    0 < phi τ u ∧ phi τ u < 1 := by
+  obtain ⟨h1, h2⟩ := tau_bounds τ hτ hpos
+  simp only [phi, u]
+  push_cast
+  constructor <;> nlinarith [h1, h2]
+
+/-- The chain k ↦ uᵏ is injective: φ(u)ᵏ is strictly decreasing (base in (0,1)). -/
+theorem upow_injective (τ : ℝ) (hτ : τ ^ 3 = 2) (hpos : 0 < τ) :
+    Function.Injective upow := by
+  obtain ⟨hp0, hp1⟩ := phi_u_mem τ hτ hpos
+  intro j k hjk
+  have hval : (phi τ u) ^ j = (phi τ u) ^ k := by
+    rw [← phi_upow τ hτ, ← phi_upow τ hτ, hjk]
+  rcases lt_trichotomy j k with hlt | heq | hgt
+  · have hcontra := pow_lt_pow_right_of_lt_one hp0 hp1 hlt
+    rw [hval] at hcontra
+    exact absurd hcontra (lt_irrefl _)
+  · exact heq
+  · have hcontra := pow_lt_pow_right_of_lt_one hp0 hp1 hgt
+    rw [hval] at hcontra
+    exact absurd hcontra (lt_irrefl _)
+
+/-- There is a real cube root of 2. (Compile-risk concentrate of this file: the
+    `rpow` manipulation. The mathematical content is trivial.) -/
+theorem exists_real_cube_root_two : ∃ τ : ℝ, τ ^ 3 = 2 ∧ 0 < τ := by
+  refine ⟨(2 : ℝ) ^ ((1 : ℝ) / 3), ?_, by positivity⟩
+  rw [← Real.rpow_natCast ((2 : ℝ) ^ ((1 : ℝ) / 3)) 3,
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 2)]
+  norm_num
+
+/-- **The set of integral solutions of N(ξ) = 1 in ℤ[∛2] is infinite.**
+    The injective chain k ↦ uᵏ lands entirely in the norm-one set, so that set
+    contains an infinite subset. This is the higher-degree analogue of "Pell's
+    equation has infinitely many solutions", proved here with no signature or
+    Dirichlet unit-theorem machinery. -/
+theorem norm_one_solutions_infinite :
+    {p : ℤ × ℤ × ℤ | cnorm3 p = 1}.Infinite := by
+  obtain ⟨τ, hτ, hpos⟩ := exists_real_cube_root_two
+  apply Set.infinite_of_injective_forall_mem (f := upow) (upow_injective τ hτ hpos)
+  intro k
+  exact cnorm_upow k
+
+/-
+## Recovering Pell (rank-1 special case)
+
+For comparison, the parent real-quadratic norm form N(p + q√2) = p² - 2q² with its
+fundamental solution (3, 2) and Brahmagupta chain (3,2) → (17,12) → (99,70) → …
+-/
+
+/-- The quadratic (Pell) norm form. -/
+def qnorm (p q : ℤ) : ℤ := p ^ 2 - 2 * q ^ 2
+
+/-- The classical fundamental Pell solution: 3² - 2·2² = 1. -/
+theorem qnorm_fundamental : qnorm 3 2 = 1 := by decide
+
+/-- One Brahmagupta composition step (3,2) ⊕ (3,2) = (17,12), all of norm 1. -/
+theorem qnorm_chain : qnorm 17 12 = 1 ∧ qnorm 99 70 = 1 ∧ qnorm 577 408 = 1 := by
+  refine ⟨?_, ?_, ?_⟩ <;> decide
+
+/-
+## Summary
+
+Pell's equation OQ-05 (norm equations in degree > 2), concrete-core formalization:
+
+1. The cubic norm form N(a,b,c) = a³ + 2b³ + 4c³ - 6abc = det of the multiplication
+   matrix (`cnorm_eq_det`) — the `Algebra.norm` of a + b∛2 + c∛4, computed.
+2. N is multiplicative (`cnorm_cmul`).
+3. u = ∛2 - 1 is a unit of norm 1 (`cnorm_u`, `cmul_u_uinv`).
+4. Every uᵏ has norm 1 (`cnorm_upow`): the higher-degree Pell chain.
+5. (NEW, S5) The chain is injective (`upow_injective`) via the real embedding φ
+   (`phi_cmul`, `phi_upow`, `phi_u_mem`), so N(ξ) = 1 has **infinitely many** integral
+   solutions (`norm_one_solutions_infinite`) — closing S4's open distinctness gap,
+   with no signature/Dirichlet machinery.
+
+Deferred (Mathlib-bearer-less): the unit *rank* = 1 via signature (1,1) of ℚ(∛2),
+needing `card (InfinitePlace (AdjoinRoot (X³-2))) = 2`, for which Mathlib ships no
+signature-from-minpoly procedure.
+
+Axiom count: 0
+Sorry count: 0
+-/
+
+end PellEquationOQ05

--- a/research/problems/pell-equation-oq-05/knowledge.md
+++ b/research/problems/pell-equation-oq-05/knowledge.md
@@ -158,3 +158,64 @@ verification de-risk the eventual ACT step.
 3. Recover-Pell lemma: real quadratic $\Rightarrow$ rank 1 (ties to parent).
 4. Cubic norm via `Algebra.norm` / det; verify $N(t-1)=1$.
 5. State finiteness of $N(\xi)=m$ classes via `ClassGroup` finiteness + `Units`.
+
+---
+
+## Session 5 (ACT, researcher-4, 2026-06-15): closed S4's distinctness gap — N(ξ)=1 is **infinite**
+
+S4 (PR #24277) formalized the cubic norm form, its multiplicativity, the unit
+$u=t-1$ of norm 1, and the chain $u^k$ (all norm 1) — but its own summary flagged
+the gap: *"Distinctness of the $u^k$, hence 'infinitely many', is not formalized
+(holds because $|u|<1$ at the real place; the analytic distinctness step is not
+formalized)."* S5 **closes exactly that gap**, with **no signature/Dirichlet
+machinery** (so it sidesteps the bearer-less place-count blocker entirely).
+
+### The argument (signature-free infinitude)
+
+Let $\tau=\sqrt[3]2\in\mathbb{R}$ ($\tau^3=2$) and
+$\varphi(a,b,c)=a+b\tau+c\tau^2$ be the **real archimedean embedding** of $K=\mathbb{Q}(\sqrt[3]2)$.
+
+1. **$\varphi$ is a ring hom** ($\varphi(\xi\eta)=\varphi(\xi)\varphi(\eta)$): the residual
+   of the 6-variable identity is exactly a multiple of $(\tau^3-2)$. The Lean
+   `linear_combination` coefficient is **$-(a_1b_2+a_2b_1+a_2b_2\tau)$**, i.e.
+   $\varphi(\xi)\varphi(\eta)-\varphi(\xi\eta)=(\tau^3-2)(a_1b_2+a_2b_1+a_2b_2\tau)$
+   (verified exactly by `verify_distinctness.py`).
+2. **$\varphi(u^k)=\varphi(u)^k$** by induction (geometric progression at the real place).
+3. **$0<\varphi(u)=\tau-1<1$**, from $1<\tau<2$ (which follows from $\tau^3=2$, $\tau>0$
+   via `nlinarith`).
+4. So $k\mapsto\varphi(u)^k$ is **strictly decreasing** $\Rightarrow$ $k\mapsto u^k$ is
+   **injective** ⟹ $\{p:N(p)=1\}$ is **infinite**
+   (`Set.infinite_of_injective_forall_mem` + `cnorm_upow`).
+
+This is the higher-degree analogue of "Pell has infinitely many solutions", now a
+*theorem* rather than a chain-of-examples. New lemmas in `PellEquationOQ05.lean`
+(supersedes #24277, items 1–4 retained): `phi`, `phi_cmul`, `phi_upow`,
+`tau_bounds`, `phi_u_mem`, `upow_injective`, `exists_real_cube_root_two`,
+`norm_one_solutions_infinite`. Still **0 axioms / 0 sorries**.
+
+### Status & risk
+
+- **Build-pending, UNREGISTERED** in `Proofs.lean`: Docker down + Aristotle MCP 404
+  (dual blackout, same as S4). The *mathematics* is fully verified by
+  `verify_distinctness.py` (symbolic ring-hom identity, exact bounds, strict
+  monotonicity, distinctness of $u^0..u^{11}$).
+- **Compile-risk concentrate**: `exists_real_cube_root_two` (the `Real.rpow_natCast`
+  / `Real.rpow_mul` manipulation) and the exact lemma name
+  `pow_lt_pow_right_of_lt_one`. If the latter was renamed, swap for the
+  `StrictAnti`/`pow_lt_pow_of_lt_one` variant. `phi_cmul`'s `linear_combination`
+  coefficient is sign-checked against the cert.
+
+### Still deferred (unchanged)
+
+The unit **rank = 1** via signature $(1,1)$ — needs
+`card (InfinitePlace (AdjoinRoot (X^3-2))) = 2`, no Mathlib bearer (see §"Bearer
+pin + ACT re-scope" item 3). S5 deliberately routes *around* this: infinitude of
+$N(\xi)=1$ does **not** need the rank, only one unit of infinite order.
+
+### Next steps
+
+1. Verify build once Docker/Aristotle return; register in `Proofs.lean`; close #24277
+   as superseded.
+2. Optional: extend `norm_one_solutions_infinite` to a `Set.Infinite` statement for
+   $N(\xi)=m$ when $m$ is a norm value (multiply the chain by one solution of $N=m$).
+3. The rank/signature place-count remains the lone hard ACT (attempt under backend-up).

--- a/research/problems/pell-equation-oq-05/sessions/2026-06-15-s5-act-distinctness-infinitude.md
+++ b/research/problems/pell-equation-oq-05/sessions/2026-06-15-s5-act-distinctness-infinitude.md
@@ -1,0 +1,47 @@
+# Session 5 (ACT) — 2026-06-15, researcher-4
+
+## Goal
+Advance `pell-equation-oq-05` beyond the S4 cubic-Pell core (PR #24277). S4's own
+summary flagged an open gap: it proved every chain element `u^k` has norm 1, but
+**never proved the `u^k` are distinct**, so "infinitely many solutions of N(ξ)=1"
+was not actually formalized.
+
+## What was done (ACT)
+Closed that gap, **without any signature/Dirichlet machinery** (so it routes around
+the bearer-less place-count blocker that has stalled the rank=1 target for 3+ sessions).
+
+Via the real embedding `φ(a,b,c) = a + bτ + cτ²` (τ = ∛2, τ³ = 2):
+- `phi_cmul`: φ is a ring hom (residual is a multiple of τ³−2; explicit
+  `linear_combination` coefficient `−(a₁b₂+a₂b₁+a₂b₂τ)`).
+- `phi_upow`: φ(uᵏ) = φ(u)ᵏ.
+- `tau_bounds`: 1 < τ < 2 (from τ³=2, τ>0, via nlinarith).
+- `phi_u_mem`: 0 < φ(u)=τ−1 < 1.
+- `upow_injective`: strictly-decreasing geometric progression ⟹ k↦uᵏ injective.
+- `exists_real_cube_root_two`: τ exists (rpow).
+- `norm_one_solutions_infinite`: **{p : cnorm3 p = 1} is infinite**.
+
+New file `proofs/Proofs/PellEquationOQ05.lean` (supersedes #24277, retains items 1–4),
+still **0 axioms / 0 sorries**.
+
+## Verification
+`research/problems/pell-equation-oq-05/verify_distinctness.py` — symbolic & exact
+(sympy): ring-hom identity reduces to 0 mod τ³−2; `linear_combination` coefficient
+verified exactly; 1<τ<2; φ(uᵏ)=φ(u)ᵏ strictly decreasing; u⁰..u¹¹ pairwise distinct
+with norm 1. ALL CHECKS PASSED.
+
+## Backends
+Dual blackout: Docker DOWN (`docker info` fails), Aristotle MCP `prove` returns
+404 "Resource not found". So **build-pending, UNREGISTERED** in `Proofs.lean`
+(avoids breaking auto-merge). Math is cert-verified; Lean is best-effort.
+
+Compile-risk concentrate: `exists_real_cube_root_two` (rpow manipulation) and the
+exact name `pow_lt_pow_right_of_lt_one`.
+
+## Still deferred (unchanged)
+Unit **rank = 1** via signature (1,1) — needs `card (InfinitePlace (AdjoinRoot
+(X³−2))) = 2`, no Mathlib bearer. S5 deliberately does not need it: infinitude of
+N(ξ)=1 follows from one unit of infinite order alone.
+
+## Next
+Verify build when backends return; register; close #24277 as superseded. Optional:
+extend to N(ξ)=m for norm values m. The signature place-count remains the lone hard ACT.

--- a/research/problems/pell-equation-oq-05/state.md
+++ b/research/problems/pell-equation-oq-05/state.md
@@ -1,19 +1,19 @@
 # Research State: pell-equation-oq-05
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-14 (S3 ORIENT bearer-pin + ACT re-scope; was 2026-06-14T21:05 S2)
-**Iteration**: 3
+**Since**: 2026-06-15 (S5 ACT distinctness/infinitude; was 2026-06-14 S3 ORIENT)
+**Iteration**: 5
 
 ## Current Focus
-S3 ORIENT (researcher-7): bearers re-confirmed at the exact lake-pin and the ACT
-re-scoped. `NumberField.Units.rank := card (InfinitePlace K) - 1` is a *definition*
-(DirichletTheorem.lean:354), and `K=ℚ(∛2)=AdjoinRoot(X^3-2)` is a free `NumberField`
-instance (Basic.lean:451 + Eisenstein), so the ACT's only hard part is proving
-`card (InfinitePlace K) = 2` — which has **no Mathlib bearer** (no signature-from-minpoly
-procedure; the cyclotomic place-count lemmas don't apply). Place-count is the LOC-dominant
-step to de-risk first. Still Docker-gated (Docker DOWN, Aristotle `prove` "Resource not found").
+S5 ACT (researcher-4): closed S4's open distinctness gap. Via the real embedding
+φ(a,b,c)=a+bτ+cτ² (τ=∛2), proved φ is a ring hom, φ(uᵏ)=φ(u)ᵏ with 0<φ(u)<1 strictly
+decreasing ⟹ k↦uᵏ injective ⟹ **{p : N(p)=1} is infinite** (`norm_one_solutions_infinite`),
+with NO signature/Dirichlet machinery. New `PellEquationOQ05.lean` supersedes #24277
+(0 axioms/0 sorries). Build-pending, UNREGISTERED (dual blackout: Docker DOWN, Aristotle
+404). Math cert-verified by `verify_distinctness.py`. The rank=1 / signature place-count
+(`card (InfinitePlace (AdjoinRoot(X^3-2)))=2`, no Mathlib bearer) remains the lone hard ACT.
 
 ## Active Approach
 Instantiate Mathlib's Dirichlet unit theorem for a concrete cubic

--- a/research/problems/pell-equation-oq-05/verify_distinctness.py
+++ b/research/problems/pell-equation-oq-05/verify_distinctness.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+pell-equation-oq-05, Session 5 (ACT): distinctness / infinitude certificate.
+
+S4 (PR #24277) formalized the cubic norm form N(a,b,c)=a^3+2b^3+4c^3-6abc of
+K=Q(cbrt 2)=Z[t]/(t^3-2), its multiplicativity, the fundamental unit u=t-1 of
+norm 1, and the Pell chain u^k (all of norm 1). But S4 explicitly LEFT OPEN the
+claim "infinitely many solutions of N(xi)=1": it never proved the chain values
+u^k are DISTINCT.
+
+This script verifies, symbolically and from first principles, the S5 argument
+that closes that gap WITHOUT any signature/Dirichlet machinery:
+
+  (A) phi(p)=p0 + p1*tau + p2*tau^2 (tau=real cube root of 2) is a ring hom:
+      phi(cmul x y) = phi(x)*phi(y), the polynomial identity using tau^3=2.
+  (B) 1 < tau < 2, hence phi(u) = tau-1 in (0,1).
+  (C) phi(u^k) = phi(u)^k is strictly decreasing in k (base in (0,1)),
+      hence the u^k are pairwise distinct.
+  (D) => {p : N(p)=1} is infinite (injective chain inside the norm-1 set).
+
+Everything is checked with exact sympy arithmetic (no floats in the proofs;
+floats only for a human-readable sanity print). Docker/Aristotle-independent.
+"""
+
+import sympy as sp
+
+a0, a1, a2, b0, b1, b2, tau = sp.symbols('a0 a1 a2 b0 b1 b2 tau')
+
+
+def cnorm(a, b, c):
+    return a**3 + 2*b**3 + 4*c**3 - 6*a*b*c
+
+
+def cmul(x, y):
+    x0, x1, x2 = x
+    y0, y1, y2 = y
+    return (x0*y0 + 2*(x1*y2 + x2*y1),
+            x0*y1 + x1*y0 + 2*x2*y2,
+            x0*y2 + x1*y1 + x2*y0)
+
+
+def cnorm3(p):
+    return cnorm(p[0], p[1], p[2])
+
+
+def phi(p):
+    # real embedding t -> tau, tau^3 = 2
+    return p[0] + p[1]*tau + p[2]*tau**2
+
+
+def reduce_tau(expr):
+    """Reduce a polynomial in tau modulo tau^3 - 2 (i.e. set tau^3 = 2)."""
+    poly = sp.Poly(sp.expand(expr), tau)
+    # rem of poly by (tau^3 - 2)
+    _, rem = sp.div(poly, sp.Poly(tau**3 - 2, tau), tau)
+    return sp.expand(rem.as_expr())
+
+
+print("=" * 70)
+print("(A) phi is a ring homomorphism:  phi(cmul x y) == phi(x)*phi(y) mod tau^3-2")
+print("=" * 70)
+x = (a0, a1, a2)
+y = (b0, b1, b2)
+lhs = reduce_tau(phi(cmul(x, y)))
+rhs = reduce_tau(phi(x) * phi(y))
+diff = sp.expand(lhs - rhs)
+print("phi(cmul x y) - phi(x)*phi(y)  (mod tau^3-2)  =", diff)
+assert diff == 0, "phi is NOT a ring hom!"
+print("PASS: phi respects multiplication.\n")
+
+# explicit linear_combination coefficient for the Lean proof:
+# phi(x)*phi(y) - phi(cmul x y) = (tau^3 - 2) * C, find C
+full = sp.expand(phi(x)*phi(y) - phi(cmul(x, y)))
+C = sp.simplify(sp.cancel(full / (tau**3 - 2)))
+print("Lean linear_combination coefficient C with")
+print("  phi(x)*phi(y) - phi(cmul x y) = (tau^3 - 2) * C :")
+print("  C =", sp.expand(C))
+assert sp.expand(full - (tau**3 - 2)*C) == 0
+print("  (verified exact)\n")
+
+print("=" * 70)
+print("(B) tau in (1,2)  =>  phi(u) = tau - 1 in (0,1)")
+print("=" * 70)
+tau_val = sp.Rational(2)**sp.Rational(1, 3)
+print("tau = 2^(1/3) ~", float(tau_val))
+assert tau_val**3 == 2
+assert 1 < tau_val < 2
+u = (-1, 1, 0)
+phi_u = phi(u).subs(tau, tau_val)
+print("phi(u) = tau - 1 ~", float(phi_u))
+assert 0 < phi_u < 1
+print("PASS: 0 < phi(u) < 1.\n")
+
+print("=" * 70)
+print("(C) phi(u^k) = phi(u)^k strictly decreasing => u^k pairwise distinct")
+print("=" * 70)
+
+
+def upow(k):
+    p = (1, 0, 0)
+    for _ in range(k):
+        p = cmul(p, u)
+    return p
+
+
+prev = None
+seen = {}
+for k in range(0, 12):
+    p = upow(k)
+    # check norm 1
+    assert cnorm3(p) == 1, f"N(u^{k}) != 1"
+    # check phi(u^k) = phi(u)^k exactly
+    val_chain = phi(p).subs(tau, tau_val)
+    val_pow = phi_u**k
+    assert sp.simplify(val_chain - val_pow) == 0, f"phi(u^{k}) != phi(u)^{k}"
+    # strictly decreasing
+    if prev is not None:
+        assert val_chain < prev, "phi(u^k) not strictly decreasing"
+    prev = val_chain
+    # distinctness of the triples themselves
+    assert p not in seen, f"collision: u^{k} == u^{seen.get(p)}"
+    seen[p] = k
+    print(f"u^{k:2d} = {str(p):>16s}   N=1   phi=phi(u)^{k} ~ {float(val_chain):.6e}")
+print("PASS: all 12 chain values distinct, norms 1, phi(u^k)=phi(u)^k decreasing.\n")
+
+print("=" * 70)
+print("(D) {p : N(p)=1} is infinite")
+print("=" * 70)
+print("k |-> u^k is injective (C) and lands in {N=1} (S4 cnorm_upow),")
+print("so the norm-one solution set contains an infinite subset => infinite.")
+print("PASS (structural).\n")
+
+print("ALL CHECKS PASSED.")


### PR DESCRIPTION
## Summary

Session 5 (ACT) on `pell-equation-oq-05` (norm equations in number fields of degree > 2). Closes the distinctness gap that S4 (PR #24277) explicitly left open.

**S4 proved** that every element `uᵏ` of the Pell chain in `ℤ[∛2]` (`u = ∛2 − 1`) has norm 1 — but **never proved the `uᵏ` are distinct**, so "infinitely many solutions of `N(ξ)=1`" was not actually formalized (S4's own summary flags this).

**S5 closes it**, with **no signature/Dirichlet machinery** — deliberately routing around the bearer-less place-count blocker (`card (InfinitePlace (AdjoinRoot (X³−2))) = 2`, no Mathlib bearer) that has stalled the `rank = 1` target for 3+ sessions. Only one unit of infinite order is needed.

Via the real archimedean embedding `φ(a,b,c) = a + bτ + cτ²` (`τ = ∛2`, `τ³ = 2`):
- `phi_cmul` — φ is a ring hom (residual is a multiple of `τ³−2`; explicit `linear_combination` coefficient `−(a₁b₂+a₂b₁+a₂b₂τ)`).
- `phi_upow` — `φ(uᵏ) = φ(u)ᵏ`.
- `tau_bounds` / `phi_u_mem` — `1 < τ < 2`, so `0 < φ(u) = τ−1 < 1`.
- `upow_injective` — strictly-decreasing geometric progression ⟹ `k ↦ uᵏ` injective.
- `norm_one_solutions_infinite` — **`{p : cnorm3 p = 1}` is `Infinite`**.

`PellEquationOQ05.lean` supersedes #24277 (retains the S4 norm-form / multiplicativity / unit-chain core), still **0 axioms / 0 sorries**.

## Verification

`research/problems/pell-equation-oq-05/verify_distinctness.py` — exact symbolic checks (sympy): ring-hom identity ≡ 0 mod `τ³−2`, `linear_combination` coefficient verified exact, `1<τ<2`, `φ(uᵏ)=φ(u)ᵏ` strictly decreasing, `u⁰..u¹¹` pairwise distinct with norm 1. **ALL CHECKS PASSED.**

## Build status

**Build-pending, UNREGISTERED** in `Proofs.lean` — dual backend blackout this session (Docker DOWN, Aristotle MCP returns 404). The *mathematics* is cert-verified; the Lean is best-effort. Compile-risk concentrate: `exists_real_cube_root_two` (the `Real.rpow` manipulation) and the exact lemma name `pow_lt_pow_right_of_lt_one`. Register + close #24277 as superseded once a build verifies.

## Still deferred (unchanged)

Unit **rank = 1** via signature `(1,1)` of `ℚ(∛2)` — needs `card (InfinitePlace (AdjoinRoot (X³−2))) = 2`, for which Mathlib ships no signature-from-minpoly procedure. S5 does not need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)