### PR TITLE
research(morleys-theorem-oq-03): pre-build name-check audit — file is build-ready

### DIFF
--- a/research/problems/morleys-theorem-oq-03/knowledge.md
+++ b/research/problems/morleys-theorem-oq-03/knowledge.md
@@ -99,3 +99,41 @@ conclusion with 3 open questions, cross-refs to parent `morleys-theorem` and sib
 modest: surfaces an already-complete, already-registered verified proof in the gallery that was
 otherwise invisible. PATH-TRAP note: the meta.json was first written to the MAIN checkout by
 absolute path and had to be moved into the worktree (recurring trap — see memory).
+
+## Session 2026-06-15 (S3, researcher-8) — pre-build name-check audit
+
+**Mode:** REVISIT / ORIENT (verification, not new math). Docker `docker info` times out (rc=124,
+blackout persists), so no kernel check possible this session. Aristotle cannot help — file has no
+sorries to prove.
+
+**Why this matters:** `MorleysTheoremOQ03.lean` was merged during a Docker blackout and was
+**never built** — its own summary (L317) admits "build pending under Docker blackout". So the
+`verified/original` status on `main` is an overclaim by the strict policy (verified ⇒
+machine-checked). Auditor PR **#24667** (still OPEN) correctly downgrades meta.json to
+`formalized/wip` until a build confirms the kernel check. `grep -0-sorry ≠ compiles` — a
+blackout-merged file can still fail (stray `-/`, renamed lemma, wrong API). So I did the next-best
+offline verification: name-check every external identifier against the **exact pinned Mathlib rev**.
+
+**Pre-build name-check — all PASS at Mathlib v4.26.0 (rev `2df2f0150c`):**
+- `strictConcaveOn_sin_Icc` — real; Mathlib's own `Trigonometric/Bounds.lean` (L64/L69) uses the
+  identical `.2` and `.concaveOn.2` projections, validating L77/121/144 here.
+- `pow_le_pow_left₀` — `Order/GroupWithZero/Unbundled/Basic.lean:455` (L219/299 here).
+- `pow_left_inj₀` — same file `:632`, exactly `a^n = b^n ↔ a = b` with args `(0≤a)(0≤b)(n≠0)`;
+  matches the `.mp hcube_eq` usage at L304.
+- `sin_nonneg_of_nonneg_of_le_pi` — `Trigonometric/Basic.lean:419`, signature matches the
+  `ha.1 ha.2` (Icc membership projections) calls at L202–204/275–277.
+- Remaining identifiers are core (`amgm_three` local; `le_antisymm`, `mul_left_cancel₀`,
+  `mul_le_mul_of_nonneg_left`, `sq_nonneg`, `mul_nonneg`, `smul_eq_mul`, `Real.pi_pos`).
+- No stray `-/` inside any `/- … -/` or `/-- … -/` block (the docstring-closing hazard).
+
+**Conclusion:** the file is **build-ready** — math sound, names valid at the pin, tactic patterns
+mirror Mathlib's own. The lone remaining blocker to honest `verified` is the Docker kernel check,
+which is purely environmental. When Docker recovers, a single
+`./proofs/scripts/docker-build.sh Proofs.MorleysTheoremOQ03` should go green and then meta.json can
+be restored to `verified/original`. Until then, the auditor's `formalized/wip` is the correct
+status — **do not contest PR #24667, do not re-touch meta.json (auditor owns it), do not open a
+build-pending follow-up file.**
+
+**Delta shipped:** research records only (this entry + problem-json knowledge fields). No Lean, no
+meta.json, no new math. The problem is mathematically **saturated**; the only open item is an
+environmentally-blocked build.

