### PR TITLE
Fix 200+ silently-dead cross-references across 60 gallery entries

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-03/meta.json
@@ -314,22 +314,16 @@
   },
   "crossReferences": [
     {
-      "type": "sibling",
-      "slug": "angle-trisection-cos-20-gal-oq-01-oq-02",
-      "title": "p=5 case: Galois group of cos(π/5)",
-      "relation": "Sibling file establishing Eisenstein at 5 for the equivalent polynomial 4X²−2X−1 (= r_5(2X+2))."
+      "targetId": "angle-trisection-cos-20-gal-oq-01-oq-02",
+      "relationship": "Sibling file establishing Eisenstein at 5 for the equivalent polynomial 4X²−2X−1 (= r_5(2X+2))."
     },
     {
-      "type": "sibling",
-      "slug": "angle-trisection-cos-20-gal-oq-01",
-      "title": "p=7 case: Galois group of cos(π/7)",
-      "relation": "Sibling file establishing Eisenstein at 7 for the equivalent polynomial 8X³−4X²−4X+1 (= r_7(2X+2))."
+      "targetId": "angle-trisection-cos-20-gal-oq-01",
+      "relationship": "Sibling file establishing Eisenstein at 7 for the equivalent polynomial 8X³−4X²−4X+1 (= r_7(2X+2))."
     },
     {
-      "type": "parent",
-      "slug": "angle-trisection-cos-20-gal",
-      "title": "Galois group of cos(20°) = cos(π/9)",
-      "relation": "Origin of the family. Uses Eisenstein at p=3 for Y³−6Y²+9Y−3. Not part of the prime-p family (9 is not prime) but structurally analogous."
+      "targetId": "angle-trisection-cos-20-gal",
+      "relationship": "Origin of the family. Uses Eisenstein at p=3 for Y³−6Y²+9Y−3. Not part of the prime-p family (9 is not prime) but structurally analogous."
     }
   ]
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -140,18 +140,14 @@
   },
   "crossReferences": [
     {
-      "slug": "arithmetic-series-oq-02-oq-02",
-      "title": "2D Hockey Stick Identity",
-      "relation": "parent-problem",
-      "description": "Parent file proving the same identity by induction; this provides the alternative generating function proof",
-      "relationship": "extends"
+      "targetId": "arithmetic-series-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent file proving the same identity by induction; this provides the alternative generating function proof"
     },
     {
-      "slug": "arithmetic-series-oq-02",
-      "title": "Simplicial Numbers and the Hockey Stick Identity",
-      "relation": "grandparent-problem",
-      "description": "Defines simplicial numbers and the 1D hockey stick used in the coefficient extraction proof",
-      "relationship": "related"
+      "targetId": "arithmetic-series-oq-02",
+      "relationship": "related",
+      "description": "Defines simplicial numbers and the 1D hockey stick used in the coefficient extraction proof"
     }
   ],
   "references": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -201,13 +201,11 @@
   },
   "crossReferences": [
     {
-      "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
-      "title": "q-Multichoose: The Gaussian Binomial as q-Analog of Multiset Coefficients",
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
       "relationship": "parent — this entry answers (partially) the (q,t)-deformation open question posed in the parent's conclusion; it recovers the parent's qMultichoose at t=1 and bridges its polynomial sub-lattice to the parent's named objects"
     },
     {
-      "id": "combinations-formula-oq-03",
-      "title": "q-Analog Binomial Coefficients (Gaussian Binomial Coefficients)",
+      "targetId": "combinations-formula-oq-03",
       "relationship": "dependency — provides qBinom, qBinom_pascal, qBinom_pascal', qBinom_eq_zero_of_lt, qBinom_one_right, and qNumber_geometric, used to derive the t=1 specialization and the polynomial-form bridges"
     }
   ],

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -156,13 +156,11 @@
   },
   "crossReferences": [
     {
-      "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-      "title": "Multiset Vandermonde Identity",
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
       "relationship": "parent — this entry answers OQ-03 from the Multiset Vandermonde entry, defining the q-analog of multichoose that generalizes its classical count"
     },
     {
-      "id": "combinations-formula-oq-03",
-      "title": "q-Analog Binomial Coefficients (Gaussian Binomial Coefficients)",
+      "targetId": "combinations-formula-oq-03",
       "relationship": "dependency — provides qBinom, qBinom_pascal, qBinom_at_one, qBinom_self, qBinom_one_right, and qBinom_penult, all used to prove qMultichoose properties"
     }
   ],

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -114,18 +114,15 @@
   },
   "crossReferences": [
     {
-      "id": "ballot-problem-oq-01-oq-02-oq-01",
-      "title": "Uniform Fiber Transfer for Multi-Candidate Ballot Theorem",
+      "targetId": "ballot-problem-oq-01-oq-02-oq-01",
       "relationship": "Parent proof where ncard_biUnion_eq_of_uniform was first developed for ballot fiber counting"
     },
     {
-      "id": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
-      "title": "General Uniform Fiber Transfer: uniformOn Preserved for All Events",
+      "targetId": "ballot-problem-oq-01-oq-02-oq-01-oq-02",
       "relationship": "Sibling that uses uniform fiber cardinality to prove probability preservation for all events simultaneously"
     },
     {
-      "id": "ballot-problem-oq-01-oq-02",
-      "title": "Multi-Candidate Ballot Theorem",
+      "targetId": "ballot-problem-oq-01-oq-02",
       "relationship": "Grandparent: the multi-candidate ballot result whose fiber structure motivated the uniform cardinality lemma"
     }
   ],

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -108,23 +108,19 @@
   },
   "crossReferences": [
     {
-      "id": "ballot-problem-oq-03-oq-01",
-      "title": "LGV Lemma 2×2",
+      "targetId": "ballot-problem-oq-03-oq-01",
       "relationship": "foundational"
     },
     {
-      "id": "ballot-problem-oq-03-oq-02",
-      "title": "LGV Lemma n×n",
+      "targetId": "ballot-problem-oq-03-oq-02",
       "relationship": "foundational"
     },
     {
-      "id": "ballot-problem-oq-03-oq-01-oq-01",
-      "title": "General n×n LGV (restatement)",
+      "targetId": "ballot-problem-oq-03-oq-01-oq-01",
       "relationship": "sibling"
     },
     {
-      "id": "ballot-problem-oq-03-oq-03",
-      "title": "2-row hook-length formula",
+      "targetId": "ballot-problem-oq-03-oq-03",
       "relationship": "extends"
     }
   ],

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-01/meta.json
@@ -153,15 +153,15 @@
   ],
   "crossReferences": [
     {
-      "id": "bertrands-postulate-oq-03-oq-04",
+      "targetId": "bertrands-postulate-oq-03-oq-04",
       "relationship": "parent: provides BHP (prime_gap_conjecture_bhp, ε=0.525) and ShortIntervalPNT infrastructure used here"
     },
     {
-      "id": "bertrands-postulate-oq-03",
+      "targetId": "bertrands-postulate-oq-03",
       "relationship": "grandparent: Bertrand's postulate [x, 2x] case, foundation of the prime gap hierarchy"
     },
     {
-      "id": "prime-number-theorem",
+      "targetId": "prime-number-theorem",
       "relationship": "related: PNT is the density statement π(x) ~ x/log(x); ShortIntervalPNT is the local analogue"
     }
   ],

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
@@ -124,13 +124,11 @@
   },
   "crossReferences": [
     {
-      "id": "birch-swinnerton-dyer-oq-06",
-      "title": "BSD Verification for Curve 389a: Height Pairing Matrix",
+      "targetId": "birch-swinnerton-dyer-oq-06",
       "relationship": "This entry is a sub-question of OQ-06, which axiomatizes the height pairing matrix H = [[h₁₁, h₁₂], [h₁₂, h₂₂]] for curve 389a. The Weierstrass computations here connect the abstract matrix entries to explicit group law calculations."
     },
     {
-      "id": "birch-swinnerton-dyer",
-      "title": "Birch and Swinnerton-Dyer Conjecture",
+      "targetId": "birch-swinnerton-dyer",
       "relationship": "The parent conjecture formulated in the 1960s. The regulator det(H) computed via the height pairing matrix of OQ-06 enters the BSD formula's main prediction relating L''(E,1) to arithmetic invariants of E over ℚ."
     }
   ],

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -101,12 +101,12 @@
   },
   "crossReferences": [
     {
-      "slug": "bounded-prime-gaps",
+      "targetId": "bounded-prime-gaps",
       "relationship": "extends",
       "description": "Parent proof containing admissible_quadruple_0_2_6_8 witness and admissible_subset lemma used in the D(4)=8 proof"
     },
     {
-      "slug": "bounded-prime-gaps-oq-03-oq-01",
+      "targetId": "bounded-prime-gaps-oq-03-oq-01",
       "relationship": "extends",
       "description": "Prior OQ file proving D(2)=2 and D(3)=6, providing not_admissible_ap_diff2 and minAdmissibleDiameter_2/3 used here"
     }

--- a/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
@@ -95,22 +95,22 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-schwarz",
+      "targetId": "cauchy-schwarz",
       "relationship": "related",
       "description": "Cauchy-Schwarz Inequality"
     },
     {
-      "slug": "cauchy-schwarz-oq-04",
+      "targetId": "cauchy-schwarz-oq-04",
       "relationship": "related",
       "description": "Cauchy-Schwarz Equality: Exact Proportionality Constant"
     },
     {
-      "slug": "cauchy-schwarz-integral",
+      "targetId": "cauchy-schwarz-integral",
       "relationship": "related",
       "description": "Cauchy-Schwarz Integral Inequality"
     },
     {
-      "slug": "amgm-inequality",
+      "targetId": "amgm-inequality",
       "relationship": "related",
       "description": "AM-GM Inequality"
     }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -176,18 +176,15 @@
   },
   "crossReferences": [
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
-      "title": "Skolem-Noether for Matrix Algebras",
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
       "relationship": "Parent: proves Skolem-Noether for the special case B = Mₙ(K) using an elementary matrix approach. This entry extends to arbitrary central simple algebras via Wedderburn-Artin + isotypic decomposition."
     },
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-01",
-      "title": "Minimal Polynomial Preservation",
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-01",
       "relationship": "Grandparent: minimal polynomial preservation under algebra equivalences — the seed of the Skolem-Noether chain. Establishes the algebraic context for why automorphisms must be inner."
     },
     {
-      "id": "cayley-hamilton",
-      "title": "Cayley-Hamilton Theorem",
+      "targetId": "cayley-hamilton",
       "relationship": "Foundational: Cayley-Hamilton provides the polynomial integrality that underlies the minimal polynomial machinery used throughout this chain."
     }
   ],

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -131,17 +131,17 @@
   },
   "crossReferences": [
     {
-      "id": "central-limit-theorem-oq-01-oq-01",
+      "targetId": "central-limit-theorem-oq-01-oq-01",
       "relationship": "parent",
       "description": "Gnedenko-Kolmogorov domain of attraction (univariate) — the d=1 scalar case that this entry generalizes"
     },
     {
-      "id": "central-limit-theorem-oq-01",
+      "targetId": "central-limit-theorem-oq-01",
       "relationship": "ancestor",
       "description": "α-stable distributions — scalar stable laws that are the 1D case of operator-stable"
     },
     {
-      "id": "central-limit-theorem",
+      "targetId": "central-limit-theorem",
       "relationship": "ancestor",
       "description": "Classical CLT — recovered as the Gaussian DOA theorem in the operator-stable framework"
     }

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-04/meta.json
@@ -189,16 +189,12 @@
   ],
   "crossReferences": [
     {
-      "type": "parent",
-      "slug": "central-limit-theorem-oq-02",
-      "title": "Central Limit Theorem OQ-02: Generalization to Dependent Random Variables",
-      "relation": "Direct parent. Defines alphaMixingCoeff, AlphaMixingSequence, longRunVariance, and martingale/mixing CLT axioms. This OQ-02-OQ-04 file imports it and adds the polynomial-rate specialization."
+      "targetId": "central-limit-theorem-oq-02",
+      "relationship": "Direct parent. Defines alphaMixingCoeff, AlphaMixingSequence, longRunVariance, and martingale/mixing CLT axioms. This OQ-02-OQ-04 file imports it and adds the polynomial-rate specialization."
     },
     {
-      "type": "ancestor",
-      "slug": "central-limit-theorem",
-      "title": "Central Limit Theorem (classical)",
-      "relation": "Foundational ancestor. The classical CLT is the i.i.d. specialization of Ibragimov's mixing CLT (α(n) = 0 for n ≥ 1)."
+      "targetId": "central-limit-theorem",
+      "relationship": "Foundational ancestor. The classical CLT is the i.i.d. specialization of Ibragimov's mixing CLT (α(n) = 0 for n ≥ 1)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
@@ -104,19 +104,19 @@
   },
   "crossReferences": [
     {
-      "id": "combinations-formula-oq-01",
+      "targetId": "combinations-formula-oq-01",
       "relationship": "parent",
-      "note": "Extended Binomial Coefficient Identities — this is OQ-04"
+      "description": "Extended Binomial Coefficient Identities — this is OQ-04"
     },
     {
-      "id": "ballot-problem-oq-03-oq-02",
+      "targetId": "ballot-problem-oq-03-oq-02",
       "relationship": "depends-on",
-      "note": "Imports the r×r LGV proof via Gessel-Viennot involution"
+      "description": "Imports the r×r LGV proof via Gessel-Viennot involution"
     },
     {
-      "id": "ballot-problem-oq-03",
+      "targetId": "ballot-problem-oq-03",
       "relationship": "related",
-      "note": "The 2×2 LGV for ballot problem lattice paths"
+      "description": "The 2×2 LGV for ballot problem lattice paths"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-06/meta.json
@@ -107,11 +107,11 @@
   },
   "crossReferences": [
     {
-      "id": "combinations-formula-oq-03",
+      "targetId": "combinations-formula-oq-03",
       "relationship": "parent — provides qNumber, qFactorial, qBinom infrastructure used throughout"
     },
     {
-      "id": "combinations-formula-oq-02",
+      "targetId": "combinations-formula-oq-02",
       "relationship": "grandparent — the original combinations formula entry"
     }
   ],

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -227,22 +227,22 @@
   },
   "crossReferences": [
     {
-      "slug": "derangements-oq-03-oq-02",
+      "targetId": "derangements-oq-03-oq-02",
       "relationship": "extends",
       "description": "Extends this convergence result to total variation convergence of the fixed-point distribution to Poisson(1)"
     },
     {
-      "slug": "derangements",
+      "targetId": "derangements",
       "relationship": "related",
       "description": "Base derangement entry proving the formula D(n) = n! · ∑(-1)^k/k! via inclusion-exclusion; this entry proves the analytic convergence"
     },
     {
-      "slug": "e-transcendental",
+      "targetId": "e-transcendental",
       "relationship": "related",
       "description": "The constant 1/e appears as the limit here; e-transcendental proves e is transcendental (Hermite 1873), providing context for why the limit is not rational"
     },
     {
-      "slug": "prob-method-expectation",
+      "targetId": "prob-method-expectation",
       "relationship": "related",
       "description": "The first moment method and indicator random variables underlie the probabilistic interpretation: P[random permutation is a derangement] → 1/e"
     }

--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -97,22 +97,22 @@
   },
   "crossReferences": [
     {
-      "slug": "derangements-oq-02",
+      "targetId": "derangements-oq-02",
       "relationship": "extends",
       "description": "Parent file providing the partial derangement formula S(n,k) = C(n,k)·D(n-k), numDerangements, and card_perms_with_kfixed"
     },
     {
-      "slug": "derangements",
+      "targetId": "derangements",
       "relationship": "related",
       "description": "Base derangement entry proving D(n) = n!·∑(-1)^k/k! via inclusion-exclusion; the partial derangement decomposition S(n,k) here generalizes that formula"
     },
     {
-      "slug": "burnside-counting",
+      "targetId": "burnside-counting",
       "relationship": "uses",
       "description": "Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) is the direct tool for proving sum_fixedPoints_eq_factorial — the orbit count collapses to 1 via transitivity"
     },
     {
-      "slug": "lagrange-theorem-oq-01",
+      "targetId": "lagrange-theorem-oq-01",
       "relationship": "related",
       "description": "The orbit-stabilizer theorem (|orbit|·|stab|=|G|) used in card_perm_fixing_point is a consequence of Lagrange's theorem applied to the stabilizer subgroup"
     }

--- a/src/data/proofs/derangements-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-02/meta.json
@@ -111,17 +111,17 @@
   ],
   "crossReferences": [
     {
-      "slug": "derangements-convergence",
+      "targetId": "derangements-convergence",
       "relationship": "uses",
       "description": "The sharp bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! is the key analytic input to the pointwise error estimate in the TV convergence proof."
     },
     {
-      "slug": "prob-method-expectation",
+      "targetId": "prob-method-expectation",
       "relationship": "related",
       "description": "Both entries develop probabilistic approximation arguments; the fixed-point distribution is a canonical example of Poisson approximation via the second moment method."
     },
     {
-      "slug": "cauchy-schwarz-oq-04-oq-01",
+      "targetId": "cauchy-schwarz-oq-04-oq-01",
       "relationship": "related",
       "description": "Both proofs rely heavily on Mathlib's summability infrastructure (tsum, Summable, summable_pow_div_factorial)."
     }

--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -128,7 +128,7 @@
   },
   "crossReferences": [
     {
-      "id": "ehrhart-cube-proven",
+      "targetId": "ehrhart-cube-proven",
       "relationship": "parent",
       "description": "Cube Ehrhart formula L([0,1]^d, n) = (n+1)^d, proved axiom-free via the Fintype bijection Fin d → Fin (n+1). This entry answers OQ-01 of that proof: both use Fintype cardinality, but the simplex uses multisets (Sym) while the cube uses functions."
     }

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -184,13 +184,11 @@
   },
   "crossReferences": [
     {
-      "slug": "ehrhart-cube-proven",
-      "title": "Ehrhart Polynomial of the Unit Cube",
+      "targetId": "ehrhart-cube-proven",
       "relationship": "Parent proof whose OQ-02 this answers. Uses (n+1)^d via Fintype.card_fun."
     },
     {
-      "slug": "ehrhart-cube-proven-oq-01",
-      "title": "Ehrhart Polynomial of the Standard Simplex",
+      "targetId": "ehrhart-cube-proven-oq-01",
       "relationship": "Sibling proof (OQ-01) using multisets Sym (Fin(d+1)) n for the simplex case."
     }
   ],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -137,15 +137,15 @@
   },
   "crossReferences": [
     {
-      "id": "elementary-quadratic-reciprocity-oq-01-oq-01",
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01",
       "relationship": "parent — outlines the full Gauss sum pathway for QR"
     },
     {
-      "id": "elementary-quadratic-reciprocity-oq-02-oq-01",
+      "targetId": "elementary-quadratic-reciprocity-oq-02-oq-01",
       "relationship": "sibling — proves the same identity from the OQ02 parent's axiom perspective"
     },
     {
-      "id": "elementary-quadratic-reciprocity",
+      "targetId": "elementary-quadratic-reciprocity",
       "relationship": "root — the Eisenstein lattice-point proof of QR"
     }
   ],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-02/meta.json
