### PR TITLE
research(ballot-problem-oq-01-oq-03): reflection form of Catalan number

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ03.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ03.lean
@@ -1,0 +1,92 @@
+/-
+  Ballot Problem — OQ-01-OQ-03: The Catalan number as a ballot/reflection count
+
+  The classical ballot theorem is proved by the *reflection principle*: the
+  number of "good" lattice paths (those that stay strictly on one side) equals
+  the total number of paths minus the number of "bad" paths, where the bad paths
+  are counted bijectively by reflecting them.  For the symmetric Dyck-path case
+  (n up-steps, n down-steps, never dipping below the axis) this reflection count
+  is
+
+      catalan n = C(2n, n) − C(2n, n+1).
+
+  This is the *reflection form* of the Catalan number.  It is mathematically
+  distinct from Mathlib's *division form*
+      `catalan_eq_centralBinom_div : catalan n = centralBinom n / (n + 1)`
+  in that it never divides: it is a literal "all paths minus reflected bad paths"
+  difference, which is exactly what the ballot/reflection argument produces.
+
+  The two forms are reconciled here in `choose_sub_choose_eq_centralBinom_div`.
+
+  Key Mathlib inputs (all from `import Mathlib`):
+  * `Nat.choose_succ_right_eq`           — adjacent-binomial recurrence
+  * `Nat.centralBinom_eq_two_mul_choose` — centralBinom n = (2n).choose n
+  * `succ_mul_catalan_eq_centralBinom` — (n+1) * catalan n = centralBinom n
+  * `catalan_eq_centralBinom_div`    — division form (for reconciliation)
+
+  Reference: https://erdosproblems.com (ballot problem family); reflection
+  principle / Catalan numbers, standard.
+-/
+
+import Mathlib
+
+namespace BallotProblemOQ01OQ03
+
+open Nat
+
+/--
+**Central binomial in terms of the Catalan number** (a convenient repackaging of
+`succ_mul_catalan_eq_centralBinom`): the central binomial coefficient
+`(2n).choose n` is `(n+1)` copies of `catalan n`.
+-/
+theorem two_mul_choose_eq (n : ℕ) :
+    (2 * n).choose n = (n + 1) * catalan n := by
+  rw [← Nat.centralBinom_eq_two_mul_choose, succ_mul_catalan_eq_centralBinom]
+
+/--
+**The "one-off" binomial is `n` copies of the Catalan number.**
+
+`(2n).choose (n+1) = n · catalan n`.  This is the count of *bad* (reflected)
+Dyck paths in the reflection argument.  Proved from the adjacent-binomial
+recurrence `choose_succ_right_eq` by cancelling the factor `(n+1)`.
+-/
+theorem two_mul_choose_succ_eq (n : ℕ) :
+    (2 * n).choose (n + 1) = n * catalan n := by
+  have h := Nat.choose_succ_right_eq (2 * n) n
+  rw [two_mul_choose_eq] at h
+  have h2n : 2 * n - n = n := by omega
+  rw [h2n] at h
+  -- h : (2*n).choose (n+1) * (n+1) = (n+1) * catalan n * n
+  have hcancel :
+      (2 * n).choose (n + 1) * (n + 1) = (n * catalan n) * (n + 1) := by
+    rw [h]; ring
+  exact Nat.eq_of_mul_eq_mul_right (by omega) hcancel
+
+/--
+**Reflection form of the Catalan number (ballot count).**
+
+    catalan n = C(2n, n) − C(2n, n+1).
+
+The right-hand side is exactly "(all monotone lattice paths) − (reflected bad
+paths)", the quantity the reflection principle delivers for the ballot theorem.
+No division is involved, in contrast to `catalan_eq_centralBinom_div`.
+-/
+theorem catalan_eq_choose_sub_choose (n : ℕ) :
+    catalan n = (2 * n).choose n - (2 * n).choose (n + 1) := by
+  rw [two_mul_choose_eq, two_mul_choose_succ_eq, add_one_mul]
+  -- goal: catalan n = n * catalan n + catalan n - n * catalan n
+  omega
+
+/--
+**Reconciliation of the reflection form with Mathlib's division form.**
+
+    C(2n, n) − C(2n, n+1) = centralBinom n / (n + 1).
+
+Both compute `catalan n`; this confirms the ballot/reflection count agrees with
+the standard closed form.
+-/
+theorem choose_sub_choose_eq_centralBinom_div (n : ℕ) :
+    (2 * n).choose n - (2 * n).choose (n + 1) = n.centralBinom / (n + 1) := by
+  rw [← catalan_eq_choose_sub_choose, catalan_eq_centralBinom_div]
+
+end BallotProblemOQ01OQ03

