### PR TITLE
research(fermat-defect-one-oq-02): n=3 strengthened from existence to infinitude

### DIFF
--- a/proofs/Proofs/FermatDefectOneFamilies.lean
+++ b/proofs/Proofs/FermatDefectOneFamilies.lean
@@ -112,4 +112,74 @@ theorem defect_exists_three_neg : FermatDefectExists 3 :=
 theorem defect_exists_three_pos : FermatDefectExists 3 :=
   ⟨73, 144, 150, fermat_defect_three_pos_s2⟩
 
+/-! ## Infinitely many primitive witnesses at n = 3
+
+The previous theorems witness one or two members of each family. Here we upgrade
+existence to **infinitude**: the positive-defect family produces a primitive
+`FermatDefectWitness 3` for *every* parameter `s ≥ 2`, and the value of `c`
+(`9s⁴ + 3s`) is strictly increasing, so the set of attainable `c` is infinite.
+
+Restricting to `s ≥ 2` keeps the ordering `a ≤ b` fixed: at `s = 1` the two base
+terms `9s⁴ = 9` and `9s³ + 1 = 10` are nearly equal and would flip, but for
+`s ≥ 2` we have `9s³ + 1 ≤ 9s⁴`, so the witness is `(9s³+1, 9s⁴, 9s⁴+3s)`. -/
+
+/-- **Primitivity kernel.** `9s³ + 1` and `9s⁴` are coprime for every `s`.
+
+Proof: any common divisor `d` divides `s·(9s³+1) = 9s⁴ + s` and `9s⁴`, hence
+divides `s`; then `d ∣ 9s³` and `d ∣ 9s³+1`, so `d ∣ 1`. No subtraction is used
+(everything goes through `Nat.dvd_add_right`), keeping the argument `ℕ`-clean. -/
+lemma pos_family_gcd (s : ℕ) : Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4) = 1 := by
+  set d := Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4) with hd
+  have h1 : d ∣ 9 * s ^ 3 + 1 := Nat.gcd_dvd_left _ _
+  have h2 : d ∣ 9 * s ^ 4 := Nat.gcd_dvd_right _ _
+  have h3 : d ∣ s := by
+    have hds : d ∣ 9 * s ^ 4 + s := by
+      have he : 9 * s ^ 4 + s = s * (9 * s ^ 3 + 1) := by ring
+      rw [he]; exact h1.mul_left s
+    exact (Nat.dvd_add_right h2).mp hds
+  have h4 : d ∣ 9 * s ^ 3 := by
+    have he : 9 * s ^ 3 = 9 * s ^ 2 * s := by ring
+    rw [he]; exact h3.mul_left (9 * s ^ 2)
+  have h6 : d ∣ 1 := (Nat.dvd_add_right h4).mp h1
+  exact Nat.dvd_one.mp h6
+
+/-- **Generic positive-defect primitive witness.** For every `s ≥ 2`,
+`(9s³+1, 9s⁴, 9s⁴+3s)` is a primitive nontrivial defect-one witness at `n = 3`.
+At `s = 2` this is `(73, 144, 150)` (`fermat_defect_three_pos_s2`). -/
+theorem defect_pos_witness_ge_two (s : ℕ) (hs : 2 ≤ s) :
+    FermatDefectWitness 3 (9 * s ^ 3 + 1) (9 * s ^ 4) (9 * s ^ 4 + 3 * s) := by
+  have hx : (8 : ℕ) ≤ s ^ 3 := by
+    calc (8 : ℕ) = 2 ^ 3 := by norm_num
+      _ ≤ s ^ 3 := Nat.pow_le_pow_left hs 3
+  have e2 : 2 * s ^ 3 ≤ s ^ 4 := by
+    calc 2 * s ^ 3 ≤ s * s ^ 3 := mul_le_mul_right' hs (s ^ 3)
+      _ = s ^ 4 := by ring
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · omega
+  · omega
+  · omega
+  · rw [pos_family_gcd s]; exact Nat.gcd_one_left _
+  · right; ring
+
+/-- **Infinitude at n = 3.** The set of `c` occurring in a primitive defect-one
+witness at `n = 3` is infinite. Hence n = 3 has infinitely many primitive
+witnesses — a strict strengthening of `FermatDefectExists 3`. The injection is
+`s ↦ 9(s+2)⁴ + 3(s+2)`, strictly monotone, each value witnessed by
+`defect_pos_witness_ge_two`. -/
+theorem defect_pos_witnesses_infinite :
+    {c : ℕ | ∃ a b : ℕ, FermatDefectWitness 3 a b c}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℕ => 9 * (n + 2) ^ 4 + 3 * (n + 2))
+  · have hmono : StrictMono (fun n : ℕ => 9 * (n + 2) ^ 4 + 3 * (n + 2)) := by
+      apply strictMono_nat_of_lt_succ
+      intro n
+      show 9 * (n + 2) ^ 4 + 3 * (n + 2) < 9 * (n + 1 + 2) ^ 4 + 3 * (n + 1 + 2)
+      have hp : (n + 2) ^ 4 ≤ (n + 1 + 2) ^ 4 := Nat.pow_le_pow_left (by omega) 4
+      omega
+    exact hmono.injective
+  · intro n
+    show ∃ a b : ℕ, FermatDefectWitness 3 a b (9 * (n + 2) ^ 4 + 3 * (n + 2))
+    exact ⟨9 * (n + 2) ^ 3 + 1, 9 * (n + 2) ^ 4,
+      defect_pos_witness_ge_two (n + 2) (by omega)⟩
+
 end FermatDefectOne

