### PR TITLE
research(four-square-distribution-oq-04): S4 — sign-count half of the orbit-size keystone

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04Sign.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04Sign.lean
@@ -1,0 +1,97 @@
+import Mathlib
+
+/-
+# Four-Square Distribution — OQ-04: the sign-count half of the orbit-size lemma
+
+## Context
+
+`FourSquareDistributionOQ04Decomp.lean` reduces the whole open question to a single
+orbit-size lemma `fiber_card_eq_contribution`: each `shape`-fiber of the
+representation set has size
+
+  (★)   `m! / ∏_v (count_v)! · 2^{#nonzero}`
+
+This is the size of a `B_m = S_m ⋉ (ℤ/2)^m` orbit. The factor splits cleanly:
+
+  (★) = (arrangement count `m! / ∏ count_v!`) · (sign count `2^{#nonzero}`).
+
+This file proves the **sign-count half** in full, as standalone reusable
+infrastructure, and records the precise decomposition blueprint reducing the
+keystone to the single remaining arrangement-count lemma.
+
+The sign count is the size of the fiber of the coordinatewise absolute-value map:
+once the (signed) absolute values `g i = |f i|` are fixed, each coordinate `f i`
+is recovered up to a sign — two choices `±g i` when `g i ≠ 0`, one choice when
+`g i = 0`. Hence the fiber has size `2^{#{i : g i ≠ 0}}`.
+
+The formula `(★)` itself was brute-force confirmed against the genuine fiber sizes
+for all `m ≤ 5`, `n ≤ 12` (58 fibers, 0 mismatches); see
+`research/problems/four-square-distribution-oq-04/verify_orbit_formula.py`.
+
+Build status: PENDING (authored under a Docker + Aristotle backend outage,
+both re-tested live this session). UNREGISTERED in `Proofs.lean`; the sign-count
+proof uses only standard `Fintype.piFinset` / `Finset.prod` API.
+-/
+
+namespace FourSquareDistributionOQ04Sign
+
+open Finset
+
+/-- The sign-fiber of a target absolute-value assignment `g : Fin m → ℤ`:
+all tuples `f` agreeing with `g` coordinatewise up to sign (`f i ∈ {g i, -g i}`).
+For `g i = |f i|` this is exactly the set of sign-flips of a fixed representation. -/
+def signFiber {m : ℕ} (g : Fin m → ℤ) : Finset (Fin m → ℤ) :=
+  Fintype.piFinset (fun i => ({g i, -g i} : Finset ℤ))
+
+/-- The single-coordinate sign count: `{c, -c}` has two elements unless `c = 0`. -/
+theorem card_pair_neg (c : ℤ) :
+    ({c, -c} : Finset ℤ).card = if c = 0 then 1 else 2 := by
+  by_cases h : c = 0
+  · subst h; simp
+  · rw [if_neg h, Finset.card_pair]
+    intro hcontra
+    exact h (by linarith)
+
+/-- **Sign-count lemma (the easy half of the orbit-size formula).**
+The number of sign-flips of a fixed coordinate profile `g` is `2` raised to the
+number of nonzero coordinates. -/
+theorem signFiber_card {m : ℕ} (g : Fin m → ℤ) :
+    (signFiber g).card = 2 ^ ((univ : Finset (Fin m)).filter (fun i => g i ≠ 0)).card := by
+  classical
+  rw [signFiber, Fintype.card_piFinset]
+  have hcard : ∀ i ∈ (univ : Finset (Fin m)),
+      ({g i, -g i} : Finset ℤ).card = if g i = 0 then 1 else 2 :=
+    fun i _ => card_pair_neg (g i)
+  rw [Finset.prod_congr rfl hcard]
+  rw [Finset.prod_ite (fun _ => (1 : ℕ)) (fun _ => (2 : ℕ))]
+  simp only [Finset.prod_const_one, one_mul, Finset.prod_const, ne_eq]
+
+end FourSquareDistributionOQ04Sign
+
+/-
+## Decomposition blueprint for `fiber_card_eq_contribution` (the remaining open lemma)
+
+With `signFiber_card` in hand, the keystone reduces to ONE standard lemma — the
+multinomial arrangement count — via a fiberwise split over the absolute-value map
+`absMap f = fun i => |f i|`:
+
+1. `absFiber_eq_signFiber` :  for `f₀` a representative,
+     `{f ∈ reps m n | absMap f = absMap f₀} = signFiber (absMap f₀)`,
+   so each abs-profile fiber has size `2^{#nonzero}` by `signFiber_card`
+   (here `#nonzero (absMap f) = #nonzero s` is constant on a shape-fiber).
+
+2. `arrangement_card` (THE remaining open target, no obvious Mathlib lemma):
+     `#{g : Fin m → ℤ | g i ≥ 0 ∀i, multiset(g) = s} = m! / ∏_v (count_v s)!`.
+   This is the multiset-permutation / multinomial coefficient count. Candidate
+   Mathlib leads to search in a build session: `Finset.card_... ` for the action
+   of `Equiv.Perm (Fin m)` on functions, `Nat.multinomial`, or
+   `Multiset.Nodup`/`Multiset.permutations` cardinalities.
+
+3. `fiber_card_eq_contribution` then follows from
+   `Finset.card_eq_sum_card_fiberwise` applied to `absMap` on the shape-fiber:
+     fiber(s).card = ∑_{abs-profiles g of shape s} (signFiber g).card
+                   = (arrangement_card) · 2^{#nonzero s}
+                   = shapeContribution m s.
+
+Step 2 is the sole genuine combinatorial residue; steps 1 and 3 are bookkeeping.
+-/

--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -181,3 +181,43 @@ of each fiber still validated by `verify_hyperoctahedral_2k.py` (PASS).
 **Next-session ACT.** Build & register `…Decomp.lean`; discharge
 `fiber_card_eq_contribution` by the `MulAction` orbit–stabilizer route (next-step
 #1) — now the *single* remaining goal rather than a per-`n` enumeration.
+
+## S4 (ACT — sign-count half of the keystone; dual blackout persists)
+Backends re-tested live: `docker info` times out; Aristotle `prove` → "Resource
+not found." No machine check possible.
+
+**Keystone factorization.** `fiber_card_eq_contribution` (the sole real `sorry`
+in `…Decomp.lean`) is a `B_m = S_m ⋉ (ℤ/2)^m` orbit-size. The formula `(★)`
+factors cleanly:
+
+    (★) = (arrangement count  m!/∏ count_v!) · (sign count  2^{#nonzero}).
+
+Brute-force **confirmed both halves** (`verify_orbit_formula.py`, PASS):
+orbit formula 58 fibers m≤5,n≤12 (0 mismatch); sign count 3905 abs-profiles m≤5
+(0 mismatch).
+
+**Shipped (build-pending, UNREGISTERED):** `…OQ04Sign.lean` proves the sign half
+in full —
+- `signFiber g := Fintype.piFinset (fun i => {g i, -g i})`,
+- `card_pair_neg c : ({c,-c}).card = if c=0 then 1 else 2` (via `Finset.card_pair`
+  + `c = -c ↔ c = 0`),
+- `signFiber_card : (signFiber g).card = 2 ^ #{i : g i ≠ 0}` via
+  `Fintype.card_piFinset` → `∏ (if … then 1 else 2)` → `Finset.prod_ite` +
+  `Finset.prod_const`.
+
+**Remaining = ONE standard lemma (arrangement_card).** With `signFiber_card`, the
+keystone reduces (blueprint in the file footer) by `card_eq_sum_card_fiberwise`
+over the abs-value map to:
+
+    arrangement_card : #{g : Fin m → ℤ | g i ≥ 0, multiset(g)=s} = m!/∏ count_v!.
+
+This multiset-permutation/multinomial count has no obvious Mathlib lemma —
+candidate leads for a build session: `Nat.multinomial`, `Equiv.Perm (Fin m)`
+action on functions, `Multiset.permutations`/`Multiset.Nodup` card. Good Aristotle
+target once the backend returns.
+
+## Remaining next steps (updated)
+1. Build `…OQ04Sign.lean` (fix any `Fintype.card_piFinset`/`Finset.prod_ite`
+   name drift), then register both `…Decomp` and `…Sign`.
+2. Prove/locate `arrangement_card` (the multinomial count) — the sole residue.
+3. Combine via the file-footer blueprint to discharge `fiber_card_eq_contribution`.

--- a/research/problems/four-square-distribution-oq-04/verify_orbit_formula.py
+++ b/research/problems/four-square-distribution-oq-04/verify_orbit_formula.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Brute-force confirmation of the hyperoctahedral orbit-size formula (★) used by
+FourSquareDistributionOQ04Decomp.lean / ...Sign.lean.
+
+For every m-tuple of integers with sum of squares = n, group by `shape` (the
+sorted multiset of absolute values) and check that each fiber has size
+
+    shapeContribution(m, shape) = (m! / prod_v count_v!) * 2^{#nonzero}.
+
+Also separately confirms the sign-count half (signFiber_card):
+    for fixed abs-profile g, #{f : |f i| = g i} = 2^{#{i : g i != 0}}.
+"""
+from itertools import product
+from collections import Counter
+from math import factorial, prod
+
+
+def fiber_sizes(m, n):
+    box = range(-n, n + 1)
+    fibers = Counter()
+    for f in product(box, repeat=m):
+        if sum(x * x for x in f) == n:
+            fibers[tuple(sorted(abs(x) for x in f))] += 1
+    return fibers
+
+
+def shape_contribution(m, shape):
+    c = Counter(shape)
+    arrangements = factorial(m) // prod(factorial(k) for k in c.values())
+    nonzero = sum(1 for v in shape if v != 0)
+    return arrangements * 2 ** nonzero
+
+
+def check_orbit():
+    mismatch = checked = 0
+    for m in range(2, 6):
+        for n in range(0, 13):
+            for shape, sz in fiber_sizes(m, n).items():
+                checked += 1
+                if shape_contribution(m, shape) != sz:
+                    mismatch += 1
+                    print(f"  MISMATCH m={m} n={n} shape={shape} "
+                          f"actual={sz} formula={shape_contribution(m, shape)}")
+    print(f"(orbit) checked {checked} fibers (m<=5, n<=12), mismatches={mismatch}")
+    return mismatch == 0
+
+
+def check_sign():
+    mismatch = checked = 0
+    for m in range(1, 6):
+        for g in product(range(-2, 3), repeat=m):
+            fiber = [f for f in product(range(-2, 3), repeat=m)
+                     if all(abs(f[i]) == abs(g[i]) for i in range(m))]
+            expected = 2 ** sum(1 for x in g if x != 0)
+            checked += 1
+            if len(fiber) != expected:
+                mismatch += 1
+                print(f"  SIGN MISMATCH m={m} g={g} actual={len(fiber)} formula={expected}")
+    print(f"(sign) checked {checked} abs-profiles (m<=5), mismatches={mismatch}")
+    return mismatch == 0
+
+
+if __name__ == "__main__":
+    ok = check_orbit() and check_sign()
+    print("RESULT:", "PASS" if ok else "FAIL")
+    raise SystemExit(0 if ok else 1)


### PR DESCRIPTION
## Summary
Advances the single remaining `sorry` of this OQ — the orbit-size lemma `fiber_card_eq_contribution` in `FourSquareDistributionOQ04Decomp.lean` — by proving one of its two factors and pinning the residue to a single standard count.

The keystone is the size of a hyperoctahedral `B_m = S_m ⋉ (ℤ/2)^m` orbit, and the formula `(★)` factors cleanly:

    (★) = (arrangement count  m!/∏ count_v!) · (sign count  2^{#nonzero}).

New **UNREGISTERED** file `proofs/Proofs/FourSquareDistributionOQ04Sign.lean` proves the **sign-count half** in full:
- `signFiber g := Fintype.piFinset (fun i => {g i, -g i})`
- `card_pair_neg c : ({c,-c}).card = if c = 0 then 1 else 2`
- `signFiber_card : (signFiber g).card = 2 ^ #{i : g i ≠ 0}` (via `Fintype.card_piFinset` → `Finset.prod_ite` → `Finset.prod_const`)

The file footer gives the precise blueprint reducing the keystone, via `Finset.card_eq_sum_card_fiberwise` over the absolute-value map, to the **single remaining lemma**:

    arrangement_card : #{g : Fin m → ℤ | g i ≥ 0, multiset(g) = s} = m!/∏ count_v!

— a standard multiset-permutation / multinomial count (no obvious Mathlib lemma; good Aristotle target once the backend returns).

## Status / honesty
- **Build PENDING.** Authored during a Docker + Aristotle outage (both re-tested live: `docker info` times out; Aristotle `prove` → "Resource not found"). UNREGISTERED in `Proofs.lean` so it cannot affect the gallery build until machine-checked.
- This does **not** close the OQ; it isolates the residue to one standard count and proves the separable sign half.

## Test plan
- [x] `research/problems/four-square-distribution-oq-04/verify_orbit_formula.py` — orbit formula 58 fibers (m≤5, n≤12) and sign count 3905 abs-profiles (m≤5), **0 mismatches, PASS**
- [ ] `./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04Sign` once Docker returns
- [ ] Prove/locate `arrangement_card`, then combine per the file-footer blueprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)