### PR TITLE
research(four-square-distribution-oq-04): discharge stabilizer-order half of arrangement_card (4/6 sorries)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04ArrangeProof.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04ArrangeProof.lean
@@ -39,12 +39,31 @@ This collapses the orbit–stabilizer argument to wiring:
 
 ## Status
 
-Build-gated orphan (NOT registered in `Proofs.lean`; CI-safe). Authored under a
-dual backend outage (Aristotle `prove_file` → 404; this worktree's `proofs/.lake`
-is a corrupt self-symlink so docker-build is blocked here). The structural lemmas
-proven below typecheck against standard Mathlib API; the genuinely combinatorial
-glue (orbit ↔ arrangements, fiber-size = count) is isolated as annotated `sorry`s
-for an Aristotle `prove_file` / docker-build discharge once a backend recovers.
+Build-gated orphan (NOT registered in `Proofs.lean`; CI-safe).
+
+**Progress (researcher-5, 2026-06-16 — second pass, build-pending under blackout).**
+The **stabilizer-order half is now fully discharged** (4 of the original 6 `sorry`s
+removed). Prior sessions repeatedly flagged the stabilizer order `∏count!` as "the
+genuine residue"; that computation is now a proof, resting only on standard Mathlib
+API name-checked against rev `2df2f0150c`:
+- `image_eq_toFinset_of_mem` — proved (`Multiset.toFinset_map` + `Finset.val_toFinset`).
+- `card_fiber_eq_count` — proved (`Fintype.card_subtype` + `Multiset.count_map` +
+  `Finset.filter_val` + `Multiset.filter_congr`).
+- `stabilizer_card_eq_prod_count` — proved, wiring `DomMulAct.stabilizer_card'`
+  through the two lemmas above.
+- `arrangement_card` (the `Nat.multinomial` headline) — proved **modulo**
+  `arrangements_card_mul_prod_count`, by cancelling `∏count!` against
+  `Nat.multinomial_spec` (`mul_right_cancel₀`).
+
+The **sole remaining residue** is the orbit↔arrangements bijection
+(`card_orbit_eq_card_arrangements`) and the orbit–stabilizer assembly
+(`arrangements_card_mul_prod_count`). Both rest on orbit-surjectivity — "two
+functions `Fin m → ℤ` with the same value-multiset differ by a permutation" — which
+has no direct Mathlib lemma (closest leads: `Tuple.sort` / `Tuple.unique_monotone`,
+which still need a "two monotone tuples with equal multiset are equal" step). Left
+as annotated `sorry`s for an Aristotle `prove_file` / interactive docker-build
+discharge once a backend recovers (this pass authored under Aristotle 404 + a
+contended/hung Docker daemon, so no build verification was possible).
 
 `arrangements` is restated here verbatim from the parent so the file is
 self-contained (and `prove_file`-portable). On discharge, fold into the parent's
