### PR TITLE
research(product-of-segments-of-chords): machine-verify forward proof, promote to verified

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChords.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChords.lean
@@ -312,7 +312,7 @@ theorem power_of_point_product (P A B : Vec2) (C : Circle)
         = ‖P' - (P' + (t * ‖A' - P'‖) • dir)‖ := by rw [hB'param]
       _ = ‖-((t * ‖A' - P'‖) • dir)‖ := by congr 1; abel
       _ = ‖(t * ‖A' - P'‖) • dir‖ := by rw [norm_neg]
-      _ = |t * ‖A' - P'‖| * ‖dir‖ := by rw [norm_smul]
+      _ = |t * ‖A' - P'‖| * ‖dir‖ := by rw [norm_smul, Real.norm_eq_abs]
       _ = |t * ‖A' - P'‖| * 1 := by rw [hdir]
       _ = |t * ‖A' - P'‖| := by ring
   -- Product of distances
@@ -391,13 +391,9 @@ theorem power_of_point_product (P A B : Vec2) (C : Circle)
             linarith
           have vieta2 : 4 * (inner ℝ P' dir)^2 = ‖A' - P'‖^2 + (t * ‖A' - P'‖)^2 + 2 * ‖A' - P'‖ * (t * ‖A' - P'‖) := by linarith [vieta]
           linarith
-        rw [abs_mul, abs_of_nonneg (sq_nonneg _)]
-        have habs : |t * ‖A' - P'‖^2| = |‖P'‖^2 - C.radius^2| := by
-          rw [abs_mul, abs_of_nonneg (sq_nonneg _)]
-          have heq : t * ‖A' - P'‖^2 = ‖A' - P'‖ * (t * ‖A' - P'‖) := by ring
-          rw [heq, hprod]
-        rw [abs_mul, abs_of_nonneg (sq_nonneg _)] at habs
-        exact habs
+        have hprod' : t * ‖A' - P'‖ ^ 2 = ‖P'‖ ^ 2 - C.radius ^ 2 := by
+          rw [← hprod]; ring
+        rw [← hprod', abs_mul, abs_of_nonneg (sq_nonneg (‖A' - P'‖))]
 
 -- ============================================================
 -- PART 6: Product of Segments (General Form)

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Power_of_a_point",
     "date": "~300 BCE",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "circles",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/ProductOfSegmentsOfChords.lean",
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -44,8 +44,8 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 55,
     "axiomCount": 0,
-    "lineCount": 530,
-    "assumptions": "0 axioms. The previously-present FALSE unsigned-converse axiom (converse_product_implies_concyclic_axiom) was REMOVED 2026-06-15: its statement is refuted by a machine-checked counterexample in Proofs/ProductOfSegmentsOfChordsConverse.lean (unsigned_converse_counterexample); the corrected signed converse is proved there (signed_converse_implies_concyclic, 0 axioms/0 sorries). NOTE: this forward file does NOT yet build against Mathlib v4.26.0 due to pre-existing API rot (vector division (A'-P')/‖A'-P'‖ in the main power_of_point_product proof must become scalar smul; a few `ring` calls on vector goals must become `abel`/`module`). The `inner`→`inner ℝ` explicit-field and `noncomputable powerOfPoint` migrations are already applied. UPDATE 2026-06-15 (researcher-4): the vector-division/`ring`-on-vectors rot has now been repaired (scalar smul + abel/sub_left_inj), and a correctness bug was fixed — power_of_point_product / product_of_segments_of_chords now require A≠B (resp. C≠D), since the chord-product identity is false when the two intersection points coincide. Lemma names verified against Mathlib rev 2df2f0150c but NOT yet machine-checked (Docker saturated). Hence status=formalized/wip pending one green build. See product-of-segments-of-chords-oq-02 knowledge.md for the blueprint.",
+    "lineCount": 514,
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChords` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 3070 jobs); registered in proofs/Proofs.lean. The previously-present FALSE unsigned-converse axiom (converse_product_implies_concyclic_axiom) was REMOVED 2026-06-15: its statement is refuted by a machine-checked counterexample in Proofs/ProductOfSegmentsOfChordsConverse.lean (unsigned_converse_counterexample); the corrected signed converse is proved there (signed_converse_implies_concyclic, 0 axioms/0 sorries). The forward proof was repaired for Mathlib v4.26.0 (vector division → scalar smul; `ring`-on-vectors → `abel`; `inner`→`inner ℝ`; `noncomputable powerOfPoint`) and a correctness bug fixed — power_of_point_product / product_of_segments_of_chords now require A≠B (resp. C≠D), since the chord-product identity is false when the two intersection points coincide. Verified green 2026-06-15 (researcher-4).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 4
@@ -209,7 +209,7 @@
       "RealInnerProductSpace"
     ],
     "namespace": null,
-    "lineCount": 530,
+    "lineCount": 514,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary
- Repaired the two residual Mathlib v4.26.0 build errors in `power_of_point_product` (the last blocker on this entry, previously `formalized`/`wip` "pending one green build").
- Docker build of `Proofs.ProductOfSegmentsOfChords` now **GREEN** (3070 jobs); the `ProductOfSegmentsOfChordsConverse` companion (false-axiom elimination) already builds green and is registered.
- Promoted gallery `meta.json` for `product-of-segments-of-chords`: `status` formalized→verified, `badge` wip→original, honest machine-checked `assumptions` text, synced stale `lineCount` 530→514.

## The two fixes (both in `power_of_point_product`)
1. `rw [norm_smul]` left a residual `‖t * ‖A'-P'‖‖ * ‖dir‖ = |t * ‖A'-P'‖| * ‖dir‖` (norm of a real ≠ abs syntactically). Added `Real.norm_eq_abs`.
2. A convoluted `abs_mul`/`abs_of_nonneg` block failed: its first `rw [abs_mul]` found no `|_ * _|` in the already-split goal `|t| * ‖A'-P'‖² = |‖P'‖² - r²|`. Replaced with a direct rewrite through `hprod` (`t * ‖A'-P'‖² = ‖P'‖² - r²`), giving `sq_nonneg` its explicit argument so `rw` doesn't greedily match `|t|`.

## Verification
```
ℹ [3070/3070] Built Proofs.ProductOfSegmentsOfChords (5.8s)
Build completed successfully (3070 jobs).
=== Build succeeded ===
```
0 axioms, 0 sorries. The previously-removed FALSE unsigned-converse axiom stays eliminated (refuted by machine-checked counterexample in the Converse file).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChords` — green
- [x] `./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsConverse` — green
- [x] `meta.json` valid JSON; status/badge/assumptions/lineCount synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)