### PR TITLE
research(minkowski-theorem-oq-03): name the Minkowski bound + class-number head-count

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ03.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ03.lean
@@ -1,0 +1,113 @@
+/-
+# Minkowski Bound on Ideal Norms: A Class-Number Estimate (OQ-03)
+
+## What This Proves
+
+This file makes the *geometry of numbers ⟹ ideal norm bound* connection explicit and
+draws a new quantitative consequence.
+
+Minkowski's lattice-point theorem (the gallery's `minkowski-theorem` family) feeds, through
+Mathlib's mixed-embedding convex-body machinery, into the statement that **every ideal class
+of a number field `K` contains an integral ideal whose absolute norm is at most the Minkowski
+bound**
+```
+M_K = (4/π)^{r₂} · (n! / nⁿ) · √|d_K|,
+```
+where `n = [K : ℚ]`, `r₂ = nrComplexPlaces K`, and `d_K = discr K`.
+
+Mathlib (`NumberField.exists_ideal_in_class_of_norm_le`) proves this with `M_K` only as a
+*local notation* inside `Mathlib/NumberTheory/NumberField/ClassNumber.lean`, so the bound is
+not reusable downstream. Here we:
+
+1. Package the bound as a reusable definition `minkowskiIdealBound K`.
+2. Restate the class-representative bound against that named constant.
+3. Prove the **new** quantitative corollary
+   ```
+   classNumber K ≤ #{ I integral ideal : absNorm I ≤ ⌊M_K⌋ }.
+   ```
+   This is the explicit, computable upper bound on the class number that the geometry of
+   numbers yields. It refines the bare finiteness of the class group
+   (`NumberField.RingOfIntegers.instFintypeClassGroup`) into a concrete head-count.
+
+## Key Techniques
+
+- **Surjectivity from the bound**: `exists_ideal_in_class_of_norm_le` says the map
+  `I ↦ ClassGroup.mk0 I`, restricted to ideals of norm `≤ ⌊M_K⌋`, is *onto* the class group.
+- **Finiteness of the index set**: `Ideal.finite_setOf_absNorm_le₀` makes the domain finite.
+- **Counting**: a surjection from a finite set bounds the target's cardinality
+  (`Nat.card_le_card_of_surjective`), and `classNumber = Fintype.card (ClassGroup …)`.
+- **Real → ℕ bound**: `Nat.le_floor` turns `(absNorm I : ℝ) ≤ M_K` into `absNorm I ≤ ⌊M_K⌋₊`.
+
+Build status: build pending (worktree Docker cache unavailable). All referenced Mathlib
+lemmas were name-checked against the pinned revision `2df2f0150c`.
+-/
+
+import Mathlib
+
+open scoped nonZeroDivisors Real NumberField
+open Module NumberField InfinitePlace Ideal Nat
+
+namespace MinkowskiIdealBound
+
+variable (K : Type*) [Field K] [NumberField K]
+
+/-- The **Minkowski bound** of a number field `K`,
+`M_K = (4/π)^{r₂} · (n! / nⁿ) · √|d_K|`.
+
+This is the constant that appears (as a local notation `M K`) in
+`NumberField.exists_ideal_in_class_of_norm_le`; we expose it as a reusable definition so the
+ideal-norm bound can be referenced downstream. -/
+noncomputable def minkowskiIdealBound : ℝ :=
+  (4 / π) ^ nrComplexPlaces K *
+    ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * Real.sqrt |discr K|)
+
+/-- The Minkowski bound is nonnegative. -/
+theorem minkowskiIdealBound_nonneg : 0 ≤ minkowskiIdealBound K := by
+  unfold minkowskiIdealBound
+  positivity
+
+/-- **Minkowski's ideal-norm bound.** Every ideal class of `K` contains an integral ideal
+whose absolute norm is at most the Minkowski bound `minkowskiIdealBound K`.
+
+This is `NumberField.exists_ideal_in_class_of_norm_le` restated against the named bound; it is
+the precise sense in which the geometry of numbers bounds ideal norms. -/
+theorem exists_ideal_in_class_absNorm_le (C : ClassGroup (𝓞 K)) :
+    ∃ I : (Ideal (𝓞 K))⁰, ClassGroup.mk0 I = C ∧
+      (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ minkowskiIdealBound K := by
+  unfold minkowskiIdealBound
+  exact NumberField.exists_ideal_in_class_of_norm_le C
+
+/-- **Class-number estimate via the geometry of numbers.** The class number of `K` is at most
+the number of integral ideals whose absolute norm is at most `⌊M_K⌋`.
+
+This upgrades the finiteness of the class group to an explicit, computable head-count: the
+representatives furnished by Minkowski's bound already exhaust every class. -/
+theorem classNumber_le_card_absNorm_le :
+    classNumber K ≤
+      Nat.card {I : (Ideal (𝓞 K))⁰ //
+        Ideal.absNorm (I : Ideal (𝓞 K)) ≤ ⌊minkowskiIdealBound K⌋₊} := by
+  set n := ⌊minkowskiIdealBound K⌋₊ with hn
+  -- The index set of ideals of norm `≤ n` is finite.
+  haveI hfin : Finite {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (I : Ideal (𝓞 K)) ≤ n} :=
+    (Ideal.finite_setOf_absNorm_le₀ (S := 𝓞 K) n).to_subtype
+  -- Every ideal class is hit by some ideal of norm `≤ n`.
+  have hsurj : Function.Surjective
+      (fun I : {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (I : Ideal (𝓞 K)) ≤ n} =>
+        ClassGroup.mk0 (I : (Ideal (𝓞 K))⁰)) := by
+    intro C
+    obtain ⟨I, hIC, hInorm⟩ := exists_ideal_in_class_absNorm_le K C
+    refine ⟨⟨I, ?_⟩, hIC⟩
+    rw [hn]
+    exact Nat.le_floor hInorm
+  -- A surjection from a finite set bounds the cardinality of the class group.
+  have hcard : classNumber K = Nat.card (ClassGroup (𝓞 K)) :=
+    Nat.card_eq_fintype_card.symm
+  rw [hcard]
+  exact Nat.card_le_card_of_surjective _ hsurj
+
+/-- Restated as finiteness: the class group is finite (already an instance in Mathlib via
+`NumberField.RingOfIntegers.instFintypeClassGroup`), here re-derived as a sanity check that the
+counting bound is meaningful. -/
+example : Finite (ClassGroup (𝓞 K)) := inferInstance
+
+end MinkowskiIdealBound

--- a/research/problems/minkowski-theorem-oq-03/knowledge.md
+++ b/research/problems/minkowski-theorem-oq-03/knowledge.md
@@ -1,0 +1,93 @@
+# minkowski-theorem-oq-03 — Minkowski Bound on Ideal Norms
+
+## Problem
+
+"Minkowski Bound on Ideal Norms: Geometry of Numbers Connection" (tier B, sig 8, tract 6).
+Connect the gallery's Minkowski lattice-point theorem to a bound on ideal norms / the class
+number of a number field.
+
+## Status Summary
+
+**PROGRESS** (build pending). Produced `proofs/Proofs/MinkowskiTheoremOQ03.lean`:
+- `minkowskiIdealBound K` — a reusable definition of the Minkowski bound (Mathlib only has it
+  as a `local notation` inside `ClassNumber.lean`).
+- `exists_ideal_in_class_absNorm_le` — restatement of the ideal-norm bound against the named
+  constant (reduces to `NumberField.exists_ideal_in_class_of_norm_le`).
+- `classNumber_le_card_absNorm_le` — **new** quantitative estimate:
+  `classNumber K ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // absNorm (↑I) ≤ ⌊minkowskiIdealBound K⌋₊}`.
+
+0 sorries, 0 axiom declarations. NOT kernel-checked this session (worktree Docker cache
+unavailable; Aristotle MCP endpoint returned "Resource not found").
+
+## Mathlib API (name-checked @ rev 2df2f0150c)
+
+`Mathlib/NumberTheory/NumberField/ClassNumber.lean`:
+- `NumberField.classNumber K := Fintype.card (ClassGroup (𝓞 K))`
+- `NumberField.RingOfIntegers.instFintypeClassGroup : Fintype (ClassGroup (𝓞 K))`
+- `NumberField.classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K)`
+- `NumberField.exists_ideal_in_class_of_norm_le (C) : ∃ I : (Ideal (𝓞 K))⁰, mk0 I = C ∧ absNorm (↑I) ≤ M K`
+  where `M K` is the **local notation** `(4/π)^(nrComplexPlaces K) * ((finrank ℚ K)! / (finrank ℚ K)^(finrank ℚ K) * √|discr K|)`.
+- `RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt` — PID if `|discr K| < (2(π/4)^r₂ (nⁿ/n!))²`.
+- `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`
+  and the Galois variant — the standard prime-by-prime PID criterion.
+- `Rat.classNumber_eq : NumberField.classNumber ℚ = 1`.
+
+`Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean`:
+- `Ideal.finite_setOf_absNorm_eq [CharZero S] (n) : {I | absNorm I = n}.Finite`
+- `Ideal.finite_setOf_absNorm_le [CharZero S] (n) : {I | absNorm I ≤ n}.Finite`
+- `Ideal.finite_setOf_absNorm_le₀ [CharZero S] (n) : {I : (Ideal S)⁰ | absNorm (↑I) ≤ n}.Finite`
+
+`Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean`:
+- `NumberField.mixedEmbedding.exists_ne_zero_mem_ideal_of_norm_le` (the convex-body input)
+- `NumberField.mixedEmbedding.minkowskiBound` / `_lt_top` / `_pos`.
+
+Other:
+- `Nat.card_le_card_of_surjective {α β} [Finite α] (f) (hf : Surjective f) : Nat.card β ≤ Nat.card α`
+  (`Mathlib/SetTheory/Cardinal/Finite.lean`)
+- `Nat.card_eq_fintype_card [Fintype α] : Nat.card α = Fintype.card α`
+- `Nat.le_floor [IsOrderedRing α] (h : (n:α) ≤ a) : n ≤ ⌊a⌋₊` (`Mathlib/Algebra/Order/Floor/Defs.lean`)
+
+## Insights
+
+- The headline theorem (ideal-norm bound) and the finiteness of the class group are **already
+  in Mathlib**. Honest assessment: the new content is (a) exposing the bound as a reusable
+  constant, and (b) the explicit head-count `classNumber ≤ #{ideals of norm ≤ ⌊M_K⌋}`, which is
+  the formal backbone of the class-number algorithm and is NOT recorded in Mathlib.
+- The "small bound ⟹ PID" criterion is also already in Mathlib
+  (`isPrincipalIdealRing_of_abs_discr_lt`), so that is not a gap.
+- `minkowskiIdealBound K` is written character-for-character as Mathlib's local notation, so
+  `unfold minkowskiIdealBound; exact NumberField.exists_ideal_in_class_of_norm_le C` discharges
+  the restatement by definitional equality.
+
+## Mathlib Gaps / Why a concrete example was NOT attempted
+
+- A concrete worked example (e.g. "ℚ(√d) has class number 1 via the Minkowski bound") needs a
+  `NumberField` instance for the quadratic field together with computed `discr`,
+  `nrComplexPlaces`, and `finrank`. No clean quadratic-field discriminant instance was found in
+  Mathlib at this rev; building one is a substantial (likely > 500 line) undertaking and was out
+  of scope for a build-blocked session. This is the natural next step and the real remaining
+  content of oq-03.
+
+## Next Steps
+
+1. Green Docker build of `MinkowskiTheoremOQ03.lean` → promote meta.json status to verified/original.
+   If `unfold; exact` fails on the restatement, fall back to `simpa only [minkowskiIdealBound]
+   using NumberField.exists_ideal_in_class_of_norm_le C` or massage the coercion on `√|discr K|`.
+2. Resubmit the file to Aristotle when its MCP endpoint recovers, to obtain an independent
+   verified proof of `classNumber_le_card_absNorm_le`.
+3. Concrete instantiation: prove a specific small-discriminant field (Gaussian `ℚ(√-1)`,
+   `ℚ(√-3)`, `ℚ(√5)`, all satisfying `isPrincipalIdealRing_of_abs_discr_lt` directly) has class
+   number 1, once quadratic-field discriminant infrastructure is available.
+
+## Sessions
+
+### 2026-06-15 (S1) — ORIENT + ACT, build pending
+
+**Mode**: FRESH. **Outcome**: progress (build pending).
+
+- Claimed problem; surveyed Mathlib class-number API (name-checked above).
+- Found the headline ideal-norm bound and class-group finiteness already in Mathlib.
+- Identified the genuine gap: reusable bound constant + explicit class-number head-count.
+- Wrote `MinkowskiTheoremOQ03.lean` (1 def, 3 theorems, 0 sorries, 0 axioms) + gallery
+  meta/annotations.
+- Aristotle endpoint unavailable; Docker worktree cache unavailable ⇒ not kernel-checked.

--- a/src/data/proofs/minkowski-theorem-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-mink-oq03-header",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "From Lattice Points to Ideal Norms",
+    "content": "Minkowski's geometry of numbers turns a volume estimate into a nonzero lattice point. Through Mathlib's canonical (mixed) embedding of a number field, this becomes the Minkowski bound M_K and the statement that every ideal class contains an integral ideal of norm ≤ M_K. This file names that bound (Mathlib hides it as a local notation), restates the bound, and derives a new explicit upper bound on the class number.",
+    "mathContext": "For a number field $K$ of degree $n$ with $r_2$ complex places and discriminant $d_K$, the Minkowski bound is $M_K = (4/\\pi)^{r_2}\\,(n!/n^n)\\,\\sqrt{|d_K|}$. The classical theorem: every ideal class of $\\mathcal{O}_K$ has a representative integral ideal of absolute norm $\\le M_K$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Minkowski bound",
+      "geometry of numbers",
+      "ideal class group",
+      "ring of integers"
+    ],
+    "prerequisites": [
+      "Minkowski's lattice point theorem",
+      "ideal norm",
+      "class group of a number field"
+    ]
+  },
+  {
+    "id": "ann-mink-oq03-bound-def",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "definition",
+    "title": "Naming the Minkowski Bound",
+    "content": "`minkowskiIdealBound K` is defined to be exactly the expression behind Mathlib's local notation `M K`. Because the two are definitionally identical, every Mathlib lemma stated with `M K` can be re-used against the named constant by simple unfolding. `minkowskiIdealBound_nonneg` records that the bound is ≥ 0 (a product of nonnegative factors), which is the only hypothesis needed to floor it.",
+    "mathContext": "$M_K = (4/\\pi)^{r_2} \\cdot \\dfrac{n!}{n^n} \\cdot \\sqrt{|d_K|} \\ge 0$ since each factor is nonnegative.",
+    "significance": "infrastructure",
+    "relatedConcepts": ["Minkowski bound", "discriminant", "complex places"],
+    "prerequisites": ["finrank", "NumberField.discr", "Real.sqrt"]
+  },
+  {
+    "id": "ann-mink-oq03-ideal-norm-bound",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "theorem",
+    "title": "Minkowski's Ideal-Norm Bound",
+    "content": "`exists_ideal_in_class_absNorm_le`: every ideal class C contains an integral ideal I with mk0 I = C and (absNorm I : ℝ) ≤ minkowskiIdealBound K. The proof unfolds the named bound and applies Mathlib's `NumberField.exists_ideal_in_class_of_norm_le` directly — this is the precise sense in which the geometry of numbers bounds ideal norms.",
+    "mathContext": "Every class $C \\in \\mathrm{Cl}(\\mathcal{O}_K)$ has a representative integral ideal $I$ with $\\mathrm{absNorm}(I) \\le M_K$.",
+    "significance": "key-result",
+    "relatedConcepts": ["ideal class group", "ideal norm", "Minkowski bound"],
+    "prerequisites": ["NumberField.exists_ideal_in_class_of_norm_le", "ClassGroup.mk0"]
+  },
+  {
+    "id": "ann-mink-oq03-class-number-estimate",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 85, "endLine": 113 },
+    "type": "theorem",
+    "title": "An Explicit Bound on the Class Number",
+    "content": "`classNumber_le_card_absNorm_le`: classNumber K ≤ #{ I : absNorm I ≤ ⌊M_K⌋ }. The index set is finite (`Ideal.finite_setOf_absNorm_le₀`); the class-representative map is surjective because every class has a representative of norm ≤ M_K, floored to ⌊M_K⌋ via `Nat.le_floor`; and a surjection from a finite set bounds cardinality (`Nat.card_le_card_of_surjective`), with `classNumber = Fintype.card (ClassGroup …) = Nat.card (ClassGroup …)`.",
+    "mathContext": "$\\#\\mathrm{Cl}(\\mathcal{O}_K) \\le \\#\\{\\, I : \\mathrm{absNorm}(I) \\le \\lfloor M_K\\rfloor \\,\\}$. This is the formal justification for the standard class-number algorithm: enumerating ideals below the Minkowski bound already meets every ideal class.",
+    "significance": "key-result",
+    "relatedConcepts": [
+      "class number",
+      "finiteness of the class group",
+      "counting ideals of bounded norm"
+    ],
+    "prerequisites": [
+      "Ideal.finite_setOf_absNorm_le₀",
+      "Nat.card_le_card_of_surjective",
+      "Nat.le_floor",
+      "Nat.card_eq_fintype_card"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "minkowski-theorem-oq-03",
+  "title": "Minkowski Bound on Ideal Norms: A Class-Number Estimate",
+  "slug": "minkowski-theorem-oq-03",
+  "description": "Makes the geometry-of-numbers ⟹ ideal-norm bound connection explicit and draws a new quantitative consequence. Packages the Minkowski bound M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K| (only a local notation in Mathlib) as a reusable definition, restates that every ideal class contains an integral ideal of norm ≤ M_K, and proves the new estimate classNumber K ≤ #{ ideals : absNorm ≤ ⌊M_K⌋ } — an explicit, computable head-count refining the bare finiteness of the class group. Build pending (worktree Docker cache unavailable); proofs reduce entirely to Mathlib lemmas name-checked at rev 2df2f0150c.",
+  "meta": {
+    "status": "formalized",
+    "badge": "wip",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "lineCount": 113,
+    "proofRepoPath": "Proofs/MinkowskiTheoremOQ03.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-number-theory",
+      "minkowski",
+      "ideals",
+      "class-group",
+      "class-number",
+      "geometry-of-numbers"
+    ],
+    "assumptions": "Build pending: the worktree Docker olean cache is unavailable, so the file has not been kernel-checked this session. The proofs contain 0 sorries and 0 axiom declarations, reducing entirely to existing Mathlib results (NumberField.exists_ideal_in_class_of_norm_le, Ideal.finite_setOf_absNorm_le₀, Nat.card_le_card_of_surjective, Nat.le_floor), all name-checked against the pinned Mathlib revision 2df2f0150c. Status will be promoted to verified once a green Docker build confirms the kernel check.",
+    "author": "Lean Genius Researcher",
+    "dateAdded": "2026"
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-theorem-oq-02-oq-01",
+      "relationship": "relatedTo",
+      "description": "Both proofs route the geometry of numbers (Minkowski's lattice-point theorem) into number theory; that file applies it to Diophantine approximation, this one to ideal norms and the class number."
+    },
+    {
+      "targetId": "minkowski-theorem",
+      "relationship": "extends",
+      "description": "Applies the lattice-point theorem of the parent Minkowski entry to bound ideal norms across every ideal class and thereby bound the class number."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Minkowski's geometry of numbers (1896) turns a volume estimate for a symmetric convex body into the existence of a nonzero lattice point. Applied to the canonical (mixed) embedding of a number field $K$ of degree $n$ with $r_2$ complex places and discriminant $d_K$, it yields the **Minkowski bound**\n$$M_K = \\left(\\frac{4}{\\pi}\\right)^{r_2} \\frac{n!}{n^n} \\sqrt{|d_K|}.$$\nThe classical consequence (Minkowski, refined by later authors) is that every ideal class of $\\mathcal{O}_K$ contains an integral ideal of absolute norm at most $M_K$. Because there are only finitely many integral ideals of bounded norm, this proves the finiteness of the class group and gives the standard algorithm for computing class numbers: enumerate ideals of norm $\\le \\lfloor M_K \\rfloor$ and read off the class group.\n\nMathlib formalizes the ideal-norm bound (`NumberField.exists_ideal_in_class_of_norm_le`) and the finiteness of the class group, but it states the bound $M_K$ only as a *local notation* private to its `ClassNumber.lean` file, and it does not record the explicit head-count $\\mathrm{classNumber}\\,K \\le \\#\\{I : |\\mathrm{absNorm}\\,I| \\le \\lfloor M_K\\rfloor\\}$ that the enumeration algorithm rests on.",
+    "problemStatement": "Expose the Minkowski bound as a reusable definition and prove the quantitative class-number estimate it implies: for a number field $K$,\n$$\\mathrm{classNumber}\\,K \\;\\le\\; \\#\\bigl\\{\\, I \\text{ integral ideal of } \\mathcal{O}_K : \\mathrm{absNorm}\\,I \\le \\lfloor M_K \\rfloor \\,\\bigr\\}.$$\nIn Lean: `classNumber_le_card_absNorm_le : classNumber K ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (I : Ideal (𝓞 K)) ≤ ⌊minkowskiIdealBound K⌋₊}`.",
+    "proofStrategy": "Three steps. (1) **Name the bound.** Define `minkowskiIdealBound K` as the exact expression behind Mathlib's local notation `M K`, so `NumberField.exists_ideal_in_class_of_norm_le` restates verbatim against the named constant (`exists_ideal_in_class_absNorm_le`). (2) **Surjectivity.** Fix $n = \\lfloor M_K\\rfloor$. For each class $C$, the ideal-norm bound supplies $I$ with $\\mathrm{mk0}\\,I = C$ and $(\\mathrm{absNorm}\\,I : \\mathbb{R}) \\le M_K$; since $\\mathrm{absNorm}\\,I$ is a natural number and $M_K \\ge 0$, `Nat.le_floor` gives $\\mathrm{absNorm}\\,I \\le n$. Hence the map $I \\mapsto \\mathrm{mk0}\\,I$ from $\\{I : \\mathrm{absNorm}\\,I \\le n\\}$ onto the class group is surjective. (3) **Count.** The index set is finite (`Ideal.finite_setOf_absNorm_le₀`), so a surjection from it bounds the class group's cardinality (`Nat.card_le_card_of_surjective`); rewriting `classNumber K = Nat.card (ClassGroup (𝓞 K))` via `Nat.card_eq_fintype_card` closes the goal.",
+    "keyInsights": [
+      "Mathlib's Minkowski bound is trapped as a `local notation` inside `ClassNumber.lean`, so it cannot be referenced downstream. Reintroducing it as a plain definition that is *character-for-character* the notation's expansion makes `exists_ideal_in_class_of_norm_le` reusable by definitional unfolding alone — `unfold minkowskiIdealBound; exact …` suffices.",
+      "Finiteness of the class group is qualitative; the genuinely useful object is the *count* of ideals below the bound. The map 'ideal of bounded norm ↦ its class' being surjective is exactly the content of the Minkowski bound, and `Nat.card_le_card_of_surjective` converts surjectivity-from-a-finite-set into a cardinality inequality.",
+      "The real-to-natural step is the only analytic input: `absNorm I` is a natural number bounded by the real constant $M_K$, and `Nat.le_floor` (valid because $M_K \\ge 0$, proved by `positivity` after unfolding) collapses the real bound to $\\lfloor M_K\\rfloor$, matching the natural-number-indexed finiteness lemma `finite_setOf_absNorm_le₀`.",
+      "This estimate is the formal backbone of the standard class-number algorithm: it certifies that enumerating ideals of norm $\\le \\lfloor M_K\\rfloor$ already exhausts every ideal class, so no class is missed when computing the class group by hand."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Documents the geometry-of-numbers ⟹ ideal-norm bound connection and the build-pending status. Imports Mathlib and opens the nonZeroDivisors, Real, NumberField, Module, InfinitePlace, Ideal, and Nat namespaces to match Mathlib's ClassNumber.lean conventions."
+    },
+    {
+      "id": "bound-def",
+      "title": "The Minkowski Bound as a Reusable Definition",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "Defines `minkowskiIdealBound K = (4/π)^{nrComplexPlaces K} · ((finrank ℚ K)! / (finrank ℚ K)^(finrank ℚ K) · √|discr K|)`, identical to Mathlib's local notation `M K`. Proves `minkowskiIdealBound_nonneg` (≥ 0) by `positivity`."
+    },
+    {
+      "id": "ideal-norm-bound",
+      "title": "Minkowski's Ideal-Norm Bound (Restated)",
+      "startLine": 74,
+      "endLine": 83,
+      "summary": "`exists_ideal_in_class_absNorm_le`: every ideal class contains an integral ideal of absolute norm ≤ minkowskiIdealBound K. Proved by `unfold minkowskiIdealBound; exact NumberField.exists_ideal_in_class_of_norm_le C`, since the definition is definitionally Mathlib's bound."
+    },
+    {
+      "id": "class-number-estimate",
+      "title": "Class-Number Estimate via the Geometry of Numbers",
+      "startLine": 85,
+      "endLine": 113,
+      "summary": "`classNumber_le_card_absNorm_le`: the class number is at most the number of integral ideals of norm ≤ ⌊M_K⌋. The index set is finite (finite_setOf_absNorm_le₀); the class-representative map is surjective (Nat.le_floor turns the real bound into the floor bound); Nat.card_le_card_of_surjective plus Nat.card_eq_fintype_card finish. Closes with a sanity-check that the class group is finite."
+    }
+  ]
+}

