### PR TITLE
Enrich mantel-theorem: structured overview/conclusion, sections, annotations

### DIFF
--- a/src/data/proofs/mantel-theorem/annotations.json
+++ b/src/data/proofs/mantel-theorem/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "mantel-ann-docstring",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 7, "endLine": 34 },
+    "type": "context",
+    "title": "Mantel's Theorem and the Turán Specialization Strategy",
+    "content": "The module docstring states Mantel's theorem and fixes the proof strategy. Rather than reproving the result combinatorially, the file derives it as the r = 2 case of Mathlib's general Turán development: the generic edge bound is specialized and its arithmetic collapsed to the familiar floor ⌊n²/4⌋, with sharpness exhibited by the canonical Turán graph.",
+    "mathContext": "A triangle-free ($K_3$-free) graph on $n$ vertices has at most $\\lfloor n^2/4\\rfloor$ edges.",
+    "significance": "context",
+    "relatedConcepts": ["extremal graph theory", "Turán's theorem", "triangle-free graphs"],
+    "prerequisites": ["simple graphs", "edge counting"]
+  },
+  {
+    "id": "mantel-ann-turan-two-simp",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 45, "endLine": 55 },
+    "type": "technique",
+    "title": "Collapsing the Turán Bound to ⌊n²/4⌋",
+    "content": "turan_two_simp is the arithmetic heart of the specialization: it proves that the general Turán right-hand side at r = 2 equals n²/4 over ℕ. Two facts drive it — the binomial correction (n%2).choose 2 is 0 because n%2 < 2, and n² splits as 4·((n/2)² + (n/2)(n%2)) + (n%2)² via Nat.div_add_mod followed by ring. With those in hand omega discharges the truncated-subtraction/integer-division goal.",
+    "mathContext": "$\\frac{(n^2-(n\\bmod 2)^2)(2-1)}{2\\cdot 2} + \\binom{n\\bmod 2}{2} = \\lfloor n^2/4\\rfloor$, since $\\binom{n\\bmod 2}{2}=0$ and $n^2-(n\\bmod 2)^2 \\equiv 0 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["natural number arithmetic", "floor division", "modular case analysis"],
+    "prerequisites": ["Nat.div_add_mod", "omega tactic", "binomial coefficients"]
+  },
+  {
+    "id": "mantel-ann-edge-bound",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 59, "endLine": 63 },
+    "type": "insight",
+    "title": "Mantel's Edge Bound from Mathlib's Turán Bound",
+    "content": "mantel_card_edgeFinset_le is Mantel's theorem proper. It applies SimpleGraph.CliqueFree.card_edgeFinset_le at r = 2 to a triangle-free graph G, then rewrites the resulting bound through turan_two_simp to land on the clean ⌊n²/4⌋. The proof is a two-line le_trans: the general bound followed by the arithmetic equality.",
+    "mathContext": "$G$ $K_3$-free $\\Rightarrow |E(G)| \\le \\lfloor |V|^2/4\\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["clique-free graphs", "Turán's theorem", "edge density"],
+    "prerequisites": ["SimpleGraph.CliqueFree", "edgeFinset"]
+  },
+  {
+    "id": "mantel-ann-turangraph-trianglefree",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 66, "endLine": 67 },
+    "type": "definition",
+    "title": "The Turán Graph is Triangle-Free",
+    "content": "turanGraph_two_cliqueFree records that turanGraph n 2 — the balanced complete bipartite graph on n vertices — is K₃-free, obtained directly from Mathlib's turanGraph_cliqueFree. This is the qualifying property the extremal witness must satisfy before its edge count can certify sharpness.",
+    "mathContext": "$\\mathrm{turanGraph}\\,n\\,2$ is $(2{+}1)$-clique-free, i.e. triangle-free.",
+    "significance": "supporting",
+    "relatedConcepts": ["Turán graph", "complete bipartite graph"],
+    "prerequisites": ["SimpleGraph.turanGraph"]
+  },
+  {
+    "id": "mantel-ann-edge-count",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 71, "endLine": 74 },
+    "type": "technique",
+    "title": "Exact Edge Count of the Turán Graph",
+    "content": "card_edgeFinset_turanGraph_two computes the number of edges of turanGraph n 2 as exactly n²/4. It rewrites with Mathlib's card_edgeFinset_turanGraph (the general edge count of the Turán graph) and then reuses the very same turan_two_simp identity — so the upper bound and the witness's edge count are reconciled by one shared arithmetic lemma.",
+    "mathContext": "$|E(\\mathrm{turanGraph}\\,n\\,2)| = \\lfloor n^2/4\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": ["edge counting", "Turán graph"],
+    "prerequisites": ["card_edgeFinset_turanGraph"]
+  },
+  {
+    "id": "mantel-ann-tight",
+    "proofId": "mantel-theorem",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "insight",
+    "title": "Sharpness: the Bound Cannot Be Improved",
+    "content": "mantel_bound_is_tight turns the inequality into a tight extremal result: for every n it produces a triangle-free graph on n vertices attaining ⌊n²/4⌋ edges — namely turanGraph n 2 with its decidability instance, triangle-freeness, and exact edge count bundled as the existential witness. Together with mantel_card_edgeFinset_le this gives the full extremal statement.",
+    "mathContext": "$\\exists G$ on $n$ vertices, $K_3$-free with $|E(G)| = \\lfloor n^2/4\\rfloor$, so $\\lfloor n^2/4\\rfloor$ is optimal.",
+    "significance": "key",
+    "relatedConcepts": ["extremal graphs", "tightness", "balanced complete bipartite graph"],
+    "prerequisites": ["existential witnesses", "DecidableRel"]
+  }
+]

