### PR TITLE
research(cube-root-3-irrational-oq-04): S26 — 20th CF convergent upper bound (a19=4)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -857,4 +857,55 @@ theorem one_five_nine_three_three_six_eight_three_seven_five_over_one_one_zero_f
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-! ## S26: twentieth CF convergent upper bound (`a₁₉ = 4`)
+
+The twentieth CF convergent of `∛3` (using `a₁₉ = 4` per a 320-digit CF
+recomputation, true prefix `a₀..a₁₉ =
+[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4]`, 0-indexed) is
+
+  `p₁₉/q₁₉ = (a₁₉·p₁₈ + p₁₇) / (a₁₉·q₁₈ + q₁₇)`
+  `       = (4 · 1593368375 + 383473988) / (4 · 1104779927 + 265886013)`
+  `       = 6_756_947_488 / 4_685_005_721`.
+
+This convergent is odd-index (19), so it lies on the UPPER side of `∛3`
+(alternating with the lower-side nineteenth convergent `1593368375/1104779927`,
+the eighteenth partial quotient `a₁₈ = 4`).
+
+Here `p₁₈/q₁₈ = 1593368375/1104779927` (the nineteenth convergent, lower, now on
+main) and `p₁₇/q₁₇ = 383473988/265886013` (the eighteenth convergent, upper) are
+the two prior rungs; this upper-bound theorem is self-contained — it is
+discharged purely by cubing the literal fraction, independent of the chain rungs.
+
+Convergent recursion (with `a₁₉ = 4`):
+
+  `q₁₉ = 4 · q₁₈ + q₁₇ = 4 · 1104779927 + 265886013 = 4_685_005_721`
+  `p₁₉ = 4 · p₁₈ + p₁₇ = 4 · 1593368375 + 383473988 = 6_756_947_488`
+
+After cubing,
+
+  `6_756_947_488³   = 308_497_487_520_026_079_326_651_318_272`
+  `3 · 4_685_005_721³ = 308_497_487_520_026_079_307_507_261_083`
+
+so `6_756_947_488³ = 308_497_487_520_026_079_326_651_318_272 >
+308_497_487_520_026_079_307_507_261_083 = 3 · 4_685_005_721³` (strict, diff
+`+19_144_057_189`), hence `(6_756_947_488/4_685_005_721)³ > 3` and
+`∛3 < 6_756_947_488/4_685_005_721` as required for an upper bound.
+
+`a₁₉ = 4` was re-derived independently from a 320-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s26_20th_convergent.py`), per the
+anti-typo discipline: never re-quote a prior sketch tail, always recompute `aᵢ`
+and verify the cube-side direction before claiming. Two-line proof via the
+cubing-iff helper. -/
+
+/-- `∛3 < 6756947488/4685005721`. Cube target:
+`(6756947488/4685005721)³ = 308_497_487_520_026_079_326_651_318_272 / 4685005721³
+> 3` (strict: `6756947488³ = 308_497_487_520_026_079_326_651_318_272 >
+308_497_487_520_026_079_307_507_261_083 = 3 · 4685005721³`, gap `19_144_057_189`).
+The twentieth convergent of the simple CF of `∛3` (using `a₁₉ = 4` per a
+320-digit CF recomputation). -/
+theorem cbrt3_lt_six_seven_five_six_nine_four_seven_four_eight_eight_over_four_six_eight_five_zero_zero_five_seven_two_one :
+    cbrt3 < (6756947488 / 4685005721 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/scripts/verify_cbrt3_oq04_s26_20th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s26_20th_convergent.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Certify the S26 twentieth-convergent UPPER bound for ∛3.
+
+Re-derives (does NOT plug in) the continued-fraction prefix of ∛3 to 320 digits,
+confirms a₁₉ = 4 and the twentieth convergent p₁₉/q₁₉ = 6756947488/4685005721,
+and verifies the exact integer cube inequality that the Lean theorem
+`cbrt3_lt_..._over_...` discharges by `norm_num`:
+
+    ∛3 < p/q   ⇔   3 < (p/q)³   ⇔   3·q³ < p³   (for p, q > 0).
+
+Exits non-zero on any mismatch.
+"""
+import sys
+
+from mpmath import mp, cbrt, floor
+
+mp.dps = 360
+x = cbrt(3)
+
+# Re-derive the simple continued fraction prefix a₀..a₁₉.
+a = []
+y = x
+for _ in range(20):
+    f = int(floor(y))
+    a.append(f)
+    y = 1 / (y - f)
+
+expected_prefix = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4]
+assert a == expected_prefix, f"CF prefix mismatch: {a} != {expected_prefix}"
+assert a[19] == 4, f"a19 expected 4, got {a[19]}"
+
+# Build convergents p_k/q_k from the a-sequence.
+p = [a[0], a[1] * a[0] + 1]
+q = [1, a[1]]
+for k in range(2, len(a)):
+    p.append(a[k] * p[-1] + p[-2])
+    q.append(a[k] * q[-1] + q[-2])
+
+# Twentieth convergent = index 19 (0-based). Odd index => UPPER side.
+P, Q = p[19], q[19]
+assert (P, Q) == (6756947488, 4685005721), f"20th convergent mismatch: {P}/{Q}"
+
+# Sanity: prior rungs match what the Lean file already contains.
+assert (p[18], q[18]) == (1593368375, 1104779927)  # 19th, lower, on main
+assert (p[17], q[17]) == (383473988, 265886013)    # 18th, upper
+
+# The exact inequality the Lean `norm_num` proves: 3·q³ < p³  (upper bound).
+P3 = P ** 3
+Q3 = 3 * Q ** 3
+assert P3 == 308497487520026079326651318272, P3
+assert Q3 == 308497487520026079307507261083, Q3
+assert P3 > Q3, "cube inequality failed: not an upper bound"
+gap = P3 - Q3
+assert gap == 19144057189, gap
+
+# Independent high-precision cross-check (float64 cannot resolve a ~1e-20 gap).
+from mpmath import mpf
+
+assert x < mpf(P) / mpf(Q), "high-precision check: bound is not above ∛3"
+
+print("OK: a19 = 4")
+print(f"OK: 20th convergent (upper) = {P}/{Q}")
+print(f"OK: {P}^3 = {P3}")
+print(f"OK: 3*{Q}^3 = {Q3}")
+print(f"OK: p^3 > 3 q^3 (upper bound), gap = +{gap}")
+sys.exit(0)


### PR DESCRIPTION
## Summary

Extends the continued-fraction convergent sandwich for ∛3 in `CubeRoot3IrrationalOQ04Helpers.lean` by one rung: adds the **20th convergent upper bound**

```
cbrt3 < 6756947488 / 4685005721
```

The 20th convergent has odd index (19) so it lies on the upper side, alternating with the 19th convergent lower bound `1593368375/1104779927` already on main (S25, #24556).

## Details

- Convergent recursion with `a₁₉ = 4`: `p₁₉ = 4·1593368375 + 383473988 = 6756947488`, `q₁₉ = 4·1104779927 + 265886013 = 4685005721`.
- Proof is **self-contained** — discharged purely by cubing the literal fraction via the existing `cbrt3_lt_iff_three_lt_cube` helper + `norm_num`, on the exact integer inequality `6756947488³ = 308497487520026079326651318272 > 308497487520026079307507261083 = 3·4685005721³` (gap `+19_144_057_189`). Independent of the still-open `a12` chain rungs (#23388/#23983) and the S23/S24 sibling helpers.
- Mirrors the established pattern of the 16th-convergent upper bound already in the file.
- 0 axioms / 0 sorries.

## Verification

- `a₁₉ = 4` and the convergent `6756947488/4685005721` were **re-derived independently** at 320 digits (not re-quoted from a prior sketch), per the anti-typo discipline (a8/a14 had typo history in earlier sessions).
- New durable cert `research/scripts/verify_cbrt3_oq04_s26_20th_convergent.py` re-derives the CF prefix, confirms the convergent, and checks the exact integer cube inequality + a high-precision bound-direction cross-check. Exits non-zero on any mismatch; **passes**.
- **Build-pending**: Docker outage this session (`docker info` times out), so no machine typecheck. The proof reuses the exact two-line pattern of the sibling upper-bound theorems in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)