### PR TITLE
research(weitzenbock-inequality-oq-01): formalize Weitzenböck's inequality (0/0, build-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3055,6 +3055,7 @@ import Proofs.VietasFormulasOQ03
 import Proofs.VietasFormulasOQ03OQ01
 import Proofs.VietasFormulasOQ03OQ05
 import Proofs.WeakGoldbach
+import Proofs.WeitzenbockInequalityOQ01
 import Proofs.WilsonsTheorem
 import Proofs.WilsonsTheoremOQ01
 import Proofs.WilsonsTheoremOQ01OQ01

--- a/proofs/Proofs/WeitzenbockInequalityOQ01.lean
+++ b/proofs/Proofs/WeitzenbockInequalityOQ01.lean
@@ -1,0 +1,220 @@
+/-
+  Weitzenböck's Inequality
+
+  For a triangle with side lengths a, b, c and area T:
+
+    a² + b² + c² ≥ 4·√3·T
+
+  with equality if and only if the triangle is equilateral (a = b = c).
+
+  Proof approach (purely elementary, no transcendental estimates):
+  - Encode the area through Heron's product: T = √(s(s-a)(s-b)(s-c)),
+    so 16·T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴.
+  - Square the target: since both sides are non-negative it suffices to show
+      (a² + b² + c²)² ≥ 48·T².
+  - Substituting the Heron expansion, the gap is the sum of squares
+      (a² + b² + c²)² − 48·T² = 2·[(a²−b²)² + (b²−c²)² + (c²−a²)²] ≥ 0.
+  - Equality forces each (a²−b²)² = 0, hence a = b = c (positivity).
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace WeitzenbockInequality
+
+open Real
+
+-- ════════════════════════════════════════════════════════════════
+-- PART I: Area via Heron's product
+-- ════════════════════════════════════════════════════════════════
+
+/-- Heron's product s(s-a)(s-b)(s-c) where s = (a+b+c)/2.
+    The area of a triangle with sides a, b, c is √(heron_product a b c). -/
+noncomputable def heron_product (a b c : ℝ) : ℝ :=
+  let s := (a + b + c) / 2
+  s * (s - a) * (s - b) * (s - c)
+
+/-- Heron product non-negativity for valid triangles. -/
+theorem heron_product_nonneg {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    0 ≤ heron_product a b c := by
+  unfold heron_product
+  have hs : 0 < (a + b + c) / 2 := by linarith
+  have hsa : 0 < (a + b + c) / 2 - a := by linarith
+  have hsb : 0 < (a + b + c) / 2 - b := by linarith
+  have hsc : 0 < (a + b + c) / 2 - c := by linarith
+  apply mul_nonneg
+  apply mul_nonneg
+  apply mul_nonneg
+  all_goals linarith
+
+/-- Classical Heron area: Area = √(s(s-a)(s-b)(s-c)). -/
+noncomputable def triangle_area (a b c : ℝ) : ℝ :=
+  sqrt (heron_product a b c)
+
+/-- The squared area equals the Heron product (for valid triangles). -/
+theorem triangle_area_sq {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    (triangle_area a b c) ^ 2 = heron_product a b c := by
+  unfold triangle_area
+  exact Real.sq_sqrt (heron_product_nonneg ha hb hc hab hbc hca)
+
+/-- **Heron's 16-fold expansion**: 16·T² is a symmetric polynomial in a, b, c. -/
+theorem heron_sixteen (a b c : ℝ) :
+    16 * heron_product a b c =
+      2 * a ^ 2 * b ^ 2 + 2 * b ^ 2 * c ^ 2 + 2 * c ^ 2 * a ^ 2
+      - a ^ 4 - b ^ 4 - c ^ 4 := by
+  unfold heron_product; ring
+
+-- ════════════════════════════════════════════════════════════════
+-- PART II: The SOS core
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Key sum-of-squares identity.** The Weitzenböck gap, after squaring the
+    target and clearing the area, is a non-negative sum of squares:
+
+      (a²+b²+c²)² − 48·heron_product = 2·[(a²−b²)²+(b²−c²)²+(c²−a²)²]. -/
+theorem weitzenbock_sos_identity (a b c : ℝ) :
+    (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 - 48 * heron_product a b c =
+      2 * ((a ^ 2 - b ^ 2) ^ 2 + (b ^ 2 - c ^ 2) ^ 2 + (c ^ 2 - a ^ 2) ^ 2) := by
+  have h := heron_sixteen a b c
+  nlinarith [h]
+
+/-- The squared form of Weitzenböck's inequality:
+      (a²+b²+c²)² ≥ 48·heron_product. -/
+theorem weitzenbock_sq (a b c : ℝ) :
+    48 * heron_product a b c ≤ (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
+  have hid := weitzenbock_sos_identity a b c
+  nlinarith [sq_nonneg (a ^ 2 - b ^ 2), sq_nonneg (b ^ 2 - c ^ 2),
+             sq_nonneg (c ^ 2 - a ^ 2), hid]
+
+-- ════════════════════════════════════════════════════════════════
+-- PART III: Weitzenböck's inequality
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Weitzenböck's inequality**: for a triangle with sides a, b, c and area
+    T = triangle_area a b c,
+
+      a² + b² + c² ≥ 4·√3·T. -/
+theorem weitzenbock {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    a ^ 2 + b ^ 2 + c ^ 2 ≥ 4 * sqrt 3 * triangle_area a b c := by
+  have hhp : 0 ≤ heron_product a b c := heron_product_nonneg ha hb hc hab hbc hca
+  set T := triangle_area a b c with hT_def
+  have hT_nonneg : 0 ≤ T := by rw [hT_def]; unfold triangle_area; exact sqrt_nonneg _
+  have hTsq : T ^ 2 = heron_product a b c := triangle_area_sq ha hb hc hab hbc hca
+  set c3 := sqrt 3 with hc3_def
+  have hc3_nonneg : 0 ≤ c3 := by rw [hc3_def]; exact sqrt_nonneg _
+  have hc3sq : c3 ^ 2 = 3 := by rw [hc3_def]; exact Real.sq_sqrt (by norm_num)
+  set S := a ^ 2 + b ^ 2 + c ^ 2 with hS_def
+  have hS_nonneg : (0 : ℝ) ≤ S := by rw [hS_def]; positivity
+  -- The right-hand side squared equals 48·heron_product.
+  have hrhs_sq : (4 * c3 * T) ^ 2 = 48 * heron_product a b c := by
+    have e : (4 * c3 * T) ^ 2 = 16 * c3 ^ 2 * T ^ 2 := by ring
+    rw [e, hc3sq, hTsq]; ring
+  have hrhs_nonneg : 0 ≤ 4 * c3 * T :=
+    mul_nonneg (mul_nonneg (by norm_num) hc3_nonneg) hT_nonneg
+  -- Squared inequality, then descend by monotonicity of √.
+  have hsq_le : (4 * c3 * T) ^ 2 ≤ S ^ 2 := by
+    rw [hrhs_sq, hS_def]; exact weitzenbock_sq a b c
+  have : 4 * c3 * T ≤ S := by
+    calc 4 * c3 * T = sqrt ((4 * c3 * T) ^ 2) := (Real.sqrt_sq hrhs_nonneg).symm
+      _ ≤ sqrt (S ^ 2) := Real.sqrt_le_sqrt hsq_le
+      _ = S := Real.sqrt_sq hS_nonneg
+  linarith
+
+-- ════════════════════════════════════════════════════════════════
+-- PART IV: Equality characterization
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Equality holds iff the triangle is equilateral.** -/
+theorem weitzenbock_eq_iff {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    a ^ 2 + b ^ 2 + c ^ 2 = 4 * sqrt 3 * triangle_area a b c ↔ a = b ∧ b = c := by
+  have hhp : 0 ≤ heron_product a b c := heron_product_nonneg ha hb hc hab hbc hca
+  have hTsq : (triangle_area a b c) ^ 2 = heron_product a b c :=
+    triangle_area_sq ha hb hc hab hbc hca
+  constructor
+  · intro heq
+    -- Square the equality: (a²+b²+c²)² = 48·heron_product.
+    have hSsq : (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 = 48 * heron_product a b c := by
+      have hrhs_sq : (4 * sqrt 3 * triangle_area a b c) ^ 2 = 48 * heron_product a b c := by
+        have e : (4 * sqrt 3 * triangle_area a b c) ^ 2
+            = 16 * (sqrt 3) ^ 2 * (triangle_area a b c) ^ 2 := by ring
+        rw [e, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 3), hTsq]; ring
+      rw [heq]; exact hrhs_sq
+    -- The SOS gap vanishes.
+    have hsos : (a ^ 2 - b ^ 2) ^ 2 + (b ^ 2 - c ^ 2) ^ 2 + (c ^ 2 - a ^ 2) ^ 2 = 0 := by
+      have hid := weitzenbock_sos_identity a b c
+      nlinarith [hid, hSsq]
+    -- Hence each squared difference is zero.
+    have e1 : (a ^ 2 - b ^ 2) ^ 2 = 0 :=
+      le_antisymm (by nlinarith [sq_nonneg (b ^ 2 - c ^ 2), sq_nonneg (c ^ 2 - a ^ 2), hsos])
+        (sq_nonneg _)
+    have e2 : (b ^ 2 - c ^ 2) ^ 2 = 0 :=
+      le_antisymm (by nlinarith [sq_nonneg (a ^ 2 - b ^ 2), sq_nonneg (c ^ 2 - a ^ 2), hsos])
+        (sq_nonneg _)
+    -- Recover a = b and b = c using positivity.
+    have hab2 : a ^ 2 - b ^ 2 = 0 := pow_eq_zero_iff (by norm_num) |>.mp e1
+    have hbc2 : b ^ 2 - c ^ 2 = 0 := pow_eq_zero_iff (by norm_num) |>.mp e2
+    have hab' : a = b := by
+      have hfac : (a - b) * (a + b) = 0 := by linear_combination hab2
+      rcases mul_eq_zero.mp hfac with h | h
+      · linarith
+      · linarith
+    have hbc' : b = c := by
+      have hfac : (b - c) * (b + c) = 0 := by linear_combination hbc2
+      rcases mul_eq_zero.mp hfac with h | h
+      · linarith
+      · linarith
+    exact ⟨hab', hbc'⟩
+  · rintro ⟨hab', hbc'⟩
+    rw [hab', hbc']
+    -- All sides equal to c; compute both sides directly.
+    have hhp3 : heron_product c c c = 3 * c ^ 4 / 16 := by unfold heron_product; ring
+    have hT3 : triangle_area c c c = sqrt 3 * (c ^ 2 / 4) := by
+      unfold triangle_area
+      rw [hhp3, show (3 : ℝ) * c ^ 4 / 16 = 3 * (c ^ 2 / 4) ^ 2 from by ring,
+        Real.sqrt_mul (by norm_num : (0:ℝ) ≤ 3), Real.sqrt_sq (by positivity)]
+    rw [hT3]
+    have h3 : (sqrt 3) ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+    linear_combination (-c ^ 2) * h3
+
+-- ════════════════════════════════════════════════════════════════
+-- PART V: Worked examples / sanity checks
+-- ════════════════════════════════════════════════════════════════
+
+/-- Equilateral triangle with side 2: equality is attained. -/
+theorem weitzenbock_equilateral_2 :
+    (2 : ℝ) ^ 2 + 2 ^ 2 + 2 ^ 2 = 4 * sqrt 3 * triangle_area 2 2 2 := by
+  have h : (0:ℝ) < 2 := by norm_num
+  exact (weitzenbock_eq_iff h h h (by norm_num) (by norm_num) (by norm_num)).mpr ⟨rfl, rfl⟩
+
+/-- The 3-4-5 right triangle is strictly non-equilateral, so the inequality
+    is strict: 9 + 16 + 25 = 50 > 4√3·6 = 24√3 ≈ 41.57. -/
+theorem weitzenbock_345_strict :
+    4 * sqrt 3 * triangle_area 3 4 5 < (3 : ℝ) ^ 2 + 4 ^ 2 + 5 ^ 2 := by
+  have h3 : (0:ℝ) < 3 := by norm_num
+  have h4 : (0:ℝ) < 4 := by norm_num
+  have h5 : (0:ℝ) < 5 := by norm_num
+  have hge := weitzenbock h3 h4 h5 (by norm_num) (by norm_num) (by norm_num)
+  rcases lt_or_eq_of_le hge with hlt | heq
+  · linarith
+  · -- equality would force equilateral, impossible here
+    exfalso
+    have := (weitzenbock_eq_iff h3 h4 h5 (by norm_num) (by norm_num) (by norm_num)).mp heq.symm
+    obtain ⟨hab, _⟩ := this
+    norm_num at hab
+
+#check @weitzenbock           -- a²+b²+c² ≥ 4√3·T
+#check @weitzenbock_eq_iff    -- equality iff equilateral
+#check @weitzenbock_sq        -- squared form
+#check @weitzenbock_sos_identity
+
+end WeitzenbockInequality

--- a/src/data/proofs/weitzenbock-inequality-oq-01/annotations.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-weitzenbock-header",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "Weitzenböck's Inequality: a²+b²+c² ≥ 4√3·T via a Sum of Squares",
+    "content": "Weitzenböck's inequality (R. Weitzenböck, 1919; IMO 1961 Problem 1) bounds a triangle's area below the sum of its squared side lengths: a²+b²+c² ≥ 4√3·T, with equality exactly for the equilateral triangle. The formalization encodes area through the Heron product T = √(s(s-a)(s-b)(s-c)) and proves the inequality by squaring the target — which removes both the √3 and the area's square root — and exhibiting the gap as a non-negative sum of squares. Zero axioms, zero sorries.",
+    "mathContext": "The constant $4\\sqrt3$ is sharp. For an equilateral triangle of side $a$: $a^2+a^2+a^2 = 3a^2$ and $T = \\frac{\\sqrt3}{4}a^2$, so $4\\sqrt3\\,T = 3a^2$ — equality. Squaring is legitimate because both sides are non-negative, and it converts the only transcendental ingredients (the constant $\\sqrt3$ and the area $T=\\sqrt{\\dots}$) into the polynomial quantity $48T^2 = 3\\cdot 16T^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Weitzenböck's inequality",
+      "Heron's formula",
+      "sum of squares",
+      "Hadwiger–Finsler inequality",
+      "IMO 1961"
+    ],
+    "prerequisites": [
+      "triangle area",
+      "Real.sqrt",
+      "polynomial sum-of-squares non-negativity"
+    ]
+  },
+  {
+    "id": "ann-weitzenbock-heron",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": {
+      "startLine": 36,
+      "endLine": 90
+    },
+    "type": "definition",
+    "title": "heron_product and the 16-fold Expansion",
+    "content": "`heron_product a b c := s*(s-a)*(s-b)*(s-c)` with s = (a+b+c)/2, and `triangle_area a b c := √(heron_product a b c)`. For a valid triangle (positive sides obeying the triangle inequalities) the Heron product is non-negative, so `triangle_area_sq` gives T² = heron_product. The lemma `heron_sixteen` records the symmetric-polynomial form 16·heron_product = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴, proved by `ring` after unfolding. This is the only place the geometry of area enters; everything downstream is algebra.",
+    "mathContext": "Heron's formula $16T^2 = 2a^2b^2+2b^2c^2+2c^2a^2-a^4-b^4-c^4$ is the classical area expansion; here it is obtained directly from the product form $s(s-a)(s-b)(s-c)$ by `ring`, so no separate appeal to a metric area definition is required.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Heron product",
+      "semiperimeter",
+      "symmetric polynomials"
+    ],
+    "prerequisites": [
+      "Real.sqrt",
+      "Real.sq_sqrt",
+      "ring"
+    ]
+  },
+  {
+    "id": "ann-weitzenbock-sos",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 122
+    },
+    "type": "key-step",
+    "title": "The Sum-of-Squares Identity",
+    "content": "`weitzenbock_sos_identity` is the algebraic heart: (a²+b²+c²)² − 48·heron_product = 2[(a²−b²)²+(b²−c²)²+(c²−a²)²]. Substituting heron_sixteen, this is a pure polynomial identity. Since the right side is manifestly ≥ 0, `weitzenbock_sq` concludes 48·heron_product ≤ (a²+b²+c²)², i.e. the squared form of Weitzenböck's inequality, with no transcendental input.",
+    "mathContext": "Expanding, $(a^2+b^2+c^2)^2 - 3(2a^2b^2+2b^2c^2+2c^2a^2-a^4-b^4-c^4) = 2(a^4+b^4+c^4) - 2(a^2b^2+b^2c^2+c^2a^2) = (a^2-b^2)^2+(b^2-c^2)^2+(c^2-a^2)^2$ doubled. The factor $48 = 3\\cdot 16$ comes from $(4\\sqrt3)^2 = 48$ paired with $16T^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sum of squares",
+      "nlinarith",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "sq_nonneg",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-weitzenbock-main",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 166
+    },
+    "type": "key-step",
+    "title": "Descending to the Inequality",
+    "content": "`weitzenbock` assembles the pieces: with c3 = √3 (so c3² = 3) and T² = heron_product, the right-hand side squared is (4·c3·T)² = 16·c3²·T² = 48·heron_product. The squared inequality from `weitzenbock_sq` then reads (4√3·T)² ≤ (a²+b²+c²)². Both sides are non-negative, so applying √ (via Real.sqrt_sq and Real.sqrt_le_sqrt) descends to 4√3·T ≤ a²+b²+c².",
+    "mathContext": "The descent step uses that $x \\mapsto \\sqrt{x}$ is monotone and $\\sqrt{y^2}=y$ for $y\\ge 0$: from $u^2 \\le v^2$ with $u,v\\ge 0$ one gets $u = \\sqrt{u^2} \\le \\sqrt{v^2} = v$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "monotonicity of sqrt",
+      "Real.sq_sqrt",
+      "Real.sqrt_le_sqrt"
+    ],
+    "prerequisites": [
+      "Real.sqrt_sq",
+      "Real.sqrt_le_sqrt"
+    ]
+  },
+  {
+    "id": "ann-weitzenbock-equality",
+    "proofId": "weitzenbock-inequality-oq-01",
+    "range": {
+      "startLine": 168,
+      "endLine": 220
+    },
+    "type": "key-step",
+    "title": "Equality iff Equilateral, and Sanity Checks",
+    "content": "`weitzenbock_eq_iff` characterizes equality. Forward: squaring a²+b²+c² = 4√3·T gives (a²+b²+c²)² = 48·heron_product, so the SOS identity forces (a²−b²)²+(b²−c²)²+(c²−a²)² = 0; each term then vanishes, giving a²=b²=c², and positivity upgrades to a=b=c. Reverse: for the equilateral triangle the area is √3·a²/4, and 4√3·(√3·a²/4) = 3a² = a²+a²+a². The examples confirm the equilateral side-2 case attains equality while the 3-4-5 triangle is strict (50 > 24√3).",
+    "mathContext": "Recovering $a=b$ from $a^2=b^2$ uses $(a-b)(a+b)=a^2-b^2=0$ with $a+b>0$, so $a=b$. This 'SOS vanishes ⟹ equal variables' pattern is exactly why the extremal configuration is the equilateral triangle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "equality case",
+      "equilateral triangle",
+      "positivity",
+      "mul_eq_zero"
+    ],
+    "prerequisites": [
+      "sq_eq_zero_iff",
+      "linear_combination",
+      "Real.sqrt_mul"
+    ]
+  }
+]

