### PR TITLE
Enrich Thue-Morse (thue-morse-oq-01): add cross-references

### DIFF
--- a/src/data/proofs/thue-morse-oq-01/meta.json
+++ b/src/data/proofs/thue-morse-oq-01/meta.json
@@ -112,5 +112,21 @@
       "Does the digit-sum definition match a `ZMod 2`-valued automaton or `Nat.popCount`-style characterization, and can the equivalence be formalized?"
     ]
   },
-  "crossReferences": []
+  "crossReferences": [
+    {
+      "proofId": "binary-gcd-oq-01",
+      "relationship": "Shared base-2 recursion",
+      "description": "Both entries are driven by the base-2 even/odd decomposition n ↦ (n % 2, n / 2). Thue-Morse reads the parity bit off `Nat.digits 2` and halves; Stein's binary GCD branches on the same parity test and halving. The bit-flip recurrences t(2n)=t(n), t(2n+1)=t(n)+1 are the digit-level analogue of binary GCD's even/odd case split."
+    },
+    {
+      "proofId": "midy-theorem-oq-01",
+      "relationship": "Base-b digits via modular arithmetic",
+      "description": "Each theorem reduces a statement about base-b digit expansions to a clean modular fact. Thue-Morse takes the base-2 digit sum modulo 2 (ZMod 2 parity); Midy's theorem reads the even-period repetend of 1/p in base b through ZMod p and the multiplicative order. Both exploit Mathlib's `Nat.digits` recursion as the bridge from digits to arithmetic."
+    },
+    {
+      "proofId": "sylvester-sequence-oq-01",
+      "relationship": "Recurrence-defined integer sequence",
+      "description": "A companion integer-sequence entry: where Thue-Morse is governed by the doubling recurrences t(2n)/t(2n+1), Sylvester's sequence a_{n+1}=aₙ²−aₙ+1 is governed by a quadratic recurrence with its own elementary number-theoretic payoff (telescoping reciprocal sum to 1 and pairwise coprimality). Both showcase how a single recurrence dictates the whole sequence's arithmetic."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `thue-morse-oq-01` (quality 96, passes 0). The entry was otherwise complete (5 aligned annotations covering the full 144-line file, 4 keyInsights, 4 sections, conclusion with 3 open questions); its one real gap was an **empty `crossReferences` array**.

## Changes
Added 3 cross-references to existing, verified gallery siblings, each a genuine mathematical/structural connection (not filler):
- **binary-gcd-oq-01** — both are driven by the base-2 even/odd decomposition `n ↦ (n%2, n/2)`; the bit-flip recurrences are the digit-level analogue of Stein's parity case split.
- **midy-theorem-oq-01** — both reduce a base-b digit-expansion statement to a modular fact (ZMod 2 parity vs ZMod p / multiplicative order), bridged by `Nat.digits`.
- **sylvester-sequence-oq-01** — companion recurrence-defined integer sequence.

## Validation
- `proofId` (preferred CrossReference field) used; all 3 target directories confirmed present
- meta.json parses cleanly (jq); no existing content removed
- Axiom integrity unchanged: status `verified`, axiomCount 0, sorries 0