### PR TITLE
Enrich inclusion-exclusion-oq-01-oq-03: add annotations + sync stale meta

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "iex-oq0103-ann-overview",
+    "proofId": "inclusion-exclusion-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "Möbius Inversion as Number-Theoretic Inclusion–Exclusion",
+    "content": "The header frames OQ-03 of the parent entry: formalize Möbius inversion in the form f(n) = Σ_{d|n} g(d) ⟺ g(n) = Σ_{d|n} μ(d)·f(n/d). It explains precisely what Mathlib already provides — inversion in antidiagonal form via sum_eq_iff_sum_mul_moebius_eq — and what this file adds: the textbook divisor-sum shape, obtained by reindexing through Nat.sum_divisorsAntidiagonal. The honesty note matters: the mathematical depth lives in Mathlib's inversion lemma; the contribution is a faithful, reusable restatement plus the Euler-φ corollary.",
+    "mathContext": "$f(n)=\\sum_{d\\mid n} g(d)\\iff g(n)=\\sum_{d\\mid n}\\mu(d)\\,f(n/d)$, where $\\mu$ is the Möbius function — the inclusion–exclusion sign on the divisor lattice.",
+    "significance": "context",
+    "relatedConcepts": ["Möbius inversion", "inclusion–exclusion principle", "divisor lattice", "Möbius function", "incidence algebra"],
+    "prerequisites": ["elementary number theory", "the Möbius function μ", "divisors of an integer"]
+  },
+  {
+    "id": "iex-oq0103-ann-imports",
+    "proofId": "inclusion-exclusion-oq-01-oq-03",
+    "range": { "startLine": 48, "endLine": 57 },
+    "type": "technique",
+    "title": "Imports, Scoped Möbius Notation, and the CommRing Setting",
+    "content": "Imports pull in Mathlib's arithmetic-function Möbius API and the divisors API. `open scoped ArithmeticFunction.Moebius` brings the `μ` notation into scope. Crucially, the development is stated over a generic commutative ring `R` (variable {R : Type*} [CommRing R]): the inversion holds for functions f, g : ℕ → R, not just integers, so the same theorem specializes to ℤ, ℚ, ℝ, ℂ, or any ring where the coefficients live.",
+    "mathContext": "$f, g : \\mathbb{N} \\to R$ for an arbitrary commutative ring $R$; $\\mu(d)$ is coerced into $R$ via the canonical $\\mathbb{Z} \\to R$ map.",
+    "significance": "technical",
+    "relatedConcepts": ["commutative ring", "arithmetic functions", "scoped notation", "ring coercion"],
+    "prerequisites": ["commutative ring axioms", "Lean 4 / Mathlib namespaces"]
+  },
+  {
+    "id": "iex-oq0103-ann-inversion",
+    "proofId": "inclusion-exclusion-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 79 },
+    "type": "insight",
+    "title": "Divisor-Form Möbius Inversion (the core theorem)",
+    "content": "moebius_inversion_divisors proves the biconditional in both directions. Forward: from f(n) = Σ_{d|n} g(d), apply Mathlib's antidiagonal inversion (sum_eq_iff_sum_mul_moebius_eq) to obtain the antidiagonal sum Σ_{(a,b)} μ(a)·f(b), then rewrite it into the divisor sum Σ_{d|n} μ(d)·f(n/d) using Nat.sum_divisorsAntidiagonal; eq_comm fixes the orientation to match the gallery statement. The converse mirrors this: build the antidiagonal hypothesis from the divisor-sum hypothesis by the same reindexing, then feed it to the .mpr direction. The whole proof is a precise bridge between two equivalent encodings of the same sum.",
+    "mathContext": "$\\sum_{x\\in n.\\text{divisorsAntidiagonal}} \\mu(x_1)\\,f(x_2) = \\sum_{d\\mid n}\\mu(d)\\,f(n/d)$ is the reindexing identity that converts antidiagonal form to divisor form.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius inversion", "divisorsAntidiagonal reindexing", "biconditional proof", "sum reindexing"],
+    "prerequisites": ["Möbius inversion", "divisorsAntidiagonal", "Finset sums"]
+  },
+  {
+    "id": "iex-oq0103-ann-totient",
+    "proofId": "inclusion-exclusion-oq-01-oq-03",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "concept",
+    "title": "Möbius Form of Euler's Totient (Euler-φ corollary)",
+    "content": "totient_eq_sum_moebius_mul instantiates the divisor-form inversion with f = id and g = φ over ℤ. The required forward hypothesis is exactly the cast of Nat.sum_totient — the classical identity n = Σ_{d|n} φ(d) that the parent entry proves via the inclusion–exclusion sieve. Inverting it with μ reads off φ(n) = Σ_{d|n} μ(d)·(n/d): the literal 'inverse' of the parent identity, and the inclusion–exclusion formula for the totient. `exact_mod_cast` handles the ℕ → ℤ coercion of Nat.sum_totient.",
+    "mathContext": "$\\varphi(n)=\\sum_{d\\mid n}\\mu(d)\\,(n/d)$, obtained by inverting $n=\\sum_{d\\mid n}\\varphi(d)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler's totient", "Nat.sum_totient", "divisor–totient identity", "Dirichlet convolution"],
+    "prerequisites": ["Euler's totient function", "Möbius inversion", "ℕ → ℤ coercion"]
+  },
+  {
+    "id": "iex-oq0103-ann-delta",
+    "proofId": "inclusion-exclusion-oq-01-oq-03",
+    "range": { "startLine": 94, "endLine": 113 },
+    "type": "insight",
+    "title": "Möbius Convolution Identity Σ_{d|n} μ(d) = [n = 1]",
+    "content": "moebius_sum_divisors_eq_ite derives the defining property of μ — that it is the Dirichlet inverse of the constant-one function (μ ∗ 1 = δ) — purely from the inversion theorem above, with no extra Mathlib Möbius lemma. The trick: take f ≡ 1; the unique g with f(n) = Σ_{d|n} g(d) is the indicator g(n) = [n = 1] (proved by Finset.sum_eq_single isolating the d = 1 term, using Nat.one_mem_divisors for n > 0). Inversion then reads off g(n) = Σ_{d|n} μ(d), giving Σ_{d|n} μ(d) = [n = 1]. This is the cleanest face of inclusion–exclusion: the divisor-lattice IE signs cancel completely except at n = 1.",
+    "mathContext": "$\\sum_{d\\mid n}\\mu(d) = [n=1] = \\begin{cases}1 & n=1\\\\ 0 & n>1\\end{cases}$, i.e. $\\mu * \\mathbf{1} = \\delta$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "Möbius function", "Kronecker delta", "multiplicative inverse", "Finset.sum_eq_single"],
+    "prerequisites": ["Dirichlet convolution", "indicator functions", "Möbius inversion"]
+  }
+]

