### PR TITLE
research(pascals-hexagon-oq-02): Brianchon's theorem via projective duality

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2679,6 +2679,7 @@ import Proofs.PartitionTheoremOQ03
 import Proofs.PartitionTheoremOQ04
 import Proofs.PartitionTheoremOQ04Aristotle
 import Proofs.PascalsHexagon
+import Proofs.PascalsHexagonOQ02
 import Proofs.PascalsHexagonOQ03
 import Proofs.PellEquation
 import Proofs.PellEquationOQ01

--- a/proofs/Proofs/PascalsHexagonOQ02.lean
+++ b/proofs/Proofs/PascalsHexagonOQ02.lean
@@ -1,0 +1,199 @@
+/-
+  Pascal's Hexagon — Open Question OQ-02: Brianchon's Theorem by Projective Duality
+
+  Parent: `pascals-hexagon` (Pascal's Hexagon Theorem, Wiedijk #28).
+
+  Open question:
+  > Brianchon's theorem is the projective dual of Pascal's theorem. Formally
+  > derive Brianchon (the three main diagonals of a hexagon circumscribed about
+  > a conic are concurrent) from the already-formalized Pascal theorem, via
+  > point–line duality.
+
+  ## Resolution
+
+  YES. In the homogeneous-coordinate model of `PascalsHexagon.lean` projective
+  duality is *built in*: points and lines are both `Fin 3 → ℝ`, the join of two
+  points and the meet of two lines are the **same** operation (`crossProduct`),
+  and `collinear` / `concurrent` are the **same** determinant predicate. Pascal,
+  applied to the six lines viewed as points on the dual (line-)conic, therefore
+  yields Brianchon directly — no new geometric axiom is introduced.
+
+  ## Mathematical content
+
+  Let `D` be the line-conic (the dual of a point-conic; concretely the adjugate
+  matrix `adj C`). A line `ℓ` is *tangent* to the point-conic `C` iff, as a
+  vector, it lies on `D`: `ℓᵀ (adj C) ℓ = 0`. Six tangent lines `a,b,c,d,e,f`
+  form a hexagon circumscribed about `C`. Its vertices are the meets of
+  consecutive sides (`a∧b`, `b∧c`, …), and its three *main diagonals* join
+  opposite vertices:
+
+      AD : (a∧b) ∨ (d∧e)
+      BE : (b∧c) ∨ (e∧f)
+      CF : (c∧d) ∨ (f∧a)
+
+  Reading the six tangent lines as six points on `D` and applying Pascal, the
+  three "opposite-side intersection points" of that inscribed hexagon are
+  collinear. But those three points are *literally* the three diagonals above
+  (join = meet = `crossProduct`), and collinearity of three lines **is**
+  concurrency. Hence the diagonals are concurrent — Brianchon's theorem.
+
+  ## Axioms
+
+  Inherits the single Pascal axiom `conic_implies_pascal_constraint` from
+  `PascalsHexagon.lean`. Brianchon adds **no** new axioms and **no** sorries.
+-/
+
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Proofs.PascalsHexagon
+
+open Matrix
+
+namespace Brianchon
+
+set_option linter.unusedVariables false
+
+-- ============================================================
+-- PART 1: The dual conic and tangency
+-- ============================================================
+
+/-- The **dual (line-)conic** of a point-conic `C`, represented by the adjugate
+    matrix.  For a nondegenerate `C` one has `adj C = (det C) • C⁻¹`, so the
+    line-conic carves out exactly the lines tangent to `C`. -/
+noncomputable def dualConic (C : Conic) : Conic := C.adjugate
+
+/-- A line `ℓ` is **tangent** to the conic `C` iff, viewed as a homogeneous
+    vector, it lies on the dual conic: `ℓᵀ (adj C) ℓ = 0`.  This is the standard
+    projective tangency/envelope condition. -/
+def IsTangentLine (l : ProjLine) (C : Conic) : Prop :=
+  pointOnConic l (dualConic C)
+
+/-- The adjugate of a symmetric matrix is symmetric, so the dual of a symmetric
+    conic is again a symmetric conic. -/
+theorem dualConic_symmetric {C : Conic} (h : C.symmetric) :
+    (dualConic C).symmetric := by
+  have hCt : Cᵀ = C := by
+    ext i j
+    rw [Matrix.transpose_apply]
+    exact h j i
+  have hadj : C.adjugate = (C.adjugate)ᵀ := by
+    have key : (Cᵀ).adjugate = (C.adjugate)ᵀ := Matrix.adjugate_transpose C
+    rwa [hCt] at key
+  intro i j
+  show C.adjugate i j = C.adjugate j i
+  calc C.adjugate i j
+      = (C.adjugate)ᵀ i j := by rw [← hadj]
+    _ = C.adjugate j i := Matrix.transpose_apply _ _ _
+
+-- ============================================================
+-- PART 2: Circumscribed hexagons
+-- ============================================================
+
+/-- A hexagon **circumscribed about** the line-conic `D`: six valid lines, each
+    lying on `D` (i.e. tangent to the point-conic whose dual is `D`).  The sides
+    are taken in cyclic order `a, b, c, d, e, f`. -/
+structure CircumscribedHexagon (D : Conic) where
+  a : ProjLine
+  b : ProjLine
+  c : ProjLine
+  d : ProjLine
+  e : ProjLine
+  f : ProjLine
+  ha : pointOnConic a D
+  hb : pointOnConic b D
+  hc : pointOnConic c D
+  hd : pointOnConic d D
+  he : pointOnConic e D
+  hf : pointOnConic f D
+  havalid : a ≠ 0
+  hbvalid : b ≠ 0
+  hcvalid : c ≠ 0
+  hdvalid : d ≠ 0
+  hevalid : e ≠ 0
+  hfvalid : f ≠ 0
+
+variable {D : Conic}
+
+/-- The main diagonal `AD`, joining vertex `a∧b` to vertex `d∧e`. -/
+noncomputable def diagAD (hex : CircumscribedHexagon D) : ProjLine :=
+  lineThrough (lineIntersection hex.a hex.b) (lineIntersection hex.d hex.e)
+
+/-- The main diagonal `BE`, joining vertex `b∧c` to vertex `e∧f`. -/
+noncomputable def diagBE (hex : CircumscribedHexagon D) : ProjLine :=
+  lineThrough (lineIntersection hex.b hex.c) (lineIntersection hex.e hex.f)
+
+/-- The main diagonal `CF`, joining vertex `c∧d` to vertex `f∧a`. -/
+noncomputable def diagCF (hex : CircumscribedHexagon D) : ProjLine :=
+  lineThrough (lineIntersection hex.c hex.d) (lineIntersection hex.f hex.a)
+
+/-- Read the six tangent lines of a circumscribed hexagon as six points
+    inscribed in the line-conic `D`.  This is the duality bridge: a line on `D`
+    is a point on `D` in the self-dual coordinate model. -/
+def toInscribed (hex : CircumscribedHexagon D) : InscribedHexagon D where
+  A := hex.a
+  B := hex.b
+  C' := hex.c
+  D := hex.d
+  E := hex.e
+  F := hex.f
+  hA := hex.ha
+  hB := hex.hb
+  hC := hex.hc
+  hD := hex.hd
+  hE := hex.he
+  hF := hex.hf
+  hAvalid := hex.havalid
+  hBvalid := hex.hbvalid
+  hCvalid := hex.hcvalid
+  hDvalid := hex.hdvalid
+  hEvalid := hex.hevalid
+  hFvalid := hex.hfvalid
+
+/-- Under the duality bridge, the Pascal point `P = AB ∩ DE` of the inscribed
+    reading is *definitionally* the diagonal `AD` of the circumscribed hexagon:
+    both are `crossProduct (crossProduct a b) (crossProduct d e)`. -/
+theorem pascalP_toInscribed (hex : CircumscribedHexagon D) :
+    pascalP (toInscribed hex) = diagAD hex := rfl
+
+theorem pascalQ_toInscribed (hex : CircumscribedHexagon D) :
+    pascalQ (toInscribed hex) = diagBE hex := rfl
+
+theorem pascalR_toInscribed (hex : CircumscribedHexagon D) :
+    pascalR (toInscribed hex) = diagCF hex := rfl
+
+-- ============================================================
+-- PART 3: Brianchon's Theorem
+-- ============================================================
+
+/-- **Brianchon's Theorem** (projective dual of Pascal's theorem).
+
+    If a hexagon is circumscribed about a conic — its six sides `a,…,f` lie on
+    the line-conic `D` — then its three main diagonals `AD`, `BE`, `CF` are
+    concurrent.
+
+    The proof is pure duality: the six sides, read as points on `D`, form an
+    inscribed hexagon; Pascal's theorem makes the three opposite-side
+    intersection points collinear; those points are exactly the three diagonals,
+    and collinearity of lines is concurrency. -/
+theorem brianchon_theorem (hex : CircumscribedHexagon D) :
+    concurrent (diagAD hex) (diagBE hex) (diagCF hex) := by
+  have hpascal := pascal_hexagon_theorem D (toInscribed hex)
+  -- `collinear` and `concurrent` are the same determinant predicate, and the
+  -- three Pascal points coincide definitionally with the three diagonals.
+  rw [pascalP_toInscribed, pascalQ_toInscribed, pascalR_toInscribed] at hpascal
+  exact hpascal
+
+/-- Brianchon's theorem phrased via tangency to a point-conic `C`: a hexagon
+    whose six sides are tangent to `C` (equivalently, lie on the dual conic
+    `adj C`) has concurrent main diagonals.  This is the corollary obtained by
+    taking the line-conic to be `dualConic C`. -/
+theorem brianchon_circumscribed (C : Conic)
+    (hex : CircumscribedHexagon (dualConic C)) :
+    concurrent (diagAD hex) (diagBE hex) (diagCF hex) :=
+  brianchon_theorem hex
+
+/-- Sanity check on the tangency framing: membership of a side in the dual conic
+    of `C` is, by definition, tangency to `C`. -/
+theorem side_tangent_iff_on_dualConic (l : ProjLine) (C : Conic) :
+    IsTangentLine l C ↔ pointOnConic l (dualConic C) := Iff.rfl
+
+end Brianchon

