### PR TITLE
research(buffons-needle-oq-01-oq-02-oq-02): S1 ACT — elementary recurrence-squeeze for Buffon constant asymptotic

### DIFF
--- a/research/problems/buffons-needle-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/buffons-needle-oq-01-oq-02-oq-02/knowledge.md
@@ -1,0 +1,127 @@
+# Knowledge Base: buffons-needle-oq-01-oq-02-oq-02
+
+Asymptotic decay of the higher-dimensional Buffon hyperplane constant.
+
+---
+
+## Problem Understanding
+
+Goal: prove `√n · c_n → √(2/π)` (equivalently `c_n ~ √(2/(π n))`) for the
+dimension-`n` Buffon crossing constant `c_n`.
+
+### CORRECTED closed form (key finding)
+
+The seeder's `problem.md` quoted the constant as `Γ(n/2)/(√π Γ((n+1)/2))`. That
+is **wrong** for this gallery's parent. The genuine parent
+(`proofs/Proofs/BuffonsNeedleOQ01OQ02.lean:56`) defines
+
+```
+  buffonConstant n = 2 · Γ(n/2) / ((n-1) · √π · Γ((n-1)/2)),   n ≥ 2
+```
+
+i.e. `c_n = E[|⟨u, e₁⟩|]`, the expected absolute coordinate of a uniform unit
+vector `u ∈ S^{n-1}`. Spot checks from the parent: `c₂ = 2/π`, `c₃ = 1/2`,
+`c₄ = 4/(3π)`. The target asymptotic `√(2/π) ≈ 0.7979` is consistent
+(`√2·c₂ ≈ 0.900`, `√3·c₃ ≈ 0.866`, `2·c₄ ≈ 0.849`, decreasing toward it).
+
+---
+
+## Insights
+
+### Elementary, Stirling-free proof (recurrence + monotonicity squeeze)
+
+Set `s n = Γ(n/2)/Γ((n-1)/2)`, so `c_n = 2·s n / ((n-1)·√π)`.
+
+1. **Product recurrence** `(REC)`: `s n · s(n+1) = (n-1)/2`.
+   Proof: `s n · s(n+1) = Γ((n+1)/2)/Γ((n-1)/2)` (the `Γ(n/2)` cancels) and
+   `Γ((n+1)/2) = Γ((n-1)/2 + 1) = ((n-1)/2)·Γ((n-1)/2)` by `Real.Gamma_add_one`.
+
+2. **Monotonicity**: `n ↦ s n` is increasing. Proof: `log s n =
+   logΓ(n/2) − logΓ((n-1)/2)`; convexity of `log∘Γ`
+   (`Real.convexOn_log_Gamma`) over the equally-spaced points
+   `(n-1)/2 < n/2 < (n+1)/2` gives, via `ConvexOn.slope_mono_adjacent`,
+   `logΓ(n/2) − logΓ((n-1)/2) ≤ logΓ((n+1)/2) − logΓ(n/2)`, i.e.
+   `log s n ≤ log s(n+1)`, hence `s n ≤ s(n+1)` (`Real.log_le_log_iff`).
+
+3. **Squeeze of the square** `(SQ)`: for `n ≥ 3`,
+   `(n-2)/2 = s(n-1)·s n ≤ (s n)² ≤ s n·s(n+1) = (n-1)/2`
+   (multiply the monotone inequalities by `s n > 0`, then apply `(REC)` at
+   `n-1` and `n`). Therefore `(s n)²/n → 1/2`, i.e. `s n ~ √(n/2)`.
+
+4. **Assemble**: `(√n·c_n)² = (4/π)·n(s n)²/(n-1)² → (4/π)(1/2) = 2/π`, and
+   `√n·c_n ≥ 0`, so by continuity of `√`, `√n·c_n → √(2/π)`.
+
+This route uses **no Stirling/Wallis machinery** — only the Gamma recurrence and
+log-convexity, both in Mathlib. The `problem.md` only listed Stirling/Wallis/logΓ
+routes; the recurrence-squeeze is cleaner and dodges even/odd uniformity issues
+entirely (it is uniform in `n`).
+
+### Why monotonicity is the only "real" analytic input
+
+Everything else is algebra over the recurrence. Monotonicity is exactly
+log-convexity applied to three equally-spaced abscissae — a one-line slope
+comparison once `slope_mono_adjacent` is in hand.
+
+---
+
+## Built Items (this session — file `lean/BuffonConstantAsymptotic.lean`)
+
+All proven (0 sorry) except the final routine packaging:
+
+- `buffonConstant`, `s` — definitions matching the parent.
+- `s_pos` — positivity of `s n` for `n ≥ 2`.
+- `s_mul_s_succ` — the product recurrence `(REC)`. **proven**
+- `s_le_s_succ` — monotonicity via `convexOn_log_Gamma` + `slope_mono_adjacent`. **proven**
+- `s_sq_bounds` — the squared squeeze `(SQ)`. **proven**
+- `buffonConstant_eq`, `sq_target_eq` — algebraic identities reducing the target
+  square to `(4/π)·n(s n)²/(n-1)²`. **proven**
+- `sqrt_mul_buffonConstant_tendsto` — main theorem; reduced to ONE isolated
+  `sorry`: the rational squeeze `(s n)²/n → 1/2` plus `√`-continuity. Routine
+  real analysis (Aristotle-suitable once the prover/Docker is unblocked).
+
+Build status: UNREGISTERED companion (research `lean/` dir, not in gallery
+build). Not compiled — Docker build + Aristotle both in blackout this session.
+Name-checked against Mathlib v4.26.0 sibling checkout.
+
+---
+
+## Mathlib lemma chain (v4.26.0, all confirmed present)
+
+- `Real.Gamma_add_one (hs : s ≠ 0) : Γ(s+1) = s·Γ s`  — Gamma/Basic.lean:423
+- `Real.Gamma_pos_of_pos (hs : 0 < s) : 0 < Γ s`        — Gamma/Basic.lean:456
+- `Real.convexOn_log_Gamma : ConvexOn ℝ (Ioi 0) (log∘Γ)` — Gamma/BohrMollerup.lean:115
+- `ConvexOn.slope_mono_adjacent`                         — Convex/Slope.lean:28
+- `slope_def_field`                                       — AffineSpace/Slope.lean:40
+- `Real.log_div`, `Real.log_le_log_iff`                  — Log/Basic.lean:135,144
+- `Real.sq_sqrt`, `Real.continuous_sqrt`                 — Data/Real/Sqrt.lean:163,123
+- `tendsto_const_div_atTop_nhds_zero_nat`                — SpecificLimits/Basic.lean:51
+
+No Mathlib gap: the only "missing" piece (a Gamma-ratio asymptotic
+`Γ(x)/Γ(x+½) ~ x^{-1/2}`) is sidestepped by the recurrence-squeeze.
+
+---
+
+## Dead Ends / Notes
+
+- The Stirling route (`Stirling.factorial_isEquivalent`) works but forces an
+  even/odd split (half-integer Gamma → factorials only for one parity); the
+  recurrence-squeeze avoids this. Not pursued.
+- Direct Gamma-ratio asymptotic: Mathlib has **no** `Real.Gamma_div_Gamma`
+  asymptotic lemma at v4.26. Would require building log-Gamma expansion (>300
+  LOC). Avoided.
+
+---
+
+## Next Steps
+
+1. Discharge the single `sorry` in `sqrt_mul_buffonConstant_tendsto`:
+   - prove `Tendsto (fun n => (s n)^2 / n) atTop (𝓝 (1/2))` by squeezing
+     between `1/2 - 1/n` and `1/2 - 1/(2n)` (use
+     `tendsto_const_div_atTop_nhds_zero_nat` and
+     `tendsto_of_tendsto_of_tendsto_of_le_of_le`);
+   - multiply by `(n/(n-1))² → 1`; scale by `4/π`; then `√`-continuity on the
+     nonnegative square via `Real.continuous_sqrt`.
+2. Build under Docker once unblocked; register as a proper proof file
+   (`proofs/Proofs/BuffonsNeedleOQ01OQ02OQ02.lean`) + gallery `meta.json`.
+3. Optionally submit the rational-squeeze lemma to Aristotle when the prover is
+   back online.

