### PR TITLE
Research: de Gua's theorem (3-D Pythagorean) — 0 sorry/0 axiom

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -583,6 +583,7 @@ import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational
 import Proofs.CubeRoot9Irrational
+import Proofs.DeGuaTheorem
 import Proofs.DeMoivre
 import Proofs.DeMoivreOQ01
 import Proofs.DeMoivreOQ02

--- a/proofs/Proofs/DeGuaTheorem.lean
+++ b/proofs/Proofs/DeGuaTheorem.lean
@@ -1,0 +1,101 @@
+/-
+# de Gua's Theorem (the 3-D Pythagorean theorem)
+
+## What This Proves
+
+For a **trirectangular tetrahedron** — a tetrahedron with a vertex at which the
+three edges are mutually perpendicular — the square of the area of the face
+opposite the right-angle vertex (the "hypotenuse face") equals the sum of the
+squares of the areas of the three faces meeting at that vertex:
+
+  Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)²
+
+This is the natural 3-D analogue of the Pythagorean theorem c² = a² + b²
+(recover Pythagoras by collapsing one dimension).
+
+## Proof Strategy
+
+Work in ℝ³ with the standard squared-area formula for a triangle,
+
+  Area(P Q R)² = ¼ ‖(Q − P) × (R − P)‖²,
+
+where × is the vector cross product. Writing the three perpendicular edges as
+`u = A − O`, `v = B − O`, `w = C − O`, the hypotenuse-face edges are `v − u`
+and `w − u`, and the cross product expands as
+
+  (v − u) × (w − u) = u×v + v×w + w×u.
+
+Hence
+
+  ‖(v−u)×(w−u)‖²
+    = ‖u×v‖² + ‖v×w‖² + ‖w×u‖²
+      + 2[(u×v)·(v×w) + (v×w)·(w×u) + (w×u)·(u×v)].
+
+By the Binet–Cauchy identity (a×b)·(c×d) = (a·c)(b·d) − (a·d)(b·c), each of the
+three cross terms reduces to a combination of pairwise dot products, and under
+the mutual-orthogonality hypotheses u·v = v·w = w·u = 0 the entire correction
+vanishes. The resulting polynomial identity is discharged by `linear_combination`
+(coefficients verified numerically over 10⁵ random samples before formalizing).
+
+## Status: 0 sorries, 0 axioms
+
+Tags: geometry, euclidean-space, pythagorean, cross-product, tetrahedron
+-/
+
+import Mathlib.Tactic
+
+namespace DeGuaTheorem
+
+/-- Dot product of two vectors in ℝ³ (represented as `Fin 3 → ℝ`). -/
+def dot (a b : Fin 3 → ℝ) : ℝ := a 0 * b 0 + a 1 * b 1 + a 2 * b 2
+
+/-- Squared Euclidean norm of the cross product `a × b` in ℝ³. -/
+def crossSq (a b : Fin 3 → ℝ) : ℝ :=
+  (a 1 * b 2 - a 2 * b 1) ^ 2 + (a 2 * b 0 - a 0 * b 2) ^ 2 + (a 0 * b 1 - a 1 * b 0) ^ 2
+
+/-- Squared area of the triangle with vertices `A B C`:
+`Area² = ¼ ‖(B − A) × (C − A)‖²`. -/
+noncomputable def areaSq (A B C : Fin 3 → ℝ) : ℝ := crossSq (B - A) (C - A) / 4
+
+/-- **Core de Gua identity (edge-vector form).**
+If three vectors `u v w` from a common vertex are mutually orthogonal, then the
+squared cross-product norm of the opposite face equals the sum of the squared
+cross-product norms of the three right-angle faces. -/
+theorem de_gua_core (u v w : Fin 3 → ℝ)
+    (huv : dot u v = 0) (hvw : dot v w = 0) (hwu : dot w u = 0) :
+    crossSq (v - u) (w - u) = crossSq u v + crossSq v w + crossSq w u := by
+  simp only [crossSq, dot, Pi.sub_apply] at *
+  linear_combination
+    (2 * (v 0 * w 0 + v 1 * w 1 + v 2 * w 2)
+        + 2 * (w 0 * u 0 + w 1 * u 1 + w 2 * u 2)
+        - 2 * (w 0 * w 0 + w 1 * w 1 + w 2 * w 2)) * huv
+    + (2 * (w 0 * u 0 + w 1 * u 1 + w 2 * u 2)
+        - 2 * (u 0 * u 0 + u 1 * u 1 + u 2 * u 2)) * hvw
+    + (-2 * (v 0 * v 0 + v 1 * v 1 + v 2 * v 2)) * hwu
+
+/-- **de Gua's theorem (vertex form).**
+For a trirectangular tetrahedron `O A B C` whose three edges at `O` are mutually
+perpendicular, the squared area of the face `ABC` opposite `O` equals the sum of
+the squared areas of the three faces meeting at `O`. -/
+theorem de_gua (O A B C : Fin 3 → ℝ)
+    (h1 : dot (A - O) (B - O) = 0) (h2 : dot (B - O) (C - O) = 0)
+    (h3 : dot (C - O) (A - O) = 0) :
+    areaSq A B C = areaSq O A B + areaSq O B C + areaSq O C A := by
+  have hBA : B - A = (B - O) - (A - O) := by ext i; simp only [Pi.sub_apply]; ring
+  have hCA : C - A = (C - O) - (A - O) := by ext i; simp only [Pi.sub_apply]; ring
+  have hcore := de_gua_core (A - O) (B - O) (C - O) h1 h2 h3
+  simp only [areaSq]
+  rw [hBA, hCA, hcore]
+  ring
+
+/-- **de Gua for the canonical axis-aligned tetrahedron.**
+With the right-angle vertex at the origin and legs of lengths `a, b, c` along the
+coordinate axes, the slant face has squared area `¼(a²b² + b²c² + c²a²)` (the
+squared norm of the cross product `(bc, ca, ab)` divided by 4), which equals the
+sum of the squared leg-face areas `(ab/2)² + (bc/2)² + (ca/2)²`. -/
+theorem de_gua_axis_aligned (a b c : ℝ) :
+    (a ^ 2 * b ^ 2 + b ^ 2 * c ^ 2 + c ^ 2 * a ^ 2) / 4
+      = (a * b / 2) ^ 2 + (b * c / 2) ^ 2 + (c * a / 2) ^ 2 := by
+  ring
+
+end DeGuaTheorem

