### PR TITLE
research(de-moivre-oq-02-oq-02-oq-01): Chebyshev U·U linearization U_m·U_n = ∑ U_{m+n−2k} (build-pending)

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean
@@ -1,0 +1,145 @@
+import Mathlib
+
+/-
+# De Moivre OQ-02 OQ-02 OQ-01: Linearization of the Chebyshev U·U Product
+
+## Open Question
+
+The companion file `DeMoivreOQ02OQ02` proves a U·U *product-to-difference*
+identity scaled by `(1 - x²)`:
+  2(1 − x²)·U_m·U_n = T_{m−n} − T_{m+n+2}.
+
+Can the product `U_m · U_n` itself be written purely in terms of second-kind
+Chebyshev polynomials, with no `T` and no `(1 − x²)` factor?
+
+## Answer: YES — the linearization (product-to-sum) formula
+
+For every `m : ℤ` and `n : ℕ`,
+  U_m · U_n = ∑_{k=0}^{n} U_{m + n − 2k}
+            = U_{m+n} + U_{m+n−2} + ⋯ + U_{m−n}        (as polynomials in R[X]).
+
+This is the second-kind analogue of the first-kind product-to-sum
+  2·T_m·T_n = T_{m+n} + T_{m−n}
+but is genuinely a *sum of `min(m,n)+1` terms* rather than two terms.
+
+## Proof Strategy
+
+Let `S(m,n) := ∑_{k=0}^{n} U_{m+n−2k}`.  Two facts give the result:
+
+1. **Sum recurrence** (pure index bookkeeping, no products):
+     2·X·S(m, n+1) = S(m, n+2) + S(m, n).
+   Distribute `2X` into the sum using `2·X·U_k = U_{k+1} + U_{k−1}`, then realign
+   the two telescoped ranges; the boundary terms (both `U_{m−n−2}`) cancel.
+
+2. **Two-step induction on n**, mirroring `U_{n+2} = 2·X·U_{n+1} − U_n`.
+   Base `n = 0, 1` are direct; the step uses (1) at index `n+1`.
+
+## Build status
+
+BUILD-PENDING (not yet machine-verified): written in a session where the Docker
+build queue was saturated and Aristotle was unavailable, so the Finset cast/term
+bookkeeping could not be checked against the compiler. The mathematics is verified
+by hand (and numerically: `U_2·U_2 = U_4+U_2+U_0`, `U_3·U_1 = U_4+U_2`); residual
+fixes, if any, are confined to index-cast matching in `Ssum_rec`. Promote the gallery
+entry to verified/original once `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` is green.
+-/
+
+open Polynomial Polynomial.Chebyshev
+
+namespace DeMoivreOQ02OQ02OQ01
+
+variable {R : Type*} [CommRing R]
+
+/-- The linearization sum `S(m,n) = ∑_{k=0}^{n} U_{m+n−2k}`. -/
+noncomputable def Ssum (m : ℤ) (n : ℕ) : R[X] :=
+  ∑ k ∈ Finset.range (n + 1), U R (m + (n : ℤ) - 2 * (k : ℤ))
+
+/-- `2·X·U_k = U_{k+1} + U_{k-1}`: rearrangement of the U recurrence. -/
+private lemma two_X_U (k : ℤ) :
+    (2 : R[X]) * X * U R k = U R (k + 1) + U R (k - 1) := by
+  have h := U_add_two (R := R) (k - 1)
+  simp only [show k - 1 + 1 = k from by ring, show k - 1 + 2 = k + 1 from by ring] at h
+  linear_combination -h
+
+/-- Expand `2·X·S(m, n+1)` into a single sum of `U`-pairs over `range (n+2)`. -/
+private lemma Ssum_succ_expand (m : ℤ) (n : ℕ) :
+    (2 : R[X]) * X * Ssum m (n + 1)
+      = ∑ k ∈ Finset.range (n + 2),
+          (U R (m + (n : ℤ) + 2 - 2 * (k : ℤ)) + U R (m + (n : ℤ) - 2 * (k : ℤ))) := by
+  rw [Ssum, Finset.mul_sum]
+  apply Finset.sum_congr (by norm_num)
+  intro k _
+  rw [two_X_U]
+  rw [show m + ((n + 1 : ℕ) : ℤ) - 2 * (k : ℤ) + 1 = m + (n : ℤ) + 2 - 2 * (k : ℤ) from by push_cast; ring,
+      show m + ((n + 1 : ℕ) : ℤ) - 2 * (k : ℤ) - 1 = m + (n : ℤ) - 2 * (k : ℤ) from by push_cast; ring]
+
+/-- **Sum recurrence**: `2·X·S(m, n+1) = S(m, n+2) + S(m, n)`.
+
+Pure index manipulation — no Chebyshev products appear. -/
+lemma Ssum_rec (m : ℤ) (n : ℕ) :
+    (2 : R[X]) * X * Ssum m (n + 1) = Ssum m (n + 2) + Ssum m n := by
+  rw [Ssum_succ_expand, Finset.sum_add_distrib]
+  -- LHS = (∑_{range(n+2)} A) + (∑_{range(n+2)} B)
+  --   A k = U_{m+n+2-2k},  B k = U_{m+n-2k}
+  -- Expand the RHS sums, then peel boundary terms with sum_range_succ.
+  have hA : Ssum (R := R) m (n + 2)
+      = (∑ k ∈ Finset.range (n + 2), U R (m + (n : ℤ) + 2 - 2 * (k : ℤ)))
+        + U R (m + (n : ℤ) + 2 - 2 * ((n : ℤ) + 2)) := by
+    rw [Ssum, Finset.sum_range_succ]
+    congr 1
+    · apply Finset.sum_congr rfl; intro k _; congr 1; push_cast; ring
+    · congr 1; push_cast; ring
+  have hB : (∑ k ∈ Finset.range (n + 2), U R (m + (n : ℤ) - 2 * (k : ℤ)))
+      = Ssum (R := R) m n + U R (m + (n : ℤ) - 2 * ((n : ℤ) + 1)) := by
+    rw [Ssum, show n + 2 = (n + 1) + 1 from rfl, Finset.sum_range_succ]
+    congr 1
+    · congr 1; push_cast; ring
+  rw [hA, hB]
+  -- Boundary terms coincide: A_{n+2} = U_{m-n-2} = B_{n+1}.
+  rw [show m + (n : ℤ) + 2 - 2 * ((n : ℤ) + 2) = m + (n : ℤ) - 2 * ((n : ℤ) + 1) from by ring]
+  ring
+
+/-- Base value: `S(m, 0) = U_m`. -/
+private lemma Ssum_zero (m : ℤ) : Ssum (R := R) m 0 = U R m := by
+  rw [Ssum, Finset.sum_range_one]
+  congr 1; push_cast; ring
+
+/-- Base value: `S(m, 1) = U_{m+1} + U_{m-1}`. -/
+private lemma Ssum_one (m : ℤ) :
+    Ssum (R := R) m 1 = U R (m + 1) + U R (m - 1) := by
+  rw [Ssum, Finset.sum_range_succ, Finset.sum_range_one]
+  rw [show m + ((1 : ℕ) : ℤ) - 2 * ((0 : ℕ) : ℤ) = m + 1 from by push_cast; ring,
+      show m + ((1 : ℕ) : ℤ) - 2 * ((1 : ℕ) : ℤ) = m - 1 from by push_cast; ring]
+
+/-- **Main linearization identity** (polynomial form):
+  `U_m · U_n = ∑_{k=0}^{n} U_{m+n−2k}`  in `R[X]`, for `m : ℤ`, `n : ℕ`.
+
+Proved by two-step induction matching the U recurrence. -/
+theorem U_mul_U (m : ℤ) (n : ℕ) :
+    U R m * U R n = Ssum m n := by
+  -- Strengthen to a paired statement to feed the two-step recurrence.
+  suffices h : ∀ j : ℕ,
+      (U R m * U R (j : ℤ) = Ssum m j) ∧
+      (U R m * U R ((j : ℤ) + 1) = Ssum m (j + 1)) from (h n).1
+  intro j
+  induction j with
+  | zero =>
+    refine ⟨?_, ?_⟩
+    · rw [Ssum_zero, Nat.cast_zero, U_zero, mul_one]
+    · rw [show ((0 : ℕ) : ℤ) + 1 = 1 from by norm_num, Ssum_one, U_one]
+      linear_combination two_X_U (R := R) m
+  | succ i ih =>
+    obtain ⟨h0, h1⟩ := ih
+    refine ⟨by simpa using h1, ?_⟩
+    -- Goal: U_m * U_{(i+1)+1} = S(m, i+2).
+    have hrec := U_add_two (R := R) (i : ℤ)   -- U_{i+2} = 2X·U_{i+1} − U_i
+    have hS := Ssum_rec (R := R) m i          -- 2X·S(m,i+1) = S(m,i+2) + S(m,i)
+    rw [show ((i + 1 : ℕ) : ℤ) + 1 = (i : ℤ) + 2 from by push_cast; ring,
+        show (i + 1 : ℕ) + 1 = i + 2 from rfl, hrec]
+    -- U_m * (2X·U_{i+1} − U_i) = 2X·S(m,i+1) − S(m,i) = S(m,i+2)
+    have e1 : U R m * ((2 : R[X]) * X * U R ((i : ℤ) + 1) - U R (i : ℤ))
+        = (2 : R[X]) * X * (U R m * U R ((i : ℤ) + 1)) - U R m * U R (i : ℤ) := by ring
+    rw [e1, h1, h0]
+    linear_combination hS
+
+end DeMoivreOQ02OQ02OQ01

