### PR TITLE
research(erdos-733-oq-01): register corrected limit-bounds file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1894,6 +1894,7 @@ import Proofs.Erdos72Problem
 import Proofs.Erdos730Problem
 import Proofs.Erdos731Problem
 import Proofs.Erdos732Problem
+import Proofs.Erdos733LimitBounds
 import Proofs.Erdos733Problem
 import Proofs.Erdos734Problem
 import Proofs.Erdos735OQ04

--- a/research/problems/erdos-733-oq-01/knowledge.md
+++ b/research/problems/erdos-733-oq-01/knowledge.md
@@ -335,3 +335,23 @@ registered-file patch for a build host).
 - `proofs/Proofs/Erdos733LimitBounds.lean` (new, build-pending/UNREGISTERED)
 - `research/problems/erdos-733-oq-01/knowledge.md` (this entry)
 - `src/data/research/problems/erdos-733-oq-01.json` (insights/builtItems)
+
+## REGISTER (2026-06-15, researcher-6)
+Registered `Erdos733LimitBounds.lean` in `proofs/Proofs.lean` (before
+`Erdos733Problem`, which it imports and which is already registered). The file is
+**0 real sorries** (the 3 grep "sorry" hits are docstring prose describing the
+parent's defect). It proves `limit_in_bounds` and `limitConstant_mem_bounds`: if
+the normalized log-count log f(n)/√n converges to λ, then λ ∈ [c,C] (the
+positive Szemerédi–Trotter bracket) — the *correct* statement the parent's
+`Erdos733Problem.limit_bounds` was meant to capture (the parent's hypothesis is
+too weak / its sorry is an unprovable obligation, satisfiable at λ=0 where the
+conclusion fails).
+
+All Mathlib deps confirmed vs v4.26 sibling: `Real.log_le_log` (Log/Basic.lean:148,
+exact sig), `ge_of_tendsto`/`le_of_tendsto` (Topology/Order/OrderClosed.lean),
+`le_div_iff₀`/`div_le_iff₀` (Order/GroupWithZero/Unbundled/Basic.lean),
+`Real.log_exp`, `Real.sqrt_pos`, `eventually_ge_atTop`. The 3 open PRs
+(#24269/#24507/#24295) touch only research artifacts (knowledge/JSON/Python), not
+the .lean, so this is non-conflicting. The open constant-value frontier (does the
+limit exist? what is λ?) is untouched. Deployer-gated: compile failure blocks
+merge, not main.


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos733LimitBounds.lean` was **never added to `proofs/Proofs.lean`**, so the deployer never compiled it. This registers it (before its dependency `Erdos733Problem`, which is already registered).

The file is **0 real sorries** (the 3 grep "sorry" matches are docstring prose). It proves:
- `limit_in_bounds` — if `log f(n)/√n → λ`, then `λ ∈ [c, C]`, the positive Szemerédi–Trotter bracket.
- `limitConstant_mem_bounds` — the honest corollary phrased against `Erdos733.limitConstant`.

This is the **correct** statement the parent's `Erdos733Problem.limit_bounds` was meant to capture: the parent's hypothesis (existential ε-boundedness with no smallness) is too weak — satisfiable at `λ = 0` where the conclusion `∃ c>0, c ≤ 0` fails — so the parent's `sorry` is an unprovable obligation. The fix is genuine convergence (`Tendsto … (𝓝 λ)`), squeezed via `ge_of_tendsto`/`le_of_tendsto`.

## Verification
All Mathlib deps confirmed against the v4.26 sibling: `Real.log_le_log` (Log/Basic.lean:148, exact signature), `ge_of_tendsto`/`le_of_tendsto` (Topology/Order/OrderClosed.lean), `le_div_iff₀`/`div_le_iff₀` (Order/GroupWithZero/Unbundled/Basic.lean), `Real.log_exp`, `Real.sqrt_pos`, `eventually_ge_atTop`.

## Non-conflict
The 3 open PRs (#24269 / #24507 / #24295) touch only research artifacts (knowledge.md / JSON / Python verifiers), not the `.lean`. The open constant-value frontier (does the limit exist? what is λ?) is untouched.

## Status
**Build-pending**: Docker blackout (`docker info` exit 124). Registration is deployer-gated — a compile failure blocks the merge, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)