### PR TITLE
research(lebesgue-measure-oq-05): sync stale tracker record to build-pending ACT

### DIFF
--- a/src/data/research/problems/lebesgue-measure-oq-05.json
+++ b/src/data/research/problems/lebesgue-measure-oq-05.json
@@ -1,44 +1,67 @@
 {
   "slug": "lebesgue-measure-oq-05",
   "title": "Lebesgue Measure: Radon-Nikodym Theorem for General σ-finite Measures",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "ACT",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in analysis: Lebesgue Measure: Radon-Nikodym Theorem for General σ-finite Measures.",
-    "whyMatters": []
+    "formal": "\\text{For } \\sigma\\text{-finite measures } \\mu \\ll \\nu \\text{ there is a measurable density } f = d\\mu/d\\nu \\text{ with } \\nu.\\text{withDensity}(f) = \\mu, \\text{ unique } \\nu\\text{-a.e.; and every } \\sigma\\text{-finite } \\mu \\text{ decomposes as } \\mu = \\mu.\\text{singularPart}(\\nu) + \\nu.\\text{withDensity}(d\\mu/d\\nu).",
+    "plain": "Assemble a self-contained σ-finite Radon–Nikodym package for the gallery: existence and measurability of the density, the integral characterization ∫⁻_s dμ/dν dν = μ s, total mass, ν-a.e. uniqueness, and the general Lebesgue decomposition.",
+    "whyMatters": [
+      "Radon–Nikodym for σ-finite measures is the foundational result behind conditional expectation, densities, and measure-theoretic probability.",
+      "The general Lebesgue decomposition (absolutely continuous + singular parts) is the structural theorem underlying differentiation of measures."
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "rnDeriv_measurable — dμ/dν is measurable",
+      "rnDeriv_isDensity — ν.withDensity (μ.rnDeriv ν) = μ for σ-finite μ ≪ ν",
+      "exists_density — existence of a measurable density",
+      "rnDeriv_setLIntegral — ∫⁻_s dμ/dν dν = μ s for measurable s",
+      "rnDeriv_lintegral — total-mass specialization",
+      "density_unique — ν-a.e. uniqueness (needs only SigmaFinite ν)",
+      "lebesgue_decomposition — μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν)"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "A clean, self-contained σ-finite Radon–Nikodym + Lebesgue-decomposition package, machine-checked under Docker."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T12:51:58.077Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-06-15T21:06:33.000Z",
+    "iteration": 2,
+    "focus": "Gallery entry LebesgueMeasureOQ05.lean drafted (7 theorems, 0 axioms, 0 sorries) and merged (#24720); awaiting kernel build to confirm and flip to verified.",
+    "blockers": [
+      "BUILD-PENDING: not kernel-checked locally. Build recompiles Mathlib from source and OOMs the 7.65GB Docker VM; Aristotle MCP returned 404. Relies on the deployer build-gate."
+    ],
+    "nextAction": "Run ./proofs/scripts/docker-build.sh Proofs.LebesgueMeasureOQ05 on a warm-cache Docker host; if green, flip meta status formalized→verified. Watch likely-fragile Mathlib v4.26.0 names: withDensity_apply arg order, Measure.rnDeriv_withDensity.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "FORMALIZATION DRAFTED & MERGED (#24720), BUILD-PENDING. 7-theorem σ-finite Radon–Nikodym + Lebesgue-decomposition package, 0 axioms / 0 sorries, registered Proofs.lean:2623, enriched to quality 100 (#24799). Not yet kernel-verified: audit #24801 downgraded the overclaimed verified/verified meta to formalized/mathlib. Remaining work is a Docker build (backend blackout).",
+    "builtItems": [
+      "LebesgueMeasureOQ05.lean — 92 lines, 7 theorems, 0 axioms, 0 sorries (rnDeriv_measurable, rnDeriv_isDensity, exists_density, rnDeriv_setLIntegral, rnDeriv_lintegral, density_unique, lebesgue_decomposition); registered in proofs/Proofs.lean:2623"
+    ],
+    "insights": [
+      "σ-finiteness of both measures is exactly what supplies Mathlib's HaveLebesgueDecomposition instance, so each result is a direct corollary — this is a Tier B formalization (one/two-line Mathlib API calls), badge mathlib not verified.",
+      "ν-a.e. uniqueness (density_unique) needs only SigmaFinite ν, derived from Measure.rnDeriv_withDensity.",
+      "The Lebesgue decomposition holds for any σ-finite μ with no absolute-continuity hypothesis."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Docker build Proofs.LebesgueMeasureOQ05 on a warm-cache host to kernel-verify; flip meta formalized→verified if green.",
+      "If v4.26.0 drift breaks it, check withDensity_apply argument order and Measure.rnDeriv_withDensity / Measure.withDensity_rnDeriv_eq names."
+    ]
   },
   "tags": [
     "analysis",
     "measure-theory",
     "radon-nikodym",
+    "lebesgue-decomposition",
     "formalization"
   ],
   "relatedProofs": [
@@ -54,111 +77,29 @@
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Measure.measurable_rnDeriv",
+      "Measure.withDensity_rnDeriv_eq",
+      "Measure.rnDeriv_withDensity",
+      "Measure.haveLebesgueDecomposition_add",
+      "withDensity_apply"
+    ]
   },
   "started": "2026-04-22T12:51:58.077Z",
-  "lastUpdate": "2026-04-22T12:51:58.077Z",
+  "lastUpdate": "2026-06-16T00:00:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/LebesgueMeasure.lean",
-      "filename": "LebesgueMeasure.lean",
-      "lineCount": 418,
-      "theoremCount": 20,
+      "path": "Proofs/LebesgueMeasureOQ05.lean",
+      "filename": "LebesgueMeasureOQ05.lean",
+      "lineCount": 92,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasure.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ01.lean",
-      "filename": "LebesgueMeasureOQ01.lean",
-      "lineCount": 198,
-      "theoremCount": 12,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ01.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ01OQ01.lean",
-      "filename": "LebesgueMeasureOQ01OQ01.lean",
-      "lineCount": 154,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02.lean",
-      "filename": "LebesgueMeasureOQ01OQ01OQ02.lean",
-      "lineCount": 241,
-      "theoremCount": 6,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ02.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ02.lean",
-      "filename": "LebesgueMeasureOQ02.lean",
-      "lineCount": 225,
-      "theoremCount": 10,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ02.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ03.lean",
-      "filename": "LebesgueMeasureOQ03.lean",
-      "lineCount": 137,
-      "theoremCount": 2,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ03.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ03OQ01.lean",
-      "filename": "LebesgueMeasureOQ03OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ03OQ01.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ06.lean",
-      "filename": "LebesgueMeasureOQ06.lean",
-      "lineCount": 1518,
-      "theoremCount": 8,
-      "axiomCount": 1,
-      "defCount": 5,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ06.lean"
-    },
-    {
-      "path": "Proofs/LebesgueMeasureOQ06Aristotle.lean",
-      "filename": "LebesgueMeasureOQ06Aristotle.lean",
-      "lineCount": 76,
-      "theoremCount": 6,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ06Aristotle.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ05.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Data-only sync of the research-tracker record for **lebesgue-measure-oq-05**. No Lean changes.

The committed record (`src/data/research/problems/lebesgue-measure-oq-05.json`) was grossly stale: `phase: NEW`, `status: active`, focus "Begin problem exploration", **empty knowledge**, and a `leanFiles` list that listed sibling files but **omitted the actual proof file**. Meanwhile the gallery entry has long existed:

- `proofs/Proofs/LebesgueMeasureOQ05.lean` — 7 theorems, **0 axioms, 0 sorries** (verified counts against origin/main)
- merged in #24720, enriched to quality 100 in #24799, registered at `proofs/Proofs.lean:2623`

## Changes

- `phase`: `NEW` → `ACT`; `status`: `active` → `in-progress`
- Filled `problemStatement`, `knownResults` (7 proven theorems), `knowledge` (builtItems / insights / nextSteps), `references.mathlib`
- `leanFiles` → the real `LebesgueMeasureOQ05.lean` (92 lines, 7 thm, 0/0)

## Honest scope

This **does not** claim verification. Audit #24801 downgraded the entry's overclaimed `verified/verified` meta to `formalized/mathlib`; PR #24720 states it is **build-pending — not kernel-checked locally**. The record now documents that blocker explicitly. The remaining work is a warm-cache Docker build (this cycle: Docker OOM + Aristotle 404). The local candidate pool was likewise moved off `available` (→ `in-progress`) to stop the picker re-handing a drafted-but-unverified entry.

## Test plan
- [x] `jq empty` validates the JSON
- [x] `phase: ACT` and `status: in-progress` are existing enum values in the tracker