### PR TITLE
audit: correct stale theorem/line counts in friendship-theorem-oq-04

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-04/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 196,
     "assumptions": "No axioms or sorries. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. BUILD-PENDING: the file is registered in Proofs.lean (via #24505) but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded once a green build is on record.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
@@ -30,7 +30,7 @@
       "infinite_friendship_has_infinite_degree: contrapositive — an infinite friendship graph must contain an infinite-degree vertex (matching the C₅ free-amalgamation counterexample)",
       "locally_finite_friendship_has_universal: combining diameter-2 + local finiteness with the finite gallery theorem recovers a universal ('politician') vertex, avoiding the spectral argument entirely"
     ],
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "overview": {


### PR DESCRIPTION
## Summary
Gallery integrity audit fix. `friendship-theorem-oq-04` meta.json understated its counts — the Lean file grew after meta was authored.

- `Proofs/FriendshipTheoremOQ04.lean` (current origin/main): **9** theorems, **196** lines
- meta.json claimed: 7 theorems, 145 lines → corrected to 9 / 196

No overclaim: this is an **understatement** (safe direction). `status: formalized`/`wip`, 0 sorries, 0 axioms — all already correct and unchanged.

## Context
Filed under gallery integrity audit (issue #24700). The other entries flagged in that issue (greens-theorem-oq-02-oq-02, spherical-law-of-cosines-oq-03, sqrt2…-oq-01) turned out to be **already consistent on current origin/main** — the earlier discrepancy was read against a churned-back commit. Only friendship had a genuine live drift.

Gallery-data only; no Lean source changes.

## Test plan
- [x] Recomputed theorem/line counts from source against current origin/main
- [x] Confirmed 0 sorries / 0 axioms / status unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)