### PR TITLE
research(four-square-distribution-oq-04): formalize the 2k=8 (|B_8|) case, completing {4,6,8}

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04M8.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04M8.lean
@@ -1,0 +1,226 @@
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.Dedup
+import Mathlib.Tactic
+
+/-
+# Four-Square Distribution — Open Question 04: generalization to r₈(n)
+
+## Parent and sibling
+
+`FourSquareDistribution.lean` proves, for `r₄(n)`, that the ordered signed
+representations partition into **types** (sorted multisets of absolute values),
+each contributing
+
+  contribution(type) = (number of orderings) × 2^(number of nonzero parts)
+                     = (4! / ∏ mᵢ!) · 2^(#nonzero).
+
+`FourSquareDistributionOQ04.lean` carries this out for `r₆(n)` (the `2k = 6`
+case). This file does the **`2k = 8` case**, the example singled out in the open
+question: `|B₈| = 8! · 2⁸ = 10 321 920`.
+
+## Open question (oq-04)
+
+Does the orbit/type bookkeeping generalize to `r_{2k}(n)` under
+`B_{2k} = S_{2k} ⋉ (ℤ/2)^{2k}`, `|B_{2k}| = (2k)! · 2^{2k}`?
+
+**Answer (this file, the `2k = 8` case): yes, verbatim.** With eight coordinates
+the orbit-size formula reads
+
+  contribution(type) = (8! / ∏ mᵢ!) · 2^(#nonzero)              (★)
+
+and `∑_{types of n} contribution = r₈(n)`. As in the parent, the factor
+`2^(#nonzero)` (not `2⁸`) is the zero-sign degeneracy: flipping the sign of a
+zero coordinate fixes the tuple, so only the nonzero coordinates contribute sign
+choices. The all-equal-nonzero shape `(1,1,1,1,1,1,1,1)` at `n = 8` contributes
+exactly `8!/8! · 2⁸ = 2⁸ = 256`; the all-distinct-nonzero shape would contribute
+the full `8! · 2⁸ = |B₈|` (its smallest realization is `n = 1²+⋯+8² = 204`, not
+tabulated here).
+
+This file mirrors the parent's **computational** approach (a sorted eight-tuple
+structure + the formula `(★)`, with concrete contributions discharged by
+`native_decide`), rather than the heavier `MulAction`/semidirect-product route.
+That is exactly the "fixed small `m`" ACT recommended in
+`research/problems/four-square-distribution-oq-04/knowledge.md`; with the `2k = 6`
+case already formalized, this completes `{4, 6, 8}`.
+
+All embedded contribution/total values are validated by
+`research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py`
+(each shape's orbit by `(★)` against an independent brute count of signed
+orderings; the per-`n` totals against an independent signed-square convolution
+computing `r₈(n)`) and by `verify_hyperoctahedral_2k.py` (which covers
+`2k ∈ {2,4,6,8}`).
+
+**Build status.** Authored under a Docker/Aristotle blackout, so this file is
+**not yet registered in `Proofs.lean`**. It uses only elementary list arithmetic
+and `native_decide`, mirroring the already-compiling parent and the `2k = 6`
+sibling; it is a verified-on-paper drop-in for the next build-enabled session.
+
+## References
+
+- Jacobi, C. G. J. (1834). *Fundamenta nova theoriae functionum ellipticarum.*
+  (Formula `r₈(n) = 16 σ₃*(n)`.)
+- Grosswald, E. (1985). *Representations of Integers as Sums of Squares.*
+-/
+
+namespace FourSquareDistributionOQ04M8
+
+open List
+
+/-! ## Part 1: Representation types for eight squares
+
+A type is a sorted eight-tuple of non-negative integers whose squares sum to
+`n`; it captures the unordered multiset of absolute values of a representation. -/
+
+/-- A sorted representation type for `n` as a sum of eight squares. -/
+structure RepType8 (n : ℕ) where
+  a₁ : ℕ
+  a₂ : ℕ
+  a₃ : ℕ
+  a₄ : ℕ
+  a₅ : ℕ
+  a₆ : ℕ
+  a₇ : ℕ
+  a₈ : ℕ
+  sorted : a₁ ≤ a₂ ∧ a₂ ≤ a₃ ∧ a₃ ≤ a₄ ∧ a₄ ≤ a₅ ∧ a₅ ≤ a₆ ∧ a₆ ≤ a₇ ∧ a₇ ≤ a₈
+  sum_eq : a₁ ^ 2 + a₂ ^ 2 + a₃ ^ 2 + a₄ ^ 2 + a₅ ^ 2 + a₆ ^ 2 + a₇ ^ 2 + a₈ ^ 2 = n
+  deriving DecidableEq
+
+/-- The eight values as a list. -/
+def RepType8.toList {n : ℕ} (t : RepType8 n) : List ℕ :=
+  [t.a₁, t.a₂, t.a₃, t.a₄, t.a₅, t.a₆, t.a₇, t.a₈]
+
+/-- Number of nonzero entries. -/
+def RepType8.nonzeroCount {n : ℕ} (t : RepType8 n) : ℕ :=
+  (if t.a₁ = 0 then 0 else 1) + (if t.a₂ = 0 then 0 else 1) +
+  (if t.a₃ = 0 then 0 else 1) + (if t.a₄ = 0 then 0 else 1) +
+  (if t.a₅ = 0 then 0 else 1) + (if t.a₆ = 0 then 0 else 1) +
+  (if t.a₇ = 0 then 0 else 1) + (if t.a₈ = 0 then 0 else 1)
+
+/-! ## Part 2: The symmetry multiplier `(★)` -/
+
+/-- Multinomial number of orderings: `8! / ∏ (multiplicity v)!`. -/
+def RepType8.permutations {n : ℕ} (t : RepType8 n) : ℕ :=
+  let vals := t.toList
+  let distinctVals := vals.dedup
+  40320 / (distinctVals.map (fun v => Nat.factorial (vals.count v))).prod
+
+/-- Sign factor `2^(#nonzero)`. -/
+def RepType8.signFactor {n : ℕ} (t : RepType8 n) : ℕ :=
+  2 ^ t.nonzeroCount
+
+/-- Contribution of a type to `r₈(n)`: orderings times sign choices. -/
+def RepType8.contribution {n : ℕ} (t : RepType8 n) : ℕ :=
+  t.permutations * t.signFactor
+
+/-- Constructor with the two proof obligations. -/
+private def mk8 (n a₁ a₂ a₃ a₄ a₅ a₆ a₇ a₈ : ℕ)
+    (hs : a₁ ≤ a₂ ∧ a₂ ≤ a₃ ∧ a₃ ≤ a₄ ∧ a₄ ≤ a₅ ∧ a₅ ≤ a₆ ∧ a₆ ≤ a₇ ∧ a₇ ≤ a₈)
+    (he : a₁ ^ 2 + a₂ ^ 2 + a₃ ^ 2 + a₄ ^ 2 + a₅ ^ 2 + a₆ ^ 2 + a₇ ^ 2 + a₈ ^ 2 = n) :
+    RepType8 n :=
+  ⟨a₁, a₂, a₃, a₄, a₅, a₆, a₇, a₈, hs, he⟩
+
+/-! ## Part 3: Enumeration of types for small `n`
+
+The types below are the complete list of sorted eight-square shapes for each `n`
+(verified exhaustively in the Python certificate). -/
+
+-- n = 1
+def t1 : RepType8 1 := mk8 1 0 0 0 0 0 0 0 1 (by decide) (by norm_num)
+-- n = 2
+def t2 : RepType8 2 := mk8 2 0 0 0 0 0 0 1 1 (by decide) (by norm_num)
+-- n = 3
+def t3 : RepType8 3 := mk8 3 0 0 0 0 0 1 1 1 (by decide) (by norm_num)
+-- n = 4 (two shapes)
+def t4a : RepType8 4 := mk8 4 0 0 0 0 0 0 0 2 (by decide) (by norm_num)
+def t4b : RepType8 4 := mk8 4 0 0 0 0 1 1 1 1 (by decide) (by norm_num)
+-- n = 5 (two shapes)
+def t5a : RepType8 5 := mk8 5 0 0 0 0 0 0 1 2 (by decide) (by norm_num)
+def t5b : RepType8 5 := mk8 5 0 0 0 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 6 (two shapes)
+def t6a : RepType8 6 := mk8 6 0 0 0 0 0 1 1 2 (by decide) (by norm_num)
+def t6b : RepType8 6 := mk8 6 0 0 1 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 7 (two shapes)
+def t7a : RepType8 7 := mk8 7 0 0 0 0 1 1 1 2 (by decide) (by norm_num)
+def t7b : RepType8 7 := mk8 7 0 1 1 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 8 (three shapes, including the all-ones shape)
+def t8a : RepType8 8 := mk8 8 0 0 0 0 0 0 2 2 (by decide) (by norm_num)
+def t8b : RepType8 8 := mk8 8 0 0 0 1 1 1 1 2 (by decide) (by norm_num)
+def t8c : RepType8 8 := mk8 8 1 1 1 1 1 1 1 1 (by decide) (by norm_num)
+-- n = 12 (three shapes)
+def t12a : RepType8 12 := mk8 12 0 0 0 0 0 2 2 2 (by decide) (by norm_num)
+def t12b : RepType8 12 := mk8 12 0 0 0 0 1 1 1 3 (by decide) (by norm_num)
+def t12c : RepType8 12 := mk8 12 0 0 1 1 1 1 2 2 (by decide) (by norm_num)
+
+/-! ## Part 4: Contributions via `(★)`, checked by `native_decide` -/
+
+theorem t1_contribution  : t1.contribution  = 16   := by native_decide
+theorem t2_contribution  : t2.contribution  = 112  := by native_decide
+theorem t3_contribution  : t3.contribution  = 448  := by native_decide
+theorem t4a_contribution : t4a.contribution = 16   := by native_decide
+theorem t4b_contribution : t4b.contribution = 1120 := by native_decide
+theorem t5a_contribution : t5a.contribution = 224  := by native_decide
+theorem t5b_contribution : t5b.contribution = 1792 := by native_decide
+theorem t6a_contribution : t6a.contribution = 1344 := by native_decide
+theorem t6b_contribution : t6b.contribution = 1792 := by native_decide
+theorem t7a_contribution : t7a.contribution = 4480 := by native_decide
+theorem t7b_contribution : t7b.contribution = 1024 := by native_decide
+theorem t8a_contribution : t8a.contribution = 112  := by native_decide
+theorem t8b_contribution : t8b.contribution = 8960 := by native_decide
+theorem t8c_contribution : t8c.contribution = 256  := by native_decide
+theorem t12a_contribution : t12a.contribution = 448   := by native_decide
+theorem t12b_contribution : t12b.contribution = 4480  := by native_decide
+theorem t12c_contribution : t12c.contribution = 26880 := by native_decide
+
+/-! ## Part 5: The decomposition `∑ contributions = r₈(n)`
+
+Jacobi's `r₈` values (computed independently in the certificate, and matching
+`r₈(n) = 16 σ₃*(n)`) are reproduced exactly by summing the type contributions. -/
+
+theorem r8_1 : t1.contribution = 16 := t1_contribution
+theorem r8_2 : t2.contribution = 112 := t2_contribution
+theorem r8_3 : t3.contribution = 448 := t3_contribution
+
+/-- `r₈(4) = 1136`: shapes `(0,…,0,2)` and `(0,0,0,0,1,1,1,1)`. -/
+theorem r8_4 : t4a.contribution + t4b.contribution = 1136 := by
+  rw [t4a_contribution, t4b_contribution]
+
+/-- `r₈(5) = 2016`: shapes `(0,…,0,1,2)` and `(0,0,0,1,1,1,1,1)`. -/
+theorem r8_5 : t5a.contribution + t5b.contribution = 2016 := by
+  rw [t5a_contribution, t5b_contribution]
+
+/-- `r₈(6) = 3136`: shapes `(0,0,0,0,0,1,1,2)` and `(0,0,1,1,1,1,1,1)`. -/
+theorem r8_6 : t6a.contribution + t6b.contribution = 3136 := by
+  rw [t6a_contribution, t6b_contribution]
+
+/-- `r₈(7) = 5504`: shapes `(0,0,0,0,1,1,1,2)` and `(0,1,1,1,1,1,1,1)`. -/
+theorem r8_7 : t7a.contribution + t7b.contribution = 5504 := by
+  rw [t7a_contribution, t7b_contribution]
+
+/-- `r₈(8) = 9328`: three shapes, including the all-equal-nonzero shape
+`(1,1,1,1,1,1,1,1)` contributing `8!/8! · 2⁸ = 256`. -/
+theorem r8_8 : t8a.contribution + t8b.contribution + t8c.contribution = 9328 := by
+  rw [t8a_contribution, t8b_contribution, t8c_contribution]
+
+/-- `r₈(12) = 31808`: three shapes. -/
+theorem r8_12 : t12a.contribution + t12b.contribution + t12c.contribution = 31808 := by
+  rw [t12a_contribution, t12b_contribution, t12c_contribution]
+
+/-! ## Part 6: Structural properties of the eight-square decomposition -/
+
+/-- The number of nonzero parts is at most eight. -/
+theorem nonzeroCount_le_eight {n : ℕ} (t : RepType8 n) : t.nonzeroCount ≤ 8 := by
+  simp only [RepType8.nonzeroCount]
+  split_ifs <;> omega
+
+/-- The sign factor is a power of two, at most `2⁸ = 256`. -/
+theorem signFactor_le_256 {n : ℕ} (t : RepType8 n) : t.signFactor ≤ 256 := by
+  have h := nonzeroCount_le_eight t
+  simp only [RepType8.signFactor]
+  calc 2 ^ t.nonzeroCount ≤ 2 ^ 8 := Nat.pow_le_pow_right (by norm_num) h
+    _ = 256 := by norm_num
+
+#check @RepType8.contribution
+#check @r8_8
+#check @nonzeroCount_le_eight
+
+end FourSquareDistributionOQ04M8

