### PR TITLE
research(erdos-1179-oq-02): S5 — extremal converse + equivalence on minimum-size sets

### DIFF
--- a/proofs/Proofs/Erdos1179OQ02Extremal.lean
+++ b/proofs/Proofs/Erdos1179OQ02Extremal.lean
@@ -1,0 +1,135 @@
+/-
+  Extremal characterization for Erdős #1179 oq-02 (power-of-two groups).
+  Date: 2026-06-15 (S5)
+  Research: erdos-1179-oq-02 (researcher-4)
+
+  Companion to:
+    * `Erdos1179OQ02.lean`       — lower bound  g_ε(N) ≥ log₂N
+      (`clog_le_card_of_epsUniform`, per-subset, hypothesis-free), and
+    * `Erdos1179OQ02Upper.lean`  — a unique-representation set is exactly
+      `0`-uniform of size `⌈log₂N⌉` (`epsUniform_zero_of_unique_repr`,
+      `unique_repr_card_eq_clog`).
+
+  Those two files give BOTH the lower bound and the forward direction
+  "unique representations ⟹ minimal 0-uniform set" on the
+  unique-representation family.  This file supplies the **converse**, i.e. the
+  extremal-rigidity statement:
+
+      if `A` is `0`-uniform AND already meets the lower bound
+      `|A| = ⌈log₂N⌉`, then every group element has a UNIQUE subset-sum
+      representation (`reprCount A g = 1` for all `g`).
+
+  Mathematical content.  `0`-uniformity forces every count to equal the
+  expected count `μ = 2^|A| / N` exactly, hence all counts are equal to a single
+  natural number `c`, and `N · c = 2^|A|` (parent `total_reprCount`).  Thus
+  `N ∣ 2^|A|`, so `N = 2^j` and `⌈log₂N⌉ = j`; the minimality hypothesis
+  `|A| = ⌈log₂N⌉` then gives `|A| = j`, whence `2^j · c = 2^j` and `c = 1`.
+
+  Combined with `epsUniform_zero_of_unique_repr` this is a full EQUIVALENCE on
+  minimum-size sets:
+
+      |A| = ⌈log₂N⌉  ⟹  ( IsEpsUniform A 0  ↔  ∀ g, reprCount A g = 1 ).
+
+  Consequence for oq-02: on the power-of-two family the conjectured additive
+  constant is *exactly* `0`, and the optimum is attained ONLY by
+  unique-representation (basis-type) sets — there is no slack at the extreme.
+  This does not address general `N` or the with-high-probability random setting,
+  which remain the genuine open content of oq-02.
+
+  No axioms, no `sorry`.  Depends on `total_reprCount` (parent) and the sibling
+  lower/upper lemmas; uses only `Nat.dvd_prime_pow`, `Nat.clog_pow`,
+  `Nat.eq_of_mul_eq_mul_left` from Mathlib.
+
+  NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
+  unavailable).  NOT registered in `Proofs.lean`; a post-blackout session should
+  confirm via `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal`
+  before registering.  Mathlib bearers name-checked @ pinned rev 2df2f01:
+  `Nat.clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x` (Data/Nat/Log.lean:453,
+  same lemma the Upper file already relies on); `Nat.dvd_prime_pow`;
+  `Nat.eq_of_mul_eq_mul_left`.
+-/
+
+import Proofs.Erdos1179Problem
+import Proofs.Erdos1179OQ02
+import Proofs.Erdos1179OQ02Upper
+import Mathlib
+
+namespace Erdos1179
+
+open Finset
+
+/-- **Extremal rigidity (converse).**  If `A` is `0`-uniform and meets the lower
+bound `|A| = ⌈log₂N⌉`, then every group element has a *unique* subset-sum
+representation.
+
+The `0`-uniformity collapses all representation counts to one natural number
+`c = 2^|A| / N`; the minimality `|A| = ⌈log₂N⌉` then forces `c = 1`. -/
+theorem unique_repr_of_epsUniform_zero_clog {G : Type*} [AddCommGroup G]
+    [Fintype G] [DecidableEq G] (A : Finset G) (hunif : IsEpsUniform A 0)
+    (hcard : A.card = Nat.clog 2 (Fintype.card G)) :
+    ∀ g, reprCount A g = 1 := by
+  -- ε = 0 forces every count to equal the expected count μ exactly.
+  have heq : ∀ g, (reprCount A g : ℝ)
+      = expectedReprCount A.card (Fintype.card G) := by
+    intro g
+    have h := hunif g
+    rw [zero_mul] at h
+    have h0 : |(reprCount A g : ℝ)
+        - expectedReprCount A.card (Fintype.card G)| = 0 :=
+      le_antisymm h (abs_nonneg _)
+    have := abs_eq_zero.mp h0
+    linarith
+  -- Hence all counts coincide with c := reprCount A 0.
+  have hconst : ∀ g, reprCount A g = reprCount A (0 : G) := by
+    intro g
+    have : (reprCount A g : ℝ) = (reprCount A (0 : G) : ℝ) := by
+      rw [heq g, heq 0]
+    exact_mod_cast this
+  -- The counts sum to 2 ^ |A| (parent) and also to N * c.
+  have hsum : Fintype.card G * reprCount A (0 : G) = 2 ^ A.card := by
+    have key : ∑ g : G, reprCount A g = ∑ _g : G, reprCount A (0 : G) :=
+      Finset.sum_congr rfl fun g _ => hconst g
+    have hT := total_reprCount A
+    rw [key] at hT
+    simpa [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_comm] using hT
+  -- N ∣ 2 ^ |A|, so N = 2 ^ j; clog forces j = |A|, so c = 1.
+  have hdvd : Fintype.card G ∣ 2 ^ A.card := ⟨_, hsum.symm⟩
+  obtain ⟨j, _, hNj⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hdvd
+  have hclog : Nat.clog 2 (Fintype.card G) = j := by
+    rw [hNj, Nat.clog_pow 2 j (by norm_num)]
+  have hAj : A.card = j := by rw [hcard, hclog]
+  have hc1 : reprCount A (0 : G) = 1 := by
+    rw [hNj, hAj] at hsum
+    have hmul : 2 ^ j * reprCount A (0 : G) = 2 ^ j * 1 := by
+      rw [mul_one]; exact hsum
+    exact Nat.eq_of_mul_eq_mul_left (pow_pos (by norm_num) j) hmul
+  intro g
+  rw [hconst g]
+  exact hc1
+
+/-- **Extremal equivalence on minimum-size sets.**  When `|A| = ⌈log₂N⌉`, the
+set `A` is `0`-uniform iff it gives every group element a unique subset-sum
+representation.  Forward direction is `unique_repr_of_epsUniform_zero_clog`;
+backward is the sibling `epsUniform_zero_of_unique_repr`. -/
+theorem epsUniform_zero_iff_unique_repr_of_clog {G : Type*} [AddCommGroup G]
+    [Fintype G] [DecidableEq G] (A : Finset G)
+    (hcard : A.card = Nat.clog 2 (Fintype.card G)) :
+    IsEpsUniform A 0 ↔ ∀ g, reprCount A g = 1 :=
+  ⟨fun hunif => unique_repr_of_epsUniform_zero_clog A hunif hcard,
+   fun h => epsUniform_zero_of_unique_repr A h⟩
+
+/-- **Optimality of unique-representation sets.**  A unique-representation set is
+a minimum-cardinality `ε`-uniform set (for every `ε < 1`): no `ε`-uniform set
+can be strictly smaller.  This is the explicit statement that the conjectured
+oq-02 additive constant is attained — indeed it is `0` — on this family.
+
+`|A| = ⌈log₂N⌉` (`unique_repr_card_eq_clog`) and `|B| ≥ ⌈log₂N⌉`
+(`clog_le_card_of_epsUniform`). -/
+theorem unique_repr_card_le_of_epsUniform {G : Type*} [AddCommGroup G]
+    [Fintype G] [DecidableEq G] (A : Finset G) (hA : ∀ g, reprCount A g = 1)
+    (B : Finset G) (ε : ℝ) (hε : ε < 1) (hB : IsEpsUniform B ε) :
+    A.card ≤ B.card := by
+  rw [unique_repr_card_eq_clog A hA]
+  exact clog_le_card_of_epsUniform B ε hε hB
+
+end Erdos1179

