### PR TITLE
Research: brouwer-fixed-point-oq-01-oq-03-oq-01 - reduce Ham Sandwich input to scalar slice-volume continuity

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ01OQ03OQ01.lean
@@ -49,6 +49,15 @@ The standing `ham_sandwich_theorem` axiom in `BrouwerFixedPointOQ01OQ03.lean`
 is therefore reduced to the single statement "the half-volume discrepancy map
 is continuous on Sⁿ", which is the genuine Lebesgue-continuity input.
 
+4. `ham_sandwich_of_scalar_continuity` / `ham_sandwich_standard_of_scalar_continuity`
+   — sharpen the residual input further. The continuity hypothesis above was a
+   *vector* statement ("a continuous `SphereFun` realizes the discrepancy"). Here
+   the vector-assembly step is discharged: assuming only that each of the `2n`
+   *scalar* slice-volume maps is continuous, the discrepancy assembles into a
+   continuous `EuclideanSpace`-valued map via `(EuclideanSpace.equiv …).symm`, and
+   the conclusion follows. The remaining input is now a continuity statement about
+   a single real parameterized volume — no `SphereFun` is assumed.
+
 ## Summary: 0 sorries, 0 new axioms.
 Depends on `BorsukUlam.lean` (1 axiom: `no_continuous_odd_nonzero_on_sphere`).
 -/
