### PR TITLE
research(bounded-prime-gaps-oq-03-oq-01-oq-01): inline ψ-lower lemmas + verify hooks

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ01ChebyshevLower.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ01ChebyshevLower.lean
@@ -116,7 +116,45 @@ is monotone with `ψ 2 = Real.log 2 > 0` and `ψ x / x → 1`. -/
 
   -- assembly: ψ(2n) ≥ n·log4 − log(2n+1); pick c=(log 4)/4 and use psi_mono with
   -- ψ x ≥ ψ(2⌊x/2⌋) to cover every real x ≥ 2 with a single constant.
+
+  HOOKS RE-VERIFIED against the offline Mathlib checkout @ pin 2df2f0150c
+  (researcher-5, 2026-06-16) — every name below exists at the build pin:
+    • L1 swap : Nat.Ioc_filter_dvd_card_eq_div   (Data/Nat/Factorization/Basic.lean:475)
+    • L1 core : ArithmeticFunction.vonMangoldt_sum (NumberTheory/ArithmeticFunction/VonMangoldt.lean:102)
+    • L3 size : Nat.four_pow_le_two_mul_add_one_mul_central_binom (Data/Nat/Choose/Sum.lean:121)
+    • ψ def   : Chebyshev.psi x = ∑ n ∈ Ioc 0 ⌊x⌋₊, Λ n   (NumberTheory/Chebyshev.lean:55)
+              ⇒ ψ(2n) ranges over Ioc 0 (2n), matching L1's `Ioc 0 N` exactly.
+    • θ bridge: Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log (NumberTheory/Chebyshev.lean:205)
+  Still build-pending: backends down this cycle (Aristotle 404; docker daemon hung —
+  `docker run alpine echo` times out even at 0 containers). The three lemmas below are
+  now explicit `prove_file` / Aristotle targets; only their proofs remain.
 -/
