### PR TITLE
research(qra-oq03): S18 M2 bearer re-audit — no transpose-sign shortcut

### DIFF
--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -613,3 +613,36 @@ conclusion.openQuestions state explicitly this is **Milestone 1 only** — the h
 are NOT yet in Lean, so the OQ is **not resolved**. Problem stays **in-progress** on the
 math; this session only surfaces the already-verified producer lemma in the gallery.
 No Lean changed. (Aristotle `prove` still 404, live-probed; the crux remains its target.)
+
+### Session 2026-06-16 (S18, researcher-1) — M2 bearer re-audit: no transpose-sign shortcut; inversion route confirmed
+
+**Mode:** CONTINUE (build-free). **Backends live-probed both down for the *safe* M2 path:**
+Aristotle MCP `prove` returns `"Resource not found"` on a trivial ping (404 persists). Docker had
+**4 `lean-build` containers** running (3 active + one 13h idle zombie) — over the ≤2-container
+safety threshold for a 7.65 GiB VM; launching a 5th concurrent Mathlib compile is the OOM-crash
+risk flagged repo-wide, so no build was attempted this session. Confirmed the merged Zolotarev
+spine is intact on `origin/main` (`QuadraticReciprocityAlgorithmOQ03.lean`: all 5 theorems,
+0 sorry / 0 axiom).
+
+**New result — ruled out a tempting M2 shortcut, narrowing the next live window to the S8 route.**
+Re-audited Mathlib at the pin (source at `/private/tmp/mathlib-grep`) for any lemma giving the
+grid-transpose / commutation-matrix permutation sign directly:
+
+- **No commutation/transpose permutation-sign bearer exists.** `LinearAlgebra/Matrix/Kronecker.lean`
+  and `Permutation.lean` carry the Kronecker product and permutation *matrices*, but **not** the
+  sign of the factor-swap (commutation) permutation. So there is no "just cite the lemma" path —
+  S8's `inv(σ) = C(p,2)·C(q,2)` remains the genuinely-new content to formalize.
+- **The `prodCongr`/`sumCongr` sign family does NOT apply.** `sign_prodCongrLeft`/`sign_prodCongrRight`
+  (`Sign.lean:535,545`) and `sign_sumCongr` (`:555`) compute signs of **block-diagonal** perms
+  (`∏ sign`), as used in `Matrix/Determinant/Basic.lean`. The grid-transpose is a **coordinate-swap**
+  (`prodComm`-type), not block-diagonal — these give it no leverage. Do not chase this detour.
+- **Clean transport lemma pinned:** `Equiv.Perm.sign_permCongr (e : α ≃ β) (p : Perm α) :
+  sign (e.permCongr p) = sign p` (`Sign.lean:551`) — a single named application that replaces S7's
+  `@[simp] sign_symm_trans_trans` glue for moving `σ` between `Perm (Fin (p*q))` and the product
+  type. (Also relevant: `sign_eq_sign_of_equiv` `:467`.)
+
+**Net for the next live window (Docker ≤2 containers or Aristotle non-404):** the M2 target is
+`inv(σ) = C(p,2)·C(q,2)` via Mathlib's `signAux = ∏ finPairsLT` definition (S8), transported with
+`sign_permCongr`; no shorter bearer route exists. Bijective characterization of the inversions
+(choose 2 rows × 2 columns → exactly one inversion) is the cleanest count to aim the Lean proof at.
+No Lean written this session.

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
@@ -4,7 +4,16 @@
 **Phase**: ACT — M1 + crux + Zolotarev headline ALL VERIFIED & MERGED (0 sorry / 0 axiom); only M2 (grid-transpose reciprocity) remains in Lean
 **Path**: full
 **Since**: 2026-06-16 (S16 — crux + headline merged to main via #24903)
-**Iteration**: 16
+**Iteration**: 18
+
+## Session 18 (2026-06-16, researcher-1) — M2 bearer re-audit; both backends down for the safe path
+Aristotle `prove` still 404 (live-probed); Docker at 4 `lean-build` containers (over the ≤2 safety
+threshold on a 7.65 GiB VM) — no build attempted (OOM risk). Merged spine confirmed intact on
+`origin/main` (5 theorems, 0 sorry / 0 axiom). **New:** re-audited Mathlib @ pin — **no commutation/
+transpose permutation-sign bearer exists** (Kronecker.lean has the matrix, not the sign), and the
+`prodCongr`/`sumCongr` sign family is block-diagonal-only, so it does NOT apply to the coordinate-swap
+transpose. The S8 inversion route (`inv(σ)=C(p,2)·C(q,2)` via `signAux=∏finPairsLT`, transported by
+`sign_permCongr` `Sign.lean:551`) is confirmed as the path — no shortcut. See knowledge.md S18.
 
 ## Session 16 sync (2026-06-16, researcher-1) — crux + headline are MERGED, not build-pending
 The S15 block below is now STALE. **PR #24903 merged 2026-06-16T07:42Z**, landing the S15 crux


### PR DESCRIPTION
## Summary
Doc-only research note for `quadratic-reciprocity-algorithm-oq-03` (the Zolotarev/permutation-sign route to QR). The Milestone-1 + crux + units-form Zolotarev headline are already verified and merged on `main` (#24903, 5 theorems, 0 sorry / 0 axiom); the sole remaining Lean work is **Milestone 2** (full reciprocity from the grid-transpose permutation sign).

This session (S18) re-audited Mathlib at the repo pin to rule out a shortcut for M2 and confirm the route:

- **No commutation/transpose permutation-sign bearer exists** in Mathlib (Kronecker.lean carries the matrix, not the sign) — so M2's `inv(σ)=C(p,2)·C(q,2)` (S8) remains genuinely-new content to formalize.
- **The `prodCongr`/`sumCongr` sign family does not apply** — those compute block-diagonal perm signs (`∏ sign`); the grid-transpose is a coordinate-swap (`prodComm`-type), not block-diagonal. Rules out a tempting detour.
- **Clean transport lemma pinned:** `Equiv.Perm.sign_permCongr` (`Sign.lean:551`) replaces S7's `@[simp]` glue for moving σ between `Perm (Fin (p*q))` and the product type.

Backends both down for the safe path this session: Aristotle `prove` 404 (live-probed); Docker at 4 `lean-build` containers, over the ≤2 OOM-safety threshold on a 7.65 GiB VM — no build attempted. Merged spine confirmed intact on `origin/main`.

No Lean changed. Problem stays in-progress; OQ not resolved.

## Test plan
- [ ] N/A — doc-only (knowledge.md + state.md). No Lean or gallery data touched.