### PR TITLE
Enrich ehrhart-cube-proven-oq-02: re-anchor 10 drifted annotations

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/annotations.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/annotations.json
@@ -2,157 +2,292 @@
   {
     "id": "ann-header",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
     "type": "context",
     "title": "Header: The Three-Pillar Axiom-Free Ehrhart Program",
     "content": "The opening docstring positions this file as the third member of an axiom-free Ehrhart triumvirate: cube ((n+1)^d via `Fin d → Fin (n+1)`), simplex ($\\binom{n+d}{d}$ via `Sym (Fin (d+1)) n`), and cross-polytope ($\\sum 2^k \\binom{d}{k} \\binom{n}{k}$ via algebraic induction). The cross-polytope $B_d = \\{x : \\|x\\|_1 \\leq 1\\}$ is geometrically the dual of the cube, and the Delannoy-number formula counts the lattice points of $n \\cdot B_d = \\{x \\in \\mathbb{Z}^d : \\sum |x_i| \\leq n\\}$. The proof avoids the general Ehrhart existence theorem entirely — it uses only Pascal's rule, the hockey-stick identity, and Finset sum algebra. Three sorries remain (polynomial identification via Lean's `Polynomial` API, and the Finset-slicing argument for `crossBall_card`'s inductive step), but all 10 algebraic/combinatorial theorems are complete.",
     "mathContext": "Cross-polytope: $B_d = \\{x \\in \\mathbb{R}^d : \\sum_{i=1}^d |x_i| \\leq 1\\}$. Lattice points in $n B_d$: $|n B_d \\cap \\mathbb{Z}^d| = \\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{n}{k}$ — the central Delannoy formula (OEIS A001850 for $d = 2$).",
     "significance": "context",
-    "relatedConcepts": ["Ehrhart polynomial", "cross-polytope", "Delannoy numbers", "axiom-free formalization"],
-    "prerequisites": ["lattice polytopes", "Ehrhart theory", "Pascal's rule", "hockey-stick identity"]
+    "relatedConcepts": [
+      "Ehrhart polynomial",
+      "cross-polytope",
+      "Delannoy numbers",
+      "axiom-free formalization"
+    ],
+    "prerequisites": [
+      "lattice polytopes",
+      "Ehrhart theory",
+      "Pascal's rule",
+      "hockey-stick identity"
+    ]
   },
   {
     "id": "ann-imports-namespace",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 38, "endLine": 46 },
+    "range": {
+      "startLine": 43,
+      "endLine": 46
+    },
     "type": "definition",
     "title": "Imports and Namespace Setup",
     "content": "A blanket `import Mathlib` (acceptable for research files; the surface area of `Nat.choose`, `Finset.sum_*`, `Polynomial`, and `Nat.choose_succ_succ` is large enough that à-la-carte imports become brittle). `open Finset Nat` brings the Finset and Nat APIs unprefixed, so `range`, `sum_range_succ`, `sum_range_succ'`, `sum_comm`, `mul_sum`, `sum_add_distrib`, `Nat.choose`, `Nat.choose_succ_succ`, `Nat.choose_zero_right`, `Nat.choose_eq_zero_of_lt`, etc., are all directly available. The `linter.unusedSimpArgs` and `linter.unusedTactic` toggles silence cosmetic noise from the dense `simp`/`rw` chains in the algebraic-expansion proof.",
     "mathContext": "Namespace: `EhrhartCrossPolytope`. Open scope: `Finset Nat`. The Finset open is essential for the `range`/`sum_range_succ`/`sum_comm` machinery used throughout.",
     "significance": "context",
-    "relatedConcepts": ["Mathlib import", "namespace scoping", "Finset API"],
-    "prerequisites": ["Lean 4 imports"]
+    "relatedConcepts": [
+      "Mathlib import",
+      "namespace scoping",
+      "Finset API"
+    ],
+    "prerequisites": [
+      "Lean 4 imports"
+    ]
   },
   {
     "id": "ann-formula-def",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 47, "endLine": 57 },
