### PR TITLE
audit: gallery-integrity coverage for 14 never-audited entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7198,9 +7198,9 @@
       "result": "clean"
     },
     "erdos-463": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:20:49Z",
+      "lastAudited": "2026-06-15T19:41:12Z",
       "result": "clean"
     },
     "erdos-464": {
@@ -15394,6 +15394,96 @@
     "central-limit-theorem-oq-02 issues-found": {
       "auditCount": 1,
       "lastAudited": "2026-06-15T15:05:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:24:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-oq-02-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:25:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-10-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:26:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1047-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:27:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1179-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:28:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "friendship-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:29:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "greens-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:30:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inclusion-exclusion-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:32:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "inverse-galois-d4-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:35:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:35:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:36:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "morleys-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:37:36Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "pascals-hexagon-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:38:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spherical-law-of-cosines-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:39:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T19:40:03Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary
Gallery integrity audit pass over the never-audited backlog (2026-06-15). Records audit coverage in `audit-tracker.json`. **14 entries audited; 12 fully clean, 2 issues already have fixes in flight.**

## Findings

| Entry | Result | Note |
|-------|--------|------|
| cayley-hamilton-cyclic-vector-all-fields-oq-02 | clean | main file 0-sorry/0-axiom, badge wip conservative |
| cevas-theorem-oq-02-oq-01-oq-02-oq-01 | clean | Tier-A, 22 thms via elementary algebra, build documented |
| erdos-10-oq-02 | clean | counts are correct 3-file aggregates (542L/16T/8D) |
| erdos-1047-oq-02 | clean | axiomCount=1 = imported `goodman_counterexample`; honest |
| erdos-1179-oq-02 | clean | result independent of parent's 3 axioms |
| friendship-theorem-oq-04 | clean | parent axiom-free; counts match |
| greens-theorem-oq-02-oq-02 | clean | axiomCount=1 = imported `greens_theorem_l1curl`; honest |
| inverse-galois-d4-oq-01 | clean | 13 substantive D₄ thms (see note on `research` badge below) |
| law-of-cosines-oq-04-oq-01 | clean | Stewart/Apollonius via inner products; counts match |
| minkowski-theorem-oq-03 | clean | class-number estimate on Mathlib; wip conservative |
| pascals-hexagon-oq-02 | clean | axiomCount=1 = imported `conic_implies_pascal_constraint` |
| spherical-law-of-cosines-oq-03 | clean | def count 4 = 1 structure + 3 defs; all match |
| sqrt2+3+5-irrational-oq-01 | clean | Tier-A, build-verified, theoremCount 10 |
| erdos-463 | clean | open conjecture stated only in comments; 9 honest aux lemmas |
| **inclusion-exclusion-oq-01-oq-03** | **issues-found** | invalid `verified` badge on a Tier-B Mathlib bridge → should be `mathlib`. Fix already open in **#24715**; regressed by merged #24693. Commented on #24715. |
| **morleys-theorem-oq-03** | **issues-found** | `description` + `conclusion` say "build-pending" while status is `verified`/assumptions say machine-verified. Fix already open in **#24737**. |

## Systemic observation (not fixed here)
Two badge values appear in gallery `meta.json` that are not in the `ProofBadge` union (`src/types/proof.ts:102`): `verified` (24 entries) and `research` (7 entries). `research` renders as no badge at all (`proof-badge.tsx:23` returns null for unknown badges). Best fixed in a batch enrichment pass, not per-entry.

## Test plan
- [x] Each entry's `sorries`/`axiomCount`/`theoremCount`/`definitionCount`/`lineCount` recomputed from Lean source and cross-checked against `meta.json`
- [x] Imported-axiom dependencies traced for axiomatized entries
- [x] No duplicate PRs filed (existing #24715/#24737 cover the two issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)