### PR TITLE
Enrich Erdős #263 (Irrationality Sequences): realign 29 stale annotations

### DIFF
--- a/src/data/proofs/erdos-263/annotations.json
+++ b/src/data/proofs/erdos-263/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "erdos-263",
     "range": {
       "startLine": 23,
-      "endLine": 27
+      "endLine": 29
     },
     "type": "concept",
     "title": "Imports and Dependencies",
-    "content": "Imports real number basics, the definition of irrationality, real-valued power functions, and the filter/topology framework needed for limits. These provide the analytic infrastructure for defining convergence of sequences and sums.",
+    "content": "Imports real number basics, the definition of irrationality, real-valued power functions, and the full tactic/filter framework needed for limits. A small compatibility shim re-adds `PNat.val_mk` (removed in newer Mathlib) so the positive-integer sequence type works cleanly.",
     "mathContext": "Requires $\\mathbb{R}$, $\\texttt{Irrational}$, $x^r$ for $r \\in \\mathbb{R}$, and the filter-based limit framework $\\mathcal{F} \\to \\mathcal{G}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -25,8 +25,8 @@
     "id": "ann-263-posintseq",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 36,
-      "endLine": 36
+      "startLine": 37,
+      "endLine": 38
     },
     "type": "definition",
     "title": "Positive Integer Sequence",
@@ -47,8 +47,8 @@
     "id": "ann-263-recipsum",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 39,
-      "endLine": 40
+      "startLine": 40,
+      "endLine": 42
     },
     "type": "definition",
     "title": "Reciprocal Sum",
@@ -71,8 +71,8 @@
     "id": "ann-263-partialsum",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 43,
-      "endLine": 44
+      "startLine": 44,
+      "endLine": 46
     },
     "type": "definition",
     "title": "Reciprocal Partial Sum",
@@ -93,8 +93,8 @@
     "id": "ann-263-perturbation",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 47,
-      "endLine": 48
+      "startLine": 48,
+      "endLine": 52
     },
     "type": "definition",
     "title": "Perturbation",
@@ -116,8 +116,8 @@
     "id": "ann-263-irrseq",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 53,
-      "endLine": 55
+      "startLine": 54,
+      "endLine": 57
     },
     "type": "definition",
     "title": "Irrationality Sequence",
@@ -140,12 +140,12 @@
     "id": "ann-263-doubleexp",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 58,
-      "endLine": 58
+      "startLine": 59,
+      "endLine": 60
     },
     "type": "definition",
     "title": "Double Exponential Sequence",
-    "content": "The sequence $a_n = 2^{2^n}$, growing as $2, 4, 16, 256, 65536, \\ldots$. This is the specific sequence Erdős asked about. Its reciprocal sum $\\sum 1/2^{2^n}$ is a Kempner-like number whose irrationality is known, but the irrationality sequence property (robustness under ALL perturbations) remains open.",
+    "content": "The sequence $a_n = 2^{2^n}$, growing as $2, 4, 16, 256, 65536, \\ldots$. This is the specific sequence Erdős asked about. Its reciprocal sum $\\sum 1/2^{2^n}$ is a Kempner-like number whose irrationality is known (and proved later in this file as `doubleExp_sum_irrational`), but the irrationality sequence property (robustness under ALL perturbations) remains open.",
     "mathContext": "$a_n = 2^{2^n}$. The sum $\\sum_{n=0}^{\\infty} 2^{-2^n}$ is known to be transcendental (it is a Fredholm number related to $\\prod_{k=0}^{\\infty}(1 - 2^{-2^k})$).",
     "significance": "key",
     "relatedConcepts": [
@@ -163,8 +163,8 @@
     "id": "ann-263-q1",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 61,
-      "endLine": 61
+      "startLine": 62,
+      "endLine": 63
     },
     "type": "definition",
     "title": "Erdős Question 1",
@@ -185,8 +185,8 @@
     "id": "ann-263-superexp",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 66,
-      "endLine": 67
+      "startLine": 67,
+      "endLine": 69
     },
     "type": "definition",
     "title": "Superexponential Growth",
@@ -209,8 +209,8 @@
     "id": "ann-263-q2",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 70,
-      "endLine": 71
+      "startLine": 71,
+      "endLine": 74
     },
     "type": "definition",
     "title": "Erdős Question 2",
@@ -231,8 +231,8 @@
     "id": "ann-263-folklore",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 76,
-      "endLine": 77
+      "startLine": 77,
+      "endLine": 79
     },
     "type": "definition",
     "title": "Folklore Growth Condition",