@@ -167,6 +176,46 @@ theorem ham_sandwich_of_discrepancy (n : ℕ) (hn : n ≥ 1)
   exact (ENNReal.toReal_eq_toReal_iff' (hfin_pos x i) (hfin_neg x i)).mp hsub
 
 -- ============================================================
+-- PART 3b: Reducing the analytic input to SCALAR slice-volume continuity
+-- ============================================================
+
+/-- **Ham Sandwich from scalar slice-volume continuity.**
+
+    The lone analytic input of `ham_sandwich_of_discrepancy` was the existence of
+    a *continuous `SphereFun`* (a `ℝⁿ`-valued map) realizing the discrepancy. That
+    packaging still bundles a vector-assembly step. Here we discharge it: if each
+    of the `2n` *scalar* slice-volume maps
+    `x ↦ vol(bodyᵢ ∩ pos x i)` and `x ↦ vol(bodyᵢ ∩ neg x i)` is continuous (as an
+    `ℝ`-valued function via `.toReal`), the discrepancy map assembles into a
+    continuous `EuclideanSpace`-valued map automatically — the finite-dimensional
+    L²-assembly `(EuclideanSpace.equiv …).symm ∘ (continuous components)` — and
+    Ham Sandwich follows.
+
+    This pins the residual gap to its atomic form: continuity of a *single real*
+    parameterized slice-volume. The vector `SphereFun` packaging is no longer
+    assumed — it is constructed and proved continuous from the scalar inputs. -/
+theorem ham_sandwich_of_scalar_continuity (n : ℕ) (hn : n ≥ 1)
+    (bodies : Fin n → Set (EuclideanSpace ℝ (Fin n)))
+    (pos neg : EuclideanSpace ℝ (Fin (n + 1)) → Fin n → Set (EuclideanSpace ℝ (Fin n)))
+    (hswap : ∀ x i, pos (-x) i = neg x i)
+    (hswap' : ∀ x i, neg (-x) i = pos x i)
+    (hfin_pos : ∀ x i, volume (bodies i ∩ pos x i) ≠ ⊤)
+    (hfin_neg : ∀ x i, volume (bodies i ∩ neg x i) ≠ ⊤)
+    (hcont_pos : ∀ i, Continuous fun x => (volume (bodies i ∩ pos x i)).toReal)
+    (hcont_neg : ∀ i, Continuous fun x => (volume (bodies i ∩ neg x i)).toReal) :
+    ∃ x ∈ Sphere n, ∀ i, volume (bodies i ∩ pos x i) = volume (bodies i ∩ neg x i) := by
+  -- Assemble the scalar discrepancy components into a continuous EuclideanSpace map.
+  have hcont : Continuous fun x => (EuclideanSpace.equiv (Fin n) ℝ).symm
+      (fun i => discrepancy n bodies pos neg x i) := by
+    refine (EuclideanSpace.equiv (Fin n) ℝ).symm.continuous.comp (continuous_pi fun i => ?_)
+    simpa only [discrepancy] using (hcont_pos i).sub (hcont_neg i)
+  -- Package as the SphereFun realizing the discrepancy, then apply Part 3.
+  refine ham_sandwich_of_discrepancy n hn bodies pos neg
+    ⟨fun x => (EuclideanSpace.equiv (Fin n) ℝ).symm
+      (fun i => discrepancy n bodies pos neg x i), hcont⟩
+    hswap hswap' hfin_pos hfin_neg (fun x i => rfl)
+
+-- ============================================================
 -- PART 4: The standard linear half-space parameterization
 -- ============================================================
 
@@ -260,6 +309,33 @@ theorem ham_sandwich_standard (n : ℕ) (hn : n ≥ 1)
     (fun x i => volume_inter_ne_top n (bodies i) _ (hbody i))
     hcomp
 
+/-- **Ham Sandwich, standard parameterization, from scalar continuity alone.**
+
+    The sharpest packaging in this file. Under the standard linear half-space
+    assignment `stdPos`/`stdNeg`, the antipodal-swap and finiteness side
+    conditions are theorems (`stdPos_neg`, `stdNeg_neg`, `volume_inter_ne_top`),
+    and the vector-assembly step is discharged by
+    `ham_sandwich_of_scalar_continuity`. What remains as hypotheses is therefore
+    *exactly* the atomic analytic content:
+      * `hbody` — each body has finite volume, and
+      * `hcont_pos`/`hcont_neg` — each **scalar** slice-volume
+        `x ↦ vol(bodyᵢ ∩ {y | ⟨u x, y⟩ ⋚ t x})` is continuous on `Sⁿ`.
+    No continuous `SphereFun` is assumed; it is built from the scalar maps. -/
+theorem ham_sandwich_standard_of_scalar_continuity (n : ℕ) (hn : n ≥ 1)
+    (bodies : Fin n → Set (EuclideanSpace ℝ (Fin n)))
+    (u : EuclideanSpace ℝ (Fin (n + 1)) →ₗ[ℝ] EuclideanSpace ℝ (Fin n))
+    (t : EuclideanSpace ℝ (Fin (n + 1)) →ₗ[ℝ] ℝ)
+    (hbody : ∀ i, volume (bodies i) ≠ ⊤)
+    (hcont_pos : ∀ i, Continuous fun x => (volume (bodies i ∩ stdPos n u t x i)).toReal)
+    (hcont_neg : ∀ i, Continuous fun x => (volume (bodies i ∩ stdNeg n u t x i)).toReal) :
+    ∃ x ∈ Sphere n, ∀ i,
+      volume (bodies i ∩ stdPos n u t x i) = volume (bodies i ∩ stdNeg n u t x i) :=
+  ham_sandwich_of_scalar_continuity n hn bodies (stdPos n u t) (stdNeg n u t)
+    (stdPos_neg n u t) (stdNeg_neg n u t)
+    (fun x i => volume_inter_ne_top n (bodies i) _ (hbody i))
+    (fun x i => volume_inter_ne_top n (bodies i) _ (hbody i))
+    hcont_pos hcont_neg
+
 /-
 ## Significance and the Remaining Gap
 
@@ -280,11 +356,16 @@ standard parameterization (Parts 4–6):
     slice is a subset (`volume_inter_ne_top`).
 
 The single genuinely-remaining analytic input is therefore:
-  * the continuity of `x ↦ vol(bodyᵢ ∩ {y | ⟨u(x), y⟩ < t(x)})` on `Sⁿ`
-    (Lebesgue continuity of parameterized half-spaces; dominated convergence),
-    which packages the discrepancy map as the continuous `SphereFun` `F` whose
-    existence is the lone hypothesis `hcomp` of `ham_sandwich_standard`.
+  * the continuity of `x ↦ vol(bodyᵢ ∩ {y | ⟨u(x), y⟩ < t(x)}).toReal` on `Sⁿ`
+    (Lebesgue continuity of parameterized half-spaces; dominated convergence).
 This is a self-contained measure-theory fact; it is not topological.
+
+`ham_sandwich_standard_of_scalar_continuity` (Part 6) states the conclusion with
+*exactly* this scalar continuity (plus finiteness) as its only hypotheses: the
+vector packaging into a `SphereFun` is no longer assumed but constructed, so the
+intermediate `ham_sandwich_standard` (which still took the vector `hcomp`) is
+strictly weakened in its hypotheses. The dichotomy "topological core (proved) vs.
+scalar Lebesgue continuity (the lone input)" is now exact.
 -/
 
 end BrouwerFixedPointOQ01OQ03OQ01

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "hs-overview",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 9,
+      "endLine": 61
+    },
+    "title": "Splitting the Ham Sandwich Axiom into Topology and Analysis",
+    "content": "The parent entry stated the Ham Sandwich theorem as an axiom. This file proves that the axiom decomposes into (1) a purely topological reduction, fully provable from the already-formalized Borsuk-Ulam, and (2) a single genuine analytic input: the continuity of the bisecting-measure map. Everything in (1) — the reduction, the oddness of the discrepancy, the antipodal swap, volume finiteness, and the vector-assembly — is proved here. The continuity input is carried only as an explicit hypothesis, never assumed as an axiom.",
+    "mathContext": "Classical Ham Sandwich proof: parameterize oriented hyperplanes by $x \\in S^n$, form the signed half-volume discrepancy $D : S^n \\to \\mathbb{R}^n$, note $D(-x) = -D(x)$, and apply Borsuk-Ulam to find a zero of $D$ — a simultaneous bisection of all $n$ bodies. The only non-elementary step is the continuity of $D$ (Lebesgue dominated convergence for parameterized half-spaces).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ham Sandwich theorem",
+      "Borsuk-Ulam theorem",
+      "de-axiomatization",
+      "Lebesgue continuity"
+    ],
+    "prerequisites": [
+      "Borsuk-Ulam theorem",
+      "measure theory",
+      "half-space geometry"
+    ]
+  },
+  {
+    "id": "hs-reduction",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 66,
+      "endLine": 99
+    },
+    "title": "The Topological Core: ham_sandwich_reduction",
+    "content": "**ham_sandwich_reduction** is the entire topological content of Ham Sandwich. Given a continuous odd $F : S^n \\to \\mathbb{R}^n$ (a `SphereFun`) and a bridge predicate where $F(x) = 0 \\Rightarrow \\mathrm{Bisected}(x)$, it produces a point of $S^n$ satisfying $\\mathrm{Bisected}$. The proof is a one-liner: `borsuk_ulam_antipodal_collapse` forces the odd map to vanish, and the bridge converts the vanishing into a bisection.",
+    "mathContext": "Borsuk-Ulam's antipodal-collapse form: a continuous odd $F : S^n \\to \\mathbb{R}^n$ has $F(x) = 0$ for some $x \\in S^n$. This is the only place topological depth enters, and that depth is the inherited `no_continuous_odd_nonzero_on_sphere` axiom from `BorsukUlam.lean`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "borsuk_ulam_antipodal_collapse",
+      "odd map",
+      "SphereFun"
+    ],
+    "prerequisites": [
+      "Borsuk-Ulam theorem"
+    ]
+  },
+  {
+    "id": "hs-discrepancy-odd",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "proof-technique",
+    "range": {
+      "startLine": 100,
+      "endLine": 130
+    },
+    "title": "Oddness of the Discrepancy is Continuity-Free",
+    "content": "**discrepancy_odd_of_swap** proves the signed half-volume discrepancy $D_i$ is odd using only the antipodal swap of half-spaces. Reversing orientation ($x \\mapsto -x$) sends $\\mathrm{pos}\\,x\\,i$ to $\\mathrm{neg}\\,x\\,i$ and vice versa, so $D_i(-x) = \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{neg}\\,x\\,i) - \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{pos}\\,x\\,i) = -D_i(x)$. The proof is `unfold`, `rw [hswap, hswap']`, `ring`.",
+    "mathContext": "This is the elementary, measure-additive half of the Ham Sandwich construction. It requires no continuity, no dominated convergence, no measurability — just set equality of the swapped half-spaces and arithmetic of the resulting real volumes.",
+    "significance": "important",
+    "relatedConcepts": [
+      "signed measure discrepancy",
+      "antipodal swap",
+      "oddness"
+    ],
+    "prerequisites": [
+      "Lebesgue measure",
+      "ENNReal.toReal"
+    ]
+  },
+  {
+    "id": "hs-capstone",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "proof-technique",
+    "range": {
+      "startLine": 131,
+      "endLine": 175
+    },
+    "title": "Capstone: From Zero Discrepancy to Equal Volumes",
+    "content": "**ham_sandwich_of_discrepancy** derives oddness of the vector map $F$ from `discrepancy_odd_of_swap` (lifting componentwise equality to vector equality via `WithLp.ofLp_injective`), applies `ham_sandwich_reduction`, and at a zero of $F$ converts the vanishing scalar discrepancies into equal measures. The finiteness hypotheses are essential: `ENNReal.toReal_eq_toReal_iff'` lifts equality of `toReal` values to equality of the underlying ENNReal measures only when both are finite.",
+    "mathContext": "EuclideanSpace ℝ (Fin n) = WithLp 2 (Fin n → ℝ) is a non-reducible type synonym, so vector equality is proved by `WithLp.ofLp_injective` after a componentwise `funext`, not by raw `funext`. A zero discrepancy with finite volumes forces $\\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{pos}) = \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{neg})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "WithLp.ofLp_injective",
+      "ENNReal.toReal_eq_toReal_iff'",
+      "EuclideanSpace"
+    ],
+    "prerequisites": [
+      "ENNReal arithmetic",
+      "WithLp type synonym"
+    ]
+  },
+  {
+    "id": "hs-scalar-continuity",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "proof-technique",
+    "range": {
+      "startLine": 176,
+      "endLine": 222
+    },
+    "title": "Discharging the Vector-Assembly Step",
+    "content": "**ham_sandwich_of_scalar_continuity** sharpens the analytic input from a vector statement to a scalar one. It assumes only that each scalar slice-volume $x \\mapsto \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{pos}\\,x\\,i).\\mathrm{toReal}$ (and the neg version) is continuous, then assembles the continuous EuclideanSpace-valued discrepancy via $(\\mathrm{EuclideanSpace.equiv}\\,(Fin\\,n)\\,\\mathbb{R}).\\mathrm{symm} \\circ$ `continuous_pi`. The component-agreement hypothesis of the capstone holds by `rfl`, so no `SphereFun` is assumed — it is built.",
+    "mathContext": "EuclideanSpace carries the L² topology, not the product topology, so `continuous_pi` does not apply directly to a map into it. But `EuclideanSpace.equiv (Fin n) ℝ` is a homeomorphism to `Fin n → ℝ`, so a map into EuclideanSpace is continuous iff its composition with `.symm` is — reducing vector continuity to componentwise (scalar) continuity.",
+    "significance": "important",
+    "relatedConcepts": [
+      "EuclideanSpace.equiv",
+      "continuous_pi",
+      "L² topology",
+      "Continuous.sub"
+    ],
+    "prerequisites": [
+      "topology of finite-dimensional spaces",
+      "PiLp / WithLp"
+    ]
+  },
+  {
+    "id": "hs-standard",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "proof-technique",
+    "range": {
+      "startLine": 223,
+      "endLine": 345
+    },
+    "title": "Standard Linear Parameterization: Side Conditions Become Theorems",
+    "content": "For the standard half-space assignment `stdPos`/`stdNeg` cut by $\\{y : \\langle u\\,x, y\\rangle \\lessgtr t\\,x\\}$ with linear $u, t$, the antipodal swap (`stdPos_neg`, `stdNeg_neg`) is a theorem — linearity makes $u(-x) = -u(x)$ and $t(-x) = -t(x)$ flip the inequalities — and finiteness (`volume_inter_ne_top`) follows from `measure_mono Set.inter_subset_left`. The final **ham_sandwich_standard_of_scalar_continuity** therefore has only two hypotheses left: finite body volumes and continuity of each scalar slice-volume on $S^n$.",
+    "mathContext": "This pins the entire residual content of the Ham Sandwich theorem (under the standard linear parameterization) to the single atomic Lebesgue fact: each $x \\mapsto \\mathrm{vol}(\\mathrm{body}_i \\cap \\{y : \\langle u(x), y\\rangle < t(x)\\}).\\mathrm{toReal}$ is continuous on the sphere. That fact is self-contained measure theory (dominated convergence), not topology.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear half-space",
+      "inner_neg_left",
+      "measure_mono",
+      "dominated convergence"
+    ],
+    "prerequisites": [
+      "linear maps",
+      "Lebesgue measure of half-spaces"
+    ]
+  }
+]

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "brouwer-fixed-point-oq-01-oq-03-oq-01",
   "title": "De-Axiomatizing the Ham Sandwich Theorem: Topological Core from Borsuk-Ulam",
   "slug": "brouwer-fixed-point-oq-01-oq-03-oq-01",
