### PR TITLE
Enrich erdos-1047-oq-02: correct stale annotation + expand coverage

### DIFF
--- a/src/data/proofs/erdos-1047-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1047-oq-02/annotations.json
@@ -1,14 +1,56 @@
 [
   {
+    "id": "ann-e1047-oq02-integrity-problem",
+    "proofId": "erdos-1047-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 27
+    },
+    "type": "concept",
+    "title": "The Integrity Problem: An Unsound Small-c Axiom",
+    "content": "The flagship `Erdos1047Problem.lean` originally defined `grunskyConjecture` with a spurious **small-c** restriction (`∃ c₀ > 0, ∀ c < c₀, …`) and then *posited* its negation as `axiom grunskyConjecture_false : ¬grunskyConjecture`, with the headline `erdos_1047 := grunskyConjecture_false`.\n\nBut the small-c statement is **true**: for a fixed monic f, as c → 0 the sublevel set {|f| ≤ c} breaks into one tiny component around each root, each a disk — hence convex. So a threshold c₀ always exists and `grunskyConjecture` holds; its negation was therefore a **false axiom**, and it did not even match the question Grunsky asked (the genuine counterexamples occur at specific non-small c).",
+    "mathContext": "Small-c form: $\\exists c_0>0,\\ \\forall c,\\ 0<c<c_0,\\ \\dots$. Near a root $r$ of multiplicity $k$ the component is $\\{|z-r|^k \\lesssim c'\\} = \\{|z-r| \\le c'^{1/k}\\}$, a disk ⇒ convex. Hence a threshold exists for every $f$, so the small-c statement holds and negating it is unsound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Axiom integrity",
+      "Polynomial lemniscates",
+      "Quantifier strength",
+      "Soundness"
+    ],
+    "prerequisites": [
+      "Polynomial lemniscates and sublevel sets",
+      "Logical strength of quantifier restrictions"
+    ]
+  },
+  {
+    "id": "ann-e1047-oq02-patch-applied",
+    "proofId": "erdos-1047-oq-02",
+    "range": {
+      "startLine": 43,
+      "endLine": 55
+    },
+    "type": "context",
+    "title": "Parent Patch Applied: Axiom Count 2 → 1",
+    "content": "The repair this companion proposed has **landed** in `Erdos1047Problem.lean` (Docker-verified, PR #24613): (1) `grunskyConjecture` was redefined to the faithful `∀ c > 0` form; (2) `axiom grunskyConjecture_false` was converted to a `theorem` proved from `goodman_counterexample`; (3) the flagship's `axiomCount` dropped `2 → 1`.\n\nConsequently `grunskyConjectureFaithful` is now *definitionally equal* to the flagship's `grunskyConjecture`, and this file stands as a redundant-but-consistent record documenting the repair. Only `goodman_counterexample` — the single genuine analytic input — remains as an assumption.",
+    "mathContext": "Post-patch dependency chain has exactly one axiom, `goodman_counterexample`; `grunskyConjecture_false : ¬grunskyConjecture` is a theorem, not an axiom.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Axiom elimination",
+      "Soundness",
+      "Definitional equality"
+    ],
+    "prerequisites": []
+  },
+  {
     "id": "ann-e1047-oq02-faithful",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 78,
-      "endLine": 81
+      "startLine": 65,
+      "endLine": 72
     },
     "type": "definition",
     "title": "Faithful Grunsky Question (∀ c > 0)",
