### PR TITLE
research(hilbert-10-oq-01-oq-02): correct stale future-work docstrings on level-2 closures

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -1336,9 +1336,12 @@ theorem intersection_isDiophantineDefinition
     This is NOT the strongest possible Π₂-closure statement (which would
     require a direct Π₂ witness for `S₁ ∩ S₂` when `S₁`, `S₂` are
     arbitrary Π₂-definable subsets — that's a strictly bigger claim than
-    Σ₁ closure). The stronger Π₂ ∩ Π₂ ⊆ Π₂ closure is left as future
-    work; this file's S11.1 (`coDiophantine_implies_universal_existential`)
-    handles the unary Π₁ ⊆ Π₂ direction without intersection. -/
+    Σ₁ closure). That stronger Π₂ ∩ Π₂ ⊆ Π₂ closure is proved directly
+    below as `pi2_intersection_isUniversalExistentialDefinition` (Part
+    VIII; sum-of-squares witness `P₁² + P₂²` paired over `evenProj`/
+    `oddProj`); this corollary is retained as the cheap Σ₁-input route.
+    (S11.1 `coDiophantine_implies_universal_existential` handles the
+    unary Π₁ ⊆ Π₂ direction without intersection.) -/
 theorem intersection_isUniversalExistentialDefinition
     {S₁ S₂ : RatSubset}
     (h₁ : IsDiophantineDefinition S₁) (h₂ : IsDiophantineDefinition S₂) :
@@ -1437,8 +1440,11 @@ theorem union_isCoDiophantineDefinition
 
     NOT the strongest possible Σ₂-closure statement (which would require
     a direct Σ₂ witness for `S₁ ∪ S₂` when `S₁`, `S₂` are arbitrary
-    Σ₂-definable subsets — strictly bigger than Π₁ ∪ closure). The
-    stronger Σ₂ ∪ Σ₂ ⊆ Σ₂ closure is left as future work. -/
+    Σ₂-definable subsets — strictly bigger than Π₁ ∪ closure). That
+    stronger Σ₂ ∪ Σ₂ ⊆ Σ₂ closure is proved directly below as
+    `sigma2_union_isExistentialUniversalDefinition` (Part VIII, via the
+    iter-5 Σ₂/Π₂ duality + `pi2_intersection_isUniversalExistentialDefinition`);
+    this corollary is retained as the cheap Π₁-input route. -/
 theorem union_isExistentialUniversalDefinition
     {S₁ S₂ : RatSubset}
     (h₁ : IsCoDiophantineDefinition S₁) (h₂ : IsCoDiophantineDefinition S₂) :


### PR DESCRIPTION
## Summary
Documentation-accuracy fix to the flagship `Hilbert10OQ01OQ02.lean` (arithmetical-hierarchy closure grid over ℚ). Two iter-12/13 corollary docstrings claimed the stronger level-2 closures were **"left as future work"**, but both have since been proved in the same file:

| Stale claim | Actually proved at |
|-------------|--------------------|
| `Π₂ ∩ Π₂ ⊆ Π₂` "left as future work" (in `intersection_isUniversalExistentialDefinition`) | `pi2_intersection_isUniversalExistentialDefinition` (Part VIII) |
| `Σ₂ ∪ Σ₂ ⊆ Σ₂` "left as future work" (in `union_isExistentialUniversalDefinition`) | `sigma2_union_isExistentialUniversalDefinition` (Part VIII) |

The level-2 closure grid is in fact **complete** (binary + list + Finset versions for both ∩ and ∪, at both Σ₂ and Π₂). The stale hedges misdirect readers — and research agents claim-scanning for open work — into re-deriving finished theorems.

## Change
Comment-only: rewrites the two cross-references to point at the proving theorems. **No code, definition, or proof term is touched** (`git diff` is entirely inside `/-- … -/` blocks).

## Why it matters
This exact stale-hedge nearly caused a duplicated-effort claim this session. Accurate cross-references in a 2900-line flagship file have real anti-duplication value.

## Build status
Comment-only change to a file already on `main`; no semantic effect, so no rebuild risk. (Docker in blackout this session regardless.)

## Test plan
- [x] `git diff` confirmed comment-only (11 insertions / 5 deletions, all docstring text)
- [ ] `./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02` (when Docker available; unchanged behavior expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)