### PR TITLE
Research: erdos-1107-oq-02-oq-01 - build-verify cubeful threshold (r=3)

### DIFF
--- a/proofs/Proofs/Erdos1107OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1107OQ02OQ01.lean
@@ -142,7 +142,7 @@ theorem isCubeful_one : IsCubeful 1 := by simp [IsCubeful]
     them) it holds for *all* `n` — no `native_decide`. -/
 theorem isCubeful_pow {n k : ℕ} (hk : 3 ≤ k) : IsCubeful (n ^ k) := by
   intro p hp
-  have hpp : Prime p := (prime_of_mem_primeFactors hp).prime
+  have hpp : _root_.Prime p := (prime_of_mem_primeFactors hp).prime
   have hpd : p ∣ n ^ k := dvd_of_mem_primeFactors hp
   have hpn : p ∣ n := hpp.dvd_of_dvd_pow hpd
   calc p ^ 3 ∣ p ^ k := pow_dvd_pow p hk

--- a/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1107-oq-02-oq-01/knowledge.md
@@ -310,3 +310,45 @@ re-attempting a cold local build that cannot succeed in this checkout.
   ~300-wide blocks mirroring the existing `range_2040_2300/2301_2600/2601_3000` checks.
 - Unblocking the deployer (stale `index.lock`, 2026-04-04 last deploy) is the real lever for
   build-verifying this and every other registered-but-unbuilt entry — flag to Loom/ops.
+
+## Session 2026-06-15 (Session 4, researcher-4) — BUILD VERIFIED
+
+**Mode**: continue (ACT → verified). Docker UP this session (cache volume attaches).
+**Outcome**: progress — flipped the registered file from build-pending to machine-verified.
+
+### What I Did
+- Ran `./proofs/scripts/docker-build.sh Proofs.Erdos1107OQ02OQ01` (6GB cap). The cache
+  volume `lean-mathlib-cache` **did attach** despite the circular `proofs/.lake` self-symlink
+  (downloaded 7727 oleans from Azure cache, built all 3057 deps) — confirming the symlink is
+  *not* the blocker; prior sessions' "OOM-doom" was the Docker outage, now recovered.
+- First compile (the file had NEVER been compiled — build-pending since session 3) surfaced
+  one **latent bug**: `Erdos1107OQ02OQ01.lean:145` had an **ambiguous `Prime`** (`_root_.Prime`
+  vs `Nat.Prime` under `open Nat`). Fixed `have hpp : Prime p` → `have hpp : _root_.Prime p`
+  (the `.prime` projection and downstream `hpp.dvd_of_dvd_pow` need the `_root_.Prime` form).
+- Rebuilt: `✔ [3058/3058] Built Proofs.Erdos1107OQ02OQ01 (48s)` — **clean**.
+- Independently re-ran `verify_cubeful_stability.py`: r=2 base case reproduces, r=3 gives
+  exactly the 45 exceptions (largest 2039), no exception in [2040, 10⁶]. Math confirmed.
+
+### Status
+- Counts verified against the compiled file: **18 theorems, 5 defs, 1 instance, 1 axiom,
+  0 sorries, 220 lines** — all match meta.json. No count drift.
+- `status: axiomatized`, `badge: axiom` are correct and unchanged (the lone axiom
+  `cubeful_sum_threshold` is the open r=3 asymptotic). Updated the meta `assumptions` field
+  to drop the stale "compilation performed by the deployer build host" clause and record the
+  clean machine-verified compile.
+
+### Files Modified
+- `proofs/Proofs/Erdos1107OQ02OQ01.lean` (1-line fix: ambiguous `Prime` → `_root_.Prime`)
+- `src/data/proofs/erdos-1107-oq-02-oq-01/meta.json` (assumptions field: build-verified)
+- `src/data/research/problems/erdos-1107-oq-02-oq-01.json` (knowledge record)
+- `research/problems/erdos-1107-oq-02-oq-01/knowledge.md` (this note)
+
+### Honesty / scope
+- This is a **build-verification + one-line latent-bug fix**, not new mathematics. The r=3
+  asymptotic remains open (the axiom). What changed: the entry is now genuinely
+  machine-checked rather than build-pending — the native_decide content is confirmed to
+  actually compile, which was the one outstanding gap.
+
+### Next Steps
+- None on the formal side: the entry is complete and verified modulo the open-conjecture axiom.
+- (Unchanged) Proving the axiom itself = a cubeful analogue of Heath-Brown's r=2 theorem; open.

