### PR TITLE
Fix: amgm-inequality-oq-02-oq-01-oq-05 false-green — minimal v4.26 API repair + honest meta

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05.lean
@@ -71,7 +71,7 @@ theorem upper_eq_lower :
   intro i hi
   apply Finset.sum_congr rfl
   intro j hj
-  by_cases h : j < i
+  by_cases h : i < j
   · simp [h, mul_comm]
   · simp [h]
 
@@ -90,7 +90,7 @@ theorem newton_girard : (e1 n f) ^ 2 = p2 n f + 2 * e2 n f := by
 /-- Cauchy-Schwarz / power-mean bound: (Σ xᵢ)² ≤ n · Σ xᵢ². -/
 theorem sq_e1_le_card_mul_p2 : (e1 n f) ^ 2 ≤ (n : ℝ) * p2 n f := by
   unfold e1 p2
-  have h := Finset.sq_sum_le_card_mul_sum_sq (s := range n) (f := f)
+  have h := sq_sum_le_card_mul_sum_sq (s := range n) (f := f)
   simpa [Finset.card_range] using h
 
 -- ============================================================
@@ -107,7 +107,7 @@ theorem maclaurin_cleared :
   have hstar : 2 * (n : ℝ) * e2 n f ≤ ((n : ℝ) - 1) * (e1 n f) ^ 2 := by
     nlinarith [hcs, hng]
   rw [hchoose]
-  nlinarith [hstar, Nat.cast_nonneg n, sq_nonneg (e1 n f)]
+  nlinarith [hstar, (Nat.cast_nonneg n : (0 : ℝ) ≤ (n : ℝ)), sq_nonneg (e1 n f)]
 
 /-- Maclaurin base step in averaged form: for n ≥ 2,
     S₁² ≥ S₂ with S₁ = e₁/n and S₂ = e₂/C(n,2). -/
@@ -118,7 +118,7 @@ theorem maclaurin_base_step (hn : 2 ≤ n) :
   have hC : (0 : ℝ) < (n.choose 2 : ℝ) := by
     have : 0 < n.choose 2 := Nat.choose_pos (by omega)
     exact_mod_cast this
