### PR TITLE
research(erdos-10-oq-02): verified-name Decidable-instance recipe + cert re-verify

### DIFF
--- a/proofs/Proofs/Erdos10OQ02Decidable.lean
+++ b/proofs/Proofs/Erdos10OQ02Decidable.lean
@@ -153,4 +153,48 @@ theorem isPrimePlusKPowers_iff_bounded_distinct (k n : ℕ) :
 #check @repWithAtMost_iff_repBoundedDistinct
 #check @isPrimePlusKPowers_iff_bounded_distinct
 
+/-! ## Part VIII: Decidability recipe (verified lemma names, build-pending)
+
+The explicit `Decidable (RepWithAtMost k n)` instance is the last mechanical
+step. The bridge below is fully name-checked against the Mathlib pin `v4.26.0`
+(sibling checkout); only an end-to-end Lean build (Docker-gated) remains to
+confirm elaboration. The target equivalence, with the search pinned to a finite
+`Finset`:
+
+  `RepWithAtMost k n ↔
+     ∃ F ∈ (Finset.range (n + 1)).powerset, F.card ≤ k ∧ (∑ a ∈ F, 2 ^ a) = n`
+
+whose right-hand side is `Decidable` (bounded `Finset` existential + decidable
+`≤`/`=` on `ℕ`), so `decidable_of_iff _ (the_iff).symm` yields the instance.
+
+Proof of the equivalence (both directions go through
+`repWithAtMost_iff_repBoundedDistinct`):
+
+* **→** From `RepBoundedDistinct` take the `Nodup` multiset `s` (card `≤ k`,
+  every exponent `≤ n`, `powSum s = n`). Set `F := s.toFinset`.
+    - `F ∈ powerset (range (n+1))`: `Finset.mem_powerset` + `Finset.subset_iff`;
+      `a ∈ F ↔ a ∈ s` is `Multiset.mem_toFinset`, and `a ≤ n ⟹ a ∈ range (n+1)`
+      by `Finset.mem_range` (`omega`).
+    - `F.card ≤ k`: `Multiset.toFinset_card_of_nodup hnd`
+      (`Data/Finset/Card.lean:188`) rewrites `#F = Multiset.card s ≤ k`.
+    - `(∑ a ∈ F, 2^a) = n`: `Finset.sum_eq_multiset_sum` turns the sum into
+      `(F.val.map (2^·)).sum`; `F.val = s` because `s` is `Nodup`
+      (`Multiset.toFinset_eq hnd : Finset.mk s hnd = s.toFinset`, take `.val`,
+      with `Multiset.Nodup.dedup`/`Multiset.toFinset_val`), so it equals
+      `powSum s = n`.
+* **←** Given `F` with `F.card ≤ k` and `(∑ a ∈ F, 2^a) = n`, set `s := F.val`
+  (a `Nodup` multiset). Then `Multiset.card s = #F ≤ k` and
+  `powSum s = (F.val.map (2^·)).sum = ∑ a ∈ F, 2^a = n`
+  (again `Finset.sum_eq_multiset_sum`), giving `RepWithAtMost` directly
+  (`⟨s, hcard, hsum⟩`).
+
+With `Decidable (RepWithAtMost k n)` in hand, `Decidable (RepBoundedDistinct k n)`
+and (via `isPrimePlusKPowers_iff_bounded_distinct` + `Nat.decidablePrime` over
+`p ∈ Finset.range (n+1)`) `Decidable (IsPrimePlusKPowers k n)` follow, and the
+concrete facts `¬ RepWithAtMost 2 905`, `¬ RepWithAtMost 3 906`-style and the
+Grechuk witness `¬ IsPrimePlusKPowers 3 1117175146` close by
+`decide`/`native_decide`. All arithmetic certified in
+`research/problems/erdos-10-oq-02/verify_decidable_membership.py` (ALL CERTS PASS:
+905/906 consecutive caps + Grechuk ∉ S₃, ∈ S₄). -/
+
 end Erdos10OQ02

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -48,13 +48,15 @@
       "S2: 905 (smallest odd needing 2) and 906 (smallest even needing 3) are CONSECUTIVE — the +1 parity offset realized back-to-back at the forcing extremes.",
       "S2: the even minPowers distribution ≈ the odd one shifted +1 (even[k]≈odd[k-1], match to ~0.02%): minPowers(2j) ≤ 1 + minPowers(2j-1) (spend 2^0 to fix parity, then the odd subproblem); equality usually but not always — even n can reach prime 2 via m=n-2, causing small deviations.",
       "GS caps 3 (odd) / 4 (even) = in-range caps 2 / 3, plus one safety power; the forcing cases live beyond brute force.",
