### PR TITLE
Enrich Schauder/Kakutani (oq-03-oq-01): realign + cover construction (9→14)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/annotations.json
@@ -3,12 +3,12 @@
     "id": "ann-setvalued-map-def",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 50,
-      "endLine": 55
+      "startLine": 70,
+      "endLine": 75
     },
     "type": "definition",
     "title": "Set-Valued Maps and Fixed Points",
-    "content": "Defines the fundamental objects: a set-valued map (correspondence) $F : X \\to 2^Y$ assigns to each point $x$ a subset $F(x)$ of the codomain. A fixed point satisfies $x \\in F(x)$, generalizing the single-valued equation $f(x) = x$ to inclusion in the image set.",
+    "content": "Defines the fundamental objects: a set-valued map (correspondence) `SetValuedMap` assigns to each point $x$ a subset $F(x)$ of the codomain, and `IsFixedPoint` holds when $x \\in F(x)$, generalizing the single-valued equation $f(x) = x$ to inclusion in the image set.",
     "mathContext": "A set-valued map $F : X \\to 2^X$ has a fixed point $x^*$ if $x^* \\in F(x^*)$. This generalizes the single-valued condition $f(x^*) = x^*$ and is the natural framework for equilibrium theory.",
     "significance": "key",
     "relatedConcepts": [
@@ -26,12 +26,12 @@
     "id": "ann-uhc-def",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 57,
-      "endLine": 61
+      "startLine": 77,
+      "endLine": 80
     },
     "type": "definition",
     "title": "Upper Hemicontinuity",
-    "content": "Upper hemicontinuity (UHC) is the set-valued analogue of continuity: $F$ is UHC if for every open set $V$, the upper preimage $\\{x \\mid F(x) \\subseteq V\\}$ is open. Intuitively, the image sets cannot suddenly 'jump outward'. This is the correct continuity notion for Kakutani's theorem — lower hemicontinuity would not suffice.",
+    "content": "`IsUpperHemicontinuous` is the set-valued analogue of continuity: $F$ is UHC if for every open set $V$, the upper preimage $\\{x \\mid F(x) \\subseteq V\\}$ is open. Intuitively, the image sets cannot suddenly 'jump outward'. This is the correct continuity notion for Kakutani's theorem — lower hemicontinuity would not suffice.",
     "mathContext": "$F$ is upper hemicontinuous if $\\{x \\mid F(x) \\subseteq V\\}$ is open for every open $V$. Equivalently, if $x_n \\to x$ and $y_n \\in F(x_n)$ with $y_n \\to y$, then $y \\in F(x)$ (when values are compact).",
     "significance": "key",
     "relatedConcepts": [
@@ -45,21 +45,44 @@
     ]
   },
   {
+    "id": "ann-uhc-thickening",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 161
+    },
+    "type": "concept",
+    "title": "UHC Local Thickening Lemmas",
+    "content": "The technical workhorses translating upper hemicontinuity into the explicit open covers the selection construction needs. `uhc_local_thickening`: around each input x there is a radius δ so that all nearby inputs map into an ε-thickening of F(x). `uhc_local_thickening_with_input_diameter` refines this to also control the diameter of the input neighborhood — needed so the partition-of-unity pieces have small support in *both* input and output.",
+    "mathContext": "UHC ⟹ for every $x$ and $\\varepsilon>0$ there is $\\delta>0$ with $F(B(x,\\delta)) \\subseteq B(F(x), \\varepsilon)$. The refined version additionally bounds the input ball radius, yielding a cover whose mesh is controlled on both sides — the metric form of UHC used throughout Part II.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "open cover from UHC",
+      "thickening / ε-neighborhood",
+      "uniform control"
+    ],
+    "prerequisites": [
+      "IsUpperHemicontinuous",
+      "metric balls"
+    ]
+  },
+  {
     "id": "ann-brouwer-axiom",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 66,
-      "endLine": 77
+      "startLine": 167,
+      "endLine": 200
     },
     "type": "concept",