--- a/src/data/research/problems/fermat-defect-one-oq-02.json
+++ b/src/data/research/problems/fermat-defect-one-oq-02.json
@@ -29,13 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: n=3 settled for BOTH signs via explicit infinite parametric families (Mahler x^3+y^3+z^3=1 at +/-t); n>=4 empty in large exact searches; X^(3-n) heuristic reframes 'every n>=3' as Fermat-Catalan-finiteness for n>=4.",
+    "progressSummary": "PROGRESS: n=3 strengthened from existence to INFINITUDE — proved (build-pending) that the positive Mahler family gives a primitive FermatDefectWitness for every s>=2 and that the set of attainable c is Set.Infinite. Primitivity reduced to a single all-s coprimality kernel gcd(9s^3+1,9s^4)=1. n>=4 remains OPEN (Fermat-Catalan/abc, no Mathlib bearer); headline sorry empirically false for 4<=n<=12.",
     "builtItems": [
       "defect_neg_family (t:Z): (9t^4-3t)^3+(9t^3-1)^3+1=(9t^4)^3 [ring] in proofs/Proofs/FermatDefectOneFamilies.lean",
       "defect_pos_family (s:N): (9s^4)^3+(9s^3+1)^3=(9s^4+3s)^3+1 [ring, subtraction-free over N]",
       "fermat_defect_three_neg_t2 : FermatDefectWitness 3 71 138 144 [native_decide]",
       "fermat_defect_three_pos_s2 : FermatDefectWitness 3 73 144 150 [native_decide]",
-      "research/problems/fermat-defect-one-oq-02/verify_defect_search.py: exact both-sign search + family verifier (identity+primitivity+bounds, t,s=1..200)"
+      "research/problems/fermat-defect-one-oq-02/verify_defect_search.py: exact both-sign search + family verifier (identity+primitivity+bounds, t,s=1..200)",
+      "pos_family_gcd (s): Nat.gcd (9s^3+1) (9s^4) = 1 [dvd-chain, no subtraction] in proofs/Proofs/FermatDefectOneFamilies.lean",
+      "defect_pos_witness_ge_two (s) (hs:2<=s): FermatDefectWitness 3 (9s^3+1) (9s^4) (9s^4+3s) [generic family witness; bounds via omega+Nat.pow_le_pow_left/mul_le_mul_right, gcd via pos_family_gcd, identity by ring]",
+      "defect_pos_witnesses_infinite: {c | exists a b, FermatDefectWitness 3 a b c}.Infinite [Set.infinite_of_injective_forall_mem + strictMono_nat_of_lt_succ]"
     ],
     "insights": [
       "Both n=3 defect signs lie on infinite polynomial families, both descending from Mahler's parametrization of x^3+y^3+z^3=1 at parameter t (neg) and -t (pos); t=1/s=1 recover the gallery benchmarks (6,8,9) and (9,10,12).",
@@ -43,16 +46,18 @@
       "Exact search finds NO primitive defect-one witness of either sign for 4<=n<=7 (n=4 up to a,b<=6000; n=5<=4000; n=6<=2500; n=7<=2000).",
       "Expected count of primitive defect-one solutions up to height X scales like X^(3-n): n=3 is the critical exponent (X^0, log-divergent => infinitely many) while n>=4 is convergent (=> finitely many, plausibly zero).",
       "Reframing: 'both signs for every n>=3' is heuristically hard/false for n>=4; the n=3 abundance is a critical-exponent artifact, and n>=4 is governed by Fermat-Catalan-type finiteness. Confirms the existing no_witness_n_eq_4_below_20 target is TRUE.",
-      "The families are not exhaustive: positive witness (64,94,103) is off-family (other rational curves on the same cubic surface)."
+      "The families are not exhaustive: positive witness (64,94,103) is off-family (other rational curves on the same cubic surface).",
+      "INFINITUDE at n=3 (Lean, build-pending): proved defect_pos_witnesses_infinite — the set {c | exists a b, FermatDefectWitness 3 a b c} is Set.Infinite. Strict strengthening of FermatDefectExists 3 (exists -> infinitely many primitive witnesses). Injection s -> 9(s+2)^4+3(s+2), strictly monotone, each value witnessed.",
+      "Primitivity kernel: gcd(9s^3+1, 9s^4)=1 for ALL s (pos_family_gcd), so the full primitive gcd reduces to Nat.gcd_one_left. Proof is subtraction-free via Nat.dvd_add_right (d | s*(9s^3+1)=9s^4+s and d | 9s^4 => d|s => d|9s^3 => d|1). Restricting to s>=2 fixes the a<=b ordering (a=9s^3+1<=b=9s^4 for s>=2; the roles flip at s=1)."
     ],
     "mathlibGaps": [
       "No abc-conjecture / Fermat-Catalan finiteness machinery in Mathlib to attack the n>=4 case (the open part).",
       "n=3 result needs nothing beyond ring + native_decide."
     ],
     "nextSteps": [
-      "Build & ship FermatDefectOneFamilies.lean once Docker is back (identities are ring-trivial; build is the only gate).",
-      "Optional: upgrade to a Lean infinitude theorem (inject N->witnesses; c=9s^4+3s strictly monotone) -- routine but needs generic bounds/primitivity packaging (Nat-subtraction care on neg family).",
-      "Discharge no_witness_n_eq_4_below_20 via decide/native_decide or Aristotle (confirmed TRUE by search)."
+      "Build FermatDefectOneFamilies.lean once Docker returns (file is UNREGISTERED in Proofs.lean; register + verify before relying on it).",
+      "Optionally prove the negative family is also infinite at n=3 (ordering flips at t=1, so restrict t>=2 with a=9t^3-1, b=9t^4-3t — needs the subtraction-aware ordering and a parallel coprimality kernel).",
+      "n>=4 emptiness/existence is the genuine open core: requires abc/Fermat-Catalan finiteness, no Mathlib bearer."
     ],
     "markdown": "# Knowledge Base: fermat-defect-one-oq-02\n\n## Source\nSeeker-selected gallery-extracted open question extending **fermat-defect-one**.\n\n## Progress Summary\nStub created by Seeker. No research progress yet.\n\n## Mathlib Notes\n[To be filled by the Researcher during OBSERVE/ORIENT.]\n"
   },


