### PR TITLE
research(amgm-oq020104): verify general-k Newton-Girard recurrence (Finset/CommRing)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -41,6 +41,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01Aristotle
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ03
+import Proofs.AmgmInequalityOQ02OQ01OQ04
 import Proofs.AmgmInequalityOQ02OQ02
 import Proofs.AmgmInequalityOQ02OQ03
 import Proofs.AmgmInequalityOQ02OQ03OQ03

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean
@@ -36,25 +36,17 @@
       dependency on uncertain Mathlib API names.  Preferred if (A)'s bridging
       lemmas are absent.
 
-  Status: ACT (build-pending).  Route A executed below: the concrete recurrence
-  is obtained by applying `MvPolynomial.aeval (fun i : ↥s => f i.1)` to Mathlib's
-  universal Newton identity `MvPolynomial.mul_esymm_eq_sum`.  Confirmed Mathlib
-  v4.26.0 API used:
-    * `MvPolynomial.mul_esymm_eq_sum`              (RingTheory/.../Symmetric/NewtonIdentities)
-    * `MvPolynomial.aeval_esymm_eq_multiset_esymm` (RingTheory/.../Symmetric/Defs)
-    * `Finset.esymm_map_val`                       (RingTheory/.../Symmetric/Defs)
+  Status: VERIFIED.  Route A executed below: the concrete recurrence is obtained
+  by applying `MvPolynomial.aeval (fun i : s => f i.1)` to Mathlib's universal
+  Newton identity `MvPolynomial.mul_esymm_eq_sum`.  Machine-checked under Lean
+  v4.26.0 (0 sorries, 0 axioms).  Mathlib API used:
+    * `MvPolynomial.mul_esymm_eq_sum`              (RingTheory Symmetric NewtonIdentities)
+    * `MvPolynomial.aeval_esymm_eq_multiset_esymm` (RingTheory Symmetric Defs)
+    * `Finset.esymm_map_val`                       (RingTheory Symmetric Defs)
     * `MvPolynomial.psum`, `MvPolynomial.aeval_X`
     * `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`, `Finset.sum_range_succ`
     * `Multiset.attach_map_val'`, `Finset.attach_val`, `Finset.sum_coe_sort`
     * `Odd.neg_one_pow`
-  This file now carries a complete proof (no `sorry`), but is BUILD-PENDING /
-  UNVERIFIED: Docker pool saturated (5 containers) and Aristotle backend 404 on
-  2026-06-15, so it was never machine-checked.  A few steps are name-/normal-form
-  fragile and may need minor adjustment on first build, in particular:
-    - the `simp only [...] at key` aeval-transport normal form;
-    - `huniv : (univ : Finset ↥s) = s.attach := rfl` (Fintype-instance defeq);
-    - the `if_pos`/`lt_self_iff_false` reindex closing.
-  Do NOT mark the gallery entry `verified` until this compiles under Docker.
 -/
 
 import Mathlib
@@ -88,9 +80,11 @@ theorem esymm_bridge (s : Finset ι) (f : ι → R) (n : ℕ) :
   rw [MvPolynomial.aeval_esymm_eq_multiset_esymm]
   -- Goal: ((univ : Finset ↥s).val.map (fun i => f i.1)).esymm n = esymm s f n
   have himg : (Finset.univ : Finset ↥s).val.map (fun i : ↥s => f i.1) = s.val.map f := by
-    -- `univ = s.attach` (Fintype instance for the coe-sort), then `attach_map_val'`.
+    -- `univ = s.attach` (Fintype instance for the coe-sort), then collapse the attach
+    -- via `Multiset.attach_map_val'` (`s.attach.map (f ∘ val) = s.map f`).
     have huniv : (Finset.univ : Finset ↥s) = s.attach := rfl
