### PR TITLE
Enrich euler-totient-oq-01-oq-03: add annotations.json, fix stale counts

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/annotations.json
@@ -1,0 +1,187 @@
+[
+  {
+    "id": "ann-rsa-header",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "context",
+    "title": "Module Header: RSA Correctness via the Carmichael Exponent λ(n)",
+    "content": "The opening docstring (lines 1-62) states open question OQ-03 of the parent entry `euler-totient-oq-01`: can Carmichael's function drive a Lean-verified RSA whose decryption identity m^(e·d) ≡ m (mod n) uses the minimal universal exponent λ(n) = lcm(p−1, q−1) rather than Euler's φ(n)? It lays out the full mathematical skeleton — reduce to a per-prime fixed point a^(m+1) = a via the Chinese Remainder Theorem, prove it by Fermat plus a case split on a = 0 — and emphasizes the crucial point that the identity must hold for EVERY message a, including those sharing a factor with n, which is what makes textbook RSA correct. It also records that squarefreeness is necessary: for n = p² the all-a fixed point fails. A stdlib certificate (verify_rsa_lambda.py) independently checks correctness over 55 moduli, λ < φ strictly, and the explicit p² failure set.",
+    "mathContext": "RSA: pick $n = pq$ (distinct primes), public $e$ with $\\gcd(e,\\lambda(n)) = 1$, private $d \\equiv e^{-1} \\pmod{\\lambda(n)}$. Then $ed = 1 + k\\lambda(n)$ and $m^{ed} \\equiv m \\pmod n$ for all $m$, where $\\lambda(n) = \\mathrm{lcm}(p-1, q-1)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "RSA cryptosystem",
+      "Carmichael's function",
+      "Chinese Remainder Theorem",
+      "Fermat's little theorem",
+      "squarefree modulus"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "public-key cryptography",
+      "number theory"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 64, "endLine": 73 },
+    "type": "context",
+    "title": "Imports, Classical Logic, and the CarmichaelFunction Namespace",
+    "content": "Lines 64-67 import `Mathlib.Data.ZMod.Basic` (the ZMod type and `ZMod.chineseRemainder`), `Mathlib.FieldTheory.Finite.Basic` (Fermat's little theorem as `ZMod.pow_card_sub_one_eq_one`), `Mathlib.Tactic`, and the parent file `Proofs.EulerTotientOQ01` (which defines `carmichael n = Monoid.exponent (ZMod n)ˣ`). `open scoped Classical` (line 69) enables classical case analysis. The namespace `EulerTotientOQ01OQ03` is opened and `open CarmichaelFunction` (line 73) brings the parent's `carmichael` definition and its lemmas (`carmichael_prime`) into scope so the bridge theorems can refer to λ(n) directly.",
+    "mathContext": "Dependency on the parent's $\\lambda(n) := \\mathrm{Monoid.exponent}\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times$ lets the bridge lemmas connect the concrete exponent $\\mathrm{lcm}(p-1,q-1)$ to the abstract group-exponent definition.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "ZMod",
+      "Mathlib imports",
+      "Monoid.exponent",
+      "namespace"
+    ],
+    "prerequisites": [
+      "Lean 4 module system",
+      "Mathlib structure"
+    ]
+  },
+  {
+    "id": "ann-zmod-pow-eq-self",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 75, "endLine": 84 },
+    "type": "technique",
+    "title": "The Per-Prime Fixed Point a^(m+1) = a (Fermat + case split)",
+    "content": "`zmod_pow_eq_self` is the arithmetic heart of the formalization: in `ZMod p` with p prime, if (p−1) ∣ m then a^(m+1) = a for EVERY a, units and 0 alike. The proof writes m = (p−1)·t (`obtain ⟨t, rfl⟩ := hm`), then splits on a = 0. When a = 0 both sides vanish since m+1 ≥ 1 (`zero_pow (Nat.succ_ne_zero _)`). When a ≠ 0, a is a unit and Fermat's little theorem `ZMod.pow_card_sub_one_eq_one h` gives a^(p−1) = 1, so a^(m+1) = a^((p−1)·t)·a = (a^(p−1))^t·a = 1·a = a via `pow_succ, pow_mul, one_pow, one_mul`. Critically, `ZMod.pow_card_sub_one_eq_one` takes its element argument {a} implicitly, so only the nonzero hypothesis h is passed.",
+    "mathContext": "For $a \\ne 0$ in $\\mathbb{Z}/p$: $a^{m+1} = a^{(p-1)t + 1} = (a^{p-1})^t \\cdot a = 1^t \\cdot a = a$. For $a = 0$: $0^{m+1} = 0$ since $m+1 \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "ZMod.pow_card_sub_one_eq_one",
+      "zero_pow",
+      "case split on units"
+    ],
+    "prerequisites": [
+      "Fermat's little theorem",
+      "finite field arithmetic",
+      "Lean pow lemmas"
+    ]
+  },
+  {
+    "id": "ann-rsa-correct",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 86, "endLine": 101 },
+    "type": "technique",
+    "title": "RSA Correctness for n = p·q via the CRT Isomorphism",
+    "content": "`rsa_correct` lifts the per-prime fixed point to ZMod(p·q). For coprime p, q and an exponent m divisible by both p−1 and q−1, the map a ↦ a^(m+1) is the identity on ZMod(p·q). The proof obtains the CRT ring isomorphism `e := ZMod.chineseRemainder hcop : ZMod (p·q) ≃+* ZMod p × ZMod q`, then reduces to checking equality after applying the injective map e (`apply e.injective; rw [map_pow]`). The image splits into two components; each is closed by `zmod_pow_eq_self` (hx for the ZMod p factor with hp, hy for ZMod q with hq), and `Prod.ext_iff.mpr ⟨_, _⟩` reassembles them, with `simpa` discharging the projection-of-power simp normal form on each side.",
+    "mathContext": "$\\mathbb{Z}/(pq) \\cong \\mathbb{Z}/p \\times \\mathbb{Z}/q$ (CRT). Since $a^{m+1} = a$ holds in each factor, injectivity of the iso forces it in $\\mathbb{Z}/(pq)$. Requires $(p-1)\\mid m$ and $(q-1)\\mid m$, i.e. $\\mathrm{lcm}(p-1,q-1)\\mid m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "ZMod.chineseRemainder",
+      "ring isomorphism",
+      "map_pow",
+      "Prod.ext_iff"
+    ],
+    "prerequisites": [
+      "Chinese Remainder Theorem",
+      "ring homomorphisms",
+      "product of rings"
+    ]
+  },
+  {
+    "id": "ann-rsa-decrypt-correct",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 103, "endLine": 114 },
+    "type": "insight",
+    "title": "Textbook RSA Decryption: a^(e·d) = a when e·d = 1 + k·λ",
+    "content": "`rsa_decrypt_correct` gives the form cryptographers actually use. If the public/private exponents satisfy e·d = 1 + k·λ where λ is any common multiple of p−1 and q−1 (the Carmichael exponent of n = p·q), then a^(e·d) = a for all a. The proof lifts the divisibilities to k·λ (`hp.mul_left k`, `hq.mul_left k`), rewrites e·d = k·λ + 1 (`ring`), and applies `rsa_correct`. This is exactly the decryption guarantee: encryption raises to e, decryption raises to d, and the composite recovers the original message for every message including non-units.",
+    "mathContext": "$d \\equiv e^{-1} \\pmod{\\lambda(n)} \\Rightarrow ed \\equiv 1 \\pmod{\\lambda(n)} \\Rightarrow ed = 1 + k\\lambda$. Then $a^{ed} = a^{k\\lambda + 1} = a$ by `rsa_correct` since $(p-1) \\mid k\\lambda$ and $(q-1) \\mid k\\lambda$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RSA decryption",
+      "modular inverse",
+      "Carmichael exponent",
+      "Dvd.mul_left"
+    ],
+    "prerequisites": [
+      "modular inverses",
+      "RSA key relation"
+    ]
+  },
+  {
+    "id": "ann-bridge-docstring",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 116, "endLine": 123 },
+    "type": "context",
+    "title": "Bridge Section: Connecting to the Genuine Carmichael Function λ(n)",
+    "content": "The results above are stated for an exponent m divisible by both p−1 and q−1. This section docstring (lines 116-123) introduces the bridge to the parent file's abstract definition λ(n) = Monoid.exponent (ZMod n)ˣ. The goal is to prove λ(p·q) = lcm(λ(p), λ(q)) = lcm(p−1, q−1) for coprime factors, so RSA decryption correctness can be stated directly against `carmichael (p·q)` — the minimal universal exponent the open question asks about, not merely a chosen common multiple.",
+    "mathContext": "The open question targets $\\lambda(n)$ as the *minimal* universal exponent. The bridge shows the concrete $\\mathrm{lcm}(p-1,q-1)$ equals the abstract group exponent $\\mathrm{Monoid.exponent}\\,(\\mathbb{Z}/n\\mathbb{Z})^\\times$ on RSA moduli.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Carmichael's function",
+      "Monoid.exponent",
+      "minimal universal exponent"
+    ],
+    "prerequisites": [
+      "group exponent",
+      "Carmichael function definition"
+    ]
+  },
+  {
+    "id": "ann-carmichael-mul-coprime",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 139 },
+    "type": "technique",
+    "title": "Carmichael Multiplicativity: λ(p·q) = lcm(λ(p), λ(q))",
+    "content": "`carmichael_mul_coprime` proves λ is 'multiplicative' on coprime factors in the lcm sense. The CRT ring isomorphism ZMod(p·q) ≃+* ZMod p × ZMod q induces a group isomorphism on units (ZMod(p·q))ˣ ≃* (ZMod p)ˣ × (ZMod q)ˣ, built via `Units.mapEquiv (ZMod.chineseRemainder hcop).toMulEquiv` followed by `MulEquiv.prodUnits`. After `unfold carmichael`, the proof rewrites with `Monoid.exponent_eq_of_mulEquiv e` (group exponent is invariant under isomorphism) and `Monoid.exponent_prod` (the exponent of a product is the lcm of the factor exponents), and closes with `rfl` since Nat.lcm is definitionally the lcm operation involved.",
+    "mathContext": "$(\\mathbb{Z}/(pq))^\\times \\cong (\\mathbb{Z}/p)^\\times \\times (\\mathbb{Z}/q)^\\times$, and $\\mathrm{exponent}(G \\times H) = \\mathrm{lcm}(\\mathrm{exponent}\\,G, \\mathrm{exponent}\\,H)$. Hence $\\lambda(pq) = \\mathrm{lcm}(\\lambda(p), \\lambda(q))$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Units.mapEquiv",
+      "MulEquiv.prodUnits",
+      "Monoid.exponent_prod",
+      "Monoid.exponent_eq_of_mulEquiv"
+    ],
+    "prerequisites": [
+      "group isomorphism",
+      "units of a product ring",
+      "exponent of a product group"
+    ]
+  },
+  {
+    "id": "ann-sub-one-dvd-carmichael",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 141, "endLine": 153 },
+    "type": "definition",
+    "title": "Divisibility Bridge: (p−1) ∣ λ(p·q) and (q−1) ∣ λ(p·q)",
+    "content": "`sub_one_dvd_carmichael_mul_left` and its right-hand twin establish that p−1 and q−1 each divide the genuine Carmichael exponent of the product. The key is the parent lemma `carmichael_prime hp : carmichael p = p − 1` (the Carmichael function of a prime is p−1, since (ZMod p)ˣ is cyclic of order p−1). Rewriting p−1 back as carmichael p and then applying `carmichael_mul_coprime`, the claim becomes carmichael p ∣ lcm(carmichael p, carmichael q), which is exactly `Nat.dvd_lcm_left` (resp. `Nat.dvd_lcm_right`). These two lemmas are the divisibility hypotheses `rsa_correct_carmichael` feeds into `rsa_correct`.",
+    "mathContext": "For prime $p$, $\\lambda(p) = p - 1$. Then $p - 1 = \\lambda(p) \\mid \\mathrm{lcm}(\\lambda(p), \\lambda(q)) = \\lambda(pq)$, and symmetrically for $q - 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "carmichael_prime",
+      "Nat.dvd_lcm_left",
+      "Nat.dvd_lcm_right",
+      "cyclic group order"
+    ],
+    "prerequisites": [
+      "lcm divisibility",
+      "Carmichael function of a prime"
+    ]
+  },
+  {
+    "id": "ann-rsa-correct-carmichael",
+    "proofId": "euler-totient-oq-01-oq-03",
+    "range": { "startLine": 155, "endLine": 169 },
+    "type": "insight",
+    "title": "Final Statement: RSA Correctness Against the Minimal Exponent λ(n)",
+    "content": "`rsa_correct_carmichael` is the open question's target theorem: for n = p·q (distinct primes), if the exponent m is a multiple of λ(n) = carmichael(p·q), then a^(m+1) = a for EVERY a : ZMod n. It is a one-line composition — `rsa_correct` applied with the two divisibility bridges transitively chained through hm (`(sub_one_dvd_carmichael_mul_left hcop).trans hm`). This closes the loop: RSA is verified correct with the minimal universal exponent λ(n), not merely Euler's φ(n). Since λ(n) ∣ φ(n), keying decryption on λ(n) yields a no-larger — and typically strictly smaller — private exponent, exactly the efficiency reason cryptographic standards prefer it.",
+    "mathContext": "$\\lambda(n) \\mid m \\Rightarrow (p-1)\\mid m \\text{ and } (q-1)\\mid m \\Rightarrow a^{m+1} = a$ for all $a$. Since $\\lambda(n) \\mid \\varphi(n)$ with equality only when $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic, $\\lambda(n)$ gives the tightest universal exponent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal universal exponent",
+      "Dvd.dvd.trans",
+      "λ(n) ∣ φ(n)",
+      "RSA efficiency"
+    ],
+    "prerequisites": [
+      "transitivity of divisibility",
+      "Carmichael vs Euler exponent"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
@@ -39,11 +39,13 @@
       "rsa_correct: RSA correctness for n = p·q via the CRT isomorphism — a^(m+1) = a for all a whenever m is divisible by both p−1 and q−1 (i.e. any multiple of λ(n) = lcm(p−1, q−1))",
       "rsa_decrypt_correct: the textbook phrasing a^(e·d) = a once e·d = 1 + k·λ, reducing to rsa_correct",
       "Demonstrates why λ(n) is the RIGHT exponent: the identity holds for ALL messages, including those sharing a factor with n — the all-a fixed point that φ(n)-based statements over units do not directly give",
-      "Documents (and the certificate exhibits) that squarefreeness is necessary: for n = p² the all-a fixed point fails, so RSA's n = p·q moduli are exactly the safe case"
+      "Documents (and the certificate exhibits) that squarefreeness is necessary: for n = p² the all-a fixed point fails, so RSA's n = p·q moduli are exactly the safe case",
+      "carmichael_mul_coprime: identifies the concrete exponent lcm(p−1, q−1) with the parent's abstract λ(n) = Monoid.exponent (ZMod n)ˣ, by transporting the group exponent across the CRT-induced units isomorphism (Units.mapEquiv + MulEquiv.prodUnits) and evaluating Monoid.exponent_prod",
+      "rsa_correct_carmichael: the open question's headline statement — RSA correctness stated directly against the minimal universal exponent λ(n) = carmichael(p·q), via the divisibility bridges (p−1) ∣ λ(n) and (q−1) ∣ λ(n)"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 113,
-    "theoremCount": 3,
+    "lineCount": 169,
+    "theoremCount": 7,
     "definitionCount": 0,
     "prerequisites": [
       "Carmichael's function λ(n) = Monoid.exponent (ZMod n)ˣ (parent file euler-totient-oq-01)",
@@ -62,7 +64,8 @@
       "The case a = 0 (a shares a factor with the prime) is the subtle one and is handled directly by zero_pow; this is exactly the case a φ(n)/unit-group argument would miss",
       "CRT turns a statement about ZMod(p·q) into two independent prime-power-free statements about ZMod p and ZMod q, each closed by Fermat — the cleanest route to all-message correctness",
       "Squarefreeness is necessary, not incidental: for n = p² the all-a fixed point fails (a divisible by p stays ≡ 0 mod p but need not return mod p²), so RSA's n = p·q moduli are exactly the safe regime — the certificate exhibits the explicit failure set for n = 49",
-      "The theorem is stated for any exponent m divisible by both p−1 and q−1, which is more general than 'a multiple of λ(n)' and makes the CRT reduction immediate"
+      "The theorem is stated for any exponent m divisible by both p−1 and q−1, which is more general than 'a multiple of λ(n)' and makes the CRT reduction immediate",
+      "The bridge λ(p·q) = lcm(λ(p), λ(q)) is proved abstractly — by transporting Monoid.exponent across the CRT-induced units isomorphism (Monoid.exponent_eq_of_mulEquiv + Monoid.exponent_prod) rather than by computing orders — so the final theorem speaks about the genuinely minimal exponent λ(n) = Monoid.exponent (ZMod n)ˣ, not merely a convenient common multiple"
     ]
   },
   "sections": [
@@ -89,6 +92,14 @@
       "endLine": 113,
       "summary": "rsa_decrypt_correct gives the textbook phrasing a^(e·d) = a once the exponents satisfy e·d = 1 + k·λ with λ a common multiple of p−1 and q−1. It rewrites e·d = k·λ + 1 and applies rsa_correct with (p−1) ∣ k·λ and (q−1) ∣ k·λ.",
       "mathContext": "$a^{ed} = a$ in $\\mathbb{Z}/(pq)$ when $ed = 1 + k\\lambda$, $\\lambda = \\mathrm{lcm}(p-1,q-1)$."
+    },
+    {
+      "id": "carmichael-bridge",
+      "title": "Bridge to the Genuine Carmichael Exponent λ(n)",
+      "startLine": 116,
+      "endLine": 169,
+      "summary": "Connects the divisibility hypotheses above to the parent file's abstract λ(n) = Monoid.exponent (ZMod n)ˣ. carmichael_mul_coprime proves λ(p·q) = lcm(λ(p), λ(q)) via the CRT-induced units isomorphism (Units.mapEquiv + MulEquiv.prodUnits), Monoid.exponent_eq_of_mulEquiv, and Monoid.exponent_prod. sub_one_dvd_carmichael_mul_left/right then give (p−1) ∣ λ(p·q) and (q−1) ∣ λ(p·q) using carmichael_prime (λ(p) = p−1). The capstone rsa_correct_carmichael states RSA correctness directly against the minimal universal exponent: if λ(n) ∣ m then a^(m+1) = a for every a.",
+      "mathContext": "$\\lambda(pq) = \\mathrm{lcm}(\\lambda(p),\\lambda(q)) = \\mathrm{lcm}(p-1,q-1)$, and $\\lambda(n)\\mid m \\Rightarrow a^{m+1} = a$ for all $a$."
     }
   ],
   "crossReferences": [
@@ -104,12 +115,12 @@
     }
   ],
   "conclusion": {
-    "summary": "RSA decryption correctness is formalized with the Carmichael exponent λ(n) = lcm(p−1, q−1): for n = p·q and any exponent divisible by both p−1 and q−1, a^(m+1) = a holds for every message a, giving the textbook a^(e·d) = a once e·d = 1 + k·λ. The proof reduces through CRT to a per-prime Fermat fixed point that explicitly covers the non-unit case. 0 axioms, 0 sorries.",
-    "implications": "Provides the verified core of a textbook-correct RSA implementation keyed on the Carmichael function rather than φ(n), and pins down why squarefree moduli n = p·q are necessary for all-message correctness.",
+    "summary": "RSA decryption correctness is formalized with the Carmichael exponent λ(n) = lcm(p−1, q−1): for n = p·q and any exponent divisible by both p−1 and q−1, a^(m+1) = a holds for every message a, giving the textbook a^(e·d) = a once e·d = 1 + k·λ. The proof reduces through CRT to a per-prime Fermat fixed point that explicitly covers the non-unit case. A bridge section then connects this to the parent's abstract λ(n) = Monoid.exponent (ZMod n)ˣ, proving λ(p·q) = lcm(λ(p), λ(q)) and stating correctness directly against the minimal universal exponent (rsa_correct_carmichael). 0 axioms, 0 sorries.",
+    "implications": "Provides the verified core of a textbook-correct RSA implementation keyed on the Carmichael function rather than φ(n), pins down why squarefree moduli n = p·q are necessary for all-message correctness, and identifies the concrete exponent lcm(p−1, q−1) with the abstract group-exponent definition λ(n) = Monoid.exponent (ZMod n)ˣ — so correctness is stated against the genuinely minimal universal exponent, which divides φ(n) and yields a no-larger private key.",
     "openQuestions": [
-      "Bridge to the parent's λ(n) = Monoid.exponent (ZMod n)ˣ explicitly, proving (p−1) ∣ λ(p·q) and (q−1) ∣ λ(p·q) from the exponent definition so rsa_decrypt_correct can be invoked with the genuine Carmichael λ (this is the subject of in-flight work)",
       "Extend to a verified key-generation/encryption pipeline: derive d as a modular inverse of e mod λ(n) and assemble end-to-end encrypt∘decrypt = id",
-      "Generalize the all-message fixed point to arbitrary squarefree n = ∏ pᵢ via the multi-prime CRT"
+      "Generalize the all-message fixed point to arbitrary squarefree n = ∏ pᵢ via the multi-prime CRT",
+      "Quantify the efficiency gain of λ(n) over φ(n): characterize the moduli where λ(n) ≪ φ(n) and the consequent reduction in the private exponent's size"
     ]
   },
   "references": [
@@ -136,9 +147,9 @@
       "Classical"
     ],
     "namespace": "EulerTotientOQ01OQ03",
