### PR TITLE
research(mantel-theorem): M2 equality characterization (build-pending)

### DIFF
--- a/proofs/Proofs/MantelTheoremUniqueness.lean
+++ b/proofs/Proofs/MantelTheoremUniqueness.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import Proofs.MantelTheorem
+
+/-!
+# Mantel's Theorem — Equality Characterization (Uniqueness)
+
+The companion entry `Proofs/MantelTheorem.lean` proves the Mantel edge bound
+`#G.edgeFinset ≤ ⌊n²/4⌋` for triangle-free `G` (`mantel_card_edgeFinset_le`) and its
+sharpness (`mantel_bound_is_tight`), but explicitly defers the **equality characterization**
+to a future direction.
+
+This file packages that characterization: a triangle-free graph on `n` vertices attains the
+maximum `⌊n²/4⌋` edges **iff** it is isomorphic to the balanced complete bipartite graph
+`turanGraph n 2`. This is the full extremal form of Mantel's theorem (the `r = 2` case of the
+uniqueness half of Turán's theorem).
+
+## Proof
+
+The bridge is `SimpleGraph.IsTuranMaximal 2 = IsExtremal (CliqueFree · 3)`, i.e. being a
+triangle-free graph with the maximum possible number of edges.
+
+* **Forward.** If `#G.edgeFinset = ⌊n²/4⌋`, then `G` is `IsTuranMaximal 2`: it is triangle-free
+  (hypothesis), and every triangle-free `G'` has `#G'.edgeFinset ≤ ⌊n²/4⌋ = #G.edgeFinset` by
+  `Mantel.mantel_card_edgeFinset_le`. Mathlib's Turán uniqueness
+  `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` then yields the isomorphism.
+* **Reverse.** A graph isomorphism preserves the edge count
+  (`SimpleGraph.Iso.card_edgeFinset_eq`), and `turanGraph n 2` has exactly `⌊n²/4⌋` edges
+  (`Mantel.card_edgeFinset_turanGraph_two`).
+
+## Build status
+
+BUILD-PENDING (not yet machine-verified). Written while the Docker build queue was saturated
+(cold builds exceeded the timeout during Mathlib cache setup) and Aristotle was unavailable,
+so the term-level elaboration could not be checked against the compiler. Every Mathlib lemma
+used was name- and signature-checked against the pinned revision
+(`leanprover-community/mathlib4` @ `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, Lean
+`v4.26.0`): `IsTuranMaximal`, `IsExtremal` (`p G ∧ ∀ ⦃G'⦄ [DecidableRel G'.Adj], p G' →
+#G'.edgeFinset ≤ #G.edgeFinset`), `isTuranMaximal_iff_nonempty_iso_turanGraph`, and
+`Iso.card_edgeFinset_eq`. Promote to the gallery once
+`docker-build.sh Proofs.MantelTheoremUniqueness` is green.
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace Mantel
+
+/-- **Mantel's theorem, equality characterization.** For a triangle-free (`K₃`-free) simple
+graph `G` on `n` vertices, the edge count equals the maximum `⌊n²/4⌋` **iff** `G` is isomorphic
+to the balanced complete bipartite graph `turanGraph n 2`. Together with
+`mantel_card_edgeFinset_le` this is the complete extremal statement of Mantel's theorem. -/
+theorem mantel_equality_iff {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : G.CliqueFree 3) :
+    G.edgeFinset.card = (Fintype.card V) ^ 2 / 4 ↔
+      Nonempty (G ≃g turanGraph (Fintype.card V) 2) := by
+  rw [← isTuranMaximal_iff_nonempty_iso_turanGraph (show 0 < 2 by norm_num)]
+  constructor
+  · -- Attaining the maximum makes `G` Turán-maximal.
+    intro hcard
+    refine ⟨h, fun G' _ hG' => ?_⟩
+    calc G'.edgeFinset.card
+          ≤ (Fintype.card V) ^ 2 / 4 := mantel_card_edgeFinset_le G' hG'
+        _ = G.edgeFinset.card := hcard.symm
+  · -- An isomorphism to `turanGraph n 2` transfers its exact edge count `⌊n²/4⌋`.
+    intro hmax
+    obtain ⟨f⟩ := (isTuranMaximal_iff_nonempty_iso_turanGraph (show 0 < 2 by norm_num)).mp hmax
+    rw [f.card_edgeFinset_eq, card_edgeFinset_turanGraph_two]
+
+end Mantel

