### PR TITLE
research(greens-oq-02-oq-02): land orientation fix in registered files, kill the false greens_theorem_l1curl axiom

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ02.lean
@@ -369,8 +369,16 @@ axiom greens_theorem_l1curl
                   deriv (fun y => P (p.1, y)) p.2)
     -- L¹ integrability of the curl over the domain
     (hL1 : IntegrableOn curlF (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    -- The curve traverses the rectangle boundary counterclockwise
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d)) :
+    -- The curve traverses the rectangle boundary
+    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
+    -- ORIENTATION: the curve's circulation equals the concretely (counterclockwise)
+    -- oriented four-edge rectangle integral. Without this, `hTraversal` (mere
+    -- image-containment in the frontier) constrains neither orientation, winding,
+    -- nor non-degeneracy, and the statement is FALSE: the constant curve γ ≡ (0,0)
+    -- with P = 0, Q(x,y) = x (curl ≡ 1) satisfies every other hypothesis yet has
+    -- circulation 0 ≠ 1 = ∬ curl. See `GreensTheoremOQ02Counterexample`.
+    (hLineEq : lipschitzLineIntegral P Q C =
+        GreensTheoremOQ01.rectLineIntegral P Q a b c d) :
     lipschitzLineIntegral P Q C =
     ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, curlF p ∂volume
 
@@ -393,10 +401,12 @@ theorem lineIntegral_zero_curl
     (hCurlZeroAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
         deriv (fun x => Q (x, p.2)) p.1 = deriv (fun y => P (p.1, y)) p.2)
     (hL1 : IntegrableOn (fun _ => (0 : ℝ)) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d)) :
+    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
+    (hLineEq : lipschitzLineIntegral P Q C =
+        GreensTheoremOQ01.rectLineIntegral P Q a b c d) :
     lipschitzLineIntegral P Q C = 0 := by
   have h := greens_theorem_l1curl C P Q (fun _ => 0) a b c d hab hcd
-    (by filter_upwards [hCurlZeroAE] with p hp; simp [hp]) hL1 hTraversal
+    (by filter_upwards [hCurlZeroAE] with p hp; simp [hp]) hL1 hTraversal hLineEq
   simp at h
   exact h
 
@@ -414,11 +424,13 @@ theorem lineIntegral_l1curl_smul
                   deriv (fun y => P (p.1, y)) p.2)
     (hL1 : IntegrableOn curlF (Set.Icc a b ×ˢ Set.Icc c d) volume)
     (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
+    (hLineEq : lipschitzLineIntegral P Q C =
+        GreensTheoremOQ01.rectLineIntegral P Q a b c d)
     (k : ℝ) :
     lipschitzLineIntegral (fun p => k * P p) (fun p => k * Q p) C =
     k * ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, curlF p ∂volume := by
   rw [lineIntegral_smul]
-  rw [greens_theorem_l1curl C P Q curlF a b c d hab hcd hCurlAE hL1 hTraversal]
+  rw [greens_theorem_l1curl C P Q curlF a b c d hab hcd hCurlAE hL1 hTraversal hLineEq]
 
 /-  **Reduction to OQ-01**: Whitney's theorem implies the rectangular FTC case.
 
@@ -440,7 +452,9 @@ theorem greens_oq1_from_l1curl
         dQdx p - dPdy p = deriv (fun x => Q (x, p.2)) p.1 -
                            deriv (fun y => P (p.1, y)) p.2)
     (hL1 : IntegrableOn (fun p => dQdx p - dPdy p) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d)) :
+    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
+    (hLineEq : lipschitzLineIntegral P Q C =
+        GreensTheoremOQ01.rectLineIntegral P Q a b c d) :
     lipschitzLineIntegral P Q C =
     ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, (dQdx p - dPdy p) ∂volume := by
   apply greens_theorem_l1curl C P Q (fun p => dQdx p - dPdy p) a b c d hab hcd
@@ -448,6 +462,7 @@ theorem greens_oq1_from_l1curl
     exact hp
   · exact hL1
   · exact hTraversal
+  · exact hLineEq
 
 /- 
 ## Part V: Example — The Unit Circle Boundary

--- a/proofs/Proofs/GreensTheoremOQ02Corrected.lean
+++ b/proofs/Proofs/GreensTheoremOQ02Corrected.lean
@@ -1,44 +1,34 @@
 /-
-# Green's theorem OQ-02-OQ-02 — CORRECTED axiom (orientation-fixed)
+# Green's theorem OQ-02-OQ-02 — soundness witness for the orientation fix
 
 `greens-theorem-oq-02-murakami` sibling: `greens-theorem-oq-02-oq-02`.
 
-## Why this file exists
+## Status
 
-Session 5 (`GreensTheoremOQ02Counterexample.lean`) proved that the registered
-axiom `GreensTheoremOQ02.greens_theorem_l1curl` is **FALSE as stated**: the only
-curve↔rectangle hypothesis `hTraversal` is image-containment in the frontier,
-which constrains neither orientation nor winding nor non-degeneracy.  The
-degenerate constant curve `γ ≡ (0,0)` with `P = 0, Q(x,y) = x` (curl ≡ 1)
-satisfies every hypothesis yet has line integral `0` while `∬ curl = 1`, forcing
-`0 = 1` (`greens_theorem_l1curl_refuted`).
-
-The fix (identified in the problem `nextSteps`) is to add ONE orientation
-hypothesis tying the curve's line integral to the concrete, correctly-oriented
-four-edge rectangle integral `GreensTheoremOQ01.rectLineIntegral`:
+The orientation correction this file originally prototyped is now **landed in the
+registered files**: `GreensTheoremOQ02.greens_theorem_l1curl` and its consumers
+(both in `GreensTheoremOQ02.lean` and `GreensTheoremOQ02OQ04.lean`) now carry the
+extra orientation hypothesis
 
     hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d
 
-This file states the CORRECTED axiom `greens_theorem_l1curl_oriented` and
-re-proves the full downstream blast radius — the three consumers in
-`GreensTheoremOQ02.lean` (`lineIntegral_zero_curl`, `lineIntegral_l1curl_smul`,
-`greens_oq1_from_l1curl`) and the two in `GreensTheoremOQ02OQ04.lean`
-(`greens_stokes_l1curl`, `closed_l1form_zero_integral`) — each with `hLineEq`
-threaded through.  Every consumer proof is the original verbatim plus the single
-extra `hLineEq` argument, so this is a pure signature-threading correction.
+tying the curve's circulation to the concrete, counterclockwise four-edge
+rectangle integral `GreensTheoremOQ01.rectLineIntegral`.  The previously separate
+`…_oriented` re-proofs in this file have therefore been deleted — they are now
+identical to the registered declarations.
 
-It also proves `counterexample_violates_hLineEq`: the Session-5 unsound witness
-fails the new orientation hypothesis (its `lipschitzLineIntegral = 0` but its
-`rectLineIntegral = 1`, by the *proven* `unit_square_area_as_line_integral`),
-so the corrected axiom is vacuously inapplicable to it — the unsoundness is
-genuinely removed, not merely hidden.
+## Why this file remains
 
