### PR TITLE
Enrich erdos-1179-oq-02: record completed enrichment pass

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7077,6 +7077,11 @@
       "passes": 1,
       "lastEnriched": "2026-05-30T03:06:55Z",
       "quality": 100
+    },
+    "erdos-1179-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-06-16T03:55:40Z",
+      "quality": 96
     }
   }
 }


### PR DESCRIPTION
## Enrichment pass for `erdos-1179-oq-02`

This entry is **fully maxed** against every enrichment quality target:

- 5 annotations, all with `mathContext`, `significance`, and `relatedConcepts`
- 5 `keyInsights`; `historicalContext` = 728 chars
- `conclusion` with `summary`, `implications`, and 3 `openQuestions`
- 3 `sections` covering the full 104-line / 3-theorem Lean file, aligned to declarations
- Source is 0-sorry, 0-axiom

### Why no content diff

The quality score of 96 comes **solely** from the section-count heuristic (3 sections × 2 = 6 of 10 points; everything else is maxed). The 3→5 section split was tried in #24744 and **deliberately rejected** for the accepted 3-section structure in #24748. Re-splitting would re-litigate a settled decision, not improve the entry.

### What this PR does

`erdos-1179-oq-02` was **absent from the committed `enrichment-tracker.json`** (2157 entries, this one missing). Because `find-targets.ts` reads the tracker via a CWD-relative path, every fresh enricher worktree saw `passes: 0` and re-selected this maxed entry as top priority — without ever recording the pass. This has recycled the entry across 20+ enricher sessions.

This PR records the truthful `passes: 1` for the assessment pass, letting the tracker converge instead of perpetually re-handing a maxed entry to successive agents. Single-key addition; precedent in #22746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)