### PR TITLE
Enrich abel-ruffini-oq-10: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-10/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-10/annotations.json
@@ -29,7 +29,7 @@
     "id": "prime-density-definition",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 66,
+      "startLine": 71,
       "endLine": 80
     },
     "type": "definition",
@@ -53,8 +53,8 @@
     "id": "chebotarev-axiom",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 81,
-      "endLine": 109
+      "startLine": 95,
+      "endLine": 108
     },
     "type": "concept",
     "title": "Chebotarev Density Axiom",
@@ -79,7 +79,7 @@
     "id": "split-completely",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 110,
+      "startLine": 114,
       "endLine": 134
     },
     "type": "theorem",
@@ -103,7 +103,7 @@
     "id": "dirichlet-special-case",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 135,
+      "startLine": 155,
       "endLine": 159
     },
     "type": "theorem",
@@ -129,7 +129,7 @@
     "id": "s5-class-structure",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 160,
+      "startLine": 174,
       "endLine": 221
     },
     "type": "insight",
@@ -155,8 +155,8 @@
     "id": "a5-class-structure",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 222,
-      "endLine": 261
+      "startLine": 242,
+      "endLine": 260
     },
     "type": "insight",
     "title": "A₅ Conjugacy Classes: 5-Cycles Split in Two",
@@ -181,8 +181,8 @@
     "id": "density-fraction-arithmetic",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 262,
-      "endLine": 307
+      "startLine": 266,
+      "endLine": 306
     },
     "type": "tactic",
     "title": "Chebotarev Density Fractions: norm_num Verification",
@@ -205,8 +205,8 @@
     "id": "density-solvability-detection",
     "proofId": "abel-ruffini-oq-10",
     "range": {
-      "startLine": 308,
-      "endLine": 369
+      "startLine": 332,
+      "endLine": 367
     },
     "type": "insight",
     "title": "Chebotarev as Solvability Detector",


### PR DESCRIPTION
## Summary
Whole-set annotation drift on the Chebotarev Density Theorem entry (`abel-ruffini-oq-10`).

- **Resolver before:** 1 valid / 8 misaligned. Drifted annotations were anchored on block-comment or blank lines preceding their target constructs.
- **Resolver after:** 9 valid / 0 misaligned. Re-anchored each to its named construct's `[doc-comment, decl-end]` range via `scripts/annotations/resolver.ts parse`.

## Axiom integrity
Two `axiom` declarations remain (`chebotarev_density`, `dirichlet_density`); `axiomCount: 2` in meta.json is accurate. No content changes.

## Validation
`npx tsx scripts/annotations/resolver.ts validate` → 9 valid, 0 misaligned. JSON parses.