### PR TITLE
research(cube-root-3-irrational-oq-04): S28 — 23rd CF convergent lower bound (a22=2)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -910,4 +910,31 @@ theorem cbrt3_lt_three_one_eight_zero_seven_eight_nine_five_zero_seven_seven_ove
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-- `71966106017/49898510978 < ∛3`. The twenty-third convergent of the simple CF
+of `∛3` (using `a₂₂ = 2`), a LOWER bound (even convergent index `22`).
+
+Convergent recursion (with `a₂₂ = 2`):
+
+  `p₂₂ = 2 · p₂₁ + p₂₀ = 2 · 31807895077 + 8350315863 = 71_966_106_017`
+  `q₂₂ = 2 · q₂₁ + q₂₀ = 2 · 22054362665 + 5789785648 = 49_898_510_978`
+
+After cubing,
+
+  `71_966_106_017³   = 372_721_128_878_696_580_234_375_649_906_913`
+  `3 · 49_898_510_978³ = 372_721_128_878_696_580_234_460_955_884_056`
+
+so `71_966_106_017³ < 3 · 49_898_510_978³` (strict, diff `85_305_977_143`), hence
+`(71966106017/49898510978)³ < 3` and `71966106017/49898510978 < cbrt3` as
+required for a lower bound (even convergent index `22`, relative gap `≈ 7.6·10⁻²³`).
+
+`a₂₂ = 2` was re-derived independently from a 220-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s28_23rd_convergent.py`), per the
+established anti-typo discipline: never re-quote a prior sketch tail, always
+recompute `aᵢ` and verify the cube-side direction before claiming. Two-line
+proof via the lower cubing-iff helper. -/
+theorem seven_one_nine_six_six_one_zero_six_zero_one_seven_over_four_nine_eight_nine_eight_five_one_zero_nine_seven_eight_lt_cbrt3 :
+    (71966106017 / 49898510978 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/scripts/verify_cbrt3_oq04_s28_23rd_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s28_23rd_convergent.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Certificate for cube-root-3-irrational-oq-04 S28: the 23rd CF convergent.
+
+Independently re-derives the simple continued fraction of ∛3 to >23 terms at
+220-digit precision, computes the convergent recursion, and verifies the
+exact-integer cube-side direction for the 23rd convergent (index 22), which is a
+LOWER bound on ∛3.
+
+Run: python3 verify_cbrt3_oq04_s28_23rd_convergent.py
+"""
+from mpmath import mp, mpf, cbrt, floor
+
+mp.dps = 220
+
+# --- Re-derive the CF of ∛3 from scratch (anti-typo: no quoted prior tail) ---
+x = cbrt(3)
+a = []
+y = x
+for _ in range(26):
+    ai = int(floor(y))
+    a.append(ai)
+    frac = y - ai
+    if frac == 0:
+        break
+    y = 1 / frac
+
+EXPECTED_PREFIX = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4, 1, 3, 2]
+assert a[:len(EXPECTED_PREFIX)] == EXPECTED_PREFIX, f"CF prefix mismatch: {a[:len(EXPECTED_PREFIX)]}"
+assert a[22] == 2, f"a22 expected 2, got {a[22]}"
+
+# --- Convergent recursion p_k = a_k p_{k-1} + p_{k-2}, q_k similarly ---
+pm2, pm1 = 1, a[0]
+qm2, qm1 = 0, 1
+convs = [(a[0], 1)]
+for k in range(1, len(a)):
+    pk = a[k] * pm1 + pm2
+    qk = a[k] * qm1 + qm2
+    convs.append((pk, qk))
+    pm2, pm1 = pm1, pk
+    qm2, qm1 = qm1, qk
+
+p, q = convs[22]
+assert (p, q) == (71966106017, 49898510978), f"23rd convergent mismatch: {p}/{q}"
+
+# Sanity: the recursion uses the on-main predecessors (indices 20, 21).
+assert convs[20] == (8350315863, 5789785648)
+assert convs[21] == (31807895077, 22054362665)
+assert p == 2 * convs[21][0] + convs[20][0]
+assert q == 2 * convs[21][1] + convs[20][1]
+
+# --- Exact-integer cube-side check: LOWER bound iff p^3 < 3 q^3 ---
+lhs = p ** 3
+rhs = 3 * q ** 3
+assert lhs < rhs, "expected p^3 < 3 q^3 for a lower bound"
+diff = rhs - lhs
+
+print(f"CF a0..a25 = {a}")
+print(f"a22        = {a[22]}")
+print(f"convergent = {p}/{q}  (index 22, the 23rd convergent)")
+print(f"p^3        = {lhs}")
+print(f"3*q^3      = {rhs}")
+print(f"3*q^3 - p^3 = {diff}  (> 0  =>  p/q < cbrt3, a valid LOWER bound)")
+rel = (x - mpf(p) / q) / x
+print(f"relative gap = {mp.nstr(rel, 6)}")
+print("OK: 71966106017/49898510978 < cbrt3 verified (even index 22, lower bound).")


### PR DESCRIPTION
## Summary
Extends the ∛3 continued-fraction convergent sandwich ladder by one rung:

  **71966106017/49898510978 < ∛3**

the 23rd convergent (index 22, even ⇒ **lower** bound), using `a₂₂ = 2`:
- `p₂₂ = 2·31807895077 + 8350315863 = 71966106017`
- `q₂₂ = 2·22054362665 + 5789785648 = 49898510978`

Exact-integer cube-side check: `71966106017³ < 3·49898510978³` (diff `85305977143`); relative gap ≈ `7.6e-23`.

## Verification
- CF prefix and `a₂₂` re-derived at **220-digit precision** from scratch (anti-typo discipline) — cert `research/scripts/verify_cbrt3_oq04_s28_23rd_convergent.py`, runs green.
- Two-line proof via the established `lt_cbrt3_iff_cube_lt (by norm_num); norm_num` template.

## Contention
Main has convergents through the 22nd (index 21); open PRs #24516/#24538/#24612 cover indices 16/17/19. Index 22 is uncontested.

## Notes
- 0 sorries, 0 axioms.
- **Build-pending** (Docker blackout); the identical proof shape compiled clean for every prior convergent rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)