--- a/proofs/Proofs/PascalsHexagonOQ02.lean
+++ b/proofs/Proofs/PascalsHexagonOQ02.lean
@@ -88,22 +88,22 @@ theorem dualConic_symmetric {C : Conic} (h : C.symmetric) :
 -- PART 2: Circumscribed hexagons
 -- ============================================================
 
-/-- A hexagon **circumscribed about** the line-conic `D`: six valid lines, each
-    lying on `D` (i.e. tangent to the point-conic whose dual is `D`).  The sides
+/-- A hexagon **circumscribed about** the line-conic `K`: six valid lines, each
+    lying on `K` (i.e. tangent to the point-conic whose dual is `K`).  The sides
     are taken in cyclic order `a, b, c, d, e, f`. -/
-structure CircumscribedHexagon (D : Conic) where
+structure CircumscribedHexagon (K : Conic) where
   a : ProjLine
   b : ProjLine
   c : ProjLine
   d : ProjLine
   e : ProjLine
   f : ProjLine
-  ha : pointOnConic a D
-  hb : pointOnConic b D
-  hc : pointOnConic c D
-  hd : pointOnConic d D
-  he : pointOnConic e D
-  hf : pointOnConic f D
+  ha : pointOnConic a K
+  hb : pointOnConic b K
+  hc : pointOnConic c K
+  hd : pointOnConic d K
+  he : pointOnConic e K
+  hf : pointOnConic f K
   havalid : a ≠ 0
   hbvalid : b ≠ 0
   hcvalid : c ≠ 0
