### PR TITLE
research(mantel-theorem): M1 edge bound ⌊n²/4⌋ + sharpness (verified)

### DIFF
--- a/proofs/Proofs/MantelTheorem.lean
+++ b/proofs/Proofs/MantelTheorem.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# Mantel's Theorem (Maximum Edges in Triangle-Free Graphs)
+
+Mantel's theorem (1907), the founding result of extremal graph theory and the `r = 2`
+base case of Turán's theorem, states:
+
+> A simple graph on `n` vertices with no triangle (`K₃`-free, i.e. `CliqueFree 3`) has at
+> most `⌊n²/4⌋` edges, and the bound is attained by the balanced complete bipartite graph.
+
+## Approach
+
+Mathlib's `Mathlib.Combinatorics.SimpleGraph.Extremal.Turan` develops Turán's theorem in full
+generality. The general edge bound `SimpleGraph.CliqueFree.card_edgeFinset_le` specializes at
+`r = 2` to
+
+  `#G.edgeFinset ≤ (n² - (n % 2)²) · (2 - 1) / (2 · 2) + (n % 2).choose 2`
+
+with `n = Fintype.card V`. The arithmetic identity `turan_two_simp` collapses that right-hand
+side to the clean floor `n² / 4`, giving Mantel's bound (`mantel_card_edgeFinset_le`).
+
+Sharpness is witnessed by `SimpleGraph.turanGraph n 2` — the canonical triangle-free graph —
+whose edge count is exactly `n² / 4` (`card_edgeFinset_turanGraph_two`), so the bound is tight
+(`mantel_bound_is_tight`).
+
+The equality *characterization* (equality holds iff `G` is the balanced complete bipartite
+graph) follows from `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` but is not packaged
+here; see the gallery notes for that future direction.
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace Mantel
+
+/-- The Turán right-hand side at `r = 2` collapses to the floor `n² / 4`.
+
+Concretely `(n² - (n % 2)²) · (2 - 1) / (2 · 2) + (n % 2).choose 2 = n² / 4`: the binomial term
+vanishes because `n % 2 < 2`, and `n² - (n % 2)²` is a multiple of `4` equal to `n²` rounded
+down. -/
+theorem turan_two_simp (n : ℕ) :
+    (n ^ 2 - (n % 2) ^ 2) * (2 - 1) / (2 * 2) + (n % 2).choose 2 = n ^ 2 / 4 := by
+  have hlt : n % 2 < 2 := Nat.mod_lt n (by norm_num)
+  have hc : (n % 2).choose 2 = 0 := Nat.choose_eq_zero_of_lt hlt
+  have hB : (n % 2) ^ 2 < 4 := by
+    rcases Nat.mod_two_eq_zero_or_one n with h | h <;> rw [h] <;> norm_num
+  have hdecomp : n ^ 2 = 4 * ((n / 2) ^ 2 + (n / 2) * (n % 2)) + (n % 2) ^ 2 := by
+    conv_lhs => rw [← Nat.div_add_mod n 2]
+    ring
+  rw [hc, add_zero, show (2 : ℕ) - 1 = 1 from rfl, mul_one, show (2 : ℕ) * 2 = 4 from rfl]
+  omega
+
+/-- **Mantel's theorem (edge bound).** A triangle-free (`K₃`-free) simple graph on `n` vertices
+has at most `⌊n²/4⌋` edges. -/
+theorem mantel_card_edgeFinset_le {V : Type*} [Fintype V] (G : SimpleGraph V)
+    [DecidableRel G.Adj] (h : G.CliqueFree 3) :
+    G.edgeFinset.card ≤ (Fintype.card V) ^ 2 / 4 := by
+  have hb := CliqueFree.card_edgeFinset_le (r := 2) (G := G) h
+  exact le_trans hb (le_of_eq (turan_two_simp _))
+
+/-- The canonical Turán graph `turanGraph n 2` is triangle-free. -/
+theorem turanGraph_two_cliqueFree (n : ℕ) : (turanGraph n 2).CliqueFree 3 :=
+  turanGraph_cliqueFree (by norm_num)
+
+/-- The Turán graph `turanGraph n 2` (balanced complete bipartite graph on `n` vertices) has
+exactly `⌊n²/4⌋` edges. -/
+theorem card_edgeFinset_turanGraph_two (n : ℕ) :
+    (turanGraph n 2).edgeFinset.card = n ^ 2 / 4 := by
+  rw [card_edgeFinset_turanGraph]
+  exact turan_two_simp n
+
+/-- **Sharpness of Mantel's bound.** For every `n` there is a triangle-free graph on `n`
+vertices attaining `⌊n²/4⌋` edges, so the bound in `mantel_card_edgeFinset_le` cannot be
+improved. -/
+theorem mantel_bound_is_tight (n : ℕ) :
+    ∃ (G : SimpleGraph (Fin n)) (_ : DecidableRel G.Adj),
+      G.CliqueFree 3 ∧ G.edgeFinset.card = n ^ 2 / 4 :=
+  ⟨turanGraph n 2, inferInstance, turanGraph_two_cliqueFree n, card_edgeFinset_turanGraph_two n⟩
+
+end Mantel

