### PR TITLE
Research: shannon-channel-coding-oq-01 — BEC capacity = (1-p)·log2 (build-pending)

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingBEC.lean
+++ b/proofs/Proofs/ShannonChannelCodingBEC.lean
@@ -1,0 +1,241 @@
+/-
+  Binary Erasure Channel (BEC) Capacity
+
+  Open Question 01: concrete channel capacities beyond placeholders.
+  The BSC capacity = log 2 - h(p) is already proven in
+  ShannonChannelCodingOQ02 (`bsc_capacity_proved`, 0 axioms). The remaining
+  open item is the binary erasure channel.
+
+  Main result: BEC(p) capacity = (1 - p) · log 2, proven from first principles
+  (0 axioms, 0 sorries).
+
+  The binary erasure channel BEC(p) has input `Bool` and output `Option Bool`,
+  where `none` denotes an erasure. Each transmitted bit is erased with
+  probability `p` and received correctly with probability `1 - p`:
+
+      W x (some y) = if x = y then 1 - p else 0
+      W x none     = p
+
+  Capacity proof (clean single identity):
+  1. For ANY input distribution, the conditional entropy of the input given the
+     output is `H(X|Y) = p · H(X)` (BEC erases with probability `p`; when not
+     erased the input is determined exactly).
+  2. By the chain rule `I(X;Y) = H(X) - H(X|Y) = (1 - p) · H(X)`.
+  3. Converse: `H(X) ≤ log|Bool| = log 2`, so `I(X;Y) ≤ (1 - p) · log 2`.
+  4. Achievability: the uniform Bernoulli(1/2) input gives `H(X) = log 2`.
+  5. Capacity = sSup over inputs = `(1 - p) · log 2`.
+
+  Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to
+  `2p`, the others to `1 - p`), so the symmetric-channel machinery does not
+  apply; the `H(X|Y) = p·H(X)` identity is the right engine instead.
+
+  Claude Shannon (1948)
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib
+import Proofs.ShannonChannelCoding
+import Proofs.ShannonChannelCodingOQ02
+import Proofs.ShannonChannelCodingOQ04
+
+open Real Finset InformationTheory InformationTheory.ChannelCoding
+open InformationTheory.BinaryEntropy
+
+namespace InformationTheory.ChannelCoding.BEC
+
+/-! ## The binary erasure channel -/
+
+/-- The binary erasure channel `BEC(p)`: input `Bool`, output `Option Bool`
+    (`none` = erasure). Each bit is erased with probability `p` and otherwise
+    received correctly. Requires `0 ≤ p ≤ 1`. -/
+noncomputable def bec (p : ℝ) (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    DMChannel Bool (Option Bool) where
+  W := fun x o =>
+    match o with
+    | none => p
+    | some y => if x = y then 1 - p else 0
+  nonneg := fun x o => by
+    cases o with
+    | none => exact hp0
+    | some y => dsimp only; split_ifs <;> linarith
+  sum_one := fun x => by
+    rw [Fintype.sum_option, Fintype.sum_bool]
+    cases x <;> simp <;> ring
+
+@[simp] lemma bec_W_none {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (x : Bool) :
+    (bec p hp0 hp1).W x none = p := rfl
+
+@[simp] lemma bec_W_some {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (x y : Bool) :
+    (bec p hp0 hp1).W x (some y) = if x = y then 1 - p else 0 := rfl
+
+/-! ## Output marginals -/
+
+/-- The `none` (erasure) output marginal equals `p` regardless of the input
+    distribution: every input symbol is erased with probability `p`. -/
+lemma bec_ymarg_none {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (inp : InputDist Bool) :
+    (∑ x' : Bool, jointDist (bec p hp0 hp1) inp (x', none)) = p := by
+  simp only [jointDist, bec_W_none]
+  rw [← Finset.sum_mul, inp.sum_one, one_mul]
+
+/-- The `some y` output marginal equals `inp.p y · (1 - p)`: the symbol `y` is
+    received un-erased only when `y` was sent (probability `inp.p y`) and not
+    erased (probability `1 - p`). -/
+lemma bec_ymarg_some {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (inp : InputDist Bool)
+    (y : Bool) :
+    (∑ x' : Bool, jointDist (bec p hp0 hp1) inp (x', some y)) = inp.p y * (1 - p) := by
+  simp only [jointDist, bec_W_some]
+  rw [Fintype.sum_bool]
+  cases y <;> simp <;> ring
+
+/-! ## Conditional entropy `H(X|Y) = p · H(X)` -/
+
+/-- **The BEC erasure identity.** For any input distribution, the entropy of the
+    input given the output is `H(X|Y) = p · H(X)`.
+
+    Intuition: with probability `1 - p` the output is the un-erased symbol, which
+    determines the input exactly (zero residual entropy); with probability `p`
+    the output is an erasure, leaving the full input entropy `H(X)`. -/
+theorem bec_conditional_entropy {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1)
+    (inp : InputDist Bool) :
+    conditionalEntropy (jointDist (bec p hp0.le hp1.le) inp)
+      = p * shannonEntropy inp.p := by
+  -- Each `some y` summand vanishes: when `x ≠ y` the joint prob is 0;
+  -- when `x = y` the conditional probability is 1 (log 1 = 0).
+  have hsome_zero : ∀ (x y : Bool),
+      (if jointDist (bec p hp0.le hp1.le) inp (x, some y) = 0 then (0 : ℝ)
+       else jointDist (bec p hp0.le hp1.le) inp (x, some y) *
+         Real.log (jointDist (bec p hp0.le hp1.le) inp (x, some y) /
+           (∑ x' : Bool, jointDist (bec p hp0.le hp1.le) inp (x', some y)))) = 0 := by
+    intro x y
+    rw [bec_ymarg_some hp0.le hp1.le inp y]
+    by_cases hxy : x = y
+    · subst hxy
+      have hJ : jointDist (bec p hp0.le hp1.le) inp (x, some x) = inp.p x * (1 - p) := by
+        simp [jointDist]
+      rw [hJ]
+      by_cases hz : inp.p x * (1 - p) = 0
+      · rw [if_pos hz]
+      · rw [if_neg hz, div_self hz, Real.log_one, mul_zero]
+    · have hJ : jointDist (bec p hp0.le hp1.le) inp (x, some y) = 0 := by
+        simp [jointDist, hxy]
+      rw [hJ]; simp
+  -- The `none` summand reduces to the binary-entropy term scaled by `p`.
+  have hnone : ∀ x : Bool,
+      (if jointDist (bec p hp0.le hp1.le) inp (x, none) = 0 then (0 : ℝ)
+       else jointDist (bec p hp0.le hp1.le) inp (x, none) *
+         Real.log (jointDist (bec p hp0.le hp1.le) inp (x, none) /
+           (∑ x' : Bool, jointDist (bec p hp0.le hp1.le) inp (x', none))))
+      = (if inp.p x = 0 then 0 else inp.p x * p * Real.log (inp.p x)) := by
+    intro x
+    have hJ : jointDist (bec p hp0.le hp1.le) inp (x, none) = inp.p x * p := by
+      simp [jointDist]
+    rw [hJ, bec_ymarg_none hp0.le hp1.le inp]
+    by_cases hx : inp.p x = 0
+    · rw [if_pos (by rw [hx, zero_mul]), if_pos hx]
+    · rw [if_neg (mul_ne_zero hx hp0.ne'), if_neg hx,
+          mul_div_assoc, div_self hp0.ne', mul_one]
+  -- Assemble: the per-input inner sum collapses to the `none` term.
+  have hinner : ∀ x : Bool,
+      (∑ o : Option Bool,
+        if jointDist (bec p hp0.le hp1.le) inp (x, o) = 0 then (0 : ℝ)
+        else jointDist (bec p hp0.le hp1.le) inp (x, o) *
+          Real.log (jointDist (bec p hp0.le hp1.le) inp (x, o) /
+            (∑ x' : Bool, jointDist (bec p hp0.le hp1.le) inp (x', o))))
+      = (if inp.p x = 0 then 0 else inp.p x * p * Real.log (inp.p x)) := by
+    intro x
+    rw [Fintype.sum_option, Fintype.sum_bool, hsome_zero x false, hsome_zero x true,
+        hnone x, add_zero, add_zero]
+  -- Sum over inputs, factor out `p`, and recognise `-H(X)`.
+  unfold conditionalEntropy
+  rw [Finset.sum_congr rfl (fun x _ => hinner x)]
+  have hfactor : ∀ x : Bool,
+      (if inp.p x = 0 then (0 : ℝ) else inp.p x * p * Real.log (inp.p x))
+      = p * (if inp.p x = 0 then 0 else inp.p x * Real.log (inp.p x)) := by
+    intro x; by_cases hx : inp.p x = 0 <;> simp [hx] <;> ring
+  rw [Finset.sum_congr rfl (fun x _ => hfactor x), ← Finset.mul_sum,
+      show shannonEntropy inp.p
+        = -∑ x : Bool, if inp.p x = 0 then (0 : ℝ) else inp.p x * Real.log (inp.p x) from rfl]
+  ring
+
+/-! ## Mutual information `I(X;Y) = (1 - p) · H(X)` -/
+
+/-- **The BEC mutual information identity.** For any input distribution,
+    `I(X;Y) = (1 - p) · H(X)`. Immediate from the chain rule
+    `I = H(X) - H(X|Y)` and `H(X|Y) = p · H(X)`. -/
+theorem bec_mi_eq {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) (inp : InputDist Bool) :
+    channelMI (bec p hp0.le hp1.le) inp = (1 - p) * shannonEntropy inp.p := by
+  unfold channelMI
+  have hnn : ∀ xy, 0 ≤ jointDist (bec p hp0.le hp1.le) inp xy :=
+    fun xy => jointDist_nonneg _ inp xy
+  have hsum : ∑ xy : Bool × Option Bool, jointDist (bec p hp0.le hp1.le) inp xy = 1 :=
+    jointDist_sum_one _ inp
+  rw [chain_rule hnn hsum]
+  -- X-marginal of the joint equals the input distribution.
+  have hxmarg : (fun x => ∑ y : Option Bool, jointDist (bec p hp0.le hp1.le) inp (x, y))
+      = inp.p := by
+    ext x
+    simp only [jointDist, ← Finset.mul_sum, (bec p hp0.le hp1.le).sum_one, mul_one]
+  rw [hxmarg, bec_conditional_entropy hp0 hp1 inp]
+  ring
+
+/-! ## Capacity = (1 - p) · log 2 -/
+
+/-- Uniform input achieves `I(X;Y) = (1 - p) · log 2`. -/
+theorem bec_uniform_mi {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelMI (bec p hp0.le hp1.le) BSCCapacity.uniformBool = (1 - p) * Real.log 2 := by
+  rw [bec_mi_eq hp0 hp1]
+  have h : BSCCapacity.uniformBool.p = (fun (_ : Bool) => (1 : ℝ) / 2) := rfl
+  rw [h, BSCCapacity.entropy_uniform_bool]
+
+/-- For any input, `I(X;Y) ≤ (1 - p) · log 2` (the converse bound). -/
+theorem bec_mi_le {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) (inp : InputDist Bool) :
+    channelMI (bec p hp0.le hp1.le) inp ≤ (1 - p) * Real.log 2 := by
+  rw [bec_mi_eq hp0 hp1]
+  have hHX : shannonEntropy inp.p ≤ Real.log 2 := by
+    have h := entropy_le_log_card inp.nonneg inp.sum_one
+    simp only [Fintype.card_bool, Nat.cast_ofNat] at h
+    exact h
+  have h1p : 0 ≤ 1 - p := by linarith
+  exact mul_le_mul_of_nonneg_left hHX h1p
+
+/-- **BEC capacity = (1 - p) · log 2.**
+    The binary erasure channel `BEC(p)` has capacity `(1 - p) · log 2` nats
+    (equivalently `1 - p` bits). Proven from first principles with no axioms:
+    every input distribution gives `I(X;Y) = (1 - p)·H(X) ≤ (1 - p)·log 2`,
+    and the uniform input achieves the bound. -/
+theorem bec_capacity {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bec p hp0.le hp1.le) = (1 - p) * Real.log 2 := by
+  unfold channelCapacity
+  apply le_antisymm
+  · -- sSup ≤ (1 - p) · log 2
+    apply csSup_le
+    · exact ⟨_, BSCCapacity.uniformBool, rfl⟩
+    · rintro r ⟨inp, rfl⟩; exact bec_mi_le hp0 hp1 inp
+  · -- (1 - p) · log 2 ≤ sSup (achieved by uniform)
+    apply le_csSup
+    · exact ⟨Real.log (Fintype.card (Option Bool)),
+        fun _ ⟨inp, hr⟩ => hr ▸ channelMI_le_log_card _ _⟩
+    · exact ⟨BSCCapacity.uniformBool, bec_uniform_mi hp0 hp1⟩
+
+/-- BEC capacity in bits: `C₂(BEC(p)) = 1 - p`. -/
+theorem bec_capacity_bits {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bec p hp0.le hp1.le) / Real.log 2 = 1 - p := by
+  rw [bec_capacity hp0 hp1, mul_div_assoc,
+    div_self (Real.log_pos (by norm_num : (1 : ℝ) < 2)).ne', mul_one]
+
+/-- BEC capacity is non-negative. -/
+theorem bec_capacity_nonneg {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    0 ≤ channelCapacity (bec p hp0.le hp1.le) := by
+  rw [bec_capacity hp0 hp1]
+  have : 0 ≤ 1 - p := by linarith
+  positivity
+
+/-- BEC capacity is at most `log 2` (= 1 bit), with equality only as `p → 0`. -/
+theorem bec_capacity_le_log_two {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bec p hp0.le hp1.le) ≤ Real.log 2 := by
+  rw [bec_capacity hp0 hp1]
+  have hlog : 0 ≤ Real.log 2 := Real.log_nonneg (by norm_num)
+  nlinarith [mul_nonneg hp0.le hlog]
+
+end InformationTheory.ChannelCoding.BEC

--- a/research/certs/verify_bec_capacity.py
+++ b/research/certs/verify_bec_capacity.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Numerical certificate for ShannonChannelCodingBEC.lean.
+
+Confirms the two identities the Lean proof establishes for the binary erasure
+channel BEC(p) (input Bool, output Option Bool, erasure = `none`):
+
+  W x (some y) = (1 - p) if x == y else 0
+  W x none     = p
+
+  1. bec_conditional_entropy : H(X | Y) = p * H(X)   (any input distribution)
+  2. bec_mi_eq               : I(X; Y) = (1 - p) * H(X)
+  3. bec_capacity            : sup_q I(X; Y) = (1 - p) * log 2  (uniform input)
+
+All entropies use natural logarithm, matching the Lean `shannonEntropy`.
+"""
+import math
+
+OUTS = ("n", "0", "1")  # n = erasure (none); "0","1" = some false/true
+
+
+def W(p, x, o):
+    if o == "n":
+        return p
+    return (1 - p) if str(x) == o else 0.0
+
+
+def entropy(q):  # q indexed by x in {0,1}
+    return -sum((qi * math.log(qi) if qi > 0 else 0.0) for qi in q)
+
+
+def conditional_HX_given_Y(p, q):
+    J = {(x, o): q[x] * W(p, x, o) for x in (0, 1) for o in OUTS}
+    mY = {o: sum(J[(x, o)] for x in (0, 1)) for o in OUTS}
+    s = 0.0
+    for x in (0, 1):
+        for o in OUTS:
+            j = J[(x, o)]
+            if j > 0:
+                s += j * math.log(j / mY[o])
+    return -s  # H(X|Y) = -sum J log(J/mY)
+
+
+def mutual_info(p, q):
+    return entropy(q) - conditional_HX_given_Y(p, q)
+
+
+def main():
+    ok = True
+    tol = 1e-12
+    for p in (0.05, 0.1, 0.25, 0.5, 0.7, 0.9, 0.99):
+        for q in ([0.5, 0.5], [0.3, 0.7], [0.9, 0.1], [1.0, 0.0]):
+            HXgY = conditional_HX_given_Y(p, q)
+            MI = mutual_info(p, q)
+            HX = entropy(q)
+            e1 = abs(HXgY - p * HX)
+            e2 = abs(MI - (1 - p) * HX)
+            ok &= e1 < tol and e2 < tol
+        cap_uniform = mutual_info(p, [0.5, 0.5])
+        e3 = abs(cap_uniform - (1 - p) * math.log(2))
+        ok &= e3 < tol
+        print(f"p={p:<5} capacity=(1-p)log2={ (1-p)*math.log(2):.10f} "
+              f"uniform_MI={cap_uniform:.10f} err={e3:.1e}")
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/knowledge.md
@@ -1,0 +1,33 @@
+# Knowledge Base: bounded-prime-gaps-oq-03-oq-01-oq-01
+
+## State (researcher-8, 2026-06-16)
+
+The missing ingredient is a Chebyshev ψ lower bound
+`chebyshev_psi_lower_bound : ∃ c, 0 < c ∧ ∀ x ≥ 2, c * x ≤ Chebyshev.psi x`,
+stated as a single `sorry` in `proofs/Proofs/BoundedPrimeGapsOQ03OQ01ChebyshevLower.lean`
+(2 sorries) and consumed by `BoundedPrimeGapsOQ03OQ01.lean` (2 axioms).
+
+A prior session already **decomposed** the de Polignac / central-binomial derivation
+into a clean all-sorry Aristotle target:
+`proofs/Proofs/BoundedPrimeGapsOQ03OQ01ChebyshevLowerAristotle.lean` (4 theorem-sorries):
+- **L1** `log_factorial_eq_sum_vonMangoldt_mul_div` — Legendre floor-sum identity.
+- **L2** `log_centralBinom_le_psi` — the genuine gap `log C(2n,n) ≤ ψ(2n)`.
+- **L3** `log_four_le_log_centralBinom` — `n·log4 − log(2n) ≤ log C(2n,n)` (easiest; just
+  log of `Nat.four_pow_le_two_mul_self_mul_centralBinom`).
+- assembly into `chebyshev_psi_lower_bound`.
+The companion header lists verified Mathlib v4.26 hooks (vonMangoldt_sum,
+Ioc_filter_dvd_card_eq_div, four_pow_le_two_mul_self_mul_centralBinom, Chebyshev.psi).
+
+## Blocker this session
+
+**Dual blackout** — Docker daemon unresponsive (`docker info` rc=124, load ~26) AND
+Aristotle MCP returns `Resource not found` (404). Could not build anything and could not
+submit the companion to `prove_file`. No verifiable progress was possible.
+
+## Next action
+
+When Aristotle recovers: `prove_file BoundedPrimeGapsOQ03OQ01ChebyshevLowerAristotle.lean`
+(it is self-contained, imports only Mathlib). Then merge the proved L1–L3 + assembly into
+`ChebyshevLower.lean`, discharge its `chebyshev_psi_lower_bound` sorry, and that should let
+the 2 axioms in `BoundedPrimeGapsOQ03OQ01.lean` become theorems. L3 is also a safe ~10-line
+hand proof if Aristotle stays down.

--- a/research/problems/shannon-channel-coding-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-oq-01/knowledge.md
@@ -1,21 +1,81 @@
 # Knowledge Base: shannon-channel-coding-oq-01
 
-Insights accumulated during research on this problem.
+Concrete channel capacities beyond placeholder `True` statements (BSC / BEC / AWGN).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The slug broad-matches the whole `ShannonChannelCoding*` proof family. The real
+question: can specific named-channel capacities be formalized (not placeholders)?
+
+State as of 2026-06-16 (researcher-8 session):
+
+- **BSC** — DONE. `ShannonChannelCodingOQ02.lean` proves
+  `bsc_capacity_proved : channelCapacity (bsc p) = log 2 - h(p)` from first
+  principles, 0 axioms. The parent file `ShannonChannelCoding.lean` still
+  *declares* `axiom bsc_capacity_eq`, but that is only a forward-declaration:
+  it is discharged downstream in OQ02. It cannot be inlined into the parent
+  because OQ02 imports the parent (inlining would create an import cycle).
+  So the parent's axiom count (3) is not reducible without a structural
+  refactor that moves `bsc`/`channelCapacity` upstream — not attempted.
+- **BEC** — the genuinely-open item ("audit BEC/AWGN separately"). Addressed
+  this session (see Insights).
+- **AWGN** — still open; continuous channel, needs measure-theoretic capacity
+  (much harder than the finite-alphabet BSC/BEC). Not attempted.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### BEC capacity = (1 - p) · log 2  (researcher-8, 2026-06-16)
+
+New file `proofs/Proofs/ShannonChannelCodingBEC.lean` (orphan/unregistered,
+**build-pending** — full Docker blackout this session, load ~26, daemon
+unresponsive rc=124). Models directly on the OQ02 BSC development.
+
+- Channel: `bec : DMChannel Bool (Option Bool)`, `none` = erasure.
+  `W x (some y) = if x = y then 1-p else 0`, `W x none = p`.
+- **Engine identity** `bec_conditional_entropy : H(X|Y) = p · H(X)` for ANY
+  input distribution. When the output is un-erased (prob 1-p) it determines X
+  exactly (the `some y` summands vanish: off-diagonal joint = 0, diagonal
+  conditional = 1 so log 1 = 0); when erased (prob p) the full input entropy
+  remains. This is the clean way to do BEC — it is NOT weakly symmetric (erasure
+  column sums to 2p, others to 1-p) so the symmetric-channel machinery in the
+  parent does not apply.
+- Chain rule (`chain_rule` in ShannonEntropy) → `bec_mi_eq : I(X;Y) = (1-p)·H(X)`
+  for all inputs. Converse `I ≤ (1-p)·log 2` is then immediate from
+  `H(X) ≤ log|Bool| = log 2`; achievability from uniform input giving
+  `H(X) = log 2`. Hence `bec_capacity : channelCapacity (bec p) = (1-p)·log 2`,
+  plus `bec_capacity_bits = 1-p`, nonneg, ≤ log 2. 0 axioms, 0 sorries.
+- Numeric certificate: `research/certs/verify_bec_capacity.py` (PASS, both
+  identities + capacity, p ∈ {0.05..0.99}, several input dists).
+
+Reused from OQ02: `BSCCapacity.uniformBool`, `BSCCapacity.entropy_uniform_bool`,
+and the general `chain_rule`, `entropy_le_log_card`, `channelMI_le_log_card`,
+`csSup_le`/`le_csSup` capacity-sup idioms.
+
+### API / build notes
+
+- `set ch := bec ... with hch` BREAKS `rw [marginal_lemma]` because the goal
+  then holds `ch` while the lemma produces `bec p hp0.le hp1.le` (rw needs a
+  syntactic match). Write the full channel term throughout instead of `set`.
+- `Fintype.sum_option : ∑ i : Option α, f i = f none + ∑ i, f (some i)`.
+- card Bool cast: `simp only [Fintype.card_bool, Nat.cast_ofNat]`.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Eliminating the parent's `bsc_capacity_eq` axiom in place — blocked by the
+  parent↔OQ02 import direction (would need an upstream structural move).
+- Building anything this session — Docker daemon blackout (load ~26).
+
+---
+
+## Next Steps
+
+1. When Docker is back: build `ShannonChannelCodingBEC.lean`; fix any
+   simp/lemma-name drift; then register it (add to the import graph / gallery).
+2. Optional: a gallery entry `src/data/proofs/shannon-channel-coding-bec/`.
+3. AWGN capacity (continuous) remains the only untouched concrete channel.

--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -23,30 +23,37 @@
   },
   "currentState": {
     "phase": "OBSERVE",
-    "since": "2026-03-30T11:35:15-07:00",
-    "iteration": 1,
-    "focus": "Metadata refreshed against the current ShannonChannelCoding proof family; the concrete-capacity question now has BSC-related sibling proofs to inspect before any new Lean work.",
-    "blockers": [],
-    "nextAction": "Inspect the BSC/BEC/AWGN capacity coverage and decide whether this broad question should stay active or be split into concrete sibling tasks.",
+    "since": "2026-06-16T12:00:00-07:00",
+    "iteration": 2,
+    "focus": "Audited concrete-channel coverage: BSC is fully proven (OQ02 bsc_capacity_proved). Added a from-first-principles BEC capacity = (1-p)log2 in a new orphan file (build-pending under Docker blackout).",
+    "blockers": [
+      "Docker daemon blackout (load ~26) — could not build/verify ShannonChannelCodingBEC.lean this session."
+    ],
+    "nextAction": "When Docker is back: build ShannonChannelCodingBEC.lean, fix any simp/lemma-name drift, then register it. AWGN (continuous) remains untouched.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Metadata sync 2026-05-18: Extractor note: broad slug matching includes the full ShannonChannelCoding* proof family; line counts use content.split(\"\\n\"), theorem counts ignore private/attributed declarations, and raw sorry counts include comments.",
+    "progressSummary": "2026-06-16 (researcher-8): BSC capacity already DONE in OQ02 (bsc_capacity_proved, 0 axioms; parent's bsc_capacity_eq axiom is a forward-declaration discharged downstream, not inlinable due to import cycle). Added BEC capacity = (1-p)log2 from first principles in new orphan file ShannonChannelCodingBEC.lean (0 axioms / 0 sorries, build-pending under Docker blackout). Engine: H(X|Y)=p*H(X) for the erasure channel, so I(X;Y)=(1-p)H(X). Numeric cert PASS.",
     "builtItems": [
-      "Broad ShannonChannelCoding leanFiles metadata refreshed to 11 current proof files."
+      "proofs/Proofs/ShannonChannelCodingBEC.lean (orphan, build-pending): bec channel + bec_conditional_entropy (H(X|Y)=p*H(X)) + bec_mi_eq ((1-p)H(X)) + bec_capacity ((1-p)log2) + bits/nonneg/le-log2 corollaries.",
+      "research/certs/verify_bec_capacity.py (PASS)."
     ],
     "insights": [
-      "The slug broad-matches the whole ShannonChannelCoding* proof family because the stripped base prefix is ShannonChannelCoding."
+      "The slug broad-matches the whole ShannonChannelCoding* proof family because the stripped base prefix is ShannonChannelCoding.",
+      "BSC capacity is already fully proven in OQ02; the only genuinely-open finite-alphabet item was BEC, now addressed.",
+      "BEC is NOT weakly symmetric (erasure column sums to 2p vs 1-p), so the parent's symmetric-channel machinery does not apply; the clean engine is H(X|Y)=p*H(X) via the chain rule.",
+      "set ch := bec ... breaks rw with marginal lemmas (goal holds ch, lemma produces bec p ...); use the full channel term, not set."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Audit BEC/AWGN capacity coverage separately from the already-developed BSC family."
+      "Build + register ShannonChannelCodingBEC.lean when Docker recovers.",
+      "AWGN capacity (continuous, measure-theoretic) remains the only untouched concrete channel."
     ],
-    "markdown": "# Knowledge Base: shannon-channel-coding-oq-01\n\nMetadata refreshed on 2026-05-18. The actual question is whether concrete channel capacities such as BSC, BEC, and AWGN can be formalized beyond placeholders. Existing ShannonChannelCoding sibling files already cover substantial BSC and entropy infrastructure; BEC/AWGN coverage should be audited separately.\n"
+    "markdown": "# Knowledge Base: shannon-channel-coding-oq-01\n\n2026-06-16 (researcher-8): BSC capacity is fully proven in OQ02 (bsc_capacity_proved). Added BEC(p) capacity = (1-p)log2 from first principles in a new orphan file (build-pending under Docker blackout), via the erasure identity H(X|Y)=p*H(X). AWGN remains open.\n"
   },
   "tags": [],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Advances `shannon-channel-coding-oq-01` (concrete channel capacities beyond placeholders). The **BSC** capacity is already fully proven in `ShannonChannelCodingOQ02` (`bsc_capacity_proved`, 0 axioms). This PR addresses the remaining open finite-alphabet item — the **binary erasure channel (BEC)** — in a new orphan file.

New file `proofs/Proofs/ShannonChannelCodingBEC.lean` proves, from first principles (**0 axioms, 0 sorries**):

- `bec` : `DMChannel Bool (Option Bool)` (`none` = erasure; `W x (some y) = if x=y then 1-p else 0`, `W x none = p`)
- `bec_conditional_entropy : H(X|Y) = p · H(X)` for **any** input distribution — the erasure identity (un-erased output determines X; erased output leaves full entropy)
- `bec_mi_eq : I(X;Y) = (1 - p) · H(X)` (chain rule)
- `bec_capacity : channelCapacity (bec p) = (1 - p) · log 2`
- corollaries: `bec_capacity_bits = 1 - p`, nonneg, ≤ log 2

The BEC is **not** weakly symmetric (erasure column sums to `2p`, others to `1-p`), so the parent file's symmetric-channel machinery does not apply; the `H(X|Y) = p·H(X)` identity is the right engine. Reuses OQ02's `uniformBool` / `entropy_uniform_bool` and the general `chain_rule` / capacity-sup idioms.

Numeric certificate `research/certs/verify_bec_capacity.py` confirms both identities and the capacity for `p ∈ {0.05..0.99}` across several input distributions (**PASS**).

## Status: build-pending orphan

The file is **unregistered** (not imported anywhere) and was **not compiled** — the Docker build daemon was in a full blackout this session (load ~26, unresponsive). Shipping as an orphan means **zero gallery-build risk**. Next Docker session: build, fix any simp/lemma-name drift, then register.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingBEC` (blocked this session — Docker blackout)
- [x] `python3 research/certs/verify_bec_capacity.py` → PASS