### PR TITLE
research(thue-morse-oq-01): formalize the Thue-Morse sequence

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3027,6 +3027,7 @@ import Proofs.ThreeSquares
 import Proofs.ThreeSquaresResidue3
 import Proofs.ThreeSquaresResidue3Obstruction
 import Proofs.ThreeSquaresSingleAP
+import Proofs.ThueMorse
 import Proofs.TractatusOntology
 import Proofs.TractatusOntologyEquiv
 import Proofs.TractatusOntologyHorn

--- a/proofs/Proofs/ThueMorse.lean
+++ b/proofs/Proofs/ThueMorse.lean
@@ -1,0 +1,146 @@
+import Mathlib.Data.Nat.Digits.Defs
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-!
+# The Thue-Morse Sequence
+
+## What This Proves
+
+The **Thue-Morse sequence** `t : ℕ → ZMod 2` assigns to each natural number the
+parity of the number of `1`s in its binary expansion.  Equivalently it is the
+unique sequence determined by
+
+* `t 0 = 0`,
+* `t (2n)   = t n`,
+* `t (2n+1) = t n + 1`   (i.e. the bit is flipped).
+
+We define `t` directly as the parity of the digit sum in base `2`
+(`thueMorse n = ((Nat.digits 2 n).sum : ZMod 2)`) and prove that it satisfies
+these defining recurrences.  From them we derive the value at powers of two and
+the four-term **Prouhet-Tarry-Escott block identities**
+
+* `t (4n)   = t (4n+3) = t n`,
+* `t (4n+1) = t (4n+2) = t n + 1`,
+
+which express the `0110 / 1001` block structure underlying Prouhet's equal-power
+partition theorem.
+
+## Historical Context
+
+The sequence was studied by Eugène Prouhet (1851) in connection with partitioning
+integers into classes with equal power sums, by Axel Thue (1906, 1912) as the
+first explicit infinite cube-free / overlap-free word, and by Marston Morse (1921)
+in symbolic dynamics.  Working in `ZMod 2` makes the "flip a bit" recurrence a
+genuine algebraic identity (`t (2n+1) = t n + 1`).
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  The base-`2` digit expansion is
+provided by Mathlib (`Nat.digits`), and all results are elementary consequences
+of its recursion.
+-/
+
+namespace ThueMorse
+
+open scoped BigOperators
+
+/-- The Thue-Morse sequence: the parity of the number of `1`s in the binary
+expansion of `n`, valued in `ZMod 2`.  Since the base-`2` digits are each `0`
+or `1`, their sum counts the `1`s, and reducing mod `2` gives the Thue-Morse
+value. -/
+def thueMorse (n : ℕ) : ZMod 2 := ((Nat.digits 2 n).sum : ZMod 2)
+
+@[simp] theorem thueMorse_zero : thueMorse 0 = 0 := by
+  simp [thueMorse]
+
+/-- Even argument: doubling prepends a `0` bit, leaving the digit sum unchanged. -/
+theorem thueMorse_two_mul (n : ℕ) : thueMorse (2 * n) = thueMorse n := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  · unfold thueMorse
+    rw [Nat.digits_def' (by norm_num) (by omega)]
+    have h1 : (2 * n) % 2 = 0 := by omega
+    have h2 : (2 * n) / 2 = n := by omega
+    rw [h1, h2]
+    simp [List.sum_cons]
+
+/-- Odd argument: `2n+1` prepends a `1` bit, flipping the Thue-Morse value. -/
+theorem thueMorse_two_mul_add_one (n : ℕ) :
+    thueMorse (2 * n + 1) = thueMorse n + 1 := by
+  unfold thueMorse
+  rw [Nat.digits_def' (by norm_num) (by omega)]
+  have h1 : (2 * n + 1) % 2 = 1 := by omega
+  have h2 : (2 * n + 1) / 2 = n := by omega
+  rw [h1, h2]
+  push_cast [List.sum_cons]
+  ring
+
+@[simp] theorem thueMorse_one : thueMorse 1 = 1 := by
+  have := thueMorse_two_mul_add_one 0
+  simpa using this
+
+/-- Consecutive even/odd pairs always differ: `t (2n+1) = t (2n) + 1`. -/
+theorem thueMorse_two_mul_add_one_eq (n : ℕ) :
+    thueMorse (2 * n + 1) = thueMorse (2 * n) + 1 := by
+  rw [thueMorse_two_mul, thueMorse_two_mul_add_one]
+
+theorem thueMorse_ne_succ_two_mul (n : ℕ) : thueMorse (2 * n) ≠ thueMorse (2 * n + 1) := by
+  rw [thueMorse_two_mul_add_one_eq]
+  intro h
+  have h1 : thueMorse (2 * n) + 0 = thueMorse (2 * n) + 1 := by rw [add_zero]; exact h
+  exact absurd (add_left_cancel h1) (by decide)
+
+/-- Value at powers of two: `2^k` has a single `1` bit, so `t (2^k) = 1`. -/
+theorem thueMorse_two_pow (k : ℕ) : thueMorse (2 ^ k) = 1 := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have : (2 : ℕ) ^ (k + 1) = 2 * 2 ^ k := by ring
+    rw [this, thueMorse_two_mul, ih]
+
+/-! ### Prouhet-Tarry-Escott block identities
+
+The four residues mod `4` split into two pairs with a common value, giving the
+length-four blocks `t(4n) t(4n+1) t(4n+2) t(4n+3) = a (a+1) (a+1) a` where
+`a = t n`.  This is the combinatorial heart of Prouhet's equal-power partition. -/
+
+theorem thueMorse_four_mul (n : ℕ) : thueMorse (4 * n) = thueMorse n := by
+  have h : (4 : ℕ) * n = 2 * (2 * n) := by ring
+  rw [h, thueMorse_two_mul, thueMorse_two_mul]
+
+theorem thueMorse_four_mul_add_one (n : ℕ) :
+    thueMorse (4 * n + 1) = thueMorse n + 1 := by
+  have h : (4 : ℕ) * n + 1 = 2 * (2 * n) + 1 := by ring
+  rw [h, thueMorse_two_mul_add_one, thueMorse_two_mul]
+
+theorem thueMorse_four_mul_add_two (n : ℕ) :
+    thueMorse (4 * n + 2) = thueMorse n + 1 := by
+  have h : (4 : ℕ) * n + 2 = 2 * (2 * n + 1) := by ring
+  rw [h, thueMorse_two_mul, thueMorse_two_mul_add_one]
+
+theorem thueMorse_four_mul_add_three (n : ℕ) :
+    thueMorse (4 * n + 3) = thueMorse n := by
+  have h : (4 : ℕ) * n + 3 = 2 * (2 * n + 1) + 1 := by ring
+  rw [h, thueMorse_two_mul_add_one, thueMorse_two_mul_add_one, add_assoc,
+    show (1 : ZMod 2) + 1 = 0 from by decide, add_zero]
+
+/-- The outer pair of a length-four block agree: `t(4n) = t(4n+3)`. -/
+theorem thueMorse_four_mul_eq_add_three (n : ℕ) :
+    thueMorse (4 * n) = thueMorse (4 * n + 3) := by
+  rw [thueMorse_four_mul, thueMorse_four_mul_add_three]
+
+/-- The inner pair of a length-four block agree: `t(4n+1) = t(4n+2)`. -/
+theorem thueMorse_four_mul_add_one_eq_add_two (n : ℕ) :
+    thueMorse (4 * n + 1) = thueMorse (4 * n + 2) := by
+  rw [thueMorse_four_mul_add_one, thueMorse_four_mul_add_two]
+
+/-- Prouhet's equal-sum partition at level `k = 2`: splitting `{0,1,2,3}` by
+Thue-Morse value gives `{0,3}` and `{1,2}`, and `0 + 3 = 1 + 2`. -/
+theorem prouhet_level_two :
+    thueMorse 0 = thueMorse 3 ∧ thueMorse 1 = thueMorse 2 ∧ (0 + 3 = 1 + 2) := by
+  refine ⟨?_, ?_, by norm_num⟩
+  · have := thueMorse_four_mul_eq_add_three 0; simpa using this
+  · have := thueMorse_four_mul_add_one_eq_add_two 0; simpa using this
+
+end ThueMorse

--- a/src/data/proofs/thue-morse-oq-01/annotations.json
+++ b/src/data/proofs/thue-morse-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "thue-morse-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "The Thue-Morse Sequence",
+    "content": "The **Thue-Morse sequence** $t : \\mathbb{N} \\to \\{0,1\\}$ records the parity of the number of $1$s in the binary expansion of $n$:\n\n$$t(n) = \\Big(\\sum \\text{binary digits of } n\\Big) \\bmod 2.$$\n\nIt is the unique sequence with $t(0) = 0$, $t(2n) = t(n)$, and $t(2n+1) = 1 - t(n)$. Working in $\\mathbb{Z}/2\\mathbb{Z}$ turns the bit-flip into the algebraic identity $t(2n+1) = t(n) + 1$.\n\n**History.** Prouhet (1851) used it to split integers into classes with equal power sums; Thue (1906, 1912) used it as the first explicit overlap-free word; Morse (1921) found it in symbolic dynamics.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binary expansion",
+      "parity",
+      "Prouhet-Tarry-Escott problem",
+      "combinatorics on words"
+    ],
+    "mathContext": "Thue-Morse value as the ZMod 2 reduction of the base-2 digit sum.",
+    "prerequisites": [
+      "binary expansions",
+      "arithmetic mod 2"
+    ]
+  },
+  {
+    "id": "ann-definition",
+    "proofId": "thue-morse-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 55
+    },
+    "type": "definition",
+    "title": "Definition via the digit sum",
+    "content": "```lean\ndef thueMorse (n : ℕ) : ZMod 2 := ((Nat.digits 2 n).sum : ZMod 2)\n```\n\n`Nat.digits 2 n` returns the base-2 digits of $n$ as a list (least significant first). Each entry is $0$ or $1$, so the sum is exactly the number of $1$ bits; casting into $\\mathbb{Z}/2\\mathbb{Z}$ keeps only its parity. Choosing $\\mathbb{Z}/2\\mathbb{Z}$ as the codomain (rather than $\\{0,1\\} \\subset \\mathbb{N}$) is what makes the recurrences clean ring identities.\n\nBy convention $t(0) = 0$ since `Nat.digits 2 0 = []`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.digits",
+      "ZMod 2",
+      "List.sum"
+    ],
+    "mathContext": "$t(n) = (\\sum \\texttt{Nat.digits } 2\\, n) \\bmod 2$."
+  },
+  {
+    "id": "ann-base-recurrences",
+    "proofId": "thue-morse-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "The bit-flip recurrences",
+    "content": "The two characterising recurrences:\n\n```lean\ntheorem thueMorse_two_mul (n : ℕ) : thueMorse (2 * n) = thueMorse n\ntheorem thueMorse_two_mul_add_one (n : ℕ) : thueMorse (2 * n + 1) = thueMorse n + 1\n```\n\nBoth come from the single Mathlib fact `Nat.digits_def'`: for $m > 0$,\n$$\\texttt{Nat.digits } 2\\, m = (m \\bmod 2) :: \\texttt{Nat.digits } 2\\, (m / 2).$$\n\nFor $2n$ the new leading digit is $0$, so the digit sum is unchanged: $t(2n) = t(n)$. For $2n+1$ the new digit is $1$, so the sum gains one: $t(2n+1) = t(n) + 1$. After `List.sum_cons` the cast to $\\mathbb{Z}/2\\mathbb{Z}$ finishes by `simp`/`ring`. The even case at $n = 0$ is closed by `simp` (both sides are $0$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.digits_def'",
+      "List.sum_cons",
+      "structural recursion"
+    ],
+    "mathContext": "$t(2n) = t(n)$ and $t(2n+1) = t(n) + 1$, equivalently $t(2n+1) = 1 - t(n)$."
+  },
+  {
+    "id": "ann-distinct-powers",
+    "proofId": "thue-morse-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Consecutive pairs differ; value at powers of two",
+    "content": "```lean\ntheorem thueMorse_ne_succ_two_mul (n : ℕ) : thueMorse (2 * n) ≠ thueMorse (2 * n + 1)\ntheorem thueMorse_two_pow (k : ℕ) : thueMorse (2 ^ k) = 1\n```\n\nSince $t(2n+1) = t(2n) + 1$ and $1 \\neq 0$ in $\\mathbb{Z}/2\\mathbb{Z}$, every adjacent even/odd pair takes both values - the sequence never repeats a value across such a pair.\n\nFor powers of two, $2^k$ has exactly one $1$ bit, so $t(2^k) = 1$. The proof inducts on $k$: $t(2^{k+1}) = t(2 \\cdot 2^k) = t(2^k)$ by the even recurrence, with base case $t(2^0) = t(1) = 1$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "ZMod 2",
+      "induction",
+      "powers of two"
+    ],
+    "mathContext": "$t(2n) \\neq t(2n+1)$ and $t(2^k) = 1$ for all $k$."
+  },
+  {
+    "id": "ann-pte-blocks",
+    "proofId": "thue-morse-oq-01",
+    "range": {
+      "startLine": 100,
+      "endLine": 144
+    },
+    "type": "theorem",
+    "title": "Prouhet-Tarry-Escott block identities",
+    "content": "Applying the two base recurrences twice gives the four-term block structure:\n\n```lean\ntheorem thueMorse_four_mul (n) : thueMorse (4*n) = thueMorse n\ntheorem thueMorse_four_mul_add_one (n) : thueMorse (4*n+1) = thueMorse n + 1\ntheorem thueMorse_four_mul_add_two (n) : thueMorse (4*n+2) = thueMorse n + 1\ntheorem thueMorse_four_mul_add_three (n) : thueMorse (4*n+3) = thueMorse n\n```\n\nso each length-four block reads $a\\,(a{+}1)\\,(a{+}1)\\,a$ with $a = t(n)$ - the outer pair agree ($t(4n) = t(4n+3)$) and the inner pair agree ($t(4n+1) = t(4n+2)$). The cancellation $1 + 1 = 0$ in $\\mathbb{Z}/2\\mathbb{Z}$ is what collapses the extra flips.\n\nThis $0110/1001$ pattern is exactly Prouhet's pairing: it splits $\\{0,1,2,3\\}$ into $\\{0,3\\}$ and $\\{1,2\\}$ with equal sums $0+3 = 1+2$, the level-2 case of his equal-power partition theorem (`prouhet_level_two`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Prouhet-Tarry-Escott problem",
+      "equal power sums",
+      "automatic sequences"
+    ],
+    "mathContext": "$t(4n) = t(4n+3) = t(n)$ and $t(4n+1) = t(4n+2) = t(n)+1$; blocks $a(a{+}1)(a{+}1)a$."
+  }
+]

