### PR TITLE
research(descartes-rule-of-signs-oq-02-oq-03): S2 ACT — P1 parity engine

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02Parity.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02Parity.lean
@@ -1,0 +1,90 @@
+import Mathlib.Tactic
+
+/-
+# Budan parity engine (P1) — companion to `DescartesRuleOfSignsOQ02.lean`
+
+This file isolates and proves **P1** from the `budan_parity` formalization plan
+(`research/problems/descartes-rule-of-signs-oq-02-oq-03/knowledge.md`, S1):
+
+> `parity(signChangesInList l) = (firstNonzeroSign l ≠ lastNonzeroSign l)`
+
+The mathematical heart of P1 is purely combinatorial and has **nothing to do**
+with polynomials: for a list whose entries are all `±1`, the number of adjacent
+sign changes (`countAdjacentDiffs`) is *even* iff the first and last entries
+agree. This is because each adjacent difference *toggles* the running value in a
+two-element set, so an even number of toggles returns to the start.
+
+`countAdjacentDiffs` is re-declared here **verbatim** from
+`DescartesRuleOfSignsOQ02.lean:130` so this file is self-contained and
+independently checkable; the proved lemma drops into the main file unchanged
+(same definition, same namespace target).
+
+## How this feeds the axiom
+
+In the main file, `signChangesInList l = countAdjacentDiffs (signs l)` where
+`signs l := (l.filter (· ≠ 0)).map (fun x => if x > 0 then 1 else -1)` takes
+values in `{1, -1}`. Hence `countAdjacentDiffs_parity` below applies directly
+to give `parity(signChangesInList l) = [firstSign ≠ lastSign]`, which is P1.
+P2 then identifies first sign `= sign p(x)` and last sign `= sign(n!·leadingCoeff)`
+(sign-constant in `x`); P3 supplies the FTA content
+`[sign p(a) ≠ sign p(b)] ⟺ Odd(rootsInInterval p a b)`.
+
+Status: build-pending (Docker + Aristotle both unavailable 2026-06-15),
+UNREGISTERED (not added to the gallery registry).
+-/
+
+namespace BudanParityEngine
+
+/-- Count adjacent pairs that differ in a list of integers.
+    (Verbatim copy of `BudanTheorem.countAdjacentDiffs`.) -/
+def countAdjacentDiffs : List ℤ → ℕ
+  | [] => 0
+  | [_] => 0
+  | a :: b :: rest =>
+    (if a ≠ b then 1 else 0) + countAdjacentDiffs (b :: rest)
+
+@[simp] theorem countAdjacentDiffs_nil : countAdjacentDiffs [] = 0 := rfl
+@[simp] theorem countAdjacentDiffs_singleton (a : ℤ) : countAdjacentDiffs [a] = 0 := rfl
+
+/-- **P1 (parity engine).** For a nonempty list `a :: t` whose entries are all
+`±1`, the number of adjacent sign changes is even iff the head equals the last
+entry. Equivalently, `countAdjacentDiffs (a :: t) % 2 = [head ≠ last]`.
+
+The proof is structural induction on the tail; the only non-formal step is that
+in a two-element value set `{1, -1}`, "`a` differs from `b`" XOR "`b` differs
+from the last" equals "`a` differs from the last" — discharged by `split_ifs`
+on the concrete `±1` cases plus `omega`. -/
+theorem countAdjacentDiffs_parity :
+    ∀ (a : ℤ) (t : List ℤ), (∀ y ∈ a :: t, y = 1 ∨ y = -1) →
+      countAdjacentDiffs (a :: t) % 2 =
+        (if a = (a :: t).getLast (List.cons_ne_nil a t) then 0 else 1)
+  | a, [], _ => by
+      have hg : ([a] : List ℤ).getLast (List.cons_ne_nil a []) = a := rfl
+      simp [countAdjacentDiffs, hg]
+  | a, b :: rest, hpm => by
+      -- last entry of the whole list = last entry of the tail; name it `z`
+      have hlast : (a :: b :: rest).getLast (List.cons_ne_nil a (b :: rest))
+          = (b :: rest).getLast (List.cons_ne_nil b rest) :=
+        List.getLast_cons (List.cons_ne_nil b rest)
+      obtain ⟨z, hz_eq⟩ :
+          ∃ z, (b :: rest).getLast (List.cons_ne_nil b rest) = z := ⟨_, rfl⟩
+      have hz_mem : z ∈ b :: rest := by
+        rw [← hz_eq]; exact List.getLast_mem _
+      -- membership ⇒ each of a, b, z is ±1
+      have ha : a = 1 ∨ a = -1 := hpm a (List.mem_cons_self _ _)
+      have hb : b = 1 ∨ b = -1 :=
+        hpm b (List.mem_cons_of_mem a (List.mem_cons_self _ _))
+      have hzpm : z = 1 ∨ z = -1 := hpm z (List.mem_cons_of_mem a hz_mem)
+      -- induction hypothesis on the tail
+      have ih := countAdjacentDiffs_parity b rest
+        (fun y hy => hpm y (List.mem_cons_of_mem a hy))
+      rw [hz_eq] at ih
+      -- unfold one step of the count, push getLast to `z`
+      simp only [countAdjacentDiffs]
+      rw [hlast, hz_eq]
+      -- `countAdjacentDiffs (b :: rest)` is an opaque atom shared by `ih` and the
+      -- goal; `omega` pins its parity from `ih`. Case-bash the ±1 endpoints.
+      rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;>
+        rcases hzpm with rfl | rfl <;> split_ifs at ih ⊢ <;> omega
+
+end BudanParityEngine

