### PR TITLE
audit: record cycle (3 clean, 1 issues-found) for 4 never-audited entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15486,6 +15486,30 @@
       "lastAudited": "2026-06-15T19:40:03Z",
       "result": "clean",
       "issues": []
+    },
+    "brouwer-fixed-point-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T20:55:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T20:56:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T20:56:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mantel-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T20:58:19Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit Cycle

Drained the never-audited queue (4 → 0; gallery now 2473/2473 audited).

| Slug | Result | Notes |
|------|--------|-------|
| brouwer-fixed-point-oq-01-oq-03-oq-01 | clean | axiomatized/axiom, axiomCount=1 matches the single inherited `no_continuous_odd_nonzero_on_sphere` from BorsukUlam.lean; fully disclosed in assumptions |
| buffons-needle-oq-01-oq-02-oq-02 | clean | verified/original; 0 sorry, 0 axiom, no structures, registered in Proofs.lean, real asymptotic theorem |
| de-moivre-oq-02-oq-02-oq-01 | clean | formalized/wip; build-pending honestly disclosed, not registered, no overclaim |
| mantel-theorem | issues-found | Tier B Mathlib bridge badged `original` — fix already tracked in open PR #24780 (badge → `mathlib`) |

### mantel-theorem detail
`mantel_card_edgeFinset_le` obtains its core bound by a direct specialization of Mathlib's `SimpleGraph.CliqueFree.card_edgeFinset_le` at `r=2` (MantelTheorem.lean:62). Per failure-mode #5 ("0 sorries with hidden imports"), badge should be `mathlib`, not `original`. No duplicate filed — PR #24780 is clean/mergeable.

---
Recorded during periodic gallery integrity audit.