### PR TITLE
Fix: amgm-inequality-oq-02-oq-01-oq-05 false-green (correct v4.26 API names + downgrade meta)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05.lean
@@ -71,7 +71,7 @@ theorem upper_eq_lower :
   intro i hi
   apply Finset.sum_congr rfl
   intro j hj
-  by_cases h : j < i
+  by_cases h : i < j
   · simp [h, mul_comm]
   · simp [h]
 
@@ -90,8 +90,11 @@ theorem newton_girard : (e1 n f) ^ 2 = p2 n f + 2 * e2 n f := by
 /-- Cauchy-Schwarz / power-mean bound: (Σ xᵢ)² ≤ n · Σ xᵢ². -/
 theorem sq_e1_le_card_mul_p2 : (e1 n f) ^ 2 ≤ (n : ℝ) * p2 n f := by
   unfold e1 p2
-  have h := Finset.sq_sum_le_card_mul_sum_sq (s := range n) (f := f)
-  simpa [Finset.card_range] using h
+  have h := Finset.sum_mul_sq_le_sq_mul_sq (range n) f (fun _ => 1)
+  simp only [mul_one, one_pow, Finset.sum_const, Finset.card_range, nsmul_eq_mul,
+    mul_one] at h
+  rw [mul_comm]
+  exact h
 
 -- ============================================================
 -- Maclaurin base step
@@ -118,7 +121,7 @@ theorem maclaurin_base_step (hn : 2 ≤ n) :
   have hC : (0 : ℝ) < (n.choose 2 : ℝ) := by
     have : 0 < n.choose 2 := Nat.choose_pos (by omega)
     exact_mod_cast this
-  rw [div_pow, div_le_div_iff hC (pow_pos hn0 2)]
+  rw [div_pow, div_le_div_iff₀ hC (pow_pos hn0 2)]
   nlinarith [maclaurin_cleared n f]
 
 end AmgmInequalityOQ02OQ01OQ05

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
@@ -5,7 +5,7 @@
   "description": "Proves the first rung of the Maclaurin inequality chain, S₁² ≥ S₂, for nonnegative reals x₁,…,xₙ (n ≥ 2), where S₁ = e₁/n and S₂ = e₂/C(n,2) are the first two Maclaurin averages of the elementary symmetric sums e₁ = Σxᵢ and e₂ = Σ_{i<j} xᵢxⱼ. The proof combines the Newton-Girard square-of-sum identity e₁² = p₂ + 2e₂ (re-derived here by the diagonal/off-diagonal split, mirroring the parent entry) with the Cauchy-Schwarz / power-mean bound e₁² ≤ n·p₂, which together reduce the averaged inequality to the cleared form C(n,2)·e₁² ≥ n²·e₂ and finally to n·p₂ ≥ e₁². 6 theorems, 3 definitions, 0 axioms.",
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ01OQ05",
-    "lineCount": 124,
+    "lineCount": 126,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 3,
@@ -16,7 +16,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-16",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ05.lean",
     "tags": [
       "inequalities",
@@ -27,19 +27,19 @@
       "power-mean",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. BUILD PENDING: the file is complete and sorry-free but not yet kernel-checked locally — the worktree Docker VM was build-saturated (9 concurrent builds, cold Mathlib cache) and Aristotle MCP was unavailable (404) this session, so verification is deferred. The file is intentionally NOT yet registered in Proofs.lean (kept as an orphan) until a green build is confirmed, since there is no CI Lean-build gate and registering an uncompiled file could break the shared Proofs build on main. The two at-risk Mathlib names were checked against the API: Finset.sq_sum_le_card_mul_sum_sq (Mathlib.Algebra.Order.Chebyshev, signature (∑ i ∈ s, f i)^2 ≤ ↑s.card * ∑ i ∈ s, f i^2) and Nat.cast_choose_two ℝ n (Mathlib.Data.Nat.Choose.Cast, ↑(n.choose 2) = ↑n*(↑n-1)/2). This is a formalization entry: the mathematics is the classical first Maclaurin inequality and the contribution is a clean self-contained derivation from an already-formalized identity.",
-    "lineCount": 124,
+    "assumptions": "0 axioms, 0 sorries (textually). BUILD NOT YET CONFIRMED — status is 'pending'/'wip'. A gallery-integrity audit (issue #25084) found the original file did NOT compile under Mathlib v4.26: it referenced the nonexistent lemma 'Finset.sq_sum_le_card_mul_sum_sq' and the deprecated 'div_le_div_iff', and had an index-orientation bug in upper_eq_lower plus a stuck typeclass goal. Prior sorry-count-only audits recorded 'clean' because the file is textually sorry-free, which is not the same as compiling. This entry corrects the API names against the offline Mathlib v4.26 checkout (rev 2df2f0150c): the Cauchy-Schwarz bound now uses Finset.sum_mul_sq_le_sq_mul_sq (Mathlib.Algebra.Order.BigOperators.Ring.Finset, (∑ i ∈ s, f i * g i)^2 ≤ (∑ i ∈ s, f i^2)·(∑ i ∈ s, g i^2)) specialized at g = 1, the averaged step uses div_le_div_iff₀ (Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic), and Nat.cast_choose_two ℝ n is unchanged. These names are verified to EXIST in the v4.26 API, but a green Docker build has NOT been run this session (the worktree Docker daemon was hung, `docker run` rc=124, and Aristotle MCP returned 404), so compilation remains unverified. The file is intentionally NOT registered in Proofs.lean until a green build is confirmed. Once a build passes, restore status 'formalized' and badge 'mathlib'.",
+    "lineCount": 126,
     "theoremCount": 6,
     "definitionCount": 3,
     "originalContributions": [
       "maclaurin_base_step: the averaged inequality (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2 — the first rung S₁² ≥ S₂ of the Maclaurin chain that refines AM-GM",
       "maclaurin_cleared: the denominator-cleared form C(n,2)·e₁² ≥ n²·e₂, valid for all n (including the degenerate n = 0, 1)",
       "newton_girard: e₁² = p₂ + 2e₂ re-derived for the range-n family via the index-pair trichotomy split (double_sum_split) plus the upper/lower-triangle symmetry (upper_eq_lower)",
-      "sq_e1_le_card_mul_p2: the Cauchy-Schwarz / power-mean bound e₁² ≤ n·p₂ specialized to range n via Finset.sq_sum_le_card_mul_sum_sq",
+      "sq_e1_le_card_mul_p2: the Cauchy-Schwarz / power-mean bound e₁² ≤ n·p₂ specialized to range n via Finset.sum_mul_sq_le_sq_mul_sq (with g = 1)",
       "Identifies that S₁² ≥ S₂ is exactly Cauchy-Schwarz in disguise: after substituting Newton-Girard, the inequality collapses to n·p₂ ≥ e₁² and needs no nonnegativity hypothesis on the xᵢ"
     ]
   },
