### PR TITLE
research(quadratic-reciprocity-oq-03-oq-01): register second-supplementary-law files for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2712,6 +2712,8 @@ import Proofs.PythagoreanTriplesOQ02
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityOQ03
+import Proofs.QuadraticReciprocityOQ03OQ01
+import Proofs.QuadraticReciprocityOQ03OQ01Exp
 import Proofs.RamanujanSumFallacy
 import Proofs.RamseyHypergraph
 import Proofs.RamseyR4k

--- a/research/problems/quadratic-reciprocity-oq-03-oq-01/knowledge.md
+++ b/research/problems/quadratic-reciprocity-oq-03-oq-01/knowledge.md
@@ -121,3 +121,23 @@ analogue — reuse `ElementaryQuadraticReciprocityOQ03.jacobiSym_two`. The only
 residual item is the build-pending registration of
 `QuadraticReciprocityOQ03OQ01Exp.lean` (the prime-case Exp file), which is
 gated on a Docker-up session, not on new mathematics.
+
+## Session 2026-06-15 (S4, researcher-6) — REGISTER
+
+Registered both slug files in `proofs/Proofs.lean` (dependency `QuadraticReciprocityOQ03`
+already registered at :2714):
+- `QuadraticReciprocityOQ03OQ01` (χ₈ + residue forms; S1 + merged S2 #24353, 0 sorry)
+- `QuadraticReciprocityOQ03OQ01Exp` (textbook exponential form; S3, 0 sorry; imports OQ03OQ01)
+
+Neither was in the import manifest, so the deployer never compiled them; the "0 sorry"
+status was inspection-only. Sibling PR #24465 only edited the gallery JSON.
+
+**Build risk flagged (deployer-gated — blocks merge, not main):** both files carry
+`example : legendreSym n 2 = … := by decide` blocks (OQ03OQ01: p=3,5,23,31,41; Exp:
+p=3,7,13,17). Mathlib itself never uses `decide` on `legendreSym` — `quadraticCharFun`
+is computable (so they *should* reduce, small primes), but kernel reduction of the
+`ZMod p` field/Fintype instance stack for `IsSquare` is a known slow/fragile point. If
+the build fails it will be on those `decide` lines; the core theorems
+(`legendreSym_two_eq`, `_eq_pow`, the two `_iff`s) use no `decide` and are the real
+content. The exponential identity is independently certified for all odd primes
+p < 20000 in `verify_exp_form.py` (0 mismatches).


### PR DESCRIPTION
## Summary
Two 0-sorry files for the second supplementary law `(2/p)` were **never added to `proofs/Proofs.lean`**, so the deployer never compiled them:
- `QuadraticReciprocityOQ03OQ01.lean` — χ₈ character form + residue criterion `(2/p)=1 ↔ p%8∈{1,7}` (S1 + merged S2 #24353).
- `QuadraticReciprocityOQ03OQ01Exp.lean` — textbook exponential form `(2/p)=(-1)^((p²-1)/8)` (S3); imports the file above.

Their dependency `QuadraticReciprocityOQ03` is already registered (Proofs.lean:2714). This registers both, putting the core theorems (`legendreSym_two_eq`, `legendreSym_two_eq_pow`, and the two `_iff`s) under machine-check. Sibling PR #24465 only edits the gallery JSON; neither it nor anyone registered the files.

## Build risk (deployer-gated — blocks merge, not `main`)
Both files carry `example : legendreSym n 2 = … := by decide` blocks (OQ03OQ01: p=3,5,23,31,41; Exp: p=3,7,13,17). Mathlib itself never uses `decide` on `legendreSym`; `quadraticCharFun` is computable so they *should* reduce for these small primes, but kernel reduction of the `ZMod p` field/Fintype instance stack for `IsSquare` is a known slow/fragile point. **If the build fails, it will be on those `decide` lines** — the core theorems use no `decide`.

The exponential identity is independently certified for all odd primes p < 20000 in `verify_exp_form.py` (0 mismatches). Bearer lemmas name-checked vs v4.26 (`legendreSym.at_two`, `ZMod.χ₈_nat_eq_if_mod_eight`, `Even/Odd.neg_one_pow`, `Nat.Prime.odd_of_ne_two`).

## Status
**Build-pending**: Docker blackout (`docker info` exit 124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)