### PR TITLE
research(weitzenbock-inequality-oq-01): Weitzenböck's inequality (build-verified, 0/0)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3059,6 +3059,7 @@ import Proofs.VietasFormulasOQ03OQ01
 import Proofs.VietasFormulasOQ03OQ05
 import Proofs.VivianiTheorem
 import Proofs.WeakGoldbach
+import Proofs.WeitzenbockInequalityOQ01
 import Proofs.WilsonsTheorem
 import Proofs.WilsonsTheoremOQ01
 import Proofs.WilsonsTheoremOQ01OQ01

--- a/proofs/Proofs/WeitzenbockInequalityOQ01.lean
+++ b/proofs/Proofs/WeitzenbockInequalityOQ01.lean
@@ -1,0 +1,107 @@
+import Mathlib.Data.Real.Sqrt
+import Mathlib.Tactic
+
+/-
+# Weitzenböck's Inequality
+
+## What This Proves
+For any triangle with side lengths `a, b, c` and area `T`,
+  `a² + b² + c² ≥ 4·√3·T`,
+with equality **iff** the triangle is equilateral (`a = b = c`).
+
+## Approach
+The proof is entirely algebraic. We take Heron's identity in its squared form
+  `16·T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴`
+as the definition of the (squared) area, square the target to
+  `(a² + b² + c²)² ≥ 48·T²`,
+and discharge the resulting polynomial inequality, which is the sum-of-squares
+identity
+  `(a²+b²+c²)² − 48T² = 2·((a²−b²)² + (b²−c²)² + (c²−a²)²) ≥ 0`.
+The √3 is handled by `Real.sqrt_sq` once both sides are known nonnegative; the
+equality case follows because the SOS vanishes exactly when `a² = b² = c²`.
+
+This is not a named Mathlib result.
+-/
+
+namespace WeitzenbockInequalityOQ01
+
+/-- Heron's area identity, squared and scaled by 16:
+`16·T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴`. We take this as the algebraic
+definition of the squared area of a triangle with sides `a, b, c`. -/
+def heronArea16Sq (a b c : ℝ) : ℝ :=
+  2 * a ^ 2 * b ^ 2 + 2 * b ^ 2 * c ^ 2 + 2 * c ^ 2 * a ^ 2
+    - a ^ 4 - b ^ 4 - c ^ 4
+
+/-- The arithmetic core: `x² + y² + z² ≥ xy + yz + zx` for all reals. -/
+theorem sos_core (x y z : ℝ) : x * y + y * z + z * x ≤ x ^ 2 + y ^ 2 + z ^ 2 := by
+  nlinarith [sq_nonneg (x - y), sq_nonneg (y - z), sq_nonneg (z - x)]
+
+/-- For nonnegative reals, equality of squares implies equality. -/
+theorem eq_of_sq_eq_sq {u v : ℝ} (hu : 0 ≤ u) (hv : 0 ≤ v) (h : u ^ 2 = v ^ 2) :
+    u = v := by
+  have h1 : Real.sqrt (u ^ 2) = Real.sqrt (v ^ 2) := by rw [h]
+  rwa [Real.sqrt_sq hu, Real.sqrt_sq hv] at h1
+
+/-- Squared form of Weitzenböck's inequality: `(a²+b²+c²)² ≥ 48·T²`. -/
+theorem weitzenbock_sq (a b c T : ℝ) (hT : 16 * T ^ 2 = heronArea16Sq a b c) :
+    48 * T ^ 2 ≤ (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+  have h48 : 48 * T ^ 2 = 3 * (16 * T ^ 2) := by ring
+  rw [h48, hT]
+  unfold heronArea16Sq
+  nlinarith [sq_nonneg (a ^ 2 - b ^ 2), sq_nonneg (b ^ 2 - c ^ 2),
+    sq_nonneg (c ^ 2 - a ^ 2)]
+
+/-- **Weitzenböck's inequality.** For a triangle with side lengths `a, b, c` and
+area `T` (given by Heron's formula), `a² + b² + c² ≥ 4·√3·T`. -/
+theorem weitzenbock (a b c T : ℝ) (hTnn : 0 ≤ T)
+    (hT : 16 * T ^ 2 = heronArea16Sq a b c) :
+    4 * Real.sqrt 3 * T ≤ a ^ 2 + b ^ 2 + c ^ 2 := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hlhs : 0 ≤ 4 * Real.sqrt 3 * T := by positivity
+  have hrhs : 0 ≤ a ^ 2 + b ^ 2 + c ^ 2 := by positivity
+  have hsqlhs : (4 * Real.sqrt 3 * T) ^ 2 = 48 * T ^ 2 := by
+    have h : (4 * Real.sqrt 3 * T) ^ 2 = 16 * Real.sqrt 3 ^ 2 * T ^ 2 := by ring
+    rw [h, hs]; ring
+  have hcore : (4 * Real.sqrt 3 * T) ^ 2 ≤ (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+    rw [hsqlhs]; exact weitzenbock_sq a b c T hT
+  calc 4 * Real.sqrt 3 * T
+      = Real.sqrt ((4 * Real.sqrt 3 * T) ^ 2) := (Real.sqrt_sq hlhs).symm
+    _ ≤ Real.sqrt ((a ^ 2 + b ^ 2 + c ^ 2) ^ 2) := Real.sqrt_le_sqrt hcore
+    _ = a ^ 2 + b ^ 2 + c ^ 2 := Real.sqrt_sq hrhs
+
+/-- **Equality case.** For a triangle with positive sides, Weitzenböck's
+inequality is an equality iff the triangle is equilateral. -/
+theorem weitzenbock_eq_iff (a b c T : ℝ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hTnn : 0 ≤ T) (hT : 16 * T ^ 2 = heronArea16Sq a b c) :
+    4 * Real.sqrt 3 * T = a ^ 2 + b ^ 2 + c ^ 2 ↔ a = b ∧ b = c := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hlhs : 0 ≤ 4 * Real.sqrt 3 * T := by positivity
+  have hrhs : 0 ≤ a ^ 2 + b ^ 2 + c ^ 2 := by positivity
+  have hsqlhs : (4 * Real.sqrt 3 * T) ^ 2 = 48 * T ^ 2 := by
+    have h : (4 * Real.sqrt 3 * T) ^ 2 = 16 * Real.sqrt 3 ^ 2 * T ^ 2 := by ring
+    rw [h, hs]; ring
+  -- Reduce the √3 equality to the polynomial equality `48T² = (a²+b²+c²)²`.
+  have hsqiff : 4 * Real.sqrt 3 * T = a ^ 2 + b ^ 2 + c ^ 2
+      ↔ 48 * T ^ 2 = (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+    constructor
+    · intro h; rw [← hsqlhs, h]
+    · intro h; exact eq_of_sq_eq_sq hlhs hrhs (by rw [hsqlhs, h])
+  rw [hsqiff, show (48 : ℝ) * T ^ 2 = 3 * (16 * T ^ 2) by ring, hT]
+  unfold heronArea16Sq
+  constructor
+  · intro h
+    have hle1 : (a ^ 2 - b ^ 2) ^ 2 ≤ 0 := by
+      nlinarith [h, sq_nonneg (b ^ 2 - c ^ 2), sq_nonneg (c ^ 2 - a ^ 2)]
+    have hle2 : (b ^ 2 - c ^ 2) ^ 2 ≤ 0 := by
+      nlinarith [h, sq_nonneg (a ^ 2 - b ^ 2), sq_nonneg (c ^ 2 - a ^ 2)]
+    have e1 : (a ^ 2 - b ^ 2) ^ 2 = 0 := le_antisymm hle1 (sq_nonneg _)
+    have e2 : (b ^ 2 - c ^ 2) ^ 2 = 0 := le_antisymm hle2 (sq_nonneg _)
+    have hab2 : a ^ 2 = b ^ 2 :=
+      sub_eq_zero.mp (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0) |>.mp e1)
+    have hbc2 : b ^ 2 = c ^ 2 :=
+      sub_eq_zero.mp (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0) |>.mp e2)
+    exact ⟨eq_of_sq_eq_sq ha.le hb.le hab2, eq_of_sq_eq_sq hb.le hc.le hbc2⟩
+  · rintro ⟨hab, hbc⟩
+    rw [hab, hbc]; ring
+
+end WeitzenbockInequalityOQ01

--- a/src/data/proofs/weitzenbock-inequality-oq-01/annotations.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-wz-header",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 4, "endLine": 24 },
+    "type": "concept",
+    "title": "Weitzenböck's Inequality: Overview",
+    "content": "Weitzenböck's inequality states that for any triangle with side lengths a, b, c and area T, a² + b² + c² ≥ 4√3·T, with equality iff the triangle is equilateral. The proof is entirely algebraic: take Heron's identity in squared form, square the target to (a²+b²+c²)² ≥ 48T², and reduce to the sum-of-squares identity (a²+b²+c²)² − 48T² = 2((a²−b²)²+(b²−c²)²+(c²−a²)²) ≥ 0. The √3 is handled by Real.sqrt_sq once both sides are nonnegative.",
+    "mathContext": "The constant $4\\sqrt{3}$ is sharp, attained by the equilateral triangle. The equality gap $2\\sum (a^2-b^2)^2$ is the seed of the Hadwiger–Finsler refinement $a^2+b^2+c^2 \\ge 4\\sqrt3\\,T + \\sum (a-b)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Weitzenböck's inequality", "Heron's formula", "sum of squares", "equilateral triangle"],
+    "prerequisites": ["triangle area", "Real.sqrt basics"]
+  },
+  {
+    "id": "ann-wz-heron",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 28, "endLine": 33 },
+    "type": "definition",
+    "title": "heronArea16Sq: Heron's Squared Area Identity",
+    "content": "Defines 16T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴, the expanded form of Heron's formula. This is taken as the algebraic definition of the (squared) area of a triangle with sides a, b, c, supplied to the main theorems as the hypothesis 16·T² = heronArea16Sq a b c.",
+    "mathContext": "Heron: $16T^2 = (a+b+c)(-a+b+c)(a-b+c)(a+b-c)$, which expands to $2a^2b^2+2b^2c^2+2c^2a^2-a^4-b^4-c^4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Heron's formula", "triangle area"],
+    "prerequisites": ["polynomial algebra"]
+  },
+  {
+    "id": "ann-wz-sos-core",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 35, "endLine": 37 },
+    "type": "theorem",
+    "title": "sos_core: x²+y²+z² ≥ xy+yz+zx",
+    "content": "The elementary symmetric sum-of-squares inequality, proved from sq_nonneg (x−y), sq_nonneg (y−z), sq_nonneg (z−x) via nlinarith. With x=a², y=b², z=c² this is the algebraic heart of Weitzenböck.",
+    "mathContext": "$x^2+y^2+z^2-(xy+yz+zx) = \\tfrac12((x-y)^2+(y-z)^2+(z-x)^2) \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of squares", "symmetric inequality"],
+    "prerequisites": ["nonnegativity of squares"]
+  },
+  {
+    "id": "ann-wz-eq-of-sq",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 39, "endLine": 43 },
+    "type": "theorem",
+    "title": "eq_of_sq_eq_sq: Square Cancellation for Nonnegatives",
+    "content": "For 0 ≤ u, 0 ≤ v, u² = v² implies u = v. Proved by applying Real.sqrt to both sides and using Real.sqrt_sq. Used both to pass from the squared inequality to the genuine one and to extract a = b = c in the equality case.",
+    "mathContext": "On $[0,\\infty)$ the squaring map is injective, with inverse $\\sqrt{\\cdot}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["square root", "injectivity"],
+    "prerequisites": ["Real.sqrt_sq"]
+  },
+  {
+    "id": "ann-wz-sq",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 45, "endLine": 52 },
+    "type": "theorem",
+    "title": "weitzenbock_sq: The Squared Inequality (a²+b²+c²)² ≥ 48T²",
+    "content": "The polynomial core of the proof. Substituting 48T² = 3·(16T²) = 3·heronArea16Sq and expanding, the gap (a²+b²+c²)² − 48T² equals 2((a²−b²)²+(b²−c²)²+(c²−a²)²), which nlinarith discharges from the three square hints.",
+    "mathContext": "$(a^2+b^2+c^2)^2 - 48T^2 = 2\\big((a^2-b^2)^2+(b^2-c^2)^2+(c^2-a^2)^2\\big) \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of squares", "Heron's formula"],
+    "prerequisites": ["heronArea16Sq", "nlinarith"]
+  },
+  {
+    "id": "ann-wz-main",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 54, "endLine": 70 },
+    "type": "theorem",
+    "title": "weitzenbock: a²+b²+c² ≥ 4√3·T",
+    "content": "The main theorem. Computes (4√3·T)² = 48T² via Real.sq_sqrt, invokes weitzenbock_sq to get the squared inequality, and then converts back to the linear inequality using u = √(u²) (Real.sqrt_sq) and Real.sqrt_le_sqrt — no analytic estimate on √3 is needed.",
+    "mathContext": "Both $4\\sqrt3\\,T \\ge 0$ and $a^2+b^2+c^2 \\ge 0$, so $u \\le v \\iff u^2 \\le v^2$ via $u=\\sqrt{u^2}$ and monotonicity of $\\sqrt{\\cdot}$.",
+    "significance": "key",
+    "relatedConcepts": ["Weitzenböck's inequality", "square root monotonicity"],
+    "prerequisites": ["weitzenbock_sq", "Real.sqrt_sq", "Real.sqrt_le_sqrt"]
+  },
+  {
+    "id": "ann-wz-eq-iff",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": { "startLine": 72, "endLine": 105 },
+    "type": "theorem",
+    "title": "weitzenbock_eq_iff: Equality ⇔ Equilateral",
+    "content": "For positive sides, equality 4√3·T = a²+b²+c² holds iff a = b ∧ b = c. The √3 equality is first reduced to the polynomial equality 48T² = (a²+b²+c²)² (via eq_of_sq_eq_sq), which forces the sum of squares to vanish; hence each (a²−b²)² = 0, giving a² = b² = c², and positivity yields a = b = c.",
+    "mathContext": "Equality in the SOS bound is equivalent to $(a^2-b^2)^2=(b^2-c^2)^2=(c^2-a^2)^2=0$, i.e. the triangle is equilateral.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "equilateral triangle", "sum of squares"],
+    "prerequisites": ["pow_eq_zero_iff", "sub_eq_zero", "eq_of_sq_eq_sq"]
+  }
+]

