### PR TITLE
Enrich law-of-cosines-oq-04-oq-01 (Stewart via Inner Products): add annotations + conclusion

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-setup-inner-product-space",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "context",
+    "title": "Ambient: an arbitrary real inner product space",
+    "content": "The whole development is parameterized over an unspecified real inner product space V, fixed only as a NormedAddCommGroup carrying an InnerProductSpace ℝ structure. No dimension, basis, or coordinate system is ever chosen. This is the structural move that distinguishes the entry from the scalar parent law-of-cosines-oq-04, where the vertices A, B, C never appear as geometric objects at all: here they are honest points of V, lengths are honest norms, and the law of cosines is available as the polarization identity ‖x‖² = ⟪x, x⟫ rather than assumed as a hypothesis.",
+    "mathContext": "$V$ a real inner product space, $\\langle\\,\\cdot\\,,\\cdot\\,\\rangle : V\\times V \\to \\mathbb{R}$ symmetric bilinear with $\\lVert x\\rVert^2 = \\langle x, x\\rangle$.",
+    "significance": "context",
+    "relatedConcepts": ["inner product space", "norm from inner product", "coordinate-free geometry"],
+    "prerequisites": ["linear algebra", "real inner product spaces"]
+  },
+  {
+    "id": "ann-bilinear-expansion",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 48, "endLine": 55 },
+    "type": "technique",
+    "title": "Bilinear norm expansion: the algebraic engine",
+    "content": "norm_smul_add_smul_sq expands the squared norm of a linear combination of two vectors. It is the single computational lemma every later result is reduced to. The proof rewrites with norm_add_sq_real (the law of cosines for ‖u+v‖²), pulls the scalars out with real_inner_smul_left/right and norm_smul, then finishes with ring. Because the scalars p, q are kept symbolic, every specialization (s, 1/2, the bisector ratio) is just a substitution into this one identity.",
+    "mathContext": "$\\lVert p\\,u + q\\,v\\rVert^2 = p^2\\lVert u\\rVert^2 + q^2\\lVert v\\rVert^2 + 2pq\\,\\langle u, v\\rangle.$",
+    "significance": "key",
+    "relatedConcepts": ["bilinearity", "polarization identity", "law of cosines"],
+    "prerequisites": ["real inner product spaces", "norm_add_sq_real"]
+  },
+  {
+    "id": "ann-master-identity",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "insight",
+    "title": "Coordinate-free Stewart identity (master result)",
+    "content": "stewart_cevian_inner is the heart of the file. The cevian foot is the affine combination D = (1−s)·B + s·C, so the displacement decomposes as A − D = (1−s)(A−B) + s(A−C) (proved by the module tactic), and the opposite side as B − C = (A−C) − (A−B). Substituting both into the bilinear engine and calling ring yields the squared cevian length directly. The result is valid in any dimension — planar triangle, spatial tetrahedron cevian, or higher — with no collinearity or sign hypotheses, because the affine encoding makes the segment relation hold by construction.",
+    "mathContext": "$\\lVert A-D\\rVert^2 = (1-s)\\lVert A-B\\rVert^2 + s\\lVert A-C\\rVert^2 - s(1-s)\\lVert B-C\\rVert^2,\\quad D=(1-s)B+sC.$",
+    "significance": "key",
+    "relatedConcepts": ["Stewart's theorem", "cevian", "affine combination", "dimension-free geometry"],
+    "prerequisites": ["real inner product spaces", "affine combinations", "Lean module tactic"]
+  },
+  {
+    "id": "ann-classical-form",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 76, "endLine": 88 },
+    "type": "concept",
+    "title": "Recovering the classical b²m + c²n = a(d² + mn)",
+    "content": "stewarts_theorem_inner specializes the master identity to Stewart's 1746 form by naming a = ‖B−C‖, m = s·a, n = (1−s)·a, b = ‖A−C‖, c = ‖A−B‖, d = ‖A−D‖. After rewriting with the master identity and a = ‖B−C‖, the whole equality closes by ring. The companion lemma stewart_m_add_n records that m + n = a holds automatically — a fact the scalar derivation has to assume as a side condition, but which is free here because the foot is an affine combination of the endpoints.",
+    "mathContext": "$b^2 m + c^2 n = a(d^2 + mn),\\quad a=\\lVert B-C\\rVert,\\ m=sa,\\ n=(1-s)a,\\ m+n=a.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Stewart's theorem", "cevian length", "mnemonic 'a man and his dad put a bomb in the sink'"],
+    "prerequisites": ["Stewart's theorem statement"]
+  },
+  {
+    "id": "ann-apollonius-median",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 90, "endLine": 99 },
+    "type": "insight",
+    "title": "Apollonius' median theorem as the s = 1/2 case",
+    "content": "apollonius_median_inner is literally the master identity at s = 1/2: the cevian foot becomes the midpoint of BC. The proof instantiates stewart_cevian_inner at 1/2, simplifies 1 − 1/2 = 1/2, and finishes with ring. The resulting median-length law ‖A − midpoint(B,C)‖² = ½‖A−B‖² + ½‖A−C‖² − ¼‖B−C‖² is exactly Apollonius' theorem, here obtained with no new geometric work — only a numerical specialization.",
+    "mathContext": "$\\lVert A-\\tfrac{B+C}{2}\\rVert^2 = \\tfrac12\\lVert A-B\\rVert^2 + \\tfrac12\\lVert A-C\\rVert^2 - \\tfrac14\\lVert B-C\\rVert^2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Apollonius' theorem", "median length", "parallelogram law", "midpoint"],
+    "prerequisites": ["Stewart's theorem"]
+  },
+  {
+    "id": "ann-angle-bisector",
+    "proofId": "law-of-cosines-oq-04-oq-01",
+    "range": { "startLine": 101, "endLine": 122 },
+    "type": "insight",
+    "title": "Internal angle-bisector length, in cleared form",
+    "content": "angle_bisector_length_inner is the case where the foot divides BC in the ratio BD:DC = c:b, encoded by the hypothesis hs: s·(‖A−C‖ + ‖A−B‖) = ‖A−B‖. After rewriting with the master identity, the goal is closed by a single linear_combination whose coefficient on hs is engineered to cancel the residual. The conclusion is stated in (b+c)²-cleared form to avoid division. A deliberate honesty note: hs only asserts the *segment* ratio; that this ratio is the one the actual angle bisector realizes (equal angles at A) is a separate geometric fact the file does not claim to prove.",
+    "mathContext": "$(b+c)^2\\lVert A-D\\rVert^2 = bc\\,((b+c)^2 - a^2),\\quad b=\\lVert A-C\\rVert,\\ c=\\lVert A-B\\rVert,\\ a=\\lVert B-C\\rVert.$",
+    "significance": "key",
+    "relatedConcepts": ["angle bisector length", "Stewart's theorem", "angle bisector theorem", "linear_combination tactic"],
+    "prerequisites": ["Stewart's theorem", "angle bisector theorem", "Lean linear_combination tactic"]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
@@ -87,5 +87,31 @@
       "endLine": 130,
       "summary": "angle_bisector_length_inner: for the foot dividing BC in ratio c:b, (b+c)²‖A−D‖² = bc((b+c)² − a²)."
     }
