### PR TITLE
research(sum-of-kth-powers-oq-03): S6 — complete Lean draft (division-free Nicomachus via odd partition)

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/SumOfKthPowersOQ03.lean
+++ b/research/problems/sum-of-kth-powers-oq-03/SumOfKthPowersOQ03.lean
@@ -1,0 +1,144 @@
+/-
+# Sum of k-th Powers — OQ-03: Nicomachus via the odd-number partition of cubes
+
+Second, structurally independent proof of Nicomachus's theorem
+
+  ∑_{i=0}^{n} i³ = (∑_{i=0}^{n} i)²
+
+The parent `SumOfKthPowers.lean` proves this **algebraically** (`sum_cubes_eq_sum_squared`,
+composing the closed forms `sum_cubes_classical` and `sum_first_powers_classical`). This file
+gives the classical **combinatorial** proof via the odd-number tiling, sharing no lemma with the
+parent beyond the Gauss sum.
+
+## The combinatorial idea
+
+Let `T n = ∑_{i<n} i` be the running Gauss sum (so `T 0 = 0`, `T (i+1) = T i + i`). The cube `i³`
+is the sum of the `i` consecutive odd numbers occupying *positions* `T i, T i + 1, …, T (i+1) − 1`
+in the sequence of all odds `1, 3, 5, …`:
+
+  ∑_{T i ≤ j < T (i+1)} (2j+1) = i³.
+
+The position blocks `[T i, T (i+1))` for `i = 0..n` tile `[0, T (n+1))` exactly, and the sum of
+the first `m` odds is `m²`, so
+
+  ∑_{i ≤ n} i³ = ∑_{j < T (n+1)} (2j+1) = (T (n+1))² = (∑_{i ≤ n} i)².
+
+## Why `T` is a *sum*, not the closed form
+
+Defining `T n` as the Gauss sum (rather than the closed form `n(n+1)/2`) sidesteps **all**
+ℕ-division and ℕ-subtraction. The whole proof uses only `ring` (valid on the ℕ semiring),
+`Finset.sum_range_succ`, `Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`, and one
+`Nat.add_left_cancel`. The triangular recurrence appears in the division-/subtraction-free form
+`2·T i + i = i²` (`two_T_add`), proved by a one-line induction.
+
+## Contents
+
+* `T`, `T_zero`, `T_succ`, `T_le_succ` — the Gauss-sum position function and its recurrence
+* `sum_odds`     — L1: `∑_{j<m} (2j+1) = m²`
+* `two_T_add`    — `2·T i + i = i²` (division-free triangular recurrence)
+* `block_sq`     — `T i² + i³ = T (i+1)²` (each block contributes a cube)
+* `block_eq_cube`— L2: `∑_{T i ≤ j < T (i+1)} (2j+1) = i³`
+* `tiling`       — L3: blocks tile the first `T n` odds
+* `sum_cubes_eq_sum_squared_via_odds` — Nicomachus, matching the parent's RHS shape
+
+Axioms: 0. Sorries: 0.
+
+NOTE (build provenance): authored during a Docker + Aristotle backend outage, so NOT yet
+machine-checked. Every arithmetic identity is independently certified (sympy + brute force,
+n = 0..60) by `research/problems/sum-of-kth-powers-oq-03/verify_m1.py`. The load-bearing Mathlib
+lemmas (`Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`) were pin-confirmed at the lake rev
+`v4.26.0`. This is a ready-to-move draft (kept in the research dir, not under `Proofs/`, to avoid
+degrading the shared safe-subset build before a typecheck); move to `proofs/Proofs/` and build via
+`./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` once backends return.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace SumOfKthPowersOQ03
+
+/-- Partial Gauss sum `T n = 0 + 1 + … + (n−1)`: the running count of odd-number positions
+consumed by the cubes `0³, 1³, …, (n−1)³`. Defined as a sum (no division). -/
+def T (n : ℕ) : ℕ := ∑ i ∈ range n, i
+
+@[simp] theorem T_zero : T 0 = 0 := rfl
+
+/-- Triangular recurrence: `T (n+1) = T n + n`. -/
+theorem T_succ (n : ℕ) : T (n + 1) = T n + n := by
+  simp [T, Finset.sum_range_succ]
+
+/-- `T` is monotone in one step (the position blocks are non-overlapping). -/
+theorem T_le_succ (n : ℕ) : T n ≤ T (n + 1) := by
+  rw [T_succ]; exact Nat.le_add_right _ _
+
+/-- **L1 — sum of the first `m` odd numbers is `m²`.** -/
+theorem sum_odds (m : ℕ) : ∑ j ∈ range m, (2 * j + 1) = m ^ 2 := by
+  induction m with
+  | zero => simp
+  | succ k ih => rw [Finset.sum_range_succ, ih]; ring
+
+/-- The Gauss-sum form of the triangular recurrence: `2·T i + i = i²`
+(division-free, subtraction-free). -/
+theorem two_T_add (i : ℕ) : 2 * T i + i = i ^ 2 := by
+  induction i with
+  | zero => simp
+  | succ k ih =>
+    rw [T_succ]
+    have h : 2 * (T k + k) + (k + 1) = (2 * T k + k) + (2 * k + 1) := by ring
+    rw [h, ih]; ring
+
+/-- **Block-square identity:** `T i² + i³ = T (i+1)²`. The odd block at positions
+`[T i, T (i+1))` contributes exactly `i³`. Proved from `two_T_add`, all over the ℕ semiring. -/
+theorem block_sq (i : ℕ) : T i ^ 2 + i ^ 3 = T (i + 1) ^ 2 := by
+  rw [T_succ]
+  have h := two_T_add i
+  calc T i ^ 2 + i ^ 3
+      = T i ^ 2 + i ^ 2 * i := by ring
+    _ = T i ^ 2 + (2 * T i + i) * i := by rw [← h]
+    _ = (T i + i) ^ 2 := by ring
+
+/-- **L2 — the `i`-th odd block sums to `i³`:** `∑_{T i ≤ j < T (i+1)} (2j+1) = i³`. -/
+theorem block_eq_cube (i : ℕ) :
+    ∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1) = i ^ 3 := by
+  have hsplit :
+      (∑ j ∈ range (T i), (2 * j + 1))
+          + (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1))
+        = ∑ j ∈ range (T (i + 1)), (2 * j + 1) := by
+    rw [Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ i)
+  rw [sum_odds, sum_odds] at hsplit
+  -- hsplit : T i ^ 2 + block = T (i+1) ^ 2
+  have hb := block_sq i  -- T i ^ 2 + i ^ 3 = T (i+1) ^ 2
+  have hcancel :
+      T i ^ 2 + (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1)) = T i ^ 2 + i ^ 3 := by
+    rw [hsplit, hb]
+  exact Nat.add_left_cancel hcancel
+
+/-- **L3 — the blocks tile the first `T n` odds:**
+`∑_{i<n} (block i) = ∑_{j < T n} (2j+1)`. -/
+theorem tiling (n : ℕ) :
+    ∑ i ∈ range n, (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1))
+      = ∑ j ∈ range (T n), (2 * j + 1) := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.sum_range_succ, ih, Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ k)
+
+/-- **Nicomachus's theorem via the odd-number partition.**
+
+`∑_{i ≤ n} i³ = (∑_{i ≤ n} i)²`, matching the parent's `sum_cubes_eq_sum_squared` exactly, but
+proved by the odd-block tiling (L1 + L2 + L3) instead of closed-form polynomials. The final `rfl`
+holds because `T (n+1)` is *definitionally* `∑ i ∈ range (n+1), i`. -/
+theorem sum_cubes_eq_sum_squared_via_odds (n : ℕ) :
+    ∑ i ∈ range (n + 1), i ^ 3 = (∑ i ∈ range (n + 1), i) ^ 2 := by
+  have key : ∑ i ∈ range (n + 1), i ^ 3
+      = ∑ i ∈ range (n + 1), (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1)) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [block_eq_cube]
+  rw [key, tiling (n + 1), sum_odds]
+  rfl
+
+end SumOfKthPowersOQ03

