### PR TITLE
research(sperner-simplicial-instance-oq-03): S7 — full FC-oddness recursion tower

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ03Tower.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ03Tower.lean
@@ -1,0 +1,87 @@
+/-
+# Sperner Simplicial Instance OQ-03: the full FC-oddness recursion tower
+
+`SpernerSimplicialInstanceOQ03.lean` isolated the *single* cross-dimensional
+inductive step `fc_odd_of_facet_bijection`:
+
+  Odd #FC(Δ^{d+1})  ⟸  (top-facet door↔FC bijection)  +  Odd #FC(Δ^d).
+
+This file closes the induction: given the base case `Odd #FC(Δ¹)` and the
+facet-restriction bijection at *every* level, `Odd #FC(Δ^d)` holds for all `d ≥ 1`
+simultaneously. This is the headline Sperner recursion (the engine behind
+`_hLastFace` / `boundary_doors_odd`), expressed as one theorem rather than a
+single step.
+
+It reduces the entire open question to exactly **two** named geometric inputs,
+both deferred to the concrete order-polytope standard triangulation:
+  * `hbase` — the 1-dimensional Sperner lemma `Odd #FC(Δ¹)` (classically `= 1`);
+  * `hstep` — the family of top-facet door↔FC bijections, one per dimension.
+Everything else (the parity counting) is already discharged, sorry-free, by
+`SpernerNDim.sperner_parity` via `fc_odd_of_facet_bijection`.
+
+Build status: PENDING (Docker + Aristotle blackout, both re-tested live this
+session). UNREGISTERED in `Proofs.lean`. The proof is a single `Nat.le_induction`
+over the proven inductive step — no new geometry.
+-/
+
+import Proofs.SpernerSimplicialInstanceOQ03
+
+namespace SpernerNDim
+
+open Finset BigOperators
+
+/-- **The full Sperner FC-oddness recursion.**
+
+Let `K d` be a Sperner-colored triangulation of dimension `d` (coloring `c d`,
+ambient size `N d`) for every `d`. Suppose:
+  * `hbase` : the 1-dimensional triangulation has an odd number of fully-colored
+    simplices (the base of the recursion);
+  * `hstep` : for every `d ≥ 1`, the number of top-facet boundary doors of `K (d+1)`
+    equals the number of fully-colored simplices of `K d` (the facet-restriction
+    bijection, the sole geometric input).
+
+Then `K d` has an odd number of fully-colored simplices for every `d ≥ 1`.
+
+The proof inducts on dimension via the proven single step
+`fc_odd_of_facet_bijection`; no parity counting is re-derived. -/
+theorem fc_odd_tower {N : ℕ → ℕ}
+    (c : ∀ d, Coloring d (N d)) (K : ∀ d, SpernerTriangulation d (N d))
+    (hc : ∀ d, IsSperner (c d))
+    (hbase : Odd (Finset.univ.filter (fun s : (K 1).Simplex => IsFC (c 1) (K 1) s)).card)
+    (hstep : ∀ d : ℕ, 1 ≤ d →
+      (Finset.univ.filter (fun p : (K (d + 1)).Simplex × Fin (d + 1 + 1) =>
+        isDoorAt (c (d + 1)) (K (d + 1)) p.1 p.2 ∧
+          (K (d + 1)).adj p.1 p.2 = none ∧ p.2 = Fin.last (d + 1))).card =
+      (Finset.univ.filter (fun s : (K d).Simplex => IsFC (c d) (K d) s)).card) :
+    ∀ d : ℕ, 1 ≤ d →
+      Odd (Finset.univ.filter (fun s : (K d).Simplex => IsFC (c d) (K d) s)).card := by
+  intro d hd
+  induction d, hd using Nat.le_induction with
+  | base => exact hbase
+  | succ n hn ih =>
+      exact fc_odd_of_facet_bijection (c (n + 1)) (K (n + 1)) (hc (n + 1))
+        (c n) (K n) (hc n) (hstep n hn) ih
+
+/-- **Existence form of the tower.** Under the same hypotheses, every
+dimension-`d` triangulation (`d ≥ 1`) contains a fully-colored simplex — the
+conclusion of Sperner's lemma, obtained from oddness (an odd count is positive).
+-/
+theorem exists_fc_tower {N : ℕ → ℕ}
+    (c : ∀ d, Coloring d (N d)) (K : ∀ d, SpernerTriangulation d (N d))
+    (hc : ∀ d, IsSperner (c d))
+    (hbase : Odd (Finset.univ.filter (fun s : (K 1).Simplex => IsFC (c 1) (K 1) s)).card)
+    (hstep : ∀ d : ℕ, 1 ≤ d →
+      (Finset.univ.filter (fun p : (K (d + 1)).Simplex × Fin (d + 1 + 1) =>
+        isDoorAt (c (d + 1)) (K (d + 1)) p.1 p.2 ∧
+          (K (d + 1)).adj p.1 p.2 = none ∧ p.2 = Fin.last (d + 1))).card =
+      (Finset.univ.filter (fun s : (K d).Simplex => IsFC (c d) (K d) s)).card)
+    (d : ℕ) (hd : 1 ≤ d) :
+    ∃ s : (K d).Simplex, IsFC (c d) (K d) s := by
+  have hodd := fc_odd_tower c K hc hbase hstep d hd
+  -- an odd-cardinality finset is nonempty
+  have hpos : 0 < (Finset.univ.filter (fun s : (K d).Simplex => IsFC (c d) (K d) s)).card := by
+    have := Nat.odd_iff.mp hodd; omega
+  obtain ⟨s, hs⟩ := Finset.card_pos.mp hpos
+  exact ⟨s, (Finset.mem_filter.mp hs).2⟩
+
+end SpernerNDim

