### PR TITLE
research(erdos-653-oq-01): S2 — discharge g_le_n axiom to theorem (3→2 axioms)

### DIFF
--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -143,8 +143,26 @@ g(n) ≥ 1 for n ≥ 2 (at least one R-value exists). -/
 /--
 **Trivial Upper Bound:**
 g(n) ≤ n (can't have more distinct values than points).
+
+Discharged from an axiom to a theorem (Axiom Integrity Policy): the R-value set
+`rValueSet S = S.image (distinctDistCount S)` is the image of `S` under a map, so
+`numDistinctRValues S = (rValueSet S).card ≤ S.card = n` by `Finset.card_image_le`,
+and `g n` is the supremum of these counts (`csSup_le'`). This reuses the exact
+proof vocabulary of the sharper `g_le_n_sub_one` below; unlike that lemma it needs
+no `n ≥ 2` hypothesis, so it remains the all-`n` bound cited by `erdos_653_summary`.
 -/
-axiom g_le_n : ∀ n : ℕ, g n ≤ n
+theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
+  intro n
+  unfold g
+  apply csSup_le'
+  intro k hk
+  simp only [Set.mem_setOf_eq] at hk
+  obtain ⟨S, hcard, rfl⟩ := hk
+  calc numDistinctRValues S
+      = (rValueSet S).card := rfl
+    _ = (S.image (distinctDistCount S)).card := rfl
+    _ ≤ S.card := Finset.card_image_le
+    _ = n := hcard
 
 /--
 **Monotonicity:**

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -61,13 +61,12 @@
       "IsRegularPolygon: regular polygon predicate",
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
-      "g_le_n axiom: g(n) ≤ n",
       "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)"
     ],
-    "axiomCount": 3,
-    "lineCount": 310,
-    "assumptions": "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries. g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is a proved theorem strictly sharper than the g_le_n axiom.",
-    "theoremCount": 3,
+    "axiomCount": 2,
+    "lineCount": 328,
+    "assumptions": "2 axioms: csizmadia_bound, upper_bound. 0 sorries. g_le_n (g(n) ≤ n) was discharged from axiom to theorem via Finset.card_image_le + csSup_le' (build-pending). g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is a sharper proved theorem.",
+    "theoremCount": 4,
     "definitionCount": 13
   },
   "overview": {
@@ -132,10 +131,10 @@
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "g_le_n axiom; g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
+      "summary": "g_le_n theorem (g(n) ≤ n, discharged from axiom); g_le_n_sub_one theorem (g(n) ≤ n-1, n ≥ 2); g_pos and g_mono discussed only in docstrings",
       "startLine": 138,
       "endLine": 210,
-      "mathContext": "g_le_n axiom (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
+      "mathContext": "discharged g_le_n theorem (g(n) ≤ n) plus the proved sharp bound g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2); g_pos and g_mono appear only in docstrings"
     },
     {
       "id": "special-configs",
@@ -203,8 +202,8 @@
       "Real"
     ],
     "namespace": "Erdos653",
-    "lineCount": 310,
-    "axiomCount": 3,
+    "lineCount": 328,
+    "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 13,
     "path": "Proofs/Erdos653Problem.lean",
@@ -227,5 +226,7 @@
       "description": "Related Erdős problem sharing themes: discrete-geometry, distinct-distances, open"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "axiomCount": 2,
+  "assumptions": "2 axioms: csizmadia_bound (g(n) > 7n/10), upper_bound (g(n) < n - cn^{2/3}). 0 sorries. The former discharged g_le_n theorem (g(n) ≤ n) was discharged to a theorem via Finset.card_image_le + csSup_le' (build-pending under Docker blackout). g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is the sharper proved theorem."
 }


### PR DESCRIPTION
## Summary

Axiom elimination on Erdős #653 (Axiom Integrity Policy): converts `axiom g_le_n : ∀ n, g n ≤ n` to a **theorem**, dropping the file's axiom count **3 → 2**.

`g n = sSup {k | ∃ S, S.card = n ∧ numDistinctRValues S = k}`. Since `rValueSet S = S.image (distinctDistCount S)`, we have `numDistinctRValues S = (rValueSet S).card ≤ S.card = n` by `Finset.card_image_le`, wrapped with `csSup_le'`:

```lean
theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
  intro n; unfold g; apply csSup_le'; intro k hk
  simp only [Set.mem_setOf_eq] at hk
  obtain ⟨S, hcard, rfl⟩ := hk
  calc numDistinctRValues S
      = (rValueSet S).card := rfl
    _ = (S.image (distinctDistCount S)).card := rfl
    _ ≤ S.card := Finset.card_image_le
    _ = n := hcard
```

The remaining two axioms (`csizmadia_bound`, `upper_bound`) are genuine deep-literature citations and correctly stay as axioms; the slug remains `axiomatized`.

## Why this is low-risk despite the build blackout

Every lemma/tactic used (`csSup_le'`, `Set.mem_setOf_eq`, the `obtain ⟨S, hcard, rfl⟩` destructuring, `Finset.card_image_le`, the `rfl`-calc on `numDistinctRValues`/`rValueSet`) is **already used and compiling** in the adjacent `g_le_n_sub_one` theorem in the **same file**. The new proof is a strict simplification of it (no `n ≥ 2`, no `Icc`/`erase`/nonempty reasoning). It deliberately uses `csSup_le'` — **not** the nonexistent `Nat.sSup_le` (which broke the aggregate once, fixed in #24368). `erdos_653_summary`/`erdos_653` still typecheck (name + type `∀ n, g n ≤ n` unchanged).

## Gallery meta

`src/data/proofs/erdos-653/meta.json`: `axiomCount` 3 → 2 (all three blocks), `theoremCount` 3 → 4, `lineCount` 310 → 328, `assumptions`/`summary` updated; status stays `axiomatized`, badge `axiom`.

## Build status

Build-pending: dual blackout (Docker `docker info` timeout, Aristotle `prove` → "Resource not found", both re-probed live). Not machine-checked this session.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos653Problem` once Docker is available.
- [x] Manual structural check against the compiling `g_le_n_sub_one` in the same file (identical opening + strict subset of lemmas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)