+    "range": {
+      "startLine": 49,
+      "endLine": 57
+    },
     "type": "definition",
     "title": "The Cross-Polytope Ehrhart Formula",
     "content": "The single line `crossEhrhart d n := ∑ k ∈ range (d+1), 2^k · C(d,k) · C(n,k)` is the entire combinatorial content. Each term is interpreted as: choose $k$ coordinates to be nonzero ($\\binom{d}{k}$ ways), choose signs for those $k$ coordinates ($2^k$), and select the multiset of magnitudes $|x_{i_1}|, \\dots, |x_{i_k}|$ summing to at most $n$ ($\\binom{n}{k}$ via stars-and-bars over $k$ positive coordinates summing to $\\leq n$). The sum over $k$ partitions lattice points by their *support size* — the number of nonzero coordinates. This is the central Delannoy formula, and the file's job is to prove it equals the actual lattice-point count (modulo the remaining `crossBall_card` sorry).",
     "mathContext": "$\\text{crossEhrhart}(d, n) = \\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{n}{k}.$ Combinatorial reading: $k$ = number of nonzero coordinates, $2^k$ = sign choices, $\\binom{d}{k}$ = position choices, $\\binom{n}{k}$ = magnitude multiset.",
     "significance": "key",
-    "relatedConcepts": ["central Delannoy number", "stars and bars", "support size partition"],
-    "prerequisites": ["Finset.sum", "Nat.choose"]
+    "relatedConcepts": [
+      "central Delannoy number",
+      "stars and bars",
+      "support size partition"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "Nat.choose"
+    ]
   },
   {
     "id": "ann-base-cases",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 59, "endLine": 89 },
+    "range": {
+      "startLine": 61,
+      "endLine": 89
+    },
     "type": "technique",
     "title": "Base Cases: d=0, n=0, d=1",
     "content": "Three sanity checks. `crossEhrhart_d0 n = 1` (a single point in $\\mathbb{R}^0$, regardless of dilation) — discharged by `simp [crossEhrhart]` since the sum over `range 1` reduces to one term. `crossEhrhart_n0 d = 1` (only the origin lies in $0 \\cdot B_d$) — proved using `Finset.sum_eq_single 0` to isolate the $k = 0$ term, with $\\binom{0}{k} = 0$ killing all $k \\geq 1$ summands. `crossEhrhart_d1 n = 2n + 1` (the segment $[-n, n]$ has $2n + 1$ lattice points) — `simp [crossEhrhart, sum_range_succ, Nat.choose_one_right]` plus `ring`. The four `native_decide` examples ($\\text{crossEhrhart}(1, 3) = 7$, $(2, 1) = 5$, $(2, 2) = 13$, $(3, 1) = 7$) act as regression tests against future Mathlib API drift.",
     "mathContext": "$d=0: \\text{xE}(0, n) = 1$. $n=0: \\text{xE}(d, 0) = 1$. $d=1: \\text{xE}(1, n) = 2n+1.$ The origin is always counted; one-dimensional cross-polytope is $[-n, n]$.",
     "significance": "supporting",
-    "relatedConcepts": ["base case verification", "native_decide", "regression test"],
-    "prerequisites": ["Finset.sum_eq_single", "Nat.choose_eq_zero_of_lt", "sum_range_succ"]
+    "relatedConcepts": [
+      "base case verification",
+      "native_decide",
+      "regression test"
+    ],
+    "prerequisites": [
+      "Finset.sum_eq_single",
+      "Nat.choose_eq_zero_of_lt",
+      "sum_range_succ"
+    ]
   },
   {
     "id": "ann-structural-properties",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 91, "endLine": 109 },