-    "title": "Axiom 1: Brouwer's Fixed Point Theorem",
-    "content": "Brouwer's FPT (1911) states that every continuous self-map of a nonempty compact convex set in $\\mathbb{R}^n$ has a fixed point. Here it is axiomatized for general compact convex subsets of Euclidean space, stated as: for any continuous $f : S \\to S$ with $S$ nonempty, compact, and convex, $\\exists x \\in S$ with $f(x) = x$. Mathlib proves this for closed unit balls; the general case follows by homeomorphism but is stated as an axiom here for modularity.",
-    "mathContext": "If $S \\subseteq \\mathbb{R}^n$ is nonempty, compact, convex, and $f : S \\to S$ is continuous, then $\\exists x \\in S$ such that $f(x) = x$.",
+    "title": "Axiom 1: Brouwer's Fixed Point Theorem (Closed Unit Ball)",
+    "content": "Brouwer's FPT (1911) on the **closed unit ball**: `axiom brouwer_unit_ball` states every continuous self-map of the closed unit ball in $\\mathbb{R}^n$ has a fixed point. This is one of the file's two axioms (axiomCount = 2). Mathlib has a closed-ball Brouwer result, but it is axiomatized here for modularity; the *general* compact-convex case is then **derived** as the theorem `brouwer_fpt` (below) via a continuous retraction, not assumed.",
+    "mathContext": "Axiom: for continuous $f : \\overline{B^n} \\to \\overline{B^n}$, $\\exists x$ with $f(x) = x$. The compact-convex generalization follows by composing with a retraction $r : \\overline{B^n} \\to S$ and the inclusion $S \\hookrightarrow \\overline{B^n}$.",
     "significance": "key",
     "relatedConcepts": [
       "Schauder fixed point theorem",
       "Lefschetz fixed point theorem",
-      "degree theory"
+      "degree theory",
+      "retraction"
     ],
     "prerequisites": [
       "compact sets",
@@ -68,21 +91,68 @@
     ]
   },
   {
+    "id": "ann-proj-convex",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 202,
+      "endLine": 328
+    },
+    "type": "lemma",
+    "title": "Continuous Retraction onto a Compact Convex Set",
+    "content": "`exists_continuous_proj_convex` (a ~110-line lemma) builds the continuous nearest-point projection onto a nonempty compact convex set $S \\subseteq \\mathbb{R}^n$. This retraction is the device that lifts Brouwer from the unit ball to arbitrary compact convex sets: rescale $S$ into a ball, solve the fixed-point problem there, and project the result back into $S$.",
+    "mathContext": "For nonempty compact convex $S$, the metric projection $\\pi_S(x) = \\arg\\min_{s\\in S}\\|x-s\\|$ is well-defined (existence + uniqueness from convexity) and 1-Lipschitz (hence continuous). It restricts to the identity on $S$, i.e. it is a retraction $\\mathbb{R}^n \\to S$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "metric projection",
+      "nearest-point map",
+      "retraction",
+      "convex geometry"
+    ],
+    "prerequisites": [
+      "convexity",
+      "compactness",
+      "Lipschitz continuity"
+    ]
+  },
+  {
+    "id": "ann-brouwer-fpt",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 330,
+      "endLine": 516
+    },
+    "type": "theorem",
+    "title": "Brouwer's FPT on Compact Convex Sets (Derived)",
+    "content": "`brouwer_fpt` (a ~145-line theorem) proves the general compact-convex Brouwer theorem *from* the unit-ball axiom and the retraction lemma. Given continuous $f : S \\to S$ with $S$ compact convex, embed $S$ in a ball, extend $f$ to the ball via the projection, apply `brouwer_unit_ball`, and check the resulting fixed point lies in $S$. This is the single-valued engine that the Kakutani argument calls at each approximation level.",
+    "mathContext": "For compact convex $S$ and continuous $f : S \\to S$: define $g = f \\circ \\pi_S$ on a ball $\\supseteq S$; $g$ has a fixed point $x^*$ by the axiom; since $g$ maps into $S$, $x^* \\in S$ and $\\pi_S(x^*) = x^*$, so $f(x^*) = x^*$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Brouwer fixed point theorem",
+      "retraction argument",
+      "compact convex domain"
+    ],
+    "prerequisites": [
+      "brouwer_unit_ball",
+      "exists_continuous_proj_convex"
+    ]
+  },
+  {
     "id": "ann-approx-selection-def",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 79,
-      "endLine": 83
+      "startLine": 518,
+      "endLine": 532
     },
     "type": "definition",
