### PR TITLE
research(cauchy-interlacing-theorem): ORIENT statement of record on Mathlib eigenvalues₀

### DIFF
--- a/research/problems/cauchy-interlacing-theorem/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem/knowledge.md
@@ -35,6 +35,48 @@ codimension-one coordinate subspace.
   (delete the last index); Hermitian-ness is inherited via
   `Matrix.IsHermitian.submatrix`.
 
+### Session 2026-06-15 (s02, REVISIT → ORIENT refine)
+
+Backends both gated this session (Aristotle MCP connected but backend returns
+`Resource not found` / 404 on a trivial probe; Docker at 3 `lean-build` peers,
+over the 2-container safety threshold on the 7.65 GiB VM — building would OOM
+peers). No verification possible; this session is a grounded design refinement.
+
+- **Gap confirmed against *current* Mathlib docs (2026-06), not just prior memory.**
+  - `Mathlib.Analysis.Matrix.Spectrum`: `eigenvalues₀`, `eigenvalues₀_antitone`,
+    `spectral_theorem` (`A = conjStarAlgAut … eigenvectorUnitary (diagonal (ofReal ∘ eigenvalues))`),
+    plus `eigenvectorBasis` / `eigenvectorUnitary`. **No** Rayleigh / min-max here.
+  - `Mathlib.Analysis.InnerProductSpace.Rayleigh`: only the **extreme** cases —
+    `IsSelfAdjoint.hasEigenvector_of_isMaxOn` (sup of `T.rayleighQuotient` is the
+    *largest* eigenvalue) and `…hasEigenvector_of_isMinOn` (inf → smallest). No
+    k-th eigenvalue / Courant–Fischer / subspace min-max anywhere. Gap is real.
+- **Corrected interlacing reduction (s01 note had the directions muddled).**
+  Set `N = n+1`, `H = span{e₀,…,e_{n-1}}` (codim 1); for `x` supported on `H`,
+  `R_B(x) = R_A(x)` because `⟨x, A x⟩ = ⟨x, B x⟩`. The admissible test subspaces
+  for `B` are **exactly** the `A`-test subspaces contained in `H` — a *subfamily*.
+  Both bounds then follow from one fact, restricting an extremum to a subfamily:
+  - `μ i ≤ λ i` from the **max–min** form: `μ i = max_{S⊆H, dim=i+1} min_S R`;
+    the family `{S ⊆ H}` ⊆ `{S ⊆ V}`, and a max over a *subfamily* is *smaller*,
+    so `μ i ≤ max_{S⊆V, dim=i+1} min_S R = λ i`.
+  - `λ (i+1) ≤ μ i` from the **min–max** (codim) form: `μ i = min_{T⊆H, dim=N-1-i} max_T R`;
+    the family `{T ⊆ H, dim = N-1-i}` ⊆ `{T ⊆ V, dim = N-1-i}` (= A-family for
+    index `i+1`, since `N-(i+1) = N-1-i`), and a min over a *subfamily* is
+    *larger*, so `μ i ≥ min_{T⊆V} max_T R = λ (i+1)`.
+- **Explicit constructive proof of the keystone min–max** (to build), with the
+  named Mathlib pigeonhole lemma:
+  - Lower (`λ k ≥ value`): test `S = span{v₀,…,v_k}` (top `k+1` eigenvectors);
+    for `x = Σ_{j≤k} c_j v_j`, `R(x) = Σ|c_j|²λ_j / Σ|c_j|² ≥ λ_k` since each
+    `λ_j ≥ λ_k`. So `min_S R ≥ λ_k`, hence the max–min `≥ λ_k`.
+  - Upper (`λ k ≤ value`): for ANY `S` with `dim S = k+1`, intersect with
+    `W = span{v_k,…,v_{N-1}}` (`dim W = N-k`). Via
+    **`Submodule.finrank_sup_add_finrank_inf_eq`**:
+    `finrank (S ⊓ W) = finrank S + finrank W − finrank (S ⊔ W) ≥ (k+1)+(N-k) − N = 1 > 0`,
+    so `S ⊓ W ≠ ⊥`. Any `0 ≠ x ∈ S ⊓ W` is a combination of `v_k,…,v_{N-1}`, so
+    `R(x) ≤ λ_k`; thus `min_S R ≤ λ_k`, hence the max–min `≤ λ_k`. (Dual argument
+    with `span{v_k}` / `span{v₀,…,v_k}` gives the min–max form.)
+  This is the actual crux s01 hand-waved as "orthogonal-complement dimension
+  counting" — the dimension pigeonhole is one named lemma, not new infrastructure.
+
 ---
 
 ## Dead Ends
