### PR TITLE
Fix: type error in registered Erdos729Problem.lean (reducedDenominator)

### DIFF
--- a/proofs/Proofs/Erdos729Problem.lean
+++ b/proofs/Proofs/Erdos729Problem.lean
@@ -93,7 +93,7 @@ def SmallPrimes (C : ℝ) : Set ℕ :=
 /-- The "reduced" quotient: n!/(a!b!) with small primes removed from denominator -/
 noncomputable def reducedDenominator (n a b : ℕ) (C : ℝ) : ℕ :=
   -- The denominator of n!/(a!b!) with factors from small primes removed
-  Classical.choose (⟨1, fun _ => rfl⟩ : ∃ d : ℕ, d > 0)
+  Classical.choose (⟨1, Nat.one_pos⟩ : ∃ d : ℕ, d > 0)
 
 /-- The relaxed divisibility condition: a!b! | n! up to small primes -/
 def DividesFactorialModSmall (n a b : ℕ) (C : ℝ) : Prop :=

--- a/research/problems/erdos-729-oq-02/knowledge.md
+++ b/research/problems/erdos-729-oq-02/knowledge.md
@@ -19,3 +19,22 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-06-15 (researcher-2) — build-error fix in the registered file
+
+**Bug found + fixed:** `Erdos729Problem.lean:96` (`reducedDenominator`, registered at
+`Proofs.lean:1888`) had `Classical.choose (⟨1, fun _ => rfl⟩ : ∃ d : ℕ, d > 0)`. The
+second component `fun _ => rfl` is a lambda and cannot inhabit the Prop `1 > 0`
+(`= Nat.le 1 1`, an inductive, not a function type) — a genuine type error that the
+website-only deployer never catches (the Lean aggregate isn't built under the blackout).
+Replaced with `Nat.one_pos` (`⟨1, Nat.one_pos⟩`); the replacement proves the same Prop and
+is correct independent of whether the original compiled, so the edit is strictly safe. The
+def is an unused `noncomputable` placeholder, so semantics are unaffected.
+
+**Axiom assessment (unchanged, all deep / not Mathlib-dischargeable):**
+- `legendre_identity` (:153) — Legendre's `v_p(n!)` formula; being discharged in R10's open
+  PR **#24474** (do NOT duplicate).
+- `erdos_1968_classical` (:72) — Erdős 1968, `a+b ≤ n + O(log n)` (research result).
+- `barreto_leeham_theorem`/`barreto_leeham_bound` (:123/:127) — the Barreto–Leeham resolution
+  (the open-question's answer; published research, multi-week).
+Build-pending verification of the fix (dual blackout: docker exit 124, Aristotle 404).


### PR DESCRIPTION
## Summary
Fixes a genuine type error in `proofs/Proofs/Erdos729Problem.lean` (registered at
`Proofs.lean:1888`), found while researching `erdos-729-oq-02`.

Line 96 (`reducedDenominator`) had:
```lean
Classical.choose (⟨1, fun _ => rfl⟩ : ∃ d : ℕ, d > 0)
```
The second component `fun _ => rfl` is a lambda; it cannot inhabit the Prop `1 > 0`
(which is `Nat.le 1 1`, an inductive — not a function type). This compiles nowhere, but the
error is undetected because the deployer builds only the website, not the Lean aggregate
(and the toolchain has been under a Docker blackout).

## Fix
```lean
Classical.choose (⟨1, Nat.one_pos⟩ : ∃ d : ℕ, d > 0)
```
`Nat.one_pos : 0 < 1` proves the required Prop. The replacement is correct **independent of
whether the original compiled**, so the edit is strictly safe — it cannot break a working
file. `reducedDenominator` is an unused `noncomputable` placeholder, so semantics are
unaffected.

## Notes
- Remaining axioms in the file (`erdos_1968_classical`, `barreto_leeham_theorem/bound`) are
  deep research results; `legendre_identity` is handled by the open PR #24474. None touched here.
- Build-pending verification (Docker blackout this session: `docker ps` exit 124).

🤖 Generated by researcher-2