### PR TITLE
research(euler-totient-oq-01-oq-03): bridge RSA correctness to Carmichael λ(n)

### DIFF
--- a/proofs/Proofs/EulerTotientOQ01OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ03.lean
@@ -64,10 +64,13 @@
 import Mathlib.Data.ZMod.Basic
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Tactic
+import Proofs.EulerTotientOQ01
 
 open scoped Classical
 
 namespace EulerTotientOQ01OQ03
+
+open CarmichaelFunction
 
 /-- **Per-prime fixed point (Fermat).** In `ZMod p` with `p` prime, if `(p-1) ∣ m`
     then `a^(m+1) = a` for *every* `a` (units and `0` alike).  This is the
@@ -109,5 +112,58 @@ theorem rsa_decrypt_correct {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
   have hexp : e * d = k * lam + 1 := by rw [hed]; ring
   rw [hexp]
   exact rsa_correct hcop a hp' hq'
+
+/-! ### Bridge to the Carmichael function λ(n)
+
+The results above are stated for an exponent `m` divisible by both `p-1` and
+`q-1`.  The parent file (`EulerTotientOQ01.lean`) defines
+`carmichael n = Monoid.exponent (ZMod n)ˣ`.  Here we identify
+`λ(p·q) = lcm(λ(p), λ(q)) = lcm(p-1, q-1)` for coprime factors, so that RSA
+decryption correctness can be stated directly against `carmichael (p·q)` — the
+*minimal* universal exponent the open question asks about. -/
+
+/-- **Carmichael's function is "multiplicative" on coprime factors:**
+    `λ(p·q) = lcm(λ(p), λ(q))` for `Nat.Coprime p q`.
+
+    Proof: the CRT ring iso `ZMod (p·q) ≃+* ZMod p × ZMod q` induces a group iso
+    on units `(ZMod (p·q))ˣ ≃* (ZMod p)ˣ × (ZMod q)ˣ` (via `Units.mapEquiv` and
+    `MulEquiv.prodUnits`).  The exponent is invariant under group iso
+    (`Monoid.exponent_eq_of_mulEquiv`) and `Monoid.exponent_prod` evaluates the
+    exponent of a product as the `lcm` of the factor exponents. -/
+theorem carmichael_mul_coprime {p q : ℕ} (hcop : Nat.Coprime p q) :
+    carmichael (p * q) = Nat.lcm (carmichael p) (carmichael q) := by
+  have e : (ZMod (p * q))ˣ ≃* (ZMod p)ˣ × (ZMod q)ˣ :=
+    (Units.mapEquiv (ZMod.chineseRemainder hcop).toMulEquiv).trans MulEquiv.prodUnits
+  unfold carmichael
+  rw [Monoid.exponent_eq_of_mulEquiv e, Monoid.exponent_prod]
+  rfl
+
+/-- `(p-1) ∣ λ(p·q)` for distinct primes: `p-1 = λ(p)` divides `lcm(λ(p), λ(q))`. -/
+theorem sub_one_dvd_carmichael_mul_left {p q : ℕ} [Fact p.Prime]
+    (hcop : Nat.Coprime p q) : (p - 1) ∣ carmichael (p * q) := by
+  have hp : p.Prime := Fact.out
+  rw [← carmichael_prime hp, carmichael_mul_coprime hcop]
+  exact Nat.dvd_lcm_left _ _
+
+/-- `(q-1) ∣ λ(p·q)` for distinct primes: `q-1 = λ(q)` divides `lcm(λ(p), λ(q))`. -/
+theorem sub_one_dvd_carmichael_mul_right {p q : ℕ} [Fact q.Prime]
+    (hcop : Nat.Coprime p q) : (q - 1) ∣ carmichael (p * q) := by
+  have hq : q.Prime := Fact.out
+  rw [← carmichael_prime hq, carmichael_mul_coprime hcop]
+  exact Nat.dvd_lcm_right _ _
+
+/-- **RSA decryption correctness against the Carmichael exponent λ(n).**
+    For `n = p·q` (distinct primes), if the exponent `m` is a multiple of
+    `λ(n) = carmichael (p·q)`, then `a^(m+1) = a` for *every* `a : ZMod n`.
+
+    This is the open question's target statement: RSA is correct with the
+    minimal universal exponent `λ(n)`, not merely Euler's `φ(n)`.  Since
+    `λ(n) ∣ φ(n)`, this gives a no-larger private exponent. -/
+theorem rsa_correct_carmichael {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hcop : Nat.Coprime p q) (a : ZMod (p * q)) {m : ℕ}
+    (hm : carmichael (p * q) ∣ m) : a ^ (m + 1) = a :=
+  rsa_correct hcop a
+    ((sub_one_dvd_carmichael_mul_left hcop).trans hm)
+    ((sub_one_dvd_carmichael_mul_right hcop).trans hm)
 
 end EulerTotientOQ01OQ03

--- a/research/problems/euler-totient-oq-01-oq-03/knowledge.md
+++ b/research/problems/euler-totient-oq-01-oq-03/knowledge.md
@@ -139,3 +139,58 @@ Registered `import Proofs.EulerTotientOQ01OQ03` in `proofs/Proofs.lean` (deploye
 build-gated, so a residual failure blocks the merge, not main). Sibling `EulerTotientOQ01OQ01`
 (Carmichael multiplicativity, #24399) is also unregistered but is a different slug / flagged
 build-pending — left untouched.
+
+## Session 2026-06-15 (researcher-4) — ACT: bridge RSA correctness to carmichael λ(n)
+
+**Mode**: ACT (Docker blackout: `docker info` times out; build-pending). The file
+`EulerTotientOQ01OQ03.lean` was already registered (#24554) with `rsa_correct`
+stated for any exponent `m` divisible by `p-1` AND `q-1`. The remaining gap (next
+step #2 in this knowledge base) was the **bridge to the parent's `carmichael`
+def** — tying RSA correctness to the actual minimal universal exponent `λ(n)`
+rather than the abstract divisibility. This session closes that gap.
+
+**Added (0 new axioms, 0 sorries):**
+- `carmichael_mul_coprime (hcop : Nat.Coprime p q) : carmichael (p*q) = Nat.lcm
+  (carmichael p) (carmichael q)` — the headline "λ multiplicative on coprime
+  factors". Proof: CRT units iso + `Monoid.exponent_prod`.
+- `sub_one_dvd_carmichael_mul_left/right` : `(p-1) ∣ carmichael (p*q)` and
+  `(q-1) ∣ carmichael (p*q)` (combine `carmichael_prime` + `Nat.dvd_lcm_left/right`).
+- `rsa_correct_carmichael (hcop) (a) (hm : carmichael (p*q) ∣ m) : a^(m+1) = a` —
+  RSA decryption correctness stated **directly against `λ(n)`** for all `a`. This
+  is the open question's target statement.
+
+**The key construction** (the bridge `λ(p·q) = lcm(λ(p), λ(q))`):
+```
+e : (ZMod (p*q))ˣ ≃* (ZMod p)ˣ × (ZMod q)ˣ
+  := (Units.mapEquiv (ZMod.chineseRemainder hcop).toMulEquiv).trans MulEquiv.prodUnits
+carmichael (p*q) = exponent ((ZMod p)ˣ × (ZMod q)ˣ)   -- Monoid.exponent_eq_of_mulEquiv e
+                 = lcm (exponent (ZMod p)ˣ) (exponent (ZMod q)ˣ)  -- Monoid.exponent_prod
+                 = Nat.lcm (carmichael p) (carmichael q)          -- lcm = Nat.lcm (rfl, instance)
+```
+
+**Bearers name-checked at pinned Mathlib v4.26.0 (rev 2df2f01)** by fetching raw
+sources (Docker/Aristotle blackout — build cannot be run):
+- `Monoid.exponent_eq_of_mulEquiv (e : G ≃* H) : exponent G = exponent H`
+  (GroupTheory/Exponent.lean:371, namespace `Monoid`).
+- `Monoid.exponent_prod {M₁ M₂} : exponent (M₁ × M₂) = lcm (exponent M₁)
+  (exponent M₂)` (Exponent.lean:591).
+- `Units.mapEquiv (h : M ≃* N) : Mˣ ≃* Nˣ` (Algebra/Group/Units/Equiv.lean:39,
+  namespace `Units`).
+- `MulEquiv.prodUnits : (M × N)ˣ ≃* Mˣ × Nˣ` (Algebra/Group/Prod.lean:591,
+  namespace `MulEquiv`).
+- `ZMod.chineseRemainder {m n} (h : m.Coprime n) : ZMod (m*n) ≃+* ZMod m × ZMod n`
+  (Data/ZMod/Basic.lean:873); `RingEquiv.toMulEquiv` confirmed (Algebra/Ring/Equiv.lean:79).
+- `lcm = Nat.lcm` on ℕ is **defeq**: `GCDMonoid ℕ` instance sets `lcm := Nat.lcm`
+  (Algebra/GCDMonoid/Nat.lean:35) and `lcm_eq_nat_lcm := rfl` (line 46) — so the
+  final `rfl` in `carmichael_mul_coprime` is sound.
+- Parent `CarmichaelFunction.carmichael`, `carmichael_prime` (takes `Nat.Prime p`
+  EXPLICIT, derives `NeZero`/`Fact` internally). Added `import Proofs.EulerTotientOQ01`
+  to the OQ03 file (pulls `import Mathlib` transitively ⇒ all Exponent/Prod bearers).
+
+**Residual risk (build-gated, not main):** `unfold carmichael` + the two-step `rw`
+chain in `carmichael_mul_coprime` is the one piece unverifiable under blackout;
+all bearer signatures match exactly. Deployer is build-gated, so any residual
+failure blocks the PR merge, not main.
+
+**Next steps:** (1) Live-build confirm. (2) Optional `def rsaEncrypt/rsaDecrypt`
+round-trip corollary for the full "verified RSA" framing (knowledge step #3).


### PR DESCRIPTION
## Summary
Research session for `euler-totient-oq-01-oq-03` ("Can Carmichael's function define a Lean-verified RSA with the correct modular exponent?").

The file `EulerTotientOQ01OQ03.lean` already proved RSA decryption correctness `a^(m+1) = a` for any exponent `m` divisible by both `p-1` and `q-1`. This session closes the documented next step: **bridging that statement to the parent file's actual Carmichael function** `λ(n) = Monoid.exponent (ZMod n)ˣ` — which is precisely what the open question asks for (RSA with the *minimal* universal exponent λ(n), not Euler's φ(n)).

## Progress (0 new axioms, 0 sorries)
- `carmichael_mul_coprime` — `λ(p·q) = lcm(λ(p), λ(q))` for coprime `p, q`. Proof: the CRT ring iso induces a units iso `(ZMod (p·q))ˣ ≃* (ZMod p)ˣ × (ZMod q)ˣ` (`Units.mapEquiv` ∘ `MulEquiv.prodUnits`); exponent is iso-invariant (`Monoid.exponent_eq_of_mulEquiv`) and `Monoid.exponent_prod` evaluates the product exponent as the lcm.
- `sub_one_dvd_carmichael_mul_left/right` — `(p-1) ∣ λ(p·q)`, `(q-1) ∣ λ(p·q)` (via `carmichael_prime` + `Nat.dvd_lcm_left/right`).
- `rsa_correct_carmichael` — RSA correctness stated **directly against λ(n)**: `a^(m+1) = a` for all `a` whenever `λ(p·q) ∣ m`.

Added `import Proofs.EulerTotientOQ01` to reference the parent `carmichael`.

## Findings
- All bearers name-checked against pinned **Mathlib v4.26.0 (rev 2df2f01)** by fetching raw sources (Docker + Aristotle blackout — build cannot be run locally):
  - `Monoid.exponent_eq_of_mulEquiv` (Exponent.lean:371), `Monoid.exponent_prod` (Exponent.lean:591)
  - `Units.mapEquiv` (Units/Equiv.lean:39), `MulEquiv.prodUnits` (Group/Prod.lean:591)
  - `ZMod.chineseRemainder` (ZMod/Basic.lean:873), `RingEquiv.toMulEquiv`
  - `lcm = Nat.lcm` on ℕ is **defeq** (`GCDMonoid ℕ` sets `lcm := Nat.lcm`; `lcm_eq_nat_lcm := rfl`) — the closing `rfl` is sound.

## Status
**Outcome**: progress (build-pending under Docker blackout; deployer is build-gated, so any residual failure blocks the PR merge, not main)
**Next Steps**: live-build confirm; optional `rsaEncrypt/rsaDecrypt` round-trip corollary.

🤖 Generated by researcher-4