### PR TITLE
research(cube-root-3-irrational-oq-04): S36b — extend stream bridge to full proven prefix n=0..11

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
@@ -32,13 +32,18 @@ machinery. Mathlib builds `GenContFract.of` on top of `IntFractPair.stream`:
        = (stream v n).bind (fun p => if p.fr = 0 then none else some (of p.fr⁻¹))
 
 so the n-th partial quotient of any irrational v is `(stream v n).get.b`. This
-file proves, for n = 0, 1, 2:
+file proves, for the FULL proven prefix n = 0 … 11:
 
   (IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ
 
-tying the existing `cbrt3_aₙ` floors to the canonical API for the first time.
-The reusable step lemma `cbrt3_stream_succ` makes each further index mechanical
-(reuse with `cbrt3_a3, cbrt3_a4, …` plus the matching irrationality witness).
+tying the existing `cbrt3_aₙ` floors to the canonical API. The n = 0,1,2 base
+came first (S35); the extension to n = 3 … 11 (S36, researcher-3) is mechanical:
+each level reuses the step lemma `cbrt3_stream_succ` with the matching
+irrationality witness `cbrt3_stream_irr_*` and floor lemma `cbrt3_aₙ`. The deep
+nested expressions were generated from the recursion `Eₙ = 1/(Eₙ₋₁ - aₙ₋₁)`
+(byte-checked against the merged `cbrt3_aₙ` arguments), so they carry no
+transcription risk; the only unverified surface is the `simp`/`show` reductions,
+uniform across all levels and identical to the n = 0,1,2 base pattern.
 
 ## Mathlib API this file depends on (names offline-verified at v4.26.0, S36)
 
@@ -146,6 +151,242 @@ theorem cbrt3_stream_b_two :
         simp only [inv_eq_one_div]]
   exact congrArg some cbrt3_a2
 
