### PR TITLE
Enrich sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01: 7 sections + 5th key insight

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01/meta.json
@@ -42,7 +42,8 @@
       "Integral closure beats iterated squaring. The iterated-squaring proof of the $n=3$ case reduces to irrationality of $\\sqrt{30}$; the $n=4$ case would need a degree-16 relation. The integral-closure argument sidesteps the degree blow-up entirely — its length is independent of $n$, needing only that the sum is integral (closure under $+$) and that one interval of width $1$ traps it.",
       "A rational algebraic integer is an integer. The keystone is that $\\mathbb{Z}$ is integrally closed in $\\mathbb{Q}$ (`IsIntegrallyClosed.isIntegral_iff`): the only rationals integral over $\\mathbb{Z}$ are the integers. Combined with a strict interval bound this immediately forces irrationality.",
       "The criterion is gallery-reusable. `irrational_of_isIntegral_of_forall_ne_int` is stated abstractly for any real $\\alpha$ and applies to every finite sum of square roots of non-squares: build integrality from `isIntegral_of_sq` + `IsIntegral.add`, then supply consecutive-integer bounds. No per-instance minimal polynomial is ever computed.",
-      "Generalisation horizon — Besicovitch (1940): for distinct squarefree positive integers $a_1,\\ldots,a_n$ the $\\sqrt{a_i}$ are $\\mathbb{Q}$-linearly independent. Strategy D proves irrationality of any such sum without the full independence theorem; the linear-independence statement itself remains absent from Mathlib v4.26.0."
+      "Generalisation horizon — Besicovitch (1940): for distinct squarefree positive integers $a_1,\\ldots,a_n$ the $\\sqrt{a_i}$ are $\\mathbb{Q}$-linearly independent. Strategy D proves irrationality of any such sum without the full independence theorem; the linear-independence statement itself remains absent from Mathlib v4.26.0.",
+      "The entire numeric burden is four loose two-decimal bounds. The only non-algebraic step is checking $8 < \\alpha < 9$, discharged by $1.41<\\sqrt2<1.42$, $1.73<\\sqrt3<1.74$, $2.23<\\sqrt5<2.24$, $2.64<\\sqrt7<2.65$ — each a single `norm_num` on rationals — summed by `linarith`. The bounds need not be tight, only good enough to land $\\alpha \\approx 8.03$ inside a unit interval; the method only stalls when a target sum sits within $\\tfrac12$ of an integer, where sharper rational bounds (still finite `norm_num` work, never a minimal polynomial) are required."
     ],
     "prerequisites": [
       "IsIntegral.add : algebraic integers are closed under addition",
@@ -52,6 +53,64 @@
       "Real.sq_sqrt, Real.lt_sqrt, Real.sqrt_lt' : square-root identities and bound lemmas"
     ]
   },
