### PR TITLE
research(bounded-prime-gaps-oq03): D(5)=12 draft — complete (0 sorries, build-pending)

### DIFF
--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/D5-draft.lean
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/D5-draft.lean
@@ -2,35 +2,44 @@
   DRAFT SKELETON (NOT registered, NOT in Proofs.lean — zero build-gate risk).
   bounded-prime-gaps-oq-03-oq-01-oq-01 — D(5) = 12 from scratch.
 
-  OBSERVE-phase draft (researcher-1, S1, 2026-06-16). Authored under DUAL
+  OBSERVE/PROVE-phase draft (researcher-1, 2026-06-16). Authored under DUAL
   BLACKOUT (Docker `docker run` hangs exit 124; Aristotle MCP `prove` 404), so
-  UNVERIFIED. Mirrors the parent's `minAdmissibleDiameter_2` /
-  `minAdmissibleDiameter_3` proof shape (`BoundedPrimeGapsOQ03OQ01.lean:173/188`).
+  the full file is UNVERIFIED (build-pending). Mirrors the parent's
+  `minAdmissibleDiameter_2` / `minAdmissibleDiameter_3` proof shape
+  (`BoundedPrimeGapsOQ03OQ01.lean:173/188`) and reuses the verified library
+  lemma `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12` for the witness.
 
-  Obligations:
-    (1) `admissible_5tuple_0_2_6_8_12` — witness admissibility. **DONE** (S2,
-        researcher-1, 2026-06-16): transcribed verbatim from the verified
-        `admissible_quadruple_0_2_6_8` (parent line 165), extended card 4→5 with
-        the extra p=5 case. Pure `decide`/`linarith`, no `native_decide`; high
-        compile confidence (build-pending only because the whole file is).
-    (2) `admissible_5tuple_diam_ge_12` — the lower bound (the real content,
-        still `sorry`). Strategy: translation-invariance to fix min = 0, then a
-        finite enumeration over the 5-subsets of {0,…,11}, each inadmissible.
-        IMPORTANT decidability note (S2): `IsAdmissible` is `∀ p prime, …`, NOT
-        directly `Decidable`, so a raw `native_decide` on `¬IsAdmissible H`
-        will NOT typecheck. The enumeration must first reduce to the decidable
-        finite-prime form
-          `∀ H ⊆ range 12, H.card = 5 → ∃ p ∈ ({2,3,5} : Finset ℕ),
-             (H.image (· % p)).card = p`
-        (only p ≤ card = 5 can cover a 5-set), then bridge that to
-        `¬IsAdmissible` via `hadm p hp`. Needs: a ~12-line translation-invariance
-        lemma for `IsAdmissible`/`fsDiameter` + the p≤5 reduction + the
-        `native_decide` enumeration (~C(12,5)=792 subsets) + assembly.
+  Obligations — both now discharged in this draft (build-pending):
+    (1) `admissible_5tuple_0_2_6_8_12` — witness admissibility. **DONE.** Now a
+        one-line delegation to the already-registered, verified
+        `admissible_quintuple_0_2_6_8_12` (BoundedPrimeGaps.lean:572) — the
+        earlier hand-transcribed copy was redundant.
+    (2) `admissible_5tuple_diam_ge_12` — the lower bound (the real content).
+        **DONE** (S3, researcher-1, 2026-06-16). Self-contained proof, no
+        `native_decide`, mirroring the verified `admissible_triple_diam_ge_6`
+        parity argument. Structure:
+          • p = 2 admissibility forces ALL elements to share `min`'s parity
+            (`(H.image (·%2)).card < 2 ⇒ = 1`), exactly the mixed-parity step
+            of the D(3) proof.
+          • Same parity + diameter < 12 ⇒ every element is `min + 2k`,
+            `k ∈ {0,…,5}`, i.e. `H ⊆ {m, m+2, m+4, m+6, m+8, m+10}` (`hsub6`).
+          • Split that 6-set into two disjoint mod-3-complete triples
+            `{m, m+2, m+4}` and `{m+6, m+8, m+10}`: the residues
+            `m, m+2, m+4 (mod 3)` are all of `{0,1,2}` (and likewise the shift
+            by 6). If H contained an entire triple, `(H.image (·%3)).card = 3`,
+            contradicting p = 3 admissibility — so H omits ≥ 1 element from
+            EACH triple, i.e. ≥ 2 omissions. But `H ⊆` a 6-set with `card 5`
+            omits exactly 1. The card bookkeeping (`insert a (insert b H)` has
+            card 7 ≤ 6) closes it.
 
