### PR TITLE
research(british-flag-theorem-oq-01): build-verified British Flag Theorem

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -324,6 +324,7 @@ import Proofs.BoundedPrimeGapsOQ04OQ01Aristotle
 import Proofs.BoundedPrimeGapsOQ04OQ02
 import Proofs.BoundedPrimeGapsSieve
 import Proofs.BoundedPrimeGapsTPC
+import Proofs.BritishFlagTheorem
 import Proofs.BrouwerFixedPoint
 import Proofs.BrouwerFixedPointOQ01
 import Proofs.BrouwerFixedPointOQ01OQ02

--- a/proofs/Proofs/BritishFlagTheorem.lean
+++ b/proofs/Proofs/BritishFlagTheorem.lean
@@ -1,0 +1,127 @@
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Tactic
+
+/-
+# The British Flag Theorem
+
+## What This Proves
+For a rectangle `ABCD` and **any** point `P` in the plane,
+  `PA² + PC² = PB² + PD²`,
+i.e. the sums of squared distances to opposite corners are equal.
+
+The name comes from the Union-Jack-like figure of the four segments drawn from
+an interior point to the corners.
+
+## Key Mathematical Content
+The identity is **not** true for a general parallelogram — it characterises the
+right angle. Writing the rectangle as `A`, `B = A + u`, `C = A + u + v`,
+`D = A + v`, a direct expansion gives
+
+  (PA² + PC²) − (PB² + PD²) = 2 ⟪u, v⟫,
+
+so the two sums agree **exactly when** `u ⊥ v`, i.e. when `ABCD` is a rectangle.
+The perpendicularity hypothesis is therefore the whole substance of the theorem,
+and the proof is a single `linear_combination` against it.
+
+## Approach
+1. `british_flag_coords`: the real-coordinate identity, proved by
+   `linear_combination 2 * hperp` (the `2⟪u,v⟫` defect cancels against `hperp`).
+2. `british_flag`: the complex-number / metric-distance statement, obtained by
+   feeding the real and imaginary parts of the points into the coordinate lemma.
+
+## Status
+- [x] Coordinate identity (over ℝ)
+- [x] Complex / `dist` form
+- [x] Sharpness witness (parallelogram counterexample)
+- [x] Complete — 0 sorries, 0 axioms
+
+## Mathlib Dependencies
+- `Complex.dist_eq_re_im` : `dist z w = Real.sqrt ((z.re-w.re)² + (z.im-w.im)²)`
+- `Real.sq_sqrt`          : `0 ≤ a → Real.sqrt a ^ 2 = a`
+- `Complex.sub_re`, `Complex.sub_im`, `Complex.add_re`, `Complex.add_im`
+-/
+
+set_option linter.unusedVariables false
+
+namespace BritishFlag
+
+-- ============================================================
+-- PART 1: The Coordinate Identity (the heart of the theorem)
+-- ============================================================
+
+/-- **British Flag Theorem (coordinate form).**
+
+The rectangle has corners `A = (ax, ay)`, `B = A + u`, `C = A + u + v`,
+`D = A + v`, with edge vectors `u = (ux, uy)` and `v = (vx, vy)`. The
+hypothesis `hperp : ux*vx + uy*vy = 0` says `u ⊥ v` (the right angle that makes
+`ABCD` a rectangle). For any point `P = (px, py)`:
+
+  `PA² + PC² = PB² + PD²`.
+
+The difference of the two sides expands to exactly `2 (ux*vx + uy*vy)`, so the
+proof is `linear_combination 2 * hperp`. -/
+theorem british_flag_coords (px py ax ay ux uy vx vy : ℝ)
+    (hperp : ux * vx + uy * vy = 0) :
+    ((px - ax) ^ 2 + (py - ay) ^ 2)
+        + ((px - (ax + ux + vx)) ^ 2 + (py - (ay + uy + vy)) ^ 2)
+      = ((px - (ax + ux)) ^ 2 + (py - (ay + uy)) ^ 2)
+        + ((px - (ax + vx)) ^ 2 + (py - (ay + vy)) ^ 2) := by
+  linear_combination 2 * hperp
+
+-- ============================================================
+-- PART 2: The Complex / Metric-Distance Form
+-- ============================================================
+
+/-- **British Flag Theorem** in the complex plane with metric distance.
+
+The rectangle `ABCD` is encoded by
+* `hrect : C = B + D - A` (so `ABCD` is a parallelogram), and
+* `hperp` : the edges `B - A` and `D - A` are orthogonal as vectors in `ℝ²`,
+  i.e. `(B-A)·(D-A) = 0`.
+
+Then for any point `P : ℂ`:
+
+  `dist P A ^ 2 + dist P C ^ 2 = dist P B ^ 2 + dist P D ^ 2`.
+
+Reduces to `british_flag_coords` on the real and imaginary parts. -/
+theorem british_flag (A B C D P : ℂ)
+    (hrect : C = B + D - A)
+    (hperp : (B - A).re * (D - A).re + (B - A).im * (D - A).im = 0) :
+    dist P A ^ 2 + dist P C ^ 2 = dist P B ^ 2 + dist P D ^ 2 := by
+  have hsq : ∀ z w : ℂ, dist z w ^ 2 = (z.re - w.re) ^ 2 + (z.im - w.im) ^ 2 := by
+    intro z w
+    rw [Complex.dist_eq_re_im, Real.sq_sqrt (by positivity)]
+  have key := british_flag_coords P.re P.im A.re A.im
+    (B - A).re (B - A).im (D - A).re (D - A).im hperp
+  rw [hsq, hsq, hsq, hsq]
+  subst hrect
+  simp only [Complex.sub_re, Complex.sub_im, Complex.add_re, Complex.add_im] at key ⊢
+  linear_combination key
+
+-- ============================================================
+-- PART 3: Sharpness — the right angle is necessary
+-- ============================================================
+
+/-- The identity fails for a non-rectangular parallelogram, confirming that the
+perpendicularity hypothesis is essential.
+
+Take edges `u = (2, 0)`, `v = (1, 1)` (so `u·v = 2 ≠ 0`, a non-right angle) with
+`A = P = 0`. Then `PA² + PC² = 0 + 10 = 10` while `PB² + PD² = 4 + 2 = 6`. The
+defect is exactly `2 (u·v) = 4`. -/
+theorem british_flag_needs_right_angle :
+    ∃ (px py ax ay ux uy vx vy : ℝ), ux * vx + uy * vy ≠ 0 ∧
+      ((px - ax) ^ 2 + (py - ay) ^ 2)
+          + ((px - (ax + ux + vx)) ^ 2 + (py - (ay + uy + vy)) ^ 2)
+        ≠ ((px - (ax + ux)) ^ 2 + (py - (ay + uy)) ^ 2)
+          + ((px - (ax + vx)) ^ 2 + (py - (ay + vy)) ^ 2) := by
+  exact ⟨0, 0, 0, 0, 2, 0, 1, 1, by norm_num, by norm_num⟩
+
+-- ============================================================
+-- Export main results
+-- ============================================================
+
+#check @british_flag_coords
+#check @british_flag
+#check @british_flag_needs_right_angle
+
+end BritishFlag

