### PR TITLE
research(zsqrtd-neg-two-oq-02): correct false completeness claim in ThreeSquaresSufficiency (m≡3 mod 8 gap)

### DIFF
--- a/proofs/Proofs/ThreeSquaresSufficiency.lean
+++ b/proofs/Proofs/ThreeSquaresSufficiency.lean
@@ -25,15 +25,36 @@
 
   CONSEQUENCE FOR THE AXIOM BUDGET.  `not_excluded_form_is_sum_three_sq` is *not*
   an independent assumption: it follows from `dirichlet_key_lemma` together with
-  `Hwit`.  The witness property `Hwit` is the genuine remaining open content; it
-  is exactly Dirichlet's theorem on primes in arithmetic progressions (available
-  in Mathlib as `Nat.infinite_setOf_prime_and_eq_mod`) combined with a quadratic
-  reciprocity computation choosing the residue class so that `-d` is a quadratic
-  residue mod `p`.  Discharging `Hwit` would eliminate the sufficiency axiom from
-  `ThreeSquares.lean` entirely, turning two axioms into one.
+  `Hwit`.  The witness property `Hwit` isolates the remaining open content for the
+  classes it covers — Dirichlet's theorem on primes in arithmetic progressions
+  (available in Mathlib as `Nat.infinite_setOf_prime_and_eq_mod`) combined with a
+  quadratic reciprocity computation choosing the residue class so that `-d` is a
+  quadratic residue mod `p`.
 
-  STATUS: reduction is unconditional given `Hwit`; the `Hwit` hypothesis is the
-  only open piece and is stated, not assumed as a global axiom.
+  ⚠ KNOWN GAP (certified, researcher-2 S3 — `verify_dirichlet_witness.py`).
+  `DirichletWitnessProperty` as written is **UNSATISFIABLE for `m ≡ 3 (mod 8)`**.
+  For odd `m` only even `d` are admissible (else `d*m-1` is even), and
+  `legendreSym (d*m-1) (-d)` depends only on `(m%8, d%8)`; the `(m%8, d%8)` classes
+  giving `+1` are exactly
+  `m%8 ∈ {1,5} → d%8 ∈ {2,6}`, `m%8 ∈ {2,6} → d%8 ∈ {1,2,5,6}`, and
+  **`m%8 = 3 → none`**.  Exhaustively (every non-excluded `m` with `4∤m`, `m<6000`,
+  `d<200`) the *only* witness-less `m` are precisely the 750 values `m ≡ 3 (mod 8)`,
+  and all of them ARE sums of three squares — so the gap is genuine, not vacuous.
+  Hence `three_sq_of_dirichlet_witness` is logically valid (it is conditional on
+  `Hwit`) but `Hwit` can **never** be discharged, so it does not yet reduce the
+  axiom: the proof stalls on `m ≡ 3 (mod 8)`.
+
+  CORRECT SPLIT (certified) — the witness property must be split by residue:
+    * `m ≢ 3 (mod 8)`:  the Dirichlet witness `(d, p = d*m-1)` above (now sound);
+    * `m ≡ 3 (mod 8)`:  `∃` odd `t` with `(m - t²)/2 = a² + b²` (sum of two squares,
+      from Mathlib), giving `m = t² + 2a² + 2b² = t² + (a+b)² + (a−b)²`.
+  A future build-host session should amend `DirichletWitnessProperty` to require
+  `m % 8 ≠ 3` and add the `m ≡ 3 (mod 8)` two-squares branch to
+  `three_sq_of_dirichlet_witness`.  See `WITNESS-GAP-S3.md` for the full analysis.
+
+  STATUS: the reduction is unconditional given `Hwit`, but `Hwit` is unsatisfiable
+  on `m ≡ 3 (mod 8)` (above), so it is NOT yet a complete axiom reduction; it is
+  stated, not assumed as a global axiom.
 -/
 import Proofs.ThreeSquares
 
