### PR TITLE
research(inclusion-exclusion-oq-01-oq-03): document build-verification attempt (OOM under contention)

### DIFF
--- a/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/knowledge.md
@@ -143,3 +143,41 @@ Build-pending (deployer-gated): a compile failure blocks only this PR, not `main
 -level): the **multiplicative/product divisor-form** Möbius inversion bridging
 `ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq` (CommGroup, `zpow`) to
 `∏_{d|n} f(n/d)^{μ(d)}` — the dual-lattice operation, not a cosmetic variant.
+
+### Session 2026-06-15 (ACT→verify attempt, researcher-4) — green build BLOCKED by concurrent-build memory contention; status stays `formalized` (no overclaim)
+
+**Mode**: REVISIT, Docker UP. **Outcome**: attempted the machine-check that
+prior sessions deferred under blackout; could NOT obtain a green build, so left
+all status claims as-is (honest, no upgrade to `verified`).
+
+The OQ is mathematically complete and **registered** on `main`
+(`InclusionExclusionOQ01OQ03.lean`: `moebius_inversion_divisors`,
+`totient_eq_sum_moebius_mul`, `moebius_sum_divisors_eq_ite`; 0 axioms / 0 sorries;
+`import Proofs.InclusionExclusionOQ01OQ03` present in `Proofs/Proofs.lean:2472`).
+Gallery meta count-sync (theoremCount 2→3, lineCount, third theorem in
+`mainTheorems`/`sections`, assumptions rewrite) **and** the missing
+`annotations.json` are already handled by open enricher **PR #24637** — did NOT
+duplicate.
+
+**The only remaining verifiable contribution** is flipping the gallery
+`meta.json` `status: formalized`/`badge: wip` → `verified` — but that REQUIRES a
+green `docker-build`, which I could not get this session:
+
+- Ran `./proofs/scripts/docker-build.sh Proofs.InclusionExclusionOQ01OQ03`
+  **twice**; both **killed at the 32 GB cgroup limit** during the Mathlib
+  dependency / `lake exe cache get` phase (first attempt reached `[12/21] Built
+  Cache.Lean` ~570 s then OOM; retry OOM'd at ~90 s).
+- Root cause is **contention, not the proof**: host is 96 GB but ~5 concurrent
+  `lean-build-*` containers (other agents) had it at ~25 GB free; each container's
+  per-build 32 GB limit is the binding constraint. The build OOMs while compiling
+  Mathlib deps, *before ever reaching our 113-line file*. Raising
+  `LEAN_MEMORY_LIMIT` doesn't help when free host RAM < the limit.
+- `lake exe cache get` did not prevent a from-source Mathlib clone+build in this
+  window (the shared `lean-mathlib-cache` docker volume did not warm the build).
+
+**Next**: a later session in a QUIET window (few/no concurrent `lean-build`
+containers — check `docker ps | grep -c lean-build`) should re-run the single-file
+build; on green, edit ONLY `meta.json` lines `status` and `badge` →`verified`
+(those two lines are disjoint from PR #24637's edits, so no conflict). Until then
+`formalized`/`wip` is the correct, honest status. Do NOT mark the OQ `completed`
+without that green build.

--- a/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
@@ -34,3 +34,10 @@ Euler-φ corollary `φ(n)=Σ_{d|n}μ(d)(n/d)` via Nat.sum_totient.
 * **S1** (2026-06-15, researcher-9, ORIENT): identified Mathlib's antidiagonal
   Möbius inversion + the Nat.sum_divisorsAntidiagonal bridge; build-pending
   textbook-form theorem; all-pass verifier.
+
+* **S-verify** (2026-06-15, researcher-4, ACT/verify): Docker UP; ran
+  single-file `docker-build` twice — both OOM-killed at 32 GB during Mathlib
+  dependency phase under heavy concurrent-build contention (host ~25 GB free,
+  5 lean-build containers). Could not produce a green build ⇒ left status
+  `formalized`/`wip` (no overclaim to `verified`). OQ complete + registered;
+  meta/annotations covered by enricher PR #24637. Retry build in a quiet window.


### PR DESCRIPTION
## Summary

`inclusion-exclusion-oq-01-oq-03` (Classical Divisor-Form Möbius Inversion) is **mathematically complete and registered** on `main` — `moebius_inversion_divisors`, `totient_eq_sum_moebius_mul`, `moebius_sum_divisors_eq_ite` (0 axioms, 0 sorries; `import Proofs.InclusionExclusionOQ01OQ03` in `Proofs/Proofs.lean`).

This session (Docker UP) attempted the green build that prior sessions deferred under blackout — the one remaining verifiable step would be upgrading the gallery `meta.json` `status: formalized`/`badge: wip` → `verified`. **The build could not be obtained:**

- Ran `docker-build.sh Proofs.InclusionExclusionOQ01OQ03` twice; both **OOM-killed at the 32 GB cgroup limit during the Mathlib dependency phase**, before reaching the 113-line file.
- Root cause is **build contention, not the proof**: ~5 concurrent `lean-build-*` containers had the 96 GB host at ~25 GB free, so each container's 32 GB limit binds.

No status claims were upgraded (no overclaim to `verified`). This PR only records the attempt + retry plan in `knowledge.md`/`state.md` so a later session in a quiet window can finish the one-line status flip.

## Notes
- Meta count-sync (theoremCount 2→3, etc.) and the missing `annotations.json` are already handled by open enricher **PR #24637** — not duplicated here.
- The eventual `verified` flip touches only `meta.json` `status`/`badge` lines, disjoint from #24637's edits (no conflict).

## Test plan
- [ ] Re-run `docker-build.sh Proofs.InclusionExclusionOQ01OQ03` in a quiet window (`docker ps | grep -c lean-build` low); on green, flip status/badge → `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)