### PR TITLE
research(sum-of-kth-powers-oq-03): promote merged Nicomachus odd-partition proof into build tree + register

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2848,6 +2848,7 @@ import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfKthPowers
 import Proofs.SumOfKthPowersOQ01
 import Proofs.SumOfKthPowersOQ02
+import Proofs.SumOfKthPowersOQ03
 import Proofs.SumOfKthPowersOQ04
 import Proofs.SumOfKthPowersOQ04Aristotle
 import Proofs.SylowTheorem

--- a/proofs/Proofs/SumOfKthPowersOQ03.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ03.lean
@@ -1,0 +1,144 @@
+/-
+# Sum of k-th Powers — OQ-03: Nicomachus via the odd-number partition of cubes
+
+Second, structurally independent proof of Nicomachus's theorem
+
+  ∑_{i=0}^{n} i³ = (∑_{i=0}^{n} i)²
+
+The parent `SumOfKthPowers.lean` proves this **algebraically** (`sum_cubes_eq_sum_squared`,
+composing the closed forms `sum_cubes_classical` and `sum_first_powers_classical`). This file
+gives the classical **combinatorial** proof via the odd-number tiling, sharing no lemma with the
+parent beyond the Gauss sum.
+
+## The combinatorial idea
+
+Let `T n = ∑_{i<n} i` be the running Gauss sum (so `T 0 = 0`, `T (i+1) = T i + i`). The cube `i³`
+is the sum of the `i` consecutive odd numbers occupying *positions* `T i, T i + 1, …, T (i+1) − 1`
+in the sequence of all odds `1, 3, 5, …`:
+
+  ∑_{T i ≤ j < T (i+1)} (2j+1) = i³.
+
+The position blocks `[T i, T (i+1))` for `i = 0..n` tile `[0, T (n+1))` exactly, and the sum of
+the first `m` odds is `m²`, so
+
+  ∑_{i ≤ n} i³ = ∑_{j < T (n+1)} (2j+1) = (T (n+1))² = (∑_{i ≤ n} i)².
+
+## Why `T` is a *sum*, not the closed form
+
+Defining `T n` as the Gauss sum (rather than the closed form `n(n+1)/2`) sidesteps **all**
+ℕ-division and ℕ-subtraction. The whole proof uses only `ring` (valid on the ℕ semiring),
+`Finset.sum_range_succ`, `Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`, and one
+`Nat.add_left_cancel`. The triangular recurrence appears in the division-/subtraction-free form
+`2·T i + i = i²` (`two_T_add`), proved by a one-line induction.
+
+## Contents
+
+* `T`, `T_zero`, `T_succ`, `T_le_succ` — the Gauss-sum position function and its recurrence
+* `sum_odds`     — L1: `∑_{j<m} (2j+1) = m²`
+* `two_T_add`    — `2·T i + i = i²` (division-free triangular recurrence)
+* `block_sq`     — `T i² + i³ = T (i+1)²` (each block contributes a cube)
+* `block_eq_cube`— L2: `∑_{T i ≤ j < T (i+1)} (2j+1) = i³`
+* `tiling`       — L3: blocks tile the first `T n` odds
+* `sum_cubes_eq_sum_squared_via_odds` — Nicomachus, matching the parent's RHS shape
+
+Axioms: 0. Sorries: 0.
+
+NOTE (build provenance): authored during a Docker + Aristotle backend outage, so NOT yet
+machine-checked. Every arithmetic identity is independently certified (sympy + brute force,
+n = 0..60) by `research/problems/sum-of-kth-powers-oq-03/verify_m1.py`. The load-bearing Mathlib
+lemmas (`Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`) were pin-confirmed at the lake rev
+`v4.26.0`. This is a ready-to-move draft (kept in the research dir, not under `Proofs/`, to avoid
+degrading the shared safe-subset build before a typecheck); move to `proofs/Proofs/` and build via
+`./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` once backends return.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace SumOfKthPowersOQ03
+
+/-- Partial Gauss sum `T n = 0 + 1 + … + (n−1)`: the running count of odd-number positions
+consumed by the cubes `0³, 1³, …, (n−1)³`. Defined as a sum (no division). -/
+def T (n : ℕ) : ℕ := ∑ i ∈ range n, i
+
+@[simp] theorem T_zero : T 0 = 0 := rfl
+
+/-- Triangular recurrence: `T (n+1) = T n + n`. -/
+theorem T_succ (n : ℕ) : T (n + 1) = T n + n := by
+  simp [T, Finset.sum_range_succ]
+
+/-- `T` is monotone in one step (the position blocks are non-overlapping). -/
+theorem T_le_succ (n : ℕ) : T n ≤ T (n + 1) := by
+  rw [T_succ]; exact Nat.le_add_right _ _
+
+/-- **L1 — sum of the first `m` odd numbers is `m²`.** -/
+theorem sum_odds (m : ℕ) : ∑ j ∈ range m, (2 * j + 1) = m ^ 2 := by
+  induction m with
+  | zero => simp
+  | succ k ih => rw [Finset.sum_range_succ, ih]; ring
+
+/-- The Gauss-sum form of the triangular recurrence: `2·T i + i = i²`
+(division-free, subtraction-free). -/
+theorem two_T_add (i : ℕ) : 2 * T i + i = i ^ 2 := by
+  induction i with
+  | zero => simp
+  | succ k ih =>
+    rw [T_succ]
+    have h : 2 * (T k + k) + (k + 1) = (2 * T k + k) + (2 * k + 1) := by ring
+    rw [h, ih]; ring
+
+/-- **Block-square identity:** `T i² + i³ = T (i+1)²`. The odd block at positions
+`[T i, T (i+1))` contributes exactly `i³`. Proved from `two_T_add`, all over the ℕ semiring. -/
+theorem block_sq (i : ℕ) : T i ^ 2 + i ^ 3 = T (i + 1) ^ 2 := by
+  rw [T_succ]
+  have h := two_T_add i
+  calc T i ^ 2 + i ^ 3
+      = T i ^ 2 + i ^ 2 * i := by ring
+    _ = T i ^ 2 + (2 * T i + i) * i := by rw [← h]
+    _ = (T i + i) ^ 2 := by ring
+
+/-- **L2 — the `i`-th odd block sums to `i³`:** `∑_{T i ≤ j < T (i+1)} (2j+1) = i³`. -/
+theorem block_eq_cube (i : ℕ) :
+    ∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1) = i ^ 3 := by
+  have hsplit :
+      (∑ j ∈ range (T i), (2 * j + 1))
+          + (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1))
+        = ∑ j ∈ range (T (i + 1)), (2 * j + 1) := by
+    rw [Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ i)
+  rw [sum_odds, sum_odds] at hsplit
+  -- hsplit : T i ^ 2 + block = T (i+1) ^ 2
+  have hb := block_sq i  -- T i ^ 2 + i ^ 3 = T (i+1) ^ 2
+  have hcancel :
+      T i ^ 2 + (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1)) = T i ^ 2 + i ^ 3 := by
+    rw [hsplit, hb]
+  exact Nat.add_left_cancel hcancel
+
+/-- **L3 — the blocks tile the first `T n` odds:**
+`∑_{i<n} (block i) = ∑_{j < T n} (2j+1)`. -/
+theorem tiling (n : ℕ) :
+    ∑ i ∈ range n, (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1))
+      = ∑ j ∈ range (T n), (2 * j + 1) := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.sum_range_succ, ih, Finset.range_eq_Ico]
+    exact Finset.sum_Ico_consecutive _ (Nat.zero_le _) (T_le_succ k)
+
+/-- **Nicomachus's theorem via the odd-number partition.**
+
+`∑_{i ≤ n} i³ = (∑_{i ≤ n} i)²`, matching the parent's `sum_cubes_eq_sum_squared` exactly, but
+proved by the odd-block tiling (L1 + L2 + L3) instead of closed-form polynomials. The final `rfl`
+holds because `T (n+1)` is *definitionally* `∑ i ∈ range (n+1), i`. -/
+theorem sum_cubes_eq_sum_squared_via_odds (n : ℕ) :
+    ∑ i ∈ range (n + 1), i ^ 3 = (∑ i ∈ range (n + 1), i) ^ 2 := by
+  have key : ∑ i ∈ range (n + 1), i ^ 3
+      = ∑ i ∈ range (n + 1), (∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1)) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [block_eq_cube]
+  rw [key, tiling (n + 1), sum_odds]
+  rfl
+
+end SumOfKthPowersOQ03