--- a/src/data/proofs/thue-morse-oq-01/meta.json
+++ b/src/data/proofs/thue-morse-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "thue-morse-oq-01",
+  "title": "The Thue-Morse Sequence",
+  "slug": "thue-morse-oq-01",
+  "description": "The Thue-Morse sequence, defined as the parity of the binary digit sum, satisfies the bit-flip recurrences t(2n)=t(n), t(2n+1)=t(n)+1, takes value 1 at every power of two, and exhibits the four-term Prouhet-Tarry-Escott block structure t(4n)=t(4n+3), t(4n+1)=t(4n+2).",
+  "meta": {
+    "author": "Eugene Prouhet (1851), Axel Thue (1906), Marston Morse (1921)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Thue%E2%80%93Morse_sequence",
+    "date": "1851",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ThueMorse.lean",
+    "tags": [
+      "combinatorics",
+      "number-theory",
+      "binary-expansion",
+      "sequences",
+      "prouhet-tarry-escott",
+      "zmod"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.digits",
+        "description": "Base-b digit expansion of a natural number as a list",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "Recursive step of the digit expansion: digits b m = m % b :: digits b (m / b)",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "ZMod",
+        "description": "Integers modulo n; here ZMod 2 carries the parity",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition of the Thue-Morse sequence as the ZMod 2 parity of the base-2 digit sum",
+      "Proof of the defining bit-flip recurrences t(2n) = t(n) and t(2n+1) = t(n) + 1",
+      "Value at powers of two: t(2^k) = 1",
+      "Consecutive pairs always differ: t(2n) != t(2n+1)",
+      "Prouhet-Tarry-Escott block identities t(4n) = t(4n+3) and t(4n+1) = t(4n+2)",
+      "Prouhet's equal-sum partition at level k=2: {0,3} and {1,2} with 0+3 = 1+2"
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "assumptions": "None. Fully machine-checked with no axioms and no sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The sequence now called Thue-Morse was first introduced by Eugene Prouhet in 1851, who used the partition of the integers it induces to solve the equal-power-sums problem (now the Prouhet-Tarry-Escott problem). It was rediscovered by Axel Thue in 1906 and 1912 as the first explicit example of an infinite overlap-free (and hence cube-free) word, founding the field of combinatorics on words. Marston Morse encountered the same sequence in 1921 while studying geodesics on surfaces of negative curvature, giving it a role in symbolic dynamics.",
+    "problemStatement": "The **Thue-Morse sequence** $t : \\mathbb{N} \\to \\{0,1\\}$ assigns to each $n$ the parity of the number of $1$s in its binary expansion. It is characterised by the recurrences $t(0) = 0$, $t(2n) = t(n)$, and $t(2n+1) = 1 - t(n)$ (the bit is flipped). Working in $\\mathbb{Z}/2\\mathbb{Z}$, the flip becomes the algebraic identity $t(2n+1) = t(n) + 1$.\n\nThis formalization defines $t$ directly as $t(n) = \\big(\\sum (\\text{base-2 digits of } n)\\big) \\bmod 2$ and derives the characterising recurrences, the value $t(2^k) = 1$, and the four-term block identities $t(4n) = t(4n+3)$, $t(4n+1) = t(4n+2)$ that encode the $0110/1001$ block structure at the heart of Prouhet's equal-power partition.",
+    "text": "We define the Thue-Morse value of $n$ as the $\\mathbb{Z}/2\\mathbb{Z}$-reduction of the sum of the base-2 digits supplied by Mathlib's `Nat.digits`. Because each binary digit is $0$ or $1$, the digit sum counts the $1$s, and its parity is exactly the Thue-Morse value. The single nontrivial input is the recursion `Nat.digits 2 m = m % 2 :: Nat.digits 2 (m / 2)` for $m > 0$: doubling prepends a $0$ digit (digit sum unchanged, so $t(2n) = t(n)$), while $2n+1$ prepends a $1$ digit (digit sum increases by one, so $t(2n+1) = t(n) + 1$). Everything else follows algebraically in $\\mathbb{Z}/2\\mathbb{Z}$: powers of two reduce by repeated halving to $t(1) = 1$; the four-term identities follow by applying the two base recurrences twice, using $1 + 1 = 0$.",
+    "proofStrategy": "**Step 1 - Definition.** Set $t(n) = (\\text{digit sum of } n \\text{ in base } 2 : \\mathbb{Z}/2\\mathbb{Z})$.\n\n**Step 2 - Base recurrences.** For $n > 0$, expand $\\texttt{Nat.digits } 2\\,(2n)$ and $\\texttt{Nat.digits } 2\\,(2n+1)$ via `Nat.digits_def'`. The new leading digit is $0$ in the even case and $1$ in the odd case, giving $t(2n) = t(n)$ and $t(2n+1) = t(n) + 1$ after casting `List.sum_cons` to $\\mathbb{Z}/2\\mathbb{Z}$. The case $n = 0$ is handled by `simp`.\n\n**Step 3 - Powers of two.** Induct on $k$: $t(2^{k+1}) = t(2\\cdot 2^k) = t(2^k)$, with base case $t(2^0) = t(1) = 1$.\n\n**Step 4 - Block identities.** Rewrite $4n,\\,4n+1,\\,4n+2,\\,4n+3$ as iterated doublings/successors and apply the two base recurrences. In $\\mathbb{Z}/2\\mathbb{Z}$, $1 + 1 = 0$ collapses the extra flips, yielding $t(4n) = t(4n+3) = t(n)$ and $t(4n+1) = t(4n+2) = t(n) + 1$.",
+    "keyInsights": [
+      "Casting the digit sum into ZMod 2 turns the informal 'flip the bit' rule into a literal ring identity t(2n+1) = t(n) + 1",
+      "The entire sequence is governed by one Mathlib fact: the base-2 digit recursion digits 2 m = m % 2 :: digits 2 (m/2)",
+      "The four-term block identities are not extra hypotheses but immediate consequences of applying the two base recurrences twice, with 1 + 1 = 0 doing the cancellation",
+      "The blocks t(4n..4n+3) = a (a+1) (a+1) a are exactly Prouhet's pairing that equalises power sums up to degree one"
+    ],
+    "prerequisites": [
+      "Binary (base-2) expansions of natural numbers",
+      "Arithmetic in ZMod 2 (parity as a ring)",
+      "Elementary induction"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Definition",
+      "startLine": 48,
+      "endLine": 55,
+      "summary": "The Thue-Morse sequence as the ZMod 2 parity of the base-2 digit sum.",
+      "mathContext": "$t(n) = \\big(\\sum \\texttt{Nat.digits } 2\\, n\\big) \\bmod 2$. Since binary digits are $0$ or $1$, the sum counts the $1$s."
+    },
+    {
+      "id": "base-recurrences",
+      "title": "Base Recurrences",
+      "startLine": 57,
+      "endLine": 91,
+      "summary": "The defining bit-flip recurrences t(2n) = t(n) and t(2n+1) = t(n) + 1, plus t(0) and t(1).",
+      "mathContext": "Doubling prepends a $0$ bit; $2n+1$ prepends a $1$ bit. The digit recursion `Nat.digits_def'` supplies the leading digit."
+    },
+    {
+      "id": "distinct-and-powers",
+      "title": "Consecutive Pairs and Powers of Two",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "Consecutive even/odd values differ, and t(2^k) = 1 for every k.",
+      "mathContext": "$t(2n) \\neq t(2n+1)$ because they differ by $1$ in $\\mathbb{Z}/2\\mathbb{Z}$; $2^k$ has a single $1$ bit so $t(2^k) = 1$."
+    },
+    {
+      "id": "pte-blocks",
+      "title": "Prouhet-Tarry-Escott Block Identities",
+      "startLine": 114,
+      "endLine": 144,
+      "summary": "The four-term identities t(4n)=t(4n+3), t(4n+1)=t(4n+2), and Prouhet's level-2 equal-sum partition.",
+      "mathContext": "Blocks read $a\\,(a{+}1)\\,(a{+}1)\\,a$ with $a = t(n)$, giving the $\\{0,3\\}\\,/\\,\\{1,2\\}$ partition with $0+3 = 1+2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry defines the Thue-Morse sequence as the ZMod 2 parity of the binary digit sum and proves, with no axioms and no sorries, its defining bit-flip recurrences, its value at powers of two, the fact that consecutive even/odd terms differ, and the four-term Prouhet-Tarry-Escott block identities together with Prouhet's level-2 equal-sum partition.",
+    "implications": "**1. Combinatorics on words.** The recurrences are the substitution rule $0 \\mapsto 01,\\ 1 \\mapsto 10$ in disguise, the starting point for Thue's overlap-free word.\n\n**2. The Prouhet-Tarry-Escott problem.** The block structure $a(a{+}1)(a{+}1)a$ is precisely Prouhet's mechanism for splitting $\\{0,\\dots,2^k-1\\}$ into two sets with equal power sums up to degree $k-1$.\n\n**3. Automatic sequences.** Thue-Morse is the prototypical $2$-automatic sequence; the $t(2n)$/$t(2n+1)$ recurrences are its automaton transitions.",
+    "openQuestions": [
+      "Can the overlap-free property of the Thue-Morse word (Thue 1912) - that it contains no factor $axaxa$ - be formalized from these recurrences?",
+      "Can Prouhet's theorem be proved in general: the Thue-Morse partition of $\\{0, \\ldots, 2^k - 1\\}$ into the two parity classes has equal sums of $j$-th powers for all $0 \\le j < k$?",
+      "Does the digit-sum definition match a `ZMod 2`-valued automaton or `Nat.popCount`-style characterization, and can the equivalence be formalized?"
+    ]
+  },
+  "crossReferences": []
+}


### PR DESCRIPTION
## Summary

Formalizes the **Thue-Morse sequence** as a new gallery entry (`thue-morse-oq-01`), fully machine-checked with **0 sorries and 0 axioms**.

The sequence is defined as the `ZMod 2` parity of the base-2 digit sum:
```lean
def thueMorse (n : ℕ) : ZMod 2 := ((Nat.digits 2 n).sum : ZMod 2)
```
Casting into `ZMod 2` turns the informal "flip the bit" rule into a genuine ring identity.

### Results proved (14 theorems)
- **Defining recurrences:** `t(2n) = t(n)` and `t(2n+1) = t(n) + 1`
- **Powers of two:** `t(2^k) = 1`
- **Consecutive pairs differ:** `t(2n) ≠ t(2n+1)`
- **Prouhet-Tarry-Escott block identities:** `t(4n) = t(4n+3)` and `t(4n+1) = t(4n+2)`, i.e. each length-four block reads `a (a+1) (a+1) a`
- **Prouhet level 2:** the `{0,3}` / `{1,2}` equal-sum partition (`0+3 = 1+2`)

Everything reduces to one Mathlib fact — the base-2 digit recursion `Nat.digits_def'` — plus elementary `ZMod 2` algebra.

### Files
- `proofs/Proofs/ThueMorse.lean` (new, 144 lines)
- `proofs/Proofs.lean` (registered import)
- `src/data/proofs/thue-morse-oq-01/{meta.json,annotations.json}` (gallery data)

Neither Mathlib nor the existing gallery had a Thue-Morse formalization.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.ThueMorse` — **Build completed successfully (3058 jobs)**, `✔ Built Proofs.ThueMorse`, no warnings
- [x] 0 `sorry`, 0 `axiom` declarations, 0 assumption-carrying structures
- [x] `meta.json` / `annotations.json` valid JSON; status `verified`, badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)