### PR TITLE
research(british-flag-theorem-oq-01): British Flag theorem (build-verified, 0/0)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -324,6 +324,7 @@ import Proofs.BoundedPrimeGapsOQ04OQ01Aristotle
 import Proofs.BoundedPrimeGapsOQ04OQ02
 import Proofs.BoundedPrimeGapsSieve
 import Proofs.BoundedPrimeGapsTPC
+import Proofs.BritishFlagTheorem
 import Proofs.BrouwerFixedPoint
 import Proofs.BrouwerFixedPointOQ01
 import Proofs.BrouwerFixedPointOQ01OQ02

--- a/proofs/Proofs/BritishFlagTheorem.lean
+++ b/proofs/Proofs/BritishFlagTheorem.lean
@@ -1,0 +1,61 @@
+import Mathlib.Tactic
+
+/-!
+# The British Flag Theorem
+
+For any rectangle `ABCD` and any point `P` in the plane,
+`|PA|² + |PC|² = |PB|² + |PD|²`, where the sum over one pair of opposite
+corners equals the sum over the other pair.
+
+We work in the coordinate plane `ℝ × ℝ` and measure squared Euclidean distance
+explicitly via `sqDist`, rather than the ambient `Prod` metric (which is the
+sup metric, not Euclidean). This keeps the statement unambiguous and the proof
+`sorry`-free and axiom-free.
+
+## Statement
+
+A rectangle `ABCD` is encoded by structural hypotheses on the vertices:
+
+* `hperp` : the sides `AB` and `AD` are perpendicular (right angle at `A`);
+* `hpar1`, `hpar2` : `ABCD` closes up as a parallelogram, `C = B + D - A`,
+  stated coordinatewise.
+
+Together these characterise a rectangle (a parallelogram with one right angle).
+The conclusion holds for an arbitrary point `P`, with no nondegeneracy
+assumption.
+
+## Proof idea
+
+Write `u = B - A`, `v = D - A`. Then `C = A + u + v`, and with `p = P - A`,
+```
+PA² + PC² = |p|² + |p - u - v|²,
+PB² + PD² = |p - u|² + |p - v|².
+```
+Their difference collapses to `|u + v|² - |u|² - |v|² = 2 (u ⬝ v) = 0`,
+using only the perpendicularity hypothesis. The whole identity is therefore a
+single polynomial consequence of `hperp`.
+-/
+
+namespace BritishFlagTheorem
+
+/-- Squared Euclidean distance between two points of the coordinate plane. -/
+def sqDist (P Q : ℝ × ℝ) : ℝ :=
+  (P.1 - Q.1) ^ 2 + (P.2 - Q.2) ^ 2
+
+/--
+**British Flag Theorem.**
+If `ABCD` is a rectangle — sides `AB ⊥ AD` (`hperp`) and the parallelogram
+closing condition `C = B + D - A` (`hpar1`, `hpar2`) — then for any point `P`,
+`sqDist P A + sqDist P C = sqDist P B + sqDist P D`.
+-/
+theorem british_flag
+    (A B C D P : ℝ × ℝ)
+    (hperp : (B.1 - A.1) * (D.1 - A.1) + (B.2 - A.2) * (D.2 - A.2) = 0)
+    (hpar1 : C.1 = B.1 + D.1 - A.1)
+    (hpar2 : C.2 = B.2 + D.2 - A.2) :
+    sqDist P A + sqDist P C = sqDist P B + sqDist P D := by
+  simp only [sqDist]
+  rw [hpar1, hpar2]
+  linear_combination 2 * hperp
+
+end BritishFlagTheorem

