### PR TITLE
research(erdos-998-oq-04): formal statement of the three-gap theorem + infrastructure

### DIFF
--- a/proofs/Proofs/Erdos998ThreeGapOQ04.lean
+++ b/proofs/Proofs/Erdos998ThreeGapOQ04.lean
@@ -34,10 +34,11 @@
     * `zero_mem_orbit`    — `0` is always an orbit point (the `i = 0` term)
     * `orbit_nonempty`    — the orbit is nonempty for `N ≥ 1`
     * `forwardGap_nonneg` — every forward gap length is `≥ 0`
+    * `orbit_card`        — for irrational `α` the orbit has exactly `N` points
+                            (injectivity of `i ↦ {iα}` via `Int.fract_eq_fract`
+                            and `Irrational.int_mul`)
 
   ISOLATED (the genuine content — see the proof-path comments and knowledge.md):
-    * `orbit_card`        — for irrational `α` the orbit has exactly `N` points
-                            (injectivity of `i ↦ {iα}` via `Int.fract_eq_fract`)
     * `three_gap`         — at most three distinct gap lengths  [HARD core]
     * `three_gap_additive`— the additive relation among the three lengths
 
@@ -105,7 +106,21 @@ theorem forwardGap_nonneg (α : ℝ) (N : ℕ) (x : ℝ) : 0 ≤ forwardGap α N
     `Finset.card_image_of_injective` and `Finset.card_range`. -/
 theorem orbit_card {α : ℝ} (hα : Irrational α) (N : ℕ) :
     (orbit α N).card = N := by
-  sorry
+  have hinj : Set.InjOn (fun i : ℕ => Int.fract ((i : ℝ) * α)) ↑(Finset.range N) := by
+    intro i _ j _ hij
+    simp only at hij
+    by_contra hne
+    rw [Int.fract_eq_fract] at hij
+    obtain ⟨z, hz⟩ := hij
+    have hm : ((i : ℤ) - (j : ℤ)) ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast hne)
+    have key : (((i : ℤ) - (j : ℤ) : ℤ) : ℝ) * α = (z : ℝ) := by
+      push_cast
+      rw [sub_mul]
+      exact hz
+    have hirr : Irrational ((((i : ℤ) - (j : ℤ) : ℤ) : ℝ) * α) := hα.int_mul hm
+    rw [key] at hirr
+    exact (not_irrational_int z) hirr
+  rw [orbit, Finset.card_image_of_injOn hinj, Finset.card_range]
 
 /-- **The Three-Gap (Three-Distance / Steinhaus) Theorem.**
 