@@ -68,14 +110,22 @@ contributes at most one to the min-max index).
 
 ## Next Steps
 
-1. State the Courant–Fischer min-max lemma precisely over
-   `Submodule ℂ (EuclideanSpace ℂ (Fin N))` using the existing Rayleigh API; prove
-   the two extreme cases (`k = 0` top, `k = N-1` bottom) directly from Mathlib.
-2. Build the general k-th min-max (induction / orthogonal-complement dimension
-   counting). This is the keystone; consider an Aristotle submission once the
-   backend is reachable (currently 404).
-3. Discharge `cauchy_interlacing` from the min-max lemma via the subspace
-   inclusion `span{e₀,…,e_{n-1}}`.
-4. Build & register only after `lake`/Docker capacity is free (this session both
-   Aristotle (404) and Docker (saturated at 3 containers) were unavailable, so the
-   skeleton is build-pending and deliberately unregistered).
+1. **Build the keystone min–max** over `Submodule ℂ (EuclideanSpace ℂ (Fin N))`
+   with `T.rayleighQuotient` (`T := Matrix.toEuclideanLin A` as a self-adjoint CLM;
+   needs the `eigenvalues₀ = sorted operator eigenvalues` bridge via
+   `spectral_theorem` / `eigenvectorBasis`). Prove both forms using the explicit
+   constructive recipe in s02: top-`k+1` eigenvector span for the lower bound, and
+   `Submodule.finrank_sup_add_finrank_inf_eq` for the upper-bound pigeonhole. This
+   is the single isolated obligation and the **ideal Aristotle target** once the
+   backend is reachable (404 this session) — submit the min–max lemma alone.
+2. Discharge `cauchy_interlacing` from the min–max lemma via the corrected
+   subfamily-monotonicity reduction in s02 (`{S ⊆ H}` ⊆ `{S ⊆ V}`; max–min over a
+   subfamily ↓ gives `μ i ≤ λ i`, min–max over a subfamily ↑ gives `λ(i+1) ≤ μ i`).
+3. As an interim verifiable win when a Docker window opens (≤ 2 peers): build the
+   *existing* skeleton (`sortedEigs_antitone`, `principalDrop_isHermitian`, the
+   `cauchy_interlacing` statement with its one `sorry`) by copying it to
+   `proofs/Proofs/CauchyInterlacing.lean` and running
+   `docker-build.sh Proofs.CauchyInterlacing` — locks in the foundation without
+   registering in `Proofs.lean`.
+4. Register & flip meta to verified only after the min–max keystone is proved and
+   the full file builds green.

