### PR TITLE
research(midy-theorem-oq-01): formalize Midy's theorem (0 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2649,6 +2649,7 @@ import Proofs.MeanValueTheoremOQ02OQ04
 import Proofs.MeanValueTheoremOQ02OQ04OQ01
 import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
+import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ02
 import Proofs.MinkowskiFundamentalTheoremOQ04

--- a/proofs/Proofs/MidyTheorem.lean
+++ b/proofs/Proofs/MidyTheorem.lean
@@ -1,0 +1,146 @@
+/-
+# Midy's Theorem: Complementary Halves of Repeating Decimals
+
+Let `p` be a prime other than the base divisors (e.g. `p ≠ 2, 5` in base 10) and
+suppose the repeating block of `1/p` in base `b` has *even* period length `2k`.
+Midy's theorem states: if the `2k`-digit repeating block is split into two halves
+of `k` digits each, the two halves sum to `bᵏ - 1` (a string of `k` nines in
+base 10).
+
+The repeating block (repetend) of `1/p` of period `d` is the integer
+`N = (b^d - 1) / p`. With `d = 2k` even we prove the two halves
+`N / bᵏ` (high digits) and `N % bᵏ` (low digits) satisfy
+
+    N / bᵏ + N % bᵏ = bᵏ - 1.
+
+## Structure
+
+1. `midy_kernel` — the pure arithmetic heart: for `N = (bᵏ-1)·m` with `1 ≤ m ≤ bᵏ`,
+   the two base-`bᵏ` halves of `N` sum to `bᵏ - 1`. (no number theory)
+2. `pow_half_orderOf_eq_neg_one` — in a field, an element of order `2k` satisfies
+   `xᵏ = -1`. (the "even period" hypothesis made algebraic)
+3. `period_even_dvd` — even period `2k` of `b` mod `p` gives `p ∣ bᵏ + 1`.
+4. `midy_theorem` — combines the kernel with the divisibility `p ∣ bᵏ + 1`
+   (equivalently, even period) to conclude the halves sum to `bᵏ - 1`.
+-/
+
+import Mathlib.Data.ZMod.Basic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Tactic
+
+namespace MidyTheorem
+
+open Nat
+
+/-!
+## 1. Arithmetic kernel
+-/
+
+/-- The arithmetic core of Midy's theorem. If `N = (bᵏ - 1)·m` with `1 ≤ m ≤ bᵏ`,
+then splitting `N` into its high and low base-`bᵏ` halves gives two numbers that
+sum to `bᵏ - 1`. Concretely the quotient is `m - 1` and the remainder is `bᵏ - m`. -/
+theorem midy_kernel (b k m : ℕ) (hb : 2 ≤ b) (hm1 : 1 ≤ m) (hm2 : m ≤ b ^ k) :
+    (b ^ k - 1) * m / b ^ k + (b ^ k - 1) * m % b ^ k = b ^ k - 1 := by
+  have hbk : 1 ≤ b ^ k := Nat.one_le_pow k b (by omega)
+  -- Decompose N = (bᵏ - m) + (m - 1)·bᵏ  (a remainder plus a multiple of bᵏ).
+  have hkey : (b ^ k - 1) * m = (b ^ k - m) + (m - 1) * b ^ k := by
+    zify [hbk, hm1, hm2]
+    ring
+  have hr : (b ^ k - 1) * m % b ^ k = b ^ k - m := by
+    rw [hkey, Nat.add_mul_mod_self_right]
+    exact Nat.mod_eq_of_lt (by omega)
+  have hq : (b ^ k - 1) * m / b ^ k = m - 1 := by
+    rw [hkey, Nat.add_mul_div_right _ _ (show 0 < b ^ k by omega),
+      Nat.div_eq_of_lt (show b ^ k - m < b ^ k by omega), Nat.zero_add]
+  rw [hq, hr]
+  omega
+
+/-!
+## 2. Algebraic content: order `2k` forces `xᵏ = -1`
+-/
+
+/-- In a field, an element of multiplicative order `2k` (with `k ≥ 1`) satisfies
+`xᵏ = -1`: indeed `(xᵏ)² = 1` so `xᵏ = ±1`, and `xᵏ = 1` is impossible since the
+order `2k` does not divide `k`. -/
+theorem pow_half_orderOf_eq_neg_one {F : Type*} [Field F] {x : F} {k : ℕ}
+    (hk : 1 ≤ k) (hord : orderOf x = 2 * k) : x ^ k = -1 := by
+  have hone : x ^ k * x ^ k = 1 := by
+    rw [← pow_add]
+    have hkk : k + k = 2 * k := by ring
+    rw [hkk, ← hord, pow_orderOf_eq_one]
+  have h0 : (x ^ k - 1) * (x ^ k + 1) = 0 := by linear_combination hone
+  rcases mul_eq_zero.mp h0 with h | h
+  · exfalso
+    have hx1 : x ^ k = 1 := by linear_combination h
+    have hdvd : orderOf x ∣ k := orderOf_dvd_of_pow_eq_one hx1
+    rw [hord] at hdvd
+    have : 2 * k ≤ k := Nat.le_of_dvd (by omega) hdvd
+    omega
+  · linear_combination h
+
+/-!
+## 3. Number-theoretic bridge: even period gives `p ∣ bᵏ + 1`
+-/
+
+/-- If the multiplicative order of `b` modulo the prime `p` is `2k` (i.e. the
+period of `1/p` in base `b` is `2k`), then `p ∣ bᵏ + 1`. This is the hypothesis
+needed by `midy_theorem`, derived from the "even period" condition. -/
+theorem period_even_dvd (p b k : ℕ) [Fact p.Prime] (hk : 1 ≤ k)
+    (hperiod : orderOf (b : ZMod p) = 2 * k) : p ∣ b ^ k + 1 := by
+  have hx : (b : ZMod p) ^ k = -1 := pow_half_orderOf_eq_neg_one hk hperiod
+  have hzero : ((b ^ k + 1 : ℕ) : ZMod p) = 0 := by
+    push_cast
+    rw [hx]; ring
+  exact (ZMod.natCast_eq_zero_iff _ p).mp hzero
+
+/-!
+## 4. Midy's theorem
+-/
+
+/-- **Midy's theorem.** Let `p ≥ 2`, `b ≥ 2`, `k ≥ 1`, and suppose `p ∣ bᵏ + 1`
+(this holds exactly when the period of `1/p` in base `b` is the even number `2k`;
+see `period_even_dvd`). Then the repetend `N = (b^(2k) - 1)/p` of `1/p`, split into
+its high and low base-`bᵏ` halves, has halves summing to `bᵏ - 1` — a block of
+`k` nines in base 10. -/
+theorem midy_theorem (p b k : ℕ) (hp : 2 ≤ p) (_hk : 1 ≤ k) (hb : 2 ≤ b)
+    (hdvd : p ∣ b ^ k + 1) :
+    (b ^ (2 * k) - 1) / p / b ^ k + (b ^ (2 * k) - 1) / p % b ^ k = b ^ k - 1 := by
+  obtain ⟨m, hm⟩ := hdvd
+  have hbk : 1 ≤ b ^ k := Nat.one_le_pow k b (by omega)
+  -- m ≥ 1, else p·m = 0 ≠ bᵏ + 1.
+  have hm1 : 1 ≤ m := by
+    rcases Nat.eq_zero_or_pos m with h0 | h
+    · subst h0; simp only [mul_zero] at hm; omega
+    · exact h
+  -- m ≤ bᵏ, since 2m ≤ p·m = bᵏ + 1 ≤ 2·bᵏ.
+  have hm2 : m ≤ b ^ k := by
+    have h2m : 2 * m ≤ p * m := Nat.mul_le_mul hp (le_refl m)
+    rw [← hm] at h2m
+    omega
+  -- The repetend factors exactly: b^(2k) - 1 = p · ((bᵏ - 1)·m).
+  have hpow : b ^ (2 * k) = (b ^ k) ^ 2 := by
+    rw [Nat.mul_comm 2 k, pow_mul]
+  have ht : (b ^ k) ^ 2 - 1 = (b ^ k - 1) * (b ^ k + 1) := by
+    have h1 : 1 ≤ (b ^ k) ^ 2 := Nat.one_le_pow 2 (b ^ k) (by omega)
+    zify [hbk, h1]
+    ring
+  have hfact : b ^ (2 * k) - 1 = p * ((b ^ k - 1) * m) := by
+    rw [hpow, ht, hm]; ring
+  have hNval : (b ^ (2 * k) - 1) / p = (b ^ k - 1) * m := by
+    rw [hfact, Nat.mul_div_cancel_left _ (show 0 < p by omega)]
+  rw [hNval]
+  exact midy_kernel b k m hb hm1 hm2
+
+/-!
+## Worked example: `1/7 = 0.\overline{142857}`, period `6 = 2·3`
+
+The repetend is `142857`; halves `142 + 857 = 999 = 10³ - 1`.
+Here `p = 7`, `b = 10`, `k = 3`, and `7 ∣ 10³ + 1 = 1001 = 7·11·13`.
+-/
+
+example : (10 ^ (2 * 3) - 1) / 7 / 10 ^ 3 + (10 ^ (2 * 3) - 1) / 7 % 10 ^ 3 = 10 ^ 3 - 1 := by
+  decide
+
+example : (7 : ℕ) ∣ 10 ^ 3 + 1 := by decide
+
+end MidyTheorem

