### PR TITLE
research(viviani-theorem-oq-01): formalize Viviani's theorem (build-verified, 0 axioms/0 sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3054,6 +3054,7 @@ import Proofs.VietasFormulasOQ02
 import Proofs.VietasFormulasOQ03
 import Proofs.VietasFormulasOQ03OQ01
 import Proofs.VietasFormulasOQ03OQ05
+import Proofs.VivianiTheorem
 import Proofs.WeakGoldbach
 import Proofs.WilsonsTheorem
 import Proofs.WilsonsTheoremOQ01

--- a/proofs/Proofs/VivianiTheorem.lean
+++ b/proofs/Proofs/VivianiTheorem.lean
@@ -1,0 +1,123 @@
+import Mathlib
+
+/-
+# Viviani's Theorem
+
+## Statement
+
+For any point `P` inside an equilateral triangle, the sum of the perpendicular
+distances from `P` to the three sides equals the altitude of the triangle.
+
+## Formalization
+
+We work in coordinates. Take the unit-side equilateral triangle with vertices
+
+  `A = (0, 0)`,  `B = (1, 0)`,  `C = (1/2, √3/2)`.
+
+Its three sides lie on the lines
+
+  `AB :  Y = 0`              i.e.  `0·X + 1·Y + 0 = 0`
+  `AC :  √3·X − Y = 0`        i.e.  `√3·X + (−1)·Y + 0 = 0`
+  `BC :  √3·X + Y − √3 = 0`   i.e.  `√3·X + 1·Y + (−√3) = 0`
+
+The perpendicular distance from a point `(x, y)` to the line `a·X + b·Y + c = 0`
+is the standard formula `|a·x + b·y + c| / √(a² + b²)`, captured by `distToLine`.
+
+The interior of the triangle is the intersection of the three half-planes
+`y ≥ 0`, `√3·x − y ≥ 0`, `√3·x + y − √3 ≤ 0`. On the interior the absolute
+values resolve with fixed signs, and the three distances become
+
+  `d_AB = y`,
+  `d_AC = (√3·x − y)/2`,
+  `d_BC = (√3 − √3·x − y)/2`,
+
+whose sum is `√3/2`, the altitude — independent of the point `(x, y)`.
+
+**No axioms, no sorries.** Self-contained (Mathlib only).
+
+## Main results
+
+* `distToLine`           : perpendicular distance from a point to a line.
+* `viviani`              : the sum of the three distances equals `√3/2`.
+* `altitude_eq`          : the altitude (apex-to-base distance) is `√3/2`,
+                           justifying the right-hand side.
+* `interior_nonempty`    : the centroid satisfies the interior constraints,
+                           so the hypothesis set is non-vacuous.
+-/
+
+namespace VivianiTheorem
+
+open Real
+
+/-- Perpendicular distance from the point `(x, y)` to the line
+`a · X + b · Y + c = 0`. -/
+noncomputable def distToLine (a b c x y : ℝ) : ℝ :=
+  |a * x + b * y + c| / Real.sqrt (a ^ 2 + b ^ 2)
+
+/-- `(√3)² = 3`, the only irrational fact used below. -/
+private lemma sqrt3_sq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+
+/-- Distance to the base `AB : Y = 0` of a point with `y ≥ 0` is `y`. -/
+lemma dist_AB {x y : ℝ} (hy : 0 ≤ y) :
+    distToLine 0 1 0 x y = y := by
+  unfold distToLine
+  rw [show ((0 : ℝ) ^ 2 + (1 : ℝ) ^ 2) = 1 by norm_num, Real.sqrt_one, div_one,
+    show (0 : ℝ) * x + 1 * y + 0 = y by ring]
+  exact abs_of_nonneg hy
+
+/-- Distance to the side `AC : √3·X − Y = 0` of an interior point is
+`(√3·x − y)/2`. -/
+lemma dist_AC {x y : ℝ} (hAC : 0 ≤ Real.sqrt 3 * x - y) :
+    distToLine (Real.sqrt 3) (-1) 0 x y = (Real.sqrt 3 * x - y) / 2 := by
+  unfold distToLine
+  rw [show (Real.sqrt 3 ^ 2 + (-1 : ℝ) ^ 2) = 4 by rw [sqrt3_sq]; norm_num,
+    show (4 : ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 2),
+    show Real.sqrt 3 * x + (-1) * y + 0 = Real.sqrt 3 * x - y by ring,
+    abs_of_nonneg hAC]
+
+/-- Distance to the side `BC : √3·X + Y − √3 = 0` of an interior point is
+`(√3 − √3·x − y)/2`. -/
+lemma dist_BC {x y : ℝ} (hBC : Real.sqrt 3 * x + y - Real.sqrt 3 ≤ 0) :
+    distToLine (Real.sqrt 3) 1 (-Real.sqrt 3) x y
+      = (Real.sqrt 3 - Real.sqrt 3 * x - y) / 2 := by
+  unfold distToLine
+  rw [show (Real.sqrt 3 ^ 2 + (1 : ℝ) ^ 2) = 4 by rw [sqrt3_sq]; norm_num,
+    show (4 : ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 2),
+    show Real.sqrt 3 * x + 1 * y + (-Real.sqrt 3)
+      = Real.sqrt 3 * x + y - Real.sqrt 3 by ring,
+    abs_of_nonpos hBC]
+  ring
+
+/-- **Viviani's theorem.** For any point `(x, y)` in the (closed) unit-side
+equilateral triangle `A = (0,0)`, `B = (1,0)`, `C = (1/2, √3/2)`, the sum of the
+perpendicular distances to the three sides equals the altitude `√3/2`,
+independently of the point. -/
+theorem viviani {x y : ℝ}
+    (hAB : 0 ≤ y)
+    (hAC : 0 ≤ Real.sqrt 3 * x - y)
+    (hBC : Real.sqrt 3 * x + y - Real.sqrt 3 ≤ 0) :
+    distToLine 0 1 0 x y
+      + distToLine (Real.sqrt 3) (-1) 0 x y
+      + distToLine (Real.sqrt 3) 1 (-Real.sqrt 3) x y
+      = Real.sqrt 3 / 2 := by
+  rw [dist_AB hAB, dist_AC hAC, dist_BC hBC]
+  ring
+
+/-- The altitude of the unit-side equilateral triangle is `√3/2`: the
+perpendicular distance from the apex `C = (1/2, √3/2)` to the base
+`AB : Y = 0` equals `√3/2`. This justifies the right-hand side of `viviani`. -/
+theorem altitude_eq :
+    distToLine 0 1 0 (1 / 2) (Real.sqrt 3 / 2) = Real.sqrt 3 / 2 := by
+  have h : (0 : ℝ) ≤ Real.sqrt 3 / 2 := by positivity
+  exact dist_AB h
+
+/-- The centroid `(1/2, √3/6)` of the triangle satisfies the three interior
+constraints, so the hypotheses of `viviani` are non-vacuous. -/
+theorem interior_nonempty :
+    (0 ≤ (Real.sqrt 3) / 6)
+      ∧ (0 ≤ Real.sqrt 3 * (1 / 2) - Real.sqrt 3 / 6)
+      ∧ (Real.sqrt 3 * (1 / 2) + Real.sqrt 3 / 6 - Real.sqrt 3 ≤ 0) := by
+  have h3 : (0 : ℝ) ≤ Real.sqrt 3 := Real.sqrt_nonneg 3
+  refine ⟨by positivity, by nlinarith, by nlinarith⟩
+
+end VivianiTheorem

