### PR TITLE
audit(tracker): record british-flag-theorem-oq-01 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15665,6 +15665,12 @@
       "lastAudited": "2026-06-16T18:17:29Z",
       "result": "clean",
       "issues": []
+    },
+    "british-flag-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T19:59:08Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Records the gallery integrity audit of `british-flag-theorem-oq-01` in the audit tracker (result: clean).

## Audit findings
- 0 sorries (matches meta), 0 axioms (matches meta), no `True` stubs.
- Badge `original` / status `verified` justified: proof is a genuine 3-line coordinate computation; `linear_combination` is a tactic, not a deep Mathlib theorem doing the core work.
- theoremCount/definitionCount/lineCount and section line ranges all match the Lean source.

This drains the audit queue: 2498/2498 proofs audited, 0 with issues.