@@ -145,23 +145,19 @@
   },
   "crossReferences": [
     {
-      "id": "elementary-quadratic-reciprocity-oq-01-oq-01",
-      "title": "Gauss Sum QR Pathway (Four-Step Outline)",
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01",
       "relationship": "parent — outlines the full four-step Gauss sum pathway for QR; this entry discharges Step 3 (τ^q = χ(q)·τ)."
     },
     {
-      "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
-      "title": "Gauss Sum Squared: τ² = χ(-1)·p",
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
       "relationship": "sibling — proves Step 2 (τ² = χ(-1)·p) which this file's qr_via_frobenius takes as a hypothesis."
     },
     {
-      "id": "elementary-quadratic-reciprocity",
-      "title": "Quadratic Reciprocity (Eisenstein Lattice-Point Proof)",
+      "targetId": "elementary-quadratic-reciprocity",
       "relationship": "root — the Eisenstein lattice-point proof of QR; semantically distinct path that the Gauss-sum argument formalized here can replace once Step 4 is assembled."
     },
     {
-      "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03",
-      "title": "Higher-Power Reciprocity via Jacobi Sums",
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03",
       "relationship": "sibling — extends to higher-power reciprocity using Jacobi sums; the analogue τ^q = J(χ,χ)·τ for cubic χ is the natural successor."
     }
   ],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02-oq-01/meta.json
