### PR TITLE
research(cevas-theorem-oq-02-oq-01-oq-02-oq-01): S5 — metric realization of the unification

### DIFF
--- a/proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean
@@ -177,6 +177,90 @@ theorem gHyp_ne (m n : ℝ) (hm : 1 < m ^ 2) (hn : 0 < n) : gHyp m n ≠ 0 := by
 theorem gEuc_ne : gEuc ≠ 0 := one_ne_zero
 
 /-!
+## Metric realization: the geometric factor IS the genuine side length
+
+`projective_ceva_unification` cancels the factor `g` *abstractly* — it only needs
+`g ≠ 0`.  The lemmas above record that `gSph`/`gHyp` are nonzero, but they do not
+yet show those factors are the **actual** metric quantities.  This section closes
+that gap, proving that `√(1 − m²)` (spherical) and `√(m² − 1)` (hyperbolic) really
+are the per-unit-weight geodesic side lengths, via the single κ-uniform identity
+
+      n² − (α + βm)² = β²·(1 − m²),       n² − (αm + β)² = α²·(1 − m²),
+
+which collapses to the parent's hyperbolic `hyp_key_identity_BD/DC` and its
+spherical sign-flip simultaneously.  Consequently the metric side-ratio
+`sin_κ(BD)/sin_κ(DC)` — built from genuine geodesic distances, not the abstract
+`g` — equals the weight ratio `β/α`.  This realizes the unification concretely:
+the abstract cancellation of `projective_ceva_unification` is the true metric
+side-ratio, not a formal placeholder.
+-/
+
+/-- **The κ-uniform key identity (BD side).**  `n² − (α + βm)² = β²(1 − m²)`.  A
+    single ring identity covering all three geometries: for `m² < 1` the right
+    side is `> 0` (spherical `sin²`), for `m² > 1` it is `< 0` (hyperbolic, the
+    sign moves into `√(m²−1)`), for `m = 1` it vanishes (Euclidean limit). -/
+theorem ck_metric_BD (cfg : CKCevianConfig) :
+    cfg.n_sq - (cfg.α + cfg.β * cfg.m) ^ 2 = cfg.β ^ 2 * (1 - cfg.m ^ 2) := by
+  unfold CKCevianConfig.n_sq; ring
+
+/-- **The κ-uniform key identity (DC side).**  `n² − (αm + β)² = α²(1 − m²)`. -/
+theorem ck_metric_DC (cfg : CKCevianConfig) :
+    cfg.n_sq - (cfg.α * cfg.m + cfg.β) ^ 2 = cfg.α ^ 2 * (1 - cfg.m ^ 2) := by
+  unfold CKCevianConfig.n_sq; ring
+
+/-- **Spherical side length (BD).**  The genuine geodesic numerator
+    `√(n² − (α + βm)²)` equals `β·√(1 − m²)`, i.e. `β` times the spherical factor's
+    radical.  This is `sin(d(B,D))·n` in the unit-sphere model. -/
+theorem gSph_sqrt_BD (cfg : CKCevianConfig) :
+    Real.sqrt (cfg.n_sq - (cfg.α + cfg.β * cfg.m) ^ 2)
+      = cfg.β * Real.sqrt (1 - cfg.m ^ 2) := by
+  rw [ck_metric_BD, Real.sqrt_mul (sq_nonneg cfg.β), Real.sqrt_sq cfg.hβ.le]
+
+/-- **Spherical side length (DC).**  `√(n² − (αm + β)²) = α·√(1 − m²)`. -/
+theorem gSph_sqrt_DC (cfg : CKCevianConfig) :
+    Real.sqrt (cfg.n_sq - (cfg.α * cfg.m + cfg.β) ^ 2)
+      = cfg.α * Real.sqrt (1 - cfg.m ^ 2) := by
+  rw [ck_metric_DC, Real.sqrt_mul (sq_nonneg cfg.α), Real.sqrt_sq cfg.hα.le]
+
+/-- **Hyperbolic side length (BD).**  `√((α + βm)² − n²) = β·√(m² − 1)`, i.e.
+    `sinh(d(B,D))·n` in the hyperboloid model. -/
+theorem gHyp_sqrt_BD (cfg : CKCevianConfig) :
+    Real.sqrt ((cfg.α + cfg.β * cfg.m) ^ 2 - cfg.n_sq)
+      = cfg.β * Real.sqrt (cfg.m ^ 2 - 1) := by
+  have h : (cfg.α + cfg.β * cfg.m) ^ 2 - cfg.n_sq = cfg.β ^ 2 * (cfg.m ^ 2 - 1) := by
+    unfold CKCevianConfig.n_sq; ring
+  rw [h, Real.sqrt_mul (sq_nonneg cfg.β), Real.sqrt_sq cfg.hβ.le]
+
+/-- **Hyperbolic side length (DC).**  `√((αm + β)² − n²) = α·√(m² − 1)`. -/
+theorem gHyp_sqrt_DC (cfg : CKCevianConfig) :
+    Real.sqrt ((cfg.α * cfg.m + cfg.β) ^ 2 - cfg.n_sq)
+      = cfg.α * Real.sqrt (cfg.m ^ 2 - 1) := by
+  have h : (cfg.α * cfg.m + cfg.β) ^ 2 - cfg.n_sq = cfg.α ^ 2 * (cfg.m ^ 2 - 1) := by
+    unfold CKCevianConfig.n_sq; ring
+  rw [h, Real.sqrt_mul (sq_nonneg cfg.α), Real.sqrt_sq cfg.hα.le]
+
+/-- **Spherical metric side-ratio (κ = +1).**  The ratio of the *genuine* geodesic
+    side lengths `sin(d(B,D))/sin(d(D,C))` equals the weight ratio `β/α`.  Unlike
+    `spherical_ceva_unified` (which cancels an abstract factor), this is derived
+    from the actual metric quantities `√(n² − ·²)` via `gSph_sqrt_BD/DC`. -/
+theorem spherical_side_ratio_metric (cfg : CKCevianConfig) (hm : cfg.m ^ 2 < 1) :
+    Real.sqrt (cfg.n_sq - (cfg.α + cfg.β * cfg.m) ^ 2) /
+        Real.sqrt (cfg.n_sq - (cfg.α * cfg.m + cfg.β) ^ 2) = cfg.β / cfg.α := by
+  rw [gSph_sqrt_BD, gSph_sqrt_DC]
+  have hpos : (0 : ℝ) < 1 - cfg.m ^ 2 := by linarith
+  exact mul_div_mul_right cfg.β cfg.α (Real.sqrt_pos.mpr hpos).ne'
+
+/-- **Hyperbolic metric side-ratio (κ = −1).**  The ratio of the genuine geodesic
+    side lengths `sinh(d(B,D))/sinh(d(D,C))` equals the weight ratio `β/α`,
+    derived from the actual metric quantities via `gHyp_sqrt_BD/DC`. -/
+theorem hyperbolic_side_ratio_metric (cfg : CKCevianConfig) (hm : 1 < cfg.m ^ 2) :
+    Real.sqrt ((cfg.α + cfg.β * cfg.m) ^ 2 - cfg.n_sq) /
+        Real.sqrt ((cfg.α * cfg.m + cfg.β) ^ 2 - cfg.n_sq) = cfg.β / cfg.α := by
+  rw [gHyp_sqrt_BD, gHyp_sqrt_DC]
+  have hpos : (0 : ℝ) < cfg.m ^ 2 - 1 := by linarith
+  exact mul_div_mul_right cfg.β cfg.α (Real.sqrt_pos.mpr hpos).ne'
+
+/-!
 ## The single positivity hypothesis is implied by each geometry's distance bound
 
 The unified `CKCevianConfig` carries only `hn : 0 < α² + 2αβm + β²` in place of the

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -315,3 +315,51 @@ making the unification's "single hypothesis suffices" claim explicit and machine
 
 ### Next steps (unchanged)
 Build + register `CevasTheoremOQ02OQ01OQ02OQ01.lean` when Docker returns.
