### PR TITLE
audit(tracker): record amgm-newton-girard + qra-oq-03 audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15534,6 +15534,18 @@
       "lastAudited": "2026-06-15T23:23:15Z",
       "result": "clean",
       "issues": []
+    },
+    "quadratic-reciprocity-algorithm-oq-03": {
+      "auditCount": 3,
+      "lastAudited": "2026-06-16T07:12:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-04": {
+      "auditCount": 3,
+      "lastAudited": "2026-06-16T07:11:53Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — Tracker Sync

Records the two remaining never-audited gallery entries so the audit queue drains (was re-handing on every interval due to the worktree-vs-main tracker split).

### amgm-inequality-oq-02-oq-01-oq-04 — issues-fixed
Badge overstated as `original` for a Mathlib-wrapper core (recurrence transported from `MvPolynomial.mul_esymm_eq_sum`). Fix already filed in open PR #24911 (badge `original`->`mathlib`, honest assumptions text).

### quadratic-reciprocity-algorithm-oq-03 — clean
Verified Lean source matches meta: 0 sorries, 0 axioms, 3 theorems, 0 True stubs, no structure-encoded assumptions. Meta is exemplary — scopes `originalContributions` to the genuinely-new producer lemma `isCycle_mulLeft_of_generator` (absent from Mathlib at rev 2df2f01), lists Mathlib deps as consumers only, and explicitly states the OQ is NOT resolved (Milestone 1 only). Badge `original` defensible; status `verified` correct.

---
Discovered during periodic gallery integrity audit.