### PR TITLE
Enrich schroeder-bernstein-oq-01: fix invalid significance enum

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-01/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-01/annotations.json
@@ -10,7 +10,7 @@
     "title": "OQ-01: Categorical Characterization of the Schroeder-Bernstein Property",
     "content": "The classical Schroeder-Bernstein theorem says Set has the Schroeder-Bernstein property (SBP): mutual injections imply bijection. The categorical generalization asks the same for an arbitrary category, with monomorphisms in place of injections and isomorphism in place of bijection. Banaschewski and Brummer (1986) gave a sufficient 'retraction condition' but the full characterization — necessary AND sufficient axioms for SBP — remains open in categorical foundations. This file does NOT solve that open question. Instead it builds a six-theorem positive/negative corpus locating SBP among Mathlib's categorical primitives: three concrete witnesses (Type, Discrete α, ¬TopCat), two vacuous abstract sufficient conditions ([IsDiscrete C], [IsGroupoid C] — both force Mono = Iso), and one genuinely non-vacuous abstract sufficient condition (full+faithful+monomorphism-preserving forgetful — narrow but admits non-iso monos). 353 lines, 0 sorries, 0 axioms.",
     "mathContext": "A category $\\mathcal{C}$ has the **Schroeder-Bernstein property** (SBP) iff for all $X, Y \\in \\mathrm{Ob}(\\mathcal{C})$, $(\\exists\\, m : X \\hookrightarrow Y\\, \\text{mono}) \\wedge (\\exists\\, n : Y \\hookrightarrow X\\, \\text{mono}) \\Rightarrow X \\cong Y$. Classical SBP holds in $\\mathbf{Set}$ (Bernstein 1898), $\\sigma$-complete Boolean algebras (Sikorski 1948), Hilbert spaces (trivially). Classical SBP fails in $\\mathbf{Grp}$ (Bumby 1965), $\\mathbf{Ban}$ (Gowers 1996), commutative rings, and $\\mathbf{Top}$ — the [0,1] vs (0,1) failure formalized in this file.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Schroeder-Bernstein theorem",
       "monomorphism",
@@ -36,7 +36,7 @@
     "title": "The `HasSBP` Predicate",
     "content": "Defines `HasSBP (C : Type*) [Category C] : Prop := ∀ X Y : C, (∃ m : X ⟶ Y, Mono m) → (∃ n : Y ⟶ X, Mono n) → Nonempty (X ≅ Y)`. The categorical generalization of mutual-injections-imply-bijection: instead of injective functions we require monomorphisms (categorical injections), and instead of a bijection we conclude existence of an isomorphism. The `Nonempty` wrapper sidesteps universe issues with `Exists` over a Type-valued iso.",
     "mathContext": "Formally: $\\mathrm{HasSBP}(\\mathcal{C}) \\iff \\forall\\, X, Y \\in \\mathrm{Ob}(\\mathcal{C}),\\; (X \\hookrightarrow_{\\text{mono}} Y) \\wedge (Y \\hookrightarrow_{\\text{mono}} X) \\Rightarrow X \\cong Y$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Mono (CategoryTheory.Mono)",
       "Iso (CategoryTheory.Iso)",
@@ -58,7 +58,7 @@
     "title": "S2/S3 — `Type u` has SBP",
     "content": "Bridges classical Schroeder-Bernstein into the categorical setting. The three-step tactic: (1) `mono_iff_injective` converts each categorical mono to a `Function.Injective` underlying function; (2) `Function.Embedding.antisymm` runs the classical Schroeder-Bernstein on the resulting `Function.Embedding`s, yielding a Type-equivalence `e`; (3) `Equiv.toIso` promotes `e` to a categorical iso. Non-vacuous witness: the inclusion `{ n // n ∈ s } ↪ ℕ` is a non-iso mono in Type.",
     "mathContext": "In $\\mathbf{Type}\\,u$, $\\mathrm{Mono}(f) \\iff \\mathrm{Injective}(f)$. The classical Schroeder-Bernstein on type embeddings is $(\\alpha \\hookrightarrow \\beta) \\wedge (\\beta \\hookrightarrow \\alpha) \\Rightarrow \\alpha \\simeq \\beta$, formalized as `Function.Embedding.antisymm` in Mathlib's `SetTheory/Cardinal/SchroederBernstein.lean`. The categorical iso is then $e.\\mathrm{toIso}$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "mono_iff_injective in Type",
       "Function.Embedding.antisymm",
