### PR TITLE
research(four-square-distribution-oq-04): S6 keystone assembly — sign×arrangement into the Decomp fiber-size lemma

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04Keystone.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04Keystone.lean
@@ -1,0 +1,185 @@
+import Mathlib
+import Proofs.FourSquareDistributionOQ04Decomp
+import Proofs.FourSquareDistributionOQ04Sign
+
+/-
+# Four-Square Distribution — OQ-04: the keystone assembly
+
+## Where this fits
+
+The open question reduces, via `FourSquareDistributionOQ04Decomp.lean`, to one
+orbit-size lemma `fiber_card_eq_contribution`: each `shape`-fiber of the genuine
+representation set `reps m n` has size
+
+  (★)   `m! / ∏_v (count_v s)! · 2^{#nonzero}`.
+
+Two pieces of `(★)` are already in place on `main`:
+
+* `FourSquareDistributionOQ04Sign.signFiber_card` — the **sign-count half**
+  `2^{#nonzero}` (the number of sign-flips of a fixed coordinate profile), proved
+  unconditionally;
+* the **arrangement-count half** `m! / ∏_v (count_v)!` — the multiset-permutation
+  count, isolated as the single residue `arrangement_card` (canonical
+  `Nat.multinomial` form set up in PR #24518).
+
+The Sign file's trailing blueprint lists the remaining bookkeeping as steps 1 & 3:
+(1) each fiber of the coordinatewise absolute-value map equals a `signFiber`, and
+(3) assemble the keystone from the fiberwise sum. **Those two steps were described
+but never encoded in Lean.** This file encodes them.
+
+## What this file proves (all unconditional except the named residue)
+
+* `absFiber_eq_signFiber` — step (1): for an absolute-value profile `g` realized on
+  the shape-fiber, the set of representations with `|f ·| = g` is *exactly*
+  `signFiber g`. (Every sign-flip of a representation is again a representation of
+  the same shape; conversely a fiber element is recovered up to coordinate signs.)
+* `nonzero_card_eq` — the `#nonzero` bridge: the number of nonzero coordinates of
+  such a `g` equals `#nonzero s` (constant across the fiber), via
+  `Multiset.countP_map`.
+* `shapeFiber_card_eq_arrangements_mul` — step (3), **unconditional**: the
+  shape-fiber size is `(#abs-profiles) · 2^{#nonzero s}`, i.e. the arrangement
+  count times the sign count, by `Finset.card_eq_sum_card_fiberwise` over the
+  absolute-value map.
+* `fiber_card_eq_contribution` — the Decomp keystone, derived from the previous
+  line **modulo the single arrangement-count residue** supplied as a hypothesis
+  `harr` (exactly the statement of #24518's `arrangement_card_div_form`, identified
+  with the abs-profile image here). With `harr` discharged, this *is* the open
+  question for every `m, n`.
+
+This file therefore collapses the entire open question to the one combinatorial
+lemma `arrangement_card`, with **no `sorry` of its own** — the residue is an
+explicit hypothesis, not an axiom or `sorry`.
+
+## Honesty / build status
+
+Authored under a Docker + Aristotle backend outage (`docker info` timed out;
+Aristotle `prove` previously returned 404), so this is **build-pending** and
+**unregistered** in `Proofs.lean`; a build-enabled session should register it and
+adjust any imports. It uses only `Finset`/`Multiset`/`Fintype.piFinset` API with
+the repo-precedented lemmas `Finset.card_eq_sum_card_fiberwise`,
+`Multiset.countP_map`, `Multiset.countP_eq_card_filter`. The end-to-end claim
+(fiber size `= (★)`) is independently certified for all `m ≤ 5`, `n ≤ 12` by
+`research/problems/four-square-distribution-oq-04/verify_orbit_formula.py`.
+-/
+
+namespace FourSquareDistributionOQ04Keystone
+
+open Finset
+open FourSquareDistributionOQ04Decomp
+open FourSquareDistributionOQ04Sign
+
+/-- The coordinatewise absolute-value profile of a tuple. Note `shape f` is exactly
+`Multiset.map (absMap f) univ.val`. -/
+def absMap {m : ℕ} (f : Fin m → ℤ) : Fin m → ℤ := fun i => |f i|
+
+/-- The shape-fiber: representations of `n` whose absolute-value multiset is `s`. -/
+def shapeFiber (m n : ℕ) (s : Multiset ℤ) : Finset (Fin m → ℤ) :=
+  (reps m n).filter (fun f => shape f = s)
+
+theorem shape_eq_map_absMap {m : ℕ} (f : Fin m → ℤ) :
+    shape f = Multiset.map (absMap f) (Finset.univ : Finset (Fin m)).val := rfl
+
+/-! ## Step 1: each abs-profile fiber is a `signFiber` -/
+
+/-- **Step (1) of the Sign-file blueprint.** For an absolute-value profile `g`
+attained on the shape-fiber, the representations with `absMap f = g` are exactly
+the sign-flips `signFiber g`. -/
+theorem absFiber_eq_signFiber {m n : ℕ} (s : Multiset ℤ) (g : Fin m → ℤ)
+    (hg : g ∈ (shapeFiber m n s).image absMap) :
+    (shapeFiber m n s).filter (fun f => absMap f = g) = signFiber g := by
+  classical
+  obtain ⟨f₀, hf₀F, hf₀g⟩ := Finset.mem_image.mp hg
+  obtain ⟨hf₀reps, hf₀shape⟩ := Finset.mem_filter.mp hf₀F
+  -- The witness gives: `g ≥ 0`, `multiset(g) = s`, and `Σ (g i)² = n`.
+  have hgnonneg : ∀ i, 0 ≤ g i := by
+    intro i; rw [← hf₀g]; exact abs_nonneg _
+  have hms : Multiset.map g (Finset.univ : Finset (Fin m)).val = s := by
+    rw [← hf₀g]; exact hf₀shape
+  have hsum : ∑ i, (g i) ^ 2 = (n : ℤ) := by
+    have hsq : ∀ i, (g i) ^ 2 = (f₀ i) ^ 2 := by
+      intro i; rw [← hf₀g]; exact sq_abs (f₀ i)
+    simp_rw [hsq]; exact (mem_reps_iff f₀).mp hf₀reps
+  ext f
+  simp only [shapeFiber, Finset.mem_filter, signFiber, Fintype.mem_piFinset,
+    Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · -- A fiber element is a sign-flip of `g`.
+    rintro ⟨⟨_, _⟩, hfabs⟩ i
+    have habs : |f i| = g i := congrFun hfabs i
+    rcases abs_cases (f i) with ⟨h1, _⟩ | ⟨h1, _⟩
+    · left; rw [← h1, habs]
+    · right; rw [h1] at habs; linarith [habs]
+  · -- A sign-flip of `g` is a representation of shape `s` with profile `g`.
+    intro hf
+    have habs : ∀ i, |f i| = g i := by
+      intro i
+      rcases hf i with h | h
+      · rw [h, abs_of_nonneg (hgnonneg i)]
+      · rw [h, abs_neg, abs_of_nonneg (hgnonneg i)]
+    have hfabs : absMap f = g := funext habs
+    have hsqeq : ∀ i, (f i) ^ 2 = (g i) ^ 2 := by
+      intro i; rw [← sq_abs (f i), habs i]
+    have hfreps : f ∈ reps m n := by
+      rw [mem_reps_iff]; simp_rw [hsqeq]; exact hsum
+    have hfshape : shape f = s := by
+      rw [shape_eq_map_absMap, hfabs]; exact hms
+    exact ⟨⟨hfreps, hfshape⟩, hfabs⟩
+
+/-! ## The `#nonzero` bridge -/
+
+/-- The number of nonzero coordinates of an attained abs-profile `g` equals the
+number of nonzero parts of `s` (constant across the shape-fiber). -/
+theorem nonzero_card_eq {m n : ℕ} (s : Multiset ℤ) (g : Fin m → ℤ)
+    (hg : g ∈ (shapeFiber m n s).image absMap) :
+    ((Finset.univ : Finset (Fin m)).filter (fun i => g i ≠ 0)).card
+      = Multiset.card (s.filter (fun v => v ≠ 0)) := by
+  classical
+  obtain ⟨f₀, hf₀F, hf₀g⟩ := Finset.mem_image.mp hg
+  obtain ⟨_, hf₀shape⟩ := Finset.mem_filter.mp hf₀F
+  have hms : Multiset.map g (Finset.univ : Finset (Fin m)).val = s := by
+    rw [← hf₀g]; exact hf₀shape
+  rw [← hms, ← Multiset.countP_eq_card_filter, Multiset.countP_map]
+  rfl
+
+/-! ## Step 3: the shape-fiber size, unconditionally -/
+
+/-- **Step (3), unconditional.** The shape-fiber decomposes over the
+absolute-value map into one `signFiber` per attained abs-profile, each of size
+`2^{#nonzero s}`; hence the fiber has size `(#abs-profiles) · 2^{#nonzero s}`. -/
+theorem shapeFiber_card_eq_arrangements_mul (m n : ℕ) (s : Multiset ℤ) :
+    (shapeFiber m n s).card
+      = ((shapeFiber m n s).image absMap).card
+          * 2 ^ Multiset.card (s.filter (fun v => v ≠ 0)) := by
+  classical
+  set M : ℕ := Multiset.card (s.filter (fun v => v ≠ 0)) with hM
+  have key : ∀ g ∈ (shapeFiber m n s).image absMap,
+      ((shapeFiber m n s).filter (fun f => absMap f = g)).card = 2 ^ M := by
+    intro g hg
+    rw [absFiber_eq_signFiber s g hg, signFiber_card]
+    rw [hM]; congr 1; exact nonzero_card_eq s g hg
+  rw [Finset.card_eq_sum_card_fiberwise
+      (fun f hf => Finset.mem_image_of_mem absMap hf)]
+  rw [Finset.sum_congr rfl key, Finset.sum_const, smul_eq_mul]
+
+/-! ## The keystone, modulo the arrangement-count residue -/
+
+/-- **The Decomp keystone**, derived modulo the single arrangement-count residue
+`harr`. `harr` is exactly #24518's `arrangement_card_div_form`, with the canonical
+arrangement set identified here as the absolute-value image of the shape-fiber.
+
+With `harr` discharged (the `Equiv.Perm (Fin m)` orbit–stabilizer count), this is
+`fiber_card_eq_contribution` from `FourSquareDistributionOQ04Decomp.lean`, hence
+the open question `r_{2k}(n) = Σ_shapes shapeContribution` for every `m, n`. -/
+theorem fiber_card_eq_contribution {m n : ℕ} (s : Multiset ℤ)
+    (harr : ((shapeFiber m n s).image absMap).card
+              = m.factorial / (s.toFinset.prod (fun v => (s.count v).factorial))) :
+    (shapeFiber m n s).card = shapeContribution m s := by
+  rw [shapeFiber_card_eq_arrangements_mul, harr]
+  rfl
+
+#check @absFiber_eq_signFiber
+#check @nonzero_card_eq
+#check @shapeFiber_card_eq_arrangements_mul
+#check @fiber_card_eq_contribution
+
+end FourSquareDistributionOQ04Keystone

--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -105,6 +105,53 @@ signed-square convolution *and* the embedded total. Largest single `m=6` orbit
 seen: `(0,0,1,2,3,4) → 5760` at `n=30`; all-nonzero-distinct would give
 `6!·2⁶ = 46080`.
 
+### Session 2026-06-15 (ACT) — the keystone ASSEMBLY (Sign-blueprint steps 1 & 3), build-pending
+
+**Mode**: continue · **Outcome**: ACT (the previously-missing Lean wiring that
+turns the Sign-file blueprint into a proof; Docker + Aristotle blackout ⟹
+build-pending, UNREGISTERED).
+
+The open question was, by now, reduced to ONE residue. The chain on `main`:
+- `Decomp.lean` keystone `fiber_card_eq_contribution` (`sorry`): fiber size = (★).
+- `Sign.lean` `signFiber_card` (proved): the sign half `2^{#nonzero}`.
+- residue `arrangement_card` = `m!/∏count!` (the arrangement half), set up in
+  `Nat.multinomial` form by **open PR #24518** (`Arrange.lean`, also `sorry`).
+
+The Sign file's trailing comment listed steps (1) `absFiber_eq_signFiber` and (3)
+the fiberwise assembly as "remaining bookkeeping" but **never encoded them in
+Lean**. This session encodes them in `FourSquareDistributionOQ04Keystone.lean`
+(0 sorry / 0 axiom of its own):
+
+- `absFiber_eq_signFiber` (step 1, **unconditional**): for an abs-profile `g`
+  attained on the shape-fiber, `{f | shape f = s, |f|=g} = signFiber g`. Witness
+  `f₀` from the image gives `g ≥ 0`, `multiset(g)=s`, `Σ(g i)²=n`; forward via
+  `abs_cases`, backward via `abs_of_nonneg`/`abs_neg` + `sq_abs` rebuilding
+  membership in `reps`/`shape`. Key subtlety: `g ≥ 0` so `|g i| = g i`.
+- `nonzero_card_eq`: `#{i | g i ≠ 0} = #nonzero(s)` via
+  `rw [← Multiset.countP_eq_card_filter, Multiset.countP_map]` then `rfl`
+  (`Finset.filter`/`Multiset.filter` defeq). Bridges signFiber_card's
+  coordinate-exponent to shapeContribution's multiset-exponent.
+- `shapeFiber_card_eq_arrangements_mul` (step 3, **unconditional**): fiber =
+  `(#abs-profiles)·2^{#nonzero s}` via `Finset.card_eq_sum_card_fiberwise` over
+  `absMap` + `Finset.sum_const` (each summand constant by the two lemmas above).
+- `fiber_card_eq_contribution`: the Decomp keystone, conditional on `harr` (=
+  `((shapeFiber).image absMap).card = m!/∏count!` = #24518's
+  `arrangement_card_div_form`); final `rfl` against `shapeContribution`.
+
+**Net effect.** The open question is now `sorry`-free *except* the single residue
+`arrangement_card`. Everything from "fiber size = (★)" down to the
+sign/arrangement split is proved (modulo that one count).
+
+**Cert (new)** `verify_keystone_assembly.py` (PASS: 62 shape-fibers + 441
+sign-fibers, m≤5/n≤12): brute-checks step 1 (each abs-fiber = the signed product
+`∏{g_i,-g_i}`) and step 3 (fiber = #profiles·2^{#nonzero}) directly against the
+genuine `reps(m,n)`; cross-checks the residue and full (★).
+
+**API pinned** (repo-precedented; no Mathlib source materialized under blackout):
+`Finset.card_eq_sum_card_fiberwise` (Erdos40, CountingG7),
+`Multiset.countP_map` (`= (s.filter fun a => p (f a)).card`) +
+`countP_eq_card_filter` (DescartesRuleOfSignsOQ01), `Finset.mem_image_of_mem _ h`.
+
 ## Next steps
 
 1. **ACT (Lean, Docker-gated).** For a FIXED small `m = 2k ∈ {4,6,8}` (avoids the

--- a/research/problems/four-square-distribution-oq-04/state.md
+++ b/research/problems/four-square-distribution-oq-04/state.md
@@ -4,18 +4,28 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T03:35:20-07:00
-**Iteration**: 2
+**Iteration**: 6
 
 ## Current Focus
-Generalization of the four-square type-decomposition to r_{2k}(n) under the
-hyperoctahedral group B_{2k} = S_{2k} ⋉ (Z/2)^{2k} CONFIRMED: orbit size
-2^{#nonzero}·(2k)!/∏m_i!, stabilizer 2^z·z!·∏(nonzero m_j!), and
-r_{2k}(n) = Σ_shapes orbit. Verified exactly for 2k ∈ {2,4,6,8}; Mathlib
-orbit–stabilizer bearer pinned.
+The whole open question now reduces (via Decomp.lean) to ONE lemma:
+`fiber_card_eq_contribution` — each shape-fiber has size (★) = m!/∏count!·2^#nonzero.
+This is the product of (a) the sign-count 2^#nonzero (Sign.lean, proved) and
+(b) the arrangement-count m!/∏count! (the residue `arrangement_card`, in flight
+PR #24518). This session encoded the previously-missing **assembly** wiring (a)
+and (b) into the keystone (Keystone.lean), leaving only the single residue.
 
 ## Active Approach
-Build-free ORIENT (Docker + Aristotle both down this session). Durable exact
-verifier `verify_hyperoctahedral_2k.py` (all checks pass).
+Build-free ACT (Docker + Aristotle both down). New file
+`FourSquareDistributionOQ04Keystone.lean` (0 sorry / 0 axiom) proves, modulo the
+named arrangement-count residue, the Decomp keystone:
+- `absFiber_eq_signFiber` (step 1): abs-map fiber = signFiber, UNCONDITIONAL.
+- `nonzero_card_eq`: #nonzero(g) = #nonzero(s) via `Multiset.countP_map`.
+- `shapeFiber_card_eq_arrangements_mul` (step 3): fiber = #profiles·2^#nonzero,
+  UNCONDITIONAL, via `Finset.card_eq_sum_card_fiberwise`.
+- `fiber_card_eq_contribution`: keystone, conditional on `harr` (= #24518's
+  arrangement_card_div_form).
+Certified end-to-end by `verify_keystone_assembly.py` (62 fibers, 441 sign-fibers,
+m≤5/n≤12, all PASS).
 
 ## Attempt Count
 - Total attempts: 1
@@ -28,8 +38,10 @@ verifier `verify_hyperoctahedral_2k.py` (all checks pass).
   `Equiv.Perm (Fin 2k)` + sign flips.
 
 ## Next Action
-ACT (next Docker session): for fixed m = 2k ∈ {4,6,8}, define the B_m MulAction on
-`{f : Fin m → ℤ // Σ f² = n}`, compute the stabilizer order (zero/nonzero split),
-and apply `MulAction.card_orbit_mul_card_stabilizer_eq_card_group` for the
-orbit-size formula. The real obstruction is the orbit PARTITION
-(r_{2k} = Σ orbit), not the orbit-size formula.
+The SOLE remaining residue is `arrangement_card` (PR #24518): the number of
+arrangements of a size-m multiset = `Nat.multinomial`. Proof route: the
+`Equiv.Perm (Fin m)` precomposition action — orbit of an arrangement = all
+arrangements; stabilizer {σ | g∘σ = g} ≅ ∏_v Perm(g⁻¹{v}) of order ∏count!; then
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group`. Once that lands AND a
+build session is available, register Decomp/Sign/Keystone in Proofs.lean and
+discharge `harr` to make `fiber_card_eq_contribution` (Decomp) unconditional.

--- a/research/problems/four-square-distribution-oq-04/verify_keystone_assembly.py
+++ b/research/problems/four-square-distribution-oq-04/verify_keystone_assembly.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Certificate for FourSquareDistributionOQ04Keystone.lean.
+
+The Lean file proves, UNCONDITIONALLY (no sorry, no axiom), the two
+bookkeeping steps of the Sign-file blueprint:
+
+  Step 1 (absFiber_eq_signFiber):
+      { f : reps(m,n) | shape f = s, |f| = g } = signFiber(g)
+      i.e. the fiber of the absolute-value map over an attained profile g
+      is exactly the set of sign-flips of g.
+
+  Step 3 (shapeFiber_card_eq_arrangements_mul):
+      |{ f : reps(m,n) | shape f = s }|
+          = (# distinct abs-profiles g of shape s realized in reps(m,n))
+            * 2 ^ (#nonzero parts of s)
+
+This script checks BOTH against brute enumeration of the genuine
+representation set reps(m,n) = { f in Z^m : sum f_i^2 = n }, for all
+m <= 5 and n <= 12.  The only remaining (conditional) input to the Lean
+keystone is then
+
+      #abs-profiles of shape s = m! / prod_v (count_v)!     (arrangement_card)
+
+which is certified separately by verify_orbit_formula.py (check_arrangement).
+
+This file does NOT re-prove that residue; it isolates exactly the part the
+new Lean file discharges, so a reader can see the unconditional content is
+sound independent of arrangement_card.
+
+Run:  python3 verify_keystone_assembly.py
+Exit 0 on success; raises AssertionError on any mismatch.
+"""
+
+from itertools import product
+from collections import Counter
+from math import factorial, prod
+
+
+def reps(m, n):
+    """All integer m-tuples with sum of squares = n (box [-n,n]^m is lossless)."""
+    rng = range(-n, n + 1)
+    out = []
+    for f in product(rng, repeat=m):
+        if sum(x * x for x in f) == n:
+            out.append(f)
+    return out
+
+
+def shape(f):
+    """Multiset of absolute values, as a sorted tuple."""
+    return tuple(sorted(abs(x) for x in f))
+
+
+def abs_profile(f):
+    """The coordinatewise |f| (an arrangement of shape f)."""
+    return tuple(abs(x) for x in f)
+
+
+def nonzero_count(s):
+    return sum(1 for v in s if v != 0)
+
+
+def arrangement_count_formula(s):
+    """m! / prod_v (count_v)! for the multiset s (a tuple)."""
+    m = len(s)
+    counts = Counter(s)
+    return factorial(m) // prod(factorial(c) for c in counts.values())
+
+
+def check(m_max=5, n_max=12):
+    checked_fibers = 0
+    checked_step1 = 0
+    for m in range(1, m_max + 1):
+        for n in range(0, n_max + 1):
+            R = reps(m, n)
+            # group representations by shape
+            by_shape = {}
+            for f in R:
+                by_shape.setdefault(shape(f), []).append(f)
+            for s, fiber in by_shape.items():
+                # --- Step 1: each abs-profile fiber is the set of sign-flips ---
+                profiles = {}
+                for f in fiber:
+                    profiles.setdefault(abs_profile(f), []).append(f)
+                for g, signfiber in profiles.items():
+                    # signFiber(g): all tuples agreeing with g up to sign,
+                    # which (since these are representations) is exactly the
+                    # product over coordinates of {g_i, -g_i}.
+                    choices = [(-c, c) if c != 0 else (0,) for c in g]
+                    brute_signfiber = set(product(*[set(ch) for ch in choices]))
+                    assert set(signfiber) == brute_signfiber, (
+                        f"Step1 fail m={m} n={n} g={g}: "
+                        f"{set(signfiber)} != {brute_signfiber}"
+                    )
+                    # each sign fiber has size 2^(#nonzero of g)
+                    assert len(signfiber) == 2 ** nonzero_count(g)
+                    checked_step1 += 1
+
+                # --- Step 3: fiber = (#profiles) * 2^(#nonzero s) ---
+                nz = nonzero_count(s)
+                assert len(fiber) == len(profiles) * (2 ** nz), (
+                    f"Step3 fail m={m} n={n} s={s}: "
+                    f"{len(fiber)} != {len(profiles)} * 2^{nz}"
+                )
+                # cross-check the (conditional) residue too, for confidence
+                assert len(profiles) == arrangement_count_formula(s), (
+                    f"arrangement residue fail m={m} n={n} s={s}: "
+                    f"{len(profiles)} != {arrangement_count_formula(s)}"
+                )
+                # and the full (★): fiber = m!/prod count! * 2^nonzero
+                assert len(fiber) == arrangement_count_formula(s) * (2 ** nz)
+                checked_fibers += 1
+    return checked_fibers, checked_step1
+
+
+if __name__ == "__main__":
+    nf, ns = check()
+    print(f"PASS: {nf} shape-fibers and {ns} sign-fibers verified "
+          f"(m<=5, n<=12).")
+    print("  Step 1 (absFiber_eq_signFiber): OK")
+    print("  Step 3 (shapeFiber = #profiles * 2^nonzero): OK")
+    print("  arrangement residue and full (star): OK (cross-check)")


### PR DESCRIPTION
## Summary

The four-square distribution OQ-04 (does the type-decomposition generalize to
`r_{2k}(n)`?) had been reduced, across prior sessions, to a single orbit-size
lemma `fiber_card_eq_contribution` (in `FourSquareDistributionOQ04Decomp.lean`):
each `shape`-fiber of the genuine representation set has size

  (★) `m! / ∏_v (count_v)! · 2^{#nonzero}`.

Two halves of (★) were already on `main`/in-flight:
- the **sign half** `2^{#nonzero}` — `Sign.signFiber_card` (proved on main);
- the **arrangement half** `m!/∏count!` — the residue `arrangement_card`, set up
  in `Nat.multinomial` form by open PR #24518.

The Sign file's trailing blueprint named the remaining bookkeeping (steps 1 & 3)
but **never encoded it in Lean**. This PR adds that wiring in a new companion
`FourSquareDistributionOQ04Keystone.lean` (**0 sorry / 0 axiom of its own**):

- `absFiber_eq_signFiber` (step 1, **unconditional**) — the absolute-value-map
  fiber of the shape-fiber is exactly `signFiber g`.
- `nonzero_card_eq` — `#nonzero(g) = #nonzero(s)` via `Multiset.countP_map`
  (bridges the coordinate exponent to the multiset exponent).
- `shapeFiber_card_eq_arrangements_mul` (step 3, **unconditional**) — fiber =
  `(#abs-profiles) · 2^{#nonzero s}` via `Finset.card_eq_sum_card_fiberwise`.
- `fiber_card_eq_contribution` — the Decomp keystone, derived **modulo the single
  arrangement-count residue** `harr` (exactly #24518's `arrangement_card_div_form`).

**Net effect:** the open question is now `sorry`-free *except* the one
combinatorial residue `arrangement_card` (the `Equiv.Perm (Fin m)`
orbit–stabilizer count, the genuine remaining work).

## Verification

`research/problems/four-square-distribution-oq-04/verify_keystone_assembly.py`
brute-checks both unconditional steps against the genuine `reps(m,n)` for all
`m ≤ 5`, `n ≤ 12`: **62 shape-fibers + 441 sign-fibers, all PASS** (step 1 = signed
product `∏{g_i,-g_i}`; step 3 = `#profiles · 2^{#nonzero}`), plus cross-checks of
the residue and the full (★).

## Build status

Authored under a Docker + Aristotle blackout (`docker info` timed out; Aristotle
`prove` previously 404), so **build-pending** and **UNREGISTERED** in `Proofs.lean`.
Uses only repo-precedented API (`Finset.card_eq_sum_card_fiberwise`,
`Multiset.countP_map`, `countP_eq_card_filter`). A build-enabled session should
register Decomp/Sign/Keystone and, once #24518's `arrangement_card` lands,
discharge `harr` to make the Decomp keystone unconditional.

## Test plan
- [ ] `python3 research/problems/four-square-distribution-oq-04/verify_keystone_assembly.py` → PASS
- [ ] (build session) `./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04Keystone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)