### PR TITLE
Enrich Legendre Relation (amgm-oq-04-oq-02): realign + cover §8–§17 (8→18)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/annotations.json
@@ -4,12 +4,12 @@
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 56
+      "endLine": 70
     },
     "type": "concept",
     "title": "Module Preamble: Goals, Plan, and Status Checklist",
-    "content": "The module docstring establishes the seven-step formalization plan: (1) reuse `AmgmInequalityOQ04OQ01.ellipticK` (already a rigorous Mathlib intervalIntegral), (2) define `ellipticE` analogously, (3) define the complementary modulus `complModulus k = √(1-k²)`, (4) define `ellipticK'`, `ellipticE'` at the complementary modulus, (5) prove basic properties (E(0) = π/2, positivity, integrability), (6) **axiomatize** the general Legendre relation (as a deep classical analytic identity whose proof requires differentiation under the integral sign), and (7) **derive** the symmetric special case at k = 1/√2 as a theorem. The status checklist (lines 36-48) tracks which steps are proved vs axiomatized — 1 axiom and 0 sorries. The preamble explicitly states that this file unblocks an axiom elimination in `AmgmInequalityOQ04OQ05` (Brent-Salamin), where the symmetric Legendre relation is currently itself an axiom.",
-    "mathContext": "Legendre's relation (NIST DLMF §19.7.1, Whittaker–Watson 1927 §22.41): for $0 < k < 1$, $$E(k) K(k') + E(k') K(k) - K(k) K(k') = \\pi/2$$ where $k' = \\sqrt{1-k^2}$ is the complementary modulus. The relation is a classical Wronskian identity arising from the Legendre ODE for $K$. Pinning down the constant $\\pi/2$ at any boundary value (e.g. $k = 1/\\sqrt{2}$ where the relation becomes $2KE - K^2 = \\pi/2$, or the limit $k \\to 0^+$ via $K \\to \\pi/2$, $E \\to \\pi/2$, etc.) gives the closed form.",
+    "content": "The module docstring establishes the formalization plan: (1) reuse `AmgmInequalityOQ04OQ01.ellipticK` (already a rigorous Mathlib intervalIntegral), (2) define `ellipticE` analogously, (3) define the complementary modulus `complModulus k = √(1-k²)`, (4) define `ellipticK'`, `ellipticE'` at the complementary modulus, (5) prove basic properties (E(0) = π/2, positivity, integrability), (6) **axiomatize** the general Legendre relation (a deep classical analytic identity whose proof requires differentiation under the integral sign), and (7) **derive** the symmetric special case at k = 1/√2 as a theorem. Beyond the original plan, the file now also builds (§8-§17) the differentiation-under-the-integral machinery itself: it proves both Wronskian-derivative ingredients dE/dk = (E−K)/k and dK/dk = (E−(1−k²)K)/(k(1−k²)). The status remains 1 axiom (the general Legendre relation) and 0 sorries. This file unblocks an axiom elimination in `AmgmInequalityOQ04OQ05` (Brent-Salamin), where the symmetric Legendre relation is currently itself an axiom.",
+    "mathContext": "Legendre's relation (NIST DLMF §19.7.1, Whittaker–Watson 1927 §22.41): for $0 < k < 1$, $$E(k) K(k') + E(k') K(k) - K(k) K(k') = \\pi/2$$ where $k' = \\sqrt{1-k^2}$ is the complementary modulus. The relation is a classical Wronskian identity arising from the Legendre ODE for $K$. Pinning down the constant $\\pi/2$ at any boundary value (e.g. $k = 1/\\sqrt{2}$ where the relation becomes $2KE - K^2 = \\pi/2$, or the limit $k \\to 0^+$) gives the closed form.",
     "significance": "supporting",
     "relatedConcepts": [
       "complete elliptic integrals K(k) and E(k)",
@@ -27,13 +27,13 @@
     "id": "ann-ellipticE-def",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 62,
-      "endLine": 76
+      "startLine": 75,
+      "endLine": 84
     },
     "type": "definition",
     "title": "ellipticIntegrandE and ellipticE: Mathlib intervalIntegral Definition",