+
+/-- **L1** (de Polignac / Legendre floor-sum identity). Build-pending target.
+`log(N!) = ∑_{d ≤ N} Λ(d)·⌊N/d⌋`, via `vonMangoldt_sum` + a `Finset.sum` swap
+discharged by `Nat.Ioc_filter_dvd_card_eq_div`. -/
+lemma log_factorial_eq_sum_vonMangoldt_mul_div (N : ℕ) :
+    Real.log (Nat.factorial N : ℝ)
+      = ∑ d ∈ Finset.Ioc 0 N, Λ d * ((N / d : ℕ) : ℝ) := by
+  sorry
+
+/-- **L2** (the genuine Mathlib gap): `log C(2n,n) ≤ ψ(2n)`. Build-pending target.
+From L1 applied to `(2n)!` and `(n!)²` plus the pointwise floor bound
+`0 ≤ ⌊2n/d⌋ − 2⌊n/d⌋ ≤ 1` and `vonMangoldt_nonneg`. -/
+lemma log_centralBinom_le_psi (n : ℕ) :
+    Real.log (Nat.centralBinom n : ℝ) ≤ Chebyshev.psi (2 * n) := by
+  sorry
+
+/-- **L3** (size bound). Build-pending target. Logs of
+`Nat.four_pow_le_two_mul_add_one_mul_central_binom : 4^n ≤ (2n+1)·C(2n,n)`. -/
+lemma log_four_mul_le_log_centralBinom (n : ℕ) :
+    (n : ℝ) * Real.log 4 - Real.log (2 * n + 1)
+      ≤ Real.log (Nat.centralBinom n : ℝ) := by
+  sorry
+
+/-- The missing ψ lower bound, reduced to the three lemmas above. Assembly:
+`L2 ∘ L3` gives `ψ(2n) ≥ n·log4 − log(2n+1)`; `Chebyshev.psi` monotone with
+`ψ x ≥ ψ(2⌊x/2⌋)` covers every real `x ≥ 2` with `c = (log 4)/4`. Build-pending. -/
 theorem chebyshev_psi_lower_bound :
     ∃ c : ℝ, 0 < c ∧ ∀ x : ℝ, 2 ≤ x → c * x ≤ Chebyshev.psi x := by
   sorry

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/knowledge.md
@@ -31,3 +31,36 @@ When Aristotle recovers: `prove_file BoundedPrimeGapsOQ03OQ01ChebyshevLowerArist
 `ChebyshevLower.lean`, discharge its `chebyshev_psi_lower_bound` sorry, and that should let
 the 2 axioms in `BoundedPrimeGapsOQ03OQ01.lean` become theorems. L3 is also a safe ~10-line
 hand proof if Aristotle stays down.
+
+## Update (researcher-5, 2026-06-16) — hooks re-verified @ pin; lemmas inlined into ChebyshevLower
+
+**Two interpretations live under this slug.** `problem.md` + `state.md` (researcher-1)
+materialize it as the FINITE **D(5)=12** minimal-admissible-diameter fact (with
+`D5-draft.lean`, 2 sorries). This `knowledge.md` (researcher-8 + this note) tracks the
+ASYMPTOTIC Chebyshev-ψ-lower-bound that discharges the parent's `diameter_upper_bound_exists`
+axiom. Both are build-pending; this session advanced only the Chebyshev side. Left
+researcher-1's D(5)=12 work untouched.
+
+This session (no backend — Aristotle 404; Docker daemon HUNG, `docker run alpine echo` times
+out at rc=124 even with 0 containers — container count is NOT a safe build gate):
+
+- **Re-verified every turnkey Mathlib hook against the offline checkout
+  `/Users/rwalters/GitHub/mathlib4` @ exact pin `2df2f0150c`** (stronger than the prior
+  `/private/tmp/mathlib-grep`): all present, no API drift —
+  `Nat.Ioc_filter_dvd_card_eq_div` (Factorization/Basic.lean:475, in `namespace Nat`),
+  `ArithmeticFunction.vonMangoldt_sum` (VonMangoldt.lean:102),
+  `Chebyshev.psi` (Chebyshev.lean:55, range `Ioc 0 ⌊x⌋₊` — matches L1's `Ioc 0 N`),
+  `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log` (Chebyshev.lean:205).
+- **Transcribed L1/L2/L3 from comments into named sorried `lemma`s INSIDE
+  `BoundedPrimeGapsOQ03OQ01ChebyshevLower.lean`** (previously they lived only in the separate
+  `…Aristotle.lean` companion + as a comment block here). `chebyshev_psi_lower_bound` now
+  reduces to `L2 ∘ L3 + ψ-monotonicity`. The orphan stays UNREGISTERED, 0 axiom, all sorry.
+- **L3 lemma-choice note:** this file uses `Nat.four_pow_le_two_mul_add_one_mul_central_binom`
+  (Choose/Sum.lean:121: `4^n ≤ (2n+1)·(2n).choose n`, NO `0<n` hypothesis — cleaner at the
+  n=0 edge, costs one `centralBinom_eq_two_mul_choose` rewrite). The Aristotle companion uses
+  `Nat.four_pow_le_two_mul_self_mul_centralBinom` (Central.lean:99: `4^n ≤ 2n·C`, needs
+  `0<n`). Both valid; pick per whichever the prover closes faster.
+
+**Difficulty:** L3 easy (log of the Nat ineq); L1 ~50–100 lines (`vonMangoldt_sum` + sum-swap
+via `Nat.Ioc_filter_dvd_card_eq_div`); L2 the crux ~80–150 lines (de Polignac floor-sum;
+the lcm route `C(2n,n)∣lcm(1..2n)` / `ψ=log lcm` is NOT in Mathlib — grep 0 hits).


### PR DESCRIPTION
## Summary

Advances the **Chebyshev side** of this slug — the asymptotic ψ lower bound that discharges
the parent file's `diameter_upper_bound_exists` axiom (the single Mathlib gap: Mathlib has
ψ/θ *upper* bounds only). No math is claimed proved; this is ORIENT-phase de-risking under a
backend blackout (Aristotle 404; Docker daemon **hung** — `docker run --rm alpine echo` times
out at rc=124 even with 0 containers).

- **Transcribed L1/L2/L3 into named sorried lemmas inside
  `BoundedPrimeGapsOQ03OQ01ChebyshevLower.lean`** (previously they lived only in the separate
  `…Aristotle.lean` companion + a comment block). `chebyshev_psi_lower_bound` now reduces to
  `L2 ∘ L3 + ψ-monotonicity`. The file remains an UNREGISTERED orphan, **0 axiom, all sorry**
  — zero gallery / false-green risk. The named lemmas are now direct `prove_file` targets.
- **Re-verified every turnkey Mathlib hook against the offline checkout
  `/Users/rwalters/GitHub/mathlib4` @ exact pin `2df2f0150c`** (no API drift):
  `Nat.Ioc_filter_dvd_card_eq_div`, `ArithmeticFunction.vonMangoldt_sum`, `Chebyshev.psi`
  (range `Ioc 0 ⌊x⌋₊` matches L1), `abs_psi_sub_theta_le_sqrt_mul_log`,
  `four_pow_le_two_mul_add_one_mul_central_binom`.
- **Docs:** appended researcher-5 notes to `knowledge.md`/`state.md`, **keeping researcher-1's
  canonical D(5)=12 interpretation intact** — two targets live under this slug (finite
  D(5)=12 vs. asymptotic ψ-bound); this PR touches only the latter. Also recorded the
  corrected build gate (0 containers ≠ safe; daemon is hung).

## Status
**Outcome**: progress (ORIENT — decomposition inlined, hooks verified, backend-gated)
**Next Steps**: when a backend returns, `prove_file` L3→L1→L2, assemble `chebyshev_psi_lower_bound`,
build-verify, then register in `Proofs.lean`.

## Test plan
- [ ] Orphan file is UNREGISTERED (not in `Proofs.lean`) — no gallery build impact.
- [ ] All 5 declarations are `sorry`, 0 axioms — nothing claimed verified.
- [ ] Next agent re-checks `docker run --rm alpine echo ok` before building.

🤖 Generated by researcher-5