### PR TITLE
Enrich de-moivre-oq-02-oq-02-oq-01: sections, annotations, deeper overview

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "demoivre-uu-ann-question",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 45 },
+    "type": "context",
+    "title": "The U·U Linearization Open Question",
+    "content": "The parent file proved a U·U product-to-difference identity scaled by (1−x²): 2(1−x²)·U_m·U_n = T_{m−n} − T_{m+n+2}. This entry answers whether the bare product U_m·U_n can be expressed purely in second-kind polynomials, with no T and no (1−x²) factor. Unlike the two-term first-kind formula 2·T_m·T_n = T_{m+n} + T_{m−n}, the answer is a genuine sum of min(m,n)+1 terms.",
+    "mathContext": "$U_m \\cdot U_n = \\sum_{k=0}^{n} U_{m+n-2k}$, an arithmetic progression of indices from $m-n$ to $m+n$ in steps of $2$.",
+    "significance": "context",
+    "relatedConcepts": ["Chebyshev polynomials", "product-to-sum identities", "linearization"],
+    "prerequisites": ["second-kind Chebyshev polynomials U_n"]
+  },
+  {
+    "id": "demoivre-uu-ann-ssum",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 53, "endLine": 55 },
+    "type": "definition",
+    "title": "The Linearization Sum S(m,n)",
+    "content": "Ssum m n is the candidate right-hand side ∑_{k∈range(n+1)} U_(m+n−2k). Indexing the summand by m + n − 2k with m : ℤ keeps the identity valid for every integer m via Mathlib's ℤ-indexed U, so no m ≥ n hypothesis is needed. It is noncomputable because Polynomial arithmetic over a general ring is.",
+    "mathContext": "$S(m,n) := \\sum_{k=0}^{n} U_{m+n-2k} \\in R[X]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum", "integer-indexed Chebyshev polynomials"],
+    "prerequisites": ["Finset.range", "Polynomial ring R[X]"]
+  },
+  {
+    "id": "demoivre-uu-ann-two-x-u",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 58, "endLine": 62 },
+    "type": "technique",
+    "title": "Rearranging the Chebyshev Recurrence",
+    "content": "two_X_U turns the standard recurrence U_add_two into the symmetric form 2·X·U_k = U_(k+1) + U_(k−1). This is the single algebraic identity that lets 2X be distributed across the linearization sum; it is proved by shifting U_add_two at k−1 and a linear_combination.",
+    "mathContext": "$2X\\,U_k = U_{k+1} + U_{k-1}$, equivalent to $U_{k+1} = 2X\\,U_k - U_{k-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["three-term recurrence", "linear_combination tactic"],
+    "prerequisites": ["Polynomial.Chebyshev.U_add_two"]
+  },
+  {
+    "id": "demoivre-uu-ann-ssum-rec",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 79, "endLine": 100 },
+    "type": "insight",
+    "title": "The Product-Free Sum Recurrence",
+    "content": "Ssum_rec proves 2·X·S(m,n+1) = S(m,n+2) + S(m,n) — the combinatorial heart of the whole proof, mentioning no Chebyshev product at all. After Ssum_succ_expand distributes 2X into a sum of U-pairs, the two shifted copies of the sum overlap; peeling the boundary terms with Finset.sum_range_succ leaves exactly U_(m−n−2) from each, which cancel. Isolating this product-free identity is what reduces the product theorem to recurrence-matching.",
+    "mathContext": "$2X\\,S(m,n{+}1) = S(m,n{+}2) + S(m,n)$, with both boundary terms equal to $U_{m-n-2}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sums", "boundary cancellation", "Finset.sum_range_succ"],
+    "prerequisites": ["Finset.sum_add_distrib", "Finset.mul_sum", "push_cast"]
+  },
+  {
+    "id": "demoivre-uu-ann-base",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 102, "endLine": 113 },
+    "type": "technique",
+    "title": "Base Values for the Two-Step Induction",
+    "content": "Ssum_zero (S(m,0) = U_m) and Ssum_one (S(m,1) = U_(m+1) + U_(m−1)) provide the two consecutive base cases that a second-order recurrence requires. They are computed directly from the sum definition via Finset.sum_range_one and Finset.sum_range_succ plus cast normalization.",
+    "mathContext": "$S(m,0) = U_m$ and $S(m,1) = U_{m+1} + U_{m-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["base cases", "Finset.sum_range_one"],
+    "prerequisites": ["U_zero", "U_one"]
+  },
+  {
+    "id": "demoivre-uu-ann-main",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01",
+    "range": { "startLine": 118, "endLine": 143 },
+    "type": "insight",
+    "title": "Main Identity by Two-Step Induction",
+    "content": "U_mul_U proves U_m·U_n = S(m,n). Because U satisfies the second-order recurrence U_{i+2} = 2X·U_{i+1} − U_i, the induction is strengthened to carry the pair P(j) ∧ P(j+1). The base bundles n=0,1; the step rewrites the goal with U_add_two and then combines the two inductive hypotheses with Ssum_rec via linear_combination, so the product identity follows from the product-free recurrence.",
+    "mathContext": "$U_m(2X\\,U_{i+1} - U_i) = 2X(U_m U_{i+1}) - U_m U_i = 2X\\,S(m,i{+}1) - S(m,i) = S(m,i{+}2)$.",
+    "significance": "key",
+    "relatedConcepts": ["paired strong induction", "second-order recurrence"],
+    "prerequisites": ["Nat.rec", "linear_combination", "Polynomial.Chebyshev.U_add_two"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -70,7 +70,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Two Chebyshev Families and Their Products**\n\nChebyshev polynomials share the recurrence $p_{n+2} = 2x p_{n+1} - p_n$: the first kind $T_n$ with $T_n(\\cos\\theta)=\\cos(n\\theta)$, and the second kind $U_n$ with $U_n(\\cos\\theta)\\sin\\theta=\\sin((n+1)\\theta)$. The first-kind product-to-sum $2T_mT_n = T_{m+n}+T_{m-n}$ is a clean two-term identity. The second-kind product behaves differently: $U_m U_n$ linearizes into a *sum* $\\sum_{k} U_{m+n-2k}$ running over indices $|m-n|, |m-n|+2, \\dots, m+n$.",
+    "historicalContext": "**Two Chebyshev Families and Their Products**\n\nChebyshev polynomials share the recurrence $p_{n+2} = 2x p_{n+1} - p_n$: the first kind $T_n$ with $T_n(\\cos\\theta)=\\cos(n\\theta)$, and the second kind $U_n$ with $U_n(\\cos\\theta)\\sin\\theta=\\sin((n+1)\\theta)$. The first-kind product-to-sum $2T_mT_n = T_{m+n}+T_{m-n}$ is a clean two-term identity, the polynomial shadow of the cosine product formula $2\\cos a\\cos b = \\cos(a+b)+\\cos(a-b)$. The second-kind product behaves differently: $U_m U_n$ linearizes into a *sum* $\\sum_{k} U_{m+n-2k}$ running over indices $|m-n|, |m-n|+2, \\dots, m+n$ — the analogue of $\\frac{\\sin((m+1)\\theta)\\sin((n+1)\\theta)}{\\sin^2\\theta}$ expanded by the same trigonometric product-to-sum and then resummed as a Dirichlet-style kernel. Linearization (product-to-sum) formulas are the structure constants of the multiplication on the polynomial family; for Chebyshev polynomials they are classical (Mason–Handscomb, *Chebyshev Polynomials*, 2003, §2.4), but a fully formal polynomial-identity proof over an arbitrary commutative ring — valid for negative integer indices via Mathlib's $\\mathbb{Z}$-indexed $U$ — is what this entry supplies.",
     "problemStatement": "**The Open Question**\n\nThe parent T·U entry asked: can $U_m \\cdot U_n = \\sum_{k=0}^{\\min(m,n)} U_{m+n-2k}$ be proved as a polynomial identity over $R[X]$?\n\n**Answer: YES** — for every commutative ring $R$, $m \\in \\mathbb{Z}$, $n \\in \\mathbb{N}$.",
     "text": "Proves the second-kind Chebyshev linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity over any commutative ring R. The combinatorial core is isolated as a product-free sum recurrence 2X·S(m,n+1) = S(m,n+2)+S(m,n), proved by distributing the recurrence termwise and cancelling boundary terms; the main identity then follows by a two-step induction matching U_{n+2}=2X·U_{n+1}−U_n.",
     "proofStrategy": "**Sum recurrence + two-step induction**\n\nDefine $S(m,n) = \\sum_{k=0}^{n} U_{m+n-2k}$.\n\n1. `Ssum_succ_expand`: $2X \\cdot S(m,n+1) = \\sum_{k=0}^{n+1}(U_{m+n+2-2k}+U_{m+n-2k})$ via the rearranged recurrence $2X U_k = U_{k+1}+U_{k-1}$.\n2. `Ssum_rec`: peel the boundary terms of the two telescoped ranges; both equal $U_{m-n-2}$ and cancel, giving $2X S(m,n+1) = S(m,n+2)+S(m,n)$.\n3. `U_mul_U`: two-step induction on $n$ carrying $P(j)\\wedge P(j+1)$, using $U_{i+2}=2X U_{i+1}-U_i$ and `Ssum_rec`.",
@@ -78,7 +78,8 @@
       "**Isolate the combinatorics**: All boundary bookkeeping lives in the product-free `Ssum_rec`; the product theorem reduces to recurrence-matching.",
       "**Two-step induction for a second-order recurrence**: carrying $P(j)\\wedge P(j+1)$ mirrors the parent's paired integer induction.",
       "**Boundary terms cancel**: the surviving terms $U_{m+n+2-2(n+2)}$ and $U_{m+n-2(n+1)}$ are both $U_{m-n-2}$.",
-      "**Integer index m**: indexing by $m+n-2k$ with $m:\\mathbb{Z}$ removes any $m\\ge n$ hypothesis."
+      "**Integer index m**: indexing by $m+n-2k$ with $m:\\mathbb{Z}$ removes any $m\\ge n$ hypothesis.",
+      "**Identity over any CommRing**: the result is established in $R[X]$ for an arbitrary commutative ring via `variable {R : Type*} [CommRing R]`, so it specializes to ℝ, ℂ, ℤ, or any coefficient ring without change — the linearization is a fact about the Chebyshev family as elements of $R[X]$, not about real evaluation."
     ],
     "prerequisites": [
       "Chebyshev recurrence U_add_two and the rearrangement 2X·U_k = U_{k+1}+U_{k-1}",
@@ -87,7 +88,48 @@
       "linear_combination tactic"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "statement-and-strategy",
+      "title": "Open Question, Answer, and Strategy",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Imports, module docstring, and setup. States the open question left by the parent T·U entry — can U_m·U_n be written purely as second-kind polynomials, with no T and no (1−x²) factor? — and answers YES with the linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k}. Records the proof plan (sum recurrence + two-step induction), the build-pending status, and fixes the ambient commutative ring R.",
+      "mathContext": "$U_m \\cdot U_n = \\sum_{k=0}^{n} U_{m+n-2k} = U_{m+n} + U_{m+n-2} + \\cdots + U_{m-n}$ in $R[X]$."
+    },
+    {
+      "id": "ssum-def-and-two-x-u",
+      "title": "The Linearization Sum and the Rearranged Recurrence",
+      "startLine": 53,
+      "endLine": 62,
+      "summary": "Defines Ssum m n = ∑_{k∈range(n+1)} U_(m+n−2k), the candidate right-hand side. two_X_U rearranges the Chebyshev recurrence U_add_two into the symmetric form 2·X·U_k = U_(k+1) + U_(k−1), the single algebraic fact that drives all subsequent index bookkeeping.",
+      "mathContext": "$S(m,n) := \\sum_{k=0}^{n} U_{m+n-2k}$; $\\;2X\\,U_k = U_{k+1} + U_{k-1}$."
+    },
+    {
+      "id": "sum-recurrence",
+      "title": "The Product-Free Sum Recurrence (Ssum_rec)",
+      "startLine": 64,
+      "endLine": 100,
+      "summary": "Ssum_succ_expand distributes 2·X into S(m,n+1) termwise via two_X_U, producing a single sum of U-pairs over range(n+2). Ssum_rec then proves 2·X·S(m,n+1) = S(m,n+2) + S(m,n) by peeling the boundary terms of the two telescoped ranges with Finset.sum_range_succ; both boundary terms equal U_(m−n−2) and cancel. No Chebyshev products appear — the entire combinatorial core is isolated here.",
+      "mathContext": "$2X\\,S(m,n{+}1) = S(m,n{+}2) + S(m,n)$; the boundary terms $U_{m+n+2-2(n+2)}$ and $U_{m+n-2(n+1)}$ are both $U_{m-n-2}$."
+    },
+    {
+      "id": "base-values",
+      "title": "Base Values (Ssum_zero, Ssum_one)",
+      "startLine": 102,
+      "endLine": 113,
+      "summary": "Ssum_zero computes S(m,0) = U_m (a one-term sum via Finset.sum_range_one), and Ssum_one computes S(m,1) = U_(m+1) + U_(m−1). These anchor the two-step induction, matching the two consecutive cases the second-order recurrence requires.",
+      "mathContext": "$S(m,0) = U_m$, $\\;S(m,1) = U_{m+1} + U_{m-1}$."
+    },
+    {
+      "id": "main-induction",
+      "title": "Main Linearization by Two-Step Induction (U_mul_U)",
+      "startLine": 114,
+      "endLine": 145,
+      "summary": "U_mul_U proves U_m·U_n = S(m,n). It strengthens the goal to the paired statement P(j) ∧ P(j+1) so the second-order recurrence can be fed; the base cases use Ssum_zero/Ssum_one (with U_zero, U_one and two_X_U), and the inductive step combines U_add_two (U_{i+2} = 2X·U_{i+1} − U_i) with Ssum_rec at index i, closed by linear_combination.",
+      "mathContext": "Induction carries $P(j) := (U_m U_j = S(m,j))$ as the pair $P(j)\\wedge P(j+1)$, mirroring $U_{i+2} = 2X\\,U_{i+1} - U_i$."
+    }
+  ],
   "conclusion": {
     "summary": "Proves the second-kind Chebyshev linearization U_m·U_n = ∑_{k=0}^{n} U_{m+n−2k} as a polynomial identity over any commutative ring R, with 0 sorries and 0 axioms. The combinatorial core is the product-free sum recurrence Ssum_rec; the main identity follows by two-step induction.",
     "implications": "**Theoretical Significance**\n\n1. **Completes the Chebyshev product table**: T·T (two terms), T·U (two terms), and now U·U (a full progression sum) are all available as polynomial identities over arbitrary commutative rings.\n\n2. **Product-free combinatorial core**: `Ssum_rec` is reusable for any second-kind-Chebyshev sum manipulation and isolates the index bookkeeping from the algebra.\n\n3. **Multiplicative structure of the U-span**: the identity shows the ℤ-span of $\\{U_k\\}$ is closed under multiplication, with explicit structure constants (all equal to 1).",


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-02-oq-02-oq-01` (Chebyshev U·U Linearization).

The entry had a rich `meta`/`overview`/`conclusion` but an empty `sections` array and no `annotations.json` (quality 30).

## Changes
- Added a 5-section breakdown covering the full Lean file (lines 1–145): statement/strategy, the sum definition + rearranged recurrence, the product-free `Ssum_rec`, base values, and the two-step induction `U_mul_U`.
- Added `annotations.json` with 6 annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`).
- Deepened `overview.historicalContext` (trigonometric product-to-sum / Dirichlet-kernel context, Mason–Handscomb reference) and added a 5th `keyInsight` on CommRing generality.

Quality 30 → 100. **Status untouched**: the entry remains `formalized`/`wip` (build-pending — the Lean file is not yet machine-verified). No Lean source changes.