+    "range": {
+      "startLine": 93,
+      "endLine": 109
+    },
     "type": "technique",
     "title": "Structural Properties: Positivity and Monotonicity",
     "content": "`crossEhrhart_pos`: the count is at least 1 — geometrically, the origin always lies in $n B_d$. The `calc` block extracts the $k = 0$ term ($2^0 \\cdot \\binom{d}{0} \\cdot \\binom{n}{0} = 1$) and uses `Finset.single_le_sum` to bound it below by the full sum. `crossEhrhart_mono`: increasing $n$ does not decrease the count. The proof uses `Finset.sum_le_sum` + `gcongr` (generalized congruence) to compare term-by-term: each $\\binom{n}{k} \\leq \\binom{n+1}{k}$, and $2^k \\binom{d}{k}$ is non-negative, so the sum is monotone. These structural results follow from the formula directly without invoking the geometric interpretation.",
     "mathContext": "$\\text{xE}(d, n) \\geq 1$ (origin always counted); $\\text{xE}(d, n) \\leq \\text{xE}(d, n+1)$ (more lattice points in larger dilation).",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.single_le_sum", "Finset.sum_le_sum", "gcongr"],
-    "prerequisites": ["crossEhrhart definition"]
+    "relatedConcepts": [
+      "Finset.single_le_sum",
+      "Finset.sum_le_sum",
+      "gcongr"
+    ],
+    "prerequisites": [
+      "crossEhrhart definition"
+    ]
   },
   {
     "id": "ann-hockey-stick",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 111, "endLine": 125 },
+    "range": {
+      "startLine": 113,
+      "endLine": 124
+    },
     "type": "insight",
     "title": "Hockey-Stick Identity",
     "content": "The hockey-stick identity $\\sum_{m=0}^{n-1} \\binom{m}{k} = \\binom{n}{k+1}$ is the file's central inductive tool. Geometrically, it sums column $k$ of Pascal's triangle from row 0 to row $n - 1$ and gets the entry diagonally below — the visual is a hockey stick laid against the triangle. The proof is a clean induction on $n$: base case `simp` (empty sum is 0, $\\binom{0}{k+1} = 0$ for $k \\geq 0$); step uses `sum_range_succ` to extract the new term, applies the inductive hypothesis, and closes via `Nat.choose_succ_succ n k` (Pascal's rule, $\\binom{n+1}{k+1} = \\binom{n}{k} + \\binom{n}{k+1}$). This identity will be used in `sum_shift_hockey` to convert generating-style sums back to enumerative sums.",
     "mathContext": "$\\sum_{m=0}^{n-1} \\binom{m}{k} = \\binom{n}{k+1}.$ Inductive step: $\\sum_{m=0}^{n} \\binom{m}{k} = \\binom{n}{k+1} + \\binom{n}{k} = \\binom{n+1}{k+1}$ by Pascal's rule.",
     "significance": "key",
-    "relatedConcepts": ["hockey-stick identity", "Pascal's triangle", "induction on n"],
-    "prerequisites": ["Nat.choose_succ_succ", "sum_range_succ"]
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "Pascal's triangle",
+      "induction on n"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ",
+      "sum_range_succ"
+    ]
   },
   {
     "id": "ann-sum-shift-hockey",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 127, "endLine": 139 },
+    "range": {
+      "startLine": 127,
+      "endLine": 139
+    },
     "type": "insight",
     "title": "Sum Interchange via Hockey-Stick",
     "content": "`sum_shift_hockey` converts $\\sum_k 2^k \\binom{d}{k} \\binom{n}{k+1}$ — a sum involving $\\binom{n}{k+1}$, hard to interpret geometrically — into $\\sum_{m < n} \\sum_k 2^k \\binom{d}{k} \\binom{m}{k}$, a *double* sum where the outer index $m$ ranges over smaller dilations. The trick: substitute $\\binom{n}{k+1} = \\sum_{m < n} \\binom{m}{k}$ (hockey-stick) inside, then commute the two sums via `Finset.sum_comm`. The end result is a closed expression for $\\sum_{m < n} \\text{crossEhrhart}(d, m)$ that bridges the algebraic expansion (next section) to the geometric recursion. This single identity is what lets us interpret the algebraic identity geometrically as a slicing argument.",
     "mathContext": "$\\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{n}{k+1} = \\sum_{m=0}^{n-1} \\sum_{k=0}^d 2^k \\binom{d}{k} \\binom{m}{k} = \\sum_{m=0}^{n-1} \\text{crossEhrhart}(d, m).$",
     "significance": "key",
