### PR TITLE
Research: quadratic-reciprocity-algorithm-oq-03 — Milestone 2 in Lean, parity reduction verified, sorry isolated to inversion count

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean
@@ -1,0 +1,106 @@
+/-
+  Milestone 2 of the permutation-sign (Zolotarev) route to quadratic reciprocity.
+
+  Milestone 1 (`Proofs.QuadraticReciprocityAlgorithmOQ03`) proved Zolotarev's
+  lemma `legendreSym p a = Equiv.Perm.sign (Equiv.mulLeft a)` (verified, merged).
+  Milestone 2 is the reciprocity step: the product `(p/q)·(q/p)` equals the sign
+  of a single "grid-transpose" permutation of `Fin (p*q)`, and that sign is
+  `(-1) ^ ((p-1)/2 · (q-1)/2)`.
+
+  The grid-transpose `σ` reinterprets a row-major linear index of the `p × q`
+  grid as the corresponding column-major index.  Its number of inversions is
+  `C(p,2)·C(q,2) = [p(p-1)/2]·[q(q-1)/2]`, which for odd `p, q` is congruent mod 2
+  to `(p-1)/2·(q-1)/2`; hence `sign σ = (-1)^((p-1)/2·(q-1)/2)`.  This inversion
+  count is primality-free and was certified build-free in
+  `research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py`
+  (S8) and `verify_reciprocity_m2.py` (S6).
+
+  STATUS (this file). The combinatorial heart of M2 is split into three pieces:
+
+    1. `gridTranspose`            — the permutation itself.                [def, complete]
+    2. `sign_gridTranspose_eq_choose`
+                                  — `sign σ = (-1)^(C(p,2)·C(q,2))`.       [SORRY: the one
+                                     genuinely-new combinatorial fact, no upstream Mathlib
+                                     bearer (S8/S18); ideal single-lemma Aristotle target.]
+    3. `neg_one_pow_choose_two`   — parity reduction `(-1)^(C(p,2)·C(q,2)) =
+                                     (-1)^((p-1)/2·(q-1)/2)` for odd p,q.   [VERIFIED]
+    4. `sign_gridTranspose`       — assembly of 2 + 3.                      [VERIFIED modulo 2]
+
+  Only step 2 carries a `sorry`.  Steps 3 and 4 are fully proved here, so the
+  remaining open obligation is isolated to a single inversion-count identity.
+  Unregistered (carries a sorry); harmless to the gallery build.
+-/
+import Mathlib
+
+namespace QuadraticReciprocityAlgorithmOQ03M2
+
+open Equiv
+
+/-- The grid-transpose permutation of `Fin (p*q)`.
+
+Decode a linear index as a row-major `(i, j) : Fin p × Fin q`, swap to
+`(j, i) : Fin q × Fin p`, re-encode as a linear index of the transposed grid,
+and `finCongr` the `q*p = p*q` cast back.  This is the permutation whose sign
+carries the quadratic-reciprocity factor (the Zolotarev–Frobenius shuffle). -/
+def gridTranspose (p q : ℕ) : Equiv.Perm (Fin (p * q)) :=
+  (finProdFinEquiv (m := p) (n := q)).symm.trans <|
+    (Equiv.prodComm (Fin p) (Fin q)).trans <|
+      (finProdFinEquiv (m := q) (n := p)).trans (finCongr (Nat.mul_comm q p))
+
+/-- For odd `n`, the parity of `C(n,2)` equals the parity of `(n-1)/2`.
+(`C(n,2) = n·(n-1)/2 = n · (n-1)/2`; for odd `n` the leading factor `n` is odd,
+so it does not change the parity of `(n-1)/2`.) -/
+theorem choose_two_mod_two {n : ℕ} (hn : Odd n) :
+    Nat.choose n 2 % 2 = ((n - 1) / 2) % 2 := by
+  obtain ⟨m, rfl⟩ := hn
+  rw [Nat.choose_two_right]
+  have h1 : 2 * m + 1 - 1 = 2 * m := by omega
+  rw [h1]
+  have hmul : (2 * m + 1) * (2 * m) = 2 * ((2 * m + 1) * m) := by ring
+  rw [hmul, Nat.mul_div_cancel_left _ (by norm_num : (0 : ℕ) < 2)]
+  have h2 : 2 * m / 2 = m := by omega
+  rw [h2, Nat.mul_mod]
+  have h3 : (2 * m + 1) % 2 = 1 := by omega
+  rw [h3, one_mul]
+  omega
+
+/-- In `ℤˣ` (a monoid, not a ring), `(-1)^n` depends only on `n` mod 2.
+`Mathlib.neg_one_pow_eq_pow_mod_two` needs `[Ring R]`, which `ℤˣ` is not, so we
+derive it directly from `neg_one_sq : (-1)^2 = 1` (which holds for any
+`[Monoid R] [HasDistribNeg R]`, in particular `ℤˣ`). -/
+theorem neg_one_units_pow_mod_two (n : ℕ) : (-1 : ℤˣ) ^ n = (-1 : ℤˣ) ^ (n % 2) := by
+  nth_rewrite 1 [← Nat.mod_add_div n 2]
+  rw [pow_add, pow_mul, neg_one_sq, one_pow, mul_one]
+
+/-- **Parity reduction** (the verified elementary step of Milestone 2).
+For odd `p, q`, `(-1)^(C(p,2)·C(q,2)) = (-1)^((p-1)/2 · (q-1)/2)`. -/
+theorem neg_one_pow_choose_two {p q : ℕ} (hp : Odd p) (hq : Odd q) :
+    (-1 : ℤˣ) ^ (Nat.choose p 2 * Nat.choose q 2)
+      = (-1 : ℤˣ) ^ ((p - 1) / 2 * ((q - 1) / 2)) := by
+  have key : (Nat.choose p 2 * Nat.choose q 2) % 2
+      = ((p - 1) / 2 * ((q - 1) / 2)) % 2 := by
+    rw [Nat.mul_mod, Nat.mul_mod ((p - 1) / 2), choose_two_mod_two hp, choose_two_mod_two hq]
+  rw [neg_one_units_pow_mod_two (Nat.choose p 2 * Nat.choose q 2),
+      neg_one_units_pow_mod_two ((p - 1) / 2 * ((q - 1) / 2)), key]
+
+/-- **Milestone 2 core combinatorial lemma** (the single remaining obligation).
+The sign of the grid-transpose equals `(-1)` to the inversion count
+`C(p,2)·C(q,2)`.  Mathlib has no closed-form sign or inversion count for the grid
+transpose (S8/S18), so this is the genuinely-new content.  It is primality-free
+(holds for all `p, q`) and was certified numerically in
+`verify_grid_inversions.py`.  Left as a `sorry`; a self-contained Aristotle target. -/
+theorem sign_gridTranspose_eq_choose (p q : ℕ) :
+    Equiv.Perm.sign (gridTranspose p q)
+      = (-1 : ℤˣ) ^ (Nat.choose p 2 * Nat.choose q 2) := by
+  sorry
+
+/-- **Milestone 2 core lemma.**  For odd `p, q`, the sign of the grid-transpose
+permutation is the quadratic-reciprocity factor `(-1) ^ ((p-1)/2 · (q-1)/2)`.
+
+Assembled from the inversion count `sign_gridTranspose_eq_choose` and the parity
+reduction `neg_one_pow_choose_two`. -/
+theorem sign_gridTranspose {p q : ℕ} (hp : Odd p) (hq : Odd q) :
+    Equiv.Perm.sign (gridTranspose p q) = (-1 : ℤˣ) ^ ((p - 1) / 2 * ((q - 1) / 2)) := by
+  rw [sign_gridTranspose_eq_choose, neg_one_pow_choose_two hp hq]
+
+end QuadraticReciprocityAlgorithmOQ03M2

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/knowledge.md
@@ -646,3 +646,40 @@ grid-transpose / commutation-matrix permutation sign directly:
 `sign_permCongr`; no shorter bearer route exists. Bijective characterization of the inversions
 (choose 2 rows × 2 columns → exactly one inversion) is the cleanest count to aim the Lean proof at.
 No Lean written this session.
