### PR TITLE
research(feuerbach-oq-02-murakami): gallery entry for verified trirectangular Grace theorem

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02-murakami/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02-murakami/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "feuerbachs-theorem-oq-02-murakami",
+    "range": {
+      "startLine": 1,
+      "endLine": 74
+    },
+    "type": "concept",
+    "title": "Trirectangular Setup and the D-Homothety Tangent-Sphere Pair",
+    "content": "The doc-comment fixes the trirectangular tetrahedron D=(0,0,0), A=(a,0,0), B=(0,b,0), C=(0,0,c) with a,b,c>0, and records the closed forms it will verify: the sphere through A,B,C has rational centre Θ=((a+b)(a+c),(a+b)(b+c),(a+c)(b+c))/(2σ) and radius R=(a²+b²+c²+ab+bc+ca)/(2σ), σ=a+b+c, while the insphere and D-exsphere carry the surd t=√(a²b²+b²c²+c²a²) with radii ρin=(ab+bc+ca−t)/(2σ) and ρex=(ab+bc+ca+t)/(2σ). The reference is Maehara & Martini, 'Tangent Spheres of Tetrahedra and a Theorem of Grace' (Amer. Math. Monthly 127(10), 2020).",
+    "mathContext": "The insphere and D-exsphere both lie on the diagonal direction (1,1,1) and form a homothety pair centred at D. This is the structural reason a single sphere through the opposite face A,B,C can be internally tangent to both: the construction is the trirectangular instance of Grace's theorem.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "trirectangular tetrahedron",
+      "Grace's theorem",
+      "insphere",
+      "exsphere",
+      "homothety",
+      "Maehara-Martini (2020)"
+    ],
+    "prerequisites": [
+      "feuerbachs-theorem",
+      "tetrahedron geometry",
+      "sphere tangency"
+    ]
+  },
+  {
+    "id": "ann-grace-theorem",
+    "proofId": "feuerbachs-theorem-oq-02-murakami",
+    "range": {
+      "startLine": 75,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "grace_feuerbach_trirectangular: Five Identities, One Sphere",
+    "content": "The single theorem bundles five real identities: three incidence goals ((qx−a)²+qy²+qz²=R² and cyclically for B, C) asserting the sphere passes through A, B, C, and two tangency goals ((qx−ρ)²+(qy−ρ)²+(qz−ρ)²=(R−ρ)² for ρ∈{ρin,ρex}) asserting internal tangency to the insphere and the D-exsphere. The surd is encoded as the hypothesis t²=a²b²+b²c²+c²a² (with t≥0), turning a √-problem into a field identity. After `have hσ : a+b+c ≠ 0 := by positivity` and substituting the closed forms, the proof splits into five goals closed by `field_simp; ring` (incidence) and `field_simp; linear_combination 2 * ht` (tangency).",
+    "mathContext": "Each incidence identity is a rational-function identity that becomes a pure polynomial identity once the shared 2σ denominator is cleared, hence ring closes it. Each tangency identity holds only modulo the surd relation: linear_combination 2*ht supplies exactly the multiple of (t² − (a²b²+b²c²+c²a²)) needed, the integer coefficient 2 being the post-field_simp image of the analytic factor 1/(2σ²).",
+    "significance": "central",
+    "relatedConcepts": [
+      "incidence identity",
+      "internal tangency",
+      "surd encoding",
+      "linear_combination",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "polynomial identities",
+      "sphere tangency",
+      "Real.sqrt"
+    ]
+  },
+  {
+    "id": "ann-surd-cancellation",
+    "proofId": "feuerbachs-theorem-oq-02-murakami",
+    "range": {
+      "startLine": 93,
+      "endLine": 100
+    },
+    "type": "insight",
+    "title": "Why One Sphere Touches Both: Even-in-t Cancellation",
+    "content": "The closing notes record the build status (Lean-checked GREEN 2026-06-15, 0 sorry / 0 axiom, registered in Proofs.lean; symbolic certificate verify_grace_proof_certificate.py 15/15 PASS) and explain the coefficient discipline: a BARE `linear_combination (1/(2σ²)) * ht` fails because ring treats (2σ)⁻¹² and (2σ²)⁻¹ as distinct opaque atoms, so denominators must be cleared by field_simp first, after which the ht-coefficient is the integer 2. The SAME Θ, R close both tangency goals because the odd-in-t part of each tangency residual is identically zero.",
+    "mathContext": "Writing each tangency residual as Eeven(a,b,c) + t·Eodd(a,b,c), the surd cancellation is exactly Eodd ≡ 0; the involution t ↦ −t then swaps the insphere identity (ρin) with the D-exsphere identity (ρex), so proving one proves the other. This even/odd decomposition is the 3D analogue of the 2D Feuerbach circle touching both the incircle and an excircle.",
+    "significance": "central",
+    "relatedConcepts": [
+      "surd cancellation",
+      "even-odd decomposition",
+      "involution t ↦ −t",
+      "proof certificate"
+    ],
+    "prerequisites": [
+      "linear_combination",
+      "ring normalization"
+    ]
+  }
+]

