### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-03): bridge operator cyclicity to span-form cyclic subspace

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean
@@ -48,14 +48,33 @@
   consequences; we record it as an explicit open gap below rather than
   attempting it here (see `## PID direction` at the end).
 
+  ## Span-form bridge (Section V)
+
+  The operator definition `IsCyclicVectorOp` used above is the *annihilator-free*
+  form ("no nonzero polynomial of degree `< finrank` kills `v`"). Section V
+  reconciles it with the standard *span* form of cyclicity from the registered
+  module-theoretic development `NonderogatoryModule` (in
+  `CayleyHamiltonMinpolyOQ05OQ01OQ03.lean`), where
+  `IsCyclicVector T v := cyclicSubspace T v = ⊤`. The link is linear
+  independence of the Krylov vectors `{Tᵏ v}_{k < finrank}`: being `finrank`-many
+  independent vectors they form a basis, so their span — which lies inside the
+  cyclic subspace — is already `⊤`. The capstone
+  `operator_nonderogatory_has_span_cyclic_vector` restates the main theorem in
+  this span vocabulary, connecting OQ-03's operator half to Mathlib's
+  `Module`/cyclic-subspace infrastructure as the problem statement requests.
+
   ## Status: 0 sorries, 0 axioms. Build-pending under Docker contention; the
   Mathlib bearers (`LinearMap.toMatrixAlgEquiv`, `minpoly.algEquiv_eq`,
   `LinearMap.toMatrix_apply`, `Matrix.charpoly_natDegree_eq_dim`,
   `Matrix.aeval_self_charpoly`, `Polynomial.aeval_algHom_apply`,
-  `Basis.equivFun_apply`) are name-checked against pinned rev 2df2f01 / v4.26.0.
+  `Basis.equivFun_apply`, `basisOfLinearIndependentOfCardEqFinrank`,
+  `Fintype.linearIndependent_iff`, `natDegree_C_mul_X_pow_le`) are name-checked
+  against pinned rev 2df2f01 / v4.26.0; the Section V Krylov-independence
+  argument mirrors the compiled matrix proof `CyclicCommutant.krylov_linearIndependent`.
 -/
 import Mathlib
 import Proofs.CayleyHamiltonCyclicVectorAllFields
+import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ03
 
 noncomputable section
 
@@ -193,6 +212,76 @@ theorem operator_nonderogatory_has_cyclic_vector [FiniteDimensional K V]
   rw [hbridge, hpann]
   funext i
   simp
