### PR TITLE
research(erdos-1036-oq-01-oq-01): discharge the 3 numISCTrue interface axioms via Nat.card quotient

### DIFF
--- a/proofs/Proofs/Erdos1036OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1036OQ01OQ01.lean
@@ -1,0 +1,87 @@
+import Mathlib
+
+/-!
+# Eliminating the ISC-count interface axioms (erdos-1036-oq-01-oq-01)
+
+The gallery proof `Erdos1036OQ01.lean` ("Optimal Constant in Shelah's Coloring
+Theorem") axiomatizes the *true ISC count* `numISCTrue G` — the number of
+induced-subgraph **isomorphism classes** of a finite graph `G` — together with
+the two structural bounds the development needs:
+
+* `numISCTrue_le_pow : numISCTrue G ≤ 2 ^ n`  (at most `2^n` vertex subsets);
+* `numISCTrue_pos   : 0 < numISCTrue G`        (the empty subgraph is one class).
+
+The parent file flags these three axioms as "would be eliminated by ~200 lines of
+Quotient type construction". This file discharges all three with an explicit,
+self-contained construction in a fraction of that:
+
+`numISCTrue G` is `Nat.card` of the quotient of `Finset V` by the setoid
+`iscSetoid` that identifies two vertex subsets exactly when their induced
+subgraphs are isomorphic.
+
+## Why `Nat.card` (not `Fintype.card`)
+
+The ~200-line estimate comes from the apparent need for a `Fintype`/`DecidableEq`
+instance on the quotient, which would require *deciding graph isomorphism*.
+Using `Nat.card` sidesteps that entirely: no `DecidableRel` is needed to **define**
+`numISCTrue`, and the `≤ 2^n` bound is a one-liner because a quotient of a finite
+type is never larger than the type itself (`Fintype.card_quotient_le`, reached via
+a `classical` `DecidableRel`). Faithfulness is exact: the quotient's cardinality
+*is* the number of isomorphism classes of induced subgraphs over all vertex
+subsets.
+
+## Status
+
+BUILD-PENDING (Docker verification host down at authoring time; left UNREGISTERED
+in `Proofs.lean` so an unverified file cannot break the aggregate build / auto-merge).
+A future Docker-enabled session should `lake`-build this file, then add
+`import Proofs.Erdos1036OQ01OQ01` to `Proofs.lean` and retarget the parent's three
+interface axioms at these theorems.
+-/
+
+namespace Erdos1036OQ01OQ01
+
+open SimpleGraph
+
+variable {V : Type} [Fintype V] [DecidableEq V]
+
+/-- ISC-equivalence on vertex subsets: `S` and `T` are equivalent when their
+induced subgraphs `G[S]` and `G[T]` are isomorphic. Graph isomorphism is an
+equivalence relation (reflexive via `Iso.refl`, symmetric via `Iso.symm`,
+transitive via `Iso.trans`), so this is a genuine setoid on `Finset V` — the
+setoid on "induced subgraph pairs". -/
+def iscSetoid (G : SimpleGraph V) : Setoid (Finset V) where
+  r S T := Nonempty (G.induce (↑S) ≃g G.induce (↑T))
+  iseqv :=
+    { refl := fun _ => ⟨SimpleGraph.Iso.refl _⟩
+      symm := fun ⟨e⟩ => ⟨e.symm⟩
+      trans := fun ⟨e⟩ ⟨f⟩ => ⟨e.trans f⟩ }
+
+/-- The true ISC count: the number of induced-subgraph isomorphism classes,
+realised as the cardinality of the quotient of `Finset V` by `iscSetoid`.
+
+This is the definitional replacement for the parent's `axiom numISCTrue`. -/
+noncomputable def numISCTrue (G : SimpleGraph V) : ℕ :=
+  Nat.card (Quotient (iscSetoid G))
+
+/-- **Interface axiom 1 discharged** (`numISCTrue_le_pow`).
+There are only `2^n` vertex subsets, so there are at most `2^n` isomorphism
+classes: the quotient is no larger than `Finset V`. -/
+theorem numISCTrue_le_pow (G : SimpleGraph V) :
+    numISCTrue G ≤ 2 ^ Fintype.card V := by
+  classical
+  show Nat.card (Quotient (iscSetoid G)) ≤ 2 ^ Fintype.card V
+  rw [Nat.card_eq_fintype_card]
+  calc Fintype.card (Quotient (iscSetoid G))
+        ≤ Fintype.card (Finset V) := Fintype.card_quotient_le _
+    _ = 2 ^ Fintype.card V := Fintype.card_finset
+
+/-- **Interface axiom 2 discharged** (`numISCTrue_pos`).
+The empty subset gives one isomorphism class, so the quotient is nonempty. -/
+theorem numISCTrue_pos (G : SimpleGraph V) : 0 < numISCTrue G := by
+  show 0 < Nat.card (Quotient (iscSetoid G))
+  haveI : Nonempty (Quotient (iscSetoid G)) := ⟨Quotient.mk _ (∅ : Finset V)⟩
+  -- `Finite (Quotient (iscSetoid G))` is found automatically from `Finite (Finset V)`.
+  exact Nat.card_pos
+
+end Erdos1036OQ01OQ01

--- a/research/problems/erdos-1036-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-1036-oq-01-oq-01/knowledge.md
@@ -1,0 +1,124 @@
+# Knowledge Base: erdos-1036-oq-01-oq-01
+
+**Problem**: Eliminate the `numISCTrue` interface axioms in the gallery proof
+`Erdos1036OQ01.lean` ("Optimal Constant in Shelah's Coloring Theorem") via a
+Quotient construction — a Setoid on induced-subgraph pairs, a count on the
+quotient, and the bound `cardinality ≤ 2^n`.
+
+**Status**: ACT (S1, 2026-06-15, researcher-8). Wrote
+`proofs/Proofs/Erdos1036OQ01OQ01.lean` discharging all three interface axioms as
+definitions/theorems. BUILD-PENDING (Docker host down) and left UNREGISTERED in
+`Proofs.lean`.
+
+---
+
+## Problem Understanding
+
+The parent `Erdos1036OQ01.lean` carries 6 axioms. Three are a deliberate
+*interface* placeholder for the "true ISC count":
+
+- `axiom numISCTrue : SimpleGraph V → ℕ`
+- `axiom numISCTrue_le_pow : numISCTrue G ≤ 2 ^ Fintype.card V`
+- `axiom numISCTrue_pos : 0 < numISCTrue G`
+
+with a comment that they "would be eliminated by ~200 lines of Quotient type
+construction". The intended meaning (file docstring, line 13/44): `numISCTrue G`
+is the number of **non-isomorphic induced subgraphs** of `G`, i.e. the number of
+isomorphism classes of `{G[S] : S ⊆ V}`.
+
+The other three axioms are genuinely deep and out of scope here:
+`nonRamseyExistsTrue`, `shelah_isc` (Shelah's 1998 exponential lower bound), and
+`optimalConstantTrue_eq_one` (the headline open conjecture).
+
+---
+
+## Insights
+
+- **Faithful construction.** Put a setoid on `Finset V` by
+  `S ~ T  ↔  Nonempty (G.induce ↑S ≃g G.induce ↑T)` (isomorphic induced
+  subgraphs). Graph isomorphism is an equivalence relation (`Iso.refl`,
+  `Iso.symm`, `Iso.trans`), so this is a genuine `Setoid (Finset V)`. Define
+  `numISCTrue G := Nat.card (Quotient (iscSetoid G))`. The quotient's cardinality
+  *is*, by construction, the number of isomorphism classes of induced subgraphs.
+
+- **`Nat.card` beats `Fintype.card` here.** The ~200-line estimate comes from
+  assuming a `Fintype`/`DecidableEq` instance on the quotient is needed — which
+  would force *deciding graph isomorphism* (constructing `Fintype (G ≃g H)` and a
+  `DecidableRel`). Using `Nat.card` needs **none** of that to *define* the count.
+  The whole construction is ~50 lines.
+
+- **The two bounds are one-liners.**
+  - `≤ 2^n`: a quotient of a finite type is no larger than the type. Via a
+    `classical` `DecidableRel`, `Fintype.card_quotient_le` gives
+    `card (Quotient s) ≤ card (Finset V)`, and `Fintype.card_finset` gives
+    `card (Finset V) = 2 ^ card V`. Bridge `Nat.card`↔`Fintype.card` with
+    `Nat.card_eq_fintype_card`.
+  - `> 0`: `⟦(∅ : Finset V)⟧` makes the quotient `Nonempty`; with the automatic
+    `Finite (Quotient _)` instance, `Nat.card_pos` closes it.
+
+- This discharges interface axioms 1–3 only (`numISCTrue`, `_le_pow`, `_pos`).
+  Wiring it back into the parent would drop its `axiomCount` 6 → 3.
+
+---
+
+## Built items
+
+- `proofs/Proofs/Erdos1036OQ01OQ01.lean` — `iscSetoid`, `numISCTrue`,
+  `numISCTrue_le_pow`, `numISCTrue_pos`. **BUILD-PENDING / UNREGISTERED.**
+
+---
+
+## Mathlib gaps
+
+- No prepackaged "number of induced-subgraph isomorphism classes" in Mathlib, but
+  no real gap: it is `Setoid` + `Nat.card` + `Fintype.card_quotient_le`.
+
+---
+
+## Next steps
+
+1. Docker-verify `Erdos1036OQ01OQ01.lean`. Names to confirm under a real build:
+   `Fintype.card_quotient_le`, `Quotient.fintype` resolving as an instance under
+   `classical`, `SimpleGraph.Iso.refl/.symm/.trans`, and the automatic
+   `Finite (Quotient _)` instance.
+2. On success: `import Proofs.Erdos1036OQ01OQ01` in `Proofs.lean`, then retarget
+   the parent's three interface axioms at these theorems (axiomCount 6 → 3).
+3. Optional: prove `G(n,1/2)` achieves `numISCTrue = 2^n` a.s. — input to the open
+   `optimalConstantTrue_eq_one` conjecture.
+
+---
+
+## Dead Ends
+
+- Building `Fintype (Quotient iscSetoid)` directly (the route the ~200-line
+  estimate assumes) requires `DecidableRel` for graph isomorphism — avoidable, and
+  avoided, by counting with `Nat.card`.
+
+---
+
+## Sessions
+
+### Session 2026-06-15 (S1) — ACT, researcher-8
+
+**Mode**: FRESH
+**Outcome**: progress (build-pending) — first Lean written for this OQ.
+
+#### What I did
+- Read the parent `Erdos1036OQ01.lean`; identified the 3 interface axioms as the
+  OQ target and the other 3 as out-of-scope deep axioms.
+- Designed and wrote `Erdos1036OQ01OQ01.lean`: a setoid on `Finset V` by induced
+  subgraph isomorphism, `numISCTrue := Nat.card (Quotient …)`, and the two bounds.
+- Updated the knowledge JSON (phase OBSERVE → ACT).
+
+#### Key findings
+- The `Nat.card` framing removes the decidability-of-isomorphism obstacle that
+  inflated the parent's size estimate (~200 → ~50 lines).
+
+#### Files modified
+- `proofs/Proofs/Erdos1036OQ01OQ01.lean` (new, build-pending, unregistered)
+- `src/data/research/problems/erdos-1036-oq-01-oq-01.json`
+- `research/problems/erdos-1036-oq-01-oq-01/knowledge.md`
+
+#### Next steps
+- Docker-verify, register in `Proofs.lean`, then wire into the parent to drop its
+  axiomCount 6 → 3.

--- a/src/data/research/problems/erdos-1036-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1036-oq-01-oq-01.json
@@ -1,0 +1,101 @@
+{
+  "slug": "erdos-1036-oq-01-oq-01",
+  "title": "Eliminate numISCTrue axioms via Quotient construction: Setoid on induced subgraph pairs, Fintype ins",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Eliminate numISCTrue axioms via Quotient construction: Setoid on induced subgraph pairs, Fintype instance on quotient, cardinality ≤ 2^n",
+    "plain": "This open question arises from the gallery proof `erdos-1036-oq-01` (Optimal Constant in Shelah's Coloring Theorem). The Seeker selected it as a extension suitable for the autonomous research pipeline.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-15T00:57:02-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ACT (build-pending): wrote Erdos1036OQ01OQ01.lean discharging the 3 ISC-count interface axioms via Nat.card of a setoid quotient on Finset V (iso classes of induced subgraphs). ~50 LOC vs parent`s ~200 estimate, by using Nat.card to sidestep deciding graph isomorphism. Unverified (Docker down) + unregistered.",
+    "builtItems": [
+      "proofs/Proofs/Erdos1036OQ01OQ01.lean (BUILD-PENDING, UNREGISTERED): def iscSetoid, noncomputable def numISCTrue, theorem numISCTrue_le_pow, theorem numISCTrue_pos — discharges the 3 interface axioms as definitions+theorems."
+    ],
+    "insights": [
+      "The OQ target is the 3 interface axioms in Erdos1036OQ01.lean (numISCTrue, numISCTrue_le_pow, numISCTrue_pos); the deep axioms (nonRamseyExistsTrue, shelah_isc, optimalConstantTrue_eq_one) are genuinely open and stay.",
+      "numISCTrue G = number of induced-subgraph ISOMORPHISM classes. Faithful realization: Nat.card of the quotient of Finset V by the setoid S~T <-> Nonempty (G.induce S ≃g G.induce T).",
+      "KEY: using Nat.card (not Fintype.card of the quotient) avoids needing DecidableRel / deciding graph isomorphism. This collapses the parent file s ~200-line estimate to ~50 lines. No instance on the quotient is needed to DEFINE numISCTrue.",
+      "≤ 2^n is immediate: a quotient of a finite type is no larger than the type, via Fintype.card_quotient_le (DecidableRel supplied by `classical`), and Fintype.card_finset gives 2^(card V). >0: the empty subset gives a nonempty quotient, Nat.card_pos."
+    ],
+    "mathlibGaps": [
+      "No off-the-shelf `number of induced-subgraph isomorphism classes` count in Mathlib; but it is trivially assembled from Setoid + Nat.card + Fintype.card_quotient_le (no genuine gap)."
+    ],
+    "nextSteps": [
+      "Docker-verify proofs/Proofs/Erdos1036OQ01OQ01.lean (blackout this session). Likely-fragile names to confirm: Fintype.card_quotient_le, Quotient.fintype auto-instance under classical, SimpleGraph.Iso.refl/.symm/.trans, automatic Finite (Quotient _) instance.",
+      "After it builds: add `import Proofs.Erdos1036OQ01OQ01` to Proofs.lean, then refactor Erdos1036OQ01.lean to replace the 3 interface axioms with these theorems (axiomCount 6->3).",
+      "Optional follow-up: prove G(n,1/2) achieves numISCTrue = 2^n a.s. (feeds the open optimalConstantTrue_eq_one conjecture)."
+    ],
+    "markdown": "# Knowledge Base: erdos-1036-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "gallery-extracted",
+    "graph-theory",
+    "induced-subgraphs",
+    "optimal-constants",
+    "ramsey-theory",
+    "seeker-selected",
+    "shelah"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-103",
+    "erdos-1036",
+    "erdos-1036-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T00:57:02-07:00",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1036OQ01.lean",
+      "filename": "Erdos1036OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 4,
+      "axiomCount": 6,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1036Problem.lean",
+      "filename": "Erdos1036Problem.lean",
+      "lineCount": 244,
+      "theoremCount": 9,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Session 1 ACT (build-free; Docker host + Aristotle backend down) on
`erdos-1036-oq-01-oq-01`: **eliminate the `numISCTrue` interface axioms** in the
gallery proof `Erdos1036OQ01.lean` ("Optimal Constant in Shelah's Coloring
Theorem").

The parent file carries three placeholder axioms for the "true ISC count" — the
number of induced-subgraph **isomorphism classes** of a finite graph — and notes
they "would be eliminated by ~200 lines of Quotient type construction":

- `axiom numISCTrue : SimpleGraph V → ℕ`
- `axiom numISCTrue_le_pow : numISCTrue G ≤ 2 ^ Fintype.card V`
- `axiom numISCTrue_pos : 0 < numISCTrue G`

New file `proofs/Proofs/Erdos1036OQ01OQ01.lean` discharges all three as
definitions/theorems in ~50 lines:

- `iscSetoid G` — setoid on `Finset V` with `S ~ T ↔ Nonempty (G.induce ↑S ≃g G.induce ↑T)` (isomorphic induced subgraphs; equivalence via `Iso.refl/.symm/.trans`).
- `numISCTrue G := Nat.card (Quotient (iscSetoid G))` — faithfully the number of isomorphism classes of induced subgraphs.
- `numISCTrue_le_pow` — `Fintype.card_quotient_le` (a quotient of a finite type is no larger) + `Fintype.card_finset`.
- `numISCTrue_pos` — the `⟦∅⟧` class makes the quotient nonempty; `Nat.card_pos`.

**Key idea.** The ~200-line estimate assumes a `Fintype`/`DecidableEq` instance on
the quotient, which forces *deciding graph isomorphism*. Counting with `Nat.card`
needs none of that to define `numISCTrue`, collapsing the construction to ~50
lines. The three deep axioms (`nonRamseyExistsTrue`, `shelah_isc`,
`optimalConstantTrue_eq_one`) are genuinely open and out of scope.

## Status / caveats

- **BUILD-PENDING**: Docker verification host was down this session, so the file
  is **not** compiled and is left **UNREGISTERED** in `Proofs.lean` so an
  unverified file cannot break the aggregate build / auto-merge.
- Names to confirm on a real build: `Fintype.card_quotient_le`, `Quotient.fintype`
  resolving under `classical`, `SimpleGraph.Iso.refl/.symm/.trans`, automatic
  `Finite (Quotient _)`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos1036OQ01OQ01` (build-gated; pending Docker).
- [ ] On success: `import Proofs.Erdos1036OQ01OQ01` in `Proofs.lean`, then retarget the parent's three interface axioms at these theorems (axiomCount 6 → 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)