--- a/research/problems/british-flag-theorem-oq-01/knowledge.md
+++ b/research/problems/british-flag-theorem-oq-01/knowledge.md
@@ -1,0 +1,40 @@
+# British Flag Theorem (british-flag-theorem-oq-01)
+
+## Problem
+For a rectangle `ABCD` and **any** point `P`, `PA² + PC² = PB² + PD²` (the sums
+of squared distances to opposite corners are equal).
+
+## Status: COMPLETED (build-verified, 0 sorries, 0 axioms)
+
+## Core Insight
+Writing the rectangle through edge vectors `u = B - A`, `v = D - A` (so
+`C = A + u + v`), the difference of the two squared-distance sums is
+
+  (PA² + PC²) − (PB² + PD²) = 2⟨u, v⟩,
+
+**independent of P**. The theorem is therefore equivalent to `⟨u, v⟩ = 0`, i.e.
+to `ABCD` being a rectangle rather than a general parallelogram. The right angle
+is the entire mathematical content.
+
+## Formalization (`proofs/Proofs/BritishFlagTheorem.lean`)
+1. `british_flag_coords` — real-coordinate identity. Both sides are real
+   polynomials whose difference is `2(ux*vx + uy*vy)`; closed by
+   `linear_combination 2 * hperp`.
+2. `british_flag` — complex / metric-distance form. Rectangle encoded by
+   `C = B + D - A` and `(B-A).re*(D-A).re + (B-A).im*(D-A).im = 0`. Each
+   `dist · · ^ 2` is rewritten to coordinates via the helper
+   `dist z w ^ 2 = (z.re-w.re)^2 + (z.im-w.im)^2` (from `Complex.dist_eq_re_im`
+   and `Real.sq_sqrt`), then reduced to `british_flag_coords`.
+3. `british_flag_needs_right_angle` — sharpness: `u = (2,0)`, `v = (1,1)` give
+   `⟨u,v⟩ = 2 ≠ 0` and `PA²+PC² = 10 ≠ 6 = PB²+PD²`. Defect `2⟨u,v⟩ = 4`.
+
+## Mathlib Notes
+- `Complex.sq_abs` does **not** exist in Mathlib v4.26.0 (build attempt 1 failed
+  on `Unknown constant 'Complex.sq_abs'`). Use `Complex.dist_eq_re_im` +
+  `Real.sq_sqrt` to convert a squared complex distance to coordinates instead.
+
+## Follow-up Open Questions
+- Higher-dimensional version in `EuclideanSpace ℝ (Fin n)` (the coordinate proof
+  is dimension-agnostic — only bilinearity + the right angle are used).
+- Converse: if `PA²+PC² = PB²+PD²` for all `P`, must the parallelogram be a
+  rectangle? (The `2⟨u,v⟩` analysis says yes.)

