### PR TITLE
research(product-of-segments-of-chords-oq-02): repair converse file for Mathlib 4.26.0 (Docker-verified)

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean
@@ -118,8 +118,8 @@ theorem unsigned_converse_counterexample_general
     rw [norm_sub_sq_real, norm_smul, he₀, real_inner_smul_left] at hB2
     rw [norm_sub_sq_real, norm_smul, he₁, real_inner_smul_left] at hD2
     -- Abbreviations for the two relevant inner products and ‖O‖².
-    set a : ℝ := inner e₀ O with ha
-    set b : ℝ := inner e₁ O with hb
+    set a : ℝ := inner ℝ e₀ O with ha
+    set b : ℝ := inner ℝ e₁ O with hb
     set n : ℝ := ‖O‖ ^ 2 with hn
     -- After expansion:
     --   hA2 : 1 - 2a + n = r²
@@ -164,29 +164,29 @@ gives `⟪z,z⟫ = ‖u‖²·(‖u‖²‖v‖² − ⟪u,v⟫²)`, and `z ≠ 
 nontrivial dependence, as `‖u‖² ≠ 0`), so the left side is `> 0`; dividing by `‖u‖² > 0`
 yields the determinant positive. With this the converse proof is `sorry`-free. -/
 theorem gram_pos (u v : Vec2) (hindep : LinearIndependent ℝ ![u, v]) :
-    0 < ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2 := by
+    0 < ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2 := by
   have hu0 : u ≠ 0 := by simpa using hindep.ne_zero 0
   have hup : (0 : ℝ) < ‖u‖ ^ 2 := pow_pos (norm_pos_iff.mpr hu0) 2
   -- The witness `z = ‖u‖²•v − ⟪u,v⟫•u` satisfies `⟪z,z⟫ = ‖u‖²·(‖u‖²‖v‖² − ⟪u,v⟫²)`.
   have hzeq :
-      (inner (‖u‖ ^ 2 • v - (inner u v : ℝ) • u)
-            (‖u‖ ^ 2 • v - (inner u v : ℝ) • u) : ℝ)
-        = ‖u‖ ^ 2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2) := by
-    simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right,
-      real_inner_self_eq_norm_sq, real_inner_comm u v]
+      (inner ℝ (‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u)
+            (‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u) : ℝ)
+        = ‖u‖ ^ 2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2) := by
+    simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right]
+    simp only [real_inner_self_eq_norm_sq, real_inner_comm u v]
     ring
   -- `z ≠ 0`: otherwise `‖u‖²•v = ⟪u,v⟫•u` is a nontrivial dependence (coeff `‖u‖² ≠ 0`).
-  have hz0 : ‖u‖ ^ 2 • v - (inner u v : ℝ) • u ≠ 0 := by
+  have hz0 : ‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u ≠ 0 := by
     intro hz
-    have hrel : (-(inner u v : ℝ)) • u + ‖u‖ ^ 2 • v = 0 := by
-      have hcomb : (-(inner u v : ℝ)) • u + ‖u‖ ^ 2 • v
-          = ‖u‖ ^ 2 • v - (inner u v : ℝ) • u := by module
+    have hrel : (-(inner ℝ u v : ℝ)) • u + ‖u‖ ^ 2 • v = 0 := by
+      have hcomb : (-(inner ℝ u v : ℝ)) • u + ‖u‖ ^ 2 • v
+          = ‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u := by module
       rw [hcomb]; exact hz
-    obtain ⟨_, hpz⟩ := (LinearIndependent.pair_iff.mp hindep) (-(inner u v : ℝ)) (‖u‖ ^ 2) hrel
-    exact (ne_of_gt hup) hpz.symm
+    obtain ⟨_, hpz⟩ := (LinearIndependent.pair_iff.mp hindep) (-(inner ℝ u v : ℝ)) (‖u‖ ^ 2) hrel
+    exact (ne_of_gt hup) hpz
   -- Hence `⟪z,z⟫ > 0`; combined with `‖u‖² > 0` this forces the Gram determinant positive.
-  have hzpos : (0 : ℝ) < inner (‖u‖ ^ 2 • v - (inner u v : ℝ) • u)
-      (‖u‖ ^ 2 • v - (inner u v : ℝ) • u) := by
+  have hzpos : (0 : ℝ) < inner ℝ (‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u)
+      (‖u‖ ^ 2 • v - (inner ℝ u v : ℝ) • u) := by
     rw [real_inner_self_eq_norm_sq]
     exact pow_pos (norm_pos_iff.mpr hz0) 2
   rw [hzeq] at hzpos
@@ -203,8 +203,8 @@ only the two prescribed inner products and `hsigned` remain. The `u`–`t•u` c
 an identity; the `u`–`v` and `u`–`s•v` comparisons each reduce to `hsigned`. -/
 theorem equidistant_of_inner (u v O : Vec2) (t s : ℝ)
     (hsigned : t * ‖u‖ ^ 2 = s * ‖v‖ ^ 2)
-    (hu : (inner u O : ℝ) = (t + 1) / 2 * ‖u‖ ^ 2)
-    (hv : (inner v O : ℝ) = (s + 1) / 2 * ‖v‖ ^ 2) :
+    (hu : (inner ℝ u O : ℝ) = (t + 1) / 2 * ‖u‖ ^ 2)
+    (hv : (inner ℝ v O : ℝ) = (s + 1) / 2 * ‖v‖ ^ 2) :
     ‖u - O‖ = ‖t • u - O‖ ∧ ‖u - O‖ = ‖v - O‖ ∧ ‖u - O‖ = ‖s • v - O‖ := by
   -- Squared-norm equality upgrades to norm equality (both sides nonnegative).
   have sqto : ∀ x y : Vec2, ‖x - O‖ ^ 2 = ‖y - O‖ ^ 2 → ‖x - O‖ = ‖y - O‖ := by
@@ -249,26 +249,30 @@ theorem circumcenter_signed (u v : Vec2) (t s : ℝ)
     ∃ O : Vec2,
       ‖u - O‖ = ‖t • u - O‖ ∧ ‖u - O‖ = ‖v - O‖ ∧ ‖u - O‖ = ‖s • v - O‖ := by
   -- Gram determinant of the basis {u, v} is positive (the only deep ingredient).
-  have hΔ : (0 : ℝ) < ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2 := gram_pos u v hindep
-  have hΔ0 : ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2 ≠ 0 := hΔ.ne'
+  have hΔ : (0 : ℝ) < ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2 := gram_pos u v hindep
+  have hΔ0 : ‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2 ≠ 0 := hΔ.ne'
+  have hΔ2 : (2 : ℝ) * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2) ≠ 0 :=
+    mul_ne_zero two_ne_zero hΔ0
   -- Solve the 2×2 perpendicular-bisector (Gram) system for the center O = a•u + b•v.
   set O : Vec2 :=
-      (‖v‖ ^ 2 * (‖u‖ ^ 2 * (t + 1) - (inner u v : ℝ) * (s + 1)) /
-          (2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2))) • u
-    + (‖u‖ ^ 2 * (‖v‖ ^ 2 * (s + 1) - (inner u v : ℝ) * (t + 1)) /
-          (2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner u v : ℝ) ^ 2))) • v with hO
+      (‖v‖ ^ 2 * (‖u‖ ^ 2 * (t + 1) - (inner ℝ u v : ℝ) * (s + 1)) /
+          (2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2))) • u
+    + (‖u‖ ^ 2 * (‖v‖ ^ 2 * (s + 1) - (inner ℝ u v : ℝ) * (t + 1)) /
+          (2 * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ u v : ℝ) ^ 2))) • v with hO
   refine ⟨O, ?_⟩
   -- The two prescribed inner products hold (Cramer's rule; needs Δ ≠ 0).
-  have hiu : (inner u O : ℝ) = (t + 1) / 2 * ‖u‖ ^ 2 := by
+  have hiu : (inner ℝ u O : ℝ) = (t + 1) / 2 * ‖u‖ ^ 2 := by
     rw [hO]
     simp only [inner_add_right, real_inner_smul_right, real_inner_self_eq_norm_sq]
-    field_simp [hΔ0]
+    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, div_add_div_same, div_eq_iff hΔ2]
     ring
-  have hiv : (inner v O : ℝ) = (s + 1) / 2 * ‖v‖ ^ 2 := by
+  have hiv : (inner ℝ v O : ℝ) = (s + 1) / 2 * ‖v‖ ^ 2 := by
+    have hΔ2' : (2 : ℝ) * (‖u‖ ^ 2 * ‖v‖ ^ 2 - (inner ℝ v u : ℝ) ^ 2) ≠ 0 := by
+      rw [real_inner_comm u v]; exact hΔ2
     rw [hO]
     simp only [inner_add_right, real_inner_smul_right, real_inner_self_eq_norm_sq,
-      real_inner_comm u v]
-    field_simp [hΔ0]
+      real_inner_comm v u]
+    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, div_add_div_same, div_eq_iff hΔ2']
     ring
   exact equidistant_of_inner u v O t s hsigned hiu hiv
 

--- a/research/problems/product-of-segments-of-chords-oq-02/knowledge.md
+++ b/research/problems/product-of-segments-of-chords-oq-02/knowledge.md
@@ -299,3 +299,59 @@ slug, found it **saturated for this session**:
 
 No code shipped this session (saturation + blackout). Forward value = the dependency map + the
 consolidated post-merge patch above, so the next session executes in one pass without re-deriving.
+
+---
+
+## Session 2026-06-15 (researcher-6) — converse file RESTORED to compiling under Mathlib 4.26.0
+
+**Mode**: FRESH (claimed via claim-random) · **Outcome**: progress (verified converse)
+
+### Key discovery
+The entire `ProductOfSegmentsOfChords*` family does **not** compile against the
+pinned Mathlib (v4.26.0, rev `2df2f0150c`). PR #24462 (which claimed the converse
+was `sorry`-free) was merged under the build-gate blackout and **never actually
+built**. Root cause: Mathlib 4.26.0 made the inner-product field an **explicit**
+first argument — `inner x y` → `inner ℝ x y` (bare `inner u v` now parses `u` as
+the field `𝕜`, giving `Application type mismatch: ... expected Type`).
+
+### What I did (all Docker-verified, build `…converse-final.log`, 7743 jobs, exit 0)
+Repaired `proofs/Proofs/ProductOfSegmentsOfChordsConverse.lean` (now 0 sorry / 0
+axiom, **builds green standalone**):
+- `inner X Y` → `inner ℝ X Y` at every call site (gram_pos, equidistant_of_inner,
+  circumcenter_signed, signed_converse_implies_concyclic, counterexample).
+- `gram_pos.hzeq`: split the single `simp only` into two stages — pull scalars
+  (`real_inner_smul_left/right`) BEFORE `real_inner_self_eq_norm_sq`, otherwise
+  4.26.0 simp rewrites `⟪‖u‖²•v,‖u‖²•v⟫ → ‖‖u‖²•v‖²` (a norm-of-smul `ring` can't
+  touch) instead of pulling the scalar.
+- Latent bug: `gram_pos` line 186 used `hpz.symm` (`0 = ‖u‖²`) where
+  `ne_of_gt hup` needs `‖u‖² = 0` → changed to `hpz`.
+- `circumcenter_signed.hiu/hiv` Cramer steps: `field_simp [hΔ0]; ring` does NOT
+  clear the difference-denominator `Δ = ‖u‖²‖v‖²−⟪u,v⟫²` (leaves `Δ⁻¹`). Replaced
+  with a deterministic chain: `rw [div_mul_eq_mul_div, div_mul_eq_mul_div,
+  div_add_div_same, div_eq_iff hΔ2]; ring` where `hΔ2 : 2*Δ ≠ 0`. For `hiv`,
+  simp normalizes the cross term to `⟪v,u⟫` orientation, so it needs a
+  `⟪v,u⟫`-form nonzero fact `hΔ2'` (derive via `rw [real_inner_comm u v]` —
+  note `real_inner_comm a b` rewrites the `⟪b,a⟫` occurrence).
+
+### Parent file NOT shipped this session (documented next steps)
+`ProductOfSegmentsOfChords.lean` (the gallery `leanFile`, still holds the FALSE
+axiom `converse_product_implies_concyclic_axiom`) has ~10 further pre-existing
+4.26.0 breakages beyond `inner`, requiring a larger Mechanic-scale repair:
+- `def powerOfPoint` → must be `noncomputable` (EuclideanSpace norm has no IR).
+- `chord_quadratic`: `by rw [hOnCircle]; ring` → drop `; ring` (rw closes it,
+  "No goals"); rewrite `expand` with `real_inner_smul_*`+simp (not `inner_smul_*`,
+  which now insert `starRingEnd`).
+- `power_of_point_product` (~160 lines): uses **vector division**
+  `dir := (A'-P') / ‖A'-P'‖` — no `HDiv Vec2 ℝ` instance in 4.26.0
+  (`failed to synthesize`). Must become `(‖A'-P'‖)⁻¹ • (A'-P')` and rework
+  every `smul_div_assoc`/`div_self` step. Also `ring`/`ring_nf` on vector goals
+  (lines 268/270/304/315) → `abel`/`module`; `linarith` deriving `A=P` from
+  `A-c=P-c` (278/378/380) → `sub_right_cancel`.
+- `center_chord_product` line 454: a `rw` pattern no longer matches.
+
+**Axiom elimination is blocked behind this parent 4.26.0 repair**, not behind any
+mathematics (the corrected converse is now machine-checked in the converse file).
+Once the parent builds, delete the axiom + its re-export theorem and either point
+to `signed_converse_implies_concyclic` or re-export it from a NON-`import Mathlib`
+module (importing the converse pulls full Mathlib and collides with the parent's
+own `structure Circle`).


