### PR TITLE
research(spherical-law-of-cosines-oq-03): S4 — pure cross-product dual law

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
@@ -60,6 +60,11 @@ trig form `cos C = − cos A · cos B + sin A · sin B · cos c`.
 * `dual_poly`            — algebraic heart of the dual law                     (ring)
 * `dual_law_cleared`     — dual law for abstract normal-form data
 * `dual_spherical_law_cleared` — dual law for a unit-vector spherical triangle
+* `dual_law_trig`        — literal trig dual law from cleared normal-form hypotheses
+* `cosA_num`/`cosB_num`/`cosC_num` — angle-cosine numerators as Binet–Cauchy
+  inner products of edge normals (geometric grounding of the normal forms)
+* `sina_sq`/`sinb_sq`/`sinc_sq` — side-sine squares as Lagrange self-inner-products
+* `dual_law_cross_product_form` — the dual law in pure cross-product form
 
 Axioms: 0.  Sorries: 0.
 
@@ -249,5 +254,84 @@ theorem dual_law_trig
       (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 + 2 * ca * cb * cc) hsc2 rfl
   apply mul_right_cancel₀ hD
   linear_combination (sc ^ 2) * hcC + hAB - cc * hsAsB + key
+
+/-! ## Part VI: Fully geometric cross-product form
+
+The cleared dual law `dual_spherical_law_cleared` is stated with the angle-cosine
+*numerators* `ca − cb·cc`, etc. and the side-sine *squares* `1 − cc²` written out
+as polynomials in the side cosines. The lemmas below show that each of those
+quantities is itself a transparent cross-product inner product:
+
+* every angle-cosine numerator is a Binet–Cauchy inner product of two edge normals
+  (`⟨u×v, u×w⟩ = cos a − cos b·cos c`, the unnormalised `cos A`);
+* every side-sine square is a Lagrange self-inner-product
+  (`⟨u×v, u×v⟩ = 1 − cos²c = sin²c`).
+
+Substituting these identifications recovers the dual law in **pure cross-product
+form** (`dual_law_cross_product_form`), with no side cosines appearing as bare
+inner products — the entire identity lives in the exterior algebra of the three
+vertex vectors. This grounds the posited normal forms of `dual_law_trig` in actual
+geometry; all proofs remain `ring`/`rw`-only (no division, no radicals). -/
+
+/-- Angle `A` (at vertex `u`) numerator as a Binet–Cauchy inner product of the two
+edge normals at `u`:  `⟨u×v, u×w⟩ = cos a − cos b·cos c`. -/
+theorem cosA_num (u v w : V) (hu : dot u u = 1) :
+    dot (cross u v) (cross u w) = dot v w - dot w u * dot u v := by
+  have h := binet_cauchy u v u w
+  rw [h, hu, dot_comm u w, dot_comm v u]; ring
+
+/-- Angle `B` (at vertex `v`) numerator as a Binet–Cauchy inner product of the two
+edge normals at `v`:  `⟨v×w, v×u⟩ = cos b − cos a·cos c`. -/
+theorem cosB_num (u v w : V) (hv : dot v v = 1) :
+    dot (cross v w) (cross v u) = dot w u - dot v w * dot u v := by
+  have h := binet_cauchy v w v u
+  rw [h, hv, dot_comm v u, dot_comm w v]; ring
+
+/-- Angle `C` (at vertex `w`) numerator as a Binet–Cauchy inner product of the two
+edge normals at `w`:  `⟨w×u, w×v⟩ = cos c − cos a·cos b`. -/
+theorem cosC_num (u v w : V) (hw : dot w w = 1) :
+    dot (cross w u) (cross w v) = dot u v - dot v w * dot w u := by
+  have h := binet_cauchy w u w v
+  rw [h, hw, dot_comm w v, dot_comm u w]; ring
+
+/-- Side `c` sine-square as a Lagrange self-inner-product:
+`⟨u×v, u×v⟩ = 1 − cos²c = sin²c`. -/
+theorem sinc_sq (u v : V) (hu : dot u u = 1) (hv : dot v v = 1) :
+    dot (cross u v) (cross u v) = 1 - dot u v ^ 2 := by
+  rw [lagrange_identity u v, hu, hv]; ring
+
+/-- Side `b` sine-square as a Lagrange self-inner-product:
+`⟨w×u, w×u⟩ = 1 − cos²b = sin²b`. -/
+theorem sinb_sq (u w : V) (hw : dot w w = 1) (hu : dot u u = 1) :
+    dot (cross w u) (cross w u) = 1 - dot w u ^ 2 := by
+  rw [lagrange_identity w u, hw, hu]; ring
+
+/-- Side `a` sine-square as a Lagrange self-inner-product:
+`⟨v×w, v×w⟩ = 1 − cos²a = sin²a`. -/
+theorem sina_sq (v w : V) (hv : dot v v = 1) (hw : dot w w = 1) :
+    dot (cross v w) (cross v w) = 1 - dot v w ^ 2 := by
+  rw [lagrange_identity v w, hv, hw]; ring
+
+/-- **Dual spherical law of cosines, pure cross-product form.**
+
+For a spherical triangle given by unit vectors `u, v, w`, the cleared dual law
+holds with *every* angle-cosine numerator and side-sine square replaced by its
+cross-product realisation:
+
+  `⟨w×u, w×v⟩ · ⟨u×v, u×v⟩ = −⟨u×v, u×w⟩ · ⟨v×w, v×u⟩ + [u v w]² · ⟨u, v⟩`.
+
+Reading off the geometric meaning (`⟨w×u,w×v⟩ = sin a sin b cos C`,
+`⟨u×v,u×v⟩ = sin²c`, `[u v w]² = sin²A sin²b sin²c`, etc.) and dividing by the
+positive product of side sines recovers `cos C = −cos A cos B + sin A sin B cos c`.
+Proved by rewriting the four cross-product quantities to their side-cosine normal
+forms (`cosA_num`/`cosB_num`/`cosC_num`/`sinc_sq`) and invoking
+`dual_spherical_law_cleared`. -/
+theorem dual_law_cross_product_form
+    (u v w : V) (hu : dot u u = 1) (hv : dot v v = 1) (hw : dot w w = 1) :
+    dot (cross w u) (cross w v) * dot (cross u v) (cross u v)
+      = -(dot (cross u v) (cross u w)) * dot (cross v w) (cross v u)
+        + (triple u v w) ^ 2 * dot u v := by
+  rw [cosC_num u v w hw, sinc_sq u v hu hv, cosA_num u v w hu, cosB_num u v w hv]
+  exact dual_spherical_law_cleared u v w hu hv hw
 
 end SphericalLawOfCosinesOQ03

