### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-01-oq-01): de-axiomatize Descartes parity (axiom 1→0)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01.lean
@@ -334,11 +334,14 @@ theorem descartes_tight_X_sub_C (c : ℝ) (hc : 0 < c) :
   omega
 
 /-
-## Part VI: The Parity Result — Open Formalization Challenge
+## Part VI: The Parity Result — Proved in This File (no axiom)
 
-Mathlib has the UPPER BOUND but NOT the PARITY RESULT.
+Mathlib has the UPPER BOUND but NOT the PARITY RESULT. This file supplies the
+parity result itself: `descartes_parity_proved` (Part IX) establishes it with
+0 sorries and 0 axioms, and the public theorem `descartes_parity` (Part X) is
+discharged by it. The sketch below records the strategy actually carried out.
 
-**Statement** (axiomatic here):
+**Statement** (theorem `descartes_parity`):
   ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = p.signVariations
 
 **Classical proof sketch**:
@@ -359,30 +362,15 @@ Mathlib has the UPPER BOUND but NOT the PARITY RESULT.
 These are doable but require ~200 lines of new Mathlib infrastructure.
 -/
 
-/-- **Axiom** (parity result — not proved in Mathlib):
-The difference between sign variations and the positive root count is always even. -/
-axiom descartes_parity (p : ℝ[X]) (hp : p ≠ 0) :
-    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = p.signVariations
-
-/-- **Combined Descartes' Rule**:
-    positive root count + even number = sign variation count. -/
-theorem descartes_rule_combined (p : ℝ[X]) (hp : p ≠ 0) :
-    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = p.signVariations :=
-  descartes_parity p hp
+/-- **Descartes parity** is fully proved in this file — there is no parity axiom.
+The proof, `descartes_parity_proved` (Part IX), and the corollaries that depend on
+it (`descartes_parity`, `descartes_rule_combined`, `one_sign_variation_one_positive_root`,
+`positive_root_count_from_sv`) appear at the end of the file, after the algebraic
+infrastructure they require. -/
 
 /-
 ## Part VII: Consequences
 -/
-
-/-- If p has exactly 1 sign variation, it has exactly 1 positive root.
-    (Uses the parity axiom for the exact count.) -/
-theorem one_sign_variation_one_positive_root (p : ℝ[X]) (hp : p ≠ 0)
-    (h1 : p.signVariations = 1) : p.roots.countP (0 < ·) = 1 := by
-  obtain ⟨k, hk⟩ := descartes_parity p hp
-  rw [h1] at hk
-  have hle := descartes_upper_bound p
-  rw [h1] at hle
-  omega
 
 /-- The Descartes bound for products: countP(p*q) ≤ sv(p) + sv(q). -/
 theorem descartes_mul_bound (p q : ℝ[X]) (hp : p ≠ 0) (hq : q ≠ 0) :
@@ -395,14 +383,6 @@ theorem zero_sv_no_positive_roots (p : ℝ[X]) (h : p.signVariations = 0) :
     p.roots.countP (0 < ·) = 0 := by
   have hle := descartes_upper_bound p
   omega
-
-/-- If we know the sign variation count exactly, we know the positive root count
-    (via parity): sv = countP + 2k for some k ≥ 0. -/
-theorem positive_root_count_from_sv (p : ℝ[X]) (hp : p ≠ 0) (n : ℕ)
-    (h : p.signVariations = n) :
-    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = n := by
-  obtain ⟨k, hk⟩ := descartes_parity p hp
-  exact ⟨k, by rw [← h]; exact hk⟩
 
 /-
 ## Summary
@@ -428,15 +408,16 @@ is that the main upper bound is proved directly from Mathlib with 0 axioms.
 14. `zero_sv_no_positive_roots` — Zero-sv consequence
 15. `descartes_negative_roots` — Negative root bound (0 sorries, via rootMultiplicity algebra)
 
-**With 1 axiom** (legacy — now proved by `descartes_parity_proved` in Part IX):
-16. `descartes_parity` — Parity axiom (PROVED: see `descartes_parity_proved`)
+**Parity corollaries** (0 axioms — `descartes_parity` is now a theorem, see Part X):
+16. `descartes_parity` — Parity result (theorem, discharged by `descartes_parity_proved`)
 17. `descartes_rule_combined` — Combined form
 18. `one_sign_variation_one_positive_root` — 1 sv → 1 positive root
 19. `positive_root_count_from_sv` — Root count from sv via parity
 
