### PR TITLE
research(friendship-theorem-oq-04): register FriendshipTheoremOQ04 in build manifest

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2321,6 +2321,7 @@ import Proofs.FriendshipTheorem
 import Proofs.FriendshipTheoremOQ01
 import Proofs.FriendshipTheoremOQ02
 import Proofs.FriendshipTheoremOQ03
+import Proofs.FriendshipTheoremOQ04
 import Proofs.FrobeniusNumber
 import Proofs.FrobeniusNumberOQ01
 import Proofs.FrobeniusNumberOQ02

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -185,3 +185,29 @@ C₅-amalgam counterexample). Spectral-free, ~6 lines.
 The **negative half** — formalizing the C₅ free-amalgamation infinite counterexample
 (an explicit friendship graph with no universal vertex) — remains open; it needs an
 infinite inductive-limit construction, not build-safe-tractable under blackout.
+
+---
+
+## Session: registration (researcher-4)
+
+### Registered `FriendshipTheoremOQ04.lean` in the build manifest
+The file had landed on `main` (8 theorems, 0 sorry, 0 axiom) but was **absent from
+`proofs/Proofs.lean`** — the explicit import manifest. The three siblings
+(`FriendshipTheorem`, `…OQ01`, `…OQ02`, `…OQ03`) were all imported; OQ04 was the lone
+gap, so its "0 sorry / 0 axiom" status was inspection-only — Lean never built it.
+
+Added the single line `import Proofs.FriendshipTheoremOQ04`. Re-confirmed before
+shipping (build-free, Docker blackout still live — `docker ps` exit 124):
+- `friendship_theorem` takes `G` **explicitly** (`variable (G : SimpleGraph V)` at
+  `FriendshipTheorem.lean:112`); the in-file caller `friendship_theorem G hF h`
+  (lines 232/255) fixes the arg order, matching the capstone's
+  `friendship_theorem G (fun u v h => hF u v h) h3`.
+- All Mathlib names in the file resolve in the pinned toolchain (see audit entry above).
+
+Registration is **deployer-gated**: if the build fails, the PR is blocked and `main`
+stays clean — safe to ship under blackout. The deployer's build now machine-checks the
+positive OQ-04 result.
+
+### Still open (unchanged)
+Negative half — the C₅ free-amalgamation infinite counterexample — still needs an
+inductive-limit construction; not build-safe-tractable under blackout.

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (build-pending): wrote FriendshipTheoremOQ04.lean — diameter-2 covering + locally-finite=>finite + universal-vertex capstone, the spectral-free positive result. Unregistered until a build backend confirms (dual blackout). Counterexample direction still open.",
+    "progressSummary": "ACT (registration): added FriendshipTheoremOQ04.lean to the Proofs.lean import manifest so the spectral-free positive result (diameter-2 covering, locally-finite=>finite, infinite=>infinite-degree obstruction, universal-vertex capstone) is finally machine-checked rather than inspection-only. 8 theorems / 0 sorry / 0 axiom. Counterexample (C5 free-amalgamation) direction still open.",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
       "friendship_diameter_two (FriendshipTheoremOQ04.lean:71): every friendship graph has diameter <=2 (G.Adj v u OR common neighbor x), no Fintype.",
       "univ_subset_two_ball (:79): univ subset {v} U N(v) U bigUnion_{x in N(v)} N(x) via exists_common_neighbor.",
       "univ_finite_of_locallyFinite (:96) + locally_finite_is_finite (:109): local finiteness => Finite V via Set.Finite.biUnion of the 2-ball covering.",
-      "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices."
+      "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices.",
+      "Added import Proofs.FriendshipTheoremOQ04 to proofs/Proofs.lean (manifest registration → file now in the machine-checked build set, deployer-gated)"
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -45,7 +46,8 @@
       "RESTORING CONDITION = local finiteness: the diameter-2 covering makes V a finite union of finite sets => finite => windmill => universal vertex. Obstruction is precisely an infinite-degree vertex.",
       "WHERE finite proof breaks: spectral step friendship_regular_implies_universal (FriendshipTheorem.lean:193) is entirely finite-matrix (trace, finite eigenvalue multiplicities, integrality) with no infinite analogue. The regularity dichotomy degrades to vacuous (all infinite degrees equal as cardinals).",
       "ACT: the positive OQ-04 result is finiteness-light and spectral-free — the diameter-2 covering (purely local) plus local finiteness gives Finite V directly, bypassing the trace/eigenvalue step that has no infinite analogue.",
-      "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting."
+      "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting.",
+      "Registered FriendshipTheoremOQ04.lean in proofs/Proofs.lean (was the only Friendship sibling absent from the import manifest, so its 8 theorems / 0 sorry / 0 axiom were inspection-only, never machine-checked). Re-verified call convention: friendship_theorem takes G explicitly (variable (G : SimpleGraph V) at FriendshipTheorem.lean:112; internal caller line 232 uses friendship_theorem G hF h), so the capstone call form is sound."
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."


### PR DESCRIPTION
## Summary
- Adds `import Proofs.FriendshipTheoremOQ04` to `proofs/Proofs.lean`.
- `FriendshipTheoremOQ04.lean` (8 theorems, **0 sorry / 0 axiom**) already lives on `main` but was the **only** Friendship sibling missing from the import manifest, so its proofs were inspection-only — Lean never machine-checked them. The three siblings (`FriendshipTheorem`, `…OQ01`, `…OQ02`, `…OQ03`) are all imported.

## What the file proves (spectral-free positive OQ-04 result)
- `friendship_diameter_two` — every friendship graph (finite **or** infinite) has diameter ≤ 2.
- `locally_finite_is_finite` — a locally finite friendship graph has a finite vertex type (2-ball covering).
- `infinite_friendship_has_infinite_degree` — the sharp obstruction: every infinite friendship graph has an infinite-degree vertex.
- `locally_finite_friendship_has_universal` — recovers a universal vertex via the finite gallery theorem.

## De-risking (Docker blackout — `docker ps` exit 124, build-free verification)
- `friendship_theorem` takes `G` **explicitly** (`variable (G : SimpleGraph V)` at `FriendshipTheorem.lean:112`); the in-file caller `friendship_theorem G hF h` (line 232) fixes the arg order, matching the capstone's `friendship_theorem G (fun u v h => hF u v h) h3`.
- OQ04's `IsFriendshipGraph` def is literally identical to `FriendshipTheorem.IsFriendshipGraph`, so the coercion lambda is definitional.
- All Mathlib names resolve in the pinned toolchain.
- **Deployer-gated**: if the build fails, this PR is blocked — `main` stays clean.

## Test plan
- [ ] Deployer/CI builds `Proofs.FriendshipTheoremOQ04` successfully via the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)