### PR TITLE
fix(meta): euler-totient-oq-01-oq-03 stale theorem/line counts

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
@@ -42,8 +42,8 @@
       "Documents (and the certificate exhibits) that squarefreeness is necessary: for n = p² the all-a fixed point fails, so RSA's n = p·q moduli are exactly the safe case"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 113,
-    "theoremCount": 3,
+    "lineCount": 169,
+    "theoremCount": 7,
     "definitionCount": 0,
     "prerequisites": [
       "Carmichael's function λ(n) = Monoid.exponent (ZMod n)ˣ (parent file euler-totient-oq-01)",
@@ -136,9 +136,9 @@
       "Classical"
     ],
     "namespace": "EulerTotientOQ01OQ03",
-    "lineCount": 113,
+    "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/EulerTotientOQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: euler-totient-oq-01-oq-03 ("Verified RSA Correctness with Carmichael's Function λ(n)")
**Issue**: stale theoremCount and lineCount
**Severity**: LOW (count drift)

## Evidence

`proofs/Proofs/EulerTotientOQ01OQ03.lean` contains **7** theorems over **169** lines:

- `zmod_pow_eq_self` (78)
- `rsa_correct` (91)
- `rsa_decrypt_correct` (106)
- `carmichael_mul_coprime` (133)
- `sub_one_dvd_carmichael_mul_left` (142)
- `sub_one_dvd_carmichael_mul_right` (149)
- `rsa_correct_carmichael` (162)

The last four (the Carmichael-bridge theorems) were added after the meta counts were last set, which still read `theoremCount: 3` / `lineCount: 113`.

`sorries: 0` and `axiomCount: 0` already match the source (no `sorry`/`admit`, no `axiom` declarations, no assumption-carrying structures). The file is registered in `Proofs.lean`. Status remains `formalized`/`wip` — the file derives its core RSA correctness from Mathlib's `ZMod.pow_card_sub_one_eq_one` (Fermat) and `ZMod.chineseRemainder` (CRT) and is build-pending, so I left the conservative wip badge rather than promoting it.

## Fix

Synced `meta.theoremCount`/`leanFile.theoremCount` 3 → 7 and both `lineCount` fields 113 → 169.

Meta-only change; no Lean rebuild required.

---
Discovered during gallery integrity audit.