### PR TITLE
Enrich erdos-103: re-anchor 11 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-103/annotations.json
+++ b/src/data/proofs/erdos-103/annotations.json
@@ -22,7 +22,7 @@
     "id": "ann-103-pointconfig",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 39,
+      "startLine": 40,
       "endLine": 44
     },
     "type": "definition",
@@ -40,7 +40,7 @@
     "id": "ann-103-separation",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 46,
+      "startLine": 47,
       "endLine": 48
     },
     "type": "definition",
@@ -58,7 +58,7 @@
     "id": "ann-103-diameter",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 50,
+      "startLine": 51,
       "endLine": 58
     },
     "type": "definition",
@@ -76,7 +76,7 @@
     "id": "ann-103-optimal",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 66,
+      "startLine": 67,
       "endLine": 76
     },
     "type": "definition",
@@ -94,8 +94,8 @@
     "id": "ann-103-isometry",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 84,
-      "endLine": 95
+      "startLine": 86,
+      "endLine": 97
     },
     "type": "definition",
     "title": "Isometry and Congruence",
@@ -112,8 +112,8 @@
     "id": "ann-103-equiv-props",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 97,
-      "endLine": 111
+      "startLine": 100,
+      "endLine": 124
     },
     "type": "concept",
     "title": "Congruence is Equivalence",
@@ -130,8 +130,8 @@
     "id": "ann-103-counting",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 121,
-      "endLine": 130
+      "startLine": 140,
+      "endLine": 147
     },
     "type": "definition",
     "title": "Counting Function h(n)",
@@ -148,8 +148,8 @@
     "id": "ann-103-conjecture",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 138,
-      "endLine": 156
+      "startLine": 156,
+      "endLine": 161
     },
     "type": "definition",
     "title": "The Main Conjecture",
@@ -166,8 +166,8 @@
     "id": "ann-103-weak",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 164,
-      "endLine": 177
+      "startLine": 178,
+      "endLine": 183
     },
     "type": "definition",
     "title": "Weaker Conjectures",
@@ -202,8 +202,8 @@
     "id": "ann-103-packing",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 185,
-      "endLine": 192
+      "startLine": 194,
+      "endLine": 200
     },
     "type": "concept",
     "title": "Packing Connection",
@@ -221,8 +221,8 @@
     "id": "ann-103-status",
     "proofId": "erdos-103",
     "range": {
-      "startLine": 216,
-      "endLine": 244
+      "startLine": 226,
+      "endLine": 232
     },
     "type": "concept",
     "title": "Problem Status",


### PR DESCRIPTION
## Enrichment pass for erdos-103

9 annotations were anchored to `--` banner comments or to the wrong
construct kind (`definition`-typed annotations sitting on a theorem/
instance), and two resolver-"valid" annotations (`equiv-props`, `status`)
pointed at the wrong declaration.

### Fix
Remapped 11 annotations to the declaration each title describes:
`PointConfig`, `HasMinSeparation`, `diameter`, the optimal-configuration
defs (`minDiameter`/`IsOptimal`/`OptimalSet`), `Isometry2D`, the congruence
equivalence theorems (`congruent_refl/symm/trans`), the counting function
`h`, `ErdosConjecture103`, `WeakConjecture`, `optimalPackingDensity`, and
`erdos_103_status`.

### Verification
`resolver.ts validate`: **13/13 valid, 0 misaligned** (was 4/13).