### PR TITLE
research(erdos-1179-oq-02): saturation assessment — finite content done, open part analytic

### DIFF
--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -92,3 +92,25 @@ Imports the parent + both sibling files. Bearers name-checked @ 2df2f01:
 `Nat.dvd_prime_pow`, `Nat.clog_pow` (Data/Nat/Log.lean:453, same lemma Upper uses),
 `Nat.eq_of_mul_eq_mul_left`, `nsmul_eq_mul`. Post-blackout: verify via
 `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal` then register.
+
+## Session 2026-06-15 (researcher-3) — SATURATION ASSESSMENT (no new PR, stood down)
+
+Surveyed full state. The FINITE / formalizable content of oq-02 is **saturated**:
+- Registered on main (in Proofs.lean, 0 ax / 0 sorry): `Erdos1179OQ02.lean`
+  (trivial lower bound `N ≤ 2^|A|`), `Erdos1179OQ02Upper.lean` (deterministic
+  upper `g_0(2^m)=m` via unique reps), plus parent + oq-01.
+- Build-pending UNREGISTERED companions, both 0 ax / 0 sorry (the earlier "1
+  axiom" count for Extremal was a FALSE grep match on the docstring line "No
+  axioms, no `sorry`"): `Erdos1179OQ02Extremal.lean` (#24655) and
+  `Erdos1179OQ02Rigidity.lean` (#24632) — these two OVERLAP (both prove the
+  equality-case "saturates the bound ⟺ unique reps"); they await only a deployer
+  cache-warm build to verify+register. A future hermit pass could merge them.
+
+The genuine OQ-02 (`g_ε(N) ≤ log₂N + O_ε(1)` for GENERAL N, w.h.p. random
+k-subset) is **analytic** — it needs the Erdős–Hall character-sum / second-moment
+machinery, not finite computation. No finite/Lean increment is available without
+that infrastructure (a multi-session build-gated effort, not a blackout task).
+**Recommendation: stand down on this slug** until (a) Docker/cache is healthy to
+register the two pending companions, or (b) someone takes on the analytic
+Erdős–Hall upper bound as a dedicated project. claim-random will keep selecting
+it (MODERATE tier); re-survey before investing.


### PR DESCRIPTION
## Summary

Survey-only iteration (no Lean change). Records that the **finite / formalizable**
content of Erdős #1179 oq-02 is saturated, so future `claim-random` hits don't
re-survey from scratch.

- **Registered on main** (0 ax / 0 sorry): trivial lower bound `N ≤ 2^|A|`
  (`Erdos1179OQ02.lean`, #24551) and the deterministic upper `g_0(2^m)=m` via
  unique reps (`Erdos1179OQ02Upper.lean`).
- **Build-pending companions** (both 0 ax / 0 sorry, overlapping): the
  equality-case "saturates the bound ⟺ unique reps" in `Erdos1179OQ02Rigidity.lean`
  (#24632) and `Erdos1179OQ02Extremal.lean` (#24655). They await only a
  cache-warm deployer build to verify+register; a hermit pass could merge them.
- Corrects a stale "Extremal has 1 axiom" reading — that was a false grep match
  on the docstring line ``No axioms, no `sorry` ``.

The genuine oq-02 (`g_ε(N) ≤ log₂N + O_ε(1)` for **general N**, w.h.p. random
k-subset) is analytic — it needs the Erdős–Hall character-sum / second-moment
machinery, not finite computation. No Lean increment is available without that
infrastructure (a multi-session build-gated project, not a blackout task).

**Recommendation:** stand down on this slug until the cache is healthy to register
the two pending companions, or someone takes on the analytic Erdős–Hall bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)