### PR TITLE
research(nth-root-irrational-oq-01-oq-01): S6 exact degree phi(n)/2 of real cyclotomic subfield

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean
@@ -1,0 +1,267 @@
+/-
+  Nth Root Irrationality OQ-01-OQ-01 (exact degree of the real subfield).
+
+  The sibling files in this family proved:
+  - `NthRootIrrationalOQ01OQ01Real.lean`: `φ(n) ≥ 3 ⟹ ζ + ζ⁻¹ ∉ ℚ` (the real
+    cyclotomic generator `2·cos(2π/n)` is irrational), i.e. `[ℚ(ζ+ζ⁻¹):ℚ] > 1`.
+  - `NthRootIrrationalOQ01OQ01CosRational.lean` / `...Cos.lean`: the full Niven
+    classification `cos(2π/n) ∈ ℚ ⟺ n ∈ {1,2,3,4,6}`.
+
+  Those prior sessions repeatedly flagged the **exact degree**
+  `[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` as the sole remaining open item, deferred as needing
+  "IntermediateField tower machinery". This file closes it.
+
+  **Main result** (`finrank_adjoin_trace_eq`, division-free form):
+
+      `3 ≤ n  ⟹  2 · [ℚ(ζ+ζ⁻¹):ℚ] = φ(n)`.
+
+  Here `ζ : ℂ` is a primitive `n`-th root of unity and `ζ + ζ⁻¹ = 2·cos(2π/n)`
+  is the generator of the maximal real subfield `ℚ(ζ)⁺` of the cyclotomic field.
+
+  **Proof outline.**
+  1. `[ℚ(ζ):ℚ] = φ(n)` — `adjoin.finrank` + `cyclotomic_eq_minpoly_rat`.
+  2. The tower `ℚ ⊆ ℚ(ζ+ζ⁻¹) ⊆ ℚ(ζ)` gives, via `finrank_bot_mul_relfinrank`,
+       `[ℚ(ζ+ζ⁻¹):ℚ] · [ℚ(ζ):ℚ(ζ+ζ⁻¹)] = φ(n)`.
+  3. `[ℚ(ζ):ℚ(ζ+ζ⁻¹)] = 2`:
+       - `≤ 2`: with `α := ζ+ζ⁻¹ ∈ ℚ(ζ+ζ⁻¹)`, `ζ` is a root of the degree-2
+         polynomial `X² − α·X + 1` over `ℚ(ζ+ζ⁻¹)`, so `minpoly` has degree ≤ 2;
+       - `≥ 2`: a degree-1 minimal polynomial would force `ζ ∈ ℚ(ζ+ζ⁻¹)`; but
+         `ζ+ζ⁻¹` is real (`|ζ| = 1`), so `ℚ(ζ+ζ⁻¹)` is a *real* subfield, while
+         `ζ` is non-real for `n ≥ 3` — contradiction.
+
+  The relative degree is computed through `relfinrank`/`extendScalars`:
+  `relfinrank ℚ(α) ℚ(ζ) = finrank ℚ(α) (extendScalars h) = finrank ℚ(α) ℚ(α)(ζ)
+  = (minpoly ℚ(α) ζ).natDegree`, using `extendScalars_adjoin` to identify the
+  relative extension with the simple adjoin `ℚ(α)(ζ)`.
+
+  **Key Mathlib facts:**
+  - `IntermediateField.adjoin.finrank` : `[K(x):K] = deg(minpoly K x)`.
+  - `IntermediateField.finrank_bot_mul_relfinrank` : tower multiplicativity.
+  - `IntermediateField.extendScalars_adjoin` : `extendScalars h = adjoin K S`.
+  - `Polynomial.cyclotomic_eq_minpoly_rat`, `Polynomial.natDegree_cyclotomic`.
+  - `Complex.norm_eq_one_of_pow_eq_one`, `Complex.inv_im` (real subfield).
+
+  **Results (0 axioms, 0 sorries):**
+  1. `relfinrank_adjoin_trace_eq_two` : `[ℚ(ζ):ℚ(ζ+ζ⁻¹)] = 2` for `n ≥ 3`.
+  2. `finrank_adjoin_trace_eq`        : `2 · [ℚ(ζ+ζ⁻¹):ℚ] = φ(n)` for `n ≥ 3`.
+  3. `fifthRoot_finrank_adjoin_trace` : concrete `n = 5`, `[ℚ(2cos(2π/5)):ℚ] = 2`.
+
+  ## References
+  - Washington, L. (1997). "Introduction to Cyclotomic Fields." §2 (real subfield).
+  - Niven, I. (1956). "Irrational Numbers." Carus Math. Monographs.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 1600000
+set_option linter.unusedVariables false
+
+open Polynomial Module IntermediateField
+
+namespace NthRootIrrationalOQ01OQ01Degree
+
+noncomputable section
+
+-- ============================================================================
+-- The maximal real subfield: the im = 0 intermediate field of ℂ over ℚ
+-- ============================================================================
+
+/-- The real subfield `{z : ℂ | z.im = 0}` of `ℂ`, as an intermediate field over
+    `ℚ`.  Every rational is real; the reals are closed under the field
+    operations and inverses. -/
+def realField : IntermediateField ℚ ℂ where
+  carrier := {z : ℂ | z.im = 0}
+  one_mem' := by simp
+  mul_mem' := by
+    intro a b ha hb
+    simp only [Set.mem_setOf_eq, Complex.mul_im] at *
+    rw [ha, hb]; ring
+  add_mem' := by
+    intro a b ha hb
+    simp only [Set.mem_setOf_eq, Complex.add_im] at *
+    rw [ha, hb]; ring
+  zero_mem' := by simp
+  algebraMap_mem' := by
+    intro r
+    simp only [Set.mem_setOf_eq, eq_ratCast]
+    exact Complex.ratCast_im r
+  inv_mem' := by
+    intro x hx
+    simp only [Set.mem_setOf_eq, Complex.inv_im] at *
+    rw [hx]; simp
+
+@[simp] theorem mem_realField {z : ℂ} : z ∈ realField ↔ z.im = 0 := Iff.rfl
+
+-- ============================================================================
+-- Setup lemmas about a primitive n-th root of unity
+-- ============================================================================
+
+variable {n : ℕ} {ζ : ℂ}
+
+/-- A primitive `n`-th root of unity (for `0 < n`) is nonzero. -/
+theorem primitiveRoot_ne_zero (hn : 0 < n) (hζ : IsPrimitiveRoot ζ n) : ζ ≠ 0 := by
+  intro h
+  have hpow : ζ ^ n = 1 := hζ.pow_eq_one
+  rw [h, zero_pow hn.ne'] at hpow
+  exact one_ne_zero hpow.symm
+
+/-- A primitive `n`-th root of unity is integral over `ℚ`.  It is integral over
+    `ℤ` (a root of `Xⁿ − 1`); lift along the tower `ℤ → ℚ → ℂ`. -/
+theorem primitiveRoot_isIntegral (hn : 0 < n) (hζ : IsPrimitiveRoot ζ n) :
+    IsIntegral ℚ ζ :=
+  (hζ.isIntegral hn).tower_top
+
+/-- The real cyclotomic generator `α = ζ + ζ⁻¹` is real, i.e. lies in `realField`.
+    Indeed `α = 2·Re ζ` because `|ζ| = 1`. -/
+theorem trace_mem_realField (hn : 0 < n) (hζ : IsPrimitiveRoot ζ n) :
+    ζ + ζ⁻¹ ∈ realField := by
+  have hnorm : ‖ζ‖ = 1 := Complex.norm_eq_one_of_pow_eq_one hζ.pow_eq_one hn.ne'
+  have hns : Complex.normSq ζ = 1 := by
+    rw [Complex.normSq_eq_norm_sq, hnorm]; norm_num
+  simp only [mem_realField, Complex.add_im, Complex.inv_im, hns]
+  ring
+
+/-- For `n ≥ 3`, a primitive `n`-th root of unity is **not** real:
+    if `ζ.im = 0` then `ζ⁻¹ = ζ`, so `ζ² = 1`, forcing `n ∣ 2`. -/
+theorem primitiveRoot_not_real (hn : 3 ≤ n) (hζ : IsPrimitiveRoot ζ n) :
+    ζ.im ≠ 0 := by
+  have hn0 : 0 < n := by omega
+  have hζ0 : ζ ≠ 0 := primitiveRoot_ne_zero hn0 hζ
+  intro him
+  -- `ζ.im = 0 ⟹ ζ = conj ζ`, and for a root of unity `conj ζ = ζ⁻¹`, so `ζ = ζ⁻¹`.
+  have hns : Complex.normSq ζ = 1 := by
+    rw [Complex.normSq_eq_norm_sq,
+      Complex.norm_eq_one_of_pow_eq_one hζ.pow_eq_one hn0.ne']; norm_num
+  -- `ζ⁻¹ = ζ` because `ζ⁻¹ = conj ζ / normSq = conj ζ` and `conj ζ = ζ` when `im = 0`.
+  have hinv : ζ⁻¹ = ζ := by
+    apply Complex.ext
+    · rw [Complex.inv_re, hns]; simp
+    · rw [Complex.inv_im, hns, him]; simp
+  -- Hence `ζ ^ 2 = 1`.
+  have hsq : ζ ^ 2 = 1 := by
+    have : ζ * ζ⁻¹ = 1 := mul_inv_cancel₀ hζ0
+    rw [hinv] at this; rw [sq]; exact this
+  -- A primitive root with `ζ ^ 2 = 1` forces `n ∣ 2`, impossible for `n ≥ 3`.
+  have hdvd : n ∣ 2 := hζ.dvd_of_pow_eq_one 2 hsq
+  have := Nat.le_of_dvd (by norm_num) hdvd
+  omega
+
+-- ============================================================================
+-- The relative degree [ℚ(ζ) : ℚ(ζ + ζ⁻¹)] = 2
+-- ============================================================================
+
+/-- **The cyclotomic field is degree 2 over its maximal real subfield.**
+    For `n ≥ 3` and `ζ` a primitive `n`-th root of unity,
+    `[ℚ(ζ) : ℚ(ζ + ζ⁻¹)] = 2`. -/
+theorem relfinrank_adjoin_trace_eq_two (hn : 3 ≤ n) (hζ : IsPrimitiveRoot ζ n) :
+    relfinrank (ℚ⟮ζ + ζ⁻¹⟯ : IntermediateField ℚ ℂ) ℚ⟮ζ⟯ = 2 := by
+  have hn0 : 0 < n := by omega
+  have hζ0 : ζ ≠ 0 := primitiveRoot_ne_zero hn0 hζ
+  set α : ℂ := ζ + ζ⁻¹ with hαdef
+  -- `α ∈ ℚ⟮ζ⟯`, so `ℚ⟮α⟯ ≤ ℚ⟮ζ⟯`.
+  have hαmem : α ∈ (ℚ⟮ζ⟯ : IntermediateField ℚ ℂ) := by
+    rw [hαdef]
+    exact add_mem (mem_adjoin_simple_self ℚ ζ) (inv_mem (mem_adjoin_simple_self ℚ ζ))
+  have hle : (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮ζ⟯ := adjoin_simple_le_iff.mpr hαmem
+  -- `ζ` is integral over the subfield `ℚ⟮α⟯`.
+  have hζintℚ : IsIntegral ℚ ζ := primitiveRoot_isIntegral hn0 hζ
+  have hζint : IsIntegral (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ := hζintℚ.tower_top
+  -- `α` as an element of the subfield `ℚ⟮α⟯`.
+  set αK : (ℚ⟮α⟯ : IntermediateField ℚ ℂ) := ⟨α, mem_adjoin_simple_self ℚ α⟩ with hαK
+  have hαKcoe : (algebraMap (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ℂ) αK = α := rfl
+  -- The rational (over `ℚ⟮α⟯`) quadratic `q = X² − αK·X + 1` has `ζ` as a root.
+  set q : (ℚ⟮α⟯ : IntermediateField ℚ ℂ)[X] := X ^ 2 - C αK * X + 1 with hq
+  have haeval : (aeval ζ) q = 0 := by
+    have hmul : ζ⁻¹ * ζ = 1 := inv_mul_cancel₀ hζ0
+    rw [hq]
+    simp only [map_add, map_sub, map_mul, map_pow, aeval_X, aeval_C, map_one, hαKcoe, hαdef]
+    linear_combination -hmul
+  have hqdeg : q.natDegree = 2 := by rw [hq]; compute_degree!
+  have hqne : q ≠ 0 := by
+    intro h; rw [h, natDegree_zero] at hqdeg; omega
+  -- The minimal polynomial of `ζ` over `ℚ⟮α⟯` divides `q`, so has degree ≤ 2.
+  have hdvd : minpoly (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ ∣ q :=
+    minpoly.dvd (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ haeval
+  have hle2 : (minpoly (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ).natDegree ≤ 2 := by
+    rw [← hqdeg]; exact natDegree_le_of_dvd hdvd hqne
+  -- The minimal polynomial has positive degree (ζ is integral).
+  have hpos : 0 < (minpoly (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ).natDegree :=
+    minpoly.natDegree_pos hζint
+  -- Every element of `ℚ⟮α⟯` is real, because its generator `α = ζ + ζ⁻¹` is.
+  have hαreal : (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ≤ realField :=
+    adjoin_simple_le_iff.mpr (by rw [hαdef]; exact trace_mem_realField hn0 hζ)
+  -- Degree ≠ 1: else `ζ ∈ ℚ⟮α⟯`, contradicting that `ℚ⟮α⟯` is real but `ζ` is not.
+  have hne1 : (minpoly (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ).natDegree ≠ 1 := by
+    intro hdeg1
+    -- `[ℚ⟮α⟯(ζ) : ℚ⟮α⟯] = 1`, so `ℚ⟮α⟯(ζ) = ⊥`, so `ζ ∈ range(algebraMap ℚ⟮α⟯ ℂ)`.
+    have hfr : finrank (ℚ⟮α⟯ : IntermediateField ℚ ℂ)
+        (ℚ⟮α⟯ : IntermediateField ℚ ℂ)⟮ζ⟯ = 1 := by
+      rw [IntermediateField.adjoin.finrank hζint, hdeg1]
+    have hbot : (ℚ⟮α⟯ : IntermediateField ℚ ℂ)⟮ζ⟯ = ⊥ :=
+      IntermediateField.finrank_eq_one_iff.mp hfr
+    have hζbot : ζ ∈ (⊥ : IntermediateField (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ℂ) := by
+      rw [← hbot]; exact mem_adjoin_simple_self _ ζ
+    rw [IntermediateField.mem_bot] at hζbot
+    obtain ⟨k, hk⟩ := hζbot
+    -- `ζ = ↑k` with `k ∈ ℚ⟮α⟯`; but every element of `ℚ⟮α⟯` is real.
+    have hkreal : (k : ℂ).im = 0 := (mem_realField).mp (hαreal k.2)
+    have hcoe : (algebraMap (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ℂ) k = (k : ℂ) := rfl
+    rw [hcoe] at hk
+    exact primitiveRoot_not_real hn hζ (hk ▸ hkreal)
+  -- Combine: degree is exactly 2.
+  have hdeg2 : (minpoly (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ζ).natDegree = 2 := by omega
+  -- Translate to the relative degree via `extendScalars`.
+  rw [IntermediateField.relfinrank_eq_finrank_of_le hle,
+    IntermediateField.extendScalars_adjoin hle,
+    IntermediateField.adjoin.finrank hζint, hdeg2]
+
+-- ============================================================================
+-- Main theorem: 2 · [ℚ(ζ + ζ⁻¹) : ℚ] = φ(n)
+-- ============================================================================
+
+/-- **Exact degree of the maximal real subfield.**  For `n ≥ 3` and `ζ` a
+    primitive `n`-th root of unity, the real cyclotomic generator
+    `ζ + ζ⁻¹ = 2·cos(2π/n)` generates a subfield of degree `φ(n)/2`:
+
+        `2 · [ℚ(ζ + ζ⁻¹) : ℚ] = φ(n)`.
+
+    (Stated division-free.  Since `φ(n)` is even for `n ≥ 3`, this pins the
+    degree to exactly `φ(n)/2`.) -/
+theorem finrank_adjoin_trace_eq (hn : 3 ≤ n) (hζ : IsPrimitiveRoot ζ n) :
+    2 * finrank ℚ (ℚ⟮ζ + ζ⁻¹⟯ : IntermediateField ℚ ℂ) = n.totient := by
+  have hn0 : 0 < n := by omega
+  set α : ℂ := ζ + ζ⁻¹ with hαdef
+  have hαmem : α ∈ (ℚ⟮ζ⟯ : IntermediateField ℚ ℂ) := by
+    rw [hαdef]
+    exact add_mem (mem_adjoin_simple_self ℚ ζ) (inv_mem (mem_adjoin_simple_self ℚ ζ))
+  have hle : (ℚ⟮α⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮ζ⟯ := adjoin_simple_le_iff.mpr hαmem
+  have hζintℚ : IsIntegral ℚ ζ := primitiveRoot_isIntegral hn0 hζ
+  -- `[ℚ(ζ) : ℚ] = φ(n)`.
+  have hcycdeg : finrank ℚ (ℚ⟮ζ⟯ : IntermediateField ℚ ℂ) = n.totient := by
+    rw [IntermediateField.adjoin.finrank hζintℚ,
+      ← cyclotomic_eq_minpoly_rat hζ hn0, natDegree_cyclotomic]
+  -- Tower: `[ℚ(α):ℚ] · [ℚ(ζ):ℚ(α)] = [ℚ(ζ):ℚ]`.
+  have htower := IntermediateField.finrank_bot_mul_relfinrank hle
+  rw [relfinrank_adjoin_trace_eq_two hn hζ, hcycdeg] at htower
+  -- `finrank ℚ ℚ⟮α⟯ * 2 = φ(n)`.
+  omega
+
+-- ============================================================================
+-- Concrete instance: [ℚ(2·cos(2π/5)) : ℚ] = 2  (φ(5) = 4)
+-- ============================================================================
+
+/-- For `n = 5`, the real cyclotomic generator `2·cos(2π/5) = (√5 − 1)/2`
+    generates a degree-2 subfield (`φ(5)/2 = 2`). -/
+theorem fifthRoot_finrank_adjoin_trace :
+    2 * finrank ℚ
+        (ℚ⟮Complex.exp (2 * ↑Real.pi * Complex.I / (5 : ℕ)) +
+          (Complex.exp (2 * ↑Real.pi * Complex.I / (5 : ℕ)))⁻¹⟯ :
+          IntermediateField ℚ ℂ) = 4 := by
+  have h := finrank_adjoin_trace_eq (n := 5) (by norm_num)
+    (Complex.isPrimitiveRoot_exp 5 (by norm_num))
+  rw [show Nat.totient 5 = 4 from by decide] at h
+  exact h
+
+end
+
+end NthRootIrrationalOQ01OQ01Degree

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -199,3 +199,69 @@ build-safe"): identifiers are standard v4.26 (`cyclotomic.irreducible_rat`,
 `Real.cos_*` lemmas, `Rat.not_irrational`). One-line-per-file change;
 deployer-build-gated (a failing build blocks the merge, not main), so safe under
 blackout. The genuinely-open exact-degree φ(n)/2 item above remains untouched.
+
+---
+
+## Session 6 (2026-06-15, researcher-1, REVISIT → ACT) — EXACT DEGREE φ(n)/2 SOLVED
+
+**The sole remaining open item is closed.** New file
+`proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean` (0 sorries, 0 axioms,
+build-pending — Docker `docker info` timed out; Aristotle blackout). Branch from
+origin/main. Every Mathlib lemma name-checked against the pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (local clone HEAD matches exactly).
+
+Every prior session (S1–S5) flagged the **exact degree**
+`[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)/2` as the lone open item, deferred as "needs
+IntermediateField tower machinery, ~150 LOC, Docker-gated". This session proves
+it (division-free to avoid `φ(n)/2` integrality fuss):
+
+> **`finrank_adjoin_trace_eq`**: `3 ≤ n → 2 · [ℚ(ζ+ζ⁻¹):ℚ] = φ(n)`.
+
+### Proof architecture (the machinery that finally worked)
+
+1. `[ℚ(ζ):ℚ] = φ(n)` — `IntermediateField.adjoin.finrank hζint`
+   (= `(minpoly ℚ ζ).natDegree`) + `cyclotomic_eq_minpoly_rat` +
+   `natDegree_cyclotomic`. (Same as S2/Real.lean.)
+2. Tower `ℚ ⊆ ℚ(ζ+ζ⁻¹) ⊆ ℚ(ζ)` via **`IntermediateField.finrank_bot_mul_relfinrank`**
+   `(h : A ≤ B) : finrank F A * relfinrank A B = finrank F B`. This is THE clean
+   tower lemma that stays inside `IntermediateField ℚ ℂ` (no scalar-tower
+   instance hassle from nesting `IntermediateField (↥K) ℂ`).
+3. `relfinrank ℚ(α) ℚ(ζ) = 2`:
+   - `relfinrank_eq_finrank_of_le h` → `finrank ↥ℚ(α) (extendScalars h)`;
+   - **`extendScalars_adjoin h : extendScalars h = adjoin K S`** (the KEY lemma,
+     `IntermediateField/Adjoin/Defs.lean:433`) identifies `extendScalars h` with
+     the *simple adjoin* `ℚ(α)⟮ζ⟯` because `ℚ(ζ) = adjoin ℚ {ζ}` definitionally;
+   - `adjoin.finrank hζint` → `(minpoly ℚ(α) ζ).natDegree`;
+   - `= 2` by `≤ 2` (ζ root of `X²−C αK·X+1` over ℚ(α), `minpoly.dvd` +
+     `natDegree_le_of_dvd`) and `≠ 0,1` (`minpoly.natDegree_pos`; degree-1 ⇒
+     `finrank_eq_one_iff` ⇒ `ℚ(α)⟮ζ⟯ = ⊥` ⇒ `mem_bot` ⇒ ζ ∈ ℚ(α), but ζ
+     non-real).
+
+### Reusable insights / fragile points
+
+- **The relfinrank/extendScalars route beats `Module.finrank_mul_finrank`** for
+  intermediate-field towers: `finrank_bot_mul_relfinrank` + `extendScalars_adjoin`
+  + `adjoin.finrank` keeps everything over the *base* ℚ and over ↥K, dodging the
+  `Algebra ℚ (↥(IntermediateField (↥K) ℂ))` transitive-instance minefield.
+- **Real subfield**, manually built as `realField : IntermediateField ℚ ℂ` with
+  carrier `{z | z.im = 0}`. Field-closure proofs: `Complex.mul_im`/`add_im`
+  (im=0 preserved), `Complex.inv_im` (`z⁻¹.im = -z.im/normSq z`),
+  `algebraMap_mem'` via `eq_ratCast` (`f q = ↑q` for any ℚ-ring-hom) +
+  `Complex.ratCast_im` (`(↑q:ℂ).im = 0`, rfl). `mem_realField := Iff.rfl`.
+- `ζ+ζ⁻¹` is real: `‖ζ‖=1` (`Complex.norm_eq_one_of_pow_eq_one`) ⇒
+  `normSq ζ = 1` (`Complex.normSq_eq_norm_sq`, decl in `Analysis/Complex/Norm.lean:146`)
+  ⇒ `(ζ+ζ⁻¹).im = ζ.im + (-ζ.im/1) = 0`.
+- ζ **non-real** for n≥3: `ζ.im=0` ⇒ `ζ⁻¹=ζ` (via `Complex.inv_re/inv_im` +
+  normSq=1) ⇒ `ζ²=1` ⇒ `n ∣ 2` (`IsPrimitiveRoot.dvd_of_pow_eq_one`) ⇒ n≤2 ⊥.
+- ζ integral over ℚ: `(hζ.isIntegral hn0).tower_top` (`IsPrimitiveRoot.isIntegral`
+  gives ℤ; `IsIntegral.tower_top` lifts ℤ→ℚ).
+- `aeval ζ (X²−C αK·X+1) = 0` closes by `linear_combination -hmul`
+  (`hmul : ζ⁻¹*ζ = 1`); `compute_degree!` for `natDegree = 2`.
+- αK := `⟨α, mem_adjoin_simple_self ℚ α⟩`; `algebraMap ↥ℚ(α) ℂ αK = α := rfl`.
+
+### Status / next
+- Left UNREGISTERED in `proofs/Proofs.lean` (build unverifiable under blackout;
+  register + `docker-build.sh Proofs.NthRootIrrationalOQ01OQ01Degree` once Docker
+  returns). With this, the Niven cosine story for this OQ is COMPLETE: rational
+  classification (n∈{1,2,3,4,6}), irrationality (φ(n)≥3), and now the **exact
+  degree** φ(n)/2. No genuinely-open sub-item remains.

--- a/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
+++ b/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Niven cosine classification COMPLETE: irrational direction (phi(n)>=3, merged #24427) + rational direction (n in {1,2,3,4,6}, this session). Build-pending/unregistered. Sole remaining open item: exact degree [Q(2cos):Q]=phi(n)/2 (Docker-gated IntermediateField tower).",
+    "progressSummary": "EXACT DEGREE SOLVED (S6, researcher-1): 2*[Q(zeta+zeta^-1):Q]=phi(n) for n>=3 (NthRootIrrationalOQ01OQ01Degree.lean, 0ax/0sorry, build-pending/unregistered under Docker blackout). Route: finrank_bot_mul_relfinrank tower + extendScalars_adjoin + adjoin.finrank; relative degree [Q(zeta):Q(zeta+zeta^-1)]=2 from X^2-(zeta+zeta^-1)X+1 (<=2) and zeta non-real (>1, via manual real subfield {im=0}). Niven cosine story for this OQ now COMPLETE: rational classification (n in {1,2,3,4,6}) + irrationality (phi(n)>=3) + exact degree phi(n)/2. No open sub-item remains.",
     "builtItems": [
       "cyclotomic_no_rational_root (NthRootIrrationalOQ01OQ01.lean): Phi_n over Q has no rational root for n>=3",
       "rational_root_of_unity_le_two: only rational roots of unity are +-1 (primitive n-th root in Q forces n<=2)",
@@ -40,14 +40,15 @@
     "insights": [
       "Cyclotomic extension of nth-root irrationality reduces to swapping X^n-p (Eisenstein) for Phi_n (cyclotomic.irreducible_rat) in the parent irreducibility-implies-irrational pipeline; only new lemma is degree bound phi(n)>=2 iff n>=3",
       "Phi_n has NO real roots for n>=3, so honest content is complex not-rational + rational-roots-of-unity=+-1; an irrational-real-root statement is vacuous",
-      "S4 (R4): rational half of Niven shipped (NthRootIrrationalOQ01OQ01CosRational.lean) — cos(2pi/n) rational for n in {1,2,3,4,6} with values {1,-1,-1/2,0,1/2}; combined with merged irrational direction gives full classification cos(2pi/n) rational <=> n in {1,2,3,4,6}."
+      "S4 (R4): rational half of Niven shipped (NthRootIrrationalOQ01OQ01CosRational.lean) — cos(2pi/n) rational for n in {1,2,3,4,6} with values {1,-1,-1/2,0,1/2}; combined with merged irrational direction gives full classification cos(2pi/n) rational <=> n in {1,2,3,4,6}.",
+      "S6 (R1): exact degree [Q(2cos(2pi/n)):Q]=phi(n)/2 proved division-free as 2*finrank=phi(n). KEY machinery: IntermediateField.finrank_bot_mul_relfinrank (tower staying over base, avoids nested-IntermediateField Algebra instances) + extendScalars_adjoin (identifies relative extension with simple adjoin Q(a)(zeta)) + adjoin.finrank. Relative degree 2 = root of quadratic X^2-(zeta+zeta^-1)X+1 (deg<=2) plus zeta non-real for n>=3 (deg>1)."
     ],
     "mathlibGaps": [
       "No gap for rational/complex statements; the real subfield story (minpoly of 2cos(2pi/n), degree phi(n)/2) was NOT formalized and is the missing piece"
     ],
     "nextSteps": [
       "Build+register NthRootIrrationalOQ01OQ01.lean once Docker/Aristotle backend available (left UNREGISTERED to protect auto-merge)",
-      "Follow-up OQ: is 2cos(2pi/n) irrational for n>=5 (n!=6) via its degree-phi(n)/2 minimal polynomial over Q?"
+      "Register NthRootIrrationalOQ01OQ01Degree in proofs/Proofs.lean and docker-build once backend returns (left UNREGISTERED under blackout)."
     ],
     "markdown": "# Knowledge Base: nth-root-irrational-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Closes the **sole remaining open item** for `nth-root-irrational-oq-01-oq-01`, flagged by every prior session (S1–S5) as deferred/Docker-gated: the **exact degree** of the maximal real subfield generated by `ζ + ζ⁻¹ = 2·cos(2π/n)`.

New file `proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean` (**0 axioms, 0 sorries**). Main result, stated division-free:

> `finrank_adjoin_trace_eq` : `3 ≤ n → 2 · [ℚ(ζ+ζ⁻¹):ℚ] = φ(n)`

together with `relfinrank_adjoin_trace_eq_two` (`[ℚ(ζ):ℚ(ζ+ζ⁻¹)] = 2`) and a concrete `n = 5` instance (`[ℚ(2cos(2π/5)):ℚ] = 2`).

## Proof architecture

- `[ℚ(ζ):ℚ] = φ(n)` via `adjoin.finrank` + `cyclotomic_eq_minpoly_rat` + `natDegree_cyclotomic`.
- Tower `ℚ ⊆ ℚ(ζ+ζ⁻¹) ⊆ ℚ(ζ)` via `IntermediateField.finrank_bot_mul_relfinrank` (stays inside `IntermediateField ℚ ℂ`, avoiding nested-field `Algebra` instance issues).
- Relative degree `= 2`: `relfinrank_eq_finrank_of_le` + `extendScalars_adjoin` (identifies the relative extension with the simple adjoin `ℚ(α)⟮ζ⟯`) + `adjoin.finrank`; degree `≤ 2` since `ζ` is a root of `X² − (ζ+ζ⁻¹)X + 1` over `ℚ(α)`, degree `> 1` since `ζ` is non-real for `n ≥ 3` while `ℚ(α)` is a real subfield (`{z | z.im = 0}`, built manually).

This completes the Niven cosine story for this OQ: rational classification (`n ∈ {1,2,3,4,6}`), irrationality (`φ(n) ≥ 3`), and now the exact degree `φ(n)/2`.

## Status

- **Build-pending**: Docker (`docker info` timed out) and Aristotle were both unavailable; the file could not be compiled this session. Every Mathlib lemma name was checked against the pinned mathlib rev (`2df2f01…`, local clone HEAD matches exactly).
- Left **UNREGISTERED** in `proofs/Proofs.lean` until a backend can build it (`docker-build.sh Proofs.NthRootIrrationalOQ01OQ01Degree`).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ01OQ01Degree` once Docker is available.
- [ ] Register the import in `proofs/Proofs.lean` after a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)