-    "relatedConcepts": ["sum interchange", "hockey-stick", "Finset.sum_comm", "double sum"],
-    "prerequisites": ["sum_choose_range (hockey-stick)", "Finset.mul_sum"]
+    "relatedConcepts": [
+      "sum interchange",
+      "hockey-stick",
+      "Finset.sum_comm",
+      "double sum"
+    ],
+    "prerequisites": [
+      "sum_choose_range (hockey-stick)",
+      "Finset.mul_sum"
+    ]
   },
   {
     "id": "ann-expand",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 141, "endLine": 194 },
+    "range": {
+      "startLine": 143,
+      "endLine": 194
+    },
     "type": "insight",
     "title": "Key Algebraic Expansion via Pascal Split",
     "content": "The technical heart of the file: $\\text{xE}(d+1, n) = \\text{xE}(d, n) + 2 \\cdot \\sum_k 2^k \\binom{d}{k} \\binom{n}{k+1}$. The proof has four explicit moves:\n\n1. **Extract $k = 0$ term** from the $(d+1)$-sum via `sum_range_succ'` (which separates $f(0)$ from $\\sum_{k=0}^d f(k+1)$). The $k = 0$ term is $2^0 \\binom{d+1}{0} \\binom{n}{0} = 1$.\n2. **Apply Pascal's rule** $\\binom{d+1}{k+1} = \\binom{d}{k} + \\binom{d}{k+1}$ to each remaining summand using `Nat.choose_succ_succ`.\n3. **Distribute and split** the sum: $2^{k+1}(\\binom{d}{k} + \\binom{d}{k+1}) \\binom{n}{k+1} = 2 \\cdot 2^k \\binom{d}{k} \\binom{n}{k+1} + 2 \\cdot 2^k \\binom{d}{k+1} \\binom{n}{k+1}$, giving $2A + 2B$ where $A$ is the desired right-hand side and $B$ is a residual.\n4. **Recognize the residual**: the `key` lemma proves $\\text{xE}(d, n) = 1 + 2 \\cdot \\sum_k 2^k \\binom{d}{k+1} \\binom{n}{k+1} = 1 + 2B$. Substituting, the LHS equals $1 + 2A + 2B = 1 + 2A + (\\text{xE}(d, n) - 1) = \\text{xE}(d, n) + 2A$ — the desired identity. `linarith [key]` does the final composition.\n\nThe `key` sub-lemma is itself non-trivial: it extracts $k = 0$ from $\\text{xE}(d, n)$, then drops the $k = d$ term from the residual via `Nat.choose_eq_zero_of_lt` (since $\\binom{d}{d+1} = 0$), then applies `Finset.mul_sum` to factor out the 2.",
     "mathContext": "$\\text{xE}(d+1, n) = \\text{xE}(d, n) + 2 \\cdot \\sum_k 2^k \\binom{d}{k} \\binom{n}{k+1}.$ Pascal split: $\\binom{d+1}{k+1} = \\binom{d}{k} + \\binom{d}{k+1}$. The 2× factor in the RHS captures the doubling of contributions from the new dimension's $\\pm$ signs.",
     "significance": "key",