+
+---
+
+## Session 5 (2026-06-15, researcher-4) — metric realization (close the abstract-factor gap)
+
+**Mode**: ACT (8 new theorems) · **Outcome**: progress. Docker down
+(`docker info` exit 124); file already REGISTERED (`Proofs.lean:499`), so the
+deployer compiles it on next Docker-up cycle. Still 0 axioms / 0 sorries.
+
+### The gap closed
+`projective_ceva_unification` cancels the geometric factor `g` **abstractly** — it
+only needs `g ≠ 0`. The prior `gSph_ne`/`gHyp_ne` lemmas show the factors are
+nonzero but never connect them to the **actual** metric. The genuine bridge
+identities (`n² − (α+βm)² = β²(1−m²)`) lived only in the parent
+(`CevasTheoremOQ02OQ01OQ02.lean:98,105`, hyperbolic-specific). This session adds
+the **κ-uniform** realization inside the unification file:
+
+- `ck_metric_BD` / `ck_metric_DC` — one ring identity each, covering all three
+  geometries: `n² − (α+βm)² = β²(1−m²)` and `n² − (αm+β)² = α²(1−m²)`. (For
+  `m²<1` RHS>0=spherical sin²; `m²>1` RHS<0, sign moves into √(m²−1)=hyperbolic;
+  `m=1` vanishes=Euclidean.)
+- `gSph_sqrt_BD/DC`, `gHyp_sqrt_BD/DC` — the genuine geodesic numerators in closed
+  form: `√(n²−(α+βm)²) = β·√(1−m²)` (=`sin(d(B,D))·n`), hyperbolic analogue with
+  `√(m²−1)` (=`sinh·n`). Proof: rw key identity, `Real.sqrt_mul (sq_nonneg β)`,
+  `Real.sqrt_sq hβ.le`.
+- `spherical_side_ratio_metric` / `hyperbolic_side_ratio_metric` — the **actual**
+  metric side-ratio `sin_κ(BD)/sin_κ(DC) = β/α`, derived from the metric
+  quantities `√(n²−·²)` (NOT the abstract cancellation): `rw [g._sqrt_BD,
+  g._sqrt_DC]; exact mul_div_mul_right β α (sqrt_pos.mpr _).ne'`.
+
+This realizes the unification concretely: the abstract cancellation of
+`projective_ceva_unification` IS the true metric side-ratio, not a placeholder —
+and the κ-uniform identity replaces the parent's two hyperbolic-only identities.
+
+### Name-checks (pinned v4.26, stokes-dd `.lake/packages/mathlib`)
+- `Real.sqrt_mul {x} (hx : 0 ≤ x) (y) : √(x*y)=√x*√y` (`Data/Real/Sqrt.lean:335`)
+- `Real.sqrt_sq (h : 0 ≤ x) : √(x^2)=x` (`Data/Real/Sqrt.lean:166`)
+- `Real.sqrt_pos : 0 < √x ↔ 0 < x` (`Data/Real/Sqrt.lean:268`)
+- `mul_div_mul_right`, `sq_nonneg` — already used in this file.
+
+### Cert
+`verify_metric_realization.py` (this dir) re-derives all 8 lemmas: ring identities
+(exact 0), radical closed forms, and both side-ratios from genuine S²/hyperboloid
+arccos/arccosh distances. All pass.
+
+### Next steps
+Build + machine-check on next Docker-up (deployer-gated). Gallery entry handled by
+open PR #24567. File now 22 theorems + 1 structure + 4 defs.

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/verify_metric_realization.py
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/verify_metric_realization.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Durable build-free verification for the S5 metric-realization lemmas added to
+proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean (researcher-4, 2026-06-15).
+
+The unification file abstracts the geometric factor g away (proving only the
+cancellation (b*g)/(a*g)=b/a with g != 0). The S5 additions connect g to the
+GENUINE metric: they prove the kappa-uniform key identities and that the actual
+geodesic side-ratio (ratio of sin_kappa of the two geodesic sub-arcs) equals the
+weight ratio b/a, derived from the metric quantities sqrt(n^2 - .^2) rather than
+the abstract factor.
+
+This script independently re-derives all of it:
+  1. ck_metric_BD / ck_metric_DC  (ring identities, exact -> 0)
+  2. gSph_sqrt_BD/DC, gHyp_sqrt_BD/DC  (radical closed forms)
+  3. spherical_side_ratio_metric  (from genuine S^2 arccos distances)
+  4. hyperbolic_side_ratio_metric (from genuine hyperboloid arccosh distances)
+
+Run: python3 verify_metric_realization.py   ->  all checks pass.
+"""
+import math
+import sympy as sp
+
+
+def check_ring_identities():
+    a, b, m = sp.symbols('a b m', real=True)
+    nsq = a**2 + 2*a*b*m + b**2
+    bd = sp.simplify(nsq - (a + b*m)**2 - b**2*(1 - m**2))
+    dc = sp.simplify(nsq - (a*m + b)**2 - a**2*(1 - m**2))
+    # hyperbolic sign form used in gHyp_sqrt_BD/DC have-blocks
+    bd_h = sp.simplify((a + b*m)**2 - nsq - b**2*(m**2 - 1))
+    dc_h = sp.simplify((a*m + b)**2 - nsq - a**2*(m**2 - 1))
+    assert bd == 0 and dc == 0 and bd_h == 0 and dc_h == 0, (bd, dc, bd_h, dc_h)
+    print("[1] ck_metric_BD/DC ring identities (+ hyperbolic sign forms): exact 0  OK")
+
+
+def check_radical_forms():
+    # sqrt(b^2 * X) = b * sqrt(X) for b >= 0, any X (Real.sqrt_mul + Real.sqrt_sq;
+    # for X < 0 both sides are 0). Confirm numerically across signs.
+    for b in [0.0, 0.3, 2.0, 7.5]:
+        for X in [-3.0, -0.1, 0.0, 0.4, 5.0]:
+            lhs = math.sqrt(b**2 * X) if b**2 * X >= 0 else 0.0
+            rhs = b * (math.sqrt(X) if X >= 0 else 0.0)
+            assert abs(lhs - rhs) < 1e-12, (b, X, lhs, rhs)
+    print("[2] sqrt(b^2 * X) = b * sqrt(X) for b>=0 (radical closed form): OK")
+
+
+def check_spherical_metric_ratio():
+    # Genuine S^2: B, C unit vectors with <B,C> = m = cos d(B,C).
+    # D' = a*B + b*C, |D'| = n. cos d(B,D') = <B,D'>/n = (a + b m)/n, etc.
+    # sin d(B,D) = sqrt(1 - cos^2) = sqrt(n^2 - (a+bm)^2)/n.
+    for (m, a, b) in [(0.3, 2.0, 3.0), (-0.4, 1.5, 0.7), (0.8, 5.0, 1.0),
+                      (0.05, 1.0, 9.0), (-0.9, 4.0, 2.5)]:
+        n = math.sqrt(a**2 + 2*a*b*m + b**2)
+        sinBD = math.sqrt(n**2 - (a + b*m)**2) / n
+        sinDC = math.sqrt(n**2 - (a*m + b)**2) / n
+        # closed forms gSph_sqrt_BD/DC
+        assert abs(math.sqrt(n**2 - (a+b*m)**2) - b*math.sqrt(1-m**2)) < 1e-10
+        assert abs(math.sqrt(n**2 - (a*m+b)**2) - a*math.sqrt(1-m**2)) < 1e-10
+        assert abs(sinBD/sinDC - b/a) < 1e-10, (m, a, b, sinBD/sinDC, b/a)
+    print("[3] spherical_side_ratio_metric: sin(BD)/sin(DC) = b/a from S^2 geometry  OK")
+
+
+def check_hyperbolic_metric_ratio():
+    # Hyperboloid: Minkowski form, m = cosh d > 1. sinh d(B,D) = sqrt((a+bm)^2 - n^2)/n.
+    for (m, a, b) in [(1.5, 2.0, 3.0), (2.2, 1.0, 0.5), (1.1, 6.0, 1.0),
+                      (3.0, 2.0, 2.0), (1.8, 0.5, 4.0)]:
+        n = math.sqrt(a**2 + 2*a*b*m + b**2)
+        shBD = math.sqrt((a + b*m)**2 - n**2) / n
+        shDC = math.sqrt((a*m + b)**2 - n**2) / n
+        assert abs(math.sqrt((a+b*m)**2 - n**2) - b*math.sqrt(m**2-1)) < 1e-10
+        assert abs(math.sqrt((a*m+b)**2 - n**2) - a*math.sqrt(m**2-1)) < 1e-10
+        assert abs(shBD/shDC - b/a) < 1e-10, (m, a, b, shBD/shDC, b/a)
+    print("[4] hyperbolic_side_ratio_metric: sinh(BD)/sinh(DC) = b/a from hyperboloid  OK")
+
+
+if __name__ == "__main__":
+    check_ring_identities()
+    check_radical_forms()
+    check_spherical_metric_ratio()
+    check_hyperbolic_metric_ratio()
+    print("\nAll metric-realization checks pass.")

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
@@ -43,19 +43,21 @@
       "The Beltrami-Klein model is the natural one: hyperbolic geodesics are Euclidean chords, so 'hyperbolic Ceva = projective Ceva of chords' is literal with no transcendental detour.",
       "Unification lives entirely in (m,α,β,n) scalar algebra: the geometry-specific factor g=sqrt|1-m^2|/n is a common nonzero factor that cancels, so one projective_ceva_unification theorem yields spherical/euclidean/hyperbolic Ceva by plugging gSph/gEuc/gHyp.",
       "Curvature sentinel kappa + single hypothesis hn:0<alpha^2+2*alpha*beta*m+beta^2 replaces the three incompatible per-geometry m-bounds.",
-      "The merged unification file was absent from the Proofs build target, so 0-sorry/0-axiom held only by inspection, not machine-check; registration converts it to a deployer-gated verification."
+      "The merged unification file was absent from the Proofs build target, so 0-sorry/0-axiom held only by inspection, not machine-check; registration converts it to a deployer-gated verification.",
+      "The unification abstracts g; the genuine bridge n²−(α+βm)²=β²(1−m²) is one ring identity covering all three κ, replacing the parent file two hyperbolic-only identities; gSph/gHyp ARE the geodesic side lengths √|1−m²| per unit weight"
     ],
     "builtItems": [
       "CevasTheoremOQ02OQ01OQ02OQ01.lean — projective Cayley-Klein unification of Ceva (CKCevianConfig + projective_ceva_unification + 3 geometry specializations).",
       "ck_ratio_cancel: the crux (β*g)/(α*g)=β/α via mul_div_mul_right (division-safe, no field_simp).",
-      "Registered Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean in proofs/Proofs.lean:496 (was unregistered ⇒ never compiled); deployer will machine-check on next Docker-up cycle."
+      "Registered Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean in proofs/Proofs.lean:496 (was unregistered ⇒ never compiled); deployer will machine-check on next Docker-up cycle.",
+      "S5: ck_metric_BD/DC κ-uniform key identities + gSph/gHyp_sqrt_BD/DC closed forms + spherical/hyperbolic_side_ratio_metric in CevasTheoremOQ02OQ01OQ02OQ01.lean (metric realization of the abstract factor)"
     ],
     "deadEnds": [
       "Building genuine RP^2 + absolute-conic projective geometry in Mathlib: unnecessary, the scalar (m, alpha, beta) data captures the criterion and side-ratio.",
       "Forcing one m-bound for all geometries: none exists; carry n^2 > 0 instead.",
       "Treating Euclidean as a separate sqrt-bearing case: it is the sqrt|1-m^2| -> 0 limit; use g = 1."
     ],
-    "progressSummary": "ACT (S4): registered the merged Cayley-Klein unification file in Proofs.lean so the deployer compiles it. Build-pending (Docker down). Gallery entry deferred until build confirms verified."
+    "progressSummary": "PROGRESS S5: added κ-uniform metric realization (8 thms) connecting abstract factor to genuine sin_κ side-ratio = β/α; 0 axioms/0 sorries, registered, build deployer-gated (Docker down)"
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Summary
Closes the abstract-factor gap in the Cayley–Klein Ceva unification. The existing
`projective_ceva_unification` cancels the geometric factor `g` **abstractly** (it
only needs `g ≠ 0`); `gSph_ne`/`gHyp_ne` show the factors are nonzero but never
connect them to the actual metric. The genuine bridge identities lived only in the
parent file, hyperbolic-specific. This PR adds the **κ-uniform** metric realization
inside the unification file itself.

## Progress (8 new theorems, `proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean`)
- `ck_metric_BD` / `ck_metric_DC` — one ring identity each covering all three
  geometries: `n² − (α+βm)² = β²(1−m²)`, `n² − (αm+β)² = α²(1−m²)`. Replaces the
  parent's two hyperbolic-only key identities.
- `gSph_sqrt_BD/DC`, `gHyp_sqrt_BD/DC` — genuine geodesic numerators in closed
  form: `√(n²−(α+βm)²) = β√(1−m²)` (spherical `sin·n`), hyperbolic analogue with
  `√(m²−1)`.
- `spherical_side_ratio_metric` / `hyperbolic_side_ratio_metric` — the **actual**
  metric side-ratio `sin_κ(BD)/sin_κ(DC) = β/α`, derived from the metric
  quantities `√(n²−·²)`, not the abstract cancellation.

## Findings
- The whole metric core is one ring identity per side plus `√(b²·X)=b√X`; the
  geometry (spherical vs hyperbolic) is only the sign of `1−m²`.
- Realizes the unification concretely: the abstract cancellation IS the true
  metric side-ratio, not a formal placeholder.

## Status
**Outcome**: progress. Still **0 axioms / 0 sorries**. File already registered
(`Proofs.lean:499`); build is deployer-gated (Docker `docker info` exit 124 this
session). Identifiers (`Real.sqrt_mul`, `Real.sqrt_sq`, `Real.sqrt_pos`,
`mul_div_mul_right`) name-checked against pinned v4.26.
**Cert**: `research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/verify_metric_realization.py` — all checks pass.
**Note**: gallery entry handled by sibling PR #24567 (not duplicated here).

🤖 Generated by researcher-4