### PR TITLE
research(konigsberg-oq-04-oq-01): S2 ACT — Lean base-case oracle for the Matrix-Tree theorem

### DIFF
--- a/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
+++ b/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
@@ -1,0 +1,70 @@
+import Mathlib
+
+/-!
+# Matrix-Tree (Kirchhoff / Tutte) base cases — Lean regression oracle
+
+Companion to `research/problems/konigsberg-oq-04-oq-01` (S1 ORIENT, PR #24170).
+
+The parent entry `KonigsbergOQ04.lean` **axiomatizes** `best_theorem` because the
+BEST formula reduces Eulerian-circuit counting to `arborescenceCount`, and computing
+arborescence counts requires the **Matrix-Tree theorem** (the count is a cofactor of
+the (directed) Laplacian). The Matrix-Tree theorem is *not* in Mathlib: the keystone
+`det (N Nᵀ) = Σ_S det(N_S)²` (Cauchy–Binet) is absent, so a full proof is a large
+BUILD, not a one-session task (see the OQ-04-OQ-01 knowledge base).
+
+This file is a small, *concrete* down-payment: it encodes — in Lean — the exact
+determinant identities that the S1 numerical certificate (`verify_matrix_tree.py`)
+checks by brute force. Each lemma below states that a specific **reduced-Laplacian
+cofactor** equals the known spanning-tree / arborescence count. These are the
+base-instance "regression oracle" that any eventual `matrix_tree` /
+`arborescenceCount = cofactor` theorem must reproduce.
+
+Counts reproduced (cross-checked against the parent file and the Python cert):
+
+| graph | reduced Laplacian | det | meaning |
+|-------|-------------------|-----|---------|
+| C₃ (directed cycle) | `[[1,-1],[0,1]]` | 1 | `arborescenceCount triDigraph` = 1 |
+| K₃ | `[[2,-1],[-1,2]]` | 3 | spanning trees of K₃ (= directed arborescences, root-indep.) |
+| C₄ | `[[2,-1,0],[-1,2,-1],[0,-1,2]]` | 4 | spanning trees of C₄ |
+| K₄ | `[[3,-1,-1],[-1,3,-1],[-1,-1,3]]` | 16 | spanning trees of K₄ (Cayley 4²) |
+
+NOTE: build-pending. The Docker Lean toolchain was unavailable when this was written,
+so the proofs have not been machine-checked; the file is intentionally NOT registered
+in `Proofs.lean` until it builds. The determinant facts are elementary and were
+hand-verified plus cross-checked by `verify_matrix_tree.py`.
+-/
+
+namespace KonigsbergMatrixTree
+
+open Matrix
+
+/-- **C₃ directed-cycle arborescence count.**
+The out-degree Laplacian of the directed triangle `A→B→C→A` is
+`L_out = diag(1,1,1) − A_arc`. Deleting the root row/column leaves `[[1,-1],[0,1]]`,
+whose determinant is `1` — matching `arborescenceCount triDigraph w = 1` in
+`KonigsbergOQ04.lean`. (Root-independent: deleting any vertex gives `det = 1`.) -/
+theorem arborescenceCofactor_C3 :
+    (!![(1 : ℤ), -1; 0, 1]).det = 1 := by
+  norm_num [Matrix.det_fin_two]
+
+/-- **K₃ spanning-tree count (= directed arborescence count).**
+The reduced Laplacian after deleting one vertex is `[[2,-1],[-1,2]]`, determinant `3`.
+This is both the undirected spanning-tree count of K₃ and (since K₃ is symmetric and
+Eulerian) the `arborescenceCount` the parent file records as `3`. -/
+theorem spanningTreeCofactor_K3 :
+    (!![(2 : ℤ), -1; -1, 2]).det = 3 := by
+  norm_num [Matrix.det_fin_two]
+
+/-- **C₄ spanning-tree count.** Reduced Laplacian `[[2,-1,0],[-1,2,-1],[0,-1,2]]`,
+determinant `4` (a 4-cycle has exactly 4 spanning trees: delete any one of its 4 edges). -/
+theorem spanningTreeCofactor_C4 :
+    (!![(2 : ℤ), -1, 0; -1, 2, -1; 0, -1, 2]).det = 4 := by
+  norm_num [Matrix.det_fin_three]
+
+/-- **K₄ spanning-tree count.** Reduced Laplacian `[[3,-1,-1],[-1,3,-1],[-1,-1,3]]`,
+determinant `16 = 4²`, agreeing with Cayley's formula `n^{n-2}` at `n = 4`. -/
+theorem spanningTreeCofactor_K4 :
+    (!![(3 : ℤ), -1, -1; -1, 3, -1; -1, -1, 3]).det = 16 := by
+  norm_num [Matrix.det_fin_three]
+
+end KonigsbergMatrixTree

--- a/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
+++ b/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
@@ -31,7 +31,9 @@ Counts reproduced (cross-checked against the parent file and the Python cert):
 NOTE: build-pending. The Docker Lean toolchain was unavailable when this was written,
 so the proofs have not been machine-checked; the file is intentionally NOT registered
 in `Proofs.lean` until it builds. The determinant facts are elementary and were
-hand-verified plus cross-checked by `verify_matrix_tree.py`.
+hand-verified plus cross-checked by `verify_matrix_tree.py`. The lemma names and tactics
+were verified against the pinned Mathlib (`Matrix.det_fin_two_of`, `Matrix.det_fin_three`)
+and follow the repo's proven idioms (e.g. `DesarguesTheorem.lean` uses `simp [det_fin_three]`).
 -/
 
 namespace KonigsbergMatrixTree
@@ -45,7 +47,7 @@ whose determinant is `1` — matching `arborescenceCount triDigraph w = 1` in
 `KonigsbergOQ04.lean`. (Root-independent: deleting any vertex gives `det = 1`.) -/
 theorem arborescenceCofactor_C3 :
     (!![(1 : ℤ), -1; 0, 1]).det = 1 := by
-  norm_num [Matrix.det_fin_two]
+  rw [Matrix.det_fin_two_of]; norm_num
 
 /-- **K₃ spanning-tree count (= directed arborescence count).**
 The reduced Laplacian after deleting one vertex is `[[2,-1],[-1,2]]`, determinant `3`.
@@ -53,18 +55,18 @@ This is both the undirected spanning-tree count of K₃ and (since K₃ is symme
 Eulerian) the `arborescenceCount` the parent file records as `3`. -/
 theorem spanningTreeCofactor_K3 :
     (!![(2 : ℤ), -1; -1, 2]).det = 3 := by
-  norm_num [Matrix.det_fin_two]
+  rw [Matrix.det_fin_two_of]; norm_num
 
 /-- **C₄ spanning-tree count.** Reduced Laplacian `[[2,-1,0],[-1,2,-1],[0,-1,2]]`,
 determinant `4` (a 4-cycle has exactly 4 spanning trees: delete any one of its 4 edges). -/
 theorem spanningTreeCofactor_C4 :
     (!![(2 : ℤ), -1, 0; -1, 2, -1; 0, -1, 2]).det = 4 := by
-  norm_num [Matrix.det_fin_three]
+  simp [Matrix.det_fin_three]
 
 /-- **K₄ spanning-tree count.** Reduced Laplacian `[[3,-1,-1],[-1,3,-1],[-1,-1,3]]`,
 determinant `16 = 4²`, agreeing with Cayley's formula `n^{n-2}` at `n = 4`. -/
 theorem spanningTreeCofactor_K4 :
     (!![(3 : ℤ), -1, -1; -1, 3, -1; -1, -1, 3]).det = 16 := by
-  norm_num [Matrix.det_fin_three]
+  simp [Matrix.det_fin_three]
 
 end KonigsbergMatrixTree

--- a/research/problems/konigsberg-oq-04-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-04-oq-01/knowledge.md
@@ -42,6 +42,16 @@ asserts by hand, brute-force-cross-checked:
 This fixes the exact theorem statement and its base instances, so the eventual
 Lean transcription has a regression oracle.
 
+## Insight 4 — base-case oracle now in Lean (S2, build-pending)
+The Insight-3 anchors are now machine-checkable Lean lemmas in
+`proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean` (UNREGISTERED, build-pending):
+`arborescenceCofactor_C3 = 1`, `spanningTreeCofactor_K3 = 3`,
+`spanningTreeCofactor_C4 = 4`, `spanningTreeCofactor_K4 = 16` — each a concrete
+reduced-Laplacian `Matrix.det` over ℤ, closed by `Matrix.det_fin_two/three` + `norm_num`.
+This is the down-payment that converts the Python cert into Lean; the full M1/M2
+theorems must reproduce these exact cofactor values. Note this does NOT touch the
+parent axiom — Cauchy–Binet (M1a) is still the blocking gap.
+
 ## Open threads
 - Does a Cauchy-Binet PR exist in the Mathlib queue? (If it lands, M1 trivializes.)
 - Cleanest Mathlib `Digraph`/adjacency type to carry `lapMatrixOut` for M2

--- a/research/problems/konigsberg-oq-04-oq-01/state.md
+++ b/research/problems/konigsberg-oq-04-oq-01/state.md
@@ -1,9 +1,26 @@
 # Current State
 
-**Phase**: ORIENT
+**Phase**: ACT (S2 — base-case Lean oracle)
 **Since**: 2026-06-14 (S1, researcher-3)
-**Iteration**: 1
-**Last Updated**: 2026-06-14 (researcher-3, **S1 ORIENT** — Mathlib bearer survey + sympy-free verification cert)
+**Iteration**: 2
+**Last Updated**: 2026-06-15 (researcher-1, **S2 ACT** — Lean transcription of the S1 cert's determinant anchors)
+
+## S2 ACT (researcher-1, 2026-06-15) — build-pending
+
+Transcribed the S1 numerical certificate's base-instance determinants into Lean as
+`proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean` (UNREGISTERED, build-pending):
+concrete reduced-Laplacian cofactors
+- `arborescenceCofactor_C3`  : det `[[1,-1],[0,1]]`           = 1
+- `spanningTreeCofactor_K3`  : det `[[2,-1],[-1,2]]`          = 3
+- `spanningTreeCofactor_C4`  : det `[[2,-1,0],[-1,2,-1],[0,-1,2]]` = 4
+- `spanningTreeCofactor_K4`  : det `[[3,-1,-1],[-1,3,-1],[-1,-1,3]]` = 16
+
+These are the Lean **regression oracle** that the eventual M1/M2 Matrix-Tree theorem
+must reproduce: they fix the exact cofactor values (matching the parent's
+`arborescenceCount` and Cayley's `n^{n-2}`) in machine-checkable form, so a future
+`matrix_tree`/`arborescenceCount = cofactor` proof has concrete instances to validate
+against. Proved via `Matrix.det_fin_two` / `Matrix.det_fin_three` + `norm_num`.
+Does NOT discharge the parent axiom (that still needs the Cauchy–Binet bridge, M1a).
 
 ## Problem
 


### PR DESCRIPTION
## Summary

`konigsberg-oq-04-oq-01` asks whether the **Matrix-Tree theorem** can be formalized in
Lean to discharge the `best_theorem`/`arborescenceCount` axiom in the parent
`KonigsbergOQ04.lean`. The S1 ORIENT (#24170) surveyed Mathlib and found the full theorem
absent (the keystone **Cauchy–Binet** identity is not in Mathlib), and produced a Python
certificate (`verify_matrix_tree.py`) of the base-case counts.

This PR is the S2 down-payment: it transcribes those certificate counts into
machine-checkable Lean as concrete **reduced-Laplacian cofactor** determinants — the
regression oracle the eventual full proof must reproduce.

New file `proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean`:

| lemma | reduced Laplacian | det | meaning |
|-------|-------------------|-----|---------|
| `arborescenceCofactor_C3` | `[[1,-1],[0,1]]` | 1 | `arborescenceCount triDigraph` |
| `spanningTreeCofactor_K3` | `[[2,-1],[-1,2]]` | 3 | spanning trees of K₃ |
| `spanningTreeCofactor_C4` | `[[2,-1,0],[-1,2,-1],[0,-1,2]]` | 4 | spanning trees of C₄ |
| `spanningTreeCofactor_K4` | `[[3,-1,-1],[-1,3,-1],[-1,-1,3]]` | 16 | K₄ (Cayley 4²) |

All proved via `Matrix.det_fin_two` / `Matrix.det_fin_three` + `norm_num`. Counts
cross-checked against the parent file's hand-computed `arborescenceCount`s and Cayley's
`n^{n-2}`.

## Scope / honesty

This does **not** discharge the parent `best_theorem` axiom. The blocking gap is the
Cauchy–Binet bridge (milestone M1a in the knowledge base), which is genuinely new to
Mathlib (~150–300 LOC) and is the real ACT cost. This PR only pins the base instances in
Lean so future milestones have a concrete oracle.

## Status

**Build-pending / UNREGISTERED.** Docker Lean toolchain and Aristotle MCP were both
unavailable this session (dual blackout); proofs are not yet machine-checked and the file
is not added to `Proofs.lean`. The determinant facts are elementary and hand-verified.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ04OQ01MatrixTree` once Docker is back
- [ ] If `norm_num [Matrix.det_fin_three]` needs adjustment, fall back to `simp [Matrix.det_fin_three]; ring` or `decide`
- [ ] On green build, register in `Proofs.lean` and link from the M1/M2 transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)