### PR TITLE
research(amgm-newton-girard): full Route-A proof of Finset Newton-Girard (build-pending)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean
@@ -36,8 +36,25 @@
       dependency on uncertain Mathlib API names.  Preferred if (A)'s bridging
       lemmas are absent.
 
-  Status: SURVEYED / ORIENT.  Statement of record below; proof deferred
-  (build infrastructure saturated, Aristotle backend unavailable this session).
+  Status: ACT (build-pending).  Route A executed below: the concrete recurrence
+  is obtained by applying `MvPolynomial.aeval (fun i : ↥s => f i.1)` to Mathlib's
+  universal Newton identity `MvPolynomial.mul_esymm_eq_sum`.  Confirmed Mathlib
+  v4.26.0 API used:
+    * `MvPolynomial.mul_esymm_eq_sum`              (RingTheory/.../Symmetric/NewtonIdentities)
+    * `MvPolynomial.aeval_esymm_eq_multiset_esymm` (RingTheory/.../Symmetric/Defs)
+    * `Finset.esymm_map_val`                       (RingTheory/.../Symmetric/Defs)
+    * `MvPolynomial.psum`, `MvPolynomial.aeval_X`
+    * `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`, `Finset.sum_range_succ`
+    * `Multiset.attach_map_val'`, `Finset.attach_val`, `Finset.sum_coe_sort`
+    * `Odd.neg_one_pow`
+  This file now carries a complete proof (no `sorry`), but is BUILD-PENDING /
+  UNVERIFIED: Docker pool saturated (5 containers) and Aristotle backend 404 on
+  2026-06-15, so it was never machine-checked.  A few steps are name-/normal-form
+  fragile and may need minor adjustment on first build, in particular:
+    - the `simp only [...] at key` aeval-transport normal form;
+    - `huniv : (univ : Finset ↥s) = s.attach := rfl` (Fintype-instance defeq);
+    - the `if_pos`/`lt_self_iff_false` reindex closing.
+  Do NOT mark the gallery entry `verified` until this compiles under Docker.
 -/
 
 import Mathlib
@@ -55,6 +72,44 @@ def psum (s : Finset ι) (f : ι → R) (k : ℕ) : R := ∑ i ∈ s, f i ^ k
 def esymm (s : Finset ι) (f : ι → R) (k : ℕ) : R :=
   ∑ T ∈ s.powersetCard k, ∏ i ∈ T, f i
 
