### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-04): genuine multinomial mean E[Xi]=n*pi (build-pending)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01.lean
@@ -174,14 +174,87 @@ theorem fair_coin_three_flips :
   simp [Finset.sum_pair Bool.false_ne_true]
   norm_num
 
-/-- **Multinomial theorem gives expected value structure**: For any function w,
-the weighted sum ∑ P(k) · w(k) can be expressed via the multinomial theorem.
-This is the general expectation formula E[w(X)] for multinomial X. -/
-theorem multinomial_expectation {α : Type*} [DecidableEq α]
+/-- **Multinomial coordinate mean**: `E[Xᵢ] = n · pᵢ`. Concretely, the weighted sum over
+all compositions `k` (with `∑ⱼ kⱼ = n`) of the probability `P(k) = multinomialProb s p n k`
+times the count `k i` equals `n · pᵢ`. We show this equals `n · pᵢ`.
+
+The proof differentiates the moment-generating function. Taking the weight function
+`g j = exp t` for `j = i` and `g j = 1` otherwise, `multinomial_mgf_real` yields, for
+every `t`,
+
+  `(pᵢ · exp t + (1 - pᵢ))ⁿ = ∑ₖ P(k) · exp(t · kᵢ)`.
+
+Both sides are functions of `t` that agree everywhere. The left-hand side has derivative
+`n · pᵢ` at `t = 0` (the inner function has value `1` and derivative `pᵢ` there); the
+right-hand side, being a finite sum, has derivative `∑ₖ P(k) · kᵢ = E[Xᵢ]`. Uniqueness of
+the derivative forces the two to be equal. This replaces the former placeholder, which
+restated a reflexive tautology, with a genuine moment formula. -/
+theorem multinomial_mean {α : Type*} [DecidableEq α]
     (s : Finset α) (p : α → ℝ) (n : ℕ) (hp : ∑ i ∈ s, p i = 1)
