### PR TITLE
research(stern-brocot-tree-oq-01): full bijection — injectivity + capstone

### DIFF
--- a/proofs/Proofs/SternBrocotTreeOQ01.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01.lean
@@ -39,13 +39,20 @@ Beyond the structural heart, this file now also proves:
 * `sb_surjective` — **surjectivity**: every reduced positive rational `a/b` labels
   some node, by strong induction on `a + b` via the subtractive Euclidean descent.
 
-## Next steps (not in this file)
+Finally, this file closes the loop:
 
-* Injectivity: the mediant strictly separates the two subtrees (now available as
-  `sb_left_lt_mediant`/`sb_mediant_lt_right`), so the labelled value is strictly
-  monotone along the in-order traversal — combine with the transfer lemmas to show
-  distinct paths give distinct labels. Together with `sb_surjective` and
-  `sb_isCoprime` this yields the full bijection with the reduced positive rationals.
+* `sb_injective` — **injectivity**: distinct paths carry distinct labels. The head
+  move of a path is *forced* by the order of `num` versus `den`: prepending `L`
+  yields `num < den` (value `< 1`), prepending `R` yields `num > den` (value `> 1`),
+  and the empty path is the unique node with `num = den` (the root `1/1`). Peeling
+  the forced head via the transfer lemmas and recursing on the tail gives
+  injectivity by a clean structural induction — the cross cases collapse to
+  positivity contradictions (`sbNum_pos`, `sbDen_pos`), needing no Mathlib beyond
+  `omega`.
+* `sb_enumerates_pos_rationals` — the **capstone**: the labelling map is a bijection
+  between finite `L/R` paths and reduced positive rationals (injective + surjective,
+  with every label coprime and positive). This is the precise content of
+  `stern-brocot-tree-oq-01`.
 -/
 
 namespace SternBrocot
@@ -295,5 +302,103 @@ theorem sb_surj_aux : ∀ (n : ℕ) (a b : ℤ), (a + b).toNat = n →
 theorem sb_surjective (a b : ℤ) (ha : 1 ≤ a) (hb : 1 ≤ b)
     (hcop : IsCoprime a b) : ∃ p : List Bool, sbNum p = a ∧ sbDen p = b :=
   sb_surj_aux (a + b).toNat a b rfl ha hb hcop
