### PR TITLE
Enrich Maclaurin Base Step (S₁² ≥ S₂)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
@@ -52,7 +52,8 @@
       "S₁² ≥ S₂ is Cauchy-Schwarz in disguise. After substituting Newton-Girard 2e₂ = e₁² − p₂ into the cleared form C(n,2)·e₁² ≥ n²·e₂, every term cancels down to n·p₂ ≥ e₁² — the power-mean bound. The 'Maclaurin' framing adds no inequality content beyond Cauchy-Schwarz at this rung.",
       "No nonnegativity is needed. Although Maclaurin's chain is stated for nonnegative reals, the base rung holds for all reals because both ingredients (Newton-Girard, Cauchy-Schwarz) are sign-agnostic. The nonnegativity hypothesis only becomes essential at higher rungs where one takes real roots.",
       "The cleared form is the robust statement. C(n,2)·e₁² ≥ n²·e₂ holds for every n including the degenerate n = 0, 1 (both sides vanish), so the only role of n ≥ 2 is to make the denominators n² and C(n,2) positive when passing to the averaged form.",
-      "Re-deriving Newton-Girard locally keeps the entry self-contained. Rather than importing the parent's identity, the diagonal/off-diagonal trichotomy split is repeated for the range-n family, so the file depends only on Mathlib's Cauchy-Schwarz lemma and the choose-two cast."
+      "Re-deriving Newton-Girard locally keeps the entry self-contained. Rather than importing the parent's identity, the diagonal/off-diagonal trichotomy split is repeated for the range-n family, so the file depends only on Mathlib's Cauchy-Schwarz lemma and the choose-two cast.",
+      "The factor of 2 in e₁² = p₂ + 2e₂ is a double-counting phenomenon. The two off-diagonal triangles (i<j and j<i) carry identical mass (upper_eq_lower via Finset.sum_comm + mul_comm), so the off-diagonal part of the squared sum is exactly twice e₂ — the same mechanism that gives the 2 in (a+b)² = a² + b² + 2ab, here generalized over a range-n index family."
     ],
     "prerequisites": [
       "Elementary symmetric sums e₁, e₂ and power sums p₂ over a Finset",
@@ -92,11 +93,18 @@
       "summary": "sq_e1_le_card_mul_p2 specializes Mathlib's Finset.sq_sum_le_card_mul_sum_sq to s = range n and simplifies the cardinality with Finset.card_range, yielding (Σ f)² ≤ n · Σ f²."
     },
     {
-      "id": "maclaurin",
-      "title": "Maclaurin Base Step",
+      "id": "maclaurin-cleared",
+      "title": "Cleared-Denominator Form: C(n,2)·e₁² ≥ n²·e₂",
       "startLine": 96,
+      "endLine": 110,
+      "summary": "maclaurin_cleared derives C(n,2)·e₁² ≥ n²·e₂ for all n (both sides vanish at n = 0, 1): it forms the intermediate bound 2n·e₂ ≤ (n−1)·e₁² from Cauchy-Schwarz + Newton-Girard (nlinarith), rewrites C(n,2) via Nat.cast_choose_two ℝ n, and closes by nlinarith with Nat.cast_nonneg n and sq_nonneg. Kept separate as a reusable polynomial inequality independent of any averaging."
+    },
+    {
+      "id": "maclaurin-base-step",
+      "title": "Averaged Form: S₁² ≥ S₂ for n ≥ 2",
+      "startLine": 112,
       "endLine": 124,
-      "summary": "maclaurin_cleared derives C(n,2)·e₁² ≥ n²·e₂ for all n: it forms 2n·e₂ ≤ (n−1)·e₁² from Cauchy-Schwarz + Newton-Girard (nlinarith), rewrites C(n,2) via Nat.cast_choose_two ℝ n, and closes by nlinarith with Nat.cast_nonneg n. maclaurin_base_step passes to the averaged form (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2 using div_pow, div_le_div_iff and positivity of n and C(n,2)."
+      "summary": "maclaurin_base_step lifts the cleared inequality to (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2, where the hypothesis supplies strict positivity of n (hn0) and C(n,2) (hC via Nat.choose_pos). div_pow distributes the square over the quotient, div_le_div_iff clears both positive denominators, and nlinarith [maclaurin_cleared n f] closes the resulting polynomial goal."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-05`

Quality score **41 → 100**. This entry previously had only `meta.json` and no inline annotations.

### Changes
- **Added `annotations.json`** — 7 line-anchored annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. The three range-n sums e₁, p₂, e₂ (definitions)
  2. Trichotomy split of the full double sum (`double_sum_split`)
  3. Symmetry of the two off-diagonal triangles (`upper_eq_lower`)
  4. Newton-Girard identity e₁² = p₂ + 2e₂
  5. Power-mean / Cauchy-Schwarz bound e₁² ≤ n·p₂
  6. Cleared-denominator form via `nlinarith` (`maclaurin_cleared`)
  7. Averaged form S₁² ≥ S₂ for n ≥ 2 (`maclaurin_base_step`)
- **meta.json**: added a 5th `keyInsight` (double-counting origin of the factor of 2); split the single Maclaurin section into a cleared-denominator section and an averaged-form section for full file coverage.

### Verification
- `jq empty` valid on both JSON files
- `find-targets.ts` quality breakdown: annotations 25, mathContext 10, significance 10, historicalContext 10, keyInsights 10, conclusion 15, sections 10, crossRefs 10 = **100**
- `pnpm build` passes

### Axiom integrity
No change to `status`/`badge`/`axiomCount`. The entry remains `formalized` / `mathlib` / 0 axioms, consistent with the Lean file (0 sorries, 0 axioms). The existing meta note that the file is build-pending and not yet registered in `Proofs.lean` is preserved unchanged.