### PR TITLE
audit(tracker): reconcile 6 stale issues-found entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1942,7 +1942,10 @@
     "central-limit-theorem-oq-02": {
       "auditCount": 5,
       "lastAudited": "2026-06-15T14:59:46Z",
-      "result": "issues-found"
+      "result": "issues-fixed",
+      "issues": [
+        "stale meta counts fixed by PR #24621; counts now match source"
+      ]
     },
     "central-limit-theorem-oq-03": {
       "auditCount": 3,
@@ -15356,16 +15359,18 @@
     "sum-of-kth-powers-oq-03": {
       "auditCount": 2,
       "lastAudited": "2026-06-15T15:01:30Z",
-      "result": "issues-found",
+      "result": "issues-fixed",
       "issues": [
-        "Stray -/ in docstring (line 31 division-/subtraction-free) closes the block comment and breaks compilation despite 0 sorries. Fix in flight: PR #24603."
+        "stray \"-/\" closing the block comment was fixed by PR #24603; file compiles cleanly"
       ]
     },
     "euler-totient-oq-01-oq-03": {
       "auditCount": 2,
       "lastAudited": "2026-06-15T15:00:57Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "Carmichael dependency/status repaired by PR #24706; counts match source"
+      ]
     },
     "erdos-1107-oq-02-oq-01 clean": {
       "auditCount": 1,
@@ -15442,8 +15447,10 @@
     "inclusion-exclusion-oq-01-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-15T19:32:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "badge \"verified\"->\"mathlib\" fixed by PR #24715; counts match source"
+      ]
     },
     "inverse-galois-d4-oq-01": {
       "auditCount": 1,
@@ -15466,8 +15473,10 @@
     "morleys-theorem-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-15T19:37:36Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "stale \"build-pending\" overclaim text fixed by PRs #24678/#24737"
+      ]
     },
     "pascals-hexagon-oq-02": {
       "auditCount": 1,
@@ -15508,8 +15517,10 @@
     "mantel-theorem": {
       "auditCount": 1,
       "lastAudited": "2026-06-15T20:58:19Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "badge \"original\"->\"mathlib\" fixed by PR #24780; equality companion now exists (PR #24869)"
+      ]
     },
     "cayley-hamilton-cyclic-vector-all-fields-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
## Fix

Six gallery proofs were flagged `issues-found` in `audit-tracker.json` on 2026-06-15, but the underlying defects were each resolved by later PRs the same day — the tracker entries were never flipped to `issues-fixed`. This leaves the auditor's `find-targets` repeatedly re-serving already-resolved findings and misreports gallery integrity.

Each was verified against current `origin/main` source/meta before flipping.

## Evidence

| slug | original finding | resolved by |
|---|---|---|
| sum-of-kth-powers-oq-03 | stray `-/` closing block comment, breaks build | #24603 (docstring intact, line 31 reworded) |
| central-limit-theorem-oq-02 | stale meta counts | #24621 (sorry 1, axiom 1, thm 23, def 14 all match) |
| euler-totient-oq-01-oq-03 | Carmichael dependency / status | #24706 (counts 0/0, thm 8, def 2 match) |
| inclusion-exclusion-oq-01-oq-03 | badge `verified`→`mathlib` | #24715 (counts match) |
| morleys-theorem-oq-03 | stale "build-pending" overclaim text | #24678 / #24737 |
| mantel-theorem | badge `original`→`mathlib` | #24780 (companion `MantelTheoremUniqueness.lean` now exists, #24869) |

**Before**: 6 entries `"result": "issues-found"` (4 with empty `issues` arrays).
**After**: each set to `"issues-fixed"` with a one-line note citing the resolving PR.

Surgical diff: only the 6 entries change; no reformatting of the 2485-entry file.

---
Automated fix by lean-mechanic agent.