### PR TITLE
research(happy-number-oq-01): happy/unhappy dichotomy (build-pending)

### DIFF
--- a/proofs/Proofs/HappyNumberOQ01.lean
+++ b/proofs/Proofs/HappyNumberOQ01.lean
@@ -1,0 +1,175 @@
+/-
+  Happy / unhappy dichotomy for the sum-of-squares-of-digits map.
+
+  Let `S n` be the sum of the squares of the decimal digits of `n`.  A positive
+  integer is *happy* if iterating `S` eventually reaches `1`, and *unhappy*
+  otherwise.  The classical theorem is that there is no third possibility: every
+  positive integer's orbit under `S` is eventually absorbed into
+
+      T = {1} ∪ {4, 16, 37, 58, 89, 145, 42, 20},
+
+  i.e. it reaches the fixed point `1` (happy) or lands on the 8-cycle
+
+      4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4
+
+  (unhappy).  Equivalently every `n ≥ 1` satisfies `∃ k, S^[k] n = 1` or
+  `∃ k, S^[k] n = 4`.
+
+  PROOF STRATEGY (genuinely covers all infinitely many `n`):
+    * `descent`: for every `n ≥ 1000`, `S n < n`.  This is a real bound, not an
+      enumeration: if `L = (digits 10 n).length` then `S n ≤ 81 · L` (each digit
+      is `≤ 9`) while `10^(L-1) ≤ n` and `81 · L < 10^(L-1)` for `L ≥ 4`.
+    * Strong induction then reduces every `n` to the finite window `[1, 999]`.
+    * `base_reaches`: a finite check (`native_decide`) that every `n ∈ [1, 999]`
+      reaches `T` within 15 iterations (the true maximum is 11, at `n = 269`).
+
+  All numeric claims were cross-checked independently in Python
+  (`research/problems/happy-number-oq-01/verify_happy.py`).
+
+  STATUS: build-pending.  This file is NOT registered in `Proofs.lean` and has
+  not been compiled this session (Docker build pool saturated / daemon
+  unresponsive).  The finite checks use `native_decide`, which introduces the
+  `Lean.ofReduceBool` axiom; the gallery status for this entry is therefore
+  `axiomatized`, NOT `verified`.
+-/
+import Mathlib
+
+namespace HappyNumberOQ01
+
+/-- Sum of the squares of the decimal digits of `n`. -/
+def S (n : ℕ) : ℕ := ((Nat.digits 10 n).map (· ^ 2)).sum
+
+/-- The absorbing set: the happy fixed point `1` together with the eight numbers
+of the unhappy cycle `4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4`. -/
+def T : Finset ℕ := {1, 4, 16, 37, 58, 89, 145, 42, 20}
+
+/-- `1` is a fixed point of `S`. -/
+theorem S_one : S 1 = 1 := by native_decide
+
+/-- The unhappy cycle, made explicit. -/
+theorem unhappy_cycle :
+    S 4 = 16 ∧ S 16 = 37 ∧ S 37 = 58 ∧ S 58 = 89 ∧ S 89 = 145 ∧
+      S 145 = 42 ∧ S 42 = 20 ∧ S 20 = 4 := by native_decide
+
+/-- `T` is closed under `S`: once an orbit reaches `T` it stays there. -/
+theorem T_absorbing : ∀ m ∈ T, S m ∈ T := by native_decide
+
+/-- Exponential beats linear: `81 · L < 10^(L-1)` for every `L ≥ 4`. -/
+theorem aux_exp : ∀ L, 4 ≤ L → 81 * L < 10 ^ (L - 1) := by
+  intro L hL
+  induction L, hL using Nat.le_induction with
+  | base => norm_num
+  | succ L hL ih =>
+    have e : (10 : ℕ) ^ L = 10 ^ (L - 1) * 10 := by
+      conv_lhs => rw [show L = (L - 1) + 1 by omega]
+      rw [pow_succ]
+    have hbig : (1000 : ℕ) ≤ 10 ^ (L - 1) := by
+      calc (1000 : ℕ) = 10 ^ 3 := by norm_num
+        _ ≤ 10 ^ (L - 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+    rw [show L + 1 - 1 = L by omega, e]
+    nlinarith [ih, hbig]
+
+/-- **Descent.** For every `n ≥ 1000`, applying `S` strictly decreases `n`. -/
+theorem descent (n : ℕ) (hn : 1000 ≤ n) : S n < n := by
+  have hn0 : n ≠ 0 := by omega
+  -- `n` has at least 4 digits.
+  have hL4 : 4 ≤ (Nat.digits 10 n).length := by
+    have hupper : n < 10 ^ (Nat.digits 10 n).length :=
+      Nat.lt_base_pow_length_digits (by norm_num)
+    have h3 : (10 : ℕ) ^ 3 ≤ n := by
+      have h1000 : (10 : ℕ) ^ 3 = 1000 := by norm_num
+      omega
+    have hlt : (10 : ℕ) ^ 3 < 10 ^ (Nat.digits 10 n).length := lt_of_le_of_lt h3 hupper
+    have h3L : 3 < (Nat.digits 10 n).length := (pow_lt_pow_iff_right' (by norm_num)).mp hlt
+    omega
+  -- Lower bound on `n` from its digit count.
+  have hlow : 10 ^ ((Nat.digits 10 n).length - 1) ≤ n := by
+    have hbpl : 10 ^ (Nat.digits 10 n).length ≤ 10 * n :=
+      Nat.base_pow_length_digits_le 10 n (by norm_num) hn0
+    have e : (10 : ℕ) ^ (Nat.digits 10 n).length
+        = 10 ^ ((Nat.digits 10 n).length - 1) * 10 := by
+      conv_lhs => rw [show (Nat.digits 10 n).length = ((Nat.digits 10 n).length - 1) + 1 by omega]
+      rw [pow_succ]
+    rw [e] at hbpl
+    have hbpl' : 10 * 10 ^ ((Nat.digits 10 n).length - 1) ≤ 10 * n := by
+      rw [mul_comm]; exact hbpl
+    exact Nat.le_of_mul_le_mul_left hbpl' (by norm_num)
+  -- Upper bound on `S n`: at most `81` per digit.
+  have hSle : S n ≤ 81 * (Nat.digits 10 n).length := by
+    have hb : ∀ x ∈ (Nat.digits 10 n).map (· ^ 2), x ≤ 81 := by
+      intro x hx
+      rw [List.mem_map] at hx
+      obtain ⟨d, hd, rfl⟩ := hx
+      have hd9 : d ≤ 9 := by have := Nat.digits_lt_base (by norm_num) hd; omega
+      calc d ^ 2 ≤ 9 ^ 2 := Nat.pow_le_pow_left hd9 2
+        _ = 81 := by norm_num
+    have h := List.sum_le_card_nsmul ((Nat.digits 10 n).map (· ^ 2)) 81 hb
+    simp only [List.length_map, nsmul_eq_mul, Nat.cast_id] at h
+    show ((Nat.digits 10 n).map (· ^ 2)).sum ≤ 81 * (Nat.digits 10 n).length
+    omega
+  have hexp : 81 * (Nat.digits 10 n).length < 10 ^ ((Nat.digits 10 n).length - 1) :=
+    aux_exp _ hL4
+  calc S n ≤ 81 * (Nat.digits 10 n).length := hSle
+    _ < 10 ^ ((Nat.digits 10 n).length - 1) := hexp
+    _ ≤ n := hlow
+
+/-- For positive `n`, `S n` is positive (the leading digit contributes a positive
+square), so the orbit never falls to `0`. -/
+theorem S_pos {n : ℕ} (hn : n ≠ 0) : 0 < S n := by
+  have hne : Nat.digits 10 n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hn
+  have hlast : (Nat.digits 10 n).getLast hne ≠ 0 := Nat.getLast_digit_ne_zero 10 hn
+  have hmem : (Nat.digits 10 n).getLast hne ∈ Nat.digits 10 n := List.getLast_mem hne
+  have hsqmem : ((Nat.digits 10 n).getLast hne) ^ 2 ∈ (Nat.digits 10 n).map (· ^ 2) :=
+    List.mem_map.mpr ⟨_, hmem, rfl⟩
+  have hle : ((Nat.digits 10 n).getLast hne) ^ 2 ≤ S n := List.le_sum_of_mem hsqmem
+  have hpos : 0 < ((Nat.digits 10 n).getLast hne) ^ 2 :=
+    pow_pos (Nat.pos_of_ne_zero hlast) 2
+  omega
+
+/-- Bounded reachability checker: does the orbit of `n` hit `T` within 15 steps? -/
+def reachesT (n : ℕ) : Bool := (List.range 15).any (fun k => decide (S^[k] n ∈ T))
+
+/-- Finite verification: every `n ∈ [1, 999]` reaches `T` within 15 iterations. -/
+theorem reachesT_below : ∀ n, n < 1000 → 1 ≤ n → reachesT n = true := by native_decide
+
+/-- Base case of the induction: every `n ∈ [1, 999]` reaches `T`. -/
+theorem base_reaches (n : ℕ) (hn1 : 1 ≤ n) (hn : n < 1000) : ∃ k, S^[k] n ∈ T := by
+  have h := reachesT_below n hn hn1
+  simp only [reachesT, List.any_eq_true, decide_eq_true_eq] at h
+  obtain ⟨k, _, hk⟩ := h
+  exact ⟨k, hk⟩
+
+/-- **Main theorem.** For every positive integer `n`, iterating `S` eventually
+lands in the absorbing set `T`. -/
+theorem reaches_T : ∀ n, 1 ≤ n → ∃ k, S^[k] n ∈ T := by
+  intro n
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+    intro hn
+    by_cases hbig : 1000 ≤ n
+    · have hdesc : S n < n := descent n hbig
+      have hpos : 1 ≤ S n := S_pos (by omega)
+      obtain ⟨k, hk⟩ := ih (S n) hdesc hpos
+      exact ⟨k + 1, by rw [Function.iterate_succ_apply]; exact hk⟩
+    · push_neg at hbig
+      exact base_reaches n hn hbig
+
+/-- **Happy / unhappy dichotomy.** Every positive integer is happy (its orbit
+reaches the fixed point `1`) or unhappy (its orbit reaches `4`, hence enters the
+8-cycle). -/
+theorem reaches_one_or_four (n : ℕ) (hn : 1 ≤ n) :
+    (∃ k, S^[k] n = 1) ∨ (∃ k, S^[k] n = 4) := by
+  obtain ⟨k, hk⟩ := reaches_T n hn
+  simp only [T, Finset.mem_insert, Finset.mem_singleton] at hk
+  rcases hk with h | h | h | h | h | h | h | h | h
+  · exact Or.inl ⟨k, h⟩
+  · exact Or.inr ⟨k, h⟩
+  · exact Or.inr ⟨7 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨6 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨5 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨4 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨3 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨2 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+  · exact Or.inr ⟨1 + k, by rw [Function.iterate_add_apply, h]; native_decide⟩
+
+end HappyNumberOQ01

--- a/research/problems/happy-number-oq-01/knowledge.md
+++ b/research/problems/happy-number-oq-01/knowledge.md
@@ -1,0 +1,71 @@
+# happy-number-oq-01 — Happy / unhappy dichotomy
+
+**Statement.** Let `S(n)` = sum of squares of the decimal digits of `n`. For every
+positive integer, iterating `S` eventually reaches the fixed point `1` (happy) or
+enters the cycle `4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4` (unhappy).
+
+## Summary
+
+- **Status:** proof complete, **build-pending** (Docker blackout this session — daemon
+  unresponsive, `docker info` rc=124, ~10 stuck build wrappers; Aristotle MCP 404).
+- **File:** `proofs/Proofs/HappyNumberOQ01.lean` (UNREGISTERED orphan — not in
+  `Proofs.lean`, no gallery dir → zero false-green risk).
+- **Axiom status:** `axiomatized`. The finite checks use `native_decide`
+  (`Lean.ofReduceBool`). Not `verified`.
+
+## Proof architecture
+
+Headline: `reaches_one_or_four : ∀ n ≥ 1, (∃ k, S^[k] n = 1) ∨ (∃ k, S^[k] n = 4)`.
+Built from:
+
+1. `reaches_T : ∀ n ≥ 1, ∃ k, S^[k] n ∈ T` where
+   `T = {1,4,16,37,58,89,145,42,20}` is the absorbing set.
+2. **Descent** (`descent`): `S n < n` for all `n ≥ 1000`. This is the part that
+   covers infinitely many `n` (NOT enumeration). With `L = (digits 10 n).length`:
+   - `S n ≤ 81 · L`  (each digit `≤ 9`, via `List.sum_le_card_nsmul` + `digits_lt_base`)
+   - `10^(L-1) ≤ n`  (`Nat.base_pow_length_digits_le`)
+   - `L ≥ 4`  (`Nat.lt_base_pow_length_digits` + `pow_lt_pow_iff_right'`)
+   - `81 · L < 10^(L-1)` for `L ≥ 4`  (`aux_exp`, by `Nat.le_induction`)
+3. **Strong induction** (`Nat.strongRecOn`) reduces every `n` to `[1, 999]`;
+   `S_pos` (leading digit ≠ 0 via `getLast_digit_ne_zero` + `List.le_sum_of_mem`)
+   keeps the orbit positive so the IH applies.
+4. **Base case** (`base_reaches`): `native_decide` that every `n ∈ [1,999]` reaches
+   `T` within 15 iterations of a bounded checker `reachesT`.
+5. From `S^[k] n ∈ T`: if it is a cycle element, a fixed extra number of steps
+   (`Function.iterate_add_apply` + `native_decide`) reaches `4`.
+
+## Independent numeric certificate
+
+`verify_happy.py` confirms (Python, base-10):
+- `S(1)=1`; the 8-cycle closes exactly.
+- `T` is closed under `S`.
+- Steps to reach `4` from each cycle element: 16→7, 37→6, 58→5, 89→4, 145→3,
+  42→2, 20→1 (these are the exponents used in `reaches_one_or_four`).
+- Every `n ∈ [1,999]` reaches `T`; **max steps = 11** (at `n = 269`) → the bound
+  `15` in `reachesT` is safe.
+- `S(n) < n` for all `1000 ≤ n < 200000` (no counterexamples); `81·L < 10^(L-1)`
+  holds for `L = 4..11`.
+
+## Next steps
+
+1. When Docker is back: `./proofs/scripts/docker-build.sh Proofs.HappyNumberOQ01`,
+   `grep -i error:` the log. If green, register in `Proofs.lean` + create gallery
+   dir `src/data/proofs/happy-number-oq-01/`.
+2. Watch points (could need a fix pass on first build):
+   - `List.le_sum_of_mem` typeclass resolution for ℕ.
+   - `nsmul_eq_mul`/`Nat.cast_id` simp in `hSle` (fallback: `smul_eq_mul`).
+   - `Nat.strongRecOn` case label `| _ n ih` (matches existing repo usage).
+3. Follow-up OQ candidate: density / counting of happy numbers below `N`
+   (asymptotic ~0.146 N is open-ended; the eventual-periodicity is what is proved here).
+
+## Session log
+
+### 2026-06-16 (Session 1, FRESH) — researcher-7
+- Mode FRESH. Selected happy-number-oq-01 (only fresh, decidable, unstarted
+  available problem; taxicab/automorphic/abundant/keith already done-or-pending).
+- Confirmed not in Mathlib, no prior proof file / gallery dir / PR.
+- Wrote complete proof (descent + strong induction + native_decide base case),
+  name-checked every lemma against offline Mathlib v4.26 (rev 2df2f0150c).
+- Verified all numeric claims in Python.
+- Dual blackout (Docker rc=124, Aristotle 404) → shipped build-pending orphan.
+- Phase: ACT.

--- a/research/problems/happy-number-oq-01/verify_happy.py
+++ b/research/problems/happy-number-oq-01/verify_happy.py
@@ -1,0 +1,48 @@
+def S(n):
+    return sum(int(c)**2 for c in str(n))
+
+T = {1,4,16,37,58,89,145,42,20}
+
+# 1) cycle facts
+cyc = [4,16,37,58,89,145,42,20]
+print("S(1)=", S(1))
+for c in cyc:
+    print(f"S({c})={S(c)}")
+# verify it's the 8-cycle 4->16->37->58->89->145->42->20->4
+seq=[4]
+x=4
+for _ in range(8):
+    x=S(x); seq.append(x)
+print("cycle from 4:", seq, "closes:", seq[-1]==4)
+
+# 2) T closed under S
+print("T closed under S:", all(S(t) in T for t in T))
+
+# 3) steps from each cycle elt to reach 4
+for c in cyc:
+    j=0; x=c
+    while x!=4:
+        x=S(x); j+=1
+    print(f"steps {c}->4 = {j}")
+
+# 4) base case: every n in [1,999] reaches T within K steps; find max K
+maxk=0; worst=None
+for n in range(1,1000):
+    x=n; k=0
+    while x not in T:
+        x=S(x); k+=1
+        if k>200: break
+    if x not in T:
+        print("FAIL reach T:", n); 
+    if k>maxk: maxk=k; worst=n
+print("max steps to reach T over [1,999] =", maxk, "at n=", worst)
+
+# 5) descent bound: S(n) < n for all n >= 1000? check up to large, plus the formula 81*L < 10^(L-1) for L>=4
+bad=[n for n in range(1000,200000) if S(n)>=n]
+print("counterexamples S(n)>=n for 1000<=n<200000:", bad[:10], "count", len(bad))
+for L in range(4,12):
+    print(f"L={L}: 81*L={81*L} 10^(L-1)={10**(L-1)} ok={81*L<10**(L-1)}")
+
+# 6) also confirm S(n)<n already holds from 100? (not used, just curiosity)
+bad100=[n for n in range(100,1000) if S(n)>=n]
+print("S(n)>=n for 100<=n<1000:", bad100)


### PR DESCRIPTION
## Summary

Formalizes the **happy/unhappy dichotomy** for the sum-of-squares-of-digits map `S`:
every positive integer's orbit under `S` reaches the fixed point `1` (happy) or
the cycle `4 → 16 → 37 → 58 → 89 → 145 → 42 → 20 → 4` (unhappy).

Headline result (`proofs/Proofs/HappyNumberOQ01.lean`):
```
reaches_one_or_four : ∀ n ≥ 1, (∃ k, S^[k] n = 1) ∨ (∃ k, S^[k] n = 4)
```
plus the absorbing-set form `reaches_T`, `S_one`, `unhappy_cycle`, `T_absorbing`.

## Why this is real progress (not enumeration)

The infinitely many `n` are covered by a genuine **descent**: for `n ≥ 1000`,
`S n < n`, because with `L = (digits 10 n).length`,
`S n ≤ 81·L < 10^(L-1) ≤ n` for `L ≥ 4`. Strong induction then reduces every `n`
to the finite window `[1, 999]`, which is discharged by a bounded `native_decide`
reachability check (true max = 11 iterations, at `n = 269`).

## Honesty / status

- **Build-pending**: Docker daemon unresponsive this session (`docker info` rc=124,
  ~10 stuck build wrappers) and Aristotle MCP returned 404. Not compiled here.
- **UNREGISTERED orphan**: not added to `Proofs.lean`, no `src/data/proofs/` gallery
  dir → cannot produce a false "verified" in the gallery.
- **Axiom status: `axiomatized`** (uses `native_decide` → `Lean.ofReduceBool`), not
  `verified`.
- Every Mathlib lemma name checked against the offline v4.26 checkout (rev
  `2df2f0150c`). All numeric claims independently verified in Python
  (`research/problems/happy-number-oq-01/verify_happy.py`).

Math agent PR — no `loom:review-requested` (deployer merges directly). Next session
with Docker up: `docker-build.sh Proofs.HappyNumberOQ01`, then register + gallery.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.HappyNumberOQ01` (when Docker recovers)
- [ ] If green: register in `Proofs.lean` and add gallery dir