-    "title": "Approximate Continuous Selections",
-    "content": "An $\\varepsilon$-approximate selection of $F$ is a continuous function $f$ such that for every $x$, $f(x)$ lies within distance $\\varepsilon$ of $F(x)$. This is the key bridge between single-valued (Brouwer) and set-valued (Kakutani) fixed point theory: one reduces the set-valued problem to a family of single-valued approximations.",
-    "mathContext": "$f$ is an $\\varepsilon$-approximate selection of $F$ if $\\forall x, \\exists y \\in F(x)$ with $d(f(x), y) < \\varepsilon$. Cellina (1969) proved these exist for UHC maps with convex values using partitions of unity.",
+    "title": "Graph-Approximate Continuous Selections",
+    "content": "`IsGraphApproxSelection` formalizes an $\\varepsilon$-approximate selection: a continuous function $f$ whose graph lies within $\\varepsilon$ of the graph of $F$ — for every $x$, $(x, f(x))$ is within $\\varepsilon$ of some $(x', y)$ with $y \\in F(x')$. This graph-distance formulation is the key bridge between single-valued (Brouwer) and set-valued (Kakutani) fixed point theory.",
+    "mathContext": "$f$ is a graph-$\\varepsilon$-approximate selection of $F$ if $\\forall x,\\ \\exists (x',y)$ with $y \\in F(x')$ and $\\|(x,f(x)) - (x',y)\\| < \\varepsilon$. Cellina (1969) proved these exist for UHC maps with convex values using partitions of unity.",
     "significance": "key",
     "relatedConcepts": [
       "Michael selection theorem",
       "partition of unity",
-      "Cellina approximation"
+      "Cellina approximation",
+      "graph distance"
     ],
     "prerequisites": [
       "metric spaces",
@@ -93,18 +163,19 @@
     "id": "ann-approx-selection-axiom",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 85,
-      "endLine": 106
+      "startLine": 534,
+      "endLine": 571
     },
     "type": "concept",
