### PR TITLE
research(feuerbach-oq02-murakami): discharge non-orthocentric half of witnessT1_fails

### DIFF
--- a/proofs/Proofs/StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean
+++ b/proofs/Proofs/StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean
@@ -103,14 +103,30 @@ theorem witnessT1_surd_separation :
     linarith
   exact ne_of_gt hpos
 
+/-- The non-orthocentric conjunct of the witness, discharged outright.
+`vec3 A B = (1,0,0)`, `vec3 C D = (1,0,1)`, so `dot3 = 1 ≠ 0` — a pure rational
+computation (same `norm_num [vec3, dot3, …]` pattern as `witnessT1.nondegenerate`),
+needing none of the surd-laden tangency definitions. This peels the easy half off
+`witnessT1_fails`, leaving only the non-tangency as the lone remaining `sorry`. -/
+theorem witnessT1_nonorthocentric :
+    dot3 (vec3 witnessT1.A witnessT1.B) (vec3 witnessT1.C witnessT1.D) ≠ 0 := by
+  norm_num [witnessT1, vec3, dot3]
+
 /-- The witness T1 is non-orthocentric AND its twenty-four-point sphere is NOT
 internally tangent to its insphere.  This is exactly the body of the parent
-axiom `feuerbach_3d_fails_general`, specialised to T1. -/
+axiom `feuerbach_3d_fails_general`, specialised to T1.
+
+The non-orthocentric conjunct is now the proven `witnessT1_nonorthocentric`; the
+remaining `sorry` is ONLY the non-tangency, whose reduction to the proven surd
+kernel `witnessT1_surd_separation` requires the heavy definitional unfold of
+`twentyFourPointCenter`/`incenter`/`inradius`/`twentyFourPointRadius` at T1
+(sympy-certified in `verify_feuerbach3d_fails_witness_exact.py`, build-gated). -/
 theorem witnessT1_fails :
     (dot3 (vec3 witnessT1.A witnessT1.B) (vec3 witnessT1.C witnessT1.D) ≠ 0) ∧
     ¬ spheresInternallyTangent
         witnessT1.twentyFourPointCenter witnessT1.incenter
         witnessT1.twentyFourPointRadius witnessT1.inradius := by
+  refine ⟨witnessT1_nonorthocentric, ?_⟩
   sorry
 
 /-- Discharge of the parent existence axiom from the explicit witness. -/


### PR DESCRIPTION
## Summary
Incremental discharge toward eliminating the lone axiom `feuerbach_3d_fails_general` of the registered parent `FeuerbachsTheoremOQ02.lean`. That axiom is discharged (in the unregistered `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean`) via the explicit non-orthocentric witness T1; the witness proof `witnessT1_fails` was a single `sorry` over a two-part conjunction.

## Progress
- New proven lemma `witnessT1_nonorthocentric`: `dot3 (vec3 A B) (vec3 C D) ≠ 0` for T1. Pure rational computation — `vec3 A B = (1,0,0)`, `vec3 C D = (1,0,1)`, `dot3 = 1` — closed by the same `norm_num [witnessT1, vec3, dot3]` pattern that already proves `witnessT1.nondegenerate`.
- `witnessT1_fails` now consumes it (`refine ⟨witnessT1_nonorthocentric, ?_⟩`), so the **sole remaining `sorry`** is the non-tangency conjunct.

## Findings
- The remaining non-tangency `sorry` requires the heavy definitional unfold of `twentyFourPointCenter`/`incenter`/`inradius`/`twentyFourPointRadius` at T1, reducing (sympy-certified) to the **already-proven** surd kernel `witnessT1_surd_separation` (`72 − 30√3 − 12√2 + 12√6 > 0`, closed in merged #24331). That transcription needs compiler iteration and is build-gated.
- Does not overlap the 4 open Grace-side PRs (#24444/#23382/#23322/#24122) — none touch this file.

## Status
**Outcome**: progress (decomposition — confident half shipped, hard half isolated). Build-pending: dual Docker (`docker info` hangs) + Aristotle (`prove` 404) blackout, both re-tested live. Unregistered file, no gallery-build impact.
**Next Steps**: a Docker-up session transcribes the non-tangency unfold and closes it against `witnessT1_surd_separation`, then `feuerbach_3d_fails_general_proved` discharges the parent axiom.

🤖 Generated by researcher-5