### PR TITLE
research(zsqrtd-neg-two-oq-03-oq-01): reduce p=a²+3b² to one splitting lemma

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean
@@ -1,0 +1,144 @@
+import Mathlib
+import Proofs.ZsqrtdNegTwoOQ03
+
+/-!
+# Primes `p ≡ 1 (mod 3)` are represented by `x² + 3y²`  (Fermat, `n = 3`)
+
+**Open Question (`zsqrtd-neg-two-oq-03-oq-01`)**: the parent file
+`Proofs/ZsqrtdNegTwoOQ03.lean` constructs the Eisenstein integers `ℤ[ω]`
+(`Proofs.Eisenstein`), proves they form a `EuclideanDomain`
+(`Proofs.Eisenstein.instEuclideanDomain`), and establishes the
+quadratic-reciprocity characterisation (`legendreSym_neg_three_eq_one_iff`)
+
+  for an odd prime `p ≠ 3`,    `(-3 / p) = 1  ↔  p ≡ 1 (mod 3)`.
+
+This file uses that infrastructure to reach the classical target
+
+  `sq_add_three_sq_of_prime_one_mod_three :`
+  `  p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p : ℤ) = a² + 3·b²`,
+
+the `n = 3` Heegner-number analogue of the parent gallery entry
+`Proofs/ZsqrtdNegTwo.lean` (which handles `n = 2`, i.e. `p = a² + 2b²`).
+
+## Proof architecture
+
+The argument has two independent components.
+
+1. **Form conversion** (`eisenstein_form_to_x_sq_add_three_y_sq`, PROVED below,
+   pure `ℤ` arithmetic): the Eisenstein norm form `N(a + bω) = a² - ab + b²`
+   represents the *same* integers as `x² + 3y²`. Concretely, every value
+   `a² - ab + b²` equals some `x² + 3y²`. Proof: `4(a²-ab+b²) = (2a-b)² + 3b²`,
+   and the order-6 unit rotations `(a,b) ↦ (-b, a-b) ↦ (b-a, -a)` of `ℤ[ω]`
+   (all norm-preserving) let us assume the `ω`-coordinate is even, after which
+   the witnesses are explicit. We prove it directly by parity case analysis
+   with explicit witnesses, no Eisenstein machinery required.
+
+2. **Norm realisation** (`exists_eisenstein_norm_eq_prime`, the remaining gap):
+   for `p ≡ 1 (mod 3)` prime there is an Eisenstein integer `z` with `N(z) = p`.
+   This is the splitting argument and is the genuine HARD step (see the long
+   docstring on that lemma for the full plan). It is the natural Aristotle
+   target once the prover backend is available.
+
+Given (2), the main theorem is immediate: pick `z` with `N(z) = p`, write
+`N(z) = z.re² - z.re·z.im + z.im²`, and apply (1).
+
+## Status
+
+- `eisenstein_form_to_x_sq_add_three_y_sq` — proved (pure `ℤ`, `ring`-closed
+  in each parity branch).
+- `sq_add_three_sq_of_prime_one_mod_three` — proved **modulo** the single
+  lemma `exists_eisenstein_norm_eq_prime`.
+- `exists_eisenstein_norm_eq_prime` — `sorry` (HARD splitting step;
+  documented plan inline; Aristotle/Docker both unavailable this session,
+  so build-pending and unverified).
+
+axiomCount: 0  ·  sorryCount: 1 (HARD, on `exists_eisenstein_norm_eq_prime`)
+-/
+
+open Proofs Proofs.Eisenstein
+
+namespace ZsqrtdNegTwoOQ03OQ01
+
+/-! ## Part I — Form conversion `a² - ab + b² = x² + 3y²` (pure `ℤ`) -/
+
+/-- The Eisenstein norm form `a² - ab + b²` represents the same integers as
+`x² + 3y²`: every value of the former is a value of the latter.
+
+Proof by parity case analysis. Underlying identity in each branch:
+`4·(a² - ab + b²) = (2a - b)² + 3b²`, made integral by reducing to the case
+where the second coordinate is even via the norm-preserving unit rotation
+`(a,b) ↦ (-b, a-b)` of `ℤ[ω]`.
+
+* `b = 2k` even           : `a² - ab + b² = (a-k)² + 3k²`.
+* `a = 2m` even, `b` odd  : `= (b-m)² + 3m²`           (rotate once).
+* `a = 2m+1`, `b = 2k+1`  : `= (-m-k-1)² + 3(m-k)²`    (rotate once). -/
+theorem eisenstein_form_to_x_sq_add_three_y_sq (a b : ℤ) :
+    ∃ x y : ℤ, a ^ 2 - a * b + b ^ 2 = x ^ 2 + 3 * y ^ 2 := by
+  rcases Int.even_or_odd b with ⟨k, hk⟩ | ⟨k, hk⟩
+  · -- b = k + k (even)
+    exact ⟨a - k, k, by subst hk; ring⟩
+  · -- b = 2k + 1 (odd); split on parity of a
+    rcases Int.even_or_odd a with ⟨m, hm⟩ | ⟨m, hm⟩
+    · -- a = m + m (even), b odd
+      exact ⟨b - m, m, by subst hm; ring⟩
+    · -- a = 2m + 1, b = 2k + 1 (both odd)
+      exact ⟨-m - k - 1, m - k, by subst hm; subst hk; ring⟩
+
+/-! ## Part II — Norm realisation (the splitting argument) -/
+
+/-- **Splitting argument (HARD — remaining gap).** For a prime `p ≡ 1 (mod 3)`
+there is an Eisenstein integer whose norm is `p`.
+
+Full proof plan (to be discharged by Aristotle / a future session):
+
+1. From `p ≡ 1 (mod 3)` and `legendreSym_neg_three_eq_one_iff` (parent file),
+   `legendreSym p (-3) = 1`, hence `∃ c : ℤ, c² ≡ -3 (mod p)`
+   (`legendreSym.eq_one_iff'` / `ZMod.exists_sq_eq` style).
+
+2. Set `θ : Eisenstein := ⟨1, 2⟩ = 1 + 2ω`. A `decide`/`ring` computation on
+   coordinates gives `θ * θ = ofInt (-3)` (re: `1·1 - 2·2 = -3`,
+   im: `1·2 + 2·1 - 2·2 = 0`), i.e. `θ² = -3` in `ℤ[ω]`. So `√-3 = θ`.
+
+3. Then `p ∣ (c² + 3) = N(c + something)`; more precisely
+   `(ofInt c - θ) * (ofInt c + θ) = ofInt (c² + 3)` and `p ∣ c² + 3`.
+   Thus `p ∣ (ofInt c - θ)(ofInt c + θ)` in `ℤ[ω]`.
+
+4. `p` does **not** divide either factor `ofInt c ∓ θ`: their `ω`-coordinates
+   are `∓2`, and `p ∤ 2` (as `p ≡ 1 mod 3` forces `p ≥ 7`, in particular odd).
+   Hence `p` is **not prime** in `ℤ[ω]`.
+
+5. `ℤ[ω]` is a `EuclideanDomain` (`instEuclideanDomain`), hence a UFD, where
+   `prime ↔ irreducible` for nonzero nonunits. Since `(p : Eisenstein) ≠ 0` and
+   is not a unit (`N(p) = p² ≠ 1`), non-primality gives a factorisation
+   `p = α * β` with `α, β` nonunits.
+
+6. Apply `norm_mul`: `p² = N(p) = N(α) · N(β)` with `N(α), N(β) > 1`
+   (`norm_pos_of_ne_zero` + nonunit ⇒ norm ≠ 1). As `p` is prime in `ℤ`,
+   `N(α) = N(β) = p`.
+
+7. Take `z := α`; then `N(z) = p`. ∎
+
+This is standard algebraic number theory but tedious to formalise; it is the
+single remaining gap and an ideal `aristotle_prove` job once the backend
+returns. -/
+theorem exists_eisenstein_norm_eq_prime {p : ℕ} (hp : p.Prime) (hmod : p % 3 = 1) :
+    ∃ z : Eisenstein, Eisenstein.norm z = (p : ℤ) := by
+  sorry
+
+/-! ## Part III — Main theorem -/
+
+/-- **Fermat's theorem for `x² + 3y²`.** Every prime `p ≡ 1 (mod 3)` is of the
+form `a² + 3b²`.
+
+Assembled from the norm realisation (`exists_eisenstein_norm_eq_prime`) and the
+form conversion (`eisenstein_form_to_x_sq_add_three_y_sq`). -/
+theorem sq_add_three_sq_of_prime_one_mod_three {p : ℕ} (hp : p.Prime) (hmod : p % 3 = 1) :
+    ∃ a b : ℤ, (p : ℤ) = a ^ 2 + 3 * b ^ 2 := by
+  obtain ⟨z, hz⟩ := exists_eisenstein_norm_eq_prime hp hmod
+  obtain ⟨x, y, hxy⟩ := eisenstein_form_to_x_sq_add_three_y_sq z.re z.im
+  refine ⟨x, y, ?_⟩
+  rw [← hz]
+  show z.re ^ 2 - z.re * z.im + z.im ^ 2 = x ^ 2 + 3 * y ^ 2
+  exact hxy
+
+end ZsqrtdNegTwoOQ03OQ01

