### PR TITLE
research(van-aubel-theorem-oq-01): register + gallery (build-verified 0/0)

### DIFF
--- a/src/data/proofs/van-aubel-theorem-oq-01/annotations.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-square-center",
+    "proofId": "van-aubel-theorem-oq-01",
+    "range": { "startLine": 37, "endLine": 39 },
+    "type": "definition",
+    "title": "squareCenter: center of the externally erected square",
+    "content": "On the directed edge u → v, the square erected outward has its center at the edge midpoint (u+v)/2 displaced by the outward normal i·(v-u)/2. Multiplication by i rotates the edge vector v-u by +90°, and dividing by 2 makes the displacement half the edge length — exactly the offset from a side's midpoint to the center of the square built on it. Encoding the plane as ℂ lets a single closed-form expression replace any synthetic construction.",
+    "mathContext": "$\\mathrm{squareCenter}(u,v) = \\dfrac{u+v}{2} + i\\,\\dfrac{v-u}{2}$. The outward normal direction is $i(v-u)$ and the square's center sits at distance $\\tfrac12\\lvert v-u\\rvert$ from the midpoint along it.",
+    "significance": "supporting",
+    "relatedConcepts": ["complex plane as ℝ²", "90° rotation via multiplication by i", "midpoint and normal offset"],
+    "prerequisites": ["complex numbers", "geometric meaning of i"]
+  },
+  {
+    "id": "ann-key-identity",
+    "proofId": "van-aubel-theorem-oq-01",
+    "range": { "startLine": 41, "endLine": 48 },
+    "type": "theorem",
+    "title": "vanAubel_key: R - P = i·(S - Q)",
+    "content": "This is the heart of the entire proof. Expanding the four square centers P, Q, R, S and simplifying, the diagonal vector R - P equals exactly i times the other diagonal vector S - Q. The proof is `linear_combination (-(a+b-c-d)/2) * Complex.I_sq`: every term is a polynomial in a,b,c,d except for a single occurrence of i², which the linear_combination absorbs using Complex.I_sq (i² = -1). Both named consequences of van Aubel's theorem are one-line corollaries of this identity.",
+    "mathContext": "With $P=\\mathrm{sc}(a,b),Q=\\mathrm{sc}(b,c),R=\\mathrm{sc}(c,d),S=\\mathrm{sc}(d,a)$: $R-P = -\\tfrac{a+b-c-d}{2} + i\\,\\tfrac{a-b-c+d}{2}$ and $i(S-Q)$ equals the same, using $i^2=-1$.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination tactic", "i² = -1", "complex rotation of diagonals"],
+    "prerequisites": ["complex arithmetic", "linear_combination in Mathlib"]
+  },
+  {
+    "id": "ann-equal-diagonals",
+    "proofId": "van-aubel-theorem-oq-01",
+    "range": { "startLine": 50, "endLine": 54 },
+    "type": "theorem",
+    "title": "vanAubel_equal_diagonals: |R - P| = |S - Q|",
+    "content": "The segments PR and QS joining opposite square centers have equal length. After rewriting with the key identity, the goal is |i·(S-Q)| = |S-Q|, which follows from norm_mul and |i| = 1. Multiplication by i is a rotation, hence an isometry, so it cannot change the length of S - Q.",
+    "mathContext": "$\\lVert R-P\\rVert = \\lVert i(S-Q)\\rVert = \\lvert i\\rvert\\,\\lVert S-Q\\rVert = 1\\cdot\\lVert S-Q\\rVert$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_mul", "Complex.norm_I", "isometry of rotation"],
+    "prerequisites": ["complex modulus", "|zw| = |z||w|"]
+  },
+  {
+    "id": "ann-perp-diagonals",
+    "proofId": "van-aubel-theorem-oq-01",
+    "range": { "startLine": 56, "endLine": 63 },
+    "type": "theorem",
+    "title": "vanAubel_perp_diagonals: PR ⟂ QS",
+    "content": "Perpendicularity is encoded as the vanishing of the real part of (R-P)·conj(S-Q) — the Euclidean inner product of the two diagonal vectors. Rewriting with the key identity and Complex.mul_conj turns the product into i·|S-Q|², which is purely imaginary, so its real part is 0. Thus the diagonals meet at a right angle.",
+    "mathContext": "$\\big((R-P)\\,\\overline{(S-Q)}\\big)_{\\mathrm{re}} = \\big(i\\,(S-Q)\\overline{(S-Q)}\\big)_{\\mathrm{re}} = \\big(i\\,\\lvert S-Q\\rvert^2\\big)_{\\mathrm{re}} = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.mul_conj", "Complex.I_mul_re", "Euclidean inner product as Re(z·conj w)"],
+    "prerequisites": ["complex conjugate", "z·conj z = |z|²", "real part of a purely imaginary number"]
+  }
+]