+  "sections": [
+    {
+      "id": "strategy-d-overview",
+      "title": "Strategy D — Algebraic Integer in a Bounded Interval",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Header docstring laying out the three-step plan, avoiding the degree-16 minimal-polynomial machinery of Strategy A: (1) α = √2+√3+√5+√7 is an algebraic integer; (2) a rational algebraic integer is an integer; (3) 8 < α < 9, so α equals no integer and is therefore irrational.",
+      "mathContext": "Each $\\sqrt{k}$ is a root of the monic $X^2 - k$, so integral over $\\mathbb{Z}$; sums of integral elements are integral; and $\\mathbb{Z}$ integrally closed in $\\mathbb{Q}$ forces a rational algebraic integer to be a genuine integer, which the interval $(8,9)$ excludes."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports & Namespace",
+      "startLine": 27,
+      "endLine": 31,
+      "summary": "Imports Mathlib, opens Real, and enters the Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01 namespace. No new Mathlib theory is introduced — only the standard integral-closure API is used.",
+      "mathContext": "The proof draws only on existing Mathlib: $\\texttt{IsIntegral}$, $\\texttt{IsIntegral.add}$, $\\texttt{isIntegral\\_algebraMap\\_iff}$, $\\texttt{IsIntegrallyClosed.isIntegral\\_iff}$ and the $\\texttt{Real.sqrt}$ bound lemmas."
+    },
+    {
+      "id": "radicals-integral",
+      "title": "Each Radical Is an Algebraic Integer via X² − C k",
+      "startLine": 33,
+      "endLine": 53,
+      "summary": "isIntegral_of_sq: a real c with c² = m (integer) is a root of the monic integer polynomial X² − C m, hence integral over ℤ. Specialised to isIntegral_sqrt_two/_three/_five/_seven, each discharged by Real.sq_sqrt and norm_num.",
+      "mathContext": "$\\sqrt{k}$ satisfies $X^2 - C\\,k$ with $\\texttt{monic\\_X\\_pow\\_sub\\_C}$; $\\texttt{aeval}$ sends it to $(\\sqrt{k})^2 - k = 0$, witnessing $\\texttt{IsIntegral}\\ \\mathbb{Z}\\ \\sqrt{k}$."
+    },
+    {
+      "id": "alpha-integral",
+      "title": "α Is an Algebraic Integer (Closed Under Addition)",
+      "startLine": 55,
+      "endLine": 58,
+      "summary": "isIntegral_alpha: α = √2 + √3 + √5 + √7 is integral over ℤ, assembled from the four summand results by repeated IsIntegral.add.",
+      "mathContext": "Algebraic integers form a subring, so $\\texttt{IsIntegral}\\ \\mathbb{Z}\\ \\alpha$ follows from $((\\sqrt2 + \\sqrt3) + \\sqrt5) + \\sqrt7$ by three applications of $\\texttt{IsIntegral.add}$."
+    },
+    {
+      "id": "interval-trap",
+      "title": "Trapping α Strictly Between 8 and 9",
+      "startLine": 60,
+      "endLine": 74,
+      "summary": "alpha_lower (8 < α) and alpha_upper (α < 9): rational two-decimal bounds on each radical (1.41<√2<1.42, etc.) summed by linarith, giving 8.01 ≤ α ≤ 8.05.",
+      "mathContext": "$1.41+1.73+2.23+2.64 = 8.01 < \\alpha < 8.05 = 1.42+1.74+2.24+2.65$, so $8 < \\alpha < 9$; bounds via $\\texttt{Real.lt\\_sqrt}$ / $\\texttt{Real.sqrt\\_lt'}$ and $\\texttt{norm\\_num}$."
+    },
+    {
+      "id": "reusable-criterion",
+      "title": "The Reusable Criterion: Integral + Avoids Every Integer ⟹ Irrational",
+      "startLine": 76,
+      "endLine": 96,
+      "summary": "irrational_of_isIntegral_of_forall_ne_int: the gallery-wide abstract core. An algebraic integer α with ∀ n : ℤ, α ≠ (n:ℝ) is irrational, since a rational root would descend (isIntegral_algebraMap_iff) to an integral q ∈ ℚ, which IsIntegrallyClosed forces to be an integer — contradicting the hypothesis.",
+      "mathContext": "If $\\alpha = q \\in \\mathbb{Q}$ then $q$ is integral over $\\mathbb{Z}$; $\\mathbb{Z}$ integrally closed in $\\mathbb{Q}$ gives $n \\in \\mathbb{Z}$ with $\\alpha = (n:\\mathbb{R})$, contradicting $\\forall n,\\ \\alpha \\neq n$. Applies to any finite sum of square roots of non-squares."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Assembling the Contradiction",
+      "startLine": 98,
+      "endLine": 113,
+      "summary": "irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7: feeds isIntegral_alpha and the interval bounds into the reusable criterion. Any integer n with α = n would satisfy 8 < n < 9, impossible by omega — so α is irrational.",
+      "mathContext": "$\\alpha = (n:\\mathbb{R})$ with $\\texttt{alpha\\_lower}$/$\\texttt{alpha\\_upper}$ casts to $8 < n < 9$ in $\\mathbb{Z}$, refuted by $\\texttt{omega}$; the unit-width interval discharges the $\\forall n,\\ \\alpha \\neq n$ hypothesis."
+    }
+  ],
   "conclusion": {
     "summary": "Fully verified (0 sorries, 0 axioms): irrational_sqrt2_add_sqrt3_add_sqrt5_add_sqrt7 : Irrational (√2 + √3 + √5 + √7). Proved by Strategy D — α is an algebraic integer over ℤ trapped strictly in (8,9), and a rational algebraic integer must be an integer. Build verified at Mathlib v4.26.0. 8 theorems, 113 lines.",
     "implications": "Closes OQ-01 of the parent `sqrt2-plus-sqrt3-plus-sqrt5-irrational` gallery entry. The reusable criterion irrational_of_isIntegral_of_forall_ne_int proves irrationality of any finite sum of square roots of non-squares once a unit-width interval bound is supplied — independent of the number of summands, with no minimal-polynomial computation.",


### PR DESCRIPTION
## Summary
This gallery entry had **no sections array** (sections sub-score 0/10). Adds seven sections spanning the full 113-line `Proofs/Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01.lean`:

1. **Strategy D — Algebraic Integer in a Bounded Interval** (1–25)
2. **Imports & Namespace** (27–31)
3. **Each Radical Is an Algebraic Integer via X² − C k** (33–53)
4. **α Is an Algebraic Integer (Closed Under Addition)** (55–58)
5. **Trapping α Strictly Between 8 and 9** (60–74)
6. **The Reusable Criterion: Integral + Avoids Every Integer ⟹ Irrational** (76–96)
7. **Main Theorem: Assembling the Contradiction** (98–113)

Also adds a fifth key insight on the cheap two-decimal interval-trap numerics (the entire non-algebraic burden is four loose `norm_num` bounds).

## Effect
- Sections 0 → 10 and keyInsights 8 → 10; gallery quality 88 → 100.
- meta.json validated as well-formed JSON; line ranges in bounds for the 113-line source.
- Pure gallery-data enrichment — no Lean or proof changes. Does not touch the two open `research`-labeled PRs (#24400, #24512), which modify `research/` and `proofs/` only.