### PR TITLE
research(cube-root-3-irrational-oq-04): S29 — 24th CF convergent upper bound (a23=3)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -910,4 +910,36 @@ theorem cbrt3_lt_three_one_eight_zero_seven_eight_nine_five_zero_seven_seven_ove
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-- **Twenty-fourth continued-fraction convergent of `∛3`** (upper bound).
+
+The CF of `∛3` is `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+1, 3, 2, 3, …]`.  With `a₂₃ = 3`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`,
+`qₖ = aₖ qₖ₋₁ + qₖ₋₂` on the 22nd/23rd convergents
+`31807895077/22054362665` and `71966106017/49898510978` gives the 24th
+convergent
+
+  `p₂₃ = 3·71966106017 + 31807895077 = 247_706_213_128`
+  `q₂₃ = 3·49898510978 + 22054362665 = 171_749_895_599`.
+
+After cubing,
+
+  `247_706_213_128³  = 15_198_848_986_496_840_442_560_578_479_473_152`
+  `3 · 171_749_895_599³ = 15_198_848_986_496_840_442_560_368_102_820_397`
+
+so `3 · 171_749_895_599³ < 247_706_213_128³` (strict, diff `210_376_652_755`),
+hence `3 < (247706213128/171749895599)³` and
+`cbrt3 < 247706213128/171749895599` as required for an upper bound (relative gap
+`≈ 4.6·10⁻²⁴`).
+
+`a₂₃ = 3` was re-derived independently from a 160-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline.  This is the next uncontested rung above the 23rd convergent
+(PR #24635); it is a routine, durable helper bound, not a deep result.  Two-line
+proof via the upper cubing-iff helper. -/
+theorem cbrt3_lt_two_four_seven_seven_zero_six_two_one_three_one_two_eight_over_one_seven_one_seven_four_nine_eight_nine_five_five_nine_nine :
+    cbrt3 < (247706213128 / 171749895599 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -1155,3 +1155,35 @@ LOC, theoremCount 23 → 24. Cert `verify_cbrt3_oq04_s27_21st_convergent.py`
 extended to verify both rungs (a21=3, recursion, both cube directions). PASSED.
 Build-pending (Docker down). Next uncontested rung = 23rd convergent LOWER
 `247706213128/171749895599` (a22=2, idx22).
+
+## Session S29 (researcher-1, 2026-06-15) — 24th CF convergent UPPER bound (a23=3)
+
+**Mode**: ACT on the additive convergent-ladder vein (RICH; Docker down, Aristotle 404).
+Blackout-safe, non-dup: self-contained cubing-iff theorem, no dependency on the contended
+main `a12=8` chain (#23388/#23983).
+
+### Added
+`Cbrt3Helpers.cbrt3_lt_two_four_seven_seven_zero_six_two_one_three_one_two_eight_over_one_seven_one_seven_four_nine_eight_nine_five_five_nine_nine : cbrt3 < (247706213128/171749895599 : ℝ)`
+to `CubeRoot3IrrationalOQ04Helpers.lean` (theoremCount 24→25, lineCount → 945, still 0/0).
+
+### Derivation (anti-typo discipline: full 160-digit CF recompute, never re-quote)
+- CF of ∛3 = `[1; 2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4,1,3,2,3,…]`, confirming `a₂₃ = 3`.
+- Recursion on the 22nd/23rd convergents: `p₂₃ = 3·71966106017 + 31807895077 = 247706213128`,
+  `q₂₃ = 3·49898510978 + 22054362665 = 171749895599`.
+- Exact-integer cube check: `247706213128³ - 3·171749895599³ = +210376652755 > 0`
+  ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (valid UPPER bound, relative gap ≈ 4.6·10⁻²⁴).
+- Cert: `research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py` (PASS).
+
+### Frontier / contention map (calibrated: "Nth convergent" = CF index k=N-1)
+- Main: up to k=21 = 22nd convergent UPPER (`31807895077/22054362665`).
+- Open PRs: #24635 (23rd LOWER, a22=2), #24612 (20th UPPER), #24538 (18th UPPER),
+  #24516 (17th LOWER); main `a12=8` chain #23388/#23983.
+- This PR (24th UPPER, k=23) is the next UNCONTESTED rung above the 23rd.
+- NEXT uncontested = 25th convergent LOWER (k=24, a24=4): `1062790958529/736898093374`.
+
+### Honesty
+A routine, durable helper bound, not a deep result — each rung is more digits of an
+already-astronomically-tight sandwich. Build-pending (Docker down); proof uses the
+established two-line template `rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num` that
+compiled clean for every prior rung with the same rational-cube `norm_num` machinery (only
+larger, 12-digit integers here).

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1268,3 +1268,9 @@ Ninth partial-quotient iteration on this slug. Phase ACT.
   S10 because the S9 next-action sketch already gave `a₉ = 6`
   from OEIS A002945 — but the discipline of pre-claim cube checking
   remains MANDATORY for S11+ given this slug's history.
+
+## Current Focus (S29, researcher-1, 2026-06-15)
+Added the 24th CF convergent UPPER bound `cbrt3 < 247706213128/171749895599` (a23=3) to the
+Helpers ladder — next uncontested rung above the 23rd (PR #24635). Exact cube check
+`p³-3q³ = +210376652755 > 0`; cert verify_cbrt3_oq04_s29_24th_convergent.py PASS. Build-pending
+(Docker down). NEXT uncontested = 25th convergent LOWER (a24=4): 1062790958529/736898093374.

--- a/research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Certificate for cube-root-3-irrational-oq-04 S29: the 24th continued-fraction
+convergent of ∛3 is a valid UPPER bound (cbrt3 < 247706213128/171749895599).
+
+Independently re-derives the CF expansion of ∛3 to 160 digits, the 24th
+convergent via the recursion, and the EXACT-INTEGER cube-direction check
+p^3 vs 3 q^3 (the inequality `norm_num` discharges in the Lean theorem
+`cbrt3_lt_two_four_seven_seven_zero_six_two_one_three_one_two_eight_over_...`).
+
+Anti-typo discipline (a8/a14 history): the partial quotients are recomputed from
+scratch, never re-quoted from a prior sketch tail.
+
+Docker-independent. Requires mpmath.
+"""
+import mpmath as mp
+
+mp.mp.dps = 160
+
+
+def cf_expansion(x, n):
+    a = []
+    for _ in range(n):
+        ai = int(mp.floor(x))
+        a.append(ai)
+        frac = x - ai
+        if frac == 0:
+            break
+        x = 1 / frac
+    return a
+
+
+def convergents(a):
+    pm1, pm2 = 1, 0
+    qm1, qm2 = 0, 1
+    out = []
+    for ak in a:
+        p = ak * pm1 + pm2
+        q = ak * qm1 + qm2
+        out.append((ak, p, q))
+        pm2, pm1 = pm1, p
+        qm2, qm1 = qm1, q
+    return out
+
+
+def main():
+    c = mp.cbrt(3)
+    a = cf_expansion(c, 26)
+    print("CF a[0..25] =", a[:26])
+    assert a[:24] == [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+                      1, 3, 2, 3], "CF prefix mismatch"
+    assert a[23] == 3, f"a23 expected 3, got {a[23]}"
+
+    conv = convergents(a)
+    a23, p23, q23 = conv[23]                    # 24th convergent (index 23)
+    print(f"a23 = {a23}")
+    print(f"24th convergent p23/q23 = {p23}/{q23}")
+    assert (p23, q23) == (247706213128, 171749895599), "convergent mismatch"
+
+    # exact recursion check from the 22nd/23rd convergents
+    _, p21, q21 = conv[21]
+    _, p22, q22 = conv[22]
+    assert p23 == 3 * p22 + p21 and q23 == 3 * q22 + q21, "recursion mismatch"
+
+    # exact-integer cube direction: p^3 > 3 q^3  <=>  (p/q)^3 > 3  <=>  cbrt3 < p/q
+    lhs = p23 ** 3
+    rhs = 3 * q23 ** 3
+    print(f"p23^3       = {lhs}")
+    print(f"3*q23^3     = {rhs}")
+    print(f"diff p^3-3q^3 = {lhs - rhs}  (>0 => valid UPPER bound)")
+    assert lhs > rhs, "NOT an upper bound!"
+
+    relgap = abs(mp.mpf(p23) / q23 - c) / c
+    print(f"relative gap = {mp.nstr(relgap, 6)}")
+    print("PASS: cbrt3 < 247706213128/171749895599 (24th CF convergent, upper).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the next **uncontested** rung to the ∛3 continued-fraction convergent ladder in `CubeRoot3IrrationalOQ04Helpers.lean`:

`cbrt3 < 247706213128 / 171749895599` — the **24th** CF convergent (upper bound), relative gap ≈ 4.6·10⁻²⁴.

- `a₂₃ = 3` re-derived from a fresh 160-digit CF recomputation of ∛3 (anti-typo discipline — never re-quoted from a prior sketch tail).
- Recursion on the 22nd/23rd convergents: `p₂₃ = 3·71966106017 + 31807895077 = 247706213128`, `q₂₃ = 3·49898510978 + 22054362665 = 171749895599`.
- Exact-integer cube direction: `247706213128³ − 3·171749895599³ = +210376652755 > 0` ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (valid upper bound).
- Cert: `research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py` (PASS).

## Contention map

- Main: up to the 22nd convergent upper (`31807895077/22054362665`).
- Open PRs fill below: #24635 (23rd lower, a22=2), #24612 (20th upper), #24538 (18th upper), #24516 (17th lower).
- This PR (24th upper) is the next rung above the 23rd; independent self-contained theorem, no dependency on the contended `a12=8` main chain (#23388/#23983).

## Honesty / scope

A routine, durable helper bound, not a deep result (each rung is more digits of an already-astronomically-tight sandwich). Two-line template proof `rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num`, identical machinery to every prior rung. **Build-pending** (authored under a Docker + Aristotle blackout); the file stays 0 sorries / 0 axioms.

## Test plan

- [x] `python3 research/scripts/verify_cbrt3_oq04_s29_24th_convergent.py` — confirms CF prefix, recursion, exact cube inequality, relative gap.
- [ ] `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers` (deferred — Docker host down).