### PR TITLE
Research: bounded-prime-gaps-oq-03-oq-01-oq-01 S1 OBSERVE — materialize D(5)=12 from scratch

### DIFF
--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/D5-draft.lean
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/D5-draft.lean
@@ -1,0 +1,60 @@
+/-
+  DRAFT SKELETON (NOT registered, NOT in Proofs.lean — zero build-gate risk).
+  bounded-prime-gaps-oq-03-oq-01-oq-01 — D(5) = 12 from scratch.
+
+  OBSERVE-phase draft (researcher-1, S1, 2026-06-16). Authored under DUAL
+  BLACKOUT (Docker `docker run` hangs exit 124; Aristotle MCP `prove` 404), so
+  UNVERIFIED. Mirrors the parent's `minAdmissibleDiameter_2` /
+  `minAdmissibleDiameter_3` proof shape (`BoundedPrimeGapsOQ03OQ01.lean:173/188`).
+
+  Two load-bearing obligations:
+    (1) `admissible_5tuple_0_2_6_8_12` — witness admissibility (easy; copy the
+        `admissible_quadruple_0_2_6_8` shape, line 165 of the parent).
+    (2) `admissible_5tuple_diam_ge_12` — the lower bound (the real content).
+        Strategy: translation-invariance to fix min = 0, then a finite
+        `native_decide` over the 5-subsets of {0,…,11} containing 0, each
+        inadmissible mod 2 or mod 3.
+
+  On a Docker-up worktree: build this file; if green, transcribe into a new
+  registered `Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (or fold into the parent
+  next to D(2)/D(3)).
+-/
+import Mathlib
+import Proofs.BoundedPrimeGaps
+import Proofs.BoundedPrimeGapsOQ03OQ01
+
+namespace BoundedPrimeGapsOQ03OQ01OQ01
+
+open Nat Finset BoundedPrimeGaps BoundedPrimeGapsOQ03OQ01
+
+/-- Witness admissibility: `{0, 2, 6, 8, 12}` is admissible (diameter 12).
+    Only p ∈ {2,3,5} can possibly cover a 5-set; none does (residues miss a
+    class), and p ≥ 7 cannot cover 5 < 7 points. `decide`/`native_decide` over
+    the `IsAdmissible` predicate, exactly as `admissible_quadruple_0_2_6_8`. -/
+theorem admissible_5tuple_0_2_6_8_12 :
+    IsAdmissible ({0, 2, 6, 8, 12} : Finset ℕ) := by
+  sorry  -- copy admissible_quadruple_0_2_6_8 shape (parent line 165)
+
+/-- **Lower bound — the real content.** Every admissible 5-tuple has diameter
+    ≥ 12. By translation-invariance assume `min = 0`; then `H ⊆ {0,…,11}` would
+    force a covering mod 2 or mod 3 (finite `native_decide`). -/
+theorem admissible_5tuple_diam_ge_12
+    (H : Finset ℕ) (hcard : H.card = 5) (hadm : IsAdmissible H) :
+    12 ≤ fsDiameter H := by
+  sorry  -- LOAD-BEARING: shift to min=0 + native_decide over 5-subsets of {0..11}
+
+/-- D(5) = 12. Same `le_antisymm` assembly as `minAdmissibleDiameter_3`. -/
+theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by
+  apply le_antisymm
+  · -- Upper: {0,2,6,8,12} witnesses D(5) ≤ 12
+    apply csInf_le ⟨0, fun _ _ => Nat.zero_le _⟩
+    exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+  · -- Lower: every admissible 5-tuple has diameter ≥ 12
+    have hne : Set.Nonempty
+        {d | ∃ H : Finset ℕ, H.card = 5 ∧ IsAdmissible H ∧ fsDiameter H = d} :=
+      ⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+    apply le_csInf hne
+    rintro d ⟨H, hcard, hadm, rfl⟩
+    exact admissible_5tuple_diam_ge_12 H hcard hadm
+
+end BoundedPrimeGapsOQ03OQ01OQ01

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/problem.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/problem.md
@@ -1,0 +1,94 @@
+# bounded-prime-gaps-oq-03-oq-01-oq-01
+
+## Provenance
+
+Auto-seeded follow-up slug (registry `started` 2026-06-16T04:40Z, phase
+OBSERVE) of the parent `bounded-prime-gaps-oq-03-oq-01`
+(`proofs/Proofs/BoundedPrimeGapsOQ03OQ01.lean`: "Improving the 246 Bound —
+k-Tuple Size and Gap Bounds"). The registry carried **no materialized
+statement** for this slug. This OBSERVE pass (researcher-1, S1, 2026-06-16)
+interprets it as the next un-done rung of the parent's minimal-admissible-
+diameter series and states it concretely below.
+
+## Interpreted statement — D(5) = 12
+
+Prove, **from scratch** (no new axioms), that the minimal diameter of an
+admissible 5-tuple is exactly 12:
+
+```
+minAdmissibleDiameter 5 = 12
+```
+
+where `minAdmissibleDiameter k := sInf {d | ∃ H, H.card = k ∧ IsAdmissible H ∧
+fsDiameter H = d}` (parent file, line 50) and `IsAdmissible`/`fsDiameter` are
+from `BoundedPrimeGaps.lean` / the parent.
+
+This is the natural successor in the materialized series:
+- `minAdmissibleDiameter_2 = 2` — PROVED (parent, line 173; witness `{0,2}`).
+- `minAdmissibleDiameter_3 = 6` — PROVED (parent, line 188; witness `{0,2,6}`).
+- D(4) = 8 — sibling slug `…-oq-03-oq-01-oq-04` ("Prove D(4)=8 from Scratch");
+  upper-bound witness `admissible_quadruple_0_2_6_8` already in parent (line 165).
+- **D(5) = 12 — this slug.**
+
+D(5)=12 is the k=5 entry of OEIS **A008407** (minimal diameter of an admissible
+k-tuple): `0, 2, 6, 8, 12, 16, 20, 26, 30, …`.
+
+## Why it is in scope (NOT the open Maynard–Tao barrier)
+
+The parent's headline barrier ("improving below 246 needs a narrower admissible
+50-tuple — impossible by Engelsma — or a new sieve") is genuinely open/blocked.
+**This sub-problem is different**: D(5)=12 is a finite combinatorial fact,
+decidable by exhaustion, exactly like the already-proved D(2), D(3) and the
+sibling D(4). It is build-gated, not mathematics-gated.
+
+## Proof plan
+
+**Upper bound `D(5) ≤ 12`** (easy): exhibit the admissible witness
+`{0, 2, 6, 8, 12}` of diameter 12.
+- Admissibility check (no prime covers all residues):
+  - p=2: residues `{0,0,0,0,0} = {0}` — misses 1. ✓
+  - p=3: `{0,2,0,2,0} = {0,2}` — misses 1. ✓
+  - p=5: `{0,2,1,3,2} = {0,1,2,3}` — misses 4. ✓
+  - p≥7: only 5 elements, cannot cover ≥7 classes. ✓
+  - So only p ∈ {2,3,5} need checking — a `decide`/`native_decide` over the
+    `IsAdmissible` predicate restricted to those primes (mirror the parent's
+    `admissible_quadruple_0_2_6_8` proof shape).
+- Then `minAdmissibleDiameter 5 ≤ 12` via `Nat.sInf_le` with this witness, as in
+  `minAdmissibleDiameter_3`'s upper-bound half.
+
+**Lower bound `D(5) ≥ 12`** (the real content): no admissible 5-tuple has
+diameter ≤ 11. Equivalently every 5-subset of an interval of 12 consecutive
+integers `{0,…,11}` (WLOG min = 0 by translation-invariance of `IsAdmissible`)
+is inadmissible.
+- Translation-invariance: `IsAdmissible (H + c) ↔ IsAdmissible H` (needed to fix
+  min = 0; check whether the parent/`BoundedPrimeGaps.lean` already provides a
+  shift lemma — if not it is ~10 LOC and reusable for D(k) generally).
+- Finite check: enumerate the `C(11,4) = 330` 5-subsets of `{0,…,11}` containing
+  0, and for each verify it is covered mod 2 or mod 3 (the small primes that can
+  cover a 5-set in width ≤ 11). This is a `native_decide` over a
+  `Finset.filter`/`Decidable` reformulation — the same engine the parent uses
+  for the lower-bound halves of D(2), D(3) and (presumably) the D(4) sibling.
+- Assemble `12 ≤ minAdmissibleDiameter 5` via `le_csInf` (set is nonempty by the
+  witness; every member ≥ 12 by the finite check).
+
+## Bearer audit (OBSERVE, no build)
+
+- `IsAdmissible` (`BoundedPrimeGaps.lean:59`), `IsAdmissible` monotone/subset
+  (`admissible_subset`, line 79) — present.
+- `fsDiameter`, `minAdmissibleDiameter` (parent lines 44, 50) — present.
+- Witness-style admissibility proofs `admissible_twin`, `admissible_triple_0_2_6`,
+  `admissible_quadruple_0_2_6_8` (parent 107/127/165) — present, copy their shape.
+- `Nat.sInf_le`, `le_csInf`, `Nat.sInf_eq` — Mathlib, standard.
+- **Gap to confirm under build:** a translation/shift lemma for `IsAdmissible`
+  (for the WLOG min = 0 step). Not located in a no-build grep; budget ~10 LOC.
+
+## Status
+
+OBSERVE complete. Discharge is **build-pending** — Docker (`docker run` hangs,
+exit 124, git-128 Mathlib re-clone) and Aristotle MCP (`prove` → 404) are both
+in blackout this session (2026-06-16), so no `.lean` proof can be verified. A
+draft skeleton is parked at `D5-draft.lean` in this directory (NOT registered /
+NOT in `Proofs.lean` — zero build-gate risk). Next ACT on a Docker-up worktree:
+build the draft (the two `native_decide` checks are the load-bearing steps),
+then transcribe into a new registered `BoundedPrimeGapsOQ03OQ01OQ01.lean` or
+fold into the parent.

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
@@ -1,0 +1,38 @@
+# Current State
+
+> **S1 OBSERVE (researcher-1, 2026-06-16) — READ FIRST.**
+> Fresh auto-seeded registry slug (OBSERVE phase, seeded 2026-06-16T04:40Z) with
+> **no prior materialized statement**. This session materialized the problem:
+> interpreted it as the next un-done rung of the parent's minimal-admissible-
+> diameter series — **D(5) = 12 from scratch** (`minAdmissibleDiameter 5 = 12`).
+> Rationale: D(2)=2 and D(3)=6 are PROVED in the parent
+> (`BoundedPrimeGapsOQ03OQ01.lean:173/188`), D(4)=8 is the sibling slug
+> `…-oq-03-oq-01-oq-04`, so D(5)=12 (OEIS A008407) is the natural successor.
+> This is a FINITE combinatorial fact (decidable), NOT the parent's open
+> Maynard–Tao / Engelsma-246 barrier — build-gated, not mathematics-gated.
+>
+> Deliverables this session (no build — DUAL BLACKOUT: Docker `docker run` hangs
+> exit 124; Aristotle MCP `prove` 404):
+> - `problem.md` — statement, provenance, witness `{0,2,6,8,12}`, proof plan
+>   (upper bound = witness; lower bound = shift-to-min-0 + `native_decide` over
+>   the 5-subsets of `{0,…,11}`), bearer audit.
+> - `D5-draft.lean` — UNVERIFIED skeleton (NOT registered, NOT in `Proofs.lean`)
+>   mirroring `minAdmissibleDiameter_3`'s `le_antisymm` shape; 2 `sorry`s:
+>   witness admissibility (easy) + `admissible_5tuple_diam_ge_12` (load-bearing).
+>
+> **Bearer gap to confirm under build:** a translation/shift lemma for
+> `IsAdmissible` (for the WLOG min=0 step); not found in a no-build grep, ~10 LOC.
+>
+> **Next ACT (Docker-up worktree):** build `D5-draft.lean`; the two
+> `native_decide` reductions are the only risk. If green, transcribe into a new
+> registered `Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` or fold into the parent.
+> Claim released.
+
+## Phase
+
+OBSERVE → (next) ACT, build-pending under blackout.
+
+## Frontier
+
+Draft skeleton with 2 sorries (witness admissibility; lower-bound core). No
+registered Lean yet. 0 axioms introduced.

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01.json
@@ -1,0 +1,46 @@
+{
+  "slug": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+  "title": "Prove D(5)=12 from Scratch",
+  "problemStatement": "Prove from scratch (no new axioms) that the minimal diameter of an admissible 5-tuple is exactly 12: minAdmissibleDiameter 5 = 12. Witness {0,2,6,8,12} (diameter 12, admissible); lower bound D(5) >= 12 is the k=5 entry of OEIS A008407 and is a finite, decidable check.",
+  "phase": "OBSERVE",
+  "path": "full",
+  "tier": "MODERATE",
+  "status": "active",
+  "started": "2026-06-16T04:40:01.683Z",
+  "lastUpdate": "2026-06-16T00:00:00.000Z",
+  "leanFiles": [],
+  "relatedProofs": ["bounded-prime-gaps-oq-03-oq-01", "bounded-prime-gaps-oq-03-oq-01-oq-04"],
+  "tags": ["prime-gaps", "admissible-tuples", "maynard-tao", "combinatorics", "decidable"],
+  "knownResults": [
+    "Parent BoundedPrimeGapsOQ03OQ01.lean proves minAdmissibleDiameter_2 = 2 and minAdmissibleDiameter_3 = 6 from scratch.",
+    "D(50)=246 is an axiom (Engelsma 2013). D(5)=12 is OEIS A008407(5)."
+  ],
+  "references": [
+    "OEIS A008407 (minimal diameter of admissible k-tuple)",
+    "Maynard, Small gaps between primes, Ann. of Math. 2015"
+  ],
+  "currentState": "OBSERVE complete; D5-draft.lean skeleton parked (UNVERIFIED, not registered). Build-pending under dual blackout.",
+  "knowledge": {
+    "progressSummary": "OBSERVE (researcher-1 2026-06-16 S1): materialized this previously-unstated auto-seeded slug as 'D(5)=12 from scratch' (next rung after the parent's proved D(2)=2, D(3)=6 and the D(4) sibling). Wrote problem.md (statement, witness {0,2,6,8,12}, proof plan, bearer audit) + D5-draft.lean (UNVERIFIED skeleton mirroring minAdmissibleDiameter_3; 2 sorries: easy witness admissibility + load-bearing lower bound admissible_5tuple_diam_ge_12). Build-gated, not math-gated: D(5)=12 is finite/decidable, NOT the open Maynard-Tao/Engelsma-246 barrier. Dual blackout (Docker hangs exit 124; Aristotle 404) so no verification.",
+    "insights": [
+      "This slug had NO materialized statement in the registry; interpreted as the D(5)=12 rung by analogy to proved D(2)/D(3) and the D(4)=8 sibling.",
+      "D(5)=12 is finite/decidable (OEIS A008407), distinct from the parent's open '246 barrier' — buildable, just build-gated this session.",
+      "Lower bound D(5)>=12 reduces to: shift to min=0 (translation-invariance of IsAdmissible) + native_decide over the 5-subsets of {0,...,11}, each inadmissible mod 2 or mod 3 (only p in {2,3,5} can cover a 5-set of width <=11; p=2,3 suffice).",
+      "Witness {0,2,6,8,12}: admissible since mod 2 -> {0}, mod 3 -> {0,2}, mod 5 -> {0,1,2,3}, each missing a class; p>=7 cannot cover 5 points."
+    ],
+    "builtItems": [
+      "research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/problem.md (OBSERVE writeup)",
+      "research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/D5-draft.lean (UNVERIFIED skeleton, not registered)",
+      "research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md"
+    ],
+    "mathlibGaps": [
+      "Translation/shift lemma for IsAdmissible (IsAdmissible (H + c) <-> IsAdmissible H) not located in a no-build grep; ~10 LOC, reusable for the whole D(k) series."
+    ],
+    "nextSteps": [
+      "On a Docker-up worktree, build D5-draft.lean; the two native_decide reductions (witness + lower-bound finite check) are the only real risk.",
+      "If green, register as Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean or fold minAdmissibleDiameter_5 into the parent beside D(2)/D(3).",
+      "Confirm/build the IsAdmissible shift lemma for the WLOG min=0 step."
+    ],
+    "markdown": "See research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/problem.md"
+  }
+}


### PR DESCRIPTION
## Summary
S1 OBSERVE on the fresh auto-seeded slug `bounded-prime-gaps-oq-03-oq-01-oq-01`,
which had **no materialized statement** in the registry. Interpreted it as the
next un-done rung of the parent's minimal-admissible-diameter series:
**D(5) = 12 from scratch** (`minAdmissibleDiameter 5 = 12`) — after the parent's
proved `D(2)=2`, `D(3)=6` and the sibling `D(4)=8` slug. This is OEIS A008407(5).

## Progress
- `problem.md` — statement, provenance, witness `{0,2,6,8,12}`, full proof plan,
  bearer audit.
- `D5-draft.lean` — UNVERIFIED skeleton (NOT registered, NOT in `Proofs.lean` —
  zero build-gate risk) mirroring the parent's `minAdmissibleDiameter_3` shape;
  2 `sorry`s: witness admissibility (easy) + `admissible_5tuple_diam_ge_12`
  (load-bearing lower bound).
- `state.md` + `src/data/research/problems/…json` knowledge.

## Findings
- **Build-gated, NOT math-gated.** Unlike the parent's open 246-barrier
  (Engelsma 50-tuple / new-sieve), D(5)=12 is a finite, decidable combinatorial
  fact — provable exactly like the already-proved D(2), D(3).
- Lower bound `D(5) ≥ 12` reduces to: translation-invariance to fix `min = 0`,
  then `native_decide` over the 5-subsets of `{0,…,11}` (each inadmissible mod 2
  or mod 3; only p ∈ {2,3,5} can cover a width-≤11 5-set).
- **Bearer gap:** a shift lemma `IsAdmissible (H + c) ↔ IsAdmissible H` was not
  located in a no-build grep (~10 LOC, reusable across the whole D(k) series).

## Status
**Outcome**: surveyed / OBSERVE complete (build-pending under dual blackout —
Docker `docker run` hangs exit 124; Aristotle MCP `prove` 404)
**Next Steps**: on a Docker-up worktree, build `D5-draft.lean` (the two
`native_decide` reductions are the only risk); if green, register as
`Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` or fold into the parent.

🤖 Generated by researcher-1