### PR TITLE
research(cube-root-3-irrational-oq-04): S30 — 25th CF convergent lower bound (a24=4)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -942,4 +942,35 @@ theorem cbrt3_lt_two_four_seven_seven_zero_six_two_one_three_one_two_eight_over_
   rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
   norm_num
 
+/-- **Twenty-fifth continued-fraction convergent of `∛3`** (lower bound).
+
+With `a₂₄ = 4`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`, `qₖ = aₖ qₖ₋₁ + qₖ₋₂`
+on the 23rd/24th convergents `71966106017/49898510978` and
+`247706213128/171749895599` gives the 25th convergent
+
+  `p₂₄ = 4·247706213128 + 71966106017 = 1_062_790_958_529`
+  `q₂₄ = 4·171749895599 + 49898510978 = 736_898_093_374`.
+
+After cubing,
+
+  `1_062_790_958_529³   = 1_200_448_555_199_027_448_961_342_537_049_069_889`
+  `3 · 736_898_093_374³ = 1_200_448_555_199_027_448_961_345_650_599_152_872`
+
+so `1_062_790_958_529³ < 3 · 736_898_093_374³` (strict, diff `3_113_550_082_983`),
+hence `(1062790958529/736898093374)³ < 3` and
+`1062790958529/736898093374 < cbrt3` as required for a lower bound (even
+convergent index `24`; relative gap `≈ 8.6·10⁻²⁵`).
+
+`a₂₄ = 4` was re-derived independently from a 160-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s30_25th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline: never re-quote a prior sketch tail, always recompute `aᵢ` and verify
+the cube-side direction before claiming.  This is the next uncontested rung above
+the 24th convergent; a routine, durable helper bound, not a deep result.
+Two-line proof via the lower cubing-iff helper. -/
+theorem one_zero_six_two_seven_nine_zero_nine_five_eight_five_two_nine_over_seven_three_six_eight_nine_eight_zero_nine_three_three_seven_four_lt_cbrt3 :
+    (1062790958529 / 736898093374 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -1187,3 +1187,34 @@ already-astronomically-tight sandwich. Build-pending (Docker down); proof uses t
 established two-line template `rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num` that
 compiled clean for every prior rung with the same rational-cube `norm_num` machinery (only
 larger, 12-digit integers here).
+
+## Session 2026-06-15 (S30, researcher-7) — 25th CF convergent LOWER bound (a24=4)
+
+**Mode**: ACT on the additive convergent-ladder vein (RICH; Docker daemon down,
+Aristotle MCP 404 — both re-tested live this session). Blackout-safe, non-dup:
+self-contained cubing-iff theorem, no dependency on the contended main `a12=8`
+chain (#23388/#23983).
+
+### Added
+`Cbrt3Helpers.one_zero_six_two_seven_nine_zero_nine_five_eight_five_two_nine_over_seven_three_six_eight_nine_eight_zero_nine_three_three_seven_four_lt_cbrt3 : (1062790958529/736898093374 : ℝ) < cbrt3`
+to `CubeRoot3IrrationalOQ04Helpers.lean` (theoremCount 25→26, still 0 sorry / 0 axiom).
+
+### Derivation (anti-typo discipline: full 160-digit CF recompute, never re-quote)
+- CF of ∛3 = `[1; 2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4,1,3,2,3,4,…]`, confirming `a₂₄ = 4`.
+- Recursion on the 23rd/24th convergents: `p₂₄ = 4·247706213128 + 71966106017 = 1062790958529`,
+  `q₂₄ = 4·171749895599 + 49898510978 = 736898093374`.
+- Exact-integer cube check: `3·736898093374³ - 1062790958529³ = +3113550082983 > 0`
+  ⟹ `(p/q)³ < 3` ⟹ `p/q < cbrt3` (valid LOWER bound, even index 24, relative gap ≈ 8.6·10⁻²⁵).
+- Cert: `research/scripts/verify_cbrt3_oq04_s30_25th_convergent.py` (PASS).
+
+### Frontier / contention map (calibrated: "Nth convergent" = CF index k=N-1)
+- Main: up to 24th convergent UPPER (`247706213128/171749895599`, S29 merged).
+- This PR (25th LOWER, k=24) is the next UNCONTESTED rung above the 24th.
+- NEXT uncontested = 26th convergent UPPER (k=25, a25=1): `1310497171657/908647988973`.
+
+### Honesty
+A routine, durable helper bound, not a deep result — each rung is more digits of an
+already-astronomically-tight sandwich. Build-pending (Docker down); proof uses the
+established two-line lower-bound template `rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`
+that compiled clean for every prior lower rung with the same rational-cube `norm_num`
+machinery (only larger, 13-digit integers here).

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1274,3 +1274,13 @@ Added the 24th CF convergent UPPER bound `cbrt3 < 247706213128/171749895599` (a2
 Helpers ladder — next uncontested rung above the 23rd (PR #24635). Exact cube check
 `p³-3q³ = +210376652755 > 0`; cert verify_cbrt3_oq04_s29_24th_convergent.py PASS. Build-pending
 (Docker down). NEXT uncontested = 25th convergent LOWER (a24=4): 1062790958529/736898093374.
+
+## Current Focus (S30, researcher-7, 2026-06-15)
+Added the 25th CF convergent LOWER bound `1062790958529/736898093374 < cbrt3` (a24=4)
+to the Helpers ladder — the next uncontested rung above the 24th (S29). Exact cube
+check `3q³-p³ = +3113550082983 > 0` ⟹ `(p/q)³ < 3` ⟹ `p/q < cbrt3` (correct
+lower-side direction for even index 24); cert
+`verify_cbrt3_oq04_s30_25th_convergent.py` PASS (relative gap ≈ 8.6·10⁻²⁵).
+Two-line proof via `lt_cbrt3_iff_cube_lt`. Build-pending (Docker daemon down,
+Aristotle MCP 404 — both re-tested live this session).
+NEXT uncontested = 26th convergent UPPER (a25=1): 1310497171657/908647988973.

--- a/research/scripts/verify_cbrt3_oq04_s30_25th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s30_25th_convergent.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Certificate for cube-root-3-irrational-oq-04 S30: the 25th continued-fraction
+convergent of ∛3 is a valid LOWER bound (1062790958529/736898093374 < cbrt3).
+
+Independently re-derives the CF expansion of ∛3 to 160 digits, the 25th
+convergent via the recursion, and the EXACT-INTEGER cube-direction check
+p^3 vs 3 q^3 (the inequality `norm_num` discharges in the Lean theorem
+`one_zero_six_two_seven_nine_zero_nine_five_eight_five_two_nine_over_...`).
+
+The 25th convergent has even index (24), so it lies on the LOWER side of ∛3
+(alternating with the upper-side 24th convergent 247706213128/171749895599).
+
+Anti-typo discipline (a8/a14 history): the partial quotients are recomputed from
+scratch, never re-quoted from a prior sketch tail.
+
+Docker-independent. Requires mpmath.
+"""
+import mpmath as mp
+
+mp.mp.dps = 160
+
+
+def cf_expansion(x, n):
+    a = []
+    for _ in range(n):
+        ai = int(mp.floor(x))
+        a.append(ai)
+        frac = x - ai
+        if frac == 0:
+            break
+        x = 1 / frac
+    return a
+
+
+def convergents(a):
+    pm1, pm2 = 1, 0
+    qm1, qm2 = 0, 1
+    out = []
+    for ak in a:
+        p = ak * pm1 + pm2
+        q = ak * qm1 + qm2
+        out.append((ak, p, q))
+        pm2, pm1 = pm1, p
+        qm2, qm1 = qm1, q
+    return out
+
+
+def main():
+    c = mp.cbrt(3)
+    a = cf_expansion(c, 27)
+    print("CF a[0..26] =", a[:27])
+    assert a[:25] == [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+                      1, 3, 2, 3, 4], "CF prefix mismatch"
+    assert a[24] == 4, f"a24 expected 4, got {a[24]}"
+
+    conv = convergents(a)
+    a24, p24, q24 = conv[24]                    # 25th convergent (index 24)
+    print(f"a24 = {a24}")
+    print(f"25th convergent p24/q24 = {p24}/{q24}")
+    assert (p24, q24) == (1062790958529, 736898093374), "convergent mismatch"
+
+    # exact recursion check from the 23rd/24th convergents
+    _, p22, q22 = conv[22]
+    _, p23, q23 = conv[23]
+    assert p24 == 4 * p23 + p22 and q24 == 4 * q23 + q22, "recursion mismatch"
+
+    # exact-integer cube direction: p^3 < 3 q^3  <=>  (p/q)^3 < 3  <=>  p/q < cbrt3
+    lhs = p24 ** 3
+    rhs = 3 * q24 ** 3
+    print(f"p24^3       = {lhs}")
+    print(f"3*q24^3     = {rhs}")
+    print(f"diff 3q^3-p^3 = {rhs - lhs}  (>0 => valid LOWER bound)")
+    assert lhs < rhs, "NOT a lower bound!"
+
+    relgap = abs(mp.mpf(p24) / q24 - c) / c
+    print(f"relative gap = {mp.nstr(relgap, 6)}")
+    print("PASS: 1062790958529/736898093374 < cbrt3 (25th CF convergent, lower).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the **25th continued-fraction convergent of ∛3** as a LOWER bound to the Helpers ladder:

`1062790958529/736898093374 < cbrt3`   (CF partial quotient `a₂₄ = 4`, even index → lower side)

This is the next uncontested rung above the 24th convergent (S29, `247706213128/171749895599`, already on main).

## Derivation (anti-typo discipline)

- Full 160-digit recomputation of the CF of ∛3 → `[1; 2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4,1,3,2,3,4,…]`, confirming `a₂₄ = 4` (never re-quoted from a prior sketch tail).
- Recursion on the 23rd/24th convergents:
  - `p₂₄ = 4·247706213128 + 71966106017 = 1062790958529`
  - `q₂₄ = 4·171749895599 + 49898510978 = 736898093374`
- Exact-integer cube direction: `3·736898093374³ − 1062790958529³ = +3113550082983 > 0` ⟹ `(p/q)³ < 3` ⟹ `p/q < cbrt3` (relative gap ≈ 8.6·10⁻²⁵).

## Changes
- `CubeRoot3IrrationalOQ04Helpers.lean`: +1 theorem (26 total), 0 sorry / 0 axiom. Two-line proof via the existing `lt_cbrt3_iff_cube_lt` cubing-iff helper.
- `research/scripts/verify_cbrt3_oq04_s30_25th_convergent.py`: certificate (re-derives CF + recursion + cube check). **PASS**.
- `state.md` / `knowledge.md`: S30 session record; next uncontested rung = 26th convergent UPPER (`a₂₅ = 1`, `1310497171657/908647988973`).

## Status
Build-pending (Docker daemon down, Aristotle MCP 404 — both re-tested live this session). The proof reuses the lower-bound template that compiled clean for every prior rung; only the integers are larger (13-digit). A routine, durable helper bound, not a deep result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)