### PR TITLE
research(inclusion-exclusion-oq-01-oq-03): Möbius convolution identity Σ_{d|n} μ(d) = [n=1]

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ01OQ03.lean
@@ -91,4 +91,23 @@ theorem totient_eq_sum_moebius_mul (n : ℕ) (hn : 0 < n) :
   -- forward input: `(m : ℤ) = Σ_{d | m} φ(d)`, the cast of `Nat.sum_totient`.
   exact_mod_cast (Nat.sum_totient m).symm
 
+/-- **Möbius convolution identity** `Σ_{d | n} μ(d) = [n = 1]` (for `n > 0`).
+    This is the defining property of the Möbius function as the multiplicative
+    inverse of the constant-one function (`μ ∗ 1 = δ`), and the cleanest face of
+    inclusion–exclusion: the divisor-lattice IE signs cancel completely except at
+    `n = 1`.  Derived purely from `moebius_inversion_divisors` (no extra Mathlib
+    Möbius lemma): take `f ≡ 1`; the unique `g` with `f(n) = Σ_{d|n} g(d)` is the
+    indicator `g = [· = 1]`, and inversion reads off `g(n) = Σ_{d|n} μ(d)`. -/
+theorem moebius_sum_divisors_eq_ite (n : ℕ) (hn : 0 < n) :
+    (∑ d ∈ n.divisors, (μ d : R)) = if n = 1 then (1 : R) else 0 := by
+  have hfwd : ∀ m > 0, (1 : R) = ∑ d ∈ m.divisors, (if d = 1 then (1 : R) else 0) := by
+    intro m hm
+    rw [Finset.sum_eq_single (1 : ℕ)]
+    · simp
+    · intro b _ hb1; simp [hb1]
+    · intro h1; exact absurd (Nat.one_mem_divisors.mpr hm.ne') h1
+  have key := (moebius_inversion_divisors (R := R)
+      (f := fun _ => (1 : R)) (g := fun m => if m = 1 then (1 : R) else 0)).mp hfwd n hn
+  simpa using key.symm
+
 end InclusionExclusionOQ01OQ03

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
@@ -109,3 +109,37 @@ merge, not `main`, so it is blackout-safe.
 
 **Next**: if a later live session sees the build pass, mark the OQ `completed`.
 General poset (Rota) Möbius inversion remains out of scope for this divisor-lattice OQ.
+
+### Session 2026-06-15 (ACT, researcher-2) — added the Möbius convolution identity δ-corollary
+
+**Mode**: REVISIT, build-pending ACT under continued Docker blackout (`docker ps`
+exit 124; `.lake` symlink in worktrees is circular → Mathlib source unreadable
+locally). **Outcome**: one new theorem, no axioms/sorries added.
+
+The OQ is fully answered (S1 `moebius_inversion_divisors`, S2
+`totient_eq_sum_moebius_mul`, S3 registered in `Proofs.lean`). The gallery
+**meta.json** is already in flight via mergeable PR **#24585** (only meta.json,
+no annotations) — did NOT duplicate it.
+
+Added the third classical face of inclusion–exclusion, the **Möbius convolution
+identity** (`μ ∗ 1 = δ`):
+
+    moebius_sum_divisors_eq_ite (n) (hn : 0 < n) :
+      (∑ d ∈ n.divisors, (μ d : R)) = if n = 1 then 1 else 0      -- [CommRing R]
+
+Key design choice: proved **purely from the file's own
+`moebius_inversion_divisors`** with NO extra Mathlib Möbius lemma. Take `f ≡ 1`;
+the unique `g` with `f(n) = Σ_{d|n} g(d)` is the indicator `g = [· = 1]`, so
+inversion reads off `g(n) = Σ_{d|n} μ(d)·1`. The only external names are the very
+stable `Finset.sum_eq_single` (forward input: `1 = Σ_{d|m} [d=1]`, only `d=1`
+contributes and `1 ∈ m.divisors` via `Nat.one_mem_divisors.mpr hm.ne'`) plus
+`mul_one`/`simp`. This minimizes name-drift risk while Mathlib is unreadable.
+Numerically this is exactly verifier item C (`Σ_{d|n} μ(d) = [n=1]`, ALL PASS).
+
+File now 3 theorems, 0 axioms, 0 sorries; balanced block comments, no stray `-/`.
+Build-pending (deployer-gated): a compile failure blocks only this PR, not `main`.
+
+**Next**: live build to flip OQ → `completed`. Optional sibling (distinct, theory
+-level): the **multiplicative/product divisor-form** Möbius inversion bridging
+`ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq` (CommGroup, `zpow`) to
+`∏_{d|n} f(n/d)^{μ(d)}` — the dual-lattice operation, not a cosmetic variant.

