### PR TITLE
Fix: resync review-tracker action-item counts (60 entries)

### DIFF
--- a/src/data/proofs/review-tracker.json
+++ b/src/data/proofs/review-tracker.json
@@ -6,16 +6,16 @@
       "lastReviewed": "2026-03-24T00:30:06Z",
       "overallGrade": "B-",
       "qualityScore": 6.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 5
     },
     "cantor-diagonalization": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T00:35:05Z",
       "overallGrade": "B+",
       "qualityScore": 7.0,
-      "actionItems": 8,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "lebesgue-measure": {
       "reviewCount": 1,
@@ -23,7 +23,7 @@
       "overallGrade": "B-",
       "qualityScore": 5.5,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 6
     },
     "kroneckers-jugendtraum": {
       "reviewCount": 1,
@@ -31,31 +31,31 @@
       "overallGrade": "C-",
       "qualityScore": 4.2,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "abel-ruffini": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T01:34:04Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "amgm-inequality": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T03:31:21Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 4
     },
     "area-of-circle-oq-01-oq-02-oq-01": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T04:32:36Z",
       "overallGrade": "B+",
       "qualityScore": 8.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "arithmetic-series": {
       "reviewCount": 1,
@@ -63,111 +63,111 @@
       "overallGrade": "B",
       "qualityScore": 7.3,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "ballot-problem": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T05:31:54Z",
       "overallGrade": "C+",
       "qualityScore": 6.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 7
     },
     "cevas-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T05:39:33Z",
       "overallGrade": "B+",
       "qualityScore": 7.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "continuum-hypothesis": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:31:41Z",
       "overallGrade": "C",
       "qualityScore": 5.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 6
     },
     "dissection-of-cubes-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T06:38:47Z",
       "overallGrade": "B-",
       "qualityScore": 6.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "erdos-szekeres": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T07:31:13Z",
       "overallGrade": "C+",
       "qualityScore": 5.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 4
     },
     "denumerability-rationals": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T08:32:27Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "fair-games-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T09:32:17Z",
       "overallGrade": "B",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 7
     },
     "fundamental-theorem-algebra": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T10:31:52Z",
       "overallGrade": "B-",
       "qualityScore": 6.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "godel-incompleteness": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T11:31:59Z",
       "overallGrade": "D+",
       "qualityScore": 4.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 6
     },
     "hilbert-15": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T14:35:25Z",
       "overallGrade": "C",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 2
     },
     "hilbert-4": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:33:11Z",
       "overallGrade": "C",
       "qualityScore": 5.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 4
     },
     "hilbert-17": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:41:27Z",
       "overallGrade": "C+",
       "qualityScore": 6.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 3
     },
     "hilbert-10": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T15:38:16Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "bezout-identity": {
       "reviewCount": 1,
@@ -175,7 +175,7 @@
       "overallGrade": "B",
       "qualityScore": 6.7,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "cauchy-schwarz": {
       "reviewCount": 1,
@@ -183,15 +183,15 @@
       "overallGrade": "B+",
       "qualityScore": 7.8,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "lagrange-four-squares": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T16:40:33Z",
       "overallGrade": "C+",
       "qualityScore": 5.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 8,
+      "resolvedItems": 4
     },
     "angle-trisection": {
       "reviewCount": 1,
@@ -199,7 +199,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "bertrands-postulate": {
       "reviewCount": 1,
@@ -207,7 +207,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.3,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "cramers-rule": {
       "reviewCount": 1,
@@ -215,7 +215,7 @@
       "overallGrade": "B-",
       "qualityScore": 5.7,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "de-moivre": {
       "reviewCount": 1,
@@ -223,7 +223,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "derangements": {
       "reviewCount": 1,
@@ -231,7 +231,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.0,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "euler-totient": {
       "reviewCount": 1,
@@ -239,7 +239,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "fundamental-arithmetic": {
       "reviewCount": 1,
@@ -247,7 +247,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "fundamental-theorem-calculus": {
       "reviewCount": 1,
@@ -255,7 +255,7 @@
       "overallGrade": "C+",
       "qualityScore": 5.3,
       "actionItems": 7,
-      "resolvedItems": 0
+      "resolvedItems": 6
     },
     "herons-formula": {
       "reviewCount": 1,
@@ -263,7 +263,7 @@
       "overallGrade": "B",
       "qualityScore": 6.8,
       "actionItems": 5,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "isosceles-triangle": {
       "reviewCount": 1,
@@ -271,7 +271,7 @@
       "overallGrade": "B-",
       "qualityScore": 6.3,
       "actionItems": 4,
-      "resolvedItems": 0
+      "resolvedItems": 4
     },
     "lagrange-theorem": {
       "reviewCount": 1,
@@ -279,207 +279,207 @@
       "overallGrade": "B",
       "qualityScore": 7.0,
       "actionItems": 6,
-      "resolvedItems": 0
+      "resolvedItems": 5
     },
     "platonic-solids": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T17:32:42Z",
       "overallGrade": "B+",
       "qualityScore": 7.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "liouville-theorem": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T18:37:05Z",
       "overallGrade": "B-",
       "qualityScore": 6.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 3
     },
     "triangular-reciprocals": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T19:32:53Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "area-of-circle-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T20:32:37Z",
       "overallGrade": "B+",
       "qualityScore": 8.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "bezout-identity-oq-02-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-24T21:37:33Z",
       "overallGrade": "A-",
       "qualityScore": 8.5,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "ptolemys-theorem": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-24T23:32:03Z",
       "overallGrade": "C+",
       "qualityScore": 5.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 5
     },
     "cevas-theorem-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:38:18Z",
       "overallGrade": "A-",
       "qualityScore": 8.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "ballot-problem-oq-01-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T00:33:41Z",
       "overallGrade": "B",
       "qualityScore": 7.2,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "cauchy-schwarz-integral-oq-02-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:34:20Z",
       "overallGrade": "A-",
       "qualityScore": 8.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 2,
+      "resolvedItems": 2
     },
     "amgm-inequality-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T01:38:33Z",
       "overallGrade": "B",
       "qualityScore": 7.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "amgm-inequality-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:33:12Z",
       "overallGrade": "B+",
       "qualityScore": 8.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 4
     },
     "amgm-inequality-oq-03-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T02:37:03Z",
       "overallGrade": "B",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "cauchy-schwarz-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T03:38:16Z",
       "overallGrade": "B+",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "area-of-circle-oq-01-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T04:34:12Z",
       "overallGrade": "B-",
       "qualityScore": 6.8,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 5
     },
     "area-of-circle-oq-01": {
       "reviewCount": 2,
       "lastReviewed": "2026-03-25T06:32:34Z",
       "overallGrade": "B",
       "qualityScore": 7.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "ballot-problem-oq-03-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T05:38:48Z",
       "overallGrade": "B+",
       "qualityScore": 7.4,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "borsuk-ulam": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T06:43:08Z",
       "overallGrade": "B-",
       "qualityScore": 7.0,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 3
     },
     "cantor-diagonalization-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T07:32:47Z",
       "overallGrade": "B+",
       "qualityScore": 8.3,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "erdos-273": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T08:33:48Z",
       "overallGrade": "B-",
       "qualityScore": 6.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 6,
+      "resolvedItems": 6
     },
     "bezout-identity-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T09:32:56Z",
       "overallGrade": "B+",
       "qualityScore": 8.1,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 3,
+      "resolvedItems": 3
     },
     "cayley-hamilton-minpoly-oq-05": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T10:32:33Z",
       "overallGrade": "B-",
       "qualityScore": 6.9,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "denumerability-rationals-oq-03": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T11:42:52Z",
       "overallGrade": "A-",
       "qualityScore": 8.4,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 5,
+      "resolvedItems": 4
     },
     "abel-ruffini-oq-04-oq-01": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T12:44:41Z",
       "overallGrade": "B+",
       "qualityScore": 7.6,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 9,
+      "resolvedItems": 8
     },
     "de-moivre-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T13:44:16Z",
       "overallGrade": "B+",
       "qualityScore": 7.7,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 4,
