### PR TITLE
Enrich Erdős #312: realign stale annotations + cover Parts IV.b–VIII

### DIFF
--- a/src/data/proofs/erdos-312/annotations.json
+++ b/src/data/proofs/erdos-312/annotations.json
@@ -23,8 +23,8 @@
     "id": "ann-e312-reciprocal-sum",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 33,
-      "endLine": 40
+      "startLine": 37,
+      "endLine": 44
     },
     "type": "definition",
     "title": "Reciprocal Sum Definitions",
@@ -39,11 +39,31 @@
     "prerequisites": []
   },
   {
+    "id": "ann-e312-subset-algebra",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 46,
+      "endLine": 120
+    },
+    "type": "insight",
+    "title": "Subset Sum Algebra",
+    "content": "A toolkit of elementary lemmas establishing that subsetReciprocalSum behaves like a well-mannered measure over subsets. The key facts that later proofs rely on:\n\n- **Monotonicity** (subsetReciprocalSum_mono): S ⊆ T ⟹ sum(S) ≤ sum(T), since every term 1/a(i) ≥ 0.\n- **Bounded by total** (subsetSum_le_totalSum): any subset sum is ≤ the full reciprocal sum.\n- **Disjoint additivity** (subsetReciprocalSum_disjoint_union): sum(S ∪ T) = sum(S) + sum(T) for disjoint S, T.\n- **Single-step changes** (subsetReciprocalSum_insert / _erase): inserting or removing one index i shifts the sum by exactly 1/a(i).\n\nThe insert/erase lemmas are the workhorses of the greedy argument in Part VII: they quantify exactly how much one element contributes, which is what bounds the gap to 1.",
+    "mathContext": "These are the order-theoretic and additive properties of a finite nonnegative sum $\\sum_{i \\in S} 1/a(i)$ over the lattice of subsets. Nonnegativity of each term $1/a(i) \\ge 0$ is what makes the sum monotone in $S$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Monotonicity",
+      "Finset.sum_insert",
+      "Disjoint union",
+      "Finitely additive"
+    ],
+    "prerequisites": []
+  },
+  {
     "id": "ann-e312-exponential-precision",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 44,
-      "endLine": 49
+      "startLine": 124,
+      "endLine": 129
     },
     "type": "definition",
     "title": "Exponential Precision Property",
@@ -61,8 +81,8 @@
     "id": "ann-e312-main-conjecture",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 51,
-      "endLine": 61
+      "startLine": 131,
+      "endLine": 141
     },
     "type": "concept",
     "title": "The Main Conjecture (OPEN)",
@@ -80,18 +100,19 @@
     "id": "ann-e312-polynomial",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 65,
-      "endLine": 80
+      "startLine": 145,
+      "endLine": 160
     },
     "type": "concept",
     "title": "Erdős-Graham Polynomial Bound",
-    "content": "**hasPolynomialPrecision:** Like exponential precision, but with error bound c/K² instead of exp(-cK).\n\n**erdos_graham_polynomial:** The known theorem of Erdős and Graham [ErGr80]: the polynomial bound c/K² holds. This is axiomatized because the proof uses sophisticated techniques from analytic number theory.\n\nThe polynomial bound means: for some c > 0, any large enough multiset with reciprocal sum > K has a subset summing to within c/K² of 1. This is already non-trivial — it says we can always find a *very* good approximation to 1.",
-    "mathContext": "The proof of the polynomial bound uses the greedy algorithm with careful analysis of the remainder terms. The transition to exponential bounds would require understanding higher-order correlations in the subset sum distribution.",
+    "content": "**hasPolynomialPrecision:** Like exponential precision, but with error bound c/K² instead of exp(-cK).\n\n**erdos_graham_polynomial:** The known theorem of Erdős and Graham [ErGr80]: the polynomial bound c/K² holds. This is the one genuine `axiom` declaration in the file — it is axiomatized because its proof uses sophisticated techniques from analytic number theory not reproduced here.\n\nThe polynomial bound means: for some c > 0, any large enough multiset with reciprocal sum > K has a subset summing to within c/K² of 1. This is already non-trivial — it says we can always find a *very* good approximation to 1.",
+    "mathContext": "The proof of the polynomial bound uses the greedy algorithm with careful analysis of the remainder terms. The transition to exponential bounds would require understanding higher-order correlations in the subset sum distribution. The sieve-and-greedy infrastructure in Part VIII (below) is a first formal step toward an in-Lean derivation of this axiom.",
     "significance": "key",
     "relatedConcepts": [
       "Erdős-Graham theorem",
       "Polynomial bounds",
-      "Greedy algorithms"
+      "Greedy algorithms",
+      "Axiomatization"
     ],
     "prerequisites": []
   },
