### PR TITLE
Enrich Multinomial Distribution and MGF: coverage, honesty, cross-ref

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-multinom-overview",
+    "proofId": "binomial-theorem-oq-02-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Open Question: Formalizing the Multinomial Distribution from the Multinomial Theorem",
+    "content": "The header poses the open question inherited from `binomial-theorem-oq-02`: can the multinomial distribution and its moment-generating function be formalized purely from the multinomial theorem? The file answers YES by exhibiting the PMF, its normalization, and the MGF as three readings of the single Mathlib lemma `Finset.sum_pow_eq_sum_piAntidiag`. The four imports are deliberately minimal — only the multinomial-coefficient and big-operators machinery — underscoring that no measure-theoretic apparatus is needed for the algebraic core.",
+    "mathContext": "The multinomial distribution models $n$ independent trials each landing in one of the categories $i \\in s$ with probability $p_i$ (where $\\sum_{i \\in s} p_i = 1$). The joint law of the category counts $(X_i)_{i \\in s}$ is $P(X = k) = \\binom{n}{k}\\prod_{i \\in s} p_i^{k_i}$ supported on $\\{k : \\sum_i k_i = n\\}$. Its MGF is $M(t) = \\bigl(\\sum_{i\\in s} p_i e^{t_i}\\bigr)^n$. Both are specializations of $(\\sum_i x_i)^n = \\sum_{k} \\binom{n}{k}\\prod_i x_i^{k_i}$, the identity Mathlib packages as `sum_pow_eq_sum_piAntidiag`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "multinomial distribution",
+      "moment-generating function",
+      "Finset.sum_pow_eq_sum_piAntidiag",
+      "open question resolution"
+    ],
+    "prerequisites": [
+      "Multinomial theorem",
+      "Basic probability (joint PMF, MGF)"
+    ]
+  },
+  {
     "id": "ann-multinom-def",
     "proofId": "binomial-theorem-oq-02-oq-01",
     "range": {
@@ -71,6 +94,30 @@
     ]
   },
   {
+    "id": "ann-multinom-uniform",
+    "proofId": "binomial-theorem-oq-02-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 141
+    },
+    "type": "technique",
+    "title": "Specialization to ℝ and the Uniform Distribution",
+    "content": "`multinomial_mgf_real` (lines 126–131) re-expresses the `CommSemiring` MGF identity over $\\mathbb{R}$ so that the coefficient $\\binom{n}{k}\\prod p_i^{k_i}$ is literally `multinomialProb s p n k` — the proof closes with `rfl`, confirming the abstract and probabilistic forms are definitionally equal. `multinomialProb_uniform_sum` (lines 136–141) then instantiates normalization at the uniform law $p_i = 1/k$ over `Fin k`: the hypothesis $\\sum_i p_i = 1$ reduces to $k \\cdot \\tfrac1k = 1$, discharged by `field_simp` after `Finset.card_fin`.",
+    "mathContext": "The uniform multinomial corresponds to rolling a fair $k$-sided die $n$ times: every category has probability $1/k$, so $\\sum_{i \\in \\mathrm{Fin}\\,k} \\tfrac1k = k\\cdot\\tfrac1k = 1$ and normalization follows from `multinomialProb_sum_eq_one`. The positivity hypothesis $0 < k$ is needed so that $1/k$ is well defined and the cardinality cancels. This is the discrete-uniform base case from which entropy and typical-set arguments in information theory are built.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "uniform distribution",
+      "Finset.card_fin",
+      "field_simp",
+      "definitional equality (rfl)"
+    ],
+    "prerequisites": [
+      "multinomialProb_sum_eq_one",
+      "Finset.sum_div",
+      "division in a field"
+    ]
+  },
+  {
     "id": "ann-multinom-binomial",
     "proofId": "binomial-theorem-oq-02-oq-01",
     "range": {
@@ -91,6 +138,29 @@
       "Bool.false_ne_true",
       "Finset.sum_pair",
       "ring normalization"
+    ]
+  },
+  {
+    "id": "ann-multinom-examples",
+    "proofId": "binomial-theorem-oq-02-oq-01",
+    "range": {
+      "startLine": 164,
+      "endLine": 184
+    },
+    "type": "context",
+    "title": "Concrete Sanity Check and a Vacuous Expectation Stub",
+    "content": "`fair_coin_three_flips` (lines 169–175) is a closed numerical instance: three flips of a $1/2$-coin sum to $1$ over the four outcomes $(3,0),(2,1),(1,2),(0,3)$ with probabilities $\\tfrac18,\\tfrac38,\\tfrac38,\\tfrac18$, closed by `norm_num` after expanding the pair sum. Note that `multinomial_expectation` (lines 180–184) is proved by `rfl` — its statement is the tautology $\\sum_k P(k)\\,w(k) = \\sum_k P(k)\\,w(k)$, so despite the docstring's framing as 'the general expectation formula $E[w(X)]$' it asserts nothing and uses no probabilistic content. It is a placeholder marking where a substantive expectation/moment result (e.g. $E[X_i] = n p_i$) would go.",
+    "mathContext": "A genuine mean derivation would differentiate the MGF: $E[X_i] = \\partial_{t_i} M(t)\\big|_{t=0} = n p_i$, and the covariance $\\mathrm{Cov}(X_i,X_j) = -n p_i p_j$ for $i \\neq j$, $\\mathrm{Var}(X_i) = n p_i(1-p_i)$. None of these are established here; `multinomial_expectation` only restates a reflexive equality. The fair-coin check, by contrast, is a real (if elementary) verification that the abstract normalization specializes correctly to numbers.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "norm_num",
+      "expected value",
+      "reflexivity (rfl)",
+      "placeholder theorem"
+    ],
+    "prerequisites": [
+      "multinomialProb_sum_eq_one",
+      "Finset.sum_pair"
     ]
   },
   {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -59,23 +59,37 @@
     {
       "id": "mgf",
       "title": "Moment-Generating Function",
-      "startLine": 85,
-      "endLine": 130,
-      "summary": "Derives the MGF formula by applying the multinomial theorem with f(i) = p(i)*g(i). Shows factorization of probability and weight terms."
+      "startLine": 84,
+      "endLine": 119,
+      "summary": "Derives the MGF formula by applying the multinomial theorem with f(i) = p(i)*g(i). Shows factorization of probability and weight terms (works over any CommSemiring)."
+    },
+    {
+      "id": "specialization",
+      "title": "Specialization to ℝ and Uniform Weights",
+      "startLine": 121,
+      "endLine": 141,
+      "summary": "Re-expresses the MGF identity over ℝ so coefficients are literally multinomialProb (closed by rfl), and instantiates normalization at the uniform law p(i) = 1/k over Fin k."
     },
     {
       "id": "binomial-connection",
       "title": "Connection to Binomial Distribution",
-      "startLine": 140,
-      "endLine": 170,
+      "startLine": 143,
+      "endLine": 162,
       "summary": "Shows the binomial distribution is the 2-outcome (Bool-indexed) special case of the multinomial distribution."
     },
     {
       "id": "examples",
       "title": "Concrete Calculations",
-      "startLine": 172,
-      "endLine": 204,
-      "summary": "Concrete examples including fair coin flips and counting identities."
+      "startLine": 164,
+      "endLine": 184,
+      "summary": "A fair-coin numerical sanity check (3 flips sum to 1) plus multinomial_expectation, a rfl placeholder that restates a tautology rather than proving a real expectation formula."
+    },
+    {
+      "id": "counting",
+      "title": "Counting Identity (Multinomial Analog of ∑C(n,k)=2ⁿ)",
+      "startLine": 186,
+      "endLine": 199,
+      "summary": "Specializes the multinomial theorem at f(i)=1 to prove |s|ⁿ = ∑ multinomial(s,k), generalizing the sum of binomial coefficients."
     }
   ],
   "conclusion": {
@@ -84,7 +98,8 @@
     "openQuestions": [
       "RESOLVED: Multinomial PMF integrated with Mathlib PMF framework in BinomialTheoremOQ02OQ01OQ01.lean — construction via Composition type + ENNReal normalization",
       "Can marginal distributions be formally derived as binomials?",
-      "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?"
+      "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?",
+      "The current `multinomial_expectation` theorem is a vacuous `rfl` (it restates ∑ P(k)·w(k) = ∑ P(k)·w(k)). Can a substantive mean E[Xi] = n·pi be derived by differentiating the MGF (∑ pj·e^{tj})^n at t = 0, giving a genuine moment formula rather than a tautology?"
     ]
   },
   "leanFile": {
@@ -121,6 +136,11 @@
       "targetId": "binomial-theorem",
       "relationship": "related",
       "description": "The binomial theorem is the 2-variable special case"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Follow-up that integrates the multinomial PMF with Mathlib's PMF framework via the Composition type and ENNReal normalization, lifting the algebraic distribution here into a genuine measure-theoretic probability mass function"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-01` (Multinomial Distribution and Moment-Generating Function), a thin entry (smallest meta.json in the gallery, 0 prior passes-worth of depth in several parts).

## Quality improvements
- **Annotation coverage 5 → 8**: added annotations for previously uncovered code regions:
  - File header / open-question context (lines 6–46)
  - The ℝ-specialization (`multinomial_mgf_real`) and the uniform-distribution case (`multinomialProb_uniform_sum`), lines 123–141
  - A concrete-examples annotation (lines 164–184) for `fair_coin_three_flips`
- **Honesty (axiom/claim integrity)**: the new examples annotation and a new open question explicitly flag that `multinomial_expectation` is a vacuous `rfl` — its statement is the tautology `∑ P(k)·w(k) = ∑ P(k)·w(k)` and asserts nothing, despite its docstring framing it as "the general expectation formula `E[w(X)]`". This avoids overclaiming, consistent with the axiom-integrity policy.
- **Sections 5 → 7**: added `specialization` (Part 4) and `counting` (Part 7) sections and realigned all line ranges to the actual Lean source.
- **Cross-reference added**: links to `binomial-theorem-oq-02-oq-01-oq-01`, the follow-up that lifts this algebraic PMF into Mathlib's measure-theoretic `PMF` framework.
- **Open question added**: proposes deriving a genuine mean `E[Xi] = n·pi` by differentiating the MGF, replacing the current tautological stub.

All new `mathContext` is in LaTeX and mathematically checked against the Lean file. `pnpm build` passes. `status: verified`, `badge: mathlib`, `axiomCount: 0` confirmed accurate (no sorries, no axioms, no structure-encoded assumptions).