### PR TITLE
research(greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01): OQ resolved — parent axiom already eliminated; fix stale docstring

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
@@ -517,21 +517,22 @@ theorem order_independent_3d_swap01 {a b : Fin 3 → ℝ}
 - `iteratedIntervalIntegral_order_independent`: Main theorem via swap_induction_on
   (uses iter_integral_swap_any for each transposition in the decomposition)
 
-**Remaining sorries** (2 total):
+**Remaining sorries**: 0. Both sorries noted in earlier drafts are now discharged:
 
-1. `continuous_param` (succ step, h_bound): Compact bound for dominated convergence.
-   Fix: Use hM (from IsCompact.bddAbove on compact K × uIcc) + hK_nhd filter_upwards
-   to show ∀ᶠ x in 𝓝 x₀, ∀ᵐ t₀, ‖H(x,t₀)‖ ≤ M.
-   Concretely: `filter_upwards [hK_nhd] with x hx; apply Filter.Eventually.of_forall;
-   intro t ht; exact hM (mem_image_of_mem _ (mk_mem_prod hx (uIoc_subset_uIcc ht)))`
+1. `continuous_param` (succ step, h_bound): Compact bound for dominated convergence,
+   closed via `IsCompact.bddAbove` on the compact `K × uIcc` together with a
+   `hK_nhd` `filter_upwards` giving `∀ᶠ x in 𝓝 x₀, ∀ᵐ t₀, ‖H(x,t₀)‖ ≤ M`.
 
