### PR TITLE
audit(euler-identity-oq01x4): badge original→mathlib (Tier B Mathlib bridge)

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "unit-circle",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 147,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: euler-identity-oq-01-oq-01-oq-01-oq-01
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Evidence

`proofs/Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean` is fully machine-checked (0 sorries, 0 axioms — confirmed), but its core results are **direct Mathlib re-exports**:

- `contMDiff_circleExp_packaged := contMDiff_circleExp` (the "requested C∞ property")
- `circleExp_homomorphism := Circle.exp_add`
- `main` bundles these plus a 3-line `HasDerivAt` derivation
- the smooth Lie group structure is Mathlib's `LieGroup (𝓡 1) ω Circle` instance

The file's own docstring is candid: *"Mathlib already supplies the entire framework, so the work is one of packaging rather than building new analysis."*

This is a Tier B bridge (failure mode #5: 0 sorries but main result via a deep Mathlib theorem). The `mathlibDependencies`, `originalContributions`, and `assumptions` fields are already honest — only the badge overstated.

## Fix

- `badge`: `original` → `mathlib`
- `status` unchanged (`verified` — kernel-accurate, 0 sorries/0 axioms; the genuine bridge lemmas are real contributions, but the headline result is Mathlib's).

---
Discovered during gallery integrity audit. Doc-only change to `meta.json`.