-UNREGISTERED, build-pending (authored under a Docker + Aristotle blackout).  This
-is intentionally a separate, isolated file: the registered files are NOT edited
-here, because a 6-consumer signature change across two registered files cannot be
-build-verified under the blackout and must land as a single Docker-checked patch.
-Once Docker returns, port `…_oriented` back onto the registered declarations
-(drop the `_oriented` suffix) and delete this file.
+It keeps the **soundness witness** `counterexample_violates_hLineEq`: the
+Session-5 unsound witness (constant curve `γ ≡ (0,0)` with field `(0, x)`, curl
+`≡ 1`) does NOT satisfy the new orientation hypothesis.  Its circulation is `0`
+(`constCurve_lineIntegral_zero`) while its four-edge rectangle integral is `1`
+(the *proven* `unit_square_area_as_line_integral`).  Hence the corrected axiom is
+vacuously inapplicable to it — the original `0 = 1` unsoundness is genuinely
+removed by the new hypothesis, not merely hidden.
+
+This is the converse-facing check that the registered fix actually excludes the
+known counterexample.
 -/
 import Mathlib
 import Proofs.GreensTheoremOQ02OQ04
@@ -47,168 +37,22 @@ import Proofs.GreensTheoremOQ02Counterexample
 open MeasureTheory
 open GreensTheoremOQ01 (rectLineIntegral)
 open GreensTheoremOQ02
-open GreensTheoremOQ02OQ04 (OneForm2D extDeriv1_2D)
 open GreensTheoremOQ02Counterexample (constCurve cexP cexQ constCurve_lineIntegral_zero)
 
 namespace GreensTheoremOQ02Corrected
 
-/-- **Whitney's theorem, orientation-corrected.**  Same as the registered
-`greens_theorem_l1curl` but with the extra hypothesis `hLineEq` fixing the
-boundary orientation: the curve's line integral equals the concrete four-edge
-rectangle integral `rectLineIntegral P Q a b c d` (OQ-01).  This excludes the
-degenerate / wrongly-oriented curves that make the original statement false. -/
-axiom greens_theorem_l1curl_oriented
-    (C : LipschitzClosedCurve)
-    (P Q : ℝ × ℝ → ℝ)
-    (curlF : ℝ × ℝ → ℝ)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hCurlAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        curlF p = deriv (fun x => Q (x, p.2)) p.1 -
-                  deriv (fun y => P (p.1, y)) p.2)
-    (hL1 : IntegrableOn curlF (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d) :
-    lipschitzLineIntegral P Q C =
-    ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, curlF p ∂volume
-
-/-- Consumer 1 (was `lineIntegral_zero_curl`): zero curl ⟹ zero circulation,
-now requiring the orientation hypothesis. -/
-theorem lineIntegral_zero_curl_oriented
-    (C : LipschitzClosedCurve)
-    (P Q : ℝ × ℝ → ℝ)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hCurlZeroAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        deriv (fun x => Q (x, p.2)) p.1 = deriv (fun y => P (p.1, y)) p.2)
-    (hL1 : IntegrableOn (fun _ => (0 : ℝ)) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d) :
-    lipschitzLineIntegral P Q C = 0 := by
-  have h := greens_theorem_l1curl_oriented C P Q (fun _ => 0) a b c d hab hcd
-    (by filter_upwards [hCurlZeroAE] with p hp; simp [hp]) hL1 hTraversal hLineEq
-  simp at h
-  exact h
-
-/-- Consumer 2 (was `lineIntegral_l1curl_smul`): scaling invariance, now
-requiring the orientation hypothesis. -/
-theorem lineIntegral_l1curl_smul_oriented
-    (C : LipschitzClosedCurve)
-    (P Q : ℝ × ℝ → ℝ)
-    (curlF : ℝ × ℝ → ℝ)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hCurlAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        curlF p = deriv (fun x => Q (x, p.2)) p.1 -
-                  deriv (fun y => P (p.1, y)) p.2)
-    (hL1 : IntegrableOn curlF (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d)
-    (k : ℝ) :
-    lipschitzLineIntegral (fun p => k * P p) (fun p => k * Q p) C =
-    k * ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, curlF p ∂volume := by
-  rw [lineIntegral_smul]
-  rw [greens_theorem_l1curl_oriented C P Q curlF a b c d hab hcd hCurlAE hL1 hTraversal hLineEq]
-
-/-- Consumer 3 (was `greens_oq1_from_l1curl`): reduction to the OQ-01 / C¹ case,
-now requiring the orientation hypothesis. -/
-theorem greens_oq1_from_l1curl_oriented
-    (P Q dQdx dPdy : ℝ × ℝ → ℝ) (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (C : LipschitzClosedCurve)
-    (hQ_ae : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        HasDerivAt (fun x => Q (x, p.2)) (dQdx p) p.1)
-    (hP_ae : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        HasDerivAt (fun y => P (p.1, y)) (dPdy p) p.2)
-    (hCurlAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        dQdx p - dPdy p = deriv (fun x => Q (x, p.2)) p.1 -
-                           deriv (fun y => P (p.1, y)) p.2)
-    (hL1 : IntegrableOn (fun p => dQdx p - dPdy p) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d) :
-    lipschitzLineIntegral P Q C =
-    ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, (dQdx p - dPdy p) ∂volume := by
-  apply greens_theorem_l1curl_oriented C P Q (fun p => dQdx p - dPdy p) a b c d hab hcd
-  · filter_upwards [hCurlAE] with p hp
-    exact hp
-  · exact hL1
-  · exact hTraversal
-  · exact hLineEq
-
-/-- Consumer 4 (was `GreensTheoremOQ02OQ04.greens_stokes_l1curl`): Stokes form,
-now requiring the orientation hypothesis. -/
-theorem greens_stokes_l1curl_oriented
-    (C : LipschitzClosedCurve)
-    (ω : OneForm2D)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hL1 : IntegrableOn (extDeriv1_2D ω) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral ω.P ω.Q C = rectLineIntegral ω.P ω.Q a b c d) :
-    lipschitzLineIntegral ω.P ω.Q C =
-    ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, extDeriv1_2D ω p ∂volume := by
-  simp only [extDeriv1_2D]
-  exact greens_theorem_l1curl_oriented C ω.P ω.Q
-    (fun p => deriv (fun x => ω.Q (x, p.2)) p.1 - deriv (fun y => ω.P (p.1, y)) p.2)
-    a b c d hab hcd (by filter_upwards [] with p; rfl) hL1 hTraversal hLineEq
-
-/-- Consumer 5 (was `GreensTheoremOQ02OQ04.closed_l1form_zero_integral`):
-Cauchy-Goursat for L¹-closed forms, now requiring the orientation hypothesis. -/
-theorem closed_l1form_zero_integral_oriented
-    (C : LipschitzClosedCurve)
-    (ω : OneForm2D)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hClosedAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-        extDeriv1_2D ω p = 0)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral ω.P ω.Q C = rectLineIntegral ω.P ω.Q a b c d) :
-    lipschitzLineIntegral ω.P ω.Q C = 0 := by
-  have hCurlZeroAE : ∀ᵐ p ∂(volume.restrict (Set.Ioo a b ×ˢ Set.Ioo c d)),
-      deriv (fun x => ω.Q (x, p.2)) p.1 = deriv (fun y => ω.P (p.1, y)) p.2 := by
-    filter_upwards [hClosedAE] with p hp
-    simp only [extDeriv1_2D] at hp; linarith
-  exact lineIntegral_zero_curl_oriented C ω.P ω.Q a b c d hab hcd hCurlZeroAE
-    integrableOn_const hTraversal hLineEq
-
-/-- **Soundness check.**  The Session-5 unsound witness (constant curve + `(0,x)`
-field) does NOT satisfy the new orientation hypothesis `hLineEq`: its line
-integral is `0` (`constCurve_lineIntegral_zero`) while its four-edge rectangle
+/-- **Soundness check for the registered orientation fix.**  The Session-5 unsound
+witness (constant curve + `(0, x)` field) does NOT satisfy the orientation
+hypothesis `hLineEq` now carried by the registered `greens_theorem_l1curl`: its
+circulation is `0` (`constCurve_lineIntegral_zero`) while its four-edge rectangle
 integral is `1` (the *proven* `unit_square_area_as_line_integral`).  Hence the
 corrected axiom is vacuously inapplicable to it — the `0 = 1` unsoundness is
 removed, not hidden. -/
 theorem counterexample_violates_hLineEq :
     lipschitzLineIntegral cexP cexQ constCurve ≠ rectLineIntegral cexP cexQ 0 1 0 1 := by
