### PR TITLE
Research: quadratic-reciprocity-oq-03-oq-01 — residue-criterion (p%8) form of the second supplementary law

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean
@@ -33,6 +33,18 @@ on residues `1,3,5,7`). Mathlib provides the χ₈ value-mod-8 facts in
 `Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean`; assembling the exponent
 bridge is the remaining (purely arithmetic) step and is left as the documented
 follow-up — the χ₈ wrapper below is the one that the algorithm actually evaluates.
+
+## The residue criterion (decision form)
+
+For algorithms that need only the residue/non-residue *verdict*, we also expose
+the `p % 8` decision form:
+
+  `legendreSym_two_eq_one_iff`     : `(2/p) = 1  ↔ p % 8 = 1 ∨ p % 8 = 7`,
+  `legendreSym_two_eq_neg_one_iff` : `(2/p) = -1 ↔ p % 8 = 3 ∨ p % 8 = 5`.
+
+These compose `legendreSym.eq_one_iff` / `legendreSym.eq_neg_one_iff` with
+`ZMod.exists_sq_eq_two_iff`; the non-vanishing side-goal `(2 : ZMod p) ≠ 0`
+reduces to `p ≠ 2` via `ZMod.natCast_eq_zero_iff` + `Nat.prime_dvd_prime_iff_eq`.
 -/
 
 open ZMod