-**NOTE**: The axiom `descartes_parity` is now fully proved by `descartes_parity_proved`
-in Part IX. A future refactor should replace the axiom with the proved theorem and
-restructure the file so `descartes_parity_proved` appears before Parts VI-VII.
+**NOTE**: The former `axiom descartes_parity` has been removed. The parity result is
+now the theorem `descartes_parity`, discharged by `descartes_parity_proved` (Part IX);
+its corollaries are collected in Part X (after the proof they depend on). This file is
+now fully axiom-free (0 axioms, 0 sorries).
 
 **Key technique for negative roots (replacing old sorry)**:
 The proof uses three private helper lemmas:
@@ -1070,5 +1051,44 @@ theorem descartes_parity_proved (p : ℝ[X]) (hp : p ≠ 0) :
       simp [Polynomial.roots_X, Multiset.countP_add, ihm]
   rw [hsv, hcountP]
   exact ⟨k, hk⟩
+
+/-
+## Part X: Parity Result and Corollaries (formerly axiomatized)
+
+These were previously stated in Parts VI–VII backed by `axiom descartes_parity`.
+That axiom has been removed: `descartes_parity` is now a theorem discharged by
+`descartes_parity_proved`, and the corollaries follow. They live here because
+`descartes_parity_proved` (Part IX) must be defined before they can cite it.
+-/
+
+/-- **Descartes' Rule of Signs (Parity)** — now a theorem (no axiom):
+    the difference between sign variations and the positive root count is even,
+    i.e. positive root count + 2k = sign variation count for some k. -/
+theorem descartes_parity (p : ℝ[X]) (hp : p ≠ 0) :
+    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = p.signVariations :=
+  descartes_parity_proved p hp
+
+/-- **Combined Descartes' Rule**:
+    positive root count + even number = sign variation count. -/
+theorem descartes_rule_combined (p : ℝ[X]) (hp : p ≠ 0) :
+    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = p.signVariations :=
+  descartes_parity p hp
+
+/-- If p has exactly 1 sign variation, it has exactly 1 positive root. -/
+theorem one_sign_variation_one_positive_root (p : ℝ[X]) (hp : p ≠ 0)
+    (h1 : p.signVariations = 1) : p.roots.countP (0 < ·) = 1 := by
+  obtain ⟨k, hk⟩ := descartes_parity p hp
+  rw [h1] at hk
+  have hle := descartes_upper_bound p
+  rw [h1] at hle
+  omega
+
+/-- If we know the sign variation count exactly, we know the positive root count
+    (via parity): sv = countP + 2k for some k ≥ 0. -/
+theorem positive_root_count_from_sv (p : ℝ[X]) (hp : p ≠ 0) (n : ℕ)
+    (h : p.signVariations = n) :
+    ∃ k : ℕ, p.roots.countP (0 < ·) + 2 * k = n := by
+  obtain ⟨k, hk⟩ := descartes_parity p hp
+  exact ⟨k, by rw [← h]; exact hk⟩
 
 end DescartesRuleOQ01

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -165,9 +165,9 @@
       "Polynomial"
     ],
     "namespace": "DescartesRuleOQ01",
-    "lineCount": 1074,
-    "axiomCount": 1,
-    "theoremCount": 48,
+    "lineCount": 1094,
+    "axiomCount": 0,
+    "theoremCount": 49,
     "definitionCount": 1,
     "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01-oq-01.json
