### PR TITLE
Enrich Refutation of OQ-04 axiom (Runge phenomenon): realign + extend annotations

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "concept",
     "range": {
-      "startLine": 4,
-      "endLine": 110
+      "startLine": 5,
+      "endLine": 134
     },
     "title": "Refutation Summary: The OQ-04 Axiom is Mathematically False",
-    "content": "The file's module docstring states the OQ-01 question (can the parent OQ-04 axiom be discharged via Mathlib's HasFPowerSeriesOnBall?) and answers NO with an explicit Runge-function counterexample. The Runge function f(x)=1/(1+x²) is real-analytic on all of ℝ, uniformly bounded by 1, but has complex poles at ±i. With a=0, R=100, M=1, r=1, n=0, x=1, every hypothesis of the parent axiom is satisfied (analytic on (-100,100), |f|≤1 there) but the conclusion |f(1)−f(0)| ≤ 1·1/(100−1) = 1/99 fails: |1/2−1| = 1/2 ≫ 1/99. The root cause is the Runge phenomenon: real-analyticity plus a real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk. The corrected statement (§3) replaces the real interval with Metric.ball (a:ℂ) R and adds the explicit R^n factor in the denominator.",
+    "content": "The file's module docstring states the OQ-01 question (can the parent OQ-04 axiom be discharged via Mathlib's HasFPowerSeriesOnBall?) and answers NO with an explicit Runge-function counterexample. The Runge function f(x)=1/(1+x²) is real-analytic on all of ℝ, uniformly bounded by 1, but has complex poles at ±i. With a=0, R=100, M=1, r=1, n=0, x=1, every hypothesis of the parent axiom is satisfied (analytic on (-100,100), |f|≤1 there) but the conclusion |f(1)−f(0)| ≤ 1·1/(100−1) = 1/99 fails: |1/2−1| = 1/2 ≫ 1/99. The root cause is the Runge phenomenon: real-analyticity plus a real sup bound does not control complex Cauchy coefficient estimates, which require a complex sup bound on a complex disk. The docstring's S7 status banner records that the file is now 0 axioms / 0 sorries: the corrected complex-disk statement (§3b) and its residual Cauchy-coefficient sub-lemma were fully discharged at S7 (2026-05-14) via Mathlib's Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le.",
     "mathContext": "Runge counterexample: $f(x) = 1/(1+x^2)$, real-analytic on $\\mathbb{R}$, $|f| \\le 1$ uniformly. At $a=0, R=100, r=1, n=0, x=1$: hypothesis side OK, conclusion would require $|f(1) - f(0)| = 1/2 \\le 1 \\cdot 1/(100-1) = 1/99 \\approx 0.0101$, but $1/2 > 1/99$. Root cause: complex radius of convergence at $0$ is $1$ (distance to $\\pm i$), not $R=100$, so Cauchy's $\\|a_k\\| \\le M/R^k$ requires the complex sup bound on $D(0, R) \\subset \\mathbb{C}$, not the real sup bound on $(-R, R) \\subset \\mathbb{R}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -31,11 +31,11 @@
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "definition",
     "range": {
-      "startLine": 119,
-      "endLine": 124
+      "startLine": 145,
+      "endLine": 150
     },
     "title": "The Runge Function",
