### PR TITLE
audit(tracker): record central-limit-theorem-oq-01 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1902,9 +1902,9 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:20:48Z",
+      "lastAudited": "2026-06-16T08:43:21Z",
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: central-limit-theorem-oq-01 (re-audit, auditCount 3→4; last audited 2026-05-03)

Verified `Proofs/CentralLimitTheoremOQ01.lean` against `meta.json`:

- 0 sorries, 0 `axiom` declarations, 0 `True` stubs
- 12 theorems + 1 def — matches `theoremCount`/`definitionCount`
- 313 lines — matches `lineCount`
- Registered in `Proofs.lean`
- Badge `mathlib` correctly reflects reliance on Mathlib `rpow`/`exp` infrastructure (Tier B)
- Honest scoping: the Gnedenko–Kolmogorov domain-of-attraction theorem is explicitly disclaimed as *documented, not formalized*; the file proves the algebraic α-stable stability identity and special cases (Gaussian/Cauchy/Lévy), not the full generalized CLT
- Title is a question, not an overclaim

No integrity issues. Tracker timestamp/count updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)