### PR TITLE
audit(tracker): binomial-theorem-oq-02-oq-01-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15581,6 +15581,12 @@
       "lastAudited": "2026-06-16T16:13:41Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T17:17:44Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `binomial-theorem-oq-02-oq-01-oq-04` (Multinomial Variance Var(Xᵢ)=n·pᵢ·(1−pᵢ))
**Result**: clean — no integrity issues.

## Checks
- sorries: 0 (matches meta)
- axiom declarations: 0 (matches meta `axiomCount`)
- True stubs: 0
- `theoremCount` 2, `lineCount` 151 — both match source
- All imports (OQ02/OQ03 siblings) and referenced lemmas exist; siblings are sorry/axiom-free
- Badge `original` / status `verified` defensible: genuine fiber-grouping derivation, not a thin Mathlib wrapper; sibling/Mathlib dependencies disclosed in `assumptions`

Tracker-only change recording the clean audit.

---
Discovered during gallery integrity audit.