### PR TITLE
Enrich Descartes Circle Theorem (OQ-01): overview, conclusion, cross-refs, annotations

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01/annotations.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-defn",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 28, "endLine": 30 },
+    "type": "definition",
+    "title": "The Descartes Relation",
+    "content": "`descartesRel` packages the curvature constraint for four mutually tangent circles. Each $k_i$ is a **signed** curvature $\\pm 1/r_i$, taken negative for a circle that internally encloses the other three. Working with signed curvatures is what lets the single algebraic relation cover both the inner and outer Soddy circles uniformly.",
+    "mathContext": "$(k_1 + k_2 + k_3 + k_4)^2 = 2(k_1^2 + k_2^2 + k_3^2 + k_4^2),\\qquad k_i = \\pm \\tfrac{1}{r_i}.$",
+    "significance": "key",
+    "relatedConcepts": ["signed curvature", "mutually tangent circles", "Soddy circles"],
+    "prerequisites": ["circle geometry", "curvature"]
+  },
+  {
+    "id": "ann-iff-sq",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 32, "endLine": 39 },
+    "type": "theorem",
+    "title": "Quadratic-in-k₄ Rewriting",
+    "content": "The heart of the algebra: the symmetric Descartes relation is *equivalent* to a perfect-square condition expressing $k_4$ as the root of a quadratic. Both directions are a single `linear_combination -h` — the relation and the perfect-square form differ by an exact polynomial identity. Writing $S = k_1+k_2+k_3$ and $D = k_1k_2+k_2k_3+k_3k_1$, the relation becomes $(k_4 - S)^2 = 4D$.",
+    "mathContext": "$\\mathrm{descartesRel} \\iff (k_4 - (k_1+k_2+k_3))^2 = 4(k_1k_2 + k_2k_3 + k_3k_1).$",
+    "significance": "critical",
+    "relatedConcepts": ["completing the square", "quadratic in one variable", "linear_combination"],
+    "prerequisites": ["polynomial identities", "quadratic equations"]
+  },
+  {
+    "id": "ann-nonneg",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 41, "endLine": 46 },
+    "type": "lemma",
+    "title": "The Discriminant Is Free",
+    "content": "A subtle but important point: one might expect to need $D = k_1k_2+k_2k_3+k_3k_1 \\ge 0$ as a hypothesis for the square root $\\sqrt{D}$ to exist. But whenever the relation holds, $D = (k_4 - S)^2/4$ is automatically a square, hence nonnegative (`nlinarith` with `sq_nonneg`). So the Soddy square root is always well defined — the discriminant condition comes for free.",
+    "mathContext": "$\\mathrm{descartesRel} \\implies D = \\tfrac{1}{4}(k_4 - S)^2 \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": ["discriminant", "nonnegativity", "sq_nonneg"],
+    "prerequisites": ["real inequalities"]
+  },
+  {
+    "id": "ann-forward",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "theorem",
+    "title": "Soddy Solutions (Forward)",
+    "content": "Given the relation, $k_4$ must be one of the two Soddy curvatures $S \\pm 2\\sqrt{D}$. The proof rewrites $(k_4 - S)^2 = 4D = (2\\sqrt D)^2$ (using `Real.sq_sqrt` on the free nonnegativity), factors the difference of squares $(k_4 - S - 2\\sqrt D)(k_4 - S + 2\\sqrt D) = 0$ via `linear_combination`, and splits with `mul_eq_zero`. This is the algebraic origin of the two tangent circles in a Soddy/Apollonian configuration.",
+    "mathContext": "$k_4 = (k_1+k_2+k_3) \\pm 2\\sqrt{k_1k_2 + k_2k_3 + k_3k_1}.$",
+    "significance": "critical",
+    "relatedConcepts": ["difference of squares", "mul_eq_zero", "Real.sq_sqrt", "Apollonian gasket"],
+    "prerequisites": ["factoring", "square roots in ℝ"]
+  },
+  {
+    "id": "ann-backward",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 65, "endLine": 75 },
+    "type": "theorem",
+    "title": "Soddy Solutions (Backward)",
+    "content": "The converse: each Soddy value satisfies the relation, given $D \\ge 0$. After rewriting to the perfect-square form, both cases $k_4 = S \\pm 2\\sqrt D$ are substituted and closed by one `linear_combination 4·hs` (where `hs : (\\sqrt D)^2 = D`). Together with the forward direction this gives the full equivalence.",
+    "mathContext": "$D \\ge 0,\\ k_4 = S \\pm 2\\sqrt D \\implies (k_4 - S)^2 = 4D \\iff \\mathrm{descartesRel}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["converse direction", "substitution"],
+    "prerequisites": ["square roots in ℝ"]
+  },
+  {
+    "id": "ann-circle",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 77, "endLine": 86 },
+    "type": "theorem",
+    "title": "Headline: The Full Equivalence",
+    "content": "Packages the two directions into the headline iff: the Descartes relation holds exactly when $D \\ge 0$ and $k_4$ is one of the two Soddy curvatures. This is the curvature-arithmetic content of the Descartes Circle Theorem — given three mutually tangent circles, there are precisely two circles tangent to all three, with curvatures $S \\pm 2\\sqrt D$.",
+    "mathContext": "$\\mathrm{descartesRel} \\iff \\big(D \\ge 0\\big) \\wedge \\big(k_4 = S + 2\\sqrt D \\ \\vee\\ k_4 = S - 2\\sqrt D\\big).$",
+    "significance": "key",
+    "relatedConcepts": ["iff packaging", "Soddy circles", "tangent circle pair"],
+    "prerequisites": ["logical equivalence"]
+  },
+  {
+    "id": "ann-vieta",
+    "proofId": "descartes-circle-theorem-oq-01",
+    "range": { "startLine": 88, "endLine": 102 },
+    "type": "theorem",
+    "title": "Vieta Relations of the Two Soddy Curvatures",
+    "content": "The two Soddy curvatures are the roots of $k^2 - 2Sk + (S^2 - 4D) = 0$, so Vieta's formulas give their sum and product directly. `soddy_sum` is a pure `ring` identity (the $\\pm 2\\sqrt D$ terms cancel); `soddy_prod` is a difference of squares closing the root via `Real.sq_sqrt`. The sum $2(k_1+k_2+k_3)$ means the inner and outer Soddy curvatures average to the outer-curvature sum.",
+    "mathContext": "$k_+ + k_- = 2(k_1+k_2+k_3),\\qquad k_+ k_- = (k_1+k_2+k_3)^2 - 4(k_1k_2+k_2k_3+k_3k_1).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Vieta's formulas", "sum and product of roots", "difference of squares"],
+    "prerequisites": ["quadratic equations", "Vieta's formulas"]
+  }
+]

