### PR TITLE
Enrich Erdős #864 (Almost-Sidon): fix severely stale annotations

### DIFF
--- a/src/data/proofs/erdos-864/annotations.json
+++ b/src/data/proofs/erdos-864/annotations.json
@@ -1,21 +1,45 @@
 [
   {
+    "id": "erdos-864-ann-header",
+    "proofId": "erdos-864",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 20
+    },
+    "title": "Erdős #864: Almost-Sidon Sets",
+    "content": "Erdős Problem #864 asks for the maximum size of $A \\subseteq \\{1,\\dots,N\\}$ in which at most one integer has multiple representations as $a+b$ ($a\\le b\\in A$) — a Sidon set relaxed to permit exactly one collision. Erdős and Freud (1991) gave a construction achieving $(1+o(1))(2/\\sqrt3)\\sqrt N$ and conjectured it optimal; the matching upper bound remains open. This file formalizes the objects, proves the elementary Sidon counting bounds (both sum- and difference-counting), and proves that the reflected construction is valid — leaving only the deep Erdős–Freud asymptotic lower bound as an axiom.",
+    "mathContext": "$\\max|A|$ over $A\\subseteq[N]$ with $|\\{n: r_A(n)\\ge 2\\}|\\le 1$; conjectured $(1+o(1))\\tfrac{2}{\\sqrt3}\\sqrt N$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sidon sets",
+      "additive combinatorics",
+      "B_2 sets",
+      "reflected construction"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "number theory",
+      "sumsets"
+    ]
+  },
+  {
     "id": "erdos-864-ann-reprcount",
     "proofId": "erdos-864",
     "type": "definition",
     "range": {
-      "startLine": 30,
-      "endLine": 31
+      "startLine": 29,
+      "endLine": 36
     },
-    "title": "Sum Representation Count",
-    "content": "Defines `sumRepCount A n` as the cardinality of $\\{(a,b) \\in A \\times A : a \\leq b,\\, a + b = n\\}$. The ordering constraint $a \\leq b$ avoids double-counting: each unordered pair $\\{a, b\\}$ contributes once. A collision at $n$ means $\\text{sumRepCount}(A, n) \\geq 2$: at least two distinct pairs sum to $n$.",
-    "mathContext": "$r_A(n) = |\\{(a,b) : a \\leq b,\\, a,b \\in A,\\, a+b = n\\}|$",
+    "title": "Sum Representation Count and Multi-Rep Set",
+    "content": "`sumRepCount A n` is the cardinality of $\\{(a,b)\\in A\\times A : a\\le b,\\ a+b=n\\}$; the constraint $a\\le b$ counts each unordered pair once. `multiRepSet A` images all pairwise sums and keeps those $n$ with $\\text{sumRepCount}\\ge 2$ — exactly the integers that suffer a collision. These two `def`s are the computational backbone: every later property (Sidon, almost-Sidon, the counting bounds) is phrased through them.",
+    "mathContext": "$r_A(n) = |\\{(a,b): a\\le b,\\ a,b\\in A,\\ a+b=n\\}|$, $\\ \\text{multiRepSet}(A)=\\{n: r_A(n)\\ge 2\\}$.",
     "significance": "key",
     "relatedConcepts": [
-      "Finset.filter",
-      "Finset.card",
       "representation function",
-      "B_2 sets"
+      "Finset.filter",
+      "Finset.image",
+      "collision detection"
     ],
     "prerequisites": [
       "Finset product",
@@ -24,249 +48,267 @@
     ]
   },
   {
-    "id": "erdos-864-ann-multirepset",
+    "id": "erdos-864-ann-sidon-defs",
     "proofId": "erdos-864",
     "type": "definition",
     "range": {
-      "startLine": 34,
-      "endLine": 36
+      "startLine": 38,
+      "endLine": 48
     },
-    "title": "Multi-Representation Set",
-    "content": "Defines `multiRepSet A` as the set of integers with $\\geq 2$ sum representations from $A$. Computed by imaging all pairwise sums from $A \\times A$ then filtering for those with $\\text{sumRepCount} \\geq 2$. For a Sidon set this is empty; for an almost-Sidon set it has at most one element.",
-    "mathContext": "$\\text{multiRepSet}(A) = \\{n \\in \\mathbb{N} : r_A(n) \\geq 2\\}$",
-    "significance": "key",
-    "relatedConcepts": [
-      "Finset.image",
-      "Finset.filter",
-      "collision detection"
-    ],
-    "prerequisites": [
-      "sumRepCount",
-      "Finset operations"
-    ]
-  },
-  {
-    "id": "erdos-864-ann-almostsidon",
-    "proofId": "erdos-864",
-    "type": "definition",
-    "range": {
-      "startLine": 39,
-      "endLine": 40
-    },
-    "title": "Almost-Sidon Set",
-    "content": "Defines `IsAlmostSidon A` as $|\\text{multiRepSet}(A)| \\leq 1$: at most one integer has multiple sum representations. This is strictly weaker than the Sidon condition ($|\\text{multiRepSet}| = 0$) and strictly stronger than unconstrained ($|\\text{multiRepSet}|$ arbitrary). The single allowed collision enables the reflected construction to exceed the Sidon bound.",
-    "mathContext": "$A$ is almost-Sidon $\\iff |\\{n : r_A(n) \\geq 2\\}| \\leq 1$",
+    "title": "Sidon, Almost-Sidon, and the Extremal Function",
+    "content": "`IsSidon A` ($|\\text{multiRepSet}(A)|=0$): all pairwise sums distinct. `IsAlmostSidon A` ($|\\text{multiRepSet}(A)|\\le 1$): at most one collision — strictly between Sidon and unconstrained. `maxAlmostSidon N` is the `Finset.sup` of $|A|$ over almost-Sidon subsets of $\\{1,\\dots,N\\}$, marked `noncomputable` only because the powerset it ranges over is exponentially large. The single permitted collision is precisely what lets the reflected construction beat the Sidon bound by the factor $2/\\sqrt3\\approx 1.155$.",
+    "mathContext": "$A$ Sidon $\\iff r_A\\le 1$ everywhere; almost-Sidon $\\iff$ at most one $n$ with $r_A(n)\\ge 2$.",
     "significance": "key",
     "relatedConcepts": [
       "Sidon sets",
-      "B_2^+ sets",
-      "collision bound"
+      "B_2 sets",
+      "extremal function",
+      "Finset.sup"
     ],
     "prerequisites": [
       "multiRepSet",
-      "Finset.card"
+      "Finset.powerset",
+      "Finset.Icc"
     ]
   },
   {
-    "id": "erdos-864-ann-sidon",
+    "id": "erdos-864-ann-freud-axiom",
     "proofId": "erdos-864",
-    "type": "definition",
+    "type": "concept",
     "range": {
-      "startLine": 43,
-      "endLine": 44
+      "startLine": 54,
+      "endLine": 60
     },
-    "title": "Sidon Set",
-    "content": "Defines `IsSidon A` as $|\\text{multiRepSet}(A)| = 0$: no integer has multiple sum representations, meaning all pairwise sums $a + b$ ($a \\leq b$) are distinct. Classical results: $|A| \\leq \\sqrt{N} + O(N^{1/4})$ (Lindström 1969), with constructions achieving $\\sqrt{N} - O(N^{5/8})$ (Cilleruelo 2010).",
-    "mathContext": "$A$ is Sidon ($B_2$) $\\iff$ all sums $a + b$ with $a \\leq b \\in A$ are distinct $\\iff |\\text{multiRepSet}(A)| = 0$",
-    "significance": "key",
+    "title": "Erdős–Freud Lower Bound (the file's sole axiom)",
+    "content": "`erdos_freud_lower_bound` is the one and only axiom in this file: for every $\\varepsilon>0$, eventually $\\text{maxAlmostSidon}(N) \\ge (2/\\sqrt3-\\varepsilon)\\sqrt N$. Its proof requires Sidon sets of size $\\sim\\sqrt{N/3}$ inside $\\{1,\\dots,N/3\\}$ (Singer/finite-geometry constructions not yet in Mathlib), reflected via $A=B\\cup\\{N-b\\}$. Notably, `reflected_construction_bound` below proves the conditional statement $\\text{maxAlmostSidon}(N)\\ge 2|B|$ outright, so this axiom is reduced to the pure existence of large Sidon sets.",
+    "mathContext": "$\\forall \\varepsilon>0,\\ \\exists N_0,\\ \\forall N\\ge N_0:\\ \\text{maxAlmostSidon}(N)\\ge (2/\\sqrt3-\\varepsilon)\\sqrt N$.",
+    "significance": "critical",
     "relatedConcepts": [
-      "B_2 sets",
-      "Lindström bound",
-      "Singer construction"
+      "Singer construction",
+      "Sidon set existence",
+      "reflected construction",
+      "axiom"
     ],
     "prerequisites": [
-      "multiRepSet"
+      "maxAlmostSidon",
+      "Real.sqrt",
+      "Sidon constructions"
     ]
   },
   {
-    "id": "erdos-864-ann-maxalmostsidon",
+    "id": "erdos-864-ann-exceeds",
     "proofId": "erdos-864",
-    "type": "definition",
+    "type": "theorem",
     "range": {
-      "startLine": 47,
-      "endLine": 48
+      "startLine": 62,
+      "endLine": 113
     },
-    "title": "Maximum Almost-Sidon Size",
-    "content": "Defines `maxAlmostSidon N` as the supremum of $|A|$ over all almost-Sidon $A \\subseteq \\{1, \\ldots, N\\}$. Computed as `Finset.sup` over the powerset of `Icc 1 N` filtered by `IsAlmostSidon`. Marked `noncomputable` since the powerset is exponentially large. The conjecture asserts this is $(1 + o(1)) \\cdot (2/\\sqrt{3}) \\cdot \\sqrt{N}$.",
-    "mathContext": "$\\text{maxAlmostSidon}(N) = \\max\\{|A| : A \\subseteq [N],\\, A \\text{ almost-Sidon}\\}$",
+    "title": "Almost-Sidon Strictly Exceeds Sidon (Proved)",
+    "content": "`almost_sidon_exceeds_sidon` proves that for large $N$, $\\text{maxAlmostSidon}(N) > \\sqrt N + 1$ — a genuine strict separation from the Sidon regime. The argument feeds $\\varepsilon=1/10$ into the Erdős–Freud lower bound and shows the coefficient $2/\\sqrt3-1/10>1$ via the rational bound $\\sqrt3 < 40/23$ (since $3 < (40/23)^2$), then multiplies by $\\sqrt N\\ge 20$ for $N\\ge 400$. The preceding comment block also records that the Lindström $\\sqrt N + O(N^{1/4})$ Sidon bound needs Fourier methods, whereas the elementary difference-counting bound `sidon_card_sq_le_2N` (proved below) gives $|A|\\le\\sqrt{2N}$.",
+    "mathContext": "$\\exists N_0,\\ \\forall N\\ge N_0:\\ \\text{maxAlmostSidon}(N) > \\sqrt N + 1$, using $2/\\sqrt3 > 1$.",
     "significance": "key",
     "relatedConcepts": [
-      "Finset.sup",
-      "powerset",
-      "noncomputable",
-      "extremal function"
+      "strict separation",
+      "rational approximation of √3",
+      "Lindström bound",
+      "Real.sqrt monotonicity"
+    ],
+    "prerequisites": [
+      "erdos_freud_lower_bound",
+      "Real.sqrt bounds",
+      "linarith / nlinarith"
+    ]
+  },
+  {
+    "id": "erdos-864-ann-basic-closure",
+    "proofId": "erdos-864",
+    "type": "theorem",
+    "range": {
+      "startLine": 115,
+      "endLine": 137
+    },
+    "title": "Basic Closure Properties (Proved)",
+    "content": "Three small proved facts: `sidon_is_almost_sidon` (every Sidon set is almost-Sidon — $0\\le 1$ by `omega` after unfolding), `isAlmostSidon_empty` (the empty set is almost-Sidon, by `simp`), and `isAlmostSidon_subset` (almost-Sidon is downward closed: $\\text{multiRepSet}$ is monotone under $\\subseteq$, so the collision count cannot increase). These establish that almost-Sidon is a genuine hereditary set property — the structural hygiene the extremal arguments rely on.",
+    "mathContext": "$\\text{IsSidon}\\,A\\Rightarrow\\text{IsAlmostSidon}\\,A$; $A\\subseteq B\\wedge\\text{IsAlmostSidon}\\,B\\Rightarrow\\text{IsAlmostSidon}\\,A$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "hereditary property",
+      "monotonicity",
+      "Finset.card_le_card",
+      "omega"
     ],
     "prerequisites": [
       "IsAlmostSidon",
-      "Finset.Icc",
-      "Finset.powerset"
-    ]
-  },
-  {
-    "id": "erdos-864-ann-conjecture",
-    "proofId": "erdos-864",
-    "type": "concept",
-    "range": {
-      "startLine": 52,
-      "endLine": 57
-    },
-    "title": "Main Conjecture (Placeholder)",
-    "content": "Axiomatizes `erdos_864_conjecture` as `True`: the full conjecture $\\text{maxAlmostSidon}(N) \\leq (1 + o(1)) \\cdot (2/\\sqrt{3}) \\cdot \\sqrt{N}$ is not formalized here. Combined with the Erdős-Freud lower bound, this would give the exact asymptotics. The placeholder indicates the statement is open and its precise formalization (involving $o(1)$ terms) is deferred.",
-    "mathContext": "Conjecture: $\\text{maxAlmostSidon}(N) = (1 + o(1)) \\cdot \\frac{2}{\\sqrt{3}} \\cdot \\sqrt{N}$",
-    "significance": "key",
-    "relatedConcepts": [
-      "asymptotic notation",
-      "o(1) terms",
-      "open problem"
-    ],
-    "prerequisites": [
-      "maxAlmostSidon",
-      "Real.sqrt"
-    ]
-  },
-  {
-    "id": "erdos-864-ann-lower",
-    "proofId": "erdos-864",
-    "type": "concept",
-    "range": {
-      "startLine": 61,
-      "endLine": 67
-    },
-    "title": "Erdős-Freud Lower Bound",
-    "content": "Axiomatizes `erdos_freud_lower_bound`: for all $\\varepsilon > 0$, eventually $\\text{maxAlmostSidon}(N) \\geq (2/\\sqrt{3} - \\varepsilon)\\sqrt{N}$. The proof: take a Sidon set $B \\subseteq \\{1, \\ldots, N/3\\}$ of size $\\approx \\sqrt{N/3}$ (exists by probabilistic/algebraic constructions), and form $A = B \\cup \\{N - b : b \\in B\\}$. Then $|A| \\approx 2\\sqrt{N/3} = (2/\\sqrt{3})\\sqrt{N}$.",
-    "mathContext": "$\\text{maxAlmostSidon}(N) \\geq (2/\\sqrt{3} - \\varepsilon)\\sqrt{N}$ for $N \\geq N_0(\\varepsilon)$",
-    "significance": "key",
-    "relatedConcepts": [
-      "reflected construction",
-      "Sidon set existence",
-      "Real.sqrt"
-    ],
-    "prerequisites": [
-      "maxAlmostSidon",
-      "Sidon set constructions"
-    ]
-  },
-  {
-    "id": "erdos-864-ann-sidonupper",
-    "proofId": "erdos-864",
-    "type": "concept",
-    "range": {
-      "startLine": 69,
-      "endLine": 73
-    },
-    "title": "Sidon Upper Bound",
-    "content": "Axiomatizes `sidon_upper_bound`: for Sidon sets in $\\{1, \\ldots, N\\}$, $|A| \\leq \\sqrt{N} + C \\cdot N^{1/4}$. This classical result (Lindström 1969, improving Erdős-Turán 1941) follows from the pigeonhole principle: $\\binom{|A|}{2} + |A|$ distinct sums must fit in $[2, 2N]$. The almost-Sidon bound is conjectured to be $(2/\\sqrt{3})\\sqrt{N}$, a factor $\\approx 1.155$ larger.",
-    "mathContext": "Sidon: $|A| \\leq \\sqrt{N} + O(N^{1/4})$; Almost-Sidon: $|A| \\leq (2/\\sqrt{3} + o(1))\\sqrt{N}$ (conjectured)",
-    "significance": "key",
-    "relatedConcepts": [
-      "Lindström bound",
-      "Erdős-Turán 1941",
-      "pigeonhole principle"
-    ],
-    "prerequisites": [
-      "IsSidon",
-      "Real.sqrt",
-      "distinct sum counting"
-    ]
-  },
-  {
-    "id": "erdos-864-ann-implies",
-    "proofId": "erdos-864",
-    "type": "concept",
-    "range": {
-      "startLine": 81,
-      "endLine": 84
-    },
-    "title": "Sidon Implies Almost-Sidon (Proved)",
-    "content": "Proves `sidon_is_almost_sidon`: every Sidon set is almost-Sidon. The proof unfolds both definitions (`IsSidon`: $|\\text{multiRepSet}| = 0$; `IsAlmostSidon`: $|\\text{multiRepSet}| \\leq 1$) and closes with `omega` since $0 \\leq 1$. This is the only proved theorem in the file, establishing the trivial containment $\\text{Sidon} \\subseteq \\text{AlmostSidon}$.",
-    "mathContext": "$|\\text{multiRepSet}(A)| = 0 \\implies |\\text{multiRepSet}(A)| \\leq 1$",
-    "significance": "key",
-    "relatedConcepts": [
-      "omega tactic",
-      "unfold",
-      "trivial implication"
-    ],
-    "prerequisites": [
-      "IsSidon",
-      "IsAlmostSidon"
+      "multiRepSet",
+      "Finset subset"
     ]
   },
   {
     "id": "erdos-864-ann-paircount",
     "proofId": "erdos-864",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 100,
-      "endLine": 101
+      "startLine": 143,
+      "endLine": 197
     },