--- a/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "weitzenbock-inequality-oq-01",
+  "title": "Weitzenböck's Inequality",
+  "slug": "weitzenbock-inequality-oq-01",
+  "description": "For any triangle with side lengths a, b, c and area T, a² + b² + c² ≥ 4·√3·T, with equality if and only if the triangle is equilateral. Proved algebraically by squaring the target to (a²+b²+c²)² ≥ 48T² and discharging the sum-of-squares identity (a²+b²+c²)² − 48T² = 2((a²−b²)²+(b²−c²)²+(c²−a²)²).",
+  "meta": {
+    "author": "Lean Genius Researcher (2026)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Weitzenb%C3%B6ck%27s_inequality",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WeitzenbockInequalityOQ01.lean",
+    "tags": [
+      "geometry",
+      "triangle-inequality",
+      "weitzenbock",
+      "sum-of-squares",
+      "heron",
+      "area"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "√(x²) = x for 0 ≤ x; turns the squared inequality into the genuine one",
+        "module": "Mathlib.Data.Real.Sqrt"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for 0 ≤ x; gives (4√3·T)² = 48T²",
+        "module": "Mathlib.Data.Real.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "Monotonicity of √ used to pass from squared to linear inequality",
+        "module": "Mathlib.Data.Real.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "Heron's squared-area identity 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ taken as the algebraic area definition",
+      "Reduction of Weitzenböck's inequality to the SOS identity (a²+b²+c²)² − 48T² = 2((a²−b²)²+(b²−c²)²+(c²−a²)²) ≥ 0",
+      "√3 handled with no analytic estimate: both sides nonnegative, so Real.sqrt_sq + Real.sqrt_le_sqrt convert the squared inequality to the genuine one",
+      "Equality characterization: equality holds iff a = b = c (positive sides), extracted from the vanishing of the sum of squares"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": "0 axioms, 0 sorries. The area is supplied via Heron's squared identity 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴; all results are fully machine-checked from Real.sqrt basics and nlinarith.",
+    "lineCount": 107
+  },
+  "overview": {
+    "historicalContext": "Weitzenböck's inequality relates the area of a triangle to the sum of the squares of its sides: a² + b² + c² ≥ 4√3·T. It was published by Roland Weitzenböck in 1919, though equivalent statements appear earlier. The constant 4√3 is sharp, attained exactly by the equilateral triangle, and the inequality is the n = 3 case of a family of isoperimetric-type bounds. A celebrated strengthening is the Hadwiger–Finsler inequality a² + b² + c² ≥ 4√3·T + (a−b)² + (b−c)² + (c−a)², which refines the equality gap. The most transparent modern proof is purely algebraic: combine Heron's formula with the elementary sum-of-squares fact x² + y² + z² ≥ xy + yz + zx, which is exactly the route formalized here.",
+    "problemStatement": "For a triangle with side lengths a, b, c > 0 and area T, prove a² + b² + c² ≥ 4√3·T, with equality iff a = b = c.",
+    "proofStrategy": "1. Encode the area through Heron's identity in squared form: 16T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴.\n2. Square the target. Since 4√3·T ≥ 0 and a²+b²+c² ≥ 0, it suffices to show (a²+b²+c²)² ≥ (4√3·T)² = 48T².\n3. Substitute 48T² = 3·(16T²) and expand: (a²+b²+c²)² − 48T² = 2((a²−b²)² + (b²−c²)² + (c²−a²)²) ≥ 0, dispatched by nlinarith.\n4. Recover the linear inequality: u = √(u²) for u ≥ 0 (Real.sqrt_sq), and Real.sqrt_le_sqrt applied to the squared inequality.\n5. Equality case: the squared inequality is tight iff each (a²−b²)² = 0, i.e. a² = b² = c², which for positive sides means a = b = c.",
+    "keyInsights": [
+      "Weitzenböck reduces to the most basic symmetric SOS inequality x²+y²+z² ≥ xy+yz+zx with x = a², y = b², z = c².",
+      "The √3 never needs an analytic bound — squaring plus nonnegativity makes Real.sqrt_sq do all the work.",
+      "The equality gap is precisely 2·Σ(a²−b²)², which exposes why equality forces an equilateral triangle and points directly at the Hadwiger–Finsler refinement."
+    ],
+    "prerequisites": [
+      "Real square root basics (Real.sqrt_sq, Real.sq_sqrt, monotonicity)",
+      "Heron's formula for triangle area",
+      "Sum-of-squares (nonnegativity of squares)"
+    ],
+    "openQuestions": [
+      "Formalize the Hadwiger–Finsler strengthening a²+b²+c² ≥ 4√3·T + Σ(a−b)².",
+      "Derive Heron's squared identity from a coordinate/EuclideanSpace definition of area to remove it as a hypothesis."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "herons-formula",
+      "relationship": "foundational",
+      "description": "Heron's formula supplies the area expression 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ that this proof takes as the algebraic definition of the squared area."
+    }
+  ],
+  "conclusion": {
+    "summary": "Weitzenböck's inequality a²+b²+c² ≥ 4√3·T is reduced to a one-line sum-of-squares identity after squaring and applying Heron's formula. The equality case (equilateral triangle) falls out of the vanishing of that sum of squares.",
+    "openQuestions": [
+      "Hadwiger–Finsler refinement",
+      "Coordinate-free derivation of the area hypothesis"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Weitzenböck, Roland",
+      "title": "Über eine Ungleichung in der Dreiecksgeometrie",
+      "year": "1919",
+      "venue": "Mathematische Zeitschrift, vol. 5, pp. 137–146",
+      "note": "Original publication of the inequality."
+    },
+    {
+      "authors": "Engel, Arthur",
+      "title": "Problem-Solving Strategies",
+      "year": "1998",
+      "venue": "Springer",
+      "note": "Presents the algebraic Heron + sum-of-squares proof used in this formalization, and the Hadwiger–Finsler strengthening."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Real.Sqrt",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "WeitzenbockInequalityOQ01",
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "sorries": 0,
+    "path": "Proofs/WeitzenbockInequalityOQ01.lean",
+    "definitionCount": 1,
+    "lineCount": 107
+  }
+}


### PR DESCRIPTION
## Summary
Adds `proofs/Proofs/WeitzenbockInequalityOQ01.lean` — a complete, **build-verified** algebraic proof of **Weitzenböck's inequality**: for a triangle with sides `a,b,c` and area `T`,
`a² + b² + c² ≥ 4·√3·T`, with **equality iff the triangle is equilateral**.

**0 sorry, 0 axiom.** Not a named Mathlib result. Registered in `Proofs.lean` + gallery `meta.json`/`annotations.json` (status `verified`, badge `original`).

### Build
`✔ [3058/3058] Built Proofs.WeitzenbockInequalityOQ01 (49s)` — `Build completed successfully` via `./proofs/scripts/docker-build.sh Proofs.WeitzenbockInequalityOQ01`.

### Proof structure
- `heronArea16Sq a b c` — Heron's squared-area identity `16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴` as the algebraic area definition.
- `sos_core` — `x²+y²+z² ≥ xy+yz+zx`.
- `weitzenbock_sq` — squared form `(a²+b²+c²)² ≥ 48T²`, via the SOS identity `(a²+b²+c²)²−48T² = 2((a²−b²)²+(b²−c²)²+(c²−a²)²)` with `nlinarith`.
- `weitzenbock` — the main inequality; `√3` handled by `Real.sqrt_sq` / `Real.sqrt_le_sqrt` (both sides nonneg).
- `weitzenbock_eq_iff` — equality holds iff `a=b ∧ b=c` (positive sides), from the SOS vanishing.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.WeitzenbockInequalityOQ01` — green (3058 jobs, 0 sorry, 0 axiom).
- [x] Registered in `Proofs.lean`; gallery `meta.json` + `annotations.json` added and JSON-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)