### PR TITLE
research(inclusion-exclusion-oq-01-oq-03): register completed Möbius-inversion file

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2453,6 +2453,7 @@ import Proofs.HurwitzTheoremOQ04
 import Proofs.InclusionExclusion
 import Proofs.InclusionExclusionGeneral
 import Proofs.InclusionExclusionOQ01
+import Proofs.InclusionExclusionOQ01OQ03
 import Proofs.InclusionExclusionOQ03
 import Proofs.InfinitudePrimes
 import Proofs.InfinitudePrimes3k2

--- a/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
@@ -40,9 +40,9 @@
   `research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py`
   (ALL PASS).
 
-  Status: 0 axioms, 0 sorries intended.  Build-pending (authored under a Docker +
-  Aristotle blackout); UNREGISTERED in `Proofs/Proofs.lean` until it compiles in a
-  live session.
+  Status: 0 axioms, 0 sorries.  Registered in `Proofs/Proofs.lean` so the gallery
+  build machine-checks it.  Lemma names verified against the pinned Mathlib v4.26.0
+  (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`, `Nat.sum_divisorsAntidiagonal`).
 -/
 
 import Mathlib.NumberTheory.ArithmeticFunction.Moebius

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
@@ -91,3 +91,21 @@ Name-checks vs pinned mathlib4 v4.26.0 (sibling): `sum_eq_iff_sum_mul_moebius_eq
 `Nat.sum_divisorsAntidiagonal` (to_additive partner of `prod_divisorsAntidiagonal`,
 Divisors.lean:543) — all present. File still 0 axioms / 0 sorries; build-pending UNREGISTERED
 (dual blackout: docker ps exit 124, Aristotle 404).
+
+### Session 2026-06-15 (ACT, researcher-3) — register the completed file for machine-checking
+
+**Mode**: build-free ACT under Docker+Aristotle blackout. **Outcome**: registration only.
+
+`InclusionExclusionOQ01OQ03.lean` was on `main` and complete (both
+`moebius_inversion_divisors` and `totient_eq_sum_moebius_mul`, 0 axioms / 0 sorries)
+but **absent from `proofs/Proofs.lean`** — i.e. never compiled by the gallery build,
+so "verified" was inspection-only. Added the single manifest line
+`import Proofs.InclusionExclusionOQ01OQ03` (between `…OQ01` and `…OQ03`) and updated
+the file's status note. Re-verified the proof logic by hand: the `(f := g)(g := f)`
+instantiation of `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` composed with the
+`Nat.sum_divisorsAntidiagonal` divisor↔antidiagonal bridge (plus `.symm`/`eq_comm`)
+is sound. Registration is deployer-build-gated: a compile failure blocks this PR's
+merge, not `main`, so it is blackout-safe.
+
+**Next**: if a later live session sees the build pass, mark the OQ `completed`.
+General poset (Rota) Möbius inversion remains out of scope for this divisor-lattice OQ.


### PR DESCRIPTION
## Summary
- `proofs/Proofs/InclusionExclusionOQ01OQ03.lean` (`moebius_inversion_divisors` + `totient_eq_sum_moebius_mul`, **0 axioms / 0 sorries**) was already on `main` but **absent from `proofs/Proofs.lean`**, so the gallery build never compiled it — "verified" was inspection-only.
- This PR adds the single manifest line `import Proofs.InclusionExclusionOQ01OQ03` so the file is machine-checked, and de-stales the file's status note.

## Why this is safe under the current Docker/Aristotle blackout
- Registration is **deployer-build-gated**: if the file fails to compile, this PR's merge is blocked — `main` is unaffected.
- Proof logic re-verified by hand against pinned **Mathlib v4.26.0**: the `(f := g)(g := f)` instantiation of `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` composed with the `Nat.sum_divisorsAntidiagonal` divisor↔antidiagonal bridge (+ `.symm`/`eq_comm`) is sound.

## Test plan
- [ ] Gallery Docker build compiles `Proofs.InclusionExclusionOQ01OQ03` (deployer gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)