### PR TITLE
Enrich Multinomial Variance (OQ-02-01-04): conclusion, cross-refs, annotations

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 9, "endLine": 42 },
+    "type": "concept",
+    "title": "The Diagonal Gap in the Multinomial Covariance Matrix",
+    "content": "For $(X_1,\\dots,X_k) \\sim \\mathrm{Multinomial}(n, p_1,\\dots,p_k)$ the full second-order structure is the covariance matrix $\\Sigma = n(\\operatorname{diag}(p) - pp^\\top)$. The sibling cross-moment lemma carries the hypothesis $i \\ne j$, so it only delivers the off-diagonal entries $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$. The diagonal entries $\\mathrm{Var}(X_i)$ — the one second moment the bivariate machinery cannot reach — are supplied here. The key structural fact is that each marginal $X_i$ is itself $\\mathrm{Binomial}(n, p_i)$, so its variance is the binomial variance.",
+    "mathContext": "$\\Sigma_{ij} = n\\,p_i(\\delta_{ij} - p_j),\\qquad \\Sigma_{ii} = \\mathrm{Var}(X_i) = n\\,p_i(1 - p_i).$",
+    "significance": "key",
+    "relatedConcepts": ["multinomial distribution", "covariance matrix", "binomial marginal", "Pearson chi-squared"],
+    "prerequisites": ["probability theory", "covariance"]
+  },
+  {
+    "id": "ann-variance-all",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 49, "endLine": 61 },
+    "type": "lemma",
+    "title": "Binomial Variance Extended to All n",
+    "content": "`BinomialTheoremOQ03.binomial_variance` requires $2 \\le n$. This private helper `binomial_variance_all` case-splits on $n \\in \\{0, 1, \\ge 2\\}$: the degenerate cases $n = 0$ (variance $0$) and $n = 1$ (a single Bernoulli trial, variance $p(1-p)$) are discharged by `simp`/`ring`, and $n \\ge 2$ is delegated to the imported lemma. This removes the $n \\ge 2$ side condition so the multinomial result holds for every $n$.",
+    "mathContext": "$\\sum_{k} k^2\\,\\mathrm{binomPMF}(n,p,k) - \\Big(\\sum_k k\\,\\mathrm{binomPMF}(n,p,k)\\Big)^2 = n\\,p(1-p),\\quad \\forall n \\ge 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial variance", "case analysis", "Bernoulli trial"],
+    "prerequisites": ["binomial distribution", "variance"]
+  },
+  {
+    "id": "ann-mean-all",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 63, "endLine": 69 },
+    "type": "lemma",
+    "title": "Binomial Mean Extended to All n",
+    "content": "Companion helper `binomial_mean_all_n`: the imported binomial mean requires $n \\ge 1$, so the $n = 0$ case (mean $0$) is added by `simp`. Having the mean as a sum $\\sum_j j\\,\\mathrm{binomPMF}(n,q,j) = nq$ valid for all $n$ lets the main theorem rewrite $(n p_i)^2$ as a squared PMF-sum, matching the form required by `binomial_variance_all`.",
+    "mathContext": "$\\sum_{j=0}^{n} j\\,\\mathrm{binomPMF}(n, q, j) = n\\,q,\\quad \\forall n \\ge 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial mean", "expected value"],
+    "prerequisites": ["binomial distribution", "expectation"]
+  },
+  {
+    "id": "ann-second-moment",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 73, "endLine": 110 },
+    "type": "theorem",
+    "title": "Second Moment via Fiber Grouping",
+    "content": "The crux: $E[X_i^2] = \\sum_j j^2\\,\\mathrm{binomPMF}(n, p_i, j)$. The multinomial expectation sums the statistic $k(i_0)^2$ over the antidiagonal `s.piAntidiag n` (all count vectors summing to $n$). `sum_fiberwise_of_maps_to` regroups this sum by the value $j = k(i_0)$; on each fiber the statistic $k(i_0)^2$ is the constant $j^2$, which factors out via `mul_sum`. The remaining fiber sum of probabilities is exactly the marginal PMF $P(X_i = j) = \\mathrm{binomPMF}(n, p_i, j)$, by `multinomial_marginal_pmf`. This is the squared-statistic analogue of the multinomial mean.",
+    "mathContext": "$E[X_i^2] = \\sum_{k \\in \\text{piAntidiag}(n)} k(i_0)^2\\,\\mathrm{multinomialProb}(k) = \\sum_{j=0}^{n} j^2\\,\\mathrm{binomPMF}(n, p_i, j).$",
+    "significance": "critical",
+    "relatedConcepts": ["fiber grouping", "second moment", "marginal PMF", "sum_fiberwise_of_maps_to"],
+    "prerequisites": ["finite sums over fibers", "multinomial distribution"]
+  },
+  {
+    "id": "ann-maps-to",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 85, "endLine": 91 },
+    "type": "tactic",
+    "title": "The maps-to Bound k(i₀) ≤ n",
+    "content": "Fiber grouping requires showing the grouping map lands in `range (n+1)`, i.e. $k(i_0) \\le n$ for every count vector $k$ in the antidiagonal. This holds because $k(i_0)$ is a single summand of $\\sum_l k(l) = n$ (nonnegative terms), so `Finset.single_le_sum` plus the antidiagonal constraint and `omega` close it. This bound is the hypothesis `sum_fiberwise_of_maps_to` needs.",
+    "mathContext": "$k(i_0) \\le \\sum_{l \\in s} k(l) = n \\implies k(i_0) \\in \\{0, \\dots, n\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.single_le_sum", "piAntidiag", "fiber grouping hypothesis"],
+    "prerequisites": ["finite sums", "omega tactic"]
+  },
+  {
+    "id": "ann-variance",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 114, "endLine": 132 },
+    "type": "theorem",
+    "title": "Main Theorem: Var(Xᵢ) = n·pᵢ·(1 − pᵢ)",
+    "content": "The variance is assembled from the pieces: rewrite the second moment via `multinomial_second_moment` and the mean via `multinomial_mean` (from the covariance sibling), re-express $(n p_i)^2$ as the squared PMF-sum using `binomial_mean_all_n`, and close with `binomial_variance_all`. The result $\\mathrm{Var}(X_i) = n p_i(1 - p_i)$ is the diagonal companion to $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$, completing the covariance matrix $\\Sigma_{ij} = n p_i(\\delta_{ij} - p_j)$.",
+    "mathContext": "$\\mathrm{Var}(X_i) = E[X_i^2] - (E[X_i])^2 = n\\,p_i(1 - p_i).$",
+    "significance": "critical",
+    "relatedConcepts": ["variance", "second moment", "covariance matrix", "multinomial distribution"],
+    "prerequisites": ["variance decomposition", "binomial distribution"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-04",
+    "range": { "startLine": 134, "endLine": 149 },
+    "type": "insight",
+    "title": "Completing the Covariance Matrix",
+    "content": "With the off-diagonal $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$ ($i \\ne j$) from the covariance sibling and this diagonal $\\mathrm{Var}(X_i) = n p_i(1 - p_i)$, the full multinomial covariance matrix is determined: $\\Sigma_{ij} = n\\,p_i(\\delta_{ij} - p_j)$. This matrix is singular of rank $k - 1$, because the constraint $\\sum_l X_l = n$ confines all variation to a hyperplane — every row of $\\Sigma$ sums to $0$, so $\\mathbf{1}$ is in its kernel.",
+    "mathContext": "$\\Sigma = n(\\operatorname{diag}(p) - pp^\\top),\\quad \\Sigma\\mathbf{1} = 0,\\quad \\operatorname{rank}\\Sigma = k - 1.$",
+    "significance": "key",
+    "relatedConcepts": ["covariance matrix", "rank deficiency", "constraint hyperplane", "singular matrix"],
+    "prerequisites": ["linear algebra", "covariance matrices"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-04/meta.json
@@ -68,5 +68,36 @@
       "endLine": 151,
       "summary": "multinomial_variance rewrites E[Xᵢ²] via multinomial_second_moment and E[Xᵢ] via multinomial_mean, re-expresses (n·pᵢ)² as (∑ⱼ j·binomPMF)² using the all-n mean, and closes by binomial_variance_all. The result is the diagonal companion to OQ03.multinomial_covariance, completing the multinomial covariance matrix."
     }
-  ]
+  ],
+  "crossReferences": [
+    {
+      "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+      "relationship": "Off-diagonal companion (covariance)",
+      "description": "Supplies $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$ for $i \\ne j$ and the multinomial mean $E[X_i] = n p_i$ reused here. This file fills the diagonal $i = j$ the covariance lemma cannot reach; together they determine $\\Sigma_{ij} = n p_i(\\delta_{ij} - p_j)$."
+    },
+    {
+      "proofId": "binomial-theorem-oq-02-oq-01-oq-02",
+      "relationship": "Marginal-PMF dependency",
+      "description": "Proves each multinomial component is marginally Binomial$(n, p_i)$ via $P(X_i = j) = \\mathrm{binomPMF}(n, p_i, j)$ — the identity that collapses each fiber sum in the second-moment computation."
+    },
+    {
+      "proofId": "binomial-theorem-oq-03",
+      "relationship": "Binomial mean/variance source",
+      "description": "Provides the binomial mean and variance $E[X] = np$, $\\mathrm{Var}(X) = np(1-p)$ (for $n \\ge 1$, $n \\ge 2$), which this file extends to all $n$ and pulls back along the binomial marginal."
+    },
+    {
+      "proofId": "binomial-theorem",
+      "relationship": "Foundational identity",
+      "description": "The binomial theorem underpins the whole family: the binomial PMF normalizes by $\\sum_k \\binom{n}{k} p^k (1-p)^{n-k} = 1$, and the multinomial coefficients generalize $\\binom{n}{k}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file machine-checks the diagonal of the multinomial covariance matrix: $\\mathrm{Var}(X_i) = n\\,p_i(1 - p_i)$, with 0 sorries and 0 axioms. The proof reduces the second moment $E[X_i^2] = \\sum_j j^2\\,\\mathrm{binomPMF}(n, p_i, j)$ to a binomial computation by fiber grouping over $j = k(i_0)$ — the squared-statistic analogue of the multinomial mean — then combines it with the mean $E[X_i] = n p_i$ and the binomial variance, extended here to all $n$.",
+    "implications": "Together with the off-diagonal covariance $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$, the variance completes the full multinomial covariance matrix $\\Sigma_{ij} = n\\,p_i(\\delta_{ij} - p_j) = n(\\operatorname{diag}(p) - pp^\\top)_{ij}$. This is the matrix at the heart of Pearson's chi-squared goodness-of-fit statistic and Fisher's analysis of contingency tables. Its rank deficiency (rank $k-1$, kernel spanned by $\\mathbf{1}$) is the analytic fingerprint of the hard constraint $\\sum_l X_l = n$: all probabilistic variation lives on the constraint hyperplane.",
+    "openQuestions": [
+      "Can the full covariance matrix $\\Sigma = n(\\operatorname{diag}(p) - pp^\\top)$ be assembled as a single Lean object combining this diagonal with the off-diagonal sibling?",
+      "Is the rank-$(k-1)$ singularity of $\\Sigma$ — equivalently $\\Sigma\\mathbf{1} = 0$ with $p \\ne 0$ — formalizable directly from the entrywise formula?",
+      "Does the fiber-grouping reduction extend to higher moments $E[X_i^r]$, recovering all marginal binomial moments uniformly?"
+    ]
+  }
 }


