### PR TITLE
research(birthday-oq-01-oq-01-oq-03): register OQ03 non-uniform + Schur files for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -276,6 +276,8 @@ import Proofs.BirthdayProblemAsymptotics
 import Proofs.BirthdayProblemOQ01
 import Proofs.BirthdayProblemOQ01OQ01
 import Proofs.BirthdayProblemOQ01OQ01Aristotle
+import Proofs.BirthdayProblemOQ01OQ01OQ03
+import Proofs.BirthdayProblemOQ01OQ01OQ03Schur
 import Proofs.BirthdayProblemOQ01OQ02
 import Proofs.BirthdayProblemOQ02
 import Proofs.BirthdayProblemOQ02OQ01

--- a/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03Schur.lean
+++ b/proofs/Proofs/BirthdayProblemOQ01OQ01OQ03Schur.lean
@@ -75,8 +75,10 @@ theorem biaffine_le_mean (A B C x y : ℝ) (hC : 0 ≤ C) :
 theorem biaffine_lt_mean (A B C x y : ℝ) (hC : 0 < C) (hxy : x ≠ y) :
     biaffine A B C x y < biaffine A B C ((x + y) / 2) ((x + y) / 2) := by
   have h := biaffine_mean_sub A B C x y
-  have hpos : 0 < ((x - y) / 2) ^ 2 * C :=
-    mul_pos (sq_pos_of_ne_zero (div_ne_zero (sub_ne_zero.mpr hxy) two_ne_zero)) hC
+  have hne : ((x - y) / 2) ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (div_ne_zero (sub_ne_zero.mpr hxy) two_ne_zero)
+  have hsq : 0 < ((x - y) / 2) ^ 2 := lt_of_le_of_ne (sq_nonneg _) (Ne.symm hne)
+  have hpos : 0 < ((x - y) / 2) ^ 2 * C := mul_pos hsq hC
   linarith [h, hpos]
 
 /-- **Equality characterization of the transfer step.** With positive weight,


### PR DESCRIPTION
## Summary

Two research files for `birthday-problem-oq-01-oq-01-oq-03` are present on `main`,
0-sorry / 0-axiom, but were **never registered** in the `proofs/Proofs.lean` import
manifest — so they have only been inspection-verified, never machine-checked. This
PR adds the two import lines so CI compiles them.

- `BirthdayProblemOQ01OQ01OQ03.lean` — non-uniform collision count. Coincidence
  index `collisionProb p = Σ pₖ²`; `E[X] = C(n,2)·Σpₖ²`; sum-of-squares identity
  `Σ(pₖ−1/d)² = Σpₖ² − 1/d` gives the sharp bound `Σpₖ² ≥ 1/d` (uniform **minimizes**
  expected collisions) plus its equality-iff-uniform characterization. (6 theorems)
- `BirthdayProblemOQ01OQ01OQ03Schur.lean` — the dual: algebraic kernel for "uniform
  **maximizes** Pr(X=0)". Biaffine-form equalization step `g(m,m) − g(x,y) = ((x−y)/2)²·C`,
  the single Hardy–Littlewood–Pólya transfer underlying Schur-concavity of `eₙ`. (5 theorems)

## Hardening note

The Schur file was written during the Docker / `lake build` blackout. I replaced its
one un-name-checkable call (`sq_pos_of_ne_zero`) with `lt_of_le_of_ne (sq_nonneg _) …`
+ `pow_ne_zero`, which use only canonical Mathlib names. No semantic change.

Supersedes the stale draft #23219, which predates these files' merge to `main` and whose
`Proofs.lean` edit never landed.

## Test plan
- [ ] CI (deployer build gate) compiles `Proofs.BirthdayProblemOQ01OQ01OQ03` and `…OQ03Schur`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)