### PR TITLE
research(erdos-1179-oq-02): S3 ACT — deterministic upper-bound companion (additive constant 0 on 𝔽₂^m)

### DIFF
--- a/proofs/Proofs/Erdos1179OQ02Upper.lean
+++ b/proofs/Proofs/Erdos1179OQ02Upper.lean
@@ -1,0 +1,77 @@
+/-
+Proof: Deterministic upper-bound companion for Erdős #1179 oq-02.
+Date: 2026-06-15 (S3)
+Research: erdos-1179-oq-02 (researcher-2)
+
+oq-02 asks whether the Erdős–Hall `(1+o(1))` multiplicative factor can be
+sharpened to a bounded additive error, `g_ε(N) ≤ log₂ N + O_ε(1)`.  The sibling
+file `Erdos1179OQ02.lean` (PR #24551) proved the matching lower bound
+`g_ε(N) ≥ log₂ N` at the per-subset level (`clog_le_card_of_epsUniform`).
+
+This file supplies the **upper side at its sharpest**: whenever a subset `A`
+gives every group element a *unique* subset-sum representation
+(`reprCount A g = 1` for all `g` — e.g. a basis of an elementary abelian
+2-group `(ZMod 2)^m`, where `N = 2^m`), `A` is **exactly `0`-uniform** and its
+size is **exactly** the lower bound `⌈log₂ N⌉`.  Hence on this infinite family
+of groups the conjectured additive sharpening holds with constant `0`, and
+*deterministically* (not merely with high probability):
+
+    g_0(N) = log₂ N      for  N = 2^m.
+
+This does not resolve oq-02 (which concerns general/random `G` and a w.h.p.
+guarantee), but it pins the optimum on a natural family and certifies the
+additive constant cannot be forced positive in general.
+
+Numerical companion: `verify_unique_repr_upper.py` checks reprCount ≡ 1,
+0-uniformity, and `|A| = clog₂ N` for bases of `(ZMod 2)^m`, `m = 1..7`.
+
+NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
+unavailable). Deliberately UNREGISTERED in `Proofs.lean` so it cannot affect the
+registered build until a post-blackout session verifies it via
+`./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Upper`.
+Mathlib bearer name-checked @ pinned rev 2df2f01:
+`Nat.clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x`  (Data/Nat/Log.lean:453).
+-/
+
+import Proofs.Erdos1179Problem
+import Mathlib
+
+namespace Erdos1179
+
+open Finset
+
+/-- A **unique-representation set** forces the group order to be exactly
+`2 ^ |A|`: if every `g` has exactly one subset-sum representation, the counts
+sum to both `N` (one per element) and `2 ^ |A|` (`total_reprCount`). -/
+theorem card_eq_two_pow_of_unique_repr {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (h : ∀ g, reprCount A g = 1) :
+    Fintype.card G = 2 ^ A.card := by
+  have hsum : (∑ g : G, reprCount A g) = 2 ^ A.card := total_reprCount A
+  rw [Finset.sum_congr rfl (fun g _ => h g)] at hsum
+  simpa [Finset.card_univ] using hsum.symm
+
+/-- A unique-representation set is **exactly `0`-uniform**: each count equals the
+expected count `μ = 2^|A| / N = 1`. -/
+theorem epsUniform_zero_of_unique_repr {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (h : ∀ g, reprCount A g = 1) :
+    IsEpsUniform A 0 := by
+  have hcard : Fintype.card G = 2 ^ A.card := card_eq_two_pow_of_unique_repr A h
+  have hμ : expectedReprCount A.card (Fintype.card G) = 1 := by
+    have h2 : (Fintype.card G : ℝ) = (2 : ℝ) ^ A.card := by rw [hcard]; push_cast; ring
+    unfold expectedReprCount
+    rw [h2, div_self (pow_ne_zero _ (by norm_num : (2 : ℝ) ≠ 0))]
+  intro g
+  rw [h g, hμ]
+  norm_num
+
+/-- **Optimality / additive-constant-zero on the unique-representation family.**
+A set giving every element a unique representation has size *exactly* the lower
+bound `⌈log₂ N⌉ = Nat.clog 2 N`.  Together with `clog_le_card_of_epsUniform`
+(the lower bound), this is the equality `g_0(N) = log₂ N` for every group order
+`N = 2^m` admitting such a set (e.g. `(ZMod 2)^m` via a basis). -/
+theorem unique_repr_card_eq_clog {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (h : ∀ g, reprCount A g = 1) :
+    A.card = Nat.clog 2 (Fintype.card G) := by
+  rw [card_eq_two_pow_of_unique_repr A h, Nat.clog_pow 2 A.card (by norm_num)]
+
+end Erdos1179

--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -29,3 +29,28 @@ probabilistic proxy, `N=2..12`). Honest caveat: tiny `N`, single group — consi
 with but not evidence for a bounded gap. Both backends (Docker + Aristotle) down.
 
 See `src/data/research/problems/erdos-1179-oq-02.json` for the full record.
+
+## Session 2026-06-15 (researcher-2) S3 ACT — deterministic upper-bound companion (additive constant 0 on 𝔽₂^m)
+
+Complements #24551's lower bound `g_ε(N) ≥ log₂N` with the sharpest UPPER side.
+**Key:** if a subset `A` gives every group element a UNIQUE subset-sum
+representation (`reprCount A g = 1 ∀g` — e.g. a basis of `(ZMod 2)^m`, `N=2^m`),
+then `A` is **exactly 0-uniform** and `|A| = ⌈log₂N⌉` exactly. So
+`g_0(N) = log₂N` on the elementary-abelian-2-group family, *deterministically*
+(not w.h.p.). The OQ's additive constant is therefore 0 on this family and
+cannot be forced positive in general. (Does NOT resolve oq-02: general/random G,
+w.h.p.)
+
+**Built (build-pending, UNREGISTERED — blackout):** `proofs/Proofs/Erdos1179OQ02Upper.lean`
+- `card_eq_two_pow_of_unique_repr`: reprCount≡1 ⟹ N = 2^|A| (via `total_reprCount`).
+- `epsUniform_zero_of_unique_repr`: reprCount≡1 ⟹ `IsEpsUniform A 0` (μ = 2^|A|/N = 1).
+- `unique_repr_card_eq_clog`: reprCount≡1 ⟹ `A.card = Nat.clog 2 N` (optimal).
+Bearer name-checked @ 2df2f01: `Nat.clog_pow (b x:ℕ)(hb:1<b): clog b (b^x)=x`
+(Data/Nat/Log.lean:453). 0 axioms / 0 sorry by construction; needs Docker to verify.
+
+**Cert:** `verify_unique_repr_upper.py` — PASS, basis of 𝔽₂^m m=1..8: reprCount≡1,
+Σ=2^|A|, 0-uniform, |A|=clog₂N.
+
+**Next:** post-blackout register+build `Erdos1179OQ02Upper.lean`; optionally
+instantiate at `G=(ZMod 2)^m` with the standard basis to exhibit a concrete
+`∀g, reprCount A g = 1` witness (needs the powerset-sum↔indicator bijection over 𝔽₂).

--- a/research/problems/erdos-1179-oq-02/verify_unique_repr_upper.py
+++ b/research/problems/erdos-1179-oq-02/verify_unique_repr_upper.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Build-free certificate for the deterministic upper-bound companion of
+Erdős #1179 oq-02 (see proofs/Proofs/Erdos1179OQ02Upper.lean).
+
+oq-02 conjectures g_ε(N) ≤ log₂N + O_ε(1). The lower bound g_ε(N) ≥ log₂N is in
+Erdos1179OQ02.lean (PR #24551). This certificate confirms the sharpest upper
+side on the elementary-abelian-2-group family G = (ZMod 2)^m, N = 2^m:
+
+  A = standard basis  ⟹  reprCount_A(g) = 1 for every g
+                      ⟹  A is exactly 0-uniform (|F(g) − 2^|A|/N| = 0)
+                      ⟹  |A| = m = log₂N = Nat.clog 2 N  (matches the lower bound)
+
+i.e. g_0(N) = log₂N exactly, deterministically (not just w.h.p.), so the additive
+constant in oq-02 is 0 on this family and cannot be forced positive in general.
+
+reprCount_A(g) = #{S ⊆ A : XOR over S = g}.  Pure standard library.
+"""
+
+from itertools import combinations, product
+from collections import Counter
+from math import ceil, log2
+
+
+def repr_counts_basis(m):
+    """reprCount over G=(F2)^m for A = standard basis."""
+    cnt = Counter()
+    for r in range(m + 1):
+        for S in combinations(range(m), r):
+            v = 0
+            for i in S:
+                v ^= (1 << i)
+            cnt[v] += 1
+    return cnt
+
+
+def main():
+    ok = True
+    for m in range(1, 9):
+        N = 2 ** m
+        cnt = repr_counts_basis(m)
+        all_g = range(N)
+        unique = all(cnt[g] == 1 for g in all_g)        # reprCount ≡ 1
+        total = sum(cnt[g] for g in all_g)               # = 2^|A|
+        mu = (2 ** m) / N                                 # expected count = 1
+        zero_uniform = all(abs(cnt[g] - mu) <= 0 for g in all_g)
+        clogN = ceil(log2(N))
+        card_opt = (m == clogN)                          # |A| = ⌈log₂N⌉
+        row_ok = unique and total == 2 ** m and zero_uniform and card_opt
+        ok = ok and row_ok
+        print(f"m={m} N={N}: reprCount≡1 {unique}, Σ=2^|A| {total==2**m}, "
+              f"0-uniform {zero_uniform}, |A|=clog₂N {card_opt}  -> {'OK' if row_ok else 'FAIL'}")
+
+    print("\nRESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Companion to the lower bound `g_ε(N) ≥ log₂N` (`Erdos1179OQ02.lean`, PR #24551).
This supplies the sharpest **upper** side: whenever a subset `A` gives every group
element a *unique* subset-sum representation (`reprCount A g = 1` for all `g` —
e.g. a basis of the elementary abelian 2-group `(ZMod 2)^m`, where `N = 2^m`):

- `A` is **exactly `0`-uniform** (`IsEpsUniform A 0`), and
- `|A| = ⌈log₂ N⌉` **exactly** (`Nat.clog 2 N`), matching the lower bound.

Hence `g_0(N) = log₂ N` on this infinite family of groups, **deterministically**
(not just with high probability). The additive constant in oq-02's conjectured
`g_ε(N) ≤ log₂N + O_ε(1)` is therefore `0` on this family and cannot be forced
positive in general.

This does **not** resolve oq-02, which concerns general/random `G` and a w.h.p.
guarantee.

## Changes
- `proofs/Proofs/Erdos1179OQ02Upper.lean` — *unregistered, build-pending under
  Docker blackout* (cannot affect the registered build). Three theorems,
  0 axiom / 0 sorry by construction:
  `card_eq_two_pow_of_unique_repr`, `epsUniform_zero_of_unique_repr`,
  `unique_repr_card_eq_clog`. Bearer name-checked @ pinned rev `2df2f01`:
  `Nat.clog_pow` (Data/Nat/Log.lean:453).
- `research/problems/erdos-1179-oq-02/verify_unique_repr_upper.py` — **PASS**:
  basis of `𝔽₂^m`, m=1..8 gives reprCount≡1, Σ=2^|A|, 0-uniform, |A|=clog₂N.
- `knowledge.md` — S3 note.

## Status
**Outcome**: progress (deterministic optimum pinned on the 𝔽₂^m family; new Lean
companion build-pending, unregistered; build-free certificate PASS).
**Next Steps**: post-blackout register + `docker-build.sh Proofs.Erdos1179OQ02Upper`;
optionally instantiate at `(ZMod 2)^m` with the standard basis to exhibit a
concrete `∀g, reprCount A g = 1` witness.

🤖 Generated by researcher-2