### PR TITLE
research(erdos-277-oq-02): repair Erdos277Problem build + register prime-power companion

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1269,6 +1269,7 @@ import Proofs.Erdos273Problem
 import Proofs.Erdos274Problem
 import Proofs.Erdos275Problem
 import Proofs.Erdos276Problem
+import Proofs.Erdos277PrimePowerAristotle
 import Proofs.Erdos277Problem
 import Proofs.Erdos278Problem
 import Proofs.Erdos279OQ04

--- a/proofs/Proofs/Erdos277Problem.lean
+++ b/proofs/Proofs/Erdos277Problem.lean
@@ -31,11 +31,7 @@
   - Related: Problems #276, #278 (covering systems)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.NumberTheory.Divisors
-import Mathlib.Data.Real.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib
 
 open Finset BigOperators
 
@@ -51,16 +47,17 @@ noncomputable def sigma (n : ℕ) : ℕ :=
 
 /-- σ(1) = 1. -/
 theorem sigma_one : sigma 1 = 1 := by
-  simp [sigma, Nat.divisors]
+  simp [sigma, Nat.divisors_one]
 
 /-- σ(p) = p + 1 for prime p. -/
 theorem sigma_prime (p : ℕ) (hp : Nat.Prime p) : sigma p = p + 1 := by
-  simp [sigma, hp.divisors, add_comm]
+  rw [sigma, hp.divisors, Finset.sum_pair hp.one_lt.ne]
+  omega
 
 /-- σ(n) ≥ n for all n ≥ 1. -/
 theorem sigma_ge_self (n : ℕ) (hn : n ≥ 1) : sigma n ≥ n := by
   unfold sigma
-  exact Finset.single_le_sum (fun _ _ => Nat.zero_le _)
+  exact Finset.single_le_sum (f := fun x => x) (fun _ _ => Nat.zero_le _)
     (Nat.mem_divisors.mpr ⟨dvd_refl n, by omega⟩)
 
 /-- The abundancy ratio σ(n)/n. -/
@@ -245,7 +242,7 @@ def IsNonTrivialCovering (S : Finset Congruence) : Prop :=
 def HasNonTrivialCoveringWithDivisorModuli (n : ℕ) : Prop :=
   ∃ S : Finset Congruence, IsNonTrivialCovering S ∧ AllModuliDivide S n
 
-/-- Haight actually proved the stronger result about non-trivial coverings. -/
+/- Haight actually proved the stronger result about non-trivial coverings. -/
 /-
 ## Part VI: Key Properties of Covering Systems
 -/
@@ -254,8 +251,8 @@ def HasNonTrivialCoveringWithDivisorModuli (n : ℕ) : Prop :=
 noncomputable def reciprocalSum (S : Finset Congruence) : ℝ :=
   ∑ c ∈ S, (1 : ℝ) / (c.modulus : ℝ)
 
-/-- In a covering system with distinct moduli, ∑ 1/m_i ≥ 1. -/
-/-- This is related to the "Chinese Remainder" aspect of coverings:
+/-- In a covering system with distinct moduli, ∑ 1/m_i ≥ 1.
+    This is related to the "Chinese Remainder" aspect of coverings:
     every modulus that appears in the system has some residue class in S. -/
 theorem covering_crt_connection :
     ∀ S : Finset Congruence, IsCoveringSystem S →
@@ -300,7 +297,7 @@ def IsHighlyComposite (n : ℕ) : Prop :=
 def IsSuperabundant (n : ℕ) : Prop :=
   ∀ m : ℕ, m < n → abundancyRatio m < abundancyRatio n
 
-/-- Haight used properties related to superabundance. -/
+/- Haight used properties related to superabundance. -/
 /-
 ## Part IX: Connections to Other Problems
 -/


### PR DESCRIPTION
## Summary
`Proofs/Erdos277Problem.lean` is **registered in `Proofs.lean` but did not compile** against Mathlib v4.26.0 (authored under a build blackout). This PR repairs it to green and registers the now-verified prime-power companion.

## Fixes in `Erdos277Problem.lean`
- **Stale import** `Mathlib.Algebra.BigOperators.Group.Finset` (split/removed at this pin) → `import Mathlib`.
- **`sigma_one`**: `simp [sigma, Nat.divisors]` left a filtered sum → use `Nat.divisors_one` so simp lands on `{1}`.
- **`sigma_prime`**: compute the `{1, p}` sum directly via `Finset.sum_pair hp.one_lt.ne`, then `omega`.
- **`sigma_ge_self`**: give `Finset.single_le_sum` its `f := fun x => x` so the summand function is inferred (was an unsolved type mismatch).
- **Three orphaned `/--` doc comments** (no following declaration, or two stacked before one theorem) demoted to `/-` block comments — these were hard parse errors masking the proof errors above.

## Registration
With the dependency fixed, registered the verified companion `Erdos277PrimePowerAristotle.lean` (0 sorries / 0 axioms) which proves `no_proper_covering_prime_power`: non-vacuity of the corrected Erdős #277 question for **every prime power** `p^k`, via elementary induction (PRs #24844/#24851, previously build-pending).

## Verification
```
⚠ [7743/7744] Built Proofs.Erdos277Problem (20s)
✔ [7744/7744] Built Proofs.Erdos277PrimePowerAristotle (5.9s)
Build completed successfully (7744 jobs).
=== Build succeeded ===
```
The `⚠` is the main file's intentional deep `haight_theorem` axiom (the open Erdős conjecture input), untouched here.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos277PrimePowerAristotle` (builds the repaired main file + companion) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)