### PR TITLE
Enrich combinations-formula-oq-03: re-anchor 10 drifted annotations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-03/annotations.json
@@ -28,7 +28,7 @@
     "id": "ann-q-number-def",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 68,
+      "startLine": 74,
       "endLine": 101
     },
     "type": "definition",
@@ -73,7 +73,7 @@
     "id": "ann-q-factorial",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 120,
+      "startLine": 126,
       "endLine": 146
     },
     "type": "definition",
@@ -95,7 +95,7 @@
     "id": "ann-q-binomial-def",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 148,
+      "startLine": 159,
       "endLine": 203
     },
     "type": "definition",
@@ -119,7 +119,7 @@
     "id": "ann-specialization",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 204,
+      "startLine": 214,
       "endLine": 222
     },
     "type": "insight",
@@ -143,7 +143,7 @@
     "id": "ann-product-formula",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 223,
+      "startLine": 232,
       "endLine": 284
     },
     "type": "insight",
@@ -167,7 +167,7 @@
     "id": "ann-concrete-verifications",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 285,
+      "startLine": 293,
       "endLine": 309
     },
     "type": "concept",
@@ -191,7 +191,7 @@
     "id": "ann-absorption",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 310,
+      "startLine": 326,
       "endLine": 374
     },
     "type": "insight",
@@ -263,7 +263,7 @@
     "id": "ann-second-pascal",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 484,
+      "startLine": 496,
       "endLine": 513
     },
     "type": "insight",
@@ -311,7 +311,7 @@
     "id": "ann-q-zero",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 570,
+      "startLine": 580,
       "endLine": 582
     },
     "type": "insight",
@@ -359,7 +359,7 @@
     "id": "ann-vandermonde",
     "proofId": "combinations-formula-oq-03",
     "range": {
-      "startLine": 607,
+      "startLine": 623,
       "endLine": 716
     },
     "type": "insight",


### PR DESCRIPTION
## Enrichment pass for combinations-formula-oq-03

10 of the 17 q-analog (Gaussian binomial) annotations were anchored to
`-- Part N` banner comments rather than Lean declarations, so the resolver
reported "No Lean construct found at line N".

### Fix
Re-anchored each annotation's `startLine` to the first declaration after
its banner (content and endLines unchanged):

| Annotation | old → new start | now anchors |
|---|---|---|
| q-number-def | 68 → 74 | `def qNumber` |
| q-factorial | 120 → 126 | `def qFactorial` |
| q-binomial-def | 148 → 159 | `def qBinom` |
| specialization | 204 → 214 | `theorem qBinom_at_one` |
| product-formula | 223 → 232 | `theorem qBinom_product` |
| concrete-verifications | 285 → 293 | first `example` block |
| absorption | 310 → 326 | `theorem qBinom_absorption` |
| second-pascal | 484 → 496 | `theorem qBinom_pascal'` |
| q-zero | 570 → 580 | `theorem qBinom_at_zero` |
| vandermonde | 607 → 623 | `theorem qBinom_vandermonde` |

### Verification
`resolver.ts validate`: **17/17 valid, 0 misaligned** (was 7/17).