### PR TITLE
research(chebyshev-oq-04-oq-01-oq-01): queue weak-Mertens floor identity + persist frontier

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
@@ -1,0 +1,79 @@
+/-
+Harmonic `*StatementOnly.lean` Aristotle/batch-submission file
+(format from Loom #22468; docs at research/SORRY-CLASSIFICATION.md).
+
+Follow-up target for research problem `chebyshev-bounds-oq-04-oq-01-oq-01`
+(toward an elementary Selberg–Erdős proof of the Prime Number Theorem,
+ψ(n)/n → 1). The parent chain lives in:
+
+  - proofs/Proofs/ChebyshevBoundsOQ04.lean      (ψ-bounds; 2 deep PNT axioms)
+  - proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean  (Selberg Λ₂ scaffold; frozen,
+                                                 18 theorems, 0 sorries, 0 axioms,
+                                                 Iter 5a-β-1)
+
+`ChebyshevBoundsOQ04OQ01.lean` is explicitly frozen at Iter 5a-β-1 with the
+documented next step "Iter 5a-β-2: weak Mertens M₁ estimate". The keystone of
+that step is the classical **Möbius–floor identity**
+
+      Σ_{d=1}^{N} μ(d) · ⌊N/d⌋ = 1        (N ≥ 1)
+
+from which the weak Mertens bound |M₁(N)| = |Σ_{d≤N} μ(d)/d| ≤ 1 follows by
+separating ⌊N/d⌋ = N/d − {N/d}. This file queues the integer-valued floor
+identity (the harder, reusable half) as a single batch target.
+
+Math (why it is true and elementary):
+  Σ_{d≤N} μ(d)⌊N/d⌋
+    = Σ_{d≤N} μ(d) · #{m ≥ 1 : d·m ≤ N}          (⌊N/d⌋ counts multiples of d)
+    = Σ_{d·m ≤ N} μ(d)                            (Fubini over the region d·m ≤ N)
+    = Σ_{n=1}^{N} Σ_{d ∣ n} μ(d)                  (reindex by n = d·m)
+    = Σ_{n=1}^{N} [n = 1]                         (Σ_{d∣n} μ(d) = δ_{n,1})
+    = 1.
+
+Expected Mathlib glue: `ArithmeticFunction.moebius`, the identity
+`ArithmeticFunction.coe_moebius_mul_coe_zeta` (μ ∗ ζ = δ, i.e.
+Σ_{d∣n} μ(d) = if n = 1 then 1 else 0 via `ArithmeticFunction.sum_moebius_...`),
+and a hyperbola/Fubini reindexing of `Finset.Icc 1 N` against the divisor sum.
+The proof requires only tactical search + bookkeeping (no creative insight),
+which is the HARD-but-known classification suited to automated search.
+
+Citations:
+- Selberg, "An elementary proof of the prime-number theorem", Ann. of Math.
+  50 (1949), 305–313.
+- Tenenbaum, "Introduction to analytic and probabilistic number theory"
+  (3rd ed., 2015), §I.3 (Möbius) and §I.6 (Selberg).
+- Apostol, "Introduction to Analytic Number Theory", Theorem 3.10.
+
+Answer: `∑ d ∈ Finset.Icc 1 N, μ d * (↑(N / d) : ℤ) = 1`.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 1000000
+set_option maxRecDepth 4000
+set_option autoImplicit false
+set_option linter.all false
+
+open scoped BigOperators
+open ArithmeticFunction
+
+namespace ChebyshevBoundsOQ04OQ01OQ01WeakMertens
+
+/--
+**Möbius–floor identity.** For every `N ≥ 1`,
+
+    Σ_{d=1}^{N} μ(d) · ⌊N/d⌋ = 1.
+
+Here `N / d` is `Nat` division, i.e. the floor `⌊N/d⌋`, and `μ` is the Möbius
+function (`ArithmeticFunction.moebius`, ℤ-valued). This is the keystone for the
+weak Mertens bound `|Σ_{d≤N} μ(d)/d| ≤ 1` (Iter 5a-β-2 of the Selberg–Erdős
+elementary-PNT roadmap in `ChebyshevBoundsOQ04OQ01.lean`).
+
+Proof idea: `⌊N/d⌋ = #{m ≥ 1 : d·m ≤ N}`, so the sum reindexes (Fubini /
+hyperbola method) to `Σ_{n=1}^{N} Σ_{d ∣ n} μ(d) = Σ_{n=1}^{N} [n = 1] = 1`,
+using `Σ_{d ∣ n} μ(d) = δ_{n,1}` (`μ ∗ ζ = δ`).
+-/
+theorem moebius_mul_floor_sum_eq_one (N : ℕ) (hN : 1 ≤ N) :
+    ∑ d ∈ Finset.Icc 1 N, μ d * (↑(N / d) : ℤ) = 1 := by
+  sorry
+
+end ChebyshevBoundsOQ04OQ01OQ01WeakMertens

--- a/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
@@ -1,0 +1,75 @@
+# chebyshev-bounds-oq-04-oq-01-oq-01 — Elementary PNT (Selberg–Erdős), Iter 5a-β-2
+
+## Summary
+
+Remove the axiom `chebyshevPsi_asymptotic` (ψ(n)/n → 1) from
+`proofs/Proofs/ChebyshevBoundsOQ04.lean` by completing the elementary
+Selberg–Erdős (1949) proof of the Prime Number Theorem.
+
+## Grounded state of the chain (on `main`)
+
+| File | sorries | axioms | role |
+|------|---------|--------|------|
+| `ChebyshevBoundsOQ04.lean` | 0 | **2** | ψ-bounds; carries `chebyshevPsi_asymptotic` (= PNT) and `pnt_equivalence` |
+| `ChebyshevBoundsOQ04Aristotle.lean` | 0 | 0 | routine supporting lemmas |
+| `ChebyshevBoundsOQ04OQ01.lean` | 0 | 0 | Selberg Λ₂ scaffold; **frozen at Iter 5a-β-1**, 18 theorems |
+
+The two parent axioms are **deep** (not provable from Mathlib v4.26.0):
+- `chebyshevPsi_asymptotic` IS the PNT for ψ; Mathlib core does not yet contain
+  a full PNT (it lives in the separate PrimeNumberTheoremAnd project).
+- `pnt_equivalence` (ψ~n ↔ π~n/log n) is the standard partial-summation
+  equivalence — substantial but more tractable than the PNT itself.
+
+`ChebyshevBoundsOQ04OQ01.lean` already proves Selberg's dual identity
+`Σ_{d∣n} Λ₂(d) = (log n)²` and its Möbius-inverse form, plus routine Λ₂ lemmas
+and the trivial Mertens bound `|M(N)| ≤ N`. Its documented next step is
+**Iter 5a-β-2: the weak Mertens M₁ estimate** `|Σ_{d≤N} μ(d)/d| ≤ 1`.
+
+## This session (2026-06-16, Researcher-8) — ORIENT, dual blackout
+
+**Outcome**: progress (queued one verifiable target + persisted frontier).
+
+Dual backend blackout: `docker run` hung (daemon down / 124), `proofs/.lake` is
+a corrupt self-referential symlink (no local Mathlib oleans → builds infeasible),
+and Aristotle `prove` returns 404. No verification possible this cycle.
+
+### Keystone identified for Iter 5a-β-2
+
+The cleanest entry point to the weak Mertens bound is the **Möbius–floor
+identity** (integer-valued, fully elementary, reusable):
+
+    Σ_{d=1}^{N} μ(d) · ⌊N/d⌋ = 1        (N ≥ 1)
+
+From it, `|M₁(N)| ≤ 1` follows by writing `⌊N/d⌋ = N/d − {N/d}`:
+`N·M₁(N) − Σ_{d≤N} μ(d){N/d} = 1`, and `|Σ μ(d){N/d}| ≤ N − 1`, so
+`|N·M₁(N) − 1| ≤ N − 1`, giving `|M₁(N)| ≤ 1`.
+
+**Why the floor identity is true (elementary):**
+`⌊N/d⌋ = #{m ≥ 1 : d·m ≤ N}`, so the double sum reindexes (Fubini / hyperbola)
+to `Σ_{n=1}^{N} Σ_{d∣n} μ(d) = Σ_{n=1}^{N} [n=1] = 1`, using `μ ∗ ζ = δ`.
+
+### Queued artifact
+
+`proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean`
+— single theorem `moebius_mul_floor_sum_eq_one` (integer form), unregistered
+orphan (NOT in `Proofs.lean`, so CI-safe), ready for the batch pipeline /
+Aristotle `prove` once a backend recovers. Expected glue:
+`ArithmeticFunction.moebius`, `coe_moebius_mul_coe_zeta` (μ ∗ ζ = δ), and a
+`Finset.Icc 1 N` hyperbola reindexing.
+
+### Mathlib search to do on recovery (could not grep — `.lake` corrupt)
+
+- Does Mathlib already have `Σ_{d≤N} μ(d)⌊N/d⌋ = 1`? Search
+  `ArithmeticFunction.sum_moebius_mul`, `Nat.sum_div`, hyperbola lemmas.
+- Möbius indicator: `ArithmeticFunction.sum_moebius_eq_...` /
+  `coe_moebius_mul_coe_zeta` for `Σ_{d∣n} μ(d) = δ_{n,1}`.
+
+### Next Steps
+
+1. On backend recovery: submit
+   `ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean` via Aristotle
+   `prove` / batch; integrate.
+2. Derive `|M₁(N)| ≤ 1` from the floor identity (fractional-part split).
+3. Then Selberg's symmetry formula `S₂(N) = 2N·log N + O(N)` (Iter 5b), the
+   Tauberian self-reference, and Erdős's combinatorial lemma (Iter 5c–5d).
+4. Do NOT add new axioms; do NOT touch the frozen `ChebyshevBoundsOQ04OQ01.lean`.


### PR DESCRIPTION
## Summary
Forward step on the Selberg–Erdős elementary-PNT chain (`chebyshev-bounds-oq-04-oq-01-oq-01`), under dual backend blackout.

## Findings
- Chain state on `main`: `ChebyshevBoundsOQ04.lean` (0 sorries, **2 deep axioms** — `chebyshevPsi_asymptotic` = PNT, `pnt_equivalence`); `ChebyshevBoundsOQ04OQ01.lean` (Selberg Λ₂ scaffold, **frozen** at Iter 5a-β-1, 18 theorems, 0/0).
- The frozen scaffold's documented next step is the **weak Mertens M₁ estimate** `|Σ_{d≤N} μ(d)/d| ≤ 1`. Its keystone is the elementary **Möbius–floor identity** `Σ_{d≤N} μ(d)⌊N/d⌋ = 1`.

## Changes
- `proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean` — single-theorem batch/Aristotle target `moebius_mul_floor_sum_eq_one` (integer form). **Unregistered orphan** (not in `Proofs.lean`) → CI-safe.
- `research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md` — persists the grounded chain state + roadmap (this slug had no tracker dir on `main`; prior agents' plans were lost each cycle).

## Status
**Outcome**: progress (verifiable target queued, frontier persisted; no verified content this cycle)
**Blackout**: Docker daemon hung; `proofs/.lake` corrupt self-referential symlink; Aristotle `prove` 404.
**Next Steps**: on backend recovery, prove the floor identity (`μ ∗ ζ = δ` + hyperbola reindex), derive `|M₁(N)| ≤ 1`, then Selberg symmetry formula (Iter 5b). Parent axioms are deep PNT (not in Mathlib v4.26.0) — leave untouched.

🤖 Generated by researcher-8