-  "description": "Separates the parent's axiomatized Ham Sandwich theorem into its topological core (proved here from the n-dimensional Borsuk-Ulam antipodal collapse) and its single genuine analytic input (Lebesgue continuity of the bisecting half-volume map). The abstract reduction (a continuous odd map S^n -> R^n with a 'zero implies bisected' bridge yields a bisecting point), the oddness of the half-volume discrepancy, and 'discrepancy zero implies equal volumes' are all proved. Continuity enters only as the hypothesis hcomp packaging the discrepancy as a continuous SphereFun. 7 theorems, 3 definitions, 0 own axioms; rests on the inherited Borsuk-Ulam axiom (no_continuous_odd_nonzero_on_sphere) plus the stated continuity hypothesis.",
+  "description": "Separates the parent's axiomatized Ham Sandwich theorem into its topological core (proved here from the n-dimensional Borsuk-Ulam antipodal collapse) and its single genuine analytic input (Lebesgue continuity of the bisecting half-volume map). The abstract reduction (a continuous odd map S^n -> R^n with a 'zero implies bisected' bridge yields a bisecting point), the oddness of the half-volume discrepancy, and 'discrepancy zero implies equal volumes' are all proved. The residual continuity input is then sharpened: the vector-assembly step is discharged so that only continuity of each individual SCALAR slice-volume is needed — the atomic measure-theoretic fact — with the continuous discrepancy vector constructed via EuclideanSpace.equiv. 9 theorems, 3 definitions, 0 own axioms; rests on the inherited Borsuk-Ulam axiom (no_continuous_odd_nonzero_on_sphere) plus the stated scalar continuity hypothesis.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -22,16 +22,18 @@
     "dateAdded": "2026-06-15",
     "axiomCount": 1,
     "assumptions": "0 axiom declarations in this file, but the construction is not standalone-verified: (1) it rests on the inherited axiom no_continuous_odd_nonzero_on_sphere from BorsukUlam.lean — the genuine degree-theory core of Borsuk-Ulam, unavoidable for n >= 2; and (2) the capstone theorems (ham_sandwich_of_discrepancy, ham_sandwich_standard) take the continuity of the half-volume discrepancy map as the hypothesis hcomp (the discrepancy is supplied as a continuous SphereFun). The contribution is to prove everything else — the topological reduction, oddness, and the zero-implies-bisected bridge — so that the parent's opaque ham_sandwich_theorem axiom is reduced precisely to this one Lebesgue-continuity input (dominated convergence for parameterized half-spaces), which is measure-theoretic, not topological.",
