### PR TITLE
research(lagrange-four-squares-oq-01-oq-03): S1 ORIENT — Jacobi four-square count formula pinned + verified; Mathlib gap + formalizability verdict

### DIFF
--- a/research/problems/lagrange-four-squares-oq-01-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-03/knowledge.md
@@ -1,0 +1,87 @@
+# Knowledge Base: lagrange-four-squares-oq-01-oq-03
+
+**OQ**: "What is the exact count of four-square representations of n, and can the
+Jacobi four-square formula `r4(n) = 8·Σ_{d|n, 4∤d} d` be formalized?"
+**Parent**: `lagrange-four-squares-oq-01` (computational complexity of four-square
+representations; `Proofs/LagrangeFourSquaresOQ01.lean` — search bounds + greedy
+algorithm, NOT a count).
+
+---
+
+## Problem Understanding (S1 ORIENT, researcher-6, 2026-06-15)
+
+The exact count is **Jacobi's four-square theorem** (1834): for `n ≥ 1`,
+```
+r4(n) = 8 · Σ_{ d | n, 4 ∤ d } d
+```
+where `r4(n) := #{ (x₁,x₂,x₃,x₄) ∈ ℤ⁴ : x₁²+x₂²+x₃²+x₄² = n }` counts **ordered,
+signed** quadruples (zeros allowed). Equivalent closed forms (all three checked
+against the brute-force lattice count in `verify_jacobi_four_squares.py`, n=1..120):
+- `n` odd:  `r4(n) = 8 · σ(n)`.
+- `n` even: `r4(n) = 24 · σ(m)`, `m` = largest odd divisor of `n`.
+
+**Convention is the formalization trap.** The `8·` (and `24·`) prefactor encodes
+the sign/coordinate symmetries; `r4(1)=8`, `r4(2)=24`, `r4(3)=32`, `r4(4)=24`,
+`r4(5)=48`, `r4(7)=64`. The `4∤d` exclusion is **load-bearing**: at `n=4` the naive
+`8·σ(4)=56` is WRONG; the true value is `r4(4)=24` (drop `d=4`). The cert asserts
+this explicitly so a future Lean statement can't silently use `8·σ`.
+
+---
+
+## Mathlib inventory (surveyed 2026-06-15 vs master + pin v4.26.0)
+
+**The COUNT is a genuine Mathlib gap.** What exists is only *existence*:
+- `Mathlib/NumberTheory/SumFourSquares.lean`: Lagrange's theorem
+  `Nat.sum_four_squares` (every `n` IS a sum of four squares) + `euler_four_squares`
+  (the 4-square multiplicativity identity). **No `r4`, no count, no Jacobi formula.**
+- `Mathlib/NumberTheory/SumTwoSquares.lean`: Fermat's two-square theorem
+  (`Nat.Prime.sq_add_sq`, the `n` characterization). **No `r2` count** either —
+  the companion fact `r2(n) = 4·(d₁(n) − d₃(n))` is also absent.
+- `Archive/ZagierTwoSquares.lean`: Zagier's one-sentence proof — existence only.
+
+**All three classical proof routes are blocked by large gaps:**
+1. **Modular forms** (θ⁴ ∈ M₂(Γ₀(4)), Eisenstein basis 1-dim ⇒ formula). Mathlib
+   has *some* modular-forms machinery (≈14 Eisenstein hits) but not the weight-2
+   level-4 theta identity. Research-grade; ≫1000 LOC.
+2. **Hurwitz quaternions** (count Hurwitz integers of norm `n`; norm-multiplicativity
+   + unique factorization + unit group of order 24). Mathlib has `Quaternion` but
+   the Hurwitz/Lipschitz *order arithmetic* is essentially absent (1 search hit
+   each, no developed order). ≫1000 LOC.
+3. **Elementary / Lambert-series** (Liouville). Needs the `r2` count first (gap)
+   plus a Liouville-style convolution identity. Still several hundred LOC of new
+   number theory.
+
+---
+
+## Insight — the one elementary, formalizable reduction
+`r4 = r2 ⋆ r2` (Cauchy convolution): `r4(n) = Σ_{k=0}^{n} r2(k)·r2(n−k)`. This is
+pure rearrangement of the defining sum (split `(x₁,x₂)` from `(x₃,x₄)`), is
+**elementary and Lean-formalizable**, and is exactly the identity the cert uses to
+compute `r4`. It reduces the four-square count to the two-square count — but the
+`r2` closed form is itself a Mathlib gap, so the reduction doesn't close the OQ on
+its own.
+
+## Recommended ACT (tractable increment, NOT the general theorem)
+Mirror the parent OQ01's "verified for small cases" pattern and the konigsberg
+Matrix-Tree base-case oracle (PR #24324): define `r4` as a **computable
+`Finset.card`** over the bounded box `[-isqrt n, isqrt n]⁴` and prove
+`r4 n = jacobiCount n` for explicit small `n` by `decide`/`native_decide`. This is
+a real, buildable artifact (when Docker returns) that pins the convention and
+serves as a regression oracle, without claiming the (Mathlib-blocked) general
+proof. Honest verdict for the **general** theorem: **BLOCKED** (needs >1000 LOC of
+new Mathlib — quaternion orders or weight-2 modular forms).
+
+---
+
+## Dead Ends
+- `8·σ(n)` as the formula for all `n` — WRONG on even `n` (`n=4`: `56 ≠ 24`); the
+  `4∤d` exclusion (equivalently the odd/even `8·σ` / `24·σ(odd part)` split) is
+  mandatory.
+- Searching Mathlib for "Jacobi" finds only `JacobiSymbol` (quadratic-residue
+  symbol) — unrelated to the four-square *formula*.
+
+## Links
+- Parent: [[lagrange-four-squares-oq-01]] (four-square representation complexity).
+- Same build-free survey + durable-cert + small-n-oracle vein as
+  [[project-researcher-1-20260615-konigsberg-oq0401-matrixtree-basecases]] and
+  [[project-researcher-6-20260615-abelruffini-galois-oq040-mapapi-gap]].

--- a/research/problems/lagrange-four-squares-oq-01-oq-03/literature/README.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for lagrange-four-squares-oq-01-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/lagrange-four-squares-oq-01-oq-03/problem.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-03/problem.md
@@ -1,0 +1,122 @@
+# Problem: What is the exact count of four-square representations of n, and can the Jacobi four-square formula 
+
+**Slug**: lagrange-four-squares-oq-01-oq-03
+**Created**: 2026-06-15
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+What is the exact count of four-square representations of n, and can the Jacobi four-square formula r₄(n) = 8·Σ_{4∤d} d be formalized?
+$$
+
+### Plain Language
+
+This open question arises from the gallery proof `lagrange-four-squares-oq-01` (Computational Complexity of Four-Square Representations (OQ-01)). The Seeker selected it as a extension suitable for the autonomous research pipeline.
+
+The specific question: What is the exact count of four-square representations of n, and can the Jacobi four-square formula r₄(n) = 8·Σ_{4∤d} d be formalized?
+
+### Why This Matters
+
+Significance score 7/10 — the problem extends a verified gallery proof in a concrete direction. Closing it would add a extension-style follow-up to the gallery corpus and exercise machinery from the parent entry.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent proof `lagrange-four-squares-oq-01` — provides the base theorem and its Mathlib infrastructure
+- Sibling open questions on the same gallery entry — see `src/data/proofs/lagrange-four-squares/meta.json` `conclusion.openQuestions`
+
+### What's Still Open
+
+- The question stated above, as a extension of the parent result
+- Quantitative / constructive refinements that the Researcher may identify during OBSERVE
+
+### Our Goal
+
+Formulate the question as a Lean 4 theorem aligned with the parent entry's namespace, identify the Mathlib lemmas that close the gap, and either prove it or carve out a precise sub-claim that is tractable.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| lagrange-four-squares | Gallery root containing the open question | Parent definitions, Mathlib infrastructure used by the proof |
+| lagrange-four-squares-oq-01 | Immediate source of this open question | Source proof techniques carried over |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Mathlib search**: Survey Mathlib for definitions and lemmas matching the question's keywords; many gallery open questions reduce to wiring an existing Mathlib API.
+   - Why it might work: Mathlib has broad coverage of classical results adjacent to the gallery proofs
+   - Risk: The question may require a definition Mathlib lacks (e.g. a specialized object), in which case the work shifts to defining it
+
+2. **Sibling reuse**: Lift the parent proof's strategy and adapt it to the new statement.
+   - Why it might work: The original proof author already structured the gallery entry to make this kind of extension feasible
+   - Risk: The sibling lemmas may not generalize cleanly; bookkeeping can dominate
+
+### Key Difficulties
+
+- Need to identify the precise Lean 4 statement; the natural-language description leaves room for interpretation
+- Mathlib coverage may be partial — the OBSERVE phase must check which pieces exist
+
+### What Would a Proof Need?
+
+- Key lemma 1: a Lean 4 formal statement of the open question above
+- Key lemma 2: connecting Mathlib infrastructure to the parent entry's definitions
+- Technical requirements: see the parent proof file for relevant `import Mathlib.*` statements
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Seeker-assigned tractability score 5/10 reflects a likely-tractable direct extension
+- Parent entry is verified, so the surrounding Lean infrastructure is in place
+- Mathlib coverage of adjacent material is non-trivial; survey by the Scout in ORIENT is advisable
+
+**Estimated Effort**:
+- Exploration: 4-8 hours during OBSERVE/ORIENT
+- If tractable: 1-3 days for a clean theorem statement plus proof
+- If hard: weeks; consider carving a narrower sub-question
+
+## References
+
+### Papers
+- See the parent gallery entry's `references` array for citations to the originating literature
+
+### Online Resources
+- https://github.com/rjwalters/lean-genius — the gallery repository hosting the parent proof
+- Mathlib4 docs at https://leanprover-community.github.io/mathlib4_docs/ — for searching Mathlib namespaces relevant to the keywords below
+
+### Mathlib
+- Relevant Mathlib modules will surface during ORIENT; start from the parent proof's existing imports
+
+## Metadata
+
+```yaml
+tags:
+  - four-squares
+  - gallery-extracted
+  - lagrange-theorem
+  - number-theory
+  - quadratic-forms
+  - seeker-selected
+  - sums-of-squares
+related_proofs:
+  - lagrange-four-squares-oq-01
+  - lagrange-four-squares
+difficulty: medium
+source: gallery-gap
+created: 2026-06-15
+significance: 7
+tractability: 5
+tier: B
+category: extension
+```
+
+**Significance**: 7/10
+**Tractability**: 5/10

--- a/research/problems/lagrange-four-squares-oq-01-oq-03/state.md
+++ b/research/problems/lagrange-four-squares-oq-01-oq-03/state.md
@@ -1,0 +1,44 @@
+# Research State: lagrange-four-squares-oq-01-oq-03
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15 (S1, researcher-6 — OBSERVE→ORIENT)
+**Iteration**: 1
+
+## Current Focus
+The exact count is **Jacobi's four-square theorem**: `r4(n) = 8·Σ_{d|n,4∤d} d`
+(ordered, signed quadruples). Verified numerically n=1..120 (durable cert
+`verify_jacobi_four_squares.py`, exits 0) against both the divisor-sum form and
+the odd/even closed forms (`8·σ(n)` / `24·σ(odd part)`). Convention pinned
+(`r4(4)=24`, not the naive `8·σ(4)=56` — the `4∤d` exclusion is load-bearing).
+
+## Active Approach
+Formalizability assessment. The general theorem is **BLOCKED** by Mathlib gaps:
+Mathlib has four-square *existence* (`Nat.sum_four_squares`) but no *count*; the
+two-square count `r2` is also absent; and all three classical proof routes —
+weight-2 modular forms (θ⁴∈M₂(Γ₀(4))), Hurwitz-quaternion order arithmetic, and
+the elementary Lambert/Liouville method — each need ≫1000 LOC of new number theory.
+The one elementary Lean-able reduction is `r4 = r2 ⋆ r2` (Cauchy convolution), but
+it bottoms out on the missing `r2` count. Recommended tractable increment: a
+computable `Finset.card` definition of `r4` + `native_decide` small-n oracle
+(mirrors parent OQ01 and the konigsberg Matrix-Tree base-case oracle PR #24324).
+
+## Attempt Count
+- Total attempts: 0 (no Lean built — Docker down)
+- Current approach attempts: 0
+- Approaches tried: 1 surveyed (Mathlib inventory + 3 proof routes assessed)
+
+## Blockers
+- Docker build wrapper down (`docker info` timeout) — cannot compile Lean.
+- Aristotle MCP `prove` → "Resource not found" — cannot delegate.
+- **General-theorem blocker (math, not infra outage)**: Jacobi's formula needs
+  Hurwitz-quaternion orders OR weight-2 modular forms, neither developed in Mathlib.
+
+## Next Action
+When a build host returns: implement the small-n `native_decide` oracle
+(`r4 n = jacobiCount n` for n ≤ ~30) as a build-pending UNREGISTERED file —
+real, checkable, convention-pinning, without overclaiming the blocked general
+theorem. Re-run `verify_jacobi_four_squares.py` to re-confirm the arithmetic.
+Track Mathlib for any Hurwitz-quaternion or `r2`-count contribution that would
+unblock the general proof.

--- a/research/problems/lagrange-four-squares-oq-01-oq-03/verify_jacobi_four_squares.py
+++ b/research/problems/lagrange-four-squares-oq-01-oq-03/verify_jacobi_four_squares.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Durable verification cert for lagrange-four-squares-oq-01-oq-03.
+
+OQ-01-OQ-03: "What is the exact count of four-square representations of n, and can
+the Jacobi four-square formula r4(n) = 8 * sum_{d|n, 4 does-not-divide d} d be
+formalized?"
+
+Here r4(n) := #{ (x1,x2,x3,x4) in Z^4 : x1^2 + x2^2 + x3^2 + x4^2 = n }, counting
+ORDERED, SIGNED quadruples (so e.g. r4(1) = 8: one coord is +-1, three are 0).
+
+**Jacobi's four-square theorem** (1834): for every n >= 1,
+        r4(n) = 8 * sum_{ d | n, 4 !| d } d.
+Equivalent closed forms (also checked):
+  * n odd        :  r4(n) = 8  * sigma(n)
+  * n even       :  r4(n) = 24 * sigma(m), where m = largest odd divisor of n.
+
+This cert brute-forces r4(n) (signed lattice-point count) and compares it to the
+divisor-sum formula for n = 1..N, and independently cross-checks the two odd/even
+closed forms. It is a regression oracle for any future Lean formalization and
+pins down EXACTLY which arithmetic function the formula computes (sign/order
+conventions are the usual formalization trap).
+
+Pure stdlib. r4 brute force is O(N^2) lattice points per n; N=120 runs in ~1s.
+"""
+
+from math import isqrt
+
+
+def r4_bruteforce(n):
+    """Count ordered signed (x1,x2,x3,x4) in Z^4 with sum of squares = n."""
+    if n == 0:
+        return 1  # the all-zero quadruple
+    b = isqrt(n)
+    # precompute squares and their multiplicity contribution via two-square counts
+    # r2(k) = #{(a,b) in Z^2 : a^2+b^2 = k}; then r4(n) = sum_k r2(k) r2(n-k).
+    r2 = [0] * (n + 1)
+    for a in range(-b, b + 1):
+        a2 = a * a
+        if a2 > n:
+            continue
+        rem = n - a2
+        rb = isqrt(rem)
+        for bb in range(-rb, rb + 1):
+            s = a2 + bb * bb
+            if s <= n:
+                r2[s] += 1
+    total = 0
+    for k in range(n + 1):
+        total += r2[k] * r2[n - k]
+    return total
+
+
+def divisors(n):
+    ds = []
+    i = 1
+    while i * i <= n:
+        if n % i == 0:
+            ds.append(i)
+            if i != n // i:
+                ds.append(n // i)
+        i += 1
+    return sorted(ds)
+
+
+def jacobi_formula(n):
+    """8 * sum of divisors d of n with 4 does-not-divide d."""
+    return 8 * sum(d for d in divisors(n) if d % 4 != 0)
+
+
+def sigma(n):
+    return sum(divisors(n))
+
+
+def odd_part(n):
+    while n % 2 == 0:
+        n //= 2
+    return n
+
+
+def closed_form(n):
+    """Odd/even split closed form (independent re-derivation of jacobi_formula)."""
+    if n % 2 == 1:
+        return 8 * sigma(n)
+    return 24 * sigma(odd_part(n))
+
+
+def main():
+    N = 120
+    fails = 0
+    spot = {1: 8, 2: 24, 3: 32, 4: 24, 5: 48, 6: 96, 7: 64}
+    for n in range(1, N + 1):
+        r = r4_bruteforce(n)
+        j = jacobi_formula(n)
+        c = closed_form(n)
+        if not (r == j == c):
+            fails += 1
+            print(f"[FAIL] n={n}: r4={r}, jacobi={j}, closed_form={c}")
+        if n in spot and r != spot[n]:
+            fails += 1
+            print(f"[FAIL] spot-check n={n}: r4={r} != expected {spot[n]}")
+
+    print(f"Checked n = 1..{N}: r4(n) == 8*sum_{{d|n,4!|d}}d == odd/even closed form.")
+    print("Spot anchors: r4(1)=8, r4(2)=24, r4(3)=32, r4(4)=24, r4(5)=48, r4(7)=64.")
+    # sanity: r4(4)=24 (NOT 8*sigma(4)=56) because d=4 is excluded by 4 !| d.
+    assert jacobi_formula(4) == 24, "the 4 !| d exclusion is load-bearing at n=4"
+    assert 8 * sigma(4) == 56, "naive 8*sigma would give the WRONG value at n=4"
+
+    print("\n=== RESULT ===")
+    if fails == 0:
+        print("ALL CHECKS PASSED: Jacobi's four-square count formula verified, n=1..120.")
+        print("Mathlib has Lagrange EXISTENCE (Nat.sum_four_squares) but not this COUNT;")
+        print("the n=4 case shows the `4 does-not-divide d` exclusion is essential")
+        print("(naive 8*sigma(4)=56 != r4(4)=24). See knowledge.md for the formalization path.")
+    else:
+        print(f"{fails} FAILURES present.")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
OBSERVE→ORIENT on OQ-01-OQ-03 ("exact count of four-square representations; can the Jacobi formula be formalized?"). Build-free.

- **The exact count is Jacobi's four-square theorem**: `r4(n) = 8·Σ_{d|n, 4∤d} d`, where `r4(n)` counts **ordered, signed** quadruples `(x₁,x₂,x₃,x₄) ∈ ℤ⁴` with `Σxᵢ² = n`. Equivalent odd/even closed forms: `8·σ(n)` for odd `n`, `24·σ(odd part)` for even `n`.
- **Durable cert** `verify_jacobi_four_squares.py` (stdlib, exit 0): brute-force signed lattice count `== 8·Σ_{d|n,4∤d}d == ` odd/even closed form for `n = 1..120`, with spot anchors `r4(1..7)`. Asserts the **load-bearing `4∤d` exclusion**: at `n=4` the naive `8·σ(4)=56` is wrong; the true `r4(4)=24`.
- **Mathlib survey (master + pin v4.26.0)**: only four-square *existence* is present (`Nat.sum_four_squares`); the *count* is absent, as is even the two-square count `r2`. All three classical proof routes are blocked by large gaps — weight-2 modular forms (θ⁴∈M₂(Γ₀(4))), Hurwitz-quaternion order arithmetic, and the elementary Lambert/Liouville method each need ≫1000 LOC of new number theory.
- **Verdict**: general theorem **BLOCKED**. The one elementary Lean-able reduction is `r4 = r2 ⋆ r2` (Cauchy convolution), but it bottoms out on the missing `r2` count. Recommended tractable increment: a computable `Finset.card` definition of `r4` + a `native_decide` small-`n` oracle (mirrors parent OQ01 and the konigsberg Matrix-Tree base-case oracle #24324).

## Verification status
- **Math**: `verify_jacobi_four_squares.py` exits 0 (n=1..120). Mathlib gap re-checked via `gh api` search against master + v4.26.0.
- **Lean build**: none — dual backend blackout (Docker `docker info` timeout; Aristotle MCP `prove` → "Resource not found"). ORIENT session: cert + docs only, **no Lean file added/changed**, nothing registered.

## Test plan
- [ ] `python3 research/problems/lagrange-four-squares-oq-01-oq-03/verify_jacobi_four_squares.py` → "ALL CHECKS PASSED", exit 0.
- [ ] (next session, build host) implement the `native_decide` small-`n` oracle as a build-pending UNREGISTERED file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)