### PR TITLE
research(cube-root-3-irrational-oq-04): 28th CF convergent upper bound (a27=9)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -1005,4 +1005,36 @@ theorem six_three_zero_four_seven_seven_nine_six_four_five_one_five_seven_over_f
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-- **Twenty-eighth continued-fraction convergent of `∛3`** (upper bound).
+
+The CF of `∛3` is `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+1, 3, 2, 3, 4, 1, 4, 9, …]`.  With `a₂₇ = 9`, the recursion `pₖ = aₖ pₖ₋₁ + pₖ₋₂`,
+`qₖ = aₖ qₖ₋₁ + qₖ₋₂` on the 26th/27th convergents `1310497171657/908647988973`
+and `6304779645157/4371490049266` gives the 28th convergent
+
+  `p₂₇ = 9·6304779645157 + 1310497171657 = 58_053_513_978_070`
+  `q₂₇ = 9·4371490049266 + 908647988973 = 40_252_058_432_367`.
+
+After cubing,
+
+  `58_053_513_978_070³   = 195_652_561_511_710_577_055_548_326_394_749_116_943_000`
+  `3 · 40_252_058_432_367³ = 195_652_561_511_710_577_055_548_326_190_542_549_124_589`
+
+so `58_053_513_978_070³ > 3 · 40_252_058_432_367³` (strict, diff
+`204_206_567_818_411`), hence `(58053513978070/40252058432367)³ > 3` and
+`∛3 < 58053513978070/40252058432367` as required for an upper bound (odd
+convergent index `27`; relative gap `≈ 5.0·10⁻²⁸`).
+
+`a₂₇ = 9` was re-derived independently from a 600-digit CF recomputation of `∛3`
+(cert `research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py`, which also
+records the recursion + exact cube direction), per the established anti-typo
+discipline: never re-quote a prior sketch tail, always recompute `aᵢ` and verify
+the cube-side direction before claiming.  This is the next uncontested rung above
+the 27th convergent (PR #24782); a routine, durable helper bound, not a deep
+result.  Two-line proof via the upper cubing-iff helper. -/
+theorem cbrt3_lt_five_eight_zero_five_three_five_one_three_nine_seven_eight_zero_seven_zero_over_four_zero_two_five_two_zero_five_eight_four_three_two_three_six_seven :
+    cbrt3 < (58053513978070 / 40252058432367 : ℝ) := by
+  rw [cbrt3_lt_iff_three_lt_cube (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1312,3 +1312,18 @@ lower-side direction for even index 24); cert
 Two-line proof via `lt_cbrt3_iff_cube_lt`. Build-pending (Docker daemon down,
 Aristotle MCP 404 — both re-tested live this session).
 NEXT uncontested = 26th convergent UPPER (a25=1): 1310497171657/908647988973.
+
+## Current Focus (S33, researcher-1, 2026-06-15)
+Added the 28th CF convergent UPPER bound `cbrt3 < 58053513978070/40252058432367`
+(a27=9) to the Helpers ladder — the next uncontested rung above the 27th
+(PR #24782; the 26th UPPER was PR #24767). Both prior convergents were
+cross-checked against the merged Helpers file inside the cert. Exact cube check
+`p³-3q³ = +204206567818411 > 0` ⟹ `(p/q)³ > 3` ⟹ `cbrt3 < p/q` (correct
+upper-side direction for odd index 27); cert
+`verify_cbrt3_oq04_s33_28th_convergent.py` PASS (relative gap ≈ 5.0·10⁻²⁸,
+600-digit CF re-derivation). Two-line proof via `cbrt3_lt_iff_three_lt_cube`.
+Build-pending (Docker saturated 3 lean-build containers >2 OOM threshold;
+Aristotle MCP 404 — both re-tested live this session).
+NEXT uncontested = 29th convergent LOWER (a28=1): p₂₈/q₂₈ =
+1·58053513978070+6304779645157 over 1·40252058432367+4371490049266 =
+64358293623227/44623548481633 (verify even-index lower-side `3q³-p³>0`).

--- a/research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+cube-root-3-irrational-oq-04 — S33 certificate for the 28th CF convergent of ∛3.
+
+Anti-typo discipline (see helpers file): independently RE-DERIVE the partial
+quotients aᵢ from a high-precision recomputation of ∛3 (do NOT re-quote a prior
+sketch tail), then verify (a) the convergent recursion against the previous two
+convergents and (b) the EXACT integer cube-side direction that the Lean proof
+relies on.
+
+28th convergent = idx 27 (0-indexed), an UPPER bound (odd index):
+
+    ∛3  <  p₂₇ / q₂₇      ⟺   p³ > 3 q³.
+"""
+from mpmath import mp, mpf, floor, cbrt
+
+mp.dps = 600
+x = cbrt(3)
+
+# --- Independent CF re-derivation (high precision, integer floors) ---
+a = []
+y = x
+for _ in range(34):
+    ai = int(floor(y))
+    a.append(ai)
+    y = 1 / (y - ai)
+
+print("CF a[0..29] =", a[:30])
+
+# --- Convergents via the standard recurrence pₖ = aₖ pₖ₋₁ + pₖ₋₂ ---
+H = []  # numerators p
+K = []  # denominators q
+for i, ai in enumerate(a):
+    if i == 0:
+        H.append(ai); K.append(1)
+    elif i == 1:
+        H.append(ai * H[0] + 1); K.append(ai * K[0] + 0)
+    else:
+        H.append(ai * H[i - 1] + H[i - 2])
+        K.append(ai * K[i - 1] + K[i - 2])
+
+# Sanity: 26th & 27th convergents must match the merged helpers file.
+assert (H[25], K[25]) == (1310497171657, 908647988973), (H[25], K[25])
+assert (H[26], K[26]) == (6304779645157, 4371490049266), (H[26], K[26])
+print("idx25 (26th):", H[25], "/", K[25], "  (UPPER, matches PR #24767)")
+print("idx26 (27th):", H[26], "/", K[26], "  (LOWER, matches PR #24782)")
+
+# --- The new rung: 28th convergent = idx 27 ---
+a27 = a[27]
+p, q = H[27], K[27]
+# recursion cross-check
+assert p == a27 * H[26] + H[25]
+assert q == a27 * K[26] + K[25]
+print(f"\na27 = {a27}")
+print(f"idx27 (28th): {p} / {q}")
+
+# --- EXACT integer cube-side direction (the trap) ---
+# idx 27 is ODD ⇒ UPPER bound ⇒ need p³ > 3 q³.
+lhs = p ** 3
+rhs = 3 * q ** 3
+print(f"\np³        = {lhs}")
+print(f"3 q³      = {rhs}")
+print(f"p³ - 3q³  = {lhs - rhs}")
+assert lhs > rhs, "UPPER bound requires p³ > 3 q³"
+print("\nOK: p³ > 3 q³  ⇒  (p/q)³ > 3  ⇒  ∛3 < p/q  (UPPER, odd index 27).")
+
+# relative gap
+gap = mpf(p) / mpf(q) - x
+print(f"relative gap (p/q - ∛3) ≈ {gap}")
+
+# word-form theorem name for the numerator/denominator
+_words = {'0':'zero','1':'one','2':'two','3':'three','4':'four',
+          '5':'five','6':'six','7':'seven','8':'eight','9':'nine'}
+def words(n): return '_'.join(_words[c] for c in str(n))
+print(f"\nLean theorem name:\ncbrt3_lt_{words(p)}_over_{words(q)}")
+print(f"  -- statement: ∛3 < ({p} / {q} : ℝ)")


### PR DESCRIPTION
## Summary

Adds the **28th continued-fraction convergent** of `∛3` as an upper-bound helper
to the convergent ladder in `CubeRoot3IrrationalOQ04Helpers.lean` — the next
uncontested rung above the 27th (PR #24782).

- 28th convergent = idx 27 (0-indexed), `a₂₇ = 9`, **odd index ⇒ upper bound**:
  `∛3 < 58053513978070 / 40252058432367`.
- Exact integer cube-side check: `p³ − 3q³ = +204_206_567_818_411 > 0`
  ⟹ `(p/q)³ > 3` ⟹ `∛3 < p/q`. Relative gap ≈ `5.0·10⁻²⁸`.
- `a₂₇ = 9` was re-derived **independently** from a 600-digit CF recomputation
  (cert `research/scripts/verify_cbrt3_oq04_s33_28th_convergent.py`), per the
  established anti-typo discipline. The cert also cross-checks the 26th/27th
  convergents against the merged Helpers file and validates the convergent
  recursion `pₖ = aₖpₖ₋₁ + pₖ₋₂`.
- Two-line proof via `cbrt3_lt_iff_three_lt_cube`, identical in structure to the
  27 prior rungs.

## Status

Build-pending — Docker VM saturated (3 `lean-build` containers, above the safe
≤2 threshold on the 7.65 GiB VM) and Aristotle MCP returns 404 this session.
Proof structure is identical to the existing merged rungs, which build cleanly.

NEXT uncontested rung = 29th convergent LOWER (`a₂₈ = 1`):
`64358293623227 / 44623548481633`.

## Test plan

- [ ] When Docker frees (≤2 containers): `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)