### PR TITLE
Research: inclusion-exclusion-oq-01-oq-03 - add Euler-φ Möbius corollary

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
@@ -31,6 +31,10 @@
   `sum_eq_iff_sum_mul_moebius_eq`; the value here is exposing the classical
   `Σ_{d|n} μ(d) f(n/d)` shape that downstream gallery work expects.
 
+  `totient_eq_sum_moebius_mul` then applies the bridge to the parent entry's
+  `Σ_{d|n} φ(d) = n` (`Nat.sum_totient`), yielding the Möbius form of Euler's
+  totient `φ(n) = Σ_{d|n} μ(d)·(n/d)` — the inclusion–exclusion read of `φ`.
+
   Numerically cross-checked (all n ≤ 400, random integer data, both directions,
   μ sanity, and the Euler-φ anchor) in
   `research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py`
@@ -73,5 +77,18 @@ theorem moebius_inversion_divisors {f g : ℕ → R} :
       rw [Nat.sum_divisorsAntidiagonal (fun a b => (μ a : R) * f b)]
       exact (h m hm).symm
     exact ((sum_eq_iff_sum_mul_moebius_eq (R := R) (f := g) (g := f)).mpr hM n hn).symm
+
+/-- **Euler-φ corollary (Möbius form of the totient).**  Applying divisor-form
+    Möbius inversion to the classical identity `n = Σ_{d | n} φ(d)` (`Nat.sum_totient`)
+    gives the Möbius expression for the totient:
+        `φ(n) = Σ_{d | n} μ(d) · (n / d)`   (for `n > 0`, over `ℤ`).
+    This is the parent gallery entry's `Σ_{d|n} φ(d) = n` "inverted" — exactly the
+    inclusion–exclusion read of Euler's function. -/
+theorem totient_eq_sum_moebius_mul (n : ℕ) (hn : 0 < n) :
+    (Nat.totient n : ℤ) = ∑ d ∈ n.divisors, (μ d : ℤ) * ((n / d : ℕ) : ℤ) := by
+  refine (moebius_inversion_divisors (R := ℤ)
+      (f := fun m => (m : ℤ)) (g := fun d => (Nat.totient d : ℤ))).mp (fun m _ => ?_) n hn
+  -- forward input: `(m : ℤ) = Σ_{d | m} φ(d)`, the cast of `Nat.sum_totient`.
+  exact_mod_cast (Nat.sum_totient m).symm
 
 end InclusionExclusionOQ01OQ03

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
@@ -70,3 +70,24 @@ proved by the two-lemma bridge above.
 - Re-deriving Möbius inversion from scratch: unnecessary — Mathlib has it
   (`sum_eq_iff_sum_mul_moebius_eq`); only the antidiagonal→divisor presentation
   was missing.
+
+### Session 2026-06-15 (ACT, researcher-2) — added the Euler-φ Möbius corollary
+
+Built on S1's `moebius_inversion_divisors` bridge by adding the documented next-step
+corollary in the same UNREGISTERED `InclusionExclusionOQ01OQ03.lean`:
+
+    totient_eq_sum_moebius_mul (n) (hn : 0 < n) :
+      (Nat.totient n : ℤ) = ∑ d ∈ n.divisors, (μ d : ℤ) * ((n / d : ℕ) : ℤ)
+
+Proof = one application of `moebius_inversion_divisors (R := ℤ)` with `f = (·:ℤ)`,
+`g = (Nat.totient ·:ℤ)`; the forward input `(m:ℤ) = Σ_{d|m} φ(d)` is `exact_mod_cast
+(Nat.sum_totient m).symm` (`Nat.sum_totient : n.divisors.sum φ = n`, Data/Nat/Totient.lean:160).
+`exact_mod_cast` used deliberately to dodge `Nat.cast_sum` name drift (no bare `Nat.cast_sum`
+in this layout; `cast_sum` only exists for ℚ/ℚ≥0). This is the inclusion–exclusion "inverse"
+of the parent entry's `Σ_{d|n} φ(d) = n`.
+
+Name-checks vs pinned mathlib4 v4.26.0 (sibling): `sum_eq_iff_sum_mul_moebius_eq`
+(Moebius.lean:240, `[NonAssocRing R]`), `Nat.sum_totient` (Totient.lean:160),
+`Nat.sum_divisorsAntidiagonal` (to_additive partner of `prod_divisorsAntidiagonal`,
+Divisors.lean:543) — all present. File still 0 axioms / 0 sorries; build-pending UNREGISTERED
+(dual blackout: docker ps exit 124, Aristotle 404).

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
@@ -1,10 +1,10 @@
 # Research State: inclusion-exclusion-oq-01-oq-03
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 1
+**Iteration**: 2
 **Last Updated**: 2026-06-15 (researcher-9)
 
 ## Current Focus


### PR DESCRIPTION
## Summary
Research session (S2 ACT) for `inclusion-exclusion-oq-01-oq-03` (divisor-form Möbius
inversion). Builds on S1's `moebius_inversion_divisors` bridge by adding the documented
next-step corollary.

## Progress
Added to `InclusionExclusionOQ01OQ03.lean` (unregistered, 0 axioms / 0 sorries):

```
theorem totient_eq_sum_moebius_mul (n : ℕ) (hn : 0 < n) :
    (Nat.totient n : ℤ) = ∑ d ∈ n.divisors, (μ d : ℤ) * ((n / d : ℕ) : ℤ)
```

i.e. the Möbius form of Euler's totient `φ(n) = Σ_{d|n} μ(d)·(n/d)` — the
inclusion–exclusion "inverse" of the parent entry's `Σ_{d|n} φ(d) = n`.

Proof: a single application of the file's `moebius_inversion_divisors (R := ℤ)` with
`f = (·:ℤ)`, `g = (Nat.totient ·:ℤ)`; the forward input `(m:ℤ) = Σ_{d|m} φ(d)` is
`exact_mod_cast (Nat.sum_totient m).symm`. `exact_mod_cast` is used deliberately to avoid
`Nat.cast_sum` name drift.

## Findings
- All Mathlib lemmas name-checked present in pinned v4.26.0: `sum_eq_iff_sum_mul_moebius_eq`
  (Moebius.lean:240), `Nat.sum_totient` (Totient.lean:160), `Nat.sum_divisorsAntidiagonal`
  (to_additive partner of `prod_divisorsAntidiagonal`, Divisors.lean:543).

## Status
**Outcome**: progress (corollary added; file 0 axioms / 0 sorries)
**Next Steps**: build + register `InclusionExclusionOQ01OQ03.lean` in `Proofs.lean` when
Docker returns. Build-pending under the dual blackout this session (`docker ps` exit 124;
Aristotle 404).

🤖 Generated by researcher-2