--- a/src/data/proofs/van-aubel-theorem-oq-01/meta.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "van-aubel-theorem-oq-01",
+  "title": "van Aubel's Theorem via a Single Complex Identity",
+  "slug": "van-aubel-theorem-oq-01",
+  "description": "van Aubel's theorem: erect squares externally on the four sides of an arbitrary planar quadrilateral and join the centers of opposite squares. The two resulting segments are equal in length and perpendicular. Modelling the plane as ℂ, the entire theorem collapses to one algebraic identity R - P = i·(S - Q), from which equal length and perpendicularity follow because multiplication by i is a length-preserving 90° rotation. 3 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Van_Aubel%27s_theorem",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanAubelTheoremOQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "quadrilateral",
+      "van-aubel",
+      "complex-numbers",
+      "coordinate-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 65,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "originalContributions": [
+      "vanAubel_key: the single complex identity R - P = i·(S - Q) relating the diagonals of the square-center quadrilateral, proved by linear_combination using i² = -1",
+      "vanAubel_equal_diagonals: the segments PR and QS joining opposite square centers have equal length, immediate from the key identity since |i| = 1",
+      "vanAubel_perp_diagonals: PR and QS are perpendicular, encoded as the vanishing real part of (R - P)·conj(S - Q)",
+      "squareCenter: closed-form complex expression (u + v)/2 + i·(v - u)/2 for the center of the square erected externally on a directed edge u → v"
+    ]
+  },
+  "overview": {
+    "historicalContext": "van Aubel's theorem was published by the Belgian mathematician Henricus Hubertus van Aubel in 1878. It is the quadrilateral analogue of Napoleon's theorem (which erects equilateral triangles on the sides of a triangle): given an arbitrary planar quadrilateral, erect a square externally on each of its four sides and mark the center of each square. van Aubel's theorem asserts that the two line segments joining the centers of opposite squares are both equal in length and perpendicular to one another. The result holds for completely arbitrary quadrilaterals — convex, concave, or self-intersecting — which makes the complex-number proof especially clean, since no case analysis on the shape is required.",
+    "problemStatement": "Let a, b, c, d ∈ ℂ be the vertices of an arbitrary quadrilateral. Erect a square externally on each directed side and let P, Q, R, S be the centers of the squares on sides a→b, b→c, c→d, d→a respectively. Prove that the segments PR and QS satisfy |PR| = |QS| (equal diagonals) and PR ⟂ QS (perpendicular diagonals).",
+    "proofStrategy": "Model the plane as ℂ. The center of the square erected externally on the directed edge u → v is squareCenter u v = (u + v)/2 + i·(v - u)/2, where multiplication by i realises the outward 90° rotation. Writing P, Q, R, S for the four centers, a direct expansion yields the single identity R - P = i·(S - Q). This is proved by linear_combination with coefficient -(a+b-c-d)/2 applied to Complex.I_sq (i² = -1), since the only non-ring fact needed is i² = -1. From the key identity, equal length follows from norm_mul and |i| = 1, and perpendicularity follows because (i·z)·conj(z) = i·|z|² is purely imaginary, so its real part vanishes.",
+    "keyInsights": [
+      "**Everything reduces to one identity.** The full geometric statement (equal length AND perpendicular) is equivalent to the single complex equation R - P = i·(S - Q). Once this is established the two named consequences are one-line corollaries.",
+      "**Multiplication by i encodes the 90° rotation twice.** It appears once in the definition of squareCenter (erecting the square outward) and once in the key identity (rotating one diagonal onto the other). The same operation that builds the squares relates the diagonals.",
+      "**Length-preservation and orthogonality are the real and modular content of i.** |i| = 1 gives |PR| = |QS|; the fact that i·(real) is purely imaginary gives the perpendicularity. No trigonometry, no coordinates beyond ℂ, no case analysis on the quadrilateral's shape.",
+      "**The proof needs exactly one non-ring fact: i² = -1.** linear_combination isolates precisely this, with the rest handled by the commutative-ring normaliser."
+    ],
+    "prerequisites": [
+      "Complex numbers as the Euclidean plane (addition = translation, multiplication by i = 90° rotation)",
+      "Complex modulus and conjugate (|zw| = |z||w|, z·conj z = |z|²)",
+      "Lean 4 linear_combination and ring tactics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "square-center",
+      "title": "Square Center Definition",
+      "startLine": 37,
+      "endLine": 39,
+      "summary": "squareCenter u v = (u + v)/2 + i·(v - u)/2 gives the center of the square erected externally on the directed edge u → v, with the +90° rotation convention i·(v - u).",
+      "mathContext": "$\\mathrm{squareCenter}(u,v) = \\frac{u+v}{2} + i\\,\\frac{v-u}{2}$. The midpoint $(u+v)/2$ is displaced by the outward normal $i(v-u)/2$ of length half the edge."
+    },
+    {
+      "id": "key-identity",
+      "title": "Key Identity R - P = i·(S - Q)",
+      "startLine": 41,
+      "endLine": 48,
+      "summary": "vanAubel_key: for any a, b, c, d the diagonal vector R - P equals i times the diagonal vector S - Q. Proved by linear_combination (-(a+b-c-d)/2)·Complex.I_sq, the only non-ring input being i² = -1.",
+      "mathContext": "$R - P = -\\tfrac{a+b-c-d}{2} + i\\,\\tfrac{a-b-c+d}{2} = i\\,(S - Q)$."
+    },
+    {
+      "id": "equal-diagonals",
+      "title": "Equal Diagonals",
+      "startLine": 50,
+      "endLine": 54,
+      "summary": "vanAubel_equal_diagonals: |R - P| = |S - Q|, immediate from the key identity via norm_mul and |i| = 1.",
+      "mathContext": "$\\lVert R - P\\rVert = \\lVert i(S-Q)\\rVert = \\lvert i\\rvert\\,\\lVert S-Q\\rVert = \\lVert S - Q\\rVert$."
+    },
+    {
+      "id": "perp-diagonals",
+      "title": "Perpendicular Diagonals",
+      "startLine": 56,
+      "endLine": 63,
+      "summary": "vanAubel_perp_diagonals: the real part of (R - P)·conj(S - Q) vanishes, so the segments are orthogonal. Uses Complex.mul_conj and I_mul_re.",
+      "mathContext": "$\\big((R-P)\\,\\overline{(S-Q)}\\big) = i\\,\\lvert S-Q\\rvert^2$ is purely imaginary, so its real part is $0$ — the Euclidean inner product of the two diagonal vectors."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully proves van Aubel's theorem for an arbitrary planar quadrilateral by reducing it to the single complex identity R - P = i·(S - Q). Equal diagonal length and perpendicularity follow as one-line corollaries from the modulus and imaginary-part properties of multiplication by i. 3 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The complex-number model turns a classical synthetic-geometry result into a short algebraic identity that holds uniformly for convex, concave, and self-intersecting quadrilaterals. It illustrates the general principle that planar rotation theorems (Napoleon, van Aubel, Thébault, Petr–Douglas–Neumann) become routine ring identities once points are encoded as complex numbers and rotations as multiplication by roots of unity.",
+    "openQuestions": [
+      "Does the same i-multiplication technique give a one-identity proof of Thébault's theorem (squares on a parallelogram) or the Petr–Douglas–Neumann theorem for n-gons?",
+      "Can the external-square construction be replaced by similar rectangles or directly-similar figures (van Aubel's generalization) while preserving a single-identity proof?",
+      "What is the locus of the common midpoint of PR and QS as the quadrilateral deforms, and can it be characterized algebraically in ℂ?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Napoleon's theorem is the triangle analogue (equilateral triangles on the sides), proved by the same complex-number / root-of-unity technique."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/VanAubelTheoremOQ01.lean",
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+    ],
+    "opens": [
+      "Complex",
+      "ComplexConjugate"
+    ],
+    "namespace": "VanAubelTheoremOQ01",
+    "lineCount": 65,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
- `Proofs/VanAubelTheoremOQ01.lean` was merged via #24989 but left **unregistered** in `Proofs.lean` with **no gallery data**. This completes it.
- **Docker build green**: `Build completed successfully (3062 jobs)`, 0 `sorry`, 0 `axiom`, 0 structure-encoded assumptions.
- Registers `import Proofs.VanAubelTheoremOQ01` in `proofs/Proofs.lean`.
- Adds gallery `src/data/proofs/van-aubel-theorem-oq-01/meta.json` + `annotations.json`.

## Math
van Aubel's theorem (1878): erect squares externally on the sides of an arbitrary planar quadrilateral; the segments joining opposite square centers are **equal in length** and **perpendicular**. Modelled over ℂ with `squareCenter u v = (u+v)/2 + i·(v-u)/2`, the whole theorem reduces to one identity `R - P = i·(S - Q)` (`vanAubel_key`, via `linear_combination … * Complex.I_sq`). Equal length follows from `|i| = 1`; perpendicularity from `(i·z)·conj z = i·|z|²` being purely imaginary.

## Notes
- The `.lean` source here is byte-identical to the version merged in #24989, which is the version I build-verified.
- `research` label only (math PR, deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)