### PR TITLE
fix: nonexistent Nat.sSup_le in 2 registered files (Erdos653/Erdos1104) breaks aggregate build

### DIFF
--- a/proofs/Proofs/Erdos1104Problem.lean
+++ b/proofs/Proofs/Erdos1104Problem.lean
@@ -69,7 +69,7 @@ theorem emptyGraph_chromaticNumber_pos {n : ℕ} (hn : 0 < n)
 1-chromatic. -/
 theorem triangleFreeMaxChi_one : triangleFreeMaxChi 1 ≤ 1 := by
   unfold triangleFreeMaxChi
-  apply Nat.sSup_le
+  apply csSup_le'
   intro k ⟨G, hDec, hTF, hChi⟩
   rw [← hChi]
   exact @SimpleGraph.chromaticNumber_le_card (Fin 1) _ G hDec
@@ -78,7 +78,7 @@ theorem triangleFreeMaxChi_one : triangleFreeMaxChi 1 ≤ 1 := by
 theorem triangleFreeMaxChi_zero : triangleFreeMaxChi 0 = 0 := by
   unfold triangleFreeMaxChi
   apply le_antisymm
-  · apply Nat.sSup_le
+  · apply csSup_le'
     intro k ⟨G, hDec, _, hChi⟩
     rw [← hChi]
     exact @SimpleGraph.chromaticNumber_le_card (Fin 0) _ G hDec
@@ -88,7 +88,7 @@ theorem triangleFreeMaxChi_zero : triangleFreeMaxChi 0 = 0 := by
 of vertices. -/
 theorem triangleFreeMaxChi_le (n : ℕ) : triangleFreeMaxChi n ≤ n := by
   unfold triangleFreeMaxChi
-  apply Nat.sSup_le
+  apply csSup_le'
   intro k ⟨G, hDec, _, hChi⟩
   rw [← hChi]
   exact @SimpleGraph.chromaticNumber_le_card (Fin n) _ G hDec

--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -171,7 +171,7 @@ Hence `rValueSet S ⊆ Finset.Icc 1 (n-1)`, whose cardinality is `n - 1`, and
 theorem g_le_n_sub_one : ∀ n : ℕ, 2 ≤ n → g n ≤ n - 1 := by
   intro n hn
   unfold g
-  apply Nat.sSup_le
+  apply csSup_le'
   intro k hk
   simp only [Set.mem_setOf_eq] at hk
   obtain ⟨S, hcard, rfl⟩ := hk


### PR DESCRIPTION
## Summary
`Erdos653Problem.lean` is **registered** in `Proofs.lean` (line 1784). Its merged theorem `g_le_n_sub_one` (from #24308, authored under the Docker blackout and never machine-checked) calls `apply Nat.sSup_le` — **a lemma that does not exist in Mathlib**. ℕ is `ConditionallyCompleteLinearOrderBot`, not a `CompleteLattice`, so neither `Nat.sSup_le` nor the generic `sSup_le` applies. The file (and the full aggregate Lean build) therefore does not compile.

## Fix
Replace with `csSup_le' (h : a ∈ upperBounds s) : sSup s ≤ a` (`Order/ConditionallyCompleteLattice/Basic.lean:609`) — the unconditional upper-bound lemma for conditionally-complete lattices with a bottom (no nonemptiness needed; the empty set maps to `⊥ = 0`). After `apply csSup_le'` the goal is `(n-1) ∈ upperBounds {...}` = `∀ k ∈ s, k ≤ n-1`, so the existing `intro k hk; …` body is unchanged.

## Findings
- Verified the name/signature against Mathlib master. The same nonexistent `Nat.sSup_le` also appears in the open PR #24302 (`g_le_n`), which I've fixed on its own branch.

## Status
**Outcome**: build-fix for a registered file (removes a confirmed compile blocker). Still build-pending locally under the Docker blackout, but the name is verified-correct.
**Priority**: unblocks the aggregate `docker-build` for the whole swarm when Docker returns.

🤖 Generated by researcher-1