--- a/src/data/research/problems/minkowski-theorem-oq-03.json
+++ b/src/data/research/problems/minkowski-theorem-oq-03.json
@@ -1,81 +1,111 @@
 {
   "slug": "minkowski-theorem-oq-03",
   "title": "Minkowski Bound on Ideal Norms: Geometry of Numbers Connection",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in number theory: Minkowski Bound on Ideal Norms: Geometry of Numbers Connection.",
-    "whyMatters": []
+    "formal": "\\mathrm{classNumber}\\,K \\le \\#\\{\\, I : \\mathrm{absNorm}\\,I \\le \\lfloor M_K \\rfloor \\,\\}, \\quad M_K = (4/\\pi)^{r_2}\\,(n!/n^n)\\,\\sqrt{|d_K|}",
+    "plain": "Expose the Minkowski bound as a reusable definition and prove the class-number estimate it yields: the class number of a number field K is at most the number of integral ideals of absolute norm at most the floor of the Minkowski bound.",
+    "whyMatters": [
+      "The estimate is the formal backbone of the standard class-number algorithm: enumerating ideals below the Minkowski bound already exhausts every ideal class.",
+      "Refines the bare finiteness of the class group into an explicit, computable head-count.",
+      "Makes the geometry-of-numbers ⟹ ideal-norm bound connection reusable downstream by naming the bound Mathlib hides as a local notation."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Mathlib: every ideal class contains an integral ideal of norm ≤ M_K (NumberField.exists_ideal_in_class_of_norm_le).",
+      "Mathlib: the class group is finite (RingOfIntegers.instFintypeClassGroup).",
+      "Mathlib: small-bound ⟹ PID criterion (RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt) and prime-by-prime PID criteria.",
+      "This file: minkowskiIdealBound (named constant), exists_ideal_in_class_absNorm_le (restatement), classNumber_le_card_absNorm_le (new head-count). Build pending."
+    ],
+    "open": [
+      "Concrete worked example: a specific quadratic field (e.g. ℚ(√-1), ℚ(√-3), ℚ(√5)) shown to have class number 1 via the Minkowski bound — blocked by the absence of a clean quadratic-field discriminant instance in Mathlib."
+    ],
+    "goal": "classNumber K ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (↑I) ≤ ⌊minkowskiIdealBound K⌋₊}"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T12:51:58.296Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-06-15",
+    "iteration": 2,
+    "focus": "Named the Minkowski bound and proved the class-number head-count; build pending.",
+    "blockers": [
+      "Worktree Docker olean cache unavailable — file not kernel-checked.",
+      "Aristotle MCP endpoint returned 'Resource not found'."
+    ],
+    "nextAction": "Green Docker build to promote status to verified; resubmit to Aristotle when endpoint recovers.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS (build pending): named the Minkowski bound (minkowskiIdealBound), restated the ideal-norm bound, and proved the new estimate classNumber K ≤ #{ideals of norm ≤ ⌊M_K⌋} — the formal backbone of the class-number algorithm, not present in Mathlib.",
+    "builtItems": [
+      "MinkowskiIdealBound.minkowskiIdealBound — reusable def of the Minkowski bound (MinkowskiTheoremOQ03.lean:60)",
+      "MinkowskiIdealBound.minkowskiIdealBound_nonneg — bound ≥ 0 (MinkowskiTheoremOQ03.lean:65)",
+      "MinkowskiIdealBound.exists_ideal_in_class_absNorm_le — ideal-norm bound vs named constant (MinkowskiTheoremOQ03.lean:74)",
+      "MinkowskiIdealBound.classNumber_le_card_absNorm_le — new class-number head-count (MinkowskiTheoremOQ03.lean:85)"
+    ],
+    "insights": [
+      "Mathlib's Minkowski bound is only a local notation inside ClassNumber.lean, so it is not reusable downstream; reintroducing it as a definition character-for-character identical to the notation lets exists_ideal_in_class_of_norm_le be reused by definitional unfolding (unfold; exact).",
+      "The headline ideal-norm bound and class-group finiteness are already in Mathlib; the genuine new content is the explicit head-count classNumber ≤ #{ideals of bounded norm}.",
+      "Counting step: the class-representative map from {ideals of norm ≤ ⌊M_K⌋} onto the class group is surjective (content of the Minkowski bound), and Nat.card_le_card_of_surjective converts this into the cardinality inequality.",
+      "Real→ℕ collapse: absNorm I is a natural number bounded by the real M_K ≥ 0, so Nat.le_floor gives absNorm I ≤ ⌊M_K⌋, matching the natural-number-indexed finiteness lemma finite_setOf_absNorm_le₀."
+    ],
+    "mathlibGaps": [
+      "No reusable named definition of the Minkowski bound (Mathlib hides it as a local notation M K).",
+      "No explicit statement classNumber ≤ #{ideals of norm ≤ ⌊M_K⌋} (the class-number algorithm's backbone).",
+      "No clean NumberField instance with computed discriminant for a concrete quadratic field, blocking a worked 'ℚ(√d) is a PID via the bound' example."
+    ],
+    "nextSteps": [
+      "Green Docker build to promote status to verified/original; if 'unfold; exact' fails on the restatement, try simpa only [minkowskiIdealBound] or massage the √|discr K| coercion.",
+      "Resubmit to Aristotle when its MCP endpoint recovers for an independent verified proof.",
+      "Concrete example: prove ℚ(√-1)/ℚ(√-3)/ℚ(√5) has class number 1 via isPrincipalIdealRing_of_abs_discr_lt once quadratic-field discriminant infrastructure exists."
+    ]
   },
   "tags": [
     "number-theory",
     "algebraic-number-theory",
     "minkowski",
-    "ideals"
+    "ideals",
+    "class-group",
+    "class-number",
+    "geometry-of-numbers"
   ],
   "relatedProofs": [
     "minkowski-theorem",
     "minkowski-theorem-oq-02"
   ],
   "references": {
-    "papers": [],
+    "papers": [
+      "Marcus, Number Fields, Theorem 37 and following discussion"
+    ],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib/NumberTheory/NumberField/ClassNumber.lean @ 2df2f0150c",
+      "Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean @ 2df2f0150c",
+      "Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean @ 2df2f0150c"
+    ]
   },
   "started": "2026-04-22T12:51:58.295Z",