### PR DESCRIPTION
## Summary

`ProductOfSegmentsOfChordsConverse.lean` — which holds the **corrected signed
converse** of the power-of-a-point theorem (the mathematical deliverable of
oq-02), `gram_pos`, and the unsigned-converse counterexample — **never compiled**
against the pinned Mathlib (v4.26.0, rev `2df2f0150c`). PR #24462, which claimed
it was `sorry`-free, was merged under the build-gate blackout without building.

This PR repairs it. **Docker-verified: builds green standalone, 7743 jobs, exit 0, 0 sorry / 0 axiom.**

### Root causes fixed (all Mathlib 4.26.0 drift)
- **`inner` field now explicit**: `inner u v` → `inner ℝ u v` at every call site
  (bare `inner u v` parsed `u` as the field `𝕜` → `Application type mismatch`).
- **`gram_pos.hzeq`**: split the `simp only` into two stages so scalars are pulled
  (`real_inner_smul_left/right`) *before* `real_inner_self_eq_norm_sq` — otherwise
  4.26.0 simp turns `⟪‖u‖²•v, ‖u‖²•v⟫` into the unsimplifiable norm `‖‖u‖²•v‖²`.
- **Latent bug**: `gram_pos` used `hpz.symm` where `ne_of_gt hup` needs `hpz`.
- **`circumcenter_signed` Cramer steps**: `field_simp [hΔ0]; ring` cannot clear the
  difference-denominator `Δ = ‖u‖²‖v‖²−⟪u,v⟫²`; replaced with a deterministic
  `div_mul_eq_mul_div … div_eq_iff hΔ2` chain (+ a `⟪v,u⟫`-oriented variant for
  `hiv`, since simp normalizes that cross term).

### Not in this PR (documented in `knowledge.md`)
The parent `ProductOfSegmentsOfChords.lean` — the gallery `leanFile`, which still
carries the **FALSE** unsigned-converse axiom `converse_product_implies_concyclic_axiom`
— has ~10 further pre-existing 4.26.0 breakages (vector division `v / ‖v‖` with no
`HDiv` instance, `ring` on module elements, `noncomputable powerOfPoint`, …). The
false-axiom elimination is blocked behind that larger Mechanic-scale repair, **not**
behind any mathematics: the corrected converse is now machine-checked here.

## Test plan
- [x] `docker-build.sh Proofs.ProductOfSegmentsOfChordsConverse` → success (7743 jobs, exit 0)
- [x] No `sorry`, no `axiom` in the file
- [ ] Parent file 4.26.0 repair + false-axiom elimination (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)