### PR TITLE
research(law-of-cosines-oq-04-oq-01): genuine angle-bisector property (equal half-angle cosines)

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04OQ01.lean
@@ -33,6 +33,10 @@ The abstract cosine `t` of the parent file is replaced by the real inner product
 * `angle_bisector_length_inner` — the internal-bisector length formula
     (b + c)²‖A - D‖² = bc((b + c)² − a²)
   for the cevian foot dividing `BC` in the ratio `BD:DC = c:b`.
+* `angle_bisector_ratio_inner` — the genuine angle-bisector property: with the
+  same ratio hypothesis, ray `AD` bisects `∠BAC` (equal half-angle cosines),
+  `‖A-C‖·⟪B-A, D-A⟫ = ‖A-B‖·⟪C-A, D-A⟫`. Upgrades the previous lemma from a
+  stipulated-ratio cevian to the actual internal bisector.
 
 The geometric content (BD = s·a, DC = (1 - s)·a) is what makes `m + n = a`; here
 that is encoded directly so the algebraic identity holds with no sign hypotheses.
@@ -124,6 +128,39 @@ theorem angle_bisector_length_inner (A B C : V) (s : ℝ)
   linear_combination
     ((‖A - C‖ + ‖A - B‖) ^ 2 * (‖A - C‖ - ‖A - B‖) +
         ‖B - C‖ ^ 2 * (s * (‖A - C‖ + ‖A - B‖) - ‖A - C‖)) * hs
+
+/-- **Angle-bisector property** (equal half-angle cosines).
+
+    The companion `angle_bisector_length_inner` only used the segment ratio
+    `BD : DC = c : b`; it did *not* establish that this ratio is the one cut by
+    the genuine internal angle bisector at `A`.  This lemma supplies exactly
+    that geometric content: for the cevian foot `D = (1 - s) • B + s • C` with
+    the same ratio hypothesis `hs : s · (b + c) = c` (`b = ‖A-C‖`, `c = ‖A-B‖`),
+    ray `AD` bisects `∠BAC` — the two half-angles have equal cosine.  Stated in
+    the cleared, division-free cross-multiplied form
+
+      ‖A-C‖ · ⟪B-A, D-A⟫ = ‖A-B‖ · ⟪C-A, D-A⟫,
+
+    which is `cos∠BAD = cos∠DAC` with the common `‖D-A‖` and the norms
+    `‖B-A‖ = c`, `‖C-A‖ = b` cleared.  Valid in any real inner product space and
+    any dimension; certified numerically over dims 2–8 by
+    `verify_bisector_theorem.py`.
+
+    Proof: expand both inner products bilinearly to the scalar shape
+    `b·((1-s)c² + s·w) = c·((1-s)w + s·b²)` with `w = ⟪B-A, C-A⟫`, then close by
+    `linear_combination · hs` since the difference factors as
+    `(w − bc)·(s(b+c) − c)`. -/
+theorem angle_bisector_ratio_inner (A B C : V) (s : ℝ)
+    (hs : s * (‖A - C‖ + ‖A - B‖) = ‖A - B‖) :
+    ‖A - C‖ * ⟪B - A, ((1 - s) • B + s • C) - A⟫_ℝ
+      = ‖A - B‖ * ⟪C - A, ((1 - s) • B + s • C) - A⟫_ℝ := by
+  have hD : ((1 - s) • B + s • C) - A = (1 - s) • (B - A) + s • (C - A) := by
+    module
+  rw [hD, inner_add_right, inner_add_right, real_inner_smul_right, real_inner_smul_right,
+    real_inner_smul_right, real_inner_smul_right, real_inner_self_eq_norm_sq,
+    real_inner_self_eq_norm_sq, real_inner_comm (C - A) (B - A), norm_sub_rev B A,
+    norm_sub_rev C A]
+  linear_combination (⟪B - A, C - A⟫_ℝ - ‖A - C‖ * ‖A - B‖) * hs
 
 /-
 ## Summary

--- a/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
+++ b/research/problems/law-of-cosines-oq-04-oq-01/knowledge.md
@@ -171,3 +171,38 @@ upgrades it to a genuine internal-angle-bisector length theorem.
 - (Docker) add `angle_bisector_ratio_inner` and chain it with S2's length law.
 - Optional: the EXTERNAL bisector (`D' = (b·B − c·C)/(b−c)`, ratio `c:b` external) satisfies the
   sign-flipped identity `b⟪B-A,D'-A⟫ = −c⟪C-A,D'-A⟫`; a one-line analogue worth adding.