-    "content": "`grunskyConjectureFaithful` states Grunsky's question with **no** small-c restriction: for every monic f of positive degree and *every* c > 0, all components of {z : |f(z)| ≤ c} are convex.\n\nThis is the statement the Erdős #1047 docstring actually describes. The parent flagship instead uses a weaker `∃ c₀ > 0, ∀ c < c₀` form — and that weaker form is TRUE (small components are disks), which is what makes the parent's `axiom grunskyConjecture_false` unsound.",
+    "content": "`grunskyConjectureFaithful` states Grunsky's question with **no** small-c restriction: for every monic f of positive degree and *every* c > 0, all components of {z : |f(z)| ≤ c} are convex.\n\nThis is the statement the Erdős #1047 docstring actually describes. After the parent patch, the flagship's `grunskyConjecture` has been redefined to this same `∀ c > 0` form, so the two are now definitionally equal. The statement is genuinely FALSE (Pommerenke 1961, Goodman 1966).",
     "mathContext": "$\\forall f$ monic, $\\deg f > 0$, $\\forall c > 0$, every component of $\\{|f(z)| \\le c\\}$ is convex. Genuinely FALSE (Pommerenke 1961, Goodman 1966).",
     "significance": "key",
     "relatedConcepts": [
@@ -21,20 +63,20 @@
     ]
   },
   {
-    "id": "ann-e1047-oq02-stronger",
+    "id": "ann-e1047-oq02-coincides",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 87,
-      "endLine": 89
+      "startLine": 74,
+      "endLine": 81
     },
     "type": "theorem",
-    "title": "Faithful Implies Small-c (Strictly Stronger)",
-    "content": "`faithful_imp_grunsky` proves the faithful ∀-c statement implies the parent's small-c `grunskyConjecture` — just take the threshold c₀ = 1.\n\nConsequently the parent's `axiom grunskyConjecture_false : ¬grunskyConjecture` negates the *weaker* of the two statements, which over-claims. This pinpoints the logical root cause of the parent axiom's unsoundness.",
-    "mathContext": "Strength comparison: $\\text{faithful} \\Rightarrow \\text{small-}c$ via $c_0 = 1$. Negating the weaker statement is a stronger (and here false) claim.",
+    "title": "Faithful Coincides with the Flagship (the Implication is the Identity)",
+    "content": "`faithful_imp_grunsky : grunskyConjectureFaithful → grunskyConjecture` is proved by `fun h => h`. Because the flagship's `grunskyConjecture` was redefined to the faithful `∀ c > 0` form (parent patch #24613), the two propositions are **definitionally equal** and the implication carries no content.\n\nHistorically — before the patch — the flagship used a weaker `∃ c₀ > 0, ∀ c < c₀` form, and this lemma was a *strict* implication (take c₀ = 1) that exposed how the parent's negation axiom over-claimed by negating the weaker statement. That unsoundness has since been removed, so the lemma is now the identity.",
+    "mathContext": "$\\mathrm{grunskyConjectureFaithful} \\equiv \\mathrm{grunskyConjecture}$ (definitional after the patch); proof term `fun h => h`. Pre-patch it was the strict implication $\\text{faithful} \\Rightarrow \\text{small-}c$ via $c_0 = 1$.",
     "significance": "supporting",
     "relatedConcepts": [
+      "Definitional equality",
       "Logical implication",
-      "Quantifier restriction",
       "Axiom integrity"
     ],
     "prerequisites": []
@@ -43,13 +85,13 @@
     "id": "ann-e1047-oq02-negation-theorem",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 96,
-      "endLine": 100
+      "startLine": 83,
+      "endLine": 92
     },
     "type": "theorem",
     "title": "The Corrected Axiom, as a Theorem",
