### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-04: fix invalid significance enum

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/annotations.json
@@ -36,7 +36,7 @@
     "title": "Mathematical Context: The Cardinality Hierarchy and Turing's Insight",
     "content": "Alan Turing's 1936 paper *On Computable Numbers* introduced the modern notion of a computable real and immediately noted: the set of computable reals is countable, because Turing-machine descriptions are finite strings (over a finite alphabet), and finite strings form a countable set. This single observation places computable reals between algebraic and ℝ in the cardinality hierarchy:\n\n    ℚ  ⊊  algebraic  ⊊  computable  ⊊  ℝ\n    ↑          ↑              ↑       ↑\n    ℵ₀         ℵ₀             ℵ₀      𝔠\n\nThe first three inclusions are strict in a *qualitative* sense (different sets) but share the same cardinality ℵ₀. The final inclusion is strict in the *cardinality* sense (ℵ₀ < 𝔠), so there exist uncountably many non-computable reals.\n\nThis sibling entry to `algebraic-numbers-countable-oq-02-oq-03` (which gave the exact cardinality 𝔠 to transcendentals) tackles the layer one finer: not just transcendental reals, but the **computable** subset of transcendentals, and proves *this* subset is countable.",
     "mathContext": "The hierarchy generalizes: each definability class (computable, definable in PA, definable in ZFC, etc.) is countable because the language of definitions has finitely many symbols. The complement of any definability class is uncountable. This is the *abstract* form of 'almost all reals are undefinable' — a Cantor-style diagonal argument adapted to definability layers.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "cardinality",
       "Turing machine",
@@ -86,7 +86,7 @@
     "title": "Proof Strategy: Code Countability + Image of Countable",
     "content": "The strategy for `computable_reals_countable` rests on three pillars from Mathlib:\n\n1. **Code countability**: `Nat.Partrec.Code` is `Encodable` (inductive type with finitely-many constructors, each over countable arguments), hence its underlying type is countable.\n\n2. **Code completeness**: every `Computable f : ℕ → ℚ` comes from a recursive code. Concretely, Mathlib's `Computable f` is defined via `Partrec`, and partial recursive functions admit codes in `Nat.Partrec.Code` (existence of TM index). Since ℚ is `Primcodable` (via `Mathlib.Data.Rat.Denumerable`), the code-extraction works for our codomain.\n\n3. **Image of countable** (`Set.Countable.image`): combining 1 and 2, the partial map `Nat.Partrec.Code → Option ℝ`, sending each code to the limit of its rational evaluations (when that limit exists), is *defined on a countable domain*. Its image (the set of computable reals) is therefore countable.\n\nThis is the standard textbook argument. The Mathlib formalization route is straightforward once the API is identified, but the present S1 PR leaves the final assembly as a `sorry` (with strategy documented) to be discharged in a follow-up iteration. The risk in S1 is API drift; pinning the strategy in a docstring rather than racing to ship a half-baked proof reflects the over-subscription guideline.",
     "mathContext": "Variant strategy: instead of going via `Nat.Partrec.Code`, one could go via `Encodable {f : ℕ → ℚ | Computable f}` and apply `Set.Countable.image` directly with the partial limit map. Both routes are valid; the `Nat.Partrec.Code` route exposes the constructive content (we get a *specific* code) more clearly.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "Nat.Partrec.Code",
       "Encodable",
@@ -136,7 +136,7 @@
     "title": "Subtle Point: Computable Reals Are Not Computably Enumerable",
     "content": "There is an important non-property worth flagging: even though the computable reals are countable (hence in bijection with ℕ as a set), they are **not computably enumerable** — there is no algorithm that lists them in a way recognizable by another algorithm. Equivalently, the set `{ Gödel number of TM : that TM computes a Cauchy sequence }` is not decidable (it's `Π_2^0`-complete).\n\nThis matters for Cantor-style diagonalization: if you could *computably* enumerate the computable reals, you could *computably* diagonalize and produce a computable real not in your enumeration — contradiction. So the diagonalization fails *not* because computable reals are uncountable (they aren't), but because the enumeration is non-computable.\n\nThe present formalization captures only the *set-theoretic* countability (`Set.Countable`). The non-computable-enumerability is a deeper, complementary fact that would require formalizing decidability of TM behavior — a substantially harder open question.",
     "mathContext": "The decidability gap is captured by the arithmetical hierarchy: `{r : ℝ | IsComputable r}` has a Π₂⁰-complete index set when viewed as a subset of TM-indices. Mathlib's `Computable` predicate avoids this issue by quantifying *existentially* over the code, hiding the non-decidability of the witness selection.",
-    "significance": "advanced",
+    "significance": "key",
     "relatedConcepts": [
       "computably enumerable",
       "arithmetical hierarchy",


### PR DESCRIPTION
Annotations used `core` and `advanced` for `significance`, not valid `AnnotationSignificance` values (`critical | key | supporting`). Mapped `core`→`critical`, `advanced`→`key`. Annotations-only, python-validated.