### PR TITLE
Enrich sum-of-kth-powers-oq-03: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/annotations.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "sumkth-oq03-ann-position-fn",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 61, "endLine": 73 },
+    "range": { "startLine": 62, "endLine": 74 },
     "type": "definition",
     "title": "The position function T as a Gauss sum",
     "content": "`T n := ∑ i ∈ range n, i` is the running count of odd-number positions consumed by the cubes 0³,…,(n−1)³. Defining it as a sum (not n(n+1)/2) is what keeps the proof division- and subtraction-free. `T_zero` is `rfl`; `T_succ` (T(n+1) = T n + n) follows from `Finset.sum_range_succ`; `T_le_succ` records that the position blocks are non-overlapping (T is monotone in one step). These three facts are everything the later interval arguments need about T.",
@@ -26,7 +26,7 @@
   {
     "id": "sumkth-oq03-ann-sum-odds",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 75, "endLine": 79 },
+    "range": { "startLine": 76, "endLine": 80 },
     "type": "technique",
     "title": "L1: the sum of the first m odds is m²",
     "content": "`sum_odds` proves the classical identity ∑_{j<m}(2j+1) = m² by induction: the step peels off the top term with `Finset.sum_range_succ` and closes with `ring` (k² + (2k+1) = (k+1)²). This is the global statement about odds; the block lemma below is its 'local' interval version. It is applied twice in `block_eq_cube` (at the two endpoints) and once at the very end of the main theorem.",
@@ -38,7 +38,7 @@
   {
     "id": "sumkth-oq03-ann-two-T-add",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 81, "endLine": 89 },
+    "range": { "startLine": 82, "endLine": 90 },
     "type": "technique",
     "title": "The division-free triangular recurrence 2·T i + i = i²",
     "content": "`two_T_add` is the one arithmetic fact the block identity rests on. The usual triangular identity T i = i(i+1)/2 involves division; multiplying through and rearranging gives the equivalent 2·T i + i = i², which lives entirely in the ℕ semiring with no division or subtraction. The proof is a one-line induction using `T_succ` and `ring`. This reformulation is the technical heart of why the whole file avoids ℕ-subtraction pitfalls.",
@@ -50,7 +50,7 @@
   {
     "id": "sumkth-oq03-ann-block-sq",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 91, "endLine": 99 },
+    "range": { "startLine": 92, "endLine": 100 },
     "type": "insight",
     "title": "Block-square identity: T i² + i³ = T(i+1)²",
     "content": "`block_sq` is the algebraic core 'each odd block contributes one cube'. Morally it is the telescoping fact T(i+1)² − T i² = i³, but stating it additively as T i² + i³ = T(i+1)² dodges the ℕ-subtraction the difference form would force. The proof is a 3-step `calc`: rewrite i³ = i²·i, substitute i² = 2·T i + i via `two_T_add`, and let `ring` recognize the result as (T i + i)² = T(i+1)². No special identities beyond the triangular recurrence are needed.",
@@ -62,7 +62,7 @@
   {
     "id": "sumkth-oq03-ann-block-eq-cube",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 101, "endLine": 116 },
+    "range": { "startLine": 102, "endLine": 117 },
     "type": "concept",
     "title": "L2: the i-th odd block sums to i³",
     "content": "`block_eq_cube` realizes the cube as a contiguous block of odds: ∑_{T i ≤ j < T(i+1)}(2j+1) = i³. The proof concatenates the initial segment [0, T i) with the block [T i, T(i+1)) to recover [0, T(i+1)) using `Finset.sum_Ico_consecutive` (with `Finset.range_eq_Ico` to switch range↔Ico). Applying `sum_odds` to both endpoints turns this into T i² + block = T(i+1)²; comparing with `block_sq` (T i² + i³ = T(i+1)²) and cancelling the common T i² via `Nat.add_left_cancel` yields block = i³ — again with no subtraction.",
@@ -74,7 +74,7 @@
   {
     "id": "sumkth-oq03-ann-tiling",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 118, "endLine": 127 },