@@ -47,7 +47,7 @@
     "historicalContext": "Colin Maclaurin (1729) refined the arithmetic-geometric mean inequality into a chain of inequalities among the symmetric means S_k = e_k / C(n,k), where e_k is the k-th elementary symmetric polynomial of nonnegative reals: S₁ ≥ √S₂ ≥ ∛S₃ ≥ ⋯ ≥ (Sₙ)^{1/n}, with the two ends recovering AM ≥ GM. The base case S₁² ≥ S₂ (equivalently S₁ ≥ √S₂) is the first and most elementary rung. It follows from the Newton-Girard square-of-sum identity e₁² = p₂ + 2e₂ — formalized in the parent entry amgm-inequality-oq-02-oq-01 — together with the power-mean/Cauchy-Schwarz bound p₂ ≥ e₁²/n. Formalizing this rung is a concrete, self-contained step toward a future formal Maclaurin chain.",
     "problemStatement": "For nonnegative reals $x_1,\\dots,x_n$ with $n \\ge 2$, let $e_1 = \\sum_i x_i$, $e_2 = \\sum_{i<j} x_i x_j$, and the Maclaurin averages $S_1 = e_1/n$, $S_2 = e_2/\\binom{n}{2}$. Then $S_1^2 \\ge S_2$.",
     "text": "The proof reduces the averaged inequality S₁² ≥ S₂ to the cleared-denominator form C(n,2)·e₁² ≥ n²·e₂, substitutes the Newton-Girard identity 2e₂ = e₁² − p₂, and observes that the resulting inequality is exactly the Cauchy-Schwarz bound n·p₂ ≥ e₁². Newton-Girard is re-derived from scratch for the range-n family; the Cauchy-Schwarz bound is taken from Mathlib.",