-  have hrect : rectLineIntegral cexP cexQ 0 1 0 1 = 1 := by
-    simp only [cexP, cexQ]
-    exact GreensTheoremOQ01.unit_square_area_as_line_integral
+  have hrect : rectLineIntegral cexP cexQ 0 1 0 1 = 1 :=
+    GreensTheoremOQ01.unit_square_area_as_line_integral
   rw [constCurve_lineIntegral_zero, hrect]
   norm_num
-
-/-- Consumer 7 (was `GreensTheoremOQ02OQ04.c1_stokes_from_whitney`): the C¹
-flagship, now requiring the orientation hypothesis.  The S5 counterexample
-(`ω = (0, x)`, constant corner curve) gives `lipschitzLineIntegral = 0 ≠ 1 = ∫∫`,
-refuting the un-oriented form; `hLineEq` excludes it.  Direct analogue of
-consumers 1–6, calling `greens_stokes_l1curl_oriented`. -/
-theorem c1_stokes_from_whitney_oriented
-    (C : LipschitzClosedCurve)
-    (ω : OneForm2D) (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hQ_cont : Continuous (fun p : ℝ × ℝ => deriv (fun x => ω.Q (x, p.2)) p.1))
-    (hP_cont : Continuous (fun p : ℝ × ℝ => deriv (fun y => ω.P (p.1, y)) p.2))
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral ω.P ω.Q C = rectLineIntegral ω.P ω.Q a b c d) :
-    lipschitzLineIntegral ω.P ω.Q C =
-    ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, extDeriv1_2D ω p ∂volume :=
-  greens_stokes_l1curl_oriented C ω a b c d hab hcd
-    (c1_form_l1_integrable ω a b c d hQ_cont hP_cont) hTraversal hLineEq
-
-/-- Consumer 8 (was `GreensTheoremOQ02OQ04.stokes_scaling`): linearity, now
-oriented (`hLineEq` on the unscaled form).  Mirrors the original proof's
-`rw [lineIntegral_smul]` then the oriented Stokes rewrite. -/
-theorem stokes_scaling_oriented
-    (C : LipschitzClosedCurve)
-    (ω : OneForm2D) (k : ℝ)
-    (a b c d : ℝ) (hab : a < b) (hcd : c < d)
-    (hL1 : IntegrableOn (extDeriv1_2D ω) (Set.Icc a b ×ˢ Set.Icc c d) volume)
-    (hTraversal : ∀ t ∈ Set.Icc 0 C.T, C.γ t ∈ frontier (Set.Icc a b ×ˢ Set.Icc c d))
-    (hLineEq : lipschitzLineIntegral ω.P ω.Q C = rectLineIntegral ω.P ω.Q a b c d) :
-    lipschitzLineIntegral (fun p => k * ω.P p) (fun p => k * ω.Q p) C =
-    k * ∫ p in Set.Ioo a b ×ˢ Set.Ioo c d, extDeriv1_2D ω p ∂volume := by
-  rw [lineIntegral_smul]
-  rw [greens_stokes_l1curl_oriented C ω a b c d hab hcd hL1 hTraversal hLineEq]
 
 end GreensTheoremOQ02Corrected

--- a/proofs/Proofs/GreensTheoremOQ02Counterexample.lean
+++ b/proofs/Proofs/GreensTheoremOQ02Counterexample.lean
@@ -1,17 +1,20 @@
 /-
-  Counterexample: `greens_theorem_l1curl` is FALSE as currently stated
+  Counterexample data for the (now corrected) `greens_theorem_l1curl`
   ====================================================================
 
   Open question: greens-theorem-oq-02-oq-02
   Main file:     proofs/Proofs/GreensTheoremOQ02.lean  (axiom at line ~361)
 
-  STATUS: build-pending, UNREGISTERED (Docker verification blackout 2026-06-15).
-  This file is NOT added to the gallery / lakefile registration; it is an
-  artifact documenting an integrity defect in the stated axiom, to be
-  compile-checked when Docker is restored.
+  STATUS (2026-06-15, S10): the axiom has been CORRECTED. The registered
+  `greens_theorem_l1curl` now carries the orientation hypothesis
+  `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`, so the
+  degenerate-curve counterexample below no longer refutes it — instead it FAILS
+  `hLineEq` (see `GreensTheoremOQ02Corrected.counterexample_violates_hLineEq`).
+  This file is still UNREGISTERED (not in Proofs.lean); it supplies the
+  counterexample data the soundness witness consumes.
 
   ----------------------------------------------------------------------
-  The finding
+  The original finding (motivation for the fix)
   ----------------------------------------------------------------------
   Five prior research sessions reduced the discharge of `greens_theorem_l1curl`
   to a SINGLE upstream keystone — the function-level FTC for absolutely
@@ -75,10 +78,9 @@ noncomputable def constCurve : LipschitzClosedCurve where
   hLip := LipschitzWith.const _
   isClosed := rfl
 
-/-- The counterexample vector field: `P = 0`, `Q(x,y) = x`, with curl `≡ 1`. -/
+/-- The counterexample vector field: `P = 0`, `Q(x,y) = x` (curl `≡ 1`). -/
 noncomputable def cexP : ℝ × ℝ → ℝ := fun _ => 0
 noncomputable def cexQ : ℝ × ℝ → ℝ := fun p => p.1
-noncomputable def cexCurl : ℝ × ℝ → ℝ := fun _ => 1
 
 /-- The line integral over the degenerate (zero-velocity) curve vanishes: the
     derivatives of both constant coordinate functions are 0, so the integrand
@@ -101,41 +103,19 @@ theorem constCurve_hTraversal :
   · rw [frontier_Icc (by norm_num : (0 : ℝ) ≤ 1)]
     exact Set.mem_insert _ _
 
