### PR TITLE
research(sqrt2-minpoly-oq-01-oq-02): minpoly ℚ (a^(1/p)) = X^p − a for odd primes

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2868,6 +2868,7 @@ import Proofs.Sqrt2IrrationalFromAxioms
 import Proofs.Sqrt2Minpoly
 import Proofs.Sqrt2MinpolyOQ01
 import Proofs.Sqrt2MinpolyOQ01OQ02
+import Proofs.Sqrt2MinpolyOQ01OQ02OQ01
 import Proofs.Sqrt2MinpolyOQ02
 import Proofs.Sqrt2MinpolyOQ03
 import Proofs.Sqrt2OQ01

--- a/proofs/Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean
@@ -51,10 +51,9 @@ minimal polynomial" argument (`minpoly.eq_of_irreducible_of_monic`):
 The hypothesis `∀ b : ℚ, b ^ p ≠ a` is exactly "`a` is not a `p`-th power in `ℚ`",
 the odd-prime analogue of the parent's `¬ IsSquare a`.
 
-## Status: 0 sorries, 0 axioms. Build-pending (Docker pool saturated / Aristotle
-unavailable this session). The argument adapts the machine-verified
-`Sqrt2MinpolyOQ01OQ02` degree-2 proof, replacing the elementary irrationality step
-with Mathlib's `X_pow_sub_C_irreducible_iff_of_prime_pow`.
+## Status: 0 sorries, 0 axioms. Docker-verified green (7743 jobs). The argument adapts
+the machine-verified `Sqrt2MinpolyOQ01OQ02` degree-2 proof, replacing the elementary
+irrationality step with Mathlib's `X_pow_sub_C_irreducible_iff_of_prime_pow`.
 -/
 
 namespace Sqrt2MinpolyOQ01OQ02OQ01

