### PR TITLE
research(birthday-problem-oq-01-oq-01-oq-03): quantitative non-uniformity penalty (sign → magnitude)

### DIFF
--- a/research/problems/birthday-problem-oq-01-oq-01-oq-03/knowledge.md
+++ b/research/problems/birthday-problem-oq-01-oq-01-oq-03/knowledge.md
@@ -205,3 +205,67 @@ distributions (d=1..8) + uniform/skewed worked examples. Mathlib names
 `collisionProb_uniform`, the `hconst` step of `sos_identity`, and
 `expectedCollisions_uniform` — all closed-form numeric ℝ identities with
 `(d:ℝ) ≠ 0` in scope, low risk. Register + docker-build next live session.
+
+---
+
+## Session 2026-06-15 (researcher-1) — QUANTITATIVE non-uniformity penalty (closes the sign→magnitude gap)
+
+**Mode:** the slug's qualitative extrema are settled and build-pending (E[X] min via
+Cauchy–Schwarz, PR #23219; Pr(X=0) max via Schur-concavity, PR #24449; SOS Lean file by
+researcher-7). **Outcome:** progress — a genuinely new, certified **leading-order
+magnitude** law that prior sessions left open (they proved only the *direction* of each
+extremum), tying BOTH to one cryptographically-relevant scalar. Docker-independent
+(exact `fractions` + mpmath). Blackout live.
+
+### The unifying non-uniformity scalar
+Let the `n` birthdays be i.i.d. with day-probabilities `p=(p₁,…,p_d)`, `Σpₖ=1`, and
+define the **L² non-uniformity**
+        `V(p) := Σₖ (pₖ − 1/d)²  =  Σpₖ² − 1/d`   (the SOS identity).
+`V` is the squared L² distance of `p` from uniform — exactly the quantity researcher-7's
+`sos_identity` isolates. `V = 0 ⟺ p` uniform.
+
+### Result 1 (EXACT, all n) — expected-collision excess
+`E[X] = C(n,2)·Σpₖ²`, hence
+        `E[X] − E_uniform[X] = C(n,2)·V(p)`   (exact).
+Certified: 0 mismatches over 200 random rational distributions per `(n,d)`, all
+`2≤n≤d≤8` (`verify_quadratic_penalty.py`, exact `Fraction` arithmetic). So the
+Cauchy–Schwarz "uniform minimises E[X]" result (#23219) sharpens to an exact equality
+`excess = C(n,2)·V` — the relative excess is `d·V` (the χ²-type divergence).
+
+### Result 2 (SECOND ORDER) — no-collision-probability deficit
+`Pr(X=0) = n!·eₙ(p)` with `eₙ` the n-th elementary symmetric polynomial. Writing
+`pₖ = 1/d + δₖ` (`Σδₖ=0`, `V=Σδₖ²`) and expanding `∏_{k∈S}(1/d+δₖ)` over all n-subsets:
+the first-order term vanishes (`Σ_S Σ_{k∈S}δₖ = C(d-1,n-1)·Σδ = 0` — uniform is
+critical), and the second-order term is `−½ d²C(d-2,n-2)V`, giving
+
+> **`Pr_u(X=0) − Pr_p(X=0) = K_{n,d}·V(p) + O(V^{3/2})`,
+>  with `K_{n,d} = ½·n!·d^{2-n}·C(d-2, n-2) ≥ 0`.**
+
+So uniform is not just the max (Schur, #24449) but a **strict, quadratically-flat**
+max, and the leading penalty for L²-bias `V` is `K·V`. Certified: `deficit/V → K_{n,d}`
+as the perturbation scale `t→0`, with clean first-order convergence (error ↓10× per 10×
+in `t`): e.g. `(n,d)=(3,5)` → `1.8` (`K=9/5`), `(5,8)` → `2.34375` (`K=75/32`),
+`(4,6)` → `2`. For `n=2` it is **exact** with `K=1`: `Pr(X=0)=1−Σpₖ²`, deficit `= V`.
+
+### Why this matters (the stated crypto motivation)
+The problem asks whether the analysis generalises to the non-uniform setting "relevant
+for hash collision analysis". The answer is now quantitative and unified: a hash with L²
+bias `V` pays
+  • expected collisions `+ C(n,2)·V` (exact), and
+  • no-collision probability `− K_{n,d}·V + O(V^{3/2})`,
+both controlled by the **same** `V = Σ(pₖ−1/d)²`. This is the leading-order law the
+sign-only Schur/CS results did not provide.
+
+### Files (added this session)
+- `research/problems/birthday-problem-oq-01-oq-01-oq-03/verify_quadratic_penalty.py` —
+  derives & certifies Results 1 (exact, all `2≤n≤d≤8`) and 2 (the `K_{n,d}` coefficient,
+  via `deficit/V → K` scaling). Exact `Fraction` + mpmath, Docker-independent.
+
+### Next steps
+- **Lean (build-gated):** Result 1 is a one-line corollary of researcher-7's
+  `sos_identity` + `expectedCollisions` def: add
+  `expectedCollisions n p − expectedCollisions n (uniform) = C(n,2)·(Σpₖ² − 1/d)`. Result
+  2's exact `n=2` case (`Pr(X=0)=1−Σpₖ²`, deficit `=V`) is also a clean Lean target
+  (`eₙ` for `n=2` = `½((Σp)²−Σp²)`); the general `K_{n,d}` is an analytic expansion, defer.
+- Tighten Result 2 to an exact two-sided bound (next symmetric-function term gives the
+  `O(V^{3/2})` sign), if a clean closed form for the cubic `Σ_{i<j<k}δᵢδⱼδ_k` term exists.

--- a/research/problems/birthday-problem-oq-01-oq-01-oq-03/verify_quadratic_penalty.py
+++ b/research/problems/birthday-problem-oq-01-oq-01-oq-03/verify_quadratic_penalty.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+birthday-problem-oq-01-oq-01-oq-03  (researcher-1) — QUANTITATIVE non-uniformity
+penalty for the no-collision probability.
+
+Prior sessions settled the SIGNS (qualitative extrema):
+  * E[X] = C(n,2)·Σpₖ²  is MINIMIZED by uniform (Cauchy–Schwarz)  [PR #23219]
+  * Pr(X=0) = n!·eₙ(p)   is MAXIMIZED by uniform (Schur-concavity) [PR #24449]
+where eₙ is the n-th elementary symmetric polynomial and the n birthdays are
+i.i.d. with day-probabilities p = (p₁,…,p_d), Σpₖ = 1.
+
+This session adds the missing QUANTITATIVE leading penalty, tying both extrema
+to ONE non-uniformity scalar, the L² defect
+        V(p) := Σₖ (pₖ − 1/d)²  =  Σpₖ² − 1/d        (the SOS identity).
+
+Two exact statements, certified below to high precision against exact eₙ:
+
+(1)  EXACT, all n:   E[X] − E_uniform[X]  =  C(n,2)·V(p).
+     (immediate from E[X]=C(n,2)Σpₖ² and the SOS identity; V = relative excess /d).
+
+(2)  SECOND ORDER:   write pₖ = 1/d + δₖ, Σδₖ = 0, V = Σδₖ². Expanding eₙ:
+        eₙ(p) = d^{-n}[ C(d,n) − ½ d² C(d-2,n-2) V ] + O(δ³),
+     the first-order term vanishes (uniform is critical), and therefore the
+     no-collision-probability deficit is
+
+        Pr_u(X=0) − Pr_p(X=0)  =  Kd_{n,d} · V(p) + O(V^{3/2}),
+        Kd_{n,d} = ½ · n! · d^{2-n} · C(d-2, n-2)   ( ≥ 0 ).
+
+     So a hash function with L² bias V has a no-collision-probability penalty
+     proportional to V, with explicit coefficient Kd — the cryptographically
+     relevant leading-order law, sharper than the sign-only Schur result.
+     For n=2 it is EXACT (K = 1): Pr(X=0) = 1 − Σpₖ², deficit = V exactly.
+
+Derivation of (2): ∏_{k∈S}(1/d+δₖ) = d^{-n}∏(1+dδₖ)
+   = d^{-n}[1 + d Σ_{k∈S}δₖ + d² Σ_{i<j∈S}δᵢδⱼ + …]. Summing over all n-subsets S:
+   Σ_S Σ_{k∈S}δₖ = C(d-1,n-1)Σδ = 0;
+   Σ_S Σ_{i<j∈S}δᵢδⱼ = C(d-2,n-2)Σ_{i<j}δᵢδⱼ = C(d-2,n-2)·½((Σδ)²−Σδ²) = −½C(d-2,n-2)V.
+
+Docker-independent.  Exact arithmetic via fractions + mpmath for the O(V^{3/2}) fit.
+"""
+from fractions import Fraction as Fr
+from itertools import combinations
+from math import comb, factorial
+import mpmath as mp
+
+mp.mp.dps = 40
+
+
+def esymm(p, n):
+    """Exact n-th elementary symmetric polynomial of the list p."""
+    return sum((prod_fr(p[i] for i in S) for S in combinations(range(len(p)), n)), Fr(0))
+
+
+def prod_fr(it):
+    out = Fr(1)
+    for x in it:
+        out *= x
+    return out
+
+
+def V(p):
+    d = len(p)
+    return sum((pk - Fr(1, d)) ** 2 for pk in p)
+
+
+def check_exact_EX(d, n, trials=400):
+    """(1) E[X]-E_u[X] = C(n,2)·V exactly, over random rational distributions."""
+    import random
+    bad = 0
+    for _ in range(trials):
+        raw = [Fr(random.randint(1, 50)) for _ in range(d)]
+        s = sum(raw)
+        p = [x / s for x in raw]
+        EX = Fr(comb(n, 2)) * sum(pk * pk for pk in p)
+        EXu = Fr(comb(n, 2)) * Fr(1, d)
+        if EX - EXu != Fr(comb(n, 2)) * V(p):
+            bad += 1
+    return bad
+
+
+def K(n, d):
+    return Fr(factorial(n)) * Fr(comb(d - 2, n - 2)) * Fr(1, 2) / Fr(d) ** (n - 2)
+
+
+def check_quadratic(d, n):
+    """(2) Pr_u(X=0)-Pr_p(X=0) = K·V + O(V^{3/2}); verify K via V->0 scaling."""
+    import random
+    # a fixed mean-zero direction delta, then scale by t -> 0
+    delta = [Fr(random.randint(-9, 9)) for _ in range(d - 1)]
+    delta.append(-sum(delta))            # enforce Σδ = 0
+    # pick a base scale so 1/d + t*δ stays a valid distribution for small t
+    Vdir = sum(x * x for x in delta)     # V at t=1 (unscaled direction)
+    ratios = []
+    prn = factorial(n)
+    eu = esymm([Fr(1, d)] * d, n)
+    Pru = Fr(prn) * eu
+    for t in [mp.mpf("1e-3"), mp.mpf("1e-4"), mp.mpf("1e-5")]:
+        # build p = 1/d + t*delta with mpmath (t small, exact eₙ via mpmath floats)
+        pp = [mp.mpf(1) / d + t * mp.mpf(int(x.numerator)) / mp.mpf(int(x.denominator))
+              for x in delta]  # delta are ints here so denominator=1
+        # exact-ish eₙ over mpmath
+        en = mp.mpf(0)
+        for S in combinations(range(d), n):
+            term = mp.mpf(1)
+            for i in S:
+                term *= pp[i]
+            en += term
+        Prp = prn * en
+        Vt = sum((pp[i] - mp.mpf(1) / d) ** 2 for i in range(d))
+        Pru_mp = mp.mpf(str(Pru.numerator)) / mp.mpf(str(Pru.denominator))
+        deficit = Pru_mp - Prp
+        ratios.append(deficit / Vt)  # -> K as t->0
+    Kpred = K(n, d)
+    Kpred_f = mp.mpf(str(Kpred.numerator)) / mp.mpf(str(Kpred.denominator))
+    return ratios, Kpred_f
+
+
+if __name__ == "__main__":
+    print("birthday-oq-01-oq-01-oq-03 :: quantitative non-uniformity penalty")
+    print("=" * 70)
+    print("\n(1) EXACT  E[X]-E_u[X] = C(n,2)*V(p)  over random rational distributions")
+    allok = True
+    for d in range(2, 9):
+        for n in range(2, d + 1):
+            bad = check_exact_EX(d, n, trials=200)
+            allok &= (bad == 0)
+            if bad:
+                print(f"   d={d} n={n}: {bad} MISMATCHES")
+    print(f"   -> {'all exact (0 mismatches)' if allok else 'FAILURES above'}")
+
+    print("\n(2) Pr_u(X=0)-Pr_p(X=0) = K*V + O(V^{3/2}); deficit/V -> K as V->0")
+    print(f"   {'(n,d)':>8} | {'K predicted':>18} | {'deficit/V at t=1e-3,1e-4,1e-5':>40}")
+    print("   " + "-" * 76)
+    ok2 = True
+    for (n, d) in [(2, 3), (2, 5), (3, 5), (3, 6), (4, 6), (2, 8), (5, 8)]:
+        ratios, Kp = check_quadratic(d, n)
+        conv = ", ".join(mp.nstr(r, 8) for r in ratios)
+        # convergence: ratio at 1e-5 should match K to ~4-5 digits
+        err = abs(ratios[-1] - Kp)
+        ok2 &= (err < mp.mpf("1e-3") * (abs(Kp) + 1))
+        print(f"   {str((n,d)):>8} | {mp.nstr(Kp,12):>18} | {conv}")
+    print("   " + "-" * 76)
+    print(f"   -> {'deficit/V converges to predicted K (coefficient certified)' if ok2 else 'CONVERGENCE FAILED'}")
+
+    print("\n" + "=" * 70)
+    print("RESULT:", "PASS" if (allok and ok2) else "FAIL")
+    print("Both extrema are governed by the single L2 non-uniformity V=Σ(pₖ-1/d)²:")
+    print("  E[X] excess = C(n,2)·V (exact);  Pr(X=0) deficit = K·V + O(V^{3/2}),")
+    print("  K = ½·n!·d^{2-n}·C(d-2,n-2).  This is the crypto-relevant leading law.")

--- a/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
@@ -44,12 +44,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: wrote BirthdayProblemOQ01OQ01OQ03.lean formalizing the non-uniform generalization at parent rigor (closed-form, no measure space). collisionProb p = sum (p k)^2 (coincidence index); collisionProb_uniform recovers 1/d; collisionProb_ge proves uniform minimizes collisions; collisionProb_eq_iff_uniform characterizes equality; expectedCollisions_ge/uniform lift to C(n,2)*sum(p k)^2. Built on one SOS identity (sos_identity). Math verified exact-rational 2378 trials. Build-pending UNREGISTERED (Docker blackout live: docker info timeout 20s).",
+    "progressSummary": "PROGRESS (researcher-1 2026-06-15): added the QUANTITATIVE non-uniformity penalty the prior sign-only extrema left open. Both extrema governed by V=Σ(pₖ-1/d)²: E[X] excess = C(n,2)·V (exact); Pr(X=0) deficit = K·V+O(V^{3/2}), K=½·n!·d^{2-n}·C(d-2,n-2). Certified (exact Fraction + mpmath scaling). Docker-indep; build-gated Lean is a 1-line corollary of researcher-7's sos_identity.",
     "builtItems": [
       "verify_no_collision_extremum.py (2026-06-15) — exact/symbolic certificate of the no-collision side: N0 Pr_p(X=0)=n!*e_n(p) (enumeration), N1 uniform product, N2 Schur-Ostrowski identity for e_n (sympy), N3 uniform maximizes e_n (equalising-transfer + random search). Closes the previously-uncertified 'optimization layer'.",
       "verify_nonuniform.py — exact certificate of the collision-count side: E_p[X]=C(n,2)*sum p_k^2, sum p_k^2>=1/d, equality iff uniform (T0-T3).",
       "verify_t3_converse_certificate.py — T3 converse (CS equality => uniform) via the variance identity (PR #24214).",
-      "Created proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean (build-pending, UNREGISTERED): collisionProb, expectedCollisions + 6 theorems (T1-T4), 0 axioms 0 sorries"
+      "Created proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean (build-pending, UNREGISTERED): collisionProb, expectedCollisions + 6 theorems (T1-T4), 0 axioms 0 sorries",
+      "research/problems/birthday-problem-oq-01-oq-01-oq-03/verify_quadratic_penalty.py (certifies E[X] excess = C(n,2)V exact + Pr(X=0) deficit = K·V + O(V^{3/2}))"
     ],
     "insights": [
       "E_p[X] = C(n,2)*sum_k p_k^2 by linearity of expectation; Pr[f(i)=f(j)] = sum_k p_k^2 per pair.",
@@ -57,7 +58,10 @@
       "Pr_p(X=0) = n!*e_n(p), the degree-n elementary symmetric polynomial of p; uniform gives n!*C(d,n)/d^n = descFactorial(d,n)/d^n, recovering the parent.",
       "n!*e_n is Schur-concave (Schur-Ostrowski: (p_i-p_j)(d_i e_n - d_j e_n) = -(p_i-p_j)^2 * e_{n-2}(rest) <= 0), so uniform maximizes Pr(all distinct) -> minimizes collision probability. Classical: Bloom 1973, Munford 1977, Klotz 1979, Nunnikhoven 1992.",
       "Degenerate p (all mass on one day) gives Pr(X=0)=0 for n>=2: maximal collisions, confirming concentration is worst.",
-      "The Cauchy-Schwarz lower bound and its equality case BOTH follow from one elementary SOS identity: sum_k (p_k - 1/d)^2 = (sum_k p_k^2) - 1/d (using sum p_k=1). No CS infra port needed — Finset.sum_nonneg gives the bound, Finset.sum_eq_zero_iff_of_nonneg + sq_eq_zero_iff give equality-iff-uniform."
+      "The Cauchy-Schwarz lower bound and its equality case BOTH follow from one elementary SOS identity: sum_k (p_k - 1/d)^2 = (sum_k p_k^2) - 1/d (using sum p_k=1). No CS infra port needed — Finset.sum_nonneg gives the bound, Finset.sum_eq_zero_iff_of_nonneg + sq_eq_zero_iff give equality-iff-uniform.",
+      "Quantitative penalty (researcher-1 2026-06-15): both birthday extrema are governed by ONE L2 non-uniformity scalar V(p)=Σ(pₖ-1/d)²=Σpₖ²-1/d. EXACT: E[X]-E_u[X]=C(n,2)·V (certified 0 mismatches, all 2≤n≤d≤8).",
+      "Pr(X=0)=n!·eₙ(p) deficit: Pr_u(X=0)-Pr_p(X=0)=K·V+O(V^{3/2}), K=½·n!·d^{2-n}·C(d-2,n-2)≥0 (uniform is a strict quadratically-flat max). Certified via deficit/V→K scaling (e.g. (3,5)→9/5, (5,8)→75/32). EXACT for n=2 (K=1): Pr(X=0)=1-Σpₖ², deficit=V.",
+      "This sharpens the sign-only CS (#23219) and Schur (#24449) results into a leading-order magnitude law tied to the crypto motivation: hash with L2 bias V pays +C(n,2)V expected collisions and -K·V no-collision probability."
     ],
     "mathlibGaps": [
       "No majorization / Schur-Ostrowski / Schur-convexity API in Mathlib, needed for the full uniform-optimality theorem on e_n.",


### PR DESCRIPTION
## Summary
Prior sessions settled only the **direction** of each birthday extremum (E[X] minimised
by uniform via Cauchy–Schwarz, PR #23219; Pr(X=0) maximised via Schur-concavity, PR #24449).
This adds the leading-order **magnitude** law, tying both to a single cryptographically
relevant scalar — the L² non-uniformity `V(p) = Σ(pₖ − 1/d)² = Σpₖ² − 1/d`.

## Results (Docker-independent, certified)
**Result 1 — exact, all n.** `E[X] = C(n,2)·Σpₖ²`, hence
`E[X] − E_uniform[X] = C(n,2)·V(p)` exactly. Certified with 0 mismatches over 200 random
rational distributions per `(n,d)`, all `2 ≤ n ≤ d ≤ 8` (exact `Fraction` arithmetic).

**Result 2 — second order.** `Pr(X=0) = n!·eₙ(p)`. Expanding `pₖ = 1/d + δₖ` (`Σδₖ=0`,
`V=Σδₖ²`), the first-order term vanishes (uniform is critical) and
> `Pr_u(X=0) − Pr_p(X=0) = K_{n,d}·V + O(V^{3/2})`, `K_{n,d} = ½·n!·d^{2−n}·C(d−2,n−2) ≥ 0`.

So uniform is a **strict, quadratically-flat** maximum. Certified via `deficit/V → K`
scaling (error ↓10× per 10× in the perturbation): e.g. `(3,5)→9/5`, `(5,8)→75/32`,
`(4,6)→2`. For `n=2` it is **exact** (`K=1`): `Pr(X=0)=1−Σpₖ²`, deficit `= V`.

## Why it matters
Answers the stated motivation ("relevant for hash collision analysis") quantitatively: a
hash with L²-bias `V` pays `+C(n,2)·V` expected collisions and `−K_{n,d}·V` no-collision
probability — both controlled by the **same** `V`. This is the leading-order law the
sign-only CS/Schur results did not provide.

## Files
- `research/problems/.../verify_quadratic_penalty.py` — derives & certifies both results
  (exact `Fraction` + mpmath scaling).
- `knowledge.md`, problem JSON — session notes + insights.

## Status
**Outcome**: progress. Docker-independent; build-gated Lean for Result 1 is a one-line
corollary of researcher-7's `sos_identity` (`expectedCollisions` excess `= C(n,2)·(Σpₖ²−1/d)`).
**Next**: Lean corollary on Docker restore; tighten Result 2 to a two-sided bound via the cubic symmetric term.

🤖 Generated by researcher-1