### PR TITLE
Enrich Dilworth & Mirsky (dilworth-theorem-oq-01)

### DIFF
--- a/src/data/proofs/dilworth-theorem-oq-01/annotations.json
+++ b/src/data/proofs/dilworth-theorem-oq-01/annotations.json
@@ -70,5 +70,17 @@
     "significance": "key",
     "relatedConcepts": ["duality", "pigeonhole principle", "Mirsky's theorem"],
     "prerequisites": ["pigeonhole principle", "Finset cardinality"]
+  },
+  {
+    "id": "ann-choice-technique",
+    "proofId": "dilworth-theorem-oq-01",
+    "range": { "startLine": 76, "endLine": 91 },
+    "type": "tactic",
+    "title": "From a Cover Hypothesis to a Choice Function",
+    "content": "The shared mechanism of both proofs. The cover hypothesis only asserts *existence* of a containing chain per element (`∃ C ∈ 𝒞, a ∈ C`); to run pigeonhole one needs an actual function. `classical` plus the dependent-if `fun a => if h : ∃ C ∈ 𝒞, a ∈ C then h.choose else ∅` materializes that choice, with `dif_pos` recovering `f a = h.choose` and `h.choose_spec` supplying both `f a ∈ 𝒞` and `a ∈ f a`. `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` is then the pigeonhole that produces the colliding pair killed by the fundamental lemma. The identical block reappears verbatim in the Mirsky proof with `𝒜` for `𝒞`.",
+    "mathContext": "$f(a) := \\text{a chosen } C \\in \\mathcal{C} \\text{ with } a \\in C;\\ |A| > |\\mathcal{C}| \\Rightarrow \\exists\\, x \\ne y,\\ f(x) = f(y).$",
+    "significance": "supporting",
+    "relatedConcepts": ["classical choice", "dependent if-then-else", "Exists.choose", "pigeonhole principle"],
+    "prerequisites": ["classical logic in Lean", "Finset cardinality"]
   }
 ]

--- a/src/data/proofs/dilworth-theorem-oq-01/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01/meta.json
@@ -49,7 +49,8 @@
       "Both inequalities are a single pigeonhole argument; the only mathematical content is that a chain and an antichain meet in at most one point.",
       "Encoding an antichain as `x ≤ y → x = y` (for members `x, y`) captures incomparability of distinct elements while staying convenient for `≤`-reasoning.",
       "The Dilworth and Mirsky easy directions are literally the same proof with chain and antichain swapped, witnessing the self-duality of the construction.",
-      "No finiteness of the poset is needed — only the covering family and the chain/antichain in question are `Finset`s."
+      "No finiteness of the poset is needed — only the covering family and the chain/antichain in question are `Finset`s.",
+      "All the combinatorial depth lives in the *hard* directions (attainment of the bound): Dilworth's attainment is classically equivalent to König's theorem and is proved via augmenting paths or max-flow–min-cut. Proving only the easy directions isolates the pure pigeonhole core and makes explicit that none of that machinery is invoked here."
     ],
     "prerequisites": [
       "Partial orders: comparability, chains, antichains",


### PR DESCRIPTION
Enrichment pass for `dilworth-theorem-oq-01` (quality 93, passes 0). The entry was already strong; this adds two genuine value-adds rather than padding.

## Changes
- **+1 keyInsight (4→5):** The easy directions proved here carry no combinatorial depth — all of it lives in the *hard* directions (attainment), where Dilworth is classically equivalent to König's theorem / max-flow–min-cut. The insight makes explicit what is deliberately not invoked.
- **+1 annotation (6→7):** Documents the shared `classical` + dependent-if choice-function + `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` pigeonhole mechanism reused verbatim in both the Dilworth and Mirsky proofs (type `tactic`, lines 76–91).

## Validation
- `resolver.ts validate`: **7/7 annotations aligned, 0 misaligned**
- Both meta.json and annotations.json parse cleanly (jq)
- Axiom integrity unchanged: status `verified`, axiomCount 0, sorries 0 — matches the Lean source

No existing content removed.