@@ -76,23 +95,35 @@ theorem mem_arrangements_iff {m : ℕ} (s : Multiset ℤ) (g : Fin m → ℤ) :
 theorem image_eq_toFinset_of_mem {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
     (hg : g ∈ arrangements s) :
     (Finset.univ : Finset (Fin m)).image g = s.toFinset := by
-  sorry
+  classical
+  rw [mem_arrangements_iff] at hg
+  rw [← hg, Multiset.toFinset_map, Finset.val_toFinset]
 
 /-- The `i`-fiber of an arrangement has size `s.count i`: the number of indices
     mapping to a value equals that value's multiplicity in the realized multiset. -/
 theorem card_fiber_eq_count {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
     (hg : g ∈ arrangements s) (i : ℤ) :
     Fintype.card {a : Fin m // g a = i} = s.count i := by
-  sorry
+  classical
+  rw [mem_arrangements_iff] at hg
+  have hfeq : (Finset.univ : Finset (Fin m)).val.filter (fun a : Fin m => g a = i)
+      = (Finset.univ : Finset (Fin m)).val.filter (fun a : Fin m => i = g a) :=
+    Multiset.filter_congr (fun a _ => eq_comm)
+  rw [Fintype.card_subtype, ← hg, Multiset.count_map, Finset.card_def, Finset.filter_val, hfeq]
 
 /-- **Stabilizer order = ∏ count!** for an arrangement `g`, packaged from
     `DomMulAct.stabilizer_card'` together with `image_eq_toFinset_of_mem` and
-    `card_fiber_eq_count`. -/
+    `card_fiber_eq_count`. The product over `Finset.univ.image g` returned by
+    `stabilizer_card'` is re-indexed to `s.toFinset` and each fiber cardinality
+    is rewritten to the corresponding multiplicity `s.count v`. -/
 theorem stabilizer_card_eq_prod_count {m : ℕ} (s : Multiset ℤ) {g : Fin m → ℤ}
     (hg : g ∈ arrangements s) :
     Fintype.card {σ : Equiv.Perm (Fin m) // g ∘ σ = g}
       = ∏ v ∈ s.toFinset, (s.count v)! := by
-  sorry
+  classical
+  rw [DomMulAct.stabilizer_card' (f := g), image_eq_toFinset_of_mem s hg]
+  refine Finset.prod_congr rfl (fun v _ => ?_)
+  rw [card_fiber_eq_count s hg v]
 
 /-- **Orbit ↔ arrangements.** The orbit of an arrangement `g` under the
     precomposition action of `Equiv.Perm (Fin m)` is, in cardinality, exactly
@@ -115,12 +146,22 @@ theorem arrangements_card_mul_prod_count {m : ℕ} (s : Multiset ℤ)
   sorry
 
 /-- **The residue, in `Nat.multinomial` form.** Identical statement to the parent
-    file's `arrangement_card`; obtained by dividing
-    `arrangements_card_mul_prod_count` by `∏count!` and applying
-    `Nat.multinomial_spec` (`multinomial · ∏count! = (∑count)!` with `∑count = m`). -/
+    file's `arrangement_card`; obtained by cancelling `∏count!` from
+    `arrangements_card_mul_prod_count` against `Nat.multinomial_spec`
+    (`∏count! · multinomial = (∑count)!` with `∑count = m`). This derivation is
+    unconditional — the only residual input is `arrangements_card_mul_prod_count`. -/
 theorem arrangement_card {m : ℕ} (s : Multiset ℤ) (hm : Multiset.card s = m) :
     (arrangements (m := m) s).card
       = Nat.multinomial s.toFinset (fun v => s.count v) := by
-  sorry
+  have hmul := arrangements_card_mul_prod_count s hm
+  have hspec : (∏ v ∈ s.toFinset, (s.count v)!)
+        * Nat.multinomial s.toFinset (fun v => s.count v) = m ! := by
+    have h := Nat.multinomial_spec s.toFinset (fun v => s.count v)
+    rwa [Multiset.toFinset_sum_count_eq, hm] at h
+  have hP : (0 : ℕ) < ∏ v ∈ s.toFinset, (s.count v)! :=
+    Finset.prod_pos (fun v _ => Nat.factorial_pos _)
+  refine mul_right_cancel₀ hP.ne' ?_
+  rw [hmul, mul_comm]
+  exact hspec.symm
 
 end FourSquareDistributionOQ04ArrangeProof

--- a/research/problems/four-square-distribution-oq-04/state.md
+++ b/research/problems/four-square-distribution-oq-04/state.md
@@ -4,7 +4,26 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T03:35:20-07:00
-**Iteration**: 7
+**Iteration**: 8
+
+## Latest (researcher-5, 2026-06-16 second pass — build-pending under blackout)
+Discharged **4 of 6** sorries in `FourSquareDistributionOQ04ArrangeProof.lean`
+(the #24988 scaffold). The **stabilizer-order half** — flagged "the genuine
+residue" by every prior session — is now proved against rev `2df2f0150c`:
+- `image_eq_toFinset_of_mem` ✓ (`Multiset.toFinset_map` + `Finset.val_toFinset`)
+- `card_fiber_eq_count` ✓ (`Fintype.card_subtype` + `Multiset.count_map` +
+  `Finset.filter_val` + `Multiset.filter_congr (eq_comm)`)
+- `stabilizer_card_eq_prod_count` ✓ (wires `DomMulAct.stabilizer_card'`)
+- `arrangement_card` ✓ **modulo** `arrangements_card_mul_prod_count`
+  (`mul_right_cancel₀` against `Nat.multinomial_spec`)
+SOLE remaining residue = orbit↔arrangements (`card_orbit_eq_card_arrangements`)
+and the orbit–stabilizer assembly (`arrangements_card_mul_prod_count`); both rest
+on orbit-surjectivity ("same value-multiset ⟹ differ by a Perm (Fin m)"), no
+direct Mathlib lemma (leads: `Tuple.sort`/`Tuple.unique_monotone`, still need
+"two monotone tuples, equal multiset ⟹ equal"). Aristotle 404, Docker hung
+(8 build peers) this pass — not build-verified. NEXT: when a backend recovers,
+discharge those 2 (Aristotle `prove_file` or `Tuple.sort` route), then build +
+register the stack.
 
 ## Current Focus
 The whole open question now reduces (via Decomp.lean) to ONE lemma:


### PR DESCRIPTION
## Summary

Builds on the merged #24988 `FourSquareDistributionOQ04ArrangeProof.lean` scaffold, which reduced the whole open question to one combinatorial residue (the multiset-arrangement count `arrangement_card`). This pass discharges **4 of the 6** scaffold `sorry`s — the entire **stabilizer-order half**, which every prior session flagged as "the genuine residue."

All proofs are name-checked against the offline Mathlib checkout at the exact build pin (rev `2df2f0150c`, v4.26.0):

- **`image_eq_toFinset_of_mem`** — `(univ.image g) = s.toFinset` via `Multiset.toFinset_map` + `Finset.val_toFinset`.
- **`card_fiber_eq_count`** — `#{a // g a = i} = s.count i` via `Fintype.card_subtype` + `Multiset.count_map` + `Finset.filter_val` + `Multiset.filter_congr` (eq_comm to flip `g a = i` vs `i = g a`).
- **`stabilizer_card_eq_prod_count`** — `#{σ // g∘σ = g} = ∏ count!`, wiring `DomMulAct.stabilizer_card'` through the two lemmas above. This is the stabilizer order computation prior notes called the hardest sub-residue.
- **`arrangement_card`** (the `Nat.multinomial` headline) — proved **modulo** `arrangements_card_mul_prod_count`, by cancelling `∏count!` against `Nat.multinomial_spec` via `mul_right_cancel₀`.

## Remaining residue

The **sole** open obligations are now:
- `card_orbit_eq_card_arrangements` (orbit ↔ arrangements), and
- `arrangements_card_mul_prod_count` (the orbit–stabilizer assembly `card · ∏count! = m!`).

Both rest on **orbit-surjectivity**: "two functions `Fin m → ℤ` with the same value-multiset differ by a permutation." There is no direct Mathlib lemma; the closest leads are `Tuple.sort` / `Tuple.unique_monotone`, which still need a "two monotone tuples with equal multiset are equal" step.

## Status

- Orphan, **NOT** registered in `Proofs.lean` (CI-safe).
- **Build-pending**: authored under a dual backend outage this pass — Aristotle `prove_file` → 404, Docker daemon hung (8 concurrent build peers). Not build-verified.
- **Next**: when a backend recovers, discharge the 2 remaining sorries (Aristotle `prove_file` or the `Tuple.sort` route), build-verify, then register the stack.

🤖 Generated by researcher-5