### PR TITLE
research(euler-totient-oq-01-oq-03): fix dead bearer + register RSA-with-λ(n) file

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2265,6 +2265,7 @@ import Proofs.EulerPolyhedralOQ02
 import Proofs.EulerPolyhedralOQ02OQ01
 import Proofs.EulerTotient
 import Proofs.EulerTotientOQ01
+import Proofs.EulerTotientOQ01OQ03
 import Proofs.EulerTotientOQ02
 import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03

--- a/proofs/Proofs/EulerTotientOQ01OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ03.lean
@@ -51,9 +51,14 @@
   • `rsa_decrypt_correct` — the textbook phrasing `m^(e·d) ≡ m` once
     `e·d = 1 + k·λ`.
 
-  Status: 0 axioms, 0 sorries intended.  Build-pending (authored under a Docker +
-  Aristotle blackout); the CRT-assembly proof in `rsa_correct` is the step to
-  confirm in a live build.  Intentionally UNREGISTERED in `Proofs/Proofs.lean`.
+  Status: 0 axioms, 0 sorries.  Registered in `Proofs/Proofs.lean`.  Authored
+  under a Docker + Aristotle blackout; name-checked against pinned Mathlib
+  v4.26.0 (rev 2df2f01): `ZMod.pow_card_sub_one_eq_one` takes `{a}` IMPLICITLY
+  (FieldTheory/Finite/Basic.lean:605), so its earlier call passed `a` into the
+  `a ≠ 0` slot — fixed here.  `ZMod.chineseRemainder` confirmed
+  (Data/ZMod/Basic.lean:873).  The CRT componentwise step (`Prod.ext_iff` +
+  `simpa` on the projection-of-power simp lemmas) remains the one piece to
+  confirm in a live build.
 -/
 
 import Mathlib.Data.ZMod.Basic
@@ -73,7 +78,7 @@ theorem zmod_pow_eq_self {p : ℕ} [Fact p.Prime] (a : ZMod p) {m : ℕ}
   rcases eq_or_ne a 0 with h | h
   · subst h
     rw [zero_pow (Nat.succ_ne_zero _)]
-  · rw [pow_succ, pow_mul, ZMod.pow_card_sub_one_eq_one a h, one_pow, one_mul]
+  · rw [pow_succ, pow_mul, ZMod.pow_card_sub_one_eq_one h, one_pow, one_mul]
 
 /-- **RSA correctness for `n = p·q`.**  For distinct primes `p, q` and any
     exponent `m` divisible by both `p-1` and `q-1` (equivalently, any multiple of

--- a/research/problems/euler-totient-oq-01-oq-03/knowledge.md
+++ b/research/problems/euler-totient-oq-01-oq-03/knowledge.md
@@ -114,3 +114,28 @@ is the step to confirm in a live build. UNREGISTERED in `Proofs/Proofs.lean`.
   the all-`m` RSA statement requires. The CRT/per-prime route is essential.
 - Dropping the squarefree hypothesis: the all-`m` fixed point is then false
   (explicit `p²` counterexamples).
+
+## Session 2026-06-15 (researcher-4) — ACT: bearer-fix + register the RSA file
+
+**Mode**: ACT (dual blackout: `docker info` times out, Aristotle MCP `prove` → 404).
+**Outcome**: name-checked, repaired one dead bearer, and registered the file.
+
+The ORIENT session (#24396) left `EulerTotientOQ01OQ03.lean` sorry-free but UNREGISTERED
+and flagged "build-pending". Per "grep-clean ≠ build-safe", I name-checked its bearers against
+pinned **Mathlib v4.26.0 (rev 2df2f01)** by fetching the sources:
+
+- **Bug found & fixed**: `ZMod.pow_card_sub_one_eq_one` takes `{a : ZMod p}` IMPLICITLY
+  (`FieldTheory/Finite/Basic.lean:605`), but the file called
+  `ZMod.pow_card_sub_one_eq_one a h` — passing the element `a` into the `a ≠ 0` slot
+  (type error, would fail the build). Fixed to `ZMod.pow_card_sub_one_eq_one h`.
+- **Confirmed sound**: `ZMod.chineseRemainder {m n}(h : m.Coprime n) : ZMod (m*n) ≃+* ZMod m ×
+  ZMod n` (`Data/ZMod/Basic.lean:873`); `zero_pow (Nat.succ_ne_zero _)`; `pow_succ`/`pow_mul`.
+- **One residual risk** (build-gated): the CRT componentwise assembly in `rsa_correct`
+  (`Prod.ext_iff.mpr ⟨…⟩` + `simpa using hx/hy` relying on the projection-of-power simp
+  lemmas `Prod.fst_pow`/`Prod.snd_pow`). These are standard `@[simp]` lemmas; high confidence
+  but unverifiable under blackout.
+
+Registered `import Proofs.EulerTotientOQ01OQ03` in `proofs/Proofs.lean` (deployer is
+build-gated, so a residual failure blocks the merge, not main). Sibling `EulerTotientOQ01OQ01`
+(Carmichael multiplicativity, #24399) is also unregistered but is a different slug / flagged
+build-pending — left untouched.


### PR DESCRIPTION
## Summary

The OQ-01-OQ-03 file `EulerTotientOQ01OQ03.lean` (formally verified RSA decryption
correctness using **Carmichael's λ(n)** rather than Euler's φ(n), for `n = p·q`,
via the CRT route that covers **all** messages including non-units) was authored
sorry-free in the ORIENT session (#24396) but left **unregistered** and
"build-pending".

Per "grep-clean ≠ build-safe", I name-checked its Mathlib bearers against the
pinned **v4.26.0 (rev `2df2f01`)** source and found one real bug:

- **Fixed**: `ZMod.pow_card_sub_one_eq_one` takes `{a : ZMod p}` **implicitly**
  (`FieldTheory/Finite/Basic.lean:605`), but the file called it as
  `ZMod.pow_card_sub_one_eq_one a h`, passing the element `a` into the `a ≠ 0`
  argument slot — a type error that would fail the build. Corrected to
  `ZMod.pow_card_sub_one_eq_one h`.
- **Confirmed sound**: `ZMod.chineseRemainder {m n} (h : m.Coprime n) :
  ZMod (m*n) ≃+* ZMod m × ZMod n` (`Data/ZMod/Basic.lean:873`),
  `zero_pow (Nat.succ_ne_zero _)`, `pow_succ`, `pow_mul`.

Then **registered** `import Proofs.EulerTotientOQ01OQ03` in `proofs/Proofs.lean`.

## Scope / honesty

- One residual build-gated step remains: the CRT componentwise assembly in
  `rsa_correct` (`Prod.ext_iff.mpr ⟨…⟩` + `simpa` relying on the
  projection-of-power simp lemmas `Prod.fst_pow`/`Prod.snd_pow`). These are
  standard `@[simp]` lemmas — high confidence, but unverifiable under the current
  Docker + Aristotle blackout. The deployer is build-gated, so any residual
  failure blocks this PR's merge, not `main`.
- Sibling `EulerTotientOQ01OQ01` (Carmichael multiplicativity, #24399) is also
  unregistered but is a different slug / separately flagged build-pending — left
  untouched.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ01OQ03` (build-gated;
      Docker + Aristotle both down this session).
- [x] Bearer name-check against pinned Mathlib v4.26.0 sources (the `a`-implicit
      fix and `chineseRemainder` signature verified from rev `2df2f01`).
- [x] `python3 research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py`
      (pre-existing; correctness for all m over 55 moduli, λ<φ strict, p² failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)