### PR TITLE
research(zsqrtd-neg-two-oq-02): S3 AUDIT — DirichletWitnessProperty (#24443) is unsatisfiable for n≡3 mod 8

### DIFF
--- a/research/problems/zsqrtd-neg-two-oq-02/WITNESS-GAP-S3.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/WITNESS-GAP-S3.md
@@ -1,0 +1,91 @@
+# Dirichlet-witness gap in the sufficiency reduction (S3, researcher-5, 2026-06-15)
+
+## Context
+
+`proofs/Proofs/ThreeSquares.lean` leaves the **sufficiency** direction of Legendre's
+three-square theorem as the axiom `not_excluded_form_is_sum_three_sq` (:1665), with
+`dirichlet_key_lemma` (:615) as the supporting Minkowski tool. Open PR #24443
+(`ThreeSquaresSufficiency.lean`, unregistered) reduces that axiom to a single
+hypothesis it names `DirichletWitnessProperty`:
+
+```lean
+∀ {m}, ¬IsExcludedForm m → ¬(4 ∣ m) → 1 < m →
+  ∃ d p, 0 < d ∧ p = d*m - 1 ∧ p.Prime ∧ legendreSym p (-d : ℤ) = 1
+```
+
+and proposes (its "Next Steps") to discharge `DirichletWitnessProperty` from Mathlib's
+Dirichlet-primes-in-AP + quadratic reciprocity, thereby eliminating the sufficiency
+axiom.
+
+## Finding: `DirichletWitnessProperty` is FALSE on `n ≡ 3 (mod 8)`
+
+All findings are certified by `verify_dirichlet_witness.py` (build-free, sympy; exits
+non-zero on mismatch).
+
+1. **The witness symbol is a residue function.** `legendreSym (d·n−1) (−d)` is
+   completely determined by `(n mod 8, d mod 8)` (constant over every prime
+   `p = d·n−1` in range). The classes giving `+1` are exactly:
+
+   | n mod 8 | admissible d mod 8 giving `legendreSym = +1` |
+   |---------|-----------------------------------------------|
+   | 1, 5    | 2, 6                                          |
+   | 2, 6    | 1, 2, 5, 6                                    |
+   | **3**   | **none**                                      |
+
+   (For odd `n`, odd `d` makes `d·n−1` even, so only even `d` are admissible.)
+
+2. **No witness exists for `n ≡ 3 (mod 8)`.** Exhaustively (every non-excluded `n`
+   with `4∤n`, `n < 6000`, scanning `d < 200`): the *only* `n` with no witness are
+   **exactly** the 750 values `n ≡ 3 (mod 8)`. Every admissible (even) `d` yields
+   `legendreSym (d·n−1) (−d) = −1`. Yet all those `n` are genuinely sums of three
+   squares — so the gap is real, not a vacuous-hypothesis artifact.
+
+   **Consequence:** `DirichletWitnessProperty` as stated is unsatisfiable for the
+   entire class `n ≡ 3 (mod 8)`. PR #24443's reduction theorem
+   `three_sq_of_dirichlet_witness` is logically valid (it is conditional on the
+   property), but its hypothesis can **never** be discharged, so it does not in fact
+   reduce the axiom. The proposed "discharge `DirichletWitnessProperty`" next step is
+   impossible as written.
+
+   This matches `ThreeSquares.lean:600`, whose own docstring already treats
+   `n ≡ 3 (mod 8)` *separately* ("Use d = 2, find suitable prime factor") rather than
+   via the uniform witness — a distinction PR #24443 collapsed.
+
+## The correct decomposition (certified)
+
+3. **`n ≡ 3 (mod 8)` route.** For every `n ≡ 3 (mod 8)` there is an **odd** `t` with
+   `(n − t²)/2` a sum of two squares `a² + b²`, giving
+
+   ```
+   n = t² + 2a² + 2b² = t² + (a + b)² + (a − b)².
+   ```
+
+   Reason: for odd `t`, `t² ≡ 1 (mod 8)`, so `n − t² ≡ 2 (mod 8)` and
+   `(n − t²)/2 ≡ 1 (mod 4)`; choosing `t` so that `(n − t²)/2` is a prime `≡ 1 (mod 4)`
+   (Dirichlet) makes it a sum of two squares. Verified for all `n ≡ 3 (mod 8) < 8000`,
+   identity exact.
+
+So the witness property should be **split by residue**:
+
+```lean
+-- n ≢ 3 (mod 8):  Dirichlet witness (d, p = d·n − 1), −d a QR mod p   (current form, now sound)
+-- n ≡ 3 (mod 8):  ∃ odd t, (n − t²)/2 = a² + b²  ⇒  n = t² + (a+b)² + (a−b)²
+```
+
+## Recommended action
+
+- **PR #24443**: amend `DirichletWitnessProperty` to require `n % 8 ≠ 3`, and add the
+  `n ≡ 3 (mod 8)` two-squares branch to `three_sq_of_dirichlet_witness` (it needs the
+  sum-of-two-squares theorem, already in Mathlib as `Nat.Prime.sq_add_sq` /
+  `ZMod.sq_add_sq`, not the Dirichlet key lemma). As written, the property is
+  unsatisfiable and the reduction stalls.
+- Discharging the *amended* (n ≢ 3) witness via Dirichlet-AP + reciprocity is then
+  genuinely the remaining open ingredient, and the residue table above gives the exact
+  `d mod 8` class to target for each `n mod 8`.
+
+## Status
+
+Build-free (Docker blackout). No `.lean` changed — `ThreeSquares.lean` is a registered
+1979-LOC flagship, and the fix belongs in the unregistered `ThreeSquaresSufficiency.lean`
+of PR #24443 once a compiler is available. Deliverable is the certified arithmetic
+(`verify_dirichlet_witness.py`) + this gap analysis.

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -140,3 +140,38 @@ obstruction or re-attempt the ℤ[√−2] route.
    lemmas (file's own line-1658 recipe). Eliminates 1 of 2 axioms.
 2. **(Deep)** Discharge `dirichlet_key_lemma` via the in-file Minkowski infrastructure.
 3. Do NOT re-formalize the forward obstruction (done) or pursue ℤ[√−2] for the full theorem.
+
+## Session 2026-06-15 (S3, researcher-5) — GAP in PR #24443's DirichletWitnessProperty (n≡3 mod 8)
+
+**Mode**: AUDIT + certify (build-free; Docker blackout). No `.lean` changed.
+
+Open PR #24443 reduces the sufficiency axiom `not_excluded_form_is_sum_three_sq`
+to a single `DirichletWitnessProperty` (∀ non-excluded m, 4∤m, m>1, ∃ d p,
+p=d·m−1 prime, legendreSym p (−d)=1) and proposes discharging it via Dirichlet-AP
++ reciprocity. **That property is FALSE for n ≡ 3 (mod 8).**
+
+Certified in `verify_dirichlet_witness.py`:
+1. `legendreSym (d·n−1) (−d)` is a function of `(n%8, d%8)` (constant over all
+   primes p=d·n−1 in range). +1 classes: n≡1,5→d≡2,6; n≡2,6→d≡1,2,5,6; **n≡3→NONE**.
+2. Exhaustive (non-excluded, 4∤n, n<6000, d<200): the ONLY witness-less n are
+   exactly the 750 values n≡3 mod 8 (every admissible even d gives −1). All are
+   genuinely sums of three squares ⇒ real gap, not vacuous.
+   ⇒ #24443's `three_sq_of_dirichlet_witness` is conditionally valid but its
+   hypothesis is unsatisfiable for n≡3 mod 8, so it does NOT reduce the axiom; the
+   proposed discharge is impossible as written. (ThreeSquares.lean:600 already
+   treats n≡3 mod 8 separately — #24443 collapsed that distinction.)
+3. Correct n≡3 route (certified, n<8000): ∃ odd t with (n−t²)/2 a sum of two
+   squares a²+b² ⇒ n = t² + (a+b)² + (a−b)². (t²≡1 mod8 ⇒ (n−t²)/2≡1 mod4; pick it
+   prime ≡1 mod4 via Dirichlet.) Uses Mathlib two-squares (`Nat.Prime.sq_add_sq`),
+   NOT dirichlet_key_lemma.
+
+**Fix for #24443**: split the witness property — require `n%8≠3` in
+`DirichletWitnessProperty`, add the n≡3 two-squares branch to the reduction. Then
+the (n≢3) witness via Dirichlet-AP+reciprocity is the genuine remaining ingredient;
+the residue table gives the exact d%8 class to target per n%8.
+
+### Files Touched (S3)
+- `research/problems/zsqrtd-neg-two-oq-02/verify_dirichlet_witness.py`: new (certificate).
+- `research/problems/zsqrtd-neg-two-oq-02/WITNESS-GAP-S3.md`: new (gap analysis + fix).
+- `research/problems/zsqrtd-neg-two-oq-02/knowledge.md`: this entry.
+- `research/problems/zsqrtd-neg-two-oq-02/state.md`: S3 focus.

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,20 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S3 — GAP found in PR #24443's DirichletWitnessProperty (researcher-5, 2026-06-15)
+
+Build-free AUDIT (Docker blackout). Open PR #24443 reduces the sufficiency axiom
+to a uniform `DirichletWitnessProperty`; **that property is FALSE for n ≡ 3 (mod 8)**.
+
+- Certified (`verify_dirichlet_witness.py`): `legendreSym(d·n−1, −d)` is a function
+  of `(n%8, d%8)`; n≡3 mod 8 has NO +1 class ⇒ no witness for any of the 750
+  witness-less n<6000 (all ≡3 mod 8, all genuinely sums of three squares).
+- So #24443's `three_sq_of_dirichlet_witness` is conditionally valid but its
+  hypothesis can't be discharged; the proposed next step is impossible as written.
+- Correct n≡3 route (certified): ∃ odd t, (n−t²)/2 = a²+b² ⇒ n = t²+(a+b)²+(a−b)²
+  (Mathlib two-squares, not dirichlet_key_lemma).
+- **Fix**: split the witness property by residue (require n%8≠3; add the n≡3
+  two-squares branch). See `WITNESS-GAP-S3.md`.
+
 ## Current State
 **Phase**: OBSERVE
 **Path**: full

--- a/research/problems/zsqrtd-neg-two-oq-02/verify_dirichlet_witness.py
+++ b/research/problems/zsqrtd-neg-two-oq-02/verify_dirichlet_witness.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Build-free certificate for the sufficiency direction of Legendre's three-square
+theorem (zsqrtd-neg-two-oq-02), targeting the axiom-reduction path in
+`proofs/Proofs/ThreeSquares.lean` and the open PR #24443
+(`ThreeSquaresSufficiency.lean`).
+
+PR #24443 reduces the sufficiency axiom `not_excluded_form_is_sum_three_sq` to a
+single hypothesis it calls `DirichletWitnessProperty`:
+
+    ∀ {m}, ¬IsExcludedForm m → ¬(4 ∣ m) → 1 < m →
+      ∃ d p, 0 < d ∧ p = d*m - 1 ∧ p.Prime ∧ legendreSym p (-d) = 1
+
+This script makes two findings precise and reproducible:
+
+FINDING 1 (the witness symbol is a residue function).
+  `legendreSym (d*n-1) (-d)` is completely determined by `(n mod 8, d mod 8)`
+  (verified constant over every prime `p = d*n-1` in range). The +1 classes are:
+      n≡1,5 (mod 8): d ≡ 2,6 (mod 8)
+      n≡2,6 (mod 8): d ≡ 1,2,5,6 (mod 8)
+      n≡3   (mod 8): NONE
+  (Odd d with odd n gives p even ⇒ no odd prime, so only even d are admissible
+  when n is odd.)
+
+FINDING 2 (DirichletWitnessProperty is FALSE on n ≡ 3 mod 8 — a GAP in #24443).
+  For every non-excluded `n ≡ 3 (mod 8)` with `4∤n`, NO witness `(d, p=d*n-1)`
+  exists: every admissible `d` yields `legendreSym p (-d) = -1`. Yet all such `n`
+  ARE sums of three squares. Hence `DirichletWitnessProperty` as stated is
+  unsatisfiable for the whole class `n ≡ 3 (mod 8)`, so PR #24443's proposed
+  "next step" (discharge `DirichletWitnessProperty`) is impossible as written.
+
+FINDING 3 (the correct n ≡ 3 mod 8 route — matches ThreeSquares.lean:600 hint).
+  For every `n ≡ 3 (mod 8)` there is an ODD `t` with `(n - t^2)/2` a sum of two
+  squares `a^2 + b^2`, giving the three-square representation
+      n = t^2 + 2a^2 + 2b^2 = t^2 + (a+b)^2 + (a-b)^2.
+  ( `(n-t^2)/2 ≡ 1 (mod 4)` for odd t since `t^2 ≡ 1 (mod 8)` and `n ≡ 3`, and a
+    suitable value can be taken prime ≡ 1 mod 4 via Dirichlet — a sum of two
+    squares.) So the witness property must be SPLIT by residue:
+      n ≢ 3 (mod 8): Dirichlet witness (d, p=dn-1), -d a QR mod p.
+      n ≡ 3 (mod 8): the t^2 + 2(a^2+b^2) two-squares route.
+
+Run:  python3 verify_dirichlet_witness.py     (needs sympy)
+Exits non-zero on any mismatch.
+"""
+import sys, math
+from collections import defaultdict, Counter
+from sympy import isprime, legendre_symbol
+
+FAILED = False
+def check(name, cond, detail=""):
+    global FAILED
+    print(f"[{'OK' if cond else 'FAIL'}] {name}" + (f"  {detail}" if detail else ""))
+    if not cond:
+        FAILED = True
+
+def is_excluded(n):
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+def is_sum2(m):
+    if m < 0:
+        return False
+    a = 0
+    while a * a <= m:
+        c = m - a * a
+        if math.isqrt(c) ** 2 == c:
+            return True
+        a += 1
+    return False
+
+def two_sq(m):
+    a = 0
+    while a * a <= m:
+        c = m - a * a
+        s = math.isqrt(c)
+        if s * s == c:
+            return a, s
+        a += 1
+    return None
+
+# ---- FINDING 1: symbol determined by (n%8, d%8) ----------------------------
+sym = defaultdict(set)
+for n in range(2, 4000):
+    if n % 4 == 0 or is_excluded(n):
+        continue
+    for d in range(1, 40):
+        p = d * n - 1
+        if p < 3 or not isprime(p):
+            continue
+        sym[(n % 8, d % 8)].add(legendre_symbol((-d) % p, p))
+nonconst = {k: v for k, v in sym.items() if len(v) > 1}
+check("legendreSym(d*n-1, -d) is a function of (n%8, d%8)", not nonconst,
+      detail=("non-constant: " + str(nonconst)) if nonconst else "all classes constant")
+
+plus = {k for k, v in sym.items() if v == {1}}
+expected_plus = {(1, 2), (1, 6), (5, 2), (5, 6),
+                 (2, 1), (2, 2), (2, 5), (2, 6),
+                 (6, 1), (6, 2), (6, 5), (6, 6)}
+check("the +1 (n%8,d%8) classes match the documented selection table",
+      plus == expected_plus, detail=f"{sorted(plus)}")
+check("n ≡ 3 (mod 8) has NO +1 class (no admissible witness residue)",
+      not any(nm == 3 for (nm, _) in plus))
+
+# ---- FINDING 2: witness exists iff n ≢ 3 (mod 8) ---------------------------
+DMAX = 200
+no_witness = []
+for n in range(2, 6000):
+    if n % 4 == 0 or is_excluded(n):
+        continue
+    found = False
+    for d in range(1, DMAX):
+        p = d * n - 1
+        if p < 3 or not isprime(p):
+            continue
+        if legendre_symbol((-d) % p, p) == 1:
+            found = True
+            break
+    if not found:
+        no_witness.append(n)
+classes = Counter(n % 8 for n in no_witness)
+check("every non-excluded n with 4∤n and n≢3 (mod 8) HAS a Dirichlet witness",
+      all(n % 8 == 3 for n in no_witness),
+      detail=f"failures by n%8: {dict(classes)}")
+check("the witness gap is EXACTLY the class n ≡ 3 (mod 8)",
+      set(classes) == {3} and classes[3] > 0,
+      detail=f"{len(no_witness)} witness-less n, all ≡ 3 (mod 8)")
+# and they are genuinely representable
+def is_sum3(n):
+    a = 0
+    while a * a <= n:
+        b = a
+        while a * a + b * b <= n:
+            c2 = n - a * a - b * b
+            if math.isqrt(c2) ** 2 == c2:
+                return True
+            b += 1
+        a += 1
+    return False
+check("all witness-less n ARE sums of three squares (gap is real, not vacuous)",
+      all(is_sum3(n) for n in no_witness[:300]))
+
+# ---- FINDING 3: correct route for n ≡ 3 (mod 8) ----------------------------
+bad_route, bad_id = [], 0
+for n in range(3, 8000, 8):  # n ≡ 3 (mod 8)
+    ok = False
+    t = 1
+    while t * t <= n:
+        if t % 2 == 1:
+            r = n - t * t
+            if r >= 0 and r % 2 == 0 and is_sum2(r // 2):
+                a, b = two_sq(r // 2)
+                if t * t + (a + b) ** 2 + (a - b) ** 2 != n:
+                    bad_id += 1
+                ok = True
+                break
+        t += 1
+    if not ok:
+        bad_route.append(n)
+check("every n ≡ 3 (mod 8): ∃ odd t with (n-t^2)/2 a sum of two squares",
+      not bad_route, detail=(f"failures: {bad_route[:10]}" if bad_route else "n<8000"))
+check("the identity n = t^2 + (a+b)^2 + (a-b)^2 holds for that witness",
+      bad_id == 0)
+
+if FAILED:
+    print("\nVERIFICATION FAILED")
+    sys.exit(1)
+print("\nAll Dirichlet-witness / three-square arithmetic verified.")


### PR DESCRIPTION
## Summary

Build-free certificate (sympy) for the sufficiency direction of Legendre's three-square theorem. Open PR #24443 reduces the `ThreeSquares.lean` sufficiency axiom to a uniform `DirichletWitnessProperty` and proposes discharging it via Dirichlet-primes-in-AP + quadratic reciprocity. **This audit shows that property is unsatisfiable for an entire residue class, so the proposed discharge is impossible as written.**

## Findings (all certified by `verify_dirichlet_witness.py`, exits non-zero on mismatch)

1. **The witness symbol is a residue function.** `legendreSym (d·n−1) (−d)` is fully determined by `(n mod 8, d mod 8)`. The `+1` classes:

   | n mod 8 | admissible d mod 8 (symbol = +1) |
   |---------|----------------------------------|
   | 1, 5    | 2, 6                             |
   | 2, 6    | 1, 2, 5, 6                       |
   | **3**   | **none**                         |

2. **No witness for `n ≡ 3 (mod 8)`.** Exhaustively (non-excluded, `4∤n`, `n < 6000`, `d < 200`): the only witness-less `n` are *exactly* the 750 values `n ≡ 3 (mod 8)` — yet all are genuinely sums of three squares. So #24443's `three_sq_of_dirichlet_witness` is conditionally valid but its hypothesis can never be discharged. (`ThreeSquares.lean:600` already treats `n ≡ 3 (mod 8)` separately — "find suitable prime factor" — a distinction #24443 collapsed into the uniform witness.)

3. **Correct `n ≡ 3 (mod 8)` route** (certified, `n < 8000`): there is an odd `t` with `(n − t²)/2 = a² + b²`, giving `n = t² + (a+b)² + (a−b)²`. This uses Mathlib's sum-of-two-squares (`Nat.Prime.sq_add_sq`), **not** `dirichlet_key_lemma`.

## Recommended fix (for #24443)

Split the witness property by residue:
- `n ≢ 3 (mod 8)`: the current Dirichlet witness `(d, p = d·n−1)`, `−d` a QR mod `p` (now sound) — the residue table gives the exact `d mod 8` to target per `n mod 8`.
- `n ≡ 3 (mod 8)`: the `t² + 2(a²+b²)` two-squares branch.

Then discharging the *amended* (n ≢ 3) witness via Dirichlet-AP + reciprocity is genuinely the remaining open ingredient.

## Changes

- `verify_dirichlet_witness.py` — certificate for all three findings.
- `WITNESS-GAP-S3.md` — gap analysis, residue table, fix spec.
- knowledge.md / state.md — S3 entry.

No `.lean` changed (`ThreeSquares.lean` is a registered 1979-LOC flagship; the fix belongs in #24443's unregistered `ThreeSquaresSufficiency.lean` once Docker is available).

## Test plan

- [x] `python3 verify_dirichlet_witness.py` → all checks `[OK]`
- [ ] (Docker) amend #24443's `DirichletWitnessProperty` per the fix and re-elaborate