### PR TITLE
research(cube-root-3-oq-04): S36 offline-verify stream-orphan API names + fix sub_int drift

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
@@ -40,18 +40,34 @@ tying the existing `cbrt3_aₙ` floors to the canonical API for the first time.
 The reusable step lemma `cbrt3_stream_succ` makes each further index mechanical
 (reuse with `cbrt3_a3, cbrt3_a4, …` plus the matching irrationality witness).
 
-## Mathlib API this file depends on (VERIFY THESE NAMES at v4.26.0 first)
+## Mathlib API this file depends on (names offline-verified at v4.26.0, S36)
 
-  * `GenContFract.IntFractPair`            (namespace + structure; opened below)
-  * `IntFractPair.of`, fields `.b`, `.fr`
-  * `IntFractPair.stream_zero`
-  * `IntFractPair.stream_succ_of_some`
-  * `Irrational.ne_int`, `Irrational.sub_int`, `Irrational.inv`
-  * `Int.fract` (unfolds under `simp`), `inv_eq_one_div`, `sub_ne_zero`
+Checked against the pinned Mathlib4 checkout `2df2f0150c` (= lakefile
+`rev = "v4.26.0"`) in S36 (researcher-3):
 
-If any name drifted, the proof structure is unchanged — only the cited lemma
-needs swapping. The numbers are cert-verified, so no math re-derivation is
-needed.
+  * `GenContFract.IntFractPair`            ✓ structure (ContinuedFractions/Computation/Basic.lean),
+                                             fields `.b : ℤ`, `.fr : K`
+  * `IntFractPair.of`                       ✓ (Basic.lean:125)
+  * `IntFractPair.stream_zero`              ✓ (Computation/Translations.lean:64), exact form
+                                             `stream v 0 = some (of v)`
+  * `IntFractPair.stream_succ_of_some`      ✓ (Translations.lean:97)
+  * `Irrational.ne_int`                     ✓ (NumberTheory/Real/Irrational.lean:180)
+  * `Irrational.sub_intCast`                ✓ (Irrational.lean:272) — NOTE: an earlier draft
+                                             cited `Irrational.sub_int`, which does NOT exist at
+                                             this pin (the Int-cast subtraction lemma is
+                                             `sub_intCast`). Fixed in S36.
+  * `Irrational.inv`                        ✓ (Irrational.lean:332, `protected theorem inv`)
+  * `Int.fract`, `inv_eq_one_div`, `sub_ne_zero`  ✓ standard
+
+`Irrational` content lives in `Mathlib.NumberTheory.Real.Irrational` at this pin
+(`Mathlib.Data.Real.Irrational` is a 5-line re-export stub) — the base file's
+`import Mathlib.Data.Real.Irrational` still resolves, and this orphan pulls full
+Mathlib transitively via `Proofs.CubeRoot3IrrationalOQ04`.
+
+The numbers are cert-verified and the only name drift (`sub_int`) is now fixed,
+so this orphan should build first-try on the next Docker-up session; remaining
+risk is purely tactic-level (`simp`/`simpa` normalising `IntFractPair.of` /
+`Int.fract` and the `⁻¹ ↔ 1/·` bridge), not name resolution.
 -/
 
 import Proofs.CubeRoot3IrrationalOQ04
@@ -113,7 +129,7 @@ theorem cbrt3_stream_two :
     IntFractPair.stream cbrt3 2
       = some (IntFractPair.of ((cbrt3 - 1)⁻¹ - 2)⁻¹) := by
   have hirr1 : Irrational ((cbrt3 - 1)⁻¹) := by
-    have hsub : Irrational (cbrt3 - 1) := by simpa using irrational_cbrt3.sub_int 1
+    have hsub : Irrational (cbrt3 - 1) := by simpa using irrational_cbrt3.sub_intCast 1
     exact hsub.inv
   have hfl1 : ⌊(cbrt3 - 1)⁻¹⌋ = (2 : ℤ) := by
     rw [inv_eq_one_div]; exact cbrt3_a1

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,5 +1,47 @@
 # Current State
 
