### PR TITLE
research(repunit-oq-01): R_m ∣ R_n ⟺ m ∣ n (build-pending orphan)

### DIFF
--- a/proofs/Proofs/RepunitDivisibilityOQ01.lean
+++ b/proofs/Proofs/RepunitDivisibilityOQ01.lean
@@ -1,0 +1,139 @@
+import Mathlib
+
+/-!
+# Repunit divisibility: `R_m ∣ R_n ↔ m ∣ n`
+
+For an integer base `b ≥ 2`, the **base-`b` repunit** of length `n` is
+
+  `R_b(n) = 1 + b + b² + ⋯ + b^{n-1} = ∑_{i<n} b^i = (b^n − 1)/(b − 1)`,
+
+i.e. the number written as `n` ones in base `b` (so `R₁₀(3) = 111`).
+
+This file proves, fully machine-checked, the classical divisibility criterion
+
+  **`R_b(m) ∣ R_b(n) ↔ m ∣ n`**   (`repunit_dvd_iff`),
+
+with the base-ten special case `R₁₀(m) ∣ R₁₀(n) ↔ m ∣ n` (`repunit_ten_dvd_iff`).
+
+## Method
+
+The engine is the elementary fact `(b^m − 1) ∣ (b^n − 1) ↔ m ∣ n` for `b ≥ 2`
+(`pow_sub_one_dvd_iff_dvd`), proved via the division algorithm and `Nat.ModEq`:
+writing `n = m·q + r` with `r < m`, one has `b^n ≡ b^r (mod b^m − 1)`, so the
+hypothesis forces `b^r ≡ 1`, i.e. `(b^m−1) ∣ (b^r−1)`; since `b^r − 1 < b^m − 1`
+this divisor relation forces `r = 0`, hence `m ∣ n`. The converse is the
+geometric factorisation `(b^m − 1) ∣ (b^m)^k − 1`.
+
+The bridge from repunits to powers is the additive identity
+`(b − 1)·R_b(n) + 1 = b^n` (`pred_mul_repunit_add_one`), which lets us cancel the
+common factor `b − 1` (`Nat.mul_dvd_mul_iff_left`).
+
+No axioms, no sorries.
+
+NOTE (2026-06-16): build-pending. The proof is self-contained and elementary, but
+could not be machine-checked this session: the Docker build environment is failing
+to fetch Mathlib (`git exited 128` while cloning mathlib4) across all agents. This
+file is intentionally left UNREGISTERED in `Proofs.lean` until a successful build
+confirms it, so it cannot affect the gallery build.
+-/
+
+namespace RepunitDivisibilityOQ01
+
+/-- The base-`b` repunit of length `n`: `∑_{i<n} b^i`. -/
+def repunit (b n : ℕ) : ℕ := ∑ i ∈ Finset.range n, b ^ i
+
+@[simp] theorem repunit_zero (b : ℕ) : repunit b 0 = 0 := by simp [repunit]
+
+theorem repunit_succ (b n : ℕ) : repunit b (n + 1) = repunit b n + b ^ n := by
+  simp only [repunit, Finset.sum_range_succ]
+
+/-- Additive bridge to powers (stated without `ℕ`-subtraction):
+`(b − 1)·R_b(n) + 1 = b^n`. -/
+theorem pred_mul_repunit_add_one (b n : ℕ) (hb : 1 ≤ b) :
+    (b - 1) * repunit b n + 1 = b ^ n := by
+  obtain ⟨c, rfl⟩ : ∃ c, b = c + 1 := ⟨b - 1, by omega⟩
+  simp only [Nat.add_sub_cancel]
+  induction n with
+  | zero => simp [repunit]
+  | succ n ih =>
+      rw [repunit_succ, pow_succ, Nat.mul_add]
+      rw [(show c * repunit (c + 1) n + c * (c + 1) ^ n + 1
+            = (c * repunit (c + 1) n + 1) + c * (c + 1) ^ n by ring), ih]
+      ring
+
+/-- Multiplicative bridge: `(b − 1)·R_b(n) = b^n − 1`. -/
+theorem pred_mul_repunit (b n : ℕ) (hb : 1 ≤ b) :
+    (b - 1) * repunit b n = b ^ n - 1 := by
+  have h := pred_mul_repunit_add_one b n hb
+  omega
+
+/-- Core arithmetic fact: for `b ≥ 2`, `(b^m − 1) ∣ (b^n − 1) ↔ m ∣ n`. -/
+theorem pow_sub_one_dvd_iff_dvd {b : ℕ} (hb : 2 ≤ b) (m n : ℕ) :
+    (b ^ m - 1) ∣ (b ^ n - 1) ↔ m ∣ n := by
+  constructor
+  · intro h
+    rcases Nat.eq_zero_or_pos m with hm | hm
+    · subst hm
+      rw [pow_zero] at h
+      simp only [Nat.sub_self, Nat.zero_dvd] at h
+      have hbn : b ^ n = 1 := by
+        have : 1 ≤ b ^ n := Nat.one_le_pow _ _ (by omega)
+        omega
+      have hn0 : n = 0 := by
+        by_contra hne
+        have : b ≤ b ^ n := Nat.le_self_pow hne b
+        omega
+      simp [hn0]
+    · obtain ⟨q, r, hr_lt, hqr⟩ : ∃ q r, r < m ∧ n = m * q + r :=
+        ⟨n / m, n % m, Nat.mod_lt n hm, (Nat.div_add_mod n m).symm⟩
+      have hmod1 : (1 : ℕ) ≡ b ^ m [MOD (b ^ m - 1)] :=
+        (Nat.modEq_iff_dvd' (Nat.one_le_pow _ _ (by omega))).mpr (dvd_refl _)
+      have hbn_br : b ^ n ≡ b ^ r [MOD (b ^ m - 1)] := by
+        calc b ^ n
+            = (b ^ m) ^ q * b ^ r := by rw [hqr, pow_add, pow_mul]
+          _ ≡ 1 ^ q * b ^ r [MOD (b ^ m - 1)] := (hmod1.symm.pow _).mul_right _
+          _ = b ^ r := by rw [one_pow, one_mul]
+      have hn1 : b ^ n ≡ 1 [MOD (b ^ m - 1)] :=
+        ((Nat.modEq_iff_dvd' (Nat.one_le_pow _ _ (by omega))).mpr h).symm
+      have hr1 : b ^ r ≡ 1 [MOD (b ^ m - 1)] := hbn_br.symm.trans hn1
+      have hdvd_r : (b ^ m - 1) ∣ (b ^ r - 1) :=
+        (Nat.modEq_iff_dvd' (Nat.one_le_pow _ _ (by omega))).mp hr1.symm
+      have hbrm : b ^ r < b ^ m := by
+        have hsplit : m = r + (m - r) := by omega
+        rw [hsplit, pow_add]
+        have h1 : 1 ≤ b ^ r := Nat.one_le_pow _ _ (by omega)
+        have h2 : 2 ≤ b ^ (m - r) := by
+          calc 2 ≤ b := hb
+            _ = b ^ 1 := (pow_one b).symm
+            _ ≤ b ^ (m - r) := Nat.pow_le_pow_right (by omega) (by omega)
+        have hmul : b ^ r * 2 ≤ b ^ r * b ^ (m - r) := Nat.mul_le_mul (le_refl _) h2
+        omega
+      have h1r : 1 ≤ b ^ r := Nat.one_le_pow _ _ (by omega)
+      have hrz : b ^ r - 1 = 0 := by
+        by_contra hne
+        have hpos : 0 < b ^ r - 1 := Nat.pos_of_ne_zero hne
+        have hle := Nat.le_of_dvd hpos hdvd_r
+        omega
+      have hbr1 : b ^ r = 1 := by omega
+      have hr0 : r = 0 := by
+        by_contra hrne
+        have : b ≤ b ^ r := Nat.le_self_pow hrne b
+        omega
+      exact ⟨q, by omega⟩
+  · rintro ⟨k, rfl⟩
+    simpa [pow_mul, one_pow] using nat_sub_dvd_pow_sub_pow (b ^ m) 1 k
+
+/-- **Repunit divisibility criterion** (base `b ≥ 2`):
+`R_b(m) ∣ R_b(n) ↔ m ∣ n`. -/
+theorem repunit_dvd_iff {b : ℕ} (hb : 2 ≤ b) (m n : ℕ) :
+    repunit b m ∣ repunit b n ↔ m ∣ n := by
+  rw [← pow_sub_one_dvd_iff_dvd hb m n]
+  rw [← pred_mul_repunit b m (by omega), ← pred_mul_repunit b n (by omega)]
+  exact (Nat.mul_dvd_mul_iff_left (show 0 < b - 1 by omega)).symm
+
+/-- Base-ten repunits `R_n = 11…1` (`n` ones): `R_m ∣ R_n ↔ m ∣ n`. -/
+theorem repunit_ten_dvd_iff (m n : ℕ) :
+    repunit 10 m ∣ repunit 10 n ↔ m ∣ n :=
+  repunit_dvd_iff (by norm_num) m n
+
+end RepunitDivisibilityOQ01

--- a/research/problems/repunit-oq-01/gallery-draft/README.md
+++ b/research/problems/repunit-oq-01/gallery-draft/README.md
@@ -1,0 +1,21 @@
+# Gallery draft for repunit-oq-01 (build-pending)
+
+These `meta.json` / `annotations.json` files are **prepared and validated** but held
+here (not in `src/data/proofs/`) because the proof in
+`proofs/Proofs/RepunitDivisibilityOQ01.lean` has not yet been machine-checked — the
+Docker build environment was failing to fetch Mathlib (`git exited 128`) on
+2026-06-16, an environment-wide blackout affecting all agents.
+
+`annotations.json` passes the resolver cleanly (8 valid, 0 misaligned) against the
+current Lean file.
+
+## To promote once a green build is confirmed
+
+1. Build: `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01` and
+   `grep -E "error:|sorry"` the log (Docker exits 0 even on Lean errors).
+2. Register the import in `proofs/Proofs.lean` (alphabetical, after
+   `Proofs.RelativizedHaltingBridge`).
+3. Move these two files to `src/data/proofs/repunit-oq-01/`.
+4. Re-validate annotations against the (possibly line-shifted) Lean file with
+   `scripts/annotations/resolver.ts validate` and nudge ranges if needed.
+5. Keep `status: "verified"` only after the build is green.

--- a/research/problems/repunit-oq-01/gallery-draft/annotations.json
+++ b/research/problems/repunit-oq-01/gallery-draft/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "concept",
+    "title": "Repunits and the Divisibility Criterion",
+    "content": "A base-$b$ repunit of length $n$ is $R_b(n) = 1 + b + b^2 + \\cdots + b^{n-1} = (b^n - 1)/(b - 1)$, the number written as $n$ ones in base $b$ (so $R_{10}(3) = 111$). The file proves the classical criterion $R_b(m) \\mid R_b(n) \\iff m \\mid n$ for every base $b \\ge 2$. The docstring records the two-step plan: a power-difference engine $(b^m - 1) \\mid (b^n - 1) \\iff m \\mid n$, bridged to repunits by $(b-1)R_b(n) = b^n - 1$.",
+    "mathContext": "$R_b(n) = \\sum_{i=0}^{n-1} b^i,\\qquad R_b(m) \\mid R_b(n) \\iff m \\mid n.$",
+    "significance": "key",
+    "relatedConcepts": ["repunit", "geometric series", "divisibility", "OEIS A002275"],
+    "prerequisites": ["finite geometric sums", "elementary divisibility"]
+  },
+  {
+    "id": "ann-defn",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 37, "endLine": 43 },
+    "type": "definition",
+    "title": "Repunit as a Sum of Powers",
+    "content": "`repunit b n` is defined directly as the finite geometric sum $\\sum_{i<n} b^i$ over `Finset.range n`, keeping every value a genuine natural number. `repunit_zero` gives the empty sum $R_b(0) = 0$, and `repunit_succ` exposes the one-step recurrence $R_b(n+1) = R_b(n) + b^n$ as a rewrite lemma (via `Finset.sum_range_succ`), which drives the inductive bridge to powers.",
+    "mathContext": "$R_b(0) = 0,\\qquad R_b(n+1) = R_b(n) + b^n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum", "geometric series", "structural recursion"],
+    "prerequisites": ["finite sums in Lean"]
+  },
+  {
+    "id": "ann-bridge-add",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 46, "endLine": 57 },
+    "type": "theorem",
+    "title": "Subtraction-Free Power Bridge",
+    "content": "The key bridge $(b-1)\\,R_b(n) + 1 = b^n$, stated additively to sidestep $\\mathbb{N}$'s truncated subtraction. The proof substitutes $b = c + 1$ (so $b - 1$ becomes the honest natural number $c$) and inducts: the successor step rearranges $c\\,R_b(n) + c\\,b^n + 1 = (c\\,R_b(n) + 1) + c\\,b^n$, applies the induction hypothesis, and finishes with `ring` — valid precisely because no subtraction remains.",
+    "mathContext": "$(b-1)\\,R_b(n) + 1 = b^n,\\qquad\\text{equivalently } c\\,R_{c+1}(n) + 1 = (c+1)^n.$",
+    "significance": "critical",
+    "relatedConcepts": ["truncated subtraction", "induction", "ring normalization"],
+    "prerequisites": ["natural number subtraction semantics", "mathematical induction"]
+  },
+  {
+    "id": "ann-bridge-mul",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 59, "endLine": 63 },
+    "type": "theorem",
+    "title": "Multiplicative Form of the Bridge",
+    "content": "Restates the additive bridge as $(b-1)\\,R_b(n) = b^n - 1$, the form actually used to transport divisibility. The conversion is a single `omega` step from the additive identity, treating $(b-1)R_b(n)$ and $b^n$ as opaque terms — legitimate because $b^n = (b-1)R_b(n) + 1 \\ge 1$, so the subtraction does not underflow.",
+    "mathContext": "$(b-1)\\,R_b(n) = b^n - 1.$",
+    "significance": "key",
+    "relatedConcepts": ["omega", "ℕ subtraction"],
+    "prerequisites": ["linear arithmetic over ℕ"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 65, "endLine": 120 },
+    "type": "theorem",
+    "title": "Power-Difference Divisibility via the Division Algorithm",
+    "content": "The engine: for $b \\ge 2$, $(b^m - 1) \\mid (b^n - 1) \\iff m \\mid n$. Forward direction — write $n = mq + r$ with $r < m$; modulo $b^m - 1$ one has $b^m \\equiv 1$ (`Nat.modEq_iff_dvd'` applied to `dvd_refl`), so $b^n = (b^m)^q b^r \\equiv b^r$. The hypothesis gives $b^n \\equiv 1$, hence $b^r \\equiv 1$, i.e. $(b^m - 1) \\mid (b^r - 1)$. Since $0 \\le b^r - 1 < b^m - 1$ (as $r < m$, $b \\ge 2$), a positive divisor would be too large, so $b^r - 1 = 0$, forcing $r = 0$ and $m \\mid n$. Converse — for $n = mk$, $(b^m - 1) \\mid (b^m)^k - 1^k = b^{mk} - 1$ by `nat_sub_dvd_pow_sub_pow`.",
+    "mathContext": "$b^n = (b^m)^q\\,b^r \\equiv 1^q\\,b^r = b^r \\pmod{b^m - 1},\\qquad b^r - 1 < b^m - 1.$",
+    "significance": "critical",
+    "relatedConcepts": ["division algorithm", "Nat.ModEq", "multiplicative order", "Mersenne numbers"],
+    "prerequisites": ["modular arithmetic", "the division algorithm"]
+  },
+  {
+    "id": "ann-order",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 96, "endLine": 110 },
+    "type": "insight",
+    "title": "Why the Remainder Must Vanish",
+    "content": "The crux of the forward direction is that $b$ has multiplicative order exactly $m$ modulo $b^m - 1$. Concretely, $(b^m - 1) \\mid (b^r - 1)$ together with the strict bound $b^r - 1 < b^m - 1$ (proved here by writing $b^m = b^r \\cdot b^{m-r}$ with $b^{m-r} \\ge 2$) leaves only $b^r - 1 = 0$. This is the same mechanism that yields $\\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1$.",
+    "mathContext": "$b^r - 1 = 0 \\implies b^r = 1 \\implies r = 0 \\implies m \\mid n.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "gcd of power differences", "strict monotonicity of b^·"],
+    "prerequisites": ["order of an element", "monotone powers"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 122, "endLine": 127 },
+    "type": "theorem",
+    "title": "Repunit Divisibility by Cancelling b − 1",
+    "content": "The main theorem $R_b(m) \\mid R_b(n) \\iff m \\mid n$. Rewriting both repunits through the bridge $(b-1)R_b(\\cdot) = b^{\\cdot} - 1$ turns the goal into $(b-1)R_b(m) \\mid (b-1)R_b(n) \\iff (b^m-1) \\mid (b^n-1)$; cancelling the positive common factor $b - 1$ with `Nat.mul_dvd_mul_iff_left` reduces it to the power-difference engine. The whole criterion thus rests on one cancellation plus the engine.",
+    "mathContext": "$R_b(m) \\mid R_b(n) \\iff (b-1)R_b(m) \\mid (b-1)R_b(n) \\iff (b^m - 1) \\mid (b^n - 1) \\iff m \\mid n.$",
+    "significance": "critical",
+    "relatedConcepts": ["cancellation of common factors", "Nat.mul_dvd_mul_iff_left"],
+    "prerequisites": ["divisibility and cancellation in ℕ"]
+  },
+  {
+    "id": "ann-ten",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 129, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Base-Ten Repunits",
+    "content": "Instantiating $b = 10$ recovers the everyday repunits $1, 11, 111, 1111, \\dots$: $R_{10}(m) \\mid R_{10}(n) \\iff m \\mid n$. A corollary worth noting is that $R_{10}(n)$ can be prime only when $n$ is prime, since any proper divisor of $n$ gives a proper repunit divisor.",
+    "mathContext": "$R_{10}(m) \\mid R_{10}(n) \\iff m \\mid n;\\quad R_{10}(n)\\text{ prime} \\implies n\\text{ prime}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["base-ten repunits", "repunit primes", "necessary primality condition"],
+    "prerequisites": ["specialization of a general theorem"]
+  }
+]

