### PR TITLE
Enrich Subset Counting for Multisets: cross-references

### DIFF
--- a/src/data/proofs/subset-count-multiset/meta.json
+++ b/src/data/proofs/subset-count-multiset/meta.json
@@ -104,6 +104,16 @@
       "targetId": "subset-count",
       "relationship": "extends",
       "description": "Generalizes the subset counting theorem from sets to multisets"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The fixed-size submultiset counts are exactly the binomial-theorem coefficients: the generating function ∑_k card(powersetCard k s)·xᵏ = (1+x)ⁿ is the binomial theorem, and multiset_choose_card establishes card(powersetCard k s) = C(n,k)"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Companion counting result: the multinomial entry proves |s|ⁿ = ∑ multinomial(s,k), the multi-outcome analog of the 2ⁿ = ∑ C(n,k) submultiset identity established here — both reduce a global count to a sum over size/type-partitioned cells via a Mathlib cardinality lemma"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `subset-count-multiset`. The entry was already well-annotated (5 quality annotations, rich historical context) but had only a single cross-reference — the genuine gap.

## Quality improvements
- **Cross-references 1 → 3**, both accurate and mathematically grounded:
  - `binomial-theorem` (related): `multiset_choose_card` proves `card(powersetCard k s) = C(n,k)`, so the fixed-size submultiset counts are exactly the binomial coefficients; their generating function `∑_k card(powersetCard k s)·xᵏ = (1+x)ⁿ` is the binomial theorem. The connection was already noted in the entry's historicalContext; this surfaces it as a navigable link.
  - `binomial-theorem-oq-02-oq-01` (related): that multinomial entry's `multinomial_count` identity `|s|ⁿ = ∑ multinomial(s,k)` is the multi-outcome analog of the `2ⁿ = ∑ C(n,k)` submultiset identity here — both reduce a global count to a sum over partitioned cells via a single Mathlib cardinality lemma.

`pnpm build` passes. `status: verified`, `badge: mathlib`, `axiomCount: 0` confirmed accurate (0 sorries, 0 axioms, no structure-encoded assumptions).