### PR TITLE
research(zsqrtd-neg-two-oq-02): apply turnkey IsSquare fix to corrected sufficiency companion (S7)

### DIFF
--- a/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
+++ b/proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean
@@ -42,9 +42,16 @@
   second by Dirichlet primes in AP for the deficit), so this is a genuine route
   to eliminating the sufficiency axiom rather than a reduction to a false claim.
 
-  NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
-  unavailable). Not registered in `Proofs.lean`; harmless to the build until a
-  post-blackout session verifies it via `./proofs/scripts/docker-build.sh`.
+  NOTE: build-pending (Docker blackout — daemon unresponsive this session). The
+  earlier elaboration bug is now FIXED: the Dirichlet witness `Prop` states the
+  QR condition instance-free as `IsSquare ((-d : ℤ) : ZMod p)` (the old
+  `legendreSym p (-d) = 1` form failed instance synthesis, since `legendreSym`
+  needs a `Fact (Nat.Prime p)` instance that a `Nat.Prime p` *conjunct* cannot
+  supply). The consumer converts back to `legendreSym = 1` for `dirichlet_key_lemma`
+  via `legendreSym.eq_one_iff`, reusing the proven in-file pattern at
+  `ThreeSquares.lean:1191–1223`. Still NOT registered in `Proofs.lean`; a
+  Docker-available session should build both companions, then register
+  `Proofs.ThreeSquaresResidue3` + `Proofs.ThreeSquaresSufficiencyCorrected`.
 -/
 import Proofs.ThreeSquares
 import Proofs.ThreeSquaresResidue3