--- a/research/problems/sum-of-kth-powers-oq-03/knowledge.md
+++ b/research/problems/sum-of-kth-powers-oq-03/knowledge.md
@@ -202,3 +202,50 @@ their exact argument order recorded (the one thing the prose spec omitted and th
 otherwise have to discover at build time). No spec change; the ACT plan stands. Still Docker-gated:
 no `.lean` written (an unbuildable file under `Proofs/` would break the shared build), exactly as
 S1–S4 deferred. Decision: **ORIENT** — pin-confirmation only, zero churn to spec.
+
+## Session 2026-06-15 (S6, researcher-5) — complete Lean transcription (division-free reformulation)
+
+Dual blackout still LIVE (`docker info` timeout; Aristotle `prove` → "Resource not found",
+re-probed this session). No build/typecheck possible. After 5 ORIENT sessions the spec was fully
+pinned; this session produced the **complete paste-ready Lean file** — but with a cleaner
+formulation that removes the spec's sole documented hazard.
+
+**Key simplification — `T` as a Gauss SUM, not the closed form.** The prior spec used
+`T k := k*(k+1)/2`, whose `/2` forced the "division-clearing" step (multiply by 4, prove evenness
+via `Nat.even_mul_succ_self`, etc.) flagged as "the one genuinely build-fiddly step". Defining
+instead
+
+  `def T (n : ℕ) : ℕ := ∑ i ∈ Finset.range n, i`
+
+makes `T 0 = 0` (`rfl`), `T (n+1) = T n + n` (`Finset.sum_range_succ`), and the triangular
+recurrence becomes the **division-free, subtraction-free** identity `2 * T i + i = i^2`
+(`two_T_add`, one-line induction). The block-square identity `T i^2 + i^3 = T (i+1)^2` (`block_sq`)
+then follows by a 3-step `calc` using only `ring` (valid on the ℕ *semiring* — no
+`linear_combination`, which needs a ring) plus `rw [← two_T_add i]`. **No ℕ-division and no
+ℕ-subtraction appear anywhere in the file.** This is a strict improvement over the M1/M1′ specs
+and should be the formulation that gets built.
+
+**File:** `research/problems/sum-of-kth-powers-oq-03/SumOfKthPowersOQ03.lean` (kept in the research
+dir, NOT under `Proofs/`, to avoid degrading the shared safe-subset build before a typecheck —
+`build-safe-subset.sh` globs `Proofs/*.lean`). 0 axioms, 0 sorries (build-pending). Lemma chain:
+`sum_odds` (L1) → `two_T_add` → `block_sq` → `block_eq_cube` (L2, via `Finset.sum_Ico_consecutive`
++ `range_eq_Ico` + `Nat.add_left_cancel`) → `tiling` (L3, induction) →
+`sum_cubes_eq_sum_squared_via_odds` (Main, closes by `rfl` since `T (n+1)` is *definitionally*
+`∑ i ∈ range (n+1), i`, matching the parent's RHS shape `(∑ i ∈ range (n+1), i)^2`).
+
+**Verification:** new durable script `verify_div_free.py` certifies every identity exactly as the
+Lean file evaluates them in ℕ (n = 0..199, exits non-zero on mismatch): L1, T_succ, two_T_add,
+block_sq, block_eq_cube, tiling, Main, and `T (n+1)^2 = RHS`. All pass.
+
+**Transcription risk notes for the Docker-up session:**
+- `Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ i)` — `f` explicit (pass `_`),
+  `m n k` implicit (inferred from goal), two `≤` hyps explicit positional (S5 pin).
+- `rw [Finset.range_eq_Ico]` (point-free `range = Ico 0`) rewrites ALL `range` occurrences in one
+  shot — use a SINGLE `rw`, not two (a second errors "no occurrence").
+- `block_eq_cube`'s `sum_congr` goal is `i^3 = block i`, closed by `rw [block_eq_cube]` (rewrites
+  the block RHS to `i^3`).
+- If Main's final `rfl` is finicky on the `T (n+1)` defeq, fall back to `simp only [T]` or
+  `show (∑ i ∈ range (n+1), i)^2 = _; rfl`.
+
+**Next:** Docker-up session — `cp` the draft to `proofs/Proofs/SumOfKthPowersOQ03.lean`, build,
+register in `Proofs.lean`, add gallery entry `src/data/proofs/sum-of-kth-powers-oq-03/`.

