### PR TITLE
research(taxicab-number-oq-01): Ta(2)=1729 decidable formalization + certificate (build-pending)

### DIFF
--- a/proofs/Proofs/TaxicabNumberOQ01.lean
+++ b/proofs/Proofs/TaxicabNumberOQ01.lean
@@ -1,0 +1,58 @@
+/-
+  Taxicab number Ta(2) = 1729  (Hardy–Ramanujan number).
+
+  1729 is the smallest positive integer expressible as a sum of two positive
+  cubes in two distinct ways:
+
+      1729 = 1³ + 12³ = 9³ + 10³.
+
+  This is a finite, fully decidable claim. The only nontrivial design point is
+  bounding the search: for any `n ≤ 1729`, a representation `n = a³ + b³` with
+  `1 ≤ a ≤ b` has `b³ ≤ n ≤ 1729 < 2197 = 13³`, so `a, b ≤ 12`. Hence the search
+  may be restricted to the `12 × 12` grid `Finset.Icc 1 12 ×ˢ Finset.Icc 1 12`,
+  and `decide` discharges both the value and the minimality.
+
+  Independent numeric certificate:
+  `research/problems/taxicab-number-oq-01/verify_taxicab.py` (reps(1729) = {(1,12),
+  (9,10)}; no m < 1729 has ≥ 2 reps; cap 12 loses no representation for n ≤ 1729).
+
+  STATUS: build-pending. This file is NOT registered in `Proofs.lean` and has not
+  been compiled (Docker pool saturated this session). `decide` is the axiom-free
+  primary tactic; if kernel reduction over the ~250k bounded-Nat checks is too
+  slow, swap to `native_decide` (introduces `Lean.ofReduceBool`; would make the
+  entry `axiomatized` rather than `verified`).
+-/
+import Mathlib
+
+namespace TaxicabNumberOQ01
+
+/-- Unordered pairs `(a, b)` with `1 ≤ a ≤ b ≤ 12` and `a³ + b³ = n`.
+
+The bound `12` on the summands is sound for every `n ≤ 1729`: any representation
+`n = a³ + b³` with `a ≤ b` has `b³ ≤ n ≤ 1729 < 13³`, so `b ≤ 12`. -/
+def reps (n : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.Icc 1 12 ×ˢ Finset.Icc 1 12).filter
+    (fun p => p.1 ≤ p.2 ∧ p.1 ^ 3 + p.2 ^ 3 = n)
+
+/-- The two representations of 1729 as a sum of two positive cubes. -/
+theorem rep_one : (1 : ℕ) ^ 3 + 12 ^ 3 = 1729 := by norm_num
+
+theorem rep_two : (9 : ℕ) ^ 3 + 10 ^ 3 = 1729 := by norm_num
+
+/-- 1729 has exactly two representations as a sum of two positive cubes. -/
+theorem card_reps_1729 : (reps 1729).card = 2 := by decide
+
+/-- No positive integer below 1729 has two distinct representations as a sum of
+two positive cubes. Combined with `card_reps_1729`, this is `Ta(2) = 1729`. -/
+theorem minimal_below_1729 : ∀ m < 1729, (reps m).card < 2 := by decide
+
+/-- `Ta(2) = 1729`: it is the least `n` with two distinct cube representations. -/
+theorem taxicab_two_eq_1729 :
+    (2 ≤ (reps 1729).card) ∧ ∀ m < 1729, ¬ 2 ≤ (reps m).card := by
+  refine ⟨?_, ?_⟩
+  · exact card_reps_1729.ge
+  · intro m hm
+    have := minimal_below_1729 m hm
+    omega
+
+end TaxicabNumberOQ01