-    "relatedConcepts": ["Pascal's rule", "sum_range_succ'", "Finset.mul_sum", "sum_add_distrib", "Nat.choose_eq_zero_of_lt"],
-    "prerequisites": ["crossEhrhart definition", "Pascal's rule"]
+    "relatedConcepts": [
+      "Pascal's rule",
+      "sum_range_succ'",
+      "Finset.mul_sum",
+      "sum_add_distrib",
+      "Nat.choose_eq_zero_of_lt"
+    ],
+    "prerequisites": [
+      "crossEhrhart definition",
+      "Pascal's rule"
+    ]
   },
   {
     "id": "ann-succ-d",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 196, "endLine": 216 },
+    "range": {
+      "startLine": 198,
+      "endLine": 216
+    },
     "type": "concept",
     "title": "Geometric Recursion: Slicing the Cross-Polytope",
     "content": "The headline geometric statement: $\\text{xE}(d+1, n) = \\text{xE}(d, n) + 2 \\cdot \\sum_{m=0}^{n-1} \\text{xE}(d, m)$. Geometric reading: slice $(n+1)$-dimensional cross-polytope $n B_{d+1}$ by its last coordinate $x_{d+1}$. The slice $\\{x_{d+1} = 0\\}$ is exactly $n B_d$ in the remaining $d$ coordinates, contributing $\\text{xE}(d, n)$ points. The slices $\\{x_{d+1} = \\pm j\\}$ for $j = 1, \\dots, n$ each contribute $\\text{xE}(d, n - j)$ (the constraint $\\sum |x_i| \\leq n$ becomes $\\sum_{i \\leq d} |x_i| \\leq n - j$ on the slice). Summing $j$ from 1 to $n$ and re-indexing $m = n - j$ gives the $2 \\sum_{m < n} \\text{xE}(d, m)$ contribution, with the factor 2 for $\\pm$. The two-line proof in Lean composes `crossEhrhart_expand` (algebraic) with `sum_shift_hockey` (combinatorial) — the geometric structure is *implicit* in the algebra.",
     "mathContext": "$\\text{xE}(d+1, n) = \\text{xE}(d, n) + 2 \\sum_{m=0}^{n-1} \\text{xE}(d, m).$ Geometry: $n B_{d+1} = (n B_d \\times \\{0\\}) \\sqcup \\bigsqcup_{j=1}^n ((n-j) B_d \\times \\{+j\\}) \\sqcup ((n-j) B_d \\times \\{-j\\}).$",
     "significance": "key",
-    "relatedConcepts": ["polytope slicing", "geometric induction", "L¹-norm decomposition"],
-    "prerequisites": ["crossEhrhart_expand", "sum_shift_hockey"]
+    "relatedConcepts": [
+      "polytope slicing",
+      "geometric induction",
+      "L¹-norm decomposition"
+    ],
+    "prerequisites": [
+      "crossEhrhart_expand",
+      "sum_shift_hockey"
+    ]
   },
   {
     "id": "ann-d2-formula",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 218, "endLine": 238 },
+    "range": {
+      "startLine": 220,
+      "endLine": 238
+    },
     "type": "technique",
     "title": "2D Diamond: 2n²+2n+1 via Recursion",
     "content": "$\\text{xE}(2, n) = 2n^2 + 2n + 1$ — the 2D rotated-square (diamond) lattice count, the central Delannoy number sequence $1, 5, 13, 25, 41, \\dots$ The proof inducts on $n$: base case $n = 0$ uses `crossEhrhart_n0`; the step applies the geometric recursion `crossEhrhart_succ_d 1 (n+1)` and `crossEhrhart_succ_d 1 n`, then `sum_range_succ` to expose the difference between the two sums, then closes with `ring`. This is a *formula derivation* via the recursion — the reverse direction of the algebraic expansion. The closing `native_decide` examples ($\\text{xE}(2, 3) = 25$, $\\text{xE}(3, 2) = 25$, $\\text{xE}(3, 3) = 63$, $\\text{xE}(3, 4) = 129$) anchor the formula at concrete values.",
     "mathContext": "$\\text{xE}(2, n) = 2n^2 + 2n + 1.$ Inductive step: $\\text{xE}(2, n+1) = \\text{xE}(2, n) + \\text{xE}(1, n+1) + \\text{xE}(1, n) = \\text{xE}(2, n) + (2n+3) + (2n+1) = \\text{xE}(2, n) + 4n + 4$, and $2(n+1)^2 + 2(n+1) + 1 - (2n^2 + 2n + 1) = 4n + 4.$",
     "significance": "supporting",
