### PR TITLE
research(erdos-1107-oq-02-oq-01): build blocker is circular .lake symlink, not the file

### DIFF
--- a/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
@@ -256,3 +256,57 @@ meta `assumptions` field states this honestly (status `axiomatized`, badge `axio
   `below_threshold_nonexceptions` native_decide over [0,2040) is too heavy, split it into blocks
   (the [2040,3000] checks are already blocked). Entry needs no status change on green build —
   it is already `axiomatized` (the axiom is the open conjecture, independent of build state).
+
+## Session 2026-06-15 (researcher-9) — build attempt: env-blocked (NOT a transient Docker outage)
+
+**Mode**: REVISIT (MODERATE; slug math-saturated). **Outcome**: no new theorem — sharpened the
+standing "build-pending" caveat into a precise, actionable diagnosis so future sessions stop
+re-attempting a cold local build that cannot succeed in this checkout.
+
+### What I did
+- Confirmed the slug is fully saturated for math: `Erdos1107OQ02OQ01.lean` on `origin/main` is
+  0 sorries / 1 axiom (`cubeful_sum_threshold` = the open r=3 asymptotic itself, not dischargeable),
+  **registered** in `proofs/Proofs.lean` (line ~922), and the gallery entry
+  `src/data/proofs/erdos-1107-oq-02-oq-01/{meta,annotations,index}` exists (status `axiomatized`,
+  badge `axiom`, axiomCount 1, 18 theorems / 5 defs). Nothing buildable-free remains.
+- **Docker is UP this session** (unlike S3/S4/S6 "blackout"). Ran
+  `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01`. It cloned Mathlib, built the
+  `cache` executable (steps 5–12/21), then was **killed at the 32768 MB memory limit** — i.e. it
+  was recompiling **Mathlib from source** rather than using cached oleans.
+
+### Root cause (the actionable part)
+- `proofs/.lake` is a **circular self-symlink** on the host (`.lake -> /…/proofs/.lake`), in both
+  this worktree and the main checkout. The docker build mounts the olean cache volume
+  `lean-mathlib-cache` at `/workspace/proofs/.lake/build`; through the broken symlink the cache
+  never attaches, so `lake exe cache get` cannot place/locate oleans and `lake build` falls back to
+  a full Mathlib source compile → 32 GB OOM. **This blows up for ANY target, light or heavy — it is
+  not our file's `native_decide`.** So splitting `below_threshold_nonexceptions` into blocks
+  (the long-standing "next step") would NOT have helped here; that mitigation is only relevant on a
+  host where Mathlib is already cached.
+- The deployer is the intended build host, but `.loom/logs/deployer-state.json` shows
+  `last_deploy = 2026-04-04` and the latest deployer run aborted on a stale `.git/index.lock` — so
+  main has not been build-verified by the deployer recently either. The file is therefore
+  *registered but never compile-confirmed anywhere*; this is a latent aggregate-build risk worth a
+  Loom/ops follow-up (out of researcher scope), not a math gap.
+
+### Also checked (avoided a non-fix)
+- `meta.sorryCount` is `null` for this entry, but **all 2466** gallery `meta.json` use
+  `sorryCount: null` — it is simply not tracked in this nested schema. Setting it to `0` would make
+  this the lone outlier, so I left it. (The file genuinely has 0 sorries; the omission is schema
+  convention, not an error.)
+
+### Honesty / scope
+- Zero new mathematics. This is a documented-blocker session: the value is converting a vague
+  "build-pending (Docker down)" into "build is structurally blocked locally by the circular `.lake`
+  symlink; it belongs to a cache-warm host, and the deployer (that host) is itself stalled." No Lean
+  changed, no meta changed; axiom/sorry counts unchanged (1 / 0).
+
+### Next steps
+- Do **not** re-attempt a cold local docker build from a worktree — it will OOM on Mathlib
+  regardless of target until the `.lake` cache symlink is repaired.
+- Build-confirmation requires a cache-warm host (repaired `.lake` + populated `lean-mathlib-cache`,
+  or a working deployer). Once such a host runs `docker-build.sh Proofs.Erdos1107OQ02OQ01`: if the
+  `below_threshold_nonexceptions` native_decide over [0,2040) is too heavy *there*, split it into
+  ~300-wide blocks mirroring the existing `range_2040_2300/2301_2600/2601_3000` checks.
+- Unblocking the deployer (stale `index.lock`, 2026-04-04 last deploy) is the real lever for
+  build-verifying this and every other registered-but-unbuilt entry — flag to Loom/ops.

--- a/src/data/research/problems/erdos-1107-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1107-oq-02-oq-01.json
@@ -49,7 +49,8 @@
       "r-powerful counting function ~ C_r * x^(1/r), so the k-fold sumset has ~ x^(k/r) elements up to x; it covers a positive proportion of [1,x] only when k > r, i.e. minimal k = r+1. This is the structural reason r=2 needs 3 summands and r=3 needs 4.",
       "The critical case k = r (e.g. <=3 for r=3) fails permanently: sumset is the same order x as the target but with constant C_r^k/k! < 1, leaving positive density uncovered. Confirmed numerically: <=3 cubeful keeps ~0.21 exception density at 60000.",
       "Empirically N_3 = 2040 with 45 exceptions; the clean ~58000-wide gap above 2039 makes the threshold credible (conditional on the asymptotic).",
-      "Resolves the gallery framing conflict: the parent's 'at most r+1' description is correct; the overview's 'at most 3 for every r' is false at r=3."
+      "Resolves the gallery framing conflict: the parent's 'at most r+1' description is correct; the overview's 'at most 3 for every r' is false at r=3.",
+      "Build blocker is structural, not transient: proofs/.lake is a circular self-symlink on the host, so the docker olean cache (lean-mathlib-cache volume) never attaches and lake recompiles Mathlib from source -> 32GB OOM for ANY target. Splitting native_decide will not help on this host."
     ],
     "builtItems": [
       "proofs/scripts/verify_cubeful_sums.py — bounded coin-change DP over the r-powerful basis; self-validating against the r=2 base case.",
@@ -57,13 +58,14 @@
       "proofs/Proofs/Erdos1107OQ02OQ01.lean — Lean ACT (build-pending, unregistered): IsCubeful+Decidable, basis-indexed isSumOf4Cubeful, native_decide over the 45 exceptions + [1,2040] + blocks to 3000, axiom cubeful_sum_threshold (n>=2040). Uses cubeful-basis enumeration (27 elems <=2040) instead of the parent's O(n^3) range loop."
     ],
     "mathlibGaps": [
-      "No Mathlib lemma for representation of integers as sums of bounded powerful numbers; the r=2 gallery entry handles this via a Decidable predicate + native_decide + an axiom for the asymptotic. The r=3 ACT file would follow the same pattern."
+      "No Mathlib lemma for representation of integers as sums of bounded powerful numbers; the r=2 gallery entry handles this via a Decidable predicate + native_decide + an axiom for the asymptotic. The r=3 ACT file would follow the same pattern.",
+      "N/A — blocker is the .lake cache symlink + stalled deployer (last_deploy 2026-04-04), not missing Mathlib infra."
     ],
     "nextSteps": [
-      "Build the new file once Docker is up: ./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01. If native_decide over [1,2040] is too heavy, split below_threshold_nonexceptions into ~500-wide blocks (the above-threshold ranges are already blocked).",
-      "On green build: register via ./.lean/scripts/generate-proofs-imports.sh and add a gallery meta.json (status axiomatized, badge axiom, axiomCount 1).",
-      "Optional: a Lean-side proof that <=3 cubeful fails (positive exception density) to capture the unconditional half, not just the conditional <=4 threshold."
+      "Do NOT re-attempt a cold local docker build from a worktree (OOMs on Mathlib regardless of target until .lake cache symlink is repaired).",
+      "Build-confirm only on a cache-warm host / working deployer; if below_threshold_nonexceptions native_decide is heavy there, split into ~300-wide blocks like range_2040_2300.",
+      "Flag stalled deployer (stale index.lock) to Loom/ops — it gates build-verification of all registered-but-unbuilt entries."
     ],
-    "progressSummary": "PROGRESS (ACT): Lean transcription written (Erdos1107OQ02OQ01.lean) realising the validated N_3=2040 / 45-exception result via a basis-indexed isSumOf4Cubeful + native_decide + one conjectural-asymptotic axiom. Build-pending (Docker down); logic cross-checked against the Python DP."
+    "progressSummary": "SATURATED (math complete: 0 sorry / 1 conjectural axiom, registered, gallery entry exists). Build is env-blocked locally (circular .lake symlink -> Mathlib-from-source OOM); belongs to a cache-warm deployer, which is itself stalled."
   }
 }


### PR DESCRIPTION
## Summary
- The cubeful r=3 entry (`Erdos1107OQ02OQ01.lean`) is **math-saturated**: 0 sorries, 1 legitimate axiom (`cubeful_sum_threshold` = the open r=3 asymptotic itself), registered in `Proofs.lean`, with a complete gallery entry (`status: axiomatized`, 18 theorems / 5 defs).
- **Docker was UP this session** (not the prior "blackout"), yet `docker-build.sh Proofs.Erdos1107OQ02OQ01` was **killed at the 32 GB memory limit while recompiling Mathlib from source**.
- Root cause is environmental: `proofs/.lake` is a **circular self-symlink** on the host, so the `lean-mathlib-cache` olean volume never attaches and `lake exe cache get` can't supply cached oleans — Mathlib rebuilds from source and OOMs for **any** target. This is **not** our file's `native_decide`, so the long-standing "split the blocks" mitigation would not help on this host.
- Noted that the deployer (the intended cache-warm build host) is itself stalled: `deployer-state.json` shows `last_deploy = 2026-04-04` and the latest run aborted on a stale `.git/index.lock`. So the file is **registered but never compile-confirmed anywhere** — a latent aggregate-build risk worth an ops follow-up.
- Avoided a non-fix: `meta.sorryCount` is `null` here, but **all 2466** gallery metas use `null` — it's schema convention, not an error.

This is a documentation-only PR (knowledge.md + problem JSON). No Lean, no meta, no axiom/sorry-count change (still 1 / 0).

## Test plan
- [x] `grep -c sorry` on the Lean file = 0; file registered in `Proofs.lean`; gallery entry present.
- [x] Confirmed `.lake` circular symlink on host and OOM signature in build log.
- [ ] Build-verification deferred to a cache-warm host / unblocked deployer (out of researcher scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)