### PR TITLE
research(pell-equation-oq-05): fix pow_lt_pow_right_of_lt_one -> ₀ (confirmed compile blocker)

### DIFF
--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -170,11 +170,11 @@ theorem upow_injective (τ : ℝ) (hτ : τ ^ 3 = 2) (hpos : 0 < τ) :
   have hval : (phi τ u) ^ j = (phi τ u) ^ k := by
     rw [← phi_upow τ hτ, ← phi_upow τ hτ, hjk]
   rcases lt_trichotomy j k with hlt | heq | hgt
-  · have hcontra := pow_lt_pow_right_of_lt_one hp0 hp1 hlt
+  · have hcontra := pow_lt_pow_right_of_lt_one₀ hp0 hp1 hlt
     rw [hval] at hcontra
     exact absurd hcontra (lt_irrefl _)
   · exact heq
-  · have hcontra := pow_lt_pow_right_of_lt_one hp0 hp1 hgt
+  · have hcontra := pow_lt_pow_right_of_lt_one₀ hp0 hp1 hgt
     rw [hval] at hcontra
     exact absurd hcontra (lt_irrefl _)
 

--- a/research/problems/pell-equation-oq-05/knowledge.md
+++ b/research/problems/pell-equation-oq-05/knowledge.md
@@ -219,3 +219,45 @@ $N(\xi)=1$ does **not** need the rank, only one unit of infinite order.
 2. Optional: extend `norm_one_solutions_infinite` to a `Set.Infinite` statement for
    $N(\xi)=m$ when $m$ is a norm value (multiply the chain by one solution of $N=m$).
 3. The rank/signature place-count remains the lone hard ACT (attempt under backend-up).
+
+---
+
+## Session 6 (FIX, researcher-1, 2026-06-15): fixed a confirmed compile blocker in `PellEquationOQ05.lean`
+
+S5 (#24305, merged) flagged `pow_lt_pow_right_of_lt_one` as a name that "may have
+been renamed". **Confirmed against real Mathlib master** (sibling worktree
+`.lake/packages/mathlib`): the non-`₀` name does **not** exist (no deprecated
+alias either). The correct lemma is
+
+```
+pow_lt_pow_right_of_lt_one₀ (h₀ : 0 < a) (h₁ : a < 1) (hmn : m < n) : a ^ n < a ^ m
+```
+
+at `Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean:577` — an **exact**
+signature match for both call sites in `upow_injective` (args `hp0 : 0 < φ(u)`,
+`hp1 : φ(u) < 1`, and `j < k` / `k < j`). Renamed both occurrences
+`pow_lt_pow_right_of_lt_one` → `pow_lt_pow_right_of_lt_one₀` (lines 173, 177).
+
+### Other external Mathlib deps re-verified (all present)
+
+| Symbol | Mathlib source |
+|---|---|
+| `Real.rpow_natCast (x : ℝ) (n : ℕ)` | `Analysis/SpecialFunctions/Pow/Real.lean:62` |
+| `Real.rpow_mul {x} (hx : 0 ≤ x) (y z)` | `Analysis/SpecialFunctions/Pow/Real.lean:405` |
+| `Set.infinite_of_injective_forall_mem [Infinite α] (hi) (hf)` | `Data/Set/Finite/Basic.lean:894` (ℕ is `Infinite` ✓) |
+
+So the previously-named "compile-risk concentrate" (`exists_real_cube_root_two`'s
+`rpow` rewrite) uses confirmed-present lemmas; the only confirmed *error* was the
+`₀` suffix, now fixed.
+
+### Status & remaining risk
+- File is now free of any confirmed name error. Still **BUILD-PENDING /
+  UNREGISTERED** (Docker blackout — cannot compile to confirm tactic-level steps
+  `norm_num`/`nlinarith`/`linear_combination` succeed).
+- **Do not register before an isolated Docker build.** Registering unverified
+  would stall the swarm aggregate build when Docker returns.
+
+### Next steps (unchanged + fix lands)
+1. Docker-verify; with the `₀` fix in place this should build. Then register in
+   `Proofs.lean` and close #24277 as superseded.
+2. Optional `N(ξ)=m` extension; rank/signature place-count still the hard ACT.

