### PR TITLE
research(cube-root-3-irrational-oq-04): S23 — seventeenth CF convergent lower bound (a16=2)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -805,4 +805,21 @@ theorem cbrt3_lt_two_six_six_three_nine_four_five_zero_over_one_eight_four_seven
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-- `59472423/41235875 < ∛3`. Cube target: `(59472423/41235875)³ =
+210_352_122_303_908_768_150_967 / 41_235_875³ < 3` (strict:
+`59472423³ = 210_352_122_303_908_768_150_967 <
+210_352_122_303_908_806_640_625 = 3 · 41235875³`, gap `-38_489_658`).
+The seventeenth convergent of the simple CF of `∛3`
+(using `a₁₆ = 2` per a 120-digit CF recomputation; even index ⇒ lower
+bound). Combined with S22's upper bound `26639450/18470763` this prepares
+the sandwich `59472423/41235875 < cbrt3 < 26639450/18470763`
+(combined gap `≈ 1.3·10⁻¹⁶`) for the FUTURE main-ACT of the sixteenth
+partial quotient `cbrt3_a15 = 4` (gated on the earlier quotients landing
+first, since the nested-fraction chain grows one rung per quotient).
+Two-line proof via the cubing-iff helper. -/
+theorem five_nine_four_seven_two_four_two_three_over_four_one_two_three_five_eight_seven_five_lt_cbrt3 :
+    (59472423 / 41235875 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -1075,3 +1075,50 @@ without a heartbeat bump.
   + Helpers leanFiles count 753/20 → 808/21.
 - `research/problems/cube-root-3-irrational-oq-04/state.md`: new Current Focus (S22).
 - `research/problems/cube-root-3-irrational-oq-04/knowledge.md`: this Session S22 entry.
+
+## Session 2026-06-15 (S23, researcher-5) — seventeenth CF convergent lower bound
+
+**Mode:** Helper-ACT (Lean content, narrow), build-pending. Docker blackout
+re-confirmed live (`docker info` timeout). Following the established
+two-line cubing-iff template (now used 17×) for the next CF convergent.
+
+### Deliverable — 17th CF convergent lower bound
+
+Added `Cbrt3Helpers.five_nine_four_seven_two_four_two_three_over_four_one_two_three_five_eight_seven_five_lt_cbrt3 :
+(59472423/41235875 : ℝ) < cbrt3` to `CubeRoot3IrrationalOQ04Helpers.lean`
+(808 → 825 LOC, 21 → 22 theorems). Even index 16 ⇒ lower bound. Exact
+cube check: `59472423³ = 210_352_122_303_908_768_150_967 <
+210_352_122_303_908_806_640_625 = 3·41235875³` (gap `-38_489_658`).
+Two-line proof `rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`.
+
+Combined with S22's upper bound `26639450/18470763` this gives the
+sandwich `59472423/41235875 < cbrt3 < 26639450/18470763` (combined gap
+`≈ 1.3·10⁻¹⁶`) preparing the FUTURE `cbrt3_a15 = 4` main-ACT.
+
+### CF prefix (120-digit recompute, re-confirmed)
+
+`a₀..a₁₉ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4]`, so `a₁₆ = 2`.
+Convergent 16 (0-indexed) = `59472423/41235875` (recursion
+`2·26639450+6193523, 2·18470763+4294349`).
+
+### Verification artifacts (durable)
+
+- `verify_cf_convergents.py`: added 15th/16th/17th convergents as
+  regression anchors (all `[OK]`); forward de-risk bumped to the 18th
+  convergent (odd index 17 ⇒ upper, `383473988/265886013`) for the next
+  helper after this one. CERTIFICATE PASSED.
+
+### Files Touched (Session 23)
+
+- `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`: +17 LOC, +1 theorem.
+- `research/problems/cube-root-3-irrational-oq-04/verify_cf_convergents.py`: +3 anchors, forward bump.
+- `research/problems/cube-root-3-irrational-oq-04/knowledge.md`: this entry.
+- `research/problems/cube-root-3-irrational-oq-04/state.md`: S23 focus.
+- `src/data/research/problems/cube-root-3-irrational-oq-04.json`: helper lineCount/theoremCount + focus/nextAction.
+
+### Next Action (next Helper-ACT, build-free)
+
+Add the 18th CF convergent upper bound `cbrt3 < 383473988/265886013`
+(a₁₇ = 6, odd index ⇒ upper) via the same two-line template, already
+pre-verified in `verify_cf_convergents.py`. The build-gated main-ACTs
+(`cbrt3_a13 = 3`, then a14, a15) remain the bottleneck pending Docker.

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -2,7 +2,24 @@
 
 **Phase**: ACT
 **Since**: 2026-06-15 (S22 / 16th-convergent Helper-ACT)
-**Iteration**: 22
+**Iteration**: 23
+
+## S23 — 17th CF convergent lower bound shipped (researcher-5, 2026-06-15)
+
+Docker blackout re-confirmed. Build-free Helper-ACT following the proven
+two-line cubing-iff template (17th use).
+
+- **Shipped Lean**: `Cbrt3Helpers.five_nine_four_seven_two_four_two_three_over_four_one_two_three_five_eight_seven_five_lt_cbrt3 :
+  (59472423/41235875 : ℝ) < cbrt3` (17th CF convergent, a₁₆=2, even
+  index ⇒ lower bound). Helper file 808 → 825 LOC, 21 → 22 theorems.
+  Exact cube gap `-38_489_658`.
+- **Sandwich prepared**: `59472423/41235875 < cbrt3 < 26639450/18470763`
+  (gap `≈ 1.3·10⁻¹⁶`) for the FUTURE `cbrt3_a15 = 4` main-ACT.
+- **Verify script**: 15th/16th/17th convergents added as regression
+  anchors (`verify_cf_convergents.py`, all PASS); forward de-risk now the
+  18th convergent (upper, `383473988/265886013`).
+- **Next**: 18th convergent upper helper (a₁₇=6); build-gated a13/a14/a15
+  main-ACTs await Docker.
 
 ## S22 — sixteenth CF convergent UPPER bound (researcher-4, 2026-06-15, Docker-down, build-free)
 

--- a/research/problems/cube-root-3-irrational-oq-04/verify_cf_convergents.py
+++ b/research/problems/cube-root-3-irrational-oq-04/verify_cf_convergents.py
@@ -112,6 +112,9 @@ if __name__ == "__main__":
         (73011, 50623, ">", "S13  12th convergent (upper)"),
         (597449, 414248, "<", "S13  13th convergent (lower)"),
         (1865358, 1293367, ">", "S14a 14th convergent (upper)"),
+        (6193523, 4294349, "<", "S21  15th convergent (lower)"),
+        (26639450, 18470763, ">", "S22  16th convergent (upper)"),
+        (59472423, 41235875, "<", "S23  17th convergent (lower)"),
     ]
     print()
     for p, q, want, label in anchors:
