### PR TITLE
Enrich Erdős #193 (Collinear Lattice Walks): realign + cover §8–§14 (10→17)

### DIFF
--- a/src/data/proofs/erdos-193/annotations.json
+++ b/src/data/proofs/erdos-193/annotations.json
@@ -164,7 +164,7 @@
       "endLine": 72
     },
     "title": "Collinearity Reflexivity",
-    "content": "Any point $p$ is collinear with $q$ and $p$: AreCollinear$(p, q, p)$ holds with $a = 1, b = 0$, verified by `ring`. This is a degenerate case where the third point coincides with the first.",
+    "content": "`collinear_refl`: any point $p$ is collinear with $q$ and $p$: AreCollinear$(p, q, p)$ holds with $a = 1, b = 0$, verified by `ring`. This is a degenerate case where the third point coincides with the first.",
     "mathContext": "AreCollinear$(p, q, p)$: take $a = 1, b = 0$. Then $1 \\cdot (q_j - p_j) = 0 \\cdot (p_j - p_j)$ simplifies to $q_j - p_j = 0$, but actually `ring` handles this directly.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -179,13 +179,13 @@
   {
     "id": "erdos-193-collinear-symm",
     "proofId": "erdos-193",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 74,
-      "endLine": 76
+      "startLine": 75,
+      "endLine": 86
     },
     "title": "Collinearity Symmetry",
