### PR TITLE
research(sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01): Docker-verify + register √2+√3+√5+√7 Strategy-D file, add gallery entry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2858,6 +2858,7 @@ import Proofs.Sqrt2PlusSqrt3IrrationalOQ03
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03Aristotle
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02
+import Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sqrt2357-strategy",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "concept",
+    "title": "Strategy D: Algebraic Integer Trapped in a Unit Interval",
+    "content": "The module docstring lays out an integral-closure argument that deliberately avoids the degree-16 minimal polynomial and the iterated-squaring chain. Three steps: (1) α = √2+√3+√5+√7 is an algebraic integer because each √k is one and algebraic integers form a ring; (2) if α were rational it would be a rational algebraic integer, hence an ordinary integer (ℤ is integrally closed in ℚ); (3) but 8 < α < 9, and no integer lies strictly between 8 and 9. The argument's length does not grow with the number of summands — the same three steps work for any finite sum of square roots of non-squares.",
+    "mathContext": "An element $\\alpha$ of a field extension is an *algebraic integer over* $\\mathbb{Z}$ if it is a root of a monic polynomial with integer coefficients. The integral elements form a subring (closure under $+$ and $\\times$). The decisive fact is that $\\mathbb{Z}$ is *integrally closed* in its fraction field $\\mathbb{Q}$: any rational number integral over $\\mathbb{Z}$ already lies in $\\mathbb{Z}$.",
+    "significance": "Shows the gallery how to prove irrationality of radical sums without minimal-polynomial machinery: the integral-closure route is uniform in the number of summands, where iterated squaring suffers a degree blow-up of $2^n$.",
+    "relatedConcepts": ["algebraic integers", "integral closure", "integrally closed domain", "irrationality"],
+    "prerequisites": ["definition of IsIntegral over ℤ", "ℤ integrally closed in ℚ"]
+  },
+  {
+    "id": "ann-sqrt2357-isintegral-of-sq",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+    "range": { "startLine": 33, "endLine": 58 },
+    "type": "insight",
+    "title": "Each Radical Is an Algebraic Integer via X² − C k",
+    "content": "isIntegral_of_sq packages the building block: a real c with c² = (m : ℝ) is a root of the monic integer polynomial X² − C m, witnessed by Polynomial.monic_X_pow_sub_C and aeval evaluation. Instantiating at m = 2,3,5,7 with Real.sq_sqrt makes each √k integral, and isIntegral_alpha chains them with IsIntegral.add. This is the only place the polynomials appear — and they are the trivial quadratics X²−k, never the degree-16 minimal polynomial of the sum.",
+    "mathContext": "For a squarefree integer $k$, $\\sqrt{k}$ is a root of $X^2 - k \\in \\mathbb{Z}[X]$, which is monic, so $\\sqrt{k}$ is an algebraic integer. Closure of integral elements under addition (`IsIntegral.add`) then makes any finite sum $\\sum_i \\sqrt{k_i}$ an algebraic integer without exhibiting its minimal polynomial.",
+    "significance": "Isolates the reusable atom: turning a square-root into an algebraic integer needs only its defining quadratic, so the construction scales to arbitrarily many summands at no extra cost.",
+    "relatedConcepts": ["monic polynomial", "Polynomial.aeval", "Real.sq_sqrt", "IsIntegral.add"],
+    "prerequisites": ["Polynomial.monic_X_pow_sub_C", "aeval evaluation of polynomials"]
+  },
+  {
+    "id": "ann-sqrt2357-bounds",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+    "range": { "startLine": 60, "endLine": 74 },
+    "type": "concept",
+    "title": "Trapping α Strictly Between 8 and 9",
+    "content": "alpha_lower and alpha_upper establish 8 < α < 9 from rational bounds on each radical: Real.lt_sqrt converts 1.41 < √2 to (1.41)² < 2 (norm_num), and Real.sqrt_lt' converts √2 < 1.42 to 2 < (1.42)² (norm_num); summing the four lower bounds clears 8 and the four upper bounds stays under 9, both via linarith. These bounds are what discharge the ∀ n, α ≠ n hypothesis of the abstract criterion.",
+    "mathContext": "$1.41+1.73+2.23+2.64 = 8.01 > 8$ and $1.42+1.74+2.24+2.65 = 8.05 < 9$. A strict interval of width $1$ excludes every integer, which is exactly what is needed to contradict $\\alpha = n$ for an integer $n$.",
+    "significance": "The interval bound is the only per-instance input Strategy D requires; supplying it for a different radical sum reuses the entire rest of the argument unchanged.",
+    "relatedConcepts": ["Real.lt_sqrt", "Real.sqrt_lt'", "linarith", "rational approximation"],
+    "prerequisites": ["square-root monotonicity lemmas"]
+  },
+  {
+    "id": "ann-sqrt2357-criterion",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+    "range": { "startLine": 76, "endLine": 96 },
+    "type": "insight",
+    "title": "The Reusable Criterion: Integral + Avoids-Every-Integer ⟹ Irrational",
+    "content": "irrational_of_isIntegral_of_forall_ne_int is the abstract heart. Assuming α = (q : ℝ) for q : ℚ, integrality transfers to q in two descents: isIntegral_algebraMap_iff along the injective algebraMap ℚ ℝ, then IsIntegrallyClosed.isIntegral_iff along ℤ ↪ ℚ, producing n : ℤ with (n : ℚ) = q. That makes α = (n : ℝ), contradicting the hypothesis ∀ n, α ≠ n. Stated for an arbitrary real α, it is gallery-wide infrastructure, not specific to √2+√3+√5+√7.",
+    "mathContext": "The composite descent $\\mathbb{R} \\hookleftarrow \\mathbb{Q} \\hookleftarrow \\mathbb{Z}$ uses (i) integrality is preserved/reflected by injective ring maps and (ii) $\\mathbb{Z}$ integrally closed in $\\mathbb{Q}$. Together they yield: a real algebraic integer that is rational is in fact an integer.",
+    "significance": "Encapsulates Strategy D as a single reusable theorem; future irrationality results for radical sums need only prove integrality and supply an interval, never re-deriving the descent.",
+    "relatedConcepts": ["isIntegral_algebraMap_iff", "IsIntegrallyClosed.isIntegral_iff", "fraction field", "ring homomorphism injectivity"],
+    "prerequisites": ["integral closure under injective ring maps", "ℤ integrally closed in ℚ"]
+  },
+  {
+    "id": "ann-sqrt2357-main",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+    "range": { "startLine": 98, "endLine": 113 },
+    "type": "concept",
+    "title": "Main Theorem: Assembling the Contradiction",
+    "content": "irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 feeds isIntegral_alpha and the interval bounds into the abstract criterion. Given a hypothetical α = (n : ℝ), rewriting alpha_lower and alpha_upper gives 8 < n and n < 9 over ℤ (via exact_mod_cast), which omega refutes. The result is fully machine-checked: 0 sorries, 0 axioms.",
+    "mathContext": "Combining the structural fact (α is an algebraic integer) with the analytic fact (8 < α < 9) yields irrationality with no computation of the degree-16 minimal polynomial — a striking economy compared to the iterated-squaring proof of the three-summand parent.",
+    "significance": "Closes OQ-01 of the parent entry and demonstrates that the integral-closure strategy is both shorter and more general than the squaring approach it replaces.",
+    "relatedConcepts": ["Irrational", "exact_mod_cast", "omega"],
+    "prerequisites": ["the reusable criterion", "the interval bounds", "integrality of α"]
+  }
+]

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+  "title": "Irrationality of √2 + √3 + √5 + √7",
+  "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01",
+  "description": "Proves that √2 + √3 + √5 + √7 is irrational (OQ-01 of the parent sqrt2-plus-sqrt3-plus-sqrt5-irrational entry, the four-summand generalization). Uses Strategy D — algebraic integer trapped in a bounded interval — avoiding the degree-16 minimal polynomial and iterated-squaring machinery entirely. Each √k is an algebraic integer (root of the monic integer polynomial X² − C k), so α = √2+√3+√5+√7 is integral over ℤ by closure under addition. A rational algebraic integer must be an integer (ℤ is integrally closed in ℚ), but 8 < α < 9 traps α strictly between consecutive integers, contradiction. 8 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-15",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean",
+    "tags": [
+      "irrationality",
+      "algebraic-numbers",
+      "integral-closure",
+      "square-roots",
+      "number-theory",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-15",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axioms. Uses Mathlib's integral-closure API — IsIntegral.add, isIntegral_algebraMap_iff, IsIntegrallyClosed.isIntegral_iff (ℤ integrally closed in ℚ), Polynomial.monic_X_pow_sub_C, Real.sq_sqrt, Real.lt_sqrt, Real.sqrt_lt'.",
+    "lineCount": 113,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7: √2 + √3 + √5 + √7 is irrational, proved via Strategy D (algebraic integer trapped in (8,9)) rather than the iterated-squaring / degree-16 minimal-polynomial route",
+      "irrational_of_isIntegral_of_forall_ne_int: reusable gallery-wide criterion — an algebraic integer over ℤ that equals no rational integer is irrational; discharges any finite sum of square roots of non-squares given a unit-width interval bound",
+      "isIntegral_of_sq: a real c with c² ∈ ℤ is an algebraic integer (root of the monic X² − C m); the building block making each √k integral",
+      "isIntegral_alpha: α = √2+√3+√5+√7 is an algebraic integer, by IsIntegral.add applied to the four radical summands",
+      "alpha_lower / alpha_upper: rational-bound chains giving 8 < α < 9 via Real.lt_sqrt and Real.sqrt_lt' on each radical"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The irrationality of $\\sqrt{2}+\\sqrt{3}+\\sqrt{5}+\\sqrt{7}$ is the four-summand member of the family generalizing $\\sqrt{2}+\\sqrt{3} \\notin \\mathbb{Q}$. The general statement — that $\\{\\sqrt{a_1},\\ldots,\\sqrt{a_n}\\}$ are $\\mathbb{Q}$-linearly independent for distinct squarefree positive integers $a_i$ — is due to A. S. Besicovitch, 'On the linear independence of fractional powers of integers' (J. London Math. Soc., 1940), via induction on the number of prime factors; the modern Galois framing computes $[\\mathbb{Q}(\\sqrt{a_1},\\ldots,\\sqrt{a_n}):\\mathbb{Q}] = 2^n$. The parent gallery entry handles $n=3$ ($\\{2,3,5\\}$) by iterated squaring, reducing to irrationality of $\\sqrt{30}$. The natural $n=4$ route would square three times into a degree-16 relation. This entry instead bypasses all of that with an integral-closure argument: it never names the minimal polynomial at all.",
+    "problemStatement": "Prove that $\\sqrt{2} + \\sqrt{3} + \\sqrt{5} + \\sqrt{7} \\notin \\mathbb{Q}$ (OQ-01 of the parent `sqrt2-plus-sqrt3-plus-sqrt5-irrational` gallery entry).",
+    "text": "Set $\\alpha := \\sqrt{2}+\\sqrt{3}+\\sqrt{5}+\\sqrt{7}$. Step 1: each $\\sqrt{k}$ is a root of the monic integer polynomial $X^2 - k$, hence $\\mathrm{IsIntegral}\\,\\mathbb{Z}\\,\\sqrt{k}$; algebraic integers are closed under addition, so $\\alpha$ is an algebraic integer. Step 2: suppose $\\alpha = (q:\\mathbb{R})$ for $q \\in \\mathbb{Q}$. Integrality descends along the injective ring map $\\mathrm{algebraMap}\\,\\mathbb{Q}\\,\\mathbb{R}$, giving $\\mathrm{IsIntegral}\\,\\mathbb{Z}\\,q$; since $\\mathbb{Z}$ is integrally closed in its fraction field $\\mathbb{Q}$, there is $n \\in \\mathbb{Z}$ with $q = n$, so $\\alpha = (n:\\mathbb{R})$. Step 3: rational bounds $1.41 < \\sqrt{2} < 1.42$, etc., give $8 < \\alpha < 9$, and no integer lies strictly between $8$ and $9$ — contradiction. Hence $\\alpha$ is irrational.",
+    "proofStrategy": "Strategy D (algebraic integer + bounded interval). The substance is the reusable criterion `irrational_of_isIntegral_of_forall_ne_int`: a $\\mathbb{Z}$-integral real that avoids every integer is irrational. The descent uses `isIntegral_algebraMap_iff` (along $\\mathbb{Q}\\hookrightarrow\\mathbb{R}$) then `IsIntegrallyClosed.isIntegral_iff` (along $\\mathbb{Z}\\hookrightarrow\\mathbb{Q}$). The interval hypothesis $\\forall n,\\ \\alpha \\ne n$ is discharged by the strict bounds $8 < \\alpha < 9$ plus `omega`. This requires no degree-$2^n$ minimal-polynomial machinery and extends verbatim to any finite sum of square roots of non-squares once a unit-width interval bound is supplied.",
+    "keyInsights": [
+      "Integral closure beats iterated squaring. The iterated-squaring proof of the $n=3$ case reduces to irrationality of $\\sqrt{30}$; the $n=4$ case would need a degree-16 relation. The integral-closure argument sidesteps the degree blow-up entirely — its length is independent of $n$, needing only that the sum is integral (closure under $+$) and that one interval of width $1$ traps it.",
+      "A rational algebraic integer is an integer. The keystone is that $\\mathbb{Z}$ is integrally closed in $\\mathbb{Q}$ (`IsIntegrallyClosed.isIntegral_iff`): the only rationals integral over $\\mathbb{Z}$ are the integers. Combined with a strict interval bound this immediately forces irrationality.",
+      "The criterion is gallery-reusable. `irrational_of_isIntegral_of_forall_ne_int` is stated abstractly for any real $\\alpha$ and applies to every finite sum of square roots of non-squares: build integrality from `isIntegral_of_sq` + `IsIntegral.add`, then supply consecutive-integer bounds. No per-instance minimal polynomial is ever computed.",
+      "Generalisation horizon — Besicovitch (1940): for distinct squarefree positive integers $a_1,\\ldots,a_n$ the $\\sqrt{a_i}$ are $\\mathbb{Q}$-linearly independent. Strategy D proves irrationality of any such sum without the full independence theorem; the linear-independence statement itself remains absent from Mathlib v4.26.0."
+    ],
+    "prerequisites": [
+      "IsIntegral.add : algebraic integers are closed under addition",
+      "Polynomial.monic_X_pow_sub_C : X^n − C a is monic",
+      "isIntegral_algebraMap_iff : integrality descends along an injective ring map",
+      "IsIntegrallyClosed.isIntegral_iff : ℤ is integrally closed in ℚ",
+      "Real.sq_sqrt, Real.lt_sqrt, Real.sqrt_lt' : square-root identities and bound lemmas"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms): irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 : Irrational (√2 + √3 + √5 + √7). Proved by Strategy D — α is an algebraic integer over ℤ trapped strictly in (8,9), and a rational algebraic integer must be an integer. Build verified at Mathlib v4.26.0. 8 theorems, 113 lines.",
+    "implications": "Closes OQ-01 of the parent `sqrt2-plus-sqrt3-plus-sqrt5-irrational` gallery entry. The reusable criterion irrational_of_isIntegral_of_forall_ne_int proves irrationality of any finite sum of square roots of non-squares once a unit-width interval bound is supplied — independent of the number of summands, with no minimal-polynomial computation.",
+    "openQuestions": [
+      "Formalise Besicovitch's (1940) general linear-independence theorem for {√a_i} with distinct squarefree a_i; not in Mathlib v4.26.0.",
+      "Compute the explicit degree-16 minimal polynomial of √2+√3+√5+√7 over ℚ (Galois-conjugate product over {±1}⁴) and prove [ℚ(√2,√3,√5,√7):ℚ] = 16.",
+      "Package Strategy D as a general Mathlib-style lemma: any sum of square roots of pairwise-distinct non-squares is irrational, deriving the interval bound automatically."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+      "relationship": "extends",
+      "description": "Parent gallery entry: irrationality of √2 + √3 + √5 (n=3) via two squarings reducing to irrationality of √30. This entry handles the n=4 case (adding √7) but switches strategy: instead of a third squaring into a degree-16 relation, it uses an integral-closure argument independent of the number of summands."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "relationship": "related",
+      "description": "Sister open question: the degree-4 minimal polynomial X⁴−10X²+1 of √2+√3. The four-summand analogue would have degree 16 — an open question listed here. Strategy D avoids computing it altogether."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Base case (n=1) of the square-root-sum irrationality family. Strategy D subsumes the whole family: every √k is an algebraic integer, so any finite sum is, and an interval bound finishes the argument."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes OQ-01 of the parent `sqrt2-plus-sqrt3-plus-sqrt5-irrational` gallery entry — the **four-summand** generalization: √2+√3+√5+√7 is irrational.

The Strategy-D Lean file `Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` already lived in `main` (S5, researcher-10) but was **unregistered and never build-verified** — the prior in-flight PRs (#24254 transcription, #24400 core, #24512 minpoly, #24522 registration) were all build-pending during the Docker blackout.

**Docker build now PASSES** at Mathlib v4.26.0 (the blackout has lifted):
```
✔ [7743/7743] Built Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01 (35s)
Build completed successfully (7743 jobs).
```
0 sorries, 0 axioms, **no lemma-name/instance drift** — the bearer audit (#24564) was correct.

## Changes
- `proofs/Proofs.lean`: hand-added the single import line (did not regenerate the manifest, to avoid pulling unrelated backlog).
- New gallery entry `src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/` (`meta.json` + `annotations.json`): `status: verified`, `badge: original`. No `-oq-01` gallery dir existed before.

## The proof (Strategy D — algebraic integer + bounded interval)
- Each √k is an algebraic integer (root of monic `X² − k`); α = √2+√3+√5+√7 is integral over ℤ by closure under `+`.
- A rational algebraic integer must be an integer (`IsIntegrallyClosed.isIntegral_iff`: ℤ integrally closed in ℚ).
- But `8 < α < 9` traps α strictly between consecutive integers → contradiction.
- Reusable criterion `irrational_of_isIntegral_of_forall_ne_int` applies to **any** finite sum of square roots of non-squares given a unit-width interval bound — no degree-2ⁿ minimal polynomial required.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01` — succeeded (7743 jobs)
- [x] Both gallery JSON files validated with `python3 json.load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)