### PR TITLE
research(geometric-series-oq-01-oq-02): S2 ACT — Cesàro (C,1) regularity + strict extension

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ02.lean
@@ -1,0 +1,198 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ01
+
+/-
+# Geometric Series OQ-01 / OQ-02: Cesàro (C,1) regularity and its strict extension
+
+## The Open Question (OQ-02 of `geometric-series-oq-01`)
+
+The parent entry proves the *concrete* Grandi instance by hand: the Cesàro
+mean of `1 - 1 + 1 - 1 + ⋯` converges to `1/2` (`grandiCesaro_tendsto`).
+OQ-02 asks for the *general* statement behind that bespoke computation — the
+**regularity** (a.k.a. consistency) property of (C,1) summation:
+
+> If a series `∑ aₙ` converges (in the ordinary sense) to `s`, then its
+> Cesàro mean also converges to `s`. Moreover (C,1) summability is *strictly*
+> stronger than convergence: there exist divergent series that are (C,1)
+> summable.
+
+## What this file proves
+
+* `cesaroMean S n = (n:ℝ)⁻¹ * ∑ k ∈ range n, S k` — the (C,1) average of the
+  *partial-sum sequence* `S` (the object one averages is the partial sums,
+  **not** the terms `aₙ`; averaging the terms gives `0` whenever `∑ aₙ`
+  converges, which is not the (C,1) mean of the series).
+* `CesaroSummable S L` — predicate: the partial-sum sequence `S` is (C,1)
+  summable to `L`.
+* **M1 — regularity** (`cesaroSummable_of_tendsto`): ordinary convergence of
+  the partial sums to `s` implies (C,1) summability to the same `s`. This is
+  a one-line consequence of Mathlib's `Filter.Tendsto.cesaro`, applied to the
+  partial-sum sequence. A `HasSum` corollary (`cesaroSummable_of_hasSum`) is
+  also provided.
+* **M2 — strict extension** (`cesaro_strictly_extends_convergence`): Grandi's
+  series witnesses that the converse of regularity fails. Its partial sums
+  `Sₙ = ∑_{i<n} (-1)ⁱ` are (C,1) summable to `1/2`, yet the sequence `Sₙ`
+  itself does *not* converge (it oscillates `0,1,0,1,…`).
+
+The (C,1) mean of Grandi here is computed via the clean closed form
+`∑_{k<n} Sₖ = (n − Sₙ)/2`, giving `cesaroMean = (n − Sₙ)/(2n)` and hence
+`|cesaroMean − 1/2| = |Sₙ|/(2n) ≤ 1/(2n) → 0`.
+
+## Relationship to the parent
+
+The parent `GeometricSeriesOQ01.grandiCesaro_tendsto` averages `S₁,…,Sₙ`
+(an index-shifted variant that drops the empty partial sum `S₀ = 0`); this
+file averages `S₀,…,S_{n-1}`, matching Mathlib's `Filter.Tendsto.cesaro`
+convention exactly. Both averages share the limit `1/2`. The parent's
+`grandi_even`, `grandi_odd`, and `grandi_double_sum` are reused here.
+
+## Axiom / sorry status
+
+No axioms, no sorries. Everything reduces to `Filter.Tendsto.cesaro`,
+`HasSum.tendsto_sum_nat`, and the parent's elementary Grandi lemmas.
+-/
+
+namespace GeometricSeriesOQ01OQ02
+
+open Finset Filter
+
+/-- The Cesàro (C,1) mean of a partial-sum sequence `S`:
+    `σₙ = (1/n) · (S₀ + S₁ + ⋯ + S_{n-1})`. Matches the convention of
+    Mathlib's `Filter.Tendsto.cesaro` (division by `n` over `range n`). -/
+noncomputable def cesaroMean (S : ℕ → ℝ) (n : ℕ) : ℝ :=
+  (n : ℝ)⁻¹ * ∑ k ∈ range n, S k
+
+/-- A partial-sum sequence `S` is **Cesàro (C,1) summable to `L`** if its
+    Cesàro means converge to `L`. -/
+def CesaroSummable (S : ℕ → ℝ) (L : ℝ) : Prop :=
+  Tendsto (cesaroMean S) atTop (nhds L)
+
+-- ============================================================
+-- M1: Regularity of (C,1) summation
+-- ============================================================
+
+/-- **Regularity / consistency of (C,1) summation.**
+    If the partial sums `S N = ∑_{i<N} aᵢ` converge to `s`, then the Cesàro
+    mean of `S` also converges to `s`. Immediate from `Filter.Tendsto.cesaro`. -/
+theorem cesaroSummable_of_tendsto {a : ℕ → ℝ} {s : ℝ}
+    (h : Tendsto (fun N => ∑ i ∈ range N, a i) atTop (nhds s)) :
+    CesaroSummable (fun N => ∑ i ∈ range N, a i) s :=
+  h.cesaro
+
+/-- Corollary: if `∑ aₙ` is unconditionally summable with sum `s`
+    (`HasSum a s`), then its ordered partial sums are (C,1) summable to `s`. -/
+theorem cesaroSummable_of_hasSum {a : ℕ → ℝ} {s : ℝ} (h : HasSum a s) :
+    CesaroSummable (fun N => ∑ i ∈ range N, a i) s :=
+  cesaroSummable_of_tendsto h.tendsto_sum_nat
+
+-- ============================================================
+-- M2: Grandi's series — (C,1) summable but divergent
+-- ============================================================
+
+/-- Closed form for the running sum of Grandi partial sums:
+    `∑_{k<n} (∑_{i<k} (-1)ⁱ) = (n − ∑_{i<n} (-1)ⁱ) / 2`.
+    Proved by induction using `grandi_double_sum` (`2·Sₙ = 1 − (−1)ⁿ`). -/
+theorem sum_grandiPartial (n : ℕ) :
+    (∑ k ∈ range n, (∑ i ∈ range k, (-1 : ℝ) ^ i))
+      = ((n : ℝ) - ∑ i ∈ range n, (-1 : ℝ) ^ i) / 2 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih, Finset.sum_range_succ]
+    have h := GeometricSeriesOQ01.grandi_double_sum n
+    push_cast
+    linarith [h]
+
+/-- The Grandi partial sum `Sₙ = ∑_{i<n} (-1)ⁱ` satisfies `|Sₙ| ≤ 1`
+    (it is `0` for even `n`, `1` for odd `n`). -/
+theorem grandi_partial_abs_le_one (n : ℕ) :
+    |∑ i ∈ range n, (-1 : ℝ) ^ i| ≤ 1 := by
+  have h := GeometricSeriesOQ01.grandi_double_sum n
+  have hb : (-1 : ℝ) ^ n = 1 ∨ (-1 : ℝ) ^ n = -1 := by
+    rcases Nat.even_or_odd n with he | ho
+    · exact Or.inl (Even.neg_one_pow he)
+    · exact Or.inr (Odd.neg_one_pow ho)
+  rw [abs_le]
+  rcases hb with hb | hb <;> rw [hb] at h <;> constructor <;> linarith
+
+/-- The Cesàro mean of Grandi's partial sums in closed form:
+    `σₙ = (1/n) · (n − Sₙ)/2`. -/
+theorem grandiCesaroMean_eq (n : ℕ) :
+    cesaroMean (fun N => ∑ i ∈ range N, (-1 : ℝ) ^ i) n
+      = (n : ℝ)⁻¹ * (((n : ℝ) - ∑ i ∈ range n, (-1 : ℝ) ^ i) / 2) := by
+  simp only [cesaroMean]
+  rw [sum_grandiPartial]
+
+/-- **The Cesàro mean of Grandi's series converges to `1/2`.**
+    Bound: `|σₙ − 1/2| = |Sₙ|/(2n) ≤ 1/(2n)`. -/
+theorem grandiCesaroMean_tendsto :
+    CesaroSummable (fun N => ∑ i ∈ range N, (-1 : ℝ) ^ i) (1 / 2) := by
+  unfold CesaroSummable
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / (2 * ε))
+  refine ⟨max N 1, fun n hn => ?_⟩
+  have hn1 : 0 < n := lt_of_lt_of_le Nat.one_pos (le_of_max_le_right hn)
+  have hnR : (0 : ℝ) < n := Nat.cast_pos.mpr hn1
+  have hne : (n : ℝ) ≠ 0 := ne_of_gt hnR
+  rw [Real.dist_eq, grandiCesaroMean_eq]
+  have hSabs : |∑ i ∈ range n, (-1 : ℝ) ^ i| ≤ 1 := grandi_partial_abs_le_one n
+  set S := ∑ i ∈ range n, (-1 : ℝ) ^ i with hSdef
+  have hkey : (n : ℝ)⁻¹ * (((n : ℝ) - S) / 2) - 1 / 2 = -(S / (2 * (n : ℝ))) := by
+    field_simp
+    ring
+  rw [hkey, abs_neg, abs_div, abs_of_pos (show (0 : ℝ) < 2 * (n : ℝ) by positivity)]
+  have hstep1 : |S| / (2 * (n : ℝ)) ≤ 1 / (2 * (n : ℝ)) := by gcongr
+  have hstep2 : 1 / (2 * (n : ℝ)) < ε := by
+    rw [div_lt_iff₀ (show (0 : ℝ) < 2 * (n : ℝ) by positivity)]
+    have hNn : (N : ℝ) ≤ n := by exact_mod_cast le_of_max_le_left hn
+    have hb2 : 1 / (2 * ε) < (n : ℝ) := lt_of_lt_of_le hN hNn
+    rw [div_lt_iff₀ (show (0 : ℝ) < 2 * ε by positivity)] at hb2
+    nlinarith
+  linarith
+
+/-- Grandi's partial sums do **not** converge: the even subsequence is `0`,
+    the odd subsequence is `1`, so no single limit can exist. -/
+theorem grandi_partial_not_tendsto :
+    ¬ ∃ L, Tendsto (fun N => ∑ i ∈ range N, (-1 : ℝ) ^ i) atTop (nhds L) := by
+  rintro ⟨L, hL⟩
+  have h2 : Tendsto (fun m : ℕ => 2 * m) atTop atTop :=
+    Filter.tendsto_atTop_atTop.2 (fun b => ⟨b, fun a ha => by omega⟩)
+  have h2' : Tendsto (fun m : ℕ => 2 * m + 1) atTop atTop :=
+    Filter.tendsto_atTop_atTop.2 (fun b => ⟨b, fun a ha => by omega⟩)
+  -- even subsequence ⟹ L = 0
+  have heven : Tendsto (fun m : ℕ => ∑ i ∈ range (2 * m), (-1 : ℝ) ^ i)
+      atTop (nhds L) := hL.comp h2
+  have hL0 : L = 0 := by
+    have hc : (fun m : ℕ => ∑ i ∈ range (2 * m), (-1 : ℝ) ^ i) = (fun _ => (0 : ℝ)) := by
+      funext m; exact GeometricSeriesOQ01.grandi_even m
+    rw [hc] at heven
+    exact tendsto_nhds_unique heven tendsto_const_nhds
+  -- odd subsequence ⟹ L = 1
+  have hodd : Tendsto (fun m : ℕ => ∑ i ∈ range (2 * m + 1), (-1 : ℝ) ^ i)
+      atTop (nhds L) := hL.comp h2'
+  have hL1 : L = 1 := by
+    have hc : (fun m : ℕ => ∑ i ∈ range (2 * m + 1), (-1 : ℝ) ^ i) = (fun _ => (1 : ℝ)) := by
+      funext m; exact GeometricSeriesOQ01.grandi_odd m
+    rw [hc] at hodd
+    exact tendsto_nhds_unique hodd tendsto_const_nhds
+  rw [hL0] at hL1
+  norm_num at hL1
+
+/-- **(C,1) summability strictly extends convergence.**
+    Grandi's series is (C,1) summable to `1/2` but its partial sums diverge. -/
+theorem cesaro_strictly_extends_convergence :
+    CesaroSummable (fun N => ∑ i ∈ range N, (-1 : ℝ) ^ i) (1 / 2)
+      ∧ ¬ ∃ L, Tendsto (fun N => ∑ i ∈ range N, (-1 : ℝ) ^ i) atTop (nhds L) :=
+  ⟨grandiCesaroMean_tendsto, grandi_partial_not_tendsto⟩
+
+-- ============================================================
+-- Sanity checks
+-- ============================================================
+
+#check @cesaroSummable_of_tendsto
+#check @cesaroSummable_of_hasSum
+#check @grandiCesaroMean_tendsto
+#check @cesaro_strictly_extends_convergence
+
+end GeometricSeriesOQ01OQ02

