### PR TITLE
research(menelaus-theorem-oq-01): formalize Menelaus's theorem (0 sorry/0 axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2881,6 +2881,7 @@ import Proofs.MeanValueTheoremOQ02OQ04OQ01
 import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
 import Proofs.MeanValueTheoremOQ05
+import Proofs.MenelausTheorem
 import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ02

--- a/proofs/Proofs/MenelausTheorem.lean
+++ b/proofs/Proofs/MenelausTheorem.lean
@@ -1,0 +1,139 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+/-!
+# Menelaus's Theorem (collinearity via signed side ratios)
+
+## What This Proves
+For a triangle `A B C` and points
+* `X` on line `BC` with `X = (1-t)·B + t·C`,
+* `Y` on line `CA` with `Y = (1-u)·C + u·A`,
+* `Z` on line `AB` with `Z = (1-v)·A + v·B`,
+
+the three points `X, Y, Z` are collinear **iff** the product of signed side ratios
+
+  (BX/XC) · (CY/YA) · (AZ/ZB) = (t/(1-t)) · (u/(1-u)) · (v/(1-v)) = -1.
+
+This is the transversal companion of Ceva's theorem (`CevasTheorem.lean`), which
+characterises *concurrency* of cevians by the same product equalling `+1`.
+
+## Approach
+Work in the affine plane `ℝ × ℝ`. Collinearity of three points is encoded by the
+vanishing of the signed-area determinant `collinearDet`. The mathematical heart is the
+factorisation
+
+  collinearDet X Y Z = (t·u·v + (1-t)·(1-u)·(1-v)) · collinearDet A B C,
+
+a pure polynomial identity discharged by `ring`. For a non-degenerate triangle the base
+determinant is non-zero, so collinearity is equivalent to the scalar factor vanishing,
+i.e. `t·u·v = -(1-t)(1-u)(1-v)`, which `field_simp` shows is exactly the signed-ratio
+product being `-1`.
+
+## Status
+- [x] Signed-area determinant and collinearity predicate
+- [x] Determinant factorisation (the geometric content)
+- [x] Main equivalence: collinearity ↔ product = -1
+- [x] Directional corollaries and a concrete numerical instance
+- [x] 0 sorries, 0 axioms
+
+## Mathlib Dependencies
+Real arithmetic, `field_simp`, `ring`, `linear_combination`, `mul_eq_zero`.
+
+Note: Menelaus's theorem is **not** a named Mathlib result.
+-/
+
+namespace MenelausTheorem
+
+set_option linter.unusedVariables false
+
+/-- A point in the affine plane. -/
+abbrev Pt := ℝ × ℝ
+
+/-- Twice the signed area of triangle `P Q R`: the `2×2` determinant of the edge
+    vectors `Q - P` and `R - P`. It vanishes exactly when the points are collinear. -/
+def collinearDet (P Q R : Pt) : ℝ :=
+  (Q.1 - P.1) * (R.2 - P.2) - (Q.2 - P.2) * (R.1 - P.1)
+
+/-- Three points are collinear when their signed-area determinant vanishes. -/
+def Collinear3 (P Q R : Pt) : Prop := collinearDet P Q R = 0
+
+/-- Configuration for Menelaus: a triangle `A B C` with transversal division
+    parameters `t, u, v`. Each parameter must avoid `1` so the corresponding signed
+    ratio `t/(1-t)` is defined, and the triangle must be non-degenerate. -/
+structure MenelausConfig where
+  A : Pt
+  B : Pt
+  C : Pt
+  t : ℝ
+  u : ℝ
+  v : ℝ
+  t_ne_1 : t ≠ 1
+  u_ne_1 : u ≠ 1
+  v_ne_1 : v ≠ 1
+  nondegen : collinearDet A B C ≠ 0
+
+/-- `X = (1-t)·B + t·C` divides line `BC`. -/
+def ptX (cfg : MenelausConfig) : Pt :=
+  ((1 - cfg.t) * cfg.B.1 + cfg.t * cfg.C.1, (1 - cfg.t) * cfg.B.2 + cfg.t * cfg.C.2)
+
+/-- `Y = (1-u)·C + u·A` divides line `CA`. -/
+def ptY (cfg : MenelausConfig) : Pt :=
+  ((1 - cfg.u) * cfg.C.1 + cfg.u * cfg.A.1, (1 - cfg.u) * cfg.C.2 + cfg.u * cfg.A.2)
+
+/-- `Z = (1-v)·A + v·B` divides line `AB`. -/
+def ptZ (cfg : MenelausConfig) : Pt :=
+  ((1 - cfg.v) * cfg.A.1 + cfg.v * cfg.B.1, (1 - cfg.v) * cfg.A.2 + cfg.v * cfg.B.2)
+
+/-- The product of the three signed side ratios
+    `(BX/XC) · (CY/YA) · (AZ/ZB) = (t/(1-t)) · (u/(1-u)) · (v/(1-v))`. -/
+noncomputable def menelausProduct (cfg : MenelausConfig) : ℝ :=
+  (cfg.t / (1 - cfg.t)) * (cfg.u / (1 - cfg.u)) * (cfg.v / (1 - cfg.v))
+
+/-- **Geometric content of Menelaus.** The collinearity determinant of the three
+    division points factors as the Menelaus scalar `t·u·v + (1-t)(1-u)(1-v)` times the
+    signed area of the underlying triangle. Pure polynomial identity. -/
+theorem collinearDet_factor (cfg : MenelausConfig) :
+    collinearDet (ptX cfg) (ptY cfg) (ptZ cfg)
+      = (cfg.t * cfg.u * cfg.v + (1 - cfg.t) * (1 - cfg.u) * (1 - cfg.v))
+        * collinearDet cfg.A cfg.B cfg.C := by
+  simp only [collinearDet, ptX, ptY, ptZ]
+  ring
+
+/-- **Menelaus's Theorem.** For a non-degenerate triangle, the transversal points
+    `X, Y, Z` are collinear iff the product of signed side ratios equals `-1`. -/
+theorem menelaus (cfg : MenelausConfig) :
+    Collinear3 (ptX cfg) (ptY cfg) (ptZ cfg) ↔ menelausProduct cfg = -1 := by
+  have ht : (1 : ℝ) - cfg.t ≠ 0 := sub_ne_zero.mpr (Ne.symm cfg.t_ne_1)
+  have hu : (1 : ℝ) - cfg.u ≠ 0 := sub_ne_zero.mpr (Ne.symm cfg.u_ne_1)
+  have hv : (1 : ℝ) - cfg.v ≠ 0 := sub_ne_zero.mpr (Ne.symm cfg.v_ne_1)
+  unfold Collinear3
+  rw [collinearDet_factor, mul_eq_zero, or_iff_left cfg.nondegen]
+  unfold menelausProduct
+  rw [div_mul_div_comm, div_mul_div_comm,
+    div_eq_iff (mul_ne_zero (mul_ne_zero ht hu) hv)]
+  constructor
+  · intro h; linear_combination h
+  · intro h; linear_combination h
+
+/-- Collinearity of the transversal points implies the signed-ratio product is `-1`. -/
+theorem product_of_collinear (cfg : MenelausConfig)
+    (h : Collinear3 (ptX cfg) (ptY cfg) (ptZ cfg)) : menelausProduct cfg = -1 :=
+  (menelaus cfg).mp h
+
+/-- If the signed-ratio product is `-1`, the transversal points are collinear. -/
+theorem collinear_of_product (cfg : MenelausConfig)
+    (h : menelausProduct cfg = -1) : Collinear3 (ptX cfg) (ptY cfg) (ptZ cfg) :=
+  (menelaus cfg).mpr h
+
+/-- A concrete instance: triangle `(0,0),(1,0),(0,1)` with `t = u = 2`, `v = -1/3`
+    gives product `-1`, hence the three division points are collinear. -/
+theorem menelaus_example :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧ Collinear3 (ptX cfg) (ptY cfg) (ptZ cfg) := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 2, u := 2, v := -1/3,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · apply collinear_of_product; unfold menelausProduct; norm_num
+
+end MenelausTheorem

