### PR TITLE
research(narcissistic-number-oq-01): finiteness scaffold + certificate (build-pending)

### DIFF
--- a/proofs/Proofs/NarcissisticNumberOQ01.lean
+++ b/proofs/Proofs/NarcissisticNumberOQ01.lean
@@ -1,0 +1,114 @@
+/-
+# Narcissistic numbers are finite  (`narcissistic-number-oq-01`)
+
+STATUS: build-pending. Written 2026-06-16 during a Docker + Aristotle blackout
+(daemon down, MCP returns 404), so this file has NOT yet been machine-checked.
+It is an UNREGISTERED orphan (deliberately not imported by `Proofs.lean`), so it
+cannot affect the gallery build until a future session verifies it.
+
+A natural number `m` with `n` decimal digits is *narcissistic* when it equals the
+sum of its decimal digits each raised to the `n`-th power, e.g.
+`153 = 1^3 + 5^3 + 3^3`, `8208 = 8^4 + 2^4 + 0^4 + 8^4`, `9474 = 9^4+4^4+7^4+4^4`.
+
+## Theorem (`narcissistic_finite`)
+The set `{ m | Narcissistic m }` is finite.
+
+## Proof idea
+For an `n`-digit number the digit-power-sum is at most `n * 9^n`, while the number
+itself is at least `10^(n-1)`. The inequality `10^(n-1) > n * 9^n` holds for all
+`n ≥ 61` (Python-certified crossover, see
+`research/certificates/narcissistic_number_oq01_finiteness.py`). Hence no
+`n`-digit number with `n ≥ 61` can be narcissistic, so every narcissistic number
+is `< 10^61`, and a set of naturals bounded above is finite.
+
+The two genuinely arithmetic facts are isolated as `crossover` (an
+`n ≥ 61` induction) and `pow_pred_length_le` (Mathlib digit lower bound). Both are
+HARD-but-known, suitable for Aristotle once the prover is reachable again.
+-/
+import Mathlib
+
+namespace NarcissisticNumberOQ01
+
+open scoped BigOperators
+
+/-- Number of decimal digits of `m` (`0` for `m = 0`). -/
+def numDigits (m : ℕ) : ℕ := (Nat.digits 10 m).length
+
+/-- `m` is narcissistic: it equals the sum of its decimal digits each raised to
+the power equal to its number of digits. -/
+def Narcissistic (m : ℕ) : Prop :=
+  m = ((Nat.digits 10 m).map (fun d => d ^ numDigits m)).sum
+
+/-- Every decimal digit is `≤ 9`. -/
+lemma digit_le_nine {m d : ℕ} (hd : d ∈ Nat.digits 10 m) : d ≤ 9 := by
+  have h : d < 10 := Nat.digits_lt_base (by norm_num) hd
+  omega
+
+/-- The digit-power-sum of `m` is at most `numDigits m * 9 ^ numDigits m`:
+each of the `n` digits is `≤ 9`, so each `n`-th power is `≤ 9^n`. -/
+lemma digitPowSum_le (m : ℕ) :
+    ((Nat.digits 10 m).map (fun d => d ^ numDigits m)).sum
+      ≤ numDigits m * 9 ^ numDigits m := by
+  set n := numDigits m with hn
+  have hbound : ∀ x ∈ (Nat.digits 10 m).map (fun d => d ^ n), x ≤ 9 ^ n := by
+    intro x hx
+    rw [List.mem_map] at hx
+    obtain ⟨d, hd, rfl⟩ := hx
+    exact Nat.pow_le_pow_left (digit_le_nine hd) n
+  calc ((Nat.digits 10 m).map (fun d => d ^ n)).sum
+      ≤ ((Nat.digits 10 m).map (fun d => d ^ n)).length • (9 ^ n) :=
+        List.sum_le_card_nsmul _ _ hbound
+    _ = n * 9 ^ n := by
+        rw [List.length_map, smul_eq_mul]; rfl
+
+/-- Crossover bound: for `n ≥ 61`, `n * 9^n < 10^(n-1)`.
+
+Proof plan (HARD, Aristotle-suitable): `Nat.le_induction` from `61`.
+* Base `n = 61`: the concrete inequality `61 * 9^61 < 10^60`, closeable by
+  `norm_num` (it evaluates both sides).
+* Step: assume `n * 9^n < 10^(n-1)` with `n ≥ 61`. Then
+  `(n+1) * 9^(n+1) = 9*(n+1) * 9^n ≤ 10*n * 9^n` (using `9*(n+1) ≤ 10*n`, valid
+  for `n ≥ 9`) `< 10 * 10^(n-1) = 10^n`. -/
+lemma crossover : ∀ n, 61 ≤ n → n * 9 ^ n < 10 ^ (n - 1) := by
+  sorry
+
+/-- Digit lower bound: a nonzero `m` is at least `10^(numDigits m - 1)`.
+
+Proof plan: from `Nat.base_pow_length_digits_le` (`10 ^ (digits).length ≤ 10 * m`
+for `m ≠ 0`) cancel one factor of `10`. -/
+lemma pow_pred_length_le {m : ℕ} (hm : m ≠ 0) : 10 ^ (numDigits m - 1) ≤ m := by
+  sorry
+
+/-- No narcissistic number has `61` or more digits. -/
+lemma numDigits_lt_61 {m : ℕ} (h : Narcissistic m) : numDigits m < 61 := by
+  by_contra hge
+  push_neg at hge          -- 61 ≤ numDigits m
+  have hm0 : m ≠ 0 := by
+    rintro rfl
+    -- numDigits 0 = 0, contradicting 61 ≤ 0
+    simp [numDigits] at hge
+  set n := numDigits m with hn
+  -- m equals its digit-power-sum, which is ≤ n * 9^n
+  have hsum : m ≤ n * 9 ^ n := by
+    calc m = ((Nat.digits 10 m).map (fun d => d ^ n)).sum := h
+      _ ≤ n * 9 ^ n := digitPowSum_le m
+  -- but m ≥ 10^(n-1) > n * 9^n, contradiction
+  have hlow : 10 ^ (n - 1) ≤ m := pow_pred_length_le hm0
+  have hcross : n * 9 ^ n < 10 ^ (n - 1) := crossover n hge
+  omega
+
+/-- **Narcissistic numbers are finite.** -/
+theorem narcissistic_finite : {m : ℕ | Narcissistic m}.Finite := by
+  apply Set.Finite.subset (Set.finite_Iio (10 ^ 61))
+  intro m hm
+  simp only [Set.mem_setOf_eq] at hm
+  simp only [Set.mem_Iio]
+  -- m < 10^(numDigits m) ≤ 10^61
+  have h1 : m < 10 ^ numDigits m := by
+    have := Nat.lt_base_pow_length_digits (b := 10) (m := m) (by norm_num)
+    simpa [numDigits] using this
+  have h2 : numDigits m < 61 := numDigits_lt_61 hm
+  calc m < 10 ^ numDigits m := h1
+    _ ≤ 10 ^ 61 := Nat.pow_le_pow_right (by norm_num) (le_of_lt h2)
+
+end NarcissisticNumberOQ01

