### PR TITLE
research(frobenius-number-oq-02): gallery entry for the Frobenius symmetry

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -20874,11 +20874,12 @@
     },
     {
       "slug": "frobenius-number-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-06-13T12:52:52.038Z",
-      "status": "active",
-      "lastUpdate": "2026-06-13T12:52:52.038Z"
+      "status": "graduated",
+      "lastUpdate": "2026-06-16T13:30:00-08:00",
+      "completed": "2026-06-16T13:30:00-08:00"
     },
     {
       "slug": "furstenberg-correspondence-oq-01-incomplete-01",

--- a/src/data/proofs/frobenius-number-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-02/annotations.json
@@ -1,0 +1,125 @@
+[
+  {
+    "id": "ann-frob-oq02-context",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 22
+    },
+    "type": "concept",
+    "title": "Frobenius Symmetry: the structural fact behind Sylvester's theorems",
+    "content": "**Open question OQ-02** to the parent `frobenius-number`. For coprime $a, b \\geq 2$ with Frobenius number $g = ab - a - b$, and any $n$ with $0 < n < g$:\n$$\\text{Rep}(a, b, n) \\;\\Longleftrightarrow\\; \\neg\\,\\text{Rep}(a, b, g - n).$$\nEquivalently, the involution $n \\mapsto g - n$ swaps the representable and non-representable values in the open interval $(0, g)$, so exactly one of each complementary pair $\\{n, g - n\\}$ is representable. This is the precise statement that the two-generator numerical semigroup $\\langle a, b\\rangle$ is **symmetric**, and it is reused as a black box by sibling OQ-01 to count the non-representable values as $\\frac{(a-1)(b-1)}{2}$.",
+    "mathContext": "A numerical semigroup $S$ with Frobenius number $g$ is *symmetric* iff $k \\in S \\Leftrightarrow g - k \\notin S$ for all $0 \\le k \\le g$. By Kunz (1970), $\\langle a, b\\rangle$ symmetric $\\Leftrightarrow k[t^a, t^b]$ is Gorenstein. Two coprime generators always give a symmetric semigroup — this file proves exactly that.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "symmetric numerical semigroup",
+      "Frobenius coin problem (Sylvester 1884)",
+      "Gorenstein ring (Kunz 1970)",
+      "involution k ↦ g − k",
+      "Chicken McNugget theorem"
+    ],
+    "prerequisites": [
+      "Frobenius number g(a, b) = ab − a − b (parent frobenius-number)",
+      "Representable a b n := ∃ x y : ℕ, n = a·x + b·y"
+    ]
+  },
+  {
+    "id": "ann-frob-oq02-statement-correction",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 8,
+      "endLine": 13
+    },
+    "type": "warning",
+    "title": "Polarity correction: Rep(n) ↔ ¬Rep(g−n), NOT ¬Rep(n) ↔ ¬Rep(g−n)",
+    "content": "The problem's originally posed statement $\\neg\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g - n)$ is **false**: it asserts representability is *invariant* under $n \\mapsto g - n$, but the truth is that representability is *anti*-symmetric under this map. The header documents the counterexample $(a, b) = (3, 5)$, $g = 7$: here $n = 1$ is non-representable while $g - n = 6 = 3\\cdot 2$ **is** representable, so $\\neg\\text{Rep}(1)$ holds but $\\neg\\text{Rep}(6)$ fails. Getting the polarity right — representable iff complement non-representable — is the entire mathematical content of the symmetry.",
+    "mathContext": "The corrected biconditional makes $n \\mapsto g - n$ an involution between the gap set and the semigroup's intersection with $(0, g)$, which is what enables the equal-cardinality count in OQ-01.",
+    "significance": "key",
+    "relatedConcepts": [
+      "anti-symmetry of representability",
+      "involution on a finite set"
+    ]
+  },
+  {
+    "id": "ann-frob-oq02-residue-helpers",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 26,
+      "endLine": 46
+    },
+    "type": "lemma",
+    "title": "Complete residue system: k ↦ kb mod a is a bijection on Fin a",
+    "content": "Two private helpers establish the constructive core. **`mul_mod_inj`**: the self-map $k \\mapsto (k b \\bmod a)$ on $\\mathrm{Fin}\\,a$ is injective. The proof lifts to $\\mathbb{Z}/a\\mathbb{Z}$, where $b$ is a **unit** because $\\gcd(a, b) = 1$ (`ZMod.isUnit_natCast_iff`), so $ib = jb$ cancels to $i = j$. **`exists_kb_mod`**: since an injective self-map of a finite type is surjective (`Finite.injective_iff_surjective`), for every residue $r < a$ there is some $k < a$ with $k b \\bmod a = r$. In other words $\\{0, b, 2b, \\ldots, (a-1)b\\}$ is a **complete residue system mod $a$** — the fact that lets the main proof locate a representation by a bounded search.",
+    "mathContext": "Multiplication by a unit permutes $\\mathbb{Z}/a\\mathbb{Z}$. This is the only place the finiteness/pigeonhole structure is used, and it is exactly why coprimality is required for representations to exist.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complete residue system",
+      "units in ℤ/aℤ",
+      "pigeonhole (injective ⇒ surjective on Fin a)",
+      "ZMod cancellation"
+    ],
+    "prerequisites": [
+      "ZMod.isUnit_natCast_iff (b unit ⇔ coprime)",
+      "Finite.injective_iff_surjective"
+    ]
+  },
+  {
+    "id": "ann-frob-oq02-no-two-reps",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "rep_and_complement_false: n and g−n cannot both be representable",
+    "content": "The 'at most one' direction. Assume $n = ax + by$ and $g - n = ax' + by'$. Adding them and substituting $g = ab - a - b$ gives the key identity $ab = a(x + x' + 1) + b(y + y' + 1)$. Since both terms on the right are non-negative, each is bounded by $ab$, forcing $x + x' + 1 \\leq b$ and $y + y' + 1 \\leq a$. Rearranging the identity shows $a \\mid b(y + y' + 1)$ and $b \\mid a(x + x' + 1)$; coprimality (`Nat.Coprime.dvd_of_dvd_mul_left`) upgrades these to $a \\mid (y + y' + 1)$ and $b \\mid (x + x' + 1)$. A `linarith` squeeze of these divisibilities against the bounds yields `False`.",
+    "mathContext": "Geometrically: a complementary pair straddling the Frobenius number cannot both lie inside the semigroup, because their witnesses would tile a·b too efficiently. Coprimality is what turns the divisibility into an impossible inequality.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "divisibility squeeze",
+      "Nat.Coprime.dvd_of_dvd_mul_left",
+      "nlinarith / linarith arithmetic"
+    ]
+  },
+  {
+    "id": "ann-frob-oq02-at-least-one-rep",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "one_of_pair_rep: at least one of n, g−n is representable",
+    "content": "The 'at least one' direction, proved constructively. Using `exists_kb_mod`, pick $k < a$ with $kb \\equiv n \\pmod a$. **Case $kb \\leq n$:** then $n - kb$ is a non-negative multiple of $a$, say $aq$, so $n = aq + bk$ gives $\\text{Rep}(n)$ with witness $\\langle q, k\\rangle$. **Case $kb > n$:** then $kb - n$ is a positive multiple of $a$; the identity $(ab - a - b - n) - b(a - 1 - k) = kb - n - a$ shows $a \\mid (g - n) - b(a-1-k)$, and writing the quotient as $q$ yields $\\text{Rep}(g - n)$ with the explicit witness $\\langle q, a - 1 - k\\rangle$.",
+    "mathContext": "The residue search always lands a concrete representation on one side of the pair {n, g−n}. Combined with Part 1 (never both), this pins down exactly one representable element per pair.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "constructive representation",
+      "case split on k·b ≤ n",
+      "Nat.dvd_sub'",
+      "explicit witness construction"
+    ]
+  },
+  {
+    "id": "ann-frob-oq02-main-symmetry",
+    "proofId": "frobenius-number-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "frobenius_symmetry: the main biconditional Rep(n) ↔ ¬Rep(g−n)",
+    "content": "Assembles the two halves. **Forward:** given $\\text{Rep}(n)$, if $\\text{Rep}(g - n)$ also held then `rep_and_complement_false` gives `False`; hence $\\text{Rep}(n) \\to \\neg\\text{Rep}(g - n)$. **Backward:** given $\\neg\\text{Rep}(g - n)$, `one_of_pair_rep` supplies $\\text{Rep}(n) \\lor \\text{Rep}(g - n)$; the right disjunct contradicts the hypothesis, leaving $\\text{Rep}(n)$. This biconditional is the engine OQ-01 imports to run its `Finset.card_bij` involution and count the gaps as $\\frac{(a-1)(b-1)}{2}$.",
+    "mathContext": "The clean two-line assembly demonstrates separation of concerns: the deep work lives in the two directional lemmas, and the public theorem is their immediate combination — the standard Lean idiom for packaging a structural result for downstream reuse.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "biconditional assembly",
+      "black-box reuse by frobenius-number-oq-01",
+      "Garsia–Milne involution principle"
+    ],
+    "prerequisites": [
+      "rep_and_complement_false (Part 1)",
+      "one_of_pair_rep (Part 2)"
+    ]
+  }
+]

