### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02): marginal of multinomial is binomial — reduction + leaf targets

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -249,6 +249,7 @@ import Proofs.BinomialTheoremOQ02OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01Aristotle
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01
+import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ03
 import Proofs.BinomialTheoremOQ02OQ01OQ02

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,163 @@
+/-
+# Multinomial Marginal Distribution is Binomial
+
+## Open Question (slug: binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02)
+
+The parent file `BinomialTheoremOQ02OQ01OQ01.lean` defers (line 178, `sorry`)
+the marginal-distribution law: in a `Multinomial(n; p)` distribution on the
+alphabet `s`, the marginal distribution of the count `X i` of a single outcome
+`i ∈ s` is `Binomial(n, p i)`. Concretely, summing the multinomial probability
+mass over all compositions `k` of `n` on `s` with the `i`-coordinate fixed to
+`m` collapses to the binomial mass:
+
+  ∑_{k ∈ piAntidiag s n, k i = m} multinomial(s,k) · ∏_{j∈s} p j ^ k j
+      = C(n,m) · p i ^ m · (1 - p i) ^ (n - m).
+
+## Strategy (this file, ACT)
+
+The proof is a reindex-then-fold:
+
+1. **Reindex (Leaf A `marginal_sum_reindex`)**: the bijection
+     {k ∈ piAntidiag s n | k i = m} ≃ piAntidiag (s.erase i) (n - m)
+   with forward map `k ↦ Function.update k i 0` and inverse
+   `f ↦ Function.update f i m`. (The forward image has `i`-coordinate 0 and
+   support in `s.erase i`, summing to `n - m`; the inverse re-installs `m` at
+   `i`.) This turns the constrained sum into an unconstrained sum over
+   compositions of `n - m` on `s.erase i`.
+
+2. **Coefficient split (Leaf B `multinomial_update_eq`)**: for `f` supported
+   on `s.erase i` (so `f i = 0`) with `∑_{s.erase i} f = n - m`,
+     multinomial s (update f i m) = C(n,m) · multinomial (s.erase i) f,
+   via `Nat.multinomial_insert` on `s = insert i (s.erase i)` (here
+   `(m) + (n-m) = n` uses `m ≤ n`).
+
+3. **Product split (Leaf C `prod_update_eq`)**:
+     ∏_{j∈s} p j ^ (update f i m) j = p i ^ m · ∏_{j∈s.erase i} p j ^ f j,
+   via `Finset.prod_insert` on `s = insert i (s.erase i)` and
+   `Function.update`.
+
+4. **Power fold (in-line, Mathlib)**: the remaining inner sum is exactly the
+   multinomial theorem on `s.erase i`:
+     ∑_{f ∈ piAntidiag (s.erase i) (n-m)} multinomial(s.erase i) f · ∏ p^f
+       = (∑_{j∈s.erase i} p j) ^ (n - m),
+   which is `Finset.sum_pow_eq_sum_piAntidiag` reversed; then
+   `Finset.sum_erase_eq_sub` and the normalization `∑_s p = 1` give
+   `∑_{s.erase i} p = 1 - p i`.
+
+## Mathlib API used (verified against mathlib4_docs, 2026-06-15)
+
+  Nat.multinomial_insert (ha : a ∉ s) :
+    multinomial (insert a s) f = (f a + ∑ i∈s, f i).choose (f a) * multinomial s f
+  Finset.sum_pow_eq_sum_piAntidiag (s) (f) (n) :
+    (∑ i∈s, f i)^n = ∑ k ∈ s.piAntidiag n, ↑(multinomial s k) * ∏ i∈s, f i ^ k i
+  Finset.mem_piAntidiag : f ∈ s.piAntidiag n ↔ s.sum f = n ∧ ∀ i, f i ≠ 0 → i ∈ s
+  Finset.insert_erase (h : a ∈ s) : insert a (s.erase a) = s
+  Finset.not_mem_erase : a ∉ s.erase a
+  Finset.sum_erase_eq_sub (h : a ∈ s) : (s.erase a).sum f = s.sum f - f a
+
+## Status
+
+The reduction (combining the leaves + the power fold) is written out. The three
+combinatorial leaf lemmas are stated precisely and left as `sorry` — they are
+self-contained, mechanical, and are ideal Aristotle targets (HARD-but-known).
+Build-pending: Docker pool saturated and Aristotle backend offline this session.
+-/
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic
+
+namespace BinomialMultinomialMarginal
+
+open Finset BigOperators
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ## Leaf A — the indexing bijection (Aristotle target)
+
+Reindex the marginal sum over the bijection
+`{k ∈ piAntidiag s n | k i = m} ≃ piAntidiag (s.erase i) (n - m)`,
+forward `k ↦ update k i 0`, inverse `f ↦ update f i m`.
+
+Proof route: `Finset.sum_nbij'` (or rewrite the filtered finset as an image of
+`piAntidiag (s.erase i) (n-m)` under `f ↦ update f i m` and use
+`Finset.sum_image`, the map being injective). Membership uses
+`Finset.mem_filter`, `Finset.mem_piAntidiag`, `Finset.not_mem_erase`,
+`Finset.ne_of_mem_erase`, `Finset.sum_erase_eq_sub`. The hypothesis `m ≤ n`
+makes `n - m` the genuine residual mass. -/
+theorem marginal_sum_reindex
+    (s : Finset α) (n m : ℕ) (i : α) (hi : i ∈ s) (hm : m ≤ n)
+    (G : (α → ℕ) → ℝ) :
+    ∑ k ∈ (s.piAntidiag n).filter (fun k => k i = m), G k =
+    ∑ f ∈ (s.erase i).piAntidiag (n - m), G (Function.update f i m) := by
+  sorry
+
+/-! ## Leaf B — multinomial coefficient split (Aristotle target)
+
+For `f` supported on `s.erase i` (`f i = 0`) with `∑_{s.erase i} f = n - m` and
+`m ≤ n`, installing `m` at coordinate `i` multiplies the multinomial coefficient
+by `C(n,m)`. Route: `s = insert i (s.erase i)` via `Finset.insert_erase hi`,
+then `Nat.multinomial_insert (Finset.not_mem_erase i s)`; evaluate
+`Function.update` at `i` (`Function.update_self`) and off `i`
+(`Function.update_of_ne` for `j ∈ s.erase i`, using `Finset.ne_of_mem_erase`);
+finally `m + (n - m) = n` via `Nat.add_sub_cancel' hm`. -/
+theorem multinomial_update_eq
+    (s : Finset α) (i : α) (hi : i ∈ s) (m n : ℕ) (hm : m ≤ n) (f : α → ℕ)
+    (hfi : f i = 0) (hfsum : ∑ j ∈ s.erase i, f j = n - m) :
+    Nat.multinomial s (Function.update f i m)
+      = n.choose m * Nat.multinomial (s.erase i) f := by
+  sorry
+
+/-! ## Leaf C — product split (Aristotle target)
+
+`∏_{j∈s} p j ^ (update f i m) j = p i ^ m · ∏_{j∈s.erase i} p j ^ f j`.
+Route: `s = insert i (s.erase i)` via `Finset.insert_erase hi`, then
+`Finset.prod_insert (Finset.not_mem_erase i s)`; the `i`-factor is
+`p i ^ (update f i m) i = p i ^ m` (`Function.update_self`) and the remaining
+factors are unchanged (`Function.update_of_ne` with `Finset.ne_of_mem_erase`). -/
+theorem prod_update_eq
+    (s : Finset α) (p : α → ℝ) (i : α) (hi : i ∈ s) (m : ℕ) (f : α → ℕ) :
+    ∏ j ∈ s, p j ^ (Function.update f i m) j
+      = p i ^ m * ∏ j ∈ s.erase i, p j ^ f j := by
+  sorry
+
+/-! ## Main theorem — marginal distribution is binomial
+
+Discharges `BinomialTheoremOQ02OQ01OQ01.multinomial_marginal_binomial`. -/
+theorem multinomial_marginal_binomial
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i : α) (hi : i ∈ s) (m : ℕ) (hm : m ≤ n) :
+    ∑ k ∈ (s.piAntidiag n).filter (fun k => k i = m),
+      (Nat.multinomial s k : ℝ) * ∏ j ∈ s, p j ^ k j =
+    (Nat.choose n m : ℝ) * p i ^ m * (1 - p i) ^ (n - m) := by
+  -- Step 1: reindex onto compositions of (n - m) on s.erase i (Leaf A).
+  rw [marginal_sum_reindex s n m i hi hm
+        (fun k => (Nat.multinomial s k : ℝ) * ∏ j ∈ s, p j ^ k j)]
+  -- Step 2: simplify each summand using the coefficient split (B) and product
+  -- split (C). For `f ∈ piAntidiag (s.erase i) (n-m)` we have `f i = 0` and
+  -- `∑_{s.erase i} f = n - m` from `mem_piAntidiag`.
+  have hsummand : ∀ f ∈ (s.erase i).piAntidiag (n - m),
+      (Nat.multinomial s (Function.update f i m) : ℝ)
+          * ∏ j ∈ s, p j ^ (Function.update f i m) j
+        = ((Nat.choose n m : ℝ) * p i ^ m)
+            * ((Nat.multinomial (s.erase i) f : ℝ) * ∏ j ∈ s.erase i, p j ^ f j) := by
+    intro f hf
+    rw [Finset.mem_piAntidiag] at hf
+    obtain ⟨hfsum, hfsupp⟩ := hf
+    have hfi : f i = 0 := by
+      by_contra h
+      exact (Finset.not_mem_erase i s) (hfsupp i h)
+    rw [multinomial_update_eq s i hi m n hm f hfi hfsum,
+        prod_update_eq s p i hi m f]
+    push_cast
+    ring
+  rw [Finset.sum_congr rfl hsummand]
+  -- Step 3: pull the constant `C(n,m) · p i ^ m` out of the sum.
+  rw [← Finset.mul_sum]
+  -- Step 4: fold the inner weighted sum into a power (multinomial theorem).
+  rw [← Finset.sum_pow_eq_sum_piAntidiag (s.erase i) p (n - m)]
+  -- Step 5: `∑_{s.erase i} p = 1 - p i` from the normalization `∑_s p = 1`.
+  rw [Finset.sum_erase_eq_sub hi, hp_sum]
+  ring
+
+end BinomialMultinomialMarginal

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,99 @@
+{
+  "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02",
+  "title": "Multinomial Marginal Distribution is Binomial via piAntidiag reindexing",
+  "phase": "ACT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall \\alpha\\ [\\mathrm{DecidableEq}\\,\\alpha]\\;\\forall (s : \\mathrm{Finset}\\,\\alpha)(p : \\alpha \\to \\mathbb{R})(n : \\mathbb{N}),\\;(\\textstyle\\sum_{j\\in s} p_j = 1) \\Rightarrow \\forall i\\in s,\\ \\forall m\\le n,\\ \\textstyle\\sum_{k\\in \\mathrm{piAntidiag}(s,n),\\,k_i=m} \\binom{n}{k} \\prod_{j\\in s} p_j^{k_j} = \\binom{n}{m} p_i^{m} (1-p_i)^{n-m}.",
+    "plain": "The parent file BinomialTheoremOQ02OQ01OQ01.lean defers (sorry, line 178) the marginal-distribution law of the multinomial: the marginal of a single coordinate count X_i of Multinomial(n; p) is Binomial(n, p_i). Summing the multinomial mass over all compositions k of n on alphabet s with k_i fixed to m collapses to the binomial mass C(n,m) p_i^m (1-p_i)^(n-m). The question is whether this can be formalized over Mathlib's piAntidiag / Nat.multinomial infrastructure.",
+    "whyMatters": [
+      "Discharges one of the four deferred sorries on the multinomial PMF in BinomialTheoremOQ02OQ01OQ01.lean (the marginal law).",
+      "Marginal-is-binomial is the canonical structural property of the multinomial distribution; it is the bridge from the gallery's multinomial PMF to the already-formalized binomial distribution.",
+      "Establishes the reusable reindex pattern {k in piAntidiag s n | k i = m} <-> piAntidiag (s.erase i) (n-m), via Function.update, which transfers to multinomial mean and covariance (the two remaining parent sorries)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Nat.multinomial_insert (Mathlib): multinomial (insert a s) f = (f a + sum_{i in s} f i).choose (f a) * multinomial s f, when a not in s.",
+      "Finset.sum_pow_eq_sum_piAntidiag (Mathlib): (sum_{i in s} f i)^n = sum_{k in s.piAntidiag n} multinomial s k * prod_{i in s} f i ^ k i.",
+      "Finset.insert_erase / Finset.not_mem_erase / Finset.sum_erase_eq_sub (Mathlib): split s at i and reduce sum_{s.erase i} p = (sum_s p) - p i = 1 - p i."
+    ],
+    "open": [
+      "Leaf A marginal_sum_reindex: the indexing bijection {k in piAntidiag s n | k i = m} <-> piAntidiag (s.erase i) (n-m) (forward update k i 0; inverse update f i m).",
+      "Leaf B multinomial_update_eq: multinomial s (update f i m) = C(n,m) * multinomial (s.erase i) f for f supported on s.erase i summing to n-m.",
+      "Leaf C prod_update_eq: prod_{j in s} p_j^(update f i m)_j = p_i^m * prod_{j in s.erase i} p_j^{f_j}."
+    ],
+    "goal": "Close BinomialTheoremOQ02OQ01OQ01.multinomial_marginal_binomial. This session produced proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean: the full reduction (combining Leaves A/B/C + the in-line power fold) written in tactics, with the three combinatorial leaves stated precisely as sorry (Aristotle targets). Build-pending: Docker pool saturated, Aristotle backend offline."
+  },
+  "knowledge": {
+    "progressSummary": "ACT (researcher-9, 2026-06-15): decomposed the parent's marginal-binomial sorry into a reindex bijection + coefficient split + product split + multinomial-theorem power fold; wrote the full reduction in tactics and isolated the three mechanical combinatorial leaves as Aristotle-ingestible sorries. All Mathlib API verified against mathlib4_docs. Build-pending (both backends offline this session).",
+    "builtItems": [
+      "proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean — namespace BinomialMultinomialMarginal: theorem multinomial_marginal_binomial proved modulo three leaf lemmas; reduction (sum_congr with B+C, mul_sum, sum_pow_eq_sum_piAntidiag reversed, sum_erase_eq_sub, ring) written in full.",
+      "Registered the file in proofs/Proofs.lean (import after BinomialTheoremOQ02OQ01OQ01OQ01OQ01)."
+    ],
+    "insights": [
+      "The whole proof is reindex-then-fold: fix k_i=m, peel coordinate i off s via s = insert i (s.erase i), then the residual sum over compositions of n-m on s.erase i is exactly the multinomial theorem, giving (1-p_i)^(n-m).",
+      "Nat.multinomial_insert turns the multinomial coefficient split into n.choose m * multinomial(erase) once m + (n-m) = n (m <= n).",
+      "The reindex bijection is the only genuinely combinatorial step; forward map update k i 0, inverse update f i m, with f_i = 0 forced because i not in s.erase i.",
+      "The same reindex pattern (Leaf A) and coefficient split (Leaf B) directly serve the parent's multinomial_mean and multinomial_covariance sorries."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no packaged 'marginal of multinomial is binomial' lemma; this is a gallery-internal de-sorry, not an upstream contribution candidate."
+    ],
+    "nextSteps": [
+      "When Aristotle recovers: submit BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean (or the three leaf lemmas individually) to fill Leaves A/B/C.",
+      "When Docker has <=2 containers: build Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02 to verify the reduction and the (currently sorry-gated) leaves once filled.",
+      "After completion, reuse Leaf A + Leaf B to attack multinomial_mean and multinomial_covariance (parent sorries)."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "multinomial",
+    "binomial",
+    "marginal-distribution",
+    "piAntidiag",
+    "probability",
+    "seeker-selected",
+    "gallery-extracted"
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-02",
+    "binomial-theorem-oq-02-oq-01",
+    "binomial-theorem-oq-02-oq-01-oq-01",
+    "binomial-theorem-oq-02-oq-01-oq-01-oq-01",
+    "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean#L178-L186"
+    ],
+    "mathlib": [
+      "Nat.multinomial_insert (Mathlib/Data/Nat/Choose/Multinomial.lean): coefficient peel for insert.",
+      "Finset.sum_pow_eq_sum_piAntidiag (Mathlib/Data/Nat/Choose/Multinomial.lean): multinomial theorem for CommSemiring.",
+      "Finset.mem_piAntidiag / Finset.piAntidiag_insert (Mathlib/Algebra/Order/Antidiag/Pi.lean): membership and insert split.",
+      "Finset.insert_erase, Finset.not_mem_erase, Finset.ne_of_mem_erase, Finset.sum_erase_eq_sub.",
+      "Function.update_self / Function.update_of_ne."
+    ]
+  },
+  "started": "2026-06-15T00:00:00.000Z",
+  "lastUpdate": "2026-06-15T00:00:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean",
+      "filename": "BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean",
+      "lineCount": 163,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Discharges (modulo three isolated leaf lemmas) the parent's deferred
`multinomial_marginal_binomial` sorry in
`BinomialTheoremOQ02OQ01OQ01.lean:178` — the marginal-distribution law of the
multinomial: the marginal of a single coordinate count `X i` of
`Multinomial(n; p)` is `Binomial(n, p i)`.

