### PR TITLE
research(erdos-1047-oq-02): BUILD GREEN + register topological reduction bridge

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -805,6 +805,7 @@ import Proofs.Erdos1045Problem
 import Proofs.Erdos1046Problem
 import Proofs.Erdos1047Problem
 import Proofs.Erdos1047OQ02
+import Proofs.Erdos1047OQ02Reduction
 import Proofs.Erdos1048Aristotle
 import Proofs.Erdos1048Problem
 import Proofs.Erdos1048ProblemAristotle

--- a/proofs/Proofs/Erdos1047OQ02Reduction.lean
+++ b/proofs/Proofs/Erdos1047OQ02Reduction.lean
@@ -33,9 +33,9 @@
   No new axioms are introduced.  The two lemmas are pure ZFC/topology facts about
   `connectedComponentIn` and the file's `IsConvexComplex` predicate.
 
-  STATUS: hand-authored under an extended Docker outage (2026-06-15); BUILD-PENDING
-  and intentionally UNREGISTERED (not in `Proofs.lean`) so it cannot affect the
-  compiling gallery until a real build confirms it.  Both proofs rest only on the
+  STATUS: BUILD-VERIFIED and REGISTERED (2026-06-15). `docker-build.sh
+  Proofs.Erdos1047OQ02Reduction` compiled green (3059 jobs); now imported in
+  `Proofs.lean` so the gallery machine-checks it.  Both proofs rest only on the
   standard Mathlib lemmas `IsPreconnected.subset_connectedComponentIn` and
   `connectedComponentIn_subset`.
 -/

--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -654,3 +654,37 @@ Docker-up session formalizes the 4 segment inequalities to eliminate the axiom
 **Non-dup check**: none of the 15 prior `*.py` scripts produce a chord-exits /
 saddle certificate (all were curvature- or onset-window-based); no open PRs on
 the slug. This is the first witness in the exact shape the reduction lemma wants.
+
+---
+
+## Session 2026-06-15 (researcher-1) — BUILD GREEN + REGISTER the reduction bridge
+
+**Mode**: ACT (build/register) · **Outcome**: `Erdos1047OQ02Reduction.lean` is now
+**machine-checked and registered**. Docker recovered this session (`lake exe cache get`
+works), so the file that prior sessions left BUILD-PENDING/UNREGISTERED under the blackout
+finally compiled.
+
+### What I did
+- `LEAN_MEMORY_LIMIT=6144 docker-build.sh Proofs.Erdos1047OQ02Reduction`
+  → **"Build completed successfully (3059 jobs)"**, module built in 32s, exit 0, 0 errors.
+- **Registered** it: added `import Proofs.Erdos1047OQ02Reduction` to `proofs/Proofs.lean`
+  (after `Erdos1047OQ02`), so the aggregate gallery build now machine-checks the two
+  reduction theorems `not_isConvexComplex_componentContaining_of_preconnected_chord_exits`
+  and `componentContaining_lemniscate_not_convex_of_chord_exits` (0 axioms, 0 sorries; rest
+  only on `IsPreconnected.subset_connectedComponentIn` + `connectedComponentIn_subset`).
+- Updated the file's STATUS header (BUILD-PENDING/UNREGISTERED → BUILD-VERIFIED/REGISTERED).
+  Only post-build edit is comment text inside a `/- -/` block — no semantic impact.
+
+### What this does and does NOT do
+- **Does**: turns the reusable topological reduction (the bridge behind *every* Grunsky
+  counterexample — Pommerenke/Goodman/referee) into verified, gallery-checked infrastructure.
+- **Does NOT**: discharge the lone axiom `goodman_counterexample` in `Erdos1047Problem.lean`.
+  The slug stays `axiomatized` (axiomCount 1). Eliminating the axiom still needs the
+  chord-exits **certificate** Lean (R4 blueprint: 4 degree-8 segment inequalities
+  `|f((1-s)a+s b)|² ≤ 125/16` on `s∈[0,1]` via nlinarith/polyrith + a preconnected polyline
+  arc `-i→(1-i)/2→2→(1+i)/2→+i`, fed into the now-verified reduction lemma). That remains the
+  next ACT step — but the consuming lemma it targets is now machine-checked, de-risking it.
+
+### Gallery meta
+Left `src/data/proofs/erdos-1047-oq-02/meta.json` untouched (status stays `axiomatized`,
+axiomCount 1 — correct; theoremCount sync is contested by open enricher PRs, deferred to them).


### PR DESCRIPTION
## Summary
- **Build-verified and registered** `Proofs/Erdos1047OQ02Reduction.lean` — `docker-build.sh Proofs.Erdos1047OQ02Reduction` compiled green (**3059 jobs**, module built in 32s, 0 errors). Prior sessions hand-authored this file under the Docker blackout and left it BUILD-PENDING/UNREGISTERED; with Docker recovered it now machine-checks.
- Added `import Proofs.Erdos1047OQ02Reduction` to `proofs/Proofs.lean` so the aggregate gallery build covers its two reduction theorems (`not_isConvexComplex_componentContaining_of_preconnected_chord_exits`, `componentContaining_lemniscate_not_convex_of_chord_exits` — 0 axioms, 0 sorries; rest only on `IsPreconnected.subset_connectedComponentIn` + `connectedComponentIn_subset`).

This is the reusable topological bridge behind every Grunsky counterexample (Pommerenke/Goodman/referee): it reduces non-convexity of a lemniscate component to "exhibit a preconnected arc whose chord pokes outside the sublevel set."

## Scope (honest)
- This does **not** discharge the lone axiom `goodman_counterexample` in `Erdos1047Problem.lean` — the slug stays `axiomatized` (axiomCount 1). Eliminating it still needs the chord-exits **certificate** Lean (the R4 blueprint: 4 degree-8 segment inequalities + a preconnected polyline arc, fed into this now-verified lemma). That remains the next ACT step; this PR de-risks it by machine-checking the consuming lemma.
- Only post-build edit to the `.lean` is a status comment inside a `/- -/` block (no semantic impact). Gallery `meta.json` left untouched (contested by open enricher PRs).

## Test plan
- [x] `docker-build.sh Proofs.Erdos1047OQ02Reduction` → "Build completed successfully (3059 jobs)", exit 0
- [x] Registered import added in alphabetical position after `Erdos1047OQ02`

🤖 Generated with [Claude Code](https://claude.com/claude-code)