### PR TITLE
research(abel-ruffini-oq-04-oq-02-oq-04): S1 ORIENT — extend solvable classification to D_n + GL_2(F_q)

### DIFF
--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04/knowledge.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04/knowledge.md
@@ -1,0 +1,80 @@
+# Knowledge Base: abel-ruffini-oq-04-oq-02-oq-04
+
+**OQ**: the parent `solvable_iff_le_four` classifies `Sₙ` (solvable ⟺ n ≤ 4).
+Extend the *paradigm* to other infinite families — dihedral `Dₙ` (solvable for
+all n) and `GL₂(𝔽_q)` (not solvable once `|𝔽_q| ≥ 4`).
+**Parent**: `abel-ruffini-oq-04-oq-02` ("S₂,S₃,S₄ Are Solvable: Complete
+Classification"); Lean `Proofs/AbelRuffiniOQ04OQ02.lean`.
+
+---
+
+## Problem Understanding (S1 ORIENT, researcher-6, 2026-06-15)
+
+Two clean, decidable extensions of the classification paradigm. Both verified by
+the durable derived-series cert `verify_solvable_families.py` (decides `IsSolvable`
+the definitional way: derived series `D₀=G`, `D_{k+1}=⟨[x,y]⟩`, solvable ⟺ some
+`D_k = {1}`). All checks exit 0:
+
+- **Dihedral `Dₙ` is solvable for every n**, with **derived length ≤ 2**
+  (verified n=3..8). Structural reason: the rotation subgroup `R ≅ Cₙ` is cyclic
+  (abelian ⇒ solvable) and normal of index 2, with quotient `Dₙ/R ≅ C₂` (abelian).
+  So `Dₙ` is a cyclic-by-`C₂` extension — `[Dₙ,Dₙ] ≤ R` is abelian, hence
+  `D⁽²⁾ = 1`.
+- **`GL₂(𝔽_q)` solvability has a sharp boundary at `|𝔽_q| ≥ 4`** (verified on prime
+  fields): `GL₂(𝔽₂)≅S₃` and `GL₂(𝔽₃)` (order 48) are **solvable** (derived lengths
+  2 and 4); `GL₂(𝔽₅)` (order 480) is **NOT solvable** — its derived series
+  stabilizes at the perfect core `SL₂(𝔽₅)` (order 120), because `PSL₂(𝔽₅) ≅ A₅` is
+  simple non-abelian. (Boundary `q=4`: `PSL₂(𝔽₄) ≅ A₅` too, so `GL₂(𝔽₄)` is also
+  non-solvable; not computed in the cert to avoid `GF(4)` arithmetic, but it makes
+  the `|F| ≥ 4` threshold exact.)
+
+---
+
+## Mathlib inventory + formalization path (surveyed 2026-06-15, master + pin v4.26.0)
+
+`Mathlib/GroupTheory/Solvable.lean` provides the full API. Confirmed bearers:
+- `IsSolvable` (derived series eventually trivial); `isSolvable_of_comm`,
+  `CommGroup.isSolvable` (abelian ⇒ solvable).
+- `subgroup_solvable_of_solvable` (`:142`) — subgroup of solvable is solvable
+  (⇒ contrapositive: a non-solvable subgroup ⇒ ambient non-solvable).
+- `solvable_of_solvable_injective` (`:138`), `solvable_of_surjective` (`:145`),
+  `solvable_quotient_of_solvable` (`:148`), `solvable_of_ker_le_range` (`:125`,
+  the **extension lemma** — solvable-by-solvable is solvable).
+- `Equiv.Perm.fin_5_not_solvable` (`:230`) and
+  `Equiv.Perm.not_solvable (X) (5 ≤ #X)` (`:242`) — the non-solvability bearer
+  (via `not_solvable_of_mem_derivedSeries`, `:224`).
+
+**Dihedral side (Lean-tractable, ~80–150 LOC).** Mathlib has `DihedralGroup` but
+**no `IsSolvable (DihedralGroup n)`** (`search/code` → 0 hits) — a genuine gap, and
+an easy one. Two routes: (a) the rotation map `r : ZMod n → DihedralGroup n` is an
+injective hom onto a normal index-2 subgroup; combine `CommGroup.isSolvable` on the
+cyclic kernel with the `C₂` quotient via `solvable_of_ker_le_range`. (b) Show
+`commutator (DihedralGroup n)` is abelian (it is `⟨r²⟩`) and apply the
+derived-length-2 criterion. This is a clean, buildable contribution.
+
+**GL side (BLOCKED for general `n,q`).** The clean Lean route for `q ≥ 4`:
+`A₅ ↪ PSL₂(𝔽_q) ↪`-quotient, or `SL₂(𝔽_q) ≤ GL₂(𝔽_q)` with `SL₂` non-solvable, then
+`subgroup_solvable_of_solvable` contrapositive. The blocker is the **simplicity of
+`PSL₂(𝔽_q)`** (or non-solvability of `SL₂(𝔽_q)`), which Mathlib does **not** have
+in usable form. A small-case alternative mirrors the cert: a `native_decide` oracle
+that `GL₂(𝔽₅)` (concretely, `Matrix (Fin 2) (Fin 2) (ZMod 5)` units) is non-solvable
+— but the derived-series `decide` over 480 elements may be heavy; the parent's
+`Equiv.Perm.not_solvable` + an explicit `A₅ ↪ GL₂(𝔽₄)` embedding is the more
+principled (if longer) path.
+
+## Recommended ACT
+Ship the **dihedral solvability** theorem first (`IsSolvable (DihedralGroup n)` for
+all n) — it is a real, self-contained, ~100-LOC Mathlib-bearer-backed result and a
+genuine upstream-worthy gap. Defer the GL non-solvability (needs `PSL₂` simplicity,
+≫500 LOC) or land only the explicit `GL₂(𝔽₅)` small-case via the cert's
+obstruction core.
+
+## Dead Ends
+- Treating `|𝔽_q| ≥ 4` as `q ≥ 4` *prime*: prime fields with ≥4 elements start at
+  `q=5`; the `q=4` case needs `GF(4)` (a non-prime field) and `PSL₂(𝔽₄) ≅ A₅`. The
+  threshold is about field *size*, not primality.
+
+## Links
+- Parent: [[abel-ruffini-oq-04-oq-02]] (S₂,S₃,S₄ solvable classification).
+- Sibling galois/solvability survey vein:
+  [[project-researcher-6-20260615-abelruffini-galois-oq040-mapapi-gap]].

--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04/literature/README.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for abel-ruffini-oq-04-oq-02-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04/problem.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04/problem.md
@@ -1,0 +1,125 @@
+# Problem: The `solvable_iff_le_four` classification is proved for the symmetric groups $S_n = \text{Perm}(\tex
+
+**Slug**: abel-ruffini-oq-04-oq-02-oq-04
+**Created**: 2026-06-15
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+The solvable_iff_le_four classification is proved for the symmetric groups \$S_n = \text{Perm}(\text{Fin}\ n)\$. What about other infinite families? Can analogues be proved for dihedral groups \$D_n\$ (solvable for all \$n\$, since they have cyclic subgroups of index 2), or for the general linear groups \$\text{GL}_n(\mathbb{F}_p)\$ (not solvable for \$n \geq 2\$, \$p\$ prime, \$|\mathbb{F}_p| \geq 4\$)? These would extend the classification paradigm beyond symmetric groups.
+$$
+
+### Plain Language
+
+This open question arises from the gallery proof `abel-ruffini-oq-04-oq-02` (S₂, S₃, S₄ Are Solvable: Complete Classification). The Seeker selected it as a extension suitable for the autonomous research pipeline.
+
+The specific question: The `solvable_iff_le_four` classification is proved for the symmetric groups $S_n = \text{Perm}(\text{Fin}\ n)$. What about other infinite families? Can analogues be proved for dihedral groups $D_n$ (solvable for all $n$, since they have cyclic subgroups of index 2), or for the general linear groups $\text{GL}_n(\mathbb{F}_p)$ (not solvable for $n \geq 2$, $p$ prime, $|\mathbb{F}_p| \geq 4$)? These would extend the classification paradigm beyond symmetric groups.
+
+### Why This Matters
+
+Significance score 6/10 — the problem extends a verified gallery proof in a concrete direction. Closing it would add a extension-style follow-up to the gallery corpus and exercise machinery from the parent entry.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent proof `abel-ruffini-oq-04-oq-02` — provides the base theorem and its Mathlib infrastructure
+- Sibling open questions on the same gallery entry — see `src/data/proofs/abel-ruffini/meta.json` `conclusion.openQuestions`
+
+### What's Still Open
+
+- The question stated above, as a extension of the parent result
+- Quantitative / constructive refinements that the Researcher may identify during OBSERVE
+
+### Our Goal
+
+Formulate the question as a Lean 4 theorem aligned with the parent entry's namespace, identify the Mathlib lemmas that close the gap, and either prove it or carve out a precise sub-claim that is tractable.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| abel-ruffini | Gallery root containing the open question | Parent definitions, Mathlib infrastructure used by the proof |
+| abel-ruffini-oq-04-oq-02 | Immediate source of this open question | Source proof techniques carried over |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Mathlib search**: Survey Mathlib for definitions and lemmas matching the question's keywords; many gallery open questions reduce to wiring an existing Mathlib API.
+   - Why it might work: Mathlib has broad coverage of classical results adjacent to the gallery proofs
+   - Risk: The question may require a definition Mathlib lacks (e.g. a specialized object), in which case the work shifts to defining it
+
+2. **Sibling reuse**: Lift the parent proof's strategy and adapt it to the new statement.
+   - Why it might work: The original proof author already structured the gallery entry to make this kind of extension feasible
+   - Risk: The sibling lemmas may not generalize cleanly; bookkeeping can dominate
+
+### Key Difficulties
+
+- Need to identify the precise Lean 4 statement; the natural-language description leaves room for interpretation
+- Mathlib coverage may be partial — the OBSERVE phase must check which pieces exist
+
+### What Would a Proof Need?
+
+- Key lemma 1: a Lean 4 formal statement of the open question above
+- Key lemma 2: connecting Mathlib infrastructure to the parent entry's definitions
+- Technical requirements: see the parent proof file for relevant `import Mathlib.*` statements
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Seeker-assigned tractability score 5/10 reflects a likely-tractable direct extension
+- Parent entry is verified, so the surrounding Lean infrastructure is in place
+- Mathlib coverage of adjacent material is non-trivial; survey by the Scout in ORIENT is advisable
+
+**Estimated Effort**:
+- Exploration: 4-8 hours during OBSERVE/ORIENT
+- If tractable: 1-3 days for a clean theorem statement plus proof
+- If hard: weeks; consider carving a narrower sub-question
+
+## References
+
+### Papers
+- See the parent gallery entry's `references` array for citations to the originating literature
+
+### Online Resources
+- https://github.com/rjwalters/lean-genius — the gallery repository hosting the parent proof
+- Mathlib4 docs at https://leanprover-community.github.io/mathlib4_docs/ — for searching Mathlib namespaces relevant to the keywords below
+
+### Mathlib
+- Relevant Mathlib modules will surface during ORIENT; start from the parent proof's existing imports
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - classification
+  - extension
+  - gallery-extracted
+  - group-theory
+  - research
+  - seeker-selected
+  - solvability
+  - symmetric-group
+  - wiedijk-100
+related_proofs:
+  - abel-ruffini-oq-04-oq-02
+  - abel-ruffini
+difficulty: medium
+source: gallery-gap
+created: 2026-06-15
+significance: 6
+tractability: 5
+tier: B
+category: extension
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10

--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04/state.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04/state.md
@@ -1,0 +1,45 @@
+# Research State: abel-ruffini-oq-04-oq-02-oq-04
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15 (S1, researcher-6 — OBSERVE→ORIENT)
+**Iteration**: 1
+
+## Current Focus
+Extend the `solvable_iff_le_four` paradigm to two families. Both decided by the
+durable derived-series cert `verify_solvable_families.py` (exit 0):
+- **Dₙ solvable for all n**, derived length ≤ 2 (verified n=3..8) — cyclic-by-C₂.
+- **GL₂(𝔽_q): sharp boundary at |𝔽_q|≥4** — GL₂(𝔽₂),GL₂(𝔽₃) solvable; GL₂(𝔽₅)
+  NOT solvable (derived series stabilizes at the perfect SL₂(𝔽₅), order 120;
+  PSL₂(𝔽₅)≅A₅ simple). q=4 also non-solvable (PSL₂(𝔽₄)≅A₅), noted not computed.
+
+## Active Approach
+Formalizability split (Mathlib `GroupTheory/Solvable.lean` bearers pinned in
+knowledge.md):
+- **Dihedral side TRACTABLE (~100 LOC)**: `IsSolvable (DihedralGroup n)` is a real
+  Mathlib gap (0 search hits) but easy — rotation subgroup cyclic+normal+index 2,
+  closed via `solvable_of_ker_le_range` (extension lemma) or derived-length-2.
+  **Recommended first ACT.**
+- **GL side BLOCKED for general n,q**: needs simplicity of PSL₂(𝔽_q) (or
+  non-solvability of SL₂(𝔽_q)), absent in Mathlib (≫500 LOC). Small-case
+  `GL₂(𝔽₅)` non-solvability possible via the cert's obstruction core but the
+  derived-series `decide` over 480 elements is heavy.
+
+## Attempt Count
+- Total attempts: 0 (no Lean built — Docker down)
+- Current approach attempts: 0
+- Approaches tried: 1 surveyed (derived-series cert + Mathlib bearer survey)
+
+## Blockers
+- Docker build wrapper down (`docker info` timeout); Aristotle MCP `prove` →
+  "Resource not found". Build-free only this session.
+- GL general case: PSL₂(𝔽_q) simplicity not in Mathlib (math/infra gap, not outage).
+
+## Next Action
+When a build host returns: implement `IsSolvable (DihedralGroup n)` (∀ n) — the
+tractable, upstream-worthy half — using the pinned `Solvable.lean` bearers
+(`solvable_of_ker_le_range` over the cyclic rotation subgroup + C₂ quotient).
+Re-run `verify_solvable_families.py` to re-confirm. Leave GL non-solvability as a
+documented BLOCKED sub-claim (needs PSL₂ simplicity) or land only the GL₂(𝔽₅)
+small case.

--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04/verify_solvable_families.py
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04/verify_solvable_families.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Durable verification cert for abel-ruffini-oq-04-oq-02-oq-04.
+
+OQ: the parent `solvable_iff_le_four` classifies Sₙ (solvable iff n ≤ 4). Extend
+the *paradigm* to other infinite families:
+  * dihedral Dₙ  -- solvable for ALL n (cyclic rotation subgroup of index 2);
+  * GL₂(𝔽_q)     -- NOT solvable once |𝔽_q| ≥ 4 (PSL₂ is simple non-abelian).
+
+This cert decides solvability the definitional way (Mathlib's `IsSolvable` =
+derived series eventually trivial): it computes the derived series
+  D₀ = G,  D_{k+1} = ⟨ [x,y] : x,y ∈ D_k ⟩
+and reports SOLVABLE iff some D_k = {1}, else NOT-SOLVABLE (the series stabilizes
+at a nontrivial perfect subgroup -- the "obstruction core").
+
+It is a regression oracle for a future Lean formalization and pins the exact
+boundary the OQ asks about. Pure stdlib; the largest group is GL₂(𝔽₅) (order 480).
+"""
+
+from itertools import product as iproduct
+
+
+def derived_series_solvable(elements, mul, inv, e, name, max_steps=12):
+    """elements: iterable of group elements (hashable). mul/inv/e: group ops.
+    Returns (is_solvable, derived_length_or_None, core_size)."""
+    G = frozenset(elements)
+
+    def closure(gens):
+        gens = set(gens)
+        gens.add(e)
+        elems = set(gens)
+        frontier = list(gens)
+        while frontier:
+            x = frontier.pop()
+            for g in list(gens):
+                for prod in (mul(x, g), mul(g, x)):
+                    if prod not in elems:
+                        elems.add(prod)
+                        frontier.append(prod)
+        return frozenset(elems)
+
+    def commutator_subgroup(H):
+        comms = set()
+        Hl = list(H)
+        for x in Hl:
+            xi = inv(x)
+            for y in Hl:
+                # [x,y] = x y x^-1 y^-1
+                comms.add(mul(mul(x, y), mul(xi, inv(y))))
+        return closure(comms)
+
+    D = G
+    for k in range(max_steps):
+        if len(D) == 1:
+            print(f"[SOLVABLE]     {name}: |G|={len(G)}, derived length {k}")
+            return True, k, 1
+        nxt = commutator_subgroup(D)
+        if nxt == D:
+            print(f"[NOT-SOLVABLE] {name}: |G|={len(G)}, derived series stabilizes "
+                  f"at a perfect core of size {len(D)} != 1")
+            return False, None, len(D)
+        D = nxt
+    print(f"[INCONCLUSIVE] {name}: did not stabilize in {max_steps} steps")
+    return None, None, len(D)
+
+
+# ---------- dihedral group D_n (order 2n) ----------
+def dihedral(n):
+    # element (s, k): s in {0,1} reflection flag, k in Z_n.
+    elems = [(s, k) for s in (0, 1) for k in range(n)]
+    e = (0, 0)
+
+    def mul(a, b):
+        s1, k1 = a
+        s2, k2 = b
+        if s1 == 0:
+            return (s2, (k1 + k2) % n)
+        else:
+            return (1 - s2, (k1 - k2) % n)
+
+    def inv(a):
+        s, k = a
+        return (0, (-k) % n) if s == 0 else (1, k)  # reflections are involutions
+
+    return elems, mul, inv, e
+
+
+# ---------- general linear group GL_2(F_p), p prime ----------
+def gl2(p):
+    e = (1, 0, 0, 1)
+
+    def det(m):
+        a, b, c, d = m
+        return (a * d - b * c) % p
+
+    elems = [m for m in iproduct(range(p), repeat=4) if det(m) != 0]
+
+    def mul(x, y):
+        a, b, c, d = x
+        e1, f1, g1, h1 = y
+        return ((a * e1 + b * g1) % p, (a * f1 + b * h1) % p,
+                (c * e1 + d * g1) % p, (c * f1 + d * h1) % p)
+
+    def inv(m):
+        a, b, c, d = m
+        di = pow(det(m), p - 2, p)  # Fermat inverse of the determinant
+        return ((d * di) % p, (-b * di) % p, (-c * di) % p, (a * di) % p)
+
+    return elems, mul, inv, e
+
+
+def main():
+    print("=== Dihedral D_n: solvable for ALL n (claim: derived length <= 2) ===")
+    dih_ok = True
+    for n in (3, 4, 5, 6, 7, 8):
+        elems, mul, inv, e = dihedral(n)
+        ok, dl, _ = derived_series_solvable(elems, mul, inv, e, f"D_{n}")
+        dih_ok = dih_ok and (ok is True) and (dl is not None and dl <= 2)
+
+    print("\n=== GL_2(F_p): solvable for p<=3, NOT solvable for p>=5 ===")
+    expect = {2: True, 3: True, 5: False}   # p=5: PSL_2(F_5) ~ A_5 simple
+    gl_ok = True
+    for p in (2, 3, 5):
+        elems, mul, inv, e = gl2(p)
+        ok, _, _ = derived_series_solvable(elems, mul, inv, e, f"GL_2(F_{p})")
+        gl_ok = gl_ok and (ok is expect[p])
+
+    print("\n=== RESULT ===")
+    if dih_ok and gl_ok:
+        print("ALL CHECKS PASSED.")
+        print(" * D_n solvable for n=3..8 with derived length <= 2 (cyclic-by-C2).")
+        print(" * GL_2(F_2), GL_2(F_3) solvable; GL_2(F_5) NOT solvable")
+        print("   (derived series stabilizes at SL_2(F_5), order 120, perfect;")
+        print("    PSL_2(F_5) ~ A_5 is simple non-abelian -- the obstruction).")
+        print(" * Boundary note: GL_2(F_4) is also NOT solvable (PSL_2(F_4) ~ A_5);")
+        print("   not computed here to avoid GF(4) arithmetic. So the OQ's |F|>=4")
+        print("   threshold is exact. See knowledge.md for the Mathlib bearers.")
+    else:
+        print(f"FAILURES: dihedral_ok={dih_ok}, gl_ok={gl_ok}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
OBSERVE→ORIENT on OQ-04-OQ-02-OQ-04 ("extend the `solvable_iff_le_four` (Sₙ) paradigm to other infinite families — Dₙ and GL₂(𝔽_q)"). Build-free.

Both extensions are decided by a durable derived-series cert `verify_solvable_families.py` (stdlib, exit 0; decides `IsSolvable` the definitional way — derived series `D₀=G`, `D_{k+1}=⟨[x,y]⟩`):

- **Dihedral `Dₙ` is solvable for every n**, with **derived length ≤ 2** (verified n=3..8). Cyclic-by-`C₂`: the rotation subgroup `R≅Cₙ` is abelian, normal, index 2, with quotient `C₂`, so `[Dₙ,Dₙ]≤R` is abelian ⇒ `D⁽²⁾=1`.
- **`GL₂(𝔽_q)` has a sharp solvability boundary at `|𝔽_q|≥4`**: `GL₂(𝔽₂)≅S₃` and `GL₂(𝔽₃)` (order 48) are **solvable** (derived lengths 2, 4); `GL₂(𝔽₅)` (order 480) is **NOT solvable** — its derived series stabilizes at the perfect core `SL₂(𝔽₅)` (order 120), since `PSL₂(𝔽₅)≅A₅` is simple non-abelian. (`q=4`: `PSL₂(𝔽₄)≅A₅` too, so `GL₂(𝔽₄)` is non-solvable; not computed to avoid `GF(4)` arithmetic — makes the `|F|≥4` threshold exact.)

## Mathlib survey + formalization verdict (master + pin v4.26.0)
`GroupTheory/Solvable.lean` bearers pinned: `subgroup_solvable_of_solvable` (:142), `solvable_of_ker_le_range` (extension lemma, :125), `Equiv.Perm.not_solvable` (:242).
- **Dihedral side TRACTABLE (~100 LOC)**: `IsSolvable (DihedralGroup n)` is a genuine Mathlib gap (0 search hits) but easy — closeable via `solvable_of_ker_le_range` over the cyclic rotation subgroup + `C₂` quotient. **Recommended first ACT (upstream-worthy).**
- **GL side BLOCKED for general `n,q`**: needs simplicity of `PSL₂(𝔽_q)` (absent in Mathlib, ≫500 LOC). Small-case `GL₂(𝔽₅)` is possible via the cert's obstruction core but the derived-series `decide` over 480 elements is heavy.

## Verification status
- **Math**: `verify_solvable_families.py` exits 0 (D_n n=3..8; GL₂(𝔽₂/₃/₅)). Mathlib bearers re-checked via `gh api`.
- **Lean build**: none — dual backend blackout (Docker `docker info` timeout; Aristotle MCP `prove` → "Resource not found"). ORIENT session: cert + docs only, **no Lean file added/changed**, nothing registered.

## Test plan
- [ ] `python3 research/problems/abel-ruffini-oq-04-oq-02-oq-04/verify_solvable_families.py` → "ALL CHECKS PASSED", exit 0.
- [ ] (next session, build host) implement `IsSolvable (DihedralGroup n)` (∀n) via the pinned bearers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)