### PR TITLE
Enrich friendship-theorem-oq-04: add annotations.json

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-04/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "friendship-oq04-ann-overview",
+    "proofId": "friendship-theorem-oq-04",
+    "range": { "startLine": 8, "endLine": 43 },
+    "type": "context",
+    "title": "The Friendship Theorem in the Infinite Case",
+    "content": "The finite Friendship Theorem (Erdős–Rényi–Sós, 1966): if every two distinct vertices of a finite graph have exactly one common neighbour, some vertex is adjacent to all others (a windmill). It is false for infinite graphs — the C₅ free-amalgamation construction (Chvátal–Kotzig–Rosenberg–Davies, 1976) gives a countable friendship graph with no universal vertex, in which every vertex has infinite degree. This file pins down the sharp restoring hypothesis without the spectral argument (which has no infinite analogue): every friendship graph has diameter ≤ 2 (purely local), so a locally finite one is finite and hence has a universal vertex. Local finiteness is therefore exactly the restoring condition — the sole obstruction to finiteness is an infinite-degree vertex.",
+    "mathContext": "Finite friendship $\\Rightarrow$ universal vertex; infinite counterexample exists $\\Rightarrow$ extra hypothesis needed. Sharp condition: local finiteness.",
+    "significance": "context",
+    "relatedConcepts": ["Friendship theorem", "windmill graph", "infinite graphs", "spectral graph theory", "free amalgamation"],
+    "prerequisites": ["graph theory", "common neighbours", "finiteness of sets"]
+  },
+  {
+    "id": "friendship-oq04-ann-defs",
+    "proofId": "friendship-theorem-oq-04",
+    "range": { "startLine": 51, "endLine": 70 },
+    "type": "definition",
+    "title": "Friendship Graphs and Common Neighbours (Fintype-Free)",
+    "content": "IsFriendshipGraph is defined without a [Fintype V] assumption — every pair of distinct vertices has exactly one common neighbour ((G.commonNeighbors u v).ncard = 1) — so it applies to infinite vertex types while being definitionally identical to the finite gallery version. exists_common_neighbor extracts that unique common neighbour from the ncard = 1 condition via Set.ncard_eq_one.",
+    "mathContext": "$\\forall u \\ne v,\\ |N(u) \\cap N(v)| = 1$ (using ncard, valid for infinite $V$).",
+    "significance": "supporting",
+    "relatedConcepts": ["common neighbours", "Set.ncard", "Fintype-free formalization", "SimpleGraph.commonNeighbors"],
+    "prerequisites": ["simple graphs", "set cardinality (ncard)"]
+  },
+  {
+    "id": "friendship-oq04-ann-diameter",
+    "proofId": "friendship-theorem-oq-04",
+    "range": { "startLine": 68, "endLine": 95 },
+    "type": "insight",
+    "title": "Diameter ≤ 2 Survives Infinity",
+    "content": "friendship_diameter_two proves that for any base vertex v and any other u, either u is adjacent to v or they share a common neighbour x — so u is within distance 2 of v, with no finiteness used. univ_subset_two_ball packages this as a covering: the whole vertex set is contained in {v} ∪ N(v) ∪ (⋃_{x ∈ N(v)} N(x)), the 2-ball around v. This purely local covering is the key structural fact the rest of the file leverages.",
+    "mathContext": "$V \\subseteq \\{v\\} \\cup N(v) \\cup \\bigcup_{x \\in N(v)} N(x)$ — every vertex lies in the 2-ball of any fixed $v$.",
+    "significance": "key",
+    "relatedConcepts": ["graph diameter", "2-ball covering", "neighbourhood", "local argument"],
+    "prerequisites": ["graph distance", "neighbourhoods", "set union"]
+  },
+  {
+    "id": "friendship-oq04-ann-finiteness",
+    "proofId": "friendship-theorem-oq-04",
+    "range": { "startLine": 92, "endLine": 126 },
+    "type": "concept",
+    "title": "Local Finiteness Forces Finiteness (the Sharp Obstruction)",
+    "content": "univ_finite_of_locallyFinite shows that if every neighbourhood is finite, the 2-ball covering exhibits V as a finite union of finite sets (singleton, N(v), and a finite biUnion of finite N(x)), so V is finite; locally_finite_is_finite restates this as Finite V. The contrapositive infinite_friendship_has_infinite_degree is the direct OQ-04 answer: every infinite friendship graph has a vertex of infinite degree — exactly the feature of the C₅ counterexample. No spectral input is used.",
+    "mathContext": "all $N(w)$ finite $\\Rightarrow V$ finite; contrapositive: $V$ infinite $\\Rightarrow \\exists w,\\ |N(w)| = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["local finiteness", "finite union of finite sets", "contrapositive", "infinite degree"],
+    "prerequisites": ["finiteness of unions", "Set.Finite.biUnion"]
+  },
+  {
+    "id": "friendship-oq04-ann-universal",
+    "proofId": "friendship-theorem-oq-04",
+    "range": { "startLine": 128, "endLine": 145 },
+    "type": "concept",
+    "title": "Recovering a Universal Vertex",
+    "content": "locally_finite_friendship_has_universal combines the finiteness result with the finite gallery theorem FriendshipTheorem.friendship_theorem to recover a universal vertex for any locally finite friendship graph with at least three vertices. The proof derives Finite V, equips it with a Fintype, establishes 3 ≤ card V from the three distinct vertices a, b, c (via card_eq_three), and applies the finite theorem. This closes the loop: local finiteness restores the full Friendship conclusion.",
+    "mathContext": "locally finite friendship graph with $|V| \\ge 3 \\Rightarrow \\exists z$ universal.",
+    "significance": "supporting",
+    "relatedConcepts": ["universal vertex", "reduction to finite case", "Fintype.ofFinite", "windmill"],
+    "prerequisites": ["finite Friendship theorem", "Fintype / Finite"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `friendship-theorem-oq-04` (The Infinite Case)

Complete `meta.json` (overview, 4 sections, conclusion) but **no `annotations.json`**. The open research PRs (#24273, #24445, #24638) modify the `.lean` file and do not add annotations, so this is non-duplicative.

### Added
- **`annotations.json`** — 5 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, aligned to the existing `sections`:
  1. Overview — finite theorem, infinite counterexample, sharp restoring condition
  2. `IsFriendshipGraph` / `exists_common_neighbor` — Fintype-free definitions
  3. `friendship_diameter_two` / `univ_subset_two_ball` — diameter ≤ 2 survives infinity
  4. `univ_finite_of_locallyFinite` / `infinite_friendship_has_infinite_degree` — local finiteness forces finiteness
  5. `locally_finite_friendship_has_universal` — recovering a universal vertex

### Verification
- JSON validated (parses; all annotations carry required fields).
- Line ranges cross-checked against `origin/main:proofs/Proofs/FriendshipTheoremOQ04.lean` (145 lines, 7 theorems, 0 axioms, 0 sorries).

No `.lean` files touched — gallery data only.