-    "title": "Axiom 2: Existence of Approximate Selections",
-    "content": "This axiom states that for a UHC map $F$ with nonempty convex values on a compact convex set, continuous $\\varepsilon$-approximate selections exist for every $\\varepsilon > 0$. The proof sketch in the docstring uses: (1) for each $x$, pick $y_x \\in F(x)$ and use UHC to get a neighborhood $U_x$; (2) extract a finite subcover by compactness; (3) take a subordinate partition of unity $\\{\\varphi_i\\}$; (4) define $f(x) = \\sum \\varphi_i(x) \\cdot y_{x_i}$. Convexity of both $S$ and $F(x)$ ensures $f$ maps into the correct sets.",
-    "mathContext": "Given compact convex $S$, UHC $F : S \\to 2^S$ with nonempty convex values, and $\\varepsilon > 0$: $\\exists f : S \\to S$ continuous with $\\forall x, \\exists y \\in F(x), d(f(x), y) < \\varepsilon$. The construction uses partitions of unity subordinate to an open cover derived from UHC.",
+    "title": "Axiom 2: Existence of Graph-Approximate Selections",
+    "content": "The file's second axiom (`approx_selection_exists`): for a UHC map $F$ with nonempty convex values on a compact convex set, continuous graph-$\\varepsilon$-approximate selections exist for every $\\varepsilon > 0$. Although axiomatized, the file then develops (lines 573–1225) most of the constructive machinery for this statement — partition of unity, Lebesgue number, finite subcover, convex combinations — so the axiom is a documented target for future elimination rather than an opaque assumption.",
+    "mathContext": "Given compact convex $S$, UHC $F : S \\to 2^S$ with nonempty convex values, and $\\varepsilon > 0$: $\\exists f : S \\to S$ continuous that is a graph-$\\varepsilon$-approximate selection. The construction uses a partition of unity subordinate to a UHC-derived open cover, with values $f(x) = \\sum_i \\varphi_i(x)\\, y_i$.",
     "significance": "key",
     "relatedConcepts": [
       "partition of unity",
       "convex combination",
-      "UHC open cover"
+      "UHC open cover",
+      "axiom elimination roadmap"
     ],
     "prerequisites": [
       "partitions of unity",
@@ -113,21 +184,69 @@
     ]
   },
   {
+    "id": "ann-selection-construction-cover",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 573,
+      "endLine": 939
+    },
+    "type": "concept",
+    "title": "Building the Selection: Cover, Lebesgue Number, and Partition of Unity",
+    "content": "The first half of the constructive selection machinery (toward eliminating Axiom 2). `convex_combination_of_partition_in_S` keeps weighted averages inside the convex set; `typeclass_witnesses_compact_subset` and `exists_finite_subcover_for_uhc` extract a finite UHC-cover by compactness; `exists_lebesgue_subcover_for_uhc` supplies a Lebesgue number making the cover mesh uniform; `exists_partition_subordinate_to_uhc_cover` builds a partition of unity subordinate to it; and `exists_continuous_selection_with_witnesses` assembles these into a continuous map $f(x) = \\sum_i \\varphi_i(x) y_i$.",
+    "mathContext": "Compactness ⟹ finite subcover $\\{U_i\\}$ of the UHC cover; the Lebesgue number $\\lambda$ guarantees every $\\lambda$-ball sits in some $U_i$; a subordinate partition $\\{\\varphi_i\\}$ (with $\\sum\\varphi_i = 1$, $\\operatorname{supp}\\varphi_i \\subseteq U_i$) yields the convex-combination selection $f(x) = \\sum_i \\varphi_i(x) y_i \\in S$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partition of unity",
+      "Lebesgue number lemma",
+      "finite subcover",
+      "convex combination"
+    ],
+    "prerequisites": [
+      "compactness",
+      "partitions of unity",
+      "convexity"
+    ]
+  },
+  {
+    "id": "ann-selection-construction-control",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 941,
+      "endLine": 1225
+    },
+    "type": "concept",
+    "title": "Selection Control: Support Locality and Output Bounds",
+    "content": "The second half: proving the assembled selection is genuinely ε-approximate. The `finsupport_*` lemmas show the partition's active terms at x come from inputs in a small ball (`finsupport_center_within_input_ball`, `finsupport_nonempty`); `exists_per_j_thickening_witness` and `finsupport_combination_within_output_ball` bound the resulting convex combination inside an ε-thickening of F; and `image_subtype_isClosed_of_isClosed_of_compact` with `exists_nearest_in_image_F` provide the closed-image and nearest-point facts that turn these bounds into the graph-distance estimate.",
+    "mathContext": "At each x only finitely many $\\varphi_i(x) \\neq 0$, all with centers in $B(x,\\delta)$; by UHC each $y_i \\in B(F(x),\\varepsilon)$, and convexity of $F(x)$'s thickening keeps $\\sum\\varphi_i(x)y_i \\in B(F(x),\\varepsilon)$. Closedness of $F$'s image and existence of nearest points convert this into $d((x,f(x)),\\operatorname{graph}F) < \\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "support locality",
+      "output thickening bound",
+      "closed image",
+      "nearest-point existence"
+    ],
+    "prerequisites": [
+      "finite support",
+      "convexity of thickenings",
+      "compactness"
+    ]
+  },
+  {
     "id": "ann-seq-compact-axiom",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 108,
-      "endLine": 114
+      "startLine": 1227,
+      "endLine": 1237
     },
     "type": "concept",
