### PR TITLE
research(dilworth-oq-01): Mirsky hard direction (attainment), build-pending orphan

### DIFF
--- a/proofs/Proofs/DilworthMirskyHardOQ01.lean
+++ b/proofs/Proofs/DilworthMirskyHardOQ01.lean
@@ -1,0 +1,215 @@
+/-
+  Mirsky's Theorem — the HARD direction (attainment), for a finite poset.
+  (dilworth-theorem-oq-01, follow-up)
+
+  ## Background
+
+  The companion file `Proofs.DilworthTheoremOQ01` proves the *easy* directions
+  of the Dilworth/Mirsky dualities: a chain and an antichain meet in at most one
+  point, hence every chain is no larger than any antichain cover
+  (`chain_card_le_of_antichainCover`).
+
+  Mirsky's theorem (1971) states that on a finite poset the **minimum number of
+  antichains needed to cover the poset equals the maximum length of a chain**.
+  The easy direction gives `maxChainLen ≤ (any antichain cover).card`.  This file
+  supplies the *hard* direction: a cover by exactly `maxChainLen` antichains
+  actually exists, so the minimum is attained.
+
+  ## Method (height / level decomposition)
+
+  For each element `x` set
+
+      `height x = max { |C| : C a chain whose maximum element is x }`.
+
+  Then:
+
+  * `1 ≤ height x ≤ maxChainLen`  (a singleton is such a chain; any such chain is
+    a chain of the whole poset).
+  * The level set `level k = { x : height x = k }` is an **antichain**: if
+    `x < y` with `height x = height y = k`, append `y` to a longest chain ending
+    at `x` to get a chain of length `k+1` ending at `y`, forcing
+    `height y ≥ k+1`, a contradiction.
+
+  The `maxChainLen` nonempty levels `level 1, …, level maxChainLen` therefore
+  cover the poset, giving `mirsky_antichain_cover`.  Combined with the easy
+  direction we obtain `mirsky_min_antichain_cover`: this cover is minimal and has
+  size exactly `maxChainLen`.
+
+  ## Status: research orphan (UNREGISTERED, build-pending).  0 axioms, 0 sorries.
+-/
+import Proofs.DilworthTheoremOQ01
+
+open Classical
+
+namespace DilworthTheoremOQ01
+
+variable {α : Type*} [PartialOrder α] [Fintype α]
+
+/-- Chains whose maximum element is `x`: chains `C` with `x ∈ C` and every member
+    of `C` below `x`. -/
+noncomputable def chainsTo (x : α) : Finset (Finset α) :=
+  Finset.univ.powerset.filter (fun C => IsChainOn C ∧ x ∈ C ∧ ∀ z ∈ C, z ≤ x)
+
+/-- `height x` = the size of a longest chain whose maximum element is `x`. -/
+noncomputable def height (x : α) : ℕ := (chainsTo x).sup Finset.card
+
+/-- All chains of the (finite) poset. -/
+noncomputable def allChains : Finset (Finset α) :=
+  Finset.univ.powerset.filter (fun C => IsChainOn C)
+
+/-- The maximum length of a chain. -/
+noncomputable def maxChainLen : ℕ := (allChains (α := α)).sup Finset.card
+
+theorem mem_chainsTo {x : α} {C : Finset α} :
+    C ∈ chainsTo x ↔ IsChainOn C ∧ x ∈ C ∧ ∀ z ∈ C, z ≤ x := by
+  unfold chainsTo
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨fun h => h.2, fun h => ⟨Finset.subset_univ _, h⟩⟩
+
+/-- A singleton is a chain whose maximum element is `x`. -/
+theorem singleton_mem_chainsTo (x : α) : ({x} : Finset α) ∈ chainsTo x := by
+  rw [mem_chainsTo]
+  refine ⟨?_, Finset.mem_singleton_self x, ?_⟩
+  · intro a ha b hb
+    rw [Finset.mem_singleton] at ha hb
+    subst ha; subst hb; exact Or.inl le_rfl
+  · intro z hz
+    rw [Finset.mem_singleton] at hz; subst hz; exact le_rfl
+
+theorem chainsTo_nonempty (x : α) : (chainsTo x).Nonempty :=
+  ⟨{x}, singleton_mem_chainsTo x⟩
+
+theorem one_le_height (x : α) : 1 ≤ height x := by
+  have h := Finset.le_sup (f := Finset.card) (singleton_mem_chainsTo x)
+  rw [Finset.card_singleton] at h
+  exact h
+
+/-- The supremum defining `height` is attained by an actual chain. -/
+theorem exists_chainsTo_card_eq_height (x : α) :
+    ∃ C ∈ chainsTo x, C.card = height x := by
+  obtain ⟨C, hC, hCard⟩ :=
+    Finset.exists_mem_eq_sup (chainsTo x) (chainsTo_nonempty x) Finset.card
+  exact ⟨C, hC, hCard.symm⟩
+
+theorem height_le_maxChainLen (x : α) : height x ≤ maxChainLen := by
+  unfold height maxChainLen
+  apply Finset.sup_mono
+  intro C hC
+  rw [mem_chainsTo] at hC
+  unfold allChains
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.subset_univ _, hC.1⟩
+
+/-- The `k`-th level: elements of height exactly `k`. -/
+noncomputable def level (k : ℕ) : Finset α := Finset.univ.filter (fun x => height x = k)
+
+theorem mem_level {k : ℕ} {x : α} : x ∈ level k ↔ height x = k := by
+  unfold level
+  rw [Finset.mem_filter]
+  exact ⟨fun h => h.2, fun h => ⟨Finset.mem_univ _, h⟩⟩
+
+/-- **Key lemma.**  Each level set is an antichain. -/
+theorem level_isAntichain (k : ℕ) : IsAntichainOn (level k) := by
+  intro x hx y hy hxy
+  rw [mem_level] at hx hy
+  by_contra hne
+  have hxlty : x < y := lt_of_le_of_ne hxy hne
+  obtain ⟨C, hC, hCcard⟩ := exists_chainsTo_card_eq_height x
+  rw [mem_chainsTo] at hC
+  obtain ⟨hChain, _hxmem, hCle⟩ := hC
+  have hyC : y ∉ C := by
+    intro hyC'
+    exact absurd (hCle y hyC') hxlty.not_ge
+  have hC' : insert y C ∈ chainsTo y := by
+    rw [mem_chainsTo]
+    refine ⟨?_, Finset.mem_insert_self y C, ?_⟩
+    · intro a ha b hb
+      rw [Finset.mem_insert] at ha hb
+      rcases ha with rfl | haC
+      · rcases hb with rfl | hbC
+        · exact Or.inl le_rfl
+        · exact Or.inr ((hCle b hbC).trans hxlty.le)
+      · rcases hb with rfl | hbC
+        · exact Or.inl ((hCle a haC).trans hxlty.le)
+        · exact hChain haC hbC
+    · intro z hz
+      rw [Finset.mem_insert] at hz
+      rcases hz with rfl | hzC
+      · exact le_rfl
+      · exact (hCle z hzC).trans hxlty.le
+  have hge : (insert y C).card ≤ height y := Finset.le_sup hC'
+  rw [Finset.card_insert_of_notMem hyC, hCcard, hx] at hge
+  omega
+
+/-- **Mirsky, hard direction.**  A finite poset is covered by at most
+    `maxChainLen` antichains. -/
+theorem mirsky_antichain_cover :
+    ∃ 𝒜 : Finset (Finset α),
+      (∀ A ∈ 𝒜, IsAntichainOn A) ∧
+      (∀ x : α, ∃ A ∈ 𝒜, x ∈ A) ∧
+      𝒜.card ≤ maxChainLen := by
+  refine ⟨(Finset.univ.image height).image level, ?_, ?_, ?_⟩
+  · intro A hA
+    rw [Finset.mem_image] at hA
+    obtain ⟨k, _, rfl⟩ := hA
+    exact level_isAntichain k
+  · intro x
+    refine ⟨level (height x), ?_, ?_⟩
+    · rw [Finset.mem_image]
+      exact ⟨height x, Finset.mem_image_of_mem height (Finset.mem_univ x), rfl⟩
+    · exact mem_level.mpr rfl
+  · calc ((Finset.univ.image height).image level).card
+        ≤ (Finset.univ.image height).card := Finset.card_image_le
+      _ ≤ (Finset.Icc 1 maxChainLen).card := by
+          apply Finset.card_le_card
+          intro k hk
+          rw [Finset.mem_image] at hk
+          obtain ⟨x, _, rfl⟩ := hk
+          rw [Finset.mem_Icc]
+          exact ⟨one_le_height x, height_le_maxChainLen x⟩
+      _ = maxChainLen := by rw [Nat.card_Icc]; omega
+
+/-- `maxChainLen` is attained by an actual chain. -/
+theorem exists_chain_card_eq_maxChainLen :
+    ∃ C : Finset α, IsChainOn C ∧ C.card = maxChainLen := by
+  have hne : (allChains (α := α)).Nonempty := by
+    refine ⟨∅, ?_⟩
+    unfold allChains
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨Finset.empty_subset _, ?_⟩
+    intro a ha; exact absurd ha (Finset.notMem_empty a)
+  obtain ⟨C, hC, hCard⟩ :=
+    Finset.exists_mem_eq_sup (allChains (α := α)) hne Finset.card
+  unfold allChains at hC
+  rw [Finset.mem_filter, Finset.mem_powerset] at hC
+  exact ⟨C, hC.2, hCard.symm⟩
+
+/-- The easy direction, re-stated: any antichain cover has at least
+    `maxChainLen` members. -/
+theorem maxChainLen_le_card_of_antichainCover {𝒜 : Finset (Finset α)}
+    (hanti : ∀ A ∈ 𝒜, IsAntichainOn A) (hcover : ∀ x : α, ∃ A ∈ 𝒜, x ∈ A) :
+    maxChainLen ≤ 𝒜.card := by
+  obtain ⟨C, hC, hCard⟩ := exists_chain_card_eq_maxChainLen
+  have hcoverC : ∀ c ∈ C, ∃ A ∈ 𝒜, c ∈ A := fun c _ => hcover c
+  have h := chain_card_le_of_antichainCover hC hanti hcoverC
+  rwa [hCard] at h
+
+/-- **Mirsky's theorem.**  There is an antichain cover of size exactly
+    `maxChainLen`, and it is minimal among all antichain covers. -/
+theorem mirsky_min_antichain_cover :
+    ∃ 𝒜 : Finset (Finset α),
+      (∀ A ∈ 𝒜, IsAntichainOn A) ∧
+      (∀ x : α, ∃ A ∈ 𝒜, x ∈ A) ∧
+      𝒜.card = maxChainLen ∧
+      (∀ ℬ : Finset (Finset α),
+        (∀ A ∈ ℬ, IsAntichainOn A) → (∀ x : α, ∃ A ∈ ℬ, x ∈ A) →
+        𝒜.card ≤ ℬ.card) := by
+  obtain ⟨𝒜, hanti, hcover, hle⟩ := mirsky_antichain_cover
+  have hge := maxChainLen_le_card_of_antichainCover hanti hcover
+  have hcard : 𝒜.card = maxChainLen := le_antisymm hle hge
+  refine ⟨𝒜, hanti, hcover, hcard, ?_⟩
+  intro ℬ hℬanti hℬcover
+  rw [hcard]
+  exact maxChainLen_le_card_of_antichainCover hℬanti hℬcover
+
+end DilworthTheoremOQ01

--- a/research/problems/dilworth-theorem-oq-01/knowledge.md
+++ b/research/problems/dilworth-theorem-oq-01/knowledge.md
@@ -51,3 +51,45 @@ File: `proofs/Proofs/DilworthTheoremOQ01.lean`.
   `<` (finite poset ⇒ `WellFoundedLT`).
 - Dilworth hard direction via König / Hall on the comparability bipartite graph,
   or strong induction removing a maximal chain.
+
+## Session 2026-06-16 (Session 2) — Mirsky hard direction (attainment)
+
+**Mode**: FRESH (revisit of completed easy directions)
+**Outcome**: progress (build-pending orphan; dual Docker+Aristotle blackout)
+
+### What I Did
+- Wrote the **Mirsky hard direction** as an UNREGISTERED orphan
+  `proofs/Proofs/DilworthMirskyHardOQ01.lean` (zero gallery risk while builds are
+  down). Imports `Proofs.DilworthTheoremOQ01` to reuse `IsChainOn`/`IsAntichainOn`
+  and the easy-direction lemma.
+- Key construction (no well-founded recursion needed): for a finite poset
+  (`[Fintype α]`), `height x` is the `Finset.sup` of chain cardinalities over
+  `chainsTo x` = chains whose maximum element is `x`. The sup is attained
+  (`Finset.exists_mem_eq_sup`), supplying an explicit longest chain ending at `x`.
+- Theorems proved (0 sorries / 0 axioms by construction):
+  - `level_isAntichain` — each level `{x : height x = k}` is an antichain.
+  - `mirsky_antichain_cover` — the poset is covered by `≤ maxChainLen` antichains.
+  - `exists_chain_card_eq_maxChainLen`, `maxChainLen_le_card_of_antichainCover`.
+  - `mirsky_min_antichain_cover` — full Mirsky: an antichain cover of size exactly
+    `maxChainLen` exists and is minimal.
+
+### Key Findings
+- The height function does NOT need `WellFoundedLT`/recursion (contra Session 1's
+  plan): a non-recursive `Finset.sup` over `chainsTo x` plus the "sup attained"
+  lemma gives a usable witness chain, and the antichain property follows by
+  appending the larger element.
+- Cover-size bound is purely cardinal: heights lie in `Icc 1 maxChainLen`, so
+  `#(image height) ≤ maxChainLen` via `card_image_le` + `card_le_card`.
+- Pin gotchas (v4.26.0 / 2df2f0150c): `not_le_of_lt`→`not_ge` (used `lt.not_ge`),
+  `card_insert_of_not_mem`→`card_insert_of_notMem`, `not_mem_empty`→`notMem_empty`,
+  `lt_iff_le_not_le`→`lt_iff_le_not_ge`. `not_le` is LinearOrder-only — avoided.
+
+### Files Modified
+- `proofs/Proofs/DilworthMirskyHardOQ01.lean` (new, orphan/unregistered)
+- `src/data/research/problems/dilworth-theorem-oq-01.json` (knowledge)
+
+### Next Steps
+- Build-verify the orphan once Docker is back; then register in `Proofs.lean` and
+  add a gallery dir for the strengthened Mirsky result.
+- Dilworth hard direction (chain cover = max antichain) remains the open frontier
+  — strictly harder (König/Hall), no Mirsky-style elementary height argument.

--- a/src/data/research/problems/dilworth-theorem-oq-01.json
+++ b/src/data/research/problems/dilworth-theorem-oq-01.json
@@ -39,24 +39,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (easy directions): 3 theorems, 2 defs, 0 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: Mirsky hard direction (full theorem incl. minimality) written as build-pending orphan; Dilworth hard direction remains open.",
     "builtItems": [
       "IsChainOn / IsAntichainOn Finset predicates over an arbitrary PartialOrder (DilworthTheoremOQ01.lean)",
       "chain_antichain_inter_subsingleton (DilworthTheoremOQ01.lean)",
       "antichain_card_le_of_chainCover — Dilworth easy direction (DilworthTheoremOQ01.lean)",
-      "chain_card_le_of_antichainCover — Mirsky easy direction (DilworthTheoremOQ01.lean)"
+      "chain_card_le_of_antichainCover — Mirsky easy direction (DilworthTheoremOQ01.lean)",
+      "Mirsky HARD direction (attainment) — orphan DilworthMirskyHardOQ01.lean: height x = max card of chain with top x; level sets are antichains; mirsky_antichain_cover (cover by ≤ maxChainLen antichains) + mirsky_min_antichain_cover (minimal cover, size = maxChainLen)"
     ],
     "insights": [
       "Both inequalities reduce to one pigeonhole step (Finset.exists_ne_map_eq_of_card_lt_of_maps_to); the sole content is the chain∩antichain subsingleton lemma.",
       "Encoding antichains as 'x ≤ y → x = y' for members keeps ≤-reasoning frictionless.",
-      "The Dilworth and Mirsky easy directions are the same proof with chain/antichain exchanged (self-dual)."
+      "The Dilworth and Mirsky easy directions are the same proof with chain/antichain exchanged (self-dual).",
+      "Mirsky hard direction needs no well-founded recursion: define height as a Finset.sup of chain cards over chainsTo x (chains with max element x); sup is attained (Finset.exists_mem_eq_sup), giving a witness chain to extend by y.",
+      "Level-set antichain proof: x<y same height k ⇒ append y to longest chain ending at x ⇒ chain length k+1 ending at y ⇒ height y ≥ k+1 > k, contradiction.",
+      "Cover-size bound is purely cardinal: heights ⊆ Icc 1 maxChainLen, so #(image height) ≤ maxChainLen via card_image_le + card_le_card."
     ],
     "mathlibGaps": [
       "Mathlib (June 2026) has no packaged Dilworth or Mirsky theorem; Set.chainHeight (Order/Height.lean) is the natural hook for a future hard-direction proof."
     ],
     "nextSteps": [
       "Mirsky hard direction via height function h(x)=longest chain ending at x; level sets are antichains partitioning the poset into max-chain-length parts.",
-      "Dilworth hard direction via König/Hall on the comparability graph or induction removing a maximal chain."
+      "Dilworth hard direction via König/Hall on the comparability graph or induction removing a maximal chain.",
+      "Dilworth HARD direction still open (chain cover = max antichain) — needs König/Hall on comparability graph or maximal-chain induction; harder than Mirsky.",
+      "Build-verify DilworthMirskyHardOQ01.lean once Docker is back, then register in Proofs.lean and add gallery dir."
     ],
     "markdown": "See research/problems/dilworth-theorem-oq-01/knowledge.md for the full session log."
   },