--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Statement and Setup",
+    "content": "The British Flag theorem states that for any rectangle ABCD and any point P in the plane, |PA|² + |PC|² = |PB|² + |PD|² — the sum of squared distances to one pair of opposite corners equals the sum to the other pair. The name comes from the Union-Jack-like figure formed by the segments from P to the four corners.\n\nThe formalization works in the coordinate plane ℝ×ℝ. Crucially, the ambient metric on a product space in Mathlib is the sup (max) metric, not the Euclidean one, so the proof defines its own squared Euclidean distance sqDist rather than reusing dist. 'ABCD is a rectangle' is encoded by two structural hypotheses on the vertices: the right angle AB ⊥ AD, and the parallelogram closing condition C = B + D − A.",
+    "mathContext": "Goal: $|PA|^2 + |PC|^2 = |PB|^2 + |PD|^2$, with $\\operatorname{sqDist}(P,Q)=(P_x-Q_x)^2+(P_y-Q_y)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rectangle",
+      "squared distance",
+      "dot product",
+      "parallelogram law"
+    ],
+    "prerequisites": [
+      "coordinate geometry of the plane",
+      "squared Euclidean distance"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-sqdist",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 43
+    },
+    "type": "definition",
+    "title": "Explicit Squared Euclidean Distance",
+    "content": "`sqDist P Q` is defined as (P.1 − Q.1)² + (P.2 − Q.2)², the squared Euclidean distance between two points of ℝ×ℝ. Working with the squared distance keeps the entire argument polynomial — no square roots, no analysis — so the final equality is an exact ring identity. Defining sqDist explicitly (rather than using the library `dist` on ℝ×ℝ, which is the sup metric) is what makes the statement the genuine Euclidean British Flag theorem.",
+    "mathContext": "$\\operatorname{sqDist}(P,Q) = (P_x - Q_x)^2 + (P_y - Q_y)^2$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Euclidean distance",
+      "sup metric on products"
+    ],
+    "prerequisites": [],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-main",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 59
+    },
+    "type": "theorem",
+    "title": "The British Flag Identity",
+    "content": "The theorem takes a rectangle ABCD — perpendicularity (B−A)·(D−A) = 0 (hperp) plus the parallelogram closing condition C = B + D − A (hpar1, hpar2 coordinatewise) — and an arbitrary point P, and proves sqDist P A + sqDist P C = sqDist P B + sqDist P D.\n\nThe proof unfolds sqDist, rewrites C using the closing condition, and closes with `linear_combination 2 * hperp`. The reason this works: setting u = B − A, v = D − A, p = P − A, the left minus right side equals |u + v|² − |u|² − |v|² = 2(u·v), and u·v is exactly the left-hand side of hperp. So the position of P cancels entirely and only the right angle of the rectangle remains.",
+    "mathContext": "$(|PA|^2+|PC|^2) - (|PB|^2+|PD|^2) = |u+v|^2 - |u|^2 - |v|^2 = 2(u\\cdot v) = 0$, where $u=B-A,\\ v=D-A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination",
+      "perpendicularity",
+      "parallelogram closing condition"
+    ],
+    "prerequisites": [
+      "dot product and perpendicularity",
+      "polynomial identities"
+    ],
+    "crossReferences": [
+      {
+        "targetId": "pythagorean-theorem",
+        "relationship": "prerequisite",
+        "description": "sqDist is the Pythagorean expression for distance in coordinates"
+      }
+    ]
+  }
+]