--- a/research/problems/mantel-theorem/knowledge.md
+++ b/research/problems/mantel-theorem/knowledge.md
@@ -1,0 +1,62 @@
+# Knowledge Base: mantel-theorem
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Mantel's theorem (1907): a triangle-free (`K₃`-free, i.e. `CliqueFree 3`) simple graph
+on `n` vertices has at most `⌊n²/4⌋` edges, attained by the balanced complete bipartite
+graph. It is the `r = 2` base case of Turán's theorem.
+
+---
+
+## Insights
+
+### M1 (researcher-6, 2026-06-15) — SOLVED via Mathlib Turán specialization (BUILD GREEN)
+
+- **Mathlib already provides the general Turán edge bound.** The Turán development lives in
+  `Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean` (the old
+  `Mathlib.Combinatorics.SimpleGraph.Turan` is now a `deprecated_module` redirect since
+  2025-08-21). The load-bearing lemma is
+
+      SimpleGraph.CliqueFree.card_edgeFinset_le (cf : G.CliqueFree (r + 1)) :
+        let n := Fintype.card V;
+        #G.edgeFinset ≤ (n ^ 2 - (n % r) ^ 2) * (r - 1) / (2 * r) + (n % r).choose 2
+
+  Specializing at `r = 2` and simplifying the RHS to `⌊n²/4⌋` IS Mantel's theorem. No new
+  graph theory required — the only real work is the closing arithmetic identity.
+
+- **The arithmetic identity `turan_two_simp`:**
+  `(n² − (n%2)²)·(2−1)/(2·2) + (n%2).choose 2 = n²/4`.
+  Two facts close it: (1) the binomial term vanishes since `n%2 < 2 ≤ 2`
+  (`Nat.choose_eq_zero_of_lt`); (2) `n² = 4·((n/2)² + (n/2)·(n%2)) + (n%2)²` (proved by
+  `conv_lhs => rw [← Nat.div_add_mod n 2]; ring`), and `(n%2)² < 4`, so `omega` finishes
+  `(n² − (n%2)²)/4 = n²/4` by abstracting `n²`, `(n%2)²`, `(n/2)²`, `(n/2)·(n%2)` as atoms.
+
+- **Sharpness is free.** `turanGraph n 2` is triangle-free (`turanGraph_cliqueFree (0<2)`)
+  and has exactly `⌊n²/4⌋` edges (`card_edgeFinset_turanGraph` + `turan_two_simp`). Packaged
+  as `mantel_bound_is_tight`.
+
+- **Gotchas:**
+  - `r` is implicit in `CliqueFree.card_edgeFinset_le`; pass `(r := 2)` and supply
+    `h : G.CliqueFree 3` directly — `3` and `2+1` are defeq for Nat literals.
+  - The conclusion is wrapped in `let n := Fintype.card V; …`. A `calc` first step against
+    the explicit (let-free) RHS mis-parses / fails to match; `exact le_trans hb
+    (le_of_eq (turan_two_simp _))` reduces the `let` by `whnf` and works.
+
+---
+
+## Dead Ends
+
+- A from-scratch AM–GM / degree-sum proof (the textbook route) was deemed unnecessary once
+  the Mathlib Turán specialization was confirmed to compile; not attempted.
+
+---
+
+## Open Follow-ups
+
+- **Equality characterization** (equality `#E = ⌊n²/4⌋` ⟺ `G ≅` balanced complete bipartite
+  graph) is reachable from `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` but not
+  yet packaged. This is the natural M2 target.

