### PR TITLE
research(zsqrtd-neg-two-oq-02): slim the residue-3 sufficiency hypothesis (mm%4≠3 is free)

### DIFF
--- a/proofs/Proofs/ThreeSquaresResidue3.lean
+++ b/proofs/Proofs/ThreeSquaresResidue3.lean
@@ -53,4 +53,33 @@ theorem three_sq_of_residue3_prime {m t mm : ℕ} [Fact (Nat.Prime mm)]
     exact_mod_cast hdecomp
   rw [hmZ]; ring
 
+/-- The `mm % 4 ≠ 3` obligation of `three_sq_of_residue3_prime` is **automatic**
+given the residue structure of the deficit decomposition. For `m ≡ 3 (mod 8)`
+and an *odd* witness `t`, the deficit `mm = (m − t²)/2` is forced into `mm ≡ 1
+(mod 4)`: an odd square is `≡ 1 (mod 8)`, so `2·mm = m − t² ≡ 2 (mod 8)` and
+`mm ≡ 1 (mod 4)`. -/
+theorem residue3_deficit_one_mod_four {m t mm : ℕ}
+    (hm8 : m % 8 = 3) (ht : Odd t) (hdecomp : m = t ^ 2 + 2 * mm) :
+    mm % 4 = 1 := by
+  obtain ⟨k, hk⟩ := ht
+  -- `t² = 8·j + 1` where `k(k+1) = j + j` (a product of consecutive naturals is even)
+  obtain ⟨j, hj⟩ := Nat.even_mul_succ_self k
+  have hsq : t ^ 2 = 8 * j + 1 := by
+    have h2 : t ^ 2 = 4 * (k * (k + 1)) + 1 := by rw [hk]; ring
+    rw [h2, hj]; ring
+  omega
+
+/-- **Residue-3 route, with the `mm % 4 ≠ 3` side-condition discharged.**
+Given `m ≡ 3 (mod 8)`, an *odd* witness `t`, and a *prime* deficit
+`mm = (m − t²)/2` (packaged as `m = t² + 2·mm`), the number `m` is a sum of three
+integer squares. This is the form actually used by the assembly: the residue
+structure makes `mm % 4 ≠ 3` free (via `residue3_deficit_one_mod_four`), so the
+caller need only exhibit an odd `t` and a prime deficit — no separate quadratic
+side-condition. -/
+theorem three_sq_of_residue3_odd {m t mm : ℕ} [Fact (Nat.Prime mm)]
+    (hm8 : m % 8 = 3) (ht : Odd t) (hdecomp : m = t ^ 2 + 2 * mm) :
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ) :=
+  three_sq_of_residue3_prime
+    (by have := residue3_deficit_one_mod_four hm8 ht hdecomp; omega) hdecomp
+
 end ThreeSquaresResidue3

--- a/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
+++ b/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
@@ -163,4 +163,35 @@ theorem legendre_three_squares_of_corrected
   ⟨fun hrep hf => excluded_form_not_sum_three_sq hf hrep,
    three_sq_of_corrected_witnesses Hne3 H3⟩
 
+/-- **Slimmed residue-3 hypothesis** (no quadratic side-condition).
+
+`Residue3Property` carries an explicit `mm % 4 ≠ 3` clause so that Fermat's
+two-square theorem applies to the deficit. But for `m ≡ 3 (mod 8)` that clause is
+*forced* the moment the witness `t` is odd: an odd square is `≡ 1 (mod 8)`, so
+`mm = (m − t²)/2 ≡ 1 (mod 4)`. This slimmer property therefore asks only for an
+odd `t` and a prime deficit — the genuinely open Dirichlet-on-a-thin-sequence
+content — with the arithmetic side-condition discharged downstream. -/
+def Residue3PropertyOdd : Prop :=
+  ∀ {m : ℕ}, m % 8 = 3 → 3 < m →
+    ∃ t mm : ℕ, Odd t ∧ Nat.Prime mm ∧ m = t ^ 2 + 2 * mm
+
+/-- The slimmer `Residue3PropertyOdd` implies the original `Residue3Property`:
+the `mm % 4 ≠ 3` clause is recovered for free from oddness of `t` via
+`ThreeSquaresResidue3.residue3_deficit_one_mod_four`. -/
+theorem Residue3Property_of_odd (H : Residue3PropertyOdd) : Residue3Property := by
+  intro m hm8 hm3
+  obtain ⟨t, mm, ht, hmm, hdecomp⟩ := H hm8 hm3
+  refine ⟨t, mm, hmm, ?_, hdecomp⟩
+  have := ThreeSquaresResidue3.residue3_deficit_one_mod_four hm8 ht hdecomp
+  omega
+
+/-- **Corrected sufficiency from the slimmed witnesses.** Same conclusion as
+`three_sq_of_corrected_witnesses`, but consuming the smaller `Residue3PropertyOdd`
+(no `mm % 4 ≠ 3` obligation). -/
+theorem three_sq_of_corrected_witnesses_odd
+    (Hne3 : DirichletWitnessNe3) (H3 : Residue3PropertyOdd)
+    {n : ℕ} (hne : ¬IsExcludedForm n) :
+    ∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = n :=
+  three_sq_of_corrected_witnesses Hne3 (Residue3Property_of_odd H3) hne
+
 end ThreeSquares

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -208,3 +208,54 @@ the obstruction (m≤4000), corroborating S3's `verify_dirichlet_witness.py`.
 Eliminating all three turns `ThreeSquares.lean`'s two axioms into a fully verified
 three-square theorem. Do NOT re-derive the forward obstruction or the ℤ[√−2]
 route (both complete); do NOT re-attempt the monolithic witness (proven false).
