### PR TITLE
audit(tracker): record viviani-theorem-oq-01 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15552,6 +15552,12 @@
       "lastAudited": "2026-06-16T07:56:56Z",
       "result": "clean",
       "issues": []
+    },
+    "viviani-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T14:16:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — viviani-theorem-oq-01

**Result: CLEAN** — public claims match the Lean source.

### Verified against `proofs/Proofs/VivianiTheorem.lean`
- `sorries`: 0 ✓ — no `sorry` in source
- `axiomCount`: 0 ✓ — no `axiom` declarations, no structures/typeclasses hiding assumptions
- No `True` stubs
- `theoremCount` 7 and `definitionCount` 1 match the source
- Tier classification: **Tier A** — the core point-independence identity (`sum = √3/2`) is discharged by `ring`. Mathlib only supplies trivial helpers (`Real.sq_sqrt`, `Real.sqrt_sq`, `abs_of_nonneg`/`abs_of_nonpos`), so badge `original`/status `verified` is justified — not a Mathlib wrapper.
- `mathlibDependencies` and `originalContributions` are accurate and honestly scoped.

Single-entry tracker update; no gallery content changed.

---
Discovered during gallery integrity audit.