### PR TITLE
research(roth-theorem-k3): sync stale state.md to COMPLETED

### DIFF
--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -324,3 +324,34 @@ Reverted these changes as the full fix requires an interactive Lean session.
 ### Next Steps
 - To eliminate the sorry: implement Dirichlet-based density increment in Case 2 using `DirichletApproximation.dirichlet_approximation`
 - This is optional since the main theorem is fully proved via Mathlib
+
+## Session (2026-06-16, researcher-9) — State-sync to COMPLETED
+
+**Mode**: REVISIT
+**Outcome**: completed (stale-doc sync, no Lean change)
+
+### What I Did
+- Found `state.md` frozen at Phase ORIENT / Iteration 1 (2026-03-22) listing 6 open
+  sorries (Fourier infrastructure), while the proof is in fact complete.
+- Verified `proofs/Proofs/RothTheorem.lean` is 0 sorries / 0 axioms and unchanged on
+  origin/main (last touched by audit #22746); registry.json already has the slug as
+  `phase: COMPLETED, status: graduated`; gallery meta is `status: verified, badge: mathlib`.
+- Synced `state.md` → COMPLETED, recording that the hand-built Fourier density-increment
+  plan was superseded by reducing `roth_density_bound` onto Mathlib's `roth_3ap_theorem_nat`
+  via the corners-theorem chain (the route state.md had filed as open Next-Action #3).
+
+### Key Findings
+- `roth_density_bound` (`RothTheorem.lean:1372`) maps `A : Finset (ZMod N)` to
+  `S = A.image ZMod.val`, bridges `APFree A → ThreeAPFree (S:Set ℕ)` via
+  `apFree_imp_threeAPFree_val` (`:1337`), and applies `roth_3ap_theorem_nat` with
+  `N₀ = cornersTheoremBound (δ/3) + 1`.
+- No build performed (triple backend blackout: Aristotle 404, Docker cold-cache 8h
+  mathlib-clone zombie, 0 local oleans). No build needed — gallery/registry already
+  verified and the Lean file is unchanged on main.
+
+### Files Modified
+- research/problems/roth-theorem-k3/state.md
+- research/problems/roth-theorem-k3/knowledge.md
+
+### Next Steps
+None for k3. Companion OQs (oq-01/02/03) hold the remaining sorries/axioms under their own slugs.

--- a/research/problems/roth-theorem-k3/state.md
+++ b/research/problems/roth-theorem-k3/state.md
@@ -1,39 +1,65 @@
 # Research State: roth-theorem-k3
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-03-22
 **Iteration**: 1
 
 ## Current Focus
-Infrastructure and proof architecture for Roth's theorem via Fourier density increment.
+Roth's theorem: every subset of ZMod N with density ≥ δ contains a non-trivial
+3-term arithmetic progression. COMPLETE — `proofs/Proofs/RothTheorem.lean` is
+0 sorries / 0 axioms; registry status `graduated`; gallery meta `verified`,
+badge `mathlib`.
 
-## Active Approach
-Fourier-analytic density increment. Six-part proof structure:
-1. AP-free definitions (COMPLETE)
-2. AP counting via tripleCount (COMPLETE — proved APFree ↔ tripleCount = 0)
-3. Fourier analysis infrastructure (3 sorries: norm bound, Parseval, AP-Fourier identity)
-4. Large Fourier coefficient (1 sorry)
-5. Density increment lemma (1 sorry — fixed to include APFree B)
-6. Iteration + main theorem (iteration PROVED from density_increment_lemma, main sorry)
+## Resolution
+The original plan (a hand-built Fourier-analytic density-increment argument, see
+"History" below) was **superseded** by the reduction route that state.md had listed
+as open Next-Action #3: `roth_density_bound` now discharges directly onto Mathlib's
+`roth_3ap_theorem_nat` via the corners-theorem chain
+(Regularity Lemma → Triangle Removal → Corners → Roth).
+
+Final proof shape (`RothTheorem.lean:1372` `roth_density_bound`):
+1. Map `A : Finset (ZMod N)` to `S = A.image ZMod.val ⊆ Finset.range N` (injective, density-preserving).
+2. Bridge `APFree A → ThreeAPFree (S : Set ℕ)` via `apFree_imp_threeAPFree_val` (`:1337`).
+3. Pick `N₀ = cornersTheoremBound (δ/3) + 1` and apply `roth_3ap_theorem_nat`.
+
+The earlier Fourier infrastructure lemmas (`parseval_on_zmod`, `fourier_large_coefficient`,
+`density_increment_lemma`, `density_iteration`) remain in the file as a self-contained
+analytic development and are themselves sorry-free.
 
 ## Attempt Count
 - Total attempts: 1
 - Current approach attempts: 1
-- Approaches tried: 1
+- Approaches tried: 2 (hand-built Fourier density increment; Mathlib corners-chain reduction — the latter closed it)
 
 ## Blockers
-None critical. Remaining sorries are well-structured intermediate results.
+None. Proof complete and verified.
 
 ## Key Findings
-- Mathlib has ZMod.dft, ZMod.stdAddChar, ThreeAPFree, additive energy — rich infrastructure
-- Mathlib may have roth_3ap_theorem via regularity/corners — verify and potentially connect
-- density_iteration theorem PROVED: k applications boost density by k·δ²/100
-- Original density_increment_lemma was missing APFree B in conclusion — fixed
+- Mathlib's `roth_3ap_theorem_nat` (`Mathlib.Combinatorics.Additive.Roth`) + `cornersTheoremBound`
+  (`...Additive.Corners`) close the ℕ-density form directly; no hand-built Fourier increment needed.
+- The ZMod → ℕ bridge is the only nontrivial glue: `ZMod.val` injectivity preserves card and density,
+  and `APFree` on `ZMod N` implies `ThreeAPFree` on the image in ℕ.
+- Mathlib's `ZMod.dft`, `ZMod.stdAddChar`, `ThreeAPFree`, additive energy remain available for the
+  companion / quantitative open questions (oq-01/02/03), which are tracked separately.
 
 ## Next Action
-1. Fill Fourier infrastructure sorries (fourierCoeff_norm_le, parseval_on_zmod)
-2. Connect APFree to Mathlib's ThreeAPFree for access to existing results
-3. Investigate if Mathlib's roth_3ap_theorem can close roth_density_bound directly
-4. Prove fourier_large_coefficient using Parseval + AP counting identity
+None — problem complete. Companion open questions (roth-theorem-k3-oq-01/02/03,
+RothTheoremOQ02/OQ03/Quantitative.lean) carry the remaining sorries/axioms and are
+tracked under their own slugs.
+
+---
+
+## History: original Active Approach (superseded)
+
+Fourier-analytic density increment. Six-part proof structure:
+1. AP-free definitions (COMPLETE)
+2. AP counting via tripleCount (COMPLETE — proved APFree ↔ tripleCount = 0)
+3. Fourier analysis infrastructure (norm bound, Parseval, AP-Fourier identity)
+4. Large Fourier coefficient
+5. Density increment lemma (with APFree B in conclusion)
+6. Iteration + main theorem
+
+All six parts are now sorry-free in `RothTheorem.lean`; the main theorem was ultimately
+closed by the Mathlib corners-chain reduction rather than by chaining the density increment.


### PR DESCRIPTION
## Summary
- `research/problems/roth-theorem-k3/state.md` was frozen at **Phase ORIENT / Iteration 1** (2026-03-22), listing 6 open Fourier-infrastructure sorries.
- The proof is in fact **complete**: `proofs/Proofs/RothTheorem.lean` is **0 sorries / 0 axioms**, unchanged on `main` since audit #22746. `registry.json` already has the slug as `phase: COMPLETED, status: graduated`; gallery `meta` is `status: verified, badge: mathlib`.
- Synced `state.md` → COMPLETED and added a knowledge.md session note.

## What actually closed it
The hand-built Fourier density-increment plan was **superseded** by reducing `roth_density_bound` (`RothTheorem.lean:1372`) onto Mathlib's `roth_3ap_theorem_nat` via the corners-theorem chain — exactly the route state.md had filed as open Next-Action #3. The ZMod→ℕ bridge (`apFree_imp_threeAPFree_val`, `:1337`) is the only nontrivial glue.

## Notes
- **No Lean change, no build.** Gallery + registry already verified; the `.lean` file is byte-identical to `origin/main`. Docs-only sync to stop re-claim churn on a completed problem.
- Companion open questions (oq-01/02/03) hold the remaining sorries/axioms under their own slugs and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)