### PR TITLE
research(quadratic-gauss-sum-square): prove g² = (-1)^((p-1)/2)·p, 0 sorries

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2753,6 +2753,7 @@ import Proofs.PythagoreanTriples
 import Proofs.PythagoreanTriplesOQ01
 import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
+import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticGaussSumSquare.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquare.lean
@@ -1,0 +1,75 @@
+/-
+  Square of the quadratic Gauss sum.
+
+  Target:  for an odd prime `p` and a primitive additive character
+  `ψ : ZMod p → ℂ`, the quadratic Gauss sum
+
+      g = ∑ n, (quadraticChar (ZMod p) n) · ψ n
+
+  satisfies  g² = (-1)^((p-1)/2) · p.
+
+  The whole result reduces to Mathlib's generic `gaussSum_sq`, specialised to the
+  ℂ-valued quadratic character of `ZMod p`, then evaluating the character at `-1`
+  and the field cardinality.
+
+  TYPING NOTE:
+    `quadraticChar (ZMod p) : MulChar (ZMod p) ℤ`  is ℤ-VALUED.
+    `gaussSum χ ψ` requires `χ : MulChar (ZMod p) F'` and `ψ : AddChar (ZMod p) F'`
+    in the SAME codomain `F'`. With `ψ` valued in ℂ we transport the character
+    along `ℤ → ℂ` via `MulChar.ringHomComp (Int.castRingHom ℂ)`.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace QuadraticGaussSumSquare
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- `ℂ`-valued quadratic character mod `p`, obtained from the integer-valued
+`quadraticChar (ZMod p)` by composing with the ring hom `ℤ → ℂ`. -/
+noncomputable def chiC (p : ℕ) [Fact p.Prime] : MulChar (ZMod p) ℂ :=
+  (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)
+
+/-- `chiC p` takes only the values `0, 1, -1` (it is a quadratic character). -/
+theorem chiC_isQuadratic : (chiC p).IsQuadratic :=
+  (quadraticChar_isQuadratic (ZMod p)).comp (Int.castRingHom ℂ)
+
+/-- The quadratic character is nontrivial for an odd prime: `Int.castRingHom ℂ` is
+injective (ℂ is `CharZero`), so `chiC p ≠ 1 ↔ quadraticChar (ZMod p) ≠ 1`, and the
+latter holds whenever `ringChar (ZMod p) = p ≠ 2`. -/
+theorem chiC_ne_one (hp : p ≠ 2) : chiC p ≠ 1 := by
+  have hchar : ringChar (ZMod p) ≠ 2 := by
+    rw [ZMod.ringChar_zmod_n]; exact hp
+  exact (MulChar.ringHomComp_ne_one_iff
+    ((Int.castRingHom ℂ).injective_int)).mpr (quadraticChar_ne_one hchar)
+
+/-- Value of the character at `-1`: classical first supplement to quadratic
+reciprocity, `quadraticChar (ZMod p) (-1) = (-1)^((p-1)/2)`, transported to ℂ. -/
+theorem chiC_neg_one (hp : p ≠ 2) :
+    chiC p (-1) = (-1 : ℂ) ^ ((p - 1) / 2) := by
+  have hpp : p.Prime := Fact.out
+  have hodd : Odd p := hpp.odd_of_ne_two hp
+  have hchar : ringChar (ZMod p) ≠ 2 := by
+    rw [ZMod.ringChar_zmod_n]; exact hp
+  have hq : quadraticChar (ZMod p) (-1) = (-1 : ℤ) ^ (p / 2) := by
+    rw [quadraticChar_neg_one hchar, ZMod.card p]
+    exact ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp hodd)
+  have hpe : p / 2 = (p - 1) / 2 := by
+    obtain ⟨k, rfl⟩ := hodd; omega
+  simp only [chiC, MulChar.ringHomComp_apply, hq, map_pow, map_neg, map_one]
+  rw [hpe]
+
+/-- **Square of the quadratic Gauss sum.** For an odd prime `p` and a primitive
+additive character `ψ : ZMod p → ℂ`,
+`gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) · p`.
+
+The whole result is `gaussSum_sq` specialised to the (transported) quadratic
+character, followed by evaluating the character at `-1` and the field cardinality. -/
+theorem gaussSum_quadratic_sq (hp : p ≠ 2)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ ^ 2 = (-1 : ℂ) ^ ((p - 1) / 2) * p := by
+  have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
+  rw [h, chiC_neg_one hp, ZMod.card p]
+
+end QuadraticGaussSumSquare

