### PR TITLE
research(pompeiu-theorem-oq-01): formalize Pompeiu's theorem (0/0, build-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2729,6 +2729,7 @@ import Proofs.PlatonicSolids
 import Proofs.PlatonicSolidsOQ01
 import Proofs.PlatonicSolidsOQ02
 import Proofs.PoincareConjecture
+import Proofs.PompeiuTheorem
 import Proofs.PowerMeanCrossZeroOQ
 import Proofs.PowerMeanLimitOQ
 import Proofs.PowerMeanMonotoneOQ

--- a/proofs/Proofs/PompeiuTheorem.lean
+++ b/proofs/Proofs/PompeiuTheorem.lean
@@ -1,0 +1,81 @@
+import Mathlib
+
+/-
+# Pompeiu's Theorem
+
+## What This Proves
+Let `ABC` be an equilateral triangle and `P` any point in its plane. Then the
+three distances `PA`, `PB`, `PC` satisfy the triangle inequality — i.e. they can
+be assembled into a (possibly degenerate) triangle. The degenerate case occurs
+exactly when `P` lies on the circumcircle of `ABC`.
+
+## Historical Context
+Discovered by the Romanian mathematician Dimitrie Pompeiu (1873–1954) in 1936.
+It is one of the cleanest illustrations of how a metric statement about an
+equilateral triangle becomes a one-line complex-number computation.
+
+## Approach
+We work with the vertices `a, b, c` and the point `p` as complex numbers. The
+purely algebraic identity
+  (p - a)(b - c) + (p - b)(c - a) + (p - c)(a - b) = 0
+holds for ANY four points. Taking absolute values and using that the three side
+lengths `|b - c| = |c - a| = |a - b|` are equal for an equilateral triangle, the
+common side length cancels and we obtain
+  |p - a| ≤ |p - b| + |p - c|
+together with its two cyclic permutations. That is exactly Pompeiu's inequality.
+-/
+
+namespace PompeiuTheorem
+
+/-- The Pompeiu identity: for any four complex numbers,
+`(p - a)(b - c) + (p - b)(c - a) + (p - c)(a - b) = 0`.
+This holds with no hypotheses — it is a polynomial identity. -/
+theorem pompeiu_identity (a b c p : ℂ) :
+    (p - a) * (b - c) + (p - b) * (c - a) + (p - c) * (a - b) = 0 := by
+  ring
+
+/-- Core Pompeiu inequality (one of the three). For an equilateral triangle with
+vertices `a, b, c` (all side lengths equal) and any point `p`,
+`dist p a ≤ dist p b + dist p c`. -/
+theorem pompeiu_dist (a b c p : ℂ)
+    (h1 : ‖a - b‖ = ‖b - c‖) (h2 : ‖b - c‖ = ‖c - a‖) :
+    dist p a ≤ dist p b + dist p c := by
+  -- Isolate the term attached to vertex `a` in the Pompeiu identity.
+  have key : (p - a) * (b - c) = -((p - b) * (c - a) + (p - c) * (a - b)) := by
+    linear_combination pompeiu_identity a b c p
+  -- Triangle inequality on the three complex products.
+  have hnorm : ‖(p - a) * (b - c)‖ ≤ ‖(p - b) * (c - a)‖ + ‖(p - c) * (a - b)‖ := by
+    rw [key, norm_neg]
+    exact norm_add_le _ _
+  -- Split each product norm and rewrite every side length to the common `‖b - c‖`.
+  rw [norm_mul, norm_mul, norm_mul, ← h2, h1] at hnorm
+  rw [dist_eq_norm, dist_eq_norm, dist_eq_norm]
+  rcases eq_or_lt_of_le (norm_nonneg (b - c)) with hs0 | hspos
+  · -- Degenerate equilateral triangle: side length is 0, so `a = b = c`.
+    have hbc : b = c := by
+      rw [← sub_eq_zero]; exact norm_eq_zero.mp hs0.symm
+    have hab : a = b := by
+      rw [← sub_eq_zero]; apply norm_eq_zero.mp; rw [h1]; exact hs0.symm
+    rw [hab, hbc]
+    have := norm_nonneg (p - c)
+    linarith
+  · -- Nondegenerate: cancel the positive common side length.
+    have h : ‖p - a‖ * ‖b - c‖ ≤ (‖p - b‖ + ‖p - c‖) * ‖b - c‖ := by
+      rw [add_mul]; exact hnorm
+    exact le_of_mul_le_mul_right h hspos
+
+/-- **Pompeiu's Theorem.** For an equilateral triangle `abc` and any point `p`,
+the three distances `pa, pb, pc` satisfy all three triangle inequalities, hence
+form a (possibly degenerate) triangle. -/
+theorem pompeiu (a b c p : ℂ)
+    (h1 : ‖a - b‖ = ‖b - c‖) (h2 : ‖b - c‖ = ‖c - a‖) :
+    dist p a ≤ dist p b + dist p c ∧
+    dist p b ≤ dist p c + dist p a ∧
+    dist p c ≤ dist p a + dist p b := by
+  refine ⟨pompeiu_dist a b c p h1 h2, ?_, ?_⟩
+  · -- isolate vertex `b`: needs ‖b-c‖=‖c-a‖ and ‖c-a‖=‖a-b‖
+    exact pompeiu_dist b c a p h2 (h1.trans h2).symm
+  · -- isolate vertex `c`: needs ‖c-a‖=‖a-b‖ and ‖a-b‖=‖b-c‖
+    exact pompeiu_dist c a b p (h1.trans h2).symm h1
+
+end PompeiuTheorem

