### PR TITLE
research(inverse-galois-d4-oq-01): external ℤ/4 ⋊ ℤ/2 packaging blueprint + knowledge

### DIFF
--- a/research/problems/inverse-galois-d4-oq-01/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-01/knowledge.md
@@ -1,27 +1,189 @@
 # Knowledge Base: inverse-galois-d4-oq-01
 
-Insights accumulated during research on this problem.
+Semidirect-product structure ℤ/4 ⋊ ℤ/2 of the D₄ Galois action.
 
 ---
 
 ## Problem Understanding
 
-(Initial observations from OBSERVE phase will be recorded here.)
+The parent gallery entry `inverse-galois-d4` proves
+`InverseGaloisExtensions.d4_realizable`: the splitting field of `X⁴ − 2`
+over `ℚ` is Galois with `|Gal| = 8`. The order 8 alone does not pin the
+isomorphism type (D₄ vs Q₈ vs three abelian groups). OQ-01 asks to make
+the structure `ℤ/4 ⋊ ℤ/2` explicit: a normal order-4 rotation subgroup and
+an order-2 reflection acting on it by inversion.
+
+---
+
+## Status (2026-06-15)
+
+**The internal semidirect decomposition is ALREADY COMPLETE.** The file
+`proofs/Proofs/InverseGaloisD4OQ01.lean` (registered, 0 sorry, 0 axiom,
+13 theorems) proves, inside the abstract group `DihedralGroup 4`:
+
+- `rotations := rHom.range ≅ ℤ/4` with `Nat.card rotations = 4`
+  (`rHom_injective`, `rotationsEquiv`, `card_rotations`).
+- `rotations_normal : rotations.Normal`.
+- `reflection_conj_rotation (i j) : sr j * r i * (sr j)⁻¹ = r (-i)` and
+  `reflection_conj_rotation' (i) : sr 0 * r i * (sr 0)⁻¹ = (r i)⁻¹`
+  (the defining ℤ/2-twist).
+- `orderOf_reflection : orderOf (sr 0) = 2`,
+  `orderOf_rotation_gen : orderOf (r 1) = 4`.
+- `reflections := {1, sr 0} ≅ ℤ/2`, with
+  `rotations ⊔ reflections = ⊤`, `rotations ⊓ reflections = ⊥`.
+- `d4_internal_semidirect`: packages normality + complement + trivial
+  intersection + inversion action — the four defining properties of the
+  internal semidirect product `ℤ/4 ⋊ ℤ/2`.
+
+So the *internal* structure question of OQ-01 is settled. The gallery
+`meta.json` lists `status: formalized` (under-claimed: 0 sorry/0 axiom
+→ `verified` once a kernel build is confirmed; not upgraded here because
+no build was possible this session — see Blockers).
 
 ---
 
 ## Insights
 
