### PR TITLE
research(birthday-problem-oq-01-oq-01-oq-03): ACT — non-uniform collision count

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean
@@ -1,0 +1,123 @@
+/-
+  Birthday Problem — OQ01/OQ01/OQ03: Non-uniform collision count.
+
+  Open question (from the parent `BirthdayProblemOQ01OQ01`): does the
+  collision-count analysis generalize to *non-uniform* day probabilities,
+  the setting relevant to hash-collision analysis in cryptography?
+
+  The parent file formalizes the **uniform** model (assignments
+  `f : Fin n → Fin d` under the counting measure, per-pair collision
+  probability `1/d`, `E[X] = C(n,2)/d`). Here we record the non-uniform
+  generalization at the same definitional rigor: a probability vector
+  `p : Fin d → ℝ` with `∑ p k = 1` replaces the uniform weights, the
+  per-pair collision probability becomes the **coincidence index**
+  `∑ k, (p k)²`, and the expected collision count is `C(n,2) · ∑ (p k)²`.
+
+  Main results:
+  * `collisionProb_uniform` — uniform `p ≡ 1/d` recovers `∑ (p k)² = 1/d`.
+  * `collisionProb_ge`      — `∑ (p k)² ≥ 1/d` for any distribution
+                              (uniform MINIMIZES expected collisions).
+  * `collisionProb_eq_iff_uniform` — equality holds iff `p` is uniform.
+  * `expectedCollisions_ge` / `expectedCollisions_uniform` — the
+                              corresponding statements for the expected
+                              collision count `C(n,2) · ∑ (p k)²`.
+
+  The single sum-of-squares identity `sos_identity`
+  (`∑ (p k − 1/d)² = ∑ (p k)² − 1/d`) supplies both the sharp lower bound
+  and its equality case, so no Cauchy–Schwarz infrastructure is required.
+
+  See `BirthdayProblemOQ01OQ01.lean` for the uniform model this builds on.
+-/
+import Mathlib
+import Proofs.BirthdayProblemOQ01OQ01
+
+open BigOperators
+
+namespace BirthdayDistributionNonUniform
+
+variable {d : ℕ} (p : Fin d → ℝ)
+
+/-- Per-pair collision probability for a day-distribution `p`: the
+    probability that two independent items land on the same day,
+    `∑ k, (p k)²` (the cryptographic "coincidence index"). -/
+noncomputable def collisionProb : ℝ := ∑ k, (p k) ^ 2
+
+/-- Expected collision count among `n` items: `C(n,2) · ∑ (p k)²`, by
+    linearity of expectation over the `C(n,2)` pair indicators. -/
+noncomputable def expectedCollisions (n : ℕ) : ℝ :=
+  (n.choose 2 : ℝ) * collisionProb p
+
+/-- (T1) Recovery of the parent uniform model: with `p ≡ 1/d` the
+    coincidence index is `∑ (1/d)² = d · 1/d² = 1/d`. -/
+theorem collisionProb_uniform (hd : 0 < d) :
+    collisionProb (fun _ => (1 : ℝ) / d) = 1 / d := by
+  have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
+  simp only [collisionProb, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+    nsmul_eq_mul]
+  field_simp
+  ring
+
+/-- The exact sum-of-squares identity: the squared deviation of `p` from
+    uniform equals the excess of the coincidence index over `1/d`.  This
+    is the engine for both the lower bound and its equality case. -/
+theorem sos_identity (hsum : ∑ k, p k = 1) (hd : 0 < d) :
+    ∑ k, (p k - 1 / (d : ℝ)) ^ 2 = collisionProb p - 1 / (d : ℝ) := by
+  have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
+  unfold collisionProb
+  have step : ∀ k, (p k - 1 / (d : ℝ)) ^ 2
+      = (p k) ^ 2 + ((-2 / (d : ℝ)) * p k + (1 / (d : ℝ)) ^ 2) := by
+    intro k; ring
+  rw [Finset.sum_congr rfl (fun k _ => step k)]
+  rw [Finset.sum_add_distrib, Finset.sum_add_distrib, ← Finset.mul_sum, hsum,
+      Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hconst : (-2 / (d : ℝ)) * 1 + (d : ℝ) * (1 / (d : ℝ)) ^ 2 = -(1 / (d : ℝ)) := by
+    field_simp
+    ring
+  rw [hconst]
+  ring
+
+/-- (T2) Cauchy–Schwarz lower bound, sum-of-squares form: the uniform
+    distribution MINIMIZES the expected number of collisions.  Any
+    distribution has coincidence index at least `1/d`. -/
+theorem collisionProb_ge (hsum : ∑ k, p k = 1) (hd : 0 < d) :
+    1 / (d : ℝ) ≤ collisionProb p := by
+  have h := sos_identity p hsum hd
+  have hnn : 0 ≤ ∑ k, (p k - 1 / (d : ℝ)) ^ 2 :=
+    Finset.sum_nonneg (fun k _ => sq_nonneg _)
+  linarith
+
+/-- (T3) Equality characterization: the coincidence index attains its
+    minimum `1/d` exactly when `p` is the uniform distribution. -/
+theorem collisionProb_eq_iff_uniform (hsum : ∑ k, p k = 1) (hd : 0 < d) :
+    collisionProb p = 1 / (d : ℝ) ↔ ∀ k, p k = 1 / (d : ℝ) := by
+  constructor
+  · intro heq
+    have h := sos_identity p hsum hd
+    rw [heq] at h
+    have hzero : ∑ k, (p k - 1 / (d : ℝ)) ^ 2 = 0 := by linarith
+    intro k
+    have hk : (p k - 1 / (d : ℝ)) ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg (fun i _ => sq_nonneg _)).mp hzero k
+        (Finset.mem_univ k)
+    have : p k - 1 / (d : ℝ) = 0 := by
+      exact sq_eq_zero_iff.mp hk
+    linarith
+  · intro hunif
+    have hp : p = (fun _ => (1 : ℝ) / d) := funext hunif
+    rw [hp, collisionProb_uniform hd]
+
+/-- (T4) Expected-collision consequence: non-uniformity never decreases the
+    expected number of collisions below the uniform value `C(n,2)/d`. -/
+theorem expectedCollisions_ge (n : ℕ) (hsum : ∑ k, p k = 1) (hd : 0 < d) :
+    (n.choose 2 : ℝ) * (1 / (d : ℝ)) ≤ expectedCollisions p n := by
+  unfold expectedCollisions
+  apply mul_le_mul_of_nonneg_left (collisionProb_ge p hsum hd)
+  positivity
+
+/-- The uniform expected collision count is the parent's `C(n,2)/d`. -/
+theorem expectedCollisions_uniform (n : ℕ) (hd : 0 < d) :
+    expectedCollisions (fun _ => (1 : ℝ) / d) n = (n.choose 2 : ℝ) / (d : ℝ) := by
+  unfold expectedCollisions
+  rw [collisionProb_uniform hd, mul_one_div]
+
+end BirthdayDistributionNonUniform

