### PR TITLE
research(spherical-law-of-cosines-oq-03): exact symbolic certificate for the trig dual law

### DIFF
--- a/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
@@ -109,6 +109,26 @@ Likely tactic risk: `field_simp` may need `mul_ne_zero`/`pow_ne_zero` side goals
 cleared identity explicitly. Numerics (check 1, cosA_nf, sinA_nf) confirm the statement is
 true, so this is purely a tactic-bookkeeping task once Docker/Aristotle return.
 
+### EXACT symbolic certificate (researcher-1, 2026-06-15 — upgrades "verified by numerics")
+`research/problems/spherical-law-of-cosines-oq-03/verify_dual_trig.py` proves the
+trig form is a **symbolic** identity (sympy, exact). Over the common denominator
+`sa·sb·sc²`, the numerator of `(cC) − (−cA·cB + sAsB·cc)` factors **exactly** as
+
+    numerator  =  (cc − ca·cb) · (sc² + cc² − 1)  =  (cc − ca·cb) · (sc² − (1 − cc²)),
+
+which is identically `0` once `hsc2 : sc² = 1 − cc²`. So the dependence on the
+side-Pythagorean identity is a single linear factor. This pins the **exact**
+`linear_combination` certificate for the drop-in: after `field_simp [hsa, hsb, hsc]`
+clears the denominators, the goal closes with
+
+    linear_combination (cc - ca * cb) * hsc2
+
+(possibly times the denominator-scaling monomial `field_simp` introduces, e.g.
+`sa * sb`; if `linear_combination (cc - ca*cb) * hsc2` leaves a nonzero monomial
+multiple, multiply the coefficient by that monomial — the residual is always a pure
+power of `sa, sb, sc`, never a new polynomial). This replaces the vague
+`(1 - cc^2) * dual_law_cleared …` fallback with the precise certificate.
+
 ## Remaining next steps
 1. Build `Proofs.SphericalLawOfCosinesOQ03` once Docker returns; add the `dual_law_trig`
    drop-in above; fix any `simp only [dot,cross]` projection hiccups (add `dsimp only`).

--- a/research/problems/spherical-law-of-cosines-oq-03/verify_dual_trig.py
+++ b/research/problems/spherical-law-of-cosines-oq-03/verify_dual_trig.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+erdos / spherical-law-of-cosines-oq-03 — EXACT symbolic verification of the
+literal trig dual law of cosines (the OQ-03 deliverable), upgrading S1's
+"verified by hand + numerics" to a closed symbolic proof, and pinning the exact
+`linear_combination` certificate for the Lean drop-in.
+
+Normal-form angle data for a spherical triangle (side cosines ca,cb,cc; side
+sines sa,sb,sc):
+    cos A = (ca - cb cc)/(sb sc),   cos B = (cb - ca cc)/(sa sc),
+    cos C = (cc - ca cb)/(sa sb),
+    sin A sin B = tp2/(sa sb sc^2),  tp2 = 1 - ca^2 - cb^2 - cc^2 + 2 ca cb cc.
+
+Claim (dual / polar law of cosines):   cos C = - cos A cos B + sin A sin B cos c.
+
+Result: (LHS - RHS) has numerator (over the common denominator sa sb sc^2)
+            (cc - ca cb) * (1 - cc^2 - sc^2),
+so it vanishes IDENTICALLY once  sc^2 = 1 - cc^2  (the side-Pythagorean
+sin^2 c = 1 - cos^2 c).  Hence the Lean proof, after `field_simp`, closes with
+            linear_combination (cc - ca*cb) * hsc2
+(up to the denominator-scaling factor field_simp introduces).
+"""
+
+import sympy as sp
+
+ca, cb, cc, sa, sb, sc = sp.symbols("ca cb cc sa sb sc", real=True)
+
+cA = (ca - cb * cc) / (sb * sc)
+cB = (cb - ca * cc) / (sa * sc)
+cC = (cc - ca * cb) / (sa * sb)
+tp2 = 1 - ca**2 - cb**2 - cc**2 + 2 * ca * cb * cc
+sAsB = tp2 / (sa * sb * sc**2)
+
+lhs = cC
+rhs = -cA * cB + sAsB * cc
+
+num, den = sp.fraction(sp.together(lhs - rhs))
+num = sp.expand(num)
+print("common denominator :", den)
+print("numerator (expanded):", num)
+
+# the closed factorization
+factored = sp.factor(num)
+print("numerator factored :", factored)
+expected = (cc - ca * cb) * (sc**2 + cc**2 - 1)
+print("matches (cc-ca*cb)*(sc^2+cc^2-1) = (cc-ca*cb)*(sc^2-(1-cc^2))?",
+      sp.simplify(num - expected) == 0)
+
+# under sc^2 = 1 - cc^2 the numerator is identically zero
+print("numerator | sc^2=1-cc^2  =", sp.simplify(num.subs(sc**2, 1 - cc**2)))
+
+# cross-check: the cleared identity (dual_law_cleared) already in the Lean file
+cleared = (cc - ca * cb) * sc**2 - (-(ca - cb * cc) * (cb - ca * cc) + tp2 * cc)
+print("dual_law_cleared residual | sc^2=1-cc^2 =",
+      sp.simplify(cleared.subs(sc**2, 1 - cc**2)))
+
+assert sp.simplify(num - expected) == 0
+assert sp.simplify(num.subs(sc**2, 1 - cc**2)) == 0
+assert sp.simplify(cleared.subs(sc**2, 1 - cc**2)) == 0
+print("\nALL EXACT CHECKS PASS — dual_law_trig is a symbolic identity mod sc^2=1-cc^2.")


### PR DESCRIPTION
## Summary
S1 (#24232, merged) formalized the **cleared** (radical-free) dual law of cosines and left the literal trig form

> cos C = − cos A · cos B + sin A · sin B · cos c

as a deferred `field_simp` drop-in, "verified by hand + numerics". This session upgrades that to an **exact symbolic proof** and pins the precise `linear_combination` certificate.

## Progress
- New `verify_dual_trig.py` (sympy, exact): over the common denominator `sa·sb·sc²`, the numerator of `(cC) − (−cA·cB + sAsB·cc)` factors **exactly** as
  `(cc − ca·cb)·(sc² + cc² − 1) = (cc − ca·cb)·(sc² − (1 − cc²))`,
  identically `0` under `hsc2 : sc² = 1 − cc²`.
- Updated `knowledge.md` drop-in with the exact certificate: after `field_simp [hsa,hsb,hsc]`, the proof closes with `linear_combination (cc - ca*cb) * hsc2` (replacing the vague `(1-cc^2)*dual_law_cleared` fallback).

## Findings
- The trig form's entire dependence on the side-Pythagorean identity is a **single linear factor** `(sc² − (1 − cc²))`. This is what makes the cleared→trig step a one-line `linear_combination`.

## Status
**Outcome**: progress (exact verification + sharpened drop-in; the registered Lean file is unchanged and still builds — only the knowledge + a reproducible script are added)
**Next Steps**: apply the now-precisely-certified `dual_law_trig` drop-in to `SphericalLawOfCosinesOQ03.lean` once Docker returns; optionally bridge to the parent's `Vec3`/`SphericalTriangle` so the normal-form cosines are derived.

🤖 Generated by researcher-1