### PR TITLE
Research: four-square-distribution-oq-04 - resolve arrangement_card Mathlib lead

### DIFF
--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -221,3 +221,35 @@ target once the backend returns.
    name drift), then register both `…Decomp` and `…Sign`.
 2. Prove/locate `arrangement_card` (the multinomial count) — the sole residue.
 3. Combine via the file-footer blueprint to discharge `fiber_card_eq_contribution`.
+
+### Session 2026-06-15 (researcher-2) — Mathlib search resolving the `arrangement_card` lead
+
+The keystone `fiber_card_eq_contribution` is reduced (in `…OQ04Sign.lean`'s blueprint) to
+one open lemma, `arrangement_card`:
+`#{g : Fin m → ℤ | g i ≥ 0 ∀i, multiset(g) = s} = m! / ∏_v (count_v s)!`.
+This session ran the build-free Mathlib search the blueprint deferred "to a build session".
+
+**Outcome (pinned mathlib4 v4.26.0):**
+- `Nat.multinomial s f` EXISTS (`Data/Nat/Choose/Multinomial.lean:43`) with the algebraic
+  identity `Nat.multinomial_spec : (∏ i ∈ s, (f i)!) * multinomial s f = (∑ i ∈ s, f i)!`
+  (:50). So `m!/∏count!` is exactly `Nat.multinomial s.toFinset (fun v => s.count v)` — the
+  `shapeContribution` numerator should be RE-EXPRESSED via `Nat.multinomial` to use
+  `multinomial_spec` (avoids the `Nat.div` and matches the factored identity directly).
+- There is **NO** ready cardinality lemma "number of functions/arrangements with a given
+  multiset image = multinomial". `List.length_permutations : (permutations l).length = l.length!`
+  counts ALL n! orderings (ignores repeats), so it is NOT the multiset count.
+- `Combinatorics/Enumerative/Bell.lean` is the closest precedent: it computes a partition
+  count via `Nat.multinomial … * ∏ …` and discharges it with `Nat.multinomial_spec` +
+  `Finset.prod_multiset_map_count` (Bell.lean:77-94). That factorial-bookkeeping technique is
+  the model for proving `arrangement_card` once the cardinality side is set up.
+
+**Recommended route for the build session (sharper than the blueprint's "candidates"):**
+prove `arrangement_card` via `Equiv.Perm (Fin m)` acting on `Fin m → ℤ` (precompose). The
+orbit of an arranged `g` (with `multiset(g)=s`) is the set of arrangements; its stabilizer is
+`{σ | g ∘ σ = g} ≅ ∏_v Equiv.Perm (g⁻¹{v})`, of order `∏_v (count_v s)!`. Then
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group` gives
+`|orbit| · ∏count! = m!`, i.e. `|orbit| = Nat.multinomial …` by `multinomial_spec`. The sole
+remaining work is the **stabilizer-order computation** `∏_v (count_v)!` (the genuine residue;
+`Equiv.Perm` of a fibered type ≅ product of perms of the fibers). Steps 1+3 of the Sign.lean
+blueprint (fiberwise split over `absMap`) remain bookkeeping. Still Docker-gated (dual
+blackout: docker exit 124, Aristotle 404); no Lean edits this session.


### PR DESCRIPTION
## Summary
Research session for `four-square-distribution-oq-04`. The open keystone
`fiber_card_eq_contribution` (orbit-size of the hyperoctahedral action) is reduced by prior
sessions to one lemma, `arrangement_card`: `#{arrangements of multiset s} = m!/∏_v count_v!`,
flagged "no obvious Mathlib lemma — search in a build session". This session runs that
(build-free) search.

## Findings (pinned mathlib4 v4.26.0)
- `Nat.multinomial` exists (`Data/Nat/Choose/Multinomial.lean:43`) with
  `multinomial_spec : (∏ i ∈ s, (f i)!) * multinomial s f = (∑ i ∈ s, f i)!` — so
  `m!/∏count!` IS `Nat.multinomial s.toFinset (s.count ·)`; recommend re-expressing
  `shapeContribution` via it (avoids `Nat.div`, matches the factored identity).
- There is **no** ready cardinality lemma counting multiset arrangements;
  `List.length_permutations` counts all `n!` orderings (ignores repeats), so it doesn't apply.
- `Combinatorics/Enumerative/Bell.lean` is the closest precedent (multinomial × ∏ via
  `multinomial_spec` + `Finset.prod_multiset_map_count`) — the model for the factorial bookkeeping.

## Sharpened route for the next build session
Prove `arrangement_card` via the `Equiv.Perm (Fin m)` action on `Fin m → ℤ`: the orbit of an
arranged `g` is the arrangement set; its stabilizer `{σ | g∘σ = g} ≅ ∏_v Perm(g⁻¹{v})` has
order `∏count!`, so `MulAction.card_orbit_mul_card_stabilizer_eq_card_group` + `multinomial_spec`
give `|orbit| = Nat.multinomial …`. The sole genuine residue is the stabilizer-order computation.

## Status
**Outcome**: surveyed (Mathlib lead resolved; route sharpened; no source change)
**Next Steps**: implement the Perm orbit-stabilizer `arrangement_card` + the Sign.lean steps 1/3
bookkeeping when Docker returns. Dual blackout this session (`docker ps` exit 124; Aristotle 404).

🤖 Generated by researcher-2