### PR TITLE
research(erdos-1107-oq-02-oq-01): S4 — general isCubeful_pow lemma

### DIFF
--- a/proofs/Proofs/Erdos1107OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1107OQ02OQ01.lean
@@ -136,6 +136,21 @@ theorem isCubeful_zero : IsCubeful 0 := by simp [IsCubeful]
 /-- 1 is cubeful (vacuously). -/
 theorem isCubeful_one : IsCubeful 1 := by simp [IsCubeful]
 
+/-- **General source of cubeful numbers**: every perfect `k`-th power with `k ≥ 3`
+    is cubeful.  If a prime `p` divides `n ^ k` then `p ∣ n`, so `p ^ 3 ∣ p ^ k ∣ n ^ k`.
+    This is the structural reason the numeric witnesses below are cubeful, and (unlike
+    them) it holds for *all* `n` — no `native_decide`. -/
+theorem isCubeful_pow {n k : ℕ} (hk : 3 ≤ k) : IsCubeful (n ^ k) := by
+  intro p hp
+  have hpp : Prime p := (prime_of_mem_primeFactors hp).prime
+  have hpd : p ∣ n ^ k := dvd_of_mem_primeFactors hp
+  have hpn : p ∣ n := hpp.dvd_of_dvd_pow hpd
+  calc p ^ 3 ∣ p ^ k := pow_dvd_pow p hk
+    _ ∣ n ^ k := pow_dvd_pow_of_dvd hpn k
+
+/-- Every perfect cube is cubeful (the `k = 3` case of `isCubeful_pow`). -/
+theorem isCubeful_cube (n : ℕ) : IsCubeful (n ^ 3) := isCubeful_pow (le_refl 3)
+
 /-- Prime powers `p^k` with `k ≥ 3` are cubeful. -/
 theorem isCubeful_8 : IsCubeful 8 := by native_decide      -- 2³
 theorem isCubeful_16 : IsCubeful 16 := by native_decide    -- 2⁴

--- a/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
@@ -148,3 +148,46 @@ avoid breaking the auto-merged main aggregate with an unverified `native_decide`
   blocks (range 0–500, 500–1000, …) as done for the above-threshold ranges.
 - On green build: register via `./.lean/scripts/generate-proofs-imports.sh` and add a gallery
   meta.json (`status: axiomatized`, `badge: axiom`, axiomCount 1) for the r=3 entry.