--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -300,3 +300,71 @@ remaining work is the **stabilizer-order computation** `∏_v (count_v)!` (the g
 `Equiv.Perm` of a fibered type ≅ product of perms of the fibers). Steps 1+3 of the Sign.lean
 blueprint (fiberwise split over `absMap`) remain bookkeeping. Still Docker-gated (dual
 blackout: docker exit 124, Aristotle 404); no Lean edits this session.
+
+---
+
+### Session 2026-06-15 (researcher-1, ACT) — the `2k = 8` (`|B₈|`) computational case + refined residue analysis
+
+**Mode**: continue · **Outcome**: ACT (new build-pending file completing the
+`{4,6,8}` fixed-`m` program; triple blackout re-confirmed live).
+
+**Backends re-tested live (all down):** `docker info` → timeout/daemon down
+(rc=124); no local Mathlib checkout under `proofs/.lake/`; Aristotle MCP `prove`
+→ HTTP 404 (`mcp-smoke-test.sh` confirms `GET /api/v1/project` 404). So neither a
+build nor an automated proof of the sole residue `arrangement_card` was possible.
+
+**Shipped (build-pending, UNREGISTERED):**
+`proofs/Proofs/FourSquareDistributionOQ04M8.lean` — the `2k = 8` case, mirroring
+the **proven** computational route of the parent and the `2k = 6` sibling
+(`RepType8` sorted eight-tuple + `(★) = 8!/∏count! · 2^{#nonzero}`, concrete
+contributions by `native_decide`). This is the example the open question names
+(`|B₈| = 8!·2⁸ = 10 321 920`) and the only one of `{4,6,8}` not previously
+formalized, so it closes the documented "ACT fixed m in {4,6,8}" next-step.
+Embedded for `n ∈ {1,2,3,4,5,6,7,8,12}`: complete sorted-shape lists, per-shape
+contributions, and `r₈(n)` totals as `∑ contributions` (`r₈(8)=9328` includes the
+all-equal-nonzero shape `(1,1,1,1,1,1,1,1) → 8!/8!·2⁸ = 256`; `r₈(12)=31808`).
+Structural bounds `nonzeroCount_le_eight`, `signFactor_le_256`.
+
+**Cert (new, PASS):**
+`research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py`
+(stdlib, exact integers) — for each embedded `n`: (a) exhaustive sorted-shape
+enumeration equals the file's shape list; (b) each shape's `(★)` orbit equals an
+INDEPENDENT brute count of distinct signed orderings *and* the embedded number;
+(c) `∑ orbits == r₈(n)` by INDEPENDENT signed-square convolution *and* the
+embedded total. All 9 `n` PASS. Confirms `r₈(n) = 16 σ₃*(n)` (e.g. `r₈(4)=1136`).
+
+**Refined residue analysis (honest correction to prior notes).** The prior
+sessions framed the `arrangement_card`/orbit-size formula as "the easy half" and
+the partition `(DECOMP)` as the only hard part. Working the orbit–stabilizer
+proof of `arrangement_card` concretely this session surfaced **two** sub-steps
+that each lack a direct Mathlib lemma, not one:
+  1. **Surjectivity onto the orbit** — "two functions `g₀, g : Fin m → ℤ` with
+     the same multiset image differ by a permutation" (∃σ, `g₀ ∘ σ = g`). This is
+     needed to identify `arrangements s` with a *single* `Equiv.Perm (Fin m)`
+     orbit, and is itself non-trivial (no obvious `Multiset.map`-to-permutation
+     lemma).
+  2. **Stabilizer order** — `|{σ | g₀ ∘ σ = g₀}| = ∏_v (count_v)!` (the
+     fibered-permutation product), the step prior notes already flagged.
+Plus nonemptiness (constructive via `s.toList`, length = `card s = m`). So a
+hand-authored proof under blackout would be ~150 lines spanning three
+sub-residues with high error risk and no way to check it — deferred. The clean,
+canonical statement of `arrangement_card` in `…Arrange.lean` (`Nat.multinomial`
+form, `arrangement_card_div_form` derived) remains the right setup; it just needs
+Aristotle or an interactive build session.
+
+**Ready-to-submit Aristotle target (for when the backend returns).** The exact
+self-contained snippet to submit (30-day server cache makes re-submission cheap):
+the `arrangements`/`mem_arrangements_iff`/`arrangement_card` block from
+`…Arrange.lean` with `import Mathlib`, hint = the `Equiv.Perm (Fin m)`
+precomposition orbit–stabilizer route (stabilizer = ∏ fiber-perms, order
+∏count!) + `Nat.multinomial_spec`, with `Mathlib.Combinatorics.Enumerative.Bell`
+as the bookkeeping precedent.
+
+## Remaining next steps (updated)
+1. **Build + register** the whole `…OQ04*` family (`Decomp`, `Sign`, `Arrange`,
+   `Keystone`, the `2k=6` `OQ04`, and now the `2k=8` `M8`) once Docker returns;
+   `native_decide` files (`OQ04`, `M8`) are lowest-risk to land first.
+2. Discharge `arrangement_card` — submit to Aristotle the moment it returns, or
+   prove the three sub-residues (nonemptiness, orbit-surjectivity, stabilizer
+   order) interactively; then `fiber_card_eq_contribution` follows via the
+   `Sign.lean` footer blueprint, closing the open question uniformly.