--- a/research/problems/menelaus-theorem-oq-01/knowledge.md
+++ b/research/problems/menelaus-theorem-oq-01/knowledge.md
@@ -1,0 +1,56 @@
+# Knowledge Base: menelaus-theorem-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Menelaus's theorem (transversal companion of Ceva): for triangle ABC and points
+X on BC, Y on CA, Z on AB, the points X,Y,Z are collinear iff the product of
+signed side ratios (BX/XC)·(CY/YA)·(AZ/ZB) = -1. Not a named Mathlib result.
+
+Parametrisation used: X=(1-t)B+tC, Y=(1-u)C+uA, Z=(1-v)A+vB, so the signed
+ratios are t/(1-t), u/(1-u), v/(1-v).
+
+---
+
+## Insights
+
+- **Determinant factorisation is the whole content.** Encode collinearity in ℝ²
+  by the signed-area determinant collinearDet P Q R = (Q.1-P.1)(R.2-P.2) -
+  (Q.2-P.2)(R.1-P.1). Then, exactly:
+      collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C.
+  Verified symbolically in sympy first; in Lean it is a one-line `ring`.
+- The scalar factor `t·u·v + (1-t)(1-u)(1-v)` expands to
+  `1 - t - u - v + tu + tv + uv` (the tuv terms cancel) — equivalently the
+  Menelaus condition tuv = -(1-t)(1-u)(1-v).
+- Non-degeneracy of the triangle (collinearDet A B C ≠ 0) is precisely what lets
+  `mul_eq_zero` + `or_iff_left` cancel the area factor and isolate the scalar.
+- Matching the scalar condition to the product form is `div_mul_div_comm` (×2) +
+  `div_eq_iff` + `linear_combination`. Only parameters ≠ 1 are needed (no t≠0).
+- Mirrors Ceva: same affine-parameter / signed-ratio framework, product +1
+  (concurrency) vs -1 (collinearity).
+
+---
+
+## Dead Ends
+
+- None. The first approach (signed-area determinant + ring factorisation) worked
+  cleanly. No EuclideanSpace / AffineMap machinery was needed — plain ℝ×ℝ with
+  coordinate projections keeps `ring` happy.
+
+---
+
+## Session Log
+
+### 2026-06-16 (s01) — FRESH, COMPLETED
+- **Outcome**: completed (pending green build + merge).
+- Wrote `proofs/Proofs/MenelausTheorem.lean` (139 lines, 0 sorry, 0 axiom):
+  `collinearDet`, `Collinear3`, `MenelausConfig`, `ptX/ptY/ptZ`,
+  `menelausProduct`, `collinearDet_factor`, main `menelaus`, two directional
+  corollaries, and a concrete numeric instance (t=u=2, v=-1/3 → product -1).
+- Authored gallery data: `src/data/proofs/menelaus-theorem-oq-01/{meta,annotations}.json`.
+- Built by module name via docker-build (`.lake` self-symlink forced a Mathlib
+  re-clone in-container).
+- **Next**: register in Proofs.lean (after MeanValueTheoremOQ04), open `research` PR.