--- a/research/problems/pompeiu-theorem-oq-01/knowledge.md
+++ b/research/problems/pompeiu-theorem-oq-01/knowledge.md
@@ -1,0 +1,48 @@
+# Pompeiu's Theorem (pompeiu-theorem-oq-01)
+
+## Problem
+For an equilateral triangle `ABC` and any point `P` in its plane, the three
+distances `PA`, `PB`, `PC` satisfy the triangle inequality (they are the side
+lengths of a possibly-degenerate triangle). Degenerate iff `P` lies on the
+circumcircle of `ABC`.
+
+## Status: COMPLETED (0 sorry / 0 axiom, build-verified)
+
+## Approach (complex numbers)
+Vertices `a, b, c` and point `p` as complex numbers. Everything follows from the
+hypothesis-free polynomial identity
+
+  (p - a)(b - c) + (p - b)(c - a) + (p - c)(a - b) = 0     -- `ring`
+
+Isolating the `a`-term and taking norms:
+
+  ‖p - a‖·‖b - c‖ ≤ ‖p - b‖·‖c - a‖ + ‖p - c‖·‖a - b‖     -- `norm_add_le`, `norm_mul`
+
+Equilateral hypothesis ‖a-b‖ = ‖b-c‖ = ‖c-a‖ lets the common side length cancel
+(`le_of_mul_le_mul_right` when positive; degenerate a=b=c case handled directly),
+giving dist p a ≤ dist p b + dist p c. Cyclic permutation of the core lemma gives
+the other two inequalities.
+
+## Files
+- `proofs/Proofs/PompeiuTheorem.lean` — 3 theorems, 0 def, 0 axiom, 0 sorry, 81 lines
+  - `pompeiu_identity` (hypothesis-free Lagrange three-term identity)
+  - `pompeiu_dist` (core inequality)
+  - `pompeiu` (full: all three cyclic triangle inequalities)
+- `src/data/proofs/pompeiu-theorem-oq-01/meta.json` — gallery entry
+
+## Key facts
+- The identity is the SAME three-term Lagrange identity as Ptolemy's inequality;
+  Pompeiu is the equilateral specialization.
+- Equality (degenerate triangle) ⇔ P on circumcircle = Ptolemy equality case.
+- Mathlib v4.26.0: use `‖·‖` / `dist_eq_norm` / `norm_mul` / `norm_add_le`
+  (avoid `Complex.abs`, which has churned). `norm_mul` works since ℂ is a
+  NormedField.
+
+## Sessions
+### 2026-06-16 (Session 1, researcher-10) — FRESH, COMPLETED
+- Formalized from scratch via the complex Lagrange identity. Build-verified
+  (docker, 0/0). Registered in Proofs.lean + gallery meta.json.
+
+## Possible follow-ups
+- Biconditional equality characterization (P on circumcircle ⇔ degenerate).
+- Regular n-gon analogue.