-    "proofStrategy": "Three layers. (1) Newton-Girard e₁² = p₂ + 2e₂: expand e₁² = (Σf)² = Σᵢ Σⱼ fᵢfⱼ via Finset.sum_mul_sum, then split each inner sum by lt_trichotomy on (i,j) into the strict-upper part (e₂), the diagonal (p₂, isolated with Finset.sum_ite_eq), and the strict-lower part (double_sum_split). The strict-lower sum equals the strict-upper one by Finset.sum_comm and mul_comm (upper_eq_lower), giving e₁² = p₂ + 2e₂. (2) Cauchy-Schwarz e₁² ≤ n·p₂: Finset.sq_sum_le_card_mul_sum_sq on range n, with Finset.card_range collapsing the cardinality to n (sq_e1_le_card_mul_p2). (3) Assembly: substitute (1) into (2) to get the linear relation 2n·e₂ ≤ (n−1)·e₁² (nlinarith), rewrite C(n,2) = n(n−1)/2 via Nat.cast_choose_two ℝ n, and close the cleared form by multiplying through by n ≥ 0 (nlinarith with Nat.cast_nonneg). The averaged statement follows from the cleared form by div_pow and div_le_div_iff, with positivity of n and C(n,2) from n ≥ 2.",
+    "proofStrategy": "Three layers. (1) Newton-Girard e₁² = p₂ + 2e₂: expand e₁² = (Σf)² = Σᵢ Σⱼ fᵢfⱼ via Finset.sum_mul_sum, then split each inner sum by lt_trichotomy on (i,j) into the strict-upper part (e₂), the diagonal (p₂, isolated with Finset.sum_ite_eq), and the strict-lower part (double_sum_split). The strict-lower sum equals the strict-upper one by Finset.sum_comm and mul_comm (upper_eq_lower), giving e₁² = p₂ + 2e₂. (2) Cauchy-Schwarz e₁² ≤ n·p₂: Finset.sum_mul_sq_le_sq_mul_sq on range n with the second sequence g = 1, simplifying ∑ 1 to n via Finset.card_range (sq_e1_le_card_mul_p2). (3) Assembly: substitute (1) into (2) to get the linear relation 2n·e₂ ≤ (n−1)·e₁² (nlinarith), rewrite C(n,2) = n(n−1)/2 via Nat.cast_choose_two ℝ n, and close the cleared form by multiplying through by n ≥ 0 (nlinarith with Nat.cast_nonneg). The averaged statement follows from the cleared form by div_pow and div_le_div_iff₀, with positivity of n and C(n,2) from n ≥ 2.",
     "keyInsights": [
       "S₁² ≥ S₂ is Cauchy-Schwarz in disguise. After substituting Newton-Girard 2e₂ = e₁² − p₂ into the cleared form C(n,2)·e₁² ≥ n²·e₂, every term cancels down to n·p₂ ≥ e₁² — the power-mean bound. The 'Maclaurin' framing adds no inequality content beyond Cauchy-Schwarz at this rung.",
       "No nonnegativity is needed. Although Maclaurin's chain is stated for nonnegative reals, the base rung holds for all reals because both ingredients (Newton-Girard, Cauchy-Schwarz) are sign-agnostic. The nonnegativity hypothesis only becomes essential at higher rungs where one takes real roots.",
@@ -58,7 +58,7 @@
     "prerequisites": [
       "Elementary symmetric sums e₁, e₂ and power sums p₂ over a Finset",
       "Newton-Girard square-of-sum identity e₁² = p₂ + 2e₂",
-      "Cauchy-Schwarz / power-mean bound (Σxᵢ)² ≤ n·Σxᵢ² (Finset.sq_sum_le_card_mul_sum_sq)",
+      "Cauchy-Schwarz / power-mean bound (Σxᵢ)² ≤ n·Σxᵢ² (Finset.sum_mul_sq_le_sq_mul_sq with g = 1)",
       "The cast Nat.cast_choose_two: ↑(n.choose 2) = ↑n(↑n−1)/2"
     ]
   },
@@ -89,22 +89,22 @@
       "id": "cauchy-schwarz",
       "title": "Power-mean bound: e₁² ≤ n·p₂",
       "startLine": 86,
