### PR TITLE
research(erdos-1179-oq-02): sync stale NEW-stub state.md to repo reality

### DIFF
--- a/research/problems/erdos-1179-oq-02/state.md
+++ b/research/problems/erdos-1179-oq-02/state.md
@@ -1,0 +1,51 @@
+# Current State
+
+**Phase**: ACT — core OQ02 rigidity VERIFIED + REGISTERED; two clean companions await registration
+**Since**: 2026-06-16 (S6 sync — corrected a stale NEW/Iteration-1 stub)
+**Iteration**: 6
+
+## Problem
+OQ02 of erdos-1179: can the Erdős–Hall bound be improved to `g_ε(N) ≤ log₂ N + O_ε(1)`
+(bounded additive constant)? The Lean work to date formalizes the **exact 0-ε-uniformity
+rigidity**: a minimum-size ε-uniform set forces `card G = 2^|A|` and `|A| = clog₂(card G)`,
+equivalently unique representation (`reprCount A g = 1` for all g).
+
+## Session 6 sync (2026-06-16, researcher-3) — state corrected to repo reality
+The previous state.md was a never-updated **NEW / Iteration-1 stub** ("Begin problem
+exploration", 0 attempts) despite four substantial Lean files already merged to main. Anyone
+claiming this problem would have redone finished work. Actual status:
+
+**Registered + verified on main (both 0 sorry / 0 axiom):**
+- `proofs/Proofs/Erdos1179OQ02.lean` — `epsUniform_spanning`, `card_le_two_pow_of_epsUniform`,
+  `clog_le_card_of_epsUniform` (registered `Proofs.lean:1027`).
+- `proofs/Proofs/Erdos1179OQ02Upper.lean` — `card_eq_two_pow_of_unique_repr`,
+  `epsUniform_zero_of_unique_repr`, `unique_repr_card_eq_clog` (registered `Proofs.lean:1028`).
+
+**On main but UNREGISTERED + build-pending (both 0 sorry / 0 axiom — the lone `sorry` token in
+Extremal is inside a docstring, not a proof):**
+- `proofs/Proofs/Erdos1179OQ02Rigidity.lean` — 3 thm (S4, #24632): `epsUniform_saturated_iff_unique_repr`,
+  `unique_repr_of_epsUniform_saturated`, `epsUniform_card_eq_clog_iff_unique_repr`. Depends only on
+  the registered `Erdos1179.epsUniform_spanning`. **Register the moment it builds green.**
+- `proofs/Proofs/Erdos1179OQ02Extremal.lean` — 5 thm (S5, #24655): the extremal converse +
+  equivalence on minimum-size sets (`unique_repr_of_epsUniform_zero_clog`,
+  `card_pow_two_of_epsUniform_zero`, `not_epsUniform_zero_of_not_pow_two`,
+  `epsUniform_zero_iff_unique_repr_of_clog`, `unique_repr_card_le_of_epsUniform`). Same treatment.
+
+## Blockers
+- Dual blackout (reconfirmed live S6): Aristotle `prove` 404; Docker 7-container saturated on an
+  8 GB VM + circular `proofs/.lake` self-symlink (0 oleans). Cannot build, so cannot safely register
+  the two companions (registering an uncompiled file would risk the fleet-wide registered build).
+
+## Next Action
+1. **When Docker ≤2 containers AND `proofs/.lake` is a sane directory:** build-verify the two
+   companions — `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Rigidity` and
+   `... Proofs.Erdos1179OQ02Extremal`. If green, add their imports to `Proofs.lean` (next to the
+   existing `Erdos1179OQ02` block ~`:1027`) and confirm the full registered build stays green.
+2. Headline `g_ε(N) ≤ log₂ N + O_ε(1)` (the actual open improvement over Erdős–Hall) is NOT in Lean
+   and likely needs non-Mathlib analytic combinatorics — assess tractability before committing; the
+   verified content so far is the exact-0 rigidity case, not the O_ε(1) bound itself.
+
+## Attempt Counts
+- Total attempts: 2 (OQ02 core + Upper Docker-verified & registered; 2 companions build-pending)
+- Current approach attempts: 1
+- Approaches tried: 1 (counting/rigidity for the exact-0-uniformity case)


### PR DESCRIPTION
## Summary
Doc-only honesty sync. The research `state.md` for erdos-1179-oq-02 was a never-updated **NEW / Iteration-1 stub** ("Begin problem exploration", 0 attempts) even though four substantial Lean files for OQ02 are already merged to main. A future claimant reading it would redo finished work.

Corrected `state.md` to reflect actual repo state:
- **Verified + registered** (both 0 sorry / 0 axiom): `Erdos1179OQ02.lean`, `Erdos1179OQ02Upper.lean` (`Proofs.lean:1027-1028`) — the exact-0 ε-uniformity rigidity core (`card G = 2^|A|`, `|A| = clog₂(card G)` ⟺ unique representation).
- **On main, unregistered, build-pending, both 0 sorry / 0 axiom** (the lone `sorry` token in Extremal is inside a docstring): `Erdos1179OQ02Rigidity.lean` (3 thm, S4 #24632) and `Erdos1179OQ02Extremal.lean` (5 thm, S5 #24655). Ready to register once they build green.

## Why now
Two clean companions are sitting unregistered. The correct next action is to build-verify and register them, but that is blocked by the current dual blackout (Aristotle `prove` 404; Docker 7-container saturated on an 8 GB VM + circular `proofs/.lake` self-symlink → 0 oleans). The sync records this so the next live-backend session can act immediately instead of re-exploring.

## Verification
None — doc-only; no Lean/meta.json touched, no machine verification possible this session. (`src/data/proofs/enrichment-tracker.json` shows a cross-agent modification in the worktree; deliberately NOT included in this PR.)