### PR TITLE
research(friendship-theorem-oq-04): finiteness-free infinite windmill structure

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -36,6 +36,15 @@ that has no infinite analogue:
   gallery theorem `FriendshipTheorem.friendship_theorem` recovers a universal
   vertex for any locally finite friendship graph with at least three vertices.
 
+* `universal_noncentral_neighborSet` / `universal_noncentral_ncard_two` — the
+  **infinite windmill structure**: in *any* friendship graph with a universal vertex
+  (finite or infinite), every non-centre vertex has exactly two neighbours — the
+  centre and a unique partner — so `N(u) = {centre, partner}`. This is the
+  finiteness-free analogue of the finite gallery's
+  `FriendshipTheorem.friendship_noncentral_degree` (which states `G.degree u = 2`, a
+  `Fintype` notion); it shows the recovered conclusion is genuinely a windmill even
+  on infinite vertex types.
+
 Where the finite proof breaks: the spectral step
 `FriendshipTheorem.friendship_regular_implies_universal` is entirely finite-matrix
 algebra (trace, finite eigenvalue multiplicities, integrality) and has no infinite
@@ -141,5 +150,47 @@ theorem locally_finite_friendship_has_universal (hF : IsFriendshipGraph G)
     calc 3 = ({a, b, c} : Finset V).card := hcard.symm
       _ ≤ Fintype.card V := Finset.card_le_univ _
   exact FriendshipTheorem.friendship_theorem G (fun u v h => hF u v h) h3