-    "title": "Axiom 3: Sequential Compactness",
-    "content": "In a compact metric space, every sequence has a convergent subsequence. This is equivalent to compactness in metrizable spaces (though not in general topological spaces). Stated here for the extraction step: the sequence of approximate fixed points $\\{x_k\\}$ must have a convergent subsequence.",
-    "mathContext": "If $S$ is compact and $(x_n) \\subseteq S$, then $\\exists$ subsequence $x_{\\varphi(k)} \\to a \\in S$ with $\\varphi$ strictly monotone. In metric spaces, compactness $\\Leftrightarrow$ sequential compactness.",
+    "title": "Sequential Compactness (Derived from Mathlib)",
+    "content": "`seq_compact_of_compact`: in a compact metric space every sequence has a convergent subsequence. **This is a proved theorem, not an axiom** — it is derived directly from Mathlib's compactness API (the file has only two axioms, Brouwer and approximate-selections). It supplies the extraction step: the sequence of approximate fixed points $\\{x_k\\}$ has a convergent subsequence whose limit is the true fixed point.",
+    "mathContext": "If $S$ is compact metric and $(x_n) \\subseteq S$, then $\\exists$ subsequence $x_{\\varphi(k)} \\to a \\in S$. In metric spaces compactness $\\Leftrightarrow$ sequential compactness, so this is immediate from `IsCompact.isSeqCompact` in Mathlib.",
     "significance": "supporting",
     "relatedConcepts": [
       "Bolzano-Weierstrass theorem",
-      "compactness",
-      "total boundedness"
+      "sequential compactness",
+      "IsCompact.isSeqCompact"
     ],
     "prerequisites": [
       "metric spaces",
@@ -136,62 +255,64 @@
     ]
   },
   {
-    "id": "ann-kakutani-theorem",
-    "proofId": "schauder-fixed-point-oq-03-oq-01",
-    "range": {
-      "startLine": 120,
-      "endLine": 147
-    },
-    "type": "concept",
-    "title": "Kakutani's FPT: The Combination Argument",
-    "content": "The central theorem combines the three axioms into a proof of Kakutani's FPT. The strategy: for each $k \\geq 1$, Axiom 2 gives a continuous $(1/k)$-selection $f_k$, and Axiom 1 gives a fixed point $x_k$ of $f_k$. By Axiom 3, extract $x_{k_j} \\to x^*$. The limit is a fixed point because: if $x^* \\notin F(x^*)$, then $\\delta = d(x^*, F(x^*)) > 0$ (since $F(x^*)$ is closed), but UHC forces $F(x_{k_j}) \\subseteq B(F(x^*), \\delta/2)$ for large $j$, while $d(x_{k_j}, F(x_{k_j})) < 1/k_j \\to 0$, giving $d(x^*, F(x^*)) \\leq \\delta/2$, a contradiction.",
-    "mathContext": "For each $k$, let $f_k$ be a $(1/k)$-approximate selection (Axiom 2), $x_k$ its Brouwer fixed point (Axiom 1). Extract $x_{k_j} \\to x^*$ (Axiom 3). Then $d(x_{k_j}, F(x_{k_j})) < 1/k_j \\to 0$, and UHC + closedness of $F(x^*)$ give $x^* \\in F(x^*)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "approximate fixed points",
-      "closed graph property",
-      "diagonal argument"
-    ],
-    "prerequisites": [
-      "Brouwer FPT",
-      "sequential compactness",
-      "upper hemicontinuity",
-      "metric space convergence"
-    ]
-  },
-  {
     "id": "ann-approx-fp-lemma",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 176,
-      "endLine": 189
+      "startLine": 1243,
+      "endLine": 1371
     },
     "type": "concept",
     "title": "Approximate Fixed Points Imply True Fixed Points",
