### PR TITLE
research(nth-root-irrational-oq-01-oq-01): S1 ACT — cyclotomic-polynomial irrationality

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01.lean
@@ -1,0 +1,133 @@
+/-
+  Nth Root Irrationality OQ-01-OQ-01: Algebraic Irrationality of Cyclotomic Roots
+
+  The parent file `NthRootIrrationalOQ01.lean` established the structural
+  principle "a root of an irreducible degree ≥ 2 polynomial over ℚ is
+  irrational", and applied it to `X^n - p` (Eisenstein).
+
+  This file extends that principle to the **cyclotomic polynomials** Φ_n and
+  their roots, the primitive n-th roots of unity.
+
+  **Key facts used:**
+  - `cyclotomic.irreducible_rat`: Φ_n is irreducible over ℚ (n > 0).
+  - `natDegree_cyclotomic`: deg Φ_n = φ(n) (Euler totient).
+  - `totient ≥ 2` exactly when n ≥ 3.
+
+  **Results (0 axioms, 0 sorries):**
+  1. `totient_ge_two`           : 3 ≤ n → 2 ≤ φ(n).
+  2. `cyclotomic_no_rational_root` : Φ_n has no rational root for n ≥ 3.
+  3. `rational_root_of_unity_le_two` : the only rational roots of unity are ±1
+       (a primitive n-th root of unity in ℚ forces n ≤ 2).
+  4. `primitiveRoot_not_rational` : a complex primitive n-th root of unity
+       (n ≥ 3) is not in the image of ℚ — i.e. it is "irrational".
+  5. `primitiveCubeRoot_not_rational` : concrete instance e^{2πi/3}.
+
+  ## References
+  - Washington, L. (1997). "Introduction to Cyclotomic Fields." Ch. 2.
+  - Dummit & Foote (2004). "Abstract Algebra." §13.6 (Cyclotomic polynomials).
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 800000
+set_option linter.unusedVariables false
+
+open Polynomial
+
+namespace NthRootIrrationalOQ01OQ01
+
+noncomputable section
+
+-- ============================================================================
+-- Part 0: Self-contained core (irreducible degree ≥ 2 ⟹ no rational root)
+--   Re-proved here (identical to NthRootIrrationalOQ01) to keep this file
+--   independent of cross-file build state.
+-- ============================================================================
+
+/-- If `p ∈ ℚ[X]` is irreducible with degree ≥ 2, then `p` has no rational root. -/
+theorem irreducible_no_rational_root {p : ℚ[X]} (hirr : Irreducible p)
+    (hdeg : 2 ≤ p.natDegree) (r : ℚ) : ¬ p.IsRoot r := by
+  intro hroot
+  obtain ⟨q, hpq⟩ := dvd_iff_isRoot.mpr hroot
+  rcases hirr.isUnit_or_isUnit hpq with hu | hu
+  · exact (irreducible_X_sub_C r).1 hu
+  · have hne1 := X_sub_C_ne_zero r
+    have hne2 : q ≠ 0 := right_ne_zero_of_mul (hpq ▸ hirr.ne_zero)
+    have hd : p.natDegree = 1 + q.natDegree := by
+      rw [hpq, natDegree_mul hne1 hne2, natDegree_X_sub_C]
+    have hq0 : q.natDegree = 0 := by
+      rcases Polynomial.isUnit_iff.mp hu with ⟨c, _, rfl⟩
+      exact natDegree_C c
+    omega
+
+-- ============================================================================
+-- Part I: The totient is ≥ 2 for n ≥ 3
+-- ============================================================================
+
+/-- Euler's totient satisfies `φ(n) ≥ 2` for all `n ≥ 3`.
+    (φ(1) = φ(2) = 1 are the only values equal to 1.) -/
+theorem totient_ge_two {n : ℕ} (hn : 3 ≤ n) : 2 ≤ n.totient := by
+  have hpos : 0 < n.totient := Nat.totient_pos.mpr (by omega)
+  have hne1 : n.totient ≠ 1 := by
+    intro h
+    rcases Nat.totient_eq_one_iff.mp h with h1 | h2 <;> omega
+  omega
+
+-- ============================================================================
+-- Part II: Cyclotomic polynomials have no rational root (n ≥ 3)
+-- ============================================================================
+
+/-- **Cyclotomic irrationality core**: for `n ≥ 3`, the cyclotomic polynomial
+    `Φ_n` has no rational root, because it is irreducible over ℚ of degree
+    `φ(n) ≥ 2`. -/
+theorem cyclotomic_no_rational_root {n : ℕ} (hn : 3 ≤ n) (r : ℚ) :
+    ¬ (cyclotomic n ℚ).IsRoot r := by
+  have hirr : Irreducible (cyclotomic n ℚ) := cyclotomic.irreducible_rat (by omega : 0 < n)
+  have hdeg : 2 ≤ (cyclotomic n ℚ).natDegree := by
+    rw [natDegree_cyclotomic]
+    exact totient_ge_two hn
+  exact irreducible_no_rational_root hirr hdeg r
+
+-- ============================================================================
+-- Part III: The only rational roots of unity are ±1
+-- ============================================================================
+
+/-- **Rational roots of unity are ±1**: if `r : ℚ` is a primitive `n`-th root
+    of unity, then `n ≤ 2`. Equivalently, the only roots of unity in ℚ are
+    `1` (n = 1) and `-1` (n = 2). -/
+theorem rational_root_of_unity_le_two {n : ℕ} {r : ℚ}
+    (hn : 0 < n) (hr : IsPrimitiveRoot r n) : n ≤ 2 := by
+  by_contra h
+  have h3 : 3 ≤ n := by omega
+  have hroot : (cyclotomic n ℚ).IsRoot r := hr.isRoot_cyclotomic hn
+  exact cyclotomic_no_rational_root h3 r hroot
+
+-- ============================================================================
+-- Part IV: Complex primitive roots of unity are irrational
+-- ============================================================================
+
+/-- **Irrationality of cyclotomic roots**: a complex primitive `n`-th root of
+    unity with `n ≥ 3` is not the image of any rational number; i.e. it is a
+    genuine algebraic irrational. -/
+theorem primitiveRoot_not_rational {n : ℕ} (hn : 3 ≤ n) {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) : ζ ∉ Set.range ((algebraMap ℚ ℂ) : ℚ → ℂ) := by
+  rintro ⟨r, rfl⟩
+  have hrat : IsPrimitiveRoot r n :=
+    hζ.of_map_of_injective (algebraMap ℚ ℂ).injective
+  have hle : n ≤ 2 := rational_root_of_unity_le_two (by omega) hrat
+  omega
+
+-- ============================================================================
+-- Part V: Concrete instance
+-- ============================================================================
+
+/-- The complex number `e^{2πi/3}` (a primitive cube root of unity) is not
+    rational. -/
+theorem primitiveCubeRoot_not_rational :
+    Complex.exp (2 * ↑Real.pi * Complex.I / (3 : ℕ)) ∉ Set.range ((algebraMap ℚ ℂ) : ℚ → ℂ) :=
+  primitiveRoot_not_rational (by norm_num)
+    (Complex.isPrimitiveRoot_exp 3 (by norm_num))
+
+end
+
+end NthRootIrrationalOQ01OQ01

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -1,0 +1,87 @@
+# Knowledge Base: nth-root-irrational-oq-01-oq-01
+
+**Title**: Algebraic irrationality of roots of cyclotomic polynomials and their subfields
+**Phase**: ACT
+**Status**: active (build-pending under Docker/Aristotle blackout)
+
+---
+
+## Problem Understanding
+
+The parent `nth-root-irrational-oq-01` (`NthRootIrrationalOQ01.lean`) proved the
+structural principle: *a root of an irreducible polynomial of degree ≥ 2 over ℚ
+is irrational*, and applied it to `X^n − p` via Eisenstein. This OQ asks to
+extend that principle to **cyclotomic polynomials** Φ_n and their roots (the
+primitive n-th roots of unity), and to their subfields.
+
+---
+
+## Result (this session, 2026-06-15, Session 1, FRESH → ACT)
+
+New file `proofs/Proofs/NthRootIrrationalOQ01OQ01.lean` (0 sorries, 0 axioms,
+build-pending — both backends down at authoring time). Reuses the parent's
+already-proven "irreducible deg ≥ 2 ⇒ no rational root" core (re-proved inline,
+verbatim, to keep the file independent of cross-file build state).
+
+1. `totient_ge_two` — `3 ≤ n → 2 ≤ Nat.totient n`. Proof: `Nat.totient_pos`
+   (positivity) + `Nat.totient_eq_one_iff` (`φ n = 1 ↔ n = 1 ∨ n = 2`) ⇒ omega.
+2. `cyclotomic_no_rational_root` — for `n ≥ 3`, `Φ_n` (over ℚ) has **no rational
+   root**. Proof: `cyclotomic.irreducible_rat` + `natDegree_cyclotomic` (= φ(n))
+   + `totient_ge_two` feed the inline core.
+3. `rational_root_of_unity_le_two` — if `r : ℚ` is a primitive `n`-th root of
+   unity (`0 < n`) then `n ≤ 2`. **The only rational roots of unity are ±1.**
+   Proof: `IsPrimitiveRoot.isRoot_cyclotomic` gives `r` a root of `Φ_n`,
+   contradicting (2) when `n ≥ 3`.
+4. `primitiveRoot_not_rational` — a **complex** primitive `n`-th root of unity
+   (`n ≥ 3`) is not in `Set.range (algebraMap ℚ ℂ)`; i.e. it is irrational.
+   Proof: descend `ζ = algebraMap r` to `r : ℚ` via
+   `IsPrimitiveRoot.of_map_of_injective` + `(algebraMap ℚ ℂ).injective`, then (3).
+5. `primitiveCubeRoot_not_rational` — concrete instance `e^{2πi/3}` via
+   `Complex.isPrimitiveRoot_exp 3`.
+
+Numerically pre-verified (sympy): φ(n) ≥ 2 for all 3 ≤ n ≤ 200; deg Φ_n = φ(n);
+Φ_n has no rational roots for n = 3,4,5,6.
+
+---
+
+## Insights
+
+- The whole extension is "swap `X^n − p` (Eisenstein) for `Φ_n`
+  (`cyclotomic.irreducible_rat`)" in the parent's irreducibility-⇒-irrational
+  pipeline. The only genuinely new lemma is the degree lower bound
+  `φ(n) ≥ 2 ⇔ n ≥ 3`.
+- `Φ_n` has **no real roots** for n ≥ 3 (Φ_3 = X²+X+1, Φ_4 = X²+1, …), so the
+  honest content lives in ℂ (not-rational) and in the rational-roots-of-unity =
+  ±1 corollary — not in any "irrational real root" statement (which is vacuous).
+
+## Mathlib gaps
+
+- None for the rational/complex statements. The real **subfield** story
+  (degree of `2cos(2π/n)` = φ(n)/2, irrational for n ≥ 5 except 6) was NOT
+  formalized this session — `minpoly` of `2cos` is the missing piece; deferred
+  as a follow-up OQ (would need the maximal-real-subfield minimal polynomial).
+
+## Next steps / fragile points if CI fails
+
+- `Nat.totient_eq_one_iff` (name) — fallback: prove φ(n) ≥ 2 via the two
+  distinct coprime witnesses `1` and `n−1` in `Finset.range n`.
+- `Nat.totient_pos.mpr` assumes the iff form (current Mathlib v4.26). If the
+  one-directional form is in scope, drop `.mpr`.
+- `IsPrimitiveRoot.of_map_of_injective` (Part IV) — assumes the bundled
+  `MonoidHomClass` form so `algebraMap ℚ ℂ` unifies directly. Fallback: descend
+  via `map_cyclotomic n (algebraMap ℚ ℂ)` + `eval_map`/`aeval` + `map_eq_zero_iff`
+  injective, landing on `cyclotomic_no_rational_root` directly.
+- `Complex.isPrimitiveRoot_exp` arg form `2 * ↑Real.pi * Complex.I / (n : ℕ)` —
+  the concrete instance matches the `↑(3:ℕ)` denominator exactly.
+- Register in `proofs/Proofs.lean` and `docker-build.sh Proofs.NthRootIrrationalOQ01OQ01`
+  once a backend is available (left UNREGISTERED to protect auto-merge).
+
+## Follow-up OQ (after SOLVED)
+
+- Maximal real subfield: is `2cos(2π/n)` irrational for n ≥ 5 (n ≠ 6), via its
+  degree-`φ(n)/2` minimal polynomial? (Genuinely distinct: needs the real
+  cyclotomic subfield minpoly, absent above.)
+
+## Dead ends
+
+- "Irrational real root of Φ_n" — vacuous; Φ_n has no real roots for n ≥ 3.