--- a/src/data/proofs/menelaus-theorem-oq-01/annotations.json
+++ b/src/data/proofs/menelaus-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-menelaus01-collinear-det",
+    "proofId": "menelaus-theorem-oq-01",
+    "range": { "startLine": 54, "endLine": 58 },
+    "type": "definition",
+    "title": "Signed-Area Determinant and Collinearity Predicate",
+    "content": "collinearDet P Q R = (Q.1-P.1)(R.2-P.2) - (Q.2-P.2)(R.1-P.1) is twice the signed area of triangle PQR — equivalently the cross product of the edge vectors Q-P and R-P. It vanishes exactly when P, Q, R lie on a common line, which is how Collinear3 P Q R is defined. This coordinate-free-looking test is purely algebraic, so all downstream reasoning reduces to polynomial identities over ℝ.",
+    "mathContext": "\\det\\begin{pmatrix} Q_x-P_x & R_x-P_x \\\\ Q_y-P_y & R_y-P_y \\end{pmatrix} = (Q_x-P_x)(R_y-P_y) - (Q_y-P_y)(R_x-P_x) = 0 \\iff P,Q,R \\text{ collinear}",
+    "significance": "key",
+    "relatedConcepts": ["signed area", "cross product", "collinearity test", "2x2 determinant"],
+    "prerequisites": ["Pt"]
+  },
+  {
+    "id": "ann-menelaus01-config",
+    "proofId": "menelaus-theorem-oq-01",
+    "range": { "startLine": 63, "endLine": 93 },
+    "type": "definition",
+    "title": "Menelaus Configuration: Transversal Division Points",
+    "content": "MenelausConfig bundles a triangle A,B,C with parameters t,u,v locating the transversal points X=(1-t)B+tC on BC, Y=(1-u)C+uA on CA, Z=(1-v)A+vB on AB. Each parameter must avoid 1 so the signed ratio t/(1-t) is defined, and the triangle must be non-degenerate (collinearDet A B C ≠ 0). The signed-ratio product menelausProduct = (t/(1-t))·(u/(1-u))·(v/(1-v)) is the quantity Menelaus's theorem characterises.",
+    "mathContext": "\\frac{BX}{XC}=\\frac{t}{1-t},\\quad \\frac{CY}{YA}=\\frac{u}{1-u},\\quad \\frac{AZ}{ZB}=\\frac{v}{1-v}",
+    "significance": "standard",
+    "relatedConcepts": ["affine combination", "signed ratio", "non-degenerate triangle"],
+    "prerequisites": ["collinearDet"]
+  },
+  {
+    "id": "ann-menelaus01-factor",
+    "proofId": "menelaus-theorem-oq-01",
+    "range": { "startLine": 95, "endLine": 102 },
+    "type": "insight",
+    "title": "Determinant Factorisation — the Geometric Heart",
+    "content": "collinearDet_factor is the entire mathematical content of the theorem: expanding the collinearity determinant of the three division points and collecting terms gives the exact factorisation collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C. The first factor is the Menelaus scalar; the second is twice the area of the underlying triangle. The identity is a pure polynomial equality verified by `ring`. Everything else is bookkeeping around this single algebraic fact (verified independently in sympy before formalization).",
+    "mathContext": "\\det(XYZ) = \\big(tuv + (1-t)(1-u)(1-v)\\big)\\cdot\\det(ABC)",
+    "significance": "key",
+    "relatedConcepts": ["polynomial identity", "ring tactic", "area factorisation"],
+    "prerequisites": ["collinearDet", "ptX", "ptY", "ptZ"]
+  },
+  {
+    "id": "ann-menelaus01-main",
+    "proofId": "menelaus-theorem-oq-01",
+    "range": { "startLine": 104, "endLine": 117 },
+    "type": "insight",
+    "title": "Menelaus's Theorem: Collinearity ⟺ Product = -1",
+    "content": "The main biconditional: for a non-degenerate triangle, X, Y, Z are collinear iff menelausProduct = -1. After rewriting by collinearDet_factor, mul_eq_zero splits the product determinant; or_iff_left discharges the non-zero base area (cfg.nondegen), leaving the scalar condition t·u·v + (1-t)(1-u)(1-v) = 0. The product form is normalised by div_mul_div_comm and div_eq_iff to t·u·v = -1·((1-t)(1-u)(1-v)); the two polynomial statements coincide, closed by linear_combination. Non-degeneracy is exactly what allows cancelling the area factor.",
+    "mathContext": "X,Y,Z \\text{ collinear} \\iff tuv = -(1-t)(1-u)(1-v) \\iff \\frac{t}{1-t}\\cdot\\frac{u}{1-u}\\cdot\\frac{v}{1-v} = -1",
+    "significance": "key",
+    "relatedConcepts": ["biconditional", "mul_eq_zero", "div_eq_iff", "linear_combination"],
+    "prerequisites": ["collinearDet_factor", "menelausProduct"]
+  },
+  {
+    "id": "ann-menelaus01-example",
+    "proofId": "menelaus-theorem-oq-01",
+    "range": { "startLine": 130, "endLine": 139 },
+    "type": "example",
+    "title": "Concrete Witness: t=u=2, v=-1/3",
+    "content": "menelaus_example exhibits a non-vacuous instance on the reference triangle (0,0),(1,0),(0,1): with t=u=2 (X, Y external to their segments) and v=-1/3, the signed-ratio product is (-2)·(-2)·(-1/4) = -1, so the main theorem certifies that the three division points are collinear. This demonstrates the external-segment parity characteristic of Menelaus configurations (an odd number of points lie outside their side segments).",
+    "mathContext": "\\frac{2}{1-2}\\cdot\\frac{2}{1-2}\\cdot\\frac{-1/3}{1+1/3} = (-2)(-2)\\left(-\\tfrac14\\right) = -1",
+    "significance": "supporting",
+    "relatedConcepts": ["external division", "parity of signs", "concrete instance"],
+    "prerequisites": ["menelaus", "collinear_of_product"]
+  }
+]

