### PR TITLE
Enrich abel-ruffini-oq-04-oq-01: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
@@ -52,12 +52,12 @@
     "id": "ann-abeloq04oq01-int-helpers",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 109,
+      "startLine": 113,
       "endLine": 143
     },
     "type": "definition",
     "title": "\u2124[X] Helper Lemmas: Degree, NatDegree, Monic \u2014 Prerequisites for Eisenstein",
-    "content": "Three private lemmas establish the structural properties of `p_int` needed before the Eisenstein criterion can be applied.\n\n`p_int_degree` (line 113): Proves `p_int.degree = 5` by `compute_degree!` \u2014 a Lean tactic that normalizes polynomial degree computations. The result is needed because Eisenstein's criterion requires checking that the coefficient at position $k < \\deg(p)$ is in the prime ideal, which requires knowing $\\deg(p)$ concretely.\n\n`p_int_natDegree` (line 117): Proves `p_int.natDegree = 5`. Lean distinguishes between `degree : WithBot \u2115` (the additive value, with $\\deg(0) = -\\infty = \\bot$) and `natDegree : \u2115` (coercing $-\\infty$ to 0). The Eisenstein API uses `natDegree` for coefficient indices, so both are needed.\n\n`p_int_monic` (lines 121-129): Proves the leading coefficient of `p_int` equals 1 by unfolding the definition and using `norm_num`. Monicity is dual-purpose: it makes `p_int` primitive (GCD of all coefficients is 1, since the leading coefficient 1 is coprime to everything), which is the Eisenstein hypothesis; it also feeds into Gauss's lemma for the $\\mathbb{Z} \\to \\mathbb{Q}$ transfer.\n\nAll three proofs are fully computational \u2014 no mathematical insight required, just term unfolding and arithmetic normalization. This is the routine infrastructure that separates clean Lean formalizations from ad-hoc ones: by establishing these canonical lemmas before the main proof, subsequent reasoning can cite them by name rather than repeating computations.",
+    "content": "Three private lemmas establish the structural properties of `p_int` needed before the Eisenstein criterion can be applied.\n\n`p_int_degree` (line 130): Proves `p_int.degree = 5` by `compute_degree!` \u2014 a Lean tactic that normalizes polynomial degree computations. The result is needed because Eisenstein's criterion requires checking that the coefficient at position $k < \\deg(p)$ is in the prime ideal, which requires knowing $\\deg(p)$ concretely.\n\n`p_int_natDegree` (line 134): Proves `p_int.natDegree = 5`. Lean distinguishes between `degree : WithBot \u2115` (the additive value, with $\\deg(0) = -\\infty = \\bot$) and `natDegree : \u2115` (coercing $-\\infty$ to 0). The Eisenstein API uses `natDegree` for coefficient indices, so both are needed.\n\n`p_int_monic` (lines 138-142): Proves the leading coefficient of `p_int` equals 1 by unfolding the definition and using `norm_num`. Monicity is dual-purpose: it makes `p_int` primitive (GCD of all coefficients is 1, since the leading coefficient 1 is coprime to everything), which is the Eisenstein hypothesis; it also feeds into Gauss's lemma for the $\\mathbb{Z} \\to \\mathbb{Q}$ transfer.\n\nAll three proofs are fully computational \u2014 no mathematical insight required, just term unfolding and arithmetic normalization. This is the routine infrastructure that separates clean Lean formalizations from ad-hoc ones: by establishing these canonical lemmas before the main proof, subsequent reasoning can cite them by name rather than repeating computations.",
     "mathContext": "$\\deg(p_{\\text{int}}) = \\deg(x^5 - 4x + 2) = 5$. Monic: leading coefficient $a_5 = 1$. Primitive: $\\gcd(1, 0, 0, 0, -4, 2) = 1$ (since $1$ is a unit). In Lean: `degree : WithBot \u2115` vs `natDegree : \u2115` distinction \u2014 both required for full API coverage.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -125,7 +125,7 @@
     "id": "ann-abeloq04oq01-structural",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 184,
+      "startLine": 188,
       "endLine": 207
     },
     "type": "concept",
@@ -150,7 +150,7 @@
     "id": "ann-abeloq04oq01-galois-bounds",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 208,
+      "startLine": 212,
       "endLine": 231
     },
     "type": "concept",
@@ -174,7 +174,7 @@
     "id": "ann-abeloq04oq01-evaluations",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 232,
+      "startLine": 236,
       "endLine": 264
     },
     "type": "concept",
@@ -199,12 +199,12 @@
     "id": "ann-abeloq04oq01-group-theory",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 265,
+      "startLine": 269,
       "endLine": 290
     },
     "type": "concept",
     "title": "Part V(b): 5-Cycle c\u2085 and the Key Group Theory Claim",
