### PR TITLE
Research: lebesgue-measure-oq-05 — RN chain-rule discharged (Measure.rnDeriv_mul_rnDeriv)

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ05ChainRuleStatementOnly.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ05ChainRuleStatementOnly.lean
@@ -5,8 +5,9 @@ Harmonic `*StatementOnly.lean` Aristotle-submission file
 Follow-up for research problem `lebesgue-measure-oq-05` (σ-finite Radon–Nikodym
 package, formalized in `proofs/Proofs/LebesgueMeasureOQ05.lean`, merged #24720).
 The seven theorems of that file are complete (0 sorries, 0 axioms); this file
-queues the natural next result — the **Radon–Nikodym chain rule** — for
-automated proof search.
+adds the natural next result — the **Radon–Nikodym chain rule** — now discharged
+(0 sorries) by Mathlib's `Measure.rnDeriv_mul_rnDeriv`. Build-pending (Docker /
+Aristotle blackout); the proof term is a verbatim match against the Mathlib pin.
 
 Statement: For σ-finite measures `μ, ν, λ` on a measurable space with `μ ≪ ν`,
 the Radon–Nikodym derivatives compose multiplicatively, `λ`-almost everywhere:
@@ -28,10 +29,11 @@ Past Aristotle history for this problem: the base file was submitted only via
 the deployer build-gate; no per-theorem Aristotle submission exists yet. This
 file establishes the chain-rule baseline.
 
-Expected proof: Mathlib's `MeasureTheory.Measure.rnDeriv_mul_rnDeriv` states
-exactly this for a σ-finite triple under `μ ≪ ν`, so the proof is anticipated
-to be a one-line `exact Measure.rnDeriv_mul_rnDeriv h` (modulo the Mathlib
-4.26.0 argument shape). It is included below only to seed the MCTS prior.
+Proof: Mathlib's `MeasureTheory.Measure.rnDeriv_mul_rnDeriv` states exactly this
+for a σ-finite triple under `μ ≪ ν` — signature
+`(hμν : μ ≪ ν) : μ.rnDeriv ν * ν.rnDeriv κ =ᵐ[κ] μ.rnDeriv κ` at the v4.26.0 pin
+(Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean:383), which is the
+goal verbatim with `κ := lam`. The term is therefore `Measure.rnDeriv_mul_rnDeriv h`.
 
 Answer: `μ.rnDeriv ν * ν.rnDeriv lam =ᵐ[lam] μ.rnDeriv lam`.
 -/
@@ -71,15 +73,7 @@ states precisely this equality for a σ-finite triple under `μ ≪ ν`.
 -/
 theorem rnDeriv_chain [SigmaFinite μ] [SigmaFinite ν] [SigmaFinite lam]
     (h : μ ≪ ν) :
-    μ.rnDeriv ν * ν.rnDeriv lam =ᵐ[lam] μ.rnDeriv lam := by
-  sorry
-
--- Proof sketch to seed the MCTS prior (Aristotle may ignore this):
---   exact Measure.rnDeriv_mul_rnDeriv h
--- `Measure.rnDeriv_mul_rnDeriv` takes the absolute-continuity hypothesis
--- `μ ≪ ν` and the three `SigmaFinite` instances, returning the a.e. identity
--- `μ.rnDeriv ν * ν.rnDeriv κ =ᵐ[κ] μ.rnDeriv κ`. If the name/shape drifted in
--- Mathlib 4.26.0, the fallback is to rewrite via `withDensity_rnDeriv_eq` and
--- `rnDeriv_withDensity` and the multiplicativity of `withDensity`.
+    μ.rnDeriv ν * ν.rnDeriv lam =ᵐ[lam] μ.rnDeriv lam :=
+  Measure.rnDeriv_mul_rnDeriv h
 
 end LebesgueMeasureOQ05ChainRuleStatement

