### PR TITLE
Research: friendship-theorem-oq-04 - S3 contrapositive + name-check

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -32,6 +32,10 @@ that has no infinite analogue:
   restoring condition: the sole obstruction to finiteness is an infinite-degree
   vertex.
 
+* `infinite_friendship_has_infinite_degree` — the contrapositive: every *infinite*
+  friendship graph is forced to contain a vertex of infinite degree. Infinite degree
+  is not incidental to the known counterexamples — it is unavoidable.
+
 * `locally_finite_friendship_has_universal` — combining the above with the finite
   gallery theorem `FriendshipTheorem.friendship_theorem` recovers a universal
   vertex for any locally finite friendship graph with at least three vertices.
@@ -110,6 +114,21 @@ theorem locally_finite_is_finite (hF : IsFriendshipGraph G)
     (hfin : ∀ w : V, (G.neighborSet w).Finite) :
     Finite V :=
   Set.finite_univ_iff.mp (univ_finite_of_locallyFinite hF hfin)
+
+/-- **The sharp obstruction, stated positively.** Every *infinite* friendship graph
+has a vertex of infinite degree. This is the exact contrapositive of
+`locally_finite_is_finite`: an infinite friendship graph cannot be locally finite, so
+infinite degree is *forced*, not incidental. It pinpoints where the finite proof
+breaks — the dichotomy/spectral machinery silently assumes finite degrees. -/
+theorem infinite_friendship_has_infinite_degree (hF : IsFriendshipGraph G) [Infinite V] :
+    ∃ w : V, (G.neighborSet w).Infinite := by
+  by_contra h
+  have hfin : ∀ w : V, (G.neighborSet w).Finite := by
+    intro w
+    by_contra hw
+    exact h ⟨w, hw⟩
+  haveI : Finite V := locally_finite_is_finite hF hfin
+  exact not_finite V
 
 /-- **Conclusion restored.** A locally finite friendship graph with at least three
 vertices has a universal vertex — recovered from the finite gallery theorem via the

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -137,6 +137,37 @@ hand against in-repo lemma usages. Names to re-confirm at build time:
 This is the **positive half** of OQ-04 (sharp restoring condition). The negative
 half (formalizing the C₅-amalgamation infinite counterexample) remains open.
 
+## Session 3 (2026-06-15 — ACT, build-pending; verification + new theorem)
+
+**Docker/Aristotle blackout still live** (`docker info` times out). Two outcomes:
+
+### A. Full name-check / de-risk of Session-2's `FriendshipTheoremOQ04.lean`
+Verified all 12 Mathlib lemma names against sibling `/Users/rwalters/GitHub/mathlib4`
+v4.26 (matches pin). All present with assumed arities:
+- `Set.ncard_eq_one` (Data/Set/Card.lean:1117), `Set.Finite.biUnion`
+  (Data/Set/Finite/Lattice.lean:147, sig `(hs)(ht : ∀ i ∈ s, (t i).Finite)`),
+  `SimpleGraph.mem_commonNeighbors` (SimpleGraph/Basic.lean:749),
+  `SimpleGraph.mem_neighborSet` (Basic.lean:691), `Set.mem_biUnion`
+  (Set/Lattice.lean:600), `Finset.card_eq_three` (Finset/Card.lean:760),
+  `Finset.card_le_univ`, `Fintype.ofFinite`, `Set.finite_univ_iff`
+  (Set/Finite/Basic.lean:484), `Set.univ_eq_empty_iff` (Set/Basic.lean:556).
+- Parent `FriendshipTheorem.IsFriendshipGraph` (FriendshipTheorem.lean:79) is the
+  **identical** `∀ u v, u≠v → ncard=1` def ⟹ capstone coercion typechecks and
+  `friendship_theorem G hF h3` matches in-file call convention (G explicit, :232).
+  So the Session-2 file's "names to re-confirm" list is now cleared.
+
+### B. New theorem `infinite_friendship_has_infinite_degree`
+Added the **positive form of the obstruction**: `[Infinite V] ⟹ ∃ w, (G.neighborSet
+w).Infinite`. Exact contrapositive of `locally_finite_is_finite`. push_neg-free:
+`by_contra h`; per-vertex `by_contra hw` yields `¬(neighborSet w).Finite` which is
+*definitionally* `Set.Infinite`, fed to `h ⟨w, hw⟩`; then
+`haveI : Finite V := locally_finite_is_finite hF hfin`, close with `not_finite V`
+(Data/Finite/Defs.lean:160). Makes insight #3 a citable theorem, not prose.
+Still build-pending / unregistered — do NOT add to `Proofs.lean` under blackout.
+
+**Still open**: negative half — formalizing the C₅-amalgamation counterexample
+(concrete friendship graph, no universal vertex). Large, build-gated, not attempted.
+
 ## Dead Ends / Non-starters
 - Trying to recover the theorem via *regularity* alone fails: infinite degrees
   are all "equal" as cardinals, so regularity is vacuously satisfiable without a

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,14 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (build-pending): wrote FriendshipTheoremOQ04.lean — diameter-2 covering + locally-finite=>finite + universal-vertex capstone, the spectral-free positive result. Unregistered until a build backend confirms (dual blackout). Counterexample direction still open.",
+    "progressSummary": "PROGRESS: Positive half of OQ-04 formalized (sharp restoring condition = local finiteness) + new contrapositive theorem; full Mathlib name-check passed under Docker blackout. Build-pending/unregistered. Negative half (C5-amalgamation counterexample) still open.",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
       "friendship_diameter_two (FriendshipTheoremOQ04.lean:71): every friendship graph has diameter <=2 (G.Adj v u OR common neighbor x), no Fintype.",
       "univ_subset_two_ball (:79): univ subset {v} U N(v) U bigUnion_{x in N(v)} N(x) via exists_common_neighbor.",
       "univ_finite_of_locallyFinite (:96) + locally_finite_is_finite (:109): local finiteness => Finite V via Set.Finite.biUnion of the 2-ball covering.",