--- a/research/problems/taxicab-number-oq-01/knowledge.md
+++ b/research/problems/taxicab-number-oq-01/knowledge.md
@@ -1,0 +1,91 @@
+# Knowledge Base: taxicab-number-oq-01
+
+## Problem Summary
+
+`Ta(2) = 1729` (Hardy–Ramanujan number): 1729 is the **smallest** positive
+integer expressible as a sum of two positive cubes in two distinct ways:
+
+    1729 = 1³ + 12³ = 9³ + 10³.
+
+Fully finite and **decidable** — no infinitary content. The task is to formalize
+the value + minimality and discharge by a bounded finite search.
+
+---
+
+## Insights
+
+### Session 2026-06-16 (s01, researcher-1) — OBSERVE/ORIENT (build-gated)
+
+**Mode**: fresh problem (EMPTY). **Backend state**: dual blackout — Aristotle MCP
+`prove` → `Resource not found` (404, probed this session); Docker pool saturated
+(13–14 concurrent `lean-build` peers on the 7.65 GiB VM, over the 2-container
+safety threshold — building a 15th would OOM peers' work). No Lean compiled.
+Deliverable is a grounded formalization design + a Python certificate, with a
+build-pending scaffold for the next Docker-up session.
+
+**Key tractability fact (the only real design point).** For any `n ≤ 1729`, a
+representation `n = a³ + b³` with `1 ≤ a ≤ b` satisfies `b³ ≤ n ≤ 1729 < 2197 = 13³`,
+so `a, b ≤ 12`. Therefore the search may be restricted to the `12 × 12` grid
+`Finset.Icc 1 12 ×ˢ Finset.Icc 1 12` for *every* `n ≤ 1729` simultaneously — this
+keeps the decidable instance small (~144 filtered pairs per `n`, ~250k total over
+the minimality range) instead of an `n`-dependent unbounded search.
+
+**Formalization (scaffold in `proofs/Proofs/TaxicabNumberOQ01.lean`, UNregistered):**
+
+```lean
+def reps (n : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.Icc 1 12 ×ˢ Finset.Icc 1 12).filter
+    (fun p => p.1 ≤ p.2 ∧ p.1 ^ 3 + p.2 ^ 3 = n)
+
+theorem card_reps_1729 : (reps 1729).card = 2 := by decide
+theorem minimal_below_1729 : ∀ m < 1729, (reps m).card < 2 := by decide
+```
+
+`∀ m < 1729, …` is decidable via `Nat.decidableBallLT`; the Finset card is
+decidable via `DecidableEq`. `taxicab_two_eq_1729` assembles these into the
+least-witness statement `2 ≤ card(reps 1729) ∧ ∀ m < 1729, ¬ 2 ≤ card(reps m)`.
+
+**Independent numeric certificate** (`verify_taxicab.py`, ran clean this session):
+- `reps(1729) = [(1,12), (9,10)]` (exactly two unordered pairs).
+- No `m < 1729` has `≥ 2` representations (minimality holds).
+- **Cap-soundness**: a generous cap (20) finds no representation that the cap-12
+  grid misses, for every `m ≤ 1729` — so bounding summands at 12 is lossless here.
+
+### Risk / open verification question (next session)
+
+The only unknown is whether kernel `decide` reduces the ~250k bounded-`Nat` cube
+checks within build limits. If it times out / OOMs in the kernel:
+- swap `minimal_below_1729` to `native_decide` — instant, but introduces
+  `Lean.ofReduceBool`, which downgrades the entry from `verified` to `axiomatized`
+  (badge `axiom`). Prefer keeping `decide` if it compiles.
+- or shrink the per-`n` work (e.g. precompute the sorted cube list, or prove
+  minimality by a coarser case split) to keep it axiom-free.
+
+---
+
+## Mathlib / Gallery Gap
+
+Absent from Mathlib and the gallery. Distinct from `ramanujan-sum-fallacy`. No
+existing `Taxicab*` Lean file. Mathlib has no `taxicab`/`Ta(k)` development.
+
+---
+
+## Dead Ends
+
+(none yet)
+
+---
+
+## Next Steps
+
+1. **Build the scaffold** when a Docker slot opens (≤ 2 peers):
+   `./proofs/scripts/docker-build.sh Proofs.TaxicabNumberOQ01`. Confirm `decide`
+   compiles; if not, apply the `native_decide` fallback (and set status
+   `axiomatized`).
+2. **Register** in `Proofs.lean` and add gallery data
+   `src/data/proofs/taxicab-number-oq-01/meta.json` only after a green build.
+3. Set status `verified` (0 sorries, 0 axioms) iff `decide` carried it; otherwise
+   `axiomatized` with the `native_decide`/`ofReduceBool` assumption documented.
+4. Optional follow-up: `Ta(2)` as the least element of `{n | 2 ≤ card(reps n)}`
+   phrased with `Nat.find`, or a `Ta(1) = 2` warm-up (`2 = 1³ + 1³`, least sum of
+   two positive cubes) — only if it adds theory, not a renaming.

--- a/research/problems/taxicab-number-oq-01/problem.md
+++ b/research/problems/taxicab-number-oq-01/problem.md
@@ -1,0 +1,42 @@
+# Problem: taxicab-number-oq-01
+
+**Slug**: taxicab-number-oq-01
+**Status**: Active (OBSERVE/ORIENT, build-gated)
+**Source**: seeker-selected
+**Tier**: B · significance 6 · tractability 6
+
+## Problem Statement
+
+### Formal Statement
+
+`Ta(2) = 1729`: 1729 is the least positive integer with two distinct
+representations as a sum of two positive cubes, namely
+`1729 = 1³ + 12³ = 9³ + 10³`, and no `m < 1729` has two such representations.
+
+### Plain Language
+
+The Hardy–Ramanujan "taxicab" number. Famous anecdote: Ramanujan instantly
+recognized 1729 as the smallest number expressible as a sum of two cubes in two
+different ways.
+
+### Why This Matters
+
+Canonical recreational-number-theory landmark, absent from Mathlib and the
+gallery. Fully decidable, so it is a clean axiom-free target once a build slot is
+available.
+
+## Known Results
+
+### What's Already Proven
+
+- Nothing in Mathlib (`Ta(k)` undeveloped) or this gallery. Distinct from
+  `ramanujan-sum-fallacy`.
+
+### What's Still Open (this entry)
+
+- Compile the bounded-search formalization (`decide` over the `12×12` grid).
+- Decide `decide` vs `native_decide` (axiom-free vs `ofReduceBool`).
+- Register + add gallery data after a green build.
+
+See `knowledge.md` for the formalization design and the Python certificate
+(`verify_taxicab.py`).

--- a/research/problems/taxicab-number-oq-01/verify_taxicab.py
+++ b/research/problems/taxicab-number-oq-01/verify_taxicab.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Independent certificate for Ta(2)=1729.
+
+Claim: 1729 is the smallest positive integer expressible as a sum of two
+positive cubes in (at least) two distinct ways (unordered, distinct pairs).
+  1729 = 1^3 + 12^3 = 9^3 + 10^3.
+
+Tractability fact used by the Lean formalization: for any n <= 1729, every
+representation n = a^3 + b^3 with 1 <= a <= b has b^3 <= n <= 1729 < 13^3,
+so a, b <= 12. Hence the finite search may be bounded to the 12x12 grid.
+"""
+
+def reps(n, cap):
+    """Unordered pairs (a,b), 1<=a<=b<=cap, a^3+b^3=n."""
+    out = []
+    for a in range(1, cap + 1):
+        for b in range(a, cap + 1):
+            if a**3 + b**3 == n:
+                out.append((a, b))
+    return out
+
+CAP = 12
+assert 12**3 == 1728 and 13**3 == 2197, "cube bound sanity"
+
+# 1) 1729 has exactly two representations within the 12x12 grid.
+r1729 = reps(1729, CAP)
+print("reps(1729) =", r1729)
+assert r1729 == [(1, 12), (9, 10)], r1729
+
+# 2) Minimality: no m < 1729 has >= 2 representations (cap 12 is valid for all m<=1729).
+worst = 0
+offenders = [m for m in range(1, 1729) if len(reps(m, CAP)) >= 2]
+print("m < 1729 with >=2 reps:", offenders)
+assert offenders == [], offenders
+
+# 3) Cap-soundness: confirm no representation of any m<=1729 escapes cap 12
+#    (i.e. brute force with a generous cap finds nothing new).
+GEN = 20
+for m in [1729] + list(range(1, 1729)):
+    assert reps(m, GEN) == reps(m, CAP), f"cap escape at {m}"
+
+print("CERTIFIED: Ta(2) = 1729; minimal; cube summands <= 12 for all n <= 1729.")


### PR DESCRIPTION
## Summary

First session on the fresh `taxicab-number-oq-01` problem (Hardy–Ramanujan
number): `Ta(2) = 1729` is the least positive integer that is a sum of two
positive cubes in two distinct ways, `1729 = 1³ + 12³ = 9³ + 10³`.

This session ran under a **backend blackout** (Aristotle MCP `prove` → 404;
Docker pool saturated at 13–14 concurrent `lean-build` peers, over the
2-container safety threshold on the 7.65 GiB VM). **No Lean was compiled.** The
deliverable is a grounded formalization design, an independent numeric
certificate, and a build-pending scaffold for the next Docker-up session — not a
verified entry.

## Contents

- **`proofs/Proofs/TaxicabNumberOQ01.lean`** — UNregistered, build-pending scaffold.
  Bounded decidable search `reps n` over `Finset.Icc 1 12 ×ˢ Finset.Icc 1 12`,
  `card_reps_1729 = 2`, `minimal_below_1729` (`∀ m < 1729`, via `decide`), and
  `taxicab_two_eq_1729` assembling the least-witness statement.
- **`verify_taxicab.py`** — independent certificate (ran clean): `reps(1729) =
  {(1,12),(9,10)}`, no `m < 1729` has ≥2 reps, and the cap-12 bound loses no
  representation vs a generous cap for every `n ≤ 1729`.
- **`knowledge.md` / `problem.md`** — survey + next steps.

## Key design point

For `n ≤ 1729`, any rep `n = a³ + b³` with `a ≤ b` has `b³ ≤ 1729 < 13³`, so
`a, b ≤ 12`. Bounding both summands at 12 makes one fixed `12×12` grid sound for
**all** `n ≤ 1729`, keeping the `decide` instance small.

## Not done (build-gated)

- Compile (`./proofs/scripts/docker-build.sh Proofs.TaxicabNumberOQ01`). Open
  question: whether kernel `decide` handles ~250k bounded-Nat checks, or whether
  `native_decide` is needed (which adds `Lean.ofReduceBool` → `axiomatized`).
- Registration in `Proofs.lean` + gallery `meta.json` — deliberately deferred
  until a green build (no Lean CI gate; an uncompiled registered file would risk
  the shared aggregate build).

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.TaxicabNumberOQ01` is green with `decide`.
- [ ] If `decide` is too slow, switch `minimal_below_1729` to `native_decide` and set status `axiomatized`.
- [ ] Register + add gallery data once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)