-(Insights from research attempts will be accumulated here.)
+- The internal decomposition reduces every defining relation to existing
+  Mathlib `DihedralGroup` rewrite lemmas: `r_mul_r`, `sr_mul_r`,
+  `sr_mul_sr`, `r_mul_sr`, `inv_r`, `inv_sr`, `sr_mul_self`. These are all
+  confirmed-valid in the pinned Mathlib (`v4.26.0`) by the existing file.
+- The natural remaining strengthening is the **external** packaging:
+  an honest `MulEquiv` `SemidirectProduct (Multiplicative (ZMod 4))
+  (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4`, where `φ` sends the
+  ℤ/2 generator to inversion of ℤ/4. Mathlib has `SemidirectProduct`
+  but (as of this pin) no `DihedralGroup n` as an explicit semidirect
+  product — this is a genuine gap, not a duplicate.
+- **Key reduction:** the `SemidirectProduct.lift` compatibility
+  hypothesis `∀ g, f₁.comp (φ g).toMonoidHom = (MulAut.conj (f₂ g)).comp f₁`
+  collapses, on the nontrivial ℤ/2 generator, to *exactly*
+  `reflection_conj_rotation'` (already proven). The identity element case
+  is trivial (`φ 1 = 1`, `sHom 1 = 1`). So the hard content is reused.
+- Bijectivity of the lift is provable without any cardinality/Fintype
+  lemma on `SemidirectProduct`: surjectivity from `r i = lift ⟨ofAdd i, 1⟩`
+  and `sr i = lift ⟨ofAdd (-i), ofAdd 1⟩`; injectivity from
+  `lift ⟨n,g⟩ = rHom n * sHom g` plus `sr a ≠ 1` in `DihedralGroup`.
+
+---
+
+## External-packaging BLUEPRINT (drafted, UNVERIFIED — needs a build)
+
+Target file (a future session copies into `proofs/Proofs/` only after a
+green build): build on `InverseGaloisD4OQ01` (reuses `rHom`,
+`reflection_conj_rotation'`).
+
+```lean
+open DihedralGroup
+
+/-- inversion automorphism of the commutative group ℤ/4. -/
+def invAut : MulAut (Multiplicative (ZMod 4)) where
+  toFun := Inv.inv
+  invFun := Inv.inv
+  left_inv := inv_inv
+  right_inv := inv_inv
+  map_mul' a b := by simp [mul_comm, mul_inv]
+
+theorem invAut_mul_self : invAut * invAut = 1 := by ext x; simp [invAut]
+
+/-- the ℤ/2 action by inversion (generator ↦ invAut). -/
+def φ : Multiplicative (ZMod 2) →* MulAut (Multiplicative (ZMod 4)) where
+  toFun g := if g.toAdd = 0 then 1 else invAut
+  map_one' := by simp
+  map_mul' a b := by
+    have key := invAut_mul_self
+    have h : (a * b).toAdd = a.toAdd + b.toAdd := toAdd_mul a b
+    -- set i := a.toAdd; set j := b.toAdd; fin_cases i <;> fin_cases j
+    -- resolve the `if` conditions by decide on ZMod 2, close with `key`
+    sorry
+
+/-- reflection complement hom ℤ/2 → D₄. -/
+def sHom : Multiplicative (ZMod 2) →* DihedralGroup 4 where
+  toFun g := if g.toAdd = 0 then 1 else sr 0
+  map_one' := by simp
+  map_mul' a b := by
+    -- same fin_cases pattern; case (1,1): sr 0 * sr 0 = 1 via sr_mul_self
+    sorry
+
+/-- compatibility — reduces to reflection_conj_rotation' on the generator. -/
+theorem lift_compat (g : Multiplicative (ZMod 2)) :
+    rHom.comp (φ g).toMonoidHom
+      = (MulAut.conj (sHom g)).toMonoidHom.comp rHom := by
+  ext n
+  -- g.toAdd = 0: both sides = rHom n.
+  -- g.toAdd = 1: LHS = rHom n⁻¹ = r(-n.toAdd) = (r n.toAdd)⁻¹;
+  --   RHS = sr 0 * r n.toAdd * (sr 0)⁻¹ = (r n.toAdd)⁻¹ by
+  --   reflection_conj_rotation' n.toAdd.
+  sorry
+
+/-- **External semidirect product**: D₄ ≅ ℤ/4 ⋊ ℤ/2 (inversion action). -/
+noncomputable def d4Equiv :
+    SemidirectProduct (Multiplicative (ZMod 4))
+      (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4 :=
+  MulEquiv.ofBijective (SemidirectProduct.lift rHom sHom lift_compat)
+    ⟨lift_injective, lift_surjective⟩
+-- lift_injective: injective_iff_map_eq_one; obtain ⟨n,g⟩; lift ⟨n,g⟩ = rHom n * sHom g;
+--   case g.toAdd: 0 ⇒ r n.toAdd = 1 ⇒ n = 1; 1 ⇒ sr(-n.toAdd) ≠ 1.
+-- lift_surjective: cases y with | r i => ⟨inl (ofAdd i), …⟩ | sr i => ⟨⟨ofAdd (-i), ofAdd 1⟩, …⟩.
+```
+
+### API points to VERIFY at build time (recollection, Mathlib v4.26.0)
+
+1. `SemidirectProduct.lift` hypothesis exact form — confirm
+   `(MulAut.conj (f₂ g)).toMonoidHom.comp f₁` vs a coercion variant.
+2. `MulAut.conj_apply : MulAut.conj g h = g * h * g⁻¹`.
+3. Element form `lift f₁ f₂ h ⟨n,g⟩ = f₁ n * f₂ g` (toFun is defeq; may
+   need `SemidirectProduct.lift_inl/lift_inr` + `inl_left_mul_inr_right`).
+4. `mul_inv : (a*b)⁻¹ = a⁻¹ * b⁻¹` (CommGroup) for `invAut.map_mul'`.
+5. `toAdd_mul`, `toAdd_inv` for `Multiplicative (ZMod n)`.
+6. `sr a ≠ 1` (constructor distinctness; `one_def : (1:DihedralGroup n) = r 0`).
+7. `fin_cases` mechanics on `ZMod 2` (use `set j := g.toAdd` first).
 
 ---
 
 ## Mathlib Coverage Audit
 