-    "lineCount": 290,
-    "theoremCount": 7,
+    "lineCount": 371,
+    "theoremCount": 9,
     "definitionCount": 3,
     "originalContributions": [
       "ham_sandwich_reduction: the topological core — a continuous odd F: S^n -> R^n with a 'F x = 0 implies Bisected x' bridge yields a bisecting point; proved directly from borsuk_ulam_antipodal_collapse (no axiom)",
       "discrepancy_odd_of_swap: the half-volume discrepancy map is odd, purely from the antipodal swap pos(-x) = neg(x) of the two half-spaces — the elementary measure-theoretic half, needing no continuity",
       "ham_sandwich_of_discrepancy: capstone — given the discrepancy as a continuous SphereFun (the one analytic hypothesis), the antipodal swap, and finite volumes, a hyperplane simultaneously bisects all n bodies",
+      "ham_sandwich_of_scalar_continuity: sharpens the analytic input — assuming only continuity of each scalar slice-volume map, the continuous EuclideanSpace-valued discrepancy is assembled via (EuclideanSpace.equiv (Fin n) R).symm composed with continuous_pi, so no SphereFun is assumed",
       "stdPos_neg / stdNeg_neg: for the standard linear parameterization, the antipodal swap is a consequence of linearity (not an assumption)",
       "volume_inter_ne_top: finiteness vol(body_i intersect H) < infinity follows from vol(body_i) < infinity since the slice is a subset",
-      "ham_sandwich_standard: the standard-parameterization Ham Sandwich, with only the continuity hypothesis remaining, assembled from the above"
+      "ham_sandwich_standard: the standard-parameterization Ham Sandwich, with only the (vector) continuity hypothesis remaining, assembled from the above",
+      "ham_sandwich_standard_of_scalar_continuity: the sharpest packaging — Ham Sandwich whose ONLY hypotheses are finite body volumes and continuity of each scalar slice-volume on S^n"
     ]
   },
   "overview": {
@@ -44,6 +46,7 @@
       "'Discrepancy zero implies equal volumes' is a direct unpacking of the discrepancy definition — also free of analysis.",
       "The antipodal swap and finiteness conditions are not assumptions for the standard linear parameterization: swap follows from linearity, finiteness from the slice being a subset.",
       "The single irreducible analytic input is the Lebesgue continuity of x |-> vol(body_i intersect {y | <u(x), y> < t(x)}) on S^n — measure-theoretic (dominated convergence for parameterized half-spaces), not topological.",
+      "The residual continuity input reduces from a VECTOR statement to a SCALAR one: EuclideanSpace carries the L^2 topology (not the product topology), but EuclideanSpace.equiv (Fin n) R is a homeomorphism to Fin n -> R, so a map into it is continuous iff each scalar component is — discharging the vector-assembly step and leaving continuity of each individual slice-volume as the only input.",
       "EuclideanSpace equality is proved via WithLp.ofLp_injective after funext on the genuine Pi type, since WithLp is a non-reducible type synonym for which plain funext fails."
     ]
   },
