### PR TITLE
audit(euler-identity-oq01x4): sync stale lineCount/theoremCount + add kernel theorem

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 147,
+    "lineCount": 175,
     "mathlibDependencies": [
       {
         "theorem": "contMDiff_circleExp",
@@ -68,6 +68,7 @@
       "hasDerivAt_circleExp: defining ODE of the Lie group exponential, γ'(t) = γ(t)·I",
       "hasDerivAt_circleExp_zero: velocity at the identity is the imaginary unit I — the Lie algebra generator",
       "generator_mem_imaginary_axis: Re(I)=0, Im(I)=1, exhibiting the Lie algebra as iℝ",
+      "circleExp_eq_one_iff: kernel of the exponential — Circle.exp t = 1 ⟺ t ∈ 2πℤ (periodicity of the one-parameter subgroup)",
       "main: bundles homomorphism + C∞ (all orders) + Lie algebra generator I"
     ],
     "dateAdded": "2026-06-15",
@@ -82,7 +83,7 @@
       "euler-identity-oq-01-oq-01-oq-01",
       "de-moivre"
     ],
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -186,8 +187,8 @@
   "leanFile": {
     "path": "Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean",
     "filename": "EulerIdentityOQ01OQ01OQ01OQ01.lean",
-    "lineCount": 147,
-    "theoremCount": 8,
+    "lineCount": 175,
+    "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

First tracker audit of `euler-identity-oq-01-oq-01-oq-01-oq-01` ("Euler's Formula as a Smooth Lie Group Exponential Map").

**Integrity verdict: substantively clean.** The Tier B classification is already correct on main (badge `mathlib`, status `verified`, 0 sorries, 0 axioms) following #24552. Independently re-verified the source `proofs/Proofs/EulerIdentityOQ01OQ01OQ01OQ01.lean`:
- 0 sorries, 0 axioms, no `True` stubs / `admit` / assumption-carrying structures
- Core smoothness comes from Mathlib's `contMDiff_circleExp` on the analytic `LieGroup (𝓡 1) ω Circle` — correctly badged `mathlib`, and the overview honestly frames the result as "resolved by *packaging*, not new analysis"
- `originalContributions` accurately scoped to bridge/identification/assembly lemmas

This PR fixes the remaining **stale auto-derived metadata**:
- `lineCount` 147 → 175 (both blocks)
- `theoremCount` 8 → 9 (both blocks) — source has 9 top-level theorems
- adds `circleExp_eq_one_iff` (exponential kernel: `Circle.exp t = 1 ⟺ t ∈ 2πℤ`) to `originalContributions`, which was previously missing

## Test plan
- [x] `python3 -m json.tool` validates the edited meta.json
- [x] Counts cross-checked against the Lean source (`wc -l` = 175, 9 `^theorem` decls)
- [ ] `pnpm build` (deferred; metadata-only change, deployer-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)