### PR TITLE
Fix: make picks_theorem provable, eliminating the inconsistent axiom (#23117)

### DIFF
--- a/proofs/Proofs/PicksTheorem.lean
+++ b/proofs/Proofs/PicksTheorem.lean
@@ -110,6 +110,14 @@ structure SimpleLatticePolygon where
   area_pos : 0 < area
   /-- Boundary has at least 3 points (polygon is non-degenerate) -/
   boundary_ge_three : 3 ≤ boundary_count
+  /-- Pick's relation: the area is determined by the lattice-point counts.
+      Without this field the three numeric components are independent, so one
+      could build a "polygon" whose area is unrelated to its point counts --
+      which makes the bare formula `A = i + b/2 - 1` an inconsistent assertion.
+      Carrying it here is the geometric-realizability constraint that every
+      genuine simple lattice polygon satisfies, and it lets `picks_theorem`
+      be a proved theorem rather than an (unsound) axiom. -/
+  pick_relation : area = (interior_count : ℚ) + (boundary_count : ℚ) / 2 - 1
 
 /-- Notation for interior point count -/
 notation "i(" P ")" => SimpleLatticePolygon.interior_count P
@@ -144,9 +152,14 @@ def picks_formula (interior boundary : ℕ) : ℚ :=
 For a simple polygon with vertices at lattice points:
   Area = (interior points) + (boundary points)/2 - 1
 
-This relates discrete counting to continuous area measurement. -/
-axiom picks_theorem (P : SimpleLatticePolygon) :
-    A(P) = picks_formula i(P) b(P)
+This relates discrete counting to continuous area measurement.
+
+Now a proved theorem (not an axiom): it follows directly from the
+`pick_relation` realizability field carried by `SimpleLatticePolygon`. -/
+theorem picks_theorem (P : SimpleLatticePolygon) :
+    A(P) = picks_formula i(P) b(P) := by
+  unfold picks_formula
+  exact P.pick_relation
 
 /-- Alternative statement: Area formula -/
 theorem picks_theorem_explicit (P : SimpleLatticePolygon) :
@@ -192,6 +205,7 @@ def unit_right_triangle : SimpleLatticePolygon where
   area := 1/2
   area_pos := by norm_num
   boundary_ge_three := by norm_num
+  pick_relation := by norm_num
 
 /-- Pick's formula gives correct area for unit right triangle -/
 theorem picks_unit_triangle :
@@ -235,6 +249,9 @@ def rectangle (m n : ℕ) (hm : 0 < m) (hn : 0 < n) : SimpleLatticePolygon where
     have hm' : 1 ≤ m := hm
     have hn' : 1 ≤ n := hn
     omega
+  pick_relation := by
+    simp only [Nat.cast_mul, Nat.cast_add, Nat.cast_sub hm, Nat.cast_sub hn, Nat.cast_one]
+    ring
 
 /-- Pick's formula verification for rectangles -/
 theorem picks_rectangle (m n : ℕ) (hm : 0 < m) (hn : 0 < n) :
@@ -286,6 +303,7 @@ def large_right_triangle : SimpleLatticePolygon where
   area := 8
   area_pos := by norm_num
   boundary_ge_three := by norm_num
+  pick_relation := by norm_num
 
 theorem picks_large_right_triangle :
     picks_formula 3 12 = 8 := by


### PR DESCRIPTION
## Fix

Adds a `pick_relation` realizability field to `SimpleLatticePolygon` in `proofs/Proofs/PicksTheorem.lean`, converting the unsound `picks_theorem` **axiom** into a **proved theorem** (option 1 of the issue's suggested fixes).

## Evidence

**Before** (`PicksTheorem.lean:148`):
```lean
axiom picks_theorem (P : SimpleLatticePolygon) :
    A(P) = picks_formula i(P) b(P)
```
`SimpleLatticePolygon` left `(interior_count, boundary_count, area)` independent, so the axiom equated e.g. `area = 1000` with `i + b/2 - 1 = 3/2` — a derivation of `False`.

**After**:
```lean
structure SimpleLatticePolygon where
  ...
  pick_relation : area = (interior_count : ℚ) + (boundary_count : ℚ) / 2 - 1

theorem picks_theorem (P : SimpleLatticePolygon) :
    A(P) = picks_formula i(P) b(P) := by
  unfold picks_formula; exact P.pick_relation
```
All four concrete polygons (`unit_right_triangle`, `rectangle`, `large_right_triangle`) discharge the new field.

**Docker-verified builds** (this session, Docker up):
- `Proofs.PicksTheorem` — 3058 jobs, success
- `Proofs.EhrhartCubeProvenOQ05` (imports the axiom) — 3060 jobs, success; its own `picks_theorem_derived` no longer rests on an unsound axiom.

## Scope note (partial fix of #23117)

The issue lists four files. This PR fixes the canonical definition file (`PicksTheorem.lean`, the cited `:148` axiom) and thereby its real importer `EhrhartCubeProvenOQ05.lean`. `PicksTheoremOQ01.lean` only mentions the axiom in a docstring (not affected).

`PicksTheoremOQ01OQ02.lean` carries its **own independent** copy of the inconsistent axiom **and** has pre-existing Mathlib-drift build breakage unrelated to soundness (deprecated `∑ … in` syntax, `Finset.PairwiseDisjoint`/`Finset.Nat.antidiagonal` renames, missing `Inhabited SimpleLatticePolygon` for an `opaque`, and a latent off-by-one in its h*-vector). That file does not currently compile on `main`, so its axiom fix is deferred to a separate follow-up issue rather than bundled here.

Refs #23117 (supersedes the stale draft #23129, which also touched the non-building OQ01OQ02 file).

---
Automated fix by lean-mechanic agent.