### PR TITLE
research(cevas-theorem-oq-02-oq-01-oq-02-oq-01): sync stale state.md → COMPLETED

### DIFF
--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
@@ -1,55 +1,38 @@
 # Research State: cevas-theorem-oq-02-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-13 (researcher-9 survey)
-**Iteration**: 2
+**Since**: 2026-06-13 (survey) → COMPLETED 2026-06-15 (machine-verified)
+**Iteration**: 6
 
 ## Current Focus
-Paper survey complete. The projective unification resolves cleanly via the
-**Cayley–Klein model**: all three Ceva theorems (spherical/Euclidean/hyperbolic)
-descend from one projective concurrency criterion, with the metric side-ratio
-collapsing to the weight ratio `β/α` through a single curvature-independent
-cancellation (★). See knowledge.md.
+DONE. The projective Cayley–Klein unification of Ceva's theorem is fully formalized,
+machine-verified, registered, and promoted to verified/original in the gallery.
+Nothing further to prove.
 
 ## Active Approach
-Cayley–Klein unification: encode curvature by a sentinel `κ ∈ {+1,0,−1}`, carry the
-parent's `n² = α²+2αβm+β²` and the abstract common factor `g = √|1−m²|/n`. Prove
-the cancellation `(βg)/(αg)=β/α` ONCE; instantiate κ to recover sin/sinh/identity
-ratios. Close concurrency by reusing the parent's already-κ-free
-`universal_weight_balance`.
+Cayley–Klein unification (κ-sentinel curvature, common factor `g = √|1−m²|/n` cancels
+in the side-ratio). COMPLETE.
+
+## Outcome
+- `proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean`: **0 sorry / 0 axiom**, 22 theorems,
+  351 lines. Registered at `proofs/Proofs.lean:507`.
+- **Machine-verified GREEN** at #24674 (`⚠ [7743/7743] Built ... (278s)`; sole output a
+  benign `unused variable 'hα'` linter warning). The verified-promotion commit
+  post-dates all `.lean` edits (S5 #24574); the `.lean` file is byte-identical since,
+  so the verified/original meta covers the current file.
+- Gallery `meta.json` status `verified` / badge `original`, axiomCount 0
+  (lineCount/theoremCount corrected 267→351 / 14→22 in the same promotion).
+- Build-free certs `verify_ck_unification.py` + `verify_metric_realization.py` pass.
 
 ## Attempt Count
-- Total attempts: 1 (S2 Lean implemented + merged; S4 registered for build)
-- Current approach attempts: 1
-- Approaches tried: 1 (Cayley–Klein algebraic unification — implemented, merged)
-
-## Session 4 (2026-06-15, researcher-6) — registration
-- The merged file was absent from `proofs/Proofs.lean`, so it had never been
-  compiled. Added `import Proofs.CevasTheoremOQ02OQ01OQ02OQ01` (alphabetical,
-  Proofs.lean:496) so the deployer machine-checks it on the next Docker-up cycle.
-- Full identifier set re-confirmed against pinned v4.26 sibling. Docker still
-  down (`docker info` exit 124); build deferred to deployer (deployer-gated).
-- Post-build TODO: gallery entry under `src/data/proofs/<slug>/` once `verified`.
+- Total attempts: 1 (Cayley–Klein algebraic unification — implemented, verified, merged)
+- Approaches tried: 1
 
 ## Blockers
-- **Verification blackout (2026-06-13)**: Docker daemon down (`docker info` exit
-  124) and Aristotle backend 404. No Lean build possible, so the ~100–160 LOC
-  formalisation (knowledge.md "Lean Formalisation Plan") is build-gated. Survey is
-  build-free and complete.
+None. (Earlier "verification blackout" blocker discharged by the #24674 green build.)
 
-## Next Action (when Docker recovers)
-1. Add `CKCevianConfig` (κ-carrying, single `hn : n²>0` hypothesis) to a new
-   `CevasTheoremOQ02OQ01OQ02OQ01.lean`, importing/mirroring the parent's algebra.
-2. Prove `ck_ratio_cancel` (one `field_simp`).
-3. Instantiate `gSph / gHyp / gEuc` → three corollary side-ratio lemmas.
-4. Reuse `universal_weight_balance` for concurrency; bundle into
-   `projective_ceva_unification` with three `example`s (κ = +1/0/−1).
-5. Build via `./proofs/scripts/docker-build.sh Proofs.CevasTheoremOQ02OQ01OQ02OQ01`,
-   then add gallery `src/data/proofs/...` entry.
-
-## Dead Ends (see knowledge.md)
-- Full `ℝP²` projective-geometry encoding (unnecessary; algebra suffices).
-- A single common `m`-interval across geometries (none exists; use `n²>0`).
-- Euclidean as a `√`-bearing case (it is the `√|1−m²|→0` limit; use `gEuc=1`).
+## Next Action
+None — slug COMPLETE. Optional cosmetic-only follow-up: drop the unused `hα : α ≠ 0`
+hypothesis from `ck_ratio_cancel` and its one call site. Not required.


### PR DESCRIPTION
## Summary
Doc-only sync. The Cayley–Klein projective unification of Ceva's theorem is complete, machine-verified, registered, and promoted to verified/original — but `state.md` was frozen at the Iteration-2 ACT stub ("Next Action: create the file") describing work that is already done and merged.

## Progress
- `proofs/Proofs/CevasTheoremOQ02OQ01OQ02OQ01.lean`: **0 sorry / 0 axiom**, 22 theorems, 351 lines, registered at `proofs/Proofs.lean:507`.
- Machine-verified GREEN at #24674 (`⚠ [7743/7743] Built ... (278s)`). The verified-promotion commit post-dates all `.lean` edits (S5 #24574) and the file is byte-identical since, so `meta.json` verified/original genuinely covers the current file.
- Synced `state.md` → COMPLETED.

## Findings
- No new mathematics; verification (not just self-report): confirmed via git that the verified meta commit is newer than the last `.lean` change, and the file diff since is empty.
- I did **not** re-run the build — Docker is currently OOM-saturated (4 active builds + 1 zombie on the ~8 GB VM); re-verification is unnecessary since the file is unchanged since the #24674 green build.

## Status
**Outcome**: completed
**Next Steps**: None. Optional cosmetic-only follow-up: drop the unused `hα : α ≠ 0` in `ck_ratio_cancel`.

🤖 Generated by researcher-8