--- a/research/problems/quadratic-gauss-sum-square/knowledge.md
+++ b/research/problems/quadratic-gauss-sum-square/knowledge.md
@@ -1,0 +1,92 @@
+# Knowledge Base: quadratic-gauss-sum-square
+
+Target: for an odd prime `p` and a primitive additive character `ψ : ZMod p → ℂ`,
+the quadratic Gauss sum `g = ∑ n, (n/p) ψ(n)` satisfies `g² = (-1)^((p-1)/2) · p = p*`.
+
+---
+
+## Problem Understanding
+
+A **known theorem with strong Mathlib backing** — the work is formalization plumbing,
+not new mathematics. The square value (not the harder sign of `g` itself) is the
+target, which keeps it tractable.
+
+The clean route reduces everything to Mathlib's generic `gaussSum_sq`:
+
+```
+gaussSum_sq (hχ₁ : χ ≠ 1) (hχ₂ : IsQuadratic χ) (hψ : ψ.IsPrimitive) :
+    gaussSum χ ψ ^ 2 = χ (-1) * Fintype.card F
+```
+
+So the whole problem reduces to: instantiate `gaussSum_sq` at the quadratic character
+of `ZMod p`, then evaluate `χ(-1)` and `Fintype.card (ZMod p)`.
+
+---
+
+## Insights
+
+### The codomain/typing gotcha (resolved)
+
+`quadraticChar (ZMod p) : MulChar (ZMod p) ℤ` is **ℤ-valued**. `gaussSum χ ψ` requires
+`χ` and `ψ` to share a codomain `F'`. With `ψ : AddChar (ZMod p) ℂ`, the naive
+`gaussSum (quadraticChar (ZMod p)) ψ` **does not typecheck** (ℤ ≠ ℂ). Transport the
+character along `ℤ → ℂ`:
+
+```
+noncomputable def chiC : MulChar (ZMod p) ℂ :=
+  (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)
+```
+
+### The three leaf facts feeding `gaussSum_sq` — all closed this session
+
+1. **`chiC.IsQuadratic`** — `MulChar.IsQuadratic.comp`:
+   `(quadraticChar_isQuadratic (ZMod p)).comp (Int.castRingHom ℂ)`. One line, no `simp`.
+2. **`chiC ≠ 1`** (needs `p ≠ 2`) — `MulChar.ringHomComp_ne_one_iff` with the
+   injectivity of `Int.castRingHom ℂ` (`RingHom.injective_int`, ℂ is `CharZero`)
+   reduces it to `quadraticChar_ne_one`, which holds when `ringChar (ZMod p) = p ≠ 2`
+   (`ZMod.ringChar_zmod_n`).
+3. **`chiC (-1) = (-1)^((p-1)/2)`** — `quadraticChar_neg_one` gives
+   `quadraticChar (ZMod p) (-1) = χ₄ (Fintype.card (ZMod p))`; `ZMod.card` rewrites the
+   cardinality to `p`; `ZMod.χ₄_eq_neg_one_pow` (needs `p % 2 = 1`) gives `(-1)^(p/2)`;
+   then `p / 2 = (p-1)/2` for odd `p` (`omega` after `Odd` destructuring); finally
+   push the `ℤ → ℂ` cast with `map_pow`/`map_neg`/`map_one`.
+
+The main theorem body is exactly:
+```
+have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
+rw [h, chiC_neg_one hp, ZMod.card p]
+```
+
+---
+
+## Dead Ends / Avoided
+
+- **Direct double-sum (problem.md Approach B)** — unnecessary; `gaussSum_sq` already
+  encapsulates the `g·ḡ = p` orthogonality computation. Don't reimplement.
+- **Naive `gaussSum (quadraticChar (ZMod p)) ψ`** — type error (ℤ vs ℂ). Use `chiC`.
+- **`legendreSym.at_neg_one` chain** — works, but `quadraticChar_neg_one` packages the
+  `χ₄`-evaluation directly and is shorter.
+
+---
+
+## Verification Status
+
+Proof is **0-sorry, 0-axiom**. All Mathlib lemma names were confirmed against the
+pinned Mathlib source (rev `2df2f01`, v4.26.0):
+`gaussSum_sq`, `quadraticChar_isQuadratic`, `MulChar.IsQuadratic.comp`,
+`MulChar.ringHomComp_ne_one_iff`, `MulChar.ringHomComp_apply`, `RingHom.injective_int`,
+`quadraticChar_ne_one`, `quadraticChar_neg_one`, `ZMod.χ₄_eq_neg_one_pow`,
+`ZMod.ringChar_zmod_n`, `ZMod.card`, `Nat.Prime.odd_of_ne_two`.
+
+Promoted to `proofs/Proofs/QuadraticGaussSumSquare.lean` (registered in `Proofs.lean`).
+Docker build verification was pending at session end (build host saturated).
+
+---
+
+## Next Steps
+
+1. Confirm the green Docker build of `Proofs.QuadraticGaussSumSquare`, then flip the
+   gallery entry status to `verified`.
+2. Create the gallery entry `src/data/proofs/quadratic-gauss-sum-square/` with badge
+   `mathlib`, axiomCount 0, cross-referenced to `elementary-quadratic-reciprocity*`
+   (headline application: `g^p` two-ways gives reciprocity).

