### PR TITLE
research(four-square-oq-04): register verified Sign.lean (sign-count component)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2333,6 +2333,7 @@ import Proofs.FourSquareDistribution
 import Proofs.FourSquareDistributionOQ01
 import Proofs.FourSquareDistributionOQ04
 import Proofs.FourSquareDistributionOQ04M8
+import Proofs.FourSquareDistributionOQ04Sign
 import Proofs.FourSquareRepresentations
 import Proofs.FourierSeries
 import Proofs.FourierSeriesOQ01


### PR DESCRIPTION
## Summary

`proofs/Proofs/FourSquareDistributionOQ04Sign.lean` (**0 sorries, 0 axioms**, Mathlib-only) proves the sign-count component of the four-square distribution problem — `signFiber_card`: a fiber of the sign-assignment map has size `2^(#nonzero coords)`. It builds GREEN standalone but was never registered in `Proofs.lean`. This PR registers it so the verified lemma joins the continuously build-checked corpus.

## Notes

- Verified: `./proofs/scripts/docker-build.sh Proofs.FourSquareDistributionOQ04Sign` → **GREEN, 7743 jobs**.
- Scope is deliberately narrow (one import line). The remaining residue of the open question — `arrangement_card` (`Arrange.lean`) and the orbit/stabilizer `sorry` (`Decomp.lean`) — is unchanged and still gated on Aristotle / a hand orbit-stabilizer proof. Those files are **not** registered here (they still carry sorries).
- `state.md` sync is handled by the separate open PR #24898; this PR intentionally does not touch it.

## Test plan

- [x] `docker-build.sh Proofs.FourSquareDistributionOQ04Sign` GREEN (7743 jobs).
- [ ] Deployer full-build gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)