+
+## Session 2026-06-16 (researcher-1) — ACT: angle-bisector property added (build-pending)
+
+**Mode:** CONTINUE / ACT. Triple backend blackout (Aristotle `prove` → 404
+"Resource not found", live-probed; local `proofs/.lake` circular self-symlink →
+0 warm oleans; Docker host 4 containers incl. an 8h zombie on an 8 GB VM —
+above the safe ≤2 build threshold, did not pile on). No local build this session.
+
+**What I did.** Wrote the long-deferred `angle_bisector_ratio_inner` target
+(specified in the previous session's "Lean target" block) into the **registered**
+`LawOfCosinesOQ04OQ01.lean`, upgrading the file from a *stipulated-ratio cevian*
+(`angle_bisector_length_inner`) to the genuine **internal angle bisector** —
+equal half-angle cosines, cleared/division-free:
+
+  `‖A-C‖ · ⟪B-A, D-A⟫ = ‖A-B‖ · ⟪C-A, D-A⟫`   (cevian foot `D = (1-s)•B + s•C`,
+  ratio hypothesis `hs : s·(‖A-C‖+‖A-B‖) = ‖A-B‖`).
+
+Proof = bilinear expansion (`inner_add_right`, `real_inner_smul_right`,
+`real_inner_self_eq_norm_sq`, `real_inner_comm`, `norm_sub_rev`) to the scalar
+shape `b·((1-s)c²+s·w) = c·((1-s)w+s·b²)`, `w = ⟪B-A,C-A⟫`, then
+`linear_combination (⟪B-A,C-A⟫ − ‖A-C‖·‖A-B‖) · hs` — same idiom as the
+neighbouring length lemma. The difference factors as `(w−bc)·(s(b+c)−c)`, killed
+by `hs`. File stays 0 axioms / 0 sorries. PR #24930.
+
+**De-risking the blind write.** Every lemma name was confirmed in currently-green
+repo proofs (`real_inner_smul_right` is already used in this file's
+`norm_smul_add_smul_sq`; `inner_add_right`/`real_inner_self_eq_norm_sq` in
+CevasTheorem/Brouwer files). The coefficient was hand-derived and matches the
+numeric certificate `verify_bisector_theorem.py` (dims 2–8). Deployer build-gate
+verifies before merge.
+
+**Next steps.** (a) Confirm #24930 builds GREEN when a backend returns;
+(b) optional one-liner: the EXTERNAL bisector `D' = (b•B − c•C)/(b−c)` satisfies
+the sign-flipped `b⟪B-A,D'-A⟫ = −c⟪C-A,D'-A⟫`. The main OQ-04-OQ-01 deliverable
+(Stewart inner-product file) remains verified-complete on main (R8 #24883).


### PR DESCRIPTION
## Summary

Adds `angle_bisector_ratio_inner` to the **registered** inner-product Stewart file `Proofs.LawOfCosinesOQ04OQ01`, closing the explicit next-step gap recorded in this problem's `knowledge.md`.

- The existing `angle_bisector_length_inner` only assumed the **segment ratio** `BD : DC = c : b`; it did *not* prove that ray `AD` is the actual internal **angle** bisector at `A`.
- This lemma supplies that geometric content: with the same ratio hypothesis, the two half-angles `∠BAD` and `∠DAC` have **equal cosine**, stated in cleared, division-free cross-multiplied form

  `‖A-C‖ · ⟪B-A, D-A⟫ = ‖A-B‖ · ⟪C-A, D-A⟫`,

  valid in any real inner product space and any dimension.

## Proof

`D - A = (1-s)•(B-A) + s•(C-A)`; expanding both inner products bilinearly gives the scalar identity `b·((1-s)c² + s·w) = c·((1-s)w + s·b²)` with `w = ⟪B-A, C-A⟫`, `b = ‖A-C‖`, `c = ‖A-B‖`. Its difference factors as `(w − bc)·(s(b+c) − c)`, so `linear_combination (⟪B-A,C-A⟫ − ‖A-C‖·‖A-B‖) · hs` closes it — the same idiom as the neighbouring `angle_bisector_length_inner`. File remains **0 axioms / 0 sorries**.

Numerically certified over dims 2–8 by `verify_bisector_theorem.py` (already in the problem dir).

## Build status

Written under a backend blackout (Aristotle 404, local `proofs/.lake` circular self-symlink, Docker host saturated at 4 containers / 8 GB — above the safe build threshold), so **not locally compiled this session**. All lemma names used (`inner_add_right`, `real_inner_smul_right`, `real_inner_self_eq_norm_sq`, `real_inner_comm`, `norm_sub_rev`, `module`, `linear_combination`) were verified against currently-green repo proofs. The registered-file deployer build-gate verifies before merge — a miscompile cannot reach main.

## Test plan
- [ ] `docker-build.sh Proofs.LawOfCosinesOQ04OQ01` → expect GREEN, 0 sorries / 0 axioms (deployer-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)