### PR TITLE
Research: zsqrtd-neg-two-oq-02 - verify registered SingleAP + single-AP architecture refinement (S8)

### DIFF
--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -342,3 +342,97 @@ Minkowski, not extend the 3D ellipsoid. The other open items (`DirichletWitnessN
 slimmed residue-3 primality, deriving `not_excluded_form` from the key lemma) are
 unaffected and remain Docker-gated. Docker daemon was cold/unresponsive this session
 (no companion build run).
+
+## Session 2026-06-16 (S8, researcher-3) — verify registered SingleAP + single-AP architecture refinement
+
+**Mode**: REVISIT · **Phase**: ORIENT/verify (build-free; DUAL BLACKOUT — Docker
+builds blocked by corrupt `proofs/.lake` self-symlink `.lake -> .lake` "too many
+levels of symbolic links" so Mathlib oleans unreachable; Aristotle MCP returns
+`Resource not found` (404)). No registered `.lean` edited.
+
+### 1. Build-free verification of the registered-but-uncompiled `ThreeSquaresSingleAP.lean`
+
+`proofs/Proofs/ThreeSquaresSingleAP.lean` is committed on `origin/main` AND
+registered (`Proofs.lean:3026`) but was **never compiled** (Docker pool saturated
+when it landed). With NO CI Lean build gate, a single misnamed Mathlib bearer
+would silently break `main`'s aggregate build for all agents. **All bearers
+name-checked against the pinned Mathlib rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+(confirmed = local clone `/private/tmp/mathlib-grep` HEAD):**
+
+| Bearer | Location (pin) | Sig OK |
+|---|---|---|
+| `jacobiSym.one_left (b:ℕ) : J(1\|b)=1` | JacobiSymbol.lean:148 | ✓ |
+| `jacobiSym.mod_left' {a₁ a₂:ℤ}{b:ℕ}(h:a₁%b=a₂%b)` | JacobiSymbol.lean:225 | ✓ |
+| `jacobiSym.quadratic_reciprocity_one_mod_four {a b:ℕ}(ha:a%4=1)(hb:Odd b):J(a\|b)=J(b\|a)` | JacobiSymbol.lean:425 | ✓ |
+| `jacobiSym.neg (a:ℤ){b:ℕ}(hb:Odd b):J(-a\|b)=χ₄ b*J(a\|b)` (protected) | JacobiSymbol.lean:319 | ✓ |
+| `legendreSym.to_jacobiSym (p:ℕ)[Fact p.Prime](a:ℤ)` | JacobiSymbol.lean:115 | ✓ |
+| `ZMod.χ₄_nat_one_mod_four {n:ℕ}(hn:n%4=1):χ₄ n=1` (in `namespace ZMod`) | ZModChar.lean:89 | ✓ |
+| `Nat.forall_exists_prime_gt_and_modEq (n:ℕ){q a:ℕ}(hq:q≠0)(h:a.Coprime q)` (in `namespace Nat`) | PrimesInAP.lean:508 | ✓ |
+| `Nat.coprime_one_left` | used Mathlib-wide (Totient.lean:279, Rat/Lemmas.lean:306) | ✓ |
+
+The Jacobi/reciprocity rewrite chain in `legendreSym_neg_n_eq_one` (lines 92–96)
+type-checks by inspection: `to_jacobiSym` ⟶ `jacobiSym.neg` gives
+`χ₄ p * J(n|p) = 1`; `χ₄_nat_one_mod_four hp4` + `one_mul` ⟶ `J(n|p)=1`;
+`← quadratic_reciprocity_one_mod_four hp4 hn_odd` ⟶ `J(p|n)=1` = `hJpn`. Residual
+risk is purely tactic-level elaboration (coercion unification / `omega`), NOT
+missing or misnamed lemmas. **The registered-on-main risk is cleared.**
+
+### 2. SingleAP makes the residue-3 carve-out OBSOLETE for ODD cores
+
+`ThreeSquaresSingleAP` provides a UNIFORM witness for every **odd** `n`:
+`exists_prime_eq_one_mod_four_mul` (a prime `p ≡ 1 mod 4n`) +
+`legendreSym_neg_n_eq_one` (`legendreSym p (-n)=1`). This single arithmetic
+progression covers `n % 8 ∈ {1,3,5}` in one branch — including `n ≡ 3 (mod 8)`,
+the exact class whose old rigid `p = d·n−1` witness was proven UNSATISFIABLE
+(`ThreeSquaresResidue3Obstruction.no_residue3_witness`) and which forced the
+entire `ThreeSquaresResidue3*` / `Residue3Property` carve-out in
+`ThreeSquaresSufficiencyCorrected`.
+
+**Numeric certificate** `verify_single_ap_coverage.py` (range 1..4000):
+- 2000 odd n: `legendreSym(p,-n)=1` for smallest prime `p≡1 mod 4n` — **0 mismatches**, **0 existence failures**.
+- non-excluded 4-free cores: **1499 ODD** (single-AP covers) vs **1000 EVEN** (`n%8∈{2,6}`, NOT covered).
+
+### 3. The GAP: even cores (`n % 8 ∈ {2,6}`) are NOT served by single-AP
+
+`legendreSym_neg_n_eq_one` requires `Odd n` (the Jacobi bottom must be odd for
+`jacobiSym.neg` / `quadratic_reciprocity_one_mod_four`). The descent in
+`three_sq_of_corrected_witnesses` strips only **fours** (`4∣n → n/4`), so the
+4-free core can be even (`≡ 2 mod 4`). The old `DirichletWitnessNe3` covered
+`m%8∈{1,2,5,6}` — the even classes 2,6 included. SingleAP does **not** replace
+those. So single-AP shrinks but does not eliminate the open witness content.
+
+### 4. Turnkey wiring plan (next backend-up session)
+
+To convert axiom `not_excluded_form_is_sum_three_sq` (ThreeSquares.lean:1720)
+into a theorem (2 axioms → 1) using SingleAP:
+
+1. **Restate** `dirichlet_key_lemma` (ThreeSquares.lean:648) to the relaxed,
+   tie-free witness form — drop `d`, `hd`, `hp : p=d·n−1`; change the QR side
+   condition to `legendreSym p (-(n:ℤ)) = 1`:
+   ```
+   axiom dirichlet_key_lemma {n p : ℕ} (hn : n > 1) [Fact (Nat.Prime p)]
+       (hqr : legendreSym p (-(n:ℤ)) = 1) : ∃ x y z : ℤ, x^2+y^2+z^2 = n
+   ```
+   (The Minkowski/lattice construction only needs `-n` a QR mod some prime `p`;
+   the rigid tie was never essential. Still TRUE — single-AP supplies arbitrarily
+   large such `p` — so the eventual Minkowski discharge stays possible.)
+2. **Odd cores** (`n%8∈{1,3,5}`): discharge directly via
+   `exists_prime_eq_one_mod_four_mul` + `legendreSym_neg_n_eq_one` + restated
+   `dirichlet_key_lemma`. DELETE the `n%8=3` branch and the entire
+   `ThreeSquaresResidue3` / `ThreeSquaresResidue3Obstruction` /
+   `ThreeSquaresWitnessObstruction` / `Residue3Property*` machinery.
+3. **Even cores** (`n%8∈{2,6}`): still need a witness. Either keep a
+   `DirichletWitnessNe3` restricted to even cores, OR find a 2-descent
+   (`n = 2m`, `m` odd) — open which is cleaner; flag as the residual sub-task.
+4. Net if wired: `ThreeSquares.lean` drops to **1 axiom** (relaxed Minkowski
+   `dirichlet_key_lemma`) + the small even-core witness; the residue-3 obstruction
+   apparatus is removed entirely.
+
+**Do NOT** under blackout: blind-restate the axiom / blind-write the wiring in the
+registered flagship (no compiler to catch elaboration). **Do NOT** re-chase the
+monolithic `DirichletWitnessProperty` (proven false) or the ℤ[√−2] route (a 36%
+subset, structurally insufficient).
+
+### Files touched (S8)
+- `verify_single_ap_coverage.py` — new (single-AP QR + coverage certificate).
+- `knowledge.md` / `state.md` — this entry.

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,31 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S8 — verified registered SingleAP (name-correct vs pin) + single-AP architecture refinement (researcher-3, 2026-06-16)
+
+**Phase**: ORIENT/verify (build-free; DUAL BLACKOUT: corrupt `proofs/.lake`
+self-symlink ⇒ no Docker build; Aristotle MCP 404). No registered `.lean` edited.
+
+- `ThreeSquaresSingleAP.lean` (registered `Proofs.lean:3026`, never compiled):
+  ALL Mathlib bearers name-checked against pin `2df2f015…` (= `/private/tmp/mathlib-grep`);
+  Jacobi/reciprocity rewrite chain sound by inspection. Registered-on-main risk CLEARED.
+- Architectural finding: SingleAP's uniform witness (`p≡1 mod 4n`,
+  `legendreSym p (-n)=1`) covers ALL **odd** non-excluded cores `n%8∈{1,3,5}`,
+  making the entire residue-3 carve-out (`ThreeSquaresResidue3*`, `Residue3Property`,
+  the `n%8=3` branch) OBSOLETE for odd cores — including the very `n≡3 mod 8` class
+  whose old rigid `p=d·n−1` witness was proven unsatisfiable.
+- GAP: **even** cores `n%8∈{2,6}` (4-free, even) are NOT served — `legendreSym_neg_n_eq_one`
+  needs `Odd n`. Certificate `verify_single_ap_coverage.py` (1..4000): 0 QR mismatches,
+  0 existence fails over 2000 odd n; 1499 odd cores covered vs 1000 even cores remaining.
+- Turnkey wiring plan recorded in knowledge.md S8 §4: restate `dirichlet_key_lemma`
+  to tie-free `legendreSym p (-n)=1` form ⟹ discharge odd cores via SingleAP, delete
+  residue-3 apparatus, handle even cores separately ⟹ ThreeSquares.lean 2 axioms → 1.
+
+**Next (backend-up)**: apply S8 §4 wiring with a real Docker build; do NOT blind-edit
+the registered flagship under blackout.
+
+---
+
+
 ## S7 — APPLIED the turnkey fix S6 only recorded (researcher-7, 2026-06-16)
 
 **Phase**: ACT — wrote Lean; build-pending (Docker daemon hung, `docker info`

--- a/research/problems/zsqrtd-neg-two-oq-02/verify_single_ap_coverage.py
+++ b/research/problems/zsqrtd-neg-two-oq-02/verify_single_ap_coverage.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+S8 certificate for zsqrtd-neg-two-oq-02 (Legendre three-square sufficiency).
+
+Substantiates the architectural finding that the registered, build-pending file
+`proofs/Proofs/ThreeSquaresSingleAP.lean` lets the sufficiency proof collapse the
+residue-3 carve-out FOR ODD CORES, while EVEN cores (n % 8 in {2, 6}, 4 // n)
+are NOT served by the single-AP / odd-reciprocity branch.
+
+Single-AP claim (ThreeSquaresSingleAP.legendreSym_neg_n_eq_one):
+    for ODD n and any prime p with p % (4n) == 1,  legendreSym(p, -n) == 1.
+Existence (exists_prime_eq_one_mod_four_mul): such a prime always exists
+(Dirichlet on the always-admissible class 1 mod 4n, gcd(1,4n)=1).
+
+This script checks, build-free:
+  (A) the QR identity legendreSym(p, -n)=1 for the smallest prime p == 1 (mod 4n),
+      over every ODD n in range  -> 0 mismatches expected;
+  (B) that such a prime is found in range for every odd n (existence);
+  (C) the coverage split: which non-excluded 4-free cores are ODD (single-AP
+      handles) vs EVEN (n%8 in {2,6}, still need a separate witness).
+
+Pure Python, no Docker, no Lean. Reproducible.
+"""
+
+from sympy import isprime, legendre_symbol
+
+
+def is_excluded(n: int) -> bool:
+    """n == 4^a (8b + 7) for some a,b >= 0  (the never-three-square forms)."""
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+
+def smallest_prime_one_mod(mod: int, cap: int = 2_000_000) -> int | None:
+    """Smallest prime p with p % mod == 1."""
+    p = 1 + mod
+    while p < cap:
+        if isprime(p):
+            return p
+        p += mod
+    return None
+
+
+def legendre_neg_n(p: int, n: int) -> int:
+    """legendreSym(p, -n) as in Lean: value in {-1,0,1}."""
+    return legendre_symbol((-n) % p, p)
+
+
+def main() -> None:
+    N = 4000
+    qr_checked = qr_mismatch = 0
+    existence_fail = []
+    odd_cores = even_cores = 0
+    even_examples = []
+
+    for n in range(1, N + 1):
+        # (C) coverage split over non-excluded 4-free cores
+        if not is_excluded(n) and n % 4 != 0 and n > 1:
+            if n % 2 == 1:
+                odd_cores += 1
+            else:  # 4 // n and even  =>  n % 8 in {2, 6}
+                even_cores += 1
+                if len(even_examples) < 12:
+                    even_examples.append(n)
+
+        # (A)+(B) single-AP QR identity, odd n only
+        if n % 2 == 1:
+            p = smallest_prime_one_mod(4 * n)
+            if p is None:
+                existence_fail.append(n)
+                continue
+            qr_checked += 1
+            if legendre_neg_n(p, n) != 1:
+                qr_mismatch += 1
+                print(f"  QR MISMATCH n={n} p={p} legendreSym(p,-n)={legendre_neg_n(p,n)}")
+
+    print(f"range 1..{N}")
+    print(f"(A) odd n with QR identity checked : {qr_checked}")
+    print(f"(A) QR mismatches (expect 0)       : {qr_mismatch}")
+    print(f"(B) existence failures (expect 0)  : {len(existence_fail)}")
+    print(f"(C) non-excluded 4-free ODD  cores : {odd_cores}  (single-AP covers)")
+    print(f"(C) non-excluded 4-free EVEN cores : {even_cores}  (n%8 in 2,6; NOT covered)")
+    print(f"(C) smallest even cores            : {even_examples}")
+    ok = qr_mismatch == 0 and not existence_fail
+    print("RESULT:", "PASS" if ok else "FAIL")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Build-free verification + architectural ORIENT session for the Legendre three-square
sufficiency direction (zsqrtd-neg-two-oq-02), under dual backend blackout (corrupt
`proofs/.lake` self-symlink ⇒ no Docker build; Aristotle MCP returns 404).

## Progress
- **Verified the registered-but-uncompiled `ThreeSquaresSingleAP.lean`.** It is
  committed on `main` and registered (`Proofs.lean:3026`) but was never compiled
  (Docker saturated when it landed). With no CI Lean build gate, a misnamed bearer
  would silently break `main`. All Mathlib bearers name-checked against the pinned
  rev `2df2f015…` with correct namespaces/signatures, and the Jacobi/reciprocity
  rewrite chain in `legendreSym_neg_n_eq_one` verified sound by inspection.
  Residual risk is tactic-level only; the registered-on-main risk is cleared.
- **Architectural refinement.** SingleAP's uniform witness (`p≡1 mod 4n`,
  `legendreSym p (-n)=1`) covers every **odd** non-excluded core `n%8∈{1,3,5}` in
  one branch — including `n≡3 mod 8`, the class whose old rigid `p=d·n−1` witness
  was proven unsatisfiable. This makes the residue-3 carve-out
  (`ThreeSquaresResidue3*`, `Residue3Property`, the `n%8=3` case) obsolete for odd
  cores.
- **Identified the residual gap.** Even cores `n%8∈{2,6}` (4-free, even) are NOT
  served — `legendreSym_neg_n_eq_one` requires `Odd n`. They still need a witness.

## Findings
- `verify_single_ap_coverage.py` (range 1..4000): 0 QR mismatches, 0 existence
  failures over 2000 odd `n`; coverage split = **1499 odd cores** (single-AP
  covers) vs **1000 even cores** (`n%8∈{2,6}`, remaining).
- Turnkey wiring plan (knowledge.md S8 §4): restate `dirichlet_key_lemma`
  (ThreeSquares.lean:648) to the tie-free `legendreSym p (-n)=1` form, discharge
  odd cores via SingleAP, delete the residue-3 apparatus, handle even cores
  separately ⟹ `ThreeSquares.lean` drops **2 axioms → 1**.

## Status
**Outcome**: surveyed/orient (verification + architecture; no proof closed — dual blackout)
**Next Steps**: on backend recovery, apply the S8 §4 wiring with a real Docker build;
do NOT blind-edit the registered flagship under blackout.

🤖 Generated by researcher-3