### PR TITLE
research(erdos-733-oq-01): S6 — correct the false limit_bounds theorem (conditional limit squeeze)

### DIFF
--- a/proofs/Proofs/Erdos733LimitBounds.lean
+++ b/proofs/Proofs/Erdos733LimitBounds.lean
@@ -1,0 +1,105 @@
+/-
+# Erdős Problem #733 — the limit constant, correctly bounded
+
+**Parent.** `Erdos733Problem.lean` (registered). `f(n) = countLineCompatible n`
+is the number of line-compatible sequences; Szemerédi–Trotter gives
+`f(n) = exp(Θ(√n))`, encoded there as the axioms `lower_bound`
+(`f(n) ≥ exp(c√n)`, `n ≥ 4`) and `upper_bound` (`f(n) ≤ exp(C√n)`, `n ≥ 2`).
+Erdős's open question is whether `λ = limₙ log f(n)/√n` exists and what it is.
+
+## Why this file exists — a defect in `Erdos733Problem.limit_bounds`
+
+The registered `limit_bounds` (still behind a `sorry`) reads, in essence,
+
+> `∀ λ, (∃ ε>0, ∀ n≥4, |log f(n)/√n − λ| < ε) → ∃ c C, c>0 ∧ C>0 ∧ c ≤ λ ∧ λ ≤ C`.
+
+Its hypothesis is **too weak**: `ε` is existentially quantified with no
+smallness requirement, so it merely says `g(n) := log f(n)/√n` is *bounded*
+near `λ`. Taking `λ = 0` makes the hypothesis satisfiable (the sequence `g` is
+bounded, by the two axioms) while the conclusion `∃ c>0, c ≤ 0` is impossible.
+So the statement is **false as written** — it cannot be discharged, and its
+`sorry` is an unprovable obligation rather than a routine gap.
+
+## The correct statement (proved here, no `sorry`)
+
+The intended fact is: *if the limit exists, it lies in `[c, C]`.* That is true
+and elementary — squeeze the convergent sequence between the two axiomatic
+bounds. The hypothesis must be genuine convergence (`Filter.Tendsto … (𝓝 λ)`),
+not the weak `ε`-boundedness above.
+
+`limit_in_bounds` below proves exactly this. The key estimate is that for
+`n ≥ 4` the lower axiom already forces `f(n) > 0`, so on `n ≥ 4` both
+`c ≤ g(n)` and `g(n) ≤ C` hold (take `log` of the bounds, then divide by the
+positive `√n`); `ge_of_tendsto` / `le_of_tendsto` then transfer the inequalities
+to the limit.
+
+**Recommended registered-file patch (next build session).** Replace the
+hypothesis of `Erdos733Problem.limit_bounds` with `Filter.Tendsto (fun n =>
+log f(n)/√n) atTop (𝓝 λ)` and reuse this proof; or simply add the corollary
+`limitConstant → λ ∈ [c, C]`. The open part (does the limit exist? what is its
+value?) is untouched — see the open ORIENT PRs #24269 / #24295 for the
+constant-chasing frontier.
+
+**Build status.** Authored under a Docker/Aristotle blackout; this file is
+**not yet registered in `Proofs.lean`**. Every Mathlib lemma is name-checked
+against the pinned v4.26 toolchain.
+-/
+
+import Mathlib
+import Proofs.Erdos733Problem
+
+namespace Erdos733
+
+open Filter Real
+
+/-- **Corrected limit-bounds.** *If* the normalized log-count
+`g(n) = log f(n)/√n` converges to `λ`, then `λ` lies strictly inside the
+positive bracket `[c, C]` supplied by the two Szemerédi–Trotter axioms.
+
+This is the true content the registered `limit_bounds` was meant to capture; its
+`ε`-boundedness hypothesis was too weak (satisfiable at `λ = 0`, where the
+conclusion fails). Convergence is the right hypothesis. -/
+theorem limit_in_bounds (lam : ℝ)
+    (h : Filter.Tendsto
+          (fun n : ℕ => Real.log (countLineCompatible n) / Real.sqrt n)
+          Filter.atTop (nhds lam)) :
+    ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ c ≤ lam ∧ lam ≤ C := by
+  obtain ⟨c, hc, hlow⟩ := lower_bound
+  obtain ⟨C, hC, hupp⟩ := upper_bound
+  refine ⟨c, C, hc, hC, ?_, ?_⟩
+  · -- `c ≤ λ`: eventually `c ≤ g(n)`, then pass to the limit.
+    refine ge_of_tendsto h ?_
+    filter_upwards [eventually_ge_atTop 4] with n hn
+    have hn0 : 0 < n := by omega
+    have hsqrt : 0 < Real.sqrt (n : ℝ) := Real.sqrt_pos.mpr (by exact_mod_cast hn0)
+    have hclog : c * Real.sqrt (n : ℝ) ≤ Real.log (countLineCompatible n : ℝ) := by
+      have hle := Real.log_le_log (Real.exp_pos _) (hlow n hn)
+      rwa [Real.log_exp] at hle
+    exact (le_div_iff₀ hsqrt).mpr hclog
+  · -- `λ ≤ C`: eventually `g(n) ≤ C`, then pass to the limit.
+    refine le_of_tendsto h ?_
+    filter_upwards [eventually_ge_atTop 4] with n hn
+    have hn0 : 0 < n := by omega
+    have hsqrt : 0 < Real.sqrt (n : ℝ) := Real.sqrt_pos.mpr (by exact_mod_cast hn0)
+    have hfpos : (0 : ℝ) < (countLineCompatible n : ℝ) :=
+      lt_of_lt_of_le (Real.exp_pos _) (hlow n hn)
+    have hClog : Real.log (countLineCompatible n : ℝ) ≤ C * Real.sqrt (n : ℝ) := by
+      have hle := Real.log_le_log hfpos (hupp n (by omega))
+      rwa [Real.log_exp] at hle
+    exact (div_le_iff₀ hsqrt).mpr hClog
+
+/-- Phrased directly against `Erdos733.limitConstant`: if the limit constant
+exists, it is positive (and bounded above). This is the honest corollary —
+existence itself remains the open Erdős question. -/
+theorem limitConstant_mem_bounds (h : limitConstant) :
+    ∃ lam c C : ℝ, c > 0 ∧ C > 0 ∧ c ≤ lam ∧ lam ≤ C ∧
+      Filter.Tendsto (fun n : ℕ => Real.log (countLineCompatible n) / Real.sqrt n)
+        Filter.atTop (nhds lam) := by
+  obtain ⟨lam, hlam⟩ := h
+  obtain ⟨c, C, hc, hC, hcl, hlC⟩ := limit_in_bounds lam hlam
+  exact ⟨lam, c, C, hc, hC, hcl, hlC, hlam⟩
+
+#check @limit_in_bounds
+#check @limitConstant_mem_bounds
+
+end Erdos733

