### PR TITLE
audit(erdos-10-oq-02): correct theoremCount 14 -> 16

### DIFF
--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -25,7 +25,7 @@
     "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (`GranvilleSoundararajanOdd`), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Build status: registered in Proofs.lean (lines 901–903) but machine-check is pending the deployer's Docker build (authored under a Docker/Aristotle blackout); the native_decide witnesses (906, etc.) are verified-on-paper and by an exact-arithmetic Python certificate, and will be machine-confirmed on the next green build.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 8
   },
   "overview": {
@@ -150,7 +150,7 @@
     "namespace": "Erdos10OQ02",
     "lineCount": 542,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "path": "Proofs/Erdos10OQ02.lean",
     "sorries": 0,
     "definitionCount": 8


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-10-oq-02 (Granville–Soundararajan k=3 reduction/popcount stack)

### Finding (LOW severity — count discrepancy)

`theoremCount` was reported as **14**, but the actual theorem/lemma count across the three-file stack is **16**:

| File | theorems/lemmas |
|------|-----------------|
| `Erdos10OQ02.lean` | 8 |
| `Erdos10OQ02Decidable.lean` | 6 |
| `Erdos10OQ02Popcount.lean` | 2 |
| **Total** | **16** |

The undercount came from a `^theorem`-anchored grep that misses attribute-prefixed declarations — specifically the two `@[simp] theorem` declarations `powSum_zero` and `powSum_cons` (14 + 2 = 16).

### Verified accurate (no change needed)

- `status: "formalized"`, `badge: "wip"` — correct; the open conjecture is a `Prop` definition (`GranvilleSoundararajanOdd`), not assumed.
- `axiomCount: 0`, `sorries: 0` — confirmed (no `axiom` declarations, no `sorry`, no `True` stubs).
- `lineCount: 542` — matches (189 + 200 + 153).
- `definitionCount: 8` — consistent (6 `def` + 2 `instance`).
- All three files registered in `Proofs.lean` (lines 905–907).

Gallery-data only; no Lean source touched.

---
Discovered during gallery integrity audit.