### PR TITLE
research(brouwer-oq-01-oq-03-oq-01): each bisecting slice is exactly half the body

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ01OQ03OQ01.lean
@@ -336,6 +336,65 @@ theorem ham_sandwich_standard_of_scalar_continuity (n : ℕ) (hn : n ≥ 1)
     (fun x i => volume_inter_ne_top n (bodies i) _ (hbody i))
     hcont_pos hcont_neg
 
+-- ============================================================
+-- PART 7: A bisecting hyperplane cuts each body into EXACT halves
+-- ============================================================
+
+/-- **Volume partition across a strict/strict/boundary cut.**
+
+    The two strict open half-spaces `P`, `N` and the boundary hyperplane `B`
+    partition the ambient space. Restricting to a measurable `body`, its volume
+    splits additively over the three slices. This is the elementary measure
+    decomposition underlying "each side gets exactly half": it needs only
+    measurability and a genuine partition (`P ∪ N ∪ B = univ`, pairwise
+    disjoint), no continuity. -/
+theorem volume_body_eq_slices_add_boundary (n : ℕ)
+    (body P N B : Set (EuclideanSpace ℝ (Fin n)))
+    (hbody : MeasurableSet body) (hP : MeasurableSet P) (hN : MeasurableSet N)
+    (hB : MeasurableSet B)
+    (hcover : P ∪ N ∪ B = Set.univ)
+    (hPN : Disjoint P N) (hPB : Disjoint P B) (hNB : Disjoint N B) :
+    volume body
+      = volume (body ∩ P) + volume (body ∩ N) + volume (body ∩ B) := by
+  have hsplit : body = (body ∩ P) ∪ (body ∩ N) ∪ (body ∩ B) := by
+    rw [← Set.inter_union_distrib_left, ← Set.inter_union_distrib_left, hcover,
+      Set.inter_univ]
+  have dPN : Disjoint (body ∩ P) (body ∩ N) :=
+    hPN.mono Set.inter_subset_right Set.inter_subset_right
+  have dPB : Disjoint (body ∩ P) (body ∩ B) :=
+    hPB.mono Set.inter_subset_right Set.inter_subset_right
+  have dNB : Disjoint (body ∩ N) (body ∩ B) :=
+    hNB.mono Set.inter_subset_right Set.inter_subset_right
+  have dUB : Disjoint ((body ∩ P) ∪ (body ∩ N)) (body ∩ B) :=
+    Disjoint.union_left dPB dNB
+  conv_lhs => rw [hsplit]
+  rw [measure_union dUB (hbody.inter hB), measure_union dPN (hbody.inter hN)]
+
+/-- **A bisecting hyperplane gives each body exactly half its volume.**
+
+    Given the strict/strict/boundary partition, a *finite-volume* body whose two
+    strict slices have equal volume (`hbis`) and whose boundary slice is null
+    (`hnull`) is split into two pieces of volume **exactly** `vol(body)/2`:
+    `2 · vol(body ∩ P) = vol(body)`.
+
+    This upgrades the conclusion of `ham_sandwich_of_discrepancy`
+    (`vol(body ∩ pos) = vol(body ∩ neg)`, i.e. the two sides are *equal*) to the
+    textbook statement that each side is *exactly half*. The only extra input is
+    that the boundary hyperplane carries no volume of the body — the same
+    Lebesgue null-set fact that the rest of the file isolates as the residual
+    analytic keystone. No continuity is used here. -/
+theorem each_slice_exactly_half (n : ℕ)
+    (body P N B : Set (EuclideanSpace ℝ (Fin n)))
+    (hbody : MeasurableSet body) (hP : MeasurableSet P) (hN : MeasurableSet N)
+    (hB : MeasurableSet B)
+    (hcover : P ∪ N ∪ B = Set.univ)
+    (hPN : Disjoint P N) (hPB : Disjoint P B) (hNB : Disjoint N B)
+    (hbis : volume (body ∩ P) = volume (body ∩ N))
+    (hnull : volume (body ∩ B) = 0) :
+    2 * volume (body ∩ P) = volume body := by
+  rw [volume_body_eq_slices_add_boundary n body P N B hbody hP hN hB hcover
+    hPN hPB hNB, ← hbis, hnull, add_zero, two_mul]
+
 /-
 ## Significance and the Remaining Gap
 

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-06-15",
     "axiomCount": 1,
     "assumptions": "0 axiom declarations in this file, but the construction is not standalone-verified: (1) it rests on the inherited axiom no_continuous_odd_nonzero_on_sphere from BorsukUlam.lean — the genuine degree-theory core of Borsuk-Ulam, unavoidable for n >= 2; and (2) the capstone theorems (ham_sandwich_of_discrepancy, ham_sandwich_standard) take the continuity of the half-volume discrepancy map as the hypothesis hcomp (the discrepancy is supplied as a continuous SphereFun). The contribution is to prove everything else — the topological reduction, oddness, and the zero-implies-bisected bridge — so that the parent's opaque ham_sandwich_theorem axiom is reduced precisely to this one Lebesgue-continuity input (dominated convergence for parameterized half-spaces), which is measure-theoretic, not topological.",
