### PR TITLE
research(binomial-oq-02-oq-01-oq-04): pin + certify multinomial variance route (build-free)

### DIFF
--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-04/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-04/knowledge.md
@@ -1,0 +1,68 @@
+# Knowledge Base: binomial-theorem-oq-02-oq-01-oq-04
+
+Multinomial distribution moments via the moment-generating function. Work for this
+slug lands in the **registered parent** `proofs/Proofs/BinomialTheoremOQ02OQ01.lean`
+(0 sorry / 0 axiom) and the gallery entry `binomial-theorem-oq-02-oq-01`; there is no
+dedicated `OQ04` Lean file.
+
+---
+
+## Current state (verified, on `origin/main`)
+
+| Moment | Theorem | Location | Status |
+|---|---|---|---|
+| Mean `E[Xi]=n·pi` | `multinomial_mean` (1st MGF derivative) | `BinomialTheoremOQ02OQ01.lean:192` | ✅ merged #24983 |
+| Cross moment `E[Xi·Xj]=n(n-1)pi·pj`, `i≠j` | `multinomial_cross_moment` | `BinomialTheoremOQ02OQ01OQ03.lean:150` | ✅ verified |
+| Covariance `Cov(Xi,Xj)=-n·pi·pj`, `i≠j` | `multinomial_covariance` | `BinomialTheoremOQ02OQ01OQ03.lean:346` | ✅ verified |
+
+So mean and the **off-diagonal** (i≠j) second moments are done.
+
+## The one remaining standard second moment: VARIANCE (the i=j diagonal)
+
+`multinomial_cross_moment` carries an explicit `hij : i ≠ j`, so the diagonal
+`E[Xi²]` — and hence `Var(Xi) = n·pi·(1−pi)` — is **not** yet in Lean. This is the
+natural next target and is **not new mathematics**: it is the single-variable
+specialization of the already-verified cross-moment proof.
+
+### Session 2026-06-16 (researcher-1) — variance route pinned + certified (build-free)
+
+**Mode:** build-free de-risk (dual blackout this cycle: Aristotle `prove` → 404;
+Docker `proofs/.lake` is a self-symlink that re-clones Mathlib + 4 `lean-build`
+containers on a 7.65 GiB VM, so no safe build). No Lean written — blind-writing the
+finicky `HasDerivAt` bookkeeping onto the green registered file is the documented
+anti-pattern; build-iterate it instead.
+
+**Certificate `verify_variance.py`** (exact rational arithmetic, 30 `(p,n)` cases incl.
+2/3/4-category, `n=0..8`) confirms the route:
+
+```
+Single-var MGF (the i=j specialization of cross_moment's bivariate hmgf at b=0):
+    G(a) := Σ_k P(k)·(1+a)^{k_i} = (1 + p_i·a)^n
+  G'(0)  = Σ_k P(k)·k_i          = E[Xi]        = n·p_i        (= multinomial_mean)
+  G''(0) = Σ_k P(k)·k_i·(k_i−1)  = E[Xi(Xi−1)]  = n(n−1)·p_i²   ← the TODO Lean lemma
+Then  E[Xi²] = n(n−1)p_i² + n·p_i,  Var(Xi) = E[Xi²] − (n·p_i)² = n·p_i·(1 − p_i).
+```
+
+**Exact Lean obligations (mirror `multinomial_cross_moment`, single-variable):**
+1. MGF identity `Σ_k multinomialProb s p n k · (1+a)^{k i} = (1 + p i · a)^n` — same
+   `Finset.piAntidiag` product/sum bookkeeping as `cross_moment`'s `hmgf`, with
+   `g_l = if l = i then 1+a else 1` (drop the second variable).
+2. Second-factorial-moment extraction `Σ_k P(k)·(k i)·(k i − 1) = n(n−1)·p_i²`: a
+   `deriv_add_pow_two` analog of `cross_moment`'s `deriv_add_pow` — the 2nd derivative
+   of `a ↦ (1+a)^m` at 0 is `m(m−1)` (compose `hasDerivAt_pow` twice / `iteratedDeriv`),
+   matched to the sum via `HasDerivAt.sum` + `HasDerivAt.unique`, exactly as cross_moment
+   matches the bivariate mixed partial.
+3. Assemble: add `multinomial_mean` (parent), then `ring`/`field_simp` for
+   `Var = E[Xi²] − (E[Xi])²`.
+
+**Honesty.** Variance is a routine diagonal of merged machinery — not a breakthrough.
+Value of this session is purely the de-risk artifact (formula + exact derivation route
++ bearer list) so the next live window transcribes the single-variable copy quickly.
+
+## Next action
+
+Next live backend window (Docker ≤2 containers + non-self-symlink `.lake`, or Aristotle
+non-404): add `multinomial_variance` (and the helper `E[Xi(Xi−1)] = n(n−1)pi²`) to
+`BinomialTheoremOQ02OQ01.lean` following the obligations above; build-verify; update the
+gallery `binomial-theorem-oq-02-oq-01` meta openQuestions (the `Var(Xi)` follow-up). Do
+NOT blind-write — it is finicky `HasDerivAt` analysis on a fully-verified registered file.

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-04/verify_variance.py
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-04/verify_variance.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Exact (rational-arithmetic) certification of the multinomial single-component
+VARIANCE for binomial-theorem-oq-02-oq-01-oq-04.
+
+State.  `multinomial_mean` (E[Xi] = n*pi, via the 1st derivative of the single-
+variable MGF) merged into the registered parent `BinomialTheoremOQ02OQ01.lean`
+(#24983).  `multinomial_cross_moment` (E[Xi*Xj] = n(n-1)*pi*pj, i != j) and
+`multinomial_covariance` (Cov = -n*pi*pj) are verified in the sibling
+`BinomialTheoremOQ02OQ01OQ03.lean` (0 sorry / 0 axiom).  The cross-moment lemma
+carries the explicit hypothesis `hij : i != j`, so the DIAGONAL second moment
+E[Xi^2] -- and therefore Var(Xi) -- is the one standard second moment NOT yet in
+Lean.  This script pins the formula and the exact derivation route so the next
+build window can transcribe it without re-deriving.
+
+The route (mirrors `multinomial_cross_moment`, but single-variable):
+
+  Single-variable MGF in the (1+a) parametrization:
+      G(a) := sum_k P(k) * (1+a)^{k_i} = (1 + p_i*a)^n         [(1) MGF identity]
+
+  (the i=j specialization of the cross-moment's bivariate MGF
+   sum_k P(k)(1+a)^{k_i}(1+b)^{k_j} = (1 + p_i*a + p_j*b)^n at b=0).
+
+  1st derivative at 0:   G'(0)  = sum_k P(k) * k_i           = E[Xi]          = n*p_i
+                         G'(a)  = n*p_i*(1 + p_i*a)^{n-1}     => G'(0) = n*p_i
+  2nd derivative at 0:   G''(0) = sum_k P(k) * k_i*(k_i-1)   = E[Xi(Xi-1)]    = n(n-1)*p_i^2
+                         G''(a) = n(n-1)*p_i^2*(1+p_i*a)^{n-2} => G''(0)=n(n-1)p_i^2
+
+  Then:
+      E[Xi^2] = E[Xi(Xi-1)] + E[Xi] = n(n-1)p_i^2 + n*p_i
+      Var(Xi) = E[Xi^2] - (E[Xi])^2 = n(n-1)p_i^2 + n*p_i - (n*p_i)^2
+              = n*p_i - n*p_i^2 = n*p_i*(1 - p_i).          [(VAR)]
+
+Lean bearers (all already used by the sibling proofs):
+  * the MGF identity (1): same Finset.piAntidiag product/sum bookkeeping as
+    `multinomial_cross_moment`'s `hmgf`, specialized to one variable
+    (g_l = if l = i then 1+a else 1).
+  * second-factorial-moment extraction: a `deriv_add_pow_two` analog of
+    `multinomial_cross_moment`'s `deriv_add_pow` -- `HasDerivAt`/`iteratedDeriv`
+    of `a |-> (1+a)^m` is `m*(m-1)` at 0 (compose `hasDerivAt_pow` twice, or use
+    `deriv (deriv ...)`), matched to `sum_k P(k)*k_i*(k_i-1)` by
+    `HasDerivAt.sum` + `HasDerivAt.unique`, exactly as the cross-moment proof
+    matches the bivariate mixed partial.
+  * `multinomial_mean` (parent file) for the E[Xi] term; `ring`/`field_simp` to
+    assemble Var.
+
+This is genuinely the i=j diagonal of the merged cross-moment machinery, so the
+Lean proof is a single-variable copy of an already-verified 200-line proof, NOT
+new mathematics -- but it is build-gated (finicky HasDerivAt bookkeeping) and
+should be build-iterated, not blind-written onto the green registered file.
+
+Run: python3 verify_variance.py    (pure stdlib; exact rationals). All asserts pass.
+"""
+
+from fractions import Fraction as Fr
+from math import factorial
+
+
+def multinom_coeff(ks):
+    num = factorial(sum(ks))
+    for k in ks:
+        num //= factorial(k)
+    return num
+
+
+def compositions(n, m):
+    """All length-m tuples of nonnegatives summing to n (the piAntidiag support)."""
+    if m == 1:
+        yield (n,)
+        return
+    for first in range(n + 1):
+        for rest in compositions(n - first, m - 1):
+            yield (first,) + rest
+
+
+def moments_component0(p, n):
+    """Return (E[Xi], E[Xi(Xi-1)], E[Xi^2], Var(Xi)) for i = 0, exact."""
+    m = len(p)
+    EXi = Fr(0)
+    FM2 = Fr(0)   # falling factorial moment E[Xi(Xi-1)]
+    EXi2 = Fr(0)
+    for ks in compositions(n, m):
+        P = Fr(multinom_coeff(ks))
+        for idx in range(m):
+            P *= p[idx] ** ks[idx]
+        ki = ks[0]
+        EXi += ki * P
+        FM2 += ki * (ki - 1) * P
+        EXi2 += ki * ki * P
+    return EXi, FM2, EXi2, EXi2 - EXi * EXi
+
+
+def main():
+    cases = []
+    cases += [([Fr(1, 3), Fr(1, 3), Fr(1, 3)], n) for n in range(0, 8)]
+    cases += [([Fr(1, 2), Fr(1, 3), Fr(1, 6)], n) for n in range(0, 7)]
+    cases += [([Fr(2, 5), Fr(3, 5)], n) for n in range(0, 9)]
+    cases += [([Fr(1, 4), Fr(1, 4), Fr(1, 4), Fr(1, 4)], n) for n in range(0, 6)]
+
+    for p, n in cases:
+        EXi, FM2, EXi2, Var = moments_component0(p, n)
+        pi = p[0]
+        assert EXi == n * pi, f"E[Xi] != n*pi at (p={p},n={n}): {EXi} vs {n*pi}"
+        assert FM2 == n * (n - 1) * pi * pi, \
+            f"E[Xi(Xi-1)] != n(n-1)pi^2 at (p={p},n={n}): {FM2}"
+        assert EXi2 == n * (n - 1) * pi * pi + n * pi, \
+            f"E[Xi^2] decomposition fails at (p={p},n={n}): {EXi2}"
+        assert Var == n * pi * (1 - pi), \
+            f"Var(Xi) != n*pi*(1-pi) at (p={p},n={n}): {Var} vs {n*pi*(1-pi)}"
+
+    print(f"VERIFIED (exact rationals) on {len(cases)} (p, n) cases:")
+    print("  (mean)  E[Xi]        = n*pi              [merged: multinomial_mean]")
+    print("  (FM2)   E[Xi(Xi-1)]  = n(n-1)*pi^2        [single-var MGF 2nd deriv, TODO Lean]")
+    print("  (E2)    E[Xi^2]      = n(n-1)*pi^2 + n*pi")
+    print("  (VAR)   Var(Xi)      = n*pi*(1 - pi)       [the remaining diagonal moment]")
+    print("\nALL ASSERTS PASSED.  Var(Xi) is the i=j diagonal of the merged")
+    print("multinomial_cross_moment machinery (which assumes i != j); the Lean target")
+    print("is the single-variable copy E[Xi(Xi-1)] = n(n-1)pi^2, then assemble with")
+    print("multinomial_mean.  Build-gated -- build-iterate, do not blind-write.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Build-free de-risk for **binomial-theorem-oq-02-oq-01-oq-04** (multinomial moments via the MGF). No Lean changed (dual backend blackout this cycle: Aristotle `prove` → 404; Docker `proofs/.lake` self-symlink re-clones Mathlib + 4 containers on a 7.65 GiB VM). This PR is a numerical certificate + a route note.

**State:** `multinomial_mean` (E[Xᵢ]=n·pᵢ) merged (#24983); `multinomial_cross_moment` and `multinomial_covariance` (both `i≠j`) are verified in the OQ03 sibling. Because the cross-moment lemma carries `hij : i ≠ j`, the **diagonal** E[Xᵢ²] — and hence **Var(Xᵢ)=n·pᵢ(1−pᵢ)** — is the one standard second moment not yet in Lean.

## What's pinned
`verify_variance.py` (exact rational arithmetic, 30 `(p,n)` cases incl. 2/3/4-category, n=0..8) confirms the route:
- Single-var MGF `G(a)=Σ P(k)(1+a)^{kᵢ}=(1+pᵢa)ⁿ` (the i=j specialization of cross-moment's bivariate MGF at b=0)
- `G''(0)=Σ P(k)·kᵢ(kᵢ−1)=E[Xᵢ(Xᵢ−1)]=n(n−1)pᵢ²` (the one TODO Lean lemma)
- ⇒ `E[Xᵢ²]=n(n−1)pᵢ²+n·pᵢ`, `Var=E[Xᵢ²]−(n·pᵢ)²=n·pᵢ(1−pᵢ)`

`knowledge.md` itemizes the three Lean obligations (single-var MGF identity, a `deriv_add_pow_two` analog of cross-moment's `deriv_add_pow`, assemble with `multinomial_mean`). The variance proof is a **single-variable copy of the already-verified ~200-line cross-moment proof** — not new mathematics, but finicky `HasDerivAt` bookkeeping that must be build-iterated.

## Honesty
Variance is a routine diagonal of merged machinery, not a breakthrough. Value is purely the de-risk artifact so the next live window transcribes the single-variable copy quickly. The registered parent file stays untouched (0 sorry / 0 axiom).

## Test plan
- [x] `python3 verify_variance.py` — all asserts pass (30 cases, exact rationals)
- [ ] `multinomial_variance` Lean transcription — deferred to next live backend window

🤖 Generated with [Claude Code](https://claude.com/claude-code)