### PR TITLE
research(erdos-565): sync stale tracker to COMPLETED (recycled)

### DIFF
--- a/research/problems/erdos-565-incomplete-01/state.md
+++ b/research/problems/erdos-565-incomplete-01/state.md
@@ -1,25 +1,31 @@
 # Research State: erdos-565-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-03T08:17:22-07:00
+**Since**: 2026-06-16
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Complete. The target sorry `induced_ramsey_ge_ordinary` (R*(G) ≥ R(G)) was
+discharged and the ill-typed `EdgeColoring` definition fixed, merged via #24707.
 
 ## Active Approach
-None yet.
+Done. `induced_ramsey_ge_ordinary` proved from the definitions via `Nat.sInf_le`
+/ `Nat.sInf_mem` monotonicity: the host graph `H` realizing R*(G) embeds in the
+complete graph (`H ≤ ⊤`), so every monochromatic induced copy in `H` is an
+ordinary monochromatic copy in `K_M`, giving R*(G) ≥ R(G).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None. File is 0 sorries. The 3 remaining axioms are legitimately deep results
+(Aragão et al. 2025 exponential upper bound, Deuber/EHP/Rödl existence,
+exponential lower bound) — gallery meta correctly marks `axiomatized`/`axiom`/3.
+Build-verification remains Docker-gated (local olean cache unavailable).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None. Research deliverable merged (#24707). Pool record marked completed.

--- a/src/data/research/problems/erdos-565-incomplete-01.json
+++ b/src/data/research/problems/erdos-565-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-565-incomplete-01",
   "title": "Erdős #565: Induced Ramsey Numbers — Complete `induced_ramsey_ge_ordinary`",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -16,24 +16,31 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-03T08:17:22-07:00",
+    "phase": "COMPLETED",
+    "since": "2026-06-16",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Complete: target sorry discharged and merged via #24707.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None. Research deliverable merged; pool record marked completed.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: induced_ramsey_ge_ordinary (R*(G) ≥ R(G)) discharged + ill-typed EdgeColoring fixed, merged #24707. File now 0 sorries, 3 legitimate deep axioms (Aragão 2025 upper bound, Deuber/EHP/Rödl existence, exponential lower bound). Gallery meta correct: axiomatized/axiom/3. Build-verification Docker-gated.",
+    "builtItems": [
+      "Proved induced_ramsey_ge_ordinary in Erdos565Problem.lean:231 via Nat.sInf_le/Nat.sInf_mem monotonicity (host graph H ≤ ⊤ = completeGraph, so induced mono copy ⟹ ordinary mono copy); merged #24707"
+    ],
+    "insights": [
+      "R*(G) ≥ R(G) reduces to sInf monotonicity: the realizing set for the induced property is contained in the realizing set for the ordinary property, since H ≤ completeGraph means restricting a K_M coloring to H's edgeSet preserves the monochromatic induced copy as an ordinary monochromatic copy.",
+      "EdgeColoring must index over G.edgeSet ({e : Sym2 V // e ∈ G.edgeSet} → EdgeColor) so c ⟨⟦(f u, f v)⟧, he⟩ typechecks via mem_edgeSet (Iff.rfl); the earlier Sym2.out-based predicate did not match the Adj-typed witnesses."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "None for this OQ. Build-verification of the merged proof remains Docker-gated (local olean cache circular-symlink unavailable)."
+    ],
     "markdown": "# Knowledge: erdos-565-incomplete-01\n\n## Overview\n\nCompletion problem for Erdős #565. One sorry in the Lean formalization.\n\n## Gallery Proof Summary\n\n- Gallery: `erdos-565`\n- Lean: `proofs/Proofs/Erdos565Problem.lean`\n- Sorries: 1, Axioms: multiple (open problem axiomatized)\n\n## What Needs Proving\n\nSee `problem.md` for the specific sorry and approach.\n\n## Known Results\n\n(To be populated during OBSERVE phase)\n\n## Key References\n\n- Gallery: `src/data/proofs/erdos-565/`\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary
- `erdos-565-incomplete-01` is **recycled-complete**: the target sorry `induced_ramsey_ge_ordinary` (R*(G) ≥ R(G)) was discharged and the ill-typed `EdgeColoring` definition fixed, merged via #24707.
- `Erdos565Problem.lean` is now **0 sorries** with **3 legitimately-deep axioms** (Aragão et al. 2025 exponential upper bound, Deuber/EHP/Rödl existence, exponential lower bound). Gallery `meta.json` correctly carries `axiomatized` / `axiom` / `axiomCount: 3`.
- The tracker artifacts (`state.md`, research knowledge JSON) were stale at phase `OBSERVE`; this PR syncs them to `COMPLETED` and records the proof approach (sInf monotonicity via `H ≤ ⊤ = completeGraph`).
- The gitignored candidate pool was also updated (direct edit, not in this PR) to mark `erdos-565-incomplete-01` and `erdos-458-oq-02` as `completed`, stopping the FRESH-mode picker from re-handing finished work.

Build-verification of the merged proof remains Docker-gated (local olean cache circular-symlink unavailable; daemon hung at session time). No Lean source changed in this PR — tracker sync only.

## Test plan
- [x] JSON validates (`jq empty`)
- [x] No Lean source modified (documentation/tracker only)