### PR TITLE
research(sqrt2-minpoly-oq-01-oq-02): minpoly ℚ (√r) = X² − r for non-square rational r

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2861,6 +2861,7 @@ import Proofs.Sqrt2Irrational
 import Proofs.Sqrt2IrrationalFromAxioms
 import Proofs.Sqrt2Minpoly
 import Proofs.Sqrt2MinpolyOQ01
+import Proofs.Sqrt2MinpolyOQ01OQ02
 import Proofs.Sqrt2MinpolyOQ02
 import Proofs.Sqrt2MinpolyOQ03
 import Proofs.Sqrt2OQ01

--- a/proofs/Proofs/Sqrt2MinpolyOQ01OQ02.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01OQ02.lean
@@ -1,0 +1,205 @@
+import Mathlib
+
+open Polynomial IntermediateField
+
+set_option maxHeartbeats 800000
+
+/-
+# Minimal Polynomial of √r over ℚ for a Rational Radicand r
+
+**Open Question (from sqrt2-minpoly-oq-01-oq-02)**:
+
+The gallery already proves `minpoly ℚ (√n) = X² - n` for every non-perfect-square
+natural number `n` (see `Sqrt2MinpolyOQ01.minpoly_sqrt_of_not_sq`). This file
+generalizes the radicand from a natural number to an arbitrary **nonnegative rational**
+`r`:
+
+  if `r ≥ 0` is not a square in `ℚ`, then `minpoly ℚ (√r) = X² - r`.
+
+Equivalently, writing `r = p/q` in lowest terms, the (monic) minimal polynomial is
+`X² - p/q`, whose cleared-denominator associate is `q·X² - p`.
+
+## Mathematical Content
+
+The minimal polynomial is, by definition, **monic**, so the canonical answer is the
+monic `X² - C r`; the form `q·X² - p` from the problem statement is the non-monic
+integer associate obtained by scaling by `C q` (see `cleared_denom_form`).
+
+The proof mirrors the natural-number argument of `Sqrt2MinpolyOQ01` Part VII:
+1. `X² - C r` is monic and has `√r` as a root, so `minpoly ℚ (√r) ∣ X² - C r`,
+   giving degree `≤ 2`.
+2. If `r` is not a rational square then `√r` is irrational, forcing degree `≥ 2`.
+3. A monic divisor of a monic degree-2 polynomial that itself has degree 2 must equal it.
+
+The irrationality step is in fact **simpler** over `ℚ` than over `ℕ`: if `√r = (s : ℝ)`
+for some rational `s`, then `s² = r` exhibits `r` as a rational square directly — no
+appeal to `irrational_nrt_of_notint_nrt` is needed.
+
+## Corollary
+
+`√r` is irrational **iff** `r` is not a rational square (for `r ≥ 0`).
+
+## Status: 0 sorries, 0 axioms. Build-pending (Docker/Aristotle unavailable this session);
+proof is a direct adaptation of the machine-verified `Sqrt2MinpolyOQ01` Part VII.
+-/
+
+namespace Sqrt2MinpolyOQ01OQ02
+
+/-! ## Part I: Irrationality for a Rational Radicand -/
+
+/-- If `r` is a nonnegative rational that is **not** a square in `ℚ`, then `√r` is
+    irrational.
+
+    Direct proof: a rational value `s` of `√r` would satisfy `s² = r`, making `r` a
+    rational square. -/
+theorem irrational_sqrt_of_not_isSquare_rat (r : ℚ) (hr : 0 ≤ r) (hns : ¬ IsSquare r) :
+    Irrational (Real.sqrt (r : ℝ)) := by
+  rintro ⟨s, hs⟩
+  apply hns
+  have hr' : (0 : ℝ) ≤ (r : ℝ) := by exact_mod_cast hr
+  have hsq : (s : ℝ) ^ 2 = (r : ℝ) := by rw [hs]; exact Real.sq_sqrt hr'
+  have hsq_q : s ^ 2 = r := by exact_mod_cast hsq
+  exact ⟨s, by rw [← hsq_q]; ring⟩
+
+/-! ## Part II: The Minimal Polynomial -/
+
+/-- **Main Theorem**: `minpoly ℚ (√r) = X² - r` for any nonnegative rational `r`
+    that is not a square in `ℚ`.
+
+    This generalizes `Sqrt2MinpolyOQ01.minpoly_sqrt_of_not_sq` from natural-number
+    radicands to rational radicands. -/
+theorem minpoly_sqrt_of_not_isSquare_rat (r : ℚ) (hr : 0 ≤ r) (hns : ¬ IsSquare r) :
+    minpoly ℚ (Real.sqrt (r : ℝ)) = X ^ 2 - C r := by
+  have hr' : (0 : ℝ) ≤ (r : ℝ) := by exact_mod_cast hr
+  have hAM : (algebraMap ℚ ℝ) r = (r : ℝ) := eq_ratCast (algebraMap ℚ ℝ) r
+  have hXn_monic : (X ^ 2 - C r : ℚ[X]).Monic := monic_X_pow_sub_C _ (by norm_num)
+  have hXn_aeval : Polynomial.aeval (Real.sqrt (r : ℝ)) (X ^ 2 - C r : ℚ[X]) = 0 := by
+    have hsq : Real.sqrt (r : ℝ) ^ 2 = (r : ℝ) := Real.sq_sqrt hr'
+    simp only [map_sub, map_pow, aeval_X, aeval_C]
+    rw [hAM, hsq, sub_self]
+  have hintegral : IsIntegral ℚ (Real.sqrt (r : ℝ)) :=
+    ⟨X ^ 2 - C r, hXn_monic, hXn_aeval⟩
+  have hdvd : minpoly ℚ (Real.sqrt (r : ℝ)) ∣ X ^ 2 - C r :=
+    minpoly.dvd ℚ (Real.sqrt (r : ℝ)) hXn_aeval
+  have hXn_ne : (X ^ 2 - C r : ℚ[X]) ≠ 0 := Polynomial.Monic.ne_zero hXn_monic
+  have hdeg_le : (minpoly ℚ (Real.sqrt (r : ℝ))).natDegree ≤ 2 := by
+    have := Polynomial.natDegree_le_of_dvd hdvd hXn_ne
+    simpa [Polynomial.natDegree_X_pow_sub_C] using this
+  have hirr : Irrational (Real.sqrt (r : ℝ)) :=
+    irrational_sqrt_of_not_isSquare_rat r hr hns
+  have hdeg_ge : 2 ≤ (minpoly ℚ (Real.sqrt (r : ℝ))).natDegree := by
+    by_contra hlt
+    push_neg at hlt
+    have hdeg1 : (minpoly ℚ (Real.sqrt (r : ℝ))).natDegree = 1 := by
+      have hge1 := minpoly.natDegree_pos hintegral; omega
+    obtain ⟨a, b, ha, hfab⟩ := Polynomial.natDegree_eq_one.mp hdeg1
+    have hmonic := minpoly.monic hintegral
+    have ha1 : a = 1 := by
+      have hlc := hmonic.leadingCoeff
+      rw [hfab] at hlc
+      simp [Polynomial.leadingCoeff_add_of_degree_lt, Polynomial.degree_C_mul_X ha,
+            Polynomial.degree_C, ha] at hlc
+      exact hlc
+    rw [ha1, one_mul] at hfab
+    have heval := minpoly.aeval ℚ (Real.sqrt (r : ℝ))
+    rw [hfab] at heval
+    simp only [map_add, aeval_X, aeval_C] at heval
+    rw [eq_ratCast (algebraMap ℚ ℝ) b] at heval
+    exact hirr ⟨-b, by push_cast; linarith⟩
+  have hdeg : (minpoly ℚ (Real.sqrt (r : ℝ))).natDegree = 2 := Nat.le_antisymm hdeg_le hdeg_ge
+  obtain ⟨c, hc⟩ := hdvd
+  have hc_ne : c ≠ 0 := by intro hc0; simp [hc0] at hc; exact hXn_ne hc
+  have hc_deg : c.natDegree = 0 := by
+    have hmul_deg := Polynomial.natDegree_mul (minpoly.ne_zero hintegral) hc_ne
+    rw [← hc, Polynomial.natDegree_X_pow_sub_C, hdeg] at hmul_deg
+    omega
+  have hc_one : c = 1 := by
+    have hmul_lc : (minpoly ℚ (Real.sqrt (r : ℝ)) * c).leadingCoeff = 1 := by
+      rw [← hc]; exact hXn_monic.leadingCoeff
+    rw [Polynomial.leadingCoeff_mul, (minpoly.monic hintegral).leadingCoeff, one_mul] at hmul_lc
+    have hc_const := Polynomial.eq_C_of_natDegree_eq_zero hc_deg
+    rw [hc_const, Polynomial.leadingCoeff_C] at hmul_lc
+    rw [hc_const, hmul_lc, map_one]
+  rw [hc_one, mul_one] at hc
+  exact hc.symm
+
+/-! ## Part III: Irrationality Characterization -/
+
+/-- **Corollary**: For `r ≥ 0`, `√r` is irrational **iff** `r` is not a rational square. -/
+theorem irrational_sqrt_iff_not_isSquare_rat (r : ℚ) (hr : 0 ≤ r) :
+    Irrational (Real.sqrt (r : ℝ)) ↔ ¬ IsSquare r := by
+  constructor
+  · rintro hirr ⟨s, hs⟩
+    -- r = s*s is a rational square, so √r = |s| is rational, contradicting irrationality.
+    apply hirr
+    refine ⟨|s|, ?_⟩
+    have hr' : (0 : ℝ) ≤ (r : ℝ) := by exact_mod_cast hr
+    have hrs : (r : ℝ) = (|s| : ℝ) ^ 2 := by
+      have : (r : ℝ) = (s : ℝ) * (s : ℝ) := by rw [hs]; push_cast; ring
+      rw [this]; push_cast; rw [sq_abs]; ring
+    rw [hrs, Real.sqrt_sq (by positivity)]
+  · exact irrational_sqrt_of_not_isSquare_rat r hr
+
+/-! ## Part IV: Degree and Field-Extension Consequences -/
+
+/-- The algebraic degree of `√r` over `ℚ` is `2`, for `r ≥ 0` not a rational square. -/
+theorem minpoly_sqrt_natDegree (r : ℚ) (hr : 0 ≤ r) (hns : ¬ IsSquare r) :
+    (minpoly ℚ (Real.sqrt (r : ℝ))).natDegree = 2 := by
+  rw [minpoly_sqrt_of_not_isSquare_rat r hr hns, Polynomial.natDegree_X_pow_sub_C]
+
+/-- `√r` is integral over `ℚ` for `r ≥ 0`. -/
+theorem sqrt_isIntegral (r : ℚ) (hr : 0 ≤ r) : IsIntegral ℚ (Real.sqrt (r : ℝ)) := by
+  have hr' : (0 : ℝ) ≤ (r : ℝ) := by exact_mod_cast hr
+  refine ⟨X ^ 2 - C r, monic_X_pow_sub_C _ (by norm_num), ?_⟩
+  have hAM : (algebraMap ℚ ℝ) r = (r : ℝ) := eq_ratCast (algebraMap ℚ ℝ) r
+  have hsq : Real.sqrt (r : ℝ) ^ 2 = (r : ℝ) := Real.sq_sqrt hr'
+  simp only [map_sub, map_pow, aeval_X, aeval_C]
+  rw [hAM, hsq, sub_self]
+
+/-- **Field Extension Degree**: `[ℚ(√r) : ℚ] = 2` for `r ≥ 0` not a rational square. -/
+theorem adjoin_sqrt_finrank (r : ℚ) (hr : 0 ≤ r) (hns : ¬ IsSquare r) :
+    Module.finrank ℚ ℚ⟮Real.sqrt (r : ℝ)⟯ = 2 := by
+  rw [IntermediateField.adjoin.finrank (sqrt_isIntegral r hr)]
+  exact minpoly_sqrt_natDegree r hr hns
+
+/-! ## Part V: Explicit `p/q` and Cleared-Denominator Forms -/
+
+/-- Pure polynomial identity relating the monic minimal polynomial `X² - p/q` to its
+    cleared-denominator integer associate `q·X² - p`. -/
+theorem cleared_denom_form (p q : ℚ) (hq : q ≠ 0) :
+    C q * (X ^ 2 - C (p / q)) = C q * X ^ 2 - C p := by
+  have hpq : q * (p / q) = p := by field_simp
+  rw [mul_sub, ← C_mul, hpq]
+
+/-- **Explicit `p/q` form**: for naturals `p`, `q` with `q > 0` such that `p/q` is not a
+    rational square, `minpoly ℚ (√(p/q)) = X² - p/q`. -/
+theorem minpoly_sqrt_div (p q : ℕ) (hq : 0 < q) (hns : ¬ IsSquare ((p : ℚ) / q)) :
+    minpoly ℚ (Real.sqrt ((p : ℝ) / q)) = X ^ 2 - C ((p : ℚ) / q) := by
+  have hr : (0 : ℚ) ≤ (p : ℚ) / q := by positivity
+  have key := minpoly_sqrt_of_not_isSquare_rat ((p : ℚ) / q) hr hns
+  have hcast : (((p : ℚ) / q : ℚ) : ℝ) = (p : ℝ) / (q : ℝ) := by push_cast; ring
+  rwa [hcast] at key
+
+/-! ## Part VI: Concrete Examples -/
+
+/-- `2` is not a square in `ℚ`, recovered from the irrationality of `√2`. -/
+private lemma not_isSquare_two : ¬ IsSquare (2 : ℚ) := by
+  have h : Irrational (Real.sqrt ((2 : ℚ) : ℝ)) := by
+    rw [show ((2 : ℚ) : ℝ) = (2 : ℝ) from by norm_num]
+    exact irrational_sqrt_two
+  exact (irrational_sqrt_iff_not_isSquare_rat 2 (by norm_num)).mp h
+
+/-- `1/2` is not a square in `ℚ` (a square iff its inverse `2` is a square). -/
+private lemma not_isSquare_half : ¬ IsSquare ((1 : ℚ) / 2) := by
+  rw [one_div, isSquare_inv]
+  exact not_isSquare_two
+
+/-- **Genuinely rational radicand**: `minpoly ℚ (√(1/2)) = X² - 1/2`.
+    Here `√(1/2) = √2 / 2` is irrational and `1/2` is not an integer. -/
+theorem minpoly_sqrt_half : minpoly ℚ (Real.sqrt ((1 : ℝ) / 2)) = X ^ 2 - C (1 / 2) := by
+  have hns : ¬ IsSquare (((1 : ℕ) : ℚ) / ((2 : ℕ) : ℚ)) := by
+    simpa using not_isSquare_half
+  have := minpoly_sqrt_div 1 2 (by norm_num) hns
+  simpa using this
+
+end Sqrt2MinpolyOQ01OQ02

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "sqrt2-minpoly-oq-01-oq-02",
+  "title": "Minimal Polynomial of √r over ℚ for a Rational Radicand",
+  "slug": "sqrt2-minpoly-oq-01-oq-02",
+  "description": "A Lean 4 proof that minpoly ℚ (√r) = X² - r for every nonnegative rational r that is not a square in ℚ, generalizing the natural-number radicand result (sqrt2-minpoly-oq-01) to rational radicands. Includes the iff-characterization of irrationality of √r, the cleared-denominator form q·X² - p, and a genuinely rational example √(1/2).",
+  "meta": {
+    "status": "formalized",
+    "tags": [
+      "algebraic-number-theory",
+      "minimal-polynomial",
+      "field-extensions",
+      "irrationality",
+      "sqrt"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/Sqrt2MinpolyOQ01OQ02.lean",
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 205,
+    "dateAdded": "2026-06-15",
+    "assumptions": "None (0 axioms, 0 sorries). Build-pending: compilation deferred this session because the Docker build pool was saturated and Aristotle was unavailable. The proof is a direct adaptation of the machine-verified Sqrt2MinpolyOQ01 Part VII argument; the deployer/auditor will build it.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for 0 ≤ x, the root witness for X² - r",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "minpoly.dvd",
+        "description": "minpoly divides any polynomial annihilating the element, giving the degree-≤-2 bound",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "eq_ratCast",
+        "description": "Any ring hom out of ℚ is the rational cast, identifying algebraMap ℚ ℝ r with (r : ℝ)",
+        "module": "Mathlib.Data.Rat.Cast.Defs"
+      },
+      {
+        "theorem": "irrational_sqrt_two",
+        "description": "√2 is irrational, used to recover ¬IsSquare (2 : ℚ) for the example",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "Main theorem: minpoly ℚ (√r) = X² - r for any nonnegative rational r that is not a square in ℚ",
+      "Irrationality characterization: √r is irrational iff r is not a rational square (for r ≥ 0)",
+      "Observation that for rational radicands the irrationality step is direct (a rational value of √r squares to r), avoiding irrational_nrt_of_notint_nrt needed in the natural-number case",
+      "Algebraic degree theorem: natDegree(minpoly ℚ √r) = 2",
+      "Field extension degree: [ℚ(√r) : ℚ] = 2",
+      "Cleared-denominator identity: C q · (X² - C(p/q)) = C q · X² - C p, relating the monic minimal polynomial to the integer associate q·X² - p",
+      "Explicit p/q form: minpoly ℚ (√(p/q)) = X² - p/q for naturals p, q",
+      "Genuinely rational example: minpoly ℚ (√(1/2)) = X² - 1/2"
+    ],
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The minimal polynomial of an algebraic number and the resulting field-extension degree are foundational in algebraic number theory. The classical statement minpoly_ℚ(√2) = X² − 2 is the prototype of a quadratic irrationality. The gallery entry sqrt2-minpoly-oq-01 generalizes this to the square root of any non-perfect-square natural number n, proving minpoly_ℚ(√n) = X² − n via an irrationality-and-degree argument. This entry takes the natural next step, listed explicitly as an open question in sqrt2-minpoly-oq-01: generalize the radicand from a natural number to an arbitrary nonnegative rational r = p/q.",
+    "problemStatement": "For a nonnegative rational r, when is minpoly ℚ (√r) = X² − r? Answer: exactly when r is not a square in ℚ. Equivalently, writing r = p/q, the monic minimal polynomial is X² − p/q, whose cleared-denominator integer associate is q·X² − p.",
+    "proofStrategy": "1. Irrationality: if √r were rational, equal to (s : ℝ) for s ∈ ℚ, then s² = r would exhibit r as a rational square; contrapositive gives irrationality from ¬IsSquare r. 2. X² − C r is monic with √r as a root (Real.sq_sqrt), so minpoly ℚ (√r) ∣ X² − C r, giving degree ≤ 2. 3. Irrationality rules out degree 1 (a monic linear minimal polynomial would put √r in ℚ), so degree = 2. 4. A monic divisor of the monic degree-2 polynomial X² − C r that has degree 2 must equal it.",
+    "keyInsights": [
+      "Over ℚ the irrationality argument is strictly simpler than over ℕ: IsSquare is taken directly in ℚ, so a rational value of √r immediately produces a rational square, with no descent or integrality lemma required.",
+      "The minimal polynomial is canonically monic, so the genuine answer is the monic X² − r; the q·X² − p form of the informal statement is the non-monic integer associate obtained by scaling by C q.",
+      "The degree argument is purely about monic divisors of a monic degree-2 polynomial, reusing the verified Sqrt2MinpolyOQ01 Part VII skeleton verbatim with the radicand type changed from ℕ to ℚ.",
+      "The irrationality characterization is an iff: √r is irrational exactly when r is not a rational square, recovering the standard irrationality criterion for square roots of rationals."
+    ]
+  },
+  "sections": [
+    {
+      "id": "irrationality",
+      "title": "Part I: Irrationality for a Rational Radicand",
+      "startLine": 50,
+      "endLine": 67,
+      "summary": "irrational_sqrt_of_not_isSquare_rat: if r ≥ 0 is not a square in ℚ then √r is irrational. A rational value s of √r would satisfy s² = r, contradicting ¬IsSquare r.",
+      "mathContext": "Direct contrapositive proof; no appeal to irrational_nrt_of_notint_nrt, which the natural-number case requires."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part II: The Minimal Polynomial",
+      "startLine": 69,
+      "endLine": 126,
+      "summary": "minpoly_sqrt_of_not_isSquare_rat: minpoly ℚ (√r) = X² − r for r ≥ 0 not a rational square. Degree ≤ 2 from divisibility, degree ≥ 2 from irrationality, equality from monic-divisor uniqueness.",
+      "mathContext": "Adapts Sqrt2MinpolyOQ01.minpoly_sqrt_of_not_sq from ℕ to ℚ radicands; algebraMap ℚ ℝ r is identified with (r : ℝ) via eq_ratCast."
+    },
+    {
+      "id": "irrationality-iff",
+      "title": "Part III: Irrationality Characterization",
+      "startLine": 128,
+      "endLine": 144,
+      "summary": "irrational_sqrt_iff_not_isSquare_rat: for r ≥ 0, √r is irrational iff r is not a rational square. The forward direction uses √(s²) = |s|.",
+      "mathContext": "Combines Part I with the elementary fact that the square root of a rational square is rational."
+    },
+    {
+      "id": "degree-results",
+      "title": "Part IV: Degree and Field-Extension Consequences",
+      "startLine": 145,
+      "endLine": 167,
+      "summary": "natDegree(minpoly ℚ √r) = 2, integrality of √r, and [ℚ(√r) : ℚ] = 2.",
+      "mathContext": "adjoin.finrank applied to the integral element √r; the minimal polynomial degree gives the extension degree."
+    },
+    {
+      "id": "explicit-forms",
+      "title": "Part V: Explicit p/q and Cleared-Denominator Forms",
+      "startLine": 168,
+      "endLine": 184,
+      "summary": "cleared_denom_form: C q·(X² − C(p/q)) = C q·X² − C p. minpoly_sqrt_div: minpoly ℚ (√(p/q)) = X² − p/q for naturals p, q with q > 0.",
+      "mathContext": "Bridges the monic minimal polynomial with the integer associate q·X² − p of the informal problem statement."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Concrete Examples",
+      "startLine": 185,
+      "endLine": 203,
+      "summary": "¬IsSquare (2 : ℚ) recovered from irrational_sqrt_two; ¬IsSquare (1/2) via isSquare_inv; and minpoly ℚ (√(1/2)) = X² − 1/2.",
+      "mathContext": "Demonstrates the theorem on a genuinely rational (non-integer) radicand 1/2 = 2⁻¹."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 205-line Lean 4 formalization generalizing minpoly ℚ (√n) = X² − n from non-perfect-square natural radicands to nonnegative rational radicands: minpoly ℚ (√r) = X² − r whenever r is not a square in ℚ. The file also proves the iff-characterization of irrationality of √r, the cleared-denominator identity relating the monic form to q·X² − p, and a worked example for the genuinely rational radicand 1/2. 0 axioms, 0 sorries; build-pending this session.",
+    "implications": "**Irrationality of square roots of rationals**: the iff-corollary gives the clean criterion that √(p/q) is irrational exactly when p/q is not a rational square, a standard result now formalized for arbitrary rational radicands. **Quadratic field theory**: [ℚ(√r) : ℚ] = 2 for non-square rational r extends the degree-2 quadratic-extension foundation from integer to rational generators, with no change in the resulting field since ℚ(√(p/q)) = ℚ(√(pq)).",
+    "openQuestions": [
+      "Show ℚ(√(p/q)) = ℚ(√(pq)) explicitly, so that every quadratic field with a rational-radicand generator is generated by a squarefree integer radicand.",
+      "Generalize to k-th roots of rationals: minpoly ℚ (r^(1/k)) = X^k − r for rational r that is not a k-th power in ℚ, matching the natural-number k-th-root result in sqrt2-minpoly-oq-02."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-minpoly-oq-01",
+      "relationship": "generalizes",
+      "description": "OQ-01 proves minpoly ℚ (√n) = X² − n for non-perfect-square natural n; this entry generalizes the radicand to any nonnegative rational r, resolving OQ-01's explicitly listed rational open question."
+    },
+    {
+      "targetId": "sqrt2-minpoly",
+      "relationship": "related",
+      "description": "The √2 case is the integer radicand r = 2; this entry covers non-integer rational radicands such as 1/2."
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-02",
+      "relationship": "sibling",
+      "description": "OQ-02 handles k-th roots of natural numbers; this entry handles square roots of rationals. A common generalization (k-th roots of rationals) is listed as an open question."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02.minpoly_sqrt_of_not_isSquare_rat",
+      "statement": "minpoly ℚ (Real.sqrt (r : ℝ)) = X ^ 2 - C r, for r : ℚ with 0 ≤ r and ¬ IsSquare r",
+      "description": "Main result: minimal polynomial of the square root of a nonnegative rational that is not a rational square."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02.irrational_sqrt_iff_not_isSquare_rat",
+      "statement": "Irrational (Real.sqrt (r : ℝ)) ↔ ¬ IsSquare r, for r : ℚ with 0 ≤ r",
+      "description": "√r is irrational iff r is not a rational square."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02.minpoly_sqrt_div",
+      "statement": "minpoly ℚ (Real.sqrt ((p : ℝ) / q)) = X ^ 2 - C ((p : ℚ) / q), for p q : ℕ with 0 < q and ¬ IsSquare (p/q)",
+      "description": "Explicit p/q form of the main theorem."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02.adjoin_sqrt_finrank",
+      "statement": "Module.finrank ℚ ℚ⟮Real.sqrt (r : ℝ)⟯ = 2",
+      "description": "The field extension ℚ(√r)/ℚ has degree 2 for non-square rational r ≥ 0."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField"
+    ],
+    "namespace": "Sqrt2MinpolyOQ01OQ02",
+    "lineCount": 205,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/Sqrt2MinpolyOQ01OQ02.lean"
+  }
+}

