### PR TITLE
Enrich desargues-theorem-oq-01: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01/annotations.json
@@ -27,7 +27,7 @@
     "id": "ann-desargues-oq01-02-cross-product",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 45,
+      "startLine": 50,
       "endLine": 66
     },
     "type": "definition",
@@ -74,7 +74,7 @@
     "id": "ann-desargues-oq01-04-lagrange",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 84,
+      "startLine": 89,
       "endLine": 116
     },
     "type": "concept",
@@ -98,7 +98,7 @@
     "id": "ann-desargues-oq01-05-collinearity",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 117,
+      "startLine": 119,
       "endLine": 126
     },
     "type": "definition",
@@ -121,7 +121,7 @@
     "id": "ann-desargues-oq01-06-master-identity",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 127,
+      "startLine": 129,
       "endLine": 200
     },
     "type": "concept",
@@ -169,7 +169,7 @@
     "id": "ann-desargues-oq01-08-theorems",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 201,
+      "startLine": 204,
       "endLine": 260
     },
     "type": "concept",
@@ -194,7 +194,7 @@
     "id": "ann-desargues-oq01-09-corollaries",
     "proofId": "desargues-theorem-oq-01",
     "range": {
-      "startLine": 261,
+      "startLine": 264,
       "endLine": 285
     },
     "type": "concept",

--- a/src/data/proofs/desargues-theorem-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01/meta.json
@@ -75,14 +75,14 @@
       "id": "header",
       "title": "Problem Statement and Answer",
       "startLine": 1,
-      "endLine": 44,
+      "endLine": 49,
       "summary": "Overview: the open question, the answer (YES, generalizes to CommRing), and the proof strategy.",
       "mathContext": "**Desargues' theorem over $K$**: triangles $\\triangle ABC$, $\\triangle A'B'C'$ are perspective from a point $\\iff$ perspective from a line. Generalized from fields to any commutative ring $K$."
     },
     {
       "id": "cross-product",
       "title": "Cross Product Setup Over K",
-      "startLine": 45,
+      "startLine": 50,
       "endLine": 66,
       "summary": "Custom cross product definition for K³, with component lemmas and anticommutativity.",
       "mathContext": "$\\mathbf{a} \\times \\mathbf{b} = (a_2b_3 - a_3b_2,\\, a_3b_1 - a_1b_3,\\, a_1b_2 - a_2b_1) \\in K^3$. Anticommutative: $\\mathbf{a} \\times \\mathbf{b} = -(\\mathbf{b} \\times \\mathbf{a})$."
@@ -91,14 +91,14 @@
       "id": "determinant",
       "title": "Three-Vector Matrix Determinant",
       "startLine": 67,
-      "endLine": 83,
+      "endLine": 88,
       "summary": "threeVecMat: rows as vectors, explicit 3×3 det expansion proved by ring.",
       "mathContext": "$\\det(\\mathbf{a}, \\mathbf{b}, \\mathbf{c}) = a_1(b_2c_3 - b_3c_2) - a_2(b_1c_3 - b_3c_1) + a_3(b_1c_2 - b_2c_1)$. Constructed via `threeVecMat` (3 vectors as rows of a $3 \\times 3$ matrix)."
     },
     {
       "id": "lagrange",
       "title": "Lagrange Cross Product Identity",
-      "startLine": 84,
+      "startLine": 89,
       "endLine": 116,
       "summary": "Key lemma: (a×b)×(c×d) = det(a,b,d)·c − det(a,b,c)·d over any CommRing K.",
       "mathContext": "$(\\mathbf{a} \\times \\mathbf{b}) \\times (\\mathbf{c} \\times \\mathbf{d}) = \\det(\\mathbf{a}, \\mathbf{b}, \\mathbf{d}) \\cdot \\mathbf{c} - \\det(\\mathbf{a}, \\mathbf{b}, \\mathbf{c}) \\cdot \\mathbf{d}$. The key algebraic identity (Lagrange's vector identity), valid over any commutative ring."
@@ -106,15 +106,15 @@
     {
       "id": "collinearity",
       "title": "Collinearity and Concurrence",
-      "startLine": 117,
-      "endLine": 126,
+      "startLine": 119,
+      "endLine": 128,
       "summary": "Definitions using determinant = 0 over K.",
       "mathContext": "Points $P, Q, R \\in K^3$ are collinear $\\iff \\det(P, Q, R) = 0$. Perspective from a point: $AA' \\cap BB' \\cap CC' \\neq \\emptyset$ ($\\iff \\det(AA', BB', CC') = 0$)."
     },
     {
       "id": "main-identity",
       "title": "The Desargues Master Identity",
-      "startLine": 127,
+      "startLine": 129,
       "endLine": 200,
       "summary": "det(P,Q,R) = det(AA',BB',CC')·det(A,B,C)·det(A',B',C') — three-step algebraic proof.",
       "mathContext": "$\\det(P, Q, R) = \\det(AA', BB', CC') \\cdot \\det(A, B, C) \\cdot \\det(A', B', C')$ where $P = AB' \\cap A'B$, $Q = BC' \\cap B'C$, $R = CA' \\cap C'A$ (as cross products in $\\mathbb{P}^2(K)$)."
@@ -122,7 +122,7 @@
     {
       "id": "main-theorems",
       "title": "Main Theorems",
-      "startLine": 201,
+      "startLine": 204,
       "endLine": 260,
       "summary": "Forward (CommRing), converse (IntegralDomain), and biconditional forms.",
       "mathContext": "**Forward** (CommRing): perspective from point $\\Rightarrow$ perspective from line. **Converse** (IntegralDomain): perspective from line $\\Rightarrow$ perspective from point (uses cancellation). **Biconditional** (IntegralDomain): equivalence."
@@ -130,7 +130,7 @@
     {
       "id": "corollaries",
       "title": "Corollaries for Specific Rings",
-      "startLine": 261,
+      "startLine": 264,
       "endLine": 285,
       "summary": "Immediate specializations to ℚ, ℤ, ZMod p, and polynomial rings.",
       "mathContext": "Specializations: $K = \\mathbb{Q}$ (classical), $K = \\mathbb{Z}$ (integer coordinates), $K = \\mathbb{Z}/p\\mathbb{Z}$ (finite projective planes), $K = R[X]$ (polynomial rings). All inherit Desargues from the CommRing instance."


### PR DESCRIPTION
Enrichment pass for desargues-theorem-oq-01 (Desargues over any commutative ring).

## Drift fix
The Lean file had shifted relative to the annotation anchors: **6 of 9 annotations were misaligned** (startLines on blank lines before each construct's doc-comment). Re-anchored all 6 onto their declaration lines.
- Resolver before: Valid 3, Misaligned 6
- Resolver after: **Valid 9, Misaligned 0**

Realigned all 8 `sections` boundaries to construct spans.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 9/9 annotations valid, 0 misaligned.
- No content changed beyond line ranges.