### PR DESCRIPTION
## Summary
Proves the **hard (attainment) direction of Mirsky's theorem** for a finite poset, the deep content left open by the easy-directions entry `DilworthTheoremOQ01`:

> minimum number of antichains covering the poset = maximum chain length, and the minimum is attained.

New file `proofs/Proofs/DilworthMirskyHardOQ01.lean` (imports and reuses the existing `IsChainOn`/`IsAntichainOn` and easy-direction lemma).

## Method
- `height x` := `Finset.sup` of chain cardinalities over `chainsTo x` (chains whose maximum element is `x`). **No well-founded recursion** — the sup is attained via `Finset.exists_mem_eq_sup`, giving an explicit longest chain ending at `x`.
- `level_isAntichain`: each `{x : height x = k}` is an antichain (append the larger element to a longest chain ⇒ height jumps, contradiction).
- `mirsky_antichain_cover`: heights lie in `Icc 1 maxChainLen`, so the poset is covered by `≤ maxChainLen` antichains.
- `mirsky_min_antichain_cover`: full theorem — a cover of size exactly `maxChainLen` exists and is minimal.

## Status
- **0 sorries, 0 axioms** by construction.
- **UNREGISTERED orphan** (not in `Proofs.lean`) ⇒ zero gallery build risk. Build verification is pending Docker/Aristotle infra recovery (dual blackout at time of writing). Lemma names checked against offline Mathlib v4.26.0 (rev `2df2f0150c`).

## Follow-up still open
Dilworth's hard direction (chain cover = max antichain) — strictly harder (König/Hall), no elementary height argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)