--- a/research/certificates/narcissistic_number_oq01_finiteness.py
+++ b/research/certificates/narcissistic_number_oq01_finiteness.py
@@ -1,0 +1,31 @@
+# Certificate for narcissistic-number-oq-01 (finiteness of narcissistic numbers).
+#
+# An n-digit number m (10^(n-1) <= m <= 10^n - 1) is narcissistic iff
+#   m = sum over digits d of m of d^n.
+# The digit-power-sum of any n-digit number is <= n * 9^n.
+# If 10^(n-1) > n * 9^n, then for every n-digit m we have
+#   m >= 10^(n-1) > n*9^n >= (digit-power-sum) , so m is NOT narcissistic.
+# Therefore every narcissistic number has fewer than D digits, where D is the
+# least n with 10^(n-1) > n*9^n.  A bounded set of naturals is FINITE.  QED.
+
+D = next(n for n in range(1, 500) if 10**(n-1) > n * 9**n)
+print(f"crossover D = {D}: for all n >= {D}, no n-digit number is narcissistic")
+for n in range(D-2, D+2):
+    lhs, rhs = 10**(n-1), n*9**n
+    print(f"  n={n}: 10^(n-1) {'>' if lhs>rhs else '<='} n*9^n   ({lhs} vs {rhs})")
+
+# Bounded enumeration for examples (digit-lengths 1..7 only, for illustration).
+def narc_of_length(n):
+    out=[]
+    lo = 1 if n==1 else 10**(n-1)
+    for m in range(lo, 10**n):
+        if sum(int(c)**n for c in str(m)) == m:
+            out.append(m)
+    return out
+ex=[]
+for n in range(1,8):
+    ex += narc_of_length(n)
+print("narcissistic numbers with <= 7 digits:", ex)
+# Known full list has 88 entries, largest = 115132219018763992565095597973971522401 (39 digits)
+print("known full count (base 10) = 88; largest = 115132219018763992565095597973971522401 (39 digits, < 10^%d)" % D)
+print("FINITE: proven by the digit-count bound D=%d" % D)