-    "lineCount": 113,
+    "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/EulerTotientOQ01OQ03.lean",
     "sorries": 0
@@ -161,6 +172,30 @@
       "type": "supporting",
       "description": "Per-prime fixed point: a^(m+1) = a in ZMod p for every a when (p−1) ∣ m",
       "leanType": "a ^ (m + 1) = a"
+    },
+    {
+      "name": "rsa_correct_carmichael",
+      "type": "core",
+      "description": "RSA correctness against the minimal universal exponent: if λ(n) = carmichael(p·q) divides m, then a^(m+1) = a for every a : ZMod (p·q)",
+      "leanType": "a ^ (m + 1) = a"
+    },
+    {
+      "name": "carmichael_mul_coprime",
+      "type": "supporting",
+      "description": "Carmichael multiplicativity on coprime factors: λ(p·q) = lcm(λ(p), λ(q)), via the CRT-induced units isomorphism and Monoid.exponent_prod",
+      "leanType": "carmichael (p * q) = Nat.lcm (carmichael p) (carmichael q)"
+    },
+    {
+      "name": "sub_one_dvd_carmichael_mul_left",
+      "type": "supporting",
+      "description": "Divisibility bridge: (p−1) ∣ λ(p·q), since p−1 = λ(p) divides lcm(λ(p), λ(q))",
+      "leanType": "(p - 1) ∣ carmichael (p * q)"
+    },
+    {
+      "name": "sub_one_dvd_carmichael_mul_right",
+      "type": "supporting",
+      "description": "Divisibility bridge: (q−1) ∣ λ(p·q), since q−1 = λ(q) divides lcm(λ(p), λ(q))",
+      "leanType": "(q - 1) ∣ carmichael (p * q)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
Enrichment pass for `euler-totient-oq-01-oq-03` (Verified RSA Correctness with Carmichael's Function λ(n)). This entry was missing `annotations.json` entirely and its `meta.json` counts were stale relative to the registered Lean file.

- **Created `annotations.json`** — 9 line-anchored annotations spanning the full 169-line file. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Covers the module header, imports, the per-prime Fermat fixed point (`zmod_pow_eq_self`), CRT correctness (`rsa_correct`), textbook decryption (`rsa_decrypt_correct`), and the **Carmichael bridge** section that the prior meta did not document at all.
- **Fixed stale counts** in both `meta.meta` and `meta.leanFile`: `lineCount` 113 → 169, `theoremCount` 3 → 7. The Lean file gained 4 bridge theorems (`carmichael_mul_coprime`, `sub_one_dvd_carmichael_mul_left/right`, `rsa_correct_carmichael`).
- **Added** a `carmichael-bridge` section (lines 116–169) and the 4 bridge theorems to `mainTheorems`.
- **Updated `conclusion`**: the λ(n) bridge was described as "in-flight work" but is now proved in-file — revised summary, implications, and open questions.
- **Added** 2 `originalContributions` and 1 `keyInsight` about the abstract exponent-transport proof of λ(p·q) = lcm(λ(p), λ(q)).

Axiom integrity unchanged: `axiomCount: 0`, `sorries: 0`, `status: formalized`, `badge: wip` — all preserved.

## Validation
- Both `meta.json` and `annotations.json` parse as valid JSON.
- The gallery data-generation step (`pnpm build`'s enrichment pass) consumed the entry cleanly.
- Full `tsc`/`vite` build not run: this worktree's `pnpm install` aborts on a `better-sqlite3` native-compile failure under node v26 (environmental, unrelated to this data change). No TypeScript was touched.

## Test plan
- [ ] Deployer's docker build / site build confirms the entry renders with annotations