--- a/research/problems/geometric-series-oq-01-oq-02/knowledge.md
+++ b/research/problems/geometric-series-oq-01-oq-02/knowledge.md
@@ -5,9 +5,14 @@
 **Problem**: Formalize the general Cesàro (C,1) regularity theorem — if a series
 `∑ aₙ` converges to `s`, then its Cesàro mean converges to the same `s`.
 
-**Status**: ORIENT (S1, 2026-06-14). OQ resolved on paper; reduces to Mathlib's
-`Filter.Tendsto.cesaro`. Buildable (< 80 LOC), no Mathlib gap. ACT deferred —
-Docker verification host down this session.
+**Status**: ACT (S2, 2026-06-15, researcher-6). Lean file written, build-pending
+(Docker host still down, Aristotle only fills sorries so cannot typecheck a
+sorry-free file). The S1 plan (M1 regularity via `Filter.Tendsto.cesaro`, M2
+Grandi converse-failure) is fully realized in
+`proofs/Proofs/GeometricSeriesOQ01OQ02.lean` — 0 sorries, 0 axioms.
+
+**Status (S1)**: ORIENT (2026-06-14). OQ resolved on paper; reduces to Mathlib's
+`Filter.Tendsto.cesaro`. Buildable (< 80 LOC), no Mathlib gap.
 
 **Progress summary**: ORIENT — formalizable core pinned to existing Mathlib API;
 two-milestone plan (M1 regularity, M2 converse-failure via Grandi). No Lean
