### PR TITLE
Enrich sum-of-kth-powers-oq-03: add annotations.json

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/annotations.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "sumkth-oq03-ann-idea",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 13, "endLine": 32 },
+    "type": "concept",
+    "title": "The odd-number tiling idea",
+    "content": "The module header lays out the combinatorial picture. Write the odd numbers 1, 3, 5, 7, … in order and group them as (1), (3,5), (7,9,11), …; the i-th group has i consecutive odds and sums to i³. The union of the first n groups is the first T(n+1) odds, whose sum is the perfect square (T(n+1))². The crucial design decision, explained here, is to define the position function T as a Gauss SUM rather than the closed form n(n+1)/2 — over ℕ this removes every truncated subtraction and floor-division, letting the whole proof close with `ring` on the ℕ semiring.",
+    "mathContext": "$\\sum_{i\\le n} i^3 = \\sum_{j<T(n+1)}(2j+1) = (T(n+1))^2 = \\big(\\sum_{i\\le n} i\\big)^2$, with $T(n)=\\sum_{i<n} i$.",
+    "significance": "context",
+    "relatedConcepts": ["squared triangular number", "Nicomachus's theorem", "figurate numbers", "ℕ semiring arithmetic"],
+    "prerequisites": ["finite sums", "triangular numbers"]
+  },
+  {
+    "id": "sumkth-oq03-ann-position-fn",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 61, "endLine": 73 },
+    "type": "definition",
+    "title": "The position function T as a Gauss sum",
+    "content": "`T n := ∑ i ∈ range n, i` is the running count of odd-number positions consumed by the cubes 0³,…,(n−1)³. Defining it as a sum (not n(n+1)/2) is what keeps the proof division- and subtraction-free. `T_zero` is `rfl`; `T_succ` (T(n+1) = T n + n) follows from `Finset.sum_range_succ`; `T_le_succ` records that the position blocks are non-overlapping (T is monotone in one step). These three facts are everything the later interval arguments need about T.",
+    "mathContext": "$T(0)=0$, $T(n+1)=T(n)+n$, $T(n)\\le T(n+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss sum", "triangular number", "Finset.range"],
+    "prerequisites": ["Finset.sum", "induction"]
+  },
+  {
+    "id": "sumkth-oq03-ann-sum-odds",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 75, "endLine": 79 },
+    "type": "technique",
+    "title": "L1: the sum of the first m odds is m²",
+    "content": "`sum_odds` proves the classical identity ∑_{j<m}(2j+1) = m² by induction: the step peels off the top term with `Finset.sum_range_succ` and closes with `ring` (k² + (2k+1) = (k+1)²). This is the global statement about odds; the block lemma below is its 'local' interval version. It is applied twice in `block_eq_cube` (at the two endpoints) and once at the very end of the main theorem.",
+    "mathContext": "$\\sum_{j<m}(2j+1) = m^2$ — the running sum of consecutive odd numbers is a perfect square.",
+    "significance": "key",
+    "relatedConcepts": ["sum of odd numbers", "perfect squares", "induction"],
+    "prerequisites": ["induction over ℕ", "Finset.sum_range_succ"]
+  },
+  {
+    "id": "sumkth-oq03-ann-two-T-add",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 81, "endLine": 89 },
+    "type": "technique",
+    "title": "The division-free triangular recurrence 2·T i + i = i²",
+    "content": "`two_T_add` is the one arithmetic fact the block identity rests on. The usual triangular identity T i = i(i+1)/2 involves division; multiplying through and rearranging gives the equivalent 2·T i + i = i², which lives entirely in the ℕ semiring with no division or subtraction. The proof is a one-line induction using `T_succ` and `ring`. This reformulation is the technical heart of why the whole file avoids ℕ-subtraction pitfalls.",
+    "mathContext": "$2T(i)+i = i^2$, the multiplied-out form of $T(i)=\\tfrac{i(i+1)}{2}$ (equivalently $T(i)=\\tfrac{i^2-i}{2}$) with no division.",
+    "significance": "key",
+    "relatedConcepts": ["triangular number recurrence", "ℕ semiring", "avoiding truncated subtraction"],
+    "prerequisites": ["induction", "ring tactic on ℕ"]
+  },
+  {
+    "id": "sumkth-oq03-ann-block-sq",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "insight",
+    "title": "Block-square identity: T i² + i³ = T(i+1)²",
+    "content": "`block_sq` is the algebraic core 'each odd block contributes one cube'. Morally it is the telescoping fact T(i+1)² − T i² = i³, but stating it additively as T i² + i³ = T(i+1)² dodges the ℕ-subtraction the difference form would force. The proof is a 3-step `calc`: rewrite i³ = i²·i, substitute i² = 2·T i + i via `two_T_add`, and let `ring` recognize the result as (T i + i)² = T(i+1)². No special identities beyond the triangular recurrence are needed.",
+    "mathContext": "$T(i)^2 + i^3 = T(i+1)^2$, i.e. $T(i+1)^2 - T(i)^2 = i^3$ written without subtraction.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "difference of squares", "triangular recurrence"],
+    "prerequisites": ["ring tactic", "algebraic manipulation over ℕ"]
+  },
+  {
+    "id": "sumkth-oq03-ann-block-eq-cube",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 101, "endLine": 116 },
+    "type": "concept",
+    "title": "L2: the i-th odd block sums to i³",
+    "content": "`block_eq_cube` realizes the cube as a contiguous block of odds: ∑_{T i ≤ j < T(i+1)}(2j+1) = i³. The proof concatenates the initial segment [0, T i) with the block [T i, T(i+1)) to recover [0, T(i+1)) using `Finset.sum_Ico_consecutive` (with `Finset.range_eq_Ico` to switch range↔Ico). Applying `sum_odds` to both endpoints turns this into T i² + block = T(i+1)²; comparing with `block_sq` (T i² + i³ = T(i+1)²) and cancelling the common T i² via `Nat.add_left_cancel` yields block = i³ — again with no subtraction.",
+    "mathContext": "$\\sum_{T(i)\\le j<T(i+1)}(2j+1) = T(i+1)^2 - T(i)^2 = i^3$.",
+    "significance": "key",
+    "relatedConcepts": ["interval sums", "Finset.sum_Ico_consecutive", "cancellation law"],
+    "prerequisites": ["Finset.Ico", "half-open interval sums"]
+  },
+  {
+    "id": "sumkth-oq03-ann-tiling",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 118, "endLine": 127 },
+    "type": "concept",
+    "title": "L3: the blocks tile the first T n odds",
+    "content": "`tiling` shows the n position-blocks fit together with no gaps or overlaps: ∑_{i<n}(block i) = ∑_{j<T n}(2j+1). The induction step extends the running interval [0, T k) by the next block [T k, T(k+1)) using `Finset.sum_Ico_consecutive` once more — the same concatenation lemma that powered `block_eq_cube`, here driving the assembly rather than a single block. This is the combinatorial 'partition' statement underlying the whole proof.",
+    "mathContext": "$\\sum_{i<n}\\Big(\\sum_{T(i)\\le j<T(i+1)}(2j+1)\\Big) = \\sum_{j<T(n)}(2j+1)$ — the blocks partition $[0,T(n))$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partition of an interval", "telescoping concatenation", "induction"],
+    "prerequisites": ["Finset.sum_Ico_consecutive", "induction over ℕ"]
+  },
+  {
+    "id": "sumkth-oq03-ann-main",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 129, "endLine": 142 },
+    "type": "concept",
+    "title": "Nicomachus's theorem assembled",
+    "content": "`sum_cubes_eq_sum_squared_via_odds` chains L1–L3. First `Finset.sum_congr` rewrites each i³ as its block via `block_eq_cube`; then `tiling` collapses the sum of blocks to ∑_{j<T(n+1)}(2j+1); then `sum_odds` evaluates that to (T(n+1))². The closing `rfl` is the elegant finish: T(n+1) is definitionally ∑ i ∈ range (n+1), i, so the result lands exactly on the parent's right-hand side (∑_{i≤n} i)² with no further rewriting. The whole identity is proved without ever leaving the ℕ semiring.",
+    "mathContext": "$\\sum_{i\\le n} i^3 = \\sum_{j<T(n+1)}(2j+1) = (T(n+1))^2 = \\big(\\sum_{i\\le n} i\\big)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Nicomachus's theorem", "squared triangular number", "definitional equality (rfl)"],
+    "prerequisites": ["Finset.sum_congr", "the supporting lemmas L1–L3"]
+  }
+]


### PR DESCRIPTION
## Summary
Enrichment pass for `sum-of-kth-powers-oq-03` (Nicomachus via the odd-number partition of cubes). The entry had **only meta.json**, so the inline-annotation quality components scored 0. This PR adds a complete `annotations.json`.

- 8 annotations spanning the whole proof of `SumOfKthPowersOQ03.lean`: the tiling idea, the Gauss-sum position function `T`, `sum_odds` (L1), the division-free recurrence `two_T_add`, `block_sq`, `block_eq_cube` (L2), `tiling` (L3), and the assembled `sum_cubes_eq_sum_squared_via_odds`.
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; line ranges target the displayed Lean source.
- meta.json was already rich (overview, sections, conclusion, crossReferences) and is left untouched; no content deleted.

`axiomCount: 0` / `status: formalized` / `badge: wip` verified accurate against the Lean file (0 axioms, 0 sorries, build-pending; no structure-encoded assumptions). JSON validated (parses; 8 annotations).

Independent of the in-flight research PR #24603, which edits the `.lean` source only.

## Test plan
- [x] annotations.json + meta.json parse as valid JSON