### PR TITLE
Enrich morleys-theorem-oq-03: full-file section coverage

### DIFF
--- a/src/data/proofs/morleys-theorem-oq-03/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-03/meta.json
@@ -71,6 +71,13 @@
   },
   "sections": [
     {
+      "id": "header-and-setup",
+      "title": "Problem Statement and Setup",
+      "summary": "Module docstring framing the extremal question (largest Morley triangle at fixed circumradius), the calculus-free strategy (substitute aᵢ=αᵢ/3, bound the product of sines by its value at the mean π/9 via AM–GM and Jensen), and the namespace/imports (Mathlib, open Real Set)",
+      "startLine": 1,
+      "endLine": 49
+    },
+    {
       "id": "analytic-inequalities",
       "title": "Two Analytic Inequalities",
       "summary": "AM–GM for three nonnegatives (explicit SOS certificate) and three-point Jensen for sin on [0, π] (chained two-point concavity)",


### PR DESCRIPTION
Enrichment pass for `morleys-theorem-oq-03`.

## Gap addressed
The `sections` array previously started at line 50, leaving the module header (docstring stating the extremal problem + proof strategy), the `import Mathlib`, and the `namespace`/`open` setup (lines 1-49) with no section coverage.

## Change
Added a 5th section **"Problem Statement and Setup"** (lines 1-49). Sections now contiguously span the entire 331-line proof file.

## Effect
Gallery quality score 98 → 100 (sections sub-score 8/10 → 10/10). No other fields touched; the entry's 5 annotations, overview, conclusion, cross-references, and references were already fully enriched and accurate (verified counts: 331 lines, 9 theorems, 0 axioms, 0 sorries).

Status (`formalized`/`wip`, build-pending) intentionally left unchanged — a verified build is a separate concern handled elsewhere.