### PR DESCRIPTION
## Enrichment pass for `binomial-theorem-oq-02-oq-01-oq-04`

This entry (Var(Xᵢ) = n·pᵢ·(1−pᵢ), the diagonal of the multinomial covariance matrix) had a rich `overview` object and 4 `sections`, but was missing the `conclusion`, all `crossReferences`, and `annotations.json` entirely.

### Changes
- **conclusion** (new): `ProofConclusion` object — `summary`, `implications` (full covariance matrix, Pearson chi-squared, rank-(k−1) singularity from the ∑Xₗ=n constraint), 3 `openQuestions`.
- **annotations.json** (new): 7 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites` covering the header, the all-n binomial mean/variance helpers, the fiber-grouping second moment, the maps-to bound, the main theorem, and the covariance-matrix summary. `resolver.ts validate`: **7 valid, 0 misaligned**.
- **crossReferences** (new): 4 links — `binomial-theorem-oq-02-oq-01-oq-03` (off-diagonal covariance + reused mean), `binomial-theorem-oq-02-oq-01-oq-02` (marginal-PMF dependency), `binomial-theorem-oq-03` (binomial mean/variance source), `binomial-theorem` (foundational identity).

### Accuracy / axiom integrity
- `status: verified`, `axiomCount: 0`, `sorries: 0` all match the Lean source (no axioms, no assumption-carrying structures). Unchanged.
- Every annotation maps to actual lemmas (`binomial_variance_all`, `binomial_mean_all_n`, `multinomial_second_moment`, `multinomial_variance`).

Validated JSON parse + resolver alignment. Full `pnpm build` skipped to avoid rewriting sibling annotations.