--- a/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
@@ -164,3 +164,43 @@ untouched — no collision (different file / different theorems).
 
 **Next:** when this merges, PR #24344 can be closed as superseded; build
 `Proofs.SphericalLawOfCosinesOQ03` to confirm typecheck.
+
+## Session 2026-06-15 (researcher-5) — geometric grounding: pure cross-product dual law
+
+**Mode:** ACT, post-SOLVED outward enrichment (the literal OQ deliverable
+`dual_law_trig` is already on main, 0 axioms / 0 sorries, line 229). Dual blackout
+persists (`docker info` times out; Aristotle 404 in recent sessions). Build-pending.
+
+**What was added (Part VI of `SphericalLawOfCosinesOQ03.lean`):** the file proved the
+dual law in *cleared abstract* and *cleared geometric* forms, but the angle normal
+forms (`cos A = (ca−cb·cc)/(sb·sc)`, etc.) were only *posited* — `dual_law_trig` takes
+them as hypotheses. Part VI grounds them in actual geometry, all `ring`/`rw`-only:
+
+- `cosA_num`/`cosB_num`/`cosC_num`: each angle-cosine **numerator** IS a Binet–Cauchy
+  inner product of the two edge normals at that vertex. E.g. at vertex `u`,
+  `⟨u×v, u×w⟩ = ⟨u,u⟩⟨v,w⟩ − ⟨u,w⟩⟨v,u⟩ = ca − cb·cc` (the unnormalised cos A).
+  Proof: `have h := binet_cauchy u v u w; rw [h, hu, dot_comm u w, dot_comm v u]; ring`.
+- `sina_sq`/`sinb_sq`/`sinc_sq`: each side-sine **square** IS a Lagrange
+  self-inner-product, `⟨u×v, u×v⟩ = 1 − cc² = sin²c`.
+  Proof: `rw [lagrange_identity u v, hu, hv]; ring`.
+- `dual_law_cross_product_form`: the capstone — the dual law with EVERY numerator and
+  side-sine² replaced by its cross-product realisation:
+  `⟨w×u,w×v⟩·⟨u×v,u×v⟩ = −⟨u×v,u×w⟩·⟨v×w,v×u⟩ + [u v w]²·⟨u,v⟩`.
+  Proof = rewrite the four cross-product terms via cosC_num/sinc_sq/cosA_num/cosB_num
+  to reduce to `dual_spherical_law_cleared`, then `exact`. The whole identity now lives
+  in the exterior algebra of the three vertex vectors — no bare side cosines.
+
+**Verification:** `verify_geometric_form.py` (3·10⁵ random unit-vector triangles): all
+seven geometric identities (3 numerators, 3 side-sine², 1 triple²=Gram) max err ~1e-15.
+Every `rw` chain hand-traced against the exact `dual_spherical_law_cleared` statement
+(numerator/denominator orderings match verbatim — see proof comments). No `field_simp`,
+no division, no radicals: blackout-safe.
+
+**Reusable Lean note:** `binet_cauchy a b c d` gives the dihedral-angle numerator at a
+shared vertex directly; pick `a=c=vertex`. The vertex-angle→edge-normal-inner-product
+identity is the clean way to connect a spherical angle to cross products without ever
+introducing `arccos`/division/`‖·‖`.
+
+**Next:** Docker-up typecheck of Part VI; optional bridge to parent
+`SphericalTriangle.angleC` (would introduce `arccos`/division — defer per
+`feedback-avoid-field-simp-under-no-build`).