--- a/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
@@ -1,0 +1,122 @@
+{
+  "slug": "sqrt2-minpoly-oq-01-oq-02",
+  "title": "Minimal polynomial of the square root of a rational",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\operatorname{minpoly}_{\\mathbb{Q}}\\!\\left(\\sqrt{p/q}\\right) = q\\,X^2 - p",
+    "plain": "The gallery already proves that the minimal polynomial of $\\sqrt{2}$ over $\\mathbb{Q}$ is $X^2 - 2$. This problem generalizes that to the square root of an arbitrary positive rational $p/q$: its minimal polynomial over $\\mathbb{Q}$ is $q X^2 - p$ (equivalently the monic $X^2 - p/q$), provided $p/q$ is not already a rational square. As a corollary, $\\sqrt{p/q}$ is irrational exactly when $p/q$ is not a rational square.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-15T12:12:21-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: complete 0-sorry/0-axiom formalization (Sqrt2MinpolyOQ01OQ02.lean, 11 thms) generalizing minpoly ℚ (√n)=X²−n to rational radicands; build-pending (infra down).",
+    "builtItems": [
+      "irrational_sqrt_of_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:55)",
+      "minpoly_sqrt_of_not_isSquare_rat — main theorem (Sqrt2MinpolyOQ01OQ02.lean:71)",
+      "irrational_sqrt_iff_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:129)",
+      "minpoly_sqrt_natDegree, sqrt_isIntegral, adjoin_sqrt_finrank (degree/extension, lines 146-163)",
+      "cleared_denom_form + minpoly_sqrt_div explicit p/q form (lines 169-181)",
+      "Example minpoly_sqrt_half: minpoly ℚ (√(1/2)) = X² − 1/2 (line 199)"
+    ],
+    "insights": [
+      "For a rational radicand r, irrationality of √r is direct: a rational value s of √r squares to r, exhibiting r as a rational square. No irrational_nrt_of_notint_nrt needed (unlike the natural-number case).",
+      "The minimal polynomial is canonically monic, so the answer is X² − r; the informal q·X² − p is the non-monic integer associate (scale by C q).",
+      "The degree argument (monic divisor of monic degree-2) transfers verbatim from the verified Sqrt2MinpolyOQ01 Part VII with radicand type ℕ → ℚ.",
+      "algebraMap ℚ ℝ r must be identified with (r : ℝ) via eq_ratCast inside aeval simp normal forms."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no direct minpoly-of-rational-square-root lemma; built from minpoly.dvd + irrationality + monic-divisor uniqueness."
+    ],
+    "nextSteps": [
+      "Build/verify via Docker (deferred this session: build pool saturated, Aristotle 404).",
+      "Prove ℚ(√(p/q)) = ℚ(√(pq)) to reduce rational-radicand quadratic fields to squarefree-integer generators.",
+      "Generalize to k-th roots of rationals: minpoly ℚ (r^(1/k)) = X^k − r."
+    ],
+    "markdown": "# Knowledge Base: sqrt2-minpoly-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "algebraic-number-theory",
+    "minimal-polynomial",
+    "field-extensions",
+    "sqrt"
+  ],
+  "relatedProofs": [
+    "sqrt2-minpoly",
+    "sqrt2-minpoly-oq-01",
+    "sqrt2-minpoly-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-15T12:12:21-07:00",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Sqrt2Minpoly.lean",
+      "filename": "Sqrt2Minpoly.lean",
+      "lineCount": 141,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Sqrt2Minpoly.lean"
+    },
+    {
+      "path": "Proofs/Sqrt2MinpolyOQ01.lean",
+      "filename": "Sqrt2MinpolyOQ01.lean",
+      "lineCount": 253,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Sqrt2MinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/Sqrt2MinpolyOQ02.lean",
+      "filename": "Sqrt2MinpolyOQ02.lean",
+      "lineCount": 203,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Sqrt2MinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/Sqrt2MinpolyOQ03.lean",
+      "filename": "Sqrt2MinpolyOQ03.lean",
+      "lineCount": 108,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Sqrt2MinpolyOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the gallery result `minpoly ℚ (√n) = X² − n` (proved for non-perfect-square **natural** radicands in `sqrt2-minpoly-oq-01`) to nonnegative **rational** radicands. This resolves the rational open question explicitly listed in `sqrt2-minpoly-oq-01`'s meta.

**Main theorem** (`Sqrt2MinpolyOQ01OQ02.minpoly_sqrt_of_not_isSquare_rat`):
for `r : ℚ` with `0 ≤ r` and `¬ IsSquare r`,
```
minpoly ℚ (Real.sqrt (r : ℝ)) = X ^ 2 - C r
```
The minimal polynomial is canonically monic, so the answer is the monic `X² − r`; the informal `q·X² − p` is its non-monic integer associate (`cleared_denom_form`).

## What's included (11 theorems, 0 axioms, 0 sorries)

- `irrational_sqrt_of_not_isSquare_rat` — √r irrational when r is not a rational square (direct proof: a rational √r squares to r).
- `minpoly_sqrt_of_not_isSquare_rat` — the main theorem.
- `irrational_sqrt_iff_not_isSquare_rat` — √r irrational **iff** r not a rational square.
- `minpoly_sqrt_natDegree`, `sqrt_isIntegral`, `adjoin_sqrt_finrank` — degree 2 and `[ℚ(√r):ℚ] = 2`.
- `cleared_denom_form`, `minpoly_sqrt_div` — explicit `p/q` form and the `q·X² − p` associate.
- `minpoly_sqrt_half` — worked example `minpoly ℚ (√(1/2)) = X² − 1/2` on a genuinely rational radicand.

## Key point

Over `ℚ` the irrationality step is **simpler** than over `ℕ`: `IsSquare` is taken directly in `ℚ`, so a rational value of `√r` immediately exhibits `r` as a rational square — no `irrational_nrt_of_notint_nrt` / integrality descent needed. The degree argument reuses the verified `Sqrt2MinpolyOQ01` Part VII skeleton with the radicand type changed `ℕ → ℚ`.

## Build status

**Build-pending.** The Docker build pool was saturated (6 concurrent `lean-build` containers against a 7.65 GiB Docker VM) and Aristotle returned 404 this session, so the file was not compiled here. The proof is a direct adaptation of the machine-verified `Sqrt2MinpolyOQ01` Part VII argument. Gallery `status` is `formalized` / badge `wip` pending a deployer/auditor build.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ01OQ02` (deferred — build pool saturated)
- [x] JSON validated (`meta.json`, problem JSON) with python
- [x] Registered in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)