### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): S6 — reusable Strategy-D irrationality criterion

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean
@@ -73,29 +73,39 @@ theorem alpha_upper : sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7 < (9 : ℝ) := by
   have b7 : sqrt 7 < (2.65 : ℝ) := (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
   linarith
 
+/-- **Reusable Strategy-D criterion** (gallery-wide): an algebraic integer over `ℤ` that is
+not equal to any rational integer is irrational. This is the abstract core of Strategy D — a
+rational algebraic integer must be an integer (`ℤ` is integrally closed in `ℚ`), so if `α` is
+integral and avoids every `(n : ℝ)`, it cannot be rational.
+
+It applies to *any* finite sum of square roots of non-squares (each `√k` is integral via
+`isIntegral_of_sq`, the sum is integral by `IsIntegral.add`, and a strict interval bound
+`m < α < m+1` discharges the `∀ n, α ≠ n` hypothesis) — no degree-`2^k` minimal-polynomial
+machinery required. -/
+theorem irrational_of_isIntegral_of_forall_ne_int {α : ℝ} (hα : IsIntegral ℤ α)
+    (h : ∀ n : ℤ, α ≠ (n : ℝ)) : Irrational α := by
+  rintro ⟨q, hq⟩
+  -- hq : (q : ℝ) = α
+  have hqℝ : IsIntegral ℤ (algebraMap ℚ ℝ q) := by
+    rw [eq_ratCast (algebraMap ℚ ℝ) q, hq]; exact hα
+  have hqℤ : IsIntegral ℤ q :=
+    (isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective).mp hqℝ
+  obtain ⟨n, hn⟩ := (IsIntegrallyClosed.isIntegral_iff).mp hqℤ
+  rw [show algebraMap ℤ ℚ n = (n : ℚ) by simp] at hn
+  -- hn : (n : ℚ) = q ⇒ α = (n : ℝ)
+  exact h n (by rw [← hq, ← hn]; push_cast; ring)
+
 /-- **Main theorem**: `√2 + √3 + √5 + √7` is irrational.
 
 Proved via Strategy D: α is an algebraic integer trapped strictly between `8` and `9`, so it
 cannot equal any integer; a rational algebraic integer must be an integer, contradiction. -/
 theorem irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 :
     Irrational (sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7) := by
-  rintro ⟨q, hq⟩
-  -- hq : (q : ℝ) = √2 + √3 + √5 + √7
-  -- Step 1: α is integral over ℤ, hence so is (q : ℝ) = algebraMap ℚ ℝ q.
-  have hqℝ : IsIntegral ℤ (algebraMap ℚ ℝ q) := by
-    rw [eq_ratCast (algebraMap ℚ ℝ) q, hq]; exact isIntegral_alpha
-  -- Step 2: descend integrality along the injective ℚ ↪ ℝ, then use ℤ integrally closed.
-  have hqℤ : IsIntegral ℤ q :=
-    (isIntegral_algebraMap_iff (algebraMap ℚ ℝ).injective).mp hqℝ
-  obtain ⟨n, hn⟩ := (IsIntegrallyClosed.isIntegral_iff).mp hqℤ
-  rw [show algebraMap ℤ ℚ n = (n : ℚ) by simp] at hn
-  -- hn : (n : ℚ) = q  ⇒  α = (n : ℝ)
-  have hαn : sqrt 2 + sqrt 3 + sqrt 5 + sqrt 7 = (n : ℝ) := by
-    rw [← hq, ← hn]; push_cast; ring
-  -- Step 3: 8 < α < 9 forces an integer strictly between 8 and 9 — impossible.
+  -- α is an algebraic integer (isIntegral_alpha); discharge `∀ n, α ≠ n` from `8 < α < 9`.
+  refine irrational_of_isIntegral_of_forall_ne_int isIntegral_alpha (fun n hn => ?_)
   have hlo := alpha_lower
   have hhi := alpha_upper
-  rw [hαn] at hlo hhi
+  rw [hn] at hlo hhi
   have h8 : (8 : ℤ) < n := by exact_mod_cast hlo
   have h9 : n < (9 : ℤ) := by exact_mod_cast hhi
   omega

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/knowledge.md
@@ -323,3 +323,45 @@ mathematical — the mathematics is verified. Status stays NOT `verified` until 
 1. Build when Docker returns; fix any lemma-name/instance drift (fallbacks: Strategy A or
    `m(α)=0` + rational-root). 2. Register + gallery `meta.json`. 3. Follow-up OQ: Strategy D
    scales to any finite sum of `√(squarefree)` with no degree blow-up.
+
+## Session 2026-06-15 (Session 6, researcher-2) — extract reusable Strategy-D criterion
+
+**Mode:** ACT (Lean refactor, build-low-risk). Dual blackout (Docker `docker info`
+timeout; Aristotle `prove` → "Resource not found", re-probed live). Build-pending,
+UNREGISTERED (unchanged status — file stays out of `Proofs.lean` so it cannot break
+the aggregate before a Docker-up session verifies it).
+
+**Delta:** Session 5 wrote the complete `√2+√3+√5+√7` Strategy-D proof. This session
+**extracts its abstract core** as a gallery-reusable irrationality criterion in the
+same file (`Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean`):
+
+```lean
+theorem irrational_of_isIntegral_of_forall_ne_int {α : ℝ}
+    (hα : IsIntegral ℤ α) (h : ∀ n : ℤ, α ≠ (n : ℝ)) : Irrational α
+```
+
+i.e. "an algebraic integer that avoids every rational integer is irrational" — the
+packaged form of *a rational algebraic integer is an integer* (`ℤ` integrally closed
+in `ℚ`). The proof is exactly Session 5's steps 2–3 (`eq_ratCast` →
+`isIntegral_algebraMap_iff (·).injective` → `IsIntegrallyClosed.isIntegral_iff`), so
+it carries the same already-bearer-pinned, math-verified content; no new Mathlib.
+
+**Validation by use:** the main theorem `irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7`
+is refactored to `refine irrational_of_isIntegral_of_forall_ne_int isIntegral_alpha
+(fun n hn => ?_)` then discharges `∀ n, α ≠ n` from the existing `alpha_lower`/
+`alpha_upper` interval `8 < α < 9` (`rw [hn]; exact_mod_cast; omega`). Main proof
+shrinks ~18 → ~8 lines; the criterion + refactor together reprove the original, so
+if the file compiles the abstraction is validated end-to-end.
+
+**Why this is genuinely additive (not churn):** the criterion is the documented
+"Strategy D scales to any finite sum of √(squarefree)" follow-up made concrete and
+reusable. Any future √-sum slug (`√2+√3+√5`, longer sums, `∛`-free integral sums)
+reuses it: prove each summand `IsIntegral` via `isIntegral_of_sq` + `IsIntegral.add`,
+then trap in `(m, m+1)`. Mathlib has the pieces (`IsIntegrallyClosed.isIntegral_iff`)
+but not this combined `IsIntegral → not-int → Irrational` criterion as a named lemma.
+
+File: 0 sorries, 0 axioms, 10 theorems (was 9), ~95 → ~113 LOC. Still build-pending.
+
+**Next Docker-up session:** build `Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01`;
+if clean, register + add gallery `meta.json`; the criterion is then ready to factor out
+into a shared `Irrational`-criterion helper for the gallery's √-sum family.


