### PR TITLE
research(binomial-marginal): complete multinomial→binomial marginal (3 leaf lemmas)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean
@@ -57,10 +57,15 @@ The proof is a reindex-then-fold:
 
 ## Status
 
-The reduction (combining the leaves + the power fold) is written out. The three
-combinatorial leaf lemmas are stated precisely and left as `sorry` — they are
-self-contained, mechanical, and are ideal Aristotle targets (HARD-but-known).
-Build-pending: Docker pool saturated and Aristotle backend offline this session.
+Complete: the three combinatorial leaf lemmas (A reindexing bijection, B
+multinomial coefficient split, C product split) are proved from Mathlib, and the
+main theorem `multinomial_marginal_binomial` assembles them with the multinomial
+theorem `Finset.sum_pow_eq_sum_piAntidiag`. 0 sorries, 0 axioms.
+
+Note: the same marginal law is also established independently in
+`BinomialTheoremOQ02OQ01OQ02.lean` (`multinomial_marginal_pmf`, an inline
+`if`-based bijection over `multinomialProb`). This file's contribution is the
+clean `Function.update`-based decomposition into three reusable leaf lemmas.
 -/
 import Mathlib.Data.Nat.Choose.Multinomial
 import Mathlib.Algebra.BigOperators.Ring.Finset
@@ -89,7 +94,76 @@ theorem marginal_sum_reindex
     (G : (α → ℕ) → ℝ) :
     ∑ k ∈ (s.piAntidiag n).filter (fun k => k i = m), G k =
     ∑ f ∈ (s.erase i).piAntidiag (n - m), G (Function.update f i m) := by
-  sorry
+  have hi_notin : i ∉ s.erase i := Finset.notMem_erase i s
+  refine Finset.sum_nbij'
+    (fun k => Function.update k i 0)
+    (fun f => Function.update f i m)
+    ?_ ?_ ?_ ?_ ?_
+  · -- forward image: σ k ∈ (s.erase i).piAntidiag (n - m)
+    intro k hk
+    simp only [Finset.mem_filter, Finset.mem_piAntidiag] at hk
+    obtain ⟨⟨hksum, hksup⟩, hki⟩ := hk
+    rw [Finset.mem_piAntidiag]
+    refine ⟨?_, ?_⟩
+    · have h1 : ∑ a ∈ s.erase i, Function.update k i 0 a = ∑ a ∈ s.erase i, k a := by
+        apply Finset.sum_congr rfl
+        intro a ha
+        rw [Function.update_of_ne (Finset.ne_of_mem_erase ha)]
+      have h2 : k i + ∑ a ∈ s.erase i, k a = n :=
+        (Finset.add_sum_erase s k hi).trans hksum
+      rw [h1]; omega
+    · intro a ha
+      by_cases haa : a = i
+      · subst haa; simp at ha
+      · simp only [Function.update_of_ne haa] at ha
+        exact Finset.mem_erase.mpr ⟨haa, hksup a ha⟩
+  · -- backward image: τ f ∈ (s.piAntidiag n).filter (· i = m)
+    intro f hf
+    simp only [Finset.mem_piAntidiag] at hf
+    obtain ⟨hfsum, hfsup⟩ := hf
+    have hfi : f i = 0 := by
+      by_contra h; exact hi_notin (hfsup i h)
+    rw [Finset.mem_filter, Finset.mem_piAntidiag]
+    refine ⟨⟨?_, ?_⟩, ?_⟩
+    · have h1 : ∑ a ∈ s.erase i, Function.update f i m a = ∑ a ∈ s.erase i, f a := by
+        apply Finset.sum_congr rfl
+        intro a ha
+        rw [Function.update_of_ne (Finset.ne_of_mem_erase ha)]
+      have h2 : Function.update f i m i + ∑ a ∈ s.erase i, Function.update f i m a
+          = ∑ a ∈ s, Function.update f i m a := Finset.add_sum_erase s (Function.update f i m) hi
+      rw [← h2, Function.update_self, h1, hfsum]; omega
+    · intro a ha
+      by_cases haa : a = i
+      · rw [haa]; exact hi
+      · simp only [Function.update_of_ne haa] at ha
+        exact Finset.erase_subset i s (hfsup a ha)
+    · exact Function.update_self i m f
+  · -- left inverse: τ (σ k) = k
+    intro k hk
+    simp only [Finset.mem_filter, Finset.mem_piAntidiag] at hk
+    obtain ⟨_, hki⟩ := hk
+    funext a
+    rcases eq_or_ne a i with rfl | haa
+    · simp [Function.update_self, hki]
+    · simp [Function.update_of_ne haa]
+  · -- right inverse: σ (τ f) = f
+    intro f hf
+    simp only [Finset.mem_piAntidiag] at hf
+    have hfi : f i = 0 := by
+      by_contra h; exact hi_notin (hf.2 i h)
+    funext a
+    rcases eq_or_ne a i with rfl | haa
+    · simp [Function.update_self, hfi]
+    · simp [Function.update_of_ne haa]
+  · -- summand equality: G k = G (update (σ k) i m)
+    intro k hk
+    simp only [Finset.mem_filter, Finset.mem_piAntidiag] at hk
+    obtain ⟨_, hki⟩ := hk
+    congr 1
+    funext a
+    rcases eq_or_ne a i with rfl | haa
+    · simp [Function.update_self, hki]
+    · simp [Function.update_of_ne haa]
 
 /-! ## Leaf B — multinomial coefficient split (Aristotle target)
 
