### PR TITLE
research(lagrange-waring-g2-oq-03): constructive Lagrange-reduction witness for the Q<2p slice leaf

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/G3-slice-constructive-route.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/G3-slice-constructive-route.md
@@ -1,0 +1,95 @@
+# G3 — A constructive (measure-theory-free) route for the `Q < 2p` slice leaf
+
+**Session:** 2026-06-16 (researcher-2). **Status:** build-free research delta;
+both Docker (`docker ps` exit 124) and Aristotle (`prove` → "Resource not found",
+the documented 404) are down, so no Lean was built or submitted.
+
+## The single open leaf
+
+After PR #24967 (merged) isolated the `Q < 2p` step into
+`proofs/Proofs/ThreeSquaresSliceMinkowski.lean`, the entire remaining open
+content of `dirichlet_key_lemma` is one self-contained 2D existence statement:
+
+```lean
+theorem exists_slice_point_lt_two_mul
+    (p d : ℕ) (hp : 0 < p) (hd : 0 < d) (hd2 : d ≤ 2) (r : ℤ) :
+    ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
+      x ^ 2 + (d : ℤ) * y ^ 2 < 2 * p := by sorry
+```
+
+The bridge (`slice_point_to_dirichlet_vector`) and the assembled existence
+(`exists_dirichlet_vector_lt_two_mul`) in that file are already proved; this
+`sorry` is the only gap, and it is flagged there as "the Aristotle target".
+
+## Finding: the witness is explicitly constructive
+
+The file's docstring proposes proving the leaf via a 2D Minkowski convex-body
+bound on the disk `x² + d·y² < 2p`. That is correct but would require porting
+Mathlib's Haar-measure GoN lemma
+(`MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`,
+used in the 3D `minkowski_ellipsoid_has_lattice_point`) down to two dimensions —
+the same measure-theoretic apparatus that proved too weak in 3D.
+
+It is unnecessary. The index-`p` sublattice
+`L = {(x,y) ∈ ℤ² : p ∣ (x − r·y)}` has the **explicit basis** `{(p,0),(r,1)}`
+(since `x = r·y + p·k`). Running **Lagrange–Gauss 2D reduction** on this basis
+under the `d`-weighted inner product `⟨(x₁,y₁),(x₂,y₂)⟩ = x₁x₂ + d·y₁y₂` returns
+the shortest nonzero vector `v ∈ L`, which satisfies the 2D Hermite bound
+
+```
+N(v) = v₀² + d·v₁² ≤ γ₂·√d·p = (2/√3)·√d·p
+```
+
+and `(2/√3)·√d < 2` **exactly for `d ≤ 2`** (d=1: 1.1547, d=2: 1.6330; d=3:
+2.0000 — the boundary). This is elementary number theory: no measure theory, no
+Haar volume, no convex-body theorem.
+
+## Certificate
+
+`verify_slice_constructive_witness.py` (committed, pure stdlib, runnable):
+over **all** primes `p < 2000`, both `d ∈ {1,2}`, and **every** residue
+`r ∈ [0,p)` — 554,100 triples:
+
+- zero-vector failures: **0**
+- membership failures (`p ∣ v₀ − r·v₁`): **0**
+- `N(v) ≥ 2p` failures: **0**
+- worst `N(v)/p`: d=1 → 1.15053 (ceiling 1.15470), d=2 → 1.63068 (ceiling
+  1.63299) — i.e. the construction saturates the Hermite bound
+- max reduction steps over all triples: **5** (O(log p) termination)
+
+This strictly extends the prior `verify_minkowski_2p_gap.py`, which (a) only
+scanned `r = √(−d) mod p` whereas the Lean leaf quantifies over arbitrary `r:ℤ`,
+and (b) used a brute-force window with no algorithm. Here the witness is produced
+by a deterministic reduction — the exact recursion a Lean proof would induct on.
+
+## Recommended formalization route (when Docker/Aristotle return)
+
+Prove `exists_slice_point_lt_two_mul` by Lagrange–Gauss reduction, not GoN:
+
+1. **Termination / shortest vector.** Reduction strictly decreases
+   `max(N(b₁),N(b₂))` until `|⟨b₁,b₂⟩| ≤ ½N(b₁)` — a well-founded recursion on
+   `ℕ` (the norm is a non-negative integer). Empirically ≤ 5 steps; the bound is
+   the continued-fraction length of `r/p`.
+2. **Reduced ⟹ bound.** For a reduced basis, `N(b₁)·N(b₂) ≤ (4/3)·det²` and
+   `det(L) = p`, giving `N(b₁) ≤ (2/√3)·√d·p`. Working over ℤ, avoid the real
+   `√` by squaring: `3·N(b₁)² ≤ 4·d·p²`, then `N(b₁) < 2p` follows from
+   `3·(2p)² = 12p² > 4·d·p²` ⇔ `d < 3`, i.e. `d ≤ 2` (`interval_cases d`).
+3. **Membership** is preserved by integer column operations from the start basis
+   `{(p,0),(r,1)} ⊂ L`.
+
+Mathlib-bearer status: a direct binary-quadratic-form *reduced-form / shortest
+vector* lemma does NOT appear to exist in the gallery or be readily citable from
+Mathlib (grep of `proofs/Proofs/` found no reduction bearer; the gallery's
+`MinkowskiTheoremOQ02OQ01.lean` is Dirichlet-approximation, not a short-vector
+bound). So step 2 must be built. It is, however, a self-contained elementary
+lemma and a far better Aristotle target than the measure-theoretic alternative —
+resubmit `exists_slice_point_lt_two_mul` to Aristotle once the 404 clears, with
+the hint "Lagrange–Gauss reduce {(p,0),(r,1)} under x²+d·y²; interval_cases d".
+
+## Honest scope
+
+This session changed **no Lean** and eliminated **no axiom** — both verification
+backends were down. The deliverable is a verified-by-computation route
+re-characterization: the keystone leaf has an explicit, measure-theory-free,
+O(log p) constructive witness, which materially de-risks (and shrinks) its
+eventual formalization. `ThreeSquares.lean` still carries its 2 axioms.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -486,3 +486,42 @@ precedent shows under-blackout files can carry real errors that grep cannot see.
 `DirichletWitnessProperty` they reference is the documented FALSE/dead-end route,
 so verify carefully before registering — registering a vacuous-hypothesis file
 is low value.)
