### PR TITLE
research(spherical-law-of-cosines-oq-03): add gallery meta.json for dual/polar spherical law

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "spherical-law-of-cosines-oq-03",
+  "title": "Dual (Angles) Spherical Law of Cosines",
+  "slug": "spherical-law-of-cosines-oq-03",
+  "description": "A radical-free, division-free Lean 4 formalization of the dual (angles) spherical law of cosines: cos C = −cos A·cos B + sin A·sin B·cos c, the polar dual of the side law cos c = cos a·cos b + sin a·sin b·cos C. The minus sign in front of cos A·cos B is the hallmark of spherical duality (the polar triangle has angles π−a and sides π−A). Working with three unit vectors u,v,w in ℝ³ via dot and cross products, the dual law is reduced to a polynomial identity (dual_poly, by ring) after clearing the radicals sin a, sin b, sin c, then lifted to the cleared geometric form, the trig form, a cross-product form, and finally the polar-triangle form establishing dual(T) = primal(polar T).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/SphericalLawOfCosinesOQ03.lean",
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "trigonometry",
+      "polar-triangle",
+      "duality",
+      "law-of-cosines",
+      "non-euclidean-geometry",
+      "research"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 424,
+    "assumptions": "No axioms or sorries. The dual law is reduced to a polynomial identity (ring) after clearing all radicals and denominators, so no non-degeneracy side conditions are needed in the cleared form. BUILD-PENDING: the file is registered in Proofs.lean but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded to original/verified once a green build is on record.",
+    "dateAdded": "2026-06-15",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Radical-free, division-free statement and proof of the dual (angles) spherical law of cosines cos C = −cos A·cos B + sin A·sin B·cos c",
+      "Self-contained 3-field vector structure V with dot/cross/triple products and the Binet–Cauchy and Lagrange identities",
+      "dual_poly: the core polynomial identity in the side cosines (ca,cb,cc), proved by ring after multiplying through by sin a·sin b·sin²c",
+      "dual_spherical_law_cleared / dual_law_trig: the geometric and trigonometric forms recovered from the polynomial identity",
+      "dual_law_cross_product_form: the dual law expressed via scalar triple products and cross-product norms",
+      "dual_law_polar_form: the polar-triangle duality made explicit — the dual law of a spherical triangle is the side law of its polar triangle (polar vertices u×v, v×w, w×u)"
+    ],
+    "theoremCount": 28,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The dual (or supplemental) law of cosines for angles is the polar companion of the classical side law of spherical trigonometry. While the side law cos c = cos a·cos b + sin a·sin b·cos C was known to medieval astronomers (Al-Battani, Regiomontanus) and systematized by Todhunter (1886), its dual cos C = −cos A·cos B + sin A·sin B·cos c expresses the cosine of an angle in terms of the other two angles and the included side. The two laws are exchanged by the polar-triangle construction: replacing a spherical triangle by the triangle whose vertices are the poles of its sides sends each side a to the supplement π−A of the opposite angle and vice versa, and the characteristic minus sign of the dual law is precisely the effect of these supplements (cos(π−A) = −cos A). This entry is OQ-03 of the parent gallery proof spherical-law-of-cosines, which formalizes the side law; here the dual is established directly in vector form and then re-derived as the side law of the polar triangle.",
+    "problemStatement": "For a spherical triangle on the unit sphere with arc-length sides a, b, c and interior angles A, B, C (angle C opposite side c), prove the dual law of cosines $\\cos C = -\\cos A\\,\\cos B + \\sin A\\,\\sin B\\,\\cos c$. Equivalently, working with three unit vectors u, v, w in ℝ³ (so cos a = ⟨v,w⟩, cos b = ⟨w,u⟩, cos c = ⟨u,v⟩), establish the cleared, radical-free polynomial form and exhibit it as the polar-triangle dual of the side law cos c = cos a·cos b + sin a·sin b·cos C.",
+    "text": "Substitutes the normal-form expressions for cos A, sin A (etc.) into the trig dual law, multiplies by sin a·sin b·sin²c to clear radicals, and closes the resulting polynomial identity by ring; the polar form is obtained by Binet–Cauchy on the polar vertices.",
+    "proofStrategy": "1. Vector toolkit: a 3-field structure V with dot, cross, triple = ⟨u, v×w⟩, plus the Binet–Cauchy identity ⟨a×b, c×d⟩ = ⟨a,c⟩⟨b,d⟩ − ⟨a,d⟩⟨b,c⟩ and the Lagrange identity. 2. Radical-free reduction: cos A = (ca − cb·cc)/(sin b·sin c), sin A = |triple|/(sin b·sin c), sin a = √(1−ca²); substituting and multiplying by sin a·sin b·sin²c turns the dual law into dual_poly, a polynomial identity in ca, cb, cc closed by ring. 3. Geometric lift: dual_law_cleared and dual_spherical_law_cleared state the cleared identity over unit vectors; dual_law_trig recovers the trigonometric form. 4. Cross-product form: dual_law_cross_product_form re-expresses the law via triple products and ‖u×v‖. 5. Polar duality: with polar vertices U = v×w, V = w×u, W = u×v, the inner products ⟨U,V⟩ etc. (polar_inner_*, via Binet–Cauchy) show that the side law of the polar triangle is exactly the dual law of the original, giving dual_law_polar_form.",
+    "keyInsights": [
+      "Clearing the three radicals sin a, sin b, sin c (and the shared denominators of cos A, cos B, cos C) turns the dual law into a pure polynomial identity in the side cosines, eliminating every non-degeneracy side condition — the entire trigonometric content collapses to a single ring call (dual_poly).",
+      "The angle cosines and sines are not primitive: cos A = (ca − cb·cc)/(sin b·sin c) and sin A = |[u v w]|/(sin b·sin c) are the side law solved for the angle together with ‖v×w‖ = sin a, so the dual law is a consequence of the side law, not an independent axiom.",
+      "The minus sign in −cos A·cos B is the algebraic shadow of the polar-triangle supplements: cos(π−A) = −cos A, cos(π−a) = −cos a, so applying the side law to the polar triangle reproduces the dual law with the sign flip built in.",
+      "Binet–Cauchy on the polar vertices U=v×w, V=w×u, W=u×v computes all polar inner products in terms of the original side cosines, making dual(T) = primal(polar T) a finished algebraic identity rather than a heuristic.",
+      "Phrasing every result over an explicit 3-field vector structure with the scalar triple product keeps the proof radical-free and division-free, so it is closed by ring/linear arithmetic rather than analytic estimates."
+    ],
+    "prerequisites": [
+      "Spherical law of cosines (side form): cos c = cos a·cos b + sin a·sin b·cos C (parent entry spherical-law-of-cosines)",
+      "Polar (dual) triangle: vertices are the poles of the sides; sides and angles swap to their supplements",
+      "Vector algebra in ℝ³: dot product, cross product, scalar triple product, Binet–Cauchy and Lagrange identities",
+      "Lean 4 tactics: ring, linear_combination, nlinarith"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-vector-toolkit",
+      "title": "Part I: Vector Toolkit in ℝ³",
+      "startLine": 100,
+      "endLine": 178,
+      "summary": "The 3-field structure V with dot/cross/triple products, the Binet–Cauchy and Lagrange identities, and the nonnegativity facts (triple_sq, cross_norm_sq_nonneg, 1−⟨u,v⟩² ≥ 0)."
+    },
+    {
+      "id": "part2-polynomial-identity",
+      "title": "Part II: The Cleared Polynomial Identity",
+      "startLine": 180,
+      "endLine": 238,
+      "summary": "dual_poly — the dual law reduced to a polynomial identity in the side cosines (closed by ring) — and its cleared geometric forms dual_law_cleared, dual_spherical_law_cleared."
+    },
+    {
+      "id": "part3-trig-form",
+      "title": "Part III: Trigonometric Form",
+      "startLine": 239,
+      "endLine": 333,
+      "summary": "dual_law_trig recovers cos C = −cos A·cos B + sin A·sin B·cos c, with the normal-form numerators (cosA_num, …) and squared sines (sina_sq, sinb_sq, sinc_sq)."
+    },
+    {
+      "id": "part4-cross-product-form",
+      "title": "Part IV: Cross-Product Form",
+      "startLine": 334,
+      "endLine": 369,
+      "summary": "dual_law_cross_product_form expresses the dual law through scalar triple products and cross-product norms."
+    },
+    {
+      "id": "part5-polar-duality",
+      "title": "Part V: Polar-Triangle Duality",
+      "startLine": 370,
+      "endLine": 424,
+      "summary": "Polar inner products of U=v×w, V=w×u, W=u×v via Binet–Cauchy (polar_inner_*, polar_self_*), and dual_law_polar_form: the dual law is the side law of the polar triangle."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Fills a gallery gap: `proofs/Proofs/SphericalLawOfCosinesOQ03.lean` (0 sorries, 0 axioms, registered in `Proofs.lean`) had **no** `src/data/proofs/` entry, so the dual (angles) spherical law of cosines and its polar-triangle duality were missing from the gallery. Adds `meta.json`.

## Progress
- Created `src/data/proofs/spherical-law-of-cosines-oq-03/meta.json` describing the file's contents: the dual law `cos C = −cos A·cos B + sin A·sin B·cos c`, its radical-free reduction to the polynomial identity `dual_poly` (closed by `ring`), the cleared geometric/trig/cross-product forms, and `dual_law_polar_form` exhibiting the dual law as the side law of the polar triangle (vertices `u×v, v×w, w×u`).
- Structure and field conventions mirror the parent entry `spherical-law-of-cosines`.

## Status
**Outcome**: progress — gallery entry added for an already-complete, already-registered proof.
**Honesty / build**: marked `badge: wip`, `status: formalized` (0 sorries / 0 axioms but **build-pending** — registered on main, yet Lean compilation not independently confirmed here under the current Docker blackout). Upgrade to `original`/`verified` once a green build is on record.
**Scope**: only the new `meta.json` (no edit to the research-problem JSON), to avoid conflicts with the open sibling PR #24520 (polar-duality research docs).

🤖 Generated by researcher-5