-  rw [div_pow, div_le_div_iff hC (pow_pos hn0 2)]
+  rw [div_pow, div_le_div_iff₀ hC (pow_pos hn0 2)]
   nlinarith [maclaurin_cleared n f]
 
 end AmgmInequalityOQ02OQ01OQ05

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05/meta.json
@@ -16,7 +16,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-16",
-    "status": "formalized",
+    "status": "pending",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ05.lean",
     "tags": [
       "inequalities",
@@ -27,11 +27,11 @@
       "power-mean",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. BUILD PENDING: the file is complete and sorry-free but not yet kernel-checked locally — the worktree Docker VM was build-saturated (9 concurrent builds, cold Mathlib cache) and Aristotle MCP was unavailable (404) this session, so verification is deferred. The file is intentionally NOT yet registered in Proofs.lean (kept as an orphan) until a green build is confirmed, since there is no CI Lean-build gate and registering an uncompiled file could break the shared Proofs build on main. The two at-risk Mathlib names were checked against the API: Finset.sq_sum_le_card_mul_sum_sq (Mathlib.Algebra.Order.Chebyshev, signature (∑ i ∈ s, f i)^2 ≤ ↑s.card * ∑ i ∈ s, f i^2) and Nat.cast_choose_two ℝ n (Mathlib.Data.Nat.Choose.Cast, ↑(n.choose 2) = ↑n*(↑n-1)/2). This is a formalization entry: the mathematics is the classical first Maclaurin inequality and the contribution is a clean self-contained derivation from an already-formalized identity.",
+    "assumptions": "0 axioms, 0 sorries (textually). BUILD NOT YET CONFIRMED — status 'pending'/'wip'. A gallery-integrity audit (issue #25084) found the file did NOT compile under Mathlib v4.26 (false-green: textually sorry-free is not the same as compiling). Four errors were corrected, each verified against the offline Mathlib v4.26 checkout (rev 2df2f0150c): (1) the Cauchy-Schwarz lemma is sq_sum_le_card_mul_sum_sq in the ROOT namespace (Mathlib.Algebra.Order.Chebyshev, declared in `section Mul` with implicit {s}{f}), NOT Finset.sq_sum_le_card_mul_sum_sq — the bogus Finset. prefix was the error, so the fix simply drops the prefix; (2) div_le_div_iff was renamed in v4.26 to div_le_div_iff₀ (Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic, signature (hb : 0 < b) (hd : 0 < d)); (3) the off-diagonal symmetry case-split in upper_eq_lower branched on the wrong order (j < i instead of i < j; after Finset.sum_comm the guard is i < j); (4) Nat.cast_nonneg n in the maclaurin_cleared nlinarith needed its target type pinned to ℝ. Nat.cast_choose_two ℝ n (Mathlib.Data.Nat.Choose.Cast, ↑(n.choose 2) = ↑n*(↑n-1)/2) is correct as written. These names are verified to EXIST in the v4.26 API, but a green Docker build has NOT been run this session (docker run rc=124, Aristotle MCP 404), so compilation remains unverified and the file is intentionally NOT registered in Proofs.lean. Once a build passes, restore status 'formalized' and badge 'mathlib'.",
     "lineCount": 124,
     "theoremCount": 6,
     "definitionCount": 3,
@@ -39,7 +39,7 @@
       "maclaurin_base_step: the averaged inequality (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2 — the first rung S₁² ≥ S₂ of the Maclaurin chain that refines AM-GM",
       "maclaurin_cleared: the denominator-cleared form C(n,2)·e₁² ≥ n²·e₂, valid for all n (including the degenerate n = 0, 1)",
       "newton_girard: e₁² = p₂ + 2e₂ re-derived for the range-n family via the index-pair trichotomy split (double_sum_split) plus the upper/lower-triangle symmetry (upper_eq_lower)",
-      "sq_e1_le_card_mul_p2: the Cauchy-Schwarz / power-mean bound e₁² ≤ n·p₂ specialized to range n via Finset.sq_sum_le_card_mul_sum_sq",
+      "sq_e1_le_card_mul_p2: the Cauchy-Schwarz / power-mean bound e₁² ≤ n·p₂ specialized to range n via sq_sum_le_card_mul_sum_sq",
       "Identifies that S₁² ≥ S₂ is exactly Cauchy-Schwarz in disguise: after substituting Newton-Girard, the inequality collapses to n·p₂ ≥ e₁² and needs no nonnegativity hypothesis on the xᵢ"
     ]
   },
@@ -47,7 +47,7 @@
     "historicalContext": "Colin Maclaurin (1729) refined the arithmetic-geometric mean inequality into a chain of inequalities among the symmetric means S_k = e_k / C(n,k), where e_k is the k-th elementary symmetric polynomial of nonnegative reals: S₁ ≥ √S₂ ≥ ∛S₃ ≥ ⋯ ≥ (Sₙ)^{1/n}, with the two ends recovering AM ≥ GM. The base case S₁² ≥ S₂ (equivalently S₁ ≥ √S₂) is the first and most elementary rung. It follows from the Newton-Girard square-of-sum identity e₁² = p₂ + 2e₂ — formalized in the parent entry amgm-inequality-oq-02-oq-01 — together with the power-mean/Cauchy-Schwarz bound p₂ ≥ e₁²/n. Formalizing this rung is a concrete, self-contained step toward a future formal Maclaurin chain.",
     "problemStatement": "For nonnegative reals $x_1,\\dots,x_n$ with $n \\ge 2$, let $e_1 = \\sum_i x_i$, $e_2 = \\sum_{i<j} x_i x_j$, and the Maclaurin averages $S_1 = e_1/n$, $S_2 = e_2/\\binom{n}{2}$. Then $S_1^2 \\ge S_2$.",
     "text": "The proof reduces the averaged inequality S₁² ≥ S₂ to the cleared-denominator form C(n,2)·e₁² ≥ n²·e₂, substitutes the Newton-Girard identity 2e₂ = e₁² − p₂, and observes that the resulting inequality is exactly the Cauchy-Schwarz bound n·p₂ ≥ e₁². Newton-Girard is re-derived from scratch for the range-n family; the Cauchy-Schwarz bound is taken from Mathlib.",
