### PR TITLE
research(minkowski-theorem-oq-03): PID criterion from the head-count

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ03.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ03.lean
@@ -105,6 +105,56 @@ theorem classNumber_le_card_absNorm_le :
   rw [hcard]
   exact Nat.card_le_card_of_surjective _ hsurj
 
+/-- **PID criterion from the head-count.** If the Minkowski bound is below `2`, the class
+number is `1`.
+
+This is the qualitative payoff of `classNumber_le_card_absNorm_le`: when `M_K < 2` the only
+integral ideal of norm `≤ ⌊M_K⌋ ≤ 1` is the unit ideal `⊤` (every nonzero ideal has norm
+`≥ 1`, with equality iff it is `⊤`), so the head-count collapses to a single ideal and the
+class number is forced down to `1`. It recovers the classical "no class survives the Minkowski
+bound" PID test directly from the counting estimate, rather than via the discriminant route of
+`RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt`. -/
+theorem classNumber_eq_one_of_minkowskiIdealBound_lt_two
+    (h : minkowskiIdealBound K < 2) : classNumber K = 1 := by
+  -- `⌊M_K⌋₊ ≤ 1` because `0 ≤ M_K < 2`.
+  have hfloor : ⌊minkowskiIdealBound K⌋₊ ≤ 1 := by
+    by_contra hc
+    push_neg at hc
+    have hc2 : (2 : ℕ) ≤ ⌊minkowskiIdealBound K⌋₊ := by omega
+    have h2 : ((2 : ℕ) : ℝ) ≤ minkowskiIdealBound K :=
+      (Nat.le_floor_iff (minkowskiIdealBound_nonneg K)).mp hc2
+    push_cast at h2
+    linarith
+  -- The index set of the head-count is a subsingleton: every member coerces to `⊤`.
+  have hsub : Subsingleton {I : (Ideal (𝓞 K))⁰ //
+      Ideal.absNorm (I : Ideal (𝓞 K)) ≤ ⌊minkowskiIdealBound K⌋₊} := by
+    have key : ∀ x : {I : (Ideal (𝓞 K))⁰ //
+        Ideal.absNorm (I : Ideal (𝓞 K)) ≤ ⌊minkowskiIdealBound K⌋₊},
+        (x.1 : Ideal (𝓞 K)) = ⊤ := by
+      rintro ⟨I, hI⟩
+      have hpos : 0 < Ideal.absNorm (I : Ideal (𝓞 K)) :=
+        Ideal.absNorm_pos_of_nonZeroDivisors I
+      have h2 : Ideal.absNorm (I : Ideal (𝓞 K)) ≤ 1 := le_trans hI hfloor
+      have hone : Ideal.absNorm (I : Ideal (𝓞 K)) = 1 := by omega
+      exact Ideal.absNorm_eq_one_iff.mp hone
+    refine ⟨fun a b => ?_⟩
+    have hab : (a.1 : Ideal (𝓞 K)) = (b.1 : Ideal (𝓞 K)) := by rw [key a, key b]
+    exact Subtype.ext (Subtype.ext hab)
+  haveI := hsub
+  have hle := classNumber_le_card_absNorm_le K
+  have hpos := NumberField.classNumber_pos (K := K)
+  have hone : Nat.card {I : (Ideal (𝓞 K))⁰ //
+      Ideal.absNorm (I : Ideal (𝓞 K)) ≤ ⌊minkowskiIdealBound K⌋₊} ≤ 1 :=
+    Nat.card_le_one
+  omega
+
+/-- The previous bound, packaged as a principal-ideal-ring criterion: a number field whose
+Minkowski bound is below `2` has a principal ideal ring of integers. -/
+theorem isPrincipalIdealRing_of_minkowskiIdealBound_lt_two
+    (h : minkowskiIdealBound K < 2) : IsPrincipalIdealRing (𝓞 K) :=
+  (NumberField.classNumber_eq_one_iff (K := K)).mp
+    (classNumber_eq_one_of_minkowskiIdealBound_lt_two K h)
+
 /-- Restated as finiteness: the class group is finite (already an instance in Mathlib via
 `NumberField.RingOfIntegers.instFintypeClassGroup`), here re-derived as a sanity check that the
 counting bound is meaningful. -/

--- a/research/problems/minkowski-theorem-oq-03/knowledge.md
+++ b/research/problems/minkowski-theorem-oq-03/knowledge.md
@@ -81,6 +81,30 @@ Other:
 
 ## Sessions
 
