### PR TITLE
Enrich Erdős #643 (Crossed Pairs): realign stale annotations & sections

### DIFF
--- a/src/data/proofs/erdos-643/annotations.json
+++ b/src/data/proofs/erdos-643/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-e643-header",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 1,
-      "endLine": 18
+      "startLine": 72,
+      "endLine": 89
     },
     "type": "concept",
     "title": "Problem Overview",
@@ -22,8 +22,8 @@
     "id": "ann-e643-hypergraph",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 33,
-      "endLine": 41
+      "startLine": 312,
+      "endLine": 320
     },
     "type": "definition",
     "title": "Hypergraph Definitions",
@@ -41,12 +41,12 @@
     "id": "ann-e643-crossed",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 54,
-      "endLine": 63
+      "startLine": 333,
+      "endLine": 342
     },
     "type": "definition",
     "title": "Crossed Pair Configuration",
-    "content": "**IsCrossedPair A B C D** holds when:\n1. A ∪ B = C ∪ D (same union)\n2. A ∩ B = ∅ (first pair disjoint)\n3. C ∩ D = ∅ (second pair disjoint)\n4. {A,B} ≠ {C,D} (different pairing)\n\nThis is the forbidden configuration we're trying to force.",
+    "content": "**IsCrossedPair A B C D** holds when:\n1. A ∪ B = C ∪ D (same union)\n2. A ∩ B = ∅ (first pair disjoint)\n3. C ∩ D = ∅ (second pair disjoint)\n4. {A,B} ≠ {C,D} (different pairing)\n\nThis is the forbidden configuration we're trying to force. **HasCrossedPair H** asserts that some four edges of H realize this configuration.",
     "mathContext": "Four edges partition the same 2t-element set in two different ways.",
     "significance": "key",
     "relatedConcepts": [
@@ -60,12 +60,12 @@
     "id": "ann-e643-extremal",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 78,
-      "endLine": 84
+      "startLine": 357,
+      "endLine": 370
     },
     "type": "definition",
     "title": "The Extremal Function",
-    "content": "**f(n,t)** is defined as the minimum m such that any t-uniform hypergraph on n vertices with at least m edges must contain a crossed pair.\n\nWe use Nat.find to select the least such m, with existence proven by noting that the total number of t-subsets is finite.",
+    "content": "**f(n,t)** is defined as the minimum m such that any t-uniform hypergraph on n vertices with at least m edges must contain a crossed pair.\n\nWe use Nat.find to select the least such m; existence of the witness is proved here by bounding edgeCount by the total number of t-subsets, C(n,t).",
     "mathContext": "f(n,t) = min{m : ∀H t-uniform on n vertices, |H| ≥ m → HasCrossedPair H}",
     "significance": "key",
     "relatedConcepts": [
@@ -79,12 +79,12 @@
     "id": "ann-e643-graph-case",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 94,
-      "endLine": 109
+      "startLine": 409,
+      "endLine": 485
     },
     "type": "concept",
-    "title": "Case t = 2: Connection to C4",
-    "content": "**For graphs (t=2)**, a crossed pair is essentially a 4-cycle!\n\nThe four 2-element edges form an alternating path v1-v2-v3-v4-v1.\n\nThe **Kovari-Sos-Turan theorem** gives f(n,2) = O(n^{3/2}), connecting this to classical extremal graph theory.",
+    "title": "Case t = 2: Connection to C₄",
+    "content": "**For graphs (t=2)**, a crossed pair is essentially a 4-cycle C₄: the four 2-element edges are two distinct perfect matchings of the same 4-vertex set, which together trace a 4-cycle.\n\nThe live development here establishes the **Kővári–Sós–Turán** regime: `common_neighbors_le_one` shows a crossed-pair-free graph has at most one common neighbor per vertex pair, and `f_two_upper_bound` derives f(n,2) = O(n^{3/2}).",
     "mathContext": "C4-free graphs have at most (1/2 + o(1))n^{3/2} edges.",
     "significance": "key",
     "relatedConcepts": [
@@ -98,12 +98,12 @@
     "id": "ann-e643-pikhurko",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 117,
-      "endLine": 124
+      "startLine": 822,
+      "endLine": 824
     },
     "type": "concept",
-    "title": "Pikhurko-Verstrate Bound",
-    "content": "**Pikhurko-Verstrate (2009)** proved that for 3-uniform hypergraphs:\n\nf(n,3) <= (13/9)*C(n,2)\n\nThis is the best known upper bound for the 3-uniform case and represents significant progress toward the conjecture.",
+    "title": "Pikhurko-Verstraëte Bound",
+    "content": "**Pikhurko-Verstraëte (2009)** proved that for 3-uniform hypergraphs:\n\nf(n,3) ≤ (13/9)·C(n,2)\n\nThis is the best known upper bound for the 3-uniform case and represents significant progress toward the conjecture. It is recorded here as an `axiom` (an external result, not re-proved in Lean).",
     "mathContext": "f(n,3) <= (13/9)*(n choose 2) for all n >= 3",
     "significance": "key",
     "relatedConcepts": [
@@ -117,13 +117,13 @@
     "id": "ann-e643-bounds",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 132,
-      "endLine": 139
+      "startLine": 1268,
+      "endLine": 1278
     },
     "type": "concept",
     "title": "General Bounds",