@@ -111,24 +111,24 @@ structure CircumscribedHexagon (D : Conic) where
   hevalid : e ≠ 0
   hfvalid : f ≠ 0
 
-variable {D : Conic}
+variable {K : Conic}
 
 /-- The main diagonal `AD`, joining vertex `a∧b` to vertex `d∧e`. -/
-noncomputable def diagAD (hex : CircumscribedHexagon D) : ProjLine :=
+noncomputable def diagAD (hex : CircumscribedHexagon K) : ProjLine :=
   lineThrough (lineIntersection hex.a hex.b) (lineIntersection hex.d hex.e)
 
 /-- The main diagonal `BE`, joining vertex `b∧c` to vertex `e∧f`. -/
-noncomputable def diagBE (hex : CircumscribedHexagon D) : ProjLine :=
+noncomputable def diagBE (hex : CircumscribedHexagon K) : ProjLine :=
   lineThrough (lineIntersection hex.b hex.c) (lineIntersection hex.e hex.f)
 
 /-- The main diagonal `CF`, joining vertex `c∧d` to vertex `f∧a`. -/
-noncomputable def diagCF (hex : CircumscribedHexagon D) : ProjLine :=
+noncomputable def diagCF (hex : CircumscribedHexagon K) : ProjLine :=
   lineThrough (lineIntersection hex.c hex.d) (lineIntersection hex.f hex.a)
 
 /-- Read the six tangent lines of a circumscribed hexagon as six points