@@ -102,7 +102,7 @@
     "title": "S5 — `¬ HasSBP TopCat` via the [0,1] vs (0,1) counterexample",
     "content": "Constructs two private continuous injections — `fHom : [0,1] → (0,1)` via $x \\mapsto (x+1)/4$ (range $[1/4, 1/2] \\subset (0,1)$) and `gHom : (0,1) → [0,1]` (inclusion) — promoted to TopCat monomorphisms via `TopCat.mono_iff_injective`. Suppose HasSBP TopCat held; then we obtain a homeomorphism `[0,1] ≅ (0,1)` and transfer compactness from `[0,1]` to `(0,1)` via `Homeomorph.compactSpace`. `isCompact_Ioo_iff` then forces $1 \\le 0$, contradiction. This is the corpus's NEGATIVE anchor: any future sufficient condition `P` must satisfy `¬ P TopCat`.",
     "mathContext": "Classical topological failure of SBP: $[0,1]$ and $(0,1)$ admit mutual continuous injections but are not homeomorphic — $[0,1]$ is compact (Heine-Borel via `CompactIccSpace`), $(0,1)$ is not (since $1 > 0$). The compression $f(x) = (x+1)/4$ lands in $[1/4, 1/2] \\subset (0,1)$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "TopCat.mono_iff_injective",
       "Homeomorph.compactSpace",
@@ -170,7 +170,7 @@
     "title": "S12 — `(forget C).Full + Faithful + PreservesMono → HasSBP C` (first genuinely non-vacuous)",
     "content": "The corpus's first sufficient condition that does NOT force Mono = Iso. Under `[HasForget C][(forget C).Full][(forget C).Faithful][(forget C).PreservesMonomorphisms]`: step (1) `(forget C).PreservesMonomorphisms` + `mono_iff_injective` (Type) converts each C-mono to a `Function.Injective` underlying map; step (2) `Function.Embedding.antisymm` yields a Type-equivalence `e`; step (3) `Functor.FullyFaithful.ofFullyFaithful (forget C) |>.preimageIso e.toIso` pulls the Type-iso back to a C-iso via the fully-faithful forgetful. NON-vacuous witness: on Type, the embedding `Set.Subtype.val : { n // n ∈ s } ↪ ℕ` is a non-iso mono — yet the proof above produces the required iso. NARROW: `(forget C).Full` essentially restricts C to a full subcategory of Type, excluding `Grp`, `TopCat`, `Ring`, `ModuleCat`. The next horizon is non-vacuous-AND-broader: Path D.ii orbit construction or Path E Banaschewski-Brümmer retraction condition.",
     "mathContext": "If $U = \\mathrm{forget}\\,\\mathcal{C} : \\mathcal{C} \\to \\mathbf{Type}$ is full, faithful, and preserves monos, then any pair of mutual $\\mathcal{C}$-monos $X \\hookrightarrow Y, Y \\hookrightarrow X$ pushes down to mutual injections $UX \\hookrightarrow UY, UY \\hookrightarrow UX$; classical Schroeder-Bernstein gives $UX \\simeq UY$; the iso $UX \\cong UY$ in $\\mathbf{Type}$ then lifts to $X \\cong Y$ in $\\mathcal{C}$ via $U$'s fully-faithful reflection of isos (`Functor.FullyFaithful.preimageIso`).",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "HasForget / concrete category",
       "Functor.Full and Functor.Faithful",


### PR DESCRIPTION
Five annotations used `central` for `significance`, not a valid `AnnotationSignificance` value (`critical | key | supporting`). Mapped to `critical`. Annotations-only, python-validated.