### PR TITLE
Enrich erdos-28: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-28/annotations.json
+++ b/src/data/proofs/erdos-28/annotations.json
@@ -8,18 +8,18 @@
     },
     "type": "concept",
     "title": "Module Documentation: Problem Statement and Status",
-    "content": "The module docstring establishes the mathematical context for Erd\u0151s Problem #28: the Erd\u0151s\u2013Tur\u00e1n conjecture on additive bases. It states the conjecture ($\\limsup r_A(n) = \\infty$ for any asymptotic basis $A$), notes the $500 prize, records the OPEN status, and lists the key partial results (Grekos et al.: $r_A(n) \\geq 6$ i.o.; Borwein et al.: $r_A(n) \\geq 8$ i.o.). The stronger conjectures (logarithmic growth and density version) are also previewed. The outline of the formalization lists five components: representation function, asymptotic basis definition, formal conjecture statement, basic properties, and constructions with unbounded representations.",
+    "content": "The module docstring establishes the mathematical context for Erdős Problem #28: the Erdős–Turán conjecture on additive bases. It states the conjecture ($\\limsup r_A(n) = \\infty$ for any asymptotic basis $A$), notes the $500 prize, records the OPEN status, and lists the key partial results (Grekos et al.: $r_A(n) \\geq 6$ i.o.; Borwein et al.: $r_A(n) \\geq 8$ i.o.). The stronger conjectures (logarithmic growth and density version) are also previewed. The outline of the formalization lists five components: representation function, asymptotic basis definition, formal conjecture statement, basic properties, and constructions with unbounded representations.",
     "mathContext": "The conjecture: if $A + A \\supseteq \\{N_0, N_0+1, \\ldots\\}$ then $\\limsup_{n \\to \\infty} r_A(n) = \\infty$, where $r_A(n) = |\\{(a,b) \\in A^2 : a+b=n\\}|$. The $500 prize reflects its status as one of the deepest open problems in additive number theory, unsolved since 1941.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s problems",
+      "Erdős problems",
       "additive bases",
       "representation functions",
-      "Erd\u0151s\u2013Tur\u00e1n conjecture"
+      "Erdős–Turán conjecture"
     ],
     "prerequisites": [
       "additive number theory",
-      "Erd\u0151s problem catalog"
+      "Erdős problem catalog"
     ]
   },
   {
@@ -48,8 +48,8 @@
     "id": "rep-function",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 47,
-      "endLine": 55
+      "startLine": 51,
+      "endLine": 62
     },
     "type": "definition",
     "title": "Representation Function",
@@ -72,8 +72,8 @@
     "id": "asymptotic-basis",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 63,
-      "endLine": 73
+      "startLine": 65,
+      "endLine": 77
     },
     "type": "definition",
     "title": "Asymptotic Basis of Order 2",
@@ -101,7 +101,7 @@
     },
     "type": "definition",
     "title": "Finset-Based Representation Function",
-    "content": "`repFuncFinset` is a computable variant of the representation function for finite sets $A$. Given a `Finset \u2115`, it forms the product $A \\times A$, filters for pairs $(a,b)$ with $a + b = n$, and returns the `Finset.card`. Unlike the `Set`-based `repFunc` (which uses `Set.ncard` and is `noncomputable`), this version can be evaluated by the kernel. The file does not use `repFuncFinset` in the main development \u2014 it serves as a computable witness.",
+    "content": "`repFuncFinset` is a computable variant of the representation function for finite sets $A$. Given a `Finset ℕ`, it forms the product $A \\times A$, filters for pairs $(a,b)$ with $a + b = n$, and returns the `Finset.card`. Unlike the `Set`-based `repFunc` (which uses `Set.ncard` and is `noncomputable`), this version can be evaluated by the kernel. The file does not use `repFuncFinset` in the main development — it serves as a computable witness.",
     "mathContext": "$r_A^{\\text{fin}}(n) = |\\{(a,b) \\in A \\times A : a+b=n\\}|$ via `(A.product A).filter (\\lambda p, p.1 + p.2 = n) |>.card$. This is the ordered count (each unordered pair $\\{a,b\\}$ with $a \\neq b$ is counted twice).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -119,13 +119,13 @@
     "id": "main-conjecture",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 201,
-      "endLine": 210
+      "startLine": 210,
+      "endLine": 211
     },
     "type": "concept",
