### PR TITLE
research(geometric-series-oq-01-oq-02): S2 ACT — full Lean proof of Cesàro (C,1) regularity + Grandi strict-extension

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ02.lean
@@ -1,0 +1,126 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ01
+
+/-
+# Cesàro (C,1) Regularity: convergent ⟹ Cesàro-summable to the same sum
+
+## What This Proves
+The general **regularity** (a.k.a. consistency) theorem of (C,1) summation,
+the open question OQ-02 of the chain rooted at `geometric-series-oq-01`:
+
+> If a series `∑ aₙ` converges to `s`, then its Cesàro mean converges to `s`.
+
+Concretely, with partial sums `Sₖ = a₀ + ⋯ + a_{k-1}` and Cesàro means
+`σₙ = (S₁ + ⋯ + Sₙ)/n`:
+
+1. **Regularity (the OQ)**: `Sₙ → s  ⟹  σₙ → s`.
+2. **Series-level corollary**: `HasSum a s  ⟹  CesaroSummable a s`.
+3. **Strictness**: Grandi's series `1 − 1 + 1 − ⋯` is Cesàro summable to `1/2`
+   yet *not* summable — so (C,1) summation is a *strict* extension of ordinary
+   convergence (the converse of regularity fails).
+
+## Relationship to the parent entry
+`geometric-series-oq-01` proves the *concrete* Grandi instance by hand
+(`grandiCesaro_tendsto`, via an explicit `|σₙ − 1/2| ≤ 1/(2n)` bound). This
+entry proves the **general** regularity theorem (which subsumes such bespoke
+computations) and reuses the parent's bound to populate the strictness example.
+
+## Approach
+- **Foundation (from Mathlib):** `Filter.Tendsto.cesaro` — the Cesàro mean of a
+  convergent sequence converges to the same limit. The key observation is that
+  the correct sequence to average is the *partial-sum* sequence, not the terms.
+- **Original contribution:** packaging regularity at the series level, the
+  `HasSum` corollary, and the strict-extension witness via Grandi.
+-/
+
+namespace GeometricSeriesOQ01OQ02
+
+open Finset Filter Topology
+
+/-- Partial sums of a series: `partialSum a k = a₀ + a₁ + ⋯ + a_{k-1}`. -/
+def partialSum (a : ℕ → ℝ) (k : ℕ) : ℝ := ∑ i ∈ Finset.range k, a i
+
+/-- The (C,1) / Cesàro mean of a series: the average of its first `n` *nonempty*
+    partial sums, `σₙ = (S₁ + S₂ + ⋯ + Sₙ) / n`. -/
+def cesaroMean (a : ℕ → ℝ) (n : ℕ) : ℝ :=
+  (n : ℝ)⁻¹ * ∑ k ∈ Finset.range n, partialSum a (k + 1)
+
+/-- A series is **Cesàro `(C,1)`-summable to `σ`** when its sequence of Cesàro
+    means converges to `σ`. -/
+def CesaroSummable (a : ℕ → ℝ) (σ : ℝ) : Prop :=
+  Tendsto (cesaroMean a) atTop (𝓝 σ)
+
+-- ============================================================
+-- PART 1: Regularity (the open question)
+-- ============================================================
+
+/-- **(C,1) regularity.** If the partial sums of `∑ aₙ` converge to `s`, then the
+    Cesàro means converge to the *same* `s`.
+
+    This is a corollary of Mathlib's `Filter.Tendsto.cesaro` applied to the
+    (shifted) partial-sum sequence `k ↦ S_{k+1}`. -/
+theorem cesaro_regularity {a : ℕ → ℝ} {s : ℝ}
+    (h : Tendsto (partialSum a) atTop (𝓝 s)) : CesaroSummable a s := by
+  have h1 : Tendsto (fun k => partialSum a (k + 1)) atTop (𝓝 s) :=
+    h.comp (tendsto_add_atTop_nat 1)
+  exact h1.cesaro
+
+/-- **Regularity at the level of the series sum.** If `∑ aₙ` actually sums to `s`
+    (`HasSum a s`), then it is Cesàro summable to `s`. -/
+theorem cesaroSummable_of_hasSum {a : ℕ → ℝ} {s : ℝ} (h : HasSum a s) :
+    CesaroSummable a s :=
+  cesaro_regularity h.tendsto_sum_nat
+
+/-- A `Summable` real series is Cesàro summable (to its ordinary sum). -/
+theorem cesaroSummable_of_summable {a : ℕ → ℝ} (h : Summable a) :
+    CesaroSummable a (∑' n, a n) :=
+  cesaroSummable_of_hasSum h.hasSum
+
+-- ============================================================
+-- PART 2: Strictness — (C,1) strictly extends convergence
+-- ============================================================
+
+/-- The Cesàro mean of Grandi's series `(-1)ⁿ` coincides, as a function of `n`,
+    with the parent entry's bespoke `grandiCesaro`. -/
+theorem cesaroMean_grandi_eq :
+    cesaroMean (fun n => (-1 : ℝ) ^ n) = GeometricSeriesOQ01.grandiCesaro := by
+  funext n
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp [cesaroMean, GeometricSeriesOQ01.grandiCesaro]
+  · simp only [cesaroMean, partialSum, GeometricSeriesOQ01.grandiCesaro,
+      if_neg hn.ne']
+    rw [div_eq_inv_mul]
+
+/-- **Grandi's series is Cesàro summable to `1/2`.** Reuses the parent entry's
+    explicit limit computation through `cesaroMean_grandi_eq`. -/
+theorem grandi_cesaroSummable : CesaroSummable (fun n => (-1 : ℝ) ^ n) (1 / 2) := by
+  unfold CesaroSummable
+  rw [cesaroMean_grandi_eq]
+  exact GeometricSeriesOQ01.grandiCesaro_tendsto
+
+/-- Grandi's series is not summable (the ordinary sum does not exist). -/
+theorem grandi_not_summable : ¬ Summable (fun n : ℕ => (-1 : ℝ) ^ n) :=
+  GeometricSeriesOQ01.not_summable_grandi
+
+/-- **(C,1) summation strictly extends ordinary convergence.** Grandi's series is
+    Cesàro summable to `1/2` yet not summable, so the converse of regularity
+    fails: Cesàro summability does *not* imply convergence. -/
+theorem cesaro_strictly_extends_convergence :
+    CesaroSummable (fun n => (-1 : ℝ) ^ n) (1 / 2) ∧
+      ¬ Summable (fun n : ℕ => (-1 : ℝ) ^ n) :=
+  ⟨grandi_cesaroSummable, grandi_not_summable⟩
+
+-- ============================================================
+-- PART 3: Examples
+-- ============================================================
+
+/-- A convergent series (here the constant-zero series) is Cesàro summable. -/
+example : CesaroSummable (fun _ : ℕ => (0 : ℝ)) 0 :=
+  cesaroSummable_of_hasSum hasSum_zero
+
+#check @cesaro_regularity
+#check @cesaroSummable_of_hasSum
+#check @grandi_cesaroSummable
+#check @cesaro_strictly_extends_convergence
+
+end GeometricSeriesOQ01OQ02

--- a/research/problems/geometric-series-oq-01-oq-02/knowledge.md
+++ b/research/problems/geometric-series-oq-01-oq-02/knowledge.md
@@ -5,13 +5,19 @@
 **Problem**: Formalize the general Cesàro (C,1) regularity theorem — if a series
 `∑ aₙ` converges to `s`, then its Cesàro mean converges to the same `s`.
 
-**Status**: ORIENT (S1, 2026-06-14). OQ resolved on paper; reduces to Mathlib's
-`Filter.Tendsto.cesaro`. Buildable (< 80 LOC), no Mathlib gap. ACT deferred —
-Docker verification host down this session.
+**Status**: ACT (S2, 2026-06-15). Full Lean proof written — 126 LOC, 0 sorries,
+0 axioms (`proofs/Proofs/GeometricSeriesOQ01OQ02.lean`). M1 regularity +
+series-level corollary + M2 Grandi strict-extension all proved. Build-pending
+UNREGISTERED (dual blackout: Docker down, no local Mathlib) — needs
+`import Proofs.GeometricSeriesOQ01OQ02` in `proofs/Proofs.lean`, a
+`docker-build.sh` pass, and gallery data before merge.
 
-**Progress summary**: ORIENT — formalizable core pinned to existing Mathlib API;
-two-milestone plan (M1 regularity, M2 converse-failure via Grandi). No Lean
-written yet.
+**Progress summary**: ACT — complete proof of the OQ. `cesaro_regularity`
+(`Sₙ → s ⟹ σₙ → s`) is `(h.comp (tendsto_add_atTop_nat 1)).cesaro`; series-level
+`cesaroSummable_of_hasSum`/`cesaroSummable_of_summable` via
+`HasSum.tendsto_sum_nat`; converse-failure `cesaro_strictly_extends_convergence`
+reuses the parent's `grandiCesaro_tendsto` + `not_summable_grandi` through a
+pointwise bridge `cesaroMean_grandi_eq`.
 
 ## Key insights
 
@@ -35,7 +41,15 @@ written yet.
 
 ## Built items
 
-- (none — ORIENT only; no Lean written this session)
+- `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` (S2, 126 LOC, 0 sorry/0 axiom):
+  - `partialSum`, `cesaroMean`, `CesaroSummable` (defs).
+  - `cesaro_regularity` — **the OQ**: `Tendsto (partialSum a) (𝓝 s) → CesaroSummable a s`.
+  - `cesaroSummable_of_hasSum`, `cesaroSummable_of_summable` — regularity at the
+    level of the actual series sum (`HasSum`/`Summable`).
+  - `cesaroMean_grandi_eq` — pointwise bridge: `cesaroMean ((-1)^·) = grandiCesaro`
+    (parent's bespoke mean), via `div_eq_inv_mul` + `if_neg`.
+  - `grandi_cesaroSummable` — Grandi (C,1)-summable to 1/2 (reuses parent's bound).
+  - `grandi_not_summable`, `cesaro_strictly_extends_convergence` — converse fails.
 
 ## Mathlib gaps
 
@@ -47,15 +61,54 @@ written yet.
 
 ## Next steps
 
-1. (ACT, Docker) Create `proofs/Proofs/GeometricSeriesOQ01OQ02.lean`.
-2. Define `cesaroMean S N := (N⁻¹:ℝ) * ∑ k ∈ range N, S k` and a
-   `CesaroSummable` predicate.
-3. M1: regularity via `exact h.cesaro` on the partial-sum sequence.
-4. M2: Grandi converse-failure using parent `grandiCesaro_tendsto` +
-   `not_summable_grandi`.
-5. Add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` and build-verify.
+1. (Build, when Docker returns) Register `import Proofs.GeometricSeriesOQ01OQ02`
+   in `proofs/Proofs.lean`, run `./proofs/scripts/docker-build.sh
+   Proofs.GeometricSeriesOQ01OQ02`. Likely-fragile points to watch if it fails:
+   - `Filter.Tendsto.cesaro` exact name/shape (`(n:ℝ)⁻¹ * ∑ i ∈ range n, u i`).
+   - `tendsto_add_atTop_nat 1` defeq with the `S_{k+1}` shift in `cesaroMean`.
+   - `cesaroMean_grandi_eq` n>0 branch closing by `rw [div_eq_inv_mul]` after the
+     `simp only` unfold (bound-var rename i↔j is harmless).
+2. Add gallery `src/data/proofs/geometric-series-oq-01-oq-02/` (mirror parent's
+   meta.json; set `status` to `verified` ONLY after the build is green).
+3. (Optional follow-up theory) Hardy–Littlewood Tauberian converse: if `σₙ → s`
+   and `aₙ = O(1/n)` then `∑ aₙ = s` — the genuine open direction, NOT yet in
+   Mathlib (this session proved only the easy regularity direction).
 
 ## Sessions
+
+### Session 2026-06-15 (S2) — ACT: full Lean proof
+
+**Mode**: REVISIT (executed the S1 ACT plan)
+**Outcome**: progress — complete proof written (build-pending; dual blackout)
+
+#### What I did
+- Wrote `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` (126 LOC, 0 sorry/0 axiom).
+- M1 `cesaro_regularity`: chose the (C,1) convention `σₙ = (S₁+⋯+Sₙ)/n` (average
+  the *nonempty* partial sums `S_{k+1}`), so the proof is
+  `(h.comp (tendsto_add_atTop_nat 1)).cesaro` — one `Filter.Tendsto.cesaro` call
+  on the shifted partial-sum sequence.
+- Added series-level corollaries `cesaroSummable_of_hasSum` (via
+  `HasSum.tendsto_sum_nat`) and `cesaroSummable_of_summable`.
+- M2: proved `cesaroMean ((-1)^·) = grandiCesaro` *pointwise* (`funext`, n=0 by
+  `simp`, n>0 by `simp only [...] ; rw [div_eq_inv_mul]`), letting me transport
+  the parent's `grandiCesaro_tendsto` to get `grandi_cesaroSummable` to 1/2 for
+  FREE, then bundle with `not_summable_grandi` into
+  `cesaro_strictly_extends_convergence`.
+
+#### Key findings
+- Picking the textbook convention (start partial sums at `S₁`, divide by `n`)
+  makes BOTH M1 (one `.cesaro` after a `+1` shift) and M2 (defeq-equal to the
+  parent's `grandiCesaro`, modulo `a/n = n⁻¹*a`) collapse to near-one-liners.
+  Choosing the convention to match the reusable artifact is the whole trick.
+- This proves only the *regularity* (easy) direction. The Hardy–Littlewood
+  Tauberian converse is the real open content and remains unformalized.
+
+#### Files modified
+- `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` (new)
+- `research/problems/geometric-series-oq-01-oq-02/{knowledge,state}.md`
+
+#### Next steps
+- Register + `docker-build` when the host returns; then add gallery data.
 
 ### Session 2026-06-14 (S1) — ORIENT feasibility survey
 

--- a/research/problems/geometric-series-oq-01-oq-02/state.md
+++ b/research/problems/geometric-series-oq-01-oq-02/state.md
@@ -2,14 +2,14 @@
 
 ## Current State
 
-**Phase**: ORIENT — S1 feasibility survey (researcher-6, 2026-06-14). OQ resolved
+**Phase**: ACT
 on paper: the general Cesàro (C,1) regularity theorem reduces to Mathlib's
 existing `Filter.Tendsto.cesaro`. Formalizable core pinned to real Mathlib API;
 milestones split. No Lean written this session (verification blackout — Docker
 down); ACT deferred until build host returns.
 
 **Path**: full
-**Since**: 2026-06-14 (S1 ORIENT, researcher-6)
+**Since**: 2026-06-15T02:00:00-07:00
 **Last Updated**: 2026-06-14 (Iteration 1, S1 ORIENT, researcher-6)
 **Iteration**: 1
 


### PR DESCRIPTION
## Summary

Answers **OQ-02** of the `geometric-series-oq-01` chain — the general **Cesàro (C,1) regularity** theorem:

> If a series `∑ aₙ` converges to `s`, then its Cesàro mean converges to the same `s`.

New file `proofs/Proofs/GeometricSeriesOQ01OQ02.lean` (**126 LOC, 0 sorry / 0 axiom**).

This is the open question explicitly listed in the parent entry's `conclusion.openQuestions` ("The general Cesàro summability theorem states that if ∑aₙ converges to s, then its Cesàro mean also converges to s (regularity). Can this be formalized…").

## What's proved

- `cesaro_regularity` — **the OQ**: `Tendsto (partialSum a) atTop (𝓝 s) → CesaroSummable a s`. One line on Mathlib's `Filter.Tendsto.cesaro` applied to the shifted partial-sum sequence: `(h.comp (tendsto_add_atTop_nat 1)).cesaro`.
- `cesaroSummable_of_hasSum`, `cesaroSummable_of_summable` — regularity at the level of the actual series sum, via `HasSum.tendsto_sum_nat`.
- `cesaroMean_grandi_eq` — pointwise bridge `cesaroMean ((-1)^·) = grandiCesaro` (the parent's bespoke mean).
- `grandi_cesaroSummable` + `grandi_not_summable` + `cesaro_strictly_extends_convergence` — Grandi's series is (C,1)-summable to `1/2` yet **not** summable, so the converse of regularity fails. Reuses the parent's `grandiCesaro_tendsto` / `not_summable_grandi`.

The key trick: choosing the textbook (C,1) convention (`σₙ = (S₁+⋯+Sₙ)/n`) makes M1 a single `.cesaro` call and M2 definitionally equal to the parent's hand-built `grandiCesaro` (modulo `a/n = n⁻¹·a`), so the parent's `O(1/n)` bound is reused for free.

## Scope honesty

Only the **regularity** (easy) direction is formalized. The Hardy–Littlewood **Tauberian converse** (`σₙ → s` and `aₙ = O(1/n) ⟹ ∑aₙ = s`) is the genuinely hard open direction and is **not** attempted here (not in Mathlib).

## ⚠️ Build-pending (do not merge until verified)

Written under a dual blackout (Docker build host down, no local Mathlib), so it is **not machine-checked yet**:

- [ ] NOT registered in `proofs/Proofs.lean` (left out to avoid breaking the gallery build if a name is off).
- [ ] No gallery data yet (`src/data/proofs/geometric-series-oq-01-oq-02/`).

Before merge: add `import Proofs.GeometricSeriesOQ01OQ02` to `proofs/Proofs.lean`, run `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02`, then add gallery `meta.json` (set `status: verified` only once green). API names relied on: `Filter.Tendsto.cesaro`, `tendsto_add_atTop_nat`, `HasSum.tendsto_sum_nat`, `div_eq_inv_mul`.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02` builds with 0 errors / 0 sorries.
- [ ] `#check` lines elaborate; `example` for the constant-zero series typechecks.