### PR TITLE
research(sum-of-kth-powers-oq-03): sync meta to build-pending (drop unverified machine-checked claim)

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Nicomachus of Gerasa (c. 100 CE), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squared_triangular_number",
     "date": "c. 100",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ03.lean",
     "tags": [
       "number-theory",
@@ -17,10 +17,10 @@
       "squared-triangular-number",
       "open-question"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7743 jobs); registered in proofs/Proofs.lean. Every arithmetic identity is additionally certified by sympy + brute force (research/problems/sum-of-kth-powers-oq-03/verify_div_free.py for n=0..199 and verify_m1.py for n=0..60).",
+    "assumptions": "0 axioms, 0 sorries. BUILD-PENDING: authored during a Docker + Aristotle backend outage and NOT yet machine-checked. Registered in proofs/Proofs.lean; the two load-bearing Mathlib lemmas (Finset.sum_Ico_consecutive, Finset.range_eq_Ico) were pin-confirmed at Lean v4.26.0 (Mathlib pin 2df2f01). Every arithmetic identity is additionally certified by sympy + brute force (research/problems/sum-of-kth-powers-oq-03/verify_div_free.py for n=0..199 and verify_m1.py for n=0..60). Promote to status verified / badge original once a green `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` confirms the typecheck.",
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_Ico_consecutive",


### PR DESCRIPTION
## Summary
Integrity fix for `sum-of-kth-powers-oq-03` (Nicomachus via odd-number partition of cubes).

The Lean header was deliberately corrected to **BUILD-PENDING / NOT machine-checked** in #24716, but `meta.json` still carried the same overclaim that #24716 set out to remove:
- `status: verified`, `badge: original`
- `assumptions`: *"Machine-checked: ... builds green (... 7743 jobs)"* — the source has **never** been docker-built, and "7743 jobs" is copied verbatim from an unrelated entry (buffons-needle-oq-01-oq-02-oq-02).

This violates the repo's status policy (`verified` requires a green machine-check). Docker is currently saturated (8 build containers, ~111MB host free), so a build cannot be confirmed this session.

## Changes
- `status`: `verified` → `formalized`
- `badge`: `original` → `wip`
- `assumptions`: replace the fabricated machine-checked line with the header's honest BUILD-PENDING provenance, retaining the sympy-certification note and the promote-when-green instruction.

The Lean source is unchanged: still **0 sorry / 0 axiom**, registered in `proofs/Proofs.lean`, with every arithmetic identity certified by sympy + brute force. Promote back to `verified`/`original` once `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ03` is green.

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] No remaining `verified`/machine-checked/Docker overclaims in the meta prose
- [ ] (follow-up, Docker-gated) green docker-build → flip back to verified/original