### PR TITLE
research(pythagorean-theorem-oq-06): de Gua's theorem (3D Pythagoras), build-gated orphan

### DIFF
--- a/proofs/Proofs/DeGuaTheorem.lean
+++ b/proofs/Proofs/DeGuaTheorem.lean
@@ -1,0 +1,102 @@
+/-
+# de Gua's Theorem (the 3-D Pythagorean theorem)
+
+## What This Proves
+
+For a **trirectangular tetrahedron** — a tetrahedron with a vertex at which the
+three edges are mutually perpendicular — the square of the area of the face
+opposite the right-angle vertex (the "hypotenuse face") equals the sum of the
+squares of the areas of the three faces meeting at that vertex:
+
+  Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)²
+
+This is the natural 3-D analogue of the Pythagorean theorem c² = a² + b²
+(recover Pythagoras by collapsing one dimension).
+
+## Proof Strategy
+
+Work in ℝ³ with the standard squared-area formula for a triangle,
+
+  Area(P Q R)² = ¼ ‖(Q − P) × (R − P)‖²,
+
+where × is the vector cross product. Writing the three perpendicular edges as
+`u = A − O`, `v = B − O`, `w = C − O`, the hypotenuse-face edges are `v − u`
+and `w − u`, and the cross product expands as
+
+  (v − u) × (w − u) = u×v + v×w + w×u.
+
+Hence
+
+  ‖(v−u)×(w−u)‖²
+    = ‖u×v‖² + ‖v×w‖² + ‖w×u‖²
+      + 2[(u×v)·(v×w) + (v×w)·(w×u) + (w×u)·(u×v)].
+
+By the Binet–Cauchy identity (a×b)·(c×d) = (a·c)(b·d) − (a·d)(b·c), each of the
+three cross terms reduces to a combination of pairwise dot products, and under
+the mutual-orthogonality hypotheses u·v = v·w = w·u = 0 the entire correction
+vanishes. The resulting polynomial identity is discharged by `linear_combination`
+(coefficients verified numerically over 10⁵ random samples before formalizing).
+
+## Status: 0 sorries, 0 axioms
+## Build status: build-pending (Docker build blackout — see knowledge.md)
+
+Tags: geometry, euclidean-space, pythagorean, cross-product, tetrahedron
+-/
+
+import Mathlib.Tactic
+
+namespace DeGuaTheorem
+
+/-- Dot product of two vectors in ℝ³ (represented as `Fin 3 → ℝ`). -/
+def dot (a b : Fin 3 → ℝ) : ℝ := a 0 * b 0 + a 1 * b 1 + a 2 * b 2
+
+/-- Squared Euclidean norm of the cross product `a × b` in ℝ³. -/
+def crossSq (a b : Fin 3 → ℝ) : ℝ :=
+  (a 1 * b 2 - a 2 * b 1) ^ 2 + (a 2 * b 0 - a 0 * b 2) ^ 2 + (a 0 * b 1 - a 1 * b 0) ^ 2
+
+/-- Squared area of the triangle with vertices `A B C`:
+`Area² = ¼ ‖(B − A) × (C − A)‖²`. -/
+noncomputable def areaSq (A B C : Fin 3 → ℝ) : ℝ := crossSq (B - A) (C - A) / 4
+
+/-- **Core de Gua identity (edge-vector form).**
+If three vectors `u v w` from a common vertex are mutually orthogonal, then the
+squared cross-product norm of the opposite face equals the sum of the squared
+cross-product norms of the three right-angle faces. -/
+theorem de_gua_core (u v w : Fin 3 → ℝ)
+    (huv : dot u v = 0) (hvw : dot v w = 0) (hwu : dot w u = 0) :
+    crossSq (v - u) (w - u) = crossSq u v + crossSq v w + crossSq w u := by
+  simp only [crossSq, dot, Pi.sub_apply] at *
+  linear_combination
+    (2 * (v 0 * w 0 + v 1 * w 1 + v 2 * w 2)
+        + 2 * (w 0 * u 0 + w 1 * u 1 + w 2 * u 2)
+        - 2 * (w 0 * w 0 + w 1 * w 1 + w 2 * w 2)) * huv
+    + (2 * (w 0 * u 0 + w 1 * u 1 + w 2 * u 2)
+        - 2 * (u 0 * u 0 + u 1 * u 1 + u 2 * u 2)) * hvw
+    + (-2 * (v 0 * v 0 + v 1 * v 1 + v 2 * v 2)) * hwu
+
+/-- **de Gua's theorem (vertex form).**
+For a trirectangular tetrahedron `O A B C` whose three edges at `O` are mutually
+perpendicular, the squared area of the face `ABC` opposite `O` equals the sum of
+the squared areas of the three faces meeting at `O`. -/
+theorem de_gua (O A B C : Fin 3 → ℝ)
+    (h1 : dot (A - O) (B - O) = 0) (h2 : dot (B - O) (C - O) = 0)
+    (h3 : dot (C - O) (A - O) = 0) :
+    areaSq A B C = areaSq O A B + areaSq O B C + areaSq O C A := by
+  have hBA : B - A = (B - O) - (A - O) := by ext i; simp only [Pi.sub_apply]; ring
+  have hCA : C - A = (C - O) - (A - O) := by ext i; simp only [Pi.sub_apply]; ring
+  have hcore := de_gua_core (A - O) (B - O) (C - O) h1 h2 h3
+  simp only [areaSq]
+  rw [hBA, hCA, hcore]
+  ring
+
+/-- **de Gua for the canonical axis-aligned tetrahedron.**
+With the right-angle vertex at the origin and legs of lengths `a, b, c` along the
+coordinate axes, the slant face has squared area `¼(a²b² + b²c² + c²a²)` (the
+squared norm of the cross product `(bc, ca, ab)` divided by 4), which equals the
+sum of the squared leg-face areas `(ab/2)² + (bc/2)² + (ca/2)²`. -/
+theorem de_gua_axis_aligned (a b c : ℝ) :
+    (a ^ 2 * b ^ 2 + b ^ 2 * c ^ 2 + c ^ 2 * a ^ 2) / 4
+      = (a * b / 2) ^ 2 + (b * c / 2) ^ 2 + (c * a / 2) ^ 2 := by
+  ring
+
+end DeGuaTheorem


