### PR TITLE
Enrich Newton-Girard arbitrary-k (oq-02-oq-01-oq-04): add annotations.json

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/annotations.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "ann-amgm-oq020104-strategy",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Route A vs Route B: Transport Instead of Induction",
+    "content": "The module header lays out the central design decision. Mathlib's `NewtonIdentities` file proves Newton's identities only for the *universal* symmetric functions `MvPolynomial.esymm`/`MvPolynomial.psum` over a `Fintype` — the polynomial-root form, where the variables are formal indeterminates. The directly usable statement, for a concrete finite family `f : ι → R` of actual ring elements, is not in Mathlib. Two routes are weighed: (A) specialize the universal identity to the index subtype `↥s` and evaluate along the algebra map `aeval`, transporting the identity for free because a ring homomorphism preserves every algebraic operation; or (B) reprove the recurrence by induction on `s` (~150–250 lines, self-contained). Route A is executed: it converts a long combinatorial induction into a short transport plus two evaluation bridges. The header also pins the exact Mathlib v4.26.0 API names used, which is what makes the brittle `aeval`-pushing step reproducible.",
+    "mathContext": "Universal identity (Mathlib): over $\\mathrm{MvPolynomial}\\,\\sigma\\,R$ with $\\sigma$ a `Fintype`, $k\\,e_k = (-1)^{k+1}\\sum_{j<k}(-1)^j e_j\\,p_{k-j}$. Transport: apply $\\mathrm{aeval}(i\\mapsto f\\,i) : \\mathrm{MvPolynomial}\\,\\uparrow s\\,R \\to R$, an $R$-algebra homomorphism, to obtain the concrete identity in $R$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MvPolynomial.NewtonIdentities",
+      "universal symmetric functions",
+      "aeval transport",
+      "Route A vs Route B"
+    ],
+    "prerequisites": [
+      "MvPolynomial.esymm / MvPolynomial.psum",
+      "algebra homomorphism (aeval)",
+      "Fintype on a Finset subtype"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-setup",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 52,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "CommRing Generality and the Index Type",
+    "content": "`import Mathlib` pulls in the full library (the gallery convention; this file is not Mathlib-bound). The variable block `{ι R : Type*} [CommRing R]` fixes the level of generality: an arbitrary index type `ι` and any commutative ring `R`. No order, positivity, or completeness is assumed — the recurrence is a pure algebraic identity, so it holds over `ℤ`, `ℚ`, polynomial rings, formal power series, and finite rings alike. This is strictly more general than the real-analysis AM-GM setting and is exactly why the result is a candidate for upstreaming: Mathlib lacks the Finset/CommRing layer.",
+    "mathContext": "A `CommRing R` provides $+,\\cdot$ with commutativity, associativity, distributivity, additive inverses, and $0,1$. The Newton–Girard identity $\\sum_{j<k}(-1)^j e_j p_{k-j} + (-1)^k k\\,e_k = 0$ uses only these axioms; no ordering $\\le$ ever appears.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CommRing",
+      "Finset",
+      "BigOperators",
+      "algebraic generality"
+    ],
+    "prerequisites": [
+      "CommRing typeclass",
+      "Lean 4 variable binders",
+      "Finset / BigOperators notation"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-defs",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 60,
+      "endLine": 65
+    },
+    "type": "definition",
+    "title": "Concrete Power Sums and Elementary Symmetric Functions",
+    "content": "The two concrete definitions are the objects the recurrence relates. `psum s f k = ∑_{i∈s} (f i)^k` is the $k$-th power sum of the family. `esymm s f k = ∑_{T ∈ s.powersetCard k} ∏_{i∈T} f i` is the $k$-th elementary symmetric function, summing the products over every $k$-element subset of `s`. Note `esymm s f 0 = 1`: there is a unique $0$-element subset, the empty set, whose product is the empty product `1`. These definitions are deliberately stated in terms of `f` and `s` directly (not as evaluated polynomials), so that the final theorem is immediately usable on concrete data; the bridge lemmas are what connect them back to Mathlib's `MvPolynomial` versions.",
+    "mathContext": "$p_k(s,f) = \\sum_{i \\in s} f(i)^k$ and $e_k(s,f) = \\sum_{T \\subseteq s,\\ |T| = k} \\prod_{i \\in T} f(i)$. In particular $e_0 = 1$ (empty product) and $e_1 = \\sum_{i\\in s} f(i) = p_1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "power sum",
+      "elementary symmetric polynomial",
+      "Finset.powersetCard",
+      "empty product convention"
+    ],
+    "prerequisites": [
+      "Finset.sum / Finset.prod",
+      "Finset.powersetCard",
+      "elementary symmetric functions"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-psum-bridge",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Power-Sum Bridge: aeval of the Universal psum",
+    "content": "`psum_bridge` shows that evaluating the universal power sum `MvPolynomial.psum (↥s) R n` along `aeval (i ↦ f i.1)` lands exactly on the concrete `psum s f n`. The proof is short because the power sum is just a sum of monomials $X_i^n$: `map_sum` pushes `aeval` through the sum, `← Finset.sum_coe_sort` re-expresses the sum over `↥s` as a sum over `s`, and each term collapses via `map_pow` and `MvPolynomial.aeval_X` (which sends the indeterminate $X_i$ to its assigned value $f(i)$). This is the easier of the two bridges; it works essentially because `aeval` is a ring homomorphism and the power sum has no combinatorial structure beyond raising variables to a power.",
+    "mathContext": "$\\mathrm{aeval}(i \\mapsto f\\,i)\\big(\\sum_{i:\\uparrow s} X_i^{\\,n}\\big) = \\sum_{i:\\uparrow s} f(i)^n = \\sum_{i\\in s} f(i)^n = p_n(s,f)$, using $\\mathrm{aeval}(X_i) = f(i)$ and that ring homomorphisms commute with $\\sum$ and $(\\cdot)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MvPolynomial.psum",
+      "MvPolynomial.aeval_X",
+      "map_sum",
+      "Finset.sum_coe_sort"
+    ],
+    "prerequisites": [
+      "aeval as a ring homomorphism",
+      "map_sum / map_pow",
+      "Finset.sum_coe_sort"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-esymm-bridge",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 75,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "Elementary-Symmetric Bridge: The Load-Bearing Step",
+    "content": "`esymm_bridge` is the substantive transport lemma. Evaluating `MvPolynomial.esymm (↥s) R n` along `aeval` must be shown to equal the concrete `esymm s f n`, but the universal esymm is defined as a sum over subsets of the index type, so the proof has to reconcile two different `Finset` layers. The chain: (1) `MvPolynomial.aeval_esymm_eq_multiset_esymm` rewrites the aeval into a `Multiset.esymm` of the mapped values; (2) the helper `himg` collapses `(univ : Finset ↥s).val.map (f ∘ val)` to `s.val.map f`, using that `univ` over the coe-sort is definitionally `s.attach` and then `Multiset.attach_map_val'` to strip the `attach`; (3) `Finset.esymm_map_val` rewrites the multiset esymm of the mapped values back to the `powersetCard` sum that defines the concrete `esymm`; (4) `rfl` closes the definitional gap. This lemma is what makes Route A pay off — without it the universal identity could not be re-expressed over the original index set.",
+    "mathContext": "$\\mathrm{aeval}(i\\mapsto f\\,i)\\big(e_n^{\\uparrow s}\\big) = \\big((\\mathrm{univ}).\\mathrm{val}.\\mathrm{map}\\,(f\\circ \\mathrm{val})\\big).\\mathrm{esymm}\\,n = (s.\\mathrm{val}.\\mathrm{map}\\,f).\\mathrm{esymm}\\,n = \\sum_{T\\in s.\\mathrm{powersetCard}\\,n}\\prod_{i\\in T} f(i) = e_n(s,f).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MvPolynomial.aeval_esymm_eq_multiset_esymm",
+      "Finset.esymm_map_val",
+      "Multiset.attach_map_val'",
+      "Finset.attach_val",
+      "Multiset.esymm"
+    ],
+    "prerequisites": [
+      "Multiset.esymm and Finset.esymm_map_val",
+      "Finset.attach and the coe-sort Fintype instance",
+      "Multiset.attach_map_val'"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-reindex",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 93,
+      "endLine": 105
+    },
+    "type": "tactic",
+    "title": "Reindexing the Antidiagonal Filter onto range k",
+    "content": "Mathlib's universal identity produces its sum over the *filtered antidiagonal* of `k` — pairs `(a₁, a₂)` with `a₁ + a₂ = k` and `a₁ < k`. `reindex_filter` normalizes this into the clean `∑ j ∈ range k` form that the final statement uses. `Finset.sum_filter` turns the filter into an `if`-guarded summand; `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` rewrites the antidiagonal sum over `range (k+1)` with second coordinate `k - j`; `Finset.sum_range_succ` peels off the top term `j = k`, which is killed by `lt_self_iff_false` (the guard `k < k` is false, contributing `0`); and the remaining terms over `range k` each satisfy the guard, closed by `if_pos` from `mem_range`. The result rewrites the transported sum into exactly $\\sum_{j<k}(-1)^j e_j\\,p_{k-j}$.",
+    "mathContext": "$\\sum_{\\substack{(a_1,a_2)\\in\\mathrm{antidiag}\\,k\\\\ a_1<k}} (-1)^{a_1} e_{a_1} p_{a_2} = \\sum_{j\\in\\mathrm{range}\\,k} (-1)^j e_j\\,p_{k-j}$, since $a_1+a_2=k \\Rightarrow a_2 = k - a_1$ and the $a_1=k$ term vanishes under the strict guard.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.Nat.antidiagonal",
+      "Finset.sum_filter",
+      "Finset.sum_range_succ",
+      "sum_antidiagonal_eq_sum_range_succ_mk"
+    ],
+    "prerequisites": [
+      "Finset.Nat antidiagonal lemmas",
+      "Finset.sum_filter and if_pos",
+      "lt_self_iff_false"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq020104-main",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-04",
+    "range": {
+      "startLine": 107,
+      "endLine": 127
+    },
+    "type": "theorem",
+    "title": "The Newton-Girard Recurrence and Sign Closure",
+    "content": "The main theorem assembles the pieces. `key := MvPolynomial.mul_esymm_eq_sum (↥s) R k` is Mathlib's universal identity; `apply_fun (aeval ...) at key` evaluates the whole equation in `R`. A single `simp only [map_mul, map_pow, map_neg, map_one, map_natCast, map_sum, esymm_bridge, psum_bridge]` discharges every ring-homomorphism commutation and substitutes the two bridges in one pass, after which `reindex_filter` cleans the sum into `range k` form. What remains is pure sign bookkeeping: Mathlib states the identity as $k\\,e_k = (-1)^{k+1}\\sum_j (-1)^j e_j p_{k-j}$, so to reach the symmetric vanishing form one multiplies by $(-1)^k$ and uses `hsign : (-1)^k (-1)^{k+1} = -1`, proved from $k + (k+1) = 2k+1$ being odd via `Odd.neg_one_pow`. The final `rw [..., hsign, neg_one_mul]` and `ring` close the goal. The hypothesis `1 ≤ k` is named `_hk` because the transported identity already holds structurally; it documents the intended range (the $k=0$ statement degenerates).",
+    "mathContext": "From $k\\,e_k = (-1)^{k+1}\\sum_{j<k}(-1)^j e_j p_{k-j}$, multiply by $(-1)^k$: $(-1)^k k\\,e_k = (-1)^{2k+1}\\sum_{j<k}(-1)^j e_j p_{k-j} = -\\sum_{j<k}(-1)^j e_j p_{k-j}$, hence $\\sum_{j<k}(-1)^j e_j p_{k-j} + (-1)^k k\\,e_k = 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MvPolynomial.mul_esymm_eq_sum",
+      "apply_fun",
+      "Odd.neg_one_pow",
+      "Newton-Girard recurrence",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "MvPolynomial.mul_esymm_eq_sum",
+      "apply_fun on an equation",
+      "Odd.neg_one_pow and pow_add",
+      "ring normalization"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: amgm-inequality-oq-02-oq-01-oq-04

The gallery entry had a rich `meta.json` but was **missing `annotations.json`** entirely — the primary driver of its low quality score (43). This pass adds it.

### Changes
- **Created `annotations.json`** with 7 substantive annotations covering the full 127-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Route A vs Route B strategy (transport vs induction) — `supporting`
  2. CommRing generality and the index subtype `↥s` — `supporting`
  3. Concrete `psum` / `esymm` definitions (incl. `e₀ = 1`) — `key`
  4. `psum_bridge` (aeval of universal power sum) — `supporting`
  5. `esymm_bridge` — `critical` (load-bearing transport step)
  6. `reindex_filter` antidiagonal→`range k` reindexing — `supporting`
  7. `newton_girard` main theorem + sign closure via `Odd.neg_one_pow` — `critical`

### Verification
- Annotations checked line-by-line against `proofs/Proofs/AmgmInequalityOQ02OQ01OQ04.lean`
- Valid `type`/`significance` enum values per `src/types/proof.ts`
- `pnpm build` green

### Axiom integrity
No change to status/badge/axiomCount. meta.json declares `verified` / `original` / 0 axioms; the Lean file has 0 sorries, 0 `axiom` declarations, and no assumption-carrying structures — consistent.