--- a/proofs/Proofs/LebesgueMeasureOQ05ChainRuleStatementOnly.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ05ChainRuleStatementOnly.lean
@@ -1,0 +1,85 @@
+/-
+Harmonic `*StatementOnly.lean` Aristotle-submission file
+(format from Loom #22468; docs at research/SORRY-CLASSIFICATION.md).
+
+Follow-up for research problem `lebesgue-measure-oq-05` (σ-finite Radon–Nikodym
+package, formalized in `proofs/Proofs/LebesgueMeasureOQ05.lean`, merged #24720).
+The seven theorems of that file are complete (0 sorries, 0 axioms); this file
+queues the natural next result — the **Radon–Nikodym chain rule** — for
+automated proof search.
+
+Statement: For σ-finite measures `μ, ν, λ` on a measurable space with `μ ≪ ν`,
+the Radon–Nikodym derivatives compose multiplicatively, `λ`-almost everywhere:
+
+    (dμ/dν) · (dν/dλ) = dμ/dλ        [=ᵐ[λ]]
+
+This is the measure-theoretic chain rule and the basis for change-of-variables
+between densities (and, via λ = a base measure, for the transitivity of
+probability-density transformations).
+
+Citations:
+- Radon, J. (1913). "Theorie und Anwendungen der absolut additiven
+  Mengenfunktionen." Sitzungsber. Akad. Wiss. Wien 122, 1295–1438.
+- Nikodym, O. (1930). "Sur une généralisation des intégrales de M. J. Radon."
+  Fund. Math. 15, 131–179.
+- Bogachev, V.I. (2007). Measure Theory, Vol. I, §3.2 (Radon–Nikodym).
+
+Past Aristotle history for this problem: the base file was submitted only via
+the deployer build-gate; no per-theorem Aristotle submission exists yet. This
+file establishes the chain-rule baseline.
+
+Expected proof: Mathlib's `MeasureTheory.Measure.rnDeriv_mul_rnDeriv` states
+exactly this for a σ-finite triple under `μ ≪ ν`, so the proof is anticipated
+to be a one-line `exact Measure.rnDeriv_mul_rnDeriv h` (modulo the Mathlib
+4.26.0 argument shape). It is included below only to seed the MCTS prior.
+
+Answer: `μ.rnDeriv ν * ν.rnDeriv lam =ᵐ[lam] μ.rnDeriv lam`.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 0
+set_option maxRecDepth 4000
+set_option synthInstance.maxHeartbeats 20000
+set_option synthInstance.maxSize 128
+set_option pp.fullNames true
+set_option relaxedAutoImplicit false
+set_option autoImplicit false
+set_option linter.all false
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace LebesgueMeasureOQ05ChainRuleStatement
+
+variable {α : Type*} [MeasurableSpace α] {μ ν lam : Measure α}
+
+/--
+**Radon–Nikodym chain rule (σ-finite).** For σ-finite measures `μ, ν, λ` with
+`μ ≪ ν`, the Radon–Nikodym derivative of `μ` w.r.t. `λ` factors through the
+intermediate measure `ν`:
+`(dμ/dν)·(dν/dλ) = dμ/dλ`, `λ`-almost everywhere.
+
+This is the measure-theoretic analogue of the calculus chain rule. Combined
+with the seven theorems of `LebesgueMeasureOQ05.lean` it completes the
+elementary calculus of densities for the σ-finite gallery package.
+
+The expected Mathlib glue is `MeasureTheory.Measure.rnDeriv_mul_rnDeriv`, which
+states precisely this equality for a σ-finite triple under `μ ≪ ν`.
+-/
+theorem rnDeriv_chain [SigmaFinite μ] [SigmaFinite ν] [SigmaFinite lam]
+    (h : μ ≪ ν) :
+    μ.rnDeriv ν * ν.rnDeriv lam =ᵐ[lam] μ.rnDeriv lam := by
+  sorry
+
+-- Proof sketch to seed the MCTS prior (Aristotle may ignore this):
+--   exact Measure.rnDeriv_mul_rnDeriv h
+-- `Measure.rnDeriv_mul_rnDeriv` takes the absolute-continuity hypothesis
+-- `μ ≪ ν` and the three `SigmaFinite` instances, returning the a.e. identity
+-- `μ.rnDeriv ν * ν.rnDeriv κ =ᵐ[κ] μ.rnDeriv κ`. If the name/shape drifted in
+-- Mathlib 4.26.0, the fallback is to rewrite via `withDensity_rnDeriv_eq` and
+-- `rnDeriv_withDensity` and the multiplicativity of `withDensity`.
+
+end LebesgueMeasureOQ05ChainRuleStatement

--- a/src/data/research/problems/lebesgue-measure-oq-05.json
+++ b/src/data/research/problems/lebesgue-measure-oq-05.json
@@ -44,12 +44,14 @@
   "knowledge": {
     "progressSummary": "FORMALIZATION DRAFTED & MERGED (#24720), BUILD-PENDING. 7-theorem σ-finite Radon–Nikodym + Lebesgue-decomposition package, 0 axioms / 0 sorries, registered Proofs.lean:2623, enriched to quality 100 (#24799). Not yet kernel-verified: audit #24801 downgraded the overclaimed verified/verified meta to formalized/mathlib. Remaining work is a Docker build (backend blackout).",
     "builtItems": [
-      "LebesgueMeasureOQ05.lean — 92 lines, 7 theorems, 0 axioms, 0 sorries (rnDeriv_measurable, rnDeriv_isDensity, exists_density, rnDeriv_setLIntegral, rnDeriv_lintegral, density_unique, lebesgue_decomposition); registered in proofs/Proofs.lean:2623"
+      "LebesgueMeasureOQ05.lean — 92 lines, 7 theorems, 0 axioms, 0 sorries (rnDeriv_measurable, rnDeriv_isDensity, exists_density, rnDeriv_setLIntegral, rnDeriv_lintegral, density_unique, lebesgue_decomposition); registered in proofs/Proofs.lean:2623",
+      "Drafted RN chain-rule batch artifact LebesgueMeasureOQ05ChainRuleStatementOnly.lean (rnDeriv_chain, expected exact Measure.rnDeriv_mul_rnDeriv) — queued for Aristotle on backend recovery"
     ],
     "insights": [
       "σ-finiteness of both measures is exactly what supplies Mathlib's HaveLebesgueDecomposition instance, so each result is a direct corollary — this is a Tier B formalization (one/two-line Mathlib API calls), badge mathlib not verified.",
       "ν-a.e. uniqueness (density_unique) needs only SigmaFinite ν, derived from Measure.rnDeriv_withDensity.",
-      "The Lebesgue decomposition holds for any σ-finite μ with no absolute-continuity hypothesis."
+      "The Lebesgue decomposition holds for any σ-finite μ with no absolute-continuity hypothesis.",
+      "lebesgue-measure-oq-05 base file is 0/0 complete and merged (#24720); only the deployer build-gate remains. Session 2 confirmed dual backend blackout (Docker exit124, Aristotle 404)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Discharges the single `sorry` in `LebesgueMeasureOQ05ChainRuleStatementOnly.lean`: the σ-finite Radon–Nikodym **chain rule** `(dμ/dν)·(dν/dλ) =ᵐ[λ] dμ/dλ` under `μ ≪ ν`.
- Proof is term-mode `Measure.rnDeriv_mul_rnDeriv h`. This Mathlib lemma at the v4.26.0 pin (`Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean:383`) has signature `[SigmaFinite μ] [SigmaFinite ν] [SigmaFinite κ] (hμν : μ ≪ ν) : μ.rnDeriv ν * ν.rnDeriv κ =ᵐ[κ] μ.rnDeriv κ` — the goal verbatim with `κ := lam`.
- Follow-up to the merged σ-finite RN package (#24720, `LebesgueMeasureOQ05.lean`, 7 theorems, 0 sorries/0 axioms).

## Status
- **Build-pending**: dual blackout this session — Docker daemon hung (`docker run alpine` rc=124, thundering-herd of stuck builds) and Aristotle MCP returns `Resource not found` (404). Could not kernel-verify.
- Confidence is high regardless: the proof term is a verbatim match against the pinned Mathlib source (name, namespace, instance args, and statement all confirmed against the offline checkout at the exact build pin).
- Orphan file is **unregistered** in `Proofs.lean` → zero gallery / false-green risk. When Docker recovers: build, then fold `rnDeriv_chain` into `LebesgueMeasureOQ05.lean` as theorem #8.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.LebesgueMeasureOQ05ChainRuleStatementOnly` green when Docker recovers
- [ ] Fold into base package + register

🤖 Generated with [Claude Code](https://claude.com/claude-code)