### PR TITLE
research(erdos-458-oq-02): lcm_upto universal-property characterization

### DIFF
--- a/proofs/Proofs/Erdos458Problem.lean
+++ b/proofs/Proofs/Erdos458Problem.lean
@@ -74,6 +74,26 @@ theorem lcm_upto_five : lcm_upto 5 = 60 := by native_decide
 /-- Small values: lcm(1,...,6) = 60 (6 = 2·3, already covered) -/
 theorem lcm_upto_six : lcm_upto 6 = 60 := by native_decide
 
+/- ## Universal Property -/
+
+/-- Every `m` with `1 ≤ m ≤ n` divides `lcm_upto n`.
+    This is the defining property of the least common multiple, obtained
+    directly from `Finset.dvd_lcm`. -/
+theorem mem_dvd_lcm_upto {m n : ℕ} (hm : 1 ≤ m) (hmn : m ≤ n) : m ∣ lcm_upto n := by
+  unfold lcm_upto
+  simpa using Finset.dvd_lcm (f := id) (Finset.mem_Icc.mpr ⟨hm, hmn⟩)
+
+/-- `lcm_upto n` is the *least* common multiple: any `k` divisible by every
+    `m` in `[1, n]` is divisible by `lcm_upto n`. Obtained from `Finset.lcm_dvd`.
+    Together with `mem_dvd_lcm_upto` this characterizes `lcm_upto n` as exactly
+    the lcm of `{1, …, n}`. -/
+theorem lcm_upto_dvd {n k : ℕ} (h : ∀ m, 1 ≤ m → m ≤ n → m ∣ k) : lcm_upto n ∣ k := by
+  unfold lcm_upto
+  apply Finset.lcm_dvd
+  intro b hb
+  rw [Finset.mem_Icc] at hb
+  simpa using h b hb.1 hb.2
+
 /- ## Growth Properties -/
 
 /-- lcm_upto is monotone in the divisibility order -/

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/458",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 176,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "overview": {
@@ -108,11 +108,11 @@
       "Nat"
     ],
     "namespace": "Erdos458",
-    "lineCount": 156,
+    "lineCount": 176,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 12
+    "theoremCount": 14
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Open question **erdos-458-oq-02** was *"prove the `lcm_upto` axioms from Mathlib `Finset.lcm` lemmas."* On inspection `Proofs/Erdos458Problem.lean` was already **0-axiom / 0-sorry** — the de-axiomatization task was already satisfied. The genuinely missing piece was the **universal property** of `lcm_upto`, which this PR adds using exactly the named Mathlib `Finset.lcm` API:

- `mem_dvd_lcm_upto` — every `m ∈ [1,n]` divides `lcm_upto n`  (via `Finset.dvd_lcm`)
- `lcm_upto_dvd` — `lcm_upto n` divides any common multiple of `{1,…,n}`  (via `Finset.lcm_dvd`)

Together these characterize `lcm_upto n` as *exactly* the lcm of `{1,…,n}` (the dvd_lcm / lcm_dvd pair), the property needed to reason about its growth.

`theoremCount` 12 → 14. The main conjecture (#458) remains **OPEN** (Legendre-hard); this PR does not touch it.

## Honesty note

These are routine supporting lemmas, not an advance on the conjecture. They fill the one fundamental gap (the universal property) in the file's lcm infrastructure.

## Build status

**Build-pending**: Docker pool was saturated this session (Aristotle backend also 404). Both new lemmas reuse the identical `Finset.lcm` proof pattern as the already-verified `lcm_upto_pos` and `lcm_upto_dvd_mono` in the same file (`unfold` + `Finset.mem_Icc` + canonical `Finset.lcm` lemma).

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos458Problem` (when a Docker slot is free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)