-    "title": "Pairwise Sum Count",
-    "content": "Axiomatizes `pairwise_sum_count`: the number of ordered pairs $(a, b)$ with $a \\leq b$ in $A$ is $|A|(|A|+1)/2 = \\binom{|A|}{2} + |A|$. This counts both the $\\binom{|A|}{2}$ pairs with $a < b$ and the $|A|$ diagonal pairs $a = b$. For Sidon sets, each pair gives a distinct sum; for almost-Sidon, at most two pairs may share one sum.",
-    "mathContext": "$|\\{(a,b) \\in A^2 : a \\leq b\\}| = \\binom{|A|}{2} + |A| = \\frac{|A|(|A|+1)}{2}$",
+    "title": "Upper-Triangle Pair Count (Proved)",
+    "content": "`pairwise_sum_count` proves (it is NOT an axiom) that the number of ordered pairs $(a,b)\\in A^2$ with $a\\le b$ is $|A|(|A|+1)/2$. The proof partitions $A\\times A$ into strict-upper, diagonal, and strict-lower triangles, shows the diagonal has $|A|$ elements (image of $a\\mapsto(a,a)$) and the two strict triangles are equinumerous via the swap involution $(a,b)\\mapsto(b,a)$, then solves $n^2 = 2u + n$ for the upper-triangle size with `omega`. This count is what the Sidon sum-bound divides into the available range $[2,2N]$.",
+    "mathContext": "$|\\{(a,b)\\in A^2: a\\le b\\}| = \\binom{|A|}{2}+|A| = \\tfrac{|A|(|A|+1)}{2}$.",
     "significance": "supporting",
     "relatedConcepts": [
-      "binomial coefficient",
-      "diagonal pairs",
-      "Finset.filter"
+      "double counting",
+      "involution",
+      "triangular numbers",
+      "Finset partition"
     ],
     "prerequisites": [
       "Finset product",
-      "cardinality arithmetic"
+      "card_image_of_injective",
+      "card_union_of_disjoint"
     ]
   },
   {
-    "id": "erdos-864-ann-sumrange",
+    "id": "erdos-864-ann-sum-counting",
     "proofId": "erdos-864",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 105,
-      "endLine": 107
+      "startLine": 199,
+      "endLine": 294
     },
