### PR TITLE
research(shannon-entropy-oq-01-oq-01): repair v4.26.0 drift, Docker-verify, flip to verified

### DIFF
--- a/proofs/Proofs/ShannonEntropyOQ01OQ01.lean
+++ b/proofs/Proofs/ShannonEntropyOQ01OQ01.lean
@@ -47,8 +47,9 @@ theorem uniformPDF_integral_eq_one {a b : ℝ} (hab : a < b) :
   have hne : b - a ≠ 0 := ne_of_gt hpos
   unfold uniformPDF
   rw [MeasureTheory.integral_indicator measurableSet_Icc,
-      MeasureTheory.setIntegral_const, Real.volume_Icc,
-      ENNReal.toReal_ofReal hpos.le, smul_eq_mul, mul_one_div, div_self hne]
+      MeasureTheory.setIntegral_const, MeasureTheory.measureReal_def,
+      Real.volume_Icc, ENNReal.toReal_ofReal hpos.le, smul_eq_mul, mul_one_div,
+      div_self hne]
 
 /-- Differential entropy of the Uniform[a,b] distribution is `ln(b - a)`. -/
 theorem uniformDifferentialEntropy {a b : ℝ} (hab : a < b) :
@@ -64,14 +65,14 @@ theorem uniformDifferentialEntropy {a b : ℝ} (hab : a < b) :
     unfold uniformPDF
     by_cases hx : x ∈ Set.Icc a b
     · simp only [Set.indicator_of_mem hx]
-    · simp only [Set.indicator_of_not_mem hx, zero_mul]
+    · simp only [Set.indicator_of_notMem hx, zero_mul]
   -- Integrate the constant over [a,b] of Lebesgue length (b-a).
   have hint :
       ∫ x, uniformPDF a b x * Real.log (uniformPDF a b x) = -Real.log (b - a) := by
     rw [hkey, MeasureTheory.integral_indicator measurableSet_Icc,
-        MeasureTheory.setIntegral_const, Real.volume_Icc,
-        ENNReal.toReal_ofReal hpos.le, smul_eq_mul, one_div, Real.log_inv,
-        ← mul_assoc, mul_inv_cancel₀ hne, one_mul]
+        MeasureTheory.setIntegral_const, MeasureTheory.measureReal_def,
+        Real.volume_Icc, ENNReal.toReal_ofReal hpos.le, smul_eq_mul, one_div,
+        Real.log_inv, ← mul_assoc, mul_inv_cancel₀ hne, one_mul]
   unfold differentialEntropy
   rw [hint, neg_neg]
 

--- a/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ShannonEntropyOQ01OQ01.lean",
     "tags": [
       "information-theory",
@@ -23,7 +23,7 @@
     "lineCount": 88,
     "theoremCount": 3,
     "definitionCount": 1,
-    "assumptions": "None mathematically (0 axioms, 0 sorries). Build pending: not yet machine-verified locally because the Docker build pool was saturated this session. Reuses the verified `differentialEntropy` definition from shannon-entropy-oq-01.",
+    "assumptions": "None mathematically (0 axioms, 0 sorries). Machine-verified locally via Docker (lean4-arm64:v4.26.0, 7744 jobs, green). Reuses the verified `differentialEntropy` definition from shannon-entropy-oq-01.",
     "originalContributions": [
       "uniformPDF: the Uniform[a,b] density as a Lebesgue indicator Set.indicator (Icc a b) (1/(b-a))",
       "uniformDifferentialEntropy: h(Uniform[a,b]) = ln(b-a)",
@@ -84,7 +84,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the differential entropy of Uniform[a,b]: h = ln(b-a), answering the first open question of shannon-entropy-oq-01. 88 lines, 3 theorems, 1 definition, 0 sorries, 0 axioms (build pending local verification).",
+    "summary": "Formalizes the differential entropy of Uniform[a,b]: h = ln(b-a), answering the first open question of shannon-entropy-oq-01. 88 lines, 3 theorems, 1 definition, 0 sorries, 0 axioms (Docker-verified, 7744 jobs green).",
     "implications": "Confirms the differentialEntropy framework of the parent entry handles concrete continuous distributions cleanly via Lebesgue indicators, and supplies the canonical example of a negative differential entropy (b-a < 1).",
     "openQuestions": [
       "Formalize the maximum-entropy characterization of the uniform distribution: among densities supported on [a,b], the uniform density maximizes differential entropy",


### PR DESCRIPTION
## Summary
- The registered `ShannonEntropyOQ01OQ01.lean` (Uniform[a,b] differential entropy, h = ln(b−a)) was registered but **did not compile** under Mathlib v4.26.0.
- Root cause: `MeasureTheory.setIntegral_const` now produces `volume.real (Icc a b) • c` (a `Measure.real` term) instead of `(volume (Icc a b)).toReal • c`, so the existing `Real.volume_Icc` rewrite found no matching `volume (Icc a b)` subterm.
- Fix: insert `MeasureTheory.measureReal_def` ahead of `Real.volume_Icc` in both `uniformPDF_integral_eq_one` and the `hint` step of `uniformDifferentialEntropy`; update deprecated `Set.indicator_of_not_mem` → `Set.indicator_of_notMem`.
- Flipped meta `status` `formalized` → `verified` and removed build-pending language.

## Verification
- Docker build green: `./proofs/scripts/docker-build.sh Proofs.ShannonEntropyOQ01OQ01` → `✔ Built Proofs.ShannonEntropyOQ01OQ01`, **7744 jobs**, build succeeded (lean4-arm64:v4.26.0).
- 0 sorries, 0 axioms, 3 theorems, 1 definition. No structure-encoded assumptions.

## Test plan
- [x] Docker-verified compile of the registered file
- [x] meta.json validates as JSON; status reflects machine-checked state

🤖 Generated with [Claude Code](https://claude.com/claude-code)