### PR TITLE
Enrich lebesgue-measure-oq-05: add annotations.json (quality 41→100)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-05/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/annotations.json
@@ -1,0 +1,144 @@
+[
+  {
+    "id": "ann-lebesgueoq05-setup",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Setup: Packaging Mathlib's HaveLebesgueDecomposition Theory",
+    "content": "The file fixes a measurable space `α` and two measures `μ ν : Measure α`, and assembles the classical σ-finite Radon–Nikodym package from Mathlib's general Lebesgue-decomposition machinery. The module docstring is explicit about scope: this is a **formalization** entry — every result is a direct corollary of existing Mathlib lemmas (`Measure.rnDeriv`, `Measure.withDensity`, the `HaveLebesgueDecomposition` typeclass). The mathematical content is due to Radon (1913) and Nikodym (1930).\n\nThe central design point: Mathlib states Radon–Nikodym at the level of the `HaveLebesgueDecomposition` typeclass rather than assuming σ-finiteness directly. σ-finite measures always carry such an instance, so the classical statement is recovered by adding `[SigmaFinite μ] [SigmaFinite ν]` instance arguments and letting instance resolution supply the rest.",
+    "mathContext": "For $\\sigma$-finite $\\mu, \\nu$ the pair $(\\mu, \\nu)$ has a Lebesgue decomposition, so $d\\mu/d\\nu$ (`Measure.rnDeriv μ ν`) is well-behaved. The `withDensity` operation turns a measurable $f : \\alpha \\to [0,\\infty]$ into the measure $s \\mapsto \\int_s f\\, d\\nu$; the Radon–Nikodym theorem says this map is surjective onto $\\{\\mu : \\mu \\ll \\nu\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.rnDeriv",
+      "MeasureTheory.Measure.withDensity",
+      "HaveLebesgueDecomposition",
+      "SigmaFinite"
+    ],
+    "prerequisites": [
+      "measures and the lower Lebesgue integral",
+      "absolute continuity μ ≪ ν",
+      "typeclass instance resolution in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-witness",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 44,
+      "endLine": 52
+    },
+    "type": "insight",
+    "title": "Measurability and the Canonical Density",
+    "content": "Two foundational results. `rnDeriv_measurable` records that the Radon–Nikodym derivative `μ.rnDeriv ν` is always measurable (`Measure.measurable_rnDeriv`), with no hypotheses on the measures. `rnDeriv_isDensity` is the heart of the theorem: for σ-finite `μ ≪ ν`, the derivative is a genuine **density**, i.e. `ν.withDensity (μ.rnDeriv ν) = μ` (`Measure.withDensity_rnDeriv_eq`). The σ-finiteness instances on `μ` and `ν` are exactly what supplies the `HaveLebesgueDecomposition` instance that this Mathlib lemma needs.",
+    "mathContext": "$d\\mu/d\\nu$ is measurable, and for $\\sigma$-finite $\\mu \\ll \\nu$ it reconstructs $\\mu$: $\\nu.\\mathrm{withDensity}(d\\mu/d\\nu) = \\mu$, i.e. $\\mu(s) = \\int_s \\frac{d\\mu}{d\\nu}\\, d\\nu$. Absolute continuity is essential here — without $\\mu \\ll \\nu$ only the absolutely-continuous part of $\\mu$ is recovered.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.measurable_rnDeriv",
+      "MeasureTheory.Measure.withDensity_rnDeriv_eq",
+      "AbsolutelyContinuous",
+      "Radon–Nikodym derivative"
+    ],
+    "prerequisites": [
+      "Radon–Nikodym derivative",
+      "withDensity and absolute continuity",
+      "σ-finite ⟹ HaveLebesgueDecomposition"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-existence",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 54,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Existence of a Density",
+    "content": "`exists_density` packages measurability and the witness identity into the classical existential form of the Radon–Nikodym theorem: for σ-finite `μ ≪ ν`, there exists a measurable `f : α → ℝ≥0∞` with `ν.withDensity f = μ`. The proof is a one-line anonymous constructor `⟨μ.rnDeriv ν, …, …⟩` exhibiting the Radon–Nikodym derivative as the witness, with the two side conditions discharged by `Measure.measurable_rnDeriv` and `Measure.withDensity_rnDeriv_eq`.",
+    "mathContext": "The textbook statement: $\\mu \\ll \\nu$ ($\\sigma$-finite) $\\implies \\exists$ measurable $f \\ge 0$ with $\\mu = \\nu.\\mathrm{withDensity}\\, f$. Existence is non-constructive in spirit but here is witnessed canonically by $f = d\\mu/d\\nu$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Radon–Nikodym theorem",
+      "existential witness",
+      "MeasureTheory.Measure.rnDeriv"
+    ],
+    "prerequisites": [
+      "canonical density (previous result)",
+      "anonymous constructors in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-integral",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 60,
+      "endLine": 71
+    },
+    "type": "insight",
+    "title": "Integral Characterization and Total Mass",
+    "content": "`rnDeriv_setLIntegral` gives the integral characterization `∫⁻ x in s, μ.rnDeriv ν x ∂ν = μ s` for every measurable `s`: the proof rewrites the set integral as `(ν.withDensity (μ.rnDeriv ν)) s` via `withDensity_apply`, then collapses it with the witness identity `Measure.withDensity_rnDeriv_eq`. `rnDeriv_lintegral` specializes this to `s = univ`, recovering the total mass `∫⁻ x, μ.rnDeriv ν x ∂ν = μ univ` after `Measure.restrict_univ` removes the restriction.",
+    "mathContext": "$\\int_s \\frac{d\\mu}{d\\nu}\\, d\\nu = \\mu(s)$ for measurable $s$ — the defining property of a density, here proved rather than assumed. Setting $s = \\mathrm{univ}$ gives $\\int \\frac{d\\mu}{d\\nu}\\, d\\nu = \\mu(\\alpha)$, the total mass. The bridge lemma `withDensity_apply` is the identity $(\\nu.\\mathrm{withDensity}\\,f)(s) = \\int_s f\\, d\\nu$ for measurable $s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.withDensity_apply",
+      "MeasureTheory.Measure.restrict_univ",
+      "setLIntegral",
+      "lower Lebesgue integral"
+    ],
+    "prerequisites": [
+      "set lower integral ∫⁻ x in s",
+      "withDensity_apply",
+      "the witness identity"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-uniqueness",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 73,
+      "endLine": 83
+    },
+    "type": "insight",
+    "title": "ν-a.e. Uniqueness of the Density",
+    "content": "`density_unique` proves that any two measurable densities `f, g` for the same measure `μ` agree `ν`-almost everywhere. The argument is purely via `Measure.rnDeriv_withDensity`, which says the Radon–Nikodym derivative of a `withDensity` recovers the integrand `ν`-a.e.: `f =ᵐ[ν] (ν.withDensity f).rnDeriv ν`. Rewriting both `ν.withDensity f` and `ν.withDensity g` to the common value `μ` makes both `f` and `g` a.e.-equal to `μ.rnDeriv ν`, and transitivity (`.trans`, `.symm`) closes the goal.\n\nNotably this requires **only** σ-finiteness of `ν` — neither absolute continuity nor σ-finiteness of `μ` is used.",
+    "mathContext": "Uniqueness is the statement that the density is well-defined as an element of $L^0(\\nu)$ (a.e.-equivalence class), not as a function. The key lemma $f =^{ae}_\\nu (\\nu.\\mathrm{withDensity}\\,f).\\mathrm{rnDeriv}\\,\\nu$ makes the derivative a one-sided inverse of $\\mathrm{withDensity}$ modulo $\\nu$-null sets.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.rnDeriv_withDensity",
+      "Filter.EventuallyEq",
+      "almost-everywhere equality",
+      "ae_eq transitivity"
+    ],
+    "prerequisites": [
+      "almost-everywhere equality =ᵐ[ν]",
+      "rnDeriv as a left inverse of withDensity",
+      "transitivity of a.e. equality"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-decomposition",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 85,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "General Lebesgue Decomposition",
+    "content": "`lebesgue_decomposition` states the general decomposition for any σ-finite pair, with **no absolute continuity assumed**: `μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν)`. The proof is a direct invocation of `Measure.haveLebesgueDecomposition_add`. This frames the earlier results: the Radon–Nikodym density `μ.rnDeriv ν` is precisely the absolutely-continuous part of `μ`, and absolute continuity `μ ≪ ν` is exactly the condition that the singular part `μ.singularPart ν` vanishes.",
+    "mathContext": "Every $\\sigma$-finite $\\mu$ splits uniquely as $\\mu = \\mu_{\\perp\\nu} + \\mu_{\\ll\\nu}$ with $\\mu_{\\perp\\nu} \\perp \\nu$ and $\\mu_{\\ll\\nu} = \\nu.\\mathrm{withDensity}(d\\mu/d\\nu) \\ll \\nu$. The Radon–Nikodym theorem is the special case where the singular part is zero, so this decomposition is the proper generalization that contains it.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.haveLebesgueDecomposition_add",
+      "MeasureTheory.Measure.singularPart",
+      "mutually singular measures",
+      "Lebesgue decomposition"
+    ],
+    "prerequisites": [
+      "singular part of a measure",
+      "mutual singularity μ ⊥ ν",
+      "decomposition into a.c. + singular parts"
+    ]
+  }
+]

