### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02): S2 ACT — derive Besicovitch main statement from degree theorem (3→2 sorries)

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean
@@ -12,19 +12,24 @@ OQ-01's "square twice to isolate √30" trick is the n = 3 shadow of the fact th
 √2+√3+√5 is a primitive element of the degree-8 multiquadratic field ℚ(√2,√3,√5).
 OQ-02 replaces the ad-hoc squaring with the uniform degree theorem.
 
-## STATUS — partial: 2 endpoints discharged, induction core still open (Docker unavailable)
+## STATUS — partial: endpoints + Besicovitch reduction discharged, induction core open
 
 This file records the *decomposition* into the load-bearing lemmas. The single
 non-trivial step is `sqrt_prime_not_mem_multiquadratic` (the induction heart);
 everything else is either a Mathlib one-liner (base case, upper bound) or follows
 from the degree theorem by linear algebra.
 
-Discharged (no sorry): `irrational_sqrt_prime` (`Nat.Prime.irrational_sqrt`) and
+Discharged (no sorry): `irrational_sqrt_prime` (`Nat.Prime.irrational_sqrt`),
 `irrational_sqrt2_add_sqrt3_add_sqrt5` (the OQ-01 corollary, by direct citation of
-the proved `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01` — see note there). Still `sorry`:
-the induction heart and the two results that depend on it (`*_linearIndependent`).
-These statements have NOT yet been checked by the Lean elaborator (no build this
-session); the file remains unregistered pending a Docker build.
+the proved `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01` — see note there), and
+`besicovitch_sqrt_linearIndependent` (the squarefree main statement) which is now a
+genuine **derivation** from `multiquadratic_subset_products_linearIndependent` via the
+`d ↦ primeFactors d` injection (`LinearIndependent.comp` +
+`Nat.prod_primeFactors_of_squarefree`). Still `sorry`: the induction heart
+`sqrt_prime_not_mem_multiquadratic` and the degree theorem
+`multiquadratic_subset_products_linearIndependent` that consumes it. These statements
+have NOT yet been checked by the Lean elaborator (no build this session); the file
+remains unregistered pending a Docker build.
 
 The mathematical content (degree = 2ⁿ, induction heart = degree doubling, and the
 linear independence) is certified exactly in
@@ -83,11 +88,53 @@ theorem multiquadratic_subset_products_linearIndependent
 /-- **Besicovitch's theorem (main OQ-02 statement).** The square roots of distinct
 squarefree integers are ℚ-linearly independent. Each squarefree `d` has a distinct
 odd-power-prime signature, hence maps to a distinct subset-product basis vector of
-`multiquadratic_subset_products_linearIndependent`. -/
+`multiquadratic_subset_products_linearIndependent`.
+
+This is now a **genuine derivation** (no `sorry` of its own) from the degree theorem:
+take `ps = ⋃_{d∈S} primeFactors d`; the map `d ↦ primeFactors d` injects `S` into
+`ps.powerset` (squarefree ⇒ `∏ primeFactors d = d`, so distinct `d` give distinct factor
+sets), and `√d = √(∏_{q | d} q)` identifies the family with a subfamily of the
+multiquadratic basis. Linear independence is then inherited via `LinearIndependent.comp`.
+Only the upstream `multiquadratic_subset_products_linearIndependent` (and through it the
+induction heart) remains open. -/
 theorem besicovitch_sqrt_linearIndependent
     (S : Finset ℕ) (hS : ∀ d ∈ S, Squarefree d) :
     LinearIndependent ℚ (fun d : S => (Real.sqrt ((d : ℕ) : ℝ) : ℝ)) := by