### PR DESCRIPTION
## Summary

Formalizes **de Gua's theorem**, the 3-D analogue of the Pythagorean theorem: for a trirectangular tetrahedron `O A B C` (three mutually perpendicular edges at `O`),

  Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)².

`proofs/Proofs/DeGuaTheorem.lean` — **0 sorries, 0 axioms**. Three theorems:
- `de_gua_core` — edge-vector form; cross-product expansion + Binet–Cauchy reduces to one polynomial identity, discharged by `linear_combination`.
- `de_gua` — full vertex form for the tetrahedron, reduced to `de_gua_core`.
- `de_gua_axis_aligned` — canonical axis-aligned model, pure `ring`.

The `linear_combination` coefficients were re-verified algebraically (all six residual polynomial terms of `LHS − RHS` match the coefficient·hypothesis expansion exactly), in addition to the prior numerical check over 10⁵ samples.

## Build status

**Build-gated orphan.** This file is intentionally **not** registered in `proofs/Proofs.lean` because the Docker build is currently unavailable (host `proofs/.lake` self-symlink → Mathlib re-clone; Aristotle 404). The proof uses only `Mathlib.Tactic` (`linear_combination`, `ring`) with local coordinate defs (`dot`/`crossSq`/`areaSq` on `Fin 3 → ℝ`), so there are no Mathlib gaps.

## Test plan

- [ ] On Docker recovery: `./proofs/scripts/docker-build.sh Proofs.DeGuaTheorem`
- [ ] Register in `proofs/Proofs.lean` once green
- [ ] Add gallery data under `src/data/proofs/de-gua-theorem/`

de Gua was absent from both Mathlib and the gallery. Recovered from a prior session whose proof file had been written but never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)