-    inscribed in the line-conic `D`.  This is the duality bridge: a line on `D`
-    is a point on `D` in the self-dual coordinate model. -/
-def toInscribed (hex : CircumscribedHexagon D) : InscribedHexagon D where
+    inscribed in the line-conic `K`.  This is the duality bridge: a line on `K`
+    is a point on `K` in the self-dual coordinate model. -/
+def toInscribed (hex : CircumscribedHexagon K) : InscribedHexagon K where
   A := hex.a
   B := hex.b
   C' := hex.c
@@ -151,13 +151,13 @@ def toInscribed (hex : CircumscribedHexagon D) : InscribedHexagon D where
 /-- Under the duality bridge, the Pascal point `P = AB ∩ DE` of the inscribed
     reading is *definitionally* the diagonal `AD` of the circumscribed hexagon:
     both are `crossProduct (crossProduct a b) (crossProduct d e)`. -/
-theorem pascalP_toInscribed (hex : CircumscribedHexagon D) :
+theorem pascalP_toInscribed (hex : CircumscribedHexagon K) :
     pascalP (toInscribed hex) = diagAD hex := rfl
 
-theorem pascalQ_toInscribed (hex : CircumscribedHexagon D) :
+theorem pascalQ_toInscribed (hex : CircumscribedHexagon K) :
     pascalQ (toInscribed hex) = diagBE hex := rfl
 
-theorem pascalR_toInscribed (hex : CircumscribedHexagon D) :
+theorem pascalR_toInscribed (hex : CircumscribedHexagon K) :
     pascalR (toInscribed hex) = diagCF hex := rfl
 
 -- ============================================================
@@ -167,16 +167,16 @@ theorem pascalR_toInscribed (hex : CircumscribedHexagon D) :
 /-- **Brianchon's Theorem** (projective dual of Pascal's theorem).
 
     If a hexagon is circumscribed about a conic — its six sides `a,…,f` lie on
-    the line-conic `D` — then its three main diagonals `AD`, `BE`, `CF` are
+    the line-conic `K` — then its three main diagonals `AD`, `BE`, `CF` are
     concurrent.
 
-    The proof is pure duality: the six sides, read as points on `D`, form an
+    The proof is pure duality: the six sides, read as points on `K`, form an
     inscribed hexagon; Pascal's theorem makes the three opposite-side
     intersection points collinear; those points are exactly the three diagonals,
     and collinearity of lines is concurrency. -/
-theorem brianchon_theorem (hex : CircumscribedHexagon D) :
+theorem brianchon_theorem (hex : CircumscribedHexagon K) :
     concurrent (diagAD hex) (diagBE hex) (diagCF hex) := by
-  have hpascal := pascal_hexagon_theorem D (toInscribed hex)
+  have hpascal := pascal_hexagon_theorem K (toInscribed hex)
   -- `collinear` and `concurrent` are the same determinant predicate, and the
   -- three Pascal points coincide definitionally with the three diagonals.
   rw [pascalP_toInscribed, pascalQ_toInscribed, pascalR_toInscribed] at hpascal