@@ -35,7 +40,13 @@ written yet.
 
 ## Built items
 
-- (none — ORIENT only; no Lean written this session)
+- `GeometricSeriesOQ01OQ02.cesaroMean` / `CesaroSummable`
+  (`proofs/Proofs/GeometricSeriesOQ01OQ02.lean`).
+- M1 `cesaroSummable_of_tendsto`, `cesaroSummable_of_hasSum` (regularity).
+- M2 `sum_grandiPartial`, `grandi_partial_abs_le_one`, `grandiCesaroMean_eq`,
+  `grandiCesaroMean_tendsto`, `grandi_partial_not_tendsto`,
+  `cesaro_strictly_extends_convergence`.
+- All 0 sorries / 0 axioms; **build-pending** (Docker host down at S2).
 
 ## Mathlib gaps
 
@@ -56,6 +67,53 @@ written yet.
 5. Add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` and build-verify.
 
 ## Sessions
+
+### Session 2026-06-15 (S2) — ACT: wrote the Lean file (build-pending)
+
+**Mode**: REVISIT (claimed available, RICH knowledge from S1)
+**Outcome**: progress — Lean file written, 0 sorries / 0 axioms, build-pending
+
+#### What I did
+- Confirmed `Filter.Tendsto.cesaro` signature via web (Mathlib4 docs):
+  `(h : Tendsto u atTop (𝓝 l)) : Tendsto (fun n => (↑n)⁻¹ * ∑ i ∈ range n, u i) atTop (𝓝 l)`.
+  Defined `cesaroMean S n := (↑n)⁻¹ * ∑ k ∈ range n, S k` to match this convention
+  exactly, so M1 is a definitional application.
+- Wrote `proofs/Proofs/GeometricSeriesOQ01OQ02.lean`:
+  - `cesaroMean`, `CesaroSummable` (predicate on the partial-sum sequence).
+  - **M1** `cesaroSummable_of_tendsto := h.cesaro` (term-mode, via defeq) +
+    `cesaroSummable_of_hasSum` corollary via `HasSum.tendsto_sum_nat`.
+  - **M2** Grandi converse-failure:
+    - `sum_grandiPartial`: closed form `∑_{k<n} Sₖ = (n − Sₙ)/2`, induction +
+      parent `grandi_double_sum`.
+    - `grandi_partial_abs_le_one`: `|Sₙ| ≤ 1` via parity of `(−1)ⁿ`.
+    - `grandiCesaroMean_eq`: `σₙ = (1/n)·(n − Sₙ)/2`.
+    - `grandiCesaroMean_tendsto`: `σₙ → 1/2` (bound `|σₙ−1/2| = |Sₙ|/(2n) ≤ 1/(2n)`).
+    - `grandi_partial_not_tendsto`: partial sums diverge (even subseq → 0, odd → 1).
+    - `cesaro_strictly_extends_convergence`: the headline ∧.
+- Could NOT verify the build: Docker host down; Aristotle MCP only proves
+  `sorry`s so it cannot typecheck a sorry-free file. File shipped build-pending
+  and **UNREGISTERED** in `Proofs.lean` (protects the aggregate build /
+  auto-merge until a Docker session verifies it).
+
+#### Key findings
+- The clean real identity `∑_{k<n} Sₖ = (n − Sₙ)/2` (proved from `2Sₙ = 1−(−1)ⁿ`)
+  gives `σₙ − 1/2 = −Sₙ/(2n)` exactly — sidesteps the parent's `⌈n/2⌉/n` ceiling
+  arithmetic and the index-shift between the two Cesàro conventions.
+- M1 is genuinely one line: matching `cesaroMean`'s shape to `Filter.Tendsto.cesaro`
+  makes the regularity theorem a definitional rewrite of the Mathlib lemma.
+
+#### Files modified
+- `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` (new, ~200 lines incl. docstring)
+- `research/problems/geometric-series-oq-01-oq-02/knowledge.md` (this update)
+
+#### Next steps (when Docker returns)
+1. `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02`; fix any
+   API drift (candidate risk points: `gcongr` leaf on `|S| ≤ 1`, `field_simp`
+   in `hkey`, `div_lt_iff₀` name).
+2. Register `import Proofs.GeometricSeriesOQ01OQ02` in `Proofs.lean`.
+3. Add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` (meta.json +
+   proof.md); status `verified`, badge `original`, 0 axioms / 0 sorries —
+   only after the build is green.
 
 ### Session 2026-06-14 (S1) — ORIENT feasibility survey
 


