### PR TITLE
audit(inclusion-exclusion-oq-01-oq-03): badge "verified" → "mathlib" (Mathlib wrapper)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "euler-totient",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Registered in Proofs.lean (import Proofs.InclusionExclusionOQ01OQ03 present on main), so the gallery build machine-checks it. The proof is a thin, faithful bridge over Mathlib's ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq and Nat.sum_divisorsAntidiagonal at pinned v4.26.0, plus the Euler-φ corollary and the Möbius convolution identity Σ_{d|n} μ(d) = [n=1] (μ ∗ 1 = δ) derived purely from the inversion theorem. All three statements are independently certified by research/problems/inclusion-exclusion-oq-01-oq-03/verify_moebius_inversion.py (all n ≤ 400, random data — all pass).",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `inclusion-exclusion-oq-01-oq-03`
**Severity**: MEDIUM (Mathlib wrapper claimed under a stronger badge)

## Problem

The entry carries `"badge": "verified"`, but the proof obtains its **main result by directly calling a Mathlib theorem** — a textbook Tier-B Mathlib wrapper, not independent verification.

`moebius_inversion_divisors` (the core theorem) is proved by wiring Mathlib's `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` through `Nat.sum_divisorsAntidiagonal`. The `totient_eq_sum_moebius_mul` corollary calls `Nat.sum_totient`. The file's own docstring states this plainly:

> "This is a **thin but faithful bridge** — the mathematical depth lives in Mathlib's `sum_eq_iff_sum_mul_moebius_eq`."

This is exactly auditor **failure mode #5** ("0 sorries with hidden imports"): the file is sorry-free but its main result comes from a deep Mathlib theorem, so the badge must be `mathlib`, not a badge implying independent proof.

Additionally, `"verified"` is **not a valid `ProofBadge`** value at all (`src/types/proof.ts` — the union is `original | mathlib | pedagogical | from-axioms | fallacy | wip | ai-solved | axiom | infrastructure`).

## Fix

- `"badge": "verified"` → `"badge": "mathlib"` ("Uses Mathlib theorems for the main result").
- `status: "verified"` **retained** — the file is genuinely machine-checked (0 sorries, 0 axioms, 0 structure-encoded assumptions), which is what `status` denotes. The badge, not the status, is what overstated independence.

The meta's prose (description, assumptions, keyInsights, mathlibDependencies, originalContributions) is already exemplary in crediting Mathlib — only the badge token was misaligned.

---
Discovered during gallery integrity audit.