### PR TITLE
research(erdos-277-oq-02): prime-power non-vacuity toolkit + elementary induction

### DIFF
--- a/proofs/Proofs/Erdos277PrimePowerAristotle.lean
+++ b/proofs/Proofs/Erdos277PrimePowerAristotle.lean
@@ -1,0 +1,107 @@
+/-
+  Erdős Problem #277 — Prime-power non-vacuity (companion / Aristotle targets)
+
+  See `Erdos277Problem.lean` for the main formalization. That file establishes
+  non-vacuity of the corrected `ErdosQuestion277` for `n = 1`
+  (`no_proper_covering_one`) and for every prime `n = p` (`no_proper_covering_prime`):
+  these are values of `n` that admit **no** proper covering (distinct divisor
+  moduli, each `> 1`), so they witness that the negation in the Erdős question is
+  not vacuous.
+
+  This file extends that line to **all prime powers** `n = p^k`, `k ≥ 1`.
+
+  ## Why every prime power blocks a proper covering
+
+  A proper covering of `p^k` uses congruences whose moduli are **distinct**
+  divisors of `p^k`, each `> 1`. The divisors of `p^k` greater than `1` are
+  exactly `p, p^2, …, p^k`, so the moduli are distinct powers `p^j`,
+  `1 ≤ j ≤ k`. There are two standard ways to see no such covering exists:
+
+  * **Density.** The reciprocal sum of the moduli is
+    `∑ 1/p^{j} ≤ 1/p + … + 1/p^k = (1 - p^{-k})/(p-1) < 1`,
+    while any covering system of ℤ has reciprocal sum `≥ 1`.
+
+  * **Elementary induction on `k`** (used in the proof sketch below, needs no
+    density theory). Base case `k = 1` is `no_proper_covering_prime`. For the
+    step, split on whether the top modulus `p^k` actually occurs:
+      - If it does not, every modulus divides `p^{k-1}`, so `S` is a proper
+        covering of `p^{k-1}` — contradiction by the induction hypothesis.
+      - If it does, let `c₀` be the unique congruence with modulus `p^k` and
+        set `S' = S.erase c₀`. Every modulus in `S'` divides `p^{k-1}`, so the
+        set of integers covered by `S'` is **periodic with period `p^{k-1}`**
+        (`covers_add_of_dvd`). If some `x` is uncovered by `S'`, then `S` covers
+        it only via `c₀`, i.e. `x ≡ c₀.residue (mod p^k)`; but `x + p^{k-1}` is
+        also uncovered by `S'` (periodicity), hence also `≡ c₀.residue (mod p^k)`
+        — forcing `p^k ∣ p^{k-1}`, impossible. So `S'` already covers ℤ. If
+        `S' = ∅` then `S = {c₀}` is a single congruence with modulus `p^k ≥ 2`,
+        which misses `c₀.residue + 1` (`single_congruence_not_covering`); else
+        `S'` is a proper covering of `p^{k-1}` — contradiction by induction.
+
+  The three supporting lemmas below (`single_congruence_not_covering`,
+  `covers_add_of_dvd`, `proper_modulus_is_prime_pow`) are the reusable toolkit
+  for the elementary argument; they are proved here. The headline theorem
+  `no_proper_covering_prime_power` is stated with `sorry` as an Aristotle /
+  build-pending target (Docker + Aristotle were unavailable at authoring time).
+-/
+
+import Mathlib
+import Proofs.Erdos277Problem
+
+namespace Erdos277
+
+/-- A single congruence with modulus `≥ 2` never covers `ℤ`: it misses
+    `c.residue + 1`. (Pulled out of `no_proper_covering_prime`; reusable.) -/
+theorem single_congruence_not_covering (c : Congruence) (hm : c.modulus ≥ 2) :
+    ¬ c.covers (c.residue + 1) := by
+  intro h
+  simp only [Congruence.covers] at h
+  have hmeq : (c.residue + 1) ≡ c.residue [ZMOD (c.modulus : ℤ)] := h
+  have hdvd1 : (c.modulus : ℤ) ∣ 1 := by
+    have hh : (c.modulus : ℤ) ∣ c.residue - (c.residue + 1) := Int.ModEq.dvd hmeq
+    have heq : c.residue - (c.residue + 1) = -1 := by ring
+    rw [heq] at hh
+    exact (dvd_neg).mp hh
+  have hle : (c.modulus : ℤ) ≤ 1 := Int.le_of_dvd one_pos hdvd1
+  have h2 : (c.modulus : ℤ) ≥ 2 := by exact_mod_cast hm
+  omega
+
+/-- The set of integers a congruence covers is invariant under shifting by any
+    multiple of its modulus: if `c.modulus ∣ d` and `c` covers `x`, then `c`
+    covers `x + d`. This makes the covered-set of a family of congruences whose
+    moduli all divide `d` periodic with period `d`. -/
+theorem covers_add_of_dvd (c : Congruence) (x d : ℤ)
+    (hdvd : (c.modulus : ℤ) ∣ d) (h : c.covers x) : c.covers (x + d) := by
+  simp only [Congruence.covers] at h ⊢
+  obtain ⟨t, rfl⟩ := hdvd
+  rw [Int.add_mul_emod_self_left]
+  exact h
+
+/-- A modulus that is a divisor of `p^k` exceeding `1` is itself a positive
+    power of `p`: `m = p^j` with `1 ≤ j ≤ k`. This is the structural fact that
+    pins the moduli of a proper covering of `p^k` to the chain `p, p², …, pᵏ`. -/
+theorem proper_modulus_is_prime_pow (p k : ℕ) (hp : p.Prime)
+    (m : ℕ) (hm1 : m > 1) (hmd : m ∣ p ^ k) :
+    ∃ j, 1 ≤ j ∧ j ≤ k ∧ m = p ^ j := by
+  obtain ⟨j, hjk, hmj⟩ := (Nat.dvd_prime_pow hp).mp hmd
+  refine ⟨j, ?_, hjk, hmj⟩
+  rcases Nat.eq_zero_or_pos j with hj0 | hjpos
+  · subst hj0
+    simp only [pow_zero] at hmj
+    omega
+  · exact hjpos
+
+/-- **Prime-power non-vacuity (Aristotle / build-pending target).**
+    No prime power `p^k` (`k ≥ 1`) admits a proper covering with distinct
+    divisor moduli each `> 1`. This strengthens `no_proper_covering_prime`
+    (the `k = 1` case) and shows the corrected `ErdosQuestion277` is non-vacuous
+    on the infinite set of all prime powers.
+
+    Proof strategy (elementary induction on `k`): see the file header. The base
+    case is `no_proper_covering_prime`; the inductive step uses
+    `single_congruence_not_covering`, `covers_add_of_dvd`, and
+    `proper_modulus_is_prime_pow`. -/
+theorem no_proper_covering_prime_power (p k : ℕ) (hp : p.Prime) (hk : 1 ≤ k) :
+    ¬ HasProperCoveringWithDivisorModuli (p ^ k) := by
+  sorry
+
+end Erdos277

