### PR TITLE
Enrich ballot-problem-oq-01-oq-04: expand annotations

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/annotations.json
@@ -1,11 +1,20 @@
 [
   {
+    "id": "ann-chung-feller-statement",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 6, "endLine": 8 },
+    "type": "concept",
+    "title": "The Chung-Feller Theorem",
+    "content": "The Chung-Feller theorem is a striking refinement of the Catalan-number count of lattice paths. Among the C(2n,n) paths from (0,0) to (2n,0) with ±1 steps, those with exactly k upsteps strictly above the x-axis number Cₙ = C(2n,n)/(n+1) for every k ∈ {0,…,n} — the count is completely independent of k. So the n+1 'types' partition the paths into equal classes, each of Catalan size, even though Dyck paths (the k=n, fully-nonnegative case) are usually singled out.",
+    "mathContext": "$\\#\\{$paths $(0,0)\\to(2n,0)$ with exactly $k$ upsteps above the axis$\\} = \\dfrac{1}{n+1}\\binom{2n}{n} = C_n$, independent of $k$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "Dyck paths", "lattice paths", "Chung-Feller theorem"],
+    "prerequisites": ["binomial coefficients", "lattice path counting"]
+  },
+  {
     "id": "ann-three-file-architecture",
     "proofId": "ballot-problem-oq-01-oq-04",
-    "range": {
-      "startLine": 1,
-      "endLine": 49
-    },
+    "range": { "startLine": 1, "endLine": 49 },
     "type": "concept",
     "title": "Three-File Architecture: Eliminating an Axiom via Re-export",
     "content": "The file header documents a notable software architecture pattern for formal proofs: a placeholder axiom was eliminated by splitting the proof into three files. The problem was a circular dependency — `chung_feller_uniform` needed to live in the gallery face file (for naming), but the bijection proof that establishes it needed to import the gallery face to access shared definitions. The solution was to extract those shared definitions into a `Core` file that both can import, then have the gallery face import the bijection file and re-export the theorem under its conventional name. This is a clean way to handle what would otherwise be an unsolvable import cycle in Lean 4. The substantive content (`IsBalancedPath`, `prepend_one_good_rotation`, `balanced_path_total`, the explicit `chungFellerMap` bijection) lives in the companion `Core` and `OQ01` files, which this face file imports.",
@@ -25,12 +34,33 @@
     ]
   },
   {
+    "id": "ann-cycle-lemma-strategy",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 25, "endLine": 34 },
+    "type": "technique",
+    "title": "The Cycle Lemma and the Uniformity Bijection",
+    "content": "The proof rests on the Dvoretzky–Motzkin cycle lemma: prepend +1 to a balanced path to get a length-(2n+1) sequence summing to 1, and then exactly one of its 2n+1 cyclic rotations has all partial sums positive. Mapping each balanced path to (the Dyck tail of its unique good rotation, its number of upsteps above the axis) is a bijection onto (Dyck paths) × (Fin (n+1)). Because the second coordinate ranges freely over all n+1 types while the first is unconstrained, the fibers over each type are equinumerous — which is exactly the uniformity statement.",
+    "mathContext": "Bijection balancedPaths$(2n) \\;\\leftrightarrow\\;$ Dyck$(n) \\times \\mathrm{Fin}(n{+}1)$; the cycle lemma supplies the unique good rotation among $2n+1$.",
+    "significance": "key",
+    "relatedConcepts": ["cycle lemma", "Dvoretzky–Motzkin", "cyclic rotations", "bijective proof"],
+    "prerequisites": ["partial sums of ±1 sequences", "the ballot problem (parent entry)"]
+  },
+  {
+    "id": "ann-deaxiomatization",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 36, "endLine": 41 },
+    "type": "context",
+    "title": "From Axiom to Theorem: 0 Axioms, 0 Sorries",
+    "content": "An earlier version of this entry stated chung_feller_uniform as an outright axiom. It is now a proved theorem: the bijection file establishes chung_feller_uniform' with no axiom uses and no sorries, and the gallery face merely re-exports it. This is the substantive integrity improvement — the headline result is machine-checked rather than assumed.",
+    "mathContext": "Status: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries across Core / bijection / face.",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity", "de-axiomatization", "machine-checked proof"],
+    "prerequisites": ["Lean axiom vs theorem distinction"]
+  },
+  {
     "id": "ann-reexport-theorem",
     "proofId": "ballot-problem-oq-01-oq-04",
-    "range": {
-      "startLine": 55,
-      "endLine": 73
-    },
+    "range": { "startLine": 55, "endLine": 73 },
     "type": "insight",
     "title": "Gallery Face: Re-exporting the Proved Chung-Feller Theorem",
     "content": "The gallery face file is intentionally thin — it exists to provide a stable named entry point `chung_feller_uniform` in the `ChungFeller` namespace while the actual proof lives in the companion bijection file. The re-export is a single invocation of `ChungFellerBijection.chung_feller_uniform'`. This pattern is widely used in Mathlib: a 'face' module exposes a stable API while the underlying proof is in a separate module that can evolve independently. The displayed theorem states that for all j, k ≤ n the j-type and k-type balanced-path sets are equinumerous (uniform distribution); combined with `balanced_path_total` (C(2n,n) = Cₙ × (n+1)) this gives exactly Cₙ paths per type. The bijection proof has 0 sorries and 0 axiom uses, which any `#check @chung_feller_uniform` at the top of a downstream file can verify.",
@@ -48,5 +78,17 @@
       "balanced_path_total",
       "balancedPathsOfType"
     ]
+  },
+  {
+    "id": "ann-catalan-corollary",
+    "proofId": "ballot-problem-oq-01-oq-04",
+    "range": { "startLine": 62, "endLine": 63 },
+    "type": "insight",
+    "title": "Per-Type Catalan Count",
+    "content": "Uniformity alone says the n+1 type-classes are equal in size; pairing it with the counting identity balanced_path_total (C(2n,n) = Cₙ·(n+1)) pins each class to exactly Cₙ. This is the quantitative payoff: the Catalan number Cₙ counts not just Dyck paths but every single Chung-Feller type, so the total C(2n,n) splits into n+1 equal Catalan blocks.",
+    "mathContext": "$\\binom{2n}{n} = C_n\\,(n+1)$ with $n+1$ equal classes $\\Rightarrow$ each class has exactly $C_n$ paths.",
+    "significance": "supporting",
+    "relatedConcepts": ["Catalan numbers", "counting identities", "balanced_path_total"],
+    "prerequisites": ["the uniformity theorem chung_feller_uniform"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-01-oq-04` (Chung-Feller Theorem via the Cycle Lemma).

The entry had only 2 annotations (quality 73; annotations/mathContext/significance sub-scores low).

## Changes
- Added 4 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
  - the Chung-Feller statement (Catalan count independent of type),
  - the Dvoretzky–Motzkin cycle-lemma uniformity bijection,
  - the de-axiomatization status (0 axioms / 0 sorries),
  - the per-type Catalan corollary via `balanced_path_total`.
- Preserved the 2 existing annotations unchanged.

Quality 73 → 100. Only `annotations.json` changed; no meta, Lean, or status edits.