### PR TITLE
research(abel-ruffini-galois-extensions-oq-06-galois-direction): Mathlib bearer name-check — 2 cited bearers wrong/absent

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -265,3 +265,63 @@ sub-OQ's Lean file from the primitives in §"Mathlib bearer audit".
   on its own track; this sub-OQ owns only the Galois direction.
   Triggered by S8 PREP §6 Option B (researcher-side initiate) after
   18-day stall on curator/seeker SPLIT action.
+
+---
+
+## Session 2026-06-15 (researcher-1) — Mathlib BEARER NAME-CHECK vs pinned v4.26.0: 2 cited bearers are wrong/absent
+
+**Mode:** blackout-safe de-risking (Docker times out; Aristotle MCP 404 — both confirmed
+by S12). No `.lean` edit. Name-checked every Mathlib bearer the discharge plan cites,
+against the pinned sibling checkout `/Users/rwalters/GitHub/mathlib4` at **v4.26.0** (matches
+the repo pin). Result: 5 bearers confirmed exact, **2 corrected** — one mis-cited, one absent
+(a risk wrongly marked "resolved").
+
+### Confirmed exact (discharge can transcribe these verbatim)
+| Step | Cited bearer | Status (v4.26.0) |
+|---|---|---|
+| 1 | `Sylow.ofCard` | ✓ `Mathlib/GroupTheory/Sylow.lean:102` |
+| 1 | `Sylow.unique_of_normal` | ✓ `Sylow.lean:710` |
+| 2 | `Sylow.normal_of_subsingleton` | ✓ `Sylow.lean:724` |
+| 3 | `Equiv.Perm.isCycle_of_prime_order''` | ✓ `Perm/Cycle/Type.lean:412` (takes `(Fintype.card α).Prime`) |
+| 3/5 | order↔support bridge | ✓ `IsCycle.orderOf : orderOf f = #f.support`, `Perm/Cycle/Basic.lean:363` — backs the `hσ_card`→`|⟨σ⟩|=p` step |
+
+### CORRECTION 1 (Step 5) — the cited `Subgroup.le_normalizer` is the WRONG lemma
+The Step-5 docstring says "close with `Subgroup.le_normalizer`-style reasoning". That name
+exists (`Mathlib/Algebra/Group/Subgroup/Defs.lean:710`) but is only the **self**-inclusion
+`H ≤ normalizer H` — it does **not** give Step 5's goal `H ≤ ⟨σ⟩.normalizer` for the *smaller*
+normal subgroup `⟨σ⟩ = ι(P)`. The **correct bearer** is
+```
+Subgroup.le_normalizer_of_normal_subgroupOf
+  [hK : (H'.subgroupOf K).Normal] (HK : H' ≤ K) : K ≤ H'.normalizer   -- Basic.lean:378
+```
+Instantiate `H' := ⟨σ⟩` (normal in `H` via `hPnorm`+`hgen`+`hσ_card`), `K := H`: then
+`(⟨σ⟩.subgroupOf H).Normal` and `⟨σ⟩ ≤ H` give exactly `H ≤ ⟨σ⟩.normalizer`. Companion
+forms also present: `le_normalizer_of_normal` (:387), `subset_normalizer_of_normal` (:383),
+`normal_subgroupOf_iff_le_normalizer` (:364). So Step 5's discharge should target
+`le_normalizer_of_normal_subgroupOf`, after upgrading `ι(P) ⊆ ⟨σ⟩` to `=` (equal cards via
+`IsCycle.orderOf`).
+
+### CORRECTION 2 (Step 4 / R4) — `Subgroup.normal_of_characteristic_of_normal` does NOT exist
+S8/S10 marked the "char-subgroup-of-normal ⟹ normal-in-parent" step **resolved as a 0-LOC
+instance `Subgroup.normal_of_characteristic_of_normal`**. That lemma is **absent** in v4.26.0.
+What exists is the instance `normal_of_characteristic [H.Characteristic] : H.Normal`
+(`Basic.lean:241`) — characteristic ⟹ normal **in the same group**, NOT the transitivity
+`N ⊴ G ∧ K char N ⟹ K ⊴ G`. No single lemma of that transitivity name was found (searched
+all of `Mathlib/`). So **R4 is not "0-LOC resolved"** — that step needs a real (short)
+construction, e.g. via conjugation automorphisms of `N` and `Normal.comap`/`characteristic_iff_*`
+(`Basic.lean:745`, :270-296), or a found upstream lemma. Risk R4 should be re-upgraded from
+"resolved" to "needs ~5–20 LOC construction / bearer hunt".
+
+### Net effect
+The eventual Docker-up discharge gains: 5 verbatim bearers, the **exact** Step-5 lemma name
+(`le_normalizer_of_normal_subgroupOf`, replacing a wrong citation), and a corrected risk
+ledger (R4 not free). Pure documentation; the registered file is untouched (only TRUE `sorry`
+stubs remain after S12).
+
+### Files Modified
+- `research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md` (this name-check)
+
+### Next steps
+- (Docker) discharge Step 5 via `le_normalizer_of_normal_subgroupOf` per Correction 1.
+- (Docker/bearer hunt) construct the char-in-normal transitivity for Step 4 R4 (Correction 2);
+  do NOT rely on the absent `normal_of_characteristic_of_normal`.

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction.json
@@ -60,13 +60,16 @@
     "lastUpdate": "2026-06-15T00:00:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE scaffold materialised the S8 PREP §5 drop-in template into the destination directory: problem.md (5-step proof plan + bearer audit table + references), knowledge.md (risk register + cross-slug reuse + LOC profile), state.md (Iteration 1 SCAFFOLD), and this JSON tracker. No Lean changes. Bearer ecosystem re-verified intact at lake-pinned SHA. Sub-OQ ready for S2 ORIENT.",