--- a/research/problems/midy-theorem-oq-01/knowledge.md
+++ b/research/problems/midy-theorem-oq-01/knowledge.md
@@ -1,0 +1,56 @@
+# Knowledge Base: midy-theorem-oq-01
+
+Midy's theorem: complementary halves of repeating decimals.
+
+---
+
+## Problem Understanding
+
+For a prime `p` coprime to the base `b` (e.g. `p ≠ 2, 5` in base 10), the decimal
+`1/p` is purely periodic with period `d = ord_p(b)` (multiplicative order of `b`
+mod `p`). The repeating block (repetend) is the integer `N = (b^d − 1)/p`.
+
+**Midy's theorem** (E. Midy, 1836): if the period `d = 2k` is *even*, then splitting
+the `2k`-digit repetend into two `k`-digit halves `N₁` (high) and `N₂` (low) gives
+`N₁ + N₂ = b^k − 1` (a block of `k` nines in base 10).
+
+Example: `1/7 = 0.\overline{142857}`, period `6 = 2·3`; `142 + 857 = 999 = 10³ − 1`.
+
+---
+
+## Insights
+
+- **The theorem decomposes into two independent facts.**
+  1. *Arithmetic kernel* (no number theory): if `N = (bᵏ − 1)·m` with `1 ≤ m ≤ bᵏ`,
+     then `N / bᵏ = m − 1` and `N % bᵏ = bᵏ − m`, so the halves sum to `bᵏ − 1`.
+     Proof: `N = (bᵏ − m) + (m − 1)·bᵏ`, a valid remainder + multiple of `bᵏ`.
+  2. *Number theory*: even period `2k` ⟺ `ord_p(b) = 2k` ⟹ `bᵏ ≡ −1 (mod p)`
+     ⟹ `p ∣ bᵏ + 1`. Then `b^{2k} − 1 = (bᵏ−1)(bᵏ+1) = (bᵏ−1)·p·m`, so
+     `N = (b^{2k}−1)/p = (bᵏ−1)·m` exactly, with `m = (bᵏ+1)/p ∈ [1, bᵏ]`.
+
+- **`bᵏ ≡ −1` is the crux.** Since `ord_p(b) = 2k`, `(bᵏ)² = b^{2k} ≡ 1` but
+  `bᵏ ≢ 1` (order does not divide `k`). In the field `ZMod p`, the only square
+  roots of 1 are `±1`, so `bᵏ ≡ −1`. This is a clean field-theoretic argument
+  (`(xᵏ − 1)(xᵏ + 1) = 0` ⟹ `xᵏ = ±1`; rule out `+1` via `orderOf_dvd_of_pow_eq_one`).
+
+- **`m ∈ [1, bᵏ]` is automatic** from `p·m = bᵏ + 1` and `p ≥ 2`: `m ≥ 1` (else
+  `p·m = 0`), and `2m ≤ p·m = bᵏ + 1 ≤ 2bᵏ` gives `m ≤ bᵏ`.
+
+---
+
+## Session 2026-06-16 (Session 1) — FRESH, build-verified
+
+**Mode**: FRESH. **Outcome**: completed (0 sorries, 0 axioms).
+
+Formalized the full chain in `proofs/Proofs/MidyTheorem.lean`:
+- `midy_kernel` — pure-Nat halves identity (`zify`/`ring` + `Nat.add_mul_div/mod_self`).
+- `pow_half_orderOf_eq_neg_one` — field lemma: `orderOf x = 2k ⟹ xᵏ = −1`.
+- `period_even_dvd` — `orderOf (b : ZMod p) = 2k ⟹ p ∣ bᵏ + 1`.
+- `midy_theorem` — top result: halves of `(b^{2k}−1)/p` sum to `bᵏ − 1`.
+- Worked example `1/7` (`p=7, b=10, k=3`) discharged by `decide`.
+
+### Next Steps / Follow-ups
+- Converse / "if-and-only-if": odd period gives the analogous Midy-for-thirds when
+  `d = 3k` (the three blocks sum to a multiple of `bᵏ − 1`). Possible OQ sibling.
+- Tie `orderOf (b : ZMod p)` to the actual decimal-expansion digit sequence to make
+  the "period" interpretation fully explicit (currently captured via `p ∣ bᵏ+1`).

