### PR TITLE
research(zsqrtd-neg-two-oq-02): S10 even-core residual — thin-prime trick fails

### DIFF
--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -436,3 +436,66 @@ subset, structurally insufficient).
 ### Files touched (S8)
 - `verify_single_ap_coverage.py` — new (single-AP QR + coverage certificate).
 - `knowledge.md` / `state.md` — this entry.
+
+## Session 2026-06-16 (S10, researcher-2) — even-core residual: thin-prime trick FAILS; correction to S8
+
+**Mode**: REVISIT · **Phase**: ORIENT/certify (build-free; DUAL BLACKOUT confirmed
+this session — `docker version` rc=124 timeout, daemon hung; `proofs/.lake` is the
+self-referential symlink loop `proofs/.lake -> proofs/.lake` ⇒ "Too many levels of
+symbolic links" ⇒ Mathlib oleans unreachable even if Docker came up). No `.lean`
+edited. Aristotle not applicable (the residual is a reduction-design question, not a
+single `sorry` target).
+
+### What S8 left open, and what this session settles
+
+S8 reduced the sufficiency picture to: ODD 4-free cores discharged via
+`ThreeSquaresSingleAP` (prime `p ≡ 1 mod 4n` ⇒ `legendreSym(p,−n)=1`), leaving the
+**EVEN 4-free cores** `n%8 ∈ {2,6}` (`4∤n`) as the sole residual, with the open
+question *"keep a Dirichlet witness restricted to even cores, OR find a 2-descent —
+which is cleaner?"*. The tempting clean option is to transplant the residue-3
+**thin-prime** trick (odd `t`, `(m−t²)/2` prime ⇒ Fermat two-squares) to even cores
+using **even** `t`.
+
+**That transplant is FALSE.** Certified in `verify_even_core_witness.py`
+(`n%4==2`, `2<n≤10⁶`, 249999 cores):
+
+- Parity: a three-square rep of `n≡2 mod4` uses exactly two ODD squares + one EVEN
+  square `t`, so `n − t² = (odd)²+(odd)² = 2s`, `s=(n−t²)/2` odd, and
+  `s=c²+d² ⟺ n = t² + (c+d)² + (c−d)²`. So an even-core witness ⟺ **even `t` with
+  `(n−t²)/2` a sum of two squares.**
+- **STRICT** ("`s` prime, `s%4=1`" — the residue-3-style reduction): **45 sporadic
+  failures**, members as large as **68566** within 10⁶:
+  `{6,18,22,54,66,102,114,130,166,190,286,306,354,438,454,478,534,646,666,694,766,
+  826,994,2146,…,36670,68566}`. E.g. `n=22`: even `t∈{0,2,4}` give `s∈{11,9,3}`;
+  `11,3` are primes `≡3 mod4`, `9` is composite — yet `9=3²+0²` so `22=2²+3²+3²`.
+  ⇒ the thin-prime trick does **not** transplant to even cores.
+- **BROAD** ("`s` a sum of two squares" — the true characterization): **0 failures**,
+  identity `n=t²+(c+d)²+(c−d)²` exact (0 failures), max even `t` needed = 96. But
+  "∃ even `t` with `(n−t²)/2` a sum of two squares" is a **reformulation of the goal**
+  (n is three squares with an even coordinate), NOT a reduction to a
+  Dirichlet-dischargeable statement.
+
+### Correction to S8 and refined wiring plan
+
+- **S8's "even-core thin-prime might be cleaner" is wrong.** There is no clean
+  thin-prime even-core lemma; a future Docker session should NOT attempt one.
+- Even cores must go through the **general QR/Minkowski route**: the relaxed
+  `dirichlet_key_lemma` `(hqr : legendreSym p (−(n:ℤ)) = 1) ⇒ ∃ x y z, x²+y²+z²=n`
+  (S8 §"Turnkey wiring", which does NOT require `Odd n` — `legendreSym p a` is fine
+  for even residue `a`). The ONLY even-specific work is the **prime finder**:
+  `ThreeSquaresSingleAP.legendreSym_neg_n_eq_one` needs `Odd n` for the Jacobi
+  reciprocity step, so for even `n=2m` (`m` odd) split `−n = −2m` and choose `p`'s
+  residue class mod `8m` so that `legendreSym p (−2)·legendreSym p m = +1` (the
+  `χ₈`/`χ₄` supplementary laws + reciprocity on the odd part `m`). Then Dirichlet-AP
+  supplies the prime. This is an **extension** of SingleAP for the factor of 2, not a
+  Fermat shortcut.
+- Net unchanged deep work (Docker-gated): (1) land the S6 elaboration fix
+  (`IsSquare ((−d:ℤ):ZMod p)` form) + build/register the corrected companions;
+  (2) generalize the SingleAP prime finder to even `n` per the split above;
+  (3) discharge the relaxed `dirichlet_key_lemma` via a **2D-slice** Minkowski
+  (S "researcher-11" note: the 3D ellipsoid cannot reach `Q<2p`).
+
+### Files touched (S9)
+- `research/problems/zsqrtd-neg-two-oq-02/verify_even_core_witness.py` — new
+  (STRICT-fails-sporadically + BROAD-always-holds + identity certificate).
+- `knowledge.md` / `state.md` — this entry.

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,32 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S10 — even-core residual: thin-prime trick FAILS (researcher-2, 2026-06-16)
+
+**Phase**: ORIENT/certify (build-free; DUAL BLACKOUT this session — `docker version`
+rc=124 daemon hung; host `proofs/.lake` self-symlink loop). No `.lean` edited.
+
+Settles the S8 open sub-task "even cores `n%8∈{2,6}`: keep a Dirichlet witness, OR
+find a cleaner thin-prime 2-descent?" — and CORRECTS S8's hint that thin-prime might
+be cleaner. Certificate `verify_even_core_witness.py` (`n%4==2`, `2<n≤10⁶`):
+
+- Even-core witness ⟺ even `t` with `(n−t²)/2` a sum of two squares
+  (`n = t²+(c+d)²+(c−d)²`).
+- STRICT (`(n−t²)/2` prime `≡1 mod4`, the residue-3 trick): **45 sporadic
+  failures**, max **68566** → the thin-prime trick does NOT transplant to even cores.
+- BROAD (`(n−t²)/2` a sum of two squares): **0 failures**, identity exact — but it is
+  a reformulation of the goal, not a Dirichlet-reducible statement.
+
+⇒ Even cores must use the general QR/Minkowski route (relaxed `dirichlet_key_lemma`,
+which does NOT need `Odd n`); the only even-specific work is extending the SingleAP
+prime finder via `−n=−2m` (`χ₈`/`χ₄` supplementary laws + reciprocity on odd `m`).
+A future Docker session should NOT attempt a (false) even-core thin-prime lemma.
+
+**Next (backend-up)**: per S8 §4 + S10 — land S6 elaboration fix, build/register
+companions, extend SingleAP finder to even `n`, discharge relaxed key lemma via 2D
+Minkowski.
+
+---
+
 ## S9 — Docker build-VERIFIED registered SingleAP green (researcher-1, 2026-06-16)
 
 **Phase**: ORIENT/verify (Docker RECOVERED — cache volume `lean-mathlib-cache`

--- a/research/problems/zsqrtd-neg-two-oq-02/verify_even_core_witness.py
+++ b/research/problems/zsqrtd-neg-two-oq-02/verify_even_core_witness.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+S9 certificate for zsqrtd-neg-two-oq-02 (Legendre three-square sufficiency).
+
+Resolves the EVEN-CORE residual that S8 flagged as the last open sub-task of the
+sufficiency wiring, and CORRECTS the S8 suggestion that an even-core thin-prime
+witness might be "cleaner" than keeping a Dirichlet witness.
+
+Background (knowledge.md S8):
+  After wiring `ThreeSquaresSingleAP`, the ODD 4-free cores (n % 8 in {1,3,5})
+  are discharged uniformly: a prime p == 1 (mod 4n) gives legendreSym(p,-n)=1,
+  fed to (relaxed) dirichlet_key_lemma. The ONLY residual witness content is the
+  EVEN 4-free cores n % 8 in {2,6} (4 // n) -- legendreSym_neg_n_eq_one requires
+  Odd n (the Jacobi bottom must be odd), so it cannot serve them.
+
+The odd residue-3 route (S3/S5) discharged its class via a THIN PRIME deficit:
+  pick odd t with s := (m - t^2)/2 PRIME; s % 4 == 1 is then automatic, so
+  s = a^2 + b^2 (Fermat, Nat.Prime.sq_add_sq), giving
+      m = t^2 + (a+b)^2 + (a-b)^2.
+The natural question (S8): does the same THIN-PRIME trick work for even cores
+with EVEN t?  This script answers it.
+
+Parity setup for n % 4 == 2:  a sum of three squares of n must use exactly two
+ODD squares and one EVEN square (1+1+0 == 2 mod 4).  Writing the even one as t:
+      n - t^2 = (odd)^2 + (odd)^2  ==  2 s,   s = (n - t^2)/2  (s odd),
+and s = c^2 + d^2  <=>  n = t^2 + (c+d)^2 + (c-d)^2.   So an even-core witness is
+exactly an even t with s := (n - t^2)/2 a SUM OF TWO SQUARES.
+
+Two candidate statements, both with EVEN t and s = (n - t^2)/2:
+  (STRICT)  s is a PRIME with s % 4 == 1            <- the residue-3-style trick
+  (BROAD)   s is a SUM OF TWO SQUARES               <- the true characterization
+
+FINDINGS (this script, n % 4 == 2, 2 < n <= NMAX):
+  * STRICT fails on a SPORADIC set: {6,18,22,54,66,...} with members as large as
+    68566 within 10^6 -- so the residue-3 thin-prime trick does NOT transplant to
+    even cores. (For these n no even t makes (n-t^2)/2 a prime == 1 mod 4; e.g.
+    n=22: t in {0,2,4} give s in {11, 9, 3}; 11,3 are primes == 3 mod 4 and 9 is
+    composite -- yet 9 = 3^2+0^2 IS a sum of two squares, so 22 = 2^2+3^2+3^2.)
+  * BROAD has ZERO failures, and the identity n = t^2+(c+d)^2+(c-d)^2 is exact.
+    But "exists even t with (n-t^2)/2 a sum of two squares" is a REFORMULATION of
+    "n is a sum of three squares with one even coordinate" -- it is the goal
+    restated, NOT a reduction to an easier (Dirichlet-discharge-able) statement.
+
+CONCLUSION (corrects S8): even cores have NO clean thin-prime reduction. They
+must be discharged by the GENERAL QR/Minkowski route -- the relaxed
+dirichlet_key_lemma with legendreSym p (-(n:int)) = 1 -- where the prime finder
+is generalized to even n by splitting -n = -2m (m = n/2 odd) and choosing p's
+residue class so legendreSym p (-2) * legendreSym p (-m)... resolves to +1.
+The SingleAP lemma must therefore be extended for the factor of 2; it is not
+replaced by a Fermat two-square shortcut. This saves a future Docker session
+from attempting a (false) even-core thin-prime lemma.
+
+Pure Python, no Docker, no Lean. Reproducible.
+"""
+
+from sympy import isprime
+
+NMAX = 1_000_000
+
+
+def is_excluded(n: int) -> bool:
+    while n % 4 == 0:
+        n //= 4
+    return n % 8 == 7
+
+
+def is_sum_two_squares(s: int) -> bool:
+    """s >= 0 is a sum of two squares <=> every prime == 3 mod 4 divides s to
+    an even power."""
+    if s < 0:
+        return False
+    if s == 0:
+        return True
+    m = s
+    d = 3
+    while d * d <= m:
+        if m % d == 0:
+            e = 0
+            while m % d == 0:
+                m //= d
+                e += 1
+            if d % 4 == 3 and e % 2 == 1:
+                return False
+        d += 2
+    if m % 4 == 3:  # leftover prime factor
+        return False
+    return True
+
+
+def two_square_decomp(s: int):
+    """Return (c,d), c>=d>=0, c^2+d^2 = s (assumes s is a sum of two squares)."""
+    c = int(s ** 0.5)
+    while c >= 0:
+        r = s - c * c
+        d = int(r ** 0.5)
+        for dd in (d - 1, d, d + 1):
+            if 0 <= dd <= c and c * c + dd * dd == s:
+                return (c, dd)
+        c -= 1
+    return None
+
+
+def main() -> None:
+    strict_fail = []
+    broad_fail = []
+    identity_fail = []
+    residue_bad = []
+    excluded_bad = []
+    max_t = 0
+    count = 0
+
+    n = 6
+    while n <= NMAX:
+        if n % 4 == 2:
+            count += 1
+            if n % 8 not in (2, 6):
+                residue_bad.append(n)
+            if is_excluded(n):
+                excluded_bad.append(n)
+
+            ok_strict = False
+            broad_witness = None
+            t = 0
+            while t * t < n:
+                rem = n - t * t
+                if rem % 2 == 0:
+                    s = rem // 2
+                    if not ok_strict and s >= 2 and s % 4 == 1 and isprime(s):
+                        ok_strict = True
+                    if broad_witness is None and is_sum_two_squares(s):
+                        broad_witness = (t, s)
+                t += 2
+
+            if not ok_strict:
+                strict_fail.append(n)
+            if broad_witness is None:
+                broad_fail.append(n)
+            else:
+                t, s = broad_witness
+                max_t = max(max_t, t)
+                cd = two_square_decomp(s)
+                if cd is None:
+                    identity_fail.append((n, "no decomp", s))
+                else:
+                    c, d = cd
+                    if t * t + (c + d) ** 2 + (c - d) ** 2 != n:
+                        identity_fail.append((n, t, c, d))
+        n += 4
+
+    print("=" * 70)
+    print(f"EVEN-CORE witness certificate  (n == 2 mod 4, 2 < n <= {NMAX})")
+    print("=" * 70)
+    print(f"cores checked (n % 4 == 2):              {count}")
+    print(f"residue check (all n%8 in {{2,6}}):        "
+          f"{'OK' if not residue_bad else residue_bad[:10]}")
+    print(f"excluded among them (expect 0):          {len(excluded_bad)}")
+    print()
+    print(f"STRICT (prime, s%4==1) FAILURES:         {len(strict_fail)}  "
+          f"(max {max(strict_fail) if strict_fail else None})")
+    print(f"   sporadic set: {strict_fail}")
+    print()
+    print(f"BROAD (sum-of-two-squares) FAILURES:     {len(broad_fail)}  "
+          f"{'OK' if not broad_fail else broad_fail[:20]}")
+    print(f"identity n=t^2+(c+d)^2+(c-d)^2 FAILURES:  {len(identity_fail)}  "
+          + (str(identity_fail[:5]) if identity_fail else "OK"))
+    print(f"max even t needed (broad):               {max_t}")
+    print("=" * 70)
+    print("INTERPRETATION:")
+    print(" * STRICT fails sporadically => the residue-3 thin-prime trick does")
+    print("   NOT transplant to even cores.")
+    print(" * BROAD always holds + identity exact, but it is a reformulation of")
+    print("   the goal, not a Dirichlet-reducible statement.")
+    print(" => even cores need the general QR/Minkowski (relaxed dirichlet_key_lemma)")
+    print("    route with the prime finder extended to the factor of 2 in -n=-2m.")
+    ok = (not broad_fail and not identity_fail
+          and not residue_bad and not excluded_bad)
+    print("=" * 70)
+    print("RESULT:", "BROAD + identity + residue checks PASS"
+          if ok else "*** CHECKS FAILED ***")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Build-free research session on **zsqrtd-neg-two-oq-02** (Legendre–Gauss three-square theorem sufficiency). Settles the last open sub-task S8 flagged — the **even 4-free cores** `n%8 ∈ {2,6}` that `ThreeSquaresSingleAP` cannot serve — and **corrects** S8's hint that a thin-prime 2-descent might be cleaner for them.

## Finding
New certificate `verify_even_core_witness.py` (`n%4==2`, `2<n≤10⁶`, 249,999 cores):

- An even-core witness ⟺ an **even** `t` with `(n−t²)/2` a **sum of two squares**, giving `n = t² + (c+d)² + (c−d)²`.
- **STRICT** (residue-3-style: `(n−t²)/2` prime `≡1 mod 4`): **45 sporadic failures**, members as large as **68566** within 10⁶ (e.g. `n=22`). → the thin-prime trick does **not** transplant to even cores.
- **BROAD** (`(n−t²)/2` a sum of two squares): **0 failures**, identity exact — but it is a *reformulation* of the goal, not a Dirichlet-reducible statement.

**Conclusion:** even cores must use the general QR/Minkowski route — the relaxed `dirichlet_key_lemma` `(legendreSym p (−(n:ℤ))=1) ⇒ ∃ x y z, x²+y²+z²=n` (which does **not** require `Odd n`). The only even-specific work is extending the SingleAP prime finder via `−n=−2m` (χ₈/χ₄ supplementary laws + reciprocity on odd `m`). A future Docker session should **not** attempt a (false) even-core thin-prime lemma.

## Infra
Dual blackout this session: Docker daemon hung (`docker version` rc=124) and host `proofs/.lake` is a self-symlink loop → no Lean build. **No `.lean` edited.** Deliverable is a reproducible pure-Python certificate + knowledge/state updates.

## Test plan
- [x] `python3 research/problems/zsqrtd-neg-two-oq-02/verify_even_core_witness.py` → "BROAD + identity + residue checks PASS"; STRICT prints the 45-member sporadic failure set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)