### PR TITLE
research(pompeiu-theorem-oq-01): Pompeiu's theorem, build-verified 0/0

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2729,6 +2729,7 @@ import Proofs.PlatonicSolids
 import Proofs.PlatonicSolidsOQ01
 import Proofs.PlatonicSolidsOQ02
 import Proofs.PoincareConjecture
+import Proofs.PompeiuTheoremOQ01
 import Proofs.PowerMeanCrossZeroOQ
 import Proofs.PowerMeanLimitOQ
 import Proofs.PowerMeanMonotoneOQ

--- a/proofs/Proofs/PompeiuTheoremOQ01.lean
+++ b/proofs/Proofs/PompeiuTheoremOQ01.lean
@@ -1,0 +1,96 @@
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+
+/-!
+# Pompeiu's theorem (pompeiu-theorem-oq-01)
+
+Let `ABC` be an equilateral triangle (vertices modelled as complex numbers `a, b, c`) and let
+`P` be an arbitrary point of the plane. Pompeiu's theorem states that the three distances
+`PA, PB, PC` satisfy the triangle inequality, i.e. they are the side lengths of a (possibly
+degenerate) triangle.
+
+The proof rests on a single algebraic identity over `ℂ`:
+
+    (P - A)(B - C) + (P - B)(C - A) + (P - C)(A - B) = 0.            (`pompeiu_identity`)
+
+This is a `ring` fact for *any* four complex numbers. Taking norms, the three summands have
+norms `PA·‖B-C‖`, `PB·‖C-A‖`, `PC·‖A-B‖`. Three complex numbers summing to zero have norms
+satisfying the triangle inequality (`norm_le_of_add_eq_zero`), because each equals minus the
+sum of the other two. For an *equilateral* triangle the three side lengths `‖A-B‖ = ‖B-C‖ =
+‖C-A‖` coincide, so after cancelling the common positive side length we obtain the triangle
+inequality on `PA, PB, PC` directly.
+
+The whole argument is elementary and fully machine-checked: no axioms, no `sorry`.
+
+Not a named Mathlib result.
+-/
+
+namespace PompeiuTheoremOQ01
+
+open Complex
+
+/-- **Pompeiu identity.** For *any* four complex numbers the three products vanish in sum.
+This is the algebraic heart of Pompeiu's theorem. -/
+theorem pompeiu_identity (a b c p : ℂ) :
+    (p - a) * (b - c) + (p - b) * (c - a) + (p - c) * (a - b) = 0 := by
+  ring
+
+/-- If three complex numbers sum to zero, the norm of any one is at most the sum of the norms
+of the other two (the triangle inequality for a closed vector triangle). -/
+theorem norm_le_of_add_eq_zero {z₁ z₂ z₃ : ℂ} (h : z₁ + z₂ + z₃ = 0) :
+    ‖z₁‖ ≤ ‖z₂‖ + ‖z₃‖ := by
+  have hz : z₁ = -(z₂ + z₃) := by linear_combination h
+  rw [hz, norm_neg]
+  exact norm_add_le z₂ z₃
+
+/-- **Pompeiu's theorem.** For an equilateral triangle `a, b, c` (all side lengths equal to the
+common positive value `‖a - b‖ = ‖b - c‖ = ‖c - a‖`) and an arbitrary point `p`, the distances
+`PA = ‖p - a‖`, `PB = ‖p - b‖`, `PC = ‖p - c‖` satisfy the triangle inequality `PA ≤ PB + PC`.
+By symmetry the other two inequalities hold as well (see `pompeiu_triangle_inequalities`). -/
+theorem pompeiu_dist_le
+    (a b c p : ℂ)
+    (hab : ‖a - b‖ = ‖b - c‖) (hbc : ‖b - c‖ = ‖c - a‖)
+    (hpos : 0 < ‖b - c‖) :
+    ‖p - a‖ ≤ ‖p - b‖ + ‖p - c‖ := by
+  -- The three closed-triangle summands sum to zero (Pompeiu identity).
+  have hkey := norm_le_of_add_eq_zero (pompeiu_identity a b c p)
+  -- Rewrite each norm as distance · side length, using the equilateral hypotheses.
+  rw [norm_mul, norm_mul, norm_mul] at hkey
+  -- Express every side length as ‖b - c‖.
+  have h1 : ‖b - c‖ = ‖b - c‖ := rfl
+  have h2 : ‖c - a‖ = ‖b - c‖ := hbc.symm
+  have h3 : ‖a - b‖ = ‖b - c‖ := hab.trans h1
+  rw [h2, h3] at hkey
+  -- hkey : ‖p - a‖ * ‖b - c‖ ≤ ‖p - b‖ * ‖b - c‖ + ‖p - c‖ * ‖b - c‖
+  have hkey' : ‖p - a‖ * ‖b - c‖ ≤ (‖p - b‖ + ‖p - c‖) * ‖b - c‖ := by
+    rw [add_mul]; exact hkey
+  exact le_of_mul_le_mul_right hkey' hpos
+
+/-- **Pompeiu's theorem (full statement).** For an equilateral triangle and an arbitrary point
+`p`, the three distances `PA, PB, PC` satisfy all three triangle inequalities; hence they are
+the side lengths of a (possibly degenerate) triangle. -/
+theorem pompeiu_triangle_inequalities
+    (a b c p : ℂ)
+    (hab : ‖a - b‖ = ‖b - c‖) (hbc : ‖b - c‖ = ‖c - a‖)
+    (hpos : 0 < ‖b - c‖) :
+    ‖p - a‖ ≤ ‖p - b‖ + ‖p - c‖ ∧
+    ‖p - b‖ ≤ ‖p - a‖ + ‖p - c‖ ∧
+    ‖p - c‖ ≤ ‖p - a‖ + ‖p - b‖ := by
+  -- The common side length and positivity, available in every cyclic relabelling.
+  have hbc' : ‖b - c‖ = ‖c - a‖ := hbc
+  have hca' : ‖c - a‖ = ‖a - b‖ := hbc.symm.trans hab.symm
+  have hposca : 0 < ‖c - a‖ := hbc ▸ hpos
+  have hposab : 0 < ‖a - b‖ := by rw [hab]; exact hpos
+  refine ⟨pompeiu_dist_le a b c p hab hbc hpos, ?_, ?_⟩
+  · -- PB ≤ PA + PC : relabel (a,b,c) → (b,c,a)
+    have := pompeiu_dist_le b c a p hbc' hca' hposca
+    -- this : ‖p - b‖ ≤ ‖p - c‖ + ‖p - a‖
+    linarith [this]
+  · -- PC ≤ PA + PB : relabel (a,b,c) → (c,a,b)
+    have hca'' : ‖c - a‖ = ‖a - b‖ := hca'
+    have hab'' : ‖a - b‖ = ‖b - c‖ := hab
+    have := pompeiu_dist_le c a b p hca'' hab'' hposab
+    -- this : ‖p - c‖ ≤ ‖p - a‖ + ‖p - b‖
+    linarith [this]
+
+end PompeiuTheoremOQ01