+    "range": { "startLine": 119, "endLine": 128 },
     "type": "concept",
     "title": "L3: the blocks tile the first T n odds",
     "content": "`tiling` shows the n position-blocks fit together with no gaps or overlaps: ∑_{i<n}(block i) = ∑_{j<T n}(2j+1). The induction step extends the running interval [0, T k) by the next block [T k, T(k+1)) using `Finset.sum_Ico_consecutive` once more — the same concatenation lemma that powered `block_eq_cube`, here driving the assembly rather than a single block. This is the combinatorial 'partition' statement underlying the whole proof.",
@@ -86,7 +86,7 @@
   {
     "id": "sumkth-oq03-ann-main",
     "proofId": "sum-of-kth-powers-oq-03",
-    "range": { "startLine": 129, "endLine": 142 },
+    "range": { "startLine": 130, "endLine": 143 },
     "type": "concept",
     "title": "Nicomachus's theorem assembled",
     "content": "`sum_cubes_eq_sum_squared_via_odds` chains L1–L3. First `Finset.sum_congr` rewrites each i³ as its block via `block_eq_cube`; then `tiling` collapses the sum of blocks to ∑_{j<T(n+1)}(2j+1); then `sum_odds` evaluates that to (T(n+1))². The closing `rfl` is the elegant finish: T(n+1) is definitionally ∑ i ∈ range (n+1), i, so the result lands exactly on the parent's right-hand side (∑_{i≤n} i)² with no further rewriting. The whole identity is proved without ever leaving the ℕ semiring.",
@@ -94,5 +94,17 @@
     "significance": "key",
     "relatedConcepts": ["Nicomachus's theorem", "squared triangular number", "definitional equality (rfl)"],
     "prerequisites": ["Finset.sum_congr", "the supporting lemmas L1–L3"]
+  },
+  {
+    "id": "sumkth-oq03-ann-cube-consecutive-odds",
+    "proofId": "sum-of-kth-powers-oq-03",
+    "range": { "startLine": 145, "endLine": 156 },
+    "type": "insight",
+    "title": "Corollary: each cube is a run of consecutive odd numbers",
+    "content": "`cube_eq_sum_consecutive_odds` restates the block lemma as a standalone identity: i³ is the sum of the i consecutive odds starting at 2·(T i)+1, i.e. 1³=1, 2³=3+5, 3³=7+9+11, 4³=13+15+17+19. The proof reindexes the block sum over `Ico (T i) (T(i+1))` to a sum over `range i` via `Finset.sum_Ico_eq_sum_range`, then simplifies the new upper bound with `T_succ` and `Nat.add_sub_cancel_left`. Crucially the first odd is written 2·(T i)+1 so that the reindexed summand 2·(T i + k)+1 introduces no ℕ-subtraction. This is the historically famous form of Nicomachus's identity — the visual 'odd-number staircase' decomposition of the cubes.",
+    "mathContext": "$i^3 = \\sum_{k<i}\\big(2(T(i)+k)+1\\big)$; e.g. $4^3 = 13+15+17+19$, the run of $i$ odds beginning at $2T(i)+1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nicomachus's theorem", "consecutive odd numbers", "Finset.sum_Ico_eq_sum_range", "reindexing"],
+    "prerequisites": ["interval-to-range reindexing", "the block lemma L2"]
   }
 ]

--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -76,39 +76,39 @@
       "id": "header-and-position-function",
       "title": "Module Header and the Position Function T",
       "startLine": 1,
