### PR TITLE
research(pompeiu-theorem-oq-01): Pompeiu's theorem via cube-root rotation identity (0/0)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2729,6 +2729,7 @@ import Proofs.PlatonicSolids
 import Proofs.PlatonicSolidsOQ01
 import Proofs.PlatonicSolidsOQ02
 import Proofs.PoincareConjecture
+import Proofs.PompeiuTheorem
 import Proofs.PowerMeanCrossZeroOQ
 import Proofs.PowerMeanLimitOQ
 import Proofs.PowerMeanMonotoneOQ

--- a/proofs/Proofs/PompeiuTheorem.lean
+++ b/proofs/Proofs/PompeiuTheorem.lean
@@ -1,0 +1,134 @@
+import Mathlib
+
+/-
+# Pompeiu's Theorem (inequality form): the complex-number proof
+
+## What This Proves
+Pompeiu's theorem states that for an equilateral triangle `ABC` and any point `P`
+in the plane, the three distances `PA`, `PB`, `PC` satisfy the triangle inequality
+— i.e. they are the side lengths of a (possibly degenerate) triangle, called the
+*Pompeiu triangle*. The triangle is degenerate exactly when `P` lies on the
+circumcircle of `ABC`.
+
+We give the classical complex-number proof of the inequality direction.
+
+## Setup
+Model the plane as `ℂ`. Fix a primitive cube root of unity `ω` (`ω² + ω + 1 = 0`).
+An equilateral triangle with vertices `a, b, c : ℂ` of one orientation satisfies
+the rotation identity
+  `a + ω·b + ω²·c = 0`.
+(This is one factor of the symmetric equilateral condition
+`a² + b² + c² = ab + bc + ca = (a + ω b + ω² c)(a + ω² b + ω c)`.)
+The hypotheses are non-vacuous: the cube roots of unity `(a,b,c) = (1, ω, ω²)`
+with `ω = e^{2πi/3}` form a genuine equilateral triangle satisfying
+`1 + ω·ω + ω²·ω² = 1 + ω² + ω⁴ = 1 + ω² + ω = 0`.
+
+## Key idea
+For any point `z` and the equilateral condition above,
+  `(z - a) + ω·(z - b) + ω²·(z - c) = z·(1 + ω + ω²) − (a + ω b + ω² c) = 0`,
+because both `1 + ω + ω² = 0` and `a + ω b + ω² c = 0`. Hence the three vectors
+`z - a`, `ω(z - b)`, `ω²(z - c)` sum to zero, so they close up into a triangle.
+Since `‖ω‖ = ‖ω²‖ = 1`, taking norms and applying the triangle inequality
+`‖x + y‖ ≤ ‖x‖ + ‖y‖` yields `PA ≤ PB + PC`. Cyclically rotating the identity
+(multiplying by `ω`, `ω²`) gives the other two inequalities.
+
+## Status
+- [x] `‖ω‖ = 1` derived from `ω² + ω + 1 = 0` (no extra hypothesis needed)
+- [x] The structural identity `(z-a) + ω(z-b) + ω²(z-c) = 0`
+- [x] All three Pompeiu inequalities (norm form and `dist` form)
+- Complete — 0 sorries, 0 axioms
+
+## Mathlib Dependencies
+- `norm_mul`, `norm_pow` : multiplicativity of the norm on the normed field `ℂ`
+- `norm_add_le` : triangle inequality for norms
+- `norm_neg`, `norm_one`, `norm_nonneg`
+- `dist_eq_norm`
+-/
+
+set_option linter.unusedVariables false
+
+namespace PompeiuTheorem
+
+-- ============================================================
+-- PART 1: A primitive cube root of unity has norm one
+-- ============================================================
+
+/-- A root of `x² + x + 1` is a primitive cube root of unity, hence has norm `1`.
+This frees the main theorem from carrying `‖ω‖ = 1` as a separate hypothesis. -/
+theorem norm_eq_one_of_cube_root {ω : ℂ} (hω : ω ^ 2 + ω + 1 = 0) : ‖ω‖ = 1 := by
+  have hcube : ω ^ 3 = 1 := by linear_combination (ω - 1) * hω
+  have hn : ‖ω‖ ^ 3 = 1 := by rw [← norm_pow, hcube, norm_one]
+  have hfac : (‖ω‖ - 1) * (‖ω‖ ^ 2 + ‖ω‖ + 1) = 0 := by linear_combination hn
+  have hpos : 0 < ‖ω‖ ^ 2 + ‖ω‖ + 1 := by
+    nlinarith [norm_nonneg ω, sq_nonneg ‖ω‖]
+  rcases mul_eq_zero.mp hfac with h | h
+  · linarith
+  · linarith
+
+-- ============================================================
+-- PART 2: The rotation lemma
+-- ============================================================
+
+/-- If three complex numbers `u, v, w` satisfy `u + ω·v + ω²·w = 0` with `‖ω‖ = 1`,
+then `‖u‖ ≤ ‖v‖ + ‖w‖`. This is the engine of Pompeiu's inequality: each Pompeiu
+distance is bounded by the sum of the other two. -/
+theorem norm_le_of_rot {ω u v w : ℂ} (hnorm : ‖ω‖ = 1)
+    (h : u + ω * v + ω ^ 2 * w = 0) : ‖u‖ ≤ ‖v‖ + ‖w‖ := by
+  have hu : u = -(ω * v + ω ^ 2 * w) := by linear_combination h
+  have hω2 : ‖ω ^ 2‖ = 1 := by rw [norm_pow, hnorm, one_pow]
+  calc ‖u‖ = ‖ω * v + ω ^ 2 * w‖ := by rw [hu, norm_neg]
+    _ ≤ ‖ω * v‖ + ‖ω ^ 2 * w‖ := norm_add_le _ _
+    _ = ‖v‖ + ‖w‖ := by rw [norm_mul, norm_mul, hnorm, hω2, one_mul, one_mul]
+
+-- ============================================================
+-- PART 3: The structural identity
+-- ============================================================
+
+/-- The structural identity at the heart of Pompeiu's theorem: for an equilateral
+triangle `a + ω b + ω² c = 0` and any point `z`, the displacement vectors close up:
+`(z - a) + ω·(z - b) + ω²·(z - c) = 0`. -/
+theorem rotation_identity {ω a b c z : ℂ} (hω : ω ^ 2 + ω + 1 = 0)
+    (heq : a + ω * b + ω ^ 2 * c = 0) :
+    (z - a) + ω * (z - b) + ω ^ 2 * (z - c) = 0 := by
+  linear_combination z * hω - heq
+
+-- ============================================================
+-- PART 4: Pompeiu's inequality (norm form)
+-- ============================================================
+
+/-- **Pompeiu's theorem (inequality form).**
+
+For an equilateral triangle with vertices `a, b, c` (encoded by the rotation
+identity `a + ω b + ω² c = 0`, where `ω² + ω + 1 = 0`) and any point `z`, the three
+distances `‖z - a‖`, `‖z - b‖`, `‖z - c‖` satisfy all three triangle inequalities.
+In other words they are the side lengths of a (possibly degenerate) triangle. -/
+theorem pompeiu_norm {ω a b c z : ℂ} (hω : ω ^ 2 + ω + 1 = 0)
+    (heq : a + ω * b + ω ^ 2 * c = 0) :
+    ‖z - a‖ ≤ ‖z - b‖ + ‖z - c‖ ∧
+    ‖z - b‖ ≤ ‖z - c‖ + ‖z - a‖ ∧
+    ‖z - c‖ ≤ ‖z - a‖ + ‖z - b‖ := by
+  have hnorm : ‖ω‖ = 1 := norm_eq_one_of_cube_root hω
+  have hcube : ω ^ 3 = 1 := by linear_combination (ω - 1) * hω
+  refine ⟨?_, ?_, ?_⟩
+  · -- ‖z-a‖ ≤ ‖z-b‖ + ‖z-c‖  from  (z-a) + ω(z-b) + ω²(z-c) = 0
+    exact norm_le_of_rot hnorm (by linear_combination z * hω - heq)
+  · -- ‖z-b‖ ≤ ‖z-c‖ + ‖z-a‖  from  (z-b) + ω(z-c) + ω²(z-a) = 0
+    exact norm_le_of_rot hnorm
+      (by linear_combination z * hω - ω ^ 2 * heq + (b + c * ω) * hcube)
+  · -- ‖z-c‖ ≤ ‖z-a‖ + ‖z-b‖  from  (z-c) + ω(z-a) + ω²(z-b) = 0
+    exact norm_le_of_rot hnorm (by linear_combination z * hω - ω * heq + c * hcube)
+
+-- ============================================================
+-- PART 5: Pompeiu's inequality (distance form)
+-- ============================================================
+
+/-- Pompeiu's theorem stated with the metric `dist`, matching the classical
+geometric phrasing `PA ≤ PB + PC` (and cyclically). -/
+theorem pompeiu_dist {ω a b c z : ℂ} (hω : ω ^ 2 + ω + 1 = 0)
+    (heq : a + ω * b + ω ^ 2 * c = 0) :
+    dist z a ≤ dist z b + dist z c ∧
+    dist z b ≤ dist z c + dist z a ∧
+    dist z c ≤ dist z a + dist z b := by
+  simpa only [dist_eq_norm] using pompeiu_norm (ω := ω) (z := z) hω heq
+
+end PompeiuTheorem