-/-- `hCurlAE` is satisfied (in fact the curl identity holds everywhere, not
-    just a.e.): `∂Q/∂x = 1` and `∂P/∂y = 0`. -/
-theorem cex_hCurlAE :
-    ∀ᵐ p ∂(volume.restrict (Set.Ioo (0 : ℝ) 1 ×ˢ Set.Ioo (0 : ℝ) 1)),
-      cexCurl p = deriv (fun x => cexQ (x, p.2)) p.1 -
-                  deriv (fun y => cexP (p.1, y)) p.2 := by
-  refine ae_of_all _ (fun p => ?_)
-  simp only [cexCurl, cexQ, cexP, deriv_id'']
-  rw [deriv_const]
-  norm_num
-
-/-- `hL1` is satisfied: the curl is the constant `1` on the compact rectangle,
-    which has finite measure. -/
-theorem cex_hL1 :
-    IntegrableOn cexCurl (Set.Icc (0 : ℝ) 1 ×ˢ Set.Icc (0 : ℝ) 1) volume := by
-  apply integrableOn_const.mpr
-  exact Or.inr (isCompact_Icc.prod isCompact_Icc).measure_lt_top
-
-/-- The double integral of the (unit) curl over the open square is its area,
-    `1` — nonzero, unlike the line integral. -/
-theorem cexCurl_double_integral :
-    (∫ p in Set.Ioo (0 : ℝ) 1 ×ˢ Set.Ioo (0 : ℝ) 1, cexCurl p ∂volume) = 1 := by
-  have hvol : volume (Set.Ioo (0 : ℝ) 1 ×ˢ Set.Ioo (0 : ℝ) 1) = 1 := by
-    rw [volume_eq_prod ℝ ℝ, Measure.prod_prod, Real.volume_Ioo, Real.volume_Ioo]
-    norm_num
-  simp [cexCurl, setIntegral_const, hvol]
-
-/-- **Refutation.** The axiom `greens_theorem_l1curl`, applied to the degenerate
-    constant curve and the curl-1 field above (all of whose hypotheses are
-    discharged), forces `0 = 1`. Hence the axiom as currently stated in
-    `GreensTheoremOQ02.lean` is FALSE: `hTraversal` is too weak. -/
-theorem greens_theorem_l1curl_refuted : (0 : ℝ) = 1 := by
-  have hkey := greens_theorem_l1curl constCurve cexP cexQ cexCurl 0 1 0 1
-      (by norm_num) (by norm_num) cex_hCurlAE cex_hL1 constCurve_hTraversal
-  rw [constCurve_lineIntegral_zero, cexCurl_double_integral] at hkey
-  exact hkey
+/-
+  Historical note. Earlier revisions of this file also carried
+  `greens_theorem_l1curl_refuted : (0 : ℝ) = 1`, which fed this degenerate curve
+  and the curl-1 field into the THEN-unsound axiom to force `0 = 1` (the finding
+  that motivated the fix; see PR #24381). That theorem can no longer be stated:
+  the registered axiom now requires the orientation hypothesis
+  `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`, and this
+  curve cannot satisfy it. The replacement is the soundness witness
+  `GreensTheoremOQ02Corrected.counterexample_violates_hLineEq`, which proves
+  exactly that `hLineEq` fails here — so the corrected axiom is vacuously
+  inapplicable to the counterexample. The supporting facts above
+  (`constCurve_lineIntegral_zero`, `constCurve_hTraversal`) remain the data that
+  witness consumes.
+-/
 
 end GreensTheoremOQ02Counterexample

--- a/proofs/Proofs/GreensTheoremOQ02OQ04.lean
+++ b/proofs/Proofs/GreensTheoremOQ02OQ04.lean
@@ -129,14 +129,17 @@ theorem greens_stokes_l1curl
     (hL1 : IntegrableOn (extDeriv1_2D ω) (Icc a b ×ˢ Icc c d) volume)
     -- C traverses the rectangle boundary
     (hTraversal : ∀ t ∈ Icc 0 C.T,
-        C.γ t ∈ frontier (Icc a b ×ˢ Icc c d)) :
+        C.γ t ∈ frontier (Icc a b ×ˢ Icc c d))
+    -- Orientation: circulation equals the counterclockwise four-edge rectangle integral
+    (hLineEq : lipschitzLineIntegral ω.P ω.Q C =
+        GreensTheoremOQ01.rectLineIntegral ω.P ω.Q a b c d) :
     -- **Stokes: ∫_C ω = ∫_D dω**
     lipschitzLineIntegral ω.P ω.Q C =
     ∫ p in Ioo a b ×ˢ Ioo c d, extDeriv1_2D ω p ∂volume := by
   simp only [extDeriv1_2D]
   exact greens_theorem_l1curl C ω.P ω.Q
     (fun p => deriv (fun x => ω.Q (x, p.2)) p.1 - deriv (fun y => ω.P (p.1, y)) p.2)
-    a b c d hab hcd (by filter_upwards [] with p; rfl) hL1 hTraversal
+    a b c d hab hcd (by filter_upwards [] with p; rfl) hL1 hTraversal hLineEq
 
 -- ============================================================================
 -- Part IV: L¹-Closed Forms Have Zero Line Integral (Cauchy-Goursat)
@@ -159,14 +162,16 @@ theorem closed_l1form_zero_integral
     (hClosedAE : ∀ᵐ p ∂(volume.restrict (Ioo a b ×ˢ Ioo c d)),
         extDeriv1_2D ω p = 0)
     (hTraversal : ∀ t ∈ Icc 0 C.T,
-        C.γ t ∈ frontier (Icc a b ×ˢ Icc c d)) :
+        C.γ t ∈ frontier (Icc a b ×ˢ Icc c d))
+    (hLineEq : lipschitzLineIntegral ω.P ω.Q C =
+        GreensTheoremOQ01.rectLineIntegral ω.P ω.Q a b c d) :
     lipschitzLineIntegral ω.P ω.Q C = 0 := by
   have hCurlZeroAE : ∀ᵐ p ∂(volume.restrict (Ioo a b ×ˢ Ioo c d)),
       deriv (fun x => ω.Q (x, p.2)) p.1 = deriv (fun y => ω.P (p.1, y)) p.2 := by
     filter_upwards [hClosedAE] with p hp
     simp only [extDeriv1_2D] at hp; linarith
   exact lineIntegral_zero_curl C ω.P ω.Q a b c d hab hcd hCurlZeroAE
-    integrableOn_const hTraversal
+    integrableOn_zero hTraversal hLineEq
 
 -- ============================================================================
 -- Part V: C¹ Forms Automatically Satisfy Whitney's L¹ Conditions
@@ -185,9 +190,8 @@ theorem c1_form_l1_integrable
     (hQ_cont : Continuous (fun p : ℝ × ℝ => deriv (fun x => ω.Q (x, p.2)) p.1))
     (hP_cont : Continuous (fun p : ℝ × ℝ => deriv (fun y => ω.P (p.1, y)) p.2)) :
     IntegrableOn (extDeriv1_2D ω) (Icc a b ×ˢ Icc c d) volume := by
-  have hcurl_cont : Continuous (extDeriv1_2D ω) := by
-    simp only [extDeriv1_2D]; exact hQ_cont.sub hP_cont
-  exact hcurl_cont.continuousOn.integrableOn_compact isCompact_Icc
+  have hcurl_cont : Continuous (extDeriv1_2D ω) := hQ_cont.sub hP_cont
+  exact hcurl_cont.continuousOn.integrableOn_compact (isCompact_Icc.prod isCompact_Icc)
 
 /-- **C¹ forms satisfy all of Whitney's hypotheses** for `greens_stokes_l1curl`.
 
@@ -214,11 +218,13 @@ theorem c1_stokes_from_whitney
     (ω : OneForm2D) (a b c d : ℝ) (hab : a < b) (hcd : c < d)
     (hQ_cont : Continuous (fun p : ℝ × ℝ => deriv (fun x => ω.Q (x, p.2)) p.1))
     (hP_cont : Continuous (fun p : ℝ × ℝ => deriv (fun y => ω.P (p.1, y)) p.2))
-    (hTraversal : ∀ t ∈ Icc 0 C.T, C.γ t ∈ frontier (Icc a b ×ˢ Icc c d)) :
+    (hTraversal : ∀ t ∈ Icc 0 C.T, C.γ t ∈ frontier (Icc a b ×ˢ Icc c d))
+    (hLineEq : lipschitzLineIntegral ω.P ω.Q C =
+        GreensTheoremOQ01.rectLineIntegral ω.P ω.Q a b c d) :
     lipschitzLineIntegral ω.P ω.Q C =
     ∫ p in Ioo a b ×ˢ Ioo c d, extDeriv1_2D ω p ∂volume :=
   greens_stokes_l1curl C ω a b c d hab hcd
