### PR TITLE
research(erdos-435-oq-01): prime-power obstruction lemma

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1472,6 +1472,7 @@ import Proofs.Erdos433Aristotle
 import Proofs.Erdos433Problem
 import Proofs.Erdos434Aristotle
 import Proofs.Erdos434Problem
+import Proofs.Erdos435PrimePowerObstruction
 import Proofs.Erdos435Problem
 import Proofs.Erdos436Improvements
 import Proofs.Erdos436Problem

--- a/proofs/Proofs/Erdos435PrimePowerObstruction.lean
+++ b/proofs/Proofs/Erdos435PrimePowerObstruction.lean
@@ -1,0 +1,83 @@
+/-
+Erdős Problem #435 — Prime-Power Obstruction (companion to Erdos435Problem.lean)
+
+This file formalizes the number-theoretic fact underlying the restriction in
+Erdős #435 to integers `n` that are NOT prime powers (Parts V and VI of the
+main file `Erdos435Problem.lean`, previously recorded only as prose).
+
+For `n = p^k` a prime power, every "middle" binomial coefficient `C(n, j)`
+(`1 ≤ j < n`) is divisible by `p`. Hence the gcd of the generators
+`{C(n,1), …, C(n,n-1)}` is divisible by `p`, so it is ≠ 1, the numerical
+semigroup they generate is not cofinite, and no Frobenius number exists.
+This is exactly why the Hwang–Song formula (`hwang_song_theorem`) is stated
+only for non-prime-powers.
+
+Status: build-pending — the gallery build environment was unavailable this
+session (circular `.lake` symlink → OOM; Aristotle MCP returning "Resource not
+found"). The proof relies only on Mathlib's Kummer-type identity
+`Nat.factorization_choose_prime_pow` and standard `ordProj` divisibility, both
+present in the pinned Mathlib v4.26.0.
+-/
+import Mathlib.Data.Nat.Choose.Factorization
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+namespace Erdos435.PrimePowerObstruction
+
+/-- **Prime-power obstruction (core lemma).**
+If `p` is prime and `1 ≤ j < p^k`, then `p ∣ C(p^k, j)`.
+
+By Kummer's identity the `p`-adic valuation of `C(p^k, j)` equals
+`k - v_p(j)`; since `0 < j < p^k` we have `v_p(j) < k`, so the valuation is
+positive and `p` divides the coefficient. -/
+theorem prime_pow_dvd_choose {p k j : ℕ} (hp : p.Prime) (hk : 1 ≤ k)
+    (hj : 1 ≤ j) (hjn : j < p ^ k) : p ∣ (p ^ k).choose j := by
+  have hj0 : j ≠ 0 := by omega
+  have hjle : j ≤ p ^ k := le_of_lt hjn
+  -- Kummer: v_p(C(p^k, j)) = k - v_p(j)
+  have hfact : ((p ^ k).choose j).factorization p = k - j.factorization p :=
+    Nat.factorization_choose_prime_pow hp.prime hjle hj0
+  -- v_p(j) < k, otherwise p^k ∣ j would contradict j < p^k
+  have hjfact_lt : j.factorization p < k := by
+    by_contra h
+    push_neg at h
+    have hdvd : p ^ k ∣ j := dvd_trans (pow_dvd_pow p h) (Nat.ordProj_dvd j p)
+    have : p ^ k ≤ j := Nat.le_of_dvd (by omega) hdvd
+    omega
+  -- hence the valuation of the binomial coefficient is positive
+  have hval_pos : 0 < ((p ^ k).choose j).factorization p := by
+    rw [hfact]; omega
+  -- positive valuation ⟹ p divides the coefficient
+  have hstep : p ^ ((p ^ k).choose j).factorization p ∣ (p ^ k).choose j :=
+    Nat.ordProj_dvd _ p
+  have hpdvd : p ∣ p ^ ((p ^ k).choose j).factorization p :=
+    dvd_pow_self p (by omega)
+  exact dvd_trans hpdvd hstep
+
+/-- **Common prime factor of all generators.**
+For a prime power `n = p^k` (`k ≥ 1`), the prime `p` divides every generator
+`C(n, j)` with `1 ≤ j ≤ n-1`. This is the per-generator statement behind the
+gcd obstruction. -/
+theorem prime_dvd_all_generators {p k : ℕ} (hp : p.Prime) (hk : 1 ≤ k)
+    (j : ℕ) (hj : 1 ≤ j) (hjn : j ≤ p ^ k - 1) : p ∣ (p ^ k).choose j := by
+  have hp1 : 1 ≤ p ^ k := Nat.one_le_pow _ _ hp.pos
+  exact prime_pow_dvd_choose hp hk hj (by omega)
+
+/-- **The generators of a prime power share a common factor `> 1`.**
+For `n = p^k`, the gcd of `{C(n,1), …, C(n,n-1)}` is divisible by `p`, hence
+is not `1`. A numerical semigroup whose generators have gcd `≠ 1` has infinite
+complement, so no Frobenius number exists — precisely why Erdős #435 excludes
+prime powers. -/
+theorem generators_gcd_ne_one {p k : ℕ} (hp : p.Prime) (hk : 1 ≤ k) :
+    (Finset.Icc 1 (p ^ k - 1)).gcd (fun j => (p ^ k).choose j) ≠ 1 := by
+  intro hgcd
+  have hpdvd : p ∣ (Finset.Icc 1 (p ^ k - 1)).gcd (fun j => (p ^ k).choose j) := by
+    apply Finset.dvd_gcd
+    intro j hj
+    rw [Finset.mem_Icc] at hj
+    exact prime_dvd_all_generators hp hk j hj.1 hj.2
+  rw [hgcd] at hpdvd
+  exact hp.one_lt.ne' (Nat.dvd_one.mp hpdvd)
+
+end Erdos435.PrimePowerObstruction

--- a/research/problems/erdos-435-oq-01/knowledge.md
+++ b/research/problems/erdos-435-oq-01/knowledge.md
@@ -1,0 +1,79 @@
+# Knowledge Base: erdos-435-oq-01
+
+Open question derived from Erdős Problem #435 (Binomial Coefficient
+Representation). Goal: "Prove the Hwang–Song formula via Kummer's theorem and
+numerical semigroups."
+
+---
+
+## Problem Understanding
+
+For `n` not a prime power, the largest integer not representable as
+`Σ_{1≤i<n} c_i · C(n,i)` (`c_i ≥ 0`) is
+`Σ_k (Σ_{1≤d≤a_k} C(n, p_k^d)) · (p_k − 1) − n`, where `n = ∏ p_k^{a_k}`
+(Hwang–Song 2024; independently Peake, Cambie).
+
+The gallery entry `Erdos435Problem.lean` states this as the axiom
+`hwang_song_theorem` (`status: axiomatized`, axiomCount 2). Fully formalizing
+the Hwang–Song proof is a research-paper-scale effort (Kummer/Lucas carry
+analysis + numerical-semigroup gap theory) and is NOT tractable in a single
+session — it is the irreducible deep content of the problem.
+
+---
+
+## Insights (Session 2026-06-15, s1, FRESH)
+
+- **The 2-generator Sylvester–Frobenius case is already done.** The gallery has
+  `FrobeniusNumber.lean` (`verified`/`original`, 0 axioms) proving
+  `frobeniusNumber a b = a*b − a − b` for coprime `a, b ≥ 2`, including
+  `sylvester_frobenius` and `frobenius_not_representable`. Do NOT rebuild it.
+- **Tractable, on-path piece formalized this session: the prime-power
+  obstruction.** This is the precise reason the problem excludes prime powers
+  (Parts V/VI of the main file, previously prose-only). For `n = p^k`, every
+  generator `C(p^k, j)` (`1 ≤ j < p^k`) is divisible by `p`, so the gcd of the
+  generators is `> 1` and the numerical semigroup is not cofinite ⟹ no
+  Frobenius number exists.
+- **Proof route (Kummer):** `Nat.factorization_choose_prime_pow` gives
+  `v_p(C(p^k, j)) = k − v_p(j)`. Since `0 < j < p^k` forces `v_p(j) < k`
+  (else `p^k ∣ j`), the valuation is positive, hence `p ∣ C(p^k, j)`.
+  `Nat.ordProj_dvd` lifts positive valuation back to divisibility;
+  `Finset.dvd_gcd` aggregates to the gcd statement.
+
+## Built Items
+
+- `proofs/Proofs/Erdos435PrimePowerObstruction.lean`:
+  - `prime_pow_dvd_choose` — `p ∣ C(p^k, j)` for prime `p`, `1 ≤ j < p^k`.
+  - `prime_dvd_all_generators` — `p` divides every generator `C(p^k, j)`,
+    `1 ≤ j ≤ p^k − 1`.
+  - `generators_gcd_ne_one` — `gcd{C(p^k,1),…,C(p^k,p^k−1)} ≠ 1`.
+  - Registered in `proofs/Proofs.lean`.
+  - **Status: build-pending** (build env unavailable: circular `.lake`
+    symlink → OOM; Aristotle MCP "Resource not found"). Proof uses only stock
+    Mathlib v4.26.0 lemmas; awaits deployer build gate.
+
+## Mathlib Gaps
+
+- No off-the-shelf "gcd of binomial coefficients of `n` = 1 iff `n` not a prime
+  power" (the full Ram/Joris characterization). We proved only the
+  prime-power ⟹ gcd > 1 direction. The converse (non-prime-power ⟹ gcd = 1) is
+  the next building block toward existence of the Frobenius number.
+- No numerical-semigroup Frobenius theory for `≥ 3` generators in Mathlib;
+  the `n`-generator gap-theoretic core of Hwang–Song is unformalized.
+
+## Next Steps
+
+1. Build-gate `Erdos435PrimePowerObstruction.lean` (deployer) to confirm green.
+2. Prove the converse direction: for `n` not a prime power,
+   `gcd{C(n,1),…,C(n,n-1)} = 1` (use that two coprime `C(n,p^a)`, `C(n,q^b)`
+   for distinct primes have gcd 1, via `factorization_choose_prime_pow` on each
+   prime separately).
+3. Connect to `Erdos435Problem.representableSet`: gcd = 1 ⟹ cofinite complement
+   ⟹ `frobeniusBinomial n` well-defined (existence half of the axioms).
+4. The exact Hwang–Song value formula remains the deep open axiom — do not
+   attempt to discharge `hwang_song_theorem` wholesale.
+
+## Dead Ends
+
+- Discharging `hwang_song_theorem` directly: research-paper scale, BLOCKED.
+- Re-deriving the 2-generator Frobenius number: already exists in
+  `FrobeniusNumber.lean`, zero added value.


