### PR TITLE
research(erdos-671): triage 7 sorries + decomposition of equidistant_diverges

### DIFF
--- a/research/problems/erdos-671/knowledge.md
+++ b/research/problems/erdos-671/knowledge.md
@@ -15,6 +15,76 @@ Can Lagrange interpolation converge pointwise at a point x where the Lebesgue fu
 **Known**: Bernstein (1931): ∃ x₀ with limsup λ_n(x₀) = ∞ for any sequence.
 **Known**: Erdős-Vértesi (1980): ∃ continuous f with |L^n f(x)| → ∞ a.e. for any sequence.
 
+## Session 2026-06-16 (Session 4) — Triage of remaining 7 sorries + concrete decomposition of `equidistant_diverges`
+
+**Mode**: REVISIT (assessment; no Lean changes pushed)
+**Outcome**: no sorries eliminated. The routine content was already harvested in sessions 1–3
+(23 → 7 sorries). This session classifies the remaining 7 and works out an accurate,
+verified-by-hand roadmap for the single tractable one.
+
+### Environment note
+- Docker daemon **up** but host heavily contended: load avg ≈ 26, 11 concurrent
+  `docker-build.sh Proofs.*` peers. A fresh build would contend / risk timeout.
+- Aristotle MCP (`prove`) reachable, but useless here: the open sorries are not
+  isolated lemmas — they need infrastructure absent from Mathlib (Baire category on
+  C[-1,1], extremal-polynomial integral estimates, a.e.-divergence measure theory).
+- No Mathlib source cached locally (no `proofs/.lake/packages`), so API names could
+  not be grep-verified — another reason no Lean was pushed to the registered file.
+
+### Classification of the 7 remaining sorries
+
+**INFRASTRUCTURE-BLOCKED (research-grade; each ≈ a paper to formalize, needs Mathlib that does not exist):**
+- `bernstein` (1931) — uniform boundedness / Baire category on C[-1,1].
+- `lebesgueConstant_growth` (Λ_n ≥ (2/π)ln n − 1) — integral estimate against an extremal polynomial.
+- `erdos_vertesi` (1980) — a.e. divergence; generic-divergence Baire argument + measure theory.
+- `faber` (1914) — Baire category (no node sequence works for all of C[-1,1]).
+- `positive_measure_divergence`, `full_measure_convergence` — measure theory on divergence/convergence sets.
+
+**TRACTABLE-BUT-LARGE (a hard *finite* computation, NOT missing infrastructure):**
+- `equidistant_diverges`: `lebesgueConstant (equidistantNodes n hn) ≥ 2^(n-1) / n^2`.
+
+### Concrete decomposition of `equidistant_diverges` (verified by hand)
+
+Equidistant nodes on [-1,1]: `x_k = -1 + 2k/(n-1)`, spacing `h = 2/(n-1)`.
+
+Two-step reduction (both steps are clean, the hard part is step 3):
+1. `lebesgueConstant pts ≥ lebesgueFunction pts x*` for any chosen `x* ∈ [-1,1]`
+   (sup lower bound; needs `BddAbove` of the image, from continuity of `lebesgueFunction`
+   on compact `Icc` — `IsCompact.bddAbove_image` + `le_ciSup`-style; NOT `le_iSup`, ℝ is
+   only conditionally complete).
+2. `lebesgueFunction pts x* = Σ_i |p_i(x*)| ≥ |p_{i₀}(x*)|` for any single index `i₀`.
+3. Pick `x* = -1 + h/2` (midpoint of the first subinterval). Then with fractional index t = ½:
+   `|p_i(x*)| = ∏_{k≠i} |½ - k| / |i - k| = P / ( |½ - i| · i! · (n-1-i)! )`,
+   where `P = ∏_{k=0}^{n-1} |½ - k| = ½ · (2n-3)!! / 2^{n-1}`.
+
+   **KEY (corrected) FACT — the dominant term is the CENTRAL node, not an endpoint one.**
+   The denominator `D_i = |½ - i| · i! · (n-1-i)!` is minimized at `i ≈ n/2`: the ratio
+   `D_{i+1}/D_i = ((i+½)/(i-½)) · (i+1)/(n-1-i)` crosses 1 near `i ≈ (n-2)/2`. So the
+   exponentially-growing basis polynomial is `p_{⌊n/2⌋}(x*)`, and `((n/2)!)²` in its
+   denominator against `(2n-3)!!` in `P` produces the `~2^n` growth.
+
+   Sanity check at n=4 (x*=-2/3): P=15/16, giving p₀=5/16, p₁=15/16, p₂=5/16, p₃=1/16,
+   λ₄≈1.625 ≥ 2³/4² = 0.5 ✓. (Exponential separation only shows for larger n; the
+   target 2^(n-1)/n² is a comfortably *weak* bound vs. the true ~2^n/(n log n).)
+
+   **DEAD END to avoid**: do NOT try to make an *endpoint*/index-0 or index-1 basis
+   polynomial carry the bound — those grow only polynomially (`p_1 ~ √(n/π)`). The bound
+   must be carried by the central index `⌊n/2⌋`.
+
+   Remaining Lean work for step 3: bound `(2n-3)!! / ( |½ - m| · m! · (n-1-m)! )` from
+   below by `2^(n-1)/n^2` (m = ⌊n/2⌋). Pure finite product/factorial inequality —
+   no analysis. Estimated 200–400 lines; candidate for `prove_file` once written, or a
+   careful manual induction. This is the highest-value next target on this entry.
+
+### Recommendation
+Entry is effectively BLOCKED for fully-autonomous progress: 6 of 7 sorries need
+Mathlib infrastructure that does not exist. `equidistant_diverges` is the only
+self-contained target and is a substantial finite estimate. Future sessions should
+either (a) implement step 3 above in an UNREGISTERED orphan file (zero gallery risk)
+and build it when Docker is uncontended, or (b) leave the entry as a well-documented
+axiomatized open problem. No Lean was changed this session to avoid pushing
+unverifiable edits to the gateless registered file under load.
+
 ## Session 2026-05-04 (Session 3) — Partition of unity + type refactoring
 
 **Mode**: REVISIT (continued from session 2)