+  ],
+  "conclusion": {
+    "summary": "Starting from a single bilinear lemma (the squared norm of a linear combination of two vectors), the entry establishes Stewart's theorem as a coordinate-free identity in an arbitrary real inner product space. The master identity ‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖², with the cevian foot encoded as the affine combination D = (1−s)·B + s·C, specializes by substitution to the classical form b²m + c²n = a(d² + mn), to Apollonius' median theorem (s = 1/2), and to the internal angle-bisector length formula (the c:b segment ratio).",
+    "implications": "Grounding Stewart's theorem in genuine inner-product geometry removes the side conditions that the scalar law-of-cosines derivation must carry. The segment relation m + n = a holds by construction rather than as a collinearity/sign hypothesis, and the abstract cosine parameter t of the parent entry is exposed as the real inner product ⟪A−B, A−C⟫. Because nothing depends on dimension, the same identity covers planar triangles, spatial-tetrahedron cevians, and arbitrary-dimensional configurations — a single algebraic fact replacing a family of case-specific geometric arguments. This is a model for how classical metric geometry lifts to inner-product spaces: the law of cosines becomes the polarization identity, and cevian results become substitutions into one bilinear expansion.",
+    "openQuestions": [
+      "Can the angle-bisector specialization be completed by proving that the segment ratio BD:DC = c:b is exactly the one realized by the true angle bisector (equal angles at A), so the formula attaches to the genuine bisector rather than to a hypothesized foot?",
+      "Does the same affine-combination encoding give a clean coordinate-free treatment of the generalized (mass-point / barycentric) Stewart relations, or of concurrent cevians (Ceva/Routh-type identities)?",
+      "Over a complex inner product space, does the bilinear engine extend with the appropriate Hermitian polarization, or does the loss of symmetry ⟪u,v⟫ ≠ ⟪v,u⟫ obstruct the ring-level closure?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines-oq-04",
+      "relationship": "scalar-counterpart",
+      "description": "The parent entry derives Stewart's theorem at the scalar level, taking the two law-of-cosines equations for the sub-triangles as hypotheses with an abstract cosine parameter $t$. This entry replaces $t$ by the genuine inner product $\\langle A-B,\\,A-C\\rangle$ and the vertices by points of a real inner product space, so the result becomes a single bilinear identity instead of an algebraic elimination."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "foundational-tool",
+      "description": "The law of cosines $c^2 = a^2 + b^2 - 2ab\\cos C$ appears here not as a hypothesis but as the polarization identity $\\lVert u-v\\rVert^2 = \\lVert u\\rVert^2 + \\lVert v\\rVert^2 - 2\\langle u,v\\rangle$, the special case of the bilinear expansion that powers the master identity."
+    },
+    {
+      "targetId": "law-of-cosines-oq-04-oq-02",
+      "relationship": "shared-corollary",
+      "description": "The angle-bisector length formula is developed as its own entry from the scalar Stewart's theorem; here the same formula $(b+c)^2\\lVert A-D\\rVert^2 = bc((b+c)^2 - a^2)$ is obtained as a direct specialization of the coordinate-free master identity."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass for `law-of-cosines-oq-04-oq-01` (Stewart's Theorem via Inner Products)

The entry shipped with only `meta.json` (quality 30, 0 passes). This pass fills the gaps without touching the Lean source.

### Added
- **`annotations.json` (new, 6 annotations)** covering all five parts of the proof — inner-product setup, bilinear norm expansion, the coordinate-free master identity, the classical `b²m + c²n = a(d² + mn)` form, Apollonius' median theorem (`s = 1/2`), and the cleared-form angle-bisector length. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **`conclusion`** in `meta.json`: summary, implications, and 3 genuine open questions (true-bisector ratio justification, barycentric/Ceva-Routh generalization, complex/Hermitian extension).
- **`crossReferences`**: to `law-of-cosines-oq-04` (scalar counterpart), `law-of-cosines` (foundational tool / polarization identity), and `law-of-cosines-oq-04-oq-02` (shared angle-bisector corollary).

### Integrity
No changes to `status`/`badge`/`axiomCount`. The file remains `badge: wip`, `status: formalized`, 0 axioms / 0 sorries, build-pending per the existing meta note.

### Verification
JSON validated with `JSON.parse` for both files. Full `pnpm build` not run — the worktree has no `node_modules` (and its data-gen step rewrites ~1300 unrelated entries); structural validity confirmed instead.