### PR TITLE
Enrich Waring g(2)=4: cross-references and annotations

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/annotations.json
@@ -118,5 +118,97 @@
       "eight_b_plus_seven_needs_four",
       "omega for 8(N+1)+7 > N"
     ]
+  },
+  {
+    "id": "ann-seven-needs-four-cascade",
+    "proofId": "lagrange-four-squares-waring-g2",
+    "range": {
+      "startLine": 85,
+      "endLine": 100
+    },
+    "type": "technique",
+    "title": "Witness 7: Ruling Out 1, 2, and 3 Squares",
+    "content": "To certify that 7 needs exactly four squares, the file rules out every smaller count. `seven_not_sum_three_sq` (the mod-8 obstruction) immediately implies `seven_not_sum_two_sq` and the single-square case, because a representation with fewer squares is a special case of a three-square representation with the extra slots set to 0: `⟨x, y, 0, _⟩`. The single-square impossibility `seven_not_sq` is closed by the bound x ≤ 2 (`nlinarith`) followed by `interval_cases`. `seven_needs_four_squares` then bundles the positive witness 7 = 1²+1²+1²+2² with the three-square impossibility — an exact lower-bound certificate, not just an upper bound on the count.",
+    "mathContext": "$7 = 1^2+1^2+1^2+2^2$ but $7 \\neq x^2+y^2+z^2$. Padding with zeros gives the monotone chain: not a sum of 3 squares $\\Rightarrow$ not a sum of $\\le 2$ $\\Rightarrow$ not a single square. Hence $\\min\\{s : 7 = \\sum_{i<s} a_i^2\\} = 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exact representation count",
+      "padding with zero squares",
+      "interval_cases tactic",
+      "lower-bound certificate"
+    ],
+    "prerequisites": [
+      "seven_not_sum_three_sq",
+      "nlinarith and interval_cases"
+    ]
+  },
+  {
+    "id": "ann-main-theorem-g2-eq-four",
+    "proofId": "lagrange-four-squares-waring-g2",
+    "range": {
+      "startLine": 106,
+      "endLine": 120
+    },
+    "type": "concept",
+    "title": "The Main Theorem: g(2) = 4 as a Conjunction of Two Bounds",
+    "content": "The headline result `waring_g2_eq_four` is stated as a conjunction rather than an equation, because g(2) = 4 is genuinely two inequalities glued together. `waring_g2_upper` (g(2) ≤ 4) is Lagrange's universally-quantified existence statement; `waring_g2_lower` (g(2) ≥ 4) is the single counterexample n = 7 for which no three-square representation exists. This is the canonical shape of a Waring-number proof: an upper bound that holds for all n, and a lower bound witnessed by one stubborn integer. Tightness — that 4 cannot be lowered to 3 — is exactly the content of the lower half.",
+    "mathContext": "$g(2) = 4 \\iff \\big(\\forall n\\, \\exists a,b,c,d:\\ n = a^2+b^2+c^2+d^2\\big) \\wedge \\big(\\exists n\\, \\forall x,y,z:\\ n \\neq x^2+y^2+z^2\\big)$. The witness for the second conjunct is $n = 7$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Waring number g(k)",
+      "upper bound vs lower bound",
+      "tightness of a bound",
+      "existential and universal quantifier interplay"
+    ],
+    "prerequisites": [
+      "waring_g2_upper",
+      "waring_g2_lower"
+    ]
+  },
+  {
+    "id": "ann-eight-b-plus-seven-family",
+    "proofId": "lagrange-four-squares-waring-g2",
+    "range": {
+      "startLine": 126,
+      "endLine": 151
+    },
+    "type": "technique",
+    "title": "From One Witness to an Arithmetic Progression: 8b + 7",
+    "content": "Rather than stopping at n = 7, `seven_mod_eight_needs_four` generalizes the mod-8 obstruction to every n ≡ 7 (mod 8): the residue argument never used the actual value 7, only its residue class. The concrete cases 15, 23, 31 are then one-liners delegating to this lemma with `norm_num`, and `eight_b_plus_seven_needs_four` closes the general arithmetic progression {8b+7 : b ∈ ℕ} with `omega`. This already exhibits an infinite, explicitly parameterized family of integers needing four squares — the seed for both the descent argument (Part 5) and the asymptotic G(2) = 4 statement (Part 8).",
+    "mathContext": "$n \\equiv 7 \\pmod 8 \\Rightarrow n \\neq x^2+y^2+z^2$, since $x^2+y^2+z^2 \\not\\equiv 7 \\pmod 8$. The family $\\{8b+7\\}_{b\\ge 0} = \\{7,15,23,31,39,\\ldots\\}$ all need four squares.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "arithmetic progression",
+      "residue class invariance",
+      "norm_num and omega",
+      "infinite exceptional family"
+    ],
+    "prerequisites": [
+      "sum_three_sq_mod_eight_ne_seven",
+      "congruence mod 8"
+    ]
+  },
+  {
+    "id": "ann-scaling-structural",
+    "proofId": "lagrange-four-squares-waring-g2",
+    "range": {
+      "startLine": 362,
+      "endLine": 401
+    },
+    "type": "technique",
+    "title": "Multiplicative Structure: Scaling and the Essential Fourth Square",
+    "content": "The descent lemma has a forward companion: `four_mul_sum_three_sq` shows that if n is a sum of three squares then so is 4n (scale each root by 2), and `sq_mul_sum_three_sq` generalizes to k²n (scale by k). Together with the descent direction, these establish that being a sum of three squares is invariant under multiplication by perfect squares — the structural reason the excluded set is closed under the 4^a factor. `fourth_square_essential` packages the dichotomy for excluded numbers: a four-square representation always exists (Lagrange) yet no three-square one does, so the fourth square is genuinely indispensable, not merely convenient.",
+    "mathContext": "If $n = x^2+y^2+z^2$ then $k^2 n = (kx)^2+(ky)^2+(kz)^2$. Conversely the descent removes a factor of 4. Hence three-square representability is stable under multiplication by squares, and for $n = 4^a(8b+7)$ the fourth square cannot be dropped.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative scaling of representations",
+      "square-factor invariance",
+      "infinite descent (converse)",
+      "necessity of the fourth square"
+    ],
+    "prerequisites": [
+      "four_mul_not_sum_three_sq",
+      "Nat.sum_four_squares"
+    ]
   }
 ]

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -224,7 +224,42 @@
     {
       "targetId": "lagrange-four-squares",
       "relationship": "extends",
-      "description": "Extends the Lagrange four-square theorem to the full Waring problem: g(2) = 4"
+      "description": "Extends the Lagrange four-square theorem to the full Waring problem: g(2) = 4. That entry supplies the upper bound $g(2) \\le 4$ (every $n$ is a sum of four squares, $\\texttt{Nat.sum\\_four\\_squares}$); this entry adds the matching lower bound $g(2) \\ge 4$ and the asymptotic statement $G(2) = 4$."
+    },
+    {
+      "targetId": "lagrange-four-squares-oq-04",
+      "relationship": "complementary",
+      "description": "Legendre–Gauss three-square theorem (necessity direction): $4^a(8b+7)$ is never a sum of three squares. This is exactly the obstruction that forces $g(2) \\ge 4$ here — the $\\texttt{excluded\\_form\\_needs\\_four}$ family in this entry is the same arithmetic content. The companion entry isolates and studies that characterization on its own."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "The two-square analogue: a prime $p$ is a sum of two squares iff $p = 2$ or $p \\equiv 1 \\pmod 4$. Both results classify which integers are representable by a fixed number of squares via congruence obstructions — mod 4 for two squares, mod 8 for three. Together they trace the descending chain $r_2, r_3, r_4$ that culminates in Lagrange's unconditional four-square theorem."
+    },
+    {
+      "targetId": "four-square-distribution",
+      "relationship": "related",
+      "description": "Where this entry asks how *many* squares are needed, the distribution entry asks how many *ways* $n = a^2+b^2+c^2+d^2$ can be written ($r_4(n)$) and how those representations split across ordering types. Complementary existence-vs-counting views of the same four-square representation problem."
+    },
+    {
+      "targetId": "four-square-distribution-oq-01",
+      "relationship": "related",
+      "description": "Jacobi's exact four-square formula $r_4(n) = 8\\sum_{d \\mid n,\\, 4 \\nmid d} d$. This quantifies Lagrange's qualitative theorem: since the divisor sum is always positive, $r_4(n) > 0$ for every $n$ — an alternative, formula-driven route to the upper bound $g(2) \\le 4$ established here."
+    },
+    {
+      "targetId": "lagrange-four-squares-oq-01",
+      "relationship": "related",
+      "description": "Computational complexity of *finding* a four-square representation, complementing this entry's computable $\\texttt{numSquaresNeeded}$ classifier. Knowing $g(2) = 4$ guarantees a representation exists; that entry studies how efficiently one can be produced."
+    },
+    {
+      "targetId": "lagrange-four-squares-oq-02",
+      "relationship": "related",
+      "description": "Classifies how the representations $n = a^2+b^2+c^2+d^2$ distribute among orderings (trivial, all-equal, three-equal, etc.). A finer structural study of the four-square representations whose mere existence is the upper bound proved here."
+    },
+    {
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "The lower bound rests on the set of quadratic residues mod 8 ($\\{0,1,4\\}$) and mod 4 ($\\{0,1\\}$). Quadratic reciprocity is the deep theory governing quadratic residues across all moduli; the elementary mod-8 census used here is the simplest instance of that residue analysis underpinning representation by quadratic forms."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2` (Waring's Problem for Squares: g(2) = 4).

This entry was content-rich in its overview/keyInsights but had only **1 cross-reference** and **5 annotations** despite being a hub classical result — the genuine gap (the quality scorer is saturated at 100 gallery-wide, so it can't surface this).

## Changes

**Cross-references: 1 → 8** (all targets verified to exist)
- `lagrange-four-squares` — the upper-bound source (refined description)
- `lagrange-four-squares-oq-04` — Legendre–Gauss three-square necessity, i.e. the exact obstruction forcing g(2) ≥ 4
- `fermat-two-squares` — the two-square (mod 4) analogue
- `four-square-distribution` + `four-square-distribution-oq-01` — r₄(n) counting / Jacobi's formula
- `lagrange-four-squares-oq-01` / `-oq-02` — representation-finding complexity and ordering distribution
- `elementary-quadratic-reciprocity` — the quadratic-residue theory underlying the mod-8 census

**Annotations: 5 → 9** (covering previously unannotated sections)
- The 7-needs-exactly-4 cascade (lines 85–100)
- The main g(2)=4 conjunction theorem (106–120)
- The 8b+7 arithmetic-progression family (126–151)
- Multiplicative scaling and the essential fourth square (362–401)

All new annotations include `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. `pnpm build` passes and confirms the additions survive regeneration. No Lean source or axiom/status metadata changed (entry remains badge `mathlib`, 0 axioms, 0 sorries).

## Test plan
- [x] `pnpm build` succeeds
- [x] JSON validates; all 8 cross-reference targets exist as gallery dirs
- [x] Annotation ids unique; committed changes preserved through the build pipeline