--- a/research/problems/de-moivre-oq-02-oq-02-oq-01/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-02-oq-01/knowledge.md
@@ -1,0 +1,60 @@
+# de-moivre-oq-02-oq-02-oq-01: Chebyshev U·U Linearization
+
+**Target**: Prove `U_m · U_n = ∑_{k=0}^{n} U_{m+n−2k}` as a polynomial identity over any
+commutative ring `R[X]`, for `m : ℤ`, `n : ℕ`. This is the genuine product-to-sum
+("linearization") formula for second-kind Chebyshev polynomials — the open question
+explicitly posed by the parent T·U entry de-moivre-oq-02-oq-02.
+
+## Summary
+
+The parent only proved the *mixed* T·U cross-product and a U·U product-to-*difference*
+scaled by `(1−x²)`. The bare product `U_m·U_n` had not been expressed purely in second-kind
+terms. The classical answer is a full arithmetic-progression sum of indices from `|m−n|` to
+`m+n` in steps of 2.
+
+## Key idea
+
+Isolate the combinatorics. Let `S(m,n) = ∑_{k=0}^{n} U_{m+n−2k}`.
+- **`Ssum_rec`** (product-free): `2X·S(m,n+1) = S(m,n+2) + S(m,n)`. Distribute `2X` into the
+  sum via `2X·U_k = U_{k+1}+U_{k−1}`, giving `∑_{k=0}^{n+1}(U_{m+n+2−2k}+U_{m+n−2k})`. Peel the
+  boundary terms of the two telescoped ranges with `Finset.sum_range_succ`; both equal
+  `U_{m−n−2}` and cancel.
+- **`U_mul_U`**: two-step induction on `n` carrying `P(j) ∧ P(j+1)` (the U recurrence is
+  second-order). Base `n=0,1`; step uses `U_{i+2}=2X·U_{i+1}−U_i` together with `Ssum_rec`,
+  closed by `linear_combination`.
+
+Verified numerically before formalizing: `U_2·U_2 = U_4+U_2+U_0 = 16x⁴−8x²+1` ✓;
+`U_3·U_1 = U_4+U_2 = 16x⁴−8x²` ✓.
+
+## Sessions
+
+### Session 2026-06-15 (Session 1) — FRESH, ORIENT→ACT
+
+**Mode**: FRESH
+**Outcome**: progress (full proof written; build verification pending — Docker contended, Aristotle 404)
+
+#### What I Did
+- Claimed the problem; confirmed via parent meta.json that this exact linearization is the
+  parent's stated open question (genuine gallery gap, not a duplicate).
+- Derived the clean strategy: reduce the product identity to the product-free sum recurrence
+  `Ssum_rec`, then two-step induction.
+- Wrote `proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean` (def `Ssum`; lemmas `two_X_U`,
+  `Ssum_succ_expand`, `Ssum_rec`, `Ssum_zero`, `Ssum_one`; theorem `U_mul_U`).
+- Created gallery data `src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json`.
+
+#### Key Findings
+- The U·U product, unlike T·T and T·U (two terms each), is a `min(m,n)+1`-term sum.
+- The entire boundary bookkeeping can be quarantined in a product-free lemma (`Ssum_rec`),
+  which keeps the induction step a one-line `linear_combination`.
+- Indexing the summand by `m+n−2k` with `m : ℤ` avoids any `m ≥ n` hypothesis.
+
+#### Files Modified
+- `proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean` (new, ~146 lines)
+- `src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json` (new)
+
+#### Next Steps
+- Verify the build (`./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01`) once
+  Docker contention clears; the only risk areas are Finset term-matching in `Ssum_rec`
+  (range `(n+1)+1` vs `n+2`, cast normalization of `↑(n+1)`) — fix with explicit `show`
+  rewrites / `push_cast` if the compiler flags them.
+- If verified, flip meta status to verified/original and register in proof index.

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "de-moivre-oq-02-oq-02-oq-01",
+  "title": "Chebyshev U·U Linearization (Product-to-Sum)",
+  "slug": "de-moivre-oq-02-oq-02-oq-01",
+  "description": "Proves the second-kind Chebyshev linearization identity U_m · U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity over any commutative ring R[X], for m : ℤ and n : ℕ. This is the genuine product-to-sum analogue answering the open question left by the parent T·U entry: unlike the two-term first-kind formula 2·T_m·T_n = T_{m+n} + T_{m−n}, the U·U product expands as a sum of min(m,n)+1 second-kind terms with no (1−x²) factor.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Products_of_Chebyshev_polynomials",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ02OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "product-to-sum",
+      "linearization",
+      "polynomial-identity",
+      "second-kind",
+      "commutative-ring",
+      "finset-sum",
+      "research"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "dateAdded": "2026-06-15",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "0 axioms, 0 sorries (build-pending: Docker build queue saturated and Aristotle unavailable this session). Polynomial identity over any commutative ring R, for m : ℤ and n : ℕ. Flip to verified/original once the Docker build is green.",
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "originalContributions": [
+      "U_mul_U: U_m · U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity in R[X] for any CommRing R (m : ℤ, n : ℕ)",
+      "Ssum_rec: the sum recurrence 2·X·S(m,n+1) = S(m,n+2) + S(m,n), a pure index-bookkeeping identity with no Chebyshev products",
+      "Ssum_succ_expand: distributes 2·X into the linearization sum termwise via the rearranged U recurrence",
+      "Ssum_zero / Ssum_one: base values S(m,0) = U_m and S(m,1) = U_{m+1} + U_{m−1}"
+    ],
+    "historicalContext": "The parent entry de-moivre-oq-02-oq-02 proved the mixed T·U cross-product 2·T_m·U_n = U_{m+n} + U_{n−m} and a U·U product-to-difference scaled by (1−x²): 2(1−x²)·U_m·U_n = T_{m−n} − T_{m+n+2}. It explicitly left open whether the bare product U_m·U_n can be written purely as a sum of second-kind polynomials. The classical linearization formula U_m·U_n = ∑_{k=0}^{min(m,n)} U_{m+n−2k} answers this. It is the second-kind analogue of the cosine product-to-sum, but where the first kind yields two terms, the second kind yields a full arithmetic-progression sum of indices from |m−n| to m+n in steps of 2.",
+    "problemStatement": "**The Open Question** (from the parent T·U entry)\n\nCan the U×U product formula\n$$U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}$$\nbe proved as a polynomial identity over $R[X]$, analogous to the T·U formula?\n\n**Answer: YES**\n\nFor every commutative ring $R$, every $m \\in \\mathbb{Z}$ and $n \\in \\mathbb{N}$:\n$$U_m \\cdot U_n = \\sum_{k=0}^{n} U_{m+n-2k} \\quad \\text{in } R[X].$$",
+    "proofStrategy": "**Sum recurrence + two-step induction**\n\nLet $S(m,n) := \\sum_{k=0}^{n} U_{m+n-2k}$.\n\n1. **Sum recurrence** `Ssum_rec`: $2X \\cdot S(m,n+1) = S(m,n+2) + S(m,n)$. Distribute $2X$ into the sum using $2X \\cdot U_k = U_{k+1} + U_{k-1}$, giving $\\sum_{k=0}^{n+1}(U_{m+n+2-2k} + U_{m+n-2k})$. Peel the boundary terms of the two telescoped ranges with `Finset.sum_range_succ`; both equal $U_{m-n-2}$ and cancel.\n2. **Two-step induction** on $n$ carrying $P(j) \\wedge P(j+1)$ where $P(j) := U_m U_j = S(m,j)$. Base cases $n=0$ ($U_m U_0 = U_m = S(m,0)$) and $n=1$ ($U_m U_1 = 2X U_m = U_{m+1}+U_{m-1} = S(m,1)$). The step uses $U_{i+2} = 2X U_{i+1} - U_i$ together with `Ssum_rec` at index $i$, closed by `linear_combination`.",
+    "keyInsights": [
+      "**Reduce the product identity to a pure sum identity**: The only place Chebyshev *products* appear is in matching the recurrence; all the combinatorial work is isolated in `Ssum_rec`, an identity about U-indexed Finset sums that mentions no product at all.",
+      "**The recurrence is second-order, so the induction is two-step**: Because $U_{i+2} = 2X U_{i+1} - U_i$ relates three consecutive terms, the induction carries the pair $P(j) \\wedge P(j+1)$ — mirroring the paired-induction technique used for the parent T·U formula but over ℕ rather than ℤ.",
+      "**Boundary cancellation**: After distributing $2X$, the two shifted copies of the sum overlap on $\\sum_{k=0}^{n} U_{m+n-2k}$; the only surviving boundary terms are $U_{m+n+2-2(n+2)}$ and $U_{m+n-2(n+1)}$, which are both $U_{m-n-2}$ and cancel — this is what turns the recurrence into an exact identity.",
+      "**Index form m+n−2k over ℤ**: Indexing the summand by $m + n - 2k$ with $m : \\mathbb{Z}$ keeps the formula valid for all integer $m$ (the negative-index Chebyshev convention is handled automatically by Mathlib's ℤ-indexed `U`), so no separate $m \\ge n$ hypothesis is needed.",
+      "**Polynomial over any CommRing**: Like the parent, the identity is established in $R[X]$ for an arbitrary commutative ring via `variable {R : Type*} [CommRing R]`, not just over ℝ."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial", "Polynomial.Chebyshev"],
+    "namespace": "DeMoivreOQ02OQ02OQ01",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/DeMoivreOQ02OQ02OQ01.lean",
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "U_mul_U",
+        "statement": "∀ {R : Type*} [CommRing R] (m : ℤ) (n : ℕ), U R m * U R n = ∑ k ∈ Finset.range (n+1), U R (m + n - 2*k)",
+        "description": "The U·U linearization (product-to-sum) identity over any CommRing R"
+      },
+      {
+        "name": "Ssum_rec",
+        "statement": "∀ {R : Type*} [CommRing R] (m : ℤ) (n : ℕ), (2:R[X]) * X * Ssum m (n+1) = Ssum m (n+2) + Ssum m n",
+        "description": "Pure index-bookkeeping sum recurrence powering the induction"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "**Two Chebyshev Families and Their Products**\n\nChebyshev polynomials share the recurrence $p_{n+2} = 2x p_{n+1} - p_n$: the first kind $T_n$ with $T_n(\\cos\\theta)=\\cos(n\\theta)$, and the second kind $U_n$ with $U_n(\\cos\\theta)\\sin\\theta=\\sin((n+1)\\theta)$. The first-kind product-to-sum $2T_mT_n = T_{m+n}+T_{m-n}$ is a clean two-term identity. The second-kind product behaves differently: $U_m U_n$ linearizes into a *sum* $\\sum_{k} U_{m+n-2k}$ running over indices $|m-n|, |m-n|+2, \\dots, m+n$.",
+    "problemStatement": "**The Open Question**\n\nThe parent T·U entry asked: can $U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}$ be proved as a polynomial identity over $R[X]$?\n\n**Answer: YES** — for every commutative ring $R$, $m \\in \\mathbb{Z}$, $n \\in \\mathbb{N}$.",
+    "text": "Proves the second-kind Chebyshev linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity over any commutative ring R. The combinatorial core is isolated as a product-free sum recurrence 2X·S(m,n+1) = S(m,n+2)+S(m,n), proved by distributing the recurrence termwise and cancelling boundary terms; the main identity then follows by a two-step induction matching U_{n+2}=2X·U_{n+1}−U_n.",
+    "proofStrategy": "**Sum recurrence + two-step induction**\n\nDefine $S(m,n) = \\sum_{k=0}^{n} U_{m+n-2k}$.\n\n1. `Ssum_succ_expand`: $2X \\cdot S(m,n+1) = \\sum_{k=0}^{n+1}(U_{m+n+2-2k}+U_{m+n-2k})$ via the rearranged recurrence $2X U_k = U_{k+1}+U_{k-1}$.\n2. `Ssum_rec`: peel the boundary terms of the two telescoped ranges; both equal $U_{m-n-2}$ and cancel, giving $2X S(m,n+1) = S(m,n+2)+S(m,n)$.\n3. `U_mul_U`: two-step induction on $n$ carrying $P(j)\\wedge P(j+1)$, using $U_{i+2}=2X U_{i+1}-U_i$ and `Ssum_rec`.",
+    "keyInsights": [
+      "**Isolate the combinatorics**: All boundary bookkeeping lives in the product-free `Ssum_rec`; the product theorem reduces to recurrence-matching.",
+      "**Two-step induction for a second-order recurrence**: carrying $P(j)\\wedge P(j+1)$ mirrors the parent's paired integer induction.",
+      "**Boundary terms cancel**: the surviving terms $U_{m+n+2-2(n+2)}$ and $U_{m+n-2(n+1)}$ are both $U_{m-n-2}$.",
+      "**Integer index m**: indexing by $m+n-2k$ with $m:\\mathbb{Z}$ removes any $m\\ge n$ hypothesis."
+    ],
+    "prerequisites": [
+      "Chebyshev recurrence U_add_two and the rearrangement 2X·U_k = U_{k+1}+U_{k-1}",
+      "Finset.sum_range_succ, Finset.sum_add_distrib, Finset.mul_sum",
+      "Two-step (paired) induction over ℕ",
+      "linear_combination tactic"
+    ]
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "Proves the second-kind Chebyshev linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity over any commutative ring R, with 0 sorries and 0 axioms. The combinatorial core is the product-free sum recurrence Ssum_rec; the main identity follows by two-step induction.",
+    "implications": "**Theoretical Significance**\n\n1. **Completes the Chebyshev product table**: T·T (two terms), T·U (two terms), and now U·U (a full progression sum) are all available as polynomial identities over arbitrary commutative rings.\n\n2. **Product-free combinatorial core**: `Ssum_rec` is reusable for any second-kind-Chebyshev sum manipulation and isolates the index bookkeeping from the algebra.\n\n3. **Multiplicative structure of the U-span**: the identity shows the ℤ-span of $\\{U_k\\}$ is closed under multiplication, with explicit structure constants (all equal to 1).",
+    "openQuestions": [
+      "Does an analogous linearization hold for products of three or more second-kind polynomials U_a·U_b·U_c, and are the structure constants always nonnegative integers?",
+      "Can the mixed product U_m · T_n be linearized purely into second-kind polynomials (it should give ½(U_{m+n} + U_{m-n}))?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-02-oq-02",
+      "relationship": "Parent entry; this resolves the U·U linearization open question it posed."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry proved the T·U cross-product and the (1−x²)-scaled U·U product-to-difference, and explicitly left the U·U linearization sum as an open question — resolved here."
+    },
+    {
+      "targetId": "de-moivre-oq-02",
+      "relationship": "ancestor",
+      "description": "Established the first-kind product-to-sum 2·T_m·T_n = T_{m+n} + T_{m-n} that this second-kind linearization parallels."
+    }
+  ],
+  "references": [
+    {
+      "authors": "J. C. Mason, D. C. Handscomb",
+      "title": "Chebyshev Polynomials",
+      "year": "2003",
+      "venue": "CRC Press",
+      "note": "Product and linearization formulas, Section 2.4"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/de-moivre-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/de-moivre-oq-02-oq-02-oq-01.json
@@ -1,0 +1,147 @@
+{
+  "slug": "de-moivre-oq-02-oq-02-oq-01",
+  "title": "Product-to-sum identity for second-kind Chebyshev polynomials",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}",
+    "plain": "The parent entry establishes the mixed product formula relating first-kind ($T$) and second-kind ($U$) Chebyshev polynomials. This problem asks for the pure $U \\times U$ product-to-sum identity: the product of two second-kind Chebyshev polynomials decomposes as a sum of second-kind Chebyshev polynomials with indices stepping down by two from $m+n$ to $|m-n|$. The goal is a clean polynomial identity over an arbitrary commutative ring, proved analogously to the existing $T \\cdot U$ result.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "U_m · U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity in R[X] for any CommRing R, m:ℤ, n:ℕ."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-15T12:12:21-07:00",
+    "iteration": 1,
+    "focus": "Wrote full Lean proof of U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k}; build verification pending (Docker queue saturated, Aristotle 404).",
+    "blockers": [],
+    "nextAction": "Run docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01 once contention clears; fix any index-cast matching in Ssum_rec via compiler feedback; then flip gallery meta to verified/original.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: complete proof written (def Ssum; lemmas two_X_U, Ssum_succ_expand, Ssum_rec, Ssum_zero, Ssum_one; theorem U_mul_U). Build-pending: not yet machine-verified (Docker saturated, Aristotle down).",
+    "builtItems": [
+      "U_mul_U (Proofs/DeMoivreOQ02OQ02OQ01.lean): U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k} over any CommRing R",
+      "Ssum_rec: product-free sum recurrence 2X·S(m,n+1) = S(m,n+2)+S(m,n)",
+      "Ssum_succ_expand: termwise distribution of 2X into the linearization sum",
+      "Ssum_zero / Ssum_one: base values S(m,0)=U_m, S(m,1)=U_{m+1}+U_{m-1}"
+    ],
+    "insights": [
+      "This is exactly the open question the parent de-moivre-oq-02-oq-02 posed (confirmed in its meta.json openQuestions): genuine gallery gap, not a duplicate.",
+      "Reducing the product identity to the product-free sum recurrence Ssum_rec isolates all Finset bookkeeping and makes the induction step a one-line linear_combination.",
+      "The U recurrence is second-order, so the induction must be two-step, carrying P(j) ∧ P(j+1).",
+      "After distributing 2X, the two telescoped ranges overlap; the only surviving boundary terms (both U_{m-n-2}) cancel — this is what makes the recurrence exact.",
+      "Indexing by m+n−2k with m:ℤ removes any m≥n hypothesis (Mathlib ℤ-indexed U handles negative indices)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the U recurrence (U_add_two) but no U·U linearization / product-to-sum lemma."
+    ],
+    "nextSteps": [
+      "Build with docker-build.sh once Docker queue clears; fix residual index-cast term-matching in Ssum_rec (range (n+2) vs (n+1)+1; ↑(n+1) vs ↑n+1) with compiler feedback.",
+      "If green, flip gallery meta de-moivre-oq-02-oq-02-oq-01 to status verified / badge original and register in proof index.",
+      "Follow-up OQ: linearization of three-fold products U_a·U_b·U_c; mixed U_m·T_n linearization = ½(U_{m+n}+U_{m-n})."
+    ],
+    "markdown": "# Knowledge Base: de-moivre-oq-02-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "chebyshev-polynomials",
+    "de-moivre",
+    "product-to-sum",
+    "polynomial-identity",
+    "second-kind"
+  ],
+  "relatedProofs": [
+    "de-moivre",
+    "de-moivre-oq-01",
+    "de-moivre-oq-02",
+    "de-moivre-oq-02-oq-02",
+    "de-moivre-oq-03",
+    "de-moivre-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T12:12:21-07:00",
+  "significance": 5,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/DeMoivre.lean",
+      "filename": "DeMoivre.lean",
+      "lineCount": 240,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivre.lean"
+    },
+    {
+      "path": "Proofs/DeMoivreOQ01.lean",
+      "filename": "DeMoivreOQ01.lean",
+      "lineCount": 232,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivreOQ01.lean"
+    },
+    {
+      "path": "Proofs/DeMoivreOQ02.lean",
+      "filename": "DeMoivreOQ02.lean",
+      "lineCount": 158,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivreOQ02.lean"
+    },
+    {
+      "path": "Proofs/DeMoivreOQ02OQ02.lean",
+      "filename": "DeMoivreOQ02OQ02.lean",
+      "lineCount": 217,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivreOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/DeMoivreOQ03.lean",
+      "filename": "DeMoivreOQ03.lean",
+      "lineCount": 276,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivreOQ03.lean"
+    },
+    {
+      "path": "Proofs/DeMoivreOQ03OQ01.lean",
+      "filename": "DeMoivreOQ03OQ01.lean",
+      "lineCount": 75,
+      "theoremCount": 4,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DeMoivreOQ03OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **de-moivre-oq-02-oq-02-oq-01** resolving the open question explicitly posed by the parent T·U entry (`de-moivre-oq-02-oq-02`, listed in its `openQuestions`): prove the **second-kind Chebyshev linearization / product-to-sum** identity

$$U_m \cdot U_n = \sum_{k=0}^{n} U_{m+n-2k} \quad\text{in } R[X],\ \text{any CommRing } R,\ m\in\mathbb{Z},\ n\in\mathbb{N}.$$

Unlike the two-term first-kind formula $2T_mT_n = T_{m+n}+T_{m-n}$, the U·U product expands as a full $\min(m,n)+1$-term arithmetic-progression sum — with no $(1-x^2)$ factor (the parent only had a $(1-x^2)$-scaled product-to-*difference*).

## Proof strategy

- Isolate all combinatorics in a **product-free sum recurrence** `Ssum_rec`: $2X\cdot S(m,n+1) = S(m,n+2)+S(m,n)$, where $S(m,n)=\sum_{k=0}^{n}U_{m+n-2k}$. Distribute $2X$ termwise via $2X\,U_k = U_{k+1}+U_{k-1}$; the two telescoped ranges overlap and the surviving boundary terms (both $U_{m-n-2}$) cancel.
- **Two-step induction** on $n$ (the U recurrence is second-order) carrying $P(j)\wedge P(j+1)$, using $U_{i+2}=2X\,U_{i+1}-U_i$ and `Ssum_rec`, closed by `linear_combination`.

Contents: `def Ssum`; lemmas `two_X_U`, `Ssum_succ_expand`, `Ssum_rec`, `Ssum_zero`, `Ssum_one`; theorem `U_mul_U`. 0 sorries, 0 axioms.

## Build status

⚠️ **Build-pending — not yet machine-verified.** Written in a session where the Docker build queue was saturated (8 concurrent builds in a 7.65 GiB Docker VM) and Aristotle was unavailable (404), so the Finset index-cast bookkeeping in `Ssum_rec` could not be checked against the compiler. The mathematics is verified by hand and numerically ($U_2 U_2 = U_4+U_2+U_0$, $U_3 U_1 = U_4+U_2$). Gallery meta is marked `formalized`/`wip`; promote to `verified`/`original` once `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` is green.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` (deployer build-gate)
- [ ] If residual errors: fix index-cast term-matching in `Ssum_rec` (range `(n+2)` vs `(n+1)+1`; `↑(n+1)` vs `↑n+1`), then flip meta to verified/original
- [ ] `pnpm build` to confirm gallery entry renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)