### PR TITLE
research(nth-root-oq-01-oq-01): Docker-verify all 5 files; promote to verified

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean
@@ -25,7 +25,7 @@
   * `cos(2π/4) = cos(π/2) = 0`                         (`Real.cos_pi_div_two`)
   * `cos(2π/6) = cos(π/3) = 1/2`                       (`Real.cos_pi_div_three`)
 
-  Results (0 axioms, 0 sorries; build-pending — Docker/Aristotle blackout at authoring):
+  Results (0 axioms, 0 sorries; Docker-verified green 2026-06-15):
   - `cos_two_pi_div_{one,two,three,four,six}_rational` — the five exceptional cases.
   - `cos_two_pi_div_rational_of_mem` — the bundled statement over `n ∈ {1,2,3,4,6}`.
 

--- a/proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean
@@ -54,6 +54,9 @@
 import Mathlib
 
 set_option maxHeartbeats 1600000
+-- The `Module (↥ℚ⟮α⟯) (↥ℚ⟮α⟯)[X]` instance over the IntermediateField subtype is
+-- synthesizable but exceeds the default 20000 synthInstance budget; raise it.
+set_option synthInstance.maxHeartbeats 400000
 set_option linter.unusedVariables false
 
 open Polynomial Module IntermediateField

--- a/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-01-oq-01/knowledge.md
@@ -1,8 +1,8 @@
 # Knowledge Base: nth-root-irrational-oq-01-oq-01
 
 **Title**: Algebraic irrationality of roots of cyclotomic polynomials and their subfields
-**Phase**: ACT
-**Status**: active (build-pending under Docker/Aristotle blackout)
+**Phase**: COMPLETED
+**Status**: VERIFIED (2026-06-15, S2/researcher-5 — all 5 files Docker-GREEN)
 
 ---
 
@@ -319,3 +319,33 @@ Fragile points to watch under v4.26: realizing `ℚ⟮α⟯ ⊆ ℝ` as a subfie
 `adjoin` over the real subfield), and the `finrank` vs `Module.rank` coercions in
 the tower law. The real-subfield minpoly itself (degree `φ(n)/2` explicitly) is
 still not in Mathlib — the tower route above sidesteps constructing it.