+
+## Session 2026-06-15 (S5, researcher-4) — slim the residue-3 hypothesis + compile-audit
+
+**Mode**: REVISIT · **Phase**: ACT · **Outcome**: additive Lean progress on the
+unregistered companions (zero blast radius); Docker down (`docker info` timeout) →
+build-pending. No registered file touched.
+
+### Compile-correctness audit of the existing reduction (de-risk)
+
+`ThreeSquaresResidue3.lean` + `ThreeSquaresSufficiencyCorrected.lean` (both on
+`main`, build-pending, written under blackout) were name-checked vs the local
+Mathlib clone and `ThreeSquares.lean`:
+- `Nat.Prime.sq_add_sq {p} [Fact p.Prime] (hp : p%4≠3) : ∃ a b, a²+b²=p` — exact
+  (`Mathlib/NumberTheory/SumTwoSquares.lean:35`).
+- `Nat.strong_induction_on (n) (∀ n, (∀ m<n, p m) → p n) : p n` — exact
+  (`Mathlib/Data/Nat/Init.lean:294`); `induction n using … with | _ n ih =>`
+  auto-reverts `hne` into the motive, so `ih : ∀ m<n, ¬IsExcludedForm m → ∃…` and
+  `ih m hmlt hmne` (Corrected:116) type-checks.
+- `four_mul_sum_three_sq` → `…=(4*n:ℕ)`; `excluded_form_four_mul_iff :
+  IsExcludedForm (4*n) ↔ IsExcludedForm n` — used with correct orientation;
+  `ThreeSquares.lean` keeps all decls inside `namespace ThreeSquares`, reopened by
+  the Corrected file, so unqualified refs resolve. Chain looks compile-correct
+  (modulo a real build).
+
+### New, verified-by-inspection content (this session)
+
+`Residue3Property` carried an explicit `mm % 4 ≠ 3` clause; that clause is
+**redundant** — for `m ≡ 3 (mod 8)` with an *odd* witness `t`, an odd square is
+`≡ 1 (mod 8)`, so `2·mm = m − t² ≡ 2 (mod 8)`, forcing `mm ≡ 1 (mod 4)`.
+
+Added (purely additive, no existing decl changed):
+- `ThreeSquaresResidue3.residue3_deficit_one_mod_four` — `m%8=3 → Odd t →
+  m=t²+2mm → mm%4=1` (odd-square-mod-8 via `Nat.even_mul_succ_self` + `omega`).
+- `ThreeSquaresResidue3.three_sq_of_residue3_odd` — residue-3 route with `mm%4≠3`
+  discharged internally; caller supplies only `Odd t` + prime deficit.
+- `ThreeSquares.Residue3PropertyOdd` — slimmer open hypothesis (drops the side
+  condition): `∀ m%8=3, 3<m, ∃ t mm, Odd t ∧ mm.Prime ∧ m=t²+2mm`.
+- `ThreeSquares.Residue3Property_of_odd : Residue3PropertyOdd → Residue3Property`
+  + `three_sq_of_corrected_witnesses_odd` (full sufficiency from
+  `DirichletWitnessNe3` + `Residue3PropertyOdd`, reusing the existing induction).
+
+**Net effect.** The residue-3 half of the sufficiency reduction now isolates a
+*cleaner* open statement — just "∃ odd `t` with `(m−t²)/2` prime" (a thin-sequence
+primality existence) — with the arithmetic mod-4 constraint dispatched. This does
+NOT discharge the hypothesis (that primality is the genuine deep input); it removes
+a spurious side-condition. Axiom budget unchanged. The deep open work in items 1–3
+above is unchanged.
+
+**Next session**: with Docker, build `Proofs.ThreeSquaresResidue3` +
+`Proofs.ThreeSquaresSufficiencyCorrected`; remaining math = items 1–3 (all
+Dirichlet/Minkowski-deep, not session-sized).

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -55,3 +55,23 @@ for `n>1`, `4∤n`, `¬excluded n`, produce `d>0` and prime `p = d·n−1` with
 + quadratic reciprocity to fix the residue class of `p` so `−d` is a QR mod `p`.
 Discharging it eliminates the sufficiency axiom from `ThreeSquares.lean` (2 axioms → 1).
 Docker-gated: verify `ThreeSquaresSufficiency.lean` builds when Docker returns.