--- a/research/problems/sum-of-kth-powers-oq-03/state.md
+++ b/research/problems/sum-of-kth-powers-oq-03/state.md
@@ -52,7 +52,14 @@ odd-position ranges and `sum_odds (m) = m²` closes it to T_n² = (∑ i)². See
 - Verification blackout: Docker down (`docker info` timeout) AND Aristotle "Resource not found".
   No Lean can be built/checked this session. M1 is spec-complete and Docker-gated only.
 
-## Next Action
+## S7 ACT (researcher-6, 2026-06-15) — PROMOTED + REGISTERED
+The complete 0-sorry/0-axiom draft merged by #24492 lived under `research/problems/.../SumOfKthPowersOQ03.lean`
+(staging), out of the build tree. Promoted a byte-identical copy to `proofs/Proofs/SumOfKthPowersOQ03.lean`
+and added `import Proofs.SumOfKthPowersOQ03` to `proofs/Proofs.lean` so the deployer build machine-checks it
+(the typecheck this entry was waiting on). Clean single-purpose branch; supersedes the file-placement portion of
+the stale, erdos-733-polluted open PR #24304. Docker still down — relying on the deployer-gated build.
+
+## Next Action (superseded — kept for reference)
 When Docker returns: create `proofs/Proofs/SumOfKthPowersOQ03.lean`, type M1 using the
 **ℕ-sub-free reindex** in knowledge.md ("ℕ-subtraction-free reindex"): L1 `sum_odds`, L2′
 `block_eq_cube` (`∑ Ico (T i) (T (i+1)) (2j+1) = (i+1)³` via `Finset.sum_Ico_consecutive _ hmn hnk`


### PR DESCRIPTION
## Summary
#24492 merged the complete **division-free combinatorial** proof of Nicomachus's theorem (`∑i³ = (∑i)²` via the odd-number tiling), but deliberately placed it in the **staging** location `research/problems/sum-of-kth-powers-oq-03/SumOfKthPowersOQ03.lean` — outside `proofs/Proofs/` — to avoid an unverified file in the build tree before a typecheck.

This PR:
- promotes a **byte-identical** copy to `proofs/Proofs/SumOfKthPowersOQ03.lean`, and
- adds `import Proofs.SumOfKthPowersOQ03` to `proofs/Proofs.lean`

so the deployer build performs exactly the typecheck the file was waiting for.

## The proof (0 sorry / 0 axiom, imports only Mathlib)
- `T n` = Gauss sum `∑_{i<n} i` (no ℕ-division/subtraction)
- triangular recurrence in the form `2·T i + i = i²` (`two_T_add`)
- `sum_odds : ∑_{j<m}(2j+1) = m²`, `block_eq_cube : ∑_{T i ≤ j < T(i+1)}(2j+1) = i³`, `tiling`
- everything closes with `ring` over the ℕ semiring + `Finset.sum_Ico_consecutive` / `range_eq_Ico`

Structurally independent of the parent's algebraic `sum_cubes_eq_sum_squared` (shares no lemma beyond the Gauss sum).

## Relationship to #24304
#24304 (open) also tries to add `proofs/Proofs/SumOfKthPowersOQ03.lean` but predates #24492's merge, is `mergeable: UNKNOWN`, and is polluted with **unrelated erdos-733 files**. This is a clean, single-purpose promotion of the now-canonical merged draft and **supersedes that file-placement**; #24304 can be closed or stripped.

## Safety
Deployer-build-gated: a compile failure blocks *this PR's* merge, not `main`. Docker is down this session, so the file is not locally built — the deployer build is the gate.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` (deployer) compiles 0 sorry / 0 axiom.
- [ ] On green: add gallery entry under `src/data/proofs/sum-of-kth-powers-oq-03/`; close #24304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)