@@ -253,8 +253,8 @@
     "id": "ann-263-folklorethm",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 80,
-      "endLine": 83
+      "startLine": 81,
+      "endLine": 85
     },
     "type": "concept",
     "title": "Folklore Irrationality Theorem",
@@ -276,13 +276,13 @@
     "id": "ann-263-doubleexp-folklore",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 86,
-      "endLine": 87
+      "startLine": 87,
+      "endLine": 114
     },
     "type": "concept",
-    "title": "Double Exponential Satisfies Folklore",
-    "content": "Verifies that $2^{2^n}$ satisfies the folklore growth condition. Since $(2^{2^n})^{1/2^n} = 2$ for all $n$, this sequence is actually on the boundary — it does NOT satisfy folklore growth (the limit is 2, not $\\infty$). This is why the irrationality sequence question for $2^{2^n}$ remains open.",
-    "mathContext": "$(2^{2^n})^{1/2^n} = 2^{2^n/2^n} = 2^1 = 2$ for all $n$. Since $2 \\not\\to \\infty$, the folklore condition does NOT hold. This sorry may represent a false claim.",
+    "title": "Double Exponential Does NOT Satisfy Folklore",
+    "content": "The theorem `doubleExp_not_folklore_growth` proves that $2^{2^n}$ does NOT satisfy the folklore growth condition: it sits exactly on the boundary, since $(2^{2^n})^{1/2^n} = 2$ for all $n$, and $2 \\not\\to \\infty$. This is precisely why the folklore sufficient condition cannot resolve Erdős Question 1 for the double exponential — the question remains open.",
+    "mathContext": "$(2^{2^n})^{1/2^n} = 2^{2^n/2^n} = 2^1 = 2$ for all $n$. Since the limit is $2 \\neq \\infty$, $\\texttt{HasFolkloreGrowth}\\;\\texttt{doubleExp}$ is false.",
     "significance": "key",
     "relatedConcepts": [
       "boundary cases",
@@ -298,8 +298,8 @@
     "id": "ann-263-increasing",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 92,
-      "endLine": 93
+      "startLine": 127,
+      "endLine": 129
     },
     "type": "definition",
     "title": "Strictly Increasing Sequence",
@@ -318,8 +318,8 @@
     "id": "ann-263-convergentsum",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 96,
-      "endLine": 97
+      "startLine": 131,
+      "endLine": 133
     },
     "type": "definition",
     "title": "Convergent Reciprocal Sum",
@@ -340,8 +340,8 @@
     "id": "ann-263-kt",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 100,
-      "endLine": 101
+      "startLine": 135,
+      "endLine": 137
     },
     "type": "definition",
     "title": "Kovač-Tao Condition",
@@ -363,8 +363,8 @@
     "id": "ann-263-ktthm",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 104,
-      "endLine": 109
+      "startLine": 139,
+      "endLine": 145
     },
     "type": "concept",
     "title": "Kovač-Tao Theorem (2024)",
@@ -387,8 +387,8 @@
     "id": "ann-263-positive",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 114,
-      "endLine": 116
+      "startLine": 170,
+      "endLine": 173
     },
     "type": "definition",
     "title": "Positive Condition (Sufficient for Irrationality)",
@@ -409,8 +409,8 @@
     "id": "ann-263-positivethm",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 119,
-      "endLine": 122
+      "startLine": 175,
+      "endLine": 181
     },
     "type": "concept",
     "title": "Positive Condition Implies Irrationality Sequence",
@@ -432,12 +432,12 @@
     "id": "ann-263-factorial",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 127,
-      "endLine": 131
+      "startLine": 183,
+      "endLine": 184
     },
     "type": "definition",
     "title": "Factorial Sequence Example",
-    "content": "The factorial sequence $a_n = (n+1)!$ as a test case. While $n!$ grows superexponentially ($(n!)^{1/n} \\sim n/e \\to \\infty$ by Stirling), it does NOT satisfy the folklore growth condition since $(n!)^{1/2^n} \\to 1$. The irrationality of $e - 1 = \\sum 1/n!$ is well-known, but whether $n!$ is an irrationality sequence remains open.",
+    "content": "The factorial sequence $a_n = (n+1)!$ as a test case. While $n!$ grows superexponentially ($(n!)^{1/n} \\sim n/e \\to \\infty$ by Stirling), it does NOT satisfy the folklore growth condition since $(n!)^{1/2^n} \\to 1$. The irrationality of $e - 1 = \\sum 1/n!$ is well-known, but whether $n!$ is an irrationality sequence remains open. The lemmas that follow verify it satisfies the Kovač-Tao condition, is strictly increasing, and has a convergent sum.",
     "mathContext": "$a_n = (n+1)!$. By Stirling's approximation, $(n!)^{1/n} \\sim n/e$, so $n!$ has superexponential growth. But $(n!)^{1/2^n} \\to 1$ since $\\log(n!)/2^n \\sim n \\log n / 2^n \\to 0$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -456,8 +456,8 @@
     "id": "ann-263-tower",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 134,