--- a/research/problems/buffons-needle-oq-01-oq-02-oq-02/lean/BuffonConstantAsymptotic.lean
+++ b/research/problems/buffons-needle-oq-01-oq-02-oq-02/lean/BuffonConstantAsymptotic.lean
@@ -1,0 +1,239 @@
+/-
+# Asymptotic decay of the higher-dimensional Buffon hyperplane constant
+
+Open question of gallery proof `buffons-needle-oq-01-oq-02`.
+
+## The constant
+
+The parent proof `BuffonsNeedleOQ01OQ02.lean` defines the dimension-`n` Buffon
+crossing constant as the expected absolute coordinate of a uniform unit vector
+`u ∈ S^{n-1}`:
+```
+  buffonConstant n = 2 * Γ(n/2) / ((n - 1) * √π * Γ((n-1)/2)),   n ≥ 2.
+```
+(NOTE: the seeder's `problem.md` quoted a *different* normalization
+`Γ(n/2)/(√π Γ((n+1)/2))`; the genuine parent constant is the one above. The
+asymptotic `c_n ~ √(2/(πn))` holds for it all the same — see the recurrence
+below.)
+
+## Result
+
+`√n · buffonConstant n → √(2/π)`  as  `n → ∞`,  equivalently
+`buffonConstant n ~ √(2/(π n))`.
+
+## Strategy (Stirling-free, elementary)
+
+Set `s n = Γ(n/2) / Γ((n-1)/2)`, so `buffonConstant n = 2 · s n / ((n-1)·√π)`.
+The Gamma recurrence `Γ(z+1) = z·Γ(z)` at `z = (n-1)/2` gives the **product
+recurrence**
+```
+  s n · s (n+1) = (n-1)/2.                                      (REC)
+```
+Log-convexity of `Γ` (Mathlib `Real.convexOn_log_Gamma`) makes `n ↦ s n`
+**monotone increasing**. Combining monotonicity with (REC) at `n-1` and `n`
+squeezes the square:
+```
+  (n-2)/2 = s(n-1)·s n ≤ (s n)^2 ≤ s n·s(n+1) = (n-1)/2,        (SQ)
+```
+hence `(s n)^2 / n → 1/2`, i.e. `s n ~ √(n/2)`. Substituting,
+`(√n · buffonConstant n)^2 = (4/π) · n (s n)^2/(n-1)^2 → (4/π)(1/2) = 2/π`,
+and taking square roots (the quantity is nonnegative) yields the claim.
+
+This file proves (REC), monotonicity, and (SQ) completely; the final
+real-analysis packaging (rational squeeze + `√` continuity) is isolated as a
+single routine step.
+
+Mathlib pin: v4.26.0.  UNREGISTERED companion (not in the gallery build).
+-/
+import Mathlib
+
+open Real Filter Topology
+open scoped BigOperators
+
+namespace BuffonOQ010202
+
+/-- The higher-dimensional Buffon crossing constant, matching the parent
+`BuffonsNeedleOQ01OQ02.buffonConstant`. -/
+noncomputable def buffonConstant (n : ℕ) : ℝ :=
+  if n ≤ 1 then 0
+  else 2 * Real.Gamma ((n : ℝ) / 2) /
+    (((n : ℝ) - 1) * Real.sqrt π * Real.Gamma (((n : ℝ) - 1) / 2))
+
+/-- The Gamma ratio `s n = Γ(n/2) / Γ((n-1)/2)`. -/
+noncomputable def s (n : ℕ) : ℝ :=
+  Real.Gamma ((n : ℝ) / 2) / Real.Gamma (((n : ℝ) - 1) / 2)
+
+/-- For `n ≥ 2`, `(n:ℝ)/2 > 0`. -/
+lemma half_pos (n : ℕ) (hn : 2 ≤ n) : (0 : ℝ) < (n : ℝ) / 2 := by
+  have : (0 : ℝ) < (n : ℝ) := by
+    have : (0 : ℕ) < n := by omega
+    exact_mod_cast this
+  linarith
+
+/-- For `n ≥ 2`, `((n:ℝ)-1)/2 > 0`. -/
+lemma half_pred_pos (n : ℕ) (hn : 2 ≤ n) : (0 : ℝ) < ((n : ℝ) - 1) / 2 := by
+  have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  linarith
+
+lemma gamma_half_pos (n : ℕ) (hn : 2 ≤ n) : 0 < Real.Gamma ((n : ℝ) / 2) :=
+  Real.Gamma_pos_of_pos (half_pos n hn)
+
+lemma gamma_half_pred_pos (n : ℕ) (hn : 2 ≤ n) :
+    0 < Real.Gamma (((n : ℝ) - 1) / 2) :=
+  Real.Gamma_pos_of_pos (half_pred_pos n hn)
+
+/-- `s n > 0` for `n ≥ 2`. -/
+lemma s_pos (n : ℕ) (hn : 2 ≤ n) : 0 < s n := by
+  unfold s
+  exact div_pos (gamma_half_pos n hn) (gamma_half_pred_pos n hn)
+
+/-- **Product recurrence**: `s n · s (n+1) = (n-1)/2` for `n ≥ 2`. -/
+lemma s_mul_s_succ (n : ℕ) (hn : 2 ≤ n) :
+    s n * s (n + 1) = ((n : ℝ) - 1) / 2 := by
+  have hb : Real.Gamma ((n : ℝ) / 2) ≠ 0 := ne_of_gt (gamma_half_pos n hn)
+  -- Γ((n+1)/2) = ((n-1)/2) · Γ((n-1)/2)
+  have hstep : Real.Gamma (((n : ℝ) + 1) / 2)
+      = (((n : ℝ) - 1) / 2) * Real.Gamma (((n : ℝ) - 1) / 2) := by
+    have harg : ((n : ℝ) + 1) / 2 = ((n : ℝ) - 1) / 2 + 1 := by ring
+    rw [harg, Real.Gamma_add_one (ne_of_gt (half_pred_pos n hn))]
+  unfold s
+  -- rewrite the (n+1) entry's argument casts
+  have hcast1 : ((↑(n + 1) : ℝ)) / 2 = ((n : ℝ) + 1) / 2 := by push_cast; ring
+  have hcast2 : ((↑(n + 1) : ℝ) - 1) / 2 = (n : ℝ) / 2 := by push_cast; ring
+  rw [hcast1, hcast2, hstep]
+  field_simp
+  ring
+
+/-- **Monotonicity**: `s n ≤ s (n+1)` for `n ≥ 2`, from log-convexity of `Γ`. -/
+lemma s_le_s_succ (n : ℕ) (hn : 2 ≤ n) : s n ≤ s (n + 1) := by
+  -- Work with φ = log ∘ Γ, convex on Ioi 0, at the three equally-spaced points
+  -- x = (n-1)/2 < y = n/2 < z = (n+1)/2.
+  have hx : ((n : ℝ) - 1) / 2 ∈ Set.Ioi (0 : ℝ) := by
+    simp only [Set.mem_Ioi]; exact half_pred_pos n hn
+  have hz : ((n : ℝ) + 1) / 2 ∈ Set.Ioi (0 : ℝ) := by
+    simp only [Set.mem_Ioi]
+    have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    linarith
+  have hxy : ((n : ℝ) - 1) / 2 < (n : ℝ) / 2 := by linarith
+  have hyz : (n : ℝ) / 2 < ((n : ℝ) + 1) / 2 := by linarith
+  have key := (Real.convexOn_log_Gamma).slope_mono_adjacent hx hz hxy hyz
+  rw [slope_def_field, slope_def_field] at key
+  simp only [Function.comp_apply] at key
+  -- the two denominators both equal 1/2
+  have e1 : (n : ℝ) / 2 - ((n : ℝ) - 1) / 2 = 1 / 2 := by ring
+  have e2 : ((n : ℝ) + 1) / 2 - (n : ℝ) / 2 = 1 / 2 := by ring
+  rw [e1, e2] at key
+  have htwo : ∀ a : ℝ, a / (1 / 2) = 2 * a := fun a => by ring
+  rw [htwo, htwo] at key
+  -- key : 2 * (log Γ(n/2) - log Γ((n-1)/2)) ≤ 2 * (log Γ((n+1)/2) - log Γ(n/2))
+  have hlog : Real.log (Real.Gamma ((n : ℝ) / 2)) - Real.log (Real.Gamma (((n : ℝ) - 1) / 2))
+      ≤ Real.log (Real.Gamma (((n : ℝ) + 1) / 2)) - Real.log (Real.Gamma ((n : ℝ) / 2)) := by
+    linarith
+  -- turn the differences of logs into logs of s n and s (n+1)
+  have hsn : Real.log (s n)
+      = Real.log (Real.Gamma ((n : ℝ) / 2)) - Real.log (Real.Gamma (((n : ℝ) - 1) / 2)) := by
+    unfold s
+    rw [Real.log_div (ne_of_gt (gamma_half_pos n hn)) (ne_of_gt (gamma_half_pred_pos n hn))]
+  have hsn1 : Real.log (s (n + 1))
+      = Real.log (Real.Gamma (((n : ℝ) + 1) / 2)) - Real.log (Real.Gamma ((n : ℝ) / 2)) := by
+    unfold s
+    have hcast1 : ((↑(n + 1) : ℝ)) / 2 = ((n : ℝ) + 1) / 2 := by push_cast; ring
+    have hcast2 : ((↑(n + 1) : ℝ) - 1) / 2 = (n : ℝ) / 2 := by push_cast; ring
+    have hzpos : (0 : ℝ) < ((n : ℝ) + 1) / 2 := by
+      have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+      linarith
+    rw [hcast1, hcast2,
+        Real.log_div (ne_of_gt (Real.Gamma_pos_of_pos hzpos))
+          (ne_of_gt (gamma_half_pos n hn))]
+  have hlog' : Real.log (s n) ≤ Real.log (s (n + 1)) := by rw [hsn, hsn1]; exact hlog
+  -- conclude via monotonicity of log on positives
+  have hsnpos : 0 < s n := s_pos n hn
+  have hsn1pos : 0 < s (n + 1) := s_pos (n + 1) (by omega)
+  exact (Real.log_le_log_iff hsnpos hsn1pos).mp hlog'
+
+/-- **Squeeze** of the square: `(n-2)/2 ≤ (s n)^2 ≤ (n-1)/2` for `n ≥ 3`. -/
+lemma s_sq_bounds (n : ℕ) (hn : 3 ≤ n) :
+    ((n : ℝ) - 2) / 2 ≤ (s n) ^ 2 ∧ (s n) ^ 2 ≤ ((n : ℝ) - 1) / 2 := by
+  have hn2 : 2 ≤ n := by omega
+  have hn1 : 2 ≤ n - 1 := by omega
+  -- monotonicity gives s(n-1) ≤ s n ≤ s(n+1)
+  have hmono_lo : s (n - 1) ≤ s n := by
+    have := s_le_s_succ (n - 1) hn1
+    rwa [Nat.sub_add_cancel (by omega : 1 ≤ n)] at this
+  have hmono_hi : s n ≤ s (n + 1) := s_le_s_succ n hn2
+  -- positivity
+  have hpos_lo : 0 < s (n - 1) := s_pos (n - 1) hn1
+  have hpos_n : 0 < s n := s_pos n hn2
+  -- the two recurrences
+  have hrec_hi : s n * s (n + 1) = ((n : ℝ) - 1) / 2 := s_mul_s_succ n hn2
+  have hrec_lo : s (n - 1) * s n = ((n : ℝ) - 2) / 2 := by
+    have h := s_mul_s_succ (n - 1) hn1
+    rw [Nat.sub_add_cancel (by omega : 1 ≤ n)] at h
+    -- ((↑(n-1)) - 1)/2 = ((n:ℝ) - 2)/2
+    have hc : ((↑(n - 1) : ℝ) - 1) / 2 = ((n : ℝ) - 2) / 2 := by
+      have : ((n - 1 : ℕ) : ℝ) = (n : ℝ) - 1 := by
+        have : 1 ≤ n := by omega
+        push_cast [Nat.cast_sub this]; ring
+      rw [this]; ring
+    rwa [hc] at h
+  constructor
+  · -- (n-2)/2 = s(n-1)·s n ≤ s n · s n = (s n)^2
+    have : s (n - 1) * s n ≤ s n * s n :=
+      mul_le_mul_of_nonneg_right hmono_lo (le_of_lt hpos_n)
+    rw [hrec_lo] at this
+    nlinarith [this]
+  · -- (s n)^2 = s n · s n ≤ s n · s(n+1) = (n-1)/2
+    have : s n * s n ≤ s n * s (n + 1) :=
+      mul_le_mul_of_nonneg_left hmono_hi (le_of_lt hpos_n)
+    rw [hrec_hi] at this
+    nlinarith [this]
+
+/-- `buffonConstant n = 2 · s n / ((n-1)·√π)` for `n ≥ 2`. -/
+lemma buffonConstant_eq (n : ℕ) (hn : 2 ≤ n) :
+    buffonConstant n = 2 * s n / (((n : ℝ) - 1) * Real.sqrt π) := by
+  unfold buffonConstant s
+  have hne : ¬ n ≤ 1 := by omega
+  rw [if_neg hne]
+  have hg : Real.Gamma (((n : ℝ) - 1) / 2) ≠ 0 := ne_of_gt (gamma_half_pred_pos n hn)
+  field_simp
+  ring
+
+/-- The squared target sequence equals `(4/π) · n (s n)^2 / (n-1)^2`. -/
+lemma sq_target_eq (n : ℕ) (hn : 2 ≤ n) :
+    (Real.sqrt (n : ℝ) * buffonConstant n) ^ 2
+      = (4 / π) * ((n : ℝ) * (s n) ^ 2 / ((n : ℝ) - 1) ^ 2) := by
+  have hnpos : (0 : ℝ) ≤ (n : ℝ) := by positivity
+  have hpi : (0 : ℝ) ≤ π := le_of_lt pi_pos
+  have hsqrtn : Real.sqrt (n : ℝ) ^ 2 = (n : ℝ) := Real.sq_sqrt hnpos
+  have hsqrtpi : Real.sqrt π ^ 2 = π := Real.sq_sqrt hpi
+  have hnm1 : ((n : ℝ) - 1) ≠ 0 := by
+    have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    linarith
+  rw [buffonConstant_eq n hn]
+  rw [mul_pow, div_pow, mul_pow, mul_pow]
+  rw [hsqrtn, hsqrtpi]
+  have hpine : (π : ℝ) ≠ 0 := ne_of_gt pi_pos
+  field_simp
+  ring
+
+/-- **Main asymptotic** (open question of `buffons-needle-oq-01-oq-02`):
+`√n · buffonConstant n → √(2/π)`, i.e. `buffonConstant n ~ √(2/(π n))`.
+
+The discrete core (recurrence, monotonicity, squared bounds, and the algebraic
+identity `sq_target_eq`) is fully established above. The remaining step is the
+routine real-analysis packaging:
+
+* From `s_sq_bounds`, `(s n)^2 / n → 1/2` by squeezing between `(1/2 - 1/n)`
+  and `(1/2 - 1/(2n))` (both `→ 1/2` via `tendsto_const_div_atTop_nhds_zero_nat`).
+* Hence `n (s n)^2 / (n-1)^2 = ((s n)^2/n) · (n/(n-1))^2 → (1/2)·1 = 1/2`,
+  using `n/(n-1) → 1`.
+* So the squared sequence `→ (4/π)(1/2) = 2/π` by `sq_target_eq`.
+* `√n · buffonConstant n ≥ 0`, so it equals `√` of its square, and
+  `Real.continuous_sqrt` gives the limit `√(2/π)`. -/
+theorem sqrt_mul_buffonConstant_tendsto :
+    Tendsto (fun n : ℕ => Real.sqrt (n : ℝ) * buffonConstant n) atTop
+      (𝓝 (Real.sqrt (2 / π))) := by
+  -- Routine analytic packaging; see the lemmas above for the mathematical content.
+  sorry
+
+end BuffonOQ010202