+/-- **Power-sum bridge.**  `aeval` of the universal power sum `MvPolynomial.psum`
+    over the index subtype `↥s`, evaluated at `i ↦ f i`, is the concrete `psum s f`. -/
+theorem psum_bridge (s : Finset ι) (f : ι → R) (n : ℕ) :
+    MvPolynomial.aeval (fun i : ↥s => f i.1) (MvPolynomial.psum (↥s) R n) = psum s f n := by
+  rw [MvPolynomial.psum, map_sum, psum]
+  rw [← Finset.sum_coe_sort s (fun i => f i ^ n)]
+  exact Finset.sum_congr rfl (fun i _ => by rw [map_pow, MvPolynomial.aeval_X])
+
+/-- **Elementary-symmetric bridge.**  `aeval` of the universal elementary symmetric
+    polynomial `MvPolynomial.esymm` over `↥s`, evaluated at `i ↦ f i`, is the
+    concrete `esymm s f`. -/
+theorem esymm_bridge (s : Finset ι) (f : ι → R) (n : ℕ) :
+    MvPolynomial.aeval (fun i : ↥s => f i.1) (MvPolynomial.esymm (↥s) R n) = esymm s f n := by
+  rw [MvPolynomial.aeval_esymm_eq_multiset_esymm]
+  -- Goal: ((univ : Finset ↥s).val.map (fun i => f i.1)).esymm n = esymm s f n
+  have himg : (Finset.univ : Finset ↥s).val.map (fun i : ↥s => f i.1) = s.val.map f := by
+    -- `univ = s.attach` (Fintype instance for the coe-sort), then `attach_map_val'`.
+    have huniv : (Finset.univ : Finset ↥s) = s.attach := rfl
+    rw [huniv, Finset.attach_val, Multiset.attach_map_val']
+  rw [himg]
+  -- `Finset.esymm_map_val f s n : (s.val.map f).esymm n = ∑ t ∈ s.powersetCard n, ∏ i ∈ t, f i`
+  rw [Finset.esymm_map_val f s n]
+  rfl
+
+/-- The filtered universal-Newton sum over `antidiagonal k` reindexes onto `range k`. -/
+theorem reindex_filter (s : Finset ι) (f : ι → R) (k : ℕ) :
+    ∑ a ∈ (Finset.antidiagonal k).filter (fun a => a.1 < k),
+        (-1) ^ a.1 * esymm s f a.1 * psum s f a.2
+      = ∑ j ∈ Finset.range k, (-1) ^ j * esymm s f j * psum s f (k - j) := by
+  rw [Finset.sum_filter,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+        (fun a => if a.1 < k then (-1) ^ a.1 * esymm s f a.1 * psum s f a.2 else 0) k,
+      Finset.sum_range_succ]
+  simp only [lt_self_iff_false, if_false, add_zero]
+  apply Finset.sum_congr rfl
+  intro j hj
+  rw [if_pos (Finset.mem_range.mp hj)]
+
 /-- **Newton–Girard recurrence** (Finset / CommRing form).
 
     Note `esymm s f 0 = 1` (empty product over the unique 0-subset `∅`), so the
@@ -63,6 +118,18 @@ def esymm (s : Finset ι) (f : ι → R) (k : ℕ) : R :=
 theorem newton_girard (s : Finset ι) (f : ι → R) (k : ℕ) (hk : 1 ≤ k) :
     (∑ j ∈ Finset.range k, (-1) ^ j * esymm s f j * psum s f (k - j))
       + (-1) ^ k * (k : R) * esymm s f k = 0 := by
-  sorry
+  classical
+  -- Universal Newton identity over `↥s`, transported by the algebra map `aeval`.
+  have key := MvPolynomial.mul_esymm_eq_sum (↥s) R k
+  apply_fun (MvPolynomial.aeval (fun i : ↥s => f i.1)) at key
+  simp only [map_mul, map_pow, map_neg, map_one, map_natCast, map_sum,
+    esymm_bridge, psum_bridge] at key
+  rw [reindex_filter s f k] at key
+  -- `key : (k : R) * esymm s f k = (-1) ^ (k + 1) * (∑ j ∈ range k, (-1)^j e_j p_{k-j})`
+  have hsign : ((-1 : R)) ^ k * ((-1 : R)) ^ (k + 1) = -1 := by
+    rw [← pow_add, show k + (k + 1) = 2 * k + 1 by ring]
+    exact Odd.neg_one_pow ⟨k, by ring⟩
+  rw [mul_assoc ((-1 : R) ^ k) (k : R) (esymm s f k), key, ← mul_assoc, hsign, neg_one_mul]
+  ring
 
 end AmgmNewtonGirard

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-04.json
@@ -29,22 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT: precise Lean statement of record written (proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean); proof deferred (Docker saturated, Aristotle 404).",
+    "progressSummary": "PROGRESS (ACT, build-pending): full Route-A proof written with confirmed v4.26 API; 0 sorries; awaiting Docker verification.",
     "builtItems": [
-      "newton_girard statement + psum/esymm Finset defs in proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean (sorry on main thm)"
+      "newton_girard statement + psum/esymm Finset defs in proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean (sorry on main thm)",
+      "proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean: complete (0-sorry) proof attempt of newton_girard plus psum_bridge, esymm_bridge, reindex_filter. BUILD-PENDING/UNVERIFIED (Docker saturated, Aristotle 404)."
     ],
     "insights": [
       "Sign convention verified on s={a,b}: k=1 gives p1-e1=0; k=2 gives e0·p2 - e1·p1 + 2e2 = (x²+y²)-(x+y)²+2xy = 0.",
       "e_0 = 1 (empty product over the unique 0-subset), so the j=0 summand is exactly p_k; recurrence closes with the (-1)^k·k·e_k correction.",
-      "Two reductions: (A) aeval-specialize Mathlib MvPolynomial.mul_esymm_eq_sum over subtype {i//i∈s}; (B) self-contained induction on s via e_k(s∪{a})=e_k(s)+a·e_{k-1}(s)."
+      "Two reductions: (A) aeval-specialize Mathlib MvPolynomial.mul_esymm_eq_sum over subtype {i//i∈s}; (B) self-contained induction on s via e_k(s∪{a})=e_k(s)+a·e_{k-1}(s).",
+      "Route A is fully concrete in Mathlib v4.26.0: applying MvPolynomial.aeval (fun i:↥s => f i.1) to MvPolynomial.mul_esymm_eq_sum transports the universal Newton identity to the Finset/CommRing form. The esymm bridge is Finset.esymm_map_val composed with Multiset.attach_map_val (univ.val.map = s.val.map).",
+      "Sign closure: (k:R)·e_k = (-1)^(k+1)·S with S=∑_{j<k}(-1)^j e_j p_{k-j}; (-1)^k·(-1)^(k+1)=(-1)^(2k+1)=-1 via Odd.neg_one_pow, so S + (-1)^k·k·e_k = S - S = 0."
     ],
     "mathlibGaps": [
-      "Mathlib provides Newton identities only in the polynomial-root / universal MvPolynomial form (NewtonSums / MvPolynomial.NewtonIdentities); the directly-usable Finset/CommRing combinatorial layer (explicit finite family) is absent and must be bridged."
+      "Mathlib provides Newton identities only in the polynomial-root / universal MvPolynomial form (NewtonSums / MvPolynomial.NewtonIdentities); the directly-usable Finset/CommRing combinatorial layer (explicit finite family) is absent and must be bridged.",
+      "No Finset/CommRing-level Newton-Girard in Mathlib; only the universal MvPolynomial form (mul_esymm_eq_sum). Bridged here via aeval + esymm_map_val."
     ],
     "nextSteps": [
       "Route A: prove aeval (MvPolynomial.esymm) = esymm s f · and aeval (psum) = psum s f ·, then transport mul_esymm_eq_sum.",
       "Route B: induction on s; base s=∅ trivial, step uses e_k(s∪{a})=e_k(s)+a·e_{k-1}(s) and p_k(s∪{a})=p_k(s)+a^k.",
-      "Submit newton_girard to Aristotle when backend returns (known result, ideal proof-search target)."
+      "Submit newton_girard to Aristotle when backend returns (known result, ideal proof-search target).",
+      "Build Proofs.AmgmInequalityOQ02OQ01OQ04 under Docker ≤2 to verify; fragile spots flagged in file header (simp-at-key normal form, huniv rfl, reindex if_pos closing).",
+      "On a normal-form mismatch in the aeval-transport simp, submit the isolated helper to Aristotle when the 404 clears."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
- Completes the open question `amgm-inequality-oq-02-oq-01-oq-04`: the general Finset/CommRing **Newton–Girard recurrence** relating power sums `pₖ` and elementary symmetric functions `eₖ`.
- Mathlib supplies only the *universal* `MvPolynomial` form (`mul_esymm_eq_sum`). This PR transports it to the directly-usable concrete form by applying the algebra map `aeval (fun i : ↥s => f i)`.

## What's in the proof
- `psum_bridge` / `esymm_bridge` — `aeval` of `MvPolynomial.psum` / `esymm` over the index subtype `↥s` equals the concrete `psum s f` / `esymm s f`. Uses `aeval_X` + `Finset.sum_coe_sort`, and `aeval_esymm_eq_multiset_esymm` + `Multiset.attach_map_val'` + `Finset.esymm_map_val`.
- `reindex_filter` — the filtered `antidiagonal k` sum reindexes onto `range k`.
- `newton_girard` — `apply_fun aeval` to `mul_esymm_eq_sum`, simp-transport through the bridges, then close with the sign identity `(-1)^(2k+1) = -1` (`Odd.neg_one_pow`).

## Status: BUILD-PENDING / UNVERIFIED
The file has **0 `sorry`s**, but was **never machine-checked**: the Docker build pool was saturated (5 containers, OOM risk on this VM) and the Aristotle backend was returning 404 on 2026-06-15. A few steps are normal-form/name fragile and may need a minor adjustment on first build — flagged explicitly in the file header. **Do not mark the gallery entry `verified` until this compiles under Docker.**

The file is unregistered in `Proofs.lean`, so it does not affect the gallery build.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ04` (when Docker pool ≤2)
- [ ] If a normal-form mismatch appears in the aeval-transport `simp`, submit the isolated helper lemma to Aristotle once the backend recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)