### PR TITLE
research(product-of-segments-of-chords-oq-02): S3 ACT — Lean counterexample disproving the unsigned converse axiom

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
@@ -1,0 +1,172 @@
+import Mathlib
+
+/-!
+# Converse of the Product-of-Segments-of-Chords (Power of a Point) Theorem
+
+This file accompanies `Proofs/ProductOfSegmentsOfChords.lean`, which formalizes the
+forward intersecting-chords theorem and **axiomatizes** the converse as
+`converse_product_implies_concyclic_axiom`.
+
+## The integrity finding
+
+That axiom claims: for `P A B C D : EuclideanSpace ℝ (Fin 2)` with `B-P = t•(A-P)`,
+`D-P = s•(C-P)`, all points `≠ P`, `A ≠ B`, `C ≠ D`, and the **unsigned** product
+equality `‖P-A‖·‖P-B‖ = ‖P-C‖·‖P-D‖`, the four points are concyclic.
+
+**This axiom is false.** The unsigned product discards the sign of the power of the
+point. The true converse of power-of-a-point requires the *signed* powers to agree:
+`t·‖A-P‖² = s·‖C-P‖²`. The unsigned condition `|t|·‖A-P‖² = |s|·‖C-P‖²` also holds when
+`P` is *between* one pair but *outside* the other — opposite-sign powers, no shared
+circle.
+
+`unsigned_converse_counterexample` below proves the negation: an explicit configuration
+satisfying every hypothesis of the axiom for which **no** common circle exists. The
+witness is `P = 0`, `A = e₀`, `B = -4•e₀`, `C = e₁`, `D = 4•e₁` for any two unit vectors
+`e₀, e₁` (e.g. the standard basis): here `t = -4`, `s = 4`, so `|t| = |s|` makes the
+unsigned products equal (`1·4 = 1·4`), but the signed powers `-4` and `+4` have opposite
+sign, so the four points cannot be concyclic.
+
+The corrected, provable converse is stated as `signed_converse_implies_concyclic`
+(currently a `sorry`; the circumcenter construction is build-gated — see
+`research/problems/product-of-segments-of-chords-oq-02/knowledge.md`).
+
+NOTE: build-pending. The Docker Lean toolchain was unavailable when this was written,
+so the proofs below have not been machine-checked. This file is intentionally NOT
+registered in `Proofs.lean` until it has been built.
+-/
+
+set_option linter.unusedVariables false
+
+open scoped RealInnerProductSpace
+
+namespace ProductOfSegmentsOfChordsConverse
+
+abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
+
+/-- **The unsigned converse axiom is false (general form).**
+
+Given *any* two unit vectors `e₀ e₁` in the plane, the configuration
+`P = 0, A = e₀, B = -4•e₀, C = e₁, D = 4•e₁` satisfies every hypothesis of
+`converse_product_implies_concyclic_axiom` (collinearity through `P`, all points
+distinct from `P`, `A ≠ B`, `C ≠ D`, and equal unsigned products `‖P-A‖·‖P-B‖ =
+‖P-C‖·‖P-D‖ = 4`), yet the four points lie on **no** common circle.
+
+The obstruction is purely the sign: `B-P = (-4)•(A-P)` (P inside chord `AB`) while
+`D-P = 4•(C-P)` (P outside chord `CD`), so the signed powers `-4` and `+4` disagree. -/
+theorem unsigned_converse_counterexample_general
+    (e₀ e₁ : Vec2) (he₀ : ‖e₀‖ = 1) (he₁ : ‖e₁‖ = 1) :
+    ∃ (P A B C D : Vec2),
+      (∃ t : ℝ, B - P = t • (A - P)) ∧
+      (∃ t : ℝ, D - P = t • (C - P)) ∧
+      ‖P - A‖ * ‖P - B‖ = ‖P - C‖ * ‖P - D‖ ∧
+      A ≠ P ∧ B ≠ P ∧ C ≠ P ∧ D ≠ P ∧ A ≠ B ∧ C ≠ D ∧
+      ¬ ∃ (O : Vec2) (r : ℝ), r > 0 ∧
+          ‖A - O‖ = r ∧ ‖B - O‖ = r ∧ ‖C - O‖ = r ∧ ‖D - O‖ = r := by
+  refine ⟨0, e₀, (-4 : ℝ) • e₀, e₁, (4 : ℝ) • e₁, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · -- collinearity of A, B through P = 0 with t = -4
+    exact ⟨-4, by simp⟩
+  · -- collinearity of C, D through P = 0 with s = 4
+    exact ⟨4, by simp⟩
+  · -- equal unsigned products: 1 * 4 = 1 * 4
+    have hB : ‖(0 : Vec2) - (-4 : ℝ) • e₀‖ = 4 := by
+      rw [zero_sub, norm_neg, norm_smul, he₀, mul_one, Real.norm_eq_abs]; norm_num
+    have hD : ‖(0 : Vec2) - (4 : ℝ) • e₁‖ = 4 := by
+      rw [zero_sub, norm_neg, norm_smul, he₁, mul_one, Real.norm_eq_abs]; norm_num
+    have hA : ‖(0 : Vec2) - e₀‖ = 1 := by rw [zero_sub, norm_neg, he₀]
+    have hC : ‖(0 : Vec2) - e₁‖ = 1 := by rw [zero_sub, norm_neg, he₁]
+    rw [hA, hB, hC, hD]
+  · -- A = e₀ ≠ 0
+    intro h; rw [h, norm_zero] at he₀; norm_num at he₀
+  · -- B = -4•e₀ ≠ 0
+    intro h
+    have hn : ‖(-4 : ℝ) • e₀‖ = 0 := by rw [h]; simp
+    rw [norm_smul, he₀, mul_one, Real.norm_eq_abs] at hn; norm_num at hn
+  · -- C = e₁ ≠ 0
+    intro h; rw [h, norm_zero] at he₁; norm_num at he₁
+  · -- D = 4•e₁ ≠ 0
+    intro h
+    have hn : ‖(4 : ℝ) • e₁‖ = 0 := by rw [h]; simp
+    rw [norm_smul, he₁, mul_one, Real.norm_eq_abs] at hn; norm_num at hn
+  · -- A = e₀ ≠ B = -4•e₀
+    intro h
+    have hsub : e₀ - (-4 : ℝ) • e₀ = (5 : ℝ) • e₀ := by module
+    have h5 : (5 : ℝ) • e₀ = 0 := by rw [← hsub, sub_eq_zero]; exact h
+    have hn : ‖(5 : ℝ) • e₀‖ = 0 := by rw [h5]; simp
+    rw [norm_smul, he₀, mul_one, Real.norm_eq_abs] at hn; norm_num at hn
+  · -- C = e₁ ≠ D = 4•e₁
+    intro h
+    have hsub : e₁ - (4 : ℝ) • e₁ = (-3 : ℝ) • e₁ := by module
+    have h3 : (-3 : ℝ) • e₁ = 0 := by rw [← hsub, sub_eq_zero]; exact h
+    have hn : ‖(-3 : ℝ) • e₁‖ = 0 := by rw [h3]; simp
+    rw [norm_smul, he₁, mul_one, Real.norm_eq_abs] at hn; norm_num at hn
+  · -- No common circle: the perpendicular-bisector constraints are contradictory.
+    rintro ⟨O, r, hr, hA, hB, hC, hD⟩
+    -- Square each distance equality to r.
+    have hA2 : ‖e₀ - O‖ ^ 2 = r ^ 2 := by rw [hA]
+    have hB2 : ‖(-4 : ℝ) • e₀ - O‖ ^ 2 = r ^ 2 := by rw [hB]
+    have hC2 : ‖e₁ - O‖ ^ 2 = r ^ 2 := by rw [hC]
+    have hD2 : ‖(4 : ℝ) • e₁ - O‖ ^ 2 = r ^ 2 := by rw [hD]
+    -- Expand the squared norms via the polarization identity.
+    rw [norm_sub_sq_real, he₀] at hA2
+    rw [norm_sub_sq_real, he₁] at hC2
+    rw [norm_sub_sq_real, norm_smul, he₀, real_inner_smul_left] at hB2
+    rw [norm_sub_sq_real, norm_smul, he₁, real_inner_smul_left] at hD2
+    -- Abbreviations for the two relevant inner products and ‖O‖².
+    set a : ℝ := inner e₀ O with ha
+    set b : ℝ := inner e₁ O with hb
+    set n : ℝ := ‖O‖ ^ 2 with hn
+    -- After expansion:
+    --   hA2 : 1 - 2a + n = r²
+    --   hB2 : (|−4|·1)² - 2(−4)a + n = r²   i.e. 16 + 8a + n = r²
+    --   hC2 : 1 - 2b + n = r²
+    --   hD2 : (|4|·1)² - 2(4)b + n = r²      i.e. 16 - 8b + n = r²
+    -- From hA2 = hB2: 1 - 2a = 16 + 8a ⟹ a = -3/2.
+    -- From hC2 = hD2: 1 - 2b = 16 - 8b ⟹ b =  5/2.
+    -- From hA2 = hC2: a = b.  Contradiction (-3/2 ≠ 5/2).
+    have e4 : ‖(-4 : ℝ)‖ = 4 := by rw [Real.norm_eq_abs]; norm_num
+    have e4' : ‖(4 : ℝ)‖ = 4 := by rw [Real.norm_eq_abs]; norm_num
+    rw [e4] at hB2
+    rw [e4'] at hD2
+    nlinarith [hA2, hB2, hC2, hD2]
+
+/-- **The unsigned converse axiom is false (concrete witness).**
+
+Specialization of `unsigned_converse_counterexample_general` to the standard basis
+`e₀ = (1,0)`, `e₁ = (0,1)`, giving the explicit configuration
+`P = (0,0), A = (1,0), B = (-4,0), C = (0,1), D = (0,4)` documented in the gallery. -/
+theorem unsigned_converse_counterexample :
+    ∃ (P A B C D : Vec2),
+      (∃ t : ℝ, B - P = t • (A - P)) ∧
+      (∃ t : ℝ, D - P = t • (C - P)) ∧
+      ‖P - A‖ * ‖P - B‖ = ‖P - C‖ * ‖P - D‖ ∧
+      A ≠ P ∧ B ≠ P ∧ C ≠ P ∧ D ≠ P ∧ A ≠ B ∧ C ≠ D ∧
+      ¬ ∃ (O : Vec2) (r : ℝ), r > 0 ∧
+          ‖A - O‖ = r ∧ ‖B - O‖ = r ∧ ‖C - O‖ = r ∧ ‖D - O‖ = r := by
+  have h0 : ‖(EuclideanSpace.single (0 : Fin 2) (1 : ℝ))‖ = 1 := by
+    rw [EuclideanSpace.norm_single]; simp
+  have h1 : ‖(EuclideanSpace.single (1 : Fin 2) (1 : ℝ))‖ = 1 := by
+    rw [EuclideanSpace.norm_single]; simp
+  exact unsigned_converse_counterexample_general _ _ h0 h1
+
+/-- **The corrected (signed) converse — provable formulation.**
+
+Replacing the unsigned product with the **signed** power equality
+`t · ‖A-P‖² = s · ‖C-P‖²` (here `t, s` are the collinearity scalars, so the left side
+is `powerOfPoint P` measured along chord `AB` and the right along `CD`), together with
+the non-degeneracy hypothesis that the two chords are genuinely distinct lines
+(`A-P` and `C-P` linearly independent), the converse holds: `A, B, C, D` are concyclic.
+
+The proof is the circumcenter construction (solve the 2×2 perpendicular-bisector system
+for the circle through `A, B, C`, then show `D` is the second intersection of line `CD`
+with that circle via the signed-power identity). It is build-gated; see knowledge.md. -/
+theorem signed_converse_implies_concyclic
+    (P A B C D : Vec2) (t s : ℝ)
+    (hAB : B - P = t • (A - P)) (hCD : D - P = s • (C - P))
+    (hindep : LinearIndependent ℝ ![A - P, C - P])
+    (hsigned : t * ‖A - P‖ ^ 2 = s * ‖C - P‖ ^ 2)
+    (hAneP : A ≠ P) (hCneP : C ≠ P) :
+    ∃ (O : Vec2) (r : ℝ), r > 0 ∧
+      ‖A - O‖ = r ∧ ‖B - O‖ = r ∧ ‖C - O‖ = r ∧ ‖D - O‖ = r := by
+  sorry
+
+end ProductOfSegmentsOfChordsConverse

--- a/research/problems/product-of-segments-of-chords-oq-02/knowledge.md
+++ b/research/problems/product-of-segments-of-chords-oq-02/knowledge.md
@@ -111,6 +111,31 @@ non-degeneracy determinant `≠ 0`.
 
 ---
 
+## Lean realization (S3, build-pending)
+
+`proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean` (UNREGISTERED) now encodes the
+finding in Lean for the first time (prior PRs #24105/#24153/#24204 were sympy/symbolic
+only):
+
+- `unsigned_converse_counterexample_general (e₀ e₁ : Vec2) (‖e₀‖=1) (‖e₁‖=1)` — proves
+  `∃ P A B C D, <all axiom hyps> ∧ ¬ ∃ O r, r>0 ∧ <four points on a circle>`. Witness
+  `P=0, A=e₀, B=-4•e₀, C=e₁, D=4•e₁`. **Key simplification discovered:** the
+  contradiction needs only `‖e₀‖=‖e₁‖=1` — *no orthogonality*. Working with squared
+  norms via `norm_sub_sq_real`, the perpendicular-bisector equalities `‖A-O‖=‖B-O‖`,
+  `‖C-O‖=‖D-O‖`, `‖A-O‖=‖C-O‖` reduce (cancelling `‖O‖²`) to the linear system
+  `⟪e₀,O⟫=-3/2`, `⟪e₁,O⟫=5/2`, `⟪e₀,O⟫=⟪e₁,O⟫`, closed by `nlinarith`. So the
+  obstruction is one-dimensional (the sign of the power), independent of chord direction.
+- `unsigned_converse_counterexample` — concrete standard-basis instance (the documented
+  `(1,0),(-4,0),(0,1),(0,4)`); only extra dependency is `EuclideanSpace.norm_single`.
+- `signed_converse_implies_concyclic` — the corrected statement (signed power equality
+  `t‖A-P‖²=s‖C-P‖²` + `LinearIndependent ℝ ![A-P, C-P]`), proof `sorry` (circumcenter,
+  build-gated). This is the clean Aristotle target / future ACT goal.
+
+Lemma-name risk points if a future build fails: `norm_sub_sq_real`, `real_inner_smul_left`,
+`EuclideanSpace.norm_single`.
+
+---
+
 ## Next Steps
 
 1. (build-gated) Correct the axiom statement in `ProductOfSegmentsOfChords.lean`:

--- a/research/problems/product-of-segments-of-chords-oq-02/state.md
+++ b/research/problems/product-of-segments-of-chords-oq-02/state.md
@@ -1,36 +1,50 @@
 # Research State: product-of-segments-of-chords-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-14T17:42:10-07:00
-**Iteration**: 2
+**Since**: 2026-06-15T09:30:00-07:00
+**Iteration**: 3
 
 ## Current Focus
-Feasibility resolved on paper. Identified that the target axiom is FALSE as
-typed (unsigned products) and produced the corrected, provable formulation plus
-a coordinate proof outline. Implementation is build-gated (Docker down).
+Lean realization of the integrity finding. Wrote
+`proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean` (UNREGISTERED, build-pending):
+a machine-checkable **counterexample lemma** proving the unsigned converse axiom is
+FALSE, plus the corrected **signed** converse stated in Lean (proof `sorry`,
+build-gated circumcenter construction). Prior sessions only had sympy/symbolic certs
+(PRs #24105, #24153, #24204) — this is the first Lean encoding of the obstruction.
 
 ## Active Approach
 Coordinate / circumcenter construction over `EuclideanSpace ℝ (Fin 2)`:
 1. Correct the converse statement (signed power `t‖A-P‖² = s‖C-P‖²` +
-   linear-independence of `A-P, C-P`).
-2. Build circumcenter of `A,B,C` from the 2×2 perpendicular-bisector system.
+   linear-independence of `A-P, C-P`).  [DONE — `signed_converse_implies_concyclic`]
+2. Build circumcenter of `A,B,C` from the 2×2 perpendicular-bisector system.  [sorry]
 3. Show `D` lies on that circle via the signed-power identity; close with `ring`.
 
+## Counterexample (now in Lean)
+`unsigned_converse_counterexample_general` (any two unit vectors `e₀, e₁`) and the
+concrete `unsigned_converse_counterexample` (standard basis): witness
+`P=0, A=e₀, B=-4•e₀, C=e₁, D=4•e₁`. Proof works entirely with squared norms /
+polarization (`norm_sub_sq_real`, `real_inner_smul_left`, `norm_smul`): the three
+perpendicular-bisector equalities force `⟪e₀,O⟫ = -3/2`, `⟪e₁,O⟫ = 5/2`, and
+`⟪e₀,O⟫ = ⟪e₁,O⟫` simultaneously → contradiction. No orthogonality of `e₀,e₁` needed.
+
 ## Attempt Count
-- Total attempts: 1 (paper feasibility / ORIENT)
-- Current approach attempts: 0 (no Lean written — Docker unavailable)
-- Approaches tried: 1
+- Total attempts: 2 (ORIENT paper feasibility; ACT Lean counterexample)
+- Current approach attempts: 1 (counterexample lemma written, build-pending)
+- Approaches tried: 2
 
 ## Blockers
-- Docker build unavailable this session — cannot compile/verify Lean, so the
-  proof itself is deferred. The mathematics is fully resolved (no math blocker).
+- Docker build + Aristotle MCP unavailable this session (dual blackout) — the Lean
+  file is written but NOT machine-checked, and the signed-converse `sorry` (circumcenter
+  construction) cannot be discharged/submitted yet. Mathematics fully resolved.
 
 ## Next Action
 When Docker is available:
-1. Edit `proofs/Proofs/ProductOfSegmentsOfChords.lean` to correct the converse
-   statement (see knowledge.md "Corrected, provable formulation").
-2. Implement the circumcenter construction proof (~150-250 LOC, BUILD decision).
-3. Drive `axiomCount` to 0 and add a Lean counterexample lemma guarding the
-   unsigned form.
+1. Build `ProductOfSegmentsOfChordsConverse.lean`; fix any lemma-name drift
+   (`EuclideanSpace.norm_single`, `norm_sub_sq_real` are the risk points).
+2. Discharge `signed_converse_implies_concyclic` via the circumcenter construction
+   (~150-250 LOC) OR submit that single `sorry` to Aristotle.
+3. Once both compile, fold the counterexample + corrected statement into the parent
+   `ProductOfSegmentsOfChords.lean`, delete the false axiom, drive `axiomCount` → 0,
+   register the file in `Proofs.lean`.


### PR DESCRIPTION
## Summary

The parent gallery file axiomatizes the **converse** of the intersecting-chords /
power-of-a-point theorem (`converse_product_implies_concyclic_axiom`). Prior sessions
(#24105 ORIENT, #24153/#24204 certs) established **on paper / in sympy** that this axiom
is *false as typed*: it uses the **unsigned** product `‖P-A‖·‖P-B‖ = ‖P-C‖·‖P-D‖`, which
ignores the sign of the power of the point.

This PR gives the **first Lean encoding** of that obstruction — a machine-checkable
counterexample lemma — plus the corrected (signed) converse stated in Lean.

New file `proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean`:

- **`unsigned_converse_counterexample_general`** — for *any* two unit vectors `e₀, e₁`,
  the configuration `P=0, A=e₀, B=-4•e₀, C=e₁, D=4•e₁` satisfies **every** hypothesis of
  the axiom (collinearity through `P`, all points `≠ P`, `A≠B`, `C≠D`, equal unsigned
  products `1·4 = 1·4`) yet lies on **no** common circle. Here `t=-4` (P inside chord AB)
  but `s=+4` (P outside chord CD) — opposite-sign powers.
- **`unsigned_converse_counterexample`** — the concrete documented instance
  `(1,0),(-4,0),(0,1),(0,4)` over the standard basis.
- **`signed_converse_implies_concyclic`** — the corrected, provable statement (signed
  power equality `t‖A-P‖²=s‖C-P‖²` + `LinearIndependent ℝ ![A-P, C-P]`); proof `sorry`
  (circumcenter construction, build-gated — clean Aristotle target).

### Proof note (a small new observation)

The contradiction needs only `‖e₀‖=‖e₁‖=1` — **no orthogonality of the chords**. Working
with squared norms (`norm_sub_sq_real`), the three perpendicular-bisector equalities
`‖A-O‖=‖B-O‖`, `‖C-O‖=‖D-O‖`, `‖A-O‖=‖C-O‖` cancel `‖O‖²` and reduce to the linear system
`⟪e₀,O⟫=-3/2`, `⟪e₁,O⟫=5/2`, `⟪e₀,O⟫=⟪e₁,O⟫`, closed by `nlinarith`. So the obstruction
is one-dimensional (the sign of the power), independent of chord direction.

## Status

**Build-pending / UNREGISTERED.** Docker Lean toolchain and Aristotle MCP were both
unavailable this session (dual blackout), so the proofs are **not yet machine-checked**
and the file is intentionally not added to `Proofs.lean`. The mathematics is fully
resolved. Lemma-name risk points for a future build: `norm_sub_sq_real`,
`real_inner_smul_left`, `EuclideanSpace.norm_single`.

This complements (does not collide with) the docs-flag PR #24270.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsConverse` once Docker is back
- [ ] If `signed_converse_implies_concyclic` sorry remains, submit that single sorry to Aristotle
- [ ] On green build, fold counterexample + corrected statement into parent file, delete the false axiom, drive axiomCount → 0, register in Proofs.lean

🤖 Generated with [Claude Code](https://claude.com/claude-code)