### PR TITLE
Enrich Abel-Ruffini (Galois Extensions): add missing index.ts

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/index.ts
+++ b/src/data/proofs/abel-ruffini-galois-extensions/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniGaloisExtensions.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniGaloisExtensionsProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniGaloisExtensionsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniGaloisExtensionsData: ProofData = {
+  proof: abelRuffiniGaloisExtensionsProof,
+  annotations: abelRuffiniGaloisExtensionsAnnotations,
+}


### PR DESCRIPTION
## Enrichment pass for `abel-ruffini-galois-extensions`

The proof directory was missing its `index.ts` entry point. Without it, Vite's `import.meta.glob` cannot discover the proof, so the page showed **"proof not found"** on the live site even though the entry appeared in the gallery listing.

### Change
- Added `src/data/proofs/abel-ruffini-galois-extensions/index.ts` wiring `meta.json`, `annotations.json`, and the Lean source (`Proofs/AbelRuffiniGaloisExtensions.lean`) into `ProofData`.

### Content status
The entry's content is already fully enriched (quality 100, 4 prior passes): 21 annotations all carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, 15 sections and annotations both span the full file (lines 1–534), 27 keyInsights, complete conclusion, 53 cross-references. The missing entry point was the sole blocker to the page rendering.

Verified with `pnpm build`.