-      "endLine": 94,
-      "summary": "sq_e1_le_card_mul_p2 specializes Mathlib's Finset.sq_sum_le_card_mul_sum_sq to s = range n and simplifies the cardinality with Finset.card_range, yielding (Σ f)² ≤ n · Σ f²."
+      "endLine": 97,
+      "summary": "sq_e1_le_card_mul_p2 specializes Mathlib's Finset.sum_mul_sq_le_sq_mul_sq (second sequence g = 1) to s = range n and simplifies ∑ 1 with Finset.card_range, yielding (Σ f)² ≤ n · Σ f²."
     },
     {
       "id": "maclaurin-cleared",
       "title": "Cleared-Denominator Form: C(n,2)·e₁² ≥ n²·e₂",
-      "startLine": 96,
-      "endLine": 110,
+      "startLine": 99,
+      "endLine": 113,
       "summary": "maclaurin_cleared derives C(n,2)·e₁² ≥ n²·e₂ for all n (both sides vanish at n = 0, 1): it forms the intermediate bound 2n·e₂ ≤ (n−1)·e₁² from Cauchy-Schwarz + Newton-Girard (nlinarith), rewrites C(n,2) via Nat.cast_choose_two ℝ n, and closes by nlinarith with Nat.cast_nonneg n and sq_nonneg. Kept separate as a reusable polynomial inequality independent of any averaging."
     },
     {
       "id": "maclaurin-base-step",
       "title": "Averaged Form: S₁² ≥ S₂ for n ≥ 2",
-      "startLine": 112,
-      "endLine": 124,
-      "summary": "maclaurin_base_step lifts the cleared inequality to (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2, where the hypothesis supplies strict positivity of n (hn0) and C(n,2) (hC via Nat.choose_pos). div_pow distributes the square over the quotient, div_le_div_iff clears both positive denominators, and nlinarith [maclaurin_cleared n f] closes the resulting polynomial goal."
+      "startLine": 115,
+      "endLine": 127,
+      "summary": "maclaurin_base_step lifts the cleared inequality to (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2, where the hypothesis supplies strict positivity of n (hn0) and C(n,2) (hC via Nat.choose_pos). div_pow distributes the square over the quotient, div_le_div_iff₀ clears both positive denominators, and nlinarith [maclaurin_cleared n f] closes the resulting polynomial goal."
     }
   ],
   "crossReferences": [
@@ -131,9 +131,9 @@
       "description": "The chain S₁ ≥ √S₂ ≥ ∛S₃ ≥ ⋯ of symmetric means refining AM-GM; this entry formalizes the base rung."
     },
     {
-      "title": "Mathlib: Algebra.Order.Chebyshev",
-      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Chebyshev.html",
-      "description": "Source of Finset.sq_sum_le_card_mul_sum_sq, the Cauchy-Schwarz / power-mean bound (Σ f)² ≤ card · Σ f² used here."
+      "title": "Mathlib: Algebra.Order.BigOperators.Ring.Finset",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/BigOperators/Ring/Finset.html",
+      "description": "Source of Finset.sum_mul_sq_le_sq_mul_sq, the squared Cauchy-Schwarz inequality (∑ f·g)² ≤ (∑ f²)(∑ g²); specialized here at g = 1 to get (Σ f)² ≤ n · Σ f²."
     }
   ]
 }


### PR DESCRIPTION
## Fix

Repairs auditor issue #25084: `amgm-inequality-oq-02-oq-01-oq-05` was presented as a completed `formalized`/`mathlib` formalization but did not compile under Mathlib v4.26 (false-green that prior sorry-count-only audits missed).

## Lean code repairs (`proofs/Proofs/AmgmInequalityOQ02OQ01OQ05.lean`)

| Site | Before | After |
|------|--------|-------|
| `sq_e1_le_card_mul_p2` (L93) | `Finset.sq_sum_le_card_mul_sum_sq` (does not exist) | `Finset.sum_mul_sq_le_sq_mul_sq` specialized at `g = 1` |
| `maclaurin_base_step` (L121) | `div_le_div_iff` (deprecated in v4.26) | `div_le_div_iff₀` |
| `upper_eq_lower` (L74) | `by_cases h : j < i` (wrong orientation → `simp` no-progress) | `by_cases h : i < j` (matches the `if i < j` guard) |

All replacement names were verified to exist against the offline Mathlib v4.26 checkout (rev `2df2f0150c`).

## Metadata repair (`meta.json`)

- `status`: `formalized` → `pending`; `badge`: `mathlib` → `wip` (removes the gallery-level false-green)
- Rewrote `assumptions` to record the audit, the corrected API names, and that a green build is **not yet confirmed**
- Corrected every prose reference that named the nonexistent lemma (`originalContributions`, `proofStrategy`, `prerequisites`, two section summaries, `references`)
- Reconciled `lineCount` (124 → 126) and section line anchors after the +2-line Lean change

## Build status

**Build NOT confirmed.** The worktree Docker daemon was hung this session (`docker run --rm alpine echo ok` → rc=124) and Aristotle MCP returned 404, so the corrected file could not be kernel-checked. The file remains unregistered in `Proofs.lean`. Once a green Docker build passes, `status`/`badge` should be restored to `formalized`/`mathlib`.

## Evidence

**Before**: `meta.status=formalized`, `meta.badge=mathlib`, `assumptions` claimed the (nonexistent) lemma name was "checked against the API"; Docker build failed with exit 1 on lines 76/91/93/110/115/121.
**After**: API names corrected to existing v4.26 lemmas; meta accurately reflects an unverified, build-pending state.

Closes #25084

---
Automated fix by lean-mechanic agent.