+
+## S5 — slim the residue-3 hypothesis + compile-audit (researcher-4, 2026-06-15)
+
+ACT, build-pending (Docker `docker info` timeout). Additive edits to the two
+UNREGISTERED companions (zero blast radius); no registered file touched.
+- Audited `ThreeSquaresResidue3.lean` + `ThreeSquaresSufficiencyCorrected.lean`
+  (both on main, build-pending) for compile-correctness vs the local Mathlib
+  clone + `ThreeSquares.lean`; the reduction chain checks out by inspection
+  (`Nat.Prime.sq_add_sq`, `Nat.strong_induction_on` auto-revert, namespace, the
+  `four_mul`/`excluded_form_four_mul_iff` orientations).
+- Proved `residue3_deficit_one_mod_four` (`m%8=3 ∧ Odd t ∧ m=t²+2mm ⟹ mm%4=1`):
+  the `mm%4≠3` side-condition of the residue-3 route is FREE from oddness of t.
+- Added `three_sq_of_residue3_odd`, `Residue3PropertyOdd`,
+  `Residue3Property_of_odd`, `three_sq_of_corrected_witnesses_odd`: the residue-3
+  open hypothesis slims to "∃ odd t with (m−t²)/2 prime" — no QR side-condition.
+- Open work unchanged (items 1–3 in knowledge.md): discharge `DirichletWitnessNe3`,
+  the slimmed residue-3 primality, and `dirichlet_key_lemma`. All Dirichlet/
+  Minkowski-deep, not session-sized.
+
+**Next**: build the two companions when Docker returns; then attack items 1–3.


### PR DESCRIPTION
## Summary
Research session on the Legendre–Gauss three-square theorem (`zsqrtd-neg-two-oq-02`). Advances the **sufficiency** reduction of `ThreeSquares.lean`'s converse axiom by shrinking the residue-3 (mod 8) open hypothesis.

`ThreeSquaresSufficiencyCorrected.lean` reduces the sufficiency axiom to `dirichlet_key_lemma` + two satisfiable hypotheses; its residue-3 hypothesis `Residue3Property` carried an explicit `mm % 4 ≠ 3` clause. **That clause is redundant**: for `m ≡ 3 (mod 8)` with an odd witness `t`, an odd square is `≡ 1 (mod 8)`, so `mm = (m − t²)/2 ≡ 1 (mod 4)`.

## Progress (additive, on the UNREGISTERED companions — zero blast radius)
- `ThreeSquaresResidue3.residue3_deficit_one_mod_four`: `m%8=3 ∧ Odd t ∧ m=t²+2mm ⟹ mm%4=1`.
- `ThreeSquaresResidue3.three_sq_of_residue3_odd`: residue-3 route with the side condition discharged internally.
- `ThreeSquares.Residue3PropertyOdd` + `Residue3Property_of_odd` + `three_sq_of_corrected_witnesses_odd`: full sufficiency from `DirichletWitnessNe3` + the slimmer `Residue3PropertyOdd` (no QR-style side condition), reusing the existing induction (no duplication).

## Findings
- The residue-3 half of the open content now isolates the cleaner statement "∃ odd `t` with `(m−t²)/2` prime" (thin-sequence primality) — the arithmetic mod-4 constraint is dispatched.
- Name-checked the existing reduction chain against the local Mathlib clone: `Nat.Prime.sq_add_sq` (`SumTwoSquares.lean:35`), `Nat.strong_induction_on` (`Data/Nat/Init.lean:294`, auto-reverts `hne` into the motive), and the `four_mul`/`excluded_form_four_mul_iff` orientations + namespace resolution all check out — the reduction is compile-correct on inspection.
- **Axiom budget unchanged.** This removes a spurious side-condition; it does not discharge the (deep, Dirichlet/Minkowski) open hypotheses.

## Status
**Outcome**: progress (build-pending — Docker `docker info` timed out; files unregistered so harmless to the aggregate build)
**Next Steps**: build `Proofs.ThreeSquaresResidue3` + `Proofs.ThreeSquaresSufficiencyCorrected` when Docker returns; then attack the three deep open items (discharge `DirichletWitnessNe3`, the slimmed residue-3 primality, and `dirichlet_key_lemma`).

🤖 Generated by researcher-4