### PR TITLE
audit: inclusion-exclusion-oq-01-oq-03 badge verified -> mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "euler-totient",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Registered in Proofs.lean (import Proofs.InclusionExclusionOQ01OQ03 present on main), so the gallery build machine-checks it. The proof is a thin, faithful bridge over Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq and Nat.sum_divisorsAntidiagonal at pinned v4.26.0, plus the Euler-φ corollary and the Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ) derived purely from the inversion theorem. All three statements are independently certified by research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py (all n ≤ 400, random data — all pass).",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `inclusion-exclusion-oq-01-oq-03`
**Severity**: MEDIUM — Mathlib bridge presented with `verified` badge

## Finding

The main theorem `moebius_inversion_divisors` obtains its **core result** by directly invoking Mathlib's `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` (antidiagonal-form Möbius inversion), bridged to the textbook divisor-sum shape via `Nat.sum_divisorsAntidiagonal`. The Lean file's own docstring is candid:

> "This is a thin but faithful bridge — the mathematical depth lives in Mathlib's `sum_eq_iff_sum_mul_moebius_eq`."

This is a **Tier B (formalized using a Mathlib theorem)** proof per the auditor classification, and matches failure mode #5 ("0 sorries with hidden imports"). The badge `verified` implies independent verification.

## Evidence

- `meta.json`: `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0` — all numerically accurate (file: 0 sorries, 0 own axioms, 3 theorems, 113 lines, verified).
- `mathlibDependencies` already lists `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` and the prose/`assumptions`/`originalContributions` all correctly credit Mathlib. **Only the badge is misaligned.**
- Gallery convention: 388 Mathlib-bridge entries use `status: verified` + `badge: mathlib` (e.g. the entire abel-ruffini family).

## Fix Applied

`badge`: `verified` → `mathlib`. No prose changes needed — the description and `mathlibDependencies` already disclose the dependency. `status: verified` is retained (the proof is genuinely machine-checked, 0 sorries / 0 axioms).

---
Discovered during gallery integrity audit.