### PR TITLE
research(four-square-distribution-oq-04): S2 ACT — formalize the 2k=6 type-decomposition

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04.lean
@@ -1,0 +1,207 @@
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.Dedup
+import Mathlib.Tactic
+
+/-
+# Four-Square Distribution — Open Question 04: generalization to r₆(n)
+
+## Parent
+
+`FourSquareDistribution.lean` proves, for `r₄(n)`, that the ordered signed
+representations partition into **types** (sorted multisets of absolute values),
+each contributing
+
+  contribution(type) = (number of orderings) × 2^(number of nonzero parts)
+                     = (4! / ∏ mᵢ!) · 2^(#nonzero)
+
+and that these contributions sum to `r₄(n)`. The symmetry group there is the
+hyperoctahedral group `B₄ = S₄ ⋉ (ℤ/2)⁴`.
+
+## Open question (oq-04)
+
+Does the orbit/type bookkeeping generalize to `r_{2k}(n)` under
+`B_{2k} = S_{2k} ⋉ (ℤ/2)^{2k}`, `|B_{2k}| = (2k)! · 2^{2k}`?
+
+**Answer (this file, the `2k = 6` case): yes, verbatim.** With six coordinates
+the orbit-size formula reads
+
+  contribution(type) = (6! / ∏ mᵢ!) · 2^(#nonzero)              (★)
+
+and `∑_{types of n} contribution = r₆(n)`. The factor `2^(#nonzero)` (not
+`2^6`) is the same zero-sign degeneracy as in the parent: flipping the sign of a
+zero coordinate fixes the tuple, so only the nonzero coordinates contribute sign
+choices.
+
+This file mirrors the parent's **computational** approach (a sorted six-tuple
+structure + the formula `(★)`, with concrete contributions discharged by
+`native_decide`), rather than the heavier `MulAction`/semidirect-product route.
+That is exactly the "fixed small `m`" first ACT recommended in
+`research/problems/four-square-distribution-oq-04/knowledge.md`.
+
+All embedded contribution/total values are validated by
+`research/problems/four-square-distribution-oq-04/verify_hyperoctahedral_2k.py`
+and the `2k = 6` extension recorded in the knowledge base (each shape's orbit by
+`(★)` against an independent brute count of signed orderings; the per-`n` totals
+against an independent signed-square convolution computing `r₆(n)`).
+
+**Build status.** Authored under a Docker/Aristotle blackout, so this file is
+**not yet registered in `Proofs.lean`**. It uses only elementary list arithmetic
+and `native_decide`, mirroring the already-compiling parent; it is a
+verified-on-paper drop-in for the next build-enabled session.
+
+## References
+
+- Jacobi, C. G. J. (1834). *Fundamenta nova theoriae functionum ellipticarum.*
+  (Formulae for `r₄`, `r₆`, `r₈`.)
+- Grosswald, E. (1985). *Representations of Integers as Sums of Squares.*
+-/
+
+namespace FourSquareDistributionOQ04
+
+open List
+
+/-! ## Part 1: Representation types for six squares
+
+A type is a sorted six-tuple of non-negative integers whose squares sum to `n`;
+it captures the unordered multiset of absolute values of a representation. -/
+
+/-- A sorted representation type for `n` as a sum of six squares. -/
+structure RepType6 (n : ℕ) where
+  a₁ : ℕ
+  a₂ : ℕ
+  a₃ : ℕ
+  a₄ : ℕ
+  a₅ : ℕ
+  a₆ : ℕ
+  sorted : a₁ ≤ a₂ ∧ a₂ ≤ a₃ ∧ a₃ ≤ a₄ ∧ a₄ ≤ a₅ ∧ a₅ ≤ a₆
+  sum_eq : a₁ ^ 2 + a₂ ^ 2 + a₃ ^ 2 + a₄ ^ 2 + a₅ ^ 2 + a₆ ^ 2 = n
+  deriving DecidableEq
+
+/-- The six values as a list. -/
+def RepType6.toList {n : ℕ} (t : RepType6 n) : List ℕ :=
+  [t.a₁, t.a₂, t.a₃, t.a₄, t.a₅, t.a₆]
+
+/-- Number of nonzero entries. -/
+def RepType6.nonzeroCount {n : ℕ} (t : RepType6 n) : ℕ :=
+  (if t.a₁ = 0 then 0 else 1) + (if t.a₂ = 0 then 0 else 1) +
+  (if t.a₃ = 0 then 0 else 1) + (if t.a₄ = 0 then 0 else 1) +
+  (if t.a₅ = 0 then 0 else 1) + (if t.a₆ = 0 then 0 else 1)
+
+/-! ## Part 2: The symmetry multiplier `(★)` -/
+
+/-- Multinomial number of orderings: `6! / ∏ (multiplicity v)!`. -/
+def RepType6.permutations {n : ℕ} (t : RepType6 n) : ℕ :=
+  let vals := t.toList
+  let distinctVals := vals.dedup
+  720 / (distinctVals.map (fun v => Nat.factorial (vals.count v))).prod
+
+/-- Sign factor `2^(#nonzero)`. -/
+def RepType6.signFactor {n : ℕ} (t : RepType6 n) : ℕ :=
+  2 ^ t.nonzeroCount
+
+/-- Contribution of a type to `r₆(n)`: orderings times sign choices. -/
+def RepType6.contribution {n : ℕ} (t : RepType6 n) : ℕ :=
+  t.permutations * t.signFactor
+
+/-- Constructor with the two proof obligations. -/
+private def mk6 (n a₁ a₂ a₃ a₄ a₅ a₆ : ℕ)
+    (hs : a₁ ≤ a₂ ∧ a₂ ≤ a₃ ∧ a₃ ≤ a₄ ∧ a₄ ≤ a₅ ∧ a₅ ≤ a₆)
+    (he : a₁ ^ 2 + a₂ ^ 2 + a₃ ^ 2 + a₄ ^ 2 + a₅ ^ 2 + a₆ ^ 2 = n) : RepType6 n :=
+  ⟨a₁, a₂, a₃, a₄, a₅, a₆, hs, he⟩
+
+/-! ## Part 3: Enumeration of types for small `n`
+
+The types below are the complete list of sorted six-square shapes for each `n`
+(verified exhaustively in the Python certificate). -/
+
+-- n = 1
+def t1 : RepType6 1 := mk6 1 0 0 0 0 0 1 (by decide) (by norm_num)
+-- n = 2
+def t2 : RepType6 2 := mk6 2 0 0 0 0 1 1 (by decide) (by norm_num)
+-- n = 3
+def t3 : RepType6 3 := mk6 3 0 0 0 1 1 1 (by decide) (by norm_num)
+-- n = 5
+def t5a : RepType6 5 := mk6 5 0 0 0 0 1 2 (by decide) (by norm_num)
+def t5b : RepType6 5 := mk6 5 0 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 6
+def t6a : RepType6 6 := mk6 6 0 0 0 1 1 2 (by decide) (by norm_num)
+def t6b : RepType6 6 := mk6 6 1 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 12
+def t12a : RepType6 12 := mk6 12 0 0 0 2 2 2 (by decide) (by norm_num)
+def t12b : RepType6 12 := mk6 12 0 0 1 1 1 3 (by decide) (by norm_num)
+def t12c : RepType6 12 := mk6 12 1 1 1 1 2 2 (by decide) (by norm_num)
+-- n = 30 (six shapes, including the all-distinct-nonzero one)
+def t30a : RepType6 30 := mk6 30 0 0 0 1 2 5 (by decide) (by norm_num)
+def t30b : RepType6 30 := mk6 30 0 0 1 2 3 4 (by decide) (by norm_num)
+def t30c : RepType6 30 := mk6 30 0 2 2 2 3 3 (by decide) (by norm_num)
+def t30d : RepType6 30 := mk6 30 1 1 1 1 1 5 (by decide) (by norm_num)
+def t30e : RepType6 30 := mk6 30 1 1 1 3 3 3 (by decide) (by norm_num)
+def t30f : RepType6 30 := mk6 30 1 1 2 2 2 4 (by decide) (by norm_num)
+
+/-! ## Part 4: Contributions via `(★)`, checked by `native_decide` -/
+
+theorem t1_contribution  : t1.contribution  = 12  := by native_decide
+theorem t2_contribution  : t2.contribution  = 60  := by native_decide
+theorem t3_contribution  : t3.contribution  = 160 := by native_decide
+theorem t5a_contribution : t5a.contribution = 120 := by native_decide
+theorem t5b_contribution : t5b.contribution = 192 := by native_decide
+theorem t6a_contribution : t6a.contribution = 480 := by native_decide
+theorem t6b_contribution : t6b.contribution = 64  := by native_decide
+theorem t12a_contribution : t12a.contribution = 160 := by native_decide
+theorem t12b_contribution : t12b.contribution = 960 := by native_decide
+theorem t12c_contribution : t12c.contribution = 960 := by native_decide
+theorem t30a_contribution : t30a.contribution = 960  := by native_decide
+theorem t30b_contribution : t30b.contribution = 5760 := by native_decide
+theorem t30c_contribution : t30c.contribution = 1920 := by native_decide
+theorem t30d_contribution : t30d.contribution = 384  := by native_decide
+theorem t30e_contribution : t30e.contribution = 1280 := by native_decide
+theorem t30f_contribution : t30f.contribution = 3840 := by native_decide
+
+/-! ## Part 5: The decomposition `∑ contributions = r₆(n)`
+
+Jacobi's `r₆` values (computed independently in the certificate) are reproduced
+exactly by summing the type contributions. -/
+
+theorem r6_1  : t1.contribution = 12 := t1_contribution
+theorem r6_2  : t2.contribution = 60 := t2_contribution
+theorem r6_3  : t3.contribution = 160 := t3_contribution
+
+/-- `r₆(5) = 312`: the two shapes `(0,0,0,0,1,2)` and `(0,1,1,1,1,1)`. -/
+theorem r6_5  : t5a.contribution + t5b.contribution = 312 := by
+  rw [t5a_contribution, t5b_contribution]
+
+/-- `r₆(6) = 544`: shapes `(0,0,0,1,1,2)` and `(1,1,1,1,1,1)`. -/
+theorem r6_6  : t6a.contribution + t6b.contribution = 544 := by
+  rw [t6a_contribution, t6b_contribution]
+
+/-- `r₆(12) = 2080`: three shapes. -/
+theorem r6_12 : t12a.contribution + t12b.contribution + t12c.contribution = 2080 := by
+  rw [t12a_contribution, t12b_contribution, t12c_contribution]
+
+/-- `r₆(30) = 14144`: six shapes, including the all-six-distinct-nonzero shape
+`(1,1,2,2,2,4)` … and `(0,0,1,2,3,4)` realizing the largest single orbit. -/
+theorem r6_30 :
+    t30a.contribution + t30b.contribution + t30c.contribution +
+      t30d.contribution + t30e.contribution + t30f.contribution = 14144 := by
+  rw [t30a_contribution, t30b_contribution, t30c_contribution,
+      t30d_contribution, t30e_contribution, t30f_contribution]
+
+/-! ## Part 6: Structural properties of the six-square decomposition -/
+
+/-- The number of nonzero parts is at most six. -/
+theorem nonzeroCount_le_six {n : ℕ} (t : RepType6 n) : t.nonzeroCount ≤ 6 := by
+  simp only [RepType6.nonzeroCount]
+  split_ifs <;> omega
+
+/-- The sign factor is a power of two, at most `2⁶ = 64`. -/
+theorem signFactor_le_64 {n : ℕ} (t : RepType6 n) : t.signFactor ≤ 64 := by
+  have h := nonzeroCount_le_six t
+  simp only [RepType6.signFactor]
+  calc 2 ^ t.nonzeroCount ≤ 2 ^ 6 := Nat.pow_le_pow_right (by norm_num) h
+    _ = 64 := by norm_num
+
+#check @RepType6.contribution
+#check @r6_30
+#check @nonzeroCount_le_six
+
+end FourSquareDistributionOQ04

--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -69,6 +69,42 @@ stab 1`, summing to `r_4(30)=576`.
 
 ---
 
+### Session 2026-06-15 (ACT) — the `2k = 6` case formalized (build-pending)
+
+**Mode**: continue · **Outcome**: ACT (Lean file mirroring the proven parent;
+Docker/Aristotle blackout ⟹ build-pending, UNREGISTERED).
+
+Chose the **computational route the parent actually uses**, not the heavier
+`MulAction` one the prior ORIENT sketched: the parent
+`FourSquareDistribution.lean` does *not* build `B₄` as a group action — it
+defines `RepType` (sorted four-tuple) + `contribution = permutations · 2^nonzero`
+and discharges concrete values by `native_decide`. New file
+`proofs/Proofs/FourSquareDistributionOQ04.lean` mirrors this for **six**
+coordinates:
+
+- `RepType6 n` = sorted six-tuple `a₁≤…≤a₆`, `Σ aᵢ² = n` (`deriving DecidableEq`,
+  exactly like the parent).
+- `contribution = (720 / ∏ (count v)!) · 2^(#nonzero)` — the `(★)` formula at
+  `m = 6`.
+- Concrete shapes for `n ∈ {1,2,3,5,6,12,30}` with per-shape contributions by
+  `native_decide`, and `r₆(n)` totals as `∑ contributions` (`r6_5=312`,
+  `r6_6=544`, `r6_12=2080`, `r6_30=14144`).
+- Structural lemmas `nonzeroCount_le_six`, `signFactor_le_64`.
+
+This executes next-step #1 below at `m = 6` without the parametric
+semidirect-product machinery. The (DECOMP) partition obstruction (next-step #2)
+is handled the *same way the parent handles it* — case-by-case per small `n` via
+the exhaustively-enumerated complete shape list (the cert checks the list is
+complete); a uniform `MulAction` partition proof remains the deep open Lean work.
+
+**Cert (new)** `verify_r6_decomposition.py` (PASS): for each embedded `n` it
+checks (a) the exhaustive sorted-shape enumeration equals the file's shape list,
+(b) the `(★)` orbit value equals an INDEPENDENT brute count of distinct signed
+orderings *and* the embedded number, (c) `Σ orbits = r₆(n)` by an INDEPENDENT
+signed-square convolution *and* the embedded total. Largest single `m=6` orbit
+seen: `(0,0,1,2,3,4) → 5760` at `n=30`; all-nonzero-distinct would give
+`6!·2⁶ = 46080`.
+
 ## Next steps
 
 1. **ACT (Lean, Docker-gated).** For a FIXED small `m = 2k ∈ {4,6,8}` (avoids the

--- a/research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py
+++ b/research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+S2 certificate for four-square-distribution-oq-04 (2k = 6 case).
+
+Pins the EXACT shapes, per-shape orbit contributions, and per-n totals embedded
+in `proofs/Proofs/FourSquareDistributionOQ04.lean`, checking each three ways:
+
+  (a) exhaustive enumeration of sorted six-square shapes for each n;
+  (b) the orbit formula (*) 2^(#nonzero) * 6! / prod(mult!) against an
+      INDEPENDENT brute count of distinct signed orderings of the shape;
+  (c) the per-n total sum_shapes orbit(shape) against r_6(n) computed by an
+      INDEPENDENT signed-square convolution.
+
+All exact integer arithmetic.
+"""
+
+from itertools import product
+from math import factorial, isqrt
+from collections import Counter, defaultdict
+
+
+def shapes(m, n):
+    """All sorted m-tuples of nonneg ints whose squares sum to n."""
+    top = isqrt(n)
+    out = []
+
+    def build(prefix, start, rem, left):
+        if left == 0:
+            if rem == 0:
+                out.append(tuple(prefix))
+            return
+        v = start
+        while v <= top and v * v <= rem:
+            build(prefix + [v], v, rem - v * v, left - 1)
+            v += 1
+
+    build([], 0, n, m)
+    return out
+
+
+def orbit_formula(shape):
+    m = len(shape)
+    nz = sum(1 for x in shape if x != 0)
+    cnt = Counter(shape)
+    perm = factorial(m)
+    for c in cnt.values():
+        perm //= factorial(c)
+    return (2 ** nz) * perm
+
+
+def orbit_brute(shape):
+    """Independent: count distinct signed orderings of the shape's values."""
+    seen = set()
+    base = shape
+    # all sign assignments
+    m = len(base)
+    for signs in product((1, -1), repeat=m):
+        signed = tuple(s * v for s, v in zip(signs, base))
+        # all orderings via permutations of indices: use set of permutations
+        # (cheap since m=6); collect every permutation of `signed`
+        from itertools import permutations as perms
+        for p in perms(signed):
+            seen.add(p)
+    return len(seen)
+
+
+def r6_convolution(n):
+    single = defaultdict(int)
+    single[0] = 1
+    for x in range(1, isqrt(n) + 1):
+        single[x * x] += 2
+    dist = defaultdict(int)
+    dist[0] = 1
+    for _ in range(6):
+        nd = defaultdict(int)
+        for a, va in dist.items():
+            for b, vb in single.items():
+                if a + b <= n:
+                    nd[a + b] += va * vb
+        dist = nd
+    return dist[n]
+
+
+# The exact data embedded in the Lean file.
+EXPECTED = {
+    1:  [((0, 0, 0, 0, 0, 1), 12)],
+    2:  [((0, 0, 0, 0, 1, 1), 60)],
+    3:  [((0, 0, 0, 1, 1, 1), 160)],
+    5:  [((0, 0, 0, 0, 1, 2), 120), ((0, 1, 1, 1, 1, 1), 192)],
+    6:  [((0, 0, 0, 1, 1, 2), 480), ((1, 1, 1, 1, 1, 1), 64)],
+    12: [((0, 0, 0, 2, 2, 2), 160), ((0, 0, 1, 1, 1, 3), 960),
+         ((1, 1, 1, 1, 2, 2), 960)],
+    30: [((0, 0, 0, 1, 2, 5), 960), ((0, 0, 1, 2, 3, 4), 5760),
+         ((0, 2, 2, 2, 3, 3), 1920), ((1, 1, 1, 1, 1, 5), 384),
+         ((1, 1, 1, 3, 3, 3), 1280), ((1, 1, 2, 2, 2, 4), 3840)],
+}
+TOTALS = {1: 12, 2: 60, 3: 160, 5: 312, 6: 544, 12: 2080, 30: 14144}
+
+
+def main():
+    for n, exp in EXPECTED.items():
+        sh = shapes(6, n)
+        # (a) enumeration matches the embedded shape list exactly
+        assert set(sh) == {s for s, _ in exp}, \
+            f"n={n}: shape set mismatch enum={sorted(sh)} exp={[s for s,_ in exp]}"
+        # (b) orbit formula == brute, and == embedded value
+        for s, v in exp:
+            ofo = orbit_formula(s)
+            obr = orbit_brute(s)
+            assert ofo == obr == v, \
+                f"n={n} shape {s}: formula={ofo} brute={obr} embedded={v}"
+        # (c) total == r_6(n) (convolution) == embedded total
+        tot = sum(orbit_formula(s) for s in sh)
+        r6 = r6_convolution(n)
+        assert tot == r6 == TOTALS[n], \
+            f"n={n}: sum={tot} r6={r6} embedded={TOTALS[n]}"
+        print(f"n={n:>2}: {len(sh)} shapes, sum orbits = r_6(n) = {tot}  OK")
+
+    print("\nALL R6 DECOMPOSITION CERTS PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/four-square-distribution-oq-04.json
+++ b/src/data/research/problems/four-square-distribution-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "four-square-distribution-oq-04",
   "title": "Type-Decomposition of Sums of 2k Squares via the Hyperoctahedral Group",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "in-progress",
   "tier": "B",
   "path": "full",
@@ -43,11 +43,14 @@
     "lastUpdate": "2026-06-15T07:05:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "ORIENT: answered the seeker's generalization question YES. The four-square orbit-stabilizer type-decomposition extends verbatim to r_{2k}(n) under B_{2k}=S_{2k} semidirect (Z/2)^{2k}: orbit(shape with z zeros, multiplicities m_i)=2^{2k-z}*(2k)!/prod m_i!, stabilizer=2^z*z!*prod(nonzero m_j!), r_{2k}(n)=sum over shapes orbit. Verified exactly for 2k in {2,4,6,8}. Lean ACT Docker-gated.",
+    "progressSummary": "ORIENT: answered the seeker's generalization question YES. The four-square orbit-stabilizer type-decomposition extends verbatim to r_{2k}(n) under B_{2k}=S_{2k} semidirect (Z/2)^{2k}: orbit(shape with z zeros, multiplicities m_i)=2^{2k-z}*(2k)!/prod m_i!, stabilizer=2^z*z!*prod(nonzero m_j!), r_{2k}(n)=sum over shapes orbit. Verified exactly for 2k in {2,4,6,8}. Lean ACT Docker-gated. S2 (ACT, build-pending): formalized the 2k=6 case mirroring the parent's COMPUTATIONAL route (not MulAction). New proofs/Proofs/FourSquareDistributionOQ04.lean: RepType6 (sorted six-tuple) + contribution=(720/prod count!)*2^nonzero, concrete shapes for n in {1,2,3,5,6,12,30} with contributions by native_decide and r_6(n) totals as sum of contributions (r6_5=312,r6_6=544,r6_12=2080,r6_30=14144) + nonzeroCount_le_six/signFactor_le_64. Executes the 'fixed small m' ACT at m=6. Cert verify_r6_decomposition.py PASS (exhaustive shapes; orbit formula vs brute signed-ordering count; totals vs convolution).",
     "builtItems": [
+      "proofs/Proofs/FourSquareDistributionOQ04.lean (S2, build-pending/UNREGISTERED) — 2k=6 type-decomposition: RepType6, the (star) orbit formula, native_decide contributions + r_6(n) totals for n in {1,2,3,5,6,12,30}, structural bounds.",
+      "research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py (S2) — pins the exact embedded shapes/contributions/totals via exhaustive enumeration + independent brute signed-ordering count + signed-square convolution.",
       "research/problems/four-square-distribution-oq-04/verify_hyperoctahedral_2k.py - stdlib exact verifier: orbit-size formula vs independent brute signed-ordering count; orbit*stab=|B_{2k}| (orbit-stabilizer); sum_shapes orbit == r_{2k}(n) (independent convolution) for 2k in {2,4,6,8}; anchors r_2=4(d1-d3), r_4=8 sigma*. All checks PASS."
     ],
     "insights": [
+      "S2: the parent four-square proof is COMPUTATIONAL (RepType + formula + native_decide), NOT a MulAction; so the cheapest first ACT for r_{2k} is to mirror it at fixed m (did m=6), discharging concrete contributions/totals by native_decide. The (DECOMP) partition is handled per-n via a complete shape list (cert-verified complete), same as the parent; a uniform MulAction partition proof stays the deep open Lean work.",
       "The orbit-stabilizer decomposition generalizes to all 2k with orbit size 2^{#nonzero}*(2k)!/prod m_i!. |B_8|=8!*2^8=10321920.",
       "Stabilizer is NOT the full Young subgroup prod m_i!: only the 2^z sign flips on ZERO coordinates fix a tuple (flipping a 0 is trivial; flipping a nonzero changes the value). So |stab|=2^z*z!*prod_{nonzero} m_j!, and the orbit carries 2^{#nonzero} not 2^{2k}. Mishandling zeros is the one place a naive |B|/Young computation fails.",
       "The orbit-size formula (orbit-stabilizer) is the easy half; the orbit PARTITION r_{2k}=sum orbit is the real Lean obstruction (the parent proved it only case-by-case for small n)."
@@ -58,7 +61,7 @@
     ],
     "nextSteps": [
       "ACT fixed m in {4,6,8}: MulAction of Equiv.Perm (Fin m) x sign flips on {f:Fin m -> Z // sum f^2 = n}; stabilizer order via zero/nonzero split; orbit size via MulAction.card_orbit_mul_card_stabilizer_eq_card_group (Mathlib/GroupTheory/GroupAction/Quotient.lean).",
-      "Prove the orbit partition r_{2k}=sum_shapes orbit (a MulAction partition argument) \u2014 the genuine obstruction.",
+      "Prove the orbit partition r_{2k}=sum_shapes orbit (a MulAction partition argument) — the genuine obstruction.",
       "Supply r_6,r_8 arithmetic totals (Jacobi/modular) to state the decomposition with explicit totals."
     ],
     "markdown": "See research/problems/four-square-distribution-oq-04/knowledge.md"
@@ -89,7 +92,7 @@
     ]
   },
   "started": "2026-06-15T07:05:00.000Z",
-  "lastUpdate": "2026-06-15T07:05:00.000Z",
+  "lastUpdate": "2026-06-15T10:25:00Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Four-square distribution OQ-04 asks whether the orbit/type bookkeeping behind `r₄(n)` generalizes to `r_{2k}(n)` under the hyperoctahedral group `B_{2k} = S_{2k} ⋉ (ℤ/2)^{2k}`. The prior ORIENT (#24253) answered **yes** in general and pinned the formula `(★) contribution = 2^(#nonzero)·(2k)!/∏ mᵢ!`. This S2 session **executes the documented "fixed small m" ACT at 2k = 6**.

**New build-pending file** `proofs/Proofs/FourSquareDistributionOQ04.lean` mirrors the parent `FourSquareDistribution.lean`'s **computational** route (sorted-tuple type + formula + `native_decide`) — *not* the heavier `MulAction`/semidirect-product route:

- `RepType6 n` — sorted six-tuple `a₁≤…≤a₆` with `Σ aᵢ² = n` (`deriving DecidableEq`, like the parent).
- `contribution = (720 / ∏ (count v)!) · 2^(#nonzero)` — the `(★)` formula at `m = 6`.
- Concrete shapes for `n ∈ {1,2,3,5,6,12,30}`, per-shape contributions by `native_decide`, and `r₆(n)` totals as `∑ contributions`: `r6_5=312`, `r6_6=544`, `r6_12=2080`, `r6_30=14144`.
- Structural lemmas `nonzeroCount_le_six`, `signFactor_le_64`.

## Validation

`research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py` (exact arithmetic, **ALL PASS**), three independent checks per `n`:
- (a) exhaustive sorted-shape enumeration equals the file's embedded shape list;
- (b) the `(★)` orbit value equals an **independent brute count of distinct signed orderings** and the embedded number;
- (c) `∑ orbits = r₆(n)` by an **independent signed-square convolution** and the embedded total.

## Notes

- **Build-pending / UNREGISTERED** (Docker + Aristotle blackout); uses only elementary list arithmetic + `native_decide`, mirroring the already-compiling parent.
- The `(DECOMP) r_{2k} = Σ orbit` partition is handled per-`n` via a complete (cert-verified) shape list, exactly as the parent does; a uniform `MulAction` partition proof remains the deep open Lean work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)