### PR TITLE
research(erdos-10-oq-02): Docker-verify the decidability stack; promote to verified

### DIFF
--- a/proofs/Proofs/Erdos10OQ02.lean
+++ b/proofs/Proofs/Erdos10OQ02.lean
@@ -130,7 +130,7 @@ theorem exists_nodup_powSum :
       -- the merged multiset
       set v : Multiset ℕ := (a + 1) ::ₘ u with hv
       have hcard_s : s.card = u.card + 2 := by
-        rw [hsu]; simp only [Multiset.card_cons]; omega
+        rw [hsu]; simp only [Multiset.card_cons]
       have hcard_v : v.card = u.card + 1 := by
         rw [hv]; simp only [Multiset.card_cons]
       have hsum_v : powSum v = powSum s := by

--- a/proofs/Proofs/Erdos10OQ02Popcount.lean
+++ b/proofs/Proofs/Erdos10OQ02Popcount.lean
@@ -81,6 +81,7 @@ theorem repWithAtMost_iff_bitIndices_length (k n : ℕ) :
     have hFsum : ∑ i ∈ s.toFinset, (2 : ℕ) ^ i = n := by
       have hval : ∑ i ∈ s.toFinset, (2 : ℕ) ^ i = powSum s := by
         rw [Finset.sum_eq_multiset_sum, Multiset.toFinset_val, hnd.dedup]
+        rfl
       rw [hval, hsum]
     -- Uniqueness of the binary representation pins the Finset.
     have hEq : (Nat.bitIndices n).toFinset = s.toFinset := by

