### PR TITLE
research(lagrange-3sq-oq-03): prove residue-3 (mod 4) Dirichlet-witness obstruction

### DIFF
--- a/proofs/Proofs/ThreeSquaresWitnessObstruction.lean
+++ b/proofs/Proofs/ThreeSquaresWitnessObstruction.lean
@@ -1,0 +1,128 @@
+import Mathlib
+import Proofs.ThreeSquaresSufficiency
+
+/-!
+# The Dirichlet-witness obstruction at residue `3 (mod 4)`
+
+`Proofs.ThreeSquares` funnels the **entire** sufficiency direction of Legendre's
+three-square theorem through the single axiom
+
+    dirichlet_key_lemma {n d p} (hn : n > 1) (hd : d > 0) (hp : p = d * n - 1)
+        [Fact p.Prime] (hqr : legendreSym p (-d) = 1) :
+        ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = n          (ThreeSquares.lean:615)
+
+and `Proofs.ThreeSquaresSufficiency` isolates the remaining open content as the
+existence statement `ThreeSquares.DirichletWitnessProperty`: *for every*
+non-excluded `m` with `4 ∤ m` and `m > 1`, a witness `(d, p)` with `p = d·m − 1`
+prime and `legendreSym p (−d) = 1` exists.
+
+**This file proves that `DirichletWitnessProperty` is FALSE.**  Earlier sessions
+only *numerically* certified (`verify_three_squares_residue_routes.py`, audit PR
+#24529) that the witness is unsatisfiable for 4-free cores `m ≡ 3 (mod 8)`.  The
+real obstruction is sharper and is a *theorem*, proved here from quadratic
+reciprocity:
+
+> **`witness_obstruction_residue3`.**  If `m ≡ 3 (mod 4)`, `p ≠ 2` is prime, and
+> `p = d·m − 1` with `d > 0`, then `legendreSym p (−d) = −1`.
+
+The derivation: with `d·m = p + 1` one has `(−d)·m ≡ −1 (mod p)`, so
+`J(−d|p)·J(m|p) = J(−1|p) = χ₄ p`.  Reciprocity gives
+`J(m|p) = (−1)^{(m/2)(p/2)}·J(p|m)`, and `p ≡ −1 (mod m)` makes
+`J(p|m) = J(−1|m) = χ₄ m = −1` (since `m ≡ 3 mod 4`).  As `m/2` is odd, the sign
+collapses to `χ₄ p`, whence `J(m|p) = −χ₄ p` and `J(−d|p) = −1`.
+
+**Consequence.**  The single-`dirichlet_key_lemma` architecture cannot represent
+any non-excluded core `m ≡ 3 (mod 4)`; that class must instead be handled by the
+two-square route in `Proofs.ThreeSquaresResidue3` (`Nat.Prime.sq_add_sq`).  Thus
+the corrected sufficiency property must restrict the Dirichlet witness to
+`m % 4 ≠ 3` and dispatch `m % 4 = 3` separately.  The concrete falsity witness is
+`m = 11` (`= 3² + 1² + 1²`, non-excluded, `4 ∤ 11`), for which every prime
+`p = 11d − 1` is odd, so the obstruction applies and no witness exists.
+
+NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
+unavailable). Not registered in `Proofs.lean`; harmless to the build until a
+post-blackout session verifies it via `./proofs/scripts/docker-build.sh`.  All
+Mathlib bearers were name-checked against the pinned manifest rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+-/
+
+open ZMod
+
+namespace ThreeSquaresWitnessObstruction
+
+/-- **Witness obstruction at residue `3 (mod 4)`.**
+
+For `m ≡ 3 (mod 4)`, any odd prime `p = d·m − 1` (with `d > 0`) makes `−d` a
+quadratic *non*-residue mod `p`, i.e. `legendreSym p (−d) = −1`.  Hence the
+`dirichlet_key_lemma` witness `legendreSym p (−d) = 1` is unsatisfiable on this
+residue class. -/
+theorem witness_obstruction_residue3
+    {m d p : ℕ} (hm4 : m % 4 = 3) (hp2 : p ≠ 2) (hd : 0 < d)
+    (hpeq : p = d * m - 1) [Fact (Nat.Prime p)] :
+    legendreSym p (-(d : ℤ)) = -1 := by
+  have hpp : Nat.Prime p := Fact.out
+  have hm0 : 0 < m := by omega
+  have hp_odd : Odd p := hpp.odd_of_ne_two hp2
+  have hp_odd' : p % 2 = 1 := Nat.odd_iff.mp hp_odd
+  have hm_odd : Odd m := by rw [Nat.odd_iff]; omega
+  have hm2odd : (m / 2) % 2 = 1 := by omega
+  -- `d * m = p + 1`
+  have hmul : 0 < d * m := Nat.mul_pos hd hm0
+  have hdm : d * m = p + 1 := by omega
+  have hdmZ : (d : ℤ) * (m : ℤ) = (p : ℤ) + 1 := by exact_mod_cast hdm
+  -- `(-d) * m ≡ -1 (mod p)`, hence `J(-d|p) · J(m|p) = χ₄ p`
+  have hmod : (-((p : ℤ) + 1)) % (p : ℤ) = (-1 : ℤ) % (p : ℤ) := by
+    have h : (-((p : ℤ) + 1)) = -1 + (p : ℤ) * (-1) := by ring
+    rw [h, Int.add_mul_emod_self_left]
+  have key : jacobiSym (-(d : ℤ)) p * jacobiSym ((m : ℤ)) p = χ₄ (p : ZMod 4) := by
+    rw [← jacobiSym.mul_left]
+    rw [show (-(d : ℤ)) * (m : ℤ) = -((p : ℤ) + 1) from by linear_combination -hdmZ]
+    rw [jacobiSym.mod_left' hmod, jacobiSym.at_neg_one hp_odd]
+  -- `p ≡ -1 (mod m)`, hence `J(p|m) = J(-1|m) = χ₄ m = -1`
+  have hpmod : (p : ℤ) % (m : ℤ) = (-1 : ℤ) % (m : ℤ) := by
+    have h : (p : ℤ) = -1 + (m : ℤ) * (d : ℤ) := by linear_combination -hdmZ
+    rw [h, Int.add_mul_emod_self_left]
+  have hpm : jacobiSym ((p : ℤ)) m = -1 := by
+    rw [jacobiSym.mod_left' hpmod, jacobiSym.at_neg_one hm_odd, χ₄_nat_three_mod_four hm4]
+  -- the reciprocity sign `(-1)^{(m/2)(p/2)}` collapses to `χ₄ p` (since `m/2` is odd)
+  have hsign : ((-1 : ℤ)) ^ (m / 2 * (p / 2)) = χ₄ (p : ZMod 4) := by
+    rw [pow_mul, Odd.neg_one_pow (Nat.odd_iff.mpr hm2odd), χ₄_eq_neg_one_pow hp_odd']
+  -- `J(m|p) = -χ₄ p`
+  have hmp : jacobiSym ((m : ℤ)) p = -(χ₄ (p : ZMod 4)) := by
+    rw [jacobiSym.quadratic_reciprocity hm_odd hp_odd, hsign, hpm]; ring
+  -- combine: `J(-d|p) · (-χ₄ p) = χ₄ p` with `(χ₄ p)² = 1`
+  have hjval : jacobiSym (-(d : ℤ)) p * (-(χ₄ (p : ZMod 4))) = χ₄ (p : ZMod 4) := by
+    rw [← hmp]; exact key
+  have hc2 : χ₄ (p : ZMod 4) * χ₄ (p : ZMod 4) = 1 := by
+    rw [χ₄_eq_neg_one_pow hp_odd', ← pow_add]
+    exact (⟨p / 2, rfl⟩ : Even (p / 2 + p / 2)).neg_one_pow
+  rw [legendreSym.to_jacobiSym]
+  calc jacobiSym (-(d : ℤ)) p
+      = jacobiSym (-(d : ℤ)) p * (χ₄ (p : ZMod 4) * χ₄ (p : ZMod 4)) := by rw [hc2, mul_one]
+    _ = (jacobiSym (-(d : ℤ)) p * (-(χ₄ (p : ZMod 4)))) * (-(χ₄ (p : ZMod 4))) := by ring
+    _ = χ₄ (p : ZMod 4) * (-(χ₄ (p : ZMod 4))) := by rw [hjval]
+    _ = -(χ₄ (p : ZMod 4) * χ₄ (p : ZMod 4)) := by ring
+    _ = -1 := by rw [hc2]
+
+/-- **The Dirichlet witness property is false.**
+
+`ThreeSquares.DirichletWitnessProperty` claims a Dirichlet witness for *every*
+non-excluded `m` with `4 ∤ m` and `m > 1`.  But `m = 11` (`= 3² + 1² + 1²`, so
+non-excluded; `4 ∤ 11`) admits no witness: any prime `p = 11·d − 1` is odd, and
+`witness_obstruction_residue3` forces `legendreSym p (−d) = −1 ≠ 1`. -/
+theorem not_dirichletWitnessProperty : ¬ ThreeSquares.DirichletWitnessProperty := by
+  intro H
+  have h11sum : ∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = ((11 : ℕ) : ℤ) :=
+    ⟨3, 1, 1, by norm_num⟩
+  have hne : ¬ ThreeSquares.IsExcludedForm 11 :=
+    fun hx => ThreeSquares.excluded_form_not_sum_three_sq hx h11sum
+  have h4 : ¬ (4 ∣ 11) := by decide
+  obtain ⟨d, p, hd, hp, hpp, hqr⟩ := H (m := 11) hne h4 (by norm_num)
+  haveI : Fact (Nat.Prime p) := ⟨hpp⟩
+  have hp2 : p ≠ 2 := by intro h; subst h; omega
+  have hobs : legendreSym p (-(d : ℤ)) = -1 :=
+    witness_obstruction_residue3 (by norm_num) hp2 hd hp
+  rw [hobs] at hqr
+  norm_num at hqr
+
+end ThreeSquaresWitnessObstruction

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_witness_obstruction_residue3.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_witness_obstruction_residue3.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Certificate for the residue-3 (mod 4) Dirichlet-witness obstruction.
+
+The registered flagship `proofs/Proofs/ThreeSquares.lean` routes the ENTIRE
+sufficiency direction of Legendre's three-square theorem through the single
+axiom `dirichlet_key_lemma`, whose hypothesis is the witness
+
+    exists d > 0, p = d*m - 1 prime, legendreSym p (-d) = 1.
+
+`Proofs.ThreeSquaresSufficiency` isolates the open content as
+`DirichletWitnessProperty`: a witness exists for EVERY non-excluded m with
+4 doesnt-divide m and m > 1.
+
+This script certifies (build-free) the theorem proved in
+`proofs/Proofs/ThreeSquaresWitnessObstruction.lean`:
+
+  THEOREM.  If m == 3 (mod 4), p != 2 is prime, p = d*m - 1, d > 0, then
+            legendreSym p (-d) = -1.
+
+  COROLLARY.  DirichletWitnessProperty is FALSE (witness: m = 11).
+
+Two independent confirmations:
+
+  [A] Brute force: over all m == 3 (mod 4) and all valid (d, p) up to bounds,
+      legendreSym p (-d) is ALWAYS -1 (never 1).  Upgrades the earlier numerical
+      result (m == 3 mod 8, 0/750 -- audit PR #24529) to the full m == 3 mod 4
+      class.
+
+  [B] Step-by-step reciprocity identity, matching the Lean proof exactly:
+        (-d/p) = (-1/p) * (d/p)                    [multiplicativity]
+        (d/p)  = (m/p)            since d*m = p+1 ≡ 1 (mod p)
+        (m/p)  = (-1)^{(m/2)(p/2)} * (p/m)         [Jacobi reciprocity]
+        (p/m)  = (-1/m) = -1      since p ≡ -1 (mod m), m ≡ 3 (mod 4)
+        (-1)^{(m/2)(p/2)} = (-1)^{p/2} = (-1/p)    since m/2 is odd
+      ==> (-d/p) = (-1/p) * (m/p) = (-1/p) * (-(-1/p)) = -1.
+      Each intermediate Jacobi/Legendre symbol is recomputed and checked.
+
+  [C] Contrast: for the residues the witness CAN serve (m % 4 in {1, 2},
+      i.e. m % 8 in {1, 2, 5, 6}), a witness with value +1 is found, so the
+      obstruction is specific to m % 4 == 3.
+"""
+
+from sympy import isprime, jacobi_symbol
+
+
+def legendre_neg_d(d, p):
+    """legendreSym p (-d) for p an odd prime (Jacobi == Legendre here)."""
+    return jacobi_symbol((-d) % p, p)
+
+
+def check_A(m_bound=6000, d_bound=400):
+    bad = 0
+    tot = 0
+    for m in range(3, m_bound):
+        if m % 4 != 3:
+            continue
+        for d in range(1, d_bound):
+            p = d * m - 1
+            if p > 2 and isprime(p):
+                tot += 1
+                if legendre_neg_d(d, p) != -1:
+                    bad += 1
+                    if bad <= 5:
+                        print(f"  COUNTEREXAMPLE m={m} d={d} p={p}")
+    print(f"[A] m%4==3: legendreSym p(-d) == -1 for all valid (d,p): "
+          f"counterexamples={bad}/{tot}")
+    return bad == 0
+
+
+def check_B(m_bound=2000, d_bound=120):
+    """Verify each step of the reciprocity identity used by the Lean proof."""
+    mism = 0
+    tot = 0
+    for m in range(3, m_bound):
+        if m % 4 != 3:
+            continue
+        for d in range(1, d_bound):
+            p = d * m - 1
+            if not (p > 2 and isprime(p)):
+                continue
+            tot += 1
+            # primitive symbols
+            sym_neg_d = jacobi_symbol((-d) % p, p)        # (-d/p)
+            sym_neg1_p = jacobi_symbol((-1) % p, p)        # (-1/p)
+            sym_d_p = jacobi_symbol(d % p, p)              # (d/p)
+            sym_m_p = jacobi_symbol(m % p, p)              # (m/p)
+            sym_p_m = jacobi_symbol(p % m, m)              # (p/m)
+            sym_neg1_m = jacobi_symbol((-1) % m, m)        # (-1/m)
+            # step 1: (-d/p) = (-1/p)*(d/p)
+            s1 = (sym_neg_d == sym_neg1_p * sym_d_p)
+            # step 2: (d/p) = (m/p)   [d*m = p+1 ≡ 1 mod p]
+            s2 = (d * m) % p == 1 and (sym_d_p == sym_m_p)
+            # step 3: reciprocity (m/p) = (-1)^{(m//2)(p//2)} (p/m)
+            sign = (-1) ** ((m // 2) * (p // 2))
+            s3 = (sym_m_p == sign * sym_p_m)
+            # step 4: (p/m) = (-1/m) = -1
+            s4 = (p % m == (m - 1)) and (sym_p_m == sym_neg1_m) and (sym_neg1_m == -1)
+            # step 5: sign = (-1)^{p//2} = (-1/p)   [m//2 odd]
+            s5 = ((m // 2) % 2 == 1) and (sign == (-1) ** (p // 2)) \
+                and ((-1) ** (p // 2) == sym_neg1_p)
+            # conclusion
+            s6 = (sym_neg_d == -1)
+            if not (s1 and s2 and s3 and s4 and s5 and s6):
+                mism += 1
+                if mism <= 5:
+                    print(f"  STEP MISMATCH m={m} d={d} p={p}: "
+                          f"{s1=} {s2=} {s3=} {s4=} {s5=} {s6=}")
+    print(f"[B] reciprocity-identity steps verified: mismatches={mism}/{tot}")
+    return mism == 0
+
+
+def check_C():
+    samples = [1, 2, 5, 6, 9, 10, 13, 14, 17, 18, 21, 22]  # m%4 in {1,2}
+    ok = 0
+    for m in samples:
+        found = False
+        for d in range(1, 800):
+            p = d * m - 1
+            if p > 2 and isprime(p) and legendre_neg_d(d, p) == 1:
+                found = True
+                break
+        ok += found
+    print(f"[C] m%4 in {{1,2}}: witness with value +1 found for {ok}/{len(samples)} samples")
+    return ok == len(samples)
+
+
+def check_falsity_witness():
+    """m = 11 is the concrete falsifier used in `not_dirichletWitnessProperty`."""
+    m = 11
+    # non-excluded: 11 = 3^2 + 1^2 + 1^2
+    assert 3 ** 2 + 1 ** 2 + 1 ** 2 == m
+    assert m % 4 != 0
+    # no witness with value +1
+    found = any(
+        (p := d * m - 1) > 2 and isprime(p) and legendre_neg_d(d, p) == 1
+        for d in range(1, 5000)
+    )
+    print(f"[D] m=11 falsifier: non-excluded sum-of-3-squares, 4-free, "
+          f"witness-with-value-+1 exists = {found}")
+    return not found
+
+
+if __name__ == "__main__":
+    a = check_A()
+    b = check_B()
+    c = check_C()
+    d = check_falsity_witness()
+    print()
+    print("ALL CHECKS PASS" if (a and b and c and d) else "FAILURE")


### PR DESCRIPTION
## Summary

Proves the **residue-3 (mod 4) obstruction** to the single-`dirichlet_key_lemma`
architecture of the registered three-square flagship — upgrading a prior numerical
conjecture (m≡3 mod 8, 0/750; audit #24529) to a **theorem** over the full m≡3 mod 4 class.

New unregistered companion `proofs/Proofs/ThreeSquaresWitnessObstruction.lean`:

- **`witness_obstruction_residue3`** — for `m ≡ 3 (mod 4)`, `p ≠ 2` prime,
  `p = d·m − 1`, `d > 0`, proves `legendreSym p (−d) = −1` via quadratic reciprocity.
  Hence the `dirichlet_key_lemma` witness `legendreSym p (−d) = 1` is unsatisfiable there.
- **`not_dirichletWitnessProperty`** — proves `ThreeSquares.DirichletWitnessProperty`
  (the sole open input isolated by #24443) is **FALSE**, concrete falsifier `m = 11`
  (`= 3²+1²+1²`, non-excluded, `4 ∤ 11`; note `m=3` has a sneaky `p=2` witness so is avoided).

## Why this matters

`three_sq_of_dirichlet_witness` (ThreeSquaresSufficiency.lean) is a valid implication
but rests on a **provably false** hypothesis, so it can never discharge the sufficiency
axiom. The correct architecture splits at **m%4≠3 (Dirichlet-witness route)** vs
**m%4=3 (two-square route via `ThreeSquaresResidue3`, `Nat.Prime.sq_add_sq`)**.

## Verification

- **Build-pending** (Docker blackout: `docker ps` exit 124). Unregistered companion —
  harmless to the registered build until a post-blackout `docker-build.sh` run.
- Mathlib bearers name-checked against pinned manifest rev `2df2f01`
  (`legendreSym.to_jacobiSym`, `jacobiSym.{mul_left,mod_left',at_neg_one,quadratic_reciprocity}`,
  `ZMod.{χ₄_eq_neg_one_pow,χ₄_nat_three_mod_four}`, `Int.add_mul_emod_self_left`,
  `Odd/Even.neg_one_pow`).
- `verify_witness_obstruction_residue3.py`: 0/61399 brute-force counterexamples and
  0/7320 step-by-step reciprocity-identity mismatches (each Lean step independently rechecked).

## Status
**Outcome**: progress (axiom-architecture correction + new theorem; build-pending under blackout)
**Next Steps**: post-blackout build-verify; remaining open inputs are now two Dirichlet-primes-in-AP existence statements (m%4∈{1,2} witness; m%4=3 prime-deficit), neither provably false.

🤖 Generated by researcher-2