### PR TITLE
research(carnot-theorem-oq-01): Carnot's theorem angle form (0 axioms, 0 sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -397,6 +397,7 @@ import Proofs.CantorsTheoremOQ01OQ03
 import Proofs.CantorsTheoremOQ01OQ03OQ04
 import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
+import Proofs.CarnotTheorem
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral
 import Proofs.CauchySchwarzIntegralOQ01

--- a/proofs/Proofs/CarnotTheorem.lean
+++ b/proofs/Proofs/CarnotTheorem.lean
@@ -1,0 +1,81 @@
+import Mathlib
+
+/-
+# Carnot's Theorem (angle form)
+
+For a triangle with interior angles `A, B, C` (so `A + B + C = π`), Carnot's
+theorem states that the signed distances from the circumcenter `O` to the three
+sides sum to `R + r`, where `R` is the circumradius and `r` the inradius.
+Dividing by `R` and using the standard chord-distance identity (the signed
+distance from `O` to the side opposite an angle `θ` is `R cos θ`) this is
+equivalent to the purely trigonometric statement
+
+  `cos A + cos B + cos C = 1 + r / R`.
+
+Since `r / R = 4 sin(A/2) sin(B/2) sin(C/2)` for any triangle (Euler's formula
+for the inradius), the analytic core of Carnot's theorem is the identity
+
+  `cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`,
+
+valid for any reals with `A + B + C = π`. This file proves that identity
+axiom-free from the FTC-free trigonometric primitives in Mathlib, together with
+the companion fundamental cosine identity
+
+  `cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1`.
+
+**No axioms, no sorries.**
+-/
+
+open Real
+
+namespace CarnotTheorem
+
+/-- Double-angle in the `1 - 2 sin²` form. -/
+private theorem cos_two_mul_sin (x : ℝ) : Real.cos (2 * x) = 1 - 2 * Real.sin x ^ 2 := by
+  rw [Real.cos_two_mul']
+  linear_combination Real.cos_sq_add_sin_sq x
+
+/-- **Carnot's theorem (angle form).**  For any reals `A, B, C` with
+`A + B + C = π`,
+`cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`.
+
+Equivalently `cos A + cos B + cos C = 1 + r/R` for a triangle with circumradius
+`R` and inradius `r`, the form of Carnot's theorem obtained by summing the
+signed circumcenter-to-side distances `R cos A + R cos B + R cos C = R + r`. -/
+theorem carnot_cos_sum (A B C : ℝ) (h : A + B + C = π) :
+    Real.cos A + Real.cos B + Real.cos C
+      = 1 + 4 * Real.sin (A / 2) * Real.sin (B / 2) * Real.sin (C / 2) := by
+  -- Express `sin (C/2)` through the half-angles of `A` and `B`.
+  have hsc : Real.sin (C / 2)
+      = Real.cos (A / 2) * Real.cos (B / 2) - Real.sin (A / 2) * Real.sin (B / 2) := by
+    have hch : C / 2 = π / 2 - (A / 2 + B / 2) := by linarith
+    rw [hch, Real.sin_pi_div_two_sub, Real.cos_add]
+  -- Rewrite each cosine in `1 - 2 sin²(·/2)` form.
+  have hcA : Real.cos A = 1 - 2 * Real.sin (A / 2) ^ 2 := by
+    have h := cos_two_mul_sin (A / 2); rwa [show 2 * (A / 2) = A by ring] at h
+  have hcB : Real.cos B = 1 - 2 * Real.sin (B / 2) ^ 2 := by
+    have h := cos_two_mul_sin (B / 2); rwa [show 2 * (B / 2) = B by ring] at h
+  have hcC : Real.cos C = 1 - 2 * Real.sin (C / 2) ^ 2 := by
+    have h := cos_two_mul_sin (C / 2); rwa [show 2 * (C / 2) = C by ring] at h
+  rw [hcA, hcB, hcC, hsc]
+  linear_combination (-2 * Real.cos (B / 2) ^ 2) * Real.sin_sq_add_cos_sq (A / 2)
+    + (2 * (Real.sin (A / 2) ^ 2 - 1)) * Real.sin_sq_add_cos_sq (B / 2)
+
+/-- **Fundamental triangle cosine identity.**  For any reals `A, B, C` with
+`A + B + C = π`,
+`cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1`.
+
+This is the companion polynomial form of Carnot's theorem; it follows by writing
+`C = π - A - B`, so `cos C = -cos(A+B)`, and a `ring` computation modulo the
+Pythagorean identities for `A` and `B`. -/
+theorem carnot_cos_sq_sum (A B C : ℝ) (h : A + B + C = π) :
+    Real.cos A ^ 2 + Real.cos B ^ 2 + Real.cos C ^ 2
+      + 2 * Real.cos A * Real.cos B * Real.cos C = 1 := by
+  have hcC : Real.cos C = -(Real.cos A * Real.cos B - Real.sin A * Real.sin B) := by
+    have hch : C = π - (A + B) := by linarith
+    rw [hch, Real.cos_pi_sub, Real.cos_add]
+  rw [hcC]
+  linear_combination (1 - Real.cos B ^ 2) * Real.sin_sq_add_cos_sq A
+    + (Real.sin A ^ 2) * Real.sin_sq_add_cos_sq B
+
+end CarnotTheorem

--- a/research/problems/carnot-theorem-oq-01/knowledge.md
+++ b/research/problems/carnot-theorem-oq-01/knowledge.md
@@ -1,0 +1,48 @@
+# Knowledge: carnot-theorem-oq-01
+
+## Problem Summary
+Carnot's theorem: for a triangle with circumradius R and inradius r, the signed
+distances from the circumcenter O to the three sides sum to R + r; equivalently
+`cos A + cos B + cos C = 1 + r/R`. The analytic core (using Euler's inradius
+formula `r/R = 4 sin(A/2) sin(B/2) sin(C/2)`) is the trigonometric identity
+
+  `cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`,  for `A + B + C = π`.
+
+## Status
+**COMPLETED** (angle form) — `Proofs/CarnotTheorem.lean`, 0 axioms, 0 sorries, build-verified.
+
+## Session 2026-06-16 (Session 1) — Carnot angle form
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Formalized the angle form of Carnot's theorem as a pure trigonometric identity
+  over reals with `A + B + C = π` (no circumcenter / EuclideanSpace machinery).
+- Proved the companion fundamental cosine identity
+  `cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1`.
+- Registered in `proofs/Proofs.lean`; added gallery entry
+  `src/data/proofs/carnot-theorem-oq-01/meta.json`.
+
+### Key Findings / Technique
+- **Half-angle linearization**: set `a=A/2, b=B/2, c=C/2`, so `a+b+c=π/2` and
+  `c = π/2 - (a+b)`. Then `sin(C/2) = sin(π/2-(a+b)) = cos(a+b) = ca·cb - sa·sb`,
+  removing the third angle.
+- Rewrite each full cosine via `cos(2x) = 1 - 2 sin²x` (derived from Mathlib's
+  `Real.cos_two_mul'` + `Real.cos_sq_add_sin_sq`).
+- The goal then becomes a polynomial identity in `sin(A/2),cos(A/2),sin(B/2),cos(B/2)`
+  closed by a single `linear_combination` of the two Pythagorean identities.
+  Coefficients (sympy-verified):
+    `(-2·cos(B/2)²)·pyth(A/2) + (2·(sin(A/2)²-1))·pyth(B/2)`.
+- Companion identity: `cos C = -cos(A+B)` via `Real.cos_pi_sub`+`Real.cos_add`,
+  then `linear_combination (1-cos²B)·pyth(A) + sin²A·pyth(B)`.
+
+### Files Modified
+- `proofs/Proofs/CarnotTheorem.lean` (new, 81 lines)
+- `proofs/Proofs.lean` (import line)
+- `src/data/proofs/carnot-theorem-oq-01/meta.json` (new)
+
+### Next Steps (follow-ups, optional)
+- Formalize the signed-distance form directly over `EuclideanSpace ℝ (Fin 2)`
+  with an explicit circumcenter; needs Euler's inradius formula
+  `r = 4R sin(A/2) sin(B/2) sin(C/2)` to bridge to the angle form.

--- a/research/problems/carnot-theorem-oq-01/state.md
+++ b/research/problems/carnot-theorem-oq-01/state.md
@@ -1,0 +1,20 @@
+# Research State: carnot-theorem-oq-01
+
+## Current State
+**Phase**: COMPLETED
+**Path**: full
+**Iteration**: 1
+
+## Current Focus
+Angle form of Carnot's theorem formalized and build-verified.
+
+## Active Approach
+Half-angle linearization → polynomial identity → `linear_combination` modulo
+Pythagorean identities. See knowledge.md.
+
+## Deliverable
+`proofs/Proofs/CarnotTheorem.lean` — `CarnotTheorem.carnot_cos_sum` and
+`CarnotTheorem.carnot_cos_sq_sum`, 0 axioms, 0 sorries.
+
+## Blockers
+None for the angle form. Metric (signed-distance) form left as a follow-up.

--- a/src/data/proofs/carnot-theorem-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "carnot-theorem-oq-01",
+  "title": "Carnot's Theorem (angle form)",
+  "slug": "carnot-theorem-oq-01",
+  "description": "For a triangle with angles A, B, C, the signed distances from the circumcenter to the three sides sum to R + r, equivalently cos A + cos B + cos C = 1 + r/R. The analytic core is the identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), proved here axiom-free for any reals with A + B + C = π.",
+  "meta": {
+    "author": "Lazare Carnot (1803)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carnot%27s_theorem_(inradius,_circumradius)",
+    "date": "1803",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CarnotTheorem.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "trigonometry",
+      "circumradius",
+      "inradius",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.cos_two_mul'",
+        "description": "Double-angle identity cos(2x) = cos²x - sin²x",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "Pythagorean identity sin²x + cos²x = 1",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Real.cos_add",
+        "description": "Angle-addition formula for cosine",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Real.cos_pi_sub",
+        "description": "cos(π - x) = -cos x, used to eliminate C = π - A - B",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_pi_div_two_sub",
+        "description": "sin(π/2 - x) = cos x, used to relate sin(C/2) to A/2, B/2",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Formalization of the angle form of Carnot's theorem: cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2) for A + B + C = π",
+      "Half-angle reduction turning the identity into a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2) closed by a single linear_combination modulo the Pythagorean identities",
+      "Companion fundamental triangle cosine identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 81,
+    "assumptions": "0 axioms. 0 sorries. Fully verified. The only hypothesis is the angle-sum relation A + B + C = π characterizing a (possibly degenerate) triangle's angles.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "title": "Double-angle helper",
+      "startLine": 39,
+      "endLine": 43,
+      "description": "The sin-form double-angle identity cos(2x) = 1 - 2 sin²x, derived from Mathlib's cos_two_mul' and the Pythagorean identity.",
+      "summary": "Double-angle helper",
+      "id": "double-angle-helper"
+    },
+    {
+      "title": "Carnot's Theorem — angle form",
+      "startLine": 45,
+      "endLine": 72,
+      "description": "The main identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2). Express sin(C/2) via A/2, B/2 using C/2 = π/2 - (A/2 + B/2); rewrite each cosine in 1 - 2 sin² form; close by linear_combination modulo the Pythagorean identities.",
+      "summary": "Carnot's Theorem — angle form",
+      "id": "carnot-theorem-angle-form"
+    },
+    {
+      "title": "Fundamental triangle cosine identity",
+      "startLine": 74,
+      "endLine": 81,
+      "description": "The companion polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1, via cos C = -cos(A+B) and a linear_combination.",
+      "summary": "Fundamental triangle cosine identity",
+      "id": "fundamental-triangle-cosine-identity"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius is due to Lazare Carnot (1753–1823), the French mathematician, engineer, and politician known as the 'Organizer of Victory' during the French Revolution. It appears in his 1803 work on the geometry of position. The theorem states that, for a triangle with circumradius R and inradius r, the sum of the signed distances from the circumcenter O to the three sides equals R + r. The sign convention is essential: a distance is counted negative when the circumcenter lies on the opposite side of an edge from the triangle's interior, which happens precisely for the side opposite an obtuse angle. With this convention the identity holds for every triangle, acute or obtuse.\n\nDividing the signed-distance form by R, and using that the signed distance from the circumcenter to the side opposite angle θ equals R cos θ (the central angle subtending that side is 2θ), Carnot's theorem becomes the compact trigonometric statement cos A + cos B + cos C = 1 + r/R. Combined with Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2), the analytic heart of the theorem is the pure identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), which holds for any real angles summing to π.",
+    "problemStatement": "**Carnot's theorem (angle form)**: For any reals A, B, C with A + B + C = π, prove\n\n  cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2).\n\nThis is equivalent to the classical statement that the signed distances from the circumcenter to the three sides of a triangle sum to R + r, since cos A + cos B + cos C = 1 + r/R and r/R = 4 sin(A/2) sin(B/2) sin(C/2).",
+    "text": "For a triangle with circumradius R and inradius r, the signed distances from the circumcenter to the three sides sum to R + r; equivalently cos A + cos B + cos C = 1 + r/R.",
+    "proofStrategy": "The proof works entirely with the angle relation A + B + C = π and reduces to a polynomial identity.\n\n1. **Half angles**: Set a = A/2, b = B/2, c = C/2, so a + b + c = π/2 and c = π/2 - (a + b). Then sin(C/2) = sin(π/2 - (a+b)) = cos(a + b) = cos a cos b - sin a sin b, expressing the third half-angle sine through A/2 and B/2.\n\n2. **Cosine reduction**: Rewrite each full-angle cosine as cos(2·) and apply the double-angle identity cos(2x) = 1 - 2 sin²x. The left side becomes 3 - 2(sin²(A/2) + sin²(B/2) + sin²(C/2)).\n\n3. **Polynomial closure**: After substituting sin(C/2), the goal is a polynomial identity in sin(A/2), cos(A/2), sin(B/2), cos(B/2). It is closed by a single linear_combination of the Pythagorean identities sin²(A/2) + cos²(A/2) = 1 and sin²(B/2) + cos²(B/2) = 1.\n\nThe companion identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is proved the same way, using cos C = -cos(A + B) and a linear_combination of the Pythagorean identities for A and B.",
+    "keyInsights": [
+      "**Half-angle linearization**: writing c = π/2 - (a + b) turns sin(C/2) into a polynomial in the sines and cosines of A/2 and B/2, removing the third angle entirely",
+      "**cos(2x) = 1 - 2 sin²x**: the sin-form double angle matches the half-angle products on the right-hand side, so both sides become polynomials in the same four quantities",
+      "**One linear_combination closes it**: modulo the two Pythagorean identities the whole theorem is a single algebraic identity — no case analysis on acute/obtuse is needed because the angle form is sign-agnostic",
+      "**r/R = 4 sin(A/2) sin(B/2) sin(C/2)**: Euler's inradius formula is what connects the proved trigonometric identity to the geometric R + r statement"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions sin and cos",
+      "Double-angle and angle-addition identities",
+      "The Pythagorean identity sin²x + cos²x = 1",
+      "The angle-sum relation A + B + C = π for a triangle"
+    ],
+    "openQuestions": [
+      "Can the signed-distance form (sum of circumcenter-to-side distances = R + r) be formalized directly over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter and inradius?",
+      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the angle form to the metric form?"
+    ]
+  },
+  "conclusion": {
+    "summary": "Carnot's theorem is formalized in its angle form, cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), for any reals summing to π. A half-angle substitution linearizes the third angle and a single linear_combination modulo the Pythagorean identities closes the proof. The companion fundamental cosine identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1 is also established.",
+    "implications": "**Theoretical Significance**: The proof shows that the analytic content of Carnot's theorem is a polynomial identity, independent of the acute/obtuse case split that the signed-distance form requires geometrically. The same half-angle linearization technique applies to the broad family of triangle identities relating cos A + cos B + cos C, the half-angle products, and r/R.",
+    "openQuestions": [
+      "Can the signed-distance form be formalized directly with an explicit circumcenter over EuclideanSpace ℝ (Fin 2)?",
+      "Can Euler's inradius formula r = 4R sin(A/2) sin(B/2) sin(C/2) be formalized to bridge the two forms?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "Both are classical metric results about an arbitrary triangle; the law of cosines relates side lengths to a single angle, while Carnot's theorem packages all three angles into the circumradius/inradius relation R + r."
+    },
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Both reduce a classical triangle theorem to an algebraic identity — Napoleon via complex coordinates and a rotation identity, Carnot via half-angle substitution and a Pythagorean linear_combination."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CarnotTheorem",
+    "lineCount": 81,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CarnotTheorem.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **angle form of Carnot's theorem** for any reals with `A + B + C = π`:

  `cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`

This is the analytic core of Carnot's theorem. The classical statement — the signed distances from the circumcenter `O` to the three sides sum to `R + r` — is equivalent to `cos A + cos B + cos C = 1 + r/R` (the signed distance to the side opposite angle θ is `R cos θ`), and `r/R = 4 sin(A/2) sin(B/2) sin(C/2)` by Euler's inradius formula.

Also proves the companion **fundamental triangle cosine identity**:

  `cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1`.

- `proofs/Proofs/CarnotTheorem.lean` — 81 lines, **0 axioms, 0 sorries**, build-verified `[7743/7743]`.
- Registered in `proofs/Proofs.lean`.
- Gallery entry `src/data/proofs/carnot-theorem-oq-01/meta.json`.

## Proof technique

Half-angle linearization: set `a=A/2, b=B/2, c=C/2`, so `c = π/2 - (a+b)` and `sin(C/2) = cos(a+b) = ca·cb - sa·sb`, eliminating the third angle. Rewrite each cosine via `cos(2x) = 1 - 2 sin²x`. The goal becomes a polynomial identity in `sin(A/2), cos(A/2), sin(B/2), cos(B/2)`, closed by a single `linear_combination` of the two Pythagorean identities (coefficients independently sympy-verified).

## Test plan

- [x] `docker-build.sh Proofs.CarnotTheorem` → `Build completed successfully (7743 jobs)`, no `error:`/`sorry`
- [x] No `axiom` declarations; only standard Mathlib trig lemmas
- [x] Dedup checked — no existing Carnot proof or PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)