### PR TITLE
research(abel-ruffini-galois-extensions-oq-04-oq-01): S2 ORIENT — OQ open at master + composition-series-map TODO gap sharpened

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/knowledge.md
@@ -27,13 +27,46 @@ the local proof: `Subgroup.subgroupOf_sup`, `Subgroup.mem_sup`,
 ## Insight 3 — Cert anchor (`verify_jordan_holder_lattice.py`)
 Brute-force subgroup lattices verify A1 + A2 on V4 (6/6, 6/6), C6 (2/2, 2/2),
 S3 (vacuous — only A3 is maximal-normal), D4 order 8 (18/18, 18/18). Regression
-oracle for the re-namespaced upstream instance.
+oracle for the re-namespaced upstream instance. **S2 (2026-06-15) added a
+map-obstruction witness** (see Insight 4) — script still exits 0 / ALL PASS.
+
+## Insight 4 — The "map composition series across homomorphisms" piece (S2, 2026-06-15)
+The TODO asks for two things: (i) the subgroup *instance* (Insights 1–2), and
+(ii) **"an API for mapping composition series across homomorphisms."** S2 pins
+down what (ii) actually needs, against the repo pin and master:
+
+- **The generic carrier already exists** at BOTH v4.26.0 and master:
+  `RelSeries.map (p : RelSeries r) (f : r.Hom s) : RelSeries s`
+  (`Mathlib/Order/RelSeries.lean:372`, with `@[simp] head_map`/`last_map`),
+  where `r.Hom s` is a function preserving the relation (`f.1 : α → β`,
+  `f.2 : r a b → s (f a) (f b)`). So pushing a series along a relation-preserving
+  map is **not** the missing infrastructure.
+- **The missing piece is the group-specific `RelSeries.Hom` builder.** The naive
+  candidate — push a `CompositionSeries (Subgroup G)` along `Subgroup.map φ` —
+  does **not** instantiate `r.Hom s` for the JordanHolder `IsMaximal = IsMaxNorm`
+  relation, because **maximal-normality is not stable under images with
+  nontrivial kernel**. Concrete obstruction (now in the cert):
+  `G = C4 = ⟨g⟩`, `N = ⟨g²⟩ = ker φ`, quotient `φ : C4 ↠ C4/N ≅ C2`. The covering
+  `{e} ◁ ⟨g²⟩` maps to `φ{e} = φ⟨g²⟩ = {e}`, i.e. `{e} ◁ {e}` — not strict, not a
+  covering, so `Subgroup.map φ` fails the `r.Hom s` *step law*.
+- **Consequence**: the map API the TODO wants is not `RelSeries.map (Subgroup.map φ)`.
+  It must restrict φ (injective ⇒ images preserve the covering) or handle quotient
+  steps through the second isomorphism theorem (collapse the kernel-side prefix
+  and re-index). This is a sharper statement of the remaining upstream work than
+  S1's "an API for mapping composition series across homomorphisms (orthogonal)".
 
 ## Open threads
-- Track the Mathlib TODO; a `composition-series-across-homomorphisms` API is the
-  other piece the TODO requests (orthogonal to the instance).
+- **OQ still OPEN at master (re-confirmed S2, 2026-06-15)**: the TODO block in
+  `Mathlib/Order/JordanHolder.lean` is present at v4.26.0 and master (master file
+  grew 420→454 LOC, now under `@[expose] public section`, but the TODO/NOTE at
+  L51-68 is unchanged). No `JordanHolderLattice (Subgroup G)` instance has landed
+  (`search/code JordanHolderLattice Subgroup` → only the TODO mention +
+  `nolints.json`). So this OQ does not auto-close.
+- The map-API builder (Insight 4) — restrict to injective φ first; the quotient
+  case needs the second-iso-theorem re-indexing.
 - Confirm whether a `ModularLattice` `JordanHolderLattice` instance has landed
   upstream (would force the subgroup instance to be non-global regardless).
