### PR TITLE
research(erdos-10-oq-02): S4 ACT — decidability keystone for prime + ≤k powers of 2

### DIFF
--- a/proofs/Proofs/Erdos10OQ02Decidable.lean
+++ b/proofs/Proofs/Erdos10OQ02Decidable.lean
@@ -1,0 +1,156 @@
+/-
+# Erdős Problem #10 — Open Question 02, decidability keystone
+
+**Parent.** Erdős Problem #10 — sums of a prime and powers of 2.
+
+**Open question (oq-02).** *Granville–Soundararajan (1998).* Is every odd
+integer `n > 1` the sum of a prime and **at most 3** powers of 2? (open)
+
+## What this file adds
+
+`Erdos10OQ02.lean` (S3) proved the **reduction lemma**: a sum of `≤ k` powers
+of two is the same as a sum of `≤ k` *pairwise-distinct* powers of two
+(`repWithAtMost_iff_repDistinct`). That collapses repeats but leaves the
+exponents a priori unbounded, so it does not yet make membership a *finite*
+search.
+
+This file supplies the missing finiteness ingredient — the **exponent bound**
+`a < 2^a ≤ n` — and uses it to upgrade the reduction lemma to a fully
+**bounded** characterization:
+
+> `n` is a sum of `≤ k` powers of two **iff** there is a `Nodup` multiset of
+> exponents, each `≤ n`, of size `≤ k`, whose `powSum` is `n`.
+
+Because the exponents now live in `{0, …, n}` and there are at most `k` of
+them, only finitely many candidate multisets remain: membership is decidable.
+We also bound the prime side (`p ≤ n`), giving a finite, two-sided search for
+`IsPrimePlusKPowers`. This is exactly the shape a `decide`/`native_decide`
+membership check consumes to discharge the concrete witnesses (the smallest
+even integer needing 3 powers is `906`; Grechuk's `1117175146` is not a prime
+plus `≤ 3` powers).
+
+The numerical decision procedure these lemmas describe is validated end-to-end
+in `research/problems/erdos-10-oq-02/verify_decidable_membership.py`
+(`RepWithAtMost k n ⟺ bounded-distinct ⟺ popcount n ≤ k`; the bounded prime
+form reproduces the `905`/`906` caps and the Grechuk witness).
+
+**Build status.** Authored under a Docker/Aristotle blackout, so this file is
+**not yet registered in `Proofs.lean`**. The proofs use only elementary
+`Multiset` algebra plus the S3 lemmas; they are a verified-on-paper drop-in.
+
+### Remaining mechanical step (next build-enabled session)
+
+The explicit `Decidable (RepWithAtMost k n)` instance: encode a `Nodup`
+exponent multiset bounded by `n` as a `Finset ⊆ Finset.range (n+1)`, so that
+`RepWithAtMost k n ↔ ∃ F ∈ (Finset.range (n+1)).powerset, F.card ≤ k ∧
+(∑ a ∈ F, 2^a) = n`, the right side being decidable by `Finset` search. The
+bridge needs `Multiset.toFinset` (sum/card preserved on `Nodup` multisets) and
+`Finset.sum`-as-`Multiset.sum`. With that instance in place, the witnesses
+`906 ∉ S_3`-style facts close by `decide`/`native_decide`.
+
+## References
+
+- Granville, A.; Soundararajan, K. (1998). *A binary additive problem of Erdős
+  and the order of `2 mod p²`.* Ramanujan J. 2, 283–298.
+- Crocker, R. (1971). *On the sum of a prime and of two powers of two.*
+  Pacific J. Math. 36, 103–107.
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Multiset.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Proofs.Erdos10OQ02
+
+namespace Erdos10OQ02
+
+/-! ## Part V: The exponent bound
+
+The single new ingredient beyond the S3 reduction lemma: an exponent appearing
+in a representation of `n` is `< n`, because `a < 2^a` and `2^a` is one of the
+summands of `powSum`. -/
+
+/-- `a < 2^a`, proved by elementary induction (no binary-representation API). -/
+theorem lt_two_pow_self (a : ℕ) : a < 2 ^ a := by
+  induction a with
+  | zero => decide
+  | succ n ih =>
+    have h2 : 0 < 2 ^ n := pow_pos (by norm_num) n
+    rw [pow_succ, Nat.mul_two]
+    omega
+
+/-- Each summand `2^a` is bounded by the whole sum: if `a ∈ s` then
+`2^a ≤ powSum s`. -/
+theorem twoPow_le_powSum {a : ℕ} {s : Multiset ℕ} (ha : a ∈ s) :
+    2 ^ a ≤ powSum s := by
+  show 2 ^ a ≤ (s.map (2 ^ ·)).sum
+  exact Multiset.single_le_sum (fun x _ => Nat.zero_le x) _
+    (Multiset.mem_map_of_mem _ ha)
+
+/-- **Exponent bound.** Any exponent occurring in a representation of `n` is
+strictly less than `n`. -/
+theorem exp_lt_of_powSum {a : ℕ} {s : Multiset ℕ} {n : ℕ}
+    (ha : a ∈ s) (hsum : powSum s = n) : a < n := by
+  have h1 : 2 ^ a ≤ n := hsum ▸ twoPow_le_powSum ha
+  have h2 : a < 2 ^ a := lt_two_pow_self a
+  omega
+
+/-! ## Part VI: The bounded reduction lemma
+
+Representability by `≤ k` powers of two is equivalent to representability by a
+`Nodup` exponent multiset, of size `≤ k`, **all of whose exponents are `≤ n`**.
+This pins the search to a finite set of candidate multisets. -/
+
+/-- `n` is a sum of at most `k` powers of two with pairwise-distinct exponents,
+each bounded by `n`. -/
+def RepBoundedDistinct (k n : ℕ) : Prop :=
+  ∃ s : Multiset ℕ, s.Nodup ∧ s.card ≤ k ∧ (∀ a ∈ s, a ≤ n) ∧ powSum s = n
+
+/-- **Bounded reduction lemma.** `RepWithAtMost` is equivalent to its
+distinct-and-exponent-bounded form. The forward direction adds the exponent
+bound from `exp_lt_of_powSum` on top of the S3 reduction lemma. -/
+theorem repWithAtMost_iff_repBoundedDistinct (k n : ℕ) :
+    RepWithAtMost k n ↔ RepBoundedDistinct k n := by
+  constructor
+  · intro h
+    obtain ⟨s, hnd, hcard, hsum⟩ := (repWithAtMost_iff_repDistinct k n).mp h
+    refine ⟨s, hnd, hcard, ?_, hsum⟩
+    intro a ha
+    have := exp_lt_of_powSum ha hsum
+    omega
+  · rintro ⟨s, _, hcard, _, hsum⟩
+    exact ⟨s, hcard, hsum⟩
+
+/-! ## Part VII: Bounding the prime side
+
+In `IsPrimePlusKPowers k n` the prime is `≤ n` and the power-part is `n - p`,
+so the search over `p` is finite as well. Combined with Part VI, membership
+becomes a finite two-sided search. -/
+
+/-- **Prime-side bound.** `IsPrimePlusKPowers k n` is equivalent to a search
+over primes `p ≤ n` with a `≤ k`-power representation of `n - p`. -/
+theorem isPrimePlusKPowers_bounded (k n : ℕ) :
+    IsPrimePlusKPowers k n ↔
+      ∃ p : ℕ, p ≤ n ∧ p.Prime ∧ RepWithAtMost k (n - p) := by
+  constructor
+  · rintro ⟨p, hp, m, hm, hn⟩
+    refine ⟨p, by omega, hp, ?_⟩
+    have hnp : n - p = m := by omega
+    rwa [hnp]
+  · rintro ⟨p, hpn, hp, hm⟩
+    exact ⟨p, hp, n - p, hm, by omega⟩
+
+/-- Fully bounded form: distinct, exponent-bounded power-part, prime `≤ n`.
+This is the predicate a decision procedure enumerates. -/
+theorem isPrimePlusKPowers_iff_bounded_distinct (k n : ℕ) :
+    IsPrimePlusKPowers k n ↔
+      ∃ p : ℕ, p ≤ n ∧ p.Prime ∧ RepBoundedDistinct k (n - p) := by
+  rw [isPrimePlusKPowers_bounded]
+  refine exists_congr (fun p => ?_)
+  rw [repWithAtMost_iff_repBoundedDistinct]
+
+#check @lt_two_pow_self
+#check @exp_lt_of_powSum
+#check @repWithAtMost_iff_repBoundedDistinct
+#check @isPrimePlusKPowers_iff_bounded_distinct
+
+end Erdos10OQ02

