### PR TITLE
Enrich Erdős #1109 (Squarefree Sumsets): realign + cover full ladder (10→22)

### DIFF
--- a/src/data/proofs/erdos-1109/annotations.json
+++ b/src/data/proofs/erdos-1109/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-1109",
     "range": {
       "startLine": 1,
-      "endLine": 32
+      "endLine": 47
     },
     "type": "concept",
     "title": "Erdős Problem #1109: Squarefree Sumsets",
@@ -27,12 +27,12 @@
     "id": "ann-e1109-squarefree",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 44,
-      "endLine": 67
+      "startLine": 52,
+      "endLine": 105
     },
     "type": "definition",
     "title": "Squarefree Numbers in Mathlib",
-    "content": "**Definition:** A number n is **squarefree** if no prime squared divides it.\n\n```lean\ndef isSquarefree (n : ℕ) : Prop := Squarefree n\n```\n\n**Equivalent characterization:** n is squarefree ⟺ ∀ primes p, p² ∤ n\n\n**Examples:**\n- 1 is squarefree (vacuously)\n- 6 = 2 · 3 is squarefree\n- 30 = 2 · 3 · 5 is squarefree\n- 4 = 2² is NOT squarefree\n- 12 = 2² · 3 is NOT squarefree\n\n**Key Fact:** The density of squarefree numbers is 6/π² ≈ 60.8%. This seems high, but constraining an entire sumset to be squarefree is much harder!",
+    "content": "**Definition:** `isSquarefree n := Squarefree n` — n is squarefree if no prime squared divides it.\n\n**Equivalent characterization** (`squarefree_iff_no_prime_sq`): n is squarefree ⟺ ∀ primes p, p² ∤ n.\n\n**Basic lemmas proved here:** `one_squarefree` (1 is squarefree, vacuously), `prime_squarefree` (every prime is squarefree), and `distinct_primes_squarefree` (a product of distinct primes is squarefree).\n\n**Examples:** 1, 6 = 2·3, 30 = 2·3·5 are squarefree; 4 = 2², 12 = 2²·3 are not.\n\n**Key Fact:** The density of squarefree numbers is 6/π² ≈ 60.8%. This seems high, but constraining an *entire sumset* to be squarefree is far harder.",
     "mathContext": "$n$ is squarefree $\\iff$ $\\forall p$ prime, $p^2 \\nmid n$. Density: $\\prod_p (1 - 1/p^2) = 6/\\pi^2 \\approx 0.608$. Mathlib's `Squarefree` predicate handles this uniformly across ring types.",
     "significance": "key",
     "relatedConcepts": [
@@ -51,12 +51,12 @@
     "id": "ann-e1109-sumset",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 69,
-      "endLine": 79
+      "startLine": 111,
+      "endLine": 117
     },
-    "type": "concept",
+    "type": "definition",
     "title": "The Sumset and Squarefree Sumset Predicate",
-    "content": "**Sumset Definition:**\n```lean\ndef sumset (A : Finset ℕ) : Finset ℕ :=\n  (A ×ˢ A).image (fun p => p.1 + p.2)\n```\n\nThis computes A + A = {a + b : a, b ∈ A}.\n\n**Squarefree Sumset Predicate:**\n```lean\ndef hasSquarefreeSumset (A : Finset ℕ) : Prop :=\n  ∀ s ∈ sumset A, isSquarefree s\n```\n\n**Size Explosion:** If |A| = m, then |A + A| can be as large as m(m+1)/2. For ALL these sums to be squarefree is an extremely strong constraint that severely limits how large A can be.",
+    "content": "**Sumset:** `sumset A := (A ×ˢ A).image (fun p => p.1 + p.2)` computes A + A = {a + b : a, b ∈ A}.\n\n**Squarefree Sumset Predicate:** `hasSquarefreeSumset A := ∀ s ∈ sumset A, isSquarefree s`.\n\n**Size Explosion:** If |A| = m, then |A + A| can be as large as m(m+1)/2. For ALL these sums to be squarefree is an extremely strong constraint that severely limits how large A can be.",
     "significance": "key",
     "relatedConcepts": [
       "Minkowski sum",
@@ -68,18 +68,18 @@
       "Finset.image",
       "Squarefree"
     ],
-    "mathContext": "See annotation content for formal details of the sumset and squarefree sumset predicate"
+    "mathContext": "$A+A = \\{a+b : a,b \\in A\\}$; the predicate requires every element of $A+A$ to be squarefree."
   },
   {
     "id": "ann-e1109-f-function",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 81,
-      "endLine": 87
+      "startLine": 123,
+      "endLine": 125
     },
     "type": "definition",
     "title": "The Function f(N)",
