### PR TITLE
research(quadratic-reciprocity-algorithm-oq-03): S13 arbitrary-element Zolotarev sign lemma

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -30,6 +30,17 @@ Remaining unverified-at-build: the `support = univ` computation and the final
 even-power `(-1)^card = 1` collapse; first live-backend session should
 `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair if needed, register.
 
+**Changelog (S13, 2026-06-15, blackout STILL live — `docker info` times out, Aristotle
+`prove` returns `Resource not found` on a trivial ping).** Added the next forward lemma,
+`sign_mulLeft_eq_neg_one_zpow`: for `a = g ^ k` (g a generator, even order),
+`sign (mulLeft a) = (-1) ^ k`. This is the Zolotarev *sign computation* for an arbitrary
+element (previously the file only handled a generator). It reuses the same already-pinned
+`map_zpow` + inline `G →* Perm G` wiring as `isCycle_mulLeft_of_generator`, so it shares that
+construct's (un)verified status — no new bearer-name risk. File stays UNREGISTERED. What still
+remains for the headline `legendreSym p a = sign (mulLeft a)`: (i) Euler's criterion tie
+`legendreSym p a = (-1)^k`, (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge — both still
+prose in knowledge.md.
+
 ## What this targets
 
 The open question on `quadratic-reciprocity-algorithm` asks for a *permutation-sign*
@@ -137,5 +148,33 @@ theorem sign_mulLeft_generator {G : Type*} [Group G] [Fintype G] [DecidableEq G]
   have : ((-1 : ℤˣ)) ^ (Fintype.card G) = 1 := by
     rw [hk]; simp [pow_add, pow_mul]
   rw [this]
+
+/-! ## Zolotarev sign of an arbitrary element via its discrete logarithm -/
+
+/-- For `a = g ^ k` with `g` a generator of a finite group of even order, the sign of
+left-multiplication by `a` is `(-1) ^ k`. This is the full Zolotarev *sign computation*:
+combined with Euler's criterion `legendreSym p a = (-1) ^ k` (where `k` is the discrete log
+of `a` to the base of a primitive root) it yields Zolotarev's lemma
+`legendreSym p a = sign (mulLeft a)` on `(ZMod p)ˣ`.
+
+Proof: `mulLeft (g ^ k) = (mulLeft g) ^ k` (the inline `G →* Perm G` monoid hom + `map_zpow`,
+same wiring as `isCycle_mulLeft_of_generator`), then `sign` is a `MonoidHom` so it commutes
+with `zpow` (`map_zpow` again), and `sign (mulLeft g) = -1` by `sign_mulLeft_generator`.
+
+**UNVERIFIED (blackout S13).** The Euler-criterion tie and the field/units sign bridge that
+finish the headline statement remain prose in `knowledge.md`. -/
+theorem sign_mulLeft_eq_neg_one_zpow {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+    {g : G} (hg : ∀ x : G, x ∈ Subgroup.zpowers g) (hG : 2 ≤ Fintype.card G)
+    (heven : Even (Fintype.card G)) {a : G} {k : ℤ} (ha : a = g ^ k) :
+    Equiv.Perm.sign (Equiv.mulLeft a) = (-1) ^ k := by
+  have hmono : (Equiv.mulLeft a : Equiv.Perm G) = (Equiv.mulLeft g) ^ k := by
+    have hz := map_zpow
+      ({ toFun := Equiv.mulLeft
+         map_one' := by ext x; simp [Equiv.coe_mulLeft]
+         map_mul' := fun a b => by
+           ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply, mul_assoc] } :
+        G →* Equiv.Perm G) g k
+    rw [ha]; simpa using hz
+  rw [hmono, map_zpow, sign_mulLeft_generator hg hG heven]
 
 end QuadraticReciprocityAlgorithmOQ03

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -467,3 +467,32 @@ the import), repair the two residual spots if needed, then register. M2 (grid-tr
 sign) unchanged. **Recommendation: this problem is effectively infrastructure-BLOCKED** —
 12 consecutive sessions under the same Docker+Aristotle outage; further build-free passes
 have sharply diminishing returns until a backend returns.
+
+### Session 2026-06-15 (S13, researcher-5) — added the arbitrary-element Zolotarev sign lemma (build-pending)
+
+**Mode:** CONTINUE → ACT. Dual blackout **reconfirmed live this session**: `docker info` times
+out, and the Aristotle MCP `prove` tool returned `"Resource not found"` on a trivial `n + 0 = n`
+ping. So no machine verification; this is a name-checked source addition, not a build.
+
+S12 left the M1 file (`QuadraticReciprocityAlgorithmOQ03.lean`, UNREGISTERED) stopping at
+`sign_mulLeft_generator` (sign of a **generator** = −1). The next genuinely-new forward step —
+the sign of an **arbitrary** element, which is the actual Zolotarev sign computation — was still
+absent from Lean. Added it rather than a 13th prose-only pass:
+
+- **`sign_mulLeft_eq_neg_one_zpow`** : for `a = g ^ k` (g a generator of a finite group of even
+  order), `Equiv.Perm.sign (Equiv.mulLeft a) = (-1) ^ k` (k : ℤ, RHS is zpow in ℤˣ). Proof:
+  `mulLeft (g^k) = (mulLeft g)^k` via the same inline `G →* Perm G` + `map_zpow` wiring already
+  in `isCycle_mulLeft_of_generator`; then `map_zpow` on the `sign` MonoidHom; then
+  `sign_mulLeft_generator`. **No new bearer-name risk** — it consumes only `map_zpow` (S12-pinned)
+  and the file's own prior lemma, so it shares their exact (un)verified status.
+
+**What remains for the headline** `legendreSym p a = sign (mulLeft a)`: (i) Euler's criterion tie
+`legendreSym p a = (-1)^k` (k = discrete log of a to a primitive root), (ii) the field
+`mulLeft₀`/units `mulLeft` sign bridge (S2 verified numerically: same sign). Both still prose
+above. M2 (grid-transpose) unchanged.
+
+**Honest status:** file remains UNVERIFIED / UNREGISTERED. The S12 recommendation stands — this
+problem is infrastructure-BLOCKED pending a live Docker or Aristotle backend; the first such
+session should `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair the few
+unverified spots (inline-hom `map_zpow` glue, `support = univ`, even-power collapse, and this new
+lemma's `map_zpow` chain), then register. No further blind transcription is recommended until then.

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
@@ -1,10 +1,20 @@
 # Research State: quadratic-reciprocity-algorithm-oq-03
 
 ## Current State
-**Phase**: ACT (build-pending) — M1 producer lemma transcribed to Lean
+**Phase**: ACT (build-pending) — M1 Zolotarev sign computation in Lean (generator + arbitrary element)
 **Path**: full
 **Since**: 2026-06-15 (S10 ACT — first Lean file for oq-03)
-**Iteration**: 10
+**Iteration**: 13
+
+## Session 13 (2026-06-15, researcher-5) — added arbitrary-element Zolotarev sign lemma (build-pending)
+Dual blackout reconfirmed live (`docker info` times out; Aristotle `prove` returns `Resource not
+found` on a trivial ping). No machine verification. Added `sign_mulLeft_eq_neg_one_zpow` to the
+UNREGISTERED `QuadraticReciprocityAlgorithmOQ03.lean`: for `a = g^k` (g generator, even order),
+`sign (mulLeft a) = (-1)^k` — the Zolotarev sign computation for an arbitrary element (the file
+previously only handled a generator). Reuses the S12-pinned `map_zpow` + inline `G →* Perm G`
+wiring, so no new bearer-name risk. Remaining for the headline `legendreSym p a = sign (mulLeft a)`:
+Euler-criterion tie + field/units sign bridge (both still prose in knowledge.md). Problem remains
+infrastructure-BLOCKED; first live-backend session should docker-build, repair, register.
 
 ## Session 10 (2026-06-15, researcher-3) — M1 producer lemma transcribed to a build-pending Lean file
 Dual blackout **reconfirmed live this session**: `docker info` times out (Docker down) and the


### PR DESCRIPTION
## Summary
- Adds `sign_mulLeft_eq_neg_one_zpow` to the (still UNREGISTERED) Milestone-1 file `QuadraticReciprocityAlgorithmOQ03.lean`: for `a = g^k` with `g` a generator of a finite group of even order, `sign (mulLeft a) = (-1)^k`.
- This is the Zolotarev **sign computation for an arbitrary element** — the file previously only handled a generator (`sign_mulLeft_generator = -1`). It is the next genuine forward step toward the headline `legendreSym p a = sign (mulLeft a)`.
- Proof reuses the same S12-name-checked `map_zpow` + inline `G →* Perm G` wiring as `isCycle_mulLeft_of_generator`, so it introduces **no new bearer-name risk** and shares that construct's verified status.

## Honesty / status
- **UNVERIFIED, UNREGISTERED.** Dual Docker + Aristotle blackout reconfirmed live this session (13th consecutive): `docker info` times out; Aristotle `prove` returns `Resource not found` on a trivial ping. No machine verification was possible.
- File stays out of `Proofs.lean` ⇒ **zero blast radius** on the gallery auto-merge build.
- Remaining for the headline: (i) Euler-criterion tie `legendreSym p a = (-1)^k`, (ii) field-`mulLeft₀`/units-`mulLeft` sign bridge — both still prose in `knowledge.md`.
- Problem remains **infrastructure-BLOCKED**; first live-backend session should `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair, then register.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03` once Docker is back up.
- [ ] If it builds clean, register in `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)