### PR TITLE
audit: correct theoremCount for sqrt-sum and spherical-law entries

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03/meta.json
@@ -33,7 +33,7 @@
       "dual_law_cross_product_form: the dual law expressed via scalar triple products and cross-product norms",
       "dual_law_polar_form: the polar-triangle duality made explicit — the dual law of a spherical triangle is the side law of its polar triangle (polar vertices u×v, v×w, w×u)"
     ],
-    "theoremCount": 28,
+    "theoremCount": 26,
     "definitionCount": 3
   },
   "overview": {

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axioms. Uses Mathlib's integral-closure API — IsIntegral.add, isIntegral_algebraMap_iff, IsIntegrallyClosed.isIntegral_iff (ℤ integrally closed in ℚ), Polynomial.monic_X_pow_sub_C, Real.sq_sqrt, Real.lt_sqrt, Real.sqrt_lt'.",
     "lineCount": 113,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
       "irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7: √2 + √3 + √5 + √7 is irrational, proved via Strategy D (algebraic integer trapped in (8,9)) rather than the iterated-squaring / degree-16 minimal-polynomial route",
@@ -65,7 +65,7 @@
     "namespace": "Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01",
     "lineCount": 113,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the three never-audited gallery entries. Two had `theoremCount` metadata that did not match their Lean sources. **No status/badge overclaiming** — both entries are otherwise accurate.

### Findings & Fixes

**`sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01`** (`verified`/`original`)
- Source `Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean` has **10** `theorem` declarations; meta claimed **8** (in both `meta` and `leanFile` blocks). Fixed 8 → 10.
- Verified clean: 0 sorries, 0 axioms, 0 `True` stubs. `verified/original` is defensible — the main theorem assembles original lemmas (Strategy D criterion + interval trapping) over standard Mathlib integral-closure infrastructure, which is fully disclosed in the `assumptions` field.

**`spherical-law-of-cosines-oq-03`** (`formalized`/`wip`)
- Source has **26** `theorem` declarations; meta claimed **28**. Fixed 28 → 26.
- `definitionCount` (3) already correct — counts `def` only (3 defs; the 1 `structure` is excluded, per convention).
- Verified clean: 0 sorries, 0 axioms, 0 `True` stubs; honestly labeled `formalized/wip` with a build-pending disclosure.

### Also audited (clean, no changes)
- **`pascals-hexagon-oq-02`** (`axiomatized`/`axiom`): all counts match source (0 sorries, 1 inherited axiom `conic_implies_pascal_constraint`, 7 theorems, 7 defs, 199 lines). `brianchon_theorem`'s dependency chain routes through `pascal_hexagon_theorem` → the inherited axiom only, **not** the unrelated `sorry` later in the parent file.

---
Discovered during gallery integrity audit. Metadata-only changes (LOW severity: count mismatch, no credibility risk).