### PR TITLE
research(sqrt2-minpoly-oq-01-oq-02): register prime-power radical minpoly ℚ(a^(1/pⁿ))=X^(pⁿ)−a

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2872,6 +2872,7 @@ import Proofs.Sqrt2Minpoly
 import Proofs.Sqrt2MinpolyOQ01
 import Proofs.Sqrt2MinpolyOQ01OQ02
 import Proofs.Sqrt2MinpolyOQ01OQ02OQ01
+import Proofs.Sqrt2MinpolyOQ01OQ02PrimePow
 import Proofs.Sqrt2MinpolyOQ02
 import Proofs.Sqrt2MinpolyOQ03
 import Proofs.Sqrt2OQ01

--- a/proofs/Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean
@@ -1,0 +1,132 @@
+import Mathlib
+
+open Polynomial IntermediateField
+
+set_option maxHeartbeats 800000
+
+/-
+# Minimal Polynomial of a Prime-Power-Degree Radical of a Rational
+
+**Open Question (follow-up to sqrt2-minpoly-oq-01-oq-02)**:
+
+The parent file `Sqrt2MinpolyOQ01OQ02` proves `minpoly ℚ (√r) = X² − r` for every
+nonnegative rational `r` that is not a rational square (the **degree-2** case).
+A companion file generalizes this to **odd-prime** degree, proving
+`minpoly ℚ (a^(1/p)) = X^p − a` for an odd prime `p` and a nonnegative rational `a`
+that is not a `p`-th power, via Mathlib's Kummer irreducibility criterion
+`X_pow_sub_C_irreducible_iff_of_prime_pow` specialized to exponent `n = 1`.
+
+This file pushes that criterion to its full strength. The same Mathlib lemma states,
+for an odd prime `p` and `n ≠ 0`,
+
+  `Irreducible (X ^ (p ^ n) − C a) ↔ ∀ b, b ^ p ≠ a`,
+
+so the criterion governs **every prime-power exponent** `p ^ n`, not just `p` itself.
+We use it to prove, for an odd prime `p`, an exponent `n ≥ 1`, and a nonnegative
+rational `a` that is not a `p`-th power,
+
+  `minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a`,
+
+together with the degree (`= pⁿ`) and field-extension (`[ℚ(a^(1/pⁿ)) : ℚ] = pⁿ`)
+corollaries. Setting `n = 1` recovers the odd-prime companion as the special case.
+
+## The Subtle Point
+
+The irreducibility hypothesis is `∀ b : ℚ, b ^ p ≠ a` — "`a` is not a `p`-th power" —
+and it is **independent of `n`**. It is *not* the weaker-looking condition "`a` is not
+a `pⁿ`-th power". Concretely, `X⁹ − 2` is irreducible over `ℚ` because `2` is not a
+**cube** (`p = 3`); whether `2` is a `9`-th power is never tested. Being a non-`p`-th
+power is exactly the obstruction for the whole tower of prime-power exponents.
+
+This is why the radical `a^(1/pⁿ)` has degree `pⁿ` over `ℚ` as soon as `a` avoids the
+single Diophantine condition `∀ b, b ^ p ≠ a`: the field `ℚ(a^(1/pⁿ))` is a degree-`pⁿ`
+extension with no intermediate "early collapse", in sharp contrast to composite
+exponents (`minpoly ℚ (4^(1/4)) = X² − 2`, since `X⁴ − 4 = (X² − 2)(X² + 2)`).
+
+## Mathematical Content
+
+The minimal polynomial is monic by definition, so the canonical answer is the monic
+`X^(pⁿ) − C a`. The proof is the standard "monic + irreducible + has the root ⟹ it is
+the minimal polynomial" argument (`minpoly.eq_of_irreducible_of_monic`):
+
+1. `a^(1/pⁿ)` is a root of `X^(pⁿ) − C a`: `(a^(1/pⁿ))^(pⁿ) = a^((1/pⁿ)·pⁿ) = a`
+   (real `rpow`, valid since `a ≥ 0`).
+2. `X^(pⁿ) − C a` is monic (`monic_X_pow_sub_C`, `pⁿ ≠ 0`).
+3. `X^(pⁿ) − C a` is irreducible over `ℚ` by `X_pow_sub_C_irreducible_iff_of_prime_pow`,
+   since `a` is not a `p`-th power.
+
+## Status: 0 sorries, 0 axioms. Build-pending (Docker pool saturated this session,
+3 lean-build containers on the 7.65 GB VM — building would risk OOM for peers). The
+argument is a verbatim adaptation of the machine-verified degree-2 / odd-prime proofs,
+replacing the exponent `p` with the prime power `pⁿ`; the only mathematical change is
+that the Kummer criterion is applied at general `n` rather than `n = 1`, so no
+`pow_one` rewrite is needed.
+-/
+
+namespace Sqrt2MinpolyOQ01OQ02PrimePow
+
+/-! ## Part I: The Radical is a Root of `X^N − C a` -/
+
+/-- For a nonnegative real `a` and `N ≠ 0`, the real `N`-th root `a^(1/N)` satisfies
+    `(a^(1/N))^N = a`. -/
+theorem rpow_inv_pow (a : ℝ) (ha : 0 ≤ a) (N : ℕ) (hN : N ≠ 0) :
+    (a ^ ((1 : ℝ) / N)) ^ N = a := by
+  have hN0 : (N : ℝ) ≠ 0 := by exact_mod_cast hN
+  rw [← Real.rpow_natCast (a ^ ((1 : ℝ) / (N : ℝ))) N, ← Real.rpow_mul ha]
+  rw [one_div, inv_mul_cancel₀ hN0, Real.rpow_one]
+
+/-- `X^N − C a` annihilates `a^(1/N)` over `ℚ`, for `a ≥ 0` a nonnegative rational. -/
+theorem aeval_rpow (a : ℚ) (ha : 0 ≤ a) (N : ℕ) (hN : N ≠ 0) :
+    (Polynomial.aeval ((a : ℝ) ^ ((1 : ℝ) / N))) (X ^ N - C a : ℚ[X]) = 0 := by
+  have ha' : (0 : ℝ) ≤ (a : ℝ) := by exact_mod_cast ha
+  have hAM : (algebraMap ℚ ℝ) a = (a : ℝ) := eq_ratCast (algebraMap ℚ ℝ) a
+  have hroot : ((a : ℝ) ^ ((1 : ℝ) / N)) ^ N = (a : ℝ) := rpow_inv_pow (a : ℝ) ha' N hN
+  simp only [map_sub, map_pow, aeval_X, aeval_C]
+  rw [hAM, hroot, sub_self]
+
+/-! ## Part II: The Minimal Polynomial -/
+
+/-- **Main Theorem**: for an odd prime `p`, an exponent `n ≥ 1`, and a nonnegative
+    rational `a` that is not a `p`-th power in `ℚ`,
+    `minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a`.
+
+    Generalizes the odd-prime companion `minpoly ℚ (a^(1/p)) = X^p − a` (its `n = 1`
+    case) to arbitrary prime-power degree. The irreducibility obstruction
+    `∀ b, b ^ p ≠ a` depends only on `p`, never on `n`. -/
+theorem minpoly_rpow_of_odd_prime_pow (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2)
+    (n : ℕ) (hn : n ≠ 0) (a : ℚ) (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / (p ^ n : ℕ))) = X ^ p ^ n - C a := by
+  have hN : p ^ n ≠ 0 := pow_ne_zero n hp.pos.ne'
+  have hmonic : (X ^ p ^ n - C a : ℚ[X]).Monic := monic_X_pow_sub_C a hN
+  have haeval : (Polynomial.aeval ((a : ℝ) ^ ((1 : ℝ) / (p ^ n : ℕ))))
+      (X ^ p ^ n - C a : ℚ[X]) = 0 :=
+    aeval_rpow a ha (p ^ n) hN
+  have hirr : Irreducible (X ^ p ^ n - C a : ℚ[X]) :=
+    (X_pow_sub_C_irreducible_iff_of_prime_pow (K := ℚ) hp hp2 hn).mpr hnp
+  exact (minpoly.eq_of_irreducible_of_monic hirr haeval hmonic).symm
+
+/-! ## Part III: Degree and Field-Extension Consequences -/
+
+/-- `a^(1/N)` is integral over `ℚ` for `a ≥ 0` and `N ≠ 0` (root of the monic
+    `X^N − C a`). -/
+theorem rpow_isIntegral (a : ℚ) (ha : 0 ≤ a) (N : ℕ) (hN : N ≠ 0) :
+    IsIntegral ℚ ((a : ℝ) ^ ((1 : ℝ) / N)) :=
+  ⟨X ^ N - C a, monic_X_pow_sub_C a hN, aeval_rpow a ha N hN⟩
+
+/-- The algebraic degree of `a^(1/pⁿ)` over `ℚ` is `pⁿ`, for odd prime `p`, `n ≥ 1`,
+    and `a` not a `p`-th power. -/
+theorem minpoly_rpow_natDegree (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2)
+    (n : ℕ) (hn : n ≠ 0) (a : ℚ) (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    (minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / (p ^ n : ℕ)))).natDegree = p ^ n := by
+  rw [minpoly_rpow_of_odd_prime_pow p hp hp2 n hn a ha hnp,
+    Polynomial.natDegree_X_pow_sub_C]
+
+/-- **Field Extension Degree**: `[ℚ(a^(1/pⁿ)) : ℚ] = pⁿ` for odd prime `p`, `n ≥ 1`,
+    and `a` not a `p`-th power. -/
+theorem adjoin_rpow_finrank (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2)
+    (n : ℕ) (hn : n ≠ 0) (a : ℚ) (ha : 0 ≤ a) (hnp : ∀ b : ℚ, b ^ p ≠ a) :
+    Module.finrank ℚ ℚ⟮(a : ℝ) ^ ((1 : ℝ) / (p ^ n : ℕ))⟯ = p ^ n := by
+  rw [IntermediateField.adjoin.finrank (rpow_isIntegral a ha (p ^ n) (pow_ne_zero n hp.pos.ne'))]
+  exact minpoly_rpow_natDegree p hp hp2 n hn a ha hnp
+
+end Sqrt2MinpolyOQ01OQ02PrimePow

--- a/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-01-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED: degree-2 (square root) result merged (#24789); odd-prime-degree generalization minpoly ℚ (a^(1/p))=X^p−a Docker-verified green (0 sorry/0 axiom, Kummer irreducibility) and registered in Proofs.lean (PR #24816).",
+    "progressSummary": "VERIFIED: degree-2 (square root) result merged (#24789); odd-prime-degree generalization minpoly ℚ (a^(1/p))=X^p−a Docker-verified green and registered (#24816). Prime-power generalization minpoly ℚ (a^(1/pⁿ))=X^(pⁿ)−a (odd prime p, n≥1) registered (Sqrt2MinpolyOQ01OQ02PrimePow.lean), 0 sorry/0 axiom; verbatim generalization of the green n=1 file via Kummer at general n (no pow_one rewrite). Build-pending deployer gate.",
     "builtItems": [
       "irrational_sqrt_of_not_isSquare_rat (Sqrt2MinpolyOQ01OQ02.lean:55)",
       "minpoly_sqrt_of_not_isSquare_rat — main theorem (Sqrt2MinpolyOQ01OQ02.lean:71)",
@@ -40,7 +40,10 @@
       "minpoly_rpow_of_odd_prime: minpoly ℚ (a^(1/p)) = X^p − a for odd prime p, a≥0 rational, ¬(p-th power) (Sqrt2MinpolyOQ01OQ02OQ01.lean:main)",
       "minpoly_rpow_natDegree (=p), rpow_isIntegral, adjoin_rpow_finrank ([ℚ(a^(1/p)):ℚ]=p) corollaries (Sqrt2MinpolyOQ01OQ02OQ01.lean)",
       "rpow_inv_pow: (a^(1/p))^p = a for a≥0 real (Real.rpow_mul + inv_mul_cancel₀)",
-      "Docker-verified GREEN build (7743 jobs) of Proofs.Sqrt2MinpolyOQ01OQ02OQ01 (registered in Proofs.lean): minpoly_rpow_of_odd_prime + degree/finrank corollaries, 0 sorry / 0 axiom"
+      "Docker-verified GREEN build (7743 jobs) of Proofs.Sqrt2MinpolyOQ01OQ02OQ01 (registered in Proofs.lean): minpoly_rpow_of_odd_prime + degree/finrank corollaries, 0 sorry / 0 axiom",
+      "minpoly_rpow_of_odd_prime_pow: minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for odd prime p, n≥1, a≥0 rational, ¬(p-th power) (Sqrt2MinpolyOQ01OQ02PrimePow.lean); n=1 recovers the odd-prime companion",
+      "minpoly_rpow_natDegree (=pⁿ), rpow_isIntegral, adjoin_rpow_finrank ([ℚ(a^(1/pⁿ)):ℚ]=pⁿ) corollaries at general prime-power exponent (Sqrt2MinpolyOQ01OQ02PrimePow.lean)",
+      "rpow_inv_pow / aeval_rpow stated at general exponent N (generic N-th root machinery, reused for the pⁿ case)"
     ],
     "insights": [
       "For a rational radicand r, irrationality of √r is direct: a rational value s of √r squares to r, exhibiting r as a rational square. No irrational_nrt_of_notint_nrt needed (unlike the natural-number case).",
@@ -48,14 +51,16 @@
       "The degree argument (monic divisor of monic degree-2) transfers verbatim from the verified Sqrt2MinpolyOQ01 Part VII with radicand type ℕ → ℚ.",
       "algebraMap ℚ ℝ r must be identified with (r : ℝ) via eq_ratCast inside aeval simp normal forms.",
       "Follow-up (k-th roots): for COMPOSITE k, minpoly ℚ (a^(1/k)) = X^k − a is FALSE (X⁴−4=(X²−2)(X²+2)); the clean statement is prime-degree only.",
-      "Mathlib has NO plain-prime X^p−C a irreducibility lemma; the usable one is X_pow_sub_C_irreducible_iff_of_prime_pow (requires p≠2, i.e. ODD prime). The p=2 case is exactly this parent file (¬IsSquare route)."
+      "Mathlib has NO plain-prime X^p−C a irreducibility lemma; the usable one is X_pow_sub_C_irreducible_iff_of_prime_pow (requires p≠2, i.e. ODD prime). The p=2 case is exactly this parent file (¬IsSquare route).",
+      "Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow governs ALL prime-power exponents pⁿ (n≥1), not just p; the irreducibility obstruction ∀b, b^p≠a is independent of n. X⁹−2 is irreducible because 2 is not a CUBE, not because it is not a 9th power.",
+      "Prime-power proof is the odd-prime proof with exponent p→pⁿ; at general n NO pow_one rewrite is needed (#24816 needed it only because it specialized to n=1) — the pⁿ statement is actually cleaner."
     ],
     "mathlibGaps": [
       "Mathlib has no direct minpoly-of-rational-square-root lemma; built from minpoly.dvd + irrationality + monic-divisor uniqueness."
     ],
     "nextSteps": [
-      "Build/register Sqrt2MinpolyOQ01OQ02OQ01.lean when Docker pool ≤2 containers (currently saturated at 3 on 7.65GB VM).",
-      "Add a concrete odd-prime example, e.g. minpoly ℚ (2^(1/3)) = X³−2, by proving ∀ b:ℚ, b³≠2 (rational-root / irrationality of cbrt 2).",
+      "Confirm the deployer's green build of Proofs.Sqrt2MinpolyOQ01OQ02PrimePow (now registered); a leaf build was not run this session (Docker pool saturated at 7 containers).",
+      "Add a concrete prime-power example, e.g. minpoly ℚ (2^(1/9)) = X⁹−2, by proving ∀ b:ℚ, b³≠2 (the obstruction is non-CUBE, independent of the exponent 9).",
       "Prove ℚ(√(p/q)) = ℚ(√(pq)) to reduce rational-radicand quadratic fields to squarefree-integer generators."
     ],
     "markdown": "# Knowledge Base: sqrt2-minpoly-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Generalizes the merged-and-green odd-prime companion (#24816, the **n=1** case) to **arbitrary prime-power exponent**. For an odd prime `p`, `n ≥ 1`, and a nonnegative rational `a` that is not a `p`-th power:

- `minpoly_rpow_of_odd_prime_pow`: `minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a`
- `minpoly_rpow_natDegree`: degree `= pⁿ`
- `adjoin_rpow_finrank`: `[ℚ(a^(1/pⁿ)) : ℚ] = pⁿ`

**0 sorries, 0 axioms.** Setting `n=1` recovers the odd-prime companion.

The irreducibility obstruction `∀b, b^p ≠ a` is **independent of `n`**: `X⁹−2` is irreducible because `2` is not a *cube* (`p=3`), never because it is not a 9th power. Proof is a verbatim adaptation of the green n=1 file via Kummer's `X_pow_sub_C_irreducible_iff_of_prime_pow` at general `n` — actually *cleaner*, since stating everything in `p^n` natively avoids the n=1 file's `pow_one` rewrite.

## Relationship to #24818
This **supersedes** the conflicting (CONFLICTING/DIRTY) #24818 by:
- basing on current `main` (resolves the tracker-json conflict),
- **registering** the file in `Proofs.lean` (#24818 left it unregistered, so it was never built/verified),
- reconciling the research json, which already records the merged n=1 result.

## Verification
Docker pool was saturated (7 containers) this session, so no leaf build was run; the deployer build-gate verifies before merge. Every lemma used in the new file appears in the **Docker-verified-green** n=1 file `Sqrt2MinpolyOQ01OQ02OQ01.lean`, and the only structural change (dropping `pow_one`) simplifies the proof.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — research json valid
- [x] All lemma names cross-checked against the merged green n=1 file
- [ ] Deployer green aggregate build (gates merge)