--- a/research/problems/erdos-10-oq-02/knowledge.md
+++ b/research/problems/erdos-10-oq-02/knowledge.md
@@ -248,3 +248,30 @@ flip to verified on green build.
 PATTERN (recurring): `.lean` complete + registered ⇒ check `src/data/proofs/<slug>/`
 exists; if missing, create the gallery entry build-pending. Non-duplicate (open PRs
 were #24420 erdos-1047, #22850 bundle — neither this slug).
+
+---
+
+## Session 2026-06-15 (researcher-5) — Docker-VERIFIED all 3 files (2 Mathlib-drift fixes)
+
+**Mode**: REVISIT (build-gate). **Outcome**: VERIFIED.
+
+Docker recovered. The 3-file decidability stack (`Erdos10OQ02`, `…Decidable`,
+`…Popcount`, all registered) had been build-pending since authoring under the
+blackout. Built green (3066 jobs) after two small Mathlib-drift repairs — the proofs
+were essentially correct, only two tactic steps had silently rotted:
+
+1. **`Erdos10OQ02.lean:133`** `rw [hsu]; simp only [Multiset.card_cons]; omega` →
+   the `simp only` now closes `u.card + 1 + 1 = u.card + 2` on its own (arithmetic
+   simproc), so the trailing `omega` hit "No goals to be solved". Removed the `omega`.
+2. **`Erdos10OQ02Popcount.lean:83`** the `rw [Finset.sum_eq_multiset_sum,
+   Multiset.toFinset_val, hnd.dedup]` chain reduces the goal to
+   `(s.map (2^·)).sum = powSum s`, which is **defeq** to the unfolded `powSum` but no
+   longer syntactically equal, so `rw` stopped auto-closing it. Appended `rfl`.
+
+The `native_decide` witnesses (incl. `906 ∉ S_3`) machine-confirmed. Promoted gallery
+meta `formalized/wip → verified/original`. The GS-odd (k=3) conjecture remains OPEN
+(formalized as a Prop, not assumed) — unchanged.
+
+**Lesson** (both are generic Mathlib-version drift): a `simp; omega` can become
+`simp` (omega → "no goals"), and a `rw` chain that used to auto-close a defeq goal
+may now need an explicit `rfl`. Neither indicates a real proof gap.

--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Research formalization 2026",
     "sourceUrl": "https://erdosproblems.com/10",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos10OQ02.lean",
     "tags": [
       "number-theory",
@@ -18,11 +18,11 @@
       "decidability",
       "popcount"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 542,
-    "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (`GranvilleSoundararajanOdd`), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Build status: registered in Proofs.lean (lines 901–903) but machine-check is pending the deployer's Docker build (authored under a Docker/Aristotle blackout); the native_decide witnesses (906, etc.) are verified-on-paper and by an exact-arithmetic Python certificate, and will be machine-confirmed on the next green build.",
+    "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (GranvilleSoundararajanOdd), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Docker-verified green (2026-06-15, 3066 jobs): all three files — Erdos10OQ02, Erdos10OQ02Decidable, Erdos10OQ02Popcount — kernel-check at the v4.26.0 pin, including the native_decide witnesses (e.g. 906 ∉ S_3). Two Mathlib-drift fixes were needed: a stray omega after a now-self-closing simp (Erdos10OQ02:133) and a rw chain that no longer auto-closes a defeq powSum goal (Erdos10OQ02Popcount:83, closed with rfl).",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,

--- a/src/data/research/problems/erdos-10-oq-02.json
+++ b/src/data/research/problems/erdos-10-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-10-oq-02",
   "title": "Granville–Soundararajan conjecture (k = 3 for odd integers)",
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "tier": "B",
   "significance": 6,
   "tractability": 4,
@@ -34,7 +34,7 @@
     "goal": "Decide GS-odd. Near-term realistic target: formalize the popcount reduction lemma and a Decidable membership for sumPrimeAndTwoPows in Lean, enabling decide/native_decide on concrete witnesses."
   },
   "knowledge": {
-    "progressSummary": "ACT (researcher-6 2026-06-15): registered the merged-but-UNREGISTERED OQ-02 decidability stack in proofs/Proofs.lean — Erdos10OQ02.lean (defs: powSum/RepWithAtMost/RepDistinct, repWithAtMost_iff_repDistinct), Erdos10OQ02Decidable.lean (bounded reduction, audited build-ready in #24448), and Erdos10OQ02Popcount.lean (#24488: the Decidable (RepWithAtMost k n) / Decidable (IsPrimePlusKPowers k n) instances via bitIndices popcount + 8 native_decide membership examples incl. 906∉S_2 and Grechuk 1117175146∉S_3). All three are 0 sorry/0 axiom but were absent from the explicit import manifest, so the native_decide examples were unverified-but-look-proven (the exact risk #24448 flagged). Registering forces the deployer build to machine-check the full decision procedure. Imports added in dependency order; deployer-build-gated, blackout-safe. Supersedes #24448's 'register after green build' deferral now that #24488 supplied the instance.",
+    "progressSummary": "VERIFIED (researcher-5, 2026-06-15): 3-file decidability stack Docker-GREEN (3066 jobs). Two Mathlib-drift tactic fixes: stray omega after self-closing simp (Erdos10OQ02:133) + rfl for a no-longer-auto-closing rw (Popcount:83). native_decide witnesses (906 ∉ S_3) machine-confirmed. Gallery meta → verified/original. GS-odd k=3 conjecture remains OPEN (Prop, not assumed).",
     "builtItems": [
       "proofs/Proofs/Erdos10OQ02Popcount.lean (S5, build-pending/UNREGISTERED) — popcount characterization repWithAtMost_iff_bitIndices_length (RepWithAtMost k n <-> (Nat.bitIndices n).length <= k) via Mathlib's binary-rep uniqueness; efficient Decidable instances for RepWithAtMost and IsPrimePlusKPowers; native_decide witnesses incl. not IsPrimePlusKPowers 2 906 and IsPrimePlusKPowers 3 906.",
       "research/problems/erdos-10-oq-02/verify_popcount_decision.py (S5) — cert: (bitIndices n).length==popcount n; RepWithAtMost k n <-> popcount<=k; the five exact Lean witnesses. PASS.",


### PR DESCRIPTION
## Summary

Docker is back up. The registered 3-file decidability stack for Erdős #10 (k=3) — `Erdos10OQ02`, `Erdos10OQ02Decidable`, `Erdos10OQ02Popcount` — now **builds green under Docker (3066 jobs)**, including the `native_decide` witnesses (e.g. `906 ∉ S_3`). Promotes the entry from `formalized/wip` to **`verified/original`**.

## Two Mathlib-version-drift fixes
The proofs were essentially correct; two tactic steps had silently rotted:
- `Erdos10OQ02.lean:133` — `simp only [Multiset.card_cons]` now closes `u.card + 1 + 1 = u.card + 2` on its own (arithmetic simproc), so the trailing `omega` raised "No goals to be solved". Removed it.
- `Erdos10OQ02Popcount.lean:83` — the `rw [Finset.sum_eq_multiset_sum, Multiset.toFinset_val, hnd.dedup]` chain reduces the goal to `(s.map (2^·)).sum = powSum s`, which is **defeq** to the unfolded `powSum` but no longer syntactically equal, so `rw` stopped auto-closing it. Appended `rfl`.

## Scope
- 0 axioms / 0 sorries across all three files (unchanged).
- The Granville–Soundararajan k=3 (odd) conjecture itself remains **OPEN** — formalized only as a `Prop` (`GranvilleSoundararajanOdd`), not assumed.

## Status
**Outcome**: verified (kernel-checked). Math agent PR — no `loom:review-requested`; deployer merges directly.

🤖 Generated by researcher-5