### PR TITLE
research: state syncs (erdos-1179-oq-02, cayley-hamilton-cyclic-vector-oq-03)

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
@@ -1,0 +1,58 @@
+# Current State
+
+**Phase**: ACT — field/operator half COMPLETE + REGISTERED; PID-module half is a scoped open gap
+**Since**: 2026-06-16 17:1?Z (S1 scoping sync — researcher-9; no prior per-problem doc existed)
+**Iteration**: 1
+
+## Problem
+OQ-03 of cayley-hamilton-cyclic-vector-all-fields ("Coordinate-Free Cyclic Vector:
+Single Operator and PID Modules") asks for two generalizations of the verified
+*matrix* cyclic-vector theorem:
+- **(a) operator version** — coordinate-free: if `(minpoly K T).natDegree = finrank K V`
+  for `T : V →ₗ[K] V` on a finite-dim space, then `T` has a cyclic vector.
+- **(b) PID-module version** — a f.g. torsion `R[X]`-module (a space with an `R`-linear
+  endomorphism) is cyclic iff its order ideal equals its characteristic ideal (the PID
+  analogue of `minpoly = charpoly`).
+
+## Status (repo reality @ 2026-06-16)
+**Direction (a) is DONE and REGISTERED — do not redo.**
+`proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean` (registered
+`Proofs.lean:444`), **0 axioms / 0 sorry**, 8 theorems incl.:
+- `operator_nonderogatory_has_cyclic_vector` — the headline (a), via basis reduction
+  to the verified matrix theorem (minpoly transport `minpoly.algEquiv_eq` +
+  `toMatrix`/`mulVec` intertwining).
+- `operator_nonderogatory_has_span_cyclic_vector` — recast in the registered
+  `NonderogatoryModule.cyclicSubspace` vocabulary (Krylov orbit spans ⊤).
+- supporting: `matrix_nonderog_of_minpoly_natDegree`, `toMatrix_mulVec_repr`,
+  `krylov_linearIndependent_op`, `cyclicSubspace_eq_top_of_isCyclicVectorOp`.
+
+**Direction (b) is the only open content** — explicitly deferred in-source (see the
+`## PID direction` block at the file tail). Infrastructure assessment (from that note):
+- Needs Mathlib PID structure theory: `Module.equiv_directSum_of_isTorsion` +
+  invariant-factor / elementary-divisor decompositions.
+- Plus a cyclic-recombination lemma: pairwise-coprime cyclic torsion summands
+  recombine into one cyclic generator via CRT; and the order-ideal = char-ideal bridge
+  for the nonderogatory hypothesis.
+- Size estimate: **> 500 lines** on top of Mathlib's PID machinery. Multi-session.
+
+## Blockers
+- **Dual blackout live S1 (2026-06-16 ~17:10Z):** `docker ps` = 14 `lean-build`
+  containers (adding a 15th risks OOMing peers); Aristotle `prove` → 404
+  ("Resource not found"). Cannot build/verify any Lean, so the PID direction —
+  which is genuinely new code requiring iterative compilation — cannot be safely
+  started this cycle. Writing it blind would be unverifiable scaffold.
+
+## Next Action
+The field/operator half is saturated. The PID-module half is the real remaining work
+and is a **focused multi-session build effort**, not a blackout task:
+1. When Docker ≤2 containers: build a `...OQ03PID.lean` companion proving the
+   cyclic-recombination lemma first (smallest self-contained piece — coprime cyclic
+   summands → single generator via CRT), keep it UNREGISTERED until green.
+2. Bridge order-ideal = char-ideal for the nonderogatory hypothesis over a PID.
+3. Assemble the `IsCyclic` iff statement; register only after a green build (math PRs
+   merge with no Lean gate, so an unverified import could break the fleet build).
+
+## Attempt Counts
+- Total attempts: 1 (direction (a), completed in a prior session — file already on main)
+- Current approach attempts: 0 (PID direction not yet started)
+- Approaches tried: 1 (basis reduction to matrix theorem — succeeded for (a))

--- a/research/problems/erdos-1179-oq-02/state.md
+++ b/research/problems/erdos-1179-oq-02/state.md
@@ -1,8 +1,23 @@
 # Current State
 
 **Phase**: ACT — core OQ02 rigidity VERIFIED + REGISTERED; two clean companions await registration
-**Since**: 2026-06-16 (S6 sync — corrected a stale NEW/Iteration-1 stub)
-**Iteration**: 6
+**Since**: 2026-06-16 (S7 sync — blackout reconfirmed, no safe increment)
+**Iteration**: 7
+
+## Session 7 sync (2026-06-16 17:08Z, researcher-9) — STAND DOWN, blackout worse
+Reconfirmed repo reality and both backends. Nothing safe to add this session:
+- Companions `Erdos1179OQ02Rigidity.lean` + `Erdos1179OQ02Extremal.lean` re-scanned:
+  **0 `axiom` / 0 `sorry`** (grep clean), still present on main, still UNREGISTERED
+  (`Proofs.lean` imports only `Erdos1179OQ02` :1032 and `Erdos1179OQ02Upper` :1033).
+- **Build blackout WORSE than S6:** `docker ps` = **14 lean-build containers** live
+  (vs ~7 prior). Adding a 15th build is the exact OOM-of-peers risk state.md warns of.
+- **Aristotle still 404** (`prove` health-check → "Resource not found.").
+- Registering the two companions = adding 2 imports to `Proofs.lean`, but math PRs are
+  deployer-merged with **no Lean gate** → an unverified import could break the
+  fleet-wide registered build. So registration must wait for a green build, which I
+  cannot safely run now. No churn PR created (S3/S5/S7 already document everything).
+- Genuine OQ (`g_ε(N) ≤ log₂N + O_ε(1)`, general N, w.h.p.) remains analytic /
+  out of reach for finite methods. **Next agent: only act when docker ≤2 containers.**
 
 ## Problem
 OQ02 of erdos-1179: can the Erdős–Hall bound be improved to `g_ε(N) ≤ log₂ N + O_ε(1)`


### PR DESCRIPTION
## Summary
Documentation-only state syncs from a researcher-9 survey session. **No Lean changes.** Both slugs were assessed under a live dual blackout (14 `lean-build` containers + Aristotle `prove` 404), so no build/verify was possible; this records accurate repo reality so the next agent doesn't redo the surveys.

- **erdos-1179-oq-02** (S7 sync): finite/formalizable content is saturated — two registered files on main (trivial lower bound `g_ε(N) ≥ log₂N`; unique-representation optimality `|A|=⌈log₂N⌉`) plus two companions (`Erdos1179OQ02Rigidity`, `Erdos1179OQ02Extremal`) that are clean (re-scanned: 0 `axiom` / 0 `sorry`) but **build-pending and unregistered**. Registration must wait for a green build (math PRs merge with no Lean gate, so an unverified import could break the fleet build). The genuine OQ (`g_ε(N) ≤ log₂N + O_ε(1)`, general N, w.h.p.) remains analytic and out of reach for finite methods.
- **cayley-hamilton-cyclic-vector-all-fields-oq-03** (new per-problem doc; pool record was empty): direction **(a) operator/coordinate-free** is done + registered (`CayleyHamiltonCyclicVectorAllFieldsOQ03.lean`, 0 ax / 0 sorry, 8 theorems). Direction **(b) PID torsion modules** is scoped as the only open content — a >500-line build-gated effort on Mathlib PID structure theory + a CRT cyclic-recombination lemma.

## Test plan
- [ ] Docs-only (two `state.md` files under `research/problems/`); no Lean, no gallery JSON, no build impact.