### PR TITLE
research(waring-g2-oq-01): S28 ACT — exact-value capstone g(k)=2^k+⌊(3/2)^k⌋−2 [build-pending]

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresWaringG2OQ01ExactValue.lean
+++ b/proofs/Proofs/LagrangeFourSquaresWaringG2OQ01ExactValue.lean
@@ -1,0 +1,158 @@
+import Mathlib
+import Proofs.LagrangeFourSquaresWaringG2OQ01General
+
+/-!
+# Waring g(k) Exact Value — Capstone Characterization (S28 ACT)
+
+Slug `lagrange-four-squares-waring-g2-oq-01` asks, for each `k ≥ 3`, to
+determine `g(k)` — the smallest `s` such that **every** `n : ℕ` is a sum of
+`s` perfect `k`-th powers. Every committed Lean artifact so far proves only
+the **lower** half (`g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2`): the per-`k` `Counting*`
+files (k=3..7) and the parametric `…General.lean` (`waring_lower_general`,
+all `k ≥ 1`). No file states the matching **upper** bound, hence no file
+states the exact value `g(k) = 2^k + ⌊(3/2)^k⌋ − 2`. This file closes that
+gap on the *statement* side and assembles the exact-value characterization.
+
+## What is proved vs assumed
+
+The exact value is `g(k) = 2^k + ⌊(3/2)^k⌋ − 2` whenever the **Dickson–Pillai
+condition** holds:
+
+> `(*)   3^k mod 2^k + ⌊(3/2)^k⌋ ≤ 2^k`     (equivalently `r + q ≤ 2^k`)
+
+which is verified to hold for all `k = 1..200` (see
+`research/problems/.../verify_ideal_condition.py`, S26) and is known for all
+but finitely many `k` (Mahler 1957), with no counterexample below
+`k ≈ 4.7·10^8` (Kubina–Wunderlich 1990).
+
+| Ingredient | Status here |
+|---|---|
+| Lower bound `g(k) ≥ formula` (witness `n_k` not a sum of `formula−1` powers) | **proved** — reuses `General.waring_lower_general` |
+| Upper bound `g(k) ≤ formula` under `(*)` (every `n` is a sum of `formula` powers) | **axiom** `ideal_waring_upper` — the deep Dickson–Pillai–Niven (1936–44) theorem, a genuine Mathlib gap |
+| `(*)` for a concrete `k` | **proved** by `decide` (decidable ℕ arithmetic) |
+| Exact value `g(k) = formula` for concrete `k = 3..7` | **proved** modulo the one axiom |
+| `g(2) = 4` upper half (k=2 anchor) | **proved unconditionally** from Mathlib's `Nat.sum_four_squares` — no axiom |
+
+The `k = 2` anchor (`upper_bound_two`) discharges the upper half *without* the
+axiom, demonstrating that `ideal_waring_upper` is a true theorem in the one
+case Mathlib can currently check (Lagrange's four-square theorem).
+
+## ⚠️ BUILD STATUS — NOT build-verified (Docker blackout, S28)
+
+Written 2026-06-15 (researcher-10) while the host Docker daemon was
+unresponsive (`docker info` timed out), so `docker-build.sh` could not run.
+The file imports the (also build-pending, unregistered) `…General.lean`; the
+two form one unit. Deliberately **NOT registered** in `proofs/Proofs.lean`
+so it cannot break the whole-library build. A follow-up session with Docker
+up should build `Proofs.LagrangeFourSquaresWaringG2OQ01ExactValue`, fix any
+v4.26.0 lemma-name drift, then register both files.
+
+* Axioms: **1** (`ideal_waring_upper`) — `axiomatized` status per the project
+  axiom-integrity policy (the upper bound is a deep classical theorem, not in
+  Mathlib). All other declarations are `theorem`/`def`, 0 sorries.
+
+## Bearer lemmas (Mathlib v4.26.0)
+
+`Nat.sum_four_squares`, `Fin.sum_univ_four` (both used in built sibling files),
+and the imported `WaringG2OQ01.General.{IsSumOfKthPowers, waring_lower_general}`.
+-/
+
+namespace WaringG2OQ01.ExactValue
+
+open WaringG2OQ01.General
+
+/-- `IsUniversalBound s k`: every `n : ℕ` is a sum of `s` perfect `k`-th powers.
+`g(k)` is the least `s` for which this holds. -/
+def IsUniversalBound (s k : ℕ) : Prop :=
+  ∀ n : ℕ, IsSumOfKthPowers s k n
+
+/-- **Lower half (proved).** The bound `2^k + ⌊(3/2)^k⌋ − 3 = g(k) − 1` is
+*not* universal: the witness `n_k = ⌊(3/2)^k⌋·2^k − 1` is not a sum of that
+many `k`-th powers (`General.waring_lower_general`). Hence `g(k) ≥ formula`. -/
+theorem g_minus_one_not_universal (k : ℕ) (hk : 1 ≤ k) :
+    ¬ IsUniversalBound (2 ^ k + 3 ^ k / 2 ^ k - 3) k :=
+  fun h => waring_lower_general k hk (h (3 ^ k / 2 ^ k * 2 ^ k - 1))
+
+/-- **Upper half (DEEP AXIOM — Dickson–Pillai–Niven).** When the Dickson–Pillai
+condition `(*) 3^k mod 2^k + ⌊(3/2)^k⌋ ≤ 2^k` holds, every `n : ℕ` is a sum of
+`2^k + ⌊(3/2)^k⌋ − 2` perfect `k`-th powers, i.e. `g(k) ≤ formula`.
+
+This is the *ideal Waring theorem* (Dickson 1936, Pillai 1940, Niven 1944);
+its proof is research-level analytic/combinatorial number theory and is absent
+from Mathlib v4.26.0. The hypothesis `(*)` is itself decidable and verified for
+all `k = 1..200` (S26 `verify_ideal_condition.py`). For `k = 2` this axiom is
+not needed — see `upper_bound_two`. -/
+axiom ideal_waring_upper (k : ℕ) (hk : 1 ≤ k)
+    (hcond : 3 ^ k % 2 ^ k + 3 ^ k / 2 ^ k ≤ 2 ^ k) :
+    IsUniversalBound (2 ^ k + 3 ^ k / 2 ^ k - 2) k
+
+/-- **Exact value characterization.** For every `k ≥ 1` satisfying the
+Dickson–Pillai condition, `formula := 2^k + ⌊(3/2)^k⌋ − 2` summands suffice for
+every `n` (upper, axiom) while `formula − 1` do not (lower, proved). Together
+these pin `g(k) = 2^k + ⌊(3/2)^k⌋ − 2` exactly. -/
+theorem waringG_exact (k : ℕ) (hk : 1 ≤ k)
+    (hcond : 3 ^ k % 2 ^ k + 3 ^ k / 2 ^ k ≤ 2 ^ k) :
+    IsUniversalBound (2 ^ k + 3 ^ k / 2 ^ k - 2) k ∧
+      ¬ IsUniversalBound (2 ^ k + 3 ^ k / 2 ^ k - 3) k :=
+  ⟨ideal_waring_upper k hk hcond, g_minus_one_not_universal k hk⟩
+
+/-- **k = 2 anchor (axiom-free).** The upper half at `k = 2` is exactly
+Lagrange's four-square theorem (`Nat.sum_four_squares`), so `IsUniversalBound 4 2`
+holds *unconditionally* — no appeal to `ideal_waring_upper`. This certifies the
+axiom is a true theorem in the one case Mathlib can check. -/
+theorem upper_bound_two : IsUniversalBound 4 2 := by
+  intro n
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n
+  exact ⟨![a, b, c, d], by rw [Fin.sum_univ_four]; simpa using h⟩
+
+/-- `g(2) = 4` exactly, fully unconditional: upper half from `upper_bound_two`
+(Lagrange), lower half from `g_minus_one_not_universal` (the parent's `7` needs
+four squares, here as the parametric witness `n_2 = 7`). No axiom used. -/
+theorem g2_eq_four :
+    IsUniversalBound 4 2 ∧ ¬ IsUniversalBound 3 2 := by
+  refine ⟨upper_bound_two, ?_⟩
+  have e : (2 : ℕ) ^ 2 + 3 ^ 2 / 2 ^ 2 - 3 = 3 := by decide
+  have h := g_minus_one_not_universal 2 (by norm_num)
+  rwa [e] at h
+
+/-- `g(3) = 9` exactly (modulo `ideal_waring_upper`). -/
+theorem g3_eq_nine :
+    IsUniversalBound 9 3 ∧ ¬ IsUniversalBound 8 3 := by
+  have e1 : (2 : ℕ) ^ 3 + 3 ^ 3 / 2 ^ 3 - 2 = 9 := by decide
+  have e2 : (2 : ℕ) ^ 3 + 3 ^ 3 / 2 ^ 3 - 3 = 8 := by decide
+  have h := waringG_exact 3 (by norm_num) (by decide)
+  rwa [e1, e2] at h
+
+/-- `g(4) = 19` exactly (modulo `ideal_waring_upper`). -/
+theorem g4_eq_nineteen :
+    IsUniversalBound 19 4 ∧ ¬ IsUniversalBound 18 4 := by
+  have e1 : (2 : ℕ) ^ 4 + 3 ^ 4 / 2 ^ 4 - 2 = 19 := by decide
+  have e2 : (2 : ℕ) ^ 4 + 3 ^ 4 / 2 ^ 4 - 3 = 18 := by decide
+  have h := waringG_exact 4 (by norm_num) (by decide)
+  rwa [e1, e2] at h
+
+/-- `g(5) = 37` exactly (modulo `ideal_waring_upper`). -/
+theorem g5_eq_thirtyseven :
+    IsUniversalBound 37 5 ∧ ¬ IsUniversalBound 36 5 := by
+  have e1 : (2 : ℕ) ^ 5 + 3 ^ 5 / 2 ^ 5 - 2 = 37 := by decide
+  have e2 : (2 : ℕ) ^ 5 + 3 ^ 5 / 2 ^ 5 - 3 = 36 := by decide
+  have h := waringG_exact 5 (by norm_num) (by decide)
+  rwa [e1, e2] at h
+
+/-- `g(6) = 73` exactly (modulo `ideal_waring_upper`). -/
+theorem g6_eq_seventythree :
+    IsUniversalBound 73 6 ∧ ¬ IsUniversalBound 72 6 := by
+  have e1 : (2 : ℕ) ^ 6 + 3 ^ 6 / 2 ^ 6 - 2 = 73 := by decide
+  have e2 : (2 : ℕ) ^ 6 + 3 ^ 6 / 2 ^ 6 - 3 = 72 := by decide
+  have h := waringG_exact 6 (by norm_num) (by decide)
+  rwa [e1, e2] at h
+
+/-- `g(7) = 143` exactly (modulo `ideal_waring_upper`). -/
+theorem g7_eq_onefortythree :
+    IsUniversalBound 143 7 ∧ ¬ IsUniversalBound 142 7 := by
+  have e1 : (2 : ℕ) ^ 7 + 3 ^ 7 / 2 ^ 7 - 2 = 143 := by decide
+  have e2 : (2 : ℕ) ^ 7 + 3 ^ 7 / 2 ^ 7 - 3 = 142 := by decide
+  have h := waringG_exact 7 (by norm_num) (by decide)
+  rwa [e1, e2] at h
+
+end WaringG2OQ01.ExactValue

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/knowledge.md
@@ -1,5 +1,54 @@
 # Knowledge — lagrange-four-squares-waring-g2-oq-01
 
+## S28 (researcher-10, 2026-06-15) — ACT: exact-value capstone (upper bound axiomatized + g(2..7) characterized)
+
+**Mode**: FRESH (RICH) · **Outcome**: new build-pending file
+`…OQ01ExactValue.lean` · **Phase**: ORIENT→ACT (statement side of the upper half)
+· Docker DOWN (`docker info` timeout), Aristotle irrelevant (0 sorries).
+
+### Gap closed
+
+Every prior artifact proved only the **lower** half (`g(k) ≥ 2^k+⌊(3/2)^k⌋−2`):
+per-`k` `Counting*` (k=3..7, merged+registered) and parametric `…General.lean`
+(`waring_lower_general`, all k≥1, merged #24228 but UNREGISTERED). **No file
+stated the exact value** — S26 flagged the Lean upper-bound side as absent. This
+session ships the capstone characterization.
+
+### New file `…OQ01ExactValue.lean` (imports `…General`)
+
+- `IsUniversalBound s k := ∀ n, IsSumOfKthPowers s k n` (reuses General's def).
+- `g_minus_one_not_universal (k) (hk:1≤k) : ¬ IsUniversalBound (2^k+3^k/2^k-3) k`
+  — **proved** one-liner `fun h => waring_lower_general k hk (h n_k)` where
+  `n_k = 3^k/2^k*2^k-1`. (formula−1 = 2^k+q−3, exactly General's count.)
+- `axiom ideal_waring_upper (k)(hk:1≤k)(hcond: 3^k%2^k + 3^k/2^k ≤ 2^k) :
+  IsUniversalBound (2^k+3^k/2^k-2) k` — the DEEP Dickson–Pillai–Niven (1936–44)
+  upper bound, Mathlib gap. `hcond` is the decidable Dickson–Pillai condition
+  `r+q ≤ 2^k` (S26 verified k=1..200).
+- `waringG_exact (k)(hk)(hcond)` : `IsUniversalBound formula k ∧ ¬IsUniversalBound (formula−1) k`
+  — pins `g(k) = 2^k+⌊(3/2)^k⌋−2` exactly (axiom + proved lower).
+- **k=2 anchor, AXIOM-FREE**: `upper_bound_two : IsUniversalBound 4 2` proved
+  from Mathlib `Nat.sum_four_squares` via `![a,b,c,d]`+`Fin.sum_univ_four`+`simpa`;
+  `g2_eq_four` is fully unconditional (no axiom). Demonstrates the axiom is a true
+  theorem in the one case Mathlib can check.
+- Concrete `g3_eq_nine … g7_eq_onefortythree` (9,19,37,73,143) via
+  `waringG_exact k (by norm_num) (by decide)` + `rw` of `by decide` numeral
+  equalities. All numerals + conditions Python-verified (r+q≤2^k true k=2..7).
+
+### Honesty / axiom accounting
+
+File has **1 axiom** (`ideal_waring_upper`) ⟹ `axiomatized` status, NOT verified.
+The axiom IS the deep classical upper bound (legitimate per axiom-integrity
+policy: deep result absent from Mathlib). Lower half genuinely proved; condition
+checks genuinely decidable; only the upper IMPLICATION is assumed. Build-pending
++ UNREGISTERED (won't touch library build); register both ExactValue+General when
+Docker returns. PR labeled `research` only.
+
+### Bearers (name-checked vs built siblings, not compiled)
+
+`Nat.sum_four_squares` + `Fin.sum_univ_four` (both in built parent/Erdos files),
+`decide`/`norm_num` on concrete ℕ (incl. Nat division), imported
+`General.{IsSumOfKthPowers, waring_lower_general}` (read from source).
+
 ## S26 (researcher-2, 2026-06-14) — ORIENT-depth: upper-bound condition + review of #24228
 
 **Mode**: FRESH (RICH, score 37) · **Outcome**: durable verification (no Lean

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
@@ -1,8 +1,19 @@
 # Current State
 
-**Phase**: ORIENT (lower bound DONE — parametric all-`k` in open PR #24228, build-pending; upper-bound condition now durably verified; remaining open half = deep Dickson–Pillai–Niven implication, Mathlib gap)
-**Since**: 2026-06-14 (S26 — upper-bound ideal-condition verified k=1..200 + independent review of #24228 Step-6 nlinarith)
-**Iteration**: 26 (S26 — ideal-Waring condition verification ; researcher-2)
+**Phase**: ORIENT→ACT (lower bound DONE — parametric `…General.lean` merged #24228, build-pending+unregistered; S28 ships exact-value capstone `…ExactValue.lean` with upper bound axiomatized as Dickson–Pillai–Niven + g(2..7) characterized; k=2 anchor axiom-free; remaining open half = formalizing the deep upper IMPLICATION, Mathlib gap)
+**Since**: 2026-06-15 (S28 — exact-value capstone: upper bound isolated as 1 axiom, g(k)=2^k+⌊(3/2)^k⌋−2 pinned for k=2..7, build-pending)
+**Iteration**: 28 (S28 — exact-value capstone ACT ; researcher-10)
+
+## S28 ACT 2026-06-15 (researcher-10) — exact-value capstone
+
+Shipped `…OQ01ExactValue.lean` (build-pending, UNREGISTERED, imports `…General`):
+`IsUniversalBound s k := ∀ n, IsSumOfKthPowers s k n`; lower half proved via
+`waring_lower_general`; **1 axiom** `ideal_waring_upper` (Dickson–Pillai–Niven
+upper bound under decidable condition `r+q ≤ 2^k`); `waringG_exact` pins
+`g(k) = 2^k+⌊(3/2)^k⌋−2`; k=2 anchor (`upper_bound_two`/`g2_eq_four`) axiom-free
+via `Nat.sum_four_squares`; concrete `g3..g7 = 9,19,37,73,143`. `axiomatized`
+status (NOT verified). Docker DOWN. See knowledge.md S28 for full detail.
+
 
 ## S26 ORIENT-depth 2026-06-14 (researcher-2) — upper-bound condition + #24228 review
 


### PR DESCRIPTION
## Summary

First Lean artifact to state the **exact value** of `g(k)` for the Waring slug
`lagrange-four-squares-waring-g2-oq-01`. Every prior file proved only the
**lower** half (`g(k) ≥ 2^k+⌊(3/2)^k⌋−2`): per-`k` `Counting*` (k=3..7) and the
parametric `…General.lean` (`waring_lower_general`, merged #24228). S26 flagged
that nothing stated the matching upper bound. This file closes that gap on the
statement side.

New file `proofs/Proofs/LagrangeFourSquaresWaringG2OQ01ExactValue.lean` (imports
`…General`):

- `IsUniversalBound s k := ∀ n, IsSumOfKthPowers s k n` (reuses General's def).
- `g_minus_one_not_universal` — **proved** lower half (one-liner over
  `waring_lower_general`, witness `n_k = ⌊(3/2)^k⌋·2^k−1`).
- `axiom ideal_waring_upper` — the **deep** Dickson–Pillai–Niven (1936–44) upper
  bound, gated on the *decidable* Dickson–Pillai condition `r+q ≤ 2^k` (S26
  verified k=1..200; Mathlib gap, hence axiomatized).
- `waringG_exact` — combines both ⟹ `g(k) = 2^k+⌊(3/2)^k⌋−2` exactly.
- `upper_bound_two` / `g2_eq_four` — **axiom-free** `k=2` anchor proved from
  Mathlib's `Nat.sum_four_squares`, certifying the axiom is true where Mathlib
  can check it.
- `g3_eq_nine … g7_eq_onefortythree` — concrete `9,19,37,73,143` via `decide`.

## Honesty / status

- **1 axiom** (`ideal_waring_upper`) ⟹ `axiomatized`, **NOT** `verified`. The
  axiom is the deep classical upper bound, legitimate per the axiom-integrity
  policy. Lower half genuinely proved; condition checks genuinely decidable;
  only the upper *implication* is assumed.
- **Build-pending**: written under a Docker daemon outage (`docker info`
  timeout) — not compiled. Deliberately **UNREGISTERED** in `proofs/Proofs.lean`
  so it cannot break the whole-library build. All bearer lemmas name-checked
  against built sibling files. Numerals + conditions Python-verified.

## Test plan

- [ ] When Docker returns: `./proofs/scripts/docker-build.sh Proofs.LagrangeFourSquaresWaringG2OQ01ExactValue`
- [ ] Fix any v4.26.0 lemma-name drift (esp. `Fin.sum_univ_four` / `simpa` in `upper_bound_two`)
- [ ] Register both `…General` and `…ExactValue` in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)