--- a/src/data/proofs/pascals-hexagon-oq-02/annotations.json
+++ b/src/data/proofs/pascals-hexagon-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "Brianchon's Theorem as the Dual of Pascal's",
+    "content": "**Brianchon's Theorem (1806)**: if a hexagon is circumscribed about a conic — each of its six sides is tangent to the conic — then its three main diagonals (joining opposite vertices) are **concurrent**. This is the exact projective dual of Pascal's hexagon theorem: points become lines, 'collinear' becomes 'concurrent', and 'inscribed' becomes 'circumscribed'. The file derives Brianchon from the already-formalized `pascal_hexagon_theorem` without introducing any new axiom.",
+    "mathContext": "Duality is built into the homogeneous-coordinate model of the parent file. Points and lines are both nonzero vectors in $\\mathbb{R}^3$; the join of two points and the meet of two lines are the same operation (the cross product); and `collinear` and `concurrent` are the same predicate $\\det(\\cdot,\\cdot,\\cdot)=0$. Reinterpreting Pascal's collinearity statement under this dictionary yields Brianchon's concurrency statement directly.",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective-duality",
+      "conic-sections",
+      "concurrency",
+      "brianchon-theorem"
+    ],
+    "prerequisites": [
+      "pascals-theorem",
+      "homogeneous-coordinates",
+      "cross-product"
+    ]
+  },
+  {
+    "id": "ann-dual-conic",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 60, "endLine": 69 },
+    "type": "definition",
+    "title": "The Dual Conic and Tangency",
+    "content": "`dualConic C` is the adjugate matrix $\\mathrm{adj}(C)$, representing the **line-conic** (envelope) dual to the point-conic $C$. A line $\\ell$ is `IsTangentLine` to $C$ exactly when, as a vector, it lies on the dual conic: $\\ell^T\\,\\mathrm{adj}(C)\\,\\ell = 0$.",
+    "mathContext": "For a nondegenerate conic, $\\mathrm{adj}(C) = (\\det C)\\,C^{-1}$, so the tangency condition $\\ell^T C^{-1}\\ell = 0$ is captured (up to the nonzero scalar $\\det C$) by membership on $\\mathrm{adj}(C)$. The adjugate is used rather than the inverse so the definition makes sense for every conic and avoids invertibility side-conditions.",
+    "significance": "important",
+    "relatedConcepts": ["dual-conic", "adjugate-matrix", "tangent-line", "envelope"],
+    "prerequisites": ["adjugate-matrix", "conic-quadratic-form"]
+  },
+  {
+    "id": "ann-dual-symmetric",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 71, "endLine": 90 },
+    "type": "theorem",
+    "title": "The Dual of a Symmetric Conic is Symmetric",
+    "content": "`dualConic_symmetric`: if $C$ is a symmetric conic then $\\mathrm{adj}(C)$ is symmetric. Hence the line-conic dual to a genuine (symmetric) conic is again a genuine conic.",
+    "mathContext": "The proof uses `Matrix.adjugate_transpose` ($\\mathrm{adj}(C^T) = \\mathrm{adj}(C)^T$). Symmetry of $C$ means $C^T = C$, so $\\mathrm{adj}(C) = \\mathrm{adj}(C^T) = \\mathrm{adj}(C)^T$, i.e. $\\mathrm{adj}(C)$ is symmetric. This confirms the geometric statement that conics are self-dual as a class.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjugate-matrix", "symmetric-matrix", "dual-conic"],
+    "prerequisites": ["adjugate-transpose", "matrix-transpose"]
+  },
+  {
+    "id": "ann-circumscribed",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 92, "endLine": 127 },
+    "type": "definition",
+    "title": "Circumscribed Hexagon and Main Diagonals",
+    "content": "`CircumscribedHexagon D` packages six valid sides $a,\\dots,f$ each lying on the line-conic $D$ (tangent to the dual point-conic). Its vertices are the meets of consecutive sides, and `diagAD`, `diagBE`, `diagCF` are the three main diagonals joining opposite vertices: $AD=(a\\wedge b)\\vee(d\\wedge e)$, $BE=(b\\wedge c)\\vee(e\\wedge f)$, $CF=(c\\wedge d)\\vee(f\\wedge a)$.",
+    "mathContext": "Each diagonal is built from the cross product twice: an inner cross product computes a vertex (meet of two sides), and an outer cross product computes the line through two opposite vertices. Because join and meet are the same cross product in this model, no separate 'line through points' machinery is needed.",
+    "significance": "important",
+    "relatedConcepts": ["circumscribed-hexagon", "main-diagonal", "meet-and-join"],
+    "prerequisites": ["cross-product", "conic-quadratic-form"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 129, "endLine": 162 },
+    "type": "technique",
+    "title": "Duality Bridge: Sides as Inscribed Points",
+    "content": "`toInscribed` reads the six tangent sides of a circumscribed hexagon as six points inscribed in the line-conic $D$. The lemmas `pascalP_toInscribed`, `pascalQ_toInscribed`, `pascalR_toInscribed` then prove — by `rfl` — that the Pascal opposite-side points of this inscribed reading are *literally* the three main diagonals of the circumscribed hexagon.",
+    "mathContext": "Both $\\mathrm{pascalP}$ and $\\mathrm{diagAD}$ reduce to $\\mathrm{cross}(\\mathrm{cross}(a,b),\\,\\mathrm{cross}(d,e))$, because `lineThrough` and `lineIntersection` are the same function (`crossProduct`). The proofs are definitional equalities, the technical heart of the duality argument: there is nothing to compute, only to recognize.",
+    "significance": "key",
+    "relatedConcepts": ["projective-duality", "definitional-equality", "pascal-line"],
+    "prerequisites": ["cross-product", "structure-projection"]
+  },
+  {
+    "id": "ann-brianchon",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 164, "endLine": 187 },
+    "type": "theorem",
+    "title": "Brianchon's Theorem",
+    "content": "`brianchon_theorem`: for a hexagon circumscribed about the line-conic $D$, the three main diagonals are concurrent. The proof applies `pascal_hexagon_theorem` to `toInscribed hex`, rewrites the three Pascal points into the three diagonals via the bridge lemmas, and finishes — since collinearity of three lines *is* their concurrency.",
+    "mathContext": "The final step `exact hpascal` relies on `collinear` and `concurrent` being the identical determinant predicate. No new axiom is introduced: Brianchon rests on exactly the same `conic_implies_pascal_constraint` axiom as Pascal, transported through duality.",
+    "significance": "key",
+    "relatedConcepts": ["brianchon-theorem", "concurrency", "projective-duality"],
+    "prerequisites": ["pascals-theorem", "matrix-determinant"]
+  },
+  {
+    "id": "ann-corollary",
+    "proofId": "pascals-hexagon-oq-02",
+    "range": { "startLine": 189, "endLine": 198 },
+    "type": "theorem",
+    "title": "Tangency Framing and Sanity Check",
+    "content": "`brianchon_circumscribed` restates the theorem for a hexagon whose sides are tangent to a point-conic $C$ (taking the line-conic to be $\\mathrm{adj}(C)$), and `side_tangent_iff_on_dualConic` records that tangency to $C$ is, by definition, membership on the dual conic.",
+    "mathContext": "These wrappers connect the general line-conic statement to the classical 'circumscribed about a conic' phrasing without any additional mathematical content — `brianchon_circumscribed` is simply `brianchon_theorem` specialized to $D = \\mathrm{adj}(C)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tangent-line", "dual-conic", "corollary"],
+    "prerequisites": ["dual-conic"]
+  }
+]

