### PR TITLE
research(pascals-hexagon-oq-02): sync stale Iteration-1 state.md to actual progress

### DIFF
--- a/research/problems/pascals-hexagon-oq-02/state.md
+++ b/research/problems/pascals-hexagon-oq-02/state.md
@@ -1,25 +1,62 @@
 # Research State: pascals-hexagon-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT (SOLVED at axiomatized level; sole residue is the inherited parent axiom)
 **Path**: full
 **Since**: 2026-04-23T13:50:28+02:00
-**Iteration**: 1
+**Iteration**: 7
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+The open question — derive Brianchon's theorem (diagonals of a hexagon
+circumscribed about a conic are concurrent) from the formalized Pascal theorem by
+projective duality — is RESOLVED in Lean. `Proofs.PascalsHexagonOQ02` (namespace
+`Brianchon`) is complete: 0 own sorries, 0 own axioms, registered in `Proofs.lean`
+(`import Proofs.PascalsHexagonOQ02`, line 2701). In the homogeneous-coordinate
+model, join = meet = `crossProduct` and collinear = concurrent = the same
+determinant predicate, so Pascal applied to the six tangent lines (as points on
+the dual line-conic `adj C`) yields Brianchon with no new geometric axiom.
+
+Gallery `meta.json` is therefore `status: axiomatized`, `badge: axiom`,
+`axiomCount: 1`, `sorries: 0` — the `1` is the single inherited Pascal axiom
+`conic_implies_pascal_constraint` from `PascalsHexagon.lean`, NOT anything specific
+to Brianchon.
 
 ## Active Approach
-None yet.
+None active — slug is at its natural axiomatized stopping point. The only way to
+upgrade `axiomCount` 1 → 0 is to discharge the parent axiom
+`conic_implies_pascal_constraint`. That path is already fully scaffolded in
+`PascalsHexagon.lean`: `proof_sketch_conic_implies_pascal` (symmetric,
+non-degenerate case) is complete except for ONE isolated standalone sorry,
+`sylvester_stdConic_of_isotropic` (line ~1216) — an invertible projective
+transformation carrying any symmetric non-degenerate conic with a real point onto
+`stdConic`, via Sylvester's law of inertia
+(`QuadraticForm.equivalent_one_neg_one_weighted_sum_squared`). Two further steps
+remain for the FULL axiom elimination: (a) reduce asymmetric `C` to its
+symmetrization `(C+Cᵀ)/2`, (b) handle degenerate `C` (pairs of lines) by a
+Pappus-type argument.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 7
+- Current approach attempts: 0 (axiomatized resolution complete)
+- Approaches tried: projective-duality Brianchon derivation (DONE), Sylvester-law
+  scaffold of `conic_implies_pascal_constraint` down to one sorry (DONE), Sylvester
+  sorry discharge (BLOCKED — Aristotle target)
 
 ## Blockers
-None.
+`sylvester_stdConic_of_isotropic` is a prime Aristotle `prove_file` target
+(Mathlib-only `QuadraticForm` API, no project-specific scaffolding needed), but
+Aristotle `prove`/`prove_file` is returning 404 ("Resource not found",
+live-probed this session). Hand-writing the `IsometryEquiv → invertible matrix`
+extraction blind is risky — the exact Mathlib API names are unverifiable without a
+checked-out Mathlib source and a green build to confirm. Docker build state is not
+the bottleneck (OQ02 is already registered/complete; nothing to build-verify for
+the axiomatized status).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Aristotle is non-404: submit `sylvester_stdConic_of_isotropic` to
+`prove_file` (file `proofs/Proofs/PascalsHexagon.lean`), verify the returned proof
+with a Docker build, then handle the asymmetric/degenerate cases to fully
+eliminate `conic_implies_pascal_constraint` and flip the gallery meta to
+`verified`. Until then the slug is correctly at `axiomatized` — do NOT re-prove or
+pad the completed Brianchon derivation, and do NOT hand-write the Sylvester step
+blind.


### PR DESCRIPTION
## Summary
- `pascals-hexagon-oq-02`'s `state.md` was never updated past the initial **Iteration 1 / OBSERVE** stub (2026-04-23: "Read problem.md and gather context"), despite the work being mature. This syncs it to the real state. Documentation-only — no Lean / gallery changes.

## Actual state (now reflected)
- **Brianchon-by-duality is done**: `Proofs.PascalsHexagonOQ02` (namespace `Brianchon`) — 0 own sorries, 0 own axioms, registered in `Proofs.lean` (line 2701). Join=meet=`crossProduct`, collinear=concurrent, so Pascal on the dual line-conic yields Brianchon with no new axiom.
- **Meta is `axiomatized` / `badge: axiom` / `axiomCount: 1`** — the `1` is the single inherited Pascal axiom `conic_implies_pascal_constraint`, not anything Brianchon-specific.
- **Sole upgrade path**: discharge that axiom. Already scaffolded in `PascalsHexagon.lean` via `proof_sketch_conic_implies_pascal`, complete except one isolated sorry `sylvester_stdConic_of_isotropic` (Sylvester's law of inertia → projective equivalence to `stdConic`), plus asymmetric/degenerate-case handling.

## Blocker
`sylvester_stdConic_of_isotropic` is a prime Aristotle `prove_file` target (Mathlib-only `QuadraticForm` API), but Aristotle is returning **404** (live-probed this session). Hand-writing it blind is risky. Slug is correctly at `axiomatized` until then.

## Test plan
- [x] No code changed; OQ02 already complete + registered.
- [x] `state.md` now consistent with `meta.json` and the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)