--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "british-flag-theorem-oq-01",
+  "title": "The British Flag Theorem",
+  "slug": "british-flag-theorem-oq-01",
+  "description": "For any rectangle ABCD and any point P in the plane, the sum of squared distances to one pair of opposite corners equals the sum to the other pair: |PA|² + |PC|² = |PB|² + |PD|².",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BritishFlagTheorem",
+    "lineCount": 61,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 1,
+    "path": "Proofs/BritishFlagTheorem.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Classical (formalized in Lean 4)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BritishFlagTheorem.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "coordinate-geometry",
+      "metric-geometry",
+      "rectangle",
+      "classical"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "linear_combination",
+        "description": "Tactic closing the final polynomial identity as a linear combination of the perpendicularity hypothesis",
+        "module": "Mathlib.Tactic.LinearCombination"
+      }
+    ],
+    "originalContributions": [
+      "Coordinate formalization of the British Flag theorem (absent from Mathlib and the existing gallery)",
+      "A coordinate-free hypothesis encoding of 'rectangle' via one perpendicularity equation plus the parallelogram closing condition, rather than hardcoded axis-aligned coordinates",
+      "The identity is proved for an arbitrary point P with no nondegeneracy assumption",
+      "Use of an explicit squared-distance function sqDist on ℝ×ℝ, deliberately avoiding the ambient Prod metric (which is the sup metric, not Euclidean)",
+      "The entire theorem reduces to a single linear_combination step over the perpendicularity hypothesis"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 61,
+    "assumptions": "None beyond the rectangle hypotheses. Fully verified with 0 axioms and 0 sorries. 'Rectangle ABCD' is encoded by AB ⊥ AD (hperp) and the parallelogram closing condition C = B + D − A (hpar1, hpar2).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 1,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The British Flag theorem takes its name from the resemblance of the diagonals and segments drawn from an interior point of a rectangle to the Union Jack. It is a staple of elementary competition geometry: for any point P and any rectangle ABCD, the two sums of squared distances to opposite corners are equal. Although the point is often pictured inside the rectangle, the statement holds for every point of the plane (indeed of space), making it a clean instance of how the parallelogram/perpendicularity structure alone, not the position of P, governs the relation.",
+    "problemStatement": "**British Flag Theorem**: Let ABCD be a rectangle and P any point. Then\n\n|PA|² + |PC|² = |PB|² + |PD|².",
+    "text": "For any rectangle ABCD and any point P, |PA|² + |PC|² = |PB|² + |PD|².",
+    "proofStrategy": "Work in the coordinate plane ℝ×ℝ with the explicit squared-distance function sqDist P Q = (P.x − Q.x)² + (P.y − Q.y)². Encode 'ABCD is a rectangle' by two structural hypotheses: AB ⊥ AD, i.e. (B−A)·(D−A) = 0 (hperp), and the parallelogram closing condition C = B + D − A (hpar1, hpar2 coordinatewise). Writing u = B − A, v = D − A and p = P − A, one has C = A + u + v and\n\n|PA|² + |PC|² = |p|² + |p − u − v|²,\n|PB|² + |PD|² = |p − u|² + |p − v|².\n\nThe difference of the two sides collapses to |u + v|² − |u|² − |v|² = 2(u·v), which vanishes by hperp. After substituting the parallelogram condition for C, the whole goal is a single polynomial identity discharged by linear_combination 2·hperp.",
+    "keyInsights": [
+      "The position of P is irrelevant: every term linear and quadratic in p cancels, leaving only 2(u·v), so the theorem is a statement about the rectangle's right angle, not about P",
+      "Only the perpendicularity hypothesis is used; the parallelogram condition merely fixes C, after which the identity is purely algebraic",
+      "Encoding the rectangle by a perpendicularity equation plus a closing condition keeps the statement coordinate-free in spirit while still living in ℝ×ℝ",
+      "Squared distances are used directly (no square roots), so the result is exact and the proof needs no analysis — just a ring/linear_combination identity",
+      "The ambient Prod metric on ℝ×ℝ is the sup metric, not Euclidean, so the proof defines sqDist explicitly rather than reusing dist"
+    ],
+    "prerequisites": [
+      "Coordinate geometry in the plane",
+      "Squared Euclidean distance and the dot product",
+      "The notion of a rectangle as a parallelogram with a right angle"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "british_flag",
+      "type": "core",
+      "description": "For a rectangle ABCD (encoded by AB ⊥ AD and C = B + D − A) and any point P, the sum of squared distances to A and C equals the sum to B and D.",
+      "leanType": "(B.1 − A.1)*(D.1 − A.1) + (B.2 − A.2)*(D.2 − A.2) = 0 → C.1 = B.1 + D.1 − A.1 → C.2 = B.2 + D.2 − A.2 → sqDist P A + sqDist P C = sqDist P B + sqDist P D"
+    }
+  ],
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Coordinate Setup and Squared Distance",
+      "startLine": 39,
+      "endLine": 43,
+      "summary": "Open the namespace and define sqDist P Q = (P.x − Q.x)² + (P.y − Q.y)², the explicit squared Euclidean distance on ℝ×ℝ (the ambient Prod metric is the sup metric and is deliberately not used).",
+      "mathContext": "$\\operatorname{sqDist}(P,Q) = (P_x - Q_x)^2 + (P_y - Q_y)^2$."
+    },
+    {
+      "id": "main",
+      "title": "The British Flag Identity",
+      "startLine": 45,
+      "endLine": 59,
+      "summary": "State the theorem with the rectangle encoded by perpendicularity (hperp) and the parallelogram closing condition (hpar1, hpar2); substitute C and close the goal with linear_combination 2·hperp.",
+      "mathContext": "With $u=B-A$, $v=D-A$, the difference of the two sums equals $|u+v|^2 - |u|^2 - |v|^2 = 2(u\\cdot v) = 0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "prerequisite",
+      "description": "The squared-distance formula is the Pythagorean theorem in coordinates; the British Flag identity is a two-dimensional algebraic consequence of it"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M. and Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "note": "Classical treatment of elementary Euclidean results of this kind"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib.Tactic.LinearCombination",
+      "year": "2024",
+      "venue": "Lean 4 Mathlib",
+      "note": "Provides the linear_combination tactic used to discharge the final polynomial identity"
+    }
+  ],
+  "conclusion": {
+    "summary": "The British Flag theorem is formalized by a direct coordinate computation: encoding the rectangle by one perpendicularity equation and the parallelogram closing condition, the equality of the two sums of squared distances reduces to the single polynomial fact 2(u·v) = 0. The formalization is fully verified — 0 axioms, 0 sorries — and self-contained over Mathlib.",
+    "implications": "The proof exposes that the British Flag relation depends only on the right angle of the rectangle and not at all on the location of P, which is why it extends verbatim to points outside the rectangle and, with the same algebra, to points in higher-dimensional space.",
+    "openQuestions": [
+      "What is the sharp generalization to a parallelogram that is not a rectangle, where the defect |PA|² + |PC|² − |PB|² − |PD|² equals 2(u·v) and measures how far the parallelogram is from having a right angle?",
+      "Does an analogous constant-defect identity characterize boxes (orthotopes) among parallelepipeds in higher dimensions?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Formalizes the **British Flag theorem**: for any rectangle `ABCD` and any point `P`,
`|PA|² + |PC|² = |PB|² + |PD|²`.

- New proof file `proofs/Proofs/BritishFlagTheorem.lean` (1 def + 1 theorem, **0 axioms, 0 sorries**).
- Works in `ℝ×ℝ` with an explicit squared Euclidean distance `sqDist` (the ambient `Prod` metric is the sup metric, deliberately not used).
- "Rectangle `ABCD`" is encoded structurally: `AB ⊥ AD` (`hperp`) plus the parallelogram closing condition `C = B + D − A` (`hpar1`, `hpar2`). The result holds for an **arbitrary** point `P`, no nondegeneracy assumption.
- Mathematical core: with `u = B−A`, `v = D−A`, the difference of the two sums collapses to `|u+v|² − |u|² − |v|² = 2(u·v)`, which vanishes by perpendicularity. The whole goal is discharged by `linear_combination 2 * hperp`.

Registered in `Proofs.lean` and added gallery data (`meta.json` + `annotations.json`).

## Verification
`./proofs/scripts/docker-build.sh Proofs.BritishFlagTheorem` → `✔ [3058/3058] Built Proofs.BritishFlagTheorem`. Cached oleans (no Mathlib rebuild). 0 axioms, 0 sorries.

## Test plan
- [x] Lean build green by name (3058 jobs)
- [x] `meta.json` / `annotations.json` valid JSON, schema mirrors existing gallery entries (e.g. viviani-theorem-oq-01)
- [x] Import added in alphabetical position; diff is additions-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)