### PR TITLE
Enrich cauchy-schwarz-integral-oq-01-oq-02: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/annotations.json
@@ -23,7 +23,7 @@
     "id": "ann-rt-interp-recip",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 60,
+      "startLine": 61,
       "endLine": 99
     },
     "type": "definition",
@@ -42,7 +42,7 @@
     "id": "ann-rt-conjugate-preservation",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 101,
+      "startLine": 115,
       "endLine": 125
     },
     "type": "concept",
@@ -63,7 +63,7 @@
     "id": "ann-rt-lplq-bounded",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 127,
+      "startLine": 150,
       "endLine": 160
     },
     "type": "definition",
@@ -83,7 +83,7 @@
     "id": "ann-rt-log-convexity",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 162,
+      "startLine": 176,
       "endLine": 246
     },
     "type": "concept",
@@ -104,7 +104,7 @@
     "id": "ann-rt-three-lines",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 248,
+      "startLine": 269,
       "endLine": 315
     },
     "type": "insight",
@@ -126,7 +126,7 @@
     "id": "ann-rt-riesz-thorin-axiom",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 317,
+      "startLine": 347,
       "endLine": 357
     },
     "type": "concept",
@@ -148,7 +148,7 @@
     "id": "ann-rt-holder-endpoint",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 359,
+      "startLine": 388,
       "endLine": 398
     },
     "type": "concept",
@@ -170,7 +170,7 @@
     "id": "ann-rt-hausdorff-young",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 400,
+      "startLine": 435,
       "endLine": 450
     },
     "type": "insight",
@@ -191,7 +191,7 @@
     "id": "ann-rt-young-convolution",
     "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
     "range": {
-      "startLine": 452,
+      "startLine": 473,
       "endLine": 510
     },
     "type": "concept",


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

All 9 of these annotations had `range.startLine` pointing at a `-- ====` section banner comment rather than the Lean declaration beneath it. The annotation resolver therefore reported "No Lean construct found" for each (only 1 of 10 valid).

Re-anchored each annotation's `startLine` to its actual construct:

| annotation | → construct |
|---|---|
| ann-rt-interp-recip | `def interpRecip` (61) |
| ann-rt-conjugate-preservation | `theorem interpRecip_sum_conj` (115) |
| ann-rt-lplq-bounded | `structure LpLqBounded` (150) |
| ann-rt-log-convexity | `def interpNorm` (176) |
| ann-rt-three-lines | `def closedStrip` / `axiom hadamard_three_lines` (269) |
| ann-rt-riesz-thorin-axiom | `axiom riesz_thorin` (347) |
| ann-rt-holder-endpoint | `theorem holder_gives_endpoint` (388) |
| ann-rt-hausdorff-young | `theorem hausdorff_young_exponents` (435) |
| ann-rt-young-convolution | `theorem young_convolution_exponents` (473) |

Content/endLines unchanged. Resolver now validates **10/10, 0 misaligned**.