-    "content": "Two `noncomputable def`s: (1) `ellipticIntegrandE k θ := Real.sqrt (1 - k^2 * Real.sin θ ^ 2)` — the integrand $\\sqrt{1 - k^2 \\sin^2 \\theta}$ defined for all real $k, \\theta$ via `Real.sqrt`'s convention; (2) `ellipticE k := ∫ θ in 0..π/2, ellipticIntegrandE k θ` — the complete elliptic integral of the second kind, computed as a Mathlib `intervalIntegral`. **Why `noncomputable`?** Because `Real.sqrt` and `MeasureTheory.integral` are noncomputable (they rely on classical choice). **Why use `Real.sqrt` instead of conditional definition?** Because `Real.sqrt`'s convention `sqrt x = 0` for `x < 0` makes the integrand definable on all of ℝ × ℝ without case-splitting; for $|k| \\leq 1$ the sub-zero branch never triggers since $1 - k^2 \\sin^2 \\theta \\geq 1 - k^2 \\geq 0$.",
-    "mathContext": "$E(k) = \\int_0^{\\pi/2} \\sqrt{1 - k^2 \\sin^2 \\theta} \\, d\\theta$ is the standard NIST DLMF §19.2.8 definition. Unlike $K(k)$ where the integrand $1/\\sqrt{1 - k^2 \\sin^2 \\theta}$ blows up at $\\theta = \\pi/2$ when $|k| = 1$, $E(k)$'s integrand is bounded and continuous on $\\mathbb{R} \\times \\mathbb{R}$ for $|k| \\leq 1$. This makes the Mathlib formalization simpler: integrability holds without any modulus restriction.",
+    "content": "Two `noncomputable def`s: (1) `ellipticIntegrandE k θ := Real.sqrt (1 - k^2 * Real.sin θ ^ 2)` — the integrand $\\sqrt{1 - k^2 \\sin^2 \\theta}$ defined for all real $k, \\theta$ via `Real.sqrt`'s convention; (2) `ellipticE k := ∫ θ in 0..π/2, ellipticIntegrandE k θ` — the complete elliptic integral of the second kind, computed as a Mathlib `intervalIntegral`. **Why `noncomputable`?** Because `Real.sqrt` and `MeasureTheory.integral` rely on classical choice. **Why `Real.sqrt` rather than a conditional definition?** Its convention `sqrt x = 0` for `x < 0` makes the integrand definable on all of ℝ × ℝ without case-splitting; for $|k| \\leq 1$ the sub-zero branch never triggers since $1 - k^2 \\sin^2 \\theta \\geq 1 - k^2 \\geq 0$.",
+    "mathContext": "$E(k) = \\int_0^{\\pi/2} \\sqrt{1 - k^2 \\sin^2 \\theta} \\, d\\theta$ is the standard NIST DLMF §19.2.8 definition. Unlike $K(k)$ where the integrand $1/\\sqrt{1 - k^2 \\sin^2 \\theta}$ blows up at $\\theta = \\pi/2$ when $|k| = 1$, $E(k)$'s integrand is bounded and continuous on $\\mathbb{R} \\times \\mathbb{R}$ for $|k| \\leq 1$, so integrability holds without any modulus restriction.",
     "significance": "critical",
     "relatedConcepts": [
       "complete elliptic integral of the second kind E(k)",
@@ -51,13 +51,13 @@
     "id": "ann-integrand-properties",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 78,
-      "endLine": 117
+      "startLine": 90,
+      "endLine": 126
     },
     "type": "technique",
     "title": "Integrand Properties: Continuity, Integrability, and the √(1-k²) Lower Bound",
-    "content": "Six lemmas establishing the basic analytic properties of `ellipticIntegrandE`. The most important is `integrandE_lower_bound`: for $k^2 < 1$ and any $\\theta$, $\\sqrt{1-k^2} \\leq \\sqrt{1 - k^2 \\sin^2 \\theta}$. **Proof technique**: apply `Real.sqrt_le_sqrt` to the underlying inequality $1 - k^2 \\leq 1 - k^2 \\sin^2 \\theta$, which reduces to $k^2 \\sin^2 \\theta \\leq k^2$ via `Real.sin_sq_le_one`. Combined with `intervalIntegral.integral_mono_on` against the constant function `√(1-k²)`, this gives the positivity bound `√(1-k²) · (π/2) ≤ E(k)`. **Continuity** is a direct composition: `Real.continuous_sqrt.comp ((continuous_const.sub (continuous_const.mul (continuous_sin.pow 2))))` — sqrt of (constant - constant·sin²) is continuous. **Integrability** then follows from `Continuous.intervalIntegrable`.",
-    "mathContext": "The lower bound $\\sqrt{1-k^2}$ is sharp (achieved at $\\theta = \\pi/2$) and is the key fact behind the integral lower bound. For the integral $\\int_0^{\\pi/2} \\sqrt{1 - k^2 \\sin^2\\theta} \\, d\\theta \\geq \\int_0^{\\pi/2} \\sqrt{1 - k^2} \\, d\\theta = \\sqrt{1-k^2} \\cdot \\frac{\\pi}{2}$, which is positive iff $k^2 < 1$. **Why this matters**: it gives a *constructive* positivity bound $E(k) > 0$, not just an existence claim. Future sessions can sharpen this — the actual value $E(0) = \\pi/2$ at $k=0$ versus the lower bound $1 \\cdot \\pi/2 = \\pi/2$ matches; for $k = 1/\\sqrt{2}$ the lower bound gives $E(1/\\sqrt{2}) \\geq \\sqrt{1/2} \\cdot \\pi/2 \\approx 1.111$, while the actual value is $\\approx 1.351$.",
+    "content": "Six lemmas establishing the basic analytic properties of `ellipticIntegrandE`. The most important is `integrandE_lower_bound`: for $k^2 < 1$ and any $\\theta$, $\\sqrt{1-k^2} \\leq \\sqrt{1 - k^2 \\sin^2 \\theta}$. **Proof technique**: apply `Real.sqrt_le_sqrt` to $1 - k^2 \\leq 1 - k^2 \\sin^2 \\theta$, which reduces to $k^2 \\sin^2 \\theta \\leq k^2$ via `Real.sin_sq_le_one`. Combined with `intervalIntegral.integral_mono_on` against the constant `√(1-k²)`, this gives `√(1-k²) · (π/2) ≤ E(k)`. **Continuity** is the composition `Real.continuous_sqrt.comp (continuous_const.sub (continuous_const.mul (continuous_sin.pow 2)))`; **integrability** then follows from `Continuous.intervalIntegrable`.",
+    "mathContext": "The lower bound $\\sqrt{1-k^2}$ is sharp (achieved at $\\theta = \\pi/2$). For the integral $\\int_0^{\\pi/2} \\sqrt{1 - k^2 \\sin^2\\theta} \\, d\\theta \\geq \\sqrt{1-k^2} \\cdot \\frac{\\pi}{2}$, which is positive iff $k^2 < 1$ — a *constructive* positivity bound for $E(k)$. At $k = 1/\\sqrt{2}$ the lower bound gives $E \\geq \\sqrt{1/2}\\cdot\\pi/2 \\approx 1.111$ versus the true value $\\approx 1.351$.",
     "significance": "supporting",
     "relatedConcepts": [
       "interval integral monotonicity",
@@ -74,13 +74,13 @@
     "id": "ann-key-values",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 119,
-      "endLine": 153
+      "startLine": 132,
+      "endLine": 192
     },
     "type": "theorem",
