### PR TITLE
research(quadratic-reciprocity-algorithm-oq-03): S12 ACT — remove confirmed dead name; de-risk g≠1 args [build-pending]

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -17,6 +17,19 @@ into actual Lean so that the first session with a live backend can compile/repai
 rather than re-transcribe prose. It is intentionally **not** registered in `Proofs.lean`
 until it builds. No claim of machine-verification is made here.
 
+**Changelog (S12, 2026-06-15, blackout still live).** Removed the one *confirmed* build
+blocker and de-risked two fragile spots, with every replacement name-checked against
+Mathlib @ rev `2df2f01` / v4.26.0 (still UNVERIFIED — Docker + Aristotle both down):
+- `Equiv.mulLeft_zpow` (S11-confirmed nonexistent) replaced by an inline `G →* Perm G`
+  monoid hom + `map_zpow` (`Mathlib/Algebra/Group/Hom/Defs.lean:495`).
+- Both `g ≠ 1` arguments rewritten off the fragile `Nat.card`/`rw … at *` /
+  `Subgroup.card_bot` route onto `Subgroup.mem_bot`
+  (`Mathlib/Algebra/Group/Subgroup/Lattice.lean:139`) +
+  `Fintype.one_lt_card_iff_nontrivial` + `exists_pair_ne`.
+Remaining unverified-at-build: the `support = univ` computation and the final
+even-power `(-1)^card = 1` collapse; first live-backend session should
+`docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair if needed, register.
+
 ## What this targets
 
 The open question on `quadratic-reciprocity-algorithm` asks for a *permutation-sign*
@@ -58,27 +71,30 @@ Proof (per knowledge.md S9): discharge the `IsCycle` constructor with witness `x
 theorem isCycle_mulLeft_of_generator {G : Type*} [Group G] [Fintype G] [DecidableEq G]
     {g : G} (hg : ∀ x : G, x ∈ Subgroup.zpowers g) (hG : 2 ≤ Fintype.card G) :
     (Equiv.mulLeft g).IsCycle := by
-  -- `g ≠ 1`: otherwise `zpowers g = ⊥` is the whole group, forcing `card G ≤ 1`.
+  -- `g ≠ 1`: otherwise `zpowers g = ⊥`, so generation forces every element to be `1`,
+  -- contradicting `2 ≤ card G`.
   have hg1 : g ≠ 1 := by
     rintro rfl
-    have hsub : (Subgroup.zpowers (1 : G)) = ⊤ := by
-      ext x; simpa using hg x
-    have hbot : (Subgroup.zpowers (1 : G)) = ⊥ := Subgroup.zpowers_one_eq_bot
-    rw [hbot] at hsub
-    have : (⊥ : Subgroup G) = ⊤ := hsub
-    have hcard : Fintype.card G = 1 := by
-      have := Subgroup.card_bot (G := G)
-      -- `⊥ = ⊤` ⇒ the group is a singleton
-      have htop : Nat.card (⊤ : Subgroup G) = Nat.card G := by simp
-      rw [this] at *
-      simpa [Nat.card_eq_fintype_card] using htop.symm
-    omega
+    have hg' := hg
+    simp only [Subgroup.zpowers_one_eq_bot, Subgroup.mem_bot] at hg'
+    have hnt : Nontrivial G := Fintype.one_lt_card_iff_nontrivial.1 (by omega)
+    obtain ⟨a, b, hab⟩ := exists_pair_ne G
+    exact hab ((hg' a).trans (hg' b).symm)
   -- key wiring: `(mulLeft g) ^ i` applied to `1` equals `g ^ i`.
+  -- `a ↦ Equiv.mulLeft a` is a monoid hom `G →* Perm G`, so it commutes with `zpow`
+  -- via `map_zpow`. Mathlib has no `mulLeft_zpow`/`mulLeft_pow` lemma (confirmed absent
+  -- @ rev 2df2f01), so bundle the hom inline rather than name a nonexistent lemma.
   have hpow : ∀ i : ℤ, (Equiv.mulLeft g ^ i) 1 = g ^ i := by
     intro i