-    rw [huniv, Finset.attach_val, Multiset.attach_map_val']
+    rw [huniv, Finset.attach_val]
+    exact Multiset.attach_map_val' s.val f
   rw [himg]
   -- `Finset.esymm_map_val f s n : (s.val.map f).esymm n = ∑ t ∈ s.powersetCard n, ∏ i ∈ t, f i`
   rw [Finset.esymm_map_val f s n]
@@ -115,7 +109,7 @@ theorem reindex_filter (s : Finset ι) (f : ι → R) (k : ℕ) :
     Note `esymm s f 0 = 1` (empty product over the unique 0-subset `∅`), so the
     `j = 0` summand is `p_k`, and the sign-alternating tail closes with the
     `(-1)^k · k · e_k` correction term. -/
-theorem newton_girard (s : Finset ι) (f : ι → R) (k : ℕ) (hk : 1 ≤ k) :
+theorem newton_girard (s : Finset ι) (f : ι → R) (k : ℕ) (_hk : 1 ≤ k) :
     (∑ j ∈ Finset.range k, (-1) ^ j * esymm s f j * psum s f (k - j))
       + (-1) ^ k * (k : R) * esymm s f k = 0 := by
   classical

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-04",
+  "title": "Newton-Girard Recurrence for Arbitrary k (Finset / CommRing Form)",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-04",
+  "description": "Proves the general Newton-Girard recurrence for every k ≥ 1, relating power sums pₖ = Σ_{i∈s} (f i)^k and elementary symmetric functions eₖ = Σ_{T⊆s,|T|=k} ∏_{i∈T} f i for an arbitrary finite family f : ι → R indexed by a Finset s over any commutative ring R: Σ_{j=0}^{k-1} (-1)^j eⱼ p_{k-j} + (-1)^k k eₖ = 0. Mathlib provides Newton's identities only in the universal MvPolynomial form; this entry transports that universal identity to the directly usable Finset/CommRing layer via the algebra map aeval, closing the parent entry's open question for arbitrary k. 4 theorems, 2 definitions, 0 axioms.",
+  "leanFile": {
+    "namespace": "AmgmNewtonGirard",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-15",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "symmetric-polynomials",
+      "newton-girard",
+      "algebraic-identities",
+      "finset",
+      "mvpolynomial",
+      "aeval-transport"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-15",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified under Lean v4.26.0 / Mathlib. Works for any commutative ring R, any index type ι, any Finset s, and every k ≥ 1.",
+    "lineCount": 127,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "originalContributions": [
+      "newton_girard: the full Newton-Girard recurrence Σ_{j<k} (-1)^j eⱼ p_{k-j} + (-1)^k k eₖ = 0 for arbitrary k ≥ 1, stated directly over a Finset family in any CommRing (not the polynomial-ring form)",
+      "psum_bridge: aeval (i ↦ f i) (MvPolynomial.psum ↥s R n) = psum s f n — transports the universal power sum to the concrete one",
+      "esymm_bridge: aeval (i ↦ f i) (MvPolynomial.esymm ↥s R n) = esymm s f n — transports the universal elementary symmetric polynomial to the concrete one via Finset.esymm_map_val and Multiset.attach_map_val'",
+      "reindex_filter: rewrites the filtered antidiagonal sum from Mathlib's universal identity onto a clean Σ_{j∈range k} form",
+      "Closes the parent entry's open question 'Prove the general Finset-level Newton-Girard recurrence for arbitrary k' by reduction to Mathlib's MvPolynomial.mul_esymm_eq_sum rather than a bespoke induction"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Isaac Newton recorded the power-sum recurrences connecting elementary symmetric polynomials $e_k = \\sum_{i_1 < \\cdots < i_k} x_{i_1} \\cdots x_{i_k}$ to power sums $p_k = \\sum x_i^k$ around 1666, building on Albert Girard's 1629 statement. In full generality Newton's identity reads $\\sum_{j=0}^{k-1} (-1)^j e_j p_{k-j} + (-1)^k k\\, e_k = 0$ for $k \\geq 1$ (with $e_0 = 1$), equivalently $p_k = e_1 p_{k-1} - e_2 p_{k-2} + \\cdots + (-1)^{k-1} k\\, e_k$. The identity is the computational core of the fundamental theorem of symmetric polynomials and underlies Vieta's formulas, Maclaurin's inequalities, and the chain that recovers AM-GM at its extremes. Mathlib formalizes Newton's identities for the universal symmetric functions over a `Fintype` (the polynomial-root form, `MvPolynomial.mul_esymm_eq_sum`), but not the directly usable Finset/CommRing statement for an explicit finite family — the layer needed when the $x_i$ are concrete ring elements rather than indeterminates.",
+    "problemStatement": "For any commutative ring $R$, index type $\\iota$, finite set $s : \\text{Finset } \\iota$, family $f : \\iota \\to R$, and $k \\geq 1$, prove $\\sum_{j=0}^{k-1} (-1)^j e_j(s,f)\\, p_{k-j}(s,f) + (-1)^k k\\, e_k(s,f) = 0$ where $p_n(s,f) = \\sum_{i \\in s} f(i)^n$ and $e_n(s,f) = \\sum_{T \\subseteq s,\\, |T|=n} \\prod_{i \\in T} f(i)$.",
+    "text": "The proof takes Mathlib's universal Newton identity over the index subtype $\\uparrow s = \\{i // i \\in s\\}$ (a `Fintype`) and pushes it through the algebra map $\\text{aeval}(i \\mapsto f\\, i.1) : \\text{MvPolynomial}\\, \\uparrow s\\, R \\to R$. Because `aeval` is a ring homomorphism it commutes with sums, products, powers, negation and `Nat.cast`, so the universal identity becomes the concrete one once two evaluation bridges are established: `psum_bridge` (aeval of `MvPolynomial.psum` is the concrete `psum`) and `esymm_bridge` (aeval of `MvPolynomial.esymm` is the concrete `esymm`). The elementary-symmetric bridge is the substantive one: `aeval_esymm_eq_multiset_esymm` reduces aeval to a multiset esymm, then `univ.val.map = s.val.map f` (via `s.attach` and `Multiset.attach_map_val'`) and `Finset.esymm_map_val` land exactly on the `powersetCard` definition of `esymm`. After transport, `reindex_filter` rewrites the filtered antidiagonal sum onto `range k`, and a short sign computation ($(-1)^k (-1)^{k+1} = -1$ via `Odd.neg_one_pow`) closes the recurrence.",
+    "proofStrategy": "**Route A (executed): transport, not induction.** Rather than re-deriving Newton's identity by induction on $s$ (the self-contained ~200-line alternative, Route B), the proof reduces to Mathlib's universal `MvPolynomial.mul_esymm_eq_sum` over $\\uparrow s$. The key move is `apply_fun (aeval (fun i : ↥s => f i.1)) at key`, turning the universal polynomial identity into a ring equation in $R$. The simp set `[map_mul, map_pow, map_neg, map_one, map_natCast, map_sum, esymm_bridge, psum_bridge]` discharges every ring-hom commutation and substitutes the two bridges in one pass. `reindex_filter` normalises the antidiagonal-filter sum (using `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` and `Finset.sum_range_succ`, peeling the vacuous $j=k$ term via `lt_self_iff_false`) to the canonical `Σ_{j ∈ range k}`. The final sign closure multiplies through by $(-1)^k$ and uses $(-1)^k (-1)^{k+1} = (-1)^{2k+1} = -1$ (`Odd.neg_one_pow ⟨k, _⟩`) so the $(-1)^k k e_k$ correction cancels the transported right-hand side, and `ring` finishes.",
+    "keyInsights": [
+      "**Transport beats re-derivation.** Mathlib already has the hard combinatorial content (Newton's identity for universal symmetric functions); the Finset/CommRing form is recovered for free by evaluating along `aeval`, since a ring homomorphism preserves the entire algebraic identity. This converts a multi-hundred-line induction into a ~15-line transport plus two bridge lemmas.",
+      "**The index subtype $\\uparrow s$ is the right `Fintype`.** Specialising the universal identity to the coe-sort $\\{i // i \\in s\\}$ (whose `univ` is definitionally `s.attach`) makes the concrete power sums and elementary symmetric functions land exactly on Mathlib's `MvPolynomial.psum`/`esymm` evaluated at $i \\mapsto f(i.1)$.",
+      "**`esymm_bridge` is the load-bearing step.** `MvPolynomial.aeval_esymm_eq_multiset_esymm` rewrites aeval of the universal esymm to a `Multiset.esymm` of the mapped values; `s.attach` together with `Multiset.attach_map_val'` collapses `univ.val.map (f ∘ val)` to `s.val.map f`, and `Finset.esymm_map_val` rewrites that to the `powersetCard` sum that defines the concrete `esymm`.",
+      "**Sign bookkeeping is the only arithmetic.** Mathlib states the identity as $k\\, e_k = (-1)^{k+1} \\sum_{j} (-1)^j e_j p_{k-j}$; multiplying by $(-1)^k$ and using $(-1)^{2k+1} = -1$ turns it into the symmetric vanishing form $\\sum_j (-1)^j e_j p_{k-j} + (-1)^k k\\, e_k = 0$, which is the cleaner statement for downstream use.",
+      "**Why $e_0 = 1$ matters.** The $j = 0$ summand is $(-1)^0 e_0 p_k = p_k$ since $e_0 = \\sum_{T \\subseteq s, |T|=0} \\prod_{i\\in T} f(i) = \\prod_{i \\in \\varnothing} = 1$; this is what makes the recurrence express $p_k$ in terms of lower power sums and the symmetric functions."
+    ],
+    "prerequisites": [
+      "MvPolynomial.mul_esymm_eq_sum: Mathlib's universal Newton identity over a Fintype",
+      "MvPolynomial.aeval as an AlgHom: commutes with sum/product/pow/neg/natCast",
+      "MvPolynomial.aeval_esymm_eq_multiset_esymm and Finset.esymm_map_val",
+      "Multiset.attach_map_val', Finset.attach_val (collapsing univ over the coe-sort)",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk, Odd.neg_one_pow"
+    ]
+  },
+  "conclusion": {
+    "summary": "The general Newton-Girard recurrence Σ_{j<k} (-1)^j eⱼ p_{k-j} + (-1)^k k eₖ = 0 for every k ≥ 1, stated over an arbitrary Finset family in any CommRing, obtained by transporting Mathlib's universal MvPolynomial identity along aeval. 4 theorems, 2 definitions, 0 axioms, 127 lines.",
+    "implications": "This entry closes the parent's standing open question — the general arbitrary-$k$ Finset/CommRing Newton-Girard recurrence — and does so by reduction rather than bespoke induction, demonstrating a reusable pattern: a universal symmetric-function identity in `MvPolynomial` becomes a concrete identity about explicit ring elements simply by evaluating along the algebra map. The two bridge lemmas `psum_bridge` and `esymm_bridge` are independently useful for any future transport of `MvPolynomial.NewtonIdentities` results to the Finset layer (e.g. complete homogeneous symmetric functions, or the dual recurrences). Because the statement holds over any commutative ring it applies to polynomial-coefficient arithmetic, formal power series, and combinatorial generating functions, not only real inequalities. The result is also a candidate Mathlib contribution: the universal form exists upstream but the directly usable Finset/CommRing combinatorial layer does not.",
+    "openQuestions": [
+      "Contribute psum_bridge / esymm_bridge and the Finset-level newton_girard upstream to Mathlib, where only the universal MvPolynomial form currently exists.",
+      "Transport the dual Newton identities (complete homogeneous symmetric functions hₖ via Σ (-1)^j eⱼ h_{k-j} = 0) to the same Finset/CommRing layer using the identical aeval bridge.",
+      "Derive the Maclaurin inequality chain S_k^{1/k} ≥ S_{k+1}^{1/(k+1)} over an ordered field directly from this recurrence together with a power-mean bound, formalizing the base case S_1^2 ≥ S_2."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-defs",
+      "title": "Module Header, Imports, and Concrete Definitions",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Documents Route A (aeval-transport) and the confirmed Mathlib v4.26.0 API. Imports Mathlib, opens Finset and BigOperators, declares variables {ι R : Type*} [CommRing R]. Defines the concrete power sum psum s f k = Σ_{i∈s} (f i)^k and elementary symmetric function esymm s f k = Σ_{T ∈ s.powersetCard k} ∏_{i∈T} f i."
+    },
+    {
+      "id": "bridges",
+      "title": "Power-Sum and Elementary-Symmetric Bridges",
+      "startLine": 67,
+      "endLine": 89,
+      "summary": "psum_bridge: aeval (i ↦ f i.1) (MvPolynomial.psum ↥s R n) = psum s f n, by pushing aeval through the sum (map_sum) and evaluating each X i via aeval_X, after ← Finset.sum_coe_sort. esymm_bridge: the harder transport, using aeval_esymm_eq_multiset_esymm, then collapsing univ.val.map over the coe-sort to s.val.map f via s.attach and Multiset.attach_map_val', then Finset.esymm_map_val to reach the powersetCard definition."
+    },
+    {
+      "id": "reindex",
+      "title": "Antidiagonal-to-Range Reindexing",
+      "startLine": 91,
+      "endLine": 103,
+      "summary": "reindex_filter rewrites Σ_{a ∈ antidiagonal k, a.1 < k} (-1)^{a.1} e_{a.1} p_{a.2} to Σ_{j ∈ range k} (-1)^j e_j p_{k-j}, via Finset.sum_filter, Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk and Finset.sum_range_succ, discharging the vacuous j=k summand with lt_self_iff_false and closing each remaining term with if_pos from mem_range."
+    },
+    {
+      "id": "newton-girard",
+      "title": "The Newton-Girard Recurrence",
+      "startLine": 105,
+      "endLine": 127,
+      "summary": "newton_girard: takes key := MvPolynomial.mul_esymm_eq_sum ↥s R k, applies aeval via apply_fun, simp-normalises with the two bridges and the ring-hom lemmas (map_mul/pow/neg/one/natCast/sum), rewrites by reindex_filter, then closes the sign with hsign : (-1)^k (-1)^{k+1} = -1 (Odd.neg_one_pow) and ring."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01",
+      "relationship": "parent-problem",
+      "description": "The n=2 Newton-Girard identity p₂ = e₁² - 2e₂ and its diagonal/off-diagonal decomposition. This entry generalizes that base case to arbitrary k and explicitly resolves its open question 'Prove the general Finset-level Newton-Girard recurrence for arbitrary k'."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "parent-problem",
+      "description": "Maclaurin's inequalities via elementary symmetric polynomials — the general Newton-Girard recurrence proved here is the algebraic engine feeding the Maclaurin chain."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric polynomials of the roots; Newton's identities convert between those eₖ and the power sums pₖ, which is exactly the recurrence formalized here."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03",
+      "relationship": "complementary",
+      "description": "Maclaurin chain from Newton's log-concavity — consumes the Newton-Girard identities (now available for all k from this entry) to establish inequalities between elementary symmetric means."
+    }
+  ],
+  "references": [
+    {
+      "title": "Newton's identities",
+      "url": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+      "description": "Statement and derivations of the power-sum / elementary-symmetric recurrences."
+    },
+    {
+      "title": "Mathlib: RingTheory.MvPolynomial.Symmetric.NewtonIdentities",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/MvPolynomial/Symmetric/NewtonIdentities.html",
+      "description": "Mathlib's universal form of Newton's identities (MvPolynomial.mul_esymm_eq_sum) transported here to the Finset/CommRing layer."
+    }
+  ]
+}

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "amgm-inequality-oq-02-oq-01-oq-04",
   "title": "General Finset-level Newton-Girard recurrence",
-  "phase": "ORIENT",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -29,28 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (ACT, build-pending): full Route-A proof written with confirmed v4.26 API; 0 sorries; awaiting Docker verification.",
+    "progressSummary": "COMPLETE: full Route-A proof Docker-verified GREEN (0 sorries, 0 axioms, Lean v4.26.0). newton_girard recurrence for arbitrary k proved by aeval-transport of MvPolynomial.mul_esymm_eq_sum; esymm_bridge fixed (Multiset.attach_map_val via rw did not match — replaced with exact Multiset.attach_map_val'). Gallery entry created, registered in Proofs.lean. Resolves parent open question.",
     "builtItems": [
       "newton_girard statement + psum/esymm Finset defs in proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean (sorry on main thm)",
-      "proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean: complete (0-sorry) proof attempt of newton_girard plus psum_bridge, esymm_bridge, reindex_filter. BUILD-PENDING/UNVERIFIED (Docker saturated, Aristotle 404)."
+      "proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean: complete (0-sorry) proof attempt of newton_girard plus psum_bridge, esymm_bridge, reindex_filter. BUILD-PENDING/UNVERIFIED (Docker saturated, Aristotle 404).",
+      "VERIFIED proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean: psum, esymm defs + psum_bridge, esymm_bridge, reindex_filter, newton_girard (4 thm, 2 def, 0 sorry, 0 axiom). Registered in proofs/Proofs.lean. Gallery entry src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json (verified/original)."
     ],
     "insights": [
       "Sign convention verified on s={a,b}: k=1 gives p1-e1=0; k=2 gives e0·p2 - e1·p1 + 2e2 = (x²+y²)-(x+y)²+2xy = 0.",
       "e_0 = 1 (empty product over the unique 0-subset), so the j=0 summand is exactly p_k; recurrence closes with the (-1)^k·k·e_k correction.",
       "Two reductions: (A) aeval-specialize Mathlib MvPolynomial.mul_esymm_eq_sum over subtype {i//i∈s}; (B) self-contained induction on s via e_k(s∪{a})=e_k(s)+a·e_{k-1}(s).",
       "Route A is fully concrete in Mathlib v4.26.0: applying MvPolynomial.aeval (fun i:↥s => f i.1) to MvPolynomial.mul_esymm_eq_sum transports the universal Newton identity to the Finset/CommRing form. The esymm bridge is Finset.esymm_map_val composed with Multiset.attach_map_val (univ.val.map = s.val.map).",
-      "Sign closure: (k:R)·e_k = (-1)^(k+1)·S with S=∑_{j<k}(-1)^j e_j p_{k-j}; (-1)^k·(-1)^(k+1)=(-1)^(2k+1)=-1 via Odd.neg_one_pow, so S + (-1)^k·k·e_k = S - S = 0."
+      "Sign closure: (k:R)·e_k = (-1)^(k+1)·S with S=∑_{j<k}(-1)^j e_j p_{k-j}; (-1)^k·(-1)^(k+1)=(-1)^(2k+1)=-1 via Odd.neg_one_pow, so S + (-1)^k·k·e_k = S - S = 0.",
+      "Docker-verified GREEN 2026-06-15: the build-pending Route-A proof compiles after one fix. The original `rw [Multiset.attach_map_val']` failed keyed-pattern matching on `Multiset.map (fun i => f ↑i) s.val.attach`; `exact Multiset.attach_map_val' s.val f` (defeq unification) closes it."
     ],
     "mathlibGaps": [
       "Mathlib provides Newton identities only in the polynomial-root / universal MvPolynomial form (NewtonSums / MvPolynomial.NewtonIdentities); the directly-usable Finset/CommRing combinatorial layer (explicit finite family) is absent and must be bridged.",
       "No Finset/CommRing-level Newton-Girard in Mathlib; only the universal MvPolynomial form (mul_esymm_eq_sum). Bridged here via aeval + esymm_map_val."
     ],
     "nextSteps": [
-      "Route A: prove aeval (MvPolynomial.esymm) = esymm s f · and aeval (psum) = psum s f ·, then transport mul_esymm_eq_sum.",
-      "Route B: induction on s; base s=∅ trivial, step uses e_k(s∪{a})=e_k(s)+a·e_{k-1}(s) and p_k(s∪{a})=p_k(s)+a^k.",
-      "Submit newton_girard to Aristotle when backend returns (known result, ideal proof-search target).",
-      "Build Proofs.AmgmInequalityOQ02OQ01OQ04 under Docker ≤2 to verify; fragile spots flagged in file header (simp-at-key normal form, huniv rfl, reindex if_pos closing).",
-      "On a normal-form mismatch in the aeval-transport simp, submit the isolated helper to Aristotle when the 404 clears."
+      "Upstream psum_bridge/esymm_bridge + Finset-level newton_girard to Mathlib (only universal MvPolynomial form exists there).",
+      "Transport dual Newton identities (complete homogeneous hₖ) via the same aeval bridge.",
+      "Derive Maclaurin base case S₁²≥S₂ over an ordered field from this recurrence + a power-mean bound."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Docker-verified GREEN (Lean v4.26.0, 7743 jobs, **0 sorries, 0 axioms**) the **general arbitrary-k Newton–Girard recurrence** over an arbitrary `Finset` family `f : ι → R` in any `CommRing`:

```
Σ_{j=0}^{k-1} (-1)^j · eⱼ · p_{k-j}  +  (-1)^k · k · eₖ  =  0   (k ≥ 1)
```

with `pₖ = Σ_{i∈s} (f i)^k` and `eₖ = Σ_{T⊆s, |T|=k} ∏_{i∈T} f i`.

**Route A (transport, not induction):** the proof applies the algebra map `aeval (i ↦ f i.1)` to Mathlib's universal Newton identity `MvPolynomial.mul_esymm_eq_sum` over the index subtype `↥s`, then bridges the universal `psum`/`esymm` to the concrete Finset versions (`psum_bridge`, `esymm_bridge`) and reindexes the antidiagonal sum onto `range k` (`reindex_filter`).

This **resolves the parent entry `amgm-inequality-oq-02-oq-01`'s standing open question** — "Prove the general Finset-level Newton-Girard recurrence for arbitrary k" — which Mathlib supplies only in the universal `MvPolynomial` form.

## What changed

- The prior build-pending file did **not** compile. Two fixes:
  - a docstring `-/` (`name-/normal-form`) closed the `/- … -/` header comment early → parse errors at the comment lines;
  - `esymm_bridge`'s `rw [Multiset.attach_map_val']` failed keyed-pattern matching → replaced with `exact Multiset.attach_map_val' s.val f` (defeq unification).
- Registered `Proofs.AmgmInequalityOQ02OQ01OQ04` in `Proofs.lean`.
- Added gallery entry `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json` (status `verified`, badge `original`, 4 theorems / 2 definitions / 0 axioms).
- Advanced the research problem to `COMPLETED`.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ04` → **Build completed successfully (7743 jobs)**, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)