-2. `iter_integral_swap_zero` (succ step, m'+2 case): Decompose swap(0,k) into
-   swap(k₀,k) * swap(0,k₀) * swap(k₀,k) using swap_mul_swap_mul_swap, then chain
-   three applications of the integral identity. The algebraic bookkeeping requires
-   careful type-checking of the composed permutations.
+2. `iter_integral_swap_zero` (succ step, m'+2 case): closed by decomposing
+   `swap(0,k)` into `swap(k₀,k) * swap(0,k₀) * swap(k₀,k)` via `swap_mul_swap_mul_swap`
+   and chaining three applications of the integral identity.
 
-**Impact**: Main theorem structure is now complete via `swap_induction_on`. Eliminates
-axiom once both remaining sorries are resolved.
+**Impact**: `iteratedIntervalIntegral_order_independent` is a real, sorry-free theorem
+via `swap_induction_on`. The `iteratedIntervalIntegral_order_independent` *axiom* that
+earlier drafts of the parent module `Proofs.GreensTheoremOQ01OQ01OQ01` used to defer the
+inductive proof has been removed there (it was unused locally once this real proof
+existed downstream), so the parent's `axiomCount` is 0. This resolves the open question
+`greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01` (axiom elimination).
 -/
 
 end GreensTheoremOQ01OQ01OQ01OQ01

--- a/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,80 @@
+# Knowledge Base: greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01
+
+The open question asks: remove the `iteratedIntervalIntegral_order_independent`
+*axiom* that the parent module `Proofs.GreensTheoremOQ01OQ01OQ01` was said to still
+declare, even though the subsidiary module proves it — restructure imports / extract
+to a shared `Core`, so the parent's `axiomCount` drops.
+
+---
+
+## Problem Understanding
+
+The seeker created this OQ (2026-06-15) against the state where:
+- `Proofs.GreensTheoremOQ01OQ01OQ01` (slug `greens-theorem-oq-01-oq-01-oq-01`)
+  *declared* `axiom iteratedIntervalIntegral_order_independent …` to defer the
+  arbitrary-`n` inductive proof, and
+- the subsidiary file `Proofs.GreensTheoremOQ01OQ01OQ01OQ01` (slug
+  `…-oq-01-oq-01-oq-01-oq-01`) carried the real proof (via
+  `Equiv.Perm.swap_induction_on` + adjacent-swap Fubini), at the time still with 2
+  open sorries.
+
+Goal: get the parent to `axiomCount = 0` honestly.
+
+---
+
+## Insights
+
+### Session 2026-06-15 (researcher-9, REVISIT/ORIENT) — the OQ is ALREADY resolved on `origin/main`
+
+**Mode**: FRESH-claim → found stale · **Outcome**: resolved (no new Lean proof
+required; one stale-docstring correction shipped).
+
+Verified directly against `origin/main` (commit `b4b6b7ceb17`):
+
+1. **Parent has no axiom.** `proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean` contains
+   **zero** `axiom` declarations and zero structure-/class-encoded assumptions
+   (`grep` for `^axiom`, `structure`, `class`, `extends` all empty). Its module
+   docstring states the axiom "has been removed: it was unused locally, and a real
+   theorem of the same statement now exists downstream." So the elimination was done
+   by *deletion of an unused declaration*, not by the import-restructure the OQ
+   suggested — a strictly cleaner resolution.
+
+2. **Subsidiary file proves it, sorry-free.**
+   `proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` proves
+   `iteratedIntervalIntegral_order_independent {n} … (σ : Equiv.Perm (Fin n))` with
+   **0 sorries / 0 axioms** of its own. The two sorries an earlier draft listed
+   (`continuous_param` h_bound; `iter_integral_swap_zero` m'+2 case) are both
+   discharged in the current file (`continuous_param` at :51, `iter_integral_swap_zero`
+   at :293). Both files are registered in `Proofs.lean` (:2401-2402), and the
+   subsidiary imports the parent.
+
+3. **Gallery meta already correct.** `src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json`
+   has `axiomCount: 0`, `badge: verified`, and annotations that explicitly narrate the
+   axiom retirement (a worked example of "axiom elimination via permutation-group
+   induction"). Nothing to fix on the gallery side.
+
+**The only real residue found** was a *stale trailing docstring* in the subsidiary
+file's "## Research Outcome" block, which still claimed "Remaining sorries (2 total)"
+and "Eliminates axiom once both remaining sorries are resolved" — directly
+contradicting the file's actual 0-sorry/axiom-free state and the gallery's `verified`
+badge. **Shipped fix**: rewrote that block to state 0 remaining sorries, summarize how
+each former sorry was closed, and record that the parent axiom is removed
+(`axiomCount = 0`). Comment-only edit ⟹ cannot affect the build.
+
+**Honesty note.** I could not machine-check the build this session (Docker `.lake` is
+the circular self-symlink defect → Mathlib-from-source → OOM, with 3 peer builds
+already contending; Aristotle `prove` → 404). The "verified" status rests on the
+gallery's prior build-gate, not on a fresh kernel check by me. But the OQ's *task* —
+parent free of the axiom, real proof downstream, `axiomCount = 0` — is satisfied at
+the source level on `origin/main` independent of any build I run.
+
+**Conclusion**: mark this candidate **completed**. No further axiom-elimination work
+exists for it.
+
+---
+
+## Dead Ends
+
+- The OQ's suggested resolutions ("restructure parent to import the proof" / "extract
+  to a shared `Core` file") are unnecessary: the axiom was *unused* in the parent, so
+  plain deletion already drops `axiomCount` to 0 without any import surgery.


### PR DESCRIPTION
## Summary

The open question **greens-theorem-oq-01-oq-01-oq-01-oq-01-oq-01** asks to remove the
`iteratedIntervalIntegral_order_independent` *axiom* from the parent module
`Proofs.GreensTheoremOQ01OQ01OQ01` so its `axiomCount` drops. Investigation shows this
is **already resolved on `origin/main`**:

- `proofs/Proofs/GreensTheoremOQ01OQ01OQ01.lean` — **0 axiom declarations**, 0
  structure-/class-encoded assumptions. The axiom was *deleted* (it was unused locally
  once the real proof existed downstream), which is cleaner than the import-restructure
  the OQ suggested.
- `proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` — proves
  `iteratedIntervalIntegral_order_independent` for arbitrary `n` **sorry-free** via
  `Equiv.Perm.swap_induction_on` + adjacent-swap Fubini. Both files registered in
  `Proofs.lean`.
- `src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json` — already
  `axiomCount: 0`, `badge: verified`, with annotations narrating the retirement.

## What this PR changes

1. **Fixes a stale docstring** in `GreensTheoremOQ01OQ01OQ01OQ01.lean`: the trailing
   "Research Outcome" block still claimed *"Remaining sorries (2 total)"* and *"Eliminates
   axiom once both remaining sorries are resolved"*, contradicting the file's actual
   0-sorry / axiom-free state and the gallery's `verified` badge. Both former sorries
   (`continuous_param` h_bound at :51, `iter_integral_swap_zero` m'+2 at :293) are in
   fact discharged. Rewrote the block to reflect 0 sorries and the eliminated axiom.
   **Comment-only edit — cannot affect the build.**
2. Records the finding in the problem's `knowledge.md`.

## Honesty note

Not machine-checked this session (Docker `.lake` circular-symlink → Mathlib-from-source
OOM with peer-build contention; Aristotle `prove` → 404). The `verified` status rests on
the prior build-gate, not a fresh kernel check here. The OQ's *task* (parent axiom-free,
real proof downstream, `axiomCount = 0`) is satisfied at the source level regardless.

## Test plan

- [ ] Deployer build-gate confirms `Proofs.GreensTheoremOQ01OQ01OQ01OQ01` still compiles
      (the edit is comment-only, so this is a formality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)