### PR TITLE
research(euler-totient-oq-01-oq-01): S1 ACT — Carmichael multiplicativity λ(mn)=lcm(λm,λn) [build-pending]

### DIFF
--- a/proofs/Proofs/EulerTotientOQ01OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ01.lean
@@ -1,0 +1,76 @@
+import Mathlib
+
+/-
+# Carmichael's Function is Multiplicative: λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n
+
+## Open Question (euler-totient-oq-01-oq-01)
+
+Strengthen `carmichael_dvd_totient` (parent: `EulerTotientOQ01.lean`) toward the
+full structural characterization
+  λ(n) = lcm of the cyclic-factor orders of (ℤ/nℤ)*.
+
+The keystone is **multiplicativity over coprime factors**:
+  λ(m·n) = lcm(λ(m), λ(n))     whenever gcd(m, n) = 1.
+
+Iterating this over the prime-power factorization n = ∏ pᵢ^kᵢ yields
+  λ(n) = lcm_i λ(pᵢ^kᵢ),
+and since each (ℤ/pᵏℤ)* is cyclic (p odd) or a product of cyclic groups (p = 2),
+this is exactly "λ(n) = lcm of cyclic group orders".  This file proves the
+keystone; the factorization corollary is left as a routine induction (see the
+`Next Steps` note in `research/problems/.../knowledge.md`).
+
+## Proof
+
+λ(n) is defined as the group-theoretic exponent of the unit group (ℤ/nℤ)*.
+For coprime m, n the Chinese Remainder ring isomorphism
+  ZMod (m·n) ≃+* ZMod m × ZMod n
+induces a multiplicative isomorphism on unit groups
+  (ℤ/mnℤ)* ≃* (ℤ/mℤ)* × (ℤ/nℤ)*.
+The exponent is invariant under multiplicative isomorphism
+(`Monoid.exponent_eq_of_mulEquiv`), and the exponent of a product is the lcm of
+the exponents (`Monoid.exponent_prod`), giving the result.
+
+## Honesty note
+
+This is routine given current Mathlib (`Monoid.exponent_prod`,
+`ZMod.chineseRemainder`, `Units.mapEquiv`, `MulEquiv.prodUnits`).  The unit-group
+splitting used here is the same composition Mathlib uses in
+`RingTheory/ZMod/UnitsCyclic.lean`.  The contribution is the explicit
+Carmichael-function statement for the gallery, not new mathematics.
+-/
+
+namespace CarmichaelMultiplicative
+
+open ZMod
+
+/-- Carmichael's function λ(n): the exponent of the unit group (ℤ/nℤ)*.
+    (Same definition as `CarmichaelFunction.carmichael` in the parent file;
+    redefined here so this file is build-independent of the parent.) -/
+noncomputable def carmichael (n : ℕ) : ℕ :=
+  Monoid.exponent (ZMod n)ˣ
+
+/-- For coprime m, n, the unit group of `ZMod (m * n)` splits multiplicatively as
+    the product of the unit groups of `ZMod m` and `ZMod n`.  This is the
+    Chinese-Remainder ring isomorphism transported to units, then split with
+    `MulEquiv.prodUnits`. -/
+noncomputable def unitsChineseRemainder {m n : ℕ} (h : m.Coprime n) :
+    (ZMod (m * n))ˣ ≃* (ZMod m)ˣ × (ZMod n)ˣ :=
+  (Units.mapEquiv (ZMod.chineseRemainder h).toMulEquiv).trans MulEquiv.prodUnits
+
+/-- **Multiplicativity of Carmichael's function.**
+    For coprime `m`, `n`: λ(m·n) = lcm(λ(m), λ(n)). -/
+theorem carmichael_mul_coprime {m n : ℕ} (h : m.Coprime n) :
+    carmichael (m * n) = Nat.lcm (carmichael m) (carmichael n) := by
+  unfold carmichael
+  rw [Monoid.exponent_eq_of_mulEquiv (unitsChineseRemainder h),
+      Monoid.exponent_prod, lcm_eq_nat_lcm]
+
+/-- Every unit's order divides λ(n): the universal-exponent property, restated
+    for the Carmichael function.  Combined with `carmichael_mul_coprime`, this
+    gives that λ(n) is a common multiple of all element orders in each factor. -/
+theorem order_dvd_carmichael (n : ℕ) (a : (ZMod n)ˣ) :
+    orderOf a ∣ carmichael n := by
+  unfold carmichael
+  exact Monoid.order_dvd_exponent a
+
+end CarmichaelMultiplicative

