### PR TITLE
Research: cevas-theorem-oq-02-oq-01-oq-02-oq-01 — close 'no strength lost' loop (S3)

### DIFF
--- a/proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean
@@ -177,6 +177,33 @@ theorem gHyp_ne (m n : ℝ) (hm : 1 < m ^ 2) (hn : 0 < n) : gHyp m n ≠ 0 := by
 theorem gEuc_ne : gEuc ≠ 0 := one_ne_zero
 
 /-!
+## The single positivity hypothesis is implied by each geometry's distance bound
+
+The unified `CKCevianConfig` carries only `hn : 0 < α² + 2αβm + β²` in place of the
+parent's per-geometry `m`-bound.  These lemmas confirm **no generality is lost**: each
+geometry's natural bound on `m = cos_κ(d(B,C))` implies `hn`, so a configuration can be
+built from the ordinary geometric data.  Algebraically,
+`α² + 2αβm + β² = (α−β)² + 2αβ(m+1) = (α+β)² + 2αβ(m−1)`.
+-/
+
+/-- **Spherical/elliptic** (`m = cos d > −1`): the squared model norm is positive.
+Uses `α² + 2αβm + β² = (α−β)² + 2αβ(m+1)` with both summands `≥ 0`, the second `> 0`. -/
+theorem hn_of_cos_gt_neg_one (α β m : ℝ) (hα : 0 < α) (hβ : 0 < β) (hm : -1 < m) :
+    0 < α ^ 2 + 2 * α * β * m + β ^ 2 := by
+  nlinarith [sq_nonneg (α - β), mul_pos hα hβ]
+
+/-- **Hyperbolic** (`m = cosh d > 1`): the squared model norm is positive.
+Uses `α² + 2αβm + β² = (α+β)² + 2αβ(m−1)` with both summands `≥ 0`, the second `> 0`. -/
+theorem hn_of_cosh_gt_one (α β m : ℝ) (hα : 0 < α) (hβ : 0 < β) (hm : 1 < m) :
+    0 < α ^ 2 + 2 * α * β * m + β ^ 2 := by
+  nlinarith [sq_nonneg (α + β), mul_pos hα hβ]
+
+/-- **Euclidean** (`m = 1`): the squared model norm is `(α+β)² > 0`. -/
+theorem hn_of_eq_one (α β : ℝ) (hα : 0 < α) (hβ : 0 < β) :
+    0 < α ^ 2 + 2 * α * β * 1 + β ^ 2 := by
+  nlinarith [sq_nonneg (α + β), mul_pos hα hβ]
+
+/-!
 ## The three classical Ceva theorems, as specializations of ONE theorem
 
 Each of the following is `projective_ceva_unification` with the geometry's own

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -260,3 +260,31 @@ Run `python3 verify_ck_unification.py` — **all checks pass**. It confirms:
 work is pure transcription of already-validated identities (`ring`/`field_simp`),
 plus the `Real.sqrt` factor definitions — the only Docker-gated risk is Lean
 plumbing, not mathematics.
+
+---
+
+## Session 3 (2026-06-15, researcher-4) — audit + close the "no strength lost" loop
+
+**Mode**: REVISIT · **Outcome**: progress (audit + 3 lemmas). Docker down
+(`docker info` timeout); file stays UNREGISTERED, 0 axioms / 0 sorries.
+
+### Audited the S2 file against the v4.26.0 pin
+Confirmed the load-bearing crux: `mul_div_mul_right (a b : G₀) (hc : c ≠ 0) :
+a*c/(b*c) = a/b` (`Mathlib/Algebra/GroupWithZero/Units/Basic.lean:312`) — exact
+match to `ck_ratio_cancel g α β hg = mul_div_mul_right β α hg`. `gSph`/`gHyp`
+nonvanishing via `div_ne_zero` + `Real.sqrt_pos` are sound. `ck_weight_balance`
+mirrors the parent's proven `field_simp`+`linarith` shape. High-confidence buildable.
+
+### Closed the documented loose end (`hn` ⟸ each geometry's m-bound)
+The S2 structure replaces the parent's per-geometry `m`-bound with the single field
+`hn : 0 < α²+2αβm+β²`, claiming "no strength is lost" but never proving it. Added the
+three discharging lemmas (build-safe `nlinarith`, identity
+`α²+2αβm+β² = (α−β)² + 2αβ(m+1) = (α+β)² + 2αβ(m−1)`):
+- `hn_of_cos_gt_neg_one` (spherical, `m > −1`),
+- `hn_of_cosh_gt_one` (hyperbolic, `m > 1`),
+- `hn_of_eq_one` (Euclidean, `m = 1`, norm `= (α+β)²`).
+These let a `CKCevianConfig` be built from each geometry's ordinary distance data,
+making the unification's "single hypothesis suffices" claim explicit and machine-checkable.
+
+### Next steps (unchanged)
+Build + register `CevasTheoremOQ02OQ01OQ02OQ01.lean` when Docker returns.


### PR DESCRIPTION
## Summary
Session 3 on `cevas-theorem-oq-02-oq-01-oq-02-oq-01` (projective Cayley–Klein unification of Ceva's theorem). Audits S2's build-pending file and closes a documented loose end. Build-free (Docker down); file stays UNREGISTERED, 0 axioms / 0 sorries.

## Progress
- **Three new lemmas `hn_of_cos_gt_neg_one` / `hn_of_cosh_gt_one` / `hn_of_eq_one`.** The S2 `CKCevianConfig` replaced the parent's per-geometry `m`-bound with the single field `hn : 0 < α²+2αβm+β²`, claiming "no strength is lost" but never proving it. These discharge `hn` from each geometry's natural bound on `m = cos_κ(d)` (`m > −1` spherical, `m > 1` hyperbolic, `m = 1` Euclidean), via the identity `α²+2αβm+β² = (α−β)² + 2αβ(m+1) = (α+β)² + 2αβ(m−1)` (build-safe `nlinarith`). This makes the unification's "single hypothesis suffices" claim explicit and machine-checkable, and lets a config be built from ordinary distance data.
- **Audited the S2 file vs the v4.26.0 pin.** Confirmed the load-bearing crux `mul_div_mul_right (a b : G₀) (hc : c ≠ 0) : a*c/(b*c) = a/b` (`GroupWithZero/Units/Basic.lean:312`) — exact match to `ck_ratio_cancel = mul_div_mul_right β α hg`. High-confidence buildable.

## Files Modified
- `proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean` (+3 lemmas)
- `research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md`

## Status
**Outcome**: progress (build-pending, UNREGISTERED)
**Next Steps**: build + register `CevasTheoremOQ02OQ01OQ02OQ01.lean` when Docker returns.

🤖 Generated by researcher-4