### PR TITLE
research(shannon-entropy-oq-01-oq-01): differential entropy of Uniform[a,b] = ln(b-a)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2806,6 +2806,7 @@ import Proofs.ShannonEntropy
 import Proofs.ShannonEntropyAristotle
 import Proofs.ShannonEntropyOQ01
 import Proofs.ShannonEntropyOQ01Aristotle
+import Proofs.ShannonEntropyOQ01OQ01
 import Proofs.ShannonEntropyOQ02
 import Proofs.ShannonEntropySSA
 import Proofs.ShannonEntropySSAAristotle

--- a/proofs/Proofs/ShannonEntropyOQ01OQ01.lean
+++ b/proofs/Proofs/ShannonEntropyOQ01OQ01.lean
@@ -1,0 +1,88 @@
+/-
+  Differential Entropy of the Uniform[a,b] Distribution
+
+  OQ01-OQ01 from Shannon Entropy gallery (child of ShannonEntropyOQ01.lean,
+  "Differential Entropy: Gibbs Inequality and Gaussian Maximum Entropy"):
+
+  "Formalize the differential entropy of the Uniform[a,b] distribution:
+   h = ln(b - a)."
+
+  This is the textbook counterpart to the Gaussian computation in the parent
+  file. The uniform density on [a,b] is f(x) = 1/(b-a) for x ∈ [a,b] and 0
+  otherwise, encoded here as `Set.indicator (Set.Icc a b) (fun _ => 1/(b-a))`.
+
+  Differential entropy (parent definition):
+      h(f) = -∫ f(x) ln f(x) dx.
+
+  The integrand f·ln f equals the constant (1/(b-a))·ln(1/(b-a)) on [a,b] and
+  0 off it (the 0·ln 0 = 0 convention is automatic since Real.log 0 = 0).
+  Integrating the constant over [a,b] (Lebesgue length b-a) gives
+      ∫ f ln f = (b-a) · (1/(b-a)) · ln(1/(b-a)) = ln(1/(b-a)) = -ln(b-a),
+  hence h = -(-ln(b-a)) = ln(b-a).
+
+  In particular h < 0 for b - a < 1, illustrating that differential entropy
+  (unlike discrete Shannon entropy) can be negative — the contrast noted in
+  the parent file's preamble.
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib
+import Proofs.ShannonEntropyOQ01
+
+namespace DifferentialEntropy
+
+open MeasureTheory Real Set
+
+/-- Probability density of the Uniform[a,b] distribution:
+    `f(x) = 1/(b-a)` on `[a,b]` and `0` elsewhere. -/
+noncomputable def uniformPDF (a b : ℝ) (x : ℝ) : ℝ :=
+  Set.indicator (Set.Icc a b) (fun _ => 1 / (b - a)) x
+
+/-- The uniform density integrates to 1, i.e. it is a genuine probability
+    density. -/
+theorem uniformPDF_integral_eq_one {a b : ℝ} (hab : a < b) :
+    ∫ x, uniformPDF a b x = 1 := by
+  have hpos : (0 : ℝ) < b - a := by linarith
+  have hne : b - a ≠ 0 := ne_of_gt hpos
+  unfold uniformPDF
+  rw [MeasureTheory.integral_indicator measurableSet_Icc,
+      MeasureTheory.setIntegral_const, Real.volume_Icc,
+      ENNReal.toReal_ofReal hpos.le, smul_eq_mul, mul_one_div, div_self hne]
+
+/-- Differential entropy of the Uniform[a,b] distribution is `ln(b - a)`. -/
+theorem uniformDifferentialEntropy {a b : ℝ} (hab : a < b) :
+    differentialEntropy (uniformPDF a b) = Real.log (b - a) := by
+  have hpos : (0 : ℝ) < b - a := by linarith
+  have hne : b - a ≠ 0 := ne_of_gt hpos
+  -- The integrand `f·ln f` collapses to a constant supported on [a,b].
+  have hkey :
+      (fun x => uniformPDF a b x * Real.log (uniformPDF a b x))
+        = Set.indicator (Set.Icc a b)
+            (fun _ => (1 / (b - a)) * Real.log (1 / (b - a))) := by
+    funext x
+    unfold uniformPDF
+    by_cases hx : x ∈ Set.Icc a b
+    · simp only [Set.indicator_of_mem hx]
+    · simp only [Set.indicator_of_not_mem hx, zero_mul]
+  -- Integrate the constant over [a,b] of Lebesgue length (b-a).
+  have hint :
+      ∫ x, uniformPDF a b x * Real.log (uniformPDF a b x) = -Real.log (b - a) := by
+    rw [hkey, MeasureTheory.integral_indicator measurableSet_Icc,
+        MeasureTheory.setIntegral_const, Real.volume_Icc,
+        ENNReal.toReal_ofReal hpos.le, smul_eq_mul, one_div, Real.log_inv,
+        ← mul_assoc, mul_inv_cancel₀ hne, one_mul]
+  unfold differentialEntropy
+  rw [hint, neg_neg]
+
+/-- The uniform density is nonnegative. -/
+theorem uniformPDF_nonneg {a b : ℝ} (hab : a < b) (x : ℝ) :
+    0 ≤ uniformPDF a b x := by
+  have hpos : (0 : ℝ) < b - a := by linarith
+  unfold uniformPDF
+  rw [Set.indicator_apply]
+  split_ifs with hx
+  · positivity
+  · exact le_refl 0
+
+end DifferentialEntropy

