### PR TITLE
research(erdos-357-oq-04): prove conjecture_equiv (little-o ⟺ ratio→0)

### DIFF
--- a/proofs/Proofs/Erdos357Problem.lean
+++ b/proofs/Proofs/Erdos357Problem.lean
@@ -21,6 +21,7 @@ then A has lower density 0 (proved) and density 0 (conjectured), and Σ 1/aₙ c
 import Mathlib.Algebra.BigOperators.Group.Finset
 import Mathlib.Order.Filter.Basic
 import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib.Analysis.Asymptotics.Lemmas
 import Mathlib.Tactic
 
 open Filter Asymptotics Real
@@ -80,6 +81,31 @@ Since g(n) = Θ(n) (Hegyvári 1986), the strict monotonicity constraint is essen
 -/
 def Erdos357Conjecture : Prop :=
   (fun n ↦ (f n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ))
+
+/--
+**Alternative formulation**: f(n)/n → 0 as n → ∞.
+
+The ratio formulation is often more convenient to work with than the little-o
+form, e.g. when transferring density statements.
+-/
+def Erdos357ConjectureAlt : Prop :=
+  Tendsto (fun n ↦ (f n : ℝ) / n) atTop (𝓝 0)
+
+/--
+The little-o formulation and the ratio-limit formulation of the main conjecture
+are equivalent.
+
+This is `Asymptotics.isLittleO_iff_tendsto'`: for `f =o[l] g`, the side condition
+`g x = 0 → f x = 0` only needs to hold eventually, and along `atTop` the
+denominator `n` is eventually nonzero, so the implication is vacuous there.
+-/
+theorem conjecture_equiv : Erdos357Conjecture ↔ Erdos357ConjectureAlt := by
+  unfold Erdos357Conjecture Erdos357ConjectureAlt
+  have hgf : ∀ᶠ n : ℕ in atTop, (n : ℝ) = 0 → (f n : ℝ) = 0 := by
+    filter_upwards [eventually_gt_atTop 0] with n hn h0
+    rw [Nat.cast_eq_zero] at h0
+    omega
+  exact isLittleO_iff_tendsto' hgf
 
 /- ## Known Results (Axiomatized) -/
 


### PR DESCRIPTION
## Summary
Resolves the OQ-04 task for Erdős #357: *Prove `conjecture_equiv` (isLittleO iff Tendsto) via Mathlib asymptotic API*.

The registered file `proofs/Proofs/Erdos357Problem.lean` previously stated only the little-o formulation of the main conjecture (`Erdos357Conjecture : (fun n ↦ (f n:ℝ)) =o[atTop] (fun n ↦ (n:ℝ))`). This PR adds the equivalent ratio-limit formulation and a **fully machine-checkable** proof that the two coincide.

- Add `Erdos357ConjectureAlt : Tendsto (fun n ↦ (f n:ℝ)/n) atTop (𝓝 0)`.
- Add `theorem conjecture_equiv : Erdos357Conjecture ↔ Erdos357ConjectureAlt`, proven via `Asymptotics.isLittleO_iff_tendsto'`. The eventual side condition `(n:ℝ)=0 → (f n:ℝ)=0` is discharged as vacuous on `atTop` (`n` is eventually positive).
- Add `import Mathlib.Analysis.Asymptotics.Lemmas` (home of `isLittleO_iff_tendsto'`).

No axioms or sorries introduced; the registered file remains 0-sorry, 3-axiom. The new theorem is fully proven.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos357Problem` (build-pending — Docker unavailable in this session)

Status: **build-pending** (Docker blackout — `docker ps` exit 124). Proof statically name-checked against the pinned Mathlib v4.26 sibling: `isLittleO_iff_tendsto'`, `eventually_gt_atTop`, `Nat.cast_eq_zero` all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)