-    "content": "Defines `runge : ℝ → ℝ := fun x => 1 / (1 + x ^ 2)`. This is the canonical witness function in numerical analysis for the Runge phenomenon: real-analytic on all of ℝ, uniformly bounded by 1, but with complex poles at ±i that limit the complex Cauchy radius around any real point to at most 1. The standard pedagogical use of runge is to demonstrate divergence of high-degree polynomial interpolation on equispaced nodes; here we use it to demonstrate the failure of the OQ-04 axiom's real-only hypothesis.",
+    "content": "Defines `runge : ℝ → ℝ := fun x => 1 / (1 + x ^ 2)`. This is the canonical witness function in numerical analysis for the Runge phenomenon: real-analytic on all of ℝ, uniformly bounded by 1, but with complex poles at ±i that limit the complex Cauchy radius around any real point to at most 1. The standard pedagogical use of runge is to demonstrate divergence of high-degree polynomial interpolation on equispaced nodes; here we use it to demonstrate the failure of the OQ-04 axiom's real-only hypothesis. Because the definition involves real division, it is placed inside the file's `noncomputable section`.",
     "mathContext": "$\\text{runge}(x) = \\dfrac{1}{1 + x^2}$. Properties: real-analytic on $\\mathbb{R}$ (denominator everywhere $\\ge 1 > 0$), $|\\text{runge}| \\le 1$ everywhere, $\\text{runge}(0) = 1$, $\\text{runge}(1) = 1/2$. Complex poles at $z = \\pm i$ (where $1 + z^2 = 0$), giving complex radius of convergence $1$ around any real point.",
     "significance": "critical",
     "relatedConcepts": [
@@ -54,19 +54,19 @@
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "tactic",
     "range": {
-      "startLine": 159,
-      "endLine": 175
+      "startLine": 182,
+      "endLine": 202
     },
     "title": "AnalyticOn Composition: A Mathlib Cookbook Recipe",
-    "content": "The proof of `runge_analyticOn_R` is a clean composition of Mathlib's analytic-function combinators: `analyticOn_id ℝ` (identity is analytic), `AnalyticOn.pow 2` (squaring is analytic), `analyticOn_const` (constants are analytic), `AnalyticOn.add` (sum of analytic is analytic), `AnalyticOn.div` with a nonzero-denominator hypothesis (quotient of analytic is analytic where denominator is nonzero). The denominator non-vanishing fact `1 + x² > 0` is supplied by `runge_one_add_sq_pos`. This pattern is the canonical Mathlib recipe for proving rational functions are analytic on intervals avoiding their real zeros — applicable far beyond this specific file.",
-    "mathContext": "Recipe: $\\text{AnalyticOn}_{\\mathbb{R}} (f / g) S$ when both $\\text{AnalyticOn}_{\\mathbb{R}} f S$ and $\\text{AnalyticOn}_{\\mathbb{R}} g S$ hold and $g(x) \\ne 0$ for all $x \\in S$. For polynomials in particular, build via `analyticOn_const + analyticOn_id + .pow + .add + .mul`, then apply `.div` with a `positivity`-discharged denominator hypothesis.",
+    "content": "The proof of `runge_analyticOn_R` builds pointwise analyticity at each `x ∈ (-100, 100)` from Mathlib's `AnalyticAt` combinators, then lifts to `AnalyticOn` via `AnalyticAt.analyticWithinAt`. The constituents are `analyticAt_const` (constants), the identity's analyticity obtained from `(ContinuousLinearMap.id ℝ ℝ).analyticAt`, `AnalyticAt.pow 2` (squaring), `AnalyticAt.add` (sum), and `AnalyticAt.div` with the nonzero-denominator fact `1 + x² ≠ 0` supplied by `runge_one_add_sq_pos`. This pattern is the canonical Mathlib recipe for proving rational functions are analytic on intervals avoiding their real zeros — applicable far beyond this specific file.",
+    "mathContext": "Recipe: $\\text{AnalyticAt}_{\\mathbb{R}} (f / g)\\,x$ when $\\text{AnalyticAt}_{\\mathbb{R}} f\\,x$, $\\text{AnalyticAt}_{\\mathbb{R}} g\\,x$, and $g(x) \\ne 0$; then `intro x _; ...; exact h_div.analyticWithinAt` discharges the `AnalyticOn` goal. For polynomials build via `analyticAt_const + id + .pow + .add`, then apply `.div` with a `positivity`-style nonzero denominator.",
     "significance": "supporting",
     "relatedConcepts": [
-      "AnalyticOn.div",
-      "AnalyticOn.pow",
-      "AnalyticOn.add",
-      "analyticOn_id",
-      "analyticOn_const",
+      "AnalyticAt.div",
+      "AnalyticAt.pow",
+      "AnalyticAt.add",
+      "AnalyticAt.analyticWithinAt",
+      "ContinuousLinearMap.analyticAt",
       "Mathlib analytic combinators"
     ],
     "prerequisites": [
@@ -81,8 +81,8 @@
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "definition",
     "range": {
-      "startLine": 179,
-      "endLine": 195
+      "startLine": 206,
+      "endLine": 218
     },
     "title": "OQ04_AxiomStatement: Prop-Encoded Axiom for Constructive Refutation",
     "content": "Packages the parent file's axiom signature as a Prop-valued definition `OQ04_AxiomStatement`. This indirection lets us refute the axiom *as a proposition* (using `¬ OQ04_AxiomStatement`) without invoking the parent file's `axiom analytic_taylor_remainder_uniform_bound` (which would close the goal trivially via `False.elim` of the inconsistency). Thus the refutation stands even if the parent axiom is later removed from the gallery. This Prop-encoding pattern is reusable for any future 'is this axiom statement true?' analyses.",
@@ -104,11 +104,11 @@
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "tactic",
     "range": {
-      "startLine": 197,
-      "endLine": 232
+      "startLine": 220,
+      "endLine": 273
     },
     "title": "The Refutation Proof: Specialize, Substitute, Contradict",
-    "content": "Three-stage refutation of OQ04_AxiomStatement at the Runge witness. Stage 1: verify all hypotheses (positivity of R, nonneg M, AnalyticOn ℝ runge with the interval rewrite, uniform sup bound on the open interval, positivity of r and r<R, x ∈ Icc). Stage 2: apply the alleged universal statement to extract `|runge 1 - taylorPolynomial runge 0 0 1| ≤ 1·1^(0+1)/(100-1)`. Stage 3: rewrite using `MeanValueTheoremOQ02.taylorPolynomial_zero` (T_0 = f(a)) to reduce to `|runge 1 - runge 0|`, substitute the numerical values `runge 1 = 1/2` and `runge 0 = 1`, simplify both sides to `|1/2 - 1| = 1/2` and `1·1/99 = 1/99`, then close with `norm_num` on the false `1/2 ≤ 1/99`. The 50× gap makes the contradiction robust.",
+    "content": "Three-stage refutation of OQ04_AxiomStatement at the Runge witness. Stage 1: verify all hypotheses (positivity of R, nonneg M, AnalyticOn ℝ runge with the interval rewrite (0-100, 0+100) = (-100, 100), uniform sup bound on the open interval, positivity of r and r<R, x ∈ Icc). Stage 2: apply the alleged universal statement to extract `|runge 1 - taylorPolynomial runge 0 0 1| ≤ 1·1^(0+1)/(100-1)`. Stage 3: rewrite using `MeanValueTheoremOQ02.taylorPolynomial_zero` (T_0 = f(a)) to reduce to `|runge 1 - runge 0|`, substitute the numerical values `runge 1 = 1/2` and `runge 0 = 1`, simplify both sides to `|1/2 - 1| = 1/2` and `1·1/99 = 1/99`, then close with `norm_num` on the false `1/2 ≤ 1/99`. The 50× gap makes the contradiction robust. The companion `oq04_parent_axiom_is_false_in_principle` re-exports the same negation framed against the parent axiom.",
     "mathContext": "Numerical contradiction: $|f(1) - f(0)| = |1/2 - 1| = 1/2 \\approx 0.5$, claimed bound $M \\cdot r^{n+1}/(R-r) = 1 \\cdot 1/99 \\approx 0.0101$. Gap factor: $\\approx 50$. The bound at $n=0$ degenerates to the standard MVT-style bound on $|f(x) - f(a)|$, but with $\\sup|f|/(R-r)$ replacing $\\sup|f'|$—and the substitution is mathematically invalid without complex hypotheses.",
     "significance": "key",
     "relatedConcepts": [
@@ -124,28 +124,154 @@
     ]
   },
   {
+    "id": "ann-mvt02oq04oq01-offbyone",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "insight",
+    "range": {
+      "startLine": 286,
+      "endLine": 405
+    },
+    "title": "Off-by-One Refutation: partialSum n vs. partialSum (n+1)",
+    "content": "A second, subtler refutation guarding against a tempting but wrong fix. §3 first notes that even the *complex* explicit form is false if one pairs the RHS M·r^(n+1)/(R^n·(R−r)) with `p.partialSum n` instead of `p.partialSum (n+1)`. Mathlib's convention is `partialSum n = ∑ k ∈ Finset.range n`, which truncates at degree n−1, so the remainder tail begins at degree n and evaluates to M·r^n·R/(R^n·(R−r)) — off by a factor r/R from the stated RHS. `OriginalRemainderForm` packages this uncorrected predicate and `originalRemainderForm_is_false` refutes it with the constant function f ≡ 1 on Metric.ball (0:ℂ) 1 at (R,M,r,n,z)=(1,1,1/4,0,0): there `partialSum 0` is the empty sum 0, so the LHS is ‖1−0‖=1 while the RHS is (1/4)/(3/4)=1/3, giving the false 1 ≤ 1/3. The lesson: index conventions matter, and §3b uses partialSum (n+1) so the truncation degree matches the parent's degree-n Taylor polynomial.",
+    "mathContext": "Mathlib: $p.\\text{partialSum}\\,n\\,(x) = \\sum_{k=0}^{n-1} p_k(x,\\dots,x)$ (degrees $0..n-1$). Tail from degree $n$: $\\sum_{k\\ge n} M(r/R)^k = M\\,r^n R/(R^n(R-r))$, which differs from $M\\,r^{n+1}/(R^n(R-r))$ by $r/R$. Constant-1 witness: $f\\equiv 1$, $R{=}1, M{=}1, r{=}1/4, n{=}0$ gives LHS $=\\|1-0\\|=1$, RHS $=(1/4)^1/(1\\cdot(1-1/4))=1/3$, so $1\\le 1/3$ is false.",
+    "significance": "key",
+    "relatedConcepts": [
+      "FormalMultilinearSeries.partialSum",
+      "constFormalMultilinearSeries",
+      "hasFPowerSeriesOnBall_const",
+      "geometric tail summation",
+      "index convention pitfalls"
+    ],
+    "prerequisites": [
+      "formal multilinear series",
+      "geometric series",
+      "Finset.range conventions"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-geometric-tail",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "tactic",
+    "range": {
+      "startLine": 409,
+      "endLine": 427
+    },
+    "title": "Geometric Tail Identity (Pure Algebra)",
+    "content": "`geometric_tail_identity` proves the rewrite (r/R)^(n+1)·R/(R−r) = r^(n+1)/(R^n·(R−r)) under 0<r<R. This is the algebraic bridge that converts the natural 'geometric-ratio' output of the geometric tail summation into the explicit 'polynomial-power' RHS that appears in the corrected theorem. The proof isolates the key step (r/R)^(n+1)·R = r^(n+1)/R^n via `div_pow` + `pow_succ` + `field_simp`, then chains two `div_div`-style rewrites in a `calc`. Splitting out this identity keeps the main assembly readable and avoids a `field_simp; ring` that would otherwise leave stray R⁻¹^n factors `ring` cannot recombine.",
+    "mathContext": "$\\left(\\dfrac{r}{R}\\right)^{n+1}\\dfrac{R}{R-r} = \\dfrac{r^{n+1}}{R^{n}(R-r)}$ for $0<r<R$. Key sub-step: $\\left(\\dfrac{r}{R}\\right)^{n+1} R = \\dfrac{r^{n+1}}{R^{n}}$ since $R^{n+1}=R^n\\cdot R$.",
+    "relatedConcepts": [
+      "geometric series tail",
+      "div_pow",
+      "pow_succ",
+      "field_simp",
+      "calc proof"
+    ],
+    "significance": "supporting",
+    "prerequisites": [
+      "field arithmetic in Lean",
+      "geometric series"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-cauchy-at-radius",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "tactic",
+    "range": {
+      "startLine": 429,
+      "endLine": 531
+    },
+    "title": "Finite-Radius Cauchy Coefficient Bound (S7 keystone)",
+    "content": "`cauchy_diag_norm_bound_at_radius` is the mathematical keystone discharged at S7: for f holomorphic on Metric.ball a R with ‖f‖≤M there, the diagonal coefficient evaluation satisfies ‖p k (fun _ ↦ w)‖ ≤ M·(‖w‖/r')^k for any strict intermediate radius r'∈(0,R). The proof routes through Mathlib's Cauchy machinery: (1) inclusions closedBall a r' ⊆ ball a R and sphere a r' ⊆ closedBall a r' transfer the sup bound to the sphere; (2) `HasFPowerSeriesOnBall.analyticOnNhd` + `.mono` gives analyticity on the closed sub-ball, packaged as `DiffContOnCl` via `DiffContOnCl.mk_ball`; (3) `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` is the actual Cauchy estimate ‖iteratedDeriv k f a‖ ≤ k!·M/r'^k on sphere a r'; (4) `HasFPowerSeriesOnBall.factorial_smul` plus the diagonal collapse `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` bridge the formal coefficient p k to iteratedDeriv k f a; (5) taking norms (`RCLike.norm_nsmul`, `norm_smul`, `norm_pow`) and dividing by k!>0 (`le_of_mul_le_mul_left`) yields the bound. Using a strict r'<R isolates the finite-radius Cauchy estimate (Mathlib produces it directly on a closed sphere) from the separate boundary-limit argument.",
+    "mathContext": "Cauchy coefficient estimate: $\\|p_k(w,\\dots,w)\\| \\le M\\left(\\dfrac{\\|w\\|}{r'}\\right)^{k}$ for $0<r'<R$, from $\\|f^{(k)}(a)\\| \\le \\dfrac{k!\\,M}{r'^{k}}$ (Cauchy on $\\partial D(a,r')$) and $p_k(w,\\dots,w) = \\dfrac{w^k}{k!}f^{(k)}(a)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy's coefficient estimates",
+      "Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le",
+      "DiffContOnCl",
+      "HasFPowerSeriesOnBall.factorial_smul",
+      "iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod",
+      "iteratedDeriv"
+    ],
+    "prerequisites": [
+      "Cauchy's integral formula",
+      "iterated derivatives",
+      "formal multilinear series",
+      "Mathlib.Analysis.Complex.CauchyIntegral"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-cauchy-boundary",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "tactic",
+    "range": {
+      "startLine": 533,
+      "endLine": 593
+    },
+    "title": "Boundary Cauchy Bound by Limit Extraction",
+    "content": "`cauchy_diag_norm_bound` upgrades the finite-radius estimate to the boundary radius R: ‖p k (fun _ ↦ w)‖ ≤ M·(‖w‖/R)^k for ‖w‖<R. Since the coefficient norm is independent of r', and r' ↦ M·(‖w‖/r')^k is continuous at R (as R>0), the bound transfers to the limit. The proof establishes the pointwise bound on (0,R) from `cauchy_diag_norm_bound_at_radius`, shows `ContinuousAt` of the upper bound via `continuousAt_const.mul`/`.div`/`.pow`, obtains `Filter.Tendsto` along `𝓝[<] R` by `mono_left nhdsWithin_le_nhds`, certifies (0,R) ∈ 𝓝[<] R via `mem_nhdsWithin`, and closes with `ge_of_tendsto` to push the eventual bound through the limit. This cleanly separates the two ingredients — the closed-sphere Cauchy estimate and the boundary limit — that an entangled single statement would have conflated.",
+    "mathContext": "From $\\|p_k(w,\\dots,w)\\| \\le M(\\|w\\|/r')^k$ for all $r'\\in(0,R)$ and continuity of $r'\\mapsto M(\\|w\\|/r')^k$ at $R$: $\\lim_{r'\\to R^-} M(\\|w\\|/r')^k = M(\\|w\\|/R)^k$, so $\\|p_k(w,\\dots,w)\\| \\le M(\\|w\\|/R)^k$ by `ge_of_tendsto`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ContinuousAt",
+      "Filter.Tendsto",
+      "nhdsWithin",
+      "ge_of_tendsto",
+      "limit of upper bounds"
+    ],
+    "prerequisites": [
+      "filters and limits in Mathlib",
+      "continuity",
+      "one-sided neighborhoods"
+    ]
+  },
+  {
     "id": "ann-mvt02oq04oq01-corrected",
     "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
     "type": "concept",
     "range": {
-      "startLine": 244,
-      "endLine": 270
+      "startLine": 595,
+      "endLine": 693
     },
-    "title": "Corrected Statement: Complex-Disk Cauchy Bound",
-    "content": "States `analytic_taylor_remainder_uniform_bound_complex`, the *correct* version of the Cauchy uniform bound. Differences from the OQ-04 axiom: (1) f is complex-valued (f : ℂ → ℂ); (2) the analyticity hypothesis is `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)` on the *complex* disk; (3) the sup bound is on `Metric.ball a R` ⊂ ℂ; (4) the conclusion uses the formal-power-series partialSum (not the parent's iteratedDeriv-based taylorPolynomial); (5) the right-hand side has the corrected denominator R^n · (R - r) (not (R - r)). The proof is `sorry`, deferred to S2 with explicit Mathlib chain documented inline: HasFPowerSeriesOnBall.uniform_geometric_approx' yields the existential C·a^n form, FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius gives the explicit Cauchy bound ‖p k‖ ≤ M / R^k, and the geometric tail summation closes.",
-    "mathContext": "$\\text{Corrected:} \\|f z - p.\\text{partialSum } n (z - a)\\| \\le M \\cdot r^{n+1} / (R^n \\cdot (R - r))$ for $f : \\mathbb{C} \\to \\mathbb{C}$ holomorphic on $\\text{Metric.ball } a R$ with sup bound $M$ on that disk, $\\|z - a\\| \\le r < R$. Note the explicit $R^n$ factor: this is what the OQ-04 axiom omits, and it is essential — at $n=0$ the bound becomes $M \\cdot r/(R-r)$, but already at $n=1$ the corrected $M \\cdot r^2 / (R \\cdot (R-r))$ is much smaller than the OQ-04 statement's $M \\cdot r^2 / (R-r)$.",
+    "title": "Corrected Statement: Complex-Disk Cauchy Bound (Proven, S7)",
+    "content": "States and now fully PROVES `analytic_taylor_remainder_uniform_bound_complex`, the *correct* version of the Cauchy uniform bound. Differences from the OQ-04 axiom: (1) f is complex-valued (f : ℂ → ℂ); (2) the analyticity hypothesis is `HasFPowerSeriesOnBall f p a (ENNReal.ofReal R)` on the *complex* disk; (3) the sup bound is on `Metric.ball a R` ⊂ ℂ; (4) the conclusion uses the formal-power-series partialSum (n+1) (not the parent's iteratedDeriv-based taylorPolynomial, and index-shifted so the truncation degree matches degree-n); (5) the right-hand side has the corrected denominator R^n · (R - r) (not (R - r)). The proof — once a deferred `sorry`, completed at S7 (PR #19063) — assembles in six steps: z ∈ EMetric.ball gives `HasFPowerSeriesOnBall.hasSum_sub` (the series sums to f z); the per-term bound ‖p k (fun _ ↦ z−a)‖ ≤ M·(r/R)^k comes from `cauchy_diag_norm_bound` + `gcongr`; `norm_sub_le_of_geometric_bound_of_hasSum` at index n+1 bounds the tail by M·(r/R)^(n+1)/(1−r/R); `norm_sub_rev` orients the difference; and `geometric_tail_identity` (with 1−r/R = (R−r)/R) rewrites the RHS to the explicit M·r^(n+1)/(R^n·(R−r)).",
+    "mathContext": "$\\text{Corrected (proven):} \\|f z - p.\\text{partialSum}(n{+}1)(z - a)\\| \\le \\dfrac{M \\cdot r^{n+1}}{R^n \\cdot (R - r)}$ for $f : \\mathbb{C} \\to \\mathbb{C}$ holomorphic on $\\text{Metric.ball}\\,a\\,R$ with sup bound $M$ there, $\\|z - a\\| \\le r < R$. The explicit $R^n$ factor is exactly what the OQ-04 axiom omits; at $n=1$ the correct $M r^2/(R(R-r))$ is far smaller than the axiom's $M r^2/(R-r)$.",
     "significance": "key",
     "relatedConcepts": [
-      "HasFPowerSeriesOnBall",
-      "Metric.ball complex",
+      "HasFPowerSeriesOnBall.hasSum_sub",
+      "norm_sub_le_of_geometric_bound_of_hasSum",
       "FormalMultilinearSeries.partialSum",
       "Cauchy coefficient estimates",
-      "geometric tail summation"
+      "geometric tail summation",
+      "norm_sub_rev"
     ],
     "prerequisites": [
       "complex analysis",
       "Mathlib.Analysis.Analytic.Basic",
       "Mathlib.Analysis.Calculus.FormalMultilinearSeries"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq04oq01-existential",
+    "proofId": "mean-value-theorem-oq-02-oq-04-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 695,
+      "endLine": 752
+    },
+    "title": "Existential Geometric Approximation (Mathlib-Native)",
+    "content": "`analytic_taylor_remainder_uniform_geometric_complex` records the weaker, hypothesis-light cousin of the explicit bound: for f admitting a power series p on Metric.ball a R and any r<R, there exist K∈(0,1) and C>0 with ‖f z − p.partialSum n (z−a)‖ ≤ C·(K·(‖z−a‖/r))^n on the subdisk. This is exactly Mathlib's `HasFPowerSeriesOnBall.uniform_geometric_approx'` after the change of variables z = a + y (the proof obtains the constants, then transports the y-centered ball membership to a z-centered one and rewrites a+(z−a)=z). The pedagogical point: this existential decay needs NO complex sup bound M — only that f admits the expansion — and is therefore the part of the Cauchy story that survives without the disk hypothesis. The §3b explicit form sharpens C and K to the genuine Cauchy constants M·R/(R−r) and ‖z−a‖/R, which is precisely where the complex sup bound the OQ-04 axiom drops re-enters.",
+    "mathContext": "$\\exists K \\in (0,1),\\, C>0:\\ \\|f z - p.\\text{partialSum}\\,n\\,(z-a)\\| \\le C\\,(K\\,\\|z-a\\|/r)^n$ on $\\text{ball}(a,r)$. Obtained from `uniform_geometric_approx'` by $z = a+y$. No sup bound $M$ required — contrast with the explicit §3b form whose constants encode $M$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasFPowerSeriesOnBall.uniform_geometric_approx'",
+      "geometric decay",
+      "change of variables",
+      "existential vs explicit bounds"
+    ],
+    "prerequisites": [
+      "formal multilinear series",
+      "Mathlib.Analysis.Analytic.Basic",
+      "geometric series"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `mean-value-theorem-oq-02-oq-04-oq-01`

This entry's `annotations.json` was written for the ~280-line Iteration-1 version of `Proofs/MeanValueTheoremOQ02OQ04OQ01.lean`. The source has since grown to **771 lines** (S5–S7 added the now-proven complex-disk Cauchy machinery in §3/§3a/§3b), leaving the annotations badly misaligned and the entire proven second half uncovered.

### Changes
- **Realigned all 6 existing annotations** to the current file's line ranges (they pointed into the old layout, e.g. the "AnalyticOn composition" note pointed at `runge_abs_le_one`).
- **Fixed stale content**: the "corrected statement" annotation still described `analytic_taylor_remainder_uniform_bound_complex` as a deferred `sorry`. S7 (PR #19063) proved it sorry-free via Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`; the annotation now documents the completed 6-step assembly.
- **Added 5 annotations** covering the previously-unannotated §3/§3a/§3b:
  - off-by-one `partialSum n` vs `partialSum (n+1)` refutation (`OriginalRemainderForm`)
  - `geometric_tail_identity` (pure-algebra bridge)
  - `cauchy_diag_norm_bound_at_radius` (finite-radius Cauchy keystone, S7)
  - `cauchy_diag_norm_bound` (boundary form by limit extraction)
  - `analytic_taylor_remainder_uniform_geometric_complex` (§3a existential)

### Validation
- `resolver.ts validate` → **Valid: 11, Misaligned: 0** against the 771-line source.
- All 11 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`; types/significance conform to the frontend enums.
- `meta.json` was already accurate (correct sections, axiom status, conclusion) and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)