### PR TITLE
Enrich Buffon Beta integral: add annotations.json

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-beta-overview",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 28 },
+    "type": "concept",
+    "title": "The Beta Integral as the Analytic Core",
+    "content": "The module docstring frames the problem: the n-dimensional Cauchy–Crofton angular averaging identity reduces, via polar-coordinate decomposition of the sphere integral on S^{n-1}, to a single one-dimensional integral. Proving that integral axiom-free closes the last gap in the n ≥ 3 case (the n = 2 case lives in the parent file). The value 1/(n-1) is exactly the proportionality factor sphereArea(n-2)/((n:ℝ)-1) needed downstream.",
+    "mathContext": "$\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}$, a special case of the Beta function $B(a,b) = 2\\int_0^{\\pi/2} \\sin^{2a-1}\\theta \\cos^{2b-1}\\theta\\, d\\theta$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy–Crofton formula", "Beta function", "integral geometry", "Buffon's needle"],
+    "prerequisites": ["integral geometry", "spherical coordinates"]
+  },
+  {
+    "id": "ann-general-statement",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 34, "endLine": 40 },
+    "type": "theorem",
+    "title": "General Natural-Exponent Beta Integral",
+    "content": "The headline lemma integral_cos_mul_sin_pow states the integral for an arbitrary natural exponent m, deliberately more general than the n-2 case actually needed. Proving the general statement first isolates the only dimension-dependent step into a one-line cast, keeping the analytic content clean.",
+    "mathContext": "$\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{m}\\theta \\, d\\theta = \\frac{1}{m+1}$ for every $m \\in \\mathbb{N}$.",
+    "significance": "critical",
+    "relatedConcepts": ["fundamental theorem of calculus", "trigonometric integrals", "generalization strategy"],
+    "prerequisites": ["real analysis", "integration"]
+  },
+  {
+    "id": "ann-antiderivative-deriv",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 53 },
+    "type": "tactic",
+    "title": "Differentiating the Closed-Form Antiderivative",
+    "content": "Rather than invoke a change-of-variables lemma, the proof exhibits the antiderivative F(θ) = sin^{m+1}(θ)/(m+1) explicitly and differentiates it. HasDerivAt.pow on Real.hasDerivAt_sin gives the derivative of sin^{m+1}, Nat.add_sub_cancel simplifies the exponent m+1-1 to m, and HasDerivAt.div_const divides by the constant. The (m+1) factors cancel via field_simp after push_cast, leaving exactly cos θ · sinᵐ θ.",
+    "mathContext": "$F(\\theta) = \\frac{\\sin^{m+1}\\theta}{m+1}, \\quad F'(\\theta) = \\frac{(m+1)\\sin^{m}\\theta \\cos\\theta}{m+1} = \\cos\\theta \\cdot \\sin^{m}\\theta.$",
+    "significance": "key",
+    "relatedConcepts": ["HasDerivAt", "chain rule", "power rule", "derivative of sine"],
+    "prerequisites": ["differentiation", "Mathlib HasDerivAt API"]
+  },
+  {
+    "id": "ann-ftc-application",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 59 },
+    "type": "tactic",
+    "title": "Applying FTC and Evaluating Endpoints",
+    "content": "Continuity of the integrand (cos times a power of sin) gives interval-integrability, so intervalIntegral.integral_eq_sub_of_hasDerivAt rewrites the integral as F(π/2) − F(0). Then sin(π/2) = 1 makes the upper term 1^{m+1}/(m+1) = 1/(m+1), while sin(0) = 0 with zero_pow (using m+1 ≠ 0) kills the lower term. No case split on m is needed.",
+    "mathContext": "$\\int_0^{\\pi/2} F'(\\theta)\\,d\\theta = F(\\pi/2) - F(0) = \\frac{1^{m+1}}{m+1} - \\frac{0^{m+1}}{m+1} = \\frac{1}{m+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of calculus", "interval integrability", "continuity", "zero_pow"],
+    "prerequisites": ["Riemann integration", "FTC"]
+  },
+  {
+    "id": "ann-dimensional-statement",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 69 },
+    "type": "theorem",
+    "title": "Dimensional Specialization (n ≥ 2)",
+    "content": "integral_cos_mul_sin_pow_dim restates the result in the form the parent Cauchy–Crofton construction consumes: exponent n − 2 and value 1/(n−1) for n ≥ 2. This is the theorem flagged as the missing analytic piece for the general n ≥ 3 angular averaging identity.",
+    "mathContext": "$\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}, \\quad n \\geq 2.$",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy–Crofton formula", "angular averaging", "dimensional reduction"],
+    "prerequisites": ["real analysis", "integral geometry"]
+  },
+  {
+    "id": "ann-cast-bridge",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 72 },
+    "type": "tactic",
+    "title": "Bridging the Natural and Real Subtractions",
+    "content": "The only dimension-dependent work: rewriting the cast ((n−2 : ℕ) : ℝ) + 1 = (n : ℝ) − 1. Nat.cast_sub (valid because hn : 2 ≤ n) pushes the natural-number subtraction across the cast into a real subtraction, after which push_cast and ring finish. The hypothesis 2 ≤ n is essential — without it, truncated ℕ subtraction would make the identity false.",
+    "mathContext": "$\\overline{(n-2)} + 1 = (n-1)$ in $\\mathbb{R}$, requiring $n \\geq 2$ so that $\\mathbb{N}$-subtraction does not truncate.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.cast_sub", "truncated subtraction", "coercion"],
+    "prerequisites": ["Lean coercions", "natural number arithmetic"]
+  }
+]


### PR DESCRIPTION
## Summary
Enrichment pass for `buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01` (Beta integral for the n-dimensional angular averaging identity). The entry had a rich meta.json but **no annotations.json** — that absence was the quality gap (q39).

## Changes
- Added `annotations.json` with **6 line-anchored annotations**, all resolver-validated (`Valid: 6, Misaligned: 0`).
- Coverage: problem framing, the general FTC lemma `integral_cos_mul_sin_pow`, the closed-form antiderivative differentiation, FTC application + endpoint evaluation, the dimensional specialization `integral_cos_mul_sin_pow_dim`, and the `Nat.cast_sub` bridge.
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- `resolver.ts validate` → 6 valid, 0 misaligned against the Lean source.
- Annotation types/significance conform to `src/types/proof.ts`.