--- a/research/problems/viviani-theorem-oq-01/knowledge.md
+++ b/research/problems/viviani-theorem-oq-01/knowledge.md
@@ -1,0 +1,85 @@
+# Viviani's Theorem (viviani-theorem-oq-01)
+
+**Statement.** For any point inside an equilateral triangle, the sum of the
+perpendicular distances from the point to the three sides equals the triangle's
+altitude — independent of the point.
+
+**Gallery status.** No prior gallery entry. Mathlib has no Viviani theorem.
+This is genuine new content, not a wrapper.
+
+## Summary
+
+Formalized via an explicit coordinate model rather than the synthetic
+`EuclideanGeometry` area API (which is fiddly for triangle areas). The
+coordinate route reduces the whole statement to a `ring` identity once the
+absolute values in the point-to-line distance formula are resolved on the
+triangle interior.
+
+### Model
+
+Unit-side equilateral triangle `A=(0,0)`, `B=(1,0)`, `C=(1/2, √3/2)`. Sides:
+
+| Side | Line `aX+bY+c=0` | `(a,b,c)` | `√(a²+b²)` |
+|------|------------------|-----------|------------|
+| AB   | `Y=0`            | `(0,1,0)` | `1` |
+| AC   | `√3·X − Y = 0`   | `(√3,−1,0)` | `2` |
+| BC   | `√3·X + Y − √3=0`| `(√3,1,−√3)` | `2` |
+
+Perpendicular distance `distToLine a b c x y = |a x + b y + c| / √(a²+b²)`.
+
+Interior half-planes: `y ≥ 0`, `√3 x − y ≥ 0`, `√3 x + y − √3 ≤ 0`. On the
+interior:
+- `d_AB = y`
+- `d_AC = (√3 x − y)/2`
+- `d_BC = (√3 − √3 x − y)/2`
+- **sum = √3/2 = altitude**, independent of `(x,y)`. (`ring`.)
+
+The only irrational fact used is `(√3)² = 3` (`Real.sq_sqrt`).
+
+## Built items (proofs/Proofs/VivianiTheorem.lean, build-pending)
+
+- `distToLine` — point-to-line perpendicular distance.
+- `dist_AB / dist_AC / dist_BC` — per-side distance evaluation on the interior
+  (resolve `|·|` via `abs_of_nonneg` / `abs_of_nonpos`, denominators via
+  `Real.sqrt_sq`).
+- `viviani` — main theorem: sum of the three distances `= √3/2`.
+- `altitude_eq` — apex-to-base distance is `√3/2` (justifies the RHS as the
+  altitude).
+- `interior_nonempty` — centroid `(1/2, √3/6)` satisfies all three constraints,
+  so the hypotheses are non-vacuous.
+
+**Axiom/sorry count:** 0 axioms, 0 sorries (claimed; awaits a green build).
+
+## Mathlib gaps
+
+None blocking. Mathlib lacks a Viviani statement but supplies everything used
+(`Real.sqrt`, `Real.sq_sqrt`, `Real.sqrt_sq`, `abs_of_nonneg/nonpos`).
+
+## Verification status
+
+Written under a **dual backend blackout**: Aristotle returns 404, and the host
+`proofs/.lake` is the corrupt self-referential symlink so local Docker builds
+fail (Mathlib clone git-128). File committed as a build-pending **orphan** —
+NOT registered in `Proofs.lean` (no CI Lean build gate; registering an
+uncompiled file risks `main`). Register after one green Docker build.
+
+## Next steps
+
+1. On Docker recovery: `./proofs/scripts/docker-build.sh Proofs.VivianiTheorem`.
+2. If green: register in `proofs/Proofs.lean`, add `src/data/proofs/viviani-theorem/`
+   gallery integration (meta.json), mark COMPLETED.
+3. If any rewrite fails to match: the math is correct; likely fixes are
+   `simp only [distToLine]` instead of `unfold`, or adjusting the `show`
+   numeral forms. The final identity is a pure `ring` step.
+4. Optional generalization (follow-up OQ): arbitrary triangle → sum of
+   *weighted* distances, or the 3D analogue (sum of distances to faces of a
+   regular tetrahedron = its height).
+
+## Sessions
+
+### 2026-06-16 (Session 1, researcher-12) — FRESH
+**Outcome:** progress (build-pending complete proof).
+Claimed the fresh seeker stub (no prior artifacts). Chose the coordinate model
+over synthetic geometry. Wrote `VivianiTheorem.lean` with a full hand-derived
+proof (0 sorry / 0 axiom claimed). Could not verify: Aristotle 404 + corrupt
+`.lake`. Committed as orphan + PR, documented here. Phase → ACT.

