### PR TITLE
research(sum-of-kth-powers-oq-03): correct build-provenance overclaim in Lean header

### DIFF
--- a/proofs/Proofs/SumOfKthPowersOQ03.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ03.lean
@@ -44,10 +44,13 @@ form `2·T i + i = i²` (`two_T_add`), proved by a one-line induction.
 
 Axioms: 0. Sorries: 0.
 
-NOTE (build provenance): machine-checked via `./proofs/scripts/docker-build.sh
-Proofs.SumOfKthPowersOQ03` (Lean `v4.26.0`, Mathlib pin `2df2f01`); registered in
-`proofs/Proofs.lean`. Every arithmetic identity is additionally certified (sympy + brute force,
-n = 0..60) by `research/problems/sum-of-kth-powers-oq-03/verify_m1.py`.
+NOTE (build provenance): BUILD-PENDING — authored during a Docker + Aristotle backend outage and
+NOT yet machine-checked. Registered in `proofs/Proofs.lean`; the two load-bearing Mathlib lemmas
+(`Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`) were pin-confirmed at Lean `v4.26.0`
+(Mathlib pin `2df2f01`). Every arithmetic identity is additionally certified (sympy + brute force,
+n = 0..60) by `research/problems/sum-of-kth-powers-oq-03/verify_m1.py`. Promote this note (and the
+meta.json status to verified/original) once a green `./proofs/scripts/docker-build.sh
+Proofs.SumOfKthPowersOQ03` confirms the typecheck.
 -/
 
 import Mathlib


### PR DESCRIPTION
## Summary

The Lean file `proofs/Proofs/SumOfKthPowersOQ03.lean` (Nicomachus via the odd-number partition of cubes) had a header NOTE claiming it was **"machine-checked via docker-build.sh"**, which directly contradicts its own `meta.json` — accurately marked `formalized`/`wip` with `assumptions` stating the file is build-pending (authored during a Docker + Aristotle outage and never typechecked). The olean cache confirms it: `proofs/.lake` is a circular self-symlink (ELOOP) and Mathlib oleans = 0, so the file has not been kernel-checked.

This PR rewrites the header NOTE to state **BUILD-PENDING** honestly, removing the false "machine-checked" claim while retaining:
- the pin-confirmed load-bearing Mathlib lemmas (`Finset.sum_Ico_consecutive`, `Finset.range_eq_Ico`) at Lean v4.26.0,
- the sympy + brute-force certification reference,
- an explicit promote-on-green-build instruction.

No mathematical content changes (still 0 axioms, 0 sorries).

## Verification done this session
- `research/problems/sum-of-kth-powers-oq-03/verify_m1.py` passes all arithmetic identities (n = 0..60).
- Proof reviewed line-by-line: `sum_odds`, `two_T_add`, `block_sq`, `block_eq_cube`, `tiling`, `sum_cubes_eq_sum_squared_via_odds`, `cube_eq_sum_consecutive_odds` — all sound.
- Docker build NOT attempted: worktree `proofs/.lake` is a circular self-symlink (cache absent) and 4 concurrent builds were running on a 7.65GB Docker VM — a from-source Mathlib recompile would OOM. Deferred to the cache-warm deployer build-gate, which should promote the entry to `verified`/`original` on a green typecheck.

## Test plan
- [ ] Deployer build-gate runs `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` green
- [ ] On green build, promote header NOTE + meta.json status to verified/original