-    "title": "Sum Range Constraint",
-    "content": "Axiomatizes `almost_sidon_sum_range`: for almost-Sidon $A \\subseteq \\{1, \\ldots, N\\}$, at most one sum has a collision, so $\\geq |A|(|A|+1)/2 - 1$ distinct sums must fit in $[2, 2N]$. This gives $|A|(|A|+1)/2 - 1 \\leq 2N - 1$, i.e., $|A| = O(\\sqrt{N})$. The precise constant in the almost-Sidon case is conjectured to be $2/\\sqrt{3}$.",
-    "mathContext": "$A \\subseteq [N]$ almost-Sidon $\\implies \\frac{|A|(|A|+1)}{2} - 1 \\leq 2N - 1$",
+    "title": "Sidon Sum-Counting Bound: k² ≤ 4N (Proved)",
+    "content": "The sum-counting route to the Sidon bound. `sum_in_range` confines each sum $a+b$ to $[2,2N]$; `distinct_sums_bounded` therefore bounds the number of distinct sums by $2N-1$; `sidon_counting_bound` shows the sum map is injective on the upper triangle for a Sidon set (via `isSidon_sumRepCount_le_one`), giving $|A|(|A|+1)/2 \\le 2N-1$; and `sidon_card_sq_le` extracts the clean corollary $|A|^2 \\le 4N$, i.e. $|A| < 2\\sqrt N + 1$. (`isSidon_subset` here also records that Sidon-ness is hereditary.)",
+    "mathContext": "Sidon $A\\subseteq[N]$: $\\tfrac{|A|(|A|+1)}{2}\\le 2N-1$, hence $|A|^2\\le 4N$.",
     "significance": "key",
     "relatedConcepts": [
-      "sum range",
-      "pigeonhole argument",
-      "quadratic constraint"
+      "injectivity on upper triangle",
+      "pigeonhole",
+      "distinct sums",
+      "Sidon counting"
     ],
     "prerequisites": [
       "pairwise_sum_count",
-      "IsAlmostSidon"
+      "Set.InjOn",
+      "card_image_of_injOn"
     ]
   },
   {
-    "id": "erdos-864-ann-reflected",
+    "id": "erdos-864-ann-diff-injective",
     "proofId": "erdos-864",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 111,
-      "endLine": 113
+      "startLine": 296,
+      "endLine": 369
     },