-    "title": "ellipticE_zero (E(0) = π/2) and ellipticE_pos (E(k) > 0 for |k| < 1)",
-    "content": "Two key theorems. **`ellipticE_zero`**: at $k = 0$ the integrand collapses to $\\sqrt{1} = 1$, so $E(0) = \\int_0^{\\pi/2} 1 \\, d\\theta = \\pi/2$. The Lean proof is three lines: unfold `ellipticE`; `simp_rw integrandE_zero_eq_one`; close with `intervalIntegral.integral_const, smul_eq_mul, mul_one, sub_zero`. **`ellipticE_pos`**: for $k^2 < 1$, $E(k) > 0$. The proof chains `intervalIntegral.integral_mono_on` (to bound $E(k)$ below by $\\sqrt{1-k^2} \\cdot (\\pi/2 - 0)$) with `mul_pos` (since both $\\sqrt{1-k^2} > 0$ and $\\pi/2 > 0$). The cumulative `simpa` invocation with `[ellipticE, intervalIntegral.integral_const, smul_eq_mul, sub_zero]` reduces the bound's LHS to the desired form.",
-    "mathContext": "At $k = 0$: the integrand is identically 1, giving $E(0) = \\pi/2$. This matches the value $K(0) = \\pi/2$ (proved in OQ04OQ01.ellipticK_zero), reflecting the fact that $E$ and $K$ agree at the degenerate point $k = 0$ (the integrals collapse to the same constant). For $k^2 < 1$: $E(k) \\geq \\sqrt{1-k^2} \\cdot \\frac{\\pi}{2} > 0$. The bound $\\sqrt{1-k^2} \\cdot \\frac{\\pi}{2}$ is the *minimum* value of $E$ on $|k| < 1$ achieved as $|k| \\to 1$ where it tends to 0 — but $E(1) = 1$ actually (the integrand at $k = 1$ is $|\\cos\\theta|$ on $[0, \\pi/2]$ which integrates to 1).",
+    "title": "Key Values of E: E(0)=π/2, E(k)>0, and E(1)=1",
+    "content": "Three theorems pinning the elliptic integral E at boundary moduli. **`ellipticE_zero`**: at $k = 0$ the integrand collapses to $\\sqrt{1} = 1$, so $E(0) = \\int_0^{\\pi/2} 1 \\, d\\theta = \\pi/2$. **`ellipticE_pos`**: for $k^2 < 1$, $E(k) > 0$, proved by chaining `intervalIntegral.integral_mono_on` (bounding $E$ below by $\\sqrt{1-k^2}\\cdot\\pi/2$) with `mul_pos`. **`ellipticE_one`**: at $k = 1$ the integrand becomes $\\sqrt{1-\\sin^2\\theta} = |\\cos\\theta| = \\cos\\theta$ on $[0,\\pi/2]$, whose integral is $1$.",
+    "mathContext": "At $k = 0$: integrand $\\equiv 1$, $E(0) = \\pi/2$, matching $K(0) = \\pi/2$. For $k^2 < 1$: $E(k) \\geq \\sqrt{1-k^2}\\cdot\\frac{\\pi}{2} > 0$. At $k = 1$: $E(1) = \\int_0^{\\pi/2}\\cos\\theta\\,d\\theta = 1$ — the unique modulus where $E$ has an elementary closed form, and the lower endpoint of $E$'s range $[1, \\pi/2]$.",
     "significance": "critical",
     "relatedConcepts": [
       "boundary values of complete elliptic integrals",
@@ -97,36 +97,37 @@
     "id": "ann-complmodulus",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 155,
-      "endLine": 184
+      "startLine": 198,
+      "endLine": 262
     },
     "type": "definition",
     "title": "complModulus: The Complementary Modulus k' = √(1-k²)",
-    "content": "Defines `complModulus k := Real.sqrt (1 - k^2)` plus five basic lemmas: (1) `complModulus_nonneg` (Real.sqrt is nonneg); (2) `complModulus_pos` (positive when $k^2 < 1$); (3) `complModulus_sq` — Pythagorean identity $(k')^2 = 1 - k^2$ for $k^2 \\leq 1$, proved via `Real.mul_self_sqrt`; (4) `complModulus_sq_lt_one` (when $0 < k^2 < 1$ then $(k')^2 < 1$); (5) `complModulus_complModulus` — involutive on $[0, 1]$: $k'' = k$, proved via `Real.sqrt_sq` after simplifying $\\sqrt{1 - (\\sqrt{1-k^2})^2} = \\sqrt{1 - (1-k^2)} = \\sqrt{k^2} = k$.",
-    "mathContext": "The complementary modulus $k' = \\sqrt{1 - k^2}$ is the standard notation in elliptic-integral theory: the pair $(k, k')$ with $k^2 + (k')^2 = 1$ parametrizes the unit circle's first quadrant. The involutive property $k'' = k$ on $[0, 1]$ is what makes the complementary-modulus operation a useful symmetry: e.g. it lets us turn $K(k') + K(k)$ into the symmetric pair $K(k') + K(k'')$ at the symmetric point $k = 1/\\sqrt{2}$ where $k = k'$. The Lean proof of `complModulus_complModulus` uses the chain `Real.mul_self_sqrt` (to flatten the inner square root) then `sub_sub_cancel` then `Real.sqrt_sq` (which requires $0 \\leq k$).",
+    "content": "Defines `complModulus k := Real.sqrt (1 - k^2)` plus its calculus: `complModulus_nonneg`, `complModulus_pos` (for $k^2 < 1$), `complModulus_sq` (Pythagorean identity $(k')^2 = 1 - k^2$ via `Real.mul_self_sqrt`), `complModulus_sq_lt_one`, the involution `complModulus_complModulus` ($k'' = k$ on $[0,1]$ via `Real.sqrt_sq`), and `complModulus_hasDerivAt` — the derivative $\\frac{d}{dk}\\sqrt{1-k^2} = -k/\\sqrt{1-k^2}$, which is the chain-rule input needed later for the K'-side differentiation.",
+    "mathContext": "The complementary modulus $k' = \\sqrt{1 - k^2}$ with $k^2 + (k')^2 = 1$ parametrizes the unit circle's first quadrant. The involution $k'' = k$ makes complementation a symmetry: at $k = 1/\\sqrt{2}$ it has the fixed point $k = k'$. Its derivative $\\frac{dk'}{dk} = -k/k'$ feeds the chain rule when differentiating $K(k') = K'(k)$ in $k$.",
     "significance": "critical",
     "relatedConcepts": [
       "complementary modulus in elliptic integrals",
       "Real.sqrt_sq",
       "Real.mul_self_sqrt",
-      "involutive operations"
+      "HasDerivAt chain rule"
     ],
     "prerequisites": [
       "Real.sqrt",
-      "sub_sub_cancel"
+      "sub_sub_cancel",
+      "Real.hasDerivAt_sqrt"
     ]
   },
   {
     "id": "ann-Kprime-Eprime",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 186,
-      "endLine": 200
+      "startLine": 269,
+      "endLine": 281
     },
     "type": "definition",
     "title": "ellipticK' and ellipticE' at the Complementary Modulus",
