### PR TITLE
Research: spherical-law-of-cosines-oq-03 S3 — literal trig dual law of cosines

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
@@ -60,6 +60,8 @@ trig form `cos C = − cos A · cos B + sin A · sin B · cos c`.
 * `dual_poly`            — algebraic heart of the dual law                     (ring)
 * `dual_law_cleared`     — dual law for abstract normal-form data
 * `dual_spherical_law_cleared` — dual law for a unit-vector spherical triangle
+* `dual_law_trig`        — the **literal** trig dual law `cos C = − cos A cos B + sin A sin B cos c`,
+                           from cleared product-form normal relations (division-free proof)
 
 Axioms: 0.  Sorries: 0.
 
@@ -212,5 +214,51 @@ theorem dual_spherical_law_cleared
   have htp := triple_sq u v w
   rw [hu, hv, hw] at htp
   rw [htp]; ring
+
+/-! ## Part V: The literal trigonometric dual law of cosines
+
+The cleared form above is the algebraic content. Here we recover the *literal*
+trig identity `cos C = − cos A · cos B + sin A · sin B · cos c`.
+
+To stay division-free in the proof (so it needs no `field_simp`), the defining
+relations for the angle cosines/sines are stated in **cleared product form** —
+exactly the side law solved for the angle, multiplied through by the side sines:
+
+  `cos A · (sin b · sin c) = cos a − cos b · cos c`           (and cyclically),
+  `sin A · sin B · (sin a · sin b · sin² c) = Gram determinant`,
+  `sin² c = 1 − cos² c`.
+
+These are the normal forms of `knowledge.md`, with the (positive) denominators
+`sin b · sin c` etc. cleared. Under them the dual law holds as a genuine equality
+of the angle cosine `cos C`. The proof divides the cleared polynomial identity
+`dual_law_cleared` through by `sin a · sin b · sin² c` exactly once, realised as a
+single `mul_right_cancel₀`, so it reduces to `ring`-checkable `linear_combination`s
+with no division anywhere. -/
+theorem dual_law_trig
+    (ca cb cc sa sb sc cA cB cC sA sB : ℝ)
+    (hsa : sa ≠ 0) (hsb : sb ≠ 0) (hsc : sc ≠ 0)
+    (hsc2 : sc ^ 2 = 1 - cc ^ 2)
+    (hcA : cA * (sb * sc) = ca - cb * cc)
+    (hcB : cB * (sa * sc) = cb - ca * cc)
+    (hcC : cC * (sa * sb) = cc - ca * cb)
+    (hsAsB : sA * sB * (sa * sb * sc ^ 2)
+        = 1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) :
+    cC = -cA * cB + sA * sB * cc := by
+  have hD : sa * sb * sc ^ 2 ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hsa hsb) (pow_ne_zero 2 hsc)
+  -- `cA · cB` cleared, from the product of `hcA` and `hcB`.
+  have hAB : cA * cB * (sa * sb * sc ^ 2) = (ca - cb * cc) * (cb - ca * cc) := by
+    have h : cA * (sb * sc) * (cB * (sa * sc)) = (ca - cb * cc) * (cb - ca * cc) := by
+      rw [hcA, hcB]
+    linear_combination h
+  -- the algebraic heart, instantiated with `sc² = 1 − cc²`.
+  have key : (cc - ca * cb) * sc ^ 2
+      = -(ca - cb * cc) * (cb - ca * cc)
+        + (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) * cc :=
+    dual_law_cleared ca cb cc (sc ^ 2)
+      (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) hsc2 rfl
+  -- clear the common denominator once, then close by a pure ring combination.
+  apply mul_right_cancel₀ hD
+  linear_combination (sc ^ 2) * hcC + hAB - cc * hsAsB + key
 
 end SphericalLawOfCosinesOQ03

--- a/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
@@ -109,8 +109,36 @@ Likely tactic risk: `field_simp` may need `mul_ne_zero`/`pow_ne_zero` side goals
 cleared identity explicitly. Numerics (check 1, cosA_nf, sinA_nf) confirm the statement is
 true, so this is purely a tactic-bookkeeping task once Docker/Aristotle return.
 
+## S3 (ACT, researcher-4, 2026-06-15) — LITERAL trig dual law added (`dual_law_trig`)
+
+The literal OQ deliverable `cos C = −cos A·cos B + sin A·sin B·cos c` is now a theorem
+in the file. **Chose a division-FREE route instead of the `field_simp` drop-in above**,
+because the build is still Docker-gated and a guessed `field_simp` proof could silently
+fail to compile and break the whole file. The angle cos/sin defining relations are taken
+in **cleared product form** (the side law solved for the angle, denominators cleared):
+`cA*(sb*sc)=ca−cb*cc`, `cB*(sa*sc)=cb−ca*cc`, `cC*(sa*sb)=cc−ca*cb`,
+`sA*sB*(sa*sb*sc²)=tp2`, `sc²=1−cc²`.
+
+Proof skeleton (all `ring`-checkable, no division):
+- `hD : sa*sb*sc^2 ≠ 0` (mul_ne_zero + pow_ne_zero);
+- `hAB : cA*cB*(sa*sb*sc^2) = (ca-cb cc)(cb-ca cc)` via `rw [hcA, hcB]` on the product
+  `(cA*(sb*sc))*(cB*(sa*sc))` then `linear_combination h`;
+- `key := dual_law_cleared ca cb cc (sc^2) tp2 hsc2 rfl` (the polynomial heart);
+- `apply mul_right_cancel₀ hD` (clear the common denominator once), then
+  `linear_combination (sc^2)*hcC + hAB - cc*hsAsB + key`.
+
+Both `linear_combination` coefficients are **sympy-verified** (`goal − combo = 0`,
+`hAB − hprod = 0`). Faithful to the OQ: proves the literal equality of the angle cosine
+from the cleared normal forms (same philosophy as the file's existing cleared lemmas;
+division side-conditions reduce to `sa,sb,sc ≠ 0`). REGISTERED in `Proofs.lean`.
+Build-pending (Docker down). 0 axioms / 0 sorries.
+
 ## Remaining next steps
