### PR TITLE
Enrich Newton-Girard Recurrence for Arbitrary k: split header section (q98→100)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-04/meta.json
@@ -74,11 +74,18 @@
   },
   "sections": [
     {
-      "id": "header-defs",
-      "title": "Module Header, Imports, and Concrete Definitions",
+      "id": "docstring-strategy",
+      "title": "Module Docstring: Statement, Two-Route Strategy, and Verification Status",
       "startLine": 1,
+      "endLine": 50,
+      "summary": "States the target Finset/CommRing Newton-Girard recurrence Σ_{j<k} (-1)^j eⱼ p_{k-j} + (-1)^k k eₖ = 0 with worked k=1,2 sanity checks on s={a,b}. Lays out the two viable reductions — Route A (apply the algebra map aeval to Mathlib's universal MvPolynomial.mul_esymm_eq_sum) versus Route B (self-contained ~150–250-line induction on s via the update rule eₖ(s∪{a}) = eₖ(s) + a·e_{k-1}(s)) — records that Route A was executed and machine-checked under Lean v4.26.0 (0 sorries, 0 axioms), and enumerates every Mathlib lemma the transport depends on."
+    },
+    {
+      "id": "imports-defs",
+      "title": "Imports, Namespace, and Concrete Definitions",
+      "startLine": 52,
       "endLine": 65,
-      "summary": "Documents Route A (aeval-transport) and the confirmed Mathlib v4.26.0 API. Imports Mathlib, opens Finset and BigOperators, declares variables {ι R : Type*} [CommRing R]. Defines the concrete power sum psum s f k = Σ_{i∈s} (f i)^k and elementary symmetric function esymm s f k = Σ_{T ∈ s.powersetCard k} ∏_{i∈T} f i."
+      "summary": "Imports Mathlib, opens Finset and BigOperators, opens namespace AmgmNewtonGirard, and declares variables {ι R : Type*} [CommRing R]. Defines the concrete power sum psum s f k = Σ_{i∈s} (f i)^k and the concrete elementary symmetric function esymm s f k = Σ_{T ∈ s.powersetCard k} ∏_{i∈T} f i — the explicit Finset-indexed objects onto which the universal MvPolynomial identity is transported."
     },
     {
       "id": "bridges",


### PR DESCRIPTION
## Enrichment pass: amgm-inequality-oq-02-oq-01-oq-04

Already richly enriched (q98). The sole structural gap was the `sections` bucket (4 sections → 8/10). This pass splits the oversized `header-defs` section (lines 1-65) into two genuine, Lean-aligned units:

- **docstring-strategy** (1-50): the module docstring — recurrence statement, k=1,2 sanity checks, Route A (aeval-transport) vs Route B (induction) strategy, and the verified-status / Mathlib-API enumeration.
- **imports-defs** (52-65): imports, namespace, variable declaration, and the two concrete definitions `psum` / `esymm`.

Sections now total 5, covering the full 127-line file with no invented content — the existing summary was split along the natural docstring/definitions boundary.

Quality: 98 → 100 (sections 8 → 10). `pnpm build` passes; JSON validated.