### PR TITLE
research(cube-root-3-irrational-oq-04): S33 — 28th CF convergent upper bound (a27=9)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -1005,4 +1005,36 @@ theorem six_three_zero_four_seven_seven_nine_six_four_five_one_five_seven_over_f
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-- **Twenty-eighth continued-fraction convergent of `∛3`** (upper bound).
+
+The CF of `∛3` is `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+1, 3, 2, 3, 4, 1, 4, 9, …]`.  With `a₂₇ = 9`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`,
+`qₖ = aₖ qₖ₋₁ + qₖ₋₂` on the 26th/27th convergents `1310497171657/908647988973`
+and `6304779645157/4371490049266` gives the 28th convergent
+
+  `p₂₇ = 9·6304779645157 + 1310497171657 = 58_053_513_978_070`
+  `q₂₇ = 9·4371490049266 + 908647988973 = 40_252_058_432_367`.
+
+After cubing,
+
+  `58_053_513_978_070³   = 195_652_561_511_710_577_055_548_326_394_749_116_943_000`
+  `3 · 40_252_058_432_367³ = 195_652_561_511_710_577_055_548_326_190_542_549_124_589`
+
+so `3 · 40_252_058_432_367³ < 58_053_513_978_070³` (strict, diff
+`204_206_567_818_411`), hence `3 < (58053513978070/40252058432367)³` and
+`cbrt3 < 58053513978070/40252058432367` as required for an upper bound (odd
+convergent index `27`; relative gap `≈ 5.0·10⁻²⁸`).
+
+`a₂₇ = 9` was re-derived independently from a 200-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline: never re-quote a prior sketch tail, always recompute `aᵢ` and verify
+the cube-side direction before claiming.  This is the next uncontested rung above
+the 27th convergent; a routine, durable helper bound, not a deep result.
+Two-line proof via the upper cubing-iff helper. -/
+theorem cbrt3_lt_five_eight_zero_five_three_five_one_three_nine_seven_eight_zero_seven_zero_over_four_zero_two_five_two_zero_five_eight_four_three_two_three_six_seven :
+    cbrt3 < (58053513978070 / 40252058432367 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -1218,3 +1218,38 @@ already-astronomically-tight sandwich. Build-pending (Docker down); proof uses t
 established two-line lower-bound template `rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`
 that compiled clean for every prior lower rung with the same rational-cube `norm_num`
 machinery (only larger, 13-digit integers here).
+
+## Session 2026-06-15 (S33, researcher-3) — 28th CF convergent UPPER bound (a27=9)
+
+**Mode**: ACT on the additive convergent-ladder vein (RICH). Blackout-safe, non-dup:
+self-contained cubing-iff theorem, no dependency on the contended main `a12=8` chain
+(#23388/#23983) nor on the still-open 26th UPPER (PR #24767).
+
+### Added
+`Cbrt3Helpers.cbrt3_lt_five_eight_zero_five_three_five_one_three_nine_seven_eight_zero_seven_zero_over_four_zero_two_five_two_zero_five_eight_four_three_two_three_six_seven : cbrt3 < (58053513978070/40252058432367 : ℝ)`
+to `CubeRoot3IrrationalOQ04Helpers.lean` (theoremCount 28→29, lineCount → 1040, still 0/0).
+
+### Derivation (anti-typo discipline: full 200-digit CF recompute, never re-quote)
+- CF of ∛3 = `[1; 2,3,1,4,1,5,1,1,6,2,5,8,3,3,4,2,6,4,4,1,3,2,3,4,1,4,9,…]`, confirming `a₂₇ = 9`.
+- Recursion on the 26th/27th convergents: `p₂₇ = 9·6304779645157 + 1310497171657 = 58053513978070`,
+  `q₂₇ = 9·4371490049266 + 908647988973 = 40252058432367`.
+- Exact-integer cube check: `58053513978070³ − 3·40252058432367³ = +204206567818411 > 0`
+  ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (valid UPPER bound, odd index 27, relative gap ≈ 5.0·10⁻²⁸).
+- Cert `research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py` — PASS. It ALSO reproduces
+  main's convergents k=23..26 (24th/25th/26th/27th) exactly, validating the recursion path.
+
+### Frontier / contention map (calibrated: "Nth convergent" = CF index k=N-1)
+- Main (merged): 24th UPPER (S29 #24653), 25th LOWER (S30 #24673), 27th LOWER (S32 #24782).
+- Open PRs: #24767 (26th UPPER, a25=1), #24635 (23rd LOWER), #24612 (20th UPPER),
+  #24538 (18th UPPER), #24516 (17th LOWER); main `a12=8` chain #23388/#23983.
+- This PR (28th UPPER, k=27) is the next UNCONTESTED rung above the 27th (main frontier).
+- NEXT uncontested = 29th convergent LOWER (k=28, a28=1): p₂₈ = 1·p₂₇ + p₂₆, q₂₈ = 1·q₂₇ + q₂₆
+  = 64358293623227/44623548481633 (predicted; re-derive a28 before claiming).
+
+### Honesty
+A routine, durable helper bound, not a deep result — each rung is more digits of an
+already-astronomically-tight sandwich. Build-pending (Docker VM at 4 lean-build
+containers on a 7.65 GiB VM — over the safe ≤2 threshold; building would OOM peers).
+Proof uses the established two-line upper template
+`rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num` that compiled clean for every
+prior rung with the same rational-cube `norm_num` machinery (only larger, 14-digit integers).

--- a/research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Certificate for cube-root-3-irrational-oq-04, Session S33.
+
+Goal: produce and validate the 28th continued-fraction convergent of ∛3 as an
+UPPER bound (CF index k = 27, odd ⟹ convergent lies ABOVE ∛3).
+
+Anti-typo discipline: the continued fraction is recomputed FROM SCRATCH here at
+high precision (never re-quoted from prior session notes). The decisive validity
+check is the EXACT-INTEGER cube sign  p³ − 3·q³ , which is ground truth
+regardless of any floating/decimal rounding used to extract CF terms.
+
+Stdlib only (decimal). Build-free.
+"""
+
+from decimal import Decimal, getcontext
+
+getcontext().prec = 200
+
+# --- high-precision ∛3 via Newton: x ← x − (x³−3)/(3x²) ---
+three = Decimal(3)
+x = Decimal("1.44224957030740838232163831078010958839186925349935")
+for _ in range(40):
+    x = x - (x * x * x - three) / (3 * x * x)
+cbrt3 = x
+assert abs(cbrt3 ** 3 - three) < Decimal(10) ** (-180), "Newton did not converge"
+
+# --- extract continued fraction terms a0, a1, ... from cbrt3 ---
+def cf_terms(val, n):
+    terms = []
+    v = val
+    for _ in range(n):
+        a = int(v)            # floor for positive v
+        terms.append(a)
+        frac = v - a
+        if frac == 0:
+            break
+        v = 1 / frac
+    return terms
+
+terms = cf_terms(cbrt3, 32)
+
+# Known prefix of the CF of ∛3 (OEIS A002945): used only as a CROSS-CHECK,
+# not as the source of truth.
+known_prefix = [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6,
+                4, 4, 1, 3, 2, 3, 4, 1, 4]   # a0 .. a26
+for i, a in enumerate(known_prefix):
+    assert terms[i] == a, f"CF mismatch at index {i}: computed {terms[i]} vs known {a}"
+print("CF prefix cross-check OK through a26 =", known_prefix[-1])
+print("Computed a27 =", terms[27], " a28 =", terms[28])
+
+# --- convergents p_k/q_k via the standard recursion ---
+pm1, qm1 = 1, 0          # p_{-1}, q_{-1}
+p0, q0 = terms[0], 1     # p_0,    q_0
+P = [pm1, p0]
+Q = [qm1, q0]
+for k in range(1, 28):
+    ak = terms[k]
+    P.append(ak * P[-1] + P[-2])
+    Q.append(ak * Q[-1] + Q[-2])
+# P[i] corresponds to p_{i-1}; reindex to p_k = P[k+1]
+def p(k): return P[k + 1]
+def q(k): return Q[k + 1]
+
+# --- sanity: reproduce the convergents already on main ---
+checks = {
+    23: (247706213128, 171749895599),   # 24th convergent, UPPER (S29)
+    24: (1062790958529, 736898093374),  # 25th convergent, LOWER (S30)
+    25: (1310497171657, 908647988973),  # 26th convergent, UPPER (S31, open PR)
+    26: (6304779645157, 4371490049266), # 27th convergent, LOWER (S32)
+}
+for k, (pe, qe) in checks.items():
+    assert (p(k), q(k)) == (pe, qe), f"convergent k={k} mismatch: {(p(k),q(k))} vs {(pe,qe)}"
+print("Reproduced main's convergents k=23..26 exactly.")
+
+# --- the NEW rung: 28th convergent, k=27 (odd ⟹ UPPER) ---
+k = 27
+pk, qk = p(k), q(k)
+print(f"\n28th convergent (k=27, a27={terms[27]}):  p/q = {pk}/{qk}")
+print(f"  p27 = a27*p26 + p25 = {terms[27]}*{p(26)} + {p(25)} = {pk}")
+print(f"  q27 = a27*q26 + q25 = {terms[27]}*{q(26)} + {q(25)} = {qk}")
+
+# Exact-integer cube sign: UPPER bound requires (p/q)³ > 3, i.e. p³ − 3q³ > 0.
+cube_diff = pk ** 3 - 3 * qk ** 3
+print(f"\n  p27³ − 3·q27³ = {cube_diff}")
+assert k % 2 == 1, "k must be odd for an UPPER bound under this CF parity"
+assert cube_diff > 0, "FAIL: not a valid UPPER bound (p³ − 3q³ ≤ 0)"
+print("  ⟹ (p/q)³ > 3  ⟹  cbrt3 < p/q   [valid UPPER bound]")
+
+# relative gap
+gap = (Decimal(pk) / Decimal(qk)) - cbrt3
+print(f"  relative gap (p/q − ∛3) ≈ {gap:.3e}")
+assert gap > 0, "FAIL: p/q is not above ∛3"
+
+# gcd check (convergents are automatically in lowest terms)
+import math
+assert math.gcd(pk, qk) == 1, "convergent not in lowest terms"
+print("\nALL CHECKS PASS.")

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "filename": "CubeRoot3IrrationalOQ04Helpers.lean",
-      "lineCount": 913,
-      "theoremCount": 24,
+      "lineCount": 1040,
+      "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds the next uncontested rung of the ∛3 continued-fraction convergent ladder:
the **28th CF convergent** (CF index `k = 27`, odd ⟹ above ∛3) as an UPPER bound.

```
cbrt3 < 58053513978070 / 40252058432367     (relative gap ≈ 5.0·10⁻²⁸)
```

- `a₂₇ = 9` re-derived from a 200-digit CF recomputation (anti-typo discipline — never re-quoted).
- Recursion: `p₂₇ = 9·6304779645157 + 1310497171657 = 58053513978070`,
  `q₂₇ = 9·4371490049266 + 908647988973 = 40252058432367`.
- Validity is the **exact-integer cube sign**: `p³ − 3q³ = +204206567818411 > 0` ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q`.
- `theoremCount` 28→29 in `CubeRoot3IrrationalOQ04Helpers.lean`, still **0 sorry / 0 axiom**.

This is the next uncontested rung above main's frontier (27th LOWER, S32 #24782).
It does **not** depend on the still-open 26th UPPER (PR #24767) nor on the contended
`a12=8` main chain — it is a self-contained two-line cubing-iff lemma.

## Certificate

`research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py` — **PASS**. Recomputes
the CF of ∛3 at 200-digit precision, cross-checks the prefix `a0..a26` against the
known sequence, **reproduces main's convergents k=23..26 exactly**, and confirms the
exact cube sign for the new rung.

## Build status

**Build-pending.** Docker VM was at 4 `lean-build` containers on a 7.65 GiB VM
(over the safe ≤2 threshold; building would OOM concurrent peers). The proof uses
the identical two-line upper template
`rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]; norm_num` that compiled clean for
every prior rung (only larger 14-digit integers here); the deployer's cache-warm
build will verify on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)