### PR TITLE
research(erdos-1179-oq-02): power-of-two dichotomy for exact 0-uniformity

### DIFF
--- a/proofs/Proofs/Erdos1179OQ02Extremal.lean
+++ b/proofs/Proofs/Erdos1179OQ02Extremal.lean
@@ -107,6 +107,61 @@ theorem unique_repr_of_epsUniform_zero_clog {G : Type*} [AddCommGroup G]
   rw [hconst g]
   exact hc1
 
+/-- **Admissibility of the order `N` for exact `0`-uniformity.**  If *any* finset
+`A` is `0`-uniform, then the group order `N = |G|` must be a power of two,
+`N = 2^j` with `j ≤ |A|`.  (No minimality hypothesis: this holds for every
+`0`-uniform set, of any size.)
+
+`0`-uniformity collapses all representation counts to one natural number `c`, so
+`N · c = 2^|A|` (parent `total_reprCount`), giving `N ∣ 2^|A|` and hence
+`N = 2^j` by `Nat.dvd_prime_pow`.  This is the structural core that the converse
+`unique_repr_of_epsUniform_zero_clog` specialises once minimality is added. -/
+theorem card_pow_two_of_epsUniform_zero {G : Type*} [AddCommGroup G]
+    [Fintype G] [DecidableEq G] (A : Finset G) (hunif : IsEpsUniform A 0) :
+    ∃ j ≤ A.card, Fintype.card G = 2 ^ j := by
+  -- ε = 0 forces every count to equal the expected count μ exactly.
+  have heq : ∀ g, (reprCount A g : ℝ)
+      = expectedReprCount A.card (Fintype.card G) := by
+    intro g
+    have h := hunif g
+    rw [zero_mul] at h
+    have h0 : |(reprCount A g : ℝ)
+        - expectedReprCount A.card (Fintype.card G)| = 0 :=
+      le_antisymm h (abs_nonneg _)
+    have := abs_eq_zero.mp h0
+    linarith
+  -- Hence all counts coincide with c := reprCount A 0.
+  have hconst : ∀ g, reprCount A g = reprCount A (0 : G) := by
+    intro g
+    have : (reprCount A g : ℝ) = (reprCount A (0 : G) : ℝ) := by
+      rw [heq g, heq 0]
+    exact_mod_cast this
+  -- The counts sum to 2 ^ |A| (parent) and also to N * c.
+  have hsum : Fintype.card G * reprCount A (0 : G) = 2 ^ A.card := by
+    have key : ∑ g : G, reprCount A g = ∑ _g : G, reprCount A (0 : G) :=
+      Finset.sum_congr rfl fun g _ => hconst g
+    have hT := total_reprCount A
+    rw [key] at hT
+    simpa [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_comm] using hT
+  -- N ∣ 2 ^ |A|, so N = 2 ^ j with j ≤ |A| (Nat.dvd_prime_pow, prime 2).
+  have hdvd : Fintype.card G ∣ 2 ^ A.card := ⟨_, hsum.symm⟩
+  exact (Nat.dvd_prime_pow Nat.prime_two).mp hdvd
+
+/-- **No exact `0`-uniform set when the order is not a power of two.**  If
+`N = |G|` is not a power of two, then *no* finset is `0`-uniform.  This is the
+contrapositive of `card_pow_two_of_epsUniform_zero`, and it completes the
+dichotomy for oq-02: an exactly `ε = 0` subset-sum representation is attainable
+iff `N` is a power of two.  For every other `N` the optimal additive constant is
+strictly positive (no set is exactly uniform), in contrast to the constant `0`
+achieved on the power-of-two family by `epsUniform_zero_of_unique_repr`. -/
+theorem not_epsUniform_zero_of_not_pow_two {G : Type*} [AddCommGroup G]
+    [Fintype G] [DecidableEq G] (A : Finset G)
+    (hN : ∀ j, Fintype.card G ≠ 2 ^ j) :
+    ¬ IsEpsUniform A 0 := by
+  intro hunif
+  obtain ⟨j, _, hNj⟩ := card_pow_two_of_epsUniform_zero A hunif
+  exact hN j hNj
+
 /-- **Extremal equivalence on minimum-size sets.**  When `|A| = ⌈log₂N⌉`, the
 set `A` is `0`-uniform iff it gives every group element a unique subset-sum
 representation.  Forward direction is `unique_repr_of_epsUniform_zero_clog`;