--- a/research/problems/ballot-problem-oq-01-oq-03/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-03/knowledge.md
@@ -1,0 +1,57 @@
+# Ballot Problem OQ-01-OQ-03 — Catalan number as a reflection/ballot count
+
+## Problem Summary
+
+Derive the Catalan number identity from the ballot problem. The ballot
+theorem is proved by the **reflection principle**: the number of "good" paths
+equals (all paths) − (reflected bad paths). For the symmetric Dyck-path case
+this gives the **reflection form**
+
+    catalan n = C(2n, n) − C(2n, n+1).
+
+This is distinct from Mathlib's **division form**
+`catalan_eq_centralBinom_div : catalan n = centralBinom n / (n + 1)`: the
+reflection form never divides — it is a literal "all minus reflected bad"
+difference, exactly what the ballot/reflection argument produces.
+
+## Session 2026-06-15 (Session 1) — FRESH / ACT
+
+**Mode**: FRESH
+**Outcome**: progress (reflection-form identity proved, build-pending)
+
+### What I Did
+- Confirmed Mathlib already has the division form (`catalan_eq_centralBinom_div`)
+  and `succ_mul_catalan_eq_centralBinom`, plus `Nat.choose_succ_right_eq`,
+  `Nat.centralBinom_eq_two_mul_choose`. Name-checked all against the sibling
+  `../mathlib4` checkout (catalan lemmas are ROOT namespace, not `Nat.`).
+- Wrote `proofs/Proofs/BallotProblemOQ01OQ03.lean` (UNREGISTERED) with:
+  - `two_mul_choose_eq` : `(2n).choose n = (n+1) * catalan n`
+  - `two_mul_choose_succ_eq` : `(2n).choose (n+1) = n * catalan n`
+    (reflected "bad path" count; from `choose_succ_right_eq` + cancel `(n+1)`)
+  - `catalan_eq_choose_sub_choose` : the headline reflection form
+  - `choose_sub_choose_eq_centralBinom_div` : reconciliation with the division form
+- Verified numerically n=0..4: 1,1,2,5,14 all match `C(2n,n)-C(2n,n+1)`.
+
+### Key Findings
+- The arithmetic crux is `(2n).choose (n+1) = n · catalan n`. Combined with
+  `(2n).choose n = (n+1)·catalan n`, the subtraction collapses:
+  `(n+1)·c − n·c = c` (via `add_one_mul` then `omega`).
+- Mathlib's gallery ballot proof is measure-theoretic (`countedSequence`), so a
+  clean integer bridge is best stated standalone, not threaded through the
+  measure objects.
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ01OQ03.lean` (new, unregistered)
+- `src/data/research/problems/ballot-problem-oq-01-oq-03.json` (new)
+- `research/problems/ballot-problem-oq-01-oq-03/knowledge.md` (this file)
+
+### Blockers
+- Dual blackout: Docker `docker info` times out (exit 124); Aristotle `prove`
+  returns 404 "Resource not found". File is therefore **build-pending,
+  unregistered** — name-checked but not machine-verified this session.
+
+### Next Steps
+- Build under Docker once available; register in the gallery aggregate.
+- Optionally make the "ballot count" literal: a Dyck-path Finset whose card
+  equals `catalan n`.
+- Add a `decide`/`native_decide` numeric example after build is available.

--- a/src/data/research/problems/ballot-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-03.json
@@ -1,0 +1,65 @@
+{
+  "slug": "ballot-problem-oq-01-oq-03",
+  "title": "Ballot Problem OQ-01 OQ-03: Catalan number as a reflection/ballot count",
+  "tier": "B",
+  "significance": 7,
+  "tractability": 7,
+  "status": "in-progress",
+  "phase": "ACT",
+  "started": "2026-06-15",
+  "lastUpdate": "2026-06-15T00:00:00Z",
+  "path": "research/problems/ballot-problem-oq-01-oq-03",
+  "tags": ["combinatorics", "catalan", "ballot", "reflection-principle", "mathlib"],
+  "problemStatement": {
+    "formal": "catalan n = (2*n).choose n - (2*n).choose (n+1)",
+    "plain": "Derive the Catalan number identity from the ballot problem. The reflection principle behind the ballot theorem expresses C_n as (all monotone lattice paths) minus (reflected bad paths): catalan n = C(2n,n) - C(2n,n+1).",
+    "whyMatters": [
+      "The reflection form is the integer-arithmetic shadow of the ballot theorem's reflection argument.",
+      "It is distinct from Mathlib's division form catalan n = centralBinom n / (n+1) (it never divides)."
+    ]
+  },
+  "knowledge": {
+    "insights": [
+      "Mathlib already proves the DIVISION form catalan n = centralBinom n / (n+1) (catalan_eq_centralBinom_div) and (n+1)*catalan n = centralBinom n (succ_mul_catalan_eq_centralBinom). The research content for OQ-03 is the REFLECTION form catalan n = C(2n,n) - C(2n,n+1), the literal ballot count.",
+      "Key arithmetic bridge: (2n).choose (n+1) = n * catalan n (the count of reflected 'bad' paths), obtained from the adjacent-binomial recurrence choose_succ_right_eq and cancellation of (n+1).",
+      "Mathlib's gallery ballot proof (BallotProblem.lean) is measure-theoretic (countedSequence / ballot measure), so the Catalan connection is cleanest as a standalone integer identity rather than a derivation through the measure objects.",
+      "Numerically verified n=0..4: 1,1,2,5,14 match C(2n,n)-C(2n,n+1)."
+    ],
+    "builtItems": [
+      "two_mul_choose_eq : (2*n).choose n = (n+1)*catalan n (Proofs/BallotProblemOQ01OQ03.lean)",
+      "two_mul_choose_succ_eq : (2*n).choose (n+1) = n*catalan n (Proofs/BallotProblemOQ01OQ03.lean)",
+      "catalan_eq_choose_sub_choose : catalan n = (2*n).choose n - (2*n).choose (n+1) (Proofs/BallotProblemOQ01OQ03.lean)",
+      "choose_sub_choose_eq_centralBinom_div : reconciles reflection form with Mathlib division form (Proofs/BallotProblemOQ01OQ03.lean)"
+    ],
+    "mathlibGaps": [
+      "No direct lemma connecting a Dyck-path / ballot-sequence count to Nat.catalan; the integer reflection identity catalan n = C(2n,n)-C(2n,n+1) is not stated in Mathlib (only the division form)."
+    ],
+    "nextSteps": [
+      "Build under Docker (currently blocked by host blackout) and register BallotProblemOQ01OQ03.lean in the gallery.",
+      "Optionally connect to a concrete Dyck-path Finset count = catalan n to make the 'ballot count' interpretation literal rather than documentary.",
+      "Add a numeric example theorem (e.g. catalan 3 = C(6,3)-C(6,4) = 5) once build is available."
+    ],
+    "progressSummary": "PROGRESS: proved the reflection form catalan n = C(2n,n) - C(2n,n+1) (0 sorries, 0 axioms) build-pending under Docker blackout; reconciled with Mathlib's division form."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/BallotProblemOQ01OQ03.lean",
+      "filename": "BallotProblemOQ01OQ03.lean",
+      "lineCount": 92,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ03.lean"
+    }
+  ],
+  "relatedProofs": [
+    "ballot-problem",
+    "ballot-problem-oq-01",
+    "ballot-problem-oq-01-oq-01",
+    "ballot-problem-oq-01-oq-02"
+  ],
+  "currentState": "Reflection-form Catalan identity proved build-pending (dual Docker/Aristotle blackout); unregistered file.",
+  "significanceNote": "Routine but genuine: fills the integer reflection identity Mathlib lacks, tying the ballot reflection argument to Nat.catalan."
+}


### PR DESCRIPTION
## Summary

Derives the **reflection (ballot) form** of the Catalan number, the integer
identity behind the ballot theorem's reflection principle:

    catalan n = C(2n, n) − C(2n, n+1)

This is mathematically distinct from Mathlib's *division form*
`catalan_eq_centralBinom_div : catalan n = centralBinom n / (n + 1)` — it never
divides; it is the literal "(all monotone lattice paths) − (reflected bad
paths)" difference that the reflection argument produces.

## What's proved (`proofs/Proofs/BallotProblemOQ01OQ03.lean`, 4 theorems, 0 sorries, 0 axioms)

- `two_mul_choose_eq` : `(2n).choose n = (n+1) * catalan n`
- `two_mul_choose_succ_eq` : `(2n).choose (n+1) = n * catalan n` (reflected bad-path count)
- `catalan_eq_choose_sub_choose` : the headline reflection form
- `choose_sub_choose_eq_centralBinom_div` : reconciliation with Mathlib's division form

**Crux:** `(2n).choose (n+1) = n·catalan n` from `Nat.choose_succ_right_eq` +
cancelling `(n+1)`; combined with `(2n).choose n = (n+1)·catalan n` the
subtraction collapses via `add_one_mul` + `omega`.

## Verification status

- Numerically checked n=0..4: 1, 1, 2, 5, 14 all match `C(2n,n)-C(2n,n+1)`.
- All Mathlib lemma names name-checked against the sibling `../mathlib4` checkout
  (note: `catalan` and its lemmas are ROOT namespace, not `Nat.`).
- **Build-pending / unregistered**: dual blackout this session (Docker
  `docker info` exit 124; Aristotle `prove` 404). Not machine-verified yet.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ03` once Docker is available
- [ ] Register in gallery aggregate after build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)