@@ -108,11 +108,11 @@
   },
   "crossReferences": [
     {
-      "id": "elementary-quadratic-reciprocity-oq-02",
+      "targetId": "elementary-quadratic-reciprocity-oq-02",
       "relationship": "parent — provides the axiom gauss_sum_sq that this proof proves/corrects"
     },
     {
-      "id": "elementary-quadratic-reciprocity",
+      "targetId": "elementary-quadratic-reciprocity",
       "relationship": "grandparent — the main QR formalization"
     }
   ],

--- a/src/data/proofs/erdos-1025/meta.json
+++ b/src/data/proofs/erdos-1025/meta.json
@@ -141,27 +141,27 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1029",
+      "targetId": "erdos-1029",
       "relationship": "related",
       "description": "Erdős Problem #1029: Ramsey Number Growth Rate"
     },
     {
-      "slug": "erdos-1028",
+      "targetId": "erdos-1028",
       "relationship": "related",
       "description": "Erdős Problem #1028: Discrepancy of Sign Functions"
     },
     {
-      "slug": "ramseys-theorem",
+      "targetId": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey's Theorem"
     },
     {
-      "slug": "szemeredi-regularity",
+      "targetId": "szemeredi-regularity",
       "relationship": "related",
       "description": "Szemeredi Regularity Lemma"
     },
     {
-      "slug": "erdos-1",
+      "targetId": "erdos-1",
       "relationship": "related",
       "description": "Erdős Problem #1: Distinct Subset Sums"
     }

--- a/src/data/proofs/erdos-1029/meta.json
+++ b/src/data/proofs/erdos-1029/meta.json
@@ -110,34 +110,29 @@
   },
   "crossReferences": [
     {
-      "slug": "ramseys-theorem",
-      "relation": "foundation",
-      "note": "Ramsey's theorem establishes that R(k) is finite for all k, providing the fundamental existence result that this problem refines into a quantitative growth-rate question.",
-      "relationship": "related"
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey's theorem establishes that R(k) is finite for all k, providing the fundamental existence result that this problem refines into a quantitative growth-rate question."
     },
     {
-      "slug": "erdos-1015",
-      "relation": "closely-related",
-      "note": "Erdős Problem #1015 concerns partitioning 2-colored complete graphs using monochromatic cliques and directly involves the off-diagonal Ramsey number R(t, t-1), sharing the same extremal graph-theoretic setting.",
-      "relationship": "related"
+      "targetId": "erdos-1015",
+      "relationship": "related",
+      "description": "Erdős Problem #1015 concerns partitioning 2-colored complete graphs using monochromatic cliques and directly involves the off-diagonal Ramsey number R(t, t-1), sharing the same extremal graph-theoretic setting."
     },
     {
-      "slug": "erdos-1",
-      "relation": "thematic",
-      "note": "Erdős Problem #1 (distinct subset sums) is another of Erdős's oldest open problems carrying a prize, illustrating his broader program of quantitative combinatorics where probabilistic lower bounds are expected to be far from tight.",
-      "relationship": "related"
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Erdős Problem #1 (distinct subset sums) is another of Erdős's oldest open problems carrying a prize, illustrating his broader program of quantitative combinatorics where probabilistic lower bounds are expected to be far from tight."
     },
     {
-      "slug": "erdos-500",
-      "relation": "thematic",
-      "note": "Turán density for hypergraphs is a parallel open problem in extremal combinatorics where the gap between probabilistic and algebraic bounds is also enormous and unresolved.",
-      "relationship": "related"
+      "targetId": "erdos-500",
+      "relationship": "related",
+      "description": "Turán density for hypergraphs is a parallel open problem in extremal combinatorics where the gap between probabilistic and algebraic bounds is also enormous and unresolved."
     },
     {
-      "slug": "szemeredi-regularity",
-      "relation": "technique",
-      "note": "The Szemerédi Regularity Lemma is a key structural tool in extremal graph theory; progress on Ramsey upper bounds often passes through regularity-type arguments and graph decompositions.",
-      "relationship": "related"
+      "targetId": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "The Szemerédi Regularity Lemma is a key structural tool in extremal graph theory; progress on Ramsey upper bounds often passes through regularity-type arguments and graph decompositions."
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -147,27 +147,27 @@
   },
   "crossReferences": [
     {
-      "slug": "wilsons-theorem",
+      "targetId": "wilsons-theorem",
       "relationship": "Wilson's theorem ($p \\mid (p-1)!+1$ iff $p$ is prime) is the direct foundation of Problem #1072: it establishes the upper bound $f(p) \\leq p-1$ and guarantees the infimum defining $f(p)$ is finite for every prime."
     },
     {
-      "slug": "erdos-1073",
+      "targetId": "erdos-1073",
       "relationship": "Immediate companion problem: #1073 asks whether composites $u$ with $u \\mid n!+1$ for some $n$ are sub-polynomial in count, while #1072 studies the least such $n$ for primes. Both probe the arithmetic of factorial residues modulo primes and composites."
     },
     {
-      "slug": "erdos-1074",
+      "targetId": "erdos-1074",
       "relationship": "Direct sibling from the same Erdős–Hardy–Subbarao (2002) paper: #1074 asks about the density of EHS numbers and Pillai primes, which are defined by the same factorial congruence $n! \\equiv -1 \\pmod{p}$ studied in #1072."
     },
     {
-      "slug": "erdos-1058",
+      "targetId": "erdos-1058",
       "relationship": "Complementary factorial-prime problem: #1058 asks which primes can divide $n!+1$ for $n$ in specific intervals, and its resolution by Luca (2001) illustrates the kind of finiteness argument that would be needed to settle #1072a."
     },
     {
-      "slug": "erdos-1056",
+      "targetId": "erdos-1056",
       "relationship": "Related modular-arithmetic problem about products of consecutive intervals modulo $p$: both #1056 and #1072 investigate when specific products (partial factorials) achieve a prescribed residue modulo a prime."
     },
     {
-      "slug": "bertrands-postulate",
+      "targetId": "bertrands-postulate",
       "relationship": "Bertrand's postulate underpins prime distribution arguments used as context for #1072: knowing that primes are 'dense enough' is relevant to understanding whether Wilson-maximal primes can be infinite or must have zero density."
     }
   ],

--- a/src/data/proofs/erdos-1080/meta.json
+++ b/src/data/proofs/erdos-1080/meta.json
@@ -172,27 +172,27 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1008",
+      "targetId": "erdos-1008",
       "relationship": "related",
       "description": "Erdős Problem #1008: C₄-Free Subgraphs"
     },
     {
-      "slug": "erdos-1021",
+      "targetId": "erdos-1021",
       "relationship": "related",
       "description": "Erdős Problem #1021: Extremal Numbers for Bipartite Pair Graphs"
     },
     {
-      "slug": "erdos-113",
+      "targetId": "erdos-113",
       "relationship": "related",
       "description": "Erdős Problem #113: Extremal Numbers and Degeneracy of Bipartite Graphs"
     },
     {
-      "slug": "erdos-1079",
+      "targetId": "erdos-1079",
       "relationship": "related",
       "description": "Erdős Problem #1079: Turán Density in Neighborhoods"
     },
     {
-      "slug": "erdos-65",
+      "targetId": "erdos-65",
       "relationship": "related",
       "description": "Erdős Problem #65: Cycle Lengths in Dense Graphs"
     }

