### PR TITLE
Enrich Ham Sandwich (brouwer-fixed-point-oq-01-oq-03-oq-01): fix invalid significance enum

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
@@ -55,7 +55,7 @@
     "title": "Oddness of the Discrepancy is Continuity-Free",
     "content": "**discrepancy_odd_of_swap** proves the signed half-volume discrepancy $D_i$ is odd using only the antipodal swap of half-spaces. Reversing orientation ($x \\mapsto -x$) sends $\\mathrm{pos}\\,x\\,i$ to $\\mathrm{neg}\\,x\\,i$ and vice versa, so $D_i(-x) = \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{neg}\\,x\\,i) - \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{pos}\\,x\\,i) = -D_i(x)$. The proof is `unfold`, `rw [hswap, hswap']`, `ring`.",
     "mathContext": "This is the elementary, measure-additive half of the Ham Sandwich construction. It requires no continuity, no dominated convergence, no measurability — just set equality of the swapped half-spaces and arithmetic of the resulting real volumes.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": [
       "signed measure discrepancy",
       "antipodal swap",
@@ -99,7 +99,7 @@
     "title": "Discharging the Vector-Assembly Step",
     "content": "**ham_sandwich_of_scalar_continuity** sharpens the analytic input from a vector statement to a scalar one. It assumes only that each scalar slice-volume $x \\mapsto \\mathrm{vol}(\\mathrm{body}_i \\cap \\mathrm{pos}\\,x\\,i).\\mathrm{toReal}$ (and the neg version) is continuous, then assembles the continuous EuclideanSpace-valued discrepancy via $(\\mathrm{EuclideanSpace.equiv}\\,(Fin\\,n)\\,\\mathbb{R}).\\mathrm{symm} \\circ$ `continuous_pi`. The component-agreement hypothesis of the capstone holds by `rfl`, so no `SphereFun` is assumed — it is built.",
     "mathContext": "EuclideanSpace carries the L² topology, not the product topology, so `continuous_pi` does not apply directly to a map into it. But `EuclideanSpace.equiv (Fin n) ℝ` is a homeomorphism to `Fin n → ℝ`, so a map into EuclideanSpace is continuous iff its composition with `.symm` is — reducing vector continuity to componentwise (scalar) continuity.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": [
       "EuclideanSpace.equiv",
       "continuous_pi",


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-03-oq-01`.

Two annotations carried `significance: "important"`, which is not a valid value — the renderer/enum recognizes only `key | supporting | technical | context`. Both annotations describe load-bearing proof steps (the continuity-free oddness lemma `discrepancy_odd_of_swap` and the scalar-continuity discharge `ham_sandwich_of_scalar_continuity`), matching the surrounding `key` annotations.

- `hs-discrepancy-odd`: `important` -> `key`
- `hs-scalar-continuity`: `important` -> `key`

Annotations-only change; does not touch meta.json (open PR #24756 owns the conclusion block on this slug).