### PR TITLE
research(spherical-law-of-cosines-oq-03): S5 — polar-triangle duality in Lean (dual law = polar side relation)

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ03.lean
@@ -65,6 +65,11 @@ trig form `cos C = − cos A · cos B + sin A · sin B · cos c`.
   inner products of edge normals (geometric grounding of the normal forms)
 * `sina_sq`/`sinb_sq`/`sinc_sq` — side-sine squares as Lagrange self-inner-products
 * `dual_law_cross_product_form` — the dual law in pure cross-product form
+* `polar_inner_uv`/`polar_inner_vw`/`polar_inner_wu` — polar-vertex inner products,
+  the `π − ·` side/angle swap of polar duality (`⟨v×w, w×u⟩ = cos a·cos b − cos c`)
+* `polar_self_uu`/`polar_self_vv`/`polar_self_ww` — polar side-sine squares
+* `dual_law_polar_form` — the dual law as a side-law relation among the polar vertices
+  (the structural realisation of the polar-triangle duality)
 
 Axioms: 0.  Sorries: 0.
 
@@ -333,5 +338,87 @@ theorem dual_law_cross_product_form
         + (triple u v w) ^ 2 * dot u v := by
   rw [cosC_num u v w hw, sinc_sq u v hu hv, cosA_num u v w hu, cosB_num u v w hv]
   exact dual_spherical_law_cleared u v w hu hv hw
+
+/-! ## Part VII: Polar-triangle duality — the dual law is a side relation among polar vertices
+
+The OQ's significance is the *polar-triangle duality*: the dual (angles) law is the
+primal (sides) law applied to the **polar triangle**. For a spherical triangle with unit
+vertices `u, v, w`, the (unnormalised) polar-triangle vertices are the edge normals
+
+  `U = v × w`,   `V = w × u`,   `W = u × v`,
+
+i.e. each polar vertex is perpendicular to the great-circle plane of the opposite side.
+Classically the polar triangle has sides `π − A` and angles `π − a`, so the cosine of a
+polar *side* is `−` the cosine of an original *angle*. The inner products among the polar
+vertices realise exactly this swap, in cleared (radical-free) form:
+
+* `polar_inner_uv` : `⟨U, V⟩ = cos a·cos b − cos c` (`= −(cos c − cos a·cos b)`, the negated
+  `cos C` numerator — the polar side opposite `W` carries `cos c' = −cos C`);
+* `polar_self_*`   : `⟨U, U⟩ = 1 − cos²a = sin²a` (the polar side sine equals the original
+  vertex-angle sine, `sin a' = sin A`).
+
+Substituting these into `dual_spherical_law_cleared` re-expresses the dual law entirely in
+terms of polar-vertex inner products (`dual_law_polar_form`): the dual law of `T` is a
+side-law-type relation among the vertices of the polar triangle `T'`. This is the structural
+"why" of the duality, derived (not merely asserted) within the file's own cross-product
+algebra — all proofs `ring`/`rw`-only, no division, no radicals. -/
+
+/-- Polar-vertex inner product `⟨v×w, w×u⟩ = cos a·cos b − cos c`.
+
+This is `−(cos c − cos a·cos b)`, the negated numerator of `cos C`: the polar side opposite
+vertex `W = u×v` has cosine `cos c' = −cos C`, the hallmark `π − C` swap of polar duality. -/
+theorem polar_inner_uv (u v w : V) (hw : dot w w = 1) :
+    dot (cross v w) (cross w u) = dot v w * dot w u - dot u v := by
+  have h := binet_cauchy v w w u
+  rw [h, hw, dot_comm v u]; ring
+
+/-- Polar-vertex inner product `⟨w×u, u×v⟩ = cos b·cos c − cos a`
+(`= −(cos a − cos b·cos c)`, the negated numerator of `cos A`). -/
+theorem polar_inner_vw (u v w : V) (hu : dot u u = 1) :
+    dot (cross w u) (cross u v) = dot w u * dot u v - dot v w := by
+  have h := binet_cauchy w u u v
+  rw [h, hu, dot_comm w v]; ring
+
+/-- Polar-vertex inner product `⟨u×v, v×w⟩ = cos c·cos a − cos b`
+(`= −(cos b − cos a·cos c)`, the negated numerator of `cos B`). -/
+theorem polar_inner_wu (u v w : V) (hv : dot v v = 1) :
+    dot (cross u v) (cross v w) = dot u v * dot v w - dot w u := by
+  have h := binet_cauchy u v v w
+  rw [h, hv, dot_comm u w]; ring
+
+/-- Polar side opposite `U`: `⟨v×w, v×w⟩ = 1 − cos²a = sin²a`
+(`= sin²a'` only up to the duality `sin a' = sin A`; here it is literally `sin²a`). -/
+theorem polar_self_uu (v w : V) (hv : dot v v = 1) (hw : dot w w = 1) :
+    dot (cross v w) (cross v w) = 1 - dot v w ^ 2 := sina_sq v w hv hw
+
+/-- Polar side opposite `V`: `⟨w×u, w×u⟩ = 1 − cos²b = sin²b`. -/
+theorem polar_self_vv (u w : V) (hw : dot w w = 1) (hu : dot u u = 1) :
+    dot (cross w u) (cross w u) = 1 - dot w u ^ 2 := sinb_sq u w hw hu
+
+/-- Polar side opposite `W`: `⟨u×v, u×v⟩ = 1 − cos²c = sin²c`. -/
+theorem polar_self_ww (u v : V) (hu : dot u u = 1) (hv : dot v v = 1) :
+    dot (cross u v) (cross u v) = 1 - dot u v ^ 2 := sinc_sq u v hu hv
+
+/-- **Dual spherical law of cosines, polar form.**
+
+The dual law re-expressed entirely in inner products of the polar-triangle vertices
+`U = v×w`, `V = w×u`, `W = u×v` (with the included side cosine `⟨u, v⟩ = cos c` and the
+Gram determinant `[u v w]²`):
+
+  `−⟨v×w, w×u⟩ · ⟨u×v, u×v⟩ = −⟨w×u, u×v⟩ · ⟨u×v, v×w⟩ + [u v w]² · ⟨u, v⟩`.
+
+Each polar inner product is the (negated) cosine numerator / side-sine square of the
+original triangle (`polar_inner_*`, `polar_self_ww`), so this is `dual_spherical_law_cleared`
+read in the polar triangle's own coordinates: the dual law of `T` *is* a side-law-shaped
+relation among the vertices of the polar triangle `T'`. Proof: rewrite the polar inner
+products to side-cosine normal forms, then it is `dual_spherical_law_cleared` verbatim. -/
+theorem dual_law_polar_form
+    (u v w : V) (hu : dot u u = 1) (hv : dot v v = 1) (hw : dot w w = 1) :
+    -dot (cross v w) (cross w u) * dot (cross u v) (cross u v)
+      = -dot (cross w u) (cross u v) * dot (cross u v) (cross v w)
+        + (triple u v w) ^ 2 * dot u v := by
+  rw [polar_inner_uv u v w hw, polar_self_ww u v hu hv,
+      polar_inner_vw u v w hu, polar_inner_wu u v w hv]
+  linear_combination dual_spherical_law_cleared u v w hu hv hw
 
 end SphericalLawOfCosinesOQ03

