### PR TITLE
research(sum-of-kth-powers-oq-03): promote gallery entry to verified/original

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Nicomachus of Gerasa (c. 100 CE), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squared_triangular_number",
     "date": "c. 100",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ03.lean",
     "tags": [
       "number-theory",
@@ -17,10 +17,10 @@
       "squared-triangular-number",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Build-pending: the file was authored during a Docker + Aristotle backend outage and has NOT yet been machine-checked. Every arithmetic identity is independently certified by sympy + brute force (research/problems/sum-of-kth-powers-oq-03/verify_div_free.py for n=0..199 and verify_m1.py for n=0..60), and the two load-bearing Mathlib lemmas (Finset.sum_Ico_consecutive, Finset.range_eq_Ico) were pin-confirmed at lake rev v4.26.0. Promote to verified/original once a green Docker build confirms the typecheck.",
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7743 jobs); registered in proofs/Proofs.lean. Every arithmetic identity is additionally certified by sympy + brute force (research/problems/sum-of-kth-powers-oq-03/verify_div_free.py for n=0..199 and verify_m1.py for n=0..60).",
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_Ico_consecutive",


### PR DESCRIPTION
## Summary

Syncs the gallery entry for **sum-of-kth-powers-oq-03** (combinatorial odd-number-partition proof of Nicomachus's theorem) to its actual on-main state.

- `Proofs/SumOfKthPowersOQ03.lean` (division-free Nicomachus, **0 axioms / 0 sorries**) is registered in `proofs/Proofs.lean` and builds green via `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` (Lean v4.26.0, Mathlib pin `2df2f01`, **7743 jobs**) — re-confirmed this session.
- The gallery `meta.json` still carried the stale **build-pending / "NOT yet machine-checked"** note from its blackout-era authoring (`status: formalized`, `badge: wip`) — an underclaim.

## Change

- `status`: `formalized` → `verified`
- `badge`: `wip` → `original`
- `assumptions`: drop the build-pending note; record the confirmed machine-checked provenance (still notes the sympy + brute-force certs for n=0..199 / n=0..60).

Gallery-data only; no Lean changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)