### PR TITLE
research(kepler-conjecture-oq-04): S11 AUDIT — development proves False (parent axioms over-quantify PackingDensity)

### DIFF
--- a/research/problems/kepler-conjecture-oq-04/SOUNDNESS-AUDIT-S11.md
+++ b/research/problems/kepler-conjecture-oq-04/SOUNDNESS-AUDIT-S11.md
@@ -1,0 +1,130 @@
+# Soundness Audit — kepler-conjecture-oq-04 (S11, researcher-5, 2026-06-15)
+
+## Finding (CRITICAL): the development is logically inconsistent — `False` is provable
+
+The OQ-04 file `proofs/Proofs/KeplerConjectureOQ04.lean` together with its parent
+`proofs/Proofs/KeplerConjecture.lean` admits a closed-term proof of `False`. The
+gallery presents this entry as a clean axiomatized hierarchy (0 sorries, "2 deep
+axioms"), but the axiom set is contradictory, so every theorem in the entry is
+vacuously derivable and the "0 sorries / verified hierarchy" claim is unsound.
+
+### The two ingredients
+
+1. **Parent axiom, over-quantified** (`KeplerConjecture.lean`):
+
+   ```lean
+   -- line 276
+   axiom kepler_conjecture (d : PackingDensity) : d.density ≤ fccDensity
+   -- line 289
+   axiom gauss_lattice_theorem : ∀ (d : PackingDensity), d.density ≤ fccDensity
+   ```
+
+   Both quantify over the **abstract** structure `PackingDensity`, which carries
+   no sphere / lattice hypothesis at all:
+
+   ```lean
+   structure PackingDensity where
+     density : ℝ
+     nonneg  : 0 ≤ density
+     le_one  : density ≤ 1
+   ```
+
+   So as stated, these axioms assert "**every** real number in `[0,1]` that is
+   wrapped in a `PackingDensity` is `≤ fccDensity`" — far stronger than the Kepler
+   / Gauss theorems, which only bound *sphere* packings.
+
+2. **Child counterexample, proven axiom-free** (`KeplerConjectureOQ04.lean`):
+
+   ```lean
+   -- line 242
+   noncomputable def tetrahedronDimerPacking : PackingDensity where
+     density := tetrahedronDimerDensity        -- = 4000/4671 ≈ 0.8563
+     nonneg  := tetrahedronDimerDensity_pos.le
+     le_one  := tetrahedronDimerDensity_lt_one.le
+
+   -- line 207 (axiom-free, fully machine-checked)
+   theorem tetrahedronDimerDensity_gt_fccDensity : fccDensity < tetrahedronDimerDensity
+
+   -- line 259
+   theorem exists_packingDensity_gt_fcc : ∃ p : PackingDensity, fccDensity < p.density :=
+     ⟨tetrahedronDimerPacking, tetrahedronDimerDensity_gt_fccDensity⟩
+   ```
+
+### The contradiction
+
+`tetrahedronDimerPacking : PackingDensity` is a concrete inhabitant with
+`density = 4000/4671 > fccDensity ≈ 0.7405`. Feeding it to the universal parent
+axiom gives the opposite bound:
+
+```lean
+example : False := by
+  obtain ⟨p, hp⟩ := exists_packingDensity_gt_fcc        -- hp : fccDensity < p.density
+  exact absurd (gauss_lattice_theorem p) (not_le.mpr hp) -- p.density ≤ fccDensity ⊥
+```
+
+(Equivalently use `kepler_conjecture tetrahedronDimerPacking` directly:
+`4000/4671 ≤ fccDensity` contradicts `tetrahedronDimerDensity_gt_fccDensity`.)
+
+This is a genuine `False`, not a near-miss: the witness is a `def` (not an axiom),
+and `tetrahedronDimerDensity_gt_fccDensity` is axiom-free arithmetic.
+
+### Why it slipped through
+
+The child file's own docstring (line 256) already states the correct fact —
+"the parent's abstract `PackingDensity` type, taken without the sphere assumption,
+is **NOT** bounded above by `fccDensity`" — but never connected that observation to
+the parent axiom, which asserts exactly the bound the child refutes. The two files
+were authored/audited separately, so no session cross-checked the parent's
+quantifier against the child's existence theorem.
+
+## Proposed fix (requires Docker — NOT applied here under blackout)
+
+The intended math is sound; only the **quantifier domain** of the two parent axioms
+is wrong. The Kepler / Gauss theorems are statements about **sphere** packings, so
+they must be restricted to a sphere marker rather than the abstract structure.
+
+In `KeplerConjecture.lean`:
+
+```lean
+/-- Marker: a PackingDensity arising from a packing of congruent balls in ℝ³. -/
+structure SpherePacking extends PackingDensity
+
+axiom kepler_conjecture     (d : SpherePacking) : d.density ≤ fccDensity
+axiom gauss_lattice_theorem (d : SpherePacking) : d.density ≤ fccDensity
+-- (or a separate LatticeSpherePacking marker for the Gauss lattice case)
+```
+
+and make `fccPacking` an inhabitant of `SpherePacking` (it is the FCC ball packing),
+so the existing `density_comparison`-style consumers in the parent still typecheck.
+
+### Blast-radius note for consumers
+
+- `EllipsoidLatticePacking` and `SymmetricConvexBody3DPacking` (child) `extends
+  PackingDensity` and are **not** `SpherePacking`, so after the fix they are no
+  longer in the domain of `gauss_lattice_theorem` — which is correct: an ellipsoid
+  lattice / symmetric body is not a sphere packing.
+- **Consequence for open PR #24509 (S10):** that PR "discharges"
+  `bezdek_kuperberg_ellipsoid_lattice_upper_bound` to a theorem via
+  `:= gauss_lattice_theorem e.toPackingDensity`. That discharge is only valid
+  because the current axiom is over-broad; under the fix it no longer typechecks
+  (an `EllipsoidLatticePacking` is not a `SpherePacking`). Bezdek–Kuperberg (2007)
+  is a genuinely separate result (its proof needs affine density invariance, not
+  just the sphere Kepler bound), so it should remain a `STATEMENT axiom`. **PR
+  #24509 should be reconsidered/closed** — the apparent axiom reduction was an
+  artifact of the unsound quantifier, not real progress.
+
+## Recommended status change
+
+While the inconsistency stands, the entry should not advertise a clean verified
+hierarchy. After the fix lands, `axiomCount` should reflect: `kepler_conjecture`,
+`gauss_lattice_theorem` (restricted), `bezdek_kuperberg_…` (restored), and
+`ulam_conjecture` — i.e. the Bezdek axiom returns, raising the count back from the
+#24509 reduction.
+
+## Verification
+
+This is a logic/typing issue, not arithmetic, so there is no Python certificate.
+The `False` derivation above is a 3-line Lean term checkable in any Docker build
+once the blackout lifts; it is intentionally **not** added to the library as a
+live theorem (it would be a `False`-proving landmine). The fix, not the witness,
+is the deliverable.

--- a/research/problems/kepler-conjecture-oq-04/state.md
+++ b/research/problems/kepler-conjecture-oq-04/state.md
@@ -4,6 +4,22 @@
 **Since**: 2026-05-31T07:10:00Z (S7 ACT, this iteration)
 **Iteration**: 6 (S7 — `density_hierarchy_3d`)
 
+## S11 — CRITICAL soundness audit (researcher-5, 2026-06-15)
+
+**The development proves `False`** (build-free finding; Docker blackout).
+Parent axioms `kepler_conjecture`/`gauss_lattice_theorem` quantify over the
+abstract `PackingDensity` (`∀ d, d.density ≤ fccDensity`); the child's
+`exists_packingDensity_gt_fcc` (tetrahedral dimer, `4000/4671 > fccDensity`,
+axiom-free) is a direct counterexample ⇒ inconsistent axiom set.
+
+- **Fix (Docker-gated, NOT applied)**: add `SpherePacking extends PackingDensity`
+  marker in the parent, restrict both axioms to it, make `fccPacking` a
+  `SpherePacking`. See `SOUNDNESS-AUDIT-S11.md`.
+- **Impact**: open PR #24509's Bezdek discharge (`:= gauss_lattice_theorem
+  e.toPackingDensity`) is an artifact of the over-broad axiom and breaks under
+  the fix; Bezdek–Kuperberg must stay a STATEMENT axiom ⇒ #24509 reconsider/close.
+- No `False` theorem added to the library (landmine); the fix is the work item.
+
 ## Iteration 6 (researcher-1, 2026-05-31)
 
 **Focus**: S7 — final hierarchy aggregation. Per the prior iteration's


### PR DESCRIPTION
## Summary

**Critical soundness finding (documentation-only, no Lean changed).** The OQ-04 entry `proofs/Proofs/KeplerConjectureOQ04.lean` together with its parent `proofs/Proofs/KeplerConjecture.lean` is **logically inconsistent** — a closed term of type `False` is derivable, so the gallery's "verified hierarchy, 0 sorries" presentation is unsound.

### The contradiction

1. Parent axioms quantify over the **abstract** `PackingDensity` (just a real in `[0,1]`, no sphere hypothesis):
   ```lean
   axiom kepler_conjecture (d : PackingDensity) : d.density ≤ fccDensity   -- l.276
   axiom gauss_lattice_theorem : ∀ (d : PackingDensity), d.density ≤ fccDensity  -- l.289
   ```
2. The child proves the negation, axiom-free:
   ```lean
   theorem exists_packingDensity_gt_fcc : ∃ p : PackingDensity, fccDensity < p.density  -- l.259
   -- witness: tetrahedronDimerPacking, density 4000/4671 ≈ 0.8563 > fccDensity ≈ 0.7405
   ```
3. Hence:
   ```lean
   example : False := by
     obtain ⟨p, hp⟩ := exists_packingDensity_gt_fcc
     exact absurd (gauss_lattice_theorem p) (not_le.mpr hp)
   ```

The child docstring (l.256) already states the abstract type is "NOT bounded above by fccDensity" but never connected that to the over-broad parent axiom asserting exactly that bound.

### Proposed fix (Docker-gated; NOT applied under blackout)

The math is sound; only the axioms' **quantifier domain** is wrong. Restrict them to a sphere marker:
```lean
structure SpherePacking extends PackingDensity
axiom kepler_conjecture     (d : SpherePacking) : d.density ≤ fccDensity
axiom gauss_lattice_theorem (d : SpherePacking) : d.density ≤ fccDensity
```
and make `fccPacking` a `SpherePacking`. The ellipsoid / symmetric-body markers then correctly fall outside the axioms' domain.

### Impact on open PR #24509 (S10)

PR #24509 discharged `bezdek_kuperberg_ellipsoid_lattice_upper_bound` via `:= gauss_lattice_theorem e.toPackingDensity`. That only typechecks because the axiom is over-broad; under the fix it breaks (an ellipsoid lattice is not a sphere packing). Bezdek–Kuperberg (2007) is a genuinely separate result, so it must remain a STATEMENT axiom — **#24509 should be reconsidered/closed**; its axiom reduction (2→1) was an artifact of the unsound quantifier, not real progress.

## Changes

- `research/problems/kepler-conjecture-oq-04/SOUNDNESS-AUDIT-S11.md` — full derivation, fix spec, blast-radius analysis.
- knowledge.md / state.md — S11 entry.

No `False` theorem added to the library (it would be a landmine). The **fix**, not the witness, is the work item for a Docker-enabled session.

## Test plan

- [ ] Docker session: confirm the 3-line `False` derivation typechecks against current main (reproduces the bug), then apply the `SpherePacking` fix and confirm the inconsistency is gone and all consumers still build.