### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02): register Besicovitch reduction file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2827,6 +2827,7 @@ import Proofs.Sqrt2PlusSqrt3Irrational
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03Aristotle
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
+import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula

--- a/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-02/state.md
@@ -45,4 +45,17 @@ When Docker is available:
    (risk: `ι` `let`-unfold in the `hcoe := rfl` step; `Function.comp_apply`/`Nat.cast_prod`).
 2. Attack the heart `sqrt_prime_not_mem_multiquadratic` via the strengthened
    coprime-squarefree induction `H(m)` (squares-of-K_m characterization).
-3. Once heart + degree theorem compile, fold into the gallery / register the file.
+3. Once heart + degree theorem compile, fold into the gallery.
+
+## S3 (2026-06-15, researcher-6, REGISTER)
+Registered the (previously unregistered) `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean`
+in `proofs/Proofs.lean` so the deployer build now machine-checks the two
+discharged endpoints + the Besicovitch reduction
+(`besicovitch_sqrt_linearIndependent`). Confirmed the one hard external
+dependency is sound: the cited `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.irrational_sqrt2_plus_sqrt3_plus_sqrt5`
+exists at OQ01.lean:116 (registered, Proofs.lean:2829). The two `sorry`s (heart +
+degree theorem) compile as warnings, not errors, so they do not block the build.
+**Residual build risk** (deployer-gated, blocks merge not main): the reduction's
+`hcoe := rfl` subtype-coercion step and the `simp only [Function.comp_apply]; rw`
+chain (lines 133–135) were authored blind and not elaborator-checked — if the
+build fails, fix is local to those lines.


### PR DESCRIPTION
## Summary
`proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02.lean` (researcher-2, the Besicovitch generalization: square roots of distinct squarefree integers are ℚ-linearly independent) was **never added to `proofs/Proofs.lean`**, so the deployer never compiled it. This registers it.

Putting it under machine-check verifies the discharged content:
- `irrational_sqrt_prime`, `irrational_sqrt2_add_sqrt3_add_sqrt5` (endpoints)
- `besicovitch_sqrt_linearIndependent` — a genuine **derivation** (no sorry of its own) of the squarefree main statement from the degree theorem, via the `d ↦ primeFactors d` injection (`LinearIndependent.comp` + `Nat.prod_primeFactors_of_squarefree`).

The two open `sorry`s (the induction heart `sqrt_prime_not_mem_multiquadratic`, ~250–450 LOC, and the degree theorem) compile as **warnings, not errors**, so they do not block the build. The slug stays `formalized` (not verified); meta.json is intentionally untouched pending a successful build.

## Verification
- Hard external dep confirmed sound: the cited `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.irrational_sqrt2_plus_sqrt3_plus_sqrt5` exists (OQ01.lean:116, a registered 0-sorry file at Proofs.lean:2829).
- Mathlib lemmas in the reduction were name-checked against the pinned v4.26 sibling (per state.md): `LinearIndependent.comp` (Defs.lean:206), `Nat.prod_primeFactors_of_squarefree` (Squarefree.lean:366), `Nat.prime_of_mem_primeFactors`, `Finset.subset_biUnion_of_mem`, `Nat.cast_prod`.

## Residual risk (deployer-gated — blocks merge, not `main`)
The reduction's `hcoe := rfl` subtype-coercion step and the `simp only [Function.comp_apply]; rw` chain (lines 133–135) were authored under the blackout and not elaborator-checked. If the build fails, the fix is local to those lines.

## Status
**Build-pending**: Docker blackout (`docker info` exit 124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)