### PR TITLE
research(law-of-cosines-oq-04-oq-01): angle-bisector length formula + name-verify Stewart file

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
@@ -30,6 +30,10 @@ The abstract cosine `t` of the parent file is replaced by the real inner product
 * `apollonius_median_inner` — the median special case `s = 1/2` (Apollonius'
   theorem): ‖A - midpoint(B,C)‖² = ½‖A - B‖² + ½‖A - C‖² − ¼‖B - C‖².
 
+* `angle_bisector_length_inner` — the internal-bisector length formula
+    (b + c)²‖A - D‖² = bc((b + c)² − a²)
+  for the cevian foot dividing `BC` in the ratio `BD:DC = c:b`.
+
 The geometric content (BD = s·a, DC = (1 - s)·a) is what makes `m + n = a`; here
 that is encoded directly so the algebraic identity holds with no sign hypotheses.
 
@@ -93,6 +97,29 @@ theorem apollonius_median_inner (A B C : V) :
   have e : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
   rw [e] at h
   rw [h]; ring
+
+/-- **Angle-bisector length formula** (a further specialization of Stewart).
+
+    If the cevian foot `D = (1 - s) • B + s • C` divides `BC` in the ratio
+    `BD : DC = AB : AC`, i.e. `s · (‖A-C‖ + ‖A-B‖) = ‖A-B‖` (equivalently
+    `s / (1-s) = ‖A-B‖ / ‖A-C‖`), then the squared cevian length satisfies
+
+      (b + c)² · ‖A - D‖² = b·c·((b + c)² − a²),    with a = ‖B-C‖, b = ‖A-C‖, c = ‖A-B‖,
+
+    i.e. `‖A-D‖² = bc(1 − a²/(b+c)²)`, the classical internal-bisector length.
+
+    The hypothesis `hs` encodes only the segment ratio `BD:DC = c:b`; that this
+    ratio is the one realized by the actual *angle* bisector (equal angles at `A`)
+    is a separate geometric fact, not used or proved here.  Stated in cleared
+    `(b+c)²`-multiplied form to avoid division. -/
+theorem angle_bisector_length_inner (A B C : V) (s : ℝ)
+    (hs : s * (‖A - C‖ + ‖A - B‖) = ‖A - B‖) :
+    (‖A - C‖ + ‖A - B‖) ^ 2 * ‖A - ((1 - s) • B + s • C)‖ ^ 2 =
+      ‖A - B‖ * ‖A - C‖ * ((‖A - C‖ + ‖A - B‖) ^ 2 - ‖B - C‖ ^ 2) := by
+  rw [stewart_cevian_inner A B C s]
+  linear_combination
+    ((‖A - C‖ + ‖A - B‖) ^ 2 * (‖A - C‖ - ‖A - B‖) +
+        ‖B - C‖ ^ 2 * (s * (‖A - C‖ + ‖A - B‖) - ‖A - C‖)) * hs
 
 /-
 ## Summary

--- a/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
+++ b/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
@@ -4,6 +4,29 @@
 **Phase**: ACT
 **Status**: active (build-pending under dual backend blackout)
 
+## Session 2 (2026-06-15, researcher-2)
+
+- **De-risked the build-pending file** under dual blackout (Docker `docker info`
+  times out >20s; Aristotle `prove` returns 404 on `n+0=n`). Verified all five
+  Mathlib identifiers against a live mathlib4 checkout (sibling worktree
+  `stokes-dd/.lake/.../InnerProductSpace/Basic.lean`):
+  - `norm_add_sq_real` (:397) `‖x+y‖² = ‖x‖² + 2⟪x,y⟫ + ‖y‖²`
+  - `norm_sub_sq_real` (:423) `‖x-y‖² = ‖x‖² − 2⟪x,y⟫ + ‖y‖²`
+  - `real_inner_smul_left` (:107), `real_inner_smul_right` (:117), `real_inner_comm`.
+  Hand-traced the `norm_smul_add_smul_sq` rewrite chain and the
+  `stewart_cevian_inner` expansion (X=‖A-B‖², Y=‖A-C‖², Z=⟪A-B,A-C⟫): both close
+  under `ring`. File is HIGH-confidence buildable; left UNREGISTERED (name-check
+  ≠ typecheck, and registering an unbuilt file risks the aggregate).
+- **Added `angle_bisector_length_inner`** (5th theorem): internal-bisector length
+  `(b+c)²‖A-D‖² = bc((b+c)²−a²)` for the cevian dividing `BC` in ratio
+  `BD:DC = c:b`, hypothesis `hs : s·(b+c) = c`. Stated in cleared
+  `(b+c)²`-multiplied form (no division → no `field_simp` under blackout). Proof:
+  `rw [stewart_cevian_inner]; linear_combination K * hs` with
+  `K = (b+c)²(b−c) + a²(s(b+c)−b)`. Coefficient **sympy-verified**:
+  `expand(LHS−RHS − (s(b+c)−c)·K) = 0`. Honesty note: `hs` only encodes the
+  segment ratio; that this ratio is the actual angle bisector is a separate fact
+  not proved here.
+
 ---
 
 ## Problem Understanding

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-01.json
@@ -19,6 +19,7 @@
       "`stewart_cevian_inner` — coordinate-free Stewart: ‖A-D‖² = (1-s)‖A-B‖² + s‖A-C‖² − s(1-s)‖B-C‖² for D = (1-s)•B + s•C in any real inner product space (build-pending under backend blackout).",
       "`stewarts_theorem_inner` — classical form b²m + c²n = a(d²+mn) recovered with a=‖B-C‖, m=s*a, n=(1-s)*a.",
       "`apollonius_median_inner` — median special case s=1/2 (Apollonius' theorem).",
