### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): S5 ACT — full Strategy D proof of Irrational(√2+√3+√5+√7)

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
@@ -1,0 +1,103 @@
+/-
+# Irrationality of √2 + √3 + √5 + √7 (OQ-01 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`)
+
+## Strategy D — algebraic integer + bounded interval
+
+Let α := √2 + √3 + √5 + √7. We avoid the entire degree-16 minimal-polynomial /
+iterated-squaring machinery (Strategy A) and argue purely from integral-closure:
+
+1. **α is an algebraic integer.** Each √k is a root of the monic integer polynomial
+   `X² − C k`, hence `IsIntegral ℤ (√k)`. Algebraic integers are closed under addition
+   (`IsIntegral.add`), so `IsIntegral ℤ α`.
+
+2. **A rational that is an algebraic integer is an integer.** Assume `α = (q : ℝ)` for some
+   `q : ℚ`. Integrality descends along the injective ring map `algebraMap ℚ ℝ`
+   (`isIntegral_algebraMap_iff`), giving `IsIntegral ℤ q`. Since `ℤ` is integrally closed in
+   its fraction field `ℚ` (`IsIntegrallyClosed.isIntegral_iff`), there is `n : ℤ` with
+   `(n : ℚ) = q`, i.e. `α = (n : ℝ)`.
+
+3. **But `8 < α < 9`.** Rational bounds on each radical (`1.41 < √2 < 1.42`, etc.) give
+   `8.01 ≤ α` and `α ≤ 8.05`, so `8 < α < 9`. No integer lies strictly between `8` and `9`,
+   contradicting `α = (n : ℝ)`. Hence α is irrational. ∎
+
+This is far shorter than the elementary 3-squaring chain (Strategy A) and introduces no new
+Mathlib theory — only the standard integral-closure API.
+-/
+
+import Mathlib
+
+open Real
+
+namespace Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
+
+/-- A real number `c` whose square is an integer `m` is an algebraic integer:
+`c` is a root of the monic integer polynomial `X² − C m`. -/
+theorem isIntegral_of_sq (c : ℝ) (m : ℤ) (hc : c ^ 2 = (m : ℝ)) : IsIntegral ℤ c := by
+  refine ⟨Polynomial.X ^ 2 - Polynomial.C m, Polynomial.monic_X_pow_sub_C m (by norm_num), ?_⟩
+  have : (Polynomial.aeval c) (Polynomial.X ^ 2 - Polynomial.C m) = 0 := by
+    rw [map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_C, hc]
+    simp
+  simpa [Polynomial.aeval_def] using this
+
+/-- Each summand is an algebraic integer over `ℤ`. -/
+theorem isIntegral_sqrt_two : IsIntegral ℤ (sqrt 2) :=
+  isIntegral_of_sq _ 2 (by rw [Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]; norm_num)
+
+theorem isIntegral_sqrt_three : IsIntegral ℤ (sqrt 3) :=
+  isIntegral_of_sq _ 3 (by rw [Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 3)]; norm_num)
+
+theorem isIntegral_sqrt_five : IsIntegral ℤ (sqrt 5) :=
+  isIntegral_of_sq _ 5 (by rw [Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 5)]; norm_num)
+
+theorem isIntegral_sqrt_seven : IsIntegral ℤ (sqrt 7) :=
+  isIntegral_of_sq _ 7 (by rw [Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 7)]; norm_num)
+
+/-- `α = √2 + √3 + √5 + √7` is an algebraic integer (closed under `+`). -/
+theorem isIntegral_alpha : IsIntegral ℤ (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7) :=
+  ((isIntegral_sqrt_two.add isIntegral_sqrt_three).add isIntegral_sqrt_five).add
+    isIntegral_sqrt_seven
+
+/-- Lower bound: `8 < √2 + √3 + √5 + √7` (via `1.41 + 1.73 + 2.23 + 2.64 = 8.01`). -/
+theorem alpha_lower : (8 : ℝ) < sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7 := by
+  have b2 : (1.41 : ℝ) < sqrt 2 := (Real.lt_sqrt (by norm_num)).mpr (by norm_num)
+  have b3 : (1.73 : ℝ) < sqrt 3 := (Real.lt_sqrt (by norm_num)).mpr (by norm_num)
+  have b5 : (2.23 : ℝ) < sqrt 5 := (Real.lt_sqrt (by norm_num)).mpr (by norm_num)
+  have b7 : (2.64 : ℝ) < sqrt 7 := (Real.lt_sqrt (by norm_num)).mpr (by norm_num)
+  linarith
+
+/-- Upper bound: `√2 + √3 + √5 + √7 < 9` (via `1.42 + 1.74 + 2.24 + 2.65 = 8.05`). -/
+theorem alpha_upper : sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7 < (9 : ℝ) := by
+  have b2 : sqrt 2 < (1.42 : ℝ) := (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+  have b3 : sqrt 3 < (1.74 : ℝ) := (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+  have b5 : sqrt 5 < (2.24 : ℝ) := (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+  have b7 : sqrt 7 < (2.65 : ℝ) := (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+  linarith
+
+/-- **Main theorem**: `√2 + √3 + √5 + √7` is irrational.
+
+Proved via Strategy D: α is an algebraic integer trapped strictly between `8` and `9`, so it
+cannot equal any integer; a rational algebraic integer must be an integer, contradiction. -/
+theorem irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 :
+    Irrational (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7) := by
+  rintro ⟨q, hq⟩
+  -- hq : (q : ℝ) = √2 + √3 + √5 + √7
+  -- Step 1: α is integral over ℤ, hence so is (q : ℝ) = algebraMap ℚ ℝ q.
+  have hqℝ : IsIntegral ℤ (algebraMap ℚ ℝ q) := by
+    rw [eq_ratCast (algebraMap ℚ ℝ) q, hq]; exact isIntegral_alpha
+  -- Step 2: descend integrality along the injective ℚ ↪ ℝ, then use ℤ integrally closed.
+  have hqℤ : IsIntegral ℤ q :=
+    (isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective).mp hqℝ
+  obtain ⟨n, hn⟩ := (IsIntegrallyClosed.isIntegral_iff).mp hqℤ
+  rw [show algebraMap ℤ ℚ n = (n : ℚ) by simp] at hn
+  -- hn : (n : ℚ) = q  ⇒  α = (n : ℝ)
+  have hαn : sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7 = (n : ℝ) := by
+    rw [← hq, ← hn]; push_cast; ring
+  -- Step 3: 8 < α < 9 forces an integer strictly between 8 and 9 — impossible.
+  have hlo := alpha_lower
+  have hhi := alpha_upper
+  rw [hαn] at hlo hhi
+  have h8 : (8 : ℤ) < n := by exact_mod_cast hlo
+  have h9 : n < (9 : ℤ) := by exact_mod_cast hhi
+  omega
+
+end Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -275,3 +275,51 @@ routine but are exactly why a real build (not an uncompilable `.lean`) is deferr
 
 ### Files modified
 - `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+
+---
+
+## Session 2026-06-15 (Session 5) — ACT: transcribe Strategy D (researcher-10)
+
+**Mode**: REVISIT/CONTINUE · **Outcome**: progress (ORIENT → ACT). Docker still down
+(`docker ps`/`docker info` timeout); Aristotle not used (only fills sorries — file is
+sorry-free by construction). Build-pending, no local Lean.
+
+### What I did
+- **Wrote the complete Strategy D proof** to
+  `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~95 LOC, 0 sorries,
+  0 axioms by construction). Structure:
+  - `isIntegral_of_sq (c m) (hc : c^2 = m) : IsIntegral ℤ c` — root of monic `X² − C m`
+    (`Polynomial.monic_X_pow_sub_C` + `aeval`/`aeval_def`).
+  - `isIntegral_sqrt_{two,three,five,seven}` — instantiate with `Real.sq_sqrt`.
+  - `isIntegral_alpha` — `IsIntegral.add` ×3.
+  - `alpha_lower : 8 < α` via `Real.lt_sqrt` on `1.41,1.73,2.23,2.64` (+ `linarith`).
+  - `alpha_upper : α < 9` via `Real.sqrt_lt'` on `1.42,1.74,2.24,2.65`.
+  - main `irrational_…` : `rintro ⟨q,hq⟩`; `eq_ratCast` bridges `(q:ℝ)=algebraMap ℚ ℝ q`;
+    descend with `isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective`; integrally-closed
+    `IsIntegrallyClosed.isIntegral_iff` gives `n:ℤ` with `(n:ℚ)=q`; `8<(n:ℝ)<9` then
+    `exact_mod_cast` + `omega` ⇒ contradiction.
+- **Re-verified all math** with the durable `verify_strategy_d.py` → `ALL CHECKS PASSED`
+  (F1 integrality, F3 minimal polynomial via resultant, F2 bound `8<α<9` + all 8 rational
+  square-witnesses). Independently re-checked my four decimal lower/upper witnesses in Python.
+
+### Why this is forward progress (not re-ORIENT churn)
+Sessions 1–4 left the problem "paste-port-ready" but produced **zero Lean**. This session
+converts the bearer-confirmed skeleton into an actual, fully-written proof file. The only
+remaining work is the Docker build verification + (if it passes) registration in
+`proofs/Proofs.lean` and a gallery `meta.json`. Strategy D needed no new Mathlib.
+
+### Honesty caveat
+**Not machine-checked** — Docker down, so the file is build-pending and deliberately
+**UNREGISTERED** in `proofs/Proofs.lean` (so it cannot break the aggregate auto-merge build).
+Residual transcription risks are lemma-name/instance-resolution only (see `nextSteps`), not
+mathematical — the mathematics is verified. Status stays NOT `verified` until a real build.
+
+### Files modified
+- `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (new)
+- `src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json`
+- `research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/{knowledge.md, state.md}`
+
+### Next steps
+1. Build when Docker returns; fix any lemma-name/instance drift (fallbacks: Strategy A or
+   `m(α)=0` + rational-root). 2. Register + gallery `meta.json`. 3. Follow-up OQ: Strategy D
+   scales to any finite sum of `√(squarefree)` with no degree blow-up.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/state.md
@@ -1,13 +1,20 @@
 # Research State: sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01
 
 ## Current State
-**Phase**: ORIENT (ACT-ready)
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-14
-**Iteration**: 5
+**Since**: 2026-06-15T02:09:02-07:00
+**Iteration**: 6
 
 ## Current Focus
-Strategy D is now **paste-port-ready** (Session 4, researcher-5). Every step of the
+**Session 5 (researcher-10, 2026-06-15): Strategy D fully transcribed** to
+`proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~95 LOC, 0 sorries/0
+axioms by construction). Build-pending (Docker down) and UNREGISTERED in `proofs/Proofs.lean`.
+All math re-verified by `verify_strategy_d.py` (ALL CHECKS PASSED). Only remaining work: the
+Docker build (fix any lemma-name/instance drift) + registration + gallery `meta.json`.
+
+### Prior focus (Session 4, researcher-5)
+Strategy D was **paste-port-ready** (Session 4, researcher-5). Every step of the
 integral-closure descent has a Mathlib bearer **confirmed at the repo pin `v4.26.0`**: the
 previously-unnamed "descent along `algebraMap ℚ ℝ`" is `isIntegral_algebraMap_iff`
 (`Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean:179`) and the ℤ-step is

--- a/research/registry.json
+++ b/research/registry.json
@@ -21821,11 +21821,11 @@
     },
     {
       "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
-      "phase": "ORIENT",
+      "phase": "ACT",
       "path": "fast",
       "started": "2026-06-15T02:22:23.646Z",
       "status": "active",
-      "lastUpdate": "2026-06-14T19:39:07-07:00"
+      "lastUpdate": "2026-06-15T02:09:02-07:00"
     },
     {
       "slug": "sum-of-kth-powers-oq-03",

--- a/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
+++ b/src/data/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01.json
@@ -22,7 +22,10 @@
     "since": "2026-06-15T01:25:28.245Z",
     "iteration": 3,
     "focus": "Survey deepened (Session 2): NEW recommended Strategy D (algebraic-integer + bound, ~60-100 LOC) supersedes A; explicit degree-16 minimal polynomial and bound 8<α<9 computed and verified (sympy/mpmath). Still Docker-gated for final build.",
-    "blockers": ["Docker build wrapper unavailable (docker info timeout).", "Aristotle backend returns 'Resource not found'."],
+    "blockers": [
+      "Docker build wrapper unavailable (docker info timeout).",
+      "Aristotle backend returns 'Resource not found'."
+    ],
     "nextAction": "When Docker returns, implement Strategy D in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (~60-100 LOC); confirm the 4 lemma names in the knowledge.md skeleton and fill the single sorry. Fallbacks: Strategy A (3-squaring chain) or m(α)=0 + rational-root theorem.",
     "attemptCounts": {
       "total": 0,
@@ -31,8 +34,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT deepened (build-free, researcher-4 2026-06-14 Session 2): found NEW recommended Strategy D (algebraic-integer + bounded-interval, ~60-100 LOC) that avoids ALL degree-16 algebra and supersedes Strategy A; computed and verified (sympy/mpmath) the explicit degree-16 monic minimal polynomial m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 and the decisive bound 8<α<9 (α≈8.0281). Also confirmed Strategy A's single-surd endgame has ugly coefficients (common denom 14499840 for √210 in the α power basis). Prior (researcher-10): resolved on paper degree-16, fixed leanFiles misattribution. Still Docker-gated for final Lean build.",
-    "builtItems": [],
+    "progressSummary": "ACT (researcher-10 2026-06-15 S5): Strategy D proof fully written to Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (0 sorries/0 axioms by construction, ~95 LOC). Build-pending (Docker down) + UNREGISTERED in Proofs.lean. Math re-verified. Remaining work: Docker build + gallery registration.",
+    "builtItems": [
+      "Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean - full Strategy D transcription (build-pending, Docker down): isIntegral_of_sq (c^2 in Z => IsIntegral Z c via monic X^2 - C m), 4 per-radical instances, isIntegral_alpha (IsIntegral.add x3), alpha_lower (8<a via Real.lt_sqrt + 1.41/1.73/2.23/2.64), alpha_upper (a<9 via Real.sqrt_lt'), main thm irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 (descent isIntegral_algebraMap_iff + IsIntegrallyClosed.isIntegral_iff + omega). 0 sorries, 0 axioms by construction; UNREGISTERED in Proofs.lean under build blackout."
+    ],
     "insights": [
       "RESOLVED ON PAPER: √2+√3+√5+√7 is irrational — in fact an algebraic integer of degree 16 over ℚ. The 16 sign-combinations ±√2±√3±√5±√7 are its full set of Galois conjugates (Galois group (ℤ/2)^4 of the multiquadratic field ℚ(√2,√3,√5,√7)); α is a primitive element, so its minimal polynomial has degree 16 with rational integer coefficients. Degree ≠ 1 ⇒ irrational.",
       "Three formalization strategies, in increasing Mathlib-infrastructure cost: (A) elementary iterated squaring; (B) ℚ-linear independence of {1,√2,√3,√5,√7} (Besicovitch); (C) field degree [ℚ(√2,√3,√5,√7):ℚ]=16.",
@@ -41,7 +46,8 @@
       "Strategy C parallels the sibling gallery proof Sqrt2PlusSqrt3IrrationalOQ03 (minimal polynomial of √2+√3 = X⁴-10X²+1 via minpoly/IntermediateField), scaled to the degree-16 multiquadratic field; needs linear-disjointness / degree-of-multiquadratic infrastructure not assembled in Mathlib (>500 LOC).",
       "NEW Strategy D (RECOMMENDED, Session 2): α = √2+√3+√5+√7 is a sum of four algebraic integers (each √k a root of monic X²-k), hence integral over ℤ (IsIntegral.add). A rational number integral over ℤ lies in ℤ (ℤ integrally closed in ℚ, IsIntegrallyClosed). But 8 < α < 9 (α≈8.0281, verified), so α ∉ ℤ ⇒ irrational. This sidesteps the ENTIRE degree-16 algebra: no squaring chain, no minimal-polynomial expansion, no surd isolation. ~60-100 LOC, no new Mathlib theory (just the integral-closure API). Lean skeleton drafted in knowledge.md with 4 lemma names to confirm at build.",
       "Explicit minimal polynomial (sympy-verified m(α)=0 exactly): m(x)=x^16-136x^14+6476x^12-141912x^10+1513334x^8-7453176x^6+13950764x^4-5596840x^2+46225 (monic, integer, even; constant 46225=215²); equivalently g(α²)=0 with g(y)=y^8-136y^7+6476y^6-141912y^5+1513334y^4-7453176y^3+13950764y^2-5596840y+46225. Confirms the degree-16 claim concretely; alternative Lean target (m(α)=0 then rational-root theorem), though the 16th-power expansion is heavy vs Strategy D.",
-      "Strategy A's single-surd endgame is NOT clean (numerically confirmed Session 2): √210=Σcᵢαⁱ in the α power basis has only even powers but rational coefficients over common denominator 14499840 (e.g. c₀=42047681/2899968). No small-integer analog of the parent's α⁴-20α²-24=8α√30 — reinforces switching to Strategy D."
+      "Strategy A's single-surd endgame is NOT clean (numerically confirmed Session 2): √210=Σcᵢαⁱ in the α power basis has only even powers but rational coefficients over common denominator 14499840 (e.g. c₀=42047681/2899968). No small-integer analog of the parent's α⁴-20α²-24=8α√30 — reinforces switching to Strategy D.",
+      "ACT (researcher-10, S5): Strategy D transcribed end-to-end. eq_ratCast (algebraMap Q R) q bridges (q:R)=algebraMap Q R q for descent; algebraMap Z Q n simplified to (n:Q) by simp; integer-in-(8,9) contradiction closed by exact_mod_cast on real bounds + omega. All 4 pinned bearers used as specced. Math re-verified by verify_strategy_d.py (ALL CHECKS PASSED)."
     ],
     "mathlibGaps": [
       "No usable Mathlib lemma for ℚ-linear independence of {√d : d squarefree} (Besicovitch); needed for Strategy B.",
@@ -50,9 +56,9 @@
       "Strategy D (recommended) needs only the integral-closure API expected to be present: IsIntegral.add, IsIntegrallyClosed ℤ / IsIntegrallyClosed.isIntegral_iff, and integrality descent along algebraMap ℚ ℝ — to be confirmed at build, no known gap."
     ],
     "nextSteps": [
-      "When Docker returns: implement Strategy D (RECOMMENDED) in Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean (~60-100 LOC). Confirm the 4 Mathlib lemma names in the knowledge.md skeleton (IsIntegral.add; integrality descent along the injective algebraMap ℚ ℝ; IsIntegrallyClosed ℤ ⇒ rational integral element is an integer; sqrt bounds for 8<α<9), then fill the single sorry.",
-      "Fallback 1: Strategy A (3-squaring chain) — no infrastructure dependency but ~300-600 LOC and ugly single-surd endgame. Fallback 2: prove m(α)=0 (explicit poly recorded) and apply the rational-root theorem (monic ℤ-poly ⇒ rational roots are integers; α∈(8,9) ⇒ none).",
-      "Aristotle-eligible once the backend returns: submit the Strategy D theorem (or m(α)=0) directly. As of 2026-06-14 Aristotle 'prove' still returns 'Resource not found' (re-confirmed Session 2)."
+      "BUILD when Docker returns: ./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01 - then add import to proofs/Proofs.lean and create src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-plus-sqrt7-irrational/meta.json (status verified iff 0 sorries/0 axioms confirmed).",
+      "Residual transcription risks at build: (a) IsScalarTower Z Q R / IsFractionRing Z Q instance firing for isIntegral_algebraMap_iff & IsIntegrallyClosed.isIntegral_iff; (b) aeval_def vs eval2 defeq in isIntegral_of_sq; (c) eq_ratCast applicability to bundled algebraMap Q R. Fallbacks: Strategy A (3-squaring octic) or m(a)=0 + rational-root.",
+      "Once verified, generate follow-up OQ: Strategy D scales to ANY finite sum of sqrt(squarefree) with NO degree blow-up (unlike Strategy A's quadratic blow-up per summand)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Transcribes the bearer-confirmed **Strategy D** (algebraic-integer + bounded-interval) into a complete Lean proof of `Irrational (√2 + √3 + √5 + √7)` — the four-summand generalization (OQ-01 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`). Sessions 1–4 left this "paste-port-ready" but produced zero Lean; this session writes the actual proof.

New file `proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` (~95 LOC, **0 sorries / 0 axioms** by construction):
- `isIntegral_of_sq` — `c² = m ∈ ℤ ⇒ IsIntegral ℤ c` (root of monic `X² − C m`)
- four per-radical instances + `isIntegral_alpha` via `IsIntegral.add ×3`
- `alpha_lower` (`8 < α`) / `alpha_upper` (`α < 9`) via `Real.lt_sqrt` / `Real.sqrt_lt'` with decimal witnesses `1.41/1.73/2.23/2.64` and `1.42/1.74/2.24/2.65`
- main theorem: descend integrality along `ℚ ↪ ℝ` (`isIntegral_algebraMap_iff`), `ℤ` integrally closed (`IsIntegrallyClosed.isIntegral_iff`) ⇒ `α = (n:ℝ)`, then integer-in-`(8,9)` ⇒ `⊥` via `omega`.

This sidesteps the entire degree-16 minimal-polynomial / 3-squaring machinery (Strategy A). Notably Strategy D scales to **any** finite sum of `√(squarefree)` with no degree blow-up.

## Verification status
- **Math**: re-verified by `verify_strategy_d.py` → `ALL CHECKS PASSED` (integrality, degree-16 minimal poly via resultant, bound `8 < α < 9`, all 8 rational square-witnesses). Decimal bounds independently re-checked.
- **Lean build**: **PENDING** — Docker daemon is down this session, so the file is **not machine-checked** and is deliberately **UNREGISTERED** in `proofs/Proofs.lean` (cannot break the aggregate build). Status is intentionally NOT marked `verified`.

## Test plan
- [ ] When Docker returns: `./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01`
- [ ] Fix any lemma-name / instance-resolution drift (residual risks: `IsScalarTower ℤ ℚ ℝ` / `IsFractionRing ℤ ℚ` firing; `aeval_def` vs `eval₂` defeq; `eq_ratCast` on bundled `algebraMap ℚ ℝ`). Fallbacks: Strategy A (3-squaring octic) or `m(α)=0` + rational-root.
- [ ] On success: add import to `proofs/Proofs.lean` + create `src/data/proofs/.../meta.json` (status `verified` iff 0 sorries/0 axioms confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)