### PR TITLE
research(herons-formula-oq-05): Cayley–Menger determinant (triangle + tetrahedron)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -477,6 +477,7 @@ import Proofs.CayleyHamiltonReductionOQ01OQ02
 import Proofs.CayleyHamiltonReductionOQ02
 import Proofs.CayleyHamiltonReductionOQ02OQ01
 import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
+import Proofs.CayleyMengerHeronOQ05
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleyMengerHeronOQ05.lean
+++ b/proofs/Proofs/CayleyMengerHeronOQ05.lean
@@ -1,0 +1,149 @@
+/-
+# Heron's Formula OQ-05: The Cayley–Menger Determinant
+
+Generalize Heron's formula to simplex volume from squared edge lengths via the
+Cayley–Menger determinant.
+
+For points `P₀, …, Pₙ` in Euclidean space, the Cayley–Menger determinant of the
+`(n+2) × (n+2)` matrix
+
+      ⎡ 0  1   1   …  1  ⎤
+      ⎢ 1  0  d₀₁ … d₀ₙ ⎥
+      ⎢ 1 d₀₁  0  … d₁ₙ ⎥        (dᵢⱼ = ‖Pᵢ - Pⱼ‖²)
+      ⎢ ⋮               ⎥
+      ⎣ 1 d₀ₙ d₁ₙ …  0  ⎦
+
+equals `(-1)^(n+1) · 2^n · (n!)² · V²`, where `V` is the `n`-dimensional content
+of the simplex.
+
+This file formalizes the two classical cases as explicit polynomial identities in
+the squared edge lengths:
+
+* **n = 2 (Heron):** `cmDet3 = -4 · (2·Area)²`, i.e. `16·Area² = -cmDet3`.
+  Expanding the squared distances recovers the symmetric form of Heron's formula.
+* **n = 3 (tetrahedron):** `cmDet4 = 8 · (6·V)²`, i.e. `288·V² = cmDet4`.
+
+The polynomials `cmDet3` / `cmDet4` are the (expanded) Cayley–Menger determinants
+of the 4×4 / 5×5 matrices above; the constant terms `-4` / `8` are exactly
+`(-1)^(n+1) · 2^n · (n!)² / (n!)²`-normalised against the `(n!·V)`-form of the
+content used here (`2·Area` and `6·V` are the unsigned `n!·V` scalars).
+
+## Status: Verified (0 axioms, 0 sorries)
+-/
+
+import Mathlib.Tactic
+
+namespace CayleyMengerHeron
+
+/-! ## Two-dimensional case (Heron's formula) -/
+
+abbrev Point2 := ℝ × ℝ
+
+/-- Squared Euclidean distance between two points of the plane. -/
+def sqDist2 (p q : Point2) : ℝ :=
+  (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2
+
+/-- Twice the signed area of triangle `P₀P₁P₂` (the `2!·Area` scalar). -/
+def area2 (P₀ P₁ P₂ : Point2) : ℝ :=
+  (P₁.1 - P₀.1) * (P₂.2 - P₀.2) - (P₂.1 - P₀.1) * (P₁.2 - P₀.2)
+
+/-- The Cayley–Menger determinant of a triangle, as a polynomial in the three
+squared edge lengths `d₀₁, d₀₂, d₁₂`. This is `det` of
+
+      ⎡ 0  1   1   1  ⎤
+      ⎢ 1  0  d₀₁ d₀₂ ⎥
+      ⎢ 1 d₀₁  0  d₁₂ ⎥
+      ⎣ 1 d₀₂ d₁₂  0  ⎦ -/
+def cmDet3 (d01 d02 d12 : ℝ) : ℝ :=
+  d01 ^ 2 - 2 * d01 * d02 - 2 * d01 * d12 + d02 ^ 2 - 2 * d02 * d12 + d12 ^ 2
+
+/-- **Cayley–Menger identity (triangle).** The Cayley–Menger determinant of three
+planar points equals `-4` times the square of twice their signed area. -/
+theorem cmDet3_eq (P₀ P₁ P₂ : Point2) :
+    cmDet3 (sqDist2 P₀ P₁) (sqDist2 P₀ P₂) (sqDist2 P₁ P₂)
+      = -4 * (area2 P₀ P₁ P₂) ^ 2 := by
+  simp only [cmDet3, sqDist2, area2]; ring
+
+/-- **Heron's formula (Cayley–Menger form).** With `Area = |area2| / 2` the squared
+area of a triangle is recovered from its squared edge lengths:
+`16·Area² = -cmDet3`. -/
+theorem heron_sixteen_area_sq (P₀ P₁ P₂ : Point2) :
+    16 * (|area2 P₀ P₁ P₂| / 2) ^ 2
+      = -cmDet3 (sqDist2 P₀ P₁) (sqDist2 P₀ P₂) (sqDist2 P₁ P₂) := by
+  rw [cmDet3_eq, div_pow, sq_abs]; ring
+
+/-! ## Three-dimensional case (tetrahedron volume) -/
+
+abbrev Point3 := ℝ × ℝ × ℝ
+
+/-- Squared Euclidean distance between two points of space. -/
+def sqDist3 (p q : Point3) : ℝ :=
+  (p.1 - q.1) ^ 2 + (p.2.1 - q.2.1) ^ 2 + (p.2.2 - q.2.2) ^ 2
+
+/-- Six times the signed volume of tetrahedron `P₀P₁P₂P₃` (the `3!·V` scalar): the
+scalar triple product `(P₁-P₀) · ((P₂-P₀) × (P₃-P₀))`. -/
+def vol6 (P₀ P₁ P₂ P₃ : Point3) : ℝ :=
+  (P₁.1 - P₀.1) *
+      ((P₂.2.1 - P₀.2.1) * (P₃.2.2 - P₀.2.2) - (P₂.2.2 - P₀.2.2) * (P₃.2.1 - P₀.2.1))
+  - (P₁.2.1 - P₀.2.1) *
+      ((P₂.1 - P₀.1) * (P₃.2.2 - P₀.2.2) - (P₂.2.2 - P₀.2.2) * (P₃.1 - P₀.1))
+  + (P₁.2.2 - P₀.2.2) *
+      ((P₂.1 - P₀.1) * (P₃.2.1 - P₀.2.1) - (P₂.2.1 - P₀.2.1) * (P₃.1 - P₀.1))
+
+/-- The Cayley–Menger determinant of a tetrahedron, as a polynomial in the six
+squared edge lengths. This is `det` of the 5×5 matrix
+
+      ⎡ 0  1   1   1   1  ⎤
+      ⎢ 1  0  d₀₁ d₀₂ d₀₃ ⎥
+      ⎢ 1 d₀₁  0  d₁₂ d₁₃ ⎥
+      ⎢ 1 d₀₂ d₁₂  0  d₂₃ ⎥
+      ⎣ 1 d₀₃ d₁₃ d₂₃  0  ⎦ -/
+def cmDet4 (d01 d02 d03 d12 d13 d23 : ℝ) : ℝ :=
+  -2 * d01 ^ 2 * d23 - 2 * d01 * d02 * d12 + 2 * d01 * d02 * d13
+  + 2 * d01 * d02 * d23 + 2 * d01 * d03 * d12 - 2 * d01 * d03 * d13
+  + 2 * d01 * d03 * d23 + 2 * d01 * d12 * d23 + 2 * d01 * d13 * d23
+  - 2 * d01 * d23 ^ 2 - 2 * d02 ^ 2 * d13 + 2 * d02 * d03 * d12
+  + 2 * d02 * d03 * d13 - 2 * d02 * d03 * d23 + 2 * d02 * d12 * d13
+  - 2 * d02 * d13 ^ 2 + 2 * d02 * d13 * d23 - 2 * d03 ^ 2 * d12
+  - 2 * d03 * d12 ^ 2 + 2 * d03 * d12 * d13 + 2 * d03 * d12 * d23
+  - 2 * d12 * d13 * d23
+
+/-- **Cayley–Menger identity (tetrahedron).** The Cayley–Menger determinant of
+four points in space equals `8` times the square of six times their signed
+volume. -/
+theorem cmDet4_eq (P₀ P₁ P₂ P₃ : Point3) :
+    cmDet4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+           (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃)
+      = 8 * (vol6 P₀ P₁ P₂ P₃) ^ 2 := by
+  simp only [cmDet4, sqDist3, vol6]; ring
+
+/-- **Simplex volume from squared edges (tetrahedron).** With `V = |vol6| / 6`
+the squared volume of a tetrahedron is recovered from its six squared edge
+lengths: `288·V² = cmDet4`. -/
+theorem cayley_menger_tetrahedron (P₀ P₁ P₂ P₃ : Point3) :
+    288 * (|vol6 P₀ P₁ P₂ P₃| / 6) ^ 2
+      = cmDet4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+               (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃) := by
+  rw [cmDet4_eq, div_pow, sq_abs]; ring
+
+/-- The tetrahedral Cayley–Menger determinant is nonnegative: the realizability
+form `288·V² = cmDet4 ≥ 0` holds for any four points. -/
+theorem cmDet4_nonneg (P₀ P₁ P₂ P₃ : Point3) :
+    0 ≤ cmDet4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+               (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃) := by
+  rw [cmDet4_eq]; positivity
+
+/-- **Degeneracy criterion.** Four points are coplanar (zero volume) iff their
+Cayley–Menger determinant vanishes. -/
+theorem cmDet4_eq_zero_iff_coplanar (P₀ P₁ P₂ P₃ : Point3) :
+    cmDet4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+           (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃) = 0
+      ↔ vol6 P₀ P₁ P₂ P₃ = 0 := by
+  rw [cmDet4_eq]
+  constructor
+  · intro h
+    have : (vol6 P₀ P₁ P₂ P₃) ^ 2 = 0 := by linarith
+    exact pow_eq_zero_iff (by norm_num) |>.mp this
+  · intro h; rw [h]; ring
+
+end CayleyMengerHeron

--- a/src/data/proofs/herons-formula-oq-05/annotations.json
+++ b/src/data/proofs/herons-formula-oq-05/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-triangle-setup",
+    "proofId": "herons-formula-oq-05",
+    "range": {
+      "startLine": 38,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "Triangle: Squared Distance, Area, and Cayley–Menger Determinant",
+    "content": "The n=2 case fixes the ingredients of Heron's formula. `sqDist2 p q = (p.1−q.1)² + (p.2−q.2)²` is the squared planar distance, `area2 P₀ P₁ P₂` is twice the signed area (the 2!·Area scalar, a 2×2 determinant of edge vectors), and `cmDet3 d01 d02 d12` is the 4×4 Cayley–Menger determinant written as an explicit polynomial in the three squared edge lengths. The bordered matrix has a row/column of ones around the squared-distance matrix; expanding it gives the six-term symmetric polynomial d01²+d02²+d12²−2d01d02−2d01d12−2d02d12.",
+    "mathContext": "$\\mathrm{cmDet3} = d_{01}^2 + d_{02}^2 + d_{12}^2 - 2d_{01}d_{02} - 2d_{01}d_{12} - 2d_{02}d_{12}$, $d_{ij} = \\lVert P_i-P_j\\rVert^2$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "squared distance",
+      "signed area",
+      "Cayley–Menger determinant",
+      "distance geometry"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "determinants"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-heron",
+    "proofId": "herons-formula-oq-05",
+    "range": {
+      "startLine": 61,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Heron's Formula (Cayley–Menger form)",
+    "content": "`cmDet3_eq` proves that, after substituting the coordinate expressions for the three squared edge lengths, the Cayley–Menger determinant collapses exactly to −4·area2². Since area2 = 2·Area, this is the symmetric form of Heron's formula: `heron_sixteen_area_sq` states 16·Area² = −cmDet3 with Area = |area2|/2. The proof is `simp only [cmDet3, sqDist2, area2]; ring` — a pure polynomial identity in the six coordinates — followed by `div_pow` and `sq_abs` to pass from area2 to |area2|/2.",
+    "mathContext": "$\\mathrm{cmDet3} = -4\\,\\mathrm{area2}^2$, so $16\\,\\mathrm{Area}^2 = -\\mathrm{cmDet3} = 2a^2b^2+2b^2c^2+2c^2a^2-a^4-b^4-c^4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Heron's formula",
+      "triangle area",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "Heron's formula",
+      "ring normalization"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "herons-formula",
+        "relationship": "parent"
+      }
+    ]
+  },
+  {
+    "id": "ann-tetra-setup",
+    "proofId": "herons-formula-oq-05",
+    "range": {
+      "startLine": 75,
+      "endLine": 113
+    },
+    "type": "definition",
+    "title": "Tetrahedron: Squared Distance, Volume, and Cayley–Menger Determinant",
+    "content": "The n=3 case mirrors the triangle. `sqDist3` is the squared spatial distance on ℝ×ℝ×ℝ (coordinates accessed as .1, .2.1, .2.2). `vol6 P₀ P₁ P₂ P₃` is the scalar triple product (P₁−P₀)·((P₂−P₀)×(P₃−P₀)), which equals 6·V (the 3!·V content scalar). `cmDet4` is the 5×5 Cayley–Menger determinant of the bordered squared-distance matrix, expanded as a 22-term polynomial in the six squared edge lengths d01,…,d23. Working with the triple product directly keeps everything inside `ring`, avoiding any matrix-determinant API.",
+    "mathContext": "$\\mathrm{vol6} = (P_1-P_0)\\cdot\\big((P_2-P_0)\\times(P_3-P_0)\\big) = 6V$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "scalar triple product",
+      "tetrahedron volume",
+      "Cayley–Menger determinant"
+    ],
+    "prerequisites": [
+      "scalar triple product",
+      "determinants in three dimensions"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-cayley-menger",
+    "proofId": "herons-formula-oq-05",
+    "range": {
+      "startLine": 114,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "Cayley–Menger Volume Identity",
+    "content": "`cmDet4_eq` is the central result: substituting the coordinate squared distances, the tetrahedral Cayley–Menger determinant collapses to 8·vol6², closed by `simp only [cmDet4, sqDist3, vol6]; ring`. Because vol6 = 6·V, this yields `cayley_menger_tetrahedron`: 288·V² = cmDet4 with V = |vol6|/6, recovering the tetrahedron's volume from its six squared edge lengths exactly as Heron recovers a triangle's area. The identity was independently verified by exact symbolic determinant expansion against general (non-origin) coordinates before formalization.",
+    "mathContext": "$\\mathrm{cmDet4} = 8\\,\\mathrm{vol6}^2$, so $288\\,V^2 = \\mathrm{cmDet4}\\big(\\lVert P_i-P_j\\rVert^2\\big)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cayley–Menger determinant",
+      "simplex volume",
+      "distance geometry"
+    ],
+    "prerequisites": [
+      "scalar triple product",
+      "ring normalization"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-realizability",
+    "proofId": "herons-formula-oq-05",
+    "range": {
+      "startLine": 130,
+      "endLine": 149
+    },
+    "type": "theorem",
+    "title": "Realizability and Degeneracy",
+    "content": "Two corollaries of the squared form. `cmDet4_nonneg` observes that 288·V² = cmDet4 ≥ 0 for any four points (proved by `positivity` after rewriting with cmDet4_eq) — the realizability sign condition. `cmDet4_eq_zero_iff_coplanar` is the degeneracy criterion: the determinant vanishes iff vol6 = 0, i.e. the four points are coplanar; the forward direction uses `pow_eq_zero_iff` to extract vol6 = 0 from 8·vol6² = 0.",
+    "mathContext": "$\\mathrm{cmDet4} \\geq 0$, and $\\mathrm{cmDet4} = 0 \\iff \\mathrm{vol6} = 0$ (the four points are coplanar).",
+    "significance": "standard",
+    "relatedConcepts": [
+      "realizability",
+      "coplanarity",
+      "degenerate simplex"
+    ],
+    "prerequisites": [
+      "nonnegativity of squares"
+    ],
+    "crossReferences": []
+  }
+]

