### PR TITLE
research(abel-ruffini-galois): turnkey orphan for Step 3 sylow_p_is_pcycle

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
@@ -1,0 +1,135 @@
+/-
+  TURNKEY ORPHAN DRAFT — Step 3 (`sylow_p_is_pcycle`) of the Galois-direction
+  classification `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection`.
+
+  The registered file carries `sylow_p_is_pcycle` as a `sorry` stub (Step 3 of
+  the 5-step plan). This companion proves the SAME statement (re-stated
+  standalone — Step 3 references no parent-file definitions). It is an ORPHAN:
+  NOT imported by `Proofs.lean`, so it is OUTSIDE any CI/registered build gate
+  and cannot affect the green registered build. Once a build backend is
+  available: build this file; if green, fold the body into the registered
+  `sylow_p_is_pcycle` (the signatures match verbatim).
+
+  ## Status — UNVERIFIED (authored 2026-06-16, researcher-5, S15)
+
+  Authored under DUAL BLACKOUT: Aristotle MCP `prove`/`prove_file` return 404
+  ("Resource not found"); the host-wide `proofs/.lake` is a self-referential
+  symlink (`.lake -> .lake`), so every worktree's Mathlib package oleans are
+  inaccessible and `docker-build.sh` would trigger a multi-GB Mathlib re-clone
+  (the known git-128 failure). No local compile was possible, so lemma names
+  are best-effort. Confidence is annotated inline: ★ = high (used elsewhere in
+  the registered file / very standard), ? = medium (verify name/arg-order on
+  first build). The ONLY residual mathematical obligation is the self-contained
+  number-theory lemma `padicValNat_factorial_self` below
+  (`(p !).factorization p = 1`, Legendre); everything else is bookkeeping.
+
+  See `research/problems/.../knowledge.md` §"S15 Step-3 discharge plan" for the
+  strategy, the shared `|P| = p` kernel (common to Steps 1 and 3), and fallbacks.
+-/
+import Mathlib
+
+namespace AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- Legendre at the prime `p` itself: `v_p(p!) = 1`.
+    `v_p(p!) = ∑_{i=1}^{p-1} ⌊p / p^i⌋`; the `i = 1` term is `1`, every `i ≥ 2`
+    term is `0` (since `p^i > p`), so the sum is `1`.  Self-contained; the only
+    genuinely new obligation in Step 3. -/
+theorem padicValNat_factorial_self (hp : p.Prime) :
+    (Nat.factorial p).factorization p = 1 := by
+  -- ? bearer name: `Nat.Prime.factorization_factorial`
+  --   `(n !).factorization p = ∑ i ∈ Finset.Ico 1 n, n / p ^ i`
+  rw [hp.factorization_factorial]
+  rw [Finset.sum_eq_single 1]
+  · rw [pow_one, Nat.div_self hp.pos]
+  · intro i hi hne
+    apply Nat.div_eq_of_lt
+    have hi2 : 2 ≤ i := by
+      rcases Finset.mem_Ico.mp hi with ⟨h1, _⟩; omega
+    calc p < p ^ 2 := by nlinarith [hp.two_le]
+      _ ≤ p ^ i := Nat.pow_le_pow_right hp.pos.le hi2
+  · intro h
+    exact absurd (Finset.mem_Ico.mpr ⟨le_refl 1, hp.one_lt⟩) h
+
+/-- **Step 3 (p-cycle structure).** The Sylow-`p` subgroup `P` of a primitive
+    solvable `H ≤ S_p` is generated (via the inclusion `ι = H.subtype ∘ P.subtype`)
+    by a single `p`-cycle `σ ∈ S_p`. -/
+theorem sylow_p_is_pcycle
+    (H : Subgroup (Equiv.Perm (ZMod p)))
+    (_hPrim : MulAction.IsPreprimitive H (ZMod p))
+    (_hSolv : IsSolvable H)
+    (P : Sylow p H) :
+    ∃ σ : Equiv.Perm (ZMod p), σ.IsCycle ∧ σ.support.card = p ∧
+      ∀ g : P, (H.subtype.comp (P : Subgroup H).subtype) g ∈
+        Subgroup.zpowers σ := by
+  have hp : p.Prime := Fact.out
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  -- ι : ↥P → S_p, composite of the two subgroup inclusions (a MonoidHom).
+  set ι : (P : Subgroup H) →* Equiv.Perm (ZMod p) :=
+    H.subtype.comp (P : Subgroup H).subtype with hιdef
+  have hι_inj : Function.Injective ι :=
+    (Subgroup.subtype_injective H).comp (Subgroup.subtype_injective _)  -- ★
+  ----------------------------------------------------------------
+  -- Step A:  p ∣ Nat.card H   (primitivity ⇒ transitivity on a p-point set).
+  ----------------------------------------------------------------
+  haveI : MulAction.IsPretransitive H (ZMod p) := _hPrim.toIsPretransitive  -- ★
+  have horbit : Nat.card (MulAction.orbit H (0 : ZMod p)) = p := by
+    have huniv : MulAction.orbit H (0 : ZMod p) = Set.univ :=
+      MulAction.orbit_eq_univ (0 : ZMod p)                                -- ★
+    rw [huniv, Nat.card_congr (Equiv.Set.univ (ZMod p)),
+        Nat.card_eq_fintype_card, ZMod.card]                             -- ★
+  have hpH : p ∣ Nat.card H := by
+    -- ? bearer (Nat.card form): orbit–stabilizer
+    have hos := MulAction.card_orbit_mul_card_stabilizer_eq_card_group
+      H (0 : ZMod p)
+    exact ⟨Nat.card (MulAction.stabilizer H (0 : ZMod p)), by rw [← hos, horbit]⟩
+  ----------------------------------------------------------------
+  -- Step B:  Nat.card ↥P = p.
+  ----------------------------------------------------------------
+  -- lower bound: p ∣ |P|  (Sylow card = p ^ v_p(|H|), and v_p(|H|) ≥ 1).
+  have hkpos : 0 < (Nat.card H).factorization p :=
+    Nat.Prime.factorization_pos_of_dvd hp Nat.card_pos.ne' hpH            -- ★ (Step 5 uses this)
+  have hpP : p ∣ Nat.card (P : Subgroup H) := by
+    rw [P.card_eq_multiplicity]                                          -- ★ (Step 5 uses this)
+    exact dvd_pow_self p hkpos.ne'
+  -- upper bound: v_p(|H|) ≤ v_p(p!) = 1   (Lagrange in S_p + Legendre).
+  have hHdvd : Nat.card H ∣ Nat.card (Equiv.Perm (ZMod p)) :=
+    Subgroup.card_subgroup_dvd_card H                                    -- ?
+  have hcard_perm : Nat.card (Equiv.Perm (ZMod p)) = Nat.factorial p := by
+    rw [Nat.card_eq_fintype_card, Fintype.card_perm, ZMod.card]          -- ?
+  have hvpH : (Nat.card H).factorization p ≤ 1 := by
+    have hle : (Nat.card H).factorization p
+        ≤ (Nat.card (Equiv.Perm (ZMod p))).factorization p :=
+      (Nat.factorization_le_iff_dvd Nat.card_pos.ne'
+        (by rw [hcard_perm]; exact (Nat.factorial_pos p).ne')).2 hHdvd p  -- ?
+    rwa [hcard_perm, padicValNat_factorial_self hp] at hle
+  have hcardP : Nat.card (P : Subgroup H) = p := by
+    have hk1 : (Nat.card H).factorization p = 1 := le_antisymm hvpH hkpos
+    rw [P.card_eq_multiplicity, hk1, pow_one]                            -- ★
+  have hcardP_ft : Fintype.card (P : Subgroup H) = p := by
+    rw [← Nat.card_eq_fintype_card]; exact hcardP
+  ----------------------------------------------------------------
+  -- Step C:  ↥P cyclic of prime order ⇒ generator a; σ := ι a is a p-cycle.
+  ----------------------------------------------------------------
+  haveI hcyc : IsCyclic (P : Subgroup H) := isCyclic_of_prime_card hcardP_ft  -- ?
+  obtain ⟨a, ha⟩ := hcyc.exists_generator                                 -- ★ (∀ x, x ∈ zpowers a)
+  have horda : orderOf a = p := by
+    rw [orderOf_eq_card_of_forall_mem_zpowers ha, hcardP_ft]              -- ?
+  have hords : orderOf (ι a) = p := by
+    rw [orderOf_injective ι hι_inj a, horda]                             -- ★
+  have hcycσ : (ι a).IsCycle := by
+    have hsupp_lt : (ι a).support.card < 2 * p := by
+      have hle : (ι a).support.card ≤ Fintype.card (ZMod p) :=
+        Finset.card_le_univ _
+      rw [ZMod.card] at hle; omega
+    exact Equiv.Perm.isCycle_of_prime_order hp hords hsupp_lt            -- ? name/args
+  refine ⟨ι a, hcycσ, ?_, ?_⟩
+  · -- support.card = orderOf = p
+    rw [← hcycσ.orderOf, hords]                                          -- ★ IsCycle.orderOf
+  · -- ι sends every element of P into ⟨σ⟩
+    intro g
+    obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp (ha g)                 -- ★ (a ^ k = g)
+    exact Subgroup.mem_zpowers_iff.mpr ⟨k, by rw [← map_zpow ι a k, hk]⟩  -- ★
+
+end AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -581,3 +581,50 @@ This session Docker recovered (1 container, warm Azure cache). I:
 4 sorry stubs remain: Step 1 `sylow_p_unique` (~70–110 LOC, the true blocker),
 Step 3 `sylow_p_is_pcycle`, Step 4 `normalizer_iso_AGL1Z`, and the main theorem.
 Aristotle `prove` still 404 (live-probed this session).
+
+## S15 Step-3 discharge plan (researcher-5, 2026-06-16) — turnkey draft authored
+
+Dual blackout again this cycle: Aristotle `prove` 404, and the host `proofs/.lake`
+is the self-referential symlink (`.lake -> .lake`), so all Mathlib package oleans
+are inaccessible host-wide and `docker-build.sh` would force a multi-GB Mathlib
+re-clone (git-128). No verified build possible. Step 3 was authored as a **turnkey
+orphan companion** `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean`
+(NOT in `Proofs.lean`, outside the build gate). UNVERIFIED — fold into the
+registered `sylow_p_is_pcycle` after one green build.
+
+### Realised proof (mirrors the verified Step-5 patterns where possible)
+Let `ι = H.subtype.comp P.subtype : ↥P →* S_p` (injective).
+- **Step A — `p ∣ Nat.card H`** from primitivity. `IsPreprimitive.toIsPretransitive`;
+  `MulAction.orbit_eq_univ (0:ZMod p)` ⟹ `Nat.card (orbit) = Nat.card (ZMod p) = p`
+  (`Equiv.Set.univ`, `ZMod.card`); orbit–stabilizer
+  `MulAction.card_orbit_mul_card_stabilizer_eq_card_group` ⟹ `p ∣ Nat.card H`.
+- **Step B — `Nat.card ↥P = p`.** Lower: `Sylow.card_eq_multiplicity` +
+  `Nat.Prime.factorization_pos_of_dvd` ⟹ `p ∣ |P|` (exactly the Step-5 idiom).
+  Upper: `Subgroup.card_subgroup_dvd_card` (|H| ∣ |S_p| = p!) +
+  `Nat.factorization_le_iff_dvd` evaluated at `p` ⟹ `v_p(|H|) ≤ v_p(p!) = 1`.
+- **Step C — generator ⟹ p-cycle.** `isCyclic_of_prime_card` ⟹ generator `a`;
+  `orderOf_eq_card_of_forall_mem_zpowers` + `orderOf_injective` ⟹ `orderOf (ι a) = p`;
+  `Equiv.Perm.isCycle_of_prime_order` (support.card ≤ p < 2p) ⟹ `(ι a).IsCycle`;
+  `IsCycle.orderOf` ⟹ `support.card = p`; `hgen` from `g ∈ zpowers a`, `map_zpow`.
+
+### KEY INSIGHT — Step 1 and Step 3 share the `|P| = p` kernel
+The hardest reusable sub-obligation is **`(p !).factorization p = 1`** (Legendre
+at the prime itself). Step 3 needs it for the |P|=p UPPER bound; Step 1
+(`sylow_p_unique`, the true blocker) needs the same fact for its step 5
+(`v_p(|H|) = 1 ⟹ |Q| = p`). It is proved self-contained in the companion as
+`padicValNat_factorial_self` via `Nat.Prime.factorization_factorial` +
+`Finset.sum_eq_single 1` (i=1 term = p/p = 1; i≥2 terms = 0 since p^i > p).
+**Recommendation:** extract a shared lemma `card_sylow_p_of_primitive : Nat.card ↥P = p`
+(Steps A+B above) once verified — it discharges Step 3's |P|=p and collapses a
+large chunk of Step 1 simultaneously.
+
+### Lemma-name confidence (verify on first build)
+Medium-confidence (?) names to check: `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`
+(Nat.card vs Fintype form), `Subgroup.card_subgroup_dvd_card`, `Fintype.card_perm`,
+`Nat.factorization_le_iff_dvd` (arg order / Finsupp `≤`), `isCyclic_of_prime_card`
+(Nat.card vs Fintype.card form — companion uses `Fintype.card`),
+`orderOf_eq_card_of_forall_mem_zpowers`, `Equiv.Perm.isCycle_of_prime_order`
+(name and whether it takes `orderOf σ = p` or `(orderOf σ).Prime`),
+`Nat.Prime.factorization_factorial`. High-confidence (★): the Step-5-shared
+idioms (`P.card_eq_multiplicity`, `Nat.Prime.factorization_pos_of_dvd`,
+`orderOf_injective`, `IsCycle.orderOf`, `map_zpow`, `Subgroup.mem_zpowers_iff`).

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -1,5 +1,21 @@
 # Current State
 
+> **S16 TURNKEY-DRAFT (researcher-5, 2026-06-16) — READ FIRST.**
+> Dual blackout persists (re-probed live): Aristotle `prove` 404; host
+> `proofs/.lake` is the self-referential symlink, so Mathlib oleans are
+> inaccessible host-wide and `docker-build.sh` would force a multi-GB
+> Mathlib re-clone (git-128) — local build UNAVAILABLE. No `.lean` change to
+> the registered (GREEN, 4-sorry) file. **Produced a turnkey ORPHAN companion**
+> `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean`
+> (NOT in `Proofs.lean`, outside the build gate) that discharges Step 3
+> `sylow_p_is_pcycle` — UNVERIFIED, fold into the registered stub after one
+> green build. Reduces Step 3 to the single number-theory lemma
+> `(p!).factorization p = 1` (proved in-file as `padicValNat_factorial_self`).
+> **KEY:** that same fact is the kernel of Step 1's hardest sub-step too —
+> extract a shared `Nat.card ↥P = p` lemma to collapse both. Full discharge
+> plan + lemma-name confidence table in knowledge.md §"S15 Step-3 discharge
+> plan". Frontier unchanged: 4 sorries (Steps 1/3/4 + main). Claim released.
+>
 > **DOCKER-REGRESSION RE-PROBE (researcher-1, 2026-06-16, S15) — READ FIRST.**
 > The S14 record below says "Docker recovered this session." That is now STALE:
 > Docker has regressed to DOWN. Re-probed live this cycle — `docker run --rm


### PR DESCRIPTION
## Summary
- **Dual blackout** this cycle: Aristotle MCP `prove`/`prove_file` return 404; the host-wide `proofs/.lake` is a self-referential symlink (`.lake -> .lake`), so Mathlib package oleans are inaccessible and `docker-build.sh` would force a multi-GB Mathlib re-clone (git-128). No local build was possible — **UNVERIFIED**.
- Adds a **turnkey ORPHAN companion** `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean` discharging Step 3 (`sylow_p_is_pcycle`) of the Galois-direction classification. It is **not** imported by `Proofs.lean`, so it sits outside any registered/CI build gate and cannot affect the green registered build.
- The proof reuses the verified Step-5 idioms (`P.card_eq_multiplicity`, `Nat.Prime.factorization_pos_of_dvd`, `orderOf_injective`, `IsCycle.orderOf`) and reduces Step 3 to a single self-contained number-theory lemma `padicValNat_factorial_self : (p!).factorization p = 1` (Legendre at the prime itself).
- **Key insight recorded:** that same `v_p(p!) = 1` fact is the kernel of Step 1's (`sylow_p_unique`, the true blocker) hardest sub-step. Extracting a shared `Nat.card ↥P = p` lemma would collapse Steps 1 and 3 together.
- `knowledge.md` gains an S15 discharge plan with a lemma-name confidence table; `state.md` gets an S16 status block.

## Next steps (build-backend recovery)
1. Build the orphan: `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3`.
2. Fix any medium-confidence lemma names flagged inline (`?`), iterate to green.
3. Fold the verified body into the registered `sylow_p_is_pcycle` (signatures match verbatim) and delete the orphan.

## Test plan
- [ ] Orphan companion builds green under Docker once `.lake`/Aristotle recover.
- [ ] Folded `sylow_p_is_pcycle` keeps the registered file green (sorry 4 → 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)