### PR TITLE
audit(morleys-theorem-oq-03): fix stale "build-pending" text vs verified status

### DIFF
--- a/src/data/proofs/morleys-theorem-oq-03/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "morleys-theorem-oq-03",
   "title": "The Morley Triangle is Largest at the Equilateral",
   "slug": "morleys-theorem-oq-03",
-  "description": "Among all triangles with a fixed circumradius R, the equilateral triangle uniquely maximizes the side length of its Morley triangle. Proves s(α,β,γ) = 8R·sin(α/3)·sin(β/3)·sin(γ/3) ≤ 8R·sin³(π/9), with equality iff α=β=γ=π/3. Fully elementary (AM–GM + Jensen for sin), 0 axioms, 0 sorries (build-pending verification).",
+  "description": "Among all triangles with a fixed circumradius R, the equilateral triangle uniquely maximizes the side length of its Morley triangle. Proves s(α,β,γ) = 8R·sin(α/3)·sin(β/3)·sin(γ/3) ≤ 8R·sin³(π/9), with equality iff α=β=γ=π/3. Fully elementary (AM–GM + Jensen for sin), 0 axioms, 0 sorries (machine-verified via docker-build 2026-06-15).",
   "meta": {
     "author": "Lean Genius research",
     "date": "2026",
@@ -107,7 +107,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; machine-check build-pending under Docker blackout): the Morley side length 8R·sin(α/3)·sin(β/3)·sin(γ/3) is maximized, over all triangles of circumradius R≥0, at the equilateral, with maximal value 8R·sin³(π/9); and for R>0 the equilateral is the unique maximizer. The proof is elementary, using only AM–GM (via an explicit SOS certificate) and the concavity of sin on [0,π].",
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; machine-verified via docker-build 2026-06-15): the Morley side length 8R·sin(α/3)·sin(β/3)·sin(γ/3) is maximized, over all triangles of circumradius R≥0, at the equilateral, with maximal value 8R·sin³(π/9); and for R>0 the equilateral is the unique maximizer. The proof is elementary, using only AM–GM (via an explicit SOS certificate) and the concavity of sin on [0,π].",
     "implications": "The result shows the 'largest Morley triangle' question reduces to a symmetric product-of-sines optimization that is fully formalizable without calculus. The two-stage inequality structure — a degree-3 AM–GM plus a chained two-point Jensen — is reusable for other symmetric trigonometric extremal problems, and the strict-uniqueness pattern (sandwiching an average via the equality cases of AM–GM and strict Jensen) generalizes to other concave-function maximizations on a simplex.",
     "openQuestions": [
       "Extremal Morley behavior under other normalizations: fix the perimeter, the area, or the longest side instead of the circumradius — is the equilateral still the maximizer, and what is the sharp constant?",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `morleys-theorem-oq-03`
**Severity**: LOW (internal inconsistency / stale text on a `verified/original` entry)

## Problem

The entry is `status: verified` / `badge: original`, and its `assumptions` field documents a confirmed build:

> "Fully machine-verified: docker-build of Proofs.MorleysTheoremOQ03 **completed successfully on 2026-06-15** (7743 jobs, no warnings)…"

(consistent with #24690, which fixed two build-breaking defects, machine-verified the file, and restored `verified/original`; the file is registered in `Proofs.lean` with 0 sorries / 0 axioms).

But two other fields still carried stale **"build-pending"** language, directly contradicting the verified status:

- `description`: "…0 sorries **(build-pending verification)**."
- `conclusion.summary`: "(0 axioms, 0 sorries; **machine-check build-pending under Docker blackout**): …"

A `verified` entry that simultaneously says "build-pending" is exactly the kind of inconsistency that undermines credibility (cf. auditor downgrade #24667, which acted on the same signal before the build was confirmed).

## Fix

Both stale parentheticals updated to "machine-verified via docker-build 2026-06-15", matching the authoritative `assumptions` field. The historical note in `assumptions` ("the prior Docker blackout" that the successful build overcame) is intentionally retained.

No change to status, badge, sorry count, axiom count, or any theorem.

---
Discovered during gallery integrity audit.