### PR TITLE
research(cevas-theorem-oq-02-oq-01-oq-02-oq-01): S4 — register merged unification file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -493,6 +493,7 @@ import Proofs.CevasTheoremOQ01OQ03
 import Proofs.CevasTheoremOQ02
 import Proofs.CevasTheoremOQ02OQ01
 import Proofs.CevasTheoremOQ02OQ01OQ02
+import Proofs.CevasTheoremOQ02OQ01OQ02OQ01
 import Proofs.CevasTheoremOQ02OQ01OQ03
 import Proofs.CevasTheoremOQ02OQ02
 import Proofs.CevasTheoremOQ04

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -42,6 +42,33 @@ All Mathlib identifiers grep-confirmed present in the pinned tree (sibling
 
 ---
 
+## Result (Session 4, 2026-06-15, researcher-6 — registration)
+
+The S2/S3 file `CevasTheoremOQ02OQ01OQ02OQ01.lean` is merged to `main` (PRs
+#24377, #24430) but was **never machine-checked**: it is absent from
+`proofs/Proofs.lean`, so the deployer's `Proofs` build target skipped compiling
+it. This session **registers** it (`import Proofs.CevasTheoremOQ02OQ01OQ02OQ01`
+inserted alphabetically at `Proofs.lean:496`) so the deployer compiles it on the
+next Docker-up cycle, turning "0-sorry by inspection" into machine-verified.
+
+Re-confirmed the full identifier set against the pinned v4.26 sibling
+(`/Users/rwalters/GitHub/mathlib4`, matches pin):
+`mul_div_mul_right (a b : G₀) (hc : c ≠ 0)` (GroupWithZero/Units/Basic:312 — exact
+shape of the crux usage `mul_div_mul_right β α hg`), `div_ne_zero (ha) (hb)`
+(GroupWithZero/Units/Basic:237), `sq_nonneg`, `Real.sqrt_pos`. File is 14
+theorems + 1 structure + 4 defs, 267 lines.
+
+Blackout still LIVE this session: `docker info` exits 124 (daemon hang); build
+remains deferred to the deployer. **Registration is deployer-gated** — a failing
+compile blocks merge rather than breaking `main`, so registering blind under
+blackout is safe here (no axiom/semantic edit, only an import line).
+
+**Remaining (post-build):** create the gallery entry
+`src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/` (deferred until the
+build confirms `verified`, to avoid an honesty-policy overclaim pre-compile).
+
+---
+
 ## Problem Understanding
 
 The parent file already proves the three classical Ceva theorems share **one

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
@@ -21,9 +21,17 @@ ratios. Close concurrency by reusing the parent's already-κ-free
 `universal_weight_balance`.
 
 ## Attempt Count
-- Total attempts: 0 (survey only; no Lean built)
-- Current approach attempts: 0
-- Approaches tried: 1 (Cayley–Klein algebraic unification — viable)
+- Total attempts: 1 (S2 Lean implemented + merged; S4 registered for build)
+- Current approach attempts: 1
+- Approaches tried: 1 (Cayley–Klein algebraic unification — implemented, merged)
+
+## Session 4 (2026-06-15, researcher-6) — registration
+- The merged file was absent from `proofs/Proofs.lean`, so it had never been
+  compiled. Added `import Proofs.CevasTheoremOQ02OQ01OQ02OQ01` (alphabetical,
+  Proofs.lean:496) so the deployer machine-checks it on the next Docker-up cycle.
+- Full identifier set re-confirmed against pinned v4.26 sibling. Docker still
+  down (`docker info` exit 124); build deferred to deployer (deployer-gated).
+- Post-build TODO: gallery entry under `src/data/proofs/<slug>/` once `verified`.
 
 ## Blockers
 - **Verification blackout (2026-06-13)**: Docker daemon down (`docker info` exit

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
@@ -42,18 +42,20 @@
       "Mathlib has no Cayley-Klein / projective-metric API, so the formalization is definitional (CKCevianConfig + three sqrt factors), not API-wiring; the hard algebra is already in the parent and reused.",
       "The Beltrami-Klein model is the natural one: hyperbolic geodesics are Euclidean chords, so 'hyperbolic Ceva = projective Ceva of chords' is literal with no transcendental detour.",
       "Unification lives entirely in (m,α,β,n) scalar algebra: the geometry-specific factor g=sqrt|1-m^2|/n is a common nonzero factor that cancels, so one projective_ceva_unification theorem yields spherical/euclidean/hyperbolic Ceva by plugging gSph/gEuc/gHyp.",
-      "Curvature sentinel kappa + single hypothesis hn:0<alpha^2+2*alpha*beta*m+beta^2 replaces the three incompatible per-geometry m-bounds."
+      "Curvature sentinel kappa + single hypothesis hn:0<alpha^2+2*alpha*beta*m+beta^2 replaces the three incompatible per-geometry m-bounds.",
+      "The merged unification file was absent from the Proofs build target, so 0-sorry/0-axiom held only by inspection, not machine-check; registration converts it to a deployer-gated verification."
     ],
     "builtItems": [
       "CevasTheoremOQ02OQ01OQ02OQ01.lean — projective Cayley-Klein unification of Ceva (CKCevianConfig + projective_ceva_unification + 3 geometry specializations).",
-      "ck_ratio_cancel: the crux (β*g)/(α*g)=β/α via mul_div_mul_right (division-safe, no field_simp)."
+      "ck_ratio_cancel: the crux (β*g)/(α*g)=β/α via mul_div_mul_right (division-safe, no field_simp).",
+      "Registered Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean in proofs/Proofs.lean:496 (was unregistered ⇒ never compiled); deployer will machine-check on next Docker-up cycle."
     ],
     "deadEnds": [
       "Building genuine RP^2 + absolute-conic projective geometry in Mathlib: unnecessary, the scalar (m, alpha, beta) data captures the criterion and side-ratio.",
       "Forcing one m-bound for all geometries: none exists; carry n^2 > 0 instead.",
       "Treating Euclidean as a separate sqrt-bearing case: it is the sqrt|1-m^2| -> 0 limit; use g = 1."
     ],
-    "progressSummary": "ACT (S2): implemented the projective Cayley-Klein unification in CevasTheoremOQ02OQ01OQ02OQ01.lean (0 axioms, 0 sorries) — one projective_ceva_unification theorem with 3 geometry specializations. Build-pending/UNREGISTERED (Docker down); all Mathlib names confirmed in pinned tree."
+    "progressSummary": "ACT (S4): registered the merged Cayley-Klein unification file in Proofs.lean so the deployer compiles it. Build-pending (Docker down). Gallery entry deferred until build confirms verified."
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Summary
- Registers `Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean` (the projective Cayley–Klein unification of Ceva's theorem, merged in #24377/#24430) in `proofs/Proofs.lean`.
- The file was **never in the `Proofs` build target**, so the deployer skipped compiling it — its `0 sorries / 0 axioms` status held only by inspection. This registration gets it machine-checked on the next Docker-up cycle.
- Updates problem knowledge/state docs (S4 entry).

## Why this is safe under the verification blackout
- `docker info` exits 124 (daemon hang) this session, so no local Lean build is possible.
- The change is a single **import line** — no axiom or semantic edit. A failing compile is **deployer-gated**: it blocks the merge rather than breaking `main`.
- Full identifier set re-confirmed against the pinned v4.26 sibling (`/Users/rwalters/GitHub/mathlib4`): `mul_div_mul_right (a b : G₀) (hc : c ≠ 0)`, `div_ne_zero`, `sq_nonneg`, `Real.sqrt_pos`.

## Build status
`build-pending` — deferred to the deployer (Docker down).

## Remaining (post-build)
Gallery entry under `src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/`, deferred until the build confirms `verified` (avoids a pre-compile honesty-policy overclaim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)