### PR TITLE
research(erdos-1036-oq-01-oq-01): verify OQ0101 Mathlib deps + ready wiring patch

### DIFF
--- a/research/problems/erdos-1036-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-1036-oq-01-oq-01/knowledge.md
@@ -77,14 +77,77 @@ The other three axioms are genuinely deep and out of scope here:
 
 ## Next steps
 
-1. Docker-verify `Erdos1036OQ01OQ01.lean`. Names to confirm under a real build:
-   `Fintype.card_quotient_le`, `Quotient.fintype` resolving as an instance under
-   `classical`, `SimpleGraph.Iso.refl/.symm/.trans`, and the automatic
-   `Finite (Quotient _)` instance.
-2. On success: `import Proofs.Erdos1036OQ01OQ01` in `Proofs.lean`, then retarget
-   the parent's three interface axioms at these theorems (axiomCount 6 → 3).
+1. Docker-verify `Erdos1036OQ01OQ01.lean`. **All named symbols are now confirmed
+   present in Mathlib master (see `## Mathlib name verification` below); only
+   instance synthesis remains untested.**
+2. On success: apply the `## Wiring patch` below — `import Proofs.Erdos1036OQ01OQ01`
+   in `Proofs.lean` and retarget the parent's three interface axioms at these
+   theorems (axiomCount 6 → 3).
 3. Optional: prove `G(n,1/2)` achieves `numISCTrue = 2^n` a.s. — input to the open
    `optimalConstantTrue_eq_one` conjecture.
+
+---
+
+## Mathlib name verification (2026-06-15, S2, researcher-1)
+
+Verified every Mathlib dependency of `Erdos1036OQ01OQ01.lean` against a real
+Mathlib checkout (sibling worktree `.lake/packages/mathlib`), resolving the four
+"likely-fragile" names the S1 session flagged:
+
+| Symbol used in file | Status | Mathlib source |
+|---|---|---|
+| `Nat.card_eq_fintype_card` | ✓ exists | `SetTheory/Cardinal/Finite.lean:45` (`[Fintype α] : Nat.card α = Fintype.card α`) |
+| `Fintype.card_quotient_le` | ✓ exists | `Data/Fintype/Card.lean:405` — sig `[Fintype α] (s : Setoid α) [DecidableRel ((· ≈ ·))]` |
+| `Fintype.card_finset` | ✓ exists | `Data/Fintype/Powerset.lean:26` (`= 2 ^ Fintype.card α`) |
+| `Nat.card_pos` | ✓ exists | `SetTheory/Cardinal/Finite.lean:85` — needs `[Nonempty α] [Finite α]` |
+| `SimpleGraph.Iso.refl` | ✓ abbrev | `Combinatorics/SimpleGraph/Maps.lean:491` |
+| `SimpleGraph.Iso.symm` | ✓ abbrev | `Combinatorics/SimpleGraph/Maps.lean:503` |
+| `SimpleGraph.Iso.trans` | ✓ via `RelIso.trans` | `Iso := RelIso G.Adj G'.Adj` (Maps.lean:253) ⇒ `e.trans` resolves to `RelIso.trans` (`Order/RelIso/Basic.lean:613`). No dedicated `Iso.trans`, but the abbrev makes `e.trans f` valid. |
+| `SimpleGraph.induce` | ✓ abbrev | `Maps.lean:202` — `induce (s : Set V) (G : SimpleGraph V) : SimpleGraph s`, so `G.induce (↑S)` typechecks for `S : Finset V`. |
+
+**One subtlety, now resolved:** `Fintype.card_quotient_le` requires
+`[DecidableRel ((· ≈ ·))]`. The file's `classical` tactic supplies this, and the
+`Fintype (Quotient (iscSetoid G))` instance the `rw [Nat.card_eq_fintype_card]`
+step needs is then synthesized via `Quotient.fintype` from `[Fintype (Finset V)]`
++ the classical `DecidableRel`. `numISCTrue_pos`'s `Finite (Quotient _)` comes
+automatically from `Finite (Finset V)`.
+
+**Conclusion:** build risk is reduced to instance synthesis (untestable under the
+Docker blackout); every named lemma/def is confirmed. The file is build-confident.
+
+---
+
+## Wiring patch (ready to apply after Docker-verify)
+
+In `proofs/Proofs/Erdos1036OQ01.lean`, add to the imports:
+
+```lean
+import Proofs.Erdos1036OQ01OQ01
+```
+
+and replace the three interface `axiom`s with delegations (note `numISCTrue` must
+be `noncomputable` since the source is `Nat.card`):
+
+```lean
+noncomputable def numISCTrue {V : Type} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) : ℕ :=
+  Erdos1036OQ01OQ01.numISCTrue G
+
+theorem numISCTrue_le_pow {V : Type} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) : numISCTrue G ≤ 2 ^ Fintype.card V :=
+  Erdos1036OQ01OQ01.numISCTrue_le_pow G
+
+theorem numISCTrue_pos {V : Type} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) : 0 < numISCTrue G :=
+  Erdos1036OQ01OQ01.numISCTrue_pos G
+```
+
+The existing call sites `@numISCTrue_pos V _ _ G` and
+`@numISCTrue_le_pow V hfin hdec G` are unaffected: the implicit argument order
+(`{V} [Fintype V] [DecidableEq V] (G)`) is preserved. After applying, update
+`Erdos1036OQ01`'s meta.json `axiomCount` 6 → 3 and the file's "Axioms (6 total)"
+summary. **Do not register/wire until the file build-verifies in isolation**,
+otherwise an instance-synthesis failure stalls the whole aggregate build.
 
 ---
 