-      "endLine": 136
+      "startLine": 350,
+      "endLine": 353
     },
     "type": "definition",
     "title": "Tower Function (Tetration)",
@@ -479,8 +479,8 @@
     "id": "ann-263-doubleexp-incr",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 139,
-      "endLine": 140
+      "startLine": 355,
+      "endLine": 360
     },
     "type": "concept",
     "title": "Double Exponential is Strictly Increasing",
@@ -499,8 +499,8 @@
     "id": "ann-263-doubleexp-conv",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 143,
-      "endLine": 144
+      "startLine": 371,
+      "endLine": 389
     },
     "type": "concept",
     "title": "Double Exponential Sum Converges",
@@ -521,8 +521,8 @@
     "id": "ann-263-gap",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 149,
-      "endLine": 151
+      "startLine": 448,
+      "endLine": 453
     },
     "type": "concept",
     "title": "Characterization Gap",
@@ -543,8 +543,8 @@
     "id": "ann-263-mainq",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 154,
-      "endLine": 155
+      "startLine": 455,
+      "endLine": 459
     },
     "type": "definition",
     "title": "Main Question",
@@ -564,12 +564,12 @@
     "id": "ann-263-conn262",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 160,
-      "endLine": 162
+      "startLine": 461,
+      "endLine": 464
     },
     "type": "definition",
     "title": "Connection to Problem #262",
-    "content": "Problem #262 asks about the growth rate of irrationality sequences: how slowly can they grow? Hančl (1991) showed $\\limsup (\\log_2 \\log_2 a_n)/n \\geq 1$ is necessary. This provides the lower bound complementing the upper bound from the folklore condition.",
+    "content": "Problem #262 asks about the growth rate of irrationality sequences: how slowly can they grow? Hančl (1991) showed $\\limsup (\\log_2 \\log_2 a_n)/n \\geq 1$ is necessary. This provides the lower bound complementing the upper bound from the folklore condition. The proposition `connection_262` states that every irrationality sequence has an irrational reciprocal sum (proved below as `connection_262_proved`).",
     "mathContext": "Connection: if $(a_n)$ is an irrationality sequence, then $\\sum 1/a_n$ is itself irrational (choosing $b_n = a_n$ as the trivial perturbation).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -586,8 +586,8 @@
     "id": "ann-263-conn264",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 165,
-      "endLine": 167
+      "startLine": 486,
+      "endLine": 489
     },
     "type": "definition",
     "title": "Connection to Problem #264",
@@ -608,35 +608,36 @@
     "id": "ann-263-noncompute",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 172,
-      "endLine": 175
+      "startLine": 640,
+      "endLine": 656
     },
     "type": "concept",