--- a/research/problems/erdos-277-oq-02/knowledge.md
+++ b/research/problems/erdos-277-oq-02/knowledge.md
@@ -1,0 +1,73 @@
+# erdos-277-oq-02 — Knowledge
+
+## Problem
+
+Erdős #277 (Haight 1979). Formalized in `proofs/Proofs/Erdos277Problem.lean`.
+`ErdosQuestion277`: for every `c > 0` there is `n` with `σ(n) > cn` but **no
+proper covering** of `n` — i.e. no covering system of ℤ whose moduli are
+**distinct divisors of `n`, each `> 1`** (`HasProperCoveringWithDivisorModuli`).
+
+The main result `erdos_277 := haight_theorem` is an **axiom** (Haight's 1979
+construction; a genuinely deep result, kept axiomatized — do not try to prove it
+from Mathlib).
+
+## State of the formalization
+
+- `haight_theorem` — deep axiom, stays. (This is the correct `axiomatized`
+  status per the project's Axiom Integrity Policy.)
+- Non-vacuity (witnesses `n` with no proper covering) is the productive vein:
+  - `no_proper_covering_one` — `n = 1` has no proper covering (only divisor is 1).
+  - `no_proper_covering_prime` — every prime `p` has none (single residue class
+    mod `p` misses `a + 1`).
+  - **NEW (this session):** target `no_proper_covering_prime_power` — every
+    prime power `p^k`, `k ≥ 1`, has none. Strictly generalizes the prime case;
+    shows non-vacuity on the infinite set of all prime powers.
+
+## Prime-power non-vacuity: elementary induction proof (no density theory)
+
+Divisors of `p^k` that are `> 1` are exactly `p, p², …, p^k`, so a proper
+covering of `p^k` uses **distinct** moduli `p^{j}`, `1 ≤ j ≤ k`. Induct on `k`.
+
+- **Base `k = 1`:** `no_proper_covering_prime`.
+- **Step.** Let `S` be a proper covering of `p^k`.
+  - If the top modulus `p^k` is **not** used, every modulus divides `p^{k-1}`,
+    so `S` is a proper covering of `p^{k-1}` → contradiction by IH.
+  - If `p^k` **is** used, it's used by a unique `c₀` (distinctness). Set
+    `S' = S.erase c₀`. Every modulus of `S'` divides `p^{k-1}`, so the set
+    covered by `S'` is **periodic with period `p^{k-1}`** (`covers_add_of_dvd`).
+    If some `x` is uncovered by `S'`, then `S` covers `x` only via `c₀`, so
+    `x ≡ c₀.residue (mod p^k)`; but `x + p^{k-1}` is *also* uncovered by `S'`
+    (periodicity), hence also `≡ c₀.residue (mod p^k)` — forcing
+    `p^k ∣ p^{k-1}`, impossible. So `S'` already covers ℤ. If `S' = ∅` then
+    `S = {c₀}`, a single congruence with modulus `p^k ≥ 2`, which misses
+    `c₀.residue + 1` (`single_congruence_not_covering`); otherwise `S'` is a
+    proper covering of `p^{k-1}` → contradiction by IH.
+
+This avoids the reciprocal-sum density theorem (`∑ 1/mᵢ ≥ 1` for covering
+systems), which is **not** in Mathlib.
+
+## Supporting lemmas (proved this session, build-pending)
+
+In `proofs/Proofs/Erdos277PrimePowerAristotle.lean` (UNREGISTERED companion):
+
+- `single_congruence_not_covering` — single congruence, modulus `≥ 2`, misses
+  `residue + 1`. (Mirrors verified code in `no_proper_covering_prime`.)
+- `covers_add_of_dvd` — if `c.modulus ∣ d` and `c` covers `x`, it covers `x + d`.
+  The periodicity engine for the induction. (Pure `Int.add_mul_emod_self_left`.)
+- `proper_modulus_is_prime_pow` — a divisor of `p^k` that is `> 1` equals `p^j`
+  with `1 ≤ j ≤ k`. (Via `Nat.dvd_prime_pow`.)
+
+Both Mathlib lemma names (`Int.add_mul_emod_self_left`, `Nat.dvd_prime_pow`)
+confirmed via Loogle. Not yet machine-checked: Docker was 7-container saturated
+(builds time out) and Aristotle backend was 404 at authoring time.
+
+## Next session
+
+1. Finish `no_proper_covering_prime_power` by the induction above — either
+   submit to Aristotle (when the backend recovers) or write the inductive
+   `Finset.erase` proof manually and build
+   `./proofs/scripts/docker-build.sh Proofs.Erdos277PrimePowerAristotle` when
+   Docker ≤ 2 containers.
+2. When green and 0-sorry, fold the three helpers + main theorem into
+   `Erdos277Problem.lean` and register if desired; bump `theoremCount`.
+3. Do **not** touch `haight_theorem` (deep axiom, correct status).


### PR DESCRIPTION
## Summary

Extends the **non-vacuity** vein of Erdős #277 (no proper covering with distinct divisor moduli, each `> 1`) from primes to **all prime powers** `p^k`. Builds directly on the merged `no_proper_covering_one` / `no_proper_covering_prime` (#24819).

New unregistered companion `proofs/Proofs/Erdos277PrimePowerAristotle.lean`:

- **`single_congruence_not_covering`** — a single congruence with modulus `≥ 2` misses `residue + 1` (extracted/reusable).
- **`covers_add_of_dvd`** — covered set is periodic under shifts by any multiple of the modulus; the periodicity engine for the induction (`Int.add_mul_emod_self_left`).
- **`proper_modulus_is_prime_pow`** — a `> 1` divisor of `p^k` equals `p^j`, `1 ≤ j ≤ k` (`Nat.dvd_prime_pow`).
- **`no_proper_covering_prime_power`** — headline theorem, stated as a build-pending / Aristotle target with a complete **elementary-induction** proof sketch in the docstring.

The induction reduces mod `p^{k-1}`: the covered set of the smaller moduli is periodic, so any point uncovered by them and its `p^{k-1}`-shift would both have to lie in the single `p^k`-residue class — impossible. This deliberately avoids the reciprocal-sum density theorem (`∑ 1/mᵢ ≥ 1`), which is not in Mathlib.

The deep axiom `haight_theorem` is untouched (correct `axiomatized` status).

## Verification status

- The three supporting lemmas are proved; both non-trivial Mathlib lemma names confirmed via Loogle.
- **Not machine-checked**: Docker was 7-container saturated (single-file builds time out) and the Aristotle backend returned 404 at authoring time. Headline theorem carries a `sorry`. File is **unregistered** (not in `Proofs.lean`), so the gallery build is unaffected.

## Test plan

- [ ] When Docker ≤ 2 containers: `./proofs/scripts/docker-build.sh Proofs.Erdos277PrimePowerAristotle` to verify the three helper lemmas compile.
- [ ] When Aristotle recovers (or Docker free): discharge `no_proper_covering_prime_power` via the documented induction, then fold into `Erdos277Problem.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)