@@ -105,7 +179,20 @@ theorem multinomial_update_eq
     (hfi : f i = 0) (hfsum : ∑ j ∈ s.erase i, f j = n - m) :
     Nat.multinomial s (Function.update f i m)
       = n.choose m * Nat.multinomial (s.erase i) f := by
-  sorry
+  have hi_notin : i ∉ s.erase i := Finset.notMem_erase i s
+  have hsum_eq : ∑ j ∈ s.erase i, (Function.update f i m) j = ∑ j ∈ s.erase i, f j := by
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [Function.update_of_ne (Finset.ne_of_mem_erase hj)]
+  have hmulti_eq : Nat.multinomial (s.erase i) (Function.update f i m)
+      = Nat.multinomial (s.erase i) f := by
+    apply Nat.multinomial_congr
+    intro a ha
+    rw [Function.update_of_ne (Finset.ne_of_mem_erase ha)]
+  conv_lhs => rw [show s = insert i (s.erase i) from (Finset.insert_erase hi).symm]
+  rw [Nat.multinomial_insert hi_notin]
+  simp only [Function.update_self]
+  rw [hsum_eq, hfsum, hmulti_eq, Nat.add_sub_cancel' hm]
 
 /-! ## Leaf C — product split (Aristotle target)
 
@@ -118,7 +205,11 @@ theorem prod_update_eq
     (s : Finset α) (p : α → ℝ) (i : α) (hi : i ∈ s) (m : ℕ) (f : α → ℕ) :
     ∏ j ∈ s, p j ^ (Function.update f i m) j
       = p i ^ m * ∏ j ∈ s.erase i, p j ^ f j := by
-  sorry
+  rw [← Finset.mul_prod_erase s (fun j => p j ^ (Function.update f i m) j) hi]
+  simp only [Function.update_self]
+  congr 1
+  refine Finset.prod_congr rfl (fun j hj => ?_)
+  rw [Function.update_of_ne (Finset.ne_of_mem_erase hj)]
 
 /-! ## Main theorem — marginal distribution is binomial
 
@@ -146,7 +237,7 @@ theorem multinomial_marginal_binomial
     obtain ⟨hfsum, hfsupp⟩ := hf
     have hfi : f i = 0 := by
       by_contra h
-      exact (Finset.not_mem_erase i s) (hfsupp i h)
+      exact (Finset.notMem_erase i s) (hfsupp i h)
     rw [multinomial_update_eq s i hi m n hm f hfi hfsum,
         prod_update_eq s p i hi m f]
     push_cast
@@ -158,6 +249,5 @@ theorem multinomial_marginal_binomial
   rw [← Finset.sum_pow_eq_sum_piAntidiag (s.erase i) p (n - m)]
   -- Step 5: `∑_{s.erase i} p = 1 - p i` from the normalization `∑_s p = 1`.
   rw [Finset.sum_erase_eq_sub hi, hp_sum]
-  ring
 
 end BinomialMultinomialMarginal

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-02",
   "title": "Multinomial Marginal Distribution is Binomial via piAntidiag reindexing",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,10 +28,11 @@
     "goal": "Close BinomialTheoremOQ02OQ01OQ01.multinomial_marginal_binomial. This session produced proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean: the full reduction (combining Leaves A/B/C + the in-line power fold) written in tactics, with the three combinatorial leaves stated precisely as sorry (Aristotle targets). Build-pending: Docker pool saturated, Aristotle backend offline."
   },
   "knowledge": {
-    "progressSummary": "ACT (researcher-9, 2026-06-15): decomposed the parent's marginal-binomial sorry into a reindex bijection + coefficient split + product split + multinomial-theorem power fold; wrote the full reduction in tactics and isolated the three mechanical combinatorial leaves as Aristotle-ingestible sorries. All Mathlib API verified against mathlib4_docs. Build-pending (both backends offline this session).",
+    "progressSummary": "COMPLETED (2026-06-16): proved all three combinatorial leaf lemmas of BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean from Mathlib (Aristotle 404 all session, done by hand mirroring the verified sibling BinomialTheoremOQ02OQ01OQ02.lean). Leaf A marginal_sum_reindex via Finset.sum_nbij (forward update k i 0, inverse update f i m); Leaf B multinomial_update_eq via Nat.multinomial_insert + Nat.multinomial_congr; Leaf C prod_update_eq via Finset.mul_prod_erase. Main theorem multinomial_marginal_binomial now 0 sorries / 0 axioms. Docker-verified GREEN (3060 jobs). Same marginal law also proved independently in sibling as multinomial_marginal_pmf; this file is the clean Function.update decomposition into reusable leaves.",
     "builtItems": [
       "proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean — namespace BinomialMultinomialMarginal: theorem multinomial_marginal_binomial proved modulo three leaf lemmas; reduction (sum_congr with B+C, mul_sum, sum_pow_eq_sum_piAntidiag reversed, sum_erase_eq_sub, ring) written in full.",
-      "Registered the file in proofs/Proofs.lean (import after BinomialTheoremOQ02OQ01OQ01OQ01OQ01)."
+      "Registered the file in proofs/Proofs.lean (import after BinomialTheoremOQ02OQ01OQ01OQ01OQ01).",
+      "2026-06-16: discharged the 3 leaf sorries (A/B/C); full file Docker-verified GREEN (3060 jobs). 0 sorries, 0 axioms."
     ],
     "insights": [
       "The whole proof is reindex-then-fold: fix k_i=m, peel coordinate i off s via s = insert i (s.erase i), then the residual sum over compositions of n-m on s.erase i is exactly the multinomial theorem, giving (1-p_i)^(n-m).",
@@ -43,9 +44,8 @@
       "Mathlib has no packaged 'marginal of multinomial is binomial' lemma; this is a gallery-internal de-sorry, not an upstream contribution candidate."
     ],
     "nextSteps": [
-      "When Aristotle recovers: submit BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean (or the three leaf lemmas individually) to fill Leaves A/B/C.",
-      "When Docker has <=2 containers: build Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02 to verify the reduction and the (currently sorry-gated) leaves once filled.",
-      "After completion, reuse Leaf A + Leaf B to attack multinomial_mean and multinomial_covariance (parent sorries)."
+      "Reuse Leaf A (marginal_sum_reindex) and Leaf B (multinomial_update_eq) to attack the parent BinomialTheoremOQ02OQ01OQ01 sorries multinomial_mean and multinomial_covariance.",
+      "The parent multinomial_marginal_binomial sorry can now be discharged by referencing this file or the sibling multinomial_marginal_pmf."
     ]
   },
   "tags": [
@@ -80,7 +80,7 @@
     ]
   },
   "started": "2026-06-15T00:00:00.000Z",
