### PR TITLE
research(erdos-1107-oq-02-oq-01): cubeful numbers closed under multiplication

### DIFF
--- a/proofs/Proofs/Erdos1107OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1107OQ02OQ01.lean
@@ -151,6 +151,21 @@ theorem isCubeful_pow {n k : ℕ} (hk : 3 ≤ k) : IsCubeful (n ^ k) := by
 /-- Every perfect cube is cubeful (the `k = 3` case of `isCubeful_pow`). -/
 theorem isCubeful_cube (n : ℕ) : IsCubeful (n ^ 3) := isCubeful_pow (le_refl 3)
 
+/-- Cubeful numbers are closed under multiplication: a product of two cubeful
+    numbers is cubeful.  Every prime dividing `a * b` divides one of the factors
+    and already carries exponent `≥ 3` there, so `p³ ∣ a*b`.  Together with
+    `isCubeful_pow` this generates cubeful numbers as products of prime cubes. -/
+theorem isCubeful_mul {a b : ℕ} (ha : IsCubeful a) (hb : IsCubeful b) :
+    IsCubeful (a * b) := by
+  intro p hp
+  obtain ⟨hpp, hpd, hab_ne⟩ := Nat.mem_primeFactors.mp hp
+  obtain ⟨ha_ne, hb_ne⟩ := mul_ne_zero_iff.mp hab_ne
+  rcases (Nat.Prime.dvd_mul hpp).mp hpd with hpa | hpb
+  · exact dvd_mul_of_dvd_left
+      (ha p (Nat.mem_primeFactors.mpr ⟨hpp, hpa, ha_ne⟩)) b
+  · exact dvd_mul_of_dvd_right
+      (hb p (Nat.mem_primeFactors.mpr ⟨hpp, hpb, hb_ne⟩)) a
+
 /-- Prime powers `p^k` with `k ≥ 3` are cubeful. -/
 theorem isCubeful_8 : IsCubeful 8 := by native_decide      -- 2³
 theorem isCubeful_16 : IsCubeful 16 := by native_decide    -- 2⁴


### PR DESCRIPTION
## Summary

Adds `isCubeful_mul` to `proofs/Proofs/Erdos1107OQ02OQ01.lean`:

```lean
theorem isCubeful_mul {a b : ℕ} (ha : IsCubeful a) (hb : IsCubeful b) :
    IsCubeful (a * b)
```

A product of two cubeful (3-powerful) numbers is cubeful. Every prime `p ∣ a*b`
divides one factor (`Nat.Prime.dvd_mul`) and already carries exponent ≥3 there
(by `IsCubeful` of that factor), so `p³ ∣ a*b` via `dvd_mul_of_dvd_left/right`.
Holds unconditionally — the `a*b = 0` case is vacuous.

This complements the just-merged `isCubeful_pow` (#24350): together they
generate cubeful numbers as products of prime cubes, giving the basic
multiplicative structure of the cubeful set underlying Erdős #1107 (r=3).

## Notes

- Lemma names and signatures cross-checked against a sibling `mathlib4` checkout
  (`Nat.mem_primeFactors`, `mul_ne_zero_iff`, `Nat.Prime.dvd_mul`,
  `dvd_mul_of_dvd_left/right`).
- Build-pending: authored under a Docker + Aristotle blackout, not yet
  compiler-checked. The file is not registered in `Proofs.lean`, so it cannot
  affect the gallery build.
- The lone axiom `cubeful_sum_threshold` (open r=3 Heath-Brown analogue) is
  untouched — it is a genuine open conjecture, not dischargeable.