### PR TITLE
research(morleys-theorem-oq-03): add missing gallery meta.json for the complete extremal proof

### DIFF
--- a/research/problems/morleys-theorem-oq-03/knowledge.md
+++ b/research/problems/morleys-theorem-oq-03/knowledge.md
@@ -74,3 +74,28 @@ question:
   `α=β=γ=π/3`, via `StrictConcaveOn` strict Jensen for `sin` and strict AM–GM.
 - Verify the build once Docker is available; register in the gallery and add
   `src/data/proofs/morleys-theorem-oq-03/` meta.json.
+
+## Session 2026-06-15 (S2, researcher-8) — created MISSING gallery meta.json
+
+**Mode:** REVISIT / ACT (gallery integration; dual blackout: Docker `docker info` times out,
+Aristotle MCP `prove` returns 404 — no Lean built this session).
+
+**State found on `origin/main` (knowledge above was stale):** `MorleysTheoremOQ03.lean` is
+**complete and registered** in `proofs/Proofs.lean` — 0 sorries, 0 axioms, 9 theorems, 1 def
+(331 lines). The "Next Steps / strict uniqueness" item is **already done**: main contains
+`sin_two_eq`, `sin_jensen_three_eq`, and `morley_side_eq_iff` (for R>0, `s = 8R·sin³(π/9)` iff
+`α=β=γ=π/3`). The only remaining gap was **gallery integration**: there was no
+`src/data/proofs/morleys-theorem-oq-03/` directory, so this verified proof did not appear in the
+gallery (the gallery auto-discovers proof dirs at build time).
+
+**Delta shipped:** created `src/data/proofs/morleys-theorem-oq-03/meta.json` (modeled on the
+sibling `morleys-theorem-oq-01`): id/title/description, meta (status verified, badge original,
+0/0, lineCount 331, theoremCount 9, definitionCount 1, mathlib deps), overview
+(historical context, problem statement, proof strategy, 5 key insights), 4 sections matching the
+file's Parts (analytic inequalities / equality cases / side-and-max / strict uniqueness),
+conclusion with 3 open questions, cross-refs to parent `morleys-theorem` and sibling OQ-01.
+
+**Honest assessment:** pure gallery metadata — no new mathematics, no Lean changed. Genuine but
+modest: surfaces an already-complete, already-registered verified proof in the gallery that was
+otherwise invisible. PATH-TRAP note: the meta.json was first written to the MAIN checkout by
+absolute path and had to be moved into the worktree (recurring trap — see memory).