--- a/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "feuerbachs-theorem-oq-02-murakami",
+  "title": "Grace's Theorem (3D Feuerbach) for the Trirectangular Tetrahedron",
+  "slug": "feuerbachs-theorem-oq-02-murakami",
+  "description": "A verified positive 3D analogue of Feuerbach's theorem for the trirectangular tetrahedron (right-angle vertex at the origin, mutually perpendicular legs a, b, c). The sphere through the opposite-face vertices A, B, C is internally tangent to BOTH the insphere and the D-exsphere, and its centre Θ and radius R are RATIONAL in (a, b, c) — the tangency surd t = √(a²b²+b²c²+c²a²) cancels. This is the elementary trirectangular case of Grace's theorem (Maehara–Martini 2020), the special case where the general 3D Feuerbach question (refuted for the N₂₄ candidate in feuerbachs-theorem-oq-02) admits a clean positive answer.",
+  "meta": {
+    "author": "Grace (1917); Maehara & Martini (2020)",
+    "date": "2026-06-15",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "solid-geometry",
+      "tetrahedra",
+      "feuerbach",
+      "tangency",
+      "trirectangular",
+      "sphere",
+      "insphere-exsphere"
+    ],
+    "proofRepoPath": "Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "linear_combination",
+        "description": "Tactic for closing polynomial identities modulo a hypothesis (here the surd relation t² = a²b²+b²c²+c²a²)",
+        "module": "Mathlib.Tactic.LinearCombination"
+      },
+      {
+        "theorem": "field_simp",
+        "description": "Clears denominators (the shared 2σ = 2(a+b+c)) to reduce rational-function goals to ring identities",
+        "module": "Mathlib.Tactic.FieldSimp"
+      }
+    ],
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "lineCount": 125,
+    "assumptions": "None beyond the geometric hypotheses a, b, c > 0 and the surd encoding t² = a²b²+b²c²+c²a² with t ≥ 0 (t is the genuine tangency surd, not an added assumption). 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries. Build verified GREEN (Docker, 2026-06-15) and registered in Proofs.lean.",
+    "originalContributions": [
+      "Lean 4 formalization of the trirectangular case of Grace's theorem: a single bundled theorem stating the three incidence identities (sphere through A, B, C) and two internal-tangency identities (to the insphere and the D-exsphere) over real variables a, b, c with the tangency surd encoded as t² = a²b²+b²c²+c²a²",
+      "Demonstrates the surd cancellation that makes the sphere's centre Θ = ((a+b)(a+c), (a+b)(b+c), (a+c)(b+c))/(2σ) and radius R = (a²+b²+c²+ab+bc+ca)/(2σ) rational in the leg data, the 3D analogue of the rational nine-point centre in 2D",
+      "Establishes the proof discipline (field_simp to clear the shared 2σ denominator, then ring for incidence and linear_combination 2·ht for tangency) that survives Lean's treatment of (2σ)⁻¹ as an opaque atom — a bare linear_combination with an inverse-denominator coefficient fails ring",
+      "Provides a verified positive counterpart to feuerbachs-theorem-oq-02, which refutes the (N₂₄, R/3) candidate sphere: the trirectangular tetrahedron is a tractable class where a correct Feuerbach-type sphere provably exists"
+    ],
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Feuerbach's theorem (1822) — that a triangle's nine-point circle is tangent to its incircle and three excircles — has long invited a 3D analogue for tetrahedra (Court 1934, Murakami 1952). The companion entry feuerbachs-theorem-oq-02 shows the naive candidate (the (N₂₄, R/3)-sphere) is FALSE even for orthocentric tetrahedra. Grace's theorem (1917), revisited with an elementary trirectangular proof by Maehara & Martini (Amer. Math. Monthly 127(10):897–910, 2020), gives a genuine positive analogue: for a tetrahedron there is a sphere through one face's vertices that is internally tangent to a homothetic tangent-sphere pair. This entry formalizes the cleanest case — the trirectangular (right-corner) tetrahedron — where every quantity is explicit and the tangency surd cancels.",
+    "problemStatement": "For the trirectangular tetrahedron with vertices A=(a,0,0), B=(0,b,0), C=(0,0,c), D=(0,0,0) (a,b,c > 0), is the sphere through A, B, C that is internally tangent to the insphere also internally tangent to the D-exsphere, and are its centre and radius rational in (a,b,c)?",
+    "text": "Yes. With t = √(a²b²+b²c²+c²a²), σ = a+b+c, the sphere of centre Θ = ((a+b)(a+c), (a+b)(b+c), (a+c)(b+c))/(2σ) and radius R = (a²+b²+c²+ab+bc+ca)/(2σ) passes through A, B, C and is internally tangent to BOTH the insphere (centre ρin·(1,1,1), ρin = (ab+bc+ca − t)/(2σ)) and the D-exsphere (centre ρex·(1,1,1), ρex = (ab+bc+ca + t)/(2σ)). The surd t appears in the two tangent spheres but cancels from Θ and R.",
+    "proofStrategy": "State the five defining identities as one theorem over real variables, encoding the tangency surd by the relation t² = a²b²+b²c²+c²a². Substitute the closed forms for Θ, R, ρin, ρex; clear the shared denominator 2σ with field_simp (σ ≠ 0 by positivity). The three incidence goals then close by ring (pure polynomial identities). The two tangency goals close by linear_combination 2·ht: their t²-terms reduce via the surd relation and their odd-in-t parts vanish identically, which is exactly why the SAME centre and radius serve both the insphere and the D-exsphere (the involution t ↦ −t swaps them).",
+    "keyInsights": [
+      "The tangency surd t = √(a²b²+b²c²+c²a²) cancels from the centre Θ and radius R, leaving them rational in (a,b,c) — the 3D echo of the rational 2D nine-point centre",
+      "One sphere is internally tangent to BOTH the insphere and the D-exsphere because the odd-in-t part of each tangency residual is identically zero; the involution t ↦ −t maps the insphere identity to the D-exsphere identity",
+      "Encoding the surd as the polynomial relation t² = a²b²+b²c²+c²a² turns a problem about √ into a pure (field) ring-identity problem closable by linear_combination",
+      "Clearing denominators with field_simp BEFORE linear_combination is essential: ring treats (2σ)⁻¹ and (2σ²)⁻¹ as distinct opaque atoms, so the post-clear ht-coefficient must be the integer 2, not 1/(2σ²)",
+      "At the base point (a,b,c) = (2,3,6): Θ = (40,45,72)/22 and R = 85/22, the explicitly checked instance"
+    ],
+    "prerequisites": [
+      "Feuerbach's theorem (2D case)",
+      "Euclidean geometry in R^3",
+      "Tetrahedron geometry (insphere, exsphere)",
+      "Sphere tangency"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-setup",
+      "title": "Statement Setup and Geometric Data",
+      "startLine": 1,
+      "endLine": 74,
+      "summary": "Doc-comment fixing the trirectangular tetrahedron A=(a,0,0), B=(0,b,0), C=(0,0,c), D=0, and recording the closed forms for the tangent sphere centre Θ, radius R, and the insphere/D-exsphere radii ρin, ρex (carrying the surd t). Lists the prior S0–S7 hand/numeric verification and the Maehara–Martini reference, then the Mathlib import and pretty-printing options.",
+      "mathContext": "The trirectangular tetrahedron is the simplest non-degenerate tetrahedron with a clean Feuerbach analogue: legs along the coordinate axes make every distinguished sphere explicit. The insphere and D-exsphere form a D-homothety pair, both centred on the diagonal (1,1,1) direction, which is what lets a single sphere through A,B,C be tangent to both."
+    },
+    {
+      "id": "grace-theorem",
+      "title": "Grace's Theorem (Trirectangular): the Five Defining Identities",
+      "startLine": 75,
+      "endLine": 100,
+      "summary": "The theorem grace_feuerbach_trirectangular bundles five real identities under the hypotheses a,b,c>0, t²=a²b²+b²c²+c²a², t≥0 and the closed forms for Θ=(qx,qy,qz), R, ρin, ρex: (1)–(3) the sphere passes through A, B, C; (4) it is internally tangent to the insphere; (5) it is internally tangent to the D-exsphere. Proof: σ≠0 by positivity, substitute the closed forms, then field_simp;ring for incidence and field_simp;linear_combination 2*ht for tangency.",
+      "mathContext": "Each incidence goal (qx−a)²+qy²+qz² = R² (and cyclic) is a rational-function identity in (a,b,c) that becomes a polynomial identity after clearing 2σ. Each tangency goal (qx−ρ)²+(qy−ρ)²+(qz−ρ)² = (R−ρ)² holds modulo the single surd relation t²=a²b²+b²c²+c²a²; the linear_combination coefficient 2 is the post-field_simp image of the analytic 1/(2σ²)."
+    },
+    {
+      "id": "proof-notes",
+      "title": "Proof Notes: Coefficient Discipline and Surd Cancellation",
+      "startLine": 101,
+      "endLine": 125,
+      "summary": "Commentary recording that the build is GREEN (Lean-checked 2026-06-15, 0 sorry / 0 axiom, registered in Proofs.lean) and corroborated by the symbolic certificate verify_grace_proof_certificate.py (15/15 PASS). Explains why the incidence goals are genuine 2σ-cleared identities (not bare (a+b+c)⁻² identities) and why each tangency goal needs field_simp before linear_combination 2*ht.",
+      "mathContext": "The even-in-t cancellation (odd-in-t part ≡ 0; the even part forcing the shared pencil constant G = abc/σ) is the structural reason the SAME Θ, R are tangent to both spheres of the D-homothety pair. This mirrors the 2D Feuerbach mechanism where one circle touches both incircle and an excircle."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Complements OQ-02's refutation of the (N₂₄, R/3) candidate with a verified POSITIVE 3D Feuerbach result for the trirectangular tetrahedron (Grace's theorem)"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "answers-question",
+      "description": "Gives a positive special-case answer to OQ-02 ('What is the 3D analogue of Feuerbach's theorem for tetrahedra?') via Grace's theorem for trirectangular tetrahedra"
+    }
+  ],
+  "conclusion": {
+    "summary": "For the trirectangular tetrahedron, a single sphere through the opposite-face vertices A, B, C is internally tangent to both the insphere and the D-exsphere, with rational centre Θ and radius R despite the irrational radii of the two tangent spheres. The result is fully machine-checked in Lean (0 sorry, 0 axiom) and is the elementary trirectangular case of Grace's theorem.",
+    "implications": "Where feuerbachs-theorem-oq-02 shows the naive (N₂₄, R/3) candidate fails, this entry exhibits a tractable tetrahedron class where a correct Feuerbach-type tangency provably holds. The surd-cancellation mechanism (encode t by t², clear denominators, close by linear_combination) is a reusable template for tangency identities involving square-root radii.",
+    "openQuestions": [
+      "Extend the verified positive result from the trirectangular class to general orthocentric (or isodynamic) tetrahedra.",
+      "Formalize Grace's theorem in its full generality (Maehara–Martini), of which the trirectangular case is the elementary instance.",
+      "Relate the rational centre Θ to a canonical tetrahedron centre (the analogue of the nine-point centre)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Real",
+      "Nat",
+      "Classical",
+      "Pointwise"
+    ],
+    "namespace": "FeuerbachOQ02MurakamiStatement",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "substantiveTheoremCount": 1,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "mainTheorems": [
+    {
+      "name": "grace_feuerbach_trirectangular",
+      "type": "core",
+      "description": "For the trirectangular tetrahedron with legs a,b,c>0, the sphere of centre Θ=((a+b)(a+c),(a+b)(b+c),(a+c)(b+c))/(2σ) and radius R=(a²+b²+c²+ab+bc+ca)/(2σ) passes through A=(a,0,0), B=(0,b,0), C=(0,0,c) and is internally tangent to both the insphere (radius ρin=(ab+bc+ca−t)/(2σ)) and the D-exsphere (radius ρex=(ab+bc+ca+t)/(2σ)), where t=√(a²b²+b²c²+c²a²). Proved by field_simp;ring (incidence) and field_simp;linear_combination 2*ht (tangency).",
+      "leanType": "(a b c t : ℝ) → 0 < a → 0 < b → 0 < c → t^2 = a^2*b^2+b^2*c^2+c^2*a^2 → 0 ≤ t → (qx qy qz R ρin ρex : ℝ) → … → (incidence A ∧ incidence B ∧ incidence C ∧ tangent insphere ∧ tangent D-exsphere)"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/feuerbachs-theorem-oq-02-murakami.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02-murakami.json
@@ -1,8 +1,8 @@
 {
   "slug": "feuerbachs-theorem-oq-02-murakami",
   "title": "3D Feuerbach analogue for tetrahedra (Murakami / Court / Mannheim)",
-  "phase": "DECOMPOSE",
-  "status": "in-progress",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "scope-then-formalize",
   "problemStatement": {
@@ -36,9 +36,10 @@
     "goal": "Land a positive 3D Feuerbach theorem in FeuerbachsTheoremOQ02.lean (or a sibling file), restoring the gallery entry from 'axiomatized via refutation' to a verified positive result."
   },
   "currentState": {
-    "phase": "ACT (axiom-discharge transcribed; build-pending under Docker/Aristotle blackout)",
-    "since": "2026-06-15T00:00:00.000Z",
-    "iteration": 6,
+    "phase": "COMPLETE (positive Grace result verified, registered, and GALLERIED 2026-06-16)",
+    "since": "2026-06-16T00:00:00.000Z",
+    "iteration": 7,
+    "completion": "S13 (2026-06-16, researcher-1): created the gallery entry src/data/proofs/feuerbachs-theorem-oq-02-murakami/ (meta.json + 3 resolver-aligned annotations) for the verified, Docker-green (2026-06-15), 0-sorry/0-axiom grace_feuerbach_trirectangular theorem (registered in Proofs.lean via PR #24874). The slug's positive deliverable — Grace's theorem (3D Feuerbach) for the trirectangular tetrahedron — is now COMPLETE and presented in the gallery (status verified / badge original). The previously-tracked parent-axiom elimination (replace axiom feuerbach_3d_fails_general in FeuerbachsTheoremOQ02.lean:581 with the sorry-free witness file) is a SEPARATE task belonging to the parent slug feuerbachs-theorem-oq-02, gated on a Docker build; it does not block this slug's completion. Validation: node JSON.parse + resolver.ts validate (3 valid, 0 misaligned), no Docker/pnpm build required.",
     "focus": "S11 (2026-06-15, build-free, sympy-certified): DISCHARGED the lone remaining sorry in witnessT1_fails (StatementOnly_FeuerbachOQ02_FailsGeneralWitness.lean) — the non-tangency half of the parent axiom feuerbach_3d_fails_general at witness T1=(0,0,0),(1,0,0),(0,1,0),(1,1,1). Transcribed closed forms of all four invariants as separate lemmas (faceAreas √3/2,√2/2,√2/2,1/2; volume 1/6; surfaceArea (1+√3+2√2)/2; inradius 1/(1+√3+2√2); circumcenter (1/2,1/2,1/2) rational via Cramer; circumradius √3/2; twentyFourPointRadius √3/6; twentyFourPointCenter (1/2,1/2,0) rational; incenter ((1+√2)/Δ,(1+√2)/Δ,1/Δ)). Non-tangency: square dist(N24,I)=|R/3-r| via dist3_sq_eq+sq_abs, put both sides over 36Δ² as pure rational identities (field_simp;ring, NO surd-square), reduce to (bΔ-6)²<18((1-b)²+2) which is the exact polynomial identity hid mod a²=2,b²=3 (a=√2,b=√3) — linear_combination (-4b²)·ha2+(-4ab-4a-b²-2b+18)·hb2 — plus numeric bounds √2<1.41422,√3<1.7321,√6>2.4494 (same 72-30√3-12√2+12√6>0 kernel as witnessT1_surd_separation). feuerbach_3d_fails_general_proved then discharges the parent existence axiom outright. Every algebraic identity sympy-certified in proofs/scripts/verify_feuerbach3d_fails_witness_exact.py (ALL CHECKS PASS incl. S11 hd/he/hid). BUILD-PENDING (Docker info exit124, Aristotle prove_file 'Resource not found'): not yet compiler-checked. File is UNREGISTERED in Proofs.lean so zero gallery-build risk. Once green, replace parent axiom feuerbach_3d_fails_general with feuerbach_3d_fails_general_proved (axiom elimination, OQ02 parent → 0 axioms).",
     "blockers": [
       "S8 (Lean compilation) is Docker-gated: verification infra is down (2026-06-13 blackout). The S4 (T0) AND S7 (general trirectangular) closed-form/statement work is build-free and complete; transcribing the general statement+proof to Lean must wait for Docker. The identities are pure algebra over the field extension by t=sqrt(a^2 b^2+b^2 c^2+c^2 a^2), so the eventual Lean proof is ring/norm_num and carries no remaining mathematical risk.",
@@ -149,8 +150,10 @@
     ]
   },
   "started": "2026-05-08T00:00:00Z",
-  "lastUpdate": "2026-06-15",
+  "lastUpdate": "2026-06-16",
   "significance": 7,
   "tractability": 4,
-  "leanFiles": []
+  "leanFiles": [
+    "Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean"
+  ]
 }


### PR DESCRIPTION
## Summary

The slug `feuerbachs-theorem-oq-02-murakami` has a **verified, registered, Docker-green** headline theorem (`grace_feuerbach_trirectangular`, 0 sorry / 0 axiom, in `Proofs.lean` via #24874) but **no gallery entry**. This PR adds one — a blackout-proof contribution (no Docker / no `pnpm build` needed).

- **meta.json** — status `verified` / badge `original`, `axiomCount: 0`. Honest scope: this is the **trirectangular special case** of Grace's theorem (the genuine 3D Feuerbach tangency analogue; Maehara–Martini, AMM 2020), the complement to the parent `feuerbachs-theorem-oq-02` which *refutes* the naive `(N₂₄, R/3)` candidate.
- **annotations.json** — 3 annotations, resolver-aligned (**3 valid / 0 misaligned**).
- Graduates the research registry to `status=completed` / `phase=COMPLETE`.

The result: the sphere through opposite-face vertices A, B, C is internally tangent to **both** the insphere and the D-exsphere, with rational centre/radius (the tangency surd `t=√(a²b²+b²c²+c²a²)` cancels).

## Scope note

The separate **parent-axiom elimination** (`feuerbach_3d_fails_general` in `FeuerbachsTheoremOQ02.lean:581`) belongs to the parent slug and is gated on a Docker build — it does **not** block this slug's completion.

## Test plan

- [x] `node JSON.parse` on meta.json + annotations.json + registry json — all OK.
- [x] `npx tsx scripts/annotations/resolver.ts validate` — 3 valid / 0 misaligned.
- [ ] (deployer) `pnpm build` to confirm gallery renders the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)