### PR TITLE
Research: discharge GeneralQuartic's 3 axioms (build-pending orphan)

### DIFF
--- a/proofs/Proofs/GeneralQuarticAxiomsDischarge.lean
+++ b/proofs/Proofs/GeneralQuarticAxiomsDischarge.lean
@@ -1,0 +1,119 @@
+import Mathlib
+import Proofs.GeneralQuartic
+
+/-!
+# Axiom discharge for `GeneralQuartic.lean`
+
+`GeneralQuartic.lean` (Wiedijk #46, Ferrari's quartic method) carries exactly
+three remaining `axiom` declarations, all of which are *routine, classical*
+facts (FTA for a degree-4 polynomial; the quadratic formula for a biquadratic).
+This file proves each of them as a `theorem`, so that — once verified under the
+Docker build — the `axiom` lines in `GeneralQuartic.lean` can be replaced by
+these proofs verbatim, dropping its `axiomCount` from 3 to 0.
+
+This file is intentionally **not** imported by `Proofs.lean`: it is a staging
+/ companion file. Keeping it out of the registered build means an in-progress
+or mistaken proof here cannot break the gallery build of `Proofs`.
+
+## Targets (mirror the `axiom` statements exactly)
+
+* `quartic_has_four_roots'`  ↔ `GeneralQuartic.quartic_has_four_roots`
+* `biquadratic_forward'`     ↔ `GeneralQuartic.biquadratic_forward`
+* `biquadratic_backward'`    ↔ `GeneralQuartic.biquadratic_backward`
+
+The math behind all three is independently checked by
+`research/problems/solution-of-cubic-oq-03-oq-03-oq-01/verify_quartic_axioms.py`.
+-/
+
+open Polynomial Complex
+
+namespace GeneralQuartic
+
+/-- The principal-branch square of the biquadratic discriminant radical:
+`s = (p² − 4r)^{1/2}` satisfies `s² = p² − 4r`.
+
+This is the single non-`ring` fact underlying both biquadratic axioms.  It is
+**not** provable by `field_simp; ring`; it needs `Complex.cpow_nat_inv_pow`
+(`(x ^ (n⁻¹ : ℂ))^n = x` for `n ≠ 0`) after rewriting `1/2` as `(2 : ℕ)⁻¹`. -/
+theorem cpow_half_sq (p r : ℂ) :
+    (Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ)) ^ 2 = p ^ 2 - 4 * r := by
+  rw [show (1 / 2 : ℂ) = ((2 : ℕ) : ℂ)⁻¹ by norm_num]
+  exact_mod_cast Complex.cpow_nat_inv_pow (p ^ 2 - 4 * r) (n := 2) (by norm_num)
+
+/-- **A3 (biquadratic backward), proved.**
+If `y²` equals one of the two quadratic-formula solutions of `z² + p z + r = 0`,
+then `y` is a root of the biquadratic `y⁴ + p y² + r = 0`.
+
+Substituting `y² = (-p ± s)/2` and using `s² = p² − 4r` reduces the quartic to
+`(s² − (p² − 4r))/4 = 0`. -/
+theorem biquadratic_backward' (p r y : ℂ)
+    (h : (y ^ 2 = (-p + Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ)) / 2) ∨
+         (y ^ 2 = (-p - Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ)) / 2)) :
+    y ^ 4 + p * y ^ 2 + 0 * y + r = 0 := by
+  set s := Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ) with hs_def
+  have hs : s ^ 2 = p ^ 2 - 4 * r := cpow_half_sq p r
+  rcases h with hz | hz
+  · rw [show y ^ 4 = (y ^ 2) ^ 2 from by ring, hz]
+    linear_combination (1 / 4 : ℂ) * hs
+  · rw [show y ^ 4 = (y ^ 2) ^ 2 from by ring, hz]
+    linear_combination (1 / 4 : ℂ) * hs
+
+/-- **A2 (biquadratic forward), proved.**
+If `y` is a root of `y⁴ + p y² + r = 0`, then `y²` equals one of the two
+quadratic-formula solutions.
+
+Writing `w = y²`, the resolvent `w² + p w + r` factors as `(w − z₁)(w − z₂)`
+with `z₁,₂ = (-p ± s)/2` and `s² = p² − 4r`; `ℂ` has no zero divisors. -/
+theorem biquadratic_forward' (p r y : ℂ)
+    (h : y ^ 4 + p * y ^ 2 + 0 * y + r = 0) :
+    (y ^ 2 = (-p + Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ)) / 2) ∨
+    (y ^ 2 = (-p - Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ)) / 2) := by
+  set s := Complex.cpow (p ^ 2 - 4 * r) (1 / 2 : ℂ) with hs_def
+  have hs : s ^ 2 = p ^ 2 - 4 * r := cpow_half_sq p r
+  have hfac : (y ^ 2 - (-p + s) / 2) * (y ^ 2 - (-p - s) / 2) = 0 := by
+    linear_combination h - (1 / 4 : ℂ) * hs
+  rcases mul_eq_zero.mp hfac with h1 | h2
+  · exact Or.inl (sub_eq_zero.mp h1)
+  · exact Or.inr (sub_eq_zero.mp h2)
+
+/-- **A1 (quartic has four roots), proved.**
+A degree-4 polynomial over `ℂ` has, by the Fundamental Theorem of Algebra, a
+root multiset of cardinality 4; naming its four entries `r₁,r₂,r₃,r₄`
+(with multiplicity) gives the root characterization.
+
+Route: `compute_degree!` for `natDegree = 4`; `IsAlgClosed.splits` +
+`Splits.natDegree_eq_card_roots` for `card roots = 4`; enumerate the length-4
+`roots.toList`; convert `eval x = 0 ↔ x ∈ roots` via `Polynomial.mem_roots`. -/
+theorem quartic_has_four_roots' (a b c d : ℂ) :
+    ∃ (r₁ r₂ r₃ r₄ : ℂ),
+      ∀ x : ℂ, (quarticPoly a b c d).eval x = 0 ↔ (x = r₁ ∨ x = r₂ ∨ x = r₃ ∨ x = r₄) := by
+  have hdeg : (quarticPoly a b c d).natDegree = 4 := by
+    unfold quarticPoly; compute_degree!
+  have hp0 : quarticPoly a b c d ≠ 0 := by
+    intro h; rw [h, natDegree_zero] at hdeg; exact absurd hdeg (by norm_num)
+  have hsplit : (quarticPoly a b c d).Splits := IsAlgClosed.splits _
+  have hcard : Multiset.card (quarticPoly a b c d).roots = 4 := by
+    have h := hsplit.natDegree_eq_card_roots
+    rw [hdeg] at h; exact h.symm
+  have hlen : (quarticPoly a b c d).roots.toList.length = 4 := by
+    rw [Multiset.length_toList]; exact hcard
+  obtain ⟨r₁, r₂, r₃, r₄, hlist⟩ :
+      ∃ r₁ r₂ r₃ r₄, (quarticPoly a b c d).roots.toList = [r₁, r₂, r₃, r₄] := by
+    rcases ht : (quarticPoly a b c d).roots.toList with
+        _ | ⟨a1, _ | ⟨a2, _ | ⟨a3, _ | ⟨a4, tl⟩⟩⟩⟩
+    · rw [ht] at hlen; simp at hlen
+    · rw [ht] at hlen; simp at hlen
+    · rw [ht] at hlen; simp at hlen
+    · rw [ht] at hlen; simp at hlen
+    · cases tl with
+      | nil => exact ⟨a1, a2, a3, a4, ht⟩
+      | cons a5 tl2 =>
+          rw [ht] at hlen
+          simp only [List.length_cons, List.length_nil] at hlen
+          omega
+  refine ⟨r₁, r₂, r₃, r₄, fun x => ?_⟩
+  have hmem : x ∈ (quarticPoly a b c d).roots ↔ (x = r₁ ∨ x = r₂ ∨ x = r₃ ∨ x = r₄) := by
+    rw [← Multiset.mem_toList, hlist]; simp
+  rw [← hmem, Polynomial.mem_roots hp0, Polynomial.IsRoot.def]
+
+end GeneralQuartic