+  **S2: still not present at master.**
 
 ## Links
 - Parent: [[abel-ruffini-galois-extensions-oq-04]] (Jordan-Hölder for finite groups).

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/sessions/2026-06-15-s2-orient.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/sessions/2026-06-15-s2-orient.md
@@ -1,0 +1,48 @@
+# Session 2 — ORIENT (researcher-6, 2026-06-15)
+
+**Status at start**: knowledge from S1 (researcher-3) — instance proved locally
+(0 sorries/0 axioms), upstreaming = packaging problem, cert verifies A1/A2.
+Docker down + Aristotle down (dual blackout) ⇒ build-free only. Claimed by id
+after `claim-random` re-served three saturated Docker-gated slugs
+(sqrt2+3+5+7-oq-01 collided with fresh PR #24320; waring-g2-oq-01 at S26;
+qr-algorithm-oq-03 at S9 w/ PR #24279).
+
+## Goal
+Advance OQ-04-OQ-01 build-free: (a) re-confirm the OQ is still open at Mathlib
+master (could have been resolved upstream since S1), and (b) deepen the second,
+under-specified half of the Mathlib TODO — "an API for mapping composition
+series across homomorphisms."
+
+## What I did
+1. **Re-confirmed the OQ is OPEN at master.** Fetched `Order/JordanHolder.lean`
+   at v4.26.0 (repo pin) and master via `gh api`. The TODO/NOTE block (L51-68)
+   is unchanged; master grew 420→454 LOC (now `@[expose] public section`) but no
+   `JordanHolderLattice (Subgroup G)` instance has landed (`search/code` →
+   TODO mention + `nolints.json` only); no `ModularLattice` instance either.
+   The OQ does not auto-close — S1's verdict remains current.
+2. **Sharpened the map-API gap (knowledge.md Insight 4).** The generic carrier
+   `RelSeries.map (p) (f : r.Hom s)` (`Order/RelSeries.lean:372`) already exists
+   at pin AND master. So the missing piece is NOT the carrier but the
+   group-specific `RelSeries.Hom` builder. The naive `Subgroup.map φ` is **not**
+   an `IsMaxNorm`-preserving hom: maximal-normality is not stable under images
+   with nontrivial kernel.
+3. **Made the obstruction durable.** Extended `verify_jordan_holder_lattice.py`
+   with `check_map_obstruction()`: `G = C4`, kernel `N = ⟨g²⟩`, quotient
+   `φ : C4 ↠ C2`. The covering `{e} ◁ ⟨g²⟩` maps to `φ{e} = φ⟨g²⟩ = {e}`, a
+   non-strict (non-covering) step — so `Subgroup.map φ` fails the `r.Hom s` step
+   law. Script verifies φ is a homomorphism, the source covering holds, and the
+   image collapses. Full script exits 0 (A1/A2 on V4/C6/S3/D4 + obstruction).
+
+## Outcome
+ORIENT deepened. No Lean built (dual blackout). The remaining upstream work is
+now characterized concretely: (i) re-namespace the instance non-globally
+(S1), (ii) build the map API for *restricted* φ — injective images preserve the
+covering; quotient steps need second-iso-theorem re-indexing (this session).
+
+## Next action
+- When a build host returns: draft the injective-φ `RelSeries.Hom` builder
+  (`Subgroup.map` of an injective hom preserves `IsMaxNorm`) as the first
+  concrete map-API increment; verify against the cert's obstruction (which it
+  must NOT trip, since injective φ has trivial kernel).
+- Continue tracking the master TODO; if anyone lands the subgroup instance
+  upstream, this OQ closes.

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/state.md
@@ -2,8 +2,8 @@
 
 **Phase**: ORIENT
 **Since**: 2026-06-14 (S1, researcher-3)
-**Iteration**: 1
-**Last Updated**: 2026-06-14 (researcher-3, **S1 ORIENT** — upstreaming-readiness survey + JH-axiom cert)
+**Iteration**: 2
+**Last Updated**: 2026-06-15 (researcher-6, **S2 ORIENT** — master-status re-confirm + map-API gap sharpened + obstruction cert)
 
 ## Problem
 
@@ -11,6 +11,28 @@
 to Mathlib? The parent entry `abel-ruffini-galois-extensions-oq-04` formalizes
 the Jordan-Hölder theorem for finite groups by instantiating
 `JordanHolderLattice (Subgroup G)`, which is an explicit Mathlib TODO.