--- a/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
@@ -42,6 +42,18 @@
     "theoremCount": 7,
     "definitionCount": 1
   },
+  "overview": {
+    "historicalContext": "René Descartes stated the curvature relation for four mutually tangent ('kissing') circles in a 1643 letter to Princess Elisabeth of Bohemia. It was rediscovered several times — notably by Frederick Soddy, the Nobel-laureate chemist, who published it as the poem *The Kiss Precise* in *Nature* (1936): 'The sum of the squares of all four bends / Is half the square of their sum.' Soddy's name now attaches to the two circles tangent to three given mutually tangent circles. In 2002 Lagarias, Mallows, and Wilks gave the *complex* Descartes theorem, encoding the circle centers as well as curvatures, which underlies the arithmetic of integral Apollonian gaskets — packings in which every curvature is an integer.",
+    "problemStatement": "For four mutually tangent circles with signed curvatures $k_1, k_2, k_3, k_4$ (curvature $\\pm 1/r$, negative for an internally enclosing circle), the Descartes relation is $(k_1+k_2+k_3+k_4)^2 = 2(k_1^2+k_2^2+k_3^2+k_4^2)$. Show it is equivalent to $k_4$ being one of the two Soddy curvatures $k_4 = (k_1+k_2+k_3) \\pm 2\\sqrt{k_1k_2+k_2k_3+k_3k_1}$, and record the Vieta relations of the two solutions.",
+    "proofStrategy": "Treat the relation as a quadratic in $k_4$. `descartesRel_iff_sq` rewrites it (in both directions, by a single `linear_combination`) as the perfect-square condition $(k_4 - S)^2 = 4D$ with $S = k_1+k_2+k_3$ and $D = k_1k_2+k_2k_3+k_3k_1$. Because the left side is a square, $D \\ge 0$ is automatic (`descartes_symmProd_nonneg`), so the Soddy square root always exists with no extra hypothesis. Factoring $(k_4 - S)^2 - (2\\sqrt D)^2$ as a difference of squares and applying `mul_eq_zero` yields the two Soddy curvatures (`descartes_soddy_forward`); substitution gives the converse (`descartes_soddy_backward`); the headline `descartes_circle` packages the equivalence. Finally `soddy_sum`/`soddy_prod` record Vieta's sum and product. The whole development is signed-curvature arithmetic and does not derive the relation from planar tangency geometry.",
+    "keyInsights": [
+      "Signed curvatures are the right coordinates: taking $k = \\pm 1/r$ (negative for an enclosing circle) lets one symmetric relation describe both the inner and outer Soddy circles at once.",
+      "The symmetric relation is secretly a quadratic in any one curvature; rewriting it as $(k_4 - S)^2 = 4D$ turns a four-variable constraint into the single-variable equation whose roots are the Soddy curvatures.",
+      "The discriminant condition $D \\ge 0$ needed for $\\sqrt D$ comes for free: whenever the relation holds, $D = (k_4 - S)^2/4$ is literally a square, so no nonnegativity hypothesis is required.",
+      "The two Soddy solutions are the two roots of $k^2 - 2Sk + (S^2 - 4D)$; Vieta's formulas immediately give sum $2S$ and product $S^2 - 4D$, recovering the inner/outer pair without solving again.",
+      "This is purely the curvature arithmetic; the planar derivation (placing centers in $\\mathbb{C}$ with tangency-distance equations — the Lagarias–Mallows–Wilks complex Descartes theorem) is a separate, deeper result left as a follow-up."
+    ]
+  },
   "sections": [
     {
       "title": "The Descartes Relation",
@@ -79,5 +91,26 @@
       "id": "vieta-relations",
       "mathContext": "The two Soddy curvatures are the roots of $k^2 - 2Sk + (2Q - S^2) = 0$, so by Vieta their sum is $2S = 2(k_1+k_2+k_3)$ and their product is $S^2 - 4D$."
     }
-  ]
+  ],
+  "crossReferences": [
+    {
+      "proofId": "ptolemys-complex-proof",
+      "relationship": "Metric relation on a circle configuration via algebra",
+      "description": "Ptolemy's relation on a cyclic quadrilateral and the Descartes curvature relation are both metric constraints on configurations of points/circles, each reduced to an exact algebraic identity (here over $\\mathbb{R}$, there over $\\mathbb{C}$)."
+    },
+    {
+      "proofId": "herons-formula",
+      "relationship": "Radius/curvature arithmetic of tangent circles",
+      "description": "Heron's formula relates a triangle to its inscribed and circumscribed circles; Descartes' theorem relates four mutually tangent circles through their curvatures $\\pm 1/r$ — neighboring results in the metric geometry of circles and radii."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file machine-checks the algebraic core of the Descartes Circle Theorem with 0 sorries and 0 axioms. The symmetric curvature relation $(k_1+k_2+k_3+k_4)^2 = 2\\sum k_i^2$ is shown equivalent to the perfect-square form $(k_4 - S)^2 = 4D$, from which the two Soddy curvatures $k_4 = S \\pm 2\\sqrt D$ follow by a difference-of-squares factoring and `mul_eq_zero`. The discriminant $D \\ge 0$ is free (it equals a square), and Vieta's relations $k_+ + k_- = 2S$, $k_+ k_- = S^2 - 4D$ are recorded.",
+    "implications": "The equivalence is the engine behind Apollonian gaskets: starting from three mutually tangent circles, the two Soddy curvatures $S \\pm 2\\sqrt D$ give the two ways to inscribe a fourth, and iterating fills the plane. When the four starting curvatures are integers with $D$ a perfect square, every descendant curvature is an integer — the gateway to the rich number theory of integral Apollonian packings (Graham–Lagarias–Mallows–Wilks–Yan). The 'discriminant is free' observation explains why the construction never stalls on a negative radicand.",
+    "openQuestions": [
+      "Can the planar tangency geometry — centers placed in $\\mathbb{C}$ with pairwise distance $r_i + r_j$ — be formalized to *derive* the curvature relation, rather than taking it as the starting definition (the Lagarias–Mallows–Wilks complex Descartes theorem)?",
+      "Does the integrality phenomenon (integer curvatures propagating through the gasket when $D$ is a perfect square) admit a clean Lean statement built on `descartes_circle`?",
+      "Can the Soddy sum/product Vieta relations be packaged to prove the curvatures of a full Apollonian generation satisfy a recurrence?"
+    ]
+  }
 }


