### PR TITLE
research(erdos-653-oq-01): sharp elementary upper bound g(n) ≤ n-1 (n ≥ 2)

### DIFF
--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -150,6 +150,63 @@ axiom g_le_n : ∀ n : ℕ, g n ≤ n
 **Monotonicity:**
 g is non-decreasing in n.
 -/
+
+/--
+**Sharp Elementary Upper Bound:** `g(n) ≤ n - 1` for `n ≥ 2`.
+
+This is strictly sharper than `g_le_n` and is the genuine elementary ceiling:
+the deep `n - c·n^{2/3}` gap (`upper_bound`) lives in the `n^{2/3}` term, not in
+the strict inequality `g(n) < n`, which is elementary.
+
+Proof: every R-value `R(p) = distinctDistCount S p` for a point `p` in an
+`n`-point configuration `S` lies in the interval `[1, n-1]`:
+- `R(p) ≤ n - 1` because `distanceSet S p` is the image of `S.filter (· ≠ p) ⊆ S.erase p`
+  (card `n - 1`) under `euclidDist p`, and `Finset.card_image_le` does not increase card;
+- `R(p) ≥ 1` because for `n ≥ 2` there is another point `q ≠ p`, so `distanceSet S p`
+  is nonempty.
+
+Hence `rValueSet S ⊆ Finset.Icc 1 (n-1)`, whose cardinality is `n - 1`, and
+`g n` is the supremum of these counts.
+-/
+theorem g_le_n_sub_one : ∀ n : ℕ, 2 ≤ n → g n ≤ n - 1 := by
+  intro n hn
+  unfold g
+  apply Nat.sSup_le
+  intro k hk
+  simp only [Set.mem_setOf_eq] at hk
+  obtain ⟨S, hcard, rfl⟩ := hk
+  have hsub : rValueSet S ⊆ Finset.Icc 1 (n - 1) := by
+    intro m hm
+    unfold rValueSet at hm
+    rw [Finset.mem_image] at hm
+    obtain ⟨p, hpS, rfl⟩ := hm
+    rw [Finset.mem_Icc]
+    refine ⟨?_, ?_⟩
+    · -- 1 ≤ distinctDistCount S p
+      have h1 : 1 < S.card := by rw [hcard]; omega
+      obtain ⟨q, hqS, hqp⟩ := Finset.exists_ne_of_one_lt_card h1 p
+      have hne : (distanceSet S p).Nonempty := by
+        refine ⟨euclidDist p q, ?_⟩
+        unfold distanceSet
+        exact Finset.mem_image.mpr ⟨q, Finset.mem_filter.mpr ⟨hqS, hqp⟩, rfl⟩
+      have hpos : 0 < distinctDistCount S p := by
+        unfold distinctDistCount; exact Finset.card_pos.mpr hne
+      omega
+    · -- distinctDistCount S p ≤ n - 1
+      have hsubE : S.filter (· ≠ p) ⊆ S.erase p := by
+        intro x hx
+        rw [Finset.mem_filter] at hx
+        exact Finset.mem_erase.mpr ⟨hx.2, hx.1⟩
+      unfold distinctDistCount distanceSet
+      calc ((S.filter (· ≠ p)).image (euclidDist p)).card
+          ≤ (S.filter (· ≠ p)).card := Finset.card_image_le
+        _ ≤ (S.erase p).card := Finset.card_le_card hsubE
+        _ = n - 1 := by rw [Finset.card_erase_of_mem hpS, hcard]
+  calc numDistinctRValues S
+      = (rValueSet S).card := rfl
+    _ ≤ (Finset.Icc 1 (n - 1)).card := Finset.card_le_card hsub
+    _ = n - 1 := by rw [Nat.card_Icc]; omega
+
 /-
 ## Part VII: Special Configurations
 -/