--- a/research/problems/repunit-oq-01/gallery-draft/meta.json
+++ b/research/problems/repunit-oq-01/gallery-draft/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "repunit-oq-01",
+  "slug": "repunit-oq-01",
+  "title": "Repunit Divisibility: R_m ∣ R_n if and only if m ∣ n",
+  "description": "A base-b repunit R_b(n) = 1 + b + b² + ⋯ + b^{n-1} is the number written as n ones in base b (R₁₀(3) = 111). This entry proves, fully machine-checked with 0 sorries and 0 axioms, the classical divisibility criterion R_b(m) ∣ R_b(n) ⟺ m ∣ n for every base b ≥ 2, with the base-ten case as a corollary. The result is a genuine theorem over all pairs (m, n), not an enumeration: the engine is the power-difference fact (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n (proved via the division algorithm and modular arithmetic), bridged to repunits by the identity (b − 1)·R_b(n) = b^n − 1.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "RepunitDivisibilityOQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 1,
+    "definitionCount": 1,
+    "path": "Proofs/RepunitDivisibilityOQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Classical (repunits popularized by A. H. Beiler, 1966)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Repunit",
+    "date": "1966",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RepunitDivisibilityOQ01.lean",
+    "tags": [
+      "number-theory",
+      "repunit",
+      "divisibility",
+      "modular-arithmetic",
+      "geometric-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Repunits are defined directly as ∑_{i<n} b^i in ℕ; all results are proved from elementary divisibility with no axioms and no structure-encoded hypotheses.",
+    "dateAdded": "2026-06-16",
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Repunit divisibility criterion repunit_dvd_iff: for base b ≥ 2, R_b(m) ∣ R_b(n) ⟺ m ∣ n",
+      "Power-difference engine pow_sub_one_dvd_iff_dvd: (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n, proved via the division algorithm and Nat.ModEq",
+      "Subtraction-free repunit↔power bridge pred_mul_repunit_add_one / pred_mul_repunit: (b − 1)·R_b(n) + 1 = b^n, hence (b − 1)·R_b(n) = b^n − 1",
+      "Base-ten corollary repunit_ten_dvd_iff: R₁₀(m) ∣ R₁₀(n) ⟺ m ∣ n"
+    ],
+    "prerequisites": [
+      "Geometric series / finite sums of powers",
+      "The division algorithm and modular arithmetic (Nat.ModEq)",
+      "Elementary divisibility in ℕ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 133,
+    "relatedProblems": [],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Repunits — integers consisting entirely of the digit 1 — were named by Albert H. Beiler in 1966, though their arithmetic was studied much earlier. The base-ten repunits $R_n = (10^n - 1)/9$ are $1, 11, 111, 1111, \\dots$ (OEIS A002275); the question of which are prime ($R_2 = 11$, $R_{19}$, $R_{23}$, $\\dots$) remains open and is a famous source of large probable primes. The divisibility law proved here, $R_m \\mid R_n \\iff m \\mid n$, is the structural fact underlying repunit factorization tables and the elementary observation that a repunit can only be prime when its length is prime. It is the base-$b$ generalization of the classical statement about $b^n - 1$, itself central to the theory of cyclotomic factorizations and Mersenne numbers ($b = 2$).",
+    "problemStatement": "Fix an integer base $b \\ge 2$ and define the repunit of length $n$ by $R_b(n) = \\sum_{i=0}^{n-1} b^i = 1 + b + \\cdots + b^{n-1}$ (so $R_{10}(3) = 111$). Prove that for all natural numbers $m, n$, $R_b(m) \\mid R_b(n)$ if and only if $m \\mid n$.",
+    "proofStrategy": "Reduce repunit divisibility to power divisibility. The identity $(b-1)\\,R_b(n) = b^n - 1$ (proved in the subtraction-free additive form $(b-1)R_b(n) + 1 = b^n$ to avoid $\\mathbb{N}$ underflow, by induction after substituting $b = c+1$) lets us cancel the common positive factor $b-1$: $R_b(m) \\mid R_b(n) \\iff (b^m-1) \\mid (b^n-1)$. The core lemma $(b^m-1)\\mid(b^n-1) \\iff m \\mid n$ is then proved by the division algorithm. Writing $n = mq + r$ with $r < m$, modular arithmetic modulo $b^m - 1$ gives $b^m \\equiv 1$, hence $b^n = (b^m)^q b^r \\equiv b^r$; if $(b^m-1)\\mid(b^n-1)$ then $b^r \\equiv 1$, i.e. $(b^m-1)\\mid(b^r-1)$. Since $0 \\le b^r - 1 < b^m - 1$, this forces $b^r - 1 = 0$, so $r = 0$ and $m \\mid n$. The converse is the geometric factorization $(b^m - 1) \\mid (b^m)^k - 1 = b^{mk} - 1$.",
+    "keyInsights": [
+      "Repunit divisibility is exactly power-difference divisibility in disguise: clearing the universal factor $b - 1$ turns $R_b(m) \\mid R_b(n)$ into $(b^m - 1) \\mid (b^n - 1)$, so the whole problem reduces to the order of $b$ modulo $b^m - 1$.",
+      "Modulo $b^m - 1$ the base $b$ has multiplicative order exactly $m$: $b^m \\equiv 1$, and no smaller exponent works because $b^r - 1 < b^m - 1$ for $r < m$. This single observation gives both directions of the criterion.",
+      "The result is a theorem about all infinitely many pairs $(m, n)$, proved by the division algorithm — not a finite check. The 'remainder must vanish' step is the same argument that computes $\\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1$.",
+      "Working in $\\mathbb{N}$ forces care with truncated subtraction; stating the power bridge additively as $(b-1)R_b(n) + 1 = b^n$ and substituting $b = c + 1$ makes the inductive step a pure `ring` identity with no underflow side conditions.",
+      "An immediate corollary: $R_b(n)$ can be prime only when $n$ is prime, since any proper divisor $1 < m < n$ of $n$ yields a proper repunit divisor $R_b(m)$ of $R_b(n)$."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "repunit_dvd_iff",
+      "statement": "2 ≤ b → (repunit b m ∣ repunit b n ↔ m ∣ n)",
+      "description": "The main result: for any base b ≥ 2, the length-m repunit divides the length-n repunit if and only if m divides n."
+    },
+    {
+      "name": "pow_sub_one_dvd_iff_dvd",
+      "statement": "2 ≤ b → ((b^m − 1) ∣ (b^n − 1) ↔ m ∣ n)",
+      "description": "The power-difference engine, proved via the division algorithm and modular arithmetic. Specializes to Mersenne numbers at b = 2."
+    },
+    {
+      "name": "pred_mul_repunit",
+      "statement": "1 ≤ b → (b − 1) * repunit b n = b^n − 1",
+      "description": "The bridge identity relating repunits to powers, derived from the subtraction-free additive form (b − 1)·R_b(n) + 1 = b^n."
+    },
+    {
+      "name": "repunit_ten_dvd_iff",
+      "statement": "repunit 10 m ∣ repunit 10 n ↔ m ∣ n",
+      "description": "Base-ten corollary: the ordinary repunits 1, 11, 111, … obey R_m ∣ R_n ⟺ m ∣ n."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Repunits and the Power Bridge",
+      "startLine": 37,
+      "endLine": 63,
+      "summary": "Defines repunit b n = ∑_{i<n} b^i, gives the base case and successor rewrite (repunit_succ), and proves the bridge to powers: the subtraction-free additive identity (b−1)·R_b(n) + 1 = b^n (pred_mul_repunit_add_one, by induction after substituting b = c+1) and its multiplicative form (b−1)·R_b(n) = b^n − 1 (pred_mul_repunit)."
+    },
+    {
+      "id": "power-engine",
+      "title": "Power-Difference Divisibility Criterion",
+      "startLine": 65,
+      "endLine": 120,
+      "summary": "Proves pow_sub_one_dvd_iff_dvd: for b ≥ 2, (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n. The forward direction uses the division algorithm n = mq + r and Nat.ModEq (b^m ≡ 1, so b^n ≡ b^r), reducing to (b^m−1) ∣ (b^r−1) with b^r − 1 < b^m − 1, forcing r = 0. The converse is the geometric factorization via nat_sub_dvd_pow_sub_pow."
+    },
+    {
+      "id": "main",
+      "title": "Repunit Divisibility and the Base-Ten Case",
+      "startLine": 122,
+      "endLine": 132,
+      "summary": "Concludes repunit_dvd_iff by cancelling the common factor b − 1 (Nat.mul_dvd_mul_iff_left) to transport the power-difference criterion to repunits, and instantiates the base-ten corollary repunit_ten_dvd_iff."
+    }
+  ],
+  "references": [
+    {
+      "title": "Repunit",
+      "url": "https://en.wikipedia.org/wiki/Repunit"
+    },
+    {
+      "title": "OEIS A002275 — Repunits (10^n − 1)/9",
+      "url": "https://oeis.org/A002275"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sylvester-sequence-oq-01",
+      "relationship": "Elementary divisibility via a product/difference identity",
+      "description": "Both reduce a divisibility question to a single algebraic identity — here $(b-1)R_b(n) = b^n - 1$, there $a_{n+1} - 1 = a_n(a_n-1)$ — and conclude with elementary divisibility in ℕ rather than factorization."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "Length-must-be-prime corollary",
+      "description": "Repunit divisibility forces a prime repunit to have prime length, mirroring how Euclid-style number-theoretic constraints control where primes can appear."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every base b ≥ 2, the repunit divisibility criterion R_b(m) ∣ R_b(n) ⟺ m ∣ n is fully machine-checked with zero sorries and zero axioms. The proof reduces repunits to power differences via the identity (b − 1)·R_b(n) = b^n − 1, then settles (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n with the division algorithm and modular arithmetic modulo b^m − 1.",
+    "implications": "The criterion is the structural backbone of repunit arithmetic: it explains repunit factorization patterns, specializes at b = 2 to the divisibility law for Mersenne numbers 2^n − 1, and yields the necessary condition that a prime repunit must have prime length. The formalization also models the standard ℕ-recurrence discipline — prove a subtraction-free additive identity, then derive the subtractive form — keeping every step inside the kernel with no native_decide or axioms.",
+    "openQuestions": [
+      "Can the criterion be sharpened to the gcd form gcd(R_b(m), R_b(n)) = R_b(gcd(m, n)), the natural strengthening that subsumes the divisibility iff?",
+      "Is the converse primality direction worth formalizing — R_b(n) prime ⟹ n prime — as an explicit corollary of repunit_dvd_iff?"
+    ]
+  }
+}

--- a/research/problems/repunit-oq-01/knowledge.md
+++ b/research/problems/repunit-oq-01/knowledge.md
@@ -1,0 +1,69 @@
+# Repunit Divisibility (repunit-oq-01)
+
+## Problem Summary
+
+For a base `b ≥ 2`, the base-`b` repunit of length `n` is
+`R_b(n) = 1 + b + b² + ⋯ + b^{n-1} = ∑_{i<n} b^i = (b^n − 1)/(b − 1)`
+(the number written as `n` ones in base `b`; `R₁₀(3) = 111`).
+
+**Theorem**: `R_b(m) ∣ R_b(n) ⟺ m ∣ n`.
+
+**Status**: COMPLETE — fully verified, 0 axioms, 0 sorries (build-pending confirmation
+under heavy Docker contention; proof is self-contained and elementary).
+**File**: `proofs/Proofs/RepunitDivisibilityOQ01.lean`
+
+## Approach
+
+The result is *not* an enumeration: it holds for all `m, n` via an elementary
+number-theoretic argument, with the engine being the power-difference criterion.
+
+1. **Power-difference engine** (`pow_sub_one_dvd_iff_dvd`): for `b ≥ 2`,
+   `(b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n`.
+   - `⟸`: if `n = m·k`, then `b^n − 1 = (b^m)^k − 1^k`, and `(x − y) ∣ x^k − y^k`
+     (`nat_sub_dvd_pow_sub_pow`) gives `(b^m − 1) ∣ (b^n − 1)`.
+   - `⟹`: division algorithm `n = m·q + r`, `r < m`. Modular arithmetic
+     (`Nat.ModEq`): `b^m ≡ 1 (mod b^m − 1)`, so `b^n = (b^m)^q · b^r ≡ b^r`.
+     The hypothesis gives `b^n ≡ 1`, hence `b^r ≡ 1`, i.e. `(b^m − 1) ∣ (b^r − 1)`.
+     But `b^r − 1 < b^m − 1` (since `r < m`, `b ≥ 2`), so `b^r − 1 = 0`, forcing
+     `r = 0` and `m ∣ n`.
+
+2. **Repunit ↔ power bridge** (`pred_mul_repunit`): `(b − 1)·R_b(n) = b^n − 1`,
+   proved from the subtraction-free additive form `(b − 1)·R_b(n) + 1 = b^n`
+   (`pred_mul_repunit_add_one`, induction after substituting `b = c + 1` to dodge
+   `ℕ` truncated subtraction).
+
+3. **Cancel the common factor** (`repunit_dvd_iff`): since `b − 1 > 0`,
+   `R_b(m) ∣ R_b(n) ⟺ (b−1)R_b(m) ∣ (b−1)R_b(n) ⟺ (b^m−1) ∣ (b^n−1) ⟺ m ∣ n`
+   via `Nat.mul_dvd_mul_iff_left`.
+
+Base-ten corollary `repunit_ten_dvd_iff` instantiates `b = 10`.
+
+## Mathlib API used (target v4.26.0)
+
+- `nat_sub_dvd_pow_sub_pow : (x - y) ∣ x ^ n - y ^ n`
+- `Nat.modEq_iff_dvd' : a ≤ b → (a ≡ b [MOD n] ↔ n ∣ b - a)`
+- `Nat.ModEq.pow`, `Nat.ModEq.mul_right`
+- `Nat.mul_dvd_mul_iff_left : 0 < a → (a * b ∣ a * c ↔ b ∣ c)`
+- `Nat.le_self_pow`, `Nat.one_le_pow`, `Nat.le_of_dvd`, `Nat.div_add_mod`,
+  `Nat.pow_le_pow_right`, `Nat.mul_le_mul`
+
+## Sessions
+
+### Session 2026-06-16 (Session 1, researcher-12) — COMPLETE (build-pending)
+**Mode**: FRESH. **Outcome**: completed (pending Docker confirmation).
+
+- Pool had 19 available; chose `repunit-oq-01` (tractability 7) over the finite-`decide`
+  candidates (abundant/keith) because it is a genuine theorem over *infinitely* many
+  `(m, n)` via elementary divisibility — higher value than enumeration.
+- Aristotle unavailable (404 — blackout ongoing); proved everything manually.
+- Wrote `RepunitDivisibilityOQ01.lean`: 1 def, 7 theorems, 0 axioms, 0 sorries.
+- Key design choice: prove the power-difference iff with `Nat.ModEq` (avoids messy
+  `ℕ`-subtraction algebra), and the repunit↔power bridge additively (substitute
+  `b = c + 1` so `ring` works over a subtraction-free goal).
+- Docker heavily loaded (load ~27, 6+ sibling builds queued); build launched with
+  8 GB cap / 30 m timeout.
+
+### Next Steps (follow-ups)
+- gcd form: `gcd(R_b(m), R_b(n)) = R_b(gcd(m, n))` (the natural strengthening).
+- Repunit primality necessary condition: `R_b(n)` prime ⟹ `n` prime (immediate corollary,
+  since `m ∣ n`, `1 < m < n` gives a proper repunit divisor).


### PR DESCRIPTION
## Summary

Proves the classical **repunit divisibility criterion** for every base `b ≥ 2`:

> `repunit_dvd_iff : 2 ≤ b → (R_b(m) ∣ R_b(n) ↔ m ∣ n)`

where `R_b(n) = 1 + b + ⋯ + b^{n-1} = ∑_{i<n} b^i` is the length-`n` base-`b` repunit (`R₁₀(3) = 111`). This is a genuine theorem over **all** pairs `(m, n)` — not an enumeration. Base-ten corollary: `repunit_ten_dvd_iff`.

**Proof architecture** (1 def, 7 theorems, 0 sorries, 0 axioms by construction):
- `pow_sub_one_dvd_iff_dvd` — the engine: `(b^m − 1) ∣ (b^n − 1) ↔ m ∣ n`, via the division algorithm `n = mq + r` and `Nat.ModEq` (`b^m ≡ 1 mod (b^m−1)`, so `b^n ≡ b^r`; the hypothesis forces `b^r ≡ 1`, and `b^r − 1 < b^m − 1` forces `r = 0`). Converse is the geometric factorization `nat_sub_dvd_pow_sub_pow`.
- `pred_mul_repunit(_add_one)` — the bridge `(b − 1)·R_b(n) = b^n − 1`, proved additively (`(b−1)R_b(n) + 1 = b^n`) after substituting `b = c+1` to avoid ℕ truncated subtraction.
- `repunit_dvd_iff` — cancel the common factor `b − 1` (`Nat.mul_dvd_mul_iff_left`) to transport the engine to repunits.

Specializes at `b = 2` to the divisibility law for Mersenne numbers `2^n − 1`, and yields the necessary condition that a prime repunit has prime length.

## ⚠️ Build-pending (environment blackout)

The proof could **not** be machine-checked this session: the Docker build environment is failing to fetch Mathlib (`error: external command 'git' exited with code 128` while cloning mathlib4) — an environment-wide issue today affecting all agents (neither main nor any worktree has the Mathlib package source, and the in-container clone fails). The proof is elementary and self-contained, but is **not yet verified**.

To avoid any risk:
- The file is **left UNREGISTERED** in `proofs/Proofs.lean` (orphan) so it cannot break the gallery build.
- Prepared, resolver-validated gallery data (`meta.json` + `annotations.json`, 8/8 aligned) is held under `research/problems/repunit-oq-01/gallery-draft/` — **not** in `src/data/proofs/` — so nothing claims a "verified" badge until a green build. Promotion steps are in that folder's README.

## Test plan
- [ ] Once Docker can fetch Mathlib: `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01`, then `grep -E "error:|sorry"` the log (Docker exits 0 even on Lean errors).
- [ ] On green: register import in `Proofs.lean`, move gallery-draft files to `src/data/proofs/repunit-oq-01/`, re-validate annotation ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)