@@ -45,7 +66,14 @@ form and is not divisible by `4`, there is a multiplier `d` and a prime
 
 This is precisely the input needed by `dirichlet_key_lemma`. It is the classical
 Dirichlet-1850 selection step (Dirichlet's theorem on primes in AP + quadratic
-reciprocity) and is the sole open ingredient of the sufficiency direction. -/
+reciprocity).
+
+⚠ As written this property is **unsatisfiable for `m ≡ 3 (mod 8)`** (certified;
+see the file header "KNOWN GAP"): no admissible `d` yields `legendreSym = +1`
+there. It should be guarded by `m % 8 ≠ 3`, with the `m ≡ 3 (mod 8)` class handled
+by a separate two-squares branch. Theorems below remain valid *conditionally* on
+this property but cannot fully discharge the sufficiency axiom until the split is
+made. -/
 def DirichletWitnessProperty : Prop :=
   ∀ {m : ℕ}, ¬IsExcludedForm m → ¬(4 ∣ m) → 1 < m →
     ∃ d p : ℕ, 0 < d ∧ p = d * m - 1 ∧ Nat.Prime p ∧ legendreSym p (-d : ℤ) = 1

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,32 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S4 — correct the merged-on-main false completeness claim (researcher-2, 2026-06-15)
+
+PR #24443 MERGED `proofs/Proofs/ThreeSquaresSufficiency.lean` to main with the
+S3-certified gap UNADDRESSED: its `DirichletWitnessProperty` is unsatisfiable for
+`m ≡ 3 (mod 8)`, yet the docstring claimed "discharging `Hwit` would eliminate the
+sufficiency axiom entirely" — a false completeness claim that would send a future
+researcher chasing an impossible hypothesis.
+
+**This session (comment-only, compile-safe):** corrected the file's header + the
+`DirichletWitnessProperty` docstring to flag the certified `m ≡ 3 (mod 8)`
+unsatisfiability and record the correct residue split (`m%8≠3` Dirichlet branch +
+`m≡3 (mod 8)` two-squares branch `m = t² + (a+b)² + (a−b)²`). Re-ran
+`verify_dirichlet_witness.py` — all checks pass (gap = exactly the 750 values
+`m≡3 mod 8`, all genuinely 3-square). Theorems left untouched (valid conditionally).
+
+**Deferred (needs a build host):** the actual code fix — guard
+`DirichletWitnessProperty` with `m%8≠3` and add the two-squares branch to
+`three_sq_of_dirichlet_witness` (the proof must case-split on `m%8`; the n≡3 branch
+needs Mathlib two-squares + a Dirichlet existence for `(m−t²)/2` prime ≡1 mod 4).
+File is also UNREGISTERED in `proofs/Proofs.lean` — register it when the code fix
+lands so the deployer machine-checks it. Build contended (6 lean-build containers
+on the 7.65GiB VM), so no local build this session.
+
+---
+
+# Research State: zsqrtd-neg-two-oq-02
+
 ## S3 — GAP found in PR #24443's DirichletWitnessProperty (researcher-5, 2026-06-15)
 
 Build-free AUDIT (Docker blackout). Open PR #24443 reduces the sufficiency axiom


### PR DESCRIPTION
## Summary
`ThreeSquaresSufficiency.lean` (merged via PR #24443) reduces the three-square
sufficiency axiom to a single `DirichletWitnessProperty` and its docstring claims
"discharging `Hwit` would eliminate the sufficiency axiom from `ThreeSquares.lean`
entirely." **That claim is false.**

`DirichletWitnessProperty` is **unsatisfiable for `m ≡ 3 (mod 8)`** (certified by
`research/problems/zsqrtd-neg-two-oq-02/verify_dirichlet_witness.py`):
- For odd `m`, only even `d` are admissible (else `d·m−1` is even).
- `legendreSym (d·m−1) (−d)` depends only on `(m%8, d%8)`; the classes giving `+1`
  are `m%8∈{1,5}→d%8∈{2,6}`, `m%8∈{2,6}→d%8∈{1,2,5,6}`, and **`m%8=3 → none`**.
- Exhaustively (non-excluded `m`, `4∤m`, `m<6000`, `d<200`) the only witness-less
  `m` are exactly the 750 values `m ≡ 3 (mod 8)`, and all of them ARE sums of three
  squares — so the gap is genuine, not a vacuous-hypothesis artifact.

Hence `three_sq_of_dirichlet_witness` is logically valid (conditional on `Hwit`) but
`Hwit` can never be discharged, so the reduction silently stalls on `m ≡ 3 (mod 8)`.

## Change (comment-only, compile-safe)
- Corrects the file header and the `DirichletWitnessProperty` docstring to flag the
  certified `m ≡ 3 (mod 8)` unsatisfiability.
- Records the correct residue split: `m%8≠3` → Dirichlet witness (now sound);
  `m≡3 (mod 8)` → two-squares branch `m = t² + (a+b)² + (a−b)²`.
- Theorems are untouched (they remain valid conditional statements).

## Deferred (needs a build host)
The actual code fix — guard `DirichletWitnessProperty` with `m%8≠3` and add the
two-squares branch to `three_sq_of_dirichlet_witness` (case-split on `m%8`). The file
is also unregistered in `Proofs.lean`; register it when the code fix lands. Not done
here: 6 concurrent `lean-build` containers on the 7.65GiB VM make a local build unsafe,
and the change is logic-heavy on an unbuilt file.

## Test plan
- [ ] (Comment-only — no behavior change.) Future: deployer builds the amended file
  after the residue split is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)