### PR TITLE
Fix: correct understated counts in friendship-theorem-oq-04 meta

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-04/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 196,
     "assumptions": "No axioms or sorries. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. BUILD-PENDING: the file is registered in Proofs.lean (via #24505) but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded once a green build is on record.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
@@ -30,7 +30,7 @@
       "infinite_friendship_has_infinite_degree: contrapositive — an infinite friendship graph must contain an infinite-degree vertex (matching the C₅ free-amalgamation counterexample)",
       "locally_finite_friendship_has_universal: combining diameter-2 + local finiteness with the finite gallery theorem recovers a universal ('politician') vertex, avoiding the spectral argument entirely"
     ],
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct the `lineCount` and `theoremCount` in `friendship-theorem-oq-04/meta.json` to match the current Lean source. Metadata-only, safe-direction (the entry was *understating* its work — no overclaim).

## Evidence (independently recounted against current origin/main)

`proofs/Proofs/FriendshipTheoremOQ04.lean`:
- **196 lines** (meta said 145)
- **9 theorems** at lines 69, 80, 88, 105, 118, 129, 140, 162, 190 — all plain `theorem` (meta said 7)
- 1 `def` (`IsFriendshipGraph`, line 64) — unchanged
- 0 sorries, 0 axioms, `status: formalized` / `badge: wip` — all correct, unchanged

**Before**: `lineCount: 145`, `theoremCount: 7`
**After**: `lineCount: 196`, `theoremCount: 9`

## Note on the second entry in the issue

The issue also flagged `greens-theorem-oq-02-oq-02` (claimed meta `182/6` vs source `214 lines/8 theorems`). That premise is **stale**: on current `origin/main` the meta already reads `lineCount: 58, theoremCount: 1`, and the `proofRepoPath` file `GreensTheoremOQ02Corrected.lean` is exactly 58 lines / 1 theorem (`counterexample_violates_hLineEq`). They already match — no fix needed. The auditor measured a pre-refactor/different file.

Closes #24700

---
Automated fix by lean-mechanic agent.