### PR TITLE
Enrich Green's Theorem OQ-02-OQ-02: annotations, crossRef, keyInsight

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
@@ -1,5 +1,43 @@
 [
   {
+    "id": "ann-greens-oq0202-staging-rationale",
+    "proofId": "greens-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "Why an Isolated, Unregistered Staging File",
+    "content": "The correction is not applied directly to the registered parent files. Fixing the false axiom requires a single signature change (`+hLineEq`) propagated through six consumers split across two *registered* files (`GreensTheoremOQ02.lean` and `GreensTheoremOQ02OQ04.lean`); such a multi-file refactor cannot be landed safely without an atomic, build-verified patch, which was impossible under the Docker + Aristotle outage this file was authored in.\n\nSo the fix is staged here under `_oriented`-suffixed names, proved in isolation, and ported back as one Docker-checked commit once tooling returns — at which point the suffix is dropped and both this file and `GreensTheoremOQ02Counterexample.lean` are retired. This is the standard axiom-integrity workflow: demonstrate the repair against a live counterexample first, land it coordinated second.",
+    "mathContext": "No new mathematics — a staging layer. The registered `greens_theorem_l1curl` is provably false (`greens_theorem_l1curl_refuted`: $0 = 1$); the patch lives here until it can be applied atomically.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Axiom integrity",
+      "Coordinated refactor",
+      "Blast radius"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-greens-oq0202-dependencies",
+    "proofId": "greens-theorem-oq-02-oq-02",
+    "range": {
+      "startLine": 43,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "Dependency Architecture",
+    "content": "Each opened sibling supplies exactly one ingredient of the correction, making this file a thin re-statement-and-rethread layer:\n\n- `GreensTheoremOQ01 (rectLineIntegral)` — the concrete, correctly-oriented four-edge rectangle integral that `hLineEq` equates the circulation to (the keystone of the fix).\n- `GreensTheoremOQ02` — the three original consumers (`lineIntegral_zero_curl`, `lineIntegral_l1curl_smul`, `greens_oq1_from_l1curl`) plus the `LipschitzClosedCurve` / `lipschitzLineIntegral` vocabulary.\n- `GreensTheoremOQ02OQ04 (OneForm2D extDeriv1_2D)` — the remaining two consumers and the differential-form layer.\n- `GreensTheoremOQ02Counterexample (constCurve cexP cexQ …)` — the Session-5 unsound witness reused to verify excision.",
+    "mathContext": "$\\text{rectLineIntegral}\\,P\\,Q\\,a\\,b\\,c\\,d$ is the sum of the four oriented edge integrals of the rectangle $[a,b]\\times[c,d]$ — the explicit boundary orientation the abstract Lipschitz curve must match.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Module dependencies",
+      "rectLineIntegral",
+      "Line integral"
+    ],
+    "prerequisites": []
+  },
+  {
     "id": "ann-greens-oq0202-corrected-axiom",
     "proofId": "greens-theorem-oq-02-oq-02",
     "range": {

--- a/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
@@ -60,7 +60,8 @@
       "**Frontier-containment is too weak:** it pins down neither orientation nor winding nor non-degeneracy, which is exactly what lets the constant curve refute the original axiom.",
       "**One hypothesis suffices:** equating the circulation with the concrete oriented rectangle integral `rectLineIntegral` (OQ-01) restores soundness without changing any consumer's mathematics.",
       "**Excision is verified, not assumed:** the counterexample is shown to fail the new hypothesis via a proven lemma, so soundness is demonstrably regained.",
-      "**Coordinated landing required:** the fix spans two registered files and six consumers, so it must be ported as a single Docker-verified patch — hence this isolated, unregistered staging file."
+      "**Coordinated landing required:** the fix spans two registered files and six consumers, so it must be ported as a single Docker-verified patch — hence this isolated, unregistered staging file.",
+      "**Orientation-soundness is necessary, not sufficient:** hLineEq removes the false counterexamples, but greens_theorem_l1curl_oriented remains an axiom — the genuine Whitney minimal-regularity content is still assumed. A fully verified proof awaits the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0), which would reduce it to OQ-01's boundary algebra by Fubini."
     ],
     "prerequisites": [
       "Green's theorem / Stokes' theorem in the plane",
@@ -113,6 +114,11 @@
       "relationship": "related-result",
       "description": "Sibling open-question entry in the same minimal-regularity Green's theorem family.",
       "targetId": "greens-theorem-oq-02-oq-04"
+    },
+    {
+      "relationship": "uses",
+      "description": "Source of rectLineIntegral, the concrete correctly-oriented four-edge rectangle integral that the corrective hypothesis hLineEq equates the Lipschitz curve's circulation to — the keystone that restores orientation-soundness.",
+      "targetId": "greens-theorem-oq-01"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `greens-theorem-oq-02-oq-02` (quality 81, 0 prior passes; no other open enrichment PR for this slug).

## Changes (gallery data only)
- **annotations.json** 3 → 5: added 2 `context` annotations covering the previously-unannotated header region (lines 1–51):
  - *Why an Isolated, Unregistered Staging File* — the axiom-integrity rationale for not editing the registered parents directly (atomic 6-consumer port deferred to a single Docker-verified patch).
  - *Dependency Architecture* — which named symbol each opened sibling supplies (`rectLineIntegral` from OQ-01, the three original consumers from OQ-02, two more + the form layer from OQ-02-OQ-04, the witness from the Counterexample file).
- **meta.json crossReferences** 2 → 3: added `greens-theorem-oq-01` (`uses`) — the source of `rectLineIntegral`, the keystone the corrective `hLineEq` hypothesis equates the circulation to. (targetId verified to exist.)
- **meta.json keyInsights** 4 → 5: clarified that orientation-soundness is necessary but not sufficient — the corrected axiom remains an assumption pending the FTC-for-AC keystone.

No `.lean` files touched; no existing content removed. JSON validated via the data-gen build pass.