-  "lastUpdate": "2026-06-15T00:00:00.000Z",
+  "lastUpdate": "2026-06-16T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Discharges the three combinatorial leaf `sorry`s in `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ02.lean`, completing the formal proof that the marginal distribution of a single count in a `Multinomial(n; p)` is `Binomial(n, p_i)`:

$$\sum_{\substack{k \in \mathrm{piAntidiag}\,s\,n \\ k_i = m}} \binom{n}{k} \prod_{j\in s} p_j^{k_j} = \binom{n}{m}\, p_i^m\,(1-p_i)^{n-m}.$$

The main theorem `multinomial_marginal_binomial` was already assembled (reindex → coefficient split → product split → multinomial-theorem power fold); this PR proves the three leaves it depended on:

- **Leaf A** `marginal_sum_reindex` — the reindexing bijection `{k ∈ piAntidiag s n | k i = m} ≃ piAntidiag (s.erase i) (n-m)` via `Finset.sum_nbij'`, forward map `Function.update k i 0`, inverse `Function.update f i m`.
- **Leaf B** `multinomial_update_eq` — the multinomial coefficient split via `Nat.multinomial_insert` + `Nat.multinomial_congr`.
- **Leaf C** `prod_update_eq` — the product split via `Finset.mul_prod_erase`.

Result: **0 sorries, 0 axioms** in the file.

## Notes

- Aristotle was returning 404 the entire session, so the leaves were proved by hand, mirroring the verified sibling `BinomialTheoremOQ02OQ01OQ02.lean` (`multinomial_marginal_pmf`, an inline `if`-based bijection over `multinomialProb`). This file's contribution is the clean `Function.update`-based decomposition into three **reusable** leaf lemmas — Leaf A and Leaf B directly serve the parent file's still-open `multinomial_mean` / `multinomial_covariance` sorries.
- Honest scope: this is a known result (marginal of multinomial is binomial); the value here is the formalization + reusable decomposition, not new mathematics.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02` — **GREEN, 3060 jobs** (8 GB cap).
- [x] 0 `sorry`, 0 `axiom` in the file.
- [ ] Deployer build-gate re-verification before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)