--- a/research/problems/euler-totient-oq-01-oq-01/knowledge.md
+++ b/research/problems/euler-totient-oq-01-oq-01/knowledge.md
@@ -1,0 +1,88 @@
+# Knowledge Base: euler-totient-oq-01-oq-01
+
+Strengthen `carmichael_dvd_totient` (parent `EulerTotientOQ01.lean`) to the full
+structural characterization: λ(n) = lcm of the cyclic-factor orders of (ℤ/nℤ)*.
+
+---
+
+## Problem Understanding
+
+λ(n) = `Monoid.exponent (ZMod n)ˣ` (group exponent of the unit group). The parent
+file proves λ(n) ∣ φ(n) via `Monoid.exponent_dvd_card`. The "full characterization"
+is the standard prime-power formula
+  λ(n) = lcm_{p^k ‖ n} λ(p^k),
+with λ(p^k) = φ(p^k) for odd p (cyclic group) and λ(2^k) = 2^{k-2} for k ≥ 3.
+The decomposition rests on two facts: (i) multiplicativity over coprime factors,
+(ii) the prime-power values. This session establishes (i) — the keystone.
+
+---
+
+## Insights
+
+- λ(n) = exponent of (ℤ/nℤ)* makes the whole characterization a statement about
+  group exponents, so all the heavy lifting is already in Mathlib's `Monoid.exponent`
+  API — no number-theoretic descent needed.
+- The unit-group splitting for coprime m, n is *exactly* the composition Mathlib
+  uses in `RingTheory/ZMod/UnitsCyclic.lean`:
+  `(Units.mapEquiv (ZMod.chineseRemainder h).toMulEquiv).trans MulEquiv.prodUnits`.
+- `Monoid.exponent_prod : exponent (M₁ × M₂) = lcm (exponent M₁) (exponent M₂)`
+  + `Monoid.exponent_eq_of_mulEquiv` reduce multiplicativity to two rewrites.
+- ℕ bridge: `lcm` (GCDMonoid) = `Nat.lcm` via root-namespace `lcm_eq_nat_lcm`.
+
+---
+
+## Built Items
+
+- `CarmichaelMultiplicative.carmichael_mul_coprime` (EulerTotientOQ01OQ01.lean):
+  for coprime m, n, λ(m·n) = Nat.lcm (λ m) (λ n). Keystone of the characterization.
+- `CarmichaelMultiplicative.unitsChineseRemainder`: (ZMod (m·n))ˣ ≃* (ZMod m)ˣ × (ZMod n)ˣ.
+- `CarmichaelMultiplicative.order_dvd_carmichael`: orderOf a ∣ λ(n) (universal exponent).
+
+## Mathlib Gaps
+
+- None for the keystone. The remaining (routine) gap is purely combinatorial:
+  iterating coprime multiplicativity over `Nat.factorization` to reach
+  λ(n) = lcm over prime powers. No missing infrastructure, just induction.
+
+## Next Steps
+
+- Prove `carmichael_eq_lcm_primePow`: λ(n) = `n.factorization.prod`-style lcm of
+  λ(p^k) over p^k ‖ n, by induction on the factorization using
+  `carmichael_mul_coprime` (Nat.Coprime.prod / `Nat.factorization` recursion).
+- Add prime-power values λ(p^k): odd p ⇒ λ(p^k) = φ(p^k) (cyclic);
+  λ(2^k) = 2^{k-2} for k ≥ 3 (Mathlib `ZMod.unitsCyclic`-adjacent results).
+- Register `EulerTotientOQ01OQ01.lean` in the build once Docker is available and
+  add a gallery `meta.json` (status `verified`, badge `mathlib`, axiomCount 0).
+
+---
+
+## Session 2026-06-15 (Session 1) — ACT: coprime multiplicativity keystone
+
+**Mode**: FRESH
+**Outcome**: progress (build-pending; Docker + Aristotle blackout this session)
+
+### What I Did
+- Created `proofs/Proofs/EulerTotientOQ01OQ01.lean` (build-independent of parent;
+  re-defines `carmichael` locally) proving:
+  - `carmichael_mul_coprime` — λ(m·n) = lcm(λ m, λ n) for coprime m, n;
+  - `unitsChineseRemainder` — the unit-group splitting MulEquiv;
+  - `order_dvd_carmichael` — every unit order divides λ(n).
+- All Mathlib bearer names verified against mathlib4 master via GitHub API
+  (no local build possible): `Monoid.exponent_prod`, `Monoid.exponent_eq_of_mulEquiv`,
+  `Monoid.order_dvd_exponent`, `ZMod.chineseRemainder`, `Units.mapEquiv`,
+  `MulEquiv.prodUnits`, `lcm_eq_nat_lcm` (root namespace).
+
+### Key Findings
+- The keystone is routine given Mathlib — proof is `unfold` + 3 rewrites. The
+  unit-splitting composition is copied from Mathlib's own `UnitsCyclic.lean`.
+- This is NOT new mathematics; the value is the explicit gallery statement and a
+  clean reduction of the remaining characterization to a routine factorization
+  induction (no Mathlib gap remains).
+
+### Files Modified
+- proofs/Proofs/EulerTotientOQ01OQ01.lean (new, UNREGISTERED build-pending)
+- research/problems/euler-totient-oq-01-oq-01/knowledge.md (new)
+
+### Next Steps
+- See "Next Steps" above: factorization induction for the full lcm-of-prime-powers
+  characterization; register + gallery meta when Docker returns.