-  sorry
+  classical
+  -- All primes occurring among the radicands.
+  set ps : Finset ℕ := S.biUnion (fun d => d.primeFactors) with hps_def
+  have hps : ∀ q ∈ ps, q.Prime := by
+    intro q hq
+    rw [hps_def, Finset.mem_biUnion] at hq
+    obtain ⟨d, _, hqd⟩ := hq
+    exact Nat.prime_of_mem_primeFactors hqd
+  -- The multiquadratic subset-product basis is ℚ-linearly independent (degree theorem).
+  have hmq := multiquadratic_subset_products_linearIndependent ps hps
+  -- `d ↦ primeFactors d` lands in `ps.powerset`.
+  have hsub : ∀ d ∈ S, d.primeFactors ∈ ps.powerset := by
+    intro d hd
+    rw [Finset.mem_powerset, hps_def]
+    exact Finset.subset_biUnion_of_mem (fun d => d.primeFactors) hd
+  -- and is injective on `S` (squarefree numbers are recovered from their prime sets).
+  let ι : {d // d ∈ S} → {T // T ∈ ps.powerset} :=
+    fun d => ⟨(d : ℕ).primeFactors, hsub d.1 d.2⟩
+  have hι : Function.Injective ι := by
+    intro a b hab
+    have hpf : (a : ℕ).primeFactors = (b : ℕ).primeFactors := by
+      simpa [ι] using congrArg Subtype.val hab
+    have hval : (a : ℕ) = (b : ℕ) := by
+      rw [← Nat.prod_primeFactors_of_squarefree (hS a.1 a.2),
+          ← Nat.prod_primeFactors_of_squarefree (hS b.1 b.2), hpf]
+    exact Subtype.ext hval
+  -- The target family is exactly the multiquadratic family restricted along `ι`.
+  have hfun : (fun d : S => (Real.sqrt ((d : ℕ) : ℝ) : ℝ))
+      = (fun T : ps.powerset => (Real.sqrt (∏ q ∈ (T : Finset ℕ), (q : ℝ)) : ℝ)) ∘ ι := by
+    funext d
+    have hcoe : ((ι d : {T // T ∈ ps.powerset}) : Finset ℕ) = (d : ℕ).primeFactors := rfl
+    simp only [Function.comp_apply]
+    rw [hcoe, ← Nat.cast_prod, Nat.prod_primeFactors_of_squarefree (hS d.1 d.2)]
+  rw [hfun]
+  exact hmq.comp ι hι
 
 /-- **OQ-01 recovered.** `√2+√3+√5` is irrational. This is the `n = 3`,
 `{2,3,5}` instance that OQ-02 generalizes, and it is already fully proved

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/knowledge.md
@@ -61,3 +61,36 @@ sibling Besicovitch effort pinned earlier today.
 **Honest assessment:** modest — one free endpoint discharged + a circular-derivation bug fixed
 in the skeleton. The theorem's actual content (the heart) is untouched and remains BUILD-class
 open. No numerical or mathematical advance beyond prior sessions.
+
+## Session 2026-06-15 (S2, researcher-2) — Besicovitch reduction discharged (build-pending)
+
+**Mode:** ACT, dual blackout persists (Docker `info` hangs; Aristotle `prove` → 404).
+Replaced the `sorry` in `besicovitch_sqrt_linearIndependent` (the squarefree MAIN
+statement) with a genuine **derivation** from the degree theorem — no new sorry, and it
+no longer relies on its own informal "distinct signature" argument.
+
+**Delta (3→2 sorries):** `besicovitch_sqrt_linearIndependent (S) (∀d∈S, Squarefree d)`
+now proved by:
+- `ps := S.biUnion (·.primeFactors)`; `hps : ∀q∈ps, q.Prime` via
+  `Finset.mem_biUnion` + `Nat.prime_of_mem_primeFactors`.
+- injection `ι : {d//d∈S} → {T//T∈ps.powerset}`, `d ↦ ⟨d.primeFactors, _⟩`
+  (`Finset.subset_biUnion_of_mem` for the powerset membership). Injective because
+  `Nat.prod_primeFactors_of_squarefree` recovers `d = ∏ primeFactors d`.
+- family identity `√(d:ℝ) = √(∏_{q∈primeFactors d}(q:ℝ))` via `← Nat.cast_prod` +
+  `Nat.prod_primeFactors_of_squarefree`; then `LinearIndependent.comp` inherits
+  independence from `multiquadratic_subset_products_linearIndependent`.
+
+So the final theorem now depends ONLY on the degree theorem (and through it the heart),
+which is the correct dependency structure. Mirrors the
+product-of-segments-of-chords-oq-02 S4 pattern: prove the linear-algebra assembly,
+isolate the one genuine geometric/number-theoretic heart.
+
+**Mathlib API verified** (sibling .lake vs master): `LinearIndependent.comp`
+(LinearIndependent/Defs.lean:206), `Nat.prod_primeFactors_of_squarefree`
+(Data/Nat/Squarefree.lean:366), `Nat.prime_of_mem_primeFactors`,
+`Finset.subset_biUnion_of_mem`, `Nat.cast_prod`. Confirmed Mathlib has **no**
+multiquadratic non-membership lemma — the heart is genuinely hand-build (~250–450 LOC).
+
+**Honest assessment:** moderate architectural progress (the MAIN statement is now a
+clean corollary of the degree theorem, removing an informal step). The heart and the
+degree theorem remain open and BUILD-class. Build-pending — reduction NOT machine-checked.

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
@@ -3,28 +3,46 @@
 ## Current State
 **Phase**: ACT (partial)
 **Path**: full
-**Since**: 2026-06-15 (researcher-5, S1→ACT-partial)
-**Iteration**: 2
+**Since**: 2026-06-15 (researcher-2, S2→ACT-partial)
+**Iteration**: 3
 
 ## Current Focus
-Lean skeleton 4→3 sorries: discharged the OQ-01 corollary endpoint
-(`irrational_sqrt2_add_sqrt3_add_sqrt5`) by citing the proved
-`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01`. Induction heart
-(`sqrt_prime_not_mem_multiquadratic`, ~250–450 LOC, BUILD-class) and its two
-dependents remain open. File unregistered, build-pending (Docker down).
+Lean skeleton 3→2 sorries: discharged `besicovitch_sqrt_linearIndependent` (the
+squarefree MAIN statement) as a genuine **derivation** from the degree theorem
+`multiquadratic_subset_products_linearIndependent`, via the `d ↦ primeFactors d`
+injection (`LinearIndependent.comp` + `Nat.prod_primeFactors_of_squarefree`). No new
+sorry — it now depends only on the (still-open) degree theorem, not on its own
+hand-waved signature argument. Remaining sorries: the induction heart
+`sqrt_prime_not_mem_multiquadratic` (~250–450 LOC, BUILD-class) and the degree theorem
+`multiquadratic_subset_products_linearIndependent` that consumes it.
 
 ## Active Approach
 Quadratic-tower induction; heart formalized via the strengthened coprime-squarefree
 non-membership hypothesis `H(m): ∀ squarefree d>1 coprime to {p₁..pₘ}, √d ∉ K_m`.
 
+## Mathlib API pinned (verified vs master in sibling .lake)
+- `LinearIndependent.comp (h) (f) (Injective f) : LinearIndependent R (v ∘ f)`
+  (`LinearAlgebra/LinearIndependent/Defs.lean:206`).
+- `Nat.prod_primeFactors_of_squarefree (Squarefree n) : ∏ p ∈ n.primeFactors, p = n`
+  (`Data/Nat/Squarefree.lean:366`).
+- `Nat.prime_of_mem_primeFactors`, `Finset.subset_biUnion_of_mem`,
+  `Finset.mem_biUnion`, `Finset.mem_powerset`, `Nat.cast_prod` — all confirmed.
+- **No** general multiquadratic non-membership lemma exists in Mathlib (the heart must
+  be built by hand; ~250–450 LOC).
+
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (endpoint discharge by citation)
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: 2 (endpoint discharge by citation; Besicovitch reduction)
 
 ## Blockers
-None.
+- Dual blackout (Docker `info` hangs; Aristotle `prove` 404) — the reduction is written
+  but NOT machine-checked. Lemma-name risk points are pinned above.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker is available:
+1. Build `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean`; fix any drift in the reduction
+   (risk: `ι` `let`-unfold in the `hcoe := rfl` step; `Function.comp_apply`/`Nat.cast_prod`).
+2. Attack the heart `sqrt_prime_not_mem_multiquadratic` via the strengthened
+   coprime-squarefree induction `H(m)` (squares-of-K_m characterization).
+3. Once heart + degree theorem compile, fold into the gallery / register the file.


### PR DESCRIPTION
## Summary

Advances the OQ-02 Besicovitch skeleton (`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean`).
Discharges the `sorry` in `besicovitch_sqrt_linearIndependent` — the **squarefree main
statement** — as a genuine derivation from the degree theorem
`multiquadratic_subset_products_linearIndependent`, with no new `sorry`.

- **Reduction**: take `ps = ⋃_{d∈S} primeFactors d`; the map `d ↦ primeFactors d` injects
  `S` into `ps.powerset` (injective because squarefree `d = ∏ primeFactors d` via
  `Nat.prod_primeFactors_of_squarefree`), and `√d = √(∏_{q|d} q)` identifies the family
  with a subfamily of the multiquadratic basis. Independence is inherited through
  `LinearIndependent.comp`.
- The main theorem now depends **only** on the (still-open) degree theorem — the correct
  dependency structure — instead of an informal "distinct signature" argument.
- **Mathlib API verified** against master (sibling `.lake`): `LinearIndependent.comp`,
  `Nat.prod_primeFactors_of_squarefree`, `Nat.prime_of_mem_primeFactors`,
  `Finset.subset_biUnion_of_mem`, `Nat.cast_prod`. Confirmed Mathlib has **no**
  multiquadratic non-membership lemma, so the induction heart is genuinely hand-build.

Sorries: 3 → 2. Remaining: the heart `sqrt_prime_not_mem_multiquadratic` (~250–450 LOC,
BUILD-class) and the degree theorem that consumes it.

## Status

**Build-pending** (dual blackout: `docker info` hangs; Aristotle `prove` → 404). File
remains UNREGISTERED. Lemma-name + `let`-unfold risk points pinned in `state.md`.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02` (when Docker available)
- [ ] Build the induction heart via the strengthened coprime-squarefree induction `H(m)`
- [ ] Once heart + degree theorem compile, register the file and fold into the gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)