### PR TITLE
Enrich erdos-1179-oq-02: refine sections to file, fix invalid annotation enums

### DIFF
--- a/src/data/proofs/erdos-1179-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1179-oq-02/annotations.json
@@ -3,11 +3,11 @@
     "id": "e1179-oq02-ann-overview",
     "proofId": "erdos-1179-oq-02",
     "range": { "startLine": 1, "endLine": 43 },
-    "type": "context",
+    "type": "concept",
     "title": "Erdős #1179 OQ-02 and the Trivial Lower Bound",
     "content": "Erdős #1179 (Erdős–Hall, 1976) gives the minimal number gₑ(N) of random group elements needed for an ε-uniform subset-sum representation in an abelian group of order N: gₑ(N) = (1 + oₑ(1))·log₂N. OQ-02 asks whether the multiplicative (1+o(1)) factor sharpens to a bounded additive error gₑ(N) ≤ log₂N + Oₑ(1), matching the trivial lower bound gₑ(N) ≥ log₂N. This file formalizes the lower-bound side concretely and axiom-free at the per-subset level, replacing the parent file's abstract axiom basic_lower_bound and removing its circular uniform_implies_spanning hypothesis. The headline additive upper bound remains open.",
     "mathContext": "$g_\\varepsilon(N) = (1+o_\\varepsilon(1))\\log_2 N$; OQ-02 target: $g_\\varepsilon(N) \\le \\log_2 N + O_\\varepsilon(1)$.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": ["Erdős problems", "additive combinatorics", "subset sums", "abelian groups", "information-theoretic lower bound"],
     "prerequisites": ["finite abelian groups", "subset-sum representations", "asymptotic notation"]
   },
@@ -31,7 +31,7 @@
     "title": "Transferring a Strict Real Bound to a ℕ Lower Bound",
     "content": "The spanning conclusion is the natural-number inequality 1 ≤ reprCount A g, but the uniformity hypothesis lives over ℝ. The proof bridges the two with a reusable three-step pattern. (1) Derive the strict real inequality 0 < (reprCount A g : ℝ) from (1−ε)·μ > 0 (a product of two positives, mul_pos) and F_A(g) ≥ (1−ε)·μ (linarith). (2) Convert positivity of the cast to non-vanishing of the natural number: reprCount A g ≠ 0, since reprCount A g = 0 would force the cast to 0, contradicting hpos (rw + simp). (3) Close with omega, which upgrades n ≠ 0 to 1 ≤ n for n : ℕ. The key subtlety is that ℕ has no strict order below 1 — there is no natural number strictly between 0 and 1 — so a real lower bound that is merely positive (not ≥ 1) still yields the sharp integer bound 1 ≤ n once cast-positivity rules out n = 0. Using nlinarith/linarith for the ℝ side and omega for the ℕ side keeps each step in the arithmetic where it is decidable.",
     "mathContext": "$0 < (\\,\\mathrm{reprCount}\\,A\\,g : \\mathbb{R}) \\Rightarrow \\mathrm{reprCount}\\,A\\,g \\neq 0 \\xrightarrow{\\;\\omega\\;} 1 \\le \\mathrm{reprCount}\\,A\\,g$, exploiting that $\\mathbb{N}$ has no element in $(0,1)$.",
-    "significance": "technical",
+    "significance": "supporting",
     "relatedConcepts": ["Nat.cast positivity", "ℕ↔ℝ coercion", "omega", "mul_pos", "discreteness of ℕ"],
     "prerequisites": ["Nat.cast and Nat.cast_pos", "linarith/nlinarith", "omega decision procedure"]
   },