+
+/-! ## Injectivity: distinct paths carry distinct labels
+
+The head move of a path is *forced* by comparing the label's numerator and
+denominator. Using the transfer lemmas:
+
+* `L :: q` has `den = num + den(q) > num` (value `< 1`);
+* `R :: q` has `num = num(q) + den > den` (value `> 1`);
+* the root `[]` is the unique node with `num = den` (namely `1 = 1`).
+
+Hence two paths with equal labels must share the same head, and (after the
+transfer lemmas peel it off) the same tail. The "wrong head" cross cases all
+collapse to a positivity contradiction via `sbNum_pos`/`sbDen_pos` and `omega`.
+-/
+
+/-- **Injectivity**: paths with the same label numerator and denominator are
+equal. Proved by structural induction on the first path, peeling the head move
+(which the label's `num` vs `den` order forces) with the transfer lemmas. -/
+theorem sb_injective :
+    ∀ (p q : List Bool), sbNum p = sbNum q → sbDen p = sbDen q → p = q := by
+  intro p
+  induction p with
+  | nil =>
+    intro q hn hd
+    rw [sb_root.1] at hn
+    rw [sb_root.2] at hd
+    cases q with
+    | nil => rfl
+    | cons c q' =>
+      exfalso
+      have hnq := sbNum_pos q'
+      have hdq := sbDen_pos q'
+      cases c with
+      | false => rw [sbNum_false_cons] at hn; rw [sbDen_false_cons] at hd; omega
+      | true  => rw [sbNum_true_cons] at hn; rw [sbDen_true_cons] at hd; omega
+  | cons b p' ih =>
+    intro q hn hd
+    have hnp := sbNum_pos p'
+    have hdp := sbDen_pos p'
+    cases b with
+    | false =>
+      rw [sbNum_false_cons] at hn
+      rw [sbDen_false_cons] at hd
+      cases q with
+      | nil =>
+        exfalso; rw [sb_root.1] at hn; rw [sb_root.2] at hd; omega
+      | cons c q' =>
+        have hnq := sbNum_pos q'
+        have hdq := sbDen_pos q'
+        cases c with
+        | false =>
+          rw [sbNum_false_cons] at hn
+          rw [sbDen_false_cons] at hd
+          have hd' : sbDen p' = sbDen q' := by omega
+          rw [ih q' hn hd']
+        | true =>
+          exfalso
+          rw [sbNum_true_cons] at hn
+          rw [sbDen_true_cons] at hd
+          omega
+    | true =>
+      rw [sbNum_true_cons] at hn
+      rw [sbDen_true_cons] at hd
+      cases q with
+      | nil =>
+        exfalso; rw [sb_root.1] at hn; rw [sb_root.2] at hd; omega
+      | cons c q' =>
+        have hnq := sbNum_pos q'
+        have hdq := sbDen_pos q'
+        cases c with
+        | false =>
+          exfalso
+          rw [sbNum_false_cons] at hn
+          rw [sbDen_false_cons] at hd
+          omega
+        | true =>
+          rw [sbNum_true_cons] at hn
+          rw [sbDen_true_cons] at hd
+          have hn' : sbNum p' = sbNum q' := by omega
+          rw [ih q' hn' hd]
+
+/-! ## Capstone: the Stern–Brocot labelling is a bijection -/
+
+/-- **The Stern–Brocot enumeration theorem** (`stern-brocot-tree-oq-01`): the map
+sending a finite `L/R` path `p` to the fraction `sbNum p / sbDen p` is a bijection
+onto the reduced positive rationals. Concretely:
+
+* every label is a *positive* fraction (`1 ≤ sbNum p`, `1 ≤ sbDen p`) in *lowest
+  terms* (`IsCoprime (sbNum p) (sbDen p)`);
+* the map is **injective**: distinct paths give distinct labels;
+* the map is **surjective**: every reduced positive rational `a/b` is some label.
+-/
+theorem sb_enumerates_pos_rationals :
+    (∀ p : List Bool, 1 ≤ sbNum p ∧ 1 ≤ sbDen p ∧ IsCoprime (sbNum p) (sbDen p)) ∧
+    (∀ p q : List Bool, sbNum p = sbNum q → sbDen p = sbDen q → p = q) ∧
+    (∀ a b : ℤ, 1 ≤ a → 1 ≤ b → IsCoprime a b →
+      ∃ p : List Bool, sbNum p = a ∧ sbDen p = b) :=
+  ⟨fun p => ⟨sbNum_pos p, sbDen_pos p, sb_isCoprime p⟩, sb_injective, sb_surjective⟩
 
 end SternBrocot

--- a/proofs/Proofs/SternBrocotTreeOQ01.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01.lean
@@ -1,0 +1,154 @@
+import Mathlib
+
+/-!
+# Stern–Brocot tree: every node is a positive rational in lowest terms
+
+**Open Question (`stern-brocot-tree-oq-01`)**: the Stern–Brocot tree enumerates
+every positive rational exactly once, in lowest terms. Mathlib has **no**
+Stern–Brocot tree, mediant, or Farey-sequence development (verified against the
+v4.26 checkout), so this file builds the structure from scratch.
+
+## What is proved here (self-contained, pure `ℤ` arithmetic, `0` sorries)
+
+A node of the tree is addressed by a finite path `p : List Bool` of left/right
+moves (`false = L`, `true = R`). Following a path maintains the pair of
+*boundary fractions* `aL/bL < aR/bR` of the current interval, starting from the
+super-interval `0/1 < 1/0`. A left move replaces the right boundary by the
+*mediant* `(aL+aR)/(bL+bR)`, a right move replaces the left boundary by it. The
+fraction *labelling* a node is the mediant of its current boundaries.
+
+* `sb_det` — the **unimodular invariant** `aL·bR − aR·bL = −1` holds at every
+  node (induction over the path; both moves preserve it).
+* `sb_pos` — the **positivity invariant** `0 ≤ aL`, `1 ≤ aR`, `1 ≤ bL`, `0 ≤ bR`.
+* `sbNum_pos`, `sbDen_pos` — consequently the label `sbNum/sbDen` is a genuine
+  **positive** rational (`1 ≤ sbNum`, `1 ≤ sbDen`).
+* `sb_isCoprime` — the label is in **lowest terms**: `IsCoprime (sbNum p) (sbDen p)`,
+  with the explicit Bézout witness `(-bR)·num + aR·den = 1` extracted from the
+  unimodular invariant.
+* `sb_root` — the root (empty path) is labelled `1/1`.
+
+This is the structural heart of the headline ("every node is a reduced positive
+rational"). The two remaining directions — **surjectivity** (every reduced
+positive rational labels some node) and **injectivity** (no rational labels two
+nodes) — are stated as goals in the research notes; see `## Next steps`.
+
+## Next steps (not in this file)
+
+* Surjectivity: strong induction on `num + den` via the subtractive Euclidean
+  descent (`a/b ↦ (a−b)/b` when `a > b`, mirror when `a < b`).
+* Injectivity: the mediant strictly separates the two subtrees, so the labelled
+  value is strictly monotone along the in-order traversal.
+-/
+
+namespace SternBrocot
+
+/-- A node of the Stern–Brocot tree, stored as its pair of boundary fractions
+`aL/bL` (left) and `aR/bR` (right). -/
+structure SB where
+  aL : ℤ
+  bL : ℤ
+  aR : ℤ
+  bR : ℤ
+  deriving Repr, DecidableEq
+
+/-- The super-interval `0/1 < 1/0` at the root of the construction. -/
+def SB.start : SB := ⟨0, 1, 1, 0⟩
+
+/-- One move: `false` (L) replaces the right boundary by the mediant,
+`true` (R) replaces the left boundary by the mediant. -/
+def SB.step (s : SB) : Bool → SB
+  | false => ⟨s.aL, s.bL, s.aL + s.aR, s.bL + s.bR⟩
+  | true  => ⟨s.aL + s.aR, s.bL + s.bR, s.aR, s.bR⟩
+
+/-- The boundary state reached by following a path `p` from a starting state. -/
+def sbFrom (s : SB) (p : List Bool) : SB := p.foldl SB.step s
+
+@[simp] theorem sbFrom_nil (s : SB) : sbFrom s [] = s := rfl
+
+@[simp] theorem sbFrom_cons (s : SB) (b : Bool) (p : List Bool) :
+    sbFrom s (b :: p) = sbFrom (s.step b) p := rfl
+
+/-- The boundary state reached by following a path from the root. -/
+def sb (p : List Bool) : SB := sbFrom SB.start p
+
+/-- The numerator labelling a node: the mediant numerator `aL + aR`. -/
+def sbNum (p : List Bool) : ℤ := (sb p).aL + (sb p).aR
+
+/-- The denominator labelling a node: the mediant denominator `bL + bR`. -/
+def sbDen (p : List Bool) : ℤ := (sb p).bL + (sb p).bR
+
+/-! ## Unimodular invariant -/
+
+/-- The unimodular invariant `aL·bR − aR·bL = −1`, as a predicate on states. -/
+def Unimod (s : SB) : Prop := s.aL * s.bR - s.aR * s.bL = -1
+
+theorem unimod_start : Unimod SB.start := by
+  simp [Unimod, SB.start]
+
+theorem unimod_step {s : SB} (h : Unimod s) (b : Bool) : Unimod (s.step b) := by
+  cases b
+  · simp only [Unimod, SB.step] at h ⊢; linear_combination h
+  · simp only [Unimod, SB.step] at h ⊢; linear_combination h
+
+theorem unimod_sbFrom :
+    ∀ (s : SB), Unimod s → ∀ (p : List Bool), Unimod (sbFrom s p) := by
+  intro s h p
+  induction p generalizing s with
+  | nil => simpa using h
+  | cons b t ih => simpa using ih (s.step b) (unimod_step h b)
+
+/-- **Unimodular invariant**: at every Stern–Brocot node, `aL·bR − aR·bL = −1`. -/
+theorem sb_det (p : List Bool) :
+    (sb p).aL * (sb p).bR - (sb p).aR * (sb p).bL = -1 := by
+  have h : Unimod (sb p) := unimod_sbFrom SB.start unimod_start p
+  exact h
+
+/-! ## Positivity invariant -/
+
+/-- The positivity invariant `0 ≤ aL`, `1 ≤ aR`, `1 ≤ bL`, `0 ≤ bR`. -/
+def Pos (s : SB) : Prop := 0 ≤ s.aL ∧ 1 ≤ s.aR ∧ 1 ≤ s.bL ∧ 0 ≤ s.bR
+
+theorem pos_start : Pos SB.start := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> norm_num [SB.start]
+
+theorem pos_step {s : SB} (h : Pos s) (b : Bool) : Pos (s.step b) := by
+  obtain ⟨h1, h2, h3, h4⟩ := h
+  cases b
+  · refine ⟨?_, ?_, ?_, ?_⟩ <;> simp only [SB.step] <;> linarith
+  · refine ⟨?_, ?_, ?_, ?_⟩ <;> simp only [SB.step] <;> linarith
+
+theorem pos_sbFrom :
+    ∀ (s : SB), Pos s → ∀ (p : List Bool), Pos (sbFrom s p) := by
+  intro s h p
+  induction p generalizing s with
+  | nil => simpa using h
+  | cons b t ih => simpa using ih (s.step b) (pos_step h b)
+
+/-- **Positivity invariant** at every node. -/
+theorem sb_pos (p : List Bool) : Pos (sb p) := pos_sbFrom SB.start pos_start p
+
+/-- The label numerator is a positive integer. -/
+theorem sbNum_pos (p : List Bool) : 1 ≤ sbNum p := by
+  obtain ⟨h1, h2, _, _⟩ := sb_pos p
+  simp only [sbNum]; linarith
+
+/-- The label denominator is a positive integer. -/
+theorem sbDen_pos (p : List Bool) : 1 ≤ sbDen p := by
+  obtain ⟨_, _, h3, h4⟩ := sb_pos p
+  simp only [sbDen]; linarith
+
+/-! ## Lowest terms -/
+
+/-- **Lowest terms**: every node's label `sbNum p / sbDen p` is reduced.
+The Bézout witness `(-bR)·num + aR·den = 1` comes straight from `sb_det`. -/
+theorem sb_isCoprime (p : List Bool) : IsCoprime (sbNum p) (sbDen p) := by
+  refine ⟨-(sb p).bR, (sb p).aR, ?_⟩
+  have h := sb_det p
+  simp only [sbNum, sbDen]
+  linear_combination -h
+
+/-- The root of the tree is labelled `1/1`. -/
+theorem sb_root : sbNum [] = 1 ∧ sbDen [] = 1 := by
+  refine ⟨?_, ?_⟩ <;> simp [sbNum, sbDen, sb, SB.start]
+
+end SternBrocot

--- a/proofs/Proofs/SternBrocotTreeOQ01.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01.lean
@@ -27,17 +27,25 @@ fraction *labelling* a node is the mediant of its current boundaries.
   unimodular invariant.
 * `sb_root` — the root (empty path) is labelled `1/1`.
 
-This is the structural heart of the headline ("every node is a reduced positive
-rational"). The two remaining directions — **surjectivity** (every reduced
-positive rational labels some node) and **injectivity** (no rational labels two
-nodes) — are stated as goals in the research notes; see `## Next steps`.
+Beyond the structural heart, this file now also proves:
+
+* `sb_left_lt_mediant`, `sb_mediant_lt_right` — **mediant separation**: the label
+  lies strictly between the two boundary fractions (division-free integer form),
+  both reducing to `sb_det`. This is the foundation for injectivity.
+* `sb_false_cons`, `sb_true_cons` and the four `sb{Num,Den}_{false,true}_cons`
+  **prefix-transfer** lemmas: prepending `L` sends `(num, den) ↦ (num, num+den)`,
+  prepending `R` sends `(num, den) ↦ (num+den, den)` — via the conjugation
+  homomorphisms `T`, `T'` that intertwine the two boundary folds.
+* `sb_surjective` — **surjectivity**: every reduced positive rational `a/b` labels
+  some node, by strong induction on `a + b` via the subtractive Euclidean descent.
 
 ## Next steps (not in this file)
 
-* Surjectivity: strong induction on `num + den` via the subtractive Euclidean
-  descent (`a/b ↦ (a−b)/b` when `a > b`, mirror when `a < b`).
-* Injectivity: the mediant strictly separates the two subtrees, so the labelled
-  value is strictly monotone along the in-order traversal.
+* Injectivity: the mediant strictly separates the two subtrees (now available as
+  `sb_left_lt_mediant`/`sb_mediant_lt_right`), so the labelled value is strictly
+  monotone along the in-order traversal — combine with the transfer lemmas to show
+  distinct paths give distinct labels. Together with `sb_surjective` and
+  `sb_isCoprime` this yields the full bijection with the reduced positive rationals.
 -/
 
 namespace SternBrocot
@@ -150,5 +158,142 @@ theorem sb_isCoprime (p : List Bool) : IsCoprime (sbNum p) (sbDen p) := by
 /-- The root of the tree is labelled `1/1`. -/
 theorem sb_root : sbNum [] = 1 ∧ sbDen [] = 1 := by
   refine ⟨?_, ?_⟩ <;> simp [sbNum, sbDen, sb, SB.start]
+
+/-! ## Mediant separation (foundation for injectivity)
+
+The label of a node lies *strictly* between its two boundary fractions. In
+cross-multiplied (division-free) integer form, with `bL, bR ≥ 1 > 0`:
+
+* `aL/bL < num/den` ⟺ `aL·den < num·bL`,
+* `num/den < aR/bR` ⟺ `num·bR < aR·den`.
+
+Both reduce, after expansion, to `aL·bR − aR·bL = −1 < 0`, i.e. exactly the
+unimodular invariant `sb_det`. This strict separation is the key fact behind
+injectivity: distinct subtrees occupy disjoint open intervals.
+-/
+
+/-- The label strictly exceeds the left boundary: `aL·den < num·bL`. -/
+theorem sb_left_lt_mediant (p : List Bool) :
+    (sb p).aL * sbDen p < sbNum p * (sb p).bL := by
+  have h := sb_det p
+  simp only [sbNum, sbDen]
+  nlinarith [h]
+
+/-- The label is strictly below the right boundary: `num·bR < aR·den`. -/
+theorem sb_mediant_lt_right (p : List Bool) :
+    sbNum p * (sb p).bR < (sb p).aR * sbDen p := by
+  have h := sb_det p
+  simp only [sbNum, sbDen]
+  nlinarith [h]
+
+/-! ## Surjectivity: every reduced positive rational labels some node
+
+We show the labelling map `p ↦ sbNum p / sbDen p` hits **every** reduced
+positive rational. The proof is a strong induction on `num + den` driven by the
+subtractive Euclidean descent (`a/b ↦ (a−b)/b` when `a > b`, mirror when `a < b`),
+using two *prefix-transfer* lemmas that describe how prepending a single move
+transforms the label:
+
+* prepending `L` (`false`):  `(num, den) ↦ (num, num + den)`;
+* prepending `R` (`true`):   `(num, den) ↦ (num + den, den)`.
+
+These are proved via the conjugation homomorphisms `T`, `T'` that intertwine the
+two boundary folds — `T` (resp. `T'`) is left-multiplication by the generator
+that the leading move contributes, and it commutes with `SB.step`.
+-/
+
+/-- `L`-conjugation: left-multiplication by `[[1,0],[1,1]]` on the boundary
+state. Intertwines the fold started at `start.step false` with the one at
+`start`. -/
+def T (s : SB) : SB := ⟨s.aL, s.aL + s.bL, s.aR, s.aR + s.bR⟩
+
+/-- `R`-conjugation: left-multiplication by `[[1,1],[0,1]]`. -/
+def T' (s : SB) : SB := ⟨s.aL + s.bL, s.bL, s.aR + s.bR, s.bR⟩
+
+theorem T_step (s : SB) (b : Bool) : (T s).step b = T (s.step b) := by
+  cases b <;> cases s <;> simp only [T, SB.step, SB.mk.injEq] <;> omega
+
+theorem T'_step (s : SB) (b : Bool) : (T' s).step b = T' (s.step b) := by
+  cases b <;> cases s <;> simp only [T', SB.step, SB.mk.injEq] <;> omega
+
+theorem T_sbFrom (s : SB) (q : List Bool) : sbFrom (T s) q = T (sbFrom s q) := by
+  induction q generalizing s with
+  | nil => simp only [sbFrom_nil]
+  | cons b t ih => rw [sbFrom_cons, T_step, ih (s.step b), sbFrom_cons]
+
+theorem T'_sbFrom (s : SB) (q : List Bool) :
+    sbFrom (T' s) q = T' (sbFrom s q) := by
+  induction q generalizing s with
+  | nil => simp only [sbFrom_nil]
+  | cons b t ih => rw [sbFrom_cons, T'_step, ih (s.step b), sbFrom_cons]
+
+/-- Prepending an `L` move conjugates the boundary state by `T`. -/
+theorem sb_false_cons (q : List Bool) : sb (false :: q) = T (sb q) := by
+  show sbFrom SB.start (false :: q) = T (sbFrom SB.start q)
+  rw [sbFrom_cons, show SB.start.step false = T SB.start from by decide, T_sbFrom]
+
+/-- Prepending an `R` move conjugates the boundary state by `T'`. -/
+theorem sb_true_cons (q : List Bool) : sb (true :: q) = T' (sb q) := by
+  show sbFrom SB.start (true :: q) = T' (sbFrom SB.start q)
+  rw [sbFrom_cons, show SB.start.step true = T' SB.start from by decide, T'_sbFrom]
+
+/-- `L`-transfer for the numerator: `num (L :: q) = num q`. -/
+theorem sbNum_false_cons (q : List Bool) : sbNum (false :: q) = sbNum q := by
+  simp only [sbNum, sb_false_cons, T]
+
+/-- `L`-transfer for the denominator: `den (L :: q) = num q + den q`. -/
+theorem sbDen_false_cons (q : List Bool) : sbDen (false :: q) = sbNum q + sbDen q := by
+  simp only [sbDen, sbNum, sb_false_cons, T]; ring
+
+/-- `R`-transfer for the numerator: `num (R :: q) = num q + den q`. -/
+theorem sbNum_true_cons (q : List Bool) : sbNum (true :: q) = sbNum q + sbDen q := by
+  simp only [sbNum, sbDen, sb_true_cons, T']; ring
+
+/-- `R`-transfer for the denominator: `den (R :: q) = den q`. -/
+theorem sbDen_true_cons (q : List Bool) : sbDen (true :: q) = sbDen q := by
+  simp only [sbDen, sb_true_cons, T']
+
+/-- Auxiliary strong-induction form of surjectivity, recursing on `num + den`. -/
+theorem sb_surj_aux : ∀ (n : ℕ) (a b : ℤ), (a + b).toNat = n →
+    1 ≤ a → 1 ≤ b → IsCoprime a b →
+    ∃ p : List Bool, sbNum p = a ∧ sbDen p = b := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro a b hn ha hb hcop
+    rcases lt_trichotomy a b with hab | hab | hab
+    · -- a < b : the value is < 1, descend via the left child to (a, b − a)
+      have hcop' : IsCoprime a (b - a) := by
+        have hb' : IsCoprime b a := hcop.symm
+        rw [show b = (b - a) + a * 1 from by ring] at hb'
+        exact (IsCoprime.of_add_mul_left_left hb').symm
+      obtain ⟨q, hq1, hq2⟩ :=
+        ih b.toNat (by omega) a (b - a) (by omega) ha (by omega) hcop'
+      refine ⟨false :: q, ?_, ?_⟩
+      · rw [sbNum_false_cons, hq1]
+      · rw [sbDen_false_cons, hq1, hq2]; ring
+    · -- a = b : coprimality forces a = b = 1, the root
+      rw [← hab] at hcop
+      have hu : IsUnit a := isCoprime_self.mp hcop
+      rcases Int.isUnit_iff.mp hu with h1 | h1
+      · refine ⟨[], ?_, ?_⟩
+        · rw [sb_root.1, h1]
+        · rw [sb_root.2, ← hab, h1]
+      · subst h1; exact absurd ha (by norm_num)
+    · -- b < a : the value is > 1, descend via the right child to (a − b, b)
+      have hcop' : IsCoprime (a - b) b := by
+        rw [show a = (a - b) + b * 1 from by ring] at hcop
+        exact IsCoprime.of_add_mul_left_left hcop
+      obtain ⟨q, hq1, hq2⟩ :=
+        ih a.toNat (by omega) (a - b) b (by omega) (by omega) hb hcop'
+      refine ⟨true :: q, ?_, ?_⟩
+      · rw [sbNum_true_cons, hq1, hq2]; ring
+      · rw [sbDen_true_cons, hq2]
+
+/-- **Surjectivity**: every reduced positive rational `a/b` (with `1 ≤ a`,
+`1 ≤ b`, `IsCoprime a b`) is the label of some Stern–Brocot node. -/
+theorem sb_surjective (a b : ℤ) (ha : 1 ≤ a) (hb : 1 ≤ b)
+    (hcop : IsCoprime a b) : ∃ p : List Bool, sbNum p = a ∧ sbDen p = b :=
+  sb_surj_aux (a + b).toNat a b rfl ha hb hcop
 
 end SternBrocot

--- a/research/problems/stern-brocot-tree-oq-01/knowledge.md
+++ b/research/problems/stern-brocot-tree-oq-01/knowledge.md
@@ -18,13 +18,65 @@ factors as: (a) every label is a reduced positive rational [kernel, done];
 - **(a) Structural kernel — DONE** (build-pending orphan, prior session):
   `sb_det` (unimodular invariant `aL·bR − aR·bL = −1`), `sb_pos`, `sbNum_pos`,
   `sbDen_pos`, `sb_isCoprime` (lowest terms via explicit Bézout), `sb_root`.
-- **(b) Surjectivity — DONE this session** (`sb_surjective`).
-- **(c) Injectivity — foundation done** (`sb_left_lt_mediant`,
-  `sb_mediant_lt_right`); full injectivity still open.
+- **(b) Surjectivity — DONE** (`sb_surjective`).
+- **(c) Injectivity — DONE this session** (`sb_injective`).
+- **Capstone — DONE this session** (`sb_enumerates_pos_rationals`): all three
+  directions (positive + coprime + injective + surjective) bundled. **The full
+  bijection is now mathematically complete; only a green Docker build + gallery
+  registration remain.**
 
 All work is in the **unregistered orphan** `SternBrocotTreeOQ01.lean` (not in
 `Proofs.lean`, no `src/data/proofs/` gallery dir) → zero gallery/build risk
 while build-pending under the Docker blackout.
+
+---
+
+## Session 2026-06-16 (s3, researcher-9) — ACT, injectivity + capstone (bijection complete)
+
+**Mode**: REVISIT (own prior in-progress work). **Backend**: Docker still
+blacked out (`docker run --rm alpine echo ok` → rc=124, 9 stuck sibling build
+wrappers); Aristotle not used. **No Lean compiled**, but the new proof uses
+**only core tactics** (`induction`, `cases`, `rw`, `exfalso`, `omega`) plus this
+file's own already-stated lemmas — **zero Mathlib API surface**, so there is no
+name-drift risk and the proof is verifiable by hand.
+
+### What I proved (new, sorry-free by construction)
+
+1. **Injectivity** `sb_injective : ∀ p q, sbNum p = sbNum q → sbDen p = sbDen q
+   → p = q`. Structural induction on the first path `p` (motive
+   `∀ q, … → p = q`, so `ih` is fully general in `q`). The head move is *forced*
+   by the label's `num` vs `den` order — proved not via mediant separation but
+   directly from the transfer lemmas + positivity:
+   - `[]` has `num = den = 1` (`sb_root`); any `c :: q'` head makes the two
+     unequal (`L` ⟹ `den = num + den q' > num`; `R` ⟹ `num = num q' + den > den`).
+   - The four "mismatched head" cross cases (`nil/L`, `nil/R`, `L/R`, `R/L`)
+     collapse to `omega` contradictions seeded by `sbNum_pos`/`sbDen_pos`
+     (a positive integer plus a positive integer is never `≤ 1` or `= 0`).
+   - The two "matching head" cases peel via `sbNum_*_cons`/`sbDen_*_cons` and an
+     `omega`-derived tail equality, then recurse with `ih`.
+
+   Note: mediant separation (`sb_left_lt_mediant`/`sb_mediant_lt_right`) turned
+   out **not** to be needed — the transfer lemmas already force the head, giving
+   a shorter, Mathlib-free injectivity proof. The separation lemmas remain as
+   independent geometric facts.
+
+2. **Capstone** `sb_enumerates_pos_rationals`: trivial bundling of
+   `⟨sbNum_pos, sbDen_pos, sb_isCoprime⟩`, `sb_injective`, `sb_surjective` —
+   the precise statement of the open question.
+
+### Files Modified
+- `proofs/Proofs/SternBrocotTreeOQ01.lean` (+~95 lines: `sb_injective`,
+  `sb_enumerates_pos_rationals`; updated module docstring "Finally / Capstone").
+
+### Next Steps
+1. **Docker-up gate** (only remaining blocker):
+   `./proofs/scripts/docker-build.sh Proofs.SternBrocotTreeOQ01`; grep log for
+   `error:`. Injectivity is core-tactic-only so the *new* risk is ~nil; the
+   pre-existing watch points from s2 (T_step `omega`, transfer `simp only [.., T]`
+   projection, `by decide` step facts) still apply to the earlier lemmas.
+2. After green build: register in `Proofs.lean` + add
+   `src/data/proofs/stern-brocot-tree-oq-01/` gallery data (meta.json +
+   annotations); status `axiomatized`→ `verified`/`original` (0 sorry/0 axiom).
 
 ---
 

--- a/research/problems/stern-brocot-tree-oq-01/knowledge.md
+++ b/research/problems/stern-brocot-tree-oq-01/knowledge.md
@@ -1,0 +1,101 @@
+# Knowledge Base: stern-brocot-tree-oq-01
+
+## Problem Summary
+
+The Stern–Brocot tree enumerates **every positive rational exactly once, in
+lowest terms**. Mathlib (v4.26) has no Stern–Brocot tree, mediant, or Farey
+development, so `proofs/Proofs/SternBrocotTreeOQ01.lean` builds the structure
+from scratch over `List Bool` paths and `ℤ` boundary pairs.
+
+Target = the full bijection `{paths} ≃ {reduced positive rationals}`, which
+factors as: (a) every label is a reduced positive rational [kernel, done];
+(b) surjectivity; (c) injectivity.
+
+---
+
+## Status
+
+- **(a) Structural kernel — DONE** (build-pending orphan, prior session):
+  `sb_det` (unimodular invariant `aL·bR − aR·bL = −1`), `sb_pos`, `sbNum_pos`,
+  `sbDen_pos`, `sb_isCoprime` (lowest terms via explicit Bézout), `sb_root`.
+- **(b) Surjectivity — DONE this session** (`sb_surjective`).
+- **(c) Injectivity — foundation done** (`sb_left_lt_mediant`,
+  `sb_mediant_lt_right`); full injectivity still open.
+
+All work is in the **unregistered orphan** `SternBrocotTreeOQ01.lean` (not in
+`Proofs.lean`, no `src/data/proofs/` gallery dir) → zero gallery/build risk
+while build-pending under the Docker blackout.
+
+---
+
+## Session 2026-06-16 (s2, researcher-9) — ACT, surjectivity + mediant separation
+
+**Mode**: REVISIT (own prior in-progress work). **Backend**: dual blackout —
+Aristotle `prove` → 404; `docker info` → rc=124 with 14 stuck sibling build
+wrappers (a 15th build would OOM peers), so **no Lean compiled**. All names
+verified against the offline Mathlib v4.26 checkout at `/Users/rwalters/GitHub/mathlib4`.
+
+### What I proved (new, sorry-free by construction)
+
+1. **Mediant separation** (injectivity foundation), division-free integer form:
+   - `sb_left_lt_mediant : (sb p).aL * sbDen p < sbNum p * (sb p).bL`
+   - `sb_mediant_lt_right : sbNum p * (sb p).bR < (sb p).aR * sbDen p`
+   Both reduce to `aL·bR − aR·bL = −1 < 0` (= `sb_det`); closed by `nlinarith [sb_det p]`.
+
+2. **Prefix-transfer lemmas** via conjugation homomorphisms `T`, `T'`:
+   - `T s = ⟨aL, aL+bL, aR, aR+bR⟩` (left-mult by `[[1,0],[1,1]]`),
+     `T' s = ⟨aL+bL, bL, aR+bR, bR⟩` (left-mult by `[[1,1],[0,1]]`).
+   - Key fact: `T`/`T'` **commute with `SB.step`** (`T_step`, `T'_step`), hence
+     with the whole fold (`T_sbFrom`, `T'_sbFrom`). Since
+     `start.step false = T start` and `start.step true = T' start`, prepending a
+     move conjugates the state: `sb (false::q) = T (sb q)`, `sb (true::q) = T' (sb q)`.
+   - Consequence on labels: prepending `L` sends `(num,den) ↦ (num, num+den)`;
+     prepending `R` sends `(num,den) ↦ (num+den, den)`
+     (`sbNum_false_cons`, `sbDen_false_cons`, `sbNum_true_cons`, `sbDen_true_cons`).
+
+3. **Surjectivity** `sb_surjective (a b : ℤ) (1≤a) (1≤b) (IsCoprime a b) :
+   ∃ p, sbNum p = a ∧ sbDen p = b`. Strong induction on `(a+b).toNat`
+   (`Nat.strong_induction_on`) via the subtractive Euclidean descent:
+   - `a = b` ⟹ `IsCoprime a a` ⟹ `IsUnit a` (`isCoprime_self`) ⟹ `a = 1`
+     (`Int.isUnit_iff`, `−1` killed by `1 ≤ a`) ⟹ root `[]`.
+   - `a < b` ⟹ recurse on `(a, b−a)` then prepend `L`; coprimality preserved by
+     `IsCoprime.of_add_mul_left_left` (with `b = (b−a) + a*1`).
+   - `b < a` ⟹ recurse on `(a−b, b)` then prepend `R`.
+
+### Why this is the right decomposition
+
+The prepend-transfer lemmas are the crux: the naive "child = remove last move"
+relation does **not** give a clean `a↦a−b` recurrence because the boundaries
+shift per node. Prepending instead corresponds to a **fixed** left-multiplication
+(`T`/`T'`) that commutes with the fold, so the label recurrence is global and
+exactly the Euclidean descent. This is the matrix identity
+`M_start·X_b·G·v = (M_start·X_b·M_start⁻¹)·(M_start·G·v)` with `M_start` its own
+inverse; `T`/`T'` are the conjugated generators, proved elementarily without
+matrices.
+
+### Files Modified
+- `proofs/Proofs/SternBrocotTreeOQ01.lean` (+~135 lines: T/T', transfer lemmas,
+  mediant separation, surjectivity; updated module docstring).
+
+### Next Steps
+1. **Docker-up**: `./proofs/scripts/docker-build.sh Proofs.SternBrocotTreeOQ01`;
+   grep log for `error:`. Likely-fragile tactics to watch: `omega` on the
+   `SB.mk.injEq` conjunctions in `T_step`/`T'_step`; `simp only [..., T]`
+   projection reduction in the four transfer lemmas; `by decide` on the two
+   `start.step _ = T _ / T' _` facts. If any fail, the fixes are local
+   (`congr 1 <;> ring` for the structure eqs; `cases`/`dsimp` to force projection
+   reduction).
+2. **Injectivity** (remaining open piece): use `sb_left_lt_mediant` /
+   `sb_mediant_lt_right` to show the two subtrees of any node occupy disjoint open
+   intervals, hence the label is injective on paths. Combined with `sb_surjective`
+   + `sb_isCoprime` this closes the full bijection.
+3. Register in `Proofs.lean` + add `src/data/proofs/stern-brocot-tree-oq-01/`
+   gallery data only after a green build.
+
+---
+
+## Mathlib / Gallery Gap
+
+No Stern–Brocot / mediant / Farey in Mathlib v4.26. Reusable recipe established:
+`det = −1` ⟹ lowest terms via Bézout; conjugation-homomorphism transfer lemmas
+for prepend recurrences on fold-based tree encodings.


### PR DESCRIPTION
## Summary

Completes `stern-brocot-tree-oq-01`: the Stern–Brocot tree enumerates **every positive rational exactly once, in lowest terms**. Mathlib v4.26 has no Stern–Brocot / mediant / Farey development, so the structure is built from scratch over `List Bool` paths and `ℤ` boundary pairs in the (unregistered) orphan `proofs/Proofs/SternBrocotTreeOQ01.lean`.

This PR adds the **final missing direction, injectivity**, and the capstone bundling all directions:

- `sb_injective : ∀ p q, sbNum p = sbNum q → sbDen p = sbDen q → p = q`
- `sb_enumerates_pos_rationals` — positive + coprime + injective + surjective (the precise content of the open question)

Prior commits on this branch already established: the structural kernel (unimodular invariant `sb_det`, positivity, lowest-terms `sb_isCoprime`, root), mediant separation, prefix-transfer lemmas, and surjectivity.

## Injectivity proof

Structural induction on the first path. The head move is *forced* by the label's `num` vs `den` order (via the existing transfer lemmas, not mediant separation):
- `[]` is the unique node with `num = den = 1`;
- prepending `L` gives `den = num + den(q') > num`; prepending `R` gives `num = num(q') + den > den`.

Matching-head cases peel the head and recurse; mismatched-head cross cases collapse to `omega` contradictions seeded by `sbNum_pos`/`sbDen_pos`. **Only core tactics** (`induction`/`cases`/`rw`/`exfalso`/`omega`) — zero Mathlib API surface, so no name-drift risk.

## Status: build-pending

Docker is blacked out (`docker run --rm alpine echo ok` → rc=124, 9 stuck sibling build wrappers), so this was **not compiled**. The file remains an **unregistered orphan** (not in `Proofs.lean`, no `src/data/proofs/` gallery dir) → **zero false-green / gallery risk**. Lemma names verified against the offline Mathlib v4.26 checkout (pin `2df2f0150c`).

## Test plan

- [ ] When Docker is up: `./proofs/scripts/docker-build.sh Proofs.SternBrocotTreeOQ01`, grep log for `error:`
- [ ] On green build: register in `Proofs.lean` + add gallery data; set status `verified`/`original` (0 sorry / 0 axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)