### PR TITLE
Enrich shannon-entropy-oq-01-oq-01: add annotations.json

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/shannon-entropy-oq-01-oq-01/annotations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "ann-uniform-pdf-def",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 37,
+      "endLine": 40
+    },
+    "type": "definition",
+    "title": "uniformPDF: the Uniform[a,b] density as a Lebesgue indicator",
+    "content": "uniformPDF a b x = Set.indicator (Set.Icc a b) (fun _ => 1/(b-a)) x encodes the Uniform[a,b] density f(x) = 1/(b-a) on [a,b] and 0 elsewhere. Using Set.indicator rather than an explicit piecewise function is the central design choice: it makes every downstream integral a one-line application of MeasureTheory.integral_indicator, which rewrites the integral over all of ℝ into a set integral over [a,b]. The definition is marked noncomputable because real division and the indicator over a measurable set are noncomputable in Mathlib. No positivity hypothesis a < b is baked into the definition — the density only behaves as a probability density once a < b is supplied to the theorems.",
+    "mathContext": "$f(x) = \\frac{1}{b-a}\\,\\mathbf{1}_{[a,b]}(x)$, i.e. $f(x) = 1/(b-a)$ for $x \\in [a,b]$ and $0$ otherwise.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.indicator",
+      "uniform distribution",
+      "probability density function",
+      "Lebesgue measure"
+    ],
+    "prerequisites": [
+      "Set.indicator",
+      "Set.Icc",
+      "measure theory"
+    ]
+  },
+  {
+    "id": "ann-uniform-integral-one",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 51
+    },
+    "type": "technique",
+    "title": "uniformPDF_integral_eq_one: the density integrates to 1",
+    "content": "uniformPDF_integral_eq_one shows ∫ uniformPDF a b = 1, certifying that uniformPDF is a genuine probability density. The proof chains four Mathlib rewrites: integral_indicator measurableSet_Icc turns the integral into a set integral over [a,b]; setIntegral_const evaluates the integral of the constant 1/(b-a) to volume(Icc a b) • (1/(b-a)); Real.volume_Icc gives volume(Icc a b) = ENNReal.ofReal (b-a); and ENNReal.toReal_ofReal hpos.le (using 0 < b-a) extracts the real length b-a. The final smul_eq_mul, mul_one_div, div_self hne collapses (b-a)·(1/(b-a)) to 1. The hypothesis a < b is essential: it both makes b-a nonzero (so div_self applies) and makes b-a nonnegative (so toReal_ofReal returns b-a rather than 0).",
+    "mathContext": "$\\int_{\\mathbb{R}} f = \\int_{[a,b]} \\frac{1}{b-a}\\,dx = \\operatorname{vol}([a,b]) \\cdot \\frac{1}{b-a} = (b-a)\\cdot\\frac{1}{b-a} = 1.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MeasureTheory.integral_indicator",
+      "MeasureTheory.setIntegral_const",
+      "Real.volume_Icc",
+      "ENNReal.toReal_ofReal"
+    ],
+    "prerequisites": [
+      "Bochner integral",
+      "Lebesgue measure of an interval",
+      "ENNReal coercion"
+    ]
+  },
+  {
+    "id": "ann-entropy-integrand-collapse",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "hkey: the integrand f·ln f collapses to a constant indicator",
+    "content": "The hkey step proves the function pointwise identity (fun x => uniformPDF a b x * Real.log (uniformPDF a b x)) = Set.indicator (Set.Icc a b) (fun _ => (1/(b-a))·Real.log(1/(b-a))). The funext/by_cases split is the heart of the argument. On [a,b], the indicator evaluates to the constant 1/(b-a), so f·ln f = (1/(b-a))·ln(1/(b-a)). Off [a,b], the indicator is 0, and the term becomes 0 · Real.log 0; this vanishes by zero_mul WITHOUT needing Real.log 0 to be defined — Lean's convention Real.log 0 = 0 is not even invoked here, since 0 multiplied by anything is 0. This is precisely the formal realization of the textbook 0·ln 0 = 0 convention that makes the off-support contribution disappear.",
+    "mathContext": "$f(x)\\ln f(x) = \\begin{cases} \\frac{1}{b-a}\\ln\\frac{1}{b-a}, & x \\in [a,b] \\\\ 0\\cdot\\ln 0 = 0, & x \\notin [a,b]\\end{cases} = \\left(\\tfrac{1}{b-a}\\ln\\tfrac{1}{b-a}\\right)\\mathbf{1}_{[a,b]}(x).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "0·ln 0 = 0 convention",
+      "Set.indicator_of_mem",
+      "Set.indicator_of_not_mem",
+      "zero_mul"
+    ],
+    "prerequisites": [
+      "funext",
+      "by_cases on set membership",
+      "Set.indicator"
+    ]
+  },
+  {
+    "id": "ann-entropy-main",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 53,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "uniformDifferentialEntropy: h(Uniform[a,b]) = ln(b-a)",
+    "content": "The main theorem evaluates differentialEntropy (uniformPDF a b) = Real.log (b-a). After collapsing the integrand via hkey, the hint step integrates the constant indicator: integral_indicator + setIntegral_const + Real.volume_Icc + ENNReal.toReal_ofReal give (b-a)·(1/(b-a))·ln(1/(b-a)). The Real.log_inv rewrite turns ln(1/(b-a)) into -ln(b-a), and mul_inv_cancel₀ hne cancels (b-a)·(1/(b-a)) to 1, leaving ∫ f·ln f = -ln(b-a). Finally unfolding differentialEntropy = -∫ f·ln f and applying neg_neg yields h = -(-ln(b-a)) = ln(b-a). The proof reuses the verified differentialEntropy definition imported from the parent file ShannonEntropyOQ01, so no new definitional machinery is introduced.",
+    "mathContext": "$h(f) = -\\int f\\ln f = -\\big[(b-a)\\cdot\\tfrac{1}{b-a}\\cdot\\ln\\tfrac{1}{b-a}\\big] = -\\ln\\tfrac{1}{b-a} = -(-\\ln(b-a)) = \\ln(b-a).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "differential entropy",
+      "Real.log_inv",
+      "mul_inv_cancel₀",
+      "neg_neg"
+    ],
+    "prerequisites": [
+      "differentialEntropy (parent definition)",
+      "MeasureTheory.setIntegral_const",
+      "Real.log_inv"
+    ]
+  },
+  {
+    "id": "ann-negative-entropy",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 53,
+      "endLine": 76
+    },
+    "type": "context",
+    "title": "Why h = ln(b-a) can be negative",
+    "content": "The closed form h = ln(b-a) exposes the single most counterintuitive feature of differential entropy: it is negative whenever b-a < 1, and tends to -∞ as the interval shrinks to a point. Discrete Shannon entropy H = -Σ p ln p is always ≥ 0 because each term -p ln p ≥ 0 for p ∈ [0,1]; differential entropy loses this guarantee because a density value 1/(b-a) can exceed 1, making ln f positive and the integrand negative. This is not a defect — differential entropy is only meaningful up to an additive constant under change of coordinates, and it is the relative quantity (KL divergence, mutual information) that is coordinate-invariant and nonnegative. The Uniform[a,b] family is the canonical witness used in every information-theory text to make this point.",
+    "mathContext": "$h(\\mathrm{Uniform}[a,b]) = \\ln(b-a) < 0 \\iff b-a < 1$, and $h \\to -\\infty$ as $b-a \\to 0^+$. Contrast discrete entropy $H \\ge 0$ always.",
+    "significance": "context",
+    "relatedConcepts": [
+      "negative differential entropy",
+      "discrete vs continuous entropy",
+      "coordinate dependence of differential entropy",
+      "KL divergence"
+    ],
+    "prerequisites": [
+      "Shannon entropy",
+      "differential entropy",
+      "natural logarithm"
+    ]
+  },
+  {
+    "id": "ann-uniform-nonneg",
+    "proofId": "shannon-entropy-oq-01-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "uniformPDF_nonneg: the density is nonnegative",
+    "content": "uniformPDF_nonneg establishes 0 ≤ uniformPDF a b x for every x, the second condition (alongside integrating to 1) for uniformPDF to be a valid probability density. The proof unfolds the indicator via Set.indicator_apply and splits on membership with split_ifs. Inside [a,b] the value is 1/(b-a), which positivity discharges using 0 < b-a (from a < b); outside, the value is exactly 0, handled by le_refl 0. Together with uniformPDF_integral_eq_one, this confirms uniformPDF is a legitimate density, justifying its use in the entropy computation.",
+    "mathContext": "$f(x) = \\frac{1}{b-a}\\mathbf{1}_{[a,b]}(x) \\ge 0$ for all $x$, since $1/(b-a) > 0$ when $a < b$ and $0 \\ge 0$ off the support.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Set.indicator_apply",
+      "positivity",
+      "probability density nonnegativity"
+    ],
+    "prerequisites": [
+      "Set.indicator",
+      "split_ifs",
+      "positivity tactic"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds the missing `annotations.json` for **shannon-entropy-oq-01-oq-01** (Differential Entropy of the Uniform[a,b] Distribution). The entry previously had only `meta.json` (no inline annotations), scoring 39 on the enrichment quality scale; this brings inline coverage to the full Lean file.

## What was added
- **6 annotations** spanning lines 37–86 of `Proofs/ShannonEntropyOQ01OQ01.lean`, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. `uniformPDF` — the Uniform[a,b] density encoded as a Lebesgue `Set.indicator`
  2. `uniformPDF_integral_eq_one` — density integrates to 1 (indicator → setIntegral_const → volume_Icc chain)
  3. `hkey` — integrand `f·ln f` collapses to a constant indicator; off-support `0·ln 0 = 0` via `zero_mul`
  4. `uniformDifferentialEntropy` — main result `h = ln(b-a)` via `Real.log_inv` + `mul_inv_cancel₀` + `neg_neg`
  5. Context: why `h = ln(b-a)` is **negative** for `b-a < 1` (discrete vs continuous entropy contrast)
  6. `uniformPDF_nonneg` — density nonnegativity

## Verification
- Both `annotations.json` and `meta.json` parse as valid JSON.
- Annotation line ranges lie within the 88-line source file and match the proof structure.
- Annotation schema mirrors the parent entry `shannon-entropy-oq-01/annotations.json`.
- `meta.json` `status: formalized`, `axiomCount: 0`, `sorries: 0` left unchanged (accurate; build pending per parent note).

No `loom:review-requested` label (math-agent enrichment PR — deployer merges directly).