### PR TITLE
research(law-of-cosines-oq-04-oq-01): repair inner API drift + register/verify Bisector companion

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2585,6 +2585,7 @@ import Proofs.LawOfCosinesOQ03
 import Proofs.LawOfCosinesOQ03OQ02
 import Proofs.LawOfCosinesOQ04
 import Proofs.LawOfCosinesOQ04OQ01
+import Proofs.LawOfCosinesOQ04OQ01Bisector
 import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05

--- a/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
@@ -43,13 +43,15 @@ Tags: geometry, stewarts-theorem, cevian, inner-product-space, law-of-cosines
 
 namespace StewartsTheoremInner
 
+open scoped RealInnerProductSpace
+
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
 
 /-- Squared norm of a linear combination of two vectors, expanded bilinearly:
     ‖p • u + q • v‖² = p²‖u‖² + q²‖v‖² + 2pq⟪u, v⟫. -/
 theorem norm_smul_add_smul_sq (p q : ℝ) (u v : V) :
     ‖p • u + q • v‖ ^ 2 =
-      p ^ 2 * ‖u‖ ^ 2 + q ^ 2 * ‖v‖ ^ 2 + 2 * (p * q) * (inner u v : ℝ) := by
+      p ^ 2 * ‖u‖ ^ 2 + q ^ 2 * ‖v‖ ^ 2 + 2 * (p * q) * ⟪u, v⟫ := by
   rw [norm_add_sq_real, norm_smul, norm_smul, real_inner_smul_left, real_inner_smul_right]
   simp only [Real.norm_eq_abs, mul_pow, sq_abs]
   ring
@@ -69,8 +71,10 @@ theorem stewart_cevian_inner (A B C : V) (s : ℝ) :
   have hAD : A - ((1 - s) • B + s • C) = (1 - s) • (A - B) + s • (A - C) := by
     module
   have hBC : B - C = (A - C) - (A - B) := by module
-  rw [hAD, hBC, norm_smul_add_smul_sq, norm_sub_sq_real,
-    real_inner_comm (A - C) (A - B)]
+  rw [hAD, hBC]
+  generalize A - B = u
+  generalize A - C = v
+  rw [norm_smul_add_smul_sq, norm_sub_sq_real, real_inner_comm v u]
   ring
 
 /-- **Stewart's theorem, classical form** `b²m + c²n = a(d² + mn)`.

--- a/proofs/Proofs/LawOfCosinesOQ04OQ01Bisector.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01Bisector.lean
@@ -55,24 +55,22 @@ triangle); `hnd` rules that out.
 
 0 axioms, 0 sorries.
 
-NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
-unavailable).  Deliberately UNREGISTERED in `Proofs.lean` until a post-blackout
-session verifies it via
-`./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ01Bisector`.
-Mathlib bearers name-checked @ pinned rev 2df2f01:
-`inner_add_right`, `real_inner_smul_right`, `real_inner_comm`,
-`real_inner_self_eq_norm_sq` (Analysis/InnerProductSpace/Basic.lean).
+Docker-verified GREEN (7744 jobs) and REGISTERED in `Proofs.lean`. Inner products
+use the `RealInnerProductSpace` notation `⟪·, ·⟫` (the field-explicit `inner ℝ`
+form under the current Mathlib pin).
 -/
 
 namespace StewartsTheoremInner
+
+open scoped RealInnerProductSpace
 
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
 
 /-- Inner product of `A-B` with the cevian direction `A-D`:
     `⟪A-B, A-D⟫ = (1-s)‖A-B‖² + s⟪A-B,A-C⟫`. -/
 theorem inner_sub_left_cevian (A B C : V) (s : ℝ) :
