### PR TITLE
Enrich Shannon Entropy (shannon-entropy): re-anchor 11 drifted annotations

### DIFF
--- a/src/data/proofs/shannon-entropy/annotations.json
+++ b/src/data/proofs/shannon-entropy/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-entropy-def",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 22,
-      "endLine": 24
+      "startLine": 23,
+      "endLine": 25
     },
     "type": "definition",
     "title": "Shannon Entropy Definition",
@@ -27,8 +27,8 @@
     "id": "ann-entropy-nonneg",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 27,
-      "endLine": 29
+      "startLine": 42,
+      "endLine": 52
     },
     "type": "concept",
     "title": "Entropy Non-Negativity",
@@ -49,8 +49,8 @@
     "id": "ann-max-entropy",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 32,
-      "endLine": 34
+      "startLine": 195,
+      "endLine": 219
     },
     "type": "concept",
     "title": "Maximum Entropy Principle",
@@ -72,8 +72,8 @@
     "id": "ann-gibbs",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 37,
-      "endLine": 40
+      "startLine": 166,
+      "endLine": 187
     },
     "type": "concept",
     "title": "Gibbs Inequality (KL Divergence Non-Negativity)",
@@ -96,8 +96,8 @@
     "id": "ann-log-sum",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 43,
-      "endLine": 46
+      "startLine": 486,
+      "endLine": 536
     },
     "type": "concept",
     "title": "Log-Sum Inequality",
@@ -120,8 +120,8 @@
     "id": "ann-entropy-proved",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 26,
-      "endLine": 71
+      "startLine": 28,
+      "endLine": 72
     },
     "type": "concept",
     "title": "Entropy Non-Negativity and Point Mass (Fully Proved)",
@@ -143,8 +143,8 @@
     "id": "ann-kl-definition",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 73,
-      "endLine": 107
+      "startLine": 80,
+      "endLine": 108
     },
     "type": "definition",
     "title": "KL Divergence, Conditional Entropy, and Mutual Information",
@@ -167,8 +167,8 @@
     "id": "ann-kl-nonneg",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 109,
-      "endLine": 156
+      "startLine": 117,
+      "endLine": 157
     },
     "type": "concept",
     "title": "KL Divergence Non-Negativity (Gibbs Master Inequality)",
@@ -190,8 +190,8 @@
     "id": "ann-gibbs-proof",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 158,
-      "endLine": 218
+      "startLine": 166,
+      "endLine": 219
     },
     "type": "concept",
     "title": "Gibbs Inequality and Maximum Entropy (Fully Proved)",
@@ -214,8 +214,8 @@
     "id": "ann-mutual-info",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 230,
-      "endLine": 310
+      "startLine": 543,
+      "endLine": 618
     },
     "type": "concept",
     "title": "Mutual Information Non-Negativity (Fully Proved)",
@@ -238,8 +238,8 @@
     "id": "ann-chain-rule",
     "proofId": "shannon-entropy",
     "range": {
-      "startLine": 312,
-      "endLine": 408
+      "startLine": 634,
+      "endLine": 716
     },
     "type": "insight",
     "title": "Chain Rule and Conditioning Reduces Entropy (Fully Proved)",


### PR DESCRIPTION
## Enrichment pass: shannon-entropy (Shannon Entropy)

Whole-set annotation drift in a large file (1196 lines). The resolver flagged 7 `No Lean construct found` (annotations anchored on banner/blank lines), and several more had drifted far from their targets as the file grew.

### Changes
- **Re-anchored all 11 annotations** to their true constructs (`resolver.ts validate`: 7 misaligned → **0**, 11/11 valid). Notable large shifts:
  - `ann-mutual-info` (was @230) → `marginal_*` helpers + `mutual_info_nonneg` @575-618 (content references `marginal_pos_of_joint_pos`, confirmed)
  - `ann-chain-rule` (was @312) → `chain_rule` @634-704 + `conditioning_reduces_entropy` @708-716 (content references `chain_rule`, confirmed)
  - `ann-entropy-def` → `def shannonEntropy`; `ann-kl-definition` → `klDivergence`/`conditionalEntropy`/`mutualInformation`; `ann-log-sum` → `log_sum_inequality` @486-536
- Verified each re-anchored annotation's content matches its new construct.

### Integrity
- `status: verified` / `axiomCount: 0`: file has 0 `axiom` declarations, 0 `sorry`, 0 assumption-carrying structures.
- `sections` (15 sections spanning 1–1196) already aligned to the current file — left unchanged.
- No annotation content rewritten — purely re-anchoring.

Validated with `scripts/annotations/resolver.ts validate` (not `pnpm build`).