--- a/src/data/proofs/erdos-1086/meta.json
+++ b/src/data/proofs/erdos-1086/meta.json
@@ -141,32 +141,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1069",
+      "targetId": "erdos-1069",
       "relationship": "related",
       "description": "Erdős Problem #1069: Szemerédi-Trotter Theorem on k-Rich Lines"
     },
     {
-      "slug": "erdos-1085",
+      "targetId": "erdos-1085",
       "relationship": "related",
       "description": "Erdős Problem #1085: The Unit Distance Problem"
     },
     {
-      "slug": "erdos-1082",
+      "targetId": "erdos-1082",
       "relationship": "related",
       "description": "Erdős Problem #1082: Distinct Distances in General Position"
     },
     {
-      "slug": "erdos-1084",
+      "targetId": "erdos-1084",
       "relationship": "related",
       "description": "Erdős Problem #1084: Unit Distances Among Separated Points"
     },
     {
-      "slug": "erdos-102",
+      "targetId": "erdos-102",
       "relationship": "related",
       "description": "Erdős Problem #102: Maximum Collinear Points Forced by Many Rich Lines"
     },
     {
-      "slug": "szemeredi-core",
+      "targetId": "szemeredi-core",
       "relationship": "related",
       "description": "Szemerédi Core Definitions"
     }

--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -175,32 +175,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-95",
+      "targetId": "erdos-95",
       "relationship": "related",
       "description": "Erdős Problem #95: Sum of Squared Distance Multiplicities"
     },
     {
-      "slug": "erdos-1085",
+      "targetId": "erdos-1085",
       "relationship": "related",
       "description": "Erdős Problem #1085: The Unit Distance Problem"
     },
     {
-      "slug": "erdos-1086",
+      "targetId": "erdos-1086",
       "relationship": "related",
       "description": "Erdős Problem #1086: Triangles of Equal Area"
     },
     {
-      "slug": "erdos-1069",
+      "targetId": "erdos-1069",
       "relationship": "related",
       "description": "Erdős Problem #1069: Szemerédi-Trotter Theorem on k-Rich Lines"
     },
     {
-      "slug": "erdos-1082",
+      "targetId": "erdos-1082",
       "relationship": "related",
       "description": "Erdős Problem #1082: Distinct Distances in General Position"
     },
     {
-      "slug": "erdos-90",
+      "targetId": "erdos-90",
       "relationship": "related",
       "description": "Erdős Problem #90: The Unit Distance Problem"
     }

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -169,46 +169,34 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-62",
-      "title": "Erdős Problem #62: Common Subgraphs of Graphs with Chromatic Number ℵ₁",
-      "relation": "sibling-problem",
-      "description": "Directly related: asks whether any two ℵ₁-chromatic graphs share a common finite subgraph, another question about finite structure inside uncountably chromatic graphs",
-      "relationship": "related"
+      "targetId": "erdos-62",
+      "relationship": "related",
+      "description": "Directly related: asks whether any two ℵ₁-chromatic graphs share a common finite subgraph, another question about finite structure inside uncountably chromatic graphs"
     },
     {
-      "slug": "erdos-111",
-      "title": "Erdős Problem #111: Edge Deletion to Bipartiteness for Large Chromatic Graphs",
-      "relation": "sibling-problem",
-      "description": "Companion problem in the series: studies how many edges must be deleted to make ℵ₁-chromatic graphs bipartite, related structure theory",
-      "relationship": "related"
+      "targetId": "erdos-111",
+      "relationship": "related",
+      "description": "Companion problem in the series: studies how many edges must be deleted to make ℵ₁-chromatic graphs bipartite, related structure theory"
     },
     {
-      "slug": "erdos-736",
-      "title": "Chromatic Numbers and Finite Subgraph Inheritance",
-      "relation": "foundational-theorem",
-      "description": "Directly relevant: concerns the inheritance of chromatic properties by finite subgraphs of infinite graphs — the central theme of Problem #110",
-      "relationship": "related"
+      "targetId": "erdos-736",
+      "relationship": "related",
+      "description": "Directly relevant: concerns the inheritance of chromatic properties by finite subgraphs of infinite graphs — the central theme of Problem #110"
     },
     {
-      "slug": "erdos-593",
-      "title": "Erdős Problem #593: Finite Subhypergraphs of Uncountably Chromatic 3-Uniform Hypergraphs",
-      "relation": "generalization",
-      "description": "Hypergraph analogue of Problem #110: asks the same question about bounded finite subhypergraphs in the uncountably chromatic setting",
-      "relationship": "related"
+      "targetId": "erdos-593",
+      "relationship": "related",
+      "description": "Hypergraph analogue of Problem #110: asks the same question about bounded finite subhypergraphs in the uncountably chromatic setting"
     },
     {
-      "slug": "erdos-918",
-      "title": "Erdős Problem #918: Chromatic Numbers of Infinite Graphs",
-      "relation": "sibling-problem",
-      "description": "Broadly related: studies chromatic number behavior and structure theory for infinite graphs, overlapping themes of ℵ₀ vs ℵ₁ chromatic behavior",
-      "relationship": "related"
+      "targetId": "erdos-918",
+      "relationship": "related",
+      "description": "Broadly related: studies chromatic number behavior and structure theory for infinite graphs, overlapping themes of ℵ₀ vs ℵ₁ chromatic behavior"
     },
     {
-      "slug": "continuum-hypothesis",
-      "title": "Independence of the Continuum Hypothesis",
-      "relation": "set-theory-context",
-      "description": "Set-theoretic backdrop: Shelah's consistency result for Problem #110 uses forcing and independence techniques analogous to those used to prove CH independence",
-      "relationship": "related"
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Set-theoretic backdrop: Shelah's consistency result for Problem #110 uses forcing and independence techniques analogous to those used to prove CH independence"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1101/meta.json
+++ b/src/data/proofs/erdos-1101/meta.json
@@ -138,27 +138,27 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-208",
+      "targetId": "erdos-208",
       "relationship": "related",
       "description": "Erdős Problem #208: Gaps Between Squarefree Numbers"
     },
     {
-      "slug": "erdos-124-complete-sequences",
+      "targetId": "erdos-124-complete-sequences",
       "relationship": "related",
       "description": "Erdős Problem #124: Complete Sequences"
     },
     {
-      "slug": "prime-reciprocal-divergence",
+      "targetId": "prime-reciprocal-divergence",
       "relationship": "related",
       "description": "Divergence of Prime Reciprocals"
     },
     {
-      "slug": "bounded-prime-gaps",
+      "targetId": "bounded-prime-gaps",
       "relationship": "related",
       "description": "Bounded Prime Gaps (Zhang/Maynard-Tao/Polymath 8b)"
     },
     {
-      "slug": "prime-gap-bounds",
+      "targetId": "prime-gap-bounds",
       "relationship": "related",
       "description": "Explicit Prime Gap Bounds from Bertrand's Postulate"
     }

