### PR TITLE
Enrich British Flag Theorem: add missing index.ts

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/index.ts
+++ b/src/data/proofs/british-flag-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BritishFlagTheorem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const britishFlagTheoremOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const britishFlagTheoremOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const britishFlagTheoremOq01Data: ProofData = {
+  proof: britishFlagTheoremOq01Proof,
+  annotations: britishFlagTheoremOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01`.

The gallery dir had `meta.json` and a strong 5-annotation `annotations.json`, but **no `index.ts`** — so Vite's `import.meta.glob` could not discover the proof and the page showed 'proof not found' on the live site.

## Change
- Added the standard `index.ts` loader (proof + annotations + Lean source export).

No content changes: the existing annotations are already resolver-validated (5 valid, 0 misaligned) and meta is high quality. This is purely the missing-loader fix that makes the page render.