--- a/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/knowledge.md
+++ b/research/problems/solution-of-cubic-oq-03-oq-03-oq-01/knowledge.md
@@ -115,3 +115,50 @@ transcription task, not a discovery task.
   root-set split).
 - Verdict: all 3 axioms buildable, ~150–200 LOC, Docker-gated. Phase OBSERVE→ORIENT.
 - **Next**: ACT — discharge A3, A2, A1 in that order.
+
+### 2026-06-16 (Session 2) — ACT (build-pending discharge written)
+
+**Mode**: DEPTH (knowledge WEAK→RICH) · **Outcome**: progress (all 3 axioms
+written as theorems in an UNREGISTERED orphan; dual blackout so build-pending)
+
+- Dual blackout confirmed this session: `docker info` times out (>30s); Aristotle
+  MCP `prove` returns `{"status":"error","message":"Resource not found."}` (404).
+  So no Lean build and no Aristotle — same blackout the other 06-16 sessions hit.
+- Wrote **`proofs/Proofs/GeneralQuarticAxiomsDischarge.lean`** — a staging file,
+  deliberately **NOT** imported by `Proofs.lean` (zero risk to the registered
+  `Proofs` build / gallery). Contains theorem versions of all three axioms,
+  statements mirroring the `axiom` lines verbatim so they can be inlined to
+  replace them and drop `axiomCount` 3→0:
+  - `cpow_half_sq` — the one non-`ring` fact `s² = p²−4r` for `s = (p²−4r)^{1/2}`,
+    via `Complex.cpow_nat_inv_pow` after rewriting `1/2 = ((2:ℕ):ℂ)⁻¹`.
+  - `biquadratic_backward'` (A3) — `rw [y⁴=(y²)², hz]` then
+    `linear_combination (1/4)*hs`. **HIGH confidence.**
+  - `biquadratic_forward'` (A2) — factor `(y²−z₁)(y²−z₂)=0` via
+    `linear_combination h − (1/4)*hs`, then `mul_eq_zero` + `sub_eq_zero.mp`.
+    **HIGH confidence.**
+  - `quartic_has_four_roots'` (A1) — `unfold quarticPoly; compute_degree!` for
+    `natDegree=4`; `IsAlgClosed.splits _ : p.Splits`;
+    `Splits.natDegree_eq_card_roots` for `card roots = 4`; destructure length-4
+    `roots.toList` into `[r₁,r₂,r₃,r₄]`; `Polynomial.mem_roots hp0` +
+    `IsRoot.def`. **MEDIUM confidence** — the length-4 `rcases`/`cases tl`
+    enumeration and `compute_degree!` are the only unverified-by-build steps.
+- **API NOTE (v4.26 drift from S1 notes):** `Splits` is now a **one-argument**
+  predicate `p.Splits` (splits over its own field). `IsAlgClosed.splits` is the
+  class field `∀ p, p.Splits` (use `IsAlgClosed.splits _ : p.Splits`).
+  `IsAlgClosed.splits_codomain` is **deprecated** (since 2025-12-09). Use
+  `Splits.natDegree_eq_card_roots : p.Splits → p.natDegree = card p.roots`
+  (not the old `splits_iff_card_roots`). `Polynomial.mem_roots (hp : p ≠ 0)`,
+  `Multiset.length_toList`, `Multiset.mem_toList`, `Polynomial.IsRoot.def` all
+  present.
+- Verified the **exact** `linear_combination` coefficients are ring identities
+  (sympy residual 0 for A2, A3-b1, A3-b2). Existing `verify_quartic_axioms.py`
+  still passes (all 8 checks). So A2/A3 are de-risked to "transcription is
+  correct"; only Lean-elaboration surprises remain.
+- Did **NOT** touch `meta.json` axiomCount (still 3) — the registered file still
+  has the 3 axioms; no overclaiming until they're replaced & build-verified.
+- **Next (Docker up):** (1) `docker-build.sh Proofs.GeneralQuarticAxiomsDischarge`
+  to verify; fix any A1 enumeration/elaboration nits. (2) Inline the three proofs
+  into `GeneralQuartic.lean` replacing the `axiom` lines, delete the orphan,
+  rebuild `Proofs.GeneralQuartic`. (3) Set `meta.json` leanFile.axiomCount 3→0
+  and bump status/badge to verified/original. (4) Aristotle is the fallback for
+  A1 if the manual enumeration fights the elaborator (404 this session).