-      "endLine": 73,
+      "endLine": 74,
       "summary": "Documents the odd-number-partition idea and introduces T n := ∑_{i<n} i as a Gauss sum (T_zero, T_succ : T(n+1) = T n + n, T_le_succ : T n ≤ T(n+1)). Defining T as a sum rather than n(n+1)/2 is what makes the whole proof division- and subtraction-free.",
       "mathContext": "$T(n) = \\sum_{i<n} i$, with $T(0)=0$ and $T(n+1)=T(n)+n$."
     },
     {
       "id": "sum-of-odds-and-recurrence",
       "title": "Sum of Odds and the Triangular Recurrence",
-      "startLine": 75,
-      "endLine": 89,
+      "startLine": 76,
+      "endLine": 90,
       "summary": "sum_odds (L1): ∑_{j<m}(2j+1) = m², by induction with Finset.sum_range_succ. two_T_add: the division-free triangular recurrence 2·T i + i = i², also a one-line induction. These two facts carry all the arithmetic the proof needs.",
       "mathContext": "$\\sum_{j<m}(2j+1)=m^2$ and $2T(i)+i=i^2$."
     },
     {
       "id": "block-square-and-block-cube",
       "title": "Each Odd Block Contributes a Cube",
-      "startLine": 91,
-      "endLine": 116,
+      "startLine": 92,
+      "endLine": 117,
       "summary": "block_sq: T i² + i³ = T(i+1)², proved from two_T_add by a 3-step calc using only ring on the ℕ semiring. block_eq_cube (L2): ∑_{T i ≤ j < T(i+1)}(2j+1) = i³, obtained by applying sum_odds to both endpoints via Finset.sum_Ico_consecutive and cancelling T i² with Nat.add_left_cancel.",
       "mathContext": "$\\sum_{T(i)\\le j < T(i+1)}(2j+1) = T(i+1)^2 - T(i)^2 = i^3$."
     },
     {
       "id": "tiling-and-main",
       "title": "Tiling and Nicomachus's Theorem",
-      "startLine": 118,
-      "endLine": 140,
+      "startLine": 119,
+      "endLine": 143,
       "summary": "tiling (L3): ∑_{i<n}(block i) = ∑_{j<T n}(2j+1), by induction with Finset.sum_Ico_consecutive (the blocks tile [0, T n)). The main theorem sum_cubes_eq_sum_squared_via_odds rewrites each i³ as its block (block_eq_cube), applies tiling and sum_odds to reach (T(n+1))², and closes by rfl since T(n+1) is definitionally ∑_{i<n+1} i — matching the parent's RHS exactly.",
       "mathContext": "$\\sum_{i\\le n} i^3 = \\sum_{j<T(n+1)}(2j+1) = (T(n+1))^2 = \\big(\\sum_{i\\le n} i\\big)^2$."
     },
     {
       "id": "per-cube-corollary",
       "title": "Per-Cube Corollary: Each Cube as Consecutive Odds",
-      "startLine": 142,
-      "endLine": 155,
+      "startLine": 145,
+      "endLine": 156,
       "summary": "cube_eq_sum_consecutive_odds restates block_eq_cube as a standalone identity over range i: i³ = ∑_{k<i}(2·(T i + k) + 1), the i consecutive odd numbers starting at 2·(T i)+1. Derived from block_eq_cube by Finset.sum_Ico_eq_sum_range and T_succ, eliminating ℕ-subtraction. This is the classical visual form of Nicomachus (1³=1, 2³=3+5, 3³=7+9+11, …).",
       "mathContext": "$i^3 = \\sum_{k<i}\\bigl(2(T_i + k) + 1\\bigr)$, the $i$ consecutive odds from $2T_i+1$."
     }


### PR DESCRIPTION
Enrichment pass for sum-of-kth-powers-oq-03 (Nicomachus via odd-number partition).

## Drift fix (primary)
The Lean file had shifted relative to the annotation/section line anchors: **7 of 8 annotations were misaligned** (pointing at blank lines between constructs). Re-anchored all 7 onto their doc-comment/declaration lines.
- Resolver before: Valid 1, Misaligned 7
- Resolver after: **Valid 9, Misaligned 0**

Also tightened 5 `sections` boundaries (off by 1–3 lines) to match exact construct spans.

## Coverage
- Added an annotation for the previously un-annotated corollary `cube_eq_sum_consecutive_odds` (i³ as a run of i consecutive odds: 1³=1, 2³=3+5, 3³=7+9+11, …).

## Note for maintainers (not changed)
meta.json `status: verified` / `assumptions` claims the file "builds green / machine-checked (7743 jobs)", but the Lean file header NOTE still says **BUILD-PENDING — not yet machine-checked**. These disagree. I left status untouched; please reconcile (update the Lean NOTE if the build has since gone green, or downgrade status otherwise).

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 9/9 annotations valid, 0 misaligned.