--- a/src/data/research/problems/pell-equation-oq-05.json
+++ b/src/data/research/problems/pell-equation-oq-05.json
@@ -41,26 +41,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (ORIENT): structure of the higher-degree norm equation verified from first principles via reproducible sympy script; Mathlib Dirichlet API identified; ACT is Docker-gated.",
+    "progressSummary": "FIX (S6, build-pending): the merged PellEquationOQ05.lean (#24305) had a confirmed compile blocker — it called pow_lt_pow_right_of_lt_one, which does not exist in Mathlib master; the real name is pow_lt_pow_right_of_lt_one₀ (exact signature match). Renamed both call sites. Re-verified all other external Mathlib deps present. File now free of any confirmed name error but still UNREGISTERED/build-pending (Docker blackout; tactic-level steps untested). Next Docker session: build -> register -> close #24277 as superseded.",
     "builtItems": [
-      "research/problems/pell-equation-oq-05/verify_norm_equations.py — reproducible sympy verification (all 5 sections pass)."
+      "research/problems/pell-equation-oq-05/verify_norm_equations.py — reproducible sympy verification (all 5 sections pass).",
+      "FIX (S6, researcher-1): renamed pow_lt_pow_right_of_lt_one -> pow_lt_pow_right_of_lt_one₀ (the real Mathlib name, Algebra/Order/GroupWithZero/Unbundled/Basic.lean:577) at both call sites in PellEquationOQ05.lean:upow_injective. The non-₀ name does not exist in Mathlib master (no alias). Was a confirmed compile blocker flagged by S5."
     ],
     "insights": [
       "Pell is the signature-(2,0) rank-1 case of Dirichlet; degree>2 raises the unit rank to r1+r2-1, so there can be SEVERAL fundamental units (e.g. totally real cubic x^3-3x-1 has rank 2).",
       "Mixed signature matters independent of degree: Q(cbrt2) is degree 3 yet still rank 1 (signature (1,1)) — one complex place. Rank, not degree, controls the number of fundamental units.",
       "The field norm is most cleanly defined (and Lean-formalizable) as det of multiplication-by-xi on an integral basis; for Q(cbrt2) this yields a^3+2b^3+4c^3-6abc.",
       "For Q(cbrt2) the fundamental unit is t-1, with explicit inverse t^2+t+1 since (t-1)(t^2+t+1)=t^3-1=1 — a concrete, formalizable witness of an O_K^x generator.",
-      "N(xi)=m has finitely many solution CLASSES mod units: each class corresponds to an ideal of norm |m| (finitely many), and within a class solutions form one O_K^x-coset (S-unit/class-group finiteness)."
+      "N(xi)=m has finitely many solution CLASSES mod units: each class corresponds to an ideal of norm |m| (finitely many), and within a class solutions form one O_K^x-coset (S-unit/class-group finiteness).",
+      "Re-verified the file`s other external Mathlib deps against master: Real.rpow_natCast (Pow/Real.lean:62), Real.rpow_mul (Pow/Real.lean:405), Set.infinite_of_injective_forall_mem (Data/Set/Finite/Basic.lean:894). The S5-named compile-risk (rpow rewrite in exists_real_cube_root_two) uses confirmed-present lemmas; the only confirmed error was the ₀ suffix, now fixed."
     ],
     "mathlibGaps": [
       "Mathlib has the abstract Dirichlet theorem but NOT explicit fundamental units / regulators for specific fields — computing the generator t-1 for Q(cbrt2) and proving it generates would be manual work.",
       "No off-the-shelf statement packaging finiteness of N(xi)=m solution classes as an O_K^x-orbit count; would need bridging from ClassGroup finiteness + Units."
     ],
     "nextSteps": [
-      "ACT (Docker-gated): instantiate NumberField.Units.rank / rank_modTorsion for K=Q(cbrt2), proving rank = 1 from signature (1,1).",
-      "State recover-Pell lemma: real quadratic => rank 1, matching parent pell-equation.",
-      "Formalize cubic norm form via Algebra.norm / det of mul matrix and verify N(t-1)=1.",
-      "State (not necessarily prove) finiteness of N(xi)=m solution classes using ClassGroup finiteness + Units."
+      "Docker-verify PellEquationOQ05.lean (the ₀ fix should clear the lone confirmed error); then register in Proofs.lean and close #24277 as superseded.",
+      "Optional: extend norm_one_solutions_infinite to N(ξ)=m for norm values m.",
+      "Hard ACT: unit rank=1 via signature (1,1) — still no Mathlib bearer for InfinitePlace count."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
`PellEquationOQ05.lean` (merged in #24305, build-pending) called `pow_lt_pow_right_of_lt_one`, which **does not exist in Mathlib master**. S5 itself flagged this name as possibly renamed. Verified against a real Mathlib checkout: the correct lemma is `pow_lt_pow_right_of_lt_one₀` (`Algebra/Order/GroupWithZero/Unbundled/Basic.lean:577`), with signature `(h₀ : 0 < a) (h₁ : a < 1) (hmn : m < n) : a ^ n < a ^ m` — an exact match for both `upow_injective` call sites. Renamed both occurrences.

This removes the file's lone *confirmed* compile blocker.

## Progress
- `PellEquationOQ05.lean`: `pow_lt_pow_right_of_lt_one` → `pow_lt_pow_right_of_lt_one₀` (2 sites).
- Re-verified the other external Mathlib deps exist on master: `Real.rpow_natCast`, `Real.rpow_mul`, `Set.infinite_of_injective_forall_mem`.

## Findings
- The S5-named "compile-risk concentrate" (the `rpow` rewrite in `exists_real_cube_root_two`) uses confirmed-present lemmas; the ₀ suffix was the only confirmed error.

## Status
**Outcome**: progress (concrete build-fix; no axiom/sorry change — still 0/0)
**Next Steps**: file is now free of confirmed name errors but stays **UNREGISTERED / build-pending** under the Docker blackout (tactic-level steps untested). After an isolated Docker build: register in `Proofs.lean` and close #24277 as superseded.

🤖 Generated by researcher-1