--- a/src/data/proofs/erdos-1179-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-02/meta.json
@@ -67,11 +67,19 @@
   "sections": [
     {
       "id": "overview-and-setup",
-      "title": "Problem Framing, Parent Dependency, and Imports",
+      "title": "Problem Framing and Parent Dependency",
       "startLine": 1,
-      "endLine": 48,
+      "endLine": 43,
       "summary": "The module docstring frames Erdős #1179 (Erdős–Hall 1976, gₑ(N) = (1+oₑ(1))·log₂N) and OQ-02's sharpening to an additive Oₑ(1) error, then states what is formalized here: the axiom-free per-subset lower bound N ≤ 2^|A| underlying the parent's abstract axiom basic_lower_bound. It explains the key non-circular insight (μ > 0 from N ≥ 1 alone drives spanning) and records the only dependencies — Erdos1179.total_reprCount and expectedReprCount_pos — followed by the imports (Proofs.Erdos1179Problem, Mathlib), the Erdos1179 namespace, and open Finset Real.",
       "mathContext": "Sets up $\\mu = 2^{|A|}/N$, the ε-uniformity bound $|F_A(g)-\\mu| \\le \\varepsilon\\mu$, and the parent identity $\\sum_g F_A(g) = 2^{|A|}$ used downstream."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and Namespace Setup",
+      "startLine": 44,
+      "endLine": 48,
+      "summary": "Imports the parent Erdős #1179 development (which supplies the definitions reprCount, expectedReprCount μ, the ε-uniformity predicate epsUniform, and the lemmas expectedReprCount_pos and total_reprCount) and opens the Erdos1179 namespace so the concrete lower-bound theorems can reuse the parent's machinery without redefining it.",
+      "mathContext": "Brings the parent identities $\\mu = 2^{|A|}/N > 0$ (for $N \\ge 1$) and $\\sum_g F_A(g) = 2^{|A|}$ into scope for the three theorems that follow."
     },
     {
       "id": "spanning",
@@ -82,12 +90,20 @@
       "mathContext": "$F_A(g) \\ge (1-\\varepsilon)\\mu > 0 \\Rightarrow F_A(g) \\ge 1$ for all $g$, given $\\varepsilon < 1$."
     },
     {
-      "id": "lower-bound",
-      "title": "The Trivial Lower Bound N ≤ 2^|A| and ⌈log₂N⌉ ≤ |A|",
+      "id": "lower-bound-card",
+      "title": "The Trivial Lower Bound N ≤ 2^|A|",
       "startLine": 77,
+      "endLine": 91,
+      "summary": "card_le_two_pow_of_epsUniform sums the spanning bound over all N group elements: N = Σ_g 1 ≤ Σ_g F_A(g) (Finset.sum_le_sum with epsUniform_spanning), and total_reprCount gives Σ_g F_A(g) = 2^|A|. The calc chain yields N ≤ 2^|A| — the information-theoretic statement that the 2^|A| subsets of A must cover all N group elements.",
+      "mathContext": "$N=\\sum_g 1 \\le \\sum_g F_A(g) = 2^{|A|}$."
+    },
+    {
+      "id": "lower-bound-clog",
+      "title": "Logarithmic Form ⌈log₂N⌉ ≤ |A|",
+      "startLine": 93,
       "endLine": 104,
-      "summary": "card_le_two_pow_of_epsUniform sums spanning over all N group elements and applies total_reprCount (Σ_g F_A(g) = 2^|A|) to get N ≤ 2^|A|. clog_le_card_of_epsUniform converts this via Nat.le_pow_iff_clog_le into the integer headline bound ⌈log₂N⌉ ≤ |A|.",
-      "mathContext": "$N=\\sum_g 1 \\le \\sum_g F_A(g) = 2^{|A|}$, so $\\lceil\\log_2 N\\rceil \\le |A|$."
+      "summary": "clog_le_card_of_epsUniform converts N ≤ 2^|A| into the integer headline bound Nat.clog 2 N ≤ |A| via Nat.le_pow_iff_clog_le (valid since base 2 > 1). Since Nat.clog 2 N = ⌈log₂N⌉, this is exactly the trivial lower bound gₑ(N) ≥ log₂N at the per-subset level.",
+      "mathContext": "$N \\le 2^{|A|} \\iff \\lceil\\log_2 N\\rceil = \\operatorname{clog}_2 N \\le |A|$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass: erdos-1179-oq-02

### Sections (3 → 5, now 1:1 with the Lean file)
The previous `sections` array lumped two distinct theorems into one entry and combined the docstring with the imports. Split into the file's actual regions:
1. Problem Framing and Parent Dependency (docstring, 1–43)
2. Imports and Namespace Setup (44–48)
3. Hypothesis-Free Spanning from ε-Uniformity (`epsUniform_spanning`, 49–75)
4. The Trivial Lower Bound N ≤ 2^|A| (`card_le_two_pow_of_epsUniform`, 77–91)
5. Logarithmic Form ⌈log₂N⌉ ≤ |A| (`clog_le_card_of_epsUniform`, 93–104)

### Annotation enum fixes
The entry carried values outside the `src/types/proof.ts` unions:
- annotation type `"context"` → `"concept"` (valid: theorem|lemma|definition|tactic|concept|insight|warning)
- significance `"context"` and `"technical"` → `"supporting"` (valid: critical|key|supporting)

### Verification
- `pnpm build` green
- Section line ranges checked against `proofs/Proofs/Erdos1179OQ02.lean`
- No content removed; meta.json `status` left as `formalized`/`wip` (badge flip requires a Docker verification build, out of scope for enrichment)