### PR TITLE
research(erdos-340-greedy-sidon-oq-01): verified discharge status + one-shot inline recipe

### DIFF
--- a/research/problems/erdos-340-greedy-sidon/state.md
+++ b/research/problems/erdos-340-greedy-sidon/state.md
@@ -2,12 +2,15 @@
 
 **Phase**: PARTIAL (verified sub-results; headline conjecture remains OPEN)
 **Since**: 2026-06-16
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
-Discharging the *well-definedness* content behind the greedy-construction axioms in
-`Erdos340GreedySidon.lean`, and repairing a parse error in that file.
+The three `greedySidonSeq*` existence axioms in `Erdos340GreedySidon.lean` are fully
+*dischargeable* — an explicit greedy (Mian–Chowla) construction proves them. The discharge
+is drafted and verified-by-inspection (PR #25131, unregistered orphan
+`Erdos340GreedyConstructionDischarge.lean`); the only remaining step is the **inline** that
+actually drops the registered axiom count, which is blocked on the Docker build wrapper.
 
 ## Active Approach
 
@@ -33,13 +36,55 @@ library. Converted to `/-` block comments.
 The headline growth bound `|A ∩ [1,N]| ≫ N^{1/2−ε}` (Erdős #340) is an OPEN conjecture
 and is not attempted. The best known bound is `N^{1/3}`.
 
-## Next Action
+## Discharge status (verified by inspection, 2026-06-16 iter 3)
 
-Optional: formalize the `N^{1/3}` lower bound (known, ~200 lines), or a constructive
-`greedyNext` using `sidon_exists_extension` (needs a `Decidable (IsSidon ·)` instance).
+The greedy construction discharging the three `greedySidonSeq*` axioms exists and is
+correct on inspection. It reuses the already-merged, verified extension lemmas
+(`sidon_exists_extension`, `sidon_insert_of_large`, #25087). The construction:
+
+- `instDecidableIsSidon` — `Decidable (IsSidon A)` via `decidable_of_iff` over the bounded
+  4-binder form. Binder order matches `IsSidon` (def line 76: `a b c d`, then `∈`, then
+  `≤`, then sum-eq), so the forward map is `fun h a b c d ha hb hc hd => h a ha b hb …`.
+- `nextSidon S b` — `if h : ∃ m, b < m ∧ IsSidon (insert m S) then Nat.find h else b+1`;
+  `nextSidon_spec` discharges the `∃` from `sidon_exists_extension`, so it never hits junk.
+- `greedyPair : ℕ → ℕ × Finset ℕ` (a₀=1, {1}), `greedySeq n = (greedyPair n).1`,
+  `greedySeqSet n = (greedyPair n).2`.
+- `greedySeqSet_isSidon` (induction; base `isSidon_singleton 1`), `greedySeq_lt_succ`,
+  `greedySeq_strictMono` (`strictMono_nat_of_lt_succ`),
+  `greedySeqSet_eq_image` (induction; `range_succ` + `image_insert`).
+
+## Next Action — one-shot inline when Docker is back up
+
+This is the only step left to take registered `axiomCount` from **4 → 1** (the remaining
+axiom being `sidon_upper_bound`, the Erdős–Turán √N upper bound — a genuinely separate
+known result, not the open conjecture). Recipe:
+
+1. **Resolve the import cycle.** The construction needs `sidon_exists_extension`, which
+   currently lives in `Erdos340GreedyExtension.lean` — a file that *imports* the base
+   `Erdos340GreedySidon.lean`. So move `sidon_insert_of_large` + `sidon_exists_extension`
+   *into* the base file, placed before "Part 3" (they only need `IsSidon` / `isSidon_singleton`,
+   both defined earlier at lines 76/90, and `open Finset`, already in scope). Leave
+   `sidon_extension_points_infinite` in the Extension file — it still resolves via the
+   base import. Remove the two moved lemmas from the Extension file to avoid duplicates.
+2. **Replace the axioms** (base file lines 396–403) with the construction above, then set
+   `noncomputable def greedySidonSeq : ℕ → ℕ := greedySeq`, and turn
+   `greedySidonSeq_strictMono` / `greedySidonSeq_isSidon` into theorems
+   (`:= greedySeq_strictMono`; for `isSidon` use `greedySeqSet_eq_image` ▸ `greedySeqSet_isSidon`).
+   `Erdos340Problem.lean` has its **own** independent `greedySidon`, so it is unaffected.
+3. `./proofs/scripts/docker-build.sh Proofs.Erdos340GreedySidon` (then the Extension target).
+   Docker exits 0 even on Lean errors — `grep error:` the log.
+4. Update `src/data/proofs/erdos-340-greedy-sidon-oq-01/meta.json` `axiomCount` 4 → 1.
+
+The full drafted file is on PR #25131's branch; copy its body (minus the orphan header) and
+the import becomes unnecessary once the extension lemmas are co-located.
+
+**Do NOT** apply this edit while the Docker wrapper is down: an unverified change to a
+registered file reaches `main` through gateless math merges and would break the whole
+`Proofs` build. The 2026-06-16 sessions (R2 #25131, R12 branch, R9 #25087) were all blocked
+here by the same Docker stall, not by any mathematical gap.
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 2
+- Current approach attempts: 2
 - Approaches tried: 1


### PR DESCRIPTION
## Summary

Documentation-only handoff for Erdős #340 (greedy Sidon sequence). No Lean changes.

The three `greedySidonSeq*` existence axioms in the registered `Erdos340GreedySidon.lean`
are **fully dischargeable** — the explicit greedy (Mian–Chowla) construction proves them,
reusing the already-merged, verified extension lemmas (`sidon_exists_extension`, #25087).
The discharge is drafted in PR #25131 (unregistered orphan) and I reviewed it line-by-line
against the base/extension files: every API name resolves and the `IsSidon` binder order
matches the decidability instance.

The only remaining step to actually drop the registered axiom count **4 → 1** is the
*inline* (the orphan, being unregistered, doesn't change the count). That inline is blocked
on the Docker build wrapper, which is currently stalled (daemon unresponsive under load).
This PR records the exact one-shot inline recipe in `state.md` — including the import-cycle
resolution (move the two extension lemmas into the base file before the greedy section) and
the `meta.json` `axiomCount` bump — so the next Docker-up session lands it without
re-deriving, as the 2026-06-16 sessions (R2/R9/R12) each had to.

The headline growth bound `|A ∩ [1,N]| ≫ N^{1/2−ε}` remains the genuinely OPEN conjecture
(the 1/3-vs-1/2 exponent gap) and is untouched.

## Why doc-only

An unverified edit to a registered Lean file reaches `main` through gateless math merges
and would break the whole `Proofs` build. With Docker down I cannot verify a build, so I
deliberately did not touch registered files — only the research-state handoff.

## Test plan

- [x] No Lean/source changes — nothing to build.
- [x] `state.md` recipe cross-checked against current `Erdos340GreedySidon.lean` (axioms at
      lines 396–403; `IsSidon` def line 76; `isSidon_singleton` line 90) and
      `Erdos340GreedyExtension.lean` (extension lemmas verified, #25087).