### PR TITLE
Enrich Erdős #1000: realign 16 scrambled annotations to real declarations

### DIFF
--- a/src/data/proofs/erdos-1000/annotations.json
+++ b/src/data/proofs/erdos-1000/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-1000",
     "type": "concept",
     "title": "Imports and Module Documentation",
-    "content": "Imports for natural number arithmetic (Nat.GCD), Finset, real number casts, and filter limits. The module formalizes Erdős Problem #1000 on generalized totients and Diophantine approximation.",
+    "content": "Imports for natural number arithmetic (Nat.GCD), Finset, real number casts, and filter limits. The module formalizes Erdős Problem #1000 on generalized totients and Diophantine approximation. The header records the status as SOLVED (by Haight) with an axiom count of 2.",
     "mathContext": "The formalization uses `Nat.gcd` for computing reduced fractions, `Finset.filter` for counting integers satisfying the totient condition, and `Filter.Tendsto` for expressing limit behavior of the Cesàro averages.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -27,7 +27,7 @@
     "proofId": "erdos-1000",
     "type": "definition",
     "title": "IncreasingSeq",
-    "content": "A strictly increasing sequence of positive integers A = {n₁ < n₂ < ⋯}. This is the fundamental input to the generalized totient function.",
+    "content": "A strictly increasing sequence of positive integers A = {n₁ < n₂ < ⋯}, packaged as a `structure` carrying the sequence and its monotonicity proof. This is the fundamental input to the generalized totient function.",
     "mathContext": "A sequence $A : \\mathbb{N} \\to \\mathbb{N}$ is **strictly increasing** if $A(i) < A(j)$ for $i < j$ and $A(0) \\geq 1$. The choice of sequence $A$ determines the behavior of $\\varphi_A$: sparse sequences (e.g., powers of 2) behave very differently from dense ones (e.g., all of $\\mathbb{N}$).",
     "significance": "key",
     "relatedConcepts": [
@@ -40,8 +40,8 @@
       "monotone sequences"
     ],
     "range": {
-      "startLine": 38,
-      "endLine": 43
+      "startLine": 42,
+      "endLine": 44
     }
   },
   {
@@ -63,8 +63,8 @@
       "integer division"
     ],
     "range": {
-      "startLine": 45,
-      "endLine": 47
+      "startLine": 48,
+      "endLine": 50
     }
   },
   {
@@ -87,8 +87,8 @@
       "finite counting"
     ],
     "range": {
-      "startLine": 49,
-      "endLine": 51
+      "startLine": 52,
+      "endLine": 58
     }
   },
   {
@@ -96,12 +96,13 @@
     "proofId": "erdos-1000",
     "type": "concept",
     "title": "φ_A(k) ≥ φ(n_k)",
-    "content": "The generalized totient is always at least the Euler totient. This provides a universal lower bound independent of the sequence A.",
+    "content": "The theorem `phiA_ge_totient` (proved): the generalized totient is always at least the Euler totient of n_k. This provides a universal lower bound independent of the sequence A. In this file it follows from the exact divisor decomposition `phiA_decomposition`.",
     "mathContext": "Since $\\varphi(n_k)$ counts $m \\leq n_k$ with $\\gcd(m, n_k) = 1$ (reduced denominator $= n_k$), and the condition for $\\varphi_A$ is weaker (denominator $\\notin \\{n_1, \\ldots, n_{k-1}\\}$ rather than denominator $= n_k$), we always have $\\varphi_A(k) \\geq \\varphi(n_k)$. Tight when $A = \\mathbb{N}$.",
     "significance": "key",
     "relatedConcepts": [
       "Euler's totient function",
       "lower bounds",
+      "divisor decomposition",
       "coprimality counting"
     ],
     "prerequisites": [
@@ -109,8 +110,8 @@
       "Euler's totient"
     ],
     "range": {
-      "startLine": 56,
-      "endLine": 73
+      "startLine": 223,
+      "endLine": 241
     }
   },
   {
@@ -118,8 +119,8 @@
     "proofId": "erdos-1000",
     "type": "definition",
     "title": "Natural Numbers Sequence",
-    "content": "The natural numbers as an increasing sequence: n ↦ n+1. The baseline case where φ_A reduces to Euler's totient.",
-    "mathContext": "When $A = \\{1, 2, 3, \\ldots\\}$, $\\varphi_A(k) = \\varphi(k)$ and the Cesàro average converges to $(1/N)\\sum_{k=1}^N \\varphi(k)/k \\to 6/\\pi^2 \\neq 0$ by the well-known identity $\\sum_{n=1}^\\infty \\varphi(n)/n^2 = \\zeta(2)/\\zeta(2) \\cdot \\ldots$ More precisely, the average density of coprime pairs is $6/\\pi^2$.",
+    "content": "The natural numbers as an increasing sequence: k ↦ k+1 (`naturalSeq`). The baseline case where φ_A reduces to Euler's totient, formalized by the theorem `naturalSeq_phiA_eq_totient`.",
+    "mathContext": "When $A = \\{1, 2, 3, \\ldots\\}$, $\\varphi_A(k) = \\varphi(k+1)$. The Cesàro average of $\\varphi(n)/n$ converges to $6/\\pi^2$ (the asymptotic density of coprime pairs), which is nonzero — so the natural sequence does NOT have vanishing average.",
     "significance": "supporting",
     "relatedConcepts": [
       "Euler's totient",
@@ -131,8 +132,8 @@
       "Euler's totient"
     ],
     "range": {
-      "startLine": 120,
-      "endLine": 188
+      "startLine": 124,
+      "endLine": 148
     }
   },
   {
@@ -140,7 +141,7 @@
     "proofId": "erdos-1000",
     "type": "definition",
     "title": "Density Ratio",
-    "content": "The ratio φ_A(k)/n_k for a single term. This measures the proportion of integers up to n_k that produce 'new' denominators.",
+    "content": "The ratio φ_A(k)/n_k for a single term (`densityRatio`), together with its basic bounds (nonneg, ≤ 1, and = 1 at k = 0). This measures the proportion of integers up to n_k that produce 'new' denominators.",
     "mathContext": "The **density ratio** $\\rho_A(k) = \\varphi_A(k)/n_k \\in [0, 1]$ measures the fraction of $m \\in \\{1, \\ldots, n_k\\}$ that are 'new.' By $\\varphi_A(k) \\geq \\varphi(n_k)$, we have $\\rho_A(k) \\geq \\varphi(n_k)/n_k = \\prod_{p | n_k}(1 - 1/p)$, which can be small for highly composite numbers but is bounded below by $c/\\log\\log n_k$.",
     "significance": "key",
     "relatedConcepts": [
@@ -154,8 +155,8 @@
       "Euler product formula"
     ],
     "range": {
-      "startLine": 75,
-      "endLine": 95
+      "startLine": 79,
+      "endLine": 102
     }
   },
   {
@@ -163,8 +164,8 @@
     "proofId": "erdos-1000",
     "type": "definition",
     "title": "Cesàro Average",
-    "content": "The average (1/N) Σ_{k≤N} φ_A(k)/n_k. The central question asks whether this can converge to 0.",
-    "mathContext": "The **Cesàro average** $C_A(N) = \\frac{1}{N} \\sum_{k=1}^{N} \\rho_A(k)$ regularizes the density ratios. By Cesàro's theorem, if $\\rho_A(k) \\to L$ then $C_A(N) \\to L$, but the converse fails: Cesàro averages can converge even when individual terms oscillate. This asymmetry is what Haight's construction exploits.",
+    "content": "The average (1/N) Σ_{k<N} φ_A(k)/n_k (`cesaroAvg`), with bounds 0 ≤ C_A(N) ≤ 1. The central question asks whether this can converge to 0.",
+    "mathContext": "The **Cesàro average** $C_A(N) = \\frac{1}{N} \\sum_{k=0}^{N-1} \\rho_A(k)$ regularizes the density ratios. By Cesàro's theorem, if $\\rho_A(k) \\to L$ then $C_A(N) \\to L$, but the converse fails: Cesàro averages can converge even when individual terms oscillate. This asymmetry is what Haight's construction exploits.",
     "significance": "key",
     "relatedConcepts": [
       "Cesàro summation",
@@ -178,77 +179,30 @@
       "limit theory"
     ],
     "range": {
-      "startLine": 100,
-      "endLine": 115
+      "startLine": 104,
+      "endLine": 122
     }
   },
   {
-    "id": "ann-1000-cassels",
+    "id": "ann-1000-question",
     "proofId": "erdos-1000",
     "type": "concept",
-    "title": "Cassels' Result (1950)",
-    "content": "There exist sequences where liminf of the Cesàro average is 0. The first indication that averages could be made small.",
-    "mathContext": "Cassels (1950) proved $\\exists A: \\liminf_{N \\to \\infty} C_A(N) = 0$, constructing sequences where the Cesàro average dips arbitrarily close to 0 along a subsequence. His construction uses rapidly growing sequences related to continued fraction convergents and metric Diophantine approximation.",
+    "title": "The Main Question",
+    "content": "The two central predicates: `VanishingAverage A` (the Cesàro average C_A(N) → 0) and `DensityToZero A` (the individual ratios ρ_A(k) → 0). Erdős's Problem #1000 asks whether there exists a sequence with vanishing average; Erdős conjectured NO, expecting the φ_A(k) ≥ φ(n_k) lower bound to obstruct it.",
+    "mathContext": "$\\text{VanishingAverage}(A) \\iff \\lim_{N} C_A(N) = 0$;\\; $\\text{DensityToZero}(A) \\iff \\lim_{k} \\rho_A(k) = 0$. The question: does some $A$ satisfy $\\text{VanishingAverage}(A)$?",
     "significance": "key",
     "relatedConcepts": [
-      "liminf",
-      "continued fractions",
-      "convergents",
-      "metric Diophantine approximation"
+      "existence problems",
+      "Cesàro convergence",
+      "probabilistic heuristics"
     ],
     "prerequisites": [
       "Cesàro average",
-      "continued fractions"
+      "density ratio"
     ],
     "range": {
-      "startLine": 219,
-      "endLine": 220
-    }
-  },
-  {
-    "id": "ann-1000-erdos-limit",
-    "proofId": "erdos-1000",
-    "type": "concept",
-    "title": "Erdős: No Zero Limit",
-    "content": "For any sequence, the individual density ratio φ_A(k)/n_k cannot converge to 0. A strong constraint: sparsity is limited term-by-term.",
-    "mathContext": "Erdős (1964) proved $\\lim_{k \\to \\infty} \\rho_A(k) \\neq 0$ for any $A$. The proof uses $\\rho_A(k) \\geq \\varphi(n_k)/n_k = \\prod_{p|n_k}(1-1/p) \\geq c/\\log\\log n_k$ (by Mertens' theorem) and the fact that $n_k \\to \\infty$ slowly enough that this lower bound cannot vanish.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Mertens' theorem",
-      "Euler product",
-      "prime factor bounds"
-    ],
-    "prerequisites": [
-      "density ratio",
-      "Euler's product formula",
-      "prime number theorem"
-    ],
-    "range": {
-      "startLine": 205,
-      "endLine": 208
-    }
-  },
-  {
-    "id": "ann-1000-erdos-dichotomy",
-    "proofId": "erdos-1000",
-    "type": "concept",
-    "title": "Erdős' Dichotomy",
-    "content": "If liminf φ_A(k)/n_k = 0, then limsup = 1. The density ratio cannot merely be small — if it approaches 0, it must also approach 1.",
-    "mathContext": "Erdős (1964) proved: $\\liminf_{k} \\rho_A(k) = 0 \\Rightarrow \\limsup_{k} \\rho_A(k) = 1$. The density ratio oscillates maximally. The proof uses the Euler product $\\varphi(n)/n = \\prod_{p|n}(1-1/p)$ and properties of smooth numbers to show that subsequences with small $\\rho_A$ force the existence of subsequences with $\\rho_A$ near 1.",
-    "significance": "key",
-    "relatedConcepts": [
-      "oscillation",
-      "liminf-limsup gap",
-      "smooth numbers",
-      "Euler product"
-    ],
-    "prerequisites": [
-      "density ratio",
-      "Erdős' no-zero-limit theorem"
-    ],
-    "range": {
-      "startLine": 210,
-      "endLine": 212
+      "startLine": 511,
+      "endLine": 519
     }
   },
   {
@@ -256,7 +210,7 @@
     "proofId": "erdos-1000",
     "type": "definition",
     "title": "Vanishing Average",
-    "content": "A sequence has vanishing average if its Cesàro average of density ratios tends to 0. This is the central predicate of Erdős Problem #1000.",
+    "content": "The predicate `VanishingAverage A`: a sequence has vanishing average if its Cesàro average of density ratios tends to 0. This is the central predicate of Erdős Problem #1000.",
     "mathContext": "The predicate $\\text{VanishingAverage}(A) \\iff \\lim_{N \\to \\infty} C_A(N) = 0$ asks whether the arithmetic mean converges to zero. By Erdős' no-zero-limit theorem, the individual terms cannot converge to 0, so vanishing average requires the 'near-1' spikes to become increasingly rare.",
     "significance": "key",
     "relatedConcepts": [
@@ -269,30 +223,52 @@
       "Erdős' no-zero-limit"
     ],
     "range": {
-      "startLine": 193,
-      "endLine": 198
+      "startLine": 513,
+      "endLine": 515
     }
   },
   {
-    "id": "ann-1000-question",
+    "id": "ann-1000-erdos-dichotomy",
     "proofId": "erdos-1000",
-    "type": "definition",
-    "title": "The Main Question",
-    "content": "Does there exist a sequence with vanishing average? Erdős conjectured NO, believing the lower bound from Euler's totient would prevent it.",
-    "mathContext": "Erdős asked $\\exists A : \\text{VanishingAverage}(A)$? His heuristic: $\\varphi_A(k) \\geq \\varphi(n_k)$ and averages of $\\varphi(n)/n$ are bounded below. But this ignores that sequences with rapidly growing, highly composite terms can make the 'near-1' events increasingly sparse while the 'near-0' events dominate the average.",
+    "type": "concept",
+    "title": "Erdős' Dichotomy",
+    "content": "Stated as the axiom `erdos_dichotomy`: if the density ratio gets arbitrarily close to 0 (frequently near 0), then it is also frequently near 1. The density ratio cannot merely be small — if it approaches 0 along a subsequence, it must also approach 1 along another.",
+    "mathContext": "Erdős (1964): if $\\rho_A(k)$ is frequently $< \\varepsilon$, then it is frequently $> 1 - \\varepsilon$. The proof (here taken as an axiom) uses the Euler product $\\varphi(n)/n = \\prod_{p|n}(1-1/p)$ and properties of smooth numbers.",
     "significance": "key",
     "relatedConcepts": [
-      "existence problems",
-      "counterexamples",
-      "probabilistic heuristics"
+      "oscillation",
+      "liminf-limsup gap",
+      "smooth numbers",
+      "Euler product"
     ],
     "prerequisites": [
-      "vanishing average",
-      "generalized totient bounds"
+      "density ratio"
     ],
     "range": {
-      "startLine": 190,
-      "endLine": 198
+      "startLine": 569,
+      "endLine": 574
+    }
+  },
+  {
+    "id": "ann-1000-erdos-limit",
+    "proofId": "erdos-1000",
+    "type": "concept",
+    "title": "Erdős: No Zero Limit",
+    "content": "The theorem `erdos_no_zero_limit` (proved): for any sequence, the individual density ratio φ_A(k)/n_k cannot converge to 0 (`¬ DensityToZero A`). A strong constraint: sparsity is limited term-by-term. In this file it is derived from `erdos_dichotomy` — convergence to 0 would contradict the frequently-near-1 conclusion.",
+    "mathContext": "Erdős (1964): $\\lnot(\\rho_A(k) \\to 0)$ for any $A$. Proof here: if $\\rho_A \\to 0$ it is frequently near 0, so by the dichotomy frequently $> 1/2$, contradicting convergence to 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Mertens' theorem",
+      "Euler product",
+      "prime factor bounds"
+    ],
+    "prerequisites": [
+      "density ratio",
+      "Erdős' dichotomy"
+    ],
+    "range": {
+      "startLine": 576,
+      "endLine": 595
     }
   },
   {
@@ -300,8 +276,8 @@
     "proofId": "erdos-1000",
     "type": "concept",
     "title": "Haight's Theorem",
-    "content": "Such sequences exist, contrary to Erdős' expectation. Haight constructed a sequence with vanishing Cesàro average, resolving the problem affirmatively.",
-    "mathContext": "Haight proved $\\exists A : \\lim_{N \\to \\infty} C_A(N) = 0$. The construction uses rapidly growing subsequences of highly composite numbers, where $\\rho_A(k)$ spends most of its time near 0 (at highly composite $n_k$) and occasionally jumps to near 1, with the jumps becoming increasingly rare to force the Cesàro average to 0.",
+    "content": "Stated as the axiom `haight_resolution`: ∃ A, VanishingAverage A. Such sequences exist, contrary to Erdős' expectation. Haight constructed a sequence with vanishing Cesàro average, resolving the problem affirmatively.",
+    "mathContext": "Haight proved $\\exists A : \\lim_{N \\to \\infty} C_A(N) = 0$. The construction uses rapidly growing subsequences of highly composite numbers, where $\\rho_A(k)$ spends most of its time near 0 and occasionally jumps to near 1, with the jumps becoming increasingly rare to force the Cesàro average to 0.",
     "significance": "key",
     "relatedConcepts": [
       "highly composite numbers",
@@ -313,28 +289,31 @@
       "Erdős' dichotomy"
     ],
     "range": {
-      "startLine": 229,
-      "endLine": 229
+      "startLine": 601,
+      "endLine": 606
     }
   },
   {
-    "id": "ann-1000-solved",
+    "id": "ann-1000-cassels",
     "proofId": "erdos-1000",
     "type": "concept",
-    "title": "Problem #1000 Solved",
-    "content": "The answer is YES — sequences with vanishing average exist. This resolves Erdős' question affirmatively, overturning his conjecture.",
-    "mathContext": "The resolution $\\exists A, \\text{VanishingAverage}(A)$ follows directly from Haight's theorem. This is one of many instances where Erdős' intuition was overturned by a clever construction exploiting the gap between pointwise and averaged behavior.",
+    "title": "Cassels' Result (1950)",
+    "content": "The theorem `cassels_liminf_zero`: there exist sequences where the liminf of the Cesàro average is 0. Historically the first indication (Cassels 1950) that averages could be made small. In this formalization it is derived as a corollary of the stronger `haight_resolution` (a vanishing limit certainly has liminf 0).",
+    "mathContext": "$\\exists A: \\liminf_{N \\to \\infty} C_A(N) = 0$. Cassels' original (1950) construction used continued-fraction convergents and metric Diophantine approximation; here it follows from Haight via `Filter.Eventually.frequently`.",
     "significance": "key",
     "relatedConcepts": [
-      "existence theorem",
-      "counterexample to conjecture"
+      "liminf",
+      "continued fractions",
+      "convergents",
+      "metric Diophantine approximation"
     ],
     "prerequisites": [
+      "Cesàro average",
       "Haight's theorem"
     ],
     "range": {
-      "startLine": 231,
-      "endLine": 297
+      "startLine": 608,
+      "endLine": 623
     }
   },
   {
@@ -342,8 +321,8 @@
     "proofId": "erdos-1000",
     "type": "concept",
     "title": "Haight Oscillation",
-    "content": "Haight's sequence has vanishing Cesàro average yet its density ratio oscillates between 0 and 1. The oscillation is not a defect but a necessity from Erdős' dichotomy.",
-    "mathContext": "For Haight's sequence $A$: $\\lim C_A(N) = 0$ while $\\liminf \\rho_A(k) = 0$ and $\\limsup \\rho_A(k) = 1$. By Erdős' dichotomy, any vanishing-average sequence must exhibit this maximal oscillation. The 'near-1' values become increasingly sparse: if the $k$-th spike occurs at index $N_k$, then $N_k$ grows fast enough that $(1/N_k) \\cdot 1 \\to 0$.",
+    "content": "The theorem `haight_oscillation`: there is a sequence with vanishing Cesàro average whose density ratio still oscillates (frequently near 0 and, by the dichotomy, frequently near 1). The oscillation is not a defect but a necessity from Erdős' dichotomy.",
+    "mathContext": "For Haight's sequence $A$: $\\lim C_A(N) = 0$ while $\\rho_A(k)$ is frequently near 0 and near 1. The theorem combines `haight_resolution` with `erdos_dichotomy` (via `vanishing_avg_visits_zero`).",
     "significance": "key",
     "relatedConcepts": [
       "Cesàro-Erdős interplay",
@@ -356,8 +335,30 @@
       "Cesàro averages"
     ],
     "range": {
-      "startLine": 283,
-      "endLine": 297
+      "startLine": 674,
+      "endLine": 688
+    }
+  },
+  {
+    "id": "ann-1000-solved",
+    "proofId": "erdos-1000",
+    "type": "concept",
+    "title": "Problem #1000 Solved",
+    "content": "The separation theorem: there exists A with VanishingAverage A ∧ ¬ DensityToZero A. This packages the affirmative resolution — sequences with vanishing average exist (Haight) yet, by Erdős, their density ratios do not tend to 0 — overturning Erdős' conjecture and exhibiting the gap between pointwise and averaged behavior.",
+    "mathContext": "$\\exists A,\\; \\text{VanishingAverage}(A) \\wedge \\lnot\\,\\text{DensityToZero}(A)$, combining `haight_resolution` with `erdos_no_zero_limit`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "existence theorem",
+      "counterexample to conjecture",
+      "pointwise vs averaged behavior"
+    ],
+    "prerequisites": [
+      "Haight's theorem",
+      "Erdős' no-zero-limit"
+    ],
+    "range": {
+      "startLine": 691,
+      "endLine": 696
     }
   }
 ]


