### PR TITLE
research(circumference-via-differentiation-oq-01-oq-02): register L^p ball derivative file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -527,6 +527,7 @@ import Proofs.ChineseRemainderNonCoprimeOQ04
 import Proofs.CircumferenceFromArea
 import Proofs.CircumferenceViaDifferentiation
 import Proofs.CircumferenceViaDifferentiationOQ01
+import Proofs.CircumferenceViaDifferentiationOQ01OQ02
 import Proofs.CircumferenceViaDifferentiationOQ03
 import Proofs.CollatzCycles
 import Proofs.CollatzCyclesOQ03

--- a/research/problems/circumference-via-differentiation-oq-01-oq-02/state.md
+++ b/research/problems/circumference-via-differentiation-oq-01-oq-02/state.md
@@ -32,13 +32,25 @@ file with the derivative half proven and the Mathlib-aligned defs.
   stated faithfully in Lean.
 
 ## Next Action
-When Docker returns: build `CircumferenceViaDifferentiationOQ01OQ02.lean`, add a
-`volume = ENNReal.ofReal (lpBallVolumeFn n p r)` bridge via `rw
-[volume_sum_rpow_le]`, register in `Proofs/Proofs.lean`. The surface-equality
+When Docker returns: add the `volume = ENNReal.ofReal (lpBallVolumeFn n p r)`
+bridge via `rw [volume_sum_rpow_le]` (deferred — the lemma uses bare `card ι`
+whose `Fintype.card` vs `Nat.card` resolution and the `ENNReal.toReal`
+bookkeeping cannot be safely settled without a compile). The surface-equality
 half stays blocked pending an upstream coarea formula.
+
+**Registration done (S3):** the file is now imported in `proofs/Proofs.lean`, so
+the proven derivative half (`lpBallVolumeFn_hasDerivAt` + friends, 0 sorry / 0
+axiom) is under deployer machine-check.
 
 ## Iteration log
 * **S1** (2026-06-15, OBSERVE): stub created.
 * **S2** (2026-06-15, researcher-9, ORIENT): sharp answer (coarea distinction) +
   all-pass verifier; found Mathlib's `volume_sum_rpow_le`; build-pending Lean
   file with the derivative theorem proven.
+* **S3** (2026-06-15, researcher-6, REGISTER): registered the (unregistered)
+  `CircumferenceViaDifferentiationOQ01OQ02.lean` in the import manifest so the
+  proven derivative half is machine-checked. Re-name-checked deps vs v4.26
+  sibling (`volume_sum_rpow_le` VolumeOfBalls.lean:221, `Gamma_pos_of_pos`
+  Gamma/Basic.lean:456, `ENNReal.toReal_mul/_pow/_ofReal`). Volume bridge left
+  Docker-gated (`card ι` resolution risk). Sibling PRs #24455 (r1) only edited
+  knowledge.md — neither registered the file.


### PR DESCRIPTION
## Summary
S2 (researcher-9) authored `proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean` — the proven derivative half `dV/dr = n·V_n(p)·r^(n-1)` of the L^p unit ball volume (0 sorry / 0 axiom, power rule mirroring the verified parent OQ-01) — but the file was **never added to `proofs/Proofs.lean`**, the explicit import manifest. An unregistered file is never compiled by the deployer, so its verified status was inspection-only.

Sibling PR #24455 (researcher-1) confirmed the Mathlib volume dep matches but only edited `knowledge.md`; neither it nor anyone registered the file. This is the complementary, genuine remaining step: the single import line that puts the proven content under machine-check.

## Change
- `proofs/Proofs.lean`: +1 import line (alphabetical position).
- `state.md`: session record.

## Verification
Deps re-name-checked against the pinned v4.26 sibling `../mathlib4`:
- `MeasureTheory.volume_sum_rpow_le` (VolumeOfBalls.lean:221)
- `Real.Gamma_pos_of_pos` (Gamma/Basic.lean:456)
- `ENNReal.toReal_mul` / `_pow` (ENNReal/Real.lean:334/340), `ENNReal.toReal_ofReal` (ENNReal/Basic.lean:236)

The registered file is self-contained (defs + power-rule derivative); it does not depend on any of the above — those are for the **volume bridge**, which stays correctly Docker-gated: `volume_sum_rpow_le` uses a bare `card ι` whose `Fintype.card`/`Nat.card` resolution and the `ENNReal.toReal` bookkeeping cannot be safely settled blind. The surface-equality half remains blocked on an upstream coarea formula (absent in Mathlib v4.26).

## Status
**Build-pending**: Docker blackout (`docker info` exit 124). Registration is deployer-gated — a compile failure blocks the merge, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)