+
+## Session 2026-06-16 (researcher-2) — the `Q<2p` slice leaf has an explicit O(log p) constructive witness (no measure theory)
+
+Dual blackout again (Docker `docker ps` exit 124; Aristotle `prove` → "Resource
+not found" 404). No Lean built/submitted. Build-free route-sharpening delta.
+
+**Current open state (verified, not stale).** PR #24967 is MERGED:
+`proofs/Proofs/ThreeSquaresSliceMinkowski.lean` now isolates the entire open
+content of `dirichlet_key_lemma` into ONE self-contained 2D leaf,
+`exists_slice_point_lt_two_mul (p d r)`, `d ≤ 2` — the bridge and assembly above
+it are proved; this lone `sorry` is the "Aristotle target". The file is
+intentionally UNregistered (carries the sorry). `ThreeSquares.lean` axiom count
+UNCHANGED (still 2). My own prior cert PR #25120 (universal single-AP QR seed) is
+still OPEN — do NOT duplicate it.
+
+**Finding.** The leaf does NOT need a 2D port of the Haar-measure Minkowski
+lemma (the file's docstring plan). The index-`p` sublattice
+`L={(x,y):p∣(x−r·y)}` has explicit basis `{(p,0),(r,1)}`; **Lagrange–Gauss 2D
+reduction** under `⟨·,·⟩=x₁x₂+d·y₁y₂` yields the shortest vector with
+`N=x²+d·y² ≤ (2/√3)·√d·p`, which is `<2p` iff `d≤2` (d=3 ceiling is EXACTLY 2.0 —
+that is the structural reason for the `d≤2` hypothesis). Elementary, no measure
+theory, terminates in ≤5 steps (O(log p), = CF length of r/p).
+
+**Certificate** `verify_slice_constructive_witness.py` (committed, pure stdlib):
+ALL primes p<2000, d∈{1,2}, EVERY residue r∈[0,p) = 554,100 triples → 0 bound
+failures, 0 membership failures, worst N/p = 1.63068 (d=2, ceiling 1.63299),
+max 5 reduction steps. Strictly extends `verify_minkowski_2p_gap.py` (which only
+scanned r=√(−d) mod p and had no algorithm; the Lean leaf quantifies over
+arbitrary r:ℤ).
+
+**Formalization recipe (post-blackout)** in `G3-slice-constructive-route.md`:
+prove the leaf by reduction, not GoN. (1) reduction = well-founded recursion on
+the integer norm; (2) reduced ⟹ `3·N(b₁)² ≤ 4·d·p²` ⟹ `N(b₁)<2p` for d≤2 via
+`interval_cases d` (square to dodge real √); (3) membership preserved by integer
+column ops. NOTE: grep found NO binary-form reduction bearer in the gallery and
+Mathlib has no readily-citable shortest-vector-of-binary-form lemma, so step (2)
+must be built — but it is elementary and a far better Aristotle target than the
+measure-theoretic route. Resubmit the leaf to Aristotle with hint "Lagrange–Gauss
+reduce {(p,0),(r,1)} under x²+d·y²; interval_cases d" once the 404 clears.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_slice_constructive_witness.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_slice_constructive_witness.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+verify_slice_constructive_witness.py
+====================================
+
+Purpose: certify that the SOLE remaining open leaf of `dirichlet_key_lemma`
+in `proofs/Proofs/ThreeSquares.lean` -- namely
+
+  ThreeSquaresSlice.exists_slice_point_lt_two_mul
+    (p d : ℕ) (hp : 0 < p) (hd : 0 < d) (hd2 : d ≤ 2) (r : ℤ) :
+      ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
+        x ^ 2 + (d : ℤ) * y ^ 2 < 2 * p
+
+-- admits an EXPLICIT, CONSTRUCTIVE witness, so its Lean proof need not port the
+heavy measure-theoretic Minkowski machinery
+(`MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`)
+down to two dimensions.
+
+Background (researcher-11, G2-minkowski-2p-gap.md): the 3D index-p^2 ellipsoid
+route cannot supply `Q < 2p` (generic 2^n Minkowski only gives Q ~ p^(4/3)).
+The attainable route is the 2D slice z=0: the index-p sublattice
+`L = {(x,y) ∈ ℤ² : p ∣ (x − r·y)}` with the binary form N(x,y)=x²+d·y². The
+abstract claim is the 2D Minkowski/Hermite bound. This script shows the SAME
+bound is realized CONSTRUCTIVELY by Lagrange–Gauss reduction of the explicit
+sublattice basis {(p,0),(r,1)} under the d-weighted inner product -- which is
+elementary (no measure theory) and terminates in a handful of steps.
+
+Two things the prior cert (verify_minkowski_2p_gap.py) did NOT establish:
+  1. It only scanned r = reduced sqrt(-d) mod p. The Lean leaf is stated for an
+     ARBITRARY r:ℤ. Here we certify ALL residues r ∈ {0,...,p-1}.
+  2. It used a brute-force window search, giving no algorithm. Here the witness
+     is produced by a deterministic O(log p) reduction, the shape a Lean proof
+     would induct on.
+
+Checks (p < PMAX prime, d ∈ {1,2}, every r):
+  [A] The reduced shortest vector v is NONZERO and lies in L (p ∣ v0 − r·v1).
+  [B] N(v) < 2p  ==>  discharges exists_slice_point_lt_two_mul.
+  [C] The worst-case ratio N(v)/p approaches the 2D Hermite ceiling
+      gamma_2 * sqrt(d) = (2/√3)·√d, which is < 2 exactly for d ≤ 2
+      (d=1: 1.1547, d=2: 1.6330); for d=3 it is 2.0000 -- the boundary that
+      forces the `d ≤ 2` hypothesis.
+  [D] Reduction terminates in a small bounded number of steps (O(log p)).
+
+Run: python3 verify_slice_constructive_witness.py
+"""
+
+import math
+
+PMAX = 2000
+
+
+def primes_below(n):
+    sieve = bytearray([1]) * n
+    sieve[0:2] = b"\x00\x00"
+    for i in range(2, int(n ** 0.5) + 1):
+        if sieve[i]:
+            sieve[i * i::i] = bytearray(len(sieve[i * i::i]))
+    return [i for i in range(2, n) if sieve[i]]
+
+
+def norm(v, d):
+    x, y = v
+    return x * x + d * y * y
+
+
+def dot(a, b, d):
+    return a[0] * b[0] + d * a[1] * b[1]
+
+
+def gauss_reduce(b1, b2, d):
+    """Lagrange–Gauss 2D reduction under the d-weighted inner product
+       <(x1,y1),(x2,y2)> = x1*x2 + d*y1*y2. Returns (b1,b2,steps) with b1 the
+       shortest nonzero vector of the lattice spanned by the inputs."""
+    steps = 0
+    while True:
+        if norm(b2, d) < norm(b1, d):
+            b1, b2 = b2, b1
+        n1 = norm(b1, d)
+        if n1 == 0:
+            return b1, b2, steps
+        # closest-integer projection coefficient
+        m = round(dot(b1, b2, d) / n1)
+        if m == 0:
+            return b1, b2, steps
+        b2 = (b2[0] - m * b1[0], b2[1] - m * b1[1])
+        steps += 1
+
+
+def shortest_in_sublattice(p, d, r):
+    """Constructive shortest vector of L = {(x,y): p | (x - r y)} under N(.,d).
+       Basis: (p,0) and (r,1) (these generate L: x = r*y + p*k)."""
+    s1, s2, steps = gauss_reduce((p, 0), (r, 1), d)
+    v = s1 if norm(s1, d) <= norm(s2, d) else s2
+    return v, steps
+
+
+def main():
+    primes = primes_below(PMAX)
+    checked = 0
+    bound_fail = 0
+    membership_fail = 0
+    zero_fail = 0
+    worst_ratio = {1: 0.0, 2: 0.0}
+    worst_at = {1: None, 2: None}
+    max_steps = 0
+
+    for p in primes:
+        for d in (1, 2):
+            for r in range(0, p):
+                v, steps = shortest_in_sublattice(p, d, r)
+                checked += 1
+                max_steps = max(max_steps, steps)
+                if v == (0, 0):
+                    zero_fail += 1
+                if (v[0] - r * v[1]) % p != 0:
+                    membership_fail += 1
+                q = norm(v, d)
+                if not (q < 2 * p):
+                    bound_fail += 1
+                ratio = q / p
+                if ratio > worst_ratio[d]:
+                    worst_ratio[d] = ratio
+                    worst_at[d] = (p, r, v, q)
+
+    hermite = {d: (2.0 / math.sqrt(3.0)) * math.sqrt(d) for d in (1, 2, 3)}
+
+    print("=" * 72)
+    print("Constructive Q<2p witness via Lagrange–Gauss reduction")
+    print(f"p prime < {PMAX}, d ∈ {{1,2}}, EVERY residue r ∈ [0,p)")
+    print("=" * 72)
+    print(f"triples checked .......... {checked}")
+    print(f"[A] zero-vector failures . {zero_fail}   (must be 0)")
+    print(f"[A] membership failures .. {membership_fail}   (p ∣ x−r·y; must be 0)")
+    print(f"[B] N(v) ≥ 2p failures ... {bound_fail}   (must be 0)")
+    print(f"[D] max reduction steps .. {max_steps}   (O(log p) termination)")
+    print()
+    print("[C] worst observed N(v)/p vs 2D Hermite ceiling (2/√3)·√d:")
+    for d in (1, 2):
+        print(f"    d={d}: worst {worst_ratio[d]:.5f}  ceiling {hermite[d]:.5f}"
+              f"   at (p,r,v,N)={worst_at[d]}")
+    print(f"    d=3 ceiling = {hermite[3]:.5f}  (= 2.0 exactly -> the boundary")
+    print("         that forces the `d ≤ 2` hypothesis of the leaf lemma)")
+    print()
+
+    ok = (zero_fail == 0 and membership_fail == 0 and bound_fail == 0
+          and all(worst_ratio[d] < 2.0 for d in (1, 2)))
+    print("RESULT:", "ALL CHECKS PASS" if ok else "FAILURES PRESENT")
+    print()
+    print("INTERPRETATION")
+    print("-" * 72)
+    print("  exists_slice_point_lt_two_mul is realized by a DETERMINISTIC,")
+    print("  measure-theory-free construction: Lagrange–Gauss reduction of the")
+    print("  explicit basis {(p,0),(r,1)} of the index-p sublattice. The Lean")
+    print("  proof can therefore induct on the reduction (a strictly decreasing")
+    print("  norm well-order) and conclude N(reduced) ≤ (2/√3)·√d·p < 2p for")
+    print("  d ∈ {1,2}, instead of porting the 3D Haar-measure Minkowski lemma")
+    print("  to 2D. The d=3 ceiling hitting exactly 2.0 is the structural reason")
+    print("  the leaf is stated only for d ≤ 2.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Build-free research delta for `lagrange-four-squares-waring-g2-oq-03` (the "if"
direction of Legendre's three-square theorem). Both verification backends are
down this cycle (Docker `docker ps` exit 124; Aristotle `prove` → 404), so no
Lean was built or submitted. **`ThreeSquares.lean` axiom count is unchanged (2).**

After PR #24967 (merged) isolated the last open step of `dirichlet_key_lemma`
into the single 2D leaf `exists_slice_point_lt_two_mul` (in
`ThreeSquaresSliceMinkowski.lean` — bridge + assembly already proved, this lone
`sorry` is the "Aristotle target"), this PR sharpens its proof route.

**Finding.** The leaf does **not** need a 2D port of the Haar-measure Minkowski
lemma. The index-`p` sublattice `L = {(x,y) : p ∣ (x−r·y)}` has explicit basis
`{(p,0),(r,1)}`; **Lagrange–Gauss reduction** under `x²+d·y²` yields the shortest
vector with `N ≤ (2/√3)·√d·p`, which is `< 2p` iff `d ≤ 2`. Elementary, no
measure theory, O(log p) termination.

## What's here

- `verify_slice_constructive_witness.py` — ALL primes `p<2000`, `d∈{1,2}`,
  **every** residue `r∈[0,p)` (554,100 triples): **0** bound failures, **0**
  membership failures, worst `N/p = 1.63068` (d=2 Hermite ceiling 1.63299), max
  **5** reduction steps. Strictly extends the prior `verify_minkowski_2p_gap.py`
  (which scanned only `r=√(−d) mod p` and gave no algorithm; the Lean leaf
  quantifies over arbitrary `r:ℤ`).
- `G3-slice-constructive-route.md` — the recommended formalization: prove the
  leaf by reduction (square to avoid real √: `3·N² ≤ 4·d·p² ⟹ N<2p` iff `d<3`,
  then `interval_cases d`), not GoN. The `d=3` Hermite ceiling is **exactly 2.0**
  — the structural reason for the `d≤2` hypothesis.
- `knowledge.md` — session note.

## Why it matters

Converts the keystone leaf from "needs a 2D Minkowski convex-body theorem
(measure theory)" to "needs an elementary binary-form reduction bound", a
materially smaller and more Aristotle-tractable target. Honest caveat: grep found
no binary-form reduction bearer in the gallery / no readily-citable Mathlib
shortest-vector lemma, so the reduced-form bound must still be built and
build-verified once Docker/Aristotle return.

## Test plan

- [x] `python3 research/problems/lagrange-four-squares-waring-g2-oq-03/verify_slice_constructive_witness.py` → ALL CHECKS PASS
- [ ] (post-blackout) formalize per G3 and build-verify; resubmit leaf to Aristotle

🤖 Generated with [Claude Code](https://claude.com/claude-code)