### PR TITLE
Enrich Newton-Girard identities (cramers-rule-oq-01-oq-04): re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
       "startLine": 1,
-      "endLine": 62
+      "endLine": 65
     },
     "type": "concept",
     "title": "Newton-Girard Framework and Chain Context",
@@ -28,8 +28,8 @@
     "id": "ann-mat-power-sum-def",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 63,
-      "endLine": 100
+      "startLine": 67,
+      "endLine": 99
     },
     "type": "definition",
     "title": "Matrix Newton Power Sums: Definition and Basic Properties",
@@ -53,7 +53,7 @@
     "id": "ann-charpoly-coeff-def",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 101,
+      "startLine": 105,
       "endLine": 144
     },
     "type": "definition",
@@ -77,8 +77,8 @@
     "id": "ann-cayley-hamilton-large-k",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 146,
-      "endLine": 186
+      "startLine": 150,
+      "endLine": 185
     },
     "type": "concept",
     "title": "Cayley-Hamilton and the Large-k Newton Recurrence (Axiom)",
@@ -101,8 +101,8 @@
     "id": "ann-concrete-newton-k2-k3",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 188,
-      "endLine": 216
+      "startLine": 191,
+      "endLine": 215
     },
     "type": "insight",
     "title": "Concrete Newton Identities for k=2 and k=3",
@@ -125,8 +125,8 @@
     "id": "ann-large-k-recurrence",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 217,
-      "endLine": 237
+      "startLine": 221,
+      "endLine": 236
     },
     "type": "concept",
     "title": "Large-k Recurrence: Clean Form and First Consequence",
@@ -149,8 +149,8 @@
     "id": "ann-faddeev-leverrier",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 238,
-      "endLine": 277
+      "startLine": 242,
+      "endLine": 276
     },
     "type": "concept",
     "title": "Faddeev-LeVerrier Inversion and 2×2 Determinant Formula",
@@ -175,8 +175,8 @@
     "id": "ann-power-sums-determined",
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
-      "startLine": 278,
-      "endLine": 310
+      "startLine": 282,
+      "endLine": 309
     },
     "type": "insight",
     "title": "All Power Sums Determined by First n: Inductive Proof",
@@ -201,7 +201,7 @@
     "proofId": "cramers-rule-oq-01-oq-04",
     "range": {
       "startLine": 311,
-      "endLine": 327
+      "endLine": 325
     },
     "type": "insight",
     "title": "tr(M²) = tr(M)² − 2·det(M): Classical 2×2 Identity Proved",

--- a/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
@@ -66,46 +66,46 @@
       "id": "charpoly-coeffs",
       "title": "Characteristic Polynomial Coefficients",
       "startLine": 101,