--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -129,3 +129,54 @@ is NOT claimed here. No Lean written (Docker down); the three axioms (`csizmadia
 - `research/problems/erdos-653-oq-01/verify_g_structure.py`: +2 checks (4a 1D-optimality,
   4b 2D-beats witnesses), +summary lines.
 - `research/problems/erdos-653-oq-01/knowledge.md`: this Session 2 entry.
+
+## Session 2026-06-15 (Session 3, researcher-5, ACT — sharp elementary upper bound g(n) ≤ n-1)
+
+**Mode:** CONTINUE / ACT (dual blackout: `docker info` reports DOCKER_DOWN, Aristotle
+MCP `prove` returns "Resource not found" 404). Builds on S1's ACT plan item #2, which
+no prior session shipped: S1/S2 were ORIENT, and the only Lean delta to date is the
+**concurrent open PR #24302** (discharges the `g_le_n` axiom → theorem).
+
+**Delta shipped:** new theorem in `Erdos653Problem.lean`
+
+```lean
+theorem g_le_n_sub_one : ∀ n : ℕ, 2 ≤ n → g n ≤ n - 1
+```
+
+This is **strictly sharper** than the file's `g_le_n` axiom (`g n ≤ n`) and is the
+genuine elementary ceiling — the deep `n - c·n^{2/3}` gap (`upper_bound`) lives in the
+`n^{2/3}` term, not in the strict inequality, which is elementary (knowledge S1 flagged
+`g(n) ≤ n-1` as "strictly sharper than the file's g_le_n axiom" but it was never
+formalized).
+
+**Proof architecture (0 sorries, 0 new axioms):**
+- `Nat.sSup_le` reduces `g n ≤ n-1` to bounding each achievable `numDistinctRValues S`.
+- Containment `rValueSet S ⊆ Finset.Icc 1 (n-1)`: every R-value `distinctDistCount S p`
+  for `p ∈ S` lies in `[1, n-1]`:
+  - **upper** `≤ n-1`: `distanceSet S p` is the image of `S.filter (· ≠ p) ⊆ S.erase p`
+    (card `n-1` via `Finset.card_erase_of_mem`) under `euclidDist p`, and
+    `Finset.card_image_le` does not increase card;
+  - **lower** `≥ 1`: for `n ≥ 2`, `Finset.exists_ne_of_one_lt_card` gives a point
+    `q ≠ p`, so `distanceSet S p` is nonempty (`Finset.card_pos.mpr`).
+- `Nat.card_Icc` gives `|Icc 1 (n-1)| = n-1`; `Finset.card_le_card` finishes.
+
+**Non-collision design:** the theorem is inserted in the previously-empty region between
+the Monotonicity docstring and Part VII — disjoint from PR #24302's edits to the `g_le_n`
+block. The two PRs compose: #24302 proves `g_le_n` (axiom→theorem), this PR adds the
+sharper `g_le_n_sub_one`. meta.json bumped relative to **main** (axiomCount 3 unchanged —
+`g_le_n` is still an axiom in main; theoremCount 2→3; lineCount 253→310). If #24302
+merges first, only the meta.json counts need reconciling (the .lean regions do not
+conflict).
+
+**Build status:** build-pending under dual blackout. All five non-trivial lemma names
+were cross-checked against existing repo usage before shipping:
+`Finset.exists_ne_of_one_lt_card` (Erdos99:55), `Finset.card_erase_of_mem ... , hcard`
+(Erdos107:246, identical pattern), `Nat.card_Icc` (Erdos817:359), `Finset.card_image_le`
+(Erdos643:466), `Nat.sSup_le` (Erdos1104:72). REGISTERED file — flag build-before-merge.
+
+**Honest assessment:** modest but genuine. Fills the one elementary upper-bound gap the
+file had (the sharp `g(n) ≤ n-1` vs the loose `g(n) ≤ n`). The OQ itself (`g(n) ≥ (1-o(1))n`)
+is OPEN and untouched; the two literature axioms (`csizmadia_bound`, `upper_bound`) remain
+correct citations. Remaining ACT item: the elementary lower bound `g(n) ≥ ⌈n/2⌉` (S1 #3),
+which needs an explicit collinear membership witness into the sSup set — deferred (heavier,
+build-gated).

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -61,12 +61,13 @@
       "IsRegularPolygon: regular polygon predicate",
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
-      "g_le_n axiom: g(n) ≤ n"
+      "g_le_n axiom: g(n) ≤ n",
+      "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)"
     ],
     "axiomCount": 3,
-    "lineCount": 253,
-    "assumptions": "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries.",
-    "theoremCount": 2,
+    "lineCount": 310,
+    "assumptions": "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries. g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is a proved theorem strictly sharper than the g_le_n axiom.",
+    "theoremCount": 3,
     "definitionCount": 13
   },
   "overview": {
@@ -131,10 +132,10 @@
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "g_le_n axiom; g_pos and g_mono discussed only in docstrings",
+      "summary": "g_le_n axiom; g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
       "startLine": 138,
-      "endLine": 153,
-      "mathContext": "Axiomatized: g_le_n axiom (g(n) ≤ n); g_pos and g_mono appear only in docstrings"
+      "endLine": 210,
+      "mathContext": "g_le_n axiom (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
     },
     {
       "id": "special-configs",
@@ -202,9 +203,9 @@
       "Real"
     ],
     "namespace": "Erdos653",
-    "lineCount": 253,
+    "lineCount": 310,
     "axiomCount": 3,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 13,
     "path": "Proofs/Erdos653Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds `g_le_n_sub_one : ∀ n, 2 ≤ n → g n ≤ n - 1` to `Erdos653Problem.lean` — the genuine **elementary** ceiling for the distinct-distance-count function `g(n)`, strictly sharper than the file's existing `g_le_n` axiom (`g n ≤ n`).

The deep `n − c·n^{2/3}` gap (the `upper_bound` axiom) lives in the `n^{2/3}` term; the strict inequality `g(n) < n` is itself elementary. This theorem makes that explicit and fills the one elementary upper-bound gap the file had (flagged but never formalized in knowledge S1).

## Proof (0 sorries, 0 new axioms)

- `Nat.sSup_le` reduces `g n ≤ n−1` to bounding each achievable `numDistinctRValues S`.
- Every R-value `distinctDistCount S p` for `p ∈ S` lies in `[1, n−1]`:
  - **upper** `≤ n−1`: `distanceSet S p` is the image of `S.filter (· ≠ p) ⊆ S.erase p` (card `n−1`) under `euclidDist p`; `Finset.card_image_le` does not increase card.
  - **lower** `≥ 1`: for `n ≥ 2`, `Finset.exists_ne_of_one_lt_card` yields a point `q ≠ p`, so `distanceSet S p` is nonempty.
- Hence `rValueSet S ⊆ Finset.Icc 1 (n−1)` (cardinality `n−1`); `Finset.card_le_card` finishes.

## Non-collision with PR #24302

This theorem is inserted in the previously-empty region between the Monotonicity docstring and Part VII, **disjoint** from the concurrent open PR #24302 (which proves the `g_le_n` axiom → theorem). The two PRs compose. `meta.json` is bumped relative to **main**: `theoremCount` 2→3, `lineCount` 253→310, `axiomCount` unchanged (`g_le_n` is still an axiom in main). If #24302 merges first, only the `meta.json` counts need reconciling — the `.lean` regions do not conflict.

## Build status

⚠️ **Build-pending** — dual backend blackout this session (`docker info` down, Aristotle MCP returns 404). Could not run `docker-build.sh`. All non-trivial lemma names were cross-checked against existing repo usage before shipping:

| Lemma | Confirmed at |
|-------|--------------|
| `Nat.sSup_le` | `Erdos1104Problem.lean:72` |
| `Finset.exists_ne_of_one_lt_card` | `Erdos99Problem.lean:55` |
| `Finset.card_erase_of_mem … , hcard` | `Erdos107Problem.lean:246` (identical pattern) |
| `Nat.card_Icc` | `Erdos817Problem.lean:359` |
| `Finset.card_image_le` | `Erdos643Problem.lean:466` |

This file is registered in `Proofs.lean` — **please build-verify before merge**.

## Scope

The OQ itself (`g(n) ≥ (1−o(1))·n`) is **OPEN** and untouched; the two literature axioms (`csizmadia_bound`, `upper_bound`) remain correct citations. The elementary lower bound `g(n) ≥ ⌈n/2⌉` (knowledge S1 item #3) is left for a follow-up (needs an explicit collinear membership witness into the sSup set).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos653Problem` (blocked this session — docker down)
- [x] `meta.json` validated (parses; counts reflect main + this theorem)
- [x] All cited lemma names confirmed against existing in-repo usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)