### PR TITLE
research(kaprekar-constant-oq-01): formalize 6174 attractor (build-pending)

### DIFF
--- a/proofs/Proofs/KaprekarConstantOQ01.lean
+++ b/proofs/Proofs/KaprekarConstantOQ01.lean
@@ -1,0 +1,106 @@
+import Mathlib
+
+/-!
+# Kaprekar's constant 6174
+
+## What This Proves
+
+Kaprekar's routine `T` acts on four-digit decimal strings (leading zeros allowed):
+write the four digits in descending order to form `D`, in ascending order to form
+`A`, and set `T(n) = D - A`.  Starting from any four-digit number whose digits are
+**not all equal**, iterating `T` reaches **6174** — *Kaprekar's constant* — in at
+most seven steps, and `6174` is the unique nonzero fixed point.
+
+The main results are:
+
+```
+kaprekar_fixed          : kaprekarStep 6174 = 6174
+kaprekar_converges      : n < 10000 → NonRepdigit n → kaprekarStep^[7] n = 6174
+kaprekar_unique_fixed   : n < 10000 → NonRepdigit n → kaprekarStep n = n → n = 6174
+kaprekar_bound_sharp    : ∃ n < 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174
+```
+
+Since `6174` is a fixed point, `kaprekarStep^[7] n = 6174` is exactly the statement
+"`n` reaches `6174` within seven steps".  `kaprekar_bound_sharp` shows seven steps
+are sometimes necessary, so the bound is tight.
+
+## Strategy
+
+`T` is defined by *pure arithmetic*: the four digits are extracted with `/` and `%`,
+sorted ascending by an explicit five-comparator network built from `min`/`max`, and
+recombined.  No `Nat.digits` or list `mergeSort` appears, so the map reduces quickly.
+The bounded-convergence and uniqueness facts are finite statements over the 10000
+four-digit strings and are discharged by `native_decide`.
+
+## Status
+
+The single-point fact `kaprekar_fixed` is kernel-checked (`decide`).  The
+finite-domain enumerations (`kaprekar_converges`, `kaprekar_unique_fixed`,
+`kaprekar_bound_sharp`) use `native_decide` and therefore depend on the
+`Lean.ofReduceBool` axiom (compiled evaluation of a decidable proposition).
+-/
+
+namespace KaprekarConstantOQ01
+
+/-- Sort four natural numbers into ascending order via a five-comparator
+sorting network (Batcher / bubble network for `n = 4`). -/
+def sortAsc4 (a b c d : ℕ) : ℕ × ℕ × ℕ × ℕ :=
+  let a' := min a b; let b' := max a b
+  let c' := min c d; let d' := max c d
+  let a'' := min a' c'; let c'' := max a' c'
+  let b'' := min b' d'; let d'' := max b' d'
+  let b''' := min c'' b''; let c''' := max c'' b''
+  (a'', b''', c''', d'')
+
+/-- One step of Kaprekar's routine on the four-digit decimal string of `n`
+(leading zeros included).  Descending arrangement minus ascending arrangement. -/
+def kaprekarStep (n : ℕ) : ℕ :=
+  let a := n / 1000 % 10
+  let b := n / 100 % 10
+  let c := n / 10 % 10
+  let d := n % 10
+  let s := sortAsc4 a b c d
+  let w := s.1; let x := s.2.1; let y := s.2.2.1; let z := s.2.2.2
+  (z * 1000 + y * 100 + x * 10 + w) - (w * 1000 + x * 100 + y * 10 + z)
+
+/-- The four-digit string of `n` does **not** have all digits equal. -/
+def NonRepdigit (n : ℕ) : Prop :=
+  ¬ (n / 1000 % 10 = n / 100 % 10 ∧ n / 100 % 10 = n / 10 % 10 ∧
+      n / 10 % 10 = n % 10)
+
+instance (n : ℕ) : Decidable (NonRepdigit n) := by unfold NonRepdigit; infer_instance
+
+/-- `6174` is a fixed point of Kaprekar's routine. -/
+theorem kaprekar_fixed : kaprekarStep 6174 = 6174 := by decide
+
+/-- **Bounded convergence (enumerated form).** Every four-digit string with not all
+digits equal reaches `6174` after at most seven steps of `T`. -/
+theorem kaprekar_converges_all :
+    ∀ n ∈ Finset.range 10000, NonRepdigit n → kaprekarStep^[7] n = 6174 := by
+  native_decide
+
+/-- **Bounded convergence.** For every `n < 10000` whose four-digit string is not a
+repdigit, iterating Kaprekar's routine seven times yields `6174`. -/
+theorem kaprekar_converges (n : ℕ) (h : n < 10000) (hn : NonRepdigit n) :
+    kaprekarStep^[7] n = 6174 :=
+  kaprekar_converges_all n (Finset.mem_range.mpr h) hn
+
+/-- **Uniqueness of the fixed point (enumerated form).** Among the four-digit
+strings with not all digits equal, `6174` is the only fixed point of `T`. -/
+theorem kaprekar_unique_fixed_all :
+    ∀ n ∈ Finset.range 10000, NonRepdigit n → kaprekarStep n = n → n = 6174 := by
+  native_decide
+
+/-- **Uniqueness of the fixed point.** `6174` is the unique nonzero fixed point of
+Kaprekar's routine on four-digit non-repdigit strings. -/
+theorem kaprekar_unique_fixed (n : ℕ) (h : n < 10000) (hn : NonRepdigit n)
+    (hf : kaprekarStep n = n) : n = 6174 :=
+  kaprekar_unique_fixed_all n (Finset.mem_range.mpr h) hn hf
+
+/-- **The bound is sharp.** Some four-digit non-repdigit string needs the full seven
+steps: six are not enough. -/
+theorem kaprekar_bound_sharp :
+    ∃ n ∈ Finset.range 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174 := by
+  native_decide
+
+end KaprekarConstantOQ01

