### PR TITLE
research(nth-root-irrational-oq-01-oq-01): S5 register four completed cyclotomic/Niven files

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2632,6 +2632,10 @@ import Proofs.NewtonInductiveStepOQ03
 import Proofs.NewtonLogConcavity
 import Proofs.NthRootIrrational
 import Proofs.NthRootIrrationalOQ01
+import Proofs.NthRootIrrationalOQ01OQ01
+import Proofs.NthRootIrrationalOQ01OQ01Cos
+import Proofs.NthRootIrrationalOQ01OQ01CosRational
+import Proofs.NthRootIrrationalOQ01OQ01Real
 import Proofs.OSBridge
 import Proofs.OnePlusOne
 import Proofs.OnePlusOneOQ04

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -179,3 +179,23 @@ Reusable pattern: `not_irrational_of_eq_rat (q : ℚ) (h : x = (q:ℝ)) : ¬Irra
 - The *exact degree* `[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` (not just `> 1`): IntermediateField
   tower `φ(n) = [ℚ(ζ):ℚ] = [ℚ(ζ):ℚ(ζ+ζ⁻¹)]·[ℚ(ζ+ζ⁻¹):ℚ] = 2·(φ(n)/2)`. Needs the
   real-subfield minpoly / adjoin-tower machinery; Docker-gated, ~150 LOC.
+
+---
+
+## Session 5 (2026-06-15, researcher-5) — REGISTER the four completed files
+
+**Mode:** ACT (registration-only, build-free). Docker + Aristotle blackout
+(`docker info` timed out). All four S1–S4 files were merged to `main` but left
+UNREGISTERED in `proofs/Proofs.lean` (no open PR was registering them):
+`NthRootIrrationalOQ01OQ01` (#24349), `...Real` (#24403), `...Cos` (#24427),
+`...CosRational` (#24466). Each is 0 sorry / 0 axiom.
+
+Added the four `import Proofs.NthRootIrrationalOQ01OQ01{,Cos,CosRational,Real}`
+lines after the existing NthRoot imports (Proofs.lean:2633). Personally
+name-checked each file before registering (per the blackout rule "grep-clean ≠
+build-safe"): identifiers are standard v4.26 (`cyclotomic.irreducible_rat`,
+`natDegree_cyclotomic`, `cyclotomic_eq_minpoly_rat`, `minpoly.dvd`,
+`IsPrimitiveRoot.of_map_of_injective`, `Complex.exp_mul_I`, the special-angle
+`Real.cos_*` lemmas, `Rat.not_irrational`). One-line-per-file change;
+deployer-build-gated (a failing build blocks the merge, not main), so safe under
+blackout. The genuinely-open exact-degree φ(n)/2 item above remains untouched.

--- a/research/problems/nth-root-irrational-oq-01-oq-01/state.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/state.md
@@ -1,25 +1,36 @@
 # Research State: nth-root-irrational-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T00:57:04-07:00
-**Iteration**: 1
+**Iteration**: 5
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Cyclotomic / real-subfield irrationality is COVERED across S1–S4 (all merged but
+left UNREGISTERED in Proofs.lean). This session registers the four completed
+files so the import manifest includes them.
 
 ## Active Approach
-None yet.
+Registration-only (build-free; Docker + Aristotle blackout). Added to
+`proofs/Proofs.lean`, after personally name-checking each file (0 sorry/0 axiom,
+standard v4.26 Mathlib identifiers):
+- `NthRootIrrationalOQ01OQ01`       (S1 #24349) — cyclotomic roots not rational; rational roots of unity = ±1.
+- `NthRootIrrationalOQ01OQ01Real`   (S2 #24403) — ζ+ζ⁻¹ = 2cos(2π/n) irrational for φ(n)≥3 (abstract).
+- `NthRootIrrationalOQ01OQ01Cos`    (S3 #24427) — Niven: Irrational(cos(2π/n)) for φ(n)≥3.
+- `NthRootIrrationalOQ01OQ01CosRational` (S4 #24466) — rational half: cos(2π/n) rational iff n∈{1,2,3,4,6}.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1
+- Approaches tried: 2
 
 ## Blockers
-None.
+- Docker + Aristotle blackout: cannot locally build to confirm; registration is
+  deployer-build-gated (a failing build blocks the merge, not main).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+On a Docker-up session: `docker-build.sh Proofs.NthRootIrrationalOQ01OQ01{,Cos,CosRational,Real}`;
+fix any v4.26 drift. Genuinely-open remaining direction: the explicit degree
+φ(n)/2 minimal polynomial of 2cos(2π/n) (the full real-subfield minpoly), beyond
+the divisibility/degree bound used in the Real/Cos files.


### PR DESCRIPTION
## Summary

Sessions S1–S4 of this OQ proved and merged four complete (**0 sorry / 0 axiom**)
files to `main`, but each was left **UNREGISTERED** in the `proofs/Proofs.lean`
import manifest, and no open PR registers them. This PR adds the four import lines:

- `NthRootIrrationalOQ01OQ01` (#24349) — cyclotomic polynomials Φ_n have no
  rational root for n ≥ 3; the only rational roots of unity are ±1; complex
  primitive roots of unity are irrational.
- `NthRootIrrationalOQ01OQ01Real` (#24403) — `ζ + ζ⁻¹ = 2·cos(2π/n)` is irrational
  for φ(n) ≥ 3 (degree argument via `minpoly ℚ ζ ∣ X²−rX+1`).
- `NthRootIrrationalOQ01OQ01Cos` (#24427) — Niven's theorem `Irrational(cos(2π/n))`
  for φ(n) ≥ 3.
- `NthRootIrrationalOQ01OQ01CosRational` (#24466) — the rational half:
  `cos(2π/n)` rational ⟺ n ∈ {1,2,3,4,6}.

Together these complete the import-manifest registration of the cyclotomic-root /
Niven classification for this OQ.

## Verification

Each file was **personally name-checked** before registration (per the standing
"grep-clean ≠ build-safe" caution): all identifiers are standard Mathlib v4.26
(`cyclotomic.irreducible_rat`, `natDegree_cyclotomic`, `cyclotomic_eq_minpoly_rat`,
`minpoly.dvd`, `natDegree_le_of_dvd`, `IsPrimitiveRoot.of_map_of_injective`,
`Complex.exp_mul_I`, the special-angle `Real.cos_*` lemmas, `Rat.not_irrational`).
Each file is self-contained (`import Mathlib`, re-proving its small core inline),
so the four imports are mutually independent.

## Build status

Authored/registered under a Docker + Aristotle blackout (`docker info` timed out),
so not locally built. Registration is **deployer-build-gated**: if any file fails
to compile, the build blocks *this PR*, not `main`.

## Test plan
- [ ] (build session) `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ01OQ01`
- [ ] (build session) `...Cos`, `...CosRational`, `...Real`
- [ ] `pnpm build` (gallery unaffected — manifest-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)