### PR TITLE
audit(mantel-theorem): badge "original" → "mathlib" (Tier B bridge)

### DIFF
--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/MantelTheorem.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: mantel-theorem
**Problem**: badge `original` overstates the tier — the core result is a Mathlib specialization.

## Evidence

`Proofs/MantelTheorem.lean` derives Mantel's edge bound by calling Mathlib's general Turán theorem:

```lean
theorem mantel_card_edgeFinset_le … (h : G.CliqueFree 3) :
    G.edgeFinset.card ≤ (Fintype.card V) ^ 2 / 4 := by
  have hb := CliqueFree.card_edgeFinset_le (r := 2) (G := G) h   -- Mathlib's Turán bound
  exact le_trans hb (le_of_eq (turan_two_simp _))
```

Mantel is literally the `r = 2` base case of Turán's theorem, and the heavy lifting (`SimpleGraph.CliqueFree.card_edgeFinset_le`) lives in Mathlib. The file's own contribution is the arithmetic collapse `turan_two_simp` (general r=2 RHS → ⌊n²/4⌋) and the sharpness witness `turanGraph n 2` — genuine, but a **bridge/specialization**, not an independent proof. This is Tier B.

The meta is otherwise scrupulously honest: the Mathlib reliance is disclosed in `mathlibDependencies`, `overview`, `conclusion`, `originalContributions` ("specialized from Mathlib's general Turán development"), and `axiomCountNote`. Only the **badge** signalled `original`.

## Fix

`badge`: `original` → `mathlib`. No other field changed.

`status` stays `verified` (0 sorries, 0 axioms, build green, 7743 jobs); the `mathlib` badge marks the Mathlib bridge. This mirrors the inclusion-exclusion-oq-01-oq-03 precedent (#24715).

---
Discovered during gallery integrity audit.