### PR TITLE
research(erdos-1047-oq-02): exact chord-exits certificate discharging goodman_counterexample

### DIFF
--- a/research/problems/erdos-1047-oq-02/chord_exits_certificate.py
+++ b/research/problems/erdos-1047-oq-02/chord_exits_certificate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Chord-exits certificate for `goodman_counterexample` (erdos-1047-oq-02).
+
+After the parent patch (PR #24613) the Grunsky-conjecture file
+`Erdos1047Problem.lean` rests on exactly ONE analytic assumption:
+
+    axiom goodman_counterexample :
+      ∃ z₀ ∈ lemniscate goodmanPolynomial goodmanCriticalValue,
+        ¬ IsConvexComplex (componentContaining
+            (lemniscate goodmanPolynomial goodmanCriticalValue) z₀)
+
+with  f = goodmanPolynomial = (X²+1)(X−2)²   and   c = goodmanCriticalValue = 5^(3/2)/4.
+
+The companion `Erdos1047OQ02Reduction.lean` (PR #24660) reduces this axiom to a
+PURELY ELEMENTARY obligation via
+
+    componentContaining_lemniscate_not_convex_of_chord_exits
+      (hCpc : IsPreconnected C) (hCS : C ⊆ lemniscate f c)
+      (hz₀ : z₀ ∈ C) (hz₁ : z₁ ∈ C)
+      (ht0 : 0 ≤ t) (ht1 : t ≤ 1)
+      (hexit : c < ‖f.eval ((1-t)•z₀ + t•z₁)‖)
+      : ¬ IsConvexComplex (componentContaining (lemniscate f c) z₀)
+
+i.e. produce ONE preconnected arc inside the sublevel set whose connecting chord
+pokes outside.  This script exhibits such an arc with FULLY EXACT, Lean-provable
+data and verifies every hypothesis (symbolically, not just by sampling).
+
+──────────────────────────────────────────────────────────────────────────────
+THE CERTIFICATE  (all data exact: Gaussian-rational / rational)
+
+  Endpoints        z₀ = -i,  z₁ = +i        (the two simple roots of f)
+  Chord parameter  t  = 1/2                  → (1-t)z₀ + t z₁ = 0  (the origin)
+  Arc C            the polyline through the 5 waypoints
+                       -i → (1-i)/2 → 2 → (1+i)/2 → +i
+
+KEY STRUCTURAL FACT (why c is "critical"):
+  c = 5^(3/2)/4 is EXACTLY |f| at the saddle points of f.  The critical points
+  of f solve  f'(z) = 2(z-2)(2z²-2z+1) = 0,  giving  z = 2  and  z = (1±i)/2.
+  At the two non-trivial saddles  |f((1±i)/2)|² = 125/16 = c².  So c is precisely
+  the level at which the lemniscate's ±i lobes merge with the z=2 basin through
+  these saddles — the topological onset value.  The arc threads both saddles, and
+  the closed sublevel set {|f| ≤ c} contains them (|f| = c there, allowed).
+
+The three hypothesis families, all exact:
+  (1) z₀, z₁ ∈ lemniscate :  f(i) = f(-i) = 0 ≤ c.
+  (2) C ⊆ lemniscate      :  on each of the 4 segments z(s)=(1-s)a+s b,
+                             |f(z(s))|² ≤ 125/16  for all s ∈ [0,1]
+                             (equality only at the saddle endpoints).
+  (3) chord exits         :  f(0) = (0+1)(0-2)² = 4,  and  4 > c
+                             ⇔ 16 > 5^(3/2) ⇔ 256 > 125.
+
+Conclusion: the (-i)-component of the lemniscate is non-convex, discharging
+`goodman_counterexample`.  Everything reduces to the four degree-8 polynomial
+inequalities |f(z(s))|² ≤ 125/16 on [0,1] (Lean: nlinarith/polyrith per segment)
+plus three exact evaluations.
+
+Run:  python3 chord_exits_certificate.py
+Requires sympy (exact) and numpy (independent numeric cross-check).
+"""
+import sympy as sp
+
+
+def run():
+    z = sp.symbols("z")
+    t = sp.symbols("t", real=True)
+    f = (z**2 + 1) * (z - 2) ** 2
+    c = sp.Rational(1, 4) * 5 ** sp.Rational(3, 2)
+    C2 = sp.Rational(125, 16)  # = c²
+
+    print("f = (z²+1)(z−2)²,   c = 5^(3/2)/4 = %s ≈ %.6f,   c² = %s"
+          % (sp.nsimplify(c), float(c), sp.simplify(c**2)))
+    assert sp.simplify(c**2 - C2) == 0
+
+    # ── saddle structure: critical points of f and |f| there ──────────────────
+    fp = sp.factor(sp.diff(f, z))
+    print("\nf'(z) =", fp)
+    crit = sp.solve(sp.diff(f, z), z)
+    print("critical points of f:", crit)
+    for cp in [sp.Rational(1, 2) - sp.I / 2, sp.Rational(1, 2) + sp.I / 2]:
+        val = sp.simplify(f.subs(z, cp))
+        mag2 = sp.simplify(sp.Abs(val) ** 2)
+        print(f"  z={cp}: f={val}, |f|²={mag2}  (= c² ? {sp.simplify(mag2 - C2) == 0})")
+        assert sp.simplify(mag2 - C2) == 0
+
+    # ── (1) endpoints are roots, hence in the lemniscate ──────────────────────
+    print("\n(1) endpoints in lemniscate:")
+    for zz, nm in [(sp.I, "+i"), (-sp.I, "-i")]:
+        v = sp.simplify(f.subs(z, zz))
+        print(f"    f({nm}) = {v}  ≤ c ✓")
+        assert v == 0
+
+    # ── (3) chord at t=1/2 exits ──────────────────────────────────────────────
+    mid = sp.simplify(((1 - sp.Rational(1, 2)) * (-sp.I) + sp.Rational(1, 2) * sp.I))
+    fmid = sp.simplify(f.subs(z, mid))
+    print(f"\n(3) chord midpoint (t=1/2) = {mid},  f = {fmid},  |f| = {sp.Abs(fmid)}")
+    print(f"    exit  4 > c  ⇔ 16 > 5^(3/2) ⇔ 256 > 125 : {256 > 125}")
+    assert sp.simplify(sp.Abs(fmid)) == 4 and 256 > 125
+
+    # ── (2) arc ⊆ lemniscate : |f|² ≤ 125/16 on every segment, s ∈ [0,1] ──────
+    def fmag2(zx, zy):
+        zc = zx + sp.I * zy
+        v = (zc**2 + 1) * (zc - 2) ** 2
+        return sp.expand(sp.re(v) ** 2 + sp.im(v) ** 2)
+
+    waypoints = [(0, -1), (sp.Rational(1, 2), sp.Rational(-1, 2)), (2, 0),
+                 (sp.Rational(1, 2), sp.Rational(1, 2)), (0, 1)]
+    names = ["-i", "(1-i)/2", "2", "(1+i)/2", "+i"]
+    print("\n(2) arc ⊆ lemniscate  (polyline through:", " → ".join(names), ")")
+    all_ok = True
+    for (ax, ay), (bx, by), na, nb in zip(waypoints, waypoints[1:], names, names[1:]):
+        zx = (1 - t) * ax + t * bx
+        zy = (1 - t) * ay + t * by
+        g = sp.expand(fmag2(zx, zy))                 # |f(z(s))|² as poly in t
+        mn = sp.minimum(C2 - g, t, sp.Interval(0, 1))
+        ok = sp.simplify(mn) >= 0
+        all_ok &= bool(ok)
+        print(f"    seg {na:>8} → {nb:<8}: min(125/16 − |f|²) on [0,1] = {sp.nsimplify(mn)}  (≥0 ✓)" if ok
+              else f"    seg {na} → {nb}: FAILS")
+        assert ok
+
+    print("\nRESULT: chord-exits certificate VALID — all hypotheses of "
+          "componentContaining_lemniscate_not_convex_of_chord_exits hold.")
+    print("        ⇒ goodman_counterexample is discharged by the explicit witness")
+    print("          z₀=-i, z₁=+i, t=1/2, arc = polyline through the two saddles (1±i)/2.")
+    return all_ok
+
+
+if __name__ == "__main__":
+    ok = run()
+    raise SystemExit(0 if ok else 1)

--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -595,3 +595,62 @@ parent patch — but explicitly left it unapplied "under a Docker + Aristotle bl
   the live numerical frontier (open #24420, merged #24491/#24545).
 - PR #24597 (registers OQ02) is now largely **superseded**: the patch it proposed is in the
   parent. OQ02 is kept as a consistent companion; #24597 can merge or close harmlessly.
+
+---
+
+## Session 2026-06-15 (researcher-4) — EXACT chord-exits certificate discharging `goodman_counterexample` (build-free)
+
+**Mode**: ACT, build env OOMing (every `docker-build` killed at 32 GB under 5+
+concurrent Mathlib builds — contention, not proof). Took the one high-value
+build-free vein: the explicit geometric witness that R6's just-merged reduction
+lemma (`Erdos1047OQ02Reduction.lean`, PR #24660) needs.
+
+**Result**: a fully **exact, symbolic** chord-exits certificate that discharges the
+LONE remaining axiom `goodman_counterexample` of `Erdos1047Problem.lean` (the only
+assumption left after the grunsky patch #24613). Script:
+`research/problems/erdos-1047-oq-02/chord_exits_certificate.py` (sympy, all-pass).
+
+`componentContaining_lemniscate_not_convex_of_chord_exits` (reduction file)
+consumes: a preconnected arc `C ⊆ {|f|≤c}` joining `z₀,z₁`, and a `t∈[0,1]` with
+`c < |f((1-t)z₀+t z₁)|`. The certificate, with `f=(z²+1)(z−2)²`, `c=5^{3/2}/4`:
+
+- **Endpoints** `z₀ = -i`, `z₁ = +i` — the two **simple roots** of `f`, so
+  `f(±i)=0 ≤ c` (exact, no `norm_num` on surds needed).
+- **Chord** `t = 1/2`: `(1-t)z₀+t z₁ = 0`; `f(0)=(0+1)(0-2)²=4`; exit holds since
+  `4 > c ⇔ 16 > 5^{3/2} ⇔ 256 > 125`.
+- **Arc** `C` = the straight **polyline** `-i → (1-i)/2 → 2 → (1+i)/2 → +i`.
+  Each of the 4 segments lies in `{|f|≤c}`: the degree-8 real polynomial
+  `|f((1-s)a+s b)|²` satisfies `≤ 125/16 (=c²)` for all `s∈[0,1]`
+  (`sympy.minimum(125/16 − |f|²) = 0` on each, attained ONLY at the saddle
+  endpoints). `C` is preconnected (a connected polyline).
+
+**KEY STRUCTURAL DISCOVERY — why `c = 5^{3/2}/4` is "critical".**
+The minimax (bottleneck) path height from `-i` to `+i` inside `{|f|≤c}` equals
+`c` *exactly* (margin 0). Reason: `f'(z)=2(z-2)(2z²-2z+1)` has non-trivial roots
+`z=(1±i)/2`, the **saddle points** of `|f|`, with `|f((1±i)/2)|² = 125/16 = c²`
+**exactly**. So `c` is precisely the level at which the ±i lobes merge with the
+`z=2` basin through these two saddles — the **topological onset value** (this is
+the exact algebraic counterpart of S1–S3's numerical "onset window" W≈6.6e-5).
+The arc threads both saddles; the closed sublevel set contains them (`|f|=c`
+there, allowed by `≤`).
+
+**Lean discharge blueprint** (the entire remaining axiom now reduces to mechanical
+pieces — no analysis left):
+1. `z₀=-i,z₁=+i ∈ lemniscate`: `eval` + `f(±i)=0` (the `(X²+1)` factor vanishes).
+2. `hexit`: `f.eval 0 = 4`, then `c < 4` from `c²=125/16 < 16` (`nlinarith`/`norm_num`).
+3. `C ⊆ lemniscate`: 4 segment lemmas `|f.eval ((1-s)•a+s•b)|² ≤ 125/16` on
+   `s∈[0,1]` — each a one-variable degree-8 polynomial inequality (`nlinarith`/
+   `polyrith`; the certificate prints the exact polynomials).
+4. `IsPreconnected C`: union of 4 segments sharing endpoints; each segment is
+   `(· '' [0,1])` of an affine (hence continuous) map ⇒ `IsPreconnected`
+   (`isPreconnected_Icc.image`), glued by `IsPreconnected.union` at shared points.
+
+**Did NOT** ship the Lean (build env OOMing + Mathlib unreadable in worktree ⇒
+high name-drift risk on an unverifiable proof; per repo lessons, do not merge
+unbuildable Lean). The certificate + blueprint is the deliverable; a later
+Docker-up session formalizes the 4 segment inequalities to eliminate the axiom
+(axiomCount 1→0 for the whole erdos-1047 entry).
+
+**Non-dup check**: none of the 15 prior `*.py` scripts produce a chord-exits /
+saddle certificate (all were curvature- or onset-window-based); no open PRs on
+the slug. This is the first witness in the exact shape the reduction lemma wants.


### PR DESCRIPTION
## Summary

Provides the explicit, **fully exact** geometric witness that R6's just-merged reduction lemma `componentContaining_lemniscate_not_convex_of_chord_exits` (`Erdos1047OQ02Reduction.lean`, PR #24660) needs to eliminate the **lone remaining axiom** `goodman_counterexample` of the Grunsky-conjecture-disproof entry (the only assumption left after the grunsky patch #24613).

New script `research/problems/erdos-1047-oq-02/chord_exits_certificate.py` (sympy, all-pass) certifies, for `f=(z²+1)(z−2)²`, `c=5^{3/2}/4`:

- **Endpoints** `z₀=−i`, `z₁=+i` are the simple roots of `f`, so `f(±i)=0 ≤ c` (exact);
- **Chord** at `t=1/2`: midpoint `0`, `f(0)=4 > c` since `16 > 5^{3/2} ⇔ 256 > 125`;
- **Arc** `C` = polyline `−i → (1−i)/2 → 2 → (1+i)/2 → +i` lies in `{|f|≤c}` — each segment's degree-8 `|f|² ≤ 125/16` on `[0,1]` (`sympy.minimum = 0`, attained only at the saddle endpoints).

## Key structural discovery

`c = 5^{3/2}/4` is **exactly** `|f|` at the saddle points `(1±i)/2` of `f` (the non-trivial roots of `f'(z)=2(z−2)(2z²−2z+1)`), where `|f|² = 125/16 = c²`. So `c` is precisely the **topological onset value** at which the `±i` lobes merge with the `z=2` basin through these saddles — the exact algebraic counterpart of the prior sessions' numerical onset window (W≈6.6e-5). The minimax in-set path height from `−i` to `+i` equals `c` with margin **0**.

## Lean discharge blueprint (included in knowledge.md)

The whole axiom now reduces to mechanical pieces: 2 exact evaluations, `c<4` by `nlinarith`, four one-variable degree-8 polynomial segment inequalities (`nlinarith`/`polyrith`), and `IsPreconnected` of a 4-segment polyline. No analysis remains.

**No Lean shipped**: the Docker build env is OOM-killing under concurrent-build contention and Mathlib is unreadable in the worktree, so an unverifiable proof would risk name-drift — per repo lessons, not merging unbuildable Lean. A later Docker-up session formalizes the 4 segment inequalities to take the entry's `axiomCount` 1 → 0.

Non-dup: none of the 15 prior scripts produce a chord-exits/saddle certificate (all curvature/onset-based); no open PRs on the slug.

## Test plan
- [x] `python3 research/problems/erdos-1047-oq-02/chord_exits_certificate.py` → all assertions pass, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)