### PR TITLE
research(friendship-theorem-oq-04): machine-verify infinite-case proof, promote to verified

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -103,7 +103,7 @@ theorem univ_subset_two_ball (hF : IsFriendshipGraph G) (v : V) :
   · by_cases hadj : G.Adj v u
     · exact Or.inl (Or.inr ((G.mem_neighborSet v u).mpr hadj))
     · obtain ⟨x, hvx, hux⟩ := exists_common_neighbor hF (Ne.symm huv)
-      refine Or.inr (Set.mem_biUnion ?_ ?_)
+      refine Or.inr (Set.mem_biUnion (x := x) ?_ ?_)
       · exact (G.mem_neighborSet v x).mpr hvx
       · exact (G.mem_neighborSet x u).mpr hux.symm
 
@@ -139,7 +139,7 @@ theorem infinite_friendship_has_infinite_degree (hF : IsFriendshipGraph G) [Infi
     ∃ w : V, (G.neighborSet w).Infinite := by
   by_contra h
   push_neg at h
-  have hfin : ∀ w : V, (G.neighborSet w).Finite := fun w => Set.not_infinite.mp (h w)
+  have hfin : ∀ w : V, (G.neighborSet w).Finite := fun w => h w
   haveI : Finite V := locally_finite_is_finite hF hfin
   exact not_finite V
 
@@ -239,6 +239,6 @@ theorem unique_infinite_degree_vertex (hF : IsFriendshipGraph G) [Infinite V]
   constructor
   · exact infinite_degree_vertex_eq_universal hF c hc w
   · rintro rfl
-    exact universal_vertex_infinite_degree hF c hc
+    exact universal_vertex_infinite_degree hF w hc
 
 end FriendshipTheoremOQ04

--- a/src/data/proofs/friendship-theorem-oq-04/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FriendshipTheoremOQ04.lean",
     "tags": [
       "graph-theory",
@@ -16,11 +16,11 @@
       "local-finiteness",
       "research"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 196,
-    "assumptions": "No axioms or sorries. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. BUILD-PENDING: the file is registered in Proofs.lean (via #24505) but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded once a green build is on record.",
+    "lineCount": 244,
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7745 jobs); registered in Proofs.lean. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. Verified green 2026-06-15 (researcher-4) after repairing three Mathlib v4.26.0 errors (Set.mem_biUnion implicit index, a redundant Set.not_infinite.mp after push_neg already normalized to Finite, and a stale `c` identifier after `rintro rfl` substituted it to `w`).",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -30,7 +30,7 @@
       "infinite_friendship_has_infinite_degree: contrapositive — an infinite friendship graph must contain an infinite-degree vertex (matching the C₅ free-amalgamation counterexample)",
       "locally_finite_friendship_has_universal: combining diameter-2 + local finiteness with the finite gallery theorem recovers a universal ('politician') vertex, avoiding the spectral argument entirely"
     ],
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "overview": {


### PR DESCRIPTION
## Summary
- `FriendshipTheoremOQ04.lean` (infinite Friendship Theorem boundary result) was registered under a Docker build blackout and **never actually compiled**. Main's version had three Mathlib v4.26.0 errors; this PR fixes them and the file now builds **GREEN (7745 jobs)**.
- Promoted gallery `meta.json`: `status` formalized→verified, `badge` wip→original, honest machine-checked `assumptions`, synced stale `lineCount` 196→244 and `theoremCount` 9→12.

## The three fixes
1. **`univ_subset_two_ball`** (line 106): `Set.mem_biUnion ?_ ?_` couldn't synthesize its implicit index from the holes — supplied `(x := x)`.
2. **`infinite_friendship_has_infinite_degree`** (line 142): `push_neg` already normalized `¬(·).Infinite` to `(·).Finite`, so the `Set.not_infinite.mp` wrapper was a type mismatch — use `h w` directly.
3. **`unique_infinite_degree_vertex`** (line 242): `rintro rfl` substituted `c := w`, leaving `c` an unknown identifier — use `w`.

## Verification
```
✔ [7745/7745] Built Proofs.FriendshipTheoremOQ04 (56s)
Build completed successfully (7745 jobs).
=== Build succeeded ===
```
0 axioms, 0 sorries.

Note: two older OQ-04 PRs (#24273, #24445) edit the same file but are now behind main (main has advanced past both); this PR verifies and promotes main's current canonical version.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` — green
- [x] `meta.json` valid JSON; status/badge/assumptions/counts synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)