### PR TITLE
research(minkowski-theorem-oq-03): sync gallery meta to verified after #24723 green build

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/meta.json
@@ -2,15 +2,16 @@
   "id": "minkowski-theorem-oq-03",
   "title": "Minkowski Bound on Ideal Norms: A Class-Number Estimate",
   "slug": "minkowski-theorem-oq-03",
-  "description": "Makes the geometry-of-numbers ⟹ ideal-norm bound connection explicit and draws new quantitative consequences. Packages the Minkowski bound M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K| (only a local notation in Mathlib) as a reusable definition, restates that every ideal class contains an integral ideal of norm ≤ M_K, and proves the new estimate classNumber K ≤ #{ ideals : absNorm ≤ ⌊M_K⌋ } — an explicit, computable head-count refining the bare finiteness of the class group. Derives from that head-count a PID criterion: if M_K < 2 then classNumber K = 1 (equivalently 𝓞 K is a principal ideal ring), recovered directly from the count rather than via the discriminant route. Build pending (worktree Docker cache unavailable); proofs reduce entirely to Mathlib lemmas name-checked at rev 2df2f0150c.",
+  "description": "Makes the geometry-of-numbers ⟹ ideal-norm bound connection explicit and draws new quantitative consequences. Packages the Minkowski bound M_K = (4/π)^{r₂}·(n!/nⁿ)·√|d_K| (only a local notation in Mathlib) as a reusable definition, restates that every ideal class contains an integral ideal of norm ≤ M_K, and proves the new estimate classNumber K ≤ #{ ideals : absNorm ≤ ⌊M_K⌋ } — an explicit, computable head-count refining the bare finiteness of the class group. Derives from that head-count a PID criterion: if M_K < 2 then classNumber K = 1 (equivalently 𝓞 K is a principal ideal ring), recovered directly from the count rather than via the discriminant route. Machine-verified via Docker (0 sorries, 0 axioms); proofs reduce entirely to Mathlib lemmas at rev 2df2f0150c.",
   "meta": {
-    "status": "formalized",
-    "badge": "wip",
+    "status": "verified",
+    "badge": "original",
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 1,
     "lineCount": 163,
+    "verifiedDate": "2026-06-15",
     "proofRepoPath": "Proofs/MinkowskiTheoremOQ03.lean",
     "tags": [
       "number-theory",
@@ -21,7 +22,7 @@
       "class-number",
       "geometry-of-numbers"
     ],
-    "assumptions": "Build pending: the worktree Docker olean cache is unavailable (circular .lake symlink) and Aristotle's MCP endpoint returned 'Resource not found', so the file has not been kernel-checked this session. The proofs contain 0 sorries and 0 axiom declarations, reducing entirely to existing Mathlib results (NumberField.exists_ideal_in_class_of_norm_le, Ideal.finite_setOf_absNorm_le₀, Nat.card_le_card_of_surjective, Nat.le_floor; for the PID criterion: Ideal.absNorm_pos_of_nonZeroDivisors, Ideal.absNorm_eq_one_iff, Nat.le_floor_iff, Nat.card_le_one, NumberField.classNumber_pos, NumberField.classNumber_eq_one_iff), all name-checked against the pinned Mathlib revision 2df2f0150c. Status will be promoted to verified once a green Docker build confirms the kernel check.",
+    "assumptions": "None. Machine-verified via Docker (green build, 7743 jobs, 0 sorries, 0 axioms; 2026-06-15, PR #24723) and registered in Proofs.lean. The proofs reduce entirely to existing Mathlib results (NumberField.exists_ideal_in_class_of_norm_le, Ideal.finite_setOf_absNorm_le₀, Nat.card_le_card_of_surjective, Nat.le_floor; for the PID criterion: Ideal.absNorm_pos_of_nonZeroDivisors, Ideal.absNorm_eq_one_iff, Nat.le_floor_iff, Nat.card_le_one, NumberField.classNumber_pos, NumberField.classNumber_eq_one_iff) at the pinned Mathlib revision 2df2f0150c.",
     "author": "Lean Genius Researcher",
     "dateAdded": "2026"
   },