-    "title": "Erd\u0151s\u2013Tur\u00e1n Conjecture (1941)",
-    "content": "The central conjecture: if $A$ is an asymptotic basis of order 2, then $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. Formalized as: for every bound $B$, there exists $n$ with $r_A(n) \\geq B$. This is stated as an axiom because the conjecture remains OPEN after 85 years. Erd\u0151s offered a $500 bounty \u2014 one of his largest prizes, reflecting the problem's depth.",
-    "mathContext": "$\\forall B \\in \\mathbb{N}, \\; \\exists n \\in \\mathbb{N}: \\; r_A(n) \\geq B$. Equivalently, $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. The negation \u2014 that some basis has $r_A(n) \\leq C$ for all $n$ \u2014 would give a remarkable **thin basis** with perfectly controlled representations.",
+    "title": "Erdős–Turán Conjecture (1941)",
+    "content": "The central conjecture: if $A$ is an asymptotic basis of order 2, then $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. Formalized as: for every bound $B$, there exists $n$ with $r_A(n) \\geq B$. This is stated as an axiom because the conjecture remains OPEN after 85 years. Erdős offered a $500 bounty — one of his largest prizes, reflecting the problem's depth.",
+    "mathContext": "$\\forall B \\in \\mathbb{N}, \\; \\exists n \\in \\mathbb{N}: \\; r_A(n) \\geq B$. Equivalently, $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. The negation — that some basis has $r_A(n) \\leq C$ for all $n$ — would give a remarkable **thin basis** with perfectly controlled representations.",
     "significance": "key",
     "relatedConcepts": [
       "thin bases",
@@ -143,12 +143,12 @@
     "id": "strong-form",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 212,
-      "endLine": 218
+      "startLine": 217,
+      "endLine": 219
     },
     "type": "concept",
     "title": "Logarithmic Growth Conjecture",
-    "content": "The stronger form predicts $\\limsup r_A(n) / \\log n > 0$: representation counts grow at least logarithmically along some subsequence. This is motivated by probabilistic heuristics \u2014 if $A$ has density $\\sim \\sqrt{N}$, then for a 'random' such set, $r_A(n)$ has expectation $\\sim \\log n$. Proving even the weaker form (unboundedness without rate) remains out of reach.",
+    "content": "The stronger form predicts $\\limsup r_A(n) / \\log n > 0$: representation counts grow at least logarithmically along some subsequence. This is motivated by probabilistic heuristics — if $A$ has density $\\sim \\sqrt{N}$, then for a 'random' such set, $r_A(n)$ has expectation $\\sim \\log n$. Proving even the weaker form (unboundedness without rate) remains out of reach.",
     "mathContext": "$\\exists c > 0, \\; \\forall N, \\; \\exists n \\geq N: \\; r_A(n) \\geq c \\log n$. Heuristically, if $\\mathbb{P}[a \\in A] \\approx 1/\\sqrt{a}$, then $\\mathbb{E}[r_A(n)] = \\sum_{a \\leq n} \\frac{1}{\\sqrt{a}} \\cdot \\frac{1}{\\sqrt{n-a}} \\approx \\log n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -172,7 +172,7 @@
     },
     "type": "concept",
     "title": "Density Version of the Conjecture (Unstated Strengthening)",
-    "content": "The module docstring mentions the stronger hypothesis $|A \\cap [1,N]| \\gg N^{1/2}$ as sufficient for the conjecture to hold. This density version replaces the basis condition ($A + A$ covers all large integers) with the weaker assumption that $A$ has density at least $\\sqrt{N}$. Since every basis of order 2 satisfies this density bound (proved as `basis_element_count_sq`), this version is strictly stronger. It is not formalized as a separate Lean definition \u2014 it remains a conceptual conjecture discussed in the metadata.",
+    "content": "The module docstring mentions the stronger hypothesis $|A \\cap [1,N]| \\gg N^{1/2}$ as sufficient for the conjecture to hold. This density version replaces the basis condition ($A + A$ covers all large integers) with the weaker assumption that $A$ has density at least $\\sqrt{N}$. Since every basis of order 2 satisfies this density bound (proved as `basis_element_count_sq`), this version is strictly stronger. It is not formalized as a separate Lean definition — it remains a conceptual conjecture discussed in the metadata.",
     "mathContext": "If $A(N) \\geq c\\sqrt{N}$ for some $c > 0$ and all $N \\geq 1$, then $\\limsup r_A(n) = \\infty$. This generalizes the main conjecture since $\\text{IsAsymptoticBasis2}(A) \\Rightarrow A(N) \\gg \\sqrt{N}$ (proved as `basis_element_count_sq`).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -190,18 +190,18 @@
     "id": "sidon-connection",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 350,
+      "startLine": 372,
       "endLine": 411
     },
     "type": "concept",
     "title": "Sidon Sets Cannot Be Bases",
