### PR TITLE
research(repunit-oq-01): fix deprecated lemma + offline certification (build-pending)

### DIFF
--- a/proofs/Proofs/RepunitDivisibilityOQ01.lean
+++ b/proofs/Proofs/RepunitDivisibilityOQ01.lean
@@ -31,10 +31,23 @@ common factor `b − 1` (`Nat.mul_dvd_mul_iff_left`).
 No axioms, no sorries.
 
 NOTE (2026-06-16): build-pending. The proof is self-contained and elementary, but
-could not be machine-checked this session: the Docker build environment is failing
-to fetch Mathlib (`git exited 128` while cloning mathlib4) across all agents. This
-file is intentionally left UNREGISTERED in `Proofs.lean` until a successful build
-confirms it, so it cannot affect the gallery build.
+could not be machine-checked this session: the Docker build host is saturated (7
+concurrent `lake build` containers, load avg ~30), so launching another 32 GB build
+would endanger the host and the in-flight builds. Pending verification, the result
+has been certified independently:
+
+* the divisibility criterion `R_b(m) ∣ R_b(n) ↔ m ∣ n` and the bridge identity
+  `(b−1)·R_b(n)+1 = b^n` were checked numerically for all bases `2 ≤ b ≤ 12` and
+  all `m, n ≤ 24` (`research/scripts/verify_repunit_oq01.py`);
+* every Mathlib lemma invoked was confirmed against the offline Mathlib v4.26.0 pin
+  (`Nat.sub_dvd_pow_sub_pow`, `Nat.modEq_iff_dvd'`, `Nat.ModEq.{pow,mul_right}`,
+  `Nat.le_self_pow`, `Nat.one_le_pow`, `Nat.pow_le_pow_right`,
+  `Nat.mul_dvd_mul_iff_left`).
+
+This file is intentionally left UNREGISTERED in `Proofs.lean` until a successful
+build confirms it, so it cannot affect the gallery build. Next session with a free
+Docker host: `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01`,
+then register the import and add the gallery entry.
 -/
 
 namespace RepunitDivisibilityOQ01
@@ -121,7 +134,7 @@ theorem pow_sub_one_dvd_iff_dvd {b : ℕ} (hb : 2 ≤ b) (m n : ℕ) :
         omega
       exact ⟨q, by omega⟩
   · rintro ⟨k, rfl⟩
-    simpa [pow_mul, one_pow] using nat_sub_dvd_pow_sub_pow (b ^ m) 1 k
+    simpa [pow_mul, one_pow] using Nat.sub_dvd_pow_sub_pow (b ^ m) 1 k
 
 /-- **Repunit divisibility criterion** (base `b ≥ 2`):
 `R_b(m) ∣ R_b(n) ↔ m ∣ n`. -/

