### PR TITLE
research(cube-root-3-irrational-oq-04): S15a — a13 lower-bound convergent helper + a14=3 math-correction

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -691,4 +691,63 @@ theorem cbrt3_lt_one_eight_six_five_three_five_eight_over_one_two_nine_three_thr
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-! ## S15a prep: new lower bound for `a₁₃ = 3` (the fourteenth partial quotient)
+
+The fifteenth CF convergent of `∛3` is
+
+  `p₁₄/q₁₄ = (a₁₄·p₁₃ + p₁₂) / (a₁₄·q₁₃ + q₁₂)`
+  `       = (3 · 1865358 + 597449) / (3 · 1293367 + 414248)`
+  `       = 6_193_523 / 4_294_349`.
+
+This convergent is even-index (14), so it lies on the LOWER side of
+`∛3` (alternating with the upper-side fourteenth convergent
+`1865358/1293367` from S14a, which is reused unchanged as the a₁₃
+sandwich's upper bound).
+
+**MATH-CORRECTION (this session).** The post-S14a sketch tail of OEIS
+A002945 read `[…, 8, 3, 4, …]`, i.e. `a₁₄ = 4`. A 120-digit recomputation
+of the CF algorithm for `∛3` gives the true prefix
+`a₀..a₁₄ = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3]`, so `a₁₄ = 3`,
+NOT `4`. With the wrong `a₁₄ = 4` the convergent would be
+`8058881/5587716`, whose cube `8058881³ = 523_388_563_470_651_811_841 >
+523_388_563_470_618_833_088 = 3 · 5587716³` lies ABOVE `∛3` — the WRONG
+side for a lower bound (a `lt_cbrt3` proof of it would fail). The correct
+even-index lower convergent is `6_193_523/4_294_349`. This repeats the
+historical `a₈` typo precedent (S9-prep): when picking the next bound,
+re-derive `aᵢ` from a high-precision CF computation, never re-quote a
+prior sketch tail.
+
+Convergent recursion (with `a₁₄ = 3`):
+
+  `q₁₄ = 3 · q₁₃ + q₁₂ = 3 · 1293367 + 414248 = 4_294_349`
+  `p₁₄ = 3 · p₁₃ + p₁₂ = 3 · 1865358 + 597449 = 6_193_523`
+
+After cubing,
+
+  `6_193_523³   = 237_581_852_386_719_346_667`
+  `3 · 4_294_349³ = 237_581_852_386_724_971_647`
+
+so `6_193_523³ = 237_581_852_386_719_346_667 < 237_581_852_386_724_971_647 =
+3 · 4_294_349³` (strict, diff `+5_624_980`), hence `(6_193_523/4_294_349)³ < 3`
+and `6_193_523/4_294_349 < cbrt3` as required for a lower bound. The new
+lower cube gap (relative-to-`3·q³`: `≈ 2.37·10⁻¹⁴`) is roughly an order
+of magnitude tighter than S14a's upper-side gap of `≈ 3.51·10⁻¹³`.
+
+Rigorous a₁₃ check (exact `Fraction` interval propagation, this session):
+with the sandwich `6193523/4294349 < cbrt3 < 1865358/1293367`, propagating
+`[lo, hi]` through the map `x ↦ 1/(x - aᵢ)` for `a₀..a₁₂ =
+[1,2,3,1,4,1,5,1,1,6,2,5,8]` yields a final `1/x ∈ [3, 10/3)`, forcing
+`⌊1/x⌋ = 3 = a₁₃`. Two-line proof via the cubing-iff helper. -/
+
+/-- `6193523/4294349 < ∛3`. Cube target: `(6193523/4294349)³ =
+237_581_852_386_719_346_667 / 4_294_349³ < 3` (strict:
+`6193523³ = 237_581_852_386_719_346_667 < 237_581_852_386_724_971_647 =
+3 · 4294349³`, gap `+5_624_980`). The fifteenth convergent of the
+simple CF of `∛3` (using `a₁₄ = 3` per a 120-digit CF recomputation;
+NOT `a₁₄ = 4`). -/
+theorem six_one_nine_three_five_two_three_over_four_two_nine_four_three_four_nine_lt_cbrt3 :
+    (6193523 / 4294349 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -948,3 +948,73 @@ contributing Lagrange's theorem upstream. (No Lean written; Docker down. ORIENT 
 ### Files Touched (Session 19)
 
 - `research/problems/cube-root-3-irrational-oq-04/knowledge.md`: this Session 19 entry appended.
+
+## Session 2026-06-15 (S21, researcher-2) — a13 sandwich lower bound (S15a Helper-ACT) + a12 frontier de-risk + a14 math-correction
+
+**Mode:** Helper-ACT (Lean content, narrow) + verification. Dual blackout
+re-confirmed live this session: `docker info` times out; Aristotle MCP `prove`
+on `n + 0 = n` → `"Resource not found"`. The a12 frontier (`cbrt3_a12 = 8`) is
+double-claimed in two **draft** build-pending PRs (#23388 draft 06-14, #23983
+draft 06-15, both by rjwalters) — drafts, so the deployer will not auto-merge
+them; do not pile on a third a12 PR.
+
+### Deliverable 1 — new helper lower bound for a₁₃ (unblocks the next main-ACT)
+
+Added `Cbrt3Helpers.six_one_nine_three_five_two_three_over_four_two_nine_four_three_four_nine_lt_cbrt3 :
+(6193523/4294349 : ℝ) < cbrt3` to `CubeRoot3IrrationalOQ04Helpers.lean`
+(694 → 753 LOC, +1 theorem). Two-line cubing-iff proof
+(`rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`); no heartbeat budget
+needed (per S17, the helper bounds evaluate an exact rational cube directly).
+This is the **lower** side of the a₁₃ sandwich; the **upper** side is the
+existing S14a helper `cbrt3_lt_one_eight_six_five_three_five_eight_over_one_two_nine_three_three_six_seven`
+(= p₁₃ = 1865358/1293367), reused unchanged. With this pair the next main-ACT
+(`cbrt3_a13 = 3`) is fully unblocked once Docker returns.
+
+### Deliverable 2 — a₁₄ MATH-CORRECTION (sixth precedent)
+
+The post-S14a sketch tail of OEIS A002945 implied `a₁₄ = 4`. A 120-digit
+Newton recomputation of the CF gives the true prefix
+`a₀..a₁₄ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3]`, so **`a₁₄ = 3`, not `4`**. The
+wrong `a₁₄ = 4` would give the convergent `8058881/5587716`, whose cube
+`8058881³ = 523_388_563_470_651_811_841 > 523_388_563_470_618_833_088 =
+3·5587716³` lies **ABOVE** `∛3` — the wrong side for a lower bound; a
+`lt_cbrt3` proof of it would have failed. The correct even-index (below)
+convergent is `6_193_523/4_294_349` (recursion `3·1865358+597449`,
+`3·1293367+414248`). This is the **sixth** math-correction precedent on this
+slug (after the `a₈` typo family); the lesson stands: re-derive each `aᵢ` from
+a high-precision CF computation, never re-quote a prior sketch tail.
+
+### Deliverable 3 — a₁₂ frontier de-risk (both draft PRs assert correct math)
+
+Independently verified `cbrt3_a12 = 8` by exact `Fraction` interval
+propagation: with the helper sandwich `597449/414248 < cbrt3 < 1865358/1293367`
+(both bounds already in the file, cube directions re-checked), propagating
+`[lo,hi]` through `x ↦ 1/(x - aᵢ)` for `a₀..a₁₁` forces the final
+`1/x ∈ [8, 25/3) ⊂ [8,9)`, so `⌊1/x⌋ = 8`. So the math behind both
+build-pending a12 drafts is correct; the only thing gating them is the Docker
+elaboration check.
+
+### Verification artifacts (durable)
+
+- `verify_a13_sandwich.py` — CF sequence (120-digit) + a₁₄ correction +
+  exact interval propagation forcing `a₁₃ = 3`. CERTIFICATE PASSED.
+- `verify_a12_chain.py` — exact interval propagation forcing `a₁₂ = 8`.
+
+### Files Touched (Session 21)
+
+- `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`: +59 LOC, +1 theorem.
+- `research/problems/cube-root-3-irrational-oq-04/verify_a13_sandwich.py`: new.
+- `research/problems/cube-root-3-irrational-oq-04/verify_a12_chain.py`: new.
+- `research/problems/cube-root-3-irrational-oq-04/knowledge.md`: this entry.
+- `research/problems/cube-root-3-irrational-oq-04/state.md`: S21 focus / next action.
+- `src/data/research/problems/cube-root-3-irrational-oq-04.json`: helper file
+  lineCount/theoremCount + iteration/focus/nextAction.
+
+### Next Action (S15b main-ACT, build-gated)
+
+Prove `cbrt3_a13 = 3` in `CubeRoot3IrrationalOQ04.lean` using the now-complete
+sandwich `6193523/4294349 < cbrt3 < 1865358/1293367`. Mirror the `cbrt3_a12`
+draft's 13-deep nested-fraction `lt_div_iff₀`/`div_lt_iff₀`/`linarith` chain;
+budget `set_option maxHeartbeats` ≈ 2× the a12 value (depth scaling). Requires
+Docker (build-gated). Floor antisymmetry closes from `1/x ∈ [3, 10/3)`:
+`⌊1/x⌋ ≤ 3` via `div_lt_iff₀` (`4·(1/3) > 1`), `3 ≤ ⌊1/x⌋` via `le_div_iff₀`.

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -2,7 +2,27 @@
 
 **Phase**: ACT
 **Since**: 2026-06-12 (S14a Helper-ACT)
-**Iteration**: 18
+**Iteration**: 21
+
+## S21 — a13 lower-bound helper shipped + a14 math-correction (researcher-2, 2026-06-15)
+
+Dual blackout re-confirmed (Docker `docker info` timeout; Aristotle `prove` →
+`Resource not found`). a12 frontier double-claimed in two **draft** build-pending
+PRs (#23388, #23983) — deployer won't auto-merge drafts; no third a12 PR.
+
+- **Shipped Lean**: `Cbrt3Helpers.six_one_nine_three_five_two_three_over_four_two_nine_four_three_four_nine_lt_cbrt3 :
+  (6193523/4294349 : ℝ) < cbrt3` (15th CF convergent, even-index lower bound;
+  the value S18 pre-verified numerically). Helper file 694 → 753 LOC. This is
+  the **lower** side of the a₁₃ sandwich; upper side = existing S14a
+  `1865358/1293367`. The a₁₃ main-ACT is now fully unblocked (build-gated).
+- **a₁₄ math-correction**: true prefix `a₀..a₁₄ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3]`
+  (120-digit recompute) ⇒ `a₁₄ = 3`, not `4`. Wrong `a₁₄ = 4` gives
+  `8058881/5587716` which is ABOVE ∛3 (invalid lower bound). Sixth precedent.
+- **a₁₂ frontier de-risk**: exact `Fraction` interval propagation forces
+  `a₁₂ = 8` ⇒ both draft PRs assert correct math (only the Docker build gates them).
+- **Artifacts**: `verify_a13_sandwich.py`, `verify_a12_chain.py` (both pass).
+
+## Current Focus
 
 ## S18 — durable CF-convergent verification (researcher-5, 2026-06-14, build-free)
 

--- a/research/problems/cube-root-3-irrational-oq-04/verify_a12_chain.py
+++ b/research/problems/cube-root-3-irrational-oq-04/verify_a12_chain.py
@@ -1,0 +1,41 @@
+from fractions import Fraction as F
+from decimal import Decimal, getcontext
+getcontext().prec = 80
+
+# High-precision cbrt3 for CF sequence sanity
+cbrt3 = Decimal(3) ** (Decimal(1)/Decimal(3))
+x = cbrt3; qs=[]
+for _ in range(13):
+    a=int(x); qs.append(a); x = Decimal(1)/(x-a)
+print("CF a0..a12 (decimal):", qs)
+expect=[1,2,3,1,4,1,5,1,1,6,2,5,8]
+print("matches OEIS A002945 prefix:", qs==expect)
+
+# RIGOROUS interval propagation using the EXACT helper sandwich for a12=8.
+# Sandwich present in helper file:
+lo = F(597449,414248)   # 5..lower < cbrt3
+hi = F(1865358,1293367) # cbrt3 < ..upper  (S14a helper)
+# verify both are valid bounds by cube direction
+print("lo^3 < 3 :", lo**3 < 3, " (diff num sign)", (3 - lo**3))
+print("hi^3 > 3 :", hi**3 > 3, " (diff)", (hi**3 - 3))
+
+# Partial quotients consumed AFTER the initial (cbrt3 - 1):
+# x0 = cbrt3; we subtract 1 then invert, etc.
+# Full sequence of a_i for i=0..11 to reach the 1/x that floors to a12.
+seq = [1,2,3,1,4,1,5,1,1,6,2,5]  # a0..a11; final 1/x gives a12
+# Interval map: start I=[lo,hi]; repeatedly I <- 1/(I - a) where subtraction
+# then reciprocal. For monotone decreasing reciprocal on positive interval,
+# 1/[u,v] = [1/v,1/u].
+def step(I,a):
+    u,v = I
+    u2,v2 = u-a, v-a
+    assert u2>0, f"interval crossed 0 at a={a}: {u2}"
+    # reciprocal flips order
+    return (F(1,v2), F(1,u2))
+I=(lo,hi)
+for a in seq:
+    I=step(I,a)
+u,v=I
+print("final 1/x interval:", float(u), float(v))
+print("floor forced =", "8" if (u>=8 and v<9) else f"NOT 8 -> [{u},{v}]")
+print("8 <= u :", u>=8, "  v < 9 :", v<9)

--- a/research/problems/cube-root-3-irrational-oq-04/verify_a13_sandwich.py
+++ b/research/problems/cube-root-3-irrational-oq-04/verify_a13_sandwich.py
@@ -1,0 +1,42 @@
+"""S15a verification: a13 = 3 (14th partial quotient) and the corrected
+p14 lower-bound convergent for the simple CF of cbrt3.
+
+Catches the a14 = 4 -> a14 = 3 math-correction. Run: python3 verify_a13_sandwich.py
+"""
+from fractions import Fraction as F
+from decimal import Decimal, getcontext
+getcontext().prec = 120
+
+# High-precision cbrt3 via Newton; independent CF sequence.
+three = Decimal(3); x = Decimal('1.44224957')
+for _ in range(25):
+    x = (2 * x + three / (x * x)) / 3
+cbrt3 = x
+v = cbrt3; qs = []
+for _ in range(16):
+    a = int(v); qs.append(a); v = Decimal(1) / (v - a)
+assert qs[:15] == [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3], qs
+print("CF a0..a14 =", qs[:15], "(a13=3, a14=3 -- NOT a14=4)")
+
+# Corrected fifteenth convergent p14/q14 = (a14*p13+p12)/(a14*q13+q12), a14=3.
+p14, q14 = 3*1865358 + 597449, 3*1293367 + 414248
+assert (p14, q14) == (6193523, 4294349)
+assert p14**3 < 3 * q14**3, "p14 must be BELOW cbrt3 (even index)"
+# The wrong a14=4 convergent is ABOVE -> would fail as a lower bound:
+pw, qw = 4*1865358 + 597449, 4*1293367 + 414248   # 8058881/5587716
+assert pw**3 > 3 * qw**3, "wrong a14=4 convergent is ABOVE cbrt3"
+print(f"correct lower bound p14/q14 = {p14}/{q14} (below); "
+      f"wrong a14=4 gives {pw}/{qw} (above, invalid)")
+
+# Rigorous a13 floor via exact interval propagation through a0..a12.
+lo, hi = F(6193523, 4294349), F(1865358, 1293367)   # p14 below, p13 above
+def step(I, a):
+    u, v = I; u2, v2 = u - a, v - a
+    assert u2 > 0, f"interval crossed 0 at a={a}"
+    return (F(1, v2), F(1, u2))
+I = (lo, hi)
+for a in [1,2,3,1,4,1,5,1,1,6,2,5,8]:
+    I = step(I, a)
+u, v = I
+assert u >= 3 and v < 4, (u, v)
+print(f"a13 floor forced: 1/x in [{float(u)}, {float(v)}) subset [3,4) => a13 = 3  CERTIFICATE PASSED")

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -124,7 +124,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.562Z",
-  "lastUpdate": "2026-06-12",
+  "lastUpdate": "2026-06-15",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [
@@ -186,8 +186,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "filename": "CubeRoot3IrrationalOQ04Helpers.lean",
-      "lineCount": 694,
-      "theoremCount": 19,
+      "lineCount": 753,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -195,5 +195,7 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean"
     }
   ],
-  "lastUpdated": "2026-06-12"
+  "lastUpdated": "2026-06-12",
+  "currentFocus": "S21 Helper-ACT: added a13 lower-bound convergent p14=6193523/4294349 (corrected a14=3, not 4); a13 sandwich now complete. a12 frontier math re-verified (exact interval propagation).",
+  "nextAction": "S15b main-ACT (build-gated): prove cbrt3_a13 = 3 using sandwich 6193523/4294349 < cbrt3 < 1865358/1293367, mirroring the cbrt3_a12 nested-fraction chain."
 }


### PR DESCRIPTION
## Summary

Advances the continued-fraction prefix work on `∛3` by one helper bound and corrects a latent OEIS-tail transcription error, under the ongoing dual blackout (Docker `docker info` times out; Aristotle MCP `prove` → `Resource not found`, both re-confirmed live this session).

- **New Lean (build-pending, low-risk)** — `Cbrt3Helpers.six_one_nine_three_five_two_three_over_four_two_nine_four_three_four_nine_lt_cbrt3 : (6193523/4294349 : ℝ) < cbrt3`, the **15th CF convergent** (even-index ⇒ lower side). Two-line cubing-iff proof (`rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`), no heartbeat budget needed. This is the **lower** side of the `cbrt3_a13 = 3` sandwich; the upper side is the existing S14a helper `1865358/1293367`, reused unchanged ⇒ the next main-ACT (`cbrt3_a13`) is now fully unblocked once Docker returns. Helper file 694 → 753 LOC, +1 theorem, **0 sorries, 0 axioms**.

- **a₁₄ math-correction (sixth precedent)** — a 120-digit Newton recompute gives the true prefix `a₀..a₁₄ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3]`, so **`a₁₄ = 3`, not `4`**. The wrong `a₁₄ = 4` yields `8058881/5587716`, whose cube lies **ABOVE** `∛3` — an invalid lower bound that a `lt_cbrt3` proof would reject. The correct convergent is `6193523/4294349`.

- **a₁₂ frontier de-risk** — exact `Fraction` interval propagation confirms `cbrt3_a12 = 8`, so both **draft** build-pending PRs (#23388, #23983) assert mathematically-correct content; only the Docker elaboration check gates them.

## Verification artifacts

- `verify_a13_sandwich.py` — CF sequence + a₁₄ correction + exact interval propagation forcing `a₁₃ = 3` (CERTIFICATE PASSED).
- `verify_a12_chain.py` — exact interval propagation forcing `a₁₂ = 8`.

## Build status

Build-pending: the new helper is intentionally a minimal `norm_num` cubing bound (the lowest-risk Lean form on this slug) but has not been machine-checked this session due to the Docker blackout. Pure addition (59 insertions, 0 deletions) to an already-building helper file.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers` once Docker is available.
- [x] `python3 verify_a13_sandwich.py` passes (a₁₃ = 3 forced).
- [x] `python3 verify_a12_chain.py` passes (a₁₂ = 8 forced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)