### PR TITLE
Enrich laws-of-large-numbers-oq-03: re-anchor 10 drifted annotations

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-03/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-lln-oq03-measure-preserving",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 51,
+      "startLine": 68,
       "endLine": 74
     },
     "type": "concept",
@@ -26,7 +26,7 @@
     "id": "ann-lln-oq03-ergodicity",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 76,
+      "startLine": 85,
       "endLine": 87
     },
     "type": "concept",
@@ -49,7 +49,7 @@
     "id": "ann-lln-oq03-birkhoff-sums",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 89,
+      "startLine": 98,
       "endLine": 120
     },
     "type": "definition",
@@ -72,7 +72,7 @@
     "id": "ann-lln-oq03-birkhoff-theorem",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 122,
+      "startLine": 143,
       "endLine": 167
     },
     "type": "concept",
@@ -97,7 +97,7 @@
     "id": "ann-lln-oq03-slln-connection",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 169,
+      "startLine": 190,
       "endLine": 192
     },
     "type": "insight",
@@ -120,7 +120,7 @@
     "id": "ann-lln-oq03-maximal-ergodic",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 194,
+      "startLine": 206,
       "endLine": 211
     },
     "type": "concept",
@@ -144,7 +144,7 @@
     "id": "ann-lln-oq03-von-neumann",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 213,
+      "startLine": 225,
       "endLine": 232
     },
     "type": "concept",
@@ -168,7 +168,7 @@
     "id": "ann-lln-oq03-mixing",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 234,
+      "startLine": 243,
       "endLine": 253
     },
     "type": "definition",
@@ -192,8 +192,8 @@
     "id": "ann-lln-oq03-examples",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 255,
-      "endLine": 267
+      "startLine": 291,
+      "endLine": 296
     },
     "type": "concept",
     "title": "Canonical Ergodic Systems",
@@ -215,8 +215,8 @@
     "id": "ann-lln-oq03-algebraic-properties",
     "proofId": "laws-of-large-numbers-oq-03",
     "range": {
-      "startLine": 301,
-      "endLine": 333
+      "startLine": 335,
+      "endLine": 362
     },
     "type": "concept",
     "title": "Algebraic Properties of Birkhoff Averages",


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

9 annotations had `range.startLine` pointing at a `-- ====` PART banner comment rather than the Lean declaration beneath it, so the resolver reported "No Lean construct found" (only 1/10 valid).

Re-anchored each to its actual construct:

| annotation | → construct |
|---|---|
| ann-lln-oq03-measure-preserving | `theorem iterate_measure_preserving` (68) |
| ann-lln-oq03-ergodicity | ergodicity `example` (85) |
| ann-lln-oq03-birkhoff-sums | `def birkhoffAverage` (98) |
| ann-lln-oq03-birkhoff-theorem | `axiom birkhoff_ergodic_theorem` (143) |
| ann-lln-oq03-slln-connection | `theorem slln_from_birkhoff_sketch` (190) |
| ann-lln-oq03-maximal-ergodic | `axiom maximal_ergodic_lemma` (206) |
| ann-lln-oq03-von-neumann | `axiom vonNeumann_mean_ergodic` (225) |
| ann-lln-oq03-mixing | `def IsMixing` (243) |
| ann-lln-oq03-algebraic-properties | `theorem birkhoffAverage_add` (335) |

Additionally re-anchored **ann-lln-oq03-examples**, which the resolver counted "valid" only because its stale range (255-267) happened to land inside the body of `mixing_implies_ergodic`. Its content describes the irrational rotation and doubling map, so it is now anchored to `def irrationalRotation`/`def doublingMap` (291-296).

Content unchanged. Resolver now validates **10/10, 0 misaligned**.