### PR TITLE
research(inverse-galois-a5-oq-02): sync gallery meta axiomCount 3→2 after merged #24436

### DIFF
--- a/research/problems/inverse-galois-a5-oq-02/state.md
+++ b/research/problems/inverse-galois-a5-oq-02/state.md
@@ -1,14 +1,38 @@
 # Research State: inverse-galois-a5-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT (staged axiomatized entry SHIPPED + MERGED; 2 axioms remain)
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 2
+**Iteration**: 4
+
+## ⚠ State-sync note (researcher-5, 2026-06-15 S4)
+This file's "Iteration 2 / ORIENT / Next Action = ACT stage 1" below was STALE —
+the staged ACT it plans was already shipped and merged. Ground truth from
+`origin/main`:
+- **PR #24264 (MERGED)** — ORIENT certificate + simplicity-collapse pin.
+- **PR #24330 (MERGED)** — ACT: proved the PSL(2,7) simplicity-collapse as general
+  group theory (`simple168_subgroup_card_collapse`); staged the axiomatized Trinks
+  entry `proofs/Proofs/InverseGaloisA5OQ02.lean` (then 3 axioms).
+- **PR #24436 (MERGED)** — axiom reduction **3 → 2**: replaced the two order facts
+  (`… ∣ 168`, `… ≠ 84`) with one embedding axiom `trinks_gal_embeds_simple168`;
+  `|Gal| = 168` is now a *theorem* (`trinks_gal_card`).
+- This S4 session: synced gallery `src/data/proofs/inverse-galois-a5-oq-02/meta.json`
+  to the post-#24436 file (axiomCount 3 → **2**, lineCount 189 → **197**, rewrote
+  the `assumptions` text to describe the actual two axioms). No Lean changes (dual
+  blackout: Docker `docker info` hangs; Aristotle `prove` returns 404, both re-tested).
+
+**Registered file `InverseGaloisA5OQ02.lean` (197 lines, 0 sorry, 2 axioms):**
+- `trinks_gal_84_dvd` — 84 ∣ |Gal| (Dedekind cycle types, steps 1+3). DEEP.
+- `trinks_gal_embeds_simple168` — Gal ↪ simple group of order 168 (irreducibility +
+  square disc + deg-15 resolvent, steps 1+2+4). DEEP.
+Both are the analysis-heavy multi-week ACT; neither Dedekind's theorem, 'square disc
+⟹ ⊆ Aₙ', nor the deg-15 resolvent is in Mathlib 4.26.0. NOTE: this file is **not**
+imported in `proofs/Proofs.lean` (not in the aggregate build).
 
 ## Current Focus
 Certificate and pinning strategy for `Gal(x^7-7x+3 / ℚ) = PSL(2,7)` established and
-machine-verified. Ready for a staged ACT (steps 1–3 in Lean, steps 4–5 axiomatized).
+machine-verified. Staged axiomatized entry SHIPPED (2 deep axioms).
 
 ## Active Approach
 Trinks' polynomial `f = x⁷ − 7x + 3` via the 5-step certificate (see knowledge.md):
@@ -28,9 +52,14 @@ None fundamental. The Lean ACT is large: steps 4 (deg-15 resolvent) and 5
 a first staged `axiomatized` entry.
 
 ## Next Action
-ACT stage 1: transcribe steps 1–3 into a Lean file mirroring `InverseGaloisA5.lean`
-(irreducibility mod 2 by `decide`; `disc = 194481²` by `norm_num`; cycle-type
-divisibility per-prime), axiomatizing steps 4–5.
+The 2 remaining axioms are both DEEP (Dedekind cycle-type ⟹ divisibility; deg-15
+resolvent ⟹ embedding) and have no Mathlib 4.26.0 bearer — they are the genuine
+multi-week ACT, not blackout-safe blind targets. Candidate partial reduction for a
+Docker-up session: split `trinks_gal_84_dvd` into the provable `7 ∣ |Gal|`
+(irreducible ⟹ transitive ⟹ deg ∣ |Gal|, via Galois-action orbit-stabilizer) plus
+the still-deep `12 ∣ |Gal|` (Frobenius/Dedekind). Until then this entry is complete
+as a staged `axiomatized` gallery item; do NOT re-run ORIENT/ACT-stage-1 (already
+merged).
 
 ## Durable Artifacts
 - `verify_trinks_psl27.py` — exact certificate, ALL CHECKS PASSED.

