### PR TITLE
research(sqrt2+sqrt3+sqrt5-irrational-oq-02): discharge OQ-01 corollary endpoint (4→3 sorries)

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean
@@ -12,13 +12,19 @@ OQ-01's "square twice to isolate √30" trick is the n = 3 shadow of the fact th
 √2+√3+√5 is a primitive element of the degree-8 multiquadratic field ℚ(√2,√3,√5).
 OQ-02 replaces the ad-hoc squaring with the uniform degree theorem.
 
-## STATUS — ORIENT skeleton, NOT build-verified (Docker unavailable this session)
+## STATUS — partial: 2 endpoints discharged, induction core still open (Docker unavailable)
 
-This file records the *decomposition* into the load-bearing lemmas. The
-statements have NOT been checked by the Lean elaborator. The single non-trivial
-step is `sqrt_prime_not_mem_multiquadratic` (the induction heart); everything
-else is either a Mathlib one-liner (base case, upper bound) or follows from the
-degree theorem by linear algebra.
+This file records the *decomposition* into the load-bearing lemmas. The single
+non-trivial step is `sqrt_prime_not_mem_multiquadratic` (the induction heart);
+everything else is either a Mathlib one-liner (base case, upper bound) or follows
+from the degree theorem by linear algebra.
+
+Discharged (no sorry): `irrational_sqrt_prime` (`Nat.Prime.irrational_sqrt`) and
+`irrational_sqrt2_add_sqrt3_add_sqrt5` (the OQ-01 corollary, by direct citation of
+the proved `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01` — see note there). Still `sorry`:
+the induction heart and the two results that depend on it (`*_linearIndependent`).
+These statements have NOT yet been checked by the Lean elaborator (no build this
+session); the file remains unregistered pending a Docker build.
 
 The mathematical content (degree = 2ⁿ, induction heart = degree doubling, and the
 linear independence) is certified exactly in
@@ -29,6 +35,7 @@ Tags: number-theory, field-theory, multiquadratic, besicovitch, linear-independe
 -/
 
 import Mathlib
+import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
 
 namespace BesicovitchOQ02
 
@@ -82,11 +89,15 @@ theorem besicovitch_sqrt_linearIndependent
     LinearIndependent ℚ (fun d : S => (Real.sqrt ((d : ℕ) : ℝ) : ℝ)) := by
   sorry
 
-/-- **OQ-01 recovered as a corollary.** `√2+√3+√5` is irrational because
-`{1,√2,√3,√5}` is ℚ-linearly independent (a special case of Besicovitch with
-`S = {1,2,3,5}`), so the nontrivial combination `√2+√3+√5` cannot be rational. -/
+/-- **OQ-01 recovered.** `√2+√3+√5` is irrational. This is the `n = 3`,
+`{2,3,5}` instance that OQ-02 generalizes, and it is already fully proved
+(0 sorries, 0 axioms) in `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01` via the
+"square twice to isolate √30" route. We discharge it here by direct citation
+of that gallery proof — note this does **not** route through the still-open
+`besicovitch_sqrt_linearIndependent` above (which would be circular), so it is
+build-verifiable independently of the induction heart. -/
 theorem irrational_sqrt2_add_sqrt3_add_sqrt5 :