--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-module-doc",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 44
+    },
+    "title": "Module Documentation: The 2⟨u,v⟩ Defect",
+    "type": "concept",
+    "content": "The documentation states the British flag theorem (PA² + PC² = PB² + PD² for a rectangle and any point P) and identifies its mathematical core: the difference of the two squared-distance sums equals 2⟨u,v⟩, where u and v are the edge vectors of the rectangle. The proof is organised into a coordinate identity proved by linear_combination and a complex/metric corollary obtained by reduction to coordinates.",
+    "mathContext": "Writing the rectangle as A, B = A+u, C = A+u+v, D = A+v, a direct expansion gives $(PA^2 + PC^2) - (PB^2 + PD^2) = 2\\langle u, v\\rangle$, a quantity independent of P. The theorem is thus equivalent to $\\langle u, v\\rangle = 0$, i.e. to ABCD being a rectangle rather than a general parallelogram.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inner product",
+      "orthogonality",
+      "squared distance",
+      "proof architecture"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "inner product spaces"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 2
+    },
+    "title": "Library Imports",
+    "type": "concept",
+    "content": "Imports Mathlib.Analysis.Complex.Basic for ℂ together with its metric-space and normSq structure, and Mathlib.Tactic for proof automation (notably linear_combination and norm_num).",
+    "mathContext": "The key Mathlib facts are Complex.dist_eq_re_im (dist z w = Real.sqrt ((z.re-w.re)^2 + (z.im-w.im)^2)) and Real.sq_sqrt (0 ≤ a → Real.sqrt a ^ 2 = a), together with the component projections Complex.sub_re/sub_im/add_re/add_im, which reduce squared distances in ℂ to real coordinate polynomials.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "complex numbers",
+      "metric space",
+      "normSq"
+    ],
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib analysis library"
+    ]
+  },
+  {
+    "id": "ann-coordinate-identity",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 69
+    },
+    "title": "Coordinate Identity (linear_combination)",
+    "type": "proof-step",
+    "content": "british_flag_coords states the theorem in pure real coordinates: corners A = (ax,ay), B = A+u, C = A+u+v, D = A+v with edge vectors u = (ux,uy), v = (vx,vy), and hypothesis hperp : ux*vx + uy*vy = 0. The goal PA² + PC² = PB² + PD² is closed by `linear_combination 2 * hperp`.",
+    "mathContext": "Expanding both sides as real polynomials in px, py, ax, ay, ux, uy, vx, vy, their difference is exactly $2(u_x v_x + u_y v_y)$. The tactic `linear_combination 2 * hperp` instructs Lean to subtract $2 \\cdot (\\text{hperp.lhs} - \\text{hperp.rhs})$ from the goal difference and verify the remainder is zero by `ring` — which it is, since the remainder is $2\\langle u,v\\rangle - 2\\langle u,v\\rangle = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination",
+      "polynomial identity",
+      "inner product"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "ring identities"
+    ]
+  },
+  {
+    "id": "ann-complex-form",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 99
+    },
+    "title": "Complex / Distance Form via Reduction to Coordinates",
+    "type": "proof-step",
+    "content": "british_flag encodes the rectangle by hrect : C = B + D - A (parallelogram) and hperp : (B-A).re*(D-A).re + (B-A).im*(D-A).im = 0 (right angle), concluding dist P A² + dist P C² = dist P B² + dist P D². The proof rewrites each squared distance via the helper dist z w ^ 2 = (z.re-w.re)^2 + (z.im-w.im)^2 (from Complex.dist_eq_re_im and Real.sq_sqrt), instantiates british_flag_coords at the real and imaginary parts of the points, and finishes with linear_combination key.",
+    "mathContext": "Under hrect, the imaginary/real components of C are those of B + D - A, so the corner C = A + (B-A) + (D-A) matches the coordinate lemma's A + u + v with u = B - A, v = D - A. The hypothesis hperp is precisely $\\langle u, v\\rangle = 0$ written in components. Thus the metric statement is a faithful instance of the coordinate identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex numbers as ℝ²",
+      "metric distance",
+      "normSq"
+    ],
+    "prerequisites": [
+      "complex arithmetic",
+      "metric spaces"
+    ]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 117
+    },
+    "title": "Sharpness: the Right Angle is Necessary",
+    "type": "concept",
+    "content": "british_flag_needs_right_angle exhibits a non-rectangular parallelogram for which the identity fails: edge vectors u = (2,0), v = (1,1) with A = P = 0 give ux*vx + uy*vy = 2 ≠ 0 and PA² + PC² = 10 ≠ 6 = PB² + PD². Proved by norm_num.",
+    "mathContext": "The defect predicted by the coordinate analysis is $2\\langle u, v\\rangle = 2 \\cdot 2 = 4$, exactly the gap $10 - 6$. This certifies that the perpendicularity hypothesis in british_flag is load-bearing: it cannot be weakened to the parallelogram condition alone.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "counterexample",
+      "necessity of hypotheses",
+      "parallelogram"
+    ],
+    "prerequisites": [
+      "coordinate geometry"
+    ]
+  }
+]