--- a/src/data/proofs/erdos-1107-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02-oq-01/meta.json
@@ -32,7 +32,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 220,
-    "assumptions": "1 axiom: cubeful_sum_threshold (every n ≥ 2040 is a sum of ≤4 cubeful numbers) — this is the open r=3 asymptotic, the cubeful analogue of Heath-Brown's r=2 theorem, which appears to remain unproven. The finite range [1, 3000] and the 45-element exceptional set are settled by native_decide. Computation independently reproduced (verify_cubeful_stability.py and an external check confirm the 45 exceptions, the tight threshold 2039/2040, and no failures in [2040, 3000]); compilation of the native_decide blocks is performed by the deployer build host.",
+    "assumptions": "1 axiom: cubeful_sum_threshold (every n ≥ 2040 is a sum of ≤4 cubeful numbers) — this is the open r=3 asymptotic, the cubeful analogue of Heath-Brown's r=2 theorem, which appears to remain unproven. The finite range [1, 3000] and the 45-element exceptional set are settled by native_decide. Computation independently reproduced (verify_cubeful_stability.py and an external check confirm the 45 exceptions, the tight threshold 2039/2040, and no failures in [2040, 3000]). The Lean file compiles cleanly (machine-verified, Lean 4.26.0 / Mathlib, 3058 jobs): all native_decide blocks and structural lemmas are checked, leaving the single axiom as the only assumption.",
     "theoremCount": 18,
     "definitionCount": 5
   },

--- a/src/data/research/problems/erdos-1107-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1107-oq-02-oq-01.json
@@ -50,12 +50,14 @@
       "The critical case k = r (e.g. <=3 for r=3) fails permanently: sumset is the same order x as the target but with constant C_r^k/k! < 1, leaving positive density uncovered. Confirmed numerically: <=3 cubeful keeps ~0.21 exception density at 60000.",
       "Empirically N_3 = 2040 with 45 exceptions; the clean ~58000-wide gap above 2039 makes the threshold credible (conditional on the asymptotic).",
       "Resolves the gallery framing conflict: the parent's 'at most r+1' description is correct; the overview's 'at most 3 for every r' is false at r=3.",
-      "Build blocker is structural, not transient: proofs/.lake is a circular self-symlink on the host, so the docker olean cache (lean-mathlib-cache volume) never attaches and lake recompiles Mathlib from source -> 32GB OOM for ANY target. Splitting native_decide will not help on this host."
+      "Build blocker is structural, not transient: proofs/.lake is a circular self-symlink on the host, so the docker olean cache (lean-mathlib-cache volume) never attaches and lake recompiles Mathlib from source -> 32GB OOM for ANY target. Splitting native_decide will not help on this host.",
+      "BUILD VERIFIED 2026-06-15 (researcher-4): the registered Lean file compiles cleanly under Docker (Lean 4.26.0/Mathlib, 3058 jobs, ✔ in 48s). The cache volume DOES attach despite the circular proofs/.lake symlink — prior OOM-doom notes were the outage, not the symlink. First compile surfaced a latent bug (ambiguous Prime at L145 under open Nat); fixed to _root_.Prime. native_decide blocks + structural lemmas all check; 1 axiom remains."
     ],
     "builtItems": [
       "proofs/scripts/verify_cubeful_sums.py — bounded coin-change DP over the r-powerful basis; self-validating against the r=2 base case.",
       "proofs/scripts/verify_cubeful_stability.py — sieve+numpy DP; certifies N_3=2040 (45 exceptions) stable to 1e6/1e7.",
-      "proofs/Proofs/Erdos1107OQ02OQ01.lean — Lean ACT (build-pending, unregistered): IsCubeful+Decidable, basis-indexed isSumOf4Cubeful, native_decide over the 45 exceptions + [1,2040] + blocks to 3000, axiom cubeful_sum_threshold (n>=2040). Uses cubeful-basis enumeration (27 elems <=2040) instead of the parent's O(n^3) range loop."
+      "proofs/Proofs/Erdos1107OQ02OQ01.lean — Lean ACT (build-pending, unregistered): IsCubeful+Decidable, basis-indexed isSumOf4Cubeful, native_decide over the 45 exceptions + [1,2040] + blocks to 3000, axiom cubeful_sum_threshold (n>=2040). Uses cubeful-basis enumeration (27 elems <=2040) instead of the parent's O(n^3) range loop.",
+      "Build-verified proofs/Proofs/Erdos1107OQ02OQ01.lean (was build-pending since session 3); fixed ambiguous Prime -> _root_.Prime at L145, the only compile error."
     ],
     "mathlibGaps": [
       "No Mathlib lemma for representation of integers as sums of bounded powerful numbers; the r=2 gallery entry handles this via a Decidable predicate + native_decide + an axiom for the asymptotic. The r=3 ACT file would follow the same pattern.",
@@ -66,6 +68,6 @@
       "Build-confirm only on a cache-warm host / working deployer; if below_threshold_nonexceptions native_decide is heavy there, split into ~300-wide blocks like range_2040_2300.",
       "Flag stalled deployer (stale index.lock) to Loom/ops — it gates build-verification of all registered-but-unbuilt entries."
     ],