--- a/research/problems/pompeiu-theorem-oq-01/knowledge.md
+++ b/research/problems/pompeiu-theorem-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# Pompeiu's Theorem (pompeiu-theorem-oq-01)
+
+## Problem
+For an equilateral triangle `ABC` and any point `P`, the distances `PA, PB, PC`
+satisfy all three triangle inequalities (they are the side lengths of a possibly
+degenerate triangle, the *Pompeiu triangle*). Degenerate iff `P` on the circumcircle.
+
+## Status
+COMPLETE (inequality direction). 0 sorries, 0 axioms. `Proofs/PompeiuTheorem.lean`.
+
+## Approach (complex numbers)
+- Plane = ℂ. Primitive cube root of unity `ω` with `ω² + ω + 1 = 0`.
+- Equilateral triangle of one orientation ⟺ `a + ω·b + ω²·c = 0`
+  (one factor of `a² + b² + c² = ab+bc+ca = (a+ωb+ω²c)(a+ω²b+ωc)`).
+- Key cancellation: `(z-a) + ω(z-b) + ω²(z-c) = z(1+ω+ω²) − (a+ωb+ω²c) = 0`.
+- So `z-a = -(ω(z-b) + ω²(z-c))`, and `‖ω‖ = ‖ω²‖ = 1` ⟹ `‖z-a‖ ≤ ‖z-b‖+‖z-c‖`.
+- Cyclic inequalities: multiply equilateral identity by `ω`, `ω²` (uses `ω³ = 1`).
+
+## What was built
+- `norm_eq_one_of_cube_root` : `ω²+ω+1=0 → ‖ω‖=1` (derives, not assumes; via ω³=1).
+- `norm_le_of_rot` : `u + ωv + ω²w = 0, ‖ω‖=1 → ‖u‖ ≤ ‖v‖+‖w‖` (rotation engine).
+- `rotation_identity` : the structural `(z-a)+ω(z-b)+ω²(z-c)=0`.
+- `pompeiu_norm` : all three triangle inequalities (norm form).
+- `pompeiu_dist` : metric (dist) form.
+
+## Mathlib hooks used
+- `norm_add_le`, `norm_mul`, `norm_pow`, `norm_neg`, `norm_one`, `norm_nonneg`
+- `dist_eq_norm`
+- tactics: `linear_combination` (all identities), `nlinarith` (positivity), `mul_eq_zero`
+
+## Non-vacuity
+Hypotheses satisfied by cube roots of unity `(a,b,c)=(1,ω,ω²)`, `ω=e^{2πi/3}`:
+`1 + ω·ω + ω²·ω² = 1 + ω² + ω⁴ = 1 + ω² + ω = 0`. (Stated in prose; a fully
+formalized non-vacuity lemma with explicit ω = ⟨-1/2, √3/2⟩ was drafted but omitted
+to keep the build robust — the concrete Complex normSq arithmetic is fragile.)
+
+## Open follow-ups
+- Degeneracy iff `P` on circumcircle (equality case of the triangle inequality:
+  `ω(z-b)`, `ω²(z-c)` positively proportional). This is the Ptolemy-equality phenomenon.
+- Petr–Douglas–Neumann generalization via higher roots of unity.
+
+## Sessions
+### 2026-06-16 (Session 1, researcher-11) — FRESH — COMPLETE
+- Claimed (took over a stale dead-pid lock; two prior pompeiu branches were empty).
+- Wrote `PompeiuTheorem.lean` (5 theorems), build-verified via docker-build, registered
+  in `Proofs.lean`, added gallery `pompeiu-theorem-oq-01/` (meta + annotations). PR opened.