+
+/-- **Infinite windmill structure.** In a friendship graph with a universal vertex
+`c` (finite **or** infinite), every non-centre vertex `u` is adjacent to *exactly*
+two vertices — the centre `c` and a unique "partner" `w` — so `N(u) = {c, w}`. The
+graph is therefore a windmill (triangles `{c, u, w}` sharing the centre) even when
+infinite. No `[Fintype V]` assumption is used: the finite gallery proof
+`FriendshipTheorem.friendship_noncentral_degree` derives `G.degree u = 2` (a
+`Fintype` notion); this states the underlying *set* equality directly, which holds
+verbatim on infinite vertex types. -/
+theorem universal_noncentral_neighborSet (hF : IsFriendshipGraph G)
+    (c : V) (hc : FriendshipTheorem.IsUniversalVertex G c) (u : V) (hu : u ≠ c) :
+    ∃ w, w ≠ c ∧ w ≠ u ∧ G.Adj u w ∧ G.neighborSet u = {c, w} := by
+  obtain ⟨w, hw⟩ := Set.ncard_eq_one.mp (hF u c hu)
+  have hw_mem : w ∈ G.commonNeighbors u c := by
+    rw [hw]; exact Set.mem_singleton_iff.mpr rfl
+  rw [SimpleGraph.mem_commonNeighbors] at hw_mem
+  have hwu : w ≠ u := fun heq => G.loopless u (heq ▸ hw_mem.1)
+  have hwc : w ≠ c := fun heq => G.loopless c (heq ▸ hw_mem.2)
+  refine ⟨w, hwc, hwu, hw_mem.1, ?_⟩
+  ext x
+  simp only [SimpleGraph.mem_neighborSet, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · intro hadj
+    by_cases hxc : x = c
+    · exact Or.inl hxc
+    · refine Or.inr ?_
+      have hcx : G.Adj c x := hc x hxc
+      have hxmem : x ∈ G.commonNeighbors u c :=
+        (SimpleGraph.mem_commonNeighbors G).mpr ⟨hadj, hcx⟩
+      exact Set.mem_singleton_iff.mp (hw ▸ hxmem)
+  · rintro (rfl | rfl)
+    · exact G.symm (hc u hu)
+    · exact hw_mem.1
+
+/-- Every non-centre vertex of a friendship graph with a universal vertex has
+exactly two neighbours (`ncard = 2`), with no `[Fintype V]` assumption — the
+finiteness-free analogue of `FriendshipTheorem.friendship_noncentral_degree`. -/
+theorem universal_noncentral_ncard_two (hF : IsFriendshipGraph G)
+    (c : V) (hc : FriendshipTheorem.IsUniversalVertex G c) (u : V) (hu : u ≠ c) :
+    (G.neighborSet u).ncard = 2 := by
+  obtain ⟨w, hwc, _, _, hset⟩ := universal_noncentral_neighborSet hF c hc u hu
+  rw [hset, Set.ncard_pair (Ne.symm hwc)]
 
 end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -211,3 +211,37 @@ positive OQ-04 result.
 ### Still open (unchanged)
 Negative half — the C₅ free-amalgamation infinite counterexample — still needs an
 inductive-limit construction; not build-safe-tractable under blackout.
+
+---
+
+## Session (researcher-6, 2026-06-15) — finiteness-free infinite windmill structure
+
+**Mode**: REVISIT (RICH) · **Outcome**: progress (2 new theorems). Docker down
+(`docker info` timeout); build-pending. Worked in a fresh `.claude/worktrees`
+worktree off `origin/main` (loom worktree resets mid-session).
+
+### Added to `FriendshipTheoremOQ04.lean` (2 theorems, still 0 sorry / 0 axiom)
+- `universal_noncentral_neighborSet`: in a friendship graph with a universal vertex
+  `c` (finite **or** infinite), every non-centre `u` satisfies `G.neighborSet u =
+  {c, w}` for a unique partner `w ≠ c` — i.e. the **infinite windmill** structure.
+- `universal_noncentral_ncard_two`: corollary `(G.neighborSet u).ncard = 2`.
+
+**Why this is new (not a dup of the finite proof):** the gallery's finite
+`FriendshipTheorem.friendship_noncentral_degree` (FriendshipTheorem.lean:135) proves
+`G.degree u = 2` — `G.degree` is a `Fintype` notion, so that lemma is unusable on
+infinite vertex types. The *set* equality `N(u) = {c, w}` underlying it needs **no
+finiteness**; this session states it directly, completing the "conclusion restored"
+side of OQ-04 by showing the recovered graph is genuinely a windmill even infinitely.
+
+**Verification (build-free).** The proof is a near-verbatim port of the compiling
+finite proof (FriendshipTheorem.lean:138–163), swapping `neighborFinset`→`neighborSet`
+and `Finset.mem_insert`/`Finset.card_pair`→`Set.mem_insert_iff`/`Set.ncard_pair`.
+All bearers in use already in this repo: `Set.ncard_eq_one`,
+`SimpleGraph.mem_commonNeighbors`, `SimpleGraph.mem_neighborSet`, `Set.ncard_pair`
+(e.g. Erdos157Problem.lean:72), `G.loopless`, `G.symm`. High static confidence;
+machine-check deferred to the next Docker-up deployer build (deployer-gated, so a
+compile error blocks the PR rather than reaching `main`).
+
+### Still open (unchanged)
+Negative half — the C₅ free-amalgamation infinite counterexample — still needs an
+inductive-limit construction; not build-safe-tractable under blackout.

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (registration): added FriendshipTheoremOQ04.lean to the Proofs.lean import manifest so the spectral-free positive result (diameter-2 covering, locally-finite=>finite, infinite=>infinite-degree obstruction, universal-vertex capstone) is finally machine-checked rather than inspection-only. 8 theorems / 0 sorry / 0 axiom. Counterexample (C5 free-amalgamation) direction still open.",
+    "progressSummary": "PROGRESS (S, build-pending): added finiteness-free infinite windmill structure theorems; positive half of OQ-04 now includes the windmill shape, not just universal-vertex existence. Negative half (C5 amalgam) still open.",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
@@ -37,7 +37,8 @@
       "univ_subset_two_ball (:79): univ subset {v} U N(v) U bigUnion_{x in N(v)} N(x) via exists_common_neighbor.",
       "univ_finite_of_locallyFinite (:96) + locally_finite_is_finite (:109): local finiteness => Finite V via Set.Finite.biUnion of the 2-ball covering.",
       "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices.",
-      "Added import Proofs.FriendshipTheoremOQ04 to proofs/Proofs.lean (manifest registration → file now in the machine-checked build set, deployer-gated)"
+      "Added import Proofs.FriendshipTheoremOQ04 to proofs/Proofs.lean (manifest registration → file now in the machine-checked build set, deployer-gated)",
+      "universal_noncentral_neighborSet + universal_noncentral_ncard_two in FriendshipTheoremOQ04.lean — finiteness-free infinite windmill structure (N(u)={c,w}, ncard=2)"
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -47,7 +48,8 @@
       "WHERE finite proof breaks: spectral step friendship_regular_implies_universal (FriendshipTheorem.lean:193) is entirely finite-matrix (trace, finite eigenvalue multiplicities, integrality) with no infinite analogue. The regularity dichotomy degrades to vacuous (all infinite degrees equal as cardinals).",
       "ACT: the positive OQ-04 result is finiteness-light and spectral-free — the diameter-2 covering (purely local) plus local finiteness gives Finite V directly, bypassing the trace/eigenvalue step that has no infinite analogue.",
       "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting.",
-      "Registered FriendshipTheoremOQ04.lean in proofs/Proofs.lean (was the only Friendship sibling absent from the import manifest, so its 8 theorems / 0 sorry / 0 axiom were inspection-only, never machine-checked). Re-verified call convention: friendship_theorem takes G explicitly (variable (G : SimpleGraph V) at FriendshipTheorem.lean:112; internal caller line 232 uses friendship_theorem G hF h), so the capstone call form is sound."
+      "Registered FriendshipTheoremOQ04.lean in proofs/Proofs.lean (was the only Friendship sibling absent from the import manifest, so its 8 theorems / 0 sorry / 0 axiom were inspection-only, never machine-checked). Re-verified call convention: friendship_theorem takes G explicitly (variable (G : SimpleGraph V) at FriendshipTheorem.lean:112; internal caller line 232 uses friendship_theorem G hF h), so the capstone call form is sound.",
+      "The finite friendship_noncentral_degree (G.degree u = 2) is Fintype-bound; the underlying set equality N(u)={c,w} needs no finiteness and holds on infinite friendship graphs with a universal vertex — the recovered graph is a genuine (infinite) windmill"
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."


### PR DESCRIPTION
## Summary
Research session on **friendship-theorem-oq-04** (the infinite Friendship Theorem). Adds the **infinite windmill structure** to `FriendshipTheoremOQ04.lean` — the missing structural shape on the "conclusion restored" side of the OQ.

## Progress
Two new theorems (file stays **0 sorry / 0 axiom**):
- `universal_noncentral_neighborSet`: in a friendship graph with a universal vertex `c` (finite **or** infinite), every non-centre vertex `u` has `G.neighborSet u = {c, w}` for a unique partner `w ≠ c`.
- `universal_noncentral_ncard_two`: corollary `(G.neighborSet u).ncard = 2`.

## Why this is new (not a dup of the finite proof)
The gallery's finite `FriendshipTheorem.friendship_noncentral_degree` proves `G.degree u = 2`, but `G.degree` is a `[Fintype V]` notion — unusable on infinite vertex types. The underlying *set* equality `N(u) = {c, w}` needs **no finiteness**; stating it directly shows the recovered graph is a genuine windmill even when infinite. This complements the file's existing positive results (`locally_finite_friendship_has_universal` etc.) with the actual windmill shape rather than just universal-vertex existence.

## Verification
Near-verbatim port of the **compiling** finite proof (`FriendshipTheorem.lean:138–163`), swapping `neighborFinset`→`neighborSet` and `Finset.mem_insert`/`Finset.card_pair`→`Set.mem_insert_iff`/`Set.ncard_pair`. All bearer lemmas are already used elsewhere in-repo (`Set.ncard_pair` e.g. `Erdos157Problem.lean:72`).

**Build-pending**: Docker host unavailable this session (blackout). Deployer-gated — a compile error blocks this PR rather than reaching `main`.

## Status
**Outcome**: progress · **Next**: Docker-up build check; negative half (C₅ free-amalgamation infinite counterexample) remains open (needs an inductive-limit construction).

🤖 Generated by researcher-6