### PR TITLE
Enrich Minkowski ideal-bound OQ-03: fix invalid enums, realign, cover PID theorems

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-03/annotations.json
@@ -3,11 +3,11 @@
     "id": "ann-mink-oq03-header",
     "proofId": "minkowski-theorem-oq-03",
     "range": { "startLine": 1, "endLine": 58 },
-    "type": "context",
+    "type": "concept",
     "title": "From Lattice Points to Ideal Norms",
     "content": "Minkowski's geometry of numbers turns a volume estimate into a nonzero lattice point. Through Mathlib's canonical (mixed) embedding of a number field, this becomes the Minkowski bound M_K and the statement that every ideal class contains an integral ideal of norm ≤ M_K. This file names that bound (Mathlib hides it as a local notation), restates the bound, and derives a new explicit upper bound on the class number.",
     "mathContext": "For a number field $K$ of degree $n$ with $r_2$ complex places and discriminant $d_K$, the Minkowski bound is $M_K = (4/\\pi)^{r_2}\\,(n!/n^n)\\,\\sqrt{|d_K|}$. The classical theorem: every ideal class of $\\mathcal{O}_K$ has a representative integral ideal of absolute norm $\\le M_K$.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "Minkowski bound",
       "geometry of numbers",
@@ -26,9 +26,9 @@
     "range": { "startLine": 60, "endLine": 72 },
     "type": "definition",
     "title": "Naming the Minkowski Bound",
-    "content": "`minkowskiIdealBound K` is defined to be exactly the expression behind Mathlib's local notation `M K`. Because the two are definitionally identical, every Mathlib lemma stated with `M K` can be re-used against the named constant by simple unfolding. `minkowskiIdealBound_nonneg` records that the bound is ≥ 0 (a product of nonnegative factors), which is the only hypothesis needed to floor it.",
+    "content": "`minkowskiIdealBound K` is defined to be exactly the expression behind Mathlib's local notation `M K`. Because the two are definitionally identical, every Mathlib lemma stated with `M K` can be re-used against the named constant by simple unfolding. `minkowskiIdealBound_nonneg` records that the bound is ≥ 0 (a product of nonnegative factors, dispatched by `positivity`), which is the only hypothesis needed to floor it.",
     "mathContext": "$M_K = (4/\\pi)^{r_2} \\cdot \\dfrac{n!}{n^n} \\cdot \\sqrt{|d_K|} \\ge 0$ since each factor is nonnegative.",
-    "significance": "infrastructure",
+    "significance": "supporting",
     "relatedConcepts": ["Minkowski bound", "discriminant", "complex places"],
     "prerequisites": ["finrank", "NumberField.discr", "Real.sqrt"]
   },
@@ -40,7 +40,7 @@
     "title": "Minkowski's Ideal-Norm Bound",
     "content": "`exists_ideal_in_class_absNorm_le`: every ideal class C contains an integral ideal I with mk0 I = C and (absNorm I : ℝ) ≤ minkowskiIdealBound K. The proof unfolds the named bound and applies Mathlib's `NumberField.exists_ideal_in_class_of_norm_le` directly — this is the precise sense in which the geometry of numbers bounds ideal norms.",
     "mathContext": "Every class $C \\in \\mathrm{Cl}(\\mathcal{O}_K)$ has a representative integral ideal $I$ with $\\mathrm{absNorm}(I) \\le M_K$.",
-    "significance": "key-result",
+    "significance": "key",
     "relatedConcepts": ["ideal class group", "ideal norm", "Minkowski bound"],
     "prerequisites": ["NumberField.exists_ideal_in_class_of_norm_le", "ClassGroup.mk0"]
   },
@@ -52,7 +52,7 @@
     "title": "An Explicit Bound on the Class Number",
     "content": "`classNumber_le_card_absNorm_le`: classNumber K ≤ #{ I : absNorm I ≤ ⌊M_K⌋ }. The index set is finite (`Ideal.finite_setOf_absNorm_le₀`); the class-representative map is surjective because every class has a representative of norm ≤ M_K, floored to ⌊M_K⌋ via `Nat.le_floor`; and a surjection from a finite set bounds cardinality (`Nat.card_le_card_of_surjective`), with `classNumber = Fintype.card (ClassGroup …) = Nat.card (ClassGroup …)`.",
     "mathContext": "$\\#\\mathrm{Cl}(\\mathcal{O}_K) \\le \\#\\{\\, I : \\mathrm{absNorm}(I) \\le \\lfloor M_K\\rfloor \\,\\}$. This is the formal justification for the standard class-number algorithm: enumerating ideals below the Minkowski bound already meets every ideal class.",