-    "content": "Two `noncomputable def`s: `ellipticK' k := ellipticK (complModulus k)` and `ellipticE' k := ellipticE (complModulus k)`. These are the *complementary* elliptic integrals, satisfying $K'(k) = K(k')$ and $E'(k) = E(k')$. Two positivity lemmas: `ellipticK'_pos` and `ellipticE'_pos` for $0 < k^2 < 1$ (which guarantees the complementary modulus also satisfies $0 < (k')^2 < 1$). The proofs delegate to `AmgmInequalityOQ04OQ01.ellipticK_pos` and `ellipticE_pos` respectively, with the hypothesis `complModulus_sq_lt_one`.",
-    "mathContext": "**Notation warning**: $K'$ is overloaded in elliptic-function literature. Some authors use $K'(k)$ for the derivative $\\frac{dK}{dk}$, others (and we, following NIST DLMF) use $K'(k) = K(k')$. Lurking in the textbook proofs of Legendre's relation is the *other* $K'$ — the derivative — which appears in the Wronskian. The Lean code's `ellipticK'` is unambiguous: it's `K(complModulus k)`, the value of $K$ at the complementary modulus. The positivity lemmas are workhorse results: any time we need $K'(k) > 0$ for some computation in the Legendre relation, we just invoke `ellipticK'_pos`.",
+    "content": "Two `noncomputable def`s: `ellipticK' k := ellipticK (complModulus k)` and `ellipticE' k := ellipticE (complModulus k)` — the *complementary* elliptic integrals $K'(k) = K(k')$ and $E'(k) = E(k')$. Positivity lemmas `ellipticK'_pos` and `ellipticE'_pos` for $0 < k^2 < 1$ delegate to `ellipticK_pos` / `ellipticE_pos` via `complModulus_sq_lt_one`.",
+    "mathContext": "**Notation warning**: $K'$ is overloaded — some authors mean $\\frac{dK}{dk}$, but here (following NIST DLMF) $K'(k) = K(k')$, the value of $K$ at the complementary modulus. The Lean name `ellipticK'` is unambiguous. The positivity lemmas are workhorses for sign conditions inside the Legendre relation.",
     "significance": "supporting",
     "relatedConcepts": [
       "complementary elliptic integrals",
@@ -143,13 +144,13 @@
     "id": "ann-legendre-axiom",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 202,
-      "endLine": 244
+      "startLine": 305,
+      "endLine": 311
     },
     "type": "axiom",
     "title": "axiom legendre_relation: The General Legendre Identity (Axiomatized)",