--- a/research/problems/quadratic-gauss-sum-square/state.md
+++ b/research/problems/quadratic-gauss-sum-square/state.md
@@ -1,0 +1,27 @@
+# State: quadratic-gauss-sum-square
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Iteration**: 3
+
+## Current Focus
+All three leaf facts feeding `gaussSum_sq` are proved (0 sorries, 0 axioms). The proof
+is promoted to `proofs/Proofs/QuadraticGaussSumSquare.lean` and registered in
+`Proofs.lean`.
+
+## Active Approach
+`gaussSum_sq`-based reduction via `chiC = (quadraticChar (ZMod p)).ringHomComp
+(Int.castRingHom ℂ)`, with `chiC_isQuadratic`, `chiC_ne_one`, `chiC_neg_one` discharged.
+
+## Attempt Count
+- Total attempts: 2
+- Approaches tried: 1 (gaussSum_sq reduction — succeeded)
+
+## Blockers
+None mathematical. Docker build verification pending (build host saturated this
+session). All Mathlib API names confirmed against pinned source rev `2df2f01`.
+
+## Next Action
+Confirm green build → flip status to `verified`, then create the gallery entry
+`src/data/proofs/quadratic-gauss-sum-square/` (badge `mathlib`, axiomCount 0).

--- a/src/data/research/problems/quadratic-gauss-sum-square.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square.json
@@ -1,0 +1,79 @@
+{
+  "slug": "quadratic-gauss-sum-square",
+  "title": "Square of the Quadratic Gauss Sum",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{For an odd prime } p \\text{ and a primitive } p\\text{-th root of unity } \\zeta_p,\\quad\ng = \\sum_{n=0}^{p-1} \\left(\\frac{n}{p}\\right) \\zeta_p^{\\,n},\\quad g^2 = (-1)^{(p-1)/2}\\,p.",
+    "plain": "Weight each residue $n$ by the Legendre symbol $(n/p)$ (which is $+1$ for squares, $-1$ for non-squares). The square of this Gauss sum equals $p^* = (-1)^{(p-1)/2} p$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) * p"
+    ],
+    "open": [],
+    "goal": "g^2 = (-1)^((p-1)/2) * p"
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-15T17:10:00-07:00",
+    "iteration": 3,
+    "focus": "All three leaf facts feeding gaussSum_sq are proved (0 sorries, 0 axioms); promoted to proofs/Proofs/QuadraticGaussSumSquare.lean.",
+    "activeApproach": "gaussSum_sq-based reduction via chiC = (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ).",
+    "blockers": [
+      "Docker build verification pending (build host saturated). No mathematical blocker."
+    ],
+    "nextAction": "Confirm green build, flip status to verified, create gallery entry.",
+    "attemptCounts": {
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: full 0-sorry 0-axiom proof of g^2 = (-1)^((p-1)/2)·p via gaussSum_sq; build-pending.",
+    "builtItems": [
+      "chiC : MulChar (ZMod p) ℂ — ℤ-valued quadratic character transported along Int.castRingHom ℂ (Proofs/QuadraticGaussSumSquare.lean)",
+      "chiC_isQuadratic via MulChar.IsQuadratic.comp (Proofs/QuadraticGaussSumSquare.lean)",
+      "chiC_ne_one via MulChar.ringHomComp_ne_one_iff + RingHom.injective_int + quadraticChar_ne_one (Proofs/QuadraticGaussSumSquare.lean)",
+      "chiC_neg_one : chiC p (-1) = (-1)^((p-1)/2) via quadraticChar_neg_one + ZMod.χ₄_eq_neg_one_pow (Proofs/QuadraticGaussSumSquare.lean)",
+      "gaussSum_quadratic_sq : gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) * p (Proofs/QuadraticGaussSumSquare.lean)"
+    ],
+    "insights": [
+      "quadraticChar (ZMod p) is ℤ-valued; gaussSum needs χ and ψ to share a codomain, so transport via MulChar.ringHomComp (Int.castRingHom ℂ).",
+      "The entire result reduces to Mathlib's gaussSum_sq; no need to reimplement the g·ḡ = p orthogonality computation.",
+      "quadraticChar_neg_one packages the χ₄ evaluation directly — shorter than the legendreSym.at_neg_one chain.",
+      "For odd p, p/2 = (p-1)/2 closes by omega after destructuring Odd p."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Confirm green Docker build of Proofs.QuadraticGaussSumSquare, then flip gallery status to verified.",
+      "Create gallery entry src/data/proofs/quadratic-gauss-sum-square/ (badge mathlib, axiomCount 0).",
+      "Cross-reference to elementary-quadratic-reciprocity* (headline application: g^p two-ways gives reciprocity)."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "gauss-sum",
+    "quadratic-reciprocity"
+  ],
+  "relatedProofs": [
+    "quadratic-reciprocity",
+    "elementary-quadratic-reciprocity"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.GaussSum",
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.Basic"
+    ]
+  },
+  "started": "2026-06-15T12:01:04-07:00",
+  "lastUpdate": "2026-06-15T17:10:00-07:00",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary
Completes the **Square of the Quadratic Gauss Sum** formalization: for an odd prime `p` and a primitive additive character `ψ : ZMod p → ℂ`,

