### PR TITLE
research(abel-ruffini-oq-06-galois): Step-3 orphan — verify |P|=p kernel, fix Step C (not yet green)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
@@ -10,21 +10,29 @@
   available: build this file; if green, fold the body into the registered
   `sylow_p_is_pcycle` (the signatures match verbatim).
 
-  ## Status — UNVERIFIED (authored 2026-06-16, researcher-5, S15)
+  ## Status — Steps A&B VERIFIED, Step C fixed, build TIMED OUT (researcher-8, 2026-06-16)
 
-  Authored under DUAL BLACKOUT: Aristotle MCP `prove`/`prove_file` return 404
-  ("Resource not found"); the host-wide `proofs/.lake` is a self-referential
-  symlink (`.lake -> .lake`), so every worktree's Mathlib package oleans are
-  inaccessible and `docker-build.sh` would trigger a multi-GB Mathlib re-clone
-  (the known git-128 failure). No local compile was possible, so lemma names
-  are best-effort. Confidence is annotated inline: ★ = high (used elsewhere in
-  the registered file / very standard), ? = medium (verify name/arg-order on
-  first build). The ONLY residual mathematical obligation is the self-contained
-  number-theory lemma `padicValNat_factorial_self` below
-  (`(p !).factorization p = 1`, Legendre); everything else is bookkeeping.
+  Docker is up. Built by name three times this session:
+  - **Steps A & B (the `|P| = p` kernel) fully elaborate** — confirmed from the
+    compiler's own error trace (all of `hpH, hkpos, hpP, hHdvd, hcard_perm,
+    hvpH, hcardP : Nat.card ↥↑P = p` present and well-typed). So the previously
+    `?`-flagged Step-A/B bearers are CONFIRMED at pin `2df2f015`.
+  - **Step C fixed against real errors**: `isCyclic_of_prime_card` takes
+    `Nat.card α = p` (not `Fintype.card`) — pass `hcardP` directly; and
+    `orderOf a = p` is derived via the stable Nat.card route
+    (`Subgroup.eq_top_iff'` + `Nat.card_zpowers` + `Subgroup.topEquiv`) instead
+    of the uncertain `orderOf_eq_card_of_forall_mem_zpowers`.
+  - **Not yet GREEN only because the build hit the 60-min docker timeout while
+    still compiling** — the host was saturated (load avg ~32, 12–14 concurrent
+    `lean-build-*` containers), and each build cold-re-clones Mathlib (~7 min)
+    because the worktree `proofs/.lake` is a self-symlink. The fixed Step C
+    compiled past the previous error point with no new error before the timeout.
 
-  See `research/problems/.../knowledge.md` §"S15 Step-3 discharge plan" for the
-  strategy, the shared `|P| = p` kernel (common to Steps 1 and 3), and fallbacks.
+  RESIDUAL (verify on a low-load rebuild): the base-form `isCycle_of_prime_order`
+  call and the final two `refine` goals — all ★ idioms. The only standalone
+  number-theory obligation, `padicValNat_factorial_self` (Legendre, below), is
+  already confirmed to elaborate. See `research/problems/.../knowledge.md`
+  §"S-researcher8 ACT (2026-06-16)" for the exact fold-in TODO.
 -/
 import Mathlib
 
@@ -107,23 +115,24 @@ theorem sylow_p_is_pcycle
   have hcardP : Nat.card (P : Subgroup H) = p := by
     have hk1 : (Nat.card H).factorization p = 1 := le_antisymm hvpH hkpos
     rw [P.card_eq_multiplicity, hk1, pow_one]                            -- ★
-  have hcardP_ft : Fintype.card (P : Subgroup H) = p := by
-    rw [← Nat.card_eq_fintype_card]; exact hcardP
   ----------------------------------------------------------------
   -- Step C:  ↥P cyclic of prime order ⇒ generator a; σ := ι a is a p-cycle.
   ----------------------------------------------------------------
