### PR TITLE
Enrich erdos-104: remap 22 drifted annotations to correct constructs

### DIFF
--- a/src/data/proofs/erdos-104/annotations.json
+++ b/src/data/proofs/erdos-104/annotations.json
@@ -27,8 +27,8 @@
     "id": "ann-104-point",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 42,
-      "endLine": 43
+      "startLine": 47,
+      "endLine": 48
     },
     "type": "definition",
     "title": "Point Type",
@@ -49,8 +49,8 @@
     "id": "ann-104-dist",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 45,
-      "endLine": 47
+      "startLine": 50,
+      "endLine": 52
     },
     "type": "definition",
     "title": "Euclidean Distance",
@@ -71,8 +71,8 @@
     "id": "ann-104-circle",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 49,
-      "endLine": 51
+      "startLine": 54,
+      "endLine": 56
     },
     "type": "definition",
     "title": "Unit Circle",
@@ -93,8 +93,8 @@
     "id": "ann-104-oncircle",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 53,
-      "endLine": 55
+      "startLine": 58,
+      "endLine": 60
     },
     "type": "definition",
     "title": "Point on Circle",
@@ -114,8 +114,8 @@
     "id": "ann-104-pointset",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 63,
-      "endLine": 64
+      "startLine": 68,
+      "endLine": 69
     },
     "type": "definition",
     "title": "Point Set",
@@ -136,8 +136,8 @@
     "id": "ann-104-contains",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 66,
-      "endLine": 68
+      "startLine": 71,
+      "endLine": 73
     },
     "type": "definition",
     "title": "Circle Contains k Points",
@@ -158,8 +158,8 @@
     "id": "ann-104-through3",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 70,
-      "endLine": 72
+      "startLine": 75,
+      "endLine": 77
     },
     "type": "definition",
     "title": "Unit Circles Through 3 Points",
@@ -179,8 +179,8 @@
     "id": "ann-104-count",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 74,
-      "endLine": 76
+      "startLine": 79,
+      "endLine": 81
     },
     "type": "definition",
     "title": "Circle Count",
@@ -200,8 +200,8 @@
     "id": "ann-104-twocircles",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 84,
-      "endLine": 88
+      "startLine": 89,
+      "endLine": 90
     },
     "type": "concept",
     "title": "Two Points, Two Circles",
@@ -223,8 +223,8 @@
     "id": "ann-104-onecircle",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 90,
-      "endLine": 93
+      "startLine": 91,
+      "endLine": 98
     },
     "type": "concept",
     "title": "Two Points, One Circle",
@@ -245,8 +245,8 @@
     "id": "ann-104-nocircle",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 95,
-      "endLine": 98
+      "startLine": 149,
+      "endLine": 154
     },
     "type": "concept",
     "title": "Two Points, No Circle",
@@ -266,8 +266,8 @@
     "id": "ann-104-trivial",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 100,
-      "endLine": 102
+      "startLine": 171,
+      "endLine": 172
     },
     "type": "concept",
     "title": "Trivial Upper Bound",
@@ -288,8 +288,8 @@
     "id": "ann-104-harborth",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 104,
-      "endLine": 107
+      "startLine": 173,
+      "endLine": 174
     },
     "type": "concept",
     "title": "Harborth-Mengersen Bound",
@@ -309,8 +309,8 @@
     "id": "ann-104-elekes",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 115,
-      "endLine": 119
+      "startLine": 181,
+      "endLine": 182
     },
     "type": "concept",
     "title": "Elekes Lower Bound",
@@ -332,8 +332,8 @@
     "id": "ann-104-linear",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 121,
-      "endLine": 125
+      "startLine": 183,
+      "endLine": 184
     },
     "type": "concept",
     "title": "Linear Lower Bound",
@@ -352,8 +352,8 @@
     "id": "ann-104-conjecture",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 133,
-      "endLine": 136
+      "startLine": 191,
+      "endLine": 194
     },
     "type": "definition",
     "title": "Main Conjecture",
@@ -373,8 +373,8 @@
     "id": "ann-104-weak",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 138,
-      "endLine": 141
+      "startLine": 196,
+      "endLine": 202
     },
     "type": "definition",
     "title": "Weak Conjecture",
@@ -394,8 +394,8 @@
     "id": "ann-104-implies",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 143,
-      "endLine": 151
+      "startLine": 204,
+      "endLine": 210
     },
     "type": "concept",
     "title": "Strong Implies Weak",
@@ -415,8 +415,8 @@
     "id": "ann-104-incidence",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 159,
-      "endLine": 161
+      "startLine": 298,
+      "endLine": 300
     },
     "type": "definition",
     "title": "Incidence Count",
@@ -437,8 +437,8 @@
     "id": "ann-104-st",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 163,
-      "endLine": 166
+      "startLine": 302,
+      "endLine": 303
     },
     "type": "concept",
     "title": "Circle Incidence Bound",
@@ -459,8 +459,8 @@
     "id": "ann-104-max",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 174,
-      "endLine": 176
+      "startLine": 311,
+      "endLine": 313
     },
     "type": "definition",
     "title": "Maximum Unit Circles",
@@ -480,8 +480,8 @@
     "id": "ann-104-values",
     "proofId": "erdos-104",
     "range": {
-      "startLine": 178,
-      "endLine": 188
+      "startLine": 315,
+      "endLine": 321
     },
     "type": "concept",
     "title": "Known Values",


### PR DESCRIPTION
## Summary
The `erdos-104` annotation set was anchored to an earlier version of `Erdos104Problem.lean`. Inserted proof bodies and new theorems (`two_points_no_circle`, `quadratic_at_most_two_roots`, expanded `strong_implies_weak`) shifted every declaration down, leaving annotations on banner comments or the **wrong** construct:
- "Two Points, No Circle" sat on the *one-circle* theorem
- "Strong Implies Weak" sat inside the *no-circle* proof
- "Main Conjecture" / "Weak Conjecture" / "Incidence Count" hit definition→theorem type mismatches

Re-anchored all 22 non-header annotations to their semantically correct construct by title — defs, theorems, and the orphan doc-comments that carry the bound/known-value discussions.

## Verification
Resolver `validate`: **14 valid / 9 misaligned → 23 valid / 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)