--- a/research/problems/spherical-law-of-cosines-oq-03/state.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/state.md
@@ -1,24 +1,32 @@
 # Research State: spherical-law-of-cosines-oq-03
 
 ## Current State
-**Phase**: NEW
+**Phase**: ACT (post-SOLVED, outward enrichment)
 **Path**: full
-**Since**: 2026-06-15T06:15:07.078468+00:00
-**Iteration**: 1
+**Since**: 2026-06-15T06:15:07Z
+**Iteration**: 4
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context from the parent gallery proof (spherical-law-of-cosines).
+The literal OQ deliverable `dual_law_trig` (`cos C = −cos A·cos B + sin A·sin B·cos c`)
+is DONE and on main (0 axioms, 0 sorries). This session adds the outward structural
+bridge: geometric grounding of the posited normal forms via cross products.
 
 ## Active Approach
-None yet.
+Identify each angle-cosine numerator with a Binet–Cauchy inner product of edge
+normals and each side-sine square with a Lagrange self-inner-product, then re-derive
+the cleared dual law in pure cross-product form. All `ring`/`rw`-only.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: cleared form, literal trig form, cross-product form
 
 ## Blockers
-None.
+Docker daemon down (`docker info` timeout) → no local typecheck. Aristotle prove 404
+in recent sessions. New lemmas are build-pending but numerically validated (3·10⁵
+random triangles, max err ~1e-15) and hand-traced.
 
 ## Next Action
-Begin OBSERVE phase: study the parent proof and identify the key lemmas needed.
+When Docker returns: build `Proofs.SphericalLawOfCosinesOQ03` to confirm typecheck of
+Part VI. Optional future step: bridge to the parent's `Vec3`/`SphericalTriangle.angleC`
+so the angle quantities are derived from `arccos`, not posited.