-    "relatedConcepts": ["central Delannoy", "induction on n", "ring tactic"],
-    "prerequisites": ["crossEhrhart_succ_d", "crossEhrhart_d1"]
+    "relatedConcepts": [
+      "central Delannoy",
+      "induction on n",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "crossEhrhart_succ_d",
+      "crossEhrhart_d1"
+    ]
   },
   {
     "id": "ann-poly-sorry",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 240, "endLine": 255 },
+    "range": {
+      "startLine": 243,
+      "endLine": 255
+    },
     "type": "context",
     "title": "Polynomial Identification (Sorry: Lean Polynomial API)",
     "content": "The first remaining sorry: showing that crossEhrhart is an actual polynomial $P \\in \\mathbb{Q}[X]$ of degree $\\leq d$ that agrees with $\\text{xE}(d, n)$ at all natural numbers $n$. Mathematically straightforward — each term $2^k \\binom{d}{k} \\binom{n}{k}$ is degree $k$ in $n$ via $\\binom{n}{k} = n^{\\underline{k}} / k!$ (falling factorial), so the sum is degree $d$. The blocker is the Lean side: constructing the polynomial $P = \\sum_k (2^k \\binom{d}{k} / k!) \\cdot X^{\\underline{k}}$ explicitly using `Polynomial` constructors and showing $P.\\text{natDegree} \\leq d$ and $P.\\text{eval}(n) = \\text{xE}(d, n)$ requires non-trivial Mathlib `Polynomial` plumbing. The mathematical content is settled; the work is API translation.",
     "mathContext": "$P(X) = \\sum_{k=0}^d \\frac{2^k \\binom{d}{k}}{k!} X^{\\underline{k}} = \\sum_{k=0}^d \\frac{2^k \\binom{d}{k}}{k!} X(X-1) \\cdots (X-k+1).$ Degree exactly $d$ (leading coefficient $2^d / d!$).",
     "significance": "context",
-    "relatedConcepts": ["Polynomial API", "falling factorial", "Newton expansion"],
-    "prerequisites": ["Mathlib Polynomial type", "Polynomial.natDegree"]
+    "relatedConcepts": [
+      "Polynomial API",
+      "falling factorial",
+      "Newton expansion"
+    ],
+    "prerequisites": [
+      "Mathlib Polynomial type",
+      "Polynomial.natDegree"
+    ]
   },
   {
     "id": "ann-crossball",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 257, "endLine": 283 },