--- a/src/data/proofs/erdos-111/meta.json
+++ b/src/data/proofs/erdos-111/meta.json
@@ -195,32 +195,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-74",
+      "targetId": "erdos-74",
       "relationship": "related",
       "description": "Erdős Problem #74: Almost Bipartite Graphs with High Chromatic Number"
     },
     {
-      "slug": "erdos-75",
+      "targetId": "erdos-75",
       "relationship": "related",
       "description": "Erdős Problem #75: Uncountable Chromatic Number and Large Independent Sets"
     },
     {
-      "slug": "erdos-57",
+      "targetId": "erdos-57",
       "relationship": "related",
       "description": "Erdős Problem #57: Odd Cycles in Graphs with Infinite Chromatic Number"
     },
     {
-      "slug": "erdos-594",
+      "targetId": "erdos-594",
       "relationship": "related",
       "description": "Erdős Problem #594: Graphs with Chromatic Number ≥ ℵ₁ and Odd Cycles"
     },
     {
-      "slug": "erdos-750",
+      "targetId": "erdos-750",
       "relationship": "related",
       "description": "Erdős Problem #750: Almost Bipartite Graphs with Infinite Chromatic Number"
     },
     {
-      "slug": "erdos-110",
+      "targetId": "erdos-110",
       "relationship": "related",
       "description": "Erdős Problem #110: Chromatic Number Growth in Uncountable Graphs"
     }

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -162,27 +162,27 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-246",
+      "targetId": "erdos-246",
       "relationship": "related",
       "description": "Erdős Problem #246: Completeness of {a^k b^l : k, l ≥ 0}"
     },
     {
-      "slug": "erdos-845",
+      "targetId": "erdos-845",
       "relationship": "related",
       "description": "Erdős Problem #845: Sums of 3-Smooth Numbers with Bounded Ratio"
     },
     {
-      "slug": "erdos-123",
+      "targetId": "erdos-123",
       "relationship": "related",
       "description": "Erdős #123: d-Complete Sequences"
     },
     {
-      "slug": "erdos-124",
+      "targetId": "erdos-124",
       "relationship": "related",
       "description": "Erdős Problem #124: Complete Sequences from Digit-Restricted Sums"
     },
     {
-      "slug": "erdos-1107",
+      "targetId": "erdos-1107",
       "relationship": "related",
       "description": "Erdős Problem #1107: Sums of r-Powerful Numbers"
     }

--- a/src/data/proofs/erdos-1115/meta.json
+++ b/src/data/proofs/erdos-1115/meta.json
@@ -128,32 +128,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1116",
+      "targetId": "erdos-1116",
       "relationship": "related",
       "description": "Erdős Problem #1116: Extreme Value Distribution of Entire Functions"
     },
     {
-      "slug": "erdos-1117",
+      "targetId": "erdos-1117",
       "relationship": "related",
       "description": "Erdős Problem #1117: Maximum Modulus Points on Circles"
     },
     {
-      "slug": "erdos-1118",
+      "targetId": "erdos-1118",
       "relationship": "related",
       "description": "Erdős Problem #1118: Entire Functions with Finite Measure Superlevel Sets"
     },
     {
-      "slug": "erdos-1120",
+      "targetId": "erdos-1120",
       "relationship": "related",
       "description": "Erdős Problem #1120: Shortest Path in Polynomial Sublevel Sets"
     },
     {
-      "slug": "erdos-1119",
+      "targetId": "erdos-1119",
       "relationship": "related",
       "description": "Erdős Problem #1119: Families of Entire Functions with Cardinal Constraints"
     },
     {
-      "slug": "liouville-theorem",
+      "targetId": "liouville-theorem",
       "relationship": "related",
       "description": "Liouville's Theorem on Transcendental Numbers"
     }

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -113,27 +113,27 @@
   },
   "crossReferences": [
     {
-      "slug": "ramseys-theorem",
+      "targetId": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey's Theorem"
     },
     {
-      "slug": "erdos-61",
+      "targetId": "erdos-61",
       "relationship": "related",
       "description": "Erdős Problem #61: The Erdős–Hajnal Conjecture"
     },
     {
-      "slug": "erdos-902",
+      "targetId": "erdos-902",
       "relationship": "related",
       "description": "Erdős #902: Tournament Domination"
     },
     {
-      "slug": "erdos-szekeres",
+      "targetId": "erdos-szekeres",
       "relationship": "related",
       "description": "Erdős–Szekeres Theorem"
     },
     {
-      "slug": "erdos-1029",
+      "targetId": "erdos-1029",
       "relationship": "related",
       "description": "Erdős Problem #1029: Ramsey Number Growth Rate"
     }

--- a/src/data/proofs/erdos-1128/meta.json
+++ b/src/data/proofs/erdos-1128/meta.json
@@ -149,39 +149,33 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1167",
+      "targetId": "erdos-1167",
       "relationship": "related",
-      "relevance": "core",
       "description": "Erdős Problem #1167: Stepping-Down Partition Relations"
     },
     {
-      "slug": "erdos-1169",
+      "targetId": "erdos-1169",
       "relationship": "related",
-      "relevance": "high",
       "description": "Erdős Problem #1169: Partition Relations for ω₁²"
     },
     {
-      "slug": "erdos-1172",
+      "targetId": "erdos-1172",
       "relationship": "related",
-      "relevance": "high",
       "description": "Erdős Problem #1172: Partition Relations under GCH and CH"
     },
     {
-      "slug": "erdos-597",
+      "targetId": "erdos-597",
       "relationship": "related",
-      "relevance": "high",
       "description": "Erdős Problem #597: Partition Relations for Ordinal Powers"
     },
     {
-      "slug": "erdos-70",
+      "targetId": "erdos-70",
       "relationship": "related",
-      "relevance": "medium",
       "description": "Erdős Problem #70: Partition Calculus for the Continuum"
     },
     {
-      "slug": "erdos-61",
+      "targetId": "erdos-61",
       "relationship": "related",
-      "relevance": "medium",
       "description": "Erdős Problem #61: The Erdős–Hajnal Conjecture"
     }
   ],