--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -49,8 +49,69 @@
     "dateAdded": "2026-06-15",
     "axiomCountNote": "0 axiom declarations, 0 structure-encoded assumptions; all results are machine-checked consequences of Mathlib's Turán theorem."
   },
-  "overview": "Mantel's theorem (1907) bounds the number of edges in a triangle-free graph. If a simple graph G on n vertices contains no triangle (it is K₃-free, i.e. CliqueFree 3), then it has at most ⌊n²/4⌋ edges. This is the founding result of extremal graph theory and the base case r = 2 of Turán's theorem (which forbids Kᵣ₊₁ instead of K₃). Mathlib develops Turán's theorem in full generality; this entry specializes the general edge bound `SimpleGraph.CliqueFree.card_edgeFinset_le` to r = 2 and collapses the resulting arithmetic to the familiar floor ⌊n²/4⌋. The bound is sharp: the balanced complete bipartite graph — realized as `turanGraph n 2` — is triangle-free and has exactly ⌊n²/4⌋ edges.",
-  "conclusion": "Mantel's edge bound is fully machine-checked in Lean 4 with no axioms or sorries, derived from Mathlib's Turán theorem. The key arithmetic step is `turan_two_simp`, which shows the general Turán right-hand side at r = 2 equals ⌊n²/4⌋ exactly (the binomial correction term vanishes since n % 2 < 2, and n² − (n%2)² is a multiple of 4). Sharpness is witnessed by `turanGraph n 2`. The equality characterization (equality holds iff G is the balanced complete bipartite graph) follows from `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` and is noted as a future direction.",
+  "overview": {
+    "historicalContext": "Willem Mantel posed and solved this problem in 1907 (Wiskundige Opgaven 10, 60–61): how many edges can a graph on n vertices have if it contains no triangle? His answer, ⌊n²/4⌋, is widely regarded as the founding result of extremal graph theory — the systematic study of how forbidding a substructure constrains size. In 1941 Pál Turán generalized it to forbidden complete graphs Kᵣ₊₁, with Mantel's theorem the r = 2 base case, launching the field in earnest. The balanced complete bipartite graph K⌈n/2⌉,⌊n/2⌋ is the unique extremal example, foreshadowing the Turán graph and the Erdős–Stone–Simonovits theorem that ties extremal edge counts to chromatic numbers.",
+    "problemStatement": "If a simple graph G on n vertices is triangle-free (K₃-free, equivalently CliqueFree 3), how many edges can it have? Mantel's theorem answers: at most ⌊n²/4⌋, with equality iff G is the balanced complete bipartite graph.",
+    "proofStrategy": "Rather than reprove Mantel from scratch, this entry derives it as the r = 2 specialization of Mathlib's general Turán development. The general bound SimpleGraph.CliqueFree.card_edgeFinset_le gives #E ≤ (n² − (n%2)²)·(2−1)/(2·2) + (n%2).choose 2; the arithmetic identity turan_two_simp collapses this right-hand side to ⌊n²/4⌋ (mantel_card_edgeFinset_le). Sharpness is exhibited concretely: turanGraph n 2 is triangle-free (turanGraph_two_cliqueFree) and has exactly ⌊n²/4⌋ edges (card_edgeFinset_turanGraph_two), so mantel_bound_is_tight shows the bound cannot be improved.",
+    "keyInsights": [
+      "Mantel's theorem is exactly the r = 2 instance of Turán's theorem; deriving it from Mathlib's general Turán bound rather than reproving it keeps the formalization short and exposes the structural relationship.",
+      "The whole content of the specialization is the arithmetic identity turan_two_simp: the generic Turán right-hand side at r = 2 equals the textbook floor ⌊n²/4⌋. The binomial correction (n%2).choose 2 vanishes because n%2 < 2, and n² − (n%2)² is the largest multiple of 4 below n².",
+      "An upper bound alone is not the theorem — sharpness matters. Exhibiting turanGraph n 2 as an explicit triangle-free graph meeting the bound turns an inequality into a tight extremal result.",
+      "The extremal graph is bipartite: triangle-freeness pushes the densest graph toward two color classes, the n=2 shadow of the Erdős–Stone–Simonovits principle that the extremal density of a forbidden graph is governed by its chromatic number.",
+      "Working over ℕ with truncated subtraction and integer division, the identity is discharged by reducing modulo 2 (the only two cases n even/odd) plus omega, avoiding any real-analytic rounding argument."
+    ]
+  },
+  "conclusion": {
+    "summary": "Mantel's edge bound — a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges — is fully machine-checked in Lean 4 with no axioms or sorries, derived as the r = 2 case of Mathlib's Turán theorem. The key arithmetic step turan_two_simp shows the general Turán right-hand side at r = 2 equals ⌊n²/4⌋ exactly, and sharpness is witnessed by the explicit triangle-free graph turanGraph n 2.",
+    "implications": "Provides a clean, reusable Lean statement of the founding theorem of extremal graph theory in its familiar ⌊n²/4⌋ form, bridging Mathlib's abstract Turán machinery to the concrete classical result. The pattern — specialize a general Mathlib extremal bound, collapse the arithmetic, and exhibit the extremal witness — transfers to other Turán-type and forbidden-substructure edge bounds.",
+    "openQuestions": [
+      "Package the equality characterization: equality #E = ⌊n²/4⌋ holds iff G is the balanced complete bipartite graph, available from SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph but not formalized here.",
+      "Formalize stability (the Erdős–Simonovits stability theorem): a triangle-free graph with close to ⌊n²/4⌋ edges is structurally close to the balanced complete bipartite graph.",
+      "Extend to the full Erdős–Stone–Simonovits asymptotic, expressing the extremal number of any forbidden graph H in terms of its chromatic number χ(H)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 6,
+      "summary": "Apache-2.0 license header and a single import Mathlib, which brings in the full SimpleGraph.Extremal.Turan development (the general Turán edge bound, the Turán graph, and its edge count) that the entire entry specializes.",
+      "mathContext": "Relies on Mathlib.Combinatorics.SimpleGraph.Extremal.Turan."
+    },
+    {
+      "id": "statement-and-approach",
+      "title": "Statement and Approach",
+      "startLine": 7,
+      "endLine": 38,
+      "summary": "Module docstring stating Mantel's theorem and fixing the strategy: specialize Mathlib's general Turán edge bound SimpleGraph.CliqueFree.card_edgeFinset_le at r = 2 and collapse the arithmetic to ⌊n²/4⌋, with sharpness via turanGraph n 2 (noting the equality characterization as a future direction). Opens Finset/Fintype/SimpleGraph and the Mantel namespace.",
+      "mathContext": "Mantel's theorem: a $K_3$-free graph on $n$ vertices has $\\le \\lfloor n^2/4\\rfloor$ edges, the $r=2$ case of Turán's theorem."
+    },
+    {
+      "id": "turan-two-simp",
+      "title": "The Arithmetic Identity (turan_two_simp)",
+      "startLine": 40,
+      "endLine": 55,
+      "summary": "turan_two_simp proves the general Turán right-hand side at r = 2, (n² − (n%2)²)·(2−1)/(2·2) + (n%2).choose 2, equals n²/4. The binomial term is 0 since n%2 < 2 (Nat.choose_eq_zero_of_lt); the decomposition n² = 4·((n/2)² + (n/2)(n%2)) + (n%2)² (from Nat.div_add_mod and ring) lets omega finish over ℕ.",
+      "mathContext": "$\\frac{(n^2-(n\\bmod 2)^2)(2-1)}{2\\cdot 2} + \\binom{n\\bmod 2}{2} = \\left\\lfloor \\frac{n^2}{4}\\right\\rfloor$."
+    },
+    {
+      "id": "mantel-bound",
+      "title": "Mantel's Edge Bound",
+      "startLine": 57,
+      "endLine": 67,
+      "summary": "mantel_card_edgeFinset_le specializes Mathlib's CliqueFree.card_edgeFinset_le at r = 2 and rewrites the bound through turan_two_simp to obtain #E ≤ ⌊n²/4⌋ for any triangle-free G. turanGraph_two_cliqueFree records that the canonical Turán graph turanGraph n 2 is itself triangle-free (from turanGraph_cliqueFree).",
+      "mathContext": "$G$ $K_3$-free $\\Rightarrow$ $|E(G)| \\le \\lfloor n^2/4\\rfloor$, with $n = |V|$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness via the Turán Graph",
+      "startLine": 69,
+      "endLine": 84,
+      "summary": "card_edgeFinset_turanGraph_two computes the edge count of turanGraph n 2 as exactly n²/4 (via card_edgeFinset_turanGraph and turan_two_simp). mantel_bound_is_tight then packages a triangle-free graph attaining ⌊n²/4⌋ edges for every n, proving the bound in mantel_card_edgeFinset_le cannot be improved.",
+      "mathContext": "$|E(\\mathrm{turanGraph}\\,n\\,2)| = \\lfloor n^2/4\\rfloor$, so the bound is attained (balanced complete bipartite graph)."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "friendship-theorem",


### PR DESCRIPTION
Enrichment pass for `mantel-theorem` (Mantel's Theorem — max edges in triangle-free graphs).

This was a freshly research-created entry: `overview` and `conclusion` were flat strings, there were no `sections`, and no `annotations.json` existed (quality 0).

## Changes
- **overview** → structured object: `historicalContext` (Mantel 1907, Turán 1941, Erdős–Stone–Simonovits), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **conclusion** → structured object: `summary`, `implications`, and 3 `openQuestions` (equality characterization, stability, Erdős–Stone–Simonovits).
- Added a 5-section breakdown covering the full Lean file (lines 1–84): imports, statement/approach, the `turan_two_simp` arithmetic identity, the edge bound, and sharpness.
- Added `annotations.json` with 6 annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`).

Quality 0 → 100. Content is faithful to `Proofs/MantelTheorem.lean`; no Lean source, badge, or status changes (entry remains `verified`/`original`, 0 axioms/0 sorries).