### PR TITLE
Enrich erdos-602: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-602/annotations.json
+++ b/src/data/proofs/erdos-602/annotations.json
@@ -22,7 +22,7 @@
     "id": "ann-602-family",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 44,
+      "startLine": 45,
       "endLine": 53
     },
     "type": "definition",
@@ -41,7 +41,7 @@
     "id": "ann-602-intersection",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 61,
+      "startLine": 62,
       "endLine": 79
     },
     "type": "definition",
@@ -60,7 +60,7 @@
     "id": "ann-602-coloring",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 87,
+      "startLine": 88,
       "endLine": 104
     },
     "type": "definition",
@@ -79,7 +79,7 @@
     "id": "ann-602-family-b",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 112,
+      "startLine": 113,
       "endLine": 123
     },
     "type": "definition",
@@ -97,8 +97,8 @@
     "id": "ann-602-conjecture",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 131,
-      "endLine": 146
+      "startLine": 132,
+      "endLine": 139
     },
     "type": "definition",
     "title": "Main Conjecture",
@@ -115,8 +115,8 @@
     "id": "ann-602-conditions",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 154,
-      "endLine": 166
+      "startLine": 140,
+      "endLine": 152
     },
     "type": "concept",
     "title": "Why Conditions Matter",
@@ -133,8 +133,8 @@
     "id": "ann-602-komjath",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 180,
-      "endLine": 181
+      "startLine": 181,
+      "endLine": 189
     },
     "type": "definition",
     "title": "Komjáth's Problem",
@@ -151,7 +151,7 @@
     "id": "ann-602-special",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 192,
+      "startLine": 193,
       "endLine": 203
     },
     "type": "definition",
@@ -188,7 +188,7 @@
     "id": "ann-602-status",
     "proofId": "erdos-602",
     "range": {
-      "startLine": 242,
+      "startLine": 243,
       "endLine": 269
     },
     "type": "concept",


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

All 9 annotations had `range.startLine` pointing at a section banner or comment rather than the Lean declaration beneath it, so the resolver reported "No Lean construct found" (only 2/11 valid).

Re-anchored each to its actual construct:

| annotation | → construct |
|---|---|
| ann-602-family | `abbrev SetFamily` (45) |
| ann-602-intersection | `def HasFiniteIntersection` (62) |
| ann-602-coloring | `abbrev TwoColoring` (88) |
| ann-602-family-b | `def IsValidColoring` (113) |
| ann-602-conjecture | `def ErdosConjecture602` (132) |
| ann-602-conditions | `theorem conjecture_equiv` (140) |
| ann-602-komjath | `def KomjathProblem` (181) |
| ann-602-special | `def IsDisjointFamily` (193) |
| ann-602-status | `def Is2ChromaticForcing` (243) |

`ann-602-conditions` ("Why the Conditions Matter") sat in a comment-only Part 6 section with no declaration; it is now anchored to `conjecture_equiv`, the theorem those condition comments elaborate, and its range no longer overlaps the conjecture annotation. Content unchanged. Resolver validates **11/11, 0 misaligned**.