### PR TITLE
Enrich Waring's Problem for Squares g(2)=4: cross-references

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -225,6 +225,21 @@
       "targetId": "lagrange-four-squares",
       "relationship": "extends",
       "description": "Extends the Lagrange four-square theorem to the full Waring problem: g(2) = 4"
+    },
+    {
+      "targetId": "lagrange-four-squares-oq-04",
+      "relationship": "related",
+      "description": "The Legendre-Gauss three-square theorem: n is a sum of three squares iff n ≠ 4ᵃ(8b+7). This is exactly the lower-bound half of g(2) = 4 — the excluded numbers (e.g. 7) are precisely those forcing a fourth square, so this entry's exclusion theorem is the negative direction of that characterization"
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "The two-square level of the sum-of-squares hierarchy: Fermat characterizes which n are sums of two squares (every prime ≡ 3 mod 4 occurring to an even power), one step below the three-square (Legendre) and four-square (Lagrange) results that pin down g(2) = 4"
+    },
+    {
+      "targetId": "four-square-distribution-oq-01",
+      "relationship": "related",
+      "description": "Jacobi's four-square formula r₄(n) = 8·σ*(n) counts the number of representations as four squares, refining the qualitative existence statement g(2) = 4 into an exact count (and confirming r₄(n) > 0 for every n)"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2` ("Waring's Problem for Squares: g(2) = 4"). Had only one cross-reference; built out the full sum-of-squares family tree.

## Quality improvements
- **Cross-references 1 → 4**, all verified to exist and mathematically accurate:
  - `lagrange-four-squares-oq-04` (related) — Legendre-Gauss three-square theorem (`n` is a sum of 3 squares iff `n ≠ 4ᵃ(8b+7)`). This entry's exclusion theorem is exactly the negative direction of that characterization — the lower-bound half of `g(2)=4`.
  - `fermat-two-squares` (related) — the two-square level of the hierarchy (which `n` are sums of two squares), one rung below the three- and four-square results.
  - `four-square-distribution-oq-01` (related) — Jacobi's `r₄(n) = 8·σ*(n)` exact representation count, refining the qualitative existence statement.

`pnpm build` passes. Axiom/status metadata reviewed and left unchanged (accurate).