--- a/research/problems/repunit-oq-01/problem.md
+++ b/research/problems/repunit-oq-01/problem.md
@@ -1,0 +1,37 @@
+# Problem: Repunit Divisibility: R_m divides R_n iff m divides n
+
+## Statement
+
+### Plain Language
+Formal investigation in number theory: Repunit Divisibility: R_m divides R_n iff m divides n.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: C
+significance: 5
+tractability: 7
+tags:
+  - seeker-selected
+  - number-theory
+  - repunit
+  - divisibility
+```
+
+**Significance**: 5/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/repunit-oq-01/state.md
+++ b/research/problems/repunit-oq-01/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-06-16T17:19:11.555Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/repunit-oq-01/state.md
+++ b/research/problems/repunit-oq-01/state.md
@@ -1,27 +1,51 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-06-16T17:19:11.555Z
-**Iteration**: 1
+**Phase**: BLOCKED (build-pending)
+**Since**: 2026-06-16T20:00:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Verify-and-ship the completed proof `R_b(m) ∣ R_b(n) ↔ m ∣ n`
+(`proofs/Proofs/RepunitDivisibilityOQ01.lean`). Mathematics is finished; the
+sole remaining step is a clean Docker `lake build` + gallery registration.
 
 ## Active Approach
 
-None yet.
+Done (no sorries, no axioms):
+- `repunit b n := ∑_{i<n} b^i`; bridge `(b-1)·R_b(n)+1 = b^n`
+  (`pred_mul_repunit_add_one`, induction) and `(b-1)·R_b(n) = b^n-1`.
+- Engine `pow_sub_one_dvd_iff_dvd`: `(b^m-1) ∣ (b^n-1) ↔ m ∣ n` via
+  division algorithm + `Nat.ModEq`.
+- Headlines `repunit_dvd_iff` (base b≥2) and `repunit_ten_dvd_iff`.
+
+Offline certification (Docker unavailable):
+- Numerical check passes: `research/scripts/verify_repunit_oq01.py`
+  (2≤b≤12, m,n≤24) — re-run 2026-06-16, OK.
+- All Mathlib lemmas confirmed against the v4.26.0 offline pin. In particular
+  the deprecated alias `nat_sub_dvd_pow_sub_pow` was replaced by
+  `Nat.sub_dvd_pow_sub_pow` (Mathlib/Algebra/Ring/GeomSum.lean:334, namespace
+  `Nat`, signature `(x y n : ℕ) : x - y ∣ x ^ n - y ^ n`).
 
 ## Blockers
 
-None.
+Docker build host saturated: load avg ~36, 17 concurrent `lake build`
+processes, `docker info` hangs (daemon unresponsive under load). Launching
+another 32 GB build would endanger the host and in-flight builds. This is an
+environment-wide infra blocker, not a proof issue.
 
 ## Next Action
 
-Begin problem exploration.
+When a Docker host is free:
+1. `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01`
+   (grep the log for `error:` — the wrapper exits 0 even on failure).
+2. On green: add `import Proofs.RepunitDivisibilityOQ01` to `proofs/Proofs.lean`,
+   then create the gallery entry under `src/data/proofs/repunit-oq-01/`
+   (meta.json status `verified`, 0 axioms, 0 sorries) and `pnpm build`.
+3. Remove the build-pending NOTE block from the `.lean` file header.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1 (build) — blocked on Docker
+- Approaches tried: 1

--- a/research/scripts/verify_repunit_oq01.py
+++ b/research/scripts/verify_repunit_oq01.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Numerical certificate for repunit-oq-01 (Proofs/RepunitDivisibilityOQ01.lean).
+
+Checks, by brute force, the two arithmetic facts the Lean proof rests on:
+
+  1. repunit_dvd_iff:  R_b(m) | R_b(n)  <->  m | n   (base b >= 2)
+  2. pred_mul_repunit_add_one:  (b - 1) * R_b(n) + 1 = b ^ n
+
+where R_b(n) = sum_{i<n} b^i.  A clean run prints "OK" and exits 0.
+"""
+
+def R(b, n):
+    return sum(b ** i for i in range(n))
+
+def main():
+    B_RANGE = range(2, 13)   # bases 2..12
+    EXP = range(0, 25)       # exponents 0..24
+
+    dvd_fail = []
+    for b in B_RANGE:
+        for m in EXP:
+            Rm = R(b, m)
+            for n in EXP:
+                lhs = (R(b, n) % Rm == 0) if Rm != 0 else (R(b, n) == 0)
+                rhs = (n % m == 0) if m != 0 else (n == 0)
+                if lhs != rhs:
+                    dvd_fail.append((b, m, n))
+
+    bridge_fail = [(b, n) for b in range(1, 13) for n in EXP
+                   if (b - 1) * R(b, n) + 1 != b ** n]
+
+    assert not dvd_fail, f"repunit_dvd_iff counterexamples: {dvd_fail[:10]}"
+    assert not bridge_fail, f"bridge identity fails: {bridge_fail[:10]}"
+    print("OK: repunit_dvd_iff and (b-1)*R_b(n)+1 = b^n verified for "
+          "2<=b<=12, m,n<=24")
+
+if __name__ == "__main__":
+    main()

--- a/src/data/research/problems/repunit-oq-01.json
+++ b/src/data/research/problems/repunit-oq-01.json
@@ -1,0 +1,82 @@
+{
+  "slug": "repunit-oq-01",
+  "title": "Repunit Divisibility: R_m divides R_n iff m divides n",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in number theory: Repunit Divisibility: R_m divides R_n iff m divides n.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-16T17:19:11.555Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: complete elementary proof of R_b(m) | R_b(n) <-> m | n (base b>=2) written in Proofs/RepunitDivisibilityOQ01.lean (0 sorry, 0 axiom). Math + Mathlib API certified offline; build-pending (Docker host saturated). UNREGISTERED until a green build.",
+    "builtItems": [
+      "Proofs/RepunitDivisibilityOQ01.lean: repunit, repunit_succ, pred_mul_repunit_add_one, pred_mul_repunit, pow_sub_one_dvd_iff_dvd, repunit_dvd_iff, repunit_ten_dvd_iff (0 sorry, 0 axiom; build-pending)",
+      "research/scripts/verify_repunit_oq01.py: numerical certificate (bases 2..12, exponents <=24)"
+    ],
+    "insights": [
+      "The criterion reduces to (b^m-1) | (b^n-1) <-> m | n via the bridge identity (b-1)*R_b(n)+1 = b^n, cancelling the common factor (b-1) with Nat.mul_dvd_mul_iff_left.",
+      "Hard direction (=>): write n = m*q + r (r<m); mod (b^m-1), b^n = (b^m)^q * b^r = b^r, so b^r = 1 (mod b^m-1), i.e. (b^m-1)|(b^r-1); since 0 <= b^r-1 < b^m-1 this forces r=0. No order theory / gcd identity needed.",
+      "Easy direction (<=): geometric factorisation b^m-1 | (b^m)^k-1 = b^(m*k)-1 via Nat.sub_dvd_pow_sub_pow.",
+      "nat_sub_dvd_pow_sub_pow is DEPRECATED (since 2025-08-23) in Mathlib v4.26 -> use Nat.sub_dvd_pow_sub_pow (x y n : ℕ)."
+    ],
+    "mathlibGaps": [
+      "No direct Mathlib lemma for (b^m-1) | (b^n-1) <-> m | n; proved here in ~50 lines via Nat.ModEq (Nat.sub_dvd_pow_sub_pow gives only the <= direction)."
+    ],
+    "nextSteps": [
+      "When Docker host is free: ./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01 ; grep error: ; if green, add import to proofs/Proofs.lean and create src/data/proofs/repunit-oq-01/ gallery entry (status verified, 0 axiom).",
+      "Possible follow-up: gcd(R_b(m), R_b(n)) = R_b(gcd(m,n)) (the repunit analogue of gcd(b^m-1,b^n-1)=b^gcd-1)."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "repunit",
+    "divisibility"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-16T17:19:11.555Z",
+  "lastUpdate": "2026-06-16T17:19:11.555Z",
+  "significance": 5,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/RepunitDivisibilityOQ01.lean",
+      "filename": "RepunitDivisibilityOQ01.lean",
+      "lineCount": 140,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RepunitDivisibilityOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The complete, elementary proof of the repunit divisibility criterion
**`R_b(m) ∣ R_b(n) ↔ m ∣ n`** (base `b ≥ 2`) already lives on `main` as an
**unregistered orphan** (`proofs/Proofs/RepunitDivisibilityOQ01.lean`, 0 sorry /
0 axiom), left build-pending by an earlier session. This PR consolidates and
de-risks it **without** a Docker build, because the host is currently saturated
(7 concurrent `lake build` containers, load avg ~30 — adding an 8th 32 GB build
would endanger the host and the in-flight builds).

## Changes
- **Fix deprecation**: `nat_sub_dvd_pow_sub_pow` → `Nat.sub_dvd_pow_sub_pow`
  (deprecated since 2025-08-23 in Mathlib v4.26; the alias compiles but warns).
- **Numerical certificate** `research/scripts/verify_repunit_oq01.py`: confirms
  `R_b(m) ∣ R_b(n) ↔ m ∣ n` and the bridge identity `(b−1)·R_b(n)+1 = b^n` for
  all bases `2 ≤ b ≤ 12` and exponents `m, n ≤ 24` (clean run).
- **Offline API audit**: every Mathlib lemma invoked verified against the pinned
  v4.26.0 checkout — `Nat.sub_dvd_pow_sub_pow`, `Nat.modEq_iff_dvd'`,
  `Nat.ModEq.{pow,mul_right}`, `Nat.le_self_pow`, `Nat.one_le_pow`,
  `Nat.pow_le_pow_right`, `Nat.mul_dvd_mul_iff_left`.
