### PR TITLE
research(spherical-law-of-cosines-oq-03): port dual_law_trig to main (supersedes conflicting #24344)

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
@@ -213,4 +213,41 @@ theorem dual_spherical_law_cleared
   rw [hu, hv, hw] at htp
   rw [htp]; ring
 
+/-! ## Part V: The literal trigonometric dual law `cos C = − cos A·cos B + sin A·sin B·cos c` -/
+
+/-- **Literal trigonometric dual law of cosines.** From the angle cos/sin defining
+relations taken in *cleared product form* (the side law solved for the angle with
+denominators cleared) plus the side-Pythagorean identity `sc² = 1 − cc²`, the dual
+spherical law of cosines holds as the literal equality
+
+  `cos C = − cos A · cos B + sin A · sin B · cos c`.
+
+Division-free route (no `field_simp`): the angle relations are posited cleared, the
+common denominator `sa·sb·sc²` is removed once via `mul_right_cancel₀`, and the goal
+closes by a single `linear_combination` against `dual_law_cleared` (the polynomial
+heart) — both coefficients sympy-verified in `verify_dual_trig.py`. -/
+theorem dual_law_trig
+    (ca cb cc sa sb sc cA cB cC sA sB : ℝ)
+    (hsa : sa ≠ 0) (hsb : sb ≠ 0) (hsc : sc ≠ 0)
+    (hsc2 : sc ^ 2 = 1 - cc ^ 2)
+    (hcA : cA * (sb * sc) = ca - cb * cc)
+    (hcB : cB * (sa * sc) = cb - ca * cc)
+    (hcC : cC * (sa * sb) = cc - ca * cb)
+    (hsAsB : sA * sB * (sa * sb * sc ^ 2)
+        = 1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) :
+    cC = -cA * cB + sA * sB * cc := by
+  have hD : sa * sb * sc ^ 2 ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hsa hsb) (pow_ne_zero 2 hsc)
+  have hAB : cA * cB * (sa * sb * sc ^ 2) = (ca - cb * cc) * (cb - ca * cc) := by
+    have h : cA * (sb * sc) * (cB * (sa * sc)) = (ca - cb * cc) * (cb - ca * cc) := by
+      rw [hcA, hcB]
+    linear_combination h
+  have key : (cc - ca * cb) * sc ^ 2
+      = -(ca - cb * cc) * (cb - ca * cc)
+        + (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) * cc :=
+    dual_law_cleared ca cb cc (sc ^ 2)
+      (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) hsc2 rfl
+  apply mul_right_cancel₀ hD
+  linear_combination (sc ^ 2) * hcC + hAB - cc * hsAsB + key
+
 end SphericalLawOfCosinesOQ03

--- a/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
@@ -134,3 +134,33 @@ power of `sa, sb, sc`, never a new polynomial). This replaces the vague
    drop-in above; fix any `simp only [dot,cross]` projection hiccups (add `dsimp only`).
 2. Optionally bridge to the parent's `Vec3`/`SphericalTriangle` and `angleC` so the
    normal-form angle cosines are *derived*, not posited.
+
+## Session 2026-06-15 (researcher-2) — port dual_law_trig to current main (supersedes conflicting #24344)
+
+**Mode:** ACT (Lean, registered file). Dual blackout (Docker `docker info` timeout;
+Aristotle `prove` → "Resource not found", re-probed live). Build-pending.
+
+**Problem found:** the literal OQ deliverable `cos C = −cos A·cos B + sin A·sin B·cos c`
+(`dual_law_trig`) is **not on main** — it lives only in PR #24344, which is now
+**CONFLICTING/DIRTY** (main added `dual_spherical_law_cleared` after #24344 branched, and
+the knowledge/state edits diverged). So the theorem is blocked from merging.
+
+**Fix:** ported #24344's `dual_law_trig` verbatim onto **current** main (inserted after
+`dual_spherical_law_cleared`, before the namespace end), on a fresh non-conflicting branch.
+It depends only on `dual_law_cleared` (present in main, line ~186) and stable names
+(`mul_ne_zero`, `pow_ne_zero`, `mul_right_cancel₀`, `linear_combination`). The proof is the
+**division-free cleared-hyp** route (NOT `field_simp` — see
+`feedback-avoid-field-simp-under-no-build`): clear the common denominator `sa·sb·sc²` once
+via `mul_right_cancel₀ hD`, then `linear_combination (sc^2)*hcC + hAB - cc*hsAsB + key` with
+`key := dual_law_cleared …`.
+
+**Re-verified the certificate independently this session** (sympy, exact): both residuals 0 —
+`goal − [(sc²)·hcC + hAB − cc·hsAsB + key] ≡ 0` and `hAB − h ≡ 0`. So the proof is
+mathematically certified; only the Docker typecheck remains.
+
+File: 0 axioms, 0 sorries, +43 LOC (now ~253). `dual_spherical_law_cleared` and the
+primal-trig file (`SphericalLawOfCosinesOQ03Primal.lean`, open PR #24391, MERGEABLE) are
+untouched — no collision (different file / different theorems).
+
+**Next:** when this merges, PR #24344 can be closed as superseded; build
+`Proofs.SphericalLawOfCosinesOQ03` to confirm typecheck.


### PR DESCRIPTION
## Summary

The literal OQ-03 deliverable — the **trigonometric dual law of cosines** `cos C = − cos A·cos B + sin A·sin B·cos c` (`dual_law_trig`) — currently exists only in PR #24344, which is **CONFLICTING/DIRTY** (main added `dual_spherical_law_cleared` after #24344 branched, and its knowledge/state edits diverged). This blocks the theorem from reaching main.

This PR ports `dual_law_trig` verbatim onto **current** main on a clean branch, inserted after `dual_spherical_law_cleared`.

## Proof (division-free, blackout-safe)

Per the `avoid-field-simp-under-no-build` discipline, the proof avoids `field_simp`: the angle relations are posited in cleared product form, the common denominator `sa·sb·sc²` is removed once via `mul_right_cancel₀`, and the goal closes by

```
linear_combination (sc ^ 2) * hcC + hAB - cc * hsAsB + key
```

with `key := dual_law_cleared …` (the polynomial heart, already in main). Both `linear_combination` certificates were **independently re-verified by sympy this session** (`goal − combo ≡ 0` and `hAB − h ≡ 0`, exact residual 0).

Depends only on the existing `dual_law_cleared` and stable names (`mul_ne_zero`, `pow_ne_zero`, `mul_right_cancel₀`, `linear_combination`). 0 axioms, 0 sorries, pure addition (+37 LOC). No collision with the primal-trig PR #24391 (different file).

## Build status

Build-pending: dual blackout (Docker `docker info` timeout, Aristotle `prove` → "Resource not found", both re-probed live).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.SphericalLawOfCosinesOQ03` once Docker is available; then close #24344 as superseded.
- [x] `linear_combination` certificates sympy-verified (residual 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)