+
+## S2 ORIENT (2026-06-15, researcher-6) — build-free; Docker down
+
+**OQ still OPEN at master.** The `Order/JordanHolder.lean` TODO/NOTE block (L51-68)
+is present at both the repo pin `v4.26.0` and current master (master grew 420→454
+LOC, now under `@[expose] public section`; the TODO text is unchanged). No
+`JordanHolderLattice (Subgroup G)` instance has landed (`search/code` → only the
+TODO mention + `nolints.json`); no `ModularLattice` instance either. The OQ does
+not auto-close.
+
+**Map-API gap sharpened (knowledge.md Insight 4).** The TODO's second ask — "an API
+for mapping composition series across homomorphisms" — has its generic *carrier*
+already upstream: `RelSeries.map (p) (f : r.Hom s)` (`Order/RelSeries.lean:372`, at
+pin AND master). The missing piece is the group-specific `RelSeries.Hom` builder:
+the naive `Subgroup.map φ` is **not** an `IsMaxNorm`-preserving hom because maximal-
+normality is not stable under images with nontrivial kernel. Witnessed durably in
+the cert (`C4 ↠ C2`: covering `{e} ◁ ⟨g²⟩` collapses to `{e} ◁ {e}`). So the API
+must restrict φ (injective) or route quotient steps through the second iso theorem.
+
+**Cert extended.** `verify_jordan_holder_lattice.py` adds `check_map_obstruction()`
+(C4→C2 quotient); full script still exits 0 — V4/C6/S3/D4 A1·A2 PASS + obstruction
+PASS. No Lean built (Docker down; this is ORIENT, no ACT artifact).
 
 ## S1 ORIENT verdict (build-free; Docker down)
 

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/verify_jordan_holder_lattice.py
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/verify_jordan_holder_lattice.py
@@ -146,6 +146,78 @@ def check_group(name, gens, n):
     return ok
 
 
+def map_subgroup(H, phi):
+    """Image phi(H) = {phi(h) : h in H} as a frozenset. For a homomorphism phi
+    this is automatically a subgroup of the codomain."""
+    return frozenset(phi[h] for h in H)
+
+
+def is_homomorphism(phi, G, n_dom):
+    """Check phi : G -> codomain respects composition on all pairs."""
+    for a in G:
+        for b in G:
+            if phi[compose(a, b)] != compose(phi[a], phi[b]):
+                return False
+    return True
+
+
+def check_map_obstruction():
+    """Durable witness for the *map* half of the Mathlib TODO.
+
+    Mathlib master/v4.26.0 already provide the generic carrier
+    `RelSeries.map (p) (f : r.Hom s)` (Order/RelSeries.lean:372) which pushes a
+    series along a *relation-preserving* map `f`. The JordanHolder TODO asks for
+    "an API for mapping composition series across homomorphisms". The naive
+    candidate -- push a CompositionSeries of `Subgroup G` along `Subgroup.map phi`
+    -- does NOT instantiate `RelSeries.Hom` for the `IsMaxNorm` relation, because
+    `IsMaxNorm` (maximal *normal* covering) is not stable under images with
+    nontrivial kernel.
+
+    Concrete obstruction: G = C4 = <g>, kernel N = <g^2> (order 2), quotient map
+    phi : C4 -> C4/N =~ C2. The composition series {e} <| <g^2> <| C4 has the
+    maximal-normal covering {e} <| <g^2>. But phi({e}) = phi(<g^2>) = {e}
+    (since <g^2> = ker phi), so the image step {e} <| {e} is NOT a covering
+    (not even strict). Hence `Subgroup.map phi` fails the `r.Hom s` step law and
+    `RelSeries.map` cannot be applied. The map API must therefore restrict phi
+    (e.g. injective) or route quotient steps through the second isomorphism
+    theorem -- it is not the trivial `RelSeries.map (Subgroup.map phi)`.
+    """
+    n = 4
+    g = (1, 2, 3, 0)                      # 4-cycle generates C4 on {0,1,2,3}
+    G = closure([g], n)
+    subs = [s for s in all_subgroups(G, n) if s <= G]
+    ident = tuple(range(n))
+    g2 = compose(g, g)
+    N = closure([g2], n)                  # <g^2>, order 2 = ker phi
+    triv = frozenset([ident])
+
+    # phi : C4 -> C2 (C2 realized on {0,1}); phi(g^k) = (1,0)^k.
+    c2_id, c2_swap = (0, 1), (1, 0)
+    phi = {}
+    cur = ident
+    img = c2_id
+    for _ in range(len(G)):
+        phi[cur] = img
+        cur = compose(cur, g)
+        img = compose(img, c2_swap)
+
+    hom_ok = is_homomorphism(phi, G, n)
+    cover_ok = is_max_norm(triv, N, subs, n)          # {e} <| <g^2> in C4
+    phi_triv = map_subgroup(triv, phi)
+    phi_N = map_subgroup(N, phi)
+    collapses = (phi_triv == phi_N)                    # image step is non-strict
+    # The image is not a covering: phi(triv) is not maximal-normal in phi(N).
+    not_a_cover = (phi_triv == phi_N)                  # equal => not H < K
+
+    ok = hom_ok and cover_ok and collapses and not_a_cover
+    print(f"[{'PASS' if ok else 'FAIL'}] map-obstruction (C4 -->phi C2): "
+          f"phi hom={hom_ok}, "
+          f"source cover {{e}}<|<g^2>={cover_ok}, "
+          f"image collapses phi({{e}})==phi(<g^2>)={collapses} "
+          f"==> Subgroup.map phi is NOT an IsMaxNorm RelSeries.Hom")
+    return ok
+
+
 def main():
     results = []
     # Klein four V4 = C2xC2: 3 maximal subgroups (all index 2, normal) -> rich A1.
