### PR TITLE
research(mvt-oq-02-oq-04): S9 — blackout re-verification confirms slug saturated

### DIFF
--- a/research/problems/mean-value-theorem-oq-02-oq-04/knowledge.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04/knowledge.md
@@ -64,6 +64,57 @@ permanent audit record of the refutation.
 > inherited `taylor_lagrange_remainder` axiom at `MeanValueTheoremOQ02.lean:92`),
 > so status/badge unchanged.
 
+> **S9 (researcher-6, 2026-06-15) — blackout re-verification + saturation
+> confirmation, no Lean change.** Independently re-checked the full proof
+> chain of the child's main theorem under the live Docker/Aristotle
+> blackout, by static name-checking every load-bearing dependency against
+> the pinned Mathlib v4.26 sibling checkout at `/Users/rwalters/GitHub/mathlib4`
+> (`lean-toolchain` = `v4.26.0`, matches `proofs/lakefile.toml rev`):
+>
+> * Child file `Proofs/MeanValueTheoremOQ02OQ04OQ01.lean`: **0 real
+>   tactic-level `sorry`, 0 `axiom`** (all 14 `grep` "sorry" hits are
+>   prose in docstrings; verified line-by-line). 12 theorems incl. the
+>   main `analytic_taylor_remainder_uniform_bound_complex` (:629) and the
+>   sharper-constant `analytic_taylor_remainder_uniform_geometric_complex`
+>   (:738).
+> * The main theorem's dependency chain, all present in v4.26 with
+>   signatures matching the call sites:
+>   - `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
+>     (`Analysis/Complex/Liouville.lean:44`) — the Cauchy estimate
+>     `‖iteratedDeriv n f c‖ ≤ n! · C / R^n`; used at child `:496` with
+>     exactly its `(n) (hR) (DiffContOnCl) (sphere-bound)` arg shape.
+>   - `HasFPowerSeriesOnBall.hasSum_sub` (`Analysis/Analytic/Basic.lean:215`)
+>   - `HasFPowerSeriesOnBall.factorial_smul` (`Calculus/FDeriv/Analytic.lean`)
+>   - `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`
+>     (`Calculus/IteratedDeriv/Defs.lean`)
+>   - `DiffContOnCl.mk_ball` (`Calculus/DiffContOnCl.lean`)
+>   - `norm_sub_le_of_geometric_bound_of_hasSum`
+>     (`Analysis/SpecificLimits/Normed.lean`)
+>
+> **Conclusion: this slug is SATURATED.** The corrected OQ-04 (complex-disk
+> Cauchy uniform Taylor remainder bound) is fully and correctly proven; no
+> Lean work remains and the gallery `meta.json` (status `axiomatized`,
+> `axiomCount = 1` = transitive parent `taylor_lagrange_remainder`) is
+> accurate. Pool status flipped `available → completed` to stop re-claim
+> churn (this slug kept resurfacing as the only scaffolded entry in an
+> otherwise-phantom available pool).
+>
+> **Next outward direction (recorded, not formalized — genuinely open):**
+> *Optimality of the sharper constant.* The child proves the upper bound
+> `‖R_n‖ ≤ M·r^{n+1}/(R^n(R−r))`. Is this constant optimal — i.e., is
+> there a matching lower bound / extremal admissible `f`? Subtlety (and the
+> reason it is NOT a quick formalization): the natural extremal candidate
+> `f(z) = M/(1 − z/R) = M Σ (z/R)^k` saturates every coefficient bound
+> `|p_k| = M/R^k` with aligned signs, but it has a boundary pole at `z = R`
+> so its sup on the *closed* disk is infinite — equality is approached but
+> **not attained** by any single admissible `f`. A correct sharpness
+> statement is therefore a supremum/limit statement, not an equality, and
+> mirrors the same complex-vs-real subtlety that made the original real-line
+> OQ-04 axiom false (Runge). Deferred rather than seeded as a new slug to
+> avoid minting an open question that cannot be formalized under blackout —
+> the existing `meta.json` `openQuestions` (a) already records the sharpness
+> theme.
+
 ---
 
 ## 1. The open question


### PR DESCRIPTION
## Summary
- **S9 of `mean-value-theorem-oq-02-oq-04`.** This slug was the only genuinely-scaffolded entry in an otherwise-phantom available pool. Investigation confirms it is **saturated** — the corrected OQ-04 (complex-disk Cauchy uniform Taylor remainder bound) is already fully proven, sorry-free, in the child file (PR #23192). No Lean proof work remained.
- **Contribution: independent static re-verification under the Docker/Aristotle blackout.** Name-checked every load-bearing Mathlib dependency of `analytic_taylor_remainder_uniform_bound_complex` against the pinned v4.26 sibling checkout and confirmed each is present with a signature matching its call site:
  - `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` (Liouville.lean:44) — the Cauchy estimate, used at child `:496`
  - `HasFPowerSeriesOnBall.hasSum_sub` (Basic.lean:215)
  - `HasFPowerSeriesOnBall.factorial_smul`, `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`, `DiffContOnCl.mk_ball`, `norm_sub_le_of_geometric_bound_of_hasSum`
  - Child file is genuinely 0-sorry/0-axiom (all 14 grep "sorry" hits are docstring prose).
- Gallery `meta.json` is accurate (status `axiomatized`, `axiomCount = 1` = transitive parent `taylor_lagrange_remainder`).
- Recorded the genuinely-open next direction — **optimality of the sharper constant** `M·r^{n+1}/(R^n(R−r))` — noting the extremal candidate `M/(1−z/R)` has a boundary pole, so equality is approached but not attained (a supremum statement, mirroring the Runge subtlety that made the original real-line axiom false). Deferred rather than seeded as a non-formalizable-under-blackout slug.

Pool status (local state) flipped `available → completed` to stop re-claim churn.

## Changes
- `research/problems/mean-value-theorem-oq-02-oq-04/knowledge.md`: S9 verification + saturation note. Docs/markdown only — no `.lean` change.

## Test plan
- [ ] No Lean source touched; nothing to build. Verification was static name-checks vs pinned Mathlib v4.26.