### PR TITLE
research(erdos-340-greedy-sidon-oq-01): constructive Sidon extendability kernel

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonExtension.lean
+++ b/proofs/Proofs/Erdos340GreedySidonExtension.lean
@@ -1,0 +1,125 @@
+import Mathlib
+
+/-!
+# Erdős #340 — Sidon Extendability (constructive existence kernel)
+
+This companion file proves the **extension lemma** underlying the greedy Sidon
+construction in `Erdos340GreedySidon.lean`. That file axiomatizes the existence of
+an infinite strictly–increasing Sidon sequence via
+
+```
+axiom greedySidonSeq            : ℕ → ℕ
+axiom greedySidonSeq_strictMono : StrictMono greedySidonSeq
+axiom greedySidonSeq_isSidon    : ∀ n, IsSidon (image greedySidonSeq (range (n+1)))
+```
+
+The mathematical content those axioms depend on is *extendability*: every finite
+Sidon set can be enlarged by one new (larger) element while staying Sidon. We prove
+this constructively here, with an **explicit** witness `m = 2 · (sup A) + 1`, and
+derive the existence of an infinite strictly–increasing Sidon sequence.
+
+This is a (sorry-free, axiom-free) result. It does **not** reproduce the *greedy*
+(Mian–Chowla, OEIS A005282) sequence — only a doubling sequence — so it does not
+literally discharge the greedy-specific axioms, but it discharges the substantive
+*existence* claim those axioms encode. The N^(1/2−ε) growth conjecture (Erdős #340)
+remains open and is untouched here.
+
+## Why `m = 2·sup A + 1` works
+
+Write `S = sup A`, so every element of `A` is `≤ S`, and put `m = 2S + 1 > S`.
+A new collision in `insert m A` is an equation `a + b = c + d` (with `a ≤ b`,
+`c ≤ d`) in which `m` participates. Since `m` is strictly larger than every element
+of `A`, on each side `m` (if present) must be the larger summand, so a side's sum
+falls in exactly one of three disjoint bands:
+
+* no `m`: sum `≤ 2S`;
+* one `m`: sum `∈ [2S+1, 3S+1]`;
+* two `m`: sum `= 4S+2`.
+
+Equal sums therefore force the two sides to use `m` the *same* number of times,
+after which `Nat` cancellation (and the original Sidon property for the
+all-in-`A` case) gives `a = c` and `b = d`.
+-/
+
+namespace Erdos340Extension
+
+/-- A finite set of naturals is **Sidon** iff all pairwise sums are distinct:
+    `a + b = c + d` with `a ≤ b`, `c ≤ d` forces `(a, b) = (c, d)`. -/
+def IsSidon (A : Finset ℕ) : Prop :=
+  ∀ a b c d : ℕ, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
+    a ≤ b → c ≤ d → a + b = c + d → a = c ∧ b = d
+
+/-- Every element of a finset is at most its `sup id`. -/
+theorem le_sup_id {A : Finset ℕ} {x : ℕ} (hx : x ∈ A) : x ≤ A.sup id :=
+  Finset.le_sup (f := id) hx
+
+/-- The explicit extension witness `2 · sup A + 1` is strictly above every element. -/
+theorem lt_two_sup_add_one {A : Finset ℕ} {a : ℕ} (ha : a ∈ A) :
+    a < 2 * A.sup id + 1 := by
+  have := le_sup_id ha
+  omega
+
+/-- **Extension lemma.** Inserting `2 · sup A + 1` into a Sidon set keeps it Sidon. -/
+theorem sidon_insert_two_sup_add_one {A : Finset ℕ} (hA : IsSidon A) :
+    IsSidon (insert (2 * A.sup id + 1) A) := by
+  set S := A.sup id with hS
+  set m := 2 * S + 1 with hm
+  have hbound : ∀ x ∈ A, x ≤ S := by
+    intro x hx; rw [hS]; exact le_sup_id hx
+  intro a b c d ha hb hc hd hab hcd hsum
+  simp only [Finset.mem_insert] at ha hb hc hd
+  rcases ha with rfl | ha <;> rcases hb with rfl | hb <;>
+    rcases hc with rfl | hc <;> rcases hd with rfl | hd <;>
+  first
+    | exact hA a b c d ha hb hc hd hab hcd hsum
+    | (try have ba := hbound _ ha
+       try have bb := hbound _ hb
+       try have bc := hbound _ hc
+       try have bd := hbound _ hd
+       omega)
+
+/-- Inserting `2 · sup A + 1` adds a genuinely new element (it is not in `A`). -/
+theorem two_sup_add_one_not_mem {A : Finset ℕ} : 2 * A.sup id + 1 ∉ A := by
+  intro hmem
+  have := lt_two_sup_add_one hmem
+  omega
+
+/-- **Extendability.** Every finite Sidon set can be enlarged by one strictly larger
+element while remaining Sidon. This is the existence content underlying the greedy
+construction's well-definedness. -/
+theorem sidon_extendable {A : Finset ℕ} (hA : IsSidon A) :
+    ∃ m, (∀ a ∈ A, a < m) ∧ m ∉ A ∧ IsSidon (insert m A) :=
+  ⟨2 * A.sup id + 1, fun _ ha => lt_two_sup_add_one ha,
+    two_sup_add_one_not_mem, sidon_insert_two_sup_add_one hA⟩
+
+/-! ## An explicit infinite strictly-increasing Sidon sequence
+
+We iterate the extension lemma to build a chain `A 0 ⊆ A 1 ⊆ …` of Sidon sets whose
+cardinalities grow without bound, witnessing that an infinite Sidon set exists.  -/
+
+/-- The doubling Sidon chain: start empty, repeatedly insert `2 · sup + 1`. -/
+def sidonChain : ℕ → Finset ℕ
+  | 0 => ∅
+  | n + 1 => insert (2 * (sidonChain n).sup id + 1) (sidonChain n)
+
+/-- Every set in the chain is Sidon. -/
+theorem sidonChain_isSidon : ∀ n, IsSidon (sidonChain n)
+  | 0 => by
+      intro a b c d ha; simp [sidonChain] at ha
+  | n + 1 => by
+      simpa [sidonChain] using sidon_insert_two_sup_add_one (sidonChain_isSidon n)
+
+/-- The chain is strictly increasing in cardinality: `|A n| = n`. -/
+theorem sidonChain_card : ∀ n, (sidonChain n).card = n
+  | 0 => by simp [sidonChain]
+  | n + 1 => by
+      have hnot : 2 * (sidonChain n).sup id + 1 ∉ sidonChain n := two_sup_add_one_not_mem
+      simp only [sidonChain, Finset.card_insert_of_not_mem hnot, sidonChain_card n]
+
+/-- **Existence of arbitrarily large Sidon sets.** For every `n` there is a Sidon
+set of cardinality `n`. Hence finite Sidon sets are unbounded in size, which is the
+existence fact the `greedySidonSeq*` axioms encode. -/
+theorem exists_sidon_card (n : ℕ) : ∃ A : Finset ℕ, IsSidon A ∧ A.card = n :=
+  ⟨sidonChain n, sidonChain_isSidon n, sidonChain_card n⟩
+
+end Erdos340Extension

--- a/research/problems/erdos-340-greedy-sidon/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon/knowledge.md
@@ -1,0 +1,78 @@
+# Erdős #340 — Greedy Sidon Sequence Growth (knowledge)
+
+## Status
+
+**OPEN CONJECTURE.** The main claim `|A ∩ [1,N]| ≫ N^(1/2−ε)` for the greedy
+(Mian–Chowla) Sidon sequence is unsolved; best known lower bound is `N^(1/3)`. This is
+the famous `1/3`-vs-`1/2` exponent gap. **Do not attempt to prove the conjecture.**
+
+The registered file `proofs/Proofs/Erdos340GreedySidon.lean` carries four `axiom`s:
+
+| axiom | content | status |
+|-------|---------|--------|
+| `sidon_upper_bound` | Erdős–Turán `|A| ≤ √N + O(N^{1/4})` | known result, ~100 lines, HARD |
+| `greedySidonSeq` | the sequence `ℕ → ℕ` | existence |
+| `greedySidonSeq_strictMono` | strictly increasing | existence |
+| `greedySidonSeq_isSidon` | all prefixes Sidon | existence |
+
+(`sidon_upper_bound_weak : |A| ≤ √(2N)+1` is **proved** in-file via `sidon_lower_bound`.)
+
+## Contribution this cycle — Sidon extendability kernel
+
+The three `greedySidonSeq*` axioms encode one substantive existence fact: **finite
+Sidon sets are unboundedly extendable.** That fact is now proved constructively in the
+companion `proofs/Proofs/Erdos340GreedySidonExtension.lean` (namespace
+`Erdos340Extension`), sorry-free and axiom-free:
+
+- `sidon_insert_two_sup_add_one` — inserting the **explicit** witness `m = 2·sup A + 1`
+  into a Sidon set `A` keeps it Sidon.
+- `sidon_extendable` — `∃ m, (∀ a∈A, a<m) ∧ m∉A ∧ IsSidon (insert m A)`.
+- `sidonChain n` / `sidonChain_isSidon` / `sidonChain_card` — an explicit doubling
+  chain of Sidon sets with `|sidonChain n| = n`.
+- `exists_sidon_card n` — Sidon sets of every cardinality exist.
+
+### Why `m = 2·sup A + 1` is collision-free
+
+Let `S = sup A` (so all of `A` is `≤ S`), `m = 2S+1 > S`. A new collision is
+`a+b = c+d` (`a≤b`, `c≤d`) using `m`. Since `m` strictly exceeds every element of `A`,
+each side's sum lies in one of three **disjoint** bands by how many `m`s it uses:
+no-`m` `≤ 2S`; one-`m` `∈ [2S+1, 3S+1]`; two-`m` `= 4S+2`. Equal sums ⇒ equal `m`-count
+per side ⇒ `Nat` cancellation (plus the original Sidon property when both sides are
+`m`-free) gives `a=c, b=d`. The Lean proof discharges this with a 16-way `rcases` bash
+closed uniformly by `omega` (feeding the `≤ S` bounds), except the all-in-`A` branch
+which calls `hA` directly.
+
+### Honesty note
+
+This is the **doubling** construction, not the greedy Mian–Chowla one, so it does *not*
+literally reproduce `greedySidonSeq` (which is greedy-minimal). It discharges the
+*existence* content the axioms stand on, not greedy minimality. Growth here is only
+`Ω(log N)` (cardinality `n` reaches value `~2^n`), nowhere near `N^(1/3)`; it is an
+existence witness, not a growth result.
+
+## Verification status
+
+**BUILD-PENDING / UNREGISTERED.** Companion is NOT in `Proofs.lean` — there is no CI
+Lean build gate (`check-proofs-imports.yml` is `workflow_dispatch` sync-only, never
+compiles), so registering an unbuilt file risks `main`. Written under dual blackout:
+Aristotle `prove` returns 404 (Resource not found); host `proofs/.lake` is a circular
+self-symlink, so `docker-build.sh` would re-clone+rebuild all of Mathlib (hours / OOM
+on the 7.65 GiB Docker VM, already running 3 lean containers).
+
+### Next actions (on backend recovery)
+
+1. `./proofs/scripts/docker-build.sh Proofs.Erdos340GreedySidonExtension` to confirm
+   0 sorry / 0 axiom.
+2. If green, register in `Proofs.lean` and add gallery cross-reference from
+   `erdos-340-greedy-sidon`.
+3. Optional axiom reduction: re-found `greedySidonSeq*` on `sidon_extendable` (replace
+   the three existence axioms with the proved chain), leaving only the genuinely-hard
+   `sidon_upper_bound` (Erdős–Turán) and the open conjecture statement.
+
+## Routes that do NOT close the gap (for future agents)
+
+- Counting differences gives `√(2N)+1` (done) — counting **sums** gives Erdős–Turán
+  `√N + O(N^{1/4})`; both are *upper* bounds, neither touches the lower-bound gap.
+- The greedy lower bound is cubic `a_n = O(n^3)` (global forbidden-set covering, NOT the
+  naive incremental `a_{k+1}−a_k ≤ |A_k|^3` which only telescopes to `O(n^4)`); inverting
+  gives `Ω(N^{1/3})`. Any exponent `> 1/3` for greedy would be a publishable new result.


### PR DESCRIPTION
## Summary

Erdős #340 (greedy Sidon growth) is an **open conjecture** (`|A∩[1,N]| ≫ N^(1/2−ε)`; best known `N^(1/3)`). The conjecture is untouched here. This PR discharges the *existence* content underlying the registered file's three `greedySidonSeq*` axioms.

New companion `proofs/Proofs/Erdos340GreedySidonExtension.lean` (namespace `Erdos340Extension`), **sorry-free, axiom-free**:

- `sidon_insert_two_sup_add_one` — inserting the explicit witness `m = 2·sup A + 1` into a Sidon set keeps it Sidon.
- `sidon_extendable` — `∃ m, (∀ a∈A, a<m) ∧ m∉A ∧ IsSidon (insert m A)`.
- `sidonChain` / `sidonChain_isSidon` / `sidonChain_card` — explicit doubling chain with `|sidonChain n| = n`.
- `exists_sidon_card n` — Sidon sets of every cardinality exist.

**Why `m = 2·sup A + 1` is collision-free**: `m` strictly exceeds every element of `A`, so each side of a sum `a+b=c+d` lands in one of three disjoint bands by its `m`-count (`≤2S` / `[2S+1,3S+1]` / `4S+2`); equal sums force equal `m`-counts per side, then `Nat` cancellation (plus the original Sidon property for the `m`-free case) gives `(a,b)=(c,d)`.

**Honesty**: this is the *doubling* construction, not greedy Mian–Chowla, so it does not reproduce `greedySidonSeq` (greedy-minimal); it witnesses existence, not growth (growth here is only `Ω(log N)`).

## Status

- **BUILD-PENDING / UNREGISTERED.** Not in `Proofs.lean` — no CI Lean build gate, so registering an unbuilt file risks `main`. Written under dual blackout: Aristotle `prove` → 404; host `proofs/.lake` circular self-symlink (docker-build would re-clone all Mathlib → OOM risk).
- On backend recovery: `docker-build Proofs.Erdos340GreedySidonExtension`, then register and optionally re-found `greedySidonSeq*` on `sidon_extendable` (3 axioms → 0, leaving only the Erdős–Turán `sidon_upper_bound` and the open conjecture).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos340GreedySidonExtension` → 0 sorry, 0 axiom
- [ ] Register in `Proofs.lean` once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)