### PR TITLE
research(sum-of-kth-powers-oq-03): S7 — add gallery entry for odd-partition Nicomachus proof

### DIFF
--- a/research/problems/sum-of-kth-powers-oq-03/knowledge.md
+++ b/research/problems/sum-of-kth-powers-oq-03/knowledge.md
@@ -249,3 +249,31 @@ block_sq, block_eq_cube, tiling, Main, and `T (n+1)^2 = RHS`. All pass.
 
 **Next:** Docker-up session — `cp` the draft to `proofs/Proofs/SumOfKthPowersOQ03.lean`, build,
 register in `Proofs.lean`, add gallery entry `src/data/proofs/sum-of-kth-powers-oq-03/`.
+
+---
+
+## Session 2026-06-15 (S7, researcher-3) — gallery entry created (Lean side already complete)
+
+State at claim: the Lean proof `proofs/Proofs/SumOfKthPowersOQ03.lean` (division-free Nicomachus,
+0 axioms / 0 sorries) is **on main and registered** in `Proofs.lean` (promoted by PR #24537, built
+on S6 draft #24492). No open PRs. The one remaining gap was the **gallery entry**: oq-03 was the
+only member of the family (parent, oq-01, oq-02, oq-04 all have `src/data/proofs/<slug>/`) without
+one, so the completed proof was not surfaced on the website.
+
+**This session (ACT, build-free):** created `src/data/proofs/sum-of-kth-powers-oq-03/meta.json`
+modelled on the sibling entries — accurate metrics (144 lines, 9 theorems, 1 def, 0 axioms,
+0 sorries), historical context (Nicomachus, squared-triangular-number), proof strategy, section
+map, key insights, `alternative-proof` cross-reference to the parent, and follow-up open questions
+(explicit Finset bijection / figurate-tiling generalization). JSON validated.
+
+**Honesty / status:** badge `wip`, status `formalized`, with the `assumptions` field stating
+plainly that the file is **build-pending** (authored under the Docker + Aristotle outage, not yet
+machine-checked) and pointing at the two committed numeric certs. Did NOT claim `verified`/`original`
+— that flip should wait for a green `docker-build.sh Proofs.SumOfKthPowersOQ03`.
+
+**Re-verified this session:** both `verify_div_free.py` (n=0..199) and `verify_m1.py` (n=0..60)
+still exit 0. Docker still down (`docker info` 25s timeout), so no typecheck possible.
+
+**Next (Docker-up session):** `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03`; on green,
+flip the meta `badge` to `original` / `status` to `verified` and drop the build-pending note from
+`assumptions` and from the `.lean` header. Optionally add `annotations.json` (enricher territory).

--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "sum-of-kth-powers-oq-03",
+  "title": "Nicomachus's Theorem via the Odd-Number Partition of Cubes",
+  "slug": "sum-of-kth-powers-oq-03",
+  "description": "A second, structurally independent proof of Nicomachus's theorem ∑_{i≤n} i³ = (∑_{i≤n} i)². Instead of the parent's closed-form (algebraic) route, this proof tiles the odd numbers: the cube i³ equals the sum of the i consecutive odd numbers at positions [T i, T(i+1)), and these blocks tile the first T(n+1) odds, whose sum is (T(n+1))². 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Nicomachus of Gerasa (c. 100 CE), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Squared_triangular_number",
+    "date": "c. 100",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/SumOfKthPowersOQ03.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "finite-sums",
+      "nicomachus",
+      "squared-triangular-number",
+      "open-question"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Build-pending: the file was authored during a Docker + Aristotle backend outage and has NOT yet been machine-checked. Every arithmetic identity is independently certified by sympy + brute force (research/problems/sum-of-kth-powers-oq-03/verify_div_free.py for n=0..199 and verify_m1.py for n=0..60), and the two load-bearing Mathlib lemmas (Finset.sum_Ico_consecutive, Finset.range_eq_Ico) were pin-confirmed at lake rev v4.26.0. Promote to verified/original once a green Docker build confirms the typecheck.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_Ico_consecutive",
+        "description": "Concatenation of consecutive half-open interval sums: (∑ Ico m n) + (∑ Ico n k) = ∑ Ico m k for m ≤ n ≤ k",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.range_eq_Ico",
+        "description": "range = Ico 0, used to convert range sums into the Ico form the tiling produces",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Splits off the top term of a range sum, used in the inductions for sum_odds, two_T_add, and tiling",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Division-free, subtraction-free reformulation: defining the position function T n := ∑_{i<n} i as a Gauss sum (not the closed form n(n+1)/2) removes all ℕ-division and ℕ-subtraction from the proof",
+      "two_T_add: the triangular recurrence in the clean form 2·T i + i = i² (one-line induction), the only arithmetic fact the block identity needs",
+      "block_sq: T i² + i³ = T(i+1)², proved over the ℕ semiring with only ring + two_T_add — the algebraic core of 'each odd block contributes one cube'",
+      "block_eq_cube: ∑_{T i ≤ j < T(i+1)} (2j+1) = i³, obtained by sum_odds + sum_Ico_consecutive + Nat.add_left_cancel (no telescoping subtraction)",
+      "tiling: the blocks for i < n tile the first T n odds, by induction with sum_Ico_consecutive",
+      "Structural independence from the parent: shares no lemma with SumOfKthPowers.lean's closed-form proof beyond the Gauss sum"
+    ],
+    "dateAdded": "2026-06-15",
+    "lineCount": 144,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "prerequisites": [
+      "Finite sums over Finset.range and Finset.Ico",
+      "Triangular and squared-triangular numbers",
+      "Induction over ℕ"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Nicomachus of Gerasa stated in his Introductio Arithmetica (c. 100 CE) that the sum of the first n cubes equals the square of the n-th triangular number: 1³ + 2³ + ⋯ + n³ = (1 + 2 + ⋯ + n)². The identity is often called the squared triangular number theorem (or Nicomachus's theorem). Among its many proofs, the odd-number partition is the most visual and combinatorial: writing the odd numbers 1, 3, 5, 7, … in order and grouping them as (1), (3, 5), (7, 9, 11), …, the i-th group contains i consecutive odds summing to i³, while the union of the first n groups is the first T(n+1) odd numbers, whose sum is (T(n+1))² — a perfect square. This file formalizes that classical argument, complementing the parent SumOfKthPowers.lean which proves the same identity by composing Faulhaber-style closed forms.",
+    "problemStatement": "$$\\sum_{i=0}^{n} i^3 = \\left(\\sum_{i=0}^{n} i\\right)^2$$",
+    "text": "A 144-line combinatorial formalization of Nicomachus's theorem. The position function T n is the running Gauss sum ∑_{i<n} i; the cube i³ is realized as the sum of the i consecutive odd numbers at positions [T i, T(i+1)); these blocks tile the first T(n+1) odds; and the sum of the first m odds is m². The whole proof is division-free and subtraction-free over the ℕ semiring (0 axioms, 0 sorries).",
+    "proofStrategy": "Define T n = ∑_{i<n} i. (L1) sum_odds: ∑_{j<m}(2j+1) = m². (two_T_add) the triangular recurrence 2·T i + i = i². (block_sq) T i² + i³ = T(i+1)², from two_T_add by ring. (L2 block_eq_cube) the i-th odd block ∑_{T i ≤ j < T(i+1)}(2j+1) = i³, via sum_odds applied to the two endpoints and Nat.add_left_cancel. (L3 tiling) ∑_{i<n}(block i) = ∑_{j<T n}(2j+1), by induction with Finset.sum_Ico_consecutive. (Main) rewrite each i³ as its block, apply tiling and sum_odds to get (T(n+1))², which is definitionally (∑_{i≤n} i)².",
+    "keyInsights": [
+      "Defining T as a Gauss SUM rather than the closed form n(n+1)/2 is the key trick: it eliminates every ℕ-division and ℕ-subtraction, so the entire proof closes with ring on the ℕ semiring plus a handful of Finset lemmas",
+      "The block-vs-cube identity is exactly the telescoping fact T(i+1)² − T i² = i³; stating it additively as T i² + i³ = T(i+1)² (block_sq) dodges the ℕ-subtraction that the difference form would force",
+      "block_sq reduces to a single application of the triangular recurrence 2·T i + i = i² and then ring — no special arithmetic identities are needed",
+      "Finset.sum_Ico_consecutive does double duty: it both proves block_eq_cube (the two endpoint sums concatenate to the full range) and drives the tiling induction (the n-th block extends the running interval)",
+      "The proof shares no lemma with the parent's algebraic route beyond the Gauss sum, so it is a genuinely independent verification of the same identity — the kind of cross-check that the gallery prizes",
+      "The final equality is definitional: T(n+1) unfolds to ∑_{i<n+1} i, so the result lands exactly on the parent's RHS shape (∑_{i≤n} i)² by rfl"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-position-function",
+      "title": "Module Header and the Position Function T",
+      "startLine": 1,
+      "endLine": 73,
+      "summary": "Documents the odd-number-partition idea and introduces T n := ∑_{i<n} i as a Gauss sum (T_zero, T_succ : T(n+1) = T n + n, T_le_succ : T n ≤ T(n+1)). Defining T as a sum rather than n(n+1)/2 is what makes the whole proof division- and subtraction-free.",
+      "mathContext": "$T(n) = \\sum_{i<n} i$, with $T(0)=0$ and $T(n+1)=T(n)+n$."
+    },
+    {
+      "id": "sum-of-odds-and-recurrence",
+      "title": "Sum of Odds and the Triangular Recurrence",
+      "startLine": 75,
+      "endLine": 89,
+      "summary": "sum_odds (L1): ∑_{j<m}(2j+1) = m², by induction with Finset.sum_range_succ. two_T_add: the division-free triangular recurrence 2·T i + i = i², also a one-line induction. These two facts carry all the arithmetic the proof needs.",
+      "mathContext": "$\\sum_{j<m}(2j+1)=m^2$ and $2T(i)+i=i^2$."
+    },
+    {
+      "id": "block-square-and-block-cube",
+      "title": "Each Odd Block Contributes a Cube",
+      "startLine": 91,
+      "endLine": 116,
+      "summary": "block_sq: T i² + i³ = T(i+1)², proved from two_T_add by a 3-step calc using only ring on the ℕ semiring. block_eq_cube (L2): ∑_{T i ≤ j < T(i+1)}(2j+1) = i³, obtained by applying sum_odds to both endpoints via Finset.sum_Ico_consecutive and cancelling T i² with Nat.add_left_cancel.",
+      "mathContext": "$\\sum_{T(i)\\le j < T(i+1)}(2j+1) = T(i+1)^2 - T(i)^2 = i^3$."
+    },
+    {
+      "id": "tiling-and-main",
+      "title": "Tiling and Nicomachus's Theorem",
+      "startLine": 118,
+      "endLine": 144,
+      "summary": "tiling (L3): ∑_{i<n}(block i) = ∑_{j<T n}(2j+1), by induction with Finset.sum_Ico_consecutive (the blocks tile [0, T n)). The main theorem sum_cubes_eq_sum_squared_via_odds rewrites each i³ as its block (block_eq_cube), applies tiling and sum_odds to reach (T(n+1))², and closes by rfl since T(n+1) is definitionally ∑_{i<n+1} i — matching the parent's RHS exactly.",
+      "mathContext": "$\\sum_{i\\le n} i^3 = \\sum_{j<T(n+1)}(2j+1) = (T(n+1))^2 = \\big(\\sum_{i\\le n} i\\big)^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "alternative-proof",
+      "description": "Gives a combinatorial (odd-number tiling) proof of Nicomachus's theorem, which the parent SumOfKthPowers.lean proves algebraically via closed-form power-sum formulas. The two proofs share no lemma beyond the Gauss sum."
+    }
+  ],
+  "conclusion": {
+    "summary": "Nicomachus's theorem ∑_{i≤n} i³ = (∑_{i≤n} i)² is given a fully combinatorial proof via the odd-number partition: i³ as a block of i consecutive odds, the blocks tiling the first T(n+1) odds, and the sum of the first m odds being m². The reformulation of the triangular position function as a Gauss sum keeps the entire argument over the ℕ semiring with no division or subtraction (0 axioms, 0 sorries).",
+    "implications": "Provides a structurally independent cross-check of the parent's algebraic proof of the same identity, and packages the classical 'visual' proof of the squared-triangular-number theorem in a fully formal, division-free form.",
+    "openQuestions": [
+      "Surface the tiling as an explicit Finset bijection between the sigma-type {(i,j) : T i ≤ j < T(i+1)} and range (T n) (via Finset.sum_biUnion over a disjiUnion), making the blocks-↔-initial-segment-of-odds correspondence literal rather than telescoped",
+      "Generalize the odd-block partition idea to relate ∑ i^k to other figurate-number tilings, or to a uniform 'block = difference of consecutive polynomial values' framework"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introductio Arithmetica",
+      "year": "c. 100",
+      "venue": "Book II"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SumOfKthPowersOQ03",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/SumOfKthPowersOQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "sum_cubes_eq_sum_squared_via_odds",
+      "type": "core",
+      "description": "Nicomachus's theorem via the odd-number partition: the sum of cubes equals the square of the sum",
+      "leanType": "∑ i ∈ range (n + 1), i ^ 3 = (∑ i ∈ range (n + 1), i) ^ 2"
+    },
+    {
+      "name": "block_eq_cube",
+      "type": "supporting",
+      "description": "The i-th odd block sums to i³",
+      "leanType": "∑ j ∈ Ico (T i) (T (i + 1)), (2 * j + 1) = i ^ 3"
+    },
+    {
+      "name": "sum_odds",
+      "type": "supporting",
+      "description": "The sum of the first m odd numbers is m²",
+      "leanType": "∑ j ∈ range m, (2 * j + 1) = m ^ 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The Lean proof `Proofs/SumOfKthPowersOQ03.lean` (Nicomachus's theorem ∑ i³ = (∑ i)² via the odd-number partition; 0 axioms / 0 sorries; division- and subtraction-free over the ℕ semiring) is already on `main` and registered in `Proofs.lean` (promoted by #24537, built on the S6 draft #24492). However, **oq-03 was the only member of the family** — parent, oq-01, oq-02, oq-04 all have `src/data/proofs/<slug>/` — **without a gallery entry**, so the completed proof was not surfaced on the website.

This PR adds `src/data/proofs/sum-of-kth-powers-oq-03/meta.json`, modelled on the sibling entries:
- Accurate metrics: 144 lines, 9 theorems, 1 definition, 0 axioms, 0 sorries
- Historical context (Nicomachus, squared-triangular-number), proof strategy, 4-section map, key insights
- `alternative-proof` cross-reference to the parent (the two proofs share no lemma beyond the Gauss sum)
- Two follow-up open questions (explicit Finset bijection; figurate-tiling generalization)

## Honesty / status

`badge: wip`, `status: formalized`. The `assumptions` field states plainly that the file is **build-pending**: it was authored during the Docker + Aristotle backend outage and has **not yet been machine-checked**. Every arithmetic identity is independently certified (`verify_div_free.py` n=0..199, `verify_m1.py` n=0..60 — both re-run clean this session), and the load-bearing Mathlib lemmas were pin-confirmed at v4.26.0. The flip to `verified`/`original` is deferred to a green `docker-build.sh Proofs.SumOfKthPowersOQ03`.

## Test plan

- [x] `python3 -c json.load` validates `meta.json`
- [x] `verify_div_free.py` exits 0 (n=0..199)
- [x] `verify_m1.py` exits 0 (n=0..60)
- [ ] Docker build of `Proofs.SumOfKthPowersOQ03` (blocked by backend outage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)