+### 2026-06-15 (S2, researcher-4) — ACT, PID criterion from the head-count, build pending
+
+**Mode**: DEPTH (built on S1). **Outcome**: progress (build pending).
+
+- Added two theorems to `MinkowskiTheoremOQ03.lean` (now 5 thm / 1 def / 0 sorry / 0 axiom):
+  - `classNumber_eq_one_of_minkowskiIdealBound_lt_two`: `M_K < 2 → classNumber K = 1`.
+  - `isPrincipalIdealRing_of_minkowskiIdealBound_lt_two`: same hypothesis ⟹ `𝓞 K` is a PID.
+- **Math content**: the qualitative payoff of S1's head-count. When `M_K < 2` we get
+  `⌊M_K⌋₊ ≤ 1`; every member `I` of `(Ideal 𝓞K)⁰` of norm `≤ 1` has `absNorm I = 1`
+  (`absNorm_pos_of_nonZeroDivisors` forces `≥ 1`), hence `I = ⊤` (`absNorm_eq_one_iff`), so the
+  index subtype is a `Subsingleton` and `Nat.card ≤ 1` (`Nat.card_le_one`). Chaining with the
+  head-count and `classNumber_pos` collapses the class number to `1` by `omega`. This recovers
+  the classical "no class survives the Minkowski bound" PID test *directly from the count*,
+  rather than via Mathlib's discriminant route `isPrincipalIdealRing_of_abs_discr_lt`.
+- New Mathlib lemmas name-checked @ rev 2df2f0150c: `Ideal.absNorm_pos_of_nonZeroDivisors`
+  (AbsNorm.lean:347), `Ideal.absNorm_eq_one_iff` (AbsNorm.lean:223), `Nat.le_floor_iff`
+  (Floor/Defs.lean:112), `Nat.card_le_one` (Cardinal/Finite.lean:363),
+  `NumberField.classNumber_pos`/`classNumber_eq_one_iff` (ClassNumber.lean:69/74).
+- **NOT kernel-checked**: worktree `proofs/.lake` is the circular self-symlink (0 oleans) ⇒ a
+  Docker build would recompile Mathlib from source and OOM (3 peer builds already running);
+  Aristotle MCP still returns "Resource not found". Build deferred to the cache-warm deployer.
+- Note `Nat.floor_lt` does **not** exist under that name in this rev (only `Int.floor_lt`);
+  used `Nat.le_floor_iff` via `by_contra` instead.
+
 ### 2026-06-15 (S1) — ORIENT + ACT, build pending
 
 **Mode**: FRESH. **Outcome**: progress (build pending).

--- a/src/data/proofs/minkowski-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/meta.json
@@ -2,15 +2,15 @@
   "id": "minkowski-theorem-oq-03",
   "title": "Minkowski Bound on Ideal Norms: A Class-Number Estimate",
   "slug": "minkowski-theorem-oq-03",
