### PR TITLE
research(binomial-oq-02-oq-01-oq-04): multinomial variance Var(Xᵢ)=n·pᵢ(1−pᵢ) (build-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -255,6 +255,7 @@ import Proofs.BinomialTheoremOQ02OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ03
 import Proofs.BinomialTheoremOQ02OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ03
+import Proofs.BinomialTheoremOQ02OQ01OQ04
 import Proofs.BinomialTheoremOQ02OQ02
 import Proofs.BinomialTheoremOQ02OQ02OQ01
 import Proofs.BinomialTheoremOQ02OQ03

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ04.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ04.lean
@@ -1,0 +1,151 @@
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic
+import Proofs.BinomialTheoremOQ02OQ01OQ02
+import Proofs.BinomialTheoremOQ02OQ01OQ03
+import Proofs.BinomialTheoremOQ03
+
+/-
+# Multinomial Variance: Var(Xᵢ) = n·pᵢ·(1 − pᵢ)
+
+*Open Question from BinomialTheoremOQ02OQ01*: the cross-moment lemma in the
+`OQ03` sibling carries the hypothesis `i ≠ j`, so it delivers
+`E[XᵢXⱼ] = n(n−1)pᵢpⱼ` and `Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ` only off the diagonal. The
+**diagonal** second moment `E[Xᵢ²]` — and hence the variance `Var(Xᵢ)` — is the
+one standard second moment that the bivariate cross-moment machinery does not
+reach. This file fills that gap.
+
+## Answer
+
+YES. For `(X₁,…,Xₖ) ~ Multinomial(n, p₁,…,pₖ)` with `∑pᵢ = 1`,
+
+  Var(Xᵢ) = E[Xᵢ²] − (E[Xᵢ])² = n·pᵢ·(1 − pᵢ).
+
+## Proof Strategy
+
+The component `Xᵢ` is *marginally* `Binomial(n, pᵢ)` — proved in
+`BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`. So both the mean and the
+second moment of `Xᵢ` reduce, by **fiber grouping** over the value `j = k(i₀)`,
+to the corresponding binomial quantities already proved in `BinomialTheoremOQ03`:
+
+1. `multinomial_second_moment`:  `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j`
+   (same fiber-grouping argument as `OQ03.multinomial_mean`, with the statistic
+   `k(i₀)` replaced by `k(i₀)²`).
+2. `multinomial_mean` (from `OQ03`):  `E[Xᵢ] = n·pᵢ`.
+3. Combine with the binomial variance `E[X²] − (E[X])² = n·p·(1−p)`
+   (`BinomialTheoremOQ03.binomial_variance`, extended here to all `n`).
+
+This is a routine diagonal of already-verified machinery, not new mathematics:
+the value is closing the last second-moment gap of the multinomial family with
+no new axioms or sorries.
+-/
+
+namespace BinomialTheoremOQ02OQ01OQ04
+
+open Finset BigOperators
+open BinomialTheoremOQ02OQ01OQ03
+
+/-! ## Binomial variance for all `n`
+
+`BinomialTheoremOQ03.binomial_variance` requires `2 ≤ n`. The cases `n = 0`
+(degenerate, variance `0`) and `n = 1` (a single Bernoulli trial, variance
+`p(1−p)`) are handled directly so the multinomial result holds for every `n`. -/
+private lemma binomial_variance_all (n : ℕ) (p : ℝ) :
+    (∑ k ∈ range (n + 1), ((k : ℝ) ^ 2 * BinomialTheoremOQ03.binomPMF n p k)) -
+    (∑ k ∈ range (n + 1), ((k : ℝ) * BinomialTheoremOQ03.binomPMF n p k)) ^ 2 =
+    (n : ℝ) * p * (1 - p) := by
+  rcases n with _ | _ | m
+  · simp [BinomialTheoremOQ03.binomPMF]
+  · simp [BinomialTheoremOQ03.binomPMF, Finset.sum_range_succ]; ring
+  · exact BinomialTheoremOQ03.binomial_variance (m + 2) (by omega) p
+
+/-! ## Mean of the marginal, for all `n` -/
+
+private lemma binomial_mean_all_n (n : ℕ) (q : ℝ) :
+    ∑ j ∈ range (n + 1), (j : ℝ) * BinomialTheoremOQ03.binomPMF n q j = n * q := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp [BinomialTheoremOQ03.binomPMF]
+  · exact BinomialTheoremOQ03.binomial_mean n hn q
+
+/-! ## Second moment `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j` -/
+
+/-- **Second moment of a multinomial component**: `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j`.
+
+    Fiber grouping over the value `j = k(i₀)`: on the fiber `{k | k(i₀) = j}` the
+    statistic `k(i₀)²` is the constant `j²`, which factors out, and the remaining
+    fiber sum is the marginal PMF `P(Xᵢ = j) = binomPMF n pᵢ j`
+    (`multinomial_marginal_pmf`). This is the squared-statistic analogue of
+    `OQ03.multinomial_mean`. -/
+theorem multinomial_second_moment {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (i₀ : α) (hi₀ : i₀ ∈ s) :
+    ∑ k ∈ s.piAntidiag n, (k i₀ : ℝ) ^ 2 * multinomialProb s p n k =
+    ∑ j ∈ range (n + 1), (j : ℝ) ^ 2 * BinomialTheoremOQ03.binomPMF n (p i₀) j := by
+  -- k(i₀) ≤ n for k ∈ piAntidiag n
+  have hmaps_to : ∀ k ∈ s.piAntidiag n, k i₀ ∈ range (n + 1) := fun k hk => by
+    rw [mem_range]
+    have hle : k i₀ ≤ ∑ l ∈ s, k l :=
+      Finset.single_le_sum (fun l _ => Nat.zero_le _) hi₀
+    have hsum : ∑ l ∈ s, k l = n := (Finset.mem_piAntidiag.mp hk).1
+    omega
+  rw [← sum_fiberwise_of_maps_to hmaps_to]
+  apply sum_congr rfl
+  intro j hj
+  rw [mem_range] at hj
+  -- On the fiber, replace k(i₀)² by j²
+  have step1 :
+      ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+        (k i₀ : ℝ) ^ 2 * multinomialProb s p n k =
+      ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+        (j : ℝ) ^ 2 * multinomialProb s p n k :=
+    sum_congr rfl fun k hk => by
+      have heq : k i₀ = j := (mem_filter.mp hk).2
+      rw [heq]
+  rw [step1, ← mul_sum]
+  -- The fiber sum of probabilities is the marginal PMF = binomPMF
+  simp_rw [multinomialProb_eq]
+  rw [BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf s p n hp_sum i₀ hi₀ j (by omega)]
+  unfold BinomialTheoremOQ03.binomPMF
+  ring
+
+/-! ## Main Theorem: Var(Xᵢ) = n·pᵢ·(1 − pᵢ) -/
+
+/-- **Multinomial variance**: `Var(Xᵢ) = n·pᵢ·(1 − pᵢ)`.
+
+    The diagonal companion to `OQ03.multinomial_covariance` (`Cov(Xᵢ,Xⱼ) =
+    −n·pᵢ·pⱼ` for `i ≠ j`). Combining the second moment `E[Xᵢ²]` with the mean
+    `E[Xᵢ] = n·pᵢ` reduces, via the binomial marginal, to the binomial variance
+    `n·p·(1 − p)`. -/
+theorem multinomial_variance {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (i₀ : α) (hi₀ : i₀ ∈ s) :
+    (∑ k ∈ s.piAntidiag n, (k i₀ : ℝ) ^ 2 * multinomialProb s p n k) -
+    (∑ k ∈ s.piAntidiag n, (k i₀ : ℝ) * multinomialProb s p n k) ^ 2 =
+    (n : ℝ) * p i₀ * (1 - p i₀) := by
+  rw [multinomial_second_moment s p n hp_sum i₀ hi₀,
+      multinomial_mean s p n hp_sum i₀ hi₀]
+  have hmean := binomial_mean_all_n n (p i₀)
+  rw [show ((n : ℝ) * p i₀) ^ 2 =
+      (∑ j ∈ range (n + 1), (j : ℝ) * BinomialTheoremOQ03.binomPMF n (p i₀) j) ^ 2 from by
+    rw [hmean]]
+  exact binomial_variance_all n (p i₀)
+
+/-! ## Summary
+
+### Proved (0 axioms, 0 sorries):
+1. `multinomial_second_moment` — `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j`
+   (fiber grouping; squared-statistic analogue of `OQ03.multinomial_mean`).
+2. `multinomial_variance`      — `Var(Xᵢ) = n·pᵢ·(1 − pᵢ)`
+   (closes the diagonal second-moment gap left by the `i ≠ j` cross-moment).
+
+### Relation to existing gallery results
+- `OQ03.multinomial_covariance` gives `Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ` for `i ≠ j`.
+- This file supplies the diagonal `i = j` entry of the covariance matrix:
+  `Var(Xᵢ) = Cov(Xᵢ,Xᵢ) = n·pᵢ·(1 − pᵢ)`.
+
+Together they determine the full multinomial covariance matrix
+`Σᵢⱼ = n·pᵢ·(δᵢⱼ − pⱼ)`.
+-/
+
+end BinomialTheoremOQ02OQ01OQ04

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-04/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-04/knowledge.md
@@ -1,0 +1,59 @@
+# binomial-theorem-oq-02-oq-01-oq-04 — Multinomial Variance
+
+## Status: COMPLETE (Lean-verified)
+
+`Var(Xᵢ) = n·pᵢ·(1 − pᵢ)` for a component of `Multinomial(n, p)` is fully
+machine-verified in `proofs/Proofs/BinomialTheoremOQ02OQ01OQ04.lean`
+(0 sorries, 0 axioms).
+
+## What was delivered
+
+- `multinomial_second_moment`: `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j`.
+- `multinomial_variance`: `E[Xᵢ²] − (E[Xᵢ])² = n·pᵢ·(1 − pᵢ)`.
+
+## History
+
+- The slug was originally "replace the vacuous `multinomial_expectation` rfl
+  with a substantive mean E[Xᵢ]=n·pᵢ". The mean was delivered separately
+  (`multinomial_mean`, merged in #24983 in the parent file, and independently
+  proved by fiber grouping in the OQ03 covariance sibling).
+- PR #25019 (build-free) pinned the remaining gap: the cross-moment lemma in
+  OQ03 carries `hij : i ≠ j`, so it gives `Cov(Xᵢ,Xⱼ) = −n·pᵢpⱼ` only off the
+  diagonal. The **diagonal** `E[Xᵢ²]` / `Var(Xᵢ)` was the one standard second
+  moment not yet in Lean. That PR proposed an MGF double-differentiation route
+  (single-variable copy of the cross-moment proof).
+
+## Route actually taken (simpler than the MGF route in #25019)
+
+Instead of double-differentiating a single-variable MGF (finicky `HasDerivAt`
+bookkeeping with nat-subtraction in the exponent), the marginal of `Xᵢ` is
+itself `Binomial(n, pᵢ)`. So the variance is just the binomial variance,
+reached by **fiber grouping** — the exact technique already used for the mean:
+
+1. `multinomial_second_moment`: group `∑ₖ k(i₀)²·P(k)` by `j = k(i₀)` with
+   `sum_fiberwise_of_maps_to`. On each fiber `k(i₀)²` is the constant `j²`,
+   factored out by `mul_sum`; the remaining fiber sum is
+   `multinomial_marginal_pmf` = `binomPMF n pᵢ j`. Result:
+   `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j`.
+2. `multinomial_variance`: rewrite `E[Xᵢ²]` and `E[Xᵢ] = n·pᵢ`
+   (`OQ03.multinomial_mean`), re-express `(n·pᵢ)²` as `(∑ⱼ j·binomPMF)²` via the
+   binomial mean, and close with the binomial variance.
+
+Reused, verified machinery (no new mathematics):
+- `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`
+- `BinomialTheoremOQ02OQ01OQ03.multinomial_mean`
+- `BinomialTheoremOQ03.binomial_variance` (needs `2 ≤ n`)
+
+The only new bookkeeping: `binomial_variance_all` / `multinomial_mean_all_n`
+discharge the degenerate `n = 0` (variance 0) and `n = 1` (single Bernoulli,
+variance `p(1−p)`) cases so the result holds for every `n`.
+
+## Together with the sibling
+
+`multinomial_covariance` (OQ03, `i ≠ j`) + `multinomial_variance` (this file,
+`i = j`) determine the full covariance matrix `Σᵢⱼ = n·pᵢ·(δᵢⱼ − pⱼ)`.
+
+## Possible follow-ups
+
+- Assemble `Σᵢⱼ = n·pᵢ·(δᵢⱼ − pⱼ)` as a single matrix-valued statement.
+- Singularity / rank `k − 1` of `Σ` from the constraint `∑Xₗ = n`.

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/meta.json
@@ -1,0 +1,72 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-04",
+  "title": "Multinomial Variance: Var(Xᵢ) = n·pᵢ·(1 − pᵢ)",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-04",
+  "description": "Proves the diagonal of the multinomial covariance matrix: the variance of a single component Var(Xᵢ) = n·pᵢ·(1 − pᵢ). The cross-moment lemma in the sibling file BinomialTheoremOQ02OQ01OQ03 carries the hypothesis i ≠ j, so it only reaches the off-diagonal entries Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ; this file supplies the missing diagonal. The proof reduces the second moment E[Xᵢ²] to the binomial second moment by fiber grouping over the value j = k(i₀) and the marginal-PMF identity, then combines with the mean E[Xᵢ] = n·pᵢ and the binomial variance. Fully machine-verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ04.lean",
+    "tags": [
+      "probability",
+      "multinomial distribution",
+      "variance",
+      "second moment",
+      "covariance matrix",
+      "fiber grouping",
+      "binomial marginal",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 151,
+    "assumptions": "None. Both theorems (second moment, variance) are fully machine-verified with 0 sorries and 0 axioms, reusing the verified marginal PMF (OQ02), multinomial mean (OQ03), and binomial variance (OQ03).",
+    "theoremCount": 2,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "For (X₁,…,Xₖ) ~ Multinomial(n, p₁,…,pₖ) the full second-order structure is the covariance matrix Σ = n·(diag(p) − ppᵀ), the object that underlies Karl Pearson's 1900 chi-squared goodness-of-fit test and R. A. Fisher's later work on contingency tables. The off-diagonal entries Σᵢⱼ = −n·pᵢpⱼ (i ≠ j) reflect the hard constraint ∑Xₗ = n: more of one outcome forces less of another. The diagonal entries Σᵢᵢ = Var(Xᵢ) = n·pᵢ(1 − pᵢ) are exactly the binomial variances, because each marginal Xᵢ is itself Binomial(n, pᵢ). This file machine-checks the diagonal, completing the covariance matrix begun in the covariance sibling.",
+    "problemStatement": "For (X₁,…,Xₖ) ~ Multinomial(n, p₁,…,pₖ) with ∑pᵢ = 1, prove that Var(Xᵢ) = E[Xᵢ²] − (E[Xᵢ])² = n·pᵢ·(1 − pᵢ).",
+    "text": "Proves Var(Xᵢ) = n·pᵢ·(1 − pᵢ) with both theorems fully machine-verified (0 sorries, 0 axioms). The second moment E[Xᵢ²] = ∑ⱼ j²·binomPMF(n, pᵢ, j) is proved by fiber grouping over j = k(i₀), the squared-statistic analogue of the multinomial mean. Combining with E[Xᵢ] = n·pᵢ and the binomial variance E[X²] − (E[X])² = n·p(1 − p) yields the result.",
+    "proofStrategy": "Each marginal Xᵢ is Binomial(n, pᵢ) (multinomial_marginal_pmf, from BinomialTheoremOQ02OQ01OQ02). The theorem multinomial_second_moment uses sum_fiberwise_of_maps_to to group the multinomial sum by the value k(i₀) = j; on each fiber the statistic k(i₀)² is the constant j², which factors out, leaving the marginal PMF P(Xᵢ=j) = binomPMF(n, pᵢ, j). This reduces E[Xᵢ²] to the binomial second moment ∑ⱼ j²·binomPMF. The variance then follows from the binomial variance (BinomialTheoremOQ03.binomial_variance, extended here to all n) together with the mean E[Xᵢ] = n·pᵢ (BinomialTheoremOQ02OQ01OQ03.multinomial_mean).",
+    "keyInsights": [
+      "The diagonal of the covariance matrix is not reachable from the cross-moment lemma, which assumes i ≠ j; the variance needs its own argument.",
+      "The component Xᵢ is marginally Binomial(n, pᵢ), so Var(Xᵢ) is literally the binomial variance n·pᵢ(1 − pᵢ) — no multinomial-specific second-moment computation is required beyond fiber grouping.",
+      "The second-moment proof is the squared-statistic copy of the multinomial mean: replacing k(i₀) by k(i₀)² in the fiber-grouping argument, the constant j² factors out of each fiber and the remaining sum is the marginal PMF.",
+      "BinomialTheoremOQ03.binomial_variance requires 2 ≤ n; the degenerate cases n = 0 (variance 0) and n = 1 (a single Bernoulli trial, variance p(1 − p)) are discharged directly so the multinomial result holds for every n.",
+      "Together with the off-diagonal Cov(Xᵢ,Xⱼ) = −n·pᵢpⱼ this determines the full covariance matrix Σᵢⱼ = n·pᵢ(δᵢⱼ − pⱼ), which is singular of rank k−1 because ∑Xₗ = n confines all variation to the constraint hyperplane."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Variance of a Multinomial Component",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports the multinomial choose lemmas, BigOperators, and three parent proof files: BinomialTheoremOQ02OQ01OQ02 (marginal PMF), BinomialTheoremOQ02OQ01OQ03 (multinomial mean, multinomialProb), and BinomialTheoremOQ03 (binomial variance). The docblock states the open question (the i ≠ j cross-moment leaves the diagonal unreached), the answer Var(Xᵢ) = n·pᵢ(1 − pᵢ), and the three-step fiber-grouping reduction to the binomial variance."
+    },
+    {
+      "id": "binomial-variance-all",
+      "title": "Binomial mean and variance for all n",
+      "startLine": 49,
+      "endLine": 70,
+      "summary": "Two private helpers extend the binomial facts to every n: binomial_variance_all case-splits on n ∈ {0, 1, ≥2}, handling the degenerate cases by simp/ring and delegating n ≥ 2 to BinomialTheoremOQ03.binomial_variance; binomial_mean_all_n similarly extends the binomial mean (which requires n ≥ 1) to n = 0."
+    },
+    {
+      "id": "second-moment",
+      "title": "Second Moment E[Xᵢ²] = ∑ⱼ j²·binomPMF",
+      "startLine": 71,
+      "endLine": 111,
+      "summary": "multinomial_second_moment proves E[Xᵢ²] = ∑ⱼ j²·binomPMF(n, pᵢ, j) by fiber grouping. sum_fiberwise_of_maps_to regroups the multinomial sum by j = k(i₀); on each fiber k(i₀)² is the constant j² (factored out via mul_sum), and the remaining probability sum is rewritten to the marginal PMF binomPMF via multinomial_marginal_pmf. This is the squared-statistic analogue of OQ03.multinomial_mean."
+    },
+    {
+      "id": "variance",
+      "title": "Main Theorem: Var(Xᵢ) = n·pᵢ·(1 − pᵢ)",
+      "startLine": 112,
+      "endLine": 151,
+      "summary": "multinomial_variance rewrites E[Xᵢ²] via multinomial_second_moment and E[Xᵢ] via multinomial_mean, re-expresses (n·pᵢ)² as (∑ⱼ j·binomPMF)² using the all-n mean, and closes by binomial_variance_all. The result is the diagonal companion to OQ03.multinomial_covariance, completing the multinomial covariance matrix."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Completes **binomial-theorem-oq-02-oq-01-oq-04** with a **build-verified** Lean proof of the multinomial variance, the diagonal of the covariance matrix.

`Var(Xᵢ) = n·pᵢ·(1 − pᵢ)` for `(X₁,…,Xₖ) ~ Multinomial(n, p)`, in new file `proofs/Proofs/BinomialTheoremOQ02OQ01OQ04.lean` (registered in `Proofs.lean`).

### Why this gap existed
The OQ03 sibling proves `Cov(Xᵢ,Xⱼ) = −n·pᵢpⱼ` via a bivariate cross-moment that carries `hij : i ≠ j`, so it reaches only the **off-diagonal** entries. The **diagonal** `E[Xᵢ²]` / `Var(Xᵢ)` was the one standard second moment not yet in Lean (pinned build-free in #25019).

### Route (simpler than the MGF double-differentiation route pinned in #25019)
Each marginal `Xᵢ` is `Binomial(n, pᵢ)`, so the variance is the binomial variance, reached by **fiber grouping** — the same technique already used for the mean:
- `multinomial_second_moment`: `E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j` (group `∑ₖ k(i₀)²·P(k)` by `j = k(i₀)`; the constant `j²` factors out, leaving the marginal PMF).
- `multinomial_variance`: combine `E[Xᵢ²]`, the mean `E[Xᵢ]=n·pᵢ` (`OQ03.multinomial_mean`), and the binomial variance (`OQ03.binomial_variance`, extended here to all `n`).

No new mathematics; reuses verified OQ02/OQ03 machinery. Together with the covariance sibling this determines the full matrix `Σᵢⱼ = n·pᵢ(δᵢⱼ − pⱼ)`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ04` → `✔ [7746/7746] Build completed successfully`
- **0 sorries, 0 axioms** (status `verified`).

## Notes
- Supersedes the build-free route certificate #25019 (that PR changed no Lean).
- Math agent PR: no `loom:review-requested` (deployer merges directly).

## Test plan
- [x] Docker build green, 0 sorry / 0 axiom
- [x] `meta.json` validates (lineCount 151, theoremCount 2, definitionCount 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)