### PR TITLE
Enrich hilbert-10-oq-01-oq-02: re-anchor 9 drifted annotations

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/annotations.json
@@ -28,8 +28,8 @@
     "id": "ann-imports-namespace",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 61,
-      "endLine": 90
+      "startLine": 89,
+      "endLine": 95
     },
     "type": "technique",
     "title": "Import Companion + Namespace",
@@ -48,7 +48,7 @@
     "id": "ann-rat-subset",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 91,
+      "startLine": 96,
       "endLine": 100
     },
     "type": "definition",
@@ -70,7 +70,7 @@
     "id": "ann-sigma1-def",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 101,
+      "startLine": 112,
       "endLine": 127
     },
     "type": "concept",
@@ -94,7 +94,7 @@
     "id": "ann-pi2-def",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 128,
+      "startLine": 138,
       "endLine": 151
     },
     "type": "concept",
@@ -118,7 +118,7 @@
     "id": "ann-containment",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 152,
+      "startLine": 164,
       "endLine": 182
     },
     "type": "insight",
@@ -139,7 +139,7 @@
     "id": "ann-h10q-consequence",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 183,
+      "startLine": 190,
       "endLine": 206
     },
     "type": "insight",
@@ -184,7 +184,7 @@
     "id": "ann-pi1-duality",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 212,
+      "startLine": 225,
       "endLine": 291
     },
     "type": "concept",
@@ -206,7 +206,7 @@
     "id": "ann-sigma2-pi1",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 292,
+      "startLine": 309,
       "endLine": 342
     },
     "type": "concept",
@@ -252,7 +252,7 @@
     "id": "ann-sec9-sigma1-pi1-closure-grid",
     "proofId": "hilbert-10-oq-01-oq-02",
     "range": {
-      "startLine": 468,
+      "startLine": 484,
       "endLine": 1840
     },
     "type": "theorem",


### PR DESCRIPTION
## Enrichment pass — banner-anchored drift fix

All 9 annotations had `range.startLine` pointing at a Part banner or the import block rather than the Lean declaration beneath it, so the resolver reported "No Lean construct found" (5/14 valid before).

Re-anchored each to its actual construct:

| annotation | → construct |
|---|---|
| ann-imports-namespace | `namespace Hilbert10Rationals` (89) |
| ann-rat-subset | `abbrev RatSubset` (96) |
| ann-sigma1-def | `def IsDiophantineDefinition` (112) |
| ann-pi2-def | `def IsUniversalExistentialDefinition` (138) |
| ann-containment | `theorem diophantine_implies_universal_existential` (164) |
| ann-h10q-consequence | `theorem integers_diophantine_sigma1_implies_h10_q_undecidable` (190) |
| ann-pi1-duality | `def IsCoDiophantineDefinition` (225) |
| ann-sigma2-pi1 | `def IsExistentialUniversalDefinition` (309) |
| ann-sec9-sigma1-pi1-closure-grid | `theorem codiophantine_iff_diophantine_complement` (484) |

Content unchanged. Resolver validates **14/14, 0 misaligned**.