### PR TITLE
research(greens-theorem-oq-02-oq-02): add gallery entry for orientation-corrected axiom

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "ann-greens-oq0202-corrected-axiom",
+    "proofId": "greens-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 72
+    },
+    "type": "axiom",
+    "title": "Orientation-Corrected Axiom",
+    "content": "`greens_theorem_l1curl_oriented` is the registered `greens_theorem_l1curl` plus ONE extra hypothesis `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`.\n\nThe registered axiom ties the Lipschitz curve to the rectangle only by `hTraversal` (the curve's image lies in the frontier), which constrains neither orientation nor winding nor non-degeneracy — and is therefore FALSE (a constant curve refutes it). `hLineEq` fixes the boundary orientation by equating the circulation with the concrete, correctly-oriented four-edge rectangle integral from OQ-01, excluding the degenerate/wrongly-oriented curves.",
+    "mathContext": "Adds $\\oint_C(P\\,dx+Q\\,dy) = \\text{rectLineIntegral}\\,P\\,Q\\,a\\,b\\,c\\,d$ to the minimal-regularity Green's identity, restoring soundness.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Green's theorem",
+      "Boundary orientation",
+      "Axiom integrity"
+    ],
+    "prerequisites": [
+      "Lipschitz curves and line integrals"
+    ]
+  },
+  {
+    "id": "ann-greens-oq0202-consumers",
+    "proofId": "greens-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 172
+    },
+    "type": "theorem",
+    "title": "Re-threaded Consumers (Signature-Only Change)",
+    "content": "All five downstream consumers of the axiom are re-proved with the new `hLineEq` argument threaded through, each proof identical to the original plus the single extra hypothesis: `lineIntegral_zero_curl_oriented`, `lineIntegral_l1curl_smul_oriented`, `greens_oq1_from_l1curl_oriented` (mirroring `GreensTheoremOQ02`), and `greens_stokes_l1curl_oriented`, `closed_l1form_zero_integral_oriented` (mirroring `GreensTheoremOQ02OQ04`).\n\nThis confirms the correction is a pure signature-threading change: no consumer's mathematics is altered. It is the build-ready blueprint for porting the fix back onto the two registered files as a single Docker-verified patch.",
+    "mathContext": "Zero-curl ⇒ zero circulation; scaling invariance; OQ-01 recovery; Stokes form; closed-form vanishing — all carry the extra orientation hypothesis unchanged.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Signature threading",
+      "Blast radius",
+      "Coordinated refactor"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-greens-oq0202-excision",
+    "proofId": "greens-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 174,
+      "endLine": 182
+    },
+    "type": "theorem",
+    "title": "Counterexample Provably Excised",
+    "content": "`counterexample_violates_hLineEq` proves the Session-5 unsound witness — the constant curve with `P = 0`, `Q(x,y) = x` — fails the new orientation hypothesis: its `lipschitzLineIntegral = 0` but its `rectLineIntegral = 1` (via the proven `unit_square_area_as_line_integral`).\n\nSo the corrected axiom is genuinely inapplicable to the curve that refuted the original. This shows the unsoundness is REMOVED, not merely hidden behind a stronger hypothesis.",
+    "mathContext": "$0 = \\text{lipschitzLineIntegral} \\ne \\text{rectLineIntegral} = 1$, so $h_{\\text{LineEq}}$ fails for the counterexample — soundness is demonstrably regained.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Soundness verification",
+      "Counterexample",
+      "Green's theorem"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "greens-theorem-oq-02-oq-02",
+  "title": "Green's Theorem OQ-02-OQ-02: Orientation-Corrected Minimal-Regularity Axiom",
+  "slug": "greens-theorem-oq-02-oq-02",
+  "description": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posits its core as an axiom that is FALSE as stated — a degenerate constant curve satisfies every hypothesis yet forces 0 = 1. This entry states the orientation-corrected axiom (one extra hypothesis hLineEq tying the curve's circulation to the concrete four-edge rectangle integral), re-threads all five downstream consumers, and proves the original counterexample fails the new hypothesis — removing the unsoundness rather than hiding it.",
+  "meta": {
+    "author": "researcher agents (Lean Genius); after Whitney (1957)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/GreensTheoremOQ02Corrected.lean",
+    "tags": [
+      "analysis",
+      "multivariable-calculus",
+      "regularity",
+      "lipschitz",
+      "whitney",
+      "vector-calculus",
+      "soundness",
+      "axiom-integrity",
+      "counterexample"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.integral",
+        "description": "Bochner/Lebesgue integral",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      },
+      {
+        "theorem": "MeasureTheory.IntegrableOn",
+        "description": "Integrability on a set",
+        "module": "Mathlib.MeasureTheory.Integral.IntegrableOn"
+      },
+      {
+        "theorem": "frontier",
+        "description": "Topological frontier of a set",
+        "module": "Mathlib.Topology.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Orientation-corrected axiom greens_theorem_l1curl_oriented: the registered greens_theorem_l1curl plus one hypothesis hLineEq (lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d) excluding degenerate/wrongly-oriented curves",
+      "All five downstream consumers re-proved with hLineEq threaded (lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl in GreensTheoremOQ02; greens_stokes_l1curl, closed_l1form_zero_integral in GreensTheoremOQ02OQ04) — a pure signature-threading correction, each proof the original verbatim plus the extra argument",
+      "counterexample_violates_hLineEq: the Session-5 unsound witness (constant curve, P=0, Q(x,y)=x) fails the new orientation hypothesis (lipschitzLineIntegral = 0 ≠ 1 = rectLineIntegral via the proven unit_square_area_as_line_integral), so the corrected axiom is genuinely inapplicable to it"
+    ],
+    "axiomCount": 1,
+    "lineCount": 182,
+    "assumptions": "BUILD-PENDING / UNREGISTERED. Authored under an extended Docker + Aristotle outage; not machine-verified, and not in Proofs.lean. IMPORTANT: the REGISTERED parent file GreensTheoremOQ02.lean still carries the FALSE axiom greens_theorem_l1curl (S5 #24381, MERGED, proved it forces 0 = 1); the correction here cannot be ported back to the registered files until Docker returns, because the 6-consumer signature change across two registered files must land as a single build-verified patch (fix spec: S6 #24424, MERGED). This entry's single remaining assumption is the corrected axiom greens_theorem_l1curl_oriented (the genuine Whitney minimal-regularity input, now orientation-sound). Not claimed verified.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**A soundness correction to the minimal-regularity Green's theorem.**\n\nThe parent entry `greens-theorem-oq-02` formalizes Whitney's 1957 theorem — Green's theorem for a Lipschitz boundary curve and an L¹-integrable curl — by positing the core identity as `axiom greens_theorem_l1curl`. Session 5 discovered this axiom is FALSE as stated: its only curve↔rectangle hypothesis (`hTraversal`, image-containment in the frontier) constrains neither orientation nor winding nor non-degeneracy, so the degenerate constant curve γ ≡ (0,0) with P = 0, Q(x,y) = x (curl ≡ 1) satisfies every hypothesis yet has circulation 0 while ∬ curl = 1, forcing 0 = 1.",
+    "problemStatement": "**The integrity problem.** `greens_theorem_l1curl` equates a Lipschitz curve's line integral with the double integral of the curl over the rectangle, but the curve is tied to the rectangle only by frontier-containment of its image — which permits degenerate and wrongly-oriented curves. Such a curve refutes the axiom (`greens_theorem_l1curl_refuted`).\n\n**The fix.** Add ONE orientation hypothesis `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`, tying the circulation to the concrete, correctly-oriented four-edge rectangle integral (from OQ-01). The corrected axiom `greens_theorem_l1curl_oriented` is sound, and the counterexample provably fails `hLineEq`.",
+    "text": "Correct the false minimal-regularity Green's-theorem axiom by adding an orientation hypothesis, re-thread all consumers, and verify the original counterexample is excluded.",
+    "proofStrategy": "**1. Corrected axiom.** `greens_theorem_l1curl_oriented` = the registered axiom plus `hLineEq` fixing the boundary orientation to `rectLineIntegral`.\n\n**2. Re-thread consumers.** All five downstream theorems (three in GreensTheoremOQ02, two in GreensTheoremOQ02OQ04) are re-proved verbatim with the single extra `hLineEq` argument passed through.\n\n**3. Excise the counterexample.** `counterexample_violates_hLineEq` shows the Session-5 unsound witness has `lipschitzLineIntegral = 0` but `rectLineIntegral = 1` (by the proven `unit_square_area_as_line_integral`), so it fails `hLineEq` and the corrected axiom does not apply to it — the unsoundness is removed, not masked.",
+    "keyInsights": [
+      "**Frontier-containment is too weak:** it pins down neither orientation nor winding nor non-degeneracy, which is exactly what lets the constant curve refute the original axiom.",
+      "**One hypothesis suffices:** equating the circulation with the concrete oriented rectangle integral `rectLineIntegral` (OQ-01) restores soundness without changing any consumer's mathematics.",
+      "**Excision is verified, not assumed:** the counterexample is shown to fail the new hypothesis via a proven lemma, so soundness is demonstrably regained.",
+      "**Coordinated landing required:** the fix spans two registered files and six consumers, so it must be ported as a single Docker-verified patch — hence this isolated, unregistered staging file."
+    ],
+    "prerequisites": [
+      "Green's theorem / Stokes' theorem in the plane",
+      "Lipschitz curves and line integrals",
+      "Lebesgue integration of L¹ functions",
+      "Orientation of boundary curves"
+    ]
+  },
+  "sections": [
+    {
+      "id": "corrected-axiom",
+      "title": "The Orientation-Corrected Axiom",
+      "summary": "greens_theorem_l1curl_oriented: registered axiom plus the hLineEq orientation hypothesis",
+      "startLine": 60,
+      "endLine": 72,
+      "mathContext": "Adds $h_{\\\\text{LineEq}}: \\\\oint_C (P\\\\,dx + Q\\\\,dy) = \\\\text{rectLineIntegral}\\\\,P\\\\,Q\\\\,a\\\\,b\\\\,c\\\\,d$, fixing the boundary orientation so the circulation equals the concrete four-edge rectangle integral."
+    },
+    {
+      "id": "consumers",
+      "title": "Re-threaded Consumers",
+      "summary": "Five downstream theorems re-proved with hLineEq threaded through",
+      "startLine": 74,
+      "endLine": 172,
+      "mathContext": "lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl (GreensTheoremOQ02) and greens_stokes_l1curl, closed_l1form_zero_integral (GreensTheoremOQ02OQ04), each verbatim plus the extra orientation argument."
+    },
+    {
+      "id": "excision",
+      "title": "Counterexample Excised",
+      "summary": "counterexample_violates_hLineEq: the unsound witness fails the new hypothesis",
+      "startLine": 174,
+      "endLine": 182,
+      "mathContext": "The constant curve with $P=0$, $Q(x,y)=x$ has circulation $0$ but $\\\\text{rectLineIntegral} = 1$ (proven), so it fails $h_{\\\\text{LineEq}}$ — the corrected axiom is genuinely inapplicable to it."
+    }
+  ],
+  "conclusion": {
+    "summary": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posits a core axiom that is false as stated. This entry states the orientation-corrected axiom greens_theorem_l1curl_oriented (one extra hypothesis hLineEq), re-threads all five downstream consumers as a pure signature change, and proves the original counterexample fails the new hypothesis — genuinely removing the unsoundness. The correction is staged in an isolated, unregistered, build-pending file; porting it back to the registered files awaits a Docker session.",
+    "implications": "Restores soundness of the minimal-regularity Green's-theorem formalization: the boundary-orientation hypothesis that the classical statement leaves implicit is made explicit, the five consumers carry it through unchanged, and the degenerate counterexample is provably excluded.",
+    "openQuestions": [
+      "Port greens_theorem_l1curl_oriented (and the re-threaded consumers) back onto the registered GreensTheoremOQ02.lean / GreensTheoremOQ02OQ04.lean as a single Docker-verified patch, then delete this staging file and retire GreensTheoremOQ02Counterexample.lean (S6 #24424 spec).",
+      "Discharge the corrected axiom itself via the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0, PR #29508) reducing it to OQ-01's boundary algebra by Fubini."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "parent-problem",
+      "description": "The registered minimal-regularity Green's theorem whose greens_theorem_l1curl axiom this entry corrects.",
+      "targetId": "greens-theorem-oq-02"
+    },
+    {
+      "relationship": "related-result",
+      "description": "Sibling open-question entry in the same minimal-regularity Green's theorem family.",
+      "targetId": "greens-theorem-oq-02-oq-04"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "H. Whitney"
+      ],
+      "title": "Geometric Integration Theory",
+      "venue": "Princeton University Press",
+      "year": "1957",
+      "note": "Source of the minimal-regularity Green's/Stokes theorem for Lipschitz boundaries and L¹ curl."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GreensTheoremOQ02OQ04",
+      "Proofs.GreensTheoremOQ02Counterexample"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "GreensTheoremOQ01",
+      "GreensTheoremOQ02",
+      "GreensTheoremOQ02OQ04",
+      "GreensTheoremOQ02Counterexample"
+    ],
+    "namespace": "GreensTheoremOQ02Corrected",
+    "lineCount": 182,
+    "axiomCount": 1,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GreensTheoremOQ02Corrected.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
- Adds the missing gallery dir `src/data/proofs/greens-theorem-oq-02-oq-02/` (`meta.json` + `annotations.json`) for `GreensTheoremOQ02Corrected.lean`.
- That file is the **soundness correction** for the minimal-regularity Green's theorem: the registered parent's `axiom greens_theorem_l1curl` is FALSE as stated (a degenerate constant curve forces `0 = 1`, S5 #24381). The correction adds one orientation hypothesis `hLineEq`, re-threads all five downstream consumers as a pure signature change, and proves the counterexample fails the new hypothesis (`counterexample_violates_hLineEq`).
- Only the parent `greens-theorem-oq-02` and sibling `-oq-04` had gallery dirs; this sub-problem had none.

## Non-conflicting / honesty
- Touches **only gallery data** (no `.lean`), so it does not conflict with the Docker-gated port of the fix onto the registered files.
- Marked `status=axiomatized` / `badge=wip`, `axiomCount=1`: the entry is **BUILD-PENDING** and the file is **UNREGISTERED** (Docker + Aristotle blackout).
- The `assumptions` field explicitly flags that the **registered parent `GreensTheoremOQ02.lean` still carries the FALSE axiom** `greens_theorem_l1curl` pending the coordinated patch (S6 #24424). **Not claimed verified.**
- Both JSON files validated with `python3 -m json.tool`.

## Test plan
- [ ] `pnpm build` (gallery data-gen) once a clean environment is available.
- [ ] Flip `badge`/`status` once the corrected axiom is ported onto the registered files and Docker-built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)