-    (c1_form_l1_integrable ω a b c d hQ_cont hP_cont) hTraversal
+    (c1_form_l1_integrable ω a b c d hQ_cont hP_cont) hTraversal hLineEq
 
 -- ============================================================================
 -- Part VI: Scaling and Linearity
@@ -233,13 +239,15 @@ theorem stokes_scaling
     (ω : OneForm2D) (k : ℝ)
     (a b c d : ℝ) (hab : a < b) (hcd : c < d)
     (hL1 : IntegrableOn (extDeriv1_2D ω) (Icc a b ×ˢ Icc c d) volume)
-    (hTraversal : ∀ t ∈ Icc 0 C.T, C.γ t ∈ frontier (Icc a b ×ˢ Icc c d)) :
+    (hTraversal : ∀ t ∈ Icc 0 C.T, C.γ t ∈ frontier (Icc a b ×ˢ Icc c d))
+    (hLineEq : lipschitzLineIntegral ω.P ω.Q C =
+        GreensTheoremOQ01.rectLineIntegral ω.P ω.Q a b c d) :
     lipschitzLineIntegral (fun p => k * ω.P p) (fun p => k * ω.Q p) C =
     k * ∫ p in Ioo a b ×ˢ Ioo c d, extDeriv1_2D ω p ∂volume := by
   -- The line integral scales by k (by linearity of integration)
   rw [lineIntegral_smul]
   -- Apply Whitney to the unscaled form
-  rw [greens_stokes_l1curl C ω a b c d hab hcd hL1 hTraversal]
+  rw [greens_stokes_l1curl C ω a b c d hab hcd hL1 hTraversal hLineEq]
 
 /-
 ## Summary: Exterior Form Stokes Hierarchy (2026-05-06)