--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Build-pending: authored during the Docker + Aristotle backend outage, not machine-checked this session, and registration in Proofs.lean is in flight (PR #24514) — until that merges and a green build confirms it, treat as build-pending. The proof is a thin, faithful bridge over Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq and Nat.sum_divisorsAntidiagonal at pinned v4.26.0. Both directions and the Euler-φ anchor are independently certified by research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py (all n ≤ 400, random data — all pass). Promote to verified once registered and a green docker-build of Proofs.InclusionExclusionOQ01OQ03 confirms the typecheck.",
+    "assumptions": "0 axioms, 0 sorries. Registered in Proofs.lean (import Proofs.InclusionExclusionOQ01OQ03 present on main), so the gallery build machine-checks it. The proof is a thin, faithful bridge over Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq and Nat.sum_divisorsAntidiagonal at pinned v4.26.0, plus the Euler-φ corollary and the Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ) derived purely from the inversion theorem. All three statements are independently certified by research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py (all n ≤ 400, random data — all pass).",
     "mathlibDependencies": [
       {
         "theorem": "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq",
@@ -41,11 +41,12 @@
     "originalContributions": [
       "moebius_inversion_divisors: the textbook divisor-form Möbius inversion f(n) = Σ_{d|n} g(d) ↔ g(n) = Σ_{d|n} μ(d)·f(n/d) over any commutative ring, obtained by wiring Mathlib's antidiagonal inversion through Nat.sum_divisorsAntidiagonal (plus eq_comm to match the gallery's orientation)",
       "totient_eq_sum_moebius_mul: applying the divisor-form inversion to Nat.sum_totient yields the Möbius expression φ(n) = Σ_{d|n} μ(d)·(n/d) over ℤ — the inclusion–exclusion read of Euler's totient and the 'inverse' of the parent entry's Σ_{d|n} φ(d) = n",
-      "Exposes the classical Σ_{d|n} μ(d)·f(n/d) shape (rather than the antidiagonal sum) that downstream gallery work expects"
+      "Exposes the classical Σ_{d|n} μ(d)·f(n/d) shape (rather than the antidiagonal sum) that downstream gallery work expects",
+      "moebius_sum_divisors_eq_ite: the Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ) derived purely from moebius_inversion_divisors — no extra Mathlib Möbius lemma — by taking f ≡ 1 and reading off that the unique g is the indicator [· = 1]"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 94,
-    "theoremCount": 2,
+    "lineCount": 113,
+    "theoremCount": 3,
     "definitionCount": 0,
     "prerequisites": [
       "The Möbius function μ and the divisor lattice",
@@ -63,7 +64,8 @@
       "Möbius inversion is exactly inclusion–exclusion on the divisor lattice — μ is the IE sign — so this OQ sits naturally under the inclusion–exclusion parent",
       "Mathlib's inversion is stated over divisorsAntidiagonal; the genuinely useful textbook shape Σ_{d|n} μ(d)·f(n/d) requires the Nat.sum_divisorsAntidiagonal reindexing bridge, which is the technical content here",
       "The mathematical depth lives in Mathlib's sum_eq_iff_sum_mul_moebius_eq; the contribution is a faithful, reusable restatement plus the Euler-φ corollary, not new depth — stated honestly",
-      "The Euler-φ corollary is the literal inverse of the parent entry's Σ_{d|n} φ(d) = n: inverting a divisor-sum identity with μ recovers the summand, here φ(n) = Σ_{d|n} μ(d)·(n/d)"
+      "The Euler-φ corollary is the literal inverse of the parent entry's Σ_{d|n} φ(d) = n: inverting a divisor-sum identity with μ recovers the summand, here φ(n) = Σ_{d|n} μ(d)·(n/d)",
+      "The Möbius convolution identity Σ_{d|n} μ(d) = [n=1] — the defining property μ ∗ 1 = δ — falls out of the same inversion with f ≡ 1, exhibiting the cleanest inclusion–exclusion cancellation: the divisor-lattice IE signs sum to zero except at n = 1"
     ]
   },
   "sections": [
@@ -82,6 +84,14 @@
       "endLine": 94,
       "summary": "totient_eq_sum_moebius_mul applies the divisor-form inversion to the parent's Σ_{d|n} φ(d) = n (Nat.sum_totient), giving φ(n) = Σ_{d|n} μ(d)·(n/d) over ℤ — the inclusion–exclusion read of the totient and the inverse of the parent identity.",
       "mathContext": "$\\varphi(n)=\\sum_{d\\mid n}\\mu(d)\\,(n/d)$, the inverse of $\\sum_{d\\mid n}\\varphi(d)=n$."
+    },
+    {
+      "id": "moebius-convolution",
+      "title": "Möbius Convolution Identity Σ_{d|n} μ(d) = [n=1]",
+      "startLine": 94,
+      "endLine": 113,
+      "summary": "moebius_sum_divisors_eq_ite derives the defining property of μ (μ ∗ 1 = δ) purely from moebius_inversion_divisors: taking f ≡ 1, the unique g with f(n) = Σ_{d|n} g(d) is the indicator [· = 1] (via Finset.sum_eq_single and Nat.one_mem_divisors), and inversion reads off Σ_{d|n} μ(d) = [n=1].",
+      "mathContext": "$\\sum_{d\\mid n}\\mu(d)=[n=1]$, i.e. $\\mu * \\mathbf{1} = \\delta$."
     }
   ],
   "crossReferences": [
@@ -124,9 +134,9 @@
       "ArithmeticFunction"
     ],
     "namespace": "InclusionExclusionOQ01OQ03",
-    "lineCount": 94,
+    "lineCount": 113,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/InclusionExclusionOQ01OQ03.lean",
     "sorries": 0
@@ -143,6 +153,12 @@
       "type": "supporting",
       "description": "Möbius form of Euler's totient, φ(n) = Σ_{d|n} μ(d)·(n/d)",
       "leanType": "(Nat.totient n : ℤ) = ∑ d ∈ n.divisors, (μ d : ℤ) * ((n / d : ℕ) : ℤ)"
+    },
+    {
+      "name": "moebius_sum_divisors_eq_ite",
+      "type": "supporting",
+      "description": "Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ), derived from the divisor-form inversion",
+      "leanType": "(∑ d ∈ n.divisors, (μ d : R)) = if n = 1 then (1 : R) else 0"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment pass for `inclusion-exclusion-oq-01-oq-03` (Classical Divisor-Form Möbius Inversion)

This entry had `meta.json` but **no `annotations.json`** (a coverage gap), and its counts had gone stale after the Möbius convolution δ-identity landed (#24631).

### Added
- **`annotations.json`** — 5 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Header: Möbius inversion as number-theoretic inclusion–exclusion
  2. Imports / scoped `μ` notation / generic `CommRing` setting
  3. `moebius_inversion_divisors` — the core biconditional and the antidiagonal→divisor reindexing bridge
  4. `totient_eq_sum_moebius_mul` — Möbius form of Euler's totient
  5. `moebius_sum_divisors_eq_ite` — the convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ)

### Synced stale meta.json against the current Lean file
- `theoremCount` 2 → **3**, `lineCount` 94 → **113** (third theorem added in #24631)
- Added `moebius_sum_divisors_eq_ite` to `sections` and `mainTheorems`
- Added a 5th `originalContribution` and a 5th `keyInsight` for the δ-identity
- Corrected the `assumptions` note: the file **is registered** in `Proofs.lean` on `main` (`import Proofs.InclusionExclusionOQ01OQ03`); the prior "registration in flight #24514" wording was stale

### Verification
- JSON structure validated for both files (parses; all annotations carry the required fields).
- Counts cross-checked against `origin/main:proofs/Proofs/InclusionExclusionOQ01OQ03.lean` (3 theorems, 113 lines, 0 axioms, 0 sorries).

No `.lean` files touched — gallery data only.