--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -1,10 +1,20 @@
 # Research State: sum-of-kth-powers-oq-03
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT (transcription complete, build-pending)
 **Path**: full
-**Since**: 2026-06-14T20:00:16-07:00
-**Iteration**: 5
+**Since**: 2026-06-15T13:54:00Z
+**Iteration**: 6
+
+## S6 (researcher-5) — complete Lean draft, division-free reformulation
+Wrote the full paste-ready Lean file `SumOfKthPowersOQ03.lean` (in the research dir, not yet under
+`Proofs/`, to protect the shared build under the persistent dual blackout). Replaced the spec's
+`T k = k*(k+1)/2` (which forced the "division-clearing" hazard) with `T n := ∑ i ∈ range n, i` (the
+Gauss SUM): now `0` axioms / `0` sorries with NO ℕ-division and NO ℕ-subtraction anywhere — the
+triangular recurrence is `2*T i + i = i^2` (`two_T_add`) and `block_sq` closes by `ring` on the ℕ
+semiring. New `verify_div_free.py` certifies every identity (n=0..199). Next Docker-up session just
+`cp`s the draft into `proofs/Proofs/`, builds, registers, and adds the gallery entry. See
+knowledge.md "S6".
 
 ## Current Focus
 OQ resolved on paper (odd-number partition of cubes). Formalizable core pinned to existing