-    "content": "A Sidon set (or $B_2$ set) has $r_A(n) \\leq 1$ for all $n$: each integer has at most one representation as $a + b$. Such sets satisfy $A(N) \\leq \\sqrt{N} + O(N^{1/4})$ (by the Lindstr\u00f6m\u2013Erd\u0151s\u2013Tur\u00e1n bound), which is too sparse for a basis. This confirms the conjecture vacuously: the extremal case $r \\leq 1$ is incompatible with being a basis.",
+    "content": "A Sidon set (or $B_2$ set) has $r_A(n) \\leq 1$ for all $n$: each integer has at most one representation as $a + b$. Such sets satisfy $A(N) \\leq \\sqrt{N} + O(N^{1/4})$ (by the Lindström–Erdős–Turán bound), which is too sparse for a basis. This confirms the conjecture vacuously: the extremal case $r \\leq 1$ is incompatible with being a basis.",
     "mathContext": "If $r_A(n) \\leq 1$ for all $n$, then $A$ is a **Sidon set** ($B_2$ set). Sidon sets satisfy $|A \\cap [1,N]| \\leq \\sqrt{N} + O(N^{1/4})$, but bases require $|A \\cap [1,N]| \\gg \\sqrt{N}$ with a constant that forces density beyond the Sidon threshold.",
     "significance": "key",
     "relatedConcepts": [
       "Sidon sets",
       "B_2 sequences",
-      "Erd\u0151s\u2013Tur\u00e1n bound on Sidon sets",
+      "Erdős–Turán bound on Sidon sets",
       "Singer difference sets"
     ],
     "prerequisites": [
@@ -214,18 +214,18 @@
     "id": "problem-40",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 220,
-      "endLine": 223
+      "startLine": 224,
+      "endLine": 224
     },
     "type": "concept",
-    "title": "Connection to Problem #40 (B\u2082[g] Sets)",
-    "content": "Problem #40 asks: if $r_A(n) \\leq g$ for some constant $g$ (i.e., $A$ is a $B_2[g]$ set), can $A$ be a basis of order 2? The Erd\u0151s\u2013Tur\u00e1n conjecture (#28) implies the answer is no for every finite $g$. This formalization shows #28 $\\Rightarrow$ #40, connecting two of Erd\u0151s's most celebrated problems in additive combinatorics.",
+    "title": "Connection to Problem #40 (B₂[g] Sets)",
+    "content": "Problem #40 asks: if $r_A(n) \\leq g$ for some constant $g$ (i.e., $A$ is a $B_2[g]$ set), can $A$ be a basis of order 2? The Erdős–Turán conjecture (#28) implies the answer is no for every finite $g$. This formalization shows #28 $\\Rightarrow$ #40, connecting two of Erdős's most celebrated problems in additive combinatorics.",
     "mathContext": "A $B_2[g]$ set satisfies $r_A(n) \\leq g$ for all $n$. Problem #28 states $\\limsup r_A(n) = \\infty$ for any basis, which immediately implies no $B_2[g]$ set (with bounded $r$) can be a basis. The converse implication (#40 $\\Rightarrow$ #28) is unknown.",
     "significance": "key",
     "relatedConcepts": [
       "B_2[g] sets",
-      "Erd\u0151s Problem #40",
-      "Erd\u0151s Problem #1145",
+      "Erdős Problem #40",
+      "Erdős Problem #1145",
       "additive structure"
     ],
     "prerequisites": [
@@ -242,13 +242,13 @@
       "endLine": 231
     },
     "type": "insight",
-    "title": "Axiom: Grekos et al. (2003) \u2014 r_A(n) \u2265 6 Infinitely Often",
-    "content": "The first quantitative partial result toward the Erd\u0151s\u2013Tur\u00e1n conjecture: for any asymptotic basis $A$ of order 2, the representation function $r_A(n) \\geq 6$ for infinitely many $n$. This is axiomatized rather than proved because the underlying argument uses Fourier analysis on $\\mathbb{Z}/N\\mathbb{Z}$ and Parseval-type estimates that are not yet in Mathlib.\n\nThe key gap illustrated: the conjecture requires $r_A(n) \\to \\infty$ pointwise, while Grekos et al. show only that $r_A(n)$ occasionally reaches 6. Even if $r_A(n) \\leq 7$ for all $n$, the Erd\u0151s\u2013Tur\u00e1n conjecture would be false. The Erd\u0151s\u2013Fuchs theorem (1956) shows the *cumulative sum* $\\sum_{n \\leq N} r_A(n)$ must oscillate with amplitude $\\Omega(N^{1/4}/\\sqrt{\\log N})$, but this fluctuation could come from rare large values without the pointwise limsup being infinite.",
+    "title": "Axiom: Grekos et al. (2003) — r_A(n) ≥ 6 Infinitely Often",
+    "content": "The first quantitative partial result toward the Erdős–Turán conjecture: for any asymptotic basis $A$ of order 2, the representation function $r_A(n) \\geq 6$ for infinitely many $n$. This is axiomatized rather than proved because the underlying argument uses Fourier analysis on $\\mathbb{Z}/N\\mathbb{Z}$ and Parseval-type estimates that are not yet in Mathlib.\n\nThe key gap illustrated: the conjecture requires $r_A(n) \\to \\infty$ pointwise, while Grekos et al. show only that $r_A(n)$ occasionally reaches 6. Even if $r_A(n) \\leq 7$ for all $n$, the Erdős–Turán conjecture would be false. The Erdős–Fuchs theorem (1956) shows the *cumulative sum* $\\sum_{n \\leq N} r_A(n)$ must oscillate with amplitude $\\Omega(N^{1/4}/\\sqrt{\\log N})$, but this fluctuation could come from rare large values without the pointwise limsup being infinite.",
     "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\text{IsAsymptoticBasis}(A) \\Rightarrow \\forall M,\\; \\exists n > M,\\; r_A(n) \\geq 6$. The proof uses exponential sum estimates: write $r_A(n) = \\sum_{a \\in A \\cap [0,n]} \\mathbf{1}_{n-a \\in A}$ and apply Parseval's theorem to the generating function $f(\\theta) = \\sum_{a \\in A} e^{2\\pi i a \\theta}$; the basis condition forces $\\|f\\|_2^2$ to be large, giving the lower bound via a pigeonhole argument.",
     "significance": "key",
     "relatedConcepts": [
-      "Erd\u0151s\u2013Tur\u00e1n conjecture",
-      "Erd\u0151s\u2013Fuchs theorem",
+      "Erdős–Turán conjecture",
+      "Erdős–Fuchs theorem",
       "exponential sums",
       "Parseval's theorem",
       "borwein_lower_bound"
@@ -267,16 +267,16 @@
       "endLine": 234
     },
     "type": "insight",
