### PR TITLE
Enrich Shannon Noisy Channel Coding Theorem: realign + expand annotations

### DIFF
--- a/src/data/proofs/shannon-channel-coding/annotations.json
+++ b/src/data/proofs/shannon-channel-coding/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "shannon-channel-coding",
     "range": {
       "startLine": 1,
-      "endLine": 10
+      "endLine": 20
     },
     "type": "concept",
     "title": "Shannon's 1948 Revolution",
-    "content": "Claude Shannon's 1948 paper 'A Mathematical Theory of Communication' is one of the most influential scientific papers ever written. It established information theory as a mathematical discipline and answered the fundamental question of telecommunications: can we communicate reliably over a noisy channel? Shannon's surprising answer was yes — at any rate below channel capacity. This overturned the engineering intuition that noise forces arbitrarily slow communication. The paper introduced entropy, mutual information, and channel capacity as rigorous mathematical quantities.",
+    "content": "Claude Shannon's 1948 paper 'A Mathematical Theory of Communication' is one of the most influential scientific papers ever written. It established information theory as a mathematical discipline and answered the fundamental question of telecommunications: can we communicate reliably over a noisy channel? Shannon's surprising answer was yes — at any rate below channel capacity. This overturned the engineering intuition that noise forces arbitrarily slow communication. The docstring records the file's exact accounting: 3 axioms (the two coding-theorem halves and the BSC capacity value), 18 proved theorems, and 0 sorries — the supporting capacity bounds and Fano machinery are fully machine-checked, while only the deep random-coding/joint-typicality arguments are taken as axioms.",
     "mathContext": "Shannon (1948): reliable communication is possible at rate $R$ iff $R < C = \\max_{p(x)} I(X;Y)$",
     "significance": "key",
     "relatedConcepts": [
@@ -24,46 +24,189 @@
     ]
   },
   {
-    "id": "ann-channel-capacity",
+    "id": "ann-dmchannel",
     "proofId": "shannon-channel-coding",
     "range": {
-      "startLine": 17,
-      "endLine": 19
+      "startLine": 35,
+      "endLine": 44
     },
     "type": "definition",
-    "title": "Channel Capacity Definition",
-    "content": "Channel capacity is defined as $C = \\max_{p(x)} I(X;Y)$, the maximum mutual information over all input distributions. The function is `noncomputable` because the optimization over the probability simplex requires the axiom of choice (existence of a maximum of a continuous function on a compact set). The channel is represented as a transition matrix $W : \\alpha \\to \\beta \\to \\mathbb{R}$ where $W(x)(y) = p(y|x)$. The sorry'd definition needs the full mutual information formula $I(X;Y) = \\sum_{x,y} p(x) W(x)(y) \\log \\frac{W(x)(y)}{\\sum_{x'} p(x') W(x')(y)}$.",
-    "mathContext": "$C = \\max_{p(x)} I(X;Y) = \\max_{p(x)} \\left[ H(Y) - H(Y|X) \\right]$",
+    "title": "Discrete Memoryless Channel and Input Distribution",
+    "content": "A discrete memoryless channel (DMChannel) is a row-stochastic transition matrix $W : \\alpha \\to \\beta \\to \\mathbb{R}$ with $W(x,y) = P(Y=y \\mid X=x)$, bundled with proofs that each row is non-negative and sums to one. The `InputDist` structure is a probability distribution on the input alphabet. Encoding the stochastic constraints as structure fields (`nonneg`, `sum_one`) rather than separate hypotheses means every channel and input distribution carries its own validity certificate, so downstream lemmas never need to re-assume them. 'Memoryless' means that over $n$ uses the channel acts independently per symbol, $P(y^n\\mid x^n)=\\prod_i W(x_i,y_i)$ — this product structure surfaces later in the achievability axiom.",
+    "mathContext": "$W : \\alpha \\to \\beta \\to \\mathbb{R}$, $W(x,y) = P(Y=y\\mid X=x)$, with $W(x,y)\\ge 0$ and $\\sum_y W(x,y)=1$ for each input $x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "transition matrix",
+      "row-stochastic matrix",
+      "conditional probability",
+      "memoryless channel"
+    ],
+    "prerequisites": [
+      "conditional probability",
+      "Fintype",
+      "probability distribution"
+    ]
+  },
+  {
+    "id": "ann-mutual-information",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 46,
+      "endLine": 57
+    },
+    "type": "definition",
+    "title": "Joint Distribution and Channel Mutual Information",
+    "content": "The joint law of input and output is $P(X=x,Y=y)=p(x)\\,W(x,y)$ (`jointDist`), and the channel mutual information `channelMI` is the `mutualInformation` of that joint distribution, imported from the companion `ShannonEntropy` development. Mutual information $I(X;Y)$ measures how many bits the output reveals about the input; it is the integrand that channel capacity maximizes. Both definitions are `noncomputable` because the underlying entropy uses `Real.log`, which is defined via classical real analysis rather than an algorithm.",
+    "mathContext": "$I(X;Y) = \\sum_{x,y} p(x)W(x,y)\\,\\log\\dfrac{W(x,y)}{\\sum_{x'} p(x')W(x',y)} = H(Y) - H(Y\\mid X)$",
     "significance": "key",
     "relatedConcepts": [
       "mutual information",
-      "optimization on simplex",
-      "concavity",
-      "noncomputable"
+      "joint distribution",
+      "Shannon entropy",
+      "Kullback–Leibler divergence"
     ],
     "prerequisites": [
+      "Shannon entropy",
+      "joint distributions",
+      "logarithms"
+    ]
+  },
+  {
+    "id": "ann-channel-capacity",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "Channel Capacity as a Supremum",
+    "content": "Channel capacity is defined as $C = \\sup\\{\\,I(X;Y) : p_X \\text{ an input distribution}\\,\\}$ using `sSup` over the set of achievable mutual informations. For finite alphabets the supremum is in fact attained (the simplex of input distributions is compact and $I$ is continuous), but the supremum formulation avoids carrying the compactness/attainment argument and is exactly what the capacity bounds below need: `le_csSup` and `csSup_le` reduce capacity inequalities to per-input inequalities. The set is non-empty (any point mass is an input distribution) and bounded above by $\\log|\\beta|$, the two facts that make `sSup` well-behaved here.",
+    "mathContext": "$C(W) = \\sup_{p_X} I(X;Y)$; finite alphabets ensure the sup is achieved by concavity of $I$ on the compact input simplex.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "supremum",
+      "channel capacity",
+      "concavity",
+      "compactness"
+    ],
+    "prerequisites": [
+      "supremum / sSup",
       "mutual information",
-      "probability simplex",
-      "Fintype"
+      "probability simplex"
+    ]
+  },
+  {
+    "id": "ann-jointdist-props",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 68,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "Joint Law Is a Probability Distribution",
+    "content": "Three foundational lemmas: `jointDist_nonneg` (each $p(x)W(x,y)\\ge 0$, a product of non-negatives), `jointDist_sum_one` (the joint law sums to 1 — pull out $p(x)$, use each channel row sums to one, then the input sums to one), and `channelMI_nonneg` ($I(X;Y)\\ge 0$, inherited from the non-negativity of mutual information of any genuine joint distribution). These certify that `jointDist` really is a probability distribution, which is the hypothesis every subsequent entropy/mutual-information bound consumes.",
+    "mathContext": "$\\sum_{x,y} p(x)W(x,y) = \\sum_x p(x)\\sum_y W(x,y) = \\sum_x p(x) = 1$, and $I(X;Y)\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "probability distribution",
+      "non-negativity of mutual information",
+      "Fubini / sum interchange"
+    ],
+    "prerequisites": [
+      "finite sums",
+      "mutual information",
+      "probability distributions"
+    ]
+  },
+  {
+    "id": "ann-mi-le-logcard",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 89,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "Mutual Information Bounded by Output Entropy",
+    "content": "`channelMI_le_log_card` proves $I(X;Y) \\le \\log|\\beta|$ via the chain $I(X;Y) \\le H(Y) \\le \\log|\\beta|$. The first inequality is `mutual_info_le_entropy_snd` (mutual information never exceeds the entropy of either marginal); the second is `entropy_le_log_card` (entropy of any distribution on $\\beta$ is maximized by the uniform law, value $\\log|\\beta|$). The proof must first check the $Y$-marginal $\\sum_x p(x)W(x,y)$ is itself a probability distribution — non-negativity is pointwise and the sum-to-one uses `Finset.sum_comm` to swap the order of summation. This bound is what makes the capacity supremum finite.",
+    "mathContext": "$I(X;Y) \\le H(Y) \\le \\log|\\beta|$, with equality in the second step iff $Y$ is uniform.",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximum entropy",
+      "uniform distribution",
+      "data processing",
+      "bounded above"
+    ],
+    "prerequisites": [
+      "entropy bounds",
+      "marginal distributions",
+      "sum interchange"
+    ]
+  },
+  {
+    "id": "ann-capacity-bounds",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 110,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "Capacity Localised to [0, log |β|]",
+    "content": "Three supremum lemmas pin down the capacity. `capacity_nonneg` ($C\\ge 0$): the point-mass input at any symbol gives a non-negative mutual information sitting below the sup, via `le_csSup_of_le`. `channelMI_le_capacity`: every particular input's $I(X;Y)$ is $\\le C$ by `le_csSup` — the single-letter ingredient the converse later rearranges. `capacity_le_log_card` ($C\\le\\log|\\beta|$): `csSup_le` reduces the upper bound on the sup to the per-input bound `channelMI_le_log_card`. Together: $0 \\le C(W) \\le \\log|\\beta|$ for every channel with a non-empty input alphabet.",
+    "mathContext": "$0 \\le C(W) \\le \\log|\\beta|$; `le_csSup`/`csSup_le` convert sup-inequalities into per-input inequalities.",
+    "significance": "key",
+    "relatedConcepts": [
+      "supremum bounds",
+      "BddAbove",
+      "single-letter characterization",
+      "point mass distribution"
+    ],
+    "prerequisites": [
+      "supremum / infimum",
+      "csSup lemmas",
+      "mutual information bounds"
+    ]
+  },
+  {
+    "id": "ann-blockcode",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 171,
+      "endLine": 188
+    },
+    "type": "definition",
+    "title": "Block Codes and Code Rate",
+    "content": "A `BlockCode` over alphabet $\\alpha$ and length $n$ packages $M$ codewords ($M>0$) as an encoder $\\mathrm{Fin}\\,M \\to \\mathrm{Fin}\\,n \\to \\alpha$. Its rate $R = \\frac{1}{n}\\log M$ (`rate_of_code`, in nats) measures information per channel use; `rate_of_code_pos` confirms $R\\ge 0$ since $\\log M\\ge 0$ for $M\\ge 1$. Rate is the operational quantity Shannon's theorem compares against the analytic capacity $C$: codes exist below $C$ and fail above it.",
+    "mathContext": "$R = \\dfrac{\\log M}{n}$ nats/use; the coding theorem contrasts $R$ with capacity $C$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "block code",
+      "code rate",
+      "encoder",
+      "information rate"
+    ],
+    "prerequisites": [
+      "logarithms",
+      "Fin / finite types",
+      "channel capacity"
     ]
   },
   {
     "id": "ann-fano",
     "proofId": "shannon-channel-coding",
     "range": {
-      "startLine": 23,
-      "endLine": 27
+      "startLine": 190,
+      "endLine": 208
     },
-    "type": "concept",
-    "title": "Fano's Inequality (Placeholder)",
-    "content": "Fano's inequality (Robert Fano, 1961) is the key tool for the converse of the channel coding theorem. It states that $H(X|Y) \\leq h(P_e) + P_e \\log(|\\mathcal{X}|-1)$, where $P_e = \\Pr[X \\neq \\hat{X}]$ is the error probability and $h$ is the binary entropy function. Intuitively: if decoding error is small, then $Y$ must carry most of the information about $X$, so conditional entropy $H(X|Y)$ is small. The formalization currently proves `True` because stating the full inequality requires defining conditional entropy and the binary entropy function.",
-    "mathContext": "$H(X|Y) \\leq h(P_e) + P_e \\log(|\\mathcal{X}|-1)$ where $h(p) = -p\\log p - (1-p)\\log(1-p)$",
-    "significance": "key",
+    "type": "theorem",
+    "title": "Fano's Inequality (Proved)",
+    "content": "Fano's inequality (Robert Fano, 1961) is the analytic heart of the converse: $H(X\\mid Y) \\le h(P_e) + P_e\\log(|\\mathcal X|-1)$, where $P_e$ is the error probability of the optimal estimator of $X$ from $Y$ and $h$ is the binary entropy function. Intuitively, if $Y$ almost determines $X$ (small $P_e$) then little uncertainty about $X$ remains. Here it is a genuine machine-checked theorem — discharged via `FanoFromConditionalEntropy.fano_inequality_proved` in the companion file `Proofs.ShannonChannelCodingOQ02OQ01` — not a placeholder. The Fano error term $P_e = 1 - \\sum_y \\sum_x p(x,y)^2/p_Y(y)$ is the explicit conditional-collision form used throughout the converse lemmas.",
+    "mathContext": "$H(X\\mid Y) \\le h(P_e) + P_e\\log(|\\mathcal X|-1)$, with $h(p) = -p\\log p - (1-p)\\log(1-p)$.",
+    "significance": "critical",
     "relatedConcepts": [
       "Fano's inequality",
       "conditional entropy",
       "binary entropy",
-      "data processing inequality"
+      "estimation error"
     ],
     "prerequisites": [
       "conditional entropy",
@@ -72,22 +215,142 @@
     ]
   },
   {
+    "id": "ann-fano-converse-step",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 210,
+      "endLine": 256
+    },
+    "type": "theorem",
+    "title": "Single-Letter Converse Step",
+    "content": "`fano_converse_step` assembles the converse's single-letter identity. For a joint distribution whose $X$-marginal is uniform ($H(p_X)=\\log|\\alpha|$), it proves $\\log|\\alpha| \\le I(X;Y) + h(P_e) + P_e\\log(|\\alpha|-1)$. The whole proof is one `linarith` over three inputs: the chain rule $I(X;Y) = H(p_X) - H(X\\mid Y)$, the uniform hypothesis $H(p_X)=\\log|\\alpha|$, and Fano's inequality bounding $H(X\\mid Y)$. Stating the uniform-entropy fact as an abstract hypothesis keeps the lemma reusable for any max-entropy marginal and avoids importing uniform-distribution plumbing into this file.",
+    "mathContext": "$\\log|\\alpha| \\le I(X;Y) + h(P_e) + P_e\\log(|\\alpha|-1)$ when $H(p_X)=\\log|\\alpha|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "chain rule",
+      "Fano's inequality",
+      "uniform input",
+      "converse"
+    ],
+    "prerequisites": [
+      "chain rule for mutual information",
+      "Fano's inequality",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-fano-converse-capacity",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 258,
+      "endLine": 325
+    },
+    "type": "theorem",
+    "title": "Single-Letter Converse with Capacity",
+    "content": "`fano_converse_capacity` specialises the converse step to an actual channel with uniform input: $\\log|\\alpha| \\le C(W) + h(P_e) + P_e\\log(|\\alpha|-1)$. Two bridges are needed: the $X$-marginal of `jointDist ch inp` equals `inp.p` (because each channel row sums to one), and a uniform `inp.p` has entropy $\\log|\\alpha|$ (via `entropy_of_uniform_eq_log_card`), discharging the abstract hypothesis of `fano_converse_step`. Replacing $I(X;Y)$ by its upper bound $C(W)$ via `channelMI_le_capacity` and combining with `linarith` yields the capacity form — the worst-case (uniform codebook) single-letter converse that block-coding arguments invoke at each channel use.",
+    "mathContext": "$\\log|\\alpha| \\le C(W) + h(P_e) + P_e\\log(|\\alpha|-1)$ for uniform input $p(x)=|\\alpha|^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "channel capacity",
+      "uniform input",
+      "marginal distribution",
+      "converse"
+    ],
+    "prerequisites": [
+      "fano_converse_step",
+      "entropy of uniform distribution",
+      "channelMI_le_capacity"
+    ]
+  },
+  {
+    "id": "ann-fano-converse-shannon",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 327,
+      "endLine": 373
+    },
+    "type": "theorem",
+    "title": "Shannon-Form Converse Bound",
+    "content": "`fano_converse_shannon_form` rearranges the capacity converse into the textbook inequality $(1-P_e)\\log|\\alpha| \\le C(W) + h(P_e)$ (Cover–Thomas §7.9 eq. 7.150; MacKay §10.4). The key move absorbs the always-non-negative slack $P_e\\log(|\\alpha|-1) \\le P_e\\log|\\alpha|$ — using `Real.log_le_log` on $|\\alpha|-1 \\le |\\alpha|$ for $|\\alpha|\\ge 2$ — then closes with `nlinarith`. This is the cleanest entry point for asymptotic block-coding converses: combined with the per-block bound $I(X^n;Y^n)\\le nC$, it forces $P_e \\ge 1 - C/\\log|\\alpha| - 1/\\log|\\alpha|$ for any rate-$R$ code with $R>C$, the quantitative impossibility statement.",
+    "mathContext": "$(1-P_e)\\log|\\alpha| \\le C(W) + h(P_e)$, the standard weak-converse form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weak converse",
+      "rate–capacity gap",
+      "binary entropy",
+      "asymptotic equipartition"
+    ],
+    "prerequisites": [
+      "fano_converse_capacity",
+      "monotonicity of log",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-fano-converse-marginal",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 375,
+      "endLine": 463
+    },
+    "type": "theorem",
+    "title": "Non-Uniform Marginal Converse",
+    "content": "`fano_converse_step_marginal` and `fano_converse_marginal` generalise the converse to arbitrary (non-uniform) input marginals: $H(p_X) \\le I(X;Y) + h(P_e) + P_e\\log(|\\alpha|-1)$, and its channel form $H(\\mathrm{inp}.p) \\le C(W) + h(P_e) + P_e\\log(|\\alpha|-1)$. The proof simply drops the uniform rewrite, carrying $H(p_X)$ through the chain rule instead of replacing it by $\\log|\\alpha|$. Because $H(p_X) < \\log|\\alpha|$ for any non-uniform marginal, the gap $\\log|\\alpha| - H(p_X) > 0$ quantifies the strict slack between this bound and the worst-case uniform-input converse — making explicit how much a sub-optimal input distribution loosens the impossibility bound.",
+    "mathContext": "$H(p_X) \\le I(X;Y) + h(P_e) + P_e\\log(|\\alpha|-1)$; uniform $p_X$ recovers the $\\log|\\alpha|$ form.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "marginal entropy",
+      "non-uniform input",
+      "entropy gap",
+      "converse"
+    ],
+    "prerequisites": [
+      "chain rule for mutual information",
+      "Fano's inequality",
+      "marginal distributions"
+    ]
+  },
+  {
+    "id": "ann-weakly-symmetric",
+    "proofId": "shannon-channel-coding",
+    "range": {
+      "startLine": 465,
+      "endLine": 543
+    },
+    "type": "theorem",
+    "title": "Weakly Symmetric Channels Achieve Capacity at Uniform Input",
+    "content": "A channel is `IsWeaklySymmetric` (Cover–Thomas §7.2) when its rows are permutations of one another and all columns share a common sum. `weaklySymmetric_colSum_eq` computes that common column sum: total mass $\\sum_{x,y} W(x,y) = |\\alpha|$ forces each of the $|\\beta|$ columns to sum to $|\\alpha|/|\\beta|$. `weaklySymmetric_uniform_output_marginal` then shows the uniform input $p(x)=|\\alpha|^{-1}$ produces a uniform output marginal $|\\beta|^{-1}$. Row-permutation invariance makes the row entropy $H(W(\\cdot\\mid x))$ independent of $x$; combined with the uniform output, this gives the closed form $C = \\log|\\beta| - H_{\\text{row}}$, achieved by uniform input — a constructive capacity formula for this symmetric class (the BSC being the canonical example).",
+    "mathContext": "$\\sum_x W(x,y) = |\\alpha|/|\\beta|$ for all $y$; uniform input $\\Rightarrow$ uniform output $\\Rightarrow$ $C = \\log|\\beta| - H_{\\text{row}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weakly symmetric channel",
+      "capacity-achieving input",
+      "uniform output marginal",
+      "row entropy"
+    ],
+    "prerequisites": [
+      "permutations / equivalences",
+      "double counting of sums",
+      "channel capacity"
+    ]
+  },
+  {
     "id": "ann-achievability",
     "proofId": "shannon-channel-coding",
     "range": {
-      "startLine": 31,
-      "endLine": 36
+      "startLine": 545,
+      "endLine": 563
     },
     "type": "concept",
-    "title": "Channel Coding Achievability (Random Coding)",
-    "content": "The achievability half of the channel coding theorem: for any rate $R < C$, codes exist with vanishing error probability. Shannon's original proof uses random coding — generate $2^{nR}$ codewords i.i.d. from the capacity-achieving input distribution and decode using joint typicality. The error probability vanishes exponentially fast: $P_e \\leq 2^{-n(C-R-\\delta)}$ for any $\\delta > 0$. This is a probabilistic method argument avant la lettre: a random codebook works, so a good deterministic codebook exists. Currently proves `True`.",
-    "mathContext": "$R < C \\implies \\exists$ code sequence with $P_e^{(n)} \\leq 2^{-n(C-R-\\delta)} \\to 0$",
-    "significance": "key",
+    "title": "Channel Coding Achievability (Axiom)",
+    "content": "The achievability half — stated as the axiom `channel_coding_achievability` — asserts that for any rate $R < C$ and any $\\varepsilon>0$, sufficiently long block codes exist whose average error probability is below $\\varepsilon$. Shannon's proof is the celebrated random-coding argument: draw $2^{nR}$ codewords i.i.d. from a capacity-achieving input and decode by joint typicality; the expected error over random codebooks vanishes as $P_e \\le 2^{-n(C-R-\\delta)}$, so some deterministic codebook is at least as good. The averaged error in the axiom statement is exactly the codebook-mean of the per-message miss probability $1 - \\sum_y P(y\\mid \\text{codeword}_i)\\,\\mathbb 1[\\text{decode}(y)=i]$. This direction is axiomatized because formalizing joint typicality and the AEP is a substantial separate development.",
+    "mathContext": "$R < C \\implies \\exists$ code family with $\\bar P_e^{(n)} \\le 2^{-n(C-R-\\delta)} \\to 0$.",
+    "significance": "critical",
     "relatedConcepts": [
       "random coding",
       "joint typicality",
-      "error exponent",
-      "probabilistic method"
+      "probabilistic method",
+      "asymptotic equipartition"
     ],
     "prerequisites": [
       "channel capacity",
@@ -99,19 +362,19 @@
     "id": "ann-converse",
     "proofId": "shannon-channel-coding",
     "range": {
-      "startLine": 40,
-      "endLine": 45
+      "startLine": 565,
+      "endLine": 580
     },
     "type": "concept",
-    "title": "Channel Coding Converse (via Fano)",
-    "content": "The converse half: for rates above capacity, error probability cannot vanish. The proof chains: data processing inequality shows $I(W; \\hat{W}) \\leq nC$ (where $W$ is the message, $\\hat{W}$ the decoded message), while Fano's inequality gives $H(W|\\hat{W}) \\leq 1 + P_e nR$. Since $H(W) = nR$, combining gives $nR \\leq nC + 1 + P_e nR$, so $P_e \\geq 1 - C/R - 1/(nR) \\to 1 - C/R > 0$ when $R > C$. Currently proves `True`.",
-    "mathContext": "$R > C \\implies \\liminf_{n \\to \\infty} P_e^{(n)} \\geq 1 - C/R > 0$",
-    "significance": "key",
+    "title": "Channel Coding Converse (Axiom)",
+    "content": "The converse half — the axiom `channel_coding_converse` — asserts that above capacity ($R>C$) the average error probability is bounded below by a positive constant $\\delta$ uniformly in block length. Its standard proof is precisely the Fano machinery proved above: the data-processing inequality gives $I(W;\\hat W)\\le nC$, Fano gives $H(W\\mid\\hat W)\\le 1 + P_e\\,nR$, and since $H(W)=nR$ one obtains $nR \\le nC + 1 + P_e nR$, hence $P_e \\ge 1 - C/R - 1/(nR)$. The single-letter lemmas `fano_converse_shannon_form` and `fano_converse_capacity` in this file are exactly the per-use ingredients of that argument; the axiom packages the full block-length statement, whose complete formalization requires stitching them across $n$ uses.",
+    "mathContext": "$R > C \\implies \\liminf_{n\\to\\infty} \\bar P_e^{(n)} \\ge 1 - C/R > 0$.",
+    "significance": "critical",
     "relatedConcepts": [
       "weak converse",
-      "strong converse",
       "data processing inequality",
-      "Fano's inequality"
+      "Fano's inequality",
+      "rate–capacity gap"
     ],
     "prerequisites": [
       "Fano's inequality",
@@ -123,18 +386,19 @@
     "id": "ann-bsc",
     "proofId": "shannon-channel-coding",
     "range": {
-      "startLine": 49,
-      "endLine": 51
+      "startLine": 582,
+      "endLine": 607
     },
-    "type": "concept",
-    "title": "Binary Symmetric Channel Capacity",
-    "content": "The binary symmetric channel BSC(p) flips each bit independently with probability $p$. Its capacity is $C = 1 - h(p)$ bits per channel use, where $h(p) = -p \\log_2 p - (1-p) \\log_2(1-p)$ is the binary entropy function. At $p = 0$ (noiseless), $C = 1$; at $p = 1/2$ (pure noise), $C = 0$. The BSC is the simplest non-trivial channel model and is the standard example in every information theory textbook. Currently proves `True`.",
-    "mathContext": "$C_{\\text{BSC}}(p) = 1 - h(p) = 1 + p\\log_2 p + (1-p)\\log_2(1-p)$",
+    "type": "definition",
+    "title": "Binary Symmetric Channel and Its Capacity",
+    "content": "The binary symmetric channel BSC($p$) (`bsc`) flips each bit independently with probability $p$: $W(x,y) = 1-p$ if $x=y$ else $p$. Its capacity $C = \\log 2 - h(p)$ nats ($1 - h(p)$ bits) is stated as the axiom `bsc_capacity_eq`, with the uniform Bernoulli$(1/2)$ input achieving it (BSC is the canonical weakly symmetric channel). Two sanity bounds are proved outright from the axiom and the general entropy inequalities: `bsc_capacity_le_one` ($C \\le \\log 2$, since $h(p)\\ge 0$) and `bsc_capacity_nonneg` ($C \\ge 0$, since $h(p)\\le\\log 2$). At $p=0$ the channel is noiseless ($C=\\log 2$); at $p=1/2$ it carries no information ($C=0$).",
+    "mathContext": "$C_{\\text{BSC}}(p) = \\log 2 - h(p)$ nats $= 1 - h(p)$ bits, with $0 \\le C \\le \\log 2$ proved.",
     "significance": "supporting",
     "relatedConcepts": [
       "binary symmetric channel",
       "binary entropy function",
-      "channel capacity computation"
+      "weakly symmetric channel",
+      "capacity computation"
     ],
     "prerequisites": [
       "binary entropy",

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -197,9 +197,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.ChannelCoding",
-    "lineCount": 555,
+    "lineCount": 609,
     "axiomCount": 3,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 9,
     "path": "Proofs/ShannonChannelCoding.lean",
     "sorries": 0


### PR DESCRIPTION
## Enrichment pass for `shannon-channel-coding`

The `annotations.json` for this entry was badly stale. It described an old
stub version of the Lean file — annotations pointed at lines 1–51 and the
content claimed the definitions were `sorry`'d and that Fano's inequality,
achievability, converse, and the BSC capacity all merely "prove `True`".
Meanwhile the actual Lean file had grown to 609 lines of fully proved
development (3 axioms, 18 proved theorems, 0 sorries).

### What changed
- **Realigned + rewrote annotations** to match the current proved file:
  17 annotations, all `Valid` / `0 Misaligned` per
  `scripts/annotations/resolver.ts validate`, now covering the whole file
  through line 607 (was 6 annotations ending at line 51).
- **Corrected false stub language**: Fano's inequality is now annotated as a
  proved theorem (discharged via `Proofs.ShannonChannelCodingOQ02OQ01`); the
  capacity bounds and single-letter converse lemmas are machine-checked;
  only `channel_coding_achievability`, `channel_coding_converse`, and
  `bsc_capacity_eq` remain as the 3 stated axioms.
- **Added coverage** for previously unannotated sections: the DMChannel /
  InputDist structures, joint-distribution properties, the
  `[0, log|β|]` capacity bounds, block codes, the Fano-converse chain
  (`fano_converse_step` → `fano_converse_capacity` → Shannon-form →
  marginal forms), weakly-symmetric channels, and the BSC.
- **Fixed stale meta fields**: `leanFile.lineCount` 555→609 and
  `leanFile.theoremCount` 16→18 (the primary `meta.meta` values were already
  correct at 609/18).

### Axiom integrity
Status remains `axiomatized` / badge `axiom` / `axiomCount: 3`, accurately
reflecting the file. No status was upgraded.

Validated via `resolver.ts validate` (JSON + line-alignment) and the strict
annotation validator (this entry: 0 errors).