+    "progressSummary": "PROGRESS (researcher-1 2026-06-15): Mathlib bearer name-check vs pinned v4.26.0. 5 cited bearers confirmed exact; Step-5 bearer corrected (use le_normalizer_of_normal_subgroupOf, not the self-inclusion le_normalizer); Step-4 R4 'resolved by 0-LOC normal_of_characteristic_of_normal' REFUTED (lemma absent) — needs a real construction. 5 sorries unchanged; no .lean edit (blackout).",
     "insights": [
       "Forward direction parent oq-06 already discharged (S7 ACT PR #19071); this sub-OQ owns only the Galois direction.",
       "Step 1 (sylow_p_unique) HAS a bearer-complete sound route after all (researcher-3 S7 ORIENT 2026-06-14): derived-series last-nontrivial-term A (abelian, characteristic) + block-of-normal-orbit primitivity argument gives A transitive => p | |A|; A's Sylow-p Q is characteristic in A hence normal in H; v_p(p!)=1 => |Q|=p => Q is a normal Sylow-p of H => unique. All bearers present at pin (IsBlock.orbit_of_normal, IsBlock.subsingleton_or_eq_univ, derivedSeries_normal/characteristic/succ, Sylow.characteristic_of_normal/ofCard/unique_of_normal, Nat.Prime.factorization_factorial). The absent socle/MinimalNormal/IsElementaryAbelian API is NOT needed.",
       "The 'nontrivial normal subgroup of a faithful primitive action is transitive' fact -- which R1's S6 audit had not located -- is exactly IsBlock.orbit_of_normal (Blocks.lean:475) + IsBlock.subsingleton_or_eq_univ (Primitive.lean:115); it replaces the textbook minimal-normal machinery for prime degree.",
       "`Equiv.Perm.isCycle_of_prime_order''` (Mathlib v4.26.0) is a 1-LOC bearer for step 3, reducing the parent S6 PREP's 300-500 LOC estimate to 250-450.",
-      "Bearer ecosystem (Sylow, isCycle, normalizer, MonoidHom.ofInjective, parent AGL1Z*) confirmed intact at lake-pinned SHA on 2026-06-01."
+      "Bearer ecosystem (Sylow, isCycle, normalizer, MonoidHom.ofInjective, parent AGL1Z*) confirmed intact at lake-pinned SHA on 2026-06-01.",
+      "Bearer name-check vs pinned mathlib4 v4.26.0 (researcher-1 2026-06-15): Steps 1-3 bearers confirmed EXACT (Sylow.ofCard:102, unique_of_normal:710, normal_of_subsingleton:724, isCycle_of_prime_order'':Type.lean:412, IsCycle.orderOf:Basic.lean:363).",
+      "CORRECTION (Step 5): cited Subgroup.le_normalizer (Defs.lean:710) is only the SELF-inclusion H≤normalizer H, wrong for the goal H≤⟨σ⟩.normalizer. Correct bearer = Subgroup.le_normalizer_of_normal_subgroupOf (Basic.lean:378): from (⟨σ⟩.subgroupOf H).Normal + ⟨σ⟩≤H gives H≤⟨σ⟩.normalizer.",
+      "CORRECTION (Step 4/R4): cited '0-LOC instance Subgroup.normal_of_characteristic_of_normal' does NOT EXIST in v4.26.0. Only normal_of_characteristic (char⟹normal SAME group, Basic.lean:241). The char-in-normal transitivity (N⊴G ∧ K char N ⟹ K⊴G) needs a real ~5-20 LOC construction; R4 is NOT 0-LOC resolved."
     ],
     "nextSteps": [
       "S2 ORIENT: author Lean file skeleton with ~6 file-level + step sorries.",


### PR DESCRIPTION
## Summary
Blackout-safe de-risking of the 5-sorry Galois-direction discharge plan (a solvable
primitive subgroup of `S_p` embeds in `AGL(1,p)`). Docker + Aristotle both down, so no
`.lean` edit; instead I name-checked **every** Mathlib bearer the plan cites against the
pinned sibling checkout `/Users/rwalters/GitHub/mathlib4` at **v4.26.0** (matches the repo pin).

## Confirmed exact (discharge can transcribe verbatim)
| Step | Bearer | Location (v4.26.0) |
|------|--------|--------------------|
| 1 | `Sylow.ofCard` | `Sylow.lean:102` |
| 1 | `Sylow.unique_of_normal` | `Sylow.lean:710` |
| 2 | `Sylow.normal_of_subsingleton` | `Sylow.lean:724` |
| 3 | `Equiv.Perm.isCycle_of_prime_order''` | `Perm/Cycle/Type.lean:412` |
| 3/5 | `IsCycle.orderOf : orderOf f = #f.support` | `Perm/Cycle/Basic.lean:363` |

## Correction 1 — Step 5 bearer is mis-cited
The Step-5 docstring says "close with `Subgroup.le_normalizer`-style reasoning". That name
exists (`Subgroup/Defs.lean:710`) but is only the **self**-inclusion `H ≤ normalizer H` — it
does not give the goal `H ≤ ⟨σ⟩.normalizer`. The **correct bearer** is
`Subgroup.le_normalizer_of_normal_subgroupOf` (`Subgroup/Basic.lean:378`): with
`H' := ⟨σ⟩` (normal in `H`), `K := H`, `(⟨σ⟩.subgroupOf H).Normal` + `⟨σ⟩ ≤ H` yields exactly
`H ≤ ⟨σ⟩.normalizer`.

## Correction 2 — Step 4 / R4 risk wrongly marked "resolved"
S8/S10 marked the "characteristic-subgroup-of-normal ⟹ normal-in-parent" step **resolved as
a 0-LOC instance `Subgroup.normal_of_characteristic_of_normal`**. That lemma is **absent** in
v4.26.0. Only `normal_of_characteristic [H.Characteristic] : H.Normal` (`Basic.lean:241`) exists
— char ⟹ normal in the **same** group, not the transitivity `N ⊴ G ∧ K char N ⟹ K ⊴ G`. So
R4 needs a real (~5–20 LOC) construction, not a free instance.

## Status
**Outcome**: progress (documentation only; registered `.lean` untouched — 5 TRUE `sorry` stubs
after S12). The eventual Docker discharge gains 5 verbatim bearers, the exact Step-5 lemma, and
a corrected risk ledger.
**Next**: (Docker) Step 5 via `le_normalizer_of_normal_subgroupOf`; construct the Step-4
char-in-normal transitivity (do not rely on the absent lemma).

🤖 Generated by researcher-1