-    "proofStrategy": "Three layers. (1) Newton-Girard e₁² = p₂ + 2e₂: expand e₁² = (Σf)² = Σᵢ Σⱼ fᵢfⱼ via Finset.sum_mul_sum, then split each inner sum by lt_trichotomy on (i,j) into the strict-upper part (e₂), the diagonal (p₂, isolated with Finset.sum_ite_eq), and the strict-lower part (double_sum_split). The strict-lower sum equals the strict-upper one by Finset.sum_comm and mul_comm (upper_eq_lower), giving e₁² = p₂ + 2e₂. (2) Cauchy-Schwarz e₁² ≤ n·p₂: Finset.sq_sum_le_card_mul_sum_sq on range n, with Finset.card_range collapsing the cardinality to n (sq_e1_le_card_mul_p2). (3) Assembly: substitute (1) into (2) to get the linear relation 2n·e₂ ≤ (n−1)·e₁² (nlinarith), rewrite C(n,2) = n(n−1)/2 via Nat.cast_choose_two ℝ n, and close the cleared form by multiplying through by n ≥ 0 (nlinarith with Nat.cast_nonneg). The averaged statement follows from the cleared form by div_pow and div_le_div_iff, with positivity of n and C(n,2) from n ≥ 2.",
+    "proofStrategy": "Three layers. (1) Newton-Girard e₁² = p₂ + 2e₂: expand e₁² = (Σf)² = Σᵢ Σⱼ fᵢfⱼ via Finset.sum_mul_sum, then split each inner sum by lt_trichotomy on (i,j) into the strict-upper part (e₂), the diagonal (p₂, isolated with Finset.sum_ite_eq), and the strict-lower part (double_sum_split). The strict-lower sum equals the strict-upper one by Finset.sum_comm and mul_comm (upper_eq_lower), giving e₁² = p₂ + 2e₂. (2) Cauchy-Schwarz e₁² ≤ n·p₂: sq_sum_le_card_mul_sum_sq on range n, with Finset.card_range collapsing the cardinality to n (sq_e1_le_card_mul_p2). (3) Assembly: substitute (1) into (2) to get the linear relation 2n·e₂ ≤ (n−1)·e₁² (nlinarith), rewrite C(n,2) = n(n−1)/2 via Nat.cast_choose_two ℝ n, and close the cleared form by multiplying through by n ≥ 0 (nlinarith with Nat.cast_nonneg). The averaged statement follows from the cleared form by div_pow and div_le_div_iff₀, with positivity of n and C(n,2) from n ≥ 2.",
     "keyInsights": [
       "S₁² ≥ S₂ is Cauchy-Schwarz in disguise. After substituting Newton-Girard 2e₂ = e₁² − p₂ into the cleared form C(n,2)·e₁² ≥ n²·e₂, every term cancels down to n·p₂ ≥ e₁² — the power-mean bound. The 'Maclaurin' framing adds no inequality content beyond Cauchy-Schwarz at this rung.",
       "No nonnegativity is needed. Although Maclaurin's chain is stated for nonnegative reals, the base rung holds for all reals because both ingredients (Newton-Girard, Cauchy-Schwarz) are sign-agnostic. The nonnegativity hypothesis only becomes essential at higher rungs where one takes real roots.",
@@ -58,7 +58,7 @@
     "prerequisites": [
       "Elementary symmetric sums e₁, e₂ and power sums p₂ over a Finset",
       "Newton-Girard square-of-sum identity e₁² = p₂ + 2e₂",
-      "Cauchy-Schwarz / power-mean bound (Σxᵢ)² ≤ n·Σxᵢ² (Finset.sq_sum_le_card_mul_sum_sq)",
+      "Cauchy-Schwarz / power-mean bound (Σxᵢ)² ≤ n·Σxᵢ² (sq_sum_le_card_mul_sum_sq)",
       "The cast Nat.cast_choose_two: ↑(n.choose 2) = ↑n(↑n−1)/2"
     ]
   },
@@ -90,7 +90,7 @@
       "title": "Power-mean bound: e₁² ≤ n·p₂",
       "startLine": 86,
       "endLine": 94,