--- a/research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py
+++ b/research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Certificate for FourSquareDistributionOQ04M8.lean (the 2k = 8 case of the
+hyperoctahedral type-decomposition of sums of squares).
+
+For each n embedded in the Lean file it checks, with exact integers and stdlib
+only:
+
+  (a) the EXHAUSTIVE sorted eight-square shape enumeration equals the file's
+      shape list (completeness of the case split);
+  (b) for each shape, the orbit-size formula
+          (star)  orbit = 8! / prod_v (count_v)!  *  2^(#nonzero)
+      equals an INDEPENDENT brute count of distinct signed orderings, and equals
+      the value embedded in the Lean file;
+  (c) sum_shapes orbit == r_8(n), where r_8(n) = #{x in Z^8 : sum x_i^2 = n} is
+      computed INDEPENDENTLY by convolving the single-coordinate signed-square
+      distribution, and equals the total embedded in the Lean file.
+
+All checks must print PASS. This makes the native_decide values in the Lean file
+(authored under a Docker blackout) independently verifiable on the host.
+"""
+
+from itertools import combinations_with_replacement, permutations, product
+from math import isqrt, factorial
+from collections import Counter
+
+# ---- the formula (star) -----------------------------------------------------
+
+def orbit_formula(shape):
+    """8! / prod(count!) * 2^(#nonzero)."""
+    k = len(shape)
+    denom = 1
+    for _, m in Counter(shape).items():
+        denom *= factorial(m)
+    perms = factorial(k) // denom
+    nonzero = sum(1 for v in shape if v != 0)
+    return perms * (2 ** nonzero)
+
+# ---- independent brute count of signed orderings ----------------------------
+
+def brute_signed_orderings(shape):
+    """Number of distinct (x_1,...,x_8) in Z^8 whose multiset of |x_i| is `shape`."""
+    seen = set()
+    # distinct positions: permutations of the (sorted) absolute values
+    for perm in set(permutations(shape)):
+        # each nonzero coordinate independently gets a sign; zeros are fixed
+        sign_slots = [(-1, 1) if v != 0 else (1,) for v in perm]
+        for signs in product(*sign_slots):
+            seen.add(tuple(s * v for s, v in zip(signs, perm)))
+    return len(seen)
+
+# ---- independent r_8(n) via convolution -------------------------------------
+
+def r_k(n, k):
+    base = [0] * (n + 1)
+    s = 0
+    while s * s <= n:
+        base[s * s] += 1 if s == 0 else 2
+        s += 1
+    dist = [1] + [0] * n
+    for _ in range(k):
+        new = [0] * (n + 1)
+        for a in range(n + 1):
+            if dist[a] == 0:
+                continue
+            for b in range(n + 1 - a):
+                if base[b]:
+                    new[a + b] += dist[a] * base[b]
+        dist = new
+    return dist[n]
+
+# ---- exhaustive sorted shapes -----------------------------------------------
+
+def sorted_shapes(n, k=8):
+    maxv = isqrt(n)
+    res = []
+    for combo in combinations_with_replacement(range(maxv + 1), k):
+        if sum(v * v for v in combo) == n:
+            res.append(combo)
+    return res
+
+# ---- values embedded in FourSquareDistributionOQ04M8.lean -------------------
+
+EMBEDDED = {
+    1:  ([((0,0,0,0,0,0,0,1), 16)], 16),
+    2:  ([((0,0,0,0,0,0,1,1), 112)], 112),
+    3:  ([((0,0,0,0,0,1,1,1), 448)], 448),
+    4:  ([((0,0,0,0,0,0,0,2), 16), ((0,0,0,0,1,1,1,1), 1120)], 1136),
+    5:  ([((0,0,0,0,0,0,1,2), 224), ((0,0,0,1,1,1,1,1), 1792)], 2016),
+    6:  ([((0,0,0,0,0,1,1,2), 1344), ((0,0,1,1,1,1,1,1), 1792)], 3136),
+    7:  ([((0,0,0,0,1,1,1,2), 4480), ((0,1,1,1,1,1,1,1), 1024)], 5504),
+    8:  ([((0,0,0,0,0,0,2,2), 112), ((0,0,0,1,1,1,1,2), 8960),
+          ((1,1,1,1,1,1,1,1), 256)], 9328),
+    12: ([((0,0,0,0,0,2,2,2), 448), ((0,0,0,0,1,1,1,3), 4480),
+          ((0,0,1,1,1,1,2,2), 26880)], 31808),
+}
+
+def main():
+    ok = True
+    for n, (shapes_embedded, total_embedded) in EMBEDDED.items():
+        # (a) completeness of the enumeration
+        enumerated = sorted_shapes(n)
+        embedded_shapes = [sh for sh, _ in shapes_embedded]
+        if sorted(enumerated) != sorted(embedded_shapes):
+            print(f"n={n}: SHAPE-SET MISMATCH  enum={enumerated}  embedded={embedded_shapes}")
+            ok = False
+            continue
+        # (b) per-shape orbit: formula == brute == embedded
+        running = 0
+        for sh, c_embedded in shapes_embedded:
+            c_formula = orbit_formula(sh)
+            c_brute = brute_signed_orderings(sh)
+            if not (c_formula == c_brute == c_embedded):
+                print(f"n={n} shape={sh}: ORBIT MISMATCH "
+                      f"formula={c_formula} brute={c_brute} embedded={c_embedded}")
+                ok = False
+            running += c_formula
+        # (c) totals: sum == r_8(n) == embedded total
+        rk = r_k(n, 8)
+        if not (running == rk == total_embedded):
+            print(f"n={n}: TOTAL MISMATCH  sum={running}  r_8={rk}  embedded={total_embedded}")
+            ok = False
+        else:
+            print(f"n={n}: PASS  r_8={rk}  shapes={len(embedded_shapes)}")
+    print("ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/research/problems/four-square-distribution-oq-04.json
+++ b/src/data/research/problems/four-square-distribution-oq-04.json
@@ -28,23 +28,25 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-15T07:05:00.000Z",
-    "iteration": 3,
-    "focus": "S5 ACT (build-pending; triple blackout re-tested live): re-expressed the orbit-size residue via Nat.multinomial per researcher-2's recommendation. New FourSquareDistributionOQ04Arrange.lean PROVES factorial_div_eq_multinomial (m!/prod count! = Nat.multinomial), prod_count_factorial_dvd (Nat.div is exact), mem_arrangements_iff; ISOLATES arrangement_card (the sole residue) in canonical multinomial form with the Equiv.Perm orbit-stabilizer route; DERIVES arrangement_card_div_form. Cert verify_orbit_formula.py check_arrangement PASS (84 multisets).",
+    "iteration": 6,
+    "focus": "S6 ACT (researcher-1; build-pending; triple blackout re-confirmed live: docker rc=124, no local Mathlib, Aristotle prove 404 via mcp-smoke-test). Formalized the 2k=8 (|B8|=10321920) case, the example named in the OQ and the only one of {4,6,8} left: new FourSquareDistributionOQ04M8.lean mirrors the PROVEN computational route (RepType8 + (star)=8!/prod count! * 2^nonzero, native_decide contributions + r8(n) totals for n in {1..8,12}; all-ones shape at n=8 gives 2^8=256). Cert verify_r8_decomposition.py PASS (9 n: exhaustive shapes vs file, (star) vs brute signed-ordering count, sum==r8(n) vs convolution). Also refined the residue analysis: arrangement_card has TWO sub-residues lacking direct Mathlib lemmas (orbit-surjectivity + stabilizer order), not one -- corrects prior 'easy half' framing.",
     "blockers": [
       "Lean ACT Docker-gated (docker info daemon down; Aristotle prove -> 404; no local Mathlib to grep this session).",
       "arrangement_card (the multiset-arrangement count = multinomial) is the sole remaining sorry; B_{2k} signed permutations absent from Mathlib by name."
     ],
-    "nextAction": "ACT (next Docker session): (1) build+register Arrange/Sign/Decomp; (2) prove arrangement_card via Equiv.Perm (Fin m) precomposition orbit-stabilizer (stabilizer = prod Perm of fibers, order prod count!) + multinomial_spec; (3) assemble fiber_card_eq_contribution from arrangement_card_div_form x signFiber_card via card_eq_sum_card_fiberwise over absMap, discharging Decomp.lean's lone sorry.",
+    "nextAction": "ACT (next Docker session): (1) build+register the OQ04 family, native_decide files (OQ04 m=6, M8 m=8) first as lowest-risk; (2) discharge arrangement_card -- submit to Aristotle when it returns, or prove the THREE sub-residues (nonemptiness via s.toList, orbit-surjectivity 'equal multiset image => differ by a perm', stabilizer order prod count!) interactively; (3) assemble fiber_card_eq_contribution from arrangement_card_div_form x signFiber_card via card_eq_sum_card_fiberwise over absMap, discharging Decomp.lean's lone sorry.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 2
     },
-    "lastUpdate": "2026-06-15T13:05:00.000Z"
+    "lastUpdate": "2026-06-15T14:05:00.000Z"
   },
   "knowledge": {
     "progressSummary": "ORIENT: answered the seeker's generalization question YES. The four-square orbit-stabilizer type-decomposition extends verbatim to r_{2k}(n) under B_{2k}=S_{2k} semidirect (Z/2)^{2k}: orbit(shape with z zeros, multiplicities m_i)=2^{2k-z}*(2k)!/prod m_i!, stabilizer=2^z*z!*prod(nonzero m_j!), r_{2k}(n)=sum over shapes orbit. Verified exactly for 2k in {2,4,6,8}. Lean ACT Docker-gated. S2 (ACT, build-pending): formalized the 2k=6 case mirroring the parent's COMPUTATIONAL route (not MulAction). New proofs/Proofs/FourSquareDistributionOQ04.lean: RepType6 (sorted six-tuple) + contribution=(720/prod count!)*2^nonzero, concrete shapes for n in {1,2,3,5,6,12,30} with contributions by native_decide and r_6(n) totals as sum of contributions (r6_5=312,r6_6=544,r6_12=2080,r6_30=14144) + nonzeroCount_le_six/signFactor_le_64. Executes the 'fixed small m' ACT at m=6. Cert verify_r6_decomposition.py PASS (exhaustive shapes; orbit formula vs brute signed-ordering count; totals vs convolution).",
     "builtItems": [
+      "proofs/Proofs/FourSquareDistributionOQ04M8.lean (S6 researcher-1, build-pending/UNREGISTERED) — the 2k=8 (|B8|=8!*2^8=10321920) case completing the {4,6,8} fixed-m program: RepType8 sorted eight-tuple + (star)=8!/prod count! * 2^nonzero, native_decide contributions + r8(n) totals for n in {1,2,3,4,5,6,7,8,12} (r8(8)=9328 incl all-ones shape -> 256; r8(12)=31808), nonzeroCount_le_eight/signFactor_le_256. Mirrors the proven parent/2k=6 computational route. Cert verify_r8_decomposition.py PASS.",
+      "research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py (S6) — stdlib exact verifier for the 2k=8 file: exhaustive sorted-shape enumeration vs embedded list; (star) orbit vs INDEPENDENT brute signed-ordering count vs embedded value; sum_shapes orbit == r8(n) vs INDEPENDENT signed-square convolution vs embedded total, for all 9 embedded n. ALL PASS.",
       "proofs/Proofs/FourSquareDistributionOQ04Arrange.lean (S5, build-pending/UNREGISTERED) — re-expresses the orbit-size residue via Nat.multinomial: PROVES factorial_div_eq_multinomial (m!/prod count! = Nat.multinomial s.toFinset s.count), prod_count_factorial_dvd (prod count! | m!, so the Nat.div in (star) is exact), mem_arrangements_iff; ISOLATES arrangement_card (the sole sorry, canonical multinomial form) with the Equiv.Perm (Fin m) orbit-stabilizer route documented; DERIVES arrangement_card_div_form. Cert check_arrangement PASS.",
       "proofs/Proofs/FourSquareDistributionOQ04.lean (S2, build-pending/UNREGISTERED) — 2k=6 type-decomposition: RepType6, the (star) orbit formula, native_decide contributions + r_6(n) totals for n in {1,2,3,5,6,12,30}, structural bounds.",
       "research/problems/four-square-distribution-oq-04/verify_r6_decomposition.py (S2) — pins the exact embedded shapes/contributions/totals via exhaustive enumeration + independent brute signed-ordering count + signed-square convolution.",
@@ -54,7 +56,7 @@
       "S2: the parent four-square proof is COMPUTATIONAL (RepType + formula + native_decide), NOT a MulAction; so the cheapest first ACT for r_{2k} is to mirror it at fixed m (did m=6), discharging concrete contributions/totals by native_decide. The (DECOMP) partition is handled per-n via a complete shape list (cert-verified complete), same as the parent; a uniform MulAction partition proof stays the deep open Lean work.",
       "The orbit-stabilizer decomposition generalizes to all 2k with orbit size 2^{#nonzero}*(2k)!/prod m_i!. |B_8|=8!*2^8=10321920.",
       "Stabilizer is NOT the full Young subgroup prod m_i!: only the 2^z sign flips on ZERO coordinates fix a tuple (flipping a 0 is trivial; flipping a nonzero changes the value). So |stab|=2^z*z!*prod_{nonzero} m_j!, and the orbit carries 2^{#nonzero} not 2^{2k}. Mishandling zeros is the one place a naive |B|/Young computation fails.",
-      "The orbit-size formula (orbit-stabilizer) is the easy half; the orbit PARTITION r_{2k}=sum orbit is the real Lean obstruction (the parent proved it only case-by-case for small n).",
+      "S6 (researcher-1): CORRECTION to the 'orbit-size formula is the easy half' framing. Proving arrangement_card (the orbit-size residue) via Equiv.Perm (Fin m) precomposition has TWO sub-steps each lacking a direct Mathlib lemma: (1) orbit-SURJECTIVITY -- 'two functions Fin m -> Z with the same multiset image differ by a permutation' (needed to identify arrangements s with a single perm-orbit; no obvious Multiset.map->perm lemma); (2) STABILIZER ORDER prod count! (fibered-permutation product). Plus nonemptiness via s.toList (length = card s = m). So even the orbit-size half is multi-residue; a hand-authored blackout proof (~150 lines) is high-risk and was deferred.",
       "S5 (R4): verified all bearers of OQ04Sign.lean (signFiber_card) against sibling Mathlib v4.26 — Fintype.card_piFinset(BigOperators:123), Finset.card_pair(Card:140), Finset.prod_ite(Piecewise:63) all confirmed; clears S4 from-memory caveat. Sign file build-confident; sole open residue = arrangement_card multinomial count (Aristotle target, backend 404)."
     ],
     "mathlibGaps": [
@@ -94,7 +96,7 @@
     ]
   },
   "started": "2026-06-15T07:05:00.000Z",
-  "lastUpdate": "2026-06-15T10:25:00Z",
+  "lastUpdate": "2026-06-15T14:05:00Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Formalizes the **2k = 8** case of the hyperoctahedral type-decomposition of sums of squares — the example named in the open question (`|B_8| = 8!·2^8 = 10,321,920`) and the only one of `{4, 6, 8}` not previously formalized. This completes the "ACT fixed m in {4,6,8}" program documented in the problem's knowledge base.

New file `proofs/Proofs/FourSquareDistributionOQ04M8.lean` mirrors the **proven** computational route of the parent (`FourSquareDistribution.lean`) and the `2k=6` sibling (`FourSquareDistributionOQ04.lean`):

- `RepType8` (sorted eight-tuple, `Σ aᵢ² = n`) + the orbit-size formula `(★) = 8!/∏count! · 2^#nonzero`;
- concrete per-shape contributions for `n ∈ {1,…,8, 12}` discharged by `native_decide`, with `r₈(n)` totals as `∑ contributions` (`r₈(8)=9328` includes the all-equal-nonzero shape `(1,…,1) → 8!/8!·2⁸ = 256`; `r₈(12)=31808`), matching Jacobi's `r₈(n)=16σ₃*(n)`;
- structural bounds `nonzeroCount_le_eight`, `signFactor_le_256`.

## Certificate

`research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py` (stdlib, exact integers) independently checks, for all 9 embedded `n`:
- (a) the exhaustive sorted-shape enumeration equals the file's shape list;
- (b) each shape's `(★)` orbit equals an **independent** brute count of distinct signed orderings **and** the embedded value;
- (c) `∑ orbits == r₈(n)` via an **independent** signed-square convolution **and** the embedded total.

All checks **PASS**.

## Status

**Build-pending / unregistered.** Triple backend outage re-confirmed live this session (`docker info` rc=124; no local Mathlib checkout; Aristotle `prove` → HTTP 404 via `mcp-smoke-test.sh`), so no kernel check was possible. The file uses only elementary list arithmetic + `native_decide`, mirroring the already-compiling parent/sibling, and every embedded value is certified by the Python script above. A build session should register it in `Proofs.lean`.

Knowledge base also refined: the sole uniform residue `arrangement_card` has **two** sub-steps each lacking a direct Mathlib lemma (orbit-surjectivity "equal multiset image ⟹ differ by a permutation" + stabilizer order `∏count!`), correcting the prior "easy half" framing.

## Test plan

- [x] `python3 research/problems/four-square-distribution-oq-04/verify_r8_decomposition.py` → ALL PASS
- [ ] `./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04M8` (deferred — Docker daemon down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)