-    "content": "**Lower bound**: f(n,t) >= C(n-1,t-1) + floor((n-1)/t)\n\nThis comes from sunflower constructions.\n\n**Upper bound**: f(n,t) < (7/2)*C(n,t-1)\n\nThe gap between these bounds is what the conjecture aims to close.",
-    "mathContext": "C(n-1,t-1) <= f(n,t) < (7/2)*C(n,t-1)",
+    "content": "**Lower bound**: f(n,t) ≥ C(n-1,t-1) + ⌊(n-1)/t⌋ (`f_lower_bound`, stated with a `sorry`; it follows from the star + matching construction).\n\n**Upper bound**: f(n,t) < (7/2)·C(n,t-1) (`f_upper_bound`, recorded as an `axiom`).\n\nThe gap between these bounds is what the conjecture aims to close.",
+    "mathContext": "C(n-1,t-1) + ⌊(n-1)/t⌋ ≤ f(n,t) < (7/2)*C(n,t-1)",
     "significance": "supporting",
     "relatedConcepts": [
       "lower-bound",
@@ -136,13 +136,13 @@
     "id": "ann-e643-conjecture",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 147,
-      "endLine": 156
+      "startLine": 1286,
+      "endLine": 1295
     },
     "type": "definition",
     "title": "The Main Conjecture",
-    "content": "**Erdos Problem #643** (OPEN): For t >= 3,\n\nlim_{n->inf} f(n,t) / C(n,t-1) = 1\n\nEquivalently, f(n,t) = (1 + o(1))*C(n,t-1).\n\nThis would show sunflower constructions are asymptotically optimal.",
-    "mathContext": "Erdos643Conjecture := forall t>=3, Tendsto (fun n => f(n,t)/C(n,t-1)) atTop (nhds 1)",
+    "content": "**Erdős Problem #643** (OPEN): For t ≥ 3,\n\nlim_{n→∞} f(n,t) / C(n,t-1) = 1\n\nEquivalently, f(n,t) = (1 + o(1))·C(n,t-1).\n\nThis would show sunflower constructions are asymptotically optimal. The Lean predicate `Erdos643Conjecture` phrases this with `Filter.Tendsto ... (nhds 1)`.",
+    "mathContext": "Erdos643Conjecture := ∀ t ≥ 3, Tendsto (fun n => f(n,t)/C(n,t-1)) atTop (nhds 1)",
     "significance": "key",
     "relatedConcepts": [
       "asymptotic",
@@ -155,13 +155,13 @@
     "id": "ann-e643-sunflower",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 165,
-      "endLine": 169
+      "startLine": 1304,
+      "endLine": 1308
     },
     "type": "definition",
     "title": "Sunflower Construction",
     "content": "**SunflowerHypergraph** is the key construction for lower bounds.\n\nAll edges share a common (t-1)-element **core**.\nEach edge adds one unique element from the **petals** set.\n\nThis gives approximately C(n-1,t-1) edges with no crossed pairs.",
-    "mathContext": "Edges have form core U {p} for p in petals, where |core| = t-1.",
+    "mathContext": "Edges have form core ∪ {p} for p in petals, where |core| = t-1.",
     "significance": "key",
     "relatedConcepts": [
       "sunflower",
@@ -174,13 +174,13 @@
     "id": "ann-e643-sunflower-proof",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 171,
-      "endLine": 181
+      "startLine": 1310,
+      "endLine": 1326
     },
     "type": "concept",
     "title": "Sunflowers Have No Crossed Pairs",
-    "content": "**Key Insight**: A sunflower cannot contain crossed pairs!\n\n**Proof sketch**: Any two edges in a sunflower intersect in the core. For a crossed pair, we need A cap B = empty. But since t >= 2, the core has size >= 1, so any two edges share at least one vertex.\n\nThis contradiction shows sunflowers are crossed-pair-free.",
-    "mathContext": "forall A,B in Sunflower: A cap B contains core != empty",
+    "content": "**Key Insight**: A sunflower cannot contain crossed pairs!\n\n**Proof sketch**: Any two edges in a sunflower intersect in the core. For a crossed pair, we need A ∩ B = ∅. But since t ≥ 2, the core has size ≥ 1, so any two edges share at least one vertex.\n\nThis contradiction shows sunflowers are crossed-pair-free (`sunflower_no_crossed_pair`, fully proved).",
+    "mathContext": "∀ A,B ∈ Sunflower: A ∩ B ⊇ core ≠ ∅",
     "significance": "key",
     "relatedConcepts": [
       "contradiction",
@@ -193,18 +193,18 @@
     "id": "ann-e643-small",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 189,
-      "endLine": 195
+      "startLine": 1247,
+      "endLine": 1259
     },
     "type": "concept",
