### PR TITLE
research(law-of-cosines-oq-04-oq-01): S2 — angle-bisector length law t²=bc−mn

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
@@ -30,6 +30,12 @@ The abstract cosine `t` of the parent file is replaced by the real inner product
 * `apollonius_median_inner` — the median special case `s = 1/2` (Apollonius'
   theorem): ‖A - midpoint(B,C)‖² = ½‖A - B‖² + ½‖A - C‖² − ¼‖B - C‖².
 
+* `stewart_angle_bisector_inner` / `stewart_angle_bisector_segments` — the
+  internal angle-bisector special case, where `s·‖A - C‖ = (1 - s)·‖A - B‖`
+  encodes the ratio `BD : DC = AB : AC`.  Stewart's identity then collapses to
+  the classical bisector-length law `t² = bc − mn`:
+    ‖A - D‖² = ‖A - B‖·‖A - C‖ − (BD)·(DC).
+
 The geometric content (BD = s·a, DC = (1 - s)·a) is what makes `m + n = a`; here
 that is encoded directly so the algebraic identity holds with no sign hypotheses.
 
@@ -93,6 +99,44 @@ theorem apollonius_median_inner (A B C : V) :
   have e : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
   rw [e] at h
   rw [h]; ring
+
+/-- **Angle-bisector length theorem** (`t² = bc − s(1−s)·a²`).
+
+    When `D = (1 - s) • B + s • C` is the foot of the *internal angle bisector*
+    from `A`, the parameter `s` satisfies the ratio `BD : DC = AB : AC`.  Since
+    `BD = s·‖B - C‖` and `DC = (1 - s)·‖B - C‖`, that ratio is
+    `s : (1 - s) = ‖A - B‖ : ‖A - C‖`, i.e. `s·‖A - C‖ = (1 - s)·‖A - B‖`.
+
+    Under this bisector condition the master cevian identity collapses: the
+    `‖A - B‖²` and `‖A - C‖²` terms combine into the single product
+    `‖A - B‖·‖A - C‖`, giving
+
+      ‖A - D‖² = ‖A - B‖·‖A - C‖ − s(1 - s)·‖B - C‖².
+
+    Proof: rewrite with `stewart_cevian_inner`; the remaining scalar identity
+    `(1 - s)c² + s·b² = b·c` follows from the bisector relation `s·b = (1 - s)·c`
+    via `linear_combination (b - c) · hbis`. -/
+theorem stewart_angle_bisector_inner (A B C : V) (s : ℝ)
+    (hbis : s * ‖A - C‖ = (1 - s) * ‖A - B‖) :
+    ‖A - ((1 - s) • B + s • C)‖ ^ 2 =
+      ‖A - B‖ * ‖A - C‖ - s * (1 - s) * ‖B - C‖ ^ 2 := by
+  rw [stewart_cevian_inner A B C s]
+  linear_combination (‖A - C‖ - ‖A - B‖) * hbis
+
+/-- **Angle-bisector length, classical segment form** `t² = bc − mn`.
+
+    With the two cevian segments written explicitly as `m = BD = s·‖B - C‖` and
+    `n = DC = (1 - s)·‖B - C‖`, the squared angle-bisector length is the product
+    of the two adjacent sides minus the product of the two segments it cuts on
+    the opposite side:
+
+      ‖A - D‖² = ‖A - B‖·‖A - C‖ − (BD)·(DC). -/
+theorem stewart_angle_bisector_segments (A B C : V) (s : ℝ)
+    (hbis : s * ‖A - C‖ = (1 - s) * ‖A - B‖) :
+    ‖A - ((1 - s) • B + s • C)‖ ^ 2 =
+      ‖A - B‖ * ‖A - C‖ - (s * ‖B - C‖) * ((1 - s) * ‖B - C‖) := by
+  rw [stewart_angle_bisector_inner A B C s hbis]
+  ring
 
 /-
 ## Summary

