### PR TITLE
audit(tracker): record lebesgue-measure-oq-01-oq-01-oq-02-oq-01 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15552,6 +15552,12 @@
       "lastAudited": "2026-06-16T07:56:56Z",
       "result": "clean",
       "issues": []
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T14:33:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: `lebesgue-measure-oq-01-oq-01-oq-02-oq-01` (Thomae's Function is Riemann Integrable, integral 0)

### Checks
| Check | meta.json | Lean source | Verdict |
|-------|-----------|-------------|---------|
| sorries | 0 | 0 (`grep sorry` hit the word "sorries" in docstring line 23) | ✅ match |
| axioms | 0 | 0 | ✅ match |
| True stubs | — | 0 | ✅ none |
| theorems | 5 | 5 | ✅ match |
| badge | `mathlib` | Tier B (core via `measure_mono_null`, `integrable_zero`, `intervalIntegral.integral_congr_ae`) | ✅ correct |
| status | `formalized` | build-pending / orphan (not registered in `Proofs.lean`, not kernel-checked) | ✅ correctly conservative |

### Notes
- The entry honestly documents **BUILD PENDING** in `assumptions` and deliberately under-claims (`formalized`, not `verified`) for an unbuilt 0-sorry draft — the safe direction for credibility.
- No delegation opacity / axiom masking / inequality-vs-theorem inflation. Mathlib reliance is disclosed up front.

No issues found. Single-entry tracker update on fresh `origin/main`.

---
Discovered during gallery integrity audit.