-    "title": "Small Cases",
-    "content": "**f(4,2) = 3**: With 4 vertices and 3 edges, we can avoid a 4-cycle. With 4 edges (K4), we must have one.\n\n**f(5,2) = 5**: Related to the Petersen graph, a famous 3-regular graph avoiding 4-cycles.",
-    "mathContext": "Exact values known for small parameters.",
+    "title": "Concrete Lower Bound (t = 3) and Small Cases",
+    "content": "**`f_three_lower_bound`** is the file's strongest fully-proved value-style result: f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋, obtained from the `LowerBoundGraph` (a star through vertex 0 together with a disjoint matching).\n\n**Small cases caveat**: the naive guesses f(4,2)=3 and f(5,2)=5 are *false* — Aristotle negated those statements, and the lower bound already forces f(4,2) ≥ 4 (the true value is 5, since the largest C₄-free graph on 4 vertices has 4 edges). The corresponding `f_four_two`/`f_five_two` blocks survive only as commented-out negations.",
+    "mathContext": "f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋;  f(4,2) = 5",
     "significance": "supporting",
     "relatedConcepts": [
-      "small-cases",
-      "petersen",
-      "exact"
+      "lower-bound",
+      "star-matching-construction",
+      "small-cases"
     ],
     "prerequisites": []
   },
@@ -212,12 +212,12 @@
     "id": "ann-e643-erdosrado",
     "proofId": "erdos-643",
     "range": {
-      "startLine": 219,
-      "endLine": 226
+      "startLine": 1384,
+      "endLine": 1391
     },
     "type": "concept",
