### PR TITLE
research(pythagorean-theorem-oq-06): sync stale state to COMPLETED (de Gua merged #24992)

### DIFF
--- a/research/problems/pythagorean-theorem-oq-06/state.md
+++ b/research/problems/pythagorean-theorem-oq-06/state.md
@@ -1,13 +1,14 @@
 # Current State
 
-**Phase**: ACT
+**Phase**: COMPLETED
 **Since**: 2026-06-16
 **Iteration**: 1
 
 ## Current Focus
 
-de Gua's theorem formalized in `proofs/Proofs/DeGuaTheorem.lean` (0 sorry / 0 axiom).
-Build-verifying `Proofs.DeGuaTheorem`, then register + add gallery data.
+de Gua's theorem is DONE: `proofs/Proofs/DeGuaTheorem.lean` (0 sorry / 0 axiom),
+Docker build GREEN, registered in `Proofs.lean` (`import Proofs.DeGuaTheorem`),
+and merged to `main` via PR #24992.
 
 ## Active Approach
 
@@ -17,11 +18,12 @@ Three theorems: `de_gua_core` (edge-vector), `de_gua` (vertex form), `de_gua_axi
 
 ## Blockers
 
-None mathematically. Verification gated on Docker build completing (in progress).
+None. Proof complete, verified, and merged.
 
 ## Next Action
 
-Confirm green build → register in `Proofs.lean` → add gallery data → PR.
+None for the researcher track. Gallery data (`src/data/proofs/...`) is delegated to
+the enricher per the standard pipeline. This problem is closed; do not re-claim.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/pythagorean-theorem-oq-06.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-06.json
@@ -1,8 +1,8 @@
 {
   "slug": "pythagorean-theorem-oq-06",
   "title": "de Gua's theorem: the 3D Pythagorean theorem",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -20,12 +20,12 @@
     "goal": "Area(ABC)^2 = Area(OAB)^2 + Area(OBC)^2 + Area(OCA)^2 for a trirectangular tetrahedron"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-06-16T12:27:51.320Z",
     "iteration": 1,
-    "focus": "de Gua proved in DeGuaTheorem.lean (0 sorry/0 axiom, Docker build GREEN); registered in Proofs.lean; PR open",
+    "focus": "de Gua proved in DeGuaTheorem.lean (0 sorry/0 axiom, Docker build GREEN); registered in Proofs.lean; merged to main via PR #24992",
     "blockers": [],
-    "nextAction": "Merge PR; add gallery data (enricher)",
+    "nextAction": "None for researcher track; gallery data delegated to enricher",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (build-pending): de Gua proved in DeGuaTheorem.lean, 0 sorry/0 axiom",
+    "progressSummary": "COMPLETE (merged): de Gua proved in DeGuaTheorem.lean, 0 sorry/0 axiom, build GREEN, registered in Proofs.lean, merged via PR #24992",
     "builtItems": [
       "de_gua_core (edge-vector form) in Proofs/DeGuaTheorem.lean — crossSq identity under mutual orthogonality, via linear_combination",
       "de_gua (vertex form) — full tetrahedron statement reduced to de_gua_core",


### PR DESCRIPTION
## Summary

`pythagorean-theorem-oq-06` (de Gua's theorem, the 3-D Pythagorean theorem) is **already done and merged** — but the research pool still listed it as `active`/available, which caused repeated wasteful re-claims (a prior researcher burned a full cycle re-deriving it as a duplicate; this cycle nearly did the same).

This PR just syncs the stale tracking state to match reality. No math changes.

### What's actually on `main`
- `proofs/Proofs/DeGuaTheorem.lean` — 0 sorry / 0 axiom, Docker build GREEN
- Registered in `Proofs.lean` (`import Proofs.DeGuaTheorem`)
- Merged via PR #24992

### Changes
- `research/problems/pythagorean-theorem-oq-06/state.md`: Phase ACT → **COMPLETED**
- `src/data/research/problems/pythagorean-theorem-oq-06.json`: `status` active → **completed**, phase/focus/progressSummary updated to reflect the merge

Gallery data (`src/data/proofs/...`) remains delegated to the enricher per the standard pipeline (the JSON's `nextAction` already said so).

## Test plan
- [x] JSON validates (`jq -e .`)
- [x] No Lean source changes (tracking-only)