--- a/src/data/proofs/midy-theorem-oq-01/meta.json
+++ b/src/data/proofs/midy-theorem-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "midy-theorem-oq-01",
+  "title": "Midy's Theorem: Complementary Halves of Repeating Decimals",
+  "slug": "midy-theorem-oq-01",
+  "description": "Formalizes Midy's theorem (1836): if 1/p has an even period 2k in base b, the two k-digit halves of the repeating block sum to b^k − 1 (a block of k nines). Proved by separating an elementary arithmetic kernel from the number-theoretic fact b^k ≡ −1 (mod p). 4 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MidyTheorem.lean",
+    "tags": [
+      "number-theory",
+      "repeating-decimals",
+      "multiplicative-order",
+      "modular-arithmetic",
+      "elementary"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "theoremCount": 4,
+    "assumptions": "None. The even-period hypothesis is captured exactly as p ∣ b^k + 1 (equivalently ord_p(b) = 2k, derived in period_even_dvd).",
+    "mathlibDependencies": [
+      {
+        "theorem": "orderOf / pow_orderOf_eq_one / orderOf_dvd_of_pow_eq_one",
+        "description": "Multiplicative order of an element and its divisibility characterization",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "Casting a natural number to ZMod p is zero iff p divides it",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-16",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Étienne Midy published this curiosity about repeating decimals in an 1836 pamphlet in Nantes. The classic illustration is 1/7 = 0.142857…: the period is 6, and splitting the repetend 142857 into 142 and 857 gives 142 + 857 = 999. Midy observed this happens for every prime p (other than 2 and 5) whose decimal period is even. The underlying mechanism is the multiplicative order of 10 modulo p: the period of 1/p equals ord_p(10), and an even order 2k forces 10^k ≡ −1 (mod p). The result generalizes verbatim to any base b coprime to p. Later generalizations (Midy's theorem 'for thirds', and Lewittes' and Gupta–Sury's extensions) handle the case where the period splits into more than two equal blocks.",
+    "problemStatement": "Let p be prime, b ≥ 2, k ≥ 1, with p ∣ b^k + 1 (equivalently, the period of 1/p in base b is the even number 2k). Show that the repetend N = (b^(2k) − 1)/p, split into its high and low base-b^k halves, satisfies N/b^k + N%b^k = b^k − 1.",
+    "proofStrategy": "Separate the statement into an elementary arithmetic kernel and a number-theoretic bridge. Kernel (midy_kernel): for any N = (b^k − 1)·m with 1 ≤ m ≤ b^k, write N = (b^k − m) + (m − 1)·b^k; since 0 ≤ b^k − m < b^k this is the unique remainder/quotient decomposition, so N/b^k = m − 1 and N%b^k = b^k − m, which sum to b^k − 1. Bridge (period_even_dvd): in the field ZMod p, ord_p(b) = 2k gives (b^k)² = 1 with b^k ≠ 1, hence b^k = −1, i.e. p ∣ b^k + 1. Composition (midy_theorem): from p ∣ b^k + 1 write b^k + 1 = p·m; then b^(2k) − 1 = (b^k − 1)(b^k + 1) = p·((b^k − 1)·m), so N = (b^(2k)−1)/p = (b^k − 1)·m with m = (b^k+1)/p ∈ [1, b^k], and the kernel applies.",
+    "keyInsights": [
+      "**Clean factoring of the theorem**: the digit-combinatorics (halves of a repetend) and the number theory (even order ⟹ b^k ≡ −1) are logically independent. Isolating the arithmetic kernel makes it a pure statement about N = (b^k−1)·m with no primes involved.",
+      "**b^k ≡ −1 is the entire number-theoretic content**: even period 2k means b^k is a square root of 1 in the field ZMod p other than 1, and a field has only ±1 as square roots of unity. This single fact yields p ∣ b^k + 1.",
+      "**The repetend factors exactly**: b^(2k) − 1 = (b^k−1)(b^k+1), and p divides the second factor, so the division (b^(2k)−1)/p is exact and equals (b^k−1)·m. No real-number or floor reasoning about the decimal expansion is needed.",
+      "**The half-bound m ∈ [1, b^k] is forced**: from p·m = b^k + 1 with p ≥ 2 one gets 2m ≤ b^k + 1 ≤ 2b^k, so m ≤ b^k; and m ≥ 1 since p·m > 0. This guarantees both halves are genuine k-digit blocks.",
+      "**Base-agnostic**: the proof uses only b ≥ 2, so it covers Midy's theorem in every base, with base 10 (nines) and base 2 (ones) as special cases."
+    ]
+  },
+  "sections": [
+    {
+      "id": "midy-kernel",
+      "title": "Arithmetic Kernel",
+      "startLine": 39,
+      "endLine": 56,
+      "summary": "midy_kernel: for N = (b^k − 1)·m with 1 ≤ m ≤ b^k, the base-b^k halves of N are m − 1 (quotient) and b^k − m (remainder), which sum to b^k − 1. Proved by the decomposition N = (b^k − m) + (m − 1)·b^k and Nat.add_mul_div/mod_self.",
+      "mathContext": "$N = (b^k-1)m = (b^k-m) + (m-1)b^k$, so $\\lfloor N/b^k\\rfloor = m-1$, $N \\bmod b^k = b^k-m$, and $(m-1)+(b^k-m) = b^k-1$."
+    },
+    {
+      "id": "midy-order",
+      "title": "Order 2k Forces x^k = −1",
+      "startLine": 62,
+      "endLine": 79,
+      "summary": "pow_half_orderOf_eq_neg_one: in any field, an element of multiplicative order 2k (k ≥ 1) satisfies x^k = −1, since (x^k − 1)(x^k + 1) = 0 and x^k = 1 would make ord x ∣ k, impossible.",
+      "mathContext": "$x^{2k}=1,\\ x^k\\neq 1 \\Rightarrow x^k=-1$ (only square roots of $1$ in a field are $\\pm 1$)."
+    },
+    {
+      "id": "midy-bridge",
+      "title": "Even Period Gives p ∣ b^k + 1",
+      "startLine": 85,
+      "endLine": 94,
+      "summary": "period_even_dvd: if ord_p(b) = 2k in ZMod p (the period of 1/p in base b), then p ∣ b^k + 1, by applying the field lemma to (b : ZMod p) and casting back to ℕ.",
+      "mathContext": "$\\mathrm{ord}_p(b) = 2k \\Rightarrow b^k \\equiv -1 \\pmod p \\Rightarrow p \\mid b^k + 1$."
+    },
+    {
+      "id": "midy-main",
+      "title": "Midy's Theorem and Worked Example",
+      "startLine": 100,
+      "endLine": 146,
+      "summary": "midy_theorem composes the bridge and kernel: from p ∣ b^k + 1 the repetend (b^(2k)−1)/p equals (b^k−1)·m with 1 ≤ m ≤ b^k, and its halves sum to b^k − 1. Includes the worked example 1/7 (p=7, b=10, k=3): 142 + 857 = 999, discharged by decide.",
+      "mathContext": "$1/7 = 0.\\overline{142857}$, period $6 = 2\\cdot 3$, $7 \\mid 10^3+1 = 1001$, and $142+857 = 999 = 10^3-1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, machine-checked proof of Midy's theorem in an arbitrary base, in 4 theorems with 0 sorries and 0 axioms. The proof cleanly separates an elementary base-b^k digit identity from the single number-theoretic fact that an even multiplicative order forces b^k ≡ −1 (mod p).",
+    "implications": "The decomposition isolates exactly where primality enters (only to make ZMod p a field, so that 1 has just two square roots). This pinpoints the natural generalizations: replacing 'two halves' by 'three thirds' when 3k is the period gives Midy's theorem for thirds (the blocks sum to a multiple of b^k − 1), and the field argument generalizes to any cyclic structure where the relevant root-of-unity count is controlled.",
+    "openQuestions": [
+      "Can the 'Midy for thirds' generalization (period 3k, three k-digit blocks summing to a multiple of b^k − 1) be formalized by the same kernel/bridge split, replacing b^k ≡ −1 with a primitive-cube-root condition?",
+      "Can ord_p(b) be tied explicitly to the digit sequence of the base-b expansion of 1/p, so that 'even period' is stated directly on the decimal rather than as p ∣ b^k + 1?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "MidyTheorem",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/MidyTheorem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [],
+  "mainTheorems": [
+    {
+      "name": "midy_theorem",
+      "type": "core",
+      "statement": "∀ p b k, 2 ≤ p → 1 ≤ k → 2 ≤ b → p ∣ b^k + 1 → (b^(2k)−1)/p / b^k + (b^(2k)−1)/p % b^k = b^k − 1",
+      "description": "Midy's theorem: the two halves of the even-period repetend of 1/p sum to b^k − 1.",
+      "significance": "Main result; combines the arithmetic kernel with the divisibility coming from an even multiplicative order."
+    },
+    {
+      "name": "midy_kernel",
+      "type": "lemma",
+      "statement": "∀ b k m, 2 ≤ b → 1 ≤ m → m ≤ b^k → (b^k−1)*m / b^k + (b^k−1)*m % b^k = b^k − 1",
+      "description": "The elementary arithmetic heart: halves of (b^k−1)·m sum to b^k − 1.",
+      "significance": "Prime-free combinatorial core of the theorem."
+    },
+    {
+      "name": "period_even_dvd",
+      "type": "lemma",
+      "statement": "∀ p b k [Fact p.Prime], 1 ≤ k → orderOf (b : ZMod p) = 2*k → p ∣ b^k + 1",
+      "description": "Even multiplicative order 2k forces p ∣ b^k + 1.",
+      "significance": "Number-theoretic bridge encoding the 'even period' hypothesis."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Midy's theorem** (É. Midy, 1836) in an arbitrary base: if the repeating block of `1/p` in base `b` has *even* period `2k`, then the two `k`-digit halves of the block sum to `b^k − 1` (a string of `k` nines in base 10).

Classic illustration: `1/7 = 0.\overline{142857}`, period `6 = 2·3`, and `142 + 857 = 999 = 10³ − 1`.

The proof cleanly separates two logically independent facts:

- **`midy_kernel`** (prime-free arithmetic): for `N = (b^k − 1)·m` with `1 ≤ m ≤ b^k`, the base-`b^k` halves are `m − 1` (quotient) and `b^k − m` (remainder), summing to `b^k − 1`. Via the decomposition `N = (b^k − m) + (m − 1)·b^k`.
- **`pow_half_orderOf_eq_neg_one`** (field algebra): an element of multiplicative order `2k` satisfies `x^k = −1` (only square roots of 1 in a field are `±1`).
- **`period_even_dvd`**: `ord_p(b) = 2k ⟹ p ∣ b^k + 1` (the even-period hypothesis made concrete).
- **`midy_theorem`**: composes the bridge and kernel — the repetend `(b^(2k)−1)/p` factors exactly as `(b^k−1)·m`, so its halves sum to `b^k − 1`.

Worked example `1/7` discharged by `decide`.

## Verification

- `proofs/Proofs/MidyTheorem.lean`: **4 theorems, 0 sorries, 0 axioms**, 146 lines.
- Docker build: `✔ [3058/3058] Built Proofs.MidyTheorem` (clean, no warnings).
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.MidyTheorem` succeeds with 0 sorries / 0 axioms
- [x] `meta.json` validates as JSON
- [x] No competing Midy PR (deduped pre-create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)