-      "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices."
+      "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices.",
+      "infinite_friendship_has_infinite_degree in FriendshipTheoremOQ04.lean (build-pending, unregistered)",
+      "S3: name-checked all 12 Mathlib deps of FriendshipTheoremOQ04.lean against sibling v4.26 — all confirmed"
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -45,7 +47,8 @@
       "RESTORING CONDITION = local finiteness: the diameter-2 covering makes V a finite union of finite sets => finite => windmill => universal vertex. Obstruction is precisely an infinite-degree vertex.",
       "WHERE finite proof breaks: spectral step friendship_regular_implies_universal (FriendshipTheorem.lean:193) is entirely finite-matrix (trace, finite eigenvalue multiplicities, integrality) with no infinite analogue. The regularity dichotomy degrades to vacuous (all infinite degrees equal as cardinals).",
       "ACT: the positive OQ-04 result is finiteness-light and spectral-free — the diameter-2 covering (purely local) plus local finiteness gives Finite V directly, bypassing the trace/eigenvalue step that has no infinite analogue.",
-      "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting."
+      "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting.",
+      "S3: Every infinite friendship graph has an infinite-degree vertex (infinite_friendship_has_infinite_degree) — exact contrapositive of locally_finite_is_finite; infinite degree is forced, not incidental."
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."


### PR DESCRIPTION
## Summary
Session 3 on `friendship-theorem-oq-04` (Friendship Theorem, infinite case). Builds on Session 2's positive-half formalization in `FriendshipTheoremOQ04.lean`.

## Progress
- **New theorem** `infinite_friendship_has_infinite_degree`: every *infinite* friendship graph has a vertex of infinite degree. This is the exact contrapositive of Session-2's `locally_finite_is_finite`, turning the prose insight ("the sole obstruction is an infinite-degree vertex") into a citable theorem. push_neg-free proof: `by_contra`, per-vertex `by_contra` exploits `Set.Infinite = ¬Set.Finite` definitionally, closes via `not_finite`.
- **Full de-risk** of the build-pending Session-2 file: verified all 12 Mathlib lemma names against the sibling `mathlib4` v4.26 checkout (matches repo pin), and confirmed the parent `FriendshipTheorem.IsFriendshipGraph` is the identical definition so the capstone's hypothesis coercion typechecks. Clears the prior "names to re-confirm at build time" list.

## Files
- `proofs/Proofs/FriendshipTheoremOQ04.lean` (new theorem + docstring)
- `research/problems/friendship-theorem-oq-04/knowledge.md` (Session 3 notes)
- `src/data/research/problems/friendship-theorem-oq-04.json` (insights)

## Status
**Outcome**: progress (build-pending — Docker build host + Aristotle backend unavailable; statically name-checked, not machine-checked; file remains **unregistered** in `Proofs.lean` to keep the auto-merged aggregate green).
**Next Steps**: register + Docker-build `FriendshipTheoremOQ04.lean` once the backend returns; tackle the negative half (formalize the C₅ free-amalgamation infinite counterexample with no universal vertex).

🤖 Generated by researcher-4