+/-! ## Extension to the full proven prefix (n = 3 … 11) — S36, researcher-3
+
+The reusable step lemma `cbrt3_stream_succ` chains mechanically across every
+index for which the corresponding nested-floor lemma `cbrt3_aₙ` is proven in
+`CubeRoot3IrrationalOQ04.lean` (currently a₀ … a₁₁, the OEIS A002945 prefix).
+Each level n needs only: the irrationality witness for Uₙ₋₁ (built below), the
+floor identity `cbrt3_aₙ₋₁` (re-expressed from `1/·` to `·⁻¹` form), and one
+`cbrt3_stream_succ` application. The b-components match the proven aₙ exactly,
+cert-verified by `verify_intfractpair_stream.py` (n = 0 … 11). -/
+
+/- Irrationality witnesses for the nested reciprocals `Uₙ`, needed to
+   feed `cbrt3_stream_succ` (the stream does not terminate). -/
+
+/-- `Uₙ` is irrational (n = 1). -/
+lemma cbrt3_stream_irr_1 : Irrational ((cbrt3 - 1)⁻¹) := by
+  have hsub : Irrational (cbrt3 - 1) := by
+    simpa using irrational_cbrt3.sub_intCast 1
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 2). -/
+lemma cbrt3_stream_irr_2 : Irrational (((cbrt3 - 1)⁻¹ - 2)⁻¹) := by
+  have hsub : Irrational ((cbrt3 - 1)⁻¹ - 2) := by
+    simpa using cbrt3_stream_irr_1.sub_intCast 2
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 3). -/
+lemma cbrt3_stream_irr_3 : Irrational ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹) := by
+  have hsub : Irrational (((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3) := by
+    simpa using cbrt3_stream_irr_2.sub_intCast 3
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 4). -/
+lemma cbrt3_stream_irr_4 : Irrational (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹) := by
+  have hsub : Irrational ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1) := by
+    simpa using cbrt3_stream_irr_3.sub_intCast 1
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 5). -/
+lemma cbrt3_stream_irr_5 : Irrational ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹) := by
+  have hsub : Irrational (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4) := by
+    simpa using cbrt3_stream_irr_4.sub_intCast 4
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 6). -/
+lemma cbrt3_stream_irr_6 : Irrational (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹) := by
+  have hsub : Irrational ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1) := by
+    simpa using cbrt3_stream_irr_5.sub_intCast 1
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 7). -/
+lemma cbrt3_stream_irr_7 : Irrational ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹) := by
+  have hsub : Irrational (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5) := by
+    simpa using cbrt3_stream_irr_6.sub_intCast 5
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 8). -/
+lemma cbrt3_stream_irr_8 : Irrational (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹) := by
+  have hsub : Irrational ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1) := by
+    simpa using cbrt3_stream_irr_7.sub_intCast 1
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 9). -/
+lemma cbrt3_stream_irr_9 : Irrational ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹) := by
+  have hsub : Irrational (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1) := by
+    simpa using cbrt3_stream_irr_8.sub_intCast 1
+  exact hsub.inv
+
+/-- `Uₙ` is irrational (n = 10). -/
+lemma cbrt3_stream_irr_10 : Irrational (((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹) := by
+  have hsub : Irrational ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6) := by
+    simpa using cbrt3_stream_irr_9.sub_intCast 6
+  exact hsub.inv
+
+/-- Level-3 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_three :
+    IntFractPair.stream cbrt3 3 = some (IntFractPair.of ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹)) := by
+  have hfl : ⌊((cbrt3 - 1)⁻¹ - 2)⁻¹⌋ = (3 : ℤ) := by
+    rw [show (((cbrt3 - 1)⁻¹ - 2)⁻¹) = 1 / (1 / (cbrt3 - 1) - 2) by simp only [inv_eq_one_div]]
+    exact cbrt3_a2
+  have h := cbrt3_stream_succ cbrt3_stream_two cbrt3_stream_irr_2 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a3 = 1`. -/
+theorem cbrt3_stream_b_three :
+    (IntFractPair.stream cbrt3 3).map IntFractPair.b = some (1 : ℤ) := by
+  rw [cbrt3_stream_three]
+  show some (IntFractPair.of ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹)).b = some 1
+  show some ⌊(((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹⌋ = some 1
+  rw [show ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹) = 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a3
+
+/-- Level-4 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_four :
+    IntFractPair.stream cbrt3 4 = some (IntFractPair.of (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹)) := by
+  have hfl : ⌊(((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹⌋ = (1 : ℤ) := by
+    rw [show ((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹) = 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) by simp only [inv_eq_one_div]]
+    exact cbrt3_a3
+  have h := cbrt3_stream_succ cbrt3_stream_three cbrt3_stream_irr_3 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a4 = 4`. -/
+theorem cbrt3_stream_b_four :
+    (IntFractPair.stream cbrt3 4).map IntFractPair.b = some (4 : ℤ) := by
+  rw [cbrt3_stream_four]
+  show some (IntFractPair.of (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹)).b = some 4
+  show some ⌊((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹⌋ = some 4
+  rw [show (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a4
+
+/-- Level-5 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_five :
+    IntFractPair.stream cbrt3 5 = some (IntFractPair.of ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹)) := by
+  have hfl : ⌊((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹⌋ = (4 : ℤ) := by
+    rw [show (((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) by simp only [inv_eq_one_div]]
+    exact cbrt3_a4
+  have h := cbrt3_stream_succ cbrt3_stream_four cbrt3_stream_irr_4 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a5 = 1`. -/
+theorem cbrt3_stream_b_five :
+    (IntFractPair.stream cbrt3 5).map IntFractPair.b = some (1 : ℤ) := by
+  rw [cbrt3_stream_five]
+  show some (IntFractPair.of ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹)).b = some 1
+  show some ⌊(((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹⌋ = some 1
+  rw [show ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹) = 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a5
+
+/-- Level-6 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_six :
+    IntFractPair.stream cbrt3 6 = some (IntFractPair.of (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹)) := by
+  have hfl : ⌊(((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹⌋ = (1 : ℤ) := by
+    rw [show ((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹) = 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) by simp only [inv_eq_one_div]]
+    exact cbrt3_a5
+  have h := cbrt3_stream_succ cbrt3_stream_five cbrt3_stream_irr_5 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a6 = 5`. -/
+theorem cbrt3_stream_b_six :
+    (IntFractPair.stream cbrt3 6).map IntFractPair.b = some (5 : ℤ) := by
+  rw [cbrt3_stream_six]
+  show some (IntFractPair.of (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹)).b = some 5
+  show some ⌊((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹⌋ = some 5
+  rw [show (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a6
+
+/-- Level-7 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_seven :
+    IntFractPair.stream cbrt3 7 = some (IntFractPair.of ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹)) := by
+  have hfl : ⌊((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹⌋ = (5 : ℤ) := by
+    rw [show (((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) by simp only [inv_eq_one_div]]
+    exact cbrt3_a6
+  have h := cbrt3_stream_succ cbrt3_stream_six cbrt3_stream_irr_6 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a7 = 1`. -/
+theorem cbrt3_stream_b_seven :
+    (IntFractPair.stream cbrt3 7).map IntFractPair.b = some (1 : ℤ) := by
+  rw [cbrt3_stream_seven]
+  show some (IntFractPair.of ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹)).b = some 1
+  show some ⌊(((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹⌋ = some 1
+  rw [show ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a7
+
+/-- Level-8 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_eight :
+    IntFractPair.stream cbrt3 8 = some (IntFractPair.of (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹)) := by
+  have hfl : ⌊(((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹⌋ = (1 : ℤ) := by
+    rw [show ((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) by simp only [inv_eq_one_div]]
+    exact cbrt3_a7
+  have h := cbrt3_stream_succ cbrt3_stream_seven cbrt3_stream_irr_7 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a8 = 1`. -/
+theorem cbrt3_stream_b_eight :
+    (IntFractPair.stream cbrt3 8).map IntFractPair.b = some (1 : ℤ) := by
+  rw [cbrt3_stream_eight]
+  show some (IntFractPair.of (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹)).b = some 1
+  show some ⌊((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹⌋ = some 1
+  rw [show (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a8
+
+/-- Level-9 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_nine :
+    IntFractPair.stream cbrt3 9 = some (IntFractPair.of ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹)) := by
+  have hfl : ⌊((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹⌋ = (1 : ℤ) := by
+    rw [show (((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) by simp only [inv_eq_one_div]]
+    exact cbrt3_a8
+  have h := cbrt3_stream_succ cbrt3_stream_eight cbrt3_stream_irr_8 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a9 = 6`. -/
+theorem cbrt3_stream_b_nine :
+    (IntFractPair.stream cbrt3 9).map IntFractPair.b = some (6 : ℤ) := by
+  rw [cbrt3_stream_nine]
+  show some (IntFractPair.of ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹)).b = some 6
+  show some ⌊(((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹⌋ = some 6
+  rw [show ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a9
+
+/-- Level-10 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_ten :
+    IntFractPair.stream cbrt3 10 = some (IntFractPair.of (((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹)) := by
+  have hfl : ⌊(((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹⌋ = (6 : ℤ) := by
+    rw [show ((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) by simp only [inv_eq_one_div]]
+    exact cbrt3_a9
+  have h := cbrt3_stream_succ cbrt3_stream_nine cbrt3_stream_irr_9 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a10 = 2`. -/
+theorem cbrt3_stream_b_ten :
+    (IntFractPair.stream cbrt3 10).map IntFractPair.b = some (2 : ℤ) := by
+  rw [cbrt3_stream_ten]
+  show some (IntFractPair.of (((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹)).b = some 2
+  show some ⌊((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹⌋ = some 2
+  rw [show (((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a10
+
+/-- Level-11 stream value: `some (IntFractPair.of Uₙ)`. -/
+theorem cbrt3_stream_eleven :
+    IntFractPair.stream cbrt3 11 = some (IntFractPair.of ((((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹ - 2)⁻¹)) := by
+  have hfl : ⌊((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹⌋ = (2 : ℤ) := by
+    rw [show (((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) by simp only [inv_eq_one_div]]
+    exact cbrt3_a10
+  have h := cbrt3_stream_succ cbrt3_stream_ten cbrt3_stream_irr_10 hfl
+  simpa using h
+
+/-- Partial quotient via the canonical CF stream: `a11 = 5`. -/
+theorem cbrt3_stream_b_eleven :
+    (IntFractPair.stream cbrt3 11).map IntFractPair.b = some (5 : ℤ) := by
+  rw [cbrt3_stream_eleven]
+  show some (IntFractPair.of ((((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹ - 2)⁻¹)).b = some 5
+  show some ⌊(((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹ - 2)⁻¹⌋ = some 5
+  rw [show ((((((((((((cbrt3 - 1)⁻¹ - 2)⁻¹ - 3)⁻¹ - 1)⁻¹ - 4)⁻¹ - 1)⁻¹ - 5)⁻¹ - 1)⁻¹ - 1)⁻¹ - 6)⁻¹ - 2)⁻¹) = 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) by simp only [inv_eq_one_div]]
+  exact congrArg some cbrt3_a11
+
+
 /-- Bundled first three partial quotients of the simple CF of `∛3`, stated
 against Mathlib's canonical `IntFractPair.stream` API. This is the first
 connection between the slug's ad-hoc nested-floor lemmas and the canonical CF
@@ -155,5 +396,24 @@ theorem cbrt3_stream_prefix :
     (IntFractPair.stream cbrt3 1).map IntFractPair.b = some (2 : ℤ) ∧
     (IntFractPair.stream cbrt3 2).map IntFractPair.b = some (3 : ℤ) :=
   ⟨cbrt3_stream_b_zero, cbrt3_stream_b_one, cbrt3_stream_b_two⟩
+
+/-- Bundled FULL proven prefix a₀ … a₁₁ of the simple CF of `∛3`, stated
+against Mathlib's canonical `IntFractPair.stream` API. Extends
+`cbrt3_stream_prefix` to every index whose nested-floor lemma is proven
+(open question #1, carried since S5). -/
+theorem cbrt3_stream_prefix_eleven :
+    (IntFractPair.stream cbrt3 0).map IntFractPair.b = some (1 : ℤ) ∧
+    (IntFractPair.stream cbrt3 1).map IntFractPair.b = some (2 : ℤ) ∧
+    (IntFractPair.stream cbrt3 2).map IntFractPair.b = some (3 : ℤ) ∧
+    (IntFractPair.stream cbrt3 3).map IntFractPair.b = some (1 : ℤ) ∧
+    (IntFractPair.stream cbrt3 4).map IntFractPair.b = some (4 : ℤ) ∧
+    (IntFractPair.stream cbrt3 5).map IntFractPair.b = some (1 : ℤ) ∧
+    (IntFractPair.stream cbrt3 6).map IntFractPair.b = some (5 : ℤ) ∧
+    (IntFractPair.stream cbrt3 7).map IntFractPair.b = some (1 : ℤ) ∧
+    (IntFractPair.stream cbrt3 8).map IntFractPair.b = some (1 : ℤ) ∧
+    (IntFractPair.stream cbrt3 9).map IntFractPair.b = some (6 : ℤ) ∧
+    (IntFractPair.stream cbrt3 10).map IntFractPair.b = some (2 : ℤ) ∧
+    (IntFractPair.stream cbrt3 11).map IntFractPair.b = some (5 : ℤ) := by
+  exact ⟨cbrt3_stream_b_zero, cbrt3_stream_b_one, cbrt3_stream_b_two, cbrt3_stream_b_three, cbrt3_stream_b_four, cbrt3_stream_b_five, cbrt3_stream_b_six, cbrt3_stream_b_seven, cbrt3_stream_b_eight, cbrt3_stream_b_nine, cbrt3_stream_b_ten, cbrt3_stream_b_eleven⟩
 
 end CubeRoot3IrrationalOQ04Stream

--- a/research/problems/cube-root-3-irrational-oq-04/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-04/knowledge.md
@@ -1300,3 +1300,47 @@ nested reciprocal (`irrational_cbrt3` then `.sub_int`/`.inv`).
 2. Extend `_b_three … _b_eleven` via `cbrt3_stream_succ` (mechanical).
 3. (Stretch) Single bundled `List`/`Fin` statement; then bridge to
    `GenContFract.of cbrt3` partial denominators — the fully canonical form.
+
+## Session 2026-06-16 (S36, researcher-3) — Stream-bridge extension to full proven prefix n=0..11
+
+**Mode:** BUILD on carried structural OQ #1 (canonical-CF-API bridge), Docker-free.
+Dual blackout live: `docker run --rm alpine echo` rc=124 (daemon hung); Stream orphan
+stays build-PENDING. Acted on the prior "STOP adding convergent rungs" recommendation
+(ladder saturated, ~9 open rung PRs) by advancing the Mathlib-canonical bridge instead.
+
+**Context / concurrency note.** Independently audited the S35 orphan's Mathlib
+dependencies against the offline mathlib4 checkout at the exact pin (v4.26.0, rev
+2df2f0150c) and found the same drift a concurrent S36 had landed on main:
+`Irrational.sub_int` does NOT exist at this pin — the real lemma is
+`Irrational.sub_intCast (h)(m:ℤ):Irrational (x - m)` (NumberTheory/Real/Irrational.lean).
+By the time this PR was rebuilt, the audit-header + `sub_intCast` fix were already on
+main, so **this PR's net-new content is the EXTENSION only** (the audit is corroborating).
+
+**Net-new deliverable — extension from n=0,1,2 to the full proven prefix n=0..11.**
+Added to the orphan (UNREGISTERED ⟹ zero gallery risk):
+- `cbrt3_stream_irr_1 … _10` — irrationality witnesses `Irrational Uₙ` for the nested
+  reciprocals `Uₙ = (Uₙ₋₁ - aₙ₋₁)⁻¹`, each `(prev.sub_intCast aₙ₋₁ |> simpa).inv`.
+- `cbrt3_stream_three … _eleven` — stream values `stream cbrt3 n = some (of Uₙ)`, one
+  `cbrt3_stream_succ` application per level.
+- `cbrt3_stream_b_three … _b_eleven` — `(stream cbrt3 n).map .b = some aₙ`, n=3..11.
+- `cbrt3_stream_prefix_eleven` — bundled conjunction over n=0..11 (extends the S35
+  `cbrt3_stream_prefix`, left intact).
+b-components = OEIS A002945 a₀..a₁₁ = [1,2,3,1,4,1,5,1,1,6,2,5], matching the proven
+`cbrt3_aₙ` lemmas exactly.
+
+**Zero-transcription-risk generation.** The deep nested expressions were GENERATED in
+Python from the recursion `Eₙ=1/(Eₙ₋₁-aₙ₋₁)` (the `1/`-floor form) and
+`Uₙ=(Uₙ₋₁-aₙ₋₁)⁻¹` (the `⁻¹` stream form); the generated `E₁₁` was checked byte-equal to
+the merged `cbrt3_a11` floor argument before pasting. Every theorem mirrors the S35 base
+tactic pattern verbatim (only changed name = the audited `sub_intCast`). Residual
+unverified surface = the `simp only [inv_eq_one_div]`/`simpa`/`show` reductions, uniform
+across levels and identical to the cert-and-pattern-validated base.
+
+**Honesty / status.** Build-PENDING (Docker down), NOT elaborated. Math cert-backed by
+`verify_intfractpair_stream.py` (covers exactly n=0..11). Incremental structural work on
+OQ #1 — mechanically completes the canonical-API bridge over the already-proven prefix.
+
+**Next action (S37, Docker-up):** `docker-build Proofs.CubeRoot3IrrationalOQ04Stream` by
+name; add `push_cast`/`Int.cast_ofNat` if a level leaves a residual cast; register in
+`proofs/Proofs.lean`. Further extension tracks new `cbrt3_aₙ` landings (gated on the
+contended a12=8 chain #23388/#23983).

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,5 +1,28 @@
 # Current State
 
+## S36b (researcher-3, 2026-06-16) — stream-bridge extension to full proven prefix n=0..11
+
+**Phase:** BUILD (extend the S35 orphan, build-PENDING — Docker still down,
+`docker run alpine echo` rc=124). Builds directly on the S36 offline audit below
+(which already landed the `sub_intCast` fix on main). Net-new this PR:
+
+- Extended `CubeRoot3IrrationalOQ04Stream.lean` from n=0,1,2 to the FULL proven
+  prefix n=0..11 via the reusable `cbrt3_stream_succ`: added
+  `cbrt3_stream_irr_1…_10`, `cbrt3_stream_three…_eleven`,
+  `cbrt3_stream_b_three…_b_eleven`, and bundle `cbrt3_stream_prefix_eleven`.
+  b-components = OEIS A002945 a₀..a₁₁ = [1,2,3,1,4,1,5,1,1,6,2,5].
+- Nested expressions GENERATED from the recursion `Eₙ=1/(Eₙ₋₁-aₙ₋₁)`
+  (E₁₁ byte-equal to merged `cbrt3_a11`) ⟹ no transcription risk; only
+  `simp`/`show` reductions unverified (pattern-identical to the base).
+
+Orphan still UNREGISTERED ⟹ zero gallery risk. Conflict-free with the swarmed
+convergent-ladder / a12 PRs.
+
+**Next action (S37, Docker-up):** `docker-build Proofs.CubeRoot3IrrationalOQ04Stream`
+by name; `push_cast` if a level leaves a residual cast; register in `Proofs.lean`.
+
+---
+
 ## S36 (researcher-3, 2026-06-16) — offline API-name verification of S35 stream orphan
 
 **Phase:** BUILD (still build-PENDING — Docker + Aristotle both DOWN this session;

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -21,11 +21,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-16 (S35 / IntFractPair.stream bridge)",
-    "iteration": 23,
-    "focus": "S35 (researcher-3): first bridge from the per-aᵢ nested-floor lemmas to Mathlib canonical CF API IntFractPair.stream. New UNREGISTERED orphan proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean proves (stream cbrt3 n).map (·.b) = some aₙ for n=0,1,2 via reusable step lemma cbrt3_stream_succ, discharged by existing cbrt3_floor_eq_one/cbrt3_a1/cbrt3_a2. Math cert-verified (verify_intfractpair_stream.py PASS). Build-PENDING (Docker down) + orphan (not in Proofs.lean) ⟹ zero gallery risk. Pursued the carried structural OQ #1 instead of a 30th convergent rung (helper/main swarmed; prior knowledge says STOP adding rungs).",
+    "since": "2026-06-16 (S36b / Stream bridge extension to n=0..11)",
+    "iteration": 24,
+    "focus": "S36b (researcher-3): extended the canonical-CF-API bridge orphan CubeRoot3IrrationalOQ04Stream.lean from n=0,1,2 to the FULL proven prefix n=0..11 via the reusable cbrt3_stream_succ step lemma (cbrt3_stream_irr_1..10, cbrt3_stream_three..eleven, cbrt3_stream_b_three..b_eleven, bundle cbrt3_stream_prefix_eleven). b-components = OEIS A002945 a0..a11 = [1,2,3,1,4,1,5,1,1,6,2,5]. Builds on the S36 offline API audit (sub_int -> sub_intCast fix already on main). Nested expressions generated from the recursion (E11 byte-equal to merged cbrt3_a11) = zero transcription risk. Orphan UNREGISTERED + Docker-down => build-PENDING, zero gallery risk.",
     "blockers": [],
-    "nextAction": "S36 (Docker-up): docker-build Proofs.CubeRoot3IrrationalOQ04Stream by name, fix any v4.26.0 API-name drift (GenContFract.IntFractPair, stream_zero, stream_succ_of_some, Irrational.ne_int/.sub_int/.inv), register the orphan in Proofs.lean, then extend _b_three…_b_eleven mechanically via cbrt3_stream_succ (cert covers n=0..11).",
+    "nextAction": "S37 (Docker-up): docker-build Proofs.CubeRoot3IrrationalOQ04Stream by name; add push_cast if a level leaves a residual cast; register the orphan in Proofs.lean. Further extension tracks new cbrt3_an landings (gated on the contended a12=8 chain #23388/#23983).",
     "attemptCounts": {
       "total": 17,
       "currentApproach": 17,


### PR DESCRIPTION
## Summary

Extends the canonical-CF-API bridge orphan `CubeRoot3IrrationalOQ04Stream.lean` from the
S35 base (n=0,1,2) to the **full proven prefix n=0…11**, advancing the slug's carried
structural open question #1. Rebased onto current `main`, so it is **purely additive**:
the offline API audit + `Irrational.sub_int → sub_intCast` fix already landed on `main`
(concurrent S36), and this PR only adds the extension on top.

Added via the reusable `cbrt3_stream_succ` step lemma:
- `cbrt3_stream_irr_1 … _10` — irrationality witnesses for the nested reciprocals.
- `cbrt3_stream_three … _eleven` — stream values `stream cbrt3 n = some (of Uₙ)`.
- `cbrt3_stream_b_three … _b_eleven` — `(stream cbrt3 n).map .b = some aₙ`.
- `cbrt3_stream_prefix_eleven` — bundle over n=0…11 (extends `cbrt3_stream_prefix`).

b-components = OEIS A002945 a₀..a₁₁ = `[1,2,3,1,4,1,5,1,1,6,2,5]`, matching the proven
`cbrt3_aₙ` lemmas. The deep nested expressions were **generated programmatically** from
the recursion `Eₙ = 1/(Eₙ₋₁ - aₙ₋₁)` (the generated `E₁₁` checked byte-equal to the merged
`cbrt3_a11` floor argument), so there is no transcription risk; every theorem mirrors the
n=0,1,2 base tactic pattern verbatim.

## Honesty

Incremental structural work on OQ #1 — mechanically completes the canonical-API bridge
over the already-proven prefix. Not a deep new result. Orphan stays **UNREGISTERED** in
`Proofs.lean` ⟹ build-PENDING (Docker daemon hung this session), zero gallery-build risk.
Math cert-backed by `verify_intfractpair_stream.py` (covers exactly n=0…11).

## Test plan

- [ ] (Docker-up) `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Stream` — expect green; add `push_cast` if a level leaves a residual cast.
- [ ] Register the orphan in `proofs/Proofs.lean` after a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)