--- a/research/problems/pythagorean-theorem-oq-06/knowledge.md
+++ b/research/problems/pythagorean-theorem-oq-06/knowledge.md
@@ -1,0 +1,79 @@
+# de Gua's Theorem (pythagorean-theorem-oq-06)
+
+## Problem Summary
+
+Formalize **de Gua's theorem**, the 3-D analogue of the Pythagorean theorem:
+for a *trirectangular tetrahedron* `O A B C` (three mutually perpendicular edges
+meeting at vertex `O`), the squared area of the face `ABC` opposite `O` equals
+the sum of the squared areas of the three right-angle faces:
+
+  Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)².
+
+## Status: COMPLETE (build-pending verification)
+
+Proof written in `proofs/Proofs/DeGuaTheorem.lean` — **0 sorries, 0 axioms**.
+
+## Approach (verified sound)
+
+Work in ℝ³ as `Fin 3 → ℝ` with the standard squared-area formula
+`Area(PQR)² = ¼‖(Q−P)×(R−P)‖²`. Writing the perpendicular edges as
+`u = A−O, v = B−O, w = C−O`, the hypotenuse-face edges are `v−u, w−u` and
+
+  (v−u)×(w−u) = u×v + v×w + w×u.
+
+Expanding the squared norm produces the three leg-face terms plus a cross-term
+`2[(u×v)·(v×w) + (v×w)·(w×u) + (w×u)·(u×v)]`. By Binet–Cauchy,
+`(a×b)·(c×d) = (a·c)(b·d) − (a·d)(b·c)`, each cross term is a combination of
+pairwise dot products that vanishes under the orthogonality hypotheses
+`u·v = v·w = w·u = 0`. The residual polynomial identity is discharged by
+`linear_combination` with explicit coefficients.
+
+### Key built items
+- `de_gua_core` (edge-vector form): `crossSq (v-u) (w-u) = crossSq u v + crossSq v w + crossSq w u` under mutual orthogonality. Closed by `linear_combination`.
+- `de_gua` (vertex form): full statement for tetrahedron `O A B C`, reduced to `de_gua_core` via `B−A = (B−O)−(A−O)`.
+- `de_gua_axis_aligned` (canonical model, legs `a,b,c` on the axes): pure `ring`.
+
+### Verification note
+The `linear_combination` coefficients were verified numerically over 10⁵ random
+integer samples (both the general orthogonal identity and the axis-aligned
+special case) before formalizing — the algebra is exact, so the only residual
+risk is Lean elaboration mechanics (def unfolding / `simp only` of `crossSq`,
+`dot`, `Pi.sub_apply`).
+
+## Mathlib gaps
+None blocking. Used only `Mathlib.Tactic` (`linear_combination`, `ring`). Defined
+`dot`/`crossSq`/`areaSq` locally in coordinates to keep the proof self-contained
+and avoid `Matrix`/`Fin` indexing fragility.
+
+## Next steps
+1. Build-verify `Proofs.DeGuaTheorem` (Docker), then register in `Proofs.lean`.
+2. Add gallery data under `src/data/proofs/de-gua-theorem/` (or `pythagorean-theorem-oq-06`).
+3. Optional follow-up: n-simplex generalization (Conant/Beeler) — squared
+   "volume" of the hypotenuse facet equals sum of squared facet volumes; or the
+   sharp-boundary question (de Gua fails without mutual orthogonality — quantify
+   the defect via the surviving cross term).
+
+## Sessions
+
+### Session 2026-06-16 (Session 1) — FRESH
+
+**Mode**: FRESH
+**Outcome**: complete (build-pending)
+
+#### What I Did
+- Claimed `pythagorean-theorem-oq-06`; confirmed de Gua not yet in gallery or Mathlib.
+- Derived the proof via cross-product expansion + Binet–Cauchy; numerically verified the `linear_combination` coefficients over 10⁵ samples.
+- Wrote `proofs/Proofs/DeGuaTheorem.lean` (3 theorems, 0 sorry / 0 axiom).
+- Launched Docker build of `Proofs.DeGuaTheorem` under the dual-blackout conditions (Aristotle 404; host `proofs/.lake` self-symlink) — cache volume + oleans confirmed accessible inside the container.
+
+#### Key Findings
+- The dangling `.lake` symlink does **not** block: Docker mounts the cache volume at `/workspace/proofs/.lake/build` and Mathlib oleans are present; lake re-clones only the Mathlib *source* (packages dir not volume-mounted).
+- de Gua reduces cleanly to a single polynomial identity; no heavy geometry infrastructure needed.
+
+#### Files Modified
+- `proofs/Proofs/DeGuaTheorem.lean` (new)
+- `research/problems/pythagorean-theorem-oq-06/knowledge.md`, `state.md`
+- `src/data/research/problems/pythagorean-theorem-oq-06.json`
+
+#### Next Steps
+Build-verify, register in `Proofs.lean`, add gallery data.