--- a/src/data/proofs/lebesgue-measure-oq-05/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/meta.json
@@ -38,7 +38,9 @@
     "keyInsights": [
       "σ-finiteness of both measures is exactly what supplies the HaveLebesgueDecomposition instance, so the classical statement falls out of Mathlib's general (typeclass-gated) theory with no extra hypotheses.",
       "ν-a.e. uniqueness does not need absolute continuity or σ-finiteness of μ: it follows from Measure.rnDeriv_withDensity (the derivative of a withDensity recovers the integrand ν-a.e.) plus transitivity, needing only σ-finiteness of ν.",
-      "The Lebesgue decomposition μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) holds for any σ-finite pair without assuming μ ≪ ν; absolute continuity is precisely the condition that the singular part vanishes."
+      "The Lebesgue decomposition μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) holds for any σ-finite pair without assuming μ ≪ ν; absolute continuity is precisely the condition that the singular part vanishes.",
+      "The integral characterization ∫⁻_s (dμ/dν) dν = μ s is proved, not assumed: it factors through withDensity_apply followed by the canonical-witness identity, so the 'density' property is a theorem about μ.rnDeriv ν rather than part of its definition.",
+      "Every theorem in the file is a one- to three-line corollary of Mathlib's HaveLebesgueDecomposition API, illustrating that the gallery contribution is curatorial — a clean, citable σ-finite package — rather than new mathematics."
     ],
     "prerequisites": [
       "Measures, withDensity, and the lower Lebesgue integral",


### PR DESCRIPTION
## Enrichment pass

Freshly research-created entry `lebesgue-measure-oq-05` (Radon–Nikodym Theorem for σ-finite Measures) had only `meta.json` and **no `annotations.json`**, zeroing the annotation-derived sub-scores.

### Changes
- New `annotations.json` with **6 line-anchored annotations** covering all six sections (setup, measurability + canonical density, existence, integral characterization + total mass, ν-a.e. uniqueness, general Lebesgue decomposition). Each carries `mathContext`, `significance`, and `relatedConcepts`.
- Added 2 more `overview.keyInsights` (integral characterization is proved not assumed; curatorial nature of the contribution).

### Quality
- Before: **41** (annotations 0, mathContext 0, significance 0, crossRefs 0)
- After: **100** (annotations 25, mathContext 10, significance 10, crossRefs 10, +keyInsights 6→10)

JSON validated. No Lean/build-status fields touched.