--- a/research/problems/cauchy-interlacing-theorem/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem/knowledge.md
@@ -1,0 +1,81 @@
+# Knowledge Base: cauchy-interlacing-theorem
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Cauchy interlacing: if `B` is the principal `(n-1)×(n-1)` submatrix of a Hermitian
+`A ∈ ℂ^{n×n}` (delete one matching row/column), the sorted eigenvalues interlace:
+`λ_k ≤ μ_k ≤ λ_{k+1}` (ascending convention). The proof of record is the
+Courant–Fischer min-max variational characterisation restricted to the
+codimension-one coordinate subspace.
+
+---
+
+## Insights
+
+### Session 2026-06-15 (s01, FRESH → ORIENT)
+
+- **Mathlib API correction (vs. older notes).** Mathlib now ships
+  `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ`, the eigenvalues
+  in **descending** order, with `Matrix.IsHermitian.eigenvalues₀_antitone`. This
+  is the sorted enumeration earlier sessions thought was absent. It makes a clean
+  statement of "the k-th eigenvalue" possible — the plain
+  `Matrix.IsHermitian.eigenvalues : n → ℝ` is reindexed by the matrix index type
+  and is **not** sorted, so it cannot express interlacing directly.
+- **Statement of record written** using `eigenvalues₀`. With the descending
+  convention the theorem reads `λ i ≥ μ i ≥ λ (i+1)` for `i : Fin n` (the
+  ascending textbook convention flips the inequalities under `i ↦ n - i`).
+- **Reusable helper `sortedEigs`**: composes `eigenvalues₀` with the canonical
+  `Fin N ≃ Fin (Fintype.card (Fin N))` so eigenvalues are indexed naturally by
+  `Fin N`; `sortedEigs_antitone` carries the descending order across.
+- **Principal submatrix** modelled as `A.submatrix Fin.castSucc Fin.castSucc`
+  (delete the last index); Hermitian-ness is inherited via
+  `Matrix.IsHermitian.submatrix`.
+
+---
+
+## Dead Ends
+
+(none yet)
+
+---
+
+## Mathlib Gap (keystone)
+
+The single missing ingredient is the **Courant–Fischer max–min characterisation**
+of the descending k-th eigenvalue:
+
+  `λ_k = max_{dim S = k+1} min_{0 ≠ x ∈ S} ⟨x, A x⟩ / ⟨x, x⟩`
+       `= min_{dim S = n-k} max_{0 ≠ x ∈ S} ⟨x, A x⟩ / ⟨x, x⟩`.
+
+Mathlib has only the **extreme cases** (top/bottom eigenvalue as a Rayleigh
+quotient sup/inf via the inner-product Rayleigh API). The general k-th min-max is
+absent. Estimated effort: a self-contained min-max over
+`Submodule ℂ (EuclideanSpace ℂ (Fin N))` with the Rayleigh quotient — a few
+hundred lines, the natural next build target (or a Mathlib contribution).
+
+Once the min-max lemma exists, interlacing is a short subspace-inclusion argument:
+the `(k+1)`-dimensional test subspaces available to `B` are exactly those
+contained in the codimension-one coordinate subspace `span{e₀,…,e_{n-1}}`, a
+subset of those available to `A`. The inclusion sandwiches `μ_k` between `λ_k`
+(more subspaces can only raise the max) and `λ_{k+1}` (the deleted dimension
+contributes at most one to the min-max index).
+
+---
+
+## Next Steps
+
+1. State the Courant–Fischer min-max lemma precisely over
+   `Submodule ℂ (EuclideanSpace ℂ (Fin N))` using the existing Rayleigh API; prove
+   the two extreme cases (`k = 0` top, `k = N-1` bottom) directly from Mathlib.
+2. Build the general k-th min-max (induction / orthogonal-complement dimension
+   counting). This is the keystone; consider an Aristotle submission once the
+   backend is reachable (currently 404).
+3. Discharge `cauchy_interlacing` from the min-max lemma via the subspace
+   inclusion `span{e₀,…,e_{n-1}}`.
+4. Build & register only after `lake`/Docker capacity is free (this session both
+   Aristotle (404) and Docker (saturated at 3 containers) were unavailable, so the
+   skeleton is build-pending and deliberately unregistered).

