### PR TITLE
Enrich feuerbachs-theorem-defs: re-anchor 8 drifted annotations

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/annotations.json
@@ -25,7 +25,7 @@
     "id": "ann-ftd-triangle-struct",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 56,
+      "startLine": 60,
       "endLine": 93
     },
     "type": "definition",
@@ -47,7 +47,7 @@
     "id": "ann-ftd-special-points",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 95,
+      "startLine": 99,
       "endLine": 138
     },
     "type": "definition",
@@ -69,7 +69,7 @@
     "id": "ann-ftd-nine-point-defs",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 139,
+      "startLine": 143,
       "endLine": 186
     },
     "type": "definition",
@@ -92,7 +92,7 @@
     "id": "ann-ftd-incircle-excircles",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 187,
+      "startLine": 191,
       "endLine": 252
     },
     "type": "definition",
@@ -116,7 +116,7 @@
     "id": "ann-ftd-euler-line-proofs",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 254,
+      "startLine": 258,
       "endLine": 372
     },
     "type": "concept",
@@ -139,7 +139,7 @@
     "id": "ann-ftd-midpoint-membership",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 373,
+      "startLine": 374,
       "endLine": 441
     },
     "type": "insight",
@@ -161,7 +161,7 @@
     "id": "ann-ftd-altitude-feet",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 442,
+      "startLine": 446,
       "endLine": 576
     },
     "type": "concept",
@@ -205,7 +205,7 @@
     "id": "ann-ftd-numerical-verification",
     "proofId": "feuerbachs-theorem-defs",
     "range": {
-      "startLine": 577,
+      "startLine": 581,
       "endLine": 687
     },
     "type": "insight",


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs`.

8 of the 10 annotations had `range.startLine` values pointing into gaps between declarations (section-banner / blank lines), so the resolver reported **'No Lean construct found'** for each — the inline highlights were anchored to nothing.

## Fix
Snapped each drifted `startLine` down to the first doc-comment/declaration inside its own block, preserving every `endLine` (so coverage is unchanged). Purely positional — no content edits.

| annotation | startLine |
|---|---|
| ann-ftd-triangle-struct | 56 → 60 |
| ann-ftd-special-points | 95 → 99 |
| ann-ftd-nine-point-defs | 139 → 143 |
| ann-ftd-incircle-excircles | 187 → 191 |
| ann-ftd-euler-line-proofs | 254 → 258 |
| ann-ftd-midpoint-membership | 373 → 374 |
| ann-ftd-altitude-feet | 442 → 446 |
| ann-ftd-numerical-verification | 577 → 581 |

Resolver result after: **10 valid, 0 misaligned** (was 2 valid / 8 misaligned).