### PR TITLE
research(inclusion-exclusion-oq-01-oq-03): ORIENT — textbook divisor-form Möbius inversion

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
@@ -1,0 +1,77 @@
+/-
+  OQ-01-OQ-03: Classical (divisor-form) Möbius inversion
+  (inclusion-exclusion-oq-01-oq-03)
+
+  Open question of the parent gallery entry `inclusion-exclusion-oq-01`
+  (which already proves the divisor–totient identity `Σ_{d|n} φ(d) = n` via the
+  inclusion–exclusion sieve):
+
+      Formalize Möbius inversion:
+          f(n) = Σ_{d | n} g(d)   ⟺   g(n) = Σ_{d | n} μ(d) · f(n/d).
+
+  This is the number-theoretic incarnation of inclusion–exclusion (the Möbius
+  function `μ` of the divisor lattice is the IE sign).
+
+  ── What Mathlib already has, and what this adds ──────────────────────────────
+
+  Mathlib v4.26 proves Möbius inversion, but in **antidiagonal** form
+  (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`):
+
+      (∀ n>0, Σ_{i ∈ n.divisors} f i = g n) ↔
+        (∀ n>0, Σ_{x ∈ n.divisorsAntidiagonal} μ x.1 · g x.2 = f n).
+
+  The textbook statement the gallery question asks for uses the **divisor** sum
+  `Σ_{d | n} μ(d) · f(n/d)` instead of the antidiagonal sum.  The bridge is
+  `Nat.sum_divisorsAntidiagonal`:
+      Σ_{x ∈ n.divisorsAntidiagonal} F x.1 x.2 = Σ_{d ∈ n.divisors} F d (n/d).
+
+  `moebius_inversion_divisors` below states and proves the textbook form by
+  wiring these two lemmas (plus `eq_comm` to match the gallery's orientation).
+  This is a thin but faithful bridge — the mathematical depth lives in Mathlib's
+  `sum_eq_iff_sum_mul_moebius_eq`; the value here is exposing the classical
+  `Σ_{d|n} μ(d) f(n/d)` shape that downstream gallery work expects.
+
+  Numerically cross-checked (all n ≤ 400, random integer data, both directions,
+  μ sanity, and the Euler-φ anchor) in
+  `research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py`
+  (ALL PASS).
+
+  Status: 0 axioms, 0 sorries intended.  Build-pending (authored under a Docker +
+  Aristotle blackout); UNREGISTERED in `Proofs/Proofs.lean` until it compiles in a
+  live session.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Moebius
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Tactic
+
+open Finset Nat ArithmeticFunction
+open scoped ArithmeticFunction.Moebius
+
+namespace InclusionExclusionOQ01OQ03
+
+variable {R : Type*} [CommRing R]
+
+/-- **Classical Möbius inversion (divisor form).**  For functions `f, g : ℕ → R`
+    into a commutative ring,
+        `f(n) = Σ_{d | n} g(d)   ↔   g(n) = Σ_{d | n} μ(d) · f(n/d)`
+    (for all `n > 0`).  Bridges Mathlib's antidiagonal
+    `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to the textbook divisor
+    sum via `Nat.sum_divisorsAntidiagonal`. -/
+theorem moebius_inversion_divisors {f g : ℕ → R} :
+    (∀ n > 0, f n = ∑ d ∈ n.divisors, g d) ↔
+      (∀ n > 0, g n = ∑ d ∈ n.divisors, (μ d : R) * f (n / d)) := by
+  constructor
+  · intro h n hn
+    have hM := (sum_eq_iff_sum_mul_moebius_eq (R := R) (f := g) (g := f)).mp
+      (fun m hm => (h m hm).symm) n hn
+    rw [Nat.sum_divisorsAntidiagonal (fun a b => (μ a : R) * f b)] at hM
+    exact hM.symm
+  · intro h n hn
+    have hM : ∀ m > 0, ∑ x ∈ m.divisorsAntidiagonal, (μ x.1 : R) * f x.2 = g m := by
+      intro m hm
+      rw [Nat.sum_divisorsAntidiagonal (fun a b => (μ a : R) * f b)]
+      exact (h m hm).symm
+    exact ((sum_eq_iff_sum_mul_moebius_eq (R := R) (f := g) (g := f)).mpr hM n hn).symm
+
+end InclusionExclusionOQ01OQ03

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
@@ -1,0 +1,72 @@
+# Knowledge Base: inclusion-exclusion-oq-01-oq-03
+
+Open question of `inclusion-exclusion-oq-01`:
+
+> Formalize Möbius inversion: `f(n) = Σ_{d|n} g(d)  ⟺  g(n) = Σ_{d|n} μ(d)·f(n/d)`.
+
+This is the number-theoretic form of inclusion–exclusion (μ = IE sign on the
+divisor lattice). The parent already proves the special case `Σ_{d|n} φ(d) = n`.
+
+---
+
+## Insights
+
+### Session 2026-06-15 (ORIENT, researcher-9) — Mathlib has it in antidiagonal form; bridge to textbook form
+
+**Mode**: FRESH. **Outcome**: ORIENT + build-pending Lean bridge; all-pass verifier.
+Honest framing: the mathematical depth is already in Mathlib; this session's
+contribution is exposing the **textbook divisor-sum** shape the gallery wants.
+
+**Mathlib already proves Möbius inversion** (v4.26.0, pin `2df2f0150c27`), but in
+**antidiagonal** form — `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`
+(`Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:240`, `[NonAssocRing R]`):
+
+    (∀ n>0, Σ_{i ∈ n.divisors} f i = g n) ↔
+      (∀ n>0, Σ_{x ∈ n.divisorsAntidiagonal} μ x.1 · g x.2 = f n).
+
+Companions: `sum_eq_iff_sum_smul_moebius_eq` (AddCommGroup, `•`),
+`prod_eq_iff_prod_pow_moebius_eq` (multiplicative), and `_on`/`_on'` variants
+restricted to a divisor-closed set.
+
+**The textbook form** `g(n) = Σ_{d|n} μ(d)·f(n/d)` differs only by replacing the
+antidiagonal sum with a divisor sum. The bridge is `Nat.sum_divisorsAntidiagonal`
+(`Mathlib/NumberTheory/Divisors.lean`, the `@[to_additive]` partner of
+`prod_divisorsAntidiagonal`):
+
+    Σ_{x ∈ n.divisorsAntidiagonal} F x.1 x.2 = Σ_{d ∈ n.divisors} F d (n/d).
+
+So the textbook theorem is `sum_eq_iff_sum_mul_moebius_eq` rewritten by
+`Nat.sum_divisorsAntidiagonal (fun a b => μ a · f b)` (plus `eq_comm` to match the
+gallery orientation `f(n) = Σ g(d)`).
+
+**Durable verification** `verify_moebius_inversion.py` (stdlib, exhaustive
+n ≤ 400, random ℤ data) — ALL PASS:
+- (A) forward→inverse `g(n) = Σ_{d|n} μ(d) f(n/d)`;
+- (B) inverse→forward `f(n) = Σ_{d|n} g(d)`;
+- (C) μ sanity + the convolution `Σ_{d|n} μ(d) = [n=1]`;
+- (D) Euler-φ anchor: `Σ_{d|n} φ(d) = n` and `φ(n) = Σ_{d|n} μ(d)·(n/d)`.
+
+**Lean artifact** (build-pending, UNREGISTERED)
+`proofs/Proofs/InclusionExclusionOQ01OQ03.lean`:
+`moebius_inversion_divisors {f g : ℕ → R} [CommRing R]` — the textbook iff,
+proved by the two-lemma bridge above.
+
+---
+
+## Next steps
+
+1. **ACT (live build).** Compile `InclusionExclusionOQ01OQ03.lean`; if a name
+   needs adjustment (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`,
+   `Nat.sum_divisorsAntidiagonal`, `μ` scoped notation), repair and register.
+2. **φ corollary.** Add `(φ n : ℤ) = Σ_{d|n} μ(d)·((n/d : ℕ) : ℤ)` as a one-line
+   consequence (`f = Nat.cast`, `g = φ`, using `Nat.sum_totient`), tying back to
+   the parent's `Σ_{d|n} φ(d) = n`.
+3. **General poset IE (optional, harder).** Möbius inversion over an arbitrary
+   locally-finite poset (Rota); Mathlib's `Mathlib/Order/...` incidence-algebra
+   coverage would need checking — out of scope for this divisor-lattice OQ.
+
+## Dead Ends / Non-starters
+
+- Re-deriving Möbius inversion from scratch: unnecessary — Mathlib has it
+  (`sum_eq_iff_sum_mul_moebius_eq`); only the antidiagonal→divisor presentation
+  was missing.

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
@@ -1,0 +1,36 @@
+# Research State: inclusion-exclusion-oq-01-oq-03
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 1
+**Last Updated**: 2026-06-15 (researcher-9)
+
+## Current Focus
+Classical (divisor-form) Möbius inversion `f(n)=Σ_{d|n}g(d) ⟺ g(n)=Σ_{d|n}μ(d)f(n/d)`.
+Mathlib already proves it in ANTIDIAGONAL form (sum_eq_iff_sum_mul_moebius_eq);
+contribution is the textbook divisor-sum presentation via Nat.sum_divisorsAntidiagonal.
+
+## Active Approach
+Build-free ORIENT (Docker + Aristotle blackout). All-pass verifier
+verify_moebius_inversion.py (both directions, μ sanity, φ anchor). Build-pending
+UNREGISTERED Lean theorem moebius_inversion_divisors bridging the two Mathlib lemmas.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- Lean ACT is Docker-gated (no build this session); file left UNREGISTERED.
+- No Mathlib gap; this is a presentation bridge over an existing theorem.
+
+## Next Action
+When Docker returns: build/register InclusionExclusionOQ01OQ03.lean; add the
+Euler-φ corollary `φ(n)=Σ_{d|n}μ(d)(n/d)` via Nat.sum_totient.
+
+## Iteration log
+* **S1** (2026-06-15, researcher-9, ORIENT): identified Mathlib's antidiagonal
+  Möbius inversion + the Nat.sum_divisorsAntidiagonal bridge; build-pending
+  textbook-form theorem; all-pass verifier.

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Durable verifier for inclusion-exclusion-oq-01-oq-03:
+classical (divisor) Mobius inversion
+    f(n) = sum_{d | n} g(d)      <==>     g(n) = sum_{d | n} mu(d) * f(n/d).
+
+This is the number-theoretic form of inclusion-exclusion.  Python stdlib only;
+exhaustive over n in 1..N for random integer-valued g (seeded), ALL PASS expected.
+
+Checks:
+  (A) FORWARD->INVERSE.  Given arbitrary g, define f(n) = sum_{d|n} g(d).  Then
+      sum_{d|n} mu(d) * f(n/d) == g(n)  for all n.
+  (B) INVERSE->FORWARD.  Given arbitrary f, define g(n) = sum_{d|n} mu(d) f(n/d).
+      Then sum_{d|n} g(d) == f(n)  for all n.
+  (C) mu sanity: mu(1)=1; mu(n)=0 iff n not squarefree; |mu(n)|=1 iff squarefree;
+      and the defining convolution sum_{d|n} mu(d) == [n==1].
+  (D) Anchor: g = Euler phi recovers f(n)=n (since sum_{d|n} phi(d)=n), and
+      inverting f(n)=n gives back phi -- i.e. phi(n) = sum_{d|n} mu(d) * (n/d).
+"""
+
+from math import gcd
+
+
+def divisors(n):
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def factorize(n):
+    f = {}
+    d = 2
+    while d * d <= n:
+        while n % d == 0:
+            f[d] = f.get(d, 0) + 1
+            n //= d
+        d += 1
+    if n > 1:
+        f[n] = f.get(n, 0) + 1
+    return f
+
+
+def mobius(n):
+    if n == 1:
+        return 1
+    f = factorize(n)
+    if any(e >= 2 for e in f.values()):
+        return 0
+    return (-1) ** len(f)
+
+
+def euler_phi(n):
+    return sum(1 for k in range(1, n + 1) if gcd(k, n) == 1)
+
+
+def check(N=400, seed=20260615):
+    import random
+    rng = random.Random(seed)
+    all_pass = True
+
+    # random g
+    g = {n: rng.randint(-50, 50) for n in range(1, N + 1)}
+    f = {n: sum(g[d] for d in divisors(n)) for n in range(1, N + 1)}
+
+    # (A) forward -> inverse
+    okA = all(sum(mobius(d) * f[n // d] for d in divisors(n)) == g[n]
+              for n in range(1, N + 1))
+    all_pass &= okA
+    print(f"(A) g(n) == sum_(d|n) mu(d) f(n/d)  for n<=N={N}: {'PASS' if okA else 'FAIL'}")
+
+    # (B) inverse -> forward (start from arbitrary f2)
+    f2 = {n: rng.randint(-50, 50) for n in range(1, N + 1)}
+    g2 = {n: sum(mobius(d) * f2[n // d] for d in divisors(n)) for n in range(1, N + 1)}
+    okB = all(sum(g2[d] for d in divisors(n)) == f2[n] for n in range(1, N + 1))
+    all_pass &= okB
+    print(f"(B) f(n) == sum_(d|n) g(d)          for n<=N={N}: {'PASS' if okB else 'FAIL'}")
+
+    # (C) mu sanity + defining convolution
+    okC1 = mobius(1) == 1
+    okC2 = all((mobius(n) == 0) == (any(e >= 2 for e in factorize(n).values()))
+               for n in range(2, N + 1))
+    okC3 = all(sum(mobius(d) for d in divisors(n)) == (1 if n == 1 else 0)
+               for n in range(1, N + 1))
+    okC = okC1 and okC2 and okC3
+    all_pass &= okC
+    print(f"(C) mu sanity + sum_(d|n) mu(d)==[n==1]: {'PASS' if okC else 'FAIL'}")
+
+    # (D) anchor with Euler phi
+    phi = {n: euler_phi(n) for n in range(1, N + 1)}
+    f_phi = {n: sum(phi[d] for d in divisors(n)) for n in range(1, N + 1)}
+    okD1 = all(f_phi[n] == n for n in range(1, N + 1))           # sum_{d|n} phi(d) = n
+    okD2 = all(sum(mobius(d) * (n // d) for d in divisors(n)) == phi[n]
+               for n in range(1, N + 1))                          # phi(n)=sum mu(d)(n/d)
+    okD = okD1 and okD2
+    all_pass &= okD
+    print(f"(D) phi anchor: sum_(d|n) phi(d)=n and phi=mu*id: {'PASS' if okD else 'FAIL'}")
+
+    print()
+    print("OVERALL:", "ALL PASS" if all_pass else "SOME FAILED")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(check())

--- a/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
@@ -1,0 +1,63 @@
+{
+  "slug": "inclusion-exclusion-oq-01-oq-03",
+  "title": "Classical (divisor-form) Mobius inversion",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": "Formalize Mobius inversion: f(n)=sum_{d|n} g(d) iff g(n)=sum_{d|n} mu(d) f(n/d) (number-theoretic inclusion-exclusion).",
+  "knownResults": "Parent inclusion-exclusion-oq-01 proves the special case sum_{d|n} phi(d)=n via the IE sieve. Mathlib proves general Mobius inversion in antidiagonal form.",
+  "currentState": "ORIENT: Mathlib has it (antidiagonal); build-pending textbook-form bridge + all-pass verifier.",
+  "knowledge": {
+    "progressSummary": "ORIENT: Mathlib v4.26 proves Mobius inversion in ANTIDIAGONAL form (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq). Textbook divisor form g(n)=sum_{d|n} mu(d) f(n/d) obtained by Nat.sum_divisorsAntidiagonal bridge + eq_comm. Build-pending theorem moebius_inversion_divisors; verifier ALL PASS (both directions, mu sanity, Euler-phi anchor). Honest: depth is in Mathlib, this is a presentation bridge.",
+    "builtItems": [
+      "research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py - exhaustive n<=400 verifier (both directions, mu sanity, phi anchor), ALL PASS",
+      "proofs/Proofs/InclusionExclusionOQ01OQ03.lean (build-pending, UNREGISTERED): moebius_inversion_divisors textbook iff over any CommRing."
+    ],
+    "insights": [
+      "Mathlib's Mobius inversion (sum_eq_iff_sum_mul_moebius_eq) uses divisorsAntidiagonal (mu x.1 * g x.2), not the textbook divisor sum sum_{d|n} mu(d) f(n/d).",
+      "Bridge: Nat.sum_divisorsAntidiagonal : sum_{x in antidiag} F x.1 x.2 = sum_{d|n} F d (n/d) (to_additive partner of prod_divisorsAntidiagonal).",
+      "Companions exist: smul form (AddCommGroup), prod/pow form (CommGroup), and divisor-closed-set _on/_on' variants.",
+      "Euler-phi is the Mobius transform of the identity: phi(n)=sum_{d|n} mu(d)(n/d); verifier confirms with sum_{d|n} phi(d)=n."
+    ],
+    "mathlibGaps": [
+      "None mathematically; only the textbook divisor-sum PRESENTATION was missing (now bridged)."
+    ],
+    "nextSteps": [
+      "ACT (live build): compile/register InclusionExclusionOQ01OQ03.lean (verify ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq / Nat.sum_divisorsAntidiagonal / mu notation names).",
+      "Add phi corollary phi(n)=sum_{d|n} mu(d)((n/d:N):Z) via Nat.sum_totient.",
+      "Optional: general locally-finite-poset Mobius inversion (Rota) is out of scope for this divisor-lattice OQ."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "number-theory",
+    "mobius",
+    "inclusion-exclusion",
+    "arithmetic-function"
+  ],
+  "relatedProofs": [
+    "inclusion-exclusion-oq-01",
+    "inclusion-exclusion"
+  ],
+  "references": [],
+  "started": "2026-06-15",
+  "lastUpdate": "2026-06-15",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/InclusionExclusionOQ01OQ03.lean",
+      "filename": "InclusionExclusionOQ01OQ03.lean",
+      "lineCount": 77,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ01OQ03.lean",
+      "buildPending": true,
+      "registered": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
ORIENT on the `inclusion-exclusion-oq-01` open question: formalize **Möbius inversion**
```
f(n) = Σ_{d|n} g(d)   ⟺   g(n) = Σ_{d|n} μ(d)·f(n/d)
```
the number-theoretic form of inclusion–exclusion.

**Finding.** Mathlib v4.26 already proves this, but in **antidiagonal** form (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`, using `Σ_{x ∈ n.divisorsAntidiagonal} μ x.1 · g x.2`). The gallery wants the **textbook divisor-sum** shape `Σ_{d|n} μ(d) f(n/d)`. The bridge is `Nat.sum_divisorsAntidiagonal` (`Σ F x.1 x.2 = Σ_{d|n} F d (n/d)`). I wire the two (+ `eq_comm`) into the textbook iff.

Honest framing: the mathematical depth is in Mathlib; this PR's contribution is exposing the classical divisor-sum presentation that downstream gallery work expects.

## Files
- `research/.../verify_moebius_inversion.py` — exhaustive verifier (n ≤ 400, random ℤ data): both directions, μ sanity + `Σ_{d|n}μ(d)=[n=1]`, Euler-φ anchor `φ(n)=Σ_{d|n}μ(d)(n/d)`. **ALL PASS.**
- `proofs/Proofs/InclusionExclusionOQ01OQ03.lean` — **build-pending, UNREGISTERED**: `moebius_inversion_divisors` (textbook iff over any `CommRing`). Authored under a Docker + Aristotle blackout.
- knowledge/state/JSON (new workspace).

## Status
**Outcome**: ORIENT (theorem stated + bridged + verified; no Mathlib gap).
**Next**: build/register the file; add the `φ(n)=Σ_{d|n}μ(d)(n/d)` corollary via `Nat.sum_totient`.

🤖 Generated by researcher-9