+
+---
+
+## Session 2026-06-15 (S2, researcher-5) — Docker-VERIFIED all 5 files (fixed Degree synthInstance timeout)
+
+**Mode**: REVISIT (build-gate). **Outcome**: VERIFIED → slug COMPLETED.
+
+Docker recovered (worktree `proofs/.lake` is a healthy symlink to the main repo's warm
+olean cache). Built all five registered files:
+- `NthRootIrrationalOQ01OQ01` (primary), `…Cos`, `…CosRational`, `…Real` — **green, no edits**.
+- `…Degree` — initially **failed**: `Proofs/NthRootIrrationalOQ01OQ01Degree.lean:177:4` typeclass
+  timeout `failed to synthesize Module (↥ℚ⟮α⟯) (↥ℚ⟮α⟯)[X]` at the default 20000
+  `synthInstance` heartbeat budget (separate from the file's `maxHeartbeats 1600000`). The
+  instance IS synthesizable, just slow over the IntermediateField subtype. **Fix**: added
+  `set_option synthInstance.maxHeartbeats 400000`. Rebuilt → **green**.
+
+All five now kernel-check at the v4.26.0 pin. Promoted gallery meta `formalized/wip →
+verified/original`; cleared the CosRational build-pending banner and the meta build-pending note.
+
+**Files Modified (S2)**
+- `proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean` (+synthInstance.maxHeartbeats option)
+- `proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean` (banner)
+- `src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json` (status/badge/assumptions)
+
+**Lesson**: a file carrying `maxHeartbeats N` can still die on `synthInstance.maxHeartbeats`
+(default 20000) — they are independent budgets. IntermediateField-subtype instance searches
+(`Module (↥K) (↥K)[X]`, field/commring derivations) are the usual culprits.
+
+**Next**: only open vein is concrete small-`n` instantiations beyond the existing `fifthRoot`
+example; the slug's core (Niven + irrationality + exact real-subfield degree) is complete and verified.

--- a/src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ivan Niven (1956); cyclotomic theory: Gauss, Kronecker; formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Niven%27s_theorem",
     "date": "1956",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/NthRootIrrationalOQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -18,10 +18,10 @@
       "irrationality",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries across all five files. Build-pending: relies on Mathlib's cyclotomic API (cyclotomic.irreducible_rat, natDegree_cyclotomic, IsPrimitiveRoot.isRoot_cyclotomic, cyclotomic_eq_minpoly_rat) plus, in the Degree companion, the IntermediateField tower API (finrank_bot_mul_relfinrank, extendScalars_adjoin, adjoin.finrank) at pinned v4.26.0. The metrics below are for the primary file (133 lines, 6 theorems); the four companions Real (113), Cos (150), CosRational (103), and Degree (267) total ≈ 766 lines. The Degree companion (added this session, all five now registered in proofs/Proofs.lean) closes the previously-open exact-degree item: 2·[ℚ(ζ+ζ⁻¹):ℚ] = φ(n), making the 'cos(2π/n) rational ⟺ φ(n) ≤ 2' equivalence a degree theorem. Local docker-build OOMs on import-Mathlib files (broken Mathlib olean cache: circular .lake symlink + cache volume mounted at the wrong path), so the typecheck is gated to the deployer build, which already builds the four merged siblings green. Promote to verified once a green build of Proofs.NthRootIrrationalOQ01OQ01 and its four companions confirms the typecheck.",
+    "assumptions": "0 axioms, 0 sorries across all five files. Docker-verified green (2026-06-15): all five — NthRootIrrationalOQ01OQ01 (primary), Real, Cos, CosRational, Degree — kernel-check at the v4.26.0 pin. Builds on Mathlib's cyclotomic API (cyclotomic.irreducible_rat, natDegree_cyclotomic, IsPrimitiveRoot.isRoot_cyclotomic, cyclotomic_eq_minpoly_rat) plus the IntermediateField tower API (finrank_bot_mul_relfinrank, extendScalars_adjoin, adjoin.finrank) in the Degree companion. The Degree companion needed set_option synthInstance.maxHeartbeats 400000 (the Module (ℚ⟮α⟯) (ℚ⟮α⟯)[X] instance over the IntermediateField subtype is synthesizable but exceeds the default 20000 budget). It closes the exact-degree item: 2·[ℚ(ζ+ζ⁻¹):ℚ] = φ(n), making 'cos(2π/n) rational ⟺ φ(n) ≤ 2' a degree theorem.",
     "mathlibDependencies": [
       {
         "theorem": "cyclotomic.irreducible_rat",

--- a/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
+++ b/src/data/research/problems/nth-root-irrational-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "nth-root-irrational-oq-01-oq-01",
   "title": "Extend to algebraic irrationality of roots of cyclotomic polynomials and their subfields",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: exact real-subfield degree phi(n)/2 certified symbolically + Lean tower plan pinned (Module.finrank_mul_finrank, [Q(zeta):K]=2). Lean proof Docker-gated. Four Niven/cyclotomic files merged+registered.",
+    "progressSummary": "VERIFIED (researcher-5, S2, 2026-06-15): all 5 registered files Docker-GREEN. Cos/CosRational/Real/primary built with no edits; Degree.lean needed set_option synthInstance.maxHeartbeats 400000 to clear a 20000-budget typeclass timeout on Module (ℚ⟮α⟯)(ℚ⟮α⟯)[X]. Gallery meta promoted formalized/wip → verified/original. Niven + irrationality + exact real-subfield degree (2·[ℚ(ζ+ζ⁻¹):ℚ]=φ(n)) all machine-checked.",
     "builtItems": [
       "cyclotomic_no_rational_root (NthRootIrrationalOQ01OQ01.lean): Phi_n over Q has no rational root for n>=3",
       "rational_root_of_unity_le_two: only rational roots of unity are +-1 (primitive n-th root in Q forces n<=2)",


### PR DESCRIPTION
## Summary

Docker is back up. All five registered files for this slug now **build green under Docker** at the v4.26.0 pin, promoting the entry from `formalized/wip` to **`verified/original`**.

- `NthRootIrrationalOQ01OQ01` (primary), `…Cos`, `…CosRational`, `…Real` — green, **no edits**.
- `…Degree` — initially failed on a typeclass timeout: `failed to synthesize Module (↥ℚ⟮α⟯) (↥ℚ⟮α⟯)[X]`, hitting the default **20000** `synthInstance` heartbeat budget (independent of the file's existing `maxHeartbeats 1600000`). The instance is synthesizable, just slow over the IntermediateField subtype. Fixed with `set_option synthInstance.maxHeartbeats 400000`; rebuilt → green.

## What's verified
Niven's theorem (`φ(n) ≥ 3 ⟹ Irrational(cos(2π/n))`), the rational-roots-of-unity = ±1 corollary, the rational classification `cos(2π/n) ∈ {1,−1,−1/2,0,1/2}` for `n ∈ {1,2,3,4,6}`, and the exact real-subfield degree `2·[ℚ(ζ+ζ⁻¹):ℚ] = φ(n)`. All 0 sorries / 0 axioms.

## Changes
- `proofs/Proofs/NthRootIrrationalOQ01OQ01Degree.lean`: `+set_option synthInstance.maxHeartbeats 400000`.
- `proofs/Proofs/NthRootIrrationalOQ01OQ01CosRational.lean`: clear build-pending banner.
- Gallery meta + research knowledge/JSON → verified.

## Status
**Outcome**: verified (kernel-checked). Math agent PR — no `loom:review-requested`; deployer merges directly.

🤖 Generated by researcher-5