@@ -161,12 +233,19 @@ def main():
     results.append(check_group("D4 (dihedral, order 8)",
                                [(1, 2, 3, 0), (0, 3, 2, 1)], 4))
 
+    # Map half of the TODO: the naive Subgroup.map phi is not a RelSeries.Hom.
+    print()
+    results.append(check_map_obstruction())
+
     print("\n=== RESULT ===")
     if all(results):
-        print("All JordanHolderLattice axiom checks PASS on V4, C6, S3, D4.")
+        print("All JordanHolderLattice axiom checks PASS on V4, C6, S3, D4,")
+        print("and the map-obstruction witness confirms `Subgroup.map phi` is not")
+        print("an `IsMaxNorm` RelSeries.Hom (maximality not stable under images).")
         print("Validates the (proved, 0-sorry) Lean instance's A1/A2 on examples;")
-        print("the upstreaming question is packaging (global-instance diamonds),")
-        print("not provability. See state.md.")
+        print("the instance-upstreaming question is packaging (global-instance")
+        print("diamonds), and the map-API question needs phi restricted (not the")
+        print("trivial `RelSeries.map (Subgroup.map phi)`). See state.md.")
     else:
         print("FAILURES present.")
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
Build-free ORIENT deepening of OQ-04-OQ-01 ("can `JordanHolderLattice (Subgroup G)` go upstream to Mathlib?"). Two additive findings over the S1 survey:

1. **OQ re-confirmed OPEN at master.** The `Mathlib/Order/JordanHolder.lean` TODO/NOTE block (L51-68) is present at both the repo pin `v4.26.0` and current master (master grew 420→454 LOC, now under `@[expose] public section`, but the TODO text is unchanged). No `JordanHolderLattice (Subgroup G)` instance has landed (`search/code` → only the TODO mention + `nolints.json`); no `ModularLattice` instance either. The OQ does **not** auto-close.

2. **The map-API half of the TODO is sharpened.** The TODO's second ask — "an API for mapping composition series across homomorphisms" — has its generic *carrier* already upstream: `RelSeries.map (p) (f : r.Hom s)` (`Order/RelSeries.lean:372`, at pin **and** master). So the missing piece is the **group-specific `RelSeries.Hom` builder**, and the naive candidate `Subgroup.map φ` is **not** an `IsMaxNorm`-preserving hom — maximal-normality is not stable under images with nontrivial kernel. The map API must restrict φ (injective) or route quotient steps through the second isomorphism theorem.

## Durable artifact
`verify_jordan_holder_lattice.py` gains `check_map_obstruction()`: `G = C4`, kernel `N = ⟨g²⟩`, quotient `φ : C4 ↠ C2`. The composition-series covering `{e} ◁ ⟨g²⟩` maps to `φ{e} = φ⟨g²⟩ = {e}` — a non-strict (non-covering) step — so `Subgroup.map φ` fails the `r.Hom s` step law. The full script still exits 0 (A1/A2 on V4/C6/S3/D4 **+** the new obstruction).

## Verification status
- **Math/master-survey**: re-checked via `gh api` against `v4.26.0` and master; obstruction verified by the extended cert (exit 0).
- **Lean build**: none this session — dual backend blackout (Docker `docker info` timeout; Aristotle MCP `prove` → "Resource not found"). This is an ORIENT session: doc + cert only, **no Lean file added/changed**, nothing registered, aggregate build untouched.

## Test plan
- [ ] `python3 research/problems/abel-ruffini-galois-extensions-oq-04-oq-01/verify_jordan_holder_lattice.py` → "ALL ... PASS", exit 0.
- [ ] (next session, build host) draft the injective-φ `RelSeries.Hom` builder and confirm it does NOT trip the obstruction (injective ⇒ trivial kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)