-    "content": "`grunsky_false_faithful` proves the faithful Grunsky statement is FALSE — directly from the parent's `goodman_counterexample` (f = (z²+1)(z-2)² at c = 5^{3/2}/4). It destructs the counterexample to exhibit a non-convex component, contradicting convexity for all c > 0.\n\nThe key point: the negation needs **no standalone axiom**. Only `goodman_counterexample` — the single genuine analytic input — remains as an assumption, so this isolates a patch dropping the parent's axiom count from 2 to 1.",
-    "mathContext": "From $\\exists z_0,\\ z_0 \\in$ Goodman component $\\wedge\\ \\neg\\text{convex}$, derive $\\neg\\text{grunskyConjectureFaithful}$. Negation is a deduction, not an axiom.",
+    "content": "`grunsky_false_faithful : ¬grunskyConjectureFaithful` proves the faithful Grunsky statement is FALSE — directly from the parent's `goodman_counterexample` (f = (z²+1)(z-2)² at c = 5^{3/2}/4). It destructs the counterexample to exhibit a non-convex component, contradicting convexity for all c > 0.\n\nThe key point: the negation needs **no standalone axiom**. Only `goodman_counterexample` — the single genuine analytic input — remains as an assumption, which is exactly what drops the parent's axiom count from 2 to 1.",
+    "mathContext": "From $\\exists z_0,\\ z_0 \\in$ Goodman component $\\wedge\\ \\neg\\text{convex}$, derive $\\neg\\mathrm{grunskyConjectureFaithful}$. The positivity side-goal for $c = 5^{3/2}/4 > 0$ is discharged by `positivity`. Negation is a deduction, not an axiom.",
     "significance": "key",
     "relatedConcepts": [
       "Goodman's counterexample",

--- a/src/data/proofs/erdos-1047-oq-02/meta.json
+++ b/src/data/proofs/erdos-1047-oq-02/meta.json
@@ -58,7 +58,8 @@
       "**The small-c statement is TRUE:** for fixed monic f, as c → 0 each component is a disk |z − r| ≤ c'^{1/k} around a root r — hence convex. So negating it (the parent axiom) is unsound.",
       "**The genuine counterexamples live at non-small c:** Pommerenke/Goodman non-convexity occurs at specific critical values, not as c → 0 — which is exactly why the faithful ∀-c statement is the right target.",
       "**Axiom integrity:** the only real assumption is goodman_counterexample; the conjecture's falsity is a deduction, not a posited axiom.",
-      "**Reduction in assumptions (applied):** the parent patch (PR #24613) dropped the flagship's axiom count from 2 to 1 — only goodman_counterexample remains."
+      "**Reduction in assumptions (applied):** the parent patch (PR #24613) dropped the flagship's axiom count from 2 to 1 — only goodman_counterexample remains.",
+      "**Where the non-convexity lives:** for Goodman's f = (z²+1)(z-2)², the critical value c = 5^{3/2}/4 is exactly |f| at the saddle points (1±i)/2 (the roots of f'/(2(z-2)) = 2z²-2z+1); at that level two lemniscate components merge and the joined component fails to be convex — confirming non-convexity is a non-small-c, saddle-driven phenomenon, not a c → 0 effect."
     ],
     "prerequisites": [
       "Polynomial lemniscates and sublevel sets",


### PR DESCRIPTION
## Enrichment pass — `erdos-1047-oq-02` (Soundness of the Grunsky-Conjecture Axiom)

Corrects a stale annotation that contradicted the Lean source, fixes drifted line ranges, and deepens coverage. **Gallery data only — no `.lean` changes.**

### Correctness fix
The `faithful_imp_grunsky` annotation still carried the **pre-patch** "Faithful Implies Small-c (Strictly Stronger), take c₀ = 1" framing. But the Lean source proves it as `fun h => h` — the **identity** — because parent patch #24613 redefined the flagship's `grunskyConjecture` to the faithful `∀ c > 0` form, making the two definitionally equal. The `meta.json` `sections` block already reflected this; the annotation did not. Reworded to match the code, keeping the historical pre-patch note as context.

### Other improvements
- **Re-anchored all annotation line ranges** to the current 94-line source (the old ranges included `96–100`, past EOF).
- **Expanded 3 → 5 annotations**: added a `concept` block for the integrity problem (the unsound small-c axiom) and a `context` block for the applied parent patch (axiomCount 2 → 1).
- **Added a 5th `keyInsight`** on the saddle geometry: c = 5^{3/2}/4 is exactly |f| at the saddles (1±i)/2 of f = (z²+1)(z−2)², so the non-convexity is a non-small-c, saddle-driven phenomenon.

### Notes
- JSON validated for both files.
- No `loom:review-requested` (math/enrichment PR; deployer merges directly).