### PR TITLE
Mantel stability (mantel-theorem-oq-01): AES min-degree ingredient

### DIFF
--- a/proofs/Proofs/MantelStabilityOQ01.lean
+++ b/proofs/Proofs/MantelStabilityOQ01.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# Mantel stability — min-degree (Andrásfai–Erdős–Sós) ingredient
+
+`Proofs/MantelTheorem.lean` and `Proofs/MantelTheoremUniqueness.lean` settle the *exact* extremal
+form of Mantel's theorem: a triangle-free (`K₃`-free) graph on `n` vertices has at most `⌊n²/4⌋`
+edges, the bound is attained by `turanGraph n 2`, and equality holds **iff** the graph is
+isomorphic to that balanced complete bipartite graph.
+
+The open question `mantel-theorem-oq-01` asks for the *robust* (Erdős–Simonovits) stability
+statement: a triangle-free graph whose edge count is within `o(n²)` of `⌊n²/4⌋` can be made
+bipartite by deleting only `o(n²)` edges. That edge-count stability is **not** yet in Mathlib and
+is genuinely harder (its standard proof routes through degree-cleaning + the
+Andrásfai–Erdős–Sós theorem, or through the triangle removal lemma).
+
+This file packages the first concrete ingredient of the degree-cleaning route, which **is**
+available in Mathlib: the triangle-free case of the Andrásfai–Erdős–Sós theorem. Mathlib's general
+`SimpleGraph.colorable_of_cliqueFree_lt_minDegree`
+(`Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean`, Brandt's proof) states that a
+`Kᵣ₊₁`-free graph with `(3r-4)·n/(3r-1) < δ(G)` is `r`-colorable. At `r = 2` this is:
+
+> A triangle-free graph on `n` vertices with minimum degree `> 2n/5` is bipartite.
+
+This is a *min-degree* stability statement (high min-degree forces exact bipartiteness), distinct
+from the edge-count stability of the open question, but it is the load-bearing lemma in the
+cleaning argument: delete vertices of degree `≤ 2n/5` (few enough that few edges are lost when the
+graph is dense), then the surviving subgraph satisfies the AES hypothesis and is bipartite.
+
+## Status
+
+ORPHAN, build-pending: not registered in `Proofs.lean`, no gallery entry — so no false "green".
+Names were checked against the offline Mathlib checkout at the pinned revision
+(`leanprover-community/mathlib4` @ `2df2f0150c`, Lean `v4.26.0`); a Docker build is still required
+to confirm it compiles. The two results below are thin specializations of
+`SimpleGraph.colorable_of_cliqueFree_lt_minDegree` and carry no new assumptions (0 sorries,
+0 axioms by construction).
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace MantelStability
+
+variable {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- **Andrásfai–Erdős–Sós, triangle-free case.** A triangle-free (`K₃`-free) simple graph on `n`
+vertices whose minimum degree exceeds `2n/5` is bipartite (`2`-colorable). This is the `r = 2`
+specialization of `SimpleGraph.colorable_of_cliqueFree_lt_minDegree`, where the general threshold
+`(3r-4)·n/(3r-1)` collapses to `2n/5`. -/
+theorem triangleFree_colorable_two_of_lt_minDegree (h3 : G.CliqueFree 3)
+    (hd : 2 * Fintype.card V / 5 < G.minDegree) : G.Colorable 2 := by
+  refine colorable_of_cliqueFree_lt_minDegree (r := 2) (show G.CliqueFree (2 + 1) from h3) ?_
+  -- The instantiated threshold `(3·2-4)·n/(3·2-1)` is literally `2·n/5`.
+  omega
+
+/-- Contrapositive form, the shape used by the degree-cleaning step toward edge-count stability:
+a triangle-free graph that fails to be bipartite must be **sparse at some vertex**, i.e. its
+minimum degree is at most `2n/5`. -/
+theorem minDegree_le_of_triangleFree_not_colorable_two (h3 : G.CliqueFree 3)
+    (hnb : ¬ G.Colorable 2) : G.minDegree ≤ 2 * Fintype.card V / 5 := by
+  by_contra hlt
+  push_neg at hlt
+  exact hnb (triangleFree_colorable_two_of_lt_minDegree G h3 hlt)
+
+end MantelStability

--- a/research/problems/mantel-theorem-oq-01/state.md
+++ b/research/problems/mantel-theorem-oq-01/state.md
@@ -1,25 +1,54 @@
 # Research State: mantel-theorem-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-16T03:36:36-07:00
-**Iteration**: 1
+**Since**: 2026-06-16T00:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Degree-cleaning route toward Erdős–Simonovits edge-count stability. Packaged the
+first load-bearing ingredient as a standalone (orphan) file:
+`proofs/Proofs/MantelStabilityOQ01.lean`.
 
 ## Active Approach
-None yet.
+**Degree-cleaning + Andrásfai–Erdős–Sós (AES).** The classical proof of edge-count
+stability for triangle-free graphs deletes the few low-degree vertices (those of
+degree `≤ 2n/5`) — which costs only `o(n²)` edges when the graph is near-extremal —
+and then invokes the triangle-free AES theorem: every triangle-free graph with
+minimum degree `> 2n/5` is bipartite. Mathlib already provides the AES theorem in
+the general form `SimpleGraph.colorable_of_cliqueFree_lt_minDegree`
+(`Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean`).
+
+## Result (this session, researcher-8)
+New orphan file `proofs/Proofs/MantelStabilityOQ01.lean` (0 sorries, 0 axioms by
+construction; UNREGISTERED so no false "green"):
+
+1. `triangleFree_colorable_two_of_lt_minDegree` — `K₃`-free `G` with
+   `2·card V / 5 < G.minDegree` ⇒ `G.Colorable 2`. The `r = 2` specialization of
+   `colorable_of_cliqueFree_lt_minDegree`; the general threshold `(3r-4)n/(3r-1)`
+   collapses to `2n/5`, discharged by `omega`.
+2. `minDegree_le_of_triangleFree_not_colorable_two` — contrapositive: a non-bipartite
+   triangle-free graph has `minDegree ≤ 2·card V / 5` (the "sparse at some vertex"
+   form used by the cleaning step).
+
+Mathlib name verified against the offline checkout at the pinned revision
+(`mathlib4 @ 2df2f0150c`, Lean `v4.26.0`): the lemma uses a `local notation ‖α‖`
+for `Fintype.card α`, so the elaborated threshold is exactly `2 * Fintype.card V / 5`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (degree-cleaning / AES ingredient)
 
 ## Blockers
-None.
+- Docker build blacked out (`docker run --rm alpine echo ok` → rc=124 timeout), so
+  the orphan is build-pending. Registration in `Proofs.lean` + gallery entry are
+  deferred until a green Docker build is possible.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+1. When Docker is healthy: `./proofs/scripts/docker-build.sh Proofs.MantelStabilityOQ01`,
+   then register in `Proofs.lean` and add a gallery entry.
+2. Next math ingredient: the *edge-count → few low-degree vertices* counting lemma
+   (deleting vertices of degree `≤ 2n/5` loses `o(n²)` edges), which combines with
+   the AES lemma above to give the full stability statement.


### PR DESCRIPTION
## Summary

First load-bearing ingredient toward Erdős–Simonovits **edge-count stability** for triangle-free graphs (`mantel-theorem-oq-01`). The gallery already has the exact extremal form (`MantelTheorem` / `MantelTheoremUniqueness`: `|E(G)| ≤ ⌊n²/4⌋`, equality iff balanced complete bipartite). Stability upgrades that numerical bound to a structural one and is **not** in Mathlib.

This PR packages the triangle-free **Andrásfai–Erdős–Sós** theorem, the load-bearing lemma in the degree-cleaning route:

- `triangleFree_colorable_two_of_lt_minDegree` — a `K₃`-free graph with `minDegree > 2n/5` is bipartite (`Colorable 2`).
- `minDegree_le_of_triangleFree_not_colorable_two` — contrapositive ("sparse at some vertex") form used by the cleaning step.

Both are thin `r = 2` specializations of Mathlib's `SimpleGraph.colorable_of_cliqueFree_lt_minDegree` (Brandt's proof, `FiveWheelLike.lean`), where the general threshold `(3r−4)n/(3r−1)` collapses to `2n/5` via `omega`. **0 sorries, 0 axioms by construction.**

## Status

- **Orphan / build-pending**: not registered in `Proofs.lean`, no gallery entry — so no false "green". Docker is currently blacked out (`docker run --rm alpine echo ok` → rc=124 timeout), so the file is unbuilt.
- Mathlib name + signature verified against the offline checkout at the pinned revision (`mathlib4 @ 2df2f0150c`, Lean `v4.26.0`); the lemma's `local notation ‖α‖` is `Fintype.card α`, so the elaborated threshold is exactly `2 * Fintype.card V / 5`.

## Next steps (recorded in `state.md`)

1. When Docker is healthy: `./proofs/scripts/docker-build.sh Proofs.MantelStabilityOQ01`, then register + add a gallery entry.
2. Next ingredient: the edge-count → few-low-degree-vertices counting lemma, which combines with the AES lemma here to give full stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)