### PR TITLE
Enrich erdos-353: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-353/annotations.json
+++ b/src/data/proofs/erdos-353/annotations.json
@@ -22,8 +22,8 @@
     "id": "ann-e353-infinite-measure",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 44,
-      "endLine": 49
+      "startLine": 49,
+      "endLine": 50
     },
     "type": "definition",
     "title": "Infinite Measure Sets",
@@ -40,8 +40,8 @@
     "id": "ann-e353-triangle-area",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 51,
-      "endLine": 67
+      "startLine": 56,
+      "endLine": 68
     },
     "type": "definition",
     "title": "Triangle and Quadrilateral Area",
@@ -59,8 +59,8 @@
     "id": "ann-e353-isosceles",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 73,
-      "endLine": 78
+      "startLine": 78,
+      "endLine": 79
     },
     "type": "definition",
     "title": "Isosceles Triangle",
@@ -77,8 +77,8 @@
     "id": "ann-e353-right-triangle",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 80,
-      "endLine": 87
+      "startLine": 85,
+      "endLine": 88
     },
     "type": "definition",
     "title": "Right-Angled Triangle",
@@ -95,8 +95,8 @@
     "id": "ann-e353-trapezoid",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 89,
-      "endLine": 101
+      "startLine": 94,
+      "endLine": 102
     },
     "type": "definition",
     "title": "Isosceles Trapezoid",
@@ -113,8 +113,8 @@
     "id": "ann-e353-parallelogram",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 103,
-      "endLine": 108
+      "startLine": 108,
+      "endLine": 109
     },
     "type": "definition",
     "title": "Parallelogram",
@@ -131,8 +131,8 @@
     "id": "ann-e353-cyclic",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 110,
-      "endLine": 120
+      "startLine": 115,
+      "endLine": 121
     },
     "type": "definition",
     "title": "Cyclic Quadrilateral",
@@ -149,8 +149,8 @@
     "id": "ann-e353-koizumi",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 190,
-      "endLine": 215
+      "startLine": 196,
+      "endLine": 216
     },
     "type": "concept",
     "title": "Koizumi's Theorems (2025)",
@@ -203,8 +203,8 @@
     "id": "ann-e353-scaling",
     "proofId": "erdos-353",
     "range": {
-      "startLine": 299,
-      "endLine": 318
+      "startLine": 301,
+      "endLine": 324
     },
     "type": "concept",
     "title": "Scaling Property",


### PR DESCRIPTION
## Enrichment pass for erdos-353

9 annotations were anchored to `-- ===` banner comments rather than Lean
declarations ("No Lean construct found at line N").

### Fix
Re-anchored each to the declaration its title describes:
`HasInfiniteMeasure`, `triangleArea`/`quadrilateralArea`,
`IsIsoscelesTriangle`, `IsRightTriangle`, `IsIsoscelesTrapezoid`,
`IsParallelogram`, `IsCyclicQuadrilateral`, the three Koizumi axioms, and
the scaling `smul` lemmas.

### Verification
`resolver.ts validate`: **13/13 valid, 0 misaligned** (was 4/13).