-    Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5) := by
-  sorry
+    Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5) :=
+  Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.irrational_sqrt2_plus_sqrt3_plus_sqrt5
 
 end BesicovitchOQ02

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
@@ -19,3 +19,45 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-06-15 (S1→ACT-partial, researcher-5) — discharge the OQ-01 corollary endpoint
+
+**Mode:** ACT (build-confident endpoint), dual blackout (docker DOWN, Aristotle MCP 404).
+The Lean skeleton `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean` had 4 sorries.
+The induction heart `sqrt_prime_not_mem_multiquadratic` is BUILD-class (~250–450 LOC,
+needs the "squares of ℚ(√q:q∈ps) are r²·∏_{T} q" characterization) — out of reach under
+blackout. But one sorry was a free endpoint:
+
+**Delta:** discharged `irrational_sqrt2_add_sqrt3_add_sqrt5` (the OQ-01 corollary, line 90)
+by **direct citation** of the already-proved, registered, 0-sorry/0-axiom gallery theorem
+`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.irrational_sqrt2_plus_sqrt3_plus_sqrt5`
+(added `import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01`). OQ-01 uses `open Real`, so its
+statement elaborates to the identical type `Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5)`.
+
+**Important correctness fix:** the original docstring claimed this followed as a "special case
+of Besicovitch with S={1,2,3,5}" — that is **circular** (1 is not squarefree>1, and
+`besicovitch_sqrt_linearIndependent` itself still has a sorry). Citing OQ-01 directly makes
+the corollary build-verifiable **independently** of the open induction heart.
+
+**State now:** 4→3 sorries. Remaining (all gated on the heart): `sqrt_prime_not_mem_multiquadratic`
+(the heart), `multiquadratic_subset_products_linearIndependent` (degree theorem by induction
+on the heart), `besicovitch_sqrt_linearIndependent` (squarefree → subset-product signature).
+`irrational_sqrt_prime` was already proved (`Nat.Prime.irrational_sqrt`).
+
+**Build status:** file remains UNREGISTERED and build-pending (no Docker this session). The
+citation change is high-confidence (identical statement type, target theorem already builds).
+verify_besicovitch.py (208 lines, checks A degree=2ⁿ / B linear independence / C heart =
+degree-doubling) unchanged — ALL PASS per prior runs.
+
+**Formalization route (pinned for when Docker returns):** the heart's cleanest formalizable
+form is the strengthened induction over **coprime squarefree radicands** (not single primes):
+`H(m): ∀ squarefree d>1 coprime to {p₁..pₘ}, √d ∉ K_m`, with the degree-2 basis step
+`x=u+v√pₘ, d=x² ⟹ 2uv=0` (u=0 or v=0 each contradicts H(m-1)). The naive single-prime
+induction FAILS (√35 ∉ ℚ(√2,√3) needs the composite radicand). This matches the route a
+sibling Besicovitch effort pinned earlier today.
+
+**Honest assessment:** modest — one free endpoint discharged + a circular-derivation bug fixed
+in the skeleton. The theorem's actual content (the heart) is untouched and remains BUILD-class
+open. No numerical or mathematical advance beyond prior sessions.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
@@ -1,21 +1,26 @@
 # Research State: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT (partial)
 **Path**: full
-**Since**: 2026-06-14T22:54:15-07:00
-**Iteration**: 1
+**Since**: 2026-06-15 (researcher-5, S1→ACT-partial)
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Lean skeleton 4→3 sorries: discharged the OQ-01 corollary endpoint
+(`irrational_sqrt2_add_sqrt3_add_sqrt5`) by citing the proved
+`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01`. Induction heart
+(`sqrt_prime_not_mem_multiquadratic`, ~250–450 LOC, BUILD-class) and its two
+dependents remain open. File unregistered, build-pending (Docker down).
 
 ## Active Approach
-None yet.
+Quadratic-tower induction; heart formalized via the strengthened coprime-squarefree
+non-membership hypothesis `H(m): ∀ squarefree d>1 coprime to {p₁..pₘ}, √d ∉ K_m`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (endpoint discharge by citation)
 
 ## Blockers
 None.


### PR DESCRIPTION
## Summary

In the Besicovitch OQ-02 skeleton (`proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean`), discharge the **OQ-01 corollary endpoint** `irrational_sqrt2_add_sqrt3_add_sqrt5` by direct citation of the already-proved, registered, 0-sorry/0-axiom gallery theorem `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.irrational_sqrt2_plus_sqrt3_plus_sqrt5` (added the corresponding `import`). OQ-01 uses `open Real`, so its statement elaborates to the identical type `Irrational (Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5)`. **4 → 3 sorries.**

Also fixes a **circular derivation** in the skeleton docstring: the corollary was described as a "special case of Besicovitch with `S = {1,2,3,5}`", but `1` is not squarefree `> 1` and `besicovitch_sqrt_linearIndependent` itself still has a `sorry`. Citing OQ-01 directly makes this endpoint build-verifiable **independently** of the open induction heart.

## Remaining work (unchanged, all gated on the induction heart)

- `sqrt_prime_not_mem_multiquadratic` — the heart, BUILD-class (~250–450 LOC: characterize squares of `ℚ(√q : q∈ps)` as `r²·∏_{T} q`). Cleanest formalizable form is the strengthened **coprime-squarefree** non-membership induction `H(m): ∀ squarefree d>1 coprime to {p₁..pₘ}, √d ∉ K_m` (the naive single-prime induction fails — `√35 ∉ ℚ(√2,√3)` needs a composite radicand).
- `multiquadratic_subset_products_linearIndependent` — degree theorem by induction on the heart.
- `besicovitch_sqrt_linearIndependent` — squarefree → subset-product signature.

`irrational_sqrt_prime` was already proved (`Nat.Prime.irrational_sqrt`).

## Build status

⚠️ **Build-pending**, dual backend blackout (`docker info` down, Aristotle MCP 404). The file stays **unregistered** in `Proofs.lean` (consistent with its prior ORIENT-skeleton state; 3 sorries remain unverified by the elaborator). The citation change itself is high-confidence: identical statement type, and the cited theorem (`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01`) is already registered and builds clean.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02` (blocked — docker down)
- [x] Cited theorem confirmed 0-sorry/0-axiom, registered, `open Real` ⇒ identical statement type
- [x] `verify_besicovitch.py` (A/B/C) unchanged — ALL PASS per prior runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)