### PR TITLE
Enrich Varignon's theorem: fix annotation type, expand to 5

### DIFF
--- a/src/data/proofs/varignon-theorem-oq-01/annotations.json
+++ b/src/data/proofs/varignon-theorem-oq-01/annotations.json
@@ -24,13 +24,36 @@
     "crossReferences": []
   },
   {
+    "id": "ann-midpoint-def",
+    "proofId": "varignon-theorem-oq-01",
+    "range": {
+      "startLine": 33,
+      "endLine": 37
+    },
+    "type": "definition",
+    "title": "Point and Midpoint Operations",
+    "content": "Point is an abbreviation for ℝ × ℝ, and midpoint2 X Y is defined as the componentwise average ((X.1+Y.1)/2, (X.2+Y.2)/2). midpoint2 is marked noncomputable only because real-number division is noncomputable in Lean; mathematically it is the ordinary midpoint. Because the whole development is phrased in these explicit coordinates, every later claim reduces to an algebraic identity that ring can verify after unfolding midpoint2.",
+    "mathContext": "$\\operatorname{midpoint2}(X,Y) = \\bigl(\\tfrac{X_1+Y_1}{2}, \\tfrac{X_2+Y_2}{2}\\bigr) \\in \\mathbb{R}\\times\\mathbb{R}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "midpoint",
+      "affine combination",
+      "noncomputable definitions"
+    ],
+    "prerequisites": [
+      "product types in Lean",
+      "the midpoint formula"
+    ],
+    "crossReferences": []
+  },
+  {
     "id": "ann-strong-form",
     "proofId": "varignon-theorem-oq-01",
     "range": {
       "startLine": 39,
-      "endLine": 55
+      "endLine": 52
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Each Varignon Side Equals Half a Diagonal",
     "content": "The two strong-form lemmas compute the opposite sides PQ and SR of the midpoint quadrilateral. Both come out equal to (C − A)/2: for PQ, Q − P = (B+C)/2 − (A+B)/2 = (C − A)/2; for SR, R − S = (C+D)/2 − (D+A)/2 = (C − A)/2. So each of these sides is parallel to the diagonal AC and exactly half its length — the strong form of Varignon's theorem. Each coordinate identity is discharged by `dsimp only [midpoint2]` (to reduce the pair projections) followed by `ring`.",
     "mathContext": "$Q-P=\\tfrac{B+C}{2}-\\tfrac{A+B}{2}=\\tfrac{C-A}{2}$ and $R-S=\\tfrac{C+D}{2}-\\tfrac{D+A}{2}=\\tfrac{C-A}{2}$.",
@@ -50,13 +73,13 @@
     "id": "ann-main",
     "proofId": "varignon-theorem-oq-01",
     "range": {
-      "startLine": 56,
-      "endLine": 70
+      "startLine": 54,
+      "endLine": 61
     },
-    "type": "concept",
+    "type": "theorem",
     "title": "The Parallelogram Conclusion",
-    "content": "The theorem varignon states the parallelogram property directly: Q − P = R − S, componentwise. This follows because both differences equal (C − A)/2, as established by the strong-form lemmas. The companion varignon_PS_eq_QR shows the other pair of opposite sides is also equal, P − S = Q − R, each equal to (B − D)/2 = half the diagonal BD. With both pairs of opposite side vectors equal, PQRS is a parallelogram. The proof invokes no Mathlib geometry — only `ring` on the coordinate identities — and uses no non-degeneracy hypothesis, so it covers arbitrary (including self-intersecting and skew) quadrilaterals.",
-    "mathContext": "Both pairs of opposite sides are equal as vectors: $Q-P=R-S=\\tfrac{C-A}{2}$ and $P-S=Q-R=\\tfrac{B-D}{2}$. Hence $PQRS$ is a parallelogram with sides half the diagonals of $ABCD$.",
+    "content": "The theorem varignon states the parallelogram property directly: Q − P = R − S, componentwise. This follows because both differences equal (C − A)/2, as established by the strong-form lemmas. With this pair of opposite side vectors equal, PQRS is a parallelogram. The proof invokes no Mathlib geometry — only `ring` on the coordinate identities — and uses no non-degeneracy hypothesis, so it covers arbitrary (including self-intersecting and skew) quadrilaterals.",
+    "mathContext": "$Q-P=R-S=\\tfrac{C-A}{2}$, so the opposite sides $PQ$ and $SR$ are equal as vectors and $PQRS$ is a parallelogram.",
     "significance": "key",
     "relatedConcepts": [
       "parallelogram",
@@ -65,6 +88,28 @@
     ],
     "prerequisites": [
       "parallelogram characterization by equal opposite side vectors"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-second-pair",
+    "proofId": "varignon-theorem-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 69
+    },
+    "type": "theorem",
+    "title": "The Second Pair of Opposite Sides",
+    "content": "varignon_PS_eq_QR confirms the parallelogram from the other pair of sides: P − S = Q − R componentwise, both equal to half the diagonal BD. Establishing both pairs of opposite sides as equal vectors gives the full parallelogram characterization rather than relying on a single pair, and exposes the symmetric role of the two diagonals AC and BD — each Varignon side is half of one of them.",
+    "mathContext": "$P-S=Q-R=\\tfrac{B-D}{2}$; together with $Q-P=R-S=\\tfrac{C-A}{2}$ the four midpoints form a parallelogram whose sides are half the diagonals of $ABCD$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "diagonal BD",
+      "opposite sides",
+      "parallelogram"
+    ],
+    "prerequisites": [
+      "vector subtraction in coordinates"
     ],
     "crossReferences": []
   }


### PR DESCRIPTION
## Summary
Enrichment pass for `varignon-theorem-oq-01`. The entry had 3 annotations, one of which used an **invalid `type`** (`"technique"`, not in the `theorem|lemma|definition|tactic|concept|insight|warning` enum from `src/types/proof.ts`).

## Changes
- Fixed `ann-strong-form` type `"technique"` → `"theorem"`; retyped `ann-main` `"concept"` → `"theorem"` and narrowed its range to the `varignon` declaration.
- Added `ann-midpoint-def` (definition): `Point`/`midpoint2` and why the definition is `noncomputable`.
- Added `ann-second-pair` (theorem): `varignon_PS_eq_QR`, the second pair of opposite sides equal to half diagonal BD.
- 3 → 5 annotations, all with `mathContext`, valid `type`/`significance`.

## Verification
- `resolver.ts validate` → 5 valid, 0 misaligned against the Lean source.