--- a/research/problems/narcissistic-number-oq-01/knowledge.md
+++ b/research/problems/narcissistic-number-oq-01/knowledge.md
@@ -1,0 +1,77 @@
+# narcissistic-number-oq-01 — Finiteness of narcissistic numbers
+
+**Statement.** An `n`-digit number `m` is *narcissistic* if it equals the sum of
+its decimal digits each raised to the `n`-th power (e.g. `153 = 1³+5³+3³`,
+`8208 = 8⁴+2⁴+0⁴+8⁴`). Prove the set of narcissistic numbers is finite.
+
+**Status:** ACT (proof structure written, build-pending under blackout).
+
+---
+
+## Summary
+
+The set is finite by a digit-count bound, not by enumeration:
+
+- An `n`-digit number's digit-power-sum is at most `n · 9ⁿ`.
+- An `n`-digit number is at least `10^(n-1)`.
+- For all `n ≥ 61`, `10^(n-1) > n · 9ⁿ`, so an `n`-digit number with `n ≥ 61`
+  cannot equal its own digit-power-sum.
+- Hence every narcissistic number has `< 61` digits, i.e. is `< 10⁶¹`. A set of
+  naturals bounded above is finite. ∎
+
+The crossover `n = 61` is Python-certified
+(`research/certificates/narcissistic_number_oq01_finiteness.py`): the inequality
+flips between `n = 60` (`10⁵⁹ ≤ 60·9⁶⁰`) and `n = 61` (`10⁶⁰ > 61·9⁶¹`). The
+bounded brute-force reproduces the known small narcissistic numbers
+`1..9, 153, 370, 371, 407, 1634, 8208, 9474, 54748, …`; the full base-10 list has
+88 members, largest `115132219018763992565095597973971522401` (39 digits < 10⁶¹).
+
+---
+
+## Session 2026-06-16 (s01) — FRESH
+
+**Mode:** FRESH. **Outcome:** progress (structure + certificate; build-pending).
+
+### Context: full toolchain blackout
+- Docker daemon DOWN (host load ~30); `lake build` impossible.
+- Aristotle MCP returns `{"status":"error","message":"Resource not found."}` (404).
+- Researcher pool thrashing: automorphic / happy / taxicab / amgm slugs each had
+  ≥1 sibling agent with a *hung* `docker-build.sh` process. Originally claimed
+  `automorphic-number-oq-01`, found researcher-9 **and** researcher-10 already had
+  a complete 0-sorry `AutomorphicNumberOQ01.lean` mid-build → released, switched to
+  the uncontested `narcissistic-number-oq-01`.
+
+### What I did
+- Certified the finiteness bound in Python (crossover `D = 61`, examples match
+  OEIS A005188). Saved to `research/certificates/`.
+- Wrote orphan `proofs/Proofs/NarcissisticNumberOQ01.lean` (UNREGISTERED):
+  - `numDigits`, `Narcissistic` definitions.
+  - `digit_le_nine`, `digitPowSum_le` — full proofs (low risk).
+  - `numDigits_lt_61`, `narcissistic_finite` — assembled from the two lemmas below.
+  - `crossover` (`∀ n ≥ 61, n·9ⁿ < 10^(n-1)`) and `pow_pred_length_le`
+    (`m ≠ 0 → 10^(numDigits m − 1) ≤ m`) left as documented `sorry` (HARD).
+
+### Key findings / Mathlib API
+- Digit upper bound: `Nat.digits_lt_base` (`d < 10`), `Nat.pow_le_pow_left`,
+  `List.sum_le_card_nsmul`, `List.length_map`.
+- Number upper bound: `Nat.lt_base_pow_length_digits` (`m < 10^(digits).length`).
+- Number lower bound (gap): expected `Nat.base_pow_length_digits_le`
+  (`10^(digits).length ≤ 10·m` for `m ≠ 0`) → cancel one `10`. **Verify exact name
+  when Docker returns.**
+- Finiteness wrapper: `Set.Finite.subset (Set.finite_Iio _)`.
+
+### Crossover induction plan (`crossover`)
+`Nat.le_induction` from 61. Base `61·9⁶¹ < 10⁶⁰` via `norm_num`. Step uses
+`9·(n+1) ≤ 10·n` for `n ≥ 9`, giving `(n+1)·9^(n+1) ≤ 10·n·9ⁿ < 10·10^(n-1) = 10ⁿ`.
+
+### Next steps (when Docker / Aristotle are back)
+1. `./proofs/scripts/docker-build.sh Proofs.NarcissisticNumberOQ01`; fix lemma
+   names (esp. `pow_pred_length_le` source lemma) from `grep error:`.
+2. Discharge the two `sorry`s manually or submit to Aristotle (both are HARD-known).
+3. If green, register in `Proofs.lean` and add gallery data under
+   `src/data/proofs/narcissistic-number-oq-01/`.
+
+### Files
+- `proofs/Proofs/NarcissisticNumberOQ01.lean` (orphan, build-pending)
+- `research/certificates/narcissistic_number_oq01_finiteness.py`
+- `research/problems/narcissistic-number-oq-01/knowledge.md`