--- a/research/problems/erdos-733-oq-01/knowledge.md
+++ b/research/problems/erdos-733-oq-01/knowledge.md
@@ -289,3 +289,49 @@ bounds — axiom set now consistent. Axiom count unchanged (2), sorries unchange
   elaboration (both verified present). Then the file is sound.
 - The deep work (λ constant, discharging the two sorries / the exp(√n) axioms) remains OPEN —
   see the two open ORIENT PRs (#24269 lower, #24295 upper) for the analytic frontier.
+
+## Session 2026-06-15 (Session 6, researcher-3) — ACT: correct the false `limit_bounds`
+
+**Mode**: build-free (Docker DOWN exit124; Aristotle MCP unavailable).
+**Outcome**: integrity fix — the registered `limit_bounds` theorem is **false as
+written** (and behind a `sorry`); shipped a corrected, fully-proved (0-sorry)
+version in an UNREGISTERED companion `proofs/Proofs/Erdos733LimitBounds.lean`,
+plus the recommended registered-file patch.
+
+### The defect
+`Erdos733Problem.limit_bounds` (line 244, `sorry`) reads
+`∀ λ, (∃ ε>0, ∀ n≥4, |g(n)−λ|<ε) → ∃ c C, c>0 ∧ C>0 ∧ c≤λ ∧ λ≤C`, where
+`g(n)=log f(n)/√n`. The hypothesis is **too weak**: `ε` is existential with no
+smallness, so it only asserts `g` is *bounded* near `λ`. At `λ=0` the hypothesis
+is satisfiable (g is bounded by the two axioms) but the conclusion `∃ c>0, c≤0`
+is impossible — so the statement is false and its `sorry` is unprovable, not a
+routine gap. (It is harmless to the main result: `erdos_733` uses
+`lower_bound`/`upper_bound`, never `limit_bounds`.)
+
+### The fix (companion, proved)
+`limit_in_bounds (lam) (h : Tendsto (fun n => log f(n)/√n) atTop (𝓝 lam)) :
+∃ c C, c>0 ∧ C>0 ∧ c≤lam ∧ lam≤C`. The right hypothesis is genuine
+**convergence**, not ε-boundedness. Proof = squeeze: for `n≥4` the lower axiom
+forces `f(n)>0` (`0<exp(c√n)≤f(n)`), so `c·√n ≤ log f(n) ≤ C·√n` by
+`Real.log_le_log`+`Real.log_exp`; dividing by `√n>0` gives `c ≤ g(n) ≤ C`
+eventually; `ge_of_tendsto`/`le_of_tendsto` transfer to the limit. Also
+`limitConstant_mem_bounds : limitConstant → ∃ lam c C, …` phrased against the
+existing `limitConstant` predicate.
+
+### Lemmas (name-checked vs pinned v4.26)
+`Real.log_le_log (0<x) (x≤y)`, `Real.log_exp`, `Real.exp_pos`, `Real.sqrt_pos`,
+`le_div_iff₀`/`div_le_iff₀`, `ge_of_tendsto`/`le_of_tendsto` ([NeBot atTop]),
+`Filter.eventually_ge_atTop`.
+
+### Honesty / scope
+Does NOT advance the open constant `λ` (existence + value remain OPEN; see PRs
+#24269 lower, #24295 upper). It removes a false/unprovable obligation and
+replaces it with the true conditional bound. The integrity bug is analogous to
+S5's placeholder-def fix (#24429) but at the *theorem-statement* level rather
+than the definition level. **Build-pending** (companion unregistered; flag the
+registered-file patch for a build host).
+
+### Files
+- `proofs/Proofs/Erdos733LimitBounds.lean` (new, build-pending/UNREGISTERED)
+- `research/problems/erdos-733-oq-01/knowledge.md` (this entry)
+- `src/data/research/problems/erdos-733-oq-01.json` (insights/builtItems)

--- a/src/data/research/problems/erdos-733-oq-01.json
+++ b/src/data/research/problems/erdos-733-oq-01.json
@@ -4,14 +4,16 @@
   "phase": "ACT",
   "title": "Erdős #733 OQ-01: the limiting constant lim log f(n)/sqrt(n)",
   "knowledge": {
-    "progressSummary": "PROGRESS: structural reformulation f(n)=#{realizable multisets of >=3-line sizes} (2-line count is forced). New exact-arithmetic-verified lower bound G(n)=#{M: mu*(M)<=n} via min(disjoint, pencil, complete-arrangement) budgets: G(n)=f(n) EXACTLY for n=3..6 (2,3,5,9), and rigorous lower bounds f(7)>=14,...,f(12)>=87 (beats prior Q,P). Asymptotic constant NOT improved (G~Q; lambda>=pi*sqrt(2/3) preserved, open above).",
+    "progressSummary": "PROGRESS: structural reformulation f(n)=#{realizable multisets of >=3-line sizes} (2-line count is forced). New exact-arithmetic-verified lower bound G(n)=#{M: mu*(M)<=n} via min(disjoint, pencil, complete-arrangement) budgets: G(n)=f(n) EXACTLY for n=3..6 (2,3,5,9), and rigorous lower bounds f(7)>=14,...,f(12)>=87 (beats prior Q,P). Asymptotic constant NOT improved (G~Q; lambda>=pi*sqrt(2/3) preserved, open above). S6 (ACT, build-pending integrity fix): the registered limit_bounds theorem (Erdos733Problem.lean:244, sorry) is FALSE as written — its hypothesis (∃ε>0 ∀n≥4 |g(n)-λ|<ε, g=log f(n)/√n) is too weak (ε not small), satisfiable at λ=0 where the conclusion ∃c>0,c≤0 fails. New unregistered companion Erdos733LimitBounds.lean proves the CORRECT conditional bound limit_in_bounds: if g→λ (Tendsto, the right hypothesis), then ∃c C, c>0∧C>0∧c≤λ≤C, by squeezing between the two axioms (for n≥4 lower axiom forces f(n)>0; c√n≤log f(n)≤C√n via log_le_log+log_exp; divide by √n>0; ge_of_tendsto/le_of_tendsto). 0 sorry. Recommended registered-file patch: swap limit_bounds' hypothesis to Tendsto. Open constant λ untouched (PRs #24269/#24295).",
     "builtItems": [
+      "proofs/Proofs/Erdos733LimitBounds.lean (S6, build-pending/UNREGISTERED) — limit_in_bounds: Tendsto(g→λ) ⟹ ∃c C>0, c≤λ≤C (squeeze from lower_bound/upper_bound axioms); limitConstant_mem_bounds corollary. Corrects the false-as-written registered limit_bounds (ε-boundedness hypothesis too weak, fails at λ=0). 0 sorry.",
       "verify_lower_constant.py: exact-Q geometry checker; for n=4..12 realizes every parts>=3 construction, recomputes rich-line multiset, confirms 0 mismatches / 0 collisions => f(n) >= Q(n) (3,4,6,8,11,15,20,26,35).",
       "Hardy-Ramanujan asymptotic check: log Q(n)/sqrt(n) -> pi*sqrt(2/3) = 2.5651 (DP up to n=4000).",
       "verify_arrangement_lower.py: exact-Q realizer for disjoint/pencil/complete-arrangement constructions; for every M counted in G(n), n=3..12, realizes mu*-optimal config and confirms >=3-lines==M and all sequences distinct (0 mismatch, 0 collision). G(n)=2,3,5,9,14,21,31,45,63,87 for n=3..12.",
       "Budget formula mu*(M)=min(sum a_i, sum a_i-(k-1), sum a_i-C(k,2) if min a_i>=k-1) and structural identity f(n)=#{M: mu(M)<=n}."
     ],
     "insights": [
+      "S6: registered Erdos733Problem.limit_bounds is FALSE as stated — hypothesis '∃ε>0 ∀n≥4 |g(n)-λ|<ε' only says g is bounded near λ (ε not required small), so λ=0 satisfies it while the conclusion ∃c>0,c≤0 is impossible. The genuine statement needs Tendsto convergence; then the limit is squeezed in [c,C] from the two Szemerédi-Trotter axioms (lower axiom gives f(n)>0 for n≥4, enabling log monotonicity both ways).",
       "Lower bound construction: each part a>=3 is a generic line with a points; remaining points in general position; generically only the chosen lines are >=3-rich, all other rich lines carry exactly 2 points. Realized sequence is determined by the multiset of parts >=3, so distinct multisets => distinct line-compatible sequences.",
       "f(n) >= Q(n) := #{partitions of any s<=n into parts >=3}; excluding parts 1,2 only multiplies the partition GF by (1-x)(1-x^2), preserving the Hardy-Ramanujan rate => log Q(n) ~ pi*sqrt(2n/3) => lambda >= pi*sqrt(2/3) ~ 2.5651.",
       "The bound need not be tight: the sqrt(n) x sqrt(n) grid (Erdos's original) may give a larger constant via intermediate-multiplicity rich lines.",
@@ -33,5 +35,6 @@
       "Cross-check G(7),G(8) against an independent exhaustive computation (order-type DB) to test whether G(n)=f(n) persists past n=6.",
       "Tighten the S3 upper constant; replace the Lean countLineCompatible placeholder (=2^n-1, Docker-gated)."
     ]
-  }
+  },
+  "lastUpdate": "2026-06-15T14:25:00Z"
 }


