### PR TITLE
Enrich Euler overpartition identities: cross-references

### DIFF
--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -120,6 +120,16 @@
       "targetId": "partition-theorem",
       "relationship": "extends",
       "description": "Extends Euler's partition identity (distinct=odd) to overpartitions via the 2^d generalization"
+    },
+    {
+      "targetId": "partition-theorem-oq-01",
+      "relationship": "related",
+      "description": "Sister partition identities of a different flavor: the Rogers–Ramanujan and Schur identities equate counts of partitions under gap/congruence restrictions. Overpartitions (this entry) have their own celebrated Rogers–Ramanujan-type analogues (Lovejoy), so both entries study the same landscape of restricted-partition bijections and generating functions."
+    },
+    {
+      "targetId": "partition-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A computational companion in the partition family: verifies the Rogers–Ramanujan identities for small $n$ by direct enumeration — the same finite-check methodology used to validate overpartition counts here before stating the general identity."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `partition-theorem-oq-03` (Euler partition identities for overpartitions).

Annotations already complete (5, all with `mathContext`); gap was **1 cross-reference**.

## Changes
**Cross-references: 1 → 3** (all targets verified to exist)
- `partition-theorem-oq-01` — Rogers–Ramanujan & Schur identities (same restricted-partition / generating-function landscape; overpartitions have RR-type analogues per Lovejoy)
- `partition-theorem-oq-01-oq-01` — computational RR verification (same finite-enumeration methodology)

No annotations padded. No Lean source or status metadata changed.

## Test plan
- [x] `pnpm build` succeeds
- [x] All cross-reference targets exist as gallery dirs
- [x] Committed change preserved through the build pipeline