### PR TITLE
Enrich erdos-1179-oq-02: ℕ↔ℝ transfer annotation + difficulty-asymmetry insight

### DIFF
--- a/src/data/proofs/erdos-1179-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1179-oq-02/annotations.json
@@ -24,6 +24,18 @@
     "prerequisites": ["expectation bounds", "ε-uniformity", "ℕ vs ℝ casting"]
   },
   {
+    "id": "e1179-oq02-ann-nat-real-transfer",
+    "proofId": "erdos-1179-oq-02",
+    "range": { "startLine": 63, "endLine": 75 },
+    "type": "tactic",
+    "title": "Transferring a Strict Real Bound to a ℕ Lower Bound",
+    "content": "The spanning conclusion is the natural-number inequality 1 ≤ reprCount A g, but the uniformity hypothesis lives over ℝ. The proof bridges the two with a reusable three-step pattern. (1) Derive the strict real inequality 0 < (reprCount A g : ℝ) from (1−ε)·μ > 0 (a product of two positives, mul_pos) and F_A(g) ≥ (1−ε)·μ (linarith). (2) Convert positivity of the cast to non-vanishing of the natural number: reprCount A g ≠ 0, since reprCount A g = 0 would force the cast to 0, contradicting hpos (rw + simp). (3) Close with omega, which upgrades n ≠ 0 to 1 ≤ n for n : ℕ. The key subtlety is that ℕ has no strict order below 1 — there is no natural number strictly between 0 and 1 — so a real lower bound that is merely positive (not ≥ 1) still yields the sharp integer bound 1 ≤ n once cast-positivity rules out n = 0. Using nlinarith/linarith for the ℝ side and omega for the ℕ side keeps each step in the arithmetic where it is decidable.",
+    "mathContext": "$0 < (\\,\\mathrm{reprCount}\\,A\\,g : \\mathbb{R}) \\Rightarrow \\mathrm{reprCount}\\,A\\,g \\neq 0 \\xrightarrow{\\;\\omega\\;} 1 \\le \\mathrm{reprCount}\\,A\\,g$, exploiting that $\\mathbb{N}$ has no element in $(0,1)$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat.cast positivity", "ℕ↔ℝ coercion", "omega", "mul_pos", "discreteness of ℕ"],
+    "prerequisites": ["Nat.cast and Nat.cast_pos", "linarith/nlinarith", "omega decision procedure"]
+  },
+  {
     "id": "e1179-oq02-ann-card-bound",
     "proofId": "erdos-1179-oq-02",
     "range": { "startLine": 77, "endLine": 91 },

--- a/src/data/proofs/erdos-1179-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-02/meta.json
@@ -60,7 +60,8 @@
       "The lower bound gₑ(N) ≥ log₂N is information-theoretic: 2^|A| subsets must cover all N group elements, so 2^|A| ≥ N regardless of uniformity quality — uniformity (ε < 1) is only needed to guarantee every element is actually hit",
       "The parent's uniform_implies_spanning was circular — it assumed |A| ≥ ⌈log₂N⌉ to prove spanning — and this file breaks the circle by deriving spanning from μ > 0 alone, making the lower bound a genuine consequence",
       "Only ε < 1 is needed (not small ε): the positivity (1−ε)μ > 0 is all that drives the spanning argument",
-      "This settles the lower-bound half of OQ-02's matching target; the open content is the additive Oₑ(1) UPPER bound, which is not decidable by finite computation (the certificate exhibits only the exact small-N gap)"
+      "This settles the lower-bound half of OQ-02's matching target; the open content is the additive Oₑ(1) UPPER bound, which is not decidable by finite computation (the certificate exhibits only the exact small-N gap)",
+      "There is an asymmetry of difficulty baked into the problem: the lower bound is a per-subset covering fact provable for one fixed A, whereas the upper bound is an existence-over-randomness statement (some A of the claimed size is ε-uniform) whose Oₑ(1) error is an asymptotic-in-N claim — no finite check can certify it, which is exactly why the formalized lower bound here is axiom-free while the upper bound resists a constructive Lean proof"
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for **erdos-1179-oq-02** (Axiom-Free Trivial Lower Bound for Uniform Subset Sums). No open PR previously served this slug; highest-priority genuine non-dup target (q87, pass 0).

## Changes (gallery data only — no `.lean` touched)
- **+1 annotation** (`e1179-oq02-ann-nat-real-transfer`, lines 63–75, type `tactic`): teaches the reusable positivity→non-vanishing→`omega` pattern that lifts the strict real bound `F_A(g) ≥ (1−ε)μ > 0` to the sharp ℕ bound `1 ≤ reprCount A g`, exploiting that ℕ has no element in (0,1). Brings annotation count 4 → 5 (the one quality-target shortfall).
- **+1 keyInsight**: the lower/upper-bound difficulty asymmetry — a fixed per-subset covering fact (axiom-free) vs. an asymptotic existence-over-randomness claim no finite check can certify, which is *why* the lower bound formalizes axiom-free while the upper bound resists a constructive Lean proof.

## Verification
- Both cross-reference targets (`erdos-1179`, `erdos-1179-oq-01`) confirmed present on `origin/main`.
- Prose checked against Lean source: `theoremCount = 3` ✓, parent deps `total_reprCount`/`expectedReprCount_pos` are theorems (not axioms) ⇒ "axiom-free" accurate ✓.
- `meta.json` + `annotations.json` parse cleanly; gallery data pipeline processed the slug without error.