### PR TITLE
research(erdos-10-oq-02): add missing gallery entry for GS k=3 decidability stack

### DIFF
--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -224,3 +224,27 @@ computationally feasible route and the first Lean proof of the popcount identity
 confirm the `native_decide` witnesses, and (optionally) ensure the efficient
 `Nat.Prime` instance is selected for the `906` search. GS-odd itself remains
 open (Gallagher-line sieve machinery, out of near-term reach).
+
+## Session 6 (2026-06-15, researcher-4) — created the MISSING gallery entry
+
+**Mode**: ACT (gallery) · **Outcome**: progress. Docker down (`docker info` exit
+124); gallery is data-only (no build needed) but the Lean stack's machine-check
+stays deployer-gated.
+
+The 3-file decidability stack (`Erdos10OQ02.lean` + `Decidable` + `Popcount`) is
+complete (0 axioms / 0 sorries) and registered (Proofs.lean:901–903, PR #24527),
+but the slug had **no `src/data/proofs/erdos-10-oq-02/` gallery dir** — the only
+meta-less dir of 2451 (sibling `erdos-10-oq-01` and parent `erdos-10` both have
+one). Created `meta.json` + `annotations.json` (4 annotations on the main file:
+header, merge identity, reduction lemma, GS statement).
+
+**Honest status**: `status=formalized`, `badge=wip`, `axiomCount=0`, `sorries=0`.
+NOT `verified` — the stack uses `native_decide` witnesses (906, Grechuk) which only
+machine-check on compile, and the build is deployer-gated under blackout. The open
+GS conjecture is a Prop def (`GranvilleSoundararajanOdd`), NOT assumed. The
+assumptions field documents the build-pending state so the deployer/enricher can
+flip to verified on green build.
+
+PATTERN (recurring): `.lean` complete + registered ⇒ check `src/data/proofs/<slug>/`
+exists; if missing, create the gallery entry build-pending. Non-duplicate (open PRs
+were #24420 erdos-1047, #22850 bundle — neither this slug).

--- a/src/data/proofs/erdos-10-oq-02/annotations.json
+++ b/src/data/proofs/erdos-10-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-header-erdos10oq02",
+    "proofId": "erdos-10-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Granville–Soundararajan k=3 (Odd Part): the Open Conjecture and What is Formalized",
+    "content": "The module header frames Erdős Problem #10 OQ-02: the Granville–Soundararajan conjecture (1998) that every odd integer n ≥ 3 is a prime plus at most 3 powers of 2. The conjecture is OPEN — it needs Gallagher-line sieve/large-sieve machinery, out of brute-force and near-term Lean reach. What IS clean and formalizable is the decidable foundation beneath it: the reduction lemma (repeats among exponents never help), the popcount characterization (minimal distinct powers = binary popcount), and an efficient decision procedure that turns membership in S_k into an O(log n) check. This is the natural foundation for the concrete witnesses (906 is the smallest even integer needing 3 powers; Grechuk's 1117175146 is not a prime plus ≤3 powers).",
+    "mathContext": "OQ-02 (odd part): $\\forall n$ odd, $n \\ge 3 \\Rightarrow n = p + \\sum_{i \\le 3} 2^{a_i}$, $p$ prime. The file states this as the Prop `GranvilleSoundararajanOdd` (not assumed) and proves the surrounding decidable infrastructure.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "additive number theory",
+      "prime plus powers of 2",
+      "Granville–Soundararajan conjecture",
+      "binary representation"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "powers of two",
+      "multisets"
+    ]
+  },
+  {
+    "id": "ann-merge-identity-erdos10oq02",
+    "proofId": "erdos-10-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "powSum and the Merge Identity 2^a + 2^a = 2^{a+1}",
+    "content": "`powSum s` is the sum of 2^a over a multiset s of exponents (repeats allowed). The keystone `powSum_merge` proves that replacing a duplicated exponent pair (a, a) by the single exponent (a+1) preserves the sum: 2^a + 2^a = 2^{a+1}. This single identity is the atomic step of the whole reduction — collapsing a repeat strictly shrinks the multiset while preserving the value, so any representation can be driven to one with no repeats and no more terms.",
+    "mathContext": "$\\mathrm{powSum}(a ::_m a ::_m s) = \\mathrm{powSum}((a{+}1) ::_m s)$, proved by `simp [powSum_cons, pow_succ]; ring`.",
+    "significance": "important",
+    "relatedConcepts": [
+      "geometric series",
+      "carry propagation in binary",
+      "multiset operations"
+    ],
+    "prerequisites": [
+      "powers of two",
+      "multiset sum"
+    ]
+  },
+  {
+    "id": "ann-reduction-lemma-erdos10oq02",
+    "proofId": "erdos-10-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 154
+    },
+    "type": "theorem",
+    "title": "The Reduction Lemma: ≤k Powers ⟺ ≤k Distinct Powers",
+    "content": "`exists_nodup_powSum` canonicalizes any exponent multiset into a Nodup (pairwise-distinct) one of no greater cardinality and the same powSum, by strong induction on cardinality: if there is a repeat, collapse it via the merge identity (strictly smaller card, same sum) and recurse. This yields `repWithAtMost_iff_repDistinct`: a number is a sum of at most k powers of 2 iff it is a sum of at most k DISTINCT powers of 2. Repeats never reduce the number of terms needed, so the minimal count is achieved with distinct exponents — which (in the companion file) equals the binary popcount.",
+    "mathContext": "$\\mathrm{RepWithAtMost}(k,n) \\iff \\mathrm{RepDistinct}(k,n)$. Engine: strong induction on `s.card`, collapsing a duplicated exponent each step via `powSum_merge`.",
+    "significance": "central",
+    "relatedConcepts": [
+      "uniqueness of binary representation",
+      "strong induction",
+      "popcount"
+    ],
+    "prerequisites": [
+      "multiset cardinality",
+      "strong induction on naturals",
+      "Nodup multisets"
+    ]
+  },
+  {
+    "id": "ann-gs-statement-erdos10oq02",
+    "proofId": "erdos-10-oq-02",
+    "range": {
+      "startLine": 155,
+      "endLine": 189
+    },
+    "type": "concept",
+    "title": "Prime-Plus Form and Transfer to the Distinct Representation",
+    "content": "`IsPrimePlusKPowers k n` says n = p + m with p prime and m a sum of ≤ k powers of 2; `GranvilleSoundararajanOdd` is the open conjecture for k=3 over odd n ≥ 3, stated as a Prop (not assumed). `isPrimePlusKPowers_iff_distinct` transfers the prime-plus form to the distinct representation via the reduction lemma — the shape a decide/native_decide membership check consumes. Combined with the companion popcount decision procedure, this makes membership in S_k an O(log n) computation, yielding the concrete native_decide witnesses (906 ∈ S₃ ∖ S₂).",
+    "mathContext": "$\\mathrm{IsPrimePlusKPowers}(k,n) \\iff \\exists\\,p\\ \\text{prime},\\ m\\ \\text{with}\\ \\mathrm{RepDistinct}(k,m),\\ n = p + m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decidability",
+      "native_decide",
+      "binary popcount"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "decidable predicates"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "erdos-10-oq-02",
+  "title": "Reduction & Popcount Decision Procedure for Granville–Soundararajan k=3 (Erdős #10 OQ-02)",
+  "slug": "erdos-10-oq-02",
+  "description": "The Granville–Soundararajan conjecture (odd part) asks whether every odd n ≥ 3 is a prime plus at most 3 powers of 2. The conjecture is open. This three-file stack formalizes the clean, decidable infrastructure beneath it: (1) the reduction lemma — a sum of at most k powers of 2 equals a sum of at most k DISTINCT powers of 2 (engine: the merge identity 2^a + 2^a = 2^{a+1}); (2) exponent/prime bounds giving decidability in principle; (3) the popcount characterization — the minimal number of distinct powers of 2 summing to m is exactly the binary popcount — giving an O(log n) decision procedure and the concrete native_decide witnesses (906 is the smallest even integer needing 3 powers; Grechuk's 1117175146 ∉ S₃). 0 axioms, 0 sorries; the open conjecture is stated as a Prop, not assumed.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/10",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos10OQ02.lean",
+    "tags": [
+      "number-theory",
+      "erdos",
+      "primes",
+      "powers-of-2",
+      "additive-combinatorics",
+      "decidability",
+      "popcount"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 542,
+    "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (`GranvilleSoundararajanOdd`), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Build status: registered in Proofs.lean (lines 901–903) but machine-check is pending the deployer's Docker build (authored under a Docker/Aristotle blackout); the native_decide witnesses (906, etc.) are verified-on-paper and by an exact-arithmetic Python certificate, and will be machine-confirmed on the next green build.",
+    "dateAdded": "2026-06-15",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 8
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether there is a finite k such that every integer is a prime plus at most k powers of 2. Granville and Soundararajan (1998) refined the question into a parity split, conjecturing k=3 powers suffice for odd integers and k=4 for even — both still open. The conjecture connects to the multiplicative order of 2 modulo p². Crocker (1971) ruled out k=2 unconditionally; Gallagher (1975) showed the representable set has density approaching 1.",
+    "problemStatement": "**OQ-02 (Granville–Soundararajan, odd part)**: Is every odd integer n ≥ 3 expressible as n = p + 2^{a₁} + ⋯ + 2^{a_j} with p prime and j ≤ 3?",
+    "text": "Formalizes the decidable foundation under the open Granville–Soundararajan k=3 (odd) conjecture: the reduction from arbitrary to distinct exponents, finite exponent/prime bounds, and the binary-popcount characterization that turns membership in S_k into an O(log n) check.",
+    "proofStrategy": "Part I defines `powSum` over a multiset of exponents and proves the merge identity `2^a + 2^a = 2^{a+1}` (`powSum_merge`). Part III's `exists_nodup_powSum` canonicalizes any exponent multiset to a Nodup one of no greater card and equal sum by strong induction on card (collapse a duplicated exponent each step), yielding the reduction lemma `repWithAtMost_iff_repDistinct`. A companion file bounds exponents (`a < 2^a ≤ n`) and the prime (`p ≤ n`), giving decidability in principle. A second companion proves the keystone `repWithAtMost_iff_bitIndices_length` (minimal distinct powers = binary popcount) via uniqueness of the binary representation (`Finset.equivBitIndices`), yielding the efficient `Decidable` instances and the concrete `native_decide` witnesses.",
+    "keyInsights": [
+      "**Reduction lemma**: `RepWithAtMost k n ↔ RepDistinct k n` — repeats never help, since `2^a + 2^a = 2^{a+1}` strictly shrinks the exponent multiset while preserving the sum.",
+      "**Popcount is the minimal count**: the least number of distinct powers of 2 summing to m equals `(Nat.bitIndices m).length`, the binary popcount — a consequence of uniqueness of binary representation.",
+      "**Decidability is feasible, not just in principle**: the naive `Finset.range (n+1)` powerset search has 2^(n+1) candidates; the popcount route decides membership in O(log n).",
+      "**Concrete witnesses**: 906 is the smallest even integer in S₃ ∖ S₂ (¬IsPrimePlusKPowers 2 906 ∧ IsPrimePlusKPowers 3 906); Grechuk's 1117175146 ∉ S₃.",
+      "**The conjecture stays open**: it is a Prop definition (`GranvilleSoundararajanOdd`), needing Gallagher-line sieve machinery — out of brute-force and near-term Lean reach."
+    ],
+    "prerequisites": [
+      "Prime numbers",
+      "Multiset representation of sums of powers of 2",
+      "Binary representation / popcount (Nat.bitIndices)",
+      "Strong induction on multiset cardinality",
+      "Decidable instances and native_decide"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Header for Erdős #10 OQ-02: the Granville–Soundararajan conjecture (odd part) asks whether every odd $n\\ge3$ is a prime plus at most $3$ powers of $2$. The conjecture is OPEN; the file formalizes the decidable reduction infrastructure beneath it, with the merge identity $2^a+2^a=2^{a+1}$ as the engine.",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "OQ-02: every odd $n\\ge3$ is $p+\\sum_{i\\le3}2^{a_i}$, $p$ prime. Open (Granville–Soundararajan 1998)."
+    },
+    {
+      "id": "part1-pow-sum",
+      "title": "Part I: Sums of Powers of Two",
+      "summary": "Defines `powSum s` $=\\sum_{a\\in s}2^a$ over a multiset of exponents, with `powSum_zero`, `powSum_cons`, `powSum_add`, and the keystone `powSum_merge`: $2^a+2^a=2^{a+1}$.",
+      "startLine": 55,
+      "endLine": 77,
+      "mathContext": "$\\mathrm{powSum}(a::a::s)=\\mathrm{powSum}((a{+}1)::s)$ — the atomic reduction step."
+    },
+    {
+      "id": "part2-representability",
+      "title": "Part II: Representability as ≤ k Powers of Two",
+      "summary": "Defines `RepWithAtMost k n` (sum of $\\le k$ powers, repeats allowed) and `RepDistinct k n` (pairwise-distinct exponents), with monotonicity `repWithAtMost_mono`.",
+      "startLine": 78,
+      "endLine": 94,
+      "mathContext": "$\\mathrm{RepWithAtMost}(k,n)$ vs $\\mathrm{RepDistinct}(k,n)$: same sum, distinct vs repeated exponents."
+    },
+    {
+      "id": "part3-reduction-lemma",
+      "title": "Part III: The Reduction Lemma",
+      "summary": "`exists_nodup_powSum` canonicalizes any exponent multiset to a `Nodup` one of no greater card and equal `powSum` (strong induction on card), giving `repWithAtMost_iff_repDistinct`: $\\le k$ powers $\\iff\\ \\le k$ distinct powers.",
+      "startLine": 95,
+      "endLine": 154,
+      "mathContext": "$\\mathrm{RepWithAtMost}(k,n)\\iff\\mathrm{RepDistinct}(k,n)$ — repeats never reduce the count needed."
+    },
+    {
+      "id": "part4-gs-statement",
+      "title": "Part IV: The Granville–Soundararajan Statement (Odd Part)",
+      "summary": "Defines `IsPrimePlusKPowers k n` and the open `GranvilleSoundararajanOdd` Prop, and proves `isPrimePlusKPowers_iff_distinct` — the prime-plus form transfers to the distinct representation, the shape a decision procedure consumes.",
+      "startLine": 155,
+      "endLine": 189,
+      "mathContext": "$\\mathrm{IsPrimePlusKPowers}(k,n)\\iff\\exists\\,p\\ \\text{prime},\\ m\\ \\text{with}\\ \\mathrm{RepDistinct}(k,m),\\ n=p+m$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The stack establishes the decidable foundation under the open Granville–Soundararajan k=3 (odd) conjecture: the reduction lemma (repeats never help), the popcount characterization (minimal distinct powers = binary popcount), and efficient Decidable instances yielding the concrete native_decide witnesses (906, Grechuk's 1117175146). 0 axioms, 0 sorries; the conjecture itself is a Prop definition, not assumed.",
+    "implications": "The reduction lemma and popcount identity make membership in S_k an O(log n) check, turning the numerical evidence around the conjecture into machine-checkable witnesses. The conjecture itself remains open, requiring Gallagher-line sieve machinery beyond near-term formalization.",
+    "openQuestions": [
+      "Is the Granville–Soundararajan odd conjecture (k=3) true?",
+      "What is the analogous minimal k for even integers? (Conjectured 4.)",
+      "Can the density results (Gallagher) be pushed to universal coverage for some explicit k?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Parent: Erdős #10 (prime plus powers of 2)"
+    },
+    {
+      "targetId": "erdos-10-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-01: the 'sufficiently large' variant and its logical hierarchy"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Granville, A., Soundararajan, K.",
+      "title": "A binary additive problem of Erdős and the order of 2 mod p²",
+      "year": "1998",
+      "venue": "Ramanujan Journal 2:283–298",
+      "note": "Conjectured k=3 powers for odd, k=4 for even"
+    },
+    {
+      "authors": "Crocker, R.",
+      "title": "On the sum of a prime and of two powers of two",
+      "year": "1971",
+      "venue": "Pacific Journal of Mathematics 36:103–107",
+      "note": "Infinitely many odd integers not expressible as p + 2^a + 2^b (rules out k=2)"
+    },
+    {
+      "authors": "Gallagher, P.X.",
+      "title": "Primes and powers of 2",
+      "year": "1975",
+      "venue": "Inventiones Mathematicae 29:125–142",
+      "note": "Density of representable integers approaches 1"
+    },
+    {
+      "authors": "Erdős, P., Graham, R.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Monographies de L'Enseignement Mathématique 28",
+      "note": "Survey context for the problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Multiset.Basic",
+      "Mathlib.Data.Nat.Prime.Basic"
+    ],
+    "namespace": "Erdos10OQ02",
+    "lineCount": 542,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "path": "Proofs/Erdos10OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 8
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Adds the missing gallery entry for `erdos-10-oq-02`. The 3-file decidability stack
(`Erdos10OQ02.lean` + `Erdos10OQ02Decidable.lean` + `Erdos10OQ02Popcount.lean`) is
complete (**0 axioms / 0 sorries**) and registered (`Proofs.lean:901-903`, #24527)
but had **no `src/data/proofs/erdos-10-oq-02/` directory** — the only meta-less dir
of 2451 (sibling `erdos-10-oq-01` and parent `erdos-10` both have one).

## Progress
- `meta.json` — full overview, 4 sections, conclusion, cross-refs, references.
- `annotations.json` — 4 annotations on the main file (header, merge identity
  `2^a + 2^a = 2^{a+1}`, the reduction lemma, the GS statement).

Documents the mathematical content: the **reduction lemma** (`≤k` powers ⟺ `≤k`
distinct powers), the **popcount characterization** (minimal distinct powers =
binary popcount → O(log n) decision), and the concrete `native_decide` witnesses
(906 ∈ S₃ ∖ S₂; Grechuk's 1117175146 ∉ S₃).

## Honesty / status
`status=formalized`, `badge=wip`, `axiomCount=0`, `sorries=0` — deliberately **NOT
`verified`**: the `native_decide` witnesses only machine-check on compile and the
build is deployer-gated (Docker `docker info` exit 124 this session). The open
Granville–Soundararajan conjecture is a `Prop` definition (`GranvilleSoundararajanOdd`),
**not assumed**. The `assumptions` field documents the build-pending state so the
deployer/enricher can flip to `verified` on the next green build.

## Status
**Outcome**: progress (gallery data only; no Lean change). Both JSON files validated.
**Next**: deployer green build → flip to `verified`.

🤖 Generated by researcher-4