--- a/src/data/proofs/pascals-hexagon-oq-02/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-02/meta.json
@@ -1,0 +1,71 @@
+{
+  "id": "pascals-hexagon-oq-02",
+  "title": "Brianchon's Theorem via Projective Duality",
+  "slug": "pascals-hexagon-oq-02",
+  "description": "Brianchon's theorem — the three main diagonals of a hexagon circumscribed about a conic are concurrent — derived as the projective dual of Pascal's hexagon theorem in the self-dual homogeneous-coordinate model.",
+  "meta": {
+    "author": "Charles-Julien Brianchon (1806); formalization derived from Pascal",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brianchon%27s_theorem",
+    "date": "1806",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/PascalsHexagonOQ02.lean",
+    "parent": "pascals-hexagon",
+    "tags": [
+      "geometry",
+      "projective",
+      "conic",
+      "duality",
+      "concurrency",
+      "brianchon",
+      "open-question"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Mathlib.LinearAlgebra.Matrix.Adjugate",
+        "description": "Adjugate matrix used to define the dual (line-)conic and prove its symmetry",
+        "module": "Mathlib.LinearAlgebra.Matrix.Adjugate"
+      },
+      {
+        "theorem": "Mathlib.LinearAlgebra.CrossProduct",
+        "description": "Cross product (inherited via PascalsHexagon) serving as both join of points and meet of lines",
+        "module": "Mathlib.LinearAlgebra.CrossProduct"
+      }
+    ],
+    "originalContributions": [
+      "Dual (line-)conic defined via the adjugate matrix, with tangency expressed as membership on the dual conic",
+      "Proof that the adjugate of a symmetric conic is symmetric (dual of a symmetric conic is a symmetric conic)",
+      "CircumscribedHexagon structure: six valid sides lying on the line-conic",
+      "Duality bridge toInscribed: reading the six tangent sides as six points inscribed in the dual conic",
+      "Definitional identification of the three main diagonals with the Pascal opposite-side points (pascalP/Q/R)",
+      "Brianchon's theorem proved with no new axioms or sorries, purely from pascal_hexagon_theorem"
+    ],
+    "dateAdded": "2026-06-15",
+    "axiomCount": 1,
+    "lineCount": 199,
+    "assumptions": "1 axiom, inherited from the parent file: conic_implies_pascal_constraint (the Cayley-Bacharach/Bezout step of Pascal's theorem). This file introduces NO new axioms and NO sorries — Brianchon follows from Pascal by duality alone.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "Charles-Julien Brianchon (1783–1864) discovered this theorem in 1806 while a student at the École Polytechnique, publishing it in the Journal de l'École Polytechnique. It is the projective dual of Pascal's 1639 hexagon theorem (Hexagrammum Mysticum): where Pascal concerns a hexagon inscribed in a conic and concludes that opposite sides meet in collinear points, Brianchon concerns a hexagon circumscribed about a conic (its sides tangent to the conic) and concludes that the three main diagonals are concurrent. The two theorems are exchanged by the principle of duality in the projective plane, which swaps points with lines, 'collinear' with 'concurrent', and 'lies on' with 'passes through'. Brianchon's discovery was an early and striking confirmation of the power of Poncelet-style projective duality, which was systematized over the following decades.",
+    "problemStatement": "**Brianchon's Theorem**: Let a hexagon with sides $a, b, c, d, e, f$ (in cyclic order) be circumscribed about a conic, i.e. each side is tangent to the conic. Its vertices are the meets of consecutive sides ($a \\wedge b$, $b \\wedge c$, …). Then the three *main diagonals* joining opposite vertices,\n$$AD = (a\\wedge b)\\vee(d\\wedge e),\\quad BE = (b\\wedge c)\\vee(e\\wedge f),\\quad CF = (c\\wedge d)\\vee(f\\wedge a),$$\nare **concurrent** (pass through a common point, the Brianchon point).",
+    "text": "Brianchon's theorem — the three main diagonals of a hexagon circumscribed about a conic are concurrent — formalized as the projective dual of Pascal's hexagon theorem.",
+    "proofStrategy": "The parent file models $\\mathbb{RP}^2$ by nonzero vectors in $\\mathbb{R}^3$. In this model duality is built in: the join of two points and the meet of two lines are the **same** operation (the cross product), and `collinear` and `concurrent` are the **same** determinant predicate $\\det(\\cdot,\\cdot,\\cdot)=0$. A line $\\ell$ is tangent to a point-conic $C$ exactly when, as a vector, it lies on the dual (line-)conic $\\mathrm{adj}(C)$, since $\\ell^T \\mathrm{adj}(C)\\,\\ell = 0$. Hence six tangent sides are six points on the dual conic — an *inscribed* hexagon there. Applying `pascal_hexagon_theorem` to that inscribed hexagon makes its three opposite-side intersection points collinear. Those three points are, by definition (join = meet = cross product), the three main diagonals of the original circumscribed hexagon, and collinearity of three lines is concurrency. Brianchon therefore follows with no new axioms: the only assumption is the Pascal constraint axiom inherited from the parent file.",
+    "keyInsights": [
+      "**Self-dual coordinates**: Because points and lines are both nonzero vectors in $\\mathbb{R}^3$ and join/meet are both the cross product, the dual of any incidence theorem is obtained for free by reinterpreting the same algebra",
+      "**Pascal point = Brianchon diagonal**: The opposite-side intersection point $P = (a\\wedge b)\\vee(d\\wedge e)$ of the inscribed reading is *definitionally equal* to the main diagonal $AD$ of the circumscribed hexagon — both reduce to $\\mathrm{cross}(\\mathrm{cross}(a,b),\\mathrm{cross}(d,e))$",
+      "**Collinear ≡ concurrent**: The predicates for three collinear points and three concurrent lines are the identical determinant condition, so Pascal's collinearity conclusion is literally Brianchon's concurrency conclusion",
+      "**Dual conic = adjugate**: For a nondegenerate conic $C$ the envelope of tangent lines is the conic $\\mathrm{adj}(C) = (\\det C)\\,C^{-1}$; the adjugate of a symmetric matrix is symmetric, so the dual of a (symmetric) conic is again a conic",
+      "**No new assumptions**: Brianchon inherits the single Pascal axiom and adds neither axioms nor sorries — the entire content is the duality reinterpretation"
+    ],
+    "prerequisites": [
+      "Pascal's hexagon theorem (parent formalization)",
+      "Projective duality in the plane (points ↔ lines, collinear ↔ concurrent)",
+      "Homogeneous coordinates and the cross product as join/meet",
+      "The adjugate matrix and the dual conic / envelope of tangent lines"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the open question **pascals-hexagon-oq-02**: formally derive **Brianchon's theorem** (the three main diagonals of a hexagon *circumscribed* about a conic are concurrent) as the projective dual of the already-formalized Pascal hexagon theorem.

New file `proofs/Proofs/PascalsHexagonOQ02.lean` (199 lines, 7 theorems, 7 definitions, **0 new axioms, 0 sorries**).

## Why this is clean

The parent file models ℝP² by nonzero vectors in ℝ³, where duality is *built in*:
- the **join** of two points and the **meet** of two lines are the same operation (`crossProduct`), so `lineThrough = lineIntersection`;
- `collinear` and `concurrent` are the **same** determinant predicate `det(·,·,·) = 0`.

A line is tangent to a point-conic `C` iff (as a vector) it lies on the dual conic `dualConic C = adj C`. Six tangent sides are therefore six points *inscribed* in the dual conic. Applying `pascal_hexagon_theorem` to that inscribed hexagon makes its three opposite-side intersection points collinear — and those points are **definitionally** the three main diagonals of the circumscribed hexagon (`pascalP/Q/R_toInscribed` close by `rfl`). Collinearity of three lines is concurrency, so Brianchon follows by `exact`.

## What's added

- `dualConic`, `IsTangentLine` — dual (line-)conic via the adjugate, tangency as membership on it.
- `dualConic_symmetric` — adjugate of a symmetric conic is symmetric (dual of a conic is a conic).
- `CircumscribedHexagon`, `diagAD/BE/CF`, `toInscribed` — duality bridge.
- `brianchon_theorem`, `brianchon_circumscribed`, `side_tangent_iff_on_dualConic`.

## Axioms

Inherits **only** the existing `conic_implies_pascal_constraint` axiom from the parent `PascalsHexagon.lean` (the Cayley–Bacharach step of Pascal). Brianchon introduces **no** new axioms. meta.json: `status: axiomatized`, `badge: axiom`, `axiomCount: 1` (inherited).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ02` — **build-pending** (Docker blackout this session). External deps name-checked against Mathlib v4.26.0: `Matrix.adjugate_transpose`, `Matrix.transpose_apply`. The three `rfl`/`exact` bridge proofs rely on `lineThrough ≡ lineIntersection ≡ crossProduct` and `collinear ≡ concurrent` being definitional in the parent model.
- [x] Gallery JSON validates (meta.json + annotations.json, ranges in-bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)