### PR TITLE
research(cube-root-3-irrational-oq-04): S32 — 27th CF convergent lower bound (a26=4)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -973,4 +973,36 @@ theorem one_zero_six_two_seven_nine_zero_nine_five_eight_five_two_nine_over_seve
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-- **Twenty-seventh continued-fraction convergent of `∛3`** (lower bound).
+
+The CF of `∛3` is `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+1, 3, 2, 3, 4, 1, 4, …]`.  With `a₂₆ = 4`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`,
+`qₖ = aₖ qₖ₋₁ + qₖ₋₂` on the 25th/26th convergents `1062790958529/736898093374`
+and `1310497171657/908647988973` gives the 27th convergent
+
+  `p₂₆ = 4·1310497171657 + 1062790958529 = 6_304_779_645_157`
+  `q₂₆ = 4·908647988973 + 736898093374 = 4_371_490_049_266`.
+
+After cubing,
+
+  `6_304_779_645_157³   = 250_616_544_228_682_948_175_334_960_223_187_684_893`
+  `3 · 4_371_490_049_266³ = 250_616_544_228_682_948_175_334_962_924_213_859_288`
+
+so `6_304_779_645_157³ < 3 · 4_371_490_049_266³` (strict, diff
+`2_701_026_174_395`), hence `(6304779645157/4371490049266)³ < 3` and
+`6304779645157/4371490049266 < cbrt3` as required for a lower bound (even
+convergent index `26`; relative gap `≈ 3.6·10⁻²⁷`).
+
+`a₂₆ = 4` was re-derived independently from a 400-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s32_27th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline: never re-quote a prior sketch tail, always recompute `aᵢ` and verify
+the cube-side direction before claiming.  This is the next uncontested rung above
+the 26th convergent (PR #24767); a routine, durable helper bound, not a deep
+result.  Two-line proof via the lower cubing-iff helper. -/
+theorem six_three_zero_four_seven_seven_nine_six_four_five_one_five_seven_over_four_three_seven_one_four_nine_zero_zero_four_nine_two_six_six_lt_cbrt3 :
+    (6304779645157 / 4371490049266 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,5 +1,33 @@
 # Current State
 
+## S32 (researcher-2, 2026-06-15) — 27th CF convergent LOWER bound
+
+**Phase:** ACT (Helper ladder — convergent bounds run ahead of the contention-blocked main quotient chain).
+
+Added the **27th CF convergent LOWER bound** `6304779645157/4371490049266 < cbrt3`
+(a26=4, even idx26 ⟹ lower) to `CubeRoot3IrrationalOQ04Helpers.lean`
+(976→1005 LOC, 27→28 theorems, 0 sorry / 0 axiom). Two-line cubing-iff proof
+(`rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`); cert
+`verify_cbrt3_oq04_s32_27th_convergent.py` PASSED (a26 re-derived at 400 digits;
+exact `p³ < 3q³`, diff 2701026174395, rel gap ≈ 3.6e-27). Build-pending (6
+concurrent lean-build containers on the 7.65GiB Docker VM ⟹ local build OOMs peers).
+
+**Ladder state:** main reaches 25th (idx24). Open PRs: 17th (#24516), 18th
+(#24538), 20th (#24612), 23rd (#24635), 26th (#24767). This PR adds the 27th —
+the next uncontested rung above #24767.
+
+**Correction logged:** the earlier S27/S28 state-note labeled
+`247706213128/171749895599` as the "23rd lower bound (a22=2)"; it is actually the
+24th convergent (idx23, a23=3, UPPER). The genuine 23rd is `71966106017/49898510978`
+(idx22, a22=2, lower, PR #24635). Always re-derive idx/sign from a fresh CF run.
+
+**Blocked frontier:** main a12=8 quotient chain (#23388 DRAFT / #23983 OPEN) —
+do not pile on a third a12 PR. Convergent helpers run ahead conflict-free.
+
+---
+
+# Current State
+
 ## S27 (researcher-2, 2026-06-15) — 21st CF convergent LOWER bound
 
 **Phase:** ACT (Helper ladder — convergent bounds run ahead of the contention-blocked main quotient chain).

--- a/research/scripts/verify_cbrt3_oq04_s32_27th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s32_27th_convergent.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+cube-root-3-irrational-oq-04 — S32 certificate for the 27th CF convergent of ∛3.
+
+Anti-typo discipline (see helpers file): independently RE-DERIVE the partial
+quotients aᵢ from a high-precision recomputation of ∛3 (do NOT re-quote a prior
+sketch tail), then verify (a) the convergent recursion against the previous two
+convergents and (b) the EXACT integer cube-side direction that the Lean proof
+relies on.
+
+27th convergent = idx 26 (0-indexed), a₂₆ = 4, a LOWER bound (even index):
+
+    6304779645157 / 4371490049266  <  ∛3      ⟺   p³ < 3 q³.
+"""
+from mpmath import mp, mpf, floor, cbrt
+import math
+
+mp.dps = 400
+x = cbrt(3)
+
+# Independent CF re-derivation
+a = []
+y = x
+for _ in range(30):
+    ai = int(floor(y))
+    a.append(ai)
+    y = 1 / (y - ai)
+
+# Convergents via the standard recurrence
+H = []; K = []
+hm1, hm2 = 1, 0
+km1, km2 = 0, 1
+for ai in a:
+    h = ai * hm1 + hm2
+    k = ai * km1 + km2
+    H.append(h); K.append(k)
+    hm2, hm1 = hm1, h
+    km2, km1 = km1, k
+
+idx = 26
+p, q = H[idx], K[idx]
+
+assert a[24] == 4, f"a24 expected 4, got {a[24]}"
+assert a[25] == 1, f"a25 expected 1, got {a[25]}"
+assert a[26] == 4, f"a26 expected 4, got {a[26]}"
+
+# Recursion check against 25th (idx24) and 26th (idx25) convergents
+assert p == a[26] * H[25] + H[24]
+assert q == a[26] * K[25] + K[24]
+assert math.gcd(p, q) == 1, "convergent must be in lowest terms"
+
+# This is a LOWER bound (even convergent index) ⟺ exact p³ < 3 q³
+p3 = p**3
+tq3 = 3 * q**3
+assert p3 < tq3, "cube-side direction wrong for a lower bound"
+
+print(f"a₂₄,a₂₅,a₂₆        = {a[24]}, {a[25]}, {a[26]}")
+print(f"25th conv (idx24)  = {H[24]}/{K[24]}")
+print(f"26th conv (idx25)  = {H[25]}/{K[25]}")
+print(f"27th conv (idx26)  = {p}/{q}")
+print(f"  p₂₆ = 4·{H[25]} + {H[24]} = {p}")
+print(f"  q₂₆ = 4·{K[25]} + {K[24]} = {q}")
+print(f"p³                 = {p3}")
+print(f"3·q³               = {tq3}")
+print(f"3·q³ − p³          = {tq3 - p3}  (>0 ⟹ lower bound, strict)")
+print(f"(p/q)³ vs 3        : {mpf(p)/q < x} (fraction < ∛3)")
+print(f"relative gap       ≈ {mp.nstr((x - mpf(p)/q)/x, 4)}")
+print("ALL CHECKS PASSED")


### PR DESCRIPTION
## Summary
Extends the verified continued-fraction convergent ladder for ∛3 (OQ-04's
finite-prefix verification goal) by one uncontested rung.

- **27th convergent (idx 26, a₂₆ = 4, lower bound):**
  `6304779645157/4371490049266 < cbrt3`.
- Proved in two lines via the existing lower cubing-iff helper; the exact integer
  inequality `6304779645157³ < 3·4371490049266³` (strict, diff `2701026174395`) is
  discharged by `norm_num` — identical in form and magnitude to the already
  machine-checked 25th-convergent theorem on `main`.
- `a₂₆ = 4` re-derived independently from a 400-digit CF recomputation; the
  convergent recursion (against the 25th/26th convergents) and the exact cube-side
  direction are certified by `research/scripts/verify_cbrt3_oq04_s32_27th_convergent.py`
  (`ALL CHECKS PASSED`). Relative gap `≈ 3.6·10⁻²⁷`.

This is the next uncontested rung above the 26th convergent (PR #24767), running
ahead conflict-free of the contention-blocked main a₁₂ quotient chain (#23388 / #23983).

Also corrects an earlier state-note mislabel: `247706213128/171749895599` is the
24th convergent (idx 23, a₂₃=3, **upper**), not the 23rd lower bound.

## Verification
- 0 sorry, 0 axiom; file already registered in `proofs/Proofs.lean`.
- **Build-pending**: 6 concurrent `lean-build` containers were sharing the 7.65GiB
  Docker VM, so a local build would OOM peers. Machine-check deferred to the
  deployer (deployer-gated).

## Test plan
- [ ] Deployer builds `Proofs.CubeRoot3IrrationalOQ04Helpers` and confirms 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)