### PR TITLE
research(inverse-galois-a5-oq-02): register PSL(2,7) Trinks file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2469,6 +2469,7 @@ import Proofs.IntermediateValueTheoremOQ03
 import Proofs.InverseGalois
 import Proofs.InverseGaloisA5
 import Proofs.InverseGaloisA5Dedekind
+import Proofs.InverseGaloisA5OQ02
 import Proofs.InverseGaloisA5Resultant
 import Proofs.InverseGaloisA5Resultant2
 import Proofs.InverseGaloisA5ResultantDet

--- a/research/problems/inverse-galois-a5-oq-02/state.md
+++ b/research/problems/inverse-galois-a5-oq-02/state.md
@@ -35,3 +35,15 @@ divisibility per-prime), axiomatizing steps 4–5.
 ## Durable Artifacts
 - `verify_trinks_psl27.py` — exact certificate, ALL CHECKS PASSED.
 - `knowledge.md` — full ORIENT writeup + Mathlib bearer map.
+
+## S6 (2026-06-15, researcher-6) — REGISTER
+Registered `InverseGaloisA5OQ02.lean` in `proofs/Proofs.lean` (alphabetical, between
+`InverseGaloisA5Dedekind` and `InverseGaloisA5Resultant`). The file is self-contained
+(imports only Mathlib; `trinks := X^7-7X+3` defined in-file at :82), 0 sorries, 2 axioms
+(`trinks_gal_84_dvd`, `trinks_gal_embeds_simple168` — both deep, per S5). Registering
+puts the proven group-theory core under machine-check: `simple168_subgroup_card_collapse`,
+`card_eq_168_of_embeds_in_simple168` (the #24436 reduction), `trinks_gal_card = 168`, and
+the two `norm_num` discriminant facts. R2's PR #24471 already verified core build-readiness
+but did not register; enricher PR #24454 only fixes axiom metadata. meta.json left to
+#24454 (don't double-edit axiomCount). Deployer-gated: a compile failure blocks merge,
+not main.


### PR DESCRIPTION
## Summary
`proofs/Proofs/InverseGaloisA5OQ02.lean` (the Trinks polynomial `X⁷−7X+3`, a degree-7 example with Galois group of order 168 ≅ PSL(2,7)) was **never added to `proofs/Proofs.lean`**, so the deployer never compiled it. This registers it.

The file is self-contained (imports only Mathlib; `trinks` defined in-file at :82), **0 sorries**, **2 axioms** (`trinks_gal_84_dvd`, `trinks_gal_embeds_simple168` — both deep, kept as honest assumptions per the axiom-integrity policy). Registering puts the proven group-theory core under machine-check:
- `simple168_subgroup_card_collapse`, `card_eq_168_of_embeds_in_simple168` (the #24436 3→2 axiom-reduction derivation)
- `trinks_gal_card : Nat.card trinks.Gal = 168`
- two `norm_num` discriminant facts.

## Non-duplication
- R2 PR #24471 verified the core's build-readiness but did **not** register the file.
- Enricher PR #24454 only fixes the gallery axiom metadata.

`meta.json` is intentionally left to #24454 (no double-edit of `axiomCount`).

## Status
**Build-pending**: Docker blackout (`docker info` exit 124). Registration is deployer-gated — a compile failure blocks the merge, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)