-    "lineCount": 371,
-    "theoremCount": 9,
+    "lineCount": 430,
+    "theoremCount": 11,
     "definitionCount": 3,
     "originalContributions": [
       "ham_sandwich_reduction: the topological core — a continuous odd F: S^n -> R^n with a 'F x = 0 implies Bisected x' bridge yields a bisecting point; proved directly from borsuk_ulam_antipodal_collapse (no axiom)",
@@ -33,7 +33,9 @@
       "stdPos_neg / stdNeg_neg: for the standard linear parameterization, the antipodal swap is a consequence of linearity (not an assumption)",
       "volume_inter_ne_top: finiteness vol(body_i intersect H) < infinity follows from vol(body_i) < infinity since the slice is a subset",
       "ham_sandwich_standard: the standard-parameterization Ham Sandwich, with only the (vector) continuity hypothesis remaining, assembled from the above",
-      "ham_sandwich_standard_of_scalar_continuity: the sharpest packaging — Ham Sandwich whose ONLY hypotheses are finite body volumes and continuity of each scalar slice-volume on S^n"
+      "ham_sandwich_standard_of_scalar_continuity: the sharpest packaging — Ham Sandwich whose ONLY hypotheses are finite body volumes and continuity of each scalar slice-volume on S^n",
+      "volume_body_eq_slices_add_boundary: the strict/strict/boundary partition decomposes a measurable body's volume additively over its two open half-space slices and the boundary hyperplane slice — the elementary measure-additivity (measure_union) underlying 'each side is exactly half', needing only measurability and a genuine partition",
+      "each_slice_exactly_half: upgrades the conclusion from 'the two slices have EQUAL volume' to 'each slice is EXACTLY half the body' (2 * vol(body ∩ P) = vol(body)) — for a finite-volume body whose boundary hyperplane slice is null, the textbook Ham Sandwich statement, isolating the same boundary-null keystone as the residual"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

Extends the Ham Sandwich de-axiomatization (`brouwer-fixed-point-oq-01-oq-03-oq-01`) with **Part 7**, upgrading the entry's conclusion.

Until now the file proved that a bisecting hyperplane gives the two open half-space slices **equal** volume (`vol(body ∩ pos) = vol(body ∩ neg)`). It never proved the textbook Ham Sandwich statement: that each side is **exactly half** the body. This PR closes that gap.

- **`volume_body_eq_slices_add_boundary`** — for the strict/strict/boundary partition (two open half-spaces `P`, `N` and the boundary hyperplane `B` with `P ∪ N ∪ B = univ`, pairwise disjoint), a measurable body's volume splits additively: `vol body = vol(body∩P) + vol(body∩N) + vol(body∩B)`. Pure measure-additivity (`measure_union`); no continuity.
- **`each_slice_exactly_half`** — `2 · vol(body ∩ P) = vol(body)` for a finite-volume body whose two strict slices have equal volume and whose boundary slice is null. This isolates exactly the same Lebesgue null-set fact (the boundary hyperplane carries no volume) that the rest of the file pins as the residual analytic keystone.

No new axioms or sorries: still **11 theorems, 3 defs, 0 sorries, 0 own axioms**, resting only on the inherited Borsuk-Ulam axiom (`no_continuous_odd_nonzero_on_sphere`).

## Verification

Docker-verified locally: `Built Proofs.BrouwerFixedPointOQ01OQ03OQ01 (41s)` → `Build completed successfully (3061 jobs)`.

meta.json updated: `theoremCount` 9→11, `lineCount` 371→430, two new `originalContributions`.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ01OQ03OQ01` succeeds
- [x] meta.json valid JSON, counts match the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)