-    "content": "Part V(b) (lines 265-290) documents the classical group-theoretic fact: a transitive subgroup of $S_p$ ($p$ prime) containing a transposition equals $S_p$ (the Key Group Theory Lemma). The section defines `c5 : Equiv.Perm (Fin 5)` \u2014 the explicit 5-cycle $(0\\;1\\;2\\;3\\;4)$ constructed as the modular successor map $i \\mapsto (i+1) \\bmod 5$ with its inverse $i \\mapsto (i+4) \\bmod 5$.\n\nThe claim is: 5-cycle + transposition generates $S_5$, which would follow from: conjugating the transposition by powers of $c_5$ yields all adjacent transpositions $(k\\;k{+}1)$, then star transpositions $(0\\;k)$, then all transpositions $(a\\;b)$. Since the Galois group acts transitively on the 5 roots (by prime degree) and contains a transposition (from complex conjugation or the discriminant sign argument), this would imply $\\text{Gal} = S_5$ directly. The actual proof of $|\\text{Gal}| = 120$ instead uses Sylow elimination (Part V(d)-(f)), making the `c5` definition available but the generation theorem unused.",
+    "content": "Part V(b) (lines 269-289) documents the classical group-theoretic fact: a transitive subgroup of $S_p$ ($p$ prime) containing a transposition equals $S_p$ (the Key Group Theory Lemma). The section defines `c5 : Equiv.Perm (Fin 5)` \u2014 the explicit 5-cycle $(0\\;1\\;2\\;3\\;4)$ constructed as the modular successor map $i \\mapsto (i+1) \\bmod 5$ with its inverse $i \\mapsto (i+4) \\bmod 5$.\n\nThe claim is: 5-cycle + transposition generates $S_5$, which would follow from: conjugating the transposition by powers of $c_5$ yields all adjacent transpositions $(k\\;k{+}1)$, then star transpositions $(0\\;k)$, then all transpositions $(a\\;b)$. Since the Galois group acts transitively on the 5 roots (by prime degree) and contains a transposition (from complex conjugation or the discriminant sign argument), this would imply $\\text{Gal} = S_5$ directly. The actual proof of $|\\text{Gal}| = 120$ instead uses Sylow elimination (Part V(d)-(f)), making the `c5` definition available but the generation theorem unused.",
     "mathContext": "$c_5: i \\mapsto (i+1) \\bmod 5$. Key claim (not formalized in this version): $\\langle c_5, (0\\;1) \\rangle = S_5$. Used for: if $\\text{Gal}$ acts transitively on 5 roots and contains a transposition, then $\\text{Gal} \\supseteq \\langle c_5, \\tau \\rangle = S_5$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -223,12 +223,12 @@
     "id": "ann-abeloq04oq01-galtoperm5",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 293,
+      "startLine": 295,
       "endLine": 340
     },
     "type": "concept",
     "title": "Part V(c): Galois Infrastructure and galToPerm5 Injection into S\u2085",
