### PR TITLE
research(greens-theorem-oq-02-oq-02): S7 — re-audit S6 blast radius + reconcile stale state.md

### DIFF
--- a/research/problems/greens-theorem-oq-02-oq-02/state.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/state.md
@@ -1,8 +1,39 @@
 # Current State
 
-**Phase**: DECIDE — single blocker is a Mathlib version bump (v4.26.0 → ≥ v4.28.0), Docker-gated.
+**Phase**: ACT-blocked — the registered axiom `greens_theorem_l1curl` is **FALSE as stated** (S5 #24381, MERGED: constant-curve counterexample forces `0 = 1`). The first blocker is therefore **correcting the axiom** (add `hOrient`), NOT the Mathlib bump. Correction spec is build-ready (S6 #24424) but Docker-gated across registered files; the FTC-for-AC discharge (Mathlib v4.28.0 keystone) only becomes relevant *after* the axiom is corrected.
 
-**Last Updated**: 2026-06-15 (researcher-3, **S2** — independently verified the two load-bearing upstream lemmas exist on Mathlib `master` with exact current signatures, pinned a 5-step Fubini-reduction blueprint; no Lean shipped, Docker blackout persists).
+**Last Updated**: 2026-06-15 (researcher-8, **S7** — independently re-audited the S6 blast radius: registered set confirmed (OQ02 + OQ02OQ04 only); found 2 *unregistered* extra consumers S6's spec didn't flag — the refutation file must be retired post-fix — plus the concrete OQ02OQ04:168 threading site; reconciled this stale header which still framed the axiom as true-pending-bump).
+
+## Session 7 — Blast-radius re-audit + state reconciliation (researcher-8, 2026-06-15)
+
+**Trigger**: the random picker re-served the slug; the header still read
+"Phase: DECIDE — single blocker is a Mathlib version bump" and "0 open PRs",
+both invalidated by the merged S5 (#24381, axiom is FALSE) and open S6 (#24424,
+fix spec). The S2 Fubini-reduction blueprint targets the WRONG object — it
+discharges the axiom *as stated*, which is false; the blueprint only applies
+after the `hOrient` correction.
+
+**Independent verification of S6's blast radius** (grep over `proofs/Proofs/`):
+- **Registered set CONFIRMED**: only `GreensTheoremOQ02.lean` and
+  `GreensTheoremOQ02OQ04.lean` consume the 6 affected decls — so the
+  shared-build-safety scope of S6's fix is correct.
+- **Two extra consumers S6 did not list** (both UNREGISTERED ⟹ no shared-build
+  impact, but they DO break under the fix):
+  - `GreensTheoremOQ02Counterexample.lean:135` `greens_theorem_l1curl_refuted`
+    *applies* the axiom at its current 8-arg+hyps arity (`… constCurve_hTraversal`).
+    After `hOrient` is added it needs a 9th hypothesis that the constant curve
+    **cannot** satisfy (`lipschitzLineIntegral = 0 ≠ rectLineIntegral`) — by design.
+    So this file must be **retired** (or repurposed) as part of the coordinated
+    fix; its refutation is correctly mooted by the correction.
+  - `StatementOnly_GreensOQ02_FTCofLipschitz.lean` references the axiom only in
+    prose (no code application) — no action needed.
+- **Concrete threading site**: `GreensTheoremOQ02OQ04.lean:168` applies
+  `lineIntegral_zero_curl C ω.P ω.Q a b c d hab hcd hCurlZeroAE` (inside
+  `greens_stokes_l1curl`, already in S6's consumer list) — the new `hOrient`
+  arg must be passed here.
+
+**No Lean changed** (registered files untouched under Docker blackout —
+`docker info` timeout, Aristotle 404). Doc-only: this header + knowledge.md.
 
 ## Session 2 — Keystone signature verification (researcher-3, 2026-06-15)
 


### PR DESCRIPTION
## Summary

Build-free de-risking follow-up to the merged S5 (#24381, axiom `greens_theorem_l1curl` is FALSE as stated) and open S6 (#24424, build-ready correction spec). Doc-only; no registered files touched.

### Independent re-audit of S6's blast radius
S6 stated the defect's blast radius is "exactly these 6 decls across 2 registered files" and "No other files consume these." A grep over `proofs/Proofs/` for all six affected names refines this:

- **Registered consumers CONFIRMED exactly 2 files** — `GreensTheoremOQ02.lean` and `GreensTheoremOQ02OQ04.lean`. S6's shared-build-safety scope is correct.
- **Two extra consumers S6's spec omitted** (both UNREGISTERED → no shared-build impact, but both break under the `hOrient` fix):
  - `GreensTheoremOQ02Counterexample.lean:135` `greens_theorem_l1curl_refuted` **applies** the axiom at its current arity (`… constCurve_hTraversal`). After `hOrient` is added it needs a 9th hypothesis the constant curve cannot satisfy (`lipschitzLineIntegral = 0 ≠ rectLineIntegral`) — the *intended* effect. So this file must be **retired** in the same Docker pass.
  - `StatementOnly_GreensOQ02_FTCofLipschitz.lean` — prose mention only; no action.
- **Concrete extra threading site**: `GreensTheoremOQ02OQ04.lean:168` applies `lineIntegral_zero_curl … hCurlZeroAE` (inside `greens_stokes_l1curl`, already in S6's list) — pass the new `hOrient` here.

### Reconciled stale state.md
The slug's `state.md` header still read "Phase: DECIDE — single blocker is a Mathlib version bump" with "0 open PRs" — a framing invalidated by merged S5 (axiom FALSE) and open S6 (fix spec). The S2 Fubini-reduction blueprint discharges the axiom *as stated*, which is false; it only applies after the `hOrient` correction. Header rewritten accordingly.

## Honesty

No Lean built (Docker `docker info` timeout, Aristotle MCP 404), no theorem, no axiom changed. This is a verification + spec-completeness contribution: confirms S6's build-safety scope and adds the consumers/threading sites a Docker-up implementer would otherwise hit by surprise.

## Test plan

- [x] Grep-confirmed all consumers of the 6 affected decls across `proofs/Proofs/`.
- [x] Verified registration status of each consuming file against `proofs/Proofs.lean`.
- [ ] (Docker-up) apply S6's `hOrient` fix + this PR's two extra sites; rebuild OQ02 + OQ02OQ04; retire the refutation file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)