### PR TITLE
research(erdos-1179-oq-02): S2 — concrete trivial lower bound N ≤ 2^|A| for ε-uniform subsets (axiom-free)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1007,6 +1007,7 @@ import Proofs.Erdos1176Problem
 import Proofs.Erdos1177Problem
 import Proofs.Erdos1178Problem
 import Proofs.Erdos1179OQ01
+import Proofs.Erdos1179OQ02
 import Proofs.Erdos1179Problem
 import Proofs.Erdos117OQ01
 import Proofs.Erdos117OQ01Aristotle

--- a/proofs/Proofs/Erdos1179OQ02.lean
+++ b/proofs/Proofs/Erdos1179OQ02.lean
@@ -1,0 +1,104 @@
+/-
+Proof: Concrete trivial lower bound for Erdős #1179 oq-02.
+Date: 2026-06-15 (S2)
+Research: erdos-1179-oq-02 (researcher-8)
+
+Erdős #1179 (PROVED, Erdős–Hall 1976) establishes that the minimal number
+of random group elements needed for an ε-uniform subset-sum representation
+function is `g_ε(N) = (1 + o_ε(1)) · log₂ N`.  oq-02 asks whether the
+`(1 + o(1))` multiplicative factor can be sharpened to a bounded additive
+error `g_ε(N) ≤ log₂ N + O_ε(1)`, matching the trivial lower bound
+`g_ε(N) ≥ log₂ N`.
+
+This file formalises the **trivial lower bound** at the level of an individual
+subset `A`, axiom-free.  The parent file `Proofs/Erdos1179Problem.lean` only
+states the lower bound abstractly as `axiom basic_lower_bound` (about the
+opaque, group-and-probability-quantified `gEps`).  Here we prove the concrete,
+per-subset statement that underlies it:
+
+    if `A` is ε-uniform with `ε < 1`, then `N ≤ 2 ^ |A|`,
+
+hence `⌈log₂ N⌉ ≤ |A|`.  Every ε-uniform subset must already have at least
+`log₂ N` elements — the matching target of oq-02's conjectured upper bound.
+
+Mathematical content.  ε-uniformity with `ε < 1` forces every representation
+count to be strictly positive: `F_A(g) ≥ (1 - ε)·μ > 0` where `μ = 2^|A|/N > 0`.
+Since `F_A(g)` is a natural number this gives `F_A(g) ≥ 1` for all `g`, so
+
+    2 ^ |A| = ∑_g F_A(g) ≥ ∑_g 1 = N            (parent `total_reprCount`).
+
+Relation to the parent.  The parent's `uniform_implies_spanning` proves the
+same spanning conclusion (`∀ g, F_A(g) ≥ 1`) but only under the *extra*
+hypothesis `|A| ≥ ⌈log₂ N⌉` — i.e. it assumes the lower bound it would help
+establish.  `epsUniform_spanning` below removes that circular hypothesis: only
+`ε < 1` is needed, because `μ > 0` already follows from `N ≥ 1` without any
+lower bound on `|A|`.  The lower bound is then a genuine *consequence*, not an
+assumption.
+
+No axioms; depends only on `Erdos1179.total_reprCount` and
+`Erdos1179.expectedReprCount_pos` from `Proofs/Erdos1179Problem.lean`.
+-/
+
+import Proofs.Erdos1179Problem
+import Mathlib
+
+namespace Erdos1179
+
+open Finset Real
+
+/-- **Spanning from ε-uniformity, hypothesis-free.**  If `A` is ε-uniform with
+`ε < 1`, then every group element has at least one subset-sum representation.
+
+Unlike the parent `uniform_implies_spanning`, this requires no lower bound on
+`A.card`: positivity of the expected count `μ = 2^|A| / N` (which holds for any
+`N ≥ 1`) together with `ε < 1` already forces `F_A(g) ≥ (1 - ε)·μ > 0`. -/
+theorem epsUniform_spanning {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (ε : ℝ) (hε1 : ε < 1)
+    (hunif : IsEpsUniform A ε) (g : G) :
+    1 ≤ reprCount A g := by
+  haveI : Nonempty G := ⟨0⟩
+  have hN1 : 1 ≤ Fintype.card G := Fintype.card_pos
+  have hμpos : 0 < expectedReprCount A.card (Fintype.card G) :=
+    expectedReprCount_pos hN1
+  -- From |F(g) - μ| ≤ ε·μ, the lower side gives F(g) ≥ (1 - ε)·μ.
+  have hge : (1 - ε) * expectedReprCount A.card (Fintype.card G)
+      ≤ (reprCount A g : ℝ) := by
+    have h := (abs_le.mp (hunif g)).1
+    nlinarith
+  -- (1 - ε)·μ > 0, so F(g) > 0, so the natural number F(g) is ≥ 1.
+  have hpos : (0 : ℝ) < (reprCount A g : ℝ) := by
+    have hprod : (0 : ℝ) < (1 - ε) * expectedReprCount A.card (Fintype.card G) :=
+      mul_pos (by linarith) hμpos
+    linarith
+  have hne : reprCount A g ≠ 0 := by
+    intro h; rw [h] at hpos; simp at hpos
+  omega
+
+/-- **Concrete trivial lower bound (exact form).**  Any ε-uniform subset `A`
+(with `ε < 1`) of an abelian group of order `N` satisfies `N ≤ 2 ^ |A|`.
+
+Proof: each of the `N` group elements has at least one representation
+(`epsUniform_spanning`), and the representation counts sum to `2 ^ |A|`
+(`total_reprCount`). -/
+theorem card_le_two_pow_of_epsUniform {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (ε : ℝ) (hε1 : ε < 1)
+    (hunif : IsEpsUniform A ε) :
+    Fintype.card G ≤ 2 ^ A.card :=
+  calc Fintype.card G = (Finset.univ : Finset G).card := Finset.card_univ.symm
+    _ = ∑ _g : G, 1 := Finset.card_eq_sum_ones _
+    _ ≤ ∑ g : G, reprCount A g :=
+        Finset.sum_le_sum (fun g _ => epsUniform_spanning A ε hε1 hunif g)
+    _ = 2 ^ A.card := total_reprCount A
+
+/-- **Concrete trivial lower bound (logarithmic form).**  Any ε-uniform subset
+`A` (with `ε < 1`) has at least `⌈log₂ N⌉` elements, where `N` is the group
+order.  This is the integer form of the headline bound `g_ε(N) ≥ log₂ N`:
+`Nat.clog 2 N = ⌈log₂ N⌉`. -/
+theorem clog_le_card_of_epsUniform {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (ε : ℝ) (hε1 : ε < 1)
+    (hunif : IsEpsUniform A ε) :
+    Nat.clog 2 (Fintype.card G) ≤ A.card :=
+  (Nat.le_pow_iff_clog_le (by norm_num)).mp
+    (card_le_two_pow_of_epsUniform A ε hε1 hunif)
+
+end Erdos1179

--- a/src/data/research/problems/erdos-1179-oq-02.json
+++ b/src/data/research/problems/erdos-1179-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1179-oq-02",
   "title": "Erdős #1179 oq-02: can the Erdős–Hall bound be sharpened to an additive constant, g_ε(N) ≤ log₂N + O_ε(1)?",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "in-progress",
   "tier": "B",
   "path": "full",
@@ -28,15 +28,15 @@
     "goal": "ORIENT/DEFINE this 0-knowledge seeker stub: pin the precise additive-gap question, record the bound hierarchy (LB log₂N / Erdős–Rényi 2+o(1) / Erdős–Hall 1+o(1)), and commit a reproducible small-N experiment grounding the definitions and the lower bound."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-14T00:00:00.000Z",
-    "iteration": 1,
-    "focus": "DEFINE the bare seeker stub. Read parent Erdos1179Problem.lean (problem PROVED for the main asymptotic; reprCount, IsEpsUniform, Σ_g F_A(g)=2^|A|). Pinned oq-02 = the additive-constant sharpening g_ε(N) ≤ log₂N + O_ε(1) of the Erdős–Hall (1+o(1)) factor. Wrote verify_uniform_subset_sums.py: confirms the identity Σ_g F_A(g)=2^|A| (N≤9), the lower bound g_ε≥⌈log₂N⌉ (no ε-uniform k<log₂N, N≤12), and tabulates the exact empirical additive gap on ℤ/N. ALL CHECKS PASSED.",
+    "phase": "ACT",
+    "since": "2026-06-15 (S2 / concrete trivial lower bound)",
+    "iteration": 2,
+    "focus": "S2 ACT (researcher-8, 2026-06-15, Docker-down build-free): created Proofs/Erdos1179OQ02.lean (registered in Proofs.lean), formalising the TRIVIAL LOWER BOUND at the per-subset level, axiom-free. Three theorems in namespace Erdos1179: (1) epsUniform_spanning — IsEpsUniform A ε with ε<1 implies forall g, 1 <= reprCount A g, with NO lower-bound hypothesis on A.card (strictly improving the parent's uniform_implies_spanning, which assumes A.card >= Nat.clog 2 N — circular); the key is that mu=2^|A|/N>0 for any N>=1 so F(g)>=(1-eps)*mu>0. (2) card_le_two_pow_of_epsUniform — Fintype.card G <= 2 ^ A.card, via spanning + parent total_reprCount (sum_g F = 2^|A|). (3) clog_le_card_of_epsUniform — Nat.clog 2 (Fintype.card G) <= A.card (= ceil(log2 N) <= |A|), the integer form of g_eps(N) >= log2 N, via Nat.le_pow_iff_clog_le. 0 sorries, 0 axioms. NOT Docker-built (docker info times out); uses only standard Mathlib (abs_le, nlinarith, Finset.sum_le_sum, Finset.card_eq_sum_ones, Nat.le_pow_iff_clog_le) plus parent total_reprCount/expectedReprCount_pos. Empirical witness already on file: research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py (no eps-uniform k<log2 N for N<=12).",
     "blockers": [
       "The OQ is asymptotic/analytic — not decidable by finite computation; this session is ORIENT/DEFINE only.",
       "Verification infra (Docker + Aristotle) down this session — no Lean build; the contribution is build-free (problem definition + reproducible Python experiment)."
     ],
-    "nextAction": "DECOMPOSE: survey whether the Erdős–Hall error term log log log N / log log N is known to be improvable, and whether any class of abelian groups (e.g. ℤ/N vs elementary-abelian 2-groups) is conjectured to achieve g_ε(N) = log₂N + O_ε(1). If a Lean target is wanted, state the conjectured additive bound as an axiomatized target alongside the parent. Extend verify_uniform_subset_sums.py to compare ℤ/N against (ℤ/2)^m at matched N to test the single-group caveat.",
+    "nextAction": "On green Docker build, optionally state oq-02's CONJECTURED additive upper bound g_eps(N) <= log2 N + O_eps(1) as an axiomatized target alongside the parent erdos_hall_upper (the multiplicative 1+o(1) form), making the gap between proven lower bound (this file) and conjectured additive upper bound explicit. The asymptotic O_eps(1) claim itself is analytic/open and not finitely decidable.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -46,7 +46,8 @@
   "knowledge": {
     "progressSummary": "ORIENT (2026-06-14, S1): this slug was a 0-knowledge seeker stub (no problem.md, no tracked JSON). Defined it from the parent: Erdős #1179 (PROVED) establishes g_ε(N)=(1+o_ε(1))log₂N for uniform subset-sum representations in abelian groups; oq-02 asks whether the (1+o(1)) multiplicative factor can be sharpened to a bounded additive error g_ε(N) ≤ log₂N + O_ε(1), matching the trivial lower bound g_ε(N) ≥ log₂N up to O_ε(1). Recorded the bound hierarchy (Erdős–Rényi 1965: 2+o(1); Erdős–Hall 1976: 1 + O(log log log N / log log N)). Committed verify_uniform_subset_sums.py (build-free, stdlib): verifies the parent identity Σ_g F_A(g)=2^|A| (every subset of ℤ/N, N≤9), confirms no ε-uniform k below log₂N (N≤12), and tabulates the EXACT empirical additive gap g_ε(N)−log₂N on ℤ/N (stays ~1–3.5 for p=0.9, ε∈{0.5,0.9}). Honest caveats: tiny N and a single group cannot decide the asymptotic O_ε(1) question. Both backends down → ORIENT/DEFINE only.",
     "builtItems": [
-      "research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py — reproducible small-N experiment (identity check + lower-bound check + additive-gap table), ALL CHECKS PASSED."
+      "research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py — reproducible small-N experiment (identity check + lower-bound check + additive-gap table), ALL CHECKS PASSED.",
+      "Proofs/Erdos1179OQ02.lean (S2, researcher-8) — epsUniform_spanning (hypothesis-free), card_le_two_pow_of_epsUniform (N <= 2^|A|), clog_le_card_of_epsUniform (ceil(log2 N) <= |A|); 0 sorry/0 axiom."
     ],
     "insights": [
       "ε-uniformity with ε<1 forces every F_A(g)>0, so 2^k=Σ_g F_A(g)≥N gives the trivial lower bound g_ε(N)≥log₂N for free from the parent definitions.",
@@ -91,8 +92,10 @@
     ]
   },
   "started": "2026-06-14T00:00:00Z",
-  "lastUpdate": "2026-06-14T00:00:00.000Z",
+  "lastUpdate": "2026-06-15",
   "significance": 6,
   "tractability": 4,
-  "leanFiles": []
+  "leanFiles": [
+    "Proofs/Erdos1179OQ02.lean"
+  ]
 }


### PR DESCRIPTION
## Summary
First Lean file for **erdos-1179-oq-02** (the additive-constant sharpening of the Erdős–Hall bound). Adds `Proofs/Erdos1179OQ02.lean` (registered in `Proofs.lean`) formalising the **trivial lower bound** `g_ε(N) ≥ log₂N` at the per-subset level, **axiom-free**.

Three theorems in `namespace Erdos1179`:
- `epsUniform_spanning` — `IsEpsUniform A ε` with `ε < 1` ⟹ `∀ g, 1 ≤ reprCount A g`, **with no lower-bound hypothesis on `A.card`**. This strictly improves the parent's `uniform_implies_spanning`, which assumes `A.card ≥ ⌈log₂N⌉` — i.e. assumes the very bound it would help prove. The key observation: `μ = 2^|A|/N > 0` for any `N ≥ 1`, so `F(g) ≥ (1-ε)·μ > 0` directly.
- `card_le_two_pow_of_epsUniform` — `Fintype.card G ≤ 2 ^ A.card`, the exact form of the lower bound, via spanning + the parent identity `total_reprCount` (`∑_g F = 2^|A|`).
- `clog_le_card_of_epsUniform` — `Nat.clog 2 (Fintype.card G) ≤ A.card` (i.e. `⌈log₂N⌉ ≤ |A|`), the integer form of `g_ε(N) ≥ log₂N`.

## Why this matters
The parent `Erdos1179Problem.lean` only states the lower bound abstractly as `axiom basic_lower_bound` (about the opaque, group-and-probability-quantified `gEps`). This PR proves the concrete per-subset statement that actually underlies it, and removes a circular hypothesis from the existing spanning lemma. oq-02 conjectures the matching additive upper bound `g_ε(N) ≤ log₂N + O_ε(1)`; the lower bound formalised here is the target it must meet.

## Status
- 0 sorries, 0 axioms. Slug remains 0/0.
- **Not Docker-built** this session (`docker info` times out — ongoing blackout). Uses only standard Mathlib (`abs_le`, `nlinarith`, `Finset.sum_le_sum`, `Finset.card_eq_sum_ones`, `Nat.le_pow_iff_clog_le`) plus parent `total_reprCount` / `expectedReprCount_pos`.

## Test plan
- [ ] Deployer Docker build of `Proofs.Erdos1179OQ02` (build-gated).
- [ ] `python3 research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py` (existing empirical witness: no ε-uniform `k < log₂N` for `N ≤ 12`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)