### PR TITLE
Enrich Roth's Theorem: cross-references

### DIFF
--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -67,6 +67,21 @@
       "targetId": "szemeredi-theorem",
       "relationship": "special-case",
       "description": "Roth's theorem is the k=3 case of Szemerédi's theorem on k-APs in dense sets"
+    },
+    {
+      "targetId": "erdos-1097",
+      "relationship": "related",
+      "description": "Studies the fine structure of the same objects — three-term arithmetic progressions — asking how many distinct common differences occur, whereas Roth's theorem guarantees a 3-AP exists in any dense set"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Provides the abstract Parseval identity ∑|ĉₙ|² = ∫|f|² for Fourier series; Roth's proof relies on the finite-group analog `parseval_on_zmod` (∑_r ‖Â(r)‖² = |A|·N over ℤ/Nℤ), the same energy-conservation principle in the discrete setting"
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Companion classical theorem about arithmetic progressions, via complementary methods: Dirichlet locates primes inside a fixed AP using L-functions and characters, while Roth locates an AP inside a dense set using Fourier analysis on ℤ/Nℤ — both rest on character/orthogonality machinery"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `roth-theorem`. This is a deep, well-documented entry (1401-line Fourier-analytic formalization, 42 theorems) whose only enrichment gap was cross-references — it had just one (`szemeredi-theorem`).

## Quality improvements
- **Cross-references 1 → 4**, all verified to exist and mathematically accurate:
  - `erdos-1097` (related) — "Common Differences in Three-Term Arithmetic Progressions": studies the fine structure of the very objects Roth produces (3-APs).
  - `cauchy-schwarz-oq-02-oq-01` (related) — "Parseval's Identity": the abstract `∑|ĉₙ|² = ∫|f|²` whose finite-group analog `parseval_on_zmod` (`∑_r ‖Â(r)‖² = |A|·N` over ℤ/Nℤ) is a load-bearing step in `fourier_large_coefficient`.
  - `dirichlets-theorem` (related) — complementary classical AP theorem (primes in a fixed AP via L-functions/characters) contrasted with Roth (an AP inside a dense set via Fourier analysis); honest framing of the methodological difference.

## Notes
- `pnpm build` passes.
- Axiom integrity reviewed and left **unchanged** — it is already accurate and well-calibrated: `status: axiomatized`, `axiomCount: 2` (the OQ-02 companion's Bloom–Sisask and Kelley–Meka quantitative bounds), main file 0 axioms / 0 sorries, with the `assumptions` field documenting the full chain. No overclaim.