--- a/research/problems/sum-of-kth-powers-oq-03/verify_div_free.py
+++ b/research/problems/sum-of-kth-powers-oq-03/verify_div_free.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Certify the DIVISION-FREE / SUBTRACTION-FREE Lean formulation of OQ-03
+(SumOfKthPowersOQ03.lean), where T n := sum_{i<n} i is the Gauss SUM (not the
+closed form n(n+1)/2). Exits non-zero on any mismatch.
+
+This complements verify_m1.py (which certifies the older T=k(k+1)/2 spec).
+Each assertion mirrors exactly one Lean lemma in the draft file."""
+import sys
+
+def T(n):        return sum(range(n))                      # def T
+def sum_odds(m): return sum(2 * j + 1 for j in range(m))   # L1 sum_odds
+def block(i):    return sum(2 * j + 1 for j in range(T(i), T(i + 1)))
+
+N = 200
+fail = 0
+for n in range(N):
+    if sum_odds(n) != n ** 2:                fail += 1; print("L1 fail", n)
+    if T(n + 1) != T(n) + n:                 fail += 1; print("T_succ fail", n)
+    if 2 * T(n) + n != n ** 2:               fail += 1; print("two_T_add fail", n)
+    if T(n) ** 2 + n ** 3 != T(n + 1) ** 2:  fail += 1; print("block_sq fail", n)
+    if block(n) != n ** 3:                   fail += 1; print("block_eq_cube fail", n)
+for n in range(N):
+    if sum(block(i) for i in range(n)) != sum_odds(T(n)):
+        fail += 1; print("tiling fail", n)
+    lhs = sum(i ** 3 for i in range(n + 1))
+    rhs = sum(i for i in range(n + 1)) ** 2
+    if lhs != rhs:           fail += 1; print("main fail", n)
+    if T(n + 1) ** 2 != rhs: fail += 1; print("T-def-RHS fail", n)
+
+if fail:
+    print(f"FAILED: {fail} mismatches"); sys.exit(1)
+print(f"OK: all division-free identities verified for n=0..{N-1}")


### PR DESCRIPTION
## Summary

Second, **structurally independent** proof of Nicomachus's theorem `∑_{i≤n} i³ = (∑_{i≤n} i)²` — via the classical odd-number tiling (each `i³` is a block of `i` consecutive odds; the blocks tile the first `T(n+1)` odds, whose sum is `T(n+1)²`). The parent `SumOfKthPowers.lean` proves the same identity algebraically from closed forms; this shares no lemma beyond the Gauss sum.

After 5 ORIENT sessions fully pinned the spec, this PR writes the **complete paste-ready Lean file** — with a reformulation that removes the spec's one documented hazard.

## Key simplification: `T` as a Gauss *sum*, not the closed form

The prior spec used `T k := k*(k+1)/2`, whose `/2` forced a "division-clearing" step (multiply by 4, prove `k(k+1)` even, etc.). Defining instead

```lean
def T (n : ℕ) : ℕ := ∑ i ∈ Finset.range n, i
```

makes `T 0 = 0` (`rfl`), `T (n+1) = T n + n` (`sum_range_succ`), and the triangular recurrence the **division-free, subtraction-free** identity `2 * T i + i = i^2` (`two_T_add`). `block_sq : T i² + i³ = T (i+1)²` then closes by a 3-step `calc` using only `ring` (valid on the ℕ semiring) + `rw [← two_T_add i]`. **No ℕ-division and no ℕ-subtraction anywhere in the file.**

Lemma chain: `sum_odds` (L1) → `two_T_add` → `block_sq` → `block_eq_cube` (L2) → `tiling` (L3) → `sum_cubes_eq_sum_squared_via_odds` (Main, matches the parent's exact RHS shape, closes by `rfl` on the `T (n+1)` defeq). 0 axioms, 0 sorries.

## Build status & file placement

**Build-pending — NOT machine-checked.** Dual backend blackout this session (Docker `docker info` times out; Aristotle `prove` → "Resource not found", re-probed). The file is deliberately kept in the **research dir** (`research/problems/sum-of-kth-powers-oq-03/SumOfKthPowersOQ03.lean`), *not* under `Proofs/`, because `build-safe-subset.sh` globs `Proofs/*.lean` and an unverified file there would degrade the shared build for all agents — matching the deferral of the 5 prior sessions.

Every identity is independently certified by the new `verify_div_free.py` (exact ℕ evaluation, n=0..199, exits non-zero on mismatch). Load-bearing Mathlib lemmas pin-confirmed at `v4.26.0` in earlier sessions.

## Test plan

- [ ] Docker-up session: `cp` draft to `proofs/Proofs/SumOfKthPowersOQ03.lean`, then `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`
- [ ] Register in `proofs/Proofs.lean`; add gallery entry `src/data/proofs/sum-of-kth-powers-oq-03/`
- [ ] Cross-check against parent `sum_cubes_eq_sum_squared` (same theorem, different proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)