-    "title": "Axiom: Borwein et al. (2006) \u2014 r_A(n) \u2265 8 Infinitely Often",
-    "content": "The current best quantitative lower bound: for any asymptotic basis $A$, $r_A(n) \\geq 8$ for infinitely many $n$. This improved the Grekos et al. (2003) bound of 6 using more refined exponential sum estimates. The axiom is stated universally: for any asymptotic basis $A$ and any threshold $M$, there exists $n > M$ with $r_A(n) \\geq 8$.\n\nThe gap between 'at least 8 infinitely often' and 'unbounded' is the fundamental difficulty: a basis could conceivably have $r_A(n) \\leq 9$ for all $n$ \u2014 this is consistent with the Borwein bound but would refute the Erd\u0151s\u2013Tur\u00e1n conjecture. No such bounded-representation basis is known to exist, and the conjecture asserts none do.",
-    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\text{IsAsymptoticBasis}(A) \\Rightarrow \\forall M,\\; \\exists n > M,\\; r_A(n) \\geq 8$. The improvement from 6 to 8 uses the identity $\\sum_{n} r_A(n)^2 = |\\{(a,b,c,d) \\in A^4 : a+b = c+d\\}|$ (additive energy $E(A,A)$) combined with Cauchy\u2013Schwarz on the basis covering condition. The conjectured true answer is $\\limsup r_A(n) = \\infty$; no finite bound $r_A(n) \\geq k$ (however large $k$) would suffice to prove this.",
+    "title": "Axiom: Borwein et al. (2006) — r_A(n) ≥ 8 Infinitely Often",
+    "content": "The current best quantitative lower bound: for any asymptotic basis $A$, $r_A(n) \\geq 8$ for infinitely many $n$. This improved the Grekos et al. (2003) bound of 6 using more refined exponential sum estimates. The axiom is stated universally: for any asymptotic basis $A$ and any threshold $M$, there exists $n > M$ with $r_A(n) \\geq 8$.\n\nThe gap between 'at least 8 infinitely often' and 'unbounded' is the fundamental difficulty: a basis could conceivably have $r_A(n) \\leq 9$ for all $n$ — this is consistent with the Borwein bound but would refute the Erdős–Turán conjecture. No such bounded-representation basis is known to exist, and the conjecture asserts none do.",
+    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\text{IsAsymptoticBasis}(A) \\Rightarrow \\forall M,\\; \\exists n > M,\\; r_A(n) \\geq 8$. The improvement from 6 to 8 uses the identity $\\sum_{n} r_A(n)^2 = |\\{(a,b,c,d) \\in A^4 : a+b = c+d\\}|$ (additive energy $E(A,A)$) combined with Cauchy–Schwarz on the basis covering condition. The conjectured true answer is $\\limsup r_A(n) = \\infty$; no finite bound $r_A(n) \\geq k$ (however large $k$) would suffice to prove this.",
     "significance": "key",
     "relatedConcepts": [
       "additive energy",
       "Cauchy-Schwarz inequality",
       "exponential sums",
       "grekos_lower_bound",
-      "Erd\u0151s\u2013Tur\u00e1n conjecture"
+      "Erdős–Turán conjecture"
     ],
     "prerequisites": [
       "repFunc",
@@ -319,7 +319,7 @@
     },
     "type": "concept",
     "title": "Part III: Finiteness of Pair Sets and Positive Representation",
