### PR TITLE
Enrich Shapley-Folkman Lemma: cross-references

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -207,6 +207,16 @@
       "targetId": "brouwer-fixed-point",
       "relationship": "related",
       "description": "Both are existence theorems with deep applications in mathematical economics. Brouwer's theorem proves Nash equilibrium existence; Shapley-Folkman justifies convex relaxation in general equilibrium theory"
+    },
+    {
+      "targetId": "shapley-folkman-oq-03",
+      "relationship": "related",
+      "description": "The quantitative Shapley-Folkman-Starr refinement: it converts this combinatorial bound (at most d excess summands) into a metric bound on the Hausdorff distance between a Minkowski sum and its convex hull — directly answering this entry's open question about formalizing the Starr distance version"
+    },
+    {
+      "targetId": "brouwer-fixed-point-oq-04",
+      "relationship": "related",
+      "description": "Kakutani's fixed-point theorem is the existence engine behind Arrow-Debreu general equilibrium; the Shapley-Folkman lemma is its companion in non-convex economies, supplying the near-convexity of aggregate demand that makes the fixed-point argument applicable when individual preferences are non-convex"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `shapley-folkman`. This entry is already richly documented (full historical narrative, 8 key insights, 5 references, detailed sections) — its one enrichment gap was cross-references (just `brouwer-fixed-point`).

## Quality improvements
- **Cross-references 1 → 3**, both verified to exist and mathematically accurate:
  - `shapley-folkman-oq-03` (related) — "Shapley-Folkman-Starr Theorem": the quantitative metric refinement bounding the Hausdorff distance `d_H(∑Sᵢ, conv(∑Sᵢ))`, converting this lemma's combinatorial "≤ d excess summands" bound into a distance bound. This directly answers the entry's own first open question about formalizing the Starr distance version.
  - `brouwer-fixed-point-oq-04` (related) — "Kakutani Fixed Point Theorem": the existence engine behind Arrow-Debreu general equilibrium, for which Shapley-Folkman provides the near-convexity of aggregate demand that makes the fixed-point argument work under non-convex individual preferences.

Deliberately did **not** link `minkowski-theorem`/`minkowski-fundamental-theorem` — those concern Minkowski's lattice-point theorem (geometry of numbers), a different "Minkowski" than the Minkowski set sum here, so a link would mislead.

`pnpm build` passes. `status: verified`, `badge: mathlib`, `axiomCount: 0` confirmed accurate (0 sorries, 0 axioms).