### PR TITLE
audit: gallery-integrity cycle (1 clean, 2 issues-fixed) for 3 never-audited entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15510,6 +15510,24 @@
       "lastAudited": "2026-06-15T20:58:19Z",
       "result": "issues-found",
       "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T21:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T21:13:29Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "sqrt2-minpoly-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-15T21:14:31Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/lebesgue-measure-oq-05/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Radon (1913), Nikodym (1930)",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LebesgueMeasureOQ05.lean",
     "tags": [
       "measure-theory",
@@ -16,7 +16,7 @@
       "lebesgue-decomposition",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 92,

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02/meta.json
@@ -52,7 +52,7 @@
       "Explicit p/q form: minpoly ℚ (√(p/q)) = X² - p/q for naturals p, q",
       "Genuinely rational example: minpoly ℚ (√(1/2)) = X² - 1/2"
     ],
-    "theoremCount": 11,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -175,7 +175,7 @@
     "namespace": "Sqrt2MinpolyOQ01OQ02",
     "lineCount": 205,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/Sqrt2MinpolyOQ01OQ02.lean"


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 3 never-audited gallery entries on `main`. All three are recent (2026-06-15) research formalizations.

| Entry | Result | Action |
|-------|--------|--------|
| `cayley-hamilton-cyclic-vector-all-fields-oq-03` | clean | none — honest `wip`/`formalized`, build-pending, counts (3 thm / 2 def / 221 lines / 0 sorry / 0 axiom) all match source |
| `lebesgue-measure-oq-05` | **issues-fixed** | status `verified`→`formalized`, badge `verified`→`mathlib` |
| `sqrt2-minpoly-oq-01-oq-02` | **issues-fixed** | `theoremCount` 11→9 (meta + leanFile) |

### lebesgue-measure-oq-05 (overclaim — HIGH)

The `assumptions` field openly states **"BUILD PENDING: not yet kernel-checked locally"**, yet `status` and `badge` were both `verified`. `verified` requires a fully machine-checked proof, so this is an overclaim.

It is also a **Tier B** entry: all 7 theorems are direct one/two-line Mathlib API calls (`Measure.measurable_rnDeriv`, `Measure.withDensity_rnDeriv_eq`, `Measure.rnDeriv_withDensity`, `Measure.haveLebesgueDecomposition_add`, `withDensity_apply`). Per the auditor tier rules, the core-via-Mathlib result must carry badge `mathlib`, not `verified` (which is also not a valid `ProofBadge` value). The description and `assumptions` text already disclose the Mathlib reliance honestly, so only the two fields needed correction.

### sqrt2-minpoly-oq-01-oq-02 (count drift — LOW)

`theoremCount` claimed 11; the Lean source has 9 top-level theorems (verifiable by grep regardless of build status). Corrected in both the `meta` and `leanFile` blocks. Everything else (0 sorry, 0 axiom, 205 lines, `wip`/`formalized`, build-pending) is accurate.

No Lean source changes; meta.json + audit-tracker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)