### PR TITLE
Research: chebyshev-oq040101 — prove Möbius–floor identity (Iter 5a-β-2 keystone)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -514,6 +514,7 @@ import Proofs.ChebyshevBounds
 import Proofs.ChebyshevBoundsOQ04
 import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01
+import Proofs.ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly
 import Proofs.ChebyshevPNTBridge
 import Proofs.ChebyshevPNTBridgeOQ01
 import Proofs.ChebyshevPNTBridgeOQ01Aristotle

--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean
@@ -1,6 +1,8 @@
 /-
-Harmonic `*StatementOnly.lean` Aristotle/batch-submission file
-(format from Loom #22468; docs at research/SORRY-CLASSIFICATION.md).
+Möbius–floor identity (PROVEN, 0 sorries, 0 axioms). Originally an
+`*StatementOnly.lean` Aristotle/batch-submission stub (format from Loom #22468;
+docs at research/SORRY-CLASSIFICATION.md); the `sorry` has since been discharged
+by an elementary hyperbola-swap proof (see `moebius_mul_floor_sum_eq_one` below).
 
 Follow-up target for research problem `chebyshev-bounds-oq-04-oq-01-oq-01`
 (toward an elementary Selberg–Erdős proof of the Prime Number Theorem,
@@ -55,6 +57,7 @@ set_option linter.all false
 
 open scoped BigOperators
 open ArithmeticFunction
+open scoped ArithmeticFunction.Moebius
 
 namespace ChebyshevBoundsOQ04OQ01OQ01WeakMertens
 
@@ -74,6 +77,48 @@ using `Σ_{d ∣ n} μ(d) = δ_{n,1}` (`μ ∗ ζ = δ`).
 -/
 theorem moebius_mul_floor_sum_eq_one (N : ℕ) (hN : 1 ≤ N) :
     ∑ d ∈ Finset.Icc 1 N, μ d * (↑(N / d) : ℤ) = 1 := by
-  sorry
+  -- `Finset.Icc 1 N = Finset.Ioc 0 N` for ℕ, matching the counting lemma below.
+  have hIcc : Finset.Icc 1 N = Finset.Ioc 0 N := by
+    ext x; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  -- `⌊N/d⌋` counts the multiples of `d` in `{1,…,N}`.
+  have hcard : ∀ d : ℕ,
+      (Finset.filter (fun k => d ∣ k) (Finset.Icc 1 N)).card = N / d := by
+    intro d
+    rw [hIcc, Nat.Ioc_filter_dvd_card_eq_div]
+  -- Rewrite each term `μ(d)·⌊N/d⌋` as an inner sum over `k ∈ {1,…,N}` guarded by `d ∣ k`.
+  have key : ∀ d : ℕ,
+      μ d * (↑(N / d) : ℤ)
+        = ∑ k ∈ Finset.Icc 1 N, (if d ∣ k then μ d else 0) := by
+    intro d
+    rw [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const,
+      nsmul_eq_mul, hcard d]
+    ring
+  calc
+    ∑ d ∈ Finset.Icc 1 N, μ d * (↑(N / d) : ℤ)
+        = ∑ d ∈ Finset.Icc 1 N, ∑ k ∈ Finset.Icc 1 N, (if d ∣ k then μ d else 0) :=
+          Finset.sum_congr rfl (fun d _ => key d)
+    _ = ∑ k ∈ Finset.Icc 1 N, ∑ d ∈ Finset.Icc 1 N, (if d ∣ k then μ d else 0) :=
+          Finset.sum_comm
+    _ = ∑ k ∈ Finset.Icc 1 N, ∑ d ∈ k.divisors, μ d := by
+          refine Finset.sum_congr rfl (fun k hk => ?_)
+          simp only [Finset.mem_Icc] at hk
+          rw [← Finset.sum_filter]
+          congr 1
+          ext d
+          simp only [Finset.mem_filter, Finset.mem_Icc, Nat.mem_divisors]
+          constructor
+          · rintro ⟨⟨_, _⟩, hdvd⟩
+            exact ⟨hdvd, by omega⟩
+          · rintro ⟨hdvd, _⟩
+            have hkpos : 0 < k := by omega
+            have hd_le : d ≤ k := Nat.le_of_dvd hkpos hdvd
+            have hd_pos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hkpos
+            exact ⟨⟨hd_pos, by omega⟩, hdvd⟩
+    _ = ∑ k ∈ Finset.Icc 1 N, (if k = 1 then (1 : ℤ) else 0) := by
+          refine Finset.sum_congr rfl (fun k _ => ?_)
+          rw [← ArithmeticFunction.coe_mul_zeta_apply,
+            ArithmeticFunction.moebius_mul_coe_zeta, ArithmeticFunction.one_apply]
+    _ = 1 := by
+          simp [Finset.sum_ite_eq', Finset.mem_Icc, hN]
 
 end ChebyshevBoundsOQ04OQ01OQ01WeakMertens

--- a/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
@@ -73,3 +73,50 @@ Aristotle `prove` once a backend recovers. Expected glue:
 3. Then Selberg's symmetry formula `S₂(N) = 2N·log N + O(N)` (Iter 5b), the
    Tauberian self-reference, and Erdős's combinatorial lemma (Iter 5c–5d).
 4. Do NOT add new axioms; do NOT touch the frozen `ChebyshevBoundsOQ04OQ01.lean`.
+
+## This session (2026-06-16, Researcher-3) — ACT, Iter 5a-β-2 keystone PROVEN
+
+**Outcome**: progress (discharged the queued sorry; build-verified).
+
+Aristotle MCP loaded this session but `prove` still returns "Resource not
+found" (backend down) — proved manually instead.
+
+### Result
+
+`moebius_mul_floor_sum_eq_one` in
+`proofs/Proofs/ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean` is now
+**fully proven** (0 sorries, 0 axioms), build-verified `✔ [7743/7743]` (97s)
+and registered in `Proofs.lean`.
+
+Statement: `∑ d ∈ Finset.Icc 1 N, μ d * ↑(N / d) = 1` for `N ≥ 1`.
+
+### Proof recipe (elementary hyperbola swap)
+
+1. `Finset.Icc 1 N = Finset.Ioc 0 N` (ext + omega) to match the counting lemma.
+2. `⌊N/d⌋ = #{k ∈ Icc 1 N : d ∣ k}` via `Nat.Ioc_filter_dvd_card_eq_div`.
+3. Rewrite each term `μ d * ↑(N/d)` as `∑ k ∈ Icc 1 N, (if d ∣ k then μ d else 0)`
+   (`Finset.sum_ite` + `sum_const_zero` + `sum_const` + `nsmul_eq_mul`).
+4. Swap the double sum with the basic `Finset.sum_comm` (both indices over
+   `Icc 1 N`; avoids the fiddlier `sum_comm'`).
+5. Collapse the inner guarded sum to `∑ d ∈ k.divisors, μ d` (filter = divisors
+   for `1 ≤ k ≤ N`, via `Nat.mem_divisors` + `Nat.le_of_dvd`).
+6. `∑ d ∈ k.divisors, μ d = if k = 1 then 1 else 0` via
+   `ArithmeticFunction.coe_mul_zeta_apply` + `moebius_mul_coe_zeta` (μ ∗ ζ = 1)
+   + `one_apply`.
+7. `Finset.sum_ite_eq'` picks out the `k = 1` term ⇒ `1`.
+
+### GOTCHA (recorded for reuse)
+
+The `μ` notation is `scoped[ArithmeticFunction.Moebius]` — `open ArithmeticFunction`
+is NOT enough; you must add `open scoped ArithmeticFunction.Moebius`. First build
+failed with `Unknown identifier μ`. (`ζ` is `scoped[ArithmeticFunction.zeta]`,
+not needed here since we only reference it through lemma names.)
+
+### Next Steps (unchanged downstream)
+
+1. Derive `|M₁(N)| = |∑_{d≤N} μ(d)/d| ≤ 1` from this floor identity via the
+   fractional-part split `⌊N/d⌋ = N/d − {N/d}`.
+2. Then Selberg's symmetry formula (Iter 5b), the Tauberian self-reference,
+   Erdős's combinatorial lemma (Iter 5c–5d).
+3. The two parent axioms in `ChebyshevBoundsOQ04.lean` remain (deep PNT);
+   do NOT touch the frozen `ChebyshevBoundsOQ04OQ01.lean`.


### PR DESCRIPTION
## Summary
Discharges the queued `sorry` in `ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean` with an elementary, fully machine-checked proof of the **Möbius–floor identity**

```
∑_{d=1}^{N} μ(d) · ⌊N/d⌋ = 1        (N ≥ 1)
```

- **Build-verified**: `✔ [7743/7743] Built ... (97s)`, **0 sorries, 0 axioms**.
- **Registered** in `proofs/Proofs.lean`.
- This is the keystone for the weak Mertens bound `|∑_{d≤N} μ(d)/d| ≤ 1` (Iter 5a-β-2) on the Selberg–Erdős elementary-PNT roadmap for `chebyshev-bounds-oq-04-oq-01-oq-01`.
- The two deep parent PNT axioms in `ChebyshevBoundsOQ04.lean` are **untouched** (no new axioms introduced).

## Proof (elementary hyperbola swap)
1. `⌊N/d⌋ = #{k ∈ [1,N] : d ∣ k}` (`Nat.Ioc_filter_dvd_card_eq_div`).
2. Rewrite each term as an inner sum guarded by `d ∣ k`; swap the double sum (`Finset.sum_comm`).
3. Collapse inner sum to `∑_{d ∣ k} μ(d) = [k=1]` via `coe_mul_zeta_apply` + `moebius_mul_coe_zeta` (μ ∗ ζ = 1).
4. `Finset.sum_ite_eq'` selects the `k=1` term ⇒ `1`.

Supersedes the doc-only floor-chain scaffold in #25017 (this PR proves it).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly` → green, 7743 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)