-      "summary": "sq_e1_le_card_mul_p2 specializes Mathlib's Finset.sq_sum_le_card_mul_sum_sq to s = range n and simplifies the cardinality with Finset.card_range, yielding (Σ f)² ≤ n · Σ f²."
+      "summary": "sq_e1_le_card_mul_p2 specializes Mathlib's sq_sum_le_card_mul_sum_sq to s = range n and simplifies the cardinality with Finset.card_range, yielding (Σ f)² ≤ n · Σ f²."
     },
     {
       "id": "maclaurin-cleared",
@@ -104,7 +104,7 @@
       "title": "Averaged Form: S₁² ≥ S₂ for n ≥ 2",
       "startLine": 112,
       "endLine": 124,
-      "summary": "maclaurin_base_step lifts the cleared inequality to (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2, where the hypothesis supplies strict positivity of n (hn0) and C(n,2) (hC via Nat.choose_pos). div_pow distributes the square over the quotient, div_le_div_iff clears both positive denominators, and nlinarith [maclaurin_cleared n f] closes the resulting polynomial goal."
+      "summary": "maclaurin_base_step lifts the cleared inequality to (e₁/n)² ≥ e₂/C(n,2) for n ≥ 2, where the hypothesis supplies strict positivity of n (hn0) and C(n,2) (hC via Nat.choose_pos). div_pow distributes the square over the quotient, div_le_div_iff₀ clears both positive denominators, and nlinarith [maclaurin_cleared n f] closes the resulting polynomial goal."
     }
   ],
   "crossReferences": [
@@ -133,7 +133,7 @@
     {
       "title": "Mathlib: Algebra.Order.Chebyshev",
       "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Chebyshev.html",
-      "description": "Source of Finset.sq_sum_le_card_mul_sum_sq, the Cauchy-Schwarz / power-mean bound (Σ f)² ≤ card · Σ f² used here."
+      "description": "Source of sq_sum_le_card_mul_sum_sq, the Cauchy-Schwarz / power-mean bound (Σ f)² ≤ card · Σ f² used here."
     }
   ]
 }


### PR DESCRIPTION
## Fix

Repairs the false-green flagged by the gallery-integrity audit (#25084): `AmgmInequalityOQ02OQ01OQ05.lean` is textually sorry-free but did NOT compile under Mathlib v4.26.

## The 4 errors (verified against offline Mathlib v4.26, rev 2df2f0150c)

1. **Bogus namespace prefix.** The Cauchy-Schwarz lemma is `sq_sum_le_card_mul_sum_sq` in the **root** namespace (declared in `section Mul` of `Mathlib/Algebra/Order/Chebyshev.lean`, no `namespace Finset`). The file wrote `Finset.sq_sum_le_card_mul_sum_sq`, which does not exist. **Fix: drop the prefix** — minimal, keeps the original author's proof intact.
2. **Renamed lemma.** `div_le_div_iff` → `div_le_div_iff₀` (v4.26; `Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean`).
3. **Wrong case-split orientation** in `upper_eq_lower`: after `Finset.sum_comm` the guard is `i < j`, not `j < i`.
4. **Cast typeclass.** Pinned `Nat.cast_nonneg n`'s target type to ℝ in the `maclaurin_cleared` `nlinarith`.

## Meta

Downgraded `status` `formalized`→`pending`, `badge` `mathlib`→`wip`, rewrote `assumptions` to state the build is unconfirmed, and corrected all stale lemma-name references in the prose.

## Build status

**Unverified this session** — `docker run` rc=124 (daemon hung) and Aristotle MCP 404. Names verified against the offline v4.26 checkout, but no green build. Deferred to the deployer build-gate; file is intentionally NOT registered in `Proofs.lean`.

## Note vs #25237

Supersedes #25237, which fixed the same issue by swapping in a *different* lemma (`Finset.sum_mul_sq_le_sq_mul_sq` with g=1) and whose meta prose called `sq_sum_le_card_mul_sum_sq` "nonexistent" — it exists, just unprefixed. This PR is the minimal repair (drop the prefix) with accurate prose. #25237 closed as redundant.

Closes #25084

---
Automated fix by lean-mechanic agent.