-      "endLine": 148,
+      "endLine": 145,
       "summary": "Defines charpolyCoeff M k = coeff(charpoly M, n−k). Proves: leading coeff = 1, k=1 identity (tr(M) = −c₁) from trace_eq_neg_charpoly_coeff, constant term = (−1)ⁿ·det(M).",
       "mathContext": "The characteristic polynomial $\\chi_M(t) = t^n + c_{n-1}t^{n-1} + \\cdots + c_0$ has $c_{n-1} = -\\text{tr}(M)$ (from Newton $k=1$) and $c_0 = (-1)^n \\det(M)$ (from $\\chi_M(0) = \\det(-M)$)."
     },
     {
       "id": "cayley-hamilton-section",
       "title": "Newton's Identities via Cayley-Hamilton",
-      "startLine": 149,
-      "endLine": 201,
+      "startLine": 146,
+      "endLine": 186,
       "summary": "cayley_hamilton: immediate wrapper for aeval_self_charpoly. newton_recurrence_large (AXIOM): pₖ + ∑cⱼpₖ₋ⱼ = 0 for k ≥ n, following from Cayley-Hamilton. newton_recurrence_small (AXIOM): Newton recurrence for k ≤ n via cofactor algebra.",
       "mathContext": "Cayley-Hamilton: $\\chi_M(M) = 0$. Multiplying by $M^{k-n}$ and taking trace gives the Newton recurrence for $k \\geq n$. The small-$k$ case requires a deeper algebraic argument involving differentiation of $\\det(tI - M)$."
     },
     {
       "id": "concrete-newton",
       "title": "Concrete Newton Identities (k=2, k=3)",
-      "startLine": 202,
-      "endLine": 231,
+      "startLine": 187,
+      "endLine": 216,
       "summary": "newton_k2: tr(M²) + c₁·tr(M) + 2·c₂ = 0. newton_k3: tr(M³) + c₁·tr(M²) + c₂·tr(M) + 3·c₃ = 0. Both derived from newton_recurrence_small.",
       "mathContext": "For $k=2$: $p_2 + e_1 p_1 + 2e_2 = 0$ where $e_1 = \\text{tr}(M)$, $e_2 = \\frac{\\text{tr}(M)^2 - \\text{tr}(M^2)}{2}$. For $k=3$: $p_3 = p_1^3 - \\frac{3}{2}p_1 p_2 + \\frac{1}{2}p_3$... the recurrence form avoids fractional coefficients."
     },
     {
       "id": "large-k",
       "title": "Large-k Recurrence",
-      "startLine": 232,
-      "endLine": 252,
+      "startLine": 217,
+      "endLine": 237,
       "summary": "newton_large_recurrence (AXIOM): clean form pₙ₊ⱼ = −∑cₘ·pₙ₊ⱼ₋ₘ. matPowerSum_card_succ: p_{n+1} in terms of p₁,...,pₙ.",
       "mathContext": "For $k > n$, Cayley-Hamilton gives a linear recurrence: $p_{n+j} = -\\sum_{m=1}^n c_m p_{n+j-m}$. This shows all higher power sums are determined by $p_1, \\ldots, p_n$."
     },
     {
       "id": "faddeev-leverrier",
       "title": "Faddeev-LeVerrier Algorithm",
-      "startLine": 253,
-      "endLine": 295,
+      "startLine": 238,
+      "endLine": 277,
       "summary": "faddeev_leverrier_inversion (AXIOM): k·cₖ = −∑cⱼ·pₖ₋ⱼ inverts Newton's identities. det_from_power_sums_2x2: det(M) = (p₁² − p₂)/2 for 2×2 matrices.",
       "mathContext": "The Faddeev-LeVerrier algorithm computes the characteristic polynomial in $O(n^2)$ using only trace operations. The inversion identity $k c_k = -\\sum_{j=0}^{k-1} c_j p_{k-j}$ follows from the triangular structure of Newton's identities."
     },
     {
       "id": "consequences",
       "title": "Consequences and 2×2 Specializations",
-      "startLine": 296,
+      "startLine": 278,
       "endLine": 327,
       "summary": "power_sums_determined_by_first_n: all pₖ (k>n) determined by p₁,...,pₙ (proved by induction). trace_sq_minus_trace_M2_2x2: tr(M²) = tr(M)² − 2·det(M) for 2×2 matrices (PROVED).",
       "mathContext": "For $2\\times 2$ matrices: $\\text{tr}(M^2) = \\text{tr}(M)^2 - 2\\det(M)$, which is Newton's $k=2$ identity specialized. This identity is fundamental in quantum mechanics (relating Casimir operators to products of generators) and in the theory of modular forms."


### PR DESCRIPTION
## Enrichment pass: cramers-rule-oq-01-oq-04 (Newton-Girard Identities for Matrix Characteristic Polynomials)

Banner-anchored annotation drift: the file shifted relative to when the gallery data was authored, leaving 7 of 9 annotations anchored on `-- ====` section-banner comment lines (not Lean constructs). The resolver reported `No Lean construct found` for all 7.

### Changes
- **Re-anchored 7 annotations** to their actual constructs (`resolver.ts validate`: 7 misaligned → **0 misaligned**, 9/9 valid):
  - `ann-mat-power-sum-def` → `matPowerSum` def + power-sum theorems
  - `ann-charpoly-coeff-def` → `charpolyCoeff` def + `newton_k1`
  - `ann-cayley-hamilton-large-k` → `cayley_hamilton` / `newton_recurrence_large/small` axioms
  - `ann-concrete-newton-k2-k3` → `newton_k2` / `newton_k3`
  - `ann-large-k-recurrence` → `newton_large_recurrence` axiom / `matPowerSum_card_succ`
  - `ann-faddeev-leverrier` → `faddeev_leverrier_inversion` axiom / `det_from_power_sums_2x2`
  - `ann-power-sums-determined` → `power_sums_determined_by_first_n`
- **Realigned 7 meta `sections`** to contiguously cover all declarations. The `consequences` section had drifted to 296-327, entirely missing `power_sums_determined_by_first_n` (284-309); now starts at the SECTION VII banner.

### Integrity
- `axiomCount: 4` verified accurate (4 `axiom` declarations: `newton_recurrence_large`, `newton_recurrence_small`, `newton_large_recurrence`, `faddeev_leverrier_inversion`). No status/badge change.
- No annotation content rewritten — purely re-anchoring; existing math content preserved.

Validated with `scripts/annotations/resolver.ts validate` and `JSON.parse` (not `pnpm build`, which rewrites ~1380 sibling entries).