--- a/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "ann-module-doc",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 46
+    },
+    "title": "Module Documentation: Setup and Proof Strategy",
+    "type": "concept",
+    "content": "The module documentation sets up the complex-number model of the plane and encodes an equilateral triangle by the cube-root relation a + ω·b + ω²·c = 0, where ω is a primitive cube root of unity (ω² + ω + 1 = 0). It explains the three-ingredient proof: derive ‖ω‖ = 1, establish the rotation identity (z-a) + ω(z-b) + ω²(z-c) = 0, and apply the norm triangle inequality. The hypotheses are noted to be non-vacuous, satisfied by the cube roots of unity (1, ω, ω²).",
+    "mathContext": "The equilateral condition a + ωb + ω²c = 0 is one factor of the symmetric form a² + b² + c² = ab + bc + ca = (a + ωb + ω²c)(a + ω²b + ωc). Choosing the factor that vanishes selects an orientation of the triangle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "roots of unity",
+      "equilateral triangle",
+      "normed field",
+      "triangle inequality"
+    ],
+    "prerequisites": [
+      "complex analysis",
+      "roots of unity"
+    ]
+  },
+  {
+    "id": "ann-norm-omega",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 66
+    },
+    "title": "Norm of a Primitive Cube Root of Unity",
+    "type": "lemma",
+    "content": "theorem norm_eq_one_of_cube_root shows that any root of x² + x + 1 has norm 1. From ω² + ω + 1 = 0 one derives ω³ = 1 (linear_combination (ω-1)·hω), hence ‖ω‖³ = ‖ω³‖ = 1. Factoring (‖ω‖ - 1)(‖ω‖² + ‖ω‖ + 1) = ‖ω‖³ - 1 = 0 and noting the second factor is strictly positive for ‖ω‖ ≥ 0 forces ‖ω‖ = 1.",
+    "mathContext": "This lets the main theorem omit ‖ω‖ = 1 as a hypothesis: it is a consequence of the defining quadratic. The positivity step uses nlinarith with norm_nonneg ω and sq_nonneg ‖ω‖.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "roots of unity",
+      "norm multiplicativity",
+      "real cube root"
+    ],
+    "prerequisites": [
+      "normed fields",
+      "polynomial factoring"
+    ]
+  },
+  {
+    "id": "ann-rotation-lemma",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 81
+    },
+    "title": "The Rotation Lemma (Engine of the Inequality)",
+    "type": "lemma",
+    "content": "theorem norm_le_of_rot: if u + ω·v + ω²·w = 0 with ‖ω‖ = 1, then ‖u‖ ≤ ‖v‖ + ‖w‖. The proof rewrites u = -(ω·v + ω²·w), takes norms (norm_neg), applies the triangle inequality norm_add_le, and uses norm_mul together with ‖ω‖ = ‖ω²‖ = 1.",
+    "mathContext": "Each Pompeiu distance ‖z - a‖ is the norm of one such u. Because ω and ω² have unit modulus, the rotations do not change lengths, so the bound is exactly ‖v‖ + ‖w‖.",
+    "significance": "core",
+    "relatedConcepts": [
+      "triangle inequality",
+      "norm multiplicativity",
+      "unit modulus rotation"
+    ],
+    "prerequisites": [
+      "normed fields",
+      "triangle inequality"
+    ]
+  },
+  {
+    "id": "ann-rotation-identity",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 93
+    },
+    "title": "The Structural Rotation Identity",
+    "type": "key-step",
+    "content": "theorem rotation_identity: for an equilateral triangle a + ω·b + ω²·c = 0 and any point z, the displacement vectors satisfy (z-a) + ω(z-b) + ω²(z-c) = 0. The single linear_combination z·hω - heq verifies that this equals z·(1+ω+ω²) - (a+ωb+ω²c), both of whose factors vanish.",
+    "mathContext": "This is the geometric core: the three displacement vectors z-a, z-b, z-c, rotated by 1, ω, ω², sum to zero and hence close into a triangle — which is precisely Pompeiu's assertion that PA, PB, PC are triangle side lengths.",
+    "significance": "core",
+    "relatedConcepts": [
+      "rotation identity",
+      "equilateral triangle",
+      "roots of unity"
+    ],
+    "prerequisites": [
+      "complex arithmetic",
+      "roots of unity"
+    ]
+  },
+  {
+    "id": "ann-pompeiu-norm",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 119
+    },
+    "title": "Pompeiu's Inequality (All Three Sides)",
+    "type": "theorem",
+    "content": "theorem pompeiu_norm: the three inequalities ‖z-a‖ ≤ ‖z-b‖+‖z-c‖, ‖z-b‖ ≤ ‖z-c‖+‖z-a‖, ‖z-c‖ ≤ ‖z-a‖+‖z-b‖. Each is norm_le_of_rot applied to the equilateral identity multiplied by 1, ω, ω² respectively; the cyclic permutations of (a,b,c) use ω³ = 1, supplied through the linear_combination coefficients.",
+    "mathContext": "Multiplying a + ωb + ω²c = 0 by ω gives c + ωa + ω²b = 0 (using ω³ = 1), rotating the roles of the vertices. One rotation lemma therefore yields all three triangle inequalities, establishing that PA, PB, PC form a triangle.",
+    "significance": "core",
+    "relatedConcepts": [
+      "triangle inequality",
+      "cyclic symmetry",
+      "Pompeiu triangle"
+    ],
+    "prerequisites": [
+      "normed fields",
+      "roots of unity"
+    ]
+  },
+  {
+    "id": "ann-pompeiu-dist",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 134
+    },
+    "title": "Metric (dist) Formulation",
+    "type": "theorem",
+    "content": "theorem pompeiu_dist restates the three inequalities using the metric dist, matching the classical geometric phrasing PA ≤ PB + PC. The proof rewrites dist z a as ‖z - a‖ via dist_eq_norm and reuses pompeiu_norm.",
+    "mathContext": "dist_eq_norm bridges the algebraic (norm) and geometric (distance) statements, confirming that the formalization captures the classical theorem about the lengths PA, PB, PC.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "metric space",
+      "distance",
+      "triangle inequality"
+    ],
+    "prerequisites": [
+      "metric spaces"
+    ]
+  }
+]

