### PR TITLE
Enrich binary-gcd-oq-03: re-anchor 10 drifted annotations

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-03/annotations.json
@@ -25,7 +25,7 @@
     "id": "ann-bgcd03-cofactor-matrix",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 33,
+      "startLine": 40,
       "endLine": 70
     },
     "type": "definition",
@@ -48,7 +48,7 @@
     "id": "ann-bgcd03-cramers-rule",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 72,
+      "startLine": 82,
       "endLine": 111
     },
     "type": "concept",
@@ -97,7 +97,7 @@
     "id": "ann-bgcd03-lehmer-step",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 160,
+      "startLine": 176,
       "endLine": 218
     },
     "type": "definition",
@@ -120,7 +120,7 @@
     "id": "ann-bgcd03-det-preservation",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 220,
+      "startLine": 227,
       "endLine": 253
     },
     "type": "concept",
@@ -143,7 +143,7 @@
     "id": "ann-bgcd03-euclidean-gcd",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 255,
+      "startLine": 258,
       "endLine": 285
     },
     "type": "concept",
@@ -166,7 +166,7 @@
     "id": "ann-bgcd03-top-bits",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 287,
+      "startLine": 292,
       "endLine": 306
     },
     "type": "definition",
@@ -188,7 +188,7 @@
     "id": "ann-bgcd03-hybrid",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 308,
+      "startLine": 313,
       "endLine": 370
     },
     "type": "definition",
@@ -212,7 +212,7 @@
     "id": "ann-bgcd03-verification",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 390,
+      "startLine": 395,
       "endLine": 417
     },
     "type": "concept",
@@ -235,7 +235,7 @@
     "id": "ann-bgcd03-cofactor-bridge",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 419,
+      "startLine": 423,
       "endLine": 431
     },
     "type": "concept",
@@ -257,7 +257,7 @@
     "id": "ann-bgcd03-step-count",
     "proofId": "binary-gcd-oq-03",
     "range": {
-      "startLine": 432,
+      "startLine": 438,
       "endLine": 488
     },
     "type": "insight",


### PR DESCRIPTION
## Enrichment pass for binary-gcd-oq-03

10 of 12 annotations were anchored to `-- ===` banner comments rather than
Lean declarations; the resolver reported "No Lean construct found at line N".

### Fix
Re-anchored each annotation's `startLine` to the first declaration after
its banner (content and endLines unchanged):

| Annotation | old → new start | now anchors |
|---|---|---|
| cofactor-matrix | 33 → 40 | `structure CofactorMatrix` |
| cramers-rule | 72 → 82 | `theorem dvd_of_det_unit` |
| lehmer-step | 160 → 176 | `def lehmerInnerStep` |
| det-preservation | 220 → 227 | `theorem lehmerInnerStep_det` |
| euclidean-gcd | 255 → 258 | `def euclidGcd` |
| top-bits | 287 → 292 | `def topBits` |
| hybrid | 308 → 313 | `def lehmerThreshold` |
| verification | 390 → 395 | `example` verification block |
| cofactor-bridge | 419 → 423 | `theorem cofactor_apply_gcd` |
| step-count | 432 → 438 | `def lehmerCofactorSteps` |

### Verification
`resolver.ts validate`: **12/12 valid, 0 misaligned** (was 2/12).