### PR TITLE
Research: sylvester-sequence-oq-01 — reciprocal sum telescopes to 1, terms pairwise coprime

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2926,6 +2926,7 @@ import Proofs.SylowTheoremOQ02Orbit
 import Proofs.SylowTheoremOQ03
 import Proofs.SylowTheoremOQ03B
 import Proofs.SylowTheoremOQ04
+import Proofs.SylvesterSequenceOQ01
 import Proofs.SynthesisCurvaturePtolemy
 import Proofs.SynthesisCurvaturePtolemyOQ01
 import Proofs.SzemerediCore

--- a/proofs/Proofs/SylvesterSequenceOQ01.lean
+++ b/proofs/Proofs/SylvesterSequenceOQ01.lean
@@ -1,0 +1,107 @@
+import Mathlib
+
+/-!
+# Sylvester's sequence: closed-form partial reciprocal sums and pairwise coprimality
+
+Sylvester's sequence is defined by `a₀ = 2` and `a_{n+1} = aₙ² - aₙ + 1`, giving
+`2, 3, 7, 43, 1807, 3263443, …`.
+
+This file establishes two classical elementary facts, fully machine-checked:
+
+* **Closed-form partial sums** (`syl_partial_sum`):
+  `∑_{k=0}^{n} 1/aₖ = 1 - 1/(a_{n+1} - 1)`.
+  Since `a_{n+1} - 1 → ∞`, the infinite sum of reciprocals equals `1`.
+
+* **Pairwise coprimality** (`syl_coprime`): distinct terms are coprime, via the
+  product formula `a_{n+1} = (∏_{k≤n} aₖ) + 1` (a Euclid-style identity).
+
+The engine is the telescoping identity `1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1)`, which holds
+because `a_{n+1} - 1 = aₙ(aₙ - 1)`.
+
+No axioms, no sorries.
+-/
+
+namespace SylvesterSequenceOQ01
+
+/-- Sylvester's sequence: `a₀ = 2`, `a_{n+1} = aₙ² - aₙ + 1`. -/
+def syl : ℕ → ℕ
+  | 0 => 2
+  | (n + 1) => syl n ^ 2 - syl n + 1
+
+@[simp] theorem syl_zero : syl 0 = 2 := rfl
+
+theorem syl_succ (n : ℕ) : syl (n + 1) = syl n ^ 2 - syl n + 1 := rfl
+
+/-- Every term is at least `2`. -/
+theorem two_le_syl (n : ℕ) : 2 ≤ syl n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    have h : syl k + 2 ≤ syl k ^ 2 := by nlinarith [ih]
+    rw [syl_succ]
+    omega
+
+/-- The recurrence, lifted to `ℤ` (no truncated subtraction). -/
+theorem syl_cast_succ (n : ℕ) :
+    (syl (n + 1) : ℤ) = (syl n : ℤ) ^ 2 - (syl n : ℤ) + 1 := by
+  have h1 : syl n ≤ syl n ^ 2 := by nlinarith [two_le_syl n]
+  rw [syl_succ]
+  push_cast [Nat.cast_sub h1]
+  ring
+
+/-- Telescoping per-term identity: `1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1)`. -/
+theorem syl_recip_term (n : ℕ) :
+    (1 : ℚ) / (syl n : ℚ)
+      = 1 / ((syl n : ℚ) - 1) - 1 / ((syl (n + 1) : ℚ) - 1) := by
+  have ha : (2 : ℚ) ≤ (syl n : ℚ) := by exact_mod_cast two_le_syl n
+  have hsucc : (syl (n + 1) : ℚ) = (syl n : ℚ) ^ 2 - (syl n : ℚ) + 1 := by
+    exact_mod_cast syl_cast_succ n
+  have h0 : (syl n : ℚ) ≠ 0 := by linarith
+  have h1 : (syl n : ℚ) - 1 ≠ 0 := by linarith
+  have h2 : (syl n : ℚ) ^ 2 - (syl n : ℚ) + 1 - 1 ≠ 0 := by nlinarith [ha]
+  rw [hsucc]
+  field_simp
+  ring
+
+/-- Closed form for partial sums of reciprocals: `∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1)`. -/
+theorem syl_partial_sum (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (1 : ℚ) / (syl k : ℚ)
+      = 1 - 1 / ((syl (n + 1) : ℚ) - 1) := by
+  induction n with
+  | zero =>
+    rw [Finset.sum_range_one]
+    norm_num [show syl 0 = 2 from rfl, show syl (0 + 1) = 3 from rfl]
+  | succ m ih =>
+    rw [Finset.sum_range_succ, ih, syl_recip_term (m + 1)]
+    ring
+
+/-- Euclid-style product formula: `a_{n+1} = (∏_{k≤n} aₖ) + 1`. -/
+theorem syl_eq_prod_add_one (n : ℕ) :
+    syl (n + 1) = (∏ k ∈ Finset.range (n + 1), syl k) + 1 := by
+  induction n with
+  | zero => rw [Finset.prod_range_one]; rfl
+  | succ m ih =>
+    rw [Finset.prod_range_succ]
+    have hp : (∏ k ∈ Finset.range (m + 1), syl k) = syl (m + 1) - 1 := by omega
+    rw [hp, syl_succ, pow_two, Nat.sub_one_mul]
+
+/-- Each term divides any later term minus one: `aᵢ ∣ a_{n+1} - 1` for `i ≤ n`. -/
+theorem syl_dvd_succ_sub_one {i n : ℕ} (h : i ≤ n) : syl i ∣ syl (n + 1) - 1 := by
+  rw [syl_eq_prod_add_one, Nat.add_sub_cancel]
+  exact Finset.dvd_prod_of_mem syl (Finset.mem_range.mpr (Nat.lt_succ_of_le h))
+
+/-- Distinct terms of Sylvester's sequence are coprime. -/
+theorem syl_coprime {i j : ℕ} (h : i < j) : Nat.Coprime (syl i) (syl j) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_add_of_lt h
+  -- now `j = i + n + 1`
+  have key : syl i ∣ syl (i + n + 1) - 1 := syl_dvd_succ_sub_one (Nat.le_add_right i n)
+  have hge : (1 : ℕ) ≤ syl (i + n + 1) := le_trans (by norm_num) (two_le_syl _)
+  have hd1 : Nat.gcd (syl i) (syl (i + n + 1)) ∣ syl i := Nat.gcd_dvd_left _ _
+  have hd2 : Nat.gcd (syl i) (syl (i + n + 1)) ∣ syl (i + n + 1) := Nat.gcd_dvd_right _ _
+  have hd3 : Nat.gcd (syl i) (syl (i + n + 1)) ∣ syl (i + n + 1) - 1 := hd1.trans key
+  have hone : Nat.gcd (syl i) (syl (i + n + 1)) ∣ 1 := by
+    have hsub := Nat.dvd_sub hd2 hd3
+    rwa [Nat.sub_sub_self hge] at hsub
+  exact Nat.dvd_one.mp hone
+
+end SylvesterSequenceOQ01

--- a/src/data/proofs/sylvester-sequence-oq-01/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01/meta.json
@@ -1,0 +1,92 @@
+{
+  "id": "sylvester-sequence-oq-01",
+  "slug": "sylvester-sequence-oq-01",
+  "title": "Sylvester's Sequence: Telescoping Reciprocal Sums and Pairwise Coprimality",
+  "description": "Sylvester's sequence a₀=2, a_{n+1}=aₙ²-aₙ+1 (2, 3, 7, 43, 1807, …) has two classical elementary properties, both fully machine-checked here with 0 sorries and 0 axioms. (1) Closed-form partial reciprocal sums: ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1), so the infinite reciprocal sum equals 1 — an explicit Egyptian-fraction representation of unity. (2) Pairwise coprimality of distinct terms, via the Euclid-style product formula a_{n+1} = (∏_{k≤n} aₖ) + 1. The engine is the telescoping identity 1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1), which follows from a_{n+1}-1 = aₙ(aₙ-1).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "SylvesterSequenceOQ01",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 4,
+    "trivialSpecializations": 2,
+    "definitionCount": 1,
+    "path": "Proofs/SylvesterSequenceOQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "James Joseph Sylvester (1880)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
+    "date": "1880",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylvesterSequenceOQ01.lean",
+    "tags": [
+      "number-theory",
+      "recurrence",
+      "egyptian-fractions",
+      "coprimality",
+      "telescoping",
+      "sylvester"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. The sequence is defined directly in ℕ; all results are proved from the recurrence with no axioms and no structure-encoded hypotheses.",
+    "dateAdded": "2026-06-16",
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Closed-form partial reciprocal sum syl_partial_sum: ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1), proved by induction using the telescoping per-term identity",
+      "Telescoping identity syl_recip_term: 1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1), the algebraic heart of the result",
+      "Euclid-style product formula syl_eq_prod_add_one: a_{n+1} = (∏_{k≤n} aₖ) + 1",
+      "Pairwise coprimality syl_coprime: distinct terms share no common factor, derived from the product formula"
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Telescoping sums",
+      "Elementary divisibility and gcd in ℕ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 107,
+    "relatedProblems": [],
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": "Sylvester's sequence is defined by a₀ = 2 and a_{n+1} = aₙ² - aₙ + 1, producing the rapidly growing sequence 2, 3, 7, 43, 1807, 3263443, …. It is the greedy sequence for the Egyptian-fraction expansion of 1: at each step one subtracts the largest unit fraction that keeps the running total below 1. This file formalizes the two facts that make the sequence famous.",
+  "mainTheorems": [
+    {
+      "name": "syl_partial_sum",
+      "statement": "∑ k ∈ Finset.range (n+1), 1/aₖ = 1 - 1/(a_{n+1} - 1)",
+      "description": "Closed form for the partial sums of reciprocals. Because a_{n+1} - 1 grows without bound, the infinite series of reciprocals converges to exactly 1."
+    },
+    {
+      "name": "syl_recip_term",
+      "statement": "1/aₙ = 1/(aₙ - 1) - 1/(a_{n+1} - 1)",
+      "description": "The telescoping per-term identity that drives the partial-sum formula, a consequence of a_{n+1} - 1 = aₙ(aₙ - 1)."
+    },
+    {
+      "name": "syl_eq_prod_add_one",
+      "statement": "a_{n+1} = (∏ k ∈ Finset.range (n+1), aₖ) + 1",
+      "description": "Euclid-style product formula: each term is one more than the product of all previous terms."
+    },
+    {
+      "name": "syl_coprime",
+      "statement": "i < j → Nat.Coprime aᵢ aⱼ",
+      "description": "Distinct terms of the sequence are coprime, since aᵢ divides aⱼ - 1 while also any common factor divides aⱼ."
+    }
+  ],
+  "sections": [],
+  "references": [
+    {
+      "title": "Sylvester's sequence",
+      "url": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence"
+    },
+    {
+      "title": "OEIS A000058 — Sylvester's sequence",
+      "url": "https://oeis.org/A000058"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": "Two elementary but elegant facts about Sylvester's sequence are now fully verified: its reciprocals form an Egyptian-fraction representation of 1 (with an exact closed form for every partial sum), and its terms are pairwise coprime. Both follow from the single observation a_{n+1} - 1 = aₙ(aₙ - 1)."
+}

--- a/src/data/research/problems/sylvester-sequence-oq-01.json
+++ b/src/data/research/problems/sylvester-sequence-oq-01.json
@@ -1,0 +1,45 @@
+{
+  "slug": "sylvester-sequence-oq-01",
+  "title": "Sylvester's Sequence: Telescoping Reciprocal Sums and Pairwise Coprimality",
+  "tier": "B",
+  "significance": 5,
+  "tractability": 6,
+  "status": "completed",
+  "phase": "COMPLETED",
+  "problemStatement": "For Sylvester's sequence a₀=2, a_{n+1}=aₙ²-aₙ+1, prove the closed-form partial reciprocal sum ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) (so the infinite reciprocal sum is 1) and that distinct terms are pairwise coprime.",
+  "tags": [
+    "number-theory",
+    "recurrence",
+    "egyptian-fractions",
+    "coprimality",
+    "telescoping",
+    "sylvester"
+  ],
+  "knownResults": "Classical (Sylvester 1880; Euclid-style coprimality). Absent from Mathlib and the gallery prior to this entry.",
+  "currentState": "COMPLETE. Full Lean proof in proofs/Proofs/SylvesterSequenceOQ01.lean, 0 sorries, 0 axioms, build-verified.",
+  "knowledge": {
+    "insights": [
+      "The entire result hinges on the algebraic identity a_{n+1} - 1 = aₙ(aₙ - 1), which makes the per-term reciprocal telescope: 1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1).",
+      "Working the recurrence in ℤ (syl_cast_succ) avoids ℕ truncated-subtraction pain; the lower bound 2 ≤ aₙ justifies the cast via Nat.cast_sub.",
+      "Pairwise coprimality follows the Euclid-numbers pattern: aᵢ divides ∏_{k≤n} aₖ = a_{n+1} - 1 for i ≤ n, so any common divisor of aᵢ and a_{n+1} divides 1.",
+      "field_simp; ring closes the per-term rational identity once the three relevant denominators are known nonzero."
+    ],
+    "builtItems": [
+      "def syl and syl_succ/syl_zero — sequence definition (SylvesterSequenceOQ01.lean)",
+      "two_le_syl : 2 ≤ syl n (induction + omega over an opaque square atom)",
+      "syl_cast_succ : (syl (n+1):ℤ) = (syl n)^2 - syl n + 1",
+      "syl_recip_term : 1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1) (telescoping engine)",
+      "syl_partial_sum : ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) (headline)",
+      "syl_eq_prod_add_one : a_{n+1} = (∏_{k≤n} aₖ) + 1 (Euclid product formula)",
+      "syl_dvd_succ_sub_one and syl_coprime : pairwise coprimality"
+    ],
+    "nextSteps": [
+      "Optional follow-up: formalize the limit Tendsto (partial sum) atTop (𝓝 1) by showing a_{n+1}-1 → ∞ (needs strict monotonicity / exponential growth bound).",
+      "Optional follow-up: the closeness 0 < 1 - ∑_{k≤n} 1/aₖ = 1/(a_{n+1}-1) connects to the Vardi constant / Erdős #315 gallery entry."
+    ],
+    "progressSummary": "COMPLETE: closed-form partial reciprocal sum and pairwise coprimality both proved, 0 sorries / 0 axioms, build-verified."
+  },
+  "started": "2026-06-16",
+  "lastUpdate": "2026-06-16",
+  "path": "proofs/Proofs/SylvesterSequenceOQ01.lean"
+}


### PR DESCRIPTION
## Summary

Formalizes two classical elementary facts about **Sylvester's sequence** (`a₀=2`, `a_{n+1}=aₙ²-aₙ+1`; `2, 3, 7, 43, 1807, …`), fully machine-checked with **0 sorries, 0 axioms**.

- **`syl_partial_sum`**: `∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1)`. Since `a_{n+1}-1 → ∞`, the infinite reciprocal sum equals exactly `1` — an explicit Egyptian-fraction representation of unity.
- **`syl_coprime`**: distinct terms are pairwise coprime, via the Euclid-style product formula `syl_eq_prod_add_one`: `a_{n+1} = (∏_{k≤n} aₖ) + 1`.

The algebraic engine is the telescoping identity `syl_recip_term`: `1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1)`, which follows from `a_{n+1}-1 = aₙ(aₙ-1)`.

Absent from Mathlib and the gallery prior to this entry.

## Files
- `proofs/Proofs/SylvesterSequenceOQ01.lean` (107 lines, 9 theorems + 1 def)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/sylvester-sequence-oq-01/meta.json` (gallery entry, badge `original`)
- `src/data/research/problems/sylvester-sequence-oq-01.json` (knowledge record)

## Verification
- `./proofs/scripts/docker-build.sh Proofs.SylvesterSequenceOQ01` → `✔ [7743/7743] Build completed successfully`
- 0 sorries, 0 axioms, no structure-encoded assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)