### PR TITLE
research(fermat-defect-one-oq-02): fix dvd_sub' drift + register n=3 infinitude companions

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2309,6 +2309,9 @@ import Proofs.FairGamesTheoremOQ02OQ03
 import Proofs.FairGamesTheoremOQ02OQ04
 import Proofs.FairGamesTheoremOQ03
 import Proofs.FairGamesTheoremOQ03Aristotle
+import Proofs.FermatDefectOne
+import Proofs.FermatDefectOneFamilies
+import Proofs.FermatDefectOneNegInfinitude
 import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01
 import Proofs.FermatTwoSquaresOQ01OQ03

--- a/proofs/Proofs/FermatDefectOneNegInfinitude.lean
+++ b/proofs/Proofs/FermatDefectOneNegInfinitude.lean
@@ -46,12 +46,12 @@ lemma neg_family_coprime (t : ℕ) (ht : 1 ≤ t) :
     intro d hda hdc
     have hdt : d ∣ t := by
       have hdta : d ∣ t * (9 * t ^ 3 - 1) := hda.mul_left t
-      have h := Nat.dvd_sub' hdc hdta
+      have h := Nat.dvd_sub hdc hdta
       rwa [hca, Nat.add_sub_cancel_left] at h
     have hd3 : d ∣ 9 * t ^ 3 := by
       have he : 9 * t ^ 3 = 9 * t ^ 2 * t := by ring
       rw [he]; exact hdt.mul_left (9 * t ^ 2)
-    have h := Nat.dvd_sub' hd3 hda
+    have h := Nat.dvd_sub hd3 hda
     rwa [Nat.sub_sub_self hpos] at h
   have hg := key (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4))
     (Nat.gcd_dvd_left _ _) (Nat.gcd_dvd_right _ _)

--- a/research/problems/fermat-defect-one-oq-02/knowledge.md
+++ b/research/problems/fermat-defect-one-oq-02/knowledge.md
@@ -107,3 +107,30 @@ documented a concrete registration gap. Docker down (no build/edit of Lean).
 
 **Recommendation:** stop serving this slug for proof work (marked `blocked`). The
 only remaining actions are Docker-gated registration and the abc-hard n≥4 direction.
+
+### Session (researcher-7, 2026-06-15) — RESOLVED the registration gap (Docker-verified)
+
+**Mode**: REVISIT · **Outcome**: progress (registration gap closed; build bug fixed).
+
+- **Build bug found & fixed.** `FermatDefectOneNegInfinitude.lean` did NOT actually
+  compile — it used `Nat.dvd_sub'` (lines 49, 54), which was **removed in Mathlib
+  v4.26.0** ("Unknown constant"). Replaced both with `Nat.dvd_sub` (same 2-arg
+  signature `k ∣ m → k ∣ n → k ∣ m - n`, no ordering hypothesis — confirmed against
+  building repo files e.g. `Erdos1201Problem`, `Erdos731Problem`, `InfinitudePrimes4k3`).
+  Confirms the recurring lesson: a merged "0-sorry complete" file is NOT verified
+  until Docker-built.
+- **Docker-verified green** (`docker-build.sh Proofs.FermatDefectOneNegInfinitude`,
+  7744 jobs, only the expected `FermatDefectOne.lean:142` headline-sorry warning +
+  a harmless `mul_le_mul_right'` deprecation warning). `FermatDefectOneFamilies`
+  likewise built (only the same deprecation warning).
+- **Registered** `FermatDefectOne`, `FermatDefectOneFamilies`,
+  `FermatDefectOneNegInfinitude` in `proofs/Proofs.lean` (skipped
+  `FermatDefectOneAristotle` — it carries open companion sorries by design).
+- **Gallery meta enriched** (`src/data/proofs/fermat-defect-one/meta.json`):
+  description + originalContributions now record that both signs of the defect occur
+  *infinitely often* at n=3 (`defect_pos_witnesses_infinite`,
+  `defect_neg_witnesses_infinite`), not merely existence. Status stays `axiomatized`
+  (headline still open) — no overclaim.
+- **Net effect:** the n=3 sign-symmetric infinitude result is now machine-checked
+  and part of the build (was orphaned/unregistered + silently broken). Slug remains
+  saturated for proof work; n≥4 is abc-hard and out of scope.

--- a/research/problems/fermat-defect-one-oq-02/state.md
+++ b/research/problems/fermat-defect-one-oq-02/state.md
@@ -1,24 +1,29 @@
 # Research State: fermat-defect-one-oq-02
 
 ## Current State
-**Phase**: NEW
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-15T06:15:07.078468+00:00
-**Iteration**: 1
+**Since**: 2026-06-15
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context from the parent gallery proof (fermat-defect-one).
+n=3 is fully settled in its strongest form (both signs occur infinitely often).
+The complete companion files are now build-verified and registered. The headline
+`∀ n ≥ 3` remains an open (likely false-as-stated for n≥4) conjecture.
 
 ## Active Approach
-None yet.
+Integration/verification of merged-but-unregistered companion proofs.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None for the n=3 result. The n≥4 direction is abc/Pillai-hard (no Mathlib bearer)
+and out of scope — do NOT submit the headline sorry to Aristotle (OPEN, not HARD).
 
 ## Next Action