@@ -58,6 +70,54 @@ namespace QRAlgorithmTwo
 theorem legendreSym_two_eq (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
     legendreSym p 2 = χ₈ (p : ZMod 8) :=
   legendreSym.at_two hp
+
+-- ============================================================
+-- The residue criterion: (2/p) = 1  ⟺  p ≡ ±1 (mod 8)
+-- ============================================================
+
+/-- **Residue criterion for the factor `2`.**
+
+    For an odd prime `p`, the value `(2/p) = 1` (i.e. `2` is a quadratic residue
+    mod `p`) exactly when `p ≡ 1` or `p ≡ 7 (mod 8)`:
+
+      `legendreSym p 2 = 1  ↔  p % 8 = 1 ∨ p % 8 = 7`.
+
+    This is the *decision form* of the second supplementary law, useful when the
+    algorithm only needs the residue/non-residue verdict rather than the signed
+    character value. It composes the standard `legendreSym.eq_one_iff`
+    (`(a/p) = 1 ↔ a` is a square) with `ZMod.exists_sq_eq_two_iff`
+    (`2` is a square mod `p` ↔ `p % 8 ∈ {1, 7}`). The non-vanishing side-condition
+    `(2 : ZMod p) ≠ 0` reduces to `p ∤ 2`, i.e. `p ≠ 2`. -/
+theorem legendreSym_two_eq_one_iff (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
+    legendreSym p 2 = 1 ↔ p % 8 = 1 ∨ p % 8 = 7 := by
+  have h2 : ((2 : ℤ) : ZMod p) ≠ 0 := by
+    have e : ((2 : ℤ) : ZMod p) = ((2 : ℕ) : ZMod p) := by norm_cast
+    rw [e]
+    intro hz
+    rw [ZMod.natCast_eq_zero_iff] at hz
+    rw [Nat.prime_dvd_prime_iff_eq (Fact.out : p.Prime) Nat.prime_two] at hz
+    exact hp hz
+  rw [legendreSym.eq_one_iff h2]
+  have e2 : ((2 : ℤ) : ZMod p) = (2 : ZMod p) := by norm_cast
+  rw [e2]
+  exact ZMod.exists_sq_eq_two_iff hp
+
+/-- Non-residue form: `(2/p) = -1` exactly when `p ≡ 3` or `p ≡ 5 (mod 8)`.
+    Since an odd prime has `p % 8 ∈ {1, 3, 5, 7}` and `(2/p) ∈ {1, -1}`, this is
+    the complement of the residue criterion. -/
+theorem legendreSym_two_eq_neg_one_iff (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :
+    legendreSym p 2 = -1 ↔ p % 8 = 3 ∨ p % 8 = 5 := by
+  have e2 : ((2 : ℤ) : ZMod p) = (2 : ZMod p) := by norm_cast
+  rw [legendreSym.eq_neg_one_iff, e2, ZMod.exists_sq_eq_two_iff hp]
+  -- `¬(p%8 = 1 ∨ p%8 = 7) ↔ p%8 = 3 ∨ p%8 = 5`, using that `p` is odd so
+  -- `p % 8 ∈ {1,3,5,7}`.
+  have hodd : Odd p := (Fact.out : p.Prime).odd_of_ne_two hp
+  have h8 : p % 8 = 1 ∨ p % 8 = 3 ∨ p % 8 = 5 ∨ p % 8 = 7 := by
+    obtain ⟨k, hk⟩ := hodd
+    omega
+  constructor
+  · intro h; omega
+  · intro h; omega
 
 -- ============================================================
 -- Verified example computations of (2/p)

--- a/src/data/research/problems/quadratic-reciprocity-oq-03-oq-01.json
+++ b/src/data/research/problems/quadratic-reciprocity-oq-03-oq-01.json
@@ -27,7 +27,7 @@
       "path": "Proofs/QuadraticReciprocityOQ03OQ01.lean",
       "filename": "QuadraticReciprocityOQ03OQ01.lean",
       "lineCount": 83,
-      "theoremCount": 1,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -52,21 +52,22 @@
     ]
   },
   "started": "2026-06-15T00:00:00.000Z",
-  "lastUpdate": "2026-06-15T00:00:00.000Z",
+  "lastUpdate": "2026-06-15",
   "knowledge": {
-    "progressSummary": "ACT (build-pending, docker blackout): answered YES. New file proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean (namespace QRAlgorithmTwo), 1 theorem + 5 decide examples, 0 axioms / 0 sorries. legendreSym_two_eq : legendreSym p 2 = χ₈ (p : ZMod 8) := legendreSym.at_two hp — the fourth reduction lemma completing the parent's algorithm toolkit, mirroring the first-supplementary wrapper QRAlgorithm.legendreSym_neg_one_eq. KEY OBSERVE finding: Mathlib states the second supplementary law ONLY in character form (legendreSym.at_two → χ₈), NOT the textbook (-1)^((p^2-1)/8) form. The χ₈ form is the one the algorithm actually evaluates (depends only on p mod 8). Five (2/p) example computations verified by decide and cross-checked against p mod 8 ∈ {1,7} ⟺ residue. NOT registered in Proofs.lean and NOT build-verified (docker-build.sh host hangs this cycle).",
+    "progressSummary": "ACT S2 (researcher-4, 2026-06-15, build-pending, docker blackout): added the RESIDUE-CRITERION (decision) form of the second supplementary law to proofs/Proofs/QuadraticReciprocityOQ03OQ01.lean. legendreSym_two_eq_one_iff: legendreSym p 2 = 1 ↔ p%8=1 ∨ p%8=7, and legendreSym_two_eq_neg_one_iff: legendreSym p 2 = -1 ↔ p%8=3 ∨ p%8=5. Proof composes legendreSym.eq_one_iff / eq_neg_one_iff with ZMod.exists_sq_eq_two_iff; the (2:ZMod p)≠0 side-goal reduces to p≠2 via ZMod.natCast_eq_zero_iff + Nat.prime_dvd_prime_iff_eq; the neg-one complement closes by omega using Odd p ⟹ p%8∈{1,3,5,7}. All bearer names verified against Mathlib pin 2df2f01 (v4.26.0) by gh-api. Still 0 axioms/0 sorries. Builds on S1's legendreSym_two_eq (χ₈ form). The textbook exponential form (-1)^((p^2-1)/8) remains the sole documented follow-up (needs a ℕ-division parity bridge, ~50-100 LOC). NOT registered in Proofs.lean (never built); docker-build.sh host hangs this cycle (dual blackout).",
     "builtItems": [
       "legendreSym_two_eq (p) (hp : p ≠ 2) : legendreSym p 2 = χ₈ (p : ZMod 8)  -- fourth reduction lemma",
-      "5 verified (2/p) example computations: p = 3,5,23,31,41"
+      "5 verified (2/p) example computations: p = 3,5,23,31,41",
+      "legendreSym_two_eq_one_iff (p)(hp:p≠2): legendreSym p 2 = 1 ↔ p%8=1 ∨ p%8=7",
+      "legendreSym_two_eq_neg_one_iff (p)(hp:p≠2): legendreSym p 2 = -1 ↔ p%8=3 ∨ p%8=5"
     ],
     "mathlibGaps": [
       "No named lemma for the textbook exponential form legendreSym p 2 = (-1)^((p^2-1)/8); Mathlib uses χ₈ (legendreSym.at_two).",
       "Bridge χ₈ (p:ZMod 8) = (-1:ℤ)^((p^2-1)/8) for odd p needs a p % 8 case analysis + parity of (p^2-1)/8 (= 0,1,1,0 mod 2 on residues 1,3,5,7); ZModChar.lean has the χ₈ value-mod-8 facts."
     ],
     "nextSteps": [
-      "Build via ./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityOQ03OQ01 once docker is back, then register in proofs/Proofs.lean.",
-      "Optional: prove the textbook exponential form legendreSym p 2 = (-1)^((p^2-1)/8) via the χ₈ value-mod-8 bridge.",
-      "Optional: add the residue-criterion form legendreSym p 2 = 1 ↔ p % 8 = 1 ∨ p % 8 = 7 from ZMod.exists_sq_eq_two_iff + legendreSym.eq_one_iff."
+      "Build via ./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityOQ03OQ01 once docker returns, then register in proofs/Proofs.lean.",
+      "Remaining gap: textbook exponential form legendreSym p 2 = (-1)^((p^2-1)/8) via the χ₈/exponent parity bridge (p%8 case analysis; (p^2-1)/8 parity = 0,1,1,0 on residues 1,3,5,7). ~50-100 LOC, ℕ-division reasoning (deferred under no-build)."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds the **residue-criterion (decision) form** of the second supplementary law to `QuadraticReciprocityOQ03OQ01.lean`, complementing the existing character wrapper `legendreSym_two_eq` ($= \chi_8$, from #24299):

- `legendreSym_two_eq_one_iff` : $(2/p) = 1 \iff p \equiv 1 \text{ or } 7 \pmod 8$
- `legendreSym_two_eq_neg_one_iff` : $(2/p) = -1 \iff p \equiv 3 \text{ or } 5 \pmod 8$

This is the verdict form the GCD-style Legendre algorithm uses when it only needs residue/non-residue, not the signed character value.

## Proof

Composes `legendreSym.eq_one_iff` / `legendreSym.eq_neg_one_iff` with `ZMod.exists_sq_eq_two_iff` (`IsSquare (2 : ZMod p) ↔ p % 8 ∈ {1,7}`). The non-vanishing side-goal `(2 : ZMod p) ≠ 0` reduces to `p ≠ 2` via `ZMod.natCast_eq_zero_iff` + `Nat.prime_dvd_prime_iff_eq`. The non-residue complement closes by `omega` using `Odd p ⟹ p % 8 ∈ {1,3,5,7}`.

All bearer lemma names were verified against the repo's Mathlib pin `2df2f01` (v4.26.0) by `gh api` (this session is under a Docker + Aristotle outage, so no local machine-check). **0 axioms / 0 sorries.**

## Status

- **Build-pending** (Docker down). File left **UNREGISTERED** in `Proofs.lean` (it has never been built; registering an unbuilt file risks breaking the aggregate build / auto-merge).
- Remaining documented follow-up: the textbook exponential form $(2/p) = (-1)^{(p^2-1)/8}$ (needs a $\mathbb{N}$-division parity bridge from $\chi_8$, deferred under no-build).

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityOQ03OQ01` once Docker returns, then register in `Proofs.lean`.
- [x] residue partition `{1,7}` vs `{3,5}` numerically checked; all Mathlib bearers confirmed at the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)