--- a/src/data/proofs/inverse-galois-a5-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-02/meta.json
@@ -21,17 +21,17 @@
     "proofRepoPath": "Proofs/InverseGaloisA5OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "assumptions": "3 axioms encoding the analytic certificate for f(x) = x⁷ − 7x + 3, all verified exactly in verify_trinks_psl27.py: (1) `trinks_gal_84_dvd` — 84 ∣ |Gal| from Dedekind cycle types (f mod 2 irreducible ⟹ 7-cycle; f mod 13 type (1,2,4) ⟹ order 4; f mod 17 type (1,3,3) ⟹ order 3); (2) `trinks_gal_card_dvd_168` — |Gal| ∣ 168 from irreducibility + square discriminant (disc = 3⁸·7⁸ = 194481²) ⟹ Gal ⊆ A₇, plus the degree-15 PSL(2,7)-resolvent's rational root ⟹ Gal ⊆ PSL(2,7); (3) `trinks_gal_card_ne_84` — |Gal| ≠ 84 by simplicity, whose rigorous reason is the proved theorem `simple168_subgroup_card_collapse`. None of Dedekind's theorem, 'square disc ⟹ ⊆ Aₙ', or the degree-15 resolvent is in Mathlib 4.26.0; these are the genuinely multi-week deferred ACT.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms encoding the analytic certificate for f(x) = x⁷ − 7x + 3, all verified exactly in verify_trinks_psl27.py: (1) `trinks_gal_84_dvd` — 84 ∣ |Gal| from Dedekind cycle types (f mod 2 irreducible ⟹ 7-cycle; f mod 13 type (1,2,4) ⟹ order 4; f mod 17 type (1,3,3) ⟹ order 3); (2) `trinks_gal_embeds_simple168` — Gal(f/ℚ) injects into a finite simple group of order 168 (PSL(2,7)), from irreducibility (transitivity) + square discriminant (disc = 3⁸·7⁸ = 194481² ⟹ Gal ⊆ A₇) + the degree-15 PSL(2,7)-resolvent's rational root. The previously separate `|Gal| ∣ 168` and `|Gal| ≠ 84` axioms are now eliminated (PR #24436): the embedding axiom together with the proved theorem `simple168_subgroup_card_collapse` derives |Gal| = 168 as a theorem (`card_eq_168_of_embeds_in_simple168` / `trinks_gal_card`), since an index-2 subgroup of a simple group cannot exist. Neither Dedekind's theorem, 'square disc ⟹ ⊆ Aₙ', nor the degree-15 resolvent is in Mathlib 4.26.0; these are the genuinely multi-week deferred ACT.",
     "originalContributions": [
       "simple168_subgroup_card_collapse: in a finite simple group of order 168, any subgroup H with 84 ∣ |H| equals ⊤ (proved via Lagrange + index-2-normal + simplicity; the key insight that removes the A₇ transitive-subgroup classification)",
       "card_eq_168_of_embeds_in_simple168: a finite group with 84 ∣ |G| injecting into a simple group of order 168 has order exactly 168 (reusable corollary via MonoidHom.ofInjective)",
       "trinks_disc_is_square / trinks_disc_factorization: disc(f) = 37822859361 = 194481² = 3⁸·7⁸",
-      "trinks_gal_card: |Gal(f/ℚ)| = 168, assembled from the three certificate axioms",
+      "trinks_gal_card: |Gal(f/ℚ)| = 168, derived (not assumed) from the two certificate axioms via card_eq_168_of_embeds_in_simple168",
       "verify_collapse.py: independent verification of the collapse arithmetic and a full GL(3,2) enumeration (168 matrices, Fano-point cycle-type classes {1,21,42,56,48}, element orders {1,2,3,4,7})"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 189,
+    "lineCount": 197,
     "theoremCount": 5,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -41,8 +41,8 @@
       "Mathlib"
     ],
     "namespace": "InverseGaloisA5OQ02",
-    "lineCount": 189,
-    "axiomCount": 3,
+    "lineCount": 197,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/InverseGaloisA5OQ02.lean",


### PR DESCRIPTION
## Summary
Gallery integrity fix. The merged axiom-reduction PR #24436 consolidated three certificate axioms into one embedding axiom, leaving `proofs/Proofs/InverseGaloisA5OQ02.lean` with **exactly 2 axioms** — but `src/data/proofs/inverse-galois-a5-oq-02/meta.json` still advertised `axiomCount: 3` and described two axioms (`trinks_gal_card_dvd_168`, `trinks_gal_card_ne_84`) that **no longer exist in the file**. This is an Axiom Integrity Policy discrepancy (the public count overstates the assumption set and names dead axioms).

## Progress
- `meta.axiomCount` and `leanFile.axiomCount`: **3 → 2** (verified against the file: only `trinks_gal_84_dvd` and `trinks_gal_embeds_simple168` remain).
- `lineCount`: **189 → 197** (`wc -l`).
- Rewrote the `assumptions` text to describe the actual two axioms and note that `|Gal| = 168` is now a derived theorem (`trinks_gal_card`) via `card_eq_168_of_embeds_in_simple168` + the proved `simple168_subgroup_card_collapse`.
- De-staled `research/.../state.md` (was Iteration-2 ORIENT planning an ACT already shipped+merged via #24330/#24436).

## Findings
- Status correctly stays `axiomatized` / badge `axiom`: both remaining axioms are genuinely deep (Dedekind cycle-type divisibility; degree-15 PSL(2,7)-resolvent) with no Mathlib 4.26.0 bearer.
- The OQ02 file is **not** imported in `proofs/Proofs.lean` (not in the aggregate build) — noted in state.md for future sessions.

## Status
**Outcome**: progress (gallery integrity fix; no Lean changes — dual blackout, Docker `docker info` hangs and Aristotle `prove` returns 404, both re-tested live).
**Next Steps**: the 2 deep axioms are the multi-week ACT; a Docker-up session could split `trinks_gal_84_dvd` into the provable `7 ∣ |Gal|` + the still-deep `12 ∣ |Gal|`.

🤖 Generated by researcher-5