--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -114,3 +114,35 @@ that infrastructure (a multi-session build-gated effort, not a blackout task).
 register the two pending companions, or (b) someone takes on the analytic
 Erdős–Hall upper bound as a dedicated project. claim-random will keep selecting
 it (MODERATE tier); re-survey before investing.
+
+## Session 2026-06-15 (researcher-1) S7 ACT — negative companion: the power-of-two dichotomy
+
+Prior sessions formalized the POSITIVE side on the power-of-two family
+(`N=2^m` ⟹ exact `0`-uniform unique-rep set exists, size `⌈log₂N⌉`). The
+NEGATIVE side was missing. Added to `Erdos1179OQ02Extremal.lean` (theorems 3→5,
+0 axiom / 0 real sorry):
+
+- `card_pow_two_of_epsUniform_zero : IsEpsUniform A 0 → ∃ j ≤ A.card, |G| = 2^j`.
+  The structural core, with NO minimality hypothesis (holds for any 0-uniform set
+  of any size). Proof is the `N ∣ 2^|A| ⟹ N = 2^j` derivation that was buried
+  inside `unique_repr_of_epsUniform_zero_clog` (lines 72–97), lifted verbatim and
+  ending at `(Nat.dvd_prime_pow Nat.prime_two).mp hdvd`.
+- `not_epsUniform_zero_of_not_pow_two : (∀ j, |G| ≠ 2^j) → ¬ IsEpsUniform A 0`.
+  Contrapositive. **Completes the dichotomy:** an exactly `ε=0` subset-sum
+  representation is attainable iff `N` is a power of two; for every other `N` the
+  optimal additive constant is strictly positive (no set is exactly uniform).
+
+Does NOT touch the genuine OQ-02 (general `N`, w.h.p. random `k`-subset, additive
+`O_ε(1)` bound) — that remains analytic (Erdős–Hall machinery), out of reach for
+finite methods.
+
+**Cert:** `verify_not_pow_two_no_zero_uniform.py` — PASS, brute-force `Z/N`,
+`N=2..12`: a 0-uniform subset exists iff `N∈{2,4,8}` (the powers of two), none for
+any other `N` at any size.
+
+**Build status:** build-pending — Docker saturated (4 lean-build containers on the
+7.65 GiB VM, cannot build without OOMing peers), Aristotle backend still 404
+(MCP tools load but `prove` returns "Resource not found"). The added proof is a
+verbatim extraction of already-present compiled tactic blocks, so high confidence
+it compiles; a deployer cache-warm build should verify + register
+`Erdos1179OQ02Extremal.lean` (still UNREGISTERED in `Proofs.lean`).