@@ -99,18 +120,82 @@
     "id": "ann-e312-relationship",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 84,
-      "endLine": 109
+      "startLine": 164,
+      "endLine": 223
     },
     "type": "concept",
     "title": "Comparing Exponential and Polynomial Bounds",
-    "content": "**exponential_stronger_than_polynomial:** For large K, exp(-cK) < c'/K². This axiom captures the fundamental fact that exponential decay beats polynomial decay.\n\n**conjecture_implies_known:** This is a *proved* theorem: if the exponential conjecture holds, then in particular we can always find subsets with reciprocal sum ≤ 1. The proof extracts the upper bound from hasExponentialPrecision by destructing the existential to get the subset S and its upper bound.\n\nThis theorem verifies the logical consistency of our formalization — the conjectured property is strictly stronger than the known property.",
-    "mathContext": "The proof uses basic Lean tactics: intro for the hypothesis, obtain to destructure existentials, and exact to provide the witness. This is a clean example of extracting weaker conclusions from stronger hypotheses.",
+    "content": "**exponential_stronger_than_polynomial:** A *proved theorem* (not an axiom): for any c, c' > 0 there is a threshold K₀ beyond which exp(-cK) < c'/K². The proof is the heart of this section — it uses Mathlib's `Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero` to show K²·exp(-cK) → 0, then extracts a metric ε-bound and divides through. This formalizes the principle that exponential decay always beats polynomial decay.\n\n**conjecture_implies_known:** Also proved: if the exponential conjecture holds, then in particular subsets with reciprocal sum ≤ 1 always exist. The proof destructures the existential from hasExponentialPrecision to extract the upper bound.\n\nTogether these verify the logical consistency of the formalization — the conjectured property is genuinely strictly stronger than the known one.",
+    "mathContext": "The limit $K^2 e^{-cK} \\to 0$ is the rigorous statement of 'exponentials dominate polynomials'. The proof composes $\\mathrm{tendsto\\_pow\\_mul\\_exp\\_neg}$ with the linear scaling $K \\mapsto cK$, then chooses $\\varepsilon = c' c^2$ so that dividing by $(cK)^2$ yields exactly $e^{-cK} < c'/K^2$.",
     "significance": "key",
     "relatedConcepts": [
-      "Implication proofs",
-      "Bound comparison",
+      "Asymptotic domination",
+      "Real.tendsto_pow_mul_exp_neg",
+      "Metric.tendsto_atTop",
       "Logical consistency"
+    ],
+    "prerequisites": [
+      "Limits and filters",
+      "Real analysis"
+    ]
+  },
+  {
+    "id": "ann-e312-exp-gap",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 254,
+      "endLine": 283
+    },
+    "type": "insight",
+    "title": "Exponential Gap: Bounds and Limit",
+    "content": "Four lemmas characterizing the precision window width g(K) = 1 - exp(-cK) for the conjectured bound:\n\n- **exponential_gap_nonneg / _lt_one:** 0 ≤ g(K) < 1, so the interval (1 - exp(-cK), 1] is always well-defined and of positive length.\n- **exponential_gap_monotone:** g is increasing in K — larger reciprocal-sum budgets give a wider window, so finding a qualifying subset gets *easier* as K grows.\n- **exponential_gap_tends_to_one:** g(K) → 1 as K → ∞, built from Real.tendsto_exp_neg_atTop_nhds_zero. In the limit the conjecture would force subset sums arbitrarily close to 1.",
+    "mathContext": "$g(K) = 1 - e^{-cK}$ is the standard saturating exponential. Monotone increasing with $g(0)=0$ and $\\lim_{K\\to\\infty} g(K) = 1$; this is the complement of the decay $e^{-cK} \\downarrow 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.exp_le_exp",
+      "Saturating exponential",
+      "Tendsto",
+      "Monotonicity"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e312-poly-gap",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 287,
+      "endLine": 325
+    },
+    "type": "insight",
+    "title": "Polynomial Gap Analysis",
+    "content": "The parallel analysis for the known bound's window width c/K²:\n\n- **polynomial_gap_pos:** c/K² > 0 for c, K > 0 (closed by `positivity`).\n- **polynomial_gap_antitone:** c/K² is *decreasing* in K — note this is the gap to 1 shrinking, i.e. precision *improving* as K grows.\n- **polynomial_gap_tends_to_zero:** c/K² → 0 as K → ∞, via tendsto_inv_atTop_zero composed with K ↦ K².\n- **polynomialPrecision_mono_c:** raising the constant c weakens the bound, so polynomial precision at c₁ implies it at any c₂ ≥ c₁.\n\nContrast with the exponential window of Part IV.b: there the *window width* g(K) → 1, here the *gap* c/K² → 0. Both describe precision improving with K, but the polynomial gap decays only inverse-quadratically.",
+    "mathContext": "$c/K^2 \\downarrow 0$ at rate $\\Theta(K^{-2})$, versus the conjectured gap $e^{-cK} \\downarrow 0$ at exponential rate. The ratio $\\frac{e^{-cK}}{c'/K^2} = \\frac{K^2 e^{-cK}}{c'} \\to 0$ is exactly what exponential_stronger_than_polynomial proves.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "tendsto_inv_atTop_zero",
+      "Antitone",
+      "Inverse-square decay",
+      "div_le_div_of_nonneg_right"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e312-taylor",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 329,
+      "endLine": 374
+    },
+    "type": "insight",
+    "title": "Taylor Sandwich for the Exponential Gap",
+    "content": "Concrete two-sided estimates on 1 - exp(-cK) using first-order Taylor information about the exponential, avoiding any appeal to limits:\n\n- **Upper bound** (exponential_gap_le_cK): from exp(-x) ≥ 1 - x (i.e. Real.add_one_le_exp), the gap satisfies 1 - exp(-cK) ≤ cK.\n- **Lower bound** (exponential_gap_concrete_bound): from exp(-x) ≤ 1/(1+x) for x ≥ 0, the gap satisfies cK/(1+cK) ≤ 1 - exp(-cK), via the identity 1 - 1/(1+t) = t/(1+t).\n- **exponential_gap_sandwich** packages both: cK/(1+cK) ≤ 1 - exp(-cK) ≤ cK.\n\nThese rational sandwiches give computable, certificate-friendly bounds — useful when one needs explicit estimates rather than asymptotics.",
+    "mathContext": "The convexity inequalities $1 - x \\le e^{-x} \\le \\frac{1}{1+x}$ (for $x \\ge 0$) yield $\\frac{x}{1+x} \\le 1 - e^{-x} \\le x$. With $x = cK$ this sandwiches the precision gap between a rational lower bound and the linear upper bound $cK$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.add_one_le_exp",
+      "Taylor bound",
+      "Convexity of exp",
+      "one_div_le_one_div_of_le"
     ],
     "prerequisites": []
   },