-    "title": "Reflected Construction Validity",
-    "content": "Axiomatizes `reflected_construction_valid`: if $B$ is Sidon in $\\{1, \\ldots, N/3\\}$, then $B \\cup \\{N - b : b \\in B\\}$ is almost-Sidon. The key insight: the only collision occurs at sum $N$, since $b + (N - b) = N$ for every $b \\in B$. No other sum has a collision because: sums within $B$ are distinct (Sidon), sums within $N - B$ are distinct (Sidon by reflection), and cross-sums $b + (N - b')$ with $b \\neq b'$ are distinct since $B \\subseteq \\{1, \\ldots, N/3\\}$ prevents overlap.",
-    "mathContext": "$B$ Sidon in $[N/3] \\implies B \\cup (N - B)$ is almost-Sidon with collision only at $n = N$",
+    "title": "Sum-Sidon ⇒ Difference-Injective (Proved)",
+    "content": "`isSidon_diff_injective` is the bridge from sum-Sidon to the sharper difference bound: if $a_1-b_1 = a_2-b_2$ with $a_i>b_i$, then $(a_1,b_1)=(a_2,b_2)$. From the equal differences it derives $a_1+b_2=a_2+b_1$, then exhibits two ordered pairs realizing that common sum and invokes the Sidon property ($\\text{sumRepCount}\\le 1$) to force them equal. The proof case-splits on the relative orders of the entries, each branch building the appropriate ordered pair in the filter; mismatched branches yield $a=b$ contradictions against $a_i>b_i$.",
+    "mathContext": "$a_1-b_1=a_2-b_2,\\ a_i>b_i \\Rightarrow a_1=a_2\\wedge b_1=b_2$ for Sidon $A$.",
     "significance": "key",
