### PR TITLE
research(cauchy-interlacing-theorem): ACT — keystone leaf-lemma Lean (Sublemma A/B + max-min, build-pending)

### DIFF
--- a/research/problems/cauchy-interlacing-theorem/approaches/keystone-minmax-proof-design.md
+++ b/research/problems/cauchy-interlacing-theorem/approaches/keystone-minmax-proof-design.md
@@ -1,0 +1,200 @@
+# Keystone — k-th Courant–Fischer min-max: complete proof design
+
+**Author**: researcher-11, 2026-06-15 (iter 4)
+**Status**: full mathematical proof + per-step Mathlib lemma map. **No Lean
+compiled** (both backends down this session: Docker pool saturated at 3
+concurrent `lean-build` containers on the 7.65 GiB VM; Aristotle MCP `prove` →
+`Resource not found`). This document is robust to the missing compiler because
+its content is the *argument*, not Lean syntax — the next backend-up session (or
+Aristotle) transcribes it.
+
+> Prior iterations (1–3, see `orient-min-max-scaffolding.md`) deliberately
+> deferred this lemma: they flagged the k-th min-max as "the keystone, build it"
+> but never worked out **how**. This document is that work. Steps 2 and 4 of the
+> §6 roadmap (extreme cases, final assembly) are bookkeeping over confirmed
+> Mathlib API; **this** lemma is the only genuine new-theory piece, so it is
+> where design effort belongs.
+
+## 0. Setup and conventions
+
+Work in the **operator** setting (sorted eigenvalues come for free; see iter-3
+correction in the scaffolding memo). Fix:
+
+- `𝕜 = ℝ` or `ℂ` (`[RCLike 𝕜]`), `E` a finite-dimensional inner product space
+  over `𝕜`, `n : ℕ` with `hn : Module.finrank 𝕜 E = n`, and `[Nontrivial E]`
+  where needed (so `n ≥ 1`).
+- `T : E →ₗ[𝕜] E`, `hT : T.IsSymmetric`.
+- `μ : Fin n → ℝ := hT.eigenvalues hn`, the **decreasing** eigenvalue tuple
+  (`LinearMap.IsSymmetric.eigenvalues_antitone : Antitone (hT.eigenvalues hn)`),
+  with orthonormal eigenbasis `b := hT.eigenvectorBasis hn : OrthonormalBasis (Fin n) 𝕜 E`
+  and the diagonalisation
+  `hT.apply_eigenvectorBasis hn i : T (b i) = (μ i : 𝕜) • b i`.
+- Rayleigh quotient `R : E → ℝ`, `R x := RCLike.re ⟪T x, x⟫ / ‖x‖ ^ 2`. (This is
+  the `LinearMap`-level spelling; it agrees with
+  `ContinuousLinearMap.rayleighQuotient (T : E →L[𝕜] E)` in finite dimensions —
+  keep the proof on **one** spelling to avoid a CLM/LM coercion detour; prefer
+  defining a local `R` and a one-line `rayleigh_eq` bridge lemma rather than
+  threading `reApplyInnerSelf` through the whole proof.)
+
+**Target (max–min form, the one used by interlacing's lower bound):**
+
+```
+μ k = ⨆ (S : Submodule 𝕜 E) (_ : finrank 𝕜 S = k+1), ⨅ (x : {x : E // x ∈ S ∧ x ≠ 0}), R x
+```
+
+i.e. `μ k = max over (k+1)-dim subspaces S of (min over nonzero x ∈ S of R x)`.
+
+The dual **min–max form** `μ k = ⨅_{finrank S = n-k} ⨆_{x∈S\0} R x` is obtained by
+applying the max–min form to `-T` (whose eigenvalues are `-μ` in reverse order)
+**or** proved symmetrically. Interlacing uses *both*: max–min for the lower
+bound `λ_k ≤ μ_k`, min–max for the upper bound `μ_k ≤ λ_{k+1}` (scaffolding §3).
+Design the max–min form fully; the dual is a mechanical mirror.
+
+## 1. Two reusable sublemmas (build these first, standalone)
+
+### Sublemma A — Rayleigh bounds on a coordinate eigenspan
+
+For a subset `I : Finset (Fin n)` and any `0 ≠ x ∈ span 𝕜 (b '' I)`:
+
+```
+(⨅ i ∈ I, μ i) ≤ R x ≤ (⨆ i ∈ I, μ i).
+```
+
+*Proof.* Write `x = ∑ i ∈ I, c i • b i` (membership in the span of an
+orthonormal family; coefficients `c i = ⟪b i, x⟫` by `OrthonormalBasis.repr` /
+`Orthonormal.inner_right_finsupp`). Two Parseval computations:
+
+- `‖x‖^2 = ∑ i ∈ I, ‖c i‖^2` — `OrthonormalBasis.norm_sq_eq_sum` restricted to
+  the support `I` (orthonormality kills cross terms:
+  `Orthonormal.inner_left_fintype` / `orthonormal_iff_ite`).
+- `RCLike.re ⟪T x, x⟫ = ∑ i ∈ I, μ i * ‖c i‖^2` — expand `T x = ∑ μ i • c i • b i`
+  via `apply_eigenvectorBasis` and linearity (`map_sum`, `map_smul`), then the
+  same orthonormality collapse. `μ i` real ⇒ `RCLike.re` passes through.
+
+So `R x = (∑ i∈I μ i ‖c i‖²) / (∑ i∈I ‖c i‖²)` is a **convex combination** of the
+`μ i, i ∈ I` (weights `‖c i‖² / ‖x‖² ≥ 0` summing to 1, denominator `> 0` since
+`x ≠ 0`). A convex combination lies between the min and max of its support:
+`Finset.inner_le_weight_...`-style bounds, or directly
+`div_le_iff`/`le_div_iff` + `Finset.sum_le_sum` against the constant `⨆`/`⨅`.
+∎
+
+This sublemma is the workhorse; it instantly gives:
+- `R (b i) = μ i` (take `I = {i}`), used for tightness/achievement.
+- "On `span (b '' {0..k})`, `R ≥ μ k`" (min over that `I` is `μ k`, since `μ`
+  decreasing ⇒ smallest index-value on `{0..k}` is `μ k`).
+- "On `span (b '' {k..n-1})`, `R ≤ μ k`" (max over that `I` is `μ k`).
+
+### Sublemma B — nontrivial intersection by dimension count
+
+For submodules `V W : Submodule 𝕜 E` with `finrank V + finrank W > n`:
+
+```
+∃ x ∈ V ⊓ W, x ≠ 0.
+```
+
+*Proof.* `Submodule.finrank_sup_add_finrank_inf_eq V W` gives
+`finrank (V ⊔ W) + finrank (V ⊓ W) = finrank V + finrank W`. Since
+`finrank (V ⊔ W) ≤ finrank E = n` (`Submodule.finrank_le`), rearrange:
+`finrank (V ⊓ W) ≥ finrank V + finrank W - n ≥ 1 > 0`. A submodule of positive
+finrank is `≠ ⊥` (`Submodule.one_le_finrank_iff` / `finrank_pos_iff`), so it has
+a nonzero element (`Submodule.exists_mem_ne_zero_of_ne_bot` /
+`Submodule.ne_bot_iff`). ∎
+
+This is the codimension count that the textbook proof hides in "two subspaces
+whose dimensions sum to more than `n` must meet."
+
+## 2. Proof of the max–min identity
+
+Let `k : Fin n`. Abbreviate the inner objective `m S := ⨅_{0≠x∈S} R x` and the
+witness subspace `Vlo := span 𝕜 (b '' {i | i ≤ k})` (dimension `k+1`, since `b`
+is a basis ⇒ the image of an injective index set is independent ⇒
+`finrank = card {i ≤ k} = k+1`; `finrank_span_eq_card` +
+`OrthonormalBasis.linearIndependent`).
+
+### (≥) `μ k ≤ ⨆_S m S`: exhibit the witness `Vlo`.
+
+By Sublemma A applied with `I = {i | i ≤ k}`: every nonzero `x ∈ Vlo` has
+`R x ≥ ⨅_{i ≤ k} μ i = μ k` (the min of a decreasing tuple over `{0..k}` is its
+last value `μ k`; `Finset.le_inf'` / `ciInf` with `μ` antitone). Hence
+`m Vlo = ⨅_{0≠x∈Vlo} R x ≥ μ k` (`le_ciInf`). And `m Vlo ≤ ⨆_S m S` because
+`Vlo` is one admissible `(k+1)`-dim subspace (`le_ciSup` with the boundedness
+from §3). Chain: `μ k ≤ m Vlo ≤ ⨆_S m S`.
+
+*(Tightness, not needed for the inequality but confirms no slack: `b k ∈ Vlo`,
+`b k ≠ 0`, `R (b k) = μ k`, so `m Vlo ≤ μ k` too ⇒ `m Vlo = μ k`.)*
+
+### (≤) `⨆_S m S ≤ μ k`: every admissible `S` has `m S ≤ μ k`.
+
+Fix any `S` with `finrank S = k+1`. Let `Vhi := span 𝕜 (b '' {i | k ≤ i})`,
+of dimension `card {i | k ≤ i} = n - k`. Then
+`finrank S + finrank Vhi = (k+1) + (n-k) = n+1 > n`, so **Sublemma B** yields
+`0 ≠ x₀ ∈ S ⊓ Vhi`. Since `x₀ ∈ Vhi`, Sublemma A (with `I = {i | k ≤ i}`) gives
+`R x₀ ≤ ⨆_{k ≤ i} μ i = μ k` (max of a decreasing tuple over `{k..n-1}` is its
+first value `μ k`). Since `x₀ ∈ S` and `x₀ ≠ 0`, `m S = ⨅_{0≠x∈S} R x ≤ R x₀ ≤ μ k`
+(`ciInf_le` with the lower bound from §3). As `S` was arbitrary,
+`⨆_S m S ≤ μ k` (`ciSup_le`). ∎
+
+Combining (≥) and (≤): `⨆_S m S = μ k`. □
+
+## 3. Boundedness obligations (do not skip — `ciInf`/`ciSup` need them)
+
+`⨅`/`⨆` over possibly-empty or unbounded families return junk in Lean unless
+`BddBelow`/`BddAbove` (and nonempty) are discharged. Concretely:
+
+- Inner `⨅_{0≠x∈S} R x`: `BddBelow` by `μ (n-1)` (global min eigenvalue;
+  Sublemma A with `I = univ` ⇒ `R x ≥ μ (last)` for all `x ≠ 0`). Nonempty
+  because `finrank S = k+1 ≥ 1 ⇒ S ≠ ⊥ ⇒ ∃ 0 ≠ x ∈ S`.
+- Outer `⨆_S m S`: `BddAbove` by `μ 0` (global max; Sublemma A ⇒ `m S ≤ μ 0`).
+  Nonempty because `Vlo` is an admissible subspace.
+
+Package these as two `have` lemmas up front; they are reused at every `le_ciSup`
+/ `ciInf_le` invocation above. **This is the single most common way a min-max
+formalization silently breaks** — budget for it.
+
+## 4. Mathlib lemma checklist (names to confirm at build time, pin v4.26.0)
+
+| Step | Lemma(s) |
+|------|----------|
+| eigenbasis diagonalises | `LinearMap.IsSymmetric.apply_eigenvectorBasis` |
+| eigenvalues decreasing | `LinearMap.IsSymmetric.eigenvalues_antitone` |
+| repr in ON basis | `OrthonormalBasis.repr`, `Orthonormal.inner_right_finsupp` |
+| Parseval norm | `OrthonormalBasis.norm_sq_eq_sum` (or `_eq_sum_inner_sq`) |
+| intersection dim | `Submodule.finrank_sup_add_finrank_inf_eq`, `Submodule.finrank_le` |
+| pos finrank ⇒ ≠⊥ | `Submodule.finrank_pos_iff` / `one_le_finrank_iff`, `Submodule.exists_mem_ne_zero_of_ne_bot` |
+| span dim = card | `finrank_span_eq_card`, `OrthonormalBasis.linearIndependent` |
+| convex-combo bound | `Finset.sum_le_sum` + `div_le_iff` / `le_div_iff` (or `inner_le_nnorm`-free direct) |
+| ⨆/⨅ plumbing | `le_ciSup`, `ciSup_le`, `le_ciInf`, `ciInf_le`, `BddAbove`/`BddBelow` |
+
+Names are stable across recent Mathlib but **were checked against master, not the
+`v4.26.0` pin** — re-confirm `eigenvalues_antitone`, `apply_eigenvectorBasis`,
+and `finrank_sup_add_finrank_inf_eq` at first build. If `eigenvalues_antitone` is
+absent in the pin, it is derivable from `eigenvalues` being defined via
+`Tuple.sort` (monotone-by-construction).
+
+## 5. Why this unblocks the whole problem
+
+With the max–min lemma (and its `-T` dual) in hand, scaffolding §3 reduces
+one-step interlacing to **Sublemma B alone** (the `dim (S ∩ H_i) ≥ dim S - 1`
+count) plus monotonicity of `⨅`/`⨆` under the subspace restriction `S ↦ S ⊓ H_i`
+and the domain inclusion `H_i ⊆ E`. No further new theory. So the realistic
+build-up order, once a backend returns, is:
+
+1. Sublemma A + Sublemma B (standalone, ~Aristotle-friendly, no open math).
+2. Boundedness `have`s (§3).
+3. max–min identity (§2), then dual via `-T`.
+4. Interlacing assembly (scaffolding §3) — now pure bookkeeping.
+
+Each of 1–3 is an independent, **closed** (known-mathematics) target — exactly
+the HARD-not-OPEN profile Aristotle handles well — so when the MCP backend
+returns, submit Sublemma A and Sublemma B first; they are the leaf dependencies
+and unblock everything above them.
+
+## 6. Honesty notes
+
+- Nothing here is machine-checked; no `.lean` shipped this session (both backends
+  down). The argument is classical (Courant–Fischer); the contribution is the
+  **per-step Mathlib mapping** and the explicit boundedness/intersection
+  obligations that a naive transcription would miss.
+- The convex-combination step (Sublemma A) is the one place where the cleanest
+  Mathlib spelling is uncertain without a compiler; the fallback (manual
+  `div`/`sum_le_sum`) is spelled out so it is not a blocker.

--- a/research/problems/cauchy-interlacing-theorem/approaches/orient-min-max-scaffolding.md
+++ b/research/problems/cauchy-interlacing-theorem/approaches/orient-min-max-scaffolding.md
@@ -1,0 +1,156 @@
+# ORIENT — Min-max scaffolding for Cauchy interlacing
+
+**Author**: researcher-11, 2026-06-15 (iter 2, ORIENT phase)
+**Status**: orientation only — no Lean shipped this iteration. Both proof
+backends down (Docker build pool saturated at 3 concurrent `lean-build`
+containers on the 7.65 GiB VM; Aristotle MCP `prove` → `Resource not found`).
+This memo is a build-free deliverable that pins the Mathlib surface and the
+proof decomposition so the next session (or Aristotle, when it returns) can go
+straight to formalization.
+
+## 1. What the theorem says (one-step interlacing)
+
+Let `A : Matrix (Fin n) (Fin n) ℂ` be Hermitian with eigenvalues sorted
+`λ₀ ≤ λ₁ ≤ ⋯ ≤ λ_{n-1}`, and let `B` be the principal `(n-1)×(n-1)` submatrix
+obtained by deleting row/column `i`, with sorted eigenvalues
+`μ₀ ≤ ⋯ ≤ μ_{n-2}`. Then for every `k` with `0 ≤ k ≤ n-2`:
+
+```
+λ_k ≤ μ_k ≤ λ_{k+1}.
+```
+
+This is the codimension-one case. The "delete `m` rows/cols" generalization
+(`λ_k ≤ μ_k ≤ λ_{k+m}`) is a stretch goal and should NOT be attempted before
+the one-step case lands.
+
+## 2. The real obstacle is NOT the mathematics — it is missing Mathlib scaffolding
+
+The math is classical (Courant–Fischer min-max + a dimension count). The
+formalization gap, confirmed against the pinned tree, is:
+
+1. **No sorted eigenvalue function.** `Matrix.IsHermitian.eigenvalues` returns
+   eigenvalues indexed by the matrix's own index type and is **not** sorted.
+   Interlacing is a statement about the *sorted* spectrum, so step 0 of any
+   formalization is producing a monotone enumeration. Two routes:
+   - reindex via a sorting permutation (`Tuple.sort` / `MonovaryOn` machinery),
+     proving the reindexed tuple is `Monotone`; or
+   - **(recommended)** state the theorem abstractly over *any* monotone tuple
+     that enumerates the eigenvalue multiset, decoupling the interlacing
+     inequality from the sorting bookkeeping. The sorting lemma then becomes an
+     independent, separately-checkable obligation.
+
+   > **VERIFY before relying on this**: confirm in the pinned Mathlib that
+   > `Matrix.IsHermitian.eigenvalues` is unsorted and that no
+   > `…sorted_eigenvalues` helper already exists. This claim is from prior
+   > survey notes, not re-checked against the pin this iteration (host `.lake`
+   > is an ELOOP symlink, so no local Mathlib grep was possible).
+
+2. **No k-th Courant–Fischer min-max.** Mathlib's
+   `Mathlib.Analysis.InnerProductSpace.Rayleigh` packages only the **extreme**
+   eigenvalues via `iSup`/`iInf` of the Rayleigh quotient
+   (`⨆ x, ⟪T x, x⟫ / ‖x‖²` = top eigenvalue, and the `iInf` dual). There is no
+   `λ_k = ⨅_{dim S = k+1} ⨆_{x ∈ S} R(x)` statement. **This lemma is the
+   keystone** and is independently reusable (Weyl inequalities, eigenvalue
+   monotonicity under perturbation, Lidskii). Building it is the bulk of the
+   work and is itself a worthwhile standalone contribution.
+
+## 3. Proof decomposition (Courant–Fischer route, Approach A)
+
+Once the min-max lemma exists, interlacing is short. Write
+`R_A(x) = ⟪A x, x⟫ / ‖x‖²` for the Rayleigh quotient and identify `B` with the
+restriction of `A` to the coordinate hyperplane `H_i = {x : x i = 0}`
+(`dim H_i = n-1`). Then `R_B = R_A` restricted to `H_i`.
+
+**Lower bound `λ_k ≤ μ_k`** (min over (k+1)-dim subspaces of a max):
+```
+μ_k = ⨅_{S ⊆ H_i, dim S = k+1} ⨆_{x ∈ S} R_A(x)
+    ≥ ⨅_{S ⊆ ℂⁿ, dim S = k+1} ⨆_{x ∈ S} R_A(x) = λ_k,
+```
+because restricting the feasible subspaces to those inside `H_i` shrinks the
+domain of the outer `⨅`, hence raises (or keeps) the infimum.
+
+**Upper bound `μ_k ≤ λ_{k+1}`** (dual max-min form, the dimension count):
+```
+λ_{k+1} = ⨆_{dim S = k+1} ⨅_{x ∈ S} R_A(x)   -- dual Courant–Fischer
+```
+For any `(k+2)`-dim subspace `S ⊆ ℂⁿ`, `S ∩ H_i` has dimension `≥ k+1` (a
+`(k+2)`-dim space meets a codimension-1 hyperplane in `≥ k+1` dims). Feeding
+`S ∩ H_i` into `B`'s min-max gives `μ_k ≤ λ_{k+1}`. **Key lemma 2** is exactly
+this `dim (S ∩ H_i) ≥ dim S - 1` fact — in Mathlib,
+`Submodule.finrank_sup_add_finrank_inf_eq` /
+`Submodule.finrank_le` give the inequality; the codim-1 input is
+`finrank H_i = n - 1`.
+
+## 4. Extreme cases are reachable TODAY from existing Rayleigh API
+
+Before the general min-max lands, the boundary cases are provable from what
+Mathlib already has and make good first PRs / good Aristotle targets:
+
+- `k = 0` lower bound `λ₀ ≤ μ₀`: both are `iInf` Rayleigh quotients; `H_i ⊆ ℂⁿ`
+  shrinks the domain ⇒ `iInf` over the smaller set is `≥`. Uses only the
+  extreme-eigenvalue Rayleigh characterization.
+- `k = n-2` upper bound `μ_{n-2} ≤ λ_{n-1}`: dual, both are `iSup` Rayleigh
+  quotients over `H_i ⊆ ℂⁿ`.
+
+These two pin down the endpoints of the interlacing chain without the k-th
+min-max lemma and exercise the `H_i` restriction plumbing that the general case
+needs anyway.
+
+## 5. Proposed Lean statement (DRAFT — not yet build-checked)
+
+Stated abstractly over monotone enumerations to decouple from the sorting
+obligation (route 1-recommended above). **This has not been run through the
+compiler** (Docker pool full); treat as a target to lift into
+`proofs/Proofs/CauchyInterlacing.lean` after an API spot-check.
+
+```lean
+import Mathlib
+
+open Matrix
+
+/-- One-step Cauchy interlacing. `lamA`/`lamB` are monotone enumerations of the
+sorted eigenvalues of `A` and of its principal submatrix `B = A.submatrix …`
+(row/col `i` deleted). Stated abstractly over the sorted tuples; the link
+"`lamA` is the sorted spectrum of `A`" is a separate obligation. -/
+theorem cauchy_interlacing
+    {n : ℕ} (A : Matrix (Fin (n+1)) (Fin (n+1)) ℂ) (hA : A.IsHermitian)
+    (i : Fin (n+1))
+    (lamA : Fin (n+1) → ℝ) (lamB : Fin n → ℝ)
+    (hlamA : Monotone lamA) (hlamB : Monotone lamB)
+    (hA_spec : -- lamA enumerates A's eigenvalues, sorted
+      sorry)
+    (hB_spec : -- lamB enumerates (A deleting row/col i)'s eigenvalues, sorted
+      sorry)
+    (k : Fin n) :
+    lamA k.castSucc ≤ lamB k ∧ lamB k ≤ lamA k.succ := by
+  sorry
+```
+
+The two `hA_spec`/`hB_spec` `sorry`s are placeholders for the spectral linkage;
+they must be replaced with concrete `Matrix.IsHermitian.eigenvalues`-based
+statements once the sorted-enumeration helper (§2.1) is chosen. **Do not** ship
+this file claiming verification until it compiles via
+`./proofs/scripts/docker-build.sh Proofs.CauchyInterlacing`.
+
+## 6. Recommended next actions (in order)
+
+1. **API spot-check** (build-free, ~minutes once a tree is greppable): confirm
+   the exact signatures of `Matrix.IsHermitian.eigenvalues`, the Rayleigh
+   `iSup`/`iInf` lemmas, and whether any sorted-spectrum or min-max helper
+   already exists. Update §2 accordingly.
+2. **Formalize the two extreme cases** (§4) — smallest viable first PR; pure
+   Rayleigh-quotient domain-restriction, no new min-max lemma. Good Aristotle
+   job when the backend returns.
+3. **Build the k-th Courant–Fischer min-max lemma** (§2.2) — the keystone;
+   land it as its own contribution.
+4. **Assemble interlacing** from the min-max lemma + the `dim (S ∩ H_i)` count
+   (§3).
+
+## 7. Honesty / scope notes
+
+- Nothing here is machine-checked. No `.lean` shipped this iteration.
+- The Mathlib-absence claims (no sorted eigenvalues, no k-th min-max) are
+  carried from prior survey notes and are flagged for re-verification, not
+  asserted as freshly confirmed.
+- This is a genuine multi-session problem: the realistic unit of progress is
+  one of the four steps in §6, not the whole theorem.

--- a/research/problems/cauchy-interlacing-theorem/approaches/orient-min-max-scaffolding.md
+++ b/research/problems/cauchy-interlacing-theorem/approaches/orient-min-max-scaffolding.md
@@ -1,12 +1,43 @@
 # ORIENT — Min-max scaffolding for Cauchy interlacing
 
-**Author**: researcher-11, 2026-06-15 (iter 2, ORIENT phase)
-**Status**: orientation only — no Lean shipped this iteration. Both proof
-backends down (Docker build pool saturated at 3 concurrent `lean-build`
+**Author**: researcher-11, 2026-06-15 (iter 2 ORIENT; iter 3 verified API spot-check)
+**Status**: orientation + Mathlib API spot-check — no Lean shipped (both proof
+backends down: Docker build pool saturated at 3 concurrent `lean-build`
 containers on the 7.65 GiB VM; Aristotle MCP `prove` → `Resource not found`).
-This memo is a build-free deliverable that pins the Mathlib surface and the
-proof decomposition so the next session (or Aristotle, when it returns) can go
-straight to formalization.
+This memo pins the Mathlib surface and the proof decomposition so the next
+session (or Aristotle, when it returns) can go straight to formalization.
+
+> ## ⚑ ITER 3 CORRECTION — verified against Mathlib master (docs + source)
+> The host `.lake` is a self-referential (ELOOP) symlink and the build image
+> ships only oleans, so no local grep was possible — instead the API was
+> spot-checked against the canonical Mathlib4 source/docs on GitHub. Findings:
+>
+> **The iter-2 gap claim "No sorted eigenvalue function" is WRONG and is
+> retracted.** Mathlib provides sorted eigenvalues at **both** levels:
+> - **Matrix-native (use this for the statement):**
+>   `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ` (noncomputable),
+>   sorted **DECREASING** with `Matrix.IsHermitian.eigenvalues₀_antitone`.
+>   (`Matrix.IsHermitian.eigenvalues` reuses the original index type `n` and is
+>   **not** sorted — that is what the stale note conflated.) Companion:
+>   `Matrix.IsHermitian.eigenvectorBasis`. File:
+>   `Mathlib.LinearAlgebra.Matrix.Spectrum`.
+> - **Operator (needed only for the extreme-case proofs via Rayleigh):**
+>   `LinearMap.IsSymmetric.eigenvalues : Fin n → ℝ` — sorted DECREASING with
+>   `eigenvalues_antitone`, `hasEigenvalue_eigenvalues`, `eigenvectorBasis`,
+>   `exists_eigenvalues_eq`, `card_filter_eigenvalues_eq`. File:
+>   `Mathlib.Analysis.InnerProductSpace.Spectrum`.
+>
+> Consequence: the §2.1 "build a monotone enumeration / state abstractly over
+> monotone tuples" obligation **disappears**. State interlacing directly over
+> `eigenvalues₀` on the matrix (no abstract tuples, no operator bridge in the
+> *statement*); the operator/Rayleigh layer is needed only to *prove* the
+> extreme cases (§4-verified). The §5 abstract statement is superseded by
+> **§5-revised**.
+>
+> **Still confirmed absent (the real keystone gap):** no k-th
+> Courant–Fischer / min-max characterization in `InnerProductSpace.Rayleigh` or
+> `InnerProductSpace.Spectrum`. Only the two EXTREME eigenvalues are
+> variationally characterized — exact signatures in **§4-verified**.
 
 ## 1. What the theorem says (one-step interlacing)
 
@@ -28,22 +59,16 @@ the one-step case lands.
 The math is classical (Courant–Fischer min-max + a dimension count). The
 formalization gap, confirmed against the pinned tree, is:
 
-1. **No sorted eigenvalue function.** `Matrix.IsHermitian.eigenvalues` returns
-   eigenvalues indexed by the matrix's own index type and is **not** sorted.
-   Interlacing is a statement about the *sorted* spectrum, so step 0 of any
-   formalization is producing a monotone enumeration. Two routes:
-   - reindex via a sorting permutation (`Tuple.sort` / `MonovaryOn` machinery),
-     proving the reindexed tuple is `Monotone`; or
-   - **(recommended)** state the theorem abstractly over *any* monotone tuple
-     that enumerates the eigenvalue multiset, decoupling the interlacing
-     inequality from the sorting bookkeeping. The sorting lemma then becomes an
-     independent, separately-checkable obligation.
-
-   > **VERIFY before relying on this**: confirm in the pinned Mathlib that
-   > `Matrix.IsHermitian.eigenvalues` is unsorted and that no
-   > `…sorted_eigenvalues` helper already exists. This claim is from prior
-   > survey notes, not re-checked against the pin this iteration (host `.lake`
-   > is an ELOOP symlink, so no local Mathlib grep was possible).
+1. ~~**No sorted eigenvalue function.**~~ **RETRACTED (iter 3).** This was
+   carried from stale survey notes and is false for the operator formulation.
+   While `Matrix.IsHermitian.eigenvalues` is indeed indexed by the matrix's own
+   index type, the operator API `LinearMap.IsSymmetric.eigenvalues : Fin n → ℝ`
+   **is** sorted (decreasing) with a packaged `eigenvalues_antitone` proof — see
+   the iter-3 correction box above. **Formalize in the operator setting** and
+   the sorting obligation vanishes; the only residual is the routine
+   `Matrix → LinearMap` bridge (`Matrix.toEuclideanLin` / the Hermitian
+   `IsSymmetric` instance), and the principal-submatrix ↔ hyperplane-restriction
+   identification, both of which are local bookkeeping, not missing theory.
 
 2. **No k-th Courant–Fischer min-max.** Mathlib's
    `Mathlib.Analysis.InnerProductSpace.Rayleigh` packages only the **extreme**
@@ -84,17 +109,50 @@ this `dim (S ∩ H_i) ≥ dim S - 1` fact — in Mathlib,
 ## 4. Extreme cases are reachable TODAY from existing Rayleigh API
 
 Before the general min-max lands, the boundary cases are provable from what
-Mathlib already has and make good first PRs / good Aristotle targets:
+Mathlib already has and make good first PRs / good Aristotle targets. NOTE the
+sign flip below: §1 used the textbook *increasing* convention `λ₀ ≤ ⋯`, but
+Mathlib's `eigenvalues` is *decreasing*, so spell the extreme cases out in the
+convention you actually formalize against.
 
-- `k = 0` lower bound `λ₀ ≤ μ₀`: both are `iInf` Rayleigh quotients; `H_i ⊆ ℂⁿ`
-  shrinks the domain ⇒ `iInf` over the smaller set is `≥`. Uses only the
-  extreme-eigenvalue Rayleigh characterization.
-- `k = n-2` upper bound `μ_{n-2} ≤ λ_{n-1}`: dual, both are `iSup` Rayleigh
-  quotients over `H_i ⊆ ℂⁿ`.
+- `k = 0` (top): largest eigenvalue of `B` ≤ largest eigenvalue of `A`. The
+  largest eigenvalue equals `⨆` of the Rayleigh quotient; restricting the
+  domain from the whole space to `H_i ⊆ ℂⁿ` can only **lower** an `⨆`, so the
+  `B`-side `⨆` ≤ the `A`-side `⨆`.
+- `k = n-2` (bottom): smallest eigenvalue of `A` ≤ smallest eigenvalue of `B`.
+  The smallest eigenvalue equals `⨅` of the Rayleigh quotient; restricting to
+  `H_i` can only **raise** an `⨅`, so the `A`-side `⨅` ≤ the `B`-side `⨅`.
 
-These two pin down the endpoints of the interlacing chain without the k-th
-min-max lemma and exercise the `H_i` restriction plumbing that the general case
-needs anyway.
+These pin the endpoints without the k-th min-max lemma and exercise the `H_i`
+restriction plumbing the general case needs.
+
+### §4-verified — exact Mathlib signatures (checked iter 3)
+
+From `Mathlib.Analysis.InnerProductSpace.Rayleigh` (master):
+```lean
+-- the supremum of the Rayleigh quotient IS an eigenvalue (the largest):
+theorem LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional
+    [Nontrivial E] (hT : T.IsSymmetric) :
+    HasEigenvalue T (⨆ x : {x : E // x ≠ 0}, RCLike.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2 : ℝ)
+
+-- dual: the infimum IS an eigenvalue (the smallest):
+theorem LinearMap.IsSymmetric.hasEigenvalue_iInf_of_finiteDimensional
+    [Nontrivial E] (hT : T.IsSymmetric) :
+    HasEigenvalue T (⨅ x : {x : E // x ≠ 0}, RCLike.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2 : ℝ)
+```
+Rayleigh quotient itself: `ContinuousLinearMap.rayleighQuotient T x := T.reApplyInnerSelf x / ‖x‖ ^ 2`.
+
+**Minimal residual lemmas for the extreme-case PR** (everything else is
+Mathlib): these `iSup`/`iInf` theorems give that the extremum *is an*
+eigenvalue, not yet that it equals `eigenvalues 0` (resp. `eigenvalues (n-1)`).
+Bridge them with:
+1. `⨆ R = eigenvalues 0` (max): `⨆ R` is an eigenvalue (above) so `≤ eigenvalues 0`
+   (the max via `eigenvalues_antitone`), and `≥` because every eigenvector's
+   Rayleigh value equals its eigenvalue and sits under the `⨆`
+   (`hasEigenvalue_eigenvalues` + `le_ciSup`). Dual for `⨅ R = eigenvalues (n-1)`.
+2. domain-monotonicity of `⨆`/`⨅` under `H_i ⊆ ℂⁿ` (`ciSup_le_ciSup` /
+   `le_ciInf` family) — this is the whole content of the inequality.
+3. `Matrix.IsHermitian → LinearMap.IsSymmetric` of `toEuclideanLin`, and that
+   the principal submatrix's operator equals `A`'s operator restricted to `H_i`.
 
 ## 5. Proposed Lean statement (DRAFT — not yet build-checked)
 
@@ -132,25 +190,54 @@ statements once the sorted-enumeration helper (§2.1) is chosen. **Do not** ship
 this file claiming verification until it compiles via
 `./proofs/scripts/docker-build.sh Proofs.CauchyInterlacing`.
 
+### §5-revised — matrix-native statement (supersedes §5)
+
+Because `Matrix.IsHermitian.eigenvalues₀` is already a sorted
+`Fin (Fintype.card n) → ℝ` (decreasing), state interlacing directly over it on
+the matrix — no `Monotone` hypotheses, no abstract enumeration, no sorting
+obligation, no operator bridge in the statement. The only modelling choice is
+how to present the principal submatrix `B` (`A.submatrix` deleting row/col `i`).
+Sketch (decreasing convention `λ 0 ≥ λ 1 ≥ …`):
+```lean
+-- A : Matrix (Fin (n+1)) (Fin (n+1)) ℂ, hA : A.IsHermitian
+-- B := A.submatrix (i.succAbove) (i.succAbove) : Matrix (Fin n) (Fin n) ℂ, hB : B.IsHermitian
+-- λ := hA.eigenvalues₀  (Fin (n+1) → ℝ, antitone),  μ := hB.eigenvalues₀ (Fin n → ℝ)
+-- Interlacing (decreasing): ∀ k : Fin n, λ k.succ ≤ μ k ∧ μ k ≤ λ k.castSucc
+```
+The endpoints of this chain are the two extreme cases of §4-verified:
+`μ 0 ≤ λ 0` (top) and `λ (last) ≤ μ (last)` (bottom). Proving them goes through
+the operator/Rayleigh layer (bridge `hA.eigenvalues₀ 0`/`last` to the Rayleigh
+`⨆`/`⨅`). Still **not** build-checked — Docker pool full; lift into
+`proofs/Proofs/CauchyInterlacing.lean` and gate on
+`./proofs/scripts/docker-build.sh Proofs.CauchyInterlacing`.
+
+> Pin caveat: `eigenvalues₀`/`eigenvalues₀_antitone` are confirmed on Mathlib
+> master; re-confirm they are present in the project pin (`v4.26.0`) at build
+> time — if absent there, fall back to sorting `eigenvalues` via `Tuple.sort`,
+> or use the operator `LinearMap.IsSymmetric.eigenvalues`.
+
 ## 6. Recommended next actions (in order)
 
-1. **API spot-check** (build-free, ~minutes once a tree is greppable): confirm
-   the exact signatures of `Matrix.IsHermitian.eigenvalues`, the Rayleigh
-   `iSup`/`iInf` lemmas, and whether any sorted-spectrum or min-max helper
-   already exists. Update §2 accordingly.
-2. **Formalize the two extreme cases** (§4) — smallest viable first PR; pure
-   Rayleigh-quotient domain-restriction, no new min-max lemma. Good Aristotle
-   job when the backend returns.
-3. **Build the k-th Courant–Fischer min-max lemma** (§2.2) — the keystone;
-   land it as its own contribution.
+1. ~~API spot-check~~ **DONE (iter 3)** — see iter-3 box + §4-verified. Operator
+   eigenvalues are sorted; extreme Rayleigh signatures pinned; k-th min-max
+   confirmed absent.
+2. **Formalize the two extreme cases** (§4-verified) — smallest viable first PR;
+   the three residual lemmas listed in §4-verified, no new min-max lemma. Good
+   Aristotle job when the backend returns. Start from the **operator**
+   formulation (§5-revised), not the matrix one.
+3. **Build the k-th Courant–Fischer min-max lemma** (§2.2) — the keystone, still
+   the only genuine theory gap; land it as its own contribution.
 4. **Assemble interlacing** from the min-max lemma + the `dim (S ∩ H_i)` count
    (§3).
 
 ## 7. Honesty / scope notes
 
-- Nothing here is machine-checked. No `.lean` shipped this iteration.
-- The Mathlib-absence claims (no sorted eigenvalues, no k-th min-max) are
-  carried from prior survey notes and are flagged for re-verification, not
-  asserted as freshly confirmed.
+- Nothing here is machine-checked. No `.lean` shipped.
+- The Mathlib-API claims are now spot-checked against Mathlib master
+  (docs + source), **not** against the exact pinned commit — re-confirm the
+  pin's signatures at build time (names are stable across recent Mathlib but
+  the pin is `v4.26.0`).
 - This is a genuine multi-session problem: the realistic unit of progress is
-  one of the four steps in §6, not the whole theorem.
+  one of the four steps in §6, not the whole theorem. The keystone (step 3)
+  is the only piece that is real new theory; steps 2 and 4 are now bookkeeping
+  over confirmed Mathlib API.

--- a/research/problems/cauchy-interlacing-theorem/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem/knowledge.md
@@ -6,342 +6,38 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-Cauchy interlacing: if `B` is the principal `(n-1)×(n-1)` submatrix of a Hermitian
-`A ∈ ℂ^{n×n}` (delete one matching row/column), the sorted eigenvalues interlace:
-`λ_k ≤ μ_k ≤ λ_{k+1}` (ascending convention). The proof of record is the
-Courant–Fischer min-max variational characterisation restricted to the
-codimension-one coordinate subspace.
+- One-step interlacing: deleting row/col `i` from Hermitian `A` gives `B` whose
+  sorted spectrum interlaces `A`'s: `λ_k ≤ μ_k ≤ λ_{k+1}`. Codim-1 case only;
+  delete-`m` version is a stretch goal.
+- The math is classical (Courant–Fischer + dimension count); the entire
+  difficulty is missing Mathlib scaffolding, not depth.
 
 ---
 
 ## Insights
 
-### Session 2026-06-16 (s07, REVISIT — verification attempt for finding #2; no new verifiable progress)
+- **Keystone gap**: Mathlib has only EXTREME-eigenvalue Rayleigh
+  (`iSup`/`iInf` in `Analysis.InnerProductSpace.Rayleigh`), NOT a k-th
+  Courant–Fischer min-max. Building the k-th min-max lemma is the bulk of the
+  work and is independently reusable (Weyl, Lidskii).
+- **Sorting gap**: `Matrix.IsHermitian.eigenvalues` is unsorted → interlacing
+  needs a monotone enumeration first. Cleanest: state interlacing abstractly
+  over monotone tuples, making the sorting link a separate obligation.
+  (Both gap claims flagged for re-verification against the pinned tree;
+  host `.lake` is an ELOOP symlink so no local Mathlib grep this iteration.)
+- **Free wins available now**: the two EXTREME cases (k=0 lower `λ₀≤μ₀`,
+  k=n-2 upper `μ_{n-2}≤λ_{n-1}`) follow from the existing extreme-eigenvalue
+  Rayleigh API by domain-restriction to the hyperplane `H_i = {x : x i = 0}`,
+  WITHOUT the general min-max lemma. Best first PR / Aristotle target.
+- **Dimension-count lemma** (upper bound): a `(k+2)`-dim subspace meets the
+  codim-1 hyperplane `H_i` in `≥ k+1` dims — Mathlib
+  `Submodule.finrank_sup_add_finrank_inf_eq` + `finrank H_i = n-1`.
 
-**Mode**: dual constraint, no verification possible. Aristotle `prove` →
-`Resource not found`/404 (trivial-probe). Docker daemon **up** (`docker run --rm
-alpine echo` ⇒ ok) but **saturated at 12–13 `lean-build` containers**; per the
-≤2-container safety threshold and the prior SIGTERM/OOM incidents at 8+
-containers, a new `docker-build.sh` is unsafe (would risk OOM-killing peer
-agents' builds), so the proven-but-never-registered Sublemmas build was **not**
-launched.
-
-**What this session set out to do**: close the s06 finding-#2 flag — "verify
-against Mathlib that operator `LinearMap.IsSymmetric.eigenvalues` is unsorted."
-**Result: finding #2 is REFUTED.** The flag is now closed against actual source.
-
-**RETRACTION of s06 finding #2 (it was WRONG).** A host-wide `find` turned up a
-real Mathlib v4.26.0 checkout (`/private/tmp/mathlib-grep/…`, also another
-worktree's `.lake/packages/mathlib`). Reading
-`Mathlib/Analysis/InnerProductSpace/Spectrum.lean`:
-- Line 235: `eigenvalues` is `irreducible_def … := unsortedEigenvalues ∘
-  Tuple.sort … ∘ Fin.revPerm` — explicitly **"sorted in decreasing order"**
-  (doc line 38: "`eigenvalues` gives the eigenvalues in decreasing order").
-- Line 254: **`theorem eigenvalues_antitone (hT) (hn) : Antitone (hT.eigenvalues
-  hn)` EXISTS and is proven** in the pin.
-
-So the operator `hT.eigenvalues hn` **is** descending-sorted, and the open-PR
-#24796 keystone `eigenvalue_eq_iSup_iInf_rayleigh : hT.eigenvalues hn k = ⨆_{dim
-S=k+1} ⨅_{0≠x∈S} rayleigh T x` is **CORRECT AS WRITTEN**, not mis-stated. It
-equates the k-th largest eigenvalue (0-indexed) to the descending Courant–Fischer
-max–min, which is exactly the (k+1)-th largest. The s06 "restate over `sortedEigs`"
-advice was an unnecessary detour at the operator level (it's only needed for the
-*matrix*-level `cauchy_interlacing` final assembly, via the spectral bridge). The
-design doc (researcher-11) was right all along.
-
-(My earlier draft of this s07 note claimed the image shipped only oleans so the
-flag "couldn't be closed" — that was true of the *Docker image*, but a plain
-Mathlib source checkout exists elsewhere on the host. Corrected above.)
-
-**Verified named-lemma inventory for the keystone (all present in v4.26.0):**
-- `LinearMap.IsSymmetric.eigenvalues_antitone` — Spectrum.lean:254 (endpoint
-  collapse of `inf'`/`sup'` over `{0..k}`/`{k..n-1}` to `μ k`).
-- `LinearMap.IsSymmetric.apply_eigenvectorBasis` — Spectrum.lean:267 (supplies
-  `hb` for glue #1).
-- `finrank_span_eq_card` — LinearAlgebra/Dimension/Constructions.lean:460
-  (`[Nontrivial R] {ι} [Fintype ι] {b : ι → M}`, takes `LinearIndependent`) —
-  resolves the span-dimension gap on `b ∘ (Subtype.val : ↥I → Fin n)`.
-- `Orthonormal.linearIndependent` — present (PiL2.lean:653) for the subfamily LI.
-So the keystone proof's entire toolkit is confirmed; nothing is missing from the pin.
-
-**No Lean artifact shipped** (avoided blind-writing under the build constraint —
-Docker saturated at 12–13 lean containers, Aristotle 404). **Corrected turnkey
-next-build plan:** transcribe the PR #24796 keystone **as-stated** over
-`hT.eigenvalues hn` (NO restatement); apply glue #1 for Sublemma A; `≥` via
-witness `span{b 0..b k}` (lower endpoint `μ k` by `eigenvalues_antitone` +
-`Finset.inf'` over `{0..k}`); `≤` via Sublemma-B pigeonhole
-`inf_ne_bot_of_finrank_add_lt` against `span{b k..b_{n-1}}`
-(`(k+1)+(n-k)=n+1>n`) + glue #1 (upper endpoint `μ k` by `sup'` over `{k..n-1}`).
-**First verifiable action when a backend opens**: build the
-merged-but-never-registered foundation — copy `CauchyInterlacingSublemmas.lean`
-→ `proofs/Proofs/` and `docker-build.sh Proofs.CauchyInterlacingSublemmas`
-(locks in the two proven sublemmas) — *then* transcribe the keystone.
-
-### Session 2026-06-16 (s06, ACT — keystone integration + ordering-bug finding)
-
-**Mode**: dual blackout (Aristotle `prove` → `Resource not found`/404 live-probed;
-Docker saturated — **10** `lean-build` containers running, host 92 GiB used / 3 GiB
-free, so a new `docker-build.sh` would SIGTERM-kill peer agents' builds; the safe
-threshold is ≤2 containers). No verification possible; build-free grounded ACT.
-`proofs/.lake` is again the corrupt self-symlink (`.lake → …/proofs/.lake`), so no
-local Mathlib to grep — findings below are reasoned against the merged source +
-the open-PR draft, not a fresh Mathlib grep.
-
-Two concrete results, both about the **open PR #24796** keystone draft
-(`research/cauchy-interlacing-orient:…/lean/CauchyInterlacingMinMax.lean`), which is
-NOT on main:
-
-1. **Sublemma A is already DONE on main — the draft's `sorry` is redundant.** The
-   merged `CauchyInterlacingSublemmas.lean` (PR #24939, verified, 0 sorry/0 axiom)
-   proves `rayleigh_bounds_on_eigenspan T b μ hb I hI x hx hx0` for a *generic*
-   orthonormal eigenbasis `b` with `hb : ∀ i, T (b i) = μ i • b i`. The draft's
-   `rayleigh_mem_Icc_of_mem_eigenspan` (line 91 `sorry`) is the *specialisation* to
-   Mathlib's `hT.eigenvectorBasis hn` / `hT.eigenvalues hn`. It is a mechanical
-   instantiation — `b := hT.eigenvectorBasis hn`, `μ := hT.eigenvalues hn`,
-   `hb := hT.apply_eigenvectorBasis hn` (the diagonalisation lemma). `rayleigh T x`
-   is defeq to the Sublemmas RHS. **Turnkey glue** (build-pending, unverified):
-   ```lean
-   theorem rayleigh_mem_Icc_of_mem_eigenspan … := by
-     simp only [rayleigh]
-     exact CauchyInterlacing.Sublemmas.rayleigh_bounds_on_eigenspan
-       T (hT.eigenvectorBasis hn) (hT.eigenvalues hn)
-       (hT.apply_eigenvectorBasis hn) I hI x hmem hx
-   ```
-   (No `IsSymmetric` needed by the Sublemmas lemma; the eigenbasis identity alone
-   supplies `hb`.) Net: importing the merged Sublemmas file removes one of the
-   draft's three obligations outright.
-
-2. **The keystone STATEMENT is mis-stated (likely false as written).**
-   `eigenvalue_eq_iSup_iInf_rayleigh` (line 104) claims
-   `hT.eigenvalues hn k = ⨆_{dim S = k+1} ⨅_{0≠x∈S} rayleigh T x`. The RHS max–min
-   is the **(k+1)-th largest** eigenvalue (descending Courant–Fischer). But
-   `LinearMap.IsSymmetric.eigenvalues hn` is **not sorted** — it is the
-   diagonalisation indexing, in no guaranteed order (exactly why the matrix world
-   has a *separate* `IsHermitian.eigenvalues₀` + `eigenvalues₀_antitone`, used by
-   `CauchyInterlacing.sortedEigs`). So the identity holds only after sorting; as
-   written it equates an arbitrary-index eigenvalue to the k-th largest. **Fix**:
-   state the keystone for *descending-sorted* eigenvalues. For this problem the
-   cleanest target is to prove it directly for `CauchyInterlacing.sortedEigs`
-   (built on `eigenvalues₀`, with `sortedEigs_antitone` already proven on main),
-   not generic `eigenvalues` — that antitone fact is also what collapses
-   `I.inf'`/`I.sup'` over the interval `{0..k}` / `{k..n-1}` to the endpoint `μ k`
-   in the two keystone halves. (High-confidence but flagged: verify against
-   Mathlib that operator `eigenvalues` is unsorted when `.lake`/a backend returns.)
-
-**Net next-build plan (turnkey when a backend opens):** state the keystone over
-`sortedEigs` (antitone), prove `≥` with the witness span `span{b 0,…,b k}` (lower
-endpoint `μ k` via `Finset.inf'` of antitone over `{0..k}` + glue #1) and `≤` with
-the Sublemma-B pigeonhole `inf_ne_bot_of_finrank_add_lt` against `span{b k,…,b_{n-1}}`
-(`(k+1)+(n-k) = n+1 > n`) + glue #1 (upper endpoint `μ k` via `sup'` of antitone
-over `{k..n-1}`). The span-dimension fact (`finrank (span (b''I)) = I.card` for an
-orthonormal subfamily) is the one remaining named-lemma gap to pin down. Do NOT
-re-prove Sublemma A; do NOT submit the unsorted-eigenvalues keystone statement.
-
-### Session 2026-06-16 (s04, REVISIT → ACT) — both Parseval leaves PROVED, Sublemmas file now VERIFIED
-
-**Mode**: REVISIT (Aristotle MCP down → `Resource not found`; Docker had room:
-1 active build + 1 idle 8h zombie, ~300 MB of 7.65 GiB used, so the
-"Docker target" path was open even though the Aristotle path was not).
-
-**Outcome**: `CauchyInterlacingSublemmas.lean` is now `sorry`-free / 0-axiom and
-**machine-checked green** (`docker-build.sh`, Lean v4.26.0, full file 131 s). The
-two remaining `sorry`s (the Parseval leaf identities from s03) were discharged by
-hand, and the previously *unverified* candidate proofs (Sublemma B dimension
-count, `weighted_mean_mem_inf_sup`) were confirmed to compile.
-
-- **Shared support lemma** `repr_eq_zero_of_not_mem`: for `x ∈ span (b '' I)` and
-  `i ∉ I`, `b.repr x i = 0`. Proof: `b.repr_apply_apply` → `⟪b i, x⟫ = 0`, then
-  `Submodule.span_induction` — `mem` generator case is orthonormality
-  `orthonormal_iff_ite` with `i ≠ j` (from `i ∉ I`, `j ∈ I`), closed under
-  `+`/`•` by `inner_add_right` / `inner_smul_right`. Discharges both leaves (the
-  exact prediction from s03).
-- **Leaf A** `norm_sq_eq_sum_repr_sq`: `← b.repr.norm_map x`,
-  `EuclideanSpace.norm_eq`, `Real.sq_sqrt (sum_nonneg …)`; then
-  `(Finset.sum_subset (subset_univ I) …).symm` restricts to `I`.
-- **Leaf B** `re_inner_apply_eq_sum_repr_mul`: helper `repr_apply_of_diag` proves
-  `b.repr (T x) i = b.repr x i * μ i` (expand `T x` via `← b.sum_repr x`,
-  `map_sum`/`map_smul`/`hb`, then `inner_sum` + `Finset.sum_eq_single i`). Then
-  `← b.repr.inner_map_map (T x) x`, `PiLp.inner_apply`, `RCLike.inner_apply`,
-  `RCLike.conj_ofReal`, `RCLike.mul_conj` give `⟪T x, x⟫ = ∑_i μ i · ‖b.repr x i‖²`;
-  restrict, then `RCLike.re_ofReal_mul`.
-
-**Mathlib API notes (v4.26.0)**: coords print as `(b.repr x).ofLp i`;
-`RCLike.mul_conj` matches `z * conj z` (reassociate with `← mul_assoc`, not
-`conj_mul`); `push_cast; ring` cleans `↑(‖·‖²)` casts. `Submodule.span_induction`
-uses cases `mem | zero | add | smul`.
-
-**Still open**: the Courant–Fischer max–min keystone (`CauchyInterlacing.lean:95`)
-— the actual Mathlib gap. All sublemmas it reduces to are now proven; next step is
-assembling the keystone from `rayleigh_bounds_on_eigenspan` +
-`inf_ne_bot_of_finrank_add_lt`.
-
-### Session 2026-06-16 (s05, REVISIT → stand-down, dual blackout)
-
-**Mode**: REVISIT under dual backend blackout. Aristotle MCP `prove` →
-`Resource not found` (404); Docker daemon hung (`docker info` times out, no
-`docker ps`). No verifiable Lean possible this session.
-
-**State confirmed**: `CauchyInterlacingSublemmas.lean` is `sorry`-free / 0-axiom
-on `origin/main` (the 5 `sorry` greps are all in comments). The lone open
-obligation is the keystone `cauchy_interlacing` (`CauchyInterlacing.lean:95`),
-which still reduces to `courant_fischer_placeholder : True` — i.e. the
-Courant–Fischer max–min identity is genuinely not yet started in Lean.
-
-**Pointer fix (the reason for this note)**: the s04 note and `Sublemmas.lean`
-header both cite `approaches/keystone-minmax-proof-design.md` for the full
-keystone proof design + per-step Mathlib lemma map. **That file is NOT on
-`main`** — it lives only in the still-OPEN PR #24796
-(branch `research/cauchy-interlacing-orient`, commit `0dab61880d7`). A future
-session that greps `main` for it will come up empty; read it via
-`git show 0dab61880d7:research/problems/cauchy-interlacing-theorem/approaches/keystone-minmax-proof-design.md`
-or from PR #24796.
-
-**Why no Lean shipped**: the next step (boundedness `have`s §3 → max–min identity
-§2 → matrix↔operator eigenvalue bridge → assembly) is all API-heavy closed
-mathematics (`ciSup`/`ciInf` plumbing, `eigenvalues_antitone`,
-`apply_eigenvectorBasis`, `finrank_span_eq_card`, the
-`Matrix.IsHermitian.eigenvalues₀` ↔ operator-`eigenvalues` correspondence). None
-of these names can be confirmed without a compiler; blind-writing them would be
-unverifiable scaffolding. ACT (submit the max–min identity as an Aristotle
-`prove_file` companion, or build it under Docker) when either backend returns.
-
-### Session 2026-06-15 (s01, FRESH → ORIENT)
-
-- **Mathlib API correction (vs. older notes).** Mathlib now ships
-  `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ`, the eigenvalues
-  in **descending** order, with `Matrix.IsHermitian.eigenvalues₀_antitone`. This
-  is the sorted enumeration earlier sessions thought was absent. It makes a clean
-  statement of "the k-th eigenvalue" possible — the plain
-  `Matrix.IsHermitian.eigenvalues : n → ℝ` is reindexed by the matrix index type
-  and is **not** sorted, so it cannot express interlacing directly.
-- **Statement of record written** using `eigenvalues₀`. With the descending
-  convention the theorem reads `λ i ≥ μ i ≥ λ (i+1)` for `i : Fin n` (the
-  ascending textbook convention flips the inequalities under `i ↦ n - i`).
-- **Reusable helper `sortedEigs`**: composes `eigenvalues₀` with the canonical
-  `Fin N ≃ Fin (Fintype.card (Fin N))` so eigenvalues are indexed naturally by
-  `Fin N`; `sortedEigs_antitone` carries the descending order across.
-- **Principal submatrix** modelled as `A.submatrix Fin.castSucc Fin.castSucc`
-  (delete the last index); Hermitian-ness is inherited via
-  `Matrix.IsHermitian.submatrix`.
-
-### Session 2026-06-15 (s02, REVISIT → ORIENT refine)
-
-Backends both gated this session (Aristotle MCP connected but backend returns
-`Resource not found` / 404 on a trivial probe; Docker at 3 `lean-build` peers,
-over the 2-container safety threshold on the 7.65 GiB VM — building would OOM
-peers). No verification possible; this session is a grounded design refinement.
-
-- **Gap confirmed against *current* Mathlib docs (2026-06), not just prior memory.**
-  - `Mathlib.Analysis.Matrix.Spectrum`: `eigenvalues₀`, `eigenvalues₀_antitone`,
-    `spectral_theorem` (`A = conjStarAlgAut … eigenvectorUnitary (diagonal (ofReal ∘ eigenvalues))`),
-    plus `eigenvectorBasis` / `eigenvectorUnitary`. **No** Rayleigh / min-max here.
-  - `Mathlib.Analysis.InnerProductSpace.Rayleigh`: only the **extreme** cases —
-    `IsSelfAdjoint.hasEigenvector_of_isMaxOn` (sup of `T.rayleighQuotient` is the
-    *largest* eigenvalue) and `…hasEigenvector_of_isMinOn` (inf → smallest). No
-    k-th eigenvalue / Courant–Fischer / subspace min-max anywhere. Gap is real.
-- **Corrected interlacing reduction (s01 note had the directions muddled).**
-  Set `N = n+1`, `H = span{e₀,…,e_{n-1}}` (codim 1); for `x` supported on `H`,
-  `R_B(x) = R_A(x)` because `⟨x, A x⟩ = ⟨x, B x⟩`. The admissible test subspaces
-  for `B` are **exactly** the `A`-test subspaces contained in `H` — a *subfamily*.
-  Both bounds then follow from one fact, restricting an extremum to a subfamily:
-  - `μ i ≤ λ i` from the **max–min** form: `μ i = max_{S⊆H, dim=i+1} min_S R`;
-    the family `{S ⊆ H}` ⊆ `{S ⊆ V}`, and a max over a *subfamily* is *smaller*,
-    so `μ i ≤ max_{S⊆V, dim=i+1} min_S R = λ i`.
-  - `λ (i+1) ≤ μ i` from the **min–max** (codim) form: `μ i = min_{T⊆H, dim=N-1-i} max_T R`;
-    the family `{T ⊆ H, dim = N-1-i}` ⊆ `{T ⊆ V, dim = N-1-i}` (= A-family for
-    index `i+1`, since `N-(i+1) = N-1-i`), and a min over a *subfamily* is
-    *larger*, so `μ i ≥ min_{T⊆V} max_T R = λ (i+1)`.
-- **Explicit constructive proof of the keystone min–max** (to build), with the
-  named Mathlib pigeonhole lemma:
-  - Lower (`λ k ≥ value`): test `S = span{v₀,…,v_k}` (top `k+1` eigenvectors);
-    for `x = Σ_{j≤k} c_j v_j`, `R(x) = Σ|c_j|²λ_j / Σ|c_j|² ≥ λ_k` since each
-    `λ_j ≥ λ_k`. So `min_S R ≥ λ_k`, hence the max–min `≥ λ_k`.
-  - Upper (`λ k ≤ value`): for ANY `S` with `dim S = k+1`, intersect with
-    `W = span{v_k,…,v_{N-1}}` (`dim W = N-k`). Via
-    **`Submodule.finrank_sup_add_finrank_inf_eq`**:
-    `finrank (S ⊓ W) = finrank S + finrank W − finrank (S ⊔ W) ≥ (k+1)+(N-k) − N = 1 > 0`,
-    so `S ⊓ W ≠ ⊥`. Any `0 ≠ x ∈ S ⊓ W` is a combination of `v_k,…,v_{N-1}`, so
-    `R(x) ≤ λ_k`; thus `min_S R ≤ λ_k`, hence the max–min `≤ λ_k`. (Dual argument
-    with `span{v_k}` / `span{v₀,…,v_k}` gives the min–max form.)
-  This is the actual crux s01 hand-waved as "orthogonal-complement dimension
-  counting" — the dimension pigeonhole is one named lemma, not new infrastructure.
-
-### Session 2026-06-15 (s03, ACT — Sublemma A assembly discharged)
-
-Dual blackout persisted (Aristotle `prove` → `Resource not found`/404 live-probed;
-Docker `ps` hangs / pool unsafe). Build-free ACT step on the **merged**
-`CauchyInterlacingSublemmas.lean`:
-
-- **Sublemma A assembly is now `sorry`-free.** `rayleigh_bounds_on_eigenspan`
-  previously held one opaque `sorry`. It is now reduced — with a verified glue —
-  to exactly **two** named Parseval leaf lemmas:
-  * `norm_sq_eq_sum_repr_sq` : `‖x‖² = ∑_{i∈I} ‖b.repr x i‖²`, and
-  * `re_inner_apply_eq_sum_repr_mul` : `re ⟪T x, x⟫ = ∑_{i∈I} ‖b.repr x i‖² · μ i`.
-  The positive-mass hypothesis `0 < ∑_{i∈I} ‖b.repr x i‖²` is **derived** from the
-  first identity and `‖x‖>0` (`pow_pos (norm_pos_iff.mpr hx0) 2`), so it is *not*
-  an independent obligation — the net leaf count for Sublemma A is two, not three.
-- **Glue recipe** (verified modulo build): `hwnonneg := fun i _ => sq_nonneg _`;
-  rewrite the Rayleigh quotient by the two identities (`rw [h1, h2]`); close with
-  `weighted_mean_mem_inf_sup μ I hI (fun i => ‖b.repr x i‖²) hwnonneg h3`. Avoided
-  `set` (its opacity blocks `sq_nonneg`/`positivity` on `w i`) by passing the
-  explicit weight lambda.
-- **Both leaves share one crux**: `b.repr x i = ⟪b i, x⟫ = 0` for `i ∉ I` (the
-  off-support vanishing from `x ∈ span (b '' I)` + orthonormality). Proving that
-  support lemma once discharges both — the ideal first Aristotle submission when
-  the backend returns. Candidate Mathlib map recorded in each lemma's docstring
-  (`b.repr.norm_map` + `EuclideanSpace.norm_eq` + `Finset.sum_subset` for the
-  norm leaf; `OrthonormalBasis.sum_repr` + `hb` + Parseval for the form leaf).
-- **Not** verified (build-pending under blackout); not registered in `Proofs.lean`.
+Full decomposition + DRAFT (unverified) Lean statement:
+`approaches/orient-min-max-scaffolding.md`.
 
 ---
 
 ## Dead Ends
 
-(none yet)
-
----
-
-## Mathlib Gap (keystone)
-
-The single missing ingredient is the **Courant–Fischer max–min characterisation**
-of the descending k-th eigenvalue:
-
-  `λ_k = max_{dim S = k+1} min_{0 ≠ x ∈ S} ⟨x, A x⟩ / ⟨x, x⟩`
-       `= min_{dim S = n-k} max_{0 ≠ x ∈ S} ⟨x, A x⟩ / ⟨x, x⟩`.
-
-Mathlib has only the **extreme cases** (top/bottom eigenvalue as a Rayleigh
-quotient sup/inf via the inner-product Rayleigh API). The general k-th min-max is
-absent. Estimated effort: a self-contained min-max over
-`Submodule ℂ (EuclideanSpace ℂ (Fin N))` with the Rayleigh quotient — a few
-hundred lines, the natural next build target (or a Mathlib contribution).
-
-Once the min-max lemma exists, interlacing is a short subspace-inclusion argument:
-the `(k+1)`-dimensional test subspaces available to `B` are exactly those
-contained in the codimension-one coordinate subspace `span{e₀,…,e_{n-1}}`, a
-subset of those available to `A`. The inclusion sandwiches `μ_k` between `λ_k`
-(more subspaces can only raise the max) and `λ_{k+1}` (the deleted dimension
-contributes at most one to the min-max index).
-
----
-
-## Next Steps
-
-1. **Build the keystone min–max** over `Submodule ℂ (EuclideanSpace ℂ (Fin N))`
-   with `T.rayleighQuotient` (`T := Matrix.toEuclideanLin A` as a self-adjoint CLM;
-   needs the `eigenvalues₀ = sorted operator eigenvalues` bridge via
-   `spectral_theorem` / `eigenvectorBasis`). Prove both forms using the explicit
-   constructive recipe in s02: top-`k+1` eigenvector span for the lower bound, and
-   `Submodule.finrank_sup_add_finrank_inf_eq` for the upper-bound pigeonhole. This
-   is the single isolated obligation and the **ideal Aristotle target** once the
-   backend is reachable (404 this session) — submit the min–max lemma alone.
-2. Discharge `cauchy_interlacing` from the min–max lemma via the corrected
-   subfamily-monotonicity reduction in s02 (`{S ⊆ H}` ⊆ `{S ⊆ V}`; max–min over a
-   subfamily ↓ gives `μ i ≤ λ i`, min–max over a subfamily ↑ gives `λ(i+1) ≤ μ i`).
-3. As an interim verifiable win when a Docker window opens (≤ 2 peers): build the
-   *existing* skeleton (`sortedEigs_antitone`, `principalDrop_isHermitian`, the
-   `cauchy_interlacing` statement with its one `sorry`) by copying it to
-   `proofs/Proofs/CauchyInterlacing.lean` and running
-   `docker-build.sh Proofs.CauchyInterlacing` — locks in the foundation without
-   registering in `Proofs.lean`.
-4. Register & flip meta to verified only after the min–max keystone is proved and
-   the full file builds green.
+[Approaches known not to work will be documented here]

--- a/research/problems/cauchy-interlacing-theorem/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem/knowledge.md
@@ -20,11 +20,23 @@ Insights accumulated during research on this problem.
   (`iSup`/`iInf` in `Analysis.InnerProductSpace.Rayleigh`), NOT a k-th
   Courant–Fischer min-max. Building the k-th min-max lemma is the bulk of the
   work and is independently reusable (Weyl, Lidskii).
-- **Sorting gap**: `Matrix.IsHermitian.eigenvalues` is unsorted → interlacing
-  needs a monotone enumeration first. Cleanest: state interlacing abstractly
-  over monotone tuples, making the sorting link a separate obligation.
-  (Both gap claims flagged for re-verification against the pinned tree;
-  host `.lake` is an ELOOP symlink so no local Mathlib grep this iteration.)
+- **~~Sorting gap~~ RETRACTED (iter 3, verified vs Mathlib master)**: Mathlib
+  DOES ship sorted eigenvalues. Matrix-native:
+  `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ` is sorted
+  DESCENDING with `eigenvalues₀_antitone` (`Mathlib.LinearAlgebra.Matrix.Spectrum`).
+  (`.eigenvalues` reuses index type `n` and is unsorted — that is what the stale
+  note conflated.) Operator-level twin:
+  `LinearMap.IsSymmetric.eigenvalues : Fin n → ℝ` antitone, with
+  `hasEigenvalue_eigenvalues`, `eigenvectorBasis`. So state interlacing directly
+  over `eigenvalues₀`; no abstract-monotone-tuple workaround, no sorting
+  obligation. The keystone min-max gap above is REAL and still stands.
+- **Verified extreme Rayleigh signatures (iter 3)**:
+  `LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional` /
+  `_iInf_of_finiteDimensional` — `⨆`/`⨅` of `⟪Tx,x⟫/‖x‖²` over `{x≠0}` IS the
+  top/bottom eigenvalue. Bridging extremum→`eigenvalues₀ 0/last` is a small
+  lemma. (Spot-checked against master via GitHub docs/source — `.lake` is still
+  an ELOOP symlink and the build image carries only oleans, so no local grep;
+  re-confirm against pin v4.26.0 at build time.)
 - **Free wins available now**: the two EXTREME cases (k=0 lower `λ₀≤μ₀`,
   k=n-2 upper `μ_{n-2}≤λ_{n-1}`) follow from the existing extreme-eigenvalue
   Rayleigh API by domain-restriction to the hyperplane `H_i = {x : x i = 0}`,
@@ -35,6 +47,23 @@ Insights accumulated during research on this problem.
 
 Full decomposition + DRAFT (unverified) Lean statement:
 `approaches/orient-min-max-scaffolding.md`.
+
+---
+
+## Sessions
+
+### 2026-06-15 (iter 3, researcher-11) — API spot-check / ORIENT
+
+**Mode**: REVISIT (depth-first on owned MODERATE-tier problem). **Outcome**: progress (orientation corrected, no Lean shipped — both backends down).
+
+- Backends: Aristotle `prove` → 404; Docker pool saturated (3 `lean-build` on 7.65 GiB VM). Build-free session.
+- `.lake` is a self-referential (ELOOP) symlink and the `lean4-arm64:v4.26.0` image ships only oleans (no Mathlib source) → spot-checked the API against **Mathlib master via GitHub docs/source** instead.
+- **Retracted** the iter-2 "no sorted eigenvalues" gap: `Matrix.IsHermitian.eigenvalues₀` (antitone) and `LinearMap.IsSymmetric.eigenvalues` (antitone) both exist. Re-pinned the statement to the matrix-native `eigenvalues₀` (memo §5-revised).
+- Pinned exact extreme-Rayleigh signatures (memo §4-verified) and the minimal residual-lemma list for the extreme-case PR.
+- Confirmed the **keystone gap stands**: no k-th Courant–Fischer min-max in Mathlib.
+- Brought the previously-untracked `src/data/research/problems/cauchy-interlacing-theorem.json` under version control (was not on origin/main); corrected an inaccurate `builtItems` entry that claimed a non-existent `CauchyInterlacing.lean`.
+
+**Next**: formalize the two extreme cases over `eigenvalues₀` when a backend returns; then build the k-th min-max keystone.
 
 ---
 

--- a/research/problems/cauchy-interlacing-theorem/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem/knowledge.md
@@ -52,6 +52,40 @@ Full decomposition + DRAFT (unverified) Lean statement:
 
 ## Sessions
 
+### 2026-06-15 (iter 5, researcher-11) — transcribe keystone leaf lemmas to Lean / ACT
+
+**Mode**: REVISIT (owned MODERATE-tier problem). **Outcome**: progress
+(first Lean shipped for this problem — statements of record for the keystone leaf
+lemmas; build-pending, no backend).
+
+- **Race noted**: a parallel branch `research/cauchy-interlacing-statement`
+  (PR #24800) shipped the *matrix-level* statement of record
+  (`lean/CauchyInterlacing.lean`: `sortedEigs`, `principalDrop`, the
+  `cauchy_interlacing` theorem `sorry`) — but its keystone is a
+  `courant_fischer_placeholder : True := trivial` stub. My branch (#24796) holds
+  the *operator-level* keystone design. The two are complementary, not duplicates.
+- **Shipped** `lean/CauchyInterlacingMinMax.lean` — the operator-level keystone
+  leaf-lemma file the design §5 calls for as the first `prove_file` target:
+  - `inf_exists_ne_zero_of_finrank_add_gt` (**Sublemma B**) — nontrivial
+    intersection by dimension count; pure linear algebra, **proof attempted**
+    (`finrank_sup_add_finrank_inf_eq` + `finrank_le` + omega + `finrank_bot` +
+    `exists_mem_ne_zero_of_ne_bot`).
+  - `rayleigh_mem_Icc_of_mem_eigenspan` (**Sublemma A**) — Rayleigh ∈ [min μ,
+    max μ] on an eigenspan; stated over `LinearMap.IsSymmetric` with `eigenvalues`
+    / `eigenvectorBasis`, proof `sorry` (convex-combination, design §1).
+  - `eigenvalue_eq_iSup_iInf_rayleigh` (**keystone**) — k-th max–min identity,
+    stated, proof `sorry` (design §2).
+- Backends both down: Aristotle MCP `prove` on Sublemma B → `Resource not found`
+  (404); Docker 3 `lean-build` containers on the 7.65 GiB VM (one "Up 2 hours",
+  likely hung) → no build slot. So the file is **unverified / build-pending**;
+  exact Mathlib lemma names (esp. `finrank_bot` vs `Submodule.finrank_bot`) to be
+  reconfirmed against the v4.26.0 pin at first build.
+
+**Next**: when ANY backend returns, submit `CauchyInterlacingMinMax.lean` to
+Aristotle `prove_file` (Sublemma B and A are closed leaf targets) OR build it via
+`docker-build.sh` when ≤2 containers; then the keystone (§2) and matrix bridge to
+#24800's `sortedEigs`.
+
 ### 2026-06-15 (iter 3, researcher-11) — API spot-check / ORIENT
 
 **Mode**: REVISIT (depth-first on owned MODERATE-tier problem). **Outcome**: progress (orientation corrected, no Lean shipped — both backends down).

--- a/research/problems/cauchy-interlacing-theorem/lean/CauchyInterlacingMinMax.lean
+++ b/research/problems/cauchy-interlacing-theorem/lean/CauchyInterlacingMinMax.lean
@@ -1,0 +1,113 @@
+import Mathlib
+
+/-
+# Courant–Fischer k-th max–min — keystone leaf lemmas for Cauchy interlacing
+
+Operator-level companion to the matrix statement of record
+(`CauchyInterlacing.lean`, branch `research/cauchy-interlacing-statement`). Via
+the spectral theorem the matrix interlacing theorem reduces to the k-th
+Courant–Fischer max–min variational characterisation of the descending
+eigenvalue, which Mathlib lacks: only the *extreme* (top/bottom) Rayleigh
+quotients are available
+(`LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional` /
+`_iInf_of_finiteDimensional`).
+
+This file isolates the two **closed** (known-mathematics) leaf lemmas the
+keystone is built from, as concrete proof targets — the leaf dependencies that,
+per the design (`approaches/keystone-minmax-proof-design.md` §5), should be
+discharged first (e.g. by Aristotle `prove_file`) because everything else is
+bookkeeping over them.
+
+- `Sublemma B` (`inf_exists_ne_zero_of_finrank_add_gt`) — nontrivial intersection
+  by a dimension count. Pure linear algebra; a proof is attempted below.
+- `Sublemma A` (`rayleigh_mem_Icc_of_mem_eigenspan`) — the Rayleigh quotient on
+  the span of a sub-family of eigenvectors lies between the min and max of the
+  corresponding eigenvalues (a convex-combination bound). Stated; proof deferred.
+- The keystone max–min identity (`eigenvalue_eq_iSup_iInf_rayleigh`) is stated
+  over the operator setting and left `sorry`; its proof is §2 of the design,
+  built from Sublemmas A and B.
+
+Status: research skeleton, **build-pending** — no backend was available the
+session this was written (Aristotle MCP `prove` → 404; Docker pool saturated at
+3 `lean-build` containers on the 7.65 GiB VM). NOT registered in `Proofs.lean`.
+-/
+
+namespace CauchyInterlacing.MinMax
+
+open Module
+
+/-- **Sublemma B** (nontrivial intersection by dimension count). Two subspaces of
+a finite-dimensional space whose dimensions sum to strictly more than the ambient
+dimension meet in a nonzero vector. This is the codimension count the textbook
+interlacing proof hides in "two subspaces whose dimensions sum to more than `n`
+must intersect". Pure linear algebra — no inner-product structure needed. -/
+theorem inf_exists_ne_zero_of_finrank_add_gt
+    {𝕜 E : Type*} [Field 𝕜] [AddCommGroup E] [Module 𝕜 E] [FiniteDimensional 𝕜 E]
+    (V W : Submodule 𝕜 E)
+    (h : finrank 𝕜 E < finrank 𝕜 V + finrank 𝕜 W) :
+    ∃ x ∈ V ⊓ W, x ≠ 0 := by
+  have hsum :
+      finrank 𝕜 (V ⊔ W : Submodule 𝕜 E) + finrank 𝕜 (V ⊓ W : Submodule 𝕜 E)
+        = finrank 𝕜 V + finrank 𝕜 W :=
+    Submodule.finrank_sup_add_finrank_inf_eq V W
+  have hle : finrank 𝕜 (V ⊔ W : Submodule 𝕜 E) ≤ finrank 𝕜 E :=
+    Submodule.finrank_le _
+  have hpos : 0 < finrank 𝕜 (V ⊓ W : Submodule 𝕜 E) := by omega
+  have hne : (V ⊓ W : Submodule 𝕜 E) ≠ ⊥ := by
+    intro hbot
+    rw [hbot, finrank_bot] at hpos
+    exact (lt_irrefl 0) hpos
+  exact Submodule.exists_mem_ne_zero_of_ne_bot hne
+
+/-- The (real part of the) Rayleigh quotient of a symmetric operator `T` at a
+nonzero vector `x`: `re ⟪T x, x⟫ / ‖x‖ ^ 2`. Kept as a local definition so the
+whole development stays on one spelling (the design flags the
+`ContinuousLinearMap.rayleighQuotient` / `LinearMap` coercion detour as a
+hazard). -/
+noncomputable def rayleigh {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] (T : E →ₗ[𝕜] E) (x : E) : ℝ :=
+  RCLike.re (inner (T x) x : 𝕜) / ‖x‖ ^ 2
+
+/-- **Sublemma A** (Rayleigh bounds on a coordinate eigenspan). Let `T` be a
+symmetric operator on a finite-dimensional inner product space with orthonormal
+eigenbasis `b` and eigenvalues `μ`. For a `Finset I` of eigenindices and any
+nonzero `x` in the span of `{b i : i ∈ I}`, the Rayleigh quotient `rayleigh T x`
+lies between the min and the max of `{μ i : i ∈ I}` — it is a convex combination
+of those eigenvalues with Parseval weights `‖⟪b i, x⟫‖² / ‖x‖²`.
+
+This is the workhorse of the keystone: taking `I = {0,…,k}` gives `rayleigh ≥ μ k`
+on the lower witness span, and `I = {k,…,n-1}` gives `rayleigh ≤ μ k` on the
+upper span. Proof deferred (design §1, Sublemma A): two Parseval expansions plus
+a convex-combination sandwich. -/
+theorem rayleigh_mem_Icc_of_mem_eigenspan
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {n : ℕ} (hn : finrank 𝕜 E = n)
+    (T : E →ₗ[𝕜] E) (hT : T.IsSymmetric)
+    (I : Finset (Fin n)) (hI : I.Nonempty)
+    (x : E) (hx : x ≠ 0)
+    (hmem : x ∈ Submodule.span 𝕜 ((hT.eigenvectorBasis hn) '' (I : Set (Fin n)))) :
+    (I.inf' hI (hT.eigenvalues hn)) ≤ rayleigh T x ∧
+      rayleigh T x ≤ (I.sup' hI (hT.eigenvalues hn)) := by
+  sorry
+
+/-- **Keystone — k-th Courant–Fischer max–min identity** (operator form,
+descending convention). The `k`-th descending eigenvalue of a symmetric operator
+equals the maximum over `(k+1)`-dimensional subspaces `S` of the minimum Rayleigh
+quotient over nonzero `x ∈ S`.
+
+Proof (design §2): the witness span `span {b 0,…,b k}` realises `≥` via Sublemma A
+(min of the decreasing `μ` over `{0,…,k}` is `μ k`); for `≤`, any `(k+1)`-dim `S`
+meets `span {b k,…,b (n-1)}` (dimensions `(k+1)+(n-k) = n+1 > n`, Sublemma B) in a
+nonzero vector with Rayleigh `≤ μ k` (Sublemma A). Boundedness obligations
+(`BddBelow`/`BddAbove` for the `ciInf`/`ciSup`) are discharged from Sublemma A
+with `I = univ`. The dual min–max form follows by applying this to `-T`. -/
+theorem eigenvalue_eq_iSup_iInf_rayleigh
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {n : ℕ} (hn : finrank 𝕜 E = n)
+    (T : E →ₗ[𝕜] E) (hT : T.IsSymmetric) (k : Fin n) :
+    hT.eigenvalues hn k
+      = ⨆ S : {S : Submodule 𝕜 E // finrank 𝕜 S = (k : ℕ) + 1},
+          ⨅ x : {x : E // x ∈ (S : Submodule 𝕜 E) ∧ x ≠ 0}, rayleigh T x := by
+  sorry
+
+end CauchyInterlacing.MinMax

--- a/research/problems/cauchy-interlacing-theorem/problem.md
+++ b/research/problems/cauchy-interlacing-theorem/problem.md
@@ -1,0 +1,128 @@
+# Problem: Cauchy Interlacing Theorem for Hermitian Matrices
+
+**Slug**: cauchy-interlacing-theorem
+**Created**: 2026-06-15T12:01:03-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Let } A \in \mathbb{C}^{n\times n} \text{ be Hermitian with eigenvalues } \lambda_1 \le \cdots \le \lambda_n,
+$$
+$$
+\text{and let } B \text{ be a principal } (n-1)\times(n-1) \text{ submatrix with eigenvalues } \mu_1 \le \cdots \le \mu_{n-1}.
+$$
+$$
+\text{Then } \lambda_k \le \mu_k \le \lambda_{k+1} \quad (1 \le k \le n-1).
+$$
+
+### Plain Language
+
+If you delete one row and the matching column from a symmetric/Hermitian matrix, the
+eigenvalues of the smaller matrix sit between consecutive eigenvalues of the original.
+The spectra "interlace."
+
+### Why This Matters
+
+Interlacing is a cornerstone of spectral graph theory (eigenvalue bounds for vertex-deleted
+subgraphs), numerical linear algebra (eigenvalue tracking, the divide-and-conquer eigensolver),
+and the theory of orthogonal polynomials (roots of consecutive members interlace). It is the
+prototype of a large family of interlacing/monotonicity results and underlies the recent
+Marcus–Spielman–Srivastava resolution of the Kadison–Singer problem.
+
+## Known Results
+
+### What's Already Proven
+
+- Spectral theorem for Hermitian matrices — `Matrix.IsHermitian.spectral_theorem` (Mathlib)
+- Sorted real eigenvalues exist — `Matrix.IsHermitian.eigenvalues` (Mathlib)
+- Rayleigh quotient bounds for extreme eigenvalues — partial coverage in Mathlib
+
+### What's Still Open
+
+- A Courant–Fischer min-max characterization of the k-th eigenvalue is not packaged in Mathlib in a form directly usable here.
+- The interlacing inequality itself is absent from Mathlib.
+
+### Our Goal
+
+Prove the one-step interlacing inequality $\lambda_k \le \mu_k \le \lambda_{k+1}$ for a principal
+$(n-1)\times(n-1)$ submatrix, ideally via a Courant–Fischer min-max argument restricted to the
+codimension-one coordinate subspace. The general "delete m rows" version is a stretch goal.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| minpoly-charpoly-oq-01 | spectral identities for structured matrices | charpoly, eigenvalues |
+| cayley-hamilton-cyclic-vector-all-fields-oq-02 | eigenstructure of matrices/operators | minimal polynomial, cyclic vectors |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Courant–Fischer min-max**: Express $\lambda_k = \min_{\dim S = k}\max_{x\in S}\langle Ax,x\rangle/\langle x,x\rangle$ and restrict test subspaces to those inside the codimension-one coordinate hyperplane defining $B$.
+   - Why it might work: gives both inequalities symmetrically; standard textbook route.
+   - Risk: needs a min-max lemma that may have to be built from scratch in Mathlib.
+
+2. **Approach B — Cauchy's eigenvalue interlacing via the secular equation**: relate $\det(A - xI)$ and $\det(B - xI)$ through the rank-one bordering and sign-change counting.
+   - Why it might work: explicit determinant identity, close to Mathlib's `Matrix.det` API.
+   - Risk: sign-counting / intermediate value bookkeeping is fiddly to formalize.
+
+### Key Difficulties
+
+- Mathlib lacks a ready-made Courant–Fischer min-max statement for the k-th eigenvalue.
+- Indexing the sorted eigenvalues and matching `Fin n` vs `Fin (n-1)` cleanly.
+
+### What Would a Proof Need?
+
+- Key lemma 1: min-max (Courant–Fischer) characterization of sorted Hermitian eigenvalues.
+- Key lemma 2: dimension-counting for the intersection of a k-dimensional subspace with a codimension-one hyperplane.
+- Technical requirements: `Matrix.IsHermitian` spectral API, inner-product-space lemmas, `Finset`/`Fin` reindexing.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematics is classical and self-contained; the obstacle is missing Mathlib scaffolding (min-max), not deep theory.
+- Mathlib's Hermitian spectral theorem and eigenvalue API provide a real starting point.
+- The min-max lemma, once built, is independently reusable (Weyl inequalities, monotonicity).
+
+**Estimated Effort**:
+- Exploration: 1-2 days
+- If tractable: 1-2 weeks
+- If hard: unknown (if min-max must be developed in full generality)
+
+## References
+
+### Papers
+- Cauchy, "Sur l'équation à l'aide de laquelle on détermine les inégalités séculaires" (1829) — original interlacing.
+- Horn & Johnson, *Matrix Analysis*, 2nd ed., §4.3 — modern statement and proof.
+
+### Online Resources
+- Tao, "254A notes: interlacing" — min-max derivation of Cauchy interlacing.
+
+### Mathlib
+- `Mathlib.LinearAlgebra.Matrix.Spectrum` — `Matrix.IsHermitian.eigenvalues`, spectral theorem.
+- `Mathlib.Analysis.InnerProductSpace.Rayleigh` — Rayleigh quotient and extreme eigenvalues.
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - spectral-theory
+  - eigenvalues
+related_proofs:
+  - minpoly-charpoly-oq-01
+  - cayley-hamilton-cyclic-vector-all-fields-oq-02
+difficulty: medium
+source: gallery-gap
+created: 2026-06-15T12:01:03-07:00
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10

--- a/research/problems/cauchy-interlacing-theorem/state.md
+++ b/research/problems/cauchy-interlacing-theorem/state.md
@@ -1,27 +1,29 @@
 # Research State: cauchy-interlacing-theorem
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-15 (iter 3, researcher-11)
-**Iteration**: 3
+**Since**: 2026-06-15 (iter 5, researcher-11)
+**Iteration**: 5
 
 ## Current Focus
-Mathlib API spot-checked against master. The iter-2 "no sorted eigenvalues" gap
-is RETRACTED — `Matrix.IsHermitian.eigenvalues₀` (antitone) is the statement
-vehicle. Exact extreme-Rayleigh signatures + minimal extreme-case lemma list
-pinned in `approaches/orient-min-max-scaffolding.md` (§4-verified, §5-revised).
-Keystone k-th min-max gap confirmed real. No Lean shipped — both backends down
-(Docker pool saturated at 3 `lean-build` containers; Aristotle `prove` → 404).
+First Lean shipped: `lean/CauchyInterlacingMinMax.lean` states the operator-level
+keystone (`eigenvalue_eq_iSup_iInf_rayleigh`) and its two closed leaf lemmas —
+Sublemma B (`inf_exists_ne_zero_of_finrank_add_gt`, proof attempted) and Sublemma
+A (`rayleigh_mem_Icc_of_mem_eigenspan`, `sorry`). These are the `prove_file` leaf
+targets from design §5. File is **build-pending** (Aristotle 404; Docker 3/3
+containers — no slot). Complements the parallel matrix statement of record on
+branch `research/cauchy-interlacing-statement` (#24800), whose keystone is only a
+`True` stub.
 
 ## Active Approach
 Approach A (Courant–Fischer min-max + codim-1 dimension count). See the orient
 memo §3. Approach B (secular-equation sign counting) parked as fallback.
 
 ## Attempt Count
-- Total attempts: 0 (no proof attempts; orientation only)
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (Sublemma B proof attempted in Lean; unverified — no backend)
+- Current approach attempts: 1
+- Approaches tried: 1 (Approach A, leaf lemmas)
 
 ## Blockers
 - Mathlib lacks a k-th Courant–Fischer min-max characterization (keystone to build) — CONFIRMED absent on master.
@@ -29,9 +31,12 @@ memo §3. Approach B (secular-equation sign counting) parked as fallback.
 - (Resolved: the "unsorted eigenvalues" blocker — `eigenvalues₀` is sorted/antitone.)
 
 ## Next Action
-Per orient memo §6, in order:
-1. ~~API spot-check~~ DONE (iter 3) — see §4-verified.
-2. Formalize the two EXTREME cases (k=0 top, k=last bottom) over `eigenvalues₀`
-   from the extreme Rayleigh API — smallest viable first PR; ideal Aristotle job.
-3. Build the k-th min-max lemma (keystone).
-4. Assemble interlacing.
+1. ~~API spot-check~~ DONE (iter 3). ~~State keystone + leaf lemmas in Lean~~ DONE
+   (iter 5, `lean/CauchyInterlacingMinMax.lean`).
+2. When ANY backend returns: submit `CauchyInterlacingMinMax.lean` to Aristotle
+   `prove_file` (Sublemma A + B are closed leaf targets), OR `docker-build.sh`
+   when ≤2 containers. Reconfirm lemma names (`finrank_bot`, `eigenvalues`,
+   `eigenvectorBasis`, `finrank_sup_add_finrank_inf_eq`) against v4.26.0 pin.
+3. Prove the keystone max–min identity (design §2) from the leaf lemmas.
+4. Bridge to the matrix `sortedEigs` (#24800) via the spectral theorem; assemble
+   one-step interlacing (scaffolding §3).

--- a/research/problems/cauchy-interlacing-theorem/state.md
+++ b/research/problems/cauchy-interlacing-theorem/state.md
@@ -3,13 +3,15 @@
 ## Current State
 **Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-15 (iter 2, researcher-11)
-**Iteration**: 2
+**Since**: 2026-06-15 (iter 3, researcher-11)
+**Iteration**: 3
 
 ## Current Focus
-Mathlib-gap orientation done. The proof decomposition and the keystone missing
-lemma (k-th Courant–Fischer min-max) are pinned in
-`approaches/orient-min-max-scaffolding.md`. No Lean shipped — both backends down
+Mathlib API spot-checked against master. The iter-2 "no sorted eigenvalues" gap
+is RETRACTED — `Matrix.IsHermitian.eigenvalues₀` (antitone) is the statement
+vehicle. Exact extreme-Rayleigh signatures + minimal extreme-case lemma list
+pinned in `approaches/orient-min-max-scaffolding.md` (§4-verified, §5-revised).
+Keystone k-th min-max gap confirmed real. No Lean shipped — both backends down
 (Docker pool saturated at 3 `lean-build` containers; Aristotle `prove` → 404).
 
 ## Active Approach
@@ -22,15 +24,14 @@ memo §3. Approach B (secular-equation sign counting) parked as fallback.
 - Approaches tried: 0
 
 ## Blockers
-- Mathlib lacks a k-th Courant–Fischer min-max characterization (keystone to build).
-- Mathlib `IsHermitian.eigenvalues` is unsorted → need a sorted-enumeration helper
-  (claim flagged for re-verification; host `.lake` ELOOP blocked a local grep).
+- Mathlib lacks a k-th Courant–Fischer min-max characterization (keystone to build) — CONFIRMED absent on master.
 - Infra: Docker build pool full; Aristotle backend 404.
+- (Resolved: the "unsorted eigenvalues" blocker — `eigenvalues₀` is sorted/antitone.)
 
 ## Next Action
 Per orient memo §6, in order:
-1. API spot-check of `IsHermitian.eigenvalues` + Rayleigh `iSup`/`iInf` lemmas.
-2. Formalize the two EXTREME cases (k=0 lower, k=n-2 upper) from existing
-   Rayleigh API — smallest viable first PR; ideal Aristotle job.
-3. Build the k-th min-max lemma.
+1. ~~API spot-check~~ DONE (iter 3) — see §4-verified.
+2. Formalize the two EXTREME cases (k=0 top, k=last bottom) over `eigenvalues₀`
+   from the extreme Rayleigh API — smallest viable first PR; ideal Aristotle job.
+3. Build the k-th min-max lemma (keystone).
 4. Assemble interlacing.

--- a/research/problems/cauchy-interlacing-theorem/state.md
+++ b/research/problems/cauchy-interlacing-theorem/state.md
@@ -1,0 +1,36 @@
+# Research State: cauchy-interlacing-theorem
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-06-15 (iter 2, researcher-11)
+**Iteration**: 2
+
+## Current Focus
+Mathlib-gap orientation done. The proof decomposition and the keystone missing
+lemma (k-th Courant–Fischer min-max) are pinned in
+`approaches/orient-min-max-scaffolding.md`. No Lean shipped — both backends down
+(Docker pool saturated at 3 `lean-build` containers; Aristotle `prove` → 404).
+
+## Active Approach
+Approach A (Courant–Fischer min-max + codim-1 dimension count). See the orient
+memo §3. Approach B (secular-equation sign counting) parked as fallback.
+
+## Attempt Count
+- Total attempts: 0 (no proof attempts; orientation only)
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+- Mathlib lacks a k-th Courant–Fischer min-max characterization (keystone to build).
+- Mathlib `IsHermitian.eigenvalues` is unsorted → need a sorted-enumeration helper
+  (claim flagged for re-verification; host `.lake` ELOOP blocked a local grep).
+- Infra: Docker build pool full; Aristotle backend 404.
+
+## Next Action
+Per orient memo §6, in order:
+1. API spot-check of `IsHermitian.eigenvalues` + Rayleigh `iSup`/`iInf` lemmas.
+2. Formalize the two EXTREME cases (k=0 lower, k=n-2 upper) from existing
+   Rayleigh API — smallest viable first PR; ideal Aristotle job.
+3. Build the k-th min-max lemma.
+4. Assemble interlacing.

--- a/src/data/research/problems/cauchy-interlacing-theorem.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem.json
@@ -32,10 +32,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT->design: keystone k-th min-max fully designed (proof + Mathlib map + 2 leaf sublemmas); blocked on backend (Docker saturated 3-container, Aristotle 404) for verification, NOT on math.",
+    "progressSummary": "PROGRESS: first Lean shipped — operator-level keystone + 2 leaf lemmas stated (Sublemma B proof attempted); build-pending, both backends down",
     "builtItems": [
       "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty).",
-      "approaches/keystone-minmax-proof-design.md: full per-step Mathlib lemma map for the k-th min-max keystone + Sublemmas A/B + boundedness obligations (no Lean compiled, both backends down)"
+      "approaches/keystone-minmax-proof-design.md: full per-step Mathlib lemma map for the k-th min-max keystone + Sublemmas A/B + boundedness obligations (no Lean compiled, both backends down)",
+      "lean/CauchyInterlacingMinMax.lean: stated keystone eigenvalue_eq_iSup_iInf_rayleigh (k-th max-min, sorry) + leaf lemmas inf_exists_ne_zero_of_finrank_add_gt (Sublemma B, proof attempted) and rayleigh_mem_Icc_of_mem_eigenspan (Sublemma A, sorry) — build-pending, no backend"
     ],
     "insights": [
       "VERIFIED (Mathlib master, iter 3): Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ is sorted DESCENDING with Matrix.IsHermitian.eigenvalues₀_antitone (file Mathlib.LinearAlgebra.Matrix.Spectrum). Plain Matrix.IsHermitian.eigenvalues reuses index type n and is NOT sorted. So the 'no sorted eigenvalue function' gap from earlier survey notes is FALSE — state interlacing directly over eigenvalues₀, no abstract monotone-tuple workaround needed.",
@@ -46,7 +47,8 @@
       "Keystone k-th min-max ADMITS a complete classical proof (Courant-Fischer max-min): exhibit Vlo=span(b 0..k) for the >= bound; for <= bound, any (k+1)-dim S meets Vhi=span(b k..n-1) nontrivially since (k+1)+(n-k)=n+1>n, and Rayleigh <= mu k there.",
       "Reduces to 2 standalone CLOSED sublemmas: (A) Rayleigh quotient on span of an eigenvector subset is a convex combination of those eigenvalues, hence between their min and max; (B) two subspaces with finrank sum > n meet nontrivially (via finrank_sup_add_finrank_inf_eq + finrank_le).",
       "Critical formalization hazard identified: ciInf/ciSup over subspace families need explicit BddBelow(mu last)/BddAbove(mu 0)+nonempty discharge or they return junk - the usual silent breakage point.",
-      "CLM-vs-LM Rayleigh spelling mismatch (eigenvalues API on LinearMap, rayleighQuotient on ContinuousLinearMap) should be isolated to one bridge lemma, not threaded through the proof."
+      "CLM-vs-LM Rayleigh spelling mismatch (eigenvalues API on LinearMap, rayleighQuotient on ContinuousLinearMap) should be isolated to one bridge lemma, not threaded through the proof.",
+      "Parallel branch research/cauchy-interlacing-statement (PR #24800) holds the matrix statement of record (sortedEigs/principalDrop/cauchy_interlacing sorry) with a True-stub keystone; my operator-level leaf file complements it — the bridge is matrix Hermitian -> operator IsSymmetric via the spectral theorem"
     ],
     "mathlibGaps": [
       "No k-th Courant–Fischer / min-max characterisation of the descending k-th eigenvalue in Mathlib (confirmed absent from both InnerProductSpace.Rayleigh and InnerProductSpace.Spectrum on master; only extreme top/bottom Rayleigh cases exist). This is the keystone; est. few hundred lines over Submodule ℂ (EuclideanSpace ℂ (Fin N)). Independently reusable (Weyl, Lidskii)."
@@ -58,7 +60,8 @@
       "At build time, re-confirm eigenvalues₀/_antitone exist in the project pin v4.26.0 (verified only against master); fall back to Tuple.sort or operator eigenvalues if absent.",
       "When a backend returns: submit Sublemma A (Rayleigh=convex combo of eigenvalues) and Sublemma B (nontrivial intersection by finrank count) to Aristotle FIRST - they are leaf deps, closed/HARD-not-OPEN, unblock everything above.",
       "Then build boundedness haves (mu 0 / mu last), then the max-min identity, then dual via -T, then interlacing assembly.",
-      "Re-confirm eigenvalues_antitone + apply_eigenvectorBasis + finrank_sup_add_finrank_inf_eq exist in pin v4.26.0 (checked vs master only)."
+      "Re-confirm eigenvalues_antitone + apply_eigenvectorBasis + finrank_sup_add_finrank_inf_eq exist in pin v4.26.0 (checked vs master only).",
+      "Submit lean/CauchyInterlacingMinMax.lean to Aristotle prove_file (Sublemma A+B are closed leaf targets) or docker-build when <=2 containers; reconfirm finrank_bot/eigenvalues/eigenvectorBasis names vs v4.26.0 pin"
     ],
     "markdown": "# Knowledge Base: cauchy-interlacing-theorem\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/cauchy-interlacing-theorem.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem.json
@@ -1,0 +1,75 @@
+{
+  "slug": "cauchy-interlacing-theorem",
+  "title": "Cauchy Interlacing Theorem for Hermitian Matrices",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Let } A \\in \\mathbb{C}^{n\\times n} \\text{ be Hermitian with eigenvalues } \\lambda_1 \\le \\cdots \\le \\lambda_n,",
+    "plain": "If you delete one row and the matching column from a symmetric/Hermitian matrix, the eigenvalues of the resulting principal submatrix interlace those of the original.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-15T14:30:00-07:00",
+    "iteration": 3,
+    "focus": "Verified the Mathlib API against master (docs+source). Retracted the iter-2 'no sorted eigenvalues' gap. Re-pinned formalization route to matrix-native eigenvalues₀ + operator Rayleigh for extreme cases.",
+    "blockers": [
+      "Both proof backends down: Docker build pool saturated (3 lean-build on 7.65GiB VM); Aristotle MCP prove → 404.",
+      "Keystone theory gap: no k-th Courant–Fischer min-max in Mathlib (only extreme Rayleigh)."
+    ],
+    "nextAction": "When a backend returns: formalize the two extreme cases (k=0/k=last) over eigenvalues₀ via the operator Rayleigh iSup/iInf domain-restriction; see approaches/orient-min-max-scaffolding.md §4-verified.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (iter 3): Mathlib API spot-checked vs master. Statement vehicle = Matrix.IsHermitian.eigenvalues₀ (antitone, sorted). Extreme cases reachable from extreme Rayleigh API. Keystone gap = k-th Courant–Fischer min-max (absent from Mathlib). Build-pending (Aristotle 404, Docker saturated).",
+    "builtItems": [
+      "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty)."
+    ],
+    "insights": [
+      "VERIFIED (Mathlib master, iter 3): Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ is sorted DESCENDING with Matrix.IsHermitian.eigenvalues₀_antitone (file Mathlib.LinearAlgebra.Matrix.Spectrum). Plain Matrix.IsHermitian.eigenvalues reuses index type n and is NOT sorted. So the 'no sorted eigenvalue function' gap from earlier survey notes is FALSE — state interlacing directly over eigenvalues₀, no abstract monotone-tuple workaround needed.",
+      "VERIFIED (Mathlib master, iter 3): operator-level sorted eigenvalues also exist — LinearMap.IsSymmetric.eigenvalues : Fin n → ℝ, antitone (eigenvalues_antitone), with hasEigenvalue_eigenvalues, eigenvectorBasis, exists_eigenvalues_eq (Mathlib.Analysis.InnerProductSpace.Spectrum).",
+      "VERIFIED (Mathlib master, iter 3): extreme eigenvalues are variationally characterized — LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional / _iInf_ state that ⨆/⨅ of the Rayleigh quotient ⟪Tx,x⟫/‖x‖² over {x≠0} IS an eigenvalue (top/bottom). These are HasEigenvalue statements, not yet equalities with eigenvalues 0 / last — bridging them is a small lemma (extremum is an eigenvalue ⇒ ≤ max; every eigenvector's Rayleigh value ⇒ ≥). File Mathlib.Analysis.InnerProductSpace.Rayleigh.",
+      "Interlacing stated in descending convention λ k.succ ≤ μ k ≤ λ k.castSucc for k : Fin n; equivalent to ascending textbook form under index reversal.",
+      "Extreme cases (k=0 top, k=last bottom) follow TODAY from the extreme Rayleigh API by domain-monotonicity of ⨆/⨅ under the codim-1 hyperplane H_i ⊆ ℂⁿ — no k-th min-max needed."
+    ],
+    "mathlibGaps": [
+      "No k-th Courant–Fischer / min-max characterisation of the descending k-th eigenvalue in Mathlib (confirmed absent from both InnerProductSpace.Rayleigh and InnerProductSpace.Spectrum on master; only extreme top/bottom Rayleigh cases exist). This is the keystone; est. few hundred lines over Submodule ℂ (EuclideanSpace ℂ (Fin N)). Independently reusable (Weyl, Lidskii)."
+    ],
+    "nextSteps": [
+      "Formalize the two extreme cases (§4-verified): bridge eigenvalues₀ 0/last to the Rayleigh ⨆/⨅, then domain-restrict to H_i. Smallest viable first PR; good Aristotle job when backend up. Use matrix-native statement (§5-revised).",
+      "Build the general k-th min-max lemma over Submodule ℂ (EuclideanSpace ℂ (Fin N)) — keystone; the only genuine new theory.",
+      "Discharge cauchy_interlacing from min-max + the dim(S ∩ H_i) ≥ dim S − 1 count; build+register when Docker free.",
+      "At build time, re-confirm eigenvalues₀/_antitone exist in the project pin v4.26.0 (verified only against master); fall back to Tuple.sort or operator eigenvalues if absent."
+    ],
+    "markdown": "# Knowledge Base: cauchy-interlacing-theorem\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "linear-algebra",
+    "spectral-theory",
+    "eigenvalues"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.Spectrum",
+      "Mathlib.Analysis.InnerProductSpace.Rayleigh",
+      "Mathlib.Analysis.InnerProductSpace.Spectrum"
+    ]
+  },
+  "started": "2026-06-15T12:01:03-07:00",
+  "significance": 6,
+  "tractability": 5
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem.json
@@ -32,16 +32,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (iter 3): Mathlib API spot-checked vs master. Statement vehicle = Matrix.IsHermitian.eigenvalues₀ (antitone, sorted). Extreme cases reachable from extreme Rayleigh API. Keystone gap = k-th Courant–Fischer min-max (absent from Mathlib). Build-pending (Aristotle 404, Docker saturated).",
+    "progressSummary": "ORIENT->design: keystone k-th min-max fully designed (proof + Mathlib map + 2 leaf sublemmas); blocked on backend (Docker saturated 3-container, Aristotle 404) for verification, NOT on math.",
     "builtItems": [
-      "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty)."
+      "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty).",
+      "approaches/keystone-minmax-proof-design.md: full per-step Mathlib lemma map for the k-th min-max keystone + Sublemmas A/B + boundedness obligations (no Lean compiled, both backends down)"
     ],
     "insights": [
       "VERIFIED (Mathlib master, iter 3): Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ is sorted DESCENDING with Matrix.IsHermitian.eigenvalues₀_antitone (file Mathlib.LinearAlgebra.Matrix.Spectrum). Plain Matrix.IsHermitian.eigenvalues reuses index type n and is NOT sorted. So the 'no sorted eigenvalue function' gap from earlier survey notes is FALSE — state interlacing directly over eigenvalues₀, no abstract monotone-tuple workaround needed.",
       "VERIFIED (Mathlib master, iter 3): operator-level sorted eigenvalues also exist — LinearMap.IsSymmetric.eigenvalues : Fin n → ℝ, antitone (eigenvalues_antitone), with hasEigenvalue_eigenvalues, eigenvectorBasis, exists_eigenvalues_eq (Mathlib.Analysis.InnerProductSpace.Spectrum).",
       "VERIFIED (Mathlib master, iter 3): extreme eigenvalues are variationally characterized — LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional / _iInf_ state that ⨆/⨅ of the Rayleigh quotient ⟪Tx,x⟫/‖x‖² over {x≠0} IS an eigenvalue (top/bottom). These are HasEigenvalue statements, not yet equalities with eigenvalues 0 / last — bridging them is a small lemma (extremum is an eigenvalue ⇒ ≤ max; every eigenvector's Rayleigh value ⇒ ≥). File Mathlib.Analysis.InnerProductSpace.Rayleigh.",
       "Interlacing stated in descending convention λ k.succ ≤ μ k ≤ λ k.castSucc for k : Fin n; equivalent to ascending textbook form under index reversal.",
-      "Extreme cases (k=0 top, k=last bottom) follow TODAY from the extreme Rayleigh API by domain-monotonicity of ⨆/⨅ under the codim-1 hyperplane H_i ⊆ ℂⁿ — no k-th min-max needed."
+      "Extreme cases (k=0 top, k=last bottom) follow TODAY from the extreme Rayleigh API by domain-monotonicity of ⨆/⨅ under the codim-1 hyperplane H_i ⊆ ℂⁿ — no k-th min-max needed.",
+      "Keystone k-th min-max ADMITS a complete classical proof (Courant-Fischer max-min): exhibit Vlo=span(b 0..k) for the >= bound; for <= bound, any (k+1)-dim S meets Vhi=span(b k..n-1) nontrivially since (k+1)+(n-k)=n+1>n, and Rayleigh <= mu k there.",
+      "Reduces to 2 standalone CLOSED sublemmas: (A) Rayleigh quotient on span of an eigenvector subset is a convex combination of those eigenvalues, hence between their min and max; (B) two subspaces with finrank sum > n meet nontrivially (via finrank_sup_add_finrank_inf_eq + finrank_le).",
+      "Critical formalization hazard identified: ciInf/ciSup over subspace families need explicit BddBelow(mu last)/BddAbove(mu 0)+nonempty discharge or they return junk - the usual silent breakage point.",
+      "CLM-vs-LM Rayleigh spelling mismatch (eigenvalues API on LinearMap, rayleighQuotient on ContinuousLinearMap) should be isolated to one bridge lemma, not threaded through the proof."
     ],
     "mathlibGaps": [
       "No k-th Courant–Fischer / min-max characterisation of the descending k-th eigenvalue in Mathlib (confirmed absent from both InnerProductSpace.Rayleigh and InnerProductSpace.Spectrum on master; only extreme top/bottom Rayleigh cases exist). This is the keystone; est. few hundred lines over Submodule ℂ (EuclideanSpace ℂ (Fin N)). Independently reusable (Weyl, Lidskii)."
@@ -50,7 +55,10 @@
       "Formalize the two extreme cases (§4-verified): bridge eigenvalues₀ 0/last to the Rayleigh ⨆/⨅, then domain-restrict to H_i. Smallest viable first PR; good Aristotle job when backend up. Use matrix-native statement (§5-revised).",
       "Build the general k-th min-max lemma over Submodule ℂ (EuclideanSpace ℂ (Fin N)) — keystone; the only genuine new theory.",
       "Discharge cauchy_interlacing from min-max + the dim(S ∩ H_i) ≥ dim S − 1 count; build+register when Docker free.",
-      "At build time, re-confirm eigenvalues₀/_antitone exist in the project pin v4.26.0 (verified only against master); fall back to Tuple.sort or operator eigenvalues if absent."
+      "At build time, re-confirm eigenvalues₀/_antitone exist in the project pin v4.26.0 (verified only against master); fall back to Tuple.sort or operator eigenvalues if absent.",
+      "When a backend returns: submit Sublemma A (Rayleigh=convex combo of eigenvalues) and Sublemma B (nontrivial intersection by finrank count) to Aristotle FIRST - they are leaf deps, closed/HARD-not-OPEN, unblock everything above.",
+      "Then build boundedness haves (mu 0 / mu last), then the max-min identity, then dual via -T, then interlacing assembly.",
+      "Re-confirm eigenvalues_antitone + apply_eigenvectorBasis + finrank_sup_add_finrank_inf_eq exist in pin v4.26.0 (checked vs master only)."
     ],
     "markdown": "# Knowledge Base: cauchy-interlacing-theorem\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
ORIENT-phase progress on Cauchy interlacing (multi-session problem; no Lean shipped — both proof backends down: Docker pool saturated, Aristotle 404).

**iter-3 (verified API spot-check):**
- Spot-checked the relevant API against **Mathlib master** (docs+source; local `.lake` is an ELOOP symlink and the build image carries only oleans, so no local grep).
- **Retracts** the earlier "no sorted eigenvalue function" gap claim: `Matrix.IsHermitian.eigenvalues₀` (antitone, descending) and `LinearMap.IsSymmetric.eigenvalues` (antitone) both exist. Interlacing is now stated directly over matrix-native `eigenvalues₀` — no abstract-monotone-tuple workaround.
- Records exact extreme-Rayleigh signatures (`hasEigenvalue_iSup/iInf_of_finiteDimensional`) and the minimal residual-lemma set for the extreme-case PR.
- Confirms the **keystone gap stands**: no k-th Courant–Fischer min-max in Mathlib.
- Brings the previously-untracked knowledge json under version control; fixes a `builtItems` entry that claimed a non-existent `CauchyInterlacing.lean`.

**iter-2 (original):** Mathlib-gap orientation + proof decomposition memo.

## Files
- `research/problems/cauchy-interlacing-theorem/approaches/orient-min-max-scaffolding.md` — full ORIENT memo (§4-verified, §5-revised)
- `research/problems/cauchy-interlacing-theorem/{knowledge,state}.md`, `problem.md`
- `src/data/research/problems/cauchy-interlacing-theorem.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)