### PR TITLE
research(law-of-cosines-oq-04-oq-01): add gallery meta.json for inner-product Stewart

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
@@ -1,0 +1,91 @@
+{
+  "id": "law-of-cosines-oq-04-oq-01",
+  "title": "Stewart's Theorem via Inner Products",
+  "slug": "law-of-cosines-oq-04-oq-01",
+  "description": "Lifts Stewart's theorem from the scalar law-of-cosines derivation to genuine inner-product geometry: vertices are points in an arbitrary real inner product space, the cevian foot is an affine combination D = (1-s)·B + s·C, and all lengths are honest norms. The master identity holds in any dimension; the classical b²m + c²n = a(d² + mn) form, Apollonius' median theorem, and the internal angle-bisector length formula follow as specializations.",
+  "meta": {
+    "author": "Matthew Stewart (1746); inner-product formalization 2026",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ04OQ01.lean",
+    "tags": [
+      "geometry",
+      "stewarts-theorem",
+      "cevian",
+      "inner-product-space",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "assumptions": "No axioms or sorries. All results proved bilinearly from the inner-product structure. BUILD-PENDING: the file is registered in Proofs.lean but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded to mathlib/verified once a green build is on record.",
+    "dateAdded": "2026-06-15",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Coordinate-free Stewart / cevian-length identity over an arbitrary real inner product space, valid in any dimension",
+      "Replaces the parent file's abstract cosine parameter t by the genuine inner product ⟪A−B, A−C⟫",
+      "Cevian foot encoded as the affine combination D = (1−s)·B + s·C, so the segment relation m + n = a holds by construction (no sign hypotheses)",
+      "Apollonius' median theorem and the internal-bisector length formula derived as specializations of the master identity"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Stewart's theorem was proved by Matthew Stewart in 1746, relating the length of a cevian to the three sides of a triangle and generalizing the law of cosines. The classical statement b²m + c²n = a(d² + mn) is usually obtained by applying the law of cosines to the two sub-triangles formed by the cevian, using that the angles the cevian makes with the base are supplementary. The companion entry law-of-cosines-oq-04 formalizes exactly that scalar derivation, taking the two law-of-cosines equations as hypotheses with an abstract cosine parameter t. This entry instead grounds the result in genuine geometry: the vertices A, B, C are points in an arbitrary real inner product space, the cevian foot is the affine combination D = (1−s)·B + s·C, and the abstract cosine t is replaced by the real inner product ⟪A−B, A−C⟫. The master identity is then a single bilinear computation, valid in any dimension, from which the classical form, Apollonius' median theorem (the case s = 1/2), and the internal angle-bisector length formula all follow by specialization.",
+    "problemStatement": "For points $A, B, C$ in a real inner product space and the affine cevian foot $D = (1-s)\\,B + s\\,C$, prove the coordinate-free Stewart identity $\\|A-D\\|^2 = (1-s)\\|A-B\\|^2 + s\\|A-C\\|^2 - s(1-s)\\|B-C\\|^2$. Recover the classical form $b^2 m + c^2 n = a(d^2 + mn)$ with $a = \\|B-C\\|$, $m = s a$, $n = (1-s) a$, $b = \\|A-C\\|$, $c = \\|A-B\\|$, $d = \\|A-D\\|$, the median special case (Apollonius), and the internal-bisector length $(b+c)^2\\|A-D\\|^2 = bc((b+c)^2 - a^2)$.",
+    "text": "Expands the cevian displacement A − D = (1−s)(A−B) + s(A−C) bilinearly and reduces every corollary to the master identity by `ring`/`linear_combination`.",
+    "proofStrategy": "1. norm_smul_add_smul_sq: the bilinear expansion ‖p•u + q•v‖² = p²‖u‖² + q²‖v‖² + 2pq⟪u,v⟫, proved from norm_add_sq_real and the smul/inner lemmas. 2. stewart_cevian_inner (master identity): rewrite A − D = (1−s)(A−B) + s(A−C) and B − C = (A−C) − (A−B), expand both sides with the bilinear lemma, close by ring. 3. stewarts_theorem_inner: substitute the master identity and a = ‖B−C‖, close by ring. 4. apollonius_median_inner: specialize s = 1/2. 5. angle_bisector_length_inner: substitute the master identity and discharge the cleared (b+c)²-form by linear_combination using the segment-ratio hypothesis hs.",
+    "keyInsights": [
+      "The single master identity stewart_cevian_inner is coordinate-free and dimension-free: it lives in any real inner product space, so it simultaneously covers the planar triangle, the spatial tetrahedron cevian, and higher dimensions.",
+      "Encoding the cevian foot as the affine combination D = (1−s)·B + s·C makes the segment relation m + n = a hold by construction (stewart_m_add_n: s·a + (1−s)·a = a), removing the sign/collinearity side conditions that the scalar derivation must assume.",
+      "The abstract cosine t of the scalar parent (law-of-cosines-oq-04) is exactly the real inner product ⟪A−B, A−C⟫ here; the geometric law of cosines is recovered as a bilinear expansion rather than assumed.",
+      "Apollonius' median theorem is literally the s = 1/2 case, and the internal angle-bisector length formula is the case where the foot divides BC in the ratio BD:DC = c:b — both obtained with no new geometric work, only specialization of the master identity.",
+      "The bisector entry is stated in cleared (b+c)²-multiplied form to avoid division, and the hypothesis hs encodes only the segment ratio; that this ratio is the one realized by the actual angle bisector (equal angles at A) is flagged as a separate geometric fact, not claimed here."
+    ],
+    "prerequisites": [
+      "Real inner product spaces: ‖x‖² = ⟪x, x⟫, bilinearity, symmetry",
+      "Law of cosines as the bilinear expansion of ‖u − v‖²",
+      "Cevian / affine combination of two points",
+      "Lean 4 tactics: module, ring, linear_combination"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-bilinear-expansion",
+      "title": "Part I: Bilinear Norm Expansion",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "The basic identity ‖p•u + q•v‖² = p²‖u‖² + q²‖v‖² + 2pq⟪u,v⟫, the algebraic engine for every later result."
+    },
+    {
+      "id": "part2-master-identity",
+      "title": "Part II: Coordinate-Free Stewart Identity",
+      "startLine": 58,
+      "endLine": 83,
+      "summary": "stewart_cevian_inner: ‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖² for D = (1−s)·B + s·C, in any real inner product space."
+    },
+    {
+      "id": "part3-classical-form",
+      "title": "Part III: Classical Form and Segment Relation",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "stewarts_theorem_inner recovers b²m + c²n = a(d² + mn); stewart_m_add_n records m + n = a by construction."
+    },
+    {
+      "id": "part4-median",
+      "title": "Part IV: Apollonius' Median Theorem",
+      "startLine": 102,
+      "endLine": 112,
+      "summary": "The s = 1/2 specialization: ‖A − midpoint(B,C)‖² = ½‖A−B‖² + ½‖A−C‖² − ¼‖B−C‖²."
+    },
+    {
+      "id": "part5-bisector",
+      "title": "Part V: Internal Angle-Bisector Length",
+      "startLine": 114,
+      "endLine": 130,
+      "summary": "angle_bisector_length_inner: for the foot dividing BC in ratio c:b, (b+c)²‖A−D‖² = bc((b+c)² − a²)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fills a gallery gap: `proofs/Proofs/LawOfCosinesOQ04OQ01.lean` (0 sorries, 0 axioms) is registered in `Proofs.lean` but had **no** `src/data/proofs/` entry, so its results never appeared in the gallery. Adds `meta.json`.

## Progress
- Created `src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json` describing the file's six theorems: the bilinear norm expansion, the coordinate-free Stewart identity `‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖²` (any real inner product space, any dimension), the classical `b²m + c²n = a(d² + mn)` form, the segment relation `m + n = a`, Apollonius' median theorem, and the internal angle-bisector length formula.
- Structure mirrors the sibling entry `law-of-cosines-oq-04`.

## Status
**Outcome**: progress — gallery entry added for an already-complete, already-registered proof.
**Honesty / build**: marked `badge: wip`, `status: formalized` (0 sorries / 0 axioms but **build-pending** — the file is registered on main, yet its Lean compilation is not independently confirmed here under the current Docker blackout). Upgrade to `mathlib`/`verified` once a green build is on record.
**Scope**: only the new `meta.json` is touched (no edit to the research-problem JSON), to avoid conflicts with the open sibling PRs #24375 / #24517 that are still editing it.

🤖 Generated by researcher-5