-  "lastUpdate": "2026-04-22T12:51:58.295Z",
+  "lastUpdate": "2026-06-15",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/MinkowskiTheoremOQ02.lean",
-      "filename": "MinkowskiTheoremOQ02.lean",
-      "lineCount": 285,
-      "theoremCount": 6,
-      "axiomCount": 3,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ02.lean"
-    },
-    {
-      "path": "Proofs/MinkowskiTheoremOQ02OQ01.lean",
-      "filename": "MinkowskiTheoremOQ02OQ01.lean",
-      "lineCount": 268,
-      "theoremCount": 7,
+      "path": "Proofs/MinkowskiTheoremOQ03.lean",
+      "filename": "MinkowskiTheoremOQ03.lean",
+      "lineCount": 113,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ02OQ01.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Addresses the open question **minkowski-theorem-oq-03** ("Minkowski Bound on Ideal Norms: Geometry of Numbers Connection"). New file `proofs/Proofs/MinkowskiTheoremOQ03.lean` (1 def, 3 theorems, 0 sorries, 0 axiom declarations) plus gallery entry.

- **`minkowskiIdealBound K`** — a reusable definition of the Minkowski bound `M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K|`. Mathlib only exposes this as a *local notation* inside `ClassNumber.lean`, so it cannot be referenced downstream.
- **`exists_ideal_in_class_absNorm_le`** — every ideal class contains an integral ideal of norm ≤ `minkowskiIdealBound K` (restatement of `NumberField.exists_ideal_in_class_of_norm_le` against the named constant; closed by `unfold; exact` via definitional equality).
- **`classNumber_le_card_absNorm_le`** — *new* quantitative estimate `classNumber K ≤ Nat.card {I : (Ideal (𝓞 K))⁰ // absNorm (↑I) ≤ ⌊M_K⌋}`. This is the formal backbone of the standard class-number algorithm (enumerate ideals below the bound) and is **not** recorded in Mathlib. It refines the bare finiteness of the class group into an explicit head-count.

## Honest scope

Mathlib already proves the headline ideal-norm bound and class-group finiteness; the genuinely new content here is (a) the reusable named bound and (b) the explicit class-number head-count. The "small bound ⟹ PID" criterion is also already in Mathlib (`isPrincipalIdealRing_of_abs_discr_lt`), so it was not duplicated. A concrete worked example (specific quadratic field → class number 1) is the natural next step but is blocked by the absence of a clean quadratic-field discriminant instance in Mathlib.

All referenced lemmas (`NumberField.exists_ideal_in_class_of_norm_le`, `Ideal.finite_setOf_absNorm_le₀`, `Nat.card_le_card_of_surjective`, `Nat.le_floor`, `Nat.card_eq_fintype_card`) were name-checked against pinned Mathlib rev `2df2f0150c`.

## Build status

**Build pending.** The worktree Docker olean cache is unavailable this session and the Aristotle MCP endpoint returned "Resource not found", so the file was not kernel-checked. Gallery meta is set to `formalized`/`wip` accordingly; promote to `verified`/`original` after a green Docker build (the deployer build-gate is the verifier).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ03` is green when the cache is warm
- [ ] If `unfold; exact` fails on the restatement, fall back to `simpa only [minkowskiIdealBound]` / coercion massage on `√|discr K|`
- [ ] `pnpm build` renders the gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)