### PR TITLE
research(abel-ruffini-galois-direction): R4 re-resolved — import char-in-normal instance, rescind S15's wrong 'absent' claim

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -33,6 +33,9 @@
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
 import Mathlib.GroupTheory.Sylow
 import Mathlib.GroupTheory.Perm.Cycle.Type
+-- Brings the char-in-normal transitivity instance `ConjAct.normal_of_characteristic_of_normal`
+-- (Step 4 / Risk R4) into scope; it is NOT transitively imported via `Sylow`.
+import Mathlib.GroupTheory.GroupAction.ConjAct
 
 namespace AbelRuffiniGaloisExtensionsOQ06GaloisDirection
 
@@ -69,7 +72,7 @@ variable {p : ℕ} [Fact p.Prime]
        in `↥A` (`Sylow.characteristic_of_normal`, Sylow.lean:728); with `A ⊴ ↥H`
        (from `A` characteristic in `↥H`) the transported subgroup
        `Q.map A.subtype` is then **normal in `↥H`** by the *instance*
-       `Subgroup.normal_of_characteristic_of_normal`
+       `ConjAct.normal_of_characteristic_of_normal`
        (`Mathlib/GroupTheory/GroupAction/ConjAct.lean:260` at pin `2df2f015`:
        `{H : Subgroup G} [H.Normal] {K : Subgroup H} [K.Characteristic] :
        (K.map H.subtype).Normal`). Instantiated with `G := ↥H`, lemma-`H := A`,
@@ -86,7 +89,7 @@ variable {p : ℕ} [Fact p.Prime]
     arithmetic, and the orbit–stabilizer transitivity. The char-in-normal step
     that S8 flagged as the single hardest residual ("no upstream bearer",
     ~10–30 LOC) is **resolved** — it is the 0-LOC instance
-    `Subgroup.normal_of_characteristic_of_normal` cited in step 4. Risk R4
+    `ConjAct.normal_of_characteristic_of_normal` cited in step 4. Risk R4
     accordingly stays MEDIUM but the budget shrinks (see knowledge.md R4 §S10).
     Discharge deferred to a Docker-up ACT session. -/
 theorem sylow_p_unique


### PR DESCRIPTION
## Summary
Corrects a knowledge regression and ships a real prep fix for Step 4 / Risk R4 of the Galois-direction sub-OQ.

## Findings
- **S15's "Correction 2" was wrong.** It claimed `Subgroup.normal_of_characteristic_of_normal` is *absent* in v4.26.0 and that Step 4's char-in-normal transitivity "needs ~5–20 LOC construction." The lemma is in fact present, exactly as the earlier S10 docstring claimed:
  `ConjAct.normal_of_characteristic_of_normal {H : Subgroup G} [H.Normal] {K : Subgroup H} [K.Characteristic] : (K.map H.subtype).Normal` — `Mathlib/GroupTheory/GroupAction/ConjAct.lean:260` (verified against the pinned sibling clone at `2df2f0150c27`). S15 searched the `Subgroup.` prefix; the lemma lives in `namespace ConjAct`, and being an `instance` its name prefix is irrelevant to typeclass resolution. **R4's char-in-normal step is a genuine 0-LOC instance** — revert the S15 downgrade.
- **Real prep fix (not just docs):** the file *cited* the instance but did **not import** the module that defines it (imports were only `Sylow` + `Perm.Cycle.Type` + parent, and `Sylow.lean` does not transitively import `GroupAction.ConjAct`). So the cited "fires by typeclass resolution" would currently fail at Step-4 discharge. Added `import Mathlib.GroupTheory.GroupAction.ConjAct` and fixed the two in-source name references `Subgroup.…` → `ConjAct.…`.

## Progress
- Files: `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean` (import + 2 name fixes), knowledge note, problem JSON.
- No proof/sorry change; the file still carries only TRUE `sorry` stubs (Steps 1, 3, 4, 5).

## Status
**Outcome**: progress (blackout-safe — an import of a verified-existing module + balanced-block docstring edits cannot break compilation, even though the file is registered).
**Next Steps**: Docker-up discharge of Step 4 (instance now in scope + correct name); Step 1 (~70–110 LOC wiring) remains the true blocker.

🤖 Generated by researcher-2