--- a/research/problems/mantel-theorem/literature/README.md
+++ b/research/problems/mantel-theorem/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for mantel-theorem
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/mantel-theorem/problem.md
+++ b/research/problems/mantel-theorem/problem.md
@@ -1,0 +1,130 @@
+# Problem: Mantel's Theorem (Maximum Edges in Triangle-Free Graphs)
+
+**Slug**: mantel-theorem
+**Created**: 2026-06-15T12:01:04-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{If a simple graph } G \text{ on } n \text{ vertices contains no triangle } (K_3\text{-free}),
+$$
+$$
+\text{then } |E(G)| \le \left\lfloor \frac{n^2}{4} \right\rfloor,
+$$
+$$
+\text{with equality iff } G \cong K_{\lfloor n/2\rfloor,\, \lceil n/2\rceil}.
+$$
+
+### Plain Language
+
+Among all graphs on $n$ vertices that contain no triangle, the one with the most edges is the
+complete bipartite graph splitting the vertices into two halves as evenly as possible, and it
+has $\lfloor n^2/4 \rfloor$ edges. You cannot do better without forcing a triangle.
+
+### Why This Matters
+
+Mantel's theorem (1907) is the founding result of extremal graph theory and the $r = 2$ base
+case of Turán's theorem. Its proof techniques — vertex-weight shifting, the AM–GM bound on
+$d(u)d(v)$, and Cauchy–Schwarz on degree sequences — recur throughout the field (Kővári–Sós–
+Turán, the Erdős–Stone theorem, flag algebras). It is a clean, self-contained target that
+exercises Mathlib's `SimpleGraph` extremal infrastructure.
+
+## Known Results
+
+### What's Already Proven
+
+- Turán's theorem and `IsTuranMaximal` — `Mathlib.Combinatorics.SimpleGraph.Turan`.
+- `SimpleGraph.cliqueFree`, edge counts via `SimpleGraph.edgeFinset` / `degree` — Mathlib.
+- Complete multipartite / `turanGraph` constructions — Mathlib.
+
+### What's Still Open
+
+- A direct, citable Mantel statement ($K_3$-free $\Rightarrow |E| \le \lfloor n^2/4\rfloor$, with the bipartite equality case) as a standalone gallery theorem, rather than only as a corollary buried inside the general Turán development.
+
+### Our Goal
+
+Prove the edge bound $|E(G)| \le \lfloor n^2/4 \rfloor$ for triangle-free $G$ on `Fin n`, and
+characterize equality as the balanced complete bipartite graph. Deriving it as a specialization
+of Mathlib's `isTuranMaximal` (with $r = 2$) is an acceptable and likely the fastest route; a
+self-contained AM–GM/degree-sum proof is the fallback.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| friendship-theorem | extremal/structural constraints on simple graphs | eigenvalue/counting arguments |
+| erdos-565-incomplete-01 | Ramsey/extremal edge-coloring on graphs | edge colorings, counting |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — specialize Turán**: Instantiate Mathlib's `isTuranMaximal` / `turanGraph` at $r = 2$ and translate "$2$-colorable extremal graph" into the $\lfloor n^2/4\rfloor$ edge count.
+   - Why it might work: reuses a fully formalized, verified theorem; minimal new mathematics.
+   - Risk: bridging Turán's `cliqueFree (r+1)` formulation to "triangle-free = $K_3$-free" and extracting the explicit edge count and equality case may be more plumbing than expected.
+
+2. **Approach B — degree-sum / AM–GM**: For each edge $uv$, neighborhoods of $u$ and $v$ are disjoint, so $d(u) + d(v) \le n$; sum over edges and apply Cauchy–Schwarz to $\sum d(v)^2$.
+   - Why it might work: elementary, self-contained, classic.
+   - Risk: formalizing the $\sum_{uv\in E}(d(u)+d(v)) = \sum_v d(v)^2$ identity and the Cauchy–Schwarz step in `Finset` form.
+
+### Key Difficulties
+
+- Extracting the explicit $\lfloor n^2/4 \rfloor$ value and the equality characterization from Mathlib's general Turán API.
+- `Finset` degree-sum identities and floor arithmetic for odd vs even $n$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: triangle-free $\Rightarrow$ for every edge $uv$, $N(u) \cap N(v) = \varnothing$, hence $d(u)+d(v)\le n$.
+- Key lemma 2: $\sum_{uv \in E} (d(u)+d(v)) = \sum_v d(v)^2$ and Cauchy–Schwarz lower bound $\sum d(v)^2 \ge (\sum d(v))^2/n$.
+- Technical requirements: `SimpleGraph.degree`, `edgeFinset`, `cliqueFree`, `Finset.inner_mul_le_norm` style Cauchy–Schwarz.
+
+## Tractability Assessment
+
+**Difficulty**: Medium (Low if the Turán specialization route works cleanly)
+
+**Justification**:
+- Mathlib already contains the harder Turán theorem; Mantel is its simplest instance.
+- Both routes use standard, well-supported `SimpleGraph`/`Finset` APIs.
+- The equality case is the most delicate part but is also covered structurally by `IsTuranMaximal` uniqueness.
+
+**Estimated Effort**:
+- Exploration: 1 day
+- If tractable: 3-7 days
+- If hard: 2 weeks (mainly the equality characterization)
+
+## References
+
+### Papers
+- Mantel, "Problem 28," *Wiskundige Opgaven* 10 (1907) — original.
+- Turán, "On an extremal problem in graph theory" (1941) — the generalization.
+- Aigner & Ziegler, *Proofs from THE BOOK* — multiple short proofs of Mantel.
+
+### Online Resources
+- Mathlib `Combinatorics.SimpleGraph.Turan` module docs — `IsTuranMaximal`, `turanGraph`.
+
+### Mathlib
+- `Mathlib.Combinatorics.SimpleGraph.Turan` — Turán's theorem, extremal graph, uniqueness.
+- `Mathlib.Combinatorics.SimpleGraph.Clique` — `cliqueFree`, `CliqueFree`.
+- `Mathlib.Combinatorics.SimpleGraph.DegreeSum` — handshake lemma, degree sums.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - graph-theory
+  - extremal-combinatorics
+related_proofs:
+  - friendship-theorem
+  - erdos-565-incomplete-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-15T12:01:04-07:00
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10

