### PR TITLE
research(cube-root-3-irrational-oq-04): S25 — nineteenth CF convergent lower bound (a18=4)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -805,4 +805,56 @@ theorem cbrt3_lt_two_six_six_three_nine_four_five_zero_over_one_eight_four_seven
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-! ## S25 prep: new lower bound for `a₁₇ = 6` (the eighteenth partial quotient)
+
+The nineteenth CF convergent of `∛3` (using `a₁₈ = 4` per a 300-digit CF
+recomputation, true prefix `a₀..a₁₈ =
+[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4]`, 0-indexed) is
+
+  `p₁₈/q₁₈ = (a₁₈·p₁₇ + p₁₆) / (a₁₈·q₁₇ + q₁₆)`
+  `       = (4 · 383473988 + 59472423) / (4 · 265886013 + 41235875)`
+  `       = 1_593_368_375 / 1_104_779_927`.
+
+This convergent is even-index (18), so it lies on the LOWER side of `∛3`
+(alternating with the upper-side eighteenth convergent `383473988/265886013`,
+the seventeenth partial quotient `a₁₇ = 6`).
+
+Here `p₁₇/q₁₇ = 383473988/265886013` (the eighteenth convergent, upper) and
+`p₁₆/q₁₆ = 59472423/41235875` (the seventeenth convergent, lower) are the two
+prior rungs; both lie in sibling helper PRs (S24, S23) but this lower-bound
+theorem is self-contained — it is discharged purely by cubing the literal
+fraction, independent of whether those rungs are present in the file.
+
+Convergent recursion (with `a₁₈ = 4`):
+
+  `q₁₈ = 4 · q₁₇ + q₁₆ = 4 · 265886013 + 41235875 = 1_104_779_927`
+  `p₁₈ = 4 · p₁₇ + p₁₆ = 4 · 383473988 + 59472423 = 1_593_368_375`
+
+After cubing,
+
+  `1_593_368_375³   = 4_045_279_924_912_085_586_177_734_375`
+  `3 · 1_104_779_927³ = 4_045_279_924_912_085_587_552_412_949`
+
+so `1_593_368_375³ = 4_045_279_924_912_085_586_177_734_375 <
+4_045_279_924_912_085_587_552_412_949 = 3 · 1_104_779_927³` (strict, diff
+`-1_374_678_574`), hence `(1_593_368_375/1_104_779_927)³ < 3` and
+`1_593_368_375/1_104_779_927 < cbrt3` as required for a lower bound.
+
+`a₁₈ = 4` was re-derived independently from a 300-digit CF recomputation of
+`∛3` (cert `research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py`), per the
+S9-prep / S14a / S15-prep anti-typo discipline: never re-quote a prior sketch
+tail, always recompute `aᵢ` and verify the cube-side direction before claiming.
+Two-line proof via the cubing-iff helper. -/
+
+/-- `1593368375/1104779927 < ∛3`. Cube target:
+`(1593368375/1104779927)³ = 4_045_279_924_912_085_586_177_734_375 / 1104779927³
+< 3` (strict: `1593368375³ = 4_045_279_924_912_085_586_177_734_375 <
+4_045_279_924_912_085_587_552_412_949 = 3 · 1104779927³`, gap `1_374_678_574`).
+The nineteenth convergent of the simple CF of `∛3` (using `a₁₈ = 4` per a
+300-digit CF recomputation). -/
+theorem one_five_nine_three_three_six_eight_three_seven_five_over_one_one_zero_four_seven_seven_nine_nine_two_seven_lt_cbrt3 :
+    (1593368375 / 1104779927 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-15-s25-helper-act-nineteenth-convergent.md
+++ b/research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-15-s25-helper-act-nineteenth-convergent.md
@@ -1,0 +1,29 @@
+# S25 — Nineteenth CF convergent lower bound (a₁₈ = 4)
+
+**Agent:** researcher-6 · **Date:** 2026-06-15 · **PR:** #24556
+
+## Result
+Added self-contained helper to `CubeRoot3IrrationalOQ04Helpers.lean`:
+
+    theorem ..._lt_cbrt3 : (1593368375 / 1104779927 : ℝ) < cbrt3
+
+The nineteenth CF convergent of ∛3 (index 18, even ⟹ lower side), partial
+quotient `a₁₈ = 4`. Proven by the standard `lt_cbrt3_iff_cube_lt` + `norm_num`
+cubing route — identical in form to the 15 prior convergent helpers on `main`.
+
+## Verification
+- 300-digit CF recomputation (`research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py`):
+  prefix `a₀..a₁₈ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4]` matches OEIS A002945.
+- Cube-side direction (exact integer): `1593368375³ − 3·1104779927³ = −1_374_678_574 < 0`
+  ⟹ lower bound. Cert PASS.
+
+## Context
+- `main` frontier was the 16th convergent (S15, upper, 26639450/18470763).
+- 17th (S23, #24516) and 18th (S24, #24538) are in unmerged sibling PRs; this
+  19th rung is self-contained and does not depend on them being present.
+- Main partial-quotient chain (`cbrt3_a12`+) remains contention-blocked
+  (#23388, #23983 own a12) — not touched.
+
+## Build
+Docker daemon in blackout (`docker info` exit 124); build deferred to deployer.
+Arithmetic independently certified.

--- a/research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py
@@ -1,0 +1,71 @@
+"""S25 certificate: nineteenth CF convergent (index 18) lower bound for cbrt3.
+
+Re-derives the simple continued fraction of 3^(1/3) to high precision (NOT
+re-quoting any prior sketch tail, per this slug's a8/a14 typo history), recomputes
+the convergent recursion, and confirms the cube-side direction so the new helper
+`1593368375/1104779927 < cbrt3` lands on the correct (LOWER) side.
+
+Run: python3 verify_cbrt3_oq04_s25_19th_convergent.py
+"""
+
+from decimal import Decimal, getcontext
+
+getcontext().prec = 300
+
+
+def cbrt3_highprec() -> Decimal:
+    x = Decimal(3)
+    g = Decimal("1.4422495703074083823216383107801")
+    for _ in range(200):
+        g = (2 * g + x / (g * g)) / 3
+    return g
+
+
+def cf(val: Decimal, n: int):
+    a = []
+    v = val
+    for _ in range(n):
+        ai = int(v)
+        a.append(ai)
+        v = 1 / (v - ai)
+    return a
+
+
+def main() -> None:
+    c = cbrt3_highprec()
+    assert abs(c ** 3 - 3) < Decimal(10) ** -290, "cbrt3 not converged"
+
+    a = cf(c, 22)
+    # Independent re-derivation of the prefix; must match OEIS A002945.
+    expected = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4]
+    assert a[: len(expected)] == expected, f"CF mismatch: {a[:len(expected)]}"
+
+    # convergent recursion
+    p_prev, p = 1, a[0]
+    q_prev, q = 0, 1
+    convs = [(p, q)]
+    for i in range(1, len(a)):
+        p, p_prev = a[i] * p + p_prev, p
+        q, q_prev = a[i] * q + q_prev, q
+        convs.append((p, q))
+
+    # index 18 == nineteenth convergent, a18 = 4
+    assert a[18] == 4, f"a18 expected 4, got {a[18]}"
+    p18, q18 = convs[18]
+    assert (p18, q18) == (1593368375, 1104779927), (p18, q18)
+
+    cube = p18 ** 3
+    three_q = 3 * q18 ** 3
+    diff = cube - three_q
+    side = "LOWER (< cbrt3)" if diff < 0 else "UPPER (> cbrt3)"
+    print(f"a18 = {a[18]}")
+    print(f"p18/q18 = {p18}/{q18}")
+    print(f"p18^3   = {cube}")
+    print(f"3*q18^3 = {three_q}")
+    print(f"diff = {diff}  => {side}")
+    assert diff < 0, "nineteenth convergent must be a LOWER bound"
+    print("PASS: 1593368375/1104779927 < cbrt3 (nineteenth convergent, a18=4)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds one self-contained helper to `CubeRoot3IrrationalOQ04Helpers.lean`: the **nineteenth** CF convergent of ∛3 as a lower bound.

- **Theorem**: `1593368375/1104779927 < cbrt3` (convergent index 18, `a₁₈ = 4`).
- Even-index ⟹ **lower side**, alternating with the upper-side eighteenth convergent `383473988/265886013` (sibling PR #24538) and lower-side seventeenth convergent `59472423/41235875` (sibling PR #24516).
- Proven by the standard cubing-iff route (`lt_cbrt3_iff_cube_lt` + `norm_num`), byte-pattern-identical to the 15 prior convergent helpers already on `main`. **Self-contained**: discharged purely by cubing the literal fraction, independent of whether the S23/S24 rungs are present.

## Verification
- `a₁₈ = 4` re-derived from an independent **300-digit** CF recomputation (`research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py`), per this slug's a8/a14 anti-typo discipline — never re-quote a sketch tail.
- Cube-side direction confirmed exact: `1593368375³ = 4_045_279_924_912_085_586_177_734_375 < 4_045_279_924_912_085_587_552_412_949 = 3·1104779927³` (gap `−1_374_678_574 < 0` ⟹ lower bound).
- CF prefix `a₀..a₁₈ = [1,2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4]` matches OEIS A002945.

## Build status
**Build-pending**: Docker daemon in blackout (`docker info` exit 124) this session, so `docker-build.sh` could not run. Arithmetic is independently certified by the committed Python cert; the theorem is structurally identical to existing passing helpers in the same file. Deployer will build on merge.

## Test plan
- [ ] `python3 research/scripts/verify_cbrt3_oq04_s25_19th_convergent.py` → `PASS`
- [ ] `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers` (when Docker available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)