-      "Grechuk's 1117175146 confirmed ∉ S_3 and ∈ S_4 (popcount 16)."
+      "Grechuk's 1117175146 confirmed ∉ S_3 and ∈ S_4 (popcount 16).",
+      "S5 (2026-06-15, researcher-3, build-free blackout): de-risked the S4 decidability keystone and DOCUMENTED the exact Decidable-instance recipe (Part VIII comment in Erdos10OQ02Decidable.lean) with v4.26-verified bridge lemma names: target RepWithAtMost k n ↔ ∃ F ∈ (Finset.range(n+1)).powerset, F.card≤k ∧ (∑ a∈F, 2^a)=n; instance via decidable_of_iff. Bridge: Multiset.toFinset_eq (Finset/Dedup.lean:57, F.val=s for Nodup s), Multiset.toFinset_card_of_nodup (Finset/Card.lean:188), Finset.sum_eq_multiset_sum, Multiset.mem_toFinset, Finset.mem_powerset/mem_range. Re-ran verify_decidable_membership.py: ALL CERTS PASS (a<2^a; RepWithAtMost==bounded-distinct==popcount≤k n≤200; 905/906 consecutive caps; Grechuk 1117175146 ∉S₃ ∈S₄). Reduces the remaining step from 'design the bridge' to 'type these verified-name lemmas + decide'. Still build-pending (docker info exit124, Aristotle prove 404); file unregistered."
     ],
     "mathlibGaps": [
       "No Decidable instance wired for sumPrimeAndTwoPows / IsPrimePlusKPowers; the popcount reduction would supply one.",
       "Crocker (1971) and Gallagher (1975) results are documented in source comments only, not formalized."
     ],
     "nextSteps": [
+      "Docker-up: type the Part VIII Decidable-instance recipe into Erdos10OQ02Decidable.lean (verified-name bridge lemmas listed there), derive Decidable (IsPrimePlusKPowers) via isPrimePlusKPowers_iff_bounded_distinct + Nat.decidablePrime, then close 906/Grechuk witnesses by native_decide. Register Erdos10OQ02.lean + Erdos10OQ02Decidable.lean in proofs/Proofs.lean.",
       "ACT (Docker-gated): formalize the popcount≤k reduction lemma and a Decidable membership for sumPrimeAndTwoPows; discharge the 906 / Grechuk witnesses by decide/native_decide.",
       "Add Crocker (1971) citation to the gallery as the precise reason k=3 (not 2) is required on the odd side.",
       "GS-odd itself needs sieve/large-sieve machinery (Gallagher line) — out of brute-force and near-term Lean reach."


### PR DESCRIPTION
## Summary
De-risks the S4 decidability keystone for Erdős #10 OQ-02 (Granville–Soundararajan: is every odd `n>1` a prime + ≤3 powers of 2?). The S4 file `Erdos10OQ02Decidable.lean` already proves the bounded reduction (`RepWithAtMost ↔ RepBoundedDistinct`, exponents ≤ n); the only remaining piece is the explicit `Decidable` instance. This PR supplies the exact, name-checked recipe.

## Added (Part VIII, doc comment)
The target equivalence pinning the search to a finite `Finset`:
```
RepWithAtMost k n ↔ ∃ F ∈ (Finset.range (n+1)).powerset, F.card ≤ k ∧ (∑ a ∈ F, 2^a) = n
```
→ `decidable_of_iff`. Every bridge lemma is name-checked against the v4.26 pin:
`Multiset.toFinset_eq` (Dedup.lean:57), `Multiset.toFinset_card_of_nodup` (Card.lean:188), `Finset.sum_eq_multiset_sum`, `Multiset.mem_toFinset`, `Finset.mem_powerset`/`mem_range`. This turns "design the bridge" into "type these lemmas + decide".

## Verification
`verify_decidable_membership.py` re-run: **ALL CERTS PASS** — `a < 2^a`; `RepWithAtMost == bounded-distinct == popcount ≤ k`; the consecutive caps 905 (smallest odd needing 2) / 906 (smallest even needing 3); Grechuk `1117175146 ∉ S₃, ∈ S₄`.

## Status
**Outcome**: progress (de-risk + recipe; doc-only change)
**Build-pending**: Docker + Aristotle blackout; file unregistered.
**Next**: Docker-up — type the recipe, derive `Decidable (IsPrimePlusKPowers)`, close witnesses by `native_decide`, register.

🤖 Generated by researcher-3