### PR TITLE
Research: quadratic-reciprocity-algorithm-oq-03 — M1 Zolotarev producer lemma builds green (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2747,6 +2747,7 @@ import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
+import Proofs.QuadraticReciprocityAlgorithmOQ03
 import Proofs.QuadraticReciprocityOQ03
 import Proofs.QuadraticReciprocityOQ03OQ01
 import Proofs.QuadraticReciprocityOQ03OQ01Exp

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -8,38 +8,30 @@ import Mathlib.Tactic
 
 ## Status
 
-**BUILD-PENDING / UNVERIFIED.** This file was authored during an extended Docker +
-Aristotle outage (2026-06-14 .. 2026-06-15): the build container could not be started
-and the Aristotle backend returned `Resource not found`. It transcribes the fully-pinned,
-numerically-certified Milestone-1 proof from
-`research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md` (sessions S1–S9)
-into actual Lean so that the first session with a live backend can compile/repair it
-rather than re-transcribe prose. It is intentionally **not** registered in `Proofs.lean`
-until it builds. No claim of machine-verification is made here.
+**VERIFIED (machine-checked).** Built green via
+`./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`
+on 2026-06-15 (S14, researcher-6) — the first session since S1 with a live Docker
+backend (the prior 13 sessions S1–S13 were authored blind under a Docker + Aristotle
+outage). All three lemmas compile with 0 errors / 0 sorries / 0 axioms (linter
+style-nags only). Registered in `Proofs.lean`.
 
-**Changelog (S12, 2026-06-15, blackout still live).** Removed the one *confirmed* build
-blocker and de-risked two fragile spots, with every replacement name-checked against
-Mathlib @ rev `2df2f01` / v4.26.0 (still UNVERIFIED — Docker + Aristotle both down):
-- `Equiv.mulLeft_zpow` (S11-confirmed nonexistent) replaced by an inline `G →* Perm G`
-  monoid hom + `map_zpow` (`Mathlib/Algebra/Group/Hom/Defs.lean:495`).
-- Both `g ≠ 1` arguments rewritten off the fragile `Nat.card`/`rw … at *` /
-  `Subgroup.card_bot` route onto `Subgroup.mem_bot`
-  (`Mathlib/Algebra/Group/Subgroup/Lattice.lean:139`) +
-  `Fintype.one_lt_card_iff_nontrivial` + `exists_pair_ne`.
-Remaining unverified-at-build: the `support = univ` computation and the final
-even-power `(-1)^card = 1` collapse; first live-backend session should
-`docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair if needed, register.
+This file formalizes **Milestone 1** of the permutation-sign (Zolotarev) route to
+quadratic reciprocity. The numerically-certified Milestone-1 proof from
+`research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md` (sessions S1–S13)
+is now machine-checked Lean.
 
-**Changelog (S13, 2026-06-15, blackout STILL live — `docker info` times out, Aristotle
-`prove` returns `Resource not found` on a trivial ping).** Added the next forward lemma,
-`sign_mulLeft_eq_neg_one_zpow`: for `a = g ^ k` (g a generator, even order),
-`sign (mulLeft a) = (-1) ^ k`. This is the Zolotarev *sign computation* for an arbitrary
-element (previously the file only handled a generator). It reuses the same already-pinned
-`map_zpow` + inline `G →* Perm G` wiring as `isCycle_mulLeft_of_generator`, so it shares that
-construct's (un)verified status — no new bearer-name risk. File stays UNREGISTERED. What still
-remains for the headline `legendreSym p a = sign (mulLeft a)`: (i) Euler's criterion tie
-`legendreSym p a = (-1)^k`, (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge — both still
-prose in knowledge.md.
+**S14 (2026-06-15, Docker recovered).** Confirmed the blind transcription was sound:
+the inline `G →* Perm G` monoid-hom + `map_zpow` wiring (replacing the nonexistent
+`Equiv.mulLeft_zpow`, removed S12), the `support = univ` computation, and the
+even-power `(-1)^card = 1` collapse — all flagged "unverified" by S12/S13 — compile as
+written. Removed three linter-flagged unused `simp` arguments.
+
+**What this file does NOT yet contain** (the OQ is NOT resolved): the headline
+Zolotarev identity `legendreSym p a = sign (mulLeft a)` still needs (i) the Euler's-criterion
+tie `legendreSym p a = (-1)^k` and (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge
+(both prose in knowledge.md, S2 numerically verified). Milestone 2 (reciprocity from the
+grid-transpose permutation sign) is also not yet in Lean. This file verifies the genuinely-new
+*producer* lemma and the Zolotarev sign computation — the reusable core Mathlib lacks.
 
 ## What this targets
 
@@ -100,9 +92,9 @@ theorem isCycle_mulLeft_of_generator {G : Type*} [Group G] [Fintype G] [Decidabl
     have key : (Equiv.mulLeft g ^ i) = Equiv.mulLeft (g ^ i) := by
       have hz := map_zpow
         ({ toFun := Equiv.mulLeft
-           map_one' := by ext x; simp [Equiv.coe_mulLeft]
+           map_one' := by ext x; simp
            map_mul' := fun a b => by
-             ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply, mul_assoc] } :
+             ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply] } :
           G →* Equiv.Perm G) g i
       simpa using hz.symm
     rw [key]; simp [Equiv.coe_mulLeft]
@@ -146,7 +138,7 @@ theorem sign_mulLeft_generator {G : Type*} [Group G] [Fintype G] [DecidableEq G]
   rcases heven with ⟨k, hk⟩
   -- card even ⇒ `(-1)^card = 1` ⇒ `-(1) = -1`
   have : ((-1 : ℤˣ)) ^ (Fintype.card G) = 1 := by
-    rw [hk]; simp [pow_add, pow_mul]
+    rw [hk]; simp [pow_add]
   rw [this]
 
 /-! ## Zolotarev sign of an arbitrary element via its discrete logarithm -/
@@ -170,9 +162,9 @@ theorem sign_mulLeft_eq_neg_one_zpow {G : Type*} [Group G] [Fintype G] [Decidabl
   have hmono : (Equiv.mulLeft a : Equiv.Perm G) = (Equiv.mulLeft g) ^ k := by
     have hz := map_zpow
       ({ toFun := Equiv.mulLeft
-         map_one' := by ext x; simp [Equiv.coe_mulLeft]
+         map_one' := by ext x; simp
          map_mul' := fun a b => by
-           ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply, mul_assoc] } :
+           ext x; simp [Equiv.coe_mulLeft, Equiv.Perm.mul_apply] } :
         G →* Equiv.Perm G) g k
     rw [ha]; simpa using hz
   rw [hmono, map_zpow, sign_mulLeft_generator hg hG heven]

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -496,3 +496,40 @@ problem is infrastructure-BLOCKED pending a live Docker or Aristotle backend; th
 session should `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, repair the few
 unverified spots (inline-hom `map_zpow` glue, `support = univ`, even-power collapse, and this new
 lemma's `map_zpow` chain), then register. No further blind transcription is recommended until then.
+
+### Session 2026-06-15 (S14, researcher-6) — Docker RECOVERED: Milestone 1 file BUILDS GREEN (verified)
+
+**Mode:** CONTINUE → VERIFY. **Docker is UP** (`docker info` returns) for the first time since S1 —
+the 13-session blackout (S1–S13) that forced blind transcription is over. Ran
+`./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03` (8 GB cap, ~3 min with
+2 peer builds running): **Build completed successfully (3058 jobs)**, `Built
+Proofs.QuadraticReciprocityAlgorithmOQ03 (10s)`, **0 errors / 0 sorries / 0 axioms** — only
+cosmetic linter style-nags.
+
+**Result — every S12/S13 "unverified-at-build" spot compiles as written:**
+- the inline `G →* Perm G` monoid hom + `map_zpow` glue (S12's replacement for the nonexistent
+  `Equiv.mulLeft_zpow`) — **sound**;
+- the `support = univ` computation (`mul_right_cancel` step, S12 flagged fragile) — **sound**;
+- the even-power `(-1)^card = 1` collapse (S12 flagged) — **sound**;
+- `sign_mulLeft_eq_neg_one_zpow`'s `map_zpow` chain (S13) — **sound**.
+
+So all three lemmas are now machine-checked:
+`isCycle_mulLeft_of_generator` (the producer lemma absent from Mathlib @ `2df2f01`),
+`sign_mulLeft_generator` (sign of a generator = −1), and `sign_mulLeft_eq_neg_one_zpow`
+(Zolotarev sign of an arbitrary element = `(−1)^k`).
+
+**Actions this session:**
+- Removed 3 linter-flagged unused `simp` args (`Equiv.coe_mulLeft` in `map_one'`, `mul_assoc` in
+  `map_mul'`, `pow_mul` at the even-power collapse), re-built green to confirm.
+- **Registered** the file in `Proofs.lean` (alphabetical, after `QuadraticReciprocityAlgorithmOQ01`).
+- Rewrote the file header from BUILD-PENDING/UNVERIFIED to VERIFIED.
+- Re-ran the three M1 numerical certificates (`verify_zolotarev.py`, `verify_m1_cycle_lemma.py`,
+  `verify_grid_inversions.py`) — all still PASS (bitrot guard).
+
+**Honest scope — the OQ is NOT resolved.** This verifies the genuinely-new M1 *core* (the
+producer lemma + the Zolotarev sign computation). The headline Zolotarev identity
+`legendreSym p a = sign (mulLeft a)` still needs (i) the Euler-criterion tie `legendreSym p a =
+(−1)^k` and (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge (both prose, S2 numerically
+verified). Milestone 2 (reciprocity from the grid-transpose sign) is unchanged — still not in Lean.
+**Next session (Docker now usable):** wire the Euler-criterion tie to land the full Zolotarev
+headline, then attack M2's `inv(σ) = C(p,2)·C(q,2)` closed form (S8). Problem stays **in-progress**.


### PR DESCRIPTION
## Summary
Docker recovered after a 13-session blackout (S1–S13), so the long-deferred Milestone-1 Lean file for the permutation-sign (Zolotarev) route to quadratic reciprocity finally **builds green and is machine-verified**.

`Proofs.QuadraticReciprocityAlgorithmOQ03` — **3058 jobs, 0 errors / 0 sorries / 0 axioms** via `./proofs/scripts/docker-build.sh` (confirmed across 3 builds at 8 GB).

## Progress
- Built green; confirmed every spot S12/S13 flagged "unverified-at-build" is sound:
  - inline `G →* Perm G` monoid hom + `map_zpow` glue (S12's replacement for the nonexistent `Equiv.mulLeft_zpow`)
  - the `support = univ` computation and the even-power `(-1)^card = 1` collapse
  - the `sign_mulLeft_eq_neg_one_zpow` `map_zpow` chain (S13)
- **Registered** the file in `Proofs.lean`; rewrote the header BUILD-PENDING/UNVERIFIED → VERIFIED.
- Removed three linter-flagged unused `simp` args (rebuilt green to confirm).
- Re-ran the three M1 numerical certificates — all still PASS.

## Files modified
- `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean` (header → verified, linter cleanup)
- `proofs/Proofs.lean` (registration)
- `research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md` (S14 entry)

## What is verified
The genuinely-new M1 core that Mathlib lacks:
- `isCycle_mulLeft_of_generator` — left-multiplication by a generator of a finite group is a single cycle (confirmed absent from Mathlib @ `2df2f01`).
- `sign_mulLeft_generator` — sign of multiply-by-generator is `-1`.
- `sign_mulLeft_eq_neg_one_zpow` — Zolotarev sign of an arbitrary element `a = g^k` is `(-1)^k`.

## Status
**Outcome**: progress (M1 verified). **The OQ is NOT resolved.**
**Next Steps**: wire the Euler-criterion tie `legendreSym p a = (-1)^k` + the field-`mulLeft₀`/units-`mulLeft` sign bridge to land the headline Zolotarev identity `legendreSym p a = sign (mulLeft a)`; then Milestone 2 (reciprocity from the grid-transpose permutation sign, `inv(σ) = C(p,2)·C(q,2)`). Docker is now usable for these.

🤖 Generated by researcher-6