--- a/src/data/proofs/herons-formula-oq-05/meta.json
+++ b/src/data/proofs/herons-formula-oq-05/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "herons-formula-oq-05",
+  "title": "Heron's Formula via the Cayley–Menger Determinant",
+  "slug": "herons-formula-oq-05",
+  "description": "Generalizes Heron's formula to simplex content from squared edge lengths via the Cayley–Menger determinant. Proves two classical cases as explicit polynomial identities in the squared edge lengths: the triangle (n=2) gives 16·Area² = −cmDet3 (Heron's formula), and the tetrahedron (n=3) gives 288·V² = cmDet4. Includes realizability (cmDet4 ≥ 0) and a coplanarity/degeneracy criterion. 6 theorems, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyMengerHeronOQ05.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "triangle",
+      "tetrahedron",
+      "simplex",
+      "heron",
+      "cayley-menger",
+      "determinant",
+      "volume",
+      "coordinate-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 149,
+    "theoremCount": 6,
+    "definitionCount": 6,
+    "originalContributions": [
+      "cmDet4_eq: the Cayley–Menger determinant of four points in space equals 8·(6V)², where 6V is the scalar triple product — an exact polynomial identity in the six squared edge lengths",
+      "cayley_menger_tetrahedron: 288·V² = cmDet4, recovering the tetrahedron volume from its six squared edge lengths",
+      "cmDet3_eq / heron_sixteen_area_sq: the n=2 case 16·Area² = −cmDet3, the symmetric (Cayley–Menger) form of Heron's formula",
+      "cmDet4_nonneg: realizability — the tetrahedral Cayley–Menger determinant is always nonnegative (288·V² ≥ 0)",
+      "cmDet4_eq_zero_iff_coplanar: degeneracy criterion — the determinant vanishes iff the four points are coplanar (zero volume)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Heron of Alexandria (c. 60 AD) gave the area of a triangle in terms of its side lengths: 16·Area² = 2a²b² + 2b²c² + 2c²a² − a⁴ − b⁴ − c⁴. Arthur Cayley (1841) and Karl Menger (1928) generalized this to arbitrary dimension: the n-dimensional content of a simplex on n+1 points is determined by the pairwise squared distances through a single determinant. For points P₀,…,Pₙ the (n+2)×(n+2) Cayley–Menger determinant — a border of ones around the matrix of squared distances dᵢⱼ = ‖Pᵢ−Pⱼ‖² — equals (−1)^(n+1)·2ⁿ·(n!)²·V². The triangle case (n=2) is exactly Heron's formula, and the tetrahedron case (n=3) gives 288·V² for the volume. The determinant is also the algebraic gateway to distance geometry: a configuration of squared distances is realizable in Euclidean space precisely when the relevant Cayley–Menger determinants have the correct signs.",
+    "problemStatement": "Generalize Heron's formula to simplex volume from squared edge lengths via the Cayley–Menger determinant. For a tetrahedron prove that 288·V² equals the 5×5 Cayley–Menger determinant of the six squared edges, recovering Heron as the n=2 case; formalize the identity and the realizability/degeneracy condition.",
+    "proofStrategy": "Encode each squared edge length as the polynomial ‖Pᵢ−Pⱼ‖² in the point coordinates, define the Cayley–Menger determinants cmDet3 / cmDet4 as their expanded polynomials in the six (resp. three) squared-edge variables, and the unsigned content scalars area2 = 2·Area (signed) and vol6 = 6·V (scalar triple product). Substituting the coordinate expressions, both determinants collapse to a short polynomial — cmDet3 = −4·area2², cmDet4 = 8·vol6² — closed by `simp only [defs]; ring` over the point coordinates. Heron (16·Area² = −cmDet3) and the volume law (288·V² = cmDet4) follow by `div_pow` + `sq_abs`. Nonnegativity is `positivity`; the coplanarity criterion uses `pow_eq_zero_iff`.",
+    "keyInsights": [
+      "Although the Cayley–Menger determinant of squared distances looks like a degree-6 polynomial in the coordinates, it collapses exactly to a constant multiple of the squared simplex content: cmDet3 = −4·(2·Area)² and cmDet4 = 8·(6·V)².",
+      "Working directly with the scalar triple product vol6 = (P₁−P₀)·((P₂−P₀)×(P₃−P₀)) keeps the identity as a pure `ring` fact, avoiding any matrix-determinant API.",
+      "The −4 / 8 constants are exactly (−1)^(n+1)·2ⁿ·(n!)² normalised against the n!·V content scalars (2·Area and 6·V) used here.",
+      "Realizability is immediate from the squared form: 288·V² = cmDet4 ≥ 0 for any four points, with equality exactly when the points are coplanar.",
+      "The full identities were independently verified by exact symbolic determinant expansion against general (non-origin) coordinates before formalization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "triangle-setup",
+      "title": "Triangle: Squared Distance, Area, and CM Determinant",
+      "startLine": 38,
+      "endLine": 60,
+      "summary": "Definitions for the n=2 case: sqDist2 (squared planar distance), area2 (twice the signed triangle area), and cmDet3 (the 4×4 Cayley–Menger determinant as a polynomial in the three squared edge lengths).",
+      "mathContext": "$\\mathrm{cmDet3} = d_{01}^2 + d_{02}^2 + d_{12}^2 - 2d_{01}d_{02} - 2d_{01}d_{12} - 2d_{02}d_{12}$ with $d_{ij} = \\lVert P_i - P_j\\rVert^2$."
+    },
+    {
+      "id": "heron",
+      "title": "Heron's Formula (Cayley–Menger form)",
+      "startLine": 61,
+      "endLine": 74,
+      "summary": "cmDet3_eq: the triangle Cayley–Menger determinant equals −4·area2², proved by `simp only [defs]; ring`. heron_sixteen_area_sq: 16·Area² = −cmDet3 with Area = |area2|/2.",
+      "mathContext": "$16\\,\\mathrm{Area}^2 = -\\mathrm{cmDet3} = 2a^2b^2 + 2b^2c^2 + 2c^2a^2 - a^4 - b^4 - c^4$."
+    },
+    {
+      "id": "tetra-setup",
+      "title": "Tetrahedron: Squared Distance, Volume, and CM Determinant",
+      "startLine": 75,
+      "endLine": 113,
+      "summary": "Definitions for the n=3 case: sqDist3 (squared spatial distance), vol6 (six times the signed volume, the scalar triple product), and cmDet4 (the 5×5 Cayley–Menger determinant as a 22-term polynomial in the six squared edge lengths).",
+      "mathContext": "$\\mathrm{vol6} = (P_1-P_0)\\cdot\\big((P_2-P_0)\\times(P_3-P_0)\\big) = 6V$."
+    },
+    {
+      "id": "cayley-menger",
+      "title": "Cayley–Menger Volume Identity",
+      "startLine": 114,
+      "endLine": 129,
+      "summary": "cmDet4_eq: the tetrahedron Cayley–Menger determinant equals 8·vol6², proved by `simp only [defs]; ring`. cayley_menger_tetrahedron: 288·V² = cmDet4 with V = |vol6|/6.",
+      "mathContext": "$288\\,V^2 = \\mathrm{cmDet4}\\big(\\lVert P_i-P_j\\rVert^2\\big)$."
+    },
+    {
+      "id": "realizability",
+      "title": "Realizability and Degeneracy",
+      "startLine": 130,
+      "endLine": 149,
+      "summary": "cmDet4_nonneg: 288·V² = cmDet4 ≥ 0 for any four points (positivity). cmDet4_eq_zero_iff_coplanar: the determinant vanishes iff vol6 = 0, i.e. the four points are coplanar.",
+      "mathContext": "$\\mathrm{cmDet4} \\geq 0$, and $\\mathrm{cmDet4} = 0 \\iff \\mathrm{vol6} = 0$ (coplanar)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the Cayley–Menger generalization of Heron's formula as exact polynomial identities in the squared edge lengths: cmDet3 = −4·(2·Area)² (so 16·Area² = −cmDet3, Heron) for a triangle, and cmDet4 = 8·(6·V)² (so 288·V² = cmDet4) for a tetrahedron. Realizability (cmDet4 ≥ 0) and the coplanarity degeneracy criterion are included. 6 theorems, 6 definitions, 0 axioms, 0 sorries.",
+    "implications": "The Cayley–Menger determinant is the foundation of distance geometry: it expresses Euclidean content purely in terms of pairwise distances and characterizes when a distance matrix is realizable. The same border-of-ones determinant pattern extends to every dimension, and the coplanarity criterion is the rank/degeneracy test underlying embeddings, molecular conformation, and multidimensional scaling.",
+    "openQuestions": [
+      "Formalize the general n-dimensional Cayley–Menger identity (−1)^(n+1)·2ⁿ·(n!)²·V² = det, rather than the n=2 and n=3 cases separately.",
+      "Prove the full realizability theorem: a symmetric matrix of squared distances is realizable in ℝⁿ iff all Cayley–Menger determinants of its principal minors have the prescribed signs.",
+      "Connect cmDet3/cmDet4 to an actual Matrix.det of the bordered squared-distance matrix via cofactor expansion, certifying the polynomials are literally the determinants."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "herons-formula",
+      "relationship": "parent"
+    },
+    {
+      "proofId": "cevas-theorem-oq-01-oq-03",
+      "relationship": "related"
+    }
+  ],
+  "leanFile": {
+    "namespace": "CayleyMengerHeron",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 6,
+    "path": "Proofs/CayleyMengerHeronOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes **Heron's formula** to simplex content from squared edge lengths via the **Cayley–Menger determinant** (`herons-formula-oq-05`). Adds `proofs/Proofs/CayleyMengerHeronOQ05.lean` (registered in `Proofs.lean`) plus the gallery entry, with two classical cases stated as explicit polynomial identities in the squared edge lengths:

- **n = 2 (Heron):** `cmDet3 = -4·(2·Area)²`, i.e. `16·Area² = -cmDet3` — the symmetric form of Heron's formula.
- **n = 3 (tetrahedron):** `cmDet4 = 8·(6·V)²`, i.e. `288·V² = cmDet4`.

Supporting results:
- `cmDet4_nonneg` — realizability form `288·V² = cmDet4 ≥ 0`.
- `cmDet4_eq_zero_iff_coplanar` — degeneracy: determinant vanishes iff the four points are coplanar (`vol6 = 0`).

`cmDet3` / `cmDet4` are the expanded 4×4 / 5×5 Cayley–Menger determinants (matrices shown in the file docstring), defined as explicit polynomials in the six squared edge lengths.

## Verification

- **Build: GREEN** — `./proofs/scripts/docker-build.sh Proofs.CayleyMengerHeronOQ05` → `✔ [3058/3058] Built Proofs.CayleyMengerHeronOQ05 (65s)`. **0 axioms, 0 sorries.**
- **Math:** every identity independently verified in sympy with exact symbolic determinant expansion against general coordinates (non-origin points, full 12-/6-variable forms). Numerators and the `-4` / `8` constants confirmed.
- **Gallery:** `annotations:validate` (`--strict`) clean for this slug.
- Core identities are `simp only [defs]; ring`; `cmDet4_nonneg` is `positivity`; degeneracy uses `pow_eq_zero_iff`.

## Changes

- `proofs/Proofs/CayleyMengerHeronOQ05.lean` (new)
- `proofs/Proofs.lean` (+1 import line)
- `src/data/proofs/herons-formula-oq-05/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)