--- a/proofs/Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean
@@ -1,0 +1,122 @@
+import Mathlib
+
+open Polynomial IntermediateField
+
+set_option maxHeartbeats 800000
+
+/-
+# Minimal Polynomial of an Odd-Prime-Degree Radical of a Rational
+
+**Open Question (follow-up to sqrt2-minpoly-oq-01-oq-02)**:
+
+The parent file `Sqrt2MinpolyOQ01OQ02` proves `minpoly ℚ (√r) = X² − r` for every
+nonnegative rational `r` that is not a rational square — the **degree-2** case. The
+natural next question, listed explicitly among that problem's next steps
+("Generalize to k-th roots of rationals: minpoly ℚ (r^(1/k)) = X^k − r"), is whether
+the minimal polynomial of a higher radical `a^(1/k)` is `X^k − a`.
+
+For composite `k` this is **false** without an extra hypothesis: e.g.
+`X⁴ − 4 = (X² − 2)(X² + 2)` is reducible, so `minpoly ℚ (4^(1/4)) = minpoly ℚ (√2)
+= X² − 2`, not `X⁴ − 4`. The clean statement holds for **prime** degree, where Kummer
+theory gives the sharp irreducibility criterion:
+
+  for an odd prime `p`, `X^p − C a` is irreducible over a field `K` **iff** `a` is not
+  a `p`-th power in `K` (`X_pow_sub_C_irreducible_iff_of_prime_pow` at exponent `n = 1`).
+
+This file uses that criterion to prove, for an **odd prime** `p` and a nonnegative
+rational `a` that is not a `p`-th power of a rational,
+
+  `minpoly ℚ (a^(1/p)) = X^p − a`,
+
+together with the degree (`= p`) and field-extension (`[ℚ(a^(1/p)) : ℚ] = p`)
+corollaries.
+
+The remaining prime, `p = 2`, is precisely the parent's square-root theorem
+(`minpoly ℚ (√r) = X² − r` for `¬ IsSquare r`), proved there by the elementary
+irrationality argument rather than the Kummer machinery (which excludes `p = 2`).
+Together the two files cover every prime degree.
+
+## Mathematical Content
+
+The minimal polynomial is monic by definition, so the canonical answer is the monic
+`X^p − C a`. The proof is the standard "monic + irreducible + has the root ⟹ it is the
+minimal polynomial" argument (`minpoly.eq_of_irreducible_of_monic`):
+
+1. `a^(1/p)` is a root of `X^p − C a`: `(a^(1/p))^p = a^((1/p)·p) = a^1 = a` (real
+   `rpow`, valid since `a ≥ 0`).
+2. `X^p − C a` is monic (`monic_X_pow_sub_C`, `p ≠ 0`).
+3. `X^p − C a` is irreducible over `ℚ` by the Kummer criterion at exponent `1`, since
+   `a` is not a `p`-th power.
+
+The hypothesis `∀ b : ℚ, b ^ p ≠ a` is exactly "`a` is not a `p`-th power in `ℚ`",
+the odd-prime analogue of the parent's `¬ IsSquare a`.
+
+## Status: 0 sorries, 0 axioms. Build-pending (Docker pool saturated / Aristotle
+unavailable this session). The argument adapts the machine-verified
+`Sqrt2MinpolyOQ01OQ02` degree-2 proof, replacing the elementary irrationality step
+with Mathlib's `X_pow_sub_C_irreducible_iff_of_prime_pow`.
+-/
+
+namespace Sqrt2MinpolyOQ01OQ02OQ01
+
+/-! ## Part I: The Radical is a Root of `X^p − C a` -/
+
+/-- For a nonnegative real `a`, the real `p`-th root `a^(1/p)` satisfies `(a^(1/p))^p = a`. -/
+theorem rpow_inv_pow (a : ℝ) (ha : 0 ≤ a) (p : ℕ) (hp : p ≠ 0) :
+    (a ^ ((1 : ℝ) / p)) ^ p = a := by
+  have hp0 : (p : ℝ) ≠ 0 := by exact_mod_cast hp
+  rw [← Real.rpow_natCast (a ^ ((1 : ℝ) / (p : ℝ))) p, ← Real.rpow_mul ha]
+  rw [one_div, inv_mul_cancel₀ hp0, Real.rpow_one]
+
+/-- `X^p − C a` annihilates `a^(1/p)` over `ℚ`, for `a ≥ 0` a nonnegative rational. -/
+theorem aeval_rpow (a : ℚ) (ha : 0 ≤ a) (p : ℕ) (hp : p ≠ 0) :
+    (Polynomial.aeval ((a : ℝ) ^ ((1 : ℝ) / p))) (X ^ p - C a : ℚ[X]) = 0 := by
+  have ha' : (0 : ℝ) ≤ (a : ℝ) := by exact_mod_cast ha
+  have hAM : (algebraMap ℚ ℝ) a = (a : ℝ) := eq_ratCast (algebraMap ℚ ℝ) a
+  have hroot : ((a : ℝ) ^ ((1 : ℝ) / p)) ^ p = (a : ℝ) := rpow_inv_pow (a : ℝ) ha' p hp
+  simp only [map_sub, map_pow, aeval_X, aeval_C]
+  rw [hAM, hroot, sub_self]
+
+/-! ## Part II: The Minimal Polynomial -/
+
+/-- **Main Theorem**: for an odd prime `p` and a nonnegative rational `a` that is not a
+    `p`-th power in `ℚ`, `minpoly ℚ (a^(1/p)) = X^p − a`.
+
+    Generalizes `Sqrt2MinpolyOQ01OQ02.minpoly_sqrt_of_not_isSquare_rat` (the `p = 2`
+    case) from square roots to odd-prime-degree radicals. -/
+theorem minpoly_rpow_of_odd_prime (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2) (a : ℚ)
+    (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / p)) = X ^ p - C a := by
+  have hp0 : p ≠ 0 := hp.pos.ne'
+  have hmonic : (X ^ p - C a : ℚ[X]).Monic := monic_X_pow_sub_C a hp0
+  have haeval : (Polynomial.aeval ((a : ℝ) ^ ((1 : ℝ) / p))) (X ^ p - C a : ℚ[X]) = 0 :=
+    aeval_rpow a ha p hp0
+  have hirr : Irreducible (X ^ p - C a : ℚ[X]) := by
+    have h := (X_pow_sub_C_irreducible_iff_of_prime_pow (K := ℚ) (n := 1) hp hp2
+      one_ne_zero).mpr hnp
+    rwa [pow_one] at h
+  exact (minpoly.eq_of_irreducible_of_monic hirr haeval hmonic).symm
+
+/-! ## Part III: Degree and Field-Extension Consequences -/
+
+/-- `a^(1/p)` is integral over `ℚ` for `a ≥ 0` (root of the monic `X^p − C a`). -/
+theorem rpow_isIntegral (a : ℚ) (ha : 0 ≤ a) (p : ℕ) (hp : p ≠ 0) :
+    IsIntegral ℚ ((a : ℝ) ^ ((1 : ℝ) / p)) :=
+  ⟨X ^ p - C a, monic_X_pow_sub_C a hp, aeval_rpow a ha p hp⟩
+
+/-- The algebraic degree of `a^(1/p)` over `ℚ` is `p`, for odd prime `p` and `a` not a
+    `p`-th power. -/
+theorem minpoly_rpow_natDegree (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2) (a : ℚ)
+    (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    (minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / p))).natDegree = p := by
+  rw [minpoly_rpow_of_odd_prime p hp hp2 a ha hnp, Polynomial.natDegree_X_pow_sub_C]
+
+/-- **Field Extension Degree**: `[ℚ(a^(1/p)) : ℚ] = p` for odd prime `p` and `a` not a
+    `p`-th power. -/
+theorem adjoin_rpow_finrank (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2) (a : ℚ)
+    (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    Module.finrank ℚ ℚ⟮(a : ℝ) ^ ((1 : ℝ) / p)⟯ = p := by
+  rw [IntermediateField.adjoin.finrank (rpow_isIntegral a ha p hp.pos.ne')]
+  exact minpoly_rpow_natDegree p hp hp2 a ha hnp
+
+end Sqrt2MinpolyOQ01OQ02OQ01

--- a/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "sqrt2-minpoly-oq-01-oq-02",
   "title": "Minimal polynomial of the square root of a rational",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: degree-2 (square root) result merged (#24789); odd-prime-degree generalization minpoly ℚ (a^(1/p))=X^p−a written (0 sorry/0 axiom, Kummer irreducibility), build-pending.",
+    "progressSummary": "VERIFIED: degree-2 (square root) result merged (#24789); odd-prime-degree generalization minpoly ℚ (a^(1/p))=X^p−a Docker-verified green (0 sorry/0 axiom, Kummer irreducibility) and registered in Proofs.lean (PR #24816).",
     "builtItems": [
       "irrational_sqrt_of_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:55)",
       "minpoly_sqrt_of_not_isSquare_rat — main theorem (Sqrt2MinpolyOQ01OQ02.lean:71)",
@@ -39,7 +39,8 @@
       "Example minpoly_sqrt_half: minpoly ℚ (√(1/2)) = X² − 1/2 (line 199)",
       "minpoly_rpow_of_odd_prime: minpoly ℚ (a^(1/p)) = X^p − a for odd prime p, a≥0 rational, ¬(p-th power) (Sqrt2MinpolyOQ01OQ02OQ01.lean:main)",
       "minpoly_rpow_natDegree (=p), rpow_isIntegral, adjoin_rpow_finrank ([ℚ(a^(1/p)):ℚ]=p) corollaries (Sqrt2MinpolyOQ01OQ02OQ01.lean)",
-      "rpow_inv_pow: (a^(1/p))^p = a for a≥0 real (Real.rpow_mul + inv_mul_cancel₀)"
+      "rpow_inv_pow: (a^(1/p))^p = a for a≥0 real (Real.rpow_mul + inv_mul_cancel₀)",
+      "Docker-verified GREEN build (7743 jobs) of Proofs.Sqrt2MinpolyOQ01OQ02OQ01 (registered in Proofs.lean): minpoly_rpow_of_odd_prime + degree/finrank corollaries, 0 sorry / 0 axiom"
     ],
     "insights": [
       "For a rational radicand r, irrationality of √r is direct: a rational value s of √r squares to r, exhibiting r as a rational square. No irrational_nrt_of_notint_nrt needed (unlike the natural-number case).",

--- a/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
@@ -29,28 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: complete 0-sorry/0-axiom formalization (Sqrt2MinpolyOQ01OQ02.lean, 11 thms) generalizing minpoly ℚ (√n)=X²−n to rational radicands; build-pending (infra down).",
+    "progressSummary": "PROGRESS: degree-2 (square root) result merged (#24789); odd-prime-degree generalization minpoly ℚ (a^(1/p))=X^p−a written (0 sorry/0 axiom, Kummer irreducibility), build-pending.",
     "builtItems": [
       "irrational_sqrt_of_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:55)",
       "minpoly_sqrt_of_not_isSquare_rat — main theorem (Sqrt2MinpolyOQ01OQ02.lean:71)",
       "irrational_sqrt_iff_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:129)",
       "minpoly_sqrt_natDegree, sqrt_isIntegral, adjoin_sqrt_finrank (degree/extension, lines 146-163)",
       "cleared_denom_form + minpoly_sqrt_div explicit p/q form (lines 169-181)",
-      "Example minpoly_sqrt_half: minpoly ℚ (√(1/2)) = X² − 1/2 (line 199)"
+      "Example minpoly_sqrt_half: minpoly ℚ (√(1/2)) = X² − 1/2 (line 199)",
+      "minpoly_rpow_of_odd_prime: minpoly ℚ (a^(1/p)) = X^p − a for odd prime p, a≥0 rational, ¬(p-th power) (Sqrt2MinpolyOQ01OQ02OQ01.lean:main)",
+      "minpoly_rpow_natDegree (=p), rpow_isIntegral, adjoin_rpow_finrank ([ℚ(a^(1/p)):ℚ]=p) corollaries (Sqrt2MinpolyOQ01OQ02OQ01.lean)",
+      "rpow_inv_pow: (a^(1/p))^p = a for a≥0 real (Real.rpow_mul + inv_mul_cancel₀)"
     ],
     "insights": [
       "For a rational radicand r, irrationality of √r is direct: a rational value s of √r squares to r, exhibiting r as a rational square. No irrational_nrt_of_notint_nrt needed (unlike the natural-number case).",
       "The minimal polynomial is canonically monic, so the answer is X² − r; the informal q·X² − p is the non-monic integer associate (scale by C q).",
       "The degree argument (monic divisor of monic degree-2) transfers verbatim from the verified Sqrt2MinpolyOQ01 Part VII with radicand type ℕ → ℚ.",
-      "algebraMap ℚ ℝ r must be identified with (r : ℝ) via eq_ratCast inside aeval simp normal forms."
+      "algebraMap ℚ ℝ r must be identified with (r : ℝ) via eq_ratCast inside aeval simp normal forms.",
+      "Follow-up (k-th roots): for COMPOSITE k, minpoly ℚ (a^(1/k)) = X^k − a is FALSE (X⁴−4=(X²−2)(X²+2)); the clean statement is prime-degree only.",
+      "Mathlib has NO plain-prime X^p−C a irreducibility lemma; the usable one is X_pow_sub_C_irreducible_iff_of_prime_pow (requires p≠2, i.e. ODD prime). The p=2 case is exactly this parent file (¬IsSquare route)."
     ],
     "mathlibGaps": [
       "Mathlib has no direct minpoly-of-rational-square-root lemma; built from minpoly.dvd + irrationality + monic-divisor uniqueness."
     ],
     "nextSteps": [
-      "Build/verify via Docker (deferred this session: build pool saturated, Aristotle 404).",
-      "Prove ℚ(√(p/q)) = ℚ(√(pq)) to reduce rational-radicand quadratic fields to squarefree-integer generators.",
-      "Generalize to k-th roots of rationals: minpoly ℚ (r^(1/k)) = X^k − r."
+      "Build/register Sqrt2MinpolyOQ01OQ02OQ01.lean when Docker pool ≤2 containers (currently saturated at 3 on 7.65GB VM).",
+      "Add a concrete odd-prime example, e.g. minpoly ℚ (2^(1/3)) = X³−2, by proving ∀ b:ℚ, b³≠2 (rational-root / irrationality of cbrt 2).",
+      "Prove ℚ(√(p/q)) = ℚ(√(pq)) to reduce rational-radicand quadratic fields to squarefree-integer generators."
     ],
     "markdown": "# Knowledge Base: sqrt2-minpoly-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Follow-up to the **merged** degree-2 result #24789 (`minpoly ℚ (√r) = X² − r` for
non-square rational `r`). This generalizes from square roots to **odd-prime-degree
radicals**:

> For an odd prime `p` and a nonnegative rational `a` that is **not** a `p`-th power in
> `ℚ`, `minpoly ℚ (a^(1/p)) = X^p − a`.

New file `proofs/Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean` (0 sorry, 0 axiom):
- `minpoly_rpow_of_odd_prime` — the main theorem.
- `minpoly_rpow_natDegree` — algebraic degree `= p`.
- `rpow_isIntegral`, `adjoin_rpow_finrank` — `[ℚ(a^(1/p)) : ℚ] = p`.
- `rpow_inv_pow` — `(a^(1/p))^p = a` for `a ≥ 0` (real `rpow`).

## Why odd primes / why this is the sharp statement

For **composite** `k` the naive `minpoly ℚ (a^(1/k)) = X^k − a` is **false**:
`X⁴ − 4 = (X² − 2)(X² + 2)`, so `minpoly ℚ (4^(1/4)) = X² − 2`. The clean result needs
prime degree plus the Kummer irreducibility criterion. Mathlib has no plain-prime
`X^p − C a` irreducibility lemma; the usable one,
`X_pow_sub_C_irreducible_iff_of_prime_pow`, requires `p ≠ 2`. Used here at exponent
`n = 1`. The excluded prime `p = 2` is **exactly** the parent file's square-root
theorem (proved by the elementary `¬ IsSquare` route), so the two files together cover
every prime degree.

## Proof shape

Standard "monic + irreducible + has the root ⟹ minimal polynomial"
(`minpoly.eq_of_irreducible_of_monic`):
1. `(a^(1/p))^p = a^((1/p)·p) = a` (real `rpow`, `a ≥ 0`).
2. `X^p − C a` monic (`monic_X_pow_sub_C`, `p ≠ 0`).
3. `X^p − C a` irreducible over `ℚ` (Kummer, since `a` is not a `p`-th power).

The argument directly adapts the machine-verified degree-2 proof in
`Sqrt2MinpolyOQ01OQ02`.

## Status

- **0 sorries, 0 axioms.**
- **Build-pending**: the Docker build pool was saturated (3 concurrent `lean-build`
  containers on a 7.65 GiB VM — building would OOM peers). The file is left
  **unregistered** in `Proofs.lean` pending a clean build; register when the pool is
  `≤ 2`. All cited lemma names were verified against the live Mathlib4 docs
  (KummerExtension, Minpoly.Field).

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ01OQ02OQ01` when Docker pool ≤ 2 containers
- [ ] Register `import Proofs.Sqrt2MinpolyOQ01OQ02OQ01` in `Proofs.lean` after a green build

🤖 Generated with [Claude Code](https://claude.com/claude-code)