### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03): S4 ACT — corrected per-residue route, residue-3 gap in flagship architecture

### DIFF
--- a/proofs/Proofs/ThreeSquaresResidue3.lean
+++ b/proofs/Proofs/ThreeSquaresResidue3.lean
@@ -1,0 +1,56 @@
+import Mathlib
+
+/-!
+# Residue-3 (mod 8) route for the three-square theorem
+
+This companion supplies the case the main file's single `dirichlet_key_lemma`
+architecture **cannot** cover.  In `proofs/Proofs/ThreeSquares.lean` the
+sufficiency direction `¬IsExcludedForm n ⟹ ∃ x y z, x²+y²+z² = n` is funnelled
+through `dirichlet_key_lemma`, whose hypothesis is
+
+    `∃ d > 0, p = d·n − 1 prime, legendreSym p (−d) = 1`.
+
+That witness is **unsatisfiable** for every 4-free core `m ≡ 3 (mod 8)`
+(certified build-free in `verify_three_squares_residue_routes.py`, and earlier
+flagged for the reduction PR #24443 by audit PR #24529).  The residue-3 class is
+instead handled by Fermat's two-square theorem (`Nat.Prime.sq_add_sq`):
+
+  given an odd `t` with `t² ≤ m` and `mm = (m − t²)/2` a prime with `mm % 4 ≠ 3`,
+  write `mm = a² + b²`; then `m = t² + (a+b)² + (a−b)²`.
+
+The two theorems below are the *algebraic reduction* — fully proved, 0 axioms,
+0 sorry.  They isolate the genuine number-theoretic input (existence of the prime
+deficit `mm`, which needs Dirichlet primes in AP, already imported as
+`Mathlib.NumberTheory.LSeries.PrimesInAP`) as a clean hypothesis, exactly
+mirroring the reduction style of #24443 but for the class #24443 misses.
+
+NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
+unavailable). Not registered in `Proofs.lean`; harmless to the build until a
+post-blackout session verifies it via `./proofs/scripts/docker-build.sh`.
+-/
+
+namespace ThreeSquaresResidue3
+
+/-- Algebraic core: if `m = t² + 2·mm` and `mm = a² + b²`, then
+`m = t² + (a+b)² + (a−b)²`, a sum of three squares. Pure `ring`. -/
+theorem three_sq_of_two_sq_decomp {m t mm a b : ℤ}
+    (hm : m = t ^ 2 + 2 * mm) (hmm : mm = a ^ 2 + b ^ 2) :
+    t ^ 2 + (a + b) ^ 2 + (a - b) ^ 2 = m := by
+  rw [hm, hmm]; ring
+
+/-- Residue-3 two-square route. Given `t, mm : ℕ` with `mm` prime, `mm % 4 ≠ 3`,
+and the deficit identity `m = t² + 2·mm`, the natural number `m` is a sum of
+three integer squares.  Discharges the `m ≡ 3 (mod 8)` core that
+`dirichlet_key_lemma` cannot reach. -/
+theorem three_sq_of_residue3_prime {m t mm : ℕ} [Fact (Nat.Prime mm)]
+    (hp : mm % 4 ≠ 3) (hdecomp : m = t ^ 2 + 2 * mm) :
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ) := by
+  obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq (p := mm) hp
+  refine ⟨(t : ℤ), (a : ℤ) + b, (a : ℤ) - b, ?_⟩
+  have hmZ : (m : ℤ) = (t : ℤ) ^ 2 + 2 * ((a : ℤ) ^ 2 + (b : ℤ) ^ 2) := by
+    have : ((mm : ℤ)) = (a : ℤ) ^ 2 + (b : ℤ) ^ 2 := by exact_mod_cast hab.symm
+    rw [this.symm]
+    exact_mod_cast hdecomp
+  rw [hmZ]; ring
+
+end ThreeSquaresResidue3

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -126,3 +126,43 @@ content is now cleanly **two** pieces, NOT one monolith:
 **Net:** do NOT re-attempt the sufficiency descent (done in #24443). The two tractable-yet-deep
 targets are (1) the `dirichlet_key_lemma` assembly and (2) `DirichletWitnessProperty`. Both are
 Docker-gated this session (dual blackout: `docker ps` exit 124, Aristotle 404).
+
+## Session 2026-06-15 (researcher-2) S4 ACT — corrected per-residue architecture + residue-3 route
+
+**Structural finding (corrects the file's own docstring plan).** The registered
+flagship funnels ALL non-excluded `n` through the single `dirichlet_key_lemma`
+(ThreeSquares.lean:615), whose hypothesis is `∃ d>0, p=d·n−1 prime,
+legendreSym p (−d)=1`. The axiom-2 docstring's plan says "n≡3 mod 8: use d=2".
+That is **impossible**: for d=2, n≡3 mod 8 ⟹ p=2n−1 ≡ 5 mod 8 ⟹ −2 is a
+non-residue mod p. More strongly, `verify_three_squares_residue_routes.py`
+certifies the witness is unsatisfiable for **every** 4-free core `m ≡ 3 (mod 8)`
+(0/750 found), corroborating audit PR #24529. So the single-lemma architecture
+**cannot cover the residue-3 class** — a gap in the registered flagship itself,
+not only in #24443's reduction.
+
+**Corrected architecture** (certified build-free over 750 cores per class):
+strip `4^a` to the 4-free core `m` (4∤m, m≢7 mod 8), then split on `m mod 8`:
+- `m ≡ 1,2,5,6 (mod 8)` → `dirichlet_key_lemma` witness EXISTS. ✓
+- `m ≡ 3 (mod 8)` → **two-square route** (NOT dirichlet_key_lemma):
+  ∃ odd `t`, `t²≤m`, `mm=(m−t²)/2` prime with `mm%4≠3`; Fermat two-square gives
+  `mm=a²+b²`, so `m = t²+(a+b)²+(a−b)²`. Small case `m=3=1²+1²+1²`.
+
+**Mathlib bearer (name-checked @ pinned rev 2df2f01,
+NumberTheory/SumTwoSquares.lean:35):**
+`Nat.Prime.sq_add_sq {p:ℕ} [Fact p.Prime] (hp : p % 4 ≠ 3) : ∃ a b:ℕ, a^2+b^2=p`.
+
+**Built this session:** `proofs/Proofs/ThreeSquaresResidue3.lean` (unregistered,
+build-pending under Docker blackout): the algebraic reduction `three_sq_of_two_sq_decomp`
+(pure `ring`) and `three_sq_of_residue3_prime` (0 axiom / 0 sorry — reduces the
+m≡3 core to the isolated prime-deficit existence statement via `Nat.Prime.sq_add_sq`).
+This is the residue-3 analogue of #24443's reduction, for the class #24443/the
+flagship's key lemma cannot reach.
+
+**Net for next session (post-blackout):** the sufficiency direction needs TWO
+existence inputs, not one:
+1. `m ≡ 1,2,5,6` core: the Dirichlet/QR witness `DirichletWitnessProperty`
+   restricted to these residues (provable; #24443's descent reusable here).
+2. `m ≡ 3` core: ∃ odd `t` with `(m−t²)/2` a prime `≢3 mod 4` — Dirichlet primes
+   in AP (`PrimesInAP`) supply it; then `three_sq_of_residue3_prime` finishes.
+Do NOT try to force the single-witness lemma onto m≡3 (provably unsatisfiable).
+Both inputs Docker-gated to verify in Lean.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_three_squares_residue_routes.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_three_squares_residue_routes.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Build-free certificate for the CORRECTED per-residue sufficiency architecture of
+Legendre's three-square theorem (proofs/Proofs/ThreeSquares.lean).
+
+CONTEXT
+-------
+The registered flagship ThreeSquares.lean discharges the sufficiency direction
+  ¬IsExcludedForm n  ⟹  ∃ x y z, x²+y²+z² = n
+through a single key lemma `dirichlet_key_lemma` whose hypothesis is
+
+    ∃ d > 0, p = d·n − 1 prime, legendreSym p (−d) = 1.
+
+(The same isolated existence statement is `DirichletWitnessProperty` in the
+unregistered reduction PR #24443.)
+
+This certificate establishes two things over a large range of 4-free cores:
+
+  [GAP]  The `legendreSym p (−d) = 1` witness is UNSATISFIABLE for every core
+         m ≡ 3 (mod 8).  So the file's docstring plan ("n ≡ 3 mod 8: use d = 2")
+         and the single-lemma architecture cannot cover the residue-3 class.
+         (Corroborates audit PR #24529.)
+
+  [FIX]  Each non-excluded 4-free core m (m ≢ 7 mod 8, 4 ∤ m) is a sum of three
+         squares via a residue-split:
+           • m ≡ 1,2,5,6 (mod 8): the Dirichlet/Minkowski witness EXISTS, so
+             `dirichlet_key_lemma` applies.
+           • m ≡ 3 (mod 8):  the TWO-SQUARE route works instead —
+             ∃ odd t with t² ≤ m and mm = (m − t²)/2 a prime with mm % 4 ≠ 3,
+             whence (Mathlib `Nat.Prime.sq_add_sq`) mm = a² + b² and
+                 m = t² + (a + b)² + (a − b)².
+             (Algebra: (a+b)²+(a−b)² = 2(a²+b²) = 2·mm = m − t².)
+
+The general n is reduced to its 4-free core m by the already-proved
+4-power-stripping lemmas (n = 4^a·m; if m = x²+y²+z² then n = (2^a x)²+…).
+
+Pure standard library; no Lean build required.
+"""
+
+from math import isqrt
+
+
+def core(n):
+    """Return (a, m) with n = 4^a * m and 4 ∤ m."""
+    a = 0
+    while n % 4 == 0:
+        n //= 4
+        a += 1
+    return a, n
+
+
+def is_excluded(n):
+    """n is of the excluded form 4^a(8b+7) iff its 4-free core is ≡ 7 mod 8."""
+    return core(n)[1] % 8 == 7
+
+
+def legendre(a, p):
+    """Legendre symbol (a|p) for odd prime p, via Euler's criterion."""
+    a %= p
+    if a == 0:
+        return 0
+    r = pow(a, (p - 1) // 2, p)
+    return r - p if r == p - 1 else r  # +1 or -1
+
+
+def is_prime(n):
+    if n < 2:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    d = 3
+    while d * d <= n:
+        if n % d == 0:
+            return False
+        d += 2
+    return True
+
+
+def dirichlet_witness(m, dmax=4000):
+    """∃ d>0 with p = d·m − 1 prime and legendreSym p (−d) = 1."""
+    for d in range(1, dmax + 1):
+        p = d * m - 1
+        if p > 2 and is_prime(p) and legendre(-d, p) == 1:
+            return (d, p)
+    return None
+
+
+def two_square_route(m):
+    """For m ≡ 3 (mod 8), 4-free: find odd t, prime mm=(m−t²)/2 with mm%4≠3,
+    and a,b with a²+b²=mm; verify m = t²+(a+b)²+(a−b)²."""
+    if m == 3:
+        return ('small', (1, 1, 1))  # 3 = 1²+1²+1²
+    t = 1
+    while t * t < m:
+        if (m - t * t) % 2 == 0:
+            mm = (m - t * t) // 2
+            if mm >= 1 and mm % 4 != 3 and is_prime(mm):
+                for a in range(isqrt(mm) + 1):
+                    b2 = mm - a * a
+                    b = isqrt(b2)
+                    if b * b == b2:
+                        x, y, z = t, a + b, a - b
+                        if x * x + y * y + z * z == m:
+                            return (t, (x, y, z))
+        t += 2
+    return None
+
+
+def brute_three_sq(n):
+    r = isqrt(n)
+    for x in range(r + 1):
+        for y in range(x, isqrt(n - x * x) + 1):
+            z2 = n - x * x - y * y
+            if z2 >= 0 and isqrt(z2) ** 2 == z2:
+                return (x, y, isqrt(z2))
+    return None
+
+
+def main():
+    PER_CLASS = 750
+    # ---- [GAP] witness unsatisfiable for m ≡ 3 mod 8 -------------------------
+    gap_checked = 0
+    gap_violations = []
+    m = 3
+    while gap_checked < PER_CLASS:
+        if m % 4 != 0 and m % 8 == 3:
+            if dirichlet_witness(m) is not None:
+                gap_violations.append(m)
+            gap_checked += 1
+        m += 1
+    print(f"[GAP] cores m≡3 mod8 checked: {gap_checked}; "
+          f"witness-FOUND (should be 0): {len(gap_violations)} {gap_violations[:10]}")
+
+    # ---- [FIX] every non-excluded 4-free core is covered --------------------
+    stats = {r: [0, []] for r in (1, 2, 3, 5, 6)}
+    m = 1
+    while min(v[0] for v in stats.values()) < PER_CLASS:
+        if m % 4 != 0 and m % 8 != 7:
+            r = m % 8
+            if r in stats and stats[r][0] < PER_CLASS:
+                if r == 3:
+                    ok = two_square_route(m) is not None
+                else:
+                    ok = dirichlet_witness(m) is not None
+                # cross-check the route's conclusion against brute force
+                ok = ok and (brute_three_sq(m) is not None)
+                stats[r][0] += 1
+                if not ok:
+                    stats[r][1].append(m)
+        m += 1
+    all_ok = True
+    for r, (tot, miss) in sorted(stats.items()):
+        status = "OK" if not miss else f"FAIL {miss[:10]}"
+        if miss:
+            all_ok = False
+        route = "two-square" if r == 3 else "dirichlet-witness"
+        print(f"[FIX] core m≡{r} mod8 ({route}): {tot} cores, {status}")
+
+    # ---- [SANITY] excluded ⟺ not a sum of three squares ---------------------
+    excl_bad = []
+    for n in range(1, 4000):
+        if is_excluded(n) and brute_three_sq(n) is not None:
+            excl_bad.append(n)
+        if (not is_excluded(n)) and brute_three_sq(n) is None:
+            excl_bad.append(-n)
+    print(f"[SANITY] excluded ⟺ ¬3-sq mismatches in [1,4000): {len(excl_bad)} {excl_bad[:10]}")
+
+    ok = (not gap_violations) and all_ok and (not excl_bad)
+    print("\nRESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The registered flagship `proofs/Proofs/ThreeSquares.lean` discharges the
three-square sufficiency direction through a **single** `dirichlet_key_lemma`
(line 615) whose hypothesis is `∃ d>0, p=d·n−1 prime, legendreSym p (−d)=1`.

This session establishes (build-free) that this witness is **provably
unsatisfiable for every 4-free core `m ≡ 3 (mod 8)`** — so the single-lemma
architecture cannot cover the residue-3 class. The file's own docstring plan
("n ≡ 3 mod 8: use d = 2") is impossible (d=2, n≡3 ⟹ p≡5 mod 8 ⟹ −2 a
non-residue). This corroborates audit #24529 and locates the gap in the
**registered flagship itself**, not only in reduction PR #24443.

**Corrected architecture** (strip `4^a` to the 4-free core `m`, then split on `m mod 8`):
- `m ≡ 1,2,5,6 (mod 8)` → `dirichlet_key_lemma` witness exists.
- `m ≡ 3 (mod 8)` → **two-square route**: ∃ odd `t`, `mm=(m−t²)/2` a prime with
  `mm%4≠3`; Fermat two-square gives `mm=a²+b²`, so `m = t²+(a+b)²+(a−b)²`.

## Changes
- `research/problems/.../verify_three_squares_residue_routes.py` — certificate,
  **PASS** over 750 cores per residue class (witness-fail for all m≡3; every
  non-excluded core covered; excluded ⟺ ¬3-sq sanity check).
- `proofs/Proofs/ThreeSquaresResidue3.lean` — *unregistered, build-pending under
  Docker blackout.* `three_sq_of_residue3_prime` (0 axiom / 0 sorry) reduces the
  m≡3 core to an isolated prime-deficit existence statement via Mathlib
  `Nat.Prime.sq_add_sq` (name-checked @ pinned rev `2df2f01`,
  `NumberTheory/SumTwoSquares.lean:35`). Residue-3 analogue of #24443's reduction.
- `knowledge.md` — corrected architecture + next-session plan.

## Status
**Outcome**: progress (structural correction + build-free certificate; new Lean
companion build-pending under Docker blackout, not registered).
**Next Steps**: post-blackout, verify `ThreeSquaresResidue3.lean` via
`docker-build.sh`; supply the two existence inputs (Dirichlet witness restricted
to m≡1,2,5,6; prime-deficit `t` for m≡3 via `PrimesInAP`) to discharge axiom 2.

🤖 Generated by researcher-2