### PR TITLE
research(euler-totient-oq-01-oq-03): repair Carmichael dep, machine-verify, restore verified

### DIFF
--- a/proofs/Proofs/EulerTotientOQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ01.lean
@@ -46,7 +46,7 @@ theorem carmichael_dvd_totient (n : ℕ) [NeZero n] :
   unfold carmichael
   rw [show Nat.totient n = Fintype.card (ZMod n)ˣ from
     (ZMod.card_units_eq_totient n).symm]
-  exact Monoid.exponent_dvd_card
+  exact Group.exponent_dvd_card
 
 /-- λ(n) is the minimal universal exponent: if a^e = 1 for all units a,
     then λ(n) | e. -/
@@ -54,7 +54,7 @@ theorem carmichael_minimal (n : ℕ) [NeZero n] (e : ℕ)
     (he : ∀ a : (ZMod n)ˣ, a ^ e = 1) :
     carmichael n ∣ e := by
   unfold carmichael
-  exact Monoid.exponent_dvd_of_forall_pow_eq_one _ e he
+  exact Monoid.exponent_dvd_of_forall_pow_eq_one he
 
 /-- For prime p, λ(p) = p - 1 = φ(p).
     The group (ℤ/pℤ)* is cyclic of order p-1, so its exponent is p-1. -/
@@ -64,12 +64,16 @@ theorem carmichael_prime {p : ℕ} (hp : Nat.Prime p) :
   haveI : NeZero p := ⟨hp.ne_zero⟩
   haveI : Fact p.Prime := ⟨hp⟩
   -- (ℤ/pℤ)* is cyclic, so exponent = card = φ(p) = p - 1
-  rw [IsCyclic.exponent_eq_card, ZMod.card_units_eq_totient, Nat.totient_prime hp]
+  rw [IsCyclic.exponent_eq_card, Nat.card_eq_fintype_card, ZMod.card_units_eq_totient,
+    Nat.totient_prime hp]
 
 /-- λ(1) = 1: the trivial group has exponent 1. -/
 theorem carmichael_one : carmichael 1 = 1 := by
   unfold carmichael
-  exact Monoid.exponent_eq_one_of_subsingleton
+  have h : Fintype.card (ZMod 1)ˣ = 1 := by
+    rw [ZMod.card_units_eq_totient]; simp
+  exact Monoid.exp_eq_one_iff.mpr
+    (Fintype.card_le_one_iff_subsingleton.mp h.le)
 
 /-- λ(2) = 1: the group (ℤ/2ℤ)* = {1} has exponent 1. -/
 theorem carmichael_two : carmichael 2 = 1 := by
@@ -77,7 +81,7 @@ theorem carmichael_two : carmichael 2 = 1 := by
   have h : Fintype.card (ZMod 2)ˣ = 1 := by
     rw [ZMod.card_units_eq_totient]
     exact Nat.totient_prime (by norm_num)
-  exact Monoid.exponent_eq_one_iff.mpr
-    (Fintype.card_le_one_iff_subsingleton.mp (h ▸ le_refl 1))
+  exact Monoid.exp_eq_one_iff.mpr
+    (Fintype.card_le_one_iff_subsingleton.mp h.le)
 
 end CarmichaelFunction

--- a/proofs/Proofs/EulerTotientOQ01OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ03.lean
@@ -51,14 +51,13 @@
   • `rsa_decrypt_correct` — the textbook phrasing `m^(e·d) ≡ m` once
     `e·d = 1 + k·λ`.
 
-  Status: 0 axioms, 0 sorries.  Registered in `Proofs/Proofs.lean`.  Authored
-  under a Docker + Aristotle blackout; name-checked against pinned Mathlib
-  v4.26.0 (rev 2df2f01): `ZMod.pow_card_sub_one_eq_one` takes `{a}` IMPLICITLY
-  (FieldTheory/Finite/Basic.lean:605), so its earlier call passed `a` into the
-  `a ≠ 0` slot — fixed here.  `ZMod.chineseRemainder` confirmed
-  (Data/ZMod/Basic.lean:873).  The CRT componentwise step (`Prod.ext_iff` +
-  `simpa` on the projection-of-power simp lemmas) remains the one piece to
-  confirm in a live build.
+  Status: 0 axioms, 0 sorries.  Registered in `Proofs/Proofs.lean`.
+  Machine-verified via docker-build on 2026-06-15 (the dependency
+  `EulerTotientOQ01.lean` required seven Mathlib-API fixes to the Carmichael
+  infrastructure first).  `ZMod.pow_card_sub_one_eq_one` takes `{a}` IMPLICITLY
+  (FieldTheory/Finite/Basic.lean:605); `ZMod.chineseRemainder` confirmed
+  (Data/ZMod/Basic.lean:873); the CRT componentwise step (`Prod.ext_iff` +
+  `simpa` on the projection-of-power simp lemmas) typechecks.
 -/
 
 import Mathlib.Data.ZMod.Basic

