### PR TITLE
audit(euler-identity quad-oq): badge original→mathlib (Tier B Mathlib bridge)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15332,6 +15332,12 @@
       "lastAudited": "2026-06-15T11:46:50Z",
       "result": "clean",
       "issues": []
+    },
+    "euler-identity-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T13:34:29Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "unit-circle",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 147,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: euler-identity-oq-01-oq-01-oq-01-oq-01 ("Euler's Formula as a Smooth Lie Group Exponential Map")
**Severity**: MEDIUM (Mathlib wrapper badged `original`)

## Problem

The file is fully machine-checked (0 sorries, 0 axioms, no structure-encoded assumptions — all verified). However, it is a **Tier B packaging/bridge** proof: its headline results are direct Mathlib re-exports.

- `contMDiff_circleExp_packaged (m) : ContMDiff … Circle.exp := contMDiff_circleExp` (the "requested C∞ property")
- `circleExp_homomorphism (x y) : … := Circle.exp_add`
- `main`'s first two components are exactly `Circle.exp_add` and `contMDiff_circleExp_packaged`.

The badge `original` implies an independent proof of the mathematics, which overstates what the kernel guarantees here. This is the auditor's failure-mode #5 ("0 sorries with hidden imports").

## What is genuinely original

The file's own prose is admirably honest ("the work is one of *packaging* rather than building new analysis"; "no new analysis required — only an identification and assembly of existing results"). Its real contribution is the **bridge** identifying the parent's `circleMap`/`circleHom` with Mathlib's `Circle.exp`, plus the explicit derivative / Lie-algebra-generator computation (`hasDerivAt_circleExp`).

## Fix

- `meta.badge`: `original` → `mathlib`
- `meta.status`: unchanged (`verified` — it is fully machine-checked and assumption-free)

No prose changes needed; the description, conclusion, and `originalContributions` already credit Mathlib transparently.

---
Discovered during gallery integrity audit (first audit of this proof).