### PR TITLE
research(lagrange-3sq-oq03): S6 frontier-sharpen — dirichlet_key_lemma isolated to one GoN statement

### DIFF
--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -525,3 +525,59 @@ Mathlib has no readily-citable shortest-vector-of-binary-form lemma, so step (2)
 must be built — but it is elementary and a far better Aristotle target than the
 measure-theoretic route. Resubmit the leaf to Aristotle with hint "Lagrange–Gauss
 reduce {(p,0),(r,1)} under x²+d·y²; interval_cases d" once the 404 clears.
+
+---
+
+## S6 FRONTIER-SHARPEN (researcher-2, 2026-06-16, dual blackout)
+
+Re-probed live: Aristotle `prove` 404 ×2; `docker run --rm alpine echo` rc=124
+(wedged daemon). No build possible. ORIENT-only triage; corrects/sharpens the
+06-15 state (two newer companions `ThreeSquaresSliceMinkowski.lean` +
+`ThreeSquaresSingleAP.lean`, created 06-16, were not in the tracked list).
+
+**Both axioms are now isolated to a TOTAL of 2 `sorry`s, both in companions:**
+
+1. **`dirichlet_key_lemma` ⇒ ONE self-contained statement.**
+   `ThreeSquaresSliceMinkowski.lean` reduces it fully to a single sorry at
+   line 51, `ThreeSquaresSlice.exists_slice_point_lt_two_mul`:
+   ```
+   (p d : ℕ) (hp : 0 < p) (hd : 0 < d) (hd2 : d ≤ 2) (r : ℤ) :
+     ∃ x y : ℤ, (x,y) ≠ (0,0) ∧ (p:ℤ) ∣ (x - r*y) ∧ x^2 + (d:ℤ)*y^2 < 2*p
+   ```
+   The bridge `slice_point_to_dirichlet_vector` (:63) and the assembly
+   `exists_dirichlet_vector_lt_two_mul` (:86) are **PROVED** — once line 51 is
+   closed the whole companion is sorry-free and `dirichlet_key_lemma` follows.
+   This statement has NO project deps (pure ℤ arithmetic + ∃) ⇒ the cleanest
+   possible Aristotle target. File is UNREGISTERED (carries the sorry).
+
+2. **`not_excluded_form_is_sum_three_sq` ⇒ ONE sorry** in
+   `ThreeSquaresSufficiencyCorrected.lean` (224 LOC, 1 real sorry), which derives
+   it from `dirichlet_key_lemma` + two satisfiable hypotheses. (The monolithic
+   single-witness route in `ThreeSquaresSufficiency.lean` is a PROVED DEAD END —
+   `ThreeSquaresWitnessObstruction.not_dirichletWitnessProperty`, falsifier m=11;
+   use the *Corrected* residue-split file.)
+
+**Registration delta vs 06-15 state:** `ThreeSquaresSingleAP` (0 sorry/0 axiom,
+prime-in-AP residue input) is now REGISTERED in `Proofs.lean` (line 3046). Still
+unregistered + build-pending: `ThreeSquaresSliceMinkowski` (1 sorry),
+`ThreeSquaresSufficiency`/`Corrected`/`WitnessObstruction`.
+
+**WHY the elementary Thue/pigeonhole shortcut does NOT work (do not attempt it).**
+Pigeonhole over pairs `(a,b)`, `0 ≤ a,b ≤ ⌊√p⌋` ((⌊√p⌋+1)² > p ⇒ a collision
+`x ≡ r·y mod p`, `|x|,|y| ≤ ⌊√p⌋`) gives only
+`x² + d·y² ≤ (1+d)·⌊√p⌋² ≤ (1+d)·p`:
+- `d = 1`: `≤ 2p` but **non-strict** — fails at perfect-square `p` (where
+  `|x|=|y|=√p` is attainable, value exactly `2p`); `p = d·n−1` is not prime so
+  perfect-square `p` does occur.
+- `d = 2`: `≤ 3p` — too weak by a factor `3/2`.
+The strict `< 2p` for `d = 2` needs the Hermite/Minkowski constant `2/√3`
+(`(2/√3)·√d ≈ 1.63 < 2`), i.e. genuine geometry-of-numbers on the covolume-`p`
+sublattice — NOT a pigeonhole bound. So line 51 must go through Mathlib GoN
+(`MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`,
+already used at `ThreeSquares.lean:983` over ℤ³ — here instantiated on the 2D
+index-`p` slice lattice). Build/Aristotle-gated; do not write blind.
+
+**Net:** infra-blocked, not math-blocked. When a backend returns: (a) Aristotle
+`prove` the clean line-51 statement (best first try), else build the 2D-GoN
+proof; (b) discharge the 1 sorry in `SufficiencyCorrected`; (c) `docker-build` +
+register the 4 unregistered companions in dep order; (d) inline both axioms.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/state.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/state.md
@@ -3,8 +3,25 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-14T17:42:09-07:00
-**Iteration**: 5
+**Since**: 2026-06-16 (S6 frontier-sharpen; was 2026-06-14T17:42:09-07:00)
+**Iteration**: 6
+
+## Session 2026-06-16 (researcher-2) — S6 FRONTIER-SHARPEN (READ FIRST; both backends down)
+
+Dual blackout re-confirmed (Aristotle 404 ×2; `docker run` rc=124 hang). ORIENT
+triage only. See knowledge.md §"S6 FRONTIER-SHARPEN" for detail. Key updates:
+- **Both axioms now reduce to a TOTAL of 2 `sorry`s in companions.**
+  `dirichlet_key_lemma` is FULLY isolated to ONE self-contained, project-dep-free
+  statement `ThreeSquaresSlice.exists_slice_point_lt_two_mul`
+  (`ThreeSquaresSliceMinkowski.lean:51`) — bridge + assembly already PROVED.
+  Cleanest Aristotle target in the slug. `not_excluded_form_is_sum_three_sq`
+  reduces to 1 sorry in `ThreeSquaresSufficiencyCorrected.lean`.
+- `ThreeSquaresSingleAP` is now REGISTERED (0/0); 06-15 state's companion list
+  was stale (SliceMinkowski + SingleAP are newer, 06-16).
+- **Recorded WHY the elementary Thue/pigeonhole route fails** (bound
+  `≤ (1+d)p`: non-strict for d=1 at perfect-square p, ≤3p for d=2) ⇒ line 51
+  genuinely needs Mathlib GoN, not pigeonhole. Do not attempt the shortcut.
+Infra-blocked, not math-blocked; no `.lean` change (no blind GoN write). Released.
 
 ## Session 2026-06-16 (researcher-2) — universal single-AP QR seed (build-free cert)
 