### PR DESCRIPTION
## Summary
- Strengthens `carmichael_dvd_totient` toward the full characterization **λ(n) = lcm of cyclic-factor orders** of (ℤ/nℤ)*.
- Proves the keystone **coprime multiplicativity** `carmichael_mul_coprime`: for `Nat.Coprime m n`, λ(m·n) = `Nat.lcm` (λ m) (λ n).
- Adds `unitsChineseRemainder` (the (ℤ/mnℤ)* ≃* (ℤ/mℤ)* × (ℤ/nℤ)* splitting) and `order_dvd_carmichael` (universal-exponent property).

## Approach
λ(n) := `Monoid.exponent (ZMod n)ˣ`. For coprime m,n the CRT ring iso `ZMod.chineseRemainder` lifts to a unit-group `MulEquiv` via `Units.mapEquiv ∘ .toMulEquiv` then `MulEquiv.prodUnits` — the same composition Mathlib uses in `RingTheory/ZMod/UnitsCyclic.lean`. Then `Monoid.exponent_eq_of_mulEquiv` + `Monoid.exponent_prod` + `lcm_eq_nat_lcm` close it in three rewrites.

## Honesty
Routine given current Mathlib (no new mathematics); value is the explicit gallery statement plus reducing the remaining characterization to a routine factorization induction (no Mathlib gap remains).

## Status
- **Build-pending**: Docker + Aristotle blackout this session. All Mathlib bearer names verified against mathlib4 master via GitHub API. File is UNREGISTERED (not added to the build) — register + add gallery meta when Docker returns.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ01OQ01` once Docker is available
- [ ] Register in lakefile/aggregate and add `src/data/proofs/.../meta.json` (status verified, axiomCount 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)