--- a/src/data/proofs/frobenius-number-oq-02/meta.json
+++ b/src/data/proofs/frobenius-number-oq-02/meta.json
@@ -1,0 +1,226 @@
+{
+  "id": "frobenius-number-oq-02",
+  "title": "Frobenius Symmetry: Rep(n) ↔ ¬Rep(g−n) for Two Coprime Generators",
+  "slug": "frobenius-number-oq-02",
+  "description": "For coprime a, b ≥ 2 with Frobenius number g = ab − a − b and 0 < n < g, a positive integer n is representable as ax + by (x, y ∈ ℕ) if and only if its complement g − n is NOT representable. This is the structural symmetry that makes the two-generator numerical semigroup ⟨a, b⟩ symmetric, and it is the black-box engine behind the genus count formula (a−1)(b−1)/2 proved in sibling OQ-01. Two halves of the argument: rep_and_complement_false (n and g−n cannot both be representable) and one_of_pair_rep (at least one of n, g−n is representable, via a residue-completion lemma). 3 theorems + 2 private lemmas, 0 sorries, 0 axioms. Note: the originally posed JSON statement ¬Rep(n) ↔ ¬Rep(g−n) is incorrect; the correct symmetry pairs each representable with a non-representable.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ02.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean"
+    ],
+    "tags": [
+      "number-theory",
+      "frobenius",
+      "coin-problem",
+      "numerical-semigroups",
+      "symmetric-semigroup",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 101,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. All results proved from first principles. The only hypotheses are the mathematical conditions of the theorem: a, b ≥ 2, gcd(a, b) = 1, and 0 < n < g. No axioms or structure-encoded assumptions.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finite.injective_iff_surjective",
+        "description": "On the finite type Fin a, injectivity of the residue map k ↦ k·b mod a implies surjectivity — used to show every residue mod a is hit by some multiple of b.",
+        "module": "Mathlib.Logic.Equiv.Defs"
+      },
+      {
+        "theorem": "ZMod.isUnit_natCast_iff",
+        "description": "b is a unit in ZMod a iff gcd(a, b) = 1 — the coprimality hypothesis enters here to cancel b in the residue injectivity proof.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.dvd_of_dvd_mul_left",
+        "description": "If gcd(a, b) = 1 and a ∣ b·c then a ∣ c — drives the contradiction in rep_and_complement_false.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_sub'",
+        "description": "Divisibility is preserved under truncated subtraction — assembles the second witness in one_of_pair_rep.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "First-principles proof of the Frobenius/Sylvester symmetry Rep(n) ↔ ¬Rep(g−n) for two coprime generators, self-contained with no external symmetry axiom.",
+      "rep_and_complement_false: if both n and g−n were representable, summing the witnesses forces a·b = a·(x+x'+1) + b·(y+y'+1) with each factor bounded by the other generator, yielding a ∣ b·(…) and b ∣ a·(…); coprimality then gives a contradiction via a counting/divisibility squeeze.",
+      "one_of_pair_rep: a constructive residue-completion argument — exists_kb_mod shows the map k ↦ k·b mod a is a bijection on Fin a (injective via ZMod cancellation by the unit b, hence surjective), so the residue n mod a equals k·b mod a for some k < a; a case split on k·b ≤ n produces an explicit representation of either n or g−n.",
+      "Correction of the problem's posed statement: the symmetry is Rep(n) ↔ ¬Rep(g−n), NOT ¬Rep(n) ↔ ¬Rep(g−n) (counterexample a=3, b=5, g=7: n=1 non-rep, g−n=6 representable)."
+    ],
+    "prerequisites": [
+      "frobenius-number (parent: Sylvester's Frobenius number formula g(a,b) = ab − a − b)",
+      "Definition Representable a b n := ∃ x y : ℕ, n = a·x + b·y (from parent FrobeniusNumber)",
+      "ZMod arithmetic: units and cancellation (b invertible mod a ⇔ coprime)",
+      "Pigeonhole on finite types: injective ⇒ surjective on Fin a"
+    ],
+    "dateAdded": "2026-06-16",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The **Frobenius coin problem** (Chicken McNugget theorem, postage-stamp problem) for two coprime generators $a, b$ was solved by **James Joseph Sylvester** (1880s): the largest non-representable integer is the *Frobenius number* $g(a, b) = ab - a - b$ (parent entry `frobenius-number`), and there are exactly $\\frac{(a-1)(b-1)}{2}$ non-representable positive integers (sibling `frobenius-number-oq-01`). Underlying *both* of Sylvester's theorems is a single structural fact: the numerical semigroup $\\langle a, b\\rangle$ is **symmetric**. A numerical semigroup $S$ with Frobenius number $g$ is called symmetric when for every $k \\in \\{0, 1, \\ldots, g\\}$, $k \\in S \\Leftrightarrow g - k \\notin S$. For two coprime generators this symmetry *always holds* — and that is precisely the statement formalized here: $\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g - n)$ for $0 < n < g$.\n\nThe notion of symmetric numerical semigroups was crystallized by **Kunz (1970)** and connected to **Gorenstein** local rings: $\\langle a, b\\rangle$ symmetric corresponds to $k[t^a, t^b]$ being a Gorenstein ring. **Herzog (1970)** generalized this to complete-intersection numerical semigroups. So the unassuming biconditional in this file is the elementary shadow of a deep duality in commutative algebra.",
+    "problemStatement": "For coprime positive integers $a, b \\geq 2$ with Frobenius number $g(a, b) = ab - a - b$, and any $n$ with $0 < n < g$, prove the symmetry\n\n$$\\text{Representable}(a, b, n) \\;\\Longleftrightarrow\\; \\neg\\,\\text{Representable}(a, b, g - n),$$\n\nwhere $\\text{Representable}(a, b, m) := \\exists\\, x, y \\in \\mathbb{N},\\ m = ax + by$. Equivalently: in the open interval $(0, g)$, exactly one of each complementary pair $\\{n, g - n\\}$ is representable.",
+    "text": "The structural symmetry of two-generator numerical semigroups: in the range below the Frobenius number, a value is representable exactly when its complement is not. This is the engine behind Sylvester's genus count.",
+    "proofStrategy": "**Two complementary halves, combined into a biconditional.** **(⇒, no two reps) `rep_and_complement_false`:** assume both $n = ax + by$ and $g - n = ax' + by'$ are representable. Adding and using $g = ab - a - b$ gives $ab = a(x + x' + 1) + b(y + y' + 1)$. Each summand is non-negative, forcing $x + x' + 1 \\leq b$ and $y + y' + 1 \\leq a$; rearranging shows $a \\mid b(y + y' + 1)$ and $b \\mid a(x + x' + 1)$. Coprimality (`Nat.Coprime.dvd_of_dvd_mul_left`) turns these into $a \\mid (y+y'+1)$ and $b \\mid (x+x'+1)$, and a `linarith` squeeze against the bounds yields `False`. **(⇐, at least one rep) `one_of_pair_rep`:** the helper `exists_kb_mod` proves $k \\mapsto k b \\bmod a$ is a bijection on $\\mathrm{Fin}\\,a$ — injectivity comes from cancelling the unit $b$ in $\\mathbb{Z}/a\\mathbb{Z}$ (coprimality via `ZMod.isUnit_natCast_iff`), and `Finite.injective_iff_surjective` upgrades to surjectivity — so some $k < a$ satisfies $kb \\equiv n \\pmod a$. Case split: if $kb \\leq n$ then $n - kb$ is a non-negative multiple of $a$, giving $\\text{Rep}(n)$ directly; otherwise an explicit witness $\\langle q, a - 1 - k\\rangle$ represents $g - n$. **Assembly `frobenius_symmetry`:** the forward direction is `rep_and_complement_false` contrapositive; the backward direction picks the representable element from `one_of_pair_rep`.",
+    "keyInsights": [
+      "**The symmetry is the single source of *both* Sylvester theorems.** The Frobenius number formula (largest gap = $g$) and the genus formula (number of gaps = $\\frac{(a-1)(b-1)}{2}$, sibling OQ-01) are both corollaries of this one biconditional: it says the involution $k \\mapsto g - k$ swaps the representable and non-representable sets in $(0, g)$. OQ-01 literally imports this file and uses it as a one-line black box inside a `Finset.card_bij`.",
+      "**Coprimality enters exactly twice, in dual guises.** In `rep_and_complement_false` it converts $a \\mid bc$ into $a \\mid c$ (a *divisibility* use). In `one_of_pair_rep` it makes $b$ a *unit* in $\\mathbb{Z}/a\\mathbb{Z}$, so multiplication by $b$ permutes residues (a *cancellation* use). Both are facets of $\\gcd(a, b) = 1$, and without it the result is false — non-coprime generators only represent multiples of the gcd.",
+      "**The residue-completion lemma is the constructive core.** `exists_kb_mod` says every residue class mod $a$ is realized by some multiple $kb$ with $k < a$. This is a finite pigeonhole (injective map on $\\mathrm{Fin}\\,a$ is surjective) and is exactly the statement that $\\{0, b, 2b, \\ldots, (a-1)b\\}$ is a complete residue system mod $a$ when $\\gcd(a, b) = 1$. It converts the *existence* of a representation into a concrete search bounded by $a$.",
+      "**Statement correction matters.** The problem JSON posed $\\neg\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g-n)$, which is FALSE: it would say representability is symmetric under $n \\mapsto g - n$, but the truth is *anti*-symmetric (representable ↔ complement non-representable). The header documents the counterexample $(a,b)=(3,5)$, $g=7$: $n=1$ is non-representable while $g-n=6 = 3\\cdot2$ is representable. Getting the polarity right is the whole content.",
+      "**`Finite.injective_iff_surjective` is the right Lean idiom for complete-residue-system arguments.** Rather than constructing an explicit inverse, the proof packages $k \\mapsto kb \\bmod a$ as an endomorphism of $\\mathrm{Fin}\\,a$, proves injectivity by `ZMod` cancellation, and reads off surjectivity for free. **Pattern reusable** for any 'multiplication by a unit permutes the residues' argument."
+    ],
+    "prerequisites": [
+      "Frobenius number $g(a, b) = ab - a - b$ for coprime $a, b \\geq 2$ (parent `frobenius-number`)",
+      "Definition $\\text{Representable}(a, b, n) := \\exists x, y \\in \\mathbb{N},\\ n = ax + by$",
+      "Units and cancellation in $\\mathbb{Z}/a\\mathbb{Z}$: $b$ invertible $\\Leftrightarrow \\gcd(a, b) = 1$",
+      "Finite pigeonhole: an injective self-map of $\\mathrm{Fin}\\,a$ is surjective"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Documentation comment stating the symmetry Rep(n) ↔ ¬Rep(g−n) for coprime a, b ≥ 2 and 0 < n < g, and flagging that the problem's posed ¬Rep ↔ ¬Rep form is incorrect (counterexample a=3, b=5, g=7). Imports the parent FrobeniusNumber (for Representable, frobeniusNumber) plus Nat GCD basics and Mathlib.Tactic.",
+      "mathContext": "Two-generator numerical semigroups are symmetric: the involution k ↦ g − k swaps representable and non-representable values in (0, g)."
+    },
+    {
+      "id": "residue-helpers",
+      "title": "Helpers: mul_mod_inj and exists_kb_mod (Complete Residue System)",
+      "startLine": 24,
+      "endLine": 46,
+      "summary": "Two private lemmas. mul_mod_inj: the map k ↦ (k·b mod a) on Fin a is injective, proved by lifting to ZMod a, cancelling the unit b (ZMod.isUnit_natCast_iff from coprimality), and an omega finish. exists_kb_mod: by Finite.injective_iff_surjective the injective map is surjective, so for every residue r < a there is some k < a with k·b mod a = r.",
+      "mathContext": "{0, b, 2b, …, (a−1)b} is a complete residue system mod a precisely when gcd(a, b) = 1 — multiplication by a unit permutes ℤ/aℤ."
+    },
+    {
+      "id": "no-two-reps",
+      "title": "Part 1: rep_and_complement_false (n and g−n not both representable)",
+      "startLine": 48,
+      "endLine": 63,
+      "summary": "If n = ax + by and g − n = ax' + by' are both representable, expanding g = ab − a − b gives ab = a(x+x'+1) + b(y+y'+1). Non-negativity bounds each factor (x+x'+1 ≤ b, y+y'+1 ≤ a); rearrangement yields a ∣ b(y+y'+1) and b ∣ a(x+x'+1), and coprimality (Nat.Coprime.dvd_of_dvd_mul_left) plus a linarith squeeze derives False.",
+      "mathContext": "The 'at most one' direction: complementary pairs straddling the Frobenius number cannot both lie in the semigroup."
+    },
+    {
+      "id": "at-least-one-rep",
+      "title": "Part 2: one_of_pair_rep (at least one of n, g−n representable)",
+      "startLine": 65,
+      "endLine": 88,
+      "summary": "Using exists_kb_mod, pick k < a with k·b ≡ n (mod a). Case split on k·b ≤ n: if so, n − k·b is a non-negative multiple of a, giving Rep(n) = ⟨q, k⟩. Otherwise k·b − n is a positive multiple of a, and a divisibility computation on (ab − a − b − n) − b(a−1−k) = k·b − n − a produces the explicit witness ⟨q, a−1−k⟩ for Rep(g − n).",
+      "mathContext": "The 'at least one' direction: the constructive residue search always lands a representation on one side of the pair."
+    },
+    {
+      "id": "main-symmetry",
+      "title": "Part 3: frobenius_symmetry (Main Biconditional)",
+      "startLine": 90,
+      "endLine": 101,
+      "summary": "Assembles the biconditional Rep(n) ↔ ¬Rep(g − n). Forward: from Rep(n) and Rep(g − n), rep_and_complement_false gives False, so Rep(n) → ¬Rep(g − n). Backward: from ¬Rep(g − n), one_of_pair_rep yields Rep(n) ∨ Rep(g − n); the second disjunct is absurd, so Rep(n).",
+      "mathContext": "The full symmetry — the structural fact that powers Sylvester's genus count formula in sibling OQ-01."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Frobenius/Sylvester symmetry is proved from first principles in 101 lines, 0 axioms, 0 sorries: for coprime $a, b \\geq 2$ with $g = ab - a - b$ and $0 < n < g$, $\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g - n)$. The 'at most one' direction is a divisibility squeeze powered by coprimality; the 'at least one' direction is a constructive residue-completion search showing $\\{kb \\bmod a\\}$ exhausts the residues mod $a$. This biconditional is the structural reason two-generator numerical semigroups are symmetric, and it is reused verbatim as the engine of the genus count $\\frac{(a-1)(b-1)}{2}$ in sibling OQ-01.",
+    "implications": "**Two-generator numerical semigroups are symmetric**, hence (via Kunz 1970) the coordinate rings $k[t^a, t^b]$ are **Gorenstein**. The elementary biconditional formalized here is the combinatorial heart of that algebraic duality. Concretely, the symmetry collapses the genus computation to a one-line bijection argument (OQ-01): the involution $k \\mapsto g - k$ pairs the $\\frac{g-1}{2}$ non-representable values in $(0, g)$ with the equally-many representable ones, and $g$ itself contributes the final gap. Beyond two generators the symmetry can FAIL — most numerical semigroups are *not* symmetric — so this result marks exactly the boundary where the clean closed-form theory of Sylvester applies.",
+    "openQuestions": [
+      "Characterize all **symmetric numerical semigroups** beyond two generators via Apéry sets (Kunz 1970): a numerical semigroup is symmetric iff its Apéry set is symmetric under the natural involution. Formalizing this would require Apéry-set infrastructure absent from Mathlib.",
+      "**Pseudo-symmetric semigroups** (Frobenius number even, with the type-2 gap structure): state and prove the analogous involution and the genus correction $\\frac{(a-1)(b-1)}{2}$ → type-dependent count.",
+      "**Gorenstein duality**: formalize the bridge from semigroup symmetry to the Gorenstein property of $k[t^a, t^b]$, connecting this combinatorial fact to commutative-algebra Mathlib (local cohomology, canonical modules)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number",
+      "relationship": "extends",
+      "description": "Direct parent: supplies the definition Representable a b n := ∃ x y, n = ax + by and the Frobenius number frobeniusNumber a b = ab − a − b. This file proves the symmetry of representability about g/2; the parent proves that g is the LARGEST non-representable value (sylvester_frobenius)."
+    },
+    {
+      "targetId": "frobenius-number-oq-01",
+      "relationship": "related",
+      "description": "Downstream consumer: OQ-01 imports this file and uses frobenius_symmetry as a black box inside Finset.card_bij to prove the genus count (a−1)(b−1)/2. The involution k ↦ g − k pairs non-representable with representable values precisely because of the biconditional proved here."
+    },
+    {
+      "targetId": "frobenius-number-oq-03",
+      "relationship": "related",
+      "description": "The three-generator companion (Representable3 a b c n). The symmetry proved here is special to two coprime generators — for three or more generators the semigroup need not be symmetric and no closed-form Frobenius number exists in general."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bézout's identity (coprime a, b represent every integer over ℤ) explains why the residue map k ↦ kb mod a is a bijection: b is a unit mod a exactly when gcd(a, b) = 1. The non-negativity constraint x, y ∈ ℕ is what makes the finite gap structure — and hence the symmetry about g — nontrivial."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The hypothesis gcd(a, b) = 1 is used twice: to cancel b as a unit in ℤ/aℤ (one_of_pair_rep) and to pass from a ∣ bc to a ∣ c (rep_and_complement_false). Without coprimality only multiples of gcd(a, b) are representable and the symmetry fails."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathematical questions, with their solutions",
+      "author": "James Joseph Sylvester",
+      "year": "1884",
+      "venue": "Educational Times 41, 21",
+      "description": "Sylvester's original solution of the two-generator Frobenius problem; the symmetry of representability underlies both the Frobenius number and the genus count."
+    },
+    {
+      "title": "The value-semigroup of a one-dimensional Gorenstein ring",
+      "author": "Ernst Kunz",
+      "year": "1970",
+      "venue": "Proceedings of the American Mathematical Society 25, 748–751",
+      "description": "Establishes that a numerical semigroup is symmetric iff its associated coordinate ring is Gorenstein — the algebraic significance of the biconditional formalized here."
+    },
+    {
+      "title": "Numerical Semigroups",
+      "author": "J. C. Rosales, P. A. García-Sánchez",
+      "year": "2009",
+      "venue": "Springer Developments in Mathematics 20",
+      "description": "Standard reference: Chapter 2 covers two-generator semigroups and Chapter 4 covers symmetric and pseudo-symmetric semigroups and their Apéry-set characterizations."
+    },
+    {
+      "title": "The Diophantine Frobenius Problem",
+      "author": "Jorge L. Ramírez Alfonsín",
+      "year": "2005",
+      "venue": "Oxford Lecture Series in Mathematics and Its Applications 30",
+      "description": "Definitive monograph on the Frobenius problem covering the two-generator (Sylvester) symmetry, three-generator (Selmer) results, and the open general case."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FrobeniusNumberOQ02.lean",
+    "filename": "FrobeniusNumberOQ02.lean",
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Tactic",
+      "Proofs.FrobeniusNumber"
+    ],
+    "namespace": "FrobeniusSymmetry",
+    "lineCount": 101,
+    "theoremCount": 3,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ02.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean"
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "frobenius-number-oq-02-oq-01",
+      "question": "Characterize symmetric numerical semigroups with more than two generators via Apéry sets (Kunz 1970), and identify which generator tuples preserve the involution symmetry k ↦ g − k.",
+      "significance": "high"
+    },
+    {
+      "id": "frobenius-number-oq-02-oq-02",
+      "question": "Formalize the Gorenstein duality: prove that ⟨a, b⟩ symmetric implies k[t^a, t^b] is Gorenstein, bridging this combinatorial symmetry to commutative-algebra Mathlib.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/frobenius-number-oq-02.json
+++ b/src/data/research/problems/frobenius-number-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "frobenius-number-oq-02",
   "title": "Symmetry of Non-Representable Numbers (Frobenius)",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-05-29T19:14:09.184Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Complete: Frobenius symmetry Rep(n) ↔ ¬Rep(g−n) proved (0 sorry/0 axiom); gallery entry created.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — graduated to gallery.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,9 +31,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: frobenius_symmetry proved from first principles (0 sorries, 0 axioms), registered in Proofs.lean and now in gallery. Engine reused as black box by OQ-01 genus count.",
+    "builtItems": [
+      "FrobeniusNumberOQ02.lean: frobenius_symmetry — Rep(n) ↔ ¬Rep(g−n) for coprime a,b≥2, 0<n<g (line 91)",
+      "rep_and_complement_false — divisibility squeeze ruling out both n,g−n representable (line 51)",
+      "one_of_pair_rep — constructive residue-completion giving Rep on one side (line 66)",
+      "exists_kb_mod/mul_mod_inj — {kb mod a} is a complete residue system via ZMod unit cancellation + Finite.injective_iff_surjective (lines 26,41)",
+      "Gallery entry src/data/proofs/frobenius-number-oq-02/ (meta.json + 6 annotations, resolver-validated)"
+    ],
+    "insights": [
+      "Posed statement ¬Rep(n)↔¬Rep(g−n) is FALSE; correct symmetry is Rep(n)↔¬Rep(g−n) (counterexample a=3,b=5,g=7: n=1 nonrep, g−n=6 rep).",
+      "Coprimality used twice dually: a∣bc⇒a∣c (rep_and_complement_false) and b a unit mod a (one_of_pair_rep residue bijection).",
+      "This symmetry = the statement that ⟨a,b⟩ is a symmetric numerical semigroup; OQ-01 imports it verbatim for the (a−1)(b−1)/2 genus count."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -53,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.184Z",
-  "lastUpdate": "2026-05-29T19:14:09.184Z",
+  "lastUpdate": "2026-06-16T13:30:00-08:00",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- `FrobeniusNumberOQ02.lean` proves the **Frobenius symmetry** `Rep(n) ↔ ¬Rep(g−n)` for coprime `a, b ≥ 2` and `0 < n < g` (where `g = ab − a − b`). It is complete (**0 sorries, 0 axioms**), already on `main`, and registered in `Proofs.lean` — but had **no gallery page**.
- This is the structural fact that `⟨a, b⟩` is a *symmetric* numerical semigroup, and it is imported verbatim by sibling **OQ-01** as the black-box engine behind the genus count `(a−1)(b−1)/2`. Worth surfacing in the gallery.
- Adds `src/data/proofs/frobenius-number-oq-02/{meta.json, annotations.json}` (6 annotations, all resolver-validated) and graduates the registry + problem-JSON entry to `COMPLETED`.

## What the proof does
- `rep_and_complement_false` — divisibility squeeze (coprimality via `Nat.Coprime.dvd_of_dvd_mul_left`) ruling out both `n` and `g−n` representable.
- `one_of_pair_rep` — constructive residue-completion (`{kb mod a}` is a complete residue system via `ZMod` unit cancellation + `Finite.injective_iff_surjective`) producing an explicit representation on one side of the pair.
- `frobenius_symmetry` — assembles the biconditional.
- Header documents that the originally posed `¬Rep(n) ↔ ¬Rep(g−n)` is **false** (counterexample `(3,5)`, `g=7`).

## Verification
- Both JSON files validated via `node JSON.parse` (NOT `pnpm build`, to avoid rewriting sibling listings).
- `resolver.ts validate` → **6 valid, 0 misaligned** against the Lean source.
- The Lean proof itself is unchanged and already builds on `main` (default target).

## Test plan
- [ ] Gallery build picks up the new `frobenius-number-oq-02` entry (deployer build).
- [ ] No regression to sibling entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)