--- a/src/data/proofs/pompeiu-theorem-oq-01/meta.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "pompeiu-theorem-oq-01",
+  "title": "Pompeiu's Theorem via a Cube-Root-of-Unity Rotation Identity",
+  "slug": "pompeiu-theorem-oq-01",
+  "description": "For an equilateral triangle and any point P, the distances PA, PB, PC satisfy all three triangle inequalities. Proved over ℂ from the rotation identity (z-a) + ω(z-b) + ω²(z-c) = 0 and the norm triangle inequality.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pompeiu%27s_theorem",
+    "date": "2026-06-16",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "complex-analysis",
+      "inequality",
+      "roots-of-unity",
+      "classic",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/PompeiuTheorem.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_add_le",
+        "description": "Triangle inequality for norms: ‖a + b‖ ≤ ‖a‖ + ‖b‖",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      },
+      {
+        "theorem": "norm_mul",
+        "description": "Multiplicativity of norm in normed fields: ‖a * b‖ = ‖a‖ * ‖b‖",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      },
+      {
+        "theorem": "norm_pow",
+        "description": "Norm of a power: ‖a ^ n‖ = ‖a‖ ^ n",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Complex-number proof of Pompeiu's theorem (inequality form) from a single rotation identity",
+      "Encodes an equilateral triangle by the cube-root relation a + ω·b + ω²·c = 0, avoiding any explicit coordinates or trigonometry",
+      "Derives ‖ω‖ = 1 directly from ω² + ω + 1 = 0, so the main theorem carries no separate norm hypothesis",
+      "All three triangle inequalities obtained uniformly by cyclically rotating the identity (×1, ×ω, ×ω²)",
+      "Both norm and metric-distance formulations"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 134,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The equilateral hypothesis a + ω b + ω² c = 0 is non-vacuous (satisfied by the cube roots of unity).",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Pompeiu's theorem was discovered by the Romanian mathematician Dimitrie Pompeiu in 1936. It is a striking and somewhat surprising elementary fact: take any equilateral triangle $ABC$ and any point $P$ in its plane; then the three distances $PA$, $PB$, $PC$ can always be assembled into a triangle of their own (the *Pompeiu triangle*). The construction degenerates — the three lengths become collinear — exactly when $P$ lies on the circumcircle of $ABC$, which is the content of the classical Ptolemy equality for the cyclic quadrilateral $PABC$.\n\nPompeiu's original argument used a $60°$ rotation about one vertex of the equilateral triangle: rotating $P$ to a point $P'$ produces a triangle $PP'C$ whose sides are precisely $PA$, $PB$, $PC$. The complex-number formulation makes this rotation algebraic. Placing the plane in $\\mathbb{C}$ and writing $\\omega = e^{2\\pi i/3}$ for a primitive cube root of unity, an equilateral triangle of one orientation satisfies $a + \\omega b + \\omega^2 c = 0$. For any point $z$ one then has the remarkable cancellation $(z-a) + \\omega(z-b) + \\omega^2(z-c) = 0$, expressing that the three displacement vectors — after the unit-modulus rotations by $1, \\omega, \\omega^2$ — close up into a triangle. The triangle inequality for the complex modulus does the rest.\n\nThe theorem sits in the same family as Napoleon's theorem, Ptolemy's theorem, and Van Aubel's theorem: classical Euclidean statements that become one-line algebraic identities once points are identified with complex numbers and the special structure of $60°$/$120°$ rotation (the cube roots of unity) is exploited.",
+    "problemStatement": "**Pompeiu's Theorem (inequality form)**:\n\nLet $ABC$ be an equilateral triangle and $P$ any point in the plane. Then\n\n$$PA \\le PB + PC, \\qquad PB \\le PC + PA, \\qquad PC \\le PA + PB,$$\n\nso $PA, PB, PC$ are the side lengths of a (possibly degenerate) triangle. The triangle is degenerate precisely when $P$ lies on the circumcircle of $ABC$.",
+    "text": "Encoding an equilateral triangle as a + ω·b + ω²·c = 0 (ω a primitive cube root of unity) gives the rotation identity (z-a) + ω(z-b) + ω²(z-c) = 0, from which the three Pompeiu inequalities follow by the norm triangle inequality.",
+    "proofStrategy": "The proof has three ingredients:\n1. **Norm of ω**: From $\\omega^2 + \\omega + 1 = 0$ one gets $\\omega^3 = 1$, hence $\\|\\omega\\|^3 = 1$ and (since $\\|\\omega\\| \\ge 0$) $\\|\\omega\\| = 1$. No separate hypothesis on $\\|\\omega\\|$ is needed.\n2. **Rotation identity**: $(z-a) + \\omega(z-b) + \\omega^2(z-c) = z(1+\\omega+\\omega^2) - (a+\\omega b+\\omega^2 c) = 0$, since both factors vanish (`linear_combination z * hω - heq`).\n3. **Triangle inequality**: writing $u = z-a$, $v = z-b$, $w = z-c$, the identity gives $u = -(\\omega v + \\omega^2 w)$, so $\\|u\\| \\le \\|\\omega v\\| + \\|\\omega^2 w\\| = \\|v\\| + \\|w\\|$ using $\\|\\omega\\| = \\|\\omega^2\\| = 1$. The other two inequalities follow by multiplying the equilateral identity by $\\omega$ and $\\omega^2$ (using $\\omega^3 = 1$), which cyclically permutes the roles of $a, b, c$.",
+    "keyInsights": [
+      "An equilateral triangle is captured exactly by the single algebraic relation a + ω·b + ω²·c = 0, where ω is a primitive cube root of unity. This is one factor of the symmetric condition a² + b² + c² = ab + bc + ca = (a + ωb + ω²c)(a + ω²b + ωc).",
+      "The whole theorem rests on one cancellation: for any z, (z-a) + ω(z-b) + ω²(z-c) = z·(1+ω+ω²) - (a+ωb+ω²c) = 0, because both 1+ω+ω² and a+ωb+ω²c vanish.",
+      "‖ω‖ = 1 need not be assumed — it is forced by ω² + ω + 1 = 0 via ω³ = 1 and a real cube-root argument. This keeps the hypotheses minimal.",
+      "All three triangle inequalities come from a single rotation lemma: multiplying the equilateral identity by 1, ω, ω² cyclically permutes (a,b,c), so one lemma applied three times yields PA ≤ PB+PC, PB ≤ PC+PA, PC ≤ PA+PB.",
+      "The degenerate case (equality in the triangle inequality) corresponds to ω(z-b) and ω²(z-c) being positively proportional, i.e. P on the circumcircle — the same Ptolemy-equality phenomenon as for cyclic quadrilaterals."
+    ],
+    "prerequisites": [
+      "Complex number arithmetic",
+      "Roots of unity (primitive cube root ω, ω² + ω + 1 = 0)",
+      "Normed fields and the triangle inequality"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Documentation of the setup (plane = ℂ, equilateral triangle as a + ωb + ω²c = 0) and the three-ingredient proof strategy. Imports Mathlib and opens the PompeiuTheorem namespace.",
+      "mathContext": "Provides ℂ as a normed field (norm_mul, norm_pow, norm_add_le) and as a metric space (dist_eq_norm)."
+    },
+    {
+      "id": "norm-omega",
+      "title": "A Primitive Cube Root of Unity Has Norm One",
+      "startLine": 52,
+      "endLine": 66,
+      "summary": "theorem norm_eq_one_of_cube_root: ω² + ω + 1 = 0 implies ‖ω‖ = 1, via ω³ = 1, ‖ω‖³ = 1, and factoring (‖ω‖-1)(‖ω‖²+‖ω‖+1) = 0 with the second factor positive.",
+      "mathContext": "Removes ‖ω‖ = 1 from the hypotheses of the main theorem. The real cube-root argument uses that ‖ω‖²+‖ω‖+1 > 0 for ‖ω‖ ≥ 0."
+    },
+    {
+      "id": "rotation-lemma",
+      "title": "The Rotation Lemma",
+      "startLine": 68,
+      "endLine": 81,
+      "summary": "theorem norm_le_of_rot: if u + ω·v + ω²·w = 0 and ‖ω‖ = 1 then ‖u‖ ≤ ‖v‖ + ‖w‖, via u = -(ωv + ω²w), norm_add_le, and norm_mul.",
+      "mathContext": "This is the engine of Pompeiu's inequality: a 'sum of unit-rotated vectors is zero' bound. Each Pompeiu distance is the norm of one such u."
+    },
+    {
+      "id": "rotation-identity",
+      "title": "The Structural Identity",
+      "startLine": 83,
+      "endLine": 93,
+      "summary": "theorem rotation_identity: for equilateral a + ωb + ω²c = 0 and any z, (z-a) + ω(z-b) + ω²(z-c) = 0 (one linear_combination).",
+      "mathContext": "The geometric heart of the proof: the three displacement vectors close into a triangle. Expresses z·(1+ω+ω²) - (a+ωb+ω²c) = 0."
+    },
+    {
+      "id": "pompeiu-norm",
+      "title": "Pompeiu's Inequality (Norm Form)",
+      "startLine": 95,
+      "endLine": 119,
+      "summary": "theorem pompeiu_norm: the three inequalities ‖z-a‖ ≤ ‖z-b‖+‖z-c‖ (and cyclic). Each is the rotation lemma applied to the equilateral identity multiplied by 1, ω, ω².",
+      "mathContext": "The cyclic versions use ω³ = 1 to rotate (a,b,c). The linear_combination coefficients are z·hω - ω²·heq + (b+cω)·hcube and z·hω - ω·heq + c·hcube."
+    },
+    {
+      "id": "pompeiu-dist",
+      "title": "Pompeiu's Inequality (Distance Form)",
+      "startLine": 121,
+      "endLine": 134,
+      "summary": "theorem pompeiu_dist: the same three inequalities phrased with the metric dist, matching the classical PA ≤ PB + PC. Proved by rewriting dist as norm.",
+      "mathContext": "dist_eq_norm identifies dist z a with ‖z - a‖, connecting the algebraic result to the geometric statement."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "ptolemys-complex-proof",
+      "relationship": "companion",
+      "description": "Both reduce a classical metric theorem to a complex-number identity plus the norm triangle inequality. Ptolemy's complex proof bounds a product of two diagonals; Pompeiu bounds one distance by the sum of the other two. The Pompeiu degeneracy case is exactly the Ptolemy equality for the cyclic quadrilateral PABC."
+    },
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Both exploit the cube roots of unity (ω² + ω + 1 = 0) to turn an equilateral-triangle statement into a one-line rotation identity over ℂ."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "foundational",
+      "description": "Pompeiu's inequality is a direct application of the norm triangle inequality ‖a+b‖ ≤ ‖a‖+‖b‖ to the rotation identity (z-a) + ω(z-b) + ω²(z-c) = 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete complex-number proof of Pompeiu's theorem (inequality form): for an equilateral triangle a + ωb + ω²c = 0 and any point z, the distances ‖z-a‖, ‖z-b‖, ‖z-c‖ satisfy all three triangle inequalities. The proof reduces to the rotation identity (z-a) + ω(z-b) + ω²(z-c) = 0 and the norm triangle inequality, with ‖ω‖ = 1 derived rather than assumed. Five theorems, 0 sorries, 0 axioms.",
+    "implications": "The formalization isolates the algebraic content of Pompeiu's theorem: the equilateral condition is one cube-root relation, and the geometry enters only through the triangle inequality for the modulus. This mirrors the complex-number proofs of Napoleon's and Ptolemy's theorems and makes the role of the cube roots of unity explicit.",
+    "openQuestions": [
+      "Can the degeneracy characterization be formalized: the Pompeiu triangle is degenerate (equality holds) if and only if P lies on the circumcircle of ABC, i.e. exactly the equality case of the triangle inequality where ω(z-b) and ω²(z-c) are positively proportional?",
+      "Does the rotation-identity technique extend to a clean ℂ-proof of the Petr–Douglas–Neumann generalization (regular-polygon analogues using higher roots of unity)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PompeiuTheorem",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/PompeiuTheorem.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "D. Pompeiu",
+      "title": "Une identité entre nombres complexes et un théorème de géométrie élémentaire",
+      "year": "1936",
+      "venue": "Bull. Math. Phys. Ecole Polytech. Bucarest",
+      "note": "Original statement and rotation proof of the theorem"
+    },
+    {
+      "authors": "T. Andreescu, D. Andrica",
+      "title": "Complex Numbers from A to ... Z",
+      "year": "2014",
+      "venue": "Birkhäuser",
+      "note": "Modern complex-number treatment of Pompeiu's theorem and related equilateral-triangle identities"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "pompeiu_norm",
+      "type": "core",
+      "description": "For an equilateral triangle a + ωb + ω²c = 0 and any point z, the distances ‖z-a‖, ‖z-b‖, ‖z-c‖ satisfy all three triangle inequalities",
+      "leanType": "{ω a b c z : ℂ} → ω^2 + ω + 1 = 0 → a + ω*b + ω^2*c = 0 → ‖z-a‖ ≤ ‖z-b‖+‖z-c‖ ∧ ‖z-b‖ ≤ ‖z-c‖+‖z-a‖ ∧ ‖z-c‖ ≤ ‖z-a‖+‖z-b‖"
+    },
+    {
+      "name": "rotation_identity",
+      "type": "core",
+      "description": "The structural identity: for equilateral a + ωb + ω²c = 0 and any z, (z-a) + ω(z-b) + ω²(z-c) = 0",
+      "leanType": "{ω a b c z : ℂ} → ω^2 + ω + 1 = 0 → a + ω*b + ω^2*c = 0 → (z-a) + ω*(z-b) + ω^2*(z-c) = 0"
+    },
+    {
+      "name": "pompeiu_dist",
+      "type": "core",
+      "description": "Pompeiu's inequality in metric form: dist z a ≤ dist z b + dist z c (and cyclic)",
+      "leanType": "{ω a b c z : ℂ} → ω^2 + ω + 1 = 0 → a + ω*b + ω^2*c = 0 → dist z a ≤ dist z b + dist z c ∧ dist z b ≤ dist z c + dist z a ∧ dist z c ≤ dist z a + dist z b"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Formalizes **Pompeiu's theorem** (inequality form): for an equilateral triangle `ABC` and any point `P`, the distances `PA, PB, PC` satisfy all three triangle inequalities — i.e. they are the side lengths of a (possibly degenerate) triangle, the *Pompeiu triangle*.

The complex-number proof:
- Model the plane as `ℂ`; encode an equilateral triangle of one orientation by the cube-root relation `a + ω·b + ω²·c = 0`, where `ω² + ω + 1 = 0`.
- Key cancellation: for any `z`, `(z-a) + ω(z-b) + ω²(z-c) = z·(1+ω+ω²) − (a+ωb+ω²c) = 0`.
- Hence `z-a = −(ω(z-b) + ω²(z-c))`, and since `‖ω‖ = ‖ω²‖ = 1`, the norm triangle inequality gives `‖z-a‖ ≤ ‖z-b‖ + ‖z-c‖`. The cyclic inequalities follow by multiplying the equilateral identity by `ω`, `ω²` (using `ω³ = 1`).
- `‖ω‖ = 1` is **derived** from `ω²+ω+1=0` (via `ω³=1`), not assumed.

`Proofs/PompeiuTheorem.lean` — 5 theorems, **0 sorries, 0 axioms**:
`norm_eq_one_of_cube_root`, `norm_le_of_rot`, `rotation_identity`, `pompeiu_norm`, `pompeiu_dist`.

## Test plan
- [x] Build-verified: `./proofs/scripts/docker-build.sh Proofs.PompeiuTheorem` → `✔ [7743/7743] Built Proofs.PompeiuTheorem`, exit 0, no warnings/errors.
- [x] Registered in `Proofs.lean` (alphabetical, single import line).
- [x] Gallery entry `src/data/proofs/pompeiu-theorem-oq-01/` (meta.json + annotations.json), valid JSON.
- [x] Knowledge recorded in `research/problems/pompeiu-theorem-oq-01/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)