-    "title": "Erdos-Rado Sunflower Lemma",
-    "content": "**The Sunflower Lemma** (Erdos-Rado 1960): Any sufficiently large k-uniform family contains a sunflower with r petals.\n\nSpecifically: there exists F(k) such that any k-uniform family with > F(k) * (r-1)^k members contains an r-sunflower.\n\nThis structural result constrains what large hypergraphs can look like.",
+    "title": "Erdős-Rado Sunflower Lemma",
+    "content": "**The Sunflower Lemma** (Erdős-Rado 1960): Any sufficiently large k-uniform family contains a sunflower with r petals.\n\nSpecifically: there exists F(k) such that any k-uniform family with > F(k)·(r-1)^k members contains an r-sunflower.\n\nThis structural result constrains what large hypergraphs can look like. It is recorded here as an `axiom`.",
     "mathContext": "Large uniform families must contain sunflowers - a foundational result.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -75,53 +75,102 @@
   },
   "sections": [
     {
+      "id": "problem-statement",
+      "title": "Problem Statement & Provenance",
+      "startLine": 1,
+      "endLine": 89,
+      "summary": "Aristotle provenance header and the Erdős #643 problem statement with known bounds"
+    },
+    {
+      "id": "tactic-prelude",
+      "title": "Harmonic generalize_proofs Prelude",
+      "startLine": 91,
+      "endLine": 298,
+      "summary": "Injected Mathlib import and Harmonic's modified generalize_proofs tactic (build infrastructure, not part of the mathematics)"
+    },
+    {
       "id": "hypergraphs",
       "title": "Hypergraph Definitions",
-      "startLine": 27,
-      "endLine": 42,
-      "summary": "Basic definitions for t-uniform hypergraphs"
+      "startLine": 300,
+      "endLine": 320,
+      "summary": "Basic definitions for t-uniform hypergraphs (Hypergraph, IsUniform, edgeCount)"
     },
     {
       "id": "crossed-pair",
       "title": "The Crossed Pair Configuration",
-      "startLine": 43,
-      "endLine": 64,
-      "summary": "Definition of crossed pairs and when hypergraphs contain them"
+      "startLine": 322,
+      "endLine": 342,
+      "summary": "Definition of crossed pairs (IsCrossedPair) and when hypergraphs contain them (HasCrossedPair)"
     },
     {
       "id": "extremal-function",
       "title": "The Extremal Function f(n,t)",
-      "startLine": 65,
-      "endLine": 85,
-      "summary": "Definition of f(n,t) as minimum edge count forcing crossed pairs"
+      "startLine": 344,
+      "endLine": 370,
+      "summary": "Definition of f(n,t) via Nat.find as the minimum edge count forcing crossed pairs"
     },
     {
       "id": "graph-case",
       "title": "Case t = 2: Graphs and C₄",
-      "startLine": 86,
-      "endLine": 110,
-      "summary": "Connection to 4-cycles and Kővári–Sós–Turán"
+      "startLine": 372,
+      "endLine": 485,
+      "summary": "Connection to 4-cycles and the Kővári–Sós–Turán bound (common_neighbors_le_one, f_two_upper_bound)"
     },
     {
-      "id": "bounds",
-      "title": "Known Bounds",
-      "startLine": 111,
-      "endLine": 140,
-      "summary": "Pikhurko-Verstraëte and general bounds"
+      "id": "t2-bounds",
+      "title": "t = 2: Θ(n^{3/2}) Bounds",
+      "startLine": 486,
+      "endLine": 811,
+      "summary": "Affine-plane lower-bound construction, f_two_lower_bound, and the matching asymptotic f_two_asymptotic"
+    },
+    {
+      "id": "pikhurko",
+      "title": "t = 3: Pikhurko–Verstraëte Bound",
+      "startLine": 816,
+      "endLine": 824,
+      "summary": "The axiom f(n,3) ≤ (13/9)·C(n,2)"
+    },
+    {
+      "id": "t3-lower",
+      "title": "t = 3 Lower-Bound Construction",
+      "startLine": 825,
+      "endLine": 1259,
+      "summary": "Star ∪ Matching (LowerBoundGraph) construction and f_three_lower_bound: f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋"
+    },
+    {
+      "id": "general-bounds",
+      "title": "General Bounds",
+      "startLine": 1262,
+      "endLine": 1278,
+      "summary": "General lower bound (f_lower_bound, sorry) and upper bound (f_upper_bound, axiom)"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "startLine": 141,
-      "endLine": 157,
-      "summary": "Statement of Erdős's asymptotic conjecture"
+      "startLine": 1280,
+      "endLine": 1295,
+      "summary": "Statement of Erdős's asymptotic conjecture (Erdos643Conjecture)"
     },
     {
       "id": "constructions",
       "title": "Sunflower Constructions",
-      "startLine": 158,
-      "endLine": 1402,
-      "summary": "Sunflower hypergraphs avoiding crossed pairs"
+      "startLine": 1297,
+      "endLine": 1326,
+      "summary": "SunflowerHypergraph and the proof that sunflowers contain no crossed pairs"
+    },
+    {
+      "id": "small-cases",
+      "title": "Small Cases",
+      "startLine": 1328,
+      "endLine": 1370,
+      "summary": "Commented-out negations of the naive guesses f(4,2)=3 and f(5,2)=5, which the lower bound refutes"
+    },
+    {
+      "id": "sunflower-lemma",
+      "title": "Erdős–Rado Sunflower Lemma & Context",
+      "startLine": 1372,
+      "endLine": 1401,
+      "summary": "The Erdős–Rado sunflower lemma (axiom) and historical context connecting to Füredi's hypergraph Turán work"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-643`. The Lean file `Erdos643Problem.lean` grew substantially after an Aristotle pass (a provenance header plus an injected `generalize_proofs` tactic prelude shifted all real content down by ~250 lines). As a result **every** annotation range and **every** `meta.json` section pointed at the wrong lines — the resolver reported 7 annotations as outright misaligned, and the others were false-positives landing on the wrong constructs.

## Changes
- **Realigned all 12 annotations** to their actual constructs. `resolver.ts validate` now reports **12 valid, 0 misaligned** (was 5 valid / 7 misaligned, with several "valid" ones anchored to the wrong code).
- **Rebuilt the `sections` array**: 7 stale sections (using pre-growth line numbers, with a `158–1402` catch-all that faked full coverage) → 14 accurate sections spanning the whole file, including the tactic prelude and the commented-out Aristotle negation blocks.
- **Fixed a mathematical inaccuracy**: the "Small Cases" annotation asserted `f(4,2)=3` and `f(5,2)=5`. These are **false** — Aristotle negated both statements, and the file's own `f_lower_bound` already forces `f(4,2) ≥ 4` (true value is 5; the largest C₄-free graph on 4 vertices has 4 edges). Re-anchored that annotation to the live `f_three_lower_bound` theorem and corrected the content.
- Clarified throughout which results are `axiom`s (Pikhurko–Verstraëte, `f_upper_bound`, Erdős–Rado sunflower lemma) vs fully proved vs `sorry`'d.

## Integrity
`status: axiomatized`, `badge: axiom`, `axiomCount: 3`, `sorries: 1` all verified against the source (3 axioms at lines 823/1277/1385, 1 sorry at line 1271). No change needed.

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → 12 valid / 0 misaligned
- `pnpm build` → green
- Cross-reference targets (erdos-1022/1023/1025) confirmed to exist.