### PR TITLE
Enrich inverse-galois-d4-oq-01: add annotations + populate sections

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "d4-oq01-ann-overview",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 3, "endLine": 51 },
+    "type": "context",
+    "title": "From |Gal| = 8 to the Structure ℤ/4 ⋊ ℤ/2",
+    "content": "The header states OQ-01 of the parent entry: the parent proves the splitting field of X⁴−2 over ℚ is Galois with |Gal| = 8 and remarks the group is D₄, but the order 8 alone does not pin down the isomorphism type — two non-abelian groups (D₄ and the quaternion group Q₈) and three abelian groups all have order 8. This file supplies the distinguishing data: a normal order-4 rotation subgroup and an order-2 reflection acting by inversion. The 'scope honesty' note is important — everything here is proved inside the abstract group DihedralGroup 4; the explicit MulEquiv from the concrete Galois group to D₄ is the harder OQ-03 bridge.",
+    "mathContext": "$D_4 \\cong \\mathbb{Z}/4 \\rtimes \\mathbb{Z}/2$, the smallest non-abelian semidirect product: cyclic rotations $\\mathbb{Z}/4$ with an order-2 reflection acting by inversion.",
+    "significance": "context",
+    "relatedConcepts": ["inverse Galois problem", "dihedral group", "semidirect product", "groups of order 8", "quaternion group"],
+    "prerequisites": ["Galois theory", "group theory", "splitting fields"]
+  },
+  {
+    "id": "d4-oq01-ann-rhom",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 57, "endLine": 94 },
+    "type": "definition",
+    "title": "Rotation Subgroup as the Range of an Injective Hom (≅ ℤ/4)",
+    "content": "rHom : Multiplicative (ZMod 4) →* DihedralGroup 4 sends i ↦ rᵢ; it is a monoid hom because r_mul_r turns addition of indices into multiplication of rotations, and toAdd_mul matches the multiplicative type tag. Injectivity (rHom_injective) follows from constructor injectivity of r composed with Multiplicative.toAdd being injective. Defining rotations := rHom.range then yields, via MonoidHom.ofInjective, the equivalence rotationsEquiv : rotations ≃* Multiplicative (ZMod 4) — so the rotation subgroup is cyclic of order 4 for free, with card_rotations = 4 read off through Nat.card_congr and ZMod.card. This is the normal ℤ/4 factor of the semidirect product.",
+    "mathContext": "$\\text{rotations} = \\operatorname{im}(\\text{rHom}) \\cong \\mathbb{Z}/4$, $\\;|\\text{rotations}| = 4$.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic group", "monoid homomorphism", "MonoidHom.ofInjective", "subgroup as hom range", "type tags"],
+    "prerequisites": ["group homomorphisms", "ℤ/n as Multiplicative type tag", "subgroups"]
+  },
+  {
+    "id": "d4-oq01-ann-inversion",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 96, "endLine": 108 },
+    "type": "insight",
+    "title": "The Inversion Action — the ℤ/2-Twist",
+    "content": "reflection_conj_rotation proves sr j · rᵢ · (sr j)⁻¹ = r₍₋ᵢ₎ for any reflection sr j, by a two-line computation with the dihedral simp lemmas (inv_sr, sr_mul_r, sr_mul_sr) finished by ring on the ZMod 4 indices. Specializing j = 0 and using inv_r gives reflection_conj_rotation': sr 0 · rᵢ · (sr 0)⁻¹ = rᵢ⁻¹. This single relation s·r·s⁻¹ = r⁻¹ is precisely what makes the product non-abelian: it is the difference between the direct product ℤ/4 × ℤ/2 and the semidirect product ℤ/4 ⋊ ℤ/2.",
+    "mathContext": "$s r_i s^{-1} = r_{-i} = r_i^{-1}$ — the defining relation of the dihedral semidirect structure.",
+    "significance": "key",
+    "relatedConcepts": ["semidirect product action", "conjugation", "non-abelian group", "dihedral relations"],
+    "prerequisites": ["conjugation in groups", "semidirect products", "dihedral multiplication"]
+  },
+  {
+    "id": "d4-oq01-ann-orders",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 110, "endLine": 116 },
+    "type": "technique",
+    "title": "Element Orders: Rotation Generator (4) and Reflection (2)",
+    "content": "orderOf_rotation_gen records orderOf (r 1) = 4 (directly from Mathlib's orderOf_r_one) and orderOf_reflection records orderOf (sr 0) = 2 (from orderOf_sr). These two order computations confirm the factor sizes: a generator of order 4 for the cyclic ℤ/4 rotation subgroup and an involution generating the ℤ/2 complement.",
+    "mathContext": "$\\operatorname{ord}(r_1) = 4,\\quad \\operatorname{ord}(s) = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["element order", "cyclic generator", "involution", "orderOf"],
+    "prerequisites": ["order of a group element"]
+  },
+  {
+    "id": "d4-oq01-ann-normal",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 118, "endLine": 132 },
+    "type": "concept",
+    "title": "Normality of the Rotation Subgroup",
+    "content": "rotations_normal proves rotations.Normal by case-splitting the conjugating element g: if g = r j is itself a rotation, conjugation stays in rotations by the r_mul_r computation (finished with ring); if g = sr j is a reflection, conjugation lands on r₍₋ᵢ₎ ∈ rotations via the inversion action reflection_conj_rotation already proved. Normality of the ℤ/4 factor is a prerequisite for the internal semidirect-product structure.",
+    "mathContext": "$g\\,r_i\\,g^{-1} \\in \\text{rotations}$ for all $g \\in D_4$, hence $\\text{rotations} \\trianglelefteq D_4$.",
+    "significance": "key",
+    "relatedConcepts": ["normal subgroup", "conjugation", "case analysis", "semidirect product"],
+    "prerequisites": ["normal subgroups", "conjugation"]
+  },
+  {
+    "id": "d4-oq01-ann-complement",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 134, "endLine": 180 },
+    "type": "concept",
+    "title": "The Order-2 Complement {1, sr 0} and Trivial Intersection / Generation",
+    "content": "reflections is built as the explicit subgroup {1, sr 0} (closure checked via sr_mul_self and inv_sr). Two facts make it a genuine complement: rotations_sup_reflections shows rotations ⊔ reflections = ⊤ — every element is a rotation or a rotation times sr 0, using the identity sr i = r₍₋ᵢ₎ · sr 0 and Subgroup.mul_mem_sup; and rotations_inf_reflections shows rotations ⊓ reflections = ⊥ — the only member of {1, sr 0} that is also a rotation is 1 (sr 0 cannot equal any rᵢ by constructor distinctness, closed by simp).",
+    "mathContext": "$\\text{rotations} \\sqcup \\text{reflections} = \\top,\\quad \\text{rotations} \\sqcap \\text{reflections} = \\bot$; the complement $\\cong \\mathbb{Z}/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["complement subgroup", "subgroup lattice", "join and meet", "internal direct/semidirect product"],
+    "prerequisites": ["subgroup lattice (⊓, ⊔)", "generated subgroups"]
+  },
+  {
+    "id": "d4-oq01-ann-capstone",
+    "proofId": "inverse-galois-d4-oq-01",
+    "range": { "startLine": 182, "endLine": 193 },
+    "type": "insight",
+    "title": "Capstone: Internal Semidirect-Product Decomposition",
+    "content": "d4_internal_semidirect bundles the four pieces — rotations.Normal, rotations ⊔ reflections = ⊤, rotations ⊓ reflections = ⊥, and the inversion action ∀ i, sr 0 · rᵢ · (sr 0)⁻¹ = rᵢ⁻¹ — into a single conjunction. By the internal-semidirect-product theorem (normal factor + trivially-intersecting generating complement + the action), this is exactly the statement D₄ ≅ ℤ/4 ⋊ ℤ/2 with the inversion action. It packages precisely the data the open question asked for.",
+    "mathContext": "$D_4 \\cong \\text{rotations} \\rtimes \\text{reflections} \\cong \\mathbb{Z}/4 \\rtimes \\mathbb{Z}/2$.",
+    "significance": "key",
+    "relatedConcepts": ["internal semidirect product", "group decomposition", "structure theorem"],
+    "prerequisites": ["internal semidirect product", "normal complements"]
+  }
+]

