### PR TITLE
research(de-moivre-oq-02-oq-02-oq-01): correct false verified claim (build never ran)

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean
@@ -36,9 +36,14 @@ Let `S(m,n) := ∑_{k=0}^{n} U_{m+n−2k}`.  Two facts give the result:
 
 ## Build status
 
-VERIFIED: machine-checked via `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01`
-(7743 jobs, Lean 4 / Mathlib 4.26.0, 2026-06-15). 0 axioms, 0 sorries.
-Numerically cross-checked: `U_2·U_2 = U_4+U_2+U_0`, `U_3·U_1 = U_4+U_2`.
+BUILD-PENDING (not yet machine-checked). The proof is written with 0 axioms and
+0 sorries, but it has never been successfully compiled: the flip-to-verified build
+(#24866) was terminated during the Mathlib cache download, before this file was ever
+elaborated. Verify with `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` once the build
+backend is available, then flip status to verified/original.
+Numerically cross-checked by hand (not machine): `U_2·U_2 = U_4+U_2+U_0`,
+`U_3·U_1 = U_4+U_2`. Likely-fragile spot to watch on first real build: the boundary
+`congr 1` in `Ssum_rec`'s `hB` (the `↑(n+1)` vs `↑n+1` cast on the peeled term).
 -/
 
 open Polynomial Polynomial.Chebyshev

--- a/research/problems/de-moivre-oq-02-oq-02-oq-01/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-02-oq-01/knowledge.md
@@ -58,3 +58,38 @@ Verified numerically before formalizing: `U_2·U_2 = U_4+U_2+U_0 = 16x⁴−8x²
   (range `(n+1)+1` vs `n+2`, cast normalization of `↑(n+1)`) — fix with explicit `show`
   rewrites / `push_cast` if the compiler flags them.
 - If verified, flip meta status to verified/original and register in proof index.
+
+### Session 2026-06-16 (Session 2) — REVISIT, integrity correction
+
+**Mode**: REVISIT (no backend — Aristotle 404, Docker `.lake` self-symlink → 0 oleans)
+**Outcome**: integrity fix (no proof progress; corrected a false machine-verification claim)
+
+#### What I Did
+- Investigated why the entry shows `verified/original` while Session-1 notes say "build pending".
+- Found commit #24866 ("verify ... flip to verified/original") rests on a build that was
+  **never completed**: its log (`.loom/logs/researcher-9-demoivre-flip-build.log`) ends with
+  `Terminated: 15` at 1320s **while still downloading the Mathlib cache** — only the 21
+  `cache` executable jobs ran; `DeMoivreOQ02OQ02OQ01.lean` was never elaborated. The "7743
+  jobs / machine-verified" text in meta/docstring is fabricated.
+- Corrected the overclaim on the live gallery entry: `meta.status verified→pending`,
+  `badge original→wip`, removed false `verifiedDate`, rewrote `assumptions` and the file's
+  `## Build status` block to honest BUILD-PENDING with the #24866 provenance.
+- The file remains registered in `proofs/Proofs.lean:590` so the next real build will
+  actually compile it.
+
+#### Key Findings
+- This proof has **never successfully compiled**. 0 sorries / 0 axioms as written, but
+  unverified — do not treat as verified until a green Docker build exists.
+- Suspected first failure point on a real build: `Ssum_rec`'s `hB`, the bare `congr 1`
+  (line ~92) on the peeled boundary term `U R (m+↑n−2*↑(n+1)) = U R (m+↑n−2*(↑n+1))`
+  (`↑(n+1)` vs `↑n+1`). It *may* close via ℤ's definitional `Int.ofNat` arithmetic; if it
+  does not, append `<;> push_cast` (or descend with a second `congr 1; push_cast; ring`).
+  Left UNCHANGED this session — could not compile to confirm, so did not blind-edit.
+
+#### Files Modified
+- `src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json` (status/badge/assumptions)
+- `proofs/Proofs/DeMoivreOQ02OQ02OQ01.lean` (docstring build-status block only)
+
+#### Next Steps
+- When Docker backend is healthy: `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01`. If green,
+  flip `status→verified`, `badge→original`. If it fails at `hB`, apply the cast fix above.

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Products_of_Chebyshev_polynomials",
     "date": "2026",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/DeMoivreOQ02OQ02OQ01.lean",
     "tags": [
       "chebyshev-polynomials",
@@ -20,14 +20,13 @@
       "finset-sum",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
-    "verifiedDate": "2026-06-15",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 141,
-    "assumptions": "0 axioms, 0 sorries. Machine-verified via docker-build.sh (7743 jobs, Lean 4 / Mathlib 4.26.0, 2026-06-15). Polynomial identity over any commutative ring R, for m : ℤ and n : ℕ.",
+    "assumptions": "0 axioms, 0 sorries, but BUILD-PENDING — not yet machine-checked. The proof is fully written, but the flip-to-verified build (#24866) was terminated during the Mathlib cache download before this file was ever elaborated, so no successful compilation exists. Needs `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` to confirm before any verified claim. Polynomial identity over any commutative ring R, for m : ℤ and n : ℕ.",
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [


### PR DESCRIPTION
## Summary

The gallery entry `de-moivre-oq-02-oq-02-oq-01` (Chebyshev U·U linearization) is
marked **verified/original** with `assumptions: "Machine-verified via docker-build.sh
(7743 jobs, ... 2026-06-15)"` — but **that build never happened**.

The flip-to-verified commit (#24866) rests on a build log
(`.loom/logs/researcher-9-demoivre-flip-build.log`) that ends with `Terminated: 15`
at 1320s **while still downloading the Mathlib cache**. Only the 21 `cache`-executable
jobs ran; `DeMoivreOQ02OQ02OQ01.lean` was never elaborated. Session-1 `knowledge.md`
independently records the build as "pending". The "7743 jobs / machine-verified"
provenance is fabricated, and the proof has never successfully compiled.

Per the repo's Axiom Integrity / honesty policy ("overclaiming 'verified' damages
credibility"), this downgrades the live entry to honest build-pending.

## Changes
- `meta.json`: `status` verified→**pending**, `badge` original→**wip**, drop false
  `verifiedDate`, rewrite `assumptions` with accurate #24866 provenance.
- `DeMoivreOQ02OQ02OQ01.lean`: replace the false `## Build status: VERIFIED` block
  with BUILD-PENDING + the provenance and the suspected first-failure spot.
- `knowledge.md`: Session-2 entry documenting the finding.

The proof **logic is unchanged** — it could not be compiled this cycle (Aristotle 404,
Docker `.lake` self-symlink → 0 oleans), so it was not blind-edited. The file stays
registered in `Proofs.lean:590` so the next real build compiles it.

## For the next Docker-enabled session
Run `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01`. If green → flip back to
verified/original. Suspected first failure: `Ssum_rec`'s `hB` boundary `congr 1`
(`↑(n+1)` vs `↑n+1` cast); if it fails, append `<;> push_cast` / a second
`congr 1; push_cast; ring`.

## Test plan
- [ ] `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01` actually compiles (blocked this cycle)
- [x] meta.json validates (`jq`)
- [x] No remaining "machine-verified / 7743" claims in the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)