### PR TITLE
research(steiner-lehmus-theorem-oq-01): build-verified algebraic core (0/0)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2903,6 +2903,7 @@ import Proofs.Sqrt2PlusSqrt3IrrationalOQ03Aristotle
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
+import Proofs.SteinerLehmusTheoremOQ01
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula

--- a/proofs/Proofs/SteinerLehmusTheoremOQ01.lean
+++ b/proofs/Proofs/SteinerLehmusTheoremOQ01.lean
@@ -1,0 +1,84 @@
+import Mathlib.Tactic
+
+/-!
+# The Steiner–Lehmus theorem (steiner-lehmus-theorem-oq-01)
+
+If a triangle has two **internal angle bisectors of equal length**, then it is isosceles.
+Concretely, if the bisectors drawn from vertices `B` and `C` have the same length, then the
+sides opposite to them are equal, `b = c`.
+
+We work with the algebraic core of the theorem. Writing `a, b, c > 0` for the side lengths of
+the triangle, the squared length of the internal bisector from `B` (which meets side `b = CA`)
+is given by the classical bisector-length formula
+
+    w_b² = a·c·(1 - (b / (a + c))²),
+
+and symmetrically `w_c² = a·b·(1 - (c / (a + b))²)`. The Steiner–Lehmus theorem reduces to the
+purely algebraic implication
+
+    w_b² = w_c²  ⟹  b = c        (for positive reals `a, b, c`).
+
+The decisive fact is the exact factorisation
+
+    w_b² - w_c²
+      = -a·(b - c)·(a + b + c)·(a³ + a²b + a²c + 3abc + b²c + bc²) / ((a + b)² (a + c)²),
+
+in which the polynomial cofactor
+`a·(a + b + c)·(a³ + a²b + a²c + 3abc + b²c + bc²)` is **strictly positive** for positive
+`a, b, c` (every monomial is positive). Hence `w_b² = w_c²` forces `b - c = 0`.
+
+The argument is elementary real algebra: clear denominators, expose the factorisation with
+`linear_combination`/`ring`, and finish with positivity. No triangle inequality is even needed —
+positivity of the three side lengths suffices. The proof is fully machine-checked, with no
+axioms and no `sorry`.
+
+Not a named Mathlib result.
+-/
+
+namespace SteinerLehmusTheoremOQ01
+
+/-- Squared length of the internal angle bisector from the vertex opposite side `b`, i.e. the
+bisector from `B` meeting side `CA`, expressed through the classical formula
+`w_b² = a·c·(1 - (b/(a+c))²)`. -/
+noncomputable def bisectorSq (a b c : ℝ) : ℝ := a * c * (1 - (b / (a + c)) ^ 2)
+
+/-- The squared bisector length, after clearing the denominator `(a + c)²`. Used to turn the
+hypothesis into a polynomial identity. -/
+theorem bisectorSq_clear (a b c : ℝ) (hac : a + c ≠ 0) :
+    bisectorSq a b c * (a + c) ^ 2 = a * c * ((a + c) ^ 2 - b ^ 2) := by
+  unfold bisectorSq
+  field_simp
+
+/-- **Steiner–Lehmus (algebraic core).** For positive side lengths `a, b, c`, equal internal
+bisector lengths from `B` and `C` force the opposite sides to be equal, `b = c`. -/
+theorem steiner_lehmus (a b c : ℝ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (heq : bisectorSq a b c = bisectorSq a c b) : b = c := by
+  have hac : a + c ≠ 0 := by positivity
+  have hab : a + b ≠ 0 := by positivity
+  -- Clear both denominators: the hypothesis becomes a polynomial equation.
+  have hcleared :
+      a * c * ((a + c) ^ 2 - b ^ 2) * (a + b) ^ 2
+        = a * b * ((a + b) ^ 2 - c ^ 2) * (a + c) ^ 2 := by
+    have hB : bisectorSq a b c * (a + c) ^ 2 = a * c * ((a + c) ^ 2 - b ^ 2) :=
+      bisectorSq_clear a b c hac
+    have hC : bisectorSq a c b * (a + b) ^ 2 = a * b * ((a + b) ^ 2 - c ^ 2) :=
+      bisectorSq_clear a c b hab
+    have key : (bisectorSq a b c) * ((a + c) ^ 2 * (a + b) ^ 2)
+        = (bisectorSq a c b) * ((a + c) ^ 2 * (a + b) ^ 2) := by rw [heq]
+    linear_combination (-(a + b) ^ 2) * hB + (a + c) ^ 2 * hC + key
+  -- Exact factorisation: w_b² - w_c² ∝ (b - c) times a positive cofactor.
+  have hfact :
+      (b - c) * (a * (a + b + c) *
+        (a ^ 3 + a ^ 2 * b + a ^ 2 * c + 3 * a * b * c + b ^ 2 * c + b * c ^ 2)) = 0 := by
+    linear_combination (-1 : ℝ) * hcleared
+  -- The cofactor is strictly positive, so the factor `b - c` must vanish.
+  have hpos : 0 < a * (a + b + c) *
+      (a ^ 3 + a ^ 2 * b + a ^ 2 * c + 3 * a * b * c + b ^ 2 * c + b * c ^ 2) := by
+    positivity
+  have hbc : b - c = 0 := by
+    rcases mul_eq_zero.mp hfact with h | h
+    · exact h
+    · exact absurd h (ne_of_gt hpos)
+  linarith
+
+end SteinerLehmusTheoremOQ01

--- a/research/problems/steiner-lehmus-theorem-oq-01/knowledge.md
+++ b/research/problems/steiner-lehmus-theorem-oq-01/knowledge.md
@@ -1,0 +1,56 @@
+# steiner-lehmus-theorem-oq-01
+
+**Statement.** If a triangle has two internal angle bisectors of equal length, then it is
+isosceles: equal bisectors from `B` and `C` force `b = c`.
+
+**Status:** COMPLETED (build-verified, 0 sorries, 0 axioms).
+
+## Summary
+
+The Steiner–Lehmus theorem reduces, via the classical internal-bisector-length formula, to a
+pure real-algebra implication over positive reals `a, b, c`. Using
+
+    w_b² = a·c·(1 - (b/(a+c))²),    w_c² = a·b·(1 - (c/(a+b))²),
+
+the theorem becomes: `w_b² = w_c² ⟹ b = c` for `a, b, c > 0`. The decisive identity is the
+exact factorisation (sympy-verified, then `ring`-checked in Lean):
+
+    w_b² - w_c²
+      = -a·(b - c)·(a + b + c)·(a³ + a²b + a²c + 3abc + b²c + bc²) / ((a+b)²(a+c)²).
+
+The cofactor `a·(a+b+c)·(a³ + a²b + a²c + 3abc + b²c + bc²)` is a sum of positive monomials,
+hence strictly positive for positive `a, b, c`. So `w_b² = w_c²` forces `b - c = 0`.
+No triangle inequality is needed — positivity of the three side lengths suffices.
+
+## Session 2026-06-16 (Session 1) — FRESH
+
+**Mode:** FRESH
+**Outcome:** completed
+
+### What I Did
+- Claimed a stale dead-pid lock (prior claimant crashed; no PR/Lean file produced).
+- Verified the bisector-difference factorisation in sympy: the cofactor is a sum of positive
+  monomials, giving the equality-case-free positivity needed for the implication.
+- Formalised `SteinerLehmusTheoremOQ01.lean`:
+  - `bisectorSq a b c = a*c*(1 - (b/(a+c))^2)` (noncomputable, real division).
+  - `bisectorSq_clear`: denominator-cleared form, `field_simp; ring`.
+  - `steiner_lehmus`: main theorem via two exact `linear_combination` steps
+    (cleared polynomial equation, then `(b-c)·cofactor = 0`) and `positivity`.
+- Registered the import in `proofs/Proofs.lean`; build-verified by module name in docker.
+
+### Key Findings
+- The whole theorem is denominator-clearing + one polynomial factorisation + positivity.
+- `linear_combination` coefficients derived by hand and confirmed in sympy:
+  `hcleared = -(a+b)²·hB + (a+c)²·hC + key`; `hfact = -1·hcleared`.
+- Treating `bisectorSq …` as a `ring` atom lets the cleared-equation combination go through
+  without unfolding inside the main proof.
+
+### Files Modified
+- `proofs/Proofs/SteinerLehmusTheoremOQ01.lean` (new)
+- `proofs/Proofs.lean` (import registration)
+
+### Next Steps
+- Enricher: add gallery `meta.json` + annotations.
+- Possible follow-up OQ: the converse / the equal-length comparison `w_b ⋛ w_c ⟺ b ⋛ c`
+  (monotonicity of bisector length in the opposite side), which the same factorisation gives
+  directly from the sign of `b - c`.


### PR DESCRIPTION
## Summary
Formalizes the **Steiner–Lehmus theorem**: if a triangle has two internal angle bisectors of equal length, it is isosceles. Concretely, equal bisectors from `B` and `C` force `b = c`.

The theorem reduces, via the classical internal-bisector-length formula
`w_b² = a·c·(1 - (b/(a+c))²)`, to a **pure real-algebra implication** over positive reals `a, b, c`:

> `w_b² = w_c²  ⟹  b = c`.

The decisive identity is the exact factorisation (verified in sympy, then `ring`-checked in Lean):

```
w_b² - w_c² = -a·(b-c)·(a+b+c)·(a³ + a²b + a²c + 3abc + b²c + bc²) / ((a+b)²(a+c)²)
```

The polynomial cofactor `a·(a+b+c)·(a³+a²b+a²c+3abc+b²c+bc²)` is a sum of positive monomials, hence strictly positive for positive side lengths. So `w_b²=w_c²` forces `b-c=0`. No triangle inequality is needed — positivity of the three side lengths suffices.

## Proof structure
- `bisectorSq` — squared internal-bisector length (noncomputable, real division).
- `bisectorSq_clear` — denominator-cleared form via `field_simp`.
- `steiner_lehmus` — two exact `linear_combination` steps (cleared polynomial equation, then `(b-c)·cofactor = 0`) finished by `positivity`.

## Verification
- `docker-build.sh Proofs.SteinerLehmusTheoremOQ01` → `✔ [3058/3058]`.
- **0 sorries, 0 axioms.**
- `linear_combination` coefficients independently confirmed symbolically.

## Files
- `proofs/Proofs/SteinerLehmusTheoremOQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `research/problems/steiner-lehmus-theorem-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)