--- a/research/problems/pompeiu-theorem-oq-01/knowledge.md
+++ b/research/problems/pompeiu-theorem-oq-01/knowledge.md
@@ -1,0 +1,39 @@
+# Pompeiu's Theorem (pompeiu-theorem-oq-01)
+
+**Status:** COMPLETED — build-verified 0 sorries / 0 axioms.
+
+## Statement
+For an equilateral triangle `ABC` and an arbitrary point `P`, the distances `PA, PB, PC`
+satisfy the triangle inequality (they are side lengths of a possibly degenerate triangle).
+
+## Proof Summary
+Model points as complex numbers. The entire argument rests on one algebraic identity:
+
+    (P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0     (pure `ring` fact for any 4 complex numbers)
+
+The three summands therefore form a closed vector triangle in ℂ. Three complex numbers
+summing to zero have norms obeying the triangle inequality (`norm_le_of_add_eq_zero`, one line
+via `norm_add_le` + `norm_neg`). Taking norms gives `PA·s ≤ PB·s + PC·s` where `s` is the
+common side length of the equilateral triangle (`norm_mul` splits each product); cancelling the
+positive `s` yields `PA ≤ PB + PC`. The other two inequalities follow by cyclic relabelling.
+
+## Files
+- `proofs/Proofs/PompeiuTheoremOQ01.lean` (96 lines, 4 theorems, 0 defs)
+- `src/data/proofs/pompeiu-theorem-oq-01/{meta.json,annotations.json}`
+- Registered in `proofs/Proofs.lean`
+
+## Key Lemmas
+- `pompeiu_identity` — the closed-triangle identity (ring)
+- `norm_le_of_add_eq_zero` — zero sum ⟹ triangle inequality on norms
+- `pompeiu_dist_le` — single inequality PA ≤ PB + PC
+- `pompeiu_triangle_inequalities` — all three, by cyclic symmetry
+
+## Session 2026-06-16 (Session 1) — FRESH, COMPLETED
+Picked from clean plane-geometry pool. Numerically verified identity + inequality in Python,
+wrote the Lean proof, docker-build green `[3062/3062]` after fixing a left-/right-associativity
+mismatch in the zero-sum hypothesis. Registered + gallery data. PR opened.
+
+## Possible Follow-ups (not pursued)
+- Degeneracy characterization: equality (degenerate triangle) iff `P` lies on the circumcircle.
+- Generalization to the inequality form of Ptolemy for non-equilateral triangles (weighted
+  distances `PA·a, PB·b, PC·c`).

--- a/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-pompeiu-identity",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": { "startLine": 36, "endLine": 39 },
+    "type": "insight",
+    "title": "The Pompeiu Identity: A Closed Vector Triangle",
+    "content": "The entire theorem reduces to the algebraic identity (P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0, which holds for ANY four complex numbers and is proved by `ring`. The P-terms cancel because (B-C)+(C-A)+(A-B) = 0, and the remaining constant terms also telescope to zero. Geometrically this says the three vectors (P-A)(B-C), (P-B)(C-A), (P-C)(A-B) form a closed triangle in the complex plane, so their lengths obey the triangle inequality. This single identity is what makes Pompeiu's theorem an elementary consequence rather than a delicate geometric argument.",
+    "mathContext": "$(P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0$. The coefficient of $P$ is $(B-C)+(C-A)+(A-B)=0$; the remaining terms $-A(B-C)-B(C-A)-C(A-B) = -(AB-AC+BC-AB+CA-CB) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["complex numbers", "vector triangle", "algebraic identity", "ring tactic"],
+    "prerequisites": ["complex arithmetic", "ring tactic"]
+  },
+  {
+    "id": "ann-norm-closed-triangle",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": { "startLine": 43, "endLine": 49 },
+    "type": "insight",
+    "title": "Norms of a Zero Sum Satisfy the Triangle Inequality",
+    "content": "If z₁ + z₂ + z₃ = 0 then ‖z₁‖ ≤ ‖z₂‖ + ‖z₃‖. The proof is one line: z₁ = -(z₂ + z₃), so ‖z₁‖ = ‖z₂ + z₃‖ ≤ ‖z₂‖ + ‖z₃‖ by the ordinary triangle inequality (`norm_add_le`) together with `norm_neg`. This is the abstract reason a closed vector polygon's side lengths obey the polygon inequality, specialized to three sides.",
+    "mathContext": "$z_1 = -(z_2+z_3) \\Rightarrow \\|z_1\\| = \\|z_2+z_3\\| \\le \\|z_2\\| + \\|z_3\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangle inequality", "normed space", "polygon inequality"],
+    "prerequisites": ["norm_add_le", "norm_neg"]
+  },
+  {
+    "id": "ann-equilateral-cancellation",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": { "startLine": 56, "endLine": 73 },
+    "type": "insight",
+    "title": "Why Equilateral Is Essential: Cancelling the Side Length",
+    "content": "Taking norms of the three Pompeiu summands gives ‖P-A‖·‖B-C‖, ‖P-B‖·‖C-A‖, ‖P-C‖·‖A-B‖ — each a distance times a side length. For a general triangle these side factors differ and no clean inequality on the distances survives. The equilateral hypothesis ‖A-B‖ = ‖B-C‖ = ‖C-A‖ makes all three side factors equal to one common positive value s, which then cancels: from PA·s ≤ PB·s + PC·s we divide by s > 0 to get PA ≤ PB + PC. The three cyclic inequalities follow by relabelling the vertices.",
+    "mathContext": "Equilateral: $\\|A-B\\|=\\|B-C\\|=\\|C-A\\|=s>0$. Then $PA\\cdot s \\le PB\\cdot s + PC\\cdot s \\Rightarrow PA \\le PB + PC$ (and cyclically).",
+    "significance": "key",
+    "relatedConcepts": ["equilateral triangle", "norm multiplicativity", "cancellation", "cyclic symmetry"],
+    "prerequisites": ["norm_mul", "le_of_mul_le_mul_right"]
+  }
+]

