### PR TITLE
Enrich inverse-galois-a5-oq-02: fix stale axiom metadata + add depth

### DIFF
--- a/src/data/proofs/inverse-galois-a5-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-a5-oq-02/annotations.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "ann-trinks-polynomial",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 82
+    },
+    "type": "definition",
+    "title": "Trinks' Polynomial f(x) = x⁷ − 7x + 3",
+    "content": "Defines the degree-7 witness whose Galois group over ℚ is PSL(2,7). Discovered by W. Trinks in 1968, it is the standard explicit polynomial realizing the order-168 simple group. The `noncomputable` marker is required because polynomial arithmetic over ℚ routes through Mathlib's noncomputable field structure. Its splitting field is a degree-168 Galois extension of ℚ, and the roots carry the PSL(2,7)-action on the 7 points of the Fano plane.",
+    "mathContext": "$f(x) = x^7 - 7x + 3,\\quad \\mathrm{Gal}(f/\\mathbb{Q}) \\cong \\mathrm{PSL}(2,7) \\cong \\mathrm{GL}(3,2),\\ |G| = 168$",
+    "significance": "key",
+    "prerequisites": [
+      "field theory",
+      "Galois theory",
+      "finite simple groups"
+    ],
+    "relatedConcepts": [
+      "inverse Galois problem",
+      "PSL(2,7)",
+      "Fano plane",
+      "splitting field",
+      "Klein quartic"
+    ]
+  },
+  {
+    "id": "ann-discriminant",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Square Discriminant: disc(f) = 194481² = 3⁸·7⁸",
+    "content": "Two `norm_num` identities establish that the discriminant value 37822859361 is a perfect square (194481²) and factors as 3⁸·7⁸. A square discriminant is exactly the criterion for Gal(f) ⊆ Aₙ (here A₇): the square root of the discriminant is fixed by the Galois action iff every element acts as an even permutation. The factorization 3⁸·7⁸ also pins the ramified primes to {3, 7}. The bridge 'square disc ⟹ ⊆ Aₙ' and the degree-7 discriminant computation itself are part of the deferred analytic certificate (not in Mathlib 4.26.0).",
+    "mathContext": "$\\mathrm{disc}(f) = 37822859361 = 194481^2 = (3^4\\cdot 7^4)^2 = 3^8\\cdot 7^8 \\in (\\mathbb{Q}^\\times)^2 \\Rightarrow \\mathrm{Gal}(f)\\subseteq A_7$",
+    "significance": "supporting",
+    "prerequisites": [
+      "discriminant of a polynomial",
+      "alternating group",
+      "even permutations"
+    ],
+    "relatedConcepts": [
+      "discriminant",
+      "alternating group",
+      "even permutation",
+      "ramification"
+    ]
+  },
+  {
+    "id": "ann-simplicity-collapse",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "The Simplicity Collapse (general group theory)",
+    "content": "The session's substantive, fully machine-checked result. In any finite simple group G of order 168, a subgroup H with 84 ∣ |H| must equal the whole group. Proof: Lagrange (|H| ∣ 168) together with 84 ∣ |H| forces |H| ∈ {84, 168}; an order-84 subgroup would have index 2, hence be normal (`Subgroup.normal_of_index_eq_two`), contradicting simplicity (`IsSimpleGroup.eq_bot_or_eq_top_of_normal` leaves only ⊥ or ⊤, neither of order 84). This isolates why |Gal| = 168 follows from the divisibility data without enumerating the transitive subgroups of A₇ — the classical bottleneck. Proved with zero axioms.",
+    "mathContext": "$G \\text{ simple},\\ |G|=168,\\ H\\le G,\\ 84\\mid|H| \\;\\Rightarrow\\; H = G.\\quad [G:H]=2 \\Rightarrow H\\trianglelefteq G \\Rightarrow H\\in\\{\\bot,\\top\\}$ — contradiction.",
+    "significance": "key",
+    "prerequisites": [
+      "group theory",
+      "Lagrange's theorem",
+      "normal subgroups",
+      "simple groups"
+    ],
+    "relatedConcepts": [
+      "simple group",
+      "Lagrange's theorem",
+      "index-2 subgroups are normal",
+      "normal subgroup"
+    ]
+  },
+  {
+    "id": "ann-embedding-corollary",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 140,
+      "endLine": 152
+    },
+    "type": "theorem",
+    "title": "Embedding Corollary: injection into simple-168 forces |G| = 168",
+    "content": "The reusable abstract form of the certificate's conclusion. If a finite group Gal with 84 ∣ |Gal| injects (via an injective homomorphism φ) into a simple group P of order 168, then |Gal| = 168 and φ is an isomorphism onto P. Proof: `MonoidHom.ofInjective` gives Gal ≃* φ.range; the collapse theorem forces φ.range = ⊤, so |Gal| = |φ.range| = |P| = 168. This is the bridge that consumes the geometric embedding axiom and outputs the order, independent of the specific polynomial.",
+    "mathContext": "$\\varphi:\\mathrm{Gal}\\hookrightarrow P \\text{ injective},\\ P \\text{ simple},\\ |P|=168,\\ 84\\mid|\\mathrm{Gal}| \\;\\Rightarrow\\; |\\mathrm{Gal}|=168 \\text{ and } \\varphi(\\mathrm{Gal})=P$",
+    "significance": "key",
+    "prerequisites": [
+      "group homomorphisms",
+      "injective maps",
+      "isomorphism theorems"
+    ],
+    "relatedConcepts": [
+      "MonoidHom.ofInjective",
+      "group embedding",
+      "first isomorphism theorem",
+      "image subgroup"
+    ]
+  },
+  {
+    "id": "ann-axiom-cycle-types",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 164,
+      "endLine": 164
+    },
+    "type": "axiom",
+    "title": "Certificate Axiom 1: 84 ∣ |Gal| from Dedekind cycle types",
+    "content": "The first deferred analytic input. Reducing f modulo unramified primes and reading off the factorization (Dedekind's theorem) yields Galois elements with prescribed cycle types: f mod 2 = x⁷+x+1 is irreducible ⟹ a 7-cycle (order 7); f mod 13 has type (1,2,4) ⟹ an order-4 element; f mod 17 has type (1,3,3) ⟹ an order-3 element. Hence lcm(7,4,3) = 84 divides |Gal|. Verified exactly in verify_trinks_psl27.py; the Lean discharge needs Dedekind's theorem, which is absent from Mathlib 4.26.0.",
+    "mathContext": "$f \\bmod 2 \\text{ irred.} \\Rightarrow 7\\mid|G|;\\ (1,2,4)\\bmod 13 \\Rightarrow 4\\mid|G|;\\ (1,3,3)\\bmod 17 \\Rightarrow 3\\mid|G|;\\ \\mathrm{lcm}(7,4,3)=84\\mid|G|$",
+    "significance": "supporting",
+    "prerequisites": [
+      "algebraic number theory",
+      "factorization mod p",
+      "Frobenius automorphism"
+    ],
+    "relatedConcepts": [
+      "Dedekind's theorem",
+      "Frobenius element",
+      "cycle type",
+      "reduction mod p",
+      "Chebotarev density"
+    ]
+  },
+  {
+    "id": "ann-axiom-embedding",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 177,
+      "endLine": 179
+    },
+    "type": "axiom",
+    "title": "Certificate Axiom 2: the geometric embedding Gal ↪ PSL(2,7)",
+    "content": "The single honest analytic input that replaced two earlier axioms (PR #24436). It states that Gal(f/ℚ) injects into a finite simple group of order 168 (PSL(2,7)): irreducibility gives transitivity, the square discriminant gives Gal ⊆ A₇, and the rational root of the degree-15 PSL(2,7)-resolvent ([A₇:PSL(2,7)] = 15) gives the injection. This is strictly stronger than the bare divisibility |Gal| ∣ 168 (mere Lagrange), and — crucially — it lets the proven simplicity collapse discharge the former separate |Gal| ≠ 84 axiom as a theorem. Net axiom economy: 3 → 2.",
+    "mathContext": "$\\exists\\,P\\ \\text{simple},\\ |P|=168,\\ \\exists\\,\\varphi:\\mathrm{Gal}(f/\\mathbb{Q})\\hookrightarrow P.\\qquad [A_7:\\mathrm{PSL}(2,7)] = 2520/168 = 15$",
+    "significance": "key",
+    "prerequisites": [
+      "Galois theory",
+      "resolvent method",
+      "group actions"
+    ],
+    "relatedConcepts": [
+      "resolvent polynomial",
+      "transitive subgroup",
+      "PSL(2,7)",
+      "axiom economy",
+      "Galois resolvent"
+    ]
+  },
+  {
+    "id": "ann-main-result",
+    "proofId": "inverse-galois-a5-oq-02",
+    "range": {
+      "startLine": 191,
+      "endLine": 195
+    },
+    "type": "theorem",
+    "title": "Main Result: |Gal(f/ℚ)| = 168 (derived, not assumed)",
+    "content": "The order of the Galois group is derived — not axiomatized — by feeding the embedding axiom `trinks_gal_embeds_simple168` and the cycle-type divisibility `trinks_gal_84_dvd` into the proven collapse corollary `card_eq_168_of_embeds_in_simple168`. Composed with the (deferred) identification of the target as PSL(2,7), this realizes PSL(2,7) as a Galois group over ℚ — the second non-solvable simple group in the gallery after A₅ (order 60). The proof destructures the existential embedding axiom, re-installs the Group/Finite instances via `haveI`, and applies the corollary.",
+    "mathContext": "$|\\mathrm{Gal}(f/\\mathbb{Q})| = 168 = |\\mathrm{PSL}(2,7)|,\\ \\text{derived from } 84\\mid|G| \\text{ and } G\\hookrightarrow \\text{simple-}168$",
+    "significance": "key",
+    "prerequisites": [
+      "Galois theory",
+      "finite simple groups"
+    ],
+    "relatedConcepts": [
+      "inverse Galois problem",
+      "PSL(2,7)",
+      "non-solvable group",
+      "A₅ realization"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-a5-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-02/meta.json
@@ -21,17 +21,17 @@
     "proofRepoPath": "Proofs/InverseGaloisA5OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "assumptions": "3 axioms encoding the analytic certificate for f(x) = x⁷ − 7x + 3, all verified exactly in verify_trinks_psl27.py: (1) `trinks_gal_84_dvd` — 84 ∣ |Gal| from Dedekind cycle types (f mod 2 irreducible ⟹ 7-cycle; f mod 13 type (1,2,4) ⟹ order 4; f mod 17 type (1,3,3) ⟹ order 3); (2) `trinks_gal_card_dvd_168` — |Gal| ∣ 168 from irreducibility + square discriminant (disc = 3⁸·7⁸ = 194481²) ⟹ Gal ⊆ A₇, plus the degree-15 PSL(2,7)-resolvent's rational root ⟹ Gal ⊆ PSL(2,7); (3) `trinks_gal_card_ne_84` — |Gal| ≠ 84 by simplicity, whose rigorous reason is the proved theorem `simple168_subgroup_card_collapse`. None of Dedekind's theorem, 'square disc ⟹ ⊆ Aₙ', or the degree-15 resolvent is in Mathlib 4.26.0; these are the genuinely multi-week deferred ACT.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms encoding the analytic certificate for f(x) = x⁷ − 7x + 3, both verified exactly in verify_trinks_psl27.py: (1) `trinks_gal_84_dvd` — 84 ∣ |Gal| from Dedekind cycle types (f mod 2 irreducible ⟹ 7-cycle; f mod 13 type (1,2,4) ⟹ order 4; f mod 17 type (1,3,3) ⟹ order 3, so lcm(7,4,3) = 84); (2) `trinks_gal_embeds_simple168` — an injection Gal ↪ P into a finite simple group P of order 168 (PSL(2,7)), from irreducibility (transitivity) + square discriminant disc(f) = 3⁸·7⁸ = 194481² (⟹ Gal ⊆ A₇) + the degree-15 PSL(2,7)-resolvent's rational root. A previous third axiom (`trinks_gal_card_ne_84`) was eliminated (PR #24436): the embedding lets the proved `simple168_subgroup_card_collapse` discharge |Gal| ≠ 84 as a theorem — an index-2 subgroup of a simple group cannot exist. Neither Dedekind's theorem, 'square disc ⟹ ⊆ Aₙ', nor the degree-15 resolvent is in Mathlib 4.26.0; these are the genuinely multi-week deferred ACT.",
     "originalContributions": [
       "simple168_subgroup_card_collapse: in a finite simple group of order 168, any subgroup H with 84 ∣ |H| equals ⊤ (proved via Lagrange + index-2-normal + simplicity; the key insight that removes the A₇ transitive-subgroup classification)",
       "card_eq_168_of_embeds_in_simple168: a finite group with 84 ∣ |G| injecting into a simple group of order 168 has order exactly 168 (reusable corollary via MonoidHom.ofInjective)",
       "trinks_disc_is_square / trinks_disc_factorization: disc(f) = 37822859361 = 194481² = 3⁸·7⁸",
-      "trinks_gal_card: |Gal(f/ℚ)| = 168, assembled from the three certificate axioms",
+      "trinks_gal_card: |Gal(f/ℚ)| = 168, derived (not assumed) from the embedding axiom `trinks_gal_embeds_simple168` and the cycle-type divisibility `trinks_gal_84_dvd` via `card_eq_168_of_embeds_in_simple168`; the former separate `|Gal| ≠ 84` axiom is eliminated",
       "verify_collapse.py: independent verification of the collapse arithmetic and a full GL(3,2) enumeration (168 matrices, Fano-point cycle-type classes {1,21,42,56,48}, element orders {1,2,3,4,7})"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 189,
+    "lineCount": 197,
     "theoremCount": 5,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -41,8 +41,8 @@
       "Mathlib"
     ],
     "namespace": "InverseGaloisA5OQ02",
-    "lineCount": 189,
-    "axiomCount": 3,
+    "lineCount": 197,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/InverseGaloisA5OQ02.lean",
@@ -60,5 +60,85 @@
       "description": "Lists PSL(2,7) (order 168) explicitly as the next target beyond A₅ on the non-solvable frontier."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The inverse Galois problem asks which finite groups arise as Gal(K/ℚ). Hilbert (1892) realized every symmetric group Sₙ and alternating group Aₙ over ℚ via his irreducibility theorem; Shafarevich (1954) settled all solvable groups; the general problem remains open. The non-solvable frontier is approached one finite simple group at a time. After A₅ (order 60, the smallest non-abelian simple group — realized in the gallery's `inverse-galois-a5`), the next is PSL(2,7) ≅ GL(3,2) ≅ PSL(3,2), the simple group of order 168 — the automorphism group of the Fano plane (the projective plane over 𝔽₂) and of Klein's quartic curve x³y + y³z + z³x = 0. W. Trinks exhibited f(x) = x⁷ − 7x + 3 in 1968 as an explicit degree-7 polynomial with this Galois group; it remains the textbook witness (it appears in Serre's 'Topics in Galois Theory' and in the LMFDB). The PSL(2,7) action on the 7 points of the Fano plane gives the degree-7 permutation realization inside S₇ that the polynomial's roots exhibit.",
+    "problemStatement": "Extend the gallery's A₅ realization to the next non-solvable simple group by proving that Trinks' polynomial realizes a Galois group of order 168 over ℚ: $|\\mathrm{Gal}(f/\\mathbb{Q})| = 168$ for $f(x) = x^7 - 7x + 3$, with $\\mathrm{Gal}(f/\\mathbb{Q}) \\cong \\mathrm{PSL}(2,7)$. The session additionally isolates the group-theoretic core as machine-checked general mathematics.",
+    "proofStrategy": "The classical certificate has five steps: (1) f mod 2 = x⁷+x+1 is irreducible over 𝔽₂, so f is irreducible over ℚ and Gal acts transitively (7 ∣ |Gal|); (2) disc(f) = 3⁸·7⁸ = 194481² is a perfect square, so Gal ⊆ A₇; (3) Frobenius cycle types {(7),(1,2,4),(1,3,3)} at primes 2, 13, 17 supply elements of orders 7, 4, 3, so lcm(7,4,3) = 84 ∣ |Gal|; (4) the degree-15 PSL(2,7)-resolvent ([A₇:PSL(2,7)] = 15) has a rational root, embedding Gal ↪ PSL(2,7); (5) the simplicity collapse: 84 ∣ |Gal| and |Gal| ∣ 168 leave |Gal| ∈ {84,168}, and an order-84 subgroup of the simple group PSL(2,7) would have index 2 hence be normal — impossible — so |Gal| = 168. The Lean file proves step 5 as a general theorem and assembles the order from two axioms encoding the analytic inputs of steps 1–4.",
+    "keyInsights": [
+      "The simplicity collapse replaces the classical bottleneck — classifying all transitive subgroups of A₇ — with a one-line order argument: an index-2 subgroup of a simple group cannot exist, so the only candidates {84, 168} collapse to 168.",
+      "Axiom economy through strengthening: stating the honest analytic input as a geometric embedding Gal ↪ PSL(2,7) (rather than the weaker numeric |Gal| ∣ 168) lets the proven collapse derive |Gal| ≠ 84, converting a separate assumption into a theorem and reducing the axiom count from 3 to 2.",
+      "The order-168 conclusion is the output of a derived chain, not an assumption: only the analytic facts (cycle types, square discriminant, resolvent root) are axiomatized, while the group theory that links them to |Gal| = 168 is fully machine-checked.",
+      "PSL(2,7) ≅ GL(3,2) ≅ PSL(3,2) is the second-smallest non-abelian simple group and the smallest of order ≠ 60; realizing it advances the gallery's non-solvable frontier and reuses the A₅ template's irreducibility/discriminant/cycle-type method on a degree-7 witness.",
+      "The lower bound 84 = lcm(7,4,3) is a Chebotarev/Frobenius phenomenon: cycle types of f mod p are the cycle types of Frobenius elements, so just three unramified primes suffice to force three coprime element orders."
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "finite simple groups",
+      "Lagrange's theorem and index of subgroups",
+      "discriminants of polynomials",
+      "algebraic number theory (Frobenius elements, Dedekind's theorem)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-docstring",
+      "title": "Problem, Witness, and Certificate",
+      "startLine": 3,
+      "endLine": 70,
+      "summary": "The open question (extend A₅ to PSL(2,7)), Trinks' polynomial witness, the five-step certificate, and the proved-vs-axiomatized split (now only two axioms)."
+    },
+    {
+      "id": "polynomial",
+      "title": "Trinks' Polynomial",
+      "startLine": 78,
+      "endLine": 82,
+      "summary": "Definition of f(x) = x⁷ − 7x + 3 over ℚ as the degree-7 witness."
+    },
+    {
+      "id": "discriminant",
+      "title": "Square Discriminant",
+      "startLine": 84,
+      "endLine": 94,
+      "summary": "disc(f) = 194481² = 3⁸·7⁸ (two norm_num identities), the witness behind Gal ⊆ A₇."
+    },
+    {
+      "id": "simplicity-collapse",
+      "title": "The Simplicity Collapse",
+      "startLine": 96,
+      "endLine": 134,
+      "summary": "General theorem: a subgroup of a simple group of order 168 with 84 dividing its order is the whole group."
+    },
+    {
+      "id": "embedding-corollary",
+      "title": "Embedding Corollary",
+      "startLine": 136,
+      "endLine": 152,
+      "summary": "Reusable corollary turning an injection into a simple-168 group plus 84-divisibility into |G| = 168."
+    },
+    {
+      "id": "certificate-axioms",
+      "title": "The Two Certificate Axioms",
+      "startLine": 154,
+      "endLine": 179,
+      "summary": "The deferred analytic inputs: cycle-type divisibility (84 ∣ |Gal|) and the geometric embedding Gal ↪ PSL(2,7)."
+    },
+    {
+      "id": "main-result",
+      "title": "Main Result",
+      "startLine": 181,
+      "endLine": 197,
+      "summary": "Derivation of |Gal(f/ℚ)| = 168 from the two axioms via the collapse corollary."
+    }
+  ],
+  "conclusion": {
+    "summary": "Trinks' polynomial f(x) = x⁷ − 7x + 3 realizes a Galois group of order 168 over ℚ; combined with the (deferred) identification of that group as PSL(2,7), this places the second non-solvable simple group in the gallery after A₅. The Lean development contributes a fully machine-checked, reusable group-theoretic core — `simple168_subgroup_card_collapse` and its embedding corollary `card_eq_168_of_embeds_in_simple168` — and reduces the analytic content to two honest axioms.",
+    "implications": "The collapse theorem is reusable for any order-168 simple-group realization and exemplifies a general tactic: derive a Galois group's order from divisibility data plus an embedding, rather than enumerating candidate subgroups. The axiom reduction from 3 to 2 (PR #24436) demonstrates how strengthening an analytic hypothesis to its natural geometric form (an embedding rather than a numeric bound) can convert a separate assumption (|Gal| ≠ 84) into a derived theorem.",
+    "openQuestions": [
+      "Discharge the two certificate axioms in Lean: formalize Dedekind's factorization theorem (cycle types from f mod p) and the degree-15 PSL(2,7)-resolvent, neither of which is in Mathlib 4.26.0.",
+      "Construct PSL(2,7) ≅ GL(3,2) concretely in Lean (e.g., as invertible 3×3 matrices over 𝔽₂) and prove its simplicity, to replace the abstract 'simple group of order 168' target with the named group.",
+      "Compute Polynomial.discr trinks = 3⁸·7⁸ directly for the degree-7 polynomial, closing the gap between the integer identity proved here (194481² = 3⁸·7⁸) and the actual discriminant of f.",
+      "Extend the template to the next non-solvable simple groups (PSL(2,8) of order 504, PSL(2,11) of order 660) and test whether an analogous order-collapse shortcut bypasses subgroup enumeration there too."
+    ]
+  }
 }


### PR DESCRIPTION
## Enrichment pass for `inverse-galois-a5-oq-02` (PSL(2,7) via Trinks' polynomial)

This entry had only a bare `meta.json` — no `overview`, `sections`, `conclusion`, and no annotations — and its axiom metadata was **stale**.

### Accuracy fix (axiom integrity)
`meta.json` claimed **3 axioms** (naming `trinks_gal_card_dvd_168` / `trinks_gal_card_ne_84`) and 189 lines. The actual Lean file (`Proofs/InverseGaloisA5OQ02.lean`, 197 lines) now has only **2 axioms** (`trinks_gal_84_dvd`, `trinks_gal_embeds_simple168`) following the 3→2 reduction in PR #24436: the embedding axiom plus the proved `simple168_subgroup_card_collapse` discharge the old `|Gal| ≠ 84` axiom as a theorem (an index-2 subgroup of a simple group cannot exist).

- `axiomCount` 3 → 2 and `lineCount` 189 → 197 (both `meta.meta` and `leanFile`)
- rewrote `assumptions` to describe the two real axioms and note the eliminated one
- updated the stale `trinks_gal_card` `originalContributions` bullet ("assembled from the three certificate axioms")

### Added depth
- `overview`: historicalContext (inverse Galois problem, Hilbert/Shafarevich, PSL(2,7)≅GL(3,2), Fano plane/Klein quartic, Trinks 1968), problemStatement, proofStrategy (5-step certificate), 5 keyInsights, prerequisites
- 7 `sections` covering all 197 lines
- `conclusion`: summary, implications, 4 openQuestions (discharge the 2 axioms, build PSL(2,7) concretely, compute `Polynomial.discr`, extend to PSL(2,8)/PSL(2,11))
- 7 annotations (polynomial, square discriminant, simplicity collapse, embedding corollary, both axioms, main result), each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`

### Verification
- `pnpm annotations:validate` (strict): **0 misalignment** for this proof — every annotation's line range lands on its actual Lean construct with a matching type.
- JSON validated for both files.
- Full `tsc`/`vite` stage not run: this worktree's `node_modules` fails to build a native dep (`better-sqlite3` gyp under node v26), unrelated to this change.

Note: uses a dedicated branch `enrich/inverse-galois-a5-oq-02` so as not to disturb the open abel-ruffini PR on `feature/enricher-1`.