### PR TITLE
research(friendship-theorem-oq-04): unique infinite-degree hub (sharp count)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -45,6 +45,15 @@ that has no infinite analogue:
   `Fintype` notion); it shows the recovered conclusion is genuinely a windmill even
   on infinite vertex types.
 
+* `unique_infinite_degree_vertex` — the **sharp** count of infinite-degree vertices
+  in the conclusion-restored case: in an infinite friendship graph with a universal
+  vertex `c`, the centre `c` is the *unique* vertex of infinite degree
+  (`(G.neighborSet w).Infinite ↔ w = c`). This refines
+  `infinite_friendship_has_infinite_degree` from "at least one infinite-degree
+  vertex" to "exactly one" once a universal vertex exists — the infinite windmill is
+  as infinite as the finite theorem permits, with a single hub and every other vertex
+  of degree two.
+
 Where the finite proof breaks: the spectral step
 `FriendshipTheorem.friendship_regular_implies_universal` is entirely finite-matrix
 algebra (trace, finite eigenvalue multiplicities, integrality) and has no infinite
@@ -192,5 +201,44 @@ theorem universal_noncentral_ncard_two (hF : IsFriendshipGraph G)
     (G.neighborSet u).ncard = 2 := by
   obtain ⟨w, hwc, _, _, hset⟩ := universal_noncentral_neighborSet hF c hc u hu
   rw [hset, Set.ncard_pair (Ne.symm hwc)]
+
+/-- **Only the centre can have infinite degree.** In any friendship graph with a
+universal vertex `c`, every vertex of infinite degree equals `c`: a non-centre
+vertex sits in a single triangle and has exactly two neighbours (`ncard = 2`),
+so an infinite neighbourhood (`ncard = 0`) is impossible. No `[Infinite V]`
+assumption is needed — this is a pure structural fact about the windmill. -/
+theorem infinite_degree_vertex_eq_universal (hF : IsFriendshipGraph G)
+    (c : V) (hc : FriendshipTheorem.IsUniversalVertex G c)
+    (w : V) (hw : (G.neighborSet w).Infinite) : w = c := by
+  by_contra hwc
+  have htwo : (G.neighborSet w).ncard = 2 := universal_noncentral_ncard_two hF c hc w hwc
+  rw [hw.ncard] at htwo
+  omega
+
+/-- **The hub has infinite degree.** If an *infinite* friendship graph has a
+universal vertex `c`, then `c` itself has infinite degree. Combined with
+`infinite_friendship_has_infinite_degree` (which guarantees *some* infinite-degree
+vertex) and `infinite_degree_vertex_eq_universal` (which forces it to be `c`), the
+hub is exactly that vertex. -/
+theorem universal_vertex_infinite_degree (hF : IsFriendshipGraph G) [Infinite V]
+    (c : V) (hc : FriendshipTheorem.IsUniversalVertex G c) :
+    (G.neighborSet c).Infinite := by
+  obtain ⟨w, hw⟩ := infinite_friendship_has_infinite_degree hF
+  rwa [infinite_degree_vertex_eq_universal hF c hc w hw] at hw
+
+/-- **Unique hub of the infinite windmill.** In an infinite friendship graph with a
+universal vertex `c`, the centre `c` is the *unique* vertex of infinite degree:
+`(G.neighborSet w).Infinite ↔ w = c`. This sharpens the obstruction
+`infinite_friendship_has_infinite_degree` (which only gives *at least one*
+infinite-degree vertex) to *exactly one* in the conclusion-restored case — the
+infinite windmill is "as infinite as the finite theorem permits", with a single
+infinite-degree hub and every other vertex of degree two. -/
+theorem unique_infinite_degree_vertex (hF : IsFriendshipGraph G) [Infinite V]
+    (c : V) (hc : FriendshipTheorem.IsUniversalVertex G c) (w : V) :
+    (G.neighborSet w).Infinite ↔ w = c := by
+  constructor
+  · exact infinite_degree_vertex_eq_universal hF c hc w
+  · rintro rfl
+    exact universal_vertex_infinite_degree hF c hc
 
 end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -245,3 +245,39 @@ compile error blocks the PR rather than reaching `main`).
 ### Still open (unchanged)
 Negative half — the C₅ free-amalgamation infinite counterexample — still needs an
 inductive-limit construction; not build-safe-tractable under blackout.