--- a/research/problems/sperner-simplicial-instance-oq-03/knowledge.md
+++ b/research/problems/sperner-simplicial-instance-oq-03/knowledge.md
@@ -257,3 +257,29 @@ ACT stays Docker-gated.
 - **Files**: `proofs/Proofs/SpernerSimplicialInstanceOQ03.lean`, `knowledge.md`, research JSON.
 - **Next**: ACT (Docker-gated) — build the concrete instance (S5 reference algorithm) and discharge
   `hbij`; then chain `fc_odd_of_facet_bijection` by induction to close `_hLastFace`.
+
+### Session 2026-06-15 (S7, researcher-5) — ACT: full recursion tower
+
+Build-free contribution (Docker `docker info` times out; Aristotle `prove` → 404,
+both re-tested live). The OQ03 file had only the *single* inductive step
+`fc_odd_of_facet_bijection`. Shipped `SpernerSimplicialInstanceOQ03Tower.lean`
+(UNREGISTERED, build-pending) closing the induction:
+
+- `fc_odd_tower` — given a tower of Sperner triangulations `K d`, the base case
+  `Odd #FC(K 1)`, and the facet-restriction bijection `hstep` at every level,
+  proves `Odd #FC(K d)` for all `d ≥ 1`. Proof is one `Nat.le_induction` over the
+  proven step (no parity re-derivation).
+- `exists_fc_tower` — existence form (odd ⟹ positive ⟹ nonempty fiber), the
+  Sperner conclusion `∃ s, IsFC` for all `d ≥ 1`.
+
+This reduces the WHOLE open question to exactly **two** named geometric inputs,
+both for the concrete order-polytope standard triangulation:
+  (1) `hbase` = the 1-D Sperner lemma `Odd #FC(Δ¹)` (classically `=1`);
+  (2) `hstep` = the per-dimension top-facet door↔FC bijection family.
+Both are exactly the objects `verify_standard_triangulation.py` (S5) validated
+numerically (checks (A)+(R)+(P), d≤4). Next build session: instantiate the
+order-polytope `K`, prove `hbase` and `hstep`, then apply `fc_odd_tower`.
+
+Name-checked vs SpernerNDim.lean / OQ03 (Coloring, SpernerTriangulation, IsFC,
+isDoorAt, IsSperner, Fin.last, fc_odd_of_facet_bijection) and Mathlib
+(Nat.le_induction, Nat.odd_iff, Finset.card_pos, Finset.mem_filter).


### PR DESCRIPTION
## Summary
Closes the induction left open by `SpernerSimplicialInstanceOQ03.lean`, which contained only the *single* cross-dimensional step `fc_odd_of_facet_bijection`.

New **UNREGISTERED** file `proofs/Proofs/SpernerSimplicialInstanceOQ03Tower.lean`:
- `fc_odd_tower` — given a tower of Sperner-colored triangulations `K d`, the base case `Odd #FC(K 1)`, and the top-facet door↔FC bijection `hstep` at every level, proves `Odd #FC(K d)` for **all** `d ≥ 1`. The proof is a single `Nat.le_induction` over the already-proven step — no parity counting is re-derived (that lives, sorry-free, in `SpernerNDim.sperner_parity`).
- `exists_fc_tower` — the existence conclusion `∃ s, IsFC (c d) (K d) s` (odd count ⟹ positive ⟹ nonempty).

This reduces the **entire** open question to exactly **two** named geometric inputs, both deferred to the concrete order-polytope standard triangulation:
1. `hbase` — the 1-D Sperner lemma `Odd #FC(Δ¹)` (classically `= 1`);
2. `hstep` — the per-dimension facet-restriction bijection family.

Both are exactly the objects already validated numerically by `verify_standard_triangulation.py` (S5: checks (A)+(R)+(P), dimensions ≤ 4).

## Status / honesty
- **Build PENDING.** Authored during a Docker + Aristotle outage (both re-tested live: `docker info` times out; Aristotle `prove` → "Resource not found"). UNREGISTERED in `Proofs.lean`.
- This does not close the OQ; it packages the proven single step into the full recursion and pins the residue to two named inputs. The dominant remaining cost (constructing the concrete triangulation instance to discharge `hbase`/`hstep`) is unchanged and Docker-gated.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialInstanceOQ03Tower` once Docker returns (depends on `Proofs.SpernerSimplicialInstanceOQ03` / `Proofs.SpernerNDim`)
- [ ] Instantiate the order-polytope tower `K`, discharge `hbase` and `hstep`, then apply `fc_odd_tower`
- [x] Names cross-checked against `SpernerNDim.lean` / OQ03 and Mathlib (`Nat.le_induction`, `Nat.odd_iff`, `Finset.card_pos`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)