- Updated build-pending note + problem knowledge (`repunit-oq-01.json`,
  `knowledge.md`).

## Method (why it's a theorem, not enumeration)
The criterion reduces to `(b^m−1) ∣ (b^n−1) ↔ m ∣ n` via the bridge identity
`(b−1)·R_b(n) = b^n−1` (cancel the common factor `b−1`). The forward direction
uses `Nat.ModEq`: write `n = m·q + r`, then `b^n ≡ b^r (mod b^m−1)`, so
`b^r ≡ 1`, i.e. `(b^m−1) ∣ (b^r−1)`; since `b^r−1 < b^m−1` this forces `r = 0`.
The converse is the geometric factorisation `b^m−1 ∣ (b^m)^k−1`.

## Status / honesty
- **Not machine-checked this session** (no Docker build). Math + API certified
  offline only.
- Kept **UNREGISTERED** in `Proofs.lean` (zero gallery-build risk) and **not**
  promoted to `src/data/proofs/` — the draft meta claims `status: "verified"`,
  which would overclaim until a successful build (Axiom Integrity Policy).

## Next step
On a free Docker host: `./proofs/scripts/docker-build.sh
Proofs.RepunitDivisibilityOQ01`; if green, register the import and promote the
gallery entry.

## Test plan
- [x] `python3 research/scripts/verify_repunit_oq01.py` → OK
- [ ] `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01` (blocked: host saturated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)