--- a/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/knowledge.md
@@ -204,3 +204,39 @@ introducing `arccos`/division/`‖·‖`.
 **Next:** Docker-up typecheck of Part VI; optional bridge to parent
 `SphericalTriangle.angleC` (would introduce `arccos`/division — defer per
 `feedback-avoid-field-simp-under-no-build`).
+
+## Session 2026-06-15 (researcher-3) — POLAR DUALITY in Lean (Part VII): the dual law as a side relation among polar vertices
+
+**Mode:** ACT, post-SOLVED outward enrichment. Dual blackout (Docker `docker info` hangs;
+Aristotle 404). Build-pending but EXACTLY certified (sympy, residual 0).
+
+**What was added (Part VII of `SphericalLawOfCosinesOQ03.lean`, +82 LOC, 0 ax / 0 sorry):**
+PR #24520 (researcher-1) *documented* the polar-triangle duality and certified it
+numerically, but recommended the algebraic Lean route as the build-gated next step. This
+session implements exactly that route — no `arccos`/division/`‖·‖`, all `ring`/`rw`/
+`linear_combination`:
+
+- `polar_inner_uv/vw/wu`: the (unnormalised) polar vertices `U=v×w, V=w×u, W=u×v` satisfy
+  `⟨U,V⟩ = cos a·cos b − cos c = −(cos C numerator)`, cyclically. Each is one
+  `binet_cauchy` + `rw [·, h_unit, dot_comm ·]; ring`. This is the `π−C` side/angle swap of
+  polar duality at the inner-product level (`cos c' = −cos C`).
+- `polar_self_uu/vv/ww`: `⟨U,U⟩ = 1 − cos²a = sin²a` (thin wrappers over `sina_sq` etc.).
+- `dual_law_polar_form` (capstone): substituting the above into `dual_spherical_law_cleared`
+  gives `−⟨U,V⟩·⟨W,W⟩ = −⟨V,W⟩·⟨W,U⟩ + [u v w]²·⟨u,v⟩` — the dual law of `T` written as a
+  side-law-shaped relation among the polar vertices. Proof: `rw` the four polar products to
+  side-cosine form, then `linear_combination dual_spherical_law_cleared u v w hu hv hw`.
+
+**Exact certificate** (`verify_polar_form.py`, sympy, no floats): (A) the three polar
+inner-product identities are component-wise polynomial identities (binet residual 0 each);
+(B) the capstone `linear_combination` residual `(goal_lhs−goal_rhs) − (dscl_lhs−dscl_rhs)`
+is identically 0. This upgrades #24520's numeric certification to a symbolic proof of the
+exact Lean certificate used.
+
+**Reusable note:** to express a vertex angle's cosine *numerator* as a polar-side cosine,
+pick `binet_cauchy P Q R S` with the two cross-product arguments sharing the relevant edge;
+`⟨v×w, w×u⟩` collapses (via `⟨w,w⟩=1`) to `cos a·cos b − cos c`. This is the clean
+division-free realisation of "the polar side opposite a vertex carries minus that vertex's
+angle cosine".
+
+**Next:** Docker-up typecheck of Parts VI–VII; the parent-`angleC` bridge remains the only
+deferred item (needs `arccos`/division).

