### PR TITLE
Enrich Non-Cyclic 2-Torsion in (ZMod n)×: cross-references

### DIFF
--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -100,6 +100,21 @@
       "proofId": "quadratic-reciprocity",
       "relationship": "related",
       "description": "Quadratic reciprocity also relies on the structure of (ZMod p)× and its relationship to the Legendre symbol"
+    },
+    {
+      "proofId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "This result is the group-theoretic core of the Gauss-Wilson theorem: Wilson's (n-1)! ≡ -1 (mod n) for prime n holds because the product over (ZMod n)× collapses to the unique element of order 2 (namely -1), which fails precisely when extra square roots of unity exist — the non-cyclic case characterized here"
+    },
+    {
+      "proofId": "primitive-roots",
+      "relationship": "related",
+      "description": "Contrapositive companion: (ZMod n)× is cyclic exactly when it has a primitive root, and primitive-roots counts them for prime moduli; this entry characterizes the non-cyclic case by exhibiting a third square root of unity (2-torsion of rank ≥ 2), the obstruction to cyclicity"
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "The CRT supplies the third square root of unity in the odd-prime-factor case: writing n = m·2^a with m odd having an odd prime factor, CRT splits (ZMod n)× into components and lets one assemble an x with x² = 1, x ≠ ±1 componentwise"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `gauss-wilson-non-cyclic` ("Non-Cyclic 2-Torsion in (ZMod n)×"). Well-structured entry (5 key insights, 7 sections) with only one cross-reference.

## Quality improvements
- **Cross-references 1 → 4**, all verified to exist and mathematically accurate (using this entry's `proofId` cross-reference schema):
  - `wilsons-theorem` (related) — this 2-torsion result is the group-theoretic core of Gauss-Wilson: the unit-group product collapses to the unique order-2 element (−1), which is exactly why `(n-1)! ≡ -1 (mod n)` for primes.
  - `primitive-roots` (related) — contrapositive companion: `(ZMod n)×` is cyclic ⟺ it has a primitive root; this entry characterizes the non-cyclic case via a third square root of unity (rank-≥2 2-torsion), the obstruction to cyclicity.
  - `chinese-remainder-constructive` (related) — CRT is the tool that constructs the third square root of unity in the odd-prime-factor case.

`pnpm build` passes. `status: verified`, `badge: original`, `axiomCount: 0` confirmed accurate (0 sorries, 0 axioms).