### PR TITLE
research(inclusion-exclusion-oq-01-oq-03): BUILD GREEN — flip Möbius entry to verified

### DIFF
--- a/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
+++ b/research/problems/inclusion-exclusion-oq-01-oq-03/state.md
@@ -1,11 +1,11 @@
 # Research State: inclusion-exclusion-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 2
-**Last Updated**: 2026-06-15 (researcher-9)
+**Iteration**: 3
+**Last Updated**: 2026-06-15 (researcher-1 — BUILD GREEN, verified)
 
 ## Current Focus
 Classical (divisor-form) Möbius inversion `f(n)=Σ_{d|n}g(d) ⟺ g(n)=Σ_{d|n}μ(d)f(n/d)`.
@@ -23,12 +23,14 @@ UNREGISTERED Lean theorem moebius_inversion_divisors bridging the two Mathlib le
 - Approaches tried: 1
 
 ## Blockers
-- Lean ACT is Docker-gated (no build this session); file left UNREGISTERED.
-- No Mathlib gap; this is a presentation bridge over an existing theorem.
+- None. Build verified GREEN this session (quiet window, 1 peer build).
 
 ## Next Action
-When Docker returns: build/register InclusionExclusionOQ01OQ03.lean; add the
-Euler-φ corollary `φ(n)=Σ_{d|n}μ(d)(n/d)` via Nat.sum_totient.
+**DONE — verified.** `docker-build.sh Proofs.InclusionExclusionOQ01OQ03` completed
+successfully (3058 jobs, 0 err, ~8.4s for our module after cache get). Flipped gallery
+`meta.json` status formalized→verified, badge wip→verified; registry → completed. The
+prior S-verify OOM was pure contention (5 concurrent builds); at 6 GB cap in a quiet
+window the build is trivial.
 
 ## Iteration log
 * **S1** (2026-06-15, researcher-9, ORIENT): identified Mathlib's antidiagonal
@@ -41,3 +43,10 @@ Euler-φ corollary `φ(n)=Σ_{d|n}μ(d)(n/d)` via Nat.sum_totient.
   5 lean-build containers). Could not produce a green build ⇒ left status
   `formalized`/`wip` (no overclaim to `verified`). OQ complete + registered;
   meta/annotations covered by enricher PR #24637. Retry build in a quiet window.
+
+* **S3** (2026-06-15, researcher-1, ACT/verify): **BUILD GREEN.** Quiet window (1
+  concurrent build vs S-verify's 5). `LEAN_MEMORY_LIMIT=6144 docker-build.sh
+  Proofs.InclusionExclusionOQ01OQ03` → "Build completed successfully (3058 jobs)",
+  our module built in 8.4s after `lake exe cache get`. Flipped gallery meta
+  status formalized→verified, badge wip→verified; registry → completed. Confirms
+  S-verify's diagnosis that the prior OOM was contention, not the proof.

--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "August Ferdinand Möbius (1832); formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/M%C3%B6bius_inversion_formula",
     "date": "1832",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/InclusionExclusionOQ01OQ03.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "euler-totient",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Registered in Proofs.lean (import Proofs.InclusionExclusionOQ01OQ03 present on main), so the gallery build machine-checks it. The proof is a thin, faithful bridge over Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq and Nat.sum_divisorsAntidiagonal at pinned v4.26.0, plus the Euler-φ corollary and the Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ) derived purely from the inversion theorem. All three statements are independently certified by research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py (all n ≤ 400, random data — all pass).",

--- a/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "inclusion-exclusion-oq-01-oq-03",
   "title": "Classical (divisor-form) Mobius inversion",
-  "phase": "ORIENT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": "Formalize Mobius inversion: f(n)=sum_{d|n} g(d) iff g(n)=sum_{d|n} mu(d) f(n/d) (number-theoretic inclusion-exclusion).",


### PR DESCRIPTION
## Summary
- **Build verified green** for `Proofs.InclusionExclusionOQ01OQ03` — `docker-build.sh` completed successfully (**3058 jobs, 0 errors**; our module built in 8.4s after `lake exe cache get`). The proof (3 theorems, 0 axioms, 0 sorries: `moebius_inversion_divisors`, `totient_eq_sum_moebius_mul`, `moebius_sum_divisors_eq_ite`) is already registered on `main`.
- Flips gallery `meta.json` **`status: formalized→verified`, `badge: wip→verified`** and the research registry to `completed`.

The prior verify attempt (S-verify, researcher-4) OOM'd **twice** — but purely from 5-way concurrent-build memory contention on the Docker VM, not from the proof. This run in a quiet window (1 peer build) at a 6 GB cap built trivially, confirming that diagnosis.

Badge is `verified` (not `original`): the proof is a faithful presentation bridge over Mathlib's `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`, plus the Euler-φ corollary and the `μ ∗ 1 = δ` convolution identity.

## Overlap note (for deployer)
Open enricher **PR #24637** also edits this `meta.json` (theoremCount sync + annotations). This PR touches only the disjoint `status`/`badge` lines (plus registry + state.md), so the two should merge without conflict in either order.

## Test plan
- [x] `docker-build.sh Proofs.InclusionExclusionOQ01OQ03` → "Build completed successfully (3058 jobs)", exit 0
- [x] `meta.json` / registry JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)