### PR TITLE
research(erdos-729-oq-02): legendre_for_two axiom-free via Mathlib Legendre digit-sum lemma

### DIFF
--- a/proofs/Proofs/Erdos729OQ04.lean
+++ b/proofs/Proofs/Erdos729OQ04.lean
@@ -1,0 +1,80 @@
+/-
+  Erdős Problem #729 — Open Question OQ-04
+
+  Question:
+    Can the proof of `legendre_for_two` (v₂(n!) = n − s₂(n), where s₂ is the
+    binary digit sum) be completed in Lean using Mathlib's `padicValNat`
+    machinery — i.e. WITHOUT the axiom `legendre_identity`?
+
+  Answer: YES.
+
+  The parent module `Proofs.Erdos729Problem` proves `legendre_for_two` only by
+  forwarding to the axiom `legendre_identity`
+    (v_p(n!) = (n − s_p(n))/(p − 1)).
+  Mathlib already contains Legendre's theorem in digit-sum form:
+
+    `sub_one_mul_padicValNat_factorial`
+      : (p − 1) * padicValNat p (n!) = n − (Nat.digits p n).sum
+
+  Specialising to p = 2 gives `1 * padicValNat 2 (n!) = n − (Nat.digits 2 n).sum`,
+  which is exactly `legendre_for_two` once we identify the binary digit sum
+  with `(Nat.digits 2 n).sum`.
+
+  This file gives the axiom-free derivation. It is self-contained (it does not
+  import the parent module): we use a structurally-mirrored recursive binary
+  digit sum `binDigitSum` matching the parent's `digitSum 2 ·` recurrence, and
+  prove it equals `(Nat.digits 2 n).sum`.
+
+  Status: 0 axioms, 0 sorries.
+
+  Follow-up (Docker-gated): retire `legendre_identity` directly in the parent
+  registered file. That edit must additionally bridge the parent's `digitSum`,
+  which is defined with `if n = 0 then … else …` (so `simp only [digitSum]`
+  loops); the bridge there needs a single-step unfold (`digitSum.eq_def`)
+  rather than the structural `simp only` usable here.
+
+  Tags: factorials, legendre-formula, p-adic-valuation, axiom-removal
+-/
+
+import Mathlib
+
+namespace Erdos729OQ04
+
+open Nat
+
+/-- Binary digit sum, defined by the same recurrence as the parent file's
+    `digitSum 2 ·` but with a structural `0 / succ` split so its equation
+    lemmas can be unfolded one step at a time without looping. -/
+def binDigitSum : ℕ → ℕ
+  | 0 => 0
+  | n + 1 => (n + 1) % 2 + binDigitSum ((n + 1) / 2)
+  decreasing_by exact Nat.div_lt_self (Nat.succ_pos n) (by norm_num)
+
+/-- The recursive binary digit sum agrees with Mathlib's `Nat.digits 2`. -/
+theorem binDigitSum_eq_digits_sum (n : ℕ) :
+    binDigitSum n = (Nat.digits 2 n).sum := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases n with _ | m
+    · simp [binDigitSum]
+    · simp only [binDigitSum]
+      rw [Nat.digits_def' (by norm_num : (1 : ℕ) < 2) (Nat.succ_pos m),
+          List.sum_cons,
+          ih ((m + 1) / 2) (Nat.div_lt_self (Nat.succ_pos m) (by norm_num))]
+
+/-- **Legendre's theorem for p = 2, axiom-free**, stated with Mathlib's native
+    base-2 digit sum.  This is a direct application of
+    `sub_one_mul_padicValNat_factorial`. -/
+theorem legendre_for_two_native (n : ℕ) :
+    padicValNat 2 n.factorial = n - (Nat.digits 2 n).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  have h := sub_one_mul_padicValNat_factorial (p := 2) n
+  simpa using h
+
+/-- v₂(n!) = n − s₂(n) with the recursive binary digit sum, proved with no
+    axioms (the parent's `legendre_for_two` uses `axiom legendre_identity`). -/
+theorem legendre_for_two (n : ℕ) :
+    padicValNat 2 n.factorial = n - binDigitSum n := by
+  rw [legendre_for_two_native, binDigitSum_eq_digits_sum]
+
+end Erdos729OQ04

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -19,3 +19,49 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-06-15 (Session 1) — RESOLVED (build-pending)
+
+**Mode**: FRESH
+**Outcome**: progress — target theorem proved axiom-free (companion file)
+
+### What I Did
+- Found that Mathlib v4.26 already contains Legendre's theorem in digit-sum form:
+  `sub_one_mul_padicValNat_factorial` (Mathlib/NumberTheory/Padics/PadicVal/Basic.lean:587):
+  `(p - 1) * padicValNat p (n!) = n - (Nat.digits p n).sum`, needing `[Fact p.Prime]`.
+- At p = 2 the `(p-1)=1` factor disappears, so the problem.md target
+  `padicValNat 2 n! = n - (Nat.digits 2 n).sum` is a one-line corollary.
+- Wrote unregistered companion `proofs/Proofs/Erdos729OQ04.lean` (0 axioms / 0 sorries):
+  - `legendre_for_two_native` — the problem.md statement, via the Mathlib lemma.
+  - `binDigitSum` — recursive binary digit sum (structural `0/succ` split on `n/2`,
+    so its equation lemmas unfold one step without looping, unlike the parent's
+    `if`-based `digitSum`).
+  - `binDigitSum_eq_digits_sum` — strong induction + `Nat.digits_def'` proves it
+    equals `(Nat.digits 2 n).sum`.
+  - `legendre_for_two` — `padicValNat 2 n! = n - binDigitSum n`.
+
+### Key Findings
+- problem.md "approach 3" (already in Mathlib) was correct; no induction needed for the core.
+- Parent `Erdos729Problem.lean` proves `legendre_for_two` only by forwarding to
+  `axiom legendre_identity`. That axiom is now unnecessary.
+- Name-checked all lemmas against the pinned v4.26 sibling (`~/GitHub/mathlib4`):
+  `sub_one_mul_padicValNat_factorial`, `Nat.digits_def'` (sig `1<b`, `0<n`),
+  `Nat.div_lt_self (Nat.succ_pos _) h` (verbatim `decreasing_by` from Digits/Defs.lean:54),
+  `induction … using Nat.strong_induction_on with | _ n ih` (Order/Fin/Basic.lean:414),
+  `List.sum_cons`.
+
+### Blackout
+- Docker build hung (exit124); Aristotle MCP returned 404. Shipped build-pending,
+  name-checked. No build verification was possible this session.
+
+### Files Modified
+- `proofs/Proofs/Erdos729OQ04.lean` (new, unregistered)
+- `src/data/research/problems/erdos-729-oq-02.json` (knowledge)
+
+### Next Steps
+- Docker-gated: retire `legendre_identity` directly in registered `Erdos729Problem.lean`
+  (4 axioms → 3) and sync `src/data/proofs/erdos-729/meta.json` in the SAME PR. The parent
+  `digitSum` is `if`-based, so unfold one step with `digitSum.eq_def` (not `simp only`,
+  which loops) — or rewrite the def structurally as `binDigitSum` here.

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-729-oq-02",
   "title": "Legendre's Formula for 2-adic Valuation of Factorials",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "fast",
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "RESOLVED (build-pending): legendre_for_two proved axiom-free in unregistered companion via Mathlib sub_one_mul_padicValNat_factorial; registered-file axiom retirement is a Docker follow-up.",
+    "builtItems": [
+      "proofs/Proofs/Erdos729OQ04.lean legendre_for_two_native : padicValNat 2 n.factorial = n - (Nat.digits 2 n).sum, 0 axioms/0 sorries via sub_one_mul_padicValNat_factorial + Fact (Nat.Prime 2).",
+      "Erdos729OQ04.lean binDigitSum (structural 0/succ recursion on n/2) + binDigitSum_eq_digits_sum proving it equals (Nat.digits 2 n).sum by strong induction + Nat.digits_def'.",
+      "Erdos729OQ04.lean legendre_for_two : padicValNat 2 n.factorial = n - binDigitSum n (recursive-digit-sum form, 0 axioms)."
+    ],
+    "insights": [
+      "Legendre v_2(n!)=n-s_2(n) is a DIRECT corollary of Mathlib v4.26 sub_one_mul_padicValNat_factorial : (p-1)*padicValNat p (n!) = n - (Nat.digits p n).sum. At p=2 the (p-1)=1 factor vanishes, giving the statement with zero axioms (approach 3 from problem.md was correct).",
+      "No induction on binary representation needed; the digit-sum form of Legendre is already in Mathlib (Mathlib/NumberTheory/Padics/PadicVal/Basic.lean:587), so the only real work is bridging a recursive binary digit sum to (Nat.digits 2 n).sum."
+    ],
+    "mathlibGaps": [
+      "No gap: sub_one_mul_padicValNat_factorial supplies the digit-sum Legendre formula directly in v4.26."
+    ],
+    "nextSteps": [
+      "Docker-gated follow-up: retire axiom legendre_identity in registered Erdos729Problem.lean by proving legendre_for_two directly. Its digitSum uses if-n=0 so simp only [digitSum] loops; unfold one step with digitSum.eq_def or rewrite the def to structural 0/succ like binDigitSum here.",
+      "Optional: state general-p v_p(n!)=(n-s_p(n))/(p-1) from the same lemma to also justify/retire legendre_identity for all p."
+    ],
     "markdown": "# Knowledge Base: erdos-729-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Resolves the open question **erdos-729-oq-02** (OQ-04): *can `legendre_for_two` (v₂(n!) = n − s₂(n)) be proved using Mathlib's `padicValNat` machinery, without the `legendre_identity` axiom?* **Yes.**

Mathlib v4.26 already contains Legendre's theorem in digit-sum form:

```
sub_one_mul_padicValNat_factorial [Fact p.Prime] (n) :
    (p - 1) * padicValNat p (n !) = n - (Nat.digits p n).sum
```
(`Mathlib/NumberTheory/Padics/PadicVal/Basic.lean:587`). At `p = 2` the `(p−1)=1` factor vanishes, giving the target directly. The parent `Proofs.Erdos729Problem` proves `legendre_for_two` only by forwarding to `axiom legendre_identity`, which this shows to be unnecessary.

## What's added

New **unregistered** companion `proofs/Proofs/Erdos729OQ04.lean` (0 axioms / 0 sorries):

- `legendre_for_two_native (n) : padicValNat 2 n.factorial = n - (Nat.digits 2 n).sum` — the problem.md statement, a one-line corollary of the Mathlib lemma.
- `binDigitSum` — recursive binary digit sum with a structural `0/succ` split (so its equation lemmas unfold without looping, unlike the parent's `if`-based `digitSum`).
- `binDigitSum_eq_digits_sum` — strong induction + `Nat.digits_def'` shows it equals `(Nat.digits 2 n).sum`.
- `legendre_for_two (n) : padicValNat 2 n.factorial = n - binDigitSum n`.

## Verification status

**Build-pending.** Docker build hung (exit 124) and the Aristotle MCP returned 404 during this session, so no machine build was possible. All lemma names/signatures were checked against the pinned **v4.26** Mathlib sibling checkout:
`sub_one_mul_padicValNat_factorial`, `Nat.digits_def'` (`1<b`, `0<n`), `Nat.div_lt_self (Nat.succ_pos _) h` (the verbatim `decreasing_by` from `Digits/Defs.lean:54`), `induction … using Nat.strong_induction_on with | _ n ih`, `List.sum_cons`.

## Follow-up (Docker-gated)

Retire `axiom legendre_identity` directly in the registered `Erdos729Problem.lean` (4 axioms → 3) and sync `src/data/proofs/erdos-729/meta.json` in the same PR. The parent `digitSum` is `if`-based, so unfold one step with `digitSum.eq_def` (not `simp only`, which loops) or restructure it like `binDigitSum`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos729OQ04` once the build host is available.