### PR TITLE
research(inverse-galois-a5-oq-02): ACT — prove PSL(2,7) simplicity-collapse as group theory; staged axiomatized Trinks entry

### DIFF
--- a/proofs/Proofs/InverseGaloisA5OQ02.lean
+++ b/proofs/Proofs/InverseGaloisA5OQ02.lean
@@ -1,0 +1,189 @@
+import Mathlib
+
+/-
+# PSL(2,7) (order 168) as a Galois Group over ℚ — Trinks' polynomial (Inverse-Galois A₅, OQ-02)
+
+## The open question
+
+Extend the gallery's `inverse-galois-a5` (an explicit quintic with Galois group A₅,
+the smallest non-solvable simple group) to the *next* simple non-solvable group,
+`PSL(2,7) ≅ GL(3,2)`, the simple group of order 168 (automorphism group of the Klein
+quartic and of the Fano plane).
+
+## The witness
+
+Trinks' polynomial (Trinks 1968)
+
+  `f(x) = x⁷ − 7x + 3`,    `Gal(f/ℚ) ≅ PSL(2,7)`.
+
+PSL(2,7) acts on the 7 points of the Fano plane (the 7 nonzero vectors of 𝔽₂³), giving
+a degree-7 permutation realization inside S₇.
+
+## The certificate (proved exactly in `verify_trinks_psl27.py`)
+
+1. `f mod 2 = x⁷ + x + 1` is irreducible over 𝔽₂  ⟹  f irreducible over ℚ  ⟹  transitive
+   ⟹  `7 ∣ |Gal|`.
+2. `disc(f) = 3⁸·7⁸ = 194481²` is a perfect square  ⟹  `Gal ⊆ A₇`.
+3. Frobenius cycle types `{(7),(1,2,4),(1,3,3),(1,1,1,2,2)}` (first witnessing primes
+   2, 13, 17, 79) give elements of orders 7, 4, 3  ⟹  `lcm(7,4,3) = 84 ∣ |Gal|`.
+4. The degree-15 PSL(2,7)-resolvent (`[A₇ : PSL(2,7)] = 15`) has a rational root
+   ⟹  `Gal` is conjugate *into* `PSL(2,7)`, i.e. `|Gal| ∣ 168`.
+5. **Simplicity collapse** (the key structural insight): `84 ∣ |Gal|` and `|Gal| ∣ 168`
+   leave only `|Gal| ∈ {84, 168}`; a subgroup of `PSL(2,7)` of order 84 would have
+   index 2, hence be normal, contradicting the *simplicity* of `PSL(2,7)`.  Therefore
+   `|Gal| = 168` and `Gal = PSL(2,7)`.
+
+## What this file proves vs. axiomatizes
+
+This is a *staged* `axiomatized` entry (the full ACT is genuinely multi-week: the
+degree-15 resolvent of step 4 and a Lean construction of `PSL(2,7)` are the heavy
+parts, neither of which is in Mathlib).
+
+**Proved here (genuine, build-checkable group theory — the session's key content):**
+* `simple168_subgroup_card_collapse` — step 5 as a general theorem: a subgroup of a
+  simple group of order 168 with `84 ∣ |H|` is the whole group.  This is the rigorous
+  backing for the "collapse" that removes the need to classify all transitive subgroups
+  of A₇.
+* `card_eq_168_of_embeds_in_simple168` — the reusable corollary: any group with
+  `84 ∣ |G|` that injects into a simple group of order 168 has order exactly 168.
+* `trinks_disc_is_square` — the discriminant value is a perfect square (`194481²`).
+* `trinks_gal_card` — assembles `|Gal| = 168` from the certificate.
+
+**Axiomatized (the deep analytic certificate, steps 1–4 specialized to `f`):**
+* `trinks_gal_84_dvd`        — steps 1+3 (Dedekind cycle types ⟹ `84 ∣ |Gal|`).
+* `trinks_gal_card_dvd_168`  — steps 1+2+4 (irreducibility + square disc + resolvent
+                               ⟹ `Gal ⊆ PSL(2,7)`, so `|Gal| ∣ 168`).
+* `trinks_gal_card_ne_84`    — step 5 specialized; the *reason* it holds is exactly
+                               `simple168_subgroup_card_collapse`, proved above.
+
+Mirrors the `InverseGaloisA5.lean` template (which carries out the analogous A₅
+argument with hand-built "square-disc ⟹ ⊆ Aₙ" and per-prime cycle-type lemmas).
+The Mathlib API used in the collapse proof matches `AbelRuffiniOQ04OQ01.lean`
+(`Subgroup.normal_of_index_eq_two`, `IsSimpleGroup.eq_bot_or_eq_top_of_normal`,
+`Subgroup.card_mul_index`, `Subgroup.card_subgroup_dvd_card`).
+-/
+
+set_option linter.unusedVariables false
+
+open Polynomial
+
+namespace InverseGaloisA5OQ02
+
+/-! ## The polynomial -/
+
+/-- **Trinks' polynomial** `f(x) = x⁷ − 7x + 3` (Trinks 1968), with
+`Gal(f/ℚ) ≅ PSL(2,7)`. -/
+noncomputable def trinks : Polynomial ℚ := X ^ 7 - 7 * X + 3
+
+/-! ## Step 2 (arithmetic part): the discriminant is a perfect square
+
+`disc(f) = 37822859361 = 3⁸·7⁸ = (3⁴·7⁴)² = 194481²`.  This integer identity is the
+square-discriminant witness behind `Gal ⊆ A₇` (the bridge "square disc ⟹ ⊆ Aₙ" itself
+is hand-built in the A₅ template; the actual `Polynomial.discr trinks = …` computation
+for a degree-7 polynomial is part of the deferred ACT). -/
+theorem trinks_disc_is_square : (37822859361 : ℤ) = 194481 ^ 2 := by norm_num
+
+/-- The discriminant value also factors as `3⁸·7⁸`, confirming the prime structure
+behind the unramified primes `{3, 7}`. -/
+theorem trinks_disc_factorization : (37822859361 : ℤ) = 3 ^ 8 * 7 ^ 8 := by norm_num
+
+/-! ## Step 5: the simplicity collapse (general finite group theory)
+
+This is the substantive content proved in this session.  It isolates *why* the
+order-168 conclusion follows from the divisibility data, without enumerating the
+transitive subgroups of A₇. -/
+
+/-- **Simplicity collapse.**  Let `G` be a finite simple group of order 168.  Any
+subgroup `H` with `84 ∣ |H|` is the whole group.
+
+Reason: `|H| ∣ 168` (Lagrange) together with `84 ∣ |H|` forces `|H| ∈ {84, 168}`.
+If `|H| = 84` then `[G : H] = 2`, so `H` is normal; but `G` is simple, so `H = ⊥`
+or `H = ⊤`, neither of which has order 84 — contradiction.  Hence `|H| = 168 = |G|`,
+i.e. `[G : H] = 1` and `H = ⊤`. -/
+theorem simple168_subgroup_card_collapse
+    {G : Type*} [Group G] [Finite G] (hsimple : IsSimpleGroup G)
+    (hG : Nat.card G = 168) (H : Subgroup G) (h84 : 84 ∣ Nat.card H) :
+    H = ⊤ := by
+  have hdvd : Nat.card H ∣ Nat.card G := Subgroup.card_subgroup_dvd_card H
+  have hmul : Nat.card H * H.index = Nat.card G := Subgroup.card_mul_index H
+  rw [hG] at hdvd hmul
+  have hpos : 0 < Nat.card H := Nat.pos_of_dvd_of_pos hdvd (by norm_num)
+  have hle : Nat.card H ≤ 168 := Nat.le_of_dvd (by norm_num) hdvd
+  obtain ⟨k, hk⟩ := h84
+  -- `|H| ∈ {84, 168}`.
+  have hcase : Nat.card H = 84 ∨ Nat.card H = 168 := by
+    rw [hk] at hpos hle ⊢
+    have hk' : k = 1 ∨ k = 2 := by omega
+    rcases hk' with h | h <;> subst h <;> omega
+  rcases hcase with h84' | h168
+  · -- Order 84 ⟹ index 2 ⟹ normal ⟹ contradiction with simplicity.
+    exfalso
+    have hidx : H.index = 2 := by rw [h84'] at hmul; omega
+    haveI : H.Normal := Subgroup.normal_of_index_eq_two hidx
+    rcases hsimple.eq_bot_or_eq_top_of_normal H inferInstance with h | h
+    · rw [h, Subgroup.index_bot, hG] at hidx; omega
+    · rw [h, Subgroup.index_top] at hidx; omega
+  · -- Order 168 = |G| ⟹ index 1 ⟹ `H = ⊤`.
+    have hidx : H.index = 1 := by rw [h168] at hmul; omega
+    exact Subgroup.index_eq_one.mp hidx
+
+/-- **Embedding corollary.**  If a finite group `Gal` with `84 ∣ |Gal|` injects into a
+simple group of order 168, then `|Gal| = 168` (and the injection is an isomorphism onto
+the target).  This is the abstract form of the certificate's conclusion: the analytic
+steps 1–4 supply an injection `Gal ↪ PSL(2,7)` with `84 ∣ |Gal|`. -/
+theorem card_eq_168_of_embeds_in_simple168
+    {Gal P : Type*} [Group Gal] [Finite Gal] [Group P] [Finite P]
+    (hP : IsSimpleGroup P) (hPcard : Nat.card P = 168)
+    (φ : Gal →* P) (hφ : Function.Injective φ) (h84 : 84 ∣ Nat.card Gal) :
+    Nat.card Gal = 168 := by
+  have e : Gal ≃* φ.range := MonoidHom.ofInjective hφ
+  have hcard_eq : Nat.card φ.range = Nat.card Gal := Nat.card_congr e.toEquiv.symm
+  have h84' : 84 ∣ Nat.card φ.range := by rw [hcard_eq]; exact h84
+  have htop : (φ.range : Subgroup P) = ⊤ :=
+    simple168_subgroup_card_collapse hP hPcard φ.range h84'
+  have hrange : Nat.card φ.range = Nat.card P := by
+    rw [htop]; exact Nat.card_congr Subgroup.topEquiv.toEquiv
+  rw [← hcard_eq, hrange, hPcard]
+
+/-! ## The deep certificate facts (steps 1–4, specialized to `f`)
+
+These encode the analytic inputs of the certificate.  Each is verified exactly in
+`verify_trinks_psl27.py`; the Lean discharge is the deferred multi-week ACT
+(Dedekind's theorem and the degree-15 resolvent are not in Mathlib). -/
+
+/-- **Steps 1 + 3** (Dedekind cycle types).  `f mod 2 = x⁷+x+1` irreducible ⟹ a 7-cycle
+(`7 ∣ |Gal|`); `f mod 13` has type `(1,2,4)` ⟹ an order-4 element (`4 ∣ |Gal|`);
+`f mod 17` has type `(1,3,3)` ⟹ an order-3 element (`3 ∣ |Gal|`).  Hence
+`lcm(7,4,3) = 84 ∣ |Gal|`. -/
+axiom trinks_gal_84_dvd : 84 ∣ Nat.card trinks.Gal
+
+/-- **Steps 1 + 2 + 4** (irreducibility + square discriminant + degree-15 resolvent).
+Irreducibility gives transitivity; the square discriminant gives `Gal ⊆ A₇`; the
+PSL(2,7)-resolvent's rational root gives `Gal` conjugate into `PSL(2,7)`.  Together
+`|Gal| ∣ |PSL(2,7)| = 168`. -/
+axiom trinks_gal_card_dvd_168 : Nat.card trinks.Gal ∣ 168
+
+/-- **Step 5** (simplicity collapse, specialized).  `Gal ⊆ PSL(2,7)` and `84 ∣ |Gal|`
+exclude `|Gal| = 84`: such a subgroup would have index 2 in the *simple* group
+`PSL(2,7)`, hence be normal — impossible.  The general reason is proved above as
+`simple168_subgroup_card_collapse`. -/
+axiom trinks_gal_card_ne_84 : Nat.card trinks.Gal ≠ 84
+
+/-! ## Main result -/
+
+/-- **Trinks' polynomial realizes a Galois group of order 168 over ℚ.**
+
+`|Gal(f/ℚ)| = 168 = |PSL(2,7)|`.  Combined with `Gal ⊆ PSL(2,7)` (the divisibility
+axiom) this pins `Gal(f/ℚ) = PSL(2,7)`, the second simple non-solvable Galois group
+realized in the gallery after A₅. -/
+theorem trinks_gal_card : Nat.card trinks.Gal = 168 := by
+  have h1 := trinks_gal_84_dvd
+  have h2 := trinks_gal_card_dvd_168
+  have h3 := trinks_gal_card_ne_84
+  obtain ⟨k, hk⟩ := h1
+  have hle : Nat.card trinks.Gal ≤ 168 := Nat.le_of_dvd (by norm_num) h2
+  have hpos : 0 < Nat.card trinks.Gal := Nat.pos_of_dvd_of_pos h2 (by norm_num)
+  rw [hk] at hle hpos h3 ⊢
+  omega
+
+end InverseGaloisA5OQ02

--- a/research/problems/inverse-galois-a5-oq-02/verify_collapse.py
+++ b/research/problems/inverse-galois-a5-oq-02/verify_collapse.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Independent verification of the *simplicity-collapse* argument formalized in
+`proofs/Proofs/InverseGaloisA5OQ02.lean` (theorem `simple168_subgroup_card_collapse`).
+
+The Lean theorem says: in a finite simple group G of order 168, any subgroup H with
+84 | |H| equals the whole group. This script checks the purely arithmetic and
+group-structural facts the proof relies on, plus the GL(3,2)=PSL(2,7) data behind the
+cycle-type certificate. No floats; exact integer / finite-field arithmetic only.
+"""
+
+from itertools import product
+
+ok = True
+def check(name, cond):
+    global ok
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+    ok = ok and cond
+
+print("== Collapse arithmetic ==")
+divs = [d for d in range(1, 169) if 168 % d == 0]
+mult84 = [d for d in divs if d % 84 == 0]
+check("divisors of 168 that are multiples of 84 are exactly {84,168}", mult84 == [84, 168])
+# index of an order-84 subgroup in a group of order 168 is 2 (the normal/simple crux)
+check("[168 : 84] = 2", 168 // 84 == 2)
+# index of an order-168 subgroup is 1 (=> whole group)
+check("[168 : 168] = 1", 168 // 168 == 1)
+# 84 = lcm(7,4,3) (the cycle-type input)
+import math
+check("lcm(7,4,3) = 84", math.lcm(7, 4, 3) == 84)
+
+print("== Order 168 factorization ==")
+check("168 = 2^3 * 3 * 7", 168 == 2**3 * 3 * 7)
+check("disc = 3^8 * 7^8 = 194481^2", 3**8 * 7**8 == 194481**2 == 37822859361)
+
+print("== GL(3,2) = PSL(2,7): order and cycle-type classes on 7 Fano points ==")
+# Build GL(3,2): invertible 3x3 matrices over F2, acting on the 7 nonzero vectors.
+F = [0, 1]
+vecs = [v for v in product(F, repeat=3) if any(v)]   # 7 nonzero vectors of F2^3
+assert len(vecs) == 7
+vindex = {v: i for i, v in enumerate(vecs)}
+
+def matvec(M, v):
+    return tuple(sum(M[r][c] * v[c] for c in range(3)) % 2 for r in range(3))
+
+def is_invertible(M):
+    # 3x3 over F2 invertible iff det == 1 (mod 2)
+    det = (
+        M[0][0]*(M[1][1]*M[2][2]-M[1][2]*M[2][1])
+        - M[0][1]*(M[1][0]*M[2][2]-M[1][2]*M[2][0])
+        + M[0][2]*(M[1][0]*M[2][1]-M[1][1]*M[2][0])
+    )
+    return det % 2 == 1
+
+def cycle_type(perm):
+    n = len(perm); seen = [False]*n; t = []
+    for i in range(n):
+        if not seen[i]:
+            ln = 0; j = i
+            while not seen[j]:
+                seen[j] = True; j = perm[j]; ln += 1
+            t.append(ln)
+    return tuple(sorted(t))
+
+mats = []
+for entries in product(F, repeat=9):
+    M = [list(entries[0:3]), list(entries[3:6]), list(entries[6:9])]
+    if is_invertible(M):
+        mats.append(M)
+
+check("|GL(3,2)| = 168", len(mats) == 168)
+
+from collections import Counter
+type_counts = Counter()
+for M in mats:
+    perm = [vindex[matvec(M, v)] for v in vecs]
+    type_counts[cycle_type(perm)] += 1
+
+# Expected class sizes on the 7 points: identity 1^7:1, 2^2 1^3:21, 4.2.1:42, 3^2.1:56, 7:48
+expected = {(1,1,1,1,1,1,1):1, (1,1,1,2,2):21, (1,2,4):42, (1,3,3):56, (7,):48}
+check("cycle-type class sizes match PSL(2,7) on Fano points", dict(type_counts) == expected)
+check("class sizes sum to 168", sum(type_counts.values()) == 168)
+# Element orders present are exactly {1,2,3,4,7} (no 5- or 6-cycle => not A7)
+orders_present = set()
+for t in type_counts:
+    orders_present.add(math.lcm(*t) if len(t) > 1 else t[0])
+check("element orders are exactly {1,2,3,4,7}", orders_present == {1,2,3,4,7})
+
+print()
+print("ALL CHECKS PASSED" if ok else "SOME CHECKS FAILED")
+exit(0 if ok else 1)

--- a/src/data/proofs/inverse-galois-a5-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-02/meta.json
@@ -1,0 +1,67 @@
+{
+  "id": "inverse-galois-a5-oq-02",
+  "title": "PSL(2,7) (order 168) as a Galois Group over ℚ: Trinks' Polynomial",
+  "slug": "inverse-galois-a5-oq-02",
+  "description": "Stages the realization of PSL(2,7) ≅ GL(3,2) (the second-smallest non-abelian simple group, order 168) as a Galois group over ℚ, extending the gallery's A₅ realization. Witness: Trinks' polynomial f(x) = x⁷ − 7x + 3 (1968). The session's key content is the simplicity-collapse argument proved as general finite group theory: in a simple group of order 168, any subgroup with 84 dividing its order is the whole group — this removes the need to classify the transitive subgroups of A₇. The analysis-heavy certificate steps (Dedekind cycle types, square discriminant, degree-15 resolvent) are axiomatized.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
+    "date": "Trinks 1968 (polynomial); PSL(2,7) realizability classical; formalized 2026",
+    "status": "axiomatized",
+    "tags": [
+      "galois-theory",
+      "inverse-galois-problem",
+      "PSL-2-7",
+      "simple-group",
+      "polynomial-irreducibility",
+      "discriminant",
+      "non-solvable",
+      "open-problem"
+    ],
+    "proofRepoPath": "Proofs/InverseGaloisA5OQ02.lean",
+    "additionalFiles": [
+      "Proofs/InverseGaloisA5.lean"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "assumptions": "3 axioms encoding the analytic certificate for f(x) = x⁷ − 7x + 3, all verified exactly in verify_trinks_psl27.py: (1) `trinks_gal_84_dvd` — 84 ∣ |Gal| from Dedekind cycle types (f mod 2 irreducible ⟹ 7-cycle; f mod 13 type (1,2,4) ⟹ order 4; f mod 17 type (1,3,3) ⟹ order 3); (2) `trinks_gal_card_dvd_168` — |Gal| ∣ 168 from irreducibility + square discriminant (disc = 3⁸·7⁸ = 194481²) ⟹ Gal ⊆ A₇, plus the degree-15 PSL(2,7)-resolvent's rational root ⟹ Gal ⊆ PSL(2,7); (3) `trinks_gal_card_ne_84` — |Gal| ≠ 84 by simplicity, whose rigorous reason is the proved theorem `simple168_subgroup_card_collapse`. None of Dedekind's theorem, 'square disc ⟹ ⊆ Aₙ', or the degree-15 resolvent is in Mathlib 4.26.0; these are the genuinely multi-week deferred ACT.",
+    "originalContributions": [
+      "simple168_subgroup_card_collapse: in a finite simple group of order 168, any subgroup H with 84 ∣ |H| equals ⊤ (proved via Lagrange + index-2-normal + simplicity; the key insight that removes the A₇ transitive-subgroup classification)",
+      "card_eq_168_of_embeds_in_simple168: a finite group with 84 ∣ |G| injecting into a simple group of order 168 has order exactly 168 (reusable corollary via MonoidHom.ofInjective)",
+      "trinks_disc_is_square / trinks_disc_factorization: disc(f) = 37822859361 = 194481² = 3⁸·7⁸",
+      "trinks_gal_card: |Gal(f/ℚ)| = 168, assembled from the three certificate axioms",
+      "verify_collapse.py: independent verification of the collapse arithmetic and a full GL(3,2) enumeration (168 matrices, Fano-point cycle-type classes {1,21,42,56,48}, element orders {1,2,3,4,7})"
+    ],
+    "dateAdded": "2026-06-15",
+    "lineCount": 189,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "InverseGaloisA5OQ02",
+    "lineCount": 189,
+    "axiomCount": 3,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/InverseGaloisA5OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "extends",
+      "description": "A₅ (order 60) is the first non-solvable Galois realization; PSL(2,7) (order 168) is the next simple non-solvable group. This entry mirrors the A₅ template's irreducibility/discriminant/cycle-type strategy."
+    },
+    {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "related",
+      "description": "Lists PSL(2,7) (order 168) explicitly as the next target beyond A₅ on the non-solvable frontier."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

First **Lean ACT** for `inverse-galois-a5-oq-02` (realize **PSL(2,7) ≅ GL(3,2)**, order 168, as a Galois group over ℚ via **Trinks' polynomial** `f = x⁷ − 7x + 3`), building directly on the build-free ORIENT certificate in #24264. This is the staged `axiomatized` entry that ORIENT recommended — but with the **key structural insight (step 5) proved as general finite group theory** instead of axiomatized.

New file `proofs/Proofs/InverseGaloisA5OQ02.lean` (UNREGISTERED, build-pending — see below).

### Proved (genuine, build-checkable content)
- **`simple168_subgroup_card_collapse`** — *step 5 as a theorem*: in a finite simple group `G` of order 168, any subgroup `H` with `84 ∣ |H|` satisfies `H = ⊤`. Proof: Lagrange (`Subgroup.card_subgroup_dvd_card`) + `84 ∣ |H|` ⟹ `|H| ∈ {84,168}`; order 84 ⟹ index 2 (`Subgroup.card_mul_index`) ⟹ normal (`Subgroup.normal_of_index_eq_two`) ⟹ `⊥`/`⊤` (`IsSimpleGroup.eq_bot_or_eq_top_of_normal`), both excluded; order 168 ⟹ index 1 ⟹ `⊤`. **This is the insight that removes the need to classify the transitive subgroups of A₇.** Every Mathlib API name is cross-checked against `AbelRuffiniOQ04OQ01.lean:468-476`, which uses the identical idiom.
- **`card_eq_168_of_embeds_in_simple168`** — reusable corollary: a finite group with `84 ∣ |G|` injecting into a simple group of order 168 has order exactly 168.
- **`trinks_disc_is_square`** / `trinks_disc_factorization` — `disc(f) = 37822859361 = 194481² = 3⁸·7⁸`.
- **`trinks_gal_card`** — `|Gal(f/ℚ)| = 168`, assembled from the three certificate axioms via pure-ℕ `omega`.

### Axiomatized (the deep analytic certificate; 3 axioms, all in `verify_trinks_psl27.py`)
- `trinks_gal_84_dvd` — Dedekind cycle types ⟹ `84 ∣ |Gal|` (steps 1+3).
- `trinks_gal_card_dvd_168` — irreducibility + square disc + degree-15 resolvent ⟹ `Gal ⊆ PSL(2,7)` (steps 1+2+4).
- `trinks_gal_card_ne_84` — step 5 specialized; its rigorous *reason* is the proved `simple168_subgroup_card_collapse`.

None of Dedekind's theorem, "square disc ⟹ ⊆ Aₙ", or the degree-15 resolvent is in Mathlib 4.26.0 — these remain the genuinely multi-week deferred ACT.

### Verification
- `verify_collapse.py` (new) — independently checks the collapse arithmetic and re-enumerates `GL(3,2)` (168 matrices) on the 7 Fano points: class sizes `{1, 21, 42, 56, 48}`, element orders `{1,2,3,4,7}`. **ALL CHECKS PASSED.**
- `verify_trinks_psl27.py` (from #24264, retained) — full certificate. **ALL CHECKS PASSED.**

### Relationship to #24264
This PR supersedes the docs-only ORIENT #24264: it carries that PR's `knowledge.md` ORIENT writeup and `verify_trinks_psl27.py` forward unchanged and appends the ACT session notes + the Lean file + gallery `meta.json`. (If #24264 merges first, this is a clean append; otherwise this PR contains the superset.)

## Test plan
- [x] `python3 research/problems/inverse-galois-a5-oq-02/verify_collapse.py` → ALL CHECKS PASSED
- [x] `python3 research/problems/inverse-galois-a5-oq-02/verify_trinks_psl27.py` → ALL CHECKS PASSED
- [ ] Lean build deferred: Docker build host is **down** this session; file kept UNREGISTERED (not added to `Proofs.lean`) so it cannot break the safe-subset auto-merge. API names cross-checked against existing repo usage for compile-confidence. Build-verify and register when Docker returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)