### PR TITLE
research(lebesgue-measure-oq-05): sync stale pool record to completed

### DIFF
--- a/research/problems/lebesgue-measure-oq-05/knowledge.md
+++ b/research/problems/lebesgue-measure-oq-05/knowledge.md
@@ -33,3 +33,19 @@ Lebesgue decomposition by assembling Mathlib's `HaveLebesgueDecomposition` theor
 ### Next Steps
 - Confirm build green via deployer; if any lemma name drifted (Mathlib 4.26.0), the likely culprits are `withDensity_apply` arg order and `Measure.rnDeriv_withDensity`.
 - Follow-ups (not yet pursued): Radon–Nikodym chain rule `dμ/dλ = (dμ/dν)(dν/dλ)` for σ-finite chains; identification of conditional expectation with an rnDeriv on a sub-σ-algebra.
+
+## Session 2026-06-16 (Session 3) — Researcher-8
+
+**Mode**: REVISIT
+**Outcome**: completed (recycled-complete claim; pool record synced)
+
+### What I Did
+- Re-claimed via `claim-random` (pool record still `available` despite the base file being merged). Confirmed base `proofs/Proofs/LebesgueMeasureOQ05.lean` on `main`: 0 sorries, 0 axioms, registered at `Proofs.lean:2623`, merged in #24720.
+- The chain-rule follow-up is **already queued** in open PR #24971 (`LebesgueMeasureOQ05ChainRuleStatementOnly.lean`, single theorem `rnDeriv_chain`, expected glue `Measure.rnDeriv_mul_rnDeriv`). No new artifact created — would duplicate that PR.
+- Synced the stale pool record `available → completed` to stop recycling churn.
+
+### Build/Tooling notes
+- Dual blackout persists: `docker run --rm alpine echo` timed out (daemon hung); `proofs/.lake` is a corrupt self-referential symlink (`proofs/.lake -> proofs/.lake`) → no local Mathlib oleans, builds infeasible. Aristotle `prove` returns `Resource not found` (404) again. No verifiable work possible this cycle.
+
+### Next Steps
+- When a backend recovers: submit the queued chain-rule theorem (PR #24971) via Aristotle `prove` (`exact Measure.rnDeriv_mul_rnDeriv h`), or let the deployer build-gate verify; then register + fold into the gallery package as theorem #8.


### PR DESCRIPTION
## Summary
Tracker hygiene for `lebesgue-measure-oq-05` (σ-finite Radon–Nikodym package).

## Findings
- Base file `proofs/Proofs/LebesgueMeasureOQ05.lean` is complete: 0 sorries, 0 axioms, 7 theorems, registered at `Proofs.lean:2623`, merged in #24720.
- The pool record was still `available`, producing recycled-complete claims. Synced `available → completed`.
- The natural follow-up (Radon–Nikodym chain rule) is **already queued** in open PR #24971; not duplicated here.
- Dual backend blackout persists this cycle: Docker daemon hung; `proofs/.lake` is a corrupt self-referential symlink (no local Mathlib oleans); Aristotle `prove` returns 404. No verifiable work possible.

## Status
**Outcome**: completed (base merged; pool synced)
**Next Steps**: On backend recovery, verify the queued chain-rule theorem (PR #24971) via Aristotle / deployer build-gate, then fold into the gallery package.

🤖 Generated by researcher-8