### PR TITLE
research(erdos-476-oq-05): fix false hypothesis in ap_sdiff_endpoint

### DIFF
--- a/proofs/Proofs/Erdos476OQ05Aristotle.lean
+++ b/proofs/Proofs/Erdos476OQ05Aristotle.lean
@@ -106,11 +106,29 @@ lemma ap_sdiff_endpoint (AP₁ AP₂ : Finset (ZMod p)) (s₁ s₂ d : ZMod p)
     (hAP₁ : IsArithmeticProgression AP₁ s₁ d)
     (hAP₂ : IsArithmeticProgression AP₂ s₂ d)
     (hd : d ≠ 0)
-    (h₁ : 0 < AP₁.card)
+    (h₁ : 2 ≤ AP₁.card)
     (h₁₂ : AP₁.card ≤ AP₂.card)
     (hlt : AP₁.card + AP₂.card ≤ p)
     (h_sdiff : (AP₁ \ AP₂).card = 1) :
     s₁ = s₂ - d ∨ s₁ = s₂ + ((AP₂.card - AP₁.card + 1 : ℕ) : ZMod p) * d := by
+  -- NOTE (hypothesis corrected): the bound here is `2 ≤ AP₁.card`, not `0 < AP₁.card`.
+  -- With only `0 < AP₁.card` the statement is FALSE: take p = 7, d = 1,
+  -- AP₂ = {0,1,2} (s₂ = 0, m = 3) and AP₁ = {4} (s₁ = 4, n = 1). Then
+  -- (AP₁ \ AP₂).card = 1 and n + m = 4 ≤ 7, yet s₁ = 4 is neither s₂ - d = 6
+  -- nor s₂ + (m - n + 1)·d = 3. A singleton AP can sit anywhere outside AP₂.
+  --
+  -- Proof blueprint for the corrected (n ≥ 2) statement [Aristotle target]:
+  -- Multiply through by d⁻¹ and translate by -s₂ (a ZMod-p bijection) to reduce to
+  -- two "intervals mod p": I₂ = {x : x.val < m} = {0,…,m-1} and
+  -- I₁ = {c, c+1, …, c+(n-1)} with c = (s₁ - s₂)·d⁻¹. Using n + m ≤ p (no
+  -- double wraparound), split on whether [γ, γ+n) wraps p where γ = c.val:
+  --   • no wrap (γ ≤ p-n): |I₁ \ I₂| = n - clamp(m-γ, 0, n); = 1 forces
+  --     (given n ≥ 2) γ = m - n + 1, i.e. c = m - n + 1, i.e. s₁ = s₂ + (m-n+1)·d.
+  --   • wrap (γ ≥ p-n+1): the high block {γ,…,p-1} lies outside I₂ (since
+  --     γ ≥ p-n+1 ≥ m) and the wrapped low block stays inside I₂ (vals < n ≤ m),
+  --     so |I₁ \ I₂| = p - γ; = 1 forces γ = p-1, i.e. c = -1, i.e. s₁ = s₂ - d.
+  -- The n = 1 case collapses both regimes to "count = n = 1" for *every* γ,
+  -- which is exactly why n ≥ 2 is required.
   sorry
 
 /-

--- a/research/problems/erdos-476-oq-05/knowledge.md
+++ b/research/problems/erdos-476-oq-05/knowledge.md
@@ -326,3 +326,40 @@ Strict-shrink (`|B'| < |B|` for a non-AP `B` and suitable `e`) and nonemptiness 
 2. State + prove `etransform_snd_ssubset` (strict `(τ).2 ⊊ B` when `B` is not an AP
    with diff `e`) and nonemptiness of both transformed components.
 3. The AP pull-back lemma → Aristotle when up, else manual.
+
+## Session 2026-06-16 (Session 2) — Correctness audit of `ap_sdiff_endpoint`
+
+**Mode**: REVISIT (FRESH-claimed from pool)
+**Outcome**: progress (correctness fix; no sorries discharged)
+
+### What I Did
+- Re-probed backends: Aristotle 404 (live `n+0=n` probe), local `.lake` circular
+  self-symlink (0 oleans), Docker saturated (5 containers incl 7h zombie). No verifiable
+  proof work possible this cycle.
+- Audited the two open sorries in `Erdos476OQ05Aristotle.lean`. Found `ap_sdiff_endpoint`
+  is **false as stated** (hypothesis `0 < AP₁.card` allows the singleton AP₁).
+
+### Key Findings
+- **Counterexample** (p=7, d=1): AP₂={0,1,2} (s₂=0, m=3), AP₁={4} (s₁=4, n=1).
+  Then (AP₁\AP₂).card=1, n+m=4≤p, yet s₁=4 ∉ {s₂−d=6, s₂+(m−n+1)d=3}.
+  A length-1 AP can sit anywhere outside AP₂, so no endpoint constraint holds.
+- **Correct hypothesis**: `2 ≤ AP₁.card`. For n≥2 the statement is true; proof reduces
+  (via ×d⁻¹ and −s₂ translation) to two intervals mod p, I₂={x:x.val<m} and
+  I₁={c,…,c+n−1} with c=(s₁−s₂)·d⁻¹. Split on wrap of [γ,γ+n) where γ=c.val (the
+  bound n+m≤p rules out double wrap):
+    - no wrap: |I₁\I₂| = n − clamp(m−γ,0,n); =1 ⟹ (n≥2) γ=m−n+1 ⟹ s₁=s₂+(m−n+1)d.
+    - wrap (γ≥p−n+1): high block {γ,…,p−1}⊄I₂, wrapped low block ⊂I₂; |I₁\I₂|=p−γ;
+      =1 ⟹ γ=p−1 ⟹ c=−1 ⟹ s₁=s₂−d.
+  n=1 collapses both regimes to "count=n=1" for every γ — exactly why n≥2 is needed.
+
+### Files Modified
+- `proofs/Proofs/Erdos476OQ05Aristotle.lean`: `ap_sdiff_endpoint` hypothesis
+  `0 < AP₁.card` → `2 ≤ AP₁.card`; full corrected blueprint inlined above the sorry.
+  Lemma is currently unused (support for the line-269 Dyson e-transform step), so the
+  strengthening is safe and cannot break call sites.
+- `research/problems/erdos-476-oq-05/state.md`: recorded finding + next action.
+
+### Next Steps
+- When Aristotle non-404 / Docker trough (≤2): prove corrected `ap_sdiff_endpoint`
+  (now TRUE), then the line-269 Dyson e-transform induction.
+- Do NOT resubmit the `0 < AP₁.card` form — Aristotle returns the n=1 counterexample.

