### PR TITLE
research(dilworth-theorem-oq-01): elementary directions of chain-antichain duality

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -623,6 +623,7 @@ import Proofs.DescartesRuleOfSignsOQ02OQ01
 import Proofs.DescartesRuleOfSignsOQ02OQ01OQ02
 import Proofs.DescartesRuleOfSignsOQ03
 import Proofs.DescartesRuleOfSignsOQ04
+import Proofs.DilworthTheoremOQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletsTheorem
 import Proofs.DirichletsTheoremOQ01

--- a/proofs/Proofs/DilworthTheoremOQ01.lean
+++ b/proofs/Proofs/DilworthTheoremOQ01.lean
@@ -1,0 +1,127 @@
+/-
+  Dilworth's Theorem — elementary (pigeonhole) directions of the
+  chain / antichain duality.  (dilworth-theorem-oq-01)
+
+  ## Background
+
+  In a partially ordered set, a *chain* is a set of pairwise comparable
+  elements and an *antichain* a set of pairwise incomparable elements.
+  Two classical duality theorems describe how chains and antichains trade
+  off against one another on a finite poset:
+
+  * **Dilworth's theorem** (1950): the minimum number of chains needed to
+    cover the poset equals the maximum size of an antichain.
+  * **Mirsky's theorem** (1971): the minimum number of antichains needed to
+    cover the poset equals the maximum size of a chain.
+
+  Each theorem has an *easy* and a *hard* direction.  The easy direction is a
+  one-line pigeonhole argument; the hard direction (that the bound is actually
+  attained) is the deep combinatorial content.
+
+  ## What this file proves
+
+  We formalize the **easy directions** of both theorems, which both rest on a
+  single elementary fact:
+
+      `chain_antichain_inter_subsingleton` :
+          a chain `C` and an antichain `A` share at most one element.
+
+  From this we obtain, by pigeonhole, the two inequalities:
+
+  * `antichain_card_le_of_chainCover` — every antichain is no larger than any
+    family of chains covering it.  This is the `≤` direction of Dilworth.
+  * `chain_card_le_of_antichainCover` — every chain is no larger than any family
+    of antichains covering it.  This is the `≤` direction of Mirsky.
+
+  Both are fully machine-checked over an arbitrary `PartialOrder` with no
+  finiteness assumption beyond the `Finset`s involved, hence **0 sorries,
+  0 axioms**.  The hard directions (equality / attainment) are the classical
+  deep content and are *not* claimed here.
+
+  ## Status: BUILD-TARGET.  0 axioms, 0 sorries.
+-/
+import Mathlib
+
+namespace DilworthTheoremOQ01
+
+variable {α : Type*} [PartialOrder α]
+
+/-- A `Finset` is a **chain** when its elements are pairwise comparable. -/
+def IsChainOn (C : Finset α) : Prop :=
+  ∀ ⦃x⦄, x ∈ C → ∀ ⦃y⦄, y ∈ C → x ≤ y ∨ y ≤ x
+
+/-- A `Finset` is an **antichain** when comparable members are equal, i.e.
+    distinct members are incomparable. -/
+def IsAntichainOn (A : Finset α) : Prop :=
+  ∀ ⦃x⦄, x ∈ A → ∀ ⦃y⦄, y ∈ A → x ≤ y → x = y
+
+/-- **Fundamental lemma.**  A chain and an antichain meet in at most one point:
+    any two common elements are comparable (chain) hence equal (antichain). -/
+theorem chain_antichain_inter_subsingleton
+    {C A : Finset α} (hC : IsChainOn C) (hA : IsAntichainOn A)
+    {x y : α} (hxC : x ∈ C) (hxA : x ∈ A) (hyC : y ∈ C) (hyA : y ∈ A) :
+    x = y := by
+  rcases hC hxC hyC with hxy | hyx
+  · exact hA hxA hyA hxy
+  · exact (hA hyA hxA hyx).symm
+
+/-- **Dilworth, easy direction.**  If every element of an antichain `A` lies in
+    some chain of the family `𝒞`, then `A` is no larger than `𝒞`: you need at
+    least `|A|` chains to cover an antichain of size `|A|`. -/
+theorem antichain_card_le_of_chainCover
+    {A : Finset α} (hA : IsAntichainOn A)
+    {𝒞 : Finset (Finset α)} (hchains : ∀ C ∈ 𝒞, IsChainOn C)
+    (hcover : ∀ a ∈ A, ∃ C ∈ 𝒞, a ∈ C) :
+    A.card ≤ 𝒞.card := by
+  classical
+  -- Pick, for each `a`, a chain of `𝒞` containing it (default `∅` otherwise).
+  let f : α → Finset α := fun a => if h : ∃ C ∈ 𝒞, a ∈ C then h.choose else ∅
+  have hchar : ∀ a ∈ A, f a ∈ 𝒞 ∧ a ∈ f a := by
+    intro a ha
+    have h : ∃ C ∈ 𝒞, a ∈ C := hcover a ha
+    have hfa : f a = h.choose := by
+      show (if h' : ∃ C ∈ 𝒞, a ∈ C then h'.choose else ∅) = h.choose
+      exact dif_pos h
+    rw [hfa]
+    exact ⟨h.choose_spec.1, h.choose_spec.2⟩
+  have hmem : ∀ a ∈ A, f a ∈ 𝒞 := fun a ha => (hchar a ha).1
+  by_contra hlt
+  push_neg at hlt
+  obtain ⟨x, hx, y, hy, hxy, hfxy⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmem
+  -- `x`, `y` both lie in the common chain `f x = f y`, and both in `A`.
+  have hxfx : x ∈ f x := (hchar x hx).2
+  have hyfx : y ∈ f x := hfxy ▸ (hchar y hy).2
+  have hCchain : IsChainOn (f x) := hchains _ (hmem x hx)
+  exact hxy (chain_antichain_inter_subsingleton hCchain hA hxfx hx hyfx hy)
+
+/-- **Mirsky, easy direction.**  If every element of a chain `C` lies in some
+    antichain of the family `𝒜`, then `C` is no larger than `𝒜`: you need at
+    least `|C|` antichains to cover a chain of size `|C|`. -/
+theorem chain_card_le_of_antichainCover
+    {C : Finset α} (hC : IsChainOn C)
+    {𝒜 : Finset (Finset α)} (hanti : ∀ A ∈ 𝒜, IsAntichainOn A)
+    (hcover : ∀ c ∈ C, ∃ A ∈ 𝒜, c ∈ A) :
+    C.card ≤ 𝒜.card := by
+  classical
+  let f : α → Finset α := fun c => if h : ∃ A ∈ 𝒜, c ∈ A then h.choose else ∅
+  have hchar : ∀ c ∈ C, f c ∈ 𝒜 ∧ c ∈ f c := by
+    intro c hc
+    have h : ∃ A ∈ 𝒜, c ∈ A := hcover c hc
+    have hfc : f c = h.choose := by
+      show (if h' : ∃ A ∈ 𝒜, c ∈ A then h'.choose else ∅) = h.choose
+      exact dif_pos h
+    rw [hfc]
+    exact ⟨h.choose_spec.1, h.choose_spec.2⟩
+  have hmem : ∀ c ∈ C, f c ∈ 𝒜 := fun c hc => (hchar c hc).1
+  by_contra hlt
+  push_neg at hlt
+  obtain ⟨x, hx, y, hy, hxy, hfxy⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmem
+  have hxfx : x ∈ f x := (hchar x hx).2
+  have hyfx : y ∈ f x := hfxy ▸ (hchar y hy).2
+  have hAanti : IsAntichainOn (f x) := hanti _ (hmem x hx)
+  -- Same fundamental lemma, roles of chain and antichain swapped.
+  exact hxy (chain_antichain_inter_subsingleton hC hAanti hx hxfx hy hyfx)
+
+end DilworthTheoremOQ01

