### PR TITLE
Enrich Shannon differential entropy (oq-01-oq-01): add framing section

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
@@ -51,6 +51,14 @@
   },
   "sections": [
     {
+      "id": "framing-and-setup",
+      "title": "Problem Statement, Derivation Sketch, and Imports",
+      "summary": "The module docstring states the open question (formalize h(Uniform[a,b]) = ln(b-a), the child of the parent's Gaussian computation), gives the full hand derivation — the integrand f·ln f is the constant (1/(b-a))·ln(1/(b-a)) on [a,b] and 0 off it, so ∫ f ln f = -ln(b-a) and h = ln(b-a) — and flags that h < 0 for b-a < 1, the hallmark distinguishing differential from discrete Shannon entropy. It imports Mathlib and the parent Proofs.ShannonEntropyOQ01 (reusing its differential-entropy definition), opens MeasureTheory/Real/Set, and records 0 axioms / 0 sorries.",
+      "startLine": 1,
+      "endLine": 36,
+      "mathContext": "Differential entropy h(f) = -∫ f(x) ln f(x) dx; the 0·ln 0 = 0 convention is automatic in Lean because Real.log 0 = 0, so the off-support branch needs no special handling."
+    },
+    {
       "id": "density",
       "title": "The Uniform Density",
       "summary": "uniformPDF a b x = Set.indicator (Set.Icc a b) (fun _ => 1/(b-a)) x — the Uniform[a,b] density encoded as a Lebesgue indicator.",


### PR DESCRIPTION
Enrichment pass for `shannon-entropy-oq-01-oq-01` (differential entropy of Uniform[a,b] = ln(b-a)). Structural quality **98 → 100**.

## Gap
The four `sections` covered lines 37–86, leaving the module docstring, imports (Mathlib + parent `Proofs.ShannonEntropyOQ01`), and namespace/opens (lines 1–36) uncovered — a real region with the problem statement and full hand derivation.

## Added
One section, **"Problem Statement, Derivation Sketch, and Imports"** (lines 1–36), summarizing the open question, the f·ln f → ln(b-a) derivation, the h < 0 observation distinguishing differential from discrete entropy, and the import/setup. The `sections` array now spans the full Lean file.

## Notes
- No mathematical claims changed; proof already `verified`, 0 sorries / 0 axioms.
- `pnpm build` green (tsc + vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)