### PR TITLE
Enrich Ceva Cayley–Klein unification (cevas-theorem-oq-02-oq-01-oq-02-oq-01): add annotations

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 56 },
+    "type": "concept",
+    "title": "The Cayley–Klein Picture: One Configuration, Three Geometries",
+    "content": "The header lays out the unification target. The parent file `CevasTheoremOQ02OQ01OQ02.lean` proved hyperbolic Ceva and merely *observed* that the spherical, Euclidean, and hyperbolic concurrency criteria coincide, deriving the three side-ratios separately. This file delivers the genuine unification the open question asks for: a single cevian configuration carrying a **curvature sentinel** $\\kappa$, from which all three classical Ceva theorems descend as specializations of one theorem.",
+    "mathContext": "All three constant-curvature plane geometries are Cayley–Klein geometries — the projective plane equipped with an *absolute conic* $Q$, with the choice of $Q$ selecting the geometry. A cevian point on $BC$ is the projective point $D \\propto \\alpha B + \\beta C$ (pure incidence, geometry-independent). The metric side-ratio normalizes through the single norm $n^2 = \\alpha^2 + 2\\alpha\\beta m + \\beta^2$: $$\\frac{t_\\kappa(BD)}{t_\\kappa(DC)} = \\frac{\\beta\\, g}{\\alpha\\, g} = \\frac{\\beta}{\\alpha}, \\qquad g = \\frac{\\sqrt{|1-m^2|}}{n},$$ where the geometry-specific factor $g$ cancels for every $\\kappa$.",
+    "significance": "key",
+    "relatedConcepts": ["cayley-klein-metric", "projective-geometry", "absolute-conic", "constant-curvature", "cevian-concurrency"],
+    "prerequisites": ["projective-geometry", "non-euclidean-geometry", "cevas-theorem"]
+  },
+  {
+    "id": "ann-config",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 89 },
+    "type": "definition",
+    "title": "The Cayley–Klein Cevian Configuration",
+    "content": "`CKCevianConfig` is the single structure that unifies the three geometries. It carries the curvature sentinel $\\kappa$ ($+1$ spherical, $0$ Euclidean, $-1$ hyperbolic), the Cayley–Klein inner product $m = \\langle B,C\\rangle_\\kappa$, the two positive barycentric weights $\\alpha, \\beta$, and a single positivity hypothesis `hn`. The squared model norm `n_sq` and `n_sq_pos` package the normalization used throughout.",
+    "mathContext": "The only analytic hypothesis is $\\texttt{hn}: 0 < \\alpha^2 + 2\\alpha\\beta m + \\beta^2 = n^2$. Crucially this one inequality replaces the parent file's three per-geometry bounds on $m$ ($-1 < m < 1$ spherical, $m=1$ Euclidean, $m>1$ hyperbolic), each of which is later shown to imply `hn`.",
+    "significance": "key",
+    "relatedConcepts": ["barycentric-coordinates", "curvature-sentinel", "model-norm", "structure-encoding"],
+    "prerequisites": ["lean-structures", "barycentric-coordinates"]
+  },
+  {
+    "id": "ann-ratio-cancel",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 104 },
+    "type": "technique",
+    "title": "The Cancellation Crux (★)",
+    "content": "`ck_ratio_cancel` is the mathematical heart of the unification: for any nonzero common factor $g$, the metric side-ratio $(\\beta g)/(\\alpha g)$ collapses to the geometry-independent weight ratio $\\beta/\\alpha$. This one identity replaces the three separate per-geometry side-ratio derivations of the parent file. `ck_side_ratio` lifts it to the configuration level, instantiating $g$ with the geometry's factor.",
+    "mathContext": "The proof is literally `mul_div_mul_right β α hg`, the Mathlib lemma $\\frac{b\\,g}{a\\,g} = \\frac{b}{a}$ for $g \\neq 0$. Because the geometry enters the side-ratio *only* through the common factor $g$, and $g \\neq 0$ in every case, the curvature is invisible to the ratio: $\\frac{\\beta g}{\\alpha g} = \\frac{\\beta}{\\alpha}$.",
+    "significance": "critical",
+    "relatedConcepts": ["factor-cancellation", "side-ratio", "weight-ratio", "geometry-independence"],
+    "prerequisites": ["field-arithmetic"]
+  },
+  {
+    "id": "ann-weight-balance",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 120 },
+    "type": "theorem",
+    "title": "The Universal Concurrency Criterion",
+    "content": "`ck_weight_balance` is the pure-algebra concurrency condition, identical in all three geometries: for positive weights, the product of the three weight ratios equals $1$ iff the weight balance $\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F$ holds. This is Ceva's concurrency criterion with all geometry stripped away.",
+    "mathContext": "$$\\frac{\\beta_D}{\\alpha_D}\\cdot\\frac{\\beta_E}{\\alpha_E}\\cdot\\frac{\\beta_F}{\\alpha_F} = 1 \\iff \\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F.$$ Both directions clear denominators with `field_simp` (using $\\alpha_i \\neq 0$ from positivity) and close with `linarith`.",
+    "significance": "key",
+    "relatedConcepts": ["cevas-theorem", "concurrency-criterion", "weight-balance"],
+    "prerequisites": ["field-arithmetic", "cevas-theorem"]
+  },
+  {
+    "id": "ann-unification",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 144 },
+    "type": "theorem",
+    "title": "Projective Ceva — The Single Unification Theorem",
+    "content": "`projective_ceva_unification` is the central result. For three cevian configurations of *arbitrary* (possibly distinct) curvatures, and arbitrary nonzero geometric factors $g_D, g_E, g_F$, the product of the three metric side-ratios equals $1$ iff the single weight-balance criterion holds. Its proof simply rewrites each side-ratio via `ck_side_ratio` (which cancels the factor) and applies `ck_weight_balance`.",
+    "mathContext": "$$\\frac{\\beta_D g_D}{\\alpha_D g_D}\\cdot\\frac{\\beta_E g_E}{\\alpha_E g_E}\\cdot\\frac{\\beta_F g_F}{\\alpha_F g_F} = 1 \\iff \\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F.$$ Allowing the three configs to carry *different* curvatures makes this strictly stronger than three separate single-geometry theorems — it covers mixed-curvature cevian configurations no classical theorem addresses.",
+    "significance": "critical",
+    "relatedConcepts": ["projective-geometry", "cevas-theorem", "unification", "mixed-curvature"],
+    "prerequisites": ["cevas-theorem", "projective-geometry"]
+  },
+  {
+    "id": "ann-factors",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 146, "endLine": 177 },
+    "type": "definition",
+    "title": "The Three Geometric Factors and Their Nonvanishing",
+    "content": "Each geometry contributes its own factor $g = \\sqrt{|1-m^2|}/n$: `gSph` $= \\sqrt{1-m^2}/n$ (spherical, $m^2<1$), `gHyp` $= \\sqrt{m^2-1}/n$ (hyperbolic, $m^2>1$), and `gEuc` $= 1$ (Euclidean, $m=1$). Only the *nonvanishing* of each matters for the unification, since `ck_ratio_cancel` discards the value — so each factor gets a nonzero lemma (`gSph_ne`, `gHyp_ne`, `gEuc_ne`).",
+    "mathContext": "Nonvanishing follows from `Real.sqrt_pos` ($0 < \\sqrt{x} \\iff 0 < x$): for the spherical factor $1-m^2 > 0$, for the hyperbolic factor $m^2-1 > 0$, and `div_ne_zero` keeps $g \\neq 0$ given $n > 0$. The Euclidean factor is nonzero trivially since it is the constant $1$ (`one_ne_zero`).",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric-factor", "square-root", "nonvanishing", "euclidean-limit"],
+    "prerequisites": ["real-analysis", "square-root"]
+  },
+  {
+    "id": "ann-metric-realization",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 179, "endLine": 261 },
+    "type": "insight",
+    "title": "Metric Realization: the Factor IS the Genuine Side Length",
+    "content": "`projective_ceva_unification` cancels $g$ *abstractly* (it only needs $g \\neq 0$). This section proves the abstract factor is the **actual** metric quantity, not a placeholder. The κ-uniform identities `ck_metric_BD`/`ck_metric_DC` give $n^2 - (\\alpha+\\beta m)^2 = \\beta^2(1-m^2)$ and $n^2 - (\\alpha m+\\beta)^2 = \\alpha^2(1-m^2)$ by `ring`. The `gSph_sqrt`/`gHyp_sqrt` lemmas extract the genuine geodesic numerators, and `spherical_side_ratio_metric`/`hyperbolic_side_ratio_metric` show the ratio of true geodesic lengths $\\sin_\\kappa(BD)/\\sin_\\kappa(DC)$ equals $\\beta/\\alpha$.",
+    "mathContext": "One ring identity covers all three sign regimes: $n^2 - (\\alpha+\\beta m)^2 = \\beta^2(1-m^2)$ is $>0$ for $m^2<1$ (spherical $\\sin^2$), $<0$ for $m^2>1$ (hyperbolic, the sign moving into $\\sqrt{m^2-1}$), and $0$ at $m=1$ (Euclidean limit). Then $\\sqrt{\\beta^2(1-m^2)} = \\beta\\sqrt{1-m^2}$ via `Real.sqrt_mul` and `Real.sqrt_sq`, so the geodesic side-ratio is genuinely $\\beta/\\alpha$.",
+    "significance": "key",
+    "relatedConcepts": ["geodesic-distance", "metric-realization", "ring-identity", "spherical-law-of-sines"],
+    "prerequisites": ["real-analysis", "non-euclidean-geometry"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 263, "endLine": 288 },
+    "type": "technique",
+    "title": "No Generality Lost: Each m-Bound Implies the Single Hypothesis",
+    "content": "The unified `CKCevianConfig` carries only `hn` in place of the parent's per-geometry $m$-bounds. These lemmas confirm no generality is lost: each geometry's natural bound on $m = \\cos_\\kappa(d(B,C))$ implies `hn`. `hn_of_cos_gt_neg_one` ($m > -1$, spherical/elliptic), `hn_of_cosh_gt_one` ($m > 1$, hyperbolic), and `hn_of_eq_one` ($m = 1$, Euclidean) each discharge the positivity by `nlinarith`.",
+    "mathContext": "The completed-square identities make positivity visible: $$\\alpha^2 + 2\\alpha\\beta m + \\beta^2 = (\\alpha-\\beta)^2 + 2\\alpha\\beta(m+1) = (\\alpha+\\beta)^2 + 2\\alpha\\beta(m-1).$$ With $\\alpha,\\beta>0$ the first form is positive when $m>-1$ (spherical), the second when $m>1$ (hyperbolic), and the Euclidean $m=1$ case reduces to $(\\alpha+\\beta)^2>0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["completing-the-square", "positivity", "nlinarith", "no-generality-lost"],
+    "prerequisites": ["real-analysis", "inequalities"]
+  },
+  {
+    "id": "ann-classical",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+    "range": { "startLine": 290, "endLine": 351 },
+    "type": "theorem",
+    "title": "The Three Classical Theorems as Specializations",
+    "content": "`spherical_ceva_unified`, `hyperbolic_ceva_unified`, and `euclidean_ceva_unified` each instantiate `projective_ceva_unification` with the appropriate geometric factor and its nonvanishing lemma. The mathematical content is identical across the three; only the choice of $g$ (and the source of its nonvanishing) differs. This is the precise sense in which all three classical Ceva theorems follow from a single projective theorem via the Klein model.",
+    "mathContext": "Each theorem is `projective_ceva_unification cfgD cfgE cfgF _ _ _` applied to $g \\in \\{g_{Sph}, g_{Hyp}, g_{Euc}\\}$, with nonvanishing supplied by `gSph_ne`/`gHyp_ne`/`gEuc_ne`. The concurrency criterion $\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F$ is the same in all three — confirming the criterion is genuinely curvature-independent. 0 axioms, 0 sorries.",
+    "significance": "key",
+    "relatedConcepts": ["spherical-geometry", "hyperbolic-geometry", "euclidean-geometry", "specialization"],
+    "prerequisites": ["cevas-theorem", "non-euclidean-geometry"]
+  }
+]


