### PR TITLE
research(seeker): seed 4 classical geometry theorems (Simson, Miquel, Pompeiu, Brianchon)

### DIFF
--- a/research/problems/brianchon-theorem-oq-01/knowledge.md
+++ b/research/problems/brianchon-theorem-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: brianchon-theorem-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/brianchon-theorem-oq-01/literature/README.md
+++ b/research/problems/brianchon-theorem-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for brianchon-theorem-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/brianchon-theorem-oq-01/problem.md
+++ b/research/problems/brianchon-theorem-oq-01/problem.md
@@ -1,0 +1,131 @@
+# Problem: Brianchon's Theorem
+
+**Slug**: brianchon-theorem-oq-01
+**Created**: 2026-06-16T06:50:00-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let a hexagon $A_1 A_2 A_3 A_4 A_5 A_6$ be circumscribed about a conic (each of
+its six sides is tangent to the conic). Then the three main diagonals
+$A_1A_4$, $A_2A_5$, $A_3A_6$ are concurrent. This point is the *Brianchon
+point*. Brianchon's theorem is the projective dual of Pascal's theorem.
+
+### Plain Language
+
+If a six-sided figure has all six sides touching a single conic (e.g. a
+circle), then the three long diagonals connecting opposite corners all pass
+through one common point.
+
+### Why This Matters
+
+Brianchon's theorem is the projective dual of Pascal's hexagon theorem — which
+is already in the gallery (`pascals-hexagon`). Formalizing it completes the
+classic Pascal/Brianchon duality pair and exercises Mathlib's projective and
+conic/duality infrastructure (or a direct coordinate/pole–polar argument).
+
+## Known Results
+
+### What's Already Proven
+
+- Pascal's hexagon theorem is formalized in the gallery (`pascals-hexagon`,
+  `PascalsHexagon.lean`) — the dual statement.
+- Projective plane / duality and conic API in Mathlib
+  (`Mathlib.LinearAlgebra.Projectivization`, projective duality).
+
+### What's Still Open
+
+- No formalization of Brianchon's theorem in Mathlib or the gallery.
+- A clean dualization bridge from the gallery's Pascal proof is unformalized.
+
+### Our Goal
+
+Formalize Brianchon's theorem, ideally by dualizing the existing Pascal proof
+via pole–polar duality with respect to the conic, or directly via a
+coordinate/projective concurrency computation for the circle case.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| pascals-hexagon | Exact projective dual statement | projective incidence |
+| ptolemys-theorem | Circle/conic incidence relations | complex/metric |
+| desargues-theorem | Projective concurrency/collinearity duality | projective geometry |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Pole–polar dualization of Pascal**: Apply the polarity induced by the
+   conic. Tangent lines (sides of the circumscribed hexagon) dualize to the
+   points of contact lying on the conic; the Pascal line of those points
+   dualizes to the Brianchon concurrency point. Reuse `pascals-hexagon`.
+   - Why it might work: leverages an already-formalized result; conceptually
+     short.
+   - Risk: building the polarity/duality map and the contact-point
+     correspondence formally in Mathlib may be heavy.
+
+2. **Direct coordinate proof for the circle**: Specialize to a hexagon
+   circumscribed about a circle, parametrize tangent points by angles, compute
+   the three diagonals, and show concurrency by a determinant/`ring` identity.
+   - Why it might work: avoids building duality; reduces to algebra.
+   - Risk: only covers the circle (not a general conic); messy parametrization.
+
+### Key Difficulties
+
+- Formalizing projective duality / the pole–polar map cleanly, or
+- Managing the algebraic concurrency computation and tangency conditions.
+- Degenerate configurations (coincident tangent points, parallel diagonals at
+  infinity) require projective treatment.
+
+### What Would a Proof Need?
+
+- A usable conic + tangency formalization, or a circle parametrization.
+- The pole–polar duality bridge to Pascal, or a determinant concurrency lemma.
+- Handling of points at infinity (projective closure).
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- The dual statement (Pascal) is already formalized, suggesting a path, but
+  projective duality in Mathlib is non-trivial to wield.
+- The circle-only coordinate route is more tractable but less general.
+
+**Estimated Effort**:
+- Exploration: 1 day
+- If tractable (circle coordinate route): 3–5 days
+- If hard (full conic duality): 1–3 weeks
+
+## References
+
+### Papers
+- C. J. Brianchon (1810); see Coxeter, *Projective Geometry*.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Brianchon%27s_theorem — statement, duality with Pascal.
+
+### Mathlib
+- `Mathlib.LinearAlgebra.Projectivization.Basic` (projective space).
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` (circle, tangency for the circle case).
+- Gallery `PascalsHexagon.lean` (the dual theorem to reuse).
+
+## Metadata
+
+```yaml
+tags:
+  - projective-geometry
+  - conics
+  - duality
+related_proofs:
+  - pascals-hexagon
+  - desargues-theorem
+  - ptolemys-theorem
+difficulty: hard
+source: gallery-gap
+created: 2026-06-16T06:50:00-07:00
+```

--- a/research/problems/brianchon-theorem-oq-01/state.md
+++ b/research/problems/brianchon-theorem-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: brianchon-theorem-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-16T06:50:55-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/miquel-pivot-theorem-oq-01/knowledge.md
+++ b/research/problems/miquel-pivot-theorem-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: miquel-pivot-theorem-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/miquel-pivot-theorem-oq-01/literature/README.md
+++ b/research/problems/miquel-pivot-theorem-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for miquel-pivot-theorem-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/miquel-pivot-theorem-oq-01/problem.md
+++ b/research/problems/miquel-pivot-theorem-oq-01/problem.md
@@ -1,0 +1,145 @@
+# Problem: Miquel's Pivot Theorem
+
+**Slug**: miquel-pivot-theorem-oq-01
+**Created**: 2026-06-16T06:31:45-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $ABC$ be a triangle, and let $X, Y, Z$ be points lying on lines $BC$,
+$CA$, $AB$ respectively. Then the three circles
+$$
+\odot(AZY), \quad \odot(BXZ), \quad \odot(CYX)
+$$
+pass through a common point $M$, the *Miquel point* of $X, Y, Z$ with respect
+to $\triangle ABC$.
+
+$$
+\exists\, M, \quad M \in \odot(AZY) \cap \odot(BXZ) \cap \odot(CYX).
+$$
+
+### Plain Language
+
+Pick one point on each side of a triangle. For each vertex, draw the circle
+through that vertex and the two chosen points on the adjacent sides. The three
+circles you get always meet at a single common point.
+
+### Why This Matters
+
+Miquel's theorem (the "pivot theorem") is a fundamental concurrency result in
+circle geometry, generalizing to the Miquel point of a complete quadrilateral
+and underlying spiral-similarity arguments used throughout olympiad and
+classical geometry. Formalizing it builds out Mathlib's circle/concyclicity
+toolkit and pairs naturally with the gallery's existing concurrency proofs.
+
+## Known Results
+
+### What's Already Proven
+
+- Concyclicity / cospherical predicates — `EuclideanGeometry.Cospherical`,
+  `EuclideanGeometry.Concyclic`, and `Sphere` API (Mathlib).
+- Directed angles and the concyclicity ⇔ equal-directed-angle criterion —
+  `EuclideanGeometry.oangle`, `Cospherical` ↔ `oangle` lemmas (Mathlib).
+
+### What's Still Open
+
+- No formalization of Miquel's pivot theorem in Mathlib or the gallery.
+- Stronger forms (Miquel point of a complete quadrilateral, spiral-similarity
+  characterization, six-circle theorem) are all unformalized.
+
+### Our Goal
+
+Formalize the base pivot theorem: define $M$ as the second intersection of
+two of the circles, then show $M$ lies on the third. The complete-quadrilateral
+and spiral-similarity generalizations are out of scope (future OQs).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| pascals-hexagon | Concurrency/incidence on conics and circles | projective/circle incidence |
+| ptolemys-theorem | Concyclicity criterion in complex coordinates | complex numbers |
+| cevas-theorem | Concurrency from ratios on triangle sides | ratio/area arguments |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Directed-angle concyclicity criterion**: Define $M$ as the second
+   intersection of $\odot(AZY)$ and $\odot(BXZ)$. Use the directed-angle
+   characterization of concyclicity ($\angle(MX, MY) = \angle(CX, CY)$ as
+   directed angles mod $\pi$) and angle-chasing to show $M, X, Y, C$ concyclic.
+   - Why it might work: Mathlib's `oangle` mod-$\pi$ machinery is exactly the
+     tool for "concyclic iff equal directed angles."
+   - Risk: defining the *second* intersection point and its existence cleanly.
+
+2. **Complex-number coordinates**: Represent points as complex numbers; a
+   circle through three points and concyclicity become cross-ratio reality
+   conditions. The common-point claim reduces to consistency of two circle
+   equations and an algebraic identity.
+   - Why it might work: aligns with successful turnkey complex-coordinate
+     gallery proofs; concyclicity = real cross-ratio.
+   - Risk: handling existence/uniqueness of the intersection algebraically.
+
+### Key Difficulties
+
+- Constructing the Miquel point $M$ (second intersection of two circles) and
+  proving it exists/well-defined before showing it lies on the third circle.
+- Degenerate configurations (chosen points coinciding with vertices, collinear
+  triples) must be excluded by hypotheses.
+
+### What Would a Proof Need?
+
+- A clean definition of "second intersection of two circles."
+- The directed-angle concyclicity criterion in usable Mathlib form, or the
+  complex cross-ratio reality condition.
+- An angle-chase / algebraic identity closing the third concyclicity.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Concyclicity and directed-angle tools exist in Mathlib; the proof is a
+  standard angle-chase once $M$ is defined.
+- Slightly harder than the pure-identity coordinate theorems (Varignon, British
+  Flag) because it requires constructing an intersection point.
+
+**Estimated Effort**:
+- Exploration: hours to 1 day
+- If tractable: 2–4 days
+- If hard: 1–2 weeks (if existence of $M$ proves awkward in Mathlib)
+
+## References
+
+### Papers
+- Classical; see Coxeter & Greitzer, *Geometry Revisited* (1967), §3.7
+  (Miquel point and the pivot theorem).
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Miquel%27s_theorem — statement and proofs.
+
+### Mathlib
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` (circles, concyclicity).
+- `Mathlib.Geometry.Euclidean.Angle.Oriented` (directed angles mod π).
+- `Mathlib.Geometry.Euclidean.Sphere.SecondInter` (second intersection of a line/sphere).
+
+## Metadata
+
+```yaml
+tags:
+  - euclidean-geometry
+  - triangle-geometry
+  - circle-geometry
+  - concurrency
+related_proofs:
+  - pascals-hexagon
+  - ptolemys-theorem
+  - cevas-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-06-16T06:31:45-07:00
+```

