### PR TITLE
research(four-square-distribution-oq-04): register build-verified Sign.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2334,6 +2334,7 @@ import Proofs.FourSquareDistribution
 import Proofs.FourSquareDistributionOQ01
 import Proofs.FourSquareDistributionOQ04
 import Proofs.FourSquareDistributionOQ04M8
+import Proofs.FourSquareDistributionOQ04Sign
 import Proofs.FourSquareRepresentations
 import Proofs.FourierSeries
 import Proofs.FourierSeriesOQ01


### PR DESCRIPTION
## Summary
- Register `Proofs.FourSquareDistributionOQ04Sign` in `Proofs.lean` (one import line). This is the **sign-count half** of the four-square orbit-size lemma — `signFiber_card` (#sign-flips of a fixed coordinate profile = `2^{#nonzero}`) and `card_pair_neg` — 0 sorry / 0 axiom, standard `Fintype.piFinset` / `Finset.prod` API.
- The file was authored under a prior backend blackout and left unregistered "register-when-Docker-free". This window Docker recovered (2 containers, ~5.6 GB free), so I **docker-built it green** (`Proofs.FourSquareDistributionOQ04Sign`, 7743 jobs, `=== Build succeeded ===`) and registered it.

## Scope
- **No meta status change.** The OQ04 open question is still gated on the genuine combinatorial residue `arrangement_card` (the multiset-arrangement / multinomial count) in `...OQ04Arrange.lean`, which is an Aristotle `prove_file` target (Aristotle currently 404). This PR only moves the already-verified sign-count infrastructure into the compiled build.

## Test plan
- [x] `LEAN_MEMORY_LIMIT=4096 ./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04Sign` → Build succeeded (7743 jobs).
- [x] File is 0 sorry / 0 axiom; only the single import line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)