### PR TITLE
research(cube-root-3-irrational-oq-04): S24 — eighteenth CF convergent upper bound (a17=6)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -805,4 +805,57 @@ theorem cbrt3_lt_two_six_six_three_nine_four_five_zero_over_one_eight_four_seven
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-! ## S24 prep: eighteenth CF convergent upper bound (one rung beyond S23)
+
+The eighteenth convergent of the simple CF of `∛3` is
+
+  `p₁₇/q₁₇ = (a₁₇·p₁₆ + p₁₅) / (a₁₇·q₁₆ + q₁₅)`
+  `       = (6 · 59472423 + 26639450) / (6 · 41235875 + 18470763)`
+  `       = 383_473_988 / 265_886_013`.
+
+It is built on the seventeenth convergent `p₁₆/q₁₆ = 59472423/41235875`
+(the lower bound being added in parallel by S23) together with the
+sixteenth convergent `p₁₅/q₁₅ = 26639450/18470763` already on `main`.
+
+This convergent is odd-index (17), so it lies on the UPPER side of `∛3`,
+alternating with the lower-side seventeenth convergent `59472423/41235875`
+(S23). `a₁₇ = 6` was derived from a 200-digit CF recomputation of `∛3`
+(true prefix `a₀..a₁₉ = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4,
+2, 6, 4, 4]`), per the S9-prep / S15a anti-typo discipline: never re-quote
+a prior sketch tail, always recompute `aᵢ`.
+
+Convergent recursion (with `a₁₇ = 6`):
+
+  `q₁₇ = 6 · q₁₆ + q₁₅ = 6 · 41235875 + 18470763 = 265_886_013`
+  `p₁₇ = 6 · p₁₆ + p₁₅ = 6 · 59472423 + 26639450 = 383_473_988`
+
+After cubing,
+
+  `383_473_988³     = 56_390_731_723_337_477_324_766_272`
+  `3 · 265_886_013³ = 56_390_731_723_337_476_944_612_591`
+
+so `383_473_988³ = 56_390_731_723_337_477_324_766_272 >
+56_390_731_723_337_476_944_612_591 = 3 · 265_886_013³` (strict, diff
+`+380_153_681`), hence `(383_473_988/265_886_013)³ > 3` and
+`cbrt3 < 383_473_988/265_886_013` as required for an upper bound. The new
+upper cube gap (relative-to-`3·q³`: `≈ 6.7·10⁻¹⁸`) is roughly two orders
+of magnitude tighter than S15's sixteenth-convergent upper gap of
+`≈ 2.55·10⁻¹⁵` — consistent with `383_473_988/265_886_013` being two true
+convergents further along than `26_639_450/18_470_763`.
+
+The theorem is self-contained (proved purely by cubing the rational via
+the cubing-iff helper) and so does not depend on the seventeenth-convergent
+theorem landing first. Two-line proof via the cubing-iff helper. -/
+
+/-- `∛3 < 383473988/265886013`. Cube target: `(383473988/265886013)³ =
+56_390_731_723_337_477_324_766_272 / 265_886_013³ > 3` (strict:
+`383473988³ = 56_390_731_723_337_477_324_766_272 >
+56_390_731_723_337_476_944_612_591 = 3 · 265886013³`, gap `+380_153_681`).
+The eighteenth convergent of the simple CF of `∛3`
+(using `a₁₇ = 6` per a 200-digit CF recomputation). -/
+theorem cbrt3_lt_three_eight_three_four_seven_three_nine_eight_eight_over_two_six_five_eight_eight_six_zero_one_three :
+    cbrt3 < (383473988 / 265886013 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Certificate for cube-root-3-irrational-oq-04 S24.
+
+Verifies the eighteenth simple-continued-fraction convergent of cbrt3 and the
+exact integer cubing inequality behind the new helper theorem
+
+    cbrt3 < 383473988 / 265886013   (UPPER bound).
+
+Run: python3 research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py
+"""
+from decimal import Decimal, getcontext
+
+
+def cf_and_convergents(n_terms: int):
+    getcontext().prec = 400
+    g, three = Decimal(1.5), Decimal(3)
+    for _ in range(800):  # high-iteration Newton for cbrt(3) at 400 digits
+        g = (2 * g + three / (g * g)) / 3
+    a, v = [], g
+    for _ in range(n_terms):
+        fl = int(v)
+        a.append(fl)
+        v = 1 / (v - fl)
+    conv, pm2, pm1, qm2, qm1 = [], 1, a[0], 0, 1
+    for k in range(1, len(a)):
+        pk, qk = a[k] * pm1 + pm2, a[k] * qm1 + qm2
+        conv.append((pk, qk))
+        pm2, pm1, qm2, qm1 = pm1, pk, qm1, qk
+    return a, conv
+
+
+def main() -> None:
+    a, conv = cf_and_convergents(20)
+    expected_prefix = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4]
+    assert a == expected_prefix, f"CF prefix mismatch: {a}"
+
+    # eighteenth convergent = p17/q17 (conv[] omits the 0th, so index 16), uses a17 = 6
+    p, q = conv[16]
+    assert a[17] == 6, a[17]
+    assert (p, q) == (383473988, 265886013), (p, q)
+    assert p == 6 * 59472423 + 26639450  # recurrence on 17th & 16th convergents
+    assert q == 6 * 41235875 + 18470763
+
+    lhs, rhs = p ** 3, 3 * q ** 3
+    assert lhs == 56390731723337477324766272, lhs
+    assert rhs == 56390731723337476944612591, rhs
+    assert lhs > rhs, "expected an UPPER bound (p^3 > 3 q^3)"
+    print("PASS: cbrt3 < 383473988/265886013 (18th convergent, a17=6)")
+    print(f"  p^3 - 3 q^3 = +{lhs - rhs}  (rel gap {(lhs - rhs) / rhs:.3e})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -21,9 +21,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-15 (S22 / 16th-convergent Helper-ACT)",
-    "iteration": 22,
-    "focus": "S22 Helper-ACT (researcher-4, 2026-06-15, Docker-down build-free): added the 16th CF convergent UPPER bound Cbrt3Helpers.cbrt3_lt_two_six_six_three_nine_four_five_zero_over_one_eight_four_seven_zero_seven_six_three : cbrt3 < (26639450/18470763 : R) to CubeRoot3IrrationalOQ04Helpers.lean via the proven two-line cubing-iff template (cbrt3_lt_iff_three_lt_cube + norm_num). Sixteenth CF convergent (odd-index 15, upper side; a_15 = 4 re-derived from a 120-digit CF recomputation, true prefix a0..a16 = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2]). Recursion: p_15 = 4*6193523 + 1865358 = 26639450, q_15 = 4*4294349 + 1293367 = 18470763. Cube sanity (exact integer + 120-digit CF): 26639450^3 = 18_904_959_980_335_633_625_000 > 18_904_959_980_335_585_454_841 = 3*18470763^3 (diff +48_170_159, relative gap ~2.55e-15). Together with S15a's lower bound prepares the sandwich 6193523/4294349 < cbrt3 < 26639450/18470763 for the FUTURE main-ACT of cbrt3_a14 = 3. Helper file 753 -> 808 LOC (+55 LOC, +1 theorem +1 prose section; theoremCount 20 -> 21). 0 sorries, 0 axioms (slug remains 0/0). NOT Docker-verified this session (docker info times out); relies on the S13/S14a/S15a-compiled identical template.",
+    "since": "2026-06-15 (S24 / 18th-convergent Helper-ACT)",
+    "iteration": 24,
+    "focus": "S24 Helper-ACT (researcher-8, 2026-06-15, Docker-down build-free): added the 18th CF convergent UPPER bound Cbrt3Helpers.cbrt3_lt_three_eight_three_four_seven_three_nine_eight_eight_over_two_six_five_eight_eight_six_zero_one_three : cbrt3 < (383473988/265886013 : R) to CubeRoot3IrrationalOQ04Helpers.lean via the proven two-line cubing-iff template (cbrt3_lt_iff_three_lt_cube + norm_num). Eighteenth CF convergent (odd-index 17, upper side; a_17 = 6 from a 200-digit CF recomputation, true prefix a0..a19 = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4]). Recursion on the 17th & 16th convergents: p_17 = 6*59472423 + 26639450 = 383473988, q_17 = 6*41235875 + 18470763 = 265886013. Exact integer cube sanity: 383473988^3 = 56_390_731_723_337_477_324_766_272 > 56_390_731_723_337_476_944_612_591 = 3*265886013^3 (diff +380_153_681, relative gap ~6.74e-18). Self-contained (cubing-only) so does NOT depend on the S23 17th-convergent lower bound (#24516) landing first. Helper file 808 -> 861 LOC (+53 LOC, +1 theorem +1 prose section; theoremCount 21 -> 22). 0 sorries, 0 axioms (slug remains 0/0). NOT Docker-verified this session (docker info times out); relies on the S13/S14a/S15a-compiled identical template + an exact-integer Python certificate (research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py, PASS).",
     "blockers": [],
     "nextAction": "S14b Main-ACT (double-claimed: PRs #23388 DRAFT, #23983 OPEN): prove the thirteenth partial quotient cbrt3_a12 = 8. THEN S15b: cbrt3_a13 = 3 (sandwich 6193523/4294349 < cbrt3 < 1865358/1293367, both on main). THEN S16b: cbrt3_a14 = 3 (sandwich 6193523/4294349 < cbrt3 < 26639450/18470763, both now on main after this S22). Each main-ACT extends the nested-fraction chain one rung and must land in order (a12 -> a13 -> a14). Forward helper prep available for S23: 17th convergent lower bound (a_16 = 2: p_16 = 2*26639450 + 6193523 = 59472423, q_16 = 2*18470763 + 4294349 = 41235875; even-index 16 => lower side, cbrt3 > 59472423/41235875 per S18 verify_cf_convergents.py table).",
     "attemptCounts": {
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "filename": "CubeRoot3IrrationalOQ04Helpers.lean",
-      "lineCount": 808,
-      "theoremCount": 21,
+      "lineCount": 861,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -199,6 +199,6 @@
     }
   ],
   "lastUpdated": "2026-06-15",
-  "currentFocus": "S21 Helper-ACT: added a13 lower-bound convergent p14=6193523/4294349 (corrected a14=3, not 4); a13 sandwich now complete. a12 frontier math re-verified (exact interval propagation).",
-  "nextAction": "S15b main-ACT (build-gated): prove cbrt3_a13 = 3 using sandwich 6193523/4294349 < cbrt3 < 1865358/1293367, mirroring the cbrt3_a12 nested-fraction chain."
+  "currentFocus": "S24 Helper-ACT: added 18th CF convergent upper bound cbrt3 < 383473988/265886013 (a17=6); self-contained cubing proof, independent of the in-flight S23 17th-convergent lower bound (#24516).",
+  "nextAction": "Main-ACT chain remains the bottleneck and must land in order: cbrt3_a12 = 8 (contended: PRs #23983 OPEN, #23388 DRAFT), THEN cbrt3_a13 = 3, THEN cbrt3_a14 = 3 (all sandwich bounds already on main). Helper convergent bounds now run through the 18th convergent (S24); a further S25 would be the 19th convergent lower bound (a18=4, p18/q18 = 1593368375/1104779927, p^3 < 3q^3)."
 }


### PR DESCRIPTION
## Summary
S24 Helper-ACT for the continued-fraction expansion of ∛3. Adds the **eighteenth** simple-CF convergent **upper** bound to `CubeRoot3IrrationalOQ04Helpers.lean`:

```
cbrt3 < (383473988 / 265886013 : ℝ)
```

proved via the established two-line cubing-iff template (`cbrt3_lt_iff_three_lt_cube` + `norm_num`).

## Math
- Convergent recurrence on the 17th & 16th convergents: `p₁₇ = 6·59472423 + 26639450 = 383473988`, `q₁₇ = 6·41235875 + 18470763 = 265886013`.
- Odd index (17) ⇒ upper side of ∛3. `a₁₇ = 6` from a 200-digit CF recomputation (prefix `a₀..a₁₉ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4]`).
- Exact integer cube check: `383473988³ = 56_390_731_723_337_477_324_766_272 > 56_390_731_723_337_476_944_612_591 = 3·265886013³` (diff `+380_153_681`, rel gap ≈ 6.74e-18).
- **Self-contained** (cubing only) ⇒ does **not** depend on the in-flight S23 17th-convergent lower bound (#24516) landing first.

## Status
- Helper file 808 → 861 LOC; theoremCount 21 → 22. Slug remains **0 sorries / 0 axioms**.
- Not Docker-built this session (`docker info` times out — ongoing blackout). Theorem is structurally identical to the Docker-compiled S13/S14a/S15a bounds; arithmetic certified by `research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py` (PASS).

## Test plan
- [ ] `python3 research/scripts/verify_cbrt3_oq04_s24_18th_convergent.py` → PASS
- [ ] Deployer Docker build of `Proofs.CubeRoot3IrrationalOQ04Helpers` (build-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)