--- a/research/problems/miquel-pivot-theorem-oq-01/state.md
+++ b/research/problems/miquel-pivot-theorem-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: miquel-pivot-theorem-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-16T06:31:45-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/pompeiu-theorem-oq-01/literature/README.md
+++ b/research/problems/pompeiu-theorem-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for pompeiu-theorem-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/pompeiu-theorem-oq-01/problem.md
+++ b/research/problems/pompeiu-theorem-oq-01/problem.md
@@ -1,0 +1,138 @@
+# Problem: Pompeiu's Theorem
+
+**Slug**: pompeiu-theorem-oq-01
+**Created**: 2026-06-16T06:50:00-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $ABC$ be an equilateral triangle and $P$ an arbitrary point in the plane.
+Then the three lengths $PA$, $PB$, $PC$ satisfy the triangle inequalities, i.e.
+they are the side lengths of a (possibly degenerate) triangle:
+$$
+PA \le PB + PC, \quad PB \le PA + PC, \quad PC \le PA + PB,
+$$
+and the triangle is degenerate (equality in one inequality) **iff** $P$ lies
+on the circumcircle of $ABC$.
+
+### Plain Language
+
+Take an equilateral triangle and any point $P$. Measure the three distances
+from $P$ to the corners. Those three distances can always be used as the side
+lengths of a triangle — and that triangle is flat (degenerate) exactly when
+$P$ sits on the circle through the three corners.
+
+### Why This Matters
+
+Pompeiu's theorem is a clean, surprising result tying the equilateral triangle
+to the triangle inequality, with a slick complex-number proof. It is a natural
+turnkey target that exercises Mathlib's complex-modulus and metric API and
+complements the gallery's complex-coordinate triangle proofs.
+
+## Known Results
+
+### What's Already Proven
+
+- Complex modulus / triangle inequality — `Complex.abs`, `abs_add`,
+  `norm_add_le`, `dist` API (Mathlib).
+- Roots of unity / equilateral characterization — `Complex.isPrimitiveRoot`
+  and `ω = e^{2πi/3}` machinery (Mathlib).
+
+### What's Still Open
+
+- No formalization of Pompeiu's theorem in Mathlib or the gallery.
+- The degenerate-iff-concyclic refinement is unformalized.
+
+### Our Goal
+
+Formalize the core triangle inequality for $PA, PB, PC$ when $ABC$ is
+equilateral, and (stretch) the degeneracy ⇔ concyclicity characterization.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| ptolemys-theorem | Distance identities on concyclic points via complex numbers | complex numbers |
+| napoleons-theorem | Equilateral-triangle construction in complex coordinates | complex coordinates |
+| varignon-theorem | Turnkey complex-coordinate plane geometry | complex numbers, ring identity |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Complex numbers with cube roots of unity**: Place $A, B, C$ at $1, \omega,
+   \omega^2$ (cube roots of unity), $P$ at $z$. The key identity
+   $(z-1) + \omega(z-\omega) + \omega^2(z-\omega^2)$-style relation, combined
+   with $|x| + |y| \ge |x+y|$, yields the triangle inequality on
+   $|z-1|, |z-\omega|, |z-\omega^2|$.
+   - Why it might work: the proof reduces to the standard triangle inequality
+     applied to a vanishing-sum of three complex numbers — exactly the turnkey
+     identity style used in Varignon/British Flag.
+   - Risk: the equality/degeneracy case requires identifying when the three
+     complex terms are positively collinear (⇔ $P$ on circumcircle).
+
+2. **Ptolemy inequality**: Pompeiu follows from the general Ptolemy inequality
+   applied to the cyclic/non-cyclic quadrilateral $PABC$ with the equilateral
+   constraint $AB = BC = CA$.
+   - Why it might work: if a Ptolemy inequality is available, this is short.
+   - Risk: Mathlib may not have the Ptolemy *inequality* (only the equality on
+     concyclic points, if that).
+
+### Key Difficulties
+
+- The equality/degeneracy characterization (concyclic ⇔ degenerate) needs the
+  positive-collinearity condition for the complex triangle inequality.
+- Encoding "equilateral" cleanly (via cube roots of unity vs. metric equalities).
+
+### What Would a Proof Need?
+
+- The vanishing linear combination of $z - \omega^k$ with unit coefficients.
+- The complex triangle inequality `Complex.abs_add` / `norm_add_le`.
+- Equality condition of the triangle inequality for the degeneracy claim.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Forward inequality is a direct application of the complex triangle inequality
+  to a vanishing sum — closely matching completed turnkey complex-coordinate
+  gallery proofs.
+- Only the degeneracy ⇔ concyclic refinement adds difficulty.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–2 days
+- If hard: up to 1 week (degeneracy characterization)
+
+## References
+
+### Papers
+- D. Pompeiu (1936); see Coxeter & Greitzer, *Geometry Revisited*.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Pompeiu%27s_theorem — statement and complex proof.
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Complex.Circle` (roots of unity).
+- `Mathlib.Analysis.Normed.Field.Basic` (`norm_add_le`, triangle inequality).
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` (circumcircle / concyclicity).
+
+## Metadata
+
+```yaml
+tags:
+  - euclidean-geometry
+  - triangle-geometry
+  - complex-numbers
+related_proofs:
+  - ptolemys-theorem
+  - napoleons-theorem
+  - varignon-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-06-16T06:50:00-07:00
+```

