### PR TITLE
research: greens-theorem-oq-02-oq-02 (keystone verify) + zsqrtd-neg-two-oq-02 (OBSERVE)

### DIFF
--- a/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
@@ -150,3 +150,23 @@ DONE (2026-06-13, doc-only): the OQ02 axiom docstring already states the accurat
 **Next Steps**
 - Bump `proofs/lakefile.toml` Mathlib pin to ≥ v4.28.0 on a dedicated branch; rebuild the full proof corpus under Docker to catch unrelated breakage **before** relying on it.
 - Then discharge `greens_theorem_l1curl` per the revised approach above and flip the `axiom` to a proved `theorem`.
+
+---
+
+## Session 2 update (2026-06-15, researcher-3) — upstream signatures VERIFIED
+
+The S1 keystone-existence claim is now **independently confirmed against
+Mathlib `master`** (S1 cited PR #29508 but never checked the live names). Both
+load-bearing wiring lemmas exist with these exact current signatures:
+
+- `AbsolutelyContinuousOnInterval.integral_deriv_eq_sub (hf) : ∫ x in a..b, deriv f x = f b - f a` (FTC for AC)
+- `IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral (h) (hc : c ∈ uIcc a b) : AbsolutelyContinuousOnInterval (fun x ↦ ∫ v in c..x, f v) a b`
+
+**Refinement**: lemma (2) carries `hc : c ∈ uIcc a b`, not recorded in S1.
+Wiring discharges it with `left_mem_uIcc` / `right_mem_uIcc` (base-point is an
+endpoint).
+
+A pinned 5-step Fubini-reduction blueprint mapping `greens_theorem_l1curl` to
+these lemmas (reusing OQ01's boundary algebra) is in
+`sessions/2026-06-15-s2-keystone-signature-verification.md`. Blocker unchanged:
+the gating Mathlib bump (v4.26.0 → ≥ v4.28.0) is cross-corpus + Docker-gated.

--- a/research/problems/greens-theorem-oq-02-oq-02/sessions/2026-06-15-s2-keystone-signature-verification.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/sessions/2026-06-15-s2-keystone-signature-verification.md
@@ -1,0 +1,150 @@
+# Session 2 — Upstream keystone signature verification + pinned Fubini blueprint (researcher-3, 2026-06-15)
+
+**Phase**: DECIDE (unchanged) — blocker is a Mathlib version bump, Docker-gated.
+
+## Goal
+
+The Session 1 survey reduced the whole OQ ("can `greens_theorem_l1curl` be
+discharged from Mathlib's BV + AC API?") to the existence of one upstream
+keystone: the **function-level FTC for absolutely continuous functions**. The
+S1 knowledge note asserted that keystone landed in Mathlib v4.28.0 (PR #29508)
+under the name `AbsolutelyContinuousOnInterval.integral_deriv_eq_sub`, citing
+PR numbers but **not independently checked against the live Mathlib tree**.
+
+Lemma names drift between releases, and the entire DECIDE verdict (and the
+recommended post-bump wiring) rests on that one name being real and stable.
+This session independently verifies the load-bearing upstream lemmas against
+**Mathlib `master`** and pins their exact current signatures, so the eventual
+post-bump wiring is correct first-try.
+
+## Verified facts (Mathlib `master`, fetched 2026-06-15)
+
+All three load-bearing declarations exist on master with the names the S1
+survey predicted. Exact current signatures:
+
+**(1) FTC for AC functions** — the keystone
+`Mathlib/MeasureTheory/Integral/IntervalIntegral/AbsolutelyContinuousFun.lean`
+```lean
+theorem AbsolutelyContinuousOnInterval.integral_deriv_eq_sub
+    {f : ℝ → ℝ} {a b : ℝ}
+    (hf : AbsolutelyContinuousOnInterval f a b) :
+    ∫ (x : ℝ) in a..b, deriv f x = f b - f a
+```
+
+**(2) Indefinite interval integral is AC** — the second wiring lemma
+`Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean`
+```lean
+theorem _root_.IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral
+    {f : ℝ → ℝ} {a b c : ℝ}
+    (h : IntervalIntegrable f volume a b)
+    (hc : c ∈ uIcc a b) :
+    AbsolutelyContinuousOnInterval (fun x ↦ ∫ v in c..x, f v) a b
+```
+
+**(3) IBP for AC functions** (available, likely not needed for the rectangle
+reduction but useful if the boundary algebra is restructured)
+```lean
+theorem AbsolutelyContinuousOnInterval.integral_mul_deriv_eq_deriv_mul
+    {f g : ℝ → ℝ} {a b : ℝ}
+    (hf : AbsolutelyContinuousOnInterval f a b)
+    (hg : AbsolutelyContinuousOnInterval g a b) :
+    ∫ x in a..b, f x * deriv g x =
+      f b * g b - f a * g a - ∫ x in a..b, deriv f x * g x
+```
+
+**AC predicate definition** (root namespace, real-valued via the `dist`
+formulation; works for any `X` with the metric structure):
+```lean
+def _root_.AbsolutelyContinuousOnInterval (f : ℝ → X) (a b : ℝ) :=
+  Tendsto (fun E ↦ ∑ i ∈ Finset.range E.1, dist (f (E.2 i).1) (f (E.2 i).2))
+    (totalLengthFilter ⊓ 𝓟 (disjWithin a b)) (𝓝 0)
+```
+
+### Correction / refinement vs S1 knowledge
+
+The S1 note recorded lemma (2) as
+`IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral` but did
+**not** record its `hc : c ∈ uIcc a b` hypothesis. The wiring must supply that
+membership proof for the base-point of each indefinite integral. For the
+rectangle reduction the base-point is an endpoint of the integration interval,
+so `hc` discharges by `left_mem_uIcc` / `right_mem_uIcc`. Recording this now
+avoids a first-try wiring miss.
+
+## Pinned Fubini-reduction blueprint (post-bump)
+
+This is the discharge recipe for `greens_theorem_l1curl`
+(`proofs/Proofs/GreensTheoremOQ02.lean:350`), mapped step-by-step to the
+verified upstream lemmas. It is a **blueprint, not committed Lean** — it cannot
+compile at the current `v4.26.0` pin (the lemmas above do not exist there) and
+cannot be Docker-verified during the blackout. It is written so that whoever
+performs the version bump can transcribe it directly.
+
+1. **Split the double integral by Fubini.** The RHS
+   `∫ p in Ioo a b ×ˢ Ioo c d, curlF p` rewrites, via `hCurlAE`, to
+   `∫ p, (deriv (fun x => Q (x, p.2)) p.1 - deriv (fun y => P (p.1, y)) p.2)`.
+   Linearity (`integral_sub`, needs each summand integrable from `hL1` +
+   `hCurlAE`) splits it into a `Q`-term and a `P`-term. Apply
+   `MeasureTheory.integral_prod` (Fubini) to each, turning the product
+   integral into iterated 1D integrals over `Ioo c d` (outer) and `Ioo a b`
+   (inner) and vice-versa.
+
+2. **Inner 1D FTC, `Q`-term.** Fix `y ∈ Ioo c d`. The inner integral is
+   `∫ x in a..b, deriv (fun x => Q (x, y)) x`. The slice `x ↦ Q (x, y)` is the
+   indefinite integral of its (L¹, a.e.) partial up to an additive constant:
+   exhibit it as `Q (a, y) + ∫ t in a..x, (∂Q/∂x)(t, y)` and apply
+   lemma (2) `IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral`
+   (with `c := a`, `hc := left_mem_uIcc`) to get
+   `AbsolutelyContinuousOnInterval (x ↦ Q (x, y)) a b`. Then lemma (1)
+   `AbsolutelyContinuousOnInterval.integral_deriv_eq_sub` gives
+   `∫ x in a..b, deriv (fun x => Q (x,y)) x = Q (b, y) - Q (a, y)`.
+
+3. **Inner 1D FTC, `P`-term.** Symmetric with roles `x ↔ y`, `a,b ↔ c,d`:
+   `∫ y in c..d, deriv (fun y => P (x, y)) y = P (x, d) - P (x, c)`.
+
+4. **Assemble boundary line integral.** The outer integrals of the
+   `Q (b,y) - Q (a,y)` and `P (x,c) - P (x,d)` differences reassemble exactly
+   the four edge contributions of `lipschitzLineIntegral P Q C` under
+   `hTraversal` (the curve traverses `frontier (Icc a b ×ˢ Icc c d)`
+   counterclockwise). **Reuse OQ01's boundary algebra** — the axiom-free
+   `GreensTheoremOQ01.lean` already assembles these four edge integrals into
+   `lipschitzLineIntegral`; the only new content versus OQ01 is steps 2–3
+   (AC-FTC in place of pointwise `intervalIntegral.integral_eq_sub_of_hasDerivAt`).
+
+5. **C¹ sanity check.** When `curlF` comes from genuine `HasDerivAt` partials,
+   `C¹ ⟹ AC` on the compact rectangle, so this reduction must reproduce
+   `greens_oq1_from_l1curl`. This is the cross-check the wiring must satisfy.
+
+## Blocker (unchanged) and why no Lean shipped this cycle
+
+The gating step is the **Mathlib bump `v4.26.0 → ≥ v4.28.0`** (master/current
+stable carry the lemmas). That bump is:
+- **cross-corpus** — it can surface unrelated breakage across the whole proof
+  set, so it must be done on a dedicated branch with a full Docker rebuild of
+  the corpus before anything relies on it;
+- **Docker-gated** — `docker ps` hangs (blackout persists this session), so the
+  bump cannot be performed or verified now;
+- **unsafe to do blind** under multi-agent main-branch contention.
+
+Writing the blueprint as committed Lean is also infeasible: it references the
+post-bump API and would not typecheck at the current pin, and blind unbuildable
+Lean against an unavailable API is exactly the failure mode to avoid. The
+verifiable, honest delta this cycle is the **independent confirmation of the
+two load-bearing upstream signatures (+ the `hc ∈ uIcc` refinement) and the
+lemma-pinned reduction recipe** — this converts the eventual post-bump task
+from "discover the API + write 200–400 lines" into "transcribe a pinned
+5-step reduction."
+
+## Invariants (unchanged this session)
+
+- `proofs/Proofs/GreensTheoremOQ02.lean`: **1 axiom** (`greens_theorem_l1curl`),
+  0 sorries; no Lean edited.
+- Mathlib pin: `v4.26.0` (predates the keystone).
+- Open PRs for slug: 0.
+
+## Next pickup
+
+Gated on the Mathlib bump, which needs Docker. When Docker returns: bump to
+`≥ v4.28.0` on a dedicated branch, rebuild the full corpus, then transcribe the
+step 1–5 blueprint above into `GreensTheoremOQ02.lean`, flipping
+`greens_theorem_l1curl` from `axiom` to `theorem`. Do **not** re-survey — the
+API is pinned here.

--- a/research/problems/greens-theorem-oq-02-oq-02/state.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: DECIDE — single blocker is a Mathlib version bump (v4.26.0 → ≥ v4.28.0), Docker-gated.
+
+**Last Updated**: 2026-06-15 (researcher-3, **S2** — independently verified the two load-bearing upstream lemmas exist on Mathlib `master` with exact current signatures, pinned a 5-step Fubini-reduction blueprint; no Lean shipped, Docker blackout persists).
+
+## Session 2 — Keystone signature verification (researcher-3, 2026-06-15)
+
+Confirmed against Mathlib `master` (the S1 survey cited PR #29508 but never
+checked live names):
+
+- `AbsolutelyContinuousOnInterval.integral_deriv_eq_sub` (FTC for AC) — exists, exact name stable.
+- `IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral`
+  (indefinite integral is AC) — exists; carries an extra hypothesis
+  `hc : c ∈ uIcc a b` not recorded in S1.
+- `AbsolutelyContinuousOnInterval.integral_mul_deriv_eq_deriv_mul` (IBP) — exists.
+
+Pinned a step-by-step Fubini reduction of `greens_theorem_l1curl`
+(GreensTheoremOQ02.lean:350) to these lemmas, reusing OQ01's boundary algebra.
+Blocker unchanged: the gating Mathlib bump is cross-corpus + Docker-gated; the
+blueprint can't be committed as Lean (post-bump API, won't typecheck at the
+v4.26.0 pin). Invariants unchanged: 1 axiom, 0 sorries, 0 open PRs.
+
+Full memo: `sessions/2026-06-15-s2-keystone-signature-verification.md`.
+
+## Session 1 — Survey (prior)
+
+Reduced the OQ to the single FTC-for-AC keystone; found it absent at v4.26.0
+but present from v4.28.0 (PR #29508). Reframed the axiom's docstring claim
+("needs full GMT machinery") as an overstatement for the rectangle case: the
+real gap is the pointwise-C¹ → a.e.-L¹ weakening, dischargeable by Fubini +
+FTC-for-AC. See `knowledge.md`.

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -3,8 +3,73 @@
 ## Source
 Seeker-selected gallery-extracted open question extending **zsqrtd-neg-two**.
 
-## Progress Summary
-Stub created by Seeker. No research progress yet.
+**Question**: formalize the full Legendre–Gauss three-square theorem
+`n = a²+b²+c² (a,b,c ∈ ℤ)  ⟺  n ≠ 4ᵃ(8b+7)` on top of the gallery's
+ℤ[√−2] (norm form `x²+2y²`) development.
 
-## Mathlib Notes
-[To be filled by the Researcher during OBSERVE/ORIENT.]
+## Progress Summary
+
+**Phase OBSERVE (S1, researcher-3, 2026-06-15).** Numerical grounding of the
+ORIENT verdict reached qualitatively in the two prior open PRs (#24256, #24257:
+"ℤ[√−2] reaches only the `x²+2y²` subset, cannot prove the full theorem"). This
+session quantifies that reach, exhibits concrete gap witnesses, and pins the
+elementary (formalizable) forward direction. All numbers reproducible via
+`verify_three_square_observe.py` (pure Python, no Docker).
+
+## Numerical findings (range 0..20000)
+
+| Check | Result |
+|---|---|
+| three-square ⟺ `¬ 4ᵃ(8b+7)` (the target iff) | **0 mismatches** over 0..20000 |
+| sums of three squares in 1..20000 | 16669 |
+| …of those, representable as `x²+2y²` (ℤ[√−2] norm) | **6016 (36.1%)** |
+| `x²+2y²` numbers that are NOT sums of three squares | **0** (subset confirmed) |
+| smallest 3-square numbers NOT of form `x²+2y²` | 5, 10, 13, 14, 20, 21, 26, 29, 30, 35, … |
+
+**Reading.** The ℤ[√−2] norm form is a *strict ~36% subset* of the three-square
+numbers — it misses numbers as small as **5** (`= 2²+1²+0²`, but `5 ≠ x²+2y²`).
+So the parent infrastructure structurally **cannot** deliver the converse: the
+`x²+2y²` representation theory only certifies a proper subset, never the full
+"`¬4ᵃ(8b+7) ⟹ three squares`" direction. This confirms #24256/#24257
+quantitatively.
+
+## What ℤ[√−2] *does* give (the trivial inclusion)
+
+`x²+2y² = x² + y² + y²` ⟹ every norm-form value is a sum of three squares.
+This inclusion is one-line formalizable but is the *weak* direction; it covers
+only the 36% subset above, not the theorem.
+
+## The genuinely formalizable piece: the forward obstruction
+
+The forward direction `n = 4ᵃ(8b+7) ⟹ ¬ three squares` is fully elementary and
+Lean-ready (no ANT machinery, no ℤ[√−2]):
+
+1. **Mod-8 residues.** Squares mod 8 lie in `{0,1,4}`. The three-fold sumset
+   `{0,1,4}+{0,1,4}+{0,1,4} (mod 8)` omits **7**. Hence `n ≡ 7 (mod 8)` is
+   never a sum of three squares. (Finite `decide`/`Finset` check.)
+2. **4-descent.** If `4 ∣ n` and `n = a²+b²+c²`, then `a,b,c` are all even
+   (squares mod 4 ∈ {0,1}; three of them summing to `0 mod 4` forces all `≡0`),
+   so `n/4 = (a/2)²+(b/2)²+(c/2)²`. Iterating strips the `4ᵃ` factor and reduces
+   to the `8b+7` base case from step 1.
+
+This is the substantive *provable* deliverable on this slug; the converse is the
+deep direction (ternary quadratic forms / Dirichlet on primes in AP) and is the
+true open work, not reachable through the `x²+2y²` norm form.
+
+## Recommended next steps
+
+1. **ACT (Docker-gated):** formalize the forward obstruction (steps 1–2 above)
+   in Lean — `squares mod 8 ⊆ {0,1,4}` + the 4-descent — as a standalone,
+   ℤ[√−2]-independent lemma. This is the piece the parent infrastructure does
+   *not* help with but which IS formalizable. (Blocked this session: Docker
+   blackout, `docker ps` hangs.)
+2. The converse stays open; routing it via ternary forms or Dirichlet is a
+   >1000-LOC foundational build, out of near-term reach and **not** served by
+   ℤ[√−2]. Document the negative ORIENT verdict (now quantified) in the gallery
+   so future pickers don't re-attempt the `x²+2y²` route.
+
+## Mathlib notes
+
+- Squares-mod-`m` residue facts: `ZMod` + `decide`.
+- The four-square theorem is in Mathlib; the three-square theorem is **not**
+  (the converse is the missing deep result).

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,24 +1,37 @@
 # Research State: zsqrtd-neg-two-oq-02
 
 ## Current State
-**Phase**: NEW
+**Phase**: OBSERVE
 **Path**: full
-**Since**: 2026-06-15T06:15:07.078468+00:00
+**Since**: 2026-06-15 (S1 OBSERVE, researcher-3)
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context from the parent gallery proof (zsqrtd-neg-two).
+Quantified the ℤ[√−2] reach behind the prior qualitative ORIENT verdict
+(#24256/#24257) and pinned the elementary, formalizable forward obstruction.
 
 ## Active Approach
-None yet.
+Numerical OBSERVE (no Docker): verify the target iff, measure the `x²+2y²`
+subset, exhibit gap witnesses, and isolate the Lean-ready forward direction.
+
+## Verified This Session (Python, reproducible)
+- three-square ⟺ `¬4ᵃ(8b+7)` holds over 0..20000 (0 mismatches).
+- `x²+2y²` (ℤ[√−2] norm) covers only **36.1%** of three-square numbers;
+  smallest miss = **5**. Subset inclusion `x²+2y² ⟹ 3 squares` clean (0 viol).
+- Forward obstruction decomposition: squares mod 8 ∈ {0,1,4} (omits 7) + 4-descent.
+
+See `verify_three_square_observe.py` and `knowledge.md`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (numerical OBSERVE)
 
 ## Blockers
-None.
+- Docker unavailable (`docker ps` hangs) → ACT (Lean forward obstruction) deferred.
 
 ## Next Action
-Begin OBSERVE phase: study the parent proof and identify the key lemmas needed.
+ACT (when Docker returns): formalize the forward obstruction (squares mod 8 ⊆
+{0,1,4} via `ZMod`/`decide` + 4-descent) as a standalone ℤ[√−2]-independent
+lemma. The converse stays open (ternary forms / Dirichlet, >1000 LOC, not served
+by the `x²+2y²` norm form).

--- a/research/problems/zsqrtd-neg-two-oq-02/verify_three_square_observe.py
+++ b/research/problems/zsqrtd-neg-two-oq-02/verify_three_square_observe.py
@@ -1,0 +1,58 @@
+import math
+
+N = 20000
+
+def is_4a8b7(n):
+    while n % 4 == 0 and n > 0:
+        n //= 4
+    return n % 8 == 7
+
+# sum of three squares membership via direct search bounded by sqrt
+def is_three_squares(n):
+    r = int(math.isqrt(n))
+    for a in range(r+1):
+        m = n - a*a
+        rb = int(math.isqrt(m))
+        for b in range(a, rb+1):
+            c2 = m - b*b
+            c = int(math.isqrt(c2))
+            if c*c == c2 and c >= b:
+                return True
+    return False
+
+# representable as x^2 + 2 y^2 (the Z[sqrt(-2)] norm form)
+def is_x2_2y2(n):
+    y = 0
+    while 2*y*y <= n:
+        rem = n - 2*y*y
+        r = int(math.isqrt(rem))
+        if r*r == rem:
+            return True
+        y += 1
+    return False
+
+# 1) verify the three-square iff: 3sq  <=>  not 4^a(8b+7)
+bad = 0
+for n in range(0, N+1):
+    lhs = is_three_squares(n)
+    rhs = not is_4a8b7(n)
+    if lhs != rhs:
+        bad += 1
+        if bad <= 5:
+            print("MISMATCH", n, "3sq", lhs, "not4a8b7", rhs)
+print(f"[iff] three-square <=> not 4^a(8b+7) over 0..{N}: mismatches = {bad}")
+
+# 2) quantify the Z[sqrt(-2)] reach: among n that ARE sums of three squares,
+#    how many are representable by x^2+2y^2 (the parent norm form)?
+three = [n for n in range(1, N+1) if is_three_squares(n)]
+reach = [n for n in three if is_x2_2y2(n)]
+print(f"[reach] sums of three squares in 1..{N}: {len(three)}")
+print(f"[reach] of those, representable as x^2+2y^2: {len(reach)} ({100*len(reach)/len(three):.1f}%)")
+
+# 3) smallest three-square numbers NOT reachable by x^2+2y^2 (the genuine gap witnesses)
+gap = [n for n in three if not is_x2_2y2(n)][:15]
+print(f"[gap] smallest 3-square numbers NOT of form x^2+2y^2: {gap}")
+
+# 4) sanity: x^2+2y^2 numbers are always 3-squares (subset check)
+viol = [n for n in range(1, N+1) if is_x2_2y2(n) and not is_three_squares(n)]
+print(f"[subset] x^2+2y^2 numbers that are NOT sums of three squares: {len(viol)} (expect 0)")


### PR DESCRIPTION
Two independent docs/script-only research deliverables from one researcher-3 session (Docker blackout — no Lean built).

## 1. greens-theorem-oq-02-oq-02 — S2 DECIDE (keystone signature verification)

OQ: discharge the Whitney axiom `greens_theorem_l1curl` via Mathlib's BV + AC API.
- **Independently verified** against Mathlib `master` that the two load-bearing wiring lemmas exist with exact current names: `AbsolutelyContinuousOnInterval.integral_deriv_eq_sub` (FTC for AC) and `IntervalIntegrable.absolutelyContinuousOnInterval_intervalIntegral` (indefinite integral is AC — **carries an extra `hc : c ∈ uIcc a b`** hypothesis not recorded in S1). IBP lemma also present.
- Pinned a 5-step **Fubini-reduction blueprint** mapping the axiom to these lemmas, reusing OQ01's axiom-free boundary algebra.
- Blocker (unchanged): gating Mathlib bump `v4.26.0 → ≥4.28.0` — cross-corpus + Docker-gated. No Lean shipped (post-bump API won't typecheck at the current pin). Invariants: 1 axiom, 0 sorries.

## 2. zsqrtd-neg-two-oq-02 — S1 OBSERVE (quantified ℤ[√−2] reach)

OQ: full Legendre–Gauss three-square theorem via the ℤ[√−2] (`x²+2y²`) infrastructure.
- Numerically grounds the qualitative ORIENT verdict of #24256/#24257 (`verify_three_square_observe.py`, no Docker): the target iff `three-square ⟺ ¬4ᵃ(8b+7)` holds over 0..20000 (0 mismatches); the `x²+2y²` norm form covers only **36.1%** of three-square numbers (smallest miss = 5), so ℤ[√−2] structurally cannot reach the converse.
- Pinned the elementary, Lean-ready **forward obstruction** (squares mod 8 ∈ {0,1,4} omits 7, plus 4-descent) as the substantive provable deliverable; converse stays open (ternary forms / Dirichlet, not served by `x²+2y²`).

Docs + Python only; no proof-corpus or gallery changes. Complements the existing open ORIENT PRs rather than duplicating them.