-    "title": "Non-Computability of Irrationality Sequence Property",
-    "content": "The property of being an irrationality sequence cannot be decided by any algorithm, because it requires checking ALL perturbation sequences — an inherently infinite verification. This is formalized by showing no Boolean function on sequences can correctly classify all irrationality sequences.",
-    "mathContext": "$\\nexists\\; \\texttt{decide} : (\\mathbb{N} \\to \\mathbb{N}^+) \\to \\texttt{Bool}$ such that $\\texttt{decide}(a) = \\texttt{true} \\iff (a_n) \\text{ is an irrationality sequence}$.",
+    "title": "The Reciprocal Sum Σ 1/2^{2ⁿ} is Irrational",
+    "content": "The headline machine-checked result of the file: $\\sum_{n=0}^{\\infty} 1/2^{2^n}$ is irrational (`doubleExp_sum_irrational`). This is a *necessary* condition for Erdős Question 1 — if the sum were rational, the identity perturbation $b = a$ would already witness that $2^{2^n}$ is NOT an irrationality sequence. The proof is a self-contained integer-gap argument (no transcendence machinery): assuming $S = p/q$, set $D = 2^{2^N}$ with $N = q.\\mathrm{den}$, split $S = A + 1/D + T$, and show $qDT$ is a nonzero integer of absolute value $< 1$ — a contradiction.",
+    "mathContext": "$\\sum_{n=0}^{\\infty} \\frac{1}{2^{2^n}} \\notin \\mathbb{Q}$. Key bound: $0 < qDT < |q|/(D-1) \\leq 1$ with $qDT \\in \\mathbb{Z}$, impossible.",
     "significance": "key",
     "relatedConcepts": [
-      "computability",
-      "undecidability",
-      "Rice's theorem",
-      "halting problem"
+      "irrationality proof",
+      "integer-gap argument",
+      "Fredholm numbers",
+      "tail estimate"
     ],
     "prerequisites": [
-      "computability theory",
-      "diagonal arguments"
+      "proof by contradiction",
+      "tsum splitting",
+      "rational denominators"
     ]
   },
   {
     "id": "ann-263-truncation",
     "proofId": "erdos-263",
     "range": {
-      "startLine": 178,
-      "endLine": 181
+      "startLine": 499,
+      "endLine": 503
     },
     "type": "concept",
     "title": "Truncation Insufficiency",
-    "content": "No finite prefix of a sequence determines whether it is an irrationality sequence: for every $N$, there exist two sequences agreeing on the first $N$ terms where one is an irrationality sequence and the other is not. This shows the property is genuinely infinitary.",
+    "content": "No finite prefix of a sequence determines whether it is an irrationality sequence: for every $N$, there exist two sequences agreeing on the first $N$ terms where one is an irrationality sequence and the other is not. This shows the property is genuinely infinitary. (The earlier 'non-computability' theorem was removed from the file because, under classical logic, decidability is not the right formalization; this truncation statement captures the intended infinitary content.)",
     "mathContext": "$\\forall N \\in \\mathbb{N},\\; \\exists a, b : \\mathbb{N} \\to \\mathbb{N}^+$ with $a_n = b_n$ for $n < N$, $(a_n)$ an irrationality sequence, $(b_n)$ not.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -135,8 +135,8 @@
     },
     {
       "id": "noncomputable",
-      "title": "Non-Computability",
-      "summary": "Shows no algorithm can decide if a sequence is an irrationality sequence (requires checking all perturbations). Any finite prefix is insufficient: $\\forall N,\\; \\exists$ two sequences agreeing on $N$ terms with opposite irrationality status.",
+      "title": "Infinitary Nature (Truncation Insufficiency)",
+      "summary": "The irrationality-sequence property is genuinely infinitary: no finite prefix determines it ($\\forall N,\\; \\exists$ two sequences agreeing on $N$ terms with opposite irrationality status). A note records that the originally-attempted 'non-computability' theorem was removed because, under classical logic, decidability is not the correct formalization.",
       "startLine": 491,
       "endLine": 504,
       "mathContext": "Undecidable: $\\forall N,\\, \\exists (a_n), (a_n')$ agreeing on $N$ terms with opposite irrationality status."


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-263`. The Lean file `Erdos263Problem.lean` grew across ~9 proof sessions to 792 lines, but the 29 annotations kept their original pre-growth line ranges. The resolver reported **20 misaligned** (12 anchored to non-construct lines, 7 with `type: "definition"` landing on `theorem`s, plus a type mismatch), and several of the nominally "valid" ones were false-positives anchored to the wrong construct.

## Changes
- **Realigned all 29 annotations** to their actual constructs. `resolver.ts validate` now reports **29 valid, 0 misaligned**.
- **Fixed an orphaned annotation**: `ann-263-noncompute` described a "non-computability" theorem that was *explicitly removed* from the file (a source comment notes it was false in classical logic). Re-anchored it to the headline machine-checked result `doubleExp_sum_irrational` (Σ 1/2^{2^n} is irrational) — previously unannotated — and rewrote the content around the file's self-contained integer-gap proof.
- **Fixed a mislabeled annotation**: `ann-263-doubleexp-folklore` was titled "Double Exponential Satisfies Folklore", but the theorem `doubleExp_not_folklore_growth` proves it does **not** (since (2^{2ⁿ})^{1/2ⁿ}=2). Corrected the title and removed a stale "this sorry may represent a false claim" note.
- Updated the stale **"Non-Computability"** section title/summary in `meta.json` to reflect the truncation-insufficiency content that actually lives there.

## Integrity
`status: formalized`, `badge: wip`, `axiomCount: 0`, `sorries: 4` — all verified against source (0 `axiom` declarations; 4 real `sorry`s at lines 85/145/179/503; the line-784 "no sorry" is a comment). No change needed.

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → 29 valid / 0 misaligned
- `pnpm build` → green