### PR TITLE
research(three-squares): repair ThreeSquares.lean build (registered file was red on main)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -1649,8 +1649,6 @@ private lemma dirichletSublatticeRealBasisLinearIndependent
   -- by definition; `Matrix.row` is the identity coercion, so the two functions agree
   -- pointwise and we can convert.
   convert hLI using 1
-  funext i
-  rfl
 
 /-- **S16b ACT** — Promote `dirichletSublatticeRealBasisVec p r` from a linearly
 independent family (S16a) to a `Module.Basis` of the ambient pi-space `Fin 3 → ℝ`.
@@ -1989,8 +1987,8 @@ theorem needs_four_iff_excluded (n : ℕ) (hn : n ≥ 1) :
     squaresNeeded n = 4 ↔ IsExcludedForm n := by
   have hn0 : ¬ (n = 0) := by omega
   unfold squaresNeeded
-  split_ifs with h0 h1 h2 h3
-  · exact absurd h0 hn0
+  rw [if_neg hn0]
+  split_ifs with h1 h2 h3
   · -- n is a perfect square, so not excluded (a² + 0² + 0² = n)
     refine iff_of_false (by norm_num) ?_
     intro hexc
@@ -2001,10 +1999,10 @@ theorem needs_four_iff_excluded (n : ℕ) (hn : n ≥ 1) :
     intro hexc
     obtain ⟨a, b, hab⟩ := h2
     exact excluded_form_not_sum_three_sq hexc ⟨(a : ℤ), (b : ℤ), 0, by rw [← hab]; push_cast; ring⟩
-  · -- value 3: ¬IsExcludedForm n holds directly
+  · -- value 4: reached only when IsExcludedForm n (h3 : IsExcludedForm n)
+    exact iff_of_true rfl h3
+  · -- value 3: ¬IsExcludedForm n holds directly (h3 : ¬IsExcludedForm n)
     exact iff_of_false (by norm_num) h3
-  · -- value 4: reached only when IsExcludedForm n
-    exact iff_of_true rfl (not_not.mp h3)
 
 /-- The density of numbers needing 4 squares:
     |{n ≤ x : n = 4^a(8b+7)}| / x → 1/6 as x → ∞.


### PR DESCRIPTION
## Summary
`Proofs/ThreeSquares.lean` is **registered in `Proofs.lean` but did not compile** against Mathlib v4.26.0 — discovered while building the three-squares dependency chain for `zsqrtd-neg-two-oq-02`. This PR restores it to a green build (no axiom-budget change, 0 sorries).

## Fixes
1. **`dirichletSublatticeRealBasisLinearIndependent`**: `convert hLI using 1` now closes the goal outright, so the trailing `funext i; rfl` hit *"No goals to be solved"*. Removed the dead lines.
2. **`needs_four_iff_excluded`**: deriving `hn0 : ¬(n=0)` *before* `split_ifs` let it auto-discharge the leading `if n = 0` branch of `squaresNeeded`, collapsing five branches to four and shifting every hypothesis name (so e.g. `h1` became the 2-variable existential). Fixed by discharging that branch explicitly with `rw [if_neg hn0]` then `split_ifs with h1 h2 h3`; the residual `¬IsExcludedForm`/`IsExcludedForm` branches also came out in the opposite order, so the value-3 and value-4 bullets were swapped to match.

## Verification
```
⚠ [3524/3524] Built Proofs.ThreeSquares (15s)
Build completed successfully (3524 jobs).
=== Build succeeded ===
```
The `⚠` is the file's two intentional axioms (the open three-square sufficiency direction); no sorries, axiom budget unchanged.

Note: the unregistered `ThreeSquaresSufficiencyCorrected.lean` (a corrected conditional reduction of the sufficiency axiom) builds on this file but has a separate pre-existing issue (`legendreSym p` cannot synthesize `Fact (Nat.Prime p)` inside its `DirichletWitnessNe3` Prop); left unregistered for a follow-up.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.ThreeSquares` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)