--- a/research/problems/cauchy-interlacing-theorem/lean/CauchyInterlacing.lean
+++ b/research/problems/cauchy-interlacing-theorem/lean/CauchyInterlacing.lean
@@ -1,0 +1,97 @@
+import Mathlib
+
+/-
+# Cauchy Interlacing Theorem — statement of record (ORIENT)
+
+For a Hermitian matrix `A : Matrix (Fin (n+1)) (Fin (n+1)) ℂ` and the principal
+`n × n` submatrix `B` obtained by deleting the last row and column, the sorted
+eigenvalues of `B` interlace those of `A`.
+
+## Convention
+
+Mathlib provides `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card …) → ℝ`,
+the eigenvalues listed in **descending** (antitone) order
+(`Matrix.IsHermitian.eigenvalues₀_antitone`). Note the ordinary
+`Matrix.IsHermitian.eigenvalues : n → ℝ` is reindexed by the matrix's index type
+and is *not* sorted, so it cannot express "the k-th eigenvalue". We therefore
+build everything on top of `eigenvalues₀`.
+
+With the descending convention `λ₀ ≥ λ₁ ≥ … ≥ λₙ` for `A` and
+`μ₀ ≥ … ≥ μ_{n-1}` for `B`, Cauchy interlacing reads
+
+  `λ i ≥ μ i ≥ λ (i+1)`   for every `i : Fin n`,
+
+equivalently `μ i ≤ λ i.castSucc` and `λ i.succ ≤ μ i`.
+
+(Under the more common *ascending* textbook convention `λ_k ≤ μ_k ≤ λ_{k+1}` the
+inequalities flip; the two are equivalent under `i ↦ n - i`.)
+
+## Status
+
+ORIENT / statement of record. The mathematical keystone is the Courant–Fischer
+max–min variational characterisation of the descending k-th eigenvalue, which is
+**not currently in Mathlib** (only the extreme cases — top/bottom eigenvalue as a
+Rayleigh-quotient sup/inf — are available, via the inner-product Rayleigh API).
+Given that characterisation, interlacing is a short subspace-inclusion argument:
+the test subspaces available to `B` are exactly those contained in the
+codimension-one coordinate subspace `span {e₀,…,e_{n-1}}`, a subset of those
+available to `A`, which sandwiches each `μ i` between `λ i` and `λ (i+1)`.
+
+The main theorem and the keystone lemma are left as `sorry`. This file is a
+research skeleton and is intentionally **not** registered in `Proofs.lean`.
+-/
+
+open Matrix
+
+namespace CauchyInterlacing
+
+variable {N n : ℕ}
+
+/-- Descending sorted eigenvalues of a Hermitian matrix on `Fin N`, indexed
+naturally by `Fin N` (composing `eigenvalues₀` with the canonical
+`Fin N ≃ Fin (Fintype.card (Fin N))`). -/
+noncomputable def sortedEigs {A : Matrix (Fin N) (Fin N) ℂ} (hA : A.IsHermitian) :
+    Fin N → ℝ :=
+  fun i => hA.eigenvalues₀ (Fin.cast (Fintype.card_fin N).symm i)
+
+/-- `sortedEigs` is antitone (descending), inherited from `eigenvalues₀_antitone`
+through the order-preserving reindexing `Fin.cast`. -/
+lemma sortedEigs_antitone {A : Matrix (Fin N) (Fin N) ℂ} (hA : A.IsHermitian) :
+    Antitone (sortedEigs hA) := by
+  intro i j hij
+  refine hA.eigenvalues₀_antitone ?_
+  simpa [Fin.le_iff_val_le_val] using hij
+
+/-- The principal `n × n` submatrix of an `(n+1) × (n+1)` matrix obtained by
+deleting the last row and the last column (keeping coordinates `0,…,n-1`). -/
+noncomputable def principalDrop (A : Matrix (Fin (n + 1)) (Fin (n + 1)) ℂ) :
+    Matrix (Fin n) (Fin n) ℂ :=
+  A.submatrix Fin.castSucc Fin.castSucc
+
+/-- A principal submatrix of a Hermitian matrix is Hermitian. -/
+lemma principalDrop_isHermitian {A : Matrix (Fin (n + 1)) (Fin (n + 1)) ℂ}
+    (hA : A.IsHermitian) : (principalDrop A).IsHermitian :=
+  hA.submatrix Fin.castSucc
+
+/-- **Courant–Fischer keystone (Mathlib gap).** The descending k-th eigenvalue of
+a Hermitian matrix is the max over all `(k+1)`-dimensional subspaces of the
+minimum Rayleigh quotient on that subspace (equivalently the min over
+codimension-`k` subspaces of the maximum). This variational characterisation is
+the single missing ingredient; once available the interlacing proof below is
+immediate from subspace inclusion.
+
+Stated here only as a documented placeholder; the precise inner-product-space
+formulation (over `Submodule ℂ (EuclideanSpace ℂ (Fin N))` with the Rayleigh
+quotient) is the object that must be built or ported. -/
+theorem courant_fischer_placeholder : True := trivial
+
+/-- **Cauchy interlacing theorem** (one deleted index, descending convention):
+for the principal submatrix `principalDrop A` of a Hermitian `A` on `Fin (n+1)`,
+each eigenvalue `μ i` of the submatrix is sandwiched as `λ (i+1) ≤ μ i ≤ λ i`. -/
+theorem cauchy_interlacing {A : Matrix (Fin (n + 1)) (Fin (n + 1)) ℂ}
+    (hA : A.IsHermitian) (i : Fin n) :
+    sortedEigs hA i.succ ≤ sortedEigs (principalDrop_isHermitian hA) i ∧
+      sortedEigs (principalDrop_isHermitian hA) i ≤ sortedEigs hA i.castSucc := by
+  sorry
+
+end CauchyInterlacing


