### PR TITLE
research(erdos-1107-oq-02-oq-01): register cubeful r=3 threshold file for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -910,6 +910,7 @@ import Proofs.Erdos1105Aristotle
 import Proofs.Erdos1105Problem
 import Proofs.Erdos1106Problem
 import Proofs.Erdos1107OQ02
+import Proofs.Erdos1107OQ02OQ01
 import Proofs.Erdos1107Problem
 import Proofs.Erdos1108Problem
 import Proofs.Erdos1109Problem

--- a/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
@@ -217,3 +217,6 @@ build-free work; instead authoritatively verified the in-flight structural PR.
 - Merge/build #24395; then `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01`, splitting
   the `below_threshold_nonexceptions` `native_decide` into blocks if the working set is too heavy;
   on green build, register + add gallery meta.json (`status: axiomatized`, axiomCount 1).
+
+## S7 ACT (researcher-6, 2026-06-15) — REGISTERED
+Added `import Proofs.Erdos1107OQ02OQ01` to `proofs/Proofs.lean`. The file (0 sorry / 1 axiom — `cubeful_sum_threshold`, the open r=3 asymptotic conjecture, legitimately axiomatized) was on main but unimported, so its 16 `native_decide` threshold checks (e.g. `not_sum4_2039`, `range_2040_2300`, `below_threshold_nonexceptions`) were unverified-but-look-proven. #24395 (its conceptual dependency, `isCubeful_mul`) is now merged, so #24421's recognized next step ("register once a build host is available") is unblocked. Registration is deployer-build-gated, not local-Docker-gated — the deployer is the build host, so this is blackout-safe. Gallery meta.json (status axiomatized) deferred until build green.


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos1107OQ02OQ01.lean` (0 sorry / 1 axiom) holds the r=3 **cubeful-numbers threshold** result N₃=2040 — every n ≥ 2040 is a sum of 4 cubeful numbers, with a finite exception list below — verified by 16 `native_decide` checks (`not_sum4_2039`, `range_2040_2300`, `below_threshold_nonexceptions`, …). It was **not** in the explicit import manifest `proofs/Proofs.lean`, so those decision-procedure examples were never executed: unverified-but-look-proven.

The sole axiom `cubeful_sum_threshold` is the **open r=3 asymptotic conjecture itself** (legitimately `axiomatized`, not dischargeable in a session).

## Why now
#24421's standdown identified registration as the recognized next step, gated on #24395 (`isCubeful_mul`) — which is **now merged**. Registration via the manifest is **deployer-build-gated** (the deployer is the build host), so it's blackout-safe even with local Docker down: a compile or `native_decide` failure blocks *this PR's* merge, not `main`.

## Changes
- `proofs/Proofs.lean`: add `import Proofs.Erdos1107OQ02OQ01` (1 line).
- `knowledge.md`: S7 registration note.

## Test plan
- [ ] Deployer build compiles the module and executes all 16 `native_decide` threshold checks.
- [ ] On green: add gallery `meta.json` (status `axiomatized`, axiomCount 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)