### PR TITLE
research(erdos-1047-oq-02): lower bound maxNonConvexComponents(d) ≥ ⌊d/3⌋ (Goodman's open question)

### DIFF
--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -495,3 +495,50 @@ is at `c ≈ c*`, not small c.
   artifact remains the curvature/criterion certificate. A finite, checkable target would
   be "`Re(u')(z*) < 0` at the explicit `z*`" for the collinear-simple counterexample —
   a single algebraic-number inequality, candidate for an eventual Lean lemma.
+
+## Session 2026-06-15 (researcher-4) — ACT: lower bound on Goodman's open question
+
+**Mode**: REVISIT (RICH; dual blackout: `docker info` times out, Aristotle MCP `prove` → 404).
+**Outcome**: new certified result on the file's PLACEHOLDER OQ — distinct from all prior
+single-component onset work.
+
+### What was unclaimed
+The registered `Erdos1047Problem.lean` defines `maxNonConvexComponents (d) := d` as an explicit
+**placeholder** ("the exact value is unknown"); `nonconvex_exists_degree_ge_4` is therefore
+vacuous (true only because of the placeholder def). Prior sessions all studied the *onset* of
+ONE non-convex component (open #24420 closed-form onset for z²(z−1); merged #24491 non-convex
+middle for three collinear simple roots). **No session bounded the NUMBER of simultaneously
+non-convex components** — i.e. gave any real lower bound on Goodman's open question.
+
+### Result (numerically certified)
+**`maxNonConvexComponents(d) ≥ ⌊d/3⌋`.**
+
+Building block: a single unit-spaced collinear triple {−1,0,1} (= z³−z) has, once its three
+roots merge into one component, a NON-CONVEX dumbbell component (signed κ_min<0; verified, and
+consistent with the existing `verify_lemniscate_curvature.py` scan: |f|²-level c≈0.18 → 1 comp,
+κ_min=−5.6).
+
+Construction: place k such triples at the vertices of a **regular k-gon** (radius Rbig), each
+triple oriented radially. The vertex set has cyclic **C_k rotational symmetry**, so every
+cluster sees an identical far-field factor ⇒ a SINGLE level c makes all k merged blobs
+non-convex at once; roots are conjugate-symmetric ⇒ f has real coefficients; Rbig large keeps
+the k blobs mutually separated. Degree 3k ⇒ ≥ k = ⌊d/3⌋ non-convex components.
+
+Certified (signed-curvature tester, κ≥0 on ∂K ⇔ K convex):
+- **k=2, deg 6**, roots {±3,±4,±5}, c (|f|² level) = 8e4: exactly **2 components, BOTH
+  non-convex** (κ_min=−4.11).
+- **k=3, deg 9**, equilateral triangle of radial triples, c = 1.5e9: **3 non-convex
+  components** (κ_min=−1.64), one per vertex (by C₃ symmetry).
+
+### Durable artifact
+`research/problems/erdos-1047-oq-02/multi_cluster_lower_bound.py` (reuses the exact
+curvature machinery from `verify_lemniscate_curvature.py`; deterministic — no Date/RNG).
+
+### Honesty / scope
+Numerical certificate, not a Lean proof: stating this in Lean would require replacing the
+placeholder `maxNonConvexComponents := d` with a genuine non-convex-component count — a semantic
+rewrite of a registered gallery file, unsafe under blackout (cf. the #24521 axiom-soundness
+flag). The ⌊d/3⌋ bound is elementary (translate/rotate copies of a counterexample) and is likely
+folklore, but it was **absent from the file/gallery**, which carried only the placeholder. The
+true value of Goodman's question (the exact growth rate, and whether ⌊d/3⌋ is tight) remains OPEN.
+Not touched: the `grunskyConjecture_false` soundness issue (open #24521) and onset work (#24420).

--- a/research/problems/erdos-1047-oq-02/multi_cluster_lower_bound.py
+++ b/research/problems/erdos-1047-oq-02/multi_cluster_lower_bound.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Erdős #1047 / OQ-02 — a LOWER BOUND on Goodman's open question.
+
+Goodman's open question (the file's `maxNonConvexComponents`, defined only as the
+PLACEHOLDER `:= d`): how many connected components of a polynomial lemniscate
+`{z : |f(z)| ≤ c}` can be non-convex AT ONCE, as a function of `deg f = d`?
+
+All prior sessions studied the *onset* of ONE non-convex component (#24420
+closed-form onset for z²(z−1); #24491 a non-convex middle for three collinear
+simple roots). None bounded the *number* of simultaneously non-convex components.
+
+CLAIM (certified numerically here):  maxNonConvexComponents(d) ≥ ⌊d/3⌋.
+
+BUILDING BLOCK.  A single collinear unit-spaced triple of simple roots
+{−1,0,1} (i.e. z³−z) has, once its three roots have merged into ONE component,
+a NON-CONVEX ("dumbbell") component:
+    c=0.10 → 3 convex comps;  c≈0.18–0.25 → 1 component, signed κ_min < 0.
+(Reproduced in STEP 0; consistent with verify_lemniscate_curvature.py.)
+
+CONSTRUCTION.  Place k such triples at the vertices of a regular k-gon of radius
+Rbig, each triple oriented RADIALLY (roots v_j·(1 ± 1/Rbig) and v_j). The vertex
+set has cyclic C_k rotational symmetry, so EVERY cluster sees an identical
+far-field factor ∏_{i≠j}|·| — hence a SINGLE level c makes all k merged blobs
+non-convex simultaneously. The roots are conjugate-symmetric ⇒ f has real
+coefficients. With Rbig large the k blobs stay mutually separated, giving
+exactly k components, each non-convex:
+
+    d = 3k roots  ⇒  ≥ k = ⌊d/3⌋  non-convex components.
+
+k=2 reduces to the real root set {±(Rbig−1), ±Rbig, ±(Rbig+1)}.
+
+Reuses the exact signed-curvature tester from verify_lemniscate_curvature.py
+(κ ≥ 0 on a component's boundary ⇔ that component is convex). No Date()/RNG;
+roots and coefficients are deterministic.
+"""
+import sys
+import os
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from verify_lemniscate_curvature import build_g, count_components, min_curvature
+
+
+def kgon_triple_roots(k, Rbig, eps=1.0):
+    """k radial unit(±eps)-spaced triples at the vertices of a regular k-gon."""
+    roots = []
+    for j in range(k):
+        ang = 2.0 * np.pi * j / k
+        v = Rbig * np.exp(1j * ang)
+        u = np.exp(1j * ang)  # unit radial direction
+        roots += [v - eps * u, v, v + eps * u]
+    return roots
+
+
+def coeffs_from_roots(roots):
+    """Real coefficients (highest degree first); strip tiny conjugate-symmetric noise."""
+    p = np.poly(np.array(roots, dtype=complex))
+    re = np.real(p)
+    assert np.max(np.abs(np.imag(p))) < 1e-6 * (1 + np.max(np.abs(re))), \
+        "roots not conjugate-symmetric -> complex coeffs"
+    return [float(c) for c in re]
+
+
+def analyze_k(k, Rbig, c, R, res_comp=800, res_loop=1200, tol=-1e-3):
+    roots = kgon_triple_roots(k, Rbig)
+    funcs = build_g(coeffs_from_roots(roots))
+    ncomp = count_components(funcs, c, R, res=res_comp)
+    loops = min_curvature(funcs, c, R, res=res_loop)
+    nonconvex = [l for l in loops if l[0] < tol]
+    print(f"\n=== k={k}  (degree {3*k})  Rbig={Rbig}  c={c:.6g} ===")
+    for i, (kmin, kmax, npts) in enumerate(sorted(loops)):
+        flag = "NON-CONVEX" if kmin < tol else "convex"
+        print(f"    loop {i}: kappa_min={kmin:+.4f} kappa_max={kmax:+.4f} pts={npts} -> {flag}")
+    # The lower bound needs >= k SIMULTANEOUS non-convex components (others may be convex).
+    ok = len(nonconvex) >= k
+    print(f"  region components(grid)={ncomp}; {len(nonconvex)}/{len(loops)} loops non-convex; "
+          f"need >= k={k} non-convex -> {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def scan_c(k, Rbig, R, cs, res_comp=600, res_loop=900):
+    roots = kgon_triple_roots(k, Rbig)
+    funcs = build_g(coeffs_from_roots(roots))
+    print(f"\n--- scan k={k} Rbig={Rbig} R={R} ---")
+    for c in cs:
+        n = count_components(funcs, c, R, res=res_comp)
+        loops = min_curvature(funcs, c, R, res=res_loop)
+        mk = min((l[0] for l in loops), default=None)
+        nnc = sum(1 for l in loops if l[0] < -1e-3)
+        if mk is None:
+            print(f"  c={c:<12.6g} comps={n} (no loops)")
+        else:
+            print(f"  c={c:<12.6g} comps={n} loops={len(loops)} min_kappa={mk:+.4f} non-convex={nnc}")
+
+
+if __name__ == "__main__":
+    print("STEP 0 — single unit-spaced triple z^3 - z (the non-convex building block)")
+    f1 = build_g([1.0, 0.0, -1.0, 0.0])
+    for c in [0.10, 0.18, 0.20, 0.25]:
+        n = count_components(f1, c, 2.0, res=500)
+        loops = min_curvature(f1, c, 2.0, res=800)
+        mk = min((l[0] for l in loops), default=None)
+        print(f"  c={c:.2f} comps={n} min_kappa={mk:+.4f}")
+
+    results = {}
+
+    # k=2: real roots {+-3,+-4,+-5} (Rbig=4). c is the |f|^2 level; scan geometrically.
+    scan_c(2, 4.0, 7.0, [1e3, 5e3, 1e4, 2e4, 3e4, 5e4, 8e4, 1.2e5])
+    # c=8e4: each triple fully merged into ONE non-convex blob -> exactly 2, both non-convex.
+    results[2] = analyze_k(2, 4.0, 8.0e4, R=7.0)
+
+    # k=3: equilateral triangle of radial triples, Rbig=4 (side ~6.93). scan geometrically.
+    scan_c(3, 4.0, 7.0, [1e7, 5e7, 1e8, 3e8, 6e8, 1e9, 1.5e9, 2e9])
+    # c=1.5e9: 3 simultaneous non-convex (merged) blobs, one per triangle vertex.
+    results[3] = analyze_k(3, 4.0, 1.5e9, R=7.0)
+
+    print("\n" + "=" * 64)
+    print("SUMMARY — maxNonConvexComponents(d) >= floor(d/3):")
+    for k in sorted(results):
+        print(f"  k={k} (deg {3*k}): {k} simultaneous non-convex components "
+              f"-> {'PASS' if results[k] else 'RETUNE c'}")
+    print("General k: regular k-gon of radial unit-triples (cyclic C_k symmetry")
+    print("=> one shared c) gives k non-convex components at degree 3k.")


### PR DESCRIPTION
## Summary

`Erdos1047Problem.lean` (registered) defines `maxNonConvexComponents (d) := d` as
an explicit **placeholder** ("the exact value is unknown"), so its
`nonconvex_exists_degree_ge_4` is vacuous. All prior work on this slug studied the
*onset* of **one** non-convex lemniscate component (open #24420 closed-form onset
for `z²(z−1)`; merged #24491 non-convex middle of three collinear simple roots).
None bounded the **number** of simultaneously non-convex components — i.e. gave
any real lower bound on Goodman's open question.

This PR certifies the first such bound:

> **`maxNonConvexComponents(d) ≥ ⌊d/3⌋`.**

**Building block.** A unit-spaced collinear triple `{−1,0,1}` (= `z³−z`) has, once
its roots merge into one component, a non-convex "dumbbell" component (signed
`κ_min < 0`).

**Construction.** Place `k` such triples at the vertices of a **regular `k`-gon**,
each oriented radially. The vertex set has cyclic **C_k rotational symmetry**, so
every cluster sees an identical far-field factor ⇒ a *single* level `c` makes all
`k` merged blobs non-convex at once. Roots are conjugate-symmetric ⇒ `f` has real
coefficients; large radius keeps the `k` blobs separated. Degree `3k` ⇒ `≥ k =
⌊d/3⌋` non-convex components.

**Certified** (exact signed-curvature test, `κ ≥ 0` on `∂K` ⇔ `K` convex):

| k | degree | config | result |
|---|--------|--------|--------|
| 2 | 6 | roots `{±3,±4,±5}`, c=8e4 | **2 components, both non-convex** (κ_min=−4.11) |
| 3 | 9 | equilateral triangle of radial triples, c=1.5e9 | **3 non-convex components** (κ_min=−1.64) |

## Scope / honesty

- **Numerical + documentation only — no Lean edit.** A Lean statement would require
  replacing the placeholder `maxNonConvexComponents := d` with a genuine non-convex
  component count, i.e. a semantic rewrite of a registered gallery file — unsafe
  under the current Docker + Aristotle blackout (cf. the `grunskyConjecture_false`
  soundness flag, open #24521).
- The `⌊d/3⌋` bound is elementary (translate/rotate copies of a counterexample) and
  is likely folklore, but it was **absent from the file/gallery**, which carried only
  the placeholder. The exact growth rate of Goodman's question — and whether `⌊d/3⌋`
  is tight — remains **OPEN**.
- Does not touch the onset work (#24420) or the axiom-soundness flag (#24521).

## Test plan

- [x] `python3 research/problems/erdos-1047-oq-02/multi_cluster_lower_bound.py` —
      STEP 0 reproduces the single-triple non-convex blob; k=2 and k=3 both PASS
      (≥k simultaneous non-convex components). Deterministic (no Date/RNG); reuses
      the existing `verify_lemniscate_curvature.py` curvature machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)