### PR TITLE
Enrich Brouwer Fixed Point via Displacement Coloring (n-dim): deepen open questions

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -135,7 +135,10 @@
     "summary": "This formalization provides the complete bridge from n-dimensional Sperner lemma to Brouwer fixed point theorem via displacement coloring. All results are fully verified with 0 axioms and 0 sorries. The approximate fixed point theorem uses UC + Sperner + displacement transfer, and Brouwer follows by compact minimization.",
     "implications": "Combined with the completion of sperner_ndim (1 sorry remaining), this gives an entirely combinatorial path to Brouwer's FPT that avoids the 2 axioms in BrouwerFixedPoint.lean (no-retraction and retraction-construction). The displacement coloring approach is more elementary and computational than the algebraic topology route.",
     "openQuestions": [
-      "Prove sperner_ndim in SpernerNDim.lean (1 sorry) to complete the full Sperner-to-Brouwer pipeline"
+      "Prove sperner_ndim in SpernerNDim.lean (1 sorry) to complete the full Sperner-to-Brouwer pipeline, discharging the lone hypothesis parameter that this file currently takes as a given.",
+      "Can the displacement-coloring bridge be pushed beyond the simplex to derive Brouwer's theorem for an arbitrary compact convex body, by composing brouwer_simplex with a homeomorphism onto the standard simplex (or a retraction argument)? This is the standard textbook extension but requires formalizing the convex-body-to-simplex transfer.",
+      "Does the same construction yield a constructive/computational fixed-point approximation algorithm (a Lean-executable version of the Scarf / Kuhn simplicial-subdivision pivoting method), turning the existence proof into an explicit ε-approximate fixed-point finder?",
+      "Can the compactness step in brouwer_simplex (Bolzano–Weierstrass extraction of a convergent subsequence) be replaced by an explicit modulus-of-continuity bound, removing the only non-constructive ingredient and yielding a fully constructive proof in the sense of Bishop?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `sperner-ndim-oq-03`.

This entry was below the quality target on `conclusion.openQuestions` (had only 1; target is 2+). All other dimensions (sections, annotations, keyInsights, crossReferences, references) were already saturated.

## Changes
- Expanded `conclusion.openQuestions` from 1 to 4 substantive, mathematically-grounded entries:
  1. Discharge sperner_ndim (existing — kept and elaborated)
  2. Extend the displacement-coloring bridge to an arbitrary compact convex body via homeomorphism to the standard simplex
  3. Turn the existence proof into a constructive ε-approximate fixed-point finder (Scarf/Kuhn simplicial pivoting)
  4. Replace the Bolzano–Weierstrass compactness step with an explicit modulus-of-continuity bound for a Bishop-constructive proof

Only `meta.json` changed; no Lean or annotation edits.