-    "content": "This section (Part V(c), lines 293-340) sets up the full injection machinery from $\\text{Gal}(p/\\mathbb{Q})$ into $S_5$.\n\n**Infrastructure instances** (lines 293-301): Three Lean instance declarations confirm that the splitting field $SF$ is a Galois extension \u2014 `Normal \u211a SF` (splitting fields of separable polynomials are normal), `Algebra.IsSeparable \u211a SF` (char 0 implies separable), and `p_splits_fact : Fact (map p).Splits` (the polynomial splits in its own splitting field). These are `inferInstance` proofs \u2014 Lean's typeclass synthesis discharges them automatically from existing Mathlib lemmas. Without these instances, `galActionHom` would not typecheck.\n\n**`galPermHomAux`** (lines 303-306): Uses `galActionAux` (the direct Galois group action on the root set, avoiding an instance diamond with `galAction` when the splitting field is the codomain). The `@MulAction.toPermHom _ _ _ (@Polynomial.Gal.galActionAux \u211a _ p)` invocation constructs the homomorphism explicitly rather than going through the synthesized typeclass instance, ensuring no diamond ambiguity.\n\n**`galPermHomAux_injective`** (lines 308-314): Proved via `injective_iff_map_eq_one` and `ext`: if $\\phi(x) = e$ for all $x$ in the root set, then $\\phi = 1$ in $\\text{Gal}$. This is the Galois group's faithful action \u2014 distinct automorphisms have distinct effects on roots.\n\n**`galToPerm5`** (lines 316-330): The composite injection $\\text{Gal} \\xrightarrow{\\text{galPermHomAux}} \\text{Perm}(\\text{rootSet}) \\xrightarrow{\\text{permCongr}} \\text{Perm}(\\text{Fin}\\;5)$. The rootEquiv bijection from $\\text{rootSet}$ to $\\text{Fin}\\;5$ is constructed via `Fintype.equivOfCardEq` using `p_rootSet_card`.\n\n**`galSign`** (lines 338-340): Defines $\\text{galSign}(\\sigma) = \\text{sign}(\\text{galToPerm5}(\\sigma)) \\in \\{\\pm 1\\}$ \u2014 the parity of the permutation of roots induced by $\\sigma$. This is the key quantity for the discriminant argument: if all $\\sigma$ had `galSign` = $+1$, then $\\Delta$ would be Galois-fixed and hence rational, contradicting $\\Delta^2 < 0$.",
+    "content": "This section (Part V(c), lines 295-340) sets up the full injection machinery from $\\text{Gal}(p/\\mathbb{Q})$ into $S_5$.\n\n**Infrastructure instances** (lines 293-301): Three Lean instance declarations confirm that the splitting field $SF$ is a Galois extension \u2014 `Normal \u211a SF` (splitting fields of separable polynomials are normal), `Algebra.IsSeparable \u211a SF` (char 0 implies separable), and `p_splits_fact : Fact (map p).Splits` (the polynomial splits in its own splitting field). These are `inferInstance` proofs \u2014 Lean's typeclass synthesis discharges them automatically from existing Mathlib lemmas. Without these instances, `galActionHom` would not typecheck.\n\n**`galPermHomAux`** (lines 303-306): Uses `galActionAux` (the direct Galois group action on the root set, avoiding an instance diamond with `galAction` when the splitting field is the codomain). The `@MulAction.toPermHom _ _ _ (@Polynomial.Gal.galActionAux \u211a _ p)` invocation constructs the homomorphism explicitly rather than going through the synthesized typeclass instance, ensuring no diamond ambiguity.\n\n**`galPermHomAux_injective`** (lines 308-314): Proved via `injective_iff_map_eq_one` and `ext`: if $\\phi(x) = e$ for all $x$ in the root set, then $\\phi = 1$ in $\\text{Gal}$. This is the Galois group's faithful action \u2014 distinct automorphisms have distinct effects on roots.\n\n**`galToPerm5`** (lines 316-330): The composite injection $\\text{Gal} \\xrightarrow{\\text{galPermHomAux}} \\text{Perm}(\\text{rootSet}) \\xrightarrow{\\text{permCongr}} \\text{Perm}(\\text{Fin}\\;5)$. The rootEquiv bijection from $\\text{rootSet}$ to $\\text{Fin}\\;5$ is constructed via `Fintype.equivOfCardEq` using `p_rootSet_card`.\n\n**`galSign`** (lines 338-340): Defines $\\text{galSign}(\\sigma) = \\text{sign}(\\text{galToPerm5}(\\sigma)) \\in \\{\\pm 1\\}$ \u2014 the parity of the permutation of roots induced by $\\sigma$. This is the key quantity for the discriminant argument: if all $\\sigma$ had `galSign` = $+1$, then $\\Delta$ would be Galois-fixed and hence rational, contradicting $\\Delta^2 < 0$.",
     "mathContext": "$\\text{galToPerm5}: \\text{Gal}(p/\\mathbb{Q}) \\hookrightarrow \\text{Perm}(\\text{Fin}\\;5) \\cong S_5$. Factored as $\\text{Gal} \\xrightarrow{\\text{galPermHomAux}} \\text{Perm}(\\text{rootSet}) \\xrightarrow{\\text{permCongr}(\\text{rootEquiv})} \\text{Perm}(\\text{Fin}\\;5)$. The `galSign` function extracts the parity: $\\text{galSign}(\\sigma) = \\text{Equiv.Perm.sign}(\\text{galToPerm5}(\\sigma)) \\in \\mathbb{Z}^\\times = \\{\\pm 1\\}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -277,7 +277,7 @@
     "id": "ann-abeloq04oq01-vandermonde",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 508,
+      "startLine": 511,
       "endLine": 634
     },
     "type": "concept",
@@ -403,7 +403,7 @@
     "id": "ann-abeloq04oq01-sylow-no15",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 337,
+      "startLine": 341,
       "endLine": 507
     },
     "type": "concept",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01`.

The Lean file had grown/shifted, leaving 8 `concept` annotations anchored to blank or banner lines — the resolver reported **8 misaligned** ("No Lean construct found").

## Changes
- Re-anchored each drifted annotation's `startLine` to the first parsed construct within its range (endLines unchanged):
  | annotation | old start | new start |
  |---|---|---|
  | int-helpers | 109 | 113 |
  | structural | 184 | 188 |
  | galois-bounds | 208 | 212 |
  | evaluations | 232 | 236 |
  | group-theory | 265 | 269 |
  | galtoperm5 | 293 | 295 |
  | sylow-no15 | 337 | 341 |
  | vandermonde | 508 | 511 |
- Fixed stale inline line references in the `int-helpers` annotation (`p_int_degree`/`natDegree`/`monic` now cite 130/134/138-142) and the two "Part V" section headers.

## Validation
`resolver.ts validate`: **25 valid / 0 misaligned** (was 17 valid / 8 misaligned).