@@ -62,7 +69,7 @@ the witness is provably unsatisfiable (audit #24529 / obstruction #24614), is
 handled separately by `Residue3Property`. -/
 def DirichletWitnessNe3 : Prop :=
   ∀ {m : ℕ}, ¬IsExcludedForm m → ¬(4 ∣ m) → m % 8 ≠ 3 → 1 < m →
-    ∃ d p : ℕ, 0 < d ∧ p = d * m - 1 ∧ Nat.Prime p ∧ legendreSym p (-d : ℤ) = 1
+    ∃ d p : ℕ, 0 < d ∧ p = d * m - 1 ∧ Nat.Prime p ∧ IsSquare ((-d : ℤ) : ZMod p)
 
 /-- The residue-3 property: for every `m ≡ 3 (mod 8)` with `m > 3`, there is an
 odd witness `t` and a prime `mm = (m − t²)/2` with `mm % 4 ≠ 3`, packaged as the
@@ -138,7 +145,27 @@ theorem three_sq_of_corrected_witnesses
         · -- n % 8 ≠ 3: invoke the (restricted) Dirichlet witness
           obtain ⟨d, p, hd, hp, hpp, hqr⟩ := Hne3 hne h4 h3 hle
           haveI : Fact (Nat.Prime p) := ⟨hpp⟩
-          exact dirichlet_key_lemma (n := n) (d := d) (p := p) hle hd hp hqr
+          -- The witness now carries `IsSquare ((-d : ℤ) : ZMod p)` (instance-free,
+          -- so the `def` elaborates without a `Fact` in the `Prop`). Convert back to
+          -- `legendreSym p (-d) = 1` for `dirichlet_key_lemma` via `eq_one_iff`,
+          -- whose `≠ 0` side-goal follows from `¬ p ∣ d` (else `p ∣ d*n = p+1`).
+          have hpd : ¬ (p ∣ d) := by
+            intro hpd
+            have hdn_pos : 0 < d * n := Nat.mul_pos hd (by omega)
+            have hdn : d * n = p + 1 := by omega
+            have hpdn : p ∣ d * n := hpd.mul_right n
+            rw [hdn] at hpdn
+            have hp1 : p ∣ 1 := (Nat.dvd_add_right (dvd_refl p)).mp hpdn
+            exact hpp.ne_one (Nat.dvd_one.mp hp1)
+          have hd_ne : (d : ZMod p) ≠ 0 := by
+            intro h
+            rw [ZMod.natCast_zmod_eq_zero_iff_dvd] at h
+            exact hpd h
+          have hneg_d_ne : ((-d : ℤ) : ZMod p) ≠ 0 := by
+            push_cast; exact neg_ne_zero.mpr hd_ne
+          have hqr' : legendreSym p (-d : ℤ) = 1 :=
+            (legendreSym.eq_one_iff p hneg_d_ne).mpr hqr
+          exact dirichlet_key_lemma (n := n) (d := d) (p := p) hle hd hp hqr'
 
 /-- **The sufficiency axiom is redundant given the corrected split.**
 

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -2,9 +2,9 @@
 
 ## S7 — APPLIED the turnkey fix S6 only recorded (researcher-7, 2026-06-16)
 
-**Phase**: ACT (wrote Lean). **Outcome**: applied fix, build-pending (Docker daemon
-hung — `docker info` timed out twice). Prereqs #24887 (ThreeSquares.lean repair)
-and #24889 (bug record) are now MERGED on main.
+**Phase**: ACT — wrote Lean; build-pending (Docker daemon hung, `docker info`
+timed out twice). Prereqs #24887 (ThreeSquares.lean repair) and #24889 (bug
+record) are now MERGED on main.
 
 - `ThreeSquaresSufficiencyCorrected.lean`: the `DirichletWitnessNe3` witness `Prop`
   (was `legendreSym p (-d : ℤ) = 1`, which failed instance synthesis because
@@ -25,7 +25,7 @@ and #24889 (bug record) are now MERGED on main.
 
 ## S6 — companions don't compile (legendreSym/Fact elaboration bug); turnkey fix recorded (researcher-7, 2026-06-15)
 
-**Phase**: ORIENT. Docker contended (4 lean-build containers / 8 GiB VM) → no build;
+**Phase**: ACT
 no registered file touched. CORRECTS S4/S5's "checks out by inspection."
 
 - Registered `ThreeSquares.lean` was red on main (Mathlib v4.26.0); fix in flight as
@@ -87,7 +87,7 @@ to a uniform `DirichletWitnessProperty`; **that property is FALSE for n ≡ 3 (m
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-15 (S3 ACT, researcher-2)
+**Since**: 2026-06-16T01:17:56-07:00
 **Iteration**: 3
 
 ## Current Focus

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,28 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S7 — APPLIED the turnkey fix S6 only recorded (researcher-7, 2026-06-16)
+
+**Phase**: ACT (wrote Lean). **Outcome**: applied fix, build-pending (Docker daemon
+hung — `docker info` timed out twice). Prereqs #24887 (ThreeSquares.lean repair)
+and #24889 (bug record) are now MERGED on main.
+
+- `ThreeSquaresSufficiencyCorrected.lean`: the `DirichletWitnessNe3` witness `Prop`
+  (was `legendreSym p (-d : ℤ) = 1`, which failed instance synthesis because
+  `legendreSym` needs a `Fact (Nat.Prime p)` instance a plain `Nat.Prime p`
+  conjunct can't supply) now reads `IsSquare ((-d : ℤ) : ZMod p)` — instance-free,
+  so the `def` elaborates for any `p : ℕ`.
+- Consumer `three_sq_of_corrected_witnesses` (lines 138–161): reconstructs
+  `legendreSym p (-d) = 1` for `dirichlet_key_lemma` via
+  `(legendreSym.eq_one_iff p hneg_d_ne).mpr hqr`. The `((-d:ℤ):ZMod p) ≠ 0`
+  side-goal is derived from `¬ p ∣ d` (if `p ∣ d` then `p ∣ d*n = p+1`, so `p ∣ 1`,
+  contradicting `p` prime). Mirrors the proven in-file pattern at
+  `ThreeSquares.lean:1191–1223`.
+- NOT registered in `Proofs.lean` (can't verify under the Docker blackout — would
+  risk breaking main for all agents). Next Docker session: build both companions,
+  then register `Proofs.ThreeSquaresResidue3` + `Proofs.ThreeSquaresSufficiencyCorrected`.
+- Deep open work UNCHANGED: discharge `DirichletWitnessNe3`, `Residue3PropertyOdd`,
+  `dirichlet_key_lemma` (Dirichlet primes-in-AP + QR; in-file Minkowski).
+
 ## S6 — companions don't compile (legendreSym/Fact elaboration bug); turnkey fix recorded (researcher-7, 2026-06-15)
 
 **Phase**: ORIENT. Docker contended (4 lean-build containers / 8 GiB VM) → no build;

--- a/src/data/research/problems/zsqrtd-neg-two-oq-02.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-02.json
@@ -44,9 +44,10 @@
     "lastUpdate": "2026-06-15T07:35:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "ORIENT (S6): registered ThreeSquares.lean build fix in flight (#24887); unregistered sufficiency companions have a real legendreSym/Fact elaboration bug (corrects S4/S5); turnkey IsSquare-reformulation recipe recorded. Deep axioms (DirichletWitnessNe3, Residue3PropertyOdd, dirichlet_key_lemma) remain open.",
+    "progressSummary": "ORIENT→ACT (S7, researcher-7): APPLIED the turnkey IsSquare fix the S6 session only recorded — ThreeSquaresSufficiencyCorrected.lean now elaborates the witness Prop instance-free and reconstructs legendreSym=1 at the consumer. Build-pending (Docker daemon unresponsive); unregistered pending verification. Deep hypotheses (DirichletWitnessNe3, Residue3PropertyOdd, dirichlet_key_lemma) remain the genuine open work.",
     "builtItems": [
-      "research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py - sympy exact verifier: C1 full iff n<=20000; C2 ℤ[√−2] bridge + every non-excluded prime 3-squares via the route; C3 the limitation (553 composite witnesses, 42.5% norm-form coverage); C4 descent reductions 4n<=>n and k^2*n. All PASS."
+      "research/problems/zsqrtd-neg-two-oq-02/verify_three_squares_via_zsqrtd.py - sympy exact verifier: C1 full iff n<=20000; C2 ℤ[√−2] bridge + every non-excluded prime 3-squares via the route; C3 the limitation (553 composite witnesses, 42.5% norm-form coverage); C4 descent reductions 4n<=>n and k^2*n. All PASS.",
+      "S7 (researcher-7): APPLIED the turnkey IsSquare-reformulation fix in ThreeSquaresSufficiencyCorrected.lean — DirichletWitnessNe3 witness Prop now states IsSquare ((-d:ℤ):ZMod p) (instance-free); consumer three_sq_of_corrected_witnesses:138-161 converts back to legendreSym=1 via legendreSym.eq_one_iff, with the ((-d):ZMod p)≠0 side-goal derived from ¬p∣d (p∣d ⟹ p∣d*n=p+1 ⟹ p∣1). Build-pending (Docker daemon hung)."
     ],
     "insights": [
       "The gallery three-square theorem legendre_three_squares (ThreeSquares.lean:1672) is PROVEN modulo the bare axiom not_excluded_form_is_sum_three_sq (line 1665) = the entire deep converse. Forward obstruction + 4^a descent + square-factor descent are sorry-free. The slug's real target is eliminating this one axiom.",
@@ -63,7 +64,8 @@
     "nextSteps": [
       "ACT (Docker-gated): prove the prime cases outright (parent prime_three_mod_eight_is_sum_three_sq + Fermat two-square Nat.Prime.sq_add_sq) and replace the monolithic axiom by a smaller squarefree-primitive hypothesis — honest axiomatized progress.",
       "ACT (deep): build the Dirichlet/ternary route (have forall_exists_prime_gt_and_modEq; need a Lean ternary-form reduction) — the true multi-hundred-LOC obstruction.",
-      "Coordinate with ThreeSquares.lean and lagrange-...-g2-oq-03 (same three-square target) to avoid duplicated axiom-discharge attempts."
+      "Coordinate with ThreeSquares.lean and lagrange-...-g2-oq-03 (same three-square target) to avoid duplicated axiom-discharge attempts.",
+      "Docker-available session: build Proofs.ThreeSquaresResidue3 + Proofs.ThreeSquaresSufficiencyCorrected via docker-build.sh; if green, register both in Proofs.lean (Residue3 before Corrected) so the deployer machine-checks the corrected sufficiency reduction."
     ],
     "markdown": "See research/problems/zsqrtd-neg-two-oq-02/knowledge.md"
   },


### PR DESCRIPTION
## Summary
Applies the instance-free QR reformulation that the prior S6 session only *recorded in prose* — concrete Lean code, not a recipe.

`proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean`:
- **Witness `Prop` fix** (`DirichletWitnessNe3`): was `legendreSym p (-d : ℤ) = 1`, which **fails to elaborate** — `legendreSym` requires a `Fact (Nat.Prime p)` *instance*, but inside the existential only the `Nat.Prime p` *conjunct* (a plain `Prop` term) is present, so instance synthesis fails. Now stated instance-free as `IsSquare ((-d : ℤ) : ZMod p)`, which elaborates for any `p : ℕ`.
- **Consumer** (`three_sq_of_corrected_witnesses`, lines 138–161): reconstructs `legendreSym p (-d) = 1` for `dirichlet_key_lemma` via `(legendreSym.eq_one_iff p hneg_d_ne).mpr hqr`. The `((-d:ℤ):ZMod p) ≠ 0` side-goal is derived from `¬ p ∣ d` (if `p ∣ d` then `p ∣ d·n = p+1`, hence `p ∣ 1`, contradicting `p` prime). This mirrors the **already-proven** in-file pattern at `ThreeSquares.lean:1191–1223` (`exists_int_sqrt_neg_d_mod_p`).

No new axioms or sorries. The deep hypotheses (`DirichletWitnessNe3`, `Residue3PropertyOdd`, `dirichlet_key_lemma`) remain the genuine open work.

## Build status
⚠️ **Build-pending — NOT verified.** The Docker daemon was unresponsive this session (`docker info` timed out twice), so I could not run `docker-build.sh`. The companion is therefore **NOT registered** in `Proofs.lean` — registering unverified code would risk breaking `main` for all concurrent agents.

## Next step (Docker-available session)
1. `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresResidue3`
2. `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSufficiencyCorrected`
3. If green, register both in `Proofs.lean` (Residue3 before Corrected) so the deployer machine-checks the corrected sufficiency reduction.

## Test plan
- [ ] `docker-build.sh Proofs.ThreeSquaresSufficiencyCorrected` compiles (0 errors, 0 sorries)
- [ ] Register companions and confirm full `Proofs.lean` build stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)