-    "content": "Collinearity is symmetric in the outer points: AreCollinear$(p, q, r) \\implies$ AreCollinear$(r, q, p)$. Axiomatized since the proof requires swapping roles of the integer witnesses.",
+    "content": "`collinear_symm` proves collinearity is symmetric in the outer points: AreCollinear$(p, q, r) \\implies$ AreCollinear$(r, q, p)$. This is a fully proved theorem (not an axiom — the file's only axiom is `gerver_ramsey_2d`): swapping the roles of the integer witnesses $(a,b) \\mapsto (b,a)$ and rearranging the defining equation discharges it.",
     "mathContext": "If $a(q_j - p_j) = b(r_j - p_j)$, then $b(q_j - r_j) = a(p_j - r_j)$, giving AreCollinear$(r, q, p)$ with witnesses $(b, a)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -199,13 +199,13 @@
   {
     "id": "erdos-193-collinear-const",
     "proofId": "erdos-193",
-    "type": "concept",
+    "type": "theorem",
     "range": {
-      "startLine": 78,
-      "endLine": 80
+      "startLine": 88,
+      "endLine": 90
     },
     "title": "Constant Walk Collinearity",
-    "content": "A constant walk (all points equal to $v$) has AreCollinear$(v, v, v)$ trivially. This shows the injectivity requirement is necessary — without it, any walk revisiting a point immediately gives collinear triples.",
+    "content": "`collinear_const`: a constant walk (all points equal to $v$) has AreCollinear$(v, v, v)$ trivially. This shows the injectivity requirement is necessary — without it, any walk revisiting a point immediately gives collinear triples.",
     "mathContext": "AreCollinear$(v, v, v)$: all difference vectors are zero, so any non-zero $(a, b)$ satisfies $a \\cdot 0 = b \\cdot 0$. This motivates requiring $w$ injective in the conjecture.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -214,6 +214,160 @@
     ],
     "prerequisites": [
       "collinear_refl"
+    ]
+  },
+  {
+    "id": "erdos-193-collinear-perm12",
+    "proofId": "erdos-193",
+    "type": "theorem",
+    "range": {
+      "startLine": 92,
+      "endLine": 103
+    },
+    "title": "Collinearity Under Swapping the First Two Points",
+    "content": "`collinear_perm12` proves AreCollinear$(p, q, r) \\implies$ AreCollinear$(q, p, r)$. Together with `collinear_symm` and `collinear_refl`, this gives the full permutation symmetry of the collinearity predicate, so the *unordered* triple $\\{p,q,r\\}$ is what matters — a convenience used repeatedly when reindexing walk points.",
+    "mathContext": "Collinearity of a triple is invariant under all $3! = 6$ permutations. `perm12` (swap first two) plus `symm` (swap outer two) generate the symmetric group $S_3$, so any reordering preserves AreCollinear.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "permutation invariance",
+      "symmetric group S₃",
+      "unordered triples"
+    ],
+    "prerequisites": [
+      "AreCollinear definition",
+      "collinear_symm"
+    ]
+  },
+  {
+    "id": "erdos-193-dim1",
+    "proofId": "erdos-193",
+    "type": "theorem",
+    "range": {
+      "startLine": 107,
+      "endLine": 122
+    },
+    "title": "Dimension 1: Collinearity is Automatic",
+    "content": "`collinear_dim1` shows that in $\\mathbb{Z}^1$ ANY three points are collinear (one coordinate means all difference vectors are integer-parallel), and `erdos193_dim1` concludes the conjecture holds trivially for $d = 1$. This is the base case of the dimension induction: the interesting content lives in $d \\geq 2$.",
+    "mathContext": "In $\\mathbb{Z}^1$, points are integers $p, q, r$; the differences $q-p, r-p$ are scalars, so $(r-p)(q-p) = (q-p)(r-p)$ gives witnesses $a = r-p$, $b = q-p$ (one nonzero unless points coincide). Hence every walk of length $\\ge 3$ has a collinear triple.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "base case of dimension induction",
+      "1D triviality"
+    ],
+    "prerequisites": [
+      "AreCollinear definition",
+      "HasThreeCollinear"
+    ]
+  },
+  {
+    "id": "erdos-193-singleton",
+    "proofId": "erdos-193",
+    "type": "theorem",
+    "range": {
+      "startLine": 126,
+      "endLine": 158
+    },
+    "title": "Singleton Step Sets: Walks on a Single Direction",
+    "content": "When the step set is a singleton $S = \\{s\\}$, every step is identical, so the walk is the arithmetic progression $w(n) = w(0) + n\\,s$. `singleton_walk_pos` records the closed form, `singleton_step_collinear` shows any three of its points are collinear (they lie on one line), and `erdos193_singleton` concludes the conjecture for singleton step sets. This is the simplest nontrivial structural case.",
+    "mathContext": "With $S = \\{s\\}$: $w(n) = w(0) + n s$, so $w(j) - w(i) = (j-i)s$. For indices $i<j<k$, $w(j)-w(i) = (j-i)s$ and $w(k)-w(i) = (k-i)s$ are parallel via $(k-i)(w(j)-w(i)) = (j-i)(w(k)-w(i))$ — collinear with integer witnesses.",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetic progression",
+      "collinear by construction",
+      "single-direction walk"
+    ],
+    "prerequisites": [
+      "IsStepWalk",
+      "AreCollinear definition"
+    ]
+  },
+  {
+    "id": "erdos-193-parallel",
+    "proofId": "erdos-193",
+    "type": "concept",
+    "range": {
+      "startLine": 162,
+      "endLine": 216
+    },
+    "title": "Parallel Step Sets: All Steps Along One Line",
+    "content": "`IsParallelStepSet S` captures step sets whose elements are all integer-multiples of a common direction $v$. `parallel_walk_on_line` shows such a walk stays on the affine line through $w(0)$ with direction $v$, `line_points_collinear` proves any three points on a line are collinear, and `parallel_step_collinear` + `erdos193_parallel` conclude the conjecture for all parallel step sets. This generalizes the singleton case from one step to many collinear steps.",
+    "mathContext": "If every $s \\in S$ satisfies $s = c_s v$ for a fixed $v$ and integers $c_s$, then $w(n) = w(0) + \\big(\\sum_{i<n} c_{s_i}\\big) v$ lies on the line $\\{w(0) + t v\\}$. Any three points on a single line are collinear, so the walk has a collinear triple regardless of injectivity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "collinear step set",
+      "affine line",
+      "common direction vector"
+    ],
+    "prerequisites": [
+      "IsStepWalk",
+      "AreCollinear definition"
+    ]
+  },
+  {
+    "id": "erdos-193-translate",
+    "proofId": "erdos-193",
+    "type": "theorem",
+    "range": {
+      "startLine": 220,
+      "endLine": 226
+    },
+    "title": "Collinearity is Translation-Invariant",
+    "content": "`collinear_translate` proves AreCollinear$(p,q,r) \\iff$ AreCollinear$(p+t, q+t, r+t)$ for any shift $t$. Since collinearity depends only on difference vectors, translating all three points by the same vector leaves it unchanged — a normalization used to assume $w(0) = 0$ without loss of generality.",
+    "mathContext": "AreCollinear depends on $q-p$ and $r-p$; replacing $p,q,r$ by $p+t,q+t,r+t$ leaves both differences identical, so the witnesses $(a,b)$ are unchanged. Translation invariance lets proofs fix the basepoint at the origin.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "translation invariance",
+      "difference-vector dependence",
+      "WLOG basepoint at origin"
+    ],
+    "prerequisites": [
+      "AreCollinear definition"
+    ]
+  },
+  {
+    "id": "erdos-193-2d-span",
+    "proofId": "erdos-193",
+    "type": "theorem",
+    "range": {
+      "startLine": 230,
+      "endLine": 264
+    },
+    "title": "2D-Span Position Formula",
+    "content": "`walk_in_2d_span` expresses a walk whose steps lie in a 2-dimensional span via integer coordinates against two basis directions, and `collinear_from_2d_coords` reduces collinearity of three such points to a 2×2 integer-determinant (cross-product) vanishing condition. This is the bridge that lets a higher-dimensional walk confined to a 2D affine subspace inherit the Gerver–Ramsey ℤ² result.",
+    "mathContext": "If every step is $s = \\alpha_s u + \\beta_s v$ for fixed $u,v$, then $w(n) - w(0) = X_n u + Y_n v$ with integer accumulated coordinates $(X_n, Y_n)$. Three points are collinear iff the $2\\times2$ determinant $\\det\\begin{pmatrix} X_j - X_i & Y_j - Y_i \\\\ X_k - X_i & Y_k - Y_i\\end{pmatrix} = 0$ — exactly the 2D collinearity test.",
+    "significance": "key",
+    "relatedConcepts": [
+      "2D coordinate representation",
+      "cross-product / determinant test",
+      "affine subspace confinement"
+    ],
+    "prerequisites": [
+      "AreCollinear definition",
+      "integer linear algebra"
+    ]
+  },
+  {
+    "id": "erdos-193-dim-reduction",
+    "proofId": "erdos-193",
+    "type": "concept",
+    "range": {
+      "startLine": 268,
+      "endLine": 389
+    },
+    "title": "Dimension Reduction: Rank-≤2 Walks Reduce to Gerver–Ramsey",
+    "content": "The file's structural heart. `SpansAtMost2D` characterizes step sets contained in a 2D lattice subspace; `accumCoords` and `accumCoords_repr` give the integer-coordinate representation of the walk in that subspace. `erdos193_rank_le_2` (the ~60-line keystone) proves the conjecture for any step set spanning at most 2 dimensions — by transporting the walk to $\\mathbb{Z}^2$ and invoking `gerver_ramsey_2d`. Finally `erdos193_reduces_to_full_rank` shows the open 3D problem reduces to the *full-rank* case: if the steps span all of $\\mathbb{Z}^3$, no lower-dimensional shortcut applies, isolating exactly where the difficulty lives.",
+    "mathContext": "A walk whose steps span a rank-$\\le 2$ sublattice embeds into $\\mathbb{Z}^2$ via $w(n) \\mapsto (X_n, Y_n)$; collinearity is preserved (cross-product test), so Gerver–Ramsey supplies the collinear triple. Thus Erdős #193 for $d=3$ is equivalent to its full-rank (genuinely 3-dimensional) instances — the rank-2 part is already a theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dimension reduction",
+      "rank of a step set",
+      "reduction to Gerver–Ramsey",
+      "full-rank residual problem"
+    ],
+    "prerequisites": [
+      "gerver_ramsey_2d",
+      "collinear_from_2d_coords",
+      "walk_in_2d_span"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-193` (Collinear Points in Lattice Walks). The 10 annotations covered only the definitions and first three lemmas (lines 14–80); the structural theorems in §8–§14 — including the rank-≤2 dimension-reduction keystone — were uncovered, and one annotation had a factual error.

## Changes

- **Fixed a factual error.** `collinear_symm` was annotated as "Axiomatized since the proof requires swapping witnesses," but it is a fully proved `theorem` (lines 77–86). The file's only axiom is `gerver_ramsey_2d` (matching `axiomCount: 1`). Corrected the content.
- **Realigned misaligned ranges.** `collinear_symm` was anchored on a blank line (74); `collinear_const` pointed into `collinear_symm`'s proof body. Both now anchor on their actual theorems.
- **Added 7 annotations** covering §8–§14: permutation symmetry (`collinear_perm12`), the d=1 base case, singleton step sets (arithmetic-progression walks), parallel step sets (walks on one line), translation invariance, the 2D-span position formula (cross-product collinearity test), and the **rank-≤2 dimension-reduction keystone** (`erdos193_rank_le_2`, `erdos193_reduces_to_full_rank`) that reduces the open 3D problem to Gerver–Ramsey ℤ².

Coverage now spans the full file (was capped at line 80). All 17 annotations pass `resolver.ts validate`.

## Verification

- `resolver.ts validate` → 17 valid, 0 misaligned (was 9 valid / 1 misaligned)
- meta.json axiom integrity confirmed: exactly 1 axiom (`gerver_ramsey_2d`), 0 sorries, no assumption-carrying structures.
- Only `erdos-193/annotations.json` changed.