### PR TITLE
research(morleys-theorem-oq-03): register MorleysTheoremOQ03 for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2615,6 +2615,7 @@ import Proofs.MinpolyCharpolyOQ03OQ01
 import Proofs.MobiusInversionIE
 import Proofs.MorleysTheorem
 import Proofs.MorleysTheoremOQ01
+import Proofs.MorleysTheoremOQ03
 import Proofs.MoserTardos
 import Proofs.MotivicFlagMaps
 import Proofs.MotivicFlagMapsOQ03

--- a/proofs/Proofs/MorleysTheoremOQ03.lean
+++ b/proofs/Proofs/MorleysTheoremOQ03.lean
@@ -139,9 +139,9 @@ theorem morley_side_le_equilateral {R α β γ : ℝ} (hR : 0 ≤ R)
   have hc : γ / 3 ∈ Icc (0 : ℝ) π := by
     have := div_three_mem_Icc hγ hα hβ (by linarith); simpa using this
   -- Nonnegativity of the three sines.
-  have hsa : 0 ≤ sin (α / 3) := sin_nonneg_of_mem_Icc ha
-  have hsb : 0 ≤ sin (β / 3) := sin_nonneg_of_mem_Icc hb
-  have hsc : 0 ≤ sin (γ / 3) := sin_nonneg_of_mem_Icc hc
+  have hsa : 0 ≤ sin (α / 3) := sin_nonneg_of_nonneg_of_le_pi ha.1 ha.2
+  have hsb : 0 ≤ sin (β / 3) := sin_nonneg_of_nonneg_of_le_pi hb.1 hb.2
+  have hsc : 0 ≤ sin (γ / 3) := sin_nonneg_of_nonneg_of_le_pi hc.1 hc.2
   -- The trisected mean is exactly π/9.
   have hmean : (α / 3 + β / 3 + γ / 3) / 3 = π / 9 := by
     rw [show (α / 3 + β / 3 + γ / 3) / 3 = (α + β + γ) / 9 by ring, hsum]


### PR DESCRIPTION
## Summary

`MorleysTheoremOQ03.lean` — the extremal result that the Morley equilateral triangle is
largest at the equilateral input triangle — is on `main`, 0 sorry / 0 axiom, 211 lines,
but was **never registered** in `proofs/Proofs.lean`, so it has only been inspection-verified.
This PR adds the import line so CI compiles it.

Contents (5 theorems):
- `amgm_three` — AM–GM for three nonnegatives, cubed form (explicit SOS certificate).
- `sin_jensen_three` — three-point Jensen for `sin` on `[0,π]` (chained two-point concavity).
- `morley_side_le_equilateral` — `s(α,β,γ) = 8R·sin(α/3)sin(β/3)sin(γ/3) ≤ 8R·sin³(π/9)`.
- `morley_side_equilateral` — the equilateral attains the bound.
- `morley_side_max` — packaged "maximum at the equilateral".

## Hardening note

The file was written during the Docker / `lake build` blackout. I replaced its three
`sin_nonneg_of_mem_Icc` calls (which I could not name-check) with
`sin_nonneg_of_nonneg_of_le_pi` applied to the `Icc` endpoints — a long-standing canonical
Mathlib lemma. No semantic change. Other non-trivial names (`strictConcaveOn_sin_Icc`,
`pow_le_pow_left₀`) are verified against prior in-repo usage.

## Test plan
- [ ] CI build gate compiles `Proofs.MorleysTheoremOQ03`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)