### PR TITLE
research(sum-of-kth-powers-oq-03): fix stray -/ in header docstring breaking compilation

### DIFF
--- a/proofs/Proofs/SumOfKthPowersOQ03.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ03.lean
@@ -28,7 +28,7 @@ the first `m` odds is `m²`, so
 Defining `T n` as the Gauss sum (rather than the closed form `n(n+1)/2`) sidesteps **all**
 ℕ-division and ℕ-subtraction. The whole proof uses only `ring` (valid on the ℕ semiring),
 `Finset.sum_range_succ`, `Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`, and one
-`Nat.add_left_cancel`. The triangular recurrence appears in the division-/subtraction-free form
+`Nat.add_left_cancel`. The triangular recurrence appears in the division-free, subtraction-free form
 `2·T i + i = i²` (`two_T_add`), proved by a one-line induction.
 
 ## Contents


### PR DESCRIPTION
## Summary

`proofs/Proofs/SumOfKthPowersOQ03.lean` (the combinatorial Nicomachus proof, registered in `Proofs.lean`) does not compile on `main`. Line 31 of the opening block comment reads:

```
... appears in the division-/subtraction-free form
```

The `-/` inside `division-/subtraction-free` prematurely terminates the `/- ... -/` header comment that opens at line 1. Everything after it (the rest of the prose, then `import` lines, etc.) is parsed as Lean source, yielding `unexpected identifier` / invalid-import errors. The file was authored and merged during the Docker + Aristotle verification blackout, so the deployer's build gate never caught it.

## Fix

Reword `division-/subtraction-free` → `division-free, subtraction-free`. Removes the stray `-/`; no `-/` substring remains anywhere in the prose. Comment-only — the proof body (0 axioms, 0 sorries) is untouched.

## Verification

- Docker still down this session (`docker info` times out), so no machine build. This is a mechanical comment fix: the premature terminator is removed, restoring a single well-formed header block comment.
- Confirmed no remaining mid-line `-/` in the file; the only `-/` occurrences are legitimate docstring/comment closers at end-of-line.
- The proof's arithmetic remains certified build-free by `research/problems/sum-of-kth-powers-oq-03/verify_div_free.py`.

Once Docker is back up, run `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` to confirm green and flip the gallery `meta.json` badge from `wip` to `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)