### PR TITLE
research(quadratic-gauss-sum-square): fix build + verified gallery entry

### DIFF
--- a/proofs/Proofs/QuadraticGaussSumSquare.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquare.lean
@@ -70,6 +70,8 @@ theorem gaussSum_quadratic_sq (hp : p ≠ 2)
     {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
     gaussSum (chiC p) ψ ^ 2 = (-1 : ℂ) ^ ((p - 1) / 2) * p := by
   have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
-  rw [h, chiC_neg_one hp, ZMod.card p]
+  calc gaussSum (chiC p) ψ ^ 2
+      = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) := h
+    _ = (-1 : ℂ) ^ ((p - 1) / 2) * p := by rw [chiC_neg_one hp, ZMod.card p]
 
 end QuadraticGaussSumSquare

--- a/research/problems/quadratic-gauss-sum-square/state.md
+++ b/research/problems/quadratic-gauss-sum-square/state.md
@@ -19,9 +19,12 @@ is promoted to `proofs/Proofs/QuadraticGaussSumSquare.lean` and registered in
 - Approaches tried: 1 (gaussSum_sq reduction — succeeded)
 
 ## Blockers
-None mathematical. Docker build verification pending (build host saturated this
-session). All Mathlib API names confirmed against pinned source rev `2df2f01`.
+None. Docker build verified GREEN (7743/7743 jobs, 0 sorries, 0 axioms). The
+build-pending file initially failed — `gaussSum_sq` unfolds `chiC p` to its MulChar
+structure literal, so `rw [h]` could not match the folded `chiC p` in the goal.
+Fixed by restating `h` in folded form via a `calc` step (defeq), after which the
+`chiC_neg_one` and `ZMod.card` rewrites apply syntactically.
 
 ## Next Action
-Confirm green build → flip status to `verified`, then create the gallery entry
-`src/data/proofs/quadratic-gauss-sum-square/` (badge `mathlib`, axiomCount 0).
+COMPLETE. Status flipped to `verified` (badge `mathlib`, axiomCount 0). Gallery entry
+created at `src/data/proofs/quadratic-gauss-sum-square/` (meta.json + annotations.json).

