### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03): 4-free classification of IsExcludedForm

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -430,6 +430,39 @@ lemma excluded_form_four_mul_iff {n : ℕ} :
     refine ⟨a + 1, b, ?_⟩
     rw [pow_succ, h]; ring
 
+/-- **Classification of the 4-free core.**  When `4 ∤ n`, the number `n` is of
+excluded form *iff* `n ≡ 7 (mod 8)`.  This is the decision rule the sufficiency
+descent reduces to: after stripping the `4 ^ a` factor via
+`excluded_form_four_mul_iff`, the remaining `4`-free core is excluded precisely
+on the single residue class `7 (mod 8)` — every other `4`-free residue
+(`1, 2, 3, 5, 6` and the even `4 ∤` case) is *non*-excluded, hence (by the open
+sufficiency direction) a sum of three squares.
+
+Together with `excluded_form_four_mul_iff` this gives a complete, elementary
+decision procedure for `IsExcludedForm` (strip factors of `4`, then test
+`% 8 = 7`), and it is the rigorous engine behind the `1/6` natural density of
+excluded forms: among `4`-free numbers exactly the `≡ 7 (mod 8)` ones are
+excluded. -/
+theorem not_four_dvd_excluded_iff {n : ℕ} (h4 : ¬ (4 ∣ n)) :
+    IsExcludedForm n ↔ n % 8 = 7 := by
+  constructor
+  · rintro ⟨a, b, rfl⟩
+    rcases a with _ | a'
+    · -- `a = 0`: `n = 8b + 7`, so `n % 8 = 7`.
+      simp only [pow_zero, one_mul]; omega
+    · -- `a ≥ 1`: then `4 ∣ n`, contradicting `h4`.
+      exact absurd ⟨4 ^ a' * (8 * b + 7), by rw [pow_succ]; ring⟩ h4
+  · intro h
+    exact ⟨0, n / 8, by simp only [pow_zero, one_mul]; omega⟩
+
+/-- **Odd characterization.**  An odd number is of excluded form iff it is
+`≡ 7 (mod 8)`.  Immediate corollary of `not_four_dvd_excluded_iff` (an odd number
+is not divisible by `4`). -/
+theorem odd_excluded_iff {n : ℕ} (hn : Odd n) : IsExcludedForm n ↔ n % 8 = 7 := by
+  apply not_four_dvd_excluded_iff
+  rw [Nat.odd_iff] at hn
+  omega
+
 /-- Primes ≡ 1 (mod 4) are sums of 3 squares.
 This follows from Fermat's two-squares theorem (they're sums of 2 squares). -/
 lemma prime_one_mod_four_is_sum_three_sq {p : ℕ} (hp : Nat.Prime p) (hmod : p % 4 = 1) :

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_excluded_classification.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_excluded_classification.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Durable build-free verification for the 4-free classification lemmas added to
+proofs/Proofs/ThreeSquares.lean (researcher-4, 2026-06-15):
+
+  not_four_dvd_excluded_iff : ¬(4 ∣ n) → (IsExcludedForm n ↔ n % 8 = 7)
+  odd_excluded_iff          :  Odd n   → (IsExcludedForm n ↔ n % 8 = 7)
+
+IsExcludedForm n  ≡  ∃ a b, n = 4^a * (8b + 7).
+
+These are the decision rule the sufficiency descent reduces to: after stripping
+the 4^a factor (excluded_form_four_mul_iff), the 4-free core is excluded exactly
+on the residue class 7 mod 8. Also the rigorous engine of the 1/6 density:
+among 4-free numbers exactly the ≡7 mod 8 are excluded (density 1/8 of all, which
+times the 4-power scaling sum 4/3 gives 1/6).
+
+Run: python3 verify_excluded_classification.py   ->  all checks pass.
+"""
+
+
+def is_excluded(n: int) -> bool:
+    """True iff n = 4^a (8b+7) for some a,b >= 0."""
+    if n <= 0:
+        return False
+    x, a = n, 0
+    while x % 4 == 0:
+        x //= 4
+        a += 1
+    # n = 4^a * x with 4 not dividing x
+    return x % 8 == 7
+
+
+def check_4free_classification(N: int = 200000) -> None:
+    bad = 0
+    for n in range(1, N):
+        if n % 4 != 0:  # hypothesis ¬(4 ∣ n)
+            if is_excluded(n) != (n % 8 == 7):
+                bad += 1
+    assert bad == 0, f"4-free classification mismatches: {bad}"
+    print(f"[1] not_four_dvd_excluded_iff over 1..{N}: 0 mismatches  OK")
+
+
+def check_odd_classification(N: int = 200000) -> None:
+    bad = 0
+    for n in range(1, N):
+        if n % 2 == 1:  # Odd n
+            if is_excluded(n) != (n % 8 == 7):
+                bad += 1
+    assert bad == 0, f"odd classification mismatches: {bad}"
+    print(f"[2] odd_excluded_iff over 1..{N}: 0 mismatches  OK")
+
+
+def check_full_decision_via_stripping(N: int = 100000) -> None:
+    # Sanity: the recursive decision (strip 4's via excluded_form_four_mul_iff,
+    # then test %8=7 on the 4-free core) agrees with is_excluded.
+    def decide(n: int) -> bool:
+        if n == 0:
+            return False
+        if n % 4 == 0:
+            return decide(n // 4)
+        return n % 8 == 7
+    bad = sum(1 for n in range(1, N) if decide(n) != is_excluded(n))
+    assert bad == 0, f"recursive-decision mismatches: {bad}"
+    print(f"[3] strip-4 then %8=7 recursive decision over 1..{N}: 0 mismatches  OK")
+
+
+def check_density(N: int = 6_000_000) -> None:
+    cnt = sum(1 for n in range(1, N) if is_excluded(n))
+    ratio = cnt / N
+    assert abs(ratio - 1 / 6) < 5e-4, (ratio, 1 / 6)
+    print(f"[4] density of excluded forms over 1..{N}: {ratio:.6f} vs 1/6={1/6:.6f}  OK")
+
+
+if __name__ == "__main__":
+    check_4free_classification()
+    check_odd_classification()
+    check_full_decision_via_stripping()
+    check_density()
+    print("\nAll excluded-form classification checks pass.")


### PR DESCRIPTION
## Summary
Adds the missing decision rule for `IsExcludedForm` in `proofs/Proofs/ThreeSquares.lean`,
and corrects a stale sorry-record.

`ThreeSquares.lean` already had the 4-stripping lemma `excluded_form_four_mul_iff`
(`IsExcludedForm (4*n) ↔ IsExcludedForm n`) but **no classification of the 4-free
core**. This PR fills that gap.

## Progress (2 new theorems)
- `not_four_dvd_excluded_iff {n} (h4 : ¬ 4 ∣ n) : IsExcludedForm n ↔ n % 8 = 7`
- `odd_excluded_iff {n} (hn : Odd n) : IsExcludedForm n ↔ n % 8 = 7` (corollary)

Together with `excluded_form_four_mul_iff` these give a **complete elementary
decision procedure** (strip factors of 4, then test `% 8 = 7`) and the **rigorous
engine of the `1/6` natural density** (among 4-free numbers exactly the `≡ 7 mod 8`
ones are excluded). They also pin which 4-free residues the open sufficiency
direction must cover: only `{1,2,3,5,6}`, never `7`.

## Record correction
`ThreeSquares.lean` is now **0 sorries / 2 axioms**. The line-1927 sorry
`needs_four_iff_excluded` was **discharged on main** (the `L1927-dischargeable.md`
plan is complete — full `split_ifs` proof off the easy direction). `state.md` and
`knowledge.md` updated to reflect this. The 2 remaining axioms (`dirichlet_key_lemma`,
`not_excluded_form_is_sum_three_sq`) are deep and **in flight via #24559** (residue-3
route) — not touched here, no duplication.

## Status
**Outcome**: progress. Build-safe (`omega`/`ring`/`pow_succ`/`Nat.odd_iff`, the
latter used across the repo). File registered (`Proofs.lean:2973`); build is
deployer-gated (Docker `docker info` exit 124 this session).
**Cert**: `research/problems/lagrange-four-squares-waring-g2-oq-03/verify_excluded_classification.py`
— 4-free + odd classification over 2e5, recursive-decision agreement, density
`0.16667` vs `1/6` over 6e6. All pass.

🤖 Generated by researcher-4