-    "content": "Three supporting lemmas establish basic properties of the representation function. `pairs_summing_finite` proves that $\\{(a,b) \\in A^2 : a+b=n\\}$ is finite by embedding it into $[0,n) \\times [0,n)$ \u2014 both components are bounded by $n$. `repFunc_pos_of_mem_sumset` shows $r_A(n) \\geq 1$ whenever $n \\in A+A$: the witness pair gives a nonempty finite set with positive `Set.ncard`. `repFunc_pos_of_zero_mem` specializes this: if $0 \\in A$ and $n \\in A$, then $(0, n)$ witnesses $n \\in A+A$. These lemmas establish the connection between sumset membership and positive representation count.",
+    "content": "Three supporting lemmas establish basic properties of the representation function. `pairs_summing_finite` proves that $\\{(a,b) \\in A^2 : a+b=n\\}$ is finite by embedding it into $[0,n) \\times [0,n)$ — both components are bounded by $n$. `repFunc_pos_of_mem_sumset` shows $r_A(n) \\geq 1$ whenever $n \\in A+A$: the witness pair gives a nonempty finite set with positive `Set.ncard`. `repFunc_pos_of_zero_mem` specializes this: if $0 \\in A$ and $n \\in A$, then $(0, n)$ witnesses $n \\in A+A$. These lemmas establish the connection between sumset membership and positive representation count.",
     "mathContext": "$n \\in A+A \\Rightarrow r_A(n) \\geq 1$. Proof: $n = a+b$ with $a,b \\in A$ gives $(a,b) \\in \\{(x,y) : x+y=n\\}$, so $|\\{(x,y) : x+y=n\\}| \\geq 1$. Finiteness: $(a,b) \\in A^2$ with $a+b=n$ forces $a,b < n+1$, so the set embeds into $[0,n] \\times [0,n]$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -343,7 +343,7 @@
       "endLine": 199
     },
     "type": "concept",
-    "title": "Sidon Sets Have Representation \u2264 2 (Original Proof)",
+    "title": "Sidon Sets Have Representation ≤ 2 (Original Proof)",
     "content": "The file's most detailed original proof. Defines `IsSidon A` as: $a+b = c+d$ with $a,b,c,d \\in A$ implies $\\{a,b\\} = \\{c,d\\}$ (all pairwise sums distinct as multisets). Then proves `sidon_repFunc_bounded`: for Sidon sets, $r_A(n) \\leq 2$ for all $n$. The proof shows that all pairs summing to $n$ must be permutations of a single pair: if $(a,b)$ and $(c,d)$ both sum to $n$, the Sidon property forces $\\{c,d\\} = \\{a,b\\}$, so $(c,d) \\in \\{(a,b), (b,a)\\}$. The subset bound $S \\subseteq \\{(a,b), (b,a)\\}$ gives $|S| \\leq 2$ via `Set.ncard_union_le`. The proof handles the empty case separately (`Set.ncard_empty`). This confirms the extremal case: Sidon sets minimize representation, and their density limitation ($A(N) \\leq \\sqrt{N} + O(N^{1/4})$) prevents them from being bases.",
     "mathContext": "IsSidon: $a+b = c+d \\Rightarrow \\{a,b\\} = \\{c,d\\}$. Theorem: $r_A(n) \\leq 2$. Proof: fix $(a,b)$ with $a+b=n$; any other $(c,d)$ with $c+d=n$ satisfies $\\{c,d\\} = \\{a,b\\}$, so $(c,d) \\in \\{(a,b), (b,a)\\}$, giving $|S| \\leq |\\{(a,b),(b,a)\\}| \\leq 2$.",
     "significance": "key",
@@ -369,7 +369,7 @@
       "endLine": 572
     },
     "type": "concept",
-    "title": "Part VIII: Ordered \u2265 Unordered Representation Count",
+    "title": "Part VIII: Ordered ≥ Unordered Representation Count",
     "content": "Proves `repFunc_ge_repFuncUnordered`: the ordered representation count $r_A(n)$ is at least the unordered count $r_A^{\\leq}(n)$. The proof is a direct subset argument: every unordered pair $(a,b)$ with $a \\leq b$ and $a+b=n$ also satisfies the ordered condition (membership in $A$ and sum $= n$), so the unordered set is a subset of the ordered set. Finiteness from `pairs_summing_finite` enables `Set.ncard_le_ncard`. This bridge lemma is used in `erdos_turan_holds_for_nat` to transfer unboundedness from the unordered to ordered count.",
     "mathContext": "$r_A(n) = |\\{(a,b) : a+b=n, a,b \\in A\\}| \\geq |\\{(a,b) : a+b=n, a \\leq b, a,b \\in A\\}| = r_A^{\\leq}(n)$. The unordered set is a subset of the ordered set (dropping the $a \\leq b$ constraint only enlarges the set).",
     "significance": "supporting",
@@ -389,13 +389,13 @@
     "id": "main-conjecture-formal",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 201,
+      "startLine": 210,
       "endLine": 224
     },
     "type": "definition",
     "title": "Part IV: Formal Conjecture Statements (Weak and Strong)",