--- a/research/problems/erdos-476-oq-05/state.md
+++ b/research/problems/erdos-476-oq-05/state.md
@@ -4,22 +4,37 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T15:38:43-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Two open sorries remain in `Erdos476OQ05Aristotle.lean`, both Aristotle targets:
+- `ap_sdiff_endpoint` (was line 114): AP set-difference endpoint lemma.
+- line ~269 (case1_exists `|B|≥3` branch): Dyson e-transform induction, ~150–200 LOC.
 
 ## Active Approach
-None yet.
+Correctness audit of the helper lemmas before delegating to Aristotle.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- Aristotle backend 404 (live-probed) — cannot delegate the two HARD sorries.
+- Local `.lake` is a circular self-symlink (0 oleans); Docker saturated (5 containers,
+  incl 7h zombie) — cannot Docker-verify a hand proof this cycle.
+
+## Key Finding (this session)
+`ap_sdiff_endpoint` was stated with `0 < AP₁.card`, which makes it **FALSE**.
+Counterexample (p=7, d=1): AP₂={0,1,2}, AP₁={4}. Then (AP₁\AP₂).card=1, n+m≤p,
+but s₁=4 is neither s₂−d=6 nor s₂+(m−n+1)d=3. Corrected hypothesis: `2 ≤ AP₁.card`.
+Full correct proof blueprint (d⁻¹-rescale to intervals mod p, wrap/no-wrap val split)
+is inlined as a comment above the sorry. The lemma is currently unused (it is intended
+support for the line-269 Dyson e-transform step), so the hypothesis strengthening is safe.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Aristotle is non-404 OR a Docker trough (≤2 containers) opens:
+1. Submit/hand-prove the corrected `ap_sdiff_endpoint` (now a TRUE statement).
+2. Then attack the line-269 Dyson e-transform induction (blueprint in knowledge.md).
+Do NOT re-submit the original `0 < AP₁.card` form — Aristotle would return the n=1
+counterexample, not a proof.


### PR DESCRIPTION
## Summary

While auditing the two open sorries in `Erdos476OQ05Aristotle.lean` (the Vosper's-theorem / equality-case-of-Cauchy-Davenport work), I found that the helper lemma `ap_sdiff_endpoint` is **false as stated**.

It carried the hypothesis `0 < AP₁.card`, which admits a singleton AP₁ that can sit anywhere outside AP₂ — no endpoint constraint then holds.

**Counterexample** (ZMod 7, d=1): AP₂ = {0,1,2} (s₂=0, m=3), AP₁ = {4} (s₁=4, n=1).
Then `(AP₁ \ AP₂).card = 1` and `n + m = 4 ≤ 7`, yet s₁ = 4 is neither `s₂ - d = 6` nor `s₂ + (m-n+1)·d = 3`.

## Change

- Hypothesis `0 < AP₁.card` → `2 ≤ AP₁.card` (the statement is true for n ≥ 2).
- Inlined the full correct proof blueprint above the sorry: rescale by d⁻¹ and translate by −s₂ to two intervals mod p, then split on whether `[γ, γ+n)` wraps p (the `n + m ≤ p` hypothesis rules out double-wrap). No-wrap forces `s₁ = s₂ + (m-n+1)d`; wrap forces `s₁ = s₂ - d`.

The lemma is currently **unused** (it is intended support for the line-269 Dyson e-transform induction step), so strengthening its hypothesis cannot break any call site.

## Honesty / scope

- This is a **statement-correctness fix only**. The proof remains `sorry`.
- The corrected lemma is now a clean Aristotle target (a *true* statement); the original would have made Aristotle return the n=1 counterexample rather than a proof.
- Not Docker-verified this cycle (Aristotle 404, local `.lake` broken, Docker saturated). The change is sorry-preserving, so it is guaranteed to elaborate — only the hypothesis type and a comment block changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)