--- a/research/problems/kaprekar-constant-oq-01/knowledge.md
+++ b/research/problems/kaprekar-constant-oq-01/knowledge.md
@@ -1,0 +1,85 @@
+# Knowledge Base: kaprekar-constant-oq-01
+
+Kaprekar's constant 6174: the global attractor of the digit-sort subtraction map
+`T` on four-digit decimal strings (not all digits equal), reached in ≤7 steps.
+
+---
+
+## Problem Understanding
+
+- Domain: four-digit strings `0000`–`9999` (i.e. `n < 10000`), excluding repdigits
+  (`0000, 1111, …, 9999`), whose orbit collapses to `0`.
+- `T(n) = D(n) − A(n)` where `D`/`A` reassemble the digits in descending/ascending
+  order. The claim is a finite, fully decidable dynamical-systems fact.
+- Because `6174` is a fixed point, "reaches `6174` within 7 steps" is *exactly*
+  `T^[7](n) = 6174`. So the bounded-convergence claim is a single clean equation.
+
+---
+
+## Insights
+
+- **Arithmetic-only `T` (no `Nat.digits` / `mergeSort`).** Digits are extracted with
+  `/` and `%`; the four digits are sorted ascending by an explicit **5-comparator
+  sorting network** (`min`/`max` only). This keeps `T` cheap to reduce, avoiding the
+  kernel cost of `Nat.digits` and list `mergeSort`. The recombination is
+  `D − A = (z·1000+y·100+x·10+w) − (w·1000+x·100+y·10+z)` for ascending `w≤x≤y≤z`.
+- **Sorting network verified.** The 5-comparator network
+  `(a,b)(c,d)(a,c)(b,d)(b,c)` reproduces `sorted` on all 10000 inputs (Python check).
+- **All claims checked exhaustively in Python before writing Lean:**
+  - `T(6174) = 6174`.
+  - `6174` is the **unique** non-repdigit fixed point in `[0,10000)`.
+  - `T^[7](n) = 6174` for **every** non-repdigit `n < 10000` (0 exceptions).
+  - **Bound is sharp:** `max steps = 7` (some inputs need the full seven), so
+    `T^[6]` does not always reach `6174`.
+
+## Lean Formalization (this session)
+
+File: `proofs/Proofs/KaprekarConstantOQ01.lean` (≈106 lines, **orphan / unregistered**
+— intentionally NOT added to `Proofs.lean` so an unverified file cannot break the
+gallery build under the Docker blackout).
+
+Statements:
+- `kaprekar_fixed : kaprekarStep 6174 = 6174` — by `decide` (kernel-checked).
+- `kaprekar_converges : n < 10000 → NonRepdigit n → kaprekarStep^[7] n = 6174`.
+- `kaprekar_unique_fixed : n < 10000 → NonRepdigit n → kaprekarStep n = n → n = 6174`.
+- `kaprekar_bound_sharp : ∃ n < 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174`.
+
+The three finite-domain enumerations use `native_decide` (over `Finset.range 10000`),
+so they depend on `Lean.ofReduceBool` → intended gallery status **axiomatized**
+(badge `axiom`), not `verified`.
+
+---
+
+## Dead Ends / Risks
+
+- **Pure-`decide` route unverified.** Kernel `decide` over 10000 inputs × 7 iterated
+  steps may be too slow / memory-heavy; `native_decide` chosen as the reliable path.
+  A future "verified" (0-axiom) version could enumerate only the ≤715 sorted-digit
+  *multiset* representatives (`T` factors through the digit multiset), but that
+  requires a multiset-invariance lemma — deferred.
+
+---
+
+## Build Status
+
+**BUILD-PENDING.** This session ran under a full tooling blackout:
+- Docker daemon down (`docker version` shows no Server; sibling builds hung at the
+  config banner for ~30 min; no containers running).
+- Aristotle MCP returns `Resource not found` (404).
+
+The Lean file is complete and Python-cross-checked but **not yet machine-verified**.
+Next Docker session: `./proofs/scripts/docker-build.sh Proofs.KaprekarConstantOQ01`,
+grep for `error:`, then (if green) register in `Proofs.lean`, add `src/data/proofs`
+gallery integration with `status: axiomatized` / `axiomCount` reflecting
+`Lean.ofReduceBool`, and flip pool status to `completed`.
+
+---
+
+## Next Steps
+
+1. Docker build-verify `Proofs.KaprekarConstantOQ01` when the daemon returns.
+2. If green: register + gallery integration (status `axiomatized`, badge `axiom`).
+3. Optional follow-up: 0-axiom version via digit-multiset representatives + a
+   `T`-factors-through-multiset lemma (the `decide`-feasible 715-case route).
+4. Optional generalization: characterise Kaprekar cycles for ≥5 digits (no single
+   fixed point; e.g. 5 digits has cycles, not a constant).