-    "content": "Three formal definitions capture the conjecture at different strengths. `erdos_turan_weak` states: for every basis $A$ and every bound $k$, there exists $n$ with $r_A(n) > k$ \u2014 the representation function is unbounded. `erdos_turan_strong` strengthens this to $r_A(n) > c \\log n$ infinitely often. `erdos_28` is defined as `erdos_turan_weak`, making the official problem statement the weaker form. The gap between weak and strong reflects a real open question: even if unboundedness is proved, the growth rate of $\\limsup r_A(n)$ remains unknown.",
-    "mathContext": "Weak: $\\forall A, \\text{IsAsymptoticBasis}(A) \\to \\forall k, \\exists n, r_A(n) > k$. Strong: $\\exists c > 0, \\forall M, \\exists n > M, r_A(n) > c \\log n$. The strong form implies the weak form but is strictly stronger \u2014 $\\log n$ growth vs mere unboundedness.",
+    "content": "Three formal definitions capture the conjecture at different strengths. `erdos_turan_weak` states: for every basis $A$ and every bound $k$, there exists $n$ with $r_A(n) > k$ — the representation function is unbounded. `erdos_turan_strong` strengthens this to $r_A(n) > c \\log n$ infinitely often. `erdos_28` is defined as `erdos_turan_weak`, making the official problem statement the weaker form. The gap between weak and strong reflects a real open question: even if unboundedness is proved, the growth rate of $\\limsup r_A(n)$ remains unknown.",
+    "mathContext": "Weak: $\\forall A, \\text{IsAsymptoticBasis}(A) \\to \\forall k, \\exists n, r_A(n) > k$. Strong: $\\exists c > 0, \\forall M, \\exists n > M, r_A(n) > c \\log n$. The strong form implies the weak form but is strictly stronger — $\\log n$ growth vs mere unboundedness.",
     "significance": "key",
     "relatedConcepts": [
       "additive basis",
@@ -412,13 +412,13 @@
     "id": "partial-results-formal",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 225,
+      "startLine": 229,
       "endLine": 234
     },
     "type": "concept",
     "title": "Part V: Axiomatized Partial Results (Grekos, Borwein)",
     "content": "Two axioms encode the best known partial results toward the conjecture. `grekos_lower_bound` (Grekos, Haddad, Helou, Pihko, 2003): for any basis $A$, $r_A(n) \\geq 6$ infinitely often. `borwein_lower_bound` (Borwein, Choi, Croot): improved to $r_A(n) \\geq 8$ infinitely often. The conjecture asserts $r_A(n) \\to \\infty$ along a subsequence, so these results confirm the first few steps of unboundedness. The gap between 8 and $\\infty$ remains one of the central challenges in additive combinatorics.",
-    "mathContext": "Grekos et al. [GHHP03]: $\\forall A, \\text{IsAsymptoticBasis2}(A) \\Rightarrow \\forall M, \\exists n > M, r_A(n) \\geq 6$. Borwein\u2013Choi\u2013Chu [BCC06]: same with $6$ replaced by $8$. Both results use a Fourier-analytic approach: if $r_A(n) \\leq k$ for all large $n$, then the generating function $\\hat{A}(\\theta)^2 = \\sum r_A(n) e^{2\\pi i n\\theta}$ must be nearly flat, contradicting the basis condition. The gap: the conjecture requires $\\forall k \\in \\mathbb{N}, \\exists n, r_A(n) \\geq k$; the best known result only gives $r_A(n) \\geq 8$ infinitely often.",
+    "mathContext": "Grekos et al. [GHHP03]: $\\forall A, \\text{IsAsymptoticBasis2}(A) \\Rightarrow \\forall M, \\exists n > M, r_A(n) \\geq 6$. Borwein–Choi–Chu [BCC06]: same with $6$ replaced by $8$. Both results use a Fourier-analytic approach: if $r_A(n) \\leq k$ for all large $n$, then the generating function $\\hat{A}(\\theta)^2 = \\sum r_A(n) e^{2\\pi i n\\theta}$ must be nearly flat, contradicting the basis condition. The gap: the conjecture requires $\\forall k \\in \\mathbb{N}, \\exists n, r_A(n) \\geq k$; the best known result only gives $r_A(n) \\geq 8$ infinitely often.",
     "significance": "key",
     "relatedConcepts": [
       "additive bases",
@@ -435,12 +435,12 @@
     "id": "examples-section",
     "proofId": "erdos-28",
     "range": {
-      "startLine": 235,
+      "startLine": 239,
       "endLine": 347
     },
     "type": "insight",
-    "title": "Part VI: Concrete Examples \u2014 Evens and \u2115",
-    "content": "Two concrete examples illustrate basis behavior. The **even numbers** $\\{0, 2, 4, \\ldots\\}$ form a basis for even integers with $r_{\\text{evens}}(2n) = \\lfloor n/2 \\rfloor + 1$ (growing linearly). **\u2115 itself** is trivially a basis with $r_{\\mathbb{N}}(n) = \\lfloor n/2 \\rfloor + 1$, confirming the conjecture for this case. These examples show that 'natural' bases have linearly growing representation functions, far exceeding the conjectured $\\log n$ threshold. The challenge is proving unboundedness for bases with potentially adversarial structure.",
+    "title": "Part VI: Concrete Examples — Evens and ℕ",
+    "content": "Two concrete examples illustrate basis behavior. The **even numbers** $\\{0, 2, 4, \\ldots\\}$ form a basis for even integers with $r_{\\text{evens}}(2n) = \\lfloor n/2 \\rfloor + 1$ (growing linearly). **ℕ itself** is trivially a basis with $r_{\\mathbb{N}}(n) = \\lfloor n/2 \\rfloor + 1$, confirming the conjecture for this case. These examples show that 'natural' bases have linearly growing representation functions, far exceeding the conjectured $\\log n$ threshold. The challenge is proving unboundedness for bases with potentially adversarial structure.",
     "mathContext": "$r_{\\text{evens}}(2n) = \\lfloor n/2 \\rfloor + 1$: pairs $(2k, 2(n-k))$ with $k \\leq n/2$. $r_{\\mathbb{N}}(n) = \\lfloor n/2 \\rfloor + 1$: pairs $(k, n-k)$ with $k \\leq n/2$. Both grow as $\\Theta(n)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -464,14 +464,14 @@
     },
     "type": "concept",
     "title": "Part VII: Sidon Density Bridge and Density Bound",