-  On a Docker-up worktree: build this file; obligation (1) should go green as-is;
-  obligation (2) is the remaining work. If green, transcribe into a new
+  This decidability route AVOIDS the `native_decide`/`Decidable IsAdmissible`
+  obstruction noted in S2: `IsAdmissible` is `∀ p prime, …` and is handled
+  symbolically (only p ∈ {2,3} are interrogated), so the proof is `decide`-free
+  on the admissibility predicate and should compile from Mathlib alone.
+
+  On a Docker-up worktree: build this file; if green, transcribe into a new
   registered `Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (or fold into the parent
-  next to D(2)/D(3)).
+  next to D(2)/D(3)) and register in `Proofs.lean`.
 -/
 import Mathlib
 import Proofs.BoundedPrimeGaps
@@ -41,40 +50,149 @@ namespace BoundedPrimeGapsOQ03OQ01OQ01
 open Nat Finset BoundedPrimeGaps BoundedPrimeGapsOQ03OQ01
 
 /-- Witness admissibility: `{0, 2, 6, 8, 12}` is admissible (diameter 12).
-    Only p ∈ {2,3,5} can possibly cover a 5-set; none does (residues miss a
-    class), and p ≥ 7 cannot cover 5 < 7 points. `decide`/`native_decide` over
-    the `IsAdmissible` predicate, exactly as `admissible_quadruple_0_2_6_8`. -/
+    Delegates to the verified, already-registered
+    `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12`. -/
 theorem admissible_5tuple_0_2_6_8_12 :
-    IsAdmissible ({0, 2, 6, 8, 12} : Finset ℕ) := by
-  -- Transcribed from the verified `admissible_quadruple_0_2_6_8` (parent line
-  -- 165), extended from card 4 to card 5 with the extra p = 5 case. Covering
-  -- check by `decide`: mod 2 → {0} (1<2), mod 3 → {0,2} (2<3),
-  -- mod 5 → {0,1,2,3} (4<5); every p ≥ 7 has image card ≤ 5 < 7 ≤ p.
-  intro p hp
-  have himg : (({0, 2, 6, 8, 12} : Finset ℕ).image (· % p)).card ≤ 5 := by
-    calc (({0, 2, 6, 8, 12} : Finset ℕ).image (· % p)).card
-        ≤ ({0, 2, 6, 8, 12} : Finset ℕ).card := Finset.card_image_le
-      _ = 5 := by decide
-  by_cases hp2 : p = 2
-  · subst hp2; decide
-  · by_cases hp3 : p = 3
-    · subst hp3; decide
-    · by_cases hp5 : p = 5
-      · subst hp5; decide
-      · have hp7 : p ≥ 7 := by
-          have h2le := hp.two_le
-          rcases hp.eq_two_or_odd with h2 | hodd
-          · exact absurd h2 hp2
-          · omega
-        linarith
+    IsAdmissible ({0, 2, 6, 8, 12} : Finset ℕ) :=
+  admissible_quintuple_0_2_6_8_12
 
 /-- **Lower bound — the real content.** Every admissible 5-tuple has diameter
-    ≥ 12. By translation-invariance assume `min = 0`; then `H ⊆ {0,…,11}` would
-    force a covering mod 2 or mod 3 (finite `native_decide`). -/
+    ≥ 12. Parity (mod 2) forces same parity; then diameter < 12 confines the set
+    to `{m, m+2, m+4, m+6, m+8, m+10}`, whose two disjoint mod-3-complete triples
+    each must lose an element, forcing ≥ 2 omissions from a 6-set of card 5. -/
 theorem admissible_5tuple_diam_ge_12
     (H : Finset ℕ) (hcard : H.card = 5) (hadm : IsAdmissible H) :
     12 ≤ fsDiameter H := by
-  sorry  -- LOAD-BEARING: shift to min=0 + native_decide over 5-subsets of {0..11}
+  have hne : H.Nonempty := Finset.card_pos.mp (by omega)
+  unfold fsDiameter; simp only [hne, dite_true]
+  by_contra h_lt; push_neg at h_lt
+  -- Facts about min'/max' captured BEFORE `set` so the abbreviation folds them.
+  have hmle0 : ∀ x ∈ H, H.min' hne ≤ x := fun x hx => Finset.min'_le H x hx
+  have hmmem0 : H.min' hne ∈ H := Finset.min'_mem H hne
+  have hmaxmem0 : H.max' hne ∈ H := Finset.max'_mem H hne
+  have hxmax0 : ∀ x ∈ H, x ≤ H.max' hne := fun x hx => Finset.le_max' H x hx
+  set m := H.min' hne with hm
+  -- Now: h_lt : H.max' hne - m < 12, hmle0 : ∀ x ∈ H, m ≤ x, hmmem0 : m ∈ H.
+  -- Step 1: p = 2 admissibility ⇒ every element shares m's parity.
+  have h2 := hadm 2 (by norm_num)
+  have hpar : ∀ x ∈ H, x % 2 = m % 2 := by
+    intro x hx
+    by_contra hdiff
+    have hsub : ({x % 2, m % 2} : Finset ℕ) ⊆ H.image (· % 2) := by
+      rw [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨Finset.mem_image_of_mem _ hx, Finset.mem_image_of_mem _ hmmem0⟩
+    have hc2 : ({x % 2, m % 2} : Finset ℕ).card = 2 :=
+      Finset.card_eq_two.mpr ⟨x % 2, m % 2, hdiff, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 2: same parity + diameter < 12 ⇒ H ⊆ {m, m+2, m+4, m+6, m+8, m+10}.
+  have hsub6 : H ⊆ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) := by
+    intro x hx
+    have hxge := hmle0 x hx
+    have hxle := hxmax0 x hx
+    have hmaxle : H.max' hne ≤ m + 11 := by
+      have := hmle0 _ hmaxmem0; omega
+    have hpx := hpar x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    set d := x - m with hd
+    have hdle : d ≤ 11 := by omega
+    have hdev : d % 2 = 0 := by omega
+    interval_cases d <;> omega
+  -- Step 3a: H cannot contain all of {m, m+2, m+4} (mod 3 would be covered).
+  have hnotT1 : m ∉ H ∨ m + 2 ∉ H ∨ m + 4 ∉ H := by
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨h0, h2', h4'⟩ := hcon
+    have h3 := hadm 3 (by norm_num)
+    have hsub : ({m % 3, (m + 2) % 3, (m + 4) % 3} : Finset ℕ) ⊆ H.image (· % 3) := by
+      intro r hr
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hr
+      rcases hr with rfl | rfl | rfl
+      · exact Finset.mem_image_of_mem _ h0
+      · exact Finset.mem_image_of_mem _ h2'
+      · exact Finset.mem_image_of_mem _ h4'
+    have hc3 : ({m % 3, (m + 2) % 3, (m + 4) % 3} : Finset ℕ).card = 3 :=
+      Finset.card_eq_three.mpr
+        ⟨m % 3, (m + 2) % 3, (m + 4) % 3, by omega, by omega, by omega, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 3b: likewise H cannot contain all of {m+6, m+8, m+10}.
+  have hnotT2 : m + 6 ∉ H ∨ m + 8 ∉ H ∨ m + 10 ∉ H := by
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨h6, h8, h10⟩ := hcon
+    have h3 := hadm 3 (by norm_num)
+    have hsub : ({(m + 6) % 3, (m + 8) % 3, (m + 10) % 3} : Finset ℕ) ⊆ H.image (· % 3) := by
+      intro r hr
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hr
+      rcases hr with rfl | rfl | rfl
+      · exact Finset.mem_image_of_mem _ h6
+      · exact Finset.mem_image_of_mem _ h8
+      · exact Finset.mem_image_of_mem _ h10
+    have hc3 : ({(m + 6) % 3, (m + 8) % 3, (m + 10) % 3} : Finset ℕ).card = 3 :=
+      Finset.card_eq_three.mpr
+        ⟨(m + 6) % 3, (m + 8) % 3, (m + 10) % 3, by omega, by omega, by omega, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 4: two omissions a (from T1) and b (from T2), a ≠ b, both in the
+  -- 6-set ⇒ insert a (insert b H) has card 7 inside a card-≤-6 set. Absurd.
+  have key : ∀ a b : ℕ,
+      a ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) →
+      b ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) →
+      a ≠ b → a ∉ H → b ∉ H → False := by
+    intro a b ha hb hab hna hnb
+    have ha_notin : a ∉ insert b H := by
+      simp only [Finset.mem_insert]; push_neg; exact ⟨hab, hna⟩
+    have hcardins : (insert a (insert b H)).card = 7 := by
+      rw [Finset.card_insert_of_not_mem ha_notin,
+          Finset.card_insert_of_not_mem hnb, hcard]
+    have hins : insert a (insert b H) ⊆
+        ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) := by
+      intro x hx
+      simp only [Finset.mem_insert] at hx
+      rcases hx with rfl | rfl | hx
+      · exact ha
+      · exact hb
+      · exact hsub6 hx
+    have hcardle := Finset.card_le_card hins
+    have c1 := Finset.card_insert_le m ({m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ)
+    have c2 := Finset.card_insert_le (m + 2) ({m + 4, m + 6, m + 8, m + 10} : Finset ℕ)
+    have c3 := Finset.card_insert_le (m + 4) ({m + 6, m + 8, m + 10} : Finset ℕ)
+    have c4 := Finset.card_insert_le (m + 6) ({m + 8, m + 10} : Finset ℕ)
+    have c5 := Finset.card_insert_le (m + 8) ({m + 10} : Finset ℕ)
+    have c6 : ({m + 10} : Finset ℕ).card = 1 := Finset.card_singleton _
+    omega
+  rcases hnotT1 with ha | ha | ha
+  · rcases hnotT2 with hb | hb | hb
+    · exact key m (m + 6)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key m (m + 8)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key m (m + 10)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+  · rcases hnotT2 with hb | hb | hb
+    · exact key (m + 2) (m + 6)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key (m + 2) (m + 8)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key (m + 2) (m + 10)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+  · rcases hnotT2 with hb | hb | hb
+    · exact key (m + 4) (m + 6)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key (m + 4) (m + 8)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
+    · exact key (m + 4) (m + 10)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega)
+        (by simp only [Finset.mem_insert, Finset.mem_singleton]; omega) (by omega) ha hb
 
 /-- D(5) = 12. Same `le_antisymm` assembly as `minAdmissibleDiameter_3`. -/
 theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
@@ -59,3 +59,40 @@ Advanced `D5-draft.lean` from 2 sorries → 1:
 
 Phase: still OBSERVE→ACT, build-pending. Draft remains UNREGISTERED (zero
 build-gate risk). 0 axioms introduced. Claim released.
+
+## S3 ACT (researcher-1, 2026-06-16) — discharged the load-bearing lower bound (1 sorry → 0)
+
+Dual blackout persists (Docker `docker run alpine echo` exit 124; Aristotle 404).
+`D5-draft.lean` now has **0 sorries** (build-pending, UNREGISTERED, 0 axioms).
+
+- **Obligation (1) simplified.** Discovered `admissible_quintuple_0_2_6_8_12`
+  ALREADY exists registered+verified in `BoundedPrimeGaps.lean:572`. Replaced the
+  S2 hand-transcribed copy with a one-line delegation — the witness is no longer
+  hand-rolled.
+- **Obligation (2) `admissible_5tuple_diam_ge_12`: DONE** with a `native_decide`-FREE,
+  fully symbolic proof (avoids the S2 `Decidable IsAdmissible` obstruction
+  entirely — only p ∈ {2,3} are interrogated). Argument mirrors the verified
+  `admissible_triple_diam_ge_6` parity proof:
+  1. p=2 admissibility (`(H.image (·%2)).card < 2 ⇒ =1`) forces all elements to
+     share `m = min`'s parity (exact mixed-parity step of D(3)).
+  2. Same parity + diameter < 12 ⇒ `H ⊆ {m, m+2, m+4, m+6, m+8, m+10}` (`hsub6`,
+     via `interval_cases (x-m)`, same shape as D(3)'s `{m,m+2,m+4}` step).
+  3. The two disjoint triples `{m,m+2,m+4}` and `{m+6,m+8,m+10}` are each
+     mod-3-COMPLETE (`m, m+2, m+4 (mod 3) = {0,1,2}`). If H held an entire triple,
+     `(H.image (·%3)).card = 3` contra p=3 admissibility ⇒ H omits ≥1 from EACH
+     triple = ≥2 omissions. But `H ⊆` a 6-set with `card 5` omits exactly 1:
+     `insert a (insert b H)` would have card 7 ≤ card(6-set) ≤ 6. Absurd.
+- Lemma names verified vs offline Mathlib @ pin 2df2f0150c: `Finset.card_insert_le`,
+  `Finset.card_singleton`, `Finset.card_eq_three` (arg order x≠y,x≠z,y≠z,s={x,y,z}).
+  All other tactics/lemmas reuse patterns already verified in the parent file.
+
+**Residual risk (build-pending):** purely Lean-elaboration (e.g. `omega` proving
+disjunctive membership goals, `interval_cases`/`set` interplay), not mathematics —
+the argument is complete and elementary. The two `native_decide` calls in
+`minAdmissibleDiameter_5` (card and diameter of the concrete `{0,2,6,8,12}`) are
+the only remaining `native_decide`, and are trivially decidable closed terms.
+
+**Next ACT (Docker-up):** build `D5-draft.lean`; if green, register as
+`Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (or fold the two lower-bound theorems
++ `minAdmissibleDiameter_5` into the parent next to D(2)/D(3)) and add to
+`Proofs.lean`. Phase OBSERVE→ACT, build-pending. Claim released.