### PR DESCRIPTION
## Summary

This gallery entry had a rich `meta.json` (full overview, sections, cross-references, conclusion, references, mainTheorems) but **no `annotations.json`** — so the proof page rendered without any inline commentary. This adds a complete `annotations.json` with **9 annotations** covering the entire 351-line `Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean`:

1. **Cayley–Klein picture overview** — curvature sentinel κ, the side-ratio identity (★)
2. **CKCevianConfig** — the unifying structure and its single positivity hypothesis `hn`
3. **ck_ratio_cancel** — the cancellation crux, `(βg)/(αg) = β/α` (significance: critical)
4. **ck_weight_balance** — the universal, κ-free concurrency criterion
5. **projective_ceva_unification** — the single unification theorem (significance: critical)
6. **gSph / gHyp / gEuc** — the three geometric factors and their nonvanishing
7. **Metric realization** — the κ-uniform key identity `n² − (α+βm)² = β²(1−m²)` and the genuine geodesic side-ratio
8. **No-generality-lost positivity** — each geometry's m-bound implies `hn` via completed-square forms
9. **The three classical theorems** as specializations of the one unification theorem

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. All significance values are valid (`critical | key | supporting`). Annotation content and line ranges were written against the actual Lean source.

## Scope note

Touches only `annotations.json`. The slug's open PRs (#24567 meta+knowledge, #24106, #23172) do not touch `annotations.json`, so there is no overlap.

## Test plan

- [x] `annotations.json` validates as JSON
- [x] `research:enrich` processes the slug cleanly (15 lean files, 13 related proofs; exit 0)
- [x] All significance values valid; all `proofId` fields match the slug
- [ ] `tsc -b && vite build` not runnable in this worktree (node_modules absent — environment limitation, not data-related)