### PR TITLE
Enrich erdos-1179-oq-02: add annotations.json

### DIFF
--- a/src/data/proofs/erdos-1179-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1179-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "e1179-oq02-ann-overview",
+    "proofId": "erdos-1179-oq-02",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Erdős #1179 OQ-02 and the Trivial Lower Bound",
+    "content": "Erdős #1179 (Erdős–Hall, 1976) gives the minimal number gₑ(N) of random group elements needed for an ε-uniform subset-sum representation in an abelian group of order N: gₑ(N) = (1 + oₑ(1))·log₂N. OQ-02 asks whether the multiplicative (1+o(1)) factor sharpens to a bounded additive error gₑ(N) ≤ log₂N + Oₑ(1), matching the trivial lower bound gₑ(N) ≥ log₂N. This file formalizes the lower-bound side concretely and axiom-free at the per-subset level, replacing the parent file's abstract axiom basic_lower_bound and removing its circular uniform_implies_spanning hypothesis. The headline additive upper bound remains open.",
+    "mathContext": "$g_\\varepsilon(N) = (1+o_\\varepsilon(1))\\log_2 N$; OQ-02 target: $g_\\varepsilon(N) \\le \\log_2 N + O_\\varepsilon(1)$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problems", "additive combinatorics", "subset sums", "abelian groups", "information-theoretic lower bound"],
+    "prerequisites": ["finite abelian groups", "subset-sum representations", "asymptotic notation"]
+  },
+  {
+    "id": "e1179-oq02-ann-spanning",
+    "proofId": "erdos-1179-oq-02",
+    "range": { "startLine": 49, "endLine": 75 },
+    "type": "insight",
+    "title": "Hypothesis-Free Spanning from ε-Uniformity",
+    "content": "epsUniform_spanning proves that ε-uniformity with ε < 1 alone forces every group element g to have at least one subset-sum representation (1 ≤ reprCount A g) — with no lower bound on |A|. The lower side of the uniformity bound |F_A(g) − μ| ≤ ε·μ gives F_A(g) ≥ (1−ε)·μ; since μ = 2^|A|/N > 0 for N ≥ 1 (expectedReprCount_pos) and ε < 1, the right side is strictly positive, so the natural number F_A(g) is ≥ 1 (closed by nlinarith for the real bound, then omega). This is the crux: it breaks the parent's circularity, where spanning was assumed under |A| ≥ ⌈log₂N⌉ — the very bound it should help prove.",
+    "mathContext": "$F_A(g) \\ge (1-\\varepsilon)\\mu > 0 \\Rightarrow F_A(g) \\ge 1$, given $\\varepsilon < 1$ and $\\mu = 2^{|A|}/N > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole / covering", "expected count μ", "breaking circular hypotheses", "nlinarith"],
+    "prerequisites": ["expectation bounds", "ε-uniformity", "ℕ vs ℝ casting"]
+  },
+  {
+    "id": "e1179-oq02-ann-card-bound",
+    "proofId": "erdos-1179-oq-02",
+    "range": { "startLine": 77, "endLine": 91 },
+    "type": "concept",
+    "title": "The Trivial Lower Bound N ≤ 2^|A|",
+    "content": "card_le_two_pow_of_epsUniform sums the spanning bound over all N group elements: N = Σ_g 1 ≤ Σ_g F_A(g) (by Finset.sum_le_sum and epsUniform_spanning), and the representation counts total to exactly 2^|A| by the parent's total_reprCount. The calc chain therefore yields N ≤ 2^|A|. This is the information-theoretic content: the 2^|A| subsets of A must cover all N group elements.",
+    "mathContext": "$N = \\sum_g 1 \\le \\sum_g F_A(g) = 2^{|A|}$.",
+    "significance": "key",
+    "relatedConcepts": ["covering bound", "Finset.sum_le_sum", "total representation count", "calc proof"],
+    "prerequisites": ["finite sums", "monotonicity of sums"]
+  },
+  {
+    "id": "e1179-oq02-ann-clog",
+    "proofId": "erdos-1179-oq-02",
+    "range": { "startLine": 93, "endLine": 104 },
+    "type": "concept",
+    "title": "Logarithmic Form ⌈log₂N⌉ ≤ |A|",
+    "content": "clog_le_card_of_epsUniform converts N ≤ 2^|A| into the integer headline bound Nat.clog 2 N ≤ |A| using Nat.le_pow_iff_clog_le (valid since base 2 > 1). Since Nat.clog 2 N = ⌈log₂N⌉, this is exactly the trivial lower bound gₑ(N) ≥ log₂N at the per-subset level: every ε-uniform subset must already have at least ⌈log₂N⌉ elements.",
+    "mathContext": "$N \\le 2^{|A|} \\iff \\lceil\\log_2 N\\rceil = \\operatorname{clog}_2 N \\le |A|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ceiling logarithm", "Nat.clog", "Nat.le_pow_iff_clog_le", "lower bound"],
+    "prerequisites": ["integer logarithms", "monotone Galois connection"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `erdos-1179-oq-02` (Axiom-Free Trivial Lower Bound for Uniform Subset Sums)

Complete `meta.json` (overview, sections, conclusion) but **no `annotations.json`** — the one gap. The open research PR (#24632, rigidity/equality case) modifies the `.lean` file and does not add annotations, so this is non-duplicative.

### Added
- **`annotations.json`** — 4 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Overview — Erdős #1179, OQ-02, and the trivial lower bound
  2. `epsUniform_spanning` — hypothesis-free spanning from ε < 1 (breaks the parent's circularity)
  3. `card_le_two_pow_of_epsUniform` — the covering bound N ≤ 2^|A|
  4. `clog_le_card_of_epsUniform` — logarithmic form ⌈log₂N⌉ ≤ |A|

### Verification
- JSON validated (parses; all annotations carry required fields).
- Line ranges cross-checked against `origin/main:proofs/Proofs/Erdos1179OQ02.lean` (104 lines, 3 theorems, 0 axioms, 0 sorries).

No `.lean` files touched — gallery data only.