+## S36 (researcher-3, 2026-06-16) — offline API-name verification of S35 stream orphan
+
+**Phase:** BUILD (still build-PENDING — Docker + Aristotle both DOWN this session;
+`docker info` rc=124 with ~14 stacked build wrappers, Aristotle `prove` 404).
+
+Could not build/verify any Lean. Did NOT add a new convergent rung (a₁₂=8 is the
+merged frontier but is already in flight via open PRs #23388/#23983, and S35
+already judged a further rung to be routine churn). Instead executed S35's stated
+**next action** in its build-free portion: verified every Mathlib API name the
+orphan `CubeRoot3IrrationalOQ04Stream.lean` depends on against the pinned offline
+Mathlib4 checkout (`/Users/rwalters/GitHub/mathlib4` @ `2df2f0150c` = lakefile
+`rev = "v4.26.0"`).
+
+**Result — exactly one name drift found and fixed:**
+- `Irrational.sub_int` → **`Irrational.sub_intCast`** (orphan line ~116). No bare
+  `sub_int` exists at this pin; the Int-cast subtraction lemma is `sub_intCast`
+  (`Mathlib/NumberTheory/Real/Irrational.lean:272`).
+- All other names confirmed correct: `GenContFract.IntFractPair` (+ fields
+  `.b : ℤ`, `.fr`), `IntFractPair.of`, `stream_zero`, `stream_succ_of_some`,
+  `Irrational.ne_int`, `Irrational.inv`, and the local `irrational_cbrt3`
+  (base file `CubeRoot3Irrational.lean:73`), `cbrt3_floor_eq_one`, `cbrt3_a1`,
+  `cbrt3_a2`.
+- Note: `Irrational` API lives in `Mathlib.NumberTheory.Real.Irrational` at this
+  pin; `Mathlib.Data.Real.Irrational` is a 5-line re-export stub (still resolves).
+
+Confirmed the orphan is genuinely build-safe to edit: the gallery/CI target is
+`lake build Proofs`, whose root `proofs/Proofs.lean` imports only
+`CubeRoot3IrrationalOQ04` + `…Helpers` (lines 587–588), NOT `…Stream` — so the
+orphan is outside the default build closure and cannot break the gallery build
+until a future session adds its import line.
+
+**Next action (S37, Docker-up):** `docker-build.sh Proofs.CubeRoot3IrrationalOQ04Stream`.
+With the name drift fixed, remaining build risk is purely tactic-level
+(`simp`/`simpa` normalising `IntFractPair.of` / `Int.fract`, and the `⁻¹ ↔ 1/·`
+bridge in `_b_two`). If green: register in `Proofs.lean`, then extend
+`_b_three … _b_eleven` mechanically via `cbrt3_stream_succ` (cert covers n=0..11).
+
+PR (doc/orphan-only, zero gallery-build risk): see branch
+`research/cube-root-3-oq04-s36-stream-api-verify`.
+
+---
+
 ## S35 (researcher-3, 2026-06-16) — IntFractPair.stream bridge (open question #1)
 
 **Phase:** BUILD (new orphan file, build-PENDING — Docker DOWN). First attempt


### PR DESCRIPTION
## Summary
Build-free de-risking of S35's build-pending `IntFractPair.stream` bridge orphan (`CubeRoot3IrrationalOQ04Stream.lean`). Docker + Aristotle were both down this session, so no Lean could be elaborated; instead I executed the build-free part of S35's stated next action — verifying the orphan's Mathlib API names against the pinned offline Mathlib4 checkout (`2df2f0150c` = lakefile `rev = "v4.26.0"`).

**Found exactly one name drift, now fixed:**
- `Irrational.sub_int` → **`Irrational.sub_intCast`** — no bare `sub_int` exists at this pin (`Mathlib/NumberTheory/Real/Irrational.lean:272`).

All other dependencies confirmed correct: `GenContFract.IntFractPair` (+ fields `.b`/`.fr`), `IntFractPair.of`, `stream_zero`, `stream_succ_of_some`, `Irrational.ne_int`, `Irrational.inv`, and local `irrational_cbrt3` / `cbrt3_floor_eq_one` / `cbrt3_a1` / `cbrt3_a2`.

## Safety
The orphan is **outside the gallery build closure**: the `Proofs` target's root `proofs/Proofs.lean` imports `CubeRoot3IrrationalOQ04` + `…Helpers` only (lines 587–588), not `…Stream`. So this edit cannot affect the gallery/CI build until a future session registers the import. No registered file touched; no `loom:review-requested` (deployer merges math PRs directly).

## Why no new convergent rung
The merged frontier is a₁₂=8, but a₁₂ is already in flight via open PRs #23388/#23983, and S35 already judged a further rung to be routine churn (the helper file is staged with cubing bounds out to the 28th convergent). This PR advances the structural open-question #1 (canonical-CF bridge) instead.

## Test plan
- [ ] **Build-pending** (Docker down). Next Docker-up session: `docker-build.sh Proofs.CubeRoot3IrrationalOQ04Stream`. With the name drift fixed, residual risk is tactic-level only (`simp`/`simpa` on `IntFractPair.of`/`Int.fract` and the `⁻¹ ↔ 1/·` bridge).
- [x] API names cross-checked against offline Mathlib4 @ v4.26.0 pin.
- [x] Orphan confirmed outside `Proofs.lean` import closure → zero gallery-build risk.