--- a/research/problems/descartes-rule-of-signs-oq-02-oq-03/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-03/knowledge.md
@@ -99,6 +99,55 @@ reduction for a sibling session.
 - `List.destutter` — `Mathlib/Data/List/Destutter.lean` (the (B) parity engine, if going via Mathlib).
 - `Polynomial.roots` / `Multiset.countP` / eval-as-product — for P3.
 
+## Session 2026-06-15 (S2, researcher-8) — ACT: P1 parity engine written (build-pending)
+
+**Mode:** FRESH (richest non-flagged available slug; 0 open PRs). **Both backends still down**
+(Docker `docker info` times out; Aristotle MCP `prove` → `"Resource not found"` on a trivial
+`n + 0 = n` ping). So: numerically certified hand proof, build-pending.
+
+### What I did
+Wrote **P1** — the combinatorial parity engine S1 flagged as elementary but never authored —
+as a self-contained companion `proofs/Proofs/DescartesRuleOfSignsOQ02Parity.lean` (UNREGISTERED):
+
+```
+theorem countAdjacentDiffs_parity (a : ℤ) (t : List ℤ)
+    (hpm : ∀ y ∈ a :: t, y = 1 ∨ y = -1) :
+    countAdjacentDiffs (a :: t) % 2 = (if a = (a :: t).getLast _ then 0 else 1)
+```
+
+i.e. for a `±1` list, sign-change count is even ⟺ head = last. `countAdjacentDiffs` is copied
+**verbatim** from `DescartesRuleOfSignsOQ02.lean:130`, so the lemma drops straight into the main
+file (same def, same intended namespace).
+
+### Proof shape (the reusable trick)
+Structural induction on the tail. Each adjacent difference *toggles* the running value in the
+2-element set `{1,-1}`; the only non-formal step is the XOR identity `[a≠b] ⊕ [b≠z] = [a≠z]`,
+discharged by `rcases` on the three `±1` endpoints (a, b, last `z`) → `split_ifs at ih ⊢` →
+`omega`. Key API: `List.getLast_cons` (push last to the tail), `List.getLast_mem` (last is `±1`),
+`obtain ⟨z, hz_eq⟩` to free the `getLast` term so its `±1` value can be `rcases`-substituted.
+**No `generalize … at`** — `omega` atomizes the opaque `countAdjacentDiffs (b::rest)` and pins its
+parity from `ih` directly.
+
+### Verification
+`countAdjacentDiffs_parity` claim checked exhaustively over **all 2046** `±1` lists of length
+1–10 (`python3` inline): 0 failures. Math is solid; only Lean-API/`rw`-fire risk remains
+(unbuildable under blackout).
+
+### Where this sits in the plan
+This is exactly **P1** from S1's table. It gives `parity(signChangesInList l) = [firstSign ≠
+lastSign]` once composed with the `signs`-map (values `±1` by construction). **P2** (first sign
+`= sign p(x)`, last `= sign(n!·leadingCoeff)`, sign-constant in `x`) and **P3** (the FTA content
+`[sign p(a)≠sign p(b)] ⟺ Odd(rootsInInterval)`) are still open; P3 is the genuine theorem and
+needs a live build to iterate the `roots`-product sign argument.
+
+### Next steps
+- Live build: typecheck the companion; if `List.getLast_cons` arg form / `mem_cons_self` arity
+  drift, repair, then **move the lemma into `DescartesRuleOfSignsOQ02.lean`** next to its `countAdjacentDiffs`.
+- P2: prove last Budan entry `= n!·leadingCoeff` (sign-constant) via in-file `iterDeriv` +
+  `Polynomial.iterate_derivative_…`; compose with P1 for `parity(budanCount) = [sign p(x) ≠ sign lead]`.
+- P3: the `Polynomial.roots` eval-as-product sign argument (~100–150 LOC) — the one piece that
+  truly discharges `budan_parity_axiom`.
+
 ## Dead Ends / Refuted
 
 - **"`budan_parity` is a direct corollary of Mathlib's Descartes (`RuleOfSigns.lean`)."** No —


### PR DESCRIPTION
## Summary
- Writes **P1** of the `budan_parity` axiom-discharge plan for `descartes-rule-of-signs-oq-02-oq-03`: the elementary combinatorial parity engine that S1 flagged as routine but never authored.
- New self-contained companion `proofs/Proofs/DescartesRuleOfSignsOQ02Parity.lean` (UNREGISTERED) proving, for a `±1` list, `countAdjacentDiffs (a :: t) % 2 = [head ≠ last]`.
- This is exactly `parity(signChangesInList l) = [firstSign ≠ lastSign]` once composed with the `signs`-map (values `±1` by construction).

## Approach
- `countAdjacentDiffs` is copied **verbatim** from `DescartesRuleOfSignsOQ02.lean:130`, so the lemma drops into the main file unchanged.
- Proof: structural induction on the tail. Each adjacent difference toggles the running value in the 2-element set `{1,-1}`; the XOR identity `[a≠b] ⊕ [b≠z] = [a≠z]` is discharged by `rcases` on the three `±1` endpoints → `split_ifs at ih ⊢` → `omega`. `omega` atomizes the opaque recursive subterm and pins its parity from the IH.
- Claim verified exhaustively over **all 2046** `±1` lists of length 1–10 (0 failures).

## Status
- **Build-pending + UNREGISTERED**: Docker (`docker info` times out) and Aristotle MCP (`prove` → "Resource not found") were both unavailable on 2026-06-15. Math is certified; residual risk is only Lean-API/`rw`-fire drift, to be repaired on the next live build, after which the lemma moves into the main file.
- **P2** (first sign `= sign p(x)`, last `= sign(n!·leadingCoeff)`) and **P3** (the FTA content `[sign p(a)≠sign p(b)] ⟺ Odd(rootsInInterval)`) remain open; P3 is the genuine theorem that discharges `budan_parity_axiom`.

## Test plan
- [ ] Live build: typecheck companion; repair any `List.getLast_cons` / `mem_cons_self` API drift.
- [ ] Move `countAdjacentDiffs_parity` into `DescartesRuleOfSignsOQ02.lean` next to `countAdjacentDiffs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)