-    "content": "Part VII opens with a bridge lemma `isSidon_set_to_finset` that converts the Set-based `IsSidon` (unordered pair equality: $a+b = c+d \\Rightarrow \\{a,b\\} = \\{c,d\\}$) to the Finset-based `Erdos340.IsSidon` (ordered pair equality with $a \\leq b$, $c \\leq d$). This bridge enables importing `sidon_density_bound` from the Erd\u0151s #340 formalization: for any Sidon set $A$ with elements in $[0, N]$, $|A| \\leq \\sqrt{2N} + 1$. The proof is a one-liner delegating to `Erdos340.sidon_upper_bound_weak` via the bridge. This density bound is the key ingredient for proving Sidon sets cannot be bases.",
+    "content": "Part VII opens with a bridge lemma `isSidon_set_to_finset` that converts the Set-based `IsSidon` (unordered pair equality: $a+b = c+d \\Rightarrow \\{a,b\\} = \\{c,d\\}$) to the Finset-based `Erdos340.IsSidon` (ordered pair equality with $a \\leq b$, $c \\leq d$). This bridge enables importing `sidon_density_bound` from the Erdős #340 formalization: for any Sidon set $A$ with elements in $[0, N]$, $|A| \\leq \\sqrt{2N} + 1$. The proof is a one-liner delegating to `Erdos340.sidon_upper_bound_weak` via the bridge. This density bound is the key ingredient for proving Sidon sets cannot be bases.",
     "mathContext": "Bridge: IsSidon (Set) $\\Rightarrow$ IsSidon (Finset). From $\\{a,b\\} = \\{c,d\\}$ with $a \\leq b, c \\leq d$: either $c = a$ (then $b = d$) or $c = b$ (then $a \\leq b = c \\leq d$ and $a + b = c + d$ force $a = c, b = d$). Density: $|A \\cap [0,N]| \\leq \\sqrt{2N} + 1$ for Sidon $A$.",
     "significance": "key",
     "relatedConcepts": [
       "Sidon sets",
       "B_2 sequences",
       "density bounds",
-      "Erd\u0151s #340",
+      "Erdős #340",
       "bridge lemma"
     ],
     "prerequisites": [
@@ -515,7 +515,7 @@
     },
     "type": "insight",
     "title": "Sidon Sets Cannot Be Bases (Fully Proved)",