### PR DESCRIPTION
## Summary

ORIENT-only triage of the three-squares sufficiency slug under the persisting
**dual blackout** (Aristotle `prove` 404 ×2; `docker run --rm alpine echo` rc=124
hang). **No `.lean` change** — the two remaining axioms are intricate
Minkowski/sublattice assembly that must not be written blind. Sharpens the
tracked frontier with verified-against-checkout facts:

- **Both axioms in `ThreeSquares.lean` now reduce to a TOTAL of 2 `sorry`s in
  companions.** `dirichlet_key_lemma` is **fully isolated to one self-contained,
  project-dependency-free statement** — `ThreeSquaresSlice.exists_slice_point_lt_two_mul`
  (`ThreeSquaresSliceMinkowski.lean:51`). Its bridge + assembly
  (`slice_point_to_dirichlet_vector`, `exists_dirichlet_vector_lt_two_mul`) are
  already **proved**, so closing that one line discharges the whole axiom. It is
  the cleanest possible Aristotle target in the slug.
  `not_excluded_form_is_sum_three_sq` reduces to 1 `sorry` in
  `ThreeSquaresSufficiencyCorrected.lean`.
- **Registration delta:** `ThreeSquaresSingleAP` (0 sorry/0 axiom) is now
  registered in `Proofs.lean` — the 06-15 tracked companion list was stale
  (`SliceMinkowski` + `SingleAP` are newer, 06-16).
- **Documents why the elementary Thue/pigeonhole shortcut is provably too weak**
  (bound `x²+d·y² ≤ (1+d)·p`: non-strict for `d=1` at perfect-square `p`, `≤3p`
  for `d=2`), so line 51 genuinely needs Mathlib geometry-of-numbers — saving the
  next session from chasing the dead shortcut.

## Status
- Infra-blocked (not math-blocked); axiom count unchanged at 2.
- **Next (backend up):** Aristotle `prove` the clean line-51 statement (or build
  the 2D-GoN proof) → discharge the 1 sorry in `SufficiencyCorrected` →
  `docker-build` + register the 4 unregistered companions in dep order → inline
  both axioms.

## Test plan
- [ ] `mcp aristotle prove` on `exists_slice_point_lt_two_mul` (when backend returns)
- [ ] `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSliceMinkowski` once the sorry is closed

🤖 Generated by researcher-2