--- a/research/problems/spherical-law-of-cosines-oq-03/state.md
+++ b/research/problems/spherical-law-of-cosines-oq-03/state.md
@@ -4,29 +4,38 @@
 **Phase**: ACT (post-SOLVED, outward enrichment)
 **Path**: full
 **Since**: 2026-06-15T06:15:07Z
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 The literal OQ deliverable `dual_law_trig` (`cos C = −cos A·cos B + sin A·sin B·cos c`)
-is DONE and on main (0 axioms, 0 sorries). This session adds the outward structural
-bridge: geometric grounding of the posited normal forms via cross products.
+is DONE and on main (0 axioms, 0 sorries). This session (researcher-3) implements the
+polar-triangle duality in Lean — the structural "why" PR #24520 documented but only
+certified numerically. New **Part VII** realises the dual law as a side-law-shaped
+relation among the polar-triangle vertices `U=v×w, V=w×u, W=u×v`.
 
 ## Active Approach
-Identify each angle-cosine numerator with a Binet–Cauchy inner product of edge
-normals and each side-sine square with a Lagrange self-inner-product, then re-derive
-the cleared dual law in pure cross-product form. All `ring`/`rw`-only.
+Each polar-vertex inner product is a Binet–Cauchy product giving the negated cosine
+numerator of the opposite original angle (`⟨U,V⟩ = cos a·cos b − cos c = −(cos C num)`),
+and each polar self-inner-product is the Lagrange side-sine square. Substituting these
+into `dual_spherical_law_cleared` re-expresses the dual law in the polar triangle's own
+coordinates (`dual_law_polar_form`). All `ring`/`rw`/`linear_combination`-only, no
+division, no radicals — blackout-safe.
 
 ## Attempt Count
-- Total attempts: 4
+- Total attempts: 5
 - Current approach attempts: 1
-- Approaches tried: cleared form, literal trig form, cross-product form
+- Approaches tried: cleared form, literal trig form, cross-product form, polar form
 
 ## Blockers
-Docker daemon down (`docker info` timeout) → no local typecheck. Aristotle prove 404
-in recent sessions. New lemmas are build-pending but numerically validated (3·10⁵
-random triangles, max err ~1e-15) and hand-traced.
+Docker daemon down (`docker info` hangs/timeout) → no local typecheck; Aristotle `prove`
+404 in recent sessions. Part VII is build-pending but EXACTLY certified (sympy, residual
+identically 0) in `verify_polar_form.py`: the three polar inner-product identities are
+component-wise polynomial identities, and the capstone `linear_combination
+dual_spherical_law_cleared` certificate has residual 0. All lemmas reuse the same
+`binet_cauchy`/`lagrange_identity` machinery already trusted in Parts II/VI.
 
 ## Next Action
 When Docker returns: build `Proofs.SphericalLawOfCosinesOQ03` to confirm typecheck of
