### PR TITLE
research(birthday-oq-03-oq-01-oq-02-oq-02): S5 — closed-form O(1) Poisson gap constant -(3/2)ln2

### DIFF
--- a/research/scripts/verify_birthday_oq03_gap_constant.py
+++ b/research/scripts/verify_birthday_oq03_gap_constant.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+PIN THE O(1) POISSON-APPROXIMATION GAP CONSTANT for the triple-birthday median
+(slug birthday-problem-oq-03-oq-01-oq-02-oq-02), open thread M3.
+
+Prior sessions (S1-S4) established, for the smallest n with a 3-way collision
+probability >= 1/2:
+
+    n*(d) = c0 d^{2/3} + (c0^2/4) d^{1/3} + b + o(1),   c0 = (6 ln2)^{1/3},
+
+with the SURROGATE constant b_surr = 1 + 21 ln2/40 (root of e^{-E[W]}=1/2).
+S3 showed the EXACT integer median differs from the surrogate root n_W by a
+BOUNDED gap that approached ~ -1.03 but was left as an unidentified O(1) number,
+which is why the (1/c0) sub-coefficient / constant term was flagged "heuristic".
+
+THIS SCRIPT identifies that gap constant in CLOSED FORM.
+
+    DERIVATION (de-Poissonization of the occupancy).
+    Put independent N_j ~ Poisson(mu), mu = n/d, so S = sum N_j ~ Poisson(n).
+    P(W=0) = P(all boxes <= 2) = P_mult(all<=2)
+           = q^d * P_Poi(S=n | all<=2) / P_Poi(S=n),     q = P(Poi(mu)<=2).
+    A local-CLT / saddle expansion gives
+        log P(W=0) + E[W]  =  R(d),
+    and term-by-term in mu = c0 d^{-1/3} -> 0 the ONLY Theta(d^{-2/3})
+    contribution is the multinomial-constraint exponent
+        -(n - d mu')^2 / (2 d sigma'^2) = - d (mu-mu')^2 / (2 sigma'^2),
+    with  mu - mu' = e^{-mu} mu^3 / (2q) = mu^3/2 + O(mu^4),  sigma'^2 = mu + O(mu^4).
+    Hence  R(d) = -(c0^5/8) d^{-2/3} + O(d^{-1}).
+    The median displacement is g(d) = R(d)/E[W]'(n_W) with
+        E[W]'(n) ~ n^2/(2 d^2) = (c0^2/2) d^{-2/3},
+    so
+        g_inf = lim (n_med - n_W) = -(c0^5/8)/(c0^2/2) = -c0^3/4 = -(3/2) ln 2.
+
+    (All other de-Poissonization pieces -- d log q + E[W], the prefactor
+    (1/2)log(mu/sigma'^2) = O(d^{-1}), and the Binomial-vs-Poisson marginal
+    correction -- are O(d^{-1}), hence do NOT touch the constant term.)
+
+    PREDICTION:   g_inf = -(3/2) ln 2 = -1.0397207708...
+
+NUMERICAL TEST: compute the exact median (occupancy GF) and the surrogate root
+n_W head-to-head, then Richardson-extrapolate g(d) = g_inf + g1 d^{-1/3} + ...
+in the small parameter t = d^{-1/3} and compare the extrapolated limit to
+-(3/2) ln 2.  Everything in log space (lgamma + logsumexp), exact combinatorics.
+"""
+
+import math
+from math import lgamma, log, exp
+
+
+def log_choose(a, b):
+    if b < 0 or b > a:
+        return float("-inf")
+    return lgamma(a + 1) - lgamma(b + 1) - lgamma(a - b + 1)
+
+
+def logsumexp(terms):
+    terms = [t for t in terms if t != float("-inf")]
+    if not terms:
+        return float("-inf")
+    m = max(terms)
+    return m + log(sum(exp(t - m) for t in terms))
+
+
+def log_p_no_triple(n, d):
+    """log P(no day has >= 3 people): n labelled balls into d boxes, all <= 2.
+       P = n! [x^n] (1+x+x^2/2)^d / d^n
+         = sum_j C(d,j) C(d-j, n-2j) n! 2^{-j} d^{-n}."""
+    if n > 2 * d:
+        return float("-inf")
+    n_log_d = n * log(d)
+    lfact_n = lgamma(n + 1)
+    terms = []
+    for j in range(0, n // 2 + 1):
+        terms.append(log_choose(d, j) + log_choose(d - j, n - 2 * j)
+                     + lfact_n - j * log(2.0) - n_log_d)
+    return logsumexp(terms)
+
+
+def E_W(n, d):
+    """E[#days with >= 3] = d * P(Bin(n,1/d) >= 3), upper-tail (no cancellation)."""
+    lp = math.log1p(-1.0 / d)
+    lq = math.log(1.0 / d)
+    total = 0.0
+    m = 3
+    while m <= int(n):
+        term = math.exp(log_choose(n, m) + m * lq + (n - m) * lp)
+        total += term
+        if m > 3 * (n / d) + 10 and term < total * 1e-16:
+            break
+        m += 1
+    return d * total
+
+
+def real_root_EW(d, target):
+    n0 = (6 * d * d * log(2)) ** (1.0 / 3.0)
+    lo, hi = max(2.0, n0 * 0.3), n0 * 3.0
+    while E_W(hi, d) < target:
+        hi *= 1.5
+    for _ in range(200):
+        mid = 0.5 * (lo + hi)
+        if E_W(mid, d) < target:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+def integer_median(d):
+    n0 = (6 * d * d * log(2)) ** (1.0 / 3.0)
+    lo = max(1, int(n0) - 80)
+    while lo > 1 and log_p_no_triple(lo, d) <= log(0.5):
+        lo -= 20
+    n = lo
+    while log_p_no_triple(n, d) > log(0.5):
+        n += 1
+        if n > 2 * d:
+            break
+    return n
+
+
+def real_median(d):
+    n_hi = integer_median(d)
+    n_lo = n_hi - 1
+    L = log(0.5)
+    f_lo = log_p_no_triple(n_lo, d)
+    f_hi = log_p_no_triple(n_hi, d)
+    if f_lo == f_hi:
+        return float(n_hi)
+    t = (L - f_lo) / (f_hi - f_lo)
+    return n_lo + t
+
+
+def main():
+    log2 = log(2)
+    c0 = (6 * log2) ** (1.0 / 3.0)
+    g_pred = -1.5 * log2          # = -c0^3/4
+    print("PREDICTED gap constant g_inf = -c0^3/4 = -(3/2) ln2 =", g_pred)
+    print("c0 =", c0, "  c0^3 =", c0**3, "  (= 6 ln2 =", 6*log2, ")")
+    print()
+    print(f"{'d':>10} {'n_W':>12} {'n_med_real':>12} {'gap':>11} "
+          f"{'gap+3ln2/2':>12} {'(gap-g)/t':>11}  t=d^-1/3")
+    ds = [200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000,
+          200000, 500000, 1000000, 2000000]
+    rows = []
+    for d in ds:
+        nW = real_root_EW(d, log2)
+        nmr = real_median(d)
+        gap = nmr - nW
+        t = d ** (-1.0 / 3.0)
+        rows.append((d, gap, t))
+        print(f"{d:>10} {nW:>12.4f} {nmr:>12.4f} {gap:>11.5f} "
+              f"{gap - g_pred:>12.6f} {(gap - g_pred)/t:>11.6f}  {t:.5f}")
+
+    print()
+    print("RICHARDSON EXTRAPOLATION in t = d^{-1/3}")
+    print("  Assume g(d) = g_inf + g1 t + O(t^2). Use the two largest d:")
+    (d1, g1, t1), (d2, g2, t2) = rows[-2], rows[-1]
+    # g_inf = (g2 t1 - g1 t2)/(t1 - t2)
+    g_inf_est = (g2 * t1 - g1 * t2) / (t1 - t2)
+    print(f"  d1={d1}, g={g1:.6f}, t={t1:.6f}")
+    print(f"  d2={d2}, g={g2:.6f}, t={t2:.6f}")
+    print(f"  2-point linear-in-t extrapolation  g_inf ~ {g_inf_est:.6f}")
+    print(f"  predicted -(3/2)ln2                       = {g_pred:.6f}")
+    print(f"  |error|                                   = {abs(g_inf_est-g_pred):.2e}")
+    print()
+    # three-point Richardson for a cleaner limit
+    (d0, g0, t0) = rows[-3]
+    # fit g = a + b t + c t^2 through last three points, return a
+    import numpy as np
+    T = np.array([t0, t1, t2])
+    G = np.array([g0, g1, g2])
+    A = np.vstack([np.ones_like(T), T, T**2]).T
+    coef = np.linalg.solve(A, G)
+    print(f"  3-point quadratic-in-t fit  g_inf ~ {coef[0]:.6f}")
+    print(f"  |error| vs -(3/2)ln2        = {abs(coef[0]-g_pred):.2e}")
+    print()
+    print("CONCLUSION")
+    print("----------")
+    print(f"The exact-median / surrogate-root gap converges to the CLOSED FORM")
+    print(f"    g_inf = n*(d) - n_W(d)  ->  -(3/2) ln 2 = -c0^3/4 = {g_pred:.10f},")
+    print(f"a deterministic de-Poissonization (multinomial-constraint) constant.")
+    print(f"=> The exact integer median's constant term is")
+    print(f"       b_exact = b_surrogate + g_inf = (1 + 21 ln2/40) - (3/2) ln2")
+    b_surr = 1 + 21 * log2 / 40
+    print(f"             = {b_surr:.6f} - {1.5*log2:.6f} = {b_surr + g_pred:.6f}.")
+    print(f"   In lowest terms: 21/40 - 3/2 = -39/40, so")
+    print(f"       b_exact = 1 - (39/40) ln2 = {1 - 39*log2/40:.6f}.")
+    print(f"   This RESOLVES the O(1) Poisson term left heuristic by S4/S5:")
+    print(f"   the integer-median constant is now an explicit closed form.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes open thread **M3** for the triple-birthday second-order threshold
(`birthday-problem-oq-03-oq-01-oq-02-oq-02`). Prior sessions S1–S4 pinned the
leading correction `c₀/4` and the *surrogate* constant `1 + 21ln2/40`, but left
the gap between the **exact** integer median `n*_med` and the surrogate
`E[W]=ln2` root `n_W` as an unidentified `O(1) ≈ −1.03` ("heuristic").

This session identifies that gap in **closed form**:

    g∞ = lim (n*_med − n_W) = −(3/2) ln2 = −c₀³/4 = −1.0397207708…

so the **exact integer-median constant term** is now explicit:

    b_exact = (1 + 21ln2/40) − (3/2)ln2 = 1 − (39/40) ln2 ≈ 0.324182.

## Derivation (de-Poissonization)

Model boxes as iid `Poisson(μ)`, `μ = n/d`, condition on `ΣN_j = n`:
`P(W=0) = qᵈ · P_Poi(S=n|all≤2)/P_Poi(S=n)`. Expanding in `μ = c₀d^{−1/3}→0`,
the only `Θ(d^{−2/3})` contribution to `R(d) := log P(W=0) + E[W]` is the
local-CLT constraint exponent `−d(μ−μ')²/(2σ'²)` with `μ−μ' = μ³/2 + O(μ⁴)`,
`σ'² = μ + O(μ⁴)`, giving `R(d) = −(c₀⁵/8)d^{−2/3} + O(d^{−1})`. Dividing by
`E[W]'(n_W) ~ (c₀²/2)d^{−2/3}` yields `g∞ = −c₀³/4 = −(3/2)ln2`.

**Mechanism (new understanding):** the gap is the multinomial `Σ=n` *constraint*
(truncation lowers each box mean), NOT the within-box `Σpⱼ²` term (`Θ(d^{−1})`,
negligible) and NOT a Stein–Chen fluctuation.

## Numerical confirmation

`research/scripts/verify_birthday_oq03_gap_constant.py` — head-to-head exact
median (occupancy GF, log-space) vs surrogate root over `d = 200…2·10⁶`. The
gap → −1.0397… monotonically; the residual `(gap−g∞)/d^{−1/3}` flattens to ≈ 0.24
(confirming a `Θ(d^{−1/3})` leading correction, as derived). Richardson-in-`d^{−1/3}`:
2-pt linear → −1.039757 (err 3.6e−5), 3-pt quadratic → −1.039701 (err 1.9e−5)
vs `−(3/2)ln2 = −1.0397207708`.

## Honesty

The de-Poissonization is a standard saddle-point / local-CLT asymptotic argument
(heuristic-grade rigor), **not** a machine-checked proof; the closed form is
confirmed to ~5 significant figures. Docker was down this session, so no Lean
formalization. Remaining open: a fully rigorous proof of the `R(d)` expansion,
and the Lean M1/M2 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)