+    "range": {
+      "startLine": 328,
+      "endLine": 363
+    },
     "type": "concept",
     "title": "Lattice Point Model: crossBall (and Sorry on Slicing)",
     "content": "`crossBall d n` is the explicit `Finset` of lattice points: functions $\\text{Fin } d \\to \\text{Fin}(2n+1)$ representing centered coordinates (encoding $x_i \\in \\{-n, -n+1, \\dots, n\\}$ as $\\text{Fin}(2n+1)$ via the obvious bijection) filtered by the $\\ell^1$ constraint $\\sum |x_i| \\leq n$. The base case $d = 0$ gives a singleton (the empty function), card 1 = $\\text{xE}(0, n)$ — `simp` closes this. The remaining sorry is the inductive step: decompose `crossBall (d+1) n` by the value of the last coordinate $j \\in \\{0, \\dots, 2n\\}$. For each $j$, the fiber is `crossBall d (n - |j - n|)`. Summing and pairing $j \\leftrightarrow 2n - j$ for the 2× factor gives $\\text{crossBall}(d, n).\\text{card} + 2 \\sum_{m < n} \\text{crossBall}(d, m).\\text{card}$, and `crossEhrhart_succ_d` finishes by induction. The argument is standard but the Finset `card_biUnion`/`Finset.card_filter` plumbing is lengthy.",
     "mathContext": "$\\text{crossBall}(d, n) = \\{x : \\text{Fin } d \\to \\text{Fin}(2n+1) \\mid \\sum_i d(x_i, n) \\leq n\\}$, where $d(\\cdot, n)$ is the centered absolute value. Card matches $\\text{xE}(d, n)$ — proved for $d = 0$, sorry for the inductive step.",
     "significance": "key",
-    "relatedConcepts": ["Finset filter", "centered coordinates", "Finset.card_biUnion", "polytope slicing"],
-    "prerequisites": ["Finset API", "crossEhrhart_succ_d"]
+    "relatedConcepts": [
+      "Finset filter",
+      "centered coordinates",
+      "Finset.card_biUnion",
+      "polytope slicing"
+    ],
+    "prerequisites": [
+      "Finset API",
+      "crossEhrhart_succ_d"
+    ]
   },
   {
     "id": "ann-summary",
     "proofId": "ehrhart-cube-proven-oq-02",
-    "range": { "startLine": 285, "endLine": 330 },
+    "range": {
+      "startLine": 285,
+      "endLine": 330
+    },
     "type": "context",
     "title": "Summary: Three Pillars and Open Questions",
     "content": "The closing comment block lays out the dependency graph (`sum_choose_range` → `sum_shift_hockey` → `crossEhrhart_expand` → `crossEhrhart_succ_d`) and the comparison table positioning cross-polytope alongside cube and simplex as the three Ehrhart families with axiom-free Lean proofs. Three open questions are posed: (1) eliminate the `crossBall_card` sorry via Finset slicing; (2) prove the equivalence with central Delannoy numbers $D(d, n)$; (3) extend to half-integer dilations (quasipolynomial of the rational cross-polytope). The `#check` directives at the end of the file expose the public API — the seven theorems any downstream consumer should be able to invoke.",
     "mathContext": "Comparison: cube $(n+1)^d$ uses functions; simplex $\\binom{n+d}{d}$ uses multisets; cross-polytope $\\sum 2^k \\binom{d}{k} \\binom{n}{k}$ uses algebraic induction with Pascal + hockey-stick. Three different combinatorial primitives, three different axiom-free proofs.",
     "significance": "context",
-    "relatedConcepts": ["dependency graph", "API surface", "research roadmap"],
-    "prerequisites": ["all earlier sections"]
+    "relatedConcepts": [
+      "dependency graph",
+      "API surface",
+      "research roadmap"
+    ],
+    "prerequisites": [
+      "all earlier sections"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for ehrhart-cube-proven-oq-02

9 annotations were anchored to `-- ===` PART banner comments rather than
Lean declarations ("No Lean construct found at line N").

### Fix
Re-anchored each to the first declaration after its banner: namespace,
`crossEhrhart`, the base-case theorems (`crossEhrhart_d0/n0/d1`),
`crossEhrhart_pos`/`crossEhrhart_mono`, `sum_choose_range`,
`crossEhrhart_expand`, `crossEhrhart_succ_d`, `crossEhrhart_d2`,
`natDegree_descPochhammer_le`.

Also corrected `ann-crossball`, which was resolver-"valid" but landed on
`eval_descPochhammer_natCast` even though it describes the `crossBall`
lattice-point model — re-anchored to the `crossBall` definition.

### Verification
`resolver.ts validate`: **13/13 valid, 0 misaligned** (was 4/13).