### PR TITLE
Research: cauchy-schwarz-integral...-oq-01 - power-mean equality for negative exponents (build-pending)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,51 @@
+/-
+  Power Mean equality condition — NEGATIVE exponents `r < t < 0`.
+
+  Extends `PowerMeanEqualityCase.power_mean_eq_iff_all_eq_pos` (positive case,
+  `CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean:84`) to negative exponents
+  via the duality `M_p(z,w) = M_{-p}(z⁻¹,w)⁻¹` (`power_mean_neg_inv`,
+  `AmgmInequalityOQ03.lean:230`). Mirrors the compiled template
+  `power_mean_monotone_neg` (`AmgmInequalityOQ03.lean:292`) line-for-line for the
+  duality bookkeeping.
+
+  STATUS: build-gated ORPHAN — NOT imported by Proofs.lean. Drafted by
+  researcher-7 (was uncommitted in their worktree); committed here so the work is
+  not lost and is turnkey for the next build slot. Do NOT register in Proofs.lean
+  until it compiles green (`./proofs/scripts/docker-build.sh
+  Proofs.CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01`).
+
+  All cited lemmas verified present on main (v4.26.0):
+  - `power_mean_neg_inv` (AmgmInequalityOQ03.lean:230)
+  - `PowerMeanEqualityCase.power_mean_eq_iff_all_eq_pos`
+    (CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean:84)
+  - `inv_inj : a⁻¹ = b⁻¹ ↔ a = b` (Mathlib/Algebra/Group/Basic.lean:294)
+
+  Cross-zero case `r < 0 < t` is a SEPARATE follow-up (needs the geometric mean
+  M₀, outside `weightedPowerMean`'s `p ≠ 0` domain); not bundled here.
+-/
+import Mathlib.Tactic
+import Proofs.CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01
+
+namespace PowerMeanEqualityNegCase
+open Real Finset
+variable {ι : Type*} (s : Finset ι) (w z : ι → ℝ)
+
+theorem power_mean_eq_iff_all_eq_neg
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hrt : r < t) (ht : t < 0) (hrne : r ≠ 0) (htne : t ≠ 0) :
+    weightedPowerMean s w z r hrne = weightedPowerMean s w z t htne ↔
+    ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have hw0 : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  have hzinv : ∀ i ∈ s, 0 < (fun i => (z i)⁻¹) i := fun i hi => inv_pos.mpr (hz i hi)
+  have hnt_pos : 0 < -t := neg_pos.mpr ht
+  have hnr_pos : 0 < -r := neg_pos.mpr (hrt.trans ht)
+  have hntr : -t < -r := neg_lt_neg hrt
+  rw [power_mean_neg_inv s w z hw0 hz hrne, power_mean_neg_inv s w z hw0 hz htne, inv_inj]
+  rw [eq_comm,
+      PowerMeanEqualityCase.power_mean_eq_iff_all_eq_pos s w (fun i => (z i)⁻¹)
+        hw hw' hzinv hnt_pos hnr_pos hntr]
+  constructor
+  · exact fun h j hj k hk => inv_inj.mp (h j hj k hk)
+  · exact fun h j hj k hk => inv_inj.mpr (h j hj k hk)
+
+end PowerMeanEqualityNegCase


### PR DESCRIPTION
## Summary
Materializes the negative-exponent extension of the power-mean equality
condition (`M_r = M_t ↔ all elements equal`, for `r < t < 0`). This rescues a
complete turnkey draft authored earlier today by researcher-7 that was left
uncommitted in their worktree.

## Progress
- Committed `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean`
  as a build-gated **ORPHAN** (NOT in `Proofs.lean` → zero CI risk).
- `power_mean_eq_iff_all_eq_neg` proves the negative case via the `z ↦ z⁻¹`
  duality (`power_mean_neg_inv`), reducing to the already-proved positive case
  (`power_mean_eq_iff_all_eq_pos`). Mirrors the compiled template
  `power_mean_monotone_neg` line-for-line for the duality bookkeeping.

## Findings
- All cited lemmas verified present on `main` (v4.26.0): `power_mean_neg_inv`
  (AmgmInequalityOQ03.lean:230), `power_mean_eq_iff_all_eq_pos`
  (CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean:84),
  `inv_inj` (Mathlib/Algebra/Group/Basic.lean:294).
- Cross-zero case `r < 0 < t` is a separate follow-up (needs the geometric mean
  `M₀`, outside `weightedPowerMean`'s `p ≠ 0` domain) — not bundled.

## Status
**Outcome**: progress (turnkey draft committed, **build-unverified**).
Not built this session — host saturated (4 lean containers on 7.65GiB, OOM risk).
**Next Steps**: `docker-build Proofs.CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01`;
if green, register in `Proofs.lean` + add gallery data.

🤖 Generated by researcher-3