### PR TITLE
research(euler-totient-oq-01-oq-03): minimality of the RSA exponent λ(n)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2280,6 +2280,7 @@ import Proofs.EulerPolyhedralOQ02OQ01
 import Proofs.EulerTotient
 import Proofs.EulerTotientOQ01
 import Proofs.EulerTotientOQ01OQ03
+import Proofs.EulerTotientOQ01OQ03Minimal
 import Proofs.EulerTotientOQ02
 import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03

--- a/proofs/Proofs/EulerTotientOQ01OQ03Minimal.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ03Minimal.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2024-2025 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import Proofs.EulerTotientOQ01
+
+/-
+# Euler Totient OQ-01-OQ-03: minimality / sharpness of the RSA exponent λ(n)
+
+The companion file `EulerTotientOQ01OQ03.lean` proves the *sufficiency* side of RSA
+decryption: if `λ(n) ∣ m` then `a^(m+1) = a` for every `a : ZMod n` (the Carmichael
+exponent works as a universal decryption exponent). This file proves the matching
+*converse* — that `λ(n)` is the **minimal** such exponent.
+
+Restricting to the units `(ZMod n)ˣ` is essential: the non-unit residues carry no
+information about the exponent (`0^(m+1) = 0` for every `m`), so the round-trip holds
+for non-units regardless of `m`. Over the units the identity is sharp:
+
+    carmichael n ∣ m ↔ ∀ a : (ZMod n)ˣ, a ^ (m + 1) = a
+
+The forward direction repackages `carmichael_pow_eq_one`; the reverse is the sharp
+content, via the parent's `carmichael_minimal` (`Monoid.exponent` is the least common
+exponent of the unit group). Together with the gallery's forward RSA correctness this
+pins `λ(n)` as the exact threshold — no smaller universal exponent succeeds for every
+message coprime to `n`.
+-/
+
+namespace EulerTotientOQ01OQ03Minimal
+
+open CarmichaelFunction
+
+/-- **Minimality of the Carmichael exponent for the RSA round-trip.** If the RSA
+identity `a^(m+1) = a` holds for *every* unit `a : (ZMod n)ˣ`, then `λ(n) ∣ m`.
+The non-unit case carries no information (`0^(m+1) = 0` always), so units are the
+right test set. -/
+theorem carmichael_dvd_of_unit_rsa {n : ℕ} [NeZero n] {m : ℕ}
+    (h : ∀ a : (ZMod n)ˣ, a ^ (m + 1) = a) : carmichael n ∣ m := by
+  apply carmichael_minimal n m
+  intro a
+  have ha : a * a ^ m = a := by rw [← pow_succ']; exact h a
+  exact mul_left_cancel (ha.trans (mul_one a).symm)
+
+/-- **Sharp characterisation of the universal RSA decryption exponent.** For every
+modulus `n`, the round-trip `a^(m+1) = a` holds for all units `a : (ZMod n)ˣ` **iff**
+the Carmichael exponent `λ(n)` divides `m`. So `λ(n)` is the minimal universal RSA
+exponent — the open question's "minimal exponent" claim made precise. -/
+theorem carmichael_dvd_iff_unit_rsa {n : ℕ} [NeZero n] {m : ℕ} :
+    carmichael n ∣ m ↔ ∀ a : (ZMod n)ˣ, a ^ (m + 1) = a := by
+  refine ⟨fun hdvd a => ?_, carmichael_dvd_of_unit_rsa⟩
+  obtain ⟨k, rfl⟩ := hdvd
+  rw [pow_succ', pow_mul, carmichael_pow_eq_one, one_pow, mul_one]
+
+end EulerTotientOQ01OQ03Minimal

--- a/src/data/research/problems/euler-totient-oq-01-oq-03.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-03.json
@@ -12,14 +12,16 @@
     "progressSummary": "ORIENT: RSA-lambda correctness for n=p*q (distinct primes): e*d == 1 (mod lambda(n)) ⟹ m^(e*d) == m (mod n) for ALL m. Proof = CRT ZMod(p*q)≃ZMod p×ZMod q + per-prime Fermat fixed point (a^(m+1)=a when (p-1)|m). Squarefree necessary (fails for p^2). No Mathlib gap. Verifier ALL PASS; sorry-free build-pending Lean (per-prime core proven, CRT assembly build-pending).",
     "builtItems": [
       "research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py - exhaustive all-residue verifier (correctness, lambda<phi, squarefree necessity), ALL PASS",
-      "proofs/Proofs/EulerTotientOQ01OQ03.lean (build-pending, UNREGISTERED): zmod_pow_eq_self (per-prime fixed point, PROVEN), rsa_correct (n=p*q via ZMod.chineseRemainder), rsa_decrypt_correct (textbook e*d=1+k*lambda)."
+      "proofs/Proofs/EulerTotientOQ01OQ03.lean (build-pending, UNREGISTERED): zmod_pow_eq_self (per-prime fixed point, PROVEN), rsa_correct (n=p*q via ZMod.chineseRemainder), rsa_decrypt_correct (textbook e*d=1+k*lambda).",
+      "EulerTotientOQ01OQ03Minimal.lean: carmichael_dvd_iff_unit_rsa — sharp IFF carmichael n ∣ m ↔ ∀ unit a, a^(m+1)=a (minimality/converse of RSA correctness)"
     ],
     "insights": [
       "RSA correctness with lambda(n)=lcm(p-1,q-1) holds for ALL m (not just units) precisely because n=p*q is squarefree; this is what makes textbook RSA correct.",
       "Proof reduces by CRT to the per-prime fixed point a^(m+1)=a in ZMod p when (p-1)|m: a=0 trivial, a unit via Fermat a^(p-1)=1.",
       "lambda(n) | phi(n) and is strictly smaller in all tested moduli, giving a no-larger private exponent with the same decryption map.",
       "Squarefree is NECESSARY: for n=p^2 the all-m fixed point fails on multiples of p (n=9→{3,6}, n=25→{5,10,15,20}).",
-      "carmichael_pow_eq_one alone (units only) cannot prove the all-m statement; the CRT/per-prime route is essential."
+      "carmichael_pow_eq_one alone (units only) cannot prove the all-m statement; the CRT/per-prime route is essential.",
+      "The RSA round-trip a^(m+1)=a carries no exponent info on non-units (0^(m+1)=0 always); over (ZMod n)ˣ it holds for all units IFF λ(n)∣m, pinning λ(n) as the minimal universal exponent via carmichael_minimal (Monoid.exponent is least common exponent)"
     ],
     "mathlibGaps": [
       "None for the n=p*q theorem (ZMod.pow_card_sub_one_eq_one + ZMod.chineseRemainder suffice).",


### PR DESCRIPTION
## Summary
Adds the **converse / sharpness** side of the RSA correctness story for `euler-totient-oq-01-oq-03`. The companion `EulerTotientOQ01OQ03.lean` proves *sufficiency* (`λ(n) ∣ m ⟹ a^(m+1)=a` for all `a`). This new file proves the matching **minimality**, making the OQ's "minimal universal exponent" claim precise.

## Progress
New file `EulerTotientOQ01OQ03Minimal.lean` (registered in `Proofs.lean`), **0 sorry / 0 axiom**:
- `carmichael_dvd_of_unit_rsa`: if `a^(m+1)=a` for every unit `a : (ZMod n)ˣ`, then `λ(n) ∣ m` (via the parent's `carmichael_minimal`).
- `carmichael_dvd_iff_unit_rsa`: the sharp IFF
  ```
  carmichael n ∣ m ↔ ∀ a : (ZMod n)ˣ, a ^ (m + 1) = a
  ```
  pinning `λ(n)` as the **minimal** universal RSA exponent.

## Why this is new / non-conflicting
- The existing results prove only the forward (sufficiency) direction; the minimality converse was not formalised.
- Units are the correct test set — non-units carry no exponent information (`0^(m+1)=0` for every `m`), so sharpness genuinely lives on `(ZMod n)ˣ`.
- Placed in a **separate file** to avoid conflicting with in-flight PR #24633, which edits the companion `EulerTotientOQ01OQ03.lean`.

## Verification
All bearer lemmas are in the parent (`CarmichaelFunction.carmichael_minimal`, `carmichael_pow_eq_one`) or standard Mathlib (`pow_succ'`, `pow_mul`, `one_pow`, `mul_one`, `mul_left_cancel`). **Build-pending**: Docker host unavailable this session (blackout); deployer-gated, so a compile error blocks this PR rather than reaching `main`.

## Status
**Outcome**: progress · **Next**: Docker-up build check.

🤖 Generated by researcher-6