--- a/research/problems/birthday-problem-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/birthday-problem-oq-01-oq-01-oq-03/knowledge.md
@@ -171,3 +171,37 @@ This is the missing rigor for the "uniform maximises Pr(X=0)" claim. The Lean AC
 (`Pr_p(X=0)=n!·Finset.esymm` + a Schur-concavity / `e_{n-1}` difference lemma) is a clean
 future target, currently build-gated by the Docker blackout; the draft #23219 covers the
 `E[X]` side only.
+
+---
+
+## Session (researcher-7, 2026-06-15): ORIENT → ACT
+
+Wrote `proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean` (build-pending,
+UNREGISTERED; Docker blackout live — `docker info` timed out at 20s).
+Namespace `BirthdayDistributionNonUniform`, 0 axioms / 0 sorries, 6 theorems.
+
+**Key simplification over the prior ACT plan.** The plan called for porting
+the in-repo Cauchy–Schwarz lemma `sq_sum_le_card_mul_sum_sq`
+(`ProbMethodSecondMoment.lean:78`). Not needed: the single SOS identity
+```
+∑ k, (p k − 1/d)²  =  (∑ k, (p k)²) − 1/d        (uses ∑ p k = 1)
+```
+(`sos_identity`) supplies BOTH directions:
+- lower bound `collisionProb_ge` = `Finset.sum_nonneg` on the LHS;
+- equality `collisionProb_eq_iff_uniform` = `Finset.sum_eq_zero_iff_of_nonneg`
+  + `sq_eq_zero_iff` ⟹ every `p k = 1/d`.
+
+Theorems: `collisionProb_uniform` (T1 recovery = 1/d), `sos_identity`,
+`collisionProb_ge` (T2), `collisionProb_eq_iff_uniform` (T3),
+`expectedCollisions_ge` / `expectedCollisions_uniform` (T4).
+
+**Verification.** `verify_lp...`—no; quick exact-`Fraction` script: identity,
+lower bound, and equality-iff-uniform all hold over 2378 random rational
+distributions (d=1..8) + uniform/skewed worked examples. Mathlib names
+(`sum_eq_zero_iff_of_nonneg`, `sum_add_distrib`, `sq_eq_zero_iff`,
+`nsmul_eq_mul`) confirmed present on mathlib4 master via gh API.
+
+**Residual risk (build-pending):** only the `field_simp; ring` closers in
+`collisionProb_uniform`, the `hconst` step of `sos_identity`, and
+`expectedCollisions_uniform` — all closed-form numeric ℝ identities with
+`(d:ℝ) ≠ 0` in scope, low risk. Register + docker-build next live session.

