### PR TITLE
research(erdos-998-oq-04): reduce three-gap theorem to one combinatorial core

### DIFF
--- a/proofs/Proofs/Erdos998ThreeGapOQ04.lean
+++ b/proofs/Proofs/Erdos998ThreeGapOQ04.lean
@@ -122,13 +122,9 @@ theorem orbit_card {α : ℝ} (hα : Irrational α) (N : ℕ) :
     exact (not_irrational_int z) hirr
   rw [orbit, Finset.card_image_of_injOn hinj, Finset.card_range]
 
-/-- **The Three-Gap (Three-Distance / Steinhaus) Theorem.**
-
-    For every irrational `α` and every `N ≥ 1`, the `N` arc lengths cut out of
-    the circle by the orbit `{0, {α}, …, {(N-1)α}}` take at most three distinct
-    values.
-
-    PROOF PATH (van Ravenstein / Sós, elementary):
+/-
+    PROOF PATH for the core classification `exists_gap_triple`
+    (van Ravenstein / Sós, elementary):
 
     1. Let `p` be the least index in `1 ≤ p < N` minimizing the *forward* return
        `{pα}` (the smallest clockwise gap at the point `0`), and `q` the least
@@ -153,9 +149,49 @@ theorem orbit_card {α : ℝ} (hα : Irrational α) (N : ℕ) :
     `Finset.exists_min_image`; the index arithmetic is `Nat`/`Finset.range`
     order theory only.  No new Mathlib infrastructure is required — only the
     case analysis above, which is the remaining work. -/
+/-- A finite set covered by an explicit triple `{a, b, c}` has at most three
+    elements.  Pure `Finset` cardinality arithmetic — the engine behind the
+    `≤ 3` bound once the gap lengths are classified. -/
+theorem card_le_three_of_subset_triple {s : Finset ℝ} {a b c : ℝ}
+    (h : s ⊆ ({a, b, c} : Finset ℝ)) : s.card ≤ 3 := by
+  have hc : ({a, b, c} : Finset ℝ).card ≤ 3 := by
+    have h1 := Finset.card_insert_le a ({b, c} : Finset ℝ)
+    have h2 := Finset.card_insert_le b ({c} : Finset ℝ)
+    have h3 : ({c} : Finset ℝ).card = 1 := Finset.card_singleton c
+    omega
+  exact le_trans (Finset.card_le_card h) hc
+
+/-- **Core combinatorial classification (Sós–Surányi–Świerczkowski /
+    van Ravenstein).**  This is the genuine mathematical content of the
+    three-gap theorem, isolated as a single statement.
+
+    There exist three real values `a, b, c` — the two "short" gaps `{pα}` and
+    `1 - {qα}` (where `p, q` are the Steinhaus first-return generators) and the
+    "long" gap `{pα} + (1 - {qα})` — such that
+
+      * every forward gap length is one of `a, b, c`  (the `⊆` part), and
+      * the long gap is the sum of the two short gaps  (`a + b = c`).
+
+    The `≤ 3` bound (`three_gap`) and the additive relation
+    (`three_gap_additive`) both follow from this lemma by pure finite
+    reasoning, so this is the sole remaining proof obligation.  The proof path
+    is the classification in step 2 of the docstring below: walk the orbit in
+    circular order and show each point's forward neighbour is reached by adding
+    `p` or `q` to its index. -/
+theorem exists_gap_triple (α : ℝ) (hα : Irrational α) {N : ℕ} (hN : 1 ≤ N) :
+    ∃ a b c : ℝ, a + b = c ∧ gapLengths α N ⊆ ({a, b, c} : Finset ℝ) := by
+  sorry
+
+/-- **The Three-Gap (Three-Distance / Steinhaus) Theorem.**
+
+    For every irrational `α` and every `N ≥ 1`, the `N` arc lengths cut out of
+    the circle by the orbit take at most three distinct values.  Reduced to the
+    combinatorial classification `exists_gap_triple` via the cardinality engine
+    `card_le_three_of_subset_triple`. -/
 theorem three_gap (α : ℝ) (hα : Irrational α) {N : ℕ} (hN : 1 ≤ N) :
     (gapLengths α N).card ≤ 3 := by
-  sorry
+  obtain ⟨a, b, c, _, hsub⟩ := exists_gap_triple α hα hN
+  exact card_le_three_of_subset_triple hsub
 
 /-- **Additive structure of the three gaps.**  When three distinct gap lengths
     occur, one of them is the sum of the other two (hence equal to the largest).
