### PR TITLE
Enrich elementary-quadratic-reciprocity-oq-03-oq-02-oq-03: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03/annotations.json
@@ -29,7 +29,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-fund-disc",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 48,
+      "startLine": 57,
       "endLine": 77
     },
     "type": "definition",
@@ -53,7 +53,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-qr-proved-cases",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 78,
+      "startLine": 83,
       "endLine": 124
     },
     "type": "technique",
@@ -77,7 +77,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-helpers",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 125,
+      "startLine": 134,
       "endLine": 156
     },
     "type": "technique",
@@ -101,7 +101,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-odd-fundamental",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 157,
+      "startLine": 162,
       "endLine": 263
     },
     "type": "insight",
@@ -127,7 +127,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-axiom",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 264,
+      "startLine": 269,
       "endLine": 286
     },
     "type": "context",
@@ -152,7 +152,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-combined",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 287,
+      "startLine": 292,
       "endLine": 321
     },
     "type": "insight",
@@ -177,7 +177,7 @@
     "id": "ann-eqr-oq3-oq2-oq3-numerical",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 322,
+      "startLine": 327,
       "endLine": 361
     },
     "type": "insight",
@@ -227,8 +227,8 @@
     "id": "ann-eqr-oq3-oq2-oq3-summary",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
     "range": {
-      "startLine": 372,
-      "endLine": 403
+      "startLine": 377,
+      "endLine": 402
     },
     "type": "context",
     "title": "Part V: kronecker_qr_all_cases — Unified Summary",


### PR DESCRIPTION
## Summary
Whole-set annotation drift on the Generalized Quadratic Reciprocity / Kronecker Symbol entry.

- **Resolver before:** 2 valid / 8 misaligned. Drifted annotations were anchored on the namespace declaration or blank lines preceding their target constructs.
- **Resolver after:** 10 valid / 0 misaligned. Re-anchored each to its named construct's `[doc-comment, decl-end]` range via `scripts/annotations/resolver.ts parse`.

## Axiom integrity
The "Sole Axiom" annotation correctly tracks `kronecker_qr_even_fundamental`, the single `axiom` in the file; `axiomCount: 1` in meta.json is accurate. No content changes.

## Validation
`npx tsx scripts/annotations/resolver.ts validate` → 10 valid, 0 misaligned. JSON parses.