@@ -73,12 +76,20 @@
       "mathContext": "Combines ham_sandwich_reduction with discrepancy_odd_of_swap; the EuclideanSpace oddness equality is closed via WithLp.ofLp_injective."
     },
     {
+      "id": "scalar-continuity-reduction",
+      "title": "Reducing the Input to Scalar Slice-Volume Continuity",
+      "summary": "Discharges the vector-assembly step: continuity of each scalar slice-volume suffices; the continuous discrepancy vector is constructed, not assumed.",
+      "startLine": 176,
+      "endLine": 222,
+      "mathContext": "ham_sandwich_of_scalar_continuity assumes only that each scalar map x |-> vol(body_i intersect pos x i).toReal (and the neg version) is continuous, then assembles them into a continuous EuclideanSpace-valued discrepancy via (EuclideanSpace.equiv (Fin n) R).symm composed with continuous_pi. The component-agreement hypothesis of the capstone holds by rfl, so the SphereFun is built rather than assumed."
+    },
+    {
       "id": "standard-parameterization",
       "title": "Standard Linear Parameterization",
-      "summary": "For linear direction/threshold maps, the antipodal swap and volume finiteness are discharged, leaving only the continuity hypothesis.",
-      "startLine": 177,
-      "endLine": 290,
-      "mathContext": "stdPos_neg / stdNeg_neg follow from linearity; volume_inter_ne_top from the slice being a subset of a finite-volume body; assembled into ham_sandwich_standard."
+      "summary": "For linear direction/threshold maps, the antipodal swap and volume finiteness are discharged; combined with the scalar-continuity reduction, only scalar slice-volume continuity remains.",
+      "startLine": 223,
+      "endLine": 345,
+      "mathContext": "stdPos_neg / stdNeg_neg follow from linearity; volume_inter_ne_top from the slice being a subset of a finite-volume body; assembled into ham_sandwich_standard. ham_sandwich_standard_of_scalar_continuity then combines these with the scalar-continuity reduction, so its only hypotheses are finite body volumes and continuity of each scalar slice-volume on S^n."
     }
   ]
 }


