### PR TITLE
research(nth-root-irrational-oq-01-oq-01): S2 ACT — real subfield 2cos(2π/n) irrational

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01Real.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01Real.lean
@@ -1,0 +1,113 @@
+/-
+  Nth Root Irrationality OQ-01-OQ-01 (Real subfield): irrationality of the
+  maximal-real-subfield generator `ζ + ζ⁻¹ = 2·cos(2π/n)`.
+
+  The sibling file `NthRootIrrationalOQ01OQ01.lean` proved that a complex
+  primitive `n`-th root of unity `ζ` is irrational for `n ≥ 3`, and that the
+  only rational roots of unity are `±1`.
+
+  This file pushes into the **maximal real subfield** `ℚ(ζ)⁺ = ℚ(ζ + ζ⁻¹)` of
+  the cyclotomic field.  The generator `ζ + ζ⁻¹ = 2·cos(2π/n)` is the real part
+  doubled; it is rational exactly when `[ℚ(ζ)⁺ : ℚ] = φ(n)/2 = 1`, i.e. when
+  `φ(n) ≤ 2` (`n ∈ {1,2,3,4,6}`).  We prove the irrational direction:
+
+      `φ(n) ≥ 3  ⟹  ζ + ζ⁻¹ ∉ ℚ`.
+
+  This is the Niven-type statement that `2·cos(2π/n)` is irrational for
+  `n ∉ {1,2,3,4,6}`.
+
+  **Proof idea (degree argument).**  If `ζ + ζ⁻¹ = r ∈ ℚ`, then `ζ` is a root of
+  the *rational* quadratic `X² − r·X + 1` (clear `ζ + ζ⁻¹ = r` by `ζ`).  Hence
+  the minimal polynomial `minpoly ℚ ζ` divides a degree-2 polynomial, so
+  `deg(minpoly ℚ ζ) ≤ 2`.  But `minpoly ℚ ζ = Φ_n` (Mathlib:
+  `cyclotomic_eq_minpoly_rat`), whose degree is `φ(n) ≥ 3` — contradiction.
+
+  **Key Mathlib facts used:**
+  - `Polynomial.cyclotomic_eq_minpoly_rat`: `cyclotomic n ℚ = minpoly ℚ ζ`.
+  - `Polynomial.natDegree_cyclotomic`: `deg Φ_n = φ(n)`.
+  - `minpoly.dvd` + `Polynomial.natDegree_le_of_dvd`: degree bound from a root.
+
+  **Results (0 axioms, 0 sorries):**
+  1. `trace_not_rational`       : `φ(n) ≥ 3 → ζ + ζ⁻¹ ∉ range(ℚ → ℂ)`.
+  2. `fifthRoot_trace_not_rational` : concrete instance `n = 5`
+       (`2·cos(2π/5) = (√5 − 1)/2` is irrational).
+
+  ## References
+  - Niven, I. (1956). "Irrational Numbers." Carus Math. Monographs, Thm 3.9.
+  - Washington, L. (1997). "Introduction to Cyclotomic Fields." §2 (real subfield).
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 800000
+set_option linter.unusedVariables false
+
+open Polynomial
+
+namespace NthRootIrrationalOQ01OQ01Real
+
+noncomputable section
+
+-- ============================================================================
+-- Main theorem: the cyclotomic "trace" ζ + ζ⁻¹ is irrational when φ(n) ≥ 3
+-- ============================================================================
+
+/-- **Irrationality of the real cyclotomic generator.**  If `ζ : ℂ` is a
+    primitive `n`-th root of unity with `φ(n) ≥ 3`, then `ζ + ζ⁻¹` (which equals
+    `2·cos(2π/n)`) is not the image of any rational number; i.e. it is
+    irrational.
+
+    The bound `φ(n) ≥ 3` is sharp: `φ(n) ≤ 2` exactly for `n ∈ {1,2,3,4,6}`,
+    where `2·cos(2π/n) ∈ {2, −2, −1, 0, 1}` is rational. -/
+theorem trace_not_rational {n : ℕ} (hn : 3 ≤ n.totient) {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) :
+    ζ + ζ⁻¹ ∉ Set.range ((algebraMap ℚ ℂ) : ℚ → ℂ) := by
+  rintro ⟨r, hr⟩
+  -- `n > 0` from `φ(n) ≥ 3 > 0`.
+  have hnpos : 0 < n := Nat.totient_pos.mp (by omega)
+  -- `ζ ≠ 0` (a primitive root of unity is a unit).
+  have hζ0 : ζ ≠ 0 := by
+    intro h
+    have hpow : ζ ^ n = 1 := hζ.pow_eq_one
+    rw [h, zero_pow hnpos.ne'] at hpow
+    exact one_ne_zero hpow.symm
+  -- `ζ` is a root of the rational quadratic `q = X² − r·X + 1`.
+  set q : ℚ[X] := X ^ 2 - C r * X + 1 with hq
+  have haeval : (aeval ζ) q = 0 := by
+    have hmul : ζ * ζ⁻¹ = 1 := mul_inv_cancel₀ hζ0
+    rw [hq]
+    simp only [map_add, map_sub, map_mul, map_pow, aeval_X, aeval_C, map_one]
+    rw [hr]
+    linear_combination -hmul
+  have hqdeg : q.natDegree = 2 := by rw [hq]; compute_degree!
+  have hqne : q ≠ 0 := by
+    intro h
+    rw [h, natDegree_zero] at hqdeg
+    omega
+  -- The minimal polynomial divides `q`, so its degree is ≤ 2.
+  have hdvd : minpoly ℚ ζ ∣ q := minpoly.dvd ℚ ζ haeval
+  have hle : (minpoly ℚ ζ).natDegree ≤ q.natDegree := natDegree_le_of_dvd hdvd hqne
+  -- But `minpoly ℚ ζ = Φ_n`, of degree `φ(n) ≥ 3`.
+  have hcyc : cyclotomic n ℚ = minpoly ℚ ζ := cyclotomic_eq_minpoly_rat hζ hnpos
+  have hmindeg : (minpoly ℚ ζ).natDegree = n.totient := by
+    rw [← hcyc, natDegree_cyclotomic]
+  rw [hmindeg, hqdeg] at hle
+  omega
+
+-- ============================================================================
+-- Concrete instance: 2·cos(2π/5) = (√5 − 1)/2 is irrational
+-- ============================================================================
+
+/-- The real cyclotomic generator for `n = 5`, namely
+    `e^{2πi/5} + e^{-2πi/5} = 2·cos(2π/5) = (√5 − 1)/2`, is irrational.
+    Here `φ(5) = 4 ≥ 3`. -/
+theorem fifthRoot_trace_not_rational :
+    Complex.exp (2 * ↑Real.pi * Complex.I / (5 : ℕ)) +
+        (Complex.exp (2 * ↑Real.pi * Complex.I / (5 : ℕ)))⁻¹ ∉
+      Set.range ((algebraMap ℚ ℂ) : ℚ → ℂ) :=
+  trace_not_rational (n := 5) (by decide)
+    (Complex.isPrimitiveRoot_exp 5 (by norm_num))
+
+end
+
+end NthRootIrrationalOQ01OQ01Real

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -85,3 +85,58 @@ Numerically pre-verified (sympy): φ(n) ≥ 2 for all 3 ≤ n ≤ 200; deg Φ_n 
 ## Dead ends
 
 - "Irrational real root of Φ_n" — vacuous; Φ_n has no real roots for n ≥ 3.
+
+---
+
+## Result (Session 2, 2026-06-15, REVISIT → ACT) — real subfield SOLVED
+
+New file `proofs/Proofs/NthRootIrrationalOQ01OQ01Real.lean` (0 sorries, 0 axioms,
+build-pending — Docker/Aristotle blackout at authoring). Separate file to avoid
+colliding with the still-open S1 PR #24349 (`NthRootIrrationalOQ01OQ01.lean`).
+
+Closes the "maximal real subfield" follow-up the S1 notes flagged as a Mathlib
+gap. **The gap was illusory.** S1 thought we'd need the minimal polynomial *of*
+`2cos(2π/n)` (absent in Mathlib). Instead the degree argument runs the other way
+and needs nothing new:
+
+1. `trace_not_rational` — for `ζ : ℂ` a primitive `n`-th root of unity with
+   `φ(n) ≥ 3`, `ζ + ζ⁻¹ = 2·cos(2π/n) ∉ Set.range (algebraMap ℚ ℂ)`
+   (i.e. irrational). **Proof:** if `ζ + ζ⁻¹ = r ∈ ℚ`, clear by `ζ` to get
+   `ζ² − r·ζ + 1 = 0`, so `ζ` is a root of the *rational* quadratic
+   `q = X² − C r·X + 1`. Then `minpoly ℚ ζ ∣ q` (`minpoly.dvd`), so
+   `deg(minpoly ℚ ζ) ≤ deg q = 2` (`natDegree_le_of_dvd`). But
+   `minpoly ℚ ζ = Φ_n` (`Polynomial.cyclotomic_eq_minpoly_rat`), of degree
+   `φ(n) ≥ 3` (`natDegree_cyclotomic`) — contradiction by `omega`.
+2. `fifthRoot_trace_not_rational` — concrete `n = 5`: `2·cos(2π/5) = (√5−1)/2`
+   is irrational (`φ(5) = 4`), via `Complex.isPrimitiveRoot_exp 5`.
+
+### Key insight
+
+The honest content of the real subfield is captured WITHOUT building any
+"minpoly of cos" machinery: the *trace* `ζ + ζ⁻¹` being rational forces `ζ` to
+satisfy a degree-2 rational polynomial, contradicting `deg Φ_n = φ(n) ≥ 3`. The
+sharp bound is `φ(n) ≥ 3` (⇔ `n ∉ {1,2,3,4,6}`), matching Niven's theorem: the
+only rational values of `2·cos(2π/n)` are `{2, −2, −1, 0, 1}`.
+
+### Mathlib lemmas used (all name-checked vs leanprover-community/mathlib4 master)
+
+- `Polynomial.cyclotomic_eq_minpoly_rat` (RingTheory/Polynomial/Cyclotomic/Roots.lean:178)
+- `Polynomial.natDegree_cyclotomic`, `minpoly.dvd` (FieldTheory/Minpoly/Field.lean:72;
+  args `(A) (x)` explicit), `Polynomial.natDegree_le_of_dvd`
+  (Algebra/Polynomial/Degree/Domain.lean:61), `Nat.totient_pos` (iff form).
+
+### Fragile points if CI fails
+
+- `by decide` for `3 ≤ Nat.totient 5` — fallback `rw [Nat.totient_prime (by norm_num)]`.
+- `compute_degree!` for `q.natDegree = 2` — fallback: prove `q.Monic` (`monicity!`)
+  for `q ≠ 0` and use `≤ 2` from `compute_degree`.
+- `rw [hr]` where `hr : algebraMap ℚ ℂ r = ζ + ζ⁻¹` after `simp` emits
+  `aeval_C` — if the coercion forms diverge, replace `rw [hr]; linear_combination -hmul`
+  with `linear_combination (-ζ) * hr - hmul` (no rewrite).
+- Register `Proofs.NthRootIrrationalOQ01OQ01Real` in `proofs/Proofs.lean` once a
+  backend is available (left UNREGISTERED to protect auto-merge).
+
+### Next follow-up (still genuinely open)
+
+- The *exact degree* `[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` (not just `> 1`) — would need the
+  minimal polynomial of the real generator, still absent in Mathlib.


### PR DESCRIPTION
## Summary

S2 ACT for `nth-root-irrational-oq-01-oq-01`. Formalizes the **maximal real subfield** direction the S1 PR (#24349) flagged as an open follow-up / Mathlib gap.

**The gap was illusory.** S1 expected to need the minimal polynomial *of* `2·cos(2π/n)` (absent in Mathlib). The degree argument runs the other way and needs nothing new:

> If `ζ + ζ⁻¹ = r ∈ ℚ`, clear by `ζ` to get `ζ² − r·ζ + 1 = 0`, so `ζ` is a root of the rational quadratic `X² − r·X + 1`. Hence `minpoly ℚ ζ ∣ q` and `deg(minpoly ℚ ζ) ≤ 2`. But `minpoly ℚ ζ = Φ_n` of degree `φ(n) ≥ 3` — contradiction.

New file `proofs/Proofs/NthRootIrrationalOQ01OQ01Real.lean` (0 axioms, 0 sorries):

1. `trace_not_rational` — `φ(n) ≥ 3 → ζ + ζ⁻¹ = 2·cos(2π/n) ∉ Set.range (algebraMap ℚ ℂ)`.
2. `fifthRoot_trace_not_rational` — concrete `n = 5`: `2·cos(2π/5) = (√5−1)/2` is irrational.

The bound `φ(n) ≥ 3` (⇔ `n ∉ {1,2,3,4,6}`) is sharp, matching Niven's theorem.

## Notes

- Separate file from the still-open S1 PR #24349 to avoid collision.
- **Build-pending / UNREGISTERED**: authored under Docker + Aristotle blackout. All Mathlib identifiers name-checked against `leanprover-community/mathlib4` master (`cyclotomic_eq_minpoly_rat`, `minpoly.dvd`, `natDegree_le_of_dvd`, `natDegree_cyclotomic`, `Nat.totient_pos`). Left out of `proofs/Proofs.lean` until a backend can compile it (protects auto-merge).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ01OQ01Real` once Docker is available.
- [ ] Register in `proofs/Proofs.lean` after a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)