### PR TITLE
research(law-of-cosines-oq-04-oq-01): register LawOfCosinesOQ04OQ01 for machine-check

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2549,6 +2549,7 @@ import Proofs.LawOfCosinesOQ01OQ04
 import Proofs.LawOfCosinesOQ03
 import Proofs.LawOfCosinesOQ03OQ02
 import Proofs.LawOfCosinesOQ04
+import Proofs.LawOfCosinesOQ04OQ01
 import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05


### PR DESCRIPTION
## Summary

`LawOfCosinesOQ04OQ01.lean` — Stewart's theorem lifted to coordinate-free inner-product
geometry — is on `main`, 0 sorry / 0 axiom, 137 lines, but was **never registered** in
`proofs/Proofs.lean`, so it has only been inspection-verified. This PR adds the single
import line. No `.lean` edit.

Contents (theorems in `StewartsTheoremInner`):
- `stewart_cevian_inner` — master identity `‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖²`
  for cevian foot `D = (1−s)•B + s•C`, in any real inner product space, any dimension.
- `stewarts_theorem_inner` — classical `b²m + c²n = a(d² + mn)` form.
- `apollonius_median_inner` — the `s = 1/2` median special case.
- `angle_bisector_length_inner` — internal-bisector length `(b+c)²‖A−D‖² = bc((b+c)²−a²)`.

Uses only standard Mathlib (`module`, `norm_add_sq_real`, `real_inner_smul_left/right`,
`real_inner_comm`, `linear_combination`).

Independent of the in-flight content PR #24375 (which edits the `.lean`; this PR touches
only `Proofs.lean`).

## Test plan
- [ ] CI build gate compiles `Proofs.LawOfCosinesOQ04OQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)