+
+-- ============================================================
+-- SECTION V: Bridge to the span-form cyclic subspace
+-- ============================================================
+
+/-- The Krylov vectors `{Tᵏ v}_{k < finrank}` of a vector that is cyclic in the
+    annihilator-free sense (`IsCyclicVectorOp`) are linearly independent.
+
+    A linear dependence `∑_{k<n} c_k Tᵏ v = 0` is exactly the polynomial
+    `p = ∑_{k<n} c_k Xᵏ` (degree `< n`) annihilating `v`, so `IsCyclicVectorOp`
+    forces `p = 0`, i.e. all `c_k = 0`. This is the operator analogue of
+    `CyclicCommutant.krylov_linearIndependent` (matrix version). -/
+theorem krylov_linearIndependent_op [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (h : IsCyclicVectorOp T v) :
+    LinearIndependent K (fun k : Fin (Module.finrank K V) => (T ^ (k : ℕ)) v) := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hc i
+  set n := Module.finrank K V with hn
+  have hnpos : 0 < n := lt_of_le_of_lt (Nat.zero_le (i : ℕ)) i.isLt
+  set p := ∑ k : Fin n, C (c k) * X ^ (k : ℕ) with hp_def
+  have hp_aeval : aeval T p = ∑ k : Fin n, c k • T ^ (k : ℕ) := by
+    simp only [p, map_sum, map_mul, map_pow, aeval_C, aeval_X,
+               Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+  have hp_ann : (aeval T p) v = 0 := by
+    rw [hp_aeval]
+    have hsum : (∑ k : Fin n, c k • T ^ (k : ℕ)) v
+        = ∑ k : Fin n, c k • (T ^ (k : ℕ)) v := by
+      simp only [LinearMap.sum_apply, LinearMap.smul_apply]
+    rw [hsum, hc]
+  have hp_deg : p.natDegree < n := by
+    apply lt_of_le_of_lt (natDegree_sum_le _ _)
+    apply (Finset.sup_lt_iff hnpos).mpr
+    intro k _; exact lt_of_le_of_lt (natDegree_C_mul_X_pow_le (c k) ↑k) k.isLt
+  have hp_zero : p = 0 := h p hp_deg hp_ann
+  have h_coeff := congr_arg (Polynomial.coeff · ↑i) hp_zero
+  simp only [Polynomial.coeff_zero, p, C_mul_X_pow_eq_monomial,
+             finset_sum_coeff, coeff_monomial] at h_coeff
+  simpa [Fin.val_injective.eq_iff] using h_coeff
+
+/-- **Bridge.** A vector cyclic in the annihilator-free sense `IsCyclicVectorOp`
+    is also cyclic in the span sense of `NonderogatoryModule`: its Krylov orbit
+    `{Tᵏ v}` spans the whole space. Since the `finrank`-many Krylov vectors are
+    linearly independent (`krylov_linearIndependent_op`) and `finrank K V` of
+    them form a basis, their span is `⊤`; this span sits inside the cyclic
+    subspace, so the cyclic subspace is `⊤`. -/
+theorem cyclicSubspace_eq_top_of_isCyclicVectorOp [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (h : IsCyclicVectorOp T v) :
+    NonderogatoryModule.cyclicSubspace T v = ⊤ := by
+  have hli := krylov_linearIndependent_op T v h
+  have hcard : Fintype.card (Fin (Module.finrank K V)) = Module.finrank K V :=
+    Fintype.card_fin _
+  have hspan :
+      Submodule.span K
+          (Set.range fun k : Fin (Module.finrank K V) => (T ^ (k : ℕ)) v) = ⊤ := by
+    have hb := (basisOfLinearIndependentOfCardEqFinrank hli hcard).span_eq
+    simpa only [coe_basisOfLinearIndependentOfCardEqFinrank] using hb
+  rw [eq_top_iff, ← hspan]
+  exact NonderogatoryModule.finiteSpan_le_cyclicSubspace T v (Module.finrank K V)
+
+/-- **Capstone (span form).** A nonderogatory operator on a finite-dimensional
+    space has a vector whose Krylov orbit spans the whole space — i.e. a cyclic
+    vector in the span-based sense `NonderogatoryModule.IsCyclicVector`. This
+    recasts `operator_nonderogatory_has_cyclic_vector` in the vocabulary of the
+    registered module-theoretic cyclic-subspace development, connecting OQ-03's
+    operator half to the `Module`/cyclic-subspace infrastructure. -/
+theorem operator_nonderogatory_has_span_cyclic_vector [FiniteDimensional K V]
+    (T : Module.End K V) (h : IsNonderogatoryOp T) :
+    ∃ v, NonderogatoryModule.cyclicSubspace T v = ⊤ := by
+  obtain ⟨v, hv⟩ := operator_nonderogatory_has_cyclic_vector T h
+  exact ⟨v, cyclicSubspace_eq_top_of_isCyclicVectorOp T v hv⟩
 
 end CyclicVectorOperator
 

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -28,17 +28,20 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 221,
-    "theoremCount": 3,
+    "lineCount": 310,
+    "theoremCount": 6,
     "definitionCount": 2,
-    "assumptions": "No axioms or sorries. Uses Mathlib's LinearMap.toMatrix / toMatrixAlgEquiv, minpoly.algEquiv_eq, Matrix charpoly API, and FiniteDimensional bases. Build-pending verification under current Docker contention; all Mathlib bearers name-checked against the pinned rev (v4.26.0). The PID-module half of OQ-03 is recorded as an explicit open gap, not formalized here.",
+    "assumptions": "No axioms or sorries. Uses Mathlib's LinearMap.toMatrix / toMatrixAlgEquiv, minpoly.algEquiv_eq, Matrix charpoly API, FiniteDimensional bases, and (for the Section V span bridge) basisOfLinearIndependentOfCardEqFinrank, Fintype.linearIndependent_iff, and the Polynomial natDegree API. The span bridge also imports the registered module-theoretic file CayleyHamiltonMinpolyOQ05OQ01OQ03 (NonderogatoryModule.cyclicSubspace / finiteSpan_le_cyclicSubspace). Build-pending verification under current Docker contention; all Mathlib bearers name-checked against the pinned rev (v4.26.0), and the Section V Krylov-independence argument mirrors the compiled matrix proof CyclicCommutant.krylov_linearIndependent. The PID-module half of OQ-03 is recorded as an explicit open gap, not formalized here.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "operator_nonderogatory_has_cyclic_vector: a finite-dimensional linear operator T with (minpoly K T).natDegree = finrank K V has a cyclic vector — the coordinate-free form of the matrix cyclic-vector theorem, with no chosen basis in the statement",
       "matrix_nonderog_of_minpoly_natDegree: a matrix whose minimal polynomial has degree n is nonderogatory (minpoly = charpoly), via the monic-cofactor argument on minpoly ∣ charpoly",
       "toMatrix_mulVec_repr: the basis-transport bridge (toMatrix b b f).mulVec (b.repr x) = b.repr (f x), proved from LinearMap.toMatrix_apply, intertwining operator application with matrix-vector multiplication",
-      "IsCyclicVectorOp / IsNonderogatoryOp: coordinate-free operator definitions matching the matrix-level GeneralCyclicVector notions"
+      "IsCyclicVectorOp / IsNonderogatoryOp: coordinate-free operator definitions matching the matrix-level GeneralCyclicVector notions",
+      "krylov_linearIndependent_op: the finrank-many Krylov vectors {T^k v} of a vector cyclic in the annihilator-free sense are linearly independent (operator analogue of the compiled matrix lemma CyclicCommutant.krylov_linearIndependent)",
+      "cyclicSubspace_eq_top_of_isCyclicVectorOp: bridges the annihilator-free cyclicity IsCyclicVectorOp to the span form NonderogatoryModule.cyclicSubspace T v = top",
+      "operator_nonderogatory_has_span_cyclic_vector: capstone restating the main theorem in the registered module-theoretic span vocabulary (NonderogatoryModule.IsCyclicVector), connecting OQ-03's operator half to Mathlib's Module/cyclic-subspace infrastructure"
     ],
     "historicalContext": "The cyclic-vector (nonderogatory) theorem is classically stated for a linear operator on a finite-dimensional vector space (Hoffman & Kunze §7.2, Roman §10.4), not just for matrices. The gallery's parent entries prove it for concrete matrices M ∈ Kⁿˣⁿ. This entry supplies the standard basis-reduction that recovers the operator statement: choose any basis, pass to the matrix of T, invoke the matrix theorem, and transport the resulting cyclic vector back through the coordinate isomorphism. The key invariance is that the minimal polynomial is unchanged under the algebra isomorphism End K V ≃ₐ Matrix (toMatrixAlgEquiv), so the nonderogatory hypothesis transfers verbatim.",
     "proofStrategy": "Pick b := Module.finBasis K V (index Fin n, n = finrank). Let M := toMatrix b b T. (1) minpoly K M = minpoly K T by minpoly.algEquiv_eq applied to toMatrixAlgEquiv b, so deg = n. (2) minpoly ∣ charpoly with both monic of degree n forces minpoly K M = M.charpoly, i.e. M nonderogatory. (3) The matrix theorem nonderogatory_has_cyclic_vector yields a cyclic w : Fin n → K. (4) v := b.equivFun.symm w transports back: b.repr (aeval T p v) = (aeval M p).mulVec w via toMatrix_mulVec_repr and aeval_algHom_apply, so aeval T p v = 0 ⟺ (aeval M p).mulVec w = 0, and matrix cyclicity of w gives operator cyclicity of v."
@@ -72,12 +75,13 @@
   "leanFile": {
     "imports": [
       "Mathlib",
-      "Proofs.CayleyHamiltonCyclicVectorAllFields"
+      "Proofs.CayleyHamiltonCyclicVectorAllFields",
+      "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ03"
     ],
     "namespace": "CyclicVectorOperator",
-    "lineCount": 221,
+    "lineCount": 310,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 6,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Builds on the merged OQ-03 operator half (PR #24793). Adds **Section V** to `CayleyHamiltonCyclicVectorAllFieldsOQ03.lean`, reconciling the file's annihilator-free cyclicity `IsCyclicVectorOp` with the *standard span form* of cyclicity from the registered module-theoretic development `NonderogatoryModule` (in `CayleyHamiltonMinpolyOQ05OQ01OQ03.lean`), where `IsCyclicVector T v := cyclicSubspace T v = ⊤`.

- `krylov_linearIndependent_op` — the `finrank`-many Krylov vectors `{Tᵏv}` of an `IsCyclicVectorOp` vector are linearly independent. A degree-`<n` dependence is exactly a low-degree annihilating polynomial, which `IsCyclicVectorOp` forbids.
- `cyclicSubspace_eq_top_of_isCyclicVectorOp` — `IsCyclicVectorOp T v ⟹ NonderogatoryModule.cyclicSubspace T v = ⊤`. The `finrank`-many independent Krylov vectors form a basis, so their span (contained in the cyclic subspace) is already `⊤`. No separate nonderogatory hypothesis is needed for the bridge.
- `operator_nonderogatory_has_span_cyclic_vector` — capstone: a nonderogatory operator has a vector whose orbit spans `V`, i.e. a cyclic vector in the span sense. This recasts the main theorem in the vocabulary the problem statement asks for (connecting the entry to Mathlib's `Module`/cyclic-subspace infrastructure).

## Verification status

- **0 sorries, 0 axioms.** Badge remains `wip` (build-pending) — Docker is at 3 `lean-build` containers on a 7.65 GB VM, above the safe concurrency limit, so a local build would OOM peers.
- The Section V Krylov-independence proof is a near-verbatim transcription of the **compiled** matrix proof `CyclicCommutant.krylov_linearIndependent` in `CayleyHamiltonCyclicVectorAllFieldsOQ02.lean` (registered in `Proofs.lean`), swapping `(Mᵏ).mulVec v` for `(Tᵏ) v`. All Mathlib bearers name-checked against pinned rev v4.26.0.
- Not registered in `Proofs.lean` yet; registration should follow a green Docker build.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ03` when Docker frees to ≤2 containers; on green, flip badge `wip → verified` and register in `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)