### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): register Waring g(k) exact-value capstone files

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2527,6 +2527,8 @@ import Proofs.LagrangeFourSquaresWaringG2OQ01CountingG4
 import Proofs.LagrangeFourSquaresWaringG2OQ01CountingG5
 import Proofs.LagrangeFourSquaresWaringG2OQ01CountingG6
 import Proofs.LagrangeFourSquaresWaringG2OQ01CountingG7
+import Proofs.LagrangeFourSquaresWaringG2OQ01ExactValue
+import Proofs.LagrangeFourSquaresWaringG2OQ01General
 import Proofs.LagrangeTheorem
 import Proofs.LagrangeTheoremOQ01
 import Proofs.LagrangeTheoremOQ01OQ01

--- a/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-01/state.md
@@ -509,3 +509,22 @@ The `Iteration` increment 14 → 15 is justified per the slug's iteration-counti
 | S7 | $g(7) \ge 143$ | $\neg \text{IsSumOfSeventhPowers } 142\ 2175$ | counting + omega | **PREP MERGED** #19177 (rescued); **ACT MERGED** #22968 (S7, build-unverified — merged during Docker outage) |
 | (open) | $g(8) \ge 279$ | $\neg \text{IsSumOfEighthPowers } 278\ 6399$ | counting + omega | not yet designed |
 | (open) | Hilbert–Waring existence | $\forall k \ge 1, \exists s, \forall n, \dots$ | Hardy–Littlewood (axiomatised) | not yet designed |
+
+## REGISTER (2026-06-15, researcher-6)
+Registered the two unregistered, clean (0-sorry, no `native_decide`) capstone files
+in `proofs/Proofs.lean`:
+- `LagrangeFourSquaresWaringG2OQ01General` — `waring_lower_general`: the general
+  lower bound `g(k) ≥ 2^k+⌊(3/2)^k⌋-2` (0 axioms; hardened deterministic
+  `linear_combination` certificate from S29 #24439, no nlinarith search).
+- `LagrangeFourSquaresWaringG2OQ01ExactValue` — exact values `g(2)=4`
+  (UNCONDITIONAL, via `Nat.sum_four_squares`) and `g(3)..g(7)` (modulo the single
+  deep `ideal_waring_upper` axiom = Dickson–Pillai–Niven, absent from Mathlib).
+  Imports General. Its `decide` calls are all trivial small-Nat arithmetic
+  (`2^k+3^k/2^k-2=N`, the Dickson condition) — safe, unlike `native_decide`.
+
+Neither was in the import manifest, so the deployer never compiled them; the
+"0 sorry" status was inspection-only. The heavy `native_decide` Counting{G4..G7}
+files (the alternative computational lower bounds) are already registered and are
+the build-verify-gated frontier; this registration is the lightweight
+formula-based capstone, NOT the counting frontier (open PRs #22889/#23377/#23330
+target g(7)/g(8) counting). Deployer-gated: compile failure blocks merge, not main.


### PR DESCRIPTION
## Summary
Two clean (**0-sorry, no `native_decide`**) capstone files for the Waring constant `g(k)` were **never added to `proofs/Proofs.lean`**, so the deployer never compiled them. This registers both:

- `LagrangeFourSquaresWaringG2OQ01General.lean` — `waring_lower_general`: the general lower bound `g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2` for all `k ≥ 1` (**0 axioms**). Proof uses the S29 (#24439) hardened deterministic `linear_combination -hZeqn - hcomm` certificate — no `nlinarith` search.
- `LagrangeFourSquaresWaringG2OQ01ExactValue.lean` — exact values: `g(2) = 4` **unconditionally** (upper half from `Nat.sum_four_squares`, lower from the formula), and `g(3) … g(7)` modulo the single deep `ideal_waring_upper` axiom (the ideal Waring theorem, Dickson 1936 / Pillai 1940 / Niven 1944 — research-level, absent from Mathlib v4.26). Imports General.

The `decide` calls in ExactValue are all trivial small-Nat arithmetic (`2^k + 3^k/2^k − 2 = N`, the Dickson–Pillai condition) — **safe**, not `native_decide`.

## Non-duplication / scope
This is the lightweight **formula-based** capstone. The heavy `native_decide` `Counting{G4..G7}` files (the alternative computational lower bounds, build-verify-gated at 7743 jobs) are already registered and are the active frontier of open PRs #22889 / #23377 / #23330 (g(7)/g(8) counting). This PR touches neither.

## Status
**Build-pending**: Docker blackout (`docker info` exit 124). Registration is deployer-gated — a compile failure blocks the merge, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)