-Begin OBSERVE phase: study the parent proof and identify the key lemmas needed.
+Slug is effectively saturated for tractable work. n=3 verified + registered.
+The only remaining direction is the abc-hard n≥4 emptiness, which is not
+session-sized. Recommend keeping `blocked`/closed for proof work.

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -2,7 +2,7 @@
   "id": "fermat-defect-one",
   "title": "Fermat Defect-One Conjecture",
   "slug": "fermat-defect-one",
-  "description": "The Fermat defect-one conjecture asks whether $|a^n + b^n - c^n| = 1$ admits a primitive nontrivial solution ($2 \\le a \\le b < c$, $\\gcd(a,b,c) = 1$) for every $n \\ge 3$ — the natural follow-up to Fermat's Last Theorem, which rules out the zero-defect case. Both signs of the defect are verified at $n = 3$: $6^3 + 8^3 + 1 = 9^3$ (negative) and $9^3 + 10^3 = 12^3 + 1$ (positive, a near-cousin of the Ramanujan-Hardy taxicab number 1729). The headline statement for all $n \\ge 3$ is left as an open conjecture (sorry placeholder).",
+  "description": "The Fermat defect-one conjecture asks whether $|a^n + b^n - c^n| = 1$ admits a primitive nontrivial solution ($2 \\le a \\le b < c$, $\\gcd(a,b,c) = 1$) for every $n \\ge 3$ — the natural follow-up to Fermat's Last Theorem, which rules out the zero-defect case. Both signs of the defect are verified at $n = 3$: $6^3 + 8^3 + 1 = 9^3$ (negative) and $9^3 + 10^3 = 12^3 + 1$ (positive, a near-cousin of the Ramanujan-Hardy taxicab number 1729). In fact each sign occurs *infinitely often* at $n = 3$ along explicit primitive polynomial families ($9t^3-1, 9t^4-3t, 9t^4$ for the negative defect; $9s^3+1, 9s^4, 9s^4+3s$ for the positive), so the set of attainable $c$ is infinite on both sides. The headline statement for all $n \\ge 3$ is left as an open conjecture (sorry placeholder).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-09",
@@ -59,6 +59,8 @@
       "fermat_defect_three_neg: verified primitive negative-defect witness 6^3 + 8^3 + 1 = 9^3 (gcd(6,8,9)=1) via native_decide",
       "fermat_defect_three_pos: verified primitive positive-defect witness 9^3 + 10^3 = 12^3 + 1 (gcd(9,10,12)=1) via native_decide — the taxicab number 1729 shifted by one",
       "fermat_defect_three: derived defect-one existence at n=3 from the negative-defect benchmark",
+      "defect_pos_witnesses_infinite (FermatDefectOneFamilies.lean): the positive-defect family (9s^3+1, 9s^4, 9s^4+3s) gives infinitely many primitive witnesses at n=3 (set of attainable c is infinite, via a strictly-monotone injection)",
+      "defect_neg_witnesses_infinite (FermatDefectOneNegInfinitude.lean): the negative-defect family (9t^3-1, 9t^4-3t, 9t^4) gives infinitely many primitive witnesses at n=3, closing the sign symmetry — both signs occur infinitely often at n=3",
       "fermat_defect_one_exists: headline open conjecture stated as a sorry'd target for all n ≥ 3"
     ]
   },


### PR DESCRIPTION
## Summary
The `fermat-defect-one` companion files were **merged but never registered** in `proofs/Proofs.lean`, and one of them was **silently broken** — a textbook "complete 0-sorry attempt ≠ verified" case. This PR fixes the build bug, Docker-verifies, and registers them so the n=3 result is actually part of the build.

- **Build fix:** `FermatDefectOneNegInfinitude.lean` used `Nat.dvd_sub'` (removed in Mathlib v4.26.0 → "Unknown constant"). Replaced both uses with `Nat.dvd_sub` (identical 2-arg signature `k ∣ m → k ∣ n → k ∣ m - n`, matching building repo files like `Erdos1201Problem`, `Erdos731Problem`, `InfinitudePrimes4k3`).
- **Registered** `FermatDefectOne`, `FermatDefectOneFamilies`, `FermatDefectOneNegInfinitude` in `Proofs.lean` (skipped `FermatDefectOneAristotle`, which carries open companion sorries by design).
- **Gallery meta enriched** to record that **both signs of the defect occur infinitely often at n=3** via explicit primitive polynomial families (`defect_pos_witnesses_infinite`, `defect_neg_witnesses_infinite`) — previously only single-witness existence was noted. Status stays `axiomatized` (the headline `∀ n ≥ 3` is genuinely open and likely false-as-stated for n ≥ 4).

## Verification
- `docker-build.sh Proofs.FermatDefectOneNegInfinitude` → **GREEN** (7744 jobs)
- `docker-build.sh Proofs.FermatDefectOneFamilies` → **GREEN** (7744 jobs)
- Only warnings: the expected `FermatDefectOne.lean:142` open-headline `sorry`, and a harmless `mul_le_mul_right'` deprecation.

## Test plan
- [x] Both companion modules compile under the Docker wrapper
- [x] No new axioms/sorries introduced (headline sorry pre-existing and honest)
- [x] meta.json remains valid JSON; status not overclaimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)