### PR TITLE
research(four-square-distribution-oq-04): S5 ACT — orbit-size residue in Nat.multinomial form [build-pending]

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04Arrange.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04Arrange.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Four-Square Distribution — OQ-04: the arrangement-count residue in `Nat.multinomial` form
+
+## Context
+
+`FourSquareDistributionOQ04Decomp.lean` reduces the whole open question to one
+orbit-size lemma `fiber_card_eq_contribution`: each `shape`-fiber of the genuine
+representation set has size
+
+  (★)   `m! / ∏_v (count_v)! · 2^{#nonzero}`.
+
+`FourSquareDistributionOQ04Sign.lean` proves the **sign-count half** `2^{#nonzero}`
+in full. The blueprint there splits `(★)` over the coordinatewise absolute-value
+map and isolates the remaining residue as a single combinatorial count — the
+**multiset-arrangement count**
+
+  `arrangement_card`:  `#{ g : Fin m → ℤ | multiset(g) = s } = m! / ∏_v (count_v s)!`.
+
+A build-free Mathlib search (researcher-2, 2026-06-15) found that `Nat.multinomial`
+already *is* `m! / ∏count!` and carries the factored identity `Nat.multinomial_spec`,
+but that there is **no ready cardinality lemma** for multiset arrangements, and
+recommended re-expressing the residue via `Nat.multinomial` so that
+`multinomial_spec` applies directly.
+
+This file executes that recommendation. It:
+
+* **proves** the reformulation bridge `factorial_div_eq_multinomial`:
+  `m! / ∏_v (count_v s)! = Nat.multinomial s.toFinset s.count`
+  (so the `Nat.div` in `shapeContribution` *is* the multinomial coefficient);
+* **proves** `prod_count_factorial_dvd`: `∏_v (count_v s)! ∣ m!`, i.e. that
+  `Nat.div` is exact (no truncation) — a genuine correctness fact about the
+  formula `(★)` used by the parent / sibling files;
+* gives the canonical `Finset` `arrangements s` of multiset arrangements with a
+  clean membership characterization `mem_arrangements_iff`;
+* states `arrangement_card` (the sole remaining residue) in canonical
+  `Nat.multinomial` form, and derives `arrangement_card_div_form` (the `m!/∏count!`
+  shape used by `shapeContribution`) from it via the proved bridge.
+
+Everything except `arrangement_card` is unconditional. The residue is now in the
+exact form `multinomial_spec` consumes, which is the recommended setup for the
+orbit–stabilizer proof (`Equiv.Perm (Fin m)` precomposition; stabilizer of an
+arrangement `g` is `≅ ∏_v Equiv.Perm (g⁻¹ {v})` of order `∏_v (count_v)!`, so
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group` gives
+`|arrangements| · ∏count! = m!`, hence `= multinomial` by `multinomial_spec`).
+
+Build status: PENDING (authored under a Docker + Aristotle backend outage, both
+re-tested live this session: `docker info` daemon down, Aristotle `prove` → 404).
+UNREGISTERED in `Proofs.lean`. Uses only standard `Nat.multinomial` /
+`Fintype.piFinset` / `Multiset` API.
+
+The exact statement of `arrangement_card` is independently certified by
+`research/problems/four-square-distribution-oq-04/verify_orbit_formula.py`
+(`check_arrangement`): the brute multiset-arrangement count equals
+`m! / ∏count!` for all multisets drawn from `{0,1,2}` of size `m ≤ 6`.
+-/
+
+namespace FourSquareDistributionOQ04Arrange
+
+open Finset
+
+/-! ## Part 1: the reformulation bridge `m! / ∏count! = Nat.multinomial`
+
+`Nat.multinomial s f = (∑ i ∈ s, f i)! / ∏ i ∈ s, (f i)!` by definition. Applied to
+`s.toFinset` and `f = s.count`, the sum of the multiplicities is `Multiset.card s`,
+so the multinomial coefficient is exactly the symmetry numerator `m! / ∏count!`. -/
+
+/-- The symmetry numerator of the orbit formula is the multinomial coefficient:
+`m! / ∏_v (count_v s)! = Nat.multinomial s.toFinset s.count`. -/
+theorem factorial_div_eq_multinomial {m : ℕ} (s : Multiset ℤ)
+    (hm : Multiset.card s = m) :
+    m.factorial / (∏ v ∈ s.toFinset, (s.count v).factorial)
+      = Nat.multinomial s.toFinset (fun v => s.count v) := by
+  have hdef : Nat.multinomial s.toFinset (fun v => s.count v)
+      = (∑ v ∈ s.toFinset, s.count v).factorial
+          / ∏ v ∈ s.toFinset, (s.count v).factorial := rfl
+  rw [hdef, Multiset.toFinset_sum_count_eq, hm]
+
+/-- The product of per-value factorials divides `m!`, so the `Nat.div` in the
+orbit formula `(★)` is exact (no truncation). This is the factored identity
+`Nat.multinomial_spec` read as a divisibility. -/
+theorem prod_count_factorial_dvd {m : ℕ} (s : Multiset ℤ)
+    (hm : Multiset.card s = m) :
+    (∏ v ∈ s.toFinset, (s.count v).factorial) ∣ m.factorial := by
+  have hspec : (∏ v ∈ s.toFinset, (s.count v).factorial)
+        * Nat.multinomial s.toFinset (fun v => s.count v)
+      = (∑ v ∈ s.toFinset, s.count v).factorial :=
+    Nat.multinomial_spec _ _
+  rw [Multiset.toFinset_sum_count_eq, hm] at hspec
+  exact ⟨_, hspec.symm⟩
+
+/-! ## Part 2: the multiset-arrangement set and the residual count -/
+
+/-- The arrangements of a multiset `s` as functions `Fin m → ℤ`: all `g` whose
+multiset of values is exactly `s`. Realized as a `Finset` on the finite box
+`(s.toFinset)^m`, which is lossless since every value of an arrangement of `s`
+lies in `s`. -/
+def arrangements {m : ℕ} (s : Multiset ℤ) : Finset (Fin m → ℤ) :=
+  (Fintype.piFinset (fun _ : Fin m => s.toFinset)).filter
+    (fun g => Multiset.map g (Finset.univ : Finset (Fin m)).val = s)
+
+/-- Membership in `arrangements s` is exactly the multiset-image condition; the
+box `(s.toFinset)^m` never clips an arrangement. -/
+theorem mem_arrangements_iff {m : ℕ} (s : Multiset ℤ) (g : Fin m → ℤ) :
+    g ∈ arrangements s ↔ Multiset.map g (Finset.univ : Finset (Fin m)).val = s := by
+  classical
+  simp only [arrangements, Finset.mem_filter, Fintype.mem_piFinset, Multiset.mem_toFinset]
+  constructor
+  · rintro ⟨_, h⟩; exact h
+  · intro h
+    refine ⟨fun i => ?_, h⟩
+    rw [← h]
+    exact Multiset.mem_map_of_mem g (Finset.mem_val.mpr (Finset.mem_univ i))
+
+/-- **The single remaining residue (OPEN / proof target).** The number of
+arrangements of a size-`m` multiset `s` is the multinomial coefficient
+`Nat.multinomial s.toFinset s.count = m! / ∏_v (count_v)!`.
+
+This is the sign-free combinatorial heart of the orbit-size formula. The
+recommended proof is the orbit–stabilizer argument for the `Equiv.Perm (Fin m)`
+action by precomposition: the orbit of an arrangement is all arrangements, and
+its stabilizer `{σ | g ∘ σ = g}` is isomorphic to the product over values `v` of
+`Equiv.Perm (g⁻¹ {v})`, of order `∏_v (count_v s)!`. Then
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group` gives
+`|arrangements s| · ∏count! = m!`, and `Nat.multinomial_spec` rewrites the right
+side, yielding the claim. (The stabilizer-order computation is the genuine
+residue; `Mathlib.Combinatorics.Enumerative.Bell` is the factorial-bookkeeping
+precedent.) -/
+theorem arrangement_card {m : ℕ} (s : Multiset ℤ) (hm : Multiset.card s = m) :
+    (arrangements (m := m) s).card
+      = Nat.multinomial s.toFinset (fun v => s.count v) := by
+  sorry
+
+/-- The arrangement count in the `m! / ∏count!` shape used by `shapeContribution`,
+obtained from `arrangement_card` through the proved reformulation bridge. -/
+theorem arrangement_card_div_form {m : ℕ} (s : Multiset ℤ)
+    (hm : Multiset.card s = m) :
+    (arrangements (m := m) s).card
+      = m.factorial / (∏ v ∈ s.toFinset, (s.count v).factorial) := by
+  rw [arrangement_card s hm, ← factorial_div_eq_multinomial s hm]
+
+#check @factorial_div_eq_multinomial
+#check @prod_count_factorial_dvd
+#check @mem_arrangements_iff
+#check @arrangement_card_div_form
+
+end FourSquareDistributionOQ04Arrange

--- a/research/problems/four-square-distribution-oq-04/verify_orbit_formula.py
+++ b/research/problems/four-square-distribution-oq-04/verify_orbit_formula.py
@@ -11,7 +11,7 @@ sorted multiset of absolute values) and check that each fiber has size
 Also separately confirms the sign-count half (signFiber_card):
     for fixed abs-profile g, #{f : |f i| = g i} = 2^{#{i : g i != 0}}.
 """
-from itertools import product
+from itertools import product, permutations
 from collections import Counter
 from math import factorial, prod
 
@@ -46,6 +46,51 @@ def check_orbit():
     return mismatch == 0
 
 
+def multinomial(toFinset, count):
+    """Nat.multinomial: (sum count)! / prod count!  over the distinct values."""
+    total = sum(count[v] for v in toFinset)
+    return factorial(total) // prod(factorial(count[v]) for v in toFinset)
+
+
+def check_arrangement():
+    """Validate the isolated residue `arrangement_card` of
+    FourSquareDistributionOQ04Arrange.lean:
+
+        #{ g : Fin m -> Z | multiset(g) = s } == Nat.multinomial s.toFinset s.count
+                                              == m! / prod_v (count_v)!.
+
+    For every multiset s drawn (with repetition) from {0,1,2} of size m <= 6, count
+    the genuine arrangements (functions whose multiset image is s) by brute force and
+    compare to BOTH the multinomial coefficient and the m!/prod count! divisor form.
+    Also confirms prod count! | m! (the Nat.div in shapeContribution is exact).
+    """
+    mismatch = checked = 0
+    values = (0, 1, 2)
+    for m in range(0, 7):
+        seen = set()
+        for combo in product(values, repeat=m):
+            s = tuple(sorted(combo))            # the multiset, as a sorted tuple
+            if s in seen:
+                continue
+            seen.add(s)
+            cnt = Counter(s)
+            toFinset = set(cnt)                 # s.toFinset
+            # genuine arrangement count: distinct orderings of the multiset s
+            actual = len(set(permutations(s)))
+            mult = multinomial(toFinset, cnt)
+            div_form = factorial(m) // prod(factorial(k) for k in cnt.values())
+            checked += 1
+            # divisibility: Nat.div is exact
+            exact = factorial(m) % prod(factorial(k) for k in cnt.values()) == 0
+            if not (actual == mult == div_form and exact):
+                mismatch += 1
+                print(f"  ARRANGE MISMATCH m={m} s={s} actual={actual} "
+                      f"multinomial={mult} divform={div_form} exact={exact}")
+    print(f"(arrange) checked {checked} multisets (values in {{0,1,2}}, m<=6), "
+          f"mismatches={mismatch}")
+    return mismatch == 0
+
+
 def check_sign():
     mismatch = checked = 0
     for m in range(1, 6):
@@ -62,6 +107,6 @@ def check_sign():
 
 
 if __name__ == "__main__":
-    ok = check_orbit() and check_sign()
+    ok = check_orbit() and check_sign() and check_arrangement()
     print("RESULT:", "PASS" if ok else "FAIL")
     raise SystemExit(0 if ok else 1)

--- a/src/data/research/problems/four-square-distribution-oq-04.json
+++ b/src/data/research/problems/four-square-distribution-oq-04.json
@@ -26,25 +26,26 @@
     "goal": "Formalize the orbit-stabilizer decomposition for r_{2k}(n) (at least fixed 2k in {4,6,8}): define the signed-permutation action, prove orbit size = 2^{#nonzero}*(2k)!/prod m_i!, and recover the total as a sum over shapes."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-06-15T07:05:00.000Z",
-    "iteration": 2,
-    "focus": "Generalization CONFIRMED for 2k in {2,4,6,8}: orbit size 2^{#nonzero}*(2k)!/prod m_i!, stabilizer 2^z*z!*prod(nonzero m_j!), r_{2k}=sum_shapes orbit. Mathlib orbit-stabilizer bearer pinned; B_{2k} has no Mathlib name (must be assembled).",
+    "iteration": 3,
+    "focus": "S5 ACT (build-pending; triple blackout re-tested live): re-expressed the orbit-size residue via Nat.multinomial per researcher-2's recommendation. New FourSquareDistributionOQ04Arrange.lean PROVES factorial_div_eq_multinomial (m!/prod count! = Nat.multinomial), prod_count_factorial_dvd (Nat.div is exact), mem_arrangements_iff; ISOLATES arrangement_card (the sole residue) in canonical multinomial form with the Equiv.Perm orbit-stabilizer route; DERIVES arrangement_card_div_form. Cert verify_orbit_formula.py check_arrangement PASS (84 multisets).",
     "blockers": [
-      "Lean ACT Docker-gated (build + Aristotle both down this session).",
-      "B_{2k} (signed permutations) absent from Mathlib by name."
+      "Lean ACT Docker-gated (docker info daemon down; Aristotle prove -> 404; no local Mathlib to grep this session).",
+      "arrangement_card (the multiset-arrangement count = multinomial) is the sole remaining sorry; B_{2k} signed permutations absent from Mathlib by name."
     ],
-    "nextAction": "ACT (next Docker session): fixed m=2k in {4,6,8}; define B_m MulAction on {f:Fin m -> Z // sum f^2 = n}, compute stabilizer (zero/nonzero split), apply MulAction.card_orbit_mul_card_stabilizer_eq_card_group. Real obstruction = orbit partition.",
+    "nextAction": "ACT (next Docker session): (1) build+register Arrange/Sign/Decomp; (2) prove arrangement_card via Equiv.Perm (Fin m) precomposition orbit-stabilizer (stabilizer = prod Perm of fibers, order prod count!) + multinomial_spec; (3) assemble fiber_card_eq_contribution from arrangement_card_div_form x signFiber_card via card_eq_sum_card_fiberwise over absMap, discharging Decomp.lean's lone sorry.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     },
-    "lastUpdate": "2026-06-15T07:05:00.000Z"
+    "lastUpdate": "2026-06-15T13:05:00.000Z"
   },
   "knowledge": {
     "progressSummary": "ORIENT: answered the seeker's generalization question YES. The four-square orbit-stabilizer type-decomposition extends verbatim to r_{2k}(n) under B_{2k}=S_{2k} semidirect (Z/2)^{2k}: orbit(shape with z zeros, multiplicities m_i)=2^{2k-z}*(2k)!/prod m_i!, stabilizer=2^z*z!*prod(nonzero m_j!), r_{2k}(n)=sum over shapes orbit. Verified exactly for 2k in {2,4,6,8}. Lean ACT Docker-gated. S2 (ACT, build-pending): formalized the 2k=6 case mirroring the parent's COMPUTATIONAL route (not MulAction). New proofs/Proofs/FourSquareDistributionOQ04.lean: RepType6 (sorted six-tuple) + contribution=(720/prod count!)*2^nonzero, concrete shapes for n in {1,2,3,5,6,12,30} with contributions by native_decide and r_6(n) totals as sum of contributions (r6_5=312,r6_6=544,r6_12=2080,r6_30=14144) + nonzeroCount_le_six/signFactor_le_64. Executes the 'fixed small m' ACT at m=6. Cert verify_r6_decomposition.py PASS (exhaustive shapes; orbit formula vs brute signed-ordering count; totals vs convolution).",
     "builtItems": [
+      "proofs/Proofs/FourSquareDistributionOQ04Arrange.lean (S5, build-pending/UNREGISTERED) — re-expresses the orbit-size residue via Nat.multinomial: PROVES factorial_div_eq_multinomial (m!/prod count! = Nat.multinomial s.toFinset s.count), prod_count_factorial_dvd (prod count! | m!, so the Nat.div in (star) is exact), mem_arrangements_iff; ISOLATES arrangement_card (the sole sorry, canonical multinomial form) with the Equiv.Perm (Fin m) orbit-stabilizer route documented; DERIVES arrangement_card_div_form. Cert check_arrangement PASS.",
       "proofs/Proofs/FourSquareDistributionOQ04.lean (S2, build-pending/UNREGISTERED) — 2k=6 type-decomposition: RepType6, the (star) orbit formula, native_decide contributions + r_6(n) totals for n in {1,2,3,5,6,12,30}, structural bounds.",
       "research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py (S2) — pins the exact embedded shapes/contributions/totals via exhaustive enumeration + independent brute signed-ordering count + signed-square convolution.",
       "research/problems/four-square-distribution-oq-04/verify_hyperoctahedral_2k.py - stdlib exact verifier: orbit-size formula vs independent brute signed-ordering count; orbit*stab=|B_{2k}| (orbit-stabilizer); sum_shapes orbit == r_{2k}(n) (independent convolution) for 2k in {2,4,6,8}; anchors r_2=4(d1-d3), r_4=8 sigma*. All checks PASS."


### PR DESCRIPTION
## Summary

The open question reduces (in `FourSquareDistributionOQ04Decomp.lean`) to one
orbit-size keystone `fiber_card_eq_contribution`, i.e. each shape-fiber has size
`(★) = m!/∏_v(count_v)! · 2^{#nonzero}`. `…Sign.lean` already proves the
`2^{#nonzero}` half. The remaining residue is the **sign-free multiset-arrangement
count** `m!/∏count!`. A prior build-free Mathlib search (researcher-2) recommended
re-expressing this via `Nat.multinomial` so that `Nat.multinomial_spec` applies
directly. This PR executes that recommendation.

New `proofs/Proofs/FourSquareDistributionOQ04Arrange.lean`:

- **PROVED** `factorial_div_eq_multinomial`: `m!/∏_v(count_v)! = Nat.multinomial s.toFinset s.count` — `shapeContribution`'s numerator *is* the multinomial coefficient.
- **PROVED** `prod_count_factorial_dvd`: `∏_v(count_v)! ∣ m!` via `Nat.multinomial_spec`, so the `Nat.div` in `(★)` is exact (no truncation) — a genuine correctness fact about the existing formula.
- **PROVED** `mem_arrangements_iff` — the box `(s.toFinset)^m` is lossless.
- **ISOLATED** `arrangement_card` as the sole `sorry`, now in the canonical form `multinomial_spec` consumes, with the `Equiv.Perm (Fin m)` precomposition orbit–stabilizer route documented (stabilizer `≅ ∏_v Equiv.Perm (g⁻¹{v})`, order `∏count!`).
- **DERIVED** `arrangement_card_div_form` from it via the bridge.

## Certificate

`verify_orbit_formula.py` gains `check_arrangement`: the brute multiset-arrangement
count equals `Nat.multinomial` equals `m!/∏count!`, and `∏count! ∣ m!`, for every
multiset drawn from `{0,1,2}` of size `m ≤ 6` (84 multisets, 0 mismatches). Full
run: orbit (58 fibers) + sign (3905 profiles) + arrange (84) all PASS.

## Honest scope

Incremental. Everything except `arrangement_card` is unconditional; the open
surface is now the pure multinomial cardinality in the exact form needed for the
orbit–stabilizer proof. **Build-pending**: triple blackout re-tested live this
session (`docker info` daemon down, Aristotle `prove` → 404, no local Mathlib to
grep). UNREGISTERED in `Proofs.lean`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04Arrange` (next Docker session)
- [x] `python3 research/problems/four-square-distribution-oq-04/verify_orbit_formula.py` → RESULT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)