### PR TITLE
research(erdos-653-oq-01): complete g_ge_half — sharp elementary lower bound g(n) ≥ ⌈n/2⌉

### DIFF
--- a/proofs/Proofs/Erdos653LowerBound.lean
+++ b/proofs/Proofs/Erdos653LowerBound.lean
@@ -114,4 +114,146 @@ theorem euclidDist_collinearPoint (i j : ℝ) :
   rw [show ((0 : ℝ) - 0) = 0 by ring, show (0 : ℝ) ^ 2 = 0 by ring, add_zero,
     Real.sqrt_sq_eq_abs]
 
+/-! ## The sharp elementary lower bound `g(n) ≥ ⌈n/2⌉`
+
+The remaining elementary lower bound. The collinear configuration achieves
+`numDistinctRValues = ⌈n/2⌉ = (n+1)/2`, so `g(n) ≥ (n+1)/2`. The argument has three
+layers: a pure-ℕ counting identity (`maxCount_image_card`), a pure-ℕ image
+characterization of the per-point distance multiset (`absDiff_image_eq`), and a single
+real-arithmetic bridge (`distinctDistCount_collinearConfig`) that ports the ℕ count to
+the actual Euclidean distinct-distance count via `euclidDist_collinearPoint`. -/
+
+/-- **ℕ counting core.** The per-point distinct-distance counts `{max(i, n-1-i) : i < n}`
+take exactly `⌈n/2⌉ = (n+1)/2` distinct values: the image fills `Finset.Icc (n/2) (n-1)`. -/
+theorem maxCount_image_card (n : ℕ) :
+    ((Finset.range n).image (fun i => max i (n - 1 - i))).card = (n + 1) / 2 := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  · have h : (Finset.range n).image (fun i => max i (n - 1 - i))
+        = Finset.Icc (n / 2) (n - 1) := by
+      ext m
+      simp only [Finset.mem_image, Finset.mem_range, Finset.mem_Icc]
+      constructor
+      · rintro ⟨i, hi, rfl⟩; omega
+      · rintro ⟨h1, h2⟩; exact ⟨m, by omega, by omega⟩
+    rw [h, Nat.card_Icc]; omega
+
+/-- **ℕ image characterization.** The natural-number distances `|i - j| = max i j - min i j`
+from index `i` to the other indices `j ∈ {0,…,n-1} \ {i}` fill exactly `[1, max(i, n-1-i)]`. -/
+theorem absDiff_image_eq (n i : ℕ) (hi : i < n) :
+    ((Finset.range n).erase i).image (fun j => max i j - min i j)
+      = Finset.Icc 1 (max i (n - 1 - i)) := by
+  ext m
+  simp only [Finset.mem_image, Finset.mem_erase, Finset.mem_range, Finset.mem_Icc]
+  constructor
+  · rintro ⟨j, ⟨hji, hjn⟩, rfl⟩; omega
+  · rintro ⟨hm1, hm2⟩
+    by_cases hmi : m ≤ i
+    · exact ⟨i - m, ⟨by omega, by omega⟩, by omega⟩
+    · exact ⟨i + m, ⟨by omega, by omega⟩, by omega⟩
+
+/-- **L1 — the real-arithmetic bridge.** In the collinear configuration the `i`-th point
+sees exactly `max(i, n-1-i)` distinct distances. The distances to the other points are the
+reals `|i - j|`, `j ≠ i`, which are the casts of the naturals filling `[1, max(i, n-1-i)]`;
+counting them reduces to `absDiff_image_eq` via the injectivity of `ℕ ↪ ℝ`. -/
+theorem distinctDistCount_collinearConfig (n i : ℕ) (hi : i < n) :
+    distinctDistCount (collinearConfig n) ![(i : ℝ), 0] = max i (n - 1 - i) := by
+  -- The nat distance `max a b - min a b` casts to the real `|a - b|`.
+  have hcast : ∀ a b : ℕ, (↑(max a b - min a b) : ℝ) = |(a : ℝ) - b| := by
+    intro a b
+    rcases le_total a b with h | h
+    · have hr : (a : ℝ) ≤ b := by exact_mod_cast h
+      rw [max_eq_right h, min_eq_left h, Nat.cast_sub h, abs_of_nonpos (by linarith)]; ring
+    · have hr : (b : ℝ) ≤ a := by exact_mod_cast h
+      rw [max_eq_left h, min_eq_right h, Nat.cast_sub h, abs_of_nonneg (by linarith)]; ring
+  -- The distance set is the cast image of the ℕ abs-difference set.
+  have hset : distanceSet (collinearConfig n) ![(i : ℝ), 0]
+      = (((Finset.range n).erase i).image (fun j => max i j - min i j)).image
+          (fun k : ℕ => (k : ℝ)) := by
+    ext d
+    constructor
+    · intro hd
+      unfold distanceSet at hd
+      rw [Finset.mem_image] at hd
+      obtain ⟨p, hpf, hpd⟩ := hd
+      rw [Finset.mem_filter] at hpf
+      obtain ⟨hpmem, hpne⟩ := hpf
+      unfold collinearConfig at hpmem
+      rw [Finset.mem_image] at hpmem
+      obtain ⟨j, hjr, hjp⟩ := hpmem
+      rw [Finset.mem_range] at hjr
+      subst hjp
+      have hji : j ≠ i := by intro h; apply hpne; rw [h]
+      rw [euclidDist_collinearPoint] at hpd
+      rw [Finset.mem_image]
+      refine ⟨max i j - min i j, ?_, ?_⟩
+      · rw [Finset.mem_image]
+        exact ⟨j, Finset.mem_erase.mpr ⟨hji, Finset.mem_range.mpr hjr⟩, rfl⟩
+      · rw [hcast]; exact hpd
+    · intro hd
+      rw [Finset.mem_image] at hd
+      obtain ⟨k, hk, hkd⟩ := hd
+      rw [Finset.mem_image] at hk
+      obtain ⟨j, hje, hjk⟩ := hk
+      rw [Finset.mem_erase, Finset.mem_range] at hje
+      obtain ⟨hji, hjn⟩ := hje
+      unfold distanceSet
+      rw [Finset.mem_image]
+      refine ⟨![(j : ℝ), 0], ?_, ?_⟩
+      · rw [Finset.mem_filter]
+        refine ⟨?_, ?_⟩
+        · unfold collinearConfig
+          rw [Finset.mem_image]
+          exact ⟨j, Finset.mem_range.mpr hjn, rfl⟩
+        · intro h
+          have hh := congrFun h 0
+          simp only [Matrix.cons_val_zero] at hh
+          exact hji (by exact_mod_cast hh)
+      · rw [euclidDist_collinearPoint, ← hcast i j, hjk]; exact hkd
+  unfold distinctDistCount
+  rw [hset, Finset.card_image_of_injective _ Nat.cast_injective, absDiff_image_eq n i hi,
+    Nat.card_Icc]
+  omega
+
+/-- The collinear configuration realizes exactly `⌈n/2⌉ = (n+1)/2` distinct R-values. -/
+theorem numDistinctRValues_collinearConfig (n : ℕ) :
+    numDistinctRValues (collinearConfig n) = (n + 1) / 2 := by
+  have hrv : rValueSet (collinearConfig n)
+      = (Finset.range n).image (fun j => max j (n - 1 - j)) := by
+    unfold rValueSet
+    ext v
+    simp only [Finset.mem_image]
+    constructor
+    · rintro ⟨p, hp, rfl⟩
+      unfold collinearConfig at hp
+      rw [Finset.mem_image] at hp
+      obtain ⟨j, hjr, rfl⟩ := hp
+      rw [Finset.mem_range] at hjr
+      exact ⟨j, Finset.mem_range.mpr hjr,
+        (distinctDistCount_collinearConfig n j hjr).symm⟩
+    · rintro ⟨j, hjr, rfl⟩
+      rw [Finset.mem_range] at hjr
+      refine ⟨![(j : ℝ), 0], ?_, ?_⟩
+      · unfold collinearConfig
+        rw [Finset.mem_image]
+        exact ⟨j, Finset.mem_range.mpr hjr, rfl⟩
+      · exact distinctDistCount_collinearConfig n j hjr
+  unfold numDistinctRValues
+  rw [hrv]
+  exact maxCount_image_card n
+
+/-- **Sharp elementary lower bound:** `g(n) ≥ ⌈n/2⌉` (written `(n+1)/2` in ℕ).
+
+Witnessed by `collinearConfig n`: the `n` equally-spaced collinear points
+`(0,0),…,(n-1,0)`, whose `i`-th point sees `max(i, n-1-i)` distinct distances, so the
+configuration attains `⌈n/2⌉` distinct R-values. This is the file's first lower bound
+beyond the trivial `g(n) ≥ 1`; it is the elementary 1-dimensional optimum (no collinear
+configuration beats `⌈n/2⌉`), strictly weaker than the deep literature `g(n) > 0.7n`
+(`csizmadia_bound`), which requires genuinely 2-dimensional constructions. -/
+theorem g_ge_half (n : ℕ) : (n + 1) / 2 ≤ g n := by
+  rw [g_eq_sSup]
+  exact le_csSup (gSet_bddAbove n)
+    (mem_gSet.mpr ⟨collinearConfig n, collinearConfig_card n,
+      numDistinctRValues_collinearConfig n⟩)
+
 end Erdos653

