### PR TITLE
Enrich Pompeiu's Theorem (pompeiu-theorem-oq-01)

### DIFF
--- a/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/annotations.json
@@ -58,5 +58,17 @@
     "significance": "key",
     "relatedConcepts": ["cyclic symmetry", "triangle inequality", "vertex relabeling"],
     "prerequisites": ["symmetry arguments"]
+  },
+  {
+    "id": "ann-linear-combination",
+    "proofId": "pompeiu-theorem-oq-01",
+    "range": { "startLine": 44, "endLine": 49 },
+    "type": "tactic",
+    "title": "Using the Identity as a Certificate: linear_combination",
+    "content": "The bridge from the hypothesis-free identity to the inequality. `linear_combination pompeiu_identity a b c p` proves the rearranged goal $(p-a)(b-c) = -((p-b)(c-a) + (p-c)(a-b))$ by certifying that goal-minus-(1·identity) reduces to $0 = 0$ under `ring`. This isolates the $a$-term so that the next line can hit it with `norm_add_le`. The pattern — prove a clean polynomial identity once, then `linear_combination` it into whatever local rearrangement a step needs — is the standard Lean idiom for reusing algebraic identities without re-running `ring` on a bespoke expression each time.",
+    "mathContext": "$\\text{goal} - 1\\cdot\\text{identity} \\xrightarrow{\\text{ring}} 0;\\quad (p-a)(b-c) = -\\big((p-b)(c-a) + (p-c)(a-b)\\big).$",
+    "significance": "supporting",
+    "relatedConcepts": ["linear_combination tactic", "polynomial certificate", "ring normalization", "norm_add_le"],
+    "prerequisites": ["Lean tactics", "commutative ring identities"]
   }
 ]

--- a/src/data/proofs/pompeiu-theorem-oq-01/meta.json
+++ b/src/data/proofs/pompeiu-theorem-oq-01/meta.json
@@ -85,7 +85,8 @@
       "**Hypothesis-free identity**: (p-a)(b-c) + (p-b)(c-a) + (p-c)(a-b) = 0 holds for *any* four points — geometry enters only through the equilateral side-length equality",
       "**Side-length cancellation**: the equilateral hypothesis equates the three coefficient magnitudes so the common side length divides out, turning a weighted inequality into the plain triangle inequality",
       "**Equality = circumcircle**: the degenerate triangle occurs exactly when P lies on the circumcircle, which is the equality case of Ptolemy's inequality for the equilateral triangle",
-      "**Same engine as Ptolemy**: the three-term Lagrange identity used here is the algebraic core shared with the complex-number proof of Ptolemy's inequality"
+      "**Same engine as Ptolemy**: the three-term Lagrange identity used here is the algebraic core shared with the complex-number proof of Ptolemy's inequality",
+      "**Rotation-free**: unlike the gallery's complex proof of Napoleon's theorem — which needs the primitive cube root of unity to encode a 60° rotation — Pompeiu uses no orientation, angle, or rotation data at all. Only the scalar equalities |a-b|=|b-c|=|c-a| are consumed, so the proof never distinguishes the two orientations of the equilateral triangle and holds verbatim for the degenerate (single-point) configuration"
     ],
     "prerequisites": [
       "Complex numbers and arithmetic in ℂ",


### PR DESCRIPTION
Enrichment pass for `pompeiu-theorem-oq-01` (quality 94, passes 0). The entry was already polished; this adds two non-redundant, substantive items rather than filler.

## Changes
- **+1 keyInsight (4→5):** Pompeiu's proof is *rotation-free* — unlike the gallery's complex proof of Napoleon's theorem (which encodes a 60° rotation via the cube root of unity), it consumes only the scalar equalities `|a-b|=|b-c|=|c-a|`, so it never references orientation and holds verbatim for the degenerate single-point configuration.
- **+1 annotation (5→6):** Isolates the `linear_combination pompeiu_identity a b c p` step (lines 44-49) — the standard Lean idiom for reusing a once-proved polynomial identity as a certificate to discharge a bespoke rearrangement without re-running `ring`.

## Validation
- `resolver.ts validate`: **6/6 annotations aligned, 0 misaligned**
- Both JSON files parse cleanly (jq); cross-ref targets `napoleons-theorem` and `ptolemys-complex-proof` confirmed present
- Axiom integrity unchanged: status `verified`, axiomCount 0, sorries 0 — matches the Lean source

No existing content removed.