### PR TITLE
research(fermat-defect-one-oq-02): negative-defect infinitude at n=3

### DIFF
--- a/proofs/Proofs/FermatDefectOneNegInfinitude.lean
+++ b/proofs/Proofs/FermatDefectOneNegInfinitude.lean
@@ -1,0 +1,118 @@
+/-
+  Negative-defect infinitude for the Fermat Defect-One Conjecture (n = 3)
+
+  Companion to `FermatDefectOneFamilies.lean`, which proves that the *positive*-
+  defect Mahler family produces infinitely many primitive witnesses at n = 3
+  (`defect_pos_witnesses_infinite`). That theorem leaves the negative-defect side
+  at mere existence (`fermat_defect_three_neg_t2`, a single witness at t = 2).
+
+  This file closes the symmetry. The negative-defect Mahler family
+
+      (9t³ − 1)³ + (9t⁴ − 3t)³ + 1 = (9t⁴)³        (defect −1, i.e. aⁿ + bⁿ − cⁿ = −1)
+
+  also yields infinitely many *primitive* witnesses. Combined with the positive
+  result, open question OQ-02 ("are both signs of the defect realised for every
+  n ≥ 3?") is settled at n = 3 in its strongest form: **each sign of the defect
+  occurs infinitely often**, along an explicit polynomial family.
+
+  Ordering note. For t ≥ 2 the base terms satisfy
+      9t³ − 1 ≤ 9t⁴ − 3t < 9t⁴,
+  so the ordered primitive witness is `(9t³ − 1, 9t⁴ − 3t, 9t⁴)`. (At t = 1 this
+  degenerates to the benchmark `(6, 8, 9)` after swapping the first two
+  coordinates.) The value of c is `9t⁴`, strictly increasing in t, so the set of
+  attainable c's is infinite.
+-/
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne
+
+/-- **Negative-defect coprimality kernel.** `9t³ − 1` and `9t⁴` are coprime for
+every `t ≥ 1`.
+
+Proof: a common divisor `d` divides `9t⁴ = t·(9t³ − 1) + t`, hence — using
+`d ∣ t·(9t³ − 1)` — divides `t`; then `d ∣ 9t³ = 9t²·t`, and together with
+`d ∣ 9t³ − 1` this forces `d ∣ 1`. The single subtraction `9t³ − 1` is unfolded
+over `ℤ` (via `zify`) inside the auxiliary identity. -/
+lemma neg_family_coprime (t : ℕ) (ht : 1 ≤ t) :
+    Nat.Coprime (9 * t ^ 3 - 1) (9 * t ^ 4) := by
+  have hpos : 1 ≤ 9 * t ^ 3 := by
+    have : 1 ≤ t ^ 3 := Nat.one_le_pow 3 t ht
+    omega
+  -- `9t⁴ = t·(9t³ − 1) + t`
+  have hca : 9 * t ^ 4 = t * (9 * t ^ 3 - 1) + t := by
+    zify [hpos]; ring
+  have key : ∀ d : ℕ, d ∣ (9 * t ^ 3 - 1) → d ∣ (9 * t ^ 4) → d ∣ 1 := by
+    intro d hda hdc
+    have hdt : d ∣ t := by
+      have hdta : d ∣ t * (9 * t ^ 3 - 1) := hda.mul_left t
+      have h := Nat.dvd_sub' hdc hdta
+      rwa [hca, Nat.add_sub_cancel_left] at h
+    have hd3 : d ∣ 9 * t ^ 3 := by
+      have he : 9 * t ^ 3 = 9 * t ^ 2 * t := by ring
+      rw [he]; exact hdt.mul_left (9 * t ^ 2)
+    have h := Nat.dvd_sub' hd3 hda
+    rwa [Nat.sub_sub_self hpos] at h
+  have hg := key (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4))
+    (Nat.gcd_dvd_left _ _) (Nat.gcd_dvd_right _ _)
+  exact Nat.dvd_one.mp hg
+
+/-- **Core negative-defect witness data at n = 3** (the equation, not the
+`FermatDefectWitness` disjunction). For every `t ≥ 2` the triple
+`(9t³ − 1, 9t⁴ − 3t, 9t⁴)` is ordered, primitive, and satisfies
+`a³ + b³ + 1 = c³`. -/
+theorem defect_neg_data (t : ℕ) (ht : 2 ≤ t) :
+    2 ≤ 9 * t ^ 3 - 1 ∧ 9 * t ^ 3 - 1 ≤ 9 * t ^ 4 - 3 * t ∧
+      9 * t ^ 4 - 3 * t < 9 * t ^ 4 ∧
+      Nat.gcd (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t)) (9 * t ^ 4) = 1 ∧
+      (9 * t ^ 3 - 1) ^ 3 + (9 * t ^ 4 - 3 * t) ^ 3 + 1 = (9 * t ^ 4) ^ 3 := by
+  have ht1 : 1 ≤ t := by omega
+  have hA : 8 ≤ t ^ 3 := by
+    calc (8 : ℕ) = 2 ^ 3 := by norm_num
+      _ ≤ t ^ 3 := Nat.pow_le_pow_left ht 3
+  have hB : t ≤ t ^ 3 := by
+    calc t = t ^ 1 := (pow_one t).symm
+      _ ≤ t ^ 3 := Nat.pow_le_pow_right ht1 (by norm_num)
+  have hC : 2 * t ^ 3 ≤ t ^ 4 := by
+    calc 2 * t ^ 3 ≤ t * t ^ 3 := mul_le_mul_right' ht (t ^ 3)
+      _ = t ^ 4 := by ring
+  refine ⟨by omega, by omega, by omega, ?_, ?_⟩
+  · exact (neg_family_coprime t ht1).coprime_dvd_left (Nat.gcd_dvd_left _ _)
+  · have hpos : 1 ≤ 9 * t ^ 3 := by omega
+    have hb : 3 * t ≤ 9 * t ^ 4 := by omega
+    zify [hpos, hb]; ring
+
+/-- **Generic negative-defect primitive witness.** For every `t ≥ 2`,
+`(9t³ − 1, 9t⁴ − 3t, 9t⁴)` is a primitive nontrivial defect-one witness at
+`n = 3`. At `t = 2` this is `(71, 138, 144)` (`fermat_defect_three_neg_t2`). -/
+theorem defect_neg_witness_ge_two (t : ℕ) (ht : 2 ≤ t) :
+    FermatDefectWitness 3 (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t) (9 * t ^ 4) := by
+  obtain ⟨h1, h2, h3, h4, h5⟩ := defect_neg_data t ht
+  exact ⟨h1, h2, h3, h4, Or.inl h5⟩
+
+/-- **Negative-defect infinitude at n = 3.** The set of `c` occurring in a
+primitive *negative*-defect witness at `n = 3` (i.e. `a³ + b³ + 1 = c³`) is
+infinite. The injection is `n ↦ 9(n + 2)⁴`, strictly monotone, each value
+witnessed by `defect_neg_data`. Symmetric to `defect_pos_witnesses_infinite`. -/
+theorem defect_neg_witnesses_infinite :
+    {c : ℕ | ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < c ∧
+      Nat.gcd (Nat.gcd a b) c = 1 ∧ a ^ 3 + b ^ 3 + 1 = c ^ 3}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℕ => 9 * (n + 2) ^ 4)
+  · have hmono : StrictMono (fun n : ℕ => 9 * (n + 2) ^ 4) := by
+      apply strictMono_nat_of_lt_succ
+      intro n
+      have hp : (n + 2) ^ 4 < (n + 1 + 2) ^ 4 :=
+        Nat.pow_lt_pow_left (by omega) (by norm_num)
+      show 9 * (n + 2) ^ 4 < 9 * (n + 1 + 2) ^ 4
+      omega
+    exact hmono.injective
+  · intro n
+    show ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < 9 * (n + 2) ^ 4 ∧
+      Nat.gcd (Nat.gcd a b) (9 * (n + 2) ^ 4) = 1 ∧
+      a ^ 3 + b ^ 3 + 1 = (9 * (n + 2) ^ 4) ^ 3
+    obtain ⟨h1, h2, h3, h4, h5⟩ := defect_neg_data (n + 2) (by omega)
+    exact ⟨9 * (n + 2) ^ 3 - 1, 9 * (n + 2) ^ 4 - 3 * (n + 2),
+      h1, h2, h3, h4, h5⟩
+
+end FermatDefectOne