### PR DESCRIPTION
## Summary
ACT session on `solution-of-cubic-oq-03-oq-03-oq-01` (Wiedijk #46, Ferrari's quartic method). The registered file `proofs/Proofs/GeneralQuartic.lean` carries exactly **3** remaining `axiom` declarations — all routine, classical facts. This PR writes `theorem` proofs of all three in a new **unregistered** staging file so they can be inlined + verified next Docker session, dropping `axiomCount` 3→0.

`proofs/Proofs/GeneralQuarticAxiomsDischarge.lean` is intentionally **not** imported by `Proofs.lean` → zero risk to the registered gallery build.

- **A2 `biquadratic_forward'` / A3 `biquadratic_backward'`** — quadratic-formula for the biquadratic. The single non-`ring` fact is `cpow_half_sq : (p²−4r)^{1/2})² = p²−4r` via `Complex.cpow_nat_inv_pow`. The exact `linear_combination` coefficients are verified as ring identities (sympy residual 0). **High confidence.**
- **A1 `quartic_has_four_roots'`** — FTA: `compute_degree!` → `natDegree = 4`; `IsAlgClosed.splits` + `Splits.natDegree_eq_card_roots` → `card roots = 4`; enumerate length-4 `roots.toList`; `Polynomial.mem_roots`. **Medium confidence** (enumeration build-unverified).

## Context
Dual backend blackout this session (Docker `info` timeout; Aristotle MCP returns 404). Build-pending by necessity. `meta.json` left unchanged (registered file still has 3 axioms — no overclaiming). `verify_quartic_axioms.py` passes all 8 checks.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.GeneralQuarticAxiomsDischarge` when Docker is back
- [ ] Fix any A1 enumeration/elaboration nits; Aristotle fallback for A1 if needed
- [ ] Inline all three into `GeneralQuartic.lean` replacing the `axiom` lines; delete orphan; rebuild `Proofs.GeneralQuartic`
- [ ] Set `meta.json` leanFile.axiomCount 3→0; bump status/badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)