--- a/proofs/Proofs/Erdos998ThreeGapOQ04.lean
+++ b/proofs/Proofs/Erdos998ThreeGapOQ04.lean
@@ -1,0 +1,155 @@
+/-
+  The Three-Gap / Three-Distance (Steinhaus) Theorem — Formal Statement and Path
+  (erdos-998-oq-04)
+
+  ## Background
+
+  Erdős Problem #998 (Kesten's equidistribution theorem) is built on the orbit
+  structure of an irrational rotation `m ↦ {mα}` on the circle `[0,1)`.  The
+  *three-distance theorem* (Steinhaus conjecture; proved by Sós, Surányi, and
+  Świerczkowski) describes that orbit structure exactly:
+
+    **For every irrational `α` and every `N ≥ 1`, the `N` points
+    `{0, {α}, {2α}, …, {(N-1)α}}` cut the circle into `N` arcs whose lengths
+    take at most THREE distinct values; moreover, when three values occur, the
+    largest is the sum of the other two.**
+
+  The parent file `Erdos998Problem.lean` only mentions this theorem in a prose
+  docstring (Part V).  This file gives the first *formal Lean statement* of the
+  theorem together with the elementary structural infrastructure, isolating the
+  remaining combinatorial core.
+
+  ## Mathlib status (June 2026)
+
+  Mathlib4 does **not** contain the three-gap theorem.  A Coq formalization
+  (van Ravenstein's proof) exists, but no Lean version.  The theorem is purely
+  finite/order-theoretic — no measure theory or analysis is needed — so it is a
+  natural Mathlib-style target built from `Int.fract`, `Finset`, and the linear
+  order on `ℝ`.
+
+  ## What is proved here vs. left open
+
+  PROVED (elementary, robust):
+    * `orbit_mem_Ico`     — every orbit point lies in `[0,1)`
+    * `zero_mem_orbit`    — `0` is always an orbit point (the `i = 0` term)
+    * `orbit_nonempty`    — the orbit is nonempty for `N ≥ 1`
+    * `forwardGap_nonneg` — every forward gap length is `≥ 0`
+
+  ISOLATED (the genuine content — see the proof-path comments and knowledge.md):
+    * `orbit_card`        — for irrational `α` the orbit has exactly `N` points
+                            (injectivity of `i ↦ {iα}` via `Int.fract_eq_fract`)
+    * `three_gap`         — at most three distinct gap lengths  [HARD core]
+    * `three_gap_additive`— the additive relation among the three lengths
+
+  ## Status: build-pending (worktree `.lake` circular-symlink OOM this cycle);
+  Mathlib bearers name-checked against the pinned rev 2df2f01 / v4.26.0.
+-/
+import Mathlib
+
+namespace Erdos998ThreeGap
+
+open Finset
+
+/-- The orbit of the rotation by `α` after `N` steps, viewed as a finite subset
+    of `[0,1)`: the fractional parts `{0, {α}, {2α}, …, {(N-1)α}}`. -/
+noncomputable def orbit (α : ℝ) (N : ℕ) : Finset ℝ :=
+  (Finset.range N).image (fun i => Int.fract ((i : ℝ) * α))
+
+/-- Every orbit point lies in the half-open unit interval `[0,1)`. -/
+theorem orbit_mem_Ico {α : ℝ} {N : ℕ} {x : ℝ} (hx : x ∈ orbit α N) :
+    0 ≤ x ∧ x < 1 := by
+  simp only [orbit, Finset.mem_image] at hx
+  obtain ⟨i, _, rfl⟩ := hx
+  exact ⟨Int.fract_nonneg _, Int.fract_lt_one _⟩
+
+/-- `0` is always an orbit point, contributed by the `i = 0` term. -/
+theorem zero_mem_orbit (α : ℝ) {N : ℕ} (hN : 0 < N) : (0 : ℝ) ∈ orbit α N := by
+  simp only [orbit, Finset.mem_image, Finset.mem_range]
+  exact ⟨0, hN, by simp⟩
+
+/-- The orbit is nonempty whenever `N ≥ 1`. -/
+theorem orbit_nonempty (α : ℝ) {N : ℕ} (hN : 0 < N) : (orbit α N).Nonempty :=
+  ⟨0, zero_mem_orbit α hN⟩
+
+/-- The forward gap of an orbit point `x`: the shortest *positive cyclic*
+    distance `{y - x}` from `x` to another orbit point `y`.  Cyclic distance is
+    measured by `Int.fract (y - x) ∈ [0,1)`, so the minimum over `y ≠ x` is the
+    length of the arc immediately clockwise-to-counterclockwise of `x`.  Defined
+    totally via `dite`; the junk value `0` is only hit on the (excluded) empty
+    case `N ≤ 1`. -/
+noncomputable def forwardGap (α : ℝ) (N : ℕ) (x : ℝ) : ℝ :=
+  if h : ((orbit α N).erase x).Nonempty then
+    ((orbit α N).erase x).inf' h (fun y => Int.fract (y - x))
+  else 0
+
+/-- The finite set of distinct gap lengths produced by the `N`-point orbit. -/
+noncomputable def gapLengths (α : ℝ) (N : ℕ) : Finset ℝ :=
+  (orbit α N).image (forwardGap α N)
+
+/-- Every forward gap length is nonnegative (each cyclic distance `{y - x}` is
+    `≥ 0`, and so is their minimum; the junk branch is `0`). -/
+theorem forwardGap_nonneg (α : ℝ) (N : ℕ) (x : ℝ) : 0 ≤ forwardGap α N x := by
+  unfold forwardGap
+  split
+  · rename_i h
+    exact Finset.le_inf' h _ (fun y _ => Int.fract_nonneg _)
+  · exact le_refl 0
+
+/-- For irrational `α` the map `i ↦ {iα}` is injective on `ℕ`, hence the orbit
+    has exactly `N` distinct points.
+
+    PROOF PATH (injectivity): if `{iα} = {jα}` then by `Int.fract_eq_fract`
+    there is `z : ℤ` with `iα - jα = z`, i.e. `(i - j) · α = z`.  If `i ≠ j`
+    then `(i - j : ℝ) ≠ 0`, so `α = z / (i - j)` is rational, contradicting
+    `hα : Irrational α`.  Cardinality then follows from
+    `Finset.card_image_of_injective` and `Finset.card_range`. -/
+theorem orbit_card {α : ℝ} (hα : Irrational α) (N : ℕ) :
+    (orbit α N).card = N := by
+  sorry
+
+/-- **The Three-Gap (Three-Distance / Steinhaus) Theorem.**
+
+    For every irrational `α` and every `N ≥ 1`, the `N` arc lengths cut out of
+    the circle by the orbit `{0, {α}, …, {(N-1)α}}` take at most three distinct
+    values.
+
+    PROOF PATH (van Ravenstein / Sós, elementary):
+
+    1. Let `p` be the least index in `1 ≤ p < N` minimizing the *forward* return
+       `{pα}` (the smallest clockwise gap at the point `0`), and `q` the least
+       index minimizing the *backward* return `1 - {qα}`.  These two "first
+       return" indices are the Steinhaus generators.
+
+    2. CLASSIFICATION OF GAPS.  Walk the points in circular order.  Each point
+       `{iα}` is the left endpoint of exactly one gap, and its forward neighbour
+       is obtained by adding either `p` or `q` to the index `i` (whichever keeps
+       the result in `[0, N)` after the rotation).  Concretely the forward
+       neighbour of `{iα}` is `{(i+p)α}` if `i + p < N`, else `{(i - q)α}` /
+       wrap.  Hence every gap length is one of:
+         • `{pα}`              (a "short" gap, count `N - p`),
+         • `1 - {qα}`          (a "short" gap, count `N - q`),
+         • `{pα} + 1 - {qα}`   (the "long" gap, count `p + q - N`).
+       This already gives ≤ 3 distinct values.
+
+    3. The three counts sum to `N` (`(N-p) + (N-q) + (p+q-N) = N`), confirming
+       the gap-count bookkeeping.
+
+    KEY MATHLIB PIECES: `Int.fract`, `Int.fract_eq_fract`, `Finset.min'`/`inf'`,
+    `Finset.exists_min_image`; the index arithmetic is `Nat`/`Finset.range`
+    order theory only.  No new Mathlib infrastructure is required — only the
+    case analysis above, which is the remaining work. -/
+theorem three_gap (α : ℝ) (hα : Irrational α) {N : ℕ} (hN : 1 ≤ N) :
+    (gapLengths α N).card ≤ 3 := by
+  sorry
+
+/-- **Additive structure of the three gaps.**  When three distinct gap lengths
+    occur, one of them is the sum of the other two (hence equal to the largest).
+    This is immediate from the classification in `three_gap`: the long gap
+    `{pα} + (1 - {qα})` is the sum of the two short gaps `{pα}` and `1 - {qα}`. -/
+theorem three_gap_additive (α : ℝ) (hα : Irrational α) {N : ℕ} (hN : 1 ≤ N)
+    (h3 : (gapLengths α N).card = 3) :
+    ∃ a b c : ℝ, a ∈ gapLengths α N ∧ b ∈ gapLengths α N ∧ c ∈ gapLengths α N ∧
+      a ≠ b ∧ a ≠ c ∧ b ≠ c ∧ a + b = c := by
+  sorry
+
+end Erdos998ThreeGap

--- a/research/problems/erdos-998-oq-04/knowledge.md
+++ b/research/problems/erdos-998-oq-04/knowledge.md
@@ -108,13 +108,19 @@ and the proof that it is the cyclic successor — pure `Nat`/order reasoning.
 
 ## Next Steps
 
-1. Prove `orbit_card` (injectivity of `i ↦ {iα}` via `Int.fract_eq_fract` +
-   `Irrational`) — fully elementary, ~15 lines.
+1. ~~Prove `orbit_card`~~ DONE (S2). Injectivity of `i ↦ {iα}` on `range N` via
+   `Int.fract_eq_fract` (→ `(i-j)·α = z ∈ ℤ`), then `Irrational.int_mul`
+   (a nonzero-int multiple of an irrational is irrational) contradicts
+   `not_irrational_int z`. Card follows from `Finset.card_image_of_injOn` +
+   `Finset.card_range`. Build-pending (circular `.lake` OOM).
 2. Formalize the first-return generators `p, q` and the successor map (step 2).
 3. Discharge `three_gap` and `three_gap_additive` from the classification.
 4. Once green, register a gallery entry (status `formalized`/`wip` until built;
    the ≤3 claim is unconditional, the additive relation follows).
 
-**progressSummary:** SURVEYED→ORIENT. Stated the theorem formally for the first
-time in Lean, built robust structural lemmas, and reduced the open content to a
-single elementary combinatorial classification with a documented proof path.
+**progressSummary:** ORIENT→ATTACK. Discharged `orbit_card` (one of the three
+isolated sorries) with a fully elementary irrationality argument. The remaining
+open content is the single combinatorial gap-classification core (`three_gap`,
+`three_gap_additive`), with the documented van Ravenstein proof path. The ≤3
+distinct-lengths statement remains the first formal Lean statement of the
+three-gap/Steinhaus theorem.

--- a/research/problems/erdos-998-oq-04/knowledge.md
+++ b/research/problems/erdos-998-oq-04/knowledge.md
@@ -1,0 +1,120 @@
+# Knowledge Base: erdos-998-oq-04
+
+**Question:** Is there a formalization path for the three-distance theorem
+using Mathlib's `Finset` and order theory?
+
+**Answer (this session): YES.** The three-distance (three-gap / Steinhaus)
+theorem is purely finite and order-theoretic — no measure theory, no analysis.
+It is a clean Mathlib-style target built from `Int.fract`, `Finset`, and the
+linear order on `ℝ`. This session gives the first formal Lean *statement* plus
+the elementary structural infrastructure, and isolates the combinatorial core.
+
+---
+
+## Problem Understanding
+
+The orbit of an irrational rotation `m ↦ {mα}` underlies Erdős #998 (Kesten's
+equidistribution theorem). The three-distance theorem describes that orbit:
+
+> For irrational `α` and every `N ≥ 1`, the `N` points
+> `{0, {α}, {2α}, …, {(N-1)α}}` cut the circle `[0,1)` into `N` arcs whose
+> lengths take **at most three distinct values**; when three values occur, the
+> largest is the sum of the other two.
+
+The parent `Erdos998Problem.lean` mentions this only in a prose docstring
+(Part V, lines 144–151). No formal statement existed before this session.
+
+---
+
+## Mathlib Status (verified June 2026)
+
+- Mathlib4 does **not** contain the three-gap theorem (web survey + local
+  inspection). A **Coq** formalization exists (van Ravenstein's proof), but no
+  Lean version. Genuine gap.
+- Available bearers: `Int.fract` (`Int.fract_nonneg`, `Int.fract_lt_one`,
+  `Int.fract_eq_fract`, `Int.fract_zero`), `Finset.image`/`erase`/`min'`/`inf'`,
+  `Finset.card_image_of_injective`, `Finset.card_range`, `Irrational`.
+- No measure/analysis dependency — the entire proof is `Nat`/`Finset` order
+  arithmetic over the linear order on `ℝ`.
+
+---
+
+## Formalization Built This Session
+
+File: `proofs/Proofs/Erdos998ThreeGapOQ04.lean` (build-pending — worktree
+`.lake` circular-symlink OOM this cycle; bearers name-checked vs rev 2df2f01).
+
+Definitions:
+- `orbit α N := (range N).image (fun i => Int.fract (i * α))` — the orbit as a
+  `Finset ℝ ⊆ [0,1)`.
+- `forwardGap α N x` — shortest positive cyclic distance `{y - x}` to another
+  orbit point, via `Finset.inf'` (total, `dite`-guarded).
+- `gapLengths α N := (orbit α N).image (forwardGap α N)` — the set of distinct
+  arc lengths.
+
+Theorem statements:
+- `three_gap : (gapLengths α N).card ≤ 3` — **the main theorem**.
+- `three_gap_additive` — among three lengths, one is the sum of the other two.
+
+Proved (elementary, robust):
+- `orbit_mem_Ico` — orbit ⊆ [0,1).
+- `zero_mem_orbit`, `orbit_nonempty` — the `i=0` point and nonemptiness.
+- `forwardGap_nonneg`.
+
+---
+
+## Proof Path for the Core (van Ravenstein / Sós–Surányi–Świerczkowski)
+
+This is the remaining work, isolated behind `sorry` in `three_gap`:
+
+1. **First-return generators.** Let `p` be the least index `1 ≤ p < N`
+   minimizing the forward return `{pα}` (smallest clockwise gap at `0`), and `q`
+   the least index minimizing the backward return `1 - {qα}`. Existence:
+   `Finset.exists_min_image` on `range N`.
+
+2. **Gap classification.** Each orbit point `{iα}` is the left endpoint of
+   exactly one arc, whose forward neighbour is `{(i+p)α}` when `i + p < N` and
+   otherwise wraps via `q`. Hence every gap length is one of:
+   - `{pα}`               (short, count `N − p`),
+   - `1 − {qα}`           (short, count `N − q`),
+   - `{pα} + 1 − {qα}`    (long, count `p + q − N`).
+   Three values ⟹ `card ≤ 3`.
+
+3. **Bookkeeping / additive relation.** Counts sum to `N`:
+   `(N−p) + (N−q) + (p+q−N) = N`. The long gap is literally the sum of the two
+   short gaps ⟹ `three_gap_additive`.
+
+The crux to formalize is step 2's neighbour map `i ↦ i+p mod (the wrap rule)`
+and the proof that it is the cyclic successor — pure `Nat`/order reasoning.
+
+---
+
+## Insights
+
+- The theorem needs **no equidistribution and no `α` irrationality for the
+  ≤3-lengths claim itself** — irrationality only guarantees the `N` points are
+  *distinct* (`orbit_card`). The gap structure is combinatorial.
+- Defining gaps via `forwardGap` (min positive cyclic distance) sidesteps an
+  explicit sort/`orderEmbOfFin`, keeping the statement order-theoretic and the
+  successor map index-arithmetic.
+
+## Dead Ends / Risks
+
+- A measure-theoretic phrasing (arc lengths as `volume`) would drag in
+  `MeasureTheory` unnecessarily; the `Finset`+`Int.fract` phrasing is lighter.
+- Build verification blocked this cycle by the repo-wide circular `.lake`
+  self-symlink (Mathlib recompiles from source → OOM). Defer kernel check to a
+  cache-warm deployer build.
+
+## Next Steps
+
+1. Prove `orbit_card` (injectivity of `i ↦ {iα}` via `Int.fract_eq_fract` +
+   `Irrational`) — fully elementary, ~15 lines.
+2. Formalize the first-return generators `p, q` and the successor map (step 2).
+3. Discharge `three_gap` and `three_gap_additive` from the classification.
+4. Once green, register a gallery entry (status `formalized`/`wip` until built;
+   the ≤3 claim is unconditional, the additive relation follows).
+
+**progressSummary:** SURVEYED→ORIENT. Stated the theorem formally for the first
+time in Lean, built robust structural lemmas, and reduced the open content to a
+single elementary combinatorial classification with a documented proof path.


### PR DESCRIPTION
## Summary

First **formal Lean statement** of the three-distance / three-gap (Steinhaus) theorem, which describes the orbit structure underlying Erdős Problem #998 (Kesten's equidistribution theorem). Answers `erdos-998-oq-04` ("Is there a formalization path... using Finset and order theory?") with **YES** and a concrete plan.

- Mathlib4 does **not** have this theorem (only a Coq formalization exists). Genuine gap.
- Pure `Finset` + order-theory phrasing via `Int.fract` — no measure theory or analysis.
- New file `proofs/Proofs/Erdos998ThreeGapOQ04.lean`:
  - **Statements**: `three_gap` (≤ 3 distinct gap lengths) and `three_gap_additive` (one length is the sum of the other two).
  - **Defs**: `orbit`, `forwardGap` (min positive cyclic distance, sort-free), `gapLengths`.
  - **Proved** (robust, elementary): `orbit_mem_Ico`, `zero_mem_orbit`, `orbit_nonempty`, `forwardGap_nonneg`.
  - **Isolated** behind documented `sorry`s: `orbit_card` (injectivity for irrational α), `three_gap`, `three_gap_additive` — full van Ravenstein proof path in the docstrings + `knowledge.md`.

## Status

`surveyed` → phase `ORIENT`. This is a research-stage statement skeleton, **not** a gallery promotion. Build is **pending** (repo-wide circular `.lake` self-symlink OOMs Mathlib-from-source this cycle); Mathlib bearers name-checked against pinned rev `2df2f01` / v4.26.0. No gallery `meta.json` status is changed.

## Test plan

- [ ] Cache-warm deployer build of `Proofs.Erdos998ThreeGapOQ04` (verifies the proved lemmas compile; remaining `sorry`s are the documented open core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)