### PR TITLE
Enrich erdos-1039: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-1039/annotations.json
+++ b/src/data/proofs/erdos-1039/annotations.json
@@ -269,8 +269,8 @@
     "id": "ann-1039-klrbetter",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 100,
-      "endLine": 104
+      "startLine": 107,
+      "endLine": 109
     },
     "type": "concept",
     "title": "klr_better_than_pommerenke",
@@ -291,8 +291,8 @@
     "id": "ann-1039-conjecture",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 110,
-      "endLine": 113
+      "startLine": 143,
+      "endLine": 154
     },
     "type": "definition",
     "title": "ehpConjecture",
@@ -333,8 +333,8 @@
     "id": "ann-1039-pombound",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 123,
-      "endLine": 125
+      "startLine": 155,
+      "endLine": 158
     },
     "type": "definition",
     "title": "pommerenkeBound",
@@ -353,8 +353,8 @@
     "id": "ann-1039-klrbound",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 127,
-      "endLine": 129
+      "startLine": 159,
+      "endLine": 162
     },
     "type": "definition",
     "title": "klrBound",
@@ -374,8 +374,8 @@
     "id": "ann-1039-conjbound",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 131,
-      "endLine": 133
+      "startLine": 163,
+      "endLine": 166
     },
     "type": "definition",
     "title": "conjecturedBound",
@@ -392,8 +392,8 @@
     "id": "ann-1039-benchbound",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 135,
-      "endLine": 137
+      "startLine": 167,
+      "endLine": 170
     },
     "type": "definition",
     "title": "benchmarkBound",
@@ -499,8 +499,8 @@
     "id": "ann-1039-rootin",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 161,
-      "endLine": 164
+      "startLine": 208,
+      "endLine": 215
     },
     "type": "concept",
     "title": "root_in_sublevelSet",
@@ -690,8 +690,8 @@
     "id": "ann-1039-state",
     "proofId": "erdos-1039",
     "range": {
-      "startLine": 219,
-      "endLine": 231
+      "startLine": 274,
+      "endLine": 285
     },
     "type": "concept",
     "title": "erdos_1039_current_state",


### PR DESCRIPTION
## Enrichment pass — annotation drift fix

The annotation set had shifted out of alignment: 3 annotations landed on section banners / blank lines ("No Lean construct found") and 5 `definition`-typed annotations landed on theorems (type mismatch). Each annotation's title names its exact target construct, so re-anchoring by title is unambiguous:

| annotation | → construct |
|---|---|
| ann-1039-klrbetter | `theorem klr_better_than_pommerenke` (107) |
| ann-1039-conjecture | `def ehpConjecture` (143) |
| ann-1039-pombound | `def pommerenkeBound` (155) |
| ann-1039-klrbound | `def klrBound` (159) |
| ann-1039-conjbound | `def conjecturedBound` (163) |
| ann-1039-benchbound | `def benchmarkBound` (167) |
| ann-1039-rootin | `theorem root_in_sublevelSet` (208) |
| ann-1039-state | `theorem erdos_1039_current_state` (274) |

Content unchanged. Resolver validates **33/33, 0 misaligned**.