### PR TITLE
research(zsqrtd-neg-two-oq-03-oq-01): S2 — prove splitting steps 2-3 (θ²=-3, factorisation)

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean
@@ -46,11 +46,15 @@ Given (2), the main theorem is immediate: pick `z` with `N(z) = p`, write
 
 - `eisenstein_form_to_x_sq_add_three_y_sq` — proved (pure `ℤ`, `ring`-closed
   in each parity branch).
+- `eisensteinSqrtNegThree_sq` (`θ² = -3`) — proved (splitting step 2).
+- `ofInt_sub_sqrt_mul_add_sqrt` (`(c-θ)(c+θ) = c²+3`) — proved (splitting step 3).
 - `sq_add_three_sq_of_prime_one_mod_three` — proved **modulo** the single
   lemma `exists_eisenstein_norm_eq_prime`.
-- `exists_eisenstein_norm_eq_prime` — `sorry` (HARD splitting step;
-  documented plan inline; Aristotle/Docker both unavailable this session,
-  so build-pending and unverified).
+- `exists_eisenstein_norm_eq_prime` — `sorry` (HARD splitting step; the
+  remaining gap is now isolated to the UFD `prime ↔ irreducible` norm-split
+  extraction, steps 4–7, with the concrete algebra of steps 2–3 discharged
+  above; Aristotle/Docker both unavailable this session, so build-pending
+  and unverified).
 
 axiomCount: 0  ·  sorryCount: 1 (HARD, on `exists_eisenstein_norm_eq_prime`)
 -/
@@ -84,7 +88,53 @@ theorem eisenstein_form_to_x_sq_add_three_y_sq (a b : ℤ) :
     · -- a = 2m + 1, b = 2k + 1 (both odd)
       exact ⟨-m - k - 1, m - k, by subst hm; subst hk; ring⟩
 
-/-! ## Part II — Norm realisation (the splitting argument) -/
+/-! ## Part II — Norm realisation (the splitting argument)
+
+The two concrete algebraic ingredients of the splitting argument (steps 2 and 3
+of the plan below) are now proved as standalone lemmas; only the UFD
+`prime ↔ irreducible` extraction (steps 4–7) remains as the documented gap. -/
+
+/-- The Eisenstein `√-3`: `θ = 1 + 2ω = ⟨1, 2⟩`, satisfying `θ² = -3`.
+This is the algebraic bridge from the quadratic-reciprocity step
+`(-3 / p) = 1` to a divisibility statement in `ℤ[ω]`. -/
+def eisensteinSqrtNegThree : Eisenstein := ⟨1, 2⟩
+
+@[simp] theorem eisensteinSqrtNegThree_re : eisensteinSqrtNegThree.re = 1 := rfl
+@[simp] theorem eisensteinSqrtNegThree_im : eisensteinSqrtNegThree.im = 2 := rfl
+
+/-- **Splitting step 2 (proved).** `θ² = -3` in `ℤ[ω]`. Direct coordinate
+computation: `re = 1·1 - 2·2 = -3`, `im = 1·2 + 2·1 - 2·2 = 0`. -/
+theorem eisensteinSqrtNegThree_sq :
+    eisensteinSqrtNegThree * eisensteinSqrtNegThree = Eisenstein.ofInt (-3) := by
+  ext
+  · simp only [Eisenstein.mul_re, eisensteinSqrtNegThree_re, eisensteinSqrtNegThree_im,
+      Eisenstein.re_ofInt]
+    norm_num
+  · simp only [Eisenstein.mul_im, eisensteinSqrtNegThree_re, eisensteinSqrtNegThree_im,
+      Eisenstein.im_ofInt]
+    norm_num
+
+/-- **Splitting step 3 (proved).** The difference-of-squares factorisation in
+`ℤ[ω]` that turns the integer divisibility `p ∣ c² + 3` into a factored
+divisibility `p ∣ (c - θ)(c + θ)`:
+
+  `(ofInt c - θ) * (ofInt c + θ) = ofInt (c² + 3)`,
+
+since `(c - θ)(c + θ) = c² - θ² = c² - (-3) = c² + 3`. Proved by direct
+coordinate computation (no Eisenstein ring lemmas beyond the projections). -/
+theorem ofInt_sub_sqrt_mul_add_sqrt (c : ℤ) :
+    (Eisenstein.ofInt c - eisensteinSqrtNegThree) *
+        (Eisenstein.ofInt c + eisensteinSqrtNegThree)
+      = Eisenstein.ofInt (c ^ 2 + 3) := by
+  ext
+  · simp only [Eisenstein.mul_re, Eisenstein.sub_re, Eisenstein.sub_im,
+      Eisenstein.add_re, Eisenstein.add_im, Eisenstein.re_ofInt, Eisenstein.im_ofInt,
+      eisensteinSqrtNegThree_re, eisensteinSqrtNegThree_im]
+    ring
+  · simp only [Eisenstein.mul_im, Eisenstein.sub_re, Eisenstein.sub_im,
+      Eisenstein.add_re, Eisenstein.add_im, Eisenstein.re_ofInt, Eisenstein.im_ofInt,
+      eisensteinSqrtNegThree_re, eisensteinSqrtNegThree_im]
+    ring
 
 /-- **Splitting argument (HARD — remaining gap).** For a prime `p ≡ 1 (mod 3)`
 there is an Eisenstein integer whose norm is `p`.