--- a/research/problems/mantel-theorem/state.md
+++ b/research/problems/mantel-theorem/state.md
@@ -1,0 +1,44 @@
+# Research State: mantel-theorem
+
+## Current State
+**Phase**: ACT (M1 shipped)
+**Path**: full
+**Since**: 2026-06-15
+**Iteration**: 1
+
+## Current Focus
+M1 complete: Mantel's edge bound + sharpness formalized and BUILD GREEN. Next natural
+target is the equality characterization (M2).
+
+## Active Approach
+Specialize Mathlib's general Turán edge bound `SimpleGraph.CliqueFree.card_edgeFinset_le`
+to `r = 2` and collapse the arithmetic to `⌊n²/4⌋`.
+
+## What Shipped (M1, researcher-6, 2026-06-15)
+New file `proofs/Proofs/MantelTheorem.lean` (84 lines, 5 theorems, 0 axioms, 0 sorries),
+BUILD GREEN (7743 jobs, exit 0, docker-build.sh @8GB):
+
+1. `turan_two_simp` — arithmetic identity collapsing the general Turán r=2 RHS to `n²/4`.
+2. `mantel_card_edgeFinset_le` — **Mantel's theorem**: `G.CliqueFree 3 ⟹ #G.edgeFinset ≤
+   (Fintype.card V)² / 4`.
+3. `turanGraph_two_cliqueFree` — `turanGraph n 2` is triangle-free.
+4. `card_edgeFinset_turanGraph_two` — `turanGraph n 2` has exactly `n²/4` edges.
+5. `mantel_bound_is_tight` — sharpness: a triangle-free graph attaining `⌊n²/4⌋` exists.
+
+Gallery data added at `src/data/proofs/mantel-theorem/meta.json` (status `verified`,
+badge `original`).
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (Mathlib Turán specialization — succeeded)
+
+## Blockers
+None.
+
+## Next Action
+**M2 — equality characterization.** Prove that equality `#G.edgeFinset = ⌊n²/4⌋` holds iff
+`G` is isomorphic to the balanced complete bipartite graph, via
+`SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph`. Requires connecting the floor bound
+to `IsTuranMaximal` (a Turán-maximal triangle-free graph attains the bound) and unfolding the
+`turanGraph n 2` structure as `K_{⌊n/2⌋,⌈n/2⌉}`.

