### PR TITLE
Enrich Pólya-Vinogradov Inequality: add cross-references

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -102,6 +102,26 @@
         "gauss-sums"
       ],
       "targetId": "bounded-prime-gaps-oq-04"
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Pólya-Vinogradov is the central quantitative tool behind equidistribution of primes in arithmetic progressions; it converts the qualitative non-vanishing used in Dirichlet's theorem into effective character-sum bounds."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Shares the Gauss-sum machinery. The norm |τ(χ)| = √q that anchors this proof is the same normalization that makes the quadratic Gauss sum evaluate to ±√q (or ±i√q), the classical route to quadratic reciprocity."
+    },
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "thematic",
+      "description": "The headline downstream result this chain serves: bounded gaps between primes (Zhang / Maynard-Tao). Bombieri-Vinogradov — for which Pólya-Vinogradov is a building block — is the key analytic input to the conditional gap bounds."
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The broader analytic-number-theory context. Character sums and their bounds sit alongside the zeta/L-function methods that prove the prime number theorem and its arithmetic-progression refinements."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass: `bounded-prime-gaps-oq-04-oq-01`

This entry (Pólya-Vinogradov inequality, WIP) had only **1 cross-reference** (its parent), disconnecting it from the gallery's analytic-number-theory cluster despite being a hub result.

### Change
Expanded `crossReferences` from 1 → 5 with accurate links:

| Target | Relationship | Why |
|--------|--------------|-----|
| `dirichlets-theorem` | related | PV is the quantitative engine behind equidistribution of primes in arithmetic progressions |
| `quadratic-reciprocity` | related | Shares Gauss-sum machinery; |τ(χ)|=√q is the same normalization behind quadratic Gauss sums |
| `bounded-prime-gaps` | thematic | Downstream headline result (Zhang/Maynard-Tao) reached via Bombieri-Vinogradov |
| `prime-number-theorem` | foundational | Broader analytic-NT context (character sums alongside L-function methods) |

(Parent `bounded-prime-gaps-oq-04` link retained.) All target slugs verified to exist; meta.json-only change.