+    "relatedConcepts": [
+      "difference set",
+      "case analysis",
+      "Sidon property",
+      "card_le_one"
+    ],
+    "prerequisites": [
+      "isSidon_sumRepCount_le_one",
+      "Finset.filter membership",
+      "omega"
+    ]
+  },
+  {
+    "id": "erdos-864-ann-diff-counting",
+    "proofId": "erdos-864",
+    "type": "theorem",
+    "range": {
+      "startLine": 371,
+      "endLine": 470
+    },
+    "title": "Improved Difference-Counting Bound: k² ≤ 2N + k (Proved)",
+    "content": "The headline elementary result, roughly twice as strong as the sum bound. `sidon_diff_counting_bound` proves the $k(k-1)/2$ positive differences of a Sidon set are distinct (by `isSidon_diff_injective`) and lie in $\\{1,\\dots,N-1\\}$, giving $k(k-1)\\le 2(N-1)$; the proof again partitions $A\\times A$ into lower/diagonal/upper triangles to relate $|L|$ to $k^2$. `sidon_card_sq_le_2N` then yields $|A|^2 \\le 2N + |A|$, i.e. $|A|\\lesssim\\sqrt{2N}$ — and, as the meta records, this PROVED bound eliminated the file's former `sidon_upper_bound` axiom (the file went from 2 axioms to 1).",
+    "mathContext": "Sidon $A\\subseteq[N]$: $k(k-1)\\le 2(N-1)$, hence $|A|^2\\le 2N+|A|$ (improves $|A|^2\\le 4N$ by $\\sim 2\\times$).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "difference counting",
+      "axiom elimination",
+      "triangle partition",
+      "Sidon bound"
+    ],
+    "prerequisites": [
+      "isSidon_diff_injective",
+      "Finset partition",
+      "omega"
+    ]
+  },
+  {
+    "id": "erdos-864-ann-false-removed",
+    "proofId": "erdos-864",
+    "type": "warning",
+    "range": {
+      "startLine": 472,
+      "endLine": 502
+    },
+    "title": "A Removed False Bound, and the Collision Lemma",
+    "content": "A documented pitfall: the tempting bound $k(k+1)/2 - 1 \\le 2N-1$ for almost-Sidon sets is FALSE — the file records the counterexample $A=\\{1,2,4,6,7\\}\\subseteq[7]$, whose single collision at sum $8$ has multiplicity $3$ ($1+7=2+6=4+4$), so the number of distinct sums drops by $c-1=2$, not $1$. The correct statement accounts for collision multiplicity; `distinct_sums_bounded` is the sound replacement. Immediately below, the private lemma `isSidon_sumRepCount_le_one` packages 'Sidon $\\Rightarrow$ every sum has $\\le 1$ representation', the workhorse used throughout the counting proofs.",
+    "mathContext": "Counterexample $\\{1,2,4,6,7\\}$: $\\tfrac{5\\cdot6}{2}-1=14 > 13 = 2\\cdot7-1$; multiplicity-3 collision breaks the naive bound.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "collision multiplicity",
+      "counterexample",
+      "false-claim removal",
+      "soundness"
+    ],
+    "prerequisites": [
+      "sumRepCount",
+      "IsAlmostSidon",
+      "IsSidon"
+    ]
+  },
+  {
+    "id": "erdos-864-ann-reflected-valid",
+    "proofId": "erdos-864",
+    "type": "theorem",
+    "range": {
+      "startLine": 504,
+      "endLine": 738
+    },
+    "title": "Reflected Construction Is Almost-Sidon (Proved)",
+    "content": "`reflected_construction_valid` is the file's largest proof (NOT an axiom): if $B$ is Sidon in $\\{1,\\dots,N/3\\}$ then $A = B \\cup \\{N-b : b\\in B\\}$ is almost-Sidon, with the only collision at sum $N$ (since $b+(N-b)=N$ for all $b$). The proof shows $\\text{multiRepSet}(A)\\subseteq\\{N\\}$ by classifying every colliding pair as same-side-$B$, cross, or same-side-$B'$, using disjoint sum ranges — $B$-sums lie in $[2,2N/3]$, cross-sums in $[N-N/3+1,\\,N/3+N-1]$, $B'$-sums in $[2(N-N/3),\\,\\dots]$ — so any repeated sum must be the unique cross value $N$, with the Sidon property of $B$ ruling out same-side repeats.",
+    "mathContext": "$B$ Sidon in $[N/3]\\Rightarrow \\text{multiRepSet}(B\\cup(N-B))\\subseteq\\{N\\}$, so $B\\cup(N-B)$ is almost-Sidon.",
+    "significance": "critical",
     "relatedConcepts": [
       "reflected construction",
       "single collision point",
-      "cross-sum analysis"
+      "range separation",
+      "case analysis"
     ],
     "prerequisites": [
-      "IsSidon",
-      "IsAlmostSidon",
-      "Finset.union",
-      "Finset.image"
+      "isSidon_sumRepCount_le_one",
+      "Finset.union / image",
+      "omega"
+    ]
+  },
+  {
+    "id": "erdos-864-ann-reflected-bound",
+    "proofId": "erdos-864",
+    "type": "theorem",
+    "range": {
+      "startLine": 740,
+      "endLine": 806
+    },
+    "title": "Quantitative Reflected Lower Bound (Proved)",
+    "content": "The construction's size payoff, proved in full. `reflected_injOn`, `reflected_disjoint`, and `reflected_card` establish that $B$ and its reflection $N-B$ are disjoint (their ranges $[1,N/3]$ and $[N-N/3,N-1]$ don't meet) and that $|B\\cup(N-B)|=2|B|$. `reflected_subset_Icc` confirms the set lies in $\\{1,\\dots,N\\}$. Combining with `reflected_construction_valid`, `reflected_construction_bound` proves $\\text{maxAlmostSidon}(N)\\ge 2|B|$ for every Sidon $B\\subseteq\\{1,\\dots,N/3\\}$ — reducing the Erdős–Freud axiom to the existence of large Sidon sets.",
+    "mathContext": "$B$ Sidon in $[N/3]\\Rightarrow \\text{maxAlmostSidon}(N)\\ge 2|B|$; with $|B|\\sim\\sqrt{N/3}$ this is $\\sim(2/\\sqrt3)\\sqrt N$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "disjoint union cardinality",
+      "Set.InjOn",
+      "Finset.le_sup",
+      "lower bound witness"
+    ],
+    "prerequisites": [
+      "reflected_construction_valid",
+      "maxAlmostSidon",
+      "Finset.card_union_of_disjoint"
     ]
   }
 ]

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -48,8 +48,9 @@
       "Formalized IsAlmostSidon (≤1 collision) and IsSidon (0 collisions) as card constraints on multiRepSet",
       "Defined maxAlmostSidon as supremum over powerset of Icc 1 N",
       "Proved sidon_is_almost_sidon by unfolding and omega",