--- a/src/data/proofs/morleys-theorem-oq-03/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-03/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "morleys-theorem-oq-03",
+  "title": "The Morley Triangle is Largest at the Equilateral",
+  "slug": "morleys-theorem-oq-03",
+  "description": "Among all triangles with a fixed circumradius R, the equilateral triangle uniquely maximizes the side length of its Morley triangle. Proves s(α,β,γ) = 8R·sin(α/3)·sin(β/3)·sin(γ/3) ≤ 8R·sin³(π/9), with equality iff α=β=γ=π/3. Fully elementary (AM–GM + Jensen for sin), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MorleysTheoremOQ03.lean",
+    "tags": [
+      "geometry",
+      "morley",
+      "trisectors",
+      "extremal",
+      "jensen",
+      "am-gm",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 331,
+    "assumptions": "No axioms or sorries. All lemmas fully proved from Mathlib (concavity of sin, AM–GM via an explicit SOS certificate).",
+    "dateAdded": "2026-06-15",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.strictConcaveOn_sin_Icc",
+        "description": "sin is strictly concave on [0, π]",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv"
+      },
+      {
+        "theorem": "Real.sin_nonneg_of_nonneg_of_le_pi",
+        "description": "sin t ≥ 0 for t ∈ [0, π]",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "pow_le_pow_left₀",
+        "description": "monotonicity of t ↦ tⁿ on the nonnegatives",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "pow_left_inj₀",
+        "description": "injectivity of t ↦ tⁿ on the nonnegatives (equality case)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "Extremal formulation orthogonal to OQ-01/OQ-02: which triangle has the largest Morley triangle?",
+      "AM–GM for three nonnegatives via an explicit sum-of-squares certificate (no rpow / weighted form)",
+      "Three-point Jensen for sin on [0, π] built by chaining the two-point midpoint inequality (avoids Finset/Matrix indexing)",
+      "The sharp bound s(α,β,γ) ≤ 8R·sin³(π/9) with the equilateral as maximizer",
+      "Strict uniqueness: for R > 0, equality holds iff α=β=γ=π/3 (equality cases of AM–GM and Jensen)"
+    ],
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Morley's trisector theorem (Frank Morley, c. 1899) states that the adjacent trisectors of any triangle meet in the vertices of an equilateral triangle. A standard corollary computes the common side length of this Morley triangle for a triangle with angles α, β, γ and circumradius R as 8R·sin(α/3)·sin(β/3)·sin(γ/3). This file (OQ-03) poses a natural extremal question that is orthogonal to OQ-01 (Conway's backward construction) and OQ-02 (second Morley triangles): over all triangles of a fixed circumradius, which has the largest Morley triangle? The answer — the equilateral, uniquely — follows from a clean, calculus-free inequality argument and is formalized here in Lean 4 with no axioms or sorries.",
+    "problemStatement": "Among triangles with fixed circumradius R, maximize the Morley side length s(α,β,γ) = 8R·sin(α/3)·sin(β/3)·sin(γ/3) subject to α+β+γ=π and α,β,γ>0.",
+    "text": "Proves the sharp upper bound s ≤ 8R·sin³(π/9) ≈ 0.32008·R, that the equilateral attains it, and that for R>0 the equilateral is the unique maximizer.",
+    "proofStrategy": "Set aᵢ = αᵢ/3 so a₁+a₂+a₃ = π/3 and the trisected mean is π/9. Bound the product of sines by its value at the mean in two steps: (1) AM–GM, u·v·w ≤ ((u+v+w)/3)³, proved from an explicit SOS decomposition; (2) Jensen for the concave sin on [0,π], sin a₁+sin a₂+sin a₃ ≤ 3·sin((a₁+a₂+a₃)/3). Chaining with monotonicity of t↦t³ on [0,∞) gives ∏ sin aᵢ ≤ sin³(π/9). Equality forces tightness in both steps, which (via the strict concavity of sin) pins a₁=a₂=a₃, i.e. the equilateral.",
+    "keyInsights": [
+      "Reframing the geometric question as a symmetric optimization of ∏ sin(αᵢ/3) under the constraint Σ αᵢ/3 = π/3 reduces Morley-triangle maximization to two textbook inequalities.",
+      "AM–GM is certified by an explicit nonnegative decomposition, (u+v+w)³ − 27uvw = 3·Σ u(v−w)² + ½(u+v+w)·Σ(u−v)², so nlinarith closes it without any rpow/weighted-mean machinery.",
+      "Three-point Jensen is obtained by treating the mean m as a fourth point and chaining the two-point (midpoint) concavity inequality, sidestepping Finset/Matrix-indexed Jensen entirely.",
+      "Strict uniqueness uses the equality cases: tightness in pow/AM–GM sandwiches the average of the three sines to exactly sin(π/9), and the strict-Jensen equality case forces the trisected angles to coincide. The hypothesis R>0 is essential — at R=0 every triangle gives Morley side 0.",
+      "π/9 = 20°, so the maximal Morley side is 8R·sin³20° ≈ 0.32008·R."
+    ]
+  },
+  "sections": [
+    {
+      "id": "analytic-inequalities",
+      "title": "Two Analytic Inequalities",
+      "summary": "AM–GM for three nonnegatives (explicit SOS certificate) and three-point Jensen for sin on [0, π] (chained two-point concavity)",
+      "startLine": 50,
+      "endLine": 108
+    },
+    {
+      "id": "equality-cases",
+      "title": "Equality Cases (Strict Concavity)",
+      "summary": "sin_two_eq and sin_jensen_three_eq: the equality cases of two- and three-point Jensen for sin, used for strict uniqueness",
+      "startLine": 109,
+      "endLine": 168
+    },
+    {
+      "id": "side-and-max",
+      "title": "Morley Side Length and Its Maximum",
+      "summary": "morleySide definition, the trisected-angle bound, the sharp inequality s ≤ 8R·sin³(π/9), and attainment at the equilateral",
+      "startLine": 169,
+      "endLine": 262
+    },
+    {
+      "id": "strict-uniqueness",
+      "title": "Strict Uniqueness of the Maximizer",
+      "summary": "morley_side_eq_iff: for R > 0, s = 8R·sin³(π/9) iff α=β=γ=π/3, via the equality cases of AM–GM and Jensen",
+      "startLine": 263,
+      "endLine": 331
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified in Lean 4 (0 axioms, 0 sorries): the Morley side length 8R·sin(α/3)·sin(β/3)·sin(γ/3) is maximized, over all triangles of circumradius R≥0, at the equilateral, with maximal value 8R·sin³(π/9); and for R>0 the equilateral is the unique maximizer. The proof is elementary, using only AM–GM (via an explicit SOS certificate) and the concavity of sin on [0,π].",
+    "implications": "The result shows the 'largest Morley triangle' question reduces to a symmetric product-of-sines optimization that is fully formalizable without calculus. The two-stage inequality structure — a degree-3 AM–GM plus a chained two-point Jensen — is reusable for other symmetric trigonometric extremal problems, and the strict-uniqueness pattern (sandwiching an average via the equality cases of AM–GM and strict Jensen) generalizes to other concave-function maximizations on a simplex.",
+    "openQuestions": [
+      "Extremal Morley behavior under other normalizations: fix the perimeter, the area, or the longest side instead of the circumradius — is the equilateral still the maximizer, and what is the sharp constant?",
+      "Minimization and degenerate limits: characterize the infimum of the Morley side length over non-degenerate triangles of fixed R, and its behavior as a triangle degenerates.",
+      "Non-Euclidean analogues: the constraint α+β+γ=π fails in hyperbolic/spherical geometry, so the trisected mean is no longer π/9 — does an extremal characterization survive?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "morleys-theorem",
+      "relationship": "parent-problem",
+      "description": "Parent: Morley's trisector theorem formalization (Wiedijk #84)"
+    },
+    {
+      "targetId": "morleys-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-01: Conway's backward construction, which establishes the Morley side length formula used here"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Frank Morley"
+      ],
+      "title": "On the metric geometry of the plane n-line",
+      "year": "1900",
+      "venue": "Transactions of the American Mathematical Society",
+      "note": "Origin of the trisector theorem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "MorleysTheoremOQ03",
+    "lineCount": 331,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/MorleysTheoremOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`proofs/Proofs/MorleysTheoremOQ03.lean` is **complete and registered** (in `proofs/Proofs.lean`)
— 0 sorries, 0 axioms, 9 theorems — but had **no gallery directory**, so this verified proof was
invisible in the gallery. This PR adds the missing `src/data/proofs/morleys-theorem-oq-03/meta.json`.

The proof answers an extremal question orthogonal to OQ-01/OQ-02: among triangles of fixed
circumradius `R`, the equilateral *uniquely* maximizes the Morley triangle. Concretely
`s(α,β,γ) = 8R·sin(α/3)·sin(β/3)·sin(γ/3) ≤ 8R·sin³(π/9)` (`morley_side_le_equilateral`), attained
at the equilateral (`morley_side_equilateral`), and for `R>0` *only* there
(`morley_side_eq_iff`). Elementary throughout: AM–GM (explicit SOS certificate) + Jensen for the
concave `sin` on `[0,π]`, plus their equality cases for uniqueness.

## Changes

- `src/data/proofs/morleys-theorem-oq-03/meta.json` (new) — modeled on sibling `morleys-theorem-oq-01`:
  status `verified` / badge `original`, 0/0, 331 lines, 9 theorems, 1 def; overview with proof
  strategy and 5 key insights; 4 sections (analytic inequalities / equality cases / side-and-max /
  strict uniqueness); conclusion + 3 open questions; cross-refs to parent `morleys-theorem` and
  sibling `morleys-theorem-oq-01`.
- `research/problems/morleys-theorem-oq-03/knowledge.md` — S2 note.

## Findings

- The knowledge file's "Next Steps" (strict uniqueness) is **already done on main**
  (`sin_two_eq`, `sin_jensen_three_eq`, `morley_side_eq_iff`); the only remaining gap was gallery
  integration. Top-level + `meta.*` keys verified to match the sibling exactly.

## Status

**Outcome**: progress (gallery integration of an already-complete, already-registered verified
proof). No Lean changed; no new mathematics. Dual blackout (Docker `docker info` times out;
Aristotle MCP `prove` returns 404) — but this PR touches only gallery JSON, not Lean, so it is
blackout-safe. The gallery auto-discovers proof dirs at build time, so no registry edit is needed.

🤖 Generated by researcher-8