--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -154,32 +154,32 @@
   },
   "crossReferences": [
     {
-      "slug": "erdos-1129",
+      "targetId": "erdos-1129",
       "relationship": "related",
       "description": "Erdős Problem #1129: Optimal Lagrange Interpolation Nodes"
     },
     {
-      "slug": "erdos-1130",
+      "targetId": "erdos-1130",
       "relationship": "related",
       "description": "Erdős Problem #1130: Lagrange Basis Function Sums"
     },
     {
-      "slug": "erdos-1131",
+      "targetId": "erdos-1131",
       "relationship": "related",
       "description": "Minimizing Lagrange Interpolation Basis Polynomial Integrals"
     },
     {
-      "slug": "erdos-1133",
+      "targetId": "erdos-1133",
       "relationship": "related",
       "description": "Erdős Problem #1133: Large Polynomial Interpolation Bound"
     },
     {
-      "slug": "erdos-671",
+      "targetId": "erdos-671",
       "relationship": "related",
       "description": "Erdos Problem #671: Lagrange Interpolation Convergence"
     },
     {
-      "slug": "lebesgue-measure",
+      "targetId": "lebesgue-measure",
       "relationship": "related",
       "description": "Lebesgue Measure"
     }

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -142,22 +142,22 @@
   ],
   "crossReferences": [
     {
-      "target": "central-limit-theorem",
+      "targetId": "central-limit-theorem",
       "relationship": "foundational",
       "description": "The CLT governs the diffusive behaviour of random walks: the position after n steps scales as √n. The favourite site problem depends on the finer local time structure beyond CLT's scope."
     },
     {
-      "target": "erdos-1139",
+      "targetId": "erdos-1139",
       "relationship": "thematic",
       "description": "Both study 'infinitely often' phenomena in sequences with number-theoretic or probabilistic structure. Erdős #1139 asks about lim sup of gaps in almost-primes; #1165 asks about lim sup of favourite site counts."
     },
     {
-      "target": "prob-method-second-moment",
+      "targetId": "prob-method-second-moment",
       "relationship": "related",
       "description": "Second moment methods are central to random walk analysis: Tóth's proof uses second moment bounds on the local time to exclude four favourite sites, while Hao et al. use refined moment estimates to construct three-way ties."
     },
     {
-      "target": "bertrands-postulate",
+      "targetId": "bertrands-postulate",
       "relationship": "thematic",
       "description": "Both demonstrate that precise quantitative bounds (Bertrand: a prime in (n, 2n]; Tóth: at most 3 favourite sites) can require decades of effort to prove, even when the statement is simple."
     }

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -114,34 +114,34 @@
   },
   "crossReferences": [
     {
-      "slug": "euler-totient",
+      "targetId": "euler-totient",
       "relationship": "foundation",
-      "note": "Euler's totient function φ(n) is the central object of this problem; its properties (φ(p) = p−1 for primes, multiplicativity, distribution) drive the entire analysis."
+      "description": "Euler's totient function φ(n) is the central object of this problem; its properties (φ(p) = p−1 for primes, multiplicativity, distribution) drive the entire analysis."
     },
     {
-      "slug": "erdos-48",
+      "targetId": "erdos-48",
       "relationship": "sibling",
-      "note": "A neighboring Erdős problem concerning the interaction of φ(n) and σ(m); both problems probe the collision structure of multiplicative arithmetic functions."
+      "description": "A neighboring Erdős problem concerning the interaction of φ(n) and σ(m); both problems probe the collision structure of multiplicative arithmetic functions."
     },
     {
-      "slug": "erdos-1003",
+      "targetId": "erdos-1003",
       "relationship": "sibling",
-      "note": "Asks whether φ(n) = φ(n+1) infinitely often — directly about the collision structure of φ that limits the size of increasing-totient sets studied here."
+      "description": "Asks whether φ(n) = φ(n+1) infinitely often — directly about the collision structure of φ that limits the size of increasing-totient sets studied here."
     },
     {
-      "slug": "erdos-1004",
+      "targetId": "erdos-1004",
       "relationship": "sibling",
-      "note": "Asks about long runs of distinct consecutive totient values; the distribution of φ-values is the same analytic ingredient underlying Tao's proof of Problem #49."
+      "description": "Asks about long runs of distinct consecutive totient values; the distribution of φ-values is the same analytic ingredient underlying Tao's proof of Problem #49."
     },
     {
-      "slug": "infinitude-primes",
+      "targetId": "infinitude-primes",
       "relationship": "prerequisite",
-      "note": "The infinitude of primes guarantees that the lower bound π(N) → ∞, and the set of primes is the explicit witness achieving asymptotic optimality in this problem."
+      "description": "The infinitude of primes guarantees that the lower bound π(N) → ∞, and the set of primes is the explicit witness achieving asymptotic optimality in this problem."
     },
     {
-      "slug": "fundamental-arithmetic",
+      "targetId": "fundamental-arithmetic",
       "relationship": "prerequisite",
-      "note": "Unique factorization underlies the multiplicativity of φ and the anatomy-of-integers techniques (used by Ford and Tao) to control the distribution of totient values."
+      "description": "Unique factorization underlies the multiplicativity of φ and the anatomy-of-integers techniques (used by Ford and Tao) to control the distribution of totient values."
     }
   ],
   "references": [

--- a/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
@@ -104,22 +104,22 @@
   },
   "crossReferences": [
     {
-      "slug": "feuerbachs-theorem",
+      "targetId": "feuerbachs-theorem",
       "relationship": "extends",
       "description": "Parent file providing the Feuerbach incircle distance theorem (|NI| = R_9 - r), triangle geometry definitions, and inradius/nine-point-radius calculations"
     },
     {
-      "slug": "feuerbachs-theorem-oq-01",
+      "targetId": "feuerbachs-theorem-oq-01",
       "relationship": "related",
       "description": "Sibling open question on Feuerbach's theorem, developing another aspect of the theory"
     },
     {
-      "slug": "feuerbachs-theorem-oq-02",
+      "targetId": "feuerbachs-theorem-oq-02",
       "relationship": "related",
       "description": "Sibling open question on Feuerbach's theorem"
     },
     {
-      "slug": "ptolemys-theorem",
+      "targetId": "ptolemys-theorem",
       "relationship": "related",
       "description": "Ptolemy's theorem is proved via inversive geometry — inversion maps circles to lines in both theorems; the technique is the same"
     }

--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -151,14 +151,12 @@
   },
   "crossReferences": [
     {
-      "slug": "frobenius-number",
-      "title": "Frobenius Number (Two Generators, Sylvester)",
+      "targetId": "frobenius-number",
       "relationship": "parent",
       "description": "The 2-generator parent: Sylvester's 1884 closed form $g(a, b) = ab - a - b$ for coprime $a, b$. The S3b bridge `large_representable3_via_two_gen` imports `FrobeniusNumber.large_representable` directly — the 3-generator Sylvester upper bound is a one-line corollary of the 2-generator theorem (setting $z = 0$). Without the parent's `large_representable`, the entire S3c/S4 stack here would be inaccessible."
     },
     {
-      "slug": "frobenius-number-oq-01",
-      "title": "Frobenius Number: Count of Non-Representable Integers = (a-1)(b-1)/2",
+      "targetId": "frobenius-number-oq-01",
       "relationship": "sibling",
       "description": "The 2-generator count theorem: exactly $(a-1)(b-1)/2$ positive integers are non-representable for coprime $a, b \\ge 2$. The 3-generator analogue (a closed-form count theorem) is **open** — there is no Roberts-type closed form for the count, only for the maximum (the Frobenius number itself, on specific families)."
     },

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -166,17 +166,17 @@
   },
   "crossReferences": [
     {
-      "id": "greens-theorem-oq-01-oq-01-oq-01",
+      "targetId": "greens-theorem-oq-01-oq-01-oq-01",
       "relationship": "parent",
       "description": "Parent file that originally axiomatized iteratedIntervalIntegral_order_independent. This entry derives that statement, leaving the parent's axiom mathematically redundant."
     },
     {
-      "id": "greens-theorem",
+      "targetId": "greens-theorem",
       "relationship": "ancestor",
       "description": "Root Green's theorem entry. The order-independence eliminated here is one of several Fubini-chain axioms feeding into the n-dimensional Green's theorem statement."
     },
     {
-      "id": "fundamental-theorem-calculus",
+      "targetId": "fundamental-theorem-calculus",
       "relationship": "related",
       "description": "Underlies the interval-integral interpretation used here: each ∫_a^b reduces to FTC + Riemann/Lebesgue agreement, and Fubini composes those one-variable statements."
     }

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -155,16 +155,12 @@
   },
   "crossReferences": [
     {
-      "type": "parent",
-      "slug": "greens-theorem-oq-01-oq-01-oq-02",
-      "title": "Standalone Interval Integral Swap (real-valued)",
-      "relation": "Direct parent. Establishes the three real-valued `intervalIntegral_swap` theorems. This OQ-03 sibling generalizes them to Banach codomain E by verbatim port (this file)."
+      "targetId": "greens-theorem-oq-01-oq-01-oq-02",
+      "relationship": "Direct parent. Establishes the three real-valued `intervalIntegral_swap` theorems. This OQ-03 sibling generalizes them to Banach codomain E by verbatim port (this file)."
     },
     {
-      "type": "ancestor",
-      "slug": "greens-theorem",
-      "title": "Green's Theorem (line integrals around closed curves)",
-      "relation": "Ancestor. Green's theorem ultimately requires Fubini for line-integral splitting; the Bochner-valued generalization (this file) is a building block for Banach-valued differential-form analogues of Green's theorem."
+      "targetId": "greens-theorem",
+      "relationship": "Ancestor. Green's theorem ultimately requires Fubini for line-integral splitting; the Bochner-valued generalization (this file) is a building block for Banach-valued differential-form analogues of Green's theorem."
     }
   ]
 }