-    "content": "**Definition:**\n```lean\nnoncomputable def f (N : ℕ) : ℕ :=\n  sSup { A.card | A : Finset ℕ // A ⊆ range (N + 1) ∧ hasSquarefreeSumset A }\n```\n\n**In words:** f(N) is the maximum cardinality of a subset A ⊆ {1, 2, ..., N} such that every element of A + A is squarefree.\n\n**The central question:** What is the growth rate of f(N) as N → ∞?\n\n- Is f(N) bounded by N^{o(1)} (subpolynomial)?\n- Is f(N) bounded by (log N)^{O(1)} (polylogarithmic)?\n\nThe answer remains unknown despite decades of research.",
+    "content": "**Definition:** `f N` is the maximum cardinality of a subset A ⊆ {0,...,N} such that every element of A + A is squarefree (a noncomputable `sSup` over admissible sets).\n\n**The central question:** What is the growth rate of f(N) as N → ∞?\n\n- Is f(N) bounded by N^{o(1)} (subpolynomial)?\n- Is f(N) bounded by (log N)^{O(1)} (polylogarithmic)?\n\nThe answer remains unknown despite decades of research.",
     "significance": "key",
     "relatedConcepts": [
       "extremal set theory",
@@ -91,18 +91,18 @@
       "sSup",
       "hasSquarefreeSumset"
     ],
-    "mathContext": "See annotation content for formal details of the function f(n)"
+    "mathContext": "$f(N) = \\sup\\{|A| : A \\subseteq \\{0,\\dots,N\\},\\ A+A \\text{ squarefree}\\}$."
   },
   {
     "id": "ann-e1109-erdos-sarkozy",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 89,
-      "endLine": 107
+      "startLine": 127,
+      "endLine": 140
     },
     "type": "concept",
     "title": "Erdős-Sárközy Bounds (1987)",
-    "content": "**Historical First Results:**\n\nErdős and Sárközy established the first bounds in their 1987 paper \"On divisibility properties of integers a + a'\":\n\n**Lower Bound:** f(N) ≫ log N\n- They constructed sets of size approximately log N with squarefree sumsets\n- The construction uses careful selection based on residue classes\n\n**Upper Bound:** f(N) ≪ N^{3/4} log N\n- Uses counting arguments about how squarefree numbers are distributed\n\n**Their Conjecture:** The lower bound is closer to the truth—f(N) should be polylogarithmic.\n\nThese bounds left a huge gap: polylogarithmic vs polynomial.",
+    "content": "**Historical First Results:**\n\nErdős and Sárközy established the first bounds in their 1987 paper \"On divisibility properties of integers a + a'\":\n\n**Lower Bound:** f(N) ≫ log N — they constructed sets of size ≈ log N with squarefree sumsets, using careful residue-class selection.\n\n**Upper Bound:** f(N) ≪ N^{3/4} log N — via counting arguments about how squarefree numbers are distributed.\n\n**Their Conjecture:** The lower bound is closer to the truth — f(N) should be polylogarithmic.\n\nThese bounds left a huge gap: polylogarithmic vs polynomial.",
     "mathContext": "$\\log N \\ll f(N) \\ll N^{3/4} \\log N$ (Erdős-Sárközy 1987). Lower bound via residue class constructions; upper bound via counting squarefree distribution.",
     "significance": "key",
     "relatedConcepts": [
@@ -119,18 +119,19 @@
     "id": "ann-e1109-konyagin",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 109,
-      "endLine": 150
+      "startLine": 145,
+      "endLine": 161
     },
     "type": "concept",