@@ -95,13 +145,12 @@ Full proof plan (to be discharged by Aristotle / a future session):
    `legendreSym p (-3) = 1`, hence `∃ c : ℤ, c² ≡ -3 (mod p)`
    (`legendreSym.eq_one_iff'` / `ZMod.exists_sq_eq` style).
 
-2. Set `θ : Eisenstein := ⟨1, 2⟩ = 1 + 2ω`. A `decide`/`ring` computation on
-   coordinates gives `θ * θ = ofInt (-3)` (re: `1·1 - 2·2 = -3`,
-   im: `1·2 + 2·1 - 2·2 = 0`), i.e. `θ² = -3` in `ℤ[ω]`. So `√-3 = θ`.
+2. Set `θ := eisensteinSqrtNegThree = ⟨1, 2⟩ = 1 + 2ω`; **proved** above as
+   `eisensteinSqrtNegThree_sq : θ * θ = ofInt (-3)`, i.e. `θ² = -3`. So `√-3 = θ`.
 
-3. Then `p ∣ (c² + 3) = N(c + something)`; more precisely
-   `(ofInt c - θ) * (ofInt c + θ) = ofInt (c² + 3)` and `p ∣ c² + 3`.
-   Thus `p ∣ (ofInt c - θ)(ofInt c + θ)` in `ℤ[ω]`.
+3. Then `p ∣ c² + 3`, and **proved** above as `ofInt_sub_sqrt_mul_add_sqrt`,
+   `(ofInt c - θ) * (ofInt c + θ) = ofInt (c² + 3)`.
+   Hence `p ∣ (ofInt c - θ)(ofInt c + θ)` in `ℤ[ω]`.
 
 4. `p` does **not** divide either factor `ofInt c ∓ θ`: their `ω`-coordinates
    are `∓2`, and `p ∤ 2` (as `p ≡ 1 mod 3` forces `p ≥ 7`, in particular odd).

--- a/research/problems/zsqrtd-neg-two-oq-03-oq-01/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-03-oq-01/knowledge.md
@@ -53,3 +53,49 @@ Proof has two parts:
   steps 5–6.
 - Build is pending: local Docker saturated (6 lean-build containers on the 7.65GiB
   VM) and Aristotle down, so the file is UNVERIFIED. Deployer/Aristotle to build.