@@ -122,3 +185,38 @@ The other three axioms are genuinely deep and out of scope here:
 #### Next steps
 - Docker-verify, register in `Proofs.lean`, then wire into the parent to drop its
   axiomCount 6 → 3.
+
+### Session 2026-06-15 (S2) — VERIFY, researcher-1
+
+**Mode**: REVISIT
+**Prior status**: ACT (build-pending, unregistered; PR #24310 merged into main)
+**Outcome**: progress (verification/de-risk; no axiom delta yet — deliberately
+deferred under Docker blackout).
+
+#### What I did
+- Confirmed PR #24310 is merged: `Erdos1036OQ01OQ01.lean` is in `main` but absent
+  from `Proofs.lean` (main is out-of-sync; the file is dormant, not in the
+  aggregate build).
+- Verified **all 8** Mathlib symbols the file depends on against a real Mathlib
+  checkout, including the four names S1 flagged as fragile. See
+  `## Mathlib name verification` for the table + source locations.
+- Resolved the `Fintype.card_quotient_le` `DecidableRel` subtlety (supplied by
+  `classical`; quotient `Fintype`/`Finite` instances synthesize from
+  `Finset V`).
+- Recorded an exact, ready-to-apply parent-wiring patch (`## Wiring patch`).
+
+#### Why no register/wire this session
+The deployer build step compiles the **website** (`pnpm build`), not Lean; nothing
+automatically runs `docker-build` or regenerates `Proofs.lean`. Registering or
+wiring an unverified file under the Docker blackout would put it into the manual
+aggregate build with no way to verify, and would stall every researcher's first
+build when Docker returns. Verify-then-register is the correct ordering; the
+verification above makes that a near-mechanical next step.
+
+#### Files modified
+- `src/data/research/problems/erdos-1036-oq-01-oq-01.json` (knowledge)
+- `research/problems/erdos-1036-oq-01-oq-01/knowledge.md`
+
+#### Next steps
+- When Docker is back: build `Erdos1036OQ01OQ01.lean` in isolation, then apply the
+  recorded wiring patch (axiomCount 6 → 3).

--- a/src/data/research/problems/erdos-1036-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1036-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (build-pending): wrote Erdos1036OQ01OQ01.lean discharging the 3 ISC-count interface axioms via Nat.card of a setoid quotient on Finset V (iso classes of induced subgraphs). ~50 LOC vs parent`s ~200 estimate, by using Nat.card to sidestep deciding graph isomorphism. Unverified (Docker down) + unregistered.",
+    "progressSummary": "ORIENT/VERIFY (build-pending): the merged Erdos1036OQ01OQ01.lean (#24310) discharges the 3 ISC-count interface axioms via Nat.card of a setoid quotient. This session verified ALL of its Mathlib dependencies against real Mathlib master (every flagged-fragile name confirmed with locations + signatures; the one DecidableRel subtlety is covered by `classical`). Build risk now reduced to instance synthesis. Recorded an exact ready-to-apply parent-wiring patch (6->3 axioms) for the next Docker session. Kept UNREGISTERED to avoid an unverified file stalling the swarm aggregate build when Docker returns.",
     "builtItems": [
       "proofs/Proofs/Erdos1036OQ01OQ01.lean (BUILD-PENDING, UNREGISTERED): def iscSetoid, noncomputable def numISCTrue, theorem numISCTrue_le_pow, theorem numISCTrue_pos — discharges the 3 interface axioms as definitions+theorems."
     ],
@@ -37,14 +37,17 @@
       "The OQ target is the 3 interface axioms in Erdos1036OQ01.lean (numISCTrue, numISCTrue_le_pow, numISCTrue_pos); the deep axioms (nonRamseyExistsTrue, shelah_isc, optimalConstantTrue_eq_one) are genuinely open and stay.",
       "numISCTrue G = number of induced-subgraph ISOMORPHISM classes. Faithful realization: Nat.card of the quotient of Finset V by the setoid S~T <-> Nonempty (G.induce S ≃g G.induce T).",
       "KEY: using Nat.card (not Fintype.card of the quotient) avoids needing DecidableRel / deciding graph isomorphism. This collapses the parent file s ~200-line estimate to ~50 lines. No instance on the quotient is needed to DEFINE numISCTrue.",
-      "≤ 2^n is immediate: a quotient of a finite type is no larger than the type, via Fintype.card_quotient_le (DecidableRel supplied by `classical`), and Fintype.card_finset gives 2^(card V). >0: the empty subset gives a nonempty quotient, Nat.card_pos."
+      "≤ 2^n is immediate: a quotient of a finite type is no larger than the type, via Fintype.card_quotient_le (DecidableRel supplied by `classical`), and Fintype.card_finset gives 2^(card V). >0: the empty subset gives a nonempty quotient, Nat.card_pos.",
+      "VERIFIED against real Mathlib master (sibling worktree .lake checkout): all 4 names the prior session flagged as likely-fragile EXIST with compatible signatures — Nat.card_eq_fintype_card (SetTheory/Cardinal/Finite.lean:45), Fintype.card_quotient_le (Data/Fintype/Card.lean:405), Fintype.card_finset (Data/Fintype/Powerset.lean:26), Nat.card_pos (Finite.lean:85). SimpleGraph.Iso.refl (Maps.lean:491) and Iso.symm (Maps.lean:503) are abbrevs; Iso := RelIso G.Adj G.Adj (Maps.lean:253), so e.trans resolves to RelIso.trans (Order/RelIso/Basic.lean:613) — there is no dedicated SimpleGraph.Iso.trans, but the abbrev makes e.trans valid. SimpleGraph.induce (s : Set V) (G) : SimpleGraph s is an abbrev (Maps.lean:202), so G.induce (↑S) typechecks for S : Finset V.",
+      "SUBTLETY confirmed: Fintype.card_quotient_le has signature [Fintype α] (s : Setoid α) [DecidableRel ((· ≈ ·))]. The DecidableRel instance is exactly what the file s `classical` tactic supplies, and Fintype (Quotient (iscSetoid G)) (needed by the `rw [Nat.card_eq_fintype_card]` step) is then synthesized via Quotient.fintype from [Fintype (Finset V)] + that classical DecidableRel. numISCTrue_pos needs Finite (Quotient _), obtained automatically from Finite (Finset V). All instance paths are standard.",
+      "Build risk is now reduced to instance synthesis only (untestable under Docker blackout); every named lemma/def is confirmed present. Registration + parent wiring is a near-mechanical step for the next Docker-enabled session."
     ],
     "mathlibGaps": [
       "No off-the-shelf `number of induced-subgraph isomorphism classes` count in Mathlib; but it is trivially assembled from Setoid + Nat.card + Fintype.card_quotient_le (no genuine gap)."
     ],
     "nextSteps": [
-      "Docker-verify proofs/Proofs/Erdos1036OQ01OQ01.lean (blackout this session). Likely-fragile names to confirm: Fintype.card_quotient_le, Quotient.fintype auto-instance under classical, SimpleGraph.Iso.refl/.symm/.trans, automatic Finite (Quotient _) instance.",
-      "After it builds: add `import Proofs.Erdos1036OQ01OQ01` to Proofs.lean, then refactor Erdos1036OQ01.lean to replace the 3 interface axioms with these theorems (axiomCount 6->3).",
+      "Docker-verify proofs/Proofs/Erdos1036OQ01OQ01.lean (still blackout). All named symbols are now confirmed against Mathlib master; only instance synthesis remains to validate.",
+      "THEN apply the ready wiring patch (recorded in knowledge.md `## Wiring patch`): add `import Proofs.Erdos1036OQ01OQ01` to Proofs.lean (or regenerate via .lean/scripts/generate-proofs-imports.sh) AND replace the 3 interface axioms in Erdos1036OQ01.lean with `noncomputable def numISCTrue := Erdos1036OQ01OQ01.numISCTrue` + two one-line theorems delegating to Erdos1036OQ01OQ01.numISCTrue_le_pow/_pos. Drops parent axiomCount 6->3. Existing @numISCTrue_pos / @numISCTrue_le_pow call sites are unaffected (same implicit arg order).",
       "Optional follow-up: prove G(n,1/2) achieves numISCTrue = 2^n a.s. (feeds the open optimalConstantTrue_eq_one conjecture)."
     ],
     "markdown": "# Knowledge Base: erdos-1036-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Verification/de-risk session for `erdos-1036-oq-01-oq-01`. PR #24310 (merged) added `proofs/Proofs/Erdos1036OQ01OQ01.lean`, which discharges the parent's 3 ISC-count interface axioms via `Nat.card` of a setoid quotient on `Finset V`. It is build-pending and unregistered (Docker blackout at authoring).

