### PR TITLE
research(quadratic-gauss-sum-square): repair broken registered file on main

### DIFF
--- a/proofs/Proofs/QuadraticGaussSumSquare.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquare.lean
@@ -70,6 +70,8 @@ theorem gaussSum_quadratic_sq (hp : p ≠ 2)
     {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
     gaussSum (chiC p) ψ ^ 2 = (-1 : ℂ) ^ ((p - 1) / 2) * p := by
   have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
-  rw [h, chiC_neg_one hp, ZMod.card p]
+  calc gaussSum (chiC p) ψ ^ 2
+      = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) := h
+    _ = (-1 : ℂ) ^ ((p - 1) / 2) * p := by rw [chiC_neg_one hp, ZMod.card p]
 
 end QuadraticGaussSumSquare


### PR DESCRIPTION
## Summary
`proofs/Proofs/QuadraticGaussSumSquare.lean` is **registered** in `proofs/Proofs.lean` (line 2773) but **does not compile on `main`**. The aggregate build fails at this module.

## Root cause
```lean
have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
rw [h, chiC_neg_one hp, ZMod.card p]   -- ❌
```
`gaussSum_sq` yields the **unfolded** `chiC` structure literal (`{ toFun := …, map_one' := …, … }`), which `rw [h]` cannot match against the **folded** `chiC p` occurrence in the goal, so the rewrite errors out.

## Fix
Use `h` as a definitional-equality bridge in a `calc`, rewriting only the scalar factors:
```lean
have h := gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
calc gaussSum (chiC p) ψ ^ 2
    = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) := h
  _ = (-1 : ℂ) ^ ((p - 1) / 2) * p := by rw [chiC_neg_one hp, ZMod.card p]
```

## Verification
- Built `main`'s current version → **Build failed** (`error: Lean exited with code 1` at `Proofs.QuadraticGaussSumSquare`, the `rw [h]` mismatch).
- Built this fix → `./proofs/scripts/docker-build.sh Proofs.QuadraticGaussSumSquare` → **Build completed successfully (7743 jobs)**.

## Context
The same one-line fix was authored in an earlier session but is stranded in open PR #24884, which bundles 46 unrelated `meta.json`/`registry.json` changes. This PR is the **focused 5-line repair** so `main` compiles again; the gallery-entry additions can land separately via #24884.

## Status
**Outcome**: build fix (repairs a broken registered file on main)
**Next Steps**: gallery entry `src/data/proofs/quadratic-gauss-sum-square/` is still pending in #24884; the open question itself remains as scoped.

🤖 Generated by researcher-5