-      "Axiomatized Erdős-Freud lower bound with explicit (2/√3 − ε)·√N form",
-      "Axiomatized the reflected construction B ∪ (N − B) with B Sidon in {1,...,N/3}",
+      "Axiomatized Erdős-Freud lower bound with explicit (2/√3 − ε)·√N form (the file's sole axiom)",
+      "Proved the elementary Sidon counting bounds: sum-counting |A|² ≤ 4N and the sharper difference-counting |A|² ≤ 2N + |A|, eliminating the former sidon_upper_bound axiom",
+      "Proved reflected_construction_valid: B ∪ (N − B) is almost-Sidon when B is Sidon in {1,...,N/3} (only collision at sum N)",
       "reflected_construction_bound: PROVED quantitative lower bound maxAlmostSidon(N) ≥ 2|B| for any Sidon B ⊆ {1,...,N/3}"
     ],
     "axiomCount": 1,
@@ -81,7 +82,7 @@
       "title": "Known Bounds, Axioms, and Basic Theorems",
       "startLine": 57,
       "endLine": 137,
-      "summary": "Axiomatizes the Erdos-Freud lower bound (exists B almost-Sidon in [1,N] with |B| >= (2/sqrt(3) - e)*sqrt(N)), the Sidon upper bound (|A| <= sqrt(N) + N^{1/4}), and almost_sidon_exceeds_sidon. Proves sidon_is_almost_sidon by omega, isAlmostSidon_empty, isAlmostSidon_subset, and isSidon_empty.",
+      "summary": "Axiomatizes only the Erdos-Freud lower bound (exists B almost-Sidon in [1,N] with |B| >= (2/sqrt(3) - e)*sqrt(N)). PROVES almost_sidon_exceeds_sidon (maxAlmostSidon(N) > sqrt(N) + 1 for large N, via 2/sqrt(3) > 1), sidon_is_almost_sidon by omega, isAlmostSidon_empty, isAlmostSidon_subset, and isSidon_empty. The former Sidon upper-bound axiom was eliminated by the difference-counting proof in the next section.",
       "mathContext": "sidon_is_almost_sidon: IsSidon A implies IsAlmostSidon A follows immediately since |multiRepSet A| = 0 implies |multiRepSet A| <= 1 (omega). isAlmostSidon_subset: if B is almost-Sidon and A is a subset of B, then multiRepSet A is a subset of multiRepSet B (monotone), so |multiRepSet A| <= |multiRepSet B| <= 1. The Erdos-Freud lower bound is axiomatized as it requires the full Singer/Sidon construction analysis."
     },
     {
@@ -105,7 +106,7 @@
     "historicalContext": "Sidon sets (also called $B_2$ sets) are sets where all pairwise sums are distinct, studied since Sidon's 1932 question to Turán. The classical result is $|A| \\leq \\sqrt{N} + O(N^{1/4})$ for Sidon $A \\subseteq \\{1, \\ldots, N\\}$, with matching constructions from finite geometry (Singer 1938, Erdős-Turán 1941). Problem 864, posed by Erdős and Freud in 1991, asks: what happens if we relax the Sidon condition to allow exactly one collision? They showed the reflected construction $B \\cup \\{N - b : b \\in B\\}$ with Sidon $B \\subseteq \\{1, \\ldots, N/3\\}$ achieves size $(2/\\sqrt{3})\\sqrt{N} \\approx 1.155\\sqrt{N}$, a 15.5% improvement over pure Sidon. The only collision occurs at sum $N$: both $b + (N-b)$ and $b' + (N-b')$ equal $N$. The conjecture that this is optimal remains open. This is a weaker version of Problem #840, which studies the general $k$-collision case.",
     "problemStatement": "What is the maximum size of $A \\subseteq \\{1, \\ldots, N\\}$ such that at most one integer $n$ has multiple representations as $a + b$ with $a \\leq b \\in A$?",
     "text": "Max size of A ⊆ {1,...,N} with at most one sum collision? Conjecture: (1+o(1))·(2/√3)·√N. Erdős-Freud (1991) matched this with a reflected Sidon construction.",
-    "proofStrategy": "The formalization defines sum representations via filtered Cartesian products, the almost-Sidon and Sidon properties via cardinality of the multi-representation set, and `maxAlmostSidon` as a supremum over the powerset. The key theorem `sidon_is_almost_sidon` is proved by unfolding definitions and `omega`. Asymptotic bounds are axiomatized with explicit real-valued inequalities using `Real.sqrt`.",
+    "proofStrategy": "The formalization defines sum representations via filtered Cartesian products, the almost-Sidon and Sidon properties via cardinality of the multi-representation set, and `maxAlmostSidon` as a supremum over the powerset. The elementary Sidon upper bounds are proved by double counting: the sum-counting route gives |A|² ≤ 4N, and the sharper difference-counting route (`isSidon_diff_injective` → `sidon_diff_counting_bound` → `sidon_card_sq_le_2N`) gives |A|² ≤ 2N + |A|. The reflected construction B ∪ (N − B) is proved almost-Sidon (`reflected_construction_valid`) with a proved quantitative lower bound `reflected_construction_bound`. Only the Erdős–Freud asymptotic lower bound (which needs large explicit Sidon sets) is axiomatized, with explicit real-valued inequalities using `Real.sqrt`.",
     "keyInsights": [
       "Almost-Sidon allows one collision; the reflected construction achieves $2/\\sqrt{3} \\approx 1.155$ times the Sidon bound by concentrating all collisions at a single sum value $N$",
       "The reflected construction $B \\cup (N - B)$: when $B$ is Sidon in $\\{1, \\ldots, N/3\\}$, the set has size $\\approx 2\\sqrt{N/3} = (2/\\sqrt{3})\\sqrt{N}$, and the only collision is at sum $N$ since $b + (N-b) = N$ for all $b \\in B$",
@@ -119,7 +120,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #864 is formalized with concrete definitions of sum representation counting, almost-Sidon and Sidon properties, the maximum function, and the Erdős-Freud reflected construction. The key theorem sidon_is_almost_sidon is proved; bounds and construction validity are axiomatized. The file has 0 sorries and 3 axioms. The false axiom almost_sidon_sum_range was identified and removed (counterexample: A={1,2,4,6,7}, N=7).",
+    "summary": "Erdős Problem #864 is formalized with concrete definitions of sum representation counting, almost-Sidon and Sidon properties, the maximum function, and the Erdős-Freud reflected construction. The elementary Sidon counting bounds (sum-counting |A|² ≤ 4N and the sharper difference-counting |A|² ≤ 2N + |A|), the strict separation almost_sidon_exceeds_sidon, and the reflected construction validity and quantitative lower bound (reflected_construction_bound: maxAlmostSidon(N) ≥ 2|B|) are all PROVED. The file has 0 sorries and 1 axiom (erdos_freud_lower_bound). The former sidon_upper_bound axiom was eliminated by the difference-counting proof, and the false axiom almost_sidon_sum_range was identified and removed (counterexample: A={1,2,4,6,7}, N=7).",
     "implications": "A resolution would precisely quantify the value of allowing one sum collision in additive combinatorics. The factor 2/√3 would establish a sharp phase transition: zero collisions gives √N, one collision gives (2/√3)√N, and understanding k collisions would complete the picture of B_2^+ set theory.",
     "openQuestions": [
       "Is |A| ≤ (1+o(1))·(2/√3)·√N the correct upper bound for almost-Sidon sets?",


### PR DESCRIPTION
## Enrichment pass for `erdos-864`

The `annotations.json` for this entry described a **much earlier version** of
the Lean file and was actively misleading to readers:

- It labeled **proved theorems as axioms** — e.g. `pairwise_sum_count`
  ("Axiomatizes pairwise_sum_count") and `reflected_construction_valid`
  ("Axiomatizes reflected_construction_valid"), both of which are fully
  proved (the latter is a ~230-line proof).
- It claimed `sidon_is_almost_sidon` was *"the only proved theorem in the
  file"* — the file actually proves 22 theorems.
- It referenced axioms that **don't exist** in the current file:
  `erdos_864_conjecture`, `sidon_upper_bound`, `almost_sidon_sum_range`.
- Coverage stopped at line 113 of an **807-line** file.

### What changed
- **Rewrote annotations** to match the current file: 13 annotations, all
  `Valid` / `0 Misaligned` per `scripts/annotations/resolver.ts validate`,
  now covering the file through line 806.
- **Correctly marked as PROVED**: the sum-counting bound (|A|² ≤ 4N), the
  sharper difference-counting bound (|A|² ≤ 2N + |A|, which eliminated the
  old `sidon_upper_bound` axiom), `almost_sidon_exceeds_sidon`,
  `reflected_construction_valid`, and `reflected_construction_bound`.
- Added a `warning` annotation documenting the **removed false bound**
  (counterexample A = {1,2,4,6,7}, N = 7, multiplicity-3 collision).
- **Fixed self-contradictory meta.json**: `conclusion.summary` said *"3
  axioms"* and that construction validity was *"axiomatized"*, while
  `meta.meta.axiomCount` correctly says **1**. Also corrected the
  bounds-and-basics section summary, `originalContributions`, and
  `proofStrategy` to reflect the proved (not axiomatized) results.

### Axiom integrity
Status remains `axiomatized` / badge `axiom` / `axiomCount: 1`, accurately
reflecting the single remaining axiom `erdos_freud_lower_bound`. No status
was changed; the edits only correct claims that *understated* what is proved.