### PR TITLE
research(product-of-segments-of-chords-oq-02): register Converse file (false-axiom finding + corrected signed converse)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2715,6 +2715,7 @@ import Proofs.ProbMethodSecondMoment
 import Proofs.ProbMethodSecondMomentOQ01
 import Proofs.ProbMethodSecondMomentOQ02
 import Proofs.ProductOfSegmentsOfChords
+import Proofs.ProductOfSegmentsOfChordsConverse
 import Proofs.ProductOfSegmentsOfChordsOQ01
 import Proofs.ProductOfSegmentsOfChordsOQ03
 import Proofs.PtolemysComplexProof


### PR DESCRIPTION
## Summary
`proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean` (0 sorries / 0 axioms — the three `sorry` tokens are docstring mentions, not tactics) was present in the build tree but **unregistered** in `Proofs.lean`, so its integrity finding for slug `product-of-segments-of-chords-oq-02` was never machine-checked. Adds the single `import` line.

## What the file establishes
- **The parent's `converse_product_implies_concyclic_axiom` is FALSE.** `unsigned_converse_counterexample` gives an explicit configuration — `P=0, A=e₀, B=-4·e₀, C=e₁, D=4·e₁` — satisfying every hypothesis of the axiom (collinearity through P, all points distinct, equal **unsigned** products `1·4 = 1·4`), yet with opposite **signed** powers `∓4`, so the four points lie on no common circle. The unsigned product discards the sign of the power of a point.
- **The corrected (signed) converse is proved:** `signed_converse_implies_concyclic`, via `gram_pos` (the Gram determinant `‖u‖²‖v‖² − ⟪u,v⟫² > 0` from linear independence), an explicit Cramer-rule circumcenter (`circumcenter_signed`), and polarization (`equidistant_of_inner`, where the `‖O‖²` term cancels uniformly so no `t=1`/`s=1` case split is needed).

## Why this is safe under the build blackout
Name-checked against current `main`. The proofs use only standard, stable inner-product/norm lemmas — `inner_sub_left`/`inner_sub_right`, `real_inner_smul_left`/`right`, `real_inner_self_eq_norm_sq`, `real_inner_comm`, `inner_add_right`, `norm_sub_sq_real`, `norm_smul`, `norm_pos_iff`, `norm_eq_zero`, `Real.sqrt_sq`, `LinearIndependent.pair_iff`/`.ne_zero`/`.injective` — plus the `module`/`abel`/`field_simp`/`nlinarith`/`linear_combination` tactics. The file's author additionally name-checked against the pinned v4.26.0. It adds **no axioms**.

## Status
**Outcome**: progress — registration ACT making the integrity finding + corrected converse machine-checkable; build-gated by the deployer.
**Note**: the parent file's (false) `converse_product_implies_concyclic_axiom` remains in place; correcting it in the registered flagship is a separate edit deferred until a live Docker session (per the axiom-edit-under-blackout rule).

🤖 Generated by researcher-5