--- a/src/data/proofs/hilbert-10-oq-04/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04/meta.json
@@ -122,22 +122,22 @@
   ],
   "crossReferences": [
     {
-      "id": "hilbert-10",
+      "targetId": "hilbert-10",
       "relationship": "parent",
       "description": "Proves H10 undecidability via halting problem reduction (MRDP axiom). This file asks about the minimal complexity."
     },
     {
-      "id": "hilbert-10-oq-01",
+      "targetId": "hilbert-10-oq-01",
       "relationship": "sibling",
       "description": "Addresses H10 over the rationals (open problem). Related question about decidability thresholds."
     },
     {
-      "id": "halting-problem",
+      "targetId": "halting-problem",
       "relationship": "ancestor",
       "description": "Halting problem — undecidable r.e. set whose Diophantine encoding (via MRDP/Jones) yields the 9-variable undecidability axiom used here."
     },
     {
-      "id": "hilbert-10-oq-01-oq-02",
+      "targetId": "hilbert-10-oq-01-oq-02",
       "relationship": "related",
       "description": "Σ₁ vs Π₂ definability for ℤ over ℚ. Different angle on H10 thresholds: where this entry asks 'how few variables for undecidability', that entry asks 'what definability class characterizes ℤ in ℚ' — both probe the boundary between effective and non-effective Diophantine descriptions."
     }

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -150,17 +150,17 @@
   },
   "crossReferences": [
     {
-      "id": "hilbert-15-oq-02",
+      "targetId": "hilbert-15-oq-02",
       "relationship": "parent",
       "description": "LR coefficient computation for 2-row partitions; saturation theorem documented"
     },
     {
-      "id": "hilbert-15",
+      "targetId": "hilbert-15",
       "relationship": "grandparent",
       "description": "Schubert calculus and intersection theory (Hilbert's 15th problem)"
     },
     {
-      "id": "hilbert-15-oq-01",
+      "targetId": "hilbert-15-oq-01",
       "relationship": "sibling",
       "description": "Explicit Gr(2,4) Chow ring whose structure constants are the 2-row LR coefficients"
     }

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
@@ -109,17 +109,17 @@
   },
   "crossReferences": [
     {
-      "id": "lagrange-theorem-oq-01-oq-01",
+      "targetId": "lagrange-theorem-oq-01-oq-01",
       "relationship": "extends",
       "description": "Parent pq-classification (Burnside 1911, via Sylow). The parent's lagrange_pq_nonabelian_n_p_eq_q is a conditional fact assuming `¬ IsCyclic G`; this file supplies an explicit such G for the p = 2 case, completing the non-cyclic side."
     },
     {
-      "id": "lagrange-theorem-oq-01",
+      "targetId": "lagrange-theorem-oq-01",
       "relationship": "related",
       "description": "Lagrange's theorem (parent of the OQ chain). The pq-classification answers OQ-01 about Sylow as a partial converse to Lagrange; this file refines OQ-01-OQ-01's classification by exhibiting witnesses."
     },
     {
-      "id": "sylow-theorem-oq-01",
+      "targetId": "sylow-theorem-oq-01",
       "relationship": "uses",
       "description": "Underlies the parent classification via the SylowPQ namespace. This file does not directly use SylowPQ but builds on the existence framework it establishes."
     }

--- a/src/data/proofs/lagrange-theorem-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01/meta.json
@@ -104,17 +104,17 @@
   },
   "crossReferences": [
     {
-      "slug": "lagrange-theorem",
+      "targetId": "lagrange-theorem",
       "relationship": "extends",
       "description": "Parent file proving Lagrange's theorem on subgroup order dividing group order; this entry proves the Sylow partial converse"
     },
     {
-      "slug": "burnside-counting",
+      "targetId": "burnside-counting",
       "relationship": "related",
       "description": "Burnside's lemma (orbit-counting) is used in the proof of the Third Sylow Theorem: the action of a Sylow p-subgroup on the set of Sylow p-subgroups by conjugation has exactly one fixed point, giving n_p ≡ 1 mod p"
     },
     {
-      "slug": "cauchy-schwarz",
+      "targetId": "cauchy-schwarz",
       "relationship": "related",
       "description": "Both Cauchy's theorem (in group theory) and Cauchy-Schwarz (in analysis) are named for Augustin-Louis Cauchy; the group theory Cauchy theorem here follows from Sylow existence"
     }

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01/meta.json
@@ -149,23 +149,19 @@
   },
   "crossReferences": [
     {
-      "id": "spherical-law-of-cosines",
-      "title": "Spherical Law of Cosines",
+      "targetId": "spherical-law-of-cosines",
       "relationship": "Direct predecessor: proves cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C). This entry proves the dual law by importing SphericalLawOfCosines and using its inner product decomposition lemma."
     },
     {
-      "id": "law-of-cosines-oq-01",
-      "title": "Spherical Law of Cosines (Open Question)",
+      "targetId": "law-of-cosines-oq-01",
       "relationship": "Parent open question about spherical trigonometry; this entry answers the specific question about the dual law."
     },
     {
-      "id": "spherical-law-of-sines",
-      "title": "Spherical Law of Sines",
+      "targetId": "spherical-law-of-sines",
       "relationship": "Sibling result: sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c). Both the dual cosine law and the sine rule follow from the same Gram determinant framework."
     },
     {
-      "id": "law-of-cosines",
-      "title": "Law of Cosines",
+      "targetId": "law-of-cosines",
       "relationship": "Planar analogue: c² = a² + b² − 2ab·cos(C). The spherical law of cosines reduces to this as the sphere radius → ∞ (small-angle limit)."
     }
   ],

--- a/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-02/meta.json
@@ -153,13 +153,11 @@
   },
   "crossReferences": [
     {
-      "id": "law-of-cosines-oq-03",
-      "title": "Hyperbolic Law of Cosines",
+      "targetId": "law-of-cosines-oq-03",
       "relationship": "parent"
     },
     {
-      "id": "law-of-cosines",
-      "title": "Euclidean Law of Cosines",
+      "targetId": "law-of-cosines",
       "relationship": "related"
     }
   ],

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02/meta.json
@@ -158,17 +158,17 @@
   },
   "crossReferences": [
     {
-      "id": "laws-of-large-numbers-oq-01",
+      "targetId": "laws-of-large-numbers-oq-01",
       "relationship": "parent",
       "description": "Proves SLLN for integrable heavy-tailed distributions via Kolmogorov's theorem. This entry quantifies the convergence rate via Marcinkiewicz-Zygmund."
     },
     {
-      "id": "laws-of-large-numbers",
+      "targetId": "laws-of-large-numbers",
       "relationship": "ancestor",
       "description": "Foundation: establishes WLLN and SLLN for finite-variance distributions. The M-Z theorem extends SLLN to the infinite-variance regime with quantitative rates n^{1/r}."
     },
     {
-      "id": "central-limit-theorem",
+      "targetId": "central-limit-theorem",
       "relationship": "related",
       "description": "Complement: the CLT gives rate n^{1/2} and Gaussian limit for L² distributions. M-Z applies when L² fails, giving slower rate n^{1/r} with α-stable (non-Gaussian) limit."
     }

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -200,18 +200,18 @@
   },
   "crossReferences": [
     {
-      "id": "laws-of-large-numbers-oq-04",
-      "relation": "parent",
+      "targetId": "laws-of-large-numbers-oq-04",
+      "relationship": "parent",
       "description": "Glivenko-Cantelli theorem (parent formalization with 3 axioms)"
     },
     {
-      "id": "laws-of-large-numbers-oq-01-oq-01",
-      "relation": "sibling",
+      "targetId": "laws-of-large-numbers-oq-01-oq-01",
+      "relationship": "sibling",
       "description": "SLLN necessity — another integration-based result in the LLN family"
     },
     {
-      "id": "laws-of-large-numbers",
-      "relation": "ancestor",
+      "targetId": "laws-of-large-numbers",
+      "relationship": "ancestor",
       "description": "Laws of large numbers (root entry)"
     }
   ]

