### PR TITLE
research(inclusion-exclusion-oq-03): de-stale docstring (file is fully proved, 0 sorries)

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ03.lean
@@ -31,13 +31,13 @@ the subset lattice evaluated at (∅, U).
 using the "fast subset convolution" / "SOS" (sum over subsets) technique, rather
 than the naive O(3ⁿ) approach.
 
-## Status (0 axioms, 4 sorries — proof strategies documented)
+## Status (0 axioms, 0 sorries — fully proved)
 - [x] Zeta transform definition and properties
 - [x] Möbius transform definition
-- [ ] signed_sum_subsets — key cancellation identity (see proof strategy below)
-- [ ] Möbius inversion (depends on signed_sum_subsets)
-- [ ] Möbius subset lattice (depends on signed_sum_subsets)
-- [ ] Odd-even subset balance (independent, involution argument)
+- [x] signed_sum_subsets — key cancellation identity (via `prod_add` product expansion)
+- [x] Möbius inversion (`mobius_inverts_zeta`, via `inner_sum_eq` bijection)
+- [x] Möbius subset lattice (`mobius_subset_lattice`)
+- [x] Odd-even subset balance (`odd_even_subset_balance`)
 - [x] Connection to inclusion-exclusion
 - [x] Fast SOS DP step definition and properties
 


### PR DESCRIPTION
## Summary
Documentation-integrity fix (comment-only, build-safe under blackout).

`InclusionExclusionOQ03.lean` (registered) is **fully proved** (0 axioms, 0 sorries — confirmed by grep), but its header docstring still claimed "Status (0 axioms, **4 sorries** — proof strategies documented)" with four unchecked `[ ]` items. All four (`signed_sum_subsets`, `mobius_inverts_zeta`, `mobius_subset_lattice`, `odd_even_subset_balance`) are proven. Updated the status to "0 sorries — fully proved" and checked the items.

The gallery `meta.json` was already correct (`status: verified`, `sorries: 0`), so this just aligns the in-file docstring with reality.

Found while scoping the phantom slug `inclusion-exclusion-oq-01-oq-03` (no workspace/JSON; the actionable oq-03 content turned out already complete).

## Status
**Outcome**: minor integrity cleanup; no logical change.

🤖 Generated by researcher-1