### PR TITLE
Enrich Simplex Ehrhart (OQ-01): cross-refs + section mathContext

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -72,49 +72,56 @@
       "title": "Main Theorem: Simplex Lattice Count",
       "startLine": 42,
       "endLine": 67,
-      "summary": "Proves simplex_lattice_count: Fintype.card (Sym (Fin (d+1)) n) = C(n+d, d). Uses Sym.card_sym_eq_choose to get C(n+d, n), then Nat.choose_symm_of_eq_add for binomial symmetry."
+      "summary": "Proves simplex_lattice_count: Fintype.card (Sym (Fin (d+1)) n) = C(n+d, d). Uses Sym.card_sym_eq_choose to get C(n+d, n), then Nat.choose_symm_of_eq_add for binomial symmetry.",
+      "mathContext": "$|\\mathrm{Sym}\\,(\\mathrm{Fin}\\,(d+1))\\,n| = \\binom{(d+1)+n-1}{n} = \\binom{n+d}{n} = \\binom{n+d}{d}$."
     },
     {
       "id": "base-cases",
       "title": "Base Cases: n=0 and n=1",
       "startLine": 69,
       "endLine": 82,
-      "summary": "simplex_at_zero: count at n=0 is 1 (the origin). simplex_at_one: count at n=1 is d+1 (the vertices). Both proved by simp with Sym.card_sym_eq_choose."
+      "summary": "simplex_at_zero: count at n=0 is 1 (the origin). simplex_at_one: count at n=1 is d+1 (the vertices). Both proved by simp with Sym.card_sym_eq_choose.",
+      "mathContext": "$L(\\Delta^d,0)=\\binom{d}{d}=1$ (origin); $L(\\Delta^d,1)=\\binom{d+1}{d}=d+1$ (the $d+1$ vertices)."
     },
     {
       "id": "dimensional-specializations",
       "title": "Dimensional Specializations: 0D, 1D, 2D, 3D",
       "startLine": 85,
       "endLine": 117,
-      "summary": "simplex_0d: single point always. simplex_1d: n+1 lattice points (same as 1D cube). simplex_2d: C(n+2,2) triangular numbers. simplex_3d: C(n+3,3) tetrahedral numbers. Concrete native_decide verifications for small values."
+      "summary": "simplex_0d: single point always. simplex_1d: n+1 lattice points (same as 1D cube). simplex_2d: C(n+2,2) triangular numbers. simplex_3d: C(n+3,3) tetrahedral numbers. Concrete native_decide verifications for small values.",
+      "mathContext": "$L(\\Delta^1,n)=n+1$; $L(\\Delta^2,n)=\\binom{n+2}{2}=\\tfrac{(n+1)(n+2)}{2}$ (triangular); $L(\\Delta^3,n)=\\binom{n+3}{3}=\\tfrac{(n+1)(n+2)(n+3)}{6}$ (tetrahedral)."
     },
     {
       "id": "interior-points",
       "title": "Interior Lattice Points",
       "startLine": 119,
       "endLine": 158,
-      "summary": "simplex_interior_count: interior points = C(n-1, d) for n ≥ d+1. Proved by shifting coordinates (yᵢ = xᵢ - 1) to reduce interior constraint to boundary constraint at n-d-1. Also proves boundary count and concrete example for 2D triangle."
+      "summary": "simplex_interior_count: interior points = C(n-1, d) for n ≥ d+1. Proved by shifting coordinates (yᵢ = xᵢ - 1) to reduce interior constraint to boundary constraint at n-d-1. Also proves boundary count and concrete example for 2D triangle.",
+      "mathContext": "Interior: $\\binom{n-1}{d}$ for $n\\ge d+1$. Boundary: $\\binom{n+d}{d}-\\binom{n-1}{d}$; for $\\Delta^2$ this is $3n$."
     },
     {
       "id": "monotonicity-recursion",
       "title": "Monotonicity and Pascal Recursion",
       "startLine": 160,
       "endLine": 185,
-      "summary": "simplex_monotone: count is increasing in n via Nat.choose_le_choose. simplex_pascal: dimensional recursion C(n+1+(d+1), d+1) = C(n+1+d, d) + C(n+(d+1), d+1) via Nat.choose_succ_succ (Pascal's rule)."
+      "summary": "simplex_monotone: count is increasing in n via Nat.choose_le_choose. simplex_pascal: dimensional recursion C(n+1+(d+1), d+1) = C(n+1+d, d) + C(n+(d+1), d+1) via Nat.choose_succ_succ (Pascal's rule).",
+      "mathContext": "Monotone: $\\binom{n+d}{d}\\le\\binom{(n+1)+d}{d}$. Pascal: $\\binom{(n+1)+(d+1)}{d+1}=\\binom{(n+1)+d}{d}+\\binom{n+(d+1)}{d+1}$."
     },
     {
       "id": "cube-comparison",
       "title": "Comparison with Cube",
       "startLine": 187,
       "endLine": 200,
-      "summary": "simplex_cube_1d_agree: 1D simplex = 1D cube (both n+1 points). Example: 3D simplex at n=2 has 10 points vs cube's 27 (C(5,3) vs 3^3)."
+      "summary": "simplex_cube_1d_agree: 1D simplex = 1D cube (both n+1 points). Example: 3D simplex at n=2 has 10 points vs cube's 27 (C(5,3) vs 3^3).",
+      "mathContext": "1D: $L(\\Delta^1,n)=L(\\square^1,n)=n+1$. Growth $\\binom{n+d}{d}\\sim n^d/d!$ vs cube $(n+1)^d$ — ratio $1/d!$ of the volumes."
     },
     {
       "id": "polynomial-form",
       "title": "Polynomial Form: Closed Form via Factorials",
       "startLine": 202,
       "endLine": 256,
-      "summary": "Three theorems exhibit L(Δ^d, n) as a degree-d polynomial in n with explicit closed forms: simplex_count_descFactorial gives count·d! = (n+d)(n+d-1)···(n+1) via Nat.descFactorial_eq_factorial_mul_choose; simplex_count_ascFactorial gives count·d! = (n+1)(n+2)···(n+d) via Nat.ascFactorial_eq_factorial_mul_choose; simplex_count_prod gives the same as a Finset.range product. The polynomial roots at n = -1, ..., -d are visible directly in the ascending-factorial form. Concrete native_decide examples verify 2D triangle (n=3), 3D tetrahedron (n=2), and 4D pentachoron (n=2)."
+      "summary": "Three theorems exhibit L(Δ^d, n) as a degree-d polynomial in n with explicit closed forms: simplex_count_descFactorial gives count·d! = (n+d)(n+d-1)···(n+1) via Nat.descFactorial_eq_factorial_mul_choose; simplex_count_ascFactorial gives count·d! = (n+1)(n+2)···(n+d) via Nat.ascFactorial_eq_factorial_mul_choose; simplex_count_prod gives the same as a Finset.range product. The polynomial roots at n = -1, ..., -d are visible directly in the ascending-factorial form. Concrete native_decide examples verify 2D triangle (n=3), 3D tetrahedron (n=2), and 4D pentachoron (n=2).",
+      "mathContext": "$\\binom{n+d}{d}\\,d! = (n+d)^{\\underline{d}} = (n+1)^{\\overline{d}} = \\prod_{i=0}^{d-1}(n+1+i)$ — degree $d$, leading coefficient $1/d!$, roots at $n=-1,\\dots,-d$."
     }
   ],
   "conclusion": {
@@ -131,6 +138,26 @@
       "targetId": "ehrhart-cube-proven",
       "relationship": "parent",
       "description": "Cube Ehrhart formula L([0,1]^d, n) = (n+1)^d, proved axiom-free via the Fintype bijection Fin d → Fin (n+1). This entry answers OQ-01 of that proof: both use Fintype cardinality, but the simplex uses multisets (Sym) while the cube uses functions."
+    },
+    {
+      "targetId": "picks-theorem-oq-03-cross-poly",
+      "relationship": "sibling",
+      "description": "Cross-polytope (octahedron) Ehrhart theory — the third member of the simplex/cube/cross-polytope trio. Open question 2 here asks whether the cross-polytope count 2^d·C(n+d-1,d-1) admits a signed multiset proof; that entry establishes the cross-polytope Ehrhart polynomials and h*(z)=(1+z)^d concretely for d=1,2,3."
+    },
+    {
+      "targetId": "picks-theorem",
+      "relationship": "related",
+      "description": "Pick's theorem A = I + B/2 − 1 is the d=2 lattice-point count. The 2D simplex is a triangle; the boundary count 3n derived here (total minus interior C(n-1,2)) is the Ehrhart shadow of Pick's boundary term B."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "uses",
+      "description": "The count C(n+d,d) is a binomial coefficient; the proof leans on binomial symmetry (Nat.choose_symm_of_eq_add) and Pascal's rule (Nat.choose_succ_succ), and the dimensional specializations are the diagonals of Pascal's triangle (triangular, tetrahedral numbers)."
+    },
+    {
+      "targetId": "subset-count-multiset",
+      "relationship": "uses",
+      "description": "The core bijection models simplex lattice points as size-n multisets from {0,…,d}, i.e. the stars-and-bars count |Sym (Fin (d+1)) n| = C(n+d, n). That entry develops multiset subset counting from which the stars-and-bars identity follows."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `ehrhart-cube-proven-oq-01` (the simplex Ehrhart OQ-01 follow-up).

Annotations and overview were already deep; the real gaps were cross-references (only 1) and sections carrying only a `summary`.

## Changes
- **+4 crossReferences** (all targets verified to exist):
  - `picks-theorem-oq-03-cross-poly` (sibling) — completes the simplex/cube/cross-polytope trio; relates to open question 2
  - `picks-theorem` (related) — 2D simplex boundary count 3n as the Ehrhart shadow of Pick's B term
  - `binomial-theorem` (uses) — C(n+d,d), binomial symmetry, Pascal's rule
  - `subset-count-multiset` (uses) — stars-and-bars / Sym multiset model
- **Added `mathContext` to all 7 sections** (previously summary-only)

No content deleted; meta only. `pnpm build` passes (exit 0).