### PR TITLE
Enrich Newton's generalized binomial theorem (binomial-theorem-oq-01-oq-01): re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01/annotations.json
@@ -30,7 +30,7 @@
     "id": "ann-binom-oq01oq01-02-ode-recurrence",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 29,
+      "startLine": 31,
       "endLine": 50
     },
     "type": "concept",
@@ -58,7 +58,7 @@
     "id": "ann-binom-oq01oq01-03-analytic",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 52,
+      "startLine": 54,
       "endLine": 57
     },
     "type": "concept",
@@ -84,7 +84,7 @@
     "id": "ann-binom-oq01oq01-04-functional-eq",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 62,
+      "startLine": 64,
       "endLine": 73
     },
     "type": "concept",
@@ -110,8 +110,8 @@
     "id": "ann-binom-oq01oq01-04b-ratio",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 75,
-      "endLine": 84
+      "startLine": 77,
+      "endLine": 83
     },
     "type": "concept",
     "title": "Coefficient Ratio and Convergence Radius",
@@ -132,8 +132,8 @@
     "id": "ann-binom-oq01oq01-04c-special-values",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 85,
-      "endLine": 105
+      "startLine": 87,
+      "endLine": 104
     },
     "type": "insight",
     "title": "Special Values: Zero Exponent and Geometric Series",
@@ -154,7 +154,7 @@
     "id": "ann-binom-oq01oq01-05-absorption",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 106,
+      "startLine": 108,
       "endLine": 143
     },
     "type": "concept",
@@ -182,7 +182,7 @@
     "id": "ann-binom-oq01oq01-06-half-integer",
     "proofId": "binomial-theorem-oq-01-oq-01",
     "range": {
-      "startLine": 145,
+      "startLine": 147,
       "endLine": 180
     },
     "type": "concept",


### PR DESCRIPTION
## Enrichment pass: binomial-theorem-oq-01-oq-01 (Newton's Generalized Binomial Theorem via Analytic Function Theory)

Banner-anchored annotation drift: 7 of 8 annotations were anchored on `-- ====` section-banner comment lines rather than Lean constructs. The resolver reported `No Lean construct found` for all 7.

### Changes
- **Re-anchored 7 annotations** to their actual constructs (`resolver.ts validate`: 7 misaligned → **0**, 8/8 valid):
  - `02-ode-recurrence` → `ode_recurrence` / `genBinom_unique_from_ode`
  - `03-analytic` → `binomial_series_analytic`
  - `04-functional-eq` → `rpow_add_exponents` / `rpow_zero_one` / `rpow_one_id`
  - `04b-ratio` → `genBinom_ratio`
  - `04c-special-values` → `genBinom_zero_succ` / `genBinom_neg_one`
  - `05-absorption` → `absorption`
  - `06-half-integer` → `genBinom_half_*` / `genBinom_half_ne_zero`

### Integrity
- Verified `status: verified` / `axiomCount: 0`: file has 0 `axiom` declarations, 0 `sorry`, 0 assumption-carrying structures.
- `sections` already cover all declarations contiguously — left unchanged.
- No annotation content rewritten — purely re-anchoring.

Validated with `scripts/annotations/resolver.ts validate` (not `pnpm build`, which rewrites ~1380 sibling entries).