### PR TITLE
audit(tracker): record amgm-inequality-oq-02-oq-01-oq-05 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15552,6 +15552,12 @@
       "lastAudited": "2026-06-16T07:56:56Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T14:09:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
Gallery integrity audit of `amgm-inequality-oq-02-oq-01-oq-05` (Maclaurin base step S₁² ≥ S₂). Records a clean result in the audit tracker.

## Findings (CLEAN — no overclaim)
- **Sorries**: 0 in source, 0 in meta.json — match
- **Axioms**: 0 `axiom` declarations, no structure-encoded assumptions — matches `axiomCount: 0`
- **True-stubs**: none
- **Counts**: 6 theorems / 3 definitions — match meta
- **Badge `mathlib`**: correctly reflects reliance on Mathlib's Cauchy-Schwarz bound (`Finset.sq_sum_le_card_mul_sum_sq`); the local Newton-Girard re-derivation is honestly scoped in `originalContributions`
- **Status `formalized`** (not `verified`); build-pending status transparently disclosed in `assumptions`

Single-line tracker addition on top of current `main` (conflict-free). Supersedes the conflicting #25002 (whose IVT record is already merged on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)