-Part VI. Optional future step: bridge to the parent's `Vec3`/`SphericalTriangle.angleC`
-so the angle quantities are derived from `arccos`, not posited.
+Parts VI–VII. Optional future step: bridge to the parent's `Vec3`/`SphericalTriangle.angleC`
+so the angle quantities are derived from `arccos`, not posited (introduces division —
+defer per `feedback-avoid-field-simp-under-no-build`).

--- a/research/problems/spherical-law-of-cosines-oq-03/verify_polar_form.py
+++ b/research/problems/spherical-law-of-cosines-oq-03/verify_polar_form.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+spherical-law-of-cosines-oq-03 (researcher-3) — EXACT symbolic certificate for
+Part VII: the dual law in POLAR form (`dual_law_polar_form`).
+
+Part VII of `proofs/Proofs/SphericalLawOfCosinesOQ03.lean` realises the polar-triangle
+duality the OQ's significance line names: the (unnormalised) polar vertices are the edge
+normals  U = v×w,  V = w×u,  W = u×v,  and the dual law of the original triangle is a
+side-law-shaped relation among them.
+
+This script certifies, EXACTLY (sympy, no floating point), the two facts the Lean proof
+relies on:
+
+  (A) the polar inner-product identities are component-wise polynomial identities in the
+      vertex coordinates, under the unit constraints ⟨u,u⟩=⟨v,v⟩=⟨w,w⟩=1:
+        ⟨v×w, w×u⟩ = cos a·cos b − cos c          (polar_inner_uv)
+        ⟨w×u, u×v⟩ = cos b·cos c − cos a          (polar_inner_vw)
+        ⟨u×v, v×w⟩ = cos c·cos a − cos b          (polar_inner_wu)
+      where cos a=⟨v,w⟩, cos b=⟨w,u⟩, cos c=⟨u,v⟩;
+
+  (B) the capstone `linear_combination dual_spherical_law_cleared` certificate has
+      residual identically 0:
+        (goal_lhs − goal_rhs) − (dscl_lhs − dscl_rhs) ≡ 0.
+
+Docker-independent. Requires sympy.
+"""
+import sympy as sp
+
+
+def dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def cross(a, b):
+    return (a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0])
+
+
+def part_A():
+    u = sp.symbols('u1 u2 u3')
+    v = sp.symbols('v1 v2 v3')
+    w = sp.symbols('w1 w2 w3')
+
+    ca = dot(v, w)   # cos a
+    cb = dot(w, u)   # cos b
+    cc = dot(u, v)   # cos c
+
+    # Unit constraints; substitute ⟨w,w⟩, ⟨u,u⟩, ⟨v,v⟩ = 1 where they appear.
+    # binet_cauchy is an unconditional identity, so each polar inner product equals a
+    # polynomial that contains exactly one ⟨·,·⟩=1 self-term; we verify the reduction by
+    # checking the difference vanishes on the unit variety via the Gröbner-free route:
+    # expand the cross-product inner product and the claimed RHS, then substitute the
+    # self-dot = 1 relations and confirm equality.
+    subs_unit = []
+    # we cannot literally set ⟨w,w⟩=1 as a single symbol; instead verify the binet form:
+    #   ⟨v×w, w×u⟩ = ⟨v,w⟩⟨w,u⟩ − ⟨v,u⟩⟨w,w⟩   (unconditional)
+    # then with ⟨w,w⟩=1 this is ca·cb − cc. Check the unconditional binet identity first.
+    checks = {
+        'binet ⟨v×w,w×u⟩': (dot(cross(v, w), cross(w, u))
+                            - (dot(v, w) * dot(w, u) - dot(v, u) * dot(w, w))),
+        'binet ⟨w×u,u×v⟩': (dot(cross(w, u), cross(u, v))
+                            - (dot(w, u) * dot(u, v) - dot(w, v) * dot(u, u))),
+        'binet ⟨u×v,v×w⟩': (dot(cross(u, v), cross(v, w))
+                            - (dot(u, v) * dot(v, w) - dot(u, w) * dot(v, v))),
+    }
+    ok = True
+    for name, expr in checks.items():
+        z = sp.expand(expr)
+        print(f'  {name}: residual = {z}  ->  {"OK" if z == 0 else "FAIL"}')
+        ok = ok and (z == 0)
+    # With ⟨w,w⟩=⟨u,u⟩=⟨v,v⟩=1 the binet RHS collapses to the claimed polar forms:
+    #   ca·cb − ⟨v,u⟩ = ca·cb − cc, etc. (⟨v,u⟩=⟨u,v⟩=cc). Symbolically obvious.
+    print('  (under unit constraints the binet RHS = ca·cb−cc, cb·cc−ca, cc·ca−cb)')
+    return ok
+
+
+def part_B():
+    ca, cb, cc = sp.symbols('ca cb cc')   # cos a, cos b, cos c
+    tp2 = 1 - ca**2 - cb**2 - cc**2 + 2 * ca * cb * cc   # [u v w]^2 (unit vectors)
+
+    # dual_spherical_law_cleared (unit form)
+    dscl_lhs = (cc - ca * cb) * (1 - cc**2)
+    dscl_rhs = -(ca - cb * cc) * (cb - ca * cc) + tp2 * cc
+
+    # polar inner products after rewrites
+    puv = ca * cb - cc          # ⟨v×w, w×u⟩
+    pvw = cb * cc - ca          # ⟨w×u, u×v⟩
+    pwu = cc * ca - cb          # ⟨u×v, v×w⟩
+    pww = 1 - cc**2             # ⟨u×v, u×v⟩
+
+    # capstone goal:  -puv*pww = -pvw*pwu + tp2*cc
+    goal_lhs = -puv * pww
+    goal_rhs = -pvw * pwu + tp2 * cc
+
+    residual = sp.expand((goal_lhs - goal_rhs) - (dscl_lhs - dscl_rhs))
+    print(f'  dscl identity holds: {sp.simplify(dscl_lhs - dscl_rhs) == 0}')
+    print(f'  capstone residual (linear_combination dscl): {residual}  ->  '
+          f'{"OK" if residual == 0 else "FAIL"}')
+    print(f'  capstone identity holds: {sp.simplify(goal_lhs - goal_rhs) == 0}')
+    return residual == 0
+
+
+if __name__ == '__main__':
+    print('Part (A): polar inner-product identities (binet_cauchy, component-wise):')
+    a_ok = part_A()
+    print('\nPart (B): capstone linear_combination certificate:')
+    b_ok = part_B()
+    print('\nALL EXACT CHECKS PASS' if (a_ok and b_ok) else '\nFAILURE')


### PR DESCRIPTION
## Summary
Implements **Part VII** of `SphericalLawOfCosinesOQ03.lean`: the polar-triangle duality
in Lean. PR #24520 documented this structure and certified it numerically; this PR provides
the actual proofs via the algebraic (division-free) route #24520 recommended.

The dual (angles) law of cosines is the primal (sides) law applied to the **polar triangle**,
whose unnormalised vertices are the edge normals `U=v×w, V=w×u, W=u×v`. This is the structural
"why" of the duality the OQ's significance line names — now *derived* within the file's own
cross-product algebra, not merely asserted.

## Progress
- `polar_inner_uv/vw/wu` — `⟨v×w, w×u⟩ = cos a·cos b − cos c = −(cos C numerator)`, cyclically:
  the `π − C` side/angle swap of polar duality at the inner-product level. Each is one
  `binet_cauchy` + `rw [·, h_unit, dot_comm ·]; ring`.
- `polar_self_uu/vv/ww` — polar side-sine squares (Lagrange self-inner-products).
- `dual_law_polar_form` — capstone: `dual_spherical_law_cleared` re-expressed entirely in
  polar-vertex inner products, closed by `linear_combination dual_spherical_law_cleared`.
- `verify_polar_form.py` — EXACT sympy certificate (residual identically 0) for both the
  polar inner-product identities and the capstone `linear_combination` coefficient.

File: +82 LOC, **0 axioms / 0 sorries**.

## Findings
- The polar-vertex inner product collapses (via the unit constraint) to the negated angle
  cosine numerator of the opposite vertex — the clean division-free realisation of polar duality.
- The capstone certificate is exact: `(goal_lhs − goal_rhs) − (dscl_lhs − dscl_rhs) ≡ 0`.

## Status
**Outcome**: progress (build-pending). All proofs reuse trusted Part II/VI machinery
(`binet_cauchy`, `lagrange_identity`); no division, no radicals — blackout-safe. Docker
daemon down and Aristotle `prove` 404, so not yet machine-checked locally, but symbolically
certified.
**Next Steps**: Docker-up typecheck of Parts VI–VII; optional parent-`angleC` bridge (deferred,
needs `arccos`/division).

🤖 Generated by researcher-3