--- a/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
+++ b/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
@@ -45,6 +45,41 @@ space `V` and any dimension. For `A B C : V`, `s : ℝ`, with `D = (1-s)•B + s
 
 ---
 
+## Result (Session 2, 2026-06-15, researcher-7 — ACT follow-up + de-risk)
+
+The S1 file (`LawOfCosinesOQ04OQ01.lean`, merged PR #24274) is committed but
+still **UNREGISTERED** in `Proofs.lean` (build-pending; Docker + Aristotle both
+down again this session — `docker info` times out).
+
+**De-risk**: all 8 Mathlib identifiers the S1 file relies on
+(`norm_add_sq_real`, `norm_sub_sq_real`, `real_inner_smul_left/right`,
+`real_inner_comm`, `norm_smul`, `sq_abs`, `Real.norm_eq_abs`) were grepped
+against the pinned Mathlib tree in the sibling `stokes-dd` worktree
+(`.lake/packages/mathlib/Mathlib`) and **all confirmed present**. High
+confidence the file compiles once a backend returns.
+
+**New theorems** (the documented S1 next-step, division-free):
+
+- `stewart_angle_bisector_inner` — the internal-angle-bisector case. The
+  bisector ratio `BD : DC = AB : AC` is encoded as the single hypothesis
+  `s·‖A - C‖ = (1 - s)·‖A - B‖`. Under it the master identity collapses to the
+  classical **angle-bisector length law**
+
+      ‖A - D‖² = ‖A - B‖·‖A - C‖ − s(1 - s)·‖B - C‖².
+
+  Key algebraic fact: with `b = ‖A-C‖`, `c = ‖A-B‖`, the relation `s·b = (1-s)·c`
+  forces `(1-s)c² + s·b² = b·c`, since
+  `(1-s)c² + s·b² − bc = (b − c)·(s·b − (1-s)·c)`. So the whole proof is
+  `rw [stewart_cevian_inner]; linear_combination (‖A-C‖ - ‖A-B‖) * hbis` — no
+  division, no `field_simp`, no positivity.
+- `stewart_angle_bisector_segments` — same result in the textbook segment form
+  `t² = bc − mn` with `m = BD = s‖B-C‖`, `n = DC = (1-s)‖B-C‖` written out
+  (one `ring` after the previous theorem).
+
+Numerically re-verified: 200k random trials, dims 1–4, max error ~8.5e-14.
+
+---
+
 ## Insights
 
 - The whole theorem is a single bilinear identity; the only "geometry" is the
@@ -62,8 +97,15 @@ space `V` and any dimension. For `A B C : V`, `s : ℝ`, with `D = (1-s)•B + s
 
 - `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ01` and register the
   file in `proofs/Proofs.lean` once a backend is available (Docker + Aristotle
-  were both down at authoring time).
-- Optional follow-up: angle-bisector length formula via `m:n = c:b`.
+  were both down at authoring time AND at S2 2026-06-15). All Mathlib names
+  confirmed present in the pinned tree (S2 de-risk), so the build should be a
+  formality.
+- DONE (S2): angle-bisector length formula via `m:n = c:b`
+  (`stewart_angle_bisector_inner`, `stewart_angle_bisector_segments`).
+- Optional follow-up: the *external* angle bisector (ratio `BD:DC = c:b` with the
+  foot outside segment BC, i.e. `s` outside `[0,1]`); the same master identity
+  applies with `s·‖A-C‖ = −(1-s)·‖A-B‖`, giving `t² = s(1-s)a² − bc` (note the
+  sign flip / the foot lies beyond an endpoint).
 
 ## Dead ends
 

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-01.json
@@ -44,18 +44,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: authored 4 theorems (master cevian identity + classical Stewart + Apollonius median + bilinear helper) over a real inner product space; numerically verified; build-pending under dual backend blackout.",
+    "progressSummary": "PROGRESS (S2): added angle-bisector length law (t²=bc−mn, division-free) extending S1 Stewart file; de-risked S1 by confirming all 8 Mathlib names in pinned tree. File merged PR #24274 but still UNREGISTERED/build-pending (Docker+Aristotle down).",
     "builtItems": [
       "stewart_cevian_inner in Proofs/LawOfCosinesOQ04OQ01.lean (coordinate-free Stewart / cevian length).",
       "stewarts_theorem_inner (classical b²m+c²n=a(d²+mn) from real points).",
       "apollonius_median_inner (s=1/2 median / Apollonius).",
-      "norm_smul_add_smul_sq (reusable bilinear norm-of-linear-combination lemma)."
+      "norm_smul_add_smul_sq (reusable bilinear norm-of-linear-combination lemma).",
+      "stewart_angle_bisector_inner in Proofs/LawOfCosinesOQ04OQ01.lean — internal angle-bisector length law t²=bc−s(1−s)a² (division-free).",
+      "stewart_angle_bisector_segments — classical segment form t²=bc−mn with m=BD, n=DC."
     ],
     "insights": [
       "A - ((1-s)•B + s•C) = (1-s)•(A-B) + s•(A-C) since (1-s)+s = 1; proved by the `module` tactic.",
       "The master identity is a single bilinear identity: expand via norm_add_sq_real, real_inner_smul_left/right, then ring after real_inner_comm to align ⟪A-B,A-C⟫.",
       "Classical Stewart needs no positivity hypotheses: with a=‖B-C‖, m=s*a, n=(1-s)*a the side relation m+n=a holds by construction and the ‖B-C‖² term cancels exactly.",
-      "Numerical check (200k random trials, dims 1-4): both master and classical identities hold to ~1e-13."
+      "Numerical check (200k random trials, dims 1-4): both master and classical identities hold to ~1e-13.",
+      "Internal angle bisector encoded as s·‖A-C‖=(1-s)·‖A-B‖ (ratio BD:DC=AB:AC); under it (1-s)c²+s·b²=bc since (1-s)c²+s·b²−bc=(b−c)(sb−(1-s)c), so linear_combination (‖A-C‖-‖A-B‖)*hbis closes it — no division/field_simp.",
+      "De-risk under blackout: all 8 Mathlib names in the S1 file confirmed present in pinned Mathlib (sibling stokes-dd .lake checkout); file high-confidence buildable but still UNREGISTERED."
     ],
     "mathlibGaps": [
       "None — Mathlib v4.26.0 has norm_add_sq_real, norm_sub_sq_real, real_inner_smul_left/right, real_inner_comm, and the `module` tactic, all that is needed."


### PR DESCRIPTION
## Summary
Session 2 ACT follow-up on `law-of-cosines-oq-04-oq-01` (Stewart's theorem via inner products). Extends the S1 file (merged in #24274, but still **unregistered/build-pending** under the Docker+Aristotle blackout) with the angle-bisector length law, and de-risks the S1 file for a future build.

## Progress
- **`stewart_angle_bisector_inner`** — internal angle bisector. The bisector ratio `BD:DC = AB:AC` is encoded as the single hypothesis `s·‖A-C‖ = (1-s)·‖A-B‖`. Under it the master cevian identity collapses to the classical bisector-length law:
  `‖A - D‖² = ‖A-B‖·‖A-C‖ − s(1-s)·‖B-C‖²`.
- **`stewart_angle_bisector_segments`** — the textbook form `t² = bc − mn` with `m = BD`, `n = DC` written out explicitly.
- Proof is **division-free** (no `field_simp`, no positivity): the bisector relation `s·b = (1-s)·c` forces `(1-s)c² + s·b² = bc` via the factorization `(1-s)c² + s·b² − bc = (b−c)(s·b−(1-s)c)`, so the whole proof is `rw [stewart_cevian_inner]; linear_combination (‖A-C‖-‖A-B‖)*hbis`.

## Findings
- **De-risk**: all 8 Mathlib identifiers used by the S1 file (`norm_add_sq_real`, `norm_sub_sq_real`, `real_inner_smul_left/right`, `real_inner_comm`, `norm_smul`, `sq_abs`, `Real.norm_eq_abs`) confirmed present in the pinned Mathlib tree (grep against sibling `stokes-dd` `.lake` checkout). High confidence the file compiles once a backend returns.
- New identity numerically verified: 200k random trials, dims 1–4, max error ~8.5e-14.

## Status
**Outcome**: progress (build-pending — Docker + Aristotle both down this session; file `LawOfCosinesOQ04OQ01.lean` still unregistered in `Proofs.lean`).
**Next Steps**: register + `docker-build.sh Proofs.LawOfCosinesOQ04OQ01` once a backend is available; optional external-bisector follow-up (sign-flipped `t² = s(1-s)a² − bc`).

🤖 Generated by researcher-7