### PR TITLE
Enrich erdos-382: re-anchor 18 systematically drifted annotations

### DIFF
--- a/src/data/proofs/erdos-382/annotations.json
+++ b/src/data/proofs/erdos-382/annotations.json
@@ -24,8 +24,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 46,
-      "endLine": 54
+      "startLine": 49,
+      "endLine": 57
     },
     "title": "Product of an Interval",
     "content": "prodInterval(u, v) computes the product of all integers from u to v inclusive: u·(u+1)·...·v. This equals v!/(u−1)! and is defined using Finset.Icc (closed-closed interval) and Finset.prod from Mathlib's BigOperators library.",
@@ -44,8 +44,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 56,
-      "endLine": 63
+      "startLine": 59,
+      "endLine": 74
     },
     "title": "Interval Product Properties",
     "content": "Two properties of prodInterval: (1) prodInterval_singleton proves that prodInterval(n,n) = n using simp on Finset.Icc_self, a genuine Lean proof. (2) prodInterval_factorial states that prodInterval(1,n) = n!, axiomatized because Mathlib's factorial API does not directly connect to Finset products over Icc.",
@@ -63,8 +63,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 65,
-      "endLine": 76
+      "startLine": 78,
+      "endLine": 86
     },
     "title": "Largest Prime Divisor",
     "content": "largestPrimeDivisor(n) returns the largest prime that divides n, or 0 if n ≤ 1. It works by taking the maximum of n.primeFactorsList — the list of prime factors with multiplicity from Mathlib. This is noncomputable because it relies on classical decidability.",
@@ -82,8 +82,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 77,
-      "endLine": 87
+      "startLine": 139,
+      "endLine": 158
     },
     "title": "Largest Prime Divisor Axioms",
     "content": "Three axioms characterize largestPrimeDivisor: (1) it divides n, (2) it is prime when n > 1, and (3) every prime divisor of n is at most largestPrimeDivisor(n). These are axiomatized because proving them requires careful manipulation of primeFactorsList and List.maximum? that is technically straightforward but verbose in Lean.",
@@ -101,8 +101,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 89,
-      "endLine": 100
+      "startLine": 162,
+      "endLine": 171
     },
     "title": "P-adic Valuation",
     "content": "exponent(p, n) is the p-adic valuation of n — the exponent of prime p in the factorization of n. It wraps Mathlib's Nat.factorization, which returns a Finsupp mapping each prime to its exponent. exponentInProduct(p, u, v) specializes this to the product of an interval.",
@@ -120,8 +120,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 102,
-      "endLine": 104
+      "startLine": 186,
+      "endLine": 194
     },
     "title": "Exponent Sum Decomposition",
     "content": "The exponent of p in a product of integers equals the sum of individual exponents: v_p(∏ m) = Σ v_p(m). This is the key property of the p-adic valuation — it converts products to sums. Axiomatized because it requires Nat.factorization_prod from Mathlib with careful handling of zero terms.",
@@ -139,8 +139,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 108,
-      "endLine": 118
+      "startLine": 198,
+      "endLine": 208
     },
     "title": "The Erdős-Graham Condition",
     "content": "satisfiesCondition(u, v) formalizes the problem's core constraint: u ≤ v, u > 0, and the largest prime dividing the product u·(u+1)·...·v has exponent at least 2 in that product. This is the central predicate around which both open questions are formulated.",
@@ -158,8 +158,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 120,
-      "endLine": 130
+      "startLine": 210,
+      "endLine": 253
     },
     "title": "Structural Axioms",
     "content": "Two structural results: (1) If the largest prime p in [u,v] satisfies p² > v, then p has exponent exactly 1 (it appears once in the product and its square exceeds v). (2) For exponent ≥ 2, some multiple of p² must lie in [u,v]. These capture the combinatorial heart of the problem.",
@@ -177,8 +177,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 134,
-      "endLine": 147
+      "startLine": 263,
+      "endLine": 273
     },
     "title": "Question 1: Subpolynomial Growth (OPEN)",
     "content": "The first open question: Is v − u = v^o(1)? Formally, for every ε > 0, there exists V such that for all u,v with v ≥ V satisfying the condition, (v−u) < v^ε. This asks whether the interval length grows slower than any fixed power of v. The axiom erdos_382_q1 asserts the answer is YES, but this is unproven.",
@@ -196,8 +196,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 149,
-      "endLine": 159
+      "startLine": 275,
+      "endLine": 282
     },
     "title": "Question 2: Unbounded Length (OPEN)",
     "content": "The second open question: Can v − u be arbitrarily large? Formally, for every L, there exist u,v satisfying the condition with v − u > L. Cambie's heuristic analysis suggests the answer is YES — near squares of large primes, the intervals [u,v] with no prime > √v can be long. The axiom erdos_382_q2_heuristic asserts YES.",
@@ -215,8 +215,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 161,
-      "endLine": 173
+      "startLine": 286,
+      "endLine": 296
     },
     "title": "Ramachandra's Bound",
     "content": "The best known unconditional result: v − u ≤ v^{1/2 + o(1)}. For any ε > 0 and sufficiently large v, intervals [u,v] satisfying the condition have v − u ≤ v^{1/2+ε}. This uses techniques from the distribution of primes in short intervals. It shows the interval length is at most roughly √v.",
