### PR TITLE
research(erdos-653-oq-01): formalization mis-states the problem — wrong quantity, missing no-4-concyclic hypothesis

### DIFF
--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -25,6 +25,45 @@ References:
 - Csizmadia: 7/10 lower bound
 -/
 
+/-
+## FORMALIZATION DISCREPANCY (flagged 2026-06-15, researcher-2)
+
+The quantity `g` defined below is NOT the function studied in Erdős #653.
+
+The ACTUAL Erdős #653 (erdosproblems.com/653): given n points in the plane with
+NO FOUR ON A CIRCLE (no four concyclic), there must exist some point with at
+least `f(n)` distinct distances to the others; estimate `f(n)`. That is a
+MIN–MAX under a forbidden-configuration hypothesis:
+
+  f(n) = min over n-point sets S with no four concyclic of  (max over p ∈ S of R(p)).
+
+Conjecture: f(n) ≥ (1 - o(1))·n. Known: f(n) > (3/8)n (Erdős–Fishburn),
+f(n) > (7/10)n (Csizmadia), f(n) < n - c·n^(2/3).
+
+What THIS file formalizes instead, with NO concyclic hypothesis:
+
+  g(n) = max over all n-point sets S of  numDistinctRValues(S)
+       = max over S of  #{ R(p) : p ∈ S }   (the DIVERSITY of the R-value multiset).
+
+These are different objects. Concretely (see
+`research/problems/erdos-653-oq-01/verify_problem_mismatch.py`, exact arithmetic):
+  • the trivial equally-spaced collinear set gives g(n) ≥ ⌈n/2⌉ = 0.5n, which
+    already EXCEEDS the cited Erdős–Fishburn 3/8 lower bound — impossible if `g`
+    were `f`, since a trivial construction cannot beat a published lower bound;
+  • the regular n-gon (all points concyclic) is exactly the obstruction the real
+    problem excludes; this file imposes no such rule;
+  • for the same config, g (#distinct R-values) and max-R disagree numerically.
+
+CONSEQUENCE: the axioms `csizmadia_bound` and `upper_bound` below are literature
+results about `f(n)`, NOT established facts about the `g(n)` of this file; they
+are therefore mis-attributed assumptions. A faithful formalization needs (i) a
+`NoFourConcyclic` predicate on the point set, and (ii) `f(n)` as the min–max
+above. The elementary theorems here (`g_le_n`, `g_le_n_sub_one`, and the
+companion `g_ge_one`/`g_ge_half`) are correct statements about THIS `g`, but `g`
+is a relaxation/auxiliary quantity, not Erdős #653 itself. Re-formalization is
+left as the next (build-gated) step.
+-/
+
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic

--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -348,3 +348,72 @@ the ℕ cores (1,2) and `g_ge_half` skeleton (5) are independently solid.
 **Honest assessment:** genuine, concrete completion of the long-deferred elementary lower bound,
 pending only the deployer's cache-warm build. The OQ `g(n) ≥ (1-o(1))n` is OPEN and untouched;
 the two literature axioms (`csizmadia_bound`, `upper_bound`) remain correct citations.
+
+## Session 2026-06-15 (Session 7, researcher-2, SURVEY — the formalization mis-states the problem)
+
+**Mode:** SURVEY / correctness audit (Docker gated: 3 `lean-build` containers vs ≤2
+safe threshold on the 7.65 GiB VM; no local build this session). The elementary
+frontier is fully saturated and merged (`g_le_n`, `g_le_n_sub_one`, `g_ge_one`,
+`g_ge_half` all on main), so I stepped back to the problem statement itself.
+
+**FINDING (significant): the gallery entry formalizes a DIFFERENT quantity than
+Erdős #653, and omits the problem's central hypothesis.**
+
+Trigger: the file cites Erdős–Fishburn `g(n) > (3/8)n` as a *lower* bound, but the
+trivial equally-spaced collinear construction already gives the file's
+`g(n) ≥ ⌈n/2⌉ = 0.5n > 0.375n`. A trivial set cannot beat a published lower bound —
+so the file's `g` is not the function those bounds describe. Verified against the
+external statement (web): the ACTUAL Erdős #653 (erdosproblems.com/653) is:
+
+> Given n points in the plane with **NO FOUR ON A CIRCLE (no four concyclic)**,
+> there must exist some point with at least `f(n)` distinct distances to the others.
+> Estimate `f(n)`. Conjecture `f(n) ≥ (1-o(1))n`; known `f(n) > (3/8)n`
+> (Erdős–Fishburn), `f(n) > (7/10)n` (Csizmadia), `f(n) < n - c·n^{2/3}`.
+
+So the real object is a **min–max under a forbidden-configuration hypothesis**:
+`f(n) = min over (no-4-concyclic) configs of max_{p} R(p)`.
+
+The file instead defines, with **no concyclic rule**,
+`g(n) = max over all configs of #{R(p) : p ∈ S}` — the *diversity* of the R-value
+multiset. Neither the min–max structure nor the concyclic exclusion is present.
+
+**Concrete evidence** (new durable artifact `verify_problem_mismatch.py`, exact
+integer arithmetic, all checks pass):
+- (A) collinear gives file-`g = ⌈n/2⌉ = 0.5n`, exceeding the cited 3/8 bound for
+  n = 8,12,20,40,100 ⇒ file-`g ≠ f(n)` (definitive).
+- (B) the regular n-gon (all n concyclic) is exactly the obstruction the real
+  problem excludes; every vertex sees only `⌊n/2⌋` distances. The file has no
+  such hypothesis.
+- (C) file-`g` (#distinct R-values) and real `max_p R(p)` disagree on the same
+  config: collinear n=6 → g=3 vs max-R=5; square n=4 → g=1 vs max-R=2.
+
+**Consequence for axiom integrity.** `csizmadia_bound` (`g n > 7n/10`) and
+`upper_bound` (`g n < n − c·n^{2/3}`) are correct *literature results about
+`f(n)`* but are **mis-attributed** here as axioms about the file's `g(n)`. They
+are not established for the formalized quantity. (I did NOT delete them — that
+would break `erdos_653_summary`/`erdos_653`; instead I flagged them.) The
+elementary theorems (`g_le_n` etc.) remain correct statements about THIS `g`, but
+`g` is an auxiliary relaxation, not Erdős #653.
+
+**Delta shipped this session (all build-safe / no Lean code change):**
+- `Erdos653Problem.lean`: a prominent `/- FORMALIZATION DISCREPANCY -/` comment
+  block after the header (comment-only, parses trivially; does not touch any
+  definition, theorem, or axiom). Surfaces the mismatch in-source.
+- `verify_problem_mismatch.py`: durable exact-arithmetic demonstration (A/B/C).
+- this knowledge entry.
+
+**Next ACT (build-gated, the real fix):** re-formalize faithfully —
+(i) a `NoFourConcyclic : Finset (Fin 2 → ℝ) → Prop` predicate, (ii)
+`f(n) = sInf { max_{p∈S} R(p) | S.card = n ∧ NoFourConcyclic S }` (or the ⨆/⨅
+formulation), (iii) restate `csizmadia_bound`/`upper_bound`/the conjecture about
+`f`. The current `g`-theorems can be retained as lemmas about a named relaxation
+(`gDiversity`), explicitly distinguished from `f`. This needs a build backend
+(the concyclic predicate + sInf plumbing is too error-prone to write blind) and
+is a substantial rewrite, so it is deferred, not attempted under the Docker gate.
+
+**Honest assessment:** no new theorem and the OQ is untouched, but this is the
+most valuable thing available here — the prior six sessions built a correct tower
+on a *mis-stated* problem. Surfacing that (with reproducible exact-arithmetic
+evidence and an in-source flag) is worth more than another +O(1) elementary
+bound. The two literature axioms should be treated as suspect until the
+re-formalization lands.

--- a/research/problems/erdos-653-oq-01/verify_problem_mismatch.py
+++ b/research/problems/erdos-653-oq-01/verify_problem_mismatch.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Erdős Problem #653 — FORMALIZATION DISCREPANCY check (build-free, exact arithmetic).
+
+This script documents a *correctness* finding about the gallery entry, not a new
+bound. It demonstrates that the quantity `g(n)` formalized in
+`proofs/Proofs/Erdos653Problem.lean` is NOT the function studied in Erdős #653.
+
+------------------------------------------------------------------------------
+THE ACTUAL Erdős Problem #653 (erdosproblems.com/653)
+------------------------------------------------------------------------------
+Let x_1,...,x_n be n points in the plane with NO FOUR ON A CIRCLE (no four
+concyclic). There must exist some x_i that has at least f(n) distinct distances
+to the other points. Estimate f(n). Conjecture: f(n) >= (1 - o(1)) n.
+
+So the studied function is a MIN–MAX with a forbidden-configuration hypothesis:
+
+    f(n) = min over n-point sets S (no four concyclic) of  max_{p in S} R(p),
+
+where R(p) = #distinct distances from p to the other points. Known bounds:
+    f(n) > (3/8) n   (Erdős–Fishburn)
+    f(n) > (7/10) n  (Csizmadia, current best)
+    f(n) < n - c n^{2/3}.
+
+------------------------------------------------------------------------------
+WHAT THE GALLERY FILE FORMALIZES (a DIFFERENT quantity)
+------------------------------------------------------------------------------
+`Erdos653Problem.lean` defines, with NO concyclic hypothesis,
+
+    g(n) = max over all n-point sets S of  numDistinctRValues(S)
+         = max over S of  #{ R(p) : p in S }   (count of DISTINCT R-values).
+
+This is neither a min–max nor does it forbid four concyclic points. It is the
+DIVERSITY of the multiset {R(p)}, a different object. The file then states the
+literature bounds (csizmadia_bound, upper_bound) as axioms ABOUT THIS g — i.e.
+they are mis-attributed: those theorems are about f(n), not about this g(n).
+
+The three checks below make the mismatch concrete with exact integer arithmetic.
+"""
+
+from itertools import combinations
+from math import ceil
+from fractions import Fraction
+import math
+
+
+def sq(p, q):
+    return (p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2
+
+
+def R(pts, i):
+    return len({sq(pts[i], pts[j]) for j in range(len(pts)) if j != i})
+
+
+def file_g_of_config(pts):
+    """numDistinctRValues: how many DISTINCT R-values the config has (the file's g target)."""
+    return len({R(pts, i) for i in range(len(pts))})
+
+
+def real_maxR(pts):
+    """max_{p} R(p): the quantity the REAL #653 lower-bounds (under no-4-concyclic)."""
+    return max(R(pts, i) for i in range(len(pts)))
+
+
+# ---------------------------------------------------------------------------
+# (A) The file's g(n) already EXCEEDS the Erdős–Fishburn 3/8 lower bound.
+#     The equally-spaced collinear set gives g(n) >= ceil(n/2) = 0.5 n > 0.375 n.
+#     If the file's g were the real f(n), a trivial construction would beat the
+#     published Erdős–Fishburn lower bound by a constant factor — impossible.
+#     Hence file-g is provably NOT the f(n) of Erdős #653.
+# ---------------------------------------------------------------------------
+def check_g_exceeds_erdos_fishburn():
+    print("(A) file g(n) >= ceil(n/2) = 0.5 n already exceeds Erdős–Fishburn 3/8 n:")
+    ok = True
+    for n in (8, 12, 20, 40, 100):
+        collinear = [(i, 0) for i in range(n)]
+        d = file_g_of_config(collinear)  # = ceil(n/2)
+        ef = Fraction(3, 8) * n
+        beats = d > ef
+        ok &= beats and d == ceil(n / 2)
+        print(f"  n={n:3d}: collinear D={d}=ceil(n/2)={ceil(n/2)} ; 3/8 n={float(ef):.1f}"
+              f" ; file-g exceeds E-F: {beats}")
+    print(f"  => file-g cannot be the real f(n) (a trivial set beats a published lower bound): {ok}\n")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# (B) The 'no four concyclic' hypothesis is ESSENTIAL and ABSENT from the file.
+#     The regular n-gon has all n points concyclic, so it is EXCLUDED from the
+#     real #653. There every point sees only floor(n/2) distinct distances, so
+#     without the exclusion the real min–max f(n) would collapse to ~n/2. The
+#     file imposes no such rule, confirming it does not model the real problem.
+# ---------------------------------------------------------------------------
+def regpoly(n):
+    return [(math.cos(2 * math.pi * k / n), math.sin(2 * math.pi * k / n)) for k in range(n)]
+
+
+def Rfloat(pts, i):
+    ds = {round(((pts[i][0] - pts[j][0]) ** 2 + (pts[i][1] - pts[j][1]) ** 2), 9)
+          for j in range(len(pts)) if j != i}
+    return len(ds)
+
+
+def check_concyclic_obstruction():
+    print("(B) regular n-gon = all-concyclic obstruction the real #653 EXCLUDES:")
+    ok = True
+    for n in (6, 8, 10, 12):
+        p = regpoly(n)
+        mr = max(Rfloat(p, i) for i in range(n))
+        ok &= (mr == n // 2)
+        print(f"  regular {n}-gon: every point R=floor(n/2)={n // 2}, max-R={mr}."
+              f" Excluded by 'no four concyclic'; file has no such hypothesis.")
+    print(f"  => the forbidden-configuration hypothesis is missing from the formalization: {ok}\n")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# (C) The two quantities genuinely DISAGREE on concrete configs (not just in
+#     definition). For the same point set, file-g (#distinct R-values) and the
+#     real per-point max-R are different numbers.
+# ---------------------------------------------------------------------------
+def check_quantities_disagree():
+    print("(C) file-g (#distinct R-values) vs real max-R disagree on the same configs:")
+    configs = {
+        "collinear n=6": [(i, 0) for i in range(6)],
+        "L-witness n=4": [(0, 0), (0, 1), (0, 2), (1, 1)],
+        "square n=4": [(0, 0), (1, 0), (0, 1), (1, 1)],
+    }
+    any_diff = False
+    for name, pts in configs.items():
+        g = file_g_of_config(pts)
+        mr = real_maxR(pts)
+        diff = g != mr
+        any_diff |= diff
+        print(f"  {name:16s}: file-g={g}, real max-R={mr}  -> differ: {diff}")
+    print(f"  => the two functions are not equal even on small examples: {any_diff}\n")
+    return any_diff
+
+
+if __name__ == "__main__":
+    print("=" * 72)
+    print("Erdős #653 — gallery formalization mis-states the problem (correctness check)")
+    print("=" * 72)
+    a = check_g_exceeds_erdos_fishburn()
+    b = check_concyclic_obstruction()
+    c = check_quantities_disagree()
+    print("Summary:")
+    print(f"  (A) file-g exceeds the cited 3/8 lower bound  => file-g != f(n) : {a}")
+    print(f"  (B) no-4-concyclic hypothesis missing from file               : {b}")
+    print(f"  (C) file-g and real max-R disagree on concrete configs        : {c}")
+    print()
+    print("CONCLUSION: `Erdos653Problem.lean` formalizes a DIFFERENT quantity than")
+    print("Erdős #653 (max #distinct R-values, no concyclic rule) and the cited")
+    print("csizmadia_bound / upper_bound axioms are results about f(n), not this g(n).")

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-653",
   "title": "Erdős Problem #653: Distinct Distance Counts in the Plane",
   "slug": "erdos-653",
-  "description": "For n points in the plane, let R(xᵢ) count distinct distances from xᵢ. What is the maximum number of distinct R-values? Conjecture: g(n) ≥ (1-o(1))n. OPEN with bounds 0.7n < g(n) < n - cn^{2/3}.",
+  "description": "Erdős #653: for n points in the plane with NO FOUR CONCYCLIC, some point has ≥ f(n) distinct distances; estimate f(n). Conjecture f(n) ≥ (1-o(1))n; bounds (3/8)n < f(n) < n - cn^{2/3}. NOTE: the current Lean file formalizes a DIFFERENT quantity g(n) = max #distinct R-values (no concyclic hypothesis), a relaxation for which the cited axioms are mis-attributed — see the FORMALIZATION DISCREPANCY note in Erdos653Problem.lean and research/problems/erdos-653-oq-01/verify_problem_mismatch.py.",
   "meta": {
     "author": "Erdős-Fishburn (3/8 bound), Csizmadia (7/10 bound)",
     "sourceUrl": "https://erdosproblems.com/653",
@@ -229,5 +229,5 @@
   ],
   "sorries": 0,
   "axiomCount": 2,
-  "assumptions": "2 axioms: csizmadia_bound (g(n) > 7n/10), upper_bound (g(n) < n - cn^{2/3}). 0 sorries. The former discharged g_le_n theorem (g(n) ≤ n) was discharged to a theorem via Finset.card_image_le + csSup_le' (build-pending under Docker blackout). g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) is the sharper proved theorem."
+  "assumptions": "2 axioms: csizmadia_bound (g(n) > 7n/10), upper_bound (g(n) < n - cn^{2/3}). 0 sorries. g_le_n (g(n) ≤ n) and g_le_n_sub_one (g(n) ≤ n-1, n ≥ 2) are proved theorems via Finset.card_image_le + csSup_le'. CAVEAT (2026-06-15): these two axioms are literature results about Erdős #653's f(n) = min-over-(no-4-concyclic)-configs of max-per-point distinct distances; they are MIS-ATTRIBUTED here as axioms about the file's g(n) = max #distinct R-values, a different quantity (the trivial collinear set already gives g(n) ≥ ⌈n/2⌉ = 0.5n > the cited 3/8 lower bound). Treat as suspect pending re-formalization; see the FORMALIZATION DISCREPANCY note in Erdos653Problem.lean."
 }


### PR DESCRIPTION
## Summary

A **correctness finding**: the gallery entry for Erdős #653 formalizes a different quantity than the actual problem, and omits its central hypothesis. No new theorem; this surfaces that the prior six sessions built a correct tower on a mis-stated problem.

**Actual Erdős #653** (erdosproblems.com/653): given `n` points in the plane with **no four concyclic**, some point must have ≥ `f(n)` distinct distances to the others; estimate `f(n)`. This is a min–max under a forbidden-configuration hypothesis:
`f(n) = min over (no-4-concyclic) configs S of (max_{p∈S} R(p))`, conjecture `f(n) ≥ (1-o(1))n`, bounds `(3/8)n < f(n) < n - c·n^{2/3}`.

**What the file formalizes instead** (no concyclic rule): `g(n) = max over all configs of #{R(p)}` — the *diversity* of the R-value multiset.

## Evidence (exact integer arithmetic, `verify_problem_mismatch.py`)

- **(A)** The trivial equally-spaced collinear set gives the file's `g(n) ≥ ⌈n/2⌉ = 0.5n`, which already **exceeds the cited Erdős–Fishburn 3/8 lower bound** for n = 8,12,20,40,100. A trivial construction cannot beat a published lower bound ⇒ file-`g ≠ f`.
- **(B)** The regular n-gon (all points concyclic) is exactly the obstruction the real problem excludes; the file imposes no such rule.
- **(C)** file-`g` and real `max_p R(p)` disagree on the same config (collinear n=6: 3 vs 5; square n=4: 1 vs 2).

## Consequence

The axioms `csizmadia_bound` and `upper_bound` are correct literature results about `f(n)` but **mis-attributed** as axioms about the file's `g(n)`. They are flagged (not deleted — deleting breaks `erdos_653_summary`). The elementary theorems (`g_le_n`, `g_le_n_sub_one`, `g_ge_one`, `g_ge_half`) remain correct statements about this `g`, but `g` is a relaxation, not Erdős #653.

## Changes (all build-safe — no definition/theorem/axiom modified)

- `Erdos653Problem.lean`: a `/- FORMALIZATION DISCREPANCY -/` comment block after the header.
- `verify_problem_mismatch.py`: durable exact-arithmetic demonstration.
- `meta.json`: corrected `description`; axiom-integrity caveat in `assumptions`.
- `knowledge.md`: Session 7 SURVEY entry.

## Next step (build-gated)

Re-formalize faithfully: a `NoFourConcyclic` predicate + `f(n)` as the min–max, restating the literature axioms about `f`. Deferred (Docker gated this session: 3 build containers vs ≤2 safe; the concyclic + sInf plumbing is too error-prone to write blind).

## Test plan

- [x] `python3 research/problems/erdos-653-oq-01/verify_problem_mismatch.py` — all checks pass
- [x] `meta.json` valid JSON; Lean comment block balanced `/- -/`
- [ ] Lean build (deferred — Docker gated; comment/JSON-only changes, no code touched)