### PR TITLE
Enrich erdos-260: re-anchor 11 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-260/annotations.json
+++ b/src/data/proofs/erdos-260/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-260-incseq",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 41,
-      "endLine": 44
+      "startLine": 43,
+      "endLine": 45
     },
     "type": "definition",
     "title": "Increasing Sequence Structure",
@@ -49,8 +49,8 @@
     "id": "ann-260-fastgrowth",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 46,
-      "endLine": 48
+      "startLine": 48,
+      "endLine": 49
     },
     "type": "definition",
     "title": "Fast Growth Condition",
@@ -72,8 +72,8 @@
     "id": "ann-260-gaps",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 50,
-      "endLine": 52
+      "startLine": 52,
+      "endLine": 53
     },
     "type": "definition",
     "title": "Gaps to Infinity",
@@ -95,8 +95,8 @@
     "id": "ann-260-superlog",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 54,
-      "endLine": 57
+      "startLine": 56,
+      "endLine": 58
     },
     "type": "definition",
     "title": "Superlogarithmic Growth",
@@ -119,8 +119,8 @@
     "id": "ann-260-series",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 61,
-      "endLine": 78
+      "startLine": 63,
+      "endLine": 79
     },
     "type": "definition",
     "title": "Series Definition and Convergence",
@@ -143,8 +143,8 @@
     "id": "ann-260-gapsirr",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 82,
-      "endLine": 90
+      "startLine": 89,
+      "endLine": 91
     },
     "type": "concept",
     "title": "Gaps to Infinity Implies Irrational",
@@ -167,8 +167,8 @@
     "id": "ann-260-superlogirr",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 92,
-      "endLine": 99
+      "startLine": 98,
+      "endLine": 100
     },
     "type": "concept",
     "title": "Superlogarithmic Growth Implies Irrational",
@@ -190,8 +190,8 @@
     "id": "ann-260-squareseq",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 117,
-      "endLine": 148
+      "startLine": 188,
+      "endLine": 203
     },
     "type": "definition",
     "title": "Square Sequence Example",
@@ -214,8 +214,8 @@
     "id": "ann-260-squareirr",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 150,
-      "endLine": 152
+      "startLine": 217,
+      "endLine": 218
     },
     "type": "concept",
     "title": "Square Sequence Series is Irrational",
@@ -236,8 +236,8 @@
     "id": "ann-260-conjecture",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 154,
-      "endLine": 162
+      "startLine": 222,
+      "endLine": 228
     },
     "type": "concept",
     "title": "The Main Conjecture (OPEN)",
@@ -259,8 +259,8 @@
     "id": "ann-260-counterex",
     "proofId": "erdos-260",
     "range": {
-      "startLine": 164,
-      "endLine": 177
+      "startLine": 239,
+      "endLine": 243
     },
     "type": "definition",
     "title": "Erdős-Graham Counterexample Specification",


### PR DESCRIPTION
## Enrichment pass for erdos-260

9 annotations were anchored to `--` banner comments or to the wrong
construct kind (`definition`-typed annotations sitting on theorems), and
two resolver-"valid" ones (`squareirr`, `conjecture`) both landed on
`fastGrowth_of_superlogarithmic`.

### Fix
Remapped 11 annotations to the declaration each title describes:
`IncreasingSeq`, `FastGrowth`, `GapsToInfinity`, `SuperlogarithmicGrowth`,
the series defs (`seriesTerm`/`partialSum`/`series_converges`/`seriesSum`),
`irrational_of_gaps_to_infinity`, `irrational_of_superlogarithmic`,
`squareSeq`, `squareSeq_irrational`, `erdos_260_conjecture`, and
`ErdosGrahamCounterexample`.

### Verification
`resolver.ts validate`: **12/12 valid, 0 misaligned** (was 3/12).