### PR TITLE
Enrich Ham Sandwich de-axiomatization (brouwer-oq-01-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
@@ -133,5 +133,27 @@
       "linear maps",
       "Lebesgue measure of half-spaces"
     ]
+  },
+  {
+    "id": "hs-remaining-gap",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
+    "type": "context",
+    "range": {
+      "startLine": 339,
+      "endLine": 369
+    },
+    "title": "The Exact Dichotomy: What Was Proved vs. the Lone Input",
+    "content": "The closing note makes the file's contribution precise. The parent's `ham_sandwich_theorem` axiom was justified solely by the difficulty of the continuity step, and this file confirms that diagnosis is exact: every other ingredient — the topological reduction, the oddness of the discrepancy, the 'zero ⇒ bisected' bridge, the antipodal swap, and volume finiteness — is dispatched here by elementary means, and two of the three originally-listed side conditions become theorems for the linear parameterization. What remains is a single, self-contained measure-theory fact, and `ham_sandwich_standard_of_scalar_continuity` states the conclusion with exactly that fact (plus finiteness) as its only hypotheses.",
+    "mathContext": "The residual input is the Lebesgue continuity of $x \\mapsto \\mathrm{vol}(\\mathrm{body}_i \\cap \\{y : \\langle u(x), y\\rangle < t(x)\\}).\\mathrm{toReal}$ on $S^n$, provable by dominated convergence for parameterized half-spaces. The dichotomy is now sharp: the topological core is fully proved, and the lone analytic input is scalar Lebesgue continuity — no longer a topological obligation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "de-axiomatization",
+      "dominated convergence",
+      "proof-scope analysis"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "Borsuk-Ulam theorem"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-03-oq-01` (quality 85, 0 prior passes).

The meta overview was already rich (deep historical context, 7 keyInsights, 5 sections with mathContext), but several genuine gaps remained:

## Changes
- **Added `conclusion` block** (was missing entirely): summary, implications, and 3 open questions — including whether the lone residual scalar slice-volume continuity can be discharged via dominated convergence to make standard Ham Sandwich fully axiom-free (mod inherited Borsuk-Ulam).
- **Added 3 `crossReferences`** (was missing entirely) to the parent `brouwer-fixed-point-oq-01-oq-03`, `borsuk-ulam` (topological foundation), and `brouwer-fixed-point` (sibling). All three target slugs verified present in the gallery.
- **Added a 7th annotation** covering the closing "exact dichotomy" significance block (lines 339–369), which prior annotations stopped short of (last ended at 345).
- **Fixed two invalid `significance: "important"` values → `"key"`.** The `AnnotationSignificance` type (`src/types/proof.ts`) only permits `critical | key | supporting`.

## Axiom integrity
No status/badge/axiomCount changes. Entry remains `axiomatized` / `axiom` / `axiomCount: 1` — accurate: it rests on the inherited `no_continuous_odd_nonzero_on_sphere` Borsuk-Ulam axiom plus the stated scalar continuity hypothesis. The conclusion text states this honestly.

JSON validated with python (annotation count 7, all significance values in enum, conclusion has summary+implications+openQuestions, crossReferences resolve).