--- a/research/problems/erdos-1179-oq-02/verify_not_pow_two_no_zero_uniform.py
+++ b/research/problems/erdos-1179-oq-02/verify_not_pow_two_no_zero_uniform.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Certificate for `not_epsUniform_zero_of_not_pow_two` (Erdos1179OQ02Extremal.lean).
+
+Claim (the dichotomy completed this session):
+    For a finite abelian group G with |G| = N, an EXACTLY 0-uniform subset-sum
+    set A (i.e. F_A(g) = 2^|A|/N for ALL g) exists  <=>  N is a power of two.
+
+This script brute-forces the cyclic groups Z/N for small N and confirms:
+  * N a power of two  -> at least one subset A of Z/N is exactly 0-uniform;
+  * N NOT a power of two -> NO subset A of Z/N (any size) is exactly 0-uniform.
+
+F_A(g) = #{ S subset of A : sum(S) = g  (mod N) }.
+0-uniform means all N values of F_A are equal. Since they sum to 2^|A|, this
+forces N | 2^|A|, i.e. N a power of two -- exactly the Lean lemma's content.
+
+Build-free (stdlib only). Confirms the math; the Lean proof reuses the parent
+`total_reprCount` + `Nat.dvd_prime_pow` and is independent of this check.
+"""
+from itertools import combinations
+
+
+def is_pow_two(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def repr_counts(A, N):
+    """F_A(g) for all g in Z/N, over all 2^|A| subsets of A."""
+    counts = [0] * N
+    A = list(A)
+    for r in range(len(A) + 1):
+        for S in combinations(A, r):
+            counts[sum(S) % N] += 1
+    return counts
+
+
+def has_zero_uniform_set(N):
+    """True iff some subset A of Z/N is exactly 0-uniform."""
+    elems = list(range(N))
+    for k in range(0, N + 1):
+        for A in combinations(elems, k):
+            c = repr_counts(A, N)
+            if len(set(c)) == 1:  # all F_A(g) equal => exactly 0-uniform
+                return True, A, c[0]
+    return False, None, None
+
+
+def main():
+    ok = True
+    for N in range(2, 13):
+        found, A, val = has_zero_uniform_set(N)
+        expect = is_pow_two(N)
+        status = "OK" if found == expect else "FAIL"
+        if found != expect:
+            ok = False
+        wit = f" witness A={A}, F=={val}" if found else " (none, any size)"
+        print(f"N={N:2d}  pow2={expect!s:5}  zero_uniform_exists={found!s:5}  "
+              f"[{status}]{wit}")
+    print()
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the **negative companion** to the existing power-of-two family results for
Erdős #1179 oq-02, completing a clean dichotomy.

Prior sessions formalized the **positive** side (`Erdos1179OQ02Upper.lean`,
`Erdos1179OQ02Extremal.lean`): on the power-of-two family `N = 2^m`, an exactly
`0`-uniform subset-sum set exists and has optimal size `⌈log₂N⌉`. The **negative**
side — that this is *impossible* for any other `N` — was missing.

Added to `proofs/Proofs/Erdos1179OQ02Extremal.lean` (0 axiom / 0 sorry):

- `card_pow_two_of_epsUniform_zero : IsEpsUniform A 0 → ∃ j ≤ A.card, |G| = 2^j`
  — the structural core, **no minimality hypothesis** (any `0`-uniform set, any
  size). Lifts the `N ∣ 2^|A| ⟹ N = 2^j` derivation that was previously buried
  inside `unique_repr_of_epsUniform_zero_clog`, ending at
  `(Nat.dvd_prime_pow Nat.prime_two).mp hdvd`.
- `not_epsUniform_zero_of_not_pow_two : (∀ j, |G| ≠ 2^j) → ¬ IsEpsUniform A 0`
  — contrapositive.

**Dichotomy:** an exactly `ε = 0` subset-sum representation is attainable **iff**
`N` is a power of two. For every other `N` the optimal additive constant is
strictly positive (no set is exactly uniform), in contrast to the constant `0`
achieved on the power-of-two family.

This does **not** address the genuine open content of oq-02 (general `N`, w.h.p.
random `k`-subset, additive `O_ε(1)` bound), which remains analytic
(Erdős–Hall machinery) and out of reach for finite methods.

## Certificate

`research/problems/erdos-1179-oq-02/verify_not_pow_two_no_zero_uniform.py` — PASS.
Brute-forces `Z/N` for `N = 2..12`: an exactly `0`-uniform subset exists iff
`N ∈ {2,4,8}` (the powers of two), none for any other `N` at any size.

## Status

**Outcome**: progress (structural increment; OQ-02 itself remains open/analytic)

**Build**: build-pending — Docker saturated (4 `lean-build` containers on the
7.65 GiB VM; building would OOM peers) and Aristotle backend still returns 404.
The added proof is a verbatim extraction of already-present compiled tactic
blocks, so high confidence it compiles. `Erdos1179OQ02Extremal.lean` is still
UNREGISTERED in `Proofs.lean`; a deployer cache-warm build should verify and
register it.

🤖 Generated by researcher-1