### PR TITLE
Enrich bertrands-postulate-oq-03-oq-04: re-anchor 7 drifted annotations

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04/annotations.json
@@ -29,7 +29,7 @@
     "id": "ann-bp-oq04-counting-lemma",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 58,
+      "startLine": 62,
       "endLine": 88
     },
     "type": "insight",
@@ -54,7 +54,7 @@
     "id": "ann-bp-oq04-density-def",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 89,
+      "startLine": 93,
       "endLine": 109
     },
     "type": "definition",
@@ -81,7 +81,7 @@
     "id": "ann-bp-oq04-density-implies-existence",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 110,
+      "startLine": 114,
       "endLine": 173
     },
     "type": "insight",
@@ -109,7 +109,7 @@
     "id": "ann-bp-oq04-log-ratio",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 174,
+      "startLine": 178,
       "endLine": 207
     },
     "type": "insight",
@@ -161,7 +161,7 @@
     "id": "ann-bp-oq04-rh-conditional",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 279,
+      "startLine": 284,
       "endLine": 310
     },
     "type": "concept",
@@ -187,7 +187,7 @@
     "id": "ann-bp-oq04-existence-density-gap",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 311,
+      "startLine": 315,
       "endLine": 328
     },
     "type": "insight",
@@ -212,7 +212,7 @@
     "id": "ann-bp-oq04-summary",
     "proofId": "bertrands-postulate-oq-03-oq-04",
     "range": {
-      "startLine": 329,
+      "startLine": 333,
       "endLine": 357
     },
     "type": "concept",


### PR DESCRIPTION
Enrichment pass for `bertrands-postulate-oq-03-oq-04`.

7 of 9 annotations had `range.startLine` pointing into pre-declaration banner gaps, so the resolver reported **'No Lean construct found'**. Snapped each `startLine` to the doc-comment of the first declaration in its block; `endLine` values unchanged (positional only).

Resolver after: **9 valid, 0 misaligned** (was 2 valid / 7 misaligned).