--- a/research/problems/nth-root-irrational-oq-01-oq-01/state.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: nth-root-irrational-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-15T00:57:04-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
+++ b/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
@@ -1,0 +1,98 @@
+{
+  "slug": "nth-root-irrational-oq-01-oq-01",
+  "title": "Extend to algebraic irrationality of roots of cyclotomic polynomials and their subfields",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Extend to algebraic irrationality of roots of cyclotomic polynomials and their subfields",
+    "plain": "This open question arises from the gallery proof `nth-root-irrational-oq-01` (Nth Root Irrationality via Irreducible Polynomials). The Seeker selected it as a generalization suitable for the autonomous research pipeline.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-15T00:57:04-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: extended nth-root irrationality to cyclotomic polynomials — Phi_n has no rational root (n>=3), rational roots of unity are +-1, complex primitive roots are irrational; 0 sorries/0 axioms, build-pending; real-subfield (2cos) deferred",
+    "builtItems": [
+      "cyclotomic_no_rational_root (NthRootIrrationalOQ01OQ01.lean): Phi_n over Q has no rational root for n>=3",
+      "rational_root_of_unity_le_two: only rational roots of unity are +-1 (primitive n-th root in Q forces n<=2)",
+      "primitiveRoot_not_rational: complex primitive n-th root of unity (n>=3) is not in range(algebraMap Q C)",
+      "totient_ge_two: 3<=n implies 2<=Nat.totient n; primitiveCubeRoot_not_rational instance e^{2pi i/3}"
+    ],
+    "insights": [
+      "Cyclotomic extension of nth-root irrationality reduces to swapping X^n-p (Eisenstein) for Phi_n (cyclotomic.irreducible_rat) in the parent irreducibility-implies-irrational pipeline; only new lemma is degree bound phi(n)>=2 iff n>=3",
+      "Phi_n has NO real roots for n>=3, so honest content is complex not-rational + rational-roots-of-unity=+-1; an irrational-real-root statement is vacuous"
+    ],
+    "mathlibGaps": [
+      "No gap for rational/complex statements; the real subfield story (minpoly of 2cos(2pi/n), degree phi(n)/2) was NOT formalized and is the missing piece"
+    ],
+    "nextSteps": [
+      "Build+register NthRootIrrationalOQ01OQ01.lean once Docker/Aristotle backend available (left UNREGISTERED to protect auto-merge)",
+      "Follow-up OQ: is 2cos(2pi/n) irrational for n>=5 (n!=6) via its degree-phi(n)/2 minimal polynomial over Q?"
+    ],
+    "markdown": "# Knowledge Base: nth-root-irrational-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "algebra",
+    "eisenstein",
+    "gallery-extracted",
+    "galois-theory",
+    "infrastructure",
+    "irrationality",
+    "polynomials",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "nth-root-irrational",
+    "nth-root-irrational-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T00:57:04-07:00",
+  "significance": 5,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/NthRootIrrational.lean",
+      "filename": "NthRootIrrational.lean",
+      "lineCount": 313,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NthRootIrrational.lean"
+    },
+    {
+      "path": "Proofs/NthRootIrrationalOQ01.lean",
+      "filename": "NthRootIrrationalOQ01.lean",
+      "lineCount": 210,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NthRootIrrationalOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the parent OQ `nth-root-irrational-oq-01` (the structural principle *a root of an irreducible degree ≥ 2 polynomial over ℚ is irrational*, applied to `X^n − p` via Eisenstein) to the **cyclotomic polynomials** Φ_n and the primitive roots of unity.

New file `proofs/Proofs/NthRootIrrationalOQ01OQ01.lean` (**0 sorries, 0 axioms**):

- `totient_ge_two` — `3 ≤ n → 2 ≤ φ(n)`.
- `cyclotomic_no_rational_root` — `Φ_n` over ℚ has **no rational root** for `n ≥ 3` (irreducible of degree `φ(n) ≥ 2`).
- `rational_root_of_unity_le_two` — the **only rational roots of unity are ±1** (a primitive `n`-th root in ℚ forces `n ≤ 2`).
- `primitiveRoot_not_rational` — a **complex** primitive `n`-th root of unity (`n ≥ 3`) is not in `range (algebraMap ℚ ℂ)`, i.e. irrational.
- `primitiveCubeRoot_not_rational` — concrete instance `e^{2πi/3}`.

The parent's "irreducible ⇒ no rational root" core is re-proved inline (verbatim) so the file is independent of cross-file build state.

## Notes

- **Build-pending**: Docker and Aristotle backends were both down at authoring time, so the file is **left UNREGISTERED** in `proofs/Proofs.lean` to protect auto-merge. Register + `docker-build.sh Proofs.NthRootIrrationalOQ01OQ01` once a backend is available.
- Math pre-verified numerically (sympy): `φ(n) ≥ 2` for all `3 ≤ n ≤ 200`; `deg Φ_n = φ(n)`; `Φ_n` has no rational roots for `n = 3,4,5,6`.
- Honest scope: `Φ_n` has no *real* roots for `n ≥ 3`, so the content lives in ℂ (not-rational) and the ±1 corollary. The real **subfield** story (`2cos(2π/n)`, degree `φ(n)/2`) is **not** formalized here and is recorded as a follow-up OQ.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ01OQ01` once Docker is back.
- [ ] Confirm risk points compile: `Nat.totient_eq_one_iff`, `Nat.totient_pos.mpr`, `IsPrimitiveRoot.of_map_of_injective`, `cyclotomic.irreducible_rat`, `natDegree_cyclotomic`, `Complex.isPrimitiveRoot_exp`.
- [ ] Register in `proofs/Proofs.lean` after a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)