### PR TITLE
Enrich Midy's theorem: add annotations.json

### DIFF
--- a/src/data/proofs/midy-theorem-oq-01/annotations.json
+++ b/src/data/proofs/midy-theorem-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-midy-overview",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Midy's Theorem: Complementary Halves of Repetends",
+    "content": "Midy's theorem (1836) concerns the repeating block (repetend) of 1/p in base b for a prime p not dividing b. If the period 2k is even, splitting the 2k-digit repetend into two k-digit halves yields halves that sum to bᵏ − 1 (a string of k nines in base 10). The formalization separates the result into a pure-arithmetic kernel, an algebraic fact about elements of order 2k, and a number-theoretic bridge linking 'even period' to the divisibility p ∣ bᵏ + 1.",
+    "mathContext": "$N = \\frac{b^{2k}-1}{p}, \\quad \\lfloor N / b^k \\rfloor + (N \\bmod b^k) = b^k - 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["repeating decimals", "multiplicative order", "cyclic numbers", "Fermat's little theorem"],
+    "prerequisites": ["modular arithmetic", "number theory"]
+  },
+  {
+    "id": "ann-midy-kernel",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 39, "endLine": 56 },
+    "type": "theorem",
+    "title": "The Arithmetic Kernel",
+    "content": "midy_kernel isolates the number-theory-free heart: for N = (bᵏ − 1)·m with 1 ≤ m ≤ bᵏ, the high and low base-bᵏ halves of N sum to bᵏ − 1. The proof exhibits the explicit decomposition N = (bᵏ − m) + (m − 1)·bᵏ, so the remainder N mod bᵏ is bᵏ − m and the quotient N / bᵏ is m − 1; their sum is (bᵏ − m) + (m − 1) = bᵏ − 1. The zify tactic lifts the natural-number subtractions to ℤ where ring applies.",
+    "mathContext": "$(b^k-1)m = (b^k - m) + (m-1)b^k \\implies \\lfloor N/b^k\\rfloor + (N \\bmod b^k) = (m-1)+(b^k-m) = b^k-1.$",
+    "significance": "critical",
+    "relatedConcepts": ["Euclidean division", "place-value decomposition", "truncated subtraction"],
+    "prerequisites": ["division with remainder", "natural number arithmetic"]
+  },
+  {
+    "id": "ann-midy-order",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 62, "endLine": 79 },
+    "type": "lemma",
+    "title": "Order 2k Forces xᵏ = −1",
+    "content": "pow_half_orderOf_eq_neg_one makes the 'even period' hypothesis algebraic: in a field, an element x of multiplicative order 2k satisfies xᵏ = −1. Since (xᵏ)² = x^{2k} = 1, factoring gives (xᵏ − 1)(xᵏ + 1) = 0, so xᵏ = ±1. The value +1 is excluded because xᵏ = 1 would force the order 2k to divide k, impossible for k ≥ 1. Hence xᵏ = −1.",
+    "mathContext": "$\\operatorname{ord}(x) = 2k \\implies (x^k)^2 = 1 \\text{ and } x^k \\neq 1 \\implies x^k = -1.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "roots of unity", "field of fractions", "orderOf_dvd_of_pow_eq_one"],
+    "prerequisites": ["group theory", "field theory"]
+  },
+  {
+    "id": "ann-midy-bridge",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 85, "endLine": 94 },
+    "type": "theorem",
+    "title": "Even Period Gives p ∣ bᵏ + 1",
+    "content": "period_even_dvd is the number-theoretic bridge: if the order of b modulo the prime p is 2k (i.e. the period of 1/p in base b is 2k), then p ∣ bᵏ + 1. It applies the field lemma to x = (b : ZMod p), obtaining bᵏ ≡ −1 (mod p), so bᵏ + 1 ≡ 0, and ZMod.natCast_eq_zero_iff converts the congruence back to a divisibility in ℕ. ZMod p is a field because p is prime (Fact p.Prime).",
+    "mathContext": "$\\operatorname{ord}_p(b) = 2k \\implies b^k \\equiv -1 \\pmod p \\implies p \\mid b^k + 1.$",
+    "significance": "key",
+    "relatedConcepts": ["ZMod p", "multiplicative order modulo p", "Fact p.Prime", "natCast_eq_zero_iff"],
+    "prerequisites": ["modular arithmetic", "finite fields"]
+  },
+  {
+    "id": "ann-midy-main",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 100, "endLine": 132 },
+    "type": "theorem",
+    "title": "Midy's Theorem (Assembled)",
+    "content": "midy_theorem combines the kernel with the divisibility p ∣ bᵏ + 1. Writing bᵏ + 1 = p·m, it shows the repetend factors exactly: b^{2k} − 1 = (bᵏ−1)(bᵏ+1) = p·((bᵏ−1)·m), so N = (b^{2k}−1)/p = (bᵏ−1)·m. The hypothesis bounds 1 ≤ m ≤ bᵏ are derived (m ≥ 1 since p·m = bᵏ+1 > 0; m ≤ bᵏ since 2m ≤ p·m = bᵏ+1 ≤ 2bᵏ), so midy_kernel finishes.",
+    "mathContext": "$b^{2k}-1 = p\\,(b^k-1)m \\implies N = (b^k-1)m, \\quad 1 \\le m \\le b^k.$",
+    "significance": "critical",
+    "relatedConcepts": ["repetend", "difference of squares", "exact division"],
+    "prerequisites": ["number theory", "divisibility"]
+  },
+  {
+    "id": "ann-midy-m-bounds",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 108, "endLine": 119 },
+    "type": "tactic",
+    "title": "Deriving the Multiplier Bounds 1 ≤ m ≤ bᵏ",
+    "content": "From p ∣ bᵏ + 1 we write bᵏ + 1 = p·m and must justify the kernel's preconditions on m. The lower bound m ≥ 1 follows because m = 0 would make p·m = 0 ≠ bᵏ + 1. The upper bound m ≤ bᵏ uses 2m ≤ p·m (as p ≥ 2) together with p·m = bᵏ + 1 ≤ 2bᵏ, closed by omega. These bounds are exactly the kernel's hypotheses hm1, hm2.",
+    "mathContext": "$2m \\le pm = b^k + 1 \\le 2b^k \\implies m \\le b^k; \\quad pm = b^k+1 > 0 \\implies m \\ge 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["omega", "linear arithmetic", "divisibility witness"],
+    "prerequisites": ["inequalities", "Lean tactics"]
+  },
+  {
+    "id": "ann-midy-example",
+    "proofId": "midy-theorem-oq-01",
+    "range": { "startLine": 134, "endLine": 144 },
+    "type": "insight",
+    "title": "Worked Example: 1/7 = 0.142857…",
+    "content": "The canonical instance: 1/7 = 0.\\overline{142857} has period 6 = 2·3, so k = 3. The repetend 142857 splits into 142 + 857 = 999 = 10³ − 1. Here p = 7, b = 10, and 7 ∣ 10³ + 1 = 1001 = 7·11·13, confirming the even-period hypothesis. Both the half-sum identity and the divisibility are checked by decide, giving a fully computational sanity check of the general theorem.",
+    "mathContext": "$142 + 857 = 999 = 10^3 - 1, \\quad 7 \\mid 1001 = 10^3 + 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic number 142857", "decide tactic", "base-10 repetends"],
+    "prerequisites": ["decimal expansions"]
+  }
+]


### PR DESCRIPTION
## Summary
Enrichment pass for `midy-theorem-oq-01` (Midy's theorem on complementary halves of repeating decimals). The entry had a complete meta.json but **no annotations.json** — the quality gap (q43).

## Changes
- Added `annotations.json` with **7 line-anchored annotations**, all resolver-validated (`Valid: 7, Misaligned: 0`).
- Coverage: the theorem overview, the arithmetic kernel `midy_kernel`, the algebraic lemma `pow_half_orderOf_eq_neg_one` (order 2k ⟹ xᵏ = −1), the number-theoretic bridge `period_even_dvd` (even period ⟹ p ∣ bᵏ + 1), the assembled `midy_theorem`, the multiplier-bound derivation, and the 1/7 = 0.142857 worked example.
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- `resolver.ts validate` → 7 valid, 0 misaligned against the Lean source.