-    "title": "Konyagin's Improvements (2004)",
-    "content": "**Current Best Bounds:**\n\nKonyagin improved both bounds in 2004:\n\n**Lower Bound:** f(N) ≥ C · (log log N)(log N)²\n```lean\naxiom konyagin_lower_2004 (N : ℕ) (hN : N ≥ 16) :\n    ∃ C > 0, f N ≥ C * Real.log (Real.log N) * (Real.log N)^2\n```\nThis is significantly stronger than log N.\n\n**Upper Bound:** f(N) ≤ C · N^{11/15 + o(1)}\n```lean\naxiom konyagin_upper_2004 (N : ℕ) (hN : N ≥ 2) :\n    ∃ C > 0, ∃ ε > 0, f N ≤ C * N^(11/15 + ε : ℝ)\n```\nNote: 11/15 ≈ 0.733 < 0.75 = 3/4\n\n**The Gap Remains:** Polylogarithmic vs N^{0.733} is still enormous!",
+    "title": "Konyagin's Improvements (2004) — the Two Axioms",
+    "content": "**Current Best Bounds**, encoded as the file's two axioms (axiomCount = 2):\n\n**Lower Bound** (`konyagin_lower_2004`, N ≥ 16): f(N) ≥ C · (log log N)(log N)² — significantly stronger than log N.\n\n**Upper Bound** (`konyagin_upper_2004`, N ≥ 2): f(N) ≤ C · N^{11/15 + ε}. Note 11/15 ≈ 0.733 < 0.75 = 3/4.\n\nThese deep analytic results (large sieve, exponential sums) are axiomatized rather than reproved in Lean. **The Gap Remains:** polylogarithmic vs N^{0.733} is still enormous.",
     "mathContext": "$(\\log\\log N)(\\log N)^2 \\ll f(N) \\ll N^{11/15+o(1)}$. The exponent $11/15 \\approx 0.733$ improves $3/4$ via refined sieve methods.",
     "significance": "key",
     "relatedConcepts": [
       "large sieve inequality",
       "exponential sum estimates",
-      "Selberg sieve"
+      "Selberg sieve",
+      "axiomatized analytic results"
     ],
     "prerequisites": [
       "Real.log",
@@ -141,12 +142,12 @@
     "id": "ann-e1109-open-questions",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 152,
-      "endLine": 178
+      "startLine": 185,
+      "endLine": 201
     },
     "type": "concept",
     "title": "The Open Questions",
-    "content": "**Question 1 (Weaker):** Is f(N) ≤ N^{o(1)}?\n```lean\ndef question1_subpolynomial : Prop :=\n  ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀, f N ≤ N^ε\n```\nThis asks: does f(N) grow slower than ANY polynomial?\n\n**Question 2 (Stronger):** Is f(N) ≤ (log N)^{O(1)}?\n```lean\ndef question2_polylogarithmic : Prop :=\n  ∃ k : ℕ, ∃ C > 0, ∀ N ≥ 2, f N ≤ C * (Real.log N)^k\n```\nThis asks: is f(N) bounded by some fixed power of log N?\n\n**Erdős-Sárközy Conjecture:** Question 2 is true—f(N) is polylogarithmic.\n\n**Status:** BOTH QUESTIONS REMAIN OPEN. We don't even know if f(N) is subpolynomial!",
+    "content": "**Question 1 (Weaker):** Is f(N) ≤ N^{o(1)}? — `question1_subpolynomial := ∀ ε > 0, ∃ N₀, ∀ N ≥ N₀, f N ≤ N^ε`. Does f(N) grow slower than ANY polynomial?\n\n**Question 2 (Stronger):** Is f(N) ≤ (log N)^{O(1)}? — `question2_polylogarithmic := ∃ k, ∃ C > 0, ∀ N ≥ 2, f N ≤ C·(log N)^k`. Is f(N) bounded by a fixed power of log N?\n\n**Erdős-Sárközy Conjecture:** Question 2 is true — f(N) is polylogarithmic.\n\n**Status:** BOTH QUESTIONS REMAIN OPEN. We don't even know if f(N) is subpolynomial.",
     "significance": "key",
     "relatedConcepts": [
       "subpolynomial growth",
@@ -158,36 +159,40 @@
       "Real.log",
       "Filter.Tendsto"
     ],
-    "mathContext": "See annotation content for formal details of the open questions"
+    "mathContext": "Q1: $\\forall \\varepsilon>0,\\ f(N) \\le N^\\varepsilon$ eventually. Q2: $\\exists k,\\ f(N) \\le C(\\log N)^k$."
   },
   {
     "id": "ann-e1109-related",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 180,
-      "endLine": 205
+      "startLine": 218,
+      "endLine": 224
     },
