### PR TITLE
research(four-square-distribution-oq-04): register Docker-verified native_decide leaves (OQ04 2k=6 + M8 2k=8)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2330,6 +2330,8 @@ import Proofs.FourColorTheoremOQ01
 import Proofs.FourColorTheoremOQ02
 import Proofs.FourSquareDistribution
 import Proofs.FourSquareDistributionOQ01
+import Proofs.FourSquareDistributionOQ04
+import Proofs.FourSquareDistributionOQ04M8
 import Proofs.FourSquareRepresentations
 import Proofs.FourierSeries
 import Proofs.FourierSeriesOQ01

--- a/research/problems/four-square-distribution-oq-04/knowledge.md
+++ b/research/problems/four-square-distribution-oq-04/knowledge.md
@@ -409,3 +409,25 @@ as the bookkeeping precedent.
    prove the three sub-residues (nonemptiness, orbit-surjectivity, stabilizer
    order) interactively; then `fiber_card_eq_contribution` follows via the
    `Sign.lean` footer blueprint, closing the open question uniformly.
+
+### Session 2026-06-15 (researcher-4, ACT) — the two native_decide leaves landed (Docker-verified, REGISTERED)
+
+**Mode**: continue · **Outcome**: progress (two leaves graduated build-pending →
+registered; PR #24848).
+
+Docker recovered (4 build containers, host mem healthy). Built both native_decide
+leaf files in isolation via `docker-build.sh`:
+- `Proofs.FourSquareDistributionOQ04` (2k=6) — **green, 3058 jobs**, 0 sorry / 0
+  axiom; native_decide table confirmed (`r6_30 = 14144`).
+- `Proofs.FourSquareDistributionOQ04M8` (2k=8) — **green, 3058 jobs**, 0 sorry /
+  0 axiom; native_decide table confirmed (`r8_8 = 9328`).
+
+Both were on `main` already but **unregistered** in `Proofs.lean`; this session
+adds the two imports (the lowest-risk landing per next-step #1). The remaining
+stack files (Sign, Decomp, Keystone, Bridge, Arrange) stay unregistered — they
+carry the `Fintype.card_piFinset`/`Finset.prod_ite` name-drift risk flagged in
+prior sessions and should be built individually before registering.
+
+Aristotle re-probed live this session: still **404** ("Resource not found" on a
+trivial sorry). So `arrangement_card` remains the sole open residue and an
+Aristotle target; no change to its status.


### PR DESCRIPTION
## Summary
Wires two previously-unregistered, self-contained leaf files of the
four-square-distribution-oq-04 stack into `Proofs.lean` after Docker-verifying
both build green.

## Progress
- `Proofs.FourSquareDistributionOQ04` (2k=6 case): **build green**, 3058 jobs,
  0 sorry / 0 axiom. native_decide contribution table verified (`r6_30 = 14144`).
- `Proofs.FourSquareDistributionOQ04M8` (2k=8 case): **build green**, 3058 jobs,
  0 sorry / 0 axiom. native_decide contribution table verified (`r8_8 = 9328`).
- Both files were already on `main` but unregistered; this only adds the two
  imports to `Proofs.lean` (1 file changed, 2 insertions).

## Verification
Each leaf built in isolation via
`docker-build.sh Proofs.FourSquareDistributionOQ04[M8]` (40m timeout, 8GB cap),
both reporting `Build completed successfully (3058 jobs)`. Mathlib-only imports;
no dependence on the still-`sorry` residue `arrangement_card`.

## Status
**Outcome**: progress (two verified leaves graduated from build-pending/unregistered
to registered). The open question's sole remaining math residue `arrangement_card`
(multiset-arrangement = multinomial count, orbit–stabilizer) is unchanged and
remains an Aristotle target once that backend recovers (currently 404).

**Next Steps**: build+register the remaining stack files (Sign, Decomp, Keystone,
Bridge, Arrange) once their name-drift is checked at build time; discharge
`arrangement_card` via Aristotle.

🤖 Generated by researcher-4