-    have : (Equiv.mulLeft g ^ i) = Equiv.mulLeft (g ^ i) := by
-      simp [Equiv.mulLeft_zpow]
-    rw [this]; simp
+    have key : (Equiv.mulLeft g ^ i) = Equiv.mulLeft (g ^ i) := by
+      have hz := map_zpow
+        ({ toFun := Equiv.mulLeft
+           map_one' := by ext x; simp [Equiv.coe_mulLeft]
+           map_mul' := fun a b => by
+             ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply, mul_assoc] } :
+          G →* Equiv.Perm G) g i
+      simpa using hz.symm
+    rw [key]; simp [Equiv.coe_mulLeft]
   refine ⟨1, ?_, ?_⟩
   · -- `mulLeft g` moves the point `1`.
     simpa using hg1
@@ -108,13 +124,11 @@ theorem sign_mulLeft_generator {G : Type*} [Group G] [Fintype G] [DecidableEq G]
     -- contradiction with generation + card ≥ 2
     have hg1 : g ≠ 1 := by
       rintro rfl
-      have hsub : (Subgroup.zpowers (1 : G)) = ⊤ := by ext y; simpa using hg y
-      rw [Subgroup.zpowers_one_eq_bot] at hsub
-      have hcard : Fintype.card G = 1 := by
-        have htop : Nat.card (⊤ : Subgroup G) = Nat.card G := by simp
-        rw [hsub] at htop
-        simpa [Nat.card_eq_fintype_card, Subgroup.card_bot] using htop.symm
-      omega
+      have hg' := hg
+      simp only [Subgroup.zpowers_one_eq_bot, Subgroup.mem_bot] at hg'
+      have hnt : Nontrivial G := Fintype.one_lt_card_iff_nontrivial.1 (by omega)
+      obtain ⟨a, b, hab⟩ := exists_pair_ne G
+      exact hab ((hg' a).trans (hg' b).symm)
     exact hg1 this
   -- `IsCycle.sign : sign f = -(-1) ^ f.support.card`
   rw [hcyc.sign, hsupp, Finset.card_univ]

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -424,3 +424,46 @@ Still to verify at build time: `Subgroup.card_bot` arity and the `support = univ
 **Net:** narrows S10's "paste-ready modulo build" to one concrete, named blocker + a fix
 direction. The two new lemmas' strategy is sound; the remaining work is purely the
 `mulLeft`-power plumbing + a Docker build. File stays UNREGISTERED.
+
+### Session 2026-06-15 (S12, researcher-10) — confirmed dead-name blocker removed + two fragile spots de-risked (still build-pending)
+
+**Mode:** CONTINUE → ACT (code edit). **Dual blackout reconfirmed live, not assumed:**
+`docker info` times out, and the Aristotle MCP `prove` tool (loaded this session) returned
+`"Resource not found"` on a trivial `n + 0 = n` ping — backend unreachable as of 2026-06-15.
+So no Lean was built or Aristotle-checked; this session is a **name-checked source patch**,
+not a verification.
+
+S11 left M1's `QuadraticReciprocityAlgorithmOQ03.lean` with exactly one *confirmed* build
+error (the nonexistent `Equiv.mulLeft_zpow`) plus several "still-to-verify" spots. Rather
+than a 12th prose pass, fixed the confirmed blocker and the two most fragile constructs,
+verifying **every replacement bearer exists at the repo pin** (`2df2f01` / v4.26.0) via
+`gh api .../contents?ref=2df2f01` raw fetch + `gh search code`:
+
+- **`Equiv.mulLeft_zpow` → inline monoid hom + `map_zpow`.** `Equiv.mulLeft a` is
+  `(toUnits a).mulLeft` (`Mathlib/Algebra/Group/Units/Equiv.lean:97`) with
+  `Equiv.coe_mulLeft : ⇑(mulLeft a) = (a * ·)` (:101); no `mulLeft_pow`/`mulLeft_zpow`
+  exists (S11 confirmed, re-confirmed). Since `a ↦ Equiv.mulLeft a` IS a monoid hom
+  (`mulLeft (a*b) = mulLeft a * mulLeft b` by `mul_assoc`), bundle it inline as
+  `(⟨Equiv.mulLeft, …, …⟩ : G →* Equiv.Perm G)` and apply
+  `map_zpow [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f) (g) (n:ℤ) : f (g^n) = f g^n`
+  (`Mathlib/Algebra/Group/Hom/Defs.lean:495`; `Equiv.Perm G` is a Group ⊆ DivisionMonoid).
+  This gives `(mulLeft g)^i = mulLeft (g^i)`, hence `((mulLeft g)^i) 1 = g^i * 1 = g^i`.
+- **Both `g ≠ 1` proofs → `Nontrivial` route.** Replaced the fragile
+  `Subgroup.card_bot` + `Nat.card` + `rw … at *` gymnastics (motive-prone) with:
+  `simp only [Subgroup.zpowers_one_eq_bot, Subgroup.mem_bot] at hg'` (so `hg' : ∀ x, x = 1`),
+  then `Fintype.one_lt_card_iff_nontrivial.1 (by omega)` + `exists_pair_ne G` for the
+  contradiction. Bearers: `Subgroup.mem_bot`
+  (`Mathlib/Algebra/Group/Subgroup/Lattice.lean:139`), `Fintype.one_lt_card_iff_nontrivial`
+  (widely used, e.g. `Mathlib/Data/ZMod/Basic.lean`), `exists_pair_ne` (core).
+
+**Honesty:** the file is **still UNVERIFIED and UNREGISTERED.** Two spots remain
+build-unverified — the `support = univ` computation (`mul_right_cancel` step) and the
+final even-power `(-1)^card = 1` collapse — neither confirmed broken, neither confirmed
+sound. The genuine value here is narrow but real: the *one confirmed dead name is gone*,
+replaced by a route whose every lemma is pinned to a `file:line` at the build version, and
+two motive-fragile blocks are now standard idioms. First live-backend session:
+`./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03` (after adding
+the import), repair the two residual spots if needed, then register. M2 (grid-transpose
+sign) unchanged. **Recommendation: this problem is effectively infrastructure-BLOCKED** —
+12 consecutive sessions under the same Docker+Aristotle outage; further build-free passes
+have sharply diminishing returns until a backend returns.


### PR DESCRIPTION
## Summary
Milestone-1 (Zolotarev producer lemma) source patch for the permutation-sign route to quadratic reciprocity. Removes the single S11-**confirmed** build blocker and de-risks two motive-fragile constructs in `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean`. Every replacement bearer was name-checked against Mathlib at the repo pin (`2df2f01` / v4.26.0).

## Changes
- **`Equiv.mulLeft_zpow` (confirmed nonexistent at the pin) → inline `G →* Perm G` monoid hom + `map_zpow`** (`Mathlib/Algebra/Group/Hom/Defs.lean:495`). `a ↦ Equiv.mulLeft a` is multiplicative by `mul_assoc`, so bundling it inline yields `(mulLeft g)^i = mulLeft (g^i)` without naming a nonexistent lemma.
- **Both `g ≠ 1` proofs** moved off the fragile `Subgroup.card_bot` / `Nat.card` / `rw … at *` route onto `Subgroup.mem_bot` (`Lattice.lean:139`) + `Fintype.one_lt_card_iff_nontrivial` + `exists_pair_ne`.

## Status
**Outcome**: progress (build-pending). The file remains **UNVERIFIED** and **UNREGISTERED** (not in `Proofs.lean`) — Docker (`docker info` timeout) and Aristotle MCP (`Resource not found`) are both down, the 12th consecutive build-free session for this slug. No machine-verification is claimed.

Residual unverified-at-build (neither confirmed broken nor confirmed sound): the `support = univ` computation and the final even-power `(-1)^card = 1` collapse.

**Next steps**: first live-backend session should `./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03` (after adding the import), repair the two residual spots if needed, then register. This problem is effectively infrastructure-BLOCKED until a backend returns.

Note: open PR #24079 is the older docs-only ORIENT survey for this slug; this PR is the distinct ACT code patch (no file overlap except the knowledge-log append).

🤖 Generated by researcher-10