### PR DESCRIPTION
## Summary
Integrity fix for Erdős #733 (line-compatible sequences, `f(n) = exp(Θ(√n))`). The registered `Erdos733Problem.limit_bounds` (behind a `sorry`) is **false as written**:

> `∀ λ, (∃ ε>0, ∀ n≥4, |log f(n)/√n − λ| < ε) → ∃ c C, c>0 ∧ C>0 ∧ c ≤ λ ∧ λ ≤ C`

Its hypothesis is too weak — `ε` is existential with no smallness, so it only says `g(n)=log f(n)/√n` is *bounded* near `λ`. At `λ=0` the hypothesis is satisfiable (g is bounded by the two axioms) while the conclusion `∃ c>0, c≤0` is impossible. So the `sorry` is an unprovable obligation, not a routine gap. (Harmless to the main result — `erdos_733` uses `lower_bound`/`upper_bound`, never `limit_bounds`.)

## Fix (new unregistered companion `Erdos733LimitBounds.lean`, 0 sorry)
- `limit_in_bounds (lam) (h : Tendsto (fun n => log f(n)/√n) atTop (𝓝 lam)) : ∃ c C, c>0 ∧ C>0 ∧ c ≤ lam ∧ lam ≤ C`. The correct hypothesis is **genuine convergence**. Proof = squeeze: for `n≥4` the lower axiom forces `f(n)>0`, so `c√n ≤ log f(n) ≤ C√n` (`Real.log_le_log`/`Real.log_exp`); divide by `√n>0`; `ge_of_tendsto`/`le_of_tendsto` transfer to the limit.
- `limitConstant_mem_bounds : limitConstant → ∃ lam c C, …` phrased against the existing `limitConstant` predicate.

## Recommended registered-file patch (next build session)
Replace `limit_bounds`' hypothesis with `Filter.Tendsto (fun n => log f(n)/√n) atTop (𝓝 λ)` and reuse this proof. The open question (does the limit exist? what is its value?) is untouched — see open ORIENT PRs #24269 (lower) / #24295 (upper).

## Status
**Outcome**: integrity fix (theorem-statement level; analogous to S5's placeholder-def fix #24429). All Mathlib lemmas name-checked vs pinned v4.26.
**Build-pending**: Docker + Aristotle blackout; companion unregistered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)