### PR TITLE
Enrich sum-of-kth-powers-oq-03: full-file section coverage

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -100,9 +100,17 @@
       "id": "tiling-and-main",
       "title": "Tiling and Nicomachus's Theorem",
       "startLine": 118,
-      "endLine": 144,
+      "endLine": 140,
       "summary": "tiling (L3): ∑_{i<n}(block i) = ∑_{j<T n}(2j+1), by induction with Finset.sum_Ico_consecutive (the blocks tile [0, T n)). The main theorem sum_cubes_eq_sum_squared_via_odds rewrites each i³ as its block (block_eq_cube), applies tiling and sum_odds to reach (T(n+1))², and closes by rfl since T(n+1) is definitionally ∑_{i<n+1} i — matching the parent's RHS exactly.",
       "mathContext": "$\\sum_{i\\le n} i^3 = \\sum_{j<T(n+1)}(2j+1) = (T(n+1))^2 = \\big(\\sum_{i\\le n} i\\big)^2$."
+    },
+    {
+      "id": "per-cube-corollary",
+      "title": "Per-Cube Corollary: Each Cube as Consecutive Odds",
+      "startLine": 142,
+      "endLine": 155,
+      "summary": "cube_eq_sum_consecutive_odds restates block_eq_cube as a standalone identity over range i: i³ = ∑_{k<i}(2·(T i + k) + 1), the i consecutive odd numbers starting at 2·(T i)+1. Derived from block_eq_cube by Finset.sum_Ico_eq_sum_range and T_succ, eliminating ℕ-subtraction. This is the classical visual form of Nicomachus (1³=1, 2³=3+5, 3³=7+9+11, …).",
+      "mathContext": "$i^3 = \\sum_{k<i}\\bigl(2(T_i + k) + 1\\bigr)$, the $i$ consecutive odds from $2T_i+1$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `sum-of-kth-powers-oq-03` (Nicomachus via the odd-number partition of cubes).

## Gap addressed
The `sections` array stopped at line 144, leaving the final corollary `cube_eq_sum_consecutive_odds` (lines 142-155) without its own section, and the preceding "Tiling and Nicomachus's Theorem" section spilled its `endLine` (144) into that corollary's docstring.

## Change
- Added a 5th section **"Per-Cube Corollary: Each Cube as Consecutive Odds"** (lines 142-155) summarizing `cube_eq_sum_consecutive_odds`: the classical visual identity $i^3 = \sum_{k<i}(2(T_i+k)+1)$.
- Tightened the "Tiling and Nicomachus's Theorem" section `endLine` 144 → 140 so it ends cleanly at `sum_cubes_eq_sum_squared_via_odds`.

Sections now contiguously cover the full 155-line proof.

## Effect
Gallery quality score 98 → 100 (sections sub-score 8/10 → 10/10). No other fields touched; the entry's annotations, overview, conclusion, cross-references, and references were already complete. Verified counts unchanged (0 axioms, 0 sorries).