--- a/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
@@ -4,7 +4,9 @@
 
 **Source**: open question on `greens-theorem-oq-02` (Green's Theorem: Minimal Regularity — Lipschitz Curves and L¹ Curl)
 
-**Status**: DECIDE — **CORRECTION (2026-06-15, Session 5/researcher-4): the axiom `greens_theorem_l1curl` is FALSE as currently stated, so it cannot be discharged at all — not even after the planned Mathlib bump.** Sessions 1–4/S2 reduced the discharge to one RHS keystone (function-level FTC-for-AC, now upstream from v4.28.0) plus a Fubini reduction, and the S2 blueprint's step 4 assumed the LHS line integral could be assembled from "OQ01's boundary algebra" for free. That assumption is wrong: the ONLY hypothesis linking the abstract curve to the rectangle is `hTraversal` = image-containment in `frontier`, which encodes neither orientation, nor winding, nor non-degeneracy. A degenerate constant curve at a corner satisfies every hypothesis yet has line integral 0 while the curl's double integral is the area ≠ 0. There are therefore **two** gaps, not one: (a) the FTC-for-AC keystone (resolved upstream, needs the bump), AND (b) a curve→boundary orientation reduction that `hTraversal` does not support and that the bump does not address. The axiom's hypotheses must be strengthened before any discharge is possible. Still Docker-gated (blackout continues 2026-06-15). Build-pending counterexample committed: `proofs/Proofs/GreensTheoremOQ02Counterexample.lean` (UNREGISTERED).
+**Status**: DECIDE — **UPDATE (2026-06-15, S10/researcher-5): the orientation fix is now LANDED + Docker-VERIFIED in the registered files. The previously-FALSE `greens_theorem_l1curl` now carries the `hLineEq` orientation hypothesis (and all 7 consumers thread it), so the registered build no longer contains the unsound statement. Remaining: discharge the (now orientation-sound) axiom via the FTC-for-AC keystone, gated on the Mathlib v4.26→≥4.28 bump. See the S10 session entry at the end of this file.**
+
+**Prior status (2026-06-15, Session 5/researcher-4): the axiom `greens_theorem_l1curl` is FALSE as currently stated, so it cannot be discharged at all — not even after the planned Mathlib bump.** Sessions 1–4/S2 reduced the discharge to one RHS keystone (function-level FTC-for-AC, now upstream from v4.28.0) plus a Fubini reduction, and the S2 blueprint's step 4 assumed the LHS line integral could be assembled from "OQ01's boundary algebra" for free. That assumption is wrong: the ONLY hypothesis linking the abstract curve to the rectangle is `hTraversal` = image-containment in `frontier`, which encodes neither orientation, nor winding, nor non-degeneracy. A degenerate constant curve at a corner satisfies every hypothesis yet has line integral 0 while the curl's double integral is the area ≠ 0. There are therefore **two** gaps, not one: (a) the FTC-for-AC keystone (resolved upstream, needs the bump), AND (b) a curve→boundary orientation reduction that `hTraversal` does not support and that the bump does not address. The axiom's hypotheses must be strengthened before any discharge is possible. Still Docker-gated (blackout continues 2026-06-15). Build-pending counterexample committed: `proofs/Proofs/GreensTheoremOQ02Counterexample.lean` (UNREGISTERED).
 
 ## Summary
 
@@ -476,3 +478,67 @@ still-Docker-gated soundness step — UNCHANGED by this session; the false axiom
 2. Apply the 8-decl correction to the REGISTERED files (`GreensTheoremOQ02.lean`,
    `GreensTheoremOQ02OQ04.lean`) — eliminate the live false axiom `greens_theorem_l1curl`.
 3. Discharge the corrected axiom (C¹ from OQ01; L¹ via FTC-for-AC keystone, Mathlib-gated).
+
+## Session 2026-06-15 (S10, researcher-5) — LANDED the registered-file orientation port (Docker-VERIFIED); fixed latent build breakage
+
+**Mode**: Docker UP. Executed the deferred step 2 above and verified it.
+
+The orientation fix is now **live in the registered build**. Branch
+`research/greens-oq0202-registered-port` (off `origin/main`).
+
+### What landed
+- **`GreensTheoremOQ02.lean`**: the false `axiom greens_theorem_l1curl` now carries
+  one extra hypothesis
+  `hLineEq : lipschitzLineIntegral P Q C = GreensTheoremOQ01.rectLineIntegral P Q a b c d`,
+  and its three consumers (`lineIntegral_zero_curl`, `lineIntegral_l1curl_smul`,
+  `greens_oq1_from_l1curl`) thread it through. Each proof is verbatim + the extra arg.
+- **`GreensTheoremOQ02OQ04.lean`**: four consumers re-threaded
+  (`greens_stokes_l1curl`, `closed_l1form_zero_integral`, `c1_stokes_from_whitney`,
+  `stokes_scaling`).
+- **`GreensTheoremOQ02Corrected.lean`**: slimmed from the redundant 8-consumer
+  `_oriented` staging copy down to the single axiom-free soundness witness
+  `counterexample_violates_hLineEq` (59 lines, 0 axioms, 1 theorem). The staging
+  re-proofs were deleted — they are now identical to the registered declarations.
+
+### Latent breakage discovered + fixed (the real surprise)
+The registered `GreensTheoremOQ02OQ04.lean` had **NEVER COMPILED** — it was merged
+unbuilt during the Docker/Aristotle blackout and carried two Mathlib-incompatibility
+errors in declarations unrelated to the orientation fix:
+1. `c1_form_l1_integrable` (~L187): `simp only [extDeriv1_2D]` "made no progress" on
+   the *unapplied* `extDeriv1_2D ω` (the equation lemma only fires on the *applied*
+   `extDeriv1_2D ω p` form), and `ContinuousOn.integrableOn_compact isCompact_Icc`
+   expected product-set compactness. **Fix**: drop the simp (the goal is defeq, so
+   `hQ_cont.sub hP_cont` discharges `Continuous (extDeriv1_2D ω)` directly) and use
+   `(isCompact_Icc.prod isCompact_Icc)` for the product rectangle.
+2. `closed_l1form_zero_integral` (~L174): `integrableOn_const` for the zero curl now
+   triggers an autoParam finiteness goal (`volume (Icc a b ×ˢ Icc c d) ≠ ⊤`) that
+   `aesop` can't close. **Fix**: the zero function is integrable on any set —
+   replace with `integrableOn_zero`.
+
+LESSON: a registered file in `Proofs.lean` is NOT proof it compiles — the
+blackout-era deployer build-gate was down, so broken files landed. Always actually
+build registered files when Docker is up before trusting them. (cf. the stray-`-/`
+docstring memory and "merged broken b/c build-gate down in blackout".)
+
+### Verification
+`./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ02OQ04` →
+**Build completed successfully (7745 jobs)**, EXIT 0 — this transitively builds
+`GreensTheoremOQ01` + the corrected `GreensTheoremOQ02` + `OQ04`. The witness file
+`Proofs.GreensTheoremOQ02Corrected` built separately.
+
+### State after this session
+- Registered build: **0 false axioms here** — `greens_theorem_l1curl` is now an
+  *orientation-sound* axiom (still 1 axiom: the genuine Whitney minimal-regularity
+  input, not yet discharged). axiomCount unchanged at the assumption level (1).
+- The S6 #24424 "single Docker-verified patch" requirement is satisfied.
+- Gallery `meta.json` re-pointed to the landed state: status badge `axiom`,
+  build-verified narrative, `leanFile` counts 59ln/1thm/0ax (witness), top-level
+  axiomCount 1 (the registered axiom the result rests on).
+
+### Remaining (genuinely open)
+1. Discharge `greens_theorem_l1curl` itself via the FTC-for-AC keystone
+   (`AbsolutelyContinuousOnInterval.integral_deriv_eq_sub`, Mathlib ≥ v4.28.0,
+   PR #29508) by the Fubini reduction in "Recommended approach" above. **Gated on
+   bumping the project Mathlib pin v4.26.0 → ≥ v4.28.0** (cross-corpus rebuild risk).
+2. Register `GreensTheoremOQ02Corrected.lean` + `GreensTheoremOQ02Counterexample.lean`
+   in `Proofs.lean` so the soundness witness is machine-checked on every build.

--- a/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "greens-theorem-oq-02-oq-02",
   "title": "Green's Theorem OQ-02-OQ-02: Orientation-Corrected Minimal-Regularity Axiom",
   "slug": "greens-theorem-oq-02-oq-02",
-  "description": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posits its core as an axiom that is FALSE as stated — a degenerate constant curve satisfies every hypothesis yet forces 0 = 1. This entry states the orientation-corrected axiom (one extra hypothesis hLineEq tying the curve's circulation to the concrete four-edge rectangle integral), re-threads all five downstream consumers, and proves the original counterexample fails the new hypothesis — removing the unsoundness rather than hiding it.",
+  "description": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posited its core as an axiom that was FALSE as stated — a degenerate constant curve satisfied every hypothesis yet forced 0 = 1. The orientation fix (one extra hypothesis hLineEq tying the curve's circulation to the concrete four-edge rectangle integral) is now LANDED in the registered files: the axiom greens_theorem_l1curl and all seven downstream consumers across GreensTheoremOQ02.lean and GreensTheoremOQ02OQ04.lean carry hLineEq, and the file compiles for the first time (two pre-existing Mathlib-incompatibility build errors, latent during the Docker blackout, were also repaired). This entry retains the axiom-free soundness witness proving the original counterexample fails the new hypothesis.",
   "meta": {
     "author": "researcher agents (Lean Genius); after Whitney (1957)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
@@ -20,7 +20,7 @@
       "axiom-integrity",
       "counterexample"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,28 +40,29 @@
       }
     ],
     "originalContributions": [
-      "Orientation-corrected axiom greens_theorem_l1curl_oriented: the registered greens_theorem_l1curl plus one hypothesis hLineEq (lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d) excluding degenerate/wrongly-oriented curves",
-      "All five downstream consumers re-proved with hLineEq threaded (lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl in GreensTheoremOQ02; greens_stokes_l1curl, closed_l1form_zero_integral in GreensTheoremOQ02OQ04) — a pure signature-threading correction, each proof the original verbatim plus the extra argument",
-      "counterexample_violates_hLineEq: the Session-5 unsound witness (constant curve, P=0, Q(x,y)=x) fails the new orientation hypothesis (lipschitzLineIntegral = 0 ≠ 1 = rectLineIntegral via the proven unit_square_area_as_line_integral), so the corrected axiom is genuinely inapplicable to it"
+      "Orientation fix LANDED in the registered files: the registered axiom greens_theorem_l1curl (GreensTheoremOQ02.lean) now carries one extra hypothesis hLineEq (lipschitzLineIntegral P Q C = GreensTheoremOQ01.rectLineIntegral P Q a b c d), excluding the degenerate/wrongly-oriented curves that made the original statement false",
+      "All seven downstream consumers re-threaded with hLineEq: lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl (GreensTheoremOQ02.lean) and greens_stokes_l1curl, closed_l1form_zero_integral, c1_stokes_from_whitney, stokes_scaling (GreensTheoremOQ02OQ04.lean) — a pure signature-threading correction, each proof the original verbatim plus the extra argument",
+      "Repaired two pre-existing Mathlib-incompatibility build errors latent in GreensTheoremOQ02OQ04.lean during the Docker blackout (c1_form_l1_integrable: product-set compactness isCompact_Icc.prod isCompact_Icc + direct Continuous.sub; closed_l1form_zero_integral: integrableOn_zero for the zero curl), so the registered file machine-checks for the first time",
+      "counterexample_violates_hLineEq (axiom-free soundness witness, this entry's anchor file): the Session-5 unsound witness (constant curve, P=0, Q(x,y)=x) fails the new orientation hypothesis (lipschitzLineIntegral = 0 ≠ 1 = rectLineIntegral via the proven unit_square_area_as_line_integral), so the corrected axiom is genuinely inapplicable to it — the unsoundness is removed, not hidden"
     ],
     "axiomCount": 1,
-    "lineCount": 182,
-    "assumptions": "BUILD-PENDING / UNREGISTERED. Authored under an extended Docker + Aristotle outage; not machine-verified, and not in Proofs.lean. IMPORTANT: the REGISTERED parent file GreensTheoremOQ02.lean still carries the FALSE axiom greens_theorem_l1curl (S5 #24381, MERGED, proved it forces 0 = 1); the correction here cannot be ported back to the registered files until Docker returns, because the 6-consumer signature change across two registered files must land as a single build-verified patch (fix spec: S6 #24424, MERGED). This entry's single remaining assumption is the corrected axiom greens_theorem_l1curl_oriented (the genuine Whitney minimal-regularity input, now orientation-sound). Not claimed verified.",
+    "lineCount": 58,
+    "assumptions": "Docker-VERIFIED. The orientation fix is now landed in the registered files GreensTheoremOQ02.lean and GreensTheoremOQ02OQ04.lean (both reachable from Proofs.lean) and the build passes; two pre-existing Mathlib-incompatibility errors latent in the registered OQ04 file (merged unbuilt during the Docker + Aristotle blackout) were repaired in the same pass. The single remaining assumption is the registered axiom greens_theorem_l1curl (the genuine Whitney minimal-regularity input, now orientation-sound) — that is the 1 in axiomCount. This entry's anchor file GreensTheoremOQ02Corrected.lean is itself axiom-free (axiomCount 0 in leanFile): it holds only the soundness witness counterexample_violates_hLineEq confirming the S5 counterexample fails the new hypothesis. The corrected axiom is not claimed verified — discharging it awaits the FTC-for-absolutely-continuous-functions keystone (Mathlib >= v4.28.0, PR #29508) reducing it to OQ-01's boundary algebra by Fubini.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 1,
     "definitionCount": 0
   },
   "overview": {
     "historicalContext": "**A soundness correction to the minimal-regularity Green's theorem.**\n\nThe parent entry `greens-theorem-oq-02` formalizes Whitney's 1957 theorem — Green's theorem for a Lipschitz boundary curve and an L¹-integrable curl — by positing the core identity as `axiom greens_theorem_l1curl`. Session 5 discovered this axiom is FALSE as stated: its only curve↔rectangle hypothesis (`hTraversal`, image-containment in the frontier) constrains neither orientation nor winding nor non-degeneracy, so the degenerate constant curve γ ≡ (0,0) with P = 0, Q(x,y) = x (curl ≡ 1) satisfies every hypothesis yet has circulation 0 while ∬ curl = 1, forcing 0 = 1.",
-    "problemStatement": "**The integrity problem.** `greens_theorem_l1curl` equates a Lipschitz curve's line integral with the double integral of the curl over the rectangle, but the curve is tied to the rectangle only by frontier-containment of its image — which permits degenerate and wrongly-oriented curves. Such a curve refutes the axiom (`greens_theorem_l1curl_refuted`).\n\n**The fix.** Add ONE orientation hypothesis `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`, tying the circulation to the concrete, correctly-oriented four-edge rectangle integral (from OQ-01). The corrected axiom `greens_theorem_l1curl_oriented` is sound, and the counterexample provably fails `hLineEq`.",
+    "problemStatement": "**The integrity problem.** `greens_theorem_l1curl` equates a Lipschitz curve's line integral with the double integral of the curl over the rectangle, but the curve is tied to the rectangle only by frontier-containment of its image — which permits degenerate and wrongly-oriented curves. Such a curve refuted the original (pre-hLineEq) axiom.\n\n**The fix (landed).** Add ONE orientation hypothesis `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`, tying the circulation to the concrete, correctly-oriented four-edge rectangle integral (from OQ-01). The registered axiom `greens_theorem_l1curl` now carries `hLineEq` and is orientation-sound, and the counterexample provably fails `hLineEq`.",
     "text": "Correct the false minimal-regularity Green's-theorem axiom by adding an orientation hypothesis, re-thread all consumers, and verify the original counterexample is excluded.",
-    "proofStrategy": "**1. Corrected axiom.** `greens_theorem_l1curl_oriented` = the registered axiom plus `hLineEq` fixing the boundary orientation to `rectLineIntegral`.\n\n**2. Re-thread consumers.** All five downstream theorems (three in GreensTheoremOQ02, two in GreensTheoremOQ02OQ04) are re-proved verbatim with the single extra `hLineEq` argument passed through.\n\n**3. Excise the counterexample.** `counterexample_violates_hLineEq` shows the Session-5 unsound witness has `lipschitzLineIntegral = 0` but `rectLineIntegral = 1` (by the proven `unit_square_area_as_line_integral`), so it fails `hLineEq` and the corrected axiom does not apply to it — the unsoundness is removed, not masked.",
+    "proofStrategy": "**1. Corrected axiom (registered).** `greens_theorem_l1curl` (GreensTheoremOQ02.lean) gains `hLineEq` fixing the boundary orientation to `rectLineIntegral`.\n\n**2. Re-thread consumers.** All seven downstream theorems (three in GreensTheoremOQ02, four in GreensTheoremOQ02OQ04) are re-proved verbatim with the single extra `hLineEq` argument passed through.\n\n**3. Repair latent build errors.** Two pre-existing Mathlib-incompatibility errors in GreensTheoremOQ02OQ04.lean (product-set compactness; integrability of the zero curl) are fixed so the registered file compiles.\n\n**4. Excise the counterexample.** `counterexample_violates_hLineEq` shows the Session-5 unsound witness has `lipschitzLineIntegral = 0` but `rectLineIntegral = 1` (by the proven `unit_square_area_as_line_integral`), so it fails `hLineEq` and the corrected axiom does not apply to it — the unsoundness is removed, not masked.",
     "keyInsights": [
       "**Frontier-containment is too weak:** it pins down neither orientation nor winding nor non-degeneracy, which is exactly what lets the constant curve refute the original axiom.",
       "**One hypothesis suffices:** equating the circulation with the concrete oriented rectangle integral `rectLineIntegral` (OQ-01) restores soundness without changing any consumer's mathematics.",
       "**Excision is verified, not assumed:** the counterexample is shown to fail the new hypothesis via a proven lemma, so soundness is demonstrably regained.",
-      "**Coordinated landing required:** the fix spans two registered files and six consumers, so it must be ported as a single Docker-verified patch — hence this isolated, unregistered staging file.",
-      "**Orientation-soundness is necessary, not sufficient:** hLineEq removes the false counterexamples, but greens_theorem_l1curl_oriented remains an axiom — the genuine Whitney minimal-regularity content is still assumed. A fully verified proof awaits the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0), which would reduce it to OQ-01's boundary algebra by Fubini."
+      "**Coordinated landing achieved:** the fix spans two registered files and seven consumers, landed here as a single Docker-verified patch that also repaired two latent build errors which had kept the registered OQ04 file from compiling since the blackout.",
+      "**Orientation-soundness is necessary, not sufficient:** hLineEq removes the false counterexamples, but greens_theorem_l1curl remains an axiom — the genuine Whitney minimal-regularity content is still assumed. A fully verified proof awaits the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0), which would reduce it to OQ-01's boundary algebra by Fubini."
     ],
     "prerequisites": [
       "Green's theorem / Stokes' theorem in the plane",
@@ -72,36 +73,28 @@
   },
   "sections": [
     {
-      "id": "corrected-axiom",
-      "title": "The Orientation-Corrected Axiom",
-      "summary": "greens_theorem_l1curl_oriented: registered axiom plus the hLineEq orientation hypothesis",
-      "startLine": 60,
-      "endLine": 72,
-      "mathContext": "Adds $h_{\\\\text{LineEq}}: \\\\oint_C (P\\\\,dx + Q\\\\,dy) = \\\\text{rectLineIntegral}\\\\,P\\\\,Q\\\\,a\\\\,b\\\\,c\\\\,d$, fixing the boundary orientation so the circulation equals the concrete four-edge rectangle integral."
+      "id": "registered-fix",
+      "title": "The Orientation Fix (Landed in the Registered Files)",
+      "summary": "The header records the landed correction: greens_theorem_l1curl and its seven consumers now carry the hLineEq orientation hypothesis in GreensTheoremOQ02.lean / GreensTheoremOQ02OQ04.lean",
+      "startLine": 1,
+      "endLine": 42,
+      "mathContext": "Each registered declaration gains $h_{\\\\text{LineEq}}: \\\\oint_C (P\\\\,dx + Q\\\\,dy) = \\\\text{rectLineIntegral}\\\\,P\\\\,Q\\\\,a\\\\,b\\\\,c\\\\,d$, fixing the boundary orientation so the circulation equals the concrete four-edge rectangle integral; the proofs are otherwise verbatim, a pure signature-threading correction."
     },
     {
-      "id": "consumers",
-      "title": "Re-threaded Consumers",
-      "summary": "Five downstream theorems re-proved with hLineEq threaded through",
-      "startLine": 74,
-      "endLine": 172,
-      "mathContext": "lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl (GreensTheoremOQ02) and greens_stokes_l1curl, closed_l1form_zero_integral (GreensTheoremOQ02OQ04), each verbatim plus the extra orientation argument."
-    },
-    {
-      "id": "excision",
-      "title": "Counterexample Excised",
-      "summary": "counterexample_violates_hLineEq: the unsound witness fails the new hypothesis",
-      "startLine": 174,
-      "endLine": 182,
-      "mathContext": "The constant curve with $P=0$, $Q(x,y)=x$ has circulation $0$ but $\\\\text{rectLineIntegral} = 1$ (proven), so it fails $h_{\\\\text{LineEq}}$ — the corrected axiom is genuinely inapplicable to it."
+      "id": "witness",
+      "title": "Soundness Witness",
+      "summary": "counterexample_violates_hLineEq: the S5 unsound witness fails the new hypothesis",
+      "startLine": 44,
+      "endLine": 57,
+      "mathContext": "The constant curve with $P=0$, $Q(x,y)=x$ has circulation $0$ but $\\\\text{rectLineIntegral} = 1$ (proven), so it fails $h_{\\\\text{LineEq}}$ — the corrected registered axiom is genuinely inapplicable to it, so the unsoundness is removed rather than hidden."
     }
   ],
   "conclusion": {
-    "summary": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posits a core axiom that is false as stated. This entry states the orientation-corrected axiom greens_theorem_l1curl_oriented (one extra hypothesis hLineEq), re-threads all five downstream consumers as a pure signature change, and proves the original counterexample fails the new hypothesis — genuinely removing the unsoundness. The correction is staged in an isolated, unregistered, build-pending file; porting it back to the registered files awaits a Docker session.",
-    "implications": "Restores soundness of the minimal-regularity Green's-theorem formalization: the boundary-orientation hypothesis that the classical statement leaves implicit is made explicit, the five consumers carry it through unchanged, and the degenerate counterexample is provably excluded.",
+    "summary": "The registered minimal-regularity Green's theorem (greens-theorem-oq-02) posited a core axiom that was false as stated. The orientation fix is now landed in the registered files: greens_theorem_l1curl carries the extra hypothesis hLineEq and all seven downstream consumers (three in GreensTheoremOQ02.lean, four in GreensTheoremOQ02OQ04.lean) thread it through as a pure signature change. Two pre-existing Mathlib-incompatibility build errors that had left the registered OQ04 file unbuilt since the Docker blackout were repaired in the same pass, so the file machine-checks for the first time. This entry retains the axiom-free witness proving the original counterexample fails the new hypothesis.",
+    "implications": "Restores soundness of the minimal-regularity Green's-theorem formalization in the registered build: the boundary-orientation hypothesis the classical statement leaves implicit is made explicit, the seven consumers carry it through unchanged, the degenerate counterexample is provably excluded, and the file now compiles under the pinned Mathlib.",
     "openQuestions": [
-      "Port greens_theorem_l1curl_oriented (and the re-threaded consumers) back onto the registered GreensTheoremOQ02.lean / GreensTheoremOQ02OQ04.lean as a single Docker-verified patch, then delete this staging file and retire GreensTheoremOQ02Counterexample.lean (S6 #24424 spec).",
-      "Discharge the corrected axiom itself via the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0, PR #29508) reducing it to OQ-01's boundary algebra by Fubini."
+      "Discharge the corrected axiom itself via the FTC-for-absolutely-continuous-functions keystone (Mathlib ≥ v4.28.0, PR #29508) reducing it to OQ-01's boundary algebra by Fubini — this requires bumping the project's Mathlib pin from v4.26.0.",
+      "Register GreensTheoremOQ02Corrected.lean and GreensTheoremOQ02Counterexample.lean in Proofs.lean so the soundness witness is itself machine-checked on every build (currently both are unregistered)."
     ]
   },
   "crossReferences": [
@@ -142,13 +135,12 @@
       "MeasureTheory",
       "GreensTheoremOQ01",
       "GreensTheoremOQ02",
-      "GreensTheoremOQ02OQ04",
       "GreensTheoremOQ02Counterexample"
     ],
     "namespace": "GreensTheoremOQ02Corrected",
-    "lineCount": 182,
-    "axiomCount": 1,
-    "theoremCount": 6,
+    "lineCount": 58,
+    "axiomCount": 0,
+    "theoremCount": 1,
     "definitionCount": 0,
     "path": "Proofs/GreensTheoremOQ02Corrected.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The registered `axiom greens_theorem_l1curl` (minimal-regularity Green's theorem) was **FALSE as stated** — a degenerate constant curve satisfies every hypothesis yet forces `0 = 1` (proved in S5, PR #24381). Prior sessions staged the fix in an isolated file and deferred the registered-file port as "a single Docker-checked patch." Docker is up, so **this lands and verifies it**.

- **`GreensTheoremOQ02.lean`** — the axiom + 3 consumers (`lineIntegral_zero_curl`, `lineIntegral_l1curl_smul`, `greens_oq1_from_l1curl`) now carry the orientation hypothesis `hLineEq : lipschitzLineIntegral P Q C = rectLineIntegral P Q a b c d`.
- **`GreensTheoremOQ02OQ04.lean`** — 4 consumers (`greens_stokes_l1curl`, `closed_l1form_zero_integral`, `c1_stokes_from_whitney`, `stokes_scaling`) re-threaded.
- **Latent breakage repaired** — the registered OQ04 file had never compiled (merged unbuilt during the Docker blackout): `c1_form_l1_integrable` (product-set compactness `isCompact_Icc.prod isCompact_Icc` + direct `Continuous.sub`) and `closed_l1form_zero_integral` (`integrableOn_zero` for the zero curl). Fixed.
- **`GreensTheoremOQ02Counterexample.lean`** — removed the now-unprovable `greens_theorem_l1curl_refuted` (the axiom is no longer false, so the refutation can't be stated against it) and its Mathlib-drifted helpers; kept the counterexample data.
- **`GreensTheoremOQ02Corrected.lean`** — slimmed to the axiom-free soundness witness `counterexample_violates_hLineEq` (the S5 curve fails `hLineEq`).
- **Gallery `meta.json`** — build-verified narrative, badge `axiom`, refreshed counts.

The registered build no longer contains the unsound statement. `greens_theorem_l1curl` remains a single **orientation-sound** axiom (the genuine Whitney minimal-regularity input); discharging it awaits the FTC-for-AC keystone (`AbsolutelyContinuousOnInterval.integral_deriv_eq_sub`, Mathlib ≥ v4.28.0), gated on a Mathlib pin bump.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ02OQ04` → **Build completed successfully (7745 jobs)** — transitively builds OQ01 + corrected OQ02 + OQ04.
- [x] `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ02Corrected` → **Build completed successfully (7747 jobs)** — witness + trimmed Counterexample.
- [x] `meta.json` validates as JSON; counts synced (axiomCount 1 / leanFile axiomCount 0 / 58 ln / 1 thm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)