### PR TITLE
Enrich central-limit-theorem-oq-04: re-anchor 6 drifted annotations

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-04/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-04/annotations.json
@@ -57,7 +57,7 @@
     "id": "ann-fclt-free-independence",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 112,
+      "startLine": 114,
       "endLine": 133,
       "startColumn": 0,
       "endColumn": 0
@@ -84,7 +84,7 @@
     "id": "ann-fclt-free-cumulants",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 139,
+      "startLine": 142,
       "endLine": 170,
       "startColumn": 0,
       "endColumn": 0
@@ -111,7 +111,7 @@
     "id": "ann-fclt-free-conv-monoid",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 188,
+      "startLine": 189,
       "endLine": 217,
       "startColumn": 0,
       "endColumn": 0
@@ -164,7 +164,7 @@
     "id": "ann-fclt-convpow-cumulant",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 240,
+      "startLine": 241,
       "endLine": 256,
       "startColumn": 0,
       "endColumn": 0
@@ -190,7 +190,7 @@
     "id": "ann-fclt-rtransform",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 278,
+      "startLine": 279,
       "endLine": 304,
       "startColumn": 0,
       "endColumn": 0
@@ -405,7 +405,7 @@
     "id": "ann-fclt-muraki",
     "proofId": "central-limit-theorem-oq-04",
     "range": {
-      "startLine": 579,
+      "startLine": 583,
       "endLine": 641,
       "startColumn": 0,
       "endColumn": 0


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem-oq-04`.

6 of 16 annotations had `range.startLine` pointing into pre-declaration banner gaps, so the resolver reported **'No Lean construct found'**. Snapped each `startLine` to the first comment/declaration in its block; `endLine` unchanged (positional only).

Resolver after: **16 valid, 0 misaligned** (was 10 valid / 6 misaligned).