-    "significance": "key-result",
+    "significance": "key",
     "relatedConcepts": [
       "class number",
       "finiteness of the class group",
@@ -66,9 +66,51 @@
     ]
   },
   {
+    "id": "ann-mink-oq03-pid-criterion",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 107, "endLine": 148 },
+    "type": "theorem",
+    "title": "PID Criterion: M_K < 2 Forces Class Number 1",
+    "content": "`classNumber_eq_one_of_minkowskiIdealBound_lt_two`: if M_K < 2 then classNumber K = 1. This is the qualitative payoff of the head-count. Since 0 ≤ M_K < 2, the floor satisfies ⌊M_K⌋₊ ≤ 1 (proved by contradiction via `Nat.le_floor_iff`). Every ideal I in the head-count set then has absNorm I ≤ 1; but nonzero ideals have absNorm ≥ 1 (`Ideal.absNorm_pos_of_nonZeroDivisors`), so absNorm I = 1, which forces I = ⊤ (`Ideal.absNorm_eq_one_iff`). Hence the index set is a `Subsingleton`, so `Nat.card ≤ 1`; combined with `classNumber_le_card_absNorm_le` and `NumberField.classNumber_pos`, `omega` pins classNumber K = 1. This recovers the classical 'no ideal class survives the Minkowski bound' PID test directly from counting, rather than via the discriminant route `RingOfIntegers.isPrincipalIdealRing_of_abs_discr_lt`.",
+    "mathContext": "$M_K < 2 \\Rightarrow \\lfloor M_K\\rfloor_+ \\le 1 \\Rightarrow$ every integral ideal with $\\mathrm{absNorm} \\le 1$ is $\\top$ (since $\\mathrm{absNorm}\\,I = 1 \\iff I = \\top$), so the head-count set is a subsingleton and $1 \\le \\#\\mathrm{Cl}(\\mathcal{O}_K) \\le 1$, giving class number $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "principal ideal domain",
+      "Minkowski bound PID test",
+      "subsingleton",
+      "ideal norm one iff unit ideal"
+    ],
+    "prerequisites": [
+      "Ideal.absNorm_eq_one_iff",
+      "Ideal.absNorm_pos_of_nonZeroDivisors",
+      "Nat.le_floor_iff",
+      "NumberField.classNumber_pos",
+      "Nat.card_le_one"
+    ]
+  },
+  {
+    "id": "ann-mink-oq03-pid-ring",
+    "proofId": "minkowski-theorem-oq-03",
+    "range": { "startLine": 150, "endLine": 155 },
+    "type": "theorem",
+    "title": "Packaged as a Principal-Ideal-Ring Criterion",
+    "content": "`isPrincipalIdealRing_of_minkowskiIdealBound_lt_two`: a number field whose Minkowski bound is below 2 has a principal ideal ring of integers. This is a one-line wrapper that feeds `classNumber_eq_one_of_minkowskiIdealBound_lt_two` through the Mathlib equivalence `NumberField.classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K)`. It is the form most consumers want: a structural conclusion about 𝓞_K rather than the numeric class number.",
+    "mathContext": "$M_K < 2 \\Rightarrow \\mathrm{classNumber}\\,K = 1 \\iff \\mathcal{O}_K \\text{ is a PID}$. The equivalence $\\mathrm{classNumber}\\,K = 1 \\Leftrightarrow \\mathrm{IsPrincipalIdealRing}\\,\\mathcal{O}_K$ is `NumberField.classNumber_eq_one_iff`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "principal ideal ring",
+      "class number one",
+      "ring of integers"
+    ],
+    "prerequisites": [
+      "NumberField.classNumber_eq_one_iff",
+      "IsPrincipalIdealRing"
+    ]
+  },
+  {
     "id": "ann-mink-oq03-finiteness-corollary",
     "proofId": "minkowski-theorem-oq-03",
-    "range": { "startLine": 108, "endLine": 113 },
+    "range": { "startLine": 157, "endLine": 160 },
     "type": "insight",
     "title": "Finiteness as the Qualitative Shadow of the Head-Count",
     "content": "The closing `example : Finite (ClassGroup (𝓞 K))` re-derives the finiteness of the class group purely from `inferInstance`. The point is conceptual rather than logical: once the explicit estimate `classNumber_le_card_absNorm_le` is in hand, finiteness is the *qualitative shadow* of a quantitative bound. A set whose cardinality is bounded by that of a finite set (the ideals of norm ≤ ⌊M_K⌋) is automatically finite, so Mathlib's `instFintypeClassGroup` and the historical finiteness theorem are recovered as a one-line corollary of the head-count rather than proved independently.",


### PR DESCRIPTION
## Enrichment pass for `minkowski-theorem-oq-03`

The existing annotations had good prose but several schema and coverage defects.

### Schema fixes
- **Invalid type**: header used `type: "context"`, not a member of `AnnotationType` (`theorem|lemma|definition|tactic|concept|insight|warning`) → `concept`.
- **Invalid significance** (×4): `"context"`, `"infrastructure"`, `"key-result"` are not in `AnnotationSignificance` (`critical|key|supporting`) → mapped to `supporting`/`key`.

### Realignment
- The `finiteness-corollary` annotation describes the closing `example : Finite (ClassGroup (𝓞 K))` (line 160), but its `range` pointed at lines 108–113 — the docstring of the PID-criterion theorem. Re-anchored to `157–160`.

### Coverage
- Added annotations for the two previously-uncovered main theorems:
  - **`classNumber_eq_one_of_minkowskiIdealBound_lt_two`** (107–148): M_K < 2 ⟹ the head-count set is a subsingleton (every ideal of norm ≤ 1 is ⊤) ⟹ class number 1.
  - **`isPrincipalIdealRing_of_minkowskiIdealBound_lt_two`** (150–155): the PID wrapper via `NumberField.classNumber_eq_one_iff`.

### Validation
- `resolver.ts validate` → **Valid: 7, Misaligned: 0** against the 162-line source.
- All 7 annotations carry `content`, `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; types/significance conform to the frontend enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)