### PR TITLE
Enrich Conway-Guy Distinct Subset Sums (Erdős #1 OQ-03): add cross-references

### DIFF
--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -121,6 +121,21 @@
       "targetId": "erdos-1",
       "relationship": "extends",
       "description": "Extends the Erdos #1 formalization with the Conway-Guy construction and optimality"
+    },
+    {
+      "targetId": "erdos-1-oq-02",
+      "relationship": "complementary",
+      "description": "The same Erdős #1 problem from the lower-bound side: the Dubroff–Fox–Xu framework for bounding f(n) from below. This entry gives the Conway-Guy upper bound f(n) ≤ a_n; together they bracket the true value of f(n)."
+    },
+    {
+      "targetId": "erdos-340-greedy-sidon",
+      "relationship": "thematic",
+      "description": "Another greedy additive-combinatorics construction: a Sidon sequence built by greedily choosing each term just large enough to avoid collisions — the same paradigm Conway-Guy uses for distinct subset sums."
+    },
+    {
+      "targetId": "erdos-28-additive-bases",
+      "relationship": "thematic",
+      "description": "A companion additive-combinatorics Erdős problem (Erdős-Turán on additive bases). Both concern how the additive/representation structure of an integer set constrains its size and growth."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass: `erdos-1-oq-03`

This verified entry (Conway-Guy construction for distinct subset sums) had only **1 cross-reference** (its parent).

### Change
Expanded `crossReferences` from 1 → 4 with accurate links:

| Target | Relationship | Why |
|--------|--------------|-----|
| `erdos-1-oq-02` | complementary | Dubroff–Fox–Xu lower-bound side of f(n); this entry is the Conway-Guy upper bound — together they bracket f(n) |
| `erdos-340-greedy-sidon` | thematic | Same greedy additive-construction paradigm (Sidon sequences) |
| `erdos-28-additive-bases` | thematic | Companion additive-combinatorics Erdős problem (Erdős-Turán) |

All target slugs verified to exist; meta.json-only change.