### PR TITLE
Enrich leibniz-pi-oq-02: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-02/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-02/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-leibniz-alt-harmonic",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 44,
-      "endLine": 71
+      "startLine": 53,
+      "endLine": 70
     },
     "type": "concept",
     "title": "Alternating Harmonic Series: $\\eta(1) = \\ln 2$",
@@ -27,8 +27,8 @@
     "id": "ann-leibniz-beta-function",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 72,
-      "endLine": 91
+      "startLine": 76,
+      "endLine": 90
     },
     "type": "definition",
     "title": "Dirichlet Beta Function Partial Sums",
@@ -50,7 +50,7 @@
     "id": "ann-leibniz-catalan",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 93,
+      "startLine": 96,
       "endLine": 119
     },
     "type": "concept",
@@ -74,7 +74,7 @@
     "id": "ann-leibniz-beta-three",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 121,
+      "startLine": 125,
       "endLine": 133
     },
     "type": "concept",
@@ -96,7 +96,7 @@
     "id": "ann-leibniz-eta-zeta",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 164,
+      "startLine": 168,
       "endLine": 176
     },
     "type": "insight",
@@ -120,7 +120,7 @@
     "id": "ann-leibniz-beta-eta-pattern",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 179,
+      "startLine": 182,
       "endLine": 200
     },
     "type": "insight",
@@ -143,7 +143,7 @@
     "id": "ann-leibniz-partial-sum-recurrence",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 202,
+      "startLine": 206,
       "endLine": 218
     },
     "type": "concept",
@@ -188,8 +188,8 @@
     "id": "ann-leibniz-irrationality",
     "proofId": "leibniz-pi-oq-02",
     "range": {
-      "startLine": 242,
-      "endLine": 276
+      "startLine": 246,
+      "endLine": 275
     },
     "type": "concept",
     "title": "Irrationality Status and Numerical Bounds",


### PR DESCRIPTION
Enrichment pass for `leibniz-pi-oq-02` (Leibniz π/4 formula and Dirichlet beta/eta family).

The annotation ranges had drifted off their constructs — the resolver flagged 8 of 9 annotations as "No Lean construct found".

## Changes
- Re-anchored each annotation to its current declaration: alt-harmonic (44→53), beta-function def (72→76), Catalan (93→96), β(3) (121→125), eta-zeta axiom (164→168), the β/η pattern table (179→182), partial-sum recurrences (202→206), irrationality/bounds (242→246).
- Verified content against the source: the file genuinely has **9 sorries** and **1 axiom** (`eta_zeta_relation`), so the existing "sorry"/"axiom" descriptions are accurate — this was pure range drift, no content changes needed.

## Validation
`resolver.ts validate`: **9 valid / 0 misaligned** (was 1 valid / 8 misaligned).