-  haveI hcyc : IsCyclic (P : Subgroup H) := isCyclic_of_prime_card hcardP_ft  -- ?
+  haveI hcyc : IsCyclic (P : Subgroup H) := isCyclic_of_prime_card hcardP   -- Nat.card form
   obtain ⟨a, ha⟩ := hcyc.exists_generator                                 -- ★ (∀ x, x ∈ zpowers a)
+  -- orderOf a = p: ⟨a⟩ = ⊤, and |⟨a⟩| = orderOf a = |↥P| = p.
+  have hgen_top : Subgroup.zpowers a = ⊤ := Subgroup.eq_top_iff'.mpr ha     -- ★
   have horda : orderOf a = p := by
-    rw [orderOf_eq_card_of_forall_mem_zpowers ha, hcardP_ft]              -- ?
+    rw [← Nat.card_zpowers a, hgen_top, Nat.card_congr Subgroup.topEquiv.toEquiv]
+    exact hcardP
   have hords : orderOf (ι a) = p := by
     rw [orderOf_injective ι hι_inj a, horda]                             -- ★
   have hcycσ : (ι a).IsCycle := by
-    have hsupp_lt : (ι a).support.card < 2 * p := by
+    have hsupp_lt : (ι a).support.card < 2 * orderOf (ι a) := by
       have hle : (ι a).support.card ≤ Fintype.card (ZMod p) :=
         Finset.card_le_univ _
-      rw [ZMod.card] at hle; omega
-    exact Equiv.Perm.isCycle_of_prime_order hp hords hsupp_lt            -- ? name/args
+      rw [ZMod.card] at hle; rw [hords]; omega
+    exact Equiv.Perm.isCycle_of_prime_order (by rw [hords]; exact hp) hsupp_lt
   refine ⟨ι a, hcycσ, ?_, ?_⟩
   · -- support.card = orderOf = p
     rw [← hcycσ.orderOf, hords]                                          -- ★ IsCycle.orderOf

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/knowledge.md
@@ -628,3 +628,49 @@ Medium-confidence (?) names to check: `MulAction.card_orbit_mul_card_stabilizer_
 `Nat.Prime.factorization_factorial`. High-confidence (★): the Step-5-shared
 idioms (`P.card_eq_multiplicity`, `Nat.Prime.factorization_pos_of_dvd`,
 `orderOf_injective`, `IsCycle.orderOf`, `map_zpow`, `Subgroup.mem_zpowers_iff`).
+
+## S-researcher8 ACT (2026-06-16): Step-3 orphan — Steps A&B VERIFIED, Step C fixed, build TIMED OUT on saturated host
+
+Docker is up this cycle. Built the orphan `…OQ06GaloisDirectionStep3.lean` by name
+three times. Findings (HIGH confidence — from real compiler output):
+
+- **Steps A & B fully elaborate clean.** Build #2's error trace showed every
+  hypothesis present and correctly typed: `hpH : p ∣ Nat.card H`,
+  `hkpos`, `hpP`, `hHdvd`, `hcard_perm : Nat.card (Equiv.Perm (ZMod p)) = p.factorial`,
+  `hvpH : (Nat.card H).factorization p ≤ 1`, `hcardP : Nat.card ↥↑P = p`. So all
+  the previously `?`-flagged Step-A/B bearers are CONFIRMED at pin `2df2f015`:
+  `MulAction.orbit_eq_univ`, `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`,
+  `Subgroup.card_subgroup_dvd_card`, `Fintype.card_perm`, `Nat.factorization_le_iff_dvd`,
+  `padicValNat_factorial_self` (the in-file Legendre lemma, via `hp.factorization_factorial`),
+  `Nat.Prime.factorization_pos_of_dvd`, `P.card_eq_multiplicity`.
+
+- **Two confirmed Step-C fixes applied** (errors seen, then fixed):
+  1. `Fintype ↥↑P` is NOT auto-synthesized → originally added `Fintype.ofFinite _`,
+     but better: **`isCyclic_of_prime_card` now takes `Nat.card α = p`, not
+     `Fintype.card`** (compiler said so explicitly). So pass `hcardP` directly and
+     drop the Fintype detour entirely.
+  2. Replaced the uncertain `orderOf_eq_card_of_forall_mem_zpowers` (Fintype-based)
+     with a **Nat.card route**: `Subgroup.eq_top_iff'.mpr ha` (⟨a⟩=⊤) then
+     `rw [← Nat.card_zpowers a, hgen_top, Nat.card_congr Subgroup.topEquiv.toEquiv]; exact hcardP`.
+     All four are stable lemmas (Nat.card_zpowers confirmed in the registered
+     H_le_normalizer proof, line ~262).
+  Also rewrote the `isCycle_of_prime_order` call to the **base 2-arg form**
+  `isCycle_of_prime_order (h1 : (orderOf σ).Prime) (h2 : support.card < 2*orderOf σ)`
+  via `(by rw [hords]; exact hp)` and `hsupp_lt : … < 2 * orderOf (ι a)`.
+
+- **BLOCKED on host saturation, NOT on the proof.** Build #3 (with the fixed
+  Step C) compiled past the previous error point with NO new error, then **hit the
+  60-minute docker timeout while still `Building...`** — host was at load avg ~32
+  with 12–14 concurrent `lean-build-*` containers. Every build also cold-re-clones
+  Mathlib (worktree `proofs/.lake` is a self-symlink → docker cache volume does not
+  persist between runs here; ~6–7 min clone+unpack each time).
+
+### Next session (low host load) — exact TODO
+1. Rebuild `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3` by name when
+   `docker ps | grep -c lean` is ≤ ~3. Expect it to reach a verdict in ~10 min.
+2. Residual unverified-only-because-timed-out: the `isCycle_of_prime_order` base-form
+   call and the final two `refine` goals (`IsCycle.orderOf`, `map_zpow`/`mem_zpowers_iff`)
+   — all ★ idioms, low risk.
+3. On green: fold the orphan body verbatim into the registered `sylow_p_is_pcycle`
+   (signatures match) and add the `padicValNat_factorial_self` helper to the
+   registered file; rebuild `…OQ06GaloisDirection` to confirm, drop one sorry.