--- a/research/problems/fermat-defect-one-oq-02/knowledge.md
+++ b/research/problems/fermat-defect-one-oq-02/knowledge.md
@@ -32,6 +32,33 @@ for every `n ≥ 3` does there exist a primitive nontrivial triple `2 ≤ a ≤ 
   infinitely many, matching the Mahler families); for `n ≥ 4` the exponent is
   negative ⇒ the series converges ⇒ only finitely many, and the search finds none.
 
+### S-this-session (researcher-6, 2026-06-15) — negative-defect infinitude (Lean)
+
+Closed the n=3 sign symmetry. PR #24322 (R7) upgraded the **positive**-defect
+family to infinitude (`defect_pos_witnesses_infinite`), but the **negative**-defect
+family still had only a single witness (`fermat_defect_three_neg_t2`, t=2). New file
+`proofs/Proofs/FermatDefectOneNegInfinitude.lean` (UNREGISTERED, build-pending under
+dual Docker/Aristotle blackout) proves:
+
+- `neg_family_coprime t (1 ≤ t)`: `gcd(9t³−1, 9t⁴)=1` — kernel via the ℕ identity
+  `9t⁴ = t·(9t³−1) + t` (the single subtraction unfolded once over ℤ by `zify`),
+  then `d ∣ t ⟹ d ∣ 9t³ ⟹ d ∣ 1`.
+- `defect_neg_data t (2 ≤ t)`: for the ordered triple `(9t³−1, 9t⁴−3t, 9t⁴)`,
+  the full witness data with the *equation* `a³+b³+1=c³` (not the disjunction);
+  ordering inequalities discharged by `omega` over the atoms `t, t³, t⁴` with the
+  three pow-bounds `8≤t³`, `t≤t³`, `2t³≤t⁴`; equation by `zify; ring`.
+- `defect_neg_witness_ge_two`: the same triple as a `FermatDefectWitness 3`.
+- `defect_neg_witnesses_infinite`: the set of `c` in a primitive *negative*-defect
+  witness is infinite, via the strictly-monotone injection `n ↦ 9(n+2)⁴`.
+
+Mirrors `defect_pos_witnesses_infinite` exactly (same Mathlib bearers:
+`Set.infinite_of_injective_forall_mem`, `strictMono_nat_of_lt_succ`,
+`Nat.pow_lt_pow_left`, `Nat.Coprime.coprime_dvd_left`). All lemma names verified vs
+mathlib4 master under blackout. Family arithmetic re-verified `t=2..20000` by
+`verify_neg_infinitude.py` (identity, ordering, primitivity, kernel, strict-mono).
+**Net effect:** at n=3 *both* signs of the defect now occur infinitely often along
+explicit polynomial families — OQ-02 fully settled at n=3 in its strongest form.
+
 ### Honest status of the headline conjecture
 The headline `∀ n ≥ 3` is **true at n=3** but **empirically false for `4 ≤ n ≤ 12`**.
 A rigorous proof of emptiness for `n ≥ 4` is out of reach here — it sits in

--- a/research/problems/fermat-defect-one-oq-02/verify_neg_infinitude.py
+++ b/research/problems/fermat-defect-one-oq-02/verify_neg_infinitude.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Verification for the negative-defect infinitude family at n = 3 formalized in
+`proofs/Proofs/FermatDefectOneNegInfinitude.lean`.
+
+The negative-defect Mahler family (parameter t >= 2):
+
+    a = 9*t**3 - 1,  b = 9*t**4 - 3*t,  c = 9*t**4
+
+is claimed to give, for every t >= 2, a primitive ordered negative-defect
+witness a^3 + b^3 + 1 = c^3 (i.e. a^3 + b^3 - c^3 = -1), with c = 9*t**4
+strictly increasing in t (hence infinitely many primitive witnesses).
+
+This script checks, for a large range of t:
+  (1) the cubic identity a^3 + b^3 + 1 = c^3,
+  (2) the ordering 2 <= a <= b < c,
+  (3) primitivity gcd(gcd(a,b),c) = 1,
+  (4) the coprimality kernel gcd(9*t**3-1, 9*t**4) = 1 (lemma neg_family_coprime),
+  (5) strict monotonicity of c = 9*t**4 (the injection 9*(n+2)**4).
+"""
+from math import gcd
+
+def witness(t):
+    return (9 * t**3 - 1, 9 * t**4 - 3 * t, 9 * t**4)
+
+def check(tmax=20000):
+    prev_c = None
+    for t in range(2, tmax + 1):
+        a, b, c = witness(t)
+        assert a**3 + b**3 + 1 == c**3, f"(1) identity fails at t={t}"
+        assert 2 <= a <= b < c, f"(2) ordering fails at t={t}: {(a,b,c)}"
+        assert gcd(gcd(a, b), c) == 1, f"(3) not primitive at t={t}: {(a,b,c)}"
+        assert gcd(9 * t**3 - 1, 9 * t**4) == 1, f"(4) kernel fails at t={t}"
+        if prev_c is not None:
+            assert c > prev_c, f"(5) c not strictly increasing at t={t}"
+        prev_c = c
+    return tmax
+
+if __name__ == "__main__":
+    n = check()
+    print(f"All checks (1)-(5) PASS for t = 2..{n}.")
+    for t in (2, 3, 4, 5):
+        a, b, c = witness(t)
+        print(f"  t={t}: (a,b,c)=({a},{b},{c}), a^3+b^3+1=c^3, gcd=1")


### PR DESCRIPTION
## Summary

Closes the **sign symmetry** of open question OQ-02 ("are both signs of the defect realised for every n ≥ 3?") at n = 3. PR #24322 upgraded the *positive*-defect family to infinitude (`defect_pos_witnesses_infinite`); the *negative*-defect family was still stuck at a single witness (`fermat_defect_three_neg_t2`, t=2). This PR proves the negative side is **also infinite**.

New UNREGISTERED, build-pending file `proofs/Proofs/FermatDefectOneNegInfinitude.lean`:

- `neg_family_coprime t (1 ≤ t)` — `gcd(9t³−1, 9t⁴)=1`, via the ℕ identity `9t⁴ = t·(9t³−1) + t` (single subtraction unfolded once over ℤ with `zify`), then `d ∣ t ⟹ d ∣ 9t³ ⟹ d ∣ 1`.
- `defect_neg_data t (2 ≤ t)` — for the ordered triple `(9t³−1, 9t⁴−3t, 9t⁴)`: ordering + primitivity + the equation `a³+b³+1=c³` (defect −1). Inequalities by `omega` over atoms `t, t³, t⁴` with pow-bounds `8≤t³`, `t≤t³`, `2t³≤t⁴`; equation by `zify; ring`.
- `defect_neg_witness_ge_two` — the same triple as a `FermatDefectWitness 3`.
- `defect_neg_witnesses_infinite` — the set of `c` in a primitive negative-defect witness is infinite, via the strictly-monotone injection `n ↦ 9(n+2)⁴`.

**Net effect:** at n = 3, *both* defect signs occur infinitely often along explicit polynomial families. OQ-02 is settled at n = 3 in its strongest form.

Proof structure mirrors `defect_pos_witnesses_infinite` exactly (same Mathlib bearers: `Set.infinite_of_injective_forall_mem`, `strictMono_nat_of_lt_succ`, `Nat.pow_lt_pow_left`, `Nat.Coprime.coprime_dvd_left`).

## Verification

- `research/problems/fermat-defect-one-oq-02/verify_neg_infinitude.py` checks the cubic identity, ordering, primitivity, the coprimality kernel, and strict monotonicity for `t = 2..20000` — all PASS.
- All Mathlib lemma names cross-checked against mathlib4 master (Docker build + Aristotle both unavailable this session, so the Lean file is **build-pending**; please build before merge).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneNegInfinitude` (build-pending; could not run under blackout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)