### PR TITLE
Research: lagrange-four-squares-waring-g2-oq-03 — build-verify+register 2 companions, repair stale lemma name on main

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3023,6 +3023,8 @@ import Proofs.TestZetaNonzero
 import Proofs.ThreePlaceIdentity
 import Proofs.ThreePlaceIdentityOQ02
 import Proofs.ThreeSquares
+import Proofs.ThreeSquaresResidue3
+import Proofs.ThreeSquaresResidue3Obstruction
 import Proofs.ThreeSquaresSingleAP
 import Proofs.TractatusOntology
 import Proofs.TractatusOntologyEquiv

--- a/proofs/Proofs/ThreeSquaresResidue3Obstruction.lean
+++ b/proofs/Proofs/ThreeSquaresResidue3Obstruction.lean
@@ -66,7 +66,7 @@ theorem legendreSym_neg_m_eq_neg_one {m p : ℕ} [Fact (Nat.Prime p)]
     legendreSym p (-(m : ℤ)) = -1 := by
   have hm_odd : Odd m := Nat.odd_iff.mpr (by omega)
   have hJpm : jacobiSym (p : ℤ) m = -1 := jacobi_p_mod_m_eq_neg_one hm3 hdvd
-  rw [legendreSym.to_jacobiSym, jacobiSym.neg (m : ℤ) hp_odd]
+  rw [jacobiSym.legendreSym.to_jacobiSym, jacobiSym.neg (m : ℤ) hp_odd]
   -- goal: χ₄ p * J(m | p) = -1
   have hp2 : p % 2 = 1 := Nat.odd_iff.mp hp_odd
   rcases (by omega : p % 4 = 1 ∨ p % 4 = 3) with hp1 | hp3
@@ -95,7 +95,6 @@ theorem legendreSym_neg_d_eq_neg_m {m d p : ℕ} [Fact (Nat.Prime p)]
     push_cast at hcast; linear_combination hcast
   have hm0 : (m : ZMod p) ≠ 0 := by
     intro h; rw [h, zero_mul] at hunit; exact zero_ne_one hunit
-  have hnm0 : ((-(m : ℤ)) : ZMod p) ≠ 0 := by push_cast; exact neg_ne_zero.mpr hm0
   -- product of the two symbols is 1
   have key : legendreSym p (-(d : ℤ)) * legendreSym p (-(m : ℤ)) = 1 := by
     rw [← legendreSym.mul]
@@ -105,7 +104,8 @@ theorem legendreSym_neg_d_eq_neg_m {m d p : ℕ} [Fact (Nat.Prime p)]
       rw [hdmZ, show ((p : ℤ) + 1) = 1 + (p : ℤ) * 1 by ring, Int.add_mul_emod_self_left]
     rw [hmod, ← legendreSym.mod, legendreSym.at_one]
   -- conclude equality using `(−m | p)² = 1`
-  have hb2 : legendreSym p (-(m : ℤ)) ^ 2 = 1 := legendreSym.sq_one p hnm0
+  have hb2 : legendreSym p (-(m : ℤ)) ^ 2 = 1 := by
+    apply legendreSym.sq_one; push_cast; simpa using hm0
   calc legendreSym p (-(d : ℤ))
       = legendreSym p (-(d : ℤ)) * legendreSym p (-(m : ℤ)) ^ 2 := by rw [hb2, mul_one]
     _ = (legendreSym p (-(d : ℤ)) * legendreSym p (-(m : ℤ))) * legendreSym p (-(m : ℤ)) := by

--- a/proofs/Proofs/ThreeSquaresSingleAP.lean
+++ b/proofs/Proofs/ThreeSquaresSingleAP.lean
@@ -89,7 +89,7 @@ theorem legendreSym_neg_n_eq_one {n p : ℕ} [Fact (Nat.Prime p)]
   have hJpn : jacobiSym (p : ℤ) n = 1 := jacobi_p_mod_n_eq_one hp_pos hn_dvd
   -- `p` is odd (needed for `jacobiSym.neg`).
   have hp_odd : Odd p := Nat.odd_iff.mpr (by omega)
-  rw [legendreSym.to_jacobiSym, jacobiSym.neg (n : ℤ) hp_odd]
+  rw [jacobiSym.legendreSym.to_jacobiSym, jacobiSym.neg (n : ℤ) hp_odd]
   -- goal: `χ₄ p * J(n | p) = 1`
   rw [ZMod.χ₄_nat_one_mod_four hp4, one_mul,
       ← jacobiSym.quadratic_reciprocity_one_mod_four hp4 hn_odd]

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -440,3 +440,49 @@ Davenport–Cassels / it duplicates GoN" advice above predates this gap analysis
 should be re-weighed against it. Full arithmetic + empirics in
 `G2-minkowski-2p-gap.md` and `verify_minkowski_2p_gap.py`. No Lean changed this
 session (Docker was free; baseline build run for health only).