--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -54,3 +54,41 @@ Bearer name-checked @ 2df2f01: `Nat.clog_pow (b x:ℕ)(hb:1<b): clog b (b^x)=x`
 **Next:** post-blackout register+build `Erdos1179OQ02Upper.lean`; optionally
 instantiate at `G=(ZMod 2)^m` with the standard basis to exhibit a concrete
 `∀g, reprCount A g = 1` witness (needs the powerset-sum↔indicator bijection over 𝔽₂).
+
+## Session 2026-06-15 (researcher-4) S5 ACT — extremal converse + equivalence on minimum-size sets
+
+**Record correction (the top "Status" block is stale).** Both sibling files are now
+REGISTERED on `main` (not "unregistered" as S3 says): `Proofs/Erdos1179OQ02.lean`
+(lower bound, #24551) and `Proofs/Erdos1179OQ02Upper.lean` are both in `Proofs.lean`,
+0 axioms / 0 sorries each. The lower bound `g_ε(N) ≥ log₂N` and the
+unique-representation optimality (`|A| = ⌈log₂N⌉`, additive constant 0 on `N=2^m`)
+are formalized, NOT merely ORIENT/DEFINE.
+
+**New this session.** The previous files give lower bound + the *forward* direction
+"unique reps ⟹ minimal 0-uniform set". This session adds the **converse / extremal
+rigidity** — the missing structural half:
+
+- `unique_repr_of_epsUniform_zero_clog`: if `A` is `0`-uniform AND meets the lower
+  bound `|A| = ⌈log₂N⌉`, then `∀g, reprCount A g = 1`. Proof: `ε=0` collapses every
+  count to the expected `μ = 2^|A|/N` (so all counts equal one nat `c`), parent
+  `total_reprCount` gives `N·c = 2^|A|`, so `N ∣ 2^|A|` ⟹ `N = 2^j`
+  (`Nat.dvd_prime_pow Nat.prime_two`), `⌈log₂N⌉ = j` (`Nat.clog_pow`), the minimality
+  hyp forces `|A| = j`, hence `2^j·c = 2^j` ⟹ `c = 1` (`Nat.eq_of_mul_eq_mul_left`).
+- `epsUniform_zero_iff_unique_repr_of_clog`: combining the converse with the sibling
+  `epsUniform_zero_of_unique_repr` gives the full EQUIVALENCE on minimum-size sets —
+  `|A| = ⌈log₂N⌉ ⟹ ( IsEpsUniform A 0 ↔ ∀g, reprCount A g = 1 )`.
+- `unique_repr_card_le_of_epsUniform`: a unique-representation set is a
+  minimum-cardinality `ε`-uniform set for every `ε<1` (the optimum `0` is attained,
+  no smaller `ε`-uniform set exists).
+
+Upshot: on the power-of-two family the conjectured additive constant is *exactly* `0`
+AND the optimum is attained ONLY by unique-representation (basis-type) sets — no slack
+at the extreme. Still does NOT touch general `N` or the w.h.p. random setting (the
+genuine open content of oq-02; both remain analytic / out of reach for finite methods).
+
+**Built (build-pending, UNREGISTERED — Docker + Aristotle both still down):**
+`proofs/Proofs/Erdos1179OQ02Extremal.lean`, 0 axioms / 0 sorry by construction.
+Imports the parent + both sibling files. Bearers name-checked @ 2df2f01:
+`Nat.dvd_prime_pow`, `Nat.clog_pow` (Data/Nat/Log.lean:453, same lemma Upper uses),
+`Nat.eq_of_mul_eq_mul_left`, `nsmul_eq_mul`. Post-blackout: verify via
+`./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal` then register.


### PR DESCRIPTION
## Summary

Adds the missing structural half of the Erdős #1179 oq-02 optimality picture. The two sibling files already on `main` give:
- `Erdos1179OQ02.lean` — lower bound `g_ε(N) ≥ log₂N` (`clog_le_card_of_epsUniform`)
- `Erdos1179OQ02Upper.lean` — forward direction: unique representations ⟹ minimal `0`-uniform set (`epsUniform_zero_of_unique_repr`, `unique_repr_card_eq_clog`)

This PR adds the **converse / extremal rigidity** in a new file `proofs/Proofs/Erdos1179OQ02Extremal.lean`:

- `unique_repr_of_epsUniform_zero_clog` — if `A` is `0`-uniform **and** meets the lower bound `|A| = ⌈log₂N⌉`, then every group element has a unique subset-sum representation (`∀ g, reprCount A g = 1`).
- `epsUniform_zero_iff_unique_repr_of_clog` — full equivalence on minimum-size sets: `|A| = ⌈log₂N⌉ ⟹ (IsEpsUniform A 0 ↔ ∀ g, reprCount A g = 1)`.
- `unique_repr_card_le_of_epsUniform` — a unique-representation set is a minimum-cardinality `ε`-uniform set for every `ε < 1`.

Proof of the converse: `ε = 0` collapses every count to the expected `μ = 2^|A|/N` (so all counts equal one nat `c`); parent `total_reprCount` gives `N·c = 2^|A|`, hence `N ∣ 2^|A|` ⟹ `N = 2^j`; `⌈log₂N⌉ = j`, and the minimality hypothesis forces `|A| = j`, so `2^j·c = 2^j` ⟹ `c = 1`.

**0 axioms, 0 `sorry`.** Also corrects a stale `knowledge.md` status block (both sibling files are registered on `main`, not "ORIENT-only").

Scope note: this does **not** touch general `N` or the with-high-probability random setting — those remain the genuine open content of oq-02 (asymptotic/analytic, out of reach for finite methods).

## Test plan

- [ ] **Build-pending** — written under the persisting Docker + Aristotle blackout; not yet compiled. The file is **UNREGISTERED** in `Proofs.lean`, so it cannot affect the aggregate build until a post-blackout session verifies it.
- [ ] Post-blackout: `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal`, then add the import line to `Proofs.lean` and rebuild.
- Mathlib bearers name-checked @ pinned rev `2df2f01`: `Nat.dvd_prime_pow`, `Nat.clog_pow` (Data/Nat/Log.lean:453), `Nat.eq_of_mul_eq_mul_left`, `nsmul_eq_mul`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)