### PR TITLE
Enrich tractatus-ontology: re-anchor 11 drifted theorem annotations

### DIFF
--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -292,8 +292,8 @@
     "id": "ann-main-result-compositionality-gen",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 319,
-      "endLine": 331
+      "startLine": 325,
+      "endLine": 336
     },
     "type": "insight",
     "title": "[Main Result] Compositionality is Model-Independent",
@@ -342,8 +342,8 @@
     "id": "ann-tractatus-thm2",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 372,
-      "endLine": 374
+      "startLine": 378,
+      "endLine": 380
     },
     "type": "insight",
     "title": "Contradictions Hold Nowhere (TLP 4.46)",
@@ -390,8 +390,8 @@
     "id": "ann-tractatus-thm4",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 412,
-      "endLine": 420
+      "startLine": 418,
+      "endLine": 425
     },
     "type": "insight",
     "title": "Truth-Functional Compositionality (TLP 5)",
@@ -442,8 +442,8 @@
     "id": "ann-tractatus-thm6",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 450,
-      "endLine": 452
+      "startLine": 456,
+      "endLine": 458
     },
     "type": "insight",
     "title": "Double Negation (Classical Logic)",
@@ -466,8 +466,8 @@
     "id": "ann-tractatus-thm7",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 463,
-      "endLine": 471
+      "startLine": 469,
+      "endLine": 478
     },
     "type": "insight",
     "title": "De Morgan's Laws (TLP 5.101)",
@@ -491,8 +491,8 @@
     "id": "ann-tractatus-thm8",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 481,
-      "endLine": 486
+      "startLine": 489,
+      "endLine": 492
     },
     "type": "insight",
     "title": "Excluded Middle as Tautology (TLP 4.46)",
@@ -517,8 +517,8 @@
     "id": "ann-tractatus-thm9",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 495,
-      "endLine": 499
+      "startLine": 502,
+      "endLine": 505
     },
     "type": "insight",
     "title": "p and not-p Is a Contradiction",
@@ -540,8 +540,8 @@
     "id": "ann-tractatus-thm10-11",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 508,
-      "endLine": 522
+      "startLine": 515,
+      "endLine": 527
     },
     "type": "insight",
     "title": "Implication and Biconditional Semantics",
@@ -617,8 +617,8 @@
     "id": "ann-main-result-constrained",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 594,
-      "endLine": 605
+      "startLine": 599,
+      "endLine": 609
     },
     "type": "insight",
     "title": "[Main Result] Independence is a Modeling Choice",
@@ -781,8 +781,8 @@
     "id": "ann-main-result-structeq",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 997,
-      "endLine": 1006
+      "startLine": 1001,
+      "endLine": 1010
     },
     "type": "insight",
     "title": "[Main Result] Structural and Semantic Equivalence Diverge",
@@ -808,8 +808,8 @@
     "id": "ann-tractatus-classification",
     "proofId": "tractatus-ontology",
     "range": {
-      "startLine": 1079,
-      "endLine": 1081
+      "startLine": 1083,
+      "endLine": 1096
     },
     "type": "insight",
     "title": "Analytical Decomposition: Invariance vs Dependence vs Limits",


### PR DESCRIPTION
## Summary
Annotation realignment pass for `tractatus-ontology` (Wittgenstein's Tractarian Ontology). The Lean file grew to 1235 lines, leaving 11 annotations anchored to blank lines just above their intended theorems.

- **Re-anchored 11 annotations** by name to the correct theorem ranges. Resolver validation: **36 valid / 0 misaligned** (was 11 misaligned).
- Content was already accurate (file is 0-sorry — the only `sorry` token is in a doc comment — and has a single intentional `axiom silence : True`), so no content changes were needed.

## Test plan
- [x] `validateLineAnnotations` → 36 valid, 0 misaligned
- [x] `annotations.json` parses as valid JSON