--- a/src/data/proofs/quadratic-gauss-sum-square/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "qgss-ann-transport",
+    "proofId": "quadratic-gauss-sum-square",
+    "range": {
+      "startLine": 28,
+      "endLine": 39
+    },
+    "type": "insight",
+    "title": "Transporting the ℤ-Valued Character to ℂ",
+    "content": "Mathlib's `quadraticChar (ZMod p)` is valued in ℤ, but `gaussSum χ ψ` demands that the multiplicative character χ and the additive character ψ live in a common codomain. Since ψ here is ℂ-valued, the quadratic character must be pushed forward along the ring hom ℤ → ℂ. The definition `chiC p = (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)` does exactly this, and `MulChar.IsQuadratic` is preserved under `ringHomComp`, so `chiC_isQuadratic` follows immediately.",
+    "mathContext": "$\\chi_{\\mathbb{C}} = \\iota \\circ \\left(\\tfrac{\\cdot}{p}\\right)$ where $\\iota : \\mathbb{Z} \\hookrightarrow \\mathbb{C}$ is the canonical embedding and $\\left(\\tfrac{\\cdot}{p}\\right)$ is the Legendre symbol viewed as a multiplicative character.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative characters",
+      "quadratic residue character",
+      "ring homomorphism composition"
+    ],
+    "prerequisites": [
+      "Legendre symbol",
+      "MulChar.ringHomComp"
+    ]
+  },
+  {
+    "id": "qgss-ann-neg-one",
+    "proofId": "quadratic-gauss-sum-square",
+    "range": {
+      "startLine": 49,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "Value at -1 and the First Supplement",
+    "content": "Evaluating χ(-1) = (-1)^((p-1)/2) is the first supplement to quadratic reciprocity (-1 is a QR mod p iff p ≡ 1 mod 4). The formalization reconciles two exponent conventions: `quadraticChar_neg_one` produces (-1)^(p/2) via `ZMod.χ₄_eq_neg_one_pow`, while the supplement is conventionally (-1)^((p-1)/2). For an odd prime p = 2k+1 these coincide because p/2 = k = (p-1)/2 (closed by `omega`), and the equality is then transported to ℂ.",
+    "mathContext": "$\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2} = \\begin{cases} +1 & p \\equiv 1 \\pmod 4 \\\\ -1 & p \\equiv 3 \\pmod 4 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic reciprocity",
+      "first supplement",
+      "χ₄ character"
+    ],
+    "prerequisites": [
+      "Legendre symbol of -1",
+      "ZMod.χ₄_eq_neg_one_pow"
+    ]
+  },
+  {
+    "id": "qgss-ann-main",
+    "proofId": "quadratic-gauss-sum-square",
+    "range": {
+      "startLine": 69,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Assembling g² = (-1)^((p-1)/2)·p",
+    "content": "The headline theorem `gaussSum_quadratic_sq` is a two-line assembly over Mathlib's generic `gaussSum_sq`, which states g² = χ(-1)·#F for a nontrivial quadratic multiplicative character and a primitive additive character over a finite field F. The three feeder lemmas (`chiC_ne_one`, `chiC_isQuadratic`, `chiC_neg_one`) supply exactly its hypotheses; substituting the character value and the cardinality `ZMod.card p = p` yields g² = (-1)^((p-1)/2)·p with zero axioms and zero sorries.",
+    "mathContext": "$g^2 = \\left(\\sum_{n \\in \\mathbb{Z}/p\\mathbb{Z}} \\left(\\tfrac{n}{p}\\right)\\psi(n)\\right)^2 = (-1)^{(p-1)/2}\\, p$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Gauss sum",
+      "gaussSum_sq",
+      "quadratic reciprocity"
+    ],
+    "prerequisites": [
+      "primitive additive character",
+      "finite field cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/quadratic-gauss-sum-square/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "quadratic-gauss-sum-square",
+  "title": "Square of the Quadratic Gauss Sum",
+  "slug": "quadratic-gauss-sum-square",
+  "description": "For an odd prime p and a primitive additive character ψ : ZMod p → ℂ, the quadratic Gauss sum g = ∑ₙ χ(n)·ψ(n) (where χ is the quadratic residue character) satisfies g² = (-1)^((p-1)/2)·p. The result specialises Mathlib's generic gaussSum_sq to the ℂ-valued quadratic character of ZMod p, evaluating that character at -1 (the first supplement to quadratic reciprocity) and using the field cardinality.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquare.lean",
+    "tags": [
+      "number-theory",
+      "gauss-sum",
+      "quadratic-character",
+      "quadratic-reciprocity",
+      "zmod",
+      "additive-character"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 75,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "Gauss introduced the sums $g = \\sum_{n} \\left(\\tfrac{n}{p}\\right) e^{2\\pi i n/p}$ in the Disquisitiones Arithmeticae (1801) and used them to give his sixth proof of quadratic reciprocity. The identity $g^2 = (-1)^{(p-1)/2} p$ is the easy half: it follows from a direct double-sum manipulation and identifies $g^2$ up to the sign that distinguishes $p \\equiv 1$ from $p \\equiv 3 \\pmod 4$. The genuinely hard part — pinning down the sign of $g$ itself (rather than $g^2$), namely $g = \\sqrt{p}$ for $p \\equiv 1$ and $g = i\\sqrt{p}$ for $p \\equiv 3 \\pmod 4$ — occupied Gauss for four years and is not addressed here.",
+    "problemStatement": "Let $p$ be an odd prime and $\\psi : \\mathbb{Z}/p\\mathbb{Z} \\to \\mathbb{C}$ a primitive additive character. Let $\\chi$ be the quadratic residue character of $\\mathbb{Z}/p\\mathbb{Z}$, transported to $\\mathbb{C}$. Prove that the Gauss sum $g = \\sum_{n} \\chi(n)\\,\\psi(n)$ satisfies $g^2 = (-1)^{(p-1)/2}\\, p$.",
+    "proofStrategy": "The proof is a clean reduction to Mathlib's generic `gaussSum_sq`, which states $g^2 = \\chi(-1)\\,\\#F$ for any nontrivial quadratic multiplicative character $\\chi$ and primitive additive character $\\psi$ over a finite field $F$. Three leaf facts feed it: (1) `chiC_isQuadratic` — the transported character is quadratic; (2) `chiC_ne_one` — it is nontrivial (the ring hom $\\mathbb{Z} \\to \\mathbb{C}$ is injective since $\\mathbb{C}$ has characteristic zero, and $\\operatorname{ringChar}(\\mathbb{Z}/p\\mathbb{Z}) = p \\neq 2$); (3) `chiC_neg_one` — $\\chi(-1) = (-1)^{(p-1)/2}$, the first supplement to quadratic reciprocity, obtained from `quadraticChar_neg_one` and `ZMod.χ₄_eq_neg_one_pow`. Substituting $\\#(\\mathbb{Z}/p\\mathbb{Z}) = p$ via `ZMod.card` finishes the computation.",
+    "keyInsights": [
+      "The typing obstruction is the crux of the formalization: `quadraticChar (ZMod p)` is ℤ-valued, but `gaussSum χ ψ` requires the multiplicative character χ and additive character ψ to share a codomain. The fix is to transport χ along the ring hom ℤ → ℂ via `MulChar.ringHomComp (Int.castRingHom ℂ)`, giving the ℂ-valued `chiC p`.",
+      "Nontriviality of the transported character reduces, via `MulChar.ringHomComp_ne_one_iff`, to injectivity of ℤ → ℂ (automatic since ℂ is `CharZero`) together with nontriviality of the original quadratic character, which holds because `ringChar (ZMod p) = p ≠ 2` for an odd prime.",
+      "Evaluating χ(-1) requires bridging two index conventions: `quadraticChar_neg_one` gives $(-1)^{p/2}$ while the reciprocity supplement is stated as $(-1)^{(p-1)/2}$. For odd $p = 2k+1$ these agree ($p/2 = k = (p-1)/2$ by `omega`), so the two forms are reconciled before transport to ℂ.",
+      "The entire mathematical content of $g^2 = \\chi(-1)\\,\\#F$ lives in Mathlib's `gaussSum_sq`; this entry is a faithful specialisation that supplies exactly the three hypotheses that lemma demands, with no axioms and no sorries."
+    ]
+  },
+  "conclusion": {
+    "summary": "The square of the quadratic Gauss sum, $g^2 = (-1)^{(p-1)/2}\\,p$, is machine-checked for every odd prime $p$ and primitive additive character $\\psi : \\mathbb{Z}/p\\mathbb{Z} \\to \\mathbb{C}$, by specialising Mathlib's `gaussSum_sq` to the ℂ-transported quadratic residue character.",
+    "implications": "This identity is the analytic engine behind Gauss's sixth proof of quadratic reciprocity and underlies the evaluation of the Legendre symbol via Gauss sums. It also gives the absolute value $|g| = \\sqrt{p}$ immediately, the starting point for the sign-determination problem (Gauss's theorem on the sign of the Gauss sum) and for the functional equation of Dirichlet $L$-functions attached to the quadratic character mod $p$.",
+    "openQuestions": [
+      "Can the sign of $g$ itself — $g = \\sqrt{p}$ for $p \\equiv 1 \\pmod 4$ and $g = i\\sqrt{p}$ for $p \\equiv 3 \\pmod 4$ (Gauss's hard theorem) — be formalized in Lean 4 on top of this $g^2$ identity?",
+      "Does the reduction generalize to the cubic and quartic Gauss sums over $\\mathbb{Z}/p\\mathbb{Z}$, whose squares/absolute values follow analogous but more delicate formulas?",
+      "Can this entry be combined with a Gauss-sum proof of quadratic reciprocity to give a self-contained gallery derivation of the reciprocity law?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The value χ(-1) = (-1)^((p-1)/2) used here is the first supplement to quadratic reciprocity, and g² = (-1)^((p-1)/2)·p is the central identity in Gauss's Gauss-sum proof of the reciprocity law."
+    },
+    {
+      "proofId": "gauss-wilson-non-cyclic",
+      "relationship": "related",
+      "description": "Both entries exploit the multiplicative structure of (ZMod p)× and the quadratic residue character; the Gauss sum is the discrete Fourier transform of that character."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/QuadraticGaussSumSquare.lean",
+    "axiomCount": 0,
+    "lineCount": 75,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "transported-character",
+      "title": "The ℂ-Valued Quadratic Character",
+      "startLine": 28,
+      "endLine": 39,
+      "summary": "Defines `chiC p : MulChar (ZMod p) ℂ` as the quadratic residue character transported along the ring hom ℤ → ℂ via `MulChar.ringHomComp (Int.castRingHom ℂ)`, and proves it is quadratic (`chiC_isQuadratic`) by transporting `quadraticChar_isQuadratic` along that hom."
+    },
+    {
+      "id": "nontriviality",
+      "title": "Nontriviality for Odd Primes",
+      "startLine": 41,
+      "endLine": 47,
+      "summary": "`chiC_ne_one` proves the transported character is nontrivial: injectivity of ℤ → ℂ (ℂ is CharZero) combined with `MulChar.ringHomComp_ne_one_iff` reduces this to `quadraticChar_ne_one`, which holds since `ringChar (ZMod p) = p ≠ 2`."
+    },
+    {
+      "id": "character-at-neg-one",
+      "title": "Value at -1: First Supplement",
+      "startLine": 49,
+      "endLine": 67,
+      "summary": "`chiC_neg_one` evaluates χ(-1) = (-1)^((p-1)/2) via `quadraticChar_neg_one` and `ZMod.χ₄_eq_neg_one_pow`, reconciling the p/2 and (p-1)/2 exponents for odd p (by `omega`) before transporting to ℂ."
+    },
+    {
+      "id": "gauss-sum-square",
+      "title": "Square of the Gauss Sum",
+      "startLine": 69,
+      "endLine": 74,
+      "summary": "`gaussSum_quadratic_sq` assembles the result: Mathlib's `gaussSum_sq` gives g² = χ(-1)·#F; substituting `chiC_neg_one` and `ZMod.card p` yields g² = (-1)^((p-1)/2)·p."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "note": "Introduces Gauss sums and the g² identity in the course of proving quadratic reciprocity."
+    },
+    {
+      "title": "A Classical Introduction to Modern Number Theory",
+      "author": "K. Ireland and M. Rosen",
+      "year": 1990,
+      "note": "Chapter 6 develops Gauss sums over finite fields and the identity g² = (-1)^((p-1)/2)·p (Proposition 6.3.1)."
+    },
+    {
+      "title": "Mathlib4: NumberTheory.GaussSum",
+      "author": "The Mathlib Community",
+      "year": 2024,
+      "note": "Provides the generic `gaussSum_sq` lemma specialised in this entry."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
- `quadratic-gauss-sum-square` proves the square of the quadratic Gauss sum: for an odd prime `p` and a primitive additive character `ψ : ZMod p → ℂ`, `gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) · p`, by specialising Mathlib's `gaussSum_sq` to the ℂ-transported quadratic residue character.
- **Build fix**: the file was registered build-pending and did **not** compile. `gaussSum_sq` unfolds `chiC p` to its `MulChar` structure literal, so `rw [h]` failed to match the folded `chiC p` in the goal. Restated `h` in folded form via a `calc` step (definitional equality), after which `chiC_neg_one` and `ZMod.card` rewrite syntactically.
- Docker-verified **GREEN** (7743/7743 jobs, 0 sorries, 0 axioms).
- Added the gallery entry `src/data/proofs/quadratic-gauss-sum-square/` (`meta.json` status=`verified`, badge=`mathlib`, axiomCount=0; `annotations.json` with 3 annotations) and synced `state.md`.

## Notes
- Branched off a fresh `research/*` branch because the stale `feature/researcher-6` remote had wildly divergent history (force-push would be destructive).
- No `loom:review-requested` — math PR for direct deployer merge per project policy.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.QuadraticGaussSumSquare` → green (7743/7743)
- [x] `meta.json` / `annotations.json` JSON-valid, schema matches sibling gallery entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)