### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03): corrected full-sufficiency assembly

### DIFF
--- a/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
+++ b/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
@@ -1,0 +1,166 @@
+/-
+  Corrected sufficiency assembly for Legendre's three-square theorem.
+
+  `Proofs.ThreeSquares` leaves the SUFFICIENCY direction
+  `¬IsExcludedForm n ⟹ ∃ x y z, x²+y²+z² = n` as an axiom
+  (`not_excluded_form_is_sum_three_sq`, ThreeSquares.lean:1665).
+
+  The earlier reduction `Proofs.ThreeSquaresSufficiency` (#24443) tried to
+  shrink that axiom to a SINGLE hypothesis `DirichletWitnessProperty`:
+
+      ¬IsExcludedForm m → ¬(4 ∣ m) → 1 < m →
+        ∃ d p, 0 < d ∧ p = d·m − 1 ∧ p.Prime ∧ legendreSym p (−d) = 1
+
+  Audit PR #24529 / obstruction PR #24614 showed that this witness is
+  UNSATISFIABLE for every 4-free core `m ≡ 3 (mod 8)`: there is no prime
+  `p = d·m − 1` with `−d` a quadratic residue mod `p`. Hence
+  `DirichletWitnessProperty` as stated is a FALSE proposition — reducing the
+  axiom to it is vacuous, since the hypothesis can never be discharged.
+
+  This file fixes the architecture by splitting the open content into TWO
+  hypotheses, each of which is SATISFIABLE (numerically certified in
+  `verify_corrected_split.py`):
+
+    * `DirichletWitnessNe3` — the Dirichlet witness, RESTRICTED to the residue
+      classes `m % 8 ∈ {1,2,5,6}` where it actually holds; and
+    * `Residue3Property` — for `m % 8 = 3` (and `m > 3`), the existence of a
+      prime deficit `mm = (m − t²)/2` with `mm % 4 ≠ 3`, handled by Fermat's
+      two-square theorem via `ThreeSquaresResidue3.three_sq_of_residue3_prime`.
+
+  Everything else — the `4`-power descent, the small cases (`n ≤ 1` and the
+  lone exceptional core `n = 3 = 1²+1²+1²`), and the assembly via
+  `dirichlet_key_lemma` — is discharged here with NO new axioms and NO `sorry`,
+  reusing only lemmas already proved in `Proofs.ThreeSquares` and
+  `Proofs.ThreeSquaresResidue3`. The witness branch is verbatim the proven
+  branch of `ThreeSquaresSufficiency.three_sq_of_dirichlet_witness`; the only
+  additions are the mod-8 case split and the residue-3 route.
+
+  CONSEQUENCE FOR THE AXIOM BUDGET. `not_excluded_form_is_sum_three_sq` follows
+  from `dirichlet_key_lemma` together with the two SATISFIABLE hypotheses above.
+  Unlike #24443, both hypotheses can in principle be discharged (the first by
+  Dirichlet primes in AP + quadratic reciprocity on the four good residues, the
+  second by Dirichlet primes in AP for the deficit), so this is a genuine route
+  to eliminating the sufficiency axiom rather than a reduction to a false claim.
+
+  NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
+  unavailable). Not registered in `Proofs.lean`; harmless to the build until a
+  post-blackout session verifies it via `./proofs/scripts/docker-build.sh`.
+-/
+import Proofs.ThreeSquares
+import Proofs.ThreeSquaresResidue3
+
+namespace ThreeSquares
+
+/-- The Dirichlet witness property, RESTRICTED to the residue classes where it
+holds. For every `n > 1` that is not of excluded form, is not divisible by `4`,
+and is **not** `≡ 3 (mod 8)`, there is a multiplier `d` and a prime `p = d·n − 1`
+with `−d` a quadratic residue mod `p`.
+
+This is the satisfiable part of the monolithic `DirichletWitnessProperty` of
+`Proofs.ThreeSquaresSufficiency`; the excluded class `m ≡ 3 (mod 8)`, on which
+the witness is provably unsatisfiable (audit #24529 / obstruction #24614), is
+handled separately by `Residue3Property`. -/
+def DirichletWitnessNe3 : Prop :=
+  ∀ {m : ℕ}, ¬IsExcludedForm m → ¬(4 ∣ m) → m % 8 ≠ 3 → 1 < m →
+    ∃ d p : ℕ, 0 < d ∧ p = d * m - 1 ∧ Nat.Prime p ∧ legendreSym p (-d : ℤ) = 1
+
+/-- The residue-3 property: for every `m ≡ 3 (mod 8)` with `m > 3`, there is an
+odd witness `t` and a prime `mm = (m − t²)/2` with `mm % 4 ≠ 3`, packaged as the
+deficit identity `m = t² + 2·mm`.
+
+This is exactly the input consumed by `ThreeSquaresResidue3.three_sq_of_residue3_prime`,
+which closes the `m ≡ 3 (mod 8)` class via Fermat's two-square theorem
+(`m = t² + (a+b)² + (a−b)²` where `mm = a² + b²`). It is satisfiable for every
+such `m`: with `t` odd we have `t² ≡ 1 (mod 8)`, so `mm ≡ 1 (mod 4)` and in
+particular `mm % 4 ≠ 3` automatically. -/
+def Residue3Property : Prop :=
+  ∀ {m : ℕ}, m % 8 = 3 → 3 < m →
+    ∃ t mm : ℕ, Nat.Prime mm ∧ mm % 4 ≠ 3 ∧ m = t ^ 2 + 2 * mm
+
+/-- **Corrected sufficiency from the split witnesses.**
+
+Assuming the two satisfiable hypotheses `DirichletWitnessNe3` and
+`Residue3Property`, every natural number that is not of the excluded form
+`4^a (8b + 7)` is a sum of three integer squares.
+
+The proof is strong induction on `n`:
+
+* small cases `n ≤ 1` are explicit;
+* if `4 ∣ n`, write `n = 4 * m`; then `¬IsExcludedForm m`
+  (by `excluded_form_four_mul_iff`), so the induction hypothesis represents `m`
+  and `four_mul_sum_three_sq` lifts the representation back to `n`;
+* otherwise `n > 1` and `4 ∤ n`, split on the residue:
+    - `n = 3 = 1² + 1² + 1²` explicitly;
+    - `n % 8 = 3` and `n > 3`: the residue-3 route via `Residue3Property`;
+    - `n % 8 ≠ 3`: the witness `(d, p)` exists and `dirichlet_key_lemma`
+      represents `n` directly. -/
+theorem three_sq_of_corrected_witnesses
+    (Hne3 : DirichletWitnessNe3) (H3 : Residue3Property)
+    {n : ℕ} (hne : ¬IsExcludedForm n) :
+    ∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = n := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    by_cases h4 : 4 ∣ n
+    · -- 4 ∣ n: descend to m = n / 4
+      obtain ⟨m, hm⟩ := h4
+      rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+      · -- m = 0 ⟹ n = 0 = 0² + 0² + 0²
+        exact ⟨0, 0, 0, by rw [hm, hm0]; norm_num⟩
+      · -- m ≥ 1 ⟹ m < n, recurse
+        have hmlt : m < n := by omega
+        have hmne : ¬IsExcludedForm m := by
+          intro hmm
+          apply hne
+          rw [hm]
+          exact excluded_form_four_mul_iff.mpr hmm
+        have hrec := ih m hmlt hmne
+        have h4m := four_mul_sum_three_sq hrec
+        rw [hm]
+        exact h4m
+    · -- 4 ∤ n
+      by_cases hle : n ≤ 1
+      · -- n ∈ {0, 1}
+        interval_cases n
+        · exact ⟨0, 0, 0, by norm_num⟩
+        · exact ⟨1, 0, 0, by norm_num⟩
+      · -- n > 1 and 4 ∤ n
+        push_neg at hle
+        by_cases h3 : n % 8 = 3
+        · -- residue-3 class
+          by_cases hn3 : n = 3
+          · -- the lone exceptional core: 3 = 1² + 1² + 1²
+            exact ⟨1, 1, 1, by rw [hn3]; norm_num⟩
+          · -- n ≡ 3 (mod 8) and n ≠ 3 ⟹ n ≥ 11 > 3
+            have h3lt : 3 < n := by omega
+            obtain ⟨t, mm, hmm_prime, hmm4, hdecomp⟩ := H3 h3 h3lt
+            haveI : Fact (Nat.Prime mm) := ⟨hmm_prime⟩
+            exact ThreeSquaresResidue3.three_sq_of_residue3_prime hmm4 hdecomp
+        · -- n % 8 ≠ 3: invoke the (restricted) Dirichlet witness
+          obtain ⟨d, p, hd, hp, hpp, hqr⟩ := Hne3 hne h4 h3 hle
+          haveI : Fact (Nat.Prime p) := ⟨hpp⟩
+          exact dirichlet_key_lemma (n := n) (d := d) (p := p) hle hd hp hqr
+
+/-- **The sufficiency axiom is redundant given the corrected split.**
+
+Restatement matching `ThreeSquares.not_excluded_form_is_sum_three_sq`, showing
+that axiom is derivable from `dirichlet_key_lemma` plus the two SATISFIABLE
+hypotheses `DirichletWitnessNe3` and `Residue3Property`. -/
+theorem not_excluded_form_is_sum_three_sq_of_corrected
+    (Hne3 : DirichletWitnessNe3) (H3 : Residue3Property)
+    {n : ℕ} (h : ¬IsExcludedForm n) :
+    ∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = n :=
+  three_sq_of_corrected_witnesses Hne3 H3 h
+
+/-- **Conditional Legendre three-square theorem (corrected).**
+
+Combining the proven necessity (`excluded_form_not_sum_three_sq`) with the
+corrected conditional sufficiency above: assuming the two split witness
+properties, `n` is a sum of three integer squares iff `n` is not of excluded
+form. -/
+theorem legendre_three_squares_of_corrected
+    (Hne3 : DirichletWitnessNe3) (H3 : Residue3Property) (n : ℕ) :
+    (∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = n) ↔ ¬IsExcludedForm n :=
+  ⟨fun hrep hf => excluded_form_not_sum_three_sq hf hrep,
+   three_sq_of_corrected_witnesses Hne3 H3⟩
+
+end ThreeSquares

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -166,3 +166,34 @@ existence inputs, not one:
    in AP (`PrimesInAP`) supply it; then `three_sq_of_residue3_prime` finishes.
 Do NOT try to force the single-witness lemma onto m≡3 (provably unsatisfiable).
 Both inputs Docker-gated to verify in Lean.
+
+## Session 2026-06-15 (researcher-4) — corrected full-sufficiency assembly (PR pending)
+
+The #24443 reduction `ThreeSquaresSufficiency.DirichletWitnessProperty` is a
+**false (unsatisfiable) proposition**: audit #24529 / obstruction #24614 proved
+no Dirichlet witness `(d, p = d·m−1, legendreSym p (−d)=1)` exists for any 4-free
+core `m ≡ 3 (mod 8)`. So reducing the sufficiency axiom to it is vacuous — the
+hypothesis can never be discharged.
+
+New file `proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean` (build-pending,
+unregistered companion) fixes the architecture by splitting the open content into
+**two SATISFIABLE hypotheses**:
+
+1. `DirichletWitnessNe3` — the Dirichlet witness restricted to `m%8 ∈ {1,2,5,6}`
+   (where it holds; numerically: 0 failures up to 4000).
+2. `Residue3Property` — for `m%8=3, m>3`, existence of a prime deficit
+   `mm=(m−t²)/2` with `mm%4≠3` (auto since odd t ⟹ t²≡1 mod 8 ⟹ mm≡1 mod 4);
+   consumed by `ThreeSquaresResidue3.three_sq_of_residue3_prime`.
+
+`three_sq_of_corrected_witnesses` proves full sufficiency from these two + the
+existing `dirichlet_key_lemma` axiom, by strong induction:
+4-power descent (verbatim #24443 template) → small cases n≤1 → mod-8 split on the
+4-free core: n=3=1²+1²+1² explicit (the LONE exceptional residue-3 core with no
+prime deficit), n%8=3∧n>3 via Residue3, else via dirichlet_key_lemma (witness
+branch verbatim from Sufficiency.lean). 0 new axioms, 0 sorry.
+
+`verify_corrected_split.py` certifies (build-free, m≤4000): the two hypotheses
+together cover all 4-free non-excluded cores, and the monolithic witness NEVER
+works on m≡3 (obstruction holds — 0 accidental successes). NET: unlike #24443
+this is a route to actually eliminating the sufficiency axiom (both pieces
+dischargeable via Dirichlet primes in AP + QR), not a reduction to a false claim.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_corrected_split.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_corrected_split.py
@@ -1,0 +1,47 @@
+from sympy import isprime
+
+def is_excluded(n):
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+def legendre(a, p):  # p odd prime
+    a %= p
+    if a == 0: return 0
+    r = pow(a, (p-1)//2, p)
+    return 1 if r == 1 else -1
+
+def witness_exists_ne3(m):
+    for d in range(1, 300):
+        p = d*m - 1
+        if p > 2 and p % 2 == 1 and isprime(p):
+            if legendre(-d, p) == 1:
+                return (d, p)
+    return None
+
+def residue3_exists(m):
+    t = 1
+    while t*t <= m:
+        rem = m - t*t
+        if rem % 2 == 0:
+            mm = rem // 2
+            if mm >= 2 and isprime(mm) and mm % 4 != 3:
+                return (t, mm)
+        t += 2
+    return None
+
+bad_ne3, bad_res3, witness_on_3 = [], [], []
+for m in range(2, 4000):
+    if m % 4 == 0 or is_excluded(m):
+        continue
+    r = m % 8
+    if r == 3:
+        if residue3_exists(m) is None: bad_res3.append(m)
+        if witness_exists_ne3(m) is not None: witness_on_3.append(m)
+    else:
+        if witness_exists_ne3(m) is None: bad_ne3.append(m)
+
+print("4-free non-excluded cores, m up to 4000")
+print("m%8 in {1,2,5,6}, NO Dirichlet witness (want empty):", bad_ne3[:20], "count", len(bad_ne3))
+print("m%8 = 3, NO residue-3 prime deficit (want empty):", bad_res3[:20], "count", len(bad_res3))
+print("m%8 = 3 where monolithic witness works (want empty=obstruction holds):", witness_on_3[:20], "count", len(witness_on_3))


### PR DESCRIPTION
## Summary

Fixes an architectural flaw in the three-square sufficiency reduction. The #24443 reduction (`ThreeSquaresSufficiency.lean`) shrinks the sufficiency axiom to a single hypothesis `DirichletWitnessProperty`, but audit #24529 / obstruction #24614 proved that witness is **unsatisfiable** for every 4-free core `m ≡ 3 (mod 8)`. Reducing the axiom to a false proposition is vacuous — the hypothesis can never be discharged.

New companion `proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean` splits the open content into **two satisfiable hypotheses** and assembles full sufficiency:

- `DirichletWitnessNe3` — the Dirichlet witness restricted to `m % 8 ∈ {1,2,5,6}` (where it holds).
- `Residue3Property` — for `m % 8 = 3`, `m > 3`, existence of a prime deficit `mm = (m−t²)/2` with `mm % 4 ≠ 3` (consumed by `ThreeSquaresResidue3.three_sq_of_residue3_prime`).
- `three_sq_of_corrected_witnesses` proves `¬IsExcludedForm n ⟹ ∃ x y z, x²+y²+z² = n` from these two plus the existing `dirichlet_key_lemma` axiom, by strong-induction 4-power descent (verbatim #24443 template) + mod-8 dispatch on the 4-free core. The lone exceptional core `n = 3 = 1²+1²+1²` is handled explicitly. **0 new axioms, 0 sorry.**

Net: unlike #24443 this is a genuine route to eliminating the sufficiency axiom (both hypotheses are dischargeable via Dirichlet primes in AP + quadratic reciprocity), not a reduction to a false claim.

## Verification

`verify_corrected_split.py` (pure stdlib + sympy `isprime`) certifies, for all 4-free non-excluded `m ≤ 4000`:
- `m % 8 ∈ {1,2,5,6}` always has a Dirichlet witness (0 failures);
- `m % 8 = 3` always has a residue-3 prime deficit, except `m = 3` (handled explicitly);
- the monolithic witness **never** works on `m ≡ 3` (0 accidental successes — confirms the obstruction).

## Build status

Build-pending: written under a Docker blackout (`docker ps` exit 124). Unregistered companion (like `ThreeSquaresSufficiency.lean` / `ThreeSquaresResidue3.lean`), harmless to the build until a post-blackout session verifies via `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSufficiencyCorrected`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSufficiencyCorrected` once Docker is available