### PR TITLE
research(erdos-565): discharge R*(G) ≥ R(G) + fix ill-typed EdgeColoring

### DIFF
--- a/proofs/Proofs/Erdos565Problem.lean
+++ b/proofs/Proofs/Erdos565Problem.lean
@@ -35,6 +35,16 @@ References:
 - Kohayakawa-Prömel-Rödl. "Induced Ramsey numbers." Combinatorica (1998)
 
 Tags: ramsey-theory, graph-theory, extremal-combinatorics
+
+Formalization status: 0 sorries, 3 axioms (the deep upper/lower bounds of
+Aragão et al. and the existence theorem of Deuber/EHP/Rödl, all legitimately
+axiomatized). The comparison `induced_ramsey_ge_ordinary` (R*(G) ≥ R(G)) is now
+proved from the definitions. The `EdgeColoring` definition was corrected to
+index over `G.edgeSet` (so `c ⟨s(a,b), h⟩` typechecks via `mem_edgeSet`, which
+is `Iff.rfl`); the previous `Sym2.out`-based predicate did not match the
+`Adj`-typed witnesses at the application sites. Build-pending: the local olean
+cache is unavailable (circular `proofs/.lake` symlink), so this is verified by
+name-check against Mathlib v4.26.0 and gated by the deployer build.
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
@@ -102,7 +112,7 @@ deriving DecidableEq
 **Edge coloring of a graph:**
 -/
 def EdgeColoring {V : Type*} [Fintype V] [DecidableEq V] (G : Graph V) :=
-  { e : Sym2 V // G.Adj e.out.1 e.out.2 } → EdgeColor
+  { e : Sym2 V // e ∈ G.edgeSet } → EdgeColor
 
 /--
 **Monochromatic induced subgraph:**
@@ -220,8 +230,35 @@ Induced Ramsey numbers are at least as large as ordinary Ramsey numbers.
 -/
 theorem induced_ramsey_ge_ordinary (n : ℕ) (G : Graph (Fin n)) :
     inducedRamseyNumber n G ≥ ordinaryRamseyNumber n G := by
-  -- Every monochromatic induced copy is also a monochromatic copy
-  sorry
+  -- The set of orders realizing the induced Ramsey property is contained in the
+  -- set realizing the ordinary one, so `sInf` monotonicity gives the inequality.
+  -- Concretely: the induced Ramsey number `M = inducedRamseyNumber n G` is realized
+  -- by some host graph `H` on `Fin M`; since `H ≤ ⊤ = completeGraph`, every
+  -- monochromatic induced copy of `G` in `H` is a (not necessarily induced)
+  -- monochromatic copy of `G` in `K_M`, so `K_M` realizes the ordinary property.
+  rw [ge_iff_le]
+  unfold ordinaryRamseyNumber
+  apply Nat.sInf_le
+  -- `M` is realized by a host graph `H`.
+  have hne : { m : ℕ | ∃ H : Graph (Fin m), HasInducedRamseyProperty H G }.Nonempty := by
+    obtain ⟨m, H, hH⟩ := induced_ramsey_exists n G
+    exact ⟨m, H, hH⟩
+  have hmem : inducedRamseyNumber n G ∈
+      { m : ℕ | ∃ H : Graph (Fin m), HasInducedRamseyProperty H G } := Nat.sInf_mem hne
+  obtain ⟨H, hH⟩ := hmem
+  -- Show `K_M` has the ordinary Ramsey property.
+  simp only [Set.mem_setOf_eq]
+  intro c
+  -- Restrict the complete-graph coloring to `H` (`H ≤ ⊤ = completeGraph`).
+  have hsub : H.edgeSet ⊆ (completeGraph (Fin (inducedRamseyNumber n G))).edgeSet :=
+    SimpleGraph.edgeSet_subset_edgeSet.mpr le_top
+  obtain ⟨color, f, _hiso, hmono⟩ := hH (fun e => c ⟨e.1, hsub e.2⟩)
+  refine ⟨color, f, ?_⟩
+  intro u v huv
+  obtain ⟨heH, hcol⟩ := hmono u v huv
+  -- `H.Adj (f u) (f v)` forces `f u ≠ f v`, hence adjacency in the complete graph;
+  -- the colour values agree by proof irrelevance of the edge-membership witness.
+  exact ⟨heH.ne, hcol⟩
 
 /--
 **Gap can be large:**

--- a/src/data/proofs/erdos-565/meta.json
+++ b/src/data/proofs/erdos-565/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 565,
     "erdosUrl": "https://erdosproblems.com/565",
     "erdosProblemStatus": "solved",
@@ -183,12 +183,12 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos565",
-    "lineCount": 286,
+    "lineCount": 323,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 10,
     "path": "Proofs/Erdos565Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -207,5 +207,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, induced-subgraphs, ramsey-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

`Erdos565Problem.lean` (Erdős #565, induced Ramsey numbers) had two defects:

1. **Ill-typed `EdgeColoring`** — defined as `{ e : Sym2 V // G.Adj e.out.1 e.out.2 }`, but every application site writes `c ⟨s(a,b), h⟩` with `h : G.Adj a b`. Since `Sym2.out ⟦(a,b)⟧` is `Quotient.out` (not defeq to `(a,b)`), those constructors did **not** typecheck — the file could not compile regardless of the sorry.
2. **A `sorry`** on `induced_ramsey_ge_ordinary : R*(G) ≥ R(G)`.

This PR fixes both:

- **Reindex `EdgeColoring` over `G.edgeSet`.** `SimpleGraph.mem_edgeSet` is `Iff.rfl` (Mathlib v4.26.0, `Basic.lean:428`), so `⟨s(a,b), h_adj⟩` now typechecks by defeq at all sites — no other edits needed.
- **Discharge the sorry.** The induced Ramsey number `M` is realized by a host graph `H` on `Fin M` (`Nat.sInf_mem` on the existence axiom). Since `H ≤ ⊤ = completeGraph`, restricting any edge-coloring of `K_M` to `H` and applying `H`'s induced Ramsey property yields a monochromatic (not-necessarily-induced) copy of `G` in `K_M`. Hence `K_M` realizes the ordinary property, and `Nat.sInf_le` monotonicity gives `R(G) ≤ R*(G)`.

**Result:** 0 sorries (was 1). 3 axioms unchanged — the deep upper/lower bounds (Aragão et al. 2025) and the existence theorem (Deuber/EHP/Rödl) remain legitimately axiomatized. `meta.json` sorries 1→0, lineCount synced. Status stays `axiomatized`/`axiom`.

## Verification

Local olean cache is unavailable (tracked `proofs/.lake` is a circular self-symlink → ELOOP → Docker builds recompile Mathlib from source and OOM the 7.65 GB VM). All Mathlib bearers were name-checked against the pinned **v4.26.0** source:

- `SimpleGraph.mem_edgeSet` (`Iff.rfl`), `top_adj` (`Iff.rfl`), `completeGraph` (`abbrev … := ⊤`)
- `edgeSet_subset_edgeSet`, `Adj.ne`, `Nat.sInf_le`, `Nat.sInf_mem`

The deployer build-gate is the authoritative verifier.

## Test plan
- [ ] Deployer builds `Proofs.Erdos565Problem` green (cache-warm environment)
- [ ] `pnpm build` gallery integrity passes