--- a/src/data/proofs/inverse-galois-d4-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/meta.json
@@ -89,6 +89,48 @@
       "Parent: Galois group of X⁴−2 has order 8"
     ]
   },
+  "sections": [
+    {
+      "id": "rotation-subgroup",
+      "title": "The Rotation Subgroup ≅ ℤ/4",
+      "startLine": 57,
+      "endLine": 94,
+      "summary": "Defines rHom : Multiplicative (ZMod 4) →* D₄ (i ↦ rᵢ), proves it injective, sets rotations := rHom.range with membership lemma mem_rotations, and derives rotationsEquiv : rotations ≃* Multiplicative (ZMod 4) and card_rotations = 4 — the normal cyclic ℤ/4 factor obtained for free from MonoidHom.ofInjective.",
+      "mathContext": "$\\text{rotations} \\cong \\mathbb{Z}/4,\\ |\\text{rotations}| = 4$."
+    },
+    {
+      "id": "inversion-action",
+      "title": "The Inversion Action (the ℤ/2-Twist)",
+      "startLine": 96,
+      "endLine": 108,
+      "summary": "reflection_conj_rotation: sr j · rᵢ · (sr j)⁻¹ = r₍₋ᵢ₎, specialized to reflection_conj_rotation': sr 0 · rᵢ · (sr 0)⁻¹ = rᵢ⁻¹ — the single relation s r s⁻¹ = r⁻¹ that makes the product non-abelian.",
+      "mathContext": "$s r_i s^{-1} = r_i^{-1}$."
+    },
+    {
+      "id": "element-orders",
+      "title": "Element Orders: Generator (4) and Reflection (2)",
+      "startLine": 110,
+      "endLine": 116,
+      "summary": "orderOf_rotation_gen (orderOf (r 1) = 4) and orderOf_reflection (orderOf (sr 0) = 2) confirm the factor sizes from Mathlib's orderOf_r_one and orderOf_sr.",
+      "mathContext": "$\\operatorname{ord}(r_1)=4,\\ \\operatorname{ord}(s)=2$."
+    },
+    {
+      "id": "normality",
+      "title": "Normality of the Rotation Subgroup",
+      "startLine": 118,
+      "endLine": 132,
+      "summary": "rotations_normal proves rotations.Normal by case-splitting the conjugator: a rotation stays in rotations by r_mul_r, a reflection by the inversion action reflection_conj_rotation.",
+      "mathContext": "$\\text{rotations} \\trianglelefteq D_4$."
+    },
+    {
+      "id": "complement-and-capstone",
+      "title": "Order-2 Complement and Internal Decomposition",
+      "startLine": 134,
+      "endLine": 193,
+      "summary": "Builds reflections = {1, sr 0} ≅ ℤ/2, proves rotations ⊔ reflections = ⊤ (via sr i = r₍₋ᵢ₎ · sr 0 and Subgroup.mul_mem_sup) and rotations ⊓ reflections = ⊥ (constructor distinctness), then bundles normality + ⊔=⊤ + ⊓=⊥ + inversion into the capstone d4_internal_semidirect — the statement D₄ ≅ ℤ/4 ⋊ ℤ/2.",
+      "mathContext": "$D_4 \\cong \\mathbb{Z}/4 \\rtimes \\mathbb{Z}/2$."
+    }
+  ],
   "conclusion": {
     "summary": "Establishes the explicit internal semidirect-product decomposition D₄ ≅ ℤ/4 ⋊ ℤ/2 for the abstract group DihedralGroup 4: a normal rotation subgroup ≅ ℤ/4 (as an injective-hom range), the order-2 reflection sr 0, the defining inversion action sr·r·sr⁻¹ = r⁻¹, and a trivially-intersecting order-2 complement that together with the rotations generates the group. 13 theorems, 4 definitions, 0 axioms, 0 sorries (build verification pending Docker availability).",
     "implications": "Supplies the group-theoretic data the parent entry asserted but did not prove (it stops at |Gal| = 8). The decomposition is the natural foundation for two follow-ups: packaging the external `SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4`, and the OQ-03 bridge identifying the concrete Galois group with DihedralGroup 4.",


### PR DESCRIPTION
## Enrichment pass for `inverse-galois-d4-oq-01` (Semidirect-Product Structure ℤ/4 ⋊ ℤ/2 of D₄)

This entry had a strong `meta.json` overview/conclusion but **no `annotations.json`** and an **empty `sections` array** — two coverage gaps.

### Added
- **`annotations.json`** — 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Overview: from |Gal| = 8 to the structure ℤ/4 ⋊ ℤ/2 (order 8 underdetermines the group)
  2. `rHom` / `rotations` / `rotationsEquiv` — rotation subgroup ≅ ℤ/4 as an injective-hom range
  3. `reflection_conj_rotation'` — the inversion action s·r·s⁻¹ = r⁻¹ (the ℤ/2-twist)
  4. `orderOf_rotation_gen` / `orderOf_reflection` — element orders 4 and 2
  5. `rotations_normal` — normality of the ℤ/4 factor
  6. `reflections` / `rotations_sup_reflections` / `rotations_inf_reflections` — the order-2 complement
  7. `d4_internal_semidirect` — the capstone internal decomposition
- **`sections`** — 5 sections mapping the Lean file's `/-! ## -/` structure to line ranges.

### Verification
- JSON validated for both files (parses; all annotations carry required fields).
- Line ranges cross-checked against `origin/main:proofs/Proofs/InverseGaloisD4OQ01.lean` (202 lines, 13 theorems, 0 axioms, 0 sorries).

No `.lean` files touched — gallery data only.