-    "type": "concept",
-    "title": "Connection to Problem #1103 and Generalizations",
-    "content": "**Infinite Analogue (Problem #1103):**\n\nProblem #1103 asks about INFINITE sequences a₁ < a₂ < ⋯ with all pairwise sums squarefree.\n\n```lean\naxiom connection_to_1103 :\n    question2_polylogarithmic →\n      ∃ c > 0, ∀ (a : ℕ → ℕ), (∀ i j : ℕ, isSquarefree (a i + a j)) →\n        ∀ n : ℕ, a n ≥ n^(c : ℝ)\n```\n\nIf f(N) is polylogarithmic, then any infinite squarefree-sumset sequence must grow at least polynomially!\n\n**k-Power-Free Generalization (Sárközy 1992):**\n```lean\ndef isKPowerFree (k n : ℕ) : Prop :=\n  ∀ p : ℕ, p.Prime → ¬(p^k ∣ n)\n```\n\nReplacing 'squarefree' (k=2) with 'k-power-free' gives a family of related problems.",
-    "mathContext": "The connection between finite and infinite cases reveals deep structural constraints.",
-    "significance": "key",
+    "type": "definition",
+    "title": "k-Power-Free Generalization and Connection to Problem #1103",
+    "content": "**k-Power-Free Generalization (Sárközy 1992):** `isKPowerFree k n := ∀ p prime, ¬(p^k ∣ n)`. Replacing 'squarefree' (k = 2) with 'k-power-free' gives a family of related problems.\n\n**Infinite Analogue (Problem #1103):** Problem #1103 asks about INFINITE sequences a₁ < a₂ < ⋯ with all pairwise sums squarefree. Heuristically, if the finite f(N) is polylogarithmic, any infinite squarefree-sumset sequence must grow at least polynomially — this conceptual link motivates the finite study, though it is stated here only as context (no separate axiom).",
+    "mathContext": "$\\text{isKPowerFree}(k,n) \\iff \\forall p\\ \\text{prime},\\ p^k \\nmid n$; $k=2$ recovers squarefree. The finite/infinite link (#1103) reflects deep structural constraints.",
+    "significance": "supporting",
     "relatedConcepts": [
       "Erdős Problem #1103",
       "k-power-free numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nat.Prime",
+      "Dvd"
+    ]
   },
   {
-    "id": "ann-e1109-intuition",
+    "id": "ann-e1109-structural",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 207,
-      "endLine": 230
+      "startLine": 230,
+      "endLine": 313
     },
     "type": "insight",
