### PR TITLE
research(erdos-653-oq-01): discharge g_le_n axiom to theorem (3→2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -141,10 +141,27 @@ def erdos653Conjecture : Prop :=
 /-- **Trivial Lower Bound:**
 g(n) ≥ 1 for n ≥ 2 (at least one R-value exists). -/
 /--
-**Trivial Upper Bound:**
-g(n) ≤ n (can't have more distinct values than points).
+**Trivial Upper Bound:** `g(n) ≤ n` (can't have more distinct values than points).
+
+Elementary and unconditional: for any `n`-point configuration `S`, the R-value set
+`rValueSet S = S.image (distinctDistCount S)` is the image of `S` under a single
+function, so its cardinality cannot exceed `S.card = n` (`Finset.card_image_le`).
+Since `g n` is the supremum of these counts, `g n ≤ n`.
+
+(Discharged from an axiom to a theorem: previously a stated assumption, now machine
+checked. The sharper `g_le_n_sub_one` below gives `g(n) ≤ n - 1` for `n ≥ 2`.)
 -/
-axiom g_le_n : ∀ n : ℕ, g n ≤ n
+theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
+  intro n
+  unfold g
+  apply csSup_le'
+  intro k hk
+  simp only [Set.mem_setOf_eq] at hk
+  obtain ⟨S, hcard, rfl⟩ := hk
+  calc numDistinctRValues S
+      = (rValueSet S).card := rfl
+    _ ≤ S.card := by unfold rValueSet; exact Finset.card_image_le
+    _ = n := hcard
 
 /--
 **Monotonicity:**

--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -180,3 +180,53 @@ is OPEN and untouched; the two literature axioms (`csizmadia_bound`, `upper_boun
 correct citations. Remaining ACT item: the elementary lower bound `g(n) ≥ ⌈n/2⌉` (S1 #3),
 which needs an explicit collinear membership witness into the sSup set — deferred (heavier,
 build-gated).
+
+## Session 2026-06-15 (Session 4, researcher-1, ACT — discharge the `g_le_n` axiom)
+
+**Mode:** CONTINUE / ACT. **Outcome:** eliminated one axiom (3 → 2). Dual blackout
+persists this session (`docker info` times out → DOCKER_DOWN; Aristotle MCP `prove`
+returns "Resource not found" 404 despite the tool being exposed), so the new theorem
+is **build-pending** but is a strict simplification of an already-building proof.
+
+**Delta shipped:** `axiom g_le_n : ∀ n, g n ≤ n` → `theorem g_le_n` (proved).
+
+```lean
+theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
+  intro n
+  unfold g
+  apply csSup_le'
+  intro k hk
+  simp only [Set.mem_setOf_eq] at hk
+  obtain ⟨S, hcard, rfl⟩ := hk
+  calc numDistinctRValues S
+      = (rValueSet S).card := rfl
+    _ ≤ S.card := by unfold rValueSet; exact Finset.card_image_le
+    _ = n := hcard
+```
+
+**Why high-confidence despite no build:** the proof skeleton (`unfold g; apply csSup_le';
+intro k hk; simp only [Set.mem_setOf_eq] at hk; obtain ⟨S, hcard, rfl⟩ := hk`) is byte-for-byte
+the opening of `g_le_n_sub_one`, which is on `origin/main` and was aggregate-build-verified
+by the `Nat.sSup_le → csSup_le'` fix (#24368). The continuation is *simpler* than
+`g_le_n_sub_one`'s: it bounds `numDistinctRValues S = (rValueSet S).card ≤ S.card = n`
+by a single `Finset.card_image_le` (already used at line ~219 in the same file), with
+no lower-bound / `Icc` machinery. So this is a proper sub-proof of code that already builds.
+
+**Axiom status now (post-session):** 2 axioms, both genuine literature citations and
+correctly left as axioms per the Axiom Integrity Policy:
+- `csizmadia_bound` (g(n) > 7n/10) — deep, out of reach (no incidence geometry in Mathlib);
+- `upper_bound` (g(n) < n - cn^{2/3}) — deep gap result, likewise out of reach.
+
+**Note on `Nat.sSup_le`:** confirmed (again, vs sibling `~/GitHub/mathlib4`) that
+`Nat.sSup_le` does **not** exist — ℕ is `ConditionallyCompleteLinearOrderBot`; the
+correct lemma is `csSup_le'` (`Mathlib/Order/ConditionallyCompleteLattice/Basic.lean:609`,
+signature `(h : a ∈ upperBounds s) : sSup s ≤ a`). The worktree had briefly diverged with
+the stale `Nat.sSup_le`; `origin/main` is already fixed.
+
+**meta.json:** axiomCount 3→2, theoremCount 3→4, lineCount 310→327; assumptions/sections
+text updated; originalContributions reclassifies `g_le_n` as a proved theorem.
+
+**Honest assessment:** modest, real progress — one axiom discharged, no new axioms/sorries,
+no scaffolding added. The OQ (`g(n) ≥ (1-o(1))n`) is OPEN and untouched. The remaining
+ACT item is still the elementary lower bound `g(n) ≥ ⌈n/2⌉` (S1 #3), which needs an
+explicit collinear membership witness into the sSup set (heavier; build-gated; deferred).

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -61,13 +61,13 @@
       "IsRegularPolygon: regular polygon predicate",
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
-      "g_le_n axiom: g(n) ≤ n",
+      "g_le_n theorem: g(n) ≤ n (proved, discharged from axiom via Finset.card_image_le)",
       "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)"
     ],
-    "axiomCount": 3,
-    "lineCount": 310,
-    "assumptions": "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries. g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is a proved theorem strictly sharper than the g_le_n axiom.",
-    "theoremCount": 3,
+    "axiomCount": 2,
+    "lineCount": 327,
+    "assumptions": "2 axioms: csizmadia_bound (g(n) > 7n/10, Csizmadia) and upper_bound (g(n) < n - cn^{2/3}), both genuine literature results. 0 sorries. g_le_n (g(n) ≤ n) and the sharper g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) are now proved theorems.",
+    "theoremCount": 4,
     "definitionCount": 13
   },
   "overview": {
@@ -132,10 +132,10 @@
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "g_le_n axiom; g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
+      "summary": "g_le_n theorem (g(n) ≤ n, proved); g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
       "startLine": 138,
-      "endLine": 210,
-      "mathContext": "g_le_n axiom (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
+      "endLine": 227,
+      "mathContext": "g_le_n theorem (g(n) ≤ n, discharged from axiom) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
     },
     {
       "id": "special-configs",
@@ -203,9 +203,9 @@
       "Real"
     ],
     "namespace": "Erdos653",
-    "lineCount": 310,
-    "axiomCount": 3,
-    "theoremCount": 3,
+    "lineCount": 327,
+    "axiomCount": 2,
+    "theoremCount": 4,
     "definitionCount": 13,
     "path": "Proofs/Erdos653Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Discharges the trivial `g_le_n` axiom (`g(n) ≤ n`) in `Erdos653Problem.lean` into a proved theorem, reducing the file's axiom count **3 → 2**.

The proof bounds `numDistinctRValues S = (rValueSet S).card ≤ S.card = n` via a single `Finset.card_image_le` (the R-value set is the image of `S` under `distinctDistCount S`). Its skeleton (`unfold g; apply csSup_le'; intro k hk; simp only [Set.mem_setOf_eq] at hk; obtain ⟨S, hcard, rfl⟩ := hk`) is identical to the already-present, building `g_le_n_sub_one`, and the continuation is strictly simpler.

The two remaining axioms — `csizmadia_bound` (g(n) > 7n/10) and `upper_bound` (g(n) < n − cn^{2/3}) — are genuine deep literature results (no incidence-geometry machinery in the pinned Mathlib) and are correctly left as axioms per the Axiom Integrity Policy.

- axioms: 3 → 2; theorems: 3 → 4; 0 sorries; lineCount 310 → 327
- meta.json updated (axiomCount, theoremCount, assumptions, sections, originalContributions)

## Status
**Outcome**: progress (one axiom eliminated; no new axioms/sorries)
**Build**: build-pending — Docker unavailable and Aristotle MCP returning 404 this session; proof is a strict sub-proof of code already verified on `main` (post-#24368 `csSup_le'` fix). Flag build-before-merge (registered file).
**Next Steps**: elementary lower bound `g(n) ≥ ⌈n/2⌉` via collinear construction (needs sSup membership witness); the OQ `g(n) ≥ (1-o(1))n` remains OPEN.

🤖 Generated by researcher-1