@@ -165,6 +201,52 @@ theorem three_gap_additive (α : ℝ) (hα : Irrational α) {N : ℕ} (hN : 1 �
     (h3 : (gapLengths α N).card = 3) :
     ∃ a b c : ℝ, a ∈ gapLengths α N ∧ b ∈ gapLengths α N ∧ c ∈ gapLengths α N ∧
       a ≠ b ∧ a ≠ c ∧ b ≠ c ∧ a + b = c := by
-  sorry
+  obtain ⟨a, b, c, hsum, hsub⟩ := exists_gap_triple α hα hN
+  -- The triple has card ≤ 3, and since `gapLengths` (card 3) sits inside it,
+  -- equality of cardinalities forces `gapLengths = {a, b, c}`.
+  have hcard3 : ({a, b, c} : Finset ℝ).card ≤ 3 := by
+    have h1 := Finset.card_insert_le a ({b, c} : Finset ℝ)
+    have h2 := Finset.card_insert_le b ({c} : Finset ℝ)
+    have hs : ({c} : Finset ℝ).card = 1 := Finset.card_singleton c
+    omega
+  have heq : gapLengths α N = ({a, b, c} : Finset ℝ) :=
+    Finset.eq_of_subset_of_card_le hsub (by rw [h3]; exact hcard3)
+  have htc : ({a, b, c} : Finset ℝ).card = 3 := by rw [← heq]; exact h3
+  -- A three-element literal `{a, b, c}` forces the three entries pairwise
+  -- distinct: collapsing any pair drops the cardinality to ≤ 2.
+  -- A 2-element literal has card ≤ 2 (used to contradict `htc : card = 3`).
+  have pair_le : ∀ x y : ℝ, ({x, y} : Finset ℝ).card ≤ 2 := by
+    intro x y
+    have hx := Finset.card_insert_le x ({y} : Finset ℝ)
+    have hy : ({y} : Finset ℝ).card = 1 := Finset.card_singleton y
+    omega
+  have hab : a ≠ b := by
+    intro he
+    rw [he] at htc
+    have hcol : ({b, b, c} : Finset ℝ) = ({b, c} : Finset ℝ) := by
+      apply Finset.ext; intro x
+      simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+    rw [hcol] at htc
+    have := pair_le b c; omega
+  have hac : a ≠ c := by
+    intro he
+    rw [he] at htc
+    have hcol : ({c, b, c} : Finset ℝ) = ({b, c} : Finset ℝ) := by
+      apply Finset.ext; intro x
+      simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+    rw [hcol] at htc
+    have := pair_le b c; omega
+  have hbc : b ≠ c := by
+    intro he
+    rw [he] at htc
+    have hcol : ({a, c, c} : Finset ℝ) = ({a, c} : Finset ℝ) := by
+      apply Finset.ext; intro x
+      simp only [Finset.mem_insert, Finset.mem_singleton]; tauto
+    rw [hcol] at htc
+    have := pair_le a c; omega
+  refine ⟨a, b, c, ?_, ?_, ?_, hab, hac, hbc, hsum⟩
+  · rw [heq]; simp
+  · rw [heq]; simp
+  · rw [heq]; simp
 
 end Erdos998ThreeGap

--- a/research/problems/erdos-998-oq-04/knowledge.md
+++ b/research/problems/erdos-998-oq-04/knowledge.md
@@ -124,3 +124,58 @@ open content is the single combinatorial gap-classification core (`three_gap`,
 `three_gap_additive`), with the documented van Ravenstein proof path. The ≤3
 distinct-lengths statement remains the first formal Lean statement of the
 three-gap/Steinhaus theorem.
+
+---
+
+## Session 2026-06-15 (Session 3) — Reduce both theorems to ONE core lemma
+
+**Mode**: REVISIT (FRESH claim of available problem) — **Outcome**: progress
+
+### What I Did
+Collapsed the two open obligations (`three_gap`, `three_gap_additive`) so they
+now depend on a **single** isolated combinatorial lemma, and proved all the
+surrounding finite-cardinality scaffolding.
+
+- Added `card_le_three_of_subset_triple : s ⊆ {a,b,c} → s.card ≤ 3` — pure
+  `Finset` arithmetic (`card_insert_le`/`card_singleton`/`card_le_card` + omega).
+  Fully proved, no sorry.
+- Introduced the core lemma `exists_gap_triple`:
+  `∃ a b c, a + b = c ∧ gapLengths α N ⊆ {a, b, c}`. This is the genuine
+  Sós–Surányi / van Ravenstein content (the two short gaps `{pα}`, `1−{qα}`
+  and the long gap `{pα}+(1−{qα})`), the SOLE remaining sorry.
+- `three_gap` now: `obtain` the triple, apply the card engine. No sorry.
+- `three_gap_additive` now fully derived from `exists_gap_triple`:
+  `Finset.eq_of_subset_of_card_le` forces `gapLengths = {a,b,c}` when card = 3;
+  pairwise distinctness comes from collapsing any pair to a ≤2-card set
+  (contradiction with card = 3); membership from `gapLengths = {a,b,c}`.
+  No sorry.
+
+### Key Findings
+- The whole theorem reduces to a **single set-containment statement** plus an
+  additive equation — a clean, self-contained Aristotle/Docker target. The
+  "≤ 3 distinct values" and "long = short + short" claims are NOT independent:
+  both fall out of `gapLengths ⊆ {a,b,c} ∧ a+b=c`.
+- Distinctness need not be hypothesized: given `card = 3` and a 3-element
+  superset literal, equality of finsets is forced, and the three witnesses are
+  automatically distinct.
+
+### Files Modified
+- `proofs/Proofs/Erdos998ThreeGapOQ04.lean` — added `card_le_three_of_subset_triple`,
+  `exists_gap_triple` (sorry), rewrote `three_gap` and `three_gap_additive` (both
+  now sorry-free, depending only on `exists_gap_triple`).
+
+### Sorry Ledger
+- Before: 2 sorries (`three_gap`, `three_gap_additive`), both HARD/combinatorial.
+- After: **1 sorry** (`exists_gap_triple`), the isolated classification core.
+
+### Next Steps
+1. Prove `exists_gap_triple` — define generators `p, q` via
+   `Finset.exists_min_image` on `range N`, then the successor/neighbour map.
+   Ideal single-lemma Aristotle target once the backend recovers (404 today).
+2. Build `Proofs.Erdos998ThreeGapOQ04` when Docker ≤ 2 containers to confirm the
+   new scaffolding compiles (build-blocked this cycle: 5 lean-build containers,
+   Aristotle 404).
+
+**progressSummary:** ATTACK. Net sorry count 2 → 1. Both headline theorems are
+now sorry-free, resting on one precisely-stated combinatorial core
+(`exists_gap_triple`). Build-pending (dual-backend blackout).


### PR DESCRIPTION
## Summary

Reduces the two open obligations of the **three-gap / three-distance (Steinhaus) theorem** (`erdos-998-oq-04`, supporting Erdős #998 / Kesten equidistribution) onto a **single** isolated combinatorial lemma, and proves all the surrounding finite-cardinality scaffolding sorry-free.

- **`card_le_three_of_subset_triple`** — `s ⊆ {a,b,c} → s.card ≤ 3`; pure `Finset` cardinality arithmetic. Proved, no sorry.
- **`exists_gap_triple`** — `∃ a b c, a + b = c ∧ gapLengths α N ⊆ {a,b,c}`. The genuine Sós–Surányi / van Ravenstein content (two short gaps `{pα}`, `1−{qα}`; long gap `{pα}+(1−{qα})`). **Sole remaining sorry.**
- **`three_gap`** — now derives from the card engine. Sorry-free.
- **`three_gap_additive`** — now fully derived from `exists_gap_triple`: `Finset.eq_of_subset_of_card_le` forces `gapLengths = {a,b,c}` at card 3, distinctness from collapse-to-pair, membership from the equality. Sorry-free.

**Net sorry count: 2 → 1.** Both headline theorems now rest on one precisely-stated combinatorial core — a clean single-lemma Aristotle/Docker target.

## Status

Build-pending: Docker was saturated (5 lean-build containers) and Aristotle returned 404 this cycle, so the new scaffolding has not been kernel-checked. Only standard, stable `Finset` lemmas are used (`card_insert_le`, `card_singleton`, `card_le_card`, `eq_of_subset_of_card_le`, `mem_insert`, `mem_singleton`, `ext`), name-checked against prior usage. File is unregistered in `Proofs.lean`, so this cannot break the gallery build.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos998ThreeGapOQ04` when Docker ≤ 2 containers
- [ ] Submit `exists_gap_triple` to Aristotle once the backend recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)