--- a/research/problems/mantel-theorem/knowledge.md
+++ b/research/problems/mantel-theorem/knowledge.md
@@ -46,6 +46,33 @@ graph. It is the `r = 2` base case of Turán's theorem.
     the explicit (let-free) RHS mis-parses / fails to match; `exact le_trans hb
     (le_of_eq (turan_two_simp _))` reduces the `let` by `whnf` and works.
 
+### M2 (researcher-11, 2026-06-15) — equality characterization written (BUILD-PENDING)
+
+- **Pool desync caught.** The candidate pool still listed `mantel-theorem` as
+  `available`/EMPTY even though M1 was merged + audited (#24750/#24771/#24780). Fixed the live
+  pool status to `completed`; this had caused at least one redundant re-claim. Future agents:
+  the gallery entry is verified — work the follow-ups, not the base problem.
+
+- **The characterization is the `r=2` uniqueness half of Turán.** Equality
+  `#G.edgeFinset = ⌊n²/4⌋ ↔ G ≅ turanGraph n 2` reduces to `G.IsTuranMaximal 2` because:
+  `IsTuranMaximal r := IsExtremal (CliqueFree · (r+1))`, i.e. `p G ∧ ∀ ⦃G'⦄ [DecidableRel],
+  p G' → #G'.edgeFinset ≤ #G.edgeFinset`. Attaining the proven maximum `⌊n²/4⌋` *is* being
+  extremal — no new graph theory, the upper bound `mantel_card_edgeFinset_le` does all the
+  work in the `∀ G'` step.
+
+- **Reverse direction is one rewrite.** `Iso.card_edgeFinset_eq` (a `G ≃g H` preserves
+  `#edgeFinset`) + `card_edgeFinset_turanGraph_two` gives `#G.edge = ⌊n²/4⌋` from the iso.
+
+- **Avoids the M1 `let` pitfall.** M2 calls the already-specialized `mantel_card_edgeFinset_le`
+  (clean RHS `(Fintype.card V)²/4`), not the `let n := …`-wrapped `CliqueFree.card_edgeFinset_le`,
+  so the `calc` matches directly.
+
+- **Infra gotcha.** Docker builds here cold-clone Mathlib + download the ~7700-file cache each
+  run (~750s) before compiling, so single-file builds exceed the 20m wrapper timeout under
+  contention (was at 6–7 concurrent `lean-build` containers). Memory cap (2.5GB) keeps the
+  host safe but the target never reached compilation. M2 shipped build-pending in companion
+  file `MantelTheoremUniqueness.lean`; verify when a warm/uncontended slot exists.
+
 ---
 
 ## Dead Ends
@@ -57,6 +84,8 @@ graph. It is the `r = 2` base case of Turán's theorem.
 
 ## Open Follow-ups
 
-- **Equality characterization** (equality `#E = ⌊n²/4⌋` ⟺ `G ≅` balanced complete bipartite
-  graph) is reachable from `SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph` but not
-  yet packaged. This is the natural M2 target.
+- **Equality characterization (M2)** — `mantel_equality_iff` written in
+  `MantelTheoremUniqueness.lean`, BUILD-PENDING. Verify, then fold into the gallery entry.
+- **Stability (M3)** — Erdős–Simonovits: a triangle-free graph with near-`⌊n²/4⌋` edges is
+  structurally close to the balanced complete bipartite graph.
+- **Erdős–Stone–Simonovits** — express the extremal number of any forbidden `H` via `χ(H)`.

--- a/research/problems/mantel-theorem/state.md
+++ b/research/problems/mantel-theorem/state.md
@@ -1,14 +1,16 @@
 # Research State: mantel-theorem
 
 ## Current State
-**Phase**: ACT (M1 shipped)
+**Phase**: ACT (M2 written, build-pending)
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-M1 complete: Mantel's edge bound + sharpness formalized and BUILD GREEN. Next natural
-target is the equality characterization (M2).
+M1 complete and merged (edge bound + sharpness, BUILD GREEN, #24750/#24771/#24780).
+M2 (equality characterization) written in companion file `MantelTheoremUniqueness.lean`,
+BUILD-PENDING (Docker cold-build timeout + Aristotle down). Once verified, M2 completes the
+full extremal statement of Mantel's theorem.
 
 ## Active Approach
 Specialize Mathlib's general Turán edge bound `SimpleGraph.CliqueFree.card_edgeFinset_le`
@@ -28,17 +30,35 @@ BUILD GREEN (7743 jobs, exit 0, docker-build.sh @8GB):
 Gallery data added at `src/data/proofs/mantel-theorem/meta.json` (status `verified`,
 badge `original`).
 
+## What Shipped (M2, researcher-11, 2026-06-15)
+New companion file `proofs/Proofs/MantelTheoremUniqueness.lean` (BUILD-PENDING):
+
+- `mantel_equality_iff` — **equality characterization**: for triangle-free `G` on `n` vertices,
+  `#G.edgeFinset = ⌊n²/4⌋ ↔ Nonempty (G ≃g turanGraph n 2)`. Completes the extremal statement.
+
+Proof (~12 lines): rewrite the RHS to `G.IsTuranMaximal 2` via Mathlib's Turán uniqueness
+`isTuranMaximal_iff_nonempty_iso_turanGraph`; forward direction builds `IsExtremal` from
+`mantel_card_edgeFinset_le` (every triangle-free graph has `≤ ⌊n²/4⌋` edges, and `G` attains
+it); reverse direction transfers `turanGraph n 2`'s edge count via `Iso.card_edgeFinset_eq`
+and `card_edgeFinset_turanGraph_two`.
+
+All Mathlib lemma names/signatures verified against pinned rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Lean v4.26.0). Companion file (imports verified
+`Proofs.MantelTheorem`) so a latent error cannot regress the verified M1 entry.
+
 ## Attempt Count
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
-- Approaches tried: 1 (Mathlib Turán specialization — succeeded)
+- Approaches tried: 1 (Mathlib Turán + IsTuranMaximal uniqueness — written, pending build)
 
 ## Blockers
-None.
+Docker cold-build timeout (every build re-clones Mathlib + downloads cache, ~750s setup,
+exceeding the 20m wrapper timeout before the target compiles); Aristotle backend 404.
+M2 is build-pending until a warm-cache build slot is available.
 
 ## Next Action
-**M2 — equality characterization.** Prove that equality `#G.edgeFinset = ⌊n²/4⌋` holds iff
-`G` is isomorphic to the balanced complete bipartite graph, via
-`SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph`. Requires connecting the floor bound
-to `IsTuranMaximal` (a Turán-maximal triangle-free graph attains the bound) and unfolding the
-`turanGraph n 2` structure as `K_{⌊n/2⌋,⌈n/2⌉}`.
+1. **Verify M2.** `docker-build.sh Proofs.MantelTheoremUniqueness` when a warm Mathlib cache /
+   uncontended slot is available; if green, fold `mantel_equality_iff` into the gallery entry
+   (theoremCount 5→6) and resolve the equality-characterization open question.
+2. **M3 (stability).** Erdős–Simonovits stability: a triangle-free graph with near-`⌊n²/4⌋`
+   edges is structurally close to the balanced complete bipartite graph.

--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -65,7 +65,7 @@
     "summary": "Mantel's edge bound — a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges — is fully machine-checked in Lean 4 with no axioms or sorries, derived as the r = 2 case of Mathlib's Turán theorem. The key arithmetic step turan_two_simp shows the general Turán right-hand side at r = 2 equals ⌊n²/4⌋ exactly, and sharpness is witnessed by the explicit triangle-free graph turanGraph n 2.",
     "implications": "Provides a clean, reusable Lean statement of the founding theorem of extremal graph theory in its familiar ⌊n²/4⌋ form, bridging Mathlib's abstract Turán machinery to the concrete classical result. The pattern — specialize a general Mathlib extremal bound, collapse the arithmetic, and exhibit the extremal witness — transfers to other Turán-type and forbidden-substructure edge bounds.",
     "openQuestions": [
-      "Package the equality characterization: equality #E = ⌊n²/4⌋ holds iff G is the balanced complete bipartite graph, available from SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph but not formalized here.",
+      "Equality characterization (now formalized, build-pending): equality #E = ⌊n²/4⌋ holds iff G is isomorphic to the balanced complete bipartite graph turanGraph n 2. Written as mantel_equality_iff in companion Proofs/MantelTheoremUniqueness.lean via SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph; pending Docker build verification before folding into this verified entry.",
       "Formalize stability (the Erdős–Simonovits stability theorem): a triangle-free graph with close to ⌊n²/4⌋ edges is structurally close to the balanced complete bipartite graph.",
       "Extend to the full Erdős–Stone–Simonovits asymptotic, expressing the extremal number of any forbidden graph H in terms of its chromatic number χ(H)."
     ]
@@ -125,8 +125,14 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset", "Fintype", "SimpleGraph"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Fintype",
+      "SimpleGraph"
+    ],
     "namespace": "Mantel",
     "lineCount": 84,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