-    "content": "**This is the file's only axiom**. States: for all $k$ with $0 < k < 1$, $$\\text{ellipticE}(k) \\cdot \\text{ellipticK}'(k) + \\text{ellipticE}'(k) \\cdot \\text{ellipticK}(k) - \\text{ellipticK}(k) \\cdot \\text{ellipticK}'(k) = \\pi/2.$$ The comment block (lines 204-220) explains the proof strategy: (1) the **Legendre ODE** $k(1-k^2) y'' + (1 - 3k^2) y' - k y = 0$ is satisfied by both $K$ and $K'$; (2) the **Wronskian** of these two solutions, viewed as a function of $k$, is constant up to a known normalizing factor; (3) explicit boundary evaluation pins the constant. **Mathlib status**: all ingredients exist (`MeasureTheory.intervalIntegral.deriv_*` for differentiation under the integral, `Real.deriv_sqrt`, the chain rule), but they are not yet wired up to `ellipticK`. **Future session goal**: replace this axiom with a constructive proof, reducing this file's axiom count to 0.",
-    "mathContext": "The standard textbook proof (Whittaker–Watson 1927 §22.41): Define $f(k) = E K' + E' K - K K'$. Compute $\\frac{df}{dk}$ using the explicit derivatives $\\frac{dK}{dk} = \\frac{E - (k')^2 K}{k (k')^2}$ (derivable from the Legendre ODE) and $\\frac{dE}{dk} = \\frac{E - K}{k}$ (derivable by differentiating under the integral). After substituting and collecting terms, $\\frac{df}{dk} = 0$ identically on $(0, 1)$, so $f$ is constant. The constant is determined by any boundary value: at $k = 1/\\sqrt{2}$ (the lemniscate case), $k' = k$ so $f = 2EK - K^2$; computing this analytically (or via the Brent-Salamin AGM machinery) gives $\\pi/2$. **Honesty assessment**: the axiom encodes a substantial mathematical fact. The Lean proof is reachable but requires ~200-500 lines of Mathlib plumbing — the kind of foundational work this gallery is built to reward.",
+    "content": "**This is the file's only axiom** (axiomCount = 1). States: for $0 < k < 1$, $$E(k)\\,K'(k) + E'(k)\\,K(k) - K(k)\\,K'(k) = \\pi/2.$$ The standard proof differentiates $f(k) = EK' + E'K - KK'$ and shows $f' \\equiv 0$, so $f$ is constant, then pins the constant at a boundary. The two derivative ingredients this requires — $\\frac{dE}{dk} = \\frac{E-K}{k}$ and $\\frac{dK}{dk} = \\frac{E-(1-k^2)K}{k(1-k^2)}$ — are **no longer hypothetical**: they are proved below in §8 (`integral_dIntegrandE_eq`) and §17 (`dK_dk`) respectively. What remains to discharge the axiom is to assemble these into the $f' = 0$ computation and evaluate the constant. Eliminating this axiom would bring the file to 0 assumptions.",
+    "mathContext": "Whittaker–Watson 1927 §22.41: with $\\frac{dK}{dk} = \\frac{E - (k')^2 K}{k (k')^2}$ (from the Legendre ODE) and $\\frac{dE}{dk} = \\frac{E - K}{k}$ (differentiation under the integral), substituting into $\\frac{df}{dk}$ and collecting terms gives $\\frac{df}{dk} = 0$ on $(0,1)$. The constant is fixed at $k = 1/\\sqrt{2}$ (where $f = 2EK - K^2$) or in the limit $k \\to 0^+$, yielding $\\pi/2$. The Lean axiom honestly encodes the as-yet-unassembled Wronskian argument.",
     "significance": "critical",
     "relatedConcepts": [
       "Legendre ODE for K(k)",
@@ -167,13 +168,13 @@
     "id": "ann-symmetric-corollary",
     "proofId": "amgm-inequality-oq-04-oq-02",
     "range": {
-      "startLine": 246,
-      "endLine": 285
+      "startLine": 342,
+      "endLine": 365
     },
     "type": "theorem",
     "title": "complModulus_symmetric and legendre_relation_symmetric: The Lemniscate Case k = 1/√2",
-    "content": "**Two main theorems**, derived from the general axiom. (1) `complModulus_symmetric : complModulus(1/√2) = 1/√2`: at $k = 1/\\sqrt{2}$ the complementary modulus equals the modulus. **Proof**: $\\sqrt{1 - (1/\\sqrt{2})^2} = \\sqrt{1 - 1/2} = \\sqrt{1/2}$. The clean Lean proof uses `Real.sqrt_sq`: rewrite $1 - 1/2 = (1/\\sqrt{2})^2$ (via `one_div_sqrt_two_sq` and `norm_num`), then apply `Real.sqrt_sq` to the resulting $\\sqrt{(1/\\sqrt{2})^2} = 1/\\sqrt{2}$ (with positivity hypothesis). (2) `legendre_relation_symmetric : 2·K(1/√2)·E(1/√2) − K(1/√2)² = π/2`. **Proof**: specialize the general `legendre_relation` axiom at $k = 1/\\sqrt{2}$, then `unfold ellipticK' ellipticE'` and `rw complModulus_symmetric` to collapse $K(k')$ to $K(k)$ and $E(k')$ to $E(k)$. The hypothesis $E·K + E·K - K·K = \\pi/2$ then differs from the goal $2KE - K^2 = \\pi/2$ only by ring-arithmetic; `linear_combination h` closes the gap.",
-    "mathContext": "**The lemniscate condition**: $k = k' = 1/\\sqrt{2}$ satisfies $k^2 + (k')^2 = 1/2 + 1/2 = 1$, the only point in $(0, 1)$ where the modulus equals its complement. At this point, the elliptic integrals $K(k)$, $E(k)$ have closed-form expressions in terms of $\\Gamma(1/4)$ (the lemniscate constant): $K(1/\\sqrt{2}) = \\frac{\\Gamma(1/4)^2}{4\\sqrt{\\pi}}$. **Why this corollary matters**: the form $2KE - K^2 = \\pi/2$ is exactly what `AmgmInequalityOQ04OQ05` (the Brent-Salamin proof) takes as an axiom (its `legendre_relation`). By providing this as a *theorem* derivable from a single more-general axiom, this file lays groundwork for a cleaner dependency chain: future PR can `import AmgmInequalityOQ04OQ02` in OQ04OQ05 and discharge the symmetric-Legendre axiom there.",
+    "content": "**Two theorems**, derived from the general axiom. (1) `complModulus_symmetric : complModulus(1/√2) = 1/√2`: $\\sqrt{1-(1/\\sqrt2)^2} = \\sqrt{1/2} = 1/\\sqrt2$, proved by rewriting $1-1/2 = (1/\\sqrt2)^2$ then `Real.sqrt_sq`. (2) `legendre_relation_symmetric : 2·K(1/√2)·E(1/√2) − K(1/√2)² = π/2`: specialize `legendre_relation` at $k = 1/\\sqrt2$, `unfold ellipticK' ellipticE'`, `rw complModulus_symmetric` to collapse $K(k')\\to K(k)$, $E(k')\\to E(k)$, and close with `linear_combination`. Supporting `sqrt_two`/`one_div_sqrt_two` lemmas (§7) provide the numeric facts.",
+    "mathContext": "The lemniscate condition $k = k' = 1/\\sqrt2$ is the unique point in $(0,1)$ where modulus equals complement. There $K(1/\\sqrt2) = \\frac{\\Gamma(1/4)^2}{4\\sqrt\\pi}$ (lemniscate constant). The symmetric form $2KE - K^2 = \\pi/2$ is exactly the axiom `AmgmInequalityOQ04OQ05` (Brent-Salamin) currently assumes — providing it here as a theorem lays groundwork to discharge that downstream axiom.",
     "significance": "critical",
     "relatedConcepts": [
       "lemniscate constant",
@@ -185,6 +186,236 @@
       "axiom legendre_relation",
       "complModulus",
       "Real.sqrt_sq"
+    ]
+  },
+  {
+    "id": "ann-dE-integral-identity",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 392,
+      "endLine": 511
+    },
+    "type": "theorem",
+    "title": "§8 Differentiating E: ∫ ∂ₖF_E = (E − K)/k",
+    "content": "Builds the first Wronskian-derivative ingredient. `dIntegrandE k θ` is the partial derivative $\\partial_k\\sqrt{1-k^2\\sin^2\\theta} = -k\\sin^2\\theta/\\sqrt{1-k^2\\sin^2\\theta}$, shown continuous and integrable. `integrandE_hasDerivAt_in_k` proves the pointwise derivative, `dIntegrandE_mul_k` an algebraic normalization, and the section's goal `integral_dIntegrandE_eq` evaluates $\\int_0^{\\pi/2}\\partial_k F_E\\,d\\theta = (E-K)/k$ — i.e. $\\frac{dE}{dk} = \\frac{E-K}{k}$. This is exactly the dE/dk formula the Legendre axiom's proof needs.",
+    "mathContext": "$\\frac{\\partial}{\\partial k}\\sqrt{1-k^2\\sin^2\\theta} = \\frac{-k\\sin^2\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}$. Integrating: $\\frac{dE}{dk} = -k\\int_0^{\\pi/2}\\frac{\\sin^2\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}\\,d\\theta = \\frac{E-K}{k}$, using $\\sin^2\\theta = (1-(1-k^2\\sin^2\\theta))/k^2$ to split the integrand into $K$- and $E$-pieces.",
+    "significance": "key",
+    "relatedConcepts": [
+      "differentiation under the integral",
+      "partial derivative of the E-integrand",
+      "dE/dk identity",
+      "intervalIntegral.deriv"
+    ],
+    "prerequisites": [
+      "HasDerivAt",
+      "intervalIntegral.integral_hasDerivAt",
+      "ellipticK definition"
+    ]
+  },
+  {
+    "id": "ann-dE-bound",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 534,
+      "endLine": 603
+    },
+    "type": "concept",
+    "title": "§9 Dominating Bound for ∂ₖF_E",
+    "content": "Supplies the dominated-derivative hypotheses that differentiation under the integral (`intervalIntegral.hasDerivAt_integral_of_dominated...`) requires. `boundDIntegrandE` is an explicit θ-function dominating `|dIntegrandE k θ|` uniformly for k in a neighborhood, with `boundDIntegrandE_continuous`/`_integrable` and `dIntegrandE_abs_le_bound` providing the uniform majorant. Without such a dominating function, swapping $\\frac{d}{dk}$ and $\\int d\\theta$ is not justified.",
+    "mathContext": "To prove $\\frac{d}{dk}\\int F_E\\,d\\theta = \\int \\partial_k F_E\\,d\\theta$ one needs an integrable $g(\\theta)$ with $|\\partial_k F_E(k,\\theta)| \\le g(\\theta)$ for all $k$ near $k_0$ (Leibniz / dominated convergence). `boundDIntegrandE` is that $g$, built to be continuous (hence integrable on $[0,\\pi/2]$) and a valid uniform bound.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dominated convergence",
+      "Leibniz integral rule",
+      "uniform integrable bound"
+    ],
+    "prerequisites": [
+      "intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_lip",
+      "Continuous.intervalIntegrable"
+    ]
+  },
+  {
+    "id": "ann-dK-chain-rule",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 642,
+      "endLine": 734
+    },
+    "type": "concept",
+    "title": "§10 Differentiating K: the Integrand Derivative and Chain Rule",
+    "content": "The K-side analog of §8. `dIntegrandK k θ` is the partial derivative $\\partial_k(1-k^2\\sin^2\\theta)^{-1/2} = k\\sin^2\\theta/(1-k^2\\sin^2\\theta)^{3/2}$, with continuity and integrability lemmas. `integrandK_hasDerivAt_in_k` establishes the pointwise derivative via the chain rule on the reciprocal-square-root. Because the K-integrand is more singular than E's, the K-side requires the additional integration-by-parts machinery of §12-§16 to reach a closed form.",
+    "mathContext": "$\\frac{\\partial}{\\partial k}(1-k^2\\sin^2\\theta)^{-1/2} = \\frac{k\\sin^2\\theta}{(1-k^2\\sin^2\\theta)^{3/2}}$. Unlike $\\frac{dE}{dk}$, the naive integral $\\int\\frac{k\\sin^2\\theta}{(1-k^2\\sin^2\\theta)^{3/2}}d\\theta$ does not split cleanly into $E,K$; the $(\\cdot)^{3/2}$ denominator forces an IBP step (§13-§16) to recover $\\frac{dK}{dk}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial derivative of the K-integrand",
+      "reciprocal-sqrt chain rule",
+      "HasDerivAt.div"
+    ],
+    "prerequisites": [
+      "HasDerivAt",
+      "Real.hasDerivAt_sqrt",
+      "ellipticK definition"
+    ]
+  },
+  {
+    "id": "ann-dK-bound",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 771,
+      "endLine": 867
+    },
+    "type": "concept",
+    "title": "§11 Dominating Bound for ∂ₖF_K",
+    "content": "The K-side counterpart of §9: `boundDIntegrandK` together with `boundDIntegrandK_continuous`, `boundDIntegrandK_integrable`, and `dIntegrandK_abs_le_bound` provide the uniform integrable majorant licensing differentiation under the integral for $K$. The bound must control the steeper $(1-k^2\\sin^2\\theta)^{-3/2}$ singularity, so it is constructed away from the endpoint where the integrand is largest.",
+    "mathContext": "Same dominated-convergence requirement as §9 but for $\\partial_k F_K$. The $(1-k^2\\sin^2\\theta)^{-3/2}$ growth near $\\theta = \\pi/2$ (for $k$ near 1) is the technical obstacle; `boundDIntegrandK` is designed to dominate it on a fixed sub-interval of moduli.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dominated convergence",
+      "uniform integrable bound",
+      "singular integrand control"
+    ],
+    "prerequisites": [
+      "intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_lip",
+      "Continuous.intervalIntegrable"
+    ]
+  },
+  {
+    "id": "ann-Kside-algebraic",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 901,
+      "endLine": 1011
+    },
+    "type": "concept",
+    "title": "§12 sin²/cos² Integral Building Blocks",
+    "content": "Algebraic identities decomposing the K-side derivative integral. `integral_sin_sq_div_sqrt_denom` and `integral_cos_sq_div_sqrt_denom` evaluate $\\int_0^{\\pi/2}\\frac{\\sin^2\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}d\\theta$ and the $\\cos^2$ analog in terms of $E$ and $K$. Since $\\sin^2+\\cos^2 = 1$, these two combine to recover $K$, and their weighted difference produces the pieces needed for the IBP closure of §16.",
+    "mathContext": "$\\int_0^{\\pi/2}\\frac{\\sin^2\\theta\\,d\\theta}{\\sqrt{1-k^2\\sin^2\\theta}} = \\frac{K-E}{k^2}$ and $\\int_0^{\\pi/2}\\frac{\\cos^2\\theta\\,d\\theta}{\\sqrt{1-k^2\\sin^2\\theta}} = \\frac{E-(1-k^2)K}{k^2}$. These follow from writing $k^2\\sin^2\\theta = 1-(1-k^2\\sin^2\\theta)$ and using $\\cos^2 = 1-\\sin^2$, giving the linear combinations of $E$ and $K$ that the dK/dk formula assembles.",
+    "significance": "key",
+    "relatedConcepts": [
+      "trigonometric integral decomposition",
+      "E and K as linear combinations",
+      "pythagorean splitting"
+    ],
+    "prerequisites": [
+      "intervalIntegral",
+      "Real.sin_sq_add_cos_sq",
+      "ellipticE/ellipticK definitions"
+    ]
+  },
+  {
+    "id": "ann-auxFnK",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 1040,
+      "endLine": 1063
+    },
+    "type": "definition",
+    "title": "§13 The IBP Auxiliary Function auxFnK",
+    "content": "`auxFnK k θ` is the antiderivative-style auxiliary chosen so that integration by parts converts the singular $(1-k^2\\sin^2\\theta)^{-3/2}$ integral into $E,K$-expressible pieces. The boundary lemmas `auxFnK_zero` ($\\text{auxFnK}\\,k\\,0 = 0$) and `auxFnK_pi_div_two` ($\\text{auxFnK}\\,k\\,(\\pi/2) = 0$) are crucial: they make the IBP boundary term $[\\text{auxFnK}]_0^{\\pi/2}$ vanish, so $\\int(\\text{auxFnK})' = 0$ (§15) reduces the K-derivative integral to a clean identity.",
+    "mathContext": "IBP $\\int u\\,dv = [uv] - \\int v\\,du$ needs the boundary term $[uv]_0^{\\pi/2}$ to vanish. `auxFnK` is engineered as the $uv$ piece — typically $\\propto \\frac{\\sin\\theta\\cos\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}$ — which is $0$ at both $\\theta=0$ ($\\sin 0=0$) and $\\theta=\\pi/2$ ($\\cos(\\pi/2)=0$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "integration by parts",
+      "vanishing boundary term",
+      "auxiliary antiderivative"
+    ],
+    "prerequisites": [
+      "Real.sin",
+      "Real.cos",
+      "Real.sqrt"
+    ]
+  },
+  {
+    "id": "ann-auxFnK-deriv",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 1095,
+      "endLine": 1249
+    },
+    "type": "concept",
+    "title": "§14 Pointwise Chain Rule for auxFnK",
+    "content": "Establishes the θ-derivative of `auxFnK`. `auxFnK_deriv_form_eq` rewrites the derivative into a canonical form, and `auxFnK_hasDerivAt` (a ~100-line proof) proves `HasDerivAt (auxFnK k) (...) θ` pointwise via the product/quotient/chain rules on $\\sin\\theta\\cos\\theta(1-k^2\\sin^2\\theta)^{-1/2}$. This derivative is precisely the integrand whose FTC closure (§15) yields the IBP identity.",
+    "mathContext": "Differentiating $\\frac{\\sin\\theta\\cos\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}$ in $\\theta$ produces, after simplification, a combination of $\\frac{1}{\\sqrt{\\cdot}}$ and $\\frac{1}{(\\cdot)^{3/2}}$ terms — exactly the singular $\\partial_k F_K$ integrand plus $E,K$-integrable remainders. Equating $\\int(\\text{auxFnK})' = 0$ then solves for the singular integral.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasDerivAt product rule",
+      "quotient rule",
+      "chain rule on sqrt"
+    ],
+    "prerequisites": [
+      "HasDerivAt.mul",
+      "HasDerivAt.div",
+      "Real.hasDerivAt_sqrt"
+    ]
+  },
+  {
+    "id": "ann-ftc-closure",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 1272,
+      "endLine": 1353
+    },
+    "type": "theorem",
+    "title": "§15 FTC Closure: ∫₀^{π/2} (auxFnK)′ dθ = 0",
+    "content": "`auxFnK_deriv_continuous` shows the θ-derivative is continuous (hence integrable), and `integral_auxFnK_deriv_eq_zero` applies the Fundamental Theorem of Calculus: $\\int_0^{\\pi/2}(\\text{auxFnK}\\,k)'\\,d\\theta = \\text{auxFnK}\\,k\\,(\\pi/2) - \\text{auxFnK}\\,k\\,0 = 0 - 0 = 0$, using the §13 boundary values. This vanishing integral is the engine that lets §16 isolate the K-side derivative.",
+    "mathContext": "FTC: $\\int_a^b g'(\\theta)\\,d\\theta = g(b)-g(a)$. With $g = \\text{auxFnK}\\,k$ vanishing at both endpoints, the integral of its derivative is $0$ — equivalently, the IBP boundary term contributes nothing, leaving only the interior $E,K$-terms.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fundamental theorem of calculus",
+      "intervalIntegral.integral_deriv_eq_sub",
+      "vanishing boundary term"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+      "auxFnK_zero",
+      "auxFnK_pi_div_two"
+    ]
+  },
+  {
+    "id": "ann-Kside-ibp",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 1383,
+      "endLine": 1452
+    },
+    "type": "theorem",
+    "title": "§16 IBP Closure for ∂ₖF_K",
+    "content": "`integral_dIntegrandK_eq` combines the §12 algebraic identities with the §15 vanishing FTC integral to evaluate $\\int_0^{\\pi/2}\\partial_k F_K\\,d\\theta$ in closed form as a combination of $E$ and $K$. This is the integration-by-parts payoff: the singular $(\\cdot)^{-3/2}$ integral that resisted direct evaluation is now expressed through $E$ and $K$, setting up the final dK/dk formula.",
+    "mathContext": "Adding $0 = \\int(\\text{auxFnK})'$ to $\\int\\partial_k F_K$ and regrouping converts the $(1-k^2\\sin^2\\theta)^{-3/2}$ term into $(1-k^2\\sin^2\\theta)^{-1/2}$ terms, which §12 expresses via $E,K$. The net result is $\\int\\partial_k F_K\\,d\\theta = \\frac{E-(1-k^2)K}{k(1-k^2)}$ once the differentiation-under-integral swap (§11) is applied.",
+    "significance": "key",
+    "relatedConcepts": [
+      "integration by parts closure",
+      "singular-integral reduction",
+      "E-K linear combination"
+    ],
+    "prerequisites": [
+      "integral_auxFnK_deriv_eq_zero",
+      "integral_sin_sq_div_sqrt_denom",
+      "integral_cos_sq_div_sqrt_denom"
+    ]
+  },
+  {
+    "id": "ann-dK-dk",
+    "proofId": "amgm-inequality-oq-04-oq-02",
+    "range": {
+      "startLine": 1493,
+      "endLine": 1599
+    },
+    "type": "theorem",
+    "title": "§17 Differentiation Under the Integral: dK/dk = (E − (1−k²)K)/(k(1−k²))",
+    "content": "The capstone `dK_dk` (a ~90-line proof) establishes the second Wronskian-derivative ingredient: $\\frac{dK}{dk} = \\frac{E-(1-k^2)K}{k(1-k^2)}$. It applies the dominated-derivative theorem (§11 bounds) to differentiate $K(k) = \\int F_K\\,d\\theta$ under the integral, then substitutes the §16 closed form for $\\int\\partial_k F_K$. Together with §8's $\\frac{dE}{dk} = \\frac{E-K}{k}$, both derivative formulas needed for the Legendre Wronskian argument are now machine-checked — the file is mid-way through eliminating its own axiom.",
+    "mathContext": "$\\frac{dK}{dk} = \\frac{E - (k')^2 K}{k (k')^2}$ with $(k')^2 = 1-k^2$ — the classical Legendre-ODE derivative of $K$. This is the formula whose Mathlib proof the earlier axiom annotation called 'reachable but ~200-500 lines of plumbing'; §8-§17 are that plumbing. The remaining step to discharge `legendre_relation` is to differentiate $f = EK' + E'K - KK'$ using these two formulas and the complModulus chain rule, show $f' = 0$, and evaluate the constant.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre ODE derivative of K",
+      "differentiation under the integral",
+      "Wronskian argument",
+      "axiom elimination progress"
+    ],
+    "prerequisites": [
+      "intervalIntegral.hasDerivAt_integral_of_dominated_loc_of_lip",
+      "integral_dIntegrandK_eq",
+      "dIntegrandK_abs_le_bound"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for `amgm-inequality-oq-04-oq-02` (Legendre's Relation for Complete Elliptic Integrals). The file has grown to 1601 lines / 18 sections, but the 8 annotations covered only the first ~285 lines and **5 of the 8 were type-misaligned** (e.g. the annotation typed `axiom` pointed at a `lemma`, because the `legendre_relation` axiom moved to line 309).

## Changes

- **Realigned all 8 existing annotations** to construct-accurate ranges; this resolves the 5 resolver type-mismatches.
- **Refreshed stale framing.** The original annotations described the two Wronskian-derivative ingredients (dE/dk, dK/dk) as "reachable but ~200–500 lines of unbuilt plumbing." That plumbing now exists: §8 (`integral_dIntegrandE_eq`) proves dE/dk = (E−K)/k and §17 (`dK_dk`) proves dK/dk = (E−(1−k²)K)/(k(1−k²)). Updated the axiom and preamble annotations to say the file is mid-way through eliminating its own axiom.
- **Added 10 annotations** covering the previously-uncovered §8–§17: the ∂ₖF_E integral identity, dominating bounds for differentiation under the integral, the ∂ₖF_K chain rule, the sin²/cos² integral building blocks, the `auxFnK` integration-by-parts function and its vanishing boundary term, the FTC closure ∫(auxFnK)′=0, and the dK/dk capstone.

Coverage now spans the full file (was capped at line 285). All 18 annotations pass `resolver.ts validate`.

## Verification

- `resolver.ts validate` → 18 valid, 0 misaligned (was 8 valid / 5 misaligned)
- meta.json axiom integrity confirmed: exactly 1 `axiom` (`legendre_relation`), 0 sorries, no assumption-carrying structures; `axiomCount: 1`, `badge: axiom`, `status: axiomatized` — no changes needed.
- Only `amgm-inequality-oq-04-oq-02/annotations.json` changed.

## Note (not changed)

The meta `title` still says "(Stub)", which is now arguably inaccurate given §8–§17. Left untouched to keep this PR scoped to annotations; flagging for a possible follow-up.