-(After ORIENT phase: list of relevant Mathlib lemmas / APIs and their applicability.)
+- `Mathlib.GroupTheory.SpecificGroups.Dihedral`: full rewrite calculus
+  (verified usable via the existing OQ-01 file).
+- `Mathlib.GroupTheory.SemidirectProduct`: `SemidirectProduct`, `inl`,
+  `inr`, `lift`. No `DihedralGroup`-as-semidirect-product result → the
+  external `d4Equiv` is a genuine addition.
 
 ---
 
 ## Anti-Goals
 
-(Things explicitly NOT to attempt — discovered duplicates, scope creep risks, etc.)
+- Do NOT add more *internal*-structure lemmas — that question is fully
+  settled by the existing file; more would be enumeration theater.
+- Do NOT touch the OQ-03 bridge (concrete `Gal(X⁴−2/ℚ) ≃* DihedralGroup 4`);
+  that needs "D₄ = unique transitive order-8 subgroup of S₄" and is a
+  separate, harder problem.
+- Do NOT add the external file to `proofs/Proofs/` until it builds green —
+  every file there is auto-aggregated into `Proofs.lean` and a broken file
+  fails the whole deploy build.
+
+---
+
+## Blockers (2026-06-15)
+
+- **Docker build unusable in this worktree**: `proofs/.lake` is a circular
+  self-symlink (`proofs/.lake -> .../proofs/.lake`), so no Mathlib olean
+  cache resolves → a build recompiles Mathlib from source and OOMs the
+  ~7.65GB Docker VM (3 concurrent lean-build containers also contending).
+- **Aristotle MCP down**: `prove` returns `Resource not found`.
+- Consequence: the external blueprint above could not be machine-checked
+  this session. Next session with a warm cache should paste it into a
+  companion file, build via `docker-build.sh`, fix the listed API points,
+  then register + flip gallery `status` to `verified`/`original`.
+
+---
+
+## Sessions
+
+### 2026-06-15 (Session 1) — researcher-7
+
+**Mode**: FRESH · **Outcome**: scouted/ORIENT (internal already complete; external blueprint drafted, unverified)
+
+- Confirmed the internal ℤ/4 ⋊ ℤ/2 decomposition is fully proven (0 sorry/0 axiom) in `InverseGaloisD4OQ01.lean`.
+- Identified the genuine remaining advance: the external `SemidirectProduct ≃* DihedralGroup 4` MulEquiv, a real Mathlib gap.
+- Derived the key reduction (lift compatibility = `reflection_conj_rotation'`) and a cardinality-free bijectivity argument; drafted full Lean blueprint with explicit API risk list.
+- Could not build (circular `.lake` symlink OOM) or use Aristotle (down); left status untouched.

--- a/research/problems/inverse-galois-d4-oq-01/state.md
+++ b/research/problems/inverse-galois-d4-oq-01/state.md
@@ -1,9 +1,9 @@
 # Research State: inverse-galois-d4-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: fast