### PR DESCRIPTION
## Summary

Realizes the S1 ORIENT plan for **geometric-series-oq-01-oq-02** (the general Cesàro (C,1) regularity theorem) in Lean. New file `proofs/Proofs/GeometricSeriesOQ01OQ02.lean`, 0 sorries / 0 axioms.

- **M1 — regularity** (`cesaroSummable_of_tendsto`): if the partial sums `S N = ∑_{i<N} aᵢ` converge to `s`, then the Cesàro mean of `S` converges to `s`. `cesaroMean` is defined to match Mathlib's `Filter.Tendsto.cesaro` convention exactly, so the proof is the term `h.cesaro` (definitional). `cesaroSummable_of_hasSum` is the `HasSum` corollary via `HasSum.tendsto_sum_nat`.
- **M2 — strict extension** (`cesaro_strictly_extends_convergence`): Grandi's series is (C,1) summable to `1/2` (`grandiCesaroMean_tendsto`) yet its partial sums diverge (`grandi_partial_not_tendsto`: even subsequence → 0, odd → 1). The mean is computed via the clean identity `∑_{k<n} Sₖ = (n − Sₙ)/2` (`sum_grandiPartial`), giving `σₙ − 1/2 = −Sₙ/(2n)` and `|σₙ − 1/2| ≤ 1/(2n)`.

Reuses the parent `GeometricSeriesOQ01`'s `grandi_even`, `grandi_odd`, `grandi_double_sum`.

## Build status

⚠️ **Build-pending and UNREGISTERED in `Proofs.lean`.** Docker verification host is down this session and Aristotle only fills `sorry`s (cannot typecheck a sorry-free file). The file is intentionally **not** imported in `Proofs.lean` so the aggregate build / auto-merge is not put at risk by an unverified file. A follow-up Docker session should:

1. `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02`
2. register the import in `Proofs.lean`
3. add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` (status `verified`, badge `original`) once green.

Candidate API risk points to check on build: `gcongr` leaf `|S| ≤ 1`, `field_simp` in `hkey`, `div_lt_iff₀`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02` succeeds (0 errors, 0 sorries)
- [ ] register import + gallery entry in a follow-up once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)