+      "resolvedItems": 4
     },
     "dissection-of-cubes-oq-02": {
       "reviewCount": 1,
       "lastReviewed": "2026-03-25T14:44:32Z",
       "overallGrade": "C+",
       "qualityScore": 6.1,
-      "actionItems": 0,
-      "resolvedItems": 0
+      "actionItems": 7,
+      "resolvedItems": 6
     },
     "euler-polyhedral-formula": {
       "reviewCount": 1,


### PR DESCRIPTION
## Fix

Resync `src/data/proofs/review-tracker.json` `actionItems`/`resolvedItems` counts to match the authoritative per-entry `review.json` status fields.

## Evidence

**Before**: All 60 tracker entries drifted from their `review.json` files. Most showed `resolvedItems: 0` despite peer reviewers having marked items `"status": "resolved"` in the per-entry files; some `actionItems` totals were also stale (e.g. `cantor-diagonalization` tracker said `ai=8, resolved=0` but `review.json` has 6 items, all resolved). The prior resync (PR #18899) was **closed unmerged** on 2026-05-13, and reviews have updated since.

**After**: Each entry's `actionItems` = total items in its `review.json`, `resolvedItems` = count of items with `status == "resolved"`. Verified 0 remaining mismatches. Diff touches only the two integer count fields per entry (104 insertions / 104 deletions); no grades, dates, or other fields modified. JSON validated; round-trip is byte-identical except the count values.

---
Automated fix by lean-mechanic agent.