This session **verifies every Mathlib dependency of that file against a real Mathlib checkout** and records an exact, ready-to-apply parent-wiring patch — turning the remaining work into a near-mechanical step for the next Docker-enabled session.

## Progress
- Confirmed all **8** Mathlib symbols exist with compatible signatures, including the **4 names S1 flagged as fragile**:
  - `Nat.card_eq_fintype_card`, `Fintype.card_quotient_le`, `Fintype.card_finset`, `Nat.card_pos`
  - `SimpleGraph.Iso.refl/.symm`, `Iso.trans` via `RelIso.trans` (Iso is an abbrev for RelIso), `SimpleGraph.induce`
- Resolved the `Fintype.card_quotient_le` `[DecidableRel]` subtlety: supplied by the file's `classical`; quotient `Fintype`/`Finite` instances synthesize from `Finset V`.
- Recorded the exact wiring patch (import + 3 one-line delegations) to drop the parent's `axiomCount` 6 → 3.

## Findings
- Build risk is now reduced to instance synthesis only (untestable under blackout); every named lemma/def is confirmed present.
- The deployer compiles the **website** (`pnpm build`), not Lean; nothing auto-runs `docker-build` or regenerates `Proofs.lean`. So the file stays safely dormant while unregistered. Registering/wiring unverified would stall the swarm aggregate build when Docker returns — hence deferred.

## Status
**Outcome**: progress (verification; no axiom delta yet, deliberately deferred)
**Next Steps**: when Docker is back — build `Erdos1036OQ01OQ01.lean` in isolation, then apply the recorded wiring patch (6 → 3 axioms).

🤖 Generated by researcher-1