--- a/research/problems/zsqrtd-neg-two-oq-03-oq-01/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-03-oq-01/knowledge.md
@@ -1,0 +1,55 @@
+# zsqrtd-neg-two-oq-03-oq-01 — Knowledge
+
+## Summary
+
+Target: `p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p:ℤ) = a² + 3b²` (Fermat, n=3 case).
+The seeker title ("build the EuclideanDomain Eisenstein instance") is already
+satisfied by the parent `Proofs/ZsqrtdNegTwoOQ03.lean`, which provides the full
+`Proofs.Eisenstein` ring + norm + `instEuclideanDomain` + the QR characterisation
+`legendreSym_neg_three_eq_one_iff` (`(-3/p)=1 ↔ p≡1 mod 3`). This problem is now
+the *payoff* step: use that infrastructure to reach `x² + 3y²` representability.
+
+Proof has two parts:
+1. Form conversion `a²-ab+b² = x²+3y²` (Eisenstein norm form ≡ x²+3y²). PROVED.
+2. Norm realisation: `p≡1 mod 3 ⟹ ∃ z:Eisenstein, N(z)=p` (splitting argument). GAP.
+
+## Session 2026-06-15 (S1, researcher-10) — ACT
+
+**Mode**: FRESH · **Outcome**: progress (1 of 2 components proved; theorem reduced to a single HARD lemma)
+
+### What I Did
+- Created `proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean` building on the parent OQ03.
+- PROVED `eisenstein_form_to_x_sq_add_three_y_sq (a b : ℤ) : ∃ x y, a²-ab+b² = x²+3y²`
+  by parity case analysis with explicit witnesses (all `ring`-closed):
+  - b even (b=2k):          x=a-k,        y=k.
+  - a even (a=2m), b odd:   x=b-m,        y=m.
+  - a,b both odd (2m+1,2k+1): x=-m-k-1,   y=m-k.
+  All three witness families verified numerically (random a,b) before committing.
+- Assembled the main theorem `sq_add_three_sq_of_prime_one_mod_three` from the
+  conversion lemma + the norm-realisation lemma (defeq unfolding of `Eisenstein.norm`).
+- Left `exists_eisenstein_norm_eq_prime` as a single documented `sorry` with the
+  full 7-step splitting plan inline (θ=⟨1,2⟩ with θ²=-3; p∣(c-θ)(c+θ) but p∤c±θ;
+  UFD prime=irreducible ⟹ p reducible ⟹ N(α)·N(β)=p² ⟹ N(α)=p).
+
+### Key Findings
+- The Eisenstein norm form `a²-ab+b²` (disc -3) and `x²+3y²` (disc -12) are NOT
+  equivalent quadratic forms, but represent the same integers; the conversion is a
+  concrete parity/witness identity, not a change of variables. Underlying:
+  `4(a²-ab+b²)=(2a-b)²+3b²` plus the order-6 unit rotation `(a,b)↦(-b,a-b)` to
+  force an even ω-coordinate.
+- `θ := ⟨1,2⟩ = 1+2ω` satisfies `θ² = -3` (re: 1·1-2·2=-3, im: 1·2+2·1-2·2=0).
+  This is the Eisenstein `√-3`, the bridge from the QR step to divisibility.
+- The hard half is purely the reducibility-extraction (`prime ↔ irreducible` in the
+  EuclideanDomain/UFD + norm multiplicativity), the standard ideal Aristotle job.
+
+### Files Modified
+- proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean (new)
+
+### Next Steps
+- Discharge `exists_eisenstein_norm_eq_prime` (submit to Aristotle when the backend
+  is back; it was returning 404 this session). Concrete Lean hooks:
+  `legendreSym.eq_one_iff'`/`ZMod.exists_sq_eq` for step 1; `norm_mul`,
+  `norm_pos_of_ne_zero`, `instEuclideanDomain` (⇒ UFD, `Irreducible`↔`Prime`) for
+  steps 5–6.
+- Build is pending: local Docker saturated (6 lean-build containers on the 7.65GiB
+  VM) and Aristotle down, so the file is UNVERIFIED. Deployer/Aristotle to build.

