### PR TITLE
audit(inverse-galois-a5-oq-02): fix false axiom undercount from spurious additionalFiles

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15326,6 +15326,12 @@
       "lastAudited": "2026-06-15T11:45:20Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "divisibility-truncation-general-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T11:46:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15320,6 +15320,12 @@
       "lastAudited": "2026-06-13T15:12:04Z",
       "result": "clean",
       "issues": []
+    },
+    "inverse-galois-a5-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T11:45:20Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/inverse-galois-a5-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-02/meta.json
@@ -19,9 +19,6 @@
       "open-problem"
     ],
     "proofRepoPath": "Proofs/InverseGaloisA5OQ02.lean",
-    "additionalFiles": [
-      "Proofs/InverseGaloisA5.lean"
-    ],
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,


### PR DESCRIPTION
## Integrity Issue

**Proof**: inverse-galois-a5-oq-02
**Severity**: LOW (axiom count off by 1, false positive)

The audit scanner flagged `inverse-galois-a5-oq-02` with:
> axiom undercount: claims 3, actual declarations 4

## Root Cause

The oq-02 `meta.json` listed `Proofs/InverseGaloisA5.lean` under `additionalFiles`. That file is the **independent** `inverse-galois-a5` gallery entry, which has its own `meta.json` and its own `axiomCount: 1` (`three_dvd_gal_card`).

`find-targets.ts` resolves `additionalFiles` and sums axiom declarations across them, so the A₅ entry's axiom was double-counted against oq-02.

## Evidence

- `proofs/Proofs/InverseGaloisA5OQ02.lean` imports only `Mathlib` (no `import Proofs.InverseGaloisA5`) — there is no real code dependency.
- The oq-02 file declares **exactly 3** axioms: `trinks_gal_84_dvd`, `trinks_gal_card_dvd_168`, `trinks_gal_card_ne_84` — matching the claimed `axiomCount: 3` and the detailed `assumptions` field.
- `inverse-galois-a5/meta.json` independently accounts for its 1 axiom.

## Fix

Removed `Proofs/InverseGaloisA5.lean` from oq-02's `additionalFiles`. The "extends" relationship between the two entries is already captured in `crossReferences`, so the cross-link is preserved.

After the fix, `find-targets.ts` reports the entry clean (✓).

---
Discovered during gallery integrity audit.