@@ -118,31 +203,74 @@
     "id": "ann-e312-harmonic",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 113,
-      "endLine": 120
+      "startLine": 378,
+      "endLine": 443
     },
     "type": "definition",
     "title": "Harmonic Numbers",
-    "content": "**harmonicNumber n:** H_n = 1 + 1/2 + 1/3 + ... + 1/n, the n-th partial sum of the harmonic series. Computed as Σ_{i=0}^{n-1} 1/(i+1).\n\n**harmonic_unbounded:** H_n → ∞ as n → ∞. This is a classical result (often proved via comparison with ln(n)). It ensures that for any K > 0, the multiset {1, 2, ..., n} for large enough n has reciprocal sum > K, providing canonical test cases for the conjecture.",
-    "mathContext": "H_n = ln(n) + γ + O(1/n) where γ ≈ 0.5772 is the Euler-Mascheroni constant. The divergence of the harmonic series, proved by Oresme (c. 1350), is one of the earliest results in analysis.",
+    "content": "**harmonicNumber n:** H_n = 1 + 1/2 + 1/3 + ... + 1/n, the n-th partial sum of the harmonic series, computed as Σ_{i=0}^{n-1} 1/(i+1).\n\n**harmonic_unbounded:** H_n → ∞ as n → ∞ (via Real.tendsto_sum_range_one_div_nat_succ_atTop). This guarantees that for any K > 0, the multiset {1, 2, ..., n} for large enough n has reciprocal sum > K, supplying canonical test inputs for the conjecture.\n\nThe surrounding lemmas record the basic facts the rest of the file uses: H is non-decreasing (harmonicNumber_mono), the boundary values H_0 = 0 and H_1 = 1, the recurrence H_{n+1} = H_n + 1/(n+1), and the bridge **canonical_reciprocalSum**: reciprocalSum of i ↦ i+1 equals H_n.",
+    "mathContext": "H_n = ln(n) + γ + O(1/n) where γ ≈ 0.5772 is the Euler-Mascheroni constant. The divergence of the harmonic series, proved by Oresme (c. 1350), is one of the earliest results in analysis and is exactly what makes 'reciprocal sum > K' achievable for every K.",
     "significance": "key",
     "relatedConcepts": [
       "Harmonic series",
       "Euler-Mascheroni constant",
-      "Divergence"
+      "Divergence",
+      "Oresme"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-e312-structural",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 447,
+      "endLine": 502
+    },
+    "type": "insight",
+    "title": "Valid Inputs and Structural Bounds",
+    "content": "Sanity-checking lemmas that the problem is non-vacuous and well-posed:\n\n- **valid_inputs_exist:** for any K there really is a multiset of positive integers with reciprocal sum > K — namely {1, ..., n} for n large, combining harmonic_unbounded with canonical_reciprocalSum.\n- **reciprocalSum_le_of_ge:** if every element is ≥ m > 0, the total sum is ≤ n/m — an upper bound complementing the lower bounds.\n- **trivial_subset_exists:** the empty set always satisfies sum ≤ 1, underscoring that the *hard* direction is approaching 1 from below, not staying under it.\n- **exponentialPrecision_subset_nonempty / polynomialPrecision_subset_sum_pos:** when the gap is nontrivial (e.g. c ≤ K²), the witnessing subset has strictly positive sum, so it is genuinely nonempty.",
+    "mathContext": "These establish the existential preconditions: the hypothesis $\\mathrm{reciprocalSum} > K$ is satisfiable for all $K$, and the precision windows $(1-\\varepsilon, 1]$ produce nonempty subsets whenever $\\varepsilon < 1$. Without these the conjecture could be vacuously true.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Non-vacuity",
+      "Well-posedness",
+      "Existence of witnesses",
+      "Upper bounds"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e312-greedy",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 511,
+      "endLine": 572
+    },
+    "type": "concept",
+    "title": "Greedy: Maximal Feasible Subsets",
+    "content": "The constructive core of the file's contribution toward the polynomial bound. A subset is **feasible** (isFeasible) if its reciprocal sum is ≤ 1, and **maximal feasible** if adding any further element would exceed 1.\n\n- **maximal_feasible_exists:** such a subset always exists — take a feasible subset of *maximum cardinality* (finitely many subsets, so a maximum exists). Adding any j ∉ S must break feasibility, or S wasn't maximum.\n- **maximalFeasible_gap_bound:** for maximal feasible S and any j ∉ S, sum(S) > 1 - 1/a(j). This is the crucial gap estimate, and it follows immediately from the insert lemma sum(S ∪ {j}) = sum(S) + 1/a(j) > 1.\n- **subset_near_one:** if all elements are ≥ m and the total exceeds 1, there is a subset with sum in (1 - 1/m, 1]. So a larger minimum element m yields a tighter approximation to 1.\n\nThis is precisely the greedy mechanism behind the Erdős-Graham bound: control the gap by controlling the smallest reciprocal you might add.",
+    "mathContext": "Greedy/maximality argument: among all $S$ with $\\sum_{i\\in S} 1/a(i) \\le 1$, pick one of maximal cardinality. Maximality forces $\\sum_{i\\in S} 1/a(i) > 1 - 1/a(j)$ for every excluded $j$, since otherwise $S \\cup \\{j\\}$ would be a larger feasible set. The gap to 1 is thus bounded by the largest admissible reciprocal $1/m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Greedy algorithm",
+      "Maximal element",
+      "Finset.exists_max_image",
+      "Gap bound"
+    ],
+    "prerequisites": [
+      "Finite combinatorics"
+    ]
   },
   {
     "id": "ann-e312-summary",
     "proofId": "erdos-312",
     "range": {
-      "startLine": 124,
-      "endLine": 137
+      "startLine": 576,
+      "endLine": 587
     },
     "type": "concept",
     "title": "Summary: Known Polynomial Bound",
-    "content": "**erdos_312_status:** A summary theorem packaging the known result — the polynomial bound exists. The proof is `exact erdos_graham_polynomial`, directly referencing the axiom.\n\n**What's known:** c/K² precision (Erdős-Graham).\n**What's conjectured:** exp(-cK) precision (OPEN).\n**What we proved:** The conjecture implies the known result (conjecture_implies_known).\n\nThe formalization cleanly separates the open conjecture from the established theorem, making the state of knowledge explicit.",
+    "content": "**erdos_312_status:** A summary theorem packaging the known result — the polynomial bound exists. The proof is `exact erdos_graham_polynomial`, directly referencing the axiom.\n\n**What's known:** c/K² precision (Erdős-Graham).\n**What's conjectured:** exp(-cK) precision (OPEN).\n**What we proved:** The conjecture implies the known result (conjecture_implies_known), the exponential bound is asymptotically stronger (exponential_stronger_than_polynomial), and a constructive sieve-and-greedy route toward c/K² precision (Part VIII).\n\nThe formalization cleanly separates the open conjecture from the established theorem, making the state of knowledge explicit.",
     "mathContext": "Summary theorems serve as entry points for understanding the formalization. The erdos_312_status theorem is the single statement that captures what has been established about this problem.",
     "significance": "key",
     "relatedConcepts": [
@@ -151,5 +279,27 @@
       "Open vs proved"
     ],
     "prerequisites": []
+  },
+  {
+    "id": "ann-e312-sieve",
+    "proofId": "erdos-312",
+    "range": {
+      "startLine": 599,
+      "endLine": 716
+    },
+    "type": "concept",
+    "title": "Sieve-and-Greedy Infrastructure",
+    "content": "The toolkit assembling the greedy gap bound into the strategy behind erdos_graham_polynomial. The idea: restrict attention to 'large' elements (those ≥ a threshold m), where each reciprocal is small, so the greedy gap 1/m is controllably tiny.\n\n- **largeElements n a m:** the sieve {i : a(i) ≥ m}, with monotonicity (largeElements_anti) and the split reciprocalSum = largeSum + smallSum (reciprocalSum_split).\n- **restricted_maximal_feasible_exists / restricted_gap_bound:** the Part VII greedy argument generalized to run *inside* an arbitrary index region T.\n- **restricted_subset_near_one:** within T, if elements are ≥ m and the restricted sum exceeds 1, there's a subset with sum in (1 - 1/m, 1].\n- **sieve_and_greedy:** the capstone — apply the restricted greedy to T = largeElements n a m. If the large-element reciprocal sum exceeds 1, we obtain a subset with sum in (1 - 1/m, 1].\n\nChoosing m strategically (balancing 'gap 1/m small' against 'sieved sum still > 1') is exactly the move that yields c/K² precision in the full Erdős-Graham proof.",
+    "mathContext": "Sieve step: discard small elements so the residual reciprocals are all $\\le 1/m$; greedy step: maximal feasible subset of the sieve has gap $< 1/m$. The Erdős-Graham optimization picks $m \\approx K$ so that the sieved mass still exceeds 1 while the gap $1/m \\approx 1/K$ tightens — iterating this scheme is what produces the $c/K^2$ bound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sieve method",
+      "Greedy algorithm",
+      "Finset.filter",
+      "Erdős-Graham strategy"
+    ],
+    "prerequisites": [
+      "Finite combinatorics"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-312` (Subset Sums of Unit Fractions). The annotations had drifted out of alignment after the Lean file grew to 718 lines, and the bottom ~80% of the file (Parts IV.b–VIII) had no annotation coverage.

## Changes

- **Realigned all 8 existing annotations.** Their line ranges no longer matched their content — e.g. "The Main Conjecture (OPEN)" pointed at `subsetReciprocalSum_nonneg` (lines 51–61). Each is now anchored to the construct it describes.
- **Fixed a factual error.** The "Comparing Bounds" annotation called `exponential_stronger_than_polynomial` an *axiom*; it is actually a **proved theorem** (built on `Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero`).
- **Added 7 annotations** covering previously uncovered code (lines 46–716): subset-sum algebra, exponential/polynomial gap analysis, the Taylor sandwich `cK/(1+cK) ≤ 1−exp(−cK) ≤ cK`, valid-inputs/structural bounds, the greedy maximal-feasible-subset gap bound, and the sieve-and-greedy infrastructure toward the Erdős–Graham `c/K²` bound.

Coverage now spans the full file (previously capped at line 137). All 15 annotations pass `resolver.ts validate`.

## Verification

- `resolver.ts validate` → 15 valid, 0 misaligned
- `pnpm build` → success
- meta.json axiom integrity accurate: 1 axiom, `axiomCount: 1`, `axiomatized`, 0 sorries — no changes needed.