### PR TITLE
audit(morleys-theorem-oq-03): fix "Fully verified" overclaim in summary

### DIFF
--- a/src/data/proofs/morleys-theorem-oq-03/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-03/meta.json
@@ -100,7 +100,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully verified in Lean 4 (0 axioms, 0 sorries): the Morley side length 8R·sin(α/3)·sin(β/3)·sin(γ/3) is maximized, over all triangles of circumradius R≥0, at the equilateral, with maximal value 8R·sin³(π/9); and for R>0 the equilateral is the unique maximizer. The proof is elementary, using only AM–GM (via an explicit SOS certificate) and the concavity of sin on [0,π].",
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; machine-check build-pending under Docker blackout): the Morley side length 8R·sin(α/3)·sin(β/3)·sin(γ/3) is maximized, over all triangles of circumradius R≥0, at the equilateral, with maximal value 8R·sin³(π/9); and for R>0 the equilateral is the unique maximizer. The proof is elementary, using only AM–GM (via an explicit SOS certificate) and the concavity of sin on [0,π].",
     "implications": "The result shows the 'largest Morley triangle' question reduces to a symmetric product-of-sines optimization that is fully formalizable without calculus. The two-stage inequality structure — a degree-3 AM–GM plus a chained two-point Jensen — is reusable for other symmetric trigonometric extremal problems, and the strict-uniqueness pattern (sandwiching an average via the equality cases of AM–GM and strict Jensen) generalizes to other concave-function maximizations on a simplex.",
     "openQuestions": [
       "Extremal Morley behavior under other normalizations: fix the perimeter, the area, or the longest side instead of the circumradius — is the equilateral still the maximizer, and what is the sharp constant?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: morleys-theorem-oq-03
**Problem**: The `conclusion.summary` claims the result is **"Fully verified in Lean 4 (0 axioms, 0 sorries)"**, but `meta.status` is `formalized` / badge `wip`, and the Lean source header states the proof is build-pending (not machine-checked).

## Evidence

- **meta.json claims** (`conclusion.summary`): *"Fully verified in Lean 4 (0 axioms, 0 sorries): ..."*
- **meta.status / badge**: `formalized` / `wip` (downgraded by #24667)
- **Lean source** `proofs/Proofs/MorleysTheoremOQ03.lean:317`: *"Proved (target: 0 sorries, 0 axioms — build pending under Docker blackout)"*

PR #24667 correctly downgraded the `status` field from `verified` but left this prose overclaim untouched. A reader of the gallery conclusion would see "Fully verified" while the kernel has not confirmed the proof.

## Fix

Reword `conclusion.summary` from "Fully verified in Lean 4" → "Formalized in Lean 4 (0 axioms, 0 sorries; machine-check build-pending under Docker blackout)", consistent with the `formalized`/`wip` status and the source header. No mathematical content changed.

---
Discovered during gallery integrity audit. Gallery-data-only change (no `.lean` touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)