### PR DESCRIPTION
## Summary
Proves (modulo two documented HARD lemmas) that **the set of narcissistic numbers is finite** — a structural finiteness theorem, not enumeration.

An `n`-digit number's digit-power-sum is `≤ n·9ⁿ`, while the number itself is `≥ 10^(n-1)`. The inequality `10^(n-1) > n·9ⁿ` holds for **all `n ≥ 61`**, so no `n`-digit number with `n ≥ 61` can equal its own digit-power-sum. Hence every narcissistic number is `< 10⁶¹`, and a bounded set of naturals is finite.

## Certificate (verified now)
`research/certificates/narcissistic_number_oq01_finiteness.py` confirms:
- crossover `D = 61` (inequality flips between `n = 60` and `n = 61`);
- bounded brute-force reproduces the known small narcissistic numbers `1..9, 153, 370, 371, 407, 1634, 8208, 9474, …` (OEIS A005188).

## ⚠️ Build-pending
Written during a **Docker + Aristotle blackout** (daemon down, MCP 404), so the Lean file is **not yet machine-checked**. It is an **UNREGISTERED orphan** (not imported by `Proofs.lean`) → cannot affect the gallery build.

Proven in-file: `digit_le_nine`, `digitPowSum_le`, `numDigits_lt_61`, `narcissistic_finite` (assembly).
Left as documented HARD `sorry` for Aristotle / next Docker session:
- `crossover : ∀ n ≥ 61, n·9ⁿ < 10^(n-1)` (`Nat.le_induction`, base via `norm_num`),
- `pow_pred_length_le : m ≠ 0 → 10^(numDigits m − 1) ≤ m` (from `Nat.base_pow_length_digits_le`).

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.NarcissisticNumberOQ01` once Docker is back; fix lemma names from `grep error:`.
- [ ] Discharge the two `sorry`s (manual or Aristotle).
- [ ] If green, register in `Proofs.lean` + add `src/data/proofs/narcissistic-number-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)