-    "content": "`sidon_not_basis` is the most substantial theorem in the file: any infinite Sidon set $A$ is not an asymptotic basis of order 2. Previously axiomatized, this is now fully proved via a combinatorial counting argument.\n\nThe proof proceeds by contradiction. Assume $A$ is an infinite Sidon set and an asymptotic basis with threshold $N_0$. Choose $T = 4N_0 + 100$ and $N = T^2$. The restricted set $S = A \\cap [0, N]$ is finite and Sidon. By the Sidon density bound (imported from Erd\u0151s #340), $|S| \\leq \\sqrt{2N} + 1 = \\sqrt{2T^2} + 1 \\leq T + \\sqrt{T} + 1 \\leq 5N_0 + 126$. But $S$ must cover $[N_0, N]$ via its sumset, giving $|\\text{sumset}(S)| \\geq N - N_0 + 1 = T^2 - N_0 + 1$. The helper bound $|\\text{sumset}(S)| \\cdot 2 \\leq |S|(|S|+1) \\leq (5N_0+126)(5N_0+127)$ then forces $2(4N_0+100)^2 + 2 \\leq (5N_0+126)(5N_0+127) + 2N_0$, which simplifies to $7N_0^2 + 333N_0 + 4000 \\leq 0$ \u2014 impossible for $N_0 \\geq 0$. The `nlinarith` tactic closes the proof.",
+    "content": "`sidon_not_basis` is the most substantial theorem in the file: any infinite Sidon set $A$ is not an asymptotic basis of order 2. Previously axiomatized, this is now fully proved via a combinatorial counting argument.\n\nThe proof proceeds by contradiction. Assume $A$ is an infinite Sidon set and an asymptotic basis with threshold $N_0$. Choose $T = 4N_0 + 100$ and $N = T^2$. The restricted set $S = A \\cap [0, N]$ is finite and Sidon. By the Sidon density bound (imported from Erdős #340), $|S| \\leq \\sqrt{2N} + 1 = \\sqrt{2T^2} + 1 \\leq T + \\sqrt{T} + 1 \\leq 5N_0 + 126$. But $S$ must cover $[N_0, N]$ via its sumset, giving $|\\text{sumset}(S)| \\geq N - N_0 + 1 = T^2 - N_0 + 1$. The helper bound $|\\text{sumset}(S)| \\cdot 2 \\leq |S|(|S|+1) \\leq (5N_0+126)(5N_0+127)$ then forces $2(4N_0+100)^2 + 2 \\leq (5N_0+126)(5N_0+127) + 2N_0$, which simplifies to $7N_0^2 + 333N_0 + 4000 \\leq 0$ — impossible for $N_0 \\geq 0$. The `nlinarith` tactic closes the proof.",
     "mathContext": "Proof by contradiction: set $T = 4N_0+100$, $N = T^2$, $s = |A \\cap [0,N]|$.\n\n(1) Sidon bound: $s \\leq \\sqrt{2N}+1 = T\\sqrt{2}+1 \\leq T + \\sqrt{T} + 1 \\leq 5N_0+126$.\n(2) Coverage: $|\\text{sumset}(A \\cap [0,N])| \\geq |[N_0, N]| = T^2 - N_0 + 1$.\n(3) Sumset bound: $|\\text{sumset}| \\cdot 2 \\leq s(s+1) \\leq (5N_0+126)(5N_0+127)$.\n(4) Combining: $2T^2 + 2 \\leq (5N_0+126)(5N_0+127) + 2N_0$.\n(5) Expanding with $T = 4N_0+100$: $32N_0^2 + 1600N_0 + 20002 \\leq 25N_0^2 + 1267N_0 + 16002$, i.e., $7N_0^2 + 333N_0 + 4000 \\leq 0$. Contradiction.",
     "significance": "key",
     "relatedConcepts": [
@@ -524,7 +524,7 @@
       "counting argument",
       "proof by contradiction",
       "nlinarith",
-      "Erd\u0151s #340 dependency"
+      "Erdős #340 dependency"
     ],
     "prerequisites": [
       "IsSidon",
@@ -542,8 +542,8 @@
       "endLine": 593
     },
     "type": "insight",
-    "title": "Part IX: The Conjecture Holds Trivially for \u2115",
-    "content": "Two proved theorems verify the Erd\u0151s-Tur\u00e1n conjecture for $\\mathbb{N}$. `nat_repFuncUnordered_unbounded`: for unordered representations, $r_{\\mathbb{N}}^{\\text{unord}}(2k+2) = k+2 > k$, so the function is unbounded. `erdos_turan_holds_for_nat`: since ordered $\\geq$ unordered ($r \\geq r^{\\text{unord}}$), the ordered count is also unbounded. These are trivial cases \u2014 the difficulty lies in adversarially constructed bases where the structure might conspire to keep $r_A(n)$ bounded.",
+    "title": "Part IX: The Conjecture Holds Trivially for ℕ",
+    "content": "Two proved theorems verify the Erdős-Turán conjecture for $\\mathbb{N}$. `nat_repFuncUnordered_unbounded`: for unordered representations, $r_{\\mathbb{N}}^{\\text{unord}}(2k+2) = k+2 > k$, so the function is unbounded. `erdos_turan_holds_for_nat`: since ordered $\\geq$ unordered ($r \\geq r^{\\text{unord}}$), the ordered count is also unbounded. These are trivial cases — the difficulty lies in adversarially constructed bases where the structure might conspire to keep $r_A(n)$ bounded.",
     "mathContext": "$r^{\\text{unord}}_{\\mathbb{N}}(2k+2) = (2k+2)/2 + 1 = k+2 > k$. Combined with $r_A(n) \\geq r_A^{\\text{unord}}(n)$: the ordered representation count for $\\mathbb{N}$ is also unbounded.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

All 9 annotations had `range.startLine` pointing at a Part banner or doc-comment line rather than the Lean declaration beneath it, so the resolver reported "No Lean construct found" (15/24 valid before).

Re-anchored each to its actual construct:

| annotation | → construct |
|---|---|
| rep-function | `def repFunc` (51) |
| asymptotic-basis | `def sumset` / `IsAsymptoticBasis` (65) |
| main-conjecture | `def erdos_turan_weak` (210) |
| main-conjecture-formal | weak+strong statements (210-224) |
| strong-form | `def erdos_turan_strong` (217) |
| problem-40 | `def erdos_28` (224) |
| partial-results-formal | `axiom grekos_lower_bound` (229) |
| examples-section | `def evens` (239) |
| sidon-connection | `theorem sidon_density_bound` (372) |

The three conjecture-statement annotations (main-conjecture, main-conjecture-formal, problem-40) previously all collided on banner lines; now each lands on a distinct def (`erdos_turan_weak`, the weak+strong span, `erdos_28`). Content unchanged. Resolver validates **24/24, 0 misaligned**.