### PR TITLE
Fix: replace invalid "research" badge on 7 gallery entries (#24758)

### DIFF
--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -16,7 +16,7 @@
       "three-generators",
       "research"
     ],
-    "badge": "research",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 440,

--- a/src/data/proofs/inverse-galois-d4-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/meta.json
@@ -18,7 +18,7 @@
       "field-extensions",
       "research"
     ],
-    "badge": "research",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 202,

--- a/src/data/proofs/inverse-galois-d4-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/meta.json
@@ -18,7 +18,7 @@
       "capelli-theorem",
       "research"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 235,

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
       "eigenspace",
       "research"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 279,

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "rational-canonical-form",
       "research"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 202,

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -19,7 +19,7 @@
       "structure-theorem-pid",
       "research"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 639,

--- a/src/data/proofs/pascals-hexagon-oq-03/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03/meta.json
@@ -20,7 +20,7 @@
       "wiedijk-100-theorems",
       "research"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
     "lineCount": 718,


### PR DESCRIPTION
## Fix

7 gallery entries set `meta.badge: "research"`, which is not a member of the `ProofBadge` union (`src/components/ui/proof-badge.tsx:186`) — invalid values fall through to the fallback and render no badge at all. Each badge is remapped to a valid value based on the entry's actual tier (verified against the Lean source).

## Evidence

**Before**: all 7 entries had `"badge": "research"` (renders nothing).

**After** — assigned per tier (sorry/axiom counts confirmed in `proofs/Proofs/*.lean`):

| Entry | Real sorries | Axioms | New badge |
|-------|-------------|--------|-----------|
| frobenius-number-oq-03 | 0 | 0 | `original` |
| inverse-galois-d4-oq-01 | 0 | 0 | `original` |
| inverse-galois-d4-oq-03 | 1 | 0 | `wip` |
| minpoly-charpoly-oq-02 | 1 | 0 | `wip` |
| minpoly-charpoly-oq-03-oq-01 | 2 | 0 | `wip` |
| minpoly-charpoly-oq-03 | 1 | 0 | `wip` |
| pascals-hexagon-oq-03 | 3 | 0 | `wip` |

The two 0-sorry/0-axiom entries prove their core results in-file (frobenius-oq-03 builds the 3-generator Frobenius API on a sibling 2-generator bridge; igd4-oq-01 constructs the ℤ/4⋊ℤ/2 decomposition directly), so `original`. The remaining five carry sorries → `wip`. All 7 meta.json files validated as well-formed JSON.

Closes #24758

---
Automated fix by lean-mechanic agent.