-    (inner (A - B) (A - ((1 - s) • B + s • C)) : ℝ)
-      = (1 - s) * ‖A - B‖ ^ 2 + s * (inner (A - B) (A - C) : ℝ) := by
+    ⟪A - B, A - ((1 - s) • B + s • C)⟫
+      = (1 - s) * ‖A - B‖ ^ 2 + s * ⟪A - B, A - C⟫ := by
   have hAD : A - ((1 - s) • B + s • C) = (1 - s) • (A - B) + s • (A - C) := by
     module
   rw [hAD, inner_add_right, real_inner_smul_right, real_inner_smul_right,
@@ -81,8 +79,8 @@ theorem inner_sub_left_cevian (A B C : V) (s : ℝ) :
 /-- Inner product of `A-C` with the cevian direction `A-D`:
     `⟪A-C, A-D⟫ = (1-s)⟪A-B,A-C⟫ + s‖A-C‖²`. -/
 theorem inner_sub_right_cevian (A B C : V) (s : ℝ) :
-    (inner (A - C) (A - ((1 - s) • B + s • C)) : ℝ)
-      = (1 - s) * (inner (A - B) (A - C) : ℝ) + s * ‖A - C‖ ^ 2 := by
+    ⟪A - C, A - ((1 - s) • B + s • C)⟫
+      = (1 - s) * ⟪A - B, A - C⟫ + s * ‖A - C‖ ^ 2 := by
   have hAD : A - ((1 - s) • B + s • C) = (1 - s) • (A - B) + s • (A - C) := by
     module
   rw [hAD, inner_add_right, real_inner_smul_right, real_inner_smul_right,
@@ -98,9 +96,9 @@ Both inner products are bilinear functions of `s`, and the difference factors
 cleanly: the geometric content of the angle bisector lives entirely in the two
 factors `b·c − p` (nondegeneracy) and `c − s·(b+c)` (the segment ratio). -/
 theorem angle_bisector_factor (A B C : V) (s : ℝ) :
-    ‖A - C‖ * (inner (A - B) (A - ((1 - s) • B + s • C)) : ℝ)
-        - ‖A - B‖ * (inner (A - C) (A - ((1 - s) • B + s • C)) : ℝ)
-      = (‖A - C‖ * ‖A - B‖ - (inner (A - B) (A - C) : ℝ))
+    ‖A - C‖ * ⟪A - B, A - ((1 - s) • B + s • C)⟫
+        - ‖A - B‖ * ⟪A - C, A - ((1 - s) • B + s • C)⟫
+      = (‖A - C‖ * ‖A - B‖ - ⟪A - B, A - C⟫)
           * (‖A - B‖ - s * (‖A - C‖ + ‖A - B‖)) := by
   rw [inner_sub_left_cevian, inner_sub_right_cevian]
   ring
@@ -109,9 +107,9 @@ theorem angle_bisector_factor (A B C : V) (s : ℝ) :
 foot `D = (1-s)•B + s•C` have equal cosine (cleared of the common factor `‖A-D‖`)
 iff the discriminant `(bc − ⟪A-B,A-C⟫)·(c − s(b+c))` vanishes. -/
 theorem angle_bisector_iff (A B C : V) (s : ℝ) :
-    ‖A - C‖ * (inner (A - B) (A - ((1 - s) • B + s • C)) : ℝ)
-        = ‖A - B‖ * (inner (A - C) (A - ((1 - s) • B + s • C)) : ℝ)
-      ↔ (‖A - C‖ * ‖A - B‖ - (inner (A - B) (A - C) : ℝ))
+    ‖A - C‖ * ⟪A - B, A - ((1 - s) • B + s • C)⟫
+        = ‖A - B‖ * ⟪A - C, A - ((1 - s) • B + s • C)⟫
+      ↔ (‖A - C‖ * ‖A - B‖ - ⟪A - B, A - C⟫)
           * (‖A - B‖ - s * (‖A - C‖ + ‖A - B‖)) = 0 := by
   rw [← angle_bisector_factor, sub_eq_zero]
 
@@ -124,9 +122,9 @@ then its foot `D = (1-s)•B + s•C` divides `BC` in the ratio `BD : DC = c : b
 
 This is precisely the ratio hypothesis assumed by `angle_bisector_length_inner`. -/
 theorem angle_bisector_ratio_of_equal_angle (A B C : V) (s : ℝ)
-    (hnd : ‖A - C‖ * ‖A - B‖ ≠ (inner (A - B) (A - C) : ℝ))
-    (hbis : ‖A - C‖ * (inner (A - B) (A - ((1 - s) • B + s • C)) : ℝ)
-      = ‖A - B‖ * (inner (A - C) (A - ((1 - s) • B + s • C)) : ℝ)) :
+    (hnd : ‖A - C‖ * ‖A - B‖ ≠ ⟪A - B, A - C⟫)
+    (hbis : ‖A - C‖ * ⟪A - B, A - ((1 - s) • B + s • C)⟫
+      = ‖A - B‖ * ⟪A - C, A - ((1 - s) • B + s • C)⟫) :
     s * (‖A - C‖ + ‖A - B‖) = ‖A - B‖ := by
   rcases mul_eq_zero.mp ((angle_bisector_iff A B C s).mp hbis) with h0 | h0
   · exact absurd (sub_eq_zero.mp h0) hnd
@@ -138,9 +136,9 @@ hypothesis at `A` (plus nondegeneracy), with no separately-assumed segment ratio
 the Angle Bisector Theorem supplies the ratio, then the registered
 `angle_bisector_length_inner` supplies the length. -/
 theorem angle_bisector_length_of_equal_angle (A B C : V) (s : ℝ)
-    (hnd : ‖A - C‖ * ‖A - B‖ ≠ (inner (A - B) (A - C) : ℝ))
-    (hbis : ‖A - C‖ * (inner (A - B) (A - ((1 - s) • B + s • C)) : ℝ)
-      = ‖A - B‖ * (inner (A - C) (A - ((1 - s) • B + s • C)) : ℝ)) :
+    (hnd : ‖A - C‖ * ‖A - B‖ ≠ ⟪A - B, A - C⟫)
+    (hbis : ‖A - C‖ * ⟪A - B, A - ((1 - s) • B + s • C)⟫
+      = ‖A - B‖ * ⟪A - C, A - ((1 - s) • B + s • C)⟫) :
     (‖A - C‖ + ‖A - B‖) ^ 2 * ‖A - ((1 - s) • B + s • C)‖ ^ 2 =
       ‖A - B‖ * ‖A - C‖ * ((‖A - C‖ + ‖A - B‖) ^ 2 - ‖B - C‖ ^ 2) :=
   angle_bisector_length_inner A B C s

--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Matthew Stewart (1746); inner-product formalization 2026",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/LawOfCosinesOQ04OQ01.lean",
     "tags": [
       "geometry",
@@ -16,11 +16,11 @@
       "law-of-cosines",
       "research"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 137,
-    "assumptions": "No axioms or sorries. All results proved bilinearly from the inner-product structure. BUILD-PENDING: the file is registered in Proofs.lean but its Lean compilation has not been independently confirmed in this entry (authored/registered under a Docker build blackout); badge will be upgraded to mathlib/verified once a green build is on record.",
+    "lineCount": 141,
+    "assumptions": "No axioms or sorries. All results proved bilinearly from the inner-product structure. Docker-verified GREEN (7744 jobs) under the current Mathlib pin. The companion file Proofs/LawOfCosinesOQ04OQ01Bisector.lean (also registered and verified) proves the coordinate-free Angle Bisector Theorem (angle_bisector_ratio_of_equal_angle), resolving open question 1 below: the segment ratio BD:DC = c:b is derived from genuine equal angles at A rather than assumed.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -92,7 +92,7 @@
     "summary": "Starting from a single bilinear lemma (the squared norm of a linear combination of two vectors), the entry establishes Stewart's theorem as a coordinate-free identity in an arbitrary real inner product space. The master identity ‖A−D‖² = (1−s)‖A−B‖² + s‖A−C‖² − s(1−s)‖B−C‖², with the cevian foot encoded as the affine combination D = (1−s)·B + s·C, specializes by substitution to the classical form b²m + c²n = a(d² + mn), to Apollonius' median theorem (s = 1/2), and to the internal angle-bisector length formula (the c:b segment ratio).",
     "implications": "Grounding Stewart's theorem in genuine inner-product geometry removes the side conditions that the scalar law-of-cosines derivation must carry. The segment relation m + n = a holds by construction rather than as a collinearity/sign hypothesis, and the abstract cosine parameter t of the parent entry is exposed as the real inner product ⟪A−B, A−C⟫. Because nothing depends on dimension, the same identity covers planar triangles, spatial-tetrahedron cevians, and arbitrary-dimensional configurations — a single algebraic fact replacing a family of case-specific geometric arguments. This is a model for how classical metric geometry lifts to inner-product spaces: the law of cosines becomes the polarization identity, and cevian results become substitutions into one bilinear expansion.",
     "openQuestions": [
-      "Can the angle-bisector specialization be completed by proving that the segment ratio BD:DC = c:b is exactly the one realized by the true angle bisector (equal angles at A), so the formula attaches to the genuine bisector rather than to a hypothesized foot?",
+      "RESOLVED (companion file LawOfCosinesOQ04OQ01Bisector.lean): the angle-bisector specialization is now completed — angle_bisector_ratio_of_equal_angle proves that equal angles at A force the segment ratio BD:DC = c:b for a nondegenerate triangle, and angle_bisector_length_of_equal_angle attaches the length formula to the genuine bisector rather than a hypothesized foot.",
       "Does the same affine-combination encoding give a clean coordinate-free treatment of the generalized (mass-point / barycentric) Stewart relations, or of concurrent cevians (Ceva/Routh-type identities)?",
       "Over a complex inner product space, does the bilinear engine extend with the appropriate Hermitian polarization, or does the loss of symmetry ⟪u,v⟫ ≠ ⟪v,u⟫ obstruct the ring-level closure?"
     ]


### PR DESCRIPTION
## Summary

The registered main file `Proofs/LawOfCosinesOQ04OQ01.lean` was **build-broken** (not merely "build-pending") under the current Mathlib pin (Lean v4.26.0). Two distinct defects, both now fixed and **Docker-verified GREEN (7744 jobs)**:

1. **`inner` API drift.** The `inner 𝕜 x y` refactor made the old 2-arg `(inner u v : ℝ)` form a type error (`@inner u` expects a `Type`, got a vector). Switched both the main file and the companion to the `RealInnerProductSpace` notation `⟪·, ·⟫` via `open scoped RealInnerProductSpace`.
2. **Wrong-occurrence rewrite in `stewart_cevian_inner`.** `rw [norm_sub_sq_real]` matched `‖A-B‖²` (from the smul expansion) instead of the intended `‖(A-C)-(A-B)‖²`, leaving an asymmetric goal that `ring` could not close — so this proof had never actually compiled. Repaired by `generalize`-ing `A-B` and `A-C` to opaque variables, so `norm_sub_sq_real` only expands the single `‖v-u‖²` term.

With the main file compiling, this also:

- **Registers** `Proofs.LawOfCosinesOQ04OQ01Bisector` (the previously orphaned, complete companion that proves the coordinate-free **Angle Bisector Theorem**) in `Proofs.lean`. It was authored under an earlier Docker blackout and left unregistered/unverified.
- **Resolves the entry's own open question 1**: `angle_bisector_ratio_of_equal_angle` derives the segment ratio `BD:DC = c:b` from genuine equal angles at `A` (rather than assuming it), and `angle_bisector_length_of_equal_angle` attaches the length formula to the true bisector.
- **Flips the gallery meta** `formalized`/`wip` → `verified` and drops the stale `BUILD-PENDING` note (0 sorries, 0 axioms).

## Verification

```
./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ04OQ01Bisector
# ✔ Built Proofs.LawOfCosinesOQ04OQ01 / Proofs.LawOfCosinesOQ04OQ01Bisector — Build succeeded (7744 jobs)
```

## Note on PR #24375

PR #24375 separately adds differently-formulated (Stewart-form) bisector theorems *inline* to the main file and is currently conflicting/unmergeable. This PR instead registers and verifies the dedicated companion file; the two do not collide at the Lean level (distinct files and theorem names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)