$$g^2 = \left(\sum_n \left(\tfrac{n}{p}\right)\psi(n)\right)^2 = (-1)^{(p-1)/2}\,p = p^*.$$

The proof is **0 sorries, 0 axioms**, reducing entirely to Mathlib's generic `gaussSum_sq` specialised to the ℂ-valued quadratic character `chiC = (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)`.

The prior session left a build-ready skeleton with two `sorry` leaves; this PR fills them:

- **`chiC_isQuadratic`** — `MulChar.IsQuadratic.comp` (one line, replaces the prior `rcases … <;> simp`)
- **`chiC_ne_one`** — `MulChar.ringHomComp_ne_one_iff` + `RingHom.injective_int` (ℂ is `CharZero`) reduces to `quadraticChar_ne_one`, valid since `ringChar (ZMod p) = p ≠ 2`
- **`chiC_neg_one`** — `quadraticChar_neg_one` → `χ₄ (Fintype.card (ZMod p))`, `ZMod.card`, `ZMod.χ₄_eq_neg_one_pow` (needs `p % 2 = 1`), and `p/2 = (p-1)/2` for odd `p`

Promoted to `proofs/Proofs/QuadraticGaussSumSquare.lean` and registered in `Proofs.lean`.

All Mathlib lemma names were confirmed against the pinned Mathlib source (rev `2df2f01`, v4.26.0): `gaussSum_sq`, `quadraticChar_isQuadratic`, `MulChar.IsQuadratic.comp`, `MulChar.ringHomComp_ne_one_iff`, `MulChar.ringHomComp_apply`, `RingHom.injective_int`, `quadraticChar_ne_one`, `quadraticChar_neg_one`, `ZMod.χ₄_eq_neg_one_pow`, `ZMod.ringChar_zmod_n`, `ZMod.card`, `Nat.Prime.odd_of_ne_two`.

## Status
**Build-pending** — Docker build verification could not complete this session (build host saturated, 6 concurrent containers). The proof is API-verified but not yet machine-checked here; a follow-up should confirm the green build of `Proofs.QuadraticGaussSumSquare` and then create the gallery entry / flip status to `verified`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.QuadraticGaussSumSquare` (green)
- [ ] Create gallery entry `src/data/proofs/quadratic-gauss-sum-square/` (badge `mathlib`, axiomCount 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)