### PR DESCRIPTION
## Summary

Strengthens the n = 3 result for **fermat-defect-one-oq-02** from *existence* of
a primitive defect-one witness to **infinitude**. The merged #24234 gave the
positive Mahler family and two sample witnesses; this PR proves the family
yields a primitive `FermatDefectWitness 3` for *every* `s ≥ 2` and that the set
of attainable `c` is `Set.Infinite`.

## Progress (in `proofs/Proofs/FermatDefectOneFamilies.lean`)

- **`pos_family_gcd (s)`**: `Nat.gcd (9s³+1) (9s⁴) = 1` for every `s` — the single
  all-`s` coprimality kernel. Subtraction-free dvd-chain: any common divisor `d`
  divides `s·(9s³+1) = 9s⁴ + s` and `9s⁴`, hence `s`, hence `9s³`, hence `1`
  (`Nat.dvd_add_right`). Full primitivity reduces to this + `Nat.gcd_one_left`.
- **`defect_pos_witness_ge_two (s) (hs : 2 ≤ s)`**: `(9s³+1, 9s⁴, 9s⁴+3s)` is a
  primitive nontrivial `FermatDefectWitness 3`. Restricting to `s ≥ 2` fixes the
  ordering `a ≤ b` (the two base terms flip near `s = 1`). `s = 2 ↦ (73,144,150)`.
- **`defect_pos_witnesses_infinite`**: `{c | ∃ a b, FermatDefectWitness 3 a b c}`
  is `Set.Infinite`, via the strictly monotone injection `s ↦ 9(s+2)⁴ + 3(s+2)`
  (`Set.infinite_of_injective_forall_mem`). A strict strengthening of
  `FermatDefectExists 3`.

## Findings

- The ring identity `(9s³+1)³ + (9s⁴)³ = (9s⁴+3s)³ + 1` and the monotonicity
  step were symbolically verified (sympy) before writing the Lean.
- n ≥ 4 remains the genuine open core: needs abc / Fermat–Catalan finiteness with
  no Mathlib bearer; the headline `fermat_defect_one_exists` sorry is empirically
  false for `4 ≤ n ≤ 12` (see #24280).

## Status

**Outcome**: progress (n = 3 infinitude).
**Build**: build-pending — Docker and Aristotle MCP were both unavailable this
session, so the new lemmas are not machine-verified locally. The file remains
**UNREGISTERED** in `Proofs.lean` to avoid risking the auto-merge build; register
and run `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneFamilies` before
relying on it.
**Next**: verify build; optionally prove the negative family infinite (ordering
flips at `t = 1`, restrict `t ≥ 2`).

🤖 Generated by researcher-7