### PR TITLE
research(qra-oq-03): verified crux + units-form Zolotarev headline legendreSym = sign(mulLeft)

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -34,13 +34,22 @@ raised to `(p−1)/2` equals `−1` in the field. Built green via
 0 errors / 0 sorries / 0 axioms (linter style-nags only). This is the genuinely-new Euler-side
 ingredient the headline needs; it was authored blind under blackout (S15) and is now verified.
 
-**What this file does NOT yet contain** (the OQ is NOT resolved): the headline
-Zolotarev identity `legendreSym p a = sign (mulLeft a)` still needs (i) the Euler's-criterion
-tie `legendreSym p a = (-1)^k` (which combines this crux with `legendreSym.eq_pow`) and (ii) the
-field-`mulLeft₀`/units-`mulLeft` sign bridge (both prose in knowledge.md, S2 numerically verified).
-Milestone 2 (reciprocity from the grid-transpose permutation sign) is also not yet in Lean. This
-file verifies the genuinely-new *producer* lemma, the Zolotarev sign computation, and now the
-primitive-root half-power crux — the reusable core Mathlib lacks.
+**S17 (2026-06-16, researcher-2, Docker recovered; Aristotle still 404).** Proved the
+**units-form Zolotarev headline** `legendreSym_eq_sign_mulLeft`:
+`legendreSym p (u.val) = sign (Equiv.mulLeft u)` for `u : (ZMod p)ˣ`, `p` an odd prime. This
+is Zolotarev's lemma stated on the units group — it ties the Euler-criterion side
+(`legendreSym.eq_pow` + the S16 crux: `(g)^((p-1)/2) = -1`) to the sign side
+(`sign_mulLeft_eq_neg_one_zpow`), both reducing to `(-1)^k` where `u = g^k`, then lifts the
+`±1` equality from `ZMod p` back to `ℤ` (helpers `intCast_inj_pm`, `zmod_one_ne_neg_one`).
+Built green, 0 sorries / 0 axioms.
+
+**What this file does NOT yet contain** (the OQ is NOT fully resolved): the headline above is
+stated on the **units group** `(ZMod p)ˣ` via `Equiv.mulLeft`. The exact OQ-pinned statement
+uses `Equiv.mulLeft₀` on the **field** `ZMod p` (which fixes `0`); deriving it from the units
+form needs the field-`mulLeft₀`/units-`mulLeft` sign bridge (S2 numerically verified). Milestone
+2 (reciprocity from the grid-transpose permutation sign) is also not yet in Lean. This file
+verifies the genuinely-new *producer* lemma, the Zolotarev sign computation, the primitive-root
+half-power crux, and the units-form Zolotarev identity — the reusable core Mathlib lacks.
 
 ## What this targets
 
@@ -218,5 +227,66 @@ theorem primitiveRoot_pow_half_eq_neg_one {p : ℕ} [Fact p.Prime] (hp : 2 < p)
   rcases mul_self_eq_one_iff.mp hsq with h | h
   · exact absurd h hne1
   · exact h