-    "content": "This structural lemma abstracts the limit argument: if for every $\\varepsilon > 0$ there exists $x \\in S$ with $d(x, F(x)) < \\varepsilon$, then compactness and closedness of the graph yield a true fixed point. This factoring separates the approximation step (Brouwer + selections) from the convergence step (compactness + UHC), making the proof more modular.",
-    "mathContext": "If $S$ is compact, $F$ is UHC with closed values, and $\\forall \\varepsilon > 0, \\exists x \\in S, \\exists y \\in F(x), d(x,y) < \\varepsilon$, then $\\exists x^* \\in S$ with $x^* \\in F(x^*)$.",
-    "significance": "supporting",
+    "content": "`approx_fixedpoint_implies_fixedpoint` (a ~105-line theorem) abstracts the limit argument: if for every $\\varepsilon > 0$ there is $x \\in S$ with $d(x, F(x)) < \\varepsilon$, then compactness and the closed graph (from UHC + closed values) yield a true fixed point. This factoring separates the approximation step (Brouwer + selections) from the convergence step (compactness + UHC), making the Kakutani proof modular.",
+    "mathContext": "If $S$ is compact, $F$ is UHC with closed values, and $\\forall \\varepsilon > 0,\\ \\exists x \\in S,\\ d(x, F(x)) < \\varepsilon$, then $\\exists x^* \\in S$ with $x^* \\in F(x^*)$. Proof: take $x_k$ with $d(x_k,F(x_k)) < 1/k$, extract $x_{k_j}\\to x^*$, and use UHC + closedness to pass to the limit.",
+    "significance": "key",
     "relatedConcepts": [
-      "Ky Fan minimax inequality",
-      "closed graph theorem for correspondences"
+      "closed graph theorem for correspondences",
+      "limit argument",
+      "Ky Fan minimax inequality"
     ],
     "prerequisites": [
       "compact metric spaces",
       "closed-valued maps",
-      "upper hemicontinuity"
+      "upper hemicontinuity",
+      "seq_compact_of_compact"
+    ]
+  },
+  {
+    "id": "ann-kakutani-theorem",
+    "proofId": "schauder-fixed-point-oq-03-oq-01",
+    "range": {
+      "startLine": 1377,
+      "endLine": 1435
+    },
+    "type": "concept",
+    "title": "Kakutani's FPT from Brouwer: The Combination Argument",
+    "content": "`kakutani_from_brouwer` assembles the pieces into Kakutani's theorem. For each $k$, Axiom 2 gives a continuous $(1/k)$-approximate selection $f_k$, and `brouwer_fpt` gives a fixed point $x_k = f_k(x_k)$ — hence $d(x_k, F(x_k)) < 1/k$. Feeding this into `approx_fixedpoint_implies_fixedpoint` (which internally uses sequential compactness and UHC) produces a true fixed point $x^* \\in F(x^*)$.",
+    "mathContext": "For each $k$: $f_k$ a $(1/k)$-approximate selection (Axiom 2), $x_k$ its Brouwer fixed point (derived `brouwer_fpt`), so $d(x_k, F(x_k)) < 1/k$. Then `approx_fixedpoint_implies_fixedpoint` yields $x^* \\in F(x^*)$ — Kakutani's theorem, built entirely from the two axioms plus derived machinery.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kakutani fixed point theorem",
+      "approximate fixed points",
+      "Nash equilibrium existence",
+      "diagonal argument"
+    ],
+    "prerequisites": [
+      "brouwer_fpt",
+      "approx_selection_exists",
+      "approx_fixedpoint_implies_fixedpoint"
     ]
   },
   {
     "id": "ann-alternative-paths",
     "proofId": "schauder-fixed-point-oq-03-oq-01",
     "range": {
-      "startLine": 149,
-      "endLine": 171
+      "startLine": 1438,
+      "endLine": 1470
     },
     "type": "concept",
-    "title": "Alternative Proof Paths and Mathlib Gaps",
-    "content": "The commentary discusses two alternative approaches: (1) simplicial approximation on triangulations (Kakutani's original approach, 1941), which avoids partitions of unity but requires triangulation machinery absent from Mathlib; (2) Michael's selection theorem, which gives exact continuous selections for lower hemicontinuous maps — stronger than needed here. The main Mathlib infrastructure gap is the partition of unity construction for finite open covers in Euclidean space.",
-    "mathContext": "Alternative 1: approximate $F$ by piecewise-linear maps on simplicial subdivisions of $S$. Alternative 2: Michael's theorem gives continuous $f$ with $f(x) \\in F(x)$ for lower hemicontinuous $F$ with closed convex values — but Kakutani requires only upper hemicontinuity.",
+    "title": "Mathematical Commentary: Alternative Proof Paths and Mathlib Gaps",
+    "content": "Part V commentary on why this route was chosen. Two alternatives: (1) simplicial approximation on triangulations (Kakutani's original 1941 approach), which avoids partitions of unity but needs triangulation machinery absent from Mathlib; (2) Michael's selection theorem, which gives *exact* continuous selections for lower hemicontinuous maps — stronger than needed, and the wrong continuity hypothesis (Kakutani needs only UHC). The remaining Mathlib gap is a packaged partition-of-unity-from-finite-cover API, which is why Axiom 2 is not yet fully discharged.",
+    "mathContext": "Alternative 1: piecewise-linear approximation on simplicial subdivisions. Alternative 2: Michael's theorem gives continuous $f$ with $f(x) \\in F(x)$ for lower hemicontinuous closed-convex-valued $F$ — but Kakutani assumes only upper hemicontinuity, so the approximate-selection route is the appropriate one.",
     "significance": "supporting",
     "relatedConcepts": [
       "simplicial approximation",


### PR DESCRIPTION
## Summary

Enrichment pass for `schauder-fixed-point-oq-03-oq-01` ("Kakutani from Brouwer via Approximate Selections"). The 9 annotations were clustered in the docstring/header region (lines 50–189); the entire 1531-line formal proof body was uncovered, and one annotation described a nonexistent axiom.

## Changes

- **Fixed a factual error.** "Axiom 3: Sequential Compactness" is not an axiom — it is the derived theorem `seq_compact_of_compact` (built from Mathlib's `IsCompact.isSeqCompact`). The file has exactly **two** axioms, `brouwer_unit_ball` and `approx_selection_exists`, matching `axiomCount: 2`.
- **Clarified Axiom 1.** `brouwer_unit_ball` is the closed-unit-ball Brouwer theorem; the general compact-convex case is *derived* as the theorem `brouwer_fpt` via a continuous retraction, not assumed.
- **Realigned all 9 annotations** to their actual constructs (2 were on blank lines; the rest sat on the docstring header rather than the definitions/axioms/theorems they describe at lines 167–1435).
- **Added 5 annotations** for the previously-uncovered body: the UHC local-thickening lemmas, the continuous retraction onto compact convex sets (`exists_continuous_proj_convex`), the derived compact-convex Brouwer theorem (`brouwer_fpt`), and the two halves of the approximate-selection construction — cover/Lebesgue-number/partition-of-unity assembly, then support-locality and output-bound control.

Coverage now spans the full file (was capped at line 189). All 14 annotations pass `resolver.ts validate`.

## Verification

- `resolver.ts validate` → 14 valid, 0 misaligned (was 7 valid / 2 misaligned)
- meta.json axiom integrity confirmed: exactly 2 axioms, 0 sorries, no assumption-carrying structures.
- Only `schauder-fixed-point-oq-03-oq-01/annotations.json` changed.