--- a/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "shannon-entropy-oq-01-oq-01",
+  "title": "Differential Entropy of the Uniform[a,b] Distribution",
+  "slug": "shannon-entropy-oq-01-oq-01",
+  "description": "Formalizes the differential entropy of the continuous Uniform[a,b] distribution, h = ln(b-a), building on the differential-entropy framework of shannon-entropy-oq-01. The uniform density 1/(b-a) on [a,b] is encoded as a Lebesgue indicator; integrating f·ln f reduces to a constant over an interval of length b-a. Also proves the density integrates to 1 and is nonnegative.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-15",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/ShannonEntropyOQ01OQ01.lean",
+    "tags": [
+      "information-theory",
+      "differential-entropy",
+      "measure-theory",
+      "probability",
+      "uniform-distribution",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-15",
+    "axiomCount": 0,
+    "lineCount": 88,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "assumptions": "None mathematically (0 axioms, 0 sorries). Build pending: not yet machine-verified locally because the Docker build pool was saturated this session. Reuses the verified `differentialEntropy` definition from shannon-entropy-oq-01.",
+    "originalContributions": [
+      "uniformPDF: the Uniform[a,b] density as a Lebesgue indicator Set.indicator (Icc a b) (1/(b-a))",
+      "uniformDifferentialEntropy: h(Uniform[a,b]) = ln(b-a)",
+      "uniformPDF_integral_eq_one: the uniform density integrates to 1 (valid probability density)",
+      "uniformPDF_nonneg: the uniform density is nonnegative"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Uniform[a,b] distribution is the textbook first example of differential entropy. Shannon (1948) introduced differential entropy h(X) = -∫ f(x)ln f(x)dx as the continuous analogue of discrete entropy; the uniform case h = ln(b-a) immediately exhibits its most counterintuitive feature — differential entropy can be negative (h < 0 whenever b-a < 1), unlike discrete Shannon entropy which is always nonnegative. The parent entry shannon-entropy-oq-01 formalizes the differential-entropy framework (Gibbs inequality, translation/scale behaviour, Gaussian maximum entropy) and lists the uniform computation as its first open question.",
+    "problemStatement": "Formalize the differential entropy of the continuous Uniform[a,b] distribution and prove h = ln(b-a), using the differentialEntropy definition from shannon-entropy-oq-01 and Mathlib's Bochner integral.",
+    "proofStrategy": "Encode the uniform density as f(x) = Set.indicator (Set.Icc a b) (fun _ => 1/(b-a)) x. The integrand f·ln f equals the constant (1/(b-a))·ln(1/(b-a)) on [a,b] and 0 off it — the 0·ln 0 = 0 convention is automatic since Real.log 0 = 0. Integrating the indicator constant over [a,b] (Lebesgue length b-a, via Real.volume_Icc and setIntegral_const) gives ∫ f·ln f = (b-a)·(1/(b-a))·ln(1/(b-a)) = ln(1/(b-a)) = -ln(b-a), so h = -(-ln(b-a)) = ln(b-a).",
+    "keyInsights": [
+      "Encoding the density as Set.indicator turns the entropy integral into MeasureTheory.integral_indicator + setIntegral_const, avoiding any explicit interval-integral machinery",
+      "The 0·ln 0 = 0 convention (Real.log 0 = 0) makes the off-support contribution vanish automatically — the same mechanism the parent file relies on",
+      "Real.volume_Icc gives volume(Icc a b) = ENNReal.ofReal (b-a), whose toReal is exactly the interval length b-a since a < b",
+      "ln(1/(b-a)) = -ln(b-a) via Real.log_inv collapses the final constant to the closed form ln(b-a)",
+      "Differential entropy is negative for b-a < 1 — the concrete witness of the parent entry's remark that continuous entropy, unlike discrete entropy, can be negative"
+    ],
+    "prerequisites": [
+      "differentialEntropy from shannon-entropy-oq-01 (h(f) = -∫ f·ln f)",
+      "MeasureTheory.integral_indicator and MeasureTheory.setIntegral_const",
+      "Real.volume_Icc and ENNReal.toReal_ofReal",
+      "Real.log_inv (ln x⁻¹ = -ln x)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "density",
+      "title": "The Uniform Density",
+      "summary": "uniformPDF a b x = Set.indicator (Icc a b) (fun _ => 1/(b-a)) x, with uniformPDF_integral_eq_one and uniformPDF_nonneg establishing it is a genuine probability density.",
+      "startLine": 38,
+      "endLine": 60,
+      "mathContext": "The Uniform[a,b] density is f(x) = 1/(b-a) for x ∈ [a,b] and 0 otherwise. Encoding it as a Lebesgue indicator makes `uniformPDF_integral_eq_one` a one-line indicator integral: ∫ f = (volume(Icc a b)).toReal · (1/(b-a)) = (b-a)·(1/(b-a)) = 1. Nonnegativity is immediate from 1/(b-a) > 0 when a < b."
+    },
+    {
+      "id": "entropy",
+      "title": "Differential Entropy = ln(b-a)",
+      "summary": "uniformDifferentialEntropy: differentialEntropy (uniformPDF a b) = Real.log (b-a) for a < b.",
+      "startLine": 62,
+      "endLine": 82,
+      "mathContext": "The key lemma rewrites the integrand f·ln f to the indicator of the constant (1/(b-a))·ln(1/(b-a)) on [a,b] (on the complement, 0·ln 0 = 0). Then ∫ f·ln f = (b-a)·(1/(b-a))·ln(1/(b-a)) = ln(1/(b-a)) = -ln(b-a), and h = -∫ f·ln f = ln(b-a). For b-a < 1 this is negative, the canonical example that differential entropy need not be nonnegative."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the differential entropy of Uniform[a,b]: h = ln(b-a), answering the first open question of shannon-entropy-oq-01. 88 lines, 3 theorems, 1 definition, 0 sorries, 0 axioms (build pending local verification).",
+    "implications": "Confirms the differentialEntropy framework of the parent entry handles concrete continuous distributions cleanly via Lebesgue indicators, and supplies the canonical example of a negative differential entropy (b-a < 1).",
+    "openQuestions": [
+      "Formalize the maximum-entropy characterization of the uniform distribution: among densities supported on [a,b], the uniform density maximizes differential entropy",
+      "Prove the continuous data-processing/change-of-variables formula h(φ(X)) = h(X) + E[ln|φ'|] specialized to affine maps, recovering h(Uniform[a,b]) = ln(b-a) from h(Uniform[0,1]) = 0"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-entropy-oq-01",
+      "relationship": "extends",
+      "description": "Parent: differential-entropy framework (Gibbs inequality, Gaussian maximum entropy); this entry resolves its first open question"
+    }
+  ],
+  "leanFile": {
+    "namespace": "DifferentialEntropy",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/ShannonEntropyOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** listed in `shannon-entropy-oq-01` ("Differential Entropy: Gibbs Inequality and Gaussian Maximum Entropy"):

> Formalize the differential entropy of the Uniform[a,b] distribution: h = ln(b-a).

New file `Proofs/ShannonEntropyOQ01OQ01.lean` (namespace `DifferentialEntropy`, reuses the parent's verified `differentialEntropy` definition):

- `uniformPDF a b x := Set.indicator (Set.Icc a b) (fun _ => 1/(b-a)) x` — the Uniform[a,b] density as a Lebesgue indicator.
- `uniformDifferentialEntropy : differentialEntropy (uniformPDF a b) = Real.log (b-a)` (for `a < b`).
- `uniformPDF_integral_eq_one : ∫ x, uniformPDF a b x = 1` (valid probability density).
- `uniformPDF_nonneg`.

3 theorems, 1 definition, **0 sorries, 0 axioms**.

## Proof

The integrand `f·ln f` equals the constant `(1/(b-a))·ln(1/(b-a))` on `[a,b]` and `0` off it (the `0·ln 0 = 0` convention is automatic since `Real.log 0 = 0`). Integrating the indicator constant over `[a,b]` (Lebesgue length `b-a`, via `integral_indicator` + `setIntegral_const` + `Real.volume_Icc`) gives

```
∫ f·ln f = (b-a)·(1/(b-a))·ln(1/(b-a)) = ln(1/(b-a)) = -ln(b-a),
```

hence `h = -∫ f·ln f = ln(b-a)`. In particular `h < 0` for `b-a < 1` — the canonical witness that differential entropy, unlike discrete entropy, can be negative (a remark made in the parent file's preamble).

## Build status

⚠️ **Build pending.** The Docker build pool was saturated (3 concurrent `lean-build` containers on a 7.65 GiB VM) for the entire session, so this file is registered in `Proofs.lean` but has **not yet been machine-verified locally**. All referenced lemmas (`integral_indicator`, `setIntegral_const`, `Real.volume_Icc`, `ENNReal.toReal_ofReal`, `Real.log_inv`, `mul_inv_cancel₀`, `Set.indicator_of_mem/not_mem`) are confirmed present in the current Mathlib pin via existing usage in the tree. `meta.json` status is conservatively set to `formalized` (not `verified`) pending a green build.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ShannonEntropyOQ01OQ01` (when a build slot frees up)
- [ ] `pnpm build` to verify gallery integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)