### PR TITLE
Enrich Pell regulator R(D): cross-references

### DIFF
--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -40,6 +40,16 @@
       "targetId": "pell-equation",
       "relationship": "extends",
       "description": "Investigates the quantitative aspect of the Pell equation: how large is the fundamental solution as a function of D? Connects to the Pell regulator, class numbers, and computational complexity."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "The irrationality of $\\sqrt D$ (here $D = 2$) is the precondition for the Pell equation to have nontrivial solutions — for a perfect square $D$, $x^2 - Dy^2 = 1$ has only $(\\pm 1, 0)$. The continued-fraction expansion $\\sqrt 2 = [1;\\overline{2}]$ is the prototype of the periodic expansion of $\\sqrt D$ whose convergents produce the fundamental solution analyzed here."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "Generalizes the irrationality of $\\sqrt D$ underlying the Pell setup: nontrivial solutions to $x^2 - Dy^2 = 1$ exist exactly when $\\sqrt D \\notin \\mathbb{Q}$ — i.e. $D$ is not a perfect square — the $n = 2$ instance of the non-perfect-power criterion proved there."
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-01` (size of the fundamental Pell solution / regulator R(D)).

Annotations already complete (5, all with `mathContext`); gap was **1 cross-reference**. Gallery neighbors are genuinely sparse here, so I added only accurate links and explicitly avoided a tempting-but-wrong one.

## Changes
**Cross-references: 1 → 3** (all targets verified to exist)
- `sqrt2-irrational` — irrationality of √D is the precondition; √2 = [1;2̄] is the prototype periodic continued fraction yielding the fundamental solution
- `nth-root-irrational` — nontrivial Pell solutions exist iff D is not a perfect square (n=2 case)
- **Not linked:** `dirichlets-theorem` (primes in arithmetic progressions — unrelated to the regulator/class-number context)

No annotations padded. No Lean source or status metadata changed.

## Test plan
- [x] `pnpm build` succeeds
- [x] All cross-reference targets exist as gallery dirs
- [x] Committed change preserved through the build pipeline