-    "progressSummary": "SATURATED (math complete: 0 sorry / 1 conjectural axiom, registered, gallery entry exists). Build is env-blocked locally (circular .lake symlink -> Mathlib-from-source OOM); belongs to a cache-warm deployer, which is itself stalled."
+    "progressSummary": "BUILD-VERIFIED (machine-checked, 0 sorry / 1 conjectural axiom). Lean file now compiles cleanly under Docker; the only remaining open input is the r=3 asymptotic axiom cubeful_sum_threshold. Math complete, registered, gallery entry verified."
   }
 }


### PR DESCRIPTION
## Summary
Build-verifies the previously **build-pending** cubeful (r=3) sum-threshold entry for Erdős #1107. The registered Lean file `Proofs/Erdos1107OQ02OQ01.lean` had never been compiled; its first compile surfaced one latent bug, now fixed, and the file builds cleanly.

## Progress
- **Fixed latent compile error**: line 145 had an ambiguous `Prime` (`_root_.Prime` vs `Nat.Prime` under `open Nat`). Changed `have hpp : Prime p` → `have hpp : _root_.Prime p` (the `.prime` projection and downstream `hpp.dvd_of_dvd_pow` require the `_root_.Prime` form). One-line change.
- **Clean Docker build**: `✔ [3058/3058] Built Proofs.Erdos1107OQ02OQ01 (48s)` on Lean 4.26.0 / Mathlib. All `native_decide` blocks (the 45 exceptions, [1,2040) non-exceptions, [2040,3000] in three blocks) and the structural cubeful lemmas (`isCubeful_pow`, `isCubeful_mul`, …) check.
- Confirmed the `lean-mathlib-cache` volume **attaches** despite the circular `proofs/.lake` self-symlink (7727 cached oleans downloaded, 3057 deps built) — prior "OOM-doom" notes were the Docker outage, not the symlink.
- Re-ran `verify_cubeful_stability.py`: r=2 base case reproduces; r=3 gives exactly the 45 exceptions (largest 2039), no exception in [2040, 10⁶].

## Files modified
- `proofs/Proofs/Erdos1107OQ02OQ01.lean` (1-line `Prime` fix)
- `src/data/proofs/erdos-1107-oq-02-oq-01/meta.json` (assumptions field: record machine-verified compile)
- `src/data/research/problems/erdos-1107-oq-02-oq-01.json`, `research/problems/.../knowledge.md` (session notes)

## Findings
- Counts verified against the compiled file: **18 theorems, 5 defs, 1 instance, 1 axiom, 0 sorries, 220 lines** — match meta.json, no drift.
- `status: axiomatized` / `badge: axiom` unchanged and correct: the lone axiom `cubeful_sum_threshold` is the open r=3 asymptotic (cubeful analogue of Heath-Brown), beyond the computationally settled range.

## Status
**Outcome**: completed (build-verified; entry now machine-checked modulo the open-conjecture axiom)
**Next Steps**: none on the formal side. Proving the axiom = a cubeful analogue of Heath-Brown's r=2 theorem (open).

🤖 Generated by researcher-4