--- a/research/problems/kaprekar-constant-oq-01/problem.md
+++ b/research/problems/kaprekar-constant-oq-01/problem.md
@@ -1,0 +1,128 @@
+# Problem: Kaprekar's Constant 6174
+
+**Slug**: kaprekar-constant-oq-01
+**Created**: 2026-06-16
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall n \in \{1000, \dots, 9999\}\ \text{with non-identical digits},\quad \exists k \le 7,\ T^{k}(n) = 6174,
+$$
+
+where $T(n) = D(n) - A(n)$, $D(n)$ is the integer formed by writing $n$'s decimal
+digits in descending order, and $A(n)$ the integer from the same digits in ascending
+order. Moreover $T(6174) = 6174$ is the unique nonzero fixed point of $T$ on this domain.
+
+### Plain Language
+
+Take any four-digit number whose digits are not all the same. Arrange its digits
+into the largest and smallest numbers possible and subtract. Repeat. No matter where
+you start, you reach 6174 — Kaprekar's constant — in at most seven steps, and once
+there you stay there.
+
+### Why This Matters
+
+A clean, fully decidable dynamical-systems fact over a finite domain: a single global
+attractor reached in bounded time. It is an appealing formalization target because the
+entire statement can be discharged by finite computation (`decide`/`Finset` enumeration),
+yet stating the digit map and the bounded-convergence claim precisely is non-trivial.
+
+## Known Results
+
+### What's Already Proven
+
+- The result is classical (D. R. Kaprekar, 1949) and verified by exhaustive computer search.
+- Analogous Kaprekar fixed points exist in other digit lengths (e.g. 495 for 3 digits); 4 and 3 digits are the only lengths with a single nonzero fixed point.
+
+### What's Still Open
+
+- Nothing mathematically open at 4 digits; the task is a faithful Lean formalization.
+- Optional extension: characterize the full set of Kaprekar cycles for 5+ digit numbers.
+
+### Our Goal
+
+Formalize the four-digit case: define the digit-sort subtraction map `T` on `Fin 10000`
+(restricted to non-repdigit inputs), and prove that iterating `T` at most 7 times yields
+6174, with 6174 the unique nonzero fixed point.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| niven-theorem-oq-01 | digit-based number theory in Lean | digit extraction, `Nat.digits` |
+| thue-morse-oq-01 | finite digit/dynamical structure | recurrence over digit data |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Exhaustive `decide` / `Finset` enumeration**: Define `T` computably, then prove the
+   bounded-convergence claim by evaluating `T^[7]` on all valid inputs.
+   - Why it might work: domain is finite (9000 numbers) and `T` is a closed-form computable function.
+   - Risk: kernel `decide` over 9000 inputs with iterated digit sorts may be slow; may need `native_decide` care or a reduced reachable-set argument.
+
+2. **Reachable-set contraction**: Show one step maps every input into a small invariant
+   set, then finish by enumerating only that set.
+   - Why it might work: drastically shrinks the search space after step 1.
+   - Risk: more lemmas to state; the set must be identified and proven invariant.
+
+### Key Difficulties
+
+- Defining $D(n)$ and $A(n)$ (descending/ascending digit reassembly) cleanly and computably.
+- Keeping the enumeration within reasonable kernel-reduction cost.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `T` is well-defined and computable on `Fin 10000`.
+- Key lemma 2: `T(6174) = 6174` and no other nonzero fixed point exists.
+- Technical requirements: `Nat.digits`, list sort, `Finset` enumeration / `decide`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Statement is finite and decidable, so no deep theory is required.
+- Main effort is engineering a computable digit map and controlling reduction cost.
+- Mathlib provides `Nat.digits`, list sorting, and `Finset` enumeration.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: days
+- If hard: days (mostly performance tuning)
+
+## References
+
+### Papers
+- D. R. Kaprekar, "Another solitaire game", Scripta Mathematica, 1949 — original description.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/6174 — overview of Kaprekar's constant and the routine.
+
+### Mathlib
+- `Mathlib.Data.Nat.Digits` — decimal digit extraction.
+- `Mathlib.Data.Finset.Basic` — finite enumeration for the decidable claim.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - digits
+  - kaprekar
+  - fixed-point
+  - decidable
+related_proofs:
+  - niven-theorem-oq-01
+  - thue-morse-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-16
+```
+
+**Significance**: 5/10
+**Tractability**: 6/10


### PR DESCRIPTION
## Summary

Formalizes **Kaprekar's constant 6174** as a finite, decidable dynamical-systems fact in `proofs/Proofs/KaprekarConstantOQ01.lean`.

The Kaprekar map `T(n) = D(n) − A(n)` (descending-digit minus ascending-digit reassembly) is defined by **pure arithmetic** — four digits via `/`,`%`, sorted ascending by an explicit **5-comparator min/max network** (no `Nat.digits`, no list `mergeSort`), so it reduces cheaply.

### Theorems
- `kaprekar_fixed : kaprekarStep 6174 = 6174` — kernel-checked (`decide`).
- `kaprekar_converges : n < 10000 → NonRepdigit n → kaprekarStep^[7] n = 6174` — every non-repdigit four-digit string reaches 6174 in ≤7 steps (6174 is a fixed point, so `T^[7] = 6174` *is* "reaches within 7").
- `kaprekar_unique_fixed : … → kaprekarStep n = n → n = 6174` — 6174 is the unique non-repdigit fixed point.
- `kaprekar_bound_sharp : ∃ n < 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174` — seven steps are sometimes necessary (bound is tight).

The three enumerations (over `Finset.range 10000`) use `native_decide` → depend on `Lean.ofReduceBool`. **Intended gallery status: `axiomatized` (badge `axiom`), not `verified`.** All four claims were cross-checked exhaustively in Python before writing Lean.

## ⚠️ Build-pending — not yet machine-verified

This session ran under a full tooling blackout: **Docker daemon down** (no Server in `docker version`; sibling builds hung ~30 min at the config banner) and **Aristotle MCP 404**. The file is therefore committed as an **orphan (NOT registered in `Proofs.lean`)** so it cannot break the gallery build while unverified.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.KaprekarConstantOQ01` when Docker returns; grep for `error:`.
- [ ] If green: register in `Proofs.lean`, add `src/data/proofs/` gallery data with `status: axiomatized` / `axiomCount` reflecting `Lean.ofReduceBool`, flip pool to `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)