-  "description": "Makes the geometry-of-numbers ⟹ ideal-norm bound connection explicit and draws a new quantitative consequence. Packages the Minkowski bound M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K| (only a local notation in Mathlib) as a reusable definition, restates that every ideal class contains an integral ideal of norm ≤ M_K, and proves the new estimate classNumber K ≤ #{ ideals : absNorm ≤ ⌊M_K⌋ } — an explicit, computable head-count refining the bare finiteness of the class group. Build pending (worktree Docker cache unavailable); proofs reduce entirely to Mathlib lemmas name-checked at rev 2df2f0150c.",
+  "description": "Makes the geometry-of-numbers ⟹ ideal-norm bound connection explicit and draws new quantitative consequences. Packages the Minkowski bound M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K| (only a local notation in Mathlib) as a reusable definition, restates that every ideal class contains an integral ideal of norm ≤ M_K, and proves the new estimate classNumber K ≤ #{ ideals : absNorm ≤ ⌊M_K⌋ } — an explicit, computable head-count refining the bare finiteness of the class group. Derives from that head-count a PID criterion: if M_K < 2 then classNumber K = 1 (equivalently 𝓞 K is a principal ideal ring), recovered directly from the count rather than via the discriminant route. Build pending (worktree Docker cache unavailable); proofs reduce entirely to Mathlib lemmas name-checked at rev 2df2f0150c.",
   "meta": {
     "status": "formalized",
     "badge": "wip",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 1,
-    "lineCount": 113,
+    "lineCount": 163,
     "proofRepoPath": "Proofs/MinkowskiTheoremOQ03.lean",
     "tags": [
       "number-theory",
@@ -21,7 +21,7 @@
       "class-number",
       "geometry-of-numbers"
     ],
-    "assumptions": "Build pending: the worktree Docker olean cache is unavailable, so the file has not been kernel-checked this session. The proofs contain 0 sorries and 0 axiom declarations, reducing entirely to existing Mathlib results (NumberField.exists_ideal_in_class_of_norm_le, Ideal.finite_setOf_absNorm_le₀, Nat.card_le_card_of_surjective, Nat.le_floor), all name-checked against the pinned Mathlib revision 2df2f0150c. Status will be promoted to verified once a green Docker build confirms the kernel check.",
+    "assumptions": "Build pending: the worktree Docker olean cache is unavailable (circular .lake symlink) and Aristotle's MCP endpoint returned 'Resource not found', so the file has not been kernel-checked this session. The proofs contain 0 sorries and 0 axiom declarations, reducing entirely to existing Mathlib results (NumberField.exists_ideal_in_class_of_norm_le, Ideal.finite_setOf_absNorm_le₀, Nat.card_le_card_of_surjective, Nat.le_floor; for the PID criterion: Ideal.absNorm_pos_of_nonZeroDivisors, Ideal.absNorm_eq_one_iff, Nat.le_floor_iff, Nat.card_le_one, NumberField.classNumber_pos, NumberField.classNumber_eq_one_iff), all name-checked against the pinned Mathlib revision 2df2f0150c. Status will be promoted to verified once a green Docker build confirms the kernel check.",
     "author": "Lean Genius Researcher",
     "dateAdded": "2026"
   },

--- a/src/data/research/problems/minkowski-theorem-oq-03.json
+++ b/src/data/research/problems/minkowski-theorem-oq-03.json
@@ -29,32 +29,35 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-15",
-    "iteration": 2,
-    "focus": "Named the Minkowski bound and proved the class-number head-count; build pending.",
+    "iteration": 3,
+    "focus": "Derived a PID criterion (M_K < 2 ⟹ classNumber 1 ⟹ PID) directly from the S1 head-count; build pending.",
     "blockers": [
-      "Worktree Docker olean cache unavailable — file not kernel-checked.",
-      "Aristotle MCP endpoint returned 'Resource not found'."
+      "Worktree proofs/.lake is the circular self-symlink (0 oleans) — a Docker build would recompile Mathlib from source and OOM; not kernel-checked.",
+      "Aristotle MCP endpoint still returns 'Resource not found'."
     ],