+
+## Session 2026-06-16 (researcher-10) — build-verified the residue-3 obstruction + repaired a stale lemma name on main
+
+Docker recovered this session (cold-cache, ~16min/file via the Azure mathlib
+cache download; the persistent volume does NOT cover the mathlib package oleans,
+so every build re-fetches 7727 files). Used it to actually BUILD the
+build-pending companions rather than trust the under-blackout "0/0" claims.
+
+**Critical correction — `legendreSym.to_jacobiSym` is NOT a Mathlib constant.**
+Both `ThreeSquaresResidue3Obstruction.lean` (line 69) and the ALREADY-REGISTERED
+`ThreeSquaresSingleAP.lean` (line 92) used `legendreSym.to_jacobiSym`, which the
+pinned Mathlib (v4.26.0) reports as `Unknown constant`. The correct name is
+**`jacobiSym.legendreSym.to_jacobiSym`** (confirmed via the green
+`QuadraticReciprocityAlgorithmOQ01.lean:163`). So the "0/0, build-pending"
+companions written under prior Docker blackouts were NOT actually compiling —
+exactly the failure mode the no-CI-Lean-gate warning predicts.
+
+**What landed (build-verified green this session):**
+- `ThreeSquaresResidue3Obstruction.lean`: fixed the bad lemma name AND a cast
+  mismatch at `legendreSym.sq_one` (the `hnm0 : ((-(m:ℤ)):ZMod p)≠0` had the
+  wrong cast shape `-↑↑m` vs expected `↑(-↑m)`; replaced with
+  `apply legendreSym.sq_one; push_cast; simpa using hm0`). Now builds, and
+  **registered** in `Proofs.lean`.
+- `ThreeSquaresSingleAP.lean` (already registered): same `legendreSym.to_jacobiSym`
+  → `jacobiSym.legendreSym.to_jacobiSym` fix. This file was registered but
+  BROKEN on main (would fail the deployer's full build); now builds green
+  (3393 jobs incl. its `ThreeSquares` dep). Pure repair, no math change.
+- `ThreeSquaresResidue3.lean` (Mathlib-only, `ring`/`omega`/`Nat.Prime.sq_add_sq`):
+  built green as-is (7743 jobs), no fix needed; **registered** in `Proofs.lean`.
+
+**Axiom status of `ThreeSquares.lean` UNCHANGED (still 2 axioms:
+`dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`).** This session is
+infrastructure repair + verification, not an axiom-delta. The deep open work
+(generalize `dirichlet_key_lemma` to an arbitrary prime with `(−n|p)=1`, then a
+sublattice Minkowski instance) is being actively worked in open PR #24967
+("isolate the Q<2p step as a 2D-slice lemma") — not duplicated here.
+
+**Still build-pending (unregistered, NOT yet verified this session):**
+`ThreeSquaresSufficiency`, `ThreeSquaresSufficiencyCorrected`,
+`ThreeSquaresWitnessObstruction`. Each must be docker-built green before
+registering — do not trust the "0/0" comments; the `legendreSym.to_jacobiSym`
+precedent shows under-blackout files can carry real errors that grep cannot see.
+(These three import `ThreeSquaresSufficiency`→`ThreeSquares`; the
+`DirichletWitnessProperty` they reference is the documented FALSE/dead-end route,
+so verify carefully before registering — registering a vacuous-hypothesis file
+is low value.)


### PR DESCRIPTION
## Summary
Docker recovered this session. Used it to actually **build** the build-pending
`ThreeSquares*` companion files (written under prior Docker blackouts and never
verified) rather than trusting their "0/0, build-pending" comments — which turned
out to hide a real broken Mathlib lemma name.

## Changes (all Docker-build-verified green)
- **`ThreeSquaresResidue3Obstruction.lean`** — fixed two real errors and registered:
  - unknown constant `legendreSym.to_jacobiSym` → `jacobiSym.legendreSym.to_jacobiSym`
    (correct name confirmed via the green `QuadraticReciprocityAlgorithmOQ01.lean`);
  - `legendreSym.sq_one` cast-shape mismatch (`-↑↑m` vs `↑(-↑m)`), replaced with
    `apply legendreSym.sq_one; push_cast; simpa using hm0`.
- **`ThreeSquaresResidue3.lean`** — built green as-is; registered.
- **`ThreeSquaresSingleAP.lean`** — **already registered but BROKEN on main**: it
  carried the same invalid `legendreSym.to_jacobiSym` name, so the deployer's full
  `Proofs` build would have failed on it. One-token fix; now builds green
  (3393 jobs incl. its `ThreeSquares` dep). Pure repair, no math change.
- `Proofs.lean` — registered the two newly-verified companions.
- `knowledge.md` — session notes + the `legendreSym.to_jacobiSym` gotcha.

## Findings
- The no-CI-Lean-gate failure mode is real: under-blackout "0/0" files can carry
  errors `grep` cannot see. `legendreSym.to_jacobiSym` is **not** a Mathlib
  constant in the pinned rev (v4.26.0); the correct name is
  `jacobiSym.legendreSym.to_jacobiSym`.
- `ThreeSquares.lean` axiom count is **unchanged** (2 axioms). This PR is
  infrastructure repair + verification, not an axiom delta.

## Status
**Outcome**: progress (build-verified + repaired; no axiom delta)
**Next Steps**: deep open work (generalize `dirichlet_key_lemma` to an arbitrary
prime with `(−n|p)=1` + sublattice Minkowski instance) is being worked in open
PR #24967 — not duplicated here. Remaining unregistered companions
(`ThreeSquaresSufficiency`, `…Corrected`, `…WitnessObstruction`) reference the
documented FALSE `DirichletWitnessProperty` route — verify value before registering.

🤖 Generated by researcher-10