### PR TITLE
research(circumference-via-differentiation-oq-01-oq-02): ORIENT — L^p ball volume + coarea answer

### DIFF
--- a/proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean
+++ b/proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean
@@ -1,0 +1,148 @@
+/-
+  OQ-01-OQ-02: L^p unit ball volume and the surface-derivative identity
+  (circumference-via-differentiation-oq-01-oq-02)
+
+  Open question (extension of the parent gallery entry
+  `circumference-via-differentiation-oq-01`, "n-Dimensional Surface Area via
+  Differentiation of Volume"):
+
+    The unit ball in L^p has volume
+        V_n(p) = 2^n · Γ(1/p + 1)^n / Γ(n/p + 1)               (Dirichlet)
+    Does the "volume-derivative-equals-surface" identity dV/dr = surface area
+    still hold for the L^p surface area when p ≠ 2?
+
+  ── ANSWER (this session, ORIENT) ─────────────────────────────────────────────
+
+  It depends on *which* surface measure is meant.
+
+  1. VOLUME + SCALING (fully tractable in Mathlib v4.26).
+     Mathlib already proves the closed form **and** the radial scaling in one
+     lemma: `MeasureTheory.volume_sum_rpow_le` gives, for `1 ≤ p` and the closed
+     L^p ball of radius `r` in `ι → ℝ` (`card ι = n`),
+
+       volume {x | (∑ i, |x i|^p)^(1/p) ≤ r}
+         = ofReal r ^ n * ofReal ((2 * Γ(1/p + 1))^n / Γ(n/p + 1)).
+
+     At `r = 1` this is exactly the Dirichlet `V_n(p)` above, and the `r^n`
+     factor is the scaling `Vol{‖x‖_p ≤ r} = V_n(p) · r^n`.  Hence
+       dV/dr = n · V_n(p) · r^(n-1)                                          (★)
+     by the power rule — proved below as `lpBallVolumeFn_hasDerivAt`, mirroring
+     the parent's Euclidean `nBallVolumeFn_hasDerivAt`.
+
+  2. WHICH "SURFACE AREA" DOES (★) EQUAL?  By the coarea formula for the radial
+     function `ρ(x) = ‖x‖_p`,
+
+       dV/dr = ∫_{‖x‖_p = r} 1 / |∇ρ(x)|  dℋ^{n-1}(x),                   (coarea)
+
+     where `|∇ρ|` is the *Euclidean* gradient norm of the L^p norm.  On the unit
+     sphere `∑ |x_i|^p = 1` one computes `∂ρ/∂x_i = sgn(x_i) |x_i|^{p-1}`, so
+
+       |∇ρ|^2 = ∑ |x_i|^{2p-2},
+
+     which is identically `1` on the sphere **iff p = 2** (then `2p-2 = p = 2`
+     and `∑|x_i|^2 = 1`).  Therefore:
+
+       • p = 2 : the coarea weight is `1`, so (★) equals the genuine Euclidean
+                 Hausdorff `(n-1)`-surface measure of the sphere.  This is the
+                 parent theorem.
+       • p ≠ 2 : the weight `1/|∇ρ|` varies over the sphere, so (★) is a
+                 `|∇ρ|^{-1}`-WEIGHTED surface integral, **not** the Euclidean
+                 Hausdorff surface measure of `{‖x‖_p = r}`.
+
+     Concrete witness (n = 2, p = 1, the L^1 "diamond"):
+       V_2(1) = 2,  dV/dr|_{r=1} = 4,  but the Euclidean perimeter is `4·√2`.
+       The coarea-weighted surface is `(4√2)/√2 = 4 = dV/dr`. ✔
+
+     So the naive identity `dV/dr = Euclidean surface area` is **FALSE for every
+     finite p ≠ 2** (it holds for p = 2, and degenerately a.e. for p = ∞, where
+     `|∇‖·‖_∞| = 1` on the open faces of the cube).
+
+  All three numeric claims are checked independently (stdlib, ALL PASS) in
+  `research/problems/circumference-via-differentiation-oq-01-oq-02/verify_lp_ball.py`.
+
+  ── Lean scope of this file ───────────────────────────────────────────────────
+
+  • `lpUnitBallVolume`, `lpBallVolumeFn` are defined to match the closed form in
+    `MeasureTheory.volume_sum_rpow_le` *verbatim*, so a future (Docker-enabled)
+    session can discharge a `volume = lpBallVolumeFn` bridge by `rw` on that
+    lemma plus `ENNReal.toReal` bookkeeping.
+  • `lpBallVolumeFn_hasDerivAt` / `deriv_lpBallVolume` prove (★) — the power-rule
+    derivative of the closed form — mirroring the verified parent OQ-01.
+  • The SURFACE side is **blocked in Mathlib v4.26**: there is no coarea formula
+    (no `Coarea` file; only `MeasureTheory/Measure/Hausdorff.lean`), so the
+    weighted identity (coarea) cannot yet be stated faithfully in Lean.  The
+    false Euclidean identity is recorded only as documentation, not as a theorem.
+
+  Status: 0 axioms; the derivative theorem is the proven content.  Build-pending
+  (authored under a Docker/Aristotle verification blackout) and intentionally
+  UNREGISTERED in `Proofs/Proofs.lean` until it compiles in a live session.
+-/
+
+import Mathlib.Analysis.Calculus.Deriv.Pow
+import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
+import Mathlib.Tactic
+
+open Real MeasureTheory
+
+noncomputable section
+
+namespace CircumferenceViaDifferentiationOQ01OQ02
+
+-- ============================================================
+-- L^p unit ball volume (matches `MeasureTheory.volume_sum_rpow_le`)
+-- ============================================================
+
+/-- The Lebesgue volume of the L^p unit ball in `ℝ^n` (Dirichlet closed form):
+    `V_n(p) = (2 · Γ(1/p + 1))^n / Γ(n/p + 1)`.
+
+    Written to match the constant in `MeasureTheory.volume_sum_rpow_le`
+    (which states `volume {x | (∑ |x i|^p)^(1/p) ≤ r} =
+    ofReal r ^ n * ofReal ((2 * Γ(1/p + 1))^n / Γ(n/p + 1))`). -/
+def lpUnitBallVolume (n : ℕ) (p : ℝ) : ℝ :=
+  (2 * Gamma (1 / p + 1)) ^ n / Gamma ((n : ℝ) / p + 1)
+
+/-- The L^p ball volume as a function of radius: `V(r) = V_n(p) · r^n`,
+    matching the `r^n` scaling factor of `MeasureTheory.volume_sum_rpow_le`. -/
+def lpBallVolumeFn (n : ℕ) (p : ℝ) (r : ℝ) : ℝ := lpUnitBallVolume n p * r ^ n
+
+/-- The L^p "surface constant" appearing in the derivative: `n · V_n(p)`. -/
+def lpSurfaceConst (n : ℕ) (p : ℝ) : ℝ := (n : ℝ) * lpUnitBallVolume n p
+
+/-- The L^p surface-derivative function `n · V_n(p) · r^(n-1)`. -/
+def lpSurfaceFn (n : ℕ) (p : ℝ) (r : ℝ) : ℝ := lpSurfaceConst n p * r ^ (n - 1)
+
+-- ============================================================
+-- (★) The derivative identity dV/dr = n · V_n(p) · r^(n-1)
+--      (power rule on the closed form; mirrors verified parent OQ-01)
+-- ============================================================
+
+/-- **Main theorem (★).** The L^p ball-volume function has derivative
+    `n · V_n(p) · r^(n-1)` at every radius `r`.  This is `d/dr (V_n(p)·r^n)`,
+    the same power-rule computation as the parent's Euclidean
+    `nBallVolumeFn_hasDerivAt`; only the leading constant differs. -/
+theorem lpBallVolumeFn_hasDerivAt (n : ℕ) (p : ℝ) (r : ℝ) :
+    HasDerivAt (lpBallVolumeFn n p) (lpSurfaceFn n p r) r := by
+  unfold lpBallVolumeFn lpSurfaceFn lpSurfaceConst
+  have h := (hasDerivAt_pow n r).const_mul (lpUnitBallVolume n p)
+  have heq : lpUnitBallVolume n p * (↑n * r ^ (n - 1)) =
+             ↑n * lpUnitBallVolume n p * r ^ (n - 1) := by ring
+  rwa [heq] at h
+
+/-- The L^p ball-volume function is differentiable everywhere. -/
+theorem lpBallVolumeFn_differentiable (n : ℕ) (p : ℝ) :
+    Differentiable ℝ (lpBallVolumeFn n p) :=
+  fun r => (lpBallVolumeFn_hasDerivAt n p r).differentiableAt
+
+/-- The `deriv` of the L^p ball volume equals the surface-derivative function. -/
+theorem deriv_lpBallVolume (n : ℕ) (p : ℝ) (r : ℝ) :
+    deriv (lpBallVolumeFn n p) r = lpSurfaceFn n p r :=
+  (lpBallVolumeFn_hasDerivAt n p r).deriv
+
+/-- At the unit radius the derivative is exactly the surface constant `n·V_n(p)`. -/
+theorem lpSurfaceFn_one (n : ℕ) (p : ℝ) :
+    lpSurfaceFn n p 1 = lpSurfaceConst n p := by
+  unfold lpSurfaceFn
+  rw [one_pow, mul_one]
+
+end CircumferenceViaDifferentiationOQ01OQ02

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/knowledge.md
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/knowledge.md
@@ -1,0 +1,141 @@
+# Knowledge Base: circumference-via-differentiation-oq-01-oq-02
+
+Extension of the gallery proof `circumference-via-differentiation-oq-01`
+("n-Dimensional Surface Area via Differentiation of Volume") to the **L^p**
+unit ball.
+
+---
+
+## Problem Understanding
+
+The unit ball `B_p^n = {x ∈ ℝ^n : Σ |x_i|^p ≤ 1}` has volume
+(Dirichlet/Liouville; the seeker stub attributes it to Pisier 1989)
+
+        V_n(p) = 2^n · Γ(1/p + 1)^n / Γ(n/p + 1).
+
+The open question: does the parent's identity **dV/dr = surface area** still hold
+for the L^p surface area when `p ≠ 2`? The stub flags the difficulty as "the L^p
+surface is not the radial derivative for p ≠ 2 because the surface is not a level
+set of the radius function in the Euclidean sense."
+
+**Refinement of the premise.** The dilated ball `r·B_p = {‖x‖_p ≤ r}` *is* a
+level set of the L^p norm `ρ(x) = ‖x‖_p`. The real subtlety is not "level set or
+not" but the **coarea weight** `1/|∇ρ|`: `|∇ρ| ≡ 1` only for the Euclidean norm.
+
+---
+
+## Insights
+
+### Session 2026-06-15 (ORIENT, researcher-9) — sharp answer + Mathlib already has the volume
+
+**Mode**: FRESH (EMPTY → ORIENT). **Outcome**: complete mathematical answer with
+an all-pass independent numerical verifier, plus the discovery that Mathlib v4.26
+already proves the volume formula, which makes the volume/derivative half a thin
+ACT.
+
+#### The answer (it depends on which surface measure)
+
+1. **Volume + radial scaling — fully tractable.** For `1 ≤ p`,
+   `Vol{‖x‖_p ≤ r} = V_n(p) · r^n`, hence by the power rule
+
+        dV/dr = n · V_n(p) · r^(n-1).                                       (★)
+
+2. **Which "surface area" does (★) equal?** By the coarea formula for `ρ = ‖·‖_p`,
+
+        dV/dr = ∫_{‖x‖_p = r} 1/|∇ρ(x)| dℋ^{n-1}(x),                    (coarea)
+
+   with `|∇ρ|` the **Euclidean** gradient norm. On the unit sphere
+   `∂ρ/∂x_i = sgn(x_i)·|x_i|^{p-1}`, so
+
+        |∇ρ|^2 = Σ |x_i|^{2p-2},
+
+   which is identically `1` on `Σ|x_i|^p = 1` **iff p = 2** (then `2p-2 = p = 2`).
+   Therefore:
+   - **p = 2**: weight `= 1`, so (★) **equals** the Euclidean Hausdorff `(n-1)`-
+     surface measure of the sphere — this is exactly the parent theorem.
+   - **p ≠ 2** (finite): the weight `1/|∇ρ|` varies, so (★) is a
+     `|∇ρ|^{-1}`-**weighted** surface integral, **NOT** the Euclidean Hausdorff
+     surface measure of `{‖x‖_p = r}`.
+   - **p = ∞** (cube): `|∇‖·‖_∞| = 1` ℋ^{n-1}-a.e. on the open faces, so the
+     identity holds again (degenerately).
+
+   **Conclusion: the naive "dV/dr = Euclidean surface area" identity is FALSE for
+   every finite p ≠ 2, and TRUE for p = 2 (and a.e. for p = ∞).** The always-true
+   statement is the coarea-weighted one.
+
+   **Anchor witness** (n=2, p=1, the L^1 diamond): `V_2(1) = 2`, `dV/dr = 4`, but
+   the Euclidean perimeter is `4√2 ≈ 5.657`. The coarea-weighted surface is
+   `(4√2)/√2 = 4 = dV/dr`. ✔
+
+#### Durable verification
+
+`verify_lp_ball.py` (Python stdlib, exact Γ via `math.gamma`, deterministic
+Simpson in n=2 + Monte-Carlo cross-checks in n=2,3,4) — **ALL PASS**:
+- (A) Lebesgue volume vs the Dirichlet closed form (n=2 Simpson; n=3,4 MC).
+- (B) radial scaling `dV/dr = n·V_n(p)·r^(n-1)`.
+- (C) for `p ∈ {1, 1.5, 2, 3, 4}` in n=2: coarea-weighted surface `== dV/dr` for
+  ALL p, while Euclidean perimeter `== dV/dr` ONLY for p = 2 (the symmetry-
+  reduced quadrature integrates only the smooth half `x ∈ [0,(½)^{1/p}]` and ×8
+  to avoid the vertical-tangent endpoint).
+
+#### Mathlib bearers (confirmed against v4.26.0, pin `2df2f0150c27`)
+
+- **The volume formula is ALREADY in Mathlib**:
+  `MeasureTheory.volume_sum_rpow_le` (and `..._lt`) in
+  `Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean`:
+
+        volume {x : ι → ℝ | (∑ i, |x i|^p)^(1/p) ≤ r}
+          = ofReal r ^ card ι
+            * ofReal ((2 * Γ(1/p + 1))^card ι / Γ(card ι/p + 1))     (1 ≤ p)
+
+  At `r = 1`, `card ι = n`, this is **verbatim** the Dirichlet `V_n(p)`, and the
+  `ofReal r ^ card ι` factor is the `r^n` scaling. Companion lemmas:
+  `MeasureTheory.measure_unitBall_eq_integral_div_gamma`,
+  `volume_sum_rpow_lt_one`, and the Euclidean specializations
+  `EuclideanSpace.volume_ball/volume_closedBall`.
+- **Derivative**: the same power-rule API the parent OQ-01 uses —
+  `hasDerivAt_pow`, `HasDerivAt.const_mul`, `HasDerivAt.deriv`. (Done below.)
+- **Coarea / surface measure is a GENUINE GAP**: Mathlib v4.26 has
+  `MeasureTheory/Measure/Hausdorff.lean` (Hausdorff measure) but **no coarea
+  formula** (no `Coarea` file; tree grep at the tag returns nothing). So the
+  always-true weighted identity (coarea) — and any faithful statement of the
+  surface side — cannot yet be expressed in Lean.
+
+#### Lean artifact (build-pending, UNREGISTERED)
+
+`proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean`:
+- `lpUnitBallVolume n p := (2·Γ(1/p+1))^n / Γ(n/p+1)` and
+  `lpBallVolumeFn n p r := lpUnitBallVolume n p · r^n` — defined to match
+  `volume_sum_rpow_le` verbatim so a future live session can `rw` that lemma to
+  prove `volume = lpBallVolumeFn` with only `ENNReal.toReal` bookkeeping.
+- `lpBallVolumeFn_hasDerivAt` / `deriv_lpBallVolume` — proof of (★), mirroring the
+  verified parent `nBallVolumeFn_hasDerivAt` (only the constant differs).
+- The surface side is documented, not stated as a theorem (coarea gap above). The
+  false Euclidean identity is recorded only as prose.
+
+Build-pending under a Docker + Aristotle blackout this session; intentionally not
+added to `Proofs/Proofs.lean` until it compiles live.
+
+---
+
+## Next steps
+
+1. **ACT (live, ~30 min once Docker returns).** Build the file; add a bridge
+   theorem `volume {x | (∑|x i|^p)^(1/p) ≤ r} = ENNReal.ofReal (lpBallVolumeFn n p r)`
+   by `rw [volume_sum_rpow_le]` + `ENNReal.ofReal` arithmetic, then register it.
+2. **Surface side is BLOCKED on Mathlib infrastructure.** A faithful Lean
+   treatment needs a coarea formula (or at least the `|∇ρ|^{-1}`-weighted surface
+   integral); neither is in Mathlib v4.26. Either wait for upstream or scope a
+   narrow n=2 perimeter computation as a separate sub-question.
+3. (Optional) state the `p = 2` recovery as a corollary once a surface-measure
+   API exists, tying back to the parent.
+
+## Dead Ends / Non-starters
+
+- Trying to prove `dV/dr = Euclidean surface area` for general p: **false**
+  (n=2, p=1 already breaks it, 4 ≠ 4√2). The correct invariant is the coarea-
+  weighted surface.
+- Re-deriving the volume formula from scratch: unnecessary —
+  `MeasureTheory.volume_sum_rpow_le` already has it.
+- A faithful Lean statement of the surface side this session: blocked (no coarea
+  formula in Mathlib v4.26).

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/literature/README.md
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for circumference-via-differentiation-oq-01-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/problem.md
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/problem.md
@@ -1,0 +1,124 @@
+# Problem: Generalizing to $L^p$ unit balls: The unit ball in $L^p$ has volume $\frac{2^n \Gamma(1/p+1)^n}{\Gam
+
+**Slug**: circumference-via-differentiation-oq-01-oq-02
+**Created**: 2026-06-15
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+**Generalizing to \$L^p\$ unit balls**: The unit ball in \$L^p\$ has volume \$\frac{2^n \Gamma(1/p+1)^n}{\Gamma(n/p+1)}\$ (Pisier 1989). Does the same volume-derivative-equals-surface identity hold for the \$L^p\$ surface area? The difficulty: the \$L^p\$ surface area is not the radial derivative for \$p \ne 2\$ because the surface is not a level set of the radius function in the Euclidean sense.
+$$
+
+### Plain Language
+
+This open question arises from the gallery proof `circumference-via-differentiation-oq-01` (n-Dimensional Surface Area via Differentiation of Volume). The Seeker selected it as a extension suitable for the autonomous research pipeline.
+
+The specific question: **Generalizing to $L^p$ unit balls**: The unit ball in $L^p$ has volume $\frac{2^n \Gamma(1/p+1)^n}{\Gamma(n/p+1)}$ (Pisier 1989). Does the same volume-derivative-equals-surface identity hold for the $L^p$ surface area? The difficulty: the $L^p$ surface area is not the radial derivative for $p \ne 2$ because the surface is not a level set of the radius function in the Euclidean sense.
+
+### Why This Matters
+
+Significance score 5/10 — the problem extends a verified gallery proof in a concrete direction. Closing it would add a extension-style follow-up to the gallery corpus and exercise machinery from the parent entry.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent proof `circumference-via-differentiation-oq-01` — provides the base theorem and its Mathlib infrastructure
+- Sibling open questions on the same gallery entry — see `src/data/proofs/circumference-via-differentiation/meta.json` `conclusion.openQuestions`
+
+### What's Still Open
+
+- The question stated above, as a extension of the parent result
+- Quantitative / constructive refinements that the Researcher may identify during OBSERVE
+
+### Our Goal
+
+Formulate the question as a Lean 4 theorem aligned with the parent entry's namespace, identify the Mathlib lemmas that close the gap, and either prove it or carve out a precise sub-claim that is tractable.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| circumference-via-differentiation | Gallery root containing the open question | Parent definitions, Mathlib infrastructure used by the proof |
+| circumference-via-differentiation-oq-01 | Immediate source of this open question | Source proof techniques carried over |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Mathlib search**: Survey Mathlib for definitions and lemmas matching the question's keywords; many gallery open questions reduce to wiring an existing Mathlib API.
+   - Why it might work: Mathlib has broad coverage of classical results adjacent to the gallery proofs
+   - Risk: The question may require a definition Mathlib lacks (e.g. a specialized object), in which case the work shifts to defining it
+
+2. **Sibling reuse**: Lift the parent proof's strategy and adapt it to the new statement.
+   - Why it might work: The original proof author already structured the gallery entry to make this kind of extension feasible
+   - Risk: The sibling lemmas may not generalize cleanly; bookkeeping can dominate
+
+### Key Difficulties
+
+- Need to identify the precise Lean 4 statement; the natural-language description leaves room for interpretation
+- Mathlib coverage may be partial — the OBSERVE phase must check which pieces exist
+
+### What Would a Proof Need?
+
+- Key lemma 1: a Lean 4 formal statement of the open question above
+- Key lemma 2: connecting Mathlib infrastructure to the parent entry's definitions
+- Technical requirements: see the parent proof file for relevant `import Mathlib.*` statements
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Seeker-assigned tractability score 5/10 reflects a likely-tractable direct extension
+- Parent entry is verified, so the surrounding Lean infrastructure is in place
+- Mathlib coverage of adjacent material is non-trivial; survey by the Scout in ORIENT is advisable
+
+**Estimated Effort**:
+- Exploration: 4-8 hours during OBSERVE/ORIENT
+- If tractable: 1-3 days for a clean theorem statement plus proof
+- If hard: weeks; consider carving a narrower sub-question
+
+## References
+
+### Papers
+- See the parent gallery entry's `references` array for citations to the originating literature
+
+### Online Resources
+- https://github.com/rjwalters/lean-genius — the gallery repository hosting the parent proof
+- Mathlib4 docs at https://leanprover-community.github.io/mathlib4_docs/ — for searching Mathlib namespaces relevant to the keywords below
+
+### Mathlib
+- Relevant Mathlib modules will surface during ORIENT; start from the parent proof's existing imports
+
+## Metadata
+
+```yaml
+tags:
+  - calculus
+  - differentiation
+  - gallery-extracted
+  - gamma-function
+  - geometry
+  - n-dimensional
+  - seeker-selected
+  - surface-area
+  - verified
+related_proofs:
+  - circumference-via-differentiation-oq-01
+  - circumference-via-differentiation
+difficulty: medium
+source: gallery-gap
+created: 2026-06-15
+significance: 5
+tractability: 5
+tier: B
+category: extension
+```
+
+**Significance**: 5/10
+**Tractability**: 5/10

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/state.md
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/state.md
@@ -1,0 +1,44 @@
+# Research State: circumference-via-differentiation-oq-01-oq-02
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 2
+**Last Updated**: 2026-06-15 (researcher-9)
+
+## Current Focus
+L^p unit ball volume / surface-derivative identity. ANSWERED: the volume formula
+`V_n(p) = 2^n Γ(1/p+1)^n / Γ(n/p+1)` and the scaling `Vol{‖x‖_p≤r}=V_n(p)·r^n`
+give `dV/dr = n·V_n(p)·r^(n-1)`. This equals the Euclidean Hausdorff surface
+measure ONLY for p=2 (and a.e. for p=∞); for finite p≠2 it equals the
+coarea-weighted surface `∫ 1/|∇‖·‖_p| dℋ^{n-1}`, NOT the Euclidean perimeter.
+
+## Active Approach
+Build-free ORIENT (Docker + Aristotle both down). Independent numeric verifier
+`verify_lp_ball.py` (ALL PASS). Discovered Mathlib already proves the volume
+(`MeasureTheory.volume_sum_rpow_le`); authored a build-pending UNREGISTERED Lean
+file with the derivative half proven and the Mathlib-aligned defs.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- Lean ACT is Docker-gated (no build this session); file left UNREGISTERED.
+- **Surface side blocked on Mathlib**: v4.26 has no coarea formula (only
+  `Hausdorff.lean`), so the always-true weighted surface identity cannot yet be
+  stated faithfully in Lean.
+
+## Next Action
+When Docker returns: build `CircumferenceViaDifferentiationOQ01OQ02.lean`, add a
+`volume = ENNReal.ofReal (lpBallVolumeFn n p r)` bridge via `rw
+[volume_sum_rpow_le]`, register in `Proofs/Proofs.lean`. The surface-equality
+half stays blocked pending an upstream coarea formula.
+
+## Iteration log
+* **S1** (2026-06-15, OBSERVE): stub created.
+* **S2** (2026-06-15, researcher-9, ORIENT): sharp answer (coarea distinction) +
+  all-pass verifier; found Mathlib's `volume_sum_rpow_le`; build-pending Lean
+  file with the derivative theorem proven.

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/verify_lp_ball.py
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/verify_lp_ball.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Durable exact-ish verifier for circumference-via-differentiation-oq-01-oq-02.
+
+Open question (gallery extension of "n-Dimensional Surface Area via
+Differentiation of Volume"):
+
+    The unit ball in L^p has volume  V_n(p) = 2^n Gamma(1+1/p)^n / Gamma(1+n/p)
+    (classical Dirichlet/Liouville; the problem attributes it to Pisier 1989).
+    Does the "volume-derivative-equals-surface" identity  dV/dr = surface area
+    still hold for the L^p surface area when p != 2 ?
+
+This script answers the question by independent numerical checks (Python stdlib
+only, deterministic Simpson quadrature in n=2 plus Monte-Carlo cross-checks in
+n=2,3,4):
+
+  (A) VOLUME FORMULA.  Lebesgue volume of B_p^n = {x : sum |x_i|^p <= 1}
+      matches the Dirichlet closed form V_n(p) = 2^n G(1+1/p)^n / G(1+n/p).
+
+  (B) RADIAL SCALING.  Vol{ ||x||_p <= r } = V_n(p) * r^n, hence
+      dV/dr = n * V_n(p) * r^{n-1}.  (Finite-difference check.)
+
+  (C) THE ANSWER.  By the coarea formula for rho(x) = ||x||_p,
+          dV/dr = integral over {||x||_p=r} of 1/|grad rho| dH^{n-1}        (coarea-weighted)
+      where |grad rho| is the *Euclidean* gradient norm of the L^p norm.
+      On the unit sphere |grad rho|^2 = sum |x_i|^{2p-2}, which is identically 1
+      iff p = 2.  Therefore:
+        * for p = 2  the weight is 1 and  dV/dr = Euclidean Hausdorff surface area;
+        * for p != 2 the weight varies and  dV/dr  is a |grad rho|^{-1}-WEIGHTED
+          surface area, NOT the Euclidean (Hausdorff) surface area.
+      We confirm in n=2 that
+          weighted_surface(p)  == dV/dr          for ALL tested p   (coarea holds)
+          euclidean_perimeter  == dV/dr          ONLY for p = 2
+      e.g. n=2, p=1 (the L^1 "diamond"): dV/dr = 4 but Euclidean perimeter = 4*sqrt(2).
+
+All numbers are checked against independent computations; the script prints
+PASS/FAIL for each assertion and exits non-zero on any failure.
+"""
+
+import math
+
+# ----------------------------------------------------------------------------- helpers
+
+def lp_volume_closed_form(n, p):
+    """Dirichlet closed form for vol of the L^p unit ball in R^n."""
+    if math.isinf(p):
+        return 2.0 ** n  # cube [-1,1]^n
+    return (2.0 ** n) * math.gamma(1.0 + 1.0 / p) ** n / math.gamma(1.0 + n / p)
+
+
+def simpson(f, a, b, m):
+    """Composite Simpson on [a,b] with m subintervals (m even)."""
+    if m % 2:
+        m += 1
+    h = (b - a) / m
+    s = f(a) + f(b)
+    for i in range(1, m):
+        s += (4 if i % 2 else 2) * f(a + i * h)
+    return s * h / 3.0
+
+
+# Deterministic high-accuracy integrand for n=2: quarter-area = \int_0^1 (1-x^p)^{1/p} dx
+def quarter_area_n2(p, m=200000):
+    # (1-x^p)^{1/p} has an integrable singularity in its derivative at x=1; Simpson
+    # on a fine uniform grid converges well for p in [1, ~6].
+    f = lambda x: (max(0.0, 1.0 - x ** p)) ** (1.0 / p)
+    return simpson(f, 0.0, 1.0, m)
+
+
+# ----------------------------------------------------------------------------- (A) volume
+
+def monte_carlo_volume(n, p, samples, rng):
+    inside = 0
+    for _ in range(samples):
+        s = 0.0
+        for _i in range(n):
+            x = rng.uniform(-1.0, 1.0)
+            s += abs(x) ** p
+            if s > 1.0:
+                break
+        else:
+            if s <= 1.0:
+                inside += 1
+    return (2.0 ** n) * inside / samples
+
+
+# ----------------------------------------------------------------------------- (C) surfaces (n=2)
+
+def surfaces_n2(p, m=20000):
+    """Return (euclidean_perimeter, coarea_weighted_surface) of the L^p unit
+    circle in R^2.
+
+    Quarter boundary: y(x) = (1 - x^p)^{1/p}, x in [0,1].
+      ds          = sqrt(1 + y'(x)^2) dx
+      |grad rho|  = sqrt( |x|^{2(p-1)} + |y|^{2(p-1)} )   (on the unit sphere)
+      weighted    = integral of ds / |grad rho|
+
+    The quarter has a vertical tangent at x=1 (y'-> -inf), which kills uniform
+    quadrature.  But the curve is symmetric under x<->y about the diagonal, and
+    BOTH integrands (ds and ds/|grad rho|) are invariant under that swap.  So the
+    quarter integral = 2 * (integral over the SMOOTH half x in [0, x0]), where
+    x0 = (1/2)^{1/p} is the diagonal point x=y.  On [0,x0] the slope runs from 0
+    (horizontal tangent at x=0) to -1 (at x0), so Simpson converges fast.
+    Full boundary = 4 quarters = 8 * (smooth-half integral).
+    """
+    def yprime(x):
+        # y = (1-x^p)^{1/p}; y' = -x^{p-1} (1-x^p)^{1/p - 1}
+        if x <= 0.0:
+            return 0.0
+        base = 1.0 - x ** p
+        if base <= 0.0:
+            return 0.0
+        return -(x ** (p - 1.0)) * (base ** (1.0 / p - 1.0))
+
+    def y_of(x):
+        return (max(0.0, 1.0 - x ** p)) ** (1.0 / p)
+
+    def ds(x):
+        yp = yprime(x)
+        return math.sqrt(1.0 + yp * yp)
+
+    def grad_norm(x):
+        y = y_of(x)
+        return math.sqrt(x ** (2.0 * (p - 1.0)) + y ** (2.0 * (p - 1.0)))
+
+    x0 = (0.5) ** (1.0 / p)
+    half_perim = simpson(ds, 0.0, x0, m)
+    half_weighted = simpson(lambda x: ds(x) / grad_norm(x), 0.0, x0, m)
+    perimeter = 8.0 * half_perim
+    weighted = 8.0 * half_weighted
+    return perimeter, weighted
+
+
+# ----------------------------------------------------------------------------- driver
+
+def approx(a, b, rel=1e-3, absolute=1e-6):
+    return abs(a - b) <= max(absolute, rel * max(abs(a), abs(b)))
+
+
+def main():
+    import random
+    rng = random.Random(20260615)
+    all_pass = True
+
+    print("=" * 72)
+    print("(A) L^p ball volume  vs  Dirichlet closed form  V_n(p)=2^n G(1+1/p)^n/G(1+n/p)")
+    print("=" * 72)
+    # n=2 deterministic (Simpson) -- high accuracy
+    for p in [1.0, 1.5, 2.0, 3.0, 4.0]:
+        cf = lp_volume_closed_form(2, p)
+        det = 4.0 * quarter_area_n2(p)
+        ok = approx(cf, det, rel=2e-3)
+        all_pass &= ok
+        print(f"  n=2 p={p:<4}  closed={cf:.6f}  Simpson(4*quarter)={det:.6f}  {'PASS' if ok else 'FAIL'}")
+    # n=3,4 Monte-Carlo cross-check
+    for (n, p, samp, tol) in [(3, 2.0, 400000, 2e-2), (3, 1.0, 400000, 2e-2),
+                              (3, 4.0, 400000, 2e-2), (4, 2.0, 600000, 3e-2),
+                              (4, 1.0, 600000, 3e-2)]:
+        cf = lp_volume_closed_form(n, p)
+        mc = monte_carlo_volume(n, p, samp, rng)
+        ok = approx(cf, mc, rel=tol)
+        all_pass &= ok
+        print(f"  n={n} p={p:<4}  closed={cf:.6f}  MonteCarlo={mc:.6f}  {'PASS' if ok else 'FAIL'}")
+
+    print()
+    print("=" * 72)
+    print("(B) radial scaling:  d/dr Vol{||x||_p<=r} = n*V_n(p)*r^{n-1}   (finite diff)")
+    print("=" * 72)
+    for (n, p) in [(2, 1.0), (2, 2.0), (2, 3.0), (3, 2.0)]:
+        Vn = lp_volume_closed_form(n, p)
+        r, h = 1.0, 1e-4
+        # Vol{||x||<=r} = Vn * r^n  (pure scaling); finite-diff the closed scaling
+        vol = lambda rr: Vn * rr ** n
+        fd = (vol(r + h) - vol(r - h)) / (2 * h)
+        analytic = n * Vn * r ** (n - 1)
+        ok = approx(fd, analytic, rel=1e-4)
+        all_pass &= ok
+        print(f"  n={n} p={p:<4}  dV/dr(fd)={fd:.6f}  n*Vn*r^(n-1)={analytic:.6f}  {'PASS' if ok else 'FAIL'}")
+
+    print()
+    print("=" * 72)
+    print("(C) THE ANSWER (n=2):  coarea-weighted surface == dV/dr for ALL p;")
+    print("    Euclidean perimeter == dV/dr ONLY for p=2.")
+    print("=" * 72)
+    for p in [1.0, 1.5, 2.0, 3.0, 4.0]:
+        Vn = lp_volume_closed_form(2, p)
+        dVdr = 2.0 * Vn  # n*Vn*r^{n-1} at n=2, r=1
+        perim, weighted = surfaces_n2(p)
+        coarea_ok = approx(weighted, dVdr, rel=3e-3)
+        eucl_eq = approx(perim, dVdr, rel=3e-3)
+        # expectation: eucl_eq is True iff p == 2
+        expect_eucl = (abs(p - 2.0) < 1e-9)
+        verdict = (coarea_ok and (eucl_eq == expect_eucl))
+        all_pass &= verdict
+        print(f"  p={p:<4} dV/dr={dVdr:.5f}  weighted={weighted:.5f} (coarea {'OK' if coarea_ok else 'BAD'})"
+              f"  perim={perim:.5f} (eucl==dVdr: {eucl_eq}, expected {expect_eucl})"
+              f"  {'PASS' if verdict else 'FAIL'}")
+
+    # explicit headline anchor: L^1 diamond
+    Vn1 = lp_volume_closed_form(2, 1.0)
+    print()
+    print(f"  ANCHOR L^1 diamond: area={Vn1:.4f} (=2), dV/dr={2*Vn1:.4f} (=4), "
+          f"Euclidean perimeter=4*sqrt(2)={4*math.sqrt(2):.4f}  ->  4 != 5.657")
+
+    print()
+    print("=" * 72)
+    print("OVERALL:", "ALL PASS" if all_pass else "SOME FAILED")
+    print("=" * 72)
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/circumference-via-differentiation-oq-01-oq-02.json
+++ b/src/data/research/problems/circumference-via-differentiation-oq-01-oq-02.json
@@ -1,0 +1,127 @@
+{
+  "slug": "circumference-via-differentiation-oq-01-oq-02",
+  "title": "Generalizing to $L^p$ unit balls: The unit ball in $L^p$ has volume $\\frac{2^n \\Gamma(1/p+1)^n}{\\Gam",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "**Generalizing to \\$L^p\\$ unit balls**: The unit ball in \\$L^p\\$ has volume \\$\\frac{2^n \\Gamma(1/p+1)^n}{\\Gamma(n/p+1)}\\$ (Pisier 1989). Does the same volume-derivative-equals-surface identity hold for the \\$L^p\\$ surface area? The difficulty: the \\$L^p\\$ surface area is not the radial derivative for \\$p \\ne 2\\$ because the surface is not a level set of the radius function in the Euclidean sense.",
+    "plain": "This open question arises from the gallery proof `circumference-via-differentiation-oq-01` (n-Dimensional Surface Area via Differentiation of Volume). The Seeker selected it as a extension suitable for the autonomous research pipeline.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-15T00:57:02-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: L^p ball volume = 2^n Gamma(1/p+1)^n/Gamma(n/p+1) (already in Mathlib as MeasureTheory.volume_sum_rpow_le, with r^n scaling). dV/dr = n*V_n(p)*r^(n-1) equals the EUCLIDEAN surface measure ONLY for p=2 (and a.e. p=inf); for finite p!=2 it equals the coarea-weighted surface int 1/|grad ||.||_p| dH^{n-1}, NOT the Euclidean perimeter (n=2,p=1: dV/dr=4 vs perimeter 4*sqrt2). All claims independently verified (verify_lp_ball.py, ALL PASS). Surface side blocked: Mathlib v4.26 has no coarea formula.",
+    "builtItems": [
+      "research/problems/circumference-via-differentiation-oq-01-oq-02/verify_lp_ball.py - independent stdlib verifier (volume, scaling, coarea vs Euclidean surface), ALL PASS",
+      "proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean (build-pending, UNREGISTERED): defs lpUnitBallVolume/lpBallVolumeFn aligned verbatim to volume_sum_rpow_le; theorems lpBallVolumeFn_hasDerivAt/deriv_lpBallVolume prove dV/dr=n*V_n(p)*r^(n-1) (mirrors verified parent)."
+    ],
+    "insights": [
+      "L^p unit ball volume V_n(p)=2^n*Gamma(1/p+1)^n/Gamma(n/p+1) (Dirichlet); Mathlib v4.26 proves it as MeasureTheory.volume_sum_rpow_le (and ..._lt), including the r^n radial scaling factor.",
+      "By coarea for rho=||.||_p: dV/dr = int_{||x||_p=r} 1/|grad rho| dH^{n-1}. On the unit sphere |grad rho|^2 = sum |x_i|^{2p-2}, identically 1 iff p=2.",
+      "So dV/dr = Euclidean Hausdorff surface measure holds iff p=2 (true), p=inf (a.e. true); FALSE for every finite p!=2. The always-true statement is the |grad rho|^{-1}-weighted surface integral.",
+      "Anchor n=2,p=1 (L^1 diamond): V=2, dV/dr=4, but Euclidean perimeter=4*sqrt2; weighted surface=(4sqrt2)/sqrt2=4=dV/dr.",
+      "The parent OQ-01 defines 'surface area' AS the derivative formula n*omega_n*r^(n-1), not independently as Hausdorff measure - so the p=2 case is consistent by construction."
+    ],
+    "mathlibGaps": [
+      "No coarea formula in Mathlib v4.26 (only MeasureTheory/Measure/Hausdorff.lean) - blocks any faithful Lean statement of the L^p surface side.",
+      "No packaged surface-measure-as-volume-derivative link beyond what the gallery proof itself defines."
+    ],
+    "nextSteps": [
+      "ACT (live, ~30 min once Docker returns): build CircumferenceViaDifferentiationOQ01OQ02.lean, add bridge volume{...<=r}=ENNReal.ofReal(lpBallVolumeFn n p r) via rw [volume_sum_rpow_le], register in Proofs/Proofs.lean.",
+      "Surface-equality half BLOCKED pending an upstream Mathlib coarea formula; alternatively scope a narrow n=2 L^p perimeter computation as a separate sub-question.",
+      "Optional: state p=2 recovery as a corollary once a surface-measure API exists."
+    ],
+    "markdown": "# Knowledge Base: circumference-via-differentiation-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "calculus",
+    "differentiation",
+    "gallery-extracted",
+    "gamma-function",
+    "geometry",
+    "n-dimensional",
+    "seeker-selected",
+    "surface-area",
+    "verified"
+  ],
+  "relatedProofs": [
+    "circumference-via-differentiation",
+    "circumference-via-differentiation-oq-01",
+    "circumference-via-differentiation-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T00:57:02-07:00",
+  "significance": 5,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/CircumferenceViaDifferentiation.lean",
+      "filename": "CircumferenceViaDifferentiation.lean",
+      "lineCount": 200,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiation.lean"
+    },
+    {
+      "path": "Proofs/CircumferenceViaDifferentiationOQ01.lean",
+      "filename": "CircumferenceViaDifferentiationOQ01.lean",
+      "lineCount": 241,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiationOQ01.lean"
+    },
+    {
+      "path": "Proofs/CircumferenceViaDifferentiationOQ03.lean",
+      "filename": "CircumferenceViaDifferentiationOQ03.lean",
+      "lineCount": 195,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean"
+    },
+    {
+      "path": "Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean",
+      "filename": "CircumferenceViaDifferentiationOQ01OQ02.lean",
+      "lineCount": 148,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean",
+      "buildPending": true,
+      "registered": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
ORIENT session on the gallery extension **L^p unit ball volume / surface-derivative identity** (open question of `circumference-via-differentiation-oq-01`).

**The answer.** The unit L^p ball has volume `V_n(p) = 2^n Γ(1/p+1)^n / Γ(n/p+1)` (Dirichlet), and `Vol{‖x‖_p ≤ r} = V_n(p)·r^n`, so `dV/dr = n·V_n(p)·r^(n-1)`. By the coarea formula for `ρ = ‖·‖_p`, this equals `∫_{‖x‖_p=r} 1/|∇ρ| dH^{n-1}`. Since `|∇ρ|² = Σ|x_i|^{2p-2}` is identically `1` on the unit sphere **iff p = 2**:

- **p = 2**: `dV/dr` = the Euclidean Hausdorff surface measure (the parent theorem).
- **p ≠ 2** (finite): `dV/dr` = a `|∇ρ|^{-1}`-**weighted** surface integral, **NOT** the Euclidean perimeter. So the naive identity is **false**.
- Anchor (n=2, p=1, L¹ diamond): `V=2`, `dV/dr=4`, but Euclidean perimeter `= 4√2`; weighted surface `= 4√2/√2 = 4 = dV/dr`. ✔

## Findings
- **Mathlib already proves the volume**: `MeasureTheory.volume_sum_rpow_le` (in `Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean`) gives exactly `(2Γ(1/p+1))^n/Γ(n/p+1)` with the `r^n` scaling — the volume/derivative half is a thin ACT.
- **Mathlib gap**: no coarea formula in v4.26 (only `Hausdorff.lean`), so the always-true weighted surface identity cannot yet be stated faithfully in Lean. The surface-equality half is blocked on upstream infrastructure.

## Files
- `research/.../verify_lp_ball.py` — independent stdlib verifier (volume vs Dirichlet form via Simpson/Monte-Carlo; radial scaling; coarea vs Euclidean surface). **ALL PASS.**
- `proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean` — **build-pending, UNREGISTERED**. Defs aligned verbatim to `volume_sum_rpow_le`; the derivative theorem `dV/dr = n·V_n(p)·r^(n-1)` is proven (mirrors verified parent OQ-01). Authored under a Docker + Aristotle blackout.
- knowledge.md / state.md / problem JSON updated (phase → ORIENT).

## Status
**Outcome**: ORIENT (sharp answer + durable verification; volume-half Lean ACT scoped, surface-half blocked on Mathlib coarea).
**Next**: build + register the Lean file and wire the `volume = ofReal(lpBallVolumeFn)` bridge when Docker returns; surface side waits on an upstream coarea formula.

🤖 Generated by researcher-9