### PR DESCRIPTION
## Summary

Completes the from-scratch **D(5) = 12** draft for `bounded-prime-gaps-oq-03-oq-01-oq-01` (`minAdmissibleDiameter 5 = 12`), the next rung after the parent's proved D(2)=2 / D(3)=6. The draft (`research/problems/.../D5-draft.lean`) now has **0 sorries**, **0 axioms**, and is **UNREGISTERED** (not in `Proofs.lean` → zero build-gate risk).

This advances the merged OBSERVE draft (#25196) and supersedes the S2 witness-only commit on this branch.

## What changed

- **Witness simplified.** `admissible_5tuple_0_2_6_8_12` now delegates to the already-registered, verified `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12` (`BoundedPrimeGaps.lean:572`) — the prior hand-transcribed copy was redundant.
- **Lower bound proved.** `admissible_5tuple_diam_ge_12` (the load-bearing content) now has a `native_decide`-free, fully symbolic proof mirroring the verified `admissible_triple_diam_ge_6`:
  1. p=2 admissibility (`card(image %2) < 2 ⇒ = 1`) forces all elements to share `min`'s parity.
  2. Same parity + diameter < 12 ⇒ `H ⊆ {m, m+2, m+4, m+6, m+8, m+10}`.
  3. The two disjoint mod-3-**complete** triples `{m,m+2,m+4}`, `{m+6,m+8,m+10}` each must lose an element (else `card(image %3) = 3`, contradicting p=3 admissibility), forcing ≥2 omissions from a 6-set of card 5 — absurd.

This sidesteps the `Decidable IsAdmissible` obstruction noted earlier (only p ∈ {2,3} are interrogated).

## Status

- **Build-pending under dual blackout** (Docker `docker run` exit 124; Aristotle MCP 404) — UNVERIFIED.
- New lemma names (`Finset.card_insert_le`, `Finset.card_singleton`, `Finset.card_eq_three`) checked against offline Mathlib @ build pin `2df2f0150c`; all other tactics reuse patterns already verified in the parent file.
- Residual risk is Lean-elaboration only (e.g. `omega` on disjunctive goals, `interval_cases`/`set` interplay), not mathematics.

## Test plan

- [ ] On a Docker-up worktree: `./proofs/scripts/docker-build.sh` after adding the file (or build the draft directly).
- [ ] If green, register as `Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (or fold the two lower-bound theorems + `minAdmissibleDiameter_5` into the parent next to D(2)/D(3)) and add to `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)