-**Since**: 2026-05-12T23:37:36Z
+**Since**: 2026-06-15T11:33:03-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/src/data/research/problems/inverse-galois-d4-oq-01.json
+++ b/src/data/research/problems/inverse-galois-d4-oq-01.json
@@ -1,0 +1,65 @@
+{
+  "slug": "inverse-galois-d4-oq-01",
+  "title": "Semidirect-Product Structure ℤ/4 ⋊ ℤ/2 of the D₄ Galois Action",
+  "phase": "ORIENT",
+  "status": "available",
+  "tier": "B",
+  "path": "Proofs/InverseGaloisD4OQ01.lean",
+  "problemStatement": {
+    "formal": "Exhibit the splitting-field Galois group of X⁴−2 over ℚ (order 8) as the internal/external semidirect product ℤ/4 ⋊ ℤ/2: a normal order-4 rotation subgroup and an order-2 reflection acting by inversion.",
+    "plain": "The Galois group of X⁴−2 over ℚ has order 8, but order alone does not fix its isomorphism type. Make the dihedral structure ℤ/4 ⋊ ℤ/2 explicit.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "Internal semidirect decomposition of DihedralGroup 4 is fully formalized (0 sorry, 0 axiom) in InverseGaloisD4OQ01.lean: normal rotation subgroup ≅ ℤ/4, reflection complement ≅ ℤ/2, trivial intersection, generation, and inversion action.",
+      "d4_internal_semidirect packages the four defining properties of the internal semidirect product."
+    ],
+    "open": [
+      "External packaging as an honest MulEquiv SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4 (blueprint drafted, not yet machine-checked).",
+      "OQ-03 bridge: concrete Gal(X⁴−2/ℚ) ≃* DihedralGroup 4 (needs uniqueness of the transitive order-8 subgroup of S₄)."
+    ],
+    "goal": "Promote the internal decomposition to the explicit external semidirect product and confirm a kernel build."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T00:00:00Z",
+    "iteration": 1,
+    "focus": "Internal structure complete; external SemidirectProduct equivalence blueprinted (lift compatibility reduces to reflection_conj_rotation'). Build + Aristotle unavailable this session."
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: internal ℤ/4 ⋊ ℤ/2 decomposition already proven (0 sorry/0 axiom); external SemidirectProduct ≃* DihedralGroup 4 drafted as a blueprint, unverified (no build, Aristotle down).",
+    "builtItems": [
+      "InverseGaloisD4OQ01.lean: rotations ≅ ℤ/4 (rHom, rHom_injective, rotationsEquiv, card_rotations)",
+      "InverseGaloisD4OQ01.lean: rotations_normal, reflection_conj_rotation, reflection_conj_rotation'",
+      "InverseGaloisD4OQ01.lean: reflections ≅ ℤ/2, rotations ⊔ reflections = ⊤, rotations ⊓ reflections = ⊥",
+      "InverseGaloisD4OQ01.lean: d4_internal_semidirect (the four defining properties)"
+    ],
+    "insights": [
+      "Order 8 does not fix the isomorphism type (D₄ vs Q₈ vs 3 abelian); the internal decomposition with the inversion action does.",
+      "SemidirectProduct.lift compatibility hypothesis collapses, on the ℤ/2 generator, to exactly reflection_conj_rotation' — the hard content is already proven.",
+      "Bijectivity of the lift needs no Fintype/cardinality lemma: surjectivity from explicit preimages of r i and sr i; injectivity from lift⟨n,g⟩ = rHom n * sHom g plus sr a ≠ 1.",
+      "Mathlib (v4.26.0) has SemidirectProduct but no DihedralGroup-as-semidirect-product result, so the external d4Equiv is a genuine addition."
+    ],
+    "mathlibGaps": [
+      "No DihedralGroup n ≃* SemidirectProduct ... result in Mathlib v4.26.0.",
+      "Need to confirm exact SemidirectProduct.lift hypothesis form and MulAut.conj_apply at build time."
+    ],
+    "nextSteps": [
+      "On a warm cache: paste the knowledge.md external blueprint into a companion file, build via docker-build.sh, fix the listed API points, register, and flip gallery status to verified/original.",
+      "Verify the existing InverseGaloisD4OQ01.lean builds, then upgrade meta.json status formalized → verified (currently under-claimed at 0 sorry/0 axiom).",
+      "Pursue OQ-03 separately (uniqueness of transitive order-8 subgroup of S₄)."
+    ]
+  },
+  "tags": [
+    "galois-theory",
+    "inverse-galois-problem",
+    "dihedral-group",
+    "semidirect-product",
+    "field-extensions"
+  ],
+  "started": "2026-06-15T00:00:00Z",
+  "lastUpdate": "2026-06-15T00:00:00Z",
+  "significance": 5,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Research progress on **inverse-galois-d4-oq-01** (Semidirect-Product Structure ℤ/4 ⋊ ℤ/2 of the D₄ Galois action). Documentation-only — **no Lean build target added**.

- **Finding:** the *internal* semidirect decomposition is already fully formalized (0 sorry / 0 axiom) in `proofs/Proofs/InverseGaloisD4OQ01.lean` (`d4_internal_semidirect` packages normality + complement + trivial intersection + inversion action). The internal-structure question of OQ-01 is settled.
- **Genuine remaining advance:** the *external* `MulEquiv` `SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4` — a real Mathlib gap (no `DihedralGroup`-as-semidirect-product result at pin v4.26.0). Drafted as a blueprint in `knowledge.md`, with:
  - the key reduction: the `SemidirectProduct.lift` compatibility hypothesis collapses, on the ℤ/2 generator, to exactly the existing `reflection_conj_rotation'`;
  - a cardinality-free bijectivity argument (explicit preimages + `sr a ≠ 1`);
  - an explicit list of Mathlib API points to confirm at build time.
- Creates the problem JSON (knowledge score 0 → 13, **MODERATE** tier) and advances phase **OBSERVE → ORIENT**.

## Honesty / scope

The external blueprint is **UNVERIFIED**: Docker build is unusable in-worktree (circular `proofs/.lake` self-symlink → Mathlib-from-source OOM on the ~7.65GB VM) and the Aristotle MCP is down (`Resource not found`). A future session with a warm cache should paste the blueprint into a companion file, build, fix the listed API points, register, and only then upgrade gallery `status`. Gallery `meta.json` is left untouched (`formalized`).

## Test plan

- [ ] No build target changed — nothing to build for this PR.
- [ ] Future: build the external companion on a warm cache before registering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)