### PR TITLE
research(inverse-galois-d4-oq-01): verify external D₄ ≅ ℤ/4 ⋊ ℤ/2 MulEquiv

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2507,6 +2507,7 @@ import Proofs.InverseGaloisA5Resultant2
 import Proofs.InverseGaloisA5ResultantDet
 import Proofs.InverseGaloisD4
 import Proofs.InverseGaloisD4OQ01
+import Proofs.InverseGaloisD4OQ01External
 import Proofs.InverseGaloisD4OQ03
 import Proofs.InverseGaloisF20
 import Proofs.InverseGaloisOQ01

--- a/proofs/Proofs/InverseGaloisD4OQ01External.lean
+++ b/proofs/Proofs/InverseGaloisD4OQ01External.lean
@@ -1,0 +1,171 @@
+import Proofs.InverseGaloisD4OQ01
+
+/-
+# Inverse Galois D₄ — OQ-01 (external packaging): `D₄ ≅ ℤ/4 ⋊ ℤ/2`
+
+`InverseGaloisD4OQ01` exhibits the *internal* semidirect-product decomposition
+of `DihedralGroup 4` (a normal rotation subgroup `≅ ℤ/4`, an order-2 reflection
+complement `≅ ℤ/2`, acting by inversion). This file packages that data as an
+honest *external* `MulEquiv`
+
+    SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ
+      ≃* DihedralGroup 4,
+
+with `φ` the ℤ/2-action sending the nontrivial generator to inversion of ℤ/4.
+Mathlib has `SemidirectProduct` but no `DihedralGroup n` as an explicit
+semidirect product, so this is a genuine addition rather than a re-export.
+
+The compatibility hypothesis of `SemidirectProduct.lift` collapses, on the
+nontrivial ℤ/2 generator, to exactly `reflection_conj_rotation'` (already
+proven); bijectivity is established directly (no `Fintype`/cardinality input).
+-/
+
+namespace InverseGaloisD4OQ01External
+
+open DihedralGroup InverseGaloisD4OQ01
+
+/-! ## The inversion action `φ : ℤ/2 → Aut(ℤ/4)` -/
+
+/-- Inversion automorphism of the commutative group `ℤ/4`. -/
+def invAut : MulAut (Multiplicative (ZMod 4)) where
+  toFun := Inv.inv
+  invFun := Inv.inv
+  left_inv := inv_inv
+  right_inv := inv_inv
+  map_mul' a b := mul_inv a b
+
+@[simp] theorem invAut_apply (x : Multiplicative (ZMod 4)) : invAut x = x⁻¹ := rfl
+
+theorem invAut_mul_self : invAut * invAut = 1 := by
+  ext x; simp [MulAut.mul_apply, MulAut.one_apply]
+
+/-- In `ℤ/2`, every nonzero element is `1`. -/
+theorem zmod2_eq_one {x : ZMod 2} (h : x ≠ 0) : x = 1 := by
+  fin_cases x
+  · exact absurd rfl h
+  · rfl
+
+/-- The ℤ/2-action by inversion: the nontrivial generator acts as `invAut`. -/
+def φ : Multiplicative (ZMod 2) →* MulAut (Multiplicative (ZMod 4)) where
+  toFun g := if g.toAdd = 0 then 1 else invAut
+  map_one' := by simp
+  map_mul' a b := by
+    have hab : (a * b).toAdd = a.toAdd + b.toAdd := toAdd_mul a b
+    rw [hab]
+    by_cases ha : a.toAdd = 0 <;> by_cases hb : b.toAdd = 0
+    · simp [ha, hb]
+    · simp [ha, hb]
+    · simp [ha, hb]
+    · have c1 : (1 + 1 : ZMod 2) = 0 := by decide
+      have c2 : ¬ (1 : ZMod 2) = 0 := by decide
+      rw [zmod2_eq_one ha, zmod2_eq_one hb, if_pos c1, if_neg c2]
+      simp [invAut_mul_self]
+
+/-- The reflection complement homomorphism `ℤ/2 → D₄`. -/
+def sHom : Multiplicative (ZMod 2) →* DihedralGroup 4 where
+  toFun g := if g.toAdd = 0 then 1 else sr 0
+  map_one' := by simp
+  map_mul' a b := by
+    have hab : (a * b).toAdd = a.toAdd + b.toAdd := toAdd_mul a b
+    rw [hab]
+    by_cases ha : a.toAdd = 0 <;> by_cases hb : b.toAdd = 0
+    · simp [ha, hb]
+    · simp [ha, hb]
+    · simp [ha, hb]
+    · have c1 : (1 + 1 : ZMod 2) = 0 := by decide
+      have c2 : ¬ (1 : ZMod 2) = 0 := by decide
+      rw [zmod2_eq_one ha, zmod2_eq_one hb, if_pos c1, if_neg c2]
+      simp [sr_mul_self]
+
+theorem sHom_ofAdd_one : sHom (Multiplicative.ofAdd (1 : ZMod 2)) = sr 0 := by
+  simp only [sHom, MonoidHom.coe_mk, OneHom.coe_mk, toAdd_ofAdd]
+  rw [if_neg (by decide)]
+
+/-! ## Compatibility of the lift (the inversion twist) -/
+
+/-- The `SemidirectProduct.lift` compatibility condition: conjugation by the
+reflection inverts the rotations, exactly `reflection_conj_rotation'`. -/
+theorem lift_compat (g : Multiplicative (ZMod 2)) :
+    rHom.comp (φ g).toMonoidHom
+      = (MulAut.conj (sHom g)).toMonoidHom.comp rHom := by
+  ext n
+  have hrn : rHom n = r (Multiplicative.toAdd n) := rfl
+  by_cases hg : Multiplicative.toAdd g = 0
+  · have hφ1 : φ g = 1 := by
+      simp only [φ, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_pos hg]
+    have hs1 : sHom g = 1 := by
+      simp only [sHom, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_pos hg]
+    simp only [MonoidHom.comp_apply, hφ1, hs1]
+    simp [MulAut.conj_apply]
+  · have hφ : φ g = invAut := by
+      simp only [φ, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_neg hg]
+    have hs : sHom g = sr 0 := by
+      simp only [sHom, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_neg hg]
+    simp only [MonoidHom.comp_apply, hφ, hs]
+    show rHom n⁻¹ = sr 0 * rHom n * (sr 0)⁻¹
+    rw [map_inv, hrn, reflection_conj_rotation']
+
+/-! ## The external semidirect-product isomorphism -/
+
+/-- The lift `ℤ/4 ⋊ ℤ/2 → D₄`. -/
+noncomputable def d4Hom :
+    SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ
+      →* DihedralGroup 4 :=
+  SemidirectProduct.lift rHom sHom lift_compat
+
+theorem d4Hom_apply
+    (x : SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ) :
+    d4Hom x = rHom x.left * sHom x.right := by
+  rw [← SemidirectProduct.inl_left_mul_inr_right x, map_mul]
+  simp [d4Hom, SemidirectProduct.lift_inl, SemidirectProduct.lift_inr]
+
+theorem d4Hom_surjective : Function.Surjective d4Hom := by
+  intro y
+  cases y with
+  | r i =>
+    exact ⟨SemidirectProduct.inl (Multiplicative.ofAdd i), by
+      simp [d4Hom, SemidirectProduct.lift_inl]⟩
+  | sr i =>
+    refine ⟨SemidirectProduct.inl (Multiplicative.ofAdd (-i)) *
+      SemidirectProduct.inr (Multiplicative.ofAdd 1), ?_⟩
+    rw [map_mul]
+    simp only [d4Hom, SemidirectProduct.lift_inl, SemidirectProduct.lift_inr,
+      rHom_ofAdd, sHom_ofAdd_one]
+    rw [r_mul_sr]; congr 1; ring
+
+theorem d4Hom_injective : Function.Injective d4Hom := by
+  rw [injective_iff_map_eq_one]
+  intro x hx
+  rw [d4Hom_apply] at hx
+  by_cases hr : x.right.toAdd = 0
+  · have hs1 : sHom x.right = 1 := by
+      simp only [sHom, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_pos hr]
+    rw [hs1, mul_one] at hx
+    have hl0 : x.left.toAdd = 0 := by
+      have h1 : (r x.left.toAdd : DihedralGroup 4) = r 0 := by
+        rw [← DihedralGroup.one_def]; exact hx
+      exact DihedralGroup.r.inj h1
+    have hxl : x.left = 1 :=
+      Multiplicative.toAdd.injective (by rw [hl0, toAdd_one])
+    have hxr : x.right = 1 :=
+      Multiplicative.toAdd.injective (by rw [hr, toAdd_one])
+    exact SemidirectProduct.ext hxl hxr
+  · exfalso
+    have hs : sHom x.right = sr 0 := by
+      simp only [sHom, MonoidHom.coe_mk, OneHom.coe_mk]; rw [if_neg hr]
+    rw [hs, show rHom x.left = r x.left.toAdd from rfl, r_mul_sr,
+      DihedralGroup.one_def] at hx
+    exact DihedralGroup.noConfusion hx
+
+theorem d4Hom_bijective : Function.Bijective d4Hom :=
+  ⟨d4Hom_injective, d4Hom_surjective⟩
+
+/-- **External semidirect product**: `D₄ ≅ ℤ/4 ⋊ ℤ/2` with the inversion
+action. The Galois group `Gal(ℚ(⁴√2, i)/ℚ)` (order 8, `d4_realizable`) is thus
+identified, as an abstract group, with the explicit semidirect product. -/
+noncomputable def d4Equiv :
+    SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ
+      ≃* DihedralGroup 4 :=
+  MulEquiv.ofBijective d4Hom d4Hom_bijective
+
+end InverseGaloisD4OQ01External

--- a/research/problems/inverse-galois-d4-oq-01/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-01/knowledge.md
@@ -179,6 +179,47 @@ noncomputable def d4Equiv :
 
 ## Sessions
 
+### 2026-06-15 (Session 3) — researcher-1
+
+**Mode**: ACT (build-iterate) · **Outcome**: VERIFIED — the external `d4Equiv`
+packaging (Session-1 blueprint, 5 deferred gaps) is now machine-checked.
+
+Caught a warm-cache Docker window (`.lake` symlink resolves to the main repo's
+Mathlib cache, NOT the circular self-symlink the older Blockers note claimed —
+that was stale). Wrote `proofs/Proofs/InverseGaloisD4OQ01External.lean` (171
+lines, 0 sorry / 0 axiom) and built it green via `docker-build.sh
+Proofs.InverseGaloisD4OQ01External` (**7746 jobs, 0 errors**), then registered it
+in `Proofs.lean`.
+
+Delivered (all the blueprint's deferred pieces, now proved):
+- `invAut` (inversion `MulAut` of ℤ/4) + `invAut_mul_self`.
+- `φ : ℤ/2 →* MulAut(ℤ/4)` (generator ↦ invAut) and `sHom : ℤ/2 →* D₄`
+  (generator ↦ sr 0), each `map_mul'` discharged by `by_cases` on the two ℤ/2
+  inputs with `decide` on the closed `(1+1 : ZMod 2)=0` / `(1:ZMod 2)≠0`
+  conditions (helper `zmod2_eq_one`).
+- `lift_compat`: the `SemidirectProduct.lift` compatibility, reduced by defeq
+  (`simp only [comp_apply, hφ, hs]; show …`) to `reflection_conj_rotation'` on the
+  nontrivial generator.
+- `d4Hom := SemidirectProduct.lift rHom sHom lift_compat`, `d4Hom_apply`
+  (`= rHom x.left * sHom x.right`), `d4Hom_surjective` (r/sr cases),
+  `d4Hom_injective` (kernel-trivial via `r i = 1 ⟹ i = 0` and `sr j ≠ 1` by
+  `noConfusion`), `d4Hom_bijective`, and `d4Equiv := MulEquiv.ofBijective …`.
+
+**Build-iterate lessons** (Mathlib v4.26, generic): (1) `MonoidHom.comp_apply`
+must be applied via `simp only`, not `rw` (rw "pattern not found"); the coercion
+lemmas `MulEquiv.coe_toMonoidHom` / `MulAut.conj_apply` don't *syntactically*
+fire, so bridge to the explicit group expression with a defeq `show`. (2) `rw`
+rewrites *all* syntactically-identical occurrences at once, so two identical
+`if (1:ZMod 2)=0` ifs need only one `if_neg`. (3) dot-notation `n.toAdd` on
+`n : Multiplicative (ZMod 4)` fails (Lean whnf's the type to `Fin 4`); use
+`Multiplicative.toAdd n` explicitly.
+
+Gallery meta unchanged at `verified`/`original`/axiomCount 0; appended the
+`d4Equiv` contribution and the external-file green-build note. The Blockers
+section below is now historical (Docker + the `.lake` issue are resolved;
+Aristotle `prove` was still 404, live-probed this session, but unused — the build
+route sufficed). OQ-03 concrete-Galois bridge remains the separate harder problem.
+
 ### 2026-06-15 (Session 2) — researcher-3
 
 **Mode**: REVISIT · **Outcome**: VERIFIED — internal decomposition machine-checked, gallery status flipped `formalized` → `verified`

--- a/src/data/proofs/inverse-galois-d4-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 202,
-    "assumptions": "0 axioms, 0 sorries. MACHINE-CHECKED: Docker build green on 2026-06-15 (`docker-build.sh Proofs.InverseGaloisD4OQ01`, 7745 jobs, 0 errors; one cosmetic unused-simp-arg linter warning at line 144). Status upgraded `formalized` → `verified`. All proofs use only standard Mathlib DihedralGroup simp lemmas (r_mul_r, sr_mul_r, r_mul_sr, sr_mul_sr, inv_r, inv_sr, sr_mul_self, r_zero, orderOf_r_one, orderOf_sr) and Subgroup API (MonoidHom.range/mem_range, MonoidHom.ofInjective, Subgroup.mem_inf/mem_sup_left/mul_mem_sup/eq_bot_iff_forall, Nat.card_congr, ZMod.card). Imports: Proofs.InverseGaloisD4 (transitively Mathlib).",
+    "assumptions": "0 axioms, 0 sorries. MACHINE-CHECKED: Docker build green on 2026-06-15 (`docker-build.sh Proofs.InverseGaloisD4OQ01`, 7745 jobs, 0 errors; one cosmetic unused-simp-arg linter warning at line 144). Status upgraded `formalized` → `verified`. All proofs use only standard Mathlib DihedralGroup simp lemmas (r_mul_r, sr_mul_r, r_mul_sr, sr_mul_sr, inv_r, inv_sr, sr_mul_self, r_zero, orderOf_r_one, orderOf_sr) and Subgroup API (MonoidHom.range/mem_range, MonoidHom.ofInjective, Subgroup.mem_inf/mem_sup_left/mul_mem_sup/eq_bot_iff_forall, Nat.card_congr, ZMod.card). Imports: Proofs.InverseGaloisD4 (transitively Mathlib). EXTERNAL packaging (companion InverseGaloisD4OQ01External.lean, 171 lines, 0 axioms/0 sorries, 8 theorems + 5 defs incl. d4Equiv) also MACHINE-CHECKED green 2026-06-15 (`docker-build.sh Proofs.InverseGaloisD4OQ01External`, 7746 jobs, 0 errors) and registered in Proofs.lean.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-15",
     "theoremCount": 13,
@@ -38,7 +38,8 @@
       "rotations_normal: the rotation subgroup is normal (conjugation by a rotation or a reflection sends rotations to rotations)",
       "reflections: the order-2 complement {1, sr 0} as an explicit Subgroup, with mem_reflections (x ∈ reflections ↔ x = 1 ∨ x = sr 0)",
       "rotations_sup_reflections: rotations ⊔ reflections = ⊤ (rotations and the reflection generate D₄); rotations_inf_reflections: rotations ⊓ reflections = ⊥ (trivial intersection)",
-      "d4_internal_semidirect: the capstone bundling normality + ⊔ = ⊤ + ⊓ = ⊥ + inversion action — the explicit internal semidirect-product decomposition D₄ ≅ ℤ/4 ⋊ ℤ/2"
+      "d4_internal_semidirect: the capstone bundling normality + ⊔ = ⊤ + ⊓ = ⊥ + inversion action — the explicit internal semidirect-product decomposition D₄ ≅ ℤ/4 ⋊ ℤ/2",
+      "d4Equiv (companion file InverseGaloisD4OQ01External.lean): the EXTERNAL packaging — an honest MulEquiv SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4, with φ the ℤ/2-action sending the generator to inversion. Mathlib has SemidirectProduct but no DihedralGroup-as-semidirect-product, so this is a genuine addition. Built on rHom and reflection_conj_rotation' from the internal file; the SemidirectProduct.lift compatibility (lift_compat) reduces exactly to reflection_conj_rotation', and bijectivity (d4Hom_injective/surjective) is proved directly without any Fintype/cardinality input."
     ],
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary
Discharges the long-deferred **external packaging** of `inverse-galois-d4-oq-01` (drafted as a blueprint with 5 open gaps in Sessions 1–2, build-gated until now). Packages the already-verified internal semidirect decomposition of `DihedralGroup 4` as an honest external `MulEquiv`:

```
d4Equiv : SemidirectProduct (Multiplicative (ZMod 4)) (Multiplicative (ZMod 2)) φ ≃* DihedralGroup 4
```

with `φ` the ℤ/2-action sending the generator to inversion of ℤ/4. Mathlib has `SemidirectProduct` but **no** `DihedralGroup n` as an explicit semidirect product, so this is a genuine addition, not a re-export.

## Details
- New file `proofs/Proofs/InverseGaloisD4OQ01External.lean` — **171 lines, 0 sorry / 0 axiom**:
  - `invAut`, `φ`, `sHom` (the action + complement homs);
  - `lift_compat` — the `SemidirectProduct.lift` compatibility, which reduces by defeq exactly to `reflection_conj_rotation'` (proved in the internal file);
  - `d4Hom := SemidirectProduct.lift rHom sHom lift_compat`, with `d4Hom_injective`/`d4Hom_surjective` proved **directly** (no `Fintype`/cardinality input);
  - `d4Equiv := MulEquiv.ofBijective …`.
- **Docker-built green: 7746 jobs, 0 errors**, and registered in `Proofs.lean`.
- Gallery `meta.json` stays `verified` / `original` / axiomCount 0; appends the `d4Equiv` contribution and the external-file build note. `knowledge.md` records the session.

The concrete-Galois bridge `Gal(ℚ(⁴√2,i)/ℚ) ≃* DihedralGroup 4` remains the separate, harder OQ-03 problem (untouched).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.InverseGaloisD4OQ01External` → green (7746 jobs, 0 errors)
- [x] `grep -c sorry` / `grep -c '^axiom '` on the new file → 0 / 0
- [x] Registered in `Proofs.lean`; `meta.json` validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)