--- a/src/data/proofs/menelaus-theorem-oq-01/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "menelaus-theorem-oq-01",
+  "title": "Menelaus's Theorem: Collinearity via Signed Side Ratios",
+  "slug": "menelaus-theorem-oq-01",
+  "description": "Formalizes Menelaus's theorem in the affine plane ℝ²: for a triangle ABC and transversal division points X on BC, Y on CA, Z on AB, the points are collinear iff the product of signed side ratios (t/(1-t))·(u/(1-u))·(v/(1-v)) equals -1. The proof rests on a determinant factorisation collinearDet X Y Z = (tuv + (1-t)(1-u)(1-v))·collinearDet A B C. 5 theorems, 0 sorries, 0 axioms. The transversal companion of Ceva's concurrency theorem.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Menelaus%27s_theorem",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MenelausTheorem.lean",
+    "tags": [
+      "geometry",
+      "menelaus",
+      "affine-coordinates",
+      "collinearity",
+      "triangles",
+      "signed-ratios"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 139,
+    "theoremCount": 5,
+    "definitionCount": 6,
+    "originalContributions": [
+      "collinearDet: signed-area 2×2 determinant predicate for three points in ℝ²",
+      "Collinear3: collinearity as vanishing of the signed-area determinant",
+      "MenelausConfig: triangle with transversal division parameters t, u, v and non-degeneracy hypothesis",
+      "collinearDet_factor: the geometric heart — collinearDet X Y Z = (tuv + (1-t)(1-u)(1-v))·collinearDet A B C, a pure polynomial identity",
+      "menelaus: the main biconditional — collinearity of the transversal points iff the signed-ratio product equals -1",
+      "product_of_collinear / collinear_of_product: the two directional corollaries",
+      "menelaus_example: a concrete instance (t=u=2, v=-1/3) exhibiting product -1 and collinearity"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Menelaus of Alexandria (c. 70–140 CE) stated this transversal theorem in his *Sphaerica*, originally for great-circle arcs on the sphere; the planar version is the limiting case. It is the projective dual companion of Ceva's theorem (1678): where Ceva characterises the *concurrency* of three cevians by a signed-ratio product of +1, Menelaus characterises the *collinearity* of three points cut on the sides (extended) of a triangle by a transversal line, with the product equal to -1. The sign difference reflects that a straight transversal must cross an odd number of side-segments externally. Both results are cornerstones of triangle geometry and projective geometry, underpinning cross-ratio computations and results such as the theorems of Desargues and Pappus.",
+    "problemStatement": "For a triangle ABC and points X on line BC, Y on line CA, Z on line AB parametrised by X=(1-t)B+tC, Y=(1-u)C+uA, Z=(1-v)A+vB, are X, Y, Z collinear? Prove they are collinear iff the product of signed side ratios (t/(1-t))·(u/(1-u))·(v/(1-v)) equals -1.",
+    "text": "Working in ℝ², collinearity of three points is encoded by the vanishing of the signed-area determinant collinearDet P Q R = (Q.1-P.1)(R.2-P.2) - (Q.2-P.2)(R.1-P.1). Expanding collinearDet for the three division points yields, after `ring`, the exact factorisation collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C. For a non-degenerate triangle the base determinant is non-zero, so collinearity is equivalent to the scalar factor vanishing, i.e. t·u·v = -(1-t)(1-u)(1-v). A `field_simp`/`div_eq_iff` calculation shows this is exactly the signed-ratio product equalling -1.",
+    "proofStrategy": "Part I sets up the affine plane (Pt := ℝ×ℝ), the signed-area determinant collinearDet, and the collinearity predicate Collinear3. Part II bundles a triangle with transversal parameters in MenelausConfig (requiring each parameter ≠ 1 and a non-degenerate triangle) and defines the division points ptX, ptY, ptZ and the signed-ratio product menelausProduct. Part III proves the determinant factorisation collinearDet_factor by `ring`. Part IV derives the main biconditional `menelaus` by factoring, discharging the non-degenerate base determinant via mul_eq_zero, and matching the remaining polynomial condition to the product form via div_eq_iff + linear_combination. Part V records the directional corollaries and a concrete numeric instance.",
+    "keyInsights": [
+      "Collinearity of the three division points is captured by a single 2×2 signed-area determinant",
+      "The determinant factors exactly as (Menelaus scalar)·(triangle area): collinearDet X Y Z = (tuv + (1-t)(1-u)(1-v))·collinearDet A B C",
+      "Non-degeneracy of the triangle is precisely what lets us cancel the area factor and isolate the scalar condition",
+      "The scalar condition tuv + (1-t)(1-u)(1-v) = 0 is identical to the signed-ratio product equalling -1 (the tuv terms cancel in the expansion)",
+      "Menelaus (-1) and Ceva (+1) differ only in the sign of the product, mirroring transversal-collinearity vs cevian-concurrency"
+    ],
+    "prerequisites": [
+      "Affine geometry: points in ℝ², affine combinations (1-t)P+tQ",
+      "2×2 determinants and the signed-area / cross-product collinearity test",
+      "Real field arithmetic: field_simp, div_eq_iff, ring, linear_combination"
+    ]
+  },
+  "conclusion": {
+    "summary": "Menelaus's theorem is fully proved in ℝ² via affine coordinates: the transversal division points X, Y, Z are collinear iff the product of signed side ratios equals -1. The proof reduces to a single determinant factorisation (collinearDet X Y Z = (tuv + (1-t)(1-u)(1-v))·collinearDet A B C) discharged by `ring`, with non-degeneracy cancelling the area factor. Both directional corollaries and a concrete numeric witness are included. 5 theorems, 6 definitions, 139 lines, 0 axioms.",
+    "implications": "Provides the collinearity counterpart to the gallery's Ceva concurrency formalizations, completing the classical Ceva/Menelaus duality. The determinant-factorisation technique is reusable for other ratio/collinearity results (e.g. Routh's theorem and the theorems of Desargues and Pappus).",
+    "openQuestions": [
+      "Signed/unsigned reconciliation: derive the unsigned |product| = 1 form and the precise external-segment parity statement",
+      "Use the same determinant factorisation to formalize Desargues's or Pappus's theorem",
+      "Spherical Menelaus: recover Menelaus of Alexandria's original great-circle version on S²"
+    ]
+  },
+  "leanFile": {
+    "namespace": "MenelausTheorem",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 6,
+    "path": "Proofs/MenelausTheorem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem-oq-01",
+      "relationship": "related",
+      "description": "Ceva's geometric theorem (concurrency, product = +1); Menelaus is its transversal-collinearity dual (product = -1)"
+    },
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "Algebraic Ceva via signed ratios; Menelaus uses the same affine-parameter signed-ratio framework"
+    }
+  ],
+  "references": [
+    {
+      "text": "Menelaus of Alexandria, Sphaerica (c. 100 CE). Planar transversal form.",
+      "url": "https://en.wikipedia.org/wiki/Menelaus%27s_theorem"
+    },
+    {
+      "text": "Coxeter, H. S. M. & Greitzer, S. L. (1967). Geometry Revisited. MAA. §3.4 on Menelaus's theorem.",
+      "url": "https://en.wikipedia.org/wiki/Geometry_Revisited"
+    }
+  ],
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 49,
+      "description": "Module docstring framing Menelaus as the transversal companion of Ceva: instead of concurrency (product +1), collinearity of three transversal points is characterised by the signed-ratio product equalling -1, proved through a signed-area determinant factorisation.",
+      "mathContext": "Menelaus: for triangle $ABC$ with transversal points $X,Y,Z$ on lines $BC,CA,AB$, collinearity holds iff $\\frac{t}{1-t}\\cdot\\frac{u}{1-u}\\cdot\\frac{v}{1-v} = -1$."
+    },
+    {
+      "id": "determinant-and-collinearity",
+      "title": "Signed-Area Determinant and Collinearity",
+      "startLine": 50,
+      "endLine": 58,
+      "description": "Primitives: `Pt := ℝ×ℝ`, `collinearDet P Q R = (Q.1-P.1)(R.2-P.2) - (Q.2-P.2)(R.1-P.1)` (twice the signed area of triangle PQR), and `Collinear3 P Q R := collinearDet P Q R = 0`.",
+      "mathContext": "Three points are collinear iff $\\det\\begin{pmatrix} Q-P & R-P\\end{pmatrix}=0$, i.e. the signed area of $\\triangle PQR$ vanishes."
+    },
+    {
+      "id": "configuration",
+      "title": "Menelaus Configuration and Division Points",
+      "startLine": 59,
+      "endLine": 93,
+      "description": "`MenelausConfig` bundles a triangle A,B,C with transversal parameters t,u,v (each ≠ 1 so signed ratios are defined) and a non-degeneracy hypothesis `collinearDet A B C ≠ 0`. Division points `ptX=(1-t)B+tC`, `ptY=(1-u)C+uA`, `ptZ=(1-v)A+vB`, and `menelausProduct = (t/(1-t))·(u/(1-u))·(v/(1-v))`.",
+      "mathContext": "$X=(1-t)B+tC$, $Y=(1-u)C+uA$, $Z=(1-v)A+vB$; signed ratios $\\tfrac{BX}{XC}=\\tfrac{t}{1-t}$ etc."
+    },
+    {
+      "id": "determinant-factorisation",
+      "title": "Determinant Factorisation (Geometric Content)",
+      "startLine": 95,
+      "endLine": 102,
+      "description": "`collinearDet_factor`: the collinearity determinant of the three division points factors as the Menelaus scalar times the triangle's signed area — `collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C` — a pure polynomial identity discharged by `ring`.",
+      "mathContext": "$\\det(XYZ) = \\big(tuv + (1-t)(1-u)(1-v)\\big)\\,\\det(ABC)$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Menelaus's Theorem (Main Biconditional)",
+      "startLine": 104,
+      "endLine": 128,
+      "description": "`menelaus`: for a non-degenerate triangle, `Collinear3 X Y Z ↔ menelausProduct = -1`. Proof factors the determinant, cancels the non-zero base area via `mul_eq_zero`/`or_iff_left`, then matches `tuv + (1-t)(1-u)(1-v) = 0` to the product form via `div_eq_iff` and `linear_combination`. Corollaries `product_of_collinear` and `collinear_of_product` give the two directions.",
+      "mathContext": "$X,Y,Z$ collinear $\\iff tuv = -(1-t)(1-u)(1-v) \\iff \\tfrac{t}{1-t}\\tfrac{u}{1-u}\\tfrac{v}{1-v} = -1$."
+    },
+    {
+      "id": "example",
+      "title": "Concrete Numerical Instance",
+      "startLine": 130,
+      "endLine": 139,
+      "description": "`menelaus_example`: the triangle (0,0),(1,0),(0,1) with t=u=2, v=-1/3 yields menelausProduct = -1 and hence, by the main theorem, collinear division points — a concrete witness that the characterisation is non-vacuous.",
+      "mathContext": "$t=u=2,\\ v=-\\tfrac13:\\ (-2)(-2)(-\\tfrac14) = -1$, so $X,Y,Z$ are collinear."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Formalizes **Menelaus's theorem** in the affine plane ℝ² — the transversal-collinearity companion of the gallery's Ceva concurrency proofs.

For triangle `ABC` with transversal points `X=(1-t)B+tC` on `BC`, `Y=(1-u)C+uA` on `CA`, `Z=(1-v)A+vB` on `AB`, the points `X,Y,Z` are **collinear iff** the product of signed side ratios `(t/(1-t))·(u/(1-u))·(v/(1-v)) = -1`.

The mathematical heart is a single determinant factorisation (verified in sympy, then `ring` in Lean):

```
collinearDet X Y Z = (t·u·v + (1-t)(1-u)(1-v)) · collinearDet A B C
```

Non-degeneracy of the triangle cancels the area factor, isolating the Menelaus scalar; `div_eq_iff` + `linear_combination` match it to the product form.

## Contents
- `proofs/Proofs/MenelausTheorem.lean` (139 lines, **0 sorry / 0 axiom**): `collinearDet`, `Collinear3`, `MenelausConfig`, `ptX/ptY/ptZ`, `menelausProduct`, `collinearDet_factor`, main `menelaus`, two directional corollaries, and a concrete numeric instance (t=u=2, v=-1/3 → product -1).
- Registered in `proofs/Proofs.lean`.
- Gallery data: `src/data/proofs/menelaus-theorem-oq-01/{meta,annotations}.json`.
- Research notes: `research/problems/menelaus-theorem-oq-01/knowledge.md`.

## Verification
Built by module name via the Docker wrapper:

```
✔ [3058/3058] Built Proofs.MenelausTheorem (7.3s)
Build completed successfully.
```

## Test plan
- [x] `docker-build.sh Proofs.MenelausTheorem` — green, 0 errors
- [x] 0 sorries, 0 axioms (no structure-encoded assumptions)
- [x] meta.json / annotations.json valid JSON
- [ ] Deployer gallery build (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)