### PR TITLE
Enrich picks-theorem cluster: fix broken xref + reciprocal links

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01/meta.json
@@ -98,9 +98,14 @@
   },
   "crossReferences": [
     {
-      "id": "picks-theorem-oq-01",
-      "title": "Pick's Theorem (Parent)",
-      "relationship": "This file provides the primitive triangulation ingredient for the constructive proof of Pick's theorem."
+      "targetId": "picks-theorem-oq-01",
+      "relationship": "parent",
+      "description": "This file provides the primitive triangulation ingredient for the constructive proof of Pick's theorem ($A = I + B/2 - 1$): every non-degenerate lattice triangle decomposes into exactly $|\\det|$ primitive lattice triangles, each of area $1/2$, which is the base case the triangulation strategy builds on."
+    },
+    {
+      "targetId": "picks-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "The complementary ingredient in the same triangulation program: this entry counts primitive triangles, while oq-02 supplies the GCD boundary formula ($\\gcd(a,b)+1$ lattice points on the segment from $(0,0)$ to $(a,b)$) needed to track how boundary points $B$ are distributed across the triangulation."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -47,6 +47,21 @@
       "targetId": "picks-theorem",
       "relationship": "extends",
       "description": "Provides the constructive proof strategy for the axiomatized Pick's theorem"
+    },
+    {
+      "targetId": "picks-theorem-oq-01-oq-01",
+      "relationship": "child",
+      "description": "Supplies the core geometric lemma of this triangulation strategy: every non-degenerate lattice triangle decomposes into exactly $|\\det|$ primitive lattice triangles, each of area $1/2$ (the unimodular base case)."
+    },
+    {
+      "targetId": "picks-theorem-oq-02",
+      "relationship": "child",
+      "description": "Supplies the boundary-counting lemma the triangulation needs: the segment from $(0,0)$ to $(a,b)$ contains exactly $\\gcd(a,b)+1$ lattice points, which determines how boundary points $B$ are apportioned among the primitive triangles."
+    },
+    {
+      "targetId": "picks-theorem-oq-01-oq-02",
+      "relationship": "child",
+      "description": "Extends this strategy to the lattice-point enumerator: derives the 2D Ehrhart polynomial $L(P,t) = A t^2 + (B/2) t + 1$, whose linear coefficient $B/2$ and constant $1$ encode Pick's formula as the $t=1$ evaluation."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -204,6 +204,24 @@
         "combinatorics"
       ],
       "targetId": "erdos-szekeres"
+    },
+    {
+      "targetId": "picks-theorem-oq-01",
+      "relationship": "A constructive proof of this theorem by triangulating the polygon into primitive lattice triangles (each of area 1/2), replacing the axiomatized statement here with an explicit derivation",
+      "sharedConcepts": [
+        "lattice-points",
+        "triangulation",
+        "area-computation"
+      ]
+    },
+    {
+      "targetId": "picks-theorem-oq-03",
+      "relationship": "The higher-dimensional generalization: Ehrhart's theorem makes Pick's formula the d=2 case of a polynomial lattice-point enumerator L(P,t), and explains why a single closed area formula fails in 3D (Reeve tetrahedra)",
+      "sharedConcepts": [
+        "lattice-points",
+        "Ehrhart-theory",
+        "polytopes"
+      ]
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Fixes a broken cross-reference and closes reciprocity gaps in the `picks-theorem` triangulation cluster.

**Bug fix:** `picks-theorem-oq-01-oq-01` had its single `crossReference` written with non-schema keys (`id`/`title` instead of `targetId`/`relationship`). The `CrossReference` loader keys on `proofId`/`targetId`, so the link resolved to nothing — a dead reference. Converted it to the correct schema (pointing at parent `picks-theorem-oq-01`) and added a sibling link to `picks-theorem-oq-02`.

**Reciprocity:** the triangulation subtree linked only upward.
- `picks-theorem-oq-01` (constructive proof) now links down to its three ingredient entries: `picks-theorem-oq-01-oq-01` (primitive triangulation), `picks-theorem-oq-02` (GCD boundary formula), `picks-theorem-oq-01-oq-02` (2D Ehrhart polynomial).
- `picks-theorem` (top entry) now links to `picks-theorem-oq-01` (its constructive proof) and `picks-theorem-oq-03` (the Ehrhart generalization).

All `targetId`s resolve to existing gallery dirs; `jq empty` passes on all three files. Purely additive except the malformed-xref repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)