### PR TITLE
Enrich four-color-theorem cluster: reciprocal cross-references

### DIFF
--- a/src/data/proofs/four-color-theorem-oq-01/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-01/meta.json
@@ -192,6 +192,11 @@
       "targetId": "four-color-theorem",
       "relationship": "parent",
       "description": "This open question investigates the proof methodology of the Four Color Theorem. The main entry axiomatizes the 4CT; this entry explores whether the axiom could be replaced by a human-verifiable proof."
+    },
+    {
+      "targetId": "four-color-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "The complementary sub-question. This entry asks whether the computer-assisted case analysis can be avoided altogether (the Kempe-chain obstruction); the sibling entry instead quantifies that case analysis, studying the unavoidable sets of reducible configurations whose size (Appel–Haken's 1476 down to RSST's 633) measures exactly how much mechanical checking a four-color proof currently demands. A human-readable proof in the sense of oq-01 would be one needing no such finite configuration set at all."
     }
   ],
   "references": [

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -28,6 +28,11 @@
       "targetId": "four-color-theorem",
       "relationship": "extends",
       "description": "Open question about the minimum size of unavoidable reducible configuration sets for the Four Color Theorem"
+    },
+    {
+      "targetId": "four-color-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "The complementary sub-question. This entry quantifies the computer-checked case analysis — the unavoidable set of reducible configurations and its minimum size; the sibling entry asks whether that case analysis can be dispensed with entirely. The Kempe-chain obstruction studied in oq-01 is precisely why a finite configuration set is needed: Kempe's elementary chain argument fails for four colors, so reducibility must instead be verified configuration-by-configuration, and the size of the set measured here is the cost of that failure."
     }
   ],
   "overview": {

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -168,6 +168,16 @@
       "targetId": "erdos-807",
       "relationship": "related",
       "description": "Erdős Problem #807 concerns graph coloring bounds, directly connecting to the chromatic theory that the Four Color Theorem resolves for planar graphs."
+    },
+    {
+      "targetId": "four-color-theorem-oq-01",
+      "relationship": "open question",
+      "description": "Asks whether the Four Color Theorem admits a human-readable proof free of computer-assisted case checking. It formalizes the Kempe-chain obstruction that makes the elementary argument succeed for five colors (the Five Color Theorem) but break down for four — pinpointing exactly where Kempe's 1879 'proof' failed and why discharging plus reducibility checking is needed instead."
+    },
+    {
+      "targetId": "four-color-theorem-oq-02",
+      "relationship": "open question",
+      "description": "Studies the unavoidable sets of reducible configurations at the heart of this proof — the objects whose exhaustive case analysis is what required a computer. It tracks the historical shrinkage of the set (Appel–Haken's 1476 configurations down to Robertson–Sanders–Seymour–Thomas's 633) and the still-open question of the minimum possible size."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Adds the missing reciprocal cross-references within the `four-color-theorem` cluster. The headline entry is otherwise saturated (the enrichment scorer reports the entire gallery at quality 100), but its two open-question sub-entries were under-linked: each pointed up to the parent, but the parent linked to neither, and the two siblings did not reference each other.

The two siblings are directly complementary aspects of the same proof methodology:
- **oq-01** — whether a human-readable proof exists (the Kempe-chain obstruction that makes the elementary argument work for 5 colors but fail for 4)
- **oq-02** — the unavoidable sets of reducible configurations whose exhaustive checking is exactly the computer-assisted case analysis oq-01 asks to eliminate

## Changes
- `four-color-theorem`: added links to `four-color-theorem-oq-01` and `four-color-theorem-oq-02`
- `four-color-theorem-oq-01`: added sibling link to `four-color-theorem-oq-02`
- `four-color-theorem-oq-02`: added sibling link to `four-color-theorem-oq-01`

Purely additive, schema-correct `crossReferences` entries. All `targetId`s resolve to existing gallery dirs; `jq empty` passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)