### PR TITLE
research(morleys-theorem-oq-03): fix 2 build-breakers, machine-verify, restore verified

### DIFF
--- a/proofs/Proofs/MorleysTheoremOQ03.lean
+++ b/proofs/Proofs/MorleysTheoremOQ03.lean
@@ -286,7 +286,7 @@ theorem morley_side_eq_iff {R α β γ : ℝ} (hR : 0 < R)
       unfold morleySide; ring
     have hprod_eq : sin (α / 3) * sin (β / 3) * sin (γ / 3) = sin (π / 9) ^ 3 := by
       have step : (8 * R) * (sin (α / 3) * sin (β / 3) * sin (γ / 3))
-          = (8 * R) * sin (π / 9) ^ 3 := by rw [← hms, heq]; ring
+          = (8 * R) * sin (π / 9) ^ 3 := by rw [← hms, heq]
       exact mul_left_cancel₀ h8R.ne' step
     -- AM–GM and Jensen, exactly as in the bound proof.
     have hamgm : sin (α / 3) * sin (β / 3) * sin (γ / 3) ≤
@@ -314,14 +314,14 @@ theorem morley_side_eq_iff {R α β γ : ℝ} (hR : 0 < R)
 /-
 ## Summary
 
-Proved (target: 0 sorries, 0 axioms — build pending under Docker blackout):
+Proved (0 sorries, 0 axioms — machine-verified via docker-build 2026-06-15):
 - `amgm_three`     : AM–GM for three nonnegatives, cubed form (explicit SOS certificate).
 - `sin_jensen_three` : three-point Jensen for `sin` on `[0, π]`.
 - `morley_side_le_equilateral` : `s(α,β,γ) ≤ 8R sin³(π/9)`.
 - `morley_side_equilateral`     : the equilateral attains the bound.
 - `morley_side_max`             : packaged "maximum at the equilateral".
 
-- `sin_two_eq` / `sin_jensen_three_eq` : equality cases of two-/three-point Jensen.
+- `sin_two_eq` / `sin_jensen_three_eq` : equality cases of two- and three-point Jensen.
 - `morley_side_eq_iff` : **strict uniqueness** — for `R > 0`, `s = 8R sin³(π/9)`
   *iff* `α = β = γ = π/3` (the equilateral is the unique maximizer).
 

--- a/src/data/proofs/morleys-theorem-oq-03/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius research",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MorleysTheoremOQ03.lean",
     "tags": [
       "geometry",
@@ -17,11 +17,11 @@
       "am-gm",
       "research"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 331,
-    "assumptions": "No axioms or sorries. All lemmas written from Mathlib (concavity of sin, AM–GM via an explicit SOS certificate). Build-pending verification: the source imports all of Mathlib plus the parent MorleysTheorem dependency and was not kernel-checked under the current Docker memory constraints, so the status is held at 'formalized' until a successful build confirms it.",
+    "assumptions": "None. Fully machine-verified: docker-build of Proofs.MorleysTheoremOQ03 completed successfully on 2026-06-15 (7743 jobs, no warnings), confirming 0 axioms and 0 sorries against the pinned Mathlib (v4.26.0). The first build attempt exposed two latent defects that had never surfaced under the prior Docker blackout — a stray '-/' in a summary comment ('two-/three-point') that prematurely closed the block comment, and a redundant 'ring' after a goal already closed by rewriting — both fixed in this session; the corrected file builds clean. All lemmas are elementary (strict concavity of sin via Jensen, AM–GM via an explicit SOS certificate).",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

The registered file `Proofs/MorleysTheoremOQ03.lean` **never actually compiled** — every prior session was under the Docker blackout, so the file's "0 sorries / 0 axioms" held only by inspection and the auditor's downgrade to `formalized`/`wip` (#24667) was correct. With Docker recovered this session, the build exposed **two latent defects**:

1. **Stray `-/` in a comment** — `"two-/three-point"` in the summary block prematurely closed the `/- … -/` comment, turning prose into code (`error: Unknown identifier \`point\``, unexpected backtick token, and a cascading `Function expected` on the reverse `iff` branch at line 312).
2. **Redundant `ring`** — `by rw [← hms, heq]; ring` left no goal after the rewrite (`error: No goals to be solved`).

Both fixed. `docker-build Proofs.MorleysTheoremOQ03` now **completes successfully (7743 jobs, no warnings)**, kernel-confirming 0 axioms / 0 sorries:

```
✔ [7743/7743] Built Proofs.MorleysTheoremOQ03 (122s)
Build completed successfully (7743 jobs).
```

## Changes

- `MorleysTheoremOQ03.lean`: reword `two-/three-point` → `two- and three-point`; drop the redundant `ring`; refresh the summary header from "build pending under Docker blackout" to machine-verified.
- `meta.json`: restore **status `verified` / badge `original`** (reverting the build-pending hold from #24667, now discharged) with the build evidence in `assumptions`.

## Test plan

- [x] `docker-build Proofs.MorleysTheoremOQ03` → green (7743 jobs, no warnings)
- [x] Both build errors from the first attempt resolved; reverse-branch cascade cleared
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)