### PR TITLE
Research: nth-root-irrational-oq-01-oq-01 - S4 rational half of Niven

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean
@@ -1,0 +1,103 @@
+/-
+  Nth Root Irrationality OQ-01-OQ-01 (Niven, rational cases):
+  the *rational* half of Niven's cosine classification.
+
+  The sibling file `NthRootIrrationalOQ01OQ01Cos.lean` proves the irrational
+  direction with the sharp bound:
+
+      `φ(n) ≥ 3  ⟹  Irrational (cos(2π/n))`,   sharp at `φ(n) ≤ 2 ⇔ n ∈ {1,2,3,4,6}`.
+
+  This file supplies the complementary direction — that for each of those five
+  exceptional `n`, `cos(2π/n)` really *is* rational — so that together the two
+  files give the full classification (Niven's theorem):
+
+      `cos(2π/n)` is rational  ⟺  `n ∈ {1, 2, 3, 4, 6}`,
+
+  with the explicit values
+
+      n: 1     2     3      4    6
+      cos: 1   −1   −1/2    0   1/2.
+
+  Each case is an elementary special-angle evaluation:
+  * `cos(2π/1) = cos(2π) = 1`                          (`Real.cos_two_pi`)
+  * `cos(2π/2) = cos π   = −1`                         (`Real.cos_pi`)
+  * `cos(2π/3) = cos(π − π/3) = −cos(π/3) = −1/2`      (`Real.cos_pi_sub`, `Real.cos_pi_div_three`)
+  * `cos(2π/4) = cos(π/2) = 0`                         (`Real.cos_pi_div_two`)
+  * `cos(2π/6) = cos(π/3) = 1/2`                       (`Real.cos_pi_div_three`)
+
+  Results (0 axioms, 0 sorries; build-pending — Docker/Aristotle blackout at authoring):
+  - `cos_two_pi_div_{one,two,three,four,six}_rational` — the five exceptional cases.
+  - `cos_two_pi_div_rational_of_mem` — the bundled statement over `n ∈ {1,2,3,4,6}`.
+
+  ## References
+  - Niven, I. (1956). "Irrational Numbers." Carus Math. Monographs, Thm 3.9.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace NthRootIrrationalOQ01OQ01CosRational
+
+open Real
+
+/-- A real number equal to the cast of a rational is not irrational. -/
+private lemma not_irrational_of_eq_rat {x : ℝ} (q : ℚ) (h : x = (q : ℝ)) :
+    ¬ Irrational x := by
+  rw [h]; exact q.not_irrational
+
+/-- `cos(2π/1) = 1`, rational. -/
+theorem cos_two_pi_div_one_rational :
+    ¬ Irrational (Real.cos (2 * Real.pi / (1 : ℕ))) := by
+  refine not_irrational_of_eq_rat 1 ?_
+  rw [Nat.cast_one, div_one, Real.cos_two_pi]
+  norm_num
+
+/-- `cos(2π/2) = cos π = −1`, rational. -/
+theorem cos_two_pi_div_two_rational :
+    ¬ Irrational (Real.cos (2 * Real.pi / (2 : ℕ))) := by
+  refine not_irrational_of_eq_rat (-1) ?_
+  have ha : (2 * Real.pi / ((2 : ℕ) : ℝ)) = Real.pi := by push_cast; ring
+  rw [ha, Real.cos_pi]
+  norm_num
+
+/-- `cos(2π/3) = cos(π − π/3) = −cos(π/3) = −1/2`, rational. -/
+theorem cos_two_pi_div_three_rational :
+    ¬ Irrational (Real.cos (2 * Real.pi / (3 : ℕ))) := by
+  refine not_irrational_of_eq_rat (-1/2) ?_
+  have ha : (2 * Real.pi / ((3 : ℕ) : ℝ)) = Real.pi - Real.pi / 3 := by push_cast; ring
+  rw [ha, Real.cos_pi_sub, Real.cos_pi_div_three]
+  norm_num
+
+/-- `cos(2π/4) = cos(π/2) = 0`, rational. -/
+theorem cos_two_pi_div_four_rational :
+    ¬ Irrational (Real.cos (2 * Real.pi / (4 : ℕ))) := by
+  refine not_irrational_of_eq_rat 0 ?_
+  have ha : (2 * Real.pi / ((4 : ℕ) : ℝ)) = Real.pi / 2 := by push_cast; ring
+  rw [ha, Real.cos_pi_div_two]
+  norm_num
+
+/-- `cos(2π/6) = cos(π/3) = 1/2`, rational. -/
+theorem cos_two_pi_div_six_rational :
+    ¬ Irrational (Real.cos (2 * Real.pi / (6 : ℕ))) := by
+  refine not_irrational_of_eq_rat (1/2) ?_
+  have ha : (2 * Real.pi / ((6 : ℕ) : ℝ)) = Real.pi / 3 := by push_cast; ring
+  rw [ha, Real.cos_pi_div_three]
+  norm_num
+
+/-- **Rational half of Niven's classification.** For every `n` in the
+exceptional set `{1, 2, 3, 4, 6}`, `cos(2π/n)` is rational. Combined with the
+sibling `cos_two_pi_div_n_irrational` (irrational for `φ(n) ≥ 3`, i.e. for all
+other `n`), this yields the full classification: `cos(2π/n)` is rational iff
+`n ∈ {1, 2, 3, 4, 6}`. -/
+theorem cos_two_pi_div_rational_of_mem {n : ℕ}
+    (hn : n = 1 ∨ n = 2 ∨ n = 3 ∨ n = 4 ∨ n = 6) :
+    ¬ Irrational (Real.cos (2 * Real.pi / (n : ℕ))) := by
+  rcases hn with rfl | rfl | rfl | rfl | rfl
+  · exact cos_two_pi_div_one_rational
+  · exact cos_two_pi_div_two_rational
+  · exact cos_two_pi_div_three_rational
+  · exact cos_two_pi_div_four_rational
+  · exact cos_two_pi_div_six_rational
+
+end NthRootIrrationalOQ01OQ01CosRational

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -140,3 +140,42 @@ only rational values of `2·cos(2π/n)` are `{2, −2, −1, 0, 1}`.
 
 - The *exact degree* `[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` (not just `> 1`) — would need the
   minimal polynomial of the real generator, still absent in Mathlib.
+
+---
+
+## Result (Session 4, 2026-06-15, researcher-4, REVISIT → ACT) — rational half of Niven (classification completed)
+
+New file `proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean` (0 sorries, 0
+axioms, build-pending — Docker `docker info` times out, Aristotle 404; both re-probed).
+Branch built from origin/main so the sibling Cos/Real files are present.
+
+The S2/S3 work (merged: #24403 real subfield, #24427 `cos_two_pi_div_n_irrational`)
+proved the **irrational** direction `φ(n) ≥ 3 ⟹ Irrational(cos(2π/n))`, sharp at
+`φ(n) ≤ 2 ⇔ n ∈ {1,2,3,4,6}`. This session adds the **complementary rational
+direction**, so the two files together give the full Niven classification:
+
+> `cos(2π/n)` is rational  ⟺  `n ∈ {1, 2, 3, 4, 6}`,  values `1, −1, −1/2, 0, 1/2`.
+
+Theorems (each an elementary special-angle evaluation):
+- `cos_two_pi_div_one_rational` — `cos(2π) = 1` (`Real.cos_two_pi`).
+- `cos_two_pi_div_two_rational` — `cos π = −1` (`Real.cos_pi`).
+- `cos_two_pi_div_three_rational` — `cos(π−π/3) = −cos(π/3) = −1/2`
+  (`Real.cos_pi_sub` + `Real.cos_pi_div_three`).
+- `cos_two_pi_div_four_rational` — `cos(π/2) = 0` (`Real.cos_pi_div_two`).
+- `cos_two_pi_div_six_rational` — `cos(π/3) = 1/2` (`Real.cos_pi_div_three`).
+- `cos_two_pi_div_rational_of_mem` — bundled over `n ∈ {1,2,3,4,6}` via `rcases … rfl`.
+
+Reusable pattern: `not_irrational_of_eq_rat (q : ℚ) (h : x = (q:ℝ)) : ¬Irrational x`
+(`rw [h]; exact q.not_irrational`); angle identity `2π/k = <std angle>` by
+`push_cast; ring`; final rational-cast equality by `norm_num`.
+
+### Mathlib lemmas name-checked vs sibling v4.26 (`/Users/rwalters/GitHub/mathlib4`)
+`Real.cos_two_pi` (Trig/Basic.lean:224), `Real.cos_pi` (:216), `Real.cos_pi_sub`
+(:331), `Real.cos_pi_div_two` (:133), `Real.cos_pi_div_three` (:775),
+`Rat.not_irrational` (NumberTheory/Real/Irrational.lean:197), `not_irrational_one`
+(:99), `not_irrational_zero` (:98).
+
+### Still genuinely open (unchanged)
+- The *exact degree* `[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` (not just `> 1`): IntermediateField
+  tower `φ(n) = [ℚ(ζ):ℚ] = [ℚ(ζ):ℚ(ζ+ζ⁻¹)]·[ℚ(ζ+ζ⁻¹):ℚ] = 2·(φ(n)/2)`. Needs the
+  real-subfield minpoly / adjoin-tower machinery; Docker-gated, ~150 LOC.

--- a/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
+++ b/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
@@ -29,16 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: extended nth-root irrationality to cyclotomic polynomials — Phi_n has no rational root (n>=3), rational roots of unity are +-1, complex primitive roots are irrational; 0 sorries/0 axioms, build-pending; real-subfield (2cos) deferred",
+    "progressSummary": "Niven cosine classification COMPLETE: irrational direction (phi(n)>=3, merged #24427) + rational direction (n in {1,2,3,4,6}, this session). Build-pending/unregistered. Sole remaining open item: exact degree [Q(2cos):Q]=phi(n)/2 (Docker-gated IntermediateField tower).",
     "builtItems": [
       "cyclotomic_no_rational_root (NthRootIrrationalOQ01OQ01.lean): Phi_n over Q has no rational root for n>=3",
       "rational_root_of_unity_le_two: only rational roots of unity are +-1 (primitive n-th root in Q forces n<=2)",
       "primitiveRoot_not_rational: complex primitive n-th root of unity (n>=3) is not in range(algebraMap Q C)",
-      "totient_ge_two: 3<=n implies 2<=Nat.totient n; primitiveCubeRoot_not_rational instance e^{2pi i/3}"
+      "totient_ge_two: 3<=n implies 2<=Nat.totient n; primitiveCubeRoot_not_rational instance e^{2pi i/3}",
+      "cos_two_pi_div_{one,two,three,four,six}_rational + cos_two_pi_div_rational_of_mem in NthRootIrrationalOQ01OQ01CosRational.lean (build-pending, unregistered)"
     ],
     "insights": [
       "Cyclotomic extension of nth-root irrationality reduces to swapping X^n-p (Eisenstein) for Phi_n (cyclotomic.irreducible_rat) in the parent irreducibility-implies-irrational pipeline; only new lemma is degree bound phi(n)>=2 iff n>=3",
-      "Phi_n has NO real roots for n>=3, so honest content is complex not-rational + rational-roots-of-unity=+-1; an irrational-real-root statement is vacuous"
+      "Phi_n has NO real roots for n>=3, so honest content is complex not-rational + rational-roots-of-unity=+-1; an irrational-real-root statement is vacuous",
+      "S4 (R4): rational half of Niven shipped (NthRootIrrationalOQ01OQ01CosRational.lean) — cos(2pi/n) rational for n in {1,2,3,4,6} with values {1,-1,-1/2,0,1/2}; combined with merged irrational direction gives full classification cos(2pi/n) rational <=> n in {1,2,3,4,6}."
     ],
     "mathlibGaps": [
       "No gap for rational/complex statements; the real subfield story (minpoly of 2cos(2pi/n), degree phi(n)/2) was NOT formalized and is the missing piece"


### PR DESCRIPTION
## Summary
Session 4 on `nth-root-irrational-oq-01-oq-01`. Completes Niven's cosine classification by adding the **rational** direction to complement the merged irrational direction (#24427).

## Progress
- New file `proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean` (0 axioms, 0 sorries, build-pending): `cos(2π/n)` is rational for each `n ∈ {1,2,3,4,6}`, with explicit values `{1, −1, −1/2, 0, 1/2}`.
- Five special-angle theorems (`cos_two_pi_div_{one,two,three,four,six}_rational`) + a bundled `cos_two_pi_div_rational_of_mem`.
- **Classification now complete**: with the sibling `cos_two_pi_div_n_irrational` (`φ(n) ≥ 3 ⟹ Irrational`, merged #24427), this gives `cos(2π/n)` rational ⟺ `n ∈ {1,2,3,4,6}`.

## Findings
- The rational cases are elementary special-angle evaluations: `cos(2π) = 1`, `cos π = −1`, `cos(π−π/3) = −1/2`, `cos(π/2) = 0`, `cos(π/3) = 1/2`. Reusable helper `not_irrational_of_eq_rat`; angle identities via `push_cast; ring`.
- All 8 Mathlib lemmas name-checked against the sibling v4.26 checkout.

## Status
**Outcome**: progress (build-pending — `docker info` times out; statically name-checked, not machine-checked; file **unregistered** to protect the auto-merge aggregate).
**Next Steps**: register + Docker-build when the backend returns; the sole remaining open item is the *exact degree* `[ℚ(2cos(2π/n)):ℚ] = φ(n)/2` (Docker-gated IntermediateField tower).

🤖 Generated by researcher-4