@@ -55,7 +56,7 @@
       "title": "Header, Imports, and Namespace",
       "startLine": 1,
       "endLine": 58,
-      "summary": "Documents the geometry-of-numbers ⟹ ideal-norm bound connection and the build-pending status. Imports Mathlib and opens the nonZeroDivisors, Real, NumberField, Module, InfinitePlace, Ideal, and Nat namespaces to match Mathlib's ClassNumber.lean conventions."
+      "summary": "Documents the geometry-of-numbers ⟹ ideal-norm bound connection and the Docker-verified build status. Imports Mathlib and opens the nonZeroDivisors, Real, NumberField, Module, InfinitePlace, Ideal, and Nat namespaces to match Mathlib's ClassNumber.lean conventions."
     },
     {
       "id": "bound-def",

--- a/src/data/research/problems/minkowski-theorem-oq-03.json
+++ b/src/data/research/problems/minkowski-theorem-oq-03.json
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (build pending): named the Minkowski bound (minkowskiIdealBound), restated the ideal-norm bound, proved the new estimate classNumber K ≤ #{ideals of norm ≤ ⌊M_K⌋} (the class-number algorithm's backbone, not in Mathlib), and (S2) derived from it a PID criterion: M_K < 2 ⟹ classNumber K = 1 ⟹ 𝓞 K is a principal ideal ring, obtained directly from the head-count rather than via the discriminant route.",
+    "progressSummary": "VERIFIED + registered + gallery meta now synced. MinkowskiTheoremOQ03.lean (1 def, 5 theorems, 0 sorry/0 axiom) Docker-verified green (#24723, 7743 jobs) and registered in Proofs.lean; meta.json promoted formalized/wip -> verified/original this session. Headline: classNumber K <= #{ideals of absNorm <= floor(M_K)} plus the M_K<2 => PID criterion. Only open vein: concrete small-discriminant instantiation, gated on quadratic-field discriminant infra in Mathlib.",
     "builtItems": [
       "MinkowskiIdealBound.minkowskiIdealBound — reusable def of the Minkowski bound (MinkowskiTheoremOQ03.lean:60)",
       "MinkowskiIdealBound.minkowskiIdealBound_nonneg — bound ≥ 0 (MinkowskiTheoremOQ03.lean:65)",
@@ -57,7 +57,8 @@
       "The headline ideal-norm bound and class-group finiteness are already in Mathlib; the genuine new content is the explicit head-count classNumber ≤ #{ideals of bounded norm}.",
       "Counting step: the class-representative map from {ideals of norm ≤ ⌊M_K⌋} onto the class group is surjective (content of the Minkowski bound), and Nat.card_le_card_of_surjective converts this into the cardinality inequality.",
       "Real→ℕ collapse: absNorm I is a natural number bounded by the real M_K ≥ 0, so Nat.le_floor gives absNorm I ≤ ⌊M_K⌋, matching the natural-number-indexed finiteness lemma finite_setOf_absNorm_le₀.",
-      "PID criterion from the count (S2): when M_K < 2, ⌊M_K⌋₊ ≤ 1, and since every nonzero ideal has absNorm ≥ 1 with equality iff it is ⊤ (absNorm_pos_of_nonZeroDivisors + absNorm_eq_one_iff), the index subtype is a Subsingleton, so Nat.card ≤ 1 (Nat.card_le_one); chaining with the head-count and classNumber_pos forces classNumber = 1 by omega. This is the classical 'no class survives the Minkowski bound' PID test obtained directly from the head-count, not from the discriminant criterion isPrincipalIdealRing_of_abs_discr_lt."
+      "PID criterion from the count (S2): when M_K < 2, ⌊M_K⌋₊ ≤ 1, and since every nonzero ideal has absNorm ≥ 1 with equality iff it is ⊤ (absNorm_pos_of_nonZeroDivisors + absNorm_eq_one_iff), the index subtype is a Subsingleton, so Nat.card ≤ 1 (Nat.card_le_one); chaining with the head-count and classNumber_pos forces classNumber = 1 by omega. This is the classical 'no class survives the Minkowski bound' PID test obtained directly from the head-count, not from the discriminant criterion isPrincipalIdealRing_of_abs_discr_lt.",
+      "Meta-sync (researcher-3, 2026-06-15): the Docker green build from #24723 (7743 jobs, registered in Proofs.lean) updated the .lean banner + knowledge.md but NOT meta.json, leaving it stale at formalized/wip. Promoted meta.json to verified/original (verifiedDate 2026-06-15) and cleared the stale build-pending assumptions text — source was already machine-verified, only the gallery metadata lagged."
     ],
     "mathlibGaps": [
       "No reusable named definition of the Minkowski bound (Mathlib hides it as a local notation M K).",
@@ -65,9 +66,8 @@
       "No clean NumberField instance with computed discriminant for a concrete quadratic field, blocking a worked 'ℚ(√d) is a PID via the bound' example."
     ],
     "nextSteps": [
-      "Green Docker build to promote status to verified/original; if 'unfold; exact' fails on the restatement, try simpa only [minkowskiIdealBound] or massage the √|discr K| coercion.",
-      "Resubmit to Aristotle when its MCP endpoint recovers for an independent verified proof.",
-      "Concrete example: prove ℚ(√-1)/ℚ(√-3)/ℚ(√5) has class number 1 via isPrincipalIdealRing_of_abs_discr_lt once quadratic-field discriminant infrastructure exists."
+      "Concrete example: prove Q(sqrt-1)/Q(sqrt-3)/Q(sqrt5) class number 1 via the head-count once quadratic-field discriminant infrastructure exists in Mathlib.",
+      "Make the head-count executable: Ideal.finite_setOf_absNorm_le0 is non-constructive, so the bound certifies an enumeration suffices but does not yet give a decide-able classNumber for e.g. Q(sqrt-5)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Stale-meta sync. The Docker-verified green build in **#24723** (7743 jobs, 0 sorry / 0 axiom) registered `MinkowskiTheoremOQ03` in `Proofs.lean` and updated the `.lean` docstring banner + `knowledge.md`, but its diff **omitted `meta.json`** — so the gallery entry was left stale at `formalized`/`wip` with a "build pending" assumptions note, despite the source being machine-verified and registered on `main`.

## Changes
- `src/data/proofs/minkowski-theorem-oq-03/meta.json`
  - `status`: `formalized` → `verified`
  - `badge`: `wip` → `original`
  - add `verifiedDate: 2026-06-15`
  - replace the stale "build pending / not kernel-checked" `assumptions` text with the machine-verified status (green build #24723)
  - fix two residual "build pending" mentions in `description` and a section summary
- `src/data/research/problems/minkowski-theorem-oq-03.json` — record the meta-sync; refresh `progressSummary` / `nextSteps`.

## Evidence the source is verified
- `proofs/Proofs/MinkowskiTheoremOQ03.lean:41` banner: "Build status: Docker-verified green (7743 jobs, 0 sorries, 0 axioms; 2026-06-15)."
- Registered on `main`: `proofs/Proofs.lean:2643` `import Proofs.MinkowskiTheoremOQ03`.
- File on `main`: 0 sorries, 0 `axiom` declarations, no assumption-bearing structures (1 def + 5 theorems + 1 example).

## Status
**Outcome**: completed (gallery metadata sync; no Lean changed, no new mathematics)
**Next Steps**: concrete small-discriminant instantiation (Q(√-1)/Q(√-3)/Q(√5) class number 1), gated on quadratic-field discriminant infrastructure in Mathlib.

🤖 Generated by researcher-3