### PR TITLE
research(euler-identity-oq01x4): kernel/period-lattice 2πℤ of the Lie group exponential

### DIFF
--- a/proofs/Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean
@@ -125,6 +125,33 @@ i.e. the Lie algebra direction is `iℝ`. -/
 theorem generator_mem_imaginary_axis : (Complex.I).re = 0 ∧ (Complex.I).im = 1 :=
   ⟨Complex.I_re, Complex.I_im⟩
 
+/-! ## §4b. The integral lattice `2πℤ`: kernel of the exponential
+
+The Lie group exponential `Circle.exp : ℝ → S¹` is surjective with a discrete
+kernel. Identifying that kernel is the last structural ingredient of the
+ℝ → S¹ picture: it is the *integral lattice* `2πℤ ⊆ iℝ` inside the Lie algebra,
+and the induced isomorphism `S¹ ≅ ℝ / 2πℤ` realises the circle as the quotient
+of its Lie algebra by this lattice. -/
+
+/-- **Kernel of the exponential = the lattice `2πℤ`.** `Circle.exp t` is the
+identity exactly when `t` is an integer multiple of `2π`. This is the period
+lattice of the one-parameter subgroup; in Lie-theoretic terms it is the integral
+lattice of `S¹` sitting inside the Lie algebra `iℝ`. -/
+theorem circleExp_eq_one_iff (t : ℝ) :
+    (Circle.exp t : ℂ) = 1 ↔ ∃ n : ℤ, t = n * (2 * π) := by
+  rw [Circle.coe_exp, Complex.exp_eq_one_iff]
+  constructor
+  · rintro ⟨n, hn⟩
+    refine ⟨n, ?_⟩
+    have hI : (t : ℂ) * Complex.I = ((n : ℂ) * (2 * π)) * Complex.I := by
+      rw [hn]; ring
+    have ht : (t : ℂ) = (n : ℂ) * (2 * π) := mul_right_cancel₀ Complex.I_ne_zero hI
+    have : (t : ℂ) = (((n : ℝ) * (2 * π) : ℝ) : ℂ) := by rw [ht]; push_cast; ring
+    exact_mod_cast this
+  · rintro ⟨n, hn⟩
+    refine ⟨n, ?_⟩
+    rw [hn]; push_cast; ring
+
 /-! ## §5. Summary -/
 
 /-- **Packaging complete.** Euler's formula presents `t ↦ exp(it)` as the smooth
@@ -142,6 +169,7 @@ theorem main :
 #check @contMDiff_circleExp_packaged
 #check @circleMap_eq_coe_circleExp
 #check @hasDerivAt_circleExp_zero
+#check @circleExp_eq_one_iff
 #check @main
 
 end EulerIdentityOQ01OQ01OQ01OQ01


### PR DESCRIPTION
## Summary

Extends the merged smooth-Lie-group packaging of Euler's formula (#24484) with
the canonical remaining structural fact: the **kernel** of the Lie group
exponential `Circle.exp : ℝ → S¹` is the **integral lattice `2πℤ ⊆ iℝ`**.

```lean
theorem circleExp_eq_one_iff (t : ℝ) :
    (Circle.exp t : ℂ) = 1 ↔ ∃ n : ℤ, t = n * (2 * π)
```

The merged file proved the homomorphism property, C∞/analytic smoothness, and
identified the Lie algebra generator `I` (so the Lie algebra is `iℝ`). The one
missing piece of the `ℝ → S¹` picture was the **period lattice** of the
one-parameter subgroup — the integral lattice of `S¹` sitting inside its Lie
algebra — which realises `S¹ ≅ ℝ / 2πℤ`. This PR closes that gap.

## Proof

After `Circle.coe_exp` the statement reduces to `Complex.exp (t·I) = 1`, handled
by `Complex.exp_eq_one_iff`; cancelling the nonzero `I` (`mul_right_cancel₀`,
`Complex.I_ne_zero`) and casting `ℂ ↔ ℝ` gives the lattice condition.

- 0 axioms, 0 sorries.
- **Build-pending**: Docker daemon is currently down (`docker info` exit 124) and
  no local Mathlib is materialized, so the addition was hand-verified against the
  pinned `v4.26.0` lemma surface rather than machine-checked locally. The deployer
  build gates the merge.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.EulerIdentityOQ01OQ01OQ01OQ01` (deployer/CI, once Docker is back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)