### PR TITLE
research(feuerbach-oq-02-murakami): fix + Docker-verify + register Grace trirectangular theorem

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2323,6 +2323,7 @@ import Proofs.FeuerbachsTheoremOQ01Aristotle
 import Proofs.FeuerbachsTheoremOQ01OQ03
 import Proofs.FeuerbachsTheoremOQ02
 import Proofs.FeuerbachsTheoremOQ02Aristotle
+import Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular
 import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FiveColorTheorem
 import Proofs.FodorPressingDown

--- a/proofs/Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean
+++ b/proofs/Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean
@@ -96,27 +96,28 @@ theorem grace_feuerbach_trirectangular
   · field_simp; ring                                       -- incidence through A
   · field_simp; ring                                       -- through B
   · field_simp; ring                                       -- through C
-  · linear_combination (1 / (2 * (a + b + c) ^ 2)) * ht    -- tangency to insphere
-  · linear_combination (1 / (2 * (a + b + c) ^ 2)) * ht    -- tangency to D-exsphere
+  · field_simp; linear_combination 2 * ht                  -- tangency to insphere
+  · field_simp; linear_combination 2 * ht                  -- tangency to D-exsphere
 
--- EXACT proof (S9, derived + symbolically certified 2026-06-14, discharged
--- 2026-06-15 — every step above is checked by
--- `proofs/Proofs/verify_grace_proof_certificate.py` (15/15 PASS). Authored under
--- a Docker + Aristotle blackout, so it is symbolically certified but NOT yet
--- machine-checked by Lean; build-pending.
+-- EXACT proof (S9 derivation; Lean-checked 2026-06-15 — Docker build GREEN,
+-- 0 sorry / 0 axiom, registered in `Proofs.lean`). The symbolic certificate
+-- `proofs/Proofs/verify_grace_proof_certificate.py` (15/15 PASS) corroborates it.
 --
--- Notes on the coefficients (all verified by the certificate script):
+-- Notes on the coefficients (Lean-confirmed):
 --  • The three incidence goals are TRUE rational-function identities (residual
 --    ≡ 0 after clearing 2σ), so `field_simp; ring` closes them; they are NOT
 --    pure (a+b+c)⁻² identities (the bare `−a`,`−b`,`−c` cross terms break the
 --    homogeneity in (a+b+c)⁻¹), which is why `field_simp` with hσ is required.
---  • Each tangency goal Eₜ satisfies Eₜ − (1/(2σ²))·(t² − (a²b²+b²c²+c²a²)) ≡ 0
---    as a FORMAL field identity (every term carries the factor (a+b+c)⁻²), so a
---    bare `linear_combination … * ht` closes it WITHOUT `field_simp` — and the
---    SAME coefficient 1/(2σ²) works for both insphere and D-exsphere because the
---    odd-in-t part of Eₜ is identically zero (the surd cancellation; t ↦ −t maps
---    insphere ↔ D-exsphere). Sibling draft PRs #23382/#23322 use the equivalent
---    `field_simp; linear_combination 2 * ht` (post-clear, 4σ²·(1/(2σ²)) = 2).
+--  • Each tangency goal needs `field_simp; linear_combination 2 * ht`. A BARE
+--    `linear_combination (1/(2σ²)) * ht` does NOT compile (it failed `ring` at
+--    build time): although the t² parts cancel exactly, `ring` treats the two
+--    denominator forms `(2σ)⁻¹²` and `(2σ²)⁻¹` as distinct opaque atoms and
+--    cannot reconcile `(2σ)⁻¹²·2 = (2σ²)⁻¹`. Clearing denominators first with
+--    `field_simp` removes the inverses; the post-clear ht-coefficient is then
+--    `4σ²·(1/(2σ²)) = 2`, matching sibling PRs #23382/#23322. The SAME coefficient
+--    closes both the insphere and D-exsphere goals because the odd-in-t part of
+--    each Eₜ is identically zero (surd cancellation; t ↦ −t maps insphere ↔
+--    D-exsphere).
 -- The even-in-t cancellation (odd-in-t part ≡ 0; even part forces the shared
 -- pencil constant G = abc/σ) is what makes (2) and (3) hold for the SAME Θ, R.
 

--- a/research/problems/feuerbachs-theorem-oq-02-murakami/state.md
+++ b/research/problems/feuerbachs-theorem-oq-02-murakami/state.md
@@ -1,27 +1,41 @@
 # Current State
 
-**Phase**: VERIFY (math + Lean transcription COMPLETE; only Docker build-check + registration remain)
-**Since**: 2026-06-15T00:00:00.000Z
-**Iteration**: 10
+**Phase**: LEAN-VERIFIED (Grace trirectangular theorem Docker-built GREEN + registered)
+**Since**: 2026-06-15T22:10:00.000Z
+**Iteration**: 11
+
+## S11 (researcher-2, 2026-06-15) — Lean build GREEN + registered + bug fix
+
+`StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean` (theorem
+`grace_feuerbach_trirectangular`, all 5 identities, 0 sorry / 0 axiom) is now
+**Docker-verified GREEN** and registered in `Proofs.lean` (after the Feuerbach
+OQ02 imports). Docker was FREE this window (Aristotle still 404).
+
+**Bug fixed:** the previously-"merged" proof did NOT actually compile. The two
+tangency goals used a BARE `linear_combination (1/(2σ²)) * ht`, which fails
+`ring` (build error at the insphere goal): although the t² parts cancel exactly,
+`ring` treats `(2σ)⁻¹²` and `(2σ²)⁻¹` as distinct opaque atoms and cannot
+reconcile `(2σ)⁻¹²·2 = (2σ²)⁻¹`. Fix = `field_simp; linear_combination 2 * ht`
+(clears the inverses first; post-clear coefficient 4σ²·(1/2σ²)=2) — the SAME form
+the file's own line-105 plan note and sibling PRs #23382/#23322 prescribe. The
+earlier note claiming "NO field_simp required" was wrong; corrected in-file.
 
 ## Current Focus
 
-The mathematics AND the Lean transcription are both finished. S4 (T0 closed
-form) and S7 (general trirectangular family) were verified by the reproducible
-sympy script `verify_grace_trirectangular.py` (16/16 identities OK). S8/S9 (the
-Lean transcription) are ALSO DONE and merged: theorem
-`grace_feuerbach_trirectangular` in
-`proofs/Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean`
-proves all five identities (3 incidence + 2 internal-tangency) with 0 sorry / 0
-axiom, symbolically certified by `verify_grace_proof_certificate.py` (15/15 PASS),
-landed build-pending in #24189 (cert) and #24444 (discharge). The proof is
-`field_simp; ring` for incidence and `linear_combination (1/(2σ²))·ht` for both
-tangency goals (surd cancels: odd-in-t part ≡ 0).
+The mathematics AND the Lean machine-check are now both finished and verified.
+S4 (T0 closed form) and S7 (general trirectangular family) were verified by the
+reproducible sympy script `verify_grace_trirectangular.py` (16/16 identities OK).
+Theorem `grace_feuerbach_trirectangular` proves all five identities (3 incidence
+`field_simp; ring` + 2 internal-tangency `field_simp; linear_combination 2 * ht`,
+surd cancels: odd-in-t part ≡ 0) with 0 sorry / 0 axiom, Docker-GREEN and
+registered. Remaining: the SEPARATE parent-axiom de-axiomatization (see Next
+Action #3 below) — not this theorem.
 
-The only remaining steps are infra-gated, NOT mathematical:
-  - machine-check the file with Docker (`docker-build.sh`), currently the file is
-    build-pending (authored under a Docker blackout);
-  - register it in `proofs/Proofs.lean` and add a gallery entry once green.
+The Grace theorem itself is DONE (Docker-GREEN, registered). The only remaining
+work is the SEPARATE parent-axiom de-axiomatization:
+  - promote `feuerbach_3d_fails_general` (`FeuerbachsTheoremOQ02.lean:581`) to a
+    theorem once `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` (currently
+    1 sorry / 2 axioms) is built green — a distinct sub-problem, still open.
 
 ## Result (general trirectangular tetrahedron) -- VERIFIED
 
@@ -50,31 +64,28 @@ D-exsphere, and passes through the opposite face A,B,C.
 
 ## Blockers
 
-- Docker build-verification is gated by container saturation (observed 6-7
-  containers, host RAM low); a cold single-file build times out under that
-  contention. The Lean file is already written and certified — only the
-  machine-check is pending.
+- None for the Grace theorem — Docker-GREEN and registered as of 2026-06-15.
 - Aristotle is irrelevant here: the file has 0 sorries, so there is nothing for
   the prover to fill.
 
-## Next Action (Docker-gated, when containers ≤ 2)
+## Next Action
 
-1. `./proofs/scripts/docker-build.sh Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular`
-   (set `LEAN_BUILD_TIMEOUT=40m` if cold) to machine-check
-   `grace_feuerbach_trirectangular`.
-2. On green: register the module in `proofs/Proofs.lean` and add a gallery entry
-   under `src/data/proofs/feuerbachs-theorem-oq-02-murakami/`.
-3. Independently, the parent slug's axiom `feuerbach_3d_fails_general`
+1. ~~Docker machine-check + register the Grace theorem~~ **DONE 2026-06-15 (S11)**:
+   build GREEN, registered in `proofs/Proofs.lean`. A gallery entry under
+   `src/data/proofs/feuerbachs-theorem-oq-02-murakami/` could optionally be added
+   (currently the slug is research-only, no gallery dir).
+2. The parent slug's axiom `feuerbach_3d_fails_general`
    (`FeuerbachsTheoremOQ02.lean:581`) can be promoted to a theorem once
-   `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` is built green — a
-   SEPARATE de-axiomatization, also Docker-gated.
+   `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` (1 sorry / 2 axioms) is
+   built green — a SEPARATE de-axiomatization, still open. The witness file's own
+   sorry/axioms need discharge first.
 
-Do NOT re-transcribe the Grace theorem (S8/S9 are complete and merged) and do
-NOT register the file unbuilt under container saturation.
+Do NOT re-transcribe the Grace theorem (done + registered).
 
 ## Attempt Counts
 
-- Total attempts: 0 Lean builds (Docker-gated throughout; file certified
-  symbolically, not yet machine-checked)
+- Total Lean builds: 3 (2026-06-15 S11) — first RED (bare `linear_combination`
+  failed `ring`), then GREEN after the `field_simp; linear_combination 2 * ht`
+  fix, plus a confirming rebuild.
 - Approaches tried: analytic derivation + sympy certification + Lean
-  transcription — all complete; only the Lean machine-check remains
+  transcription + Docker machine-check — all complete and GREEN.


### PR DESCRIPTION
## Summary

The 3D Feuerbach (Grace) theorem for the trirectangular tetrahedron (`grace_feuerbach_trirectangular`) was sitting **build-pending** with a proof that **did not actually compile**. Docker is free this window, so I built it, found the bug, fixed it, and registered the now-verified module.

**Bug:** the two tangency goals used a bare `linear_combination (1/(2σ²)) * ht`. This fails `ring` (build error at the insphere goal): the t² parts cancel exactly, but `ring` treats the denominator forms `(2σ)⁻¹²` and `(2σ²)⁻¹` as distinct opaque atoms and cannot reconcile `(2σ)⁻¹²·2 = (2σ²)⁻¹`.

**Fix:** clear denominators first — `field_simp; linear_combination 2 * ht` (post-clear coefficient `4σ²·(1/2σ²)=2`). This is exactly the form the file's own line-105 plan note and sibling PRs #23382/#23322 prescribe; the file's "no field_simp required" comment was wrong and is corrected here.

**Result:** `docker-build.sh Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular` → **GREEN**, 0 sorry / 0 axiom. Registered in `proofs/Proofs.lean`. The Grace sphere through A,B,C is proved internally tangent to both the insphere and the D-exsphere for the whole trirectangular family.

Note: the parent slug's `feuerbach_3d_fails_general` axiom is a **separate** de-axiomatization (its witness file still has 1 sorry / 2 axioms) and is out of scope here.

## Test plan

- [x] `docker-build.sh Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular` — GREEN (3 builds: RED with old proof, GREEN after fix, confirming rebuild)
- [x] 0 sorry, 0 axiom in the proof file
- [x] Registered in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)