### PR TITLE
research(cube-root-3-irrational-oq-04): S31 — 26th CF convergent upper bound (a25=1)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -973,4 +973,35 @@ theorem one_zero_six_two_seven_nine_zero_nine_five_eight_five_two_nine_over_seve
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-- **Twenty-sixth continued-fraction convergent of `∛3`** (upper bound).
+
+With `a₂₅ = 1`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`, `qₖ = aₖ qₖ₋₁ + qₖ₋₂`
+on the 24th/25th convergents `247706213128/171749895599` and
+`1062790958529/736898093374` gives the 26th convergent
+
+  `p₂₅ = 1·1062790958529 + 247706213128 = 1_310_497_171_657`
+  `q₂₅ = 1·736898093374 + 171749895599 = 908_647_988_973`.
+
+After cubing,
+
+  `1_310_497_171_657³  = 2_250_651_560_380_673_959_224_590_979_389_530_393`
+  `3 · 908_647_988_973³ = 2_250_651_560_380_673_959_224_589_825_052_769_951`
+
+so `3 · 908_647_988_973³ < 1_310_497_171_657³` (strict, diff `1_154_336_760_442`),
+hence `3 < (1310497171657/908647988973)³` and
+`cbrt3 < 1310497171657/908647988973` as required for an upper bound (odd
+convergent index `25`; relative gap `≈ 1.7·10⁻²⁵`).
+
+`a₂₅ = 1` was re-derived independently from a 160-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s31_26th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline: never re-quote a prior sketch tail, always recompute `aᵢ` and verify
+the cube-side direction before claiming.  This is the next uncontested rung above
+the 25th convergent; a routine, durable helper bound, not a deep result.
+Two-line proof via the upper cubing-iff helper. -/
+theorem cbrt3_lt_one_three_one_zero_four_nine_seven_one_seven_one_six_five_seven_over_nine_zero_eight_six_four_seven_nine_eight_eight_nine_seven_three :
+    cbrt3 < (1310497171657 / 908647988973 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1284,3 +1284,15 @@ lower-side direction for even index 24); cert
 Two-line proof via `lt_cbrt3_iff_cube_lt`. Build-pending (Docker daemon down,
 Aristotle MCP 404 — both re-tested live this session).
 NEXT uncontested = 26th convergent UPPER (a25=1): 1310497171657/908647988973.
+
+## Current Focus (S31, researcher-9, 2026-06-15)
+Added the 26th CF convergent UPPER bound `cbrt3 < 1310497171657/908647988973` (a25=1)
+to the Helpers ladder — the next uncontested rung above the 25th (S30). Exact cube
+check `p³-3q³ = +1154336760442 > 0` ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (correct
+upper-side direction for odd index 25); cert
+`verify_cbrt3_oq04_s31_26th_convergent.py` PASS (a25=1 re-derived from 160-digit CF;
+relative gap ≈ 1.7·10⁻²⁵). Two-line proof via `cbrt3_lt_iff_three_lt_cube`.
+Build-pending (Docker VM oversubscribed: 9 concurrent lean-build containers on the
+7.65 GiB VM — building would OOM peers; Aristotle MCP 404 — both re-tested live).
+NEXT uncontested = 27th convergent LOWER (a26=4): recompute p26/q26 = 4·p25+p24 over
+4·q25+q24 and verify `3q³-p³>0` before claiming.

--- a/research/scripts/verify_cbrt3_oq04_s31_26th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s31_26th_convergent.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Certificate for cube-root-3-irrational-oq-04 S31: the 26th continued-fraction
+convergent of ∛3 is a valid UPPER bound (cbrt3 < 1310497171657/908647988973).
+
+Independently re-derives the CF expansion of ∛3 to 160 digits, the 26th
+convergent via the recursion, and the EXACT-INTEGER cube-direction check
+p^3 vs 3 q^3 (the inequality `norm_num` discharges in the Lean theorem
+`cbrt3_lt_one_three_one_zero_four_nine_seven_one_seven_one_six_five_seven_over_...`).
+
+The 26th convergent has odd index (25), so it lies on the UPPER side of ∛3
+(alternating with the lower-side 25th convergent 1062790958529/736898093374).
+
+Anti-typo discipline (a8/a14 history): the partial quotients are recomputed from
+scratch, never re-quoted from a prior sketch tail.
+
+Docker-independent. Requires mpmath.
+"""
+import mpmath as mp
+
+mp.mp.dps = 160
+
+
+def cf_expansion(x, n):
+    a = []
+    for _ in range(n):
+        ai = int(mp.floor(x))
+        a.append(ai)
+        frac = x - ai
+        if frac == 0:
+            break
+        x = 1 / frac
+    return a
+
+
+def convergents(a):
+    pm1, pm2 = 1, 0
+    qm1, qm2 = 0, 1
+    out = []
+    for ak in a:
+        p = ak * pm1 + pm2
+        q = ak * qm1 + qm2
+        out.append((ak, p, q))
+        pm2, pm1 = pm1, p
+        qm2, qm1 = qm1, q
+    return out
+
+
+def main():
+    c = mp.cbrt(3)
+    a = cf_expansion(c, 28)
+    print("CF a[0..27] =", a[:28])
+    assert a[:26] == [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+                      1, 3, 2, 3, 4, 1], "CF prefix mismatch"
+    assert a[25] == 1, f"a25 expected 1, got {a[25]}"
+
+    conv = convergents(a)
+    a25, p25, q25 = conv[25]                    # 26th convergent (index 25)
+    print(f"a25 = {a25}")
+    print(f"26th convergent p25/q25 = {p25}/{q25}")
+    assert (p25, q25) == (1310497171657, 908647988973), "convergent mismatch"
+
+    # exact recursion check from the 24th/25th convergents
+    _, p23, q23 = conv[23]
+    _, p24, q24 = conv[24]
+    assert p25 == 1 * p24 + p23 and q25 == 1 * q24 + q23, "recursion mismatch"
+
+    # exact-integer cube direction: p^3 > 3 q^3  <=>  (p/q)^3 > 3  <=>  cbrt3 < p/q
+    lhs = p25 ** 3
+    rhs = 3 * q25 ** 3
+    print(f"p25^3       = {lhs}")
+    print(f"3*q25^3     = {rhs}")
+    print(f"diff p^3-3q^3 = {lhs - rhs}  (>0 => valid UPPER bound)")
+    assert lhs > rhs, "NOT an upper bound!"
+
+    relgap = abs(mp.mpf(p25) / q25 - c) / c
+    print(f"relative gap = {mp.nstr(relgap, 6)}")
+    print("PASS: cbrt3 < 1310497171657/908647988973 (26th CF convergent, upper).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds the next uncontested rung to the `∛3` continued-fraction convergent ladder in `CubeRoot3IrrationalOQ04Helpers.lean`:

- **26th convergent (upper bound):** `cbrt3 < 1310497171657/908647988973` (a₂₅=1, odd index 25 ⟹ upper side, alternating with the lower-side 25th convergent from S30).

## Verification (build-free, reproducible)
`research/scripts/verify_cbrt3_oq04_s31_26th_convergent.py` (PASS):
- `a₂₅ = 1` re-derived independently from a 160-digit CF recomputation of `∛3` (anti-typo discipline — not re-quoted from a prior sketch tail).
- Recursion `p₂₅ = 1·1062790958529 + 247706213128 = 1310497171657`, `q₂₅ = 1·736898093374 + 171749895599 = 908647988973`.
- Exact-integer cube direction: `p³ − 3q³ = +1154336760442 > 0` ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (correct upper-side direction).
- Relative gap ≈ 1.7·10⁻²⁵.

Two-line Lean proof via `cbrt3_lt_iff_three_lt_cube`, structurally identical to the verified S29 24th-convergent upper-bound rung.

## Build status
**Build-pending.** Docker VM is oversubscribed (9 concurrent `lean-build` containers on the 7.65 GiB VM — building now would OOM peers); Aristotle MCP returns 404. Both re-tested live this session. The proof matches an already-verified sibling pattern; the deployer can build when capacity frees.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers` when VM capacity frees (≤2 concurrent builds)