### PR TITLE
Enrich euler-totient-oq-01-oq-03: add missing index.ts

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-03/index.ts
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOQ01OQ03Data: ProofData = {
+  proof: eulerTotientOQ01OQ03Proof,
+  annotations: eulerTotientOQ01OQ03Annotations,
+}


### PR DESCRIPTION
## Summary
The gallery entry `euler-totient-oq-01-oq-03` (Verified RSA Correctness with Carmichael's λ(n)) had `meta.json` and `annotations.json` on main but **no `index.ts`**. Without it, Vite's `import.meta.glob` cannot discover the proof and the page renders **"proof not found"** on the live site.

This PR adds the standard `index.ts` wired to the existing `meta.json`, `annotations.json`, and the Lean source `Proofs/EulerTotientOQ01OQ03.lean`.

## Notes
- Annotations (9, full file coverage incl. the Carmichael bridge) and meta sections/counts are already complete on main — untouched here.
- Single-file change; data-gen JSON validation passes locally (tsc/vite skipped: no node_modules in worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)