+
+## Session (researcher-2, 2026-06-15) — unique infinite-degree hub (sharp count)
+
+**Mode**: REVISIT (RICH) · **Outcome**: progress (3 new theorems, still 0 sorry / 0
+axiom). Docker reachable but **8 concurrent lean-build containers** on the 7.65GiB VM
+⟹ a local build would OOM all peers (see [[project-docker-7gb-vm-is-the-real-oom-constraint]]),
+so build-pending → deployer-gated machine-check. File already registered in
+`proofs/Proofs.lean`. Aristotle still 404.
+
+### Added to `FriendshipTheoremOQ04.lean` (3 theorems)
+Sharpens the obstruction `infinite_friendship_has_infinite_degree` ("≥1 infinite-degree
+vertex") to an *exact count* in the conclusion-restored (universal-vertex) case:
+- `infinite_degree_vertex_eq_universal`: in ANY friendship graph with universal `c`,
+  every infinite-degree vertex equals `c` (no `[Infinite V]`). Proof: a non-centre
+  vertex has `ncard N = 2` (`universal_noncentral_ncard_two`), but an infinite set has
+  `ncard = 0` (`Set.Infinite.ncard`); `omega` on `0 = 2`.
+- `universal_vertex_infinite_degree`: `[Infinite V]` + universal `c` ⟹ `c` itself has
+  infinite degree. Proof: `infinite_friendship_has_infinite_degree` yields some
+  infinite-degree `w`; the previous lemma forces `w = c`; `rwa`.
+- `unique_infinite_degree_vertex` (capstone iff): `[Infinite V]` + universal `c` ⟹
+  `(G.neighborSet w).Infinite ↔ w = c`. The infinite windmill has a **single** hub of
+  infinite degree, every other vertex degree two — "as infinite as the finite theorem
+  permits."
+
+**Why new (not cosmetic):** `infinite_friendship_has_infinite_degree` only bounds the
+infinite-degree set below by 1; this pins it to exactly 1 (in the universal case) and
+identifies it with the hub. Structural sharp-boundary result, theory-level.
+
+**Verification (build-free).** Each proof is a 3–5 line composition of already-compiling
+in-file lemmas (`universal_noncentral_ncard_two`, `infinite_friendship_has_infinite_degree`)
+plus `Set.Infinite.ncard` (used in `Erdos152ProblemAPN.lean:247`). High static confidence.
+
+### Still open (unchanged)
+Negative half — the C₅ free-amalgamation infinite counterexample (an explicit friendship
+graph with no universal vertex) — still needs an inductive-limit / colimit construction;
+not build-safe-tractable in one session, and confirmed so across S1–S6.


### PR DESCRIPTION
## Summary
Sharpens the Friendship Theorem OQ-04 obstruction result. The existing
`infinite_friendship_has_infinite_degree` only guarantees **at least one**
infinite-degree vertex in an infinite friendship graph. This PR pins the count to
**exactly one** in the conclusion-restored (universal-vertex) case, and identifies
that vertex with the windmill hub.

Three new theorems in `FriendshipTheoremOQ04.lean` (still 0 sorry / 0 axiom):

- `infinite_degree_vertex_eq_universal` — in any friendship graph with a universal
  vertex `c`, every infinite-degree vertex equals `c` (no `[Infinite V]` needed):
  non-centre vertices have `ncard N = 2`, but infinite sets have `ncard = 0`.
- `universal_vertex_infinite_degree` — for an infinite friendship graph with
  universal `c`, the hub `c` itself has infinite degree.
- `unique_infinite_degree_vertex` — capstone iff `(G.neighborSet w).Infinite ↔ w = c`:
  the infinite windmill is "as infinite as the finite theorem permits", with a single
  infinite-degree hub and every other vertex of degree two.

Each proof is a 3–5 line composition of already-compiling in-file lemmas plus
`Set.Infinite.ncard` (used elsewhere in the repo, `Erdos152ProblemAPN.lean:247`).

## Verification
- 0 sorry, 0 axiom; file already registered in `proofs/Proofs.lean`.
- **Build-pending**: Docker is reachable but 8 concurrent `lean-build` containers were
  sharing the 7.65GiB VM, so a local build would OOM all peers. Machine-check deferred
  to the deployer (deployer-gated: a compile error blocks this PR rather than reaching
  `main`).

## Test plan
- [ ] Deployer builds `Proofs.FriendshipTheoremOQ04` and confirms 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)