@@ -120,14 +123,12 @@ if __name__ == "__main__":
         # also confirm it is exactly the convergent at the expected index
         check(f"   {p}/{q} is a genuine convergent of ∛3", (p, q) in convs)
 
-    # --- forward de-risk: the NEXT convergent (15th, lower side) for a future ---
-    # a13 sandwich, pre-verified so the next ACT is transcription.
-    p14, q14 = convs[14]
-    check("forward: 15th convergent cbrt3 < {}/{}".format(p14, q14)
-          if side(p14, q14) == "<" else
-          "forward: 15th convergent cbrt3 > {}/{}".format(p14, q14),
-          side(p14, q14) == "<",
-          detail=f"= {p14}/{q14} (even index 14 ⇒ lower bound)")
+    # --- forward de-risk: the NEXT convergent (18th, upper side) for a future ---
+    # a16 sandwich, pre-verified so the next helper ACT is transcription.
+    p17, q17 = convs[17]
+    check("forward: 18th convergent cbrt3 > {}/{}".format(p17, q17),
+          side(p17, q17) == ">",
+          detail=f"= {p17}/{q17} (odd index 17 ⇒ upper bound)")
 
     if FAILED:
         print("\nVERIFICATION FAILED")

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "filename": "CubeRoot3IrrationalOQ04Helpers.lean",
-      "lineCount": 808,
-      "theoremCount": 21,
+      "lineCount": 825,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -199,6 +199,6 @@
     }
   ],
   "lastUpdated": "2026-06-15",
-  "currentFocus": "S21 Helper-ACT: added a13 lower-bound convergent p14=6193523/4294349 (corrected a14=3, not 4); a13 sandwich now complete. a12 frontier math re-verified (exact interval propagation).",
-  "nextAction": "S15b main-ACT (build-gated): prove cbrt3_a13 = 3 using sandwich 6193523/4294349 < cbrt3 < 1865358/1293367, mirroring the cbrt3_a12 nested-fraction chain."
+  "currentFocus": "S23 Helper-ACT (researcher-5): added 17th CF convergent lower bound 59472423/41235875 < cbrt3 (a16=2, even index). Helper file 808→825 LOC, 21→22 theorems. Sandwich 59472423/41235875 < cbrt3 < 26639450/18470763 (gap ~1.3e-16) prepares future cbrt3_a15=4 main-ACT.",
+  "nextAction": "S15b main-ACT (build-gated): prove cbrt3_a13 = 3 using sandwich 6193523/4294349 < cbrt3 < 1865358/1293367; then a14=3, a15=4 mirroring the cbrt3_a12 nested-fraction chain (each quotient adds one rung). Gated on Docker return."
 }


### PR DESCRIPTION
## Summary

Build-free Helper-ACT for the ∛3 continued-fraction grind (the only currently-formalizable route to OQ-04 per prior sessions; Lagrange's CF-periodicity bridge is not yet in Mathlib).

Adds the **seventeenth simple-CF convergent** of ∛3 as a lower bound:

```
Cbrt3Helpers.five_nine_four_seven_two_four_two_three_over_four_one_two_three_five_eight_seven_five_lt_cbrt3 :
    (59472423 / 41235875 : ℝ) < cbrt3
```

Even index 16 ⇒ lower bound. Proof is the proven two-line cubing-iff template (17th use on this slug):

```
rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num
```

Exact certificate: `59472423³ = 210_352_122_303_908_768_150_967 < 210_352_122_303_908_806_640_625 = 3·41235875³` (gap `-38_489_658`).

Combined with S22's upper bound `26639450/18470763`, this gives the sandwich `59472423/41235875 < cbrt3 < 26639450/18470763` (gap `≈ 1.3·10⁻¹⁶`), preparing the future `cbrt3_a15 = 4` main-ACT.

## Changes

- `CubeRoot3IrrationalOQ04Helpers.lean`: +17 LOC, +1 theorem (808→825 LOC, 21→22 theorems, still 0 sorry / 0 axiom).
- `verify_cf_convergents.py`: 15th/16th/17th convergents added as regression anchors (all PASS); forward de-risk bumped to the 18th convergent.
- Metadata + knowledge/state notes.

## Status

Build-pending — Docker blackout re-confirmed live this session (`docker info` timeout). The bound follows the identical template already merged 16× on this slug; the Python certificate (`verify_cf_convergents.py`) independently confirms the cube-direction inequality.

## Test plan

- [x] `python3 verify_cf_convergents.py` → all CF/convergent arithmetic verified, including the new 17th-convergent anchor
- [ ] Docker `lake build` once blackout lifts (build-gated)