--- a/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "weitzenbock-inequality-oq-01",
+  "title": "Weitzenböck's Inequality",
+  "slug": "weitzenbock-inequality-oq-01",
+  "description": "For a triangle with side lengths a, b, c and area T, a² + b² + c² ≥ 4√3·T, with equality if and only if the triangle is equilateral. The classical lower bound relating a triangle's side lengths to its area.",
+  "meta": {
+    "author": "Roland Weitzenböck (1919)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Weitzenb%C3%B6ck%27s_inequality",
+    "date": "1919",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WeitzenbockInequalityOQ01.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "inequality",
+      "area",
+      "sum-of-squares",
+      "heron"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sqrt",
+        "description": "Square root used to encode triangle area and the constant √3",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for x ≥ 0, recovering area² = Heron product",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "Monotonicity of √ used to descend from the squared inequality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "Self-contained formalization of Weitzenböck's inequality a²+b²+c² ≥ 4√3·T with area encoded through Heron's product",
+      "Sum-of-squares identity (a²+b²+c²)² − 48T² = 2[(a²−b²)²+(b²−c²)²+(c²−a²)²], the algebraic heart of the proof",
+      "Full equality characterization: equality holds iff a = b = c (equilateral), via vanishing of each squared difference",
+      "Worked sanity checks: equilateral side-2 attains equality; the 3-4-5 triangle is strict"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 220,
+    "assumptions": "0 axioms. 0 sorries. Fully verified. Area is encoded via the Heron product heron_product a b c = s(s-a)(s-b)(s-c) with T = √(heron_product); the inequality is proved for valid triangles (positive sides satisfying the triangle inequalities).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "title": "Area via Heron's Product",
+      "startLine": 36,
+      "endLine": 90,
+      "description": "Define heron_product a b c = s(s-a)(s-b)(s-c) and triangle_area = √(heron_product), prove non-negativity for valid triangles, and establish area² = heron_product.",
+      "summary": "Area via Heron's Product",
+      "id": "area-via-herons-product"
+    },
+    {
+      "title": "Heron 16-fold Expansion",
+      "startLine": 78,
+      "endLine": 90,
+      "description": "16·T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴, the symmetric polynomial form of the squared area, proved by ring after unfolding the Heron product.",
+      "summary": "Heron 16-fold Expansion",
+      "id": "heron-sixteen-expansion"
+    },
+    {
+      "title": "The Sum-of-Squares Core",
+      "startLine": 92,
+      "endLine": 122,
+      "description": "The key identity (a²+b²+c²)² − 48·heron_product = 2[(a²−b²)²+(b²−c²)²+(c²−a²)²], giving the squared inequality (a²+b²+c²)² ≥ 48T² with no transcendental input.",
+      "summary": "The Sum-of-Squares Core",
+      "id": "sum-of-squares-core"
+    },
+    {
+      "title": "Weitzenböck's Inequality",
+      "startLine": 124,
+      "endLine": 166,
+      "description": "Descend from the squared inequality to a²+b²+c² ≥ 4√3·T using (√3)² = 3, area² = heron_product, and monotonicity of √.",
+      "summary": "Weitzenböck's Inequality",
+      "id": "weitzenbock-inequality"
+    },
+    {
+      "title": "Equality Characterization",
+      "startLine": 168,
+      "endLine": 200,
+      "description": "Equality a²+b²+c² = 4√3·T holds iff a = b = c. The forward direction squares the equality, forces the sum of squares to vanish, and recovers a = b = c by positivity; the reverse direction computes both sides for the equilateral triangle.",
+      "summary": "Equality Characterization",
+      "id": "equality-characterization"
+    },
+    {
+      "title": "Worked Examples",
+      "startLine": 202,
+      "endLine": 220,
+      "description": "Equilateral triangle with side 2 attains equality; the 3-4-5 right triangle yields a strict inequality (50 > 24√3).",
+      "summary": "Worked Examples",
+      "id": "worked-examples"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Weitzenböck's inequality was published by the Austrian mathematician Roland Weitzenböck in 1919. It states that for any triangle with side lengths a, b, c and area T, one has a² + b² + c² ≥ 4√3·T, with equality precisely for the equilateral triangle. The constant 4√3 is sharp: an equilateral triangle of side a has a² + a² + a² = 3a² and area T = (√3/4)a², so 4√3·T = 3a², attaining equality.\n\nThe inequality became widely known after it appeared as Problem 1 of the 1961 International Mathematical Olympiad. It is the simplest member of a family of triangle inequalities; the Hadwiger–Finsler inequality a² + b² + c² ≥ 4√3·T + (a−b)² + (b−c)² + (c−a)² is a strengthening that recovers Weitzenböck by dropping the non-negative correction terms.\n\nThe slickest proofs route through Heron's formula 16T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴, reducing the squared inequality to a sum of squares — exactly the path taken in this formalization.",
+    "problemStatement": "**Weitzenböck's Inequality**: For a triangle with side lengths a, b, c and area T,\n\n  a² + b² + c² ≥ 4√3·T,\n\nwith equality if and only if the triangle is equilateral (a = b = c).",
+    "text": "For a triangle with side lengths a, b, c and area T, a² + b² + c² ≥ 4√3·T, with equality iff the triangle is equilateral.",
+    "proofStrategy": "The proof is entirely elementary and reduces the geometric inequality to a polynomial sum of squares.\n\n1. **Encode area via Heron.** Set s = (a+b+c)/2 and T = √(s(s-a)(s-b)(s-c)). For a valid triangle the Heron product is non-negative, so T² = s(s-a)(s-b)(s-c) and 16T² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴.\n\n2. **Square the target.** Since both a²+b²+c² and 4√3·T are non-negative, it suffices to prove (a²+b²+c²)² ≥ (4√3·T)² = 48T².\n\n3. **Sum of squares.** Substituting the Heron expansion gives the identity\n   (a²+b²+c²)² − 48T² = 2[(a²−b²)² + (b²−c²)² + (c²−a²)²] ≥ 0,\n   dischargeable by nlinarith / ring.\n\n4. **Descend.** From (4√3·T)² ≤ (a²+b²+c²)² and non-negativity of both sides, monotonicity of √ yields 4√3·T ≤ a²+b²+c².\n\n5. **Equality.** Equality forces the sum of squares to vanish, hence a² = b² = c², and positivity gives a = b = c. Conversely the equilateral triangle attains equality by direct computation.",
+    "keyInsights": [
+      "**Squaring removes the irrational constant**: the √3 and the area's √ both disappear once the target is squared, leaving a pure polynomial inequality in a, b, c.",
+      "**Heron is the bridge**: 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ converts 'area' into a symmetric polynomial, so no metric geometry is needed.",
+      "**The whole theorem is one SOS identity**: (a²+b²+c²)² − 48T² = 2[(a²−b²)²+(b²−c²)²+(c²−a²)²], making both the inequality and its equality case transparent.",
+      "**Equality is structural**: vanishing of the three squared differences is exactly a=b=c, so the equilateral characterization is read straight off the identity.",
+      "**Sharp constant**: 4√3 is the largest constant that works, witnessed by the equilateral triangle."
+    ],
+    "prerequisites": [
+      "Heron's formula for the area of a triangle",
+      "Real square root and (√x)² = x for x ≥ 0",
+      "Sum-of-squares non-negativity (nlinarith)",
+      "Monotonicity of the square root"
+    ],
+    "openQuestions": [
+      "Can the Hadwiger–Finsler strengthening a²+b²+c² ≥ 4√3·T + (a−b)²+(b−c)²+(c−a)² be formalized on top of this SOS identity?",
+      "Does the same squaring/SOS template extend to the Pedoe inequality relating two triangles?"
+    ]
+  },
+  "conclusion": {
+    "summary": "Weitzenböck's inequality a²+b²+c² ≥ 4√3·T is formalized with area encoded through the Heron product. Squaring the target eliminates both √3 and the area's square root, reducing the inequality to the sum-of-squares identity (a²+b²+c²)² − 48T² = 2[(a²−b²)²+(b²−c²)²+(c²−a²)²]. The equality case a = b = c is fully characterized. Zero axioms, zero sorries.",
+    "implications": "The proof illustrates a reusable template: geometric inequalities whose only transcendental content is an area (a square root) and a fixed irrational constant can often be reduced, by squaring, to a polynomial sum-of-squares problem that nlinarith dispatches mechanically. The same scaffold supports the Hadwiger–Finsler refinement and related triangle inequalities.",
+    "openQuestions": [
+      "Can the Hadwiger–Finsler strengthening be derived by keeping the correction terms in the SOS identity?",
+      "Can the equality analysis be packaged as a general 'SOS equality ⟹ equal variables' lemma for reuse?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "herons-formula",
+      "relationship": "foundational",
+      "description": "Weitzenböck's inequality is proved by substituting Heron's formula 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ for the area, turning a metric statement into a polynomial sum of squares."
+    },
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Both are classical triangle results that reduce to algebra: Napoleon's theorem to a complex-coordinate rotation identity, Weitzenböck's inequality to a real sum-of-squares identity, and both attain their extremal/structural case at the equilateral triangle."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "WeitzenbockInequality",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/WeitzenbockInequalityOQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary
Formalizes **Weitzenböck's inequality**: for a triangle with sides a, b, c and area T,

  a² + b² + c² ≥ 4√3·T,   with equality iff the triangle is equilateral.

New file `proofs/Proofs/WeitzenbockInequalityOQ01.lean` — **0 sorries, 0 axioms**, registered in `Proofs.lean`, with gallery `meta.json` + `annotations.json`.

## Approach
Area is encoded through the Heron product `heron_product a b c = s(s-a)(s-b)(s-c)`, `T = √(heron_product)`. Squaring the target removes both `√3` and the area's square root, reducing the inequality to a single sum-of-squares identity:

```
(a²+b²+c²)² − 48·T² = 2·[(a²−b²)² + (b²−c²)² + (c²−a²)²] ≥ 0
```

discharged by `nlinarith`, then descended via monotonicity of `√`. The equality case follows by forcing the SOS to vanish (a² = b² = c², hence a = b = c by positivity).

Key declarations: `weitzenbock`, `weitzenbock_eq_iff`, `weitzenbock_sq`, `weitzenbock_sos_identity`, plus sanity checks (`weitzenbock_equilateral_2`, `weitzenbock_345_strict`).

Not a named Mathlib result — genuine first formalization in the gallery.

## Build verification
```
ℹ [3058/3058] Built Proofs.WeitzenbockInequalityOQ01 (13s)
Build completed successfully (3058 jobs).
```
(`./proofs/scripts/docker-build.sh Proofs.WeitzenbockInequalityOQ01`)

## Test plan
- [x] Docker build green, 0 sorry / 0 axiom
- [x] Registered in `Proofs.lean` (import line)
- [x] Gallery `meta.json` + `annotations.json` valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)