### PR TITLE
Enrich erdos-931: re-anchor 8 drifted annotations + add coverage

### DIFF
--- a/src/data/proofs/erdos-931/annotations.json
+++ b/src/data/proofs/erdos-931/annotations.json
@@ -4,8 +4,8 @@
     "proofId": "erdos-931",
     "type": "definition",
     "range": {
-      "startLine": 34,
-      "endLine": 40
+      "startLine": 35,
+      "endLine": 41
     },
     "title": "Consecutive Product and Prime Factors",
     "content": "Two core definitions: `consecutiveProduct n k` computes $\\prod_{i=1}^{k}(n+i) = (n+1)(n+2)\\cdots(n+k)$ using `Finset.Icc 1 k` and `Finset.prod`, while `consecutivePrimeFactors n k` extracts the set of prime divisors via `Nat.primeFactors`. The product $(n+1)\\cdots(n+k) = (n+k)!/n!$ is always positive since each factor $n+i \\geq 1$. The prime factor set $\\text{rad}(\\prod(n+i))$ captures the radical of the product, discarding multiplicity information.",
@@ -29,11 +29,11 @@
     "proofId": "erdos-931",
     "type": "definition",
     "range": {
-      "startLine": 42,
-      "endLine": 48
+      "startLine": 43,
+      "endLine": 49
     },
     "title": "Same Prime Factors Property",