--- a/research/problems/spherical-law-of-cosines-oq-03/verify_geometric_form.py
+++ b/research/problems/spherical-law-of-cosines-oq-03/verify_geometric_form.py
@@ -1,0 +1,30 @@
+import numpy as np
+rng = np.random.default_rng(0)
+maxerr = {}
+def upd(k,e):
+    maxerr[k]=max(maxerr.get(k,0.0),abs(e))
+N=300000
+for _ in range(N):
+    # random unit vectors
+    u=rng.normal(size=3); u/=np.linalg.norm(u)
+    v=rng.normal(size=3); v/=np.linalg.norm(v)
+    w=rng.normal(size=3); w/=np.linalg.norm(w)
+    ca=np.dot(v,w); cb=np.dot(w,u); cc=np.dot(u,v)
+    # Binet-Cauchy numerators (vertex angles A@u, B@v, C@w)
+    # cosA numerator = ca - cb*cc  == <u x v, u x w>
+    upd('A_num', np.dot(np.cross(u,v),np.cross(u,w)) - (ca - cb*cc))
+    # cosB numerator = cb - ca*cc  == <v x w, v x u>
+    upd('B_num', np.dot(np.cross(v,w),np.cross(v,u)) - (cb - ca*cc))
+    # cosC numerator = cc - ca*cb  == <w x u, w x v>
+    upd('C_num', np.dot(np.cross(w,u),np.cross(w,v)) - (cc - ca*cb))
+    # side sine-norms: ||u x v||^2 = 1-cc^2 (=sin^2 c)
+    upd('sc2', np.dot(np.cross(u,v),np.cross(u,v)) - (1-cc**2))
+    upd('sb2', np.dot(np.cross(w,u),np.cross(w,u)) - (1-cb**2))
+    upd('sa2', np.dot(np.cross(v,w),np.cross(v,w)) - (1-ca**2))
+    # triple^2 = Gram = tp2
+    tp = np.dot(u,np.cross(v,w))
+    tp2 = 1 - ca**2 - cb**2 - cc**2 + 2*ca*cb*cc
+    upd('tp2', tp**2 - tp2)
+for k,e in maxerr.items():
+    print(f"{k}: max|err| = {e:.2e}")
+print("OK" if all(e<1e-10 for e in maxerr.values()) else "FAIL")


### PR DESCRIPTION
## Summary

The literal OQ-03 deliverable `dual_law_trig` (`cos C = −cos A·cos B + sin A·sin B·cos c`) is **already on main** (0 axioms, 0 sorries). This PR adds the outward structural bridge that was the file's documented remaining step: grounding the *posited* angle normal forms in actual geometry.

New `Part VI` of `SphericalLawOfCosinesOQ03.lean`:

- **`cosA_num` / `cosB_num` / `cosC_num`** — each angle-cosine numerator IS a Binet–Cauchy inner product of the two edge normals at that vertex, e.g. `⟨u×v, u×w⟩ = cos a − cos b·cos c` (the unnormalised `cos A`).
- **`sina_sq` / `sinb_sq` / `sinc_sq`** — each side-sine square IS a Lagrange self-inner-product, `⟨u×v, u×v⟩ = 1 − cos²c = sin²c`.
- **`dual_law_cross_product_form`** — the capstone: the dual law with every numerator and side-sine² replaced by its cross-product realisation,
  `⟨w×u,w×v⟩·⟨u×v,u×v⟩ = −⟨u×v,u×w⟩·⟨v×w,v×u⟩ + [u v w]²·⟨u,v⟩`,
  so the entire identity lives in the exterior algebra of the vertex vectors — no bare side cosines. Proof reduces it to the existing `dual_spherical_law_cleared`.

All proofs are `ring`/`rw`-only: no `field_simp`, no division, no radicals.

## Verification

- `verify_geometric_form.py`: 3·10⁵ random unit-vector triangles, all seven geometric identities (3 numerators, 3 side-sine², triple²=Gram) max err ~1e-15.
- Every `rw` chain hand-traced against the exact `dual_spherical_law_cleared` statement (numerator/denominator orderings match verbatim).

## Build status

**Build-pending.** Docker daemon down this session (`docker info` times out), so no local typecheck. Consistent with the file's existing provenance note; additions are pure `ring`/`rw` algebra.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.SphericalLawOfCosinesOQ03` once Docker returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)