### PR TITLE
Enrich euler-identity-oq-01-oq-01-oq-01-oq-01: add annotations.json

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "eioq01x4-ann-01",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Goal: Package t ↦ exp(it) as a Smooth Lie Group Exponential",
+    "content": "The docstring states the open question inherited from the parent `EulerIdentityOQ01OQ01OQ01`: the parent proved that `circleMap : t ↦ e^{it}` is a *continuous* group homomorphism $(\\mathbb{R}, +) \\to (\\mathbb{C}^\\times, \\cdot)$ onto the unit circle, but a Lie group exponential demands more — *smoothness* as a map of manifolds and an identification of the Lie algebra. The answer is YES, achieved by *packaging* rather than new analysis: Mathlib already equips `Circle = {z : ℂ // ‖z‖ = 1}` with an analytic Lie group structure `LieGroup (𝓡 1) ω Circle` and proves `Circle.exp` is `ContMDiff` of every order. The file's job is to (1) bridge the gallery's `circleMap` to Mathlib's `Circle.exp`, (2) cite all-order smoothness, (3) reconcile the two homomorphism packagings, and (4) exhibit the Lie algebra $i\\mathbb{R}$ via the defining ODE. The imports pull in the manifold/sphere instances, complex real-derivative lemmas, and the verified parent file.",
+    "mathContext": "A Lie group exponential is a smooth map $\\exp_G : \\mathfrak{g} \\to G$ from the Lie algebra (the tangent space $T_e G$) to the group. For $G = S^1 \\subset \\mathbb{C}^\\times$, $\\mathfrak{g} = T_1 S^1 = i\\mathbb{R}$ and $\\exp(it) = e^{it}$. Upgrading a *continuous* homomorphism to a *smooth* one is exactly the difference between a topological-group map and a Lie-group exponential.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lie group exponential map",
+      "one-parameter subgroup",
+      "analytic Lie group structure on S¹",
+      "Lie algebra as tangent space at identity",
+      "packaging vs. new analysis"
+    ],
+    "prerequisites": [
+      "Parent entry: t ↦ exp(it) as a continuous homomorphism (EulerIdentityOQ01OQ01OQ01)",
+      "Mathlib manifold model 𝓡 1 and ContMDiff",
+      "basic Lie theory (exponential, Lie algebra)"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-02",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "technique",
+    "title": "§1 Bridge: circleMap t = ↑(Circle.exp t)",
+    "content": "`circleMap_eq_coe_circleExp` is the linchpin: it proves the parent's `circleMap t` equals the coercion into $\\mathbb{C}$ of Mathlib's canonical circle exponential `Circle.exp t`. The proof is two lines — `unfold EulerIdentityOQ01OQ01OQ01.circleMap` reduces the parent map to `Complex.exp (↑t * I)`, and `rw [Circle.coe_exp]` rewrites `↑(Circle.exp t)` to the very same expression, so the two sides are definitionally identical. This identification is what lets every smooth-structure result Mathlib proves about `Circle.exp` transfer verbatim to the gallery's construction; without it the gallery's `circleMap` would be an opaque $\\mathbb{C}$-valued map carrying no manifold structure.",
+    "mathContext": "$\\text{circleMap}(t) = e^{it} = \\text{Complex.exp}(t\\cdot i)$, and Mathlib's $\\overline{\\text{Circle.exp}(t)} = \\text{Complex.exp}(t\\cdot i)$ by `Circle.coe_exp`. Hence $\\text{circleMap}(t) = \\overline{\\text{Circle.exp}(t)}$ on the nose — the same complex number, one viewed in $\\mathbb{C}$ and one as an element of the subtype `Circle`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex exponential",
+      "Circle.exp",
+      "subtype coercion",
+      "definitional equality"
+    ],
+    "prerequisites": [
+      "Circle.coe_exp",
+      "parent definition circleMap"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-03",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 81 },
+    "type": "insight",
+    "title": "§2 Smoothness: ContMDiff of Every Order m",
+    "content": "`contMDiff_circleExp_packaged` is the requested $C^\\infty$ property, stated in its strongest form: `Circle.exp` is `ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) m` for an *arbitrary* order `m : WithTop ℕ∞`. The proof is the single term `contMDiff_circleExp` — Mathlib's top-level lemma. Quantifying over all `m` simultaneously delivers $C^\\infty$ (the case $m = \\infty$) and real-analyticity (the case $m = \\omega$, the top element). The model maps are explicit: `𝓘(ℝ, ℝ)` is the trivial chart on the 1-dimensional source $\\mathbb{R}$, and `𝓡 1` (notation for `modelWithCornersEuclideanHalfSpace`/the sphere model) is the 1-dimensional real manifold model carried by `Circle`. The key methodological point — flagged in the proof-strategy — is that no new differential geometry is built here; smoothness is *cited*, because Mathlib's sphere instance already supplies it.",
+    "mathContext": "`ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) m f` means $f : \\mathbb{R} \\to S^1$ is $C^m$ in manifold charts. Taking $m = \\infty$ gives $C^\\infty$; the lattice top $m = \\omega$ gives analyticity. Since the statement holds for every $m$, the requested $C^\\infty$ smoothness follows a fortiori, as does the stronger analytic regularity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ContMDiff",
+      "C∞ smoothness",
+      "real-analyticity (ω)",
+      "manifold model 𝓡 1",
+      "WithTop ℕ∞ smoothness order"
+    ],
+    "prerequisites": [
+      "contMDiff_circleExp (Geometry.Manifold.Instances.Sphere)",
+      "manifold smoothness ContMDiff",
+      "the analytic Lie group instance LieGroup (𝓡 1) ω Circle"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-04",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 96 },
+    "type": "definition",
+    "title": "§3 Homomorphism in the Genuine Circle Group",
+    "content": "Two facts reconcile the gallery's algebra with Mathlib's. `circleExp_homomorphism` records the one-parameter-subgroup law `Circle.exp (x + y) = Circle.exp x * Circle.exp y` directly from `Circle.exp_add` — this is multiplication in the *genuine* group `(Circle, ·)`, not merely in `ℂˣ`. `circleHom_coe_eq_circleExp` then shows the parent's homomorphism `circleHom : Multiplicative ℝ →* ℂˣ` agrees, after coercion to $\\mathbb{C}$, with `Circle.exp`; the proof rewrites through the parent lemma `circleHom_apply` and the §1 bridge `circleMap_eq_coe_circleExp`. Together they establish that the parent's map into $\\mathbb{C}^\\times$ and Mathlib's map into `Circle` are two coherent packagings of the same exponential, the difference being only the choice of algebraic codomain.",
+    "mathContext": "Homomorphism law $e^{i(x+y)} = e^{ix}e^{iy}$, now in `(Circle, ·)`. Mathlib bundles it as `Circle.expHom : ℝ →+ Additive Circle`. Compatibility: $\\overline{\\text{circleHom}(\\text{ofAdd}\\,t)} = \\overline{\\text{Circle.exp}(t)}$, so the two homomorphisms coincide under the canonical $\\text{Circle} \\hookrightarrow \\mathbb{C}^\\times$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "group homomorphism",
+      "Circle.expHom",
+      "Multiplicative/Additive wrappers",
+      "one-parameter subgroup"
+    ],
+    "prerequisites": [
+      "Circle.exp_add",
+      "parent lemma circleHom_apply",
+      "§1 bridge circleMap_eq_coe_circleExp"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-05",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 113 },
+    "type": "technique",
+    "title": "§4 Defining ODE: γ'(t) = γ(t)·I",
+    "content": "`hasDerivAt_circleExp` proves the defining ODE of the Lie group exponential: the derivative of $t \\mapsto e^{it}$ (viewed in $\\mathbb{C}$) at any $t$ equals `Circle.exp t · I` — the value times the Lie-algebra generator. The proof assembles the chain rule cleanly: `hbase` establishes that the real coordinate $s \\mapsto (s : \\mathbb{C})$ is differentiable with derivative $1$ via `(hasDerivAt_id t).ofReal_comp`; then `hbase.mul_const Complex.I` differentiates $s \\mapsto s\\cdot I$, and `.cexp` applies the chain rule for the complex exponential, giving the derivative of $s \\mapsto \\exp(s\\cdot I)$. Crucially the base point is kept *real* throughout (`ofReal_comp` preserves the real base point), avoiding the coercion-of-base-point pitfall that arises if one composes with `↑t` directly. The final `simpa` reconciles `exp(t·I)·I` with `Circle.exp t · I`.",
+    "mathContext": "$\\frac{d}{dt} e^{it} = i\\,e^{it} = e^{it}\\cdot i$, the ODE $\\gamma'(t) = \\gamma(t)\\cdot X$ of a one-parameter subgroup with generator $X = i$. The HasDerivAt chain: $\\frac{d}{ds}(s) = 1 \\Rightarrow \\frac{d}{ds}(s\\,i) = i \\Rightarrow \\frac{d}{ds} e^{s i} = e^{si}\\cdot i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasDerivAt chain rule",
+      "one-parameter subgroup ODE",
+      "left-invariant vector field",
+      "HasDerivAt.ofReal_comp",
+      "coercion-of-base-point pitfall"
+    ],
+    "prerequisites": [
+      "HasDerivAt.cexp, HasDerivAt.mul_const, HasDerivAt.ofReal_comp",
+      "derivative of the complex exponential",
+      "§1 identification of circleMap with Circle.exp"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-06",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 126 },
+    "type": "insight",
+    "title": "§4 Lie Algebra Generator: Velocity at the Identity is i",
+    "content": "`hasDerivAt_circleExp_zero` specializes the ODE at $t = 0$: since `Circle.exp 0 = 1`, the velocity of the one-parameter subgroup at the identity is exactly the imaginary unit `I` (the `simpa` collapses `Circle.exp 0 · I = 1 · I = I`). This is the infinitesimal generator of the exponential, and `generator_mem_imaginary_axis` pins it to the imaginary axis by computing `(I).re = 0` and `(I).im = 1` via `Complex.I_re` and `Complex.I_im`. Geometrically, the tangent space $T_1 S^1$ — the Lie algebra of the circle group — is the imaginary axis $i\\mathbb{R} \\subset \\mathbb{C}$, generated by $i$. This is the precise sense in which the open question's request to 'identify the Lie algebra as $i\\mathbb{R}$' is answered.",
+    "mathContext": "$\\gamma'(0) = i\\,e^{i\\cdot 0} = i$. The tangent space at the identity $1 \\in S^1$ is $T_1 S^1 = \\{z : \\mathrm{Re}(z) = 0\\} = i\\mathbb{R}$, the Lie algebra $\\mathfrak{s}^1$, with generator $i$ ($\\mathrm{Re}(i)=0$, $\\mathrm{Im}(i)=1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lie algebra of S¹",
+      "tangent space at identity",
+      "infinitesimal generator",
+      "imaginary axis iℝ"
+    ],
+    "prerequisites": [
+      "the defining ODE hasDerivAt_circleExp",
+      "Circle.exp 0 = 1",
+      "Complex.I_re, Complex.I_im"
+    ]
+  },
+  {
+    "id": "eioq01x4-ann-07",
+    "proofId": "euler-identity-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 147 },
+    "type": "insight",
+    "title": "§5 Summary: the Packaged Answer (main)",
+    "content": "`main` bundles the three Lie-theoretic pillars into one conjunction: (1) the homomorphism law `∀ x y, Circle.exp (x + y) = Circle.exp x * Circle.exp y`; (2) all-order smoothness `∀ m, ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) m Circle.exp`; and (3) the Lie-algebra generator `HasDerivAt (fun s => Circle.exp s) Complex.I 0`. The proof is a triple `⟨Circle.exp_add, fun m => contMDiff_circleExp_packaged m, hasDerivAt_circleExp_zero⟩` — each component discharged by a result proved above. This is the formal statement that $t \\mapsto e^{it}$ is the smooth Lie group exponential of $S^1$: a smooth homomorphism from the additive line whose infinitesimal generator is $i$, closing the open question entirely within Mathlib's existing `LieGroup` framework with 0 axioms and 0 sorries.",
+    "mathContext": "$\\exp : \\mathbb{R} \\to S^1$, $\\exp(t) = e^{it}$, is simultaneously a group homomorphism $(\\mathbb{R},+)\\to(S^1,\\cdot)$, $C^\\infty$/analytic as a manifold map, and has $\\exp'(0) = i$ generating the Lie algebra $i\\mathbb{R}$ — the three defining properties of a Lie group exponential, here assembled into a single theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lie group exponential map",
+      "smooth homomorphism",
+      "infinitesimal generator",
+      "axiom-free verification"
+    ],
+    "prerequisites": [
+      "all preceding theorems in this file",
+      "Circle.exp_add"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: euler-identity-oq-01-oq-01-oq-01-oq-01

This was the **only entry in the 2450-proof gallery missing `annotations.json`** — the research PR #24484 that created the gallery entry shipped a rich `meta.json` (overview, 5 sections, conclusion, references) but no inline annotations, leaving the proof page without annotation coverage.

### Change
Adds `annotations.json` with **7 source-accurate annotations**, each carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` (gallery quality target is ≥5):

| § | Lines | Theorem(s) | Significance |
|---|-------|-----------|--------------|
| header | 1–54 | open question + packaging answer | context |
| §1 | 56–67 | `circleMap_eq_coe_circleExp` (bridge to `Circle.exp`) | key |
| §2 | 69–81 | `contMDiff_circleExp_packaged` (ContMDiff every order) | key |
| §3 | 83–96 | `circleExp_homomorphism`, `circleHom_coe_eq_circleExp` | supporting |
| §4 | 98–113 | `hasDerivAt_circleExp` (ODE γ'(t)=γ(t)·I) | key |
| §4 | 115–126 | `hasDerivAt_circleExp_zero`, `generator_mem_imaginary_axis` | key |
| §5 | 128–147 | `main` (packaged bundle) | key |

Content is tied to the actual Lean tactics (e.g. the `HasDerivAt.ofReal_comp ∘ mul_const I ∘ cexp` assembly and the real-base-point note) and line ranges match the existing `sections` in `meta.json`.

### Accuracy / axiom integrity
Verified against `proofs/Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean`: 0 sorries, 0 axioms, no structure-encoded assumptions — `status: verified` / `badge: original` in meta.json is accurate. No meta claims changed.

### Verification
- `pnpm build` passes (exit 0).
- Only `annotations.json` is added; no other files modified.