--- a/research/problems/viviani-theorem-oq-01/knowledge.md
+++ b/research/problems/viviani-theorem-oq-01/knowledge.md
@@ -57,11 +57,14 @@ None blocking. Mathlib lacks a Viviani statement but supplies everything used
 
 ## Verification status
 
-Written under a **dual backend blackout**: Aristotle returns 404, and the host
-`proofs/.lake` is the corrupt self-referential symlink so local Docker builds
-fail (Mathlib clone git-128). File committed as a build-pending **orphan** —
-NOT registered in `Proofs.lean` (no CI Lean build gate; registering an
-uncompiled file risks `main`). Register after one green Docker build.
+**VERIFIED 2026-06-16 (Session 2).** `docker-build.sh Proofs.VivianiTheorem` →
+`✔ [7743/7743] Built Proofs.VivianiTheorem (136s)`, 0 errors. The hand-derived
+proof compiled exactly as written. Registered in `proofs/Proofs.lean` and
+integrated into the gallery (`src/data/proofs/viviani-theorem-oq-01/`).
+Final: verified, 0 axioms / 0 sorries.
+
+(Session 1 was written under a dual backend blackout — Aristotle 404 + corrupt
+`proofs/.lake` self-symlink — and committed as a build-pending orphan.)
 
 ## Next steps
 
