### PR TITLE
audit(amgm-newton-girard): badge original -> mathlib (Mathlib-wrapper core)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
@@ -27,11 +27,11 @@
       "mvpolynomial",
       "aeval-transport"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-15",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified under Lean v4.26.0 / Mathlib. Works for any commutative ring R, any index type ι, any Finset s, and every k ≥ 1.",
+    "assumptions": "No axioms or sorries. Fully machine-verified under Lean v4.26.0 / Mathlib for any commutative ring R, any index type ι, any Finset s, and every k ≥ 1. The core recurrence is obtained by transporting Mathlib's universal identity MvPolynomial.mul_esymm_eq_sum along the algebra map aeval — the combinatorial content lives in Mathlib; this entry contributes the concrete Finset/CommRing statement plus the bridge lemmas (psum_bridge, esymm_bridge, reindex_filter).",
     "lineCount": 127,
     "theoremCount": 4,
     "definitionCount": 2,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `amgm-inequality-oq-02-oq-01-oq-04` (Newton-Girard Recurrence for Arbitrary k)
**Severity**: MEDIUM (Mathlib wrapper badged `original`)

### Mechanical checks — all PASS
- sorries: 0 claimed / 0 actual
- axiomCount: 0 claimed / 0 actual (no `axiom` decls, no structure-encoded assumptions)
- No `True` stubs
- theoremCount 4/4, definitionCount 2/2

### Finding
Auditor skill **check #3 (Mathlib Wrapper Detection)**: the headline theorem
`newton_girard` obtains its result by directly calling Mathlib's
`MvPolynomial.mul_esymm_eq_sum` and transporting it along `aeval`
(`AmgmInequalityOQ02OQ01OQ04.lean:117-127`). When the main result is obtained by
calling a Mathlib theorem, the badge should be `mathlib`, not `original`.

The meta prose was already exemplary — it transparently and repeatedly credits
Mathlib ("transport beats re-derivation"). The only mismatch was the discrete
`badge` field, which reads as an independent original proof.

### Fix
- `badge`: `original` -> `mathlib`
- `assumptions`: note the core result is via the Mathlib bridge; the genuine
  contributions are the concrete Finset/CommRing statement + bridge lemmas
  (`psum_bridge`, `esymm_bridge`, `reindex_filter`).

No change to `status` (still machine-verified, 0 sorries / 0 axioms).

---
Discovered during gallery integrity audit.