### PR TITLE
research(birthday-problem-oq-01-oq-01-oq-03): S4 ACT — Schur-concavity kernel for Pr(X=0) extremum

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03Schur.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03Schur.lean
@@ -1,0 +1,96 @@
+/-
+  Birthday Problem OQ-01-OQ-01-OQ-03 (Schur side): the no-collision probability
+  `Pr_p(X = 0)` is *maximized* at the uniform distribution.
+
+  Companion to `BirthdayProblemOQ01OQ01OQ03.lean` (draft PR #23219), which settles
+  the *collision-count* side: `E_p[X] = C(n,2)·∑ p_k²` is *minimized* at uniform via
+  Cauchy–Schwarz. This file formalizes the algebraic kernel of the dual statement,
+  certified symbolically in `verify_no_collision_extremum.py`:
+
+      Pr_p(X = 0) = n! · e_n(p)        (e_n = degree-n elementary symmetric poly)
+
+  and uniform maximizes `e_n` on the probability simplex because `e_n` is
+  Schur-concave. The whole Schur-concavity argument reduces, via the
+  Hardy–Littlewood–Pólya transfer principle, to a single pairwise-equalization
+  step: replacing two coordinates `(x, y)` by their common mean `m = (x+y)/2`
+  never decreases `e_n` (and strictly increases it unless `x = y`).
+
+  The key structural fact making this elementary is that `e_n` is **biaffine** in
+  any two of its arguments: degree ≤ 1 in each separately. Fixing all other
+  coordinates and isolating two distinguished ones `x, y`, the symmetric
+  elementary polynomial takes the shape
+
+      g x y = A + (x + y)·B + x·y·C,
+
+  where `A = e_n(rest)`, `B = e_{n-1}(rest)`, `C = e_{n-2}(rest)` are the
+  elementary symmetric polynomials of the *remaining* coordinates, and for a
+  probability vector `C ≥ 0` (a sum of products of nonnegatives). The transfer
+  step is then a pure inequality about this biaffine form, proved below.
+
+  This is the missing Lean kernel for "uniform maximizes Pr(X=0)"; assembling it
+  into the full simplex extremum (a finite chain of such transfers, i.e.
+  majorization) plus the `Pr = n!·e_n` counting identity is the remaining ACT,
+  build-gated by the Docker outage of 2026-06-13/15.
+
+  BUILD STATUS: not yet machine-checked (written during the Docker / `lake build`
+  verification outage). All Mathlib lemma names verified against the pinned
+  Mathlib v4.26.0 sibling checkout; the inequalities are discharged by
+  `nlinarith`/`linear_combination` with explicit `sq_nonneg` witnesses.
+-/
+import Mathlib
+
+namespace BirthdayCollisionSchur
+
+/-- A symmetric **biaffine** form in two real variables:
+    `g x y = A + (x + y)·B + x·y·C`. Any elementary symmetric polynomial,
+    viewed as a function of two of its coordinates with the rest fixed, has this
+    shape, with `A`, `B`, `C` the elementary symmetric polynomials of the
+    remaining coordinates. -/
+def biaffine (A B C x y : ℝ) : ℝ := A + (x + y) * B + x * y * C
+
+/-- **Equalization increment.** Moving the two coordinates to their common mean
+    `m = (x+y)/2` changes the biaffine form by exactly `((x - y)/2)² · C`.
+    This is the one identity underlying Schur-concavity of `e_n`. -/
+theorem biaffine_mean_sub (A B C x y : ℝ) :
+    biaffine A B C ((x + y) / 2) ((x + y) / 2) - biaffine A B C x y
+      = ((x - y) / 2) ^ 2 * C := by
+  unfold biaffine
+  ring
+
+/-- **Hardy–Littlewood–Pólya transfer step (weak form).** If the "weight"
+    coefficient `C` is nonnegative, replacing `(x, y)` by their mean never
+    decreases the biaffine form. For `e_n` of a probability vector, `C = e_{n-2}`
+    of the remaining coordinates is `≥ 0`, so this says equalizing two
+    probabilities never decreases `e_n` — uniform is the maximizer. -/
+theorem biaffine_le_mean (A B C x y : ℝ) (hC : 0 ≤ C) :
+    biaffine A B C x y ≤ biaffine A B C ((x + y) / 2) ((x + y) / 2) := by
+  have h := biaffine_mean_sub A B C x y
+  have hsq : 0 ≤ ((x - y) / 2) ^ 2 * C := mul_nonneg (sq_nonneg _) hC
+  linarith [h, hsq]
+
+/-- **Strict transfer step.** If the weight `C` is strictly positive and the two
+    coordinates differ, equalizing them strictly increases the form. This gives
+    uniqueness: uniform is the *unique* maximizer of `e_n` (hence of `Pr(X=0)`)
+    whenever the relevant lower-order symmetric weights are positive. -/
+theorem biaffine_lt_mean (A B C x y : ℝ) (hC : 0 < C) (hxy : x ≠ y) :
+    biaffine A B C x y < biaffine A B C ((x + y) / 2) ((x + y) / 2) := by
+  have h := biaffine_mean_sub A B C x y
+  have hpos : 0 < ((x - y) / 2) ^ 2 * C :=
+    mul_pos (sq_pos_of_ne_zero (div_ne_zero (sub_ne_zero.mpr hxy) two_ne_zero)) hC
+  linarith [h, hpos]
+
+/-- **Equality characterization of the transfer step.** With positive weight,
+    equality of the biaffine form at `(x, y)` and at the equalized pair holds iff
+    the two coordinates were already equal. -/
+theorem biaffine_eq_mean_iff (A B C x y : ℝ) (hC : 0 < C) :
+    biaffine A B C x y = biaffine A B C ((x + y) / 2) ((x + y) / 2) ↔ x = y := by
+  constructor
+  · intro heq
+    by_contra hne
+    exact absurd heq (ne_of_lt (biaffine_lt_mean A B C x y hC hne))
+  · intro hxy
+    subst hxy
+    have : (x + x) / 2 = x := by ring
+    rw [this]
+
+end BirthdayCollisionSchur

--- a/research/problems/birthday-problem-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/birthday-problem-oq-01-oq-01-oq-03/state.md
@@ -4,7 +4,35 @@
 **Phase**: ACT (written, build-pending)
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 3
+**Iteration**: 4
+
+## Session 2026-06-15 (S4, researcher-5) — Pr(X=0) Schur kernel + #23219 name-check
+Dual blackout still LIVE (`docker info` hangs >15s; Aristotle 404 per prior sessions).
+Build-free deliverables this session:
+
+1. **De-risked draft #23219** (the artifact gating completion). Name-checked
+   EVERY Mathlib lemma it uses against the pinned v4.26.0 sibling
+   (`/Users/rwalters/GitHub/mathlib4`): all current, non-deprecated —
+   `div_le_iff₀`, `Finset.sum_sub_distrib`, `sum_add_distrib`, `sq_eq_zero_iff`,
+   `mul_le_mul_of_nonneg_left`, `card_insert_of_notMem` (NOT the deprecated
+   `_not_mem` alias), `Finset.sum_eq_zero_iff_of_nonneg`. The CS port is verbatim
+   from a building ℚ file. ⟹ #23219 is name-clean; when Docker returns it should
+   build and can be promoted immediately.
+
+2. **NEW Lean: the Schur-concavity kernel** for the dual "uniform MAXIMISES
+   Pr(X=0)" side, in a non-colliding companion `BirthdayProblemOQ01OQ01OQ03Schur.lean`
+   (namespace `BirthdayCollisionSchur`). e_n is biaffine in any two coords:
+   `g x y = A + (x+y)B + xy·C`. Proved (0 sorry, 0 axiom):
+   - `biaffine_mean_sub`: `g(m,m) − g(x,y) = ((x−y)/2)²·C`  (m=(x+y)/2), pure `ring`.
+   - `biaffine_le_mean` (C≥0): equalizing never decreases g — the HLP transfer step.
+   - `biaffine_lt_mean` (C>0, x≠y): strict increase ⟹ uniqueness.
+   - `biaffine_eq_mean_iff` (C>0): equality ⟺ x=y.
+   This is the algebraic heart of N2/N3 (Schur-concavity of e_n), Python-certified
+   in verify_no_collision_extremum.py. All names verified (`sq_pos_of_ne_zero`,
+   `div_ne_zero`, `two_ne_zero`, `sub_ne_zero`, `mul_pos`). Build-pending UNREGISTERED.
+
+3. Re-ran all 3 certifiers (verify_nonuniform / verify_t3_converse_certificate /
+   verify_no_collision_extremum): ALL PASS.
 
 ## Current Focus
 Non-uniform generalization surveyed. Precise formal target fixed:


### PR DESCRIPTION
## Summary
Research session S4 for `birthday-problem-oq-01-oq-01-oq-03` (non-uniform birthday / hash-collision generalization). The OQ resolves to: uniform is the extremum on **both** sides — it *minimizes* `E[X] = C(n,2)·∑pₖ²` (Cauchy–Schwarz, draft #23219) and *maximizes* the no-collision probability `Pr(X=0) = n!·eₙ(p)` (Schur-concavity of `eₙ`). This PR formalizes the **algebraic kernel of the Pr(X=0) side**, the half with no Lean yet.

## Progress
- **New `proofs/Proofs/BirthdayProblemOQ01OQ01OQ03Schur.lean`** (0 sorry, 0 axiom; non-colliding with draft #23219). `eₙ` is biaffine in any two coordinates: `g x y = A + (x+y)B + xy·C` with `A=eₙ(rest)`, `B=eₙ₋₁(rest)`, `C=eₙ₋₂(rest) ≥ 0`. Proved:
  - `biaffine_mean_sub`: `g(m,m) − g(x,y) = ((x−y)/2)²·C` for `m=(x+y)/2` (pure `ring`).
  - `biaffine_le_mean` (C≥0): equalizing two coords never decreases `g` — the Hardy–Littlewood–Pólya transfer step underlying Schur-concavity.
  - `biaffine_lt_mean` (C>0, x≠y) and `biaffine_eq_mean_iff` (C>0): strictness + uniqueness.
- **De-risked draft #23219** (E[X] side, the artifact gating completion): name-checked every Mathlib lemma against the pinned **v4.26.0** sibling checkout — all current and non-deprecated.
- Re-ran all three Python certifiers (`verify_nonuniform`, `verify_t3_converse_certificate`, `verify_no_collision_extremum`): **all pass**.

## Findings
- The entire Schur-concavity argument reduces to one pairwise-equalization inequality about a biaffine form; the increment is exactly `((x−y)/2)²·C`. Formalizing this needs no `eₙ`/measure machinery and is fully discharged by `ring`/`linarith` + verified `sq_pos_of_ne_zero`/`div_ne_zero`/`mul_pos`.
- Mathlib provides `MvPolynomial.esymm` / `Multiset.esymm` (Vieta.lean) but **no** ready Schur-concavity of `eₙ`; the transfer-chain route (kernel now done) is the path.

## Status
**Outcome**: progress (build-pending — Docker `lake build` + Aristotle outage still live; new file not yet machine-checked).
**Next Steps**: when Docker returns, build both files; promote #23219. To fully close the Pr(X=0) side: (1) `Pr(X=0)=n!·eₙ` counting identity, (2) bridge `eₙ`-in-two-coords ↔ `biaffine` with `C=eₙ₋₂≥0`, (3) majorization transfer-chain to uniform.

🤖 Generated by researcher-5