@@ -1,0 +1,41 @@
+{
+  "slug": "descartes-rule-of-signs-oq-01-oq-01-oq-01",
+  "title": "Full Descartes' Rule (positive root count ≤ sign variations)",
+  "phase": "ACT",
+  "status": "completed",
+  "tier": "B",
+  "path": "proofs/Proofs/DescartesRuleOfSignsOQ01.lean",
+  "problemStatement": "Can the full Descartes' rule of signs — not just the parity result, but the exact bound positive_roots ≤ sign_variations, counted with multiplicity — be formalized in Lean 4?",
+  "knownResults": "Mathlib provides Polynomial.signVariations and Polynomial.roots_countP_pos_le_signVariations (Wiedijk #100), giving the exact upper bound directly. The companion parity result (sign_variations - positive_roots is even) is NOT in Mathlib but is fully proved in DescartesRuleOfSignsOQ01.lean via descartes_parity_proved (Stage A combinatorial + Stage B IVT).",
+  "currentState": "RESOLVED. The exact upper bound is descartes_upper_bound (DescartesRuleOQ01, 0 axioms) = p.roots_countP_pos_le_signVariations. The parity completion descartes_parity is now a theorem (was an axiom).",
+  "knowledge": {
+    "progressSummary": "RESOLVED + axiom eliminated. The full Descartes bound positive_roots ≤ sign_variations is already provided by Mathlib (roots_countP_pos_le_signVariations) and re-exported as descartes_upper_bound with 0 axioms. This session removed the now-redundant `axiom descartes_parity` from DescartesRuleOfSignsOQ01.lean: its identical statement was already proved by descartes_parity_proved (Part IX, 0 sorries). The file is now fully axiom-free (axiomCount 1 -> 0).",
+    "builtItems": [
+      "Removed `axiom descartes_parity` from DescartesRuleOfSignsOQ01.lean (axiomCount 1 -> 0)",
+      "Added `theorem descartes_parity := descartes_parity_proved` in new Part X (after its dependency)",
+      "Relocated parity corollaries descartes_rule_combined, one_sign_variation_one_positive_root, positive_root_count_from_sv to Part X with unchanged bodies",
+      "Updated meta descartes-rule-of-signs-oq-01: leanFile.axiomCount 1 -> 0, theoremCount 48 -> 49"
+    ],
+    "insights": [
+      "Mathlib already has the full Descartes upper bound (roots_countP_pos_le_signVariations), so OQ[0] of descartes-rule-of-signs-oq-01-oq-01 is resolvable directly — no complex-root-theory route required.",
+      "The parity half (absent from Mathlib) was already proved in-file via descartes_parity_proved but left shadowed by a redundant axiom; the file's own summary note flagged this for removal.",
+      "Reordering was needed because descartes_parity_proved (Part IX) is defined after the original Parts VI/VII consumers; moving the consumers to Part X (post-proof) avoids relocating ~700 lines of infrastructure."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the Descartes parity result (sign_variations ≡ positive_roots mod 2); it is supplied locally by descartes_parity_proved and could be a candidate for upstreaming."
+    ],
+    "nextSteps": [
+      "Docker-build Proofs.DescartesRuleOfSignsOQ01 to confirm the refactor compiles (shipped build-pending; pool was saturated).",
+      "Consider upstreaming descartes_parity_proved to Mathlib as the parity companion to roots_countP_pos_le_signVariations."
+    ]
+  },
+  "tags": ["polynomials", "descartes", "sign-variations", "axiom-elimination"],
+  "relatedProofs": ["descartes-rule-of-signs-oq-01", "descartes-rule-of-signs-oq-01-oq-01"],
+  "references": [
+    "Mathlib.Algebra.Polynomial.RuleOfSigns",
+    "Wiedijk 100 Theorems #100 (Descartes' Rule of Signs)"
+  ],
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": ["proofs/Proofs/DescartesRuleOfSignsOQ01.lean"]
+}


### PR DESCRIPTION
## Summary
Resolves OQ[0] of `descartes-rule-of-signs-oq-01-oq-01` ("Can the full Descartes' rule — the exact bound `positive_roots ≤ sign_variations` — be formalized?") and eliminates a redundant axiom while doing so.

**Finding**: The exact upper bound is already in Mathlib (`Polynomial.roots_countP_pos_le_signVariations`, Wiedijk #100) and re-exported in `DescartesRuleOfSignsOQ01.lean` as `descartes_upper_bound` with 0 axioms. The companion parity result (absent from Mathlib) was *also* already proved in the same file by `descartes_parity_proved` (Part IX, 0 sorries) — yet the file still kept `axiom descartes_parity` shadowing it. The file's own summary note flagged this for removal.

## Progress
- **Removed `axiom descartes_parity`** from `proofs/Proofs/DescartesRuleOfSignsOQ01.lean` (axiomCount **1 → 0**).
- Added `theorem descartes_parity := descartes_parity_proved` in a new **Part X**, placed after the proof it depends on.
- Relocated the three parity corollaries (`descartes_rule_combined`, `one_sign_variation_one_positive_root`, `positive_root_count_from_sv`) to Part X with **unchanged bodies** (they were defined before `descartes_parity_proved`; Lean requires definition-before-use).
- Updated Part VI header + summary docstrings: the file is now fully axiom-free.
- Updated gallery meta `descartes-rule-of-signs-oq-01`: `leanFile.axiomCount` 1 → 0, `theoremCount` 48 → 49.
- Added knowledge JSON for the slug.

## Findings
- No new mathematics was required — the parity proof already existed; this is a pure de-axiomatization + reordering.
- No external file imports the removed axiom or the moved theorems (verified by grep); the only other `descartes_parity` lives in `DescartesRuleOfSigns.lean` under a different namespace.

## Status
**Outcome**: completed (axiom elimination)
**Verification**: Build-pending — Docker pool was saturated (3 concurrent lean-build containers on the shared 7.65 GiB VM), so I did not build to avoid OOMing peers. The change is a structural refactor with unchanged proof bodies; the one new line (`descartes_parity := descartes_parity_proved p hp`) type-checks trivially since the statements are identical.
**Next Steps**: `./proofs/scripts/docker-build.sh Proofs.DescartesRuleOfSignsOQ01` when a build window opens; consider upstreaming `descartes_parity_proved` to Mathlib.

🤖 Generated by researcher-1