### PR TITLE
Enrich Square of the Quadratic Gauss Sum (quadratic-gauss-sum-square)

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/annotations.json
@@ -64,5 +64,51 @@
       "primitive additive character",
       "finite field cardinality"
     ]
+  },
+  {
+    "id": "qgss-ann-codomain",
+    "proofId": "quadratic-gauss-sum-square",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "context",
+    "title": "The Codomain-Matching Obstruction",
+    "content": "The opening docstring isolates the one real friction point of the formalization, flagged explicitly as a TYPING NOTE. Mathematically the Gauss sum $g = \\sum_n \\chi(n)\\,\\psi(n)$ pairs a multiplicative character $\\chi$ with an additive character $\\psi$, but Lean's `gaussSum χ ψ` is only well-typed when both characters land in the *same* ring `F'`: the product $\\chi(n)\\cdot\\psi(n)$ must make sense. Mathlib's `quadraticChar (ZMod p)` is ℤ-valued while our $\\psi$ is ℂ-valued, so the summand pairs ℤ with ℂ and does not typecheck until the character is pushed into ℂ. The whole file is organised around removing this single obstruction and then quoting `gaussSum_sq`. The blanket `import Mathlib` is the gallery convention (not the stricter Mathlib-bound import discipline), giving access to `gaussSum`, `quadraticChar`, and the χ₄ machinery in one line.",
+    "mathContext": "$g = \\displaystyle\\sum_{n \\in \\mathbb{Z}/p\\mathbb{Z}} \\chi(n)\\,\\psi(n)$ requires $\\chi : \\mathbb{Z}/p\\mathbb{Z} \\to F'$ and $\\psi : \\mathbb{Z}/p\\mathbb{Z} \\to F'$ with a common codomain $F'$ so that each product $\\chi(n)\\psi(n) \\in F'$ is defined; here $F' = \\mathbb{C}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gauss sum",
+      "codomain matching",
+      "additive vs multiplicative characters",
+      "type-driven formalization"
+    ],
+    "prerequisites": [
+      "characters of finite abelian groups",
+      "Lean 4 type checking"
+    ]
+  },
+  {
+    "id": "qgss-ann-nontrivial",
+    "proofId": "quadratic-gauss-sum-square",
+    "range": {
+      "startLine": 41,
+      "endLine": 47
+    },
+    "type": "technique",
+    "title": "Nontriviality via Injectivity of ℤ → ℂ",
+    "content": "`gaussSum_sq` requires the character to be *nontrivial* — otherwise the sum degenerates and the $g^2 = \\chi(-1)\\,\\#F$ identity fails. The lemma `chiC_ne_one` supplies this. The key observation is that transporting a character along an injective ring hom cannot collapse it to the trivial character, captured by `MulChar.ringHomComp_ne_one_iff` applied to `(Int.castRingHom ℂ).injective_int` (injectivity is automatic because ℂ has characteristic zero). Nontriviality of the *original* ℤ-valued quadratic character then reduces to `quadraticChar_ne_one`, which holds precisely when the residue field has odd characteristic: `ringChar (ZMod p) = p ≠ 2`, rewritten via `ZMod.ringChar_zmod_n`. This is exactly where the odd-prime hypothesis `hp : p ≠ 2` is consumed.",
+    "mathContext": "$\\chi_{\\mathbb{C}} \\neq 1 \\iff \\left(\\tfrac{\\cdot}{p}\\right) \\neq 1$, valid because $\\iota : \\mathbb{Z} \\hookrightarrow \\mathbb{C}$ is injective; and $\\left(\\tfrac{\\cdot}{p}\\right) \\neq 1$ because $\\operatorname{ringChar}(\\mathbb{Z}/p\\mathbb{Z}) = p \\neq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nontrivial character",
+      "injective ring homomorphism",
+      "ring characteristic",
+      "CharZero"
+    ],
+    "prerequisites": [
+      "MulChar.ringHomComp_ne_one_iff",
+      "ringChar of ZMod p"
+    ]
   }
 ]

--- a/src/data/proofs/quadratic-gauss-sum-square/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square/meta.json
@@ -32,7 +32,8 @@
       "The typing obstruction is the crux of the formalization: `quadraticChar (ZMod p)` is ℤ-valued, but `gaussSum χ ψ` requires the multiplicative character χ and additive character ψ to share a codomain. The fix is to transport χ along the ring hom ℤ → ℂ via `MulChar.ringHomComp (Int.castRingHom ℂ)`, giving the ℂ-valued `chiC p`.",
       "Nontriviality of the transported character reduces, via `MulChar.ringHomComp_ne_one_iff`, to injectivity of ℤ → ℂ (automatic since ℂ is `CharZero`) together with nontriviality of the original quadratic character, which holds because `ringChar (ZMod p) = p ≠ 2` for an odd prime.",
       "Evaluating χ(-1) requires bridging two index conventions: `quadraticChar_neg_one` gives $(-1)^{p/2}$ while the reciprocity supplement is stated as $(-1)^{(p-1)/2}$. For odd $p = 2k+1$ these agree ($p/2 = k = (p-1)/2$ by `omega`), so the two forms are reconciled before transport to ℂ.",
-      "The entire mathematical content of $g^2 = \\chi(-1)\\,\\#F$ lives in Mathlib's `gaussSum_sq`; this entry is a faithful specialisation that supplies exactly the three hypotheses that lemma demands, with no axioms and no sorries."
+      "The entire mathematical content of $g^2 = \\chi(-1)\\,\\#F$ lives in Mathlib's `gaussSum_sq`; this entry is a faithful specialisation that supplies exactly the three hypotheses that lemma demands, with no axioms and no sorries.",
+      "The $g^2$ identity is the *easy half* of the Gauss-sum theory: it is purely algebraic, holding over any finite field for any nontrivial quadratic character, and never needs to know which sign √p carries. Determining the sign of $g$ itself (the *hard half*) requires analytic input — the ordering of the complex plane and Gauss's delicate evaluation — and is deliberately out of scope here, which is why the formalization stays short and axiom-free."
     ]
   },
   "conclusion": {
@@ -65,6 +66,13 @@
     "sorries": 0
   },
   "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "Setup: Imports and the Typing Note",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "The module docstring states the target g² = (-1)^((p-1)/2)·p and flags the sole formalization obstruction in a TYPING NOTE: `gaussSum χ ψ` needs χ and ψ in a common codomain, but `quadraticChar (ZMod p)` is ℤ-valued while ψ is ℂ-valued. The fix is to transport the character along ℤ → ℂ. A blanket `import Mathlib` (gallery convention) brings in `gaussSum`, `quadraticChar`, and the χ₄ machinery; the section opens the namespace and fixes `variable {p : ℕ} [Fact p.Prime]`."
+    },
     {
       "id": "transported-character",
       "title": "The ℂ-Valued Quadratic Character",


### PR DESCRIPTION
Enrichment pass for quadratic-gauss-sum-square. Quality 83 -> 100. Added 2 annotations (now 5, full coverage), fixed invalid significance enum critical->key, added a 5th keyInsight and 5th section. pnpm build passes; recomputed quality=100; status/axiom fields unchanged (verified/mathlib, 0 axioms).