@@ -234,8 +234,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 175,
-      "endLine": 188
+      "startLine": 300,
+      "endLine": 310
     },
     "title": "Cramér's Conjecture",
     "content": "Cramér's conjecture (1936): the gap between consecutive primes p_n and p_{n+1} is O((log p_n)²). Formally, there exists C > 0 such that for all n, p_{n+1} − p_n ≤ C·(log p_n)². This is one of the most important open conjectures in number theory. If true, it prevents long prime-free intervals.",
@@ -253,8 +253,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 190,
-      "endLine": 191
+      "startLine": 373,
+      "endLine": 390
     },
     "title": "Cramér Implies Question 1",
     "content": "If Cramér's conjecture holds, then Question 1 has answer YES. The reasoning: Cramér's conjecture bounds prime gaps by O((log p)²), so any interval of length v^ε (for ε > 0) contains a prime for large v. This means intervals [u,v] satisfying the Erdős-Graham condition (no prime > √v) must have v−u = v^o(1).",
@@ -272,8 +272,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 195,
-      "endLine": 198
+      "startLine": 490,
+      "endLine": 493
     },
     "title": "Concrete Example: [2,4]",
     "content": "A verified computational example: prodInterval(2, 4) = 2·3·4 = 24. The proof uses native_decide, which evaluates the expression at compile time. Note: 24 = 2³·3, so the largest prime is 3 with exponent 1 — this interval does NOT satisfy the Erdős-Graham condition.",
@@ -291,8 +291,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 203,
-      "endLine": 206
+      "startLine": 495,
+      "endLine": 515
     },
     "title": "No Large Primes Under Condition",
     "content": "If [u,v] satisfies the Erdős-Graham condition, then there is no prime p with √v < p ≤ v. This is the contrapositive of the structural result: such a prime p would have p² > v, forcing exponent 1, contradicting the condition requiring exponent ≥ 2.",
@@ -310,8 +310,8 @@
     "proofId": "erdos-382",
     "type": "definition",
     "range": {
-      "startLine": 209,
-      "endLine": 224
+      "startLine": 592,
+      "endLine": 602
     },
     "title": "Prime-Free Interval Perspective",
     "content": "noPrimeLargerThanSqrt(u, v) captures the equivalent formulation: all primes in [u,v] are at most √v. The axiom condition_iff_no_large_prime establishes this equivalence with satisfiesCondition. This reformulates Problem 382 as a question about the existence and length of prime-free intervals above √v.",
@@ -329,8 +329,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 229,
-      "endLine": 254
+      "startLine": 621,
+      "endLine": 647
     },
     "title": "Summary Theorem",
     "content": "erdos_382_summary combines the three main known results into a single theorem: (1) Ramachandra's bound holds (from ramachandra_bound axiom), (2) Cramér's conjecture implies Question 1 (from cramer_implies_q1 axiom), and (3) both questions are formally stated (trivially True). The proof is a direct triple ⟨ramachandra_bound, cramer_implies_q1, trivial⟩.",
@@ -348,8 +348,8 @@
     "proofId": "erdos-382",
     "type": "concept",
     "range": {
-      "startLine": 256,
-      "endLine": 264
+      "startLine": 649,
+      "endLine": 657
     },
     "title": "Ramachandra Bound Consistency",
     "content": "ramachandra_consistent_with_questions demonstrates that the Ramachandra bound v−u ≤ v^{1/2+ε} is logically consistent with both open questions. The proof is the identity function: the bound itself is the conclusion, showing it does not contradict either subpolynomial growth (Question 1) or unbounded length (Question 2). Both questions remain OPEN.",


### PR DESCRIPTION
## Enrichment pass for erdos-382

The entire annotation set was stale after the Lean file grew/reorganized.
The 9 resolver-flagged annotations landed on `--` banner comments or the
wrong construct kind (`definition` typed annotations sitting on lemmas),
and most of the 10 "valid" ones were silently pointing one or more
declarations off their intended target — e.g. `ann-e382-q1` landed on
`largestPrimeDivisor_dvd`, `ann-e382-summary` on `largest_prime_exp_one`.

### Fix
Remapped 18 annotations to the declaration each title/content describes,
anchored at `[docCommentStart, endLine]` from the parser: `prodInterval`,
the singleton/factorial prop theorems, `largestPrimeDivisor` + its three
characterization theorems, `exponent`, `exponentInProduct_sum`,
`satisfiesCondition`, `largest_prime_exp_one`, `question1`/`question2`,
`ramachandra_bound`, `cramersConjecture`, `cramer_implies_q1`,
`example_491`, `no_prime_in_upper_half`, `noPrimeLargerThanSqrt`,
`erdos_382_summary`, `ramachandra_consistent_with_questions`.

### Verification
`resolver.ts validate`: **19/19 valid, 0 misaligned** (was 10/19, with most
of the "valid" ones semantically pointing at the wrong declaration).