### PR TITLE
Enrich greens-theorem-oq-01-oq-02: fix invalid significance enum

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-02/annotations.json
@@ -42,7 +42,7 @@
     "title": "Orientation reversal = intervalIntegral.integral_symm",
     "content": "`pathLineIntegral_swap_endpoints` proves `pathLineIntegral … b a = - pathLineIntegral … a b`. The proof is one line: unfold the definition, apply `integral_symm`. This is the standard fact 'reversing curve direction negates the line integral' — but we get it for free from the convention `∫ x in a..b = -∫ x in b..a` baked into Mathlib's `intervalIntegral`. No separate orientation theory is needed.",
     "mathContext": "Mathlib's `intervalIntegral.integral_symm : ∫ x in b..a, f x = -∫ x in a..b, f x` is the only ingredient. The orientation-reversal property of line integrals is inherited verbatim from this single sign convention.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "intervalIntegral.integral_symm",
       "orientation of curves"
@@ -59,7 +59,7 @@
     "title": "Edge specializations: horizontal and vertical segments",
     "content": "On the horizontal segment `γ(t) = (t, c)` with velocity `(1, 0)`, the integrand of `pathLineIntegral` simplifies to `P(t, c) · 1 + Q(t, c) · 0 = P(t, c)`. The proof is `integral_congr` (pointwise equality lifts to integral equality) + `simp` (which handles the `*1` and `*0`). Symmetrically for vertical segments. These two lemmas connect each edge of the rectangle parametrization to the corresponding `∫ P(x, c)` or `∫ Q(b, y)` appearing in `rectLineIntegral` from OQ-01.",
     "mathContext": "On a horizontal line $y = c$ parametrized by $x \\in [a, b]$, the parametric line integral becomes $\\int_a^b P(x, c)\\,dx$ — exactly what OQ-01 calls 'the bottom-edge integral'. The smooth-curve framework subsumes the rectangular one without any additional integration steps.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "intervalIntegral.integral_congr",
       "rectLineIntegral edge integrals"
@@ -76,7 +76,7 @@
     "title": "Bridge: four-edge boundary equals rectLineIntegral",
     "content": "`rectBoundaryPathIntegral` parametrizes the rectangle boundary as four straight segments traversed counterclockwise: bottom (left → right), right (bottom → top), top (right → left, written as parameter range `[b, a]`), left (top → bottom, parameter range `[d, c]`). Theorem `pathLineIntegral_rect_boundary_eq_rectLineIntegral` proves this assembly equals OQ-01's `rectLineIntegral` exactly. Proof: rewrite each edge using its specialization lemma, apply `pathLineIntegral_swap_endpoints` to the top and left edges (the parameter ranges are 'backward'), then `ring` closes the algebra. This is the load-bearing identity: the smooth-curve framework strictly extends OQ-01's rectangular formulation, recovering it on the nose.",
     "mathContext": "Counterclockwise traversal of $\\partial([a,b] \\times [c,d])$ has top and left edges parametrized 'backward' relative to the natural rectangle orientation. The two `swap_endpoints` applications produce the −∫ P(x,d) dx and −∫ Q(a,y) dy terms of `rectLineIntegral`; bottom and right contribute positively. After substitution, `ring` checks the four-term arithmetic.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "rectLineIntegral",
       "counterclockwise orientation",
@@ -114,7 +114,7 @@
     "title": "Summary corollary: smooth-curve framework recovers rectangular case",
     "content": "`oq02_summary` restates the bridge identity as the headline result: `rectBoundaryPathIntegral = rectLineIntegral`. This is the OQ-02 answer in one line — the smooth-curve framework strictly extends OQ-01's rectangular formulation, with the four-edge parametrization recovering the rectangular case exactly. Combined with OQ-01's `greens_theorem_concrete`, this gives a complete proof of Green's theorem on rectangles via the smooth-curve definition: the rectangle boundary (parametrized as four smooth segments) integrates to the same value `rectDoubleIntegral` of the curl.",
     "mathContext": "The framework defined here is a true extension: every result OQ-01 proves about `rectLineIntegral` lifts to `rectBoundaryPathIntegral`, and the framework additionally accepts arbitrary smooth and piecewise-smooth boundaries (with the general identity captured by `greens_theorem_smooth_boundary`).",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "extension of formalizations",
       "consistency check"


### PR DESCRIPTION
Four annotations used `core` for `significance`, not a valid `AnnotationSignificance` value (`critical | key | supporting`). Mapped to `critical`. Annotations-only, python-validated.