### PR TITLE
research(nth-root-irrational-oq-01-oq-01): add gallery entry for cyclotomic-root / Niven's-theorem proof family

### DIFF
--- a/src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "nth-root-irrational-oq-01-oq-01",
+  "title": "Cyclotomic Roots and Niven's Theorem on Rational Cosines",
+  "slug": "nth-root-irrational-oq-01-oq-01",
+  "description": "Extends the 'root of an irreducible degree ≥ 2 polynomial is irrational' principle to cyclotomic polynomials Φ_n and their roots, and uses it to prove Niven's theorem: cos(2π/n) is rational iff n ∈ {1,2,3,4,6}. A complex primitive n-th root of unity is irrational for n ≥ 3, the maximal-real-subfield generator ζ+ζ⁻¹ = 2cos(2π/n) is irrational when φ(n) ≥ 3, and the five exceptional rational cases complete the classification. A 4-file family, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Ivan Niven (1956); cyclotomic theory: Gauss, Kronecker; formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Niven%27s_theorem",
+    "date": "1956",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/NthRootIrrationalOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "field-theory",
+      "cyclotomic-polynomials",
+      "roots-of-unity",
+      "niven-theorem",
+      "irrationality",
+      "open-question"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries across all four files. Build-pending: authored during the Docker + Aristotle backend outage and not machine-checked this session; relies on Mathlib's cyclotomic API (cyclotomic.irreducible_rat, natDegree_cyclotomic, IsPrimitiveRoot.isRoot_cyclotomic) and special-angle cosine lemmas at pinned v4.26.0. The metrics below are for the primary file (133 lines, 6 theorems); the three companions Cos (150), CosRational (103), Real (113) total ≈ 499 lines and 17 theorems. Promote to verified once a green docker-build of Proofs.NthRootIrrationalOQ01OQ01 (and its three companions) confirms the typecheck.",
+    "mathlibDependencies": [
+      {
+        "theorem": "cyclotomic.irreducible_rat",
+        "description": "The cyclotomic polynomial Φ_n is irreducible over ℚ for n > 0",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_cyclotomic",
+        "description": "deg Φ_n = φ(n) (Euler's totient)",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.isRoot_cyclotomic",
+        "description": "A primitive n-th root of unity is a root of Φ_n",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Basic"
+      }
+    ],
+    "originalContributions": [
+      "irreducible_no_rational_root: a self-contained re-proof that an irreducible p ∈ ℚ[X] of degree ≥ 2 has no rational root, keeping the file independent of cross-file build state",
+      "cyclotomic_no_rational_root: Φ_n has no rational root for n ≥ 3, since it is irreducible of degree φ(n) ≥ 2 (totient_ge_two)",
+      "rational_root_of_unity_le_two: the only rational roots of unity are ±1 (a rational primitive n-th root forces n ≤ 2)",
+      "primitiveRoot_not_rational / primitiveCubeRoot_not_rational: a complex primitive n-th root of unity (n ≥ 3) is not in the image of ℚ — e.g. e^{2πi/3}",
+      "trace_not_rational (Real.lean): the maximal-real-subfield generator ζ+ζ⁻¹ = 2cos(2π/n) is irrational when φ(n) ≥ 3, by a minimal-polynomial degree argument (minpoly ℚ ζ = Φ_n divides a rational quadratic ⟹ φ(n) ≤ 2)",
+      "cos_two_pi_div_n_irrational (Cos.lean): the textbook Niven statement φ(n) ≥ 3 ⟹ Irrational(cos(2π/n)), connecting ζ+ζ⁻¹ to the genuine analytic Real.cos via Complex.exp_mul_I",
+      "cos_two_pi_div_rational_of_mem (CosRational.lean): the complementary rational direction — cos(2π/n) ∈ {1,−1,−1/2,0,1/2} for n ∈ {1,2,3,4,6} — completing Niven's classification"
+    ],
+    "dateAdded": "2026-06-15",
+    "lineCount": 133,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrationalOQ01OQ01Real.lean",
+      "Proofs/NthRootIrrationalOQ01OQ01Cos.lean",
+      "Proofs/NthRootIrrationalOQ01OQ01CosRational.lean"
+    ],
+    "prerequisites": [
+      "Cyclotomic polynomials Φ_n and their irreducibility over ℚ",
+      "Primitive roots of unity and the maximal real subfield ℚ(ζ)⁺",
+      "Euler's totient and minimal-polynomial degree arguments"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Niven's theorem (Ivan Niven, Irrational Numbers, 1956) classifies the rational values of cosine at rational multiples of π: cos(2π/n) is rational only for n ∈ {1, 2, 3, 4, 6}, where it takes the values 1, −1, −1/2, 0, 1/2. The result is a consequence of cyclotomic field theory: the primitive n-th roots of unity are the roots of the irreducible cyclotomic polynomial Φ_n of degree φ(n), and 2cos(2π/n) = ζ + ζ⁻¹ generates the maximal real subfield ℚ(ζ)⁺ of degree φ(n)/2. This entry (OQ-01-OQ-01 of the nth-root-irrationality line) extends the parent's structural principle 'a root of an irreducible degree ≥ 2 polynomial over ℚ is irrational' from X^n − p (Eisenstein) to the cyclotomic polynomials, then walks the full distance to Niven's theorem: complex roots of unity, the real generator ζ + ζ⁻¹, the analytic Real.cos, and the five exceptional rational cases.",
+    "problemStatement": "For which n is cos(2π/n) rational, and are the primitive n-th roots of unity irrational? (Niven: rational exactly for n ∈ {1,2,3,4,6}.)",
+    "text": "A four-file family. The primary file proves that Φ_n has no rational root for n ≥ 3 (irreducible of degree φ(n) ≥ 2), hence the only rational roots of unity are ±1 and complex primitive n-th roots of unity are irrational. NthRootIrrationalOQ01OQ01Real.lean proves ζ + ζ⁻¹ = 2cos(2π/n) is irrational for φ(n) ≥ 3 via a minimal-polynomial degree argument. NthRootIrrationalOQ01OQ01Cos.lean connects this to the analytic Real.cos, giving the sharp Niven irrational direction. NthRootIrrationalOQ01OQ01CosRational.lean supplies the five exceptional rational cases, completing the classification. 0 axioms, 0 sorries throughout.",
+    "proofStrategy": "Cyclotomic core: Φ_n is irreducible over ℚ (cyclotomic.irreducible_rat) of degree φ(n) (natDegree_cyclotomic) which is ≥ 2 for n ≥ 3 (totient_ge_two), so irreducible_no_rational_root rules out rational roots; a rational primitive n-th root would be a root of Φ_n, forcing n ≤ 2. Real generator: if ζ + ζ⁻¹ = r ∈ ℚ then ζ is a root of the rational quadratic X² − rX + 1, so minpoly ℚ ζ = Φ_n has degree ≤ 2, i.e. φ(n) ≤ 2 — contradiction when φ(n) ≥ 3. Analytic bridge: ζ + ζ⁻¹ = 2cos(2π/n) via Complex.exp_mul_I, transferring irrationality to Real.cos. Rational cases: elementary special-angle evaluations for n ∈ {1,2,3,4,6}.",
+    "keyInsights": [
+      "Niven's theorem is fundamentally a statement about the degree of cyclotomic fields: cos(2π/n) is rational iff [ℚ(ζ)⁺ : ℚ] = φ(n)/2 = 1, i.e. φ(n) ≤ 2, which happens exactly for n ∈ {1,2,3,4,6}",
+      "The structural principle 'irreducible degree ≥ 2 ⟹ no rational root' unifies the Eisenstein X^n − p case (parent) and the cyclotomic Φ_n case (this file) — only the irreducibility input changes",
+      "The bound φ(n) ≥ 3 (⇔ n ∉ {1,2,3,4,6}) is sharp, and the CosRational companion proves the boundary is genuinely rational, so the two directions together give an iff, not just an implication",
+      "The 'last mile' from the abstract ζ + ζ⁻¹ to the analytic Real.cos (via Complex.exp_mul_I) is what turns a field-theory fact into the textbook trigonometric statement — done explicitly in the Cos companion",
+      "Each file re-proves the small irreducible-root core locally to stay independent of cross-file build state — a deliberate robustness choice for a multi-file family"
+    ]
+  },
+  "sections": [
+    {
+      "id": "primary-cyclotomic",
+      "title": "Cyclotomic Roots Are Irrational (primary file)",
+      "startLine": 41,
+      "endLine": 133,
+      "summary": "NthRootIrrationalOQ01OQ01.lean: the self-contained core irreducible_no_rational_root, then totient_ge_two (φ(n) ≥ 2 for n ≥ 3), cyclotomic_no_rational_root (Φ_n has no rational root for n ≥ 3), rational_root_of_unity_le_two (rational roots of unity are ±1), and primitiveRoot_not_rational / primitiveCubeRoot_not_rational (complex primitive n-th roots of unity are irrational).",
+      "mathContext": "$\\Phi_n$ irreducible of degree $\\varphi(n)\\ge 2$ for $n\\ge 3$, so its roots (primitive $n$-th roots of unity) are irrational."
+    },
+    {
+      "id": "real-subfield",
+      "title": "The Real Generator ζ + ζ⁻¹ (Real companion)",
+      "startLine": 1,
+      "endLine": 113,
+      "summary": "NthRootIrrationalOQ01OQ01Real.lean: trace_not_rational proves ζ + ζ⁻¹ = 2cos(2π/n) ∉ ℚ when φ(n) ≥ 3, via the degree argument (a rational ζ + ζ⁻¹ would make ζ a root of a rational quadratic, forcing deg(minpoly ℚ ζ) = φ(n) ≤ 2). Instance fifthRoot_trace_not_rational for n = 5.",
+      "mathContext": "$\\zeta+\\zeta^{-1}=2\\cos(2\\pi/n)\\notin\\mathbb{Q}$ when $\\varphi(n)\\ge 3$, since $[\\mathbb{Q}(\\zeta)^+:\\mathbb{Q}]=\\varphi(n)/2$."
+    },
+    {
+      "id": "analytic-cos",
+      "title": "Niven Irrational Direction for Real.cos (Cos companion)",
+      "startLine": 1,
+      "endLine": 150,
+      "summary": "NthRootIrrationalOQ01OQ01Cos.lean: cos_two_pi_div_n_irrational proves φ(n) ≥ 3 ⟹ Irrational(cos(2π/n)) by connecting ζ + ζ⁻¹ = 2cos(2π/n) (Complex.exp_mul_I) to the analytic Real.cos. The bound is sharp (n ∉ {1,2,3,4,6}); instance cos_two_pi_div_five_irrational.",
+      "mathContext": "$\\varphi(n)\\ge 3 \\Rightarrow \\cos(2\\pi/n)$ is irrational; sharp at $n\\in\\{1,2,3,4,6\\}$."
+    },
+    {
+      "id": "rational-cases",
+      "title": "The Five Rational Cases (CosRational companion)",
+      "startLine": 1,
+      "endLine": 103,
+      "summary": "NthRootIrrationalOQ01OQ01CosRational.lean: the complementary direction — cos(2π/n) is rational for each n ∈ {1,2,3,4,6}, with values 1, −1, −1/2, 0, 1/2 (cos_two_pi_div_{one,two,three,four,six}_rational and the bundling cos_two_pi_div_rational_of_mem). Together with the Cos companion this gives Niven's full iff classification.",
+      "mathContext": "$\\cos(2\\pi/n)\\in\\{1,-1,-\\tfrac12,0,\\tfrac12\\}$ for $n\\in\\{1,2,3,4,6\\}$ — the rational half of Niven's theorem."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "nth-root-irrational-oq-01",
+      "relationship": "extends",
+      "description": "Extends the parent's principle 'a root of an irreducible degree ≥ 2 polynomial over ℚ is irrational' from the Eisenstein case X^n − p to cyclotomic polynomials Φ_n and on to Niven's theorem."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "applies",
+      "description": "Applies the nth-root irrationality machinery to roots of unity and to the cosine values cos(2π/n)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Cyclotomic polynomials Φ_n have no rational root for n ≥ 3, so primitive n-th roots of unity are irrational; the maximal-real-subfield generator ζ + ζ⁻¹ = 2cos(2π/n) is irrational when φ(n) ≥ 3; and the five exceptional rational cases (n ∈ {1,2,3,4,6}) complete Niven's classification: cos(2π/n) is rational iff n ∈ {1,2,3,4,6}. A four-file family with 0 axioms and 0 sorries throughout.",
+    "implications": "Turns the abstract 'irreducible degree ≥ 2 ⟹ irrational' principle into the concrete, classical Niven theorem on rational cosine values, exercising Mathlib's cyclotomic and roots-of-unity API end to end.",
+    "openQuestions": [
+      "Extend Niven's theorem to cos(qπ) for general rational q (not just q = 2/n), classifying all rational values via the same cyclotomic degree argument",
+      "Prove the companion classification for tan(2π/n) and sin(2π/n) rational values using the same maximal-real-subfield machinery",
+      "Compute [ℚ(ζ)⁺ : ℚ] = φ(n)/2 explicitly in Lean to make the 'rational iff φ(n) ≤ 2' equivalence a degree theorem rather than a case analysis"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers (Carus Mathematical Monographs 11)",
+      "year": "1956",
+      "venue": "Mathematical Association of America"
+    },
+    {
+      "authors": "Washington, Lawrence C.",
+      "title": "Introduction to Cyclotomic Fields",
+      "year": "1997",
+      "venue": "Graduate Texts in Mathematics 83, Springer, Ch. 2"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "NthRootIrrationalOQ01OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/NthRootIrrationalOQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrationalOQ01OQ01Real.lean",
+      "Proofs/NthRootIrrationalOQ01OQ01Cos.lean",
+      "Proofs/NthRootIrrationalOQ01OQ01CosRational.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "cos_two_pi_div_n_irrational",
+      "type": "core",
+      "description": "Niven irrational direction: cos(2π/n) is irrational when φ(n) ≥ 3",
+      "leanType": "3 ≤ n.totient → Irrational (Real.cos (2 * π / n))"
+    },
+    {
+      "name": "cyclotomic_no_rational_root",
+      "type": "core",
+      "description": "Φ_n has no rational root for n ≥ 3",
+      "leanType": "3 ≤ n → ¬ (cyclotomic n ℚ).IsRoot r"
+    },
+    {
+      "name": "primitiveRoot_not_rational",
+      "type": "supporting",
+      "description": "A complex primitive n-th root of unity (n ≥ 3) is not in the image of ℚ",
+      "leanType": "3 ≤ n → IsPrimitiveRoot ζ n → ζ ∉ Set.range (algebraMap ℚ ℂ)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The four-file proof family for this slug is already on `main` and registered, but it had **no `src/data/proofs/<slug>/` gallery entry**, so the completed Niven's-theorem formalization was not surfaced on the website:

- `Proofs/NthRootIrrationalOQ01OQ01.lean` (primary, 133 lines) — Φ_n has no rational root for n ≥ 3; rational roots of unity are ±1; complex primitive n-th roots of unity are irrational
- `…Real.lean` — ζ+ζ⁻¹ = 2cos(2π/n) is irrational for φ(n) ≥ 3 (minimal-polynomial degree argument)
- `…Cos.lean` — the sharp Niven irrational direction for the analytic `Real.cos`
- `…CosRational.lean` — the five exceptional rational cases, completing the iff classification

All four are 0 axioms / 0 sorries.

This PR adds `src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json`: primary-file metrics (133 lines, 6 theorems) with the three companions as `additionalFiles`, Niven/cyclotomic historical context, the cyclotomic-degree proof strategy, a section per file, key insights, and `extends`/`applies` cross-references.

**Uncontended:** the only open PR matching the slug is the unrelated bundle #22850, which does not touch these files.

## Honesty / status

`badge: wip`, `status: formalized`. The `assumptions` field states the files are **build-pending**: authored during the Docker + Aristotle outage and not machine-checked this session; they rely on Mathlib's cyclotomic API (`cyclotomic.irreducible_rat`, `natDegree_cyclotomic`, `IsPrimitiveRoot.isRoot_cyclotomic`) at pinned v4.26.0. The flip to `verified` is deferred to a green `docker-build.sh` of the four files.

## Test plan

- [x] `python3 -c json.load` validates `meta.json`
- [ ] Docker build of `Proofs.NthRootIrrationalOQ01OQ01` + companions (blocked by backend outage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)