### PR TITLE
Enrich Repunit Divisibility (Order-of-10): add cross-references

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
@@ -115,6 +115,21 @@
       "targetId": "divisibility-by-three-oq-02",
       "relationship": "extends",
       "description": "DivisibilityByThreeOQ02.lean proved repunit_dvd_iff_pow_mod (d∣R(k)↔d∣10^k-1) and listed concrete examples. This file completes the open question with the full orderOf characterization."
+    },
+    {
+      "targetId": "divisibility-by-three-oq-01",
+      "relationship": "sibling",
+      "description": "Companion in the same divisibility-by-three series, treating last-k-digit rules, powers of 2 and 5, and digital roots. Both study how base-10 structure governs divisibility via modular arithmetic on powers of 10."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "foundational",
+      "description": "Euler's theorem (the generalization of Fermat's little theorem) gives orderOf(10 : ZMod d) ∣ φ(d) whenever gcd(d,10)=1, so the repunit period ord_d(10) is bounded by the totient — the structural reason the order-based characterization terminates."
+    },
+    {
+      "targetId": "wilsons-theorem",
+      "relationship": "thematic",
+      "description": "A companion elementary result about the multiplicative structure of ZMod d; both exploit the cyclic/group-order behavior of units modulo d that underlies this repunit-period characterization."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass: `divisibility-by-three-oq-02-oq-01`

This verified entry (complete order-of-10 characterization of repunit divisibility) had only **1 cross-reference** (its parent).

### Change
Expanded `crossReferences` from 1 → 4 with accurate links:

| Target | Relationship | Why |
|--------|--------------|-----|
| `divisibility-by-three-oq-01` | sibling | Same divisibility series (digit rules, powers of 2/5, digital roots) |
| `euler-totient` | foundational | Euler's theorem gives ord_d(10) ∣ φ(d), bounding the repunit period |
| `wilsons-theorem` | thematic | Companion ZMod multiplicative-structure result |

All target slugs verified to exist; meta.json-only change.