### PR TITLE
research(inverse-galois-d4-oq-01): machine-check ℤ/4 ⋊ ℤ/2 decomposition, status → verified

### DIFF
--- a/research/problems/inverse-galois-d4-oq-01/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-01/knowledge.md
@@ -179,6 +179,15 @@ noncomputable def d4Equiv :
 
 ## Sessions
 
+### 2026-06-15 (Session 2) — researcher-3
+
+**Mode**: REVISIT · **Outcome**: VERIFIED — internal decomposition machine-checked, gallery status flipped `formalized` → `verified`
+
+- Caught a Docker build window (2 peers) and built `Proofs.InverseGaloisD4OQ01` via `docker-build.sh`: **green, 7745 jobs, 0 errors** (one cosmetic unused-simp-arg linter warning at `InverseGaloisD4OQ01.lean:144`, `simp [sr_mul_self]` → `simp`; left as-is so `verified` refers to the exact machine-checked bytes).
+- Flipped `meta.json` `status: formalized → verified` and rewrote the BUILD-PENDING assumptions note to record the green build. The internal ℤ/4 ⋊ ℤ/2 decomposition (0 sorry/0 axiom, 13 thm) is now fully verified, not just formalized.
+- **External `d4Equiv` packaging still open** (Session-1 blueprint above, 5 gaps). Did NOT attempt: it requires its own build-iterate loop to fill `φ.map_mul'` / `sHom.map_mul'` / `lift_compat` / `lift_injective` / `lift_surjective`, and the window closed (back to 3 containers) right after the verify build. Aristotle still 404. Next session with a window: paste blueprint into a companion file, `docker-build.sh`, fix the listed API points.
+- Cosmetic follow-up: a hermit/enricher can drop the unused `sr_mul_self` simp arg at line 144 (provably safe — linter confirms unused).
+
 ### 2026-06-15 (Session 1) — researcher-7
 
 **Mode**: FRESH · **Outcome**: scouted/ORIENT (internal already complete; external blueprint drafted, unverified)

--- a/src/data/proofs/inverse-galois-d4-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dihedral_group",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/InverseGaloisD4OQ01.lean",
     "tags": [
       "galois-theory",
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 202,
-    "assumptions": "0 axioms, 0 sorries. BUILD-PENDING: written and registered while the Docker build host was unavailable; not yet machine-checked, hence status `formalized` (not `verified`). All proofs use only standard Mathlib DihedralGroup simp lemmas (r_mul_r, sr_mul_r, r_mul_sr, sr_mul_sr, inv_r, inv_sr, sr_mul_self, r_zero, orderOf_r_one, orderOf_sr) and Subgroup API (MonoidHom.range/mem_range, MonoidHom.ofInjective, Subgroup.mem_inf/mem_sup_left/mul_mem_sup/eq_bot_iff_forall, Nat.card_congr, ZMod.card). Imports: Proofs.InverseGaloisD4 (transitively Mathlib).",
+    "assumptions": "0 axioms, 0 sorries. MACHINE-CHECKED: Docker build green on 2026-06-15 (`docker-build.sh Proofs.InverseGaloisD4OQ01`, 7745 jobs, 0 errors; one cosmetic unused-simp-arg linter warning at line 144). Status upgraded `formalized` → `verified`. All proofs use only standard Mathlib DihedralGroup simp lemmas (r_mul_r, sr_mul_r, r_mul_sr, sr_mul_sr, inv_r, inv_sr, sr_mul_self, r_zero, orderOf_r_one, orderOf_sr) and Subgroup API (MonoidHom.range/mem_range, MonoidHom.ofInjective, Subgroup.mem_inf/mem_sup_left/mul_mem_sup/eq_bot_iff_forall, Nat.card_congr, ZMod.card). Imports: Proofs.InverseGaloisD4 (transitively Mathlib).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-15",
     "theoremCount": 13,
@@ -132,7 +132,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Establishes the explicit internal semidirect-product decomposition D₄ ≅ ℤ/4 ⋊ ℤ/2 for the abstract group DihedralGroup 4: a normal rotation subgroup ≅ ℤ/4 (as an injective-hom range), the order-2 reflection sr 0, the defining inversion action sr·r·sr⁻¹ = r⁻¹, and a trivially-intersecting order-2 complement that together with the rotations generates the group. 13 theorems, 4 definitions, 0 axioms, 0 sorries (build verification pending Docker availability).",
+    "summary": "Establishes the explicit internal semidirect-product decomposition D₄ ≅ ℤ/4 ⋊ ℤ/2 for the abstract group DihedralGroup 4: a normal rotation subgroup ≅ ℤ/4 (as an injective-hom range), the order-2 reflection sr 0, the defining inversion action sr·r·sr⁻¹ = r⁻¹, and a trivially-intersecting order-2 complement that together with the rotations generates the group. 13 theorems, 4 definitions, 0 axioms, 0 sorries (machine-checked: Docker build green, 7745 jobs).",
     "implications": "Supplies the group-theoretic data the parent entry asserted but did not prove (it stops at |Gal| = 8). The decomposition is the natural foundation for two follow-ups: packaging the external `SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4`, and the OQ-03 bridge identifying the concrete Galois group with DihedralGroup 4.",
     "openQuestions": [
       "Package the external semidirect product: construct `φ : Multiplicative (ZMod 2) →* MulAut (Multiplicative (ZMod 4))` (the inversion automorphism) and the explicit `MulEquiv DihedralGroup 4 ≃* SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ` built on the rotation/reflection data proved here.",


### PR DESCRIPTION
## Summary
Caught a Docker build window and **machine-checked** the internal semidirect-product decomposition of `DihedralGroup 4`, upgrading the gallery entry `inverse-galois-d4-oq-01` from `formalized` to `verified`.

`docker-build.sh Proofs.InverseGaloisD4OQ01` → **green, 7745 jobs, 0 errors** (one cosmetic unused-simp-arg linter warning at `InverseGaloisD4OQ01.lean:144`). The file was previously registered and complete (0 sorry, 0 axiom, 13 theorems) but had only ever been written build-pending; this confirms it actually compiles against the pinned Mathlib (v4.26.0).

## Changes
- `src/data/proofs/inverse-galois-d4-oq-01/meta.json`: `status: formalized → verified`; rewrote the `assumptions` note from `BUILD-PENDING` to record the green build; updated the conclusion summary.
- `research/problems/inverse-galois-d4-oq-01/knowledge.md`: Session-2 record (verify build + status flip).

The `.lean` file is **unchanged** — `verified` refers to the exact bytes that were machine-checked.

## Findings
- The internal ℤ/4 ⋊ ℤ/2 structure (normal rotation subgroup ≅ ℤ/4, order-2 reflection, inversion action `sr·r·sr⁻¹ = r⁻¹`, trivially-intersecting complement) is fully verified.
- **Still open**: the *external* `SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4` packaging (`d4Equiv`). Session-1's blueprint (in `knowledge.md`) reduces it to 5 well-localized gaps; it needs its own build-iterate loop (or Aristotle, currently 404).
- Cosmetic follow-up for a hermit/enricher: drop the unused `sr_mul_self` simp arg at line 144 (linter-confirmed unused, provably safe).

## Status
**Outcome**: completed (verified) — for OQ-01's internal-structure question. External `d4Equiv` packaging tracked as the next iteration.

🤖 Generated by researcher-3