--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -120,6 +120,45 @@ GS but, as in S1, only weak evidence for it.
 
 **Files (S2):** `research/problems/erdos-10-oq-02/verify_min_powers_parity.py` (new).
 
+## Session 4 (2026-06-15) — the decidability keystone (build-pending Lean)
+
+S3 (`Erdos10OQ02.lean`, PR #24287) proved the **reduction lemma**
+`RepWithAtMost k n ↔ RepDistinct k n` (≤ k powers ⟺ ≤ k *distinct* powers, via
+the `2^a + 2^a = 2^{a+1}` merge). That collapses repeats but leaves exponents
+unbounded, so it does **not** yet make membership a finite search. S4 supplies
+the missing finiteness ingredient and bounds the prime side.
+
+**New file** `proofs/Proofs/Erdos10OQ02Decidable.lean` (build-pending,
+UNREGISTERED — Docker + Aristotle down). All proofs elementary `Multiset`
+algebra + the S3 lemmas; verified on paper, validated numerically (below).
+
+- **K1 — exponent bound.** `lt_two_pow_self : a < 2^a` (self-contained
+  induction, no binary API) ⟹ `exp_lt_of_powSum : a ∈ s → powSum s = n → a < n`
+  (each summand `2^a ≤ powSum s` via `Multiset.single_le_sum`). The one fact S3
+  lacked.
+- **K2 — bounded reduction lemma.**
+  `repWithAtMost_iff_repBoundedDistinct : RepWithAtMost k n ↔ RepBoundedDistinct k n`
+  where `RepBoundedDistinct k n := ∃ s, s.Nodup ∧ s.card ≤ k ∧ (∀ a ∈ s, a ≤ n)
+  ∧ powSum s = n`. Exponents now live in `{0,…,n}`, at most `k` of them ⟹ only
+  finitely many candidate multisets ⟹ membership is decidable in principle.
+- **K3 — prime-side bound.** `isPrimePlusKPowers_bounded`: the prime is `p ≤ n`,
+  the power-part `n − p`; `isPrimePlusKPowers_iff_bounded_distinct` combines both
+  bounds into a finite two-sided search — the predicate a `decide`/`native_decide`
+  membership check enumerates.
+
+**Remaining mechanical step** (next build session): the explicit
+`Decidable (RepWithAtMost k n)` instance via a `Finset.range (n+1)` powerset
+encoding (`Multiset.toFinset` bridge), after which `906 ∉ S_2`, `906 ∈ S_3`, and
+Grechuk `1117175146 ∉ S_3` close by `native_decide`. The file documents this
+encoding precisely.
+
+**Numerical cert** `verify_decidable_membership.py` (new, exact arithmetic,
+PASS): C1 `a < 2^a` and `2^a ≤ n ⟹ a < n`; C2 `RepWithAtMost k n ⟺
+bounded-distinct ⟺ popcount n ≤ k` (n ≤ 200, k ≤ 5, vs naive multiset search);
+C3 `IsPrimePlusKPowers` bounded form ⟺ naive form (n < 400, k < 4), and it
+reproduces the parity caps (905/906 consecutive; all odd n < 2000 in `S_2`, all
+even in `S_3`) plus the Grechuk witness (`1117175146 ∉ S_3`, `∈ S_4`).
+
 ## References
 
 - Granville, A.; Soundararajan, K. (1998). *A binary additive problem of Erdős and

--- a/research/problems/erdos-10-oq-02/verify_decidable_membership.py
+++ b/research/problems/erdos-10-oq-02/verify_decidable_membership.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+S4 certificate for erdos-10-oq-02 (Granville-Soundararajan, k=3 odd).
+
+Validates the DECISION PROCEDURE that the build-pending Lean file
+`Erdos10OQ02Decidable.lean` formalizes.  Three independent claims, each
+checked by brute force against a naive reference:
+
+  C1 (exponent bound).  If a sum of distinct powers of two equals n>=1, every
+     exponent a in the representation satisfies a < n  (since a < 2^a <= n).
+     => the search for representations is FINITE: exponents live in {0,...,n}.
+
+  C2 (bounded-distinct = unrestricted).  For all k,n:
+        RepWithAtMost k n
+          (== exists a MULTISET s of exponents, |s| <= k, sum 2^a = n)
+     is equivalent to
+        exists a SUBSET F of {0,...,n} with |F| <= k and sum_{a in F} 2^a = n.
+     The right side is decidable by finite search.  The merge identity
+     2^a + 2^a = 2^{a+1} (the S3 reduction lemma) is what lets the multiset
+     collapse to a distinct set without using more terms.
+     Equivalently: RepWithAtMost k n  <->  popcount(n) <= k.
+
+  C3 (decidable prime-plus-k-powers).  For all k,n:
+        IsPrimePlusKPowers k n
+          (== exists prime p, exists m with RepWithAtMost k m, n = p+m)
+     is equivalent to the BOUNDED, decidable predicate
+        exists p in [2,n], p prime and popcount(n-p) <= k.
+     We confirm this matches the minimal-power-count data (minPowers) from the
+     prior sessions, and discharge the concrete witnesses:
+       - 906 is the smallest even n with minPowers = 3 (needs k>=3);
+       - every odd n in range needs k<=2, and 905 is the smallest odd needing 2.
+
+All reference computations are exact integer arithmetic.
+"""
+
+from itertools import combinations
+from sympy import isprime
+
+
+# ---------- reference (naive) definitions ----------
+
+def rep_with_at_most_naive(k, n, max_exp):
+    """exists multiset of <= k exponents in [0,max_exp] with sum of 2^a == n.
+    Reference allows repeated exponents (true multiset), bounded by max_exp."""
+    # enumerate multisets of size 0..k over exponents 0..max_exp
+    exps = list(range(max_exp + 1))
+    from itertools import combinations_with_replacement
+    for size in range(k + 1):
+        for combo in combinations_with_replacement(exps, size):
+            if sum(1 << a for a in combo) == n:
+                return True
+    return False
+
+
+def rep_bounded_distinct(k, n):
+    """exists subset F of {0,...,n} with |F| <= k and sum_{a in F} 2^a == n.
+    This is the DECIDABLE form the Lean file uses.
+
+    Equivalent (and far cheaper) to search only exponents in
+    {0,...,bit_length(n)}: by C1, any exponent a with 2^a <= n has a <= n, and
+    a distinct rep summing to n can only use exponents a with 2^a <= n, i.e.
+    a < bit_length(n)+1.  We search that tight window; C1/C2 below confirm this
+    agrees with the full {0,...,n} window and with the naive multiset form."""
+    top = n.bit_length()           # 2^a <= n  =>  a <= top
+    exps = list(range(top + 1))
+    for size in range(k + 1):
+        for F in combinations(exps, size):
+            if sum(1 << a for a in F) == n:
+                return True
+    return False
+
+
+def popcount(n):
+    return bin(n).count("1")
+
+
+def min_powers(n):
+    """minimal number of powers of two summing to n == popcount(n)."""
+    return popcount(n)
+
+
+def is_prime_plus_k_powers_bounded(k, n):
+    """exists prime p in [2,n] with popcount(n-p) <= k."""
+    for p in range(2, n + 1):
+        if isprime(p) and popcount(n - p) <= k:
+            return True
+    return False
+
+
+def is_prime_plus_k_powers_naive(k, n, max_exp):
+    """exists prime p, exists m = sum of <= k powers (mult, exps<=max_exp), n=p+m."""
+    for p in range(2, n + 1):
+        if not isprime(p):
+            continue
+        m = n - p
+        if rep_with_at_most_naive(k, m, max_exp):
+            return True
+    return False
+
+
+# ---------- C1: exponent bound a < 2^a <= n ----------
+
+def check_C1(limit=4000):
+    for a in range(limit):
+        assert a < (1 << a), f"a < 2^a fails at {a}"
+    # and: if 2^a <= n then a < n  (since a < 2^a <= n)
+    for n in range(1, 300):
+        for a in range(n + 2):
+            if (1 << a) <= n:
+                assert a < n, f"exponent bound fails n={n} a={a}"
+    print(f"C1 OK: a < 2^a (a<{limit}); 2^a<=n => a<n (n<300)")
+
+
+# ---------- C2: bounded-distinct == unrestricted == popcount ----------
+
+def check_C2(N=200, K=5):
+    # max_exp for the naive multiset reference: exponents need not exceed N
+    # (2^a <= n <= N), and with repeats the largest useful exponent is < N too.
+    max_exp = N.bit_length() + 1
+    mism = 0
+    for n in range(0, N + 1):
+        for k in range(0, K + 1):
+            a = rep_with_at_most_naive(k, n, max_exp)
+            b = rep_bounded_distinct(k, n)
+            c = (popcount(n) <= k)
+            if not (a == b == c):
+                mism += 1
+                if mism <= 5:
+                    print(f"  MISMATCH n={n} k={k}: naive={a} bdd={b} popc={c}")
+    assert mism == 0, f"C2 had {mism} mismatches"
+    print(f"C2 OK: RepWithAtMost == bounded-distinct == (popcount<=k)  (n<={N}, k<={K})")
+
+
+# ---------- C3: decidable prime-plus-k-powers ----------
+
+def check_C3(N=2000):
+    # equivalence of bounded-decidable form with the naive form
+    max_exp = N.bit_length() + 2
+    mism = 0
+    for n in range(2, 400):       # naive form is expensive; smaller range
+        for k in range(0, 4):
+            a = is_prime_plus_k_powers_naive(k, n, max_exp)
+            b = is_prime_plus_k_powers_bounded(k, n)
+            if a != b:
+                mism += 1
+                if mism <= 5:
+                    print(f"  MISMATCH n={n} k={k}: naive={a} bdd={b}")
+    assert mism == 0, f"C3 equivalence had {mism} mismatches"
+    print("C3a OK: IsPrimePlusKPowers == bounded form (n<400, k<4)")
+
+    # Now use the cheap bounded form to reproduce the parity-cap facts.
+    # smallest odd n with min #powers needed (over p prime) == 2
+    def min_k_needed(n):
+        k = 0
+        while not is_prime_plus_k_powers_bounded(k, n):
+            k += 1
+            if k > 10:
+                return None
+        return k
+
+    smallest_odd_2 = next(n for n in range(3, N, 2) if min_k_needed(n) == 2)
+    smallest_even_3 = next(n for n in range(2, N, 2) if min_k_needed(n) == 3)
+    assert smallest_odd_2 == 905, f"expected 905 got {smallest_odd_2}"
+    assert smallest_even_3 == 906, f"expected 906 got {smallest_even_3}"
+    # consecutive
+    assert smallest_even_3 == smallest_odd_2 + 1
+    print(f"C3b OK: smallest odd needing 2 = {smallest_odd_2}, "
+          f"smallest even needing 3 = {smallest_even_3} (consecutive)")
+
+    # every odd n in [3,N) needs k<=2; every even n in [2,N) needs k<=3
+    assert all(min_k_needed(n) <= 2 for n in range(3, N, 2))
+    assert all(min_k_needed(n) <= 3 for n in range(2, N, 2))
+    print(f"C3c OK: odd n in [3,{N}) all in S_2; even n in [2,{N}) all in S_3")
+
+    # Grechuk: 1117175146 (even) not in S_3 but in S_4 (popcount-offset form)
+    g = 1117175146
+    assert not is_prime_plus_k_powers_bounded_fast(3, g)
+    assert is_prime_plus_k_powers_bounded_fast(4, g)
+    print(f"C3d OK: Grechuk {g} not in S_3, in S_4")
+
+
+def is_prime_plus_k_powers_bounded_fast(k, n):
+    """Same as bounded form but only scans p where n-p has small popcount.
+    For large n we scan primes p<=n with popcount(n-p)<=k; to keep it feasible
+    we iterate over offsets m with popcount<=k and test (n-m) prime."""
+    from itertools import combinations as comb
+    bits = n.bit_length() + 1
+    for j in range(k + 1):
+        for F in comb(range(bits), j):
+            m = sum(1 << a for a in F)
+            p = n - m
+            if p >= 2 and isprime(p):
+                return True
+    return False
+
+
+if __name__ == "__main__":
+    check_C1()
+    check_C2()
+    check_C3()
+    print("\nALL CERTS PASS")

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -2,12 +2,12 @@
   "slug": "erdos-10-oq-02",
   "title": "Granville–Soundararajan conjecture (k = 3 for odd integers)",
   "status": "in-progress",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "tier": "B",
   "significance": 6,
   "tractability": 4,
   "started": "2026-06-15T06:02:35Z",
-  "lastUpdate": "2026-06-15T06:02:35Z",
+  "lastUpdate": "2026-06-15T10:05:00Z",
   "path": "research/problems/erdos-10-oq-02",
   "tags": [
     "number-theory",
@@ -34,12 +34,15 @@
     "goal": "Decide GS-odd. Near-term realistic target: formalize the popcount reduction lemma and a Decidable membership for sumPrimeAndTwoPows in Lean, enabling decide/native_decide on concrete witnesses."
   },
   "knowledge": {
-    "progressSummary": "ORIENT (build-free; Docker + Lean down). S1: popcount≤k reduction for S_k membership + sweeps. S2 (this session) sharpens the parity caps: the odd cap is GENUINELY 2 (not trivial) — smallest odd needing exactly 2 powers is 905 = 5·181, a de Polignac number (odd composite, not 2^a+prime), and it is CONSECUTIVE with 906 (smallest even needing 3, S1). Moreover the even minPowers distribution is the odd one shifted up by exactly 1, matching to ~0.02% (even[k]≈odd[k-1]); deviations come from even n reaching prime 2 via the even offset m=n-2. GS caps 3(odd)/4(even) = in-range caps 2/3 plus one. The forcing cases (Crocker odd ∉ S_2, Grechuk even 1117175146 ∉ S_3) lie far beyond brute force.",
+    "progressSummary": "ORIENT (build-free; Docker + Lean down). S1: popcount≤k reduction for S_k membership + sweeps. S2 (this session) sharpens the parity caps: the odd cap is GENUINELY 2 (not trivial) — smallest odd needing exactly 2 powers is 905 = 5·181, a de Polignac number (odd composite, not 2^a+prime), and it is CONSECUTIVE with 906 (smallest even needing 3, S1). Moreover the even minPowers distribution is the odd one shifted up by exactly 1, matching to ~0.02% (even[k]≈odd[k-1]); deviations come from even n reaching prime 2 via the even offset m=n-2. GS caps 3(odd)/4(even) = in-range caps 2/3 plus one. The forcing cases (Crocker odd ∉ S_2, Grechuk even 1117175146 ∉ S_3) lie far beyond brute force. S4 (ACT, build-pending): the DECIDABILITY KEYSTONE. New file proofs/Proofs/Erdos10OQ02Decidable.lean adds the exponent bound (lt_two_pow_self: a<2^a; exp_lt_of_powSum: a in s & powSum s=n => a<n via Multiset.single_le_sum) and upgrades the S3 reduction lemma to a BOUNDED form repWithAtMost_iff_repBoundedDistinct (distinct exponents all <= n, card <= k => finite candidate set => decidable in principle); plus prime-side bound isPrimePlusKPowers_bounded (p<=n) and the combined isPrimePlusKPowers_iff_bounded_distinct. Remaining mechanical step: explicit Decidable instance via Finset.range(n+1) powerset, then 906/Grechuk witnesses by native_decide. Cert verify_decidable_membership.py PASS.",
     "builtItems": [
+      "proofs/Proofs/Erdos10OQ02Decidable.lean (S4, build-pending/UNREGISTERED) — exponent bound a<2^a, bounded reduction lemma RepWithAtMost<->RepBoundedDistinct (exponents<=n), prime-side bound; the finiteness/decidability keystone on top of the S3 reduction lemma.",
+      "research/problems/erdos-10-oq-02/verify_decidable_membership.py (S4) — exact-arithmetic cert: RepWithAtMost==bounded-distinct==popcount<=k; bounded prime form==naive; 905/906 caps; Grechuk 1117175146 not-in-S_3.",
       "research/problems/erdos-10-oq-02/verify_min_powers_parity.py (S2) — exact stdlib sieve, minPowers over both parities to 10^6; pins smallest n by minPowers value, confirms 905/906 consecutive caps and the approximate +1 distribution shift.",
       "research/problems/erdos-10-oq-02/verify_granville_soundararajan_odd.py (S1) — stdlib+sympy experiment (odd/even sweeps, distributions, Grechuk check)."
     ],
     "insights": [
+      "S4: the S3 reduction lemma alone does NOT bound exponents; the finiteness ingredient is a<2^a, giving exp<n for any exponent in a rep of n. With distinct exponents all <=n and at most k of them, membership is a finite search (decidable). Prime side bounds as p<=n. This is the exact shape native_decide needs.",
       "S_k membership reduces to popcount(m) ≤ k offsets: n ∈ S_k ⟺ ∃ m with popcount(m) ≤ k and (n−m) prime, n−m ≥ 2.",
       "S2: the odd cap of 2 is NECESSARY, not trivial — smallest odd needing exactly 2 powers is 905 = 5·181 (a de Polignac number: odd composite, not 2^a+prime). So odd n ∉ S_1 exist.",
       "S2: 905 (smallest odd needing 2) and 906 (smallest even needing 3) are CONSECUTIVE — the +1 parity offset realized back-to-back at the forcing extremes.",


### PR DESCRIPTION
## Summary

Erdős #10 / Granville–Soundararajan (k=3 odd) — **open conjecture**. This S4 session adds the *finiteness ingredient* that the S3 reduction lemma (#24287) lacked, turning membership in `S_k = {prime + ≤k powers of 2}` into a genuinely finite search.

**New build-pending file** `proofs/Proofs/Erdos10OQ02Decidable.lean` (extends, does not modify, the S3 `Erdos10OQ02.lean`):

- **Exponent bound** — `lt_two_pow_self : a < 2^a` (self-contained induction, no binary API); `exp_lt_of_powSum : a ∈ s → powSum s = n → a < n` (each summand `2^a ≤ powSum s` via `Multiset.single_le_sum`).
- **Bounded reduction lemma** — `repWithAtMost_iff_repBoundedDistinct`: `RepWithAtMost k n ↔ ∃ s, s.Nodup ∧ s.card ≤ k ∧ (∀ a ∈ s, a ≤ n) ∧ powSum s = n`. Exponents now live in `{0,…,n}`, at most `k` of them ⟹ finitely many candidates ⟹ decidable in principle.
- **Prime-side bound** — `isPrimePlusKPowers_bounded` (`p ≤ n`) and the combined `isPrimePlusKPowers_iff_bounded_distinct`: the finite two-sided search a `decide`/`native_decide` membership check consumes.

The remaining mechanical step (explicit `Decidable` instance via a `Finset.range (n+1)` powerset encoding, then discharging `906`/Grechuk witnesses by `native_decide`) is documented precisely in the file header for the next build-enabled session.

## Validation

`research/problems/erdos-10-oq-02/verify_decidable_membership.py` (exact integer arithmetic, **ALL PASS**):
- C1: `a < 2^a`; `2^a ≤ n ⟹ a < n`.
- C2: `RepWithAtMost k n ⟺ bounded-distinct ⟺ popcount n ≤ k` (n ≤ 200, k ≤ 5, vs naive multiset search).
- C3: bounded prime form ⟺ naive form (n < 400, k < 4); reproduces the parity caps (smallest odd needing 2 = 905, smallest even needing 3 = 906, consecutive; all odd n < 2000 in `S_2`, all even in `S_3`) and the Grechuk witness `1117175146 ∉ S_3`, `∈ S_4`.

## Notes

- **Build-pending / UNREGISTERED** (not in `Proofs.lean`): authored under a Docker + Aristotle blackout; proofs use only elementary `Multiset` algebra plus the S3 lemmas (verified on paper).
- The conjecture itself remains open (needs sieve/large-sieve machinery); this PR is infrastructure toward a decidable witness checker, not a proof of GS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)