-    (w : (α → ℕ) → ℝ) :
-    ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * w k =
-    ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * w k := rfl
+    (i : α) (hi : i ∈ s) :
+    ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * (k i : ℝ) = n * p i := by
+  -- Step 1: ∑ⱼ pⱼ · (if j = i then exp t else 1) = pᵢ · exp t + (1 - pᵢ).
+  have hsum : ∀ t : ℝ,
+      ∑ j ∈ s, p j * (if j = i then Real.exp t else 1)
+        = p i * Real.exp t + (1 - p i) := by
+    intro t
+    have hrw : ∀ j ∈ s, p j * (if j = i then Real.exp t else 1)
+        = p j + (if j = i then p j * (Real.exp t - 1) else 0) := by
+      intro j _; split <;> ring
+    rw [Finset.sum_congr rfl hrw, Finset.sum_add_distrib, hp,
+      Finset.sum_ite_eq' s i (fun j => p j * (Real.exp t - 1)), if_pos hi]
+    ring
+  -- Step 2: ∏ⱼ (if j = i then exp t else 1) ^ kⱼ = exp(t · kᵢ).
+  have hprod : ∀ (t : ℝ) (k : α → ℕ),
+      ∏ j ∈ s, (if j = i then Real.exp t else 1) ^ k j = Real.exp (t * k i) := by
+    intro t k
+    have hrw : ∀ j ∈ s, (if j = i then Real.exp t else 1) ^ k j
+        = (if j = i then Real.exp (t * k i) else 1) := by
+      intro j _
+      split with h
+      · subst h; rw [← Real.exp_nat_mul, mul_comm]
+      · exact one_pow _
+    rw [Finset.prod_congr rfl hrw,
+      Finset.prod_ite_eq' s i (fun _ => Real.exp (t * k i)), if_pos hi]
+  -- Step 3: the MGF identity, as an equality of functions of t.
+  have hMGF : ∀ t : ℝ,
+      (p i * Real.exp t + (1 - p i)) ^ n
+        = ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * Real.exp (t * k i) := by
+    intro t
+    calc (p i * Real.exp t + (1 - p i)) ^ n
+        = (∑ j ∈ s, p j * (if j = i then Real.exp t else 1)) ^ n := by rw [hsum t]
+      _ = ∑ k ∈ s.piAntidiag n, multinomialProb s p n k
+            * ∏ j ∈ s, (if j = i then Real.exp t else 1) ^ k j :=
+          multinomial_mgf_real s p (fun j => if j = i then Real.exp t else 1) n
+      _ = ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * Real.exp (t * k i) :=
+          Finset.sum_congr rfl (fun k _ => by rw [hprod t k])
+  -- Step 4: differentiate the left-hand side; derivative is n · pᵢ at t = 0.
+  have hL : HasDerivAt (fun t : ℝ => (p i * Real.exp t + (1 - p i)) ^ n)
+      ((n : ℝ) * p i) 0 := by
+    have hbase : HasDerivAt (fun t : ℝ => p i * Real.exp t + (1 - p i)) (p i) 0 := by
+      simpa using ((Real.hasDerivAt_exp (0 : ℝ)).const_mul (p i)).add_const (1 - p i)
+    have hpow := hbase.pow n
+    convert hpow using 1
+    simp only [Real.exp_zero, mul_one]
+    rw [show p i + (1 - p i) = (1 : ℝ) by ring, one_pow, mul_one]
+  -- Step 5: differentiate the right-hand side; derivative is the target sum.
+  have hR : HasDerivAt
+      (fun t : ℝ => ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * Real.exp (t * k i))
+      (∑ k ∈ s.piAntidiag n, multinomialProb s p n k * (k i : ℝ)) 0 := by
+    apply HasDerivAt.sum
+    intro k _
+    have hinner : HasDerivAt (fun t : ℝ => Real.exp (t * (k i : ℝ))) ((k i : ℝ)) 0 := by
+      have hmul : HasDerivAt (fun t : ℝ => t * (k i : ℝ)) ((k i : ℝ)) 0 := by
+        simpa using (hasDerivAt_id (0 : ℝ)).mul_const ((k i : ℝ))
+      have hc := (Real.hasDerivAt_exp ((0 : ℝ) * (k i : ℝ))).comp 0 hmul
+      simpa using hc
+    simpa [mul_comm] using hinner.const_mul (multinomialProb s p n k)
+  -- Step 6: equate the two derivatives.
+  have hfun : (fun t : ℝ => (p i * Real.exp t + (1 - p i)) ^ n)
+      = fun t : ℝ => ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * Real.exp (t * k i) :=
+    funext hMGF
+  rw [hfun] at hL
+  exact (hL.unique hR).symm
 
 /-! ## Part 7: Power Sum Identity (Mean Derivation) -/
 

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/annotations.json
@@ -145,18 +145,18 @@
     "proofId": "binomial-theorem-oq-02-oq-01",
     "range": {
       "startLine": 164,
-      "endLine": 184
+      "endLine": 258
     },
     "type": "context",
-    "title": "Concrete Sanity Check and a Vacuous Expectation Stub",
-    "content": "`fair_coin_three_flips` (lines 169–175) is a closed numerical instance: three flips of a $1/2$-coin sum to $1$ over the four outcomes $(3,0),(2,1),(1,2),(0,3)$ with probabilities $\\tfrac18,\\tfrac38,\\tfrac38,\\tfrac18$, closed by `norm_num` after expanding the pair sum. Note that `multinomial_expectation` (lines 180–184) is proved by `rfl` — its statement is the tautology $\\sum_k P(k)\\,w(k) = \\sum_k P(k)\\,w(k)$, so despite the docstring's framing as 'the general expectation formula $E[w(X)]$' it asserts nothing and uses no probabilistic content. It is a placeholder marking where a substantive expectation/moment result (e.g. $E[X_i] = n p_i$) would go.",
-    "mathContext": "A genuine mean derivation would differentiate the MGF: $E[X_i] = \\partial_{t_i} M(t)\\big|_{t=0} = n p_i$, and the covariance $\\mathrm{Cov}(X_i,X_j) = -n p_i p_j$ for $i \\neq j$, $\\mathrm{Var}(X_i) = n p_i(1-p_i)$. None of these are established here; `multinomial_expectation` only restates a reflexive equality. The fair-coin check, by contrast, is a real (if elementary) verification that the abstract normalization specializes correctly to numbers.",
+    "title": "Concrete Sanity Check and the Coordinate Mean",
+    "content": "`fair_coin_three_flips` is a closed numerical instance: three flips of a $1/2$-coin sum to $1$ over the four outcomes $(3,0),(2,1),(1,2),(0,3)$ with probabilities $\\tfrac18,\\tfrac38,\\tfrac38,\\tfrac18$, closed by `norm_num` after expanding the pair sum. The former `rfl` placeholder `multinomial_expectation` (which restated the tautology $\\sum_k P(k)\\,w(k) = \\sum_k P(k)\\,w(k)$) has been replaced by `multinomial_mean`, a genuine moment formula: $\\sum_k P(k)\\,k_i = n\\,p_i$, i.e. $E[X_i] = n p_i$.",
+    "mathContext": "`multinomial_mean` is proved by differentiating the MGF. Specializing the weight $g_j = e^t$ for $j=i$ and $g_j = 1$ otherwise reduces `multinomial_mgf_real` to the one-variable identity $(p_i e^t + (1-p_i))^n = \\sum_k P(k)\\,e^{t k_i}$ for all $t$; differentiating both sides at $t=0$ and applying uniqueness of the derivative ($\\partial_t\\,\\text{LHS}|_0 = n p_i$, $\\partial_t\\,\\text{RHS}|_0 = \\sum_k P(k)\\,k_i$) yields $E[X_i] = n p_i$. The natural follow-ups via second MGF derivatives are $\\mathrm{Var}(X_i) = n p_i(1-p_i)$ and $\\mathrm{Cov}(X_i,X_j) = -n p_i p_j$ for $i\\neq j$.",
     "significance": "technical",
     "relatedConcepts": [
       "norm_num",
       "expected value",
-      "reflexivity (rfl)",
-      "placeholder theorem"
+      "moment-generating function",
+      "HasDerivAt.unique"
     ],
     "prerequisites": [
       "multinomialProb_sum_eq_one",
@@ -167,8 +167,8 @@
     "id": "ann-multinom-count",
     "proofId": "binomial-theorem-oq-02-oq-01",
     "range": {
-      "startLine": 195,
-      "endLine": 222
+      "startLine": 259,
+      "endLine": 294
     },
     "type": "concept",
     "title": "multinomial_count: |s|^n = ∑ Multinomial Coefficients",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -81,14 +81,14 @@
       "id": "examples",
       "title": "Concrete Calculations",
       "startLine": 164,
-      "endLine": 184,
-      "summary": "A fair-coin numerical sanity check (3 flips sum to 1) plus multinomial_expectation, a rfl placeholder that restates a tautology rather than proving a real expectation formula."
+      "endLine": 258,
+      "summary": "A fair-coin numerical sanity check (3 flips sum to 1) plus multinomial_mean, a genuine moment formula E[Xi] = n·pi derived by differentiating the MGF at t=0 (replacing the former rfl placeholder)."
     },
     {
       "id": "counting",
       "title": "Counting Identity (Multinomial Analog of ∑C(n,k)=2ⁿ)",
-      "startLine": 186,
-      "endLine": 199,
+      "startLine": 259,
+      "endLine": 294,
       "summary": "Specializes the multinomial theorem at f(i)=1 to prove |s|ⁿ = ∑ multinomial(s,k), generalizing the sum of binomial coefficients."
     }
   ],
@@ -99,7 +99,7 @@
       "RESOLVED: Multinomial PMF integrated with Mathlib PMF framework in BinomialTheoremOQ02OQ01OQ01.lean — construction via Composition type + ENNReal normalization",
       "Can marginal distributions be formally derived as binomials?",
       "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?",
-      "The current `multinomial_expectation` theorem is a vacuous `rfl` (it restates ∑ P(k)·w(k) = ∑ P(k)·w(k)). Can a substantive mean E[Xi] = n·pi be derived by differentiating the MGF (∑ pj·e^{tj})^n at t = 0, giving a genuine moment formula rather than a tautology?"
+      "RESOLVED: `multinomial_mean` now proves E[Xi] = n·pi by differentiating the MGF (∑ pj·e^{tj})^n at t = 0 (specializing multinomial_mgf_real to g_j = if j=i then e^t else 1, then HasDerivAt.unique), replacing the former vacuous `rfl` placeholder. Open follow-up: variance Var(Xi) = n·pi·(1-pi) and covariance Cov(Xi,Xj) = -n·pi·pj via second MGF derivatives."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary
Replaces the vacuous `rfl` placeholder `multinomial_expectation` in `proofs/Proofs/BinomialTheoremOQ02OQ01.lean` with **`multinomial_mean`**, a genuine moment formula:

  `∑_k multinomialProb s p n k · (k i) = n · p_i`   (i.e. `E[X_i] = n·p_i`)

The placeholder restated the tautology `∑ P(k)·w(k) = ∑ P(k)·w(k)` and asserted nothing; its own gallery annotations flagged it as a stub.

## Proof
Differentiates the moment-generating function. Specialize the already-proven file lemma `multinomial_mgf_real` to the weight `g_j = if j=i then exp t else 1`, which collapses (via `Finset.sum_ite_eq'` / `Finset.prod_ite_eq'` + `Real.exp_nat_mul`) to the one-variable identity `(p_i·exp t + (1-p_i))^n = ∑_k P(k)·exp(t·k_i)` for all `t`. Differentiating both sides at `t=0` gives LHS' = `n·p_i` (`HasDerivAt.pow`) and RHS' = `∑_k P(k)·k_i` (`HasDerivAt.sum`); `HasDerivAt.unique` closes the goal. 0 sorries, 0 axioms.

Also syncs the parent `annotations.json` / `meta.json` (placeholder → proven mean; shifted line ranges) and records variance/covariance follow-ups.

## BUILD-PENDING / verification status
Local verification was NOT possible this session: Docker build blocked by the corrupt `proofs/.lake` self-symlink and Aristotle backend 404. Math is elementary and lemma names are standard Mathlib, but the deployer build gate is the verification step — please confirm a green build of `Proofs.BinomialTheoremOQ02OQ01` before merge.

Context: original proof authored in a prior session but lost when a concurrent agent reverted main's uncommitted working tree; this PR rescues it.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01` green
- [ ] `pnpm build` (gallery) succeeds with updated annotations/meta