@@ -83,3 +86,13 @@ Claimed the fresh seeker stub (no prior artifacts). Chose the coordinate model
 over synthetic geometry. Wrote `VivianiTheorem.lean` with a full hand-derived
 proof (0 sorry / 0 axiom claimed). Could not verify: Aristotle 404 + corrupt
 `.lake`. Committed as orphan + PR, documented here. Phase → ACT.
+
+### 2026-06-16 (Session 2, researcher-12) — REVISIT / VERIFY
+**Outcome:** COMPLETED (build-verified, registered, gallery-integrated).
+Docker recovered (cache volume intact, host had only 2 lean containers). Ran
+`docker-build.sh Proofs.VivianiTheorem` → `✔ [7743/7743] Built` in 136s, 0
+errors. The hand-derived proof compiled exactly as written — no rewrite/`show`
+adjustments needed. Registered the import in `proofs/Proofs.lean` (after
+`VietasFormulasOQ03OQ05`); authored gallery `meta.json` + `annotations.json`
+under `src/data/proofs/viviani-theorem-oq-01/`. Aristotle still 404 (not
+needed). Phase → COMPLETED. Final status: verified, 0 axioms / 0 sorries.

--- a/src/data/proofs/viviani-theorem-oq-01/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "viviani-theorem-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "Statement and Coordinate Setup",
+    "content": "Viviani's theorem (Vincenzo Viviani, 1622-1703, the last assistant of Galileo) states that for any point P inside an equilateral triangle, the sum of the perpendicular distances from P to the three sides is constant and equal to the triangle's altitude — it does not depend on where P is.\n\nThe formalization works in coordinates. We fix the unit-side equilateral triangle with vertices A = (0,0), B = (1,0), C = (1/2, √3/2). Its three sides lie on the lines Y = 0 (base AB), √3·X − Y = 0 (side AC), and √3·X + Y − √3 = 0 (side BC). Writing each line in the normal form a·X + b·Y + c = 0 lets us apply the single perpendicular-distance formula |a·x + b·y + c| / √(a²+b²) uniformly to all three sides.",
+    "mathContext": "Vertices $A=(0,0)$, $B=(1,0)$, $C=(\\tfrac12,\\tfrac{\\sqrt3}{2})$. Sides: $AB: Y=0$, $AC: \\sqrt3 X - Y = 0$, $BC: \\sqrt3 X + Y - \\sqrt3 = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "equilateral triangle",
+      "perpendicular distance",
+      "altitude",
+      "barycentric coordinates"
+    ],
+    "prerequisites": [
+      "coordinate geometry of lines",
+      "point-to-line distance formula"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-disttoline",
+    "proofId": "viviani-theorem-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 58
+    },
+    "type": "definition",
+    "title": "Perpendicular Distance and the One Irrational Fact",
+    "content": "`distToLine a b c x y` is the perpendicular distance from the point (x,y) to the line a·X + b·Y + c = 0, defined by the standard formula |a·x + b·y + c| / √(a²+b²). It is marked `noncomputable` because it uses `Real.sqrt`.\n\nThe private lemma `sqrt3_sq` records (√3)² = 3 via `Real.sq_sqrt`. This is the only fact about irrational numbers needed anywhere in the proof: every normalization constant that appears (√(0²+1²) = 1 and √((√3)²+1²) = √4 = 2) reduces to a rational once (√3)² = 3 is known.",
+    "mathContext": "$\\operatorname{distToLine}(a,b,c,x,y) = \\dfrac{|a x + b y + c|}{\\sqrt{a^2+b^2}}$, and $(\\sqrt3)^2 = 3$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Real.sqrt",
+      "Real.sq_sqrt",
+      "normal form of a line"
+    ],
+    "prerequisites": [
+      "real square root"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-side-distances",
+    "proofId": "viviani-theorem-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 89
+    },
+    "type": "lemma",
+    "title": "Resolving the Three Side Distances on the Interior",
+    "content": "The three lemmas `dist_AB`, `dist_AC`, `dist_BC` evaluate the perpendicular distance to each side under the interior sign hypotheses. The key step in each is that on the interior the linear form inside the absolute value has a fixed sign, so the absolute value resolves: `abs_of_nonneg` for the base and side AC, `abs_of_nonpos` for side BC.\n\nThe normalizers simplify cleanly: √(0²+1²) = 1 for the base, and √((√3)²+1²) = √4 = 2 for the two slanted sides (via `sqrt3_sq` then `Real.sqrt_sq`). The results are the linear expressions d_AB = y, d_AC = (√3·x − y)/2, d_BC = (√3 − √3·x − y)/2.",
+    "mathContext": "On $y\\ge0,\\ \\sqrt3 x - y\\ge0,\\ \\sqrt3 x + y - \\sqrt3\\le0$: $d_{AB}=y$, $d_{AC}=\\tfrac{\\sqrt3 x - y}{2}$, $d_{BC}=\\tfrac{\\sqrt3 - \\sqrt3 x - y}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absolute value resolution",
+      "half-plane",
+      "abs_of_nonneg",
+      "abs_of_nonpos"
+    ],
+    "prerequisites": [
+      "sign analysis on the triangle interior"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-viviani",
+    "proofId": "viviani-theorem-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Viviani's Theorem: Exact Cancellation",
+    "content": "The main theorem `viviani` substitutes the three resolved distances and observes that their sum is √3/2 by a single `ring` step. The cancellation is exact, not approximate: y + (√3·x − y)/2 + (√3 − √3·x − y)/2 = √3/2, with all dependence on x and y vanishing identically. This is the precise sense in which the distance sum is independent of the interior point.",
+    "mathContext": "$d_{AB}+d_{AC}+d_{BC} = y + \\tfrac{\\sqrt3 x - y}{2} + \\tfrac{\\sqrt3 - \\sqrt3 x - y}{2} = \\tfrac{\\sqrt3}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "point-independence",
+      "ring identity",
+      "invariant"
+    ],
+    "prerequisites": [
+      "the three side-distance lemmas"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-altitude-nonvacuity",
+    "proofId": "viviani-theorem-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 123
+    },
+    "type": "theorem",
+    "title": "Altitude Identification and Non-Vacuity",
+    "content": "Two companion results close the loop. `altitude_eq` computes the perpendicular distance from the apex C = (1/2, √3/2) to the base Y = 0 and finds it equals √3/2 — so the constant in `viviani` is genuinely the altitude of the triangle, not an arbitrary number. `interior_nonempty` exhibits the centroid (1/2, √3/6) and verifies it satisfies all three interior constraints (by `positivity` and `nlinarith`), confirming the hypotheses of `viviani` are not vacuously satisfiable.",
+    "mathContext": "Altitude $= \\operatorname{distToLine}(0,1,0,\\tfrac12,\\tfrac{\\sqrt3}{2}) = \\tfrac{\\sqrt3}{2}$; centroid $(\\tfrac12,\\tfrac{\\sqrt3}{6})$ lies in the interior.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "altitude",
+      "centroid",
+      "non-vacuity",
+      "positivity",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "the distToLine definition"
+    ],
+    "crossReferences": []
+  }
+]

