### PR TITLE
Fix: sync stale meta.json lineCount for 3 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -311,7 +311,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2583,
+    "lineCount": 2589,
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 46,

--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 104,
+    "lineCount": 112,
     "assumptions": "0 axioms. 0 sorries. All theorems fully proved. The three docstring blocks (Camera-Gol'dberg criterion, SCV differences, plurisubharmonicity) are documentation, not axiom declarations.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -112,7 +112,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1118OQ02",
-    "lineCount": 104,
+    "lineCount": 112,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -52,7 +52,7 @@
       "erdos_311_conjecture axiom (ε-N₀ form)"
     ],
     "axiomCount": 3,
-    "lineCount": 129,
+    "lineCount": 130,
     "assumptions": "3 axioms: delta_lower_bound_pnt (PNT-based lower bound e^{-(1+ε)N}), tang_upper_bound (Tang's subexponential upper bound), erdos_311_conjecture (the main open conjecture: log δ(N)/N → -c for c ∈ (0,1)). No sorries.",
     "theoremCount": 7,
     "definitionCount": 5
@@ -147,7 +147,7 @@
       "Classical"
     ],
     "namespace": null,
-    "lineCount": 114,
+    "lineCount": 130,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata in three gallery `meta.json` files to match the actual Lean source.

## Evidence

`wc -l` on the source files:

| slug | file | `wc -l` | meta block | leanFile block |
|------|------|--------:|-----------:|---------------:|
| erdos-311 | Erdos311Problem.lean | 130 | 129 → **130** | 114 → **130** |
| erdos-1118-oq-02 | Erdos1118OQ02.lean | 112 | 104 → **112** | 104 → **112** |
| ballot-problem-oq-03-oq-02 | BallotProblemOQ03OQ02.lean | 2589 | 2589 (already correct) | 2583 → **2589** |

**Before**: `leanFile.lineCount` (and two `meta.lineCount`) were stale after source edits, undercounting by up to 17 lines.
**After**: all `lineCount` fields match `wc -l` of the source. Only `lineCount` was touched; theorem/def counts left untouched (they follow a separate, intentional convention that includes `private` declarations).

Other slugs in the same scan with larger drifts (shannon-channel-coding, stirling-formula-oq-01, general-quartic, minpoly-charpoly) already have in-flight claim branches and were excluded.

---
Automated fix by lean-mechanic agent.