### PR DESCRIPTION
## Summary

Session 4 assessment of **Erdős Problem #671** (Lagrange interpolation convergence, OPEN, \$250 prize). The routine content was already harvested in sessions 1–3 (23 → 7 sorries). This is a **documentation-only** PR recording an honest triage of the remaining 7 sorries and a verified-by-hand roadmap for the only self-contained one.

## What this records (in `research/problems/erdos-671/knowledge.md`)

- **6 of 7 sorries are infrastructure-blocked** — `bernstein`, `lebesgueConstant_growth`, `erdos_vertesi`, `faber`, and the two measure-theoretic results each require Mathlib that does not exist (Baire category on C[-1,1], extremal-polynomial integral estimates, a.e.-divergence measure theory).
- **`equidistant_diverges` is the only self-contained target** — a hard *finite* product/factorial estimate, not missing infrastructure. Documents:
  - the two-step reduction (sup ≥ pointwise ≥ single basis polynomial), and
  - the **corrected key fact**: at the first-subinterval midpoint `x* = -1 + h/2`, the exponentially-growing basis polynomial is the **central** node `p_{⌊n/2⌋}` (denominator `D_i` is minimized at `i ≈ n/2`), **not** an endpoint node — endpoint basis polynomials grow only `~√n`. Includes the explicit formula `|p_i(x*)| = P / (|½−i|·i!·(n−1−i)!)` and a sanity check at n=4 (λ₄ ≈ 1.625 ≥ 0.5).

## Notes

- **No Lean was changed.** This avoids pushing unverifiable edits to the gateless registered `Erdos671Problem.lean` (Docker host contended — load ≈26, 11 concurrent builds; no local Mathlib to grep-verify v4.26 API names).
- Entry remains correctly `axiomatized` (3 open-question axioms + 7 sorries). No metadata change needed.

## Test plan
- [x] Documentation-only change; no build impact (Lean source untouched).
- [ ] Future session: implement the `equidistant_diverges` step-3 estimate in an unregistered orphan file and build when Docker is uncontended.