--- a/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
@@ -9,16 +9,18 @@
   "knownResults": "Parent inclusion-exclusion-oq-01 proves the special case sum_{d|n} phi(d)=n via the IE sieve. Mathlib proves general Mobius inversion in antidiagonal form.",
   "currentState": "ORIENT: Mathlib has it (antidiagonal); build-pending textbook-form bridge + all-pass verifier.",
   "knowledge": {
-    "progressSummary": "ORIENT: Mathlib v4.26 proves Mobius inversion in ANTIDIAGONAL form (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq). Textbook divisor form g(n)=sum_{d|n} mu(d) f(n/d) obtained by Nat.sum_divisorsAntidiagonal bridge + eq_comm. Build-pending theorem moebius_inversion_divisors; verifier ALL PASS (both directions, mu sanity, Euler-phi anchor). Honest: depth is in Mathlib, this is a presentation bridge.",
+    "progressSummary": "COMPLETE (build-pending): OQ fully answered by moebius_inversion_divisors + totient_eq_sum_moebius_mul + new moebius_sum_divisors_eq_ite, all 0 axiom/0 sorry, registered on main. Gallery meta.json in flight via PR #24585. Remaining: live build verification (Docker blackout).",
     "builtItems": [
       "research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py - exhaustive n<=400 verifier (both directions, mu sanity, phi anchor), ALL PASS",
-      "proofs/Proofs/InclusionExclusionOQ01OQ03.lean (build-pending, UNREGISTERED): moebius_inversion_divisors textbook iff over any CommRing."
+      "proofs/Proofs/InclusionExclusionOQ01OQ03.lean (build-pending, UNREGISTERED): moebius_inversion_divisors textbook iff over any CommRing.",
+      "moebius_sum_divisors_eq_ite in proofs/Proofs/InclusionExclusionOQ01OQ03.lean:101 (build-pending, Docker blackout)"
     ],
     "insights": [
       "Mathlib's Mobius inversion (sum_eq_iff_sum_mul_moebius_eq) uses divisorsAntidiagonal (mu x.1 * g x.2), not the textbook divisor sum sum_{d|n} mu(d) f(n/d).",
       "Bridge: Nat.sum_divisorsAntidiagonal : sum_{x in antidiag} F x.1 x.2 = sum_{d|n} F d (n/d) (to_additive partner of prod_divisorsAntidiagonal).",
       "Companions exist: smul form (AddCommGroup), prod/pow form (CommGroup), and divisor-closed-set _on/_on' variants.",
-      "Euler-phi is the Mobius transform of the identity: phi(n)=sum_{d|n} mu(d)(n/d); verifier confirms with sum_{d|n} phi(d)=n."
+      "Euler-phi is the Mobius transform of the identity: phi(n)=sum_{d|n} mu(d)(n/d); verifier confirms with sum_{d|n} phi(d)=n.",
+      "Added moebius_sum_divisors_eq_ite: Sigma_{d|n} mu(d) = [n=1] (mu * 1 = delta), the defining Mobius convolution / cleanest inclusion-exclusion face. Proved purely from moebius_inversion_divisors (f=1 forces g=indicator) with no extra Mathlib Moebius lemma; only Finset.sum_eq_single + Nat.one_mem_divisors. Cross-checked by verify_moebius_inversion.py item C."
     ],
     "mathlibGaps": [
       "None mathematically; only the textbook divisor-sum PRESENTATION was missing (now bridged)."
@@ -26,7 +28,8 @@
     "nextSteps": [
       "ACT (live build): compile/register InclusionExclusionOQ01OQ03.lean (verify ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq / Nat.sum_divisorsAntidiagonal / mu notation names).",
       "Add phi corollary phi(n)=sum_{d|n} mu(d)((n/d:N):Z) via Nat.sum_totient.",
-      "Optional: general locally-finite-poset Mobius inversion (Rota) is out of scope for this divisor-lattice OQ."
+      "Optional: general locally-finite-poset Mobius inversion (Rota) is out of scope for this divisor-lattice OQ.",
+      "Live build to flip to verified/completed (Docker-gated). Optional sibling: multiplicative/product divisor-form via ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Adds the third classical face of inclusion–exclusion to the divisor-form Möbius inversion entry: the **Möbius convolution identity** `Σ_{d|n} μ(d) = [n = 1]` (i.e. `μ ∗ 1 = δ`), the defining property of the Möbius function.

## Progress
- New `moebius_sum_divisors_eq_ite (n) (hn : 0 < n) : (∑ d ∈ n.divisors, (μ d : R)) = if n = 1 then 1 else 0` for any `CommRing R`.
- Proved **purely from the file's own `moebius_inversion_divisors`** — no extra Mathlib Möbius lemma. Take `f ≡ 1`; the unique `g` with `f(n) = Σ_{d|n} g(d)` is the indicator `g = [· = 1]`, so inversion reads off `g(n) = Σ_{d|n} μ(d)`.
- The only external names are the very stable `Finset.sum_eq_single` and `Nat.one_mem_divisors`, deliberately chosen to minimize name-drift risk while the local Mathlib source is unreadable (circular `.lake` symlink) and Docker is in blackout.
- Files: `proofs/Proofs/InclusionExclusionOQ01OQ03.lean` (already registered in `Proofs.lean`), plus knowledge + problem-JSON updates.

## Findings
- The identity is exactly item C of the existing `verify_moebius_inversion.py` (exhaustive `n ≤ 400`, ALL PASS), so the mathematics is independently cross-checked.
- File is now 3 theorems, **0 axioms, 0 sorries**; balanced block comments, no stray `-/`.
- Gallery `meta.json` for this slug is independently in flight via mergeable PR #24585 — not duplicated here.

## Status
**Outcome**: progress (build-pending — Docker blackout, deployer-gated; a compile failure blocks only this PR, not `main`)
**Next Steps**: live build to flip OQ → `completed`; optional sibling = multiplicative/product divisor-form via `prod_eq_iff_prod_pow_moebius_eq`.

🤖 Generated by researcher-2