--- a/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-01/meta.json
@@ -103,7 +103,7 @@
   },
   "crossReferences": [
     {
-      "slug": "product-of-segments-of-chords",
+      "targetId": "product-of-segments-of-chords",
       "relationship": "extends",
       "description": "Parent file proving the 2D intersecting chords theorem (Wiedijk #55)"
     }

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -128,17 +128,17 @@
   },
   "crossReferences": [
     {
-      "slug": "ptolemys-theorem-oq-01",
+      "targetId": "ptolemys-theorem-oq-01",
       "relationship": "extends",
       "description": "Provides the forward direction (CCW → Ptolemy equality) and defines IsCCWOrder; this file proves the converse"
     },
     {
-      "slug": "ptolemys-complex-proof",
+      "targetId": "ptolemys-complex-proof",
       "relationship": "uses",
       "description": "Source of ptolemy_equality_of_proportional, used in the backward direction of the biconditional"
     },
     {
-      "slug": "ptolemys-complex-proof-oq-01",
+      "targetId": "ptolemys-complex-proof-oq-01",
       "relationship": "uses",
       "description": "Source of ptolemy_equality_implies_proportional, the first step of the converse proof"
     }

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -147,17 +147,17 @@
   },
   "crossReferences": [
     {
-      "target": "shannon-channel-coding",
+      "targetId": "shannon-channel-coding",
       "relationship": "extends",
       "description": "Provides a proved version of channel_coding_converse for the asymptotic regime"
     },
     {
-      "target": "shannon-channel-coding-oq-03",
+      "targetId": "shannon-channel-coding-oq-03",
       "relationship": "uses",
       "description": "Fano's inequality (proved in OQ03) underlies the fano_mi_converse_bound axiom"
     },
     {
-      "target": "shannon-channel-coding-oq-02",
+      "targetId": "shannon-channel-coding-oq-02",
       "relationship": "related",
       "description": "BSC capacity proof and achievability lemma — the other half of the channel coding theorem"
     }

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -165,12 +165,12 @@
   },
   "crossReferences": [
     {
-      "target": "shannon-channel-coding",
+      "targetId": "shannon-channel-coding",
       "relationship": "extends",
       "description": "Proves the bsc_capacity_eq axiom from the parent formalization"
     },
     {
-      "target": "shannon-channel-coding-oq-04",
+      "targetId": "shannon-channel-coding-oq-04",
       "relationship": "uses",
       "description": "Uses binary entropy function h(p) and its properties"
     }

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -84,12 +84,12 @@
   },
   "crossReferences": [
     {
-      "id": "sperner-ndim",
+      "targetId": "sperner-ndim",
       "relationship": "generalizes",
       "description": "The n-dimensional Sperner lemma via Freudenthal triangulation"
     },
     {
-      "id": "sperner-simplicial-instance",
+      "targetId": "sperner-simplicial-instance",
       "relationship": "specializes",
       "description": "Sperner's lemma instantiated for triangulation data structures"
     }

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -95,18 +95,15 @@
   },
   "crossReferences": [
     {
-      "id": "sperner-mathlib",
-      "title": "Sperner's Lemma (Alternative)",
+      "targetId": "sperner-mathlib",
       "relationship": "Alternative door-counting proof with more explicit combinatorial lemmas."
     },
     {
-      "id": "sperner-simplicial-instance",
-      "title": "Simplicial Instantiation",
+      "targetId": "sperner-simplicial-instance",
       "relationship": "Concrete triangulation instantiation of the CellComplex axioms."
     },
     {
-      "id": "sperner-ndim",
-      "title": "n-Dimensional Sperner",
+      "targetId": "sperner-ndim",
       "relationship": "n-dimensional version via Freudenthal triangulation."
     }
   ],

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -117,34 +117,28 @@
   ],
   "crossReferences": [
     {
-      "type": "generalisation-of",
-      "slug": "sperner-simplicial-bridge",
-      "rationale": "OQ-01 strictly generalises the pure pseudomanifold case to mixed-dimension complexes. `MixedPseudomanifold.of_pure` proves the embedding of pure data into the mixed framework."
+      "targetId": "sperner-simplicial-bridge",
+      "description": "OQ-01 strictly generalises the pure pseudomanifold case to mixed-dimension complexes. `MixedPseudomanifold.of_pure` proves the embedding of pure data into the mixed framework."
     },
     {
-      "type": "uses",
-      "slug": "sperner-simplicial-bridge",
-      "rationale": "The per-stratum proof is a single application of the parent's `exists_panchromatic` on the chosen stratum after packaging per-stratum `hcard`, `hpseudo`, and `hbdry`."
+      "targetId": "sperner-simplicial-bridge",
+      "description": "The per-stratum proof is a single application of the parent's `exists_panchromatic` on the chosen stratum after packaging per-stratum `hcard`, `hpseudo`, and `hbdry`."
     },
     {
-      "type": "sibling-of",
-      "slug": "sperner-simplicial-instance",
-      "rationale": "Both slugs build on `sperner-simplicial-bridge`. `sperner-simplicial-instance` provides concrete Kuhn-style triangulation instances of the parent; this slug extends the parent's framework to non-pure (mixed-dimension) complexes."
+      "targetId": "sperner-simplicial-instance",
+      "description": "Both slugs build on `sperner-simplicial-bridge`. `sperner-simplicial-instance` provides concrete Kuhn-style triangulation instances of the parent; this slug extends the parent's framework to non-pure (mixed-dimension) complexes."
     },
     {
-      "type": "depends-on",
-      "slug": "sperner-mathlib",
-      "rationale": "The parent's `exists_panchromatic` (which this slug's headline theorem applies stratum-by-stratum) is built on the abstract door-counting parity machinery established in `sperner-mathlib`. Transitively, the mixed-dimension result inherits its combinatorial backbone from the `Sperner.IsDoor` / `Sperner.IsPanchromatic` predicates introduced there."
+      "targetId": "sperner-mathlib",
+      "description": "The parent's `exists_panchromatic` (which this slug's headline theorem applies stratum-by-stratum) is built on the abstract door-counting parity machinery established in `sperner-mathlib`. Transitively, the mixed-dimension result inherits its combinatorial backbone from the `Sperner.IsDoor` / `Sperner.IsPanchromatic` predicates introduced there."
     },
     {
-      "type": "related-to",
-      "slug": "sperner-ndim-mathlib",
-      "rationale": "`sperner-ndim-mathlib` proves Sperner's lemma on the standard `n`-simplex in Mathlib's `CellComplex` setting. The mixed-pseudomanifold framework here is the abstract-`Finset (Finset E)`-of-cells counterpart, with the dimensional stratification playing the role of `CellComplex.facesOfDim`. The two lines of work converge in OQ-02 (`Mathlib.Geometry.SimplicialComplex.facets` bridge)."
+      "targetId": "sperner-ndim-mathlib",
+      "description": "`sperner-ndim-mathlib` proves Sperner's lemma on the standard `n`-simplex in Mathlib's `CellComplex` setting. The mixed-pseudomanifold framework here is the abstract-`Finset (Finset E)`-of-cells counterpart, with the dimensional stratification playing the role of `CellComplex.facesOfDim`. The two lines of work converge in OQ-02 (`Mathlib.Geometry.SimplicialComplex.facets` bridge)."
     },
     {
-      "type": "related-to",
-      "slug": "sperner-ndim-mathlib-oq-01",
-      "rationale": "`sperner-ndim-mathlib-oq-01` lifts Sperner to the Freudenthal `CellComplex` framework — a parallel exercise in extending Sperner beyond its pure-simplicial origins. Both slugs address Open Question 1 of their respective parents; the mixed-dimension generalisation here is to abstract simplicial complexes what the Freudenthal lift is to cell complexes."
+      "targetId": "sperner-ndim-mathlib-oq-01",
+      "description": "`sperner-ndim-mathlib-oq-01` lifts Sperner to the Freudenthal `CellComplex` framework — a parallel exercise in extending Sperner beyond its pure-simplicial origins. Both slugs address Open Question 1 of their respective parents; the mixed-dimension generalisation here is to abstract simplicial complexes what the Freudenthal lift is to cell complexes."
     }
   ],
   "overview": {

--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -102,11 +102,9 @@
   },
   "crossReferences": [
     {
-      "slug": "sqrt2-examples",
-      "title": "Basic Lean Examples",
-      "relation": "parent-problem",
-      "description": "Parent file with the original ℤ-specific proof",
-      "relationship": "extends"
+      "targetId": "sqrt2-examples",
+      "relationship": "extends",
+      "description": "Parent file with the original ℤ-specific proof"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/sylow-theorem/meta.json
+++ b/src/data/proofs/sylow-theorem/meta.json
@@ -128,7 +128,7 @@
       "description": "Applies Sylow's theorems to prove simplicity of A5 and the Abel-Ruffini theorem."
     },
     {
-      "slug": "lagrange-theorem-oq-01",
+      "targetId": "lagrange-theorem-oq-01",
       "relationship": "related",
       "description": "Companion proof presenting the Sylow theorems as partial converse to Lagrange's theorem, with explicit carryCount and exponent formulas."
     }


### PR DESCRIPTION
## Summary

A gallery-wide audit turned up **263 `crossReferences` written with the wrong keys** — `id`, `slug`, `target`, `relation`, plus stray `title`/`type`/`note`/`rationale`/`relevance` — instead of the `CrossReference` schema's `targetId`/`proofId` + `relationship` + `description`. The loader keys on `proofId`/`targetId`, so each of these rendered as a **dead link**, silently, even though the intended target exists in the gallery.

This PR fixes the **60 entries** whose `meta.json` is already in canonical JSON format. A round-trip-stability guard (reserialize the untouched object and require byte-identical output) guarantees the change touches only the `crossReferences` array — no formatting or content drift anywhere else.

### Normalization
- `targetId` ← `id` / `slug` / `target` — **all 209 verified to resolve to a real proof directory**
- `relationship` ← `relationship` / `relation`
- `description` ← `description` / `note` / `rationale`
- dropped non-schema keys: `title`, `type`, `relevance`

### Verification
- diff is confined entirely to crossReference keys (209 target-id keys removed → 209 `targetId` added)
- every one of the 60 files is valid JSON
- 0 malformed cross-references remain in the touched files

### Deferred
20 further entries have the same bug but use non-canonical JSON formatting; normalizing them safely needs a surgical (non-reserializing) edit, so they're left to a follow-up to keep this diff purely mechanical and review-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)