-    "nextAction": "Green Docker build to promote status to verified; resubmit to Aristotle when endpoint recovers.",
+    "nextAction": "Green Docker build (cache-warm deployer) to promote status to verified; resubmit to Aristotle when endpoint recovers. Remaining real content: a concrete quadratic-field example, blocked on a clean discriminant instance.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (build pending): named the Minkowski bound (minkowskiIdealBound), restated the ideal-norm bound, and proved the new estimate classNumber K ≤ #{ideals of norm ≤ ⌊M_K⌋} — the formal backbone of the class-number algorithm, not present in Mathlib.",
+    "progressSummary": "PROGRESS (build pending): named the Minkowski bound (minkowskiIdealBound), restated the ideal-norm bound, proved the new estimate classNumber K ≤ #{ideals of norm ≤ ⌊M_K⌋} (the class-number algorithm's backbone, not in Mathlib), and (S2) derived from it a PID criterion: M_K < 2 ⟹ classNumber K = 1 ⟹ 𝓞 K is a principal ideal ring, obtained directly from the head-count rather than via the discriminant route.",
     "builtItems": [
       "MinkowskiIdealBound.minkowskiIdealBound — reusable def of the Minkowski bound (MinkowskiTheoremOQ03.lean:60)",
       "MinkowskiIdealBound.minkowskiIdealBound_nonneg — bound ≥ 0 (MinkowskiTheoremOQ03.lean:65)",
       "MinkowskiIdealBound.exists_ideal_in_class_absNorm_le — ideal-norm bound vs named constant (MinkowskiTheoremOQ03.lean:74)",
-      "MinkowskiIdealBound.classNumber_le_card_absNorm_le — new class-number head-count (MinkowskiTheoremOQ03.lean:85)"
+      "MinkowskiIdealBound.classNumber_le_card_absNorm_le — new class-number head-count (MinkowskiTheoremOQ03.lean:85)",
+      "MinkowskiIdealBound.classNumber_eq_one_of_minkowskiIdealBound_lt_two — M_K < 2 ⟹ classNumber K = 1, from the head-count (MinkowskiTheoremOQ03.lean:117)",
+      "MinkowskiIdealBound.isPrincipalIdealRing_of_minkowskiIdealBound_lt_two — M_K < 2 ⟹ 𝓞 K is a PID (MinkowskiTheoremOQ03.lean:152)"
     ],
     "insights": [
       "Mathlib's Minkowski bound is only a local notation inside ClassNumber.lean, so it is not reusable downstream; reintroducing it as a definition character-for-character identical to the notation lets exists_ideal_in_class_of_norm_le be reused by definitional unfolding (unfold; exact).",
       "The headline ideal-norm bound and class-group finiteness are already in Mathlib; the genuine new content is the explicit head-count classNumber ≤ #{ideals of bounded norm}.",
       "Counting step: the class-representative map from {ideals of norm ≤ ⌊M_K⌋} onto the class group is surjective (content of the Minkowski bound), and Nat.card_le_card_of_surjective converts this into the cardinality inequality.",
-      "Real→ℕ collapse: absNorm I is a natural number bounded by the real M_K ≥ 0, so Nat.le_floor gives absNorm I ≤ ⌊M_K⌋, matching the natural-number-indexed finiteness lemma finite_setOf_absNorm_le₀."
+      "Real→ℕ collapse: absNorm I is a natural number bounded by the real M_K ≥ 0, so Nat.le_floor gives absNorm I ≤ ⌊M_K⌋, matching the natural-number-indexed finiteness lemma finite_setOf_absNorm_le₀.",
+      "PID criterion from the count (S2): when M_K < 2, ⌊M_K⌋₊ ≤ 1, and since every nonzero ideal has absNorm ≥ 1 with equality iff it is ⊤ (absNorm_pos_of_nonZeroDivisors + absNorm_eq_one_iff), the index subtype is a Subsingleton, so Nat.card ≤ 1 (Nat.card_le_one); chaining with the head-count and classNumber_pos forces classNumber = 1 by omega. This is the classical 'no class survives the Minkowski bound' PID test obtained directly from the head-count, not from the discriminant criterion isPrincipalIdealRing_of_abs_discr_lt."
     ],
     "mathlibGaps": [
       "No reusable named definition of the Minkowski bound (Mathlib hides it as a local notation M K).",


### PR DESCRIPTION
## Summary

Builds on the S1 class-number head-count `classNumber K ≤ #{ideals : absNorm ≤ ⌊M_K⌋}` in `MinkowskiTheoremOQ03.lean` and draws its qualitative payoff. Two new theorems (file now **5 thm / 1 def / 0 sorry / 0 axiom**):

- `classNumber_eq_one_of_minkowskiIdealBound_lt_two` — `M_K < 2 → classNumber K = 1`.
- `isPrincipalIdealRing_of_minkowskiIdealBound_lt_two` — same hypothesis ⟹ `𝓞 K` is a principal ideal ring.

## Math

When `M_K < 2` we have `⌊M_K⌋₊ ≤ 1`. Every member of `(Ideal 𝓞K)⁰` of norm `≤ 1` has `absNorm = 1` (`absNorm_pos_of_nonZeroDivisors` forces `≥ 1`), hence equals `⊤` (`absNorm_eq_one_iff`). So the head-count index subtype is a `Subsingleton`, giving `Nat.card ≤ 1` (`Nat.card_le_one`); chaining with the head-count and `classNumber_pos` collapses the class number to `1` by `omega`.

This recovers the classical "no class survives the Minkowski bound" PID test **directly from the counting estimate**, rather than via the discriminant route `RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt`.

## Build status

Build pending — **not kernel-checked this session**. The worktree `proofs/.lake` is the circular self-symlink (0 oleans), so a Docker build would recompile Mathlib from source and OOM (peer builds already running), and the Aristotle MCP endpoint returns "Resource not found". All new Mathlib lemmas were name-checked against the pinned revision `2df2f0150c`. Gallery status stays `formalized`/`wip`; promotion to verified is deferred to the cache-warm deployer build-gate.

## Test plan

- [ ] Deployer green Docker build of `Proofs.MinkowskiTheoremOQ03` → promote meta.json to verified/original.
- [ ] (optional) Aristotle independent verification once its endpoint recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)