### PR DESCRIPTION
## Summary
Enrichment pass for `erdos-1000` (generalized totients / vanishing Cesàro averages, solved by Haight). The Lean file `Erdos1000Problem.lean` was heavily reorganized, scrambling every annotation range — the resolver reported **6 misaligned** and the remaining "valid" ones were false-positives anchored to the wrong construct.

## Changes
- **Realigned all 16 annotations** to their actual constructs. `resolver.ts validate` → **16 valid, 0 misaligned**.
- **Re-anchored the `φ_A(k) ≥ φ(n_k)` annotation** to the real proved theorem `phiA_ge_totient` (it had been sitting on the unrelated `phiA_le` / `phiA_zero` block).
- **Mapped the resolution-history annotations 1:1 to the real declarations**: `erdos_dichotomy` (axiom), `erdos_no_zero_limit` (proved *from* the dichotomy axiom), `haight_resolution` (axiom), `cassels_liminf_zero` (proved as a corollary of Haight), `haight_oscillation`, and the separation theorem `∃ A, VanishingAverage A ∧ ¬ DensityToZero A`. Clarified axiom-vs-proved status in each.
- Cleaned a garbled $\zeta(2)/\zeta(2)\cdots$ identity in the natural-sequence annotation (the correct fact — Cesàro density $6/\pi^2$ — is retained).

## Integrity
`status: axiomatized`, `badge: axiom`, `axiomCount: 2`, `sorries: 0` — verified against source (the two axioms are `erdos_dichotomy` and `haight_resolution`; everything else is proved). No change needed. `meta.json` sections already cover the full 1149-line file and were left unchanged.

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → 16 valid / 0 misaligned
- `pnpm build` → green