+
+## Session 2026-06-15 (S2, researcher-5) — ACT (decompose under blackout)
+
+**Mode**: CONTINUE · **Outcome**: progress (2 plan steps converted from prose to
+proved standalone lemmas; HARD sorry isolated to UFD-extraction core)
+
+### Infra state
+- Aristotle backend still **404** ("Resource not found") on a trivial probe — DOWN.
+- Docker **5** lean-build containers on the 7.65GiB VM — saturation edge; no build
+  window (a 6th leaf build risks OOMing the host). File remains build-pending.
+- Mathlib not checked out locally (Docker-only build); could not grep Mathlib for a
+  prebuilt `x²+3y²` lemma. Mathlib has the two-squares theorem but, to my knowledge,
+  no general `p ≡ 1 mod 3 → p = x²+3y²`, so no shortcut.
+
+### What I Did (build-free decomposition, role-doc STUCK strategy)
+Split the monolithic HARD `sorry` into concrete, hand-verified algebraic lemmas,
+using the parent's explicit struct definitions (no unverifiable Mathlib API):
+- `eisensteinSqrtNegThree : Eisenstein := ⟨1, 2⟩` (= θ = 1 + 2ω) + `@[simp]`
+  projection lemmas.
+- **`eisensteinSqrtNegThree_sq` (step 2, PROVED)**: `θ * θ = ofInt (-3)`. Coordinate
+  computation `re = 1·1 - 2·2 = -3`, `im = 1·2 + 2·1 - 2·2 = 0`
+  (`ext <;> simp only [mul_re/mul_im, proj] <;> norm_num`).
+- **`ofInt_sub_sqrt_mul_add_sqrt` (step 3, PROVED)**:
+  `(ofInt c - θ)(ofInt c + θ) = ofInt (c² + 3)` (difference of squares, since
+  `θ² = -3`). Coordinate `ring` after projection simp; verified `re = (c-1)(c+1) +
+  4 = c²+3`, `im = 0` by hand.
+Updated the inline plan + Status block to mark steps 2–3 done; remaining gap is now
+isolated to the UFD `prime ↔ irreducible` norm-split (steps 4–7).
+
+### Key Findings
+- The two algebraic ingredients of the splitting argument are **pure coordinate
+  computations** on the parent's `Mul`/`ofInt` definitions — no class-field or UFD
+  machinery — and are now de-risked/proved. The genuine difficulty is entirely the
+  UFD extraction (steps 4–7), the ideal isolated Aristotle target.
+- File is UNREGISTERED in `proofs/Proofs.lean` (explicit import list, not a glob),
+  so adding these unverified lemmas cannot break the gallery build.
+
+### Files Modified
+- proofs/Proofs/ZsqrtdNegTwoOQ03OQ01.lean (added 2 proved lemmas + θ def + simp
+  projections; updated docstrings/status)
+
+### Next Steps
+- Build `Proofs.ZsqrtdNegTwoOQ03OQ01` when Docker ≤ 2 to verify the 2 new lemmas
+  (and the whole file modulo the 1 sorry).
+- Submit `exists_eisenstein_norm_eq_prime` to Aristotle once the backend stops 404ing
+  — now a cleaner target since steps 2–3 are lemmas it can cite.


### PR DESCRIPTION
## Summary

Primes `p ≡ 1 (mod 3)` are represented by `x² + 3y²` (Fermat, n=3). The proof file
`ZsqrtdNegTwoOQ03OQ01.lean` reduces this to one HARD lemma
`exists_eisenstein_norm_eq_prime` (the Eisenstein splitting argument), previously a
single monolithic `sorry` with a 7-step prose plan.

This session **decomposes** that sorry by proving two of the plan steps as concrete,
standalone lemmas — pure coordinate computations on the parent `Proofs.Eisenstein`
struct, no UFD/class-field machinery:

- `eisensteinSqrtNegThree_sq` (step 2): `θ² = -3` for `θ = 1 + 2ω = ⟨1,2⟩`.
- `ofInt_sub_sqrt_mul_add_sqrt` (step 3): `(ofInt c - θ)(ofInt c + θ) = ofInt (c²+3)`
  (difference of squares), turning `p ∣ c²+3` into a factored divisibility in `ℤ[ω]`.

The remaining gap is now isolated to the UFD `prime ↔ irreducible` norm-split
(steps 4–7) — the ideal Aristotle target once the backend recovers.

## Status / honesty

- **Build-pending / UNVERIFIED this session**: Aristotle backend 404, Docker at
  saturation edge (5 containers on the 7.65GiB VM — no safe build window), and
  Mathlib is not checked out locally. The two new lemmas' arithmetic was verified by
  hand (re/im computations) but not machine-checked.
- The file is **unregistered** in `proofs/Proofs.lean` (explicit import list, not a
  glob), so this cannot break the gallery build.
- axiomCount: 0 · sorryCount: 1 (unchanged — the HARD splitting lemma).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ZsqrtdNegTwoOQ03OQ01` when Docker ≤ 2
      containers (verifies the 2 new lemmas + whole file modulo the 1 sorry).
- [ ] Submit `exists_eisenstein_norm_eq_prime` to Aristotle when the backend is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)