--- a/research/problems/pythagorean-theorem-oq-06/problem.md
+++ b/research/problems/pythagorean-theorem-oq-06/problem.md
@@ -1,0 +1,40 @@
+# Problem: de Gua's theorem: the 3D Pythagorean theorem
+
+## Statement
+
+### Plain Language
+AVAILABLE: Formalize de Gua's theorem — for a trirectangular tetrahedron the squared area of the face opposite the right-angle vertex equals the sum of squared areas of the three perpendicular faces (A₀²=A₁²+A₂²+A₃²).
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 5
+tractability: 6
+tags:
+  - geometry
+  - euclidean-space
+  - pythagorean
+  - pythagorean-theorem
+  - seeker-selected
+  - gallery-extracted
+  - research
+```
+
+**Significance**: 5/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: Formalize de Gua's theorem — for a trirectangular tetrahedron the squared area of the face opposite the right-angle vertex equals the sum of squared areas of the three perpendicular faces (A₀²=A₁²+A₂²+A₃²)
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/pythagorean-theorem-oq-06/state.md
+++ b/research/problems/pythagorean-theorem-oq-06/state.md
@@ -1,0 +1,30 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-16
+**Iteration**: 1
+
+## Current Focus
+
+de Gua's theorem formalized in `proofs/Proofs/DeGuaTheorem.lean` (0 sorry / 0 axiom).
+Build-verifying `Proofs.DeGuaTheorem`, then register + add gallery data.
+
+## Active Approach
+
+Cross-product / Binet–Cauchy reduction to a single polynomial identity, discharged
+by `linear_combination` (coefficients numerically verified over 10⁵ samples).
+Three theorems: `de_gua_core` (edge-vector), `de_gua` (vertex form), `de_gua_axis_aligned`.
+
+## Blockers
+
+None mathematically. Verification gated on Docker build completing (in progress).
+
+## Next Action
+
+Confirm green build → register in `Proofs.lean` → add gallery data → PR.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/research/problems/pythagorean-theorem-oq-06.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-06.json
@@ -1,0 +1,113 @@
+{
+  "slug": "pythagorean-theorem-oq-06",
+  "title": "de Gua's theorem: the 3D Pythagorean theorem",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Formalize de Gua's theorem — for a trirectangular tetrahedron the squared area of the face opposite the right-angle vertex equals the sum of squared areas of the three perpendicular faces (A₀²=A₁²+A₂²+A₃²).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "de Gua: squared area of hypotenuse face = sum of squared areas of the three right-angle faces (general orthogonal + axis-aligned forms)"
+    ],
+    "open": [],
+    "goal": "Area(ABC)^2 = Area(OAB)^2 + Area(OBC)^2 + Area(OCA)^2 for a trirectangular tetrahedron"
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-16T12:27:51.320Z",
+    "iteration": 1,
+    "focus": "de Gua proved in DeGuaTheorem.lean (0 sorry/0 axiom, Docker build GREEN); registered in Proofs.lean; PR open",
+    "blockers": [],
+    "nextAction": "Merge PR; add gallery data (enricher)",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (build-pending): de Gua proved in DeGuaTheorem.lean, 0 sorry/0 axiom",
+    "builtItems": [
+      "de_gua_core (edge-vector form) in Proofs/DeGuaTheorem.lean — crossSq identity under mutual orthogonality, via linear_combination",
+      "de_gua (vertex form) — full tetrahedron statement reduced to de_gua_core",
+      "de_gua_axis_aligned — canonical axis-aligned model, pure ring"
+    ],
+    "insights": [
+      "de Gua reduces to one polynomial identity: (v-u)x(w-u) = uxv+vxw+wxu, then Binet-Cauchy cross terms vanish under orthogonality",
+      "linear_combination coefficients verified numerically over 1e5 random samples before formalizing",
+      "Local coordinate defs (dot/crossSq/areaSq on Fin 3 -> R) avoid Matrix/Fin indexing fragility"
+    ],
+    "mathlibGaps": [
+      "None blocking — only Mathlib.Tactic needed (linear_combination, ring)"
+    ],
+    "nextSteps": [
+      "Build-verify Proofs.DeGuaTheorem, register in Proofs.lean",
+      "Add gallery data under src/data/proofs/",
+      "Follow-up: n-simplex generalization; or quantify de Gua defect without orthogonality"
+    ]
+  },
+  "tags": [
+    "geometry",
+    "euclidean-space",
+    "pythagorean",
+    "pythagorean-theorem",
+    "seeker-selected",
+    "gallery-extracted",
+    "research"
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "pythagorean-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-16T12:27:51.318Z",
+  "lastUpdate": "2026-06-16",
+  "significance": 5,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/PythagoreanTheorem.lean",
+      "filename": "PythagoreanTheorem.lean",
+      "lineCount": 215,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheorem.lean"
+    },
+    {
+      "path": "Proofs/PythagoreanTheoremOQ03.lean",
+      "filename": "PythagoreanTheoremOQ03.lean",
+      "lineCount": 1432,
+      "theoremCount": 104,
+      "axiomCount": 0,
+      "defCount": 18,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/PythagoreanTheoremOQ05.lean",
+      "filename": "PythagoreanTheoremOQ05.lean",
+      "lineCount": 375,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Formalizes **de Gua's theorem**, the 3-D analogue of the Pythagorean theorem, for `pythagorean-theorem-oq-06`. For a trirectangular tetrahedron `O A B C` (three mutually perpendicular edges at `O`):

  Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)²

New file `proofs/Proofs/DeGuaTheorem.lean` — **Docker build GREEN, 0 sorry / 0 axiom** — and registered in `Proofs.lean`. de Gua was absent from both Mathlib and the gallery.

## Theorems
- `de_gua_core` (edge-vector form): `‖(v−u)×(w−u)‖² = ‖u×v‖² + ‖v×w‖² + ‖w×u‖²` under mutual orthogonality `u·v = v·w = w·u = 0`.
- `de_gua` (vertex form): the full tetrahedron statement, reduced to `de_gua_core` via `B−A = (B−O)−(A−O)`.
- `de_gua_axis_aligned`: canonical axis-aligned model (legs `a,b,c` on the axes), pure `ring`.

## Proof approach
Cross-product expansion `(v−u)×(w−u) = u×v + v×w + w×u`, then the Binet–Cauchy identity `(a×b)·(c×d) = (a·c)(b·d) − (a·d)(b·c)` makes the three cross terms vanish under orthogonality. The residual polynomial identity is discharged by `linear_combination`; its coefficients were verified numerically over 10⁵ random integer samples before formalizing. Local coordinate defs (`dot`/`crossSq`/`areaSq` on `Fin 3 → ℝ`) keep the proof self-contained — only `Mathlib.Tactic` is imported.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.DeGuaTheorem` succeeds (`✔ Built Proofs.DeGuaTheorem`)
- [x] 0 sorries, 0 axioms in the file
- [x] Registered alphabetically in `Proofs.lean`
- [ ] Follow-up (enricher): gallery data under `src/data/proofs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)