### PR TITLE
Enrich erdos-991: re-anchor 7 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-991/annotations.json
+++ b/src/data/proofs/erdos-991/annotations.json
@@ -22,7 +22,7 @@
     "id": "ann-e991-unit-sphere",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 42,
+      "startLine": 43,
       "endLine": 48
     },
     "type": "definition",
@@ -40,7 +40,7 @@
     "id": "ann-e991-sphere-dist",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 49,
+      "startLine": 50,
       "endLine": 55
     },
     "type": "definition",
@@ -58,7 +58,7 @@
     "id": "ann-e991-log-energy",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 63,
+      "startLine": 64,
       "endLine": 73
     },
     "type": "definition",
@@ -77,7 +77,7 @@
     "id": "ann-e991-optimal-config",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 74,
+      "startLine": 75,
       "endLine": 85
     },
     "type": "definition",
@@ -95,7 +95,7 @@
     "id": "ann-e991-spherical-cap",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 92,
+      "startLine": 93,
       "endLine": 99
     },
     "type": "definition",
@@ -113,7 +113,7 @@
     "id": "ann-e991-cap-area",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 100,
+      "startLine": 101,
       "endLine": 107
     },
     "type": "definition",
@@ -131,7 +131,7 @@
     "id": "ann-e991-cap-count",
     "proofId": "erdos-991",
     "range": {
-      "startLine": 108,
+      "startLine": 109,
       "endLine": 114
     },
     "type": "definition",


### PR DESCRIPTION
Enrichment pass for `erdos-991`.

7 of 17 annotations had `range.startLine` one line above their target doc-comment (banner drift), so the resolver reported **'No Lean construct found'**. Snapped each `startLine` to the doc-comment of the first declaration in its block; `endLine` unchanged.

Resolver after: **17 valid, 0 misaligned** (was 10 valid / 7 misaligned).