### PR DESCRIPTION
## Enrichment pass for `descartes-circle-theorem-oq-01`

This entry (curvature relation + Soddy circles) had rich `sections` but was missing the `overview` and `conclusion` objects entirely, had no `crossReferences`, and no `annotations.json` (quality 8 — the gallery's lowest non-zero).

### Changes
- **overview** (new): `ProofOverview` object — `historicalContext` (Descartes' 1643 letter to Princess Elisabeth, Soddy's *The Kiss Precise* in *Nature* 1936, Lagarias–Mallows–Wilks 2002 complex Descartes / integral Apollonian gaskets), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **conclusion** (new): `ProofConclusion` object — `summary`, `implications` (Apollonian gaskets, integer-curvature propagation), 3 `openQuestions`.
- **annotations.json** (new): 7 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites` covering the relation, quadratic rewriting, free discriminant, both Soddy directions, the headline iff, and the Vieta relations. `resolver.ts validate`: **7 valid, 0 misaligned**.
- **crossReferences** (new): `ptolemys-complex-proof`, `herons-formula`.

### Accuracy / axiom integrity
- `status: verified`, `axiomCount: 0`, `sorries: 0` match the Lean source. Unchanged.
- The `assumptions` field already correctly scopes the work to curvature arithmetic (not the planar tangency derivation); the new overview/conclusion preserve that scoping and flag the LMW complex-Descartes derivation as a follow-up.
- Every annotation maps to actual lemmas (`descartesRel_iff_sq`, `descartes_symmProd_nonneg`, `descartes_soddy_forward/backward`, `descartes_circle`, `soddy_sum/prod`).

Validated JSON parse + resolver alignment. Full `pnpm build` skipped to avoid rewriting sibling annotations.