--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -1,0 +1,83 @@
+{
+  "id": "mantel-theorem",
+  "title": "Mantel's Theorem",
+  "slug": "mantel-theorem",
+  "description": "A triangle-free simple graph on n vertices has at most ⌊n²/4⌋ edges, and the bound is attained by the balanced complete bipartite graph. Mantel's theorem (1907) is the founding result of extremal graph theory and the r = 2 case of Turán's theorem.",
+  "meta": {
+    "author": "Willem Mantel (1907), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tur%C3%A1n%27s_theorem#Mantel's_theorem",
+    "date": "1907",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "turan-theorem",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/MantelTheorem.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.CliqueFree.card_edgeFinset_le",
+        "description": "General Turán edge bound: an (r+1)-clique-free graph has at most as many edges as the Turán graph",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.turanGraph",
+        "description": "The canonical (r+1)-clique-free Turán graph on n vertices",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.card_edgeFinset_turanGraph",
+        "description": "Exact edge count of the Turán graph",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.turanGraph_cliqueFree",
+        "description": "The Turán graph turanGraph n r is (r+1)-clique-free",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      }
+    ],
+    "originalContributions": [
+      "Standalone statement of Mantel's edge bound (CliqueFree 3 ⟹ #E ≤ ⌊n²/4⌋), specialized from Mathlib's general Turán development",
+      "Arithmetic identity turan_two_simp collapsing the general Turán r=2 bound (n² − (n%2)²)·(2−1)/(2·2) + (n%2).choose 2 to the clean floor n²/4",
+      "Sharpness theorem exhibiting turanGraph n 2 as a triangle-free graph attaining ⌊n²/4⌋ edges, proving the bound is tight"
+    ],
+    "dateAdded": "2026-06-15",
+    "axiomCountNote": "0 axiom declarations, 0 structure-encoded assumptions; all results are machine-checked consequences of Mathlib's Turán theorem."
+  },
+  "overview": "Mantel's theorem (1907) bounds the number of edges in a triangle-free graph. If a simple graph G on n vertices contains no triangle (it is K₃-free, i.e. CliqueFree 3), then it has at most ⌊n²/4⌋ edges. This is the founding result of extremal graph theory and the base case r = 2 of Turán's theorem (which forbids Kᵣ₊₁ instead of K₃). Mathlib develops Turán's theorem in full generality; this entry specializes the general edge bound `SimpleGraph.CliqueFree.card_edgeFinset_le` to r = 2 and collapses the resulting arithmetic to the familiar floor ⌊n²/4⌋. The bound is sharp: the balanced complete bipartite graph — realized as `turanGraph n 2` — is triangle-free and has exactly ⌊n²/4⌋ edges.",
+  "conclusion": "Mantel's edge bound is fully machine-checked in Lean 4 with no axioms or sorries, derived from Mathlib's Turán theorem. The key arithmetic step is `turan_two_simp`, which shows the general Turán right-hand side at r = 2 equals ⌊n²/4⌋ exactly (the binomial correction term vanishes since n % 2 < 2, and n² − (n%2)² is a multiple of 4). Sharpness is witnessed by `turanGraph n 2`. The equality characterization (equality holds iff G is the balanced complete bipartite graph) follows from `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` and is noted as a future direction.",
+  "crossReferences": [
+    {
+      "targetId": "friendship-theorem",
+      "relationship": "related",
+      "description": "Both are structural/extremal results constraining simple graphs; the friendship theorem forbids a local configuration while Mantel forbids triangles globally."
+    },
+    {
+      "targetId": "erdos-565-incomplete-01",
+      "relationship": "related",
+      "description": "Both sit in extremal/Ramsey graph theory and reason about edge counts under forbidden substructures."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset", "Fintype", "SimpleGraph"],
+    "namespace": "Mantel",
+    "lineCount": 84,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/MantelTheorem.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "mantel_card_edgeFinset_le",
+    "card_edgeFinset_turanGraph_two",
+    "mantel_bound_is_tight"
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **Mantel's Theorem** (1907) — the founding result of extremal graph theory and the `r = 2` base case of Turán's theorem.

`proofs/Proofs/MantelTheorem.lean` (84 lines, **5 theorems, 0 axioms, 0 sorries**) — **BUILD GREEN** via `docker-build.sh Proofs.MantelTheorem` (7743 jobs, exit 0, @8GB).

- `mantel_card_edgeFinset_le` — **Mantel's theorem**: a triangle-free (`CliqueFree 3`) simple graph on `n` vertices has `#E ≤ ⌊n²/4⌋`. Specializes Mathlib's general Turán bound `SimpleGraph.CliqueFree.card_edgeFinset_le` at `r = 2`.
- `turan_two_simp` — the arithmetic identity collapsing the general Turán `r=2` right-hand side `(n² − (n%2)²)·(2−1)/(2·2) + (n%2).choose 2` to the clean floor `n²/4`.
- `card_edgeFinset_turanGraph_two` / `turanGraph_two_cliqueFree` / `mantel_bound_is_tight` — **sharpness**: `turanGraph n 2` (balanced complete bipartite) is triangle-free and attains exactly `⌊n²/4⌋` edges, so the bound is tight.

Gallery data: `src/data/proofs/mantel-theorem/meta.json` (status `verified`, badge `original`, `axiomCount 0`).

## Notes
- The general Mathlib Turán file moved to `Mathlib.Combinatorics.SimpleGraph.Extremal.Turan` (old `…SimpleGraph.Turan` is now a deprecated redirect).
- Equality characterization (equality ⟺ balanced complete bipartite) is reachable from `isTuranMaximal_iff_nonempty_iso_turanGraph` and noted as the M2 follow-up; not in scope here.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.MantelTheorem` — green (7743 jobs)
- [x] `meta.json` validates as JSON
- [x] 0 sorries / 0 axioms / 0 structure-encoded assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)