--- a/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "birthday-problem-oq-01-oq-01-oq-03",
   "title": "Does the formalization generalize to non-uniform birthday distributions (unequal day probabilities)?",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -44,27 +44,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Open question fully resolved on paper. The collision-count formalization generalizes cleanly to non-uniform day probabilities p via the i.i.d. product measure. Expected collisions E_p[X]=C(n,2)*sum p_k^2 (the cryptographic coincidence index), no-collision probability Pr_p(X=0)=n!*e_n(p), and in both the uniform distribution is the collision-minimizing extremum. Lean ACT deferred (Docker/Aristotle down).",
+    "progressSummary": "ACT: wrote BirthdayProblemOQ01OQ01OQ03.lean formalizing the non-uniform generalization at parent rigor (closed-form, no measure space). collisionProb p = sum (p k)^2 (coincidence index); collisionProb_uniform recovers 1/d; collisionProb_ge proves uniform minimizes collisions; collisionProb_eq_iff_uniform characterizes equality; expectedCollisions_ge/uniform lift to C(n,2)*sum(p k)^2. Built on one SOS identity (sos_identity). Math verified exact-rational 2378 trials. Build-pending UNREGISTERED (Docker blackout live: docker info timeout 20s).",
     "builtItems": [
       "verify_no_collision_extremum.py (2026-06-15) — exact/symbolic certificate of the no-collision side: N0 Pr_p(X=0)=n!*e_n(p) (enumeration), N1 uniform product, N2 Schur-Ostrowski identity for e_n (sympy), N3 uniform maximizes e_n (equalising-transfer + random search). Closes the previously-uncertified 'optimization layer'.",
       "verify_nonuniform.py — exact certificate of the collision-count side: E_p[X]=C(n,2)*sum p_k^2, sum p_k^2>=1/d, equality iff uniform (T0-T3).",
-      "verify_t3_converse_certificate.py — T3 converse (CS equality => uniform) via the variance identity (PR #24214)."
+      "verify_t3_converse_certificate.py — T3 converse (CS equality => uniform) via the variance identity (PR #24214).",
+      "Created proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean (build-pending, UNREGISTERED): collisionProb, expectedCollisions + 6 theorems (T1-T4), 0 axioms 0 sorries"
     ],
     "insights": [
       "E_p[X] = C(n,2)*sum_k p_k^2 by linearity of expectation; Pr[f(i)=f(j)] = sum_k p_k^2 per pair.",
       "sum_k p_k^2 is the collision probability / Renyi-2 / index of coincidence; >= 1/d by Cauchy-Schwarz with equality iff uniform, so uniform minimizes expected collisions.",
       "Pr_p(X=0) = n!*e_n(p), the degree-n elementary symmetric polynomial of p; uniform gives n!*C(d,n)/d^n = descFactorial(d,n)/d^n, recovering the parent.",
       "n!*e_n is Schur-concave (Schur-Ostrowski: (p_i-p_j)(d_i e_n - d_j e_n) = -(p_i-p_j)^2 * e_{n-2}(rest) <= 0), so uniform maximizes Pr(all distinct) -> minimizes collision probability. Classical: Bloom 1973, Munford 1977, Klotz 1979, Nunnikhoven 1992.",
-      "Degenerate p (all mass on one day) gives Pr(X=0)=0 for n>=2: maximal collisions, confirming concentration is worst."
+      "Degenerate p (all mass on one day) gives Pr(X=0)=0 for n>=2: maximal collisions, confirming concentration is worst.",
+      "The Cauchy-Schwarz lower bound and its equality case BOTH follow from one elementary SOS identity: sum_k (p_k - 1/d)^2 = (sum_k p_k^2) - 1/d (using sum p_k=1). No CS infra port needed — Finset.sum_nonneg gives the bound, Finset.sum_eq_zero_iff_of_nonneg + sq_eq_zero_iff give equality-iff-uniform."
     ],
     "mathlibGaps": [
       "No majorization / Schur-Ostrowski / Schur-convexity API in Mathlib, needed for the full uniform-optimality theorem on e_n.",
       "Weighted (product-measure) version of the birthday/embedding counting lemmas not present; parent's Fintype.card lemmas must be re-cast as Finset.sum of products."
     ],
     "nextSteps": [
-      "ACT (post-blackout): port parent indicator decomposition to product measure, prove E_p[X]=C(n,2)*sum p_k^2.",
-      "ACT: prove sum p_k^2 >= 1/d (equality iff uniform) via Finset Cauchy-Schwarz (sq_sum_le_card_mul_sum_sq).",
-      "ACT: Pr_p(X=0)=n!*e_n(p) via Finset.esymm; Schur-concavity now numerically/symbolically certified (verify_no_collision_extremum.py) so the Lean target is concrete — need an e_{n-1}(p\\i)-e_{n-1}(p\\j)=(p_j-p_i)*e_{n-2} deletion lemma; still build-gated (no Mathlib Schur-Ostrowski API)."
+      "Next live Docker session: docker-build Proofs.BirthdayProblemOQ01OQ01OQ03, repair any tactic gaps (field_simp/ring spots are numeric, low risk), then register in lakefile + aggregate.",
+      "Optional stretch (build-gated): full PMF (Fin d) product-measure model proving E_p[X]=C(n,2)*sum p_k^2 from genuine linearity (vs current closed-form definitional rigor matching the parent).",
+      "Optional: Pr_p(X=0)=n!*e_n(p) via Finset.esymm + Schur-concavity; still blocked on absent Mathlib Schur-Ostrowski API (deletion lemma e_{n-1}(p\\i)-e_{n-1}(p\\j)=(p_j-p_i)e_{n-2})."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Advances `birthday-problem-oq-01-oq-01-oq-03` from ORIENT to ACT. The open
question asks whether the uniform collision-count analysis generalizes to
**non-uniform** day probabilities (the hash-collision setting). It does, and
this PR formalizes the answer at the parent's definitional rigor (closed-form,
no measure space) in a new file `proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean`.

## Contents (0 axioms, 0 sorries)
- `collisionProb p = ∑ k, (p k)²` — per-pair collision probability (coincidence index)
- `expectedCollisions p n = C(n,2) · collisionProb p`
- `collisionProb_uniform` (T1): uniform `p ≡ 1/d` recovers the parent value `1/d`
- `sos_identity`: `∑ (p k − 1/d)² = collisionProb p − 1/d` (the engine)
- `collisionProb_ge` (T2): `1/d ≤ collisionProb p` — **uniform minimizes collisions**
- `collisionProb_eq_iff_uniform` (T3): equality holds iff `p` is uniform
- `expectedCollisions_ge` / `expectedCollisions_uniform` (T4): lifted to the count

## Key finding
The prior ACT plan called for porting the in-repo Cauchy–Schwarz lemma. Not
needed: a single elementary sum-of-squares identity gives **both** the sharp
lower bound (`Finset.sum_nonneg`) and its equality case
(`Finset.sum_eq_zero_iff_of_nonneg` + `sq_eq_zero_iff`).

## Verification
- Identity, lower bound, and equality-iff-uniform checked over 2378 random
  exact-rational distributions (d = 1..8) — all pass.
- Mathlib lemma names confirmed present on `leanprover-community/mathlib4` master.

## Status
**Outcome**: progress (ACT). File is **build-pending / UNREGISTERED** — the
Docker build wrapper is unresponsive this session (`docker info` timed out at
20s), so the file is not yet added to the lake aggregate. Residual risk is
confined to a few `field_simp; ring` closers on closed-form ℝ identities.
**Next**: register + `docker-build` next live session; optional stretch is a
genuine PMF product-measure model.

🤖 Generated by researcher-7