### PR TITLE
Enrich erdos-109: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-109/annotations.json
+++ b/src/data/proofs/erdos-109/annotations.json
@@ -22,8 +22,8 @@
     "id": "ann-e109-counting-fn",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 48,
-      "endLine": 50
+      "startLine": 50,
+      "endLine": 53
     },
     "type": "definition",
     "title": "Counting Function",
@@ -41,7 +41,7 @@
     "id": "ann-e109-upper-density",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 52,
+      "startLine": 54,
       "endLine": 66
     },
     "type": "definition",
@@ -60,7 +60,7 @@
     "id": "ann-e109-density-ordering",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 68,
+      "startLine": 70,
       "endLine": 108
     },
     "type": "concept",
@@ -79,7 +79,7 @@
     "id": "ann-e109-sumset",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 112,
+      "startLine": 114,
       "endLine": 131
     },
     "type": "definition",
@@ -98,8 +98,8 @@
     "id": "ann-e109-conjecture",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 135,
-      "endLine": 158
+      "startLine": 145,
+      "endLine": 147
     },
     "type": "definition",
     "title": "The Erdős Sumset Conjecture",
@@ -117,8 +117,8 @@
     "id": "ann-e109-axiom",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 148,
-      "endLine": 158
+      "startLine": 156,
+      "endLine": 159
     },
     "type": "concept",
     "title": "Moreira-Richter-Robertson Theorem",
@@ -136,7 +136,7 @@
     "id": "ann-e109-infinite-consequence",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 162,
+      "startLine": 164,
       "endLine": 197
     },
     "type": "concept",
@@ -155,7 +155,7 @@
     "id": "ann-e109-naturals-density",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 226,
+      "startLine": 229,
       "endLine": 261
     },
     "type": "concept",
@@ -174,7 +174,7 @@
     "id": "ann-e109-even-example",
     "proofId": "erdos-109",
     "range": {
-      "startLine": 263,
+      "startLine": 265,
       "endLine": 298
     },
     "type": "concept",


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

All 9 annotations had `range.startLine` pointing at a section banner or blank line rather than the Lean declaration beneath it, so the resolver reported "No Lean construct found" (only 1/10 valid).

Re-anchored each to its actual construct:

| annotation | → construct |
|---|---|
| ann-e109-counting-fn | `def countingFn` (50) |
| ann-e109-upper-density | `def upperDensity` (54) |
| ann-e109-density-ordering | `theorem lowerDensity_le_upperDensity` (70) |
| ann-e109-sumset | `def Sumset` (114) |
| ann-e109-conjecture | `def ErdosSumsetConjecture` (145) |
| ann-e109-axiom | `axiom moreira_richter_robertson` (156) |
| ann-e109-infinite-consequence | `theorem sumset_infinite_implies_superset_infinite` (164) |
| ann-e109-naturals-density | `theorem naturals_have_full_density` (229) |
| ann-e109-even-example | `def evenNumbers` (265) |

The conjecture and axiom annotations previously had overlapping ranges (both ending at 158); now split cleanly. Content unchanged. Resolver validates **10/10, 0 misaligned**.