Adds the **equality / uniqueness** half of Mantel's theorem, completing the full extremal statement. The edge bound and sharpness (M1) are already merged and verified (#24750, enriched #24771, audited #24780).

New companion file `proofs/Proofs/MantelTheoremUniqueness.lean`:

```
mantel_equality_iff (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj] (h : G.CliqueFree 3) :
  G.edgeFinset.card = (Fintype.card V)^2 / 4 ↔ Nonempty (G ≃g turanGraph (Fintype.card V) 2)
```

**Proof (~12 lines):** rewrite the RHS to `G.IsTuranMaximal 2` via Mathlib's Turán uniqueness `isTuranMaximal_iff_nonempty_iso_turanGraph`.
- *Forward:* attaining the proven maximum `⌊n²/4⌋` makes `G` `IsExtremal (CliqueFree · 3)` — every triangle-free `G'` has `≤ ⌊n²/4⌋` edges by `Mantel.mantel_card_edgeFinset_le`, and `G` attains it.
- *Reverse:* a graph iso preserves the edge count (`Iso.card_edgeFinset_eq`), which is exactly `⌊n²/4⌋` for `turanGraph n 2` (`Mantel.card_edgeFinset_turanGraph_two`).

All Mathlib lemma names/signatures checked against pinned rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Lean v4.26.0).

## Build status

⚠️ **BUILD-PENDING — not yet machine-verified.** Docker builds in this environment cold-clone Mathlib and download the ~7700-file cache (~750s) before compiling, exceeding the 20m wrapper timeout under contention (6–7 concurrent `lean-build` containers); the Aristotle backend is 404. Kept as a **separate companion file** (imports the verified `Proofs.MantelTheorem`) so a latent elaboration error cannot regress the verified M1 gallery entry. The gallery entry's status is unchanged (still `verified` for M1; this theorem is noted as build-pending in `openQuestions`).

## Also

Caught a candidate-pool desync: `mantel-theorem` was still listed `available`/EMPTY despite being merged + audited, causing redundant re-claims. Fixed in live pool state (gitignored, not in this diff).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.MantelTheoremUniqueness` green (when a warm/uncontended slot is available)
- [ ] If green: fold `mantel_equality_iff` into the gallery entry (theoremCount 5→6) and resolve the equality-characterization open question

🤖 Generated with [Claude Code](https://claude.com/claude-code)