### PR DESCRIPTION
## Summary
Formalizes the previously prose-only **Parts V/VI** of `Erdos435Problem.lean` — the number-theoretic reason Erdős #435 restricts to integers that are *not* prime powers.

For `n = p^k`, every middle binomial coefficient `C(p^k, j)` (`1 ≤ j < p^k`) is divisible by `p`, hence `gcd{C(n,1),…,C(n,n-1)} ≠ 1`, the generators do not span a cofinite numerical semigroup, and **no Frobenius number exists**. This is exactly why the Hwang–Song formula is stated only for non-prime-powers.

New file `proofs/Proofs/Erdos435PrimePowerObstruction.lean`:
- `prime_pow_dvd_choose` — `p ∣ C(p^k, j)` via Kummer's identity (`Nat.factorization_choose_prime_pow`): `v_p(C(p^k,j)) = k − v_p(j) > 0`.
- `prime_dvd_all_generators` — per-generator divisibility for `1 ≤ j ≤ p^k−1`.
- `generators_gcd_ne_one` — gcd of all generators is `≠ 1` (`Finset.dvd_gcd`).

Registered in `proofs/Proofs.lean`. Knowledge documented in `research/problems/erdos-435-oq-01/knowledge.md`.

## Scope / honesty
- This is **partial infrastructure** toward the OQ "prove Hwang–Song via Kummer + numerical semigroups", not a resolution. The full `hwang_song_theorem` remains a deep research-paper-scale axiom and is untouched. The 2-generator Sylvester–Frobenius case already exists (`FrobeniusNumber.lean`) and was deliberately not duplicated.
- **Build-pending**: the gallery build environment was unavailable this session (circular `proofs/.lake` self-symlink → OOM; Aristotle MCP returning "Resource not found"). The proof uses only stock Mathlib v4.26.0 lemmas already used elsewhere in the repo, but has **not** been kernel-checked here. No gallery `status` was flipped.

## Test plan
- [ ] Deployer build gate: `./proofs/scripts/docker-build.sh Proofs.Erdos435PrimePowerObstruction` (in a cache-warm env) compiles green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)