--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "british-flag-theorem-oq-01",
+  "title": "The British Flag Theorem",
+  "slug": "british-flag-theorem-oq-01",
+  "description": "For a rectangle ABCD and any point P, PA² + PC² = PB² + PD². The squared-distance defect equals 2⟨u,v⟩ for edge vectors u, v, so the identity holds exactly when u ⊥ v — the right angle is the whole content.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/British_flag_theorem",
+    "date": "2026-06-16",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "complex-analysis",
+      "classic",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/BritishFlagTheorem.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.dist_eq_re_im",
+        "description": "dist z w = Real.sqrt ((z.re-w.re)^2 + (z.im-w.im)^2), expressing complex distance in coordinates",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "0 ≤ a → Real.sqrt a ^ 2 = a, removing the square root from the squared distance",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Complex.sub_re / Complex.sub_im / Complex.add_re / Complex.add_im",
+        "description": "Component projections of complex sums and differences, reducing the goal to a real polynomial identity",
+        "module": "Mathlib.Data.Complex.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Coordinate-form identity proved by a single linear_combination against the perpendicularity hypothesis",
+      "Complex / metric-distance formulation reduced to the coordinate lemma via real and imaginary parts",
+      "Sharpness witness: an explicit non-right parallelogram for which the identity fails, showing the right-angle hypothesis is necessary"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The complex form assumes the rectangle hypotheses C = B + D - A (parallelogram) and ⟨B-A, D-A⟩ = 0 (right angle).",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The British flag theorem is a staple of elementary Euclidean geometry, named for the resemblance of the four segments drawn from an interior point to the corners of a rectangle to the diagonals and cross of the Union Jack. Its classical proof drops perpendiculars from the point to the sides and applies the Pythagorean theorem four times; the cross-terms cancel in pairs, leaving the equality of opposite sums of squared distances.\n\nThe theorem is a clean instance of a recurring phenomenon in metric geometry: an apparently geometric statement about distances reduces, once coordinates are introduced, to a polynomial identity plus a single scalar hypothesis. Here the scalar hypothesis is orthogonality of the two edge vectors. Writing the rectangle through its edge vectors u and v, the difference of the two squared-distance sums is exactly 2⟨u, v⟩, independent of where the point P lies. The theorem is therefore equivalent to ⟨u, v⟩ = 0, which is precisely the statement that the parallelogram is a rectangle. This makes the British flag theorem a particularly transparent witness to how the inner product encodes angle.\n\nThe same identity holds verbatim in any dimension and for any point in the ambient space, not just points in the plane of the rectangle, because the computation never uses planarity — only the bilinearity of the inner product and the right angle between the edges.",
+    "problemStatement": "**British Flag Theorem**:\n\nLet $ABCD$ be a rectangle and $P$ any point. Then\n$$PA^2 + PC^2 = PB^2 + PD^2,$$\ni.e. the sums of squared distances from $P$ to opposite corners are equal.",
+    "text": "For a rectangle ABCD and any point P, the sums of squared distances to opposite corners agree: PA² + PC² = PB² + PD². The defect for a general parallelogram is 2⟨u,v⟩, so equality characterises the right angle.",
+    "proofStrategy": "The proof has two layers:\n1. **Coordinate identity** (`british_flag_coords`): with edge vectors $u = (u_x, u_y)$, $v = (v_x, v_y)$ and corners $A$, $B = A+u$, $C = A+u+v$, $D = A+v$, the difference $(PA^2 + PC^2) - (PB^2 + PD^2)$ expands to exactly $2(u_x v_x + u_y v_y) = 2\\langle u, v\\rangle$. Under the hypothesis $\\langle u, v\\rangle = 0$ this is `linear_combination 2 * hperp`.\n2. **Complex / distance form** (`british_flag`): feeding the real and imaginary parts of $A, B, C, D, P$ into the coordinate lemma, then rewriting each squared distance $\\mathrm{dist}\\,z\\,w^2 = (z.re-w.re)^2 + (z.im-w.im)^2$ via `Complex.dist_eq_re_im` and `Real.sq_sqrt`, yields the metric statement.\n\nA third theorem (`british_flag_needs_right_angle`) exhibits edge vectors with $\\langle u, v\\rangle = 2 \\neq 0$ for which the two sums differ ($10 \\neq 6$), proving the right-angle hypothesis cannot be dropped.",
+    "keyInsights": [
+      "The squared-distance defect $(PA^2 + PC^2) - (PB^2 + PD^2)$ equals $2\\langle u, v\\rangle$ where $u, v$ are the edge vectors — completely independent of the point $P$. The British flag theorem is therefore equivalent to the orthogonality of the edges.",
+      "Because the proof uses only bilinearity of the inner product and the right angle, the identity holds for any point in any dimension, not merely points coplanar with the rectangle.",
+      "The right-angle hypothesis is genuinely necessary, not a convenience: for a non-rectangular parallelogram the defect $2\\langle u, v\\rangle$ is nonzero, witnessed explicitly by $u = (2,0)$, $v = (1,1)$.",
+      "Reducing the metric statement to a real polynomial identity lets a one-line `linear_combination` discharge a theorem that classically requires four applications of the Pythagorean theorem."
+    ],
+    "prerequisites": [
+      "Coordinate geometry in the plane",
+      "Inner product and orthogonality",
+      "Complex numbers as ℝ² (real and imaginary parts)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Documentation of the theorem, the 2⟨u,v⟩ defect, and the two-layer proof plan. Imports Mathlib.Analysis.Complex.Basic for ℂ and its metric/normSq structure and Mathlib.Tactic for automation.",
+      "mathContext": "The imports provide ℂ as a metric space (Complex.dist_eq_re_im) and the real square-root facts (Real.sq_sqrt) needed to turn squared distances into coordinate polynomials."
+    },
+    {
+      "id": "coordinate-identity",
+      "title": "The Coordinate Identity",
+      "startLine": 52,
+      "endLine": 69,
+      "summary": "british_flag_coords: the rectangle written through edge vectors u, v, with PA²+PC²=PB²+PD² proved by linear_combination 2 * hperp once ⟨u,v⟩ = 0.",
+      "mathContext": "Both sides expand to real polynomials whose difference is 2(u_x v_x + u_y v_y). The hypothesis hperp asserts this is 0, so linear_combination with coefficient 2 closes the goal by ring."
+    },
+    {
+      "id": "complex-form",
+      "title": "The Complex / Metric-Distance Form",
+      "startLine": 71,
+      "endLine": 99,
+      "summary": "british_flag: the rectangle encoded by C = B + D - A and ⟨B-A, D-A⟩ = 0, with dist P A² + dist P C² = dist P B² + dist P D². Reduced to british_flag_coords on real and imaginary parts.",
+      "mathContext": "Complex.dist_eq_re_im writes each distance as a square root of a sum of squared component differences; Real.sq_sqrt removes the square root, and the component projections expand the result into coordinates matching the coordinate lemma."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness — the Right Angle is Necessary",
+      "startLine": 101,
+      "endLine": 117,
+      "summary": "british_flag_needs_right_angle: explicit edge vectors u=(2,0), v=(1,1) with ⟨u,v⟩=2≠0 for which PA²+PC²=10 but PB²+PD²=6, so the identity fails.",
+      "mathContext": "The defect 2⟨u,v⟩ = 4 is exactly the gap 10 - 6, confirming the perpendicularity hypothesis is essential rather than cosmetic."
+    },
+    {
+      "id": "exports",
+      "title": "Exported Theorems",
+      "startLine": 119,
+      "endLine": 127,
+      "summary": "#check verification of the three exported theorems.",
+      "mathContext": "Three theorems: british_flag_coords (coordinate identity), british_flag (complex/dist form), british_flag_needs_right_angle (sharpness)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "ptolemys-complex-proof",
+      "relationship": "companion",
+      "description": "Both transform a classical Euclidean distance statement into an algebraic identity over coordinates — Ptolemy via a CommRing factorization and the triangle inequality, the British flag theorem via a polynomial identity whose defect is the inner product of the rectangle's edges."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The classical proof of the British flag theorem applies the Pythagorean theorem four times; the coordinate proof here absorbs all four applications into a single polynomial identity, with the right-angle hypothesis surfacing as the orthogonality condition ⟨u,v⟩ = 0."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "Both quantify how squared distances depend on angle: the law of cosines via the −2ab·cos C term, the British flag theorem via the 2⟨u,v⟩ defect that vanishes exactly at a right angle."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, axiom-free formalization of the British flag theorem. The coordinate identity is a one-line linear_combination against the orthogonality hypothesis; the complex/metric form follows by reduction to coordinates; and an explicit counterexample shows the right-angle hypothesis is necessary. Three theorems, 0 sorries, 0 axioms.",
+    "implications": "The formalization makes precise that the British flag theorem is, at its core, the statement that the squared-distance defect between opposite corner sums equals twice the inner product of the edge vectors. Everything else — the point P, the dimension of the ambient space — is irrelevant. This isolates the right angle as the single load-bearing hypothesis and explains why the theorem generalizes unchanged to higher dimensions.",
+    "openQuestions": [
+      "Can the theorem be stated and proved directly in EuclideanSpace ℝ (Fin n) for arbitrary n, confirming the dimension-independence observed in the coordinate proof?",
+      "Is there a converse: if PA² + PC² = PB² + PD² holds for all points P of a parallelogram ABCD, must ABCD be a rectangle?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Complex.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "BritishFlag",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/BritishFlagTheorem.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Wikipedia",
+      "title": "British flag theorem",
+      "year": "2026",
+      "note": "Statement, the Pythagorean-drop classical proof, and the higher-dimensional generalization"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "british_flag",
+      "type": "core",
+      "description": "For a rectangle ABCD (C = B + D - A, edges orthogonal) and any point P: dist P A² + dist P C² = dist P B² + dist P D²",
+      "leanType": "(A B C D P : ℂ) → C = B + D - A → (B-A).re*(D-A).re + (B-A).im*(D-A).im = 0 → dist P A ^ 2 + dist P C ^ 2 = dist P B ^ 2 + dist P D ^ 2"
+    },
+    {
+      "name": "british_flag_coords",
+      "type": "core",
+      "description": "Coordinate identity: with edge vectors u, v satisfying u·v = 0, the opposite-corner squared-distance sums are equal",
+      "leanType": "(px py ax ay ux uy vx vy : ℝ) → ux*vx + uy*vy = 0 → (PA² + PC²) = (PB² + PD²)"
+    },
+    {
+      "name": "british_flag_needs_right_angle",
+      "type": "supporting",
+      "description": "Sharpness: an explicit non-right parallelogram (u·v = 2 ≠ 0) for which the identity fails",
+      "leanType": "∃ (px py ax ay ux uy vx vy : ℝ), ux*vx + uy*vy ≠ 0 ∧ (PA² + PC²) ≠ (PB² + PD²)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Build-verified formalization of the **British Flag Theorem**: for a rectangle `ABCD` and **any** point `P`,
`PA² + PC² = PB² + PD²`. 0 sorries, 0 axioms.

The mathematical core: writing the rectangle through edge vectors `u = B - A`, `v = D - A`, the difference
`(PA² + PC²) − (PB² + PD²)` equals exactly `2⟨u, v⟩`, **independent of P**. The theorem is therefore
equivalent to `⟨u, v⟩ = 0` — the right angle is the entire content.

## Theorems (`proofs/Proofs/BritishFlagTheorem.lean`)
- `british_flag_coords` — real-coordinate identity, closed by `linear_combination 2 * hperp`.
- `british_flag` — complex / metric-distance form; each `dist · · ^2` rewritten via
  `Complex.dist_eq_re_im` + `Real.sq_sqrt`, then reduced to the coordinate lemma.
- `british_flag_needs_right_angle` — sharpness: a non-right parallelogram (`u=(2,0)`, `v=(1,1)`,
  `⟨u,v⟩=2≠0`) for which the identity fails (`10 ≠ 6`), proving the hypothesis is necessary.

## Build
`./proofs/scripts/docker-build.sh Proofs.BritishFlagTheorem` → **Build completed successfully (3058 jobs)**.

## Changes
- New proof file + registration in `proofs/Proofs.lean` (one import line)
- Gallery `meta.json` + `annotations.json` under `src/data/proofs/british-flag-theorem-oq-01/`
- Research `knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)