+
+## Session 2026-06-15 (Session 4, researcher-3) — ACT, general structural lemma (build-pending)
+
+**Mode**: continue (ACT; Docker DOWN + Aristotle `prove` returns "Resource not found"/404 —
+re-probed this session, dual blackout confirmed).
+**Outcome**: progress — added the *general* cubeful-source lemma the file was missing.
+
+### What I Did
+- The Session-3 file proved cubefulness only for specific literals (`isCubeful_8/16/27/2000`,
+  each `native_decide`). Added the underlying **general theorem**, valid for all `n` and *not*
+  `native_decide`:
+  - `isCubeful_pow {n k} (hk : 3 ≤ k) : IsCubeful (n ^ k)` — every perfect `k`-th power with
+    `k ≥ 3` is cubeful. Proof: for `p ∈ (n^k).primeFactors`, `Prime p` and `p ∣ n^k`, so
+    `p ∣ n` (`Prime.dvd_of_dvd_pow`); then `p^3 ∣ p^k ∣ n^k` (`pow_dvd_pow` + `pow_dvd_pow_of_dvd`).
+  - `isCubeful_cube (n) : IsCubeful (n ^ 3)` — the `k = 3` corollary.
+- This generalizes all four ad-hoc numeric witnesses (8 = 2³, 27 = 3³, … are special cases)
+  with one short Mathlib proof.
+
+### Verification done WITHOUT the build (Docker down)
+- Verified every Mathlib identifier and signature against the live checkout in the sibling
+  worktree `.loom/worktrees/stokes-dd/.../mathlib/Mathlib` (own worktree has no Mathlib):
+  - `Nat.mem_primeFactors` / `prime_of_mem_primeFactors` / `dvd_of_mem_primeFactors`
+    (PrimeFin.lean:39,62,63)
+  - `Prime.dvd_of_dvd_pow` (Algebra/Prime/Defs.lean:74)
+  - `pow_dvd_pow (a) (h : m ≤ n) : a^m ∣ a^n` (Algebra/Divisibility/Basic.lean:134)
+  - `pow_dvd_pow_of_dvd (h : a ∣ b) (n) : a^n ∣ b^n` (Algebra/Divisibility/Basic.lean:200)
+- `calc` over `∣` uses Mathlib's `Trans` instance for `Dvd.dvd` — standard.
+
+### Honesty / scope
+- No new mathematics about the threshold — this is a structural-cleanliness improvement: the
+  file now states *why* powers are cubeful in general, rather than only asserting it for four
+  constants. Axiom count unchanged (still 1 = the open r=3 asymptotic); sorry count still 0.
+- **Build-pending**: name/signature-checked against master but NOT compiled (Docker DOWN, direct
+  `lake` banned). File remains UNREGISTERED in `Proofs.lean`.
+
+### Files Modified
+- `proofs/Proofs/Erdos1107OQ02OQ01.lean` (added `isCubeful_pow`, `isCubeful_cube`)
+- `research/problems/erdos-1107-oq-02-oq-01/knowledge.md` (this note)
+
+### Next Steps (unchanged from Session 3, all Docker-gated)
+- Build `Proofs.Erdos1107OQ02OQ01`; split `below_threshold_nonexceptions` into blocks if the
+  single `native_decide` over `[0,2040)` is too heavy. On green build: register + add gallery
+  meta.json (`status: axiomatized`, `badge: axiom`, axiomCount 1).


### PR DESCRIPTION
## Summary
Session 4 (researcher-3) on the cubeful r=3 case of Erdős #1107 — a build-free **structural cleanup** of the existing build-pending Lean file.

- Adds `isCubeful_pow {n k} (hk : 3 ≤ k) : IsCubeful (n ^ k)` — every perfect `k`-th power with `k ≥ 3` is cubeful, valid for **all** `n` (a real proof, not `native_decide`).
- Adds the `k = 3` corollary `isCubeful_cube (n) : IsCubeful (n ^ 3)`.
- These generalize the four ad-hoc literal witnesses already in the file (`8 = 2³`, `27 = 3³`, …), stating *why* powers are cubeful rather than only asserting it for constants.

Proof: for `p ∈ (n^k).primeFactors`, `Prime p` and `p ∣ n^k` ⟹ `p ∣ n` (`Prime.dvd_of_dvd_pow`); then `p^3 ∣ p^k ∣ n^k` (`pow_dvd_pow` + `pow_dvd_pow_of_dvd`).

## Verification (no build — dual blackout)
Docker is down and direct `lake` is banned; Aristotle `prove` returns "Resource not found" (404). Every Mathlib identifier and signature was name-checked against the live master checkout in a sibling worktree:
- `Nat.{mem,prime_of_mem,dvd_of_mem}_primeFactors` (PrimeFin.lean:39,62,63)
- `Prime.dvd_of_dvd_pow` (Algebra/Prime/Defs.lean:74)
- `pow_dvd_pow` (Algebra/Divisibility/Basic.lean:134), `pow_dvd_pow_of_dvd` (:200)

**Build-pending**: not compiled, file remains UNREGISTERED in `Proofs.lean`. Axiom count unchanged (1 = the open r=3 asymptotic); sorry count 0.

## Test plan
- [ ] On Docker-up: `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01`
- [ ] If `native_decide` over `[0,2040)` is heavy, split `below_threshold_nonexceptions` into blocks
- [ ] On green build: register + add gallery meta.json (`status: axiomatized`, axiomCount 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)