--- a/research/problems/dilworth-theorem-oq-01/knowledge.md
+++ b/research/problems/dilworth-theorem-oq-01/knowledge.md
@@ -1,0 +1,53 @@
+# Dilworth's Theorem (dilworth-theorem-oq-01)
+
+## Summary
+
+Formalize the chain–antichain duality of Dilworth (1950) and its dual Mirsky
+(1971). Each is a min–max theorem with a trivial (pigeonhole) inequality and a
+deep inequality (attainment). This problem targets the **elementary directions**,
+fully machine-checked, with the deep directions documented as follow-ups.
+
+**Status**: COMPLETED (easy directions). 0 axioms, 0 sorries.
+File: `proofs/Proofs/DilworthTheoremOQ01.lean`.
+
+## Session 2026-06-16 (Session 1) — Elementary directions of the duality
+
+**Mode**: FRESH
+**Outcome**: completed (easy directions)
+
+### What I Did
+- Selected `dilworth-theorem-oq-01` after deferring `midy-theorem-oq-01`
+  (researcher-5 was actively build-running an identical proof — concurrent
+  collision avoided).
+- Defined `IsChainOn` / `IsAntichainOn` on `Finset`s over an arbitrary
+  `PartialOrder` (no global finiteness assumption).
+- Proved the fundamental lemma `chain_antichain_inter_subsingleton`: a chain and
+  an antichain meet in at most one point.
+- Derived the two pigeonhole inequalities:
+  - `antichain_card_le_of_chainCover` — Dilworth `≤`: any antichain is ≤ any
+    chain family covering it.
+  - `chain_card_le_of_antichainCover` — Mirsky `≤`: any chain is ≤ any antichain
+    family covering it (same proof, roles swapped).
+
+### Key Findings
+- Both inequalities reduce to a single pigeonhole step
+  (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`); the only real content is the
+  subsingleton lemma.
+- Encoding an antichain as `x ≤ y → x = y` keeps the `≤`-reasoning frictionless.
+- The Dilworth and Mirsky easy directions are literally dual: identical proof
+  with chain/antichain exchanged.
+- Mathlib (June 2026) has no packaged Dilworth/Mirsky theorem; `Set.chainHeight`
+  (Order/Height.lean) is the natural hook for a future hard-direction proof.
+
+### Files Modified
+- `proofs/Proofs/DilworthTheoremOQ01.lean` (new)
+- `src/data/proofs/dilworth-theorem-oq-01/meta.json` (new)
+- `proofs/Proofs.lean` (registration)
+
+### Next Steps (deep directions — open follow-ups)
+- Mirsky hard direction via the height function: `h(x)` = longest chain ending
+  at `x`; level sets `{x : h x = i}` are antichains and partition the poset into
+  `max-chain-length` antichains. Constructive; needs well-founded recursion on
+  `<` (finite poset ⇒ `WellFoundedLT`).
+- Dilworth hard direction via König / Hall on the comparability bipartite graph,
+  or strong induction removing a maximal chain.

--- a/src/data/proofs/dilworth-theorem-oq-01/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "dilworth-theorem-oq-01",
+  "title": "Dilworth & Mirsky: the elementary directions of chain–antichain duality",
+  "slug": "dilworth-theorem-oq-01",
+  "description": "The pigeonhole (easy) directions of Dilworth's and Mirsky's theorems: a chain and an antichain meet in at most one point, hence any antichain is no larger than any chain-cover (Dilworth ≤) and any chain is no larger than any antichain-cover (Mirsky ≤).",
+  "meta": {
+    "author": "Dilworth (1950), Mirsky (1971); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dilworth%27s_theorem",
+    "date": "1950",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "order-theory",
+      "poset",
+      "dilworth",
+      "mirsky",
+      "pigeonhole"
+    ],
+    "proofRepoPath": "Proofs/DilworthTheoremOQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+        "description": "Pigeonhole principle for Finsets: a map from a larger Finset into a smaller one collides on two distinct elements",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      }
+    ],
+    "originalContributions": [
+      "Finset-level definitions of chain (IsChainOn) and antichain (IsAntichainOn) on an arbitrary PartialOrder",
+      "Fundamental lemma chain_antichain_inter_subsingleton: a chain and an antichain share at most one element",
+      "Dilworth easy direction antichain_card_le_of_chainCover: |antichain| ≤ |chain cover| via pigeonhole",
+      "Mirsky easy direction chain_card_le_of_antichainCover: |chain| ≤ |antichain cover| (the dual statement)"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Only the elementary (≤) directions are proved; the deep directions (attainment of the bound) are noted as open follow-ups.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Two dual theorems.** Robert Dilworth (1950) proved that in any finite partially ordered set the minimum number of chains needed to cover the set equals the maximum size of an antichain. Leon Mirsky (1971) proved the dual: the minimum number of antichains needed to cover the set equals the maximum length of a chain. Each is a min–max theorem with a trivial inequality (one part can be read off by pigeonhole) and a deep inequality (the bound is actually attained).",
+    "problemStatement": "**Dilworth–Mirsky duality (OQ-01).** Formalize the elementary directions of both min–max theorems. Concretely: show that a chain and an antichain intersect in at most one element, and derive that an antichain can never outnumber a family of chains that covers it, nor a chain outnumber a family of antichains that covers it.",
+    "text": "The pigeonhole (easy) directions of Dilworth's and Mirsky's theorems, resting on the single fact that a chain and an antichain meet in at most one point.",
+    "proofStrategy": "**Strategy.**\n\n1. Define `IsChainOn`/`IsAntichainOn` on `Finset`s over an arbitrary `PartialOrder`.\n2. Prove the fundamental lemma: if `x, y` both lie in a chain `C` and an antichain `A`, then they are comparable (chain) and hence equal (antichain).\n3. For Dilworth's `≤`: pick for each antichain element a covering chain. The selection is injective (two elements sharing a chain would be comparable, contradicting the antichain property), so `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` forbids `|chain cover| < |antichain|`.\n4. For Mirsky's `≤`: the identical argument with the roles of chain and antichain exchanged.",
+    "keyInsights": [
+      "Both inequalities are a single pigeonhole argument; the only mathematical content is that a chain and an antichain meet in at most one point.",
+      "Encoding an antichain as `x ≤ y → x = y` (for members `x, y`) captures incomparability of distinct elements while staying convenient for `≤`-reasoning.",
+      "The Dilworth and Mirsky easy directions are literally the same proof with chain and antichain swapped, witnessing the self-duality of the construction.",
+      "No finiteness of the poset is needed — only the covering family and the chain/antichain in question are `Finset`s."
+    ],
+    "prerequisites": [
+      "Partial orders: comparability, chains, antichains",
+      "Finset cardinality and the pigeonhole principle",
+      "Classical choice (to select a covering chain per element)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Chains and Antichains on Finsets",
+      "summary": "Defines IsChainOn (pairwise comparable members) and IsAntichainOn (comparable members are equal) over an arbitrary PartialOrder.",
+      "startLine": 49,
+      "endLine": 62,
+      "mathContext": "A chain has all members pairwise comparable; an antichain has distinct members incomparable, encoded as `x ≤ y → x = y`."
+    },
+    {
+      "id": "fundamental-lemma",
+      "title": "Chain ∩ Antichain is a subsingleton",
+      "summary": "chain_antichain_inter_subsingleton: two elements common to a chain and an antichain are comparable (chain) hence equal (antichain).",
+      "startLine": 64,
+      "endLine": 73,
+      "mathContext": "The crux of both min–max bounds: $|C \\cap A| \\le 1$ for any chain $C$ and antichain $A$."
+    },
+    {
+      "id": "dilworth-easy",
+      "title": "Dilworth's Theorem (easy direction)",
+      "summary": "antichain_card_le_of_chainCover: an antichain covered by a family of chains is no larger than that family, by pigeonhole on the chain-selection map.",
+      "startLine": 75,
+      "endLine": 102,
+      "mathContext": "$|A| \\le |\\mathcal{C}|$ whenever the chains $\\mathcal{C}$ cover the antichain $A$: you need at least $|A|$ chains."
+    },
+    {
+      "id": "mirsky-easy",
+      "title": "Mirsky's Theorem (easy direction)",
+      "summary": "chain_card_le_of_antichainCover: the dual statement, a chain covered by a family of antichains is no larger than that family.",
+      "startLine": 104,
+      "endLine": 127,
+      "mathContext": "$|C| \\le |\\mathcal{A}|$ whenever the antichains $\\mathcal{A}$ cover the chain $C$: the Dilworth argument with chain and antichain exchanged."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file establishes the elementary (≤) directions of the Dilworth and Mirsky min–max theorems over an arbitrary partial order, all resting on the single fact that a chain and an antichain meet in at most one point. Verified with 0 sorries and 0 axioms.",
+    "implications": "The two inequalities are the trivial halves of two of the most important duality theorems in order theory. They already suffice for many lower-bound arguments (e.g. certifying that a poset cannot be covered by fewer than k chains by exhibiting an antichain of size k). The deep directions — that these bounds are attained — are the substantial content of Dilworth's and Mirsky's theorems and are left as open follow-ups.",
+    "openQuestions": [
+      "Formalize the hard direction of Mirsky's theorem via the height function (level sets of longest-chain-length form an optimal antichain partition).",
+      "Formalize the hard direction of Dilworth's theorem (e.g. via König's theorem / Hall's marriage theorem on a bipartite incidence structure).",
+      "Derive Mirsky's hard direction constructively for finite posets and connect it to Mathlib's Set.chainHeight."
+    ]
+  },
+  "crossReferences": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "DilworthTheoremOQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/DilworthTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "R. P. Dilworth",
+      "title": "A Decomposition Theorem for Partially Ordered Sets",
+      "year": "1950",
+      "venue": "Annals of Mathematics 51 (1): 161–166",
+      "note": "Original chain-cover / antichain duality"
+    },
+    {
+      "authors": "L. Mirsky",
+      "title": "A Dual of Dilworth's Decomposition Theorem",
+      "year": "1971",
+      "venue": "American Mathematical Monthly 78 (8): 876–877",
+      "note": "Antichain-cover / chain duality"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/dilworth-theorem-oq-01.json
+++ b/src/data/research/problems/dilworth-theorem-oq-01.json
@@ -1,0 +1,95 @@
+{
+  "slug": "dilworth-theorem-oq-01",
+  "title": "Dilworth's Theorem: Chain–Antichain Duality",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall \\text{ chain } C, \\text{ antichain } A:\\ |C \\cap A| \\le 1;\\quad |A| \\le |\\mathcal{C}|\\ (\\text{chain cover});\\quad |C| \\le |\\mathcal{A}|\\ (\\text{antichain cover})",
+    "plain": "Formalize the elementary (pigeonhole) directions of Dilworth's and Mirsky's chain-antichain duality theorems.",
+    "whyMatters": [
+      "Dilworth's and Mirsky's theorems are foundational min-max dualities in order theory.",
+      "The easy directions already certify lower bounds (e.g. a size-k antichain forces at least k chains to cover the poset)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "chain_antichain_inter_subsingleton: a chain and an antichain share at most one element",
+      "antichain_card_le_of_chainCover: Dilworth easy direction (|antichain| <= |chain cover|)",
+      "chain_card_le_of_antichainCover: Mirsky easy direction (|chain| <= |antichain cover|)"
+    ],
+    "open": [
+      "Hard direction of Dilworth (chain cover number = max antichain size)",
+      "Hard direction of Mirsky (antichain cover number = max chain length)"
+    ],
+    "goal": "Machine-checked elementary directions of the chain-antichain duality; hard directions left as follow-ups."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-16T08:00:00.000Z",
+    "iteration": 1,
+    "focus": "Elementary (pigeonhole) directions of Dilworth and Mirsky.",
+    "blockers": [],
+    "nextAction": "Optional: formalize the hard direction of Mirsky via the height function.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (easy directions): 3 theorems, 2 defs, 0 axioms, 0 sorries.",
+    "builtItems": [
+      "IsChainOn / IsAntichainOn Finset predicates over an arbitrary PartialOrder (DilworthTheoremOQ01.lean)",
+      "chain_antichain_inter_subsingleton (DilworthTheoremOQ01.lean)",
+      "antichain_card_le_of_chainCover — Dilworth easy direction (DilworthTheoremOQ01.lean)",
+      "chain_card_le_of_antichainCover — Mirsky easy direction (DilworthTheoremOQ01.lean)"
+    ],
+    "insights": [
+      "Both inequalities reduce to one pigeonhole step (Finset.exists_ne_map_eq_of_card_lt_of_maps_to); the sole content is the chain∩antichain subsingleton lemma.",
+      "Encoding antichains as 'x ≤ y → x = y' for members keeps ≤-reasoning frictionless.",
+      "The Dilworth and Mirsky easy directions are the same proof with chain/antichain exchanged (self-dual)."
+    ],
+    "mathlibGaps": [
+      "Mathlib (June 2026) has no packaged Dilworth or Mirsky theorem; Set.chainHeight (Order/Height.lean) is the natural hook for a future hard-direction proof."
+    ],
+    "nextSteps": [
+      "Mirsky hard direction via height function h(x)=longest chain ending at x; level sets are antichains partitioning the poset into max-chain-length parts.",
+      "Dilworth hard direction via König/Hall on the comparability graph or induction removing a maximal chain."
+    ],
+    "markdown": "See research/problems/dilworth-theorem-oq-01/knowledge.md for the full session log."
+  },
+  "approaches": [
+    {
+      "name": "Pigeonhole on chain/antichain selection map",
+      "outcome": "success",
+      "note": "Easy directions of both Dilworth and Mirsky via Finset pigeonhole."
+    }
+  ],
+  "tags": [
+    "combinatorics",
+    "order-theory",
+    "poset",
+    "dilworth",
+    "mirsky"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [
+      "R. P. Dilworth, A Decomposition Theorem for Partially Ordered Sets, Ann. Math. 51 (1950) 161-166",
+      "L. Mirsky, A Dual of Dilworth's Decomposition Theorem, Amer. Math. Monthly 78 (1971) 876-877"
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Dilworth%27s_theorem"
+    ],
+    "mathlib": [
+      "Mathlib.Combinatorics.Pigeonhole"
+    ]
+  },
+  "started": "2026-06-16T08:00:00.000Z",
+  "lastUpdate": "2026-06-16T08:00:00.000Z",
+  "completed": "2026-06-16T08:00:00.000Z",
+  "significance": 5,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Formalizes the **easy (pigeonhole) directions** of two classical order-theory min–max theorems, over an arbitrary `PartialOrder` (no global finiteness assumption):

- **Dilworth (1950)** — chain cover vs. max antichain.
- **Mirsky (1971)** — antichain cover vs. max chain.

Both rest on one elementary fact and are proved by a single pigeonhole step.

## What's proved (`proofs/Proofs/DilworthTheoremOQ01.lean`, 127 lines)

- `chain_antichain_inter_subsingleton` — a chain and an antichain share at most one element (comparable ⟹ equal).
- `antichain_card_le_of_chainCover` — Dilworth's `≤`: `|A| ≤ |𝒞|` when chains `𝒞` cover antichain `A`.
- `chain_card_le_of_antichainCover` — Mirsky's `≤`: `|C| ≤ |𝒜|` when antichains `𝒜` cover chain `C` (same proof, roles swapped).

Engine: `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (pigeonhole) applied to a chain/antichain-selection map that is forced injective by the subsingleton lemma.

## Verification

- `✔ [7743/7743] Built Proofs.DilworthTheoremOQ01` via docker-build.sh
- **0 axioms, 0 sorries**, 3 theorems, 2 definitions.

## Scope / honesty

Only the **elementary directions** are claimed. The deep directions (that these bounds are *attained*) are the substantial content of Dilworth's/Mirsky's theorems and are left as documented open follow-ups (Mirsky via the height function; Dilworth via König/Hall).

## Files

- `proofs/Proofs/DilworthTheoremOQ01.lean` (new), registered in `proofs/Proofs.lean`
- `src/data/proofs/dilworth-theorem-oq-01/meta.json` (gallery)
- `src/data/research/problems/dilworth-theorem-oq-01.json`, `research/problems/dilworth-theorem-oq-01/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)