New file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean` proves

```
∑_{k ∈ piAntidiag s n, k i = m} multinomial(s,k) · ∏_{j∈s} p j ^ k j
    = C(n,m) · p i ^ m · (1 - p i) ^ (n - m)
```

by **reindex-then-fold**:

1. Reindex onto compositions of `n - m` on `s.erase i`
   (`{k | k i = m} ≃ piAntidiag (s.erase i) (n-m)`, forward `update k i 0`,
   inverse `update f i m`).
2. Split the multinomial coefficient via `Nat.multinomial_insert`:
   `multinomial s (update f i m) = C(n,m) · multinomial (s.erase i) f`.
3. Split the product via `Finset.prod_insert`.
4. Fold the residual inner sum with `Finset.sum_pow_eq_sum_piAntidiag`
   (the multinomial theorem) and `Finset.sum_erase_eq_sub` +
   `∑_s p = 1` ⟹ `∑_{s.erase i} p = 1 - p i`.

The full reduction (steps 2–4) is written in tactics. The three genuinely
combinatorial leaves (the reindex bijection and the two `update` splits) are
stated precisely and left as **Aristotle-ingestible `sorry`** targets, with the
exact Mathlib API cited inline.

## Status

- Mathlib API verified against mathlib4_docs (2026-06-15): `Nat.multinomial_insert`,
  `Finset.sum_pow_eq_sum_piAntidiag`, `Finset.piAntidiag_insert`/`mem_piAntidiag`,
  `Finset.insert_erase`, `Finset.sum_erase_eq_sub`.
- Registered in `proofs/Proofs.lean`.
- **Build-pending**: Docker pool saturated and Aristotle backend offline this
  session. `status: in-progress`, 3 sorries — NOT verified.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02` when Docker ≤2 containers
- [ ] Submit leaves A/B/C to Aristotle when the backend recovers