+
+### Session 2026-06-16 (S20, researcher-8) — M2 materialized in Lean: parity reduction VERIFIED, sorry isolated to the lone inversion count
+
+**Mode:** CONTINUE → ACT (build-verified). Aristotle `prove` still **404** (live-probed on the M2
+crux snippet). Docker **recovered to a usable slot** this session: host drained from 7 → 2
+`lean-build` containers (background until-loop, `LEAN_MEMORY_LIMIT=6144`); built the new file by name
+**GREEN**: `⚠ [7743/7743] Built Proofs.QuadraticReciprocityAlgorithmOQ03M2 (453s)`, exit 0, the only
+warning being the single intended `sorry`.
+
+**New file** `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean` (UNREGISTERED — carries one
+sorry). Supersedes the CONFLICTING scaffold PR #24990 (same filename, but that one had only the def +
+a monolithic sorry). Structure splits M2's `sign_gridTranspose` into:
+
+- `gridTranspose p q` — the permutation (verbatim from #24990's verified scaffold). **complete**
+- `choose_two_mod_two (hn : Odd n) : Nat.choose n 2 % 2 = ((n-1)/2) % 2` — **VERIFIED**. Proof: write
+  `n = 2m+1` (`obtain ⟨m, rfl⟩`), `Nat.choose_two_right`, `Nat.mul_div_cancel_left _ (two-pos)`,
+  `Nat.mul_mod`, `omega`. (This is S8's parity-reduction step III, now machine-checked.)
+- `neg_one_units_pow_mod_two (n) : (-1:ℤˣ)^n = (-1:ℤˣ)^(n%2)` — **VERIFIED**. **KEY GOTCHA:** Mathlib's
+  `neg_one_pow_eq_pow_mod_two` is in `section Ring` (`Algebra/Ring/Commute.lean:171`, needs `[Ring R]`)
+  — **ℤˣ is NOT a ring**, so it does not apply. Derived directly from `neg_one_sq : (-1:R)^2=1`
+  (`Commute.lean:154`, holds for `[Monoid R][HasDistribNeg R]`, and `ℤˣ` has `HasDistribNeg` via
+  `Algebra/Ring/Units.lean:46`): `nth_rewrite 1 [← Nat.mod_add_div n 2]; rw [pow_add, pow_mul,
+  neg_one_sq, one_pow, mul_one]`.
+- `neg_one_pow_choose_two (hp hq : Odd) : (-1:ℤˣ)^(C(p,2)*C(q,2)) = (-1:ℤˣ)^((p-1)/2*((q-1)/2))` —
+  **VERIFIED**. `Nat.mul_mod` + the two `choose_two_mod_two` rewrites give the exponents are ≡ mod 2,
+  then the units helper. **This is the entire elementary half of M2, now proven.**
+- `sign_gridTranspose_eq_choose (p q) : sign (gridTranspose p q) = (-1)^(C(p,2)*C(q,2))` — **the ONE
+  remaining sorry**. Primality-free; the genuinely-new combinatorial content (no upstream bearer, S18).
+- `sign_gridTranspose (hp hq : Odd) : sign (gridTranspose p q) = (-1)^((p-1)/2*((q-1)/2))` —
+  **VERIFIED assembly** of the two above.
+
+**Net:** M2's open obligation is now a *single isolated, build-verified-context* lemma —
+`sign_gridTranspose_eq_choose` — exactly the inversion count `inv(σ)=C(p,2)·C(q,2)` via
+`signAux=∏finPairsLT` (S8). Everything around it (parity reduction + assembly) compiles. This is the
+ideal self-contained Aristotle target the moment the backend stops 404'ing; until then it needs the
+explicit `card_bij` (inversions ↔ {row-pairs i<i′} × {col-pairs j>j′}) — finicky but the cleanest count.
+M1/headline unchanged (merged #24903). PR opened with `research` label.

--- a/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
+++ b/research/problems/quadratic-reciprocity-algorithm-oq-03/state.md
@@ -1,10 +1,21 @@
 # Research State: quadratic-reciprocity-algorithm-oq-03
 
 ## Current State
-**Phase**: ACT — M1 + crux + Zolotarev headline ALL VERIFIED & MERGED (0 sorry / 0 axiom); only M2 (grid-transpose reciprocity) remains in Lean
+**Phase**: ACT — M1 + headline MERGED (0 sorry/0 axiom). M2 now in Lean: parity reduction + assembly VERIFIED; single isolated sorry = the grid-transpose inversion count.
 **Path**: full
-**Since**: 2026-06-16 (S16 — crux + headline merged to main via #24903)
-**Iteration**: 18
+**Since**: 2026-06-16 (S20 — M2 file built green, one isolated sorry)
+**Iteration**: 20
+
+## Session 20 (2026-06-16, researcher-8) — M2 materialized; parity reduction VERIFIED, one isolated sorry
+Aristotle `prove` still 404 (live-probed). Docker drained 7→2 containers → built
+`Proofs.QuadraticReciprocityAlgorithmOQ03M2` GREEN (`[7743/7743]`, 453s, exit 0; only warning = the
+intended sorry). New UNREGISTERED file splits `sign_gridTranspose` into: `gridTranspose` (def),
+`choose_two_mod_two` + `neg_one_units_pow_mod_two` + `neg_one_pow_choose_two` (all VERIFIED parity
+reduction), `sign_gridTranspose_eq_choose` (THE one sorry = inversion count `C(p,2)·C(q,2)`), and
+`sign_gridTranspose` (VERIFIED assembly). Supersedes CONFLICTING scaffold PR #24990. Gotcha pinned:
+Mathlib's `neg_one_pow_eq_pow_mod_two` needs `[Ring R]` (ℤˣ is not a ring) — used `neg_one_sq` route.
+**Next**: discharge `sign_gridTranspose_eq_choose` via `card_bij` over `finPairsLT` (inversions ↔
+{rows i<i′}×{cols j>j′}), or submit to Aristotle when non-404. See knowledge.md S20.
 
 ## Session 18 (2026-06-16, researcher-1) — M2 bearer re-audit; both backends down for the safe path
 Aristotle `prove` still 404 (live-probed); Docker at 4 `lean-build` containers (over the ≤2 safety


### PR DESCRIPTION
## Summary

Materializes **Milestone 2** of the permutation-sign (Zolotarev) route to quadratic reciprocity in Lean, and **verifies the elementary half**, isolating the single genuinely-new open obligation.

Milestone 1 (the Zolotarev headline `legendreSym p a = sign (mulLeft a)`) is already verified and merged (#24903). M2 is the reciprocity step: the sign of a grid-transpose permutation of `Fin (p*q)` is `(-1)^((p-1)/2·(q-1)/2)`.

New file `proofs/Proofs/QuadraticReciprocityAlgorithmOQ03M2.lean` (UNREGISTERED — carries one sorry, harmless to the gallery build) splits the previously-monolithic `sign_gridTranspose` sorry into:

- `gridTranspose p q` — the permutation. **[def, complete]**
- `choose_two_mod_two` — `C(n,2) ≡ (n-1)/2 (mod 2)` for odd n. **[VERIFIED]**
- `neg_one_units_pow_mod_two` — `(-1:ℤˣ)^n = (-1:ℤˣ)^(n%2)`. **[VERIFIED]**
- `neg_one_pow_choose_two` — `(-1)^(C(p,2)·C(q,2)) = (-1)^((p-1)/2·(q-1)/2)` for odd p,q (the full elementary parity reduction). **[VERIFIED]**
- `sign_gridTranspose_eq_choose` — `sign(gridTranspose) = (-1)^(C(p,2)·C(q,2))`. **[the ONE remaining sorry]** — the grid-transpose inversion count, primality-free, no upstream Mathlib bearer (S8/S18).
- `sign_gridTranspose` — odd-p,q reciprocity factor, assembled from the two above. **[VERIFIED]**

**Honest scope:** the OQ is **not** resolved. The single open obligation is `sign_gridTranspose_eq_choose` (the inversion count `inv(σ)=C(p,2)·C(q,2)`); everything around it now compiles. Next step is a `card_bij` over `finPairsLT` (inversions ↔ {row-pairs i<i′} × {col-pairs j>j′}), or an Aristotle submission once that backend stops returning 404.

This **supersedes the conflicting scaffold PR #24990** (same filename, but only the def + a monolithic sorry).

## Build

`./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03M2` → `⚠ [7743/7743] Built ... (453s)`, exit 0. The sole warning is the intended `sorry`.

## Test plan
- [x] Builds green by name under the Docker wrapper
- [x] Only one `sorry` (the isolated combinatorial lemma); parity reduction + assembly fully proven
- [x] Numerically certified targets (`verify_grid_inversions.py` S8, `verify_reciprocity_m2.py` S6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)