### PR TITLE
research(feuerbach-oq02-murakami): sync stale state.md — witness file 0 sorry/0 axiom, sole gate = green build

### DIFF
--- a/research/problems/feuerbachs-theorem-oq-02-murakami/state.md
+++ b/research/problems/feuerbachs-theorem-oq-02-murakami/state.md
@@ -34,8 +34,16 @@ Action #3 below) — not this theorem.
 The Grace theorem itself is DONE (Docker-GREEN, registered). The only remaining
 work is the SEPARATE parent-axiom de-axiomatization:
   - promote `feuerbach_3d_fails_general` (`FeuerbachsTheoremOQ02.lean:581`) to a
-    theorem once `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` (currently
-    1 sorry / 2 axioms) is built green — a distinct sub-problem, still open.
+    theorem once `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` is built
+    green and registered — a distinct sub-problem, still open. UPDATE
+    (researcher-1, 2026-06-16): that witness file is now **0 sorry / 0 axiom** as
+    authored — the last `witnessT1_fails` non-tangency sorry was discharged in
+    #24583 (S11) and `feuerbach_3d_fails_general_proved` (:294) is fully written.
+    It is **BUILD-PENDING** (sympy-certified via
+    `verify_feuerbach3d_fails_witness_exact.py`, never compiler-checked) and
+    intentionally **unregistered** so it cannot affect the gallery build. The sole
+    remaining gate is a green Docker build → then register it and replace the
+    parent axiom. (The "1 sorry / 2 axioms" descriptions below are stale.)
 
 ## Result (general trirectangular tetrahedron) -- VERIFIED
 
@@ -76,9 +84,13 @@ D-exsphere, and passes through the opposite face A,B,C.
    (currently the slug is research-only, no gallery dir).
 2. The parent slug's axiom `feuerbach_3d_fails_general`
    (`FeuerbachsTheoremOQ02.lean:581`) can be promoted to a theorem once
-   `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` (1 sorry / 2 axioms) is
-   built green — a SEPARATE de-axiomatization, still open. The witness file's own
-   sorry/axioms need discharge first.
+   `StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` is built green and
+   registered — a SEPARATE de-axiomatization, still open. As of 2026-06-16 that
+   witness file is **0 sorry / 0 axiom** as authored (sorry discharged in #24583)
+   but **BUILD-PENDING / unregistered**: the only remaining gate is a green Docker
+   build, then register it and replace the parent axiom with
+   `feuerbach_3d_fails_general_proved` (:294). Docker daemon was hung this session
+   (`docker run` exit 124) and Aristotle 404, so the build could not be run.
 
 Do NOT re-transcribe the Grace theorem (done + registered).
 


### PR DESCRIPTION
## Summary

Documentation-accuracy fix (no Lean changed). The witness file
`StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean` had its last
`witnessT1_fails` non-tangency sorry discharged in #24583 (S11), making it
**0 sorry / 0 axiom** as authored — `feuerbach_3d_fails_general_proved` (:294)
is fully written. But `research/problems/feuerbachs-theorem-oq-02-murakami/state.md`
still described it as "1 sorry / 2 axioms" needing discharge, which would send
the next agent hunting for a sorry that no longer exists.

Corrected `state.md` to reflect the true status:
- witness file is **0 sorry / 0 axiom** as authored (sorry discharged #24583)
- **BUILD-PENDING**: sympy-certified via `verify_feuerbach3d_fails_witness_exact.py`,
  never compiler-checked; intentionally **unregistered** so it cannot affect the
  gallery build
- the **sole remaining gate** to discharge the parent axiom
  `feuerbach_3d_fails_general` is a green Docker build + registration

## Session note

Backend-gated session (researcher-1, 2026-06-16): Docker daemon hung
(`docker run --rm alpine` exit 124) and Aristotle returns 404, so the witness
file's green build could not be run this session. The frozen 0-sorry green
files were not touched.

## Test plan
- [x] No Lean source changed; `state.md` only
- [x] Verified witness file has 0 real `axiom`/`sorry` declarations (matches in file are comment prose)