### PR TITLE
Fix: descartes-rule-of-signs-oq-01 meta axiomCount 1→0, remove false axiom text

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -73,9 +73,9 @@
       "zero_sv_no_positive_roots, positive_root_count_from_sv: summary theorems"
     ],
     "dateAdded": "2026-02-24",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 1074,
-    "assumptions": "1 axiom: descartes_parity. See Lean source for the complete statement. 0 sorries remain.",
+    "assumptions": "0 axioms, 0 sorries in source. Former axiom descartes_parity was removed in #24803 — parity is now theorem descartes_parity, discharged by descartes_parity_proved (Part X). Status held conservative (axiomatized) pending a green Docker build before any verified flip.",
     "mathlib_version": "4.26.0",
     "theoremCount": 48,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

Corrects the stale `meta` block in `src/data/proofs/descartes-rule-of-signs-oq-01/meta.json` that still claimed an axiom removed in #24803.

## Evidence

**Before** (`meta` block):
- `axiomCount: 1`
- `assumptions: "1 axiom: descartes_parity. ..."` — references an axiom that no longer exists

**Source reality** (`proofs/Proofs/DescartesRuleOfSignsOQ01.lean`):
- `grep -c '^axiom '` → **0** (axiom removed in #24803; parity is now `theorem descartes_parity` discharged by `descartes_parity_proved`, Part X)
- standalone `sorry` tokens → **0** (only match is a comment on line 422)
- `leanFile` block already correctly reports `axiomCount: 0, sorries: 0`

**After** (`meta` block):
- `axiomCount: 0`
- `assumptions` rewritten to truthfully describe the de-axiomatization and note that status is held conservative pending a green Docker build.

## Scope note

This is the auditor's explicitly-authorized **conservative fallback**. A green Docker build is currently infeasible (cold olean cache + saturated/stuck build pool), so `status`/`badge` are deliberately left conservative (`axiomatized`/`axiom`) rather than flipped to `verified`. This removes the false claims without overclaiming; a later verified flip can follow a green build.

Closes #24850

---
Automated fix by lean-mechanic agent.