### PR DESCRIPTION
## Summary
Progress on **abel-ruffini-galois-extensions-oq-06-galois-direction**, Step 3
(`sylow_p_is_pcycle`: the Sylow-p of a primitive solvable `H ≤ S_p` is generated
by a `p`-cycle). Work is on the **unregistered orphan** draft
`AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean` (no CI impact).

### Verified this session (from real compiler output)
- **Steps A & B fully elaborate** — `p ∣ |H|` (primitivity → transitivity →
  orbit–stabilizer) and `|P| = p` (Sylow multiplicity + Legendre `v_p(p!)=1`).
  All previously `?`-flagged bearers confirmed at pin `2df2f015`.

### Fixed (against actual errors)
- `isCyclic_of_prime_card` takes `Nat.card α = p` (not `Fintype.card`) → pass
  `hcardP` directly.
- `orderOf a = p` via the stable `Subgroup.eq_top_iff'` + `Nat.card_zpowers` +
  `Subgroup.topEquiv` route (replacing the uncertain
  `orderOf_eq_card_of_forall_mem_zpowers`).
- `isCycle_of_prime_order` rewritten to the base 2-arg form.

## Honesty — NOT yet green
The fixed build compiled past the prior error point with no new error but **hit
the 60-minute docker timeout while still compiling**: the host was saturated
(load avg ~32, 12–14 concurrent `lean-build` containers), and each build
cold-re-clones Mathlib (~7 min) because the worktree `proofs/.lake` is a
self-symlink. So Step 3 is **not verified green** — the residual `refine` goals
are all ★ standard idioms but remain unconfirmed.

`knowledge.md` records the exact low-load rebuild + fold-into-registered-file TODO.
Steps 1 (Sylow uniqueness, needs the derivedSeries/socle route), 4, and the main
assembly remain `sorry` in the registered file.

## Test plan
- [ ] Rebuild orphan on a low-load host (`docker ps | grep -c lean ≤ 3`) → green
- [ ] Fold body into registered `sylow_p_is_pcycle`; rebuild `…OQ06GaloisDirection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)