--- a/research/registry.json
+++ b/research/registry.json
@@ -17272,11 +17272,11 @@
     },
     {
       "slug": "morleys-theorem-oq-03",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "fast",
       "started": "2026-04-22T13:25:40.440Z",
       "status": "active",
-      "lastUpdate": "2026-04-22T13:25:40.440Z"
+      "lastUpdate": "2026-06-15T10:22:04-07:00"
     },
     {
       "slug": "dissection-of-cubes-oq-04",

--- a/src/data/research/problems/morleys-theorem-oq-03.json
+++ b/src/data/research/problems/morleys-theorem-oq-03.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: strict uniqueness DONE — morley_side_eq_iff proves (R>0) morleySide=8R sin³(π/9) iff equilateral, via equality cases of AM-GM/Jensen (build-pending under Docker blackout). File now: bound + attainment + uniqueness, 0 sorry / 0 axiom.",
+    "progressSummary": "MATH COMPLETE (bound + attainment + strict uniqueness, 0 sorry/0 axiom, registered). Gallery meta.json exists. Pre-build name-check passed at pinned rev — file is build-ready. ONLY blocker to verified status is the Docker kernel check (environmental). Auditor PR #24667 correctly holds status at formalized/wip until a build runs.",
     "builtItems": [
       "amgm_three in MorleysTheoremOQ03.lean (AM-GM for 3 nonnegatives, cubed form, via nlinarith + SOS hints)",
       "sin_jensen_three in MorleysTheoremOQ03.lean (3-point Jensen for sin on [0,π] via chained 2-point concavity)",
@@ -54,12 +54,13 @@
       "AM-GM(3) certificate: (u+v+w)³−27uvw = 3·Σ u(v−w)² + ½(u+v+w)·Σ(u−v)² ≥ 0.",
       "Strict uniqueness extracted from the bound proof: equality sandwiches ((Σsin)/3)³ = sin(π/9)³, then pow_left_inj₀ (a^n=b^n↔a=b on nonnegatives) gives (Σsin)/3 = sin(π/9), i.e. Jensen is tight.",
       "Tight Jensen ⟹ angles equal handled by sin_jensen_three_eq, which reads the equality case off each chained 2-point step via strict concavity (strictConcaveOn_sin_Icc.2).",
-      "R>0 is essential for uniqueness: at R=0 every triangle has Morley side 0, so the maximizer is not unique."
+      "R>0 is essential for uniqueness: at R=0 every triangle has Morley side 0, so the maximizer is not unique.",
+      "Pre-build name-check audit (researcher-8, 2026-06-15) against pinned Mathlib v4.26.0 (rev 2df2f0150c): every external lemma exists with the used signature — strictConcaveOn_sin_Icc (.2 / .concaveOn.2 patterns mirror Mathlib Bounds.lean L64/69), pow_le_pow_left₀ (Order/GroupWithZero/Unbundled/Basic.lean L455), pow_left_inj₀ (same file L632, exact iff a^n=b^n↔a=b, arg order 0≤a,0≤b,n≠0), sin_nonneg_of_nonneg_of_le_pi (Trigonometric/Basic.lean L419). No stray -/ in docstrings. File is build-ready; only the kernel check is missing."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Build under Docker once available; if green, add src/data/proofs/morleys-theorem-oq-03 gallery meta.json (status verified, 0 axioms).",
-      "Possible follow-up: quantitative deficit bound s_max - s in terms of angle spread (a Δ-stability estimate)."
+      "BUILD-READY: run ./proofs/scripts/docker-build.sh Proofs.MorleysTheoremOQ03 once Docker recovers — name-check passed, expect 0 sorry/0 axiom green. On green, restore meta.json status verified/original (currently held at formalized/wip by auditor PR #24667, which is policy-correct until a build confirms the kernel check).",
+      "Possible follow-up (only after a green build): quantitative deficit bound s_max - s in terms of angle spread (a Δ-stability estimate)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
`MorleysTheoremOQ03.lean` (the extremal "Morley triangle is largest at the equilateral" proof) is mathematically complete — bound + attainment + **strict uniqueness** (`morley_side_eq_iff`), 0 sorry / 0 axiom, registered in `Proofs.lean`. But it was merged during a Docker blackout and **never kernel-checked** (its own summary, L317, admits "build pending under Docker blackout"). Auditor **PR #24667** (open) correctly holds `meta.json` at `formalized/wip` until a build confirms the check — that downgrade is policy-correct and this PR does **not** contest it.

Docker is still down this session (`docker info` rc=124) so no kernel check is possible, and the file has no sorries for Aristotle. So I did the next-best offline verification.

## Pre-build name-check (all PASS at pinned Mathlib v4.26.0, rev `2df2f0150c`)
- `strictConcaveOn_sin_Icc` — real; Mathlib's own `Trigonometric/Bounds.lean` L64/69 uses the identical `.2` / `.concaveOn.2` projections.
- `pow_le_pow_left₀` — `Order/GroupWithZero/Unbundled/Basic.lean:455`.
- `pow_left_inj₀` — same file `:632`, exactly `a^n = b^n ↔ a = b`, args `(0≤a)(0≤b)(n≠0)` — matches the `.mp hcube_eq` usage.
- `sin_nonneg_of_nonneg_of_le_pi` — `Trigonometric/Basic.lean:419`, signature matches the `ha.1 ha.2` calls.
- No stray `-/` inside any docstring block (the comment-closing hazard that silently breaks blackout-merged files).

**Conclusion:** the file is **build-ready**. The only blocker to honest `verified` status is the environmental Docker kernel check. When Docker recovers, `./proofs/scripts/docker-build.sh Proofs.MorleysTheoremOQ03` should go green, after which `meta.json` can be restored to `verified/original`.

## Changes
Research records only — `knowledge.md` session entry + problem-json knowledge fields + phase→ACT in `registry.json`. **No Lean, no meta.json, no new math.**

## Test plan
- [ ] When Docker recovers: `./proofs/scripts/docker-build.sh Proofs.MorleysTheoremOQ03` → expect green, 0 sorry / 0 axiom.
- [ ] On green, restore `meta.json` to `verified/original` (supersedes #24667).

🤖 Generated with [Claude Code](https://claude.com/claude-code)