### PR TITLE
research(qra-oq-03): verify Milestone-1 headline legendreSym = sign(mulLeft)

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -34,13 +34,22 @@ raised to `(p−1)/2` equals `−1` in the field. Built green via
 0 errors / 0 sorries / 0 axioms (linter style-nags only). This is the genuinely-new Euler-side
 ingredient the headline needs; it was authored blind under blackout (S15) and is now verified.
 
-**What this file does NOT yet contain** (the OQ is NOT resolved): the headline
-Zolotarev identity `legendreSym p a = sign (mulLeft a)` still needs (i) the Euler's-criterion
-tie `legendreSym p a = (-1)^k` (which combines this crux with `legendreSym.eq_pow`) and (ii) the
-field-`mulLeft₀`/units-`mulLeft` sign bridge (both prose in knowledge.md, S2 numerically verified).
-Milestone 2 (reciprocity from the grid-transpose permutation sign) is also not yet in Lean. This
-file verifies the genuinely-new *producer* lemma, the Zolotarev sign computation, and now the
-primitive-root half-power crux — the reusable core Mathlib lacks.
+**S17 (2026-06-16, researcher-4, Docker recovered; Aristotle still 404).** Assembled the
+**headline** Zolotarev identity `legendreSym_eq_sign_mulLeft`:
+
+  `legendreSym p (u.val) = sign (mulLeft u)`,    for `u : (ZMod p)ˣ`, `p` an odd prime,
+
+by combining the verified sign computation `sign_mulLeft_eq_neg_one_zpow` (RHS `= (-1)^k`),
+Euler's criterion `legendreSym.eq_pow`, and the crux `primitiveRoot_pow_half_eq_neg_one`
+(LHS `= (-1)^k`), then lifting the `±1` equality from `ZMod p` to `ℤ`. Stated on the units group
+`(ZMod p)ˣ` (S15 observation), which removes the field-`mulLeft₀`/units-`mulLeft` bridge entirely.
+Built green via `docker-build.sh` (uniquely-named build copy), 0 errors / 0 sorries / 0 axioms.
+
+**What this file does NOT yet contain** (the OQ is NOT resolved): Milestone 2 — full reciprocity
+`(p/q)(q/p) = (-1)^{(p-1)/2·(q-1)/2}` from the grid-transpose permutation sign — is not yet in
+Lean. This file now verifies the genuinely-new *producer* lemma, the Zolotarev sign computation,
+the primitive-root half-power crux, and the **full Milestone-1 headline** (Zolotarev's lemma) —
+the permutation-sign characterisation of the Legendre symbol that Mathlib lacks.
 
 ## What this targets
 
@@ -218,5 +227,74 @@ theorem primitiveRoot_pow_half_eq_neg_one {p : ℕ} [Fact p.Prime] (hp : 2 < p)
   rcases mul_self_eq_one_iff.mp hsq with h | h
   · exact absurd h hne1
   · exact h
+
+/-! ## The headline Zolotarev identity (units form)
+
+Assembles the three verified ingredients into Zolotarev's lemma on `(ZMod p)ˣ`:
+
+  `legendreSym p (u.val) = sign (mulLeft u)`,    for `u : (ZMod p)ˣ`, `p` an odd prime.
+
+Write `u = g ^ k` for a generator `g` (`k : ℕ`, finite group ⇒ `powers = zpowers`). Then
+- **RHS** `sign (mulLeft u) = (-1) ^ k`  — `sign_mulLeft_eq_neg_one_zpow` (the Zolotarev sign
+  computation), since `|(ZMod p)ˣ| = p − 1` is even.
+- **LHS** `legendreSym p u.val = (-1) ^ k` — Euler's criterion `legendreSym.eq_pow`
+  (`(legendreSym p a : ZMod p) = (a)^(p/2)`) plus the crux `primitiveRoot_pow_half_eq_neg_one`
+  (`(g : ZMod p)^((p−1)/2) = −1`), using `p/2 = (p−1)/2` for odd `p`.
+Both sides are `±1` in `ℤ`; the `ZMod p` equality lifts to `ℤ` because `1 ≠ −1` in `ZMod p`
+(as `p ≠ 2`). This is the headline of Milestone 1: the permutation-sign characterisation of the
+Legendre symbol that Mathlib lacks. -/
+theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p) (u : (ZMod p)ˣ) :
+    legendreSym p ((u : ZMod p).val : ℤ) = (Equiv.Perm.sign (Equiv.mulLeft u) : ℤ) := by
+  classical
+  -- a generator `g` of `(ZMod p)ˣ` and a NAT discrete log `u = g ^ k`
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
+  obtain ⟨k, hk⟩ : ∃ k : ℕ, g ^ k = u := by
+    have hmem : u ∈ Submonoid.powers g := mem_powers_iff_mem_zpowers.mpr (hg u)
+    obtain ⟨k, hk⟩ := hmem
+    exact ⟨k, hk⟩
+  -- `|(ZMod p)ˣ| = p − 1`, even and `≥ 2` for odd `p`
+  have hcard : Fintype.card (ZMod p)ˣ = p - 1 := ZMod.card_units p
+  have hge2 : 2 ≤ Fintype.card (ZMod p)ˣ := by rw [hcard]; omega
+  have hodd : Odd p := (Fact.out : p.Prime).odd_of_ne_two (by omega)
+  have heven : Even (Fintype.card (ZMod p)ˣ) := by
+    rw [hcard]; obtain ⟨t, ht⟩ := hodd; exact ⟨t, by omega⟩
+  -- RHS as an integer: `sign (mulLeft u) = (-1) ^ k`
+  have hRHS : (Equiv.Perm.sign (Equiv.mulLeft u) : ℤ) = (-1 : ℤ) ^ k := by
+    have h := sign_mulLeft_eq_neg_one_zpow hg hge2 heven (a := u) (k := (k : ℤ))
+      (by rw [zpow_natCast]; exact hk.symm)
+    rw [h, zpow_natCast]
+    simp [Units.val_pow_eq_pow_val]
+  -- LHS via Euler's criterion + the crux: `(legendreSym p u.val : ZMod p) = (-1 : ZMod p) ^ k`
+  have hhalf : p / 2 = (p - 1) / 2 := by obtain ⟨t, ht⟩ := hodd; omega
+  have hcrux : (g : ZMod p) ^ ((p - 1) / 2) = -1 := primitiveRoot_pow_half_eq_neg_one hp hg
+  have hval : (((u : ZMod p).val : ℤ) : ZMod p) = (u : ZMod p) := by
+    push_cast; simp [ZMod.natCast_val, ZMod.cast_id]
+  have hcast : (u : ZMod p) = (g : ZMod p) ^ k := by
+    rw [← hk]; exact Units.val_pow_eq_pow_val g k
+  have hLHS : (legendreSym p ((u : ZMod p).val : ℤ) : ZMod p) = (-1 : ZMod p) ^ k := by
+    rw [legendreSym.eq_pow, hval, hcast, hhalf, ← pow_mul, mul_comm, pow_mul, hcrux]
+  -- both sides are `±1` in `ℤ`; lift the `ZMod p` equality to `ℤ`
+  have ha0 : (((u : ZMod p).val : ℤ) : ZMod p) ≠ 0 := by rw [hval]; exact u.ne_zero
+  have hL1 : legendreSym p ((u : ZMod p).val : ℤ) = 1 ∨
+             legendreSym p ((u : ZMod p).val : ℤ) = -1 :=
+    legendreSym.eq_one_or_neg_one _ ha0
+  have hR1 : (-1 : ℤ) ^ k = 1 ∨ (-1 : ℤ) ^ k = -1 := by
+    rcases Nat.even_or_odd k with he | ho
+    · exact Or.inl he.neg_one_pow
+    · exact Or.inr ho.neg_one_pow
+  have hne : (1 : ZMod p) ≠ -1 := by
+    intro h
+    have h2 : ((2 : ℕ) : ZMod p) = 0 := by push_cast; linear_combination h
+    rw [ZMod.natCast_eq_zero_iff] at h2
+    have := Nat.le_of_dvd (by norm_num) h2
+    omega
+  have hcastEq : ((legendreSym p ((u : ZMod p).val : ℤ) : ℤ) : ZMod p)
+      = (((-1 : ℤ) ^ k : ℤ) : ZMod p) := by rw [hLHS]; push_cast; ring
+  rw [hRHS]
+  rcases hL1 with h1 | h1 <;> rcases hR1 with hr | hr
+  · rw [h1, hr]
+  · rw [h1, hr] at hcastEq; push_cast at hcastEq; exact absurd hcastEq hne
+  · rw [h1, hr] at hcastEq; push_cast at hcastEq; exact absurd hcastEq.symm hne
+  · rw [h1, hr]
 
 end QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean
@@ -1,6 +1,7 @@
 import Mathlib.NumberTheory.LegendreSymbol.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Tactic
 
 /-
@@ -26,12 +27,20 @@ the inline `G →* Perm G` monoid-hom + `map_zpow` wiring (replacing the nonexis
 even-power `(-1)^card = 1` collapse — all flagged "unverified" by S12/S13 — compile as
 written. Removed three linter-flagged unused `simp` arguments.
 
+**S16 (2026-06-15, researcher-2, Docker recovered; Aristotle still 404).** Added the
+machine-checked **crux** `primitiveRoot_pow_half_eq_neg_one`: a generator of `(ZMod p)ˣ`
+raised to `(p−1)/2` equals `−1` in the field. Built green via
+`docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03Crux` (a uniquely-named build copy),
+0 errors / 0 sorries / 0 axioms (linter style-nags only). This is the genuinely-new Euler-side
+ingredient the headline needs; it was authored blind under blackout (S15) and is now verified.
+
 **What this file does NOT yet contain** (the OQ is NOT resolved): the headline
 Zolotarev identity `legendreSym p a = sign (mulLeft a)` still needs (i) the Euler's-criterion
-tie `legendreSym p a = (-1)^k` and (ii) the field-`mulLeft₀`/units-`mulLeft` sign bridge
-(both prose in knowledge.md, S2 numerically verified). Milestone 2 (reciprocity from the
-grid-transpose permutation sign) is also not yet in Lean. This file verifies the genuinely-new
-*producer* lemma and the Zolotarev sign computation — the reusable core Mathlib lacks.
+tie `legendreSym p a = (-1)^k` (which combines this crux with `legendreSym.eq_pow`) and (ii) the
+field-`mulLeft₀`/units-`mulLeft` sign bridge (both prose in knowledge.md, S2 numerically verified).
+Milestone 2 (reciprocity from the grid-transpose permutation sign) is also not yet in Lean. This
+file verifies the genuinely-new *producer* lemma, the Zolotarev sign computation, and now the
+primitive-root half-power crux — the reusable core Mathlib lacks.
 
 ## What this targets
 
@@ -168,5 +177,46 @@ theorem sign_mulLeft_eq_neg_one_zpow {G : Type*} [Group G] [Fintype G] [Decidabl
         G →* Equiv.Perm G) g k
     rw [ha]; simpa using hz
   rw [hmono, map_zpow, sign_mulLeft_generator hg hG heven]
+
+/-! ## The crux: a primitive root raised to `(p-1)/2` equals `-1`
+
+This is the single remaining genuinely-new ingredient (S15) the headline Zolotarev identity
+needs beyond the verified sign computation `sign_mulLeft_eq_neg_one_zpow`. Stated in the field
+`ZMod p` (not the units group) so the order-2 dichotomy uses `mul_self_eq_one_iff` directly and
+`ZMod.pow_card_sub_one_eq_one` supplies `xᵖ⁻¹ = 1` — avoiding the units `Neg`-instance question
+flagged by S15.
+
+Let `x = (g : ZMod p)` for a generator `g` of `(ZMod p)ˣ`, and `m = (p-1)/2`. Then
+`(xᵐ)² = xᵖ⁻¹ = 1`, while `xᵐ ≠ 1` because `orderOf x = p − 1 > m`; the only square root of `1`
+in a field other than `1` is `−1`. -/
+theorem primitiveRoot_pow_half_eq_neg_one {p : ℕ} [Fact p.Prime] (hp : 2 < p)
+    {g : (ZMod p)ˣ} (hg : ∀ x : (ZMod p)ˣ, x ∈ Subgroup.zpowers g) :
+    (g : ZMod p) ^ ((p - 1) / 2) = -1 := by
+  set x : ZMod p := (g : ZMod p) with hx
+  have hxne : x ≠ 0 := g.ne_zero
+  -- `orderOf x = p − 1` (a generator of the units is a primitive root in the field)
+  have hord : orderOf x = p - 1 := by
+    rw [hx, orderOf_units, orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card,
+      ZMod.card_units p]
+  set m := (p - 1) / 2 with hm
+  have heven : 2 ∣ (p - 1) := by
+    have hodd : Odd p := (Fact.out : p.Prime).odd_of_ne_two (by omega)
+    obtain ⟨t, ht⟩ := hodd
+    exact ⟨t, by omega⟩
+  have hmpos : 0 < m := by rw [hm]; omega
+  have hmlt : m < p - 1 := by rw [hm]; omega
+  have h2m : 2 * m = p - 1 := by rw [hm]; omega
+  -- `(xᵐ)² = xᵖ⁻¹ = 1`
+  have hsq : x ^ m * x ^ m = 1 := by
+    rw [← pow_add, ← two_mul, h2m]
+    exact ZMod.pow_card_sub_one_eq_one hxne
+  -- `xᵐ ≠ 1` since `m < orderOf x`
+  have hne1 : x ^ m ≠ 1 := by
+    rw [← hord] at hmlt
+    exact pow_ne_one_of_lt_orderOf (by omega) hmlt
+  -- the only non-`1` square root of `1` in a field is `-1`
+  rcases mul_self_eq_one_iff.mp hsq with h | h
+  · exact absurd h hne1
+  · exact h
 
 end QuadraticReciprocityAlgorithmOQ03

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -613,3 +613,37 @@ conclusion.openQuestions state explicitly this is **Milestone 1 only** — the h
 are NOT yet in Lean, so the OQ is **not resolved**. Problem stays **in-progress** on the
 math; this session only surfaces the already-verified producer lemma in the gallery.
 No Lean changed. (Aristotle `prove` still 404, live-probed; the crux remains its target.)
+
+## Session 2026-06-16 (S17, researcher-4) — Milestone-1 HEADLINE verified (Docker green)
+
+**Mode:** CONTINUE → ACT. Aristotle still 404 (live-probed). Docker recovered (warm cache volume).
+Built on the crux from PR #24903 (`research/qra-oq03-crux-verified`).
+
+**Result.** Machine-verified the headline Zolotarev identity, the actual goal of Milestone 1:
+
+```
+theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p) (u : (ZMod p)ˣ) :
+    legendreSym p ((u : ZMod p).val : ℤ) = (Equiv.Perm.sign (Equiv.mulLeft u) : ℤ)
+```
+
+`legendreSym p (u.val) = sign (mulLeft u)` for `u : (ZMod p)ˣ`, `p` an odd prime — the
+permutation-sign characterisation of the Legendre symbol that Mathlib lacks. 0 sorry / 0 axiom,
+3058 build jobs green.
+
+**Proof shape (now confirmed, not prose):**
+1. Generator `g`, NAT discrete log `u = g^k`: `IsCyclic.exists_generator`, then
+   `mem_powers_iff_mem_zpowers.mpr (hg u) : u ∈ Submonoid.powers g`, destructured to `∃ k:ℕ, g^k=u`.
+2. RHS `= (-1)^k`: `sign_mulLeft_eq_neg_one_zpow` with `a := u`, `k := (k:ℤ)`
+   (`zpow_natCast` bridges `g^(k:ℤ) = g^k`); cast `ℤˣ → ℤ` via `Units.val_pow_eq_pow_val`.
+3. LHS `= (-1)^k` in `ZMod p`: `legendreSym.eq_pow` (Euler) gives `(legendreSym p a : ZMod p)
+   = (a:ZMod p)^(p/2)`; rewrite `(u.val:ZMod p)=(u:ZMod p)=(g:ZMod p)^k` and `p/2=(p-1)/2`
+   (odd `p`), regroup `((g:ZMod p)^((p-1)/2))^k`, apply the crux to get `(-1)^k`.
+4. Lift to `ℤ`: both `legendreSym p a` (`legendreSym.eq_one_or_neg_one _ ha0`) and `(-1)^k`
+   (`Even/Odd.neg_one_pow`) are `±1`; the `ZMod p` cast equality forces equality in `ℤ` since
+   `1 ≠ -1` in `ZMod p` (`ZMod.natCast_eq_zero_iff`, `2 ∤ p`).
+
+**Net:** Milestone 1 of the Zolotarev route is COMPLETE in Lean (producer lemma + sign computation
++ crux + headline, all 0-axiom). **Milestone 2 — full reciprocity** `(p/q)(q/p) =
+(-1)^{(p-1)/2·(q-1)/2}` from the grid-transpose permutation sign (`inv(σ) = C(p,2)·C(q,2)`,
+S6/S8 certified numerically) — remains the only open Lean work; a clean Aristotle target. Problem
+stays **in-progress**.

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
@@ -1,10 +1,56 @@
 # Research State: quadratic-reciprocity-algorithm-oq-03
 
 ## Current State
-**Phase**: ACT (build-pending) — M1 Zolotarev sign computation in Lean (generator + arbitrary element)
+**Phase**: ACT — M1 COMPLETE (headline `legendreSym = sign(mulLeft)` VERIFIED); M2 (full reciprocity) open
 **Path**: full
-**Since**: 2026-06-15 (S10 ACT — first Lean file for oq-03)
-**Iteration**: 13
+**Since**: 2026-06-16 (S17 — Milestone-1 headline Docker-verified green)
+**Iteration**: 17
+
+## Session 17 (2026-06-16, researcher-4) — Milestone-1 headline VERIFIED (Docker green)
+Aristotle still 404 (live-probed `n+0=n`); Docker recovered (warm `lean-mathlib-cache` volume,
+~4 containers, built fine). Assembled and machine-verified the **headline Zolotarev identity**
+`legendreSym_eq_sign_mulLeft` in `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean`:
+
+  `legendreSym p (u.val) = sign (mulLeft u)`,    for `u : (ZMod p)ˣ`, `p` an odd prime.
+
+Built green via `docker-build.sh Proofs.QRAOQ03HeadlineBuild` (uniquely-named build copy in MAIN,
+per the worktree-`.lake`-symlink workaround), 3058 jobs, 0 errors / 0 sorries / 0 axioms (only the
+two pre-existing `simpa` linter nags in the producer/sign lemmas). Proof: combine
+`sign_mulLeft_eq_neg_one_zpow` (RHS `= (-1)^k`) with Euler's criterion `legendreSym.eq_pow` and the
+crux `primitiveRoot_pow_half_eq_neg_one` (LHS `= (-1)^k`), then lift the `±1` equality from
+`ZMod p` to `ℤ` (using `1 ≠ -1` in `ZMod p` as `p ≠ 2`). Stated on `(ZMod p)ˣ` so the S15
+field/units bridge is unnecessary — eliminated entirely.
+
+Key resolved names (build-confirmed): nat discrete-log via `mem_powers_iff_mem_zpowers` +
+destructuring `Submonoid.powers` membership (NOT `Submonoid.mem_powers_iff.mp`); `hhalf : p/2 =
+(p-1)/2` needs `obtain ⟨t,ht⟩ := hodd; omega` (omega can't use `Odd p` directly);
+`legendreSym.eq_one_or_neg_one _ ha0` (2 args: p + nonzero proof); `ZMod.natCast_eq_zero_iff`
+(the `..._zmod_eq_zero_iff_dvd` form is deprecated); `Units.val_pow_eq_pow_val` for `↑(g^k)=(↑g)^k`.
+
+Branch `research/qra-oq03-headline` is based on `research/qra-oq03-crux-verified` (PR #24903), so
+this PR contains the crux commit + the headline commit and **supersedes #24903**. Problem stays
+**in-progress**: Milestone 2 (full reciprocity from the grid-transpose permutation sign,
+`inv(σ) = C(p,2)·C(q,2)`, S6/S8 certified on paper) is the remaining work — a major formalization
+and a clean Aristotle target once the backend returns.
+
+## Session 15 sync (2026-06-16, researcher-3) — state corrected to match repo reality
+Earlier session blocks (S10–S13) and the old "Next Action" below are STALE: they framed M1 as
+build-pending and proposed creating a NEW file `QuadraticReciprocityZolotarev.lean`. Repo reality:
+
+- **M1 is VERIFIED and REGISTERED on main.** File `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03.lean`
+  (NOT a `...Zolotarev.lean`) holds all three M1 lemmas — `isCycle_mulLeft_of_generator`,
+  `sign_mulLeft_generator`, `sign_mulLeft_eq_neg_one_zpow` — 0 sorry / 0 axiom, Docker-green
+  (S14, researcher-6), registered at `Proofs.lean:2771`. **Do NOT redo M1 or create a duplicate file.**
+- **S15 headline crux is written, build-pending, on branch `research/qra-oq03-crux` (no PR yet):**
+  `primitiveRoot_pow_half_eq_neg_one` — for a generator `g` of `(ZMod p)ˣ`, `(g:ZMod p)^((p-1)/2) = -1`
+  (Euler tie crux, stated in the field to dodge the units `Neg`-instance question). Never compiled
+  (dual blackout: Aristotle 404 live-probed, Docker 7-container saturated + circular `proofs/.lake`
+  self-symlink → 0 oleans). Build-verify it the moment Docker is at ≤2 containers and `.lake` is sane.
+- **Remaining for the headline `legendreSym p a = sign (mulLeft a)`:** the field/units sign bridge
+  to lift the crux + `sign_mulLeft_eq_neg_one_zpow` onto `(ZMod p)ˣ`, assembled with Euler's
+  criterion. Finicky NT — submit to Aristotle when non-404 rather than blind-writing.
+
+No machine verification this session (dual blackout reconfirmed live). Doc-only sync.
 
 ## Session 13 (2026-06-15, researcher-5) — added arbitrary-element Zolotarev sign lemma (build-pending)
 Dual blackout reconfirmed live (`docker info` times out; Aristotle `prove` returns `Resource not
@@ -73,24 +119,23 @@ the grid-transpose sign lemma (B, `sign(σ)=(-1)^((p-1)/2·(q-1)/2)`, S6-certifi
 M1; the exact statement is now pinned and numerically de-risked (was "gated/assess after M1").
 
 ## Attempt Count
-- Total attempts: 0 (no Lean built — Docker down, no materialized Mathlib)
-- Current approach attempts: 0
+- Total attempts: 1 (M1 Docker-built green S14; crux S15 still build-pending)
+- Current approach attempts: 1
 - Approaches tried: 1 surveyed (Zolotarev direct), 1 deprioritized (algorithm-confluence)
 
 ## Blockers
-- Docker build environment down (`docker info` times out); cannot compile/verify Lean this session.
-- No new foundational Mathlib gap for Milestone 1 — it is buildable once the environment returns.
+- Dual blackout (reconfirmed live S15): Aristotle `prove` 404; Docker 7-container saturated on an
+  8 GB VM + circular `proofs/.lake` self-symlink (0 oleans) — no safe/successful build possible.
+- Headline assembly (Euler tie + field/units sign bridge) is finicky NT; Aristotle target, not blind-write.
 
 ## Next Action
-**ACT Milestone 1 (when Docker returns):** new file `proofs/Proofs/QuadraticReciprocityZolotarev.lean`
-proving `legendreSym p (a.val : ℤ) = (Equiv.Perm.sign (Equiv.mulLeft₀ a ha) : ℤ)` for odd prime `p`,
-`a : ZMod p`, `a ≠ 0`. Steps: (1) `π_g` is a single `(p−1)`-cycle on the units ⇒ `sign = −1`;
-(2) `a = g^k`, `sign (π_a) = (−1)^k` via `map_pow`; (3) Euler's criterion gives `legendreSym p a =
-(−1)^k`. **All bearers confirmed @ v4.26.0 (rev `2df2f01`) — no name-discovery left** (see S4 in
-knowledge.md for the file:line table): `Equiv.mulLeft₀` (Algebra/GroupWithZero/Units/Equiv.lean:34,
-returns `Perm G₀`), `IsCyclic Rˣ` instance (RingTheory/IntegralDomain.lean:137) + `IsCyclic.exists_generator`,
-`Equiv.Perm.IsCycle.sign` (GroupTheory/Perm/Cycle/Basic.lean:434), `legendreSym.eq_pow` /
-`euler_criterion` (NumberTheory/LegendreSymbol/Basic.lean:114/:62). Then create the gallery entry
-`src/data/proofs/quadratic-reciprocity-zolotarev/`.
+**Build-verify the S15 crux** on branch `research/qra-oq03-crux`:
+`./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03` the moment Docker is at
+≤2 containers AND `proofs/.lake` is a sane (non-circular) directory. If green, register/keep and the
+crux `primitiveRoot_pow_half_eq_neg_one` is discharged. Then assemble the headline
+`legendreSym p a = sign (mulLeft a)`: lift crux + `sign_mulLeft_eq_neg_one_zpow` from the field
+`ZMod p` onto `(ZMod p)ˣ` (field/units sign bridge) and tie via Euler's criterion
+`legendreSym.eq_pow`/`euler_criterion` (NumberTheory/LegendreSymbol/Basic.lean:114/:62) — submit the
+bridge to Aristotle when non-404 rather than hand-writing. M1 itself is DONE; do not recreate it.
 
-See knowledge.md for the full survey, Mathlib inventory, and the honesty flag on Milestone 2.
+See knowledge.md (S4 bearer table, S14/S15 notes) for the full survey and the honesty flag on Milestone 2.


### PR DESCRIPTION
## Summary

Machine-verifies the **headline Zolotarev identity** — the actual goal of Milestone 1 of the permutation-sign route to quadratic reciprocity:

```lean
theorem legendreSym_eq_sign_mulLeft {p : ℕ} [Fact p.Prime] (hp : 2 < p) (u : (ZMod p)ˣ) :
    legendreSym p ((u : ZMod p).val : ℤ) = (Equiv.Perm.sign (Equiv.mulLeft u) : ℤ)
```

`legendreSym p (u.val) = sign (mulLeft u)` for `u : (ZMod p)ˣ`, `p` an odd prime — the permutation-sign characterisation of the Legendre symbol that **Mathlib lacks**.

Built green: `docker-build.sh Proofs.QRAOQ03HeadlineBuild` (uniquely-named build copy), 3058 jobs, **0 errors / 0 sorries / 0 axioms** (only the two pre-existing `simpa` linter nags in the producer/sign lemmas).

## Proof

Combines the three verified ingredients, stated on `(ZMod p)ˣ` so the S15 field/units bridge is eliminated entirely:
- **RHS** `sign (mulLeft u) = (-1)^k` — `sign_mulLeft_eq_neg_one_zpow` (Zolotarev sign computation).
- **LHS** `legendreSym p u.val = (-1)^k` — Euler's criterion `legendreSym.eq_pow` + the crux `primitiveRoot_pow_half_eq_neg_one` (`(g:ZMod p)^((p-1)/2) = -1`), using `p/2 = (p-1)/2` for odd `p`.
- Both sides are `±1` in `ℤ`; the `ZMod p` equality lifts to `ℤ` because `1 ≠ -1` in `ZMod p`.

## Relationship to #24903

This branch is based on `research/qra-oq03-crux-verified` (PR #24903), so it contains the crux commit **plus** the headline commit and **supersedes #24903**. Merging either one is safe; if #24903 merges first, this rebases to just the headline.

## Scope

Milestone 1 is now complete in Lean. **The OQ is NOT resolved** — Milestone 2 (full reciprocity from the grid-transpose permutation sign) remains open and is a clean Aristotle target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)