+      "`angle_bisector_length_inner` — internal-bisector length (b+c)²‖A-D‖² = bc((b+c)²−a²) for the cevian dividing BC in ratio BD:DC = c:b (hypothesis s·(b+c)=c); sympy-verified linear_combination coefficient.",
       "`norm_smul_add_smul_sq` — reusable bilinear lemma ‖p•u + q•v‖² = p²‖u‖² + q²‖v‖² + 2pq⟪u,v⟫."
     ],
     "open": [
@@ -30,7 +31,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-15T00:00:00Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Authored coordinate-free Stewart identity over a real inner product space plus classical and median corollaries; numerically verified to 1e-13; build-pending under blackout.",
     "blockers": [
       "Docker build wrapper hangs (cannot lake-build to verify).",
@@ -89,13 +90,13 @@
     ]
   },
   "started": "2026-06-15T00:00:00Z",
-  "lastUpdate": "2026-06-15T00:00:00Z",
+  "lastUpdate": "2026-06-15T11:40:00Z",
   "leanFiles": [
     {
       "path": "Proofs/LawOfCosinesOQ04OQ01.lean",
       "filename": "LawOfCosinesOQ04OQ01.lean",
-      "lineCount": 110,
-      "theoremCount": 4,
+      "lineCount": 137,
+      "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Session 2 ACT on `law-of-cosines-oq-04-oq-01` (Stewart's theorem via inner products). The file `LawOfCosinesOQ04OQ01.lean` was authored in S1 (PR #24274, merged) but left **build-pending and unregistered** under a dual backend blackout. This session de-risks it and adds one specialization.

- **New theorem `angle_bisector_length_inner`** — the internal-bisector length formula
  `(b+c)²‖A−D‖² = bc((b+c)² − a²)` for the cevian foot dividing `BC` in ratio `BD:DC = c:b` (hypothesis `s·(b+c)=c`, with `a=‖B−C‖`, `b=‖A−C‖`, `c=‖A−B‖`). Proved as a build-safe specialization of the existing `stewart_cevian_inner` via `linear_combination K · hs`, `K = (b+c)²(b−c) + a²(s(b+c)−b)`. The coefficient is **sympy-verified**: `expand(LHS − RHS − (s(b+c)−c)·K) = 0`. Stated in cleared `(b+c)²`-multiplied form to avoid division/`field_simp` under no-build.
  - Honesty note: `hs` encodes only the *segment ratio*; that this ratio is the actual angle bisector (equal angles at `A`) is a separate geometric fact, not claimed here.

- **De-risking under blackout** (Docker `docker info` times out >20s; Aristotle `prove` returns 404 on `n+0=n`): verified all five Mathlib identifiers used by the file (`norm_add_sq_real` :397, `norm_sub_sq_real` :423, `real_inner_smul_left` :107, `real_inner_smul_right` :117, `real_inner_comm`) against a live mathlib4 checkout, and hand-traced the `norm_smul_add_smul_sq` rewrite chain and the `stewart_cevian_inner` expansion — both close under `ring`. File is high-confidence buildable.

File stays **UNREGISTERED** in `Proofs.lean` (name-check ≠ typecheck; registering an unbuilt file risks the aggregate). 0 axioms, 0 sorries, 5 theorems.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ01` once a backend is available
- [ ] Register in `proofs/Proofs.lean` after a green build