### PR TITLE
Research: erdos-131-oq-01-oq-01 — S1 OBSERVE (exact F(1..54), honest growth-rate analysis)

### DIFF
--- a/research/problems/erdos-131-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-131-oq-01-oq-01/knowledge.md
@@ -1,0 +1,86 @@
+# Knowledge Base: erdos-131-oq-01-oq-01
+
+OQ: determine the exact growth rate of F(N) (Erdős #131, non-dividing sets) — is it
+`N^{1/5+o(1)}` or some other power?
+
+---
+
+## Session 2026-06-15 (S1) — FRESH OBSERVE (build-free; Docker + Aristotle blackout)
+
+**Mode**: FRESH · **Outcome**: OBSERVE — pinned the exact object, computed verified
+exact values `F(1..54)`, laid out the rigorous bound landscape, and gave an HONEST
+negative meta-finding: the exponent is empirically inaccessible at computable N. No
+growth-exponent claim is made (that would be unsupportable from small N). No Lean file
+written (build-gated; the OQ is a hard open asymptotic, not a wiring task).
+
+### The exact object (matches the Lean parent)
+
+`IsNonDividing A` (Erdos131Problem.lean:47): `∀ a ∈ A, ∀ S ⊆ A.erase a, |S| ≥ 2 →
+¬(a ∣ S.sum)`. `F N` (line 109) = max card of a non-dividing `A ⊆ Icc 1 N`. Note the
+condition is over EVERY ≥2-element subset of the others (not just the sum of all
+others), so it is the *strong* non-dividing notion. Consequences pinned:
+- `1 ∈ A` forces `|A| ≤ 2` (1 divides every sum, so no ≥2-subset may coexist).
+- Witnesses: `{2,4,5}` is non-dividing; `{2,3,4}` is not (3 ∣ 2+4).
+
+### Verified exact values (certificate `verify_Fn.py`, two independent methods agree)
+
+Computed two ways — brute force over all ≥2-subsets, and a residue-class DP tracking
+size-1 vs size-≥2 reachability mod `a` — which **agree on F(1..30)** (internal
+cross-validation, guards the predicate against off-by-one). DP extends to N=54:
+
+    F(1..54) = 1 2 2 2 3 3 3 3 3 4 4 4 4 4 4 5 5 5 5 5 5 5 5 5 5 5 5 5 5 6
+               6 6 6 6 6 6 6 6 6 6 6 6 7 7 7 7 7 7 7 7 7 7 7 7
+
+    smallest N with F(N)=k:  F=1→N=1, 2→2, 3→5, 4→10, 5→16, 6→30, 7→43
+
+(NOTE: an OEIS A068063 cross-check — referenced by the parent meta — is PENDING;
+oeis.org returned HTTP 403 to the fetcher this session. The two-method internal
+agreement is the integrity anchor instead. A future session with OEIS access should
+confirm whether A068063 uses this exact ≥2-subset variant or the "sum of all others"
+variant; the values above are unambiguous for the Lean `IsNonDividing` definition.)
+
+### Rigorous bound landscape (NOT closed by this session)
+
+    exp(c·√log N)   ≤   F(N)   ≤   N^{1/4 + o(1)}
+
+- Lower: Straus, `exp(c√log N)` (sub-polynomial). Improving it to polynomial would
+  need fundamentally new large-non-dividing-set constructions (open).
+- Upper: Pham–Zakharov (2024), `N^{1/4+o(1)}`, via the non-averaging connection
+  (`IsNonDividing ⟹ IsNonAveraging`, proven in the parent at line 95). This refuted
+  the original Erdős guess `F(N) > N^{1/2-o(1)}` (answer: NO).
+- The OQ's `N^{1/5}` is one guess inside the wide `[exp(c√log N), N^{1/4}]` window;
+  whether `F` is even a clean power (`N^{θ+o(1)}`) vs genuinely intermediate growth
+  is itself open.
+
+### Honest negative meta-finding (why small N can't help)
+
+The finite-N effective exponent `log F(N)/log N` at the thresholds:
+
+    F=3 @N=5: 0.683   F=4 @10: 0.602   F=5 @16: 0.580
+    F=6 @30: 0.527    F=7 @43: 0.517   (and ≈0.49 at N=54)
+
+It decreases only glacially and at N=54 is still ≈0.49 — about **double** the proven
+asymptotic ceiling 1/4, and nowhere near the conjectured 1/5 = 0.20. So the lower-order
+terms dominate completely at every computable N: brute small-N computation provably
+cannot distinguish `N^{1/5}` from `N^{1/4}` from `exp(c√log N)`. Any "empirical exponent
+fit" here would be misleading — the OQ is not attackable by enumeration.
+
+### Decision / where the real progress is
+
+This OQ is a genuine open asymptotic; build-free computation does not move it. The only
+honest formalization targets (for a Docker-up session) are *infrastructure*, not the OQ:
+1. A decidable instance / `native_decide`-friendly reformulation of `IsNonDividing` and
+   small `F(N)` values as certified gallery facts (the values above).
+2. Formalizing the `IsNonDividing ⟹ IsNonAveraging` bridge is already done (parent:95);
+   the Pham–Zakharov upper bound itself is far out of formalization reach.
+Recommend: keep this OQ as a documented hard-open with the verified `F(1..54)` table;
+do NOT spawn enumeration-theater sessions chasing the exponent.
+
+---
+
+## Dead Ends
+
+- **Empirical exponent fitting**: ruled out as dishonest — effective exponent at N=54 is
+  ~0.49, dominated by lower-order terms; cannot resolve 1/5 vs 1/4 vs sub-polynomial.
+- **OEIS fetch** (oeis.org/A068063): blocked by HTTP 403 this session; use an
+  authenticated/MCP fetch or local OEIS mirror next time.

--- a/research/problems/erdos-131-oq-01-oq-01/state.md
+++ b/research/problems/erdos-131-oq-01-oq-01/state.md
@@ -1,0 +1,30 @@
+# Research State: erdos-131-oq-01-oq-01
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 1
+
+## Current Focus
+Exact values F(1..54) computed (two independent methods agree on F(1..30)); bound
+landscape and honest "exponent is empirically inaccessible" meta-finding documented in
+knowledge.md. The growth-rate OQ itself is a hard open asymptotic, not closed here.
+
+## Active Approach
+OBSERVE/ORIENT only. No Lean ACT — the OQ is an open exponent, not a wiring task.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+The OQ (exact growth exponent of F(N)) is genuinely open in the literature
+(window exp(c√log N) ≤ F(N) ≤ N^{1/4+o(1)}; Pham–Zakharov 2024). Not build-blocked —
+research-blocked. OEIS A068063 cross-check pending (oeis.org 403 to fetcher).
+
+## Next Action
+Do NOT chase the exponent by enumeration (small-N effective exponent ≈0.49 at N=54 is
+useless). If anything: a Docker-up session could certify small F(N) values via a
+decidable reformulation. Otherwise keep as documented hard-open.

--- a/research/problems/erdos-131-oq-01-oq-01/verify_Fn.py
+++ b/research/problems/erdos-131-oq-01-oq-01/verify_Fn.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Certificate for erdos-131-oq-01-oq-01 — exact small values of F(N) (Erdős #131).
+
+F(N) = maximum size of A ⊆ {1,...,N} that is "non-dividing": no element a ∈ A
+divides the sum of any subset S ⊆ A minus {a} with |S| ≥ 2.  (This is exactly the Lean
+definition `IsNonDividing` / `F` in Proofs/Erdos131Problem.lean:47,109.)
+
+OQ-01-OQ-01 asks for the *growth rate* of F(N) (is it N^{1/5+o(1)}?).  That is a
+hard open asymptotic — the known rigorous window is
+    exp(c·sqrt(log N))   ≤   F(N)   ≤   N^{1/4 + o(1)}
+(Straus lower bound; Pham–Zakharov 2024 upper bound, which refuted F(N) > N^{1/2-o(1)}).
+
+This script does NOT attempt to answer the exponent question (it cannot be answered
+from small N — see the effective-exponent table below).  It provides two things of
+honest value:
+
+  (1) EXACT values F(1..M) computed two independent ways that must agree
+      (brute-force over all ≥2-subsets  vs.  a residue-class DP), an internal
+      cross-validation guarding against an off-by-one in the predicate.
+  (2) A quantified demonstration of WHY the exponent is empirically inaccessible:
+      the finite-N effective exponent log F(N)/log N is still ≈0.49 at N=54 —
+      about double the proven asymptotic ceiling 1/4 and far above the conjectured
+      1/5 — and is decreasing only glacially.
+
+Run: python3 verify_Fn.py
+"""
+
+from itertools import combinations
+import math
+
+
+# ---- Predicate, method 1: brute force over all >=2 subsets of the others -----
+def is_nondividing_brute(A):
+    A = list(A)
+    for a in A:
+        others = [b for b in A if b != a]
+        for r in range(2, len(others) + 1):
+            for S in combinations(others, r):
+                if sum(S) % a == 0:
+                    return False
+    return True
+
+
+# ---- Predicate, method 2: residue DP tracking size-1 vs size->=2 reachability -
+def is_nondividing_dp(A):
+    for a in A:
+        if a == 1:
+            if len(A) - 1 >= 2:   # 1 divides every sum
+                return False
+            continue
+        reach1, reach2 = set(), set()      # residues mod a by 1-subset / >=2-subset
+        for b in A:
+            if b == a:
+                continue
+            x = b % a
+            new2 = set(reach2)
+            for r in reach1:
+                new2.add((r + x) % a)
+            for r in reach2:
+                new2.add((r + x) % a)
+            reach1.add(x)
+            reach2 = new2
+            if 0 in reach2:                # some >=2 subset of others ≡ 0 (mod a)
+                return False
+    return True
+
+
+# ---- F(N) via DFS with a size-based bound; pred = which predicate to use ------
+def F(N, pred):
+    best = 0
+
+    def dfs(start, cur):
+        nonlocal best
+        if len(cur) + (N - start + 1) <= best:
+            return
+        if len(cur) > best:
+            best = len(cur)
+        for x in range(start, N + 1):
+            if len(cur) + (N - x + 1) <= best:
+                break
+            cur.append(x)
+            if pred(cur):
+                dfs(x + 1, cur)
+            cur.pop()
+    dfs(1, [])
+    return best
+
+
+def main():
+    # (1) cross-validate the two predicates on F(1..30)
+    M_cross = 30
+    vb = [F(N, is_nondividing_brute) for N in range(1, M_cross + 1)]
+    vd = [F(N, is_nondividing_dp) for N in range(1, M_cross + 1)]
+    assert vb == vd, f"predicate mismatch!\nbrute={vb}\ndp   ={vd}"
+    print(f"[cross-validation] brute == DP on F(1..{M_cross}): PASS")
+    print(f"  F(1..{M_cross}) = {vb}")
+
+    # spot-check a known witness: {2,4,5} is non-dividing, {2,3,4} is not
+    assert is_nondividing_brute([2, 4, 5]) and is_nondividing_dp([2, 4, 5])
+    assert not is_nondividing_brute([2, 3, 4]) and not is_nondividing_dp([2, 3, 4])
+    # 1 can sit in a set of size <=2 only
+    assert is_nondividing_dp([1, 7]) and not is_nondividing_dp([1, 3, 5])
+    print("[witnesses] {2,4,5} ok, {2,3,4} bad, {1,x} size-2 ok / size-3 bad: PASS")
+
+    # (2) extend with the fast DP and report thresholds + effective exponent
+    M = 54
+    vals = list(vd) + [F(N, is_nondividing_dp) for N in range(M_cross + 1, M + 1)]
+    print(f"\n  F(1..{M}) = {vals}")
+
+    thresholds = {}
+    for i, v in enumerate(vals, start=1):
+        thresholds.setdefault(v, i)
+    print(f"  smallest N with F(N)=k:  {thresholds}")
+
+    print("\n  effective exponent  log F(N)/log N  at each new threshold:")
+    for k, N in sorted(thresholds.items()):
+        if N > 1:
+            print(f"    F={k} first at N={N:>2}:  exp = {math.log(k)/math.log(N):.3f}")
+    print("\n  => at N=54 the effective exponent is still ~0.49, ~2x the proven")
+    print("     asymptotic ceiling 1/4 and far from the conjectured 1/5 = 0.20.")
+    print("     Small-N data cannot resolve the growth exponent.")
+    print("\nALL CHECKS PASS.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
First session on `erdos-131-oq-01-oq-01` (Erdős #131, non-dividing sets): the OQ asks for the exact growth exponent of `F(N)` (is it `N^{1/5+o(1)}`?). This is a genuinely open asymptotic; the session is an honest OBSERVE — exact small values + bound landscape — and deliberately makes **no** exponent claim and writes **no** blind Lean.

## Findings
- **Object pinned** to the Lean parent: `F(N)` = max `|A|`, `A⊆{1..N}`, with no `a∈A` dividing the sum of any ≥2-element subset of `A\{a}` (`Erdos131Problem.lean:47,109`). Consequence: `1∈A ⟹ |A|≤2`.
- **Verified exact values** `F(1..54)` via `verify_Fn.py`, computed **two independent ways** (brute-force ≥2-subset enumeration vs. a residue-class DP) that agree on `F(1..30)` — an internal cross-validation of the predicate. Thresholds: `F=k` first reached at `N = 1,2,5,10,16,30,43`.
- **Bound landscape** documented: `exp(c√log N) ≤ F(N) ≤ N^{1/4+o(1)}` (Straus lower; Pham–Zakharov 2024 upper, which refuted the original `N^{1/2-o(1)}`), reusing the parent's proven `IsNonDividing ⟹ IsNonAveraging` bridge.
- **Honest negative meta-finding**: the finite-N effective exponent `log F(N)/log N` is ≈0.49 at `N=54` — about double the proven `1/4` ceiling and far from the conjectured `1/5` — so small-N computation provably cannot resolve the exponent. Enumeration is not a path here.

## Status
**Outcome**: surveyed (OBSERVE) — verified data + landscape; OQ remains open (research-blocked, not build-blocked).
**Next Steps**: do not chase the exponent by enumeration. Optionally a Docker-up session could certify small `F(N)` values via a decidable reformulation. OEIS A068063 cross-check pending (oeis.org returned 403 to the fetcher).

🤖 Generated by researcher-2