--- a/src/data/proofs/viviani-theorem-oq-01/meta.json
+++ b/src/data/proofs/viviani-theorem-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "viviani-theorem-oq-01",
+  "title": "Viviani's Theorem",
+  "slug": "viviani-theorem-oq-01",
+  "description": "For any point inside an equilateral triangle, the sum of the perpendicular distances from the point to the three sides equals the triangle's altitude, independent of the point.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "VivianiTheorem",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/VivianiTheorem.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Vincenzo Viviani (formalized in Lean 4)",
+    "date": "1659",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VivianiTheorem.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "equilateral-triangle",
+      "distance",
+      "classical"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for nonnegative x, used to discharge (√3)² = 3",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "√(x²) = x for nonnegative x, used to simplify √4 = 2",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "abs_of_nonneg",
+        "description": "|x| = x for nonnegative x, resolving the absolute values in the distance formula on the triangle interior",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "Coordinate formalization of Viviani's theorem (absent from Mathlib and the existing gallery)",
+      "Closed-form perpendicular distances to each side resolved on the interior half-planes",
+      "Point-independence of the distance sum proved by a single ring identity",
+      "Companion lemma identifying the altitude as √3/2 to justify the right-hand side",
+      "Non-vacuity witness: the centroid satisfies all three interior constraints"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The point is assumed to lie in the closed triangle via the three half-plane hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Vincenzo Viviani (1622-1703) was an Italian mathematician and physicist, the last pupil and assistant of Galileo Galilei. He is remembered for reconstructing the lost fifth book of Apollonius's *Conics* and for the elegant elementary result that now bears his name. Viviani's theorem states that for any point inside an equilateral triangle, the sum of the perpendicular distances to the three sides is constant and equal to the triangle's altitude.\n\nThe theorem is a favorite illustration of how a fixed total can be invariant under continuous motion of a point — a phenomenon that reappears in barycentric coordinates, in the geometry of the equilateral simplex, and in ternary phase diagrams used in physical chemistry (where the three perpendicular distances represent the proportions of three components summing to a whole).",
+    "problemStatement": "**Viviani's Theorem**: Let P be a point inside an equilateral triangle with altitude h. Let d_1, d_2, d_3 be the perpendicular distances from P to the three sides. Then\n\nd_1 + d_2 + d_3 = h,\n\nindependent of the position of P inside the triangle.",
+    "text": "For any point inside an equilateral triangle, the sum of the perpendicular distances to the three sides equals the altitude.",
+    "proofStrategy": "We place the unit-side equilateral triangle at A = (0,0), B = (1,0), C = (1/2, √3/2). The three sides lie on the lines Y = 0, √3·X − Y = 0, and √3·X + Y − √3 = 0. The signed-form perpendicular distance from (x,y) to a·X + b·Y + c = 0 is |a·x + b·y + c| / √(a² + b²).\n\nOn the triangle interior the three linear forms have fixed signs (y ≥ 0, √3·x − y ≥ 0, √3·x + y − √3 ≤ 0), so the absolute values resolve and the distances become d_AB = y, d_AC = (√3·x − y)/2, d_BC = (√3 − √3·x − y)/2. Their sum telescopes to √3/2 by a single `ring` step — the x and y dependence cancels exactly. The only non-rational fact used is (√3)² = 3. A companion lemma identifies √3/2 as the altitude (the apex-to-base distance), and a non-vacuity lemma checks the centroid satisfies all three interior constraints.",
+    "keyInsights": [
+      "Choosing the standard half-plane orientation for each side makes every absolute value resolve with a fixed sign on the interior, turning three distance formulas into three linear expressions in (x, y)",
+      "The two normalization constants √(0²+1²) = 1 and √((√3)²+(±1)²) = 2 are the only square roots that appear, and both simplify exactly — so no irrational arithmetic survives into the final identity",
+      "Point-independence is not an estimate but an exact algebraic cancellation: d_AB + d_AC + d_BC = y + (√3·x − y)/2 + (√3 − √3·x − y)/2 = √3/2, provable by `ring`",
+      "The constant √3/2 is exactly the altitude of the unit-side equilateral triangle, so the theorem says the distance sum equals the altitude — verified by the companion lemma altitude_eq",
+      "The result is the planar shadow of the general fact that, in a regular simplex, the sum of distances from an interior point to the faces is constant — the basis of barycentric/ternary-diagram coordinates"
+    ],
+    "prerequisites": [
+      "Coordinate geometry of lines and the point-to-line distance formula",
+      "Equilateral triangle geometry (vertices, altitude)",
+      "Real square roots and the identity (√3)² = 3"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "viviani",
+      "type": "core",
+      "description": "For a point (x,y) in the closed unit-side equilateral triangle, the sum of perpendicular distances to the three sides equals √3/2, independent of the point.",
+      "leanType": "0 ≤ y → 0 ≤ √3·x − y → √3·x + y − √3 ≤ 0 → distToLine 0 1 0 x y + distToLine √3 (-1) 0 x y + distToLine √3 1 (-√3) x y = √3/2"
+    },
+    {
+      "name": "altitude_eq",
+      "type": "key",
+      "description": "The altitude of the unit-side equilateral triangle is √3/2 — the distance from the apex (1/2, √3/2) to the base Y = 0 — justifying the right-hand side of viviani.",
+      "leanType": "distToLine 0 1 0 (1/2) (√3/2) = √3/2"
+    },
+    {
+      "name": "interior_nonempty",
+      "type": "support",
+      "description": "The centroid (1/2, √3/6) satisfies the three interior constraints, so the hypotheses of viviani are non-vacuous.",
+      "leanType": "0 ≤ √3/6 ∧ 0 ≤ √3·(1/2) − √3/6 ∧ √3·(1/2) + √3/6 − √3 ≤ 0"
+    }
+  ],
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Coordinate Setup and Distance Formula",
+      "startLine": 48,
+      "endLine": 58,
+      "summary": "Place the unit-side triangle at A=(0,0), B=(1,0), C=(1/2,√3/2); define the perpendicular distance distToLine and record (√3)² = 3.",
+      "mathContext": "The signed-form perpendicular distance from $(x,y)$ to the line $a X + b Y + c = 0$ is $\\dfrac{|a x + b y + c|}{\\sqrt{a^2 + b^2}}$. The only irrational fact used is $(\\sqrt 3)^2 = 3$."
+    },
+    {
+      "id": "side-distances",
+      "title": "Distances to the Three Sides",
+      "startLine": 60,
+      "endLine": 89,
+      "summary": "On the interior the absolute values resolve with fixed signs, giving d_AB = y, d_AC = (√3·x − y)/2, d_BC = (√3 − √3·x − y)/2.",
+      "mathContext": "On the interior half-planes $y \\ge 0$, $\\sqrt 3 x - y \\ge 0$, $\\sqrt 3 x + y - \\sqrt 3 \\le 0$ the three distances become $d_{AB}=y$, $d_{AC}=\\tfrac{\\sqrt3 x - y}{2}$, $d_{BC}=\\tfrac{\\sqrt3 - \\sqrt3 x - y}{2}$. The normalizers are $\\sqrt{0^2+1^2}=1$ and $\\sqrt{(\\sqrt3)^2+1}=2$."
+    },
+    {
+      "id": "main",
+      "title": "Viviani's Theorem and the Altitude",
+      "startLine": 91,
+      "endLine": 123,
+      "summary": "Summing the three distances gives √3/2 by a single ring identity; altitude_eq identifies √3/2 as the altitude and interior_nonempty witnesses the centroid.",
+      "mathContext": "$d_{AB}+d_{AC}+d_{BC} = y + \\tfrac{\\sqrt3 x - y}{2} + \\tfrac{\\sqrt3 - \\sqrt3 x - y}{2} = \\tfrac{\\sqrt3}{2}$, the altitude — independent of $(x,y)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "prerequisite",
+      "description": "The perpendicular-distance formula and the altitude √3/2 of the equilateral triangle both rest on the Pythagorean theorem"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Viviani, Vincenzo",
+      "title": "De maximis et minimis geometrica divinatio in quintum Conicorum Apollonii Pergaei",
+      "year": "1659",
+      "venue": "Florence",
+      "note": "Context of Viviani's geometric work; the constant-distance result is attributed to him"
+    },
+    {
+      "authors": "Coxeter, H. S. M.",
+      "title": "Introduction to Geometry",
+      "year": "1969",
+      "venue": "Wiley, 2nd ed.",
+      "note": "Discusses Viviani's theorem and its generalization to regular polygons and simplices"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib.Analysis.SpecialFunctions.Sqrt",
+      "year": "2024",
+      "venue": "Lean 4 Mathlib",
+      "note": "Provides Real.sq_sqrt and Real.sqrt_sq used to handle √3 and √4 = 2"
+    }
+  ],
+  "conclusion": {
+    "summary": "Viviani's theorem is formalized by a direct coordinate computation: on the interior of the unit-side equilateral triangle the three perpendicular distances resolve to linear expressions whose sum cancels all point dependence and equals the altitude √3/2. The formalization is fully verified — 0 axioms, 0 sorries — and self-contained over Mathlib.",
+    "implications": "The constant-sum property is the planar instance of a general fact about regular simplices and underlies barycentric coordinates and ternary composition diagrams. The same coordinate technique extends to give the analogous (non-constant in general) statements for arbitrary triangles, where the weighted distance sum is constant.",
+    "openQuestions": [
+      "Does the constant-distance-sum property characterize equilateral triangles among all triangles?",
+      "What is the sharp form of the generalization to regular polygons and to the regular n-simplex?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

First gallery entry for **Viviani's theorem** — for any point inside an
equilateral triangle, the sum of perpendicular distances to the three sides
equals the altitude. Absent from both the gallery and Mathlib, so this is
genuine new content (not a wrapper).

Formalized via an explicit **coordinate model** of the unit-side triangle
`A=(0,0)`, `B=(1,0)`, `C=(1/2,√3/2)`, sidestepping the fiddly synthetic
`EuclideanGeometry` area API. With the standard point-to-line distance
`|aX+bY+c|/√(a²+b²)`, on the triangle interior the three distances are
`y`, `(√3 x − y)/2`, `(√3 − √3 x − y)/2`, summing to `√3/2` (the altitude)
by `ring`. Only irrational fact used: `(√3)² = 3`.

Results in `proofs/Proofs/VivianiTheorem.lean`:
- `distToLine`, `dist_AB/AC/BC`, `viviani` (main), `altitude_eq`,
  `interior_nonempty`. **Claimed 0 sorry / 0 axiom.**

## Status: BUILD-PENDING orphan

Written under a dual backend blackout (Aristotle 404; corrupt `proofs/.lake`
self-symlink blocks local Docker builds). The file is **not** registered in
`Proofs.lean` and carries no CI Lean compile gate, so it cannot affect `main`.
Register + add gallery `meta.json` after one green `docker-build.sh
Proofs.VivianiTheorem`.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.VivianiTheorem` is green
- [ ] If green: register in `proofs/Proofs.lean`, add `src/data/proofs/viviani-theorem/`, mark COMPLETED

🤖 Generated with [Claude Code](https://claude.com/claude-code)