### PR TITLE
audit(erdos-191): correct stale sorry count 1→0 in meta.json

### DIFF
--- a/src/data/proofs/erdos-191/meta.json
+++ b/src/data/proofs/erdos-191/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 191,
     "erdosUrl": "https://erdosproblems.com/191",
     "erdosProblemStatus": "solved",
@@ -70,7 +70,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 357,
-    "assumptions": "4 axioms: erdos_191, rodl_upper_construction, conlon_fox_sudakov_bound, tripleLog_unbounded. 1 sorry.",
+    "assumptions": "4 axioms: erdos_191, rodl_upper_construction, conlon_fox_sudakov_bound, tripleLog_unbounded. 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 13
   },
@@ -222,7 +222,7 @@
     "theoremCount": 10,
     "definitionCount": 13,
     "path": "Proofs/Erdos191Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -271,5 +271,5 @@
       "note": "Partition theory for combinatorial structures"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-191
**Severity**: HIGH (sorry-count mismatch)

## Evidence

`proofs/Proofs/Erdos191Problem.lean` contains **0 sorries** and **4 axioms** (`erdos_191`, `rodl_upper_construction`, `conlon_fox_sudakov_bound`, `tripleLog_unbounded`). The last sorry, `small_n_bound` (∑ 1/log x ≤ 10 over X ⊆ {2..10}), was fully proved in #24485.

`meta.json` still claimed **1 sorry** in all three `sorries` fields and the `assumptions` string.

## Fix

- `sorries`: 1 → 0 (all three occurrences)
- `assumptions`: "... 1 sorry." → "... 0 sorries."

`axiomCount` (4) is correct and unchanged; `status` remains `axiomatized` / badge `axiom` (4 axioms present).

---
Discovered during gallery integrity audit. Doc-only change to `src/data/proofs/erdos-191/meta.json`.