-    "title": "Why Squarefree Sumsets Must Be Small",
-    "content": "**Intuition for the Upper Bound:**\n\n**1. Sumset Explosion:** If |A| = m, then A + A has roughly m² elements.\n\n**2. Avoiding 4 = 2²:** Every element of A + A must avoid being divisible by 4.\n- If a + b ≡ 0 (mod 4), that's forbidden\n- This forces A into special residue classes mod 4\n\n**3. Multiple Primes:** A + A must simultaneously avoid p² for EVERY prime p.\n- Avoiding 4 = 2² is one constraint\n- Avoiding 9 = 3² is another constraint\n- Avoiding 25 = 5² is another... and so on!\n\nAt each prime p, the constraint forces A into at most p/2 + 1 residue classes mod p². These constraints interact multiplicatively, severely limiting the size of A.",
+    "title": "Why Squarefree Sumsets Must Be Small: Structural Constraints",
+    "content": "The first formal theorems, capturing *why* the sumset constraint is so restrictive.\n\n**Intuition:** Avoiding 4 = 2² forces A into special residue classes mod 4; avoiding 9 = 3² adds another constraint mod 9; and so on for every prime. At each prime p these constraints interact multiplicatively.\n\n**Theorems:** `all_odd` (if A is large with squarefree sumset, its elements share parity structure forced by avoiding 4 | a+b), `prime_sq_avoidance` (sums avoid every p²), `double_squarefree` (2a is squarefree, so each a is squarefree and odd-ish), `element_not_div_prime_sq`, and `element_squarefree` (every element of A is itself squarefree, since a + a = 2a must be squarefree).",
+    "mathContext": "If $a+b$ is squarefree for all $a,b \\in A$, then in particular $2a$ is squarefree (so $4 \\nmid 2a$, forcing $a$ odd) and $a$ itself is squarefree. Avoiding $p^2 \\mid a+b$ restricts the residues of $A$ mod $p^2$ — the seed of all later density bounds.",
     "significance": "key",
     "relatedConcepts": [
       "Chinese Remainder Theorem",
@@ -198,19 +203,18 @@
       "Nat.Prime",
       "Dvd",
       "ZMod"
-    ],
-    "mathContext": "See annotation content for formal details of why squarefree sumsets must be small"
+    ]
   },
   {
     "id": "ann-e1109-summary",
     "proofId": "erdos-1109",
     "range": {
-      "startLine": 232,
-      "endLine": 253
+      "startLine": 319,
+      "endLine": 337
     },
     "type": "concept",
     "title": "Main Results Summary",
-    "content": "**Erdős Problem #1109: Complete Timeline**\n\n| Year | Authors | Lower Bound | Upper Bound |\n|------|---------|-------------|-------------|\n| 1987 | Erdős-Sárközy | log N | N^{3/4} log N |\n| 2001 | Gyarmati | log N (alt. proof) | — |\n| 2004 | Konyagin | (log log N)(log N)² | N^{11/15+o(1)} |\n\n**The Summary Theorem:**\n```lean\ntheorem erdos_1109_summary :\n    (∀ N ≥ 16, ∃ C > 0, f N ≥ C * Real.log (Real.log N) * (Real.log N)^2) ∧\n    (∀ N ≥ 2, ∃ C > 0, ∃ ε > 0, f N ≤ C * N^(11/15 + ε : ℝ)) := ...\n```\n\nThis combines Konyagin's lower and upper bounds into a single summary theorem.\n\n**Status:** OPEN. The gap between polylogarithmic and polynomial growth represents one of the fundamental open questions in additive combinatorics.",
+    "content": "**Erdős Problem #1109 timeline:** 1987 Erdős-Sárközy (log N, N^{3/4} log N) → 2004 Konyagin ((log log N)(log N)², N^{11/15+o(1)}).\n\n**`erdos_1109_summary`** packages Konyagin's lower and upper bounds into a single theorem (combining the two axioms). The remainder of the file then develops, fully constructively, an explicit *lower-bound ladder* f(N) ≥ 2, 3, 4, …, 12 via concrete sets, and matching *upper bounds* from CRT residue-density products.\n\n**Status:** OPEN — the gap between polylogarithmic and polynomial growth is a fundamental open question in additive combinatorics.",
     "significance": "key",
     "relatedConcepts": [
       "additive combinatorics timeline",
@@ -221,6 +225,279 @@
       "Real.rpow",
       "f"
     ],
-    "mathContext": "See annotation content for formal details of main results summary"
+    "mathContext": "Summary theorem: lower bound for $N \\ge 16$ and upper bound for $N \\ge 2$, conjoined."
+  },
+  {
+    "id": "ann-e1109-examples-f3",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 343,
+      "endLine": 588
+    },
+    "type": "theorem",
+    "title": "Concrete Constructions and the First Lower Bound f(N) ≥ 3",
+    "content": "Builds the base of the lower-bound ladder by hand. `singleton_one_squarefree_sumset` and `pair_1_3_not_squarefree_sumset` (showing {1,3} fails because 1+3 = 4 = 2²) illustrate the obstruction. Explicit `squarefree_N` facts (squarefree_2, _6, _10, _22, _26, _42, …) verify individual sums by `decide`/`norm_num`. `pair_1_5_squarefree_sumset` and `triple_1_5_21_squarefree_sumset` exhibit admissible sets, culminating in `f_ge_three`. Mod-4 and mod-9 lemmas (`residue_mod_4`, `not_div_9`, `same_residue_mod_4`, `no_sum_div_9`) plus monotonicity scaffolding (`empty_squarefree_sumset`, `subset_squarefree_sumset`, `f_monotone`) support the ladder.",
+    "mathContext": "The witness sets grow as {1}, {1,5}, {1,5,21}, … chosen so every pairwise sum avoids all $p^2$. E.g. {1,5,21}: sums 2,6,10,22,26,42 are all squarefree. Each explicit set gives $f(N) \\ge |A|$ for $N \\ge \\max A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "explicit extremal constructions",
+      "decide/norm_num verification",
+      "monotonicity of f"
+    ],
+    "prerequisites": [
+      "hasSquarefreeSumset",
+      "Finset.card",
+      "Nat.sqrt"
+    ]
+  },
+  {
+    "id": "ann-e1109-residue-bounds",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 594,
+      "endLine": 704
+    },
+    "type": "theorem",
+    "title": "Residue Constraints and Basic Lower Bounds",
+    "content": "Deeper residue-class analysis turning the avoidance constraints into structure. `forbidden_class_zero` and `forbidden_residue_sum` identify residues that A must avoid; `no_zero_element`, `elements_positive`, `elements_are_squarefree` pin down basic membership facts; `sumset_lower_bound` and `f_ge_one` give the trivial base of the ladder; `sumset_elements_squarefree` and `sumset_not_div_prime_sq` record that every sumset element is squarefree and avoids each p².",
+    "mathContext": "For a prime $p$, $p^2 \\mid a+b$ is forbidden, so the residues $\\{a \\bmod p^2\\}$ avoid the 'complementary' pairs summing to $0 \\bmod p^2$. This caps the number of admissible residues per prime — quantified in the counting sections that follow.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "forbidden residue classes",
+      "complementary pairs",
+      "ZMod arithmetic"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Nat.Prime",
+      "hasSquarefreeSumset"
+    ]
+  },
+  {
+    "id": "ann-e1109-multiprime-f2",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 727,
+      "endLine": 815
+    },
+    "type": "theorem",
+    "title": "Multiple-Prime Constraints and f(N) ≥ 2",
+    "content": "Combines constraints across primes. `self_sum_mod` analyzes 2a mod p²; `complementary_residue_exclusion` and `no_complementary_mod_9` show A cannot contain two elements whose residues are complementary mod 9; `mod_4_single_class` forces A into a single residue class mod 4. These culminate in `f_ge_two`, a rigorously proved (not merely exhibited) lower bound.",
+    "mathContext": "If $a \\equiv r,\\ b \\equiv 9-r \\pmod 9$ then $9 \\mid a+b$, forbidden — so A's mod-9 residues avoid complementary pairs. Simultaneously $4 \\nmid a+b$ forces all of A into one class mod 4. Intersecting these constraints still leaves room for $|A| \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "simultaneous residue constraints",
+      "complementary mod-9 pairs",
+      "single class mod 4"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Nat.ModEq"
+    ]
+  },
+  {
+    "id": "ann-e1109-mod25-framework",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 824,
+      "endLine": 934
+    },
+    "type": "theorem",
+    "title": "Mod 25 Constraints and the Residue-Counting Framework",
+    "content": "Extends the analysis to p = 5 and abstracts the counting machinery. `five_prime`, `not_div_25`, `no_sum_div_25`, `forbidden_class_zero_25`, `no_complementary_mod_25` are the mod-25 analogs of the mod-9 results. The general framework lemmas `residue_class_zero_forbidden`, `sum_residue_nonzero`, `residue_image_avoids_zero`, `mod_4_residue_image_small`, and `self_sum_not_div_9` package 'how many residues mod p² can A occupy' as a reusable counting tool.",
+    "mathContext": "For each prime $p$, the admissible residues of A mod $p^2$ form a set avoiding $0$ and closed under no complementary pair; its size is at most $\\approx (p^2 - p)/2 + 1$. The framework lemmas express this as a bound on the image of $A$ under reduction mod $p^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "residue image counting",
+      "mod p² constraints",
+      "reusable counting framework"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Finset.image",
+      "Finset.card"
+    ]
+  },
+  {
+    "id": "ann-e1109-count-mod9",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 950,
+      "endLine": 1014
+    },
+    "type": "theorem",
+    "title": "Counting Allowed Residues mod 9",
+    "content": "A complete case analysis of admissible residues mod 9. `mod_9_class_0_forbidden` rules out 0; the four pair lemmas `mod_9_pair_1_8`, `mod_9_pair_2_7`, `mod_9_pair_3_6`, `mod_9_pair_4_5` show each complementary pair {r, 9−r} can contribute at most one residue. Together they yield `mod_9_residue_image_le_4`: the image of A mod 9 has at most 4 elements.",
+    "mathContext": "Residues mod 9 are {0,…,8}; 0 is forbidden ($9 \\mid 2a$ excluded) and the four pairs $\\{1,8\\},\\{2,7\\},\\{3,6\\},\\{4,5\\}$ each lose one member (complementary sums hit $0 \\bmod 9$). Hence $|A \\bmod 9| \\le 4$, a multiplicative factor $4/9$ in the density bound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exhaustive residue case analysis",
+      "complementary-pair counting",
+      "density factor per prime"
+    ],
+    "prerequisites": [
+      "ZMod 9",
+      "Finset.card",
+      "decide"
+    ]
+  },
+  {
+    "id": "ann-e1109-count-mod25",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 1314,
+      "endLine": 1515
+    },
+    "type": "theorem",
+    "title": "Counting Allowed Residues mod 25",
+    "content": "The p = 5 analog of the mod-9 count, but with 25 residues the case analysis is much larger. `no_complementary_mod_25_general` establishes that complementary residues mod 25 cannot coexist, and the headline `mod_25_residue_image_le_12` bounds the image of A mod 25 by 12 residues. This is the density factor 12/25 contributed by the prime 5.",
+    "mathContext": "Mod 25: exclude $0$ and one of each complementary pair $\\{r, 25-r\\}$ for $r = 1,\\dots,12$, leaving at most 12 admissible residues, i.e. density factor $12/25$. Multiplying $4/9 \\cdot 12/25 \\cdots$ across primes drives the upper bound on $f(N)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mod 25 residue counting",
+      "density factor 12/25",
+      "complementary pairs"
+    ],
+    "prerequisites": [
+      "ZMod 25",
+      "Finset.card"
+    ]
+  },
+  {
+    "id": "ann-e1109-density-f4",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 1532,
+      "endLine": 1642
+    },
+    "type": "theorem",
+    "title": "General Density Framework and f(N) ≥ 4",
+    "content": "Abstracts the per-prime counting into a reusable density statement. `no_complementary_pair_general` and `density_per_prime` give, for an arbitrary prime, the admissible-residue bound. The explicit set {1,5,21,37} (`quad_1_5_21_37_squarefree_sumset`, with supporting squarefree_38/58/74 facts) then proves `f_ge_four`.",
+    "mathContext": "`density_per_prime` packages 'A occupies $\\le c_p$ residues mod $p^2$' uniformly in $p$. The witness $\\{1,5,21,37\\}$ has all $\\binom{4}{2}+4 = 10$ pairwise sums squarefree, giving $f(N) \\ge 4$ for $N \\ge 37$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "general density framework",
+      "explicit quadruple construction",
+      "per-prime residue bound"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "hasSquarefreeSumset"
+    ]
+  },
+  {
+    "id": "ann-e1109-ladder-f5-f6",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 1678,
+      "endLine": 1991
+    },
+    "type": "theorem",
+    "title": "Extending the Ladder: f(N) ≥ 5 and ≥ 6, and the General Residue Count",
+    "content": "Continues the explicit ladder. {1,5,21,37,41} gives `f_ge_five` and {1,5,21,37,41,65} gives `f_ge_six`, each backed by `squarefree_N` verifications. Between them, `general_residue_image_le` (a ~90-line theorem) proves the uniform residue-image bound for an arbitrary prime power — the engine that makes the per-prime density factors rigorous rather than case-by-case.",
+    "mathContext": "The witness sets extend by appending one admissible element at a time: {1,5,21,37,41}, {1,5,21,37,41,65}. `general_residue_image_le` shows $|A \\bmod p^2| \\le (p^2-p)/2 + 1$ for every prime $p$, generalizing the explicit mod-9 and mod-25 counts.",
+    "significance": "key",
+    "relatedConcepts": [
+      "explicit ladder constructions",
+      "general residue-image bound",
+      "uniform per-prime counting"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Finset.image",
+      "hasSquarefreeSumset"
+    ]
+  },
+  {
+    "id": "ann-e1109-crt",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 2002,
+      "endLine": 2234
+    },
+    "type": "theorem",
+    "title": "Coprime Moduli and the CRT Residue Bound",
+    "content": "Combines per-prime constraints across distinct primes via the Chinese Remainder Theorem — the key to a *multiplicative* density bound. `coprime_prime_sq` (distinct primes give coprime squares), `crt_residue_injective` (residues mod ∏p² are determined by the component residues), and `combined_residue_bound` multiply the individual factors. Worked instances `mod_36_residue_image_le_4` (= mod 4 × mod 9) and `mod_900_residue_image_le_48` (= mod 4 × mod 9 × mod 25) show the product bound in action.",
+    "mathContext": "By CRT, $\\mathbb{Z}/(p_1^2 p_2^2 \\cdots) \\cong \\prod \\mathbb{Z}/p_i^2$, so $|A \\bmod \\prod p_i^2| \\le \\prod c_{p_i}$. E.g. mod 900 = 4·9·25: $|A \\bmod 900| \\le 1 \\cdot 4 \\cdot 12 = 48$ (the file's bound), giving density $\\le 48/900$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "multiplicative density product",
+      "ZMod.chineseRemainder"
+    ],
+    "prerequisites": [
+      "Nat.Coprime",
+      "ZMod.chineseRemainder",
+      "Finset.image"
+    ]
+  },
+  {
+    "id": "ann-e1109-ladder-f7-f10",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 2280,
+      "endLine": 2798
+    },
+    "type": "theorem",
+    "title": "Explicit Constructions: f(N) ≥ 7, 8, 9, 10",
+    "content": "The high end of the lower-bound ladder, each a hand-built set with all pairwise sums verified squarefree: {…,73} → `f_ge_seven`, {…,101} → `f_ge_eight`, the 9-element `nona_…` → `f_ge_nine`, and the 10-element `deca_1_5_21_37_41_65_73_101_137_165` → `f_ge_ten`. Dozens of supporting `squarefree_N` lemmas discharge the individual sum checks.",
+    "mathContext": "The maximal explicit witness is $\\{1,5,21,37,41,65,73,101,137,165\\}$ (10 elements); all $\\binom{10}{2}+10 = 55$ pairwise sums are squarefree, certifying $f(N) \\ge 10$ for $N \\ge 165$. Each step appends a single residue-compatible element.",
+    "significance": "key",
+    "relatedConcepts": [
+      "explicit extremal sets",
+      "exhaustive sum verification",
+      "lower-bound ladder"
+    ],
+    "prerequisites": [
+      "hasSquarefreeSumset",
+      "Finset.card",
+      "decide"
+    ]
+  },
+  {
+    "id": "ann-e1109-crt-upper",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 2817,
+      "endLine": 3176
+    },
+    "type": "theorem",
+    "title": "CRT Density Upper Bounds and the f(N) Sandwich",
+    "content": "Turns the multiplicative residue bounds into genuine *upper* bounds on f(N). `mod_44100_residue_image_le_1152` (4·9·25·49) and `mod_5336100_residue_image_le_69120` (adding 121) compute residue-image bounds for products of four and five prime squares. `fiber_card_bound` and `density_from_residues` convert a residue-image bound into a density (hence cardinality) bound, yielding `f_upper_44100` and `f_upper_5336100`. `f_sandwich` and `density_improvement_chain` combine these upper bounds with the lower-bound ladder, and `two_prime_density` records the base case.",
+    "mathContext": "If $A \\subseteq \\{0,\\dots,N\\}$ occupies $\\le R$ residues mod $M = \\prod p_i^2$, then $|A| \\le R\\lceil N/M\\rceil$, so $f(N) \\le (R/M)N + O(1)$. With $M = 44100,\\ R = 1152$ the density is $\\le 1152/44100 \\approx 0.026$; adding more primes drives it toward the conjectured subpolynomial behaviour.",
+    "significance": "key",
+    "relatedConcepts": [
+      "density-to-cardinality bound",
+      "CRT product of residue images",
+      "upper bound on f(N)"
+    ],
+    "prerequisites": [
+      "ZMod.chineseRemainder",
+      "Finset.card",
+      "Nat.div"
+    ]
+  },
+  {
+    "id": "ann-e1109-f11-final",
+    "proofId": "erdos-1109",
+    "range": {
+      "startLine": 3253,
+      "endLine": 3710
+    },
+    "type": "theorem",
+    "title": "f(N) ≥ 11, ≥ 12, and the Complete Bound Chain",
+    "content": "The top of the ladder and the file's concluding theorems. The 11-element `undeca_…squarefree_sumset` proves `f_ge_eleven` and the 12-element `dodeca_…` proves `f_ge_twelve` — large explicit certificates. `f_sublinear` records the sublinear (subpolynomial-flavored) growth target, and `f_complete_bounds` / `f_lower_bound_chain` assemble the full ladder f(N) ≥ 2, 3, …, 12 together with the CRT upper bounds into the file's summary of what is now machine-verified about f(N).",
+    "mathContext": "The 12-element witness pushes the explicit lower bound to $f(N) \\ge 12$ for the corresponding $N$, while the CRT density product gives matching upper bounds. The chain $f(N) \\ge 2,3,\\dots,12$ plus density upper bounds brackets $f$ on concrete ranges, complementing Konyagin's asymptotic axioms.",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal explicit construction",
+      "complete bound chain",
+      "sublinear growth"
+    ],
+    "prerequisites": [
+      "hasSquarefreeSumset",
+      "Finset.card",
+      "f_monotone"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-1109` (Squarefree Sumsets), a 3713-line / 30-section file. The 10 existing annotations were all descriptive and covered only the first ~253 lines (intro, history, open questions); the entire formal body — the constructive f(N) lower-bound ladder and the CRT density upper bounds — had zero coverage.

## Changes

- **Realigned all 10 descriptive annotations** to real constructs (2 were anchored on blank lines; others sat on section-header comments rather than the defs/theorems they describe).
- **Fixed a factual error.** The "related problems" annotation displayed an `axiom connection_to_1103` that does not exist in the file. The file has exactly two axioms — `konyagin_lower_2004` and `konyagin_upper_2004` — matching `axiomCount: 2`. Rewrote the annotation around the actual `isKPowerFree` definition, presenting the #1103 link as context rather than a (nonexistent) axiom.
- **Added 12 annotations** covering lines 230–3710: structural constraints (`all_odd`, `element_squarefree`), the explicit lower-bound ladder f(N) ≥ 3…12 (the `pair`/`triple`/…/`dodeca` constructions and `f_ge_*` theorems), residue counting mod 9 and mod 25, the general density framework, the CRT residue-product bounds (`mod_900`, `mod_44100`, `mod_5336100`), and the density-to-cardinality upper bounds that sandwich f(N).

Coverage now spans the full file (was capped at line 253). All 22 annotations pass `resolver.ts validate`.

## Verification

- `resolver.ts validate` → 22 valid, 0 misaligned (was 10 valid / 2 misaligned)
- meta.json axiom integrity confirmed: exactly 2 axioms, 0 sorries, no assumption-carrying structures; `axiomCount: 2`, `badge: axiom`, `status: axiomatized` — no changes needed.
- Only `erdos-1109/annotations.json` changed.