### PR DESCRIPTION
## Summary

ORIENT-phase deliverable for `cauchy-interlacing-theorem` (was EMPTY/available, now surveyed). Provides a faithful **statement of record** for the one-step Cauchy interlacing theorem and isolates the single Mathlib gap.

- **Key correction vs. prior sessions:** Mathlib now ships `Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ`, the eigenvalues in **descending/antitone** order (`eigenvalues₀_antitone`). Earlier notes assumed no sorted k-th eigenvalue existed. (Plain `.eigenvalues : n → ℝ` is reindexed by the matrix index type and is *not* sorted, so it cannot express interlacing.)
- **Statement** (descending convention): for the principal submatrix `B = principalDrop A` of Hermitian `A` on `Fin (n+1)`, `λ (i+1) ≤ μ i ≤ λ i` for every `i : Fin n`.
- **Helpers:** `sortedEigs` (eigenvalues₀ reindexed to `Fin N`), `sortedEigs_antitone`, `principalDrop` (= `submatrix Fin.castSucc Fin.castSucc`), `principalDrop_isHermitian`.
- **Keystone gap documented:** the Courant–Fischer max–min variational characterisation of the descending k-th eigenvalue is absent from Mathlib (only extreme top/bottom Rayleigh-quotient cases exist). Given it, interlacing follows from the codim-1 coordinate-subspace inclusion `span{e₀,…,e_{n-1}}`.

## Status / honesty

- The main theorem and the keystone are `sorry`. This is a **statement of record + decomposition**, not a verified proof.
- The file is a research skeleton under `research/problems/.../lean/` and is **intentionally NOT registered in `Proofs.lean`** (it would break the build with its sorries).
- **Build-pending:** Aristotle backend was 404 and Docker was saturated (3 containers) this session, so no compile was possible. Mathlib API names were cross-checked against the mathlib4 docs but not compiled — minor `Fin.cast` plumbing may need adjustment on first build.

## Test plan

- [ ] When Docker capacity is free, add to a scratch build target and fix any `Fin.cast`/`eigenvalues₀_antitone` plumbing.
- [ ] Build the Courant–Fischer min-max lemma (keystone), then discharge `cauchy_interlacing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)