--- a/research/problems/buffons-needle-oq-01-oq-02-oq-02/literature/README.md
+++ b/research/problems/buffons-needle-oq-01-oq-02-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for buffons-needle-oq-01-oq-02-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/buffons-needle-oq-01-oq-02-oq-02/problem.md
+++ b/research/problems/buffons-needle-oq-01-oq-02-oq-02/problem.md
@@ -1,0 +1,136 @@
+# Problem: Asymptotic decay $c_n \sim \sqrt{2/(\pi n)}$ for the Buffon hyperplane constant
+
+**Slug**: buffons-needle-oq-01-oq-02-oq-02
+**Created**: 2026-06-15
+**Status**: Active
+**Source**: proof-suggestion <!-- open question of gallery proof buffons-needle-oq-01-oq-02 -->
+
+## Problem Statement
+
+### Formal Statement
+
+In the higher-dimensional Buffon problem (a convex body / needle dropped on a stationary
+arrangement of parallel hyperplanes in $\mathbb{R}^n$), the proportionality constant $c_n$
+relating expected crossings to mean width carries a dimension factor built from Gamma
+functions, of the form
+$$
+c_n = \frac{\Gamma\!\left(\frac{n}{2}\right)}{\sqrt{\pi}\,\Gamma\!\left(\frac{n+1}{2}\right)}
+\quad\text{(up to the parent proof's normalization).}
+$$
+The goal is to prove the asymptotic decay rate
+$$
+c_n \sim \sqrt{\frac{2}{\pi n}} \qquad (n \to \infty).
+$$
+
+### Plain Language
+
+Buffon's needle generalizes to higher dimensions, where the chance of crossing a hyperplane
+involves a constant that depends on the dimension through Gamma functions. As the dimension
+grows, that constant shrinks. We want to prove it shrinks like $\sqrt{2/(\pi n)}$ — a clean
+square-root decay — by applying Gamma-function asymptotics.
+
+### Why This Matters
+
+The asymptotic pins down the large-dimension behavior of the integral-geometry constant,
+closing a stated open question of the parent proof. The proof exercises Mathlib's Gamma-ratio
+asymptotics (`Real.Gamma_div_Gamma`-type estimates), a reusable tool for hypergeometric and
+volume-of-ball constants.
+
+## Known Results
+
+### What's Already Proven
+
+- The parent proof `buffons-needle-oq-01-oq-02` derives the higher-dimensional crossing
+  constant via Cauchy–Crofton / mean-width and identifies its closed Gamma-function form.
+- Mathlib has `Real.Gamma`, `Real.Gamma_add_one`, the Legendre duplication formula
+  (`Real.Gamma_mul_Gamma_add_half` / `Real.Gamma_nat_eq_...`), and Stirling-type asymptotics
+  for the factorial (`Stirling.factorial_isEquivalent`).
+
+### What's Still Open
+
+- The asymptotic equivalence $c_n \sim \sqrt{2/(\pi n)}$ itself, i.e. the limit
+  $\sqrt{n}\,c_n \to \sqrt{2/\pi}$.
+- A Lean form of the Gamma-ratio asymptotic
+  $\Gamma(x)/\Gamma(x+\tfrac12) \sim x^{-1/2}$ as $x \to \infty$, specialized to $x = n/2$.
+
+### Our Goal
+
+Prove $\lim_{n\to\infty}\sqrt{n}\,c_n = \sqrt{2/\pi}$ (equivalently the `IsEquivalent`
+statement), using the Gamma duplication formula and Stirling/Wallis asymptotics already in
+Mathlib, after first confirming the parent proof's exact closed form for $c_n$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| buffons-needle-oq-01-oq-02 | Parent: higher-dim constant, closed form | Cauchy–Crofton, mean width |
+| buffons-needle | Base geometric probability | integral geometry |
+| stirling-formula | Gamma/factorial asymptotics | Stirling, Wallis |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Gamma-ratio via duplication + Stirling**: rewrite $c_n$ using the duplication formula,
+   reduce to a ratio of factorials/central binomial, and apply `Stirling.factorial_isEquivalent`
+   and the Wallis product to extract $\sqrt{2/(\pi n)}$.
+   - Risk: assembling the `Asymptotics.IsEquivalent` chain through several rewrites.
+
+2. **Direct $\log\Gamma$ asymptotic**: use the asymptotic expansion of $\log\Gamma$ to get
+   $\log c_n = -\tfrac12\log n + \tfrac12\log(2/\pi) + o(1)$, then exponentiate.
+   - Risk: Mathlib's `log Gamma` asymptotic coverage may be thinner than the factorial route.
+
+### Key Difficulties
+
+- Bridging $\Gamma(n/2)/\Gamma((n+1)/2)$ to factorial/central-binomial asymptotics for even
+  and odd $n$ uniformly.
+- Managing `IsEquivalent` / `Tendsto` plumbing through the duplication rewrite.
+
+### What Would a Proof Need?
+
+- Exact closed form of $c_n$ from the parent proof.
+- Gamma duplication formula and Stirling/Wallis asymptotics (in Mathlib).
+- A clean `IsEquivalent` or `Tendsto (sqrt n * c n) atTop (𝓝 (sqrt (2/π)))` target.
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- The closed form is known; the work is asymptotic analysis with Mathlib's Gamma/Stirling API.
+- The main risk is `IsEquivalent` bookkeeping and even/odd uniformity, not a missing theorem.
+
+**Estimated Effort**:
+- Exploration: days
+- If tractable: weeks
+
+## References
+
+### Papers
+- Classical integral-geometry references (Santaló, *Integral Geometry and Geometric Probability*).
+
+### Mathlib
+- `Mathlib/Analysis/SpecialFunctions/Gamma/...` — `Real.Gamma`, duplication formula.
+- `Mathlib/Analysis/SpecialFunctions/Stirling.lean` — factorial asymptotics; Wallis product.
+- `Mathlib/Analysis/Asymptotics/...` — `IsEquivalent`.
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - geometric-probability
+  - integral-geometry
+  - asymptotics
+  - gamma-function
+related_proofs:
+  - buffons-needle-oq-01-oq-02
+  - buffons-needle
+  - stirling-formula
+difficulty: high
+source: proof-suggestion
+created: 2026-06-15
+```
+
+**Significance**: 5/10
+**Tractability**: 4/10

--- a/research/problems/buffons-needle-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/buffons-needle-oq-01-oq-02-oq-02/state.md
@@ -1,0 +1,28 @@
+# Research State: buffons-needle-oq-01-oq-02-oq-02
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 2
+
+## Current Focus
+Elementary recurrence-squeeze proof of `√n·c_n → √(2/π)`. Discrete core proven;
+final analytic packaging isolated as one sorry.
+
+## Active Approach
+`s n = Γ(n/2)/Γ((n-1)/2)`; recurrence `s n·s(n+1)=(n-1)/2`; monotonicity via
+log-convexity of Γ; squeeze `(n-2)/2 ≤ (s n)² ≤ (n-1)/2`; assemble.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (recurrence-squeeze)
+
+## Blockers
+- Docker build + Aristotle both in blackout this session (file not compiled).
+- One isolated routine `sorry` (rational squeeze + √-continuity) remains.
+
+## Next Action
+Discharge the single analytic `sorry`, compile under Docker, register as a
+gallery proof file. See knowledge.md "Next Steps".

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-02.json
@@ -1,0 +1,230 @@
+{
+  "slug": "buffons-needle-oq-01-oq-02-oq-02",
+  "title": "Asymptotic decay $c_n \\sim \\sqrt{2/(\\pi n)}$ for the Buffon hyperplane constant",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "c_n = \\frac{\\Gamma\\!\\left(\\frac{n}{2}\\right)}{\\sqrt{\\pi}\\,\\Gamma\\!\\left(\\frac{n+1}{2}\\right)}\n\\quad\\text{(up to the parent proof's normalization).}",
+    "plain": "Buffon's needle generalizes to higher dimensions, where the chance of crossing a hyperplane",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-15T00:34:10-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: elementary recurrence-squeeze proof of sqrt(n)*c_n -> sqrt(2/pi); discrete core proven (recurrence, monotonicity, squared bounds), one routine analytic sorry remains. Corrected parent closed form.",
+    "builtItems": [
+      "s_mul_s_succ (product recurrence, proven) — lean/BuffonConstantAsymptotic.lean",
+      "s_le_s_succ (monotonicity via log-convexity, proven) — lean/BuffonConstantAsymptotic.lean",
+      "s_sq_bounds (squared squeeze (n-2)/2..(n-1)/2, proven) — lean/BuffonConstantAsymptotic.lean",
+      "buffonConstant_eq, sq_target_eq (algebraic reduction, proven) — lean/BuffonConstantAsymptotic.lean",
+      "sqrt_mul_buffonConstant_tendsto (main thm, reduced to 1 routine analytic sorry)"
+    ],
+    "insights": [
+      "CORRECTION: problem.md quoted constant Gamma(n/2)/(sqrt(pi)Gamma((n+1)/2)) is WRONG; genuine parent (BuffonsNeedleOQ01OQ02.lean:56) is c_n = 2*Gamma(n/2)/((n-1)*sqrt(pi)*Gamma((n-1)/2)) = E[|<u,e1>|] for uniform u in S^{n-1}. Asymptotic sqrt(2/pi) still holds.",
+      "Set s n = Gamma(n/2)/Gamma((n-1)/2). Gamma recurrence gives product recurrence s n * s(n+1) = (n-1)/2, cancelling Gamma(n/2).",
+      "Log-convexity of Gamma (convexOn_log_Gamma) + slope_mono_adjacent over equally-spaced (n-1)/2 < n/2 < (n+1)/2 proves n |-> s n increasing, with NO Stirling/Wallis.",
+      "Squeeze: (n-2)/2 = s(n-1)*s n <= (s n)^2 <= s n*s(n+1) = (n-1)/2, so (s n)^2/n -> 1/2, s n ~ sqrt(n/2).",
+      "(sqrt(n)*c_n)^2 = (4/pi)*n(s n)^2/(n-1)^2 -> (4/pi)(1/2) = 2/pi; nonnegativity + sqrt continuity gives sqrt(2/pi)."
+    ],
+    "mathlibGaps": [
+      "No Gamma-ratio asymptotic Gamma(x)/Gamma(x+1/2) ~ x^{-1/2} at v4.26 — but sidestepped by the recurrence-squeeze (no gap blocks the proof)."
+    ],
+    "nextSteps": [
+      "Discharge the single sorry: Tendsto ((s n)^2/n) -> 1/2 by squeeze between 1/2-1/n and 1/2-1/(2n); times (n/(n-1))^2 -> 1; scale 4/pi; sqrt continuity.",
+      "Compile under Docker when unblocked; register as proofs/Proofs/BuffonsNeedleOQ01OQ02OQ02.lean + gallery meta.json."
+    ],
+    "markdown": "# Knowledge Base: buffons-needle-oq-01-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "probability",
+    "geometric-probability",
+    "integral-geometry",
+    "asymptotics",
+    "gamma-function"
+  ],
+  "relatedProofs": [
+    "buffons-needle",
+    "buffons-needle-oq-01",
+    "buffons-needle-oq-01-oq-01",
+    "buffons-needle-oq-01-oq-01-oq-01",
+    "buffons-needle-oq-01-oq-01-oq-04",
+    "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+    "buffons-needle-oq-01-oq-02",
+    "buffons-needle-oq-01-oq-04",
+    "buffons-needle-oq-02",
+    "buffons-needle-oq-02-oq-01",
+    "buffons-needle-oq-02-oq-02",
+    "buffons-needle-oq-02-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T00:34:10-07:00",
+  "significance": 5,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/BuffonsNeedle.lean",
+      "filename": "BuffonsNeedle.lean",
+      "lineCount": 267,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedle.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01.lean",
+      "filename": "BuffonsNeedleOQ01.lean",
+      "lineCount": 251,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01.lean",
+      "lineCount": 391,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01OQ01.lean",
+      "lineCount": 224,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
+      "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
+      "lineCount": 569,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01OQ04OQ01.lean",
+      "lineCount": 194,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean",
+      "filename": "BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean",
+      "lineCount": 75,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ02.lean",
+      "filename": "BuffonsNeedleOQ01OQ02.lean",
+      "lineCount": 326,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ04.lean",
+      "filename": "BuffonsNeedleOQ01OQ04.lean",
+      "lineCount": 210,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02.lean",
+      "filename": "BuffonsNeedleOQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ01.lean",
+      "filename": "BuffonsNeedleOQ02OQ01.lean",
+      "lineCount": 310,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",
+      "filename": "BuffonsNeedleOQ02OQ02.lean",
+      "lineCount": 377,
+      "theoremCount": 15,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ03.lean",
+      "filename": "BuffonsNeedleOQ02OQ03.lean",
+      "lineCount": 286,
+      "theoremCount": 18,
+      "axiomCount": 3,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Open question of gallery proof `buffons-needle-oq-01-oq-02`: prove the decay
rate `c_n ~ √(2/(π n))` (equivalently `√n·c_n → √(2/π)`) for the
higher-dimensional Buffon hyperplane crossing constant.

- **Corrected closed form**: the seeder's `problem.md` quoted
  `Γ(n/2)/(√π Γ((n+1)/2))`, but the genuine parent
  (`proofs/Proofs/BuffonsNeedleOQ01OQ02.lean:56`) defines
  `c_n = 2·Γ(n/2)/((n-1)·√π·Γ((n-1)/2)) = E[|⟨u,e₁⟩|]`, `u` uniform on `S^{n-1}`.
  The asymptotic `√(2/π)` holds for it (consistent with `c₂=2/π, c₃=1/2, c₄=4/(3π)`).
- **Stirling-free proof** via `s_n = Γ(n/2)/Γ((n-1)/2)`:
  - product recurrence `s_n·s_{n+1} = (n-1)/2` (Gamma recurrence),
  - monotonicity from log-convexity of `Γ` (`convexOn_log_Gamma` + `slope_mono_adjacent`),
  - squared squeeze `(n-2)/2 ≤ s_n² ≤ (n-1)/2`, hence `s_n ~ √(n/2)`.
- **Lean** (`research/problems/.../lean/BuffonConstantAsymptotic.lean`,
  unregistered companion, name-checked against Mathlib v4.26): recurrence,
  monotonicity, squared bounds, and the algebraic reduction `sq_target_eq` all
  proven (0 sorry). The main theorem `sqrt_mul_buffonConstant_tendsto` is reduced
  to **one** isolated routine `sorry` (rational squeeze `s_n²/n → 1/2` + `√`
  continuity).

No Mathlib gap blocks the proof; the only "missing" tool (a Gamma-ratio
asymptotic) is sidestepped by the recurrence-squeeze.

## Status

Docker build and Aristotle both in blackout this session — file is **not
compiled** (build-pending). Math is verified on paper; Lean name-checked against
the v4.26 sibling checkout.

## Test plan

- [ ] Compile `BuffonConstantAsymptotic.lean` under Docker once unblocked.
- [ ] Discharge the single analytic `sorry` (or submit to Aristotle).
- [ ] Register as `proofs/Proofs/BuffonsNeedleOQ01OQ02OQ02.lean` + gallery `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)