--- a/src/data/proofs/pompeiu-theorem-oq-01/meta.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/meta.json
@@ -1,0 +1,48 @@
+{
+  "id": "pompeiu-theorem-oq-01",
+  "title": "Pompeiu's Theorem",
+  "slug": "pompeiu-theorem-oq-01",
+  "description": "For an equilateral triangle ABC and an arbitrary point P in the plane, the three distances PA, PB, PC satisfy the triangle inequality — they are the side lengths of a (possibly degenerate) triangle. The proof models the points as complex numbers and rests on the algebraic identity (P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0: three complex numbers summing to zero have norms obeying the triangle inequality, and for an equilateral triangle the common side length cancels.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pompeiu%27s_theorem",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PompeiuTheoremOQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "equilateral-triangle",
+      "complex-numbers",
+      "triangle-inequality",
+      "plane-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "",
+    "lineCount": 96,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "instanceCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_add_le",
+        "description": "The triangle inequality for the norm on a normed space: ‖x + y‖ ≤ ‖x‖ + ‖y‖. Combined with norm_neg, this gives the central lemma norm_le_of_add_eq_zero: if z₁ + z₂ + z₃ = 0 then ‖z₁‖ ≤ ‖z₂‖ + ‖z₃‖, because z₁ = -(z₂ + z₃).",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      },
+      {
+        "theorem": "norm_mul",
+        "description": "Multiplicativity of the norm on a normed field: ‖x * y‖ = ‖x‖ * ‖y‖. Applied over ℂ to split each Pompeiu summand ‖(P-A)(B-C)‖ into the product of a distance ‖P-A‖ and a side length ‖B-C‖, so the equilateral hypothesis (equal side lengths) can be factored out.",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Pompeiu identity (P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0 over ℂ, the algebraic heart of the theorem (pure ring fact)",
+      "norm_le_of_add_eq_zero: three complex numbers summing to zero have norms satisfying the triangle inequality",
+      "pompeiu_dist_le: PA ≤ PB + PC for an equilateral triangle, via cancellation of the common side length",
+      "pompeiu_triangle_inequalities: all three triangle inequalities on PA, PB, PC by cyclic relabelling"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Formalizes **Pompeiu's theorem**: for an equilateral triangle `ABC` and an arbitrary point `P` in the plane, the three distances `PA, PB, PC` satisfy the triangle inequality — they are the side lengths of a (possibly degenerate) triangle.

Fully machine-checked: **0 sorries, 0 axioms**. Docker build green `✔ [3062/3062]`.

## Approach
Points modelled as complex numbers. The whole theorem reduces to one algebraic identity (a pure `ring` fact for any four complex numbers):

```
(P-A)(B-C) + (P-B)(C-A) + (P-C)(A-B) = 0
```

so the three summands form a closed vector triangle in ℂ. Three complex numbers summing to zero have norms obeying the triangle inequality (`norm_le_of_add_eq_zero`, one line via `norm_add_le` + `norm_neg`). Taking norms turns each summand into `distance × side length`; for an equilateral triangle the common side length `s > 0` cancels, giving `PA ≤ PB + PC`. The two remaining inequalities follow by cyclic relabelling.

## Theorems
- `pompeiu_identity` — the closed-triangle identity
- `norm_le_of_add_eq_zero` — zero sum ⟹ triangle inequality on norms
- `pompeiu_dist_le` — `PA ≤ PB + PC`
- `pompeiu_triangle_inequalities` — all three inequalities

## Files
- `proofs/Proofs/PompeiuTheoremOQ01.lean` (new, 96 lines)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/pompeiu-theorem-oq-01/{meta.json,annotations.json}` (gallery)
- `research/problems/pompeiu-theorem-oq-01/knowledge.md`

Not a named Mathlib result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)