### PR TITLE
Enrich solution-of-cubic-oq-03: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-omega-def-cubed",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 30,
-      "endLine": 44
+      "startLine": 34,
+      "endLine": 43
     },
     "type": "definition",
     "title": "Primitive Cube Root of Unity: Definition and ω³ = 1",
@@ -95,7 +95,7 @@
     "id": "ann-cardano-roots",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 80,
+      "startLine": 84,
       "endLine": 91
     },
     "type": "definition",
@@ -118,7 +118,7 @@
     "id": "ann-vieta-sum",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 93,
+      "startLine": 97,
       "endLine": 104
     },
     "type": "insight",
@@ -141,7 +141,7 @@
     "id": "ann-vieta-pairs",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 106,
+      "startLine": 110,
       "endLine": 128
     },
     "type": "concept",
@@ -164,7 +164,7 @@
     "id": "ann-vieta-product",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 130,
+      "startLine": 134,
       "endLine": 148
     },
     "type": "insight",
@@ -186,7 +186,7 @@
     "id": "ann-factorization",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 150,
+      "startLine": 154,
       "endLine": 170
     },
     "type": "insight",
@@ -208,8 +208,8 @@
     "id": "ann-roots-satisfy",
     "proofId": "solution-of-cubic-oq-03",
     "range": {
-      "startLine": 172,
-      "endLine": 187
+      "startLine": 176,
+      "endLine": 185
     },
     "type": "concept",
     "title": "Root Verification: All Three Roots Are Zeros",

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -92,15 +92,15 @@
       "id": "cube-root-unity",
       "title": "Section I: Cube Root of Unity",
       "startLine": 1,
-      "endLine": 80,
+      "endLine": 82,
       "summary": "Defines $\\omega = e^{2\\pi i/3}$ and proves the fundamental identities: $\\omega^3 = 1$, $\\omega \\neq 1$, $1 + \\omega + \\omega^2 = 0$, $\\omega^2 + \\omega = -1$, and $\\omega^4 = \\omega$",
       "mathContext": "Defines $\\omega = e^{2\\pi i/3}$ and proves the fundamental identities: $\\omega^3 = 1$, $\\omega \\neq 1$, $1 + \\omega + \\omega^2 = 0$, $\\omega^2 + \\omega = -1$, and $\\omega^4 = \\omega$"
     },
     {
       "id": "cardano-roots",
       "title": "Section II: The Three Cardano Roots",
-      "startLine": 81,
-      "endLine": 96,
+      "startLine": 84,
+      "endLine": 95,
       "summary": "Defines the three roots: $x_1 = u + v$, $x_2 = \\omega u + \\omega^2 v$, $x_3 = \\omega^2 u + \\omega v$",
       "mathContext": "The choice of pairing (root $k$ uses $\\omega^k u + \\omega^{2k} v$) ensures $uv = -p/3$ is preserved for all three root pairs, which is essential for Vieta II."
     },
@@ -108,23 +108,23 @@
       "id": "vieta-sum",
       "title": "Section III: Vieta I — Sum of Roots",
       "startLine": 97,
-      "endLine": 110,
+      "endLine": 108,
       "summary": "$x_1 + x_2 + x_3 = (1+\\omega+\\omega^2)(u+v) = 0$. Proved via linear_combination with omega_sum",
       "mathContext": "For a monic polynomial $x^n + a_{n-1}x^{n-1} + \\cdots$, the sum of roots equals $-a_{n-1}$. Here $a_{n-1} = 0$ (no $x^2$ term)."
     },
     {
       "id": "vieta-pairs",
       "title": "Section IV: Vieta II — Sum of Pairwise Products",
-      "startLine": 111,
-      "endLine": 135,
+      "startLine": 110,
+      "endLine": 132,
       "summary": "After expanding, the $u^2$ and $v^2$ coefficients are $(1+\\omega+\\omega^2) = 0$, and the $uv$ coefficient reduces to $-3$ via $\\omega^3 = 1$ and $\\omega^4 = \\omega$. With $uv = -p/3$, this gives $p$",
       "mathContext": "The second elementary symmetric polynomial $\\sigma_2 = \\sum_{i<j} x_i x_j$ equals the coefficient of $x$ in the monic depressed cubic."
     },
     {
       "id": "vieta-product",
       "title": "Section V: Vieta III — Product of All Roots",
-      "startLine": 136,
-      "endLine": 153,
+      "startLine": 134,
+      "endLine": 152,
       "summary": "The triple product expands with cross-terms ($u^2 v$, $uv^2$) that vanish by $1+\\omega+\\omega^2 = 0$, leaving $\\omega^3(u^3+v^3) = u^3 + v^3 = -q$",
       "mathContext": "The third elementary symmetric polynomial $\\sigma_3 = x_1 x_2 x_3$ equals $(-1)^3$ times the constant term, giving $-q$."
     },
@@ -132,15 +132,15 @@
       "id": "factorization",
       "title": "Section VI: Polynomial Factorization",
       "startLine": 154,
-      "endLine": 172,
+      "endLine": 174,
       "summary": "Combines all three Vieta formulas with the expansion $(x-r_1)(x-r_2)(x-r_3) = x^3 - \\sigma_1 x^2 + \\sigma_2 x - \\sigma_3$ to prove $x^3 + px + q = (x - x_1)(x - x_2)(x - x_3)$",
       "mathContext": "This is the fundamental theorem of algebra applied to degree 3: every cubic over $\\mathbb{C}$ splits into linear factors."
     },
     {
       "id": "roots-satisfy",
       "title": "Section VII: Root Verification",
-      "startLine": 173,
-      "endLine": 187,
+      "startLine": 176,
+      "endLine": 185,
       "summary": "As a corollary of the factorization, all three Cardano roots satisfy $x_i^3 + px_i + q = 0$",
       "mathContext": "Each root is a zero of the polynomial because the factorization puts $(x - x_i)$ as a factor."
     }


### PR DESCRIPTION
Enrichment pass for solution-of-cubic-oq-03 (Vieta's formulas for the Cardano roots).

## Drift fix
The Lean file had shifted relative to the annotation anchors: **7 of 10 annotations were misaligned** (startLines landing on blank lines just before each construct's doc-comment). Re-anchored all 7 onto their doc-comment/declaration lines.
- Resolver before: Valid 3, Misaligned 7
- Resolver after: **Valid 10, Misaligned 0**

Also tightened all 7 `sections` boundaries to match exact construct spans.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 10/10 annotations valid, 0 misaligned.
- No content changed beyond line ranges.