### PR TITLE
Research: chebyshev-bounds-oq-04-oq-01-oq-01 — ground Möbius–floor identity to confirmed Mathlib hooks

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
@@ -29,12 +29,55 @@ Math (why it is true and elementary):
     = Σ_{n=1}^{N} [n = 1]                         (Σ_{d∣n} μ(d) = δ_{n,1})
     = 1.
 
-Expected Mathlib glue: `ArithmeticFunction.moebius`, the identity
-`ArithmeticFunction.coe_moebius_mul_coe_zeta` (μ ∗ ζ = δ, i.e.
-Σ_{d∣n} μ(d) = if n = 1 then 1 else 0 via `ArithmeticFunction.sum_moebius_...`),
-and a hyperbola/Fubini reindexing of `Finset.Icc 1 N` against the divisor sum.
+Mathlib glue — ALL hooks CONFIRMED present in v4.26.0 (researcher-5, 2026-06-16,
+located via source grep; resolves the "searches to do on recovery" the prior
+session left open):
+
+  1. `Nat.Ioc_filter_dvd_card_eq_div (n p : ℕ) : #{x ∈ Finset.Ioc 0 n | p ∣ x} = n / p`
+       — Mathlib/Data/Nat/Factorization/Basic.lean:475.  ⌊N/d⌋ = #{multiples of d in (0,N]}.
+  2. `ArithmeticFunction.coe_mul_zeta_apply : (f * ζ) x = ∑ i ∈ x.divisors, f i`
+       — Mathlib/NumberTheory/ArithmeticFunction/Zeta.lean:81.  divisor sum = (μ*ζ) x.
+  3. `ArithmeticFunction.moebius_mul_coe_zeta : (μ * ζ : ArithmeticFunction ℤ) = 1`
+       — Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean:157.  μ ∗ ζ = δ.
+  4. `ArithmeticFunction.one_apply : (1 : ArithmeticFunction R) x = ite (x = 1) 1 0`
+       — Mathlib/NumberTheory/ArithmeticFunction/Defs.lean:96.  δ as if-then-else.
+
 The proof requires only tactical search + bookkeeping (no creative insight),
 which is the HARD-but-known classification suited to automated search.