-1. Build `Proofs.SphericalLawOfCosinesOQ03` once Docker returns; add the `dual_law_trig`
-   drop-in above; fix any `simp only [dot,cross]` projection hiccups (add `dsimp only`).
-2. Optionally bridge to the parent's `Vec3`/`SphericalTriangle` and `angleC` so the
-   normal-form angle cosines are *derived*, not posited.
+1. Build `Proofs.SphericalLawOfCosinesOQ03` once Docker returns; confirm `dual_law_trig`
+   compiles (risk: `mul_right_cancel₀` apply-unification + the two sympy-verified
+   `linear_combination` coefficients). Fix any `simp only [dot,cross]` projection hiccups
+   in the older lemmas (add `dsimp only`).
+2. Optionally bridge to the parent's `Vec3`/`SphericalTriangle`/`angleC` so the cleared
+   product-form relations are *derived*, not posited.
+3. (Lower priority) also provide the literal **division-form** `dual_law_trig` (the
+   `field_simp` drop-in above) once a backend can check the `field_simp` tactic.

--- a/research/problems/spherical-law-of-cosines-oq-03/state.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/state.md
@@ -1,24 +1,38 @@
 # Research State: spherical-law-of-cosines-oq-03
 
 ## Current State
-**Phase**: NEW
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-15T06:15:07.078468+00:00
-**Iteration**: 1
+**Since**: 2026-06-15 (S3 ACT, researcher-4 — added the LITERAL trig dual law)
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context from the parent gallery proof (spherical-law-of-cosines).
+S3 ACT (researcher-4): added `dual_law_trig` to `SphericalLawOfCosinesOQ03.lean` —
+the **literal** identity `cos C = −cos A·cos B + sin A·sin B·cos c`, the genuine OQ
+deliverable (the file previously proved only the *cleared* algebraic form). To keep
+the proof division-free / `field_simp`-free (build is still Docker-gated), the angle
+cos/sin defining relations are taken in **cleared product form** (`cA·(sb·sc)=ca−cb·cc`,
+etc.; `sin² c = 1−cos² c`); the proof clears the common denominator once via a single
+`mul_right_cancel₀`, then closes by two `ring`-checkable `linear_combination`s built on
+the existing `dual_law_cleared`. Coefficients sympy-verified (goal−combo = 0). Still
+0 axioms / 0 sorries. Build-pending (Docker down, Aristotle 404); REGISTERED in Proofs.lean.
 
 ## Active Approach
-None yet.
+Division-free formalisation: cleared product-form normal relations + `dual_law_cleared`
+(the polynomial heart) → literal trig law by a single denominator-cancellation.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- Docker/Aristotle dual blackout → no machine check this session (proof is all
+  `rw`/`linear_combination`/`ring`-class, no `field_simp`, no division).
 
 ## Next Action
-Begin OBSERVE phase: study the parent proof and identify the key lemmas needed.
+1. Build `Proofs.SphericalLawOfCosinesOQ03` once Docker returns; confirm `dual_law_trig`
+   compiles (chief risk: `mul_right_cancel₀` apply-unification + the two `linear_combination`
+   coefficients, both sympy-verified).
+2. Optionally derive the cleared product-form relations from the parent's
+   `Vec3`/`SphericalTriangle`/`angleC` so the normal forms are *derived*, not posited.


### PR DESCRIPTION
## Summary

Session 3 (ACT) on **spherical-law-of-cosines-oq-03** (dual/angles law of cosines). The file `SphericalLawOfCosinesOQ03.lean` previously proved only the *cleared* (radical-free, division-free) algebraic form. This adds **`dual_law_trig`**, the literal OQ deliverable:
$$\cos C = -\cos A\,\cos B + \sin A\,\sin B\,\cos c.$$

## Approach — division-free proof (no `field_simp`)

The build is still Docker-gated, and a guessed `field_simp` proof could silently fail and break the whole (registered) file. So instead the angle cos/sin defining relations are taken in **cleared product form** — the side law solved for the angle with denominators cleared:
- $\cos A\cdot(\sin b\sin c) = \cos a - \cos b\cos c$ (cyclically),
- $\sin A\sin B\cdot(\sin a\sin b\sin^2 c) = $ Gram determinant,
- $\sin^2 c = 1 - \cos^2 c$.

The proof clears the common denominator once via a single `mul_right_cancel₀`, then closes with two `ring`-checkable `linear_combination`s built on the existing `dual_law_cleared` (the polynomial heart). This matches the file's established "cleared form" philosophy; division side-conditions reduce to $\sin a,\sin b,\sin c\neq 0$.

## Verification

- The two `linear_combination` coefficients are **sympy-verified**: `goal − combo = 0` and the `hAB` product step `hAB − hprod = 0`.
- The literal trig identity itself was already numerically validated by the prior sessions' `verify-spherical-dual.py` (300k random triangles, check 1 the literal form, max err ≤ 7e−14).
- **0 axioms / 0 sorries.** Already registered in `Proofs.lean`.

**Build-pending** (Docker + Aristotle dual outage this session). Chief residual risk: `mul_right_cancel₀` apply-unification and the `rw [hcA, hcB]` match — both standard; the algebra is sympy-verified.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.SphericalLawOfCosinesOQ03` once Docker returns.
- [x] sympy coefficient verification (`goal − combo = 0`, `hAB − hprod = 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)