--- a/research/problems/pompeiu-theorem-oq-01/state.md
+++ b/research/problems/pompeiu-theorem-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: pompeiu-theorem-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-16T06:50:55-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/simson-line-theorem-oq-01/literature/README.md
+++ b/research/problems/simson-line-theorem-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for simson-line-theorem-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/simson-line-theorem-oq-01/problem.md
+++ b/research/problems/simson-line-theorem-oq-01/problem.md
@@ -1,0 +1,145 @@
+# Problem: Simson Line Theorem
+
+**Slug**: simson-line-theorem-oq-01
+**Created**: 2026-06-16T06:31:45-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $ABC$ be a triangle and $P$ a point. Let $X, Y, Z$ be the feet of the
+perpendiculars from $P$ onto lines $BC$, $CA$, $AB$ respectively. Then
+$X, Y, Z$ are collinear **if and only if** $P$ lies on the circumcircle of
+$ABC$. The line $XYZ$ is the *Simson line* (or Wallace line) of $P$.
+
+$$
+P \in \odot(ABC) \iff \operatorname{collinear}\{X, Y, Z\}.
+$$
+
+### Plain Language
+
+Drop perpendiculars from a point $P$ to the three sides of a triangle. The
+three feet of those perpendiculars line up on a single straight line exactly
+when $P$ sits on the triangle's circumscribed circle.
+
+### Why This Matters
+
+The Simson line is a cornerstone of classical triangle geometry, connecting
+the circumcircle to a family of remarkable lines (its envelope is a deltoid;
+the Simson lines of antipodal points are perpendicular). It is a natural,
+self-contained target that exercises Mathlib's Euclidean-geometry and
+orthogonal-projection API, and complements existing circle/triangle proofs in
+the gallery.
+
+## Known Results
+
+### What's Already Proven
+
+- Foot-of-perpendicular / orthogonal projection onto an affine subspace —
+  `EuclideanGeometry.orthogonalProjection` (Mathlib).
+- Concyclicity and the inscribed-angle machinery — `EuclideanGeometry.Sphere`,
+  `Cospherical`, `oangle` (directed angles) in Mathlib.
+- Collinearity predicate — `Collinear ℝ {X, Y, Z}` (Mathlib).
+
+### What's Still Open
+
+- No formalization of the Simson line theorem appears in Mathlib or the gallery.
+- The biconditional (collinearity $\iff$ concyclic) and the deltoid envelope are
+  both unformalized.
+
+### Our Goal
+
+Formalize the core biconditional: the three pedal feet of $P$ w.r.t. triangle
+$ABC$ are collinear iff $P$ is concyclic with $A, B, C$. The deltoid envelope
+and antipodal-perpendicularity are out of scope (future OQs).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| ptolemys-theorem | Concyclicity criterion via complex/metric identities | complex numbers, metric geometry |
+| feuerbachs-theorem | Pedal/contact geometry on a triangle | coordinate + circle geometry |
+| napoleons-theorem | Triangle construction proved with complex coordinates | complex-number coordinates |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Directed-angle (Mathlib `oangle`) approach**: Use the fact that pairs of
+   pedal feet are concyclic with $P$ and a vertex (right angles subtend a
+   diameter), then chase directed angles to force collinearity exactly when
+   $P$ is on the circumcircle.
+   - Why it might work: Mathlib has a substantial directed-angle library
+     (`EuclideanGeometry.oangle`, `Sphere.oangle_eq` style lemmas).
+   - Risk: directed-angle bookkeeping is fiddly; orientation hypotheses.
+
+2. **Complex-number coordinates**: Place the circumcircle as the unit circle,
+   $A, B, C, P$ on $|z| = 1$. The foot of the perpendicular from $P$ to chord
+   $AB$ has a closed form $\tfrac12(a + b + p - ab\bar p)$; collinearity of the
+   three feet reduces to a polynomial identity that holds iff $|p| = 1$.
+   - Why it might work: mirrors the successful turnkey complex-coordinate
+     proofs (Varignon, British Flag, van Aubel) — reduces to a
+     `linear_combination`/`ring` identity.
+   - Risk: the general off-circle direction needs the converse handled too.
+
+### Key Difficulties
+
+- Stating "foot of perpendicular onto a line" cleanly and connecting it to the
+  closed-form chord-foot formula.
+- The converse direction (collinear $\Rightarrow$ concyclic) requires ruling
+  out the degenerate/off-circle case.
+
+### What Would a Proof Need?
+
+- Closed form for the pedal foot of $P$ onto a chord of the unit circle.
+- A collinearity criterion (e.g. the imaginary part of a cross-ratio / a
+  determinant vanishing) in complex coordinates.
+- The algebraic identity reducing collinearity to $p\bar p = 1$.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Strongly analogous to already-completed turnkey complex-coordinate triangle
+  theorems in the gallery (Varignon, British Flag, van Aubel, Viviani).
+- The forward direction reduces to a single algebraic identity; the converse is
+  the only genuinely new piece.
+- Mathlib provides orthogonal projection, collinearity, and concyclicity APIs.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–3 days
+- If hard: 1 week (if forced onto the synthetic directed-angle route)
+
+## References
+
+### Papers
+- Classical; see Coxeter & Greitzer, *Geometry Revisited* (1967), §2.5.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Simson_line — statement, proof sketches, deltoid envelope.
+
+### Mathlib
+- `Mathlib.Geometry.Euclidean.Projection` (orthogonal projection / feet of perpendiculars).
+- `Mathlib.Geometry.Euclidean.Angle.Oriented` (directed angles).
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` (circumcircle, concyclicity).
+
+## Metadata
+
+```yaml
+tags:
+  - euclidean-geometry
+  - triangle-geometry
+  - coordinate-geometry
+  - circle-geometry
+related_proofs:
+  - ptolemys-theorem
+  - feuerbachs-theorem
+  - napoleons-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-06-16T06:31:45-07:00
+```

--- a/research/problems/simson-line-theorem-oq-01/state.md
+++ b/research/problems/simson-line-theorem-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: simson-line-theorem-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-16T06:31:45-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary
Seeds four gallery-absent, non-Mathlib classical geometry theorems into the research candidate pool to keep researchers fed and provide headroom under active consumption (authoritative `.lean/state` pool was at 14 vs the 15 threshold; now 16).

- **Simson line** (`simson-line-theorem-oq-01`) — pedal feet of a point onto a triangle's sides are collinear iff the point is on the circumcircle.
- **Miquel pivot** (`miquel-pivot-theorem-oq-01`) — the three circles through each vertex and its two adjacent side-points concur at the Miquel point.
- **Pompeiu** (`pompeiu-theorem-oq-01`) — for an equilateral triangle, PA/PB/PC form a triangle (degenerate iff P on circumcircle).
- **Brianchon** (`brianchon-theorem-oq-01`) — diagonals of a conic-circumscribed hexagon concur (projective dual of the gallery's Pascal proof).

All four verified absent from the gallery (`src/data/proofs/`, `proofs/Proofs/`) and from Mathlib (`/private/tmp/mathlib-grep`). Simson/Miquel/Pompeiu are complex-coordinate / directed-angle tractable, matching recent turnkey geometry proofs (Varignon, British Flag, van Aubel, Viviani); Brianchon pairs with the existing Pascal formalization via duality.

This cycle also fixed DB drift: `menelaus-theorem-oq-01` (done in #24998) and `weitzenbock-inequality-oq-01` (in-progress, #24999) were stale-`available` in the DB snapshot and corrected to match the authoritative state.

## Notes
- DB / candidate-pool / `.lean/state` are gitignored local runtime and already updated; this PR carries only the durable `research/problems/<slug>/` stubs.
- All stubs validated with `validate-seeker-stubs.ts` (no template placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)