### PR TITLE
Enrich ballot-problem-oq-03-oq-02: re-anchor 13 drifted annotations

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-lgv-lpath",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 77,
+      "startLine": 82,
       "endLine": 110
     },
     "type": "definition",
@@ -27,7 +27,7 @@
     "id": "ann-lgv-nonintersect",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 111,
+      "startLine": 116,
       "endLine": 222
     },
     "type": "definition",
@@ -49,7 +49,7 @@
     "id": "ann-lgv-config",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 223,
+      "startLine": 228,
       "endLine": 251
     },
     "type": "definition",
@@ -73,7 +73,7 @@
     "id": "ann-lgv-pathmatrix",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 252,
+      "startLine": 257,
       "endLine": 261
     },
     "type": "concept",
@@ -96,7 +96,7 @@
     "id": "ann-lgv-permtuples",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 262,
+      "startLine": 267,
       "endLine": 289
     },
     "type": "concept",
@@ -118,7 +118,7 @@
     "id": "ann-lgv-swaptails",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 290,
+      "startLine": 296,
       "endLine": 338
     },
     "type": "concept",
@@ -142,7 +142,7 @@
     "id": "ann-lgv-firstnonfixed",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 339,
+      "startLine": 345,
       "endLine": 378
     },
     "type": "definition",
@@ -165,7 +165,7 @@
     "id": "ann-lgv-algebraic-bridge",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 380,
+      "startLine": 446,
       "endLine": 599
     },
     "type": "insight",
@@ -189,7 +189,7 @@
     "id": "ann-lgv-tagged-tuples",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 600,
+      "startLine": 611,
       "endLine": 648
     },
     "type": "definition",
@@ -213,7 +213,7 @@
     "id": "ann-lgv-wellformed",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 736,
+      "startLine": 745,
       "endLine": 825
     },
     "type": "concept",
@@ -237,7 +237,7 @@
     "id": "ann-lgv-prefix-lemmas",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 826,
+      "startLine": 840,
       "endLine": 1078
     },
     "type": "concept",
@@ -316,7 +316,7 @@
     "id": "ann-lgv-self-inverse",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 1886,
+      "startLine": 1888,
       "endLine": 2091
     },
     "type": "concept",
@@ -362,7 +362,7 @@
     "id": "ann-lgv-crossing-lemma",
     "proofId": "ballot-problem-oq-03-oq-02",
     "range": {
-      "startLine": 649,
+      "startLine": 655,
       "endLine": 735
     },
     "type": "insight",


### PR DESCRIPTION
## Enrichment pass for ballot-problem-oq-03-oq-02

All 13 LGV (Lindström–Gessel–Viennot) annotations were anchored to
`-- ===` PART banner comments instead of Lean declarations. The resolver
flagged them as misaligned ("No Lean construct found at line N") because a
banner comment is not a construct.

### Fix
Re-anchored each annotation's `startLine` to the first real declaration
following its banner (endLines and all content unchanged):

| Annotation | old → new start | now anchors |
|---|---|---|
| lpath | 77 → 82 | `abbrev LPath` |
| nonintersect | 111 → 116 | `def northBeforeEast` |
| config | 223 → 228 | `structure LGVConfig` |
| pathmatrix | 252 → 257 | `def pathMatrix` |
| permtuples | 262 → 267 | `def PermPathTuple` |
| swaptails | 290 → 296 | `def swapTailsAt` |
| firstnonfixed | 339 → 345 | `def firstNonFixed` |
| algebraic-bridge | 380 → 446 | `theorem pathMN_card` |
| tagged-tuples | 600 → 611 | `def TaggedPathTuple` |
| crossing-lemma | 649 → 655 | `def yAtCol` |
| wellformed | 736 → 745 | `def LGVConfig.wellFormed` |
| prefix-lemmas | 826 → 840 | `private lemma take_at_column_entry` |
| self-inverse | 1886 → 1888 | `private lemma gvCanonInv_targets_eq_cj` |

### Verification
`resolver.ts validate`: **17/17 valid, 0 misaligned** (was 4/17).