### PR TITLE
Enrich Weitzenböck inequality: sections, keyInsights, implications

### DIFF
--- a/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01/meta.json
@@ -57,7 +57,9 @@
     "keyInsights": [
       "Weitzenböck reduces to the most basic symmetric SOS inequality x²+y²+z² ≥ xy+yz+zx with x = a², y = b², z = c².",
       "The √3 never needs an analytic bound — squaring plus nonnegativity makes Real.sqrt_sq do all the work.",
-      "The equality gap is precisely 2·Σ(a²−b²)², which exposes why equality forces an equilateral triangle and points directly at the Hadwiger–Finsler refinement."
+      "The equality gap is precisely 2·Σ(a²−b²)², which exposes why equality forces an equilateral triangle and points directly at the Hadwiger–Finsler refinement.",
+      "Taking Heron's identity in squared form 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ as the definition of area sidesteps all of measure theory: the entire proof becomes a polynomial fact that nlinarith can certify from three sq_nonneg hints.",
+      "The squared formulation weitzenbock_sq is reused verbatim in the equality characterization — the same SOS identity that proves the inequality also pins down its equality case, so no separate analysis is needed."
     ],
     "prerequisites": [
       "Real square root basics (Real.sqrt_sq, Real.sq_sqrt, monotonicity)",
@@ -78,11 +80,63 @@
   ],
   "conclusion": {
     "summary": "Weitzenböck's inequality a²+b²+c² ≥ 4√3·T is reduced to a one-line sum-of-squares identity after squaring and applying Heron's formula. The equality case (equilateral triangle) falls out of the vanishing of that sum of squares.",
+    "implications": "The proof demonstrates that a classically geometric isoperimetric-type bound collapses to elementary polynomial algebra once area is encoded via Heron's identity: no trigonometry, no calculus, and no analytic estimate of √3 is required. The explicit equality gap 2·Σ(a²−b²)² is the algebraic seed of the stronger Hadwiger–Finsler inequality, so this formalization is a natural base case for a hierarchy of sharper triangle inequalities. More broadly it illustrates a reusable pattern — square a √-laden inequality, discharge the polynomial residue with nlinarith, then recover the linear form via sqrt monotonicity — applicable to many geometric inequalities involving √3 or √2.",
     "openQuestions": [
       "Hadwiger–Finsler refinement",
       "Coordinate-free derivation of the area hypothesis"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview and Approach",
+      "startLine": 4,
+      "endLine": 24,
+      "summary": "Module docstring stating a²+b²+c² ≥ 4√3·T with equality iff equilateral, and outlining the algebraic route: Heron's squared identity, squaring the target to (a²+b²+c²)² ≥ 48T², and the sum-of-squares residue."
+    },
+    {
+      "id": "sec-heron-def",
+      "title": "Heron's Squared-Area Definition",
+      "startLine": 28,
+      "endLine": 33,
+      "summary": "Defines heronArea16Sq a b c = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴, taken as the algebraic definition of 16T²."
+    },
+    {
+      "id": "sec-sos-core",
+      "title": "Sum-of-Squares Core",
+      "startLine": 35,
+      "endLine": 37,
+      "summary": "sos_core: the elementary inequality x²+y²+z² ≥ xy+yz+zx for all reals, proved by nlinarith on three sq_nonneg hints."
+    },
+    {
+      "id": "sec-sq-cancel",
+      "title": "Square Cancellation for Nonnegatives",
+      "startLine": 39,
+      "endLine": 43,
+      "summary": "eq_of_sq_eq_sq: for u, v ≥ 0, u² = v² implies u = v, via Real.sqrt_sq. Used to recover linear equalities from squared ones."
+    },
+    {
+      "id": "sec-weitzenbock-sq",
+      "title": "Squared Inequality",
+      "startLine": 45,
+      "endLine": 52,
+      "summary": "weitzenbock_sq: (a²+b²+c²)² ≥ 48T². Rewrites 48T² = 3·(16T²), unfolds Heron, and discharges the SOS residue 2((a²−b²)²+(b²−c²)²+(c²−a²)²) ≥ 0 with nlinarith."
+    },
+    {
+      "id": "sec-weitzenbock",
+      "title": "Main Inequality",
+      "startLine": 54,
+      "endLine": 70,
+      "summary": "weitzenbock: a²+b²+c² ≥ 4√3·T. Establishes both sides nonnegative, (4√3·T)² = 48T² via Real.sq_sqrt, then a calc chain using Real.sqrt_sq and Real.sqrt_le_sqrt to pass from the squared to the linear inequality."
+    },
+    {
+      "id": "sec-equality",
+      "title": "Equality Characterization",
+      "startLine": 72,
+      "endLine": 105,
+      "summary": "weitzenbock_eq_iff: equality holds iff a = b = c for positive sides. Reduces the √3 equality to 48T² = (a²+b²+c²)², forces each (a²−b²)² = 0, and recovers a = b = c via eq_of_sq_eq_sq."
+    }
+  ],
   "references": [
     {
       "authors": "Weitzenböck, Roland",


### PR DESCRIPTION
## Summary
Enrichment pass for `weitzenbock-inequality-oq-01`. The entry already had 7 solid annotations (q81) but the meta.json had structural gaps: no `sections`, only 3 `keyInsights`, and a `conclusion` missing `implications`.

## Changes
- **Sections (0 → 7):** added sections covering the full Lean file — overview, Heron squared-area definition, SOS core, square-cancellation lemma, squared inequality, main inequality, and equality characterization — with line ranges matching the source.
- **keyInsights (3 → 5):** added that taking Heron's identity as the area definition sidesteps measure theory, and that the squared form is reused verbatim for the equality case.
- **conclusion.implications:** added (algebraic collapse of a geometric bound, the explicit gap as the Hadwiger–Finsler seed, and the reusable square-then-nlinarith pattern).

## Verification
- meta.json parses; keyInsights = 5, sections = 7, conclusion has summary/implications/openQuestions.
- Section line ranges checked against `proofs/Proofs/WeitzenbockInequalityOQ01.lean`.