### PR TITLE
audit(tracker): 13 gallery audits (12 clean + miquel description fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15623,6 +15623,48 @@
       "lastAudited": "2026-06-16T18:11:09Z",
       "result": "clean",
       "issues": []
+    },
+    "miquel-pivot-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:14:09Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "pompeiu-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:14:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "simson-line-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:15:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylvester-sequence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:16:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "thue-morse-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:16:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "varignon-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:17:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "weitzenbock-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:17:29Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15587,6 +15587,42 @@
       "lastAudited": "2026-06-16T17:17:44Z",
       "result": "clean",
       "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:07:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "carnot-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:08:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-circle-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:08:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dilworth-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:09:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "herons-formula-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:10:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "midy-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T18:11:09Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/miquel-pivot-theorem-oq-01/meta.json
+++ b/src/data/proofs/miquel-pivot-theorem-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "miquel-pivot-theorem-oq-01",
   "title": "Miquel's Pivot Theorem",
   "slug": "miquel-pivot-theorem-oq-01",
-  "description": "For points X, Y, Z on the sides BC, CA, AB of a triangle ABC, the three circles (AYZ), (BZX), (CXY) pass through a common point — the Miquel point. Proved via complex cross-ratios: the product of the three Miquel cross-ratios is independent of the pivot point.",
+  "description": "For points X, Y, Z on the sides BC, CA, AB of a triangle ABC, the three circles (AYZ), (BZX), (CXY) are classically concurrent at the Miquel point. This file formalizes the sharp conditional (pivot) form: assuming a point lies on two of the circles, it lies on the third — it does not construct the intersection point itself. Proved via complex cross-ratios: the product of the three Miquel cross-ratios is independent of the pivot point, so the third is a quotient of reals.",
   "meta": {
     "author": "Auguste Miquel (1838)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Miquel%27s_theorem",


### PR DESCRIPTION
## Summary

Gallery integrity audit cycle — cleared the entire unaudited backlog except one target held by a concurrent auditor. 13 entries checked against their registered Lean sources.

### Clean (12)
buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01, carnot-theorem-oq-01, descartes-circle-theorem-oq-01, dilworth-theorem-oq-01, herons-formula-oq-05, midy-theorem-oq-01, pompeiu-theorem-oq-01, simson-line-theorem-oq-01, sylvester-sequence-oq-01, thue-morse-oq-01, varignon-theorem-oq-01, weitzenbock-inequality-oq-01

### issues-fixed (1)
**miquel-pivot-theorem-oq-01** — the short `description` asserted the *existence* form ("the three circles pass through a common point"), but the Lean file proves only the sharp **conditional** pivot form (if a point lies on two of the circles it lies on the third) and explicitly does not construct the intersection point. Qualified the description to match the verified content. (`problemStatement`, `conclusion`, `proofStrategy`, and the Lean docstring already disclosed the conditional framing.)

## Checks performed (each entry)
- `sorries` / `axiomCount` in meta.json match the source (all 0/0)
- `theoremCount` / `definitionCount` reconciled with declarations (private helpers excluded by convention)
- No `True` stubs, no `sorry`, no `native_decide` shortcuts
- File registered in `proofs/Proofs.lean` (not a false-green orphan)
- No hidden Mathlib-wrapper overclaim; badge tier appropriate
- Scope wording honest — Dilworth/Descartes disclaim the hard directions; Heron–Cayley–Menger discloses expanded-determinant defs; Simson/Weitzenböck disclose their WLOG / Heron-as-area normalizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)