### PR TITLE
Research: product-of-segments-of-chords-oq-02 - discharge gram_pos (converse now sorry-free)

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
@@ -29,14 +29,15 @@ sign, so the four points cannot be concyclic.
 The corrected, provable converse is stated as `signed_converse_implies_concyclic`. Its
 proof reduces (via a translation putting `P` at the origin) to the geometric lemma
 `circumcenter_signed`, which is now **fully constructed**: an explicit Cramer-rule center
-plus the `equidistant_of_inner` cancellation core. The entire converse is therefore proved
-modulo the single standard fact `gram_pos` (positivity of the Gram determinant of two
-linearly independent vectors — strict Cauchy–Schwarz), which is the **sole remaining
-`sorry`** and a clean target for automated search. See
+plus the `equidistant_of_inner` cancellation core. The Gram determinant positivity
+`gram_pos` — previously the sole remaining `sorry` — is now **discharged** via the witness
+`z = ‖u‖²•v − ⟪u,v⟫•u` (one has `⟪z,z⟫ = ‖u‖²·Δ`, and `z ≠ 0` by linear independence). The
+file therefore contains **no `sorry` and no axioms**. See
 `research/problems/product-of-segments-of-chords-oq-02/knowledge.md`.
 
 NOTE: build-pending. The Docker Lean toolchain was unavailable when this was written,
-so the proofs below have not been machine-checked. This file is intentionally NOT
+so the proofs below have not been machine-checked (every Mathlib lemma used was, however,
+name-checked against the pinned `mathlib4` v4.26.0). This file is intentionally NOT
 registered in `Proofs.lean` until it has been built.
 -/
 
@@ -158,12 +159,38 @@ Gram determinant `‖u‖²‖v‖² − ⟪u,v⟫²` is strictly positive. This
 Cauchy–Schwarz: `⟪u,v⟫² ≤ ‖u‖²‖v‖²` always, with equality only when `u, v` are parallel,
 which linear independence rules out.
 
-This is now the **sole remaining `sorry`** in the converse proof — a standard,
-self-contained linear-algebra fact and a clean target for automated search. The
-circumcenter construction below is fully discharged in terms of it. -/
+Proved here via the witness `z = ‖u‖²•v − ⟪u,v⟫•u`: expanding `⟪z,z⟫` by bilinearity
+gives `⟪z,z⟫ = ‖u‖²·(‖u‖²‖v‖² − ⟪u,v⟫²)`, and `z ≠ 0` (else `‖u‖²•v = ⟪u,v⟫•u` is a
+nontrivial dependence, as `‖u‖² ≠ 0`), so the left side is `> 0`; dividing by `‖u‖² > 0`
+yields the determinant positive. With this the converse proof is `sorry`-free. -/
 theorem gram_pos (u v : Vec2) (hindep : LinearIndependent ℝ ![u, v]) :
     0 < ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2 := by
-  sorry
+  have hu0 : u ≠ 0 := by simpa using hindep.ne_zero 0
+  have hup : (0 : ℝ) < ‖u‖ ^ 2 := pow_pos (norm_pos_iff.mpr hu0) 2
+  -- The witness `z = ‖u‖²•v − ⟪u,v⟫•u` satisfies `⟪z,z⟫ = ‖u‖²·(‖u‖²‖v‖² − ⟪u,v⟫²)`.
+  have hzeq :
+      (inner (‖u‖ ^ 2 • v - (inner u v : ℝ) • u)
+            (‖u‖ ^ 2 • v - (inner u v : ℝ) • u) : ℝ)
+        = ‖u‖ ^ 2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2) := by
+    simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right,
+      real_inner_self_eq_norm_sq, real_inner_comm u v]
+    ring
+  -- `z ≠ 0`: otherwise `‖u‖²•v = ⟪u,v⟫•u` is a nontrivial dependence (coeff `‖u‖² ≠ 0`).
+  have hz0 : ‖u‖ ^ 2 • v - (inner u v : ℝ) • u ≠ 0 := by
+    intro hz
+    have hrel : (-(inner u v : ℝ)) • u + ‖u‖ ^ 2 • v = 0 := by
+      have hcomb : (-(inner u v : ℝ)) • u + ‖u‖ ^ 2 • v
+          = ‖u‖ ^ 2 • v - (inner u v : ℝ) • u := by module
+      rw [hcomb]; exact hz
+    obtain ⟨_, hpz⟩ := (LinearIndependent.pair_iff.mp hindep) (-(inner u v : ℝ)) (‖u‖ ^ 2) hrel
+    exact (ne_of_gt hup) hpz.symm
+  -- Hence `⟪z,z⟫ > 0`; combined with `‖u‖² > 0` this forces the Gram determinant positive.
+  have hzpos : (0 : ℝ) < inner (‖u‖ ^ 2 • v - (inner u v : ℝ) • u)
+      (‖u‖ ^ 2 • v - (inner u v : ℝ) • u) := by
+    rw [real_inner_self_eq_norm_sq]
+    exact pow_pos (norm_pos_iff.mpr hz0) 2
+  rw [hzeq] at hzpos
+  nlinarith [hzpos, hup]
 
 /-- **Equidistance core (the `‖O‖²` cancels).** Any center `O` whose inner products
 against `u` and `v` hit the perpendicular-bisector values `⟪u,O⟫ = (t+1)/2·‖u‖²` and


### PR DESCRIPTION
## Summary
Research session (S6 ACT) for `product-of-segments-of-chords-oq-02`.

A prior session reduced the corrected (signed) converse of the power-of-a-point theorem
to a single remaining `sorry`: **`gram_pos`** — the Gram determinant
`‖u‖²‖v‖² − ⟪u,v⟫²` of a linearly independent pair `u, v` is strictly positive. This PR
**discharges it**, leaving `ProductOfSegmentsOfChordsConverse.lean` with **0 sorry and 0
axiom**.

## Progress
- `gram_pos` proved via the explicit orthogonalization witness `z = ‖u‖²•v − ⟪u,v⟫•u`:
  - `⟪z,z⟫ = ‖u‖²·(‖u‖²‖v‖² − ⟪u,v⟫²)` by inner-product bilinearity + `ring`;
  - `z ≠ 0` (otherwise `‖u‖²•v = ⟪u,v⟫•u` is a nontrivial dependence, since `‖u‖² ≠ 0`),
    via `LinearIndependent.pair_iff`;
  - hence `⟪z,z⟫ = ‖z‖² > 0`, and `‖u‖² > 0` forces the determinant positive (`nlinarith`).
  - No strict-Cauchy–Schwarz equality lemma is required.
- Updated the file/lemma docstrings: the converse `signed_converse_implies_concyclic` is
  now fully proved.

## Findings
- For "Gram determinant > 0 from linear independence", the witness
  `z = ‖u‖²•v − ⟪u,v⟫•u` (with `⟪z,z⟫ = ‖u‖²·Δ`) is a cleaner Lean route than the parallel-
  vector equality case of Cauchy–Schwarz.

## Status
**Outcome**: progress (sole remaining `sorry` discharged; file now sorry-free/axiom-free)
**Next Steps**: replace the false unsigned `converse_..._axiom` in the parent flagship
`ProductOfSegmentsOfChords.lean`, drive gallery `meta.json` `axiomCount` → 0, and register
the converse file in `Proofs.lean`. Docker-gated (registered flagship). Build-pending under
the Docker blackout this session (`docker ps` exit 124; Aristotle `prove` → 404); all
Mathlib lemma names were name-checked against the sibling `mathlib4` @ v4.26.0.

🤖 Generated by researcher-2