### PR TITLE
research(cube-root-3-irrational-oq-04): S34 — 29th CF convergent lower bound (a28=1)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -1005,4 +1005,45 @@ theorem six_three_zero_four_seven_seven_nine_six_four_five_one_five_seven_over_f
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-- **Twenty-ninth continued-fraction convergent of `∛3`** (lower bound).
+
+The CF of `∛3` is `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4,
+1, 3, 2, 3, 4, 1, 4, 9, 1, …]`.  With `a₂₇ = 9` and `a₂₈ = 1`, the recursion
+`pₖ = aₖ pₖ₋₁ + pₖ₋₂`, `qₖ = aₖ qₖ₋₁ + qₖ₋₂` builds the 28th convergent from the
+27th `6304779645157/4371490049266` (PR #24782) and the 26th
+`1310497171657/908647988973`,
+
+  `p₂₇ = 9·6304779645157 + 1310497171657 = 58_053_513_978_070`
+  `q₂₇ = 9·4371490049266 +  908647988973 = 40_252_058_432_367`,
+
+then the 29th convergent from the 28th and 27th,
+
+  `p₂₈ = 1·58053513978070 + 6304779645157 = 64_358_293_623_227`
+  `q₂₈ = 1·40252058432367 + 4371490049266 = 44_623_548_481_633`.
+
+After cubing,
+
+  `64_358_293_623_227³     = 266_571_405_907_439_242_825_392_459_510_337_159_398_083`
+  `3 · 44_623_548_481_633³ = 266_571_405_907_439_242_825_392_459_540_815_108_589_411`
+
+so `64_358_293_623_227³ < 3 · 44_623_548_481_633³` (strict, diff
+`30_477_949_191_328`), hence `(64358293623227/44623548481633)³ < 3` and
+`64358293623227/44623548481633 < cbrt3` as required for a lower bound (even
+convergent index `28`; relative gap `≈ 3.8·10⁻²⁹`).
+
+`a₂₇ = 9` and `a₂₈ = 1` were re-derived independently from a 500-digit CF
+recomputation of `∛3` (cert `research/scripts/verify_cbrt3_oq04_s34_29th_convergent.py`,
+which recomputes BOTH the 28th and 29th convergents from the recursion and
+records the exact cube direction), per the established anti-typo discipline:
+never re-quote a prior sketch tail, always recompute `aᵢ` and verify the
+cube-side direction before claiming.  The intermediate 28th convergent
+(`a₂₇ = 9`) currently lives only in open PRs #24802/#24809, so this rung is
+built on freshly re-derived integers rather than an unmerged sketch.  A routine,
+durable helper bound, not a deep result.  Two-line proof via the lower
+cubing-iff helper. -/
+theorem six_four_three_five_eight_two_nine_three_six_two_three_two_two_seven_over_four_four_six_two_three_five_four_eight_four_eight_one_six_three_three_lt_cbrt3 :
+    (64358293623227 / 44623548481633 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,5 +1,28 @@
 # Current State
 
+## S34 (researcher-11, 2026-06-15) — 29th CF convergent LOWER bound
+
+**Phase:** ACT (Helper ladder — convergent bounds run ahead of the contention-blocked main quotient chain).
+
+Added the **29th CF convergent LOWER bound** `64358293623227/44623548481633 < cbrt3`
+(a27=9, a28=1; even idx28 ⟹ lower) to `CubeRoot3IrrationalOQ04Helpers.lean`
+(28→29 theorems, 0 sorry / 0 axiom). Two-line cubing-iff proof
+(`rw [lt_cbrt3_iff_cube_lt (by norm_num)]; norm_num`); cert
+`verify_cbrt3_oq04_s34_29th_convergent.py` PASSED (a27,a28 re-derived at 500
+digits; the 28th convergent `58053513978070/40252058432367` and the 29th both
+recomputed from the recurrence; exact `p³ < 3q³`, diff 30477949191328, rel gap
+≈ 3.8e-29).
+
+**Ladder state:** main reaches the 27th (idx26, #24782 merged). The 28th
+convergent (a27=9) is double-covered by open PRs #24802/#24809; this PR adds the
+**29th** — the next uncontested rung — built on freshly re-derived integers so it
+does not depend on the unmerged 28th.
+
+**Blocked frontier:** main a12=8 quotient chain (#23388 DRAFT / #23983 OPEN) —
+do not pile on a third a12 PR. Convergent helpers run ahead conflict-free.
+
+---
+
 ## S32 (researcher-2, 2026-06-15) — 27th CF convergent LOWER bound
 
 **Phase:** ACT (Helper ladder — convergent bounds run ahead of the contention-blocked main quotient chain).

--- a/research/scripts/verify_cbrt3_oq04_s34_29th_convergent.py
+++ b/research/scripts/verify_cbrt3_oq04_s34_29th_convergent.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+cube-root-3-irrational-oq-04 — S34 certificate for the 29th CF convergent of ∛3.
+
+Anti-typo discipline (see helpers file): independently RE-DERIVE the partial
+quotients aᵢ from a high-precision recomputation of ∛3 (do NOT re-quote a prior
+sketch tail), then verify (a) the convergent recursion against the previous two
+convergents and (b) the EXACT integer cube-side direction that the Lean proof
+relies on.
+
+29th convergent = idx 28 (0-indexed), a₂₈ = ?, a LOWER bound (even index):
+
+    p / q  <  ∛3      ⟺   p³ < 3 q³.
+
+The 28th convergent (idx 27, a₂₇) is itself only in open PRs #24802/#24809;
+this certificate recomputes BOTH the 28th and the 29th convergents from the CF
+recurrence so the 29th rung stands on independently re-derived integers, not on
+an unmerged sketch.
+"""
+from mpmath import mp, mpf, floor, cbrt
+import math
+
+mp.dps = 500
+x = cbrt(3)
+
+# Independent CF re-derivation
+a = []
+y = x
+for _ in range(32):
+    ai = int(floor(y))
+    a.append(ai)
+    y = 1 / (y - ai)
+
+# Convergents via the standard recurrence
+H = []; K = []
+hm1, hm2 = 1, 0
+km1, km2 = 0, 1
+for ai in a:
+    h = ai * hm1 + hm2
+    k = ai * km1 + km2
+    H.append(h); K.append(k)
+    hm2, hm1 = hm1, h
+    km2, km1 = km1, k
+
+# Sanity-anchor the known merged tail (27th convergent, idx26, a26=4)
+assert a[24] == 4, f"a24 expected 4, got {a[24]}"
+assert a[25] == 1, f"a25 expected 1, got {a[25]}"
+assert a[26] == 4, f"a26 expected 4, got {a[26]}"
+assert H[26] == 6304779645157 and K[26] == 4371490049266, \
+    f"27th convergent drift: {H[26]}/{K[26]}"
+
+a27 = a[27]
+a28 = a[28]
+print(f"a₂₇ (28th rung)    = {a27}")
+print(f"a₂₈ (29th rung)    = {a28}")
+
+# 28th convergent (idx 27)
+p27, q27 = H[27], K[27]
+assert p27 == a[27] * H[26] + H[25]
+assert q27 == a[27] * K[26] + K[25]
+assert math.gcd(p27, q27) == 1
+
+# 29th convergent (idx 28) — the new rung
+idx = 28
+p, q = H[idx], K[idx]
+assert p == a[28] * H[27] + H[26], "29th recursion (p) failed"
+assert q == a[28] * K[27] + K[26], "29th recursion (q) failed"
+assert math.gcd(p, q) == 1, "convergent must be in lowest terms"
+
+# idx 28 is EVEN ⟹ LOWER bound ⟺ exact p³ < 3 q³
+p3 = p**3
+tq3 = 3 * q**3
+assert p3 < tq3, "cube-side direction wrong for a lower bound"
+
+print(f"27th conv (idx26)  = {H[26]}/{K[26]}")
+print(f"28th conv (idx27)  = {p27}/{q27}")
+print(f"  p₂₇ = {a27}·{H[26]} + {H[25]} = {p27}")
+print(f"  q₂₇ = {a27}·{K[26]} + {K[25]} = {q27}")
+print(f"29th conv (idx28)  = {p}/{q}")
+print(f"  p₂₈ = {a28}·{p27} + {H[26]} = {p}")
+print(f"  q₂₈ = {a28}·{q27} + {K[26]} = {q}")
+print(f"p³                 = {p3}")
+print(f"3·q³               = {tq3}")
+print(f"3·q³ − p³          = {tq3 - p3}  (>0 ⟹ lower bound, strict)")
+print(f"(p/q)³ vs 3        : {mpf(p)/q < x} (fraction < ∛3)")
+print(f"relative gap       ≈ {mp.nstr((x - mpf(p)/q)/x, 4)}")
+print("ALL CHECKS PASSED")


### PR DESCRIPTION
## Summary

Adds the **29th continued-fraction convergent lower bound** of `∛3` to
`CubeRoot3IrrationalOQ04Helpers.lean`:

```lean
(64358293623227 / 44623548481633 : ℝ) < cbrt3
```

`a₂₇ = 9`, `a₂₈ = 1`; even convergent index `28` ⟹ lower bound. This is the next
**uncontested** rung above the merged 27th convergent (#24782). The 28th
convergent (`a₂₇ = 9`) is currently double-covered by open PRs #24802 / #24809,
so this rung is built on **freshly re-derived integers** (the cert recomputes
both the 28th and the 29th from the recurrence) and does not depend on the
unmerged 28th.

## Verification

- **Docker-verified:** `✔ [7744/7744] Built Proofs.CubeRoot3IrrationalOQ04Helpers`. 0 sorry / 0 axiom.
- **Certificate:** `research/scripts/verify_cbrt3_oq04_s34_29th_convergent.py` PASSED — 500-digit CF recomputation of `∛3`, independent re-derivation of `a₂₇=9` and `a₂₈=1`, recurrence checks for both the 28th (`58053513978070/40252058432367`) and 29th convergents, lowest-terms checks, and the exact integer cube-side direction `p³ < 3·q³` (diff `30_477_949_191_328`, relative gap ≈ `3.8·10⁻²⁹`).

Two-line proof via the existing `lt_cbrt3_iff_cube_lt` cubing-iff helper. A
routine, durable helper bound, not a deep result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)