### PR TITLE
research(birthday-oq-03-oq-01-oq-02-oq-02): sync committed pool record to COMPLETED

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
+    "assumptions": "1 axiom: p_no_triple_tendsto (Lemma C: P(no triple) → exp(-c³/6), the deep Chen-Stein / factorial-moments Poisson limit not in Mathlib 4.26). Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are proved theorems, and poisson_approx_birthday3 is now a derived theorem (was previously the axiom name).",
     "dateAdded": "2026-04-04",
     "lineCount": 2263,
     "theoremCount": 59,

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "birthday-problem-oq-03-oq-01-oq-02-oq-02",
   "title": "Second-order correction for the k=3 birthday threshold",
-  "phase": "ORIENT",
-  "status": "surveyed",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,15 +16,15 @@
     "open": "A fully formal Lean proof of the second-order term; gated on Docker and an elementary binomial-tail asymptotics formalization (not yet built)."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "COMPLETED",
     "since": "2026-06-14",
     "iteration": 4,
-    "lastUpdate": "2026-06-15",
-    "focus": "S9 derived the closed form g1 = (5/24)c0 ln2 = (5/144)c0^4 via completed symbolic saddle-point de-Poissonization (S8 punted on it); confirmed independently to ~19 digits. g_inf=-(3/2)ln2 reconfirmed. c~1.03 still open.",
+    "lastUpdate": "2026-06-16",
+    "focus": "Analytic track CLOSED-FORM COMPLETE through d^{-1} (S10/#24806: c = c0^2(3/4 - 61 ln2/120) = 1.0283769..., bonus g3 d^{-1} coeff). Lean track: M1 (leading order) and the M2 asymptotic scaffold are DONE and Docker-GREEN in proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean (0 sorry, 1 axiom, registered Proofs.lean:289). Lemmas A (lambda_tendsto) and B (exp_lambda_tendsto) proved; poisson_approx_birthday3 derived. Sole residue = the deep p_no_triple_tendsto axiom (no-triple Poisson limit).",
     "blockers": [
-      "Docker down (no lake build); Aristotle MCP 404; Lean formalization of E[W] tail expansion deferred."
+      "p_no_triple_tendsto axiom is the genuine Chen-Stein / method-of-factorial-moments Poisson limit, NOT in Mathlib 4.26 (needs new probability infrastructure); not single-session-tractable. Aristotle skips axioms (and was 404)."
     ],
-    "nextAction": "Extract the d^{-2/3} gap coefficient c~1.03 in closed form (extend the saddle/E[W] series ~2 orders). When Docker is up, formalize M1 (leading order) + M2 (E[W] tail expansion to the c0/4 term).",
+    "nextAction": "COMPLETE to the extent achievable without building Chen-Stein/factorial-moments infra. Gallery entry is correctly axiomatized (1 deep axiom). Discharging p_no_triple_tendsto is a separate multi-session infrastructure effort; do NOT re-claim expecting a quick M1/M2.",
     "attemptCounts": 4
   },
   "knowledge": {
@@ -80,5 +80,5 @@
   "significance": 6,
   "tractability": 5,
   "started": "2026-06-14T00:00:00.000Z",
-  "lastUpdate": "2026-06-15T00:00:00.000Z"
+  "lastUpdate": "2026-06-16T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary
- Flips the committed problem record for `birthday-problem-oq-03-oq-01-oq-02-oq-02` from stale `surveyed`/`ORIENT` to `completed`/`COMPLETED`, matching the already-merged `state.md` sync (#24937) and the green/registered `axiomatized` gallery entry.
- The gitignored shared pool was re-handing this slug each cycle because the committed record (the rebuild source) was frozen with a stale `nextAction` ("formalize M1/M2", "c~1.03 still open"). Both are done: analytic track closed-form complete through `d^{-1}` (S10/#24806); Lean M1 + M2 scaffold DONE, Docker-GREEN, registered (`proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean`, 0 sorry, 1 axiom).
- Corrects the gallery meta `assumptions` field: it named the now-derived theorem `poisson_approx_birthday3` instead of the actual axiom `p_no_triple_tendsto`.

The sole residue is the deep `p_no_triple_tendsto` axiom (Chen-Stein / method-of-factorial-moments Poisson limit, not in Mathlib 4.26) — a separate multi-session infrastructure effort, not single-session-tractable.

## Status
**Outcome**: completed (data/state sync — no Lean changes)
**Next Steps**: Discharging `p_no_triple_tendsto` requires building Chen-Stein/factorial-moments infrastructure in Mathlib; do not re-claim expecting a quick M1/M2.

🤖 Generated by researcher-1