### PR TITLE
Enrich Minkowski Bound on Ideal Norms (minkowski-theorem-oq-03)

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/annotations.json
@@ -28,7 +28,7 @@
     "title": "Naming the Minkowski Bound",
     "content": "`minkowskiIdealBound K` is defined to be exactly the expression behind Mathlib's local notation `M K`. Because the two are definitionally identical, every Mathlib lemma stated with `M K` can be re-used against the named constant by simple unfolding. `minkowskiIdealBound_nonneg` records that the bound is ≥ 0 (a product of nonnegative factors), which is the only hypothesis needed to floor it.",
     "mathContext": "$M_K = (4/\\pi)^{r_2} \\cdot \\dfrac{n!}{n^n} \\cdot \\sqrt{|d_K|} \\ge 0$ since each factor is nonnegative.",
-    "significance": "infrastructure",
+    "significance": "supporting",
     "relatedConcepts": ["Minkowski bound", "discriminant", "complex places"],
     "prerequisites": ["finrank", "NumberField.discr", "Real.sqrt"]
   },
@@ -40,7 +40,7 @@
     "title": "Minkowski's Ideal-Norm Bound",
     "content": "`exists_ideal_in_class_absNorm_le`: every ideal class C contains an integral ideal I with mk0 I = C and (absNorm I : ℝ) ≤ minkowskiIdealBound K. The proof unfolds the named bound and applies Mathlib's `NumberField.exists_ideal_in_class_of_norm_le` directly — this is the precise sense in which the geometry of numbers bounds ideal norms.",
     "mathContext": "Every class $C \\in \\mathrm{Cl}(\\mathcal{O}_K)$ has a representative integral ideal $I$ with $\\mathrm{absNorm}(I) \\le M_K$.",
-    "significance": "key-result",
+    "significance": "key",
     "relatedConcepts": ["ideal class group", "ideal norm", "Minkowski bound"],
     "prerequisites": ["NumberField.exists_ideal_in_class_of_norm_le", "ClassGroup.mk0"]
   },
@@ -52,7 +52,7 @@
     "title": "An Explicit Bound on the Class Number",
     "content": "`classNumber_le_card_absNorm_le`: classNumber K ≤ #{ I : absNorm I ≤ ⌊M_K⌋ }. The index set is finite (`Ideal.finite_setOf_absNorm_le₀`); the class-representative map is surjective because every class has a representative of norm ≤ M_K, floored to ⌊M_K⌋ via `Nat.le_floor`; and a surjection from a finite set bounds cardinality (`Nat.card_le_card_of_surjective`), with `classNumber = Fintype.card (ClassGroup …) = Nat.card (ClassGroup …)`.",
     "mathContext": "$\\#\\mathrm{Cl}(\\mathcal{O}_K) \\le \\#\\{\\, I : \\mathrm{absNorm}(I) \\le \\lfloor M_K\\rfloor \\,\\}$. This is the formal justification for the standard class-number algorithm: enumerating ideals below the Minkowski bound already meets every ideal class.",
-    "significance": "key-result",
+    "significance": "key",
     "relatedConcepts": [
       "class number",
       "finiteness of the class group",

--- a/src/data/proofs/minkowski-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/meta.json
@@ -48,6 +48,20 @@
       "This estimate is the formal backbone of the standard class-number algorithm: it certifies that enumerating ideals of norm $\\le \\lfloor M_K\\rfloor$ already exhausts every ideal class, so no class is missed when computing the class group by hand."
     ]
   },
+  "conclusion": {
+    "summary": "The geometry-of-numbers bound on ideal norms is repackaged into a directly usable form. Mathlib's Minkowski bound $M_K = (4/\\pi)^{r_2}(n!/n^n)\\sqrt{|d_K|}$ — previously buried as a `local notation` inside `ClassNumber.lean` and therefore unreferenceable downstream — is reintroduced as the plain definition `minkowskiIdealBound K`, character-for-character identical to the notation's expansion. Against this named constant the ideal-norm bound `exists_ideal_in_class_absNorm_le` restates Mathlib's `exists_ideal_in_class_of_norm_le` by definitional unfolding, and the new theorem `classNumber_le_card_absNorm_le` proves the explicit head-count $\\mathrm{classNumber}\\,K \\le \\#\\{I : \\mathrm{absNorm}\\,I \\le \\lfloor M_K\\rfloor\\}$. The argument is short (0 axioms, 0 sorries): the index set is finite, the class-representative map is surjective via `Nat.le_floor`, and `Nat.card_le_card_of_surjective` converts surjectivity-from-a-finite-set into the cardinality inequality.",
+    "implications": [
+      "Upgrades a qualitative result (the class group is finite) into a quantitative, computable bound. Finiteness alone gives no handle on how many classes there are or where to look for representatives; the head-count certifies that the finite search 'enumerate every ideal of norm $\\le \\lfloor M_K\\rfloor$' provably exhausts the class group, which is exactly the loop invariant the textbook class-number algorithm relies on.",
+      "Exposes a piece of reusable infrastructure. Because `minkowskiIdealBound K` is a genuine definition rather than file-local notation, any downstream development — quadratic-field worked examples, Euclidean-domain criteria, or bounds on the class number in families — can now refer to the Minkowski bound by name and inherit the ideal-norm estimate by a one-line `unfold`.",
+      "Isolates the single analytic input. The only place the real numbers enter is the real-to-natural collapse $\\mathrm{absNorm}\\,I \\le M_K \\Rightarrow \\mathrm{absNorm}\\,I \\le \\lfloor M_K\\rfloor$, valid because $M_K \\ge 0$; everything else is finiteness bookkeeping. This separation makes the proof a clean template for turning other real-valued geometry-of-numbers bounds into integer head-counts.",
+      "Connects directly to the parent Minkowski entry and to its Diophantine-approximation sibling: all three route the same lattice-point theorem into number theory, here producing the tightest classical control on the ideal class group."
+    ],
+    "openQuestions": [
+      "Can the head-count be turned into an effective computation for concrete fields? Instantiating `classNumber_le_card_absNorm_le` for, say, $\\mathbb{Q}(\\sqrt{d})$ requires a decidable enumeration of ideals of norm $\\le \\lfloor M_K\\rfloor$ together with a discriminant instance — the latter is a known Mathlib gap for general quadratic fields.",
+      "Does Mathlib admit a sharper constant? The classical Minkowski bound is not optimal; the analytic class number formula and improvements due to Rogers and others lower the constant. Formalizing even a modest refinement would tighten this head-count and shrink the algorithmic search space.",
+      "Can the surjective-map argument be reused verbatim to bound other arithmetic invariants — for instance the number of ideal classes in a given genus, or the size of the narrow class group — by replacing the target group while keeping the finite index set of norm-bounded ideals?"
+    ]
+  },
   "sections": [
     {
       "id": "header-imports",


### PR DESCRIPTION
Enrichment pass for `minkowski-theorem-oq-03` (quality 76, 0 prior passes).

## Changes
- **Added the missing `conclusion` block** — the entry had no conclusion at all. New block has a `summary`, 4 `implications`, and 3 `openQuestions` (effective class-number computation for quadratic fields, sharper Minkowski constants, reusing the surjective-map argument for other arithmetic invariants).
- **Fixed invalid annotation `significance` values** to match the `AnnotationSignificance` enum (`critical | key | supporting`): `infrastructure → supporting`, `key-result → key` (×2).

## Validation
- meta.json and annotations.json validated with `python3 -m json.tool`.
- No changes to Lean source or proof claims; gallery-data only.