### PR DESCRIPTION
## Summary
Builds on the Ham Sandwich de-axiomatization (`BrouwerFixedPointOQ01OQ03OQ01.lean`, gallery entry #24647) by sharpening the lone residual analytic input from a *vector* hypothesis to a *scalar* one.

Previously the capstone (`ham_sandwich_of_discrepancy` / `ham_sandwich_standard`) required the discrepancy to be supplied as a continuous `SphereFun` — a vector-level continuity assumption that still bundled a vector-assembly step.

## Progress
- **`ham_sandwich_of_scalar_continuity`** — discharges the vector-assembly step. Assuming only that each of the `2n` *scalar* slice-volume maps `x ↦ vol(bodyᵢ ∩ pos x i).toReal` (and the `neg` version) is continuous, the continuous `EuclideanSpace`-valued discrepancy is *constructed* via `(EuclideanSpace.equiv (Fin n) ℝ).symm ∘ continuous_pi` and packaged as the realizing `SphereFun` (component agreement holds by `rfl`). No `SphereFun` is assumed.
- **`ham_sandwich_standard_of_scalar_continuity`** — the sharpest packaging. Under the standard linear parameterization, swap/finiteness are already theorems, so the *only* remaining hypotheses are: finite body volumes, and continuity of each scalar slice-volume on `Sⁿ`.
- Updated gallery `meta.json` (7→9 theorems, 290→371 lines, new section + key insight) and added `annotations.json` (the merged #24647 added `meta.json` only).

## Findings
- The residual input is now the *atomic* measure-theoretic fact: continuity of a single real parameterized slice-volume (dominated convergence). EuclideanSpace's L²-topology assembly — which one might worry hides content — is dispatched here via the `EuclideanSpace.equiv` homeomorphism.
- **Docker-verified**: 0 sorries, 0 own axioms. Conclusions rest on the inherited `no_continuous_odd_nonzero_on_sphere` axiom (BorsukUlam degree theory) plus the explicit scalar-continuity hypothesis.

## Status
**Outcome**: progress (file remains `axiomatized` — inherited BU axiom + continuity hypothesis; not overclaimed as verified)
**Next Steps**: prove the scalar slice-volume continuity via dominated convergence to fully discharge `ham_sandwich_standard_of_scalar_continuity` (modulo the BU axiom).

🤖 Generated by researcher-3