+
+PASTE-READY PROOF ATTEMPT (BUILD-UNVERIFIED — dual blackout: `.lake` self-symlink
++ Aristotle 404 prevented compilation this cycle. Next build slot: verify/fix the
+two fiddly steps — the `Finset.sum_comm` swap and the `filter = divisors` set
+equality — then delete the `sorry`. Every step cites a confirmed lemma above.):
+
+  -- Step 1: ⌊N/d⌋ counts multiples of d in (0,N]; rewrite each product as a sum.
+  have step1 : ∀ d ∈ Finset.Icc 1 N,
+      μ d * (↑(N / d) : ℤ)
+        = ∑ _x ∈ (Finset.Ioc 0 N).filter (fun x => d ∣ x), μ d := fun d _ => by
+    rw [Finset.sum_const, Nat.Ioc_filter_dvd_card_eq_div, nsmul_eq_mul]; ring
+  rw [Finset.sum_congr rfl step1]
+  -- Step 2: filters → if-then-else, then swap order of summation.
+  simp_rw [Finset.sum_filter]
+  rw [Finset.sum_comm]
+  -- Goal: ∑ x ∈ Ioc 0 N, ∑ d ∈ Icc 1 N, (if d ∣ x then μ d else 0)
+  -- Step 3: for x ∈ Ioc 0 N, {d ∈ Icc 1 N | d ∣ x} = x.divisors, so inner = δ_{x,1}.
+  have step3 : ∀ x ∈ Finset.Ioc 0 N,
+      (∑ d ∈ Finset.Icc 1 N, if d ∣ x then μ d else 0) = if x = 1 then (1:ℤ) else 0 := by
+    intro x hx
+    rw [Finset.mem_Ioc] at hx; obtain ⟨hx0, hxN⟩ := hx
+    rw [← Finset.sum_filter]
+    have hfilter : (Finset.Icc 1 N).filter (fun d => d ∣ x) = x.divisors := by
+      ext d
+      simp only [Finset.mem_filter, Finset.mem_Icc, Nat.mem_divisors]
+      exact ⟨fun ⟨_, hd⟩ => ⟨hd, hx0.ne'⟩,
+        fun ⟨hd, _⟩ => ⟨⟨Nat.pos_of_dvd_of_pos hd hx0, (Nat.le_of_dvd hx0 hd).trans hxN⟩, hd⟩⟩
+    rw [hfilter,
+      show (∑ d ∈ x.divisors, μ d) = (μ * ζ : ArithmeticFunction ℤ) x from coe_mul_zeta_apply.symm,
+      moebius_mul_coe_zeta, one_apply]
+  rw [Finset.sum_congr rfl step3]
+  -- Step 4: only x = 1 survives; 1 ∈ Ioc 0 N since N ≥ 1.
+  rw [Finset.sum_ite_eq' (Finset.Ioc 0 N) 1 (fun _ => (1:ℤ)), if_pos]
+  exact Finset.mem_Ioc.mpr ⟨Nat.zero_lt_one, hN⟩
 
 Citations:
 - Selberg, "An elementary proof of the prime-number theorem", Ann. of Math.

--- a/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
@@ -57,12 +57,41 @@ Aristotle `prove` once a backend recovers. Expected glue:
 `ArithmeticFunction.moebius`, `coe_moebius_mul_coe_zeta` (μ ∗ ζ = δ), and a
 `Finset.Icc 1 N` hyperbola reindexing.
 
-### Mathlib search to do on recovery (could not grep — `.lake` corrupt)
+## This session (2026-06-16, Researcher-5) — Mathlib searches RESOLVED
 
-- Does Mathlib already have `Σ_{d≤N} μ(d)⌊N/d⌋ = 1`? Search
-  `ArithmeticFunction.sum_moebius_mul`, `Nat.sum_div`, hyperbola lemmas.
-- Möbius indicator: `ArithmeticFunction.sum_moebius_eq_...` /
-  `coe_moebius_mul_coe_zeta` for `Σ_{d∣n} μ(d) = δ_{n,1}`.
+Dual blackout persists (`.lake` literal self-symlink → builds re-clone Mathlib;
+Aristotle `prove` → 404). But the `/private/tmp/mathlib-grep` v4.26.0 mirror was
+readable, so I resolved every "search to do on recovery" the prior session left.
+
+**No, Mathlib does NOT have `Σ_{d≤N} μ(d)⌊N/d⌋ = 1` directly** (only
+`sum_moebius_mul_log_eq` in VonMangoldt.lean). But all four building blocks exist:
+
+| # | Lemma | Location | Role |
+|---|-------|----------|------|
+| 1 | `Nat.Ioc_filter_dvd_card_eq_div (n p) : #{x∈Ioc 0 n \| p∣x} = n/p` | `Data/Nat/Factorization/Basic.lean:475` | ⌊N/d⌋ = #multiples |
+| 2 | `coe_mul_zeta_apply : (f*ζ) x = ∑ i∈x.divisors, f i` | `NumberTheory/ArithmeticFunction/Zeta.lean:81` | divisor sum ← (μ*ζ) x |
+| 3 | `moebius_mul_coe_zeta : (μ*ζ : ArithmeticFunction ℤ) = 1` | `…/Moebius.lean:157` | μ∗ζ = δ |
+| 4 | `one_apply : (1:ArithmeticFunction R) x = ite (x=1) 1 0` | `…/Defs.lean:96` | δ as if-then-else |
+
+**Full grounded proof chain** (now embedded as a paste-ready attempt in the
+orphan file's docstring, kept behind `sorry` since BUILD-UNVERIFIED):
+
+```
+Σ_{d∈Icc 1 N} μ d·(N/d)
+ = Σ_{d∈Icc 1 N} Σ_{x∈Ioc 0 N, d∣x} μ d     [1: sum_const + Ioc_filter_dvd_card_eq_div + nsmul_eq_mul]
+ = Σ_{x∈Ioc 0 N} Σ_{d∈Icc 1 N, d∣x} μ d     [Finset.sum_filter then Finset.sum_comm]
+ = Σ_{x∈Ioc 0 N} Σ_{d∈x.divisors} μ d        [for x≤N: {d∈Icc 1 N : d∣x} = x.divisors]
+ = Σ_{x∈Ioc 0 N} (μ*ζ) x                       [2: coe_mul_zeta_apply]
+ = Σ_{x∈Ioc 0 N} ite(x=1) 1 0                  [3+4: moebius_mul_coe_zeta, one_apply]
+ = 1                                            [Finset.sum_ite_eq'; 1∈Ioc 0 N as N≥1]
+```
+
+**Residual compile risks** (what the next build slot must check): the
+`Finset.sum_comm` order swap producing the exact double-sum shape; the
+`filter = divisors` `ext` (binder order, `Nat.pos_of_dvd_of_pos`); and the
+`show … from coe_mul_zeta_apply.symm` typeclass elaboration (`μ` as
+`ArithmeticFunction ℤ`). The mathematics is fully grounded; only Lean
+bookkeeping remains.
 
 ### Next Steps
 


### PR DESCRIPTION
## Summary
Advances the elementary Selberg–Erdős PNT roadmap (`chebyshev-bounds-oq-04-oq-01-oq-01`)
by **resolving the prior session's open Mathlib searches** for the keystone Möbius–floor
identity `Σ_{d≤N} μ(d)⌊N/d⌋ = 1` (Iter 5a-β-2, toward the weak Mertens bound |M₁(N)|≤1).

## Findings
Mathlib v4.26.0 has **no** direct `Σ μ(d)⌊N/d⌋=1`, but all four building blocks exist
(located via the source mirror; prior session could not grep because `.lake` is corrupt):

1. `Nat.Ioc_filter_dvd_card_eq_div` — `Data/Nat/Factorization/Basic.lean:475` — `⌊N/d⌋ = #{x∈Ioc 0 N | d∣x}`
2. `ArithmeticFunction.coe_mul_zeta_apply` — `…/Zeta.lean:81` — `(μ*ζ) x = Σ_{d∣x} μ d`
3. `ArithmeticFunction.moebius_mul_coe_zeta` — `…/Moebius.lean:157` — `μ*ζ = 1`
4. `ArithmeticFunction.one_apply` — `…/Defs.lean:96` — `(1) x = ite (x=1) 1 0`

The full proof chain (Fubini reindex over multiples → divisor sum → δ) is now embedded
as a **paste-ready attempt** in the orphan's docstring, kept behind `sorry`.

## Status
**Outcome**: progress (frontier de-risked; proof grounded to named lemmas).
**Build-unverified** — dual blackout this cycle: `proofs/.lake` is a literal self-symlink
(builds re-clone all of Mathlib) and Aristotle `prove` returns 404. The orphan is **not**
registered in `Proofs.lean`, so zero CI risk.
**Next Steps**: next build/Aristotle slot — compile the embedded attempt, fix the two
fiddly steps (`Finset.sum_comm` swap, `filter = divisors` ext), drop `sorry`; then derive
`|M₁(N)| ≤ 1` via the fractional-part split.

🤖 Generated by researcher-5