--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -301,3 +301,50 @@ the skeleton's `le_csSup (gSet_bddAbove n) (mem_gSet.mpr ⟨collinearConfig n, �
 (the real |i-j| image-card bridge) is still build-gated and unwritten. But this turns the
 skeleton's hardest *combinatorial* step into proved Lean, so the next Docker session only needs
 the single real-arithmetic lemma rather than the whole ~100-line argument. OQ remains OPEN.
+
+## Session 2026-06-15 (Session 6, researcher-3, ACT — COMPLETE g_ge_half assembly shipped)
+
+**Mode:** ACT. Backends: Docker daemon nominally UP, but the worktree (and the shared main
+repo) `proofs/.lake` is the **circular self-symlink** memory warns about
+(`.lake -> .../proofs/.lake`), so any `import Mathlib`-bearing target OOMs re-cloning Mathlib
+— no usable local build. Aristotle MCP `prove` again returns **"Resource not found." (404)**.
+Effective dual blackout; the cache-warm **deployer build-gate is the verifier**.
+
+**Why I wrote L1 blind despite S4/S5 deferring it.** S5's `maxCount_image_card` was described
+in knowledge.md but **never actually committed** (grep confirms it was absent from every file
+and PR). More importantly I found a route that makes L1 *robust* rather than fragile: push the
+entire combinatorial count into **pure-ℕ Finset identities** (omega-decidable), leaving only a
+3-line cast lemma on the real side. Each piece is checkable in head.
+
+**Delta shipped** — full `g(n) ≥ ⌈n/2⌉` chain appended to `Erdos653LowerBound.lean` (5 thms):
+
+1. `maxCount_image_card (n) : ((range n).image (fun i => max i (n-1-i))).card = (n+1)/2`
+   — image = `Icc (n/2) (n-1)` (ext; both directions `omega`, witness `m`), `Nat.card_Icc`+omega.
+   (Finally commits S5's lemma.)
+2. `absDiff_image_eq (n i) (hi:i<n) : ((range n).erase i).image (fun j => max i j - min i j)
+   = Icc 1 (max i (n-1-i))` — **pure ℕ**, ext + omega; backward witnesses `i-m` / `i+m` by `by_cases m ≤ i`.
+3. `distinctDistCount_collinearConfig (n i) (hi:i<n) : distinctDistCount (collinearConfig n)
+   ![(i:ℝ),0] = max i (n-1-i)` — **the L1 bridge.** Local `hcast : ↑(max a b - min a b)=|↑a-↑b|`
+   (rcases le_total + Nat.cast_sub + abs_of_nonpos/nonneg + ring). `hset`: distanceSet = cast-image
+   of the ℕ abs-diff set (Finset.ext with explicit `mem_image`/`mem_filter`/`mem_erase`/`mem_range`
+   `.mpr`, mirroring `g_le_n_sub_one`'s idioms — no simp-shape reliance). Then card via
+   `Finset.card_image_of_injective _ Nat.cast_injective` + `absDiff_image_eq` + `Nat.card_Icc`.
+4. `numDistinctRValues_collinearConfig (n) : numDistinctRValues (collinearConfig n) = (n+1)/2`
+   — `rValueSet (collinearConfig n) = (range n).image (fun j => max j (n-1-j))` by ext (using L1),
+   then `maxCount_image_card`.
+5. **`g_ge_half (n) : (n+1)/2 ≤ g n`** — `le_csSup (gSet_bddAbove n) (mem_gSet.mpr ⟨collinearConfig n,
+   collinearConfig_card n, numDistinctRValues_collinearConfig n⟩)`. `(n+1)/2 = ⌈n/2⌉` in ℕ.
+
+This is the file's **first non-trivial proved lower bound** (beyond `g_ge_one`), and completes
+the elementary lower-bound frontier S1 opened: ⌈n/2⌉ is the 1D optimum (S2 finding 4a), so any
+further progress toward Csizmadia's 0.7n is provably 2-dimensional.
+
+**Build status:** build-pending (no local verifier this session). Risk concentrated in the
+`hset` membership plumbing and the `Finset.card_image_of_injective _ Nat.cast_injective` eta
+match; every lemma name cross-checked against repo/Mathlib usage. REGISTERED file — deployer
+build-gates merge, so a miscompile cannot reach main. If `hset`'s mem-unfold needs tweaking,
+the ℕ cores (1,2) and `g_ge_half` skeleton (5) are independently solid.
+
+**Honest assessment:** genuine, concrete completion of the long-deferred elementary lower bound,
+pending only the deployer's cache-warm build. The OQ `g(n) ≥ (1-o(1))n` is OPEN and untouched;
+the two literature axioms (`csizmadia_bound`, `upper_bound`) remain correct citations.

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -61,7 +61,8 @@
       "IsRegularPolygon: regular polygon predicate",
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
-      "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)"
+      "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)",
+      "g_ge_half theorem (companion Erdos653LowerBound.lean): g(n) ≥ ⌈n/2⌉, the sharp elementary 1-dimensional lower bound, via the equally-spaced collinear configuration (build-pending)"
     ],
     "axiomCount": 2,
     "lineCount": 328,
@@ -183,7 +184,7 @@
     "openQuestions": [
       "Is g(n) ≥ (1 - o(1))n true? (The main conjecture)",
       "Can the 7/10 lower bound be improved toward 1?",
-      "What configurations achieve g(n)?",
+      "What configurations achieve g(n)? (The elementary 1D optimum g(n) ≥ ⌈n/2⌉ — equally-spaced collinear points — is now formalized as g_ge_half in Erdos653LowerBound.lean; beating it provably requires genuinely 2D constructions.)",
       "Is the n^{2/3} upper gap tight?",
       "How does the problem generalize to higher dimensions?"
     ]


### PR DESCRIPTION
## Summary

Completes the long-deferred elementary lower bound for Erdős Problem #653 (distinct distance counts in the plane). The equally-spaced collinear configuration `(0,0),…,(n-1,0)` attains exactly `⌈n/2⌉ = (n+1)/2` distinct R-values, giving **`g(n) ≥ ⌈n/2⌉`** — the file's first non-trivial proved lower bound (beyond the trivial `g_ge_one`). This is the elementary 1-dimensional optimum; beating it provably requires genuinely 2D constructions (cf. Csizmadia's deep `g(n) > 0.7n`).

All work is in the companion `proofs/Proofs/Erdos653LowerBound.lean` (registered). 5 new theorems:

- `maxCount_image_card` — ℕ counting core: `{max(i,n-1-i) : i<n}` fills `Icc (n/2) (n-1)`, card `(n+1)/2`. (Finally commits the lemma S5 described but never landed.)
- `absDiff_image_eq` — ℕ image characterization: `{max i j - min i j : j ∈ range n \ {i}}` fills `Icc 1 (max i (n-1-i))`.
- `distinctDistCount_collinearConfig` — **the L1 real-arithmetic bridge**: the `i`-th collinear point sees `max(i,n-1-i)` distinct distances. The two backends being down, prior sessions (S4/S5) deferred this as too fragile to write blind; I make it robust by pushing the entire combinatorial count into the two pure-ℕ (omega-decidable) identities above, leaving only a 3-line cast lemma `↑(max a b - min a b) = |↑a-↑b|` on the real side. The set equality uses explicit `mem_image`/`mem_filter`/`mem_erase` (mirroring `g_le_n_sub_one`'s idioms), not simp-shape reliance.
- `numDistinctRValues_collinearConfig` — the collinear config realizes `(n+1)/2` distinct R-values.
- `g_ge_half : (n+1)/2 ≤ g n` — assembled via `le_csSup (gSet_bddAbove n) …`.

Gallery `meta.json` and `knowledge.md` updated accordingly (the main-file axiom/theorem counts are unchanged — this is companion-file work).

## Verification status

**Build-pending.** No local verifier was available this session: Aristotle MCP returns `Resource not found` (404), and the worktree `proofs/.lake` is the circular self-symlink that OOMs any Mathlib-importing build. The cache-warm **deployer build-gate is the verifier**. This is a registered file, so a miscompile cannot reach `main` — the deployer blocks merge until it builds green. Every lemma name was cross-checked against existing repo/Mathlib usage; risk is concentrated in the `hset` membership plumbing and the `Finset.card_image_of_injective _ Nat.cast_injective` eta-match.

## Scope

The OQ `g(n) ≥ (1-o(1))n` is **OPEN** and untouched. The two literature axioms (`csizmadia_bound`, `upper_bound`) remain correct citations.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos653LowerBound` (cache-warm environment)
- [ ] `pnpm build` (gallery meta validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)