### PR DESCRIPTION
## Summary

Extracts the abstract core of Session 5's Strategy-D proof (`√2+√3+√5+√7` irrational) as a **gallery-reusable irrationality criterion** in the same file:

```lean
theorem irrational_of_isIntegral_of_forall_ne_int {α : ℝ}
    (hα : IsIntegral ℤ α) (h : ∀ n : ℤ, α ≠ (n : ℝ)) : Irrational α
```

"An algebraic integer that avoids every rational integer is irrational" — the packaged form of *a rational algebraic integer is an integer* (ℤ integrally closed in ℚ). The proof is exactly Session 5's steps 2–3 (`eq_ratCast` → `isIntegral_algebraMap_iff (·).injective` → `IsIntegrallyClosed.isIntegral_iff`), so it carries the same already-bearer-pinned, math-verified content; no new Mathlib.

The main theorem is **refactored to use it** (`refine irrational_of_isIntegral_of_forall_ne_int isIntegral_alpha (fun n hn => ?_)`, discharging `∀ n, α ≠ n` from the existing `alpha_lower`/`alpha_upper` bounds `8 < α < 9`), validating the abstraction end-to-end and shrinking the main proof ~18 → ~8 lines.

## Why additive (not churn)

This is the documented "Strategy D scales to any finite sum of √(squarefree)" follow-up made concrete and reusable. Any future √-sum slug reuses it: prove each summand `IsIntegral` via `isIntegral_of_sq` + `IsIntegral.add`, then trap in `(m, m+1)`. Mathlib has the pieces but not this combined `IsIntegral → not-int → Irrational` criterion as a named lemma.

## Build status

0 sorries, 0 axioms. Build-pending and UNREGISTERED (file stays out of `Proofs.lean` so it cannot break the aggregate) under dual blackout (Docker `docker info` timeout, Aristotle `prove` → "Resource not found", both re-probed live).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01` once Docker is available; if clean, register + add gallery meta.json.
- [x] Lemmas unchanged from Session 5's bearer-pinned set; refactor reuses the verified bound steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)