### PR TITLE
research(buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01): register Beta integral (0/0, build-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -355,6 +355,7 @@ import Proofs.BuffonsNeedleOQ01OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01
+import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta
 import Proofs.BuffonsNeedleOQ01OQ02
 import Proofs.BuffonsNeedleOQ01OQ04
 import Proofs.BuffonsNeedleOQ02

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+  "title": "Beta Integral for the n-Dimensional Angular Averaging Identity",
+  "slug": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+  "description": "Proves the one-dimensional Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2, axiom-free. This is the analytic core flagged as the key missing piece for the general n ≥ 3 case of the Cauchy–Crofton angular averaging identity. The proof uses the fundamental theorem of calculus with antiderivative F(θ) = sin^{m+1}(θ)/(m+1), equivalently the substitution u = sin θ reducing to ∫_0^1 uᵐ du = 1/(m+1).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Crofton_formula",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean",
+    "tags": [
+      "integral-geometry",
+      "beta-integral",
+      "buffon",
+      "cauchy-crofton",
+      "angular-averaging",
+      "trigonometric-integrals",
+      "fundamental-theorem-of-calculus",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 74,
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+    "question": "Can the Beta integral identity ∫_0^{π/2} cos(θ)·sin^{n-2}(θ) dθ = 1/(n-1) be formalized in Lean 4 using Mathlib's integration lemmas?",
+    "answer": "Yes, axiom-free. The general lemma ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) is proved for every m : ℕ by the fundamental theorem of calculus with antiderivative F(θ) = sin^{m+1}(θ)/(m+1), whose derivative is cos θ · sinᵐ θ (this is the closed form of the substitution u = sin θ, ∫_0^1 uᵐ du = 1/(m+1)). Specializing m := n-2 with the cast (n-2 : ℕ) + 1 = (n:ℝ) - 1 for n ≥ 2 yields the stated Beta integral. No measure-theoretic axioms beyond Mathlib's intervalIntegral.integral_eq_sub_of_hasDerivAt are required."
+  },
+  "overview": {
+    "historicalContext": "The Cauchy–Crofton formula generalizes the 2D Buffon needle crossing identity ∫_0^π |cos θ| dθ = 2 to higher dimensions, replacing it with the sphere integral ∫_{S^{n-1}} |⟨v, ω⟩| dσ(ω) = 2σ_{n-2}/(n-1) · ‖v‖. The parent proof established the angular averaging identity for all n ≥ 2 by constructing the AngularAverageData structure with the explicit linear factor σ_{n-2}/(n-1). The remaining analytic gap — flagged as the key missing piece — was to prove the one-dimensional Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1), which supplies that proportionality factor when the sphere integral is decomposed in polar coordinates.",
+    "problemStatement": "For $n \\geq 2$, prove the Beta integral identity $\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}$. Equivalently, for every natural number $m$, $\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{m}\\theta \\, d\\theta = \\frac{1}{m+1}$.",
+    "proofStrategy": "The general identity is proved by the fundamental theorem of calculus. The antiderivative is F(θ) = sin^{m+1}(θ)/(m+1); its derivative is computed via HasDerivAt.pow on Real.sin composed with HasDerivAt.div_const, giving F'(θ) = cos θ · sinᵐ θ after cancelling the (m+1) factor. The integrand is continuous (Real.continuous_cos.mul (Real.continuous_sin.pow m)), hence interval-integrable, so intervalIntegral.integral_eq_sub_of_hasDerivAt applies. Evaluating F at the endpoints uses sin(π/2) = 1 and sin(0) = 0, with zero_pow eliminating the lower term. The dimensional form specializes m := n - 2 and rewrites the cast (n - 2 : ℕ) + 1 = (n : ℝ) - 1 using Nat.cast_sub for n ≥ 2.",
+    "keyInsights": [
+      "Closed-form antiderivative beats substitution machinery: rather than invoking a change-of-variables lemma, the proof exhibits F(θ) = sin^{m+1}(θ)/(m+1) directly and differentiates it, so the whole integral collapses to a two-point evaluation via FTC.",
+      "The endpoint evaluation is trivial because sin(π/2) = 1 makes the upper term 1^{m+1}/(m+1) = 1/(m+1) and sin(0) = 0 with zero_pow (m+1 ≠ 0) kills the lower term — no special-casing of m is needed.",
+      "Proving the general natural-exponent version ∫ cos θ · sinᵐ θ = 1/(m+1) first, then specializing m := n-2, isolates the only dimension-dependent step (the cast (n-2)+1 = n-1 for n ≥ 2) into a one-line Nat.cast_sub rewrite.",
+      "The identity supplies exactly the σ_{n-2}/(n-1) factor needed by the parent Cauchy–Crofton construction, closing the last analytic gap in the n ≥ 3 angular averaging argument."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Namespace",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Imports Mathlib and opens Real, intervalIntegral, and MeasureTheory. The file is self-contained — it depends only on Mathlib, not on the parent Buffon files."
+    },
+    {
+      "id": "sec-general-beta",
+      "title": "General Beta Integral via FTC",
+      "startLine": 34,
+      "endLine": 59,
+      "summary": "Proves integral_cos_mul_sin_pow: ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) for all m : ℕ. Establishes HasDerivAt for the antiderivative sin^{m+1}(θ)/(m+1) on the interval, proves continuity of the integrand, applies intervalIntegral.integral_eq_sub_of_hasDerivAt, and evaluates at the endpoints with sin(π/2) = 1, sin(0) = 0."
+    },
+    {
+      "id": "sec-dimensional",
+      "title": "Dimensional Specialization",
+      "startLine": 61,
+      "endLine": 74,
+      "summary": "Proves integral_cos_mul_sin_pow_dim: ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2. Specializes the general lemma with m := n - 2 and rewrites the cast (n - 2 : ℕ) + 1 = (n : ℝ) - 1 via Nat.cast_sub."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file gives a complete axiom-free Lean formalization of the Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2, together with its general natural-exponent form 1/(m+1). Both theorems are machine-checked with 0 sorries and 0 axioms, using only the fundamental theorem of calculus.",
+    "implications": "The identity closes the last analytic gap in the parent Cauchy–Crofton angular averaging proof for n ≥ 3: it supplies the σ_{n-2}/(n-1) proportionality factor that the AngularAverageData construction requires. More broadly, it provides a reusable closed-form template for trigonometric power integrals of the shape ∫ cos θ · sinᵐ θ.",
+    "openQuestions": [
+      "Can the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) (and more generally the full Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ) be formalized by the same FTC template?",
+      "Does Mathlib's existing integral_sin_pow / integral_cos_pow recurrence machinery yield an independent proof, and is the FTC route strictly shorter?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+      "relationship": "Parent proof of the angular averaging identity; this file supplies the Beta integral analytic core it flagged as the missing piece for n ≥ 3"
+    },
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04",
+      "relationship": "Defines AngularAverageData and the Cauchy–Crofton constant whose σ_{n-2}/(n-1) factor this integral justifies"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
+    }
+  ],
+  "highlights": [
+    "Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) proved axiom-free for n ≥ 2",
+    "General form ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) via fundamental theorem of calculus",
+    "Closes the last analytic gap in the n ≥ 3 Cauchy–Crofton angular averaging argument",
+    "Self-contained: depends only on Mathlib, 0 sorries, 0 axioms"
+  ],
+  "assumptions": [],
+  "leanFile": {
+    "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean",
+    "lineCount": 74,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "imports": [
+      "import Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "BuffonsNeedleOQ01OQ01OQ04OQ01Beta"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the candidate `buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01` by registering the already build-verified orphan `BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean` and adding its gallery entry.

The file proves the **Beta integral identity**
∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2
(and the general natural-exponent form ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1)), **axiom-free**, via the fundamental theorem of calculus with antiderivative F(θ) = sin^{m+1}(θ)/(m+1). This is the analytic core the parent Cauchy–Crofton angular-averaging proof (`buffons-needle-oq-01-oq-01-oq-04-oq-01`) flagged as the missing piece for the general n ≥ 3 case.

## Changes
- `proofs/Proofs.lean`: add `import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta`
- `src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json`: new gallery entry

## Verification
- Docker build green: **7743 jobs**, 0 sorries, 0 axioms
- `status: verified`, `badge: verified`

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta` succeeds
- [x] meta.json valid JSON, mirrors parent slug schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)