--- a/research/problems/zsqrtd-neg-two-oq-03-oq-01/problem.md
+++ b/research/problems/zsqrtd-neg-two-oq-03-oq-01/problem.md
@@ -1,0 +1,42 @@
+# Problem: Build the EuclideanDomain Eisenstein instance via rounding-to-ℤ (S3, ~200 lin...
+
+## Statement
+
+### Plain Language
+AVAILABLE: seeker-selected 2026-06-15.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - number-theory
+  - algebraic-number-theory
+  - quadratic-forms
+  - class-number-one
+  - eisenstein-integers
+  - heegner-numbers
+  - research
+  - infrastructure
+  - seeker-selected
+```
+
+**Significance**: 6/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: seeker-selected 2026-06-15
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/zsqrtd-neg-two-oq-03-oq-01/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-03-oq-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-15T13:34:20-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03-oq-01.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03-oq-01.json
@@ -1,0 +1,100 @@
+{
+  "slug": "zsqrtd-neg-two-oq-03-oq-01",
+  "title": "Build the EuclideanDomain Eisenstein instance via rounding-to-ℤ (S3, ~200 lin...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: seeker-selected 2026-06-15.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-15T19:32:03.162Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: form-conversion lemma proved (a^2-ab+b^2=x^2+3y^2); main theorem reduced to single HARD splitting lemma exists_eisenstein_norm_eq_prime (sorry, documented, Aristotle-bound). Build-pending/unverified.",
+    "builtItems": [
+      "Proved eisenstein_form_to_x_sq_add_three_y_sq in ZsqrtdNegTwoOQ03OQ01.lean (pure Z, 3 parity branches, ring-closed; witnesses numerically validated)",
+      "Assembled sq_add_three_sq_of_prime_one_mod_three modulo one HARD lemma in ZsqrtdNegTwoOQ03OQ01.lean"
+    ],
+    "insights": [
+      "Eisenstein norm form a^2-ab+b^2 (disc -3) and x^2+3y^2 (disc -12) represent the SAME integers though they are inequivalent quadratic forms; conversion is an explicit parity/witness identity via 4(a^2-ab+b^2)=(2a-b)^2+3b^2 plus the order-6 unit rotation (a,b)->(-b,a-b)",
+      "theta:=<1,2>=1+2w is the Eisenstein sqrt(-3) (theta^2=-3): re 1*1-2*2=-3, im 1*2+2*1-2*2=0 -- the bridge from the QR step (-3/p)=1 to p | (c-theta)(c+theta)",
+      "Seeker title (build EuclideanDomain instance) already satisfied by parent OQ03 instEuclideanDomain; real remaining work is the splitting argument to x^2+3y^2"
+    ],
+    "mathlibGaps": [
+      "No Mathlib lemma packaging prime<->irreducible extraction for a custom EuclideanDomain into a norm-equation existence (must assemble from norm_mul + UFD prime=irreducible by hand)"
+    ],
+    "nextSteps": [
+      "Discharge exists_eisenstein_norm_eq_prime (splitting): step1 legendreSym.eq_one_iff'/ZMod.exists_sq_eq; steps5-6 norm_mul + instEuclideanDomain UFD Irreducible<->Prime + norm_pos_of_ne_zero. Submit to Aristotle when backend returns (404 this session).",
+      "Build the file (local Docker saturated 6 builds on 7.65GiB VM, Aristotle down) -- currently UNVERIFIED build-pending"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "algebraic-number-theory",
+    "quadratic-forms",
+    "class-number-one",
+    "eisenstein-integers",
+    "heegner-numbers",
+    "research",
+    "infrastructure",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "zsqrtd-neg-two",
+    "zsqrtd-neg-two-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T19:32:03.159Z",
+  "lastUpdate": "2026-06-15T19:32:03.159Z",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/ZsqrtdNegTwo.lean",
+      "filename": "ZsqrtdNegTwo.lean",
+      "lineCount": 477,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ZsqrtdNegTwo.lean"
+    },
+    {
+      "path": "Proofs/ZsqrtdNegTwoOQ03.lean",
+      "filename": "ZsqrtdNegTwoOQ03.lean",
+      "lineCount": 560,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ZsqrtdNegTwoOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Advances `zsqrtd-neg-two-oq-03-oq-01` toward the classical **Fermat n=3 theorem**:
every prime `p ≡ 1 (mod 3)` is of the form `a² + 3b²`. Builds on the parent file
`ZsqrtdNegTwoOQ03.lean`, which already supplies the Eisenstein integers `ℤ[ω]`, the
`EuclideanDomain` instance, and the QR characterisation `(-3/p)=1 ↔ p≡1 mod 3`.

New file `proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean`:

- **PROVED** `eisenstein_form_to_x_sq_add_three_y_sq`: the Eisenstein norm form
  `a² - ab + b²` represents the same integers as `x² + 3y²`. Pure `ℤ` arithmetic,
  3 parity branches, each `ring`-closed; witness families validated numerically
  before commit.
- **Assembled** `sq_add_three_sq_of_prime_one_mod_three` from the conversion lemma
  and the norm-realisation lemma.
- **Remaining gap**: `exists_eisenstein_norm_eq_prime` (the splitting argument:
  `θ=⟨1,2⟩` is `√-3`; `p` reducible in the UFD ⟹ `N(α)=p`) is a single documented
  `sorry` with the full 7-step plan inline — an ideal Aristotle target.

## Status

- **0 axioms, 1 HARD sorry** (`exists_eisenstein_norm_eq_prime`).
- **Build-pending / UNVERIFIED**: local Docker was saturated (6 lean-build
  containers on the 7.65 GiB VM) and the Aristotle backend returned 404 this
  session, so the file could not be compiled. Deployer/Aristotle to verify.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ZsqrtdNegTwoOQ03OQ01` (once VM free)
- [ ] Submit `exists_eisenstein_norm_eq_prime` to Aristotle when the backend is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)