### PR TITLE
audit(tracker): record 3 clean audits — queue fully drained

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15552,6 +15552,24 @@
       "lastAudited": "2026-06-16T07:56:56Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T16:11:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T16:12:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "viviani-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T16:13:41Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Three audit targets verified clean. Records appended to `audit-tracker.json`.

| Slug | Claim | Verdict |
|------|-------|---------|
| amgm-inequality-oq-02-oq-01-oq-05 | formalized / mathlib | ✅ metrics match (124L, 0 ax, 0 sorry, 6 thm, 3 def); orphan as declared; honest build-pending note |
| lebesgue-measure-oq-01-oq-01-oq-02-oq-01 | formalized / mathlib | ✅ metrics match (68L, 0 ax, 0 sorry, 5 thm); orphan as declared; honest build-pending note |
| viviani-theorem-oq-01 | **verified / original** | ✅ 0 ax, 0 sorry, 0 structure-encoded assumptions; registered in Proofs.lean; Mathlib deps only routine arithmetic — Viviani genuinely absent from Mathlib, so `original` is correct |

### Notes
- Two orphan entries correctly use `formalized`/`mathlib` with transparent BUILD-PENDING assumptions text — no overclaiming.
- Viviani's stronger `verified`/`original` claim is fully supported: registered file, no axioms/sorries/structure assumptions, no True stubs, no Mathlib-wrapper masking.
- Minor cosmetic nit (not blocking): viviani `lineCount` says 124 vs `wc -l` 123 (trailing-newline off-by-one).

**Audit queue now fully drained: 2483/2483 audited, 0 issues, 0 critical.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)