--- a/src/data/proofs/pompeiu-theorem-oq-01/meta.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "pompeiu-theorem-oq-01",
+  "title": "Pompeiu's Theorem",
+  "slug": "pompeiu-theorem-oq-01",
+  "description": "For an equilateral triangle ABC and any point P in its plane, the three distances PA, PB, PC satisfy the triangle inequality and so form a (possibly degenerate) triangle. A 1936 result of Dimitrie Pompeiu, proved here by a one-line complex-number identity.",
+  "meta": {
+    "author": "Dimitrie Pompeiu (1936)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pompeiu%27s_theorem",
+    "date": "1936",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PompeiuTheorem.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "equilateral",
+      "complex-coordinates",
+      "triangle-inequality",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex",
+        "description": "Complex number field ℂ and basic arithmetic",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "norm_add_le",
+        "description": "Triangle inequality for the norm, applied to the three complex products",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      },
+      {
+        "theorem": "norm_mul",
+        "description": "Multiplicativity of the complex norm, used to split |(p-a)(b-c)| = |p-a||b-c|",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Pompeiu identity: (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0 holds for any four complex points (hypothesis-free polynomial identity)",
+      "Core inequality pompeiu_dist: dist p a ≤ dist p b + dist p c via the triangle inequality on complex products plus cancellation of the common side length",
+      "Full Pompeiu theorem: all three cyclic triangle inequalities, obtained by cyclically permuting the core lemma",
+      "Explicit handling of the degenerate equilateral triangle (zero side length collapses a = b = c)"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 81,
+    "assumptions": "0 axioms. 0 sorries. Fully verified.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "title": "Pompeiu Identity",
+      "startLine": 33,
+      "endLine": 38,
+      "description": "The hypothesis-free polynomial identity (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0, the algebraic engine of the whole proof.",
+      "summary": "Pompeiu Identity",
+      "id": "pompeiu-identity"
+    },
+    {
+      "title": "Core Inequality",
+      "startLine": 40,
+      "endLine": 68,
+      "description": "dist p a ≤ dist p b + dist p c. Take absolute values in the identity, apply the triangle inequality to the three complex products, and cancel the common equilateral side length (with the degenerate zero-length case handled separately).",
+      "summary": "Core Inequality",
+      "id": "core-inequality"
+    },
+    {
+      "title": "Pompeiu's Theorem",
+      "startLine": 70,
+      "endLine": 80,
+      "description": "All three cyclic triangle inequalities among PA, PB, PC, obtained by applying the core lemma to cyclic relabelings of the vertices.",
+      "summary": "Pompeiu's Theorem",
+      "id": "pompeius-theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Pompeiu's theorem was discovered by the Romanian mathematician Dimitrie Pompeiu (1873–1954) in 1936. Pompeiu studied in Paris under Henri Poincaré and is also remembered for the Pompeiu problem in integral geometry and for early work on the maximum modulus principle.\n\nThe theorem is a classic of elementary triangle geometry: it says that the three distances from an arbitrary point to the vertices of an equilateral triangle are themselves the side lengths of some triangle. The triangle they form degenerates to a segment exactly when the point lies on the circumcircle of the equilateral triangle — this is the equality case of the underlying triangle inequality and is the geometric content of (the equilateral case of) Ptolemy's theorem.\n\nThe complex-number proof reduces the metric statement to the polynomial identity (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0, which is the same Lagrange-style three-term identity that underlies Ptolemy's inequality. For a general triangle the three terms have different magnitudes |b-c|, |c-a|, |a-b|; the equilateral hypothesis makes them equal so that the common factor cancels.",
+    "problemStatement": "**Pompeiu's Theorem.** Let ABC be an equilateral triangle and let P be any point in its plane. Then the three lengths PA, PB, PC satisfy the triangle inequalities\n\n  PA ≤ PB + PC,  PB ≤ PC + PA,  PC ≤ PA + PB,\n\nso a triangle with these three side lengths exists. The triangle is degenerate (one inequality is an equality) if and only if P lies on the circumcircle of ABC.",
+    "text": "The three distances from any point to the vertices of an equilateral triangle are the sides of a triangle.",
+    "proofStrategy": "Place the vertices a, b, c and the point p in the complex plane.\n\n1. **Identity.** The expression (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) expands to 0 for all a, b, c, p — a polynomial identity proved by `ring`.\n\n2. **Take norms.** Writing the first term as the negative of the sum of the other two, the triangle inequality for the complex norm gives |p-a||b-c| ≤ |p-b||c-a| + |p-c||a-b|.\n\n3. **Cancel the side length.** For an equilateral triangle |b-c| = |c-a| = |a-b|. When this common length s is positive, divide through to get |p-a| ≤ |p-b| + |p-c|, i.e. dist p a ≤ dist p b + dist p c. When s = 0 the triangle is a single point and the inequality is trivial.\n\n4. **Cyclic permutation.** Applying the core lemma to the relabelings (b,c,a) and (c,a,b) yields the remaining two inequalities.",
+    "keyInsights": [
+      "**Hypothesis-free identity**: (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0 holds for *any* four points — geometry enters only through the equilateral side-length equality",
+      "**Side-length cancellation**: the equilateral hypothesis equates the three coefficient magnitudes so the common side length divides out, turning a weighted inequality into the plain triangle inequality",
+      "**Equality = circumcircle**: the degenerate triangle occurs exactly when P lies on the circumcircle, which is the equality case of Ptolemy's inequality for the equilateral triangle",
+      "**Same engine as Ptolemy**: the three-term Lagrange identity used here is the algebraic core shared with the complex-number proof of Ptolemy's inequality"
+    ],
+    "prerequisites": [
+      "Complex numbers and arithmetic in ℂ",
+      "The norm (modulus) of a complex number and its multiplicativity",
+      "The triangle inequality for norms"
+    ],
+    "openQuestions": [
+      "Can the equality characterization (P on the circumcircle ⇔ degenerate triangle) be formalized as a biconditional?",
+      "Does an analogous distance-triangle result hold for the vertices of a regular n-gon, and under what condition on P?"
+    ]
+  },
+  "conclusion": {
+    "summary": "Pompeiu's theorem is formalized over the complex plane. The whole proof rests on the polynomial identity (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0: taking norms gives a weighted triangle inequality, and the equilateral hypothesis cancels the common side length to yield the three triangle inequalities among PA, PB, PC. The degenerate (zero side length) case is handled explicitly.",
+    "implications": "The proof is another instance of complex coordinates collapsing a metric theorem of plane geometry into a single algebraic identity, mirroring the gallery's complex-number proofs of Napoleon's and Ptolemy's theorems.",
+    "openQuestions": [
+      "Can the equality characterization (P on the circumcircle ⇔ degenerate triangle) be formalized as a biconditional?",
+      "Does an analogous distance-triangle result hold for the vertices of a regular n-gon?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "companion",
+      "description": "Both transform an equilateral-triangle statement into a complex-number identity; Napoleon uses a rotation identity, Pompeiu uses the three-term Lagrange identity and the triangle inequality for norms"
+    },
+    {
+      "targetId": "ptolemys-complex-proof",
+      "relationship": "related",
+      "description": "Pompeiu's theorem is the equilateral specialization of Ptolemy's inequality; the equality case (degenerate triangle) corresponds exactly to P lying on the circumcircle, and both proofs share the same Lagrange three-term identity over ℂ"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PompeiuTheorem",
+    "lineCount": 81,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/PompeiuTheorem.lean"
+  }
+}


### PR DESCRIPTION
## Summary
Formalizes **Pompeiu's theorem** (`pompeiu-theorem-oq-01`): for an equilateral triangle `ABC` and any point `P` in its plane, the three distances `PA`, `PB`, `PC` satisfy the triangle inequality and so form a (possibly degenerate) triangle.

## Approach
Vertices `a,b,c` and point `p` as complex numbers. Everything rests on the hypothesis-free polynomial identity
`(p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0`.
Taking norms and applying the triangle inequality to the three complex products gives
`‖p-a‖·‖b-c‖ ≤ ‖p-b‖·‖c-a‖ + ‖p-c‖·‖a-b‖`.
The equilateral hypothesis `‖a-b‖=‖b-c‖=‖c-a‖` cancels the common side length (degenerate zero-length case handled directly), yielding `dist p a ≤ dist p b + dist p c`; cyclic permutation gives all three.

## Contents
- `proofs/Proofs/PompeiuTheorem.lean` — 3 theorems, 0 def, **0 sorry / 0 axiom**, 81 lines
  - `pompeiu_identity`, `pompeiu_dist` (core), `pompeiu` (full cyclic statement)
- Registered in `proofs/Proofs.lean`
- Gallery entry `src/data/proofs/pompeiu-theorem-oq-01/meta.json`
- `research/problems/pompeiu-theorem-oq-01/knowledge.md`

## Verification
`./proofs/scripts/docker-build.sh Proofs.PompeiuTheorem` → `✔ [7743/7743] Built Proofs.PompeiuTheorem`, build completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)