### PR TITLE
Enrich borsuk-ulam-oq-03-oq-01-oq-01: re-anchor 7 drifted annotations

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-tucker-labeling",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 36,
+      "startLine": 37,
       "endLine": 39
     },
     "type": "definition",
@@ -25,7 +25,7 @@
     "id": "ann-antipodal-labeling",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 41,
+      "startLine": 42,
       "endLine": 46
     },
     "type": "definition",
@@ -48,7 +48,7 @@
     "id": "ann-complementary",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 48,
+      "startLine": 49,
       "endLine": 65
     },
     "type": "definition",
@@ -70,7 +70,7 @@
     "id": "ann-complementary-pairs",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 71,
+      "startLine": 72,
       "endLine": 81
     },
     "type": "concept",
@@ -91,7 +91,7 @@
     "id": "ann-triangulated-complex",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 87,
+      "startLine": 88,
       "endLine": 100
     },
     "type": "definition",
@@ -114,7 +114,7 @@
     "id": "ann-boundary",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 112,
+      "startLine": 113,
       "endLine": 117
     },
     "type": "definition",
@@ -136,7 +136,7 @@
     "id": "ann-parity-principle",
     "proofId": "borsuk-ulam-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 123,
+      "startLine": 124,
       "endLine": 162
     },
     "type": "insight",


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-03-oq-01-oq-01`.

7 of 10 annotations had `range.startLine` one line above their target doc-comment (banner drift), so the resolver reported **'No Lean construct found'**. Snapped each `startLine` to the doc-comment of the first declaration in its block; `endLine` unchanged.

Resolver after: **10 valid, 0 misaligned** (was 3 valid / 7 misaligned).