-    "content": "The predicate `SamePrimeFactors n₁ k₁ n₂ k₂` holds when $\\text{rad}(\\prod_{i=1}^{k_1}(n_1+i)) = \\text{rad}(\\prod_{j=1}^{k_2}(n_2+j))$, i.e., the two consecutive products have identical sets of prime divisors. This is decidable since it reduces to equality of finite sets. The relation is an equivalence relation (reflexive, symmetric, transitive), as proved later in the file.",
+    "content": "The predicate `SamePrimeFactors n₁ k₁ n₂ k₂` holds when $\\text{rad}(\\prod_{i=1}^{k_1}(n_1+i)) = \\text{rad}(\\prod_{j=1}^{k_2}(n_2+j))$, i.e., the two consecutive products have identical sets of prime divisors. This is decidable since it reduces to equality of finite sets (the `SamePrimeFactorsDecidable` instance), which is what makes the `native_decide` counterexample checks possible. The relation is an equivalence relation (reflexive, symmetric, transitive), as proved later in the file.",
     "mathContext": "$\\text{SamePrimeFactors}(n_1, k_1, n_2, k_2) \\iff \\{p \\text{ prime} : p \\mid \\prod_{i=1}^{k_1}(n_1+i)\\} = \\{p \\text{ prime} : p \\mid \\prod_{j=1}^{k_2}(n_2+j)\\}$",
     "significance": "key",
     "relatedConcepts": [
@@ -53,11 +53,11 @@
     "proofId": "erdos-931",
     "type": "concept",
     "range": {
-      "startLine": 54,
-      "endLine": 68
+      "startLine": 55,
+      "endLine": 65
     },
     "title": "Verified Small Computations",
-    "content": "Four concrete product computations verified by `native_decide`: $1 \\cdot 2 \\cdots 10 = 10! = 3628800$, $14 \\cdot 15 \\cdot 16 = 3360$, $19 \\cdot 20 \\cdot 21 \\cdot 22 = 175560$, and $54 \\cdot 55 \\cdot 56 \\cdot 57 = 9459360$. These ground the abstract definitions in explicit numerical values and support the counterexample verifications. The `native_decide` tactic evaluates these equalities by computation in the kernel.",
+    "content": "Four concrete product computations verified by `native_decide`: $1 \\cdot 2 \\cdots 10 = 10! = 3628800$, $14 \\cdot 15 \\cdot 16 = 3360$, $19 \\cdot 20 \\cdot 21 \\cdot 22 = 175560$, and $54 \\cdot 55 \\cdot 56 \\cdot 57 = 9480240$. These ground the abstract definitions in explicit numerical values and support the counterexample verifications. The `native_decide` tactic evaluates these equalities by compiling them to native code, sidestepping the slow kernel reduction that `decide` would require for such large numbers.",
     "mathContext": "$10! = 3628800 = 2^8 \\cdot 3^4 \\cdot 5^2 \\cdot 7$, $14 \\cdot 15 \\cdot 16 = 3360 = 2^5 \\cdot 3 \\cdot 5 \\cdot 7$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -75,8 +75,8 @@
     "proofId": "erdos-931",
     "type": "insight",
     "range": {
-      "startLine": 90,
-      "endLine": 95
+      "startLine": 91,
+      "endLine": 96
     },
     "title": "Erdős Problem 931: Main Finiteness Conjecture",
     "content": "For all $k_1 \\geq k_2 \\geq 3$, the set $\\{(n_1, n_2) : n_2 \\geq n_1 + k_1 \\wedge \\text{SamePrimeFactors}(n_1, k_1, n_2, k_2)\\}$ is finite. This asks whether far-apart blocks of consecutive integers can share the same prime factor set only finitely often. The constraint $k_1, k_2 \\geq 3$ is necessary: for $k = 2$, the products $n(n+1)$ and $m(m+1)$ can share prime factors for infinitely many pairs (e.g., all pairs where both are even). The formalization uses `Set.Finite` on the set of pairs satisfying both the gap and same-factors conditions.",
@@ -99,8 +99,8 @@
     "proofId": "erdos-931",
     "type": "insight",
     "range": {
-      "startLine": 97,
-      "endLine": 102
+      "startLine": 98,
+      "endLine": 103
     },
     "title": "Stronger Conjecture: n₂ > 2(n₁+k₁)",
     "content": "Erdős himself expressed doubt about the main conjecture, proposing instead the weaker claim that same-prime-factor pairs must satisfy $n_2 > 2(n_1 + k_1)$, with only finitely many exceptions. This stronger conjecture was disproved by the AlphaProof counterexample. The formalization defines `StrongerConjecture` as finiteness of pairs with the additional constraint $n_2 \\leq 2(n_1 + k_1)$.",
@@ -122,8 +122,8 @@
     "proofId": "erdos-931",
     "type": "concept",
     "range": {
-      "startLine": 108,
-      "endLine": 117
+      "startLine": 109,
+      "endLine": 118
     },
     "title": "AlphaProof Counterexample (Verified)",
     "content": "The counterexample $10! = 2^8 \\cdot 3^4 \\cdot 5^2 \\cdot 7$ and $14 \\cdot 15 \\cdot 16 = 2^5 \\cdot 3 \\cdot 5 \\cdot 7$ share prime factors $\\{2, 3, 5, 7\\}$. With $n_1 = 0, k_1 = 10, n_2 = 13, k_2 = 3$, we have $n_2 = 13 \\leq 20 = 2(n_1 + k_1)$, disproving the stronger conjecture. All three facts (`alphaproof_same_factors`, `alphaproof_gap`, `alphaproof_within_double`) are proved by `native_decide` or `omega`—fully verified, no sorry.",
@@ -146,11 +146,11 @@
     "proofId": "erdos-931",
     "type": "concept",
     "range": {
-      "startLine": 119,
-      "endLine": 126
+      "startLine": 120,
+      "endLine": 127
     },
     "title": "Tijdeman's Example (Verified)",
-    "content": "Tijdeman found that $19 \\cdot 20 \\cdot 21 \\cdot 22 = 175560$ and $54 \\cdot 55 \\cdot 56 \\cdot 57 = 9459360$ share the same prime factors. With $n_1 = 18, k_1 = k_2 = 4, n_2 = 53$, we have $n_2 = 53 > 44 = 2(n_1 + k_1)$, so this example does not violate the stronger conjecture. The factorizations are $175560 = 2^3 \\cdot 3 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 19$ and $9459360 = 2^5 \\cdot 3^3 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 19 \\cdot ...$, sharing primes $\\{2, 3, 5, 7, 11, 19\\}$. All verified by `native_decide`/`omega`.",
+    "content": "Tijdeman found that $19 \\cdot 20 \\cdot 21 \\cdot 22 = 175560$ and $54 \\cdot 55 \\cdot 56 \\cdot 57 = 9480240$ share the same prime factors. With $n_1 = 18, k_1 = k_2 = 4, n_2 = 53$, we have $n_2 = 53 > 44 = 2(n_1 + k_1)$, so this example does not violate the stronger conjecture—it lies beyond the double-gap threshold. The shared prime set is $\\{2, 3, 5, 7, 11, 19\\}$. All facts verified by `native_decide`/`omega`.",
     "mathContext": "$\\text{rad}(19 \\cdot 20 \\cdot 21 \\cdot 22) = \\text{rad}(54 \\cdot 55 \\cdot 56 \\cdot 57)$, with $53 > 2 \\cdot 22 = 44$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -169,11 +169,11 @@
     "proofId": "erdos-931",
     "type": "concept",
     "range": {
-      "startLine": 132,
-      "endLine": 170
+      "startLine": 154,
+      "endLine": 192
     },
     "title": "Properties of Prime Factors and Equivalence",
-    "content": "Seven lemmas establishing structural properties: (1) prime factors divide the product, (2) prime factors are prime, (3) a prime dividing any $n+i$ divides the whole product, (4) such a prime is in the prime factor set, (5) `SamePrimeFactors` is reflexive, (6) symmetric, (7) transitive. The first four connect individual factors to the product via `Finset.dvd_prod_of_mem`, while the last three show `SamePrimeFactors` is an equivalence relation on $\\mathbb{N}^2$ pairs. The positivity lemma `consecutiveProduct_pos` is proved by showing each factor $n + i \\geq 1$.",
+    "content": "Seven lemmas establishing structural properties: (1) `prime_factor_dvd` — prime factors divide the product, (2) `prime_factor_is_prime` — elements of the factor set are prime, (3) `factor_prime_dvd_product` — a prime dividing any $n+i$ divides the whole product, (4) `factor_prime_mem` — such a prime lies in the prime factor set, (5)–(7) `samePrimeFactors_refl/symm/trans` — `SamePrimeFactors` is reflexive, symmetric, and transitive. The first four connect individual factors to the product via `Finset.dvd_prod_of_mem`; the last three show `SamePrimeFactors` is an equivalence relation on $\\mathbb{N}^2$ pairs. Lemma (4) is the workhorse reused throughout the hard-case analysis to certify membership of specific primes.",
     "mathContext": "$p \\mid (n+i) \\wedge 1 \\leq i \\leq k \\implies p \\in \\text{rad}(\\prod_{i=1}^k(n+i))$. SamePrimeFactors is an equivalence relation.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -193,23 +193,47 @@
     "proofId": "erdos-931",
     "type": "insight",
     "range": {
-      "startLine": 176,
-      "endLine": 179
+      "startLine": 207,
+      "endLine": 217
     },
     "title": "Stronger Conjecture Implies Main Conjecture",
-    "content": "The axiom `stronger_implies_main` records that the stronger conjecture (finiteness of pairs with $n_2 \\leq 2(n_1 + k_1)$) would imply the main finiteness conjecture. The argument is: for $n_2 > 2(n_1 + k_1)$, Bertrand's postulate guarantees a prime $p$ in $(n_1 + k_1, 2(n_1 + k_1)]$. Since $p \\leq n_2 \\leq n_2 + k_2$ but $p > n_1 + k_1$, this prime divides some factor in the second block but no factor in the first, contradicting same prime factors. Thus only finitely many pairs with $n_2 \\leq 2(n_1 + k_1)$ can exist.",
-    "mathContext": "StrongerConjecture $\\implies$ ErdosProblem931. Sketch: Bertrand's postulate gives $p \\in (n_1+k_1, 2(n_1+k_1)]$, so $n_2 > 2(n_1+k_1) \\implies p \\mid \\prod(n_2+j)$ but $p \\nmid \\prod(n_1+i)$.",
+    "content": "The theorem `stronger_implies_main` records that the stronger conjecture (finiteness of pairs with $n_2 \\leq 2(n_1 + k_1)$) would imply the main finiteness conjecture. It is stated as `theorem … := by sorry`: the proof is an acknowledged gap, not an asserted axiom. The intended argument decomposes the main set into the inner range $n_1+k_1 \\leq n_2 \\leq 2(n_1+k_1)$ (finite by the stronger conjecture) and the outer range $n_2 > 2(n_1+k_1)$. Showing the outer set finite requires that `SamePrimeFactors` forces both blocks to be $n_1$-smooth, after which Størmer's theorem on consecutive smooth numbers gives finiteness—but smooth-number theory of this kind is not yet in Mathlib.",
+    "mathContext": "StrongerConjecture $\\implies$ ErdosProblem931. Outer range $n_2 > 2(n_1+k_1)$: SamePrimeFactors $\\Rightarrow$ both blocks $n_1$-smooth $\\Rightarrow$ finitely many by Størmer.",
     "significance": "key",
     "relatedConcepts": [
-      "Bertrand's postulate",
-      "prime gap",
+      "Størmer's theorem",
+      "smooth numbers",
       "logical implication",
       "finiteness reduction"
     ],
     "prerequisites": [
       "StrongerConjecture",
       "ErdosProblem931",
-      "Bertrand's postulate"
+      "smooth numbers"
+    ]
+  },
+  {
+    "id": "erdos-931-prime-between-partial",
+    "proofId": "erdos-931",
+    "type": "lemma",
+    "range": {
+      "startLine": 234,
+      "endLine": 283
+    },
+    "title": "Prime Between Blocks: Partial Results via Bertrand",
+    "content": "Three lemmas that discharge the easy cases of the prime-between-blocks claim. `exists_prime_between_of_prime_in_block` observes that a prime already in range needs no hypothesis. `first_block_has_prime` uses Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) to show that when $n_1 \\leq k_1$ the first block always contains a prime (with $2$ handling $n_1 = 0$). `exists_prime_between_of_large_prime_factor` handles the case where the first product has a prime factor $q > n_1$: by `SamePrimeFactors`, $q$ also divides the second product, so via `Prime.dvd_finset_prod_iff` it divides some $n_2 + j \\leq n_2 + k_2$, placing $q$ in range.",
+    "mathContext": "Bertrand: $\\forall n \\geq 1,\\; \\exists p$ prime with $n < p \\leq 2n$. Transfer: $q \\in \\text{rad}(\\prod(n_1+i)) \\wedge \\text{SamePrimeFactors} \\implies q \\mid \\prod(n_2+j) \\implies q \\leq n_2 + k_2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "Prime.dvd_finset_prod_iff",
+      "prime transfer",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "Nat.exists_prime_lt_and_le_two_mul",
+      "SamePrimeFactors",
+      "Nat.dvd_of_mem_primeFactors"
     ]
   },
   {
@@ -217,23 +241,95 @@
     "proofId": "erdos-931",
     "type": "insight",
     "range": {
-      "startLine": 185,
-      "endLine": 191
+      "startLine": 321,
+      "endLine": 344
     },
-    "title": "Open Question: Prime Between Blocks",
-    "content": "If two consecutive products share the same prime factors with $n_2 \\geq n_1 + k_1$, must there exist a prime $p$ with $n_1 < p \\leq n_2 + k_2$? Erdős himself could not prove this seemingly weaker consequence. By Bertrand's postulate, there is always a prime in $(n_1, 2n_1]$, but the constraint here is that $p$ must also divide one of the block products—which is guaranteed if $p \\leq n_2 + k_2$ since $p$ would divide some $n_2 + j$. The difficulty is showing $p$ falls in the right range when $n_2$ is much larger than $n_1$.",
+    "title": "Prime Between Blocks (General Case)",
+    "content": "`exists_prime_between_blocks` proves that if two products share prime factors with $n_2 \\geq n_1 + k_1$, then there is a prime $p$ with $n_1 < p \\leq n_2 + k_2$. The proof is a four-way case split: (1) $n_1 \\leq k_1$ → Bertrand prime in the first block; (2) $n_2 + k_2 \\geq 2n_1$ → Bertrand prime in $(n_1, 2n_1]$ fits; (3) the first product has a prime factor $> n_1$ → transfer via `SamePrimeFactors`; (4) the hard case where all three fail. Cases 1–3 are fully proved; only case 4 reduces to `exists_prime_between_blocks_hard`, which carries the single substantive `sorry`. This turns a claim Erdős himself could not prove into a problem isolated to one sharply-constrained smooth-number case.",
     "mathContext": "$\\text{SamePrimeFactors}(n_1, k_1, n_2, k_2) \\wedge n_2 \\geq n_1 + k_1 \\implies \\exists p \\text{ prime},\\; n_1 < p \\leq n_2 + k_2$",
     "significance": "key",
     "relatedConcepts": [
       "Bertrand's postulate",
-      "prime existence",
+      "exhaustive case analysis",
       "prime gap",
-      "open question"
+      "reduction to hard case"
     ],
     "prerequisites": [
+      "exists_prime_between_blocks_small",
+      "exists_prime_between_of_large_prime_factor",
+      "exists_prime_between_blocks_hard"
+    ]
+  },
+  {
+    "id": "erdos-931-structural-lemmas",
+    "proofId": "erdos-931",
+    "type": "lemma",
+    "range": {
+      "startLine": 354,
+      "endLine": 380
+    },
+    "title": "Structural Lemmas: Multiples and Small Primes",
+    "content": "`exists_multiple_in_block` shows that among $k$ consecutive integers $n+1, \\ldots, n+k$, any $d \\leq k$ divides at least one of them—the next multiple of $d$ after $n$ is $n + (d - n \\bmod d)$, and $d - n\\bmod d \\leq d \\leq k$ lands inside the block. Building on this, `prime_le_k_mem_factors` proves every prime $p \\leq k$ is a prime factor of the product, and `two_mem_factors` specializes to $p = 2$ for $k \\geq 2$. These pigeonhole-style facts are what force the hard case to be $n_1$-smooth and entirely composite.",
+    "mathContext": "$d \\leq k \\implies \\exists i \\in [1,k],\\; d \\mid (n+i)$, with witness $i = d - (n \\bmod d)$; hence $p$ prime, $p \\leq k \\implies p \\in \\text{rad}(\\prod_{i=1}^k(n+i))$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "division algorithm",
+      "Nat.div_add_mod",
+      "smooth numbers"
+    ],
+    "prerequisites": [
+      "Nat.mod_lt",
+      "factor_prime_mem",
+      "Finset.Icc"
+    ]
+  },
+  {
+    "id": "erdos-931-hard-case-structure",
+    "proofId": "erdos-931",
+    "type": "insight",
+    "range": {
+      "startLine": 391,
+      "endLine": 465
+    },
+    "title": "Hard Case: Both Blocks Entirely Composite",
+    "content": "Under the hard-case hypotheses ($k_1 < n_1$, $n_2 + k_2 < 2n_1$, all prime factors $\\leq n_1$), a chain of lemmas pins down the structure. `hard_case_first_block_composite`: no $n_1 + i$ can be prime, else it would be a prime factor exceeding $n_1$. `hard_case_second_block_composite`: likewise no $n_2 + j$ is prime, via `SamePrimeFactors` transfer. `hard_case_second_block_smooth`: every prime factor of the second product is $\\leq n_1$. `hard_case_summary` bundles these into: both blocks fully composite, second product $n_1$-smooth, and every second-block element exceeds $n_1$. This is the crux—$k_2 \\geq 3$ consecutive composite $n_1$-smooth integers above $n_1$—which Størmer-type theory suggests is impossible for all but finitely many $n_1$.",
+    "mathContext": "Hard case $\\implies$ $\\forall i \\in [1,k_1], \\neg(n_1+i)\\text{ prime}$; $\\forall j \\in [1,k_2], \\neg(n_2+j)\\text{ prime} \\wedge n_1 < n_2+j$; $\\forall p \\in \\text{rad}(\\prod(n_2+j)), p \\leq n_1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "smooth numbers",
+      "Størmer's theorem",
+      "consecutive composite integers",
+      "SamePrimeFactors transfer"
+    ],
+    "prerequisites": [
+      "factor_prime_mem",
       "SamePrimeFactors",
-      "Nat.Prime",
-      "Bertrand's postulate"
+      "consecutivePrimeFactors"
+    ]
+  },
+  {
+    "id": "erdos-931-hard-case-computational",
+    "proofId": "erdos-931",
+    "type": "concept",
+    "range": {
+      "startLine": 530,
+      "endLine": 538
+    },
+    "title": "Hard Case: Computational Verification (k₁=k₂=3, n₁≤30)",
+    "content": "`hard_case_vacuous_k3_n30` verifies by `native_decide` that for $k_1 = k_2 = 3$ and every $n_1 \\in [7, 30]$, no $n_2 \\in [n_1 + 3, 2n_1 - 4]$ simultaneously satisfies the smoothness hypothesis ($h_7$: all prime factors $\\leq n_1$) and `SamePrimeFactors`. In other words, the hard-case hypotheses are mutually inconsistent over this finite window: either the first block already carries a prime factor $> n_1$, or the prime-factor sets differ. This is concrete empirical evidence that the hard case is vacuously true—the remaining `sorry` is conjectured to hold because its hypotheses are never simultaneously satisfiable.",
+    "mathContext": "$\\forall n_1 \\in [7,30],\\, \\forall n_2 \\in [n_1+3, 2n_1-4]:\\; (\\forall p \\in \\text{rad}(\\prod(n_1{+}i)),\\, p \\leq n_1) \\implies \\neg\\,\\text{SamePrimeFactors}(n_1,3,n_2,3)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "native_decide",
+      "vacuous truth",
+      "exhaustive verification",
+      "smooth numbers"
+    ],
+    "prerequisites": [
+      "consecutivePrimeFactors",
+      "SamePrimeFactors",
+      "native_decide"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass: erdos-931 (Same Prime Factors in Products of Consecutive Integers)

The Lean file grew from ~192 to 540 lines (new prime-between-blocks machinery and hard-case smooth-number analysis), leaving all 8 original annotations anchored to wrong line ranges. Resolver reported **8 misaligned / 0 aligned** before this pass.

### Changes
- **Re-anchored all 8 drifted annotations** to their current constructs (definitions, counterexamples, equivalence-relation lemmas).
- **Fixed stale content claims:**
  - `stronger_implies_main` annotation called it an `axiom`; it is now a `theorem … := by sorry` (acknowledged gap, not asserted claim). Updated to reflect the Størmer-theorem reduction.
  - Corrected a computation typo: `54·55·56·57 = 9480240` (was `9459360`).
- **Added 4 coverage annotations** for previously uncovered substantial sections:
  - Prime-between-blocks partial results via Bertrand's postulate
  - Structural lemmas (multiples in a block, small primes as factors)
  - Hard-case structure (both blocks entirely composite, second product n₁-smooth)
  - `native_decide` vacuity check for k₁=k₂=3, n₁≤30

### Verification
`resolver.ts validate`: **14 valid, 0 misaligned**. JSON parses. Only `src/data/proofs/erdos-931/annotations.json` touched.

Note: this is an OPEN problem with 2 sorries (`stronger_implies_main`, `exists_prime_between_blocks_hard`); meta.json correctly carries `badge: wip` / `sorries: 2` / `axiomCount: 0` and is unchanged.