--- a/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Robert Carmichael (1910); RSA: Rivest–Shamir–Adleman (1977); formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Carmichael_function",
     "date": "1977",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/EulerTotientOQ01OQ03.lean",
     "tags": [
       "number-theory",
@@ -18,10 +18,10 @@
       "chinese-remainder-theorem",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Build-pending: authored during the Docker + Aristotle backend outage and not machine-checked this session. The load-bearing Mathlib bearers were name-checked against pinned v4.26.0 (rev 2df2f01): ZMod.pow_card_sub_one_eq_one takes its element {a} IMPLICITLY (FieldTheory/Finite/Basic.lean:605), and ZMod.chineseRemainder is confirmed (Data/ZMod/Basic.lean:873). The file's own header flags the CRT componentwise step (Prod.ext_iff + simpa on the projection-of-power simp lemmas) as the one piece to confirm in a live build. Every arithmetic claim is independently certified by research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py (all-a correctness over 55 moduli, λ < φ strictly, and the explicit p² failure set — all pass). Promote to verified once a green docker-build of Proofs.EulerTotientOQ01OQ03 confirms the typecheck.",
+    "assumptions": "None. Fully machine-verified: docker-build of Proofs.EulerTotientOQ01OQ03 completed successfully on 2026-06-15 (7744 jobs), confirming 0 axioms and 0 sorries against the pinned Mathlib (v4.26.0). The build first surfaced — and this session fixed — seven Mathlib-API mismatches in the imported Carmichael-function dependency Proofs/EulerTotientOQ01.lean (exponent_dvd / exp_eq_one_iff / exp_eq_one_of_subsingleton renames, IsCyclic.exponent_eq_card now returning Nat.card, Group.exponent_dvd_card, and invalid `▸` motives replaced by Eq.le), which had blocked the whole chain. Every arithmetic claim is additionally certified build-free by research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py (all-a correctness over 55 moduli, λ < φ strictly, and the explicit p² failure set — all pass).",
     "mathlibDependencies": [
       {
         "theorem": "ZMod.pow_card_sub_one_eq_one",


### PR DESCRIPTION
## Summary

`EulerTotientOQ01OQ03.lean` (RSA correctness via the Carmichael function λ) is registered but **had never compiled** — its imported dependency `EulerTotientOQ01.lean` (the Carmichael-function infrastructure) carried **seven Mathlib-API mismatches** from the Docker-blackout era, so the whole import chain failed to build and the gallery entry was held at `formalized`/`wip`.

With Docker recovered, the build pinpointed each defect. Fixes in `EulerTotientOQ01.lean`:

| Was | Now |
|-----|-----|
| `Monoid.exponent_dvd_card` | `Group.exponent_dvd_card` |
| `Monoid.exponent_dvd_of_forall_pow_eq_one _ e he` | `… he` (n is implicit now) |
| `IsCyclic.exponent_eq_card` (now returns `Nat.card`) | `… , Nat.card_eq_fintype_card, …` |
| `Monoid.exponent_eq_one_of_subsingleton` / `exponent_eq_one_iff` | `Monoid.exp_eq_one_iff` |
| `(h ▸ le_refl 1)` (invalid `▸` motive) | `h.le` |

`docker-build Proofs.EulerTotientOQ01OQ03` now **completes successfully (7744 jobs)**:

```
✔ Built Proofs.EulerTotientOQ01 (28s)
✔ Built Proofs.EulerTotientOQ01OQ03 (130s)
Build completed successfully (7744 jobs).
```

## Changes

- `EulerTotientOQ01.lean`: the 7 API fixes above (0 axioms / 0 sorries).
- `EulerTotientOQ01OQ03.lean`: refresh the source header from "authored under blackout" to machine-verified (comment-only).
- `meta.json` (oq-01-oq-03): restore **status `verified` / badge `original`** with build evidence.

**Side benefit:** `euler-totient-oq-01`'s gallery entry already claimed `verified`/`mathlib` despite its file not compiling — this PR makes that claim honest.

## Test plan

- [x] `docker-build Proofs.EulerTotientOQ01OQ03` → green (7744 jobs), both files built
- [x] All 7 original build errors resolved; second-round errors (L49, ▸) resolved
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)