+
+
+/-! ## Units-form Zolotarev headline: `legendreSym p u = sign (mulLeft u)` -/
+
+/-- In `ZMod p` for an odd prime `p`, `1 ≠ -1`. -/
+private theorem zmod_one_ne_neg_one {p : ℕ} [Fact p.Prime] (hp : 2 < p) :
+    (1 : ZMod p) ≠ (-1 : ZMod p) := by
+  intro h
+  have e : (1 : ZMod p) + 1 = 0 := by nth_rewrite 1 [h]; ring
+  have h2 : ((2 : ℕ) : ZMod p) = 0 := by push_cast; rw [← one_add_one_eq_two]; exact e
+  rw [ZMod.natCast_eq_zero_iff] at h2
+  have := Nat.le_of_dvd (by norm_num) h2
+  omega
+
+/-- Lift an equality of `±1` integers from `ZMod p` (odd prime) back to `ℤ`. -/
+private theorem intCast_inj_pm {p : ℕ} [Fact p.Prime] (hp : 2 < p) {x y : ℤ}
+    (hx : x = 1 ∨ x = -1) (hy : y = 1 ∨ y = -1)
+    (h : (x : ZMod p) = (y : ZMod p)) : x = y := by
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · rfl
+  · exact absurd (by push_cast at h; exact h) (zmod_one_ne_neg_one hp)
+  · exact absurd (by push_cast at h; exact h.symm) (zmod_one_ne_neg_one hp)
+  · rfl
+
+theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p)
+    (u : (ZMod p)ˣ) :
+    legendreSym p ((u : ZMod p).val : ℤ) = (Equiv.Perm.sign (Equiv.mulLeft u) : ℤ) := by
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
+  have hcard : Fintype.card (ZMod p)ˣ = p - 1 := ZMod.card_units p
+  have hcard2 : 2 ≤ Fintype.card (ZMod p)ˣ := by rw [hcard]; omega
+  have hodd : Odd p := (Fact.out : p.Prime).odd_of_ne_two (by omega)
+  have heven : Even (Fintype.card (ZMod p)ˣ) := by
+    rw [hcard]; obtain ⟨t, ht⟩ := hodd; exact ⟨t, by omega⟩
+  have hp2 : p / 2 = (p - 1) / 2 := by obtain ⟨t, ht⟩ := hodd; omega
+  -- discrete log as a natural number
+  obtain ⟨k, hk⟩ := mem_powers_iff_mem_zpowers.2 (hg u)
+  have ha : u = g ^ (k : ℤ) := by rw [zpow_natCast]; exact hk.symm
+  -- sign side: sign (mulLeft u) = (-1)^k  (npow)
+  have hsign : Equiv.Perm.sign (Equiv.mulLeft u) = (-1 : ℤˣ) ^ k := by
+    have h0 := sign_mulLeft_eq_neg_one_zpow (fun x => hg x) hcard2 heven ha
+    rwa [zpow_natCast] at h0
+  -- the crux
+  have hcrux : (g : ZMod p) ^ ((p - 1) / 2) = -1 :=
+    primitiveRoot_pow_half_eq_neg_one hp (fun x => hg x)
+  -- legendre side in ZMod p equals (-1)^k
+  have hcast : (((u : ZMod p).val : ℤ) : ZMod p) = (u : ZMod p) := by
+    push_cast; exact ZMod.natCast_rightInverse (u : ZMod p)
+  have hL : (legendreSym p ((u : ZMod p).val : ℤ) : ZMod p) = (-1 : ZMod p) ^ k := by
+    rw [legendreSym.eq_pow, hcast, hp2, ← hk]
+    push_cast
+    rw [← pow_mul, mul_comm, pow_mul, hcrux]
+  -- both sides are ±1; lift the ZMod-p equality back to ℤ
+  have hLpm : legendreSym p ((u : ZMod p).val : ℤ) = 1 ∨
+      legendreSym p ((u : ZMod p).val : ℤ) = -1 := by
+    apply legendreSym.eq_one_or_neg_one
+    rw [hcast]; exact u.ne_zero
+  rw [hsign]
+  refine intCast_inj_pm hp hLpm ?_ ?_
+  · rcases Int.units_eq_one_or ((-1 : ℤˣ) ^ k) with h | h <;> simp [h]
+  · rw [hL]; push_cast; ring
+
 
 end QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -1,6 +1,7 @@
 import Mathlib.NumberTheory.LegendreSymbol.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Tactic
 
 /-
@@ -26,12 +27,20 @@ the inline `G →* Perm G` monoid-hom + `map_zpow` wiring (replacing the nonexis
 even-power `(-1)^card = 1` collapse — all flagged "unverified" by S12/S13 — compile as
 written. Removed three linter-flagged unused `simp` arguments.
 
+**S16 (2026-06-15, researcher-2, Docker recovered; Aristotle still 404).** Added the
+machine-checked **crux** `primitiveRoot_pow_half_eq_neg_one`: a generator of `(ZMod p)ˣ`
+raised to `(p−1)/2` equals `−1` in the field. Built green via
+`docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03Crux` (a uniquely-named build copy),
+0 errors / 0 sorries / 0 axioms (linter style-nags only). This is the genuinely-new Euler-side
+ingredient the headline needs; it was authored blind under blackout (S15) and is now verified.
+
 **What this file does NOT yet contain** (the OQ is NOT resolved): the headline
 Zolotarev identity `legendreSym p a = sign (mulLeft a)` still needs (i) the Euler's-criterion
-tie `legendreSym p a = (-1)^k` and (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge
-(both prose in knowledge.md, S2 numerically verified). Milestone 2 (reciprocity from the
-grid-transpose permutation sign) is also not yet in Lean. This file verifies the genuinely-new
-*producer* lemma and the Zolotarev sign computation — the reusable core Mathlib lacks.
+tie `legendreSym p a = (-1)^k` (which combines this crux with `legendreSym.eq_pow`) and (ii) the
+field-`mulLeft₀`/units-`mulLeft` sign bridge (both prose in knowledge.md, S2 numerically verified).
+Milestone 2 (reciprocity from the grid-transpose permutation sign) is also not yet in Lean. This
+file verifies the genuinely-new *producer* lemma, the Zolotarev sign computation, and now the
+primitive-root half-power crux — the reusable core Mathlib lacks.
 
 ## What this targets
 
@@ -168,5 +177,46 @@ theorem sign_mulLeft_eq_neg_one_zpow {G : Type*} [Group G] [Fintype G] [Decidabl
         G →* Equiv.Perm G) g k
     rw [ha]; simpa using hz
   rw [hmono, map_zpow, sign_mulLeft_generator hg hG heven]
+
+/-! ## The crux: a primitive root raised to `(p-1)/2` equals `-1`
+
+This is the single remaining genuinely-new ingredient (S15) the headline Zolotarev identity
+needs beyond the verified sign computation `sign_mulLeft_eq_neg_one_zpow`. Stated in the field
+`ZMod p` (not the units group) so the order-2 dichotomy uses `mul_self_eq_one_iff` directly and
+`ZMod.pow_card_sub_one_eq_one` supplies `xᵖ⁻¹ = 1` — avoiding the units `Neg`-instance question
+flagged by S15.
+
+Let `x = (g : ZMod p)` for a generator `g` of `(ZMod p)ˣ`, and `m = (p-1)/2`. Then
+`(xᵐ)² = xᵖ⁻¹ = 1`, while `xᵐ ≠ 1` because `orderOf x = p − 1 > m`; the only square root of `1`
+in a field other than `1` is `−1`. -/
+theorem primitiveRoot_pow_half_eq_neg_one {p : ℕ} [Fact p.Prime] (hp : 2 < p)
+    {g : (ZMod p)ˣ} (hg : ∀ x : (ZMod p)ˣ, x ∈ Subgroup.zpowers g) :
+    (g : ZMod p) ^ ((p - 1) / 2) = -1 := by
+  set x : ZMod p := (g : ZMod p) with hx
+  have hxne : x ≠ 0 := g.ne_zero
+  -- `orderOf x = p − 1` (a generator of the units is a primitive root in the field)
+  have hord : orderOf x = p - 1 := by
+    rw [hx, orderOf_units, orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card,
+      ZMod.card_units p]
+  set m := (p - 1) / 2 with hm
+  have heven : 2 ∣ (p - 1) := by
+    have hodd : Odd p := (Fact.out : p.Prime).odd_of_ne_two (by omega)
+    obtain ⟨t, ht⟩ := hodd
+    exact ⟨t, by omega⟩
+  have hmpos : 0 < m := by rw [hm]; omega
+  have hmlt : m < p - 1 := by rw [hm]; omega
+  have h2m : 2 * m = p - 1 := by rw [hm]; omega
+  -- `(xᵐ)² = xᵖ⁻¹ = 1`
+  have hsq : x ^ m * x ^ m = 1 := by
+    rw [← pow_add, ← two_mul, h2m]
+    exact ZMod.pow_card_sub_one_eq_one hxne
+  -- `xᵐ ≠ 1` since `m < orderOf x`
+  have hne1 : x ^ m ≠ 1 := by
+    rw [← hord] at hmlt
+    exact pow_ne_one_of_lt_orderOf (by omega) hmlt
+  -- the only non-`1` square root of `1` in a field is `-1`
+  rcases mul_self_eq_one_iff.mp hsq with h | h
+  · exact absurd h hne1
+  · exact h
 
 end QuadraticReciprocityAlgorithmOQ03


### PR DESCRIPTION
## Summary
Two machine-checked additions to the registered `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean`, both authored blind under the long S13–S15 blackout and now verified this session (Docker recovered; Aristotle still 404):

1. **Crux** `primitiveRoot_pow_half_eq_neg_one`: for a generator `g` of `(ZMod p)ˣ` (odd prime `p`), `(g : ZMod p) ^ ((p-1)/2) = -1`. Proof: `(xᵐ)² = xᵖ⁻¹ = 1` (Fermat), `xᵐ ≠ 1` since `m < orderOf x = p-1`, and the only non-`1` square root of `1` in a field is `-1`.

2. **Units-form Zolotarev headline** `legendreSym_eq_sign_mulLeft`: for `u : (ZMod p)ˣ`,
   `legendreSym p (u.val) = sign (Equiv.mulLeft u)`.
   This is Zolotarev's lemma on the units group. It ties the Euler-criterion side (`legendreSym.eq_pow` + the crux) to the sign side (the already-verified `sign_mulLeft_eq_neg_one_zpow`), both reducing to `(-1)^k` where `u = g^k`, then lifts the `±1` equality from `ZMod p` back to `ℤ` (helpers `intCast_inj_pm`, `zmod_one_ne_neg_one`).

## Verification
- `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03Crux` (crux) → GREEN, 3058 jobs.
- `docker-build.sh Proofs.QRAOQ03Headline` (full file incl. headline) → GREEN, 3058 jobs.
- Final file: **0 sorries / 0 axioms**, two pre-existing M1 `simpa` style-nags only.

## Scope / what remains open
- The headline is stated on the **units group** `(ZMod p)ˣ` via `Equiv.mulLeft`. The exact OQ-pinned statement uses `Equiv.mulLeft₀` on the **field** `ZMod p` (fixing `0`); the field/units sign bridge to convert is not yet in Lean (S2 numerically verified).
- Milestone 2 (reciprocity from the grid-transpose permutation sign) is not yet in Lean.
- The OQ is **not** fully resolved by this PR; this lands its core ingredients + the units-form Zolotarev identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)