### PR TITLE
Research: zsqrtd-neg-two-oq-02 — ORIENT correction, recommended ACT already proved (S2)

### DIFF
--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -73,3 +73,70 @@ true open work, not reachable through the `x²+2y²` norm form.
 - Squares-mod-`m` residue facts: `ZMod` + `decide`.
 - The four-square theorem is in Mathlib; the three-square theorem is **not**
   (the converse is the missing deep result).
+
+---
+
+## Session 2 (researcher-4, 2026-06-15) — CORRECTION: the recommended ACT is already done
+
+**Mode**: REVISIT · **Outcome**: ORIENT correction (build-free; Docker `docker info`
+timeout >15s, so no build/edit of registered files). This session AUDITS the actual
+gallery state, which the S1 OBSERVE notes did not reflect.
+
+### Key finding: `ThreeSquares.lean` already exists and is REGISTERED
+
+`proofs/Proofs/ThreeSquares.lean` (1979 LOC, registered at `proofs/Proofs.lean:2949`,
+imports `Proofs.ZsqrtdNegTwo`) already contains a far more developed treatment than the
+S1 notes assume. **The S1-recommended ACT — "formalize squares mod 8 ⊆ {0,1,4} + the
+4-descent forward obstruction" — IS ALREADY FULLY PROVED THERE.** Do not re-derive it:
+
+- `nat_sq_mod_eight`, `int_sq_mod_eight` — squares ≡ 0,1,4 (mod 8). ✓ proved
+- `sum_three_sq_mod_eight_ne_seven` — three squares never ≡ 7 (mod 8). ✓ proved
+- `four_dvd_sum_three_sq_implies_even` + `excluded_form_not_sum_three_sq` — the full
+  4-descent **necessity** direction (`IsExcludedForm n ⟹ ¬ three squares`). ✓ proved,
+  0 axioms, by `Nat.strong_induction_on`.
+- All prime cases p ≢ 7 (mod 8) proved: p≡1,5 mod 8 via Fermat two-squares
+  (`prime_one/five_mod_eight_is_sum_three_sq`); **p≡3 mod 8 via the ℤ[√−2] bridge**
+  `ZsqrtdNegTwo.prime_three_mod_eight_is_sum_three_sq'` (ZsqrtdNegTwo.lean:463, **0 axioms**).
+
+### The REAL open work = eliminate 2 axioms in ThreeSquares.lean
+
+`grep "^axiom"` ⟹ exactly two:
+1. **`not_excluded_form_is_sum_three_sq`** (line 1665) — the entire **sufficiency**
+   direction `¬IsExcludedForm n ⟹ ∃ a b c, a²+b²+c² = n`. This is the iff's hard half;
+   `legendre_three_squares` (line 1672) pairs it with the proved necessity.
+2. **`dirichlet_key_lemma`** (line 615) — Dirichlet's 1850 representation lemma
+   (`n>1, d>0, p=dn−1 prime, −d a QR mod p ⟹ n = x²+y²+z²`), the Minkowski/lattice tool.
+
+**Axiom-reduction path (the genuine next ACT, Docker-gated):**
+- Axiom (1) should be **derived from** axiom (2) + the proved prime cases + the proved
+  reductions (`sum_three_sq_iff_four_mul`, `excluded_form_four_mul_iff`,
+  `excluded_form_of_sq_mul`). The file itself outlines this at line 1658 (~150–200 LOC:
+  case-split n mod 8, choose d, find a suitable prime, apply the key lemma). Completing
+  it turns 2 axioms into 1 — real progress.
+- Axiom (2) is the deep target: ~60% of its Minkowski infrastructure is already built
+  in-file (lines 619–1665: `dirichletEllipsoid` convex/symmetric, `dirichletScale`
+  det = R^{3/2}/d, `dirichletEllipsoid_eq_image`, `stdLattice3` covolume = 1, the
+  sublattice basis machinery). The missing piece is the Minkowski-bound count + the
+  QR ⟹ lattice-point ⟹ representation step.
+
+### ℤ[√−2] verdict (confirms #24256/#24257, now with the file open)
+The slug's premise — "prove the full three-square theorem **on top of ℤ[√−2]**" — is
+structurally bounded: ℤ[√−2] (`x²+2y²`) contributes **only** the p≡3 (mod 8) prime case
+(`prime_three_mod_eight_is_sum_three_sq'`). The general sufficiency goes through Dirichlet
++ Minkowski, not the norm form. S1's numeric "x²+2y² is a 36% subset" quantifies the same
+fact. So the open work is NOT a ℤ[√−2] task; it is axiom elimination in `ThreeSquares.lean`.
+
+### Why build-free this session
+`ThreeSquares.lean` is a REGISTERED 1979-LOC flagship; under Docker blackout, blind-editing
+it risks the aggregate build, and both axiom eliminations (~150–400 LOC of delicate
+Dirichlet/QR/Minkowski work) cannot be developed safely without a compiler. The honest,
+useful deliverable is this correction: future sessions should target the two axioms in
+`ThreeSquares.lean` with a working build, NOT re-derive the already-complete forward
+obstruction or re-attempt the ℤ[√−2] route.
+
+### Next steps
+1. **(Docker-gated, highest value)** In `ThreeSquares.lean`, derive
+   `not_excluded_form_is_sum_three_sq` from `dirichlet_key_lemma` + proved prime/reduction
+   lemmas (file's own line-1658 recipe). Eliminates 1 of 2 axioms.
+2. **(Deep)** Discharge `dirichlet_key_lemma` via the in-file Minkowski infrastructure.
+3. Do NOT re-formalize the forward obstruction (done) or pursue ℤ[√−2] for the full theorem.


### PR DESCRIPTION
## Summary
Session 2 (REVISIT) on `zsqrtd-neg-two-oq-02` (Legendre three-square theorem on top of ℤ[√−2]). An audit of the actual gallery state, which the S1 OBSERVE notes did not reflect. Build-free (Docker down).

## Key correction
The S1-recommended ACT — "formalize squares mod 8 ⊆ {0,1,4} + the 4-descent forward obstruction" — **is already fully proved** in the registered flagship `proofs/Proofs/ThreeSquares.lean` (1979 LOC, `Proofs.lean:2949`):
- `excluded_form_not_sum_three_sq` — full **necessity** direction, 0 axioms.
- All prime cases p ≢ 7 (mod 8), including **p≡3 mod 8 via the 0-axiom ℤ[√−2] bridge** `ZsqrtdNegTwo.prime_three_mod_eight_is_sum_three_sq'`.

## The real open work: eliminate 2 axioms in ThreeSquares.lean
1. `not_excluded_form_is_sum_three_sq` (line 1665) — the entire **sufficiency** direction. Should be **derived from** axiom (2) + the proved prime cases + reductions (`sum_three_sq_iff_four_mul`, `excluded_form_four_mul_iff`); the file outlines this at line 1658 (~150–200 LOC). Completing it turns 2 axioms → 1.
2. `dirichlet_key_lemma` (line 615) — Minkowski/lattice representation lemma; ~60% of its infrastructure is already built in-file (lines 619–1665).

## ℤ[√−2] verdict
Confirms #24256/#24257 with the file open: ℤ[√−2] contributes **only** the p≡3 (mod 8) prime case. The general sufficiency goes through Dirichlet + Minkowski, not the `x²+2y²` norm form — so the open work is axiom elimination in `ThreeSquares.lean`, not a ℤ[√−2] task.

## Why build-free
`ThreeSquares.lean` is a registered 1979-LOC flagship; under Docker blackout, blind-editing it risks the aggregate build, and both axiom eliminations (delicate Dirichlet/QR/Minkowski work) need a compiler to develop safely.

## Files Modified
- `research/problems/zsqrtd-neg-two-oq-02/knowledge.md`

## Status
**Outcome**: surveyed (ORIENT correction; redirects future sessions away from already-complete work)
**Next Steps**: with Docker, derive `not_excluded_form_is_sum_three_sq` from `dirichlet_key_lemma` (eliminate 1 axiom); then discharge `dirichlet_key_lemma` via the in-file Minkowski infra. Do NOT re-derive the forward obstruction or pursue ℤ[√−2] for the full theorem.

🤖 Generated by researcher-4