### PR TITLE
research(dirichlet-approximation-theorem): gallery entry for complete-but-ungalleried proof

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-interval-bound",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 31, "endLine": 38 },
+    "type": "lemma",
+    "title": "interval_bound — Equal Floor Forces Proximity",
+    "content": "Two reals x, y lying in [0, Q) with the same floor satisfy |x − y| < 1. This is the arithmetic incarnation of 'two points in the same unit cell are close'. The proof splits on the sign of x − y and in each branch invokes `sub_lt_one_of_floor_eq`, which combines ⌊x⌋ ≤ x and x < ⌊x⌋ + 1 (with the floors equal) by `linarith`. In the main theorem this is applied to Q·frac(iα) and Q·frac(jα), whose floors agree precisely because intervalMap sent i and j to the same Fin Q index — so 'same sub-interval' becomes |Q·frac(iα) − Q·frac(jα)| < 1.",
+    "mathContext": "$\\lfloor x\\rfloor = \\lfloor y\\rfloor,\\ x,y\\in[0,Q) \\;\\Rightarrow\\; |x-y| < 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "floor function",
+      "pigeonhole interval",
+      "real number bracketing"
+    ],
+    "prerequisites": [
+      "Int.floor_le and Int.lt_floor_add_one",
+      "sign case split with abs",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-frac-def",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 41, "endLine": 41 },
+    "type": "definition",
+    "title": "frac — The Fractional Part",
+    "content": "Defines frac(x) = x − ⌊x⌋, the fractional part of a real number, which always lies in [0,1) (proved immediately after by `frac_nonneg` and `frac_lt_one`). The Q+1 points whose collision drives the whole proof are the fractional parts frac(0·α), …, frac(Q·α). Working with frac rather than Mathlib's `Int.fract` keeps every step inside the explicit floor/linarith fragment.",
+    "mathContext": "$\\operatorname{frac}(x) = x - \\lfloor x\\rfloor,\\qquad \\operatorname{frac}(x)\\in[0,1)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fractional part",
+      "floor function",
+      "unit interval"
+    ],
+    "prerequisites": [
+      "floor of a real number",
+      "real subtraction"
+    ]
+  },
+  {
+    "id": "ann-interval-map",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 53, "endLine": 65 },
+    "type": "definition",
+    "title": "intervalMap — Assigning Points to Sub-Intervals",
+    "content": "The pigeonhole assignment: intervalMap sends index j ∈ Fin (Q+1) to ⌊Q·frac(jα)⌋ ∈ Fin Q, i.e. the index of the sub-interval [k/Q, (k+1)/Q) containing the fractional part {jα}. The Fin Q membership obligation — that the value is < Q — is discharged inline from 0 ≤ Q·frac(jα) < Q (using frac ∈ [0,1) and Q > 0) via `Int.floor_lt` and the `toNat` round-trip. This map having domain strictly larger than codomain (Q+1 > Q) is exactly what makes the pigeonhole principle fire.",
+    "mathContext": "$\\operatorname{intervalMap}(j) = \\lfloor Q\\cdot\\operatorname{frac}(j\\alpha)\\rfloor,\\quad 0 \\le Q\\cdot\\operatorname{frac}(j\\alpha) < Q$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole map",
+      "partition of [0,1) into Q cells",
+      "Fin n indexing",
+      "floor to Fin coercion"
+    ],
+    "prerequisites": [
+      "frac and its [0,1) bounds",
+      "Int.floor_lt, Int.floor_nonneg, Int.toNat_of_nonneg",
+      "Fin Q membership proofs"
+    ]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 72, "endLine": 140 },
+    "type": "theorem",
+    "title": "dirichlet_approximation — The Main Theorem",
+    "content": "The headline result: for every real α and every Q ≥ 1 there exist integers p, q with 1 ≤ q ≤ Q and |qα − p| < 1/Q. The proof applies `Fintype.exists_ne_map_eq_of_card_lt` to intervalMap (legal since |Fin (Q+1)| > |Fin Q|), obtaining distinct i ≠ j with the same interval index. A `wlog` reduces to j < i; then q = i − j satisfies 1 ≤ q ≤ Q (since i, j ∈ {0,…,Q}) and p = ⌊iα⌋ − ⌊jα⌋ is the numerator. The algebraic identity qα − p = frac(iα) − frac(jα) rewrites the goal, and `interval_bound` applied to Q·frac(iα), Q·frac(jα) (whose floors coincide by the collision) gives |frac(iα) − frac(jα)| < 1/Q after factoring out Q. This is Dirichlet's 1842 argument transcribed faithfully.",
+    "mathContext": "$\\forall \\alpha\\in\\mathbb{R},\\ \\forall Q\\ge 1,\\ \\exists p\\in\\mathbb{Z},\\ q\\in\\mathbb{N}:\\ 1\\le q\\le Q \\,\\wedge\\, |q\\alpha - p| < 1/Q$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "Diophantine approximation",
+      "wlog reduction",
+      "denominator extraction q = i − j"
+    ],
+    "prerequisites": [
+      "Fintype.exists_ne_map_eq_of_card_lt",
+      "intervalMap and interval_bound",
+      "wlog tactic",
+      "Nat/Int/Real casting"
+    ]
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "dirichlet-approximation-theorem",
+  "title": "Dirichlet's Approximation Theorem",
+  "slug": "dirichlet-approximation-theorem",
+  "description": "For any real number α and any positive integer Q, there exist integers p and q with 1 ≤ q ≤ Q such that |qα − p| < 1/Q. Every real number admits an infinitely good rational approximation: the error of the best denominator-≤-Q approximation is smaller than 1/Q, beating the trivial 1/(2Q) achievable for a single fixed denominator. This is the foundational pigeonhole result of Diophantine approximation.",
+  "meta": {
+    "author": "Peter Gustav Lejeune Dirichlet (1842), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
+    "date": "1842",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximation.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "pigeonhole-principle",
+      "continued-fractions",
+      "rational-approximation",
+      "floor-function"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.exists_ne_map_eq_of_card_lt",
+        "description": "The pigeonhole principle in finite-cardinality form: a map from a larger finite type to a smaller one is not injective. This is the engine that forces two of the Q+1 fractional parts into the same interval.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Int.lt_floor_add_one",
+        "description": "x < ⌊x⌋ + 1, used to bound how far a real number can sit above its floor.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Int.floor_le",
+        "description": "⌊x⌋ ≤ x, the lower half of the floor bracketing used for the fractional part.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Int.floor_lt / Int.floor_nonneg / Int.toNat_of_nonneg",
+        "description": "Floor comparison and toNat round-trip lemmas used to land the interval index inside Fin Q.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      }
+    ],
+    "originalContributions": [
+      "A self-contained Lean formalization of Dirichlet's approximation theorem from the pigeonhole principle, avoiding any continued-fraction machinery",
+      "An explicit interval-assignment map intervalMap : Fin (Q+1) → Fin Q sending point j to ⌊Q·frac(jα)⌋, with the Fin Q membership proof discharged inline",
+      "A reusable bracketing lemma interval_bound: two reals in [0,Q) with equal floor differ by less than 1, reducing the geometric pigeonhole step to floor arithmetic",
+      "The denominator/numerator extraction q = i − j, p = ⌊iα⌋ − ⌊jα⌋ with the identity qα − p = frac(iα) − frac(jα) making the final bound a direct consequence of the collision"
+    ],
+    "dateAdded": "2026-06-16",
+    "relatedProblems": [
+      {
+        "id": "dirichlets-theorem",
+        "relationship": "A different theorem of Dirichlet — on the infinitude of primes in arithmetic progressions. Shares the author and the pigeonhole spirit but is an analytic, not a Diophantine, result."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 142,
+    "assumptions": "0 axioms, 0 sorries. The only hypothesis is Q ≥ 1 (a positive bound on the denominator), which is an input to the statement rather than a standing assumption. Every lemma and the main theorem are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Dirichlet's approximation theorem, published by Peter Gustav Lejeune Dirichlet in 1842, is the cornerstone of Diophantine approximation — the study of how well real numbers can be approximated by rationals. Its proof is the prototypical application of the pigeonhole principle (Schubfachprinzip, 'drawer principle'), which Dirichlet himself articulated as a formal proof method.\n\nThe theorem guarantees that every real number α has a rational approximation p/q whose error |α − p/q| is smaller than 1/(qQ) ≤ 1/q², far better than the 1/(2q) one gets by simply rounding. Applied with arbitrarily large Q, it yields infinitely many rationals p/q with |α − p/q| < 1/q² — a statement that fails for no irrational and is sharp (Hurwitz's theorem refines the constant to 1/(√5 q²)).\n\nThe result is foundational: it underlies the theory of continued fractions, the construction of Liouville numbers and transcendence proofs, the density-increment lemma in Roth's theorem on arithmetic progressions, and Weyl's equidistribution theory. Dirichlet's pigeonhole argument is also the historical seed of the metric and geometry-of-numbers approaches later developed by Minkowski.",
+    "problemStatement": "Let $\\alpha \\in \\mathbb{R}$ and let $Q$ be a positive integer. Then there exist integers $p$ and $q$ with $1 \\le q \\le Q$ such that\n\n$$|q\\alpha - p| < \\frac{1}{Q}.$$\n\nEquivalently, $\\left|\\alpha - \\dfrac{p}{q}\\right| < \\dfrac{1}{qQ} \\le \\dfrac{1}{q^2}.$",
+    "text": "Among the denominators 1 through Q, some q yields a rational approximation p/q to α with error below 1/(qQ) — strictly better than any fixed-denominator rounding. The proof packs Q+1 fractional parts into Q sub-intervals of [0,1) and lets the pigeonhole principle force a collision.",
+    "proofStrategy": "The formalization follows Dirichlet's original pigeonhole argument literally. Consider the Q+1 fractional parts frac(0·α), frac(1·α), …, frac(Q·α), all lying in [0,1). Partition [0,1) into the Q equal sub-intervals [k/Q, (k+1)/Q). The map `intervalMap j = ⌊Q·frac(jα)⌋` sends each of the Q+1 points to one of Q interval indices; the Fin Q membership proof is exactly the bound 0 ≤ Q·frac(jα) < Q.\n\nBy the pigeonhole principle (`Fintype.exists_ne_map_eq_of_card_lt`, since |Fin (Q+1)| > |Fin Q|), two distinct indices i ≠ j receive the same interval. A `wlog` reduces to the case j < i. Setting q = i − j and p = ⌊iα⌋ − ⌊jα⌋, an algebraic identity gives qα − p = frac(iα) − frac(jα). The reusable lemma `interval_bound` (two reals in [0,Q) with equal floor differ by < 1) applied to Q·frac(iα) and Q·frac(jα) yields |Q·frac(iα) − Q·frac(jα)| < 1; factoring out Q and dividing gives |frac(iα) − frac(jα)| < 1/Q. Combined with 1 ≤ q ≤ Q (read off from i,j ∈ {0,…,Q}), this is the theorem.",
+    "keyInsights": [
+      "**Pigeonhole on fractional parts**: Q+1 points {0·α}, …, {Q·α} cannot all lie in distinct members of a Q-element partition of [0,1), so two must collide — this single counting fact is the whole theorem",
+      "**The collision gives the denominator for free**: if frac(iα) and frac(jα) are close, then (i−j)α is close to the integer ⌊iα⌋ − ⌊jα⌋, so the denominator q = i − j and numerator p emerge directly from the two colliding indices",
+      "**Equal floor of Q·frac is the interval predicate**: assigning point j to ⌊Q·frac(jα)⌋ ∈ Fin Q is exactly 'which of the Q sub-intervals does {jα} fall into', turning the geometric pigeonhole into a clean floor computation",
+      "**Floor bracketing replaces interval geometry**: the lemma 'two reals in [0,Q) with equal floor differ by < 1' converts the 'same drawer ⇒ close' step into elementary floor inequalities (⌊x⌋ ≤ x < ⌊x⌋+1), keeping the proof inside ordered-field and floor arithmetic"
+    ],
+    "prerequisites": [
+      "The floor function and fractional part of a real number",
+      "The pigeonhole principle in finite-cardinality form",
+      "Basic real-number inequalities and the ordered-field tactics linarith/ring",
+      "Indexing with Fin n and casting between ℕ, ℤ, ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "floor-bracketing",
+      "title": "Floor Bracketing: Equal Floor ⇒ Difference < 1",
+      "startLine": 22,
+      "endLine": 38,
+      "mathContext": "If $\\lfloor x\\rfloor = \\lfloor y\\rfloor$ then $|x-y| < 1$, since both lie in $[\\lfloor x\\rfloor, \\lfloor x\\rfloor + 1)$.",
+      "summary": "`sub_lt_one_of_floor_eq` and `interval_bound`: two reals with the same floor differ by strictly less than 1. This is the arithmetic core of the 'same sub-interval ⇒ close' step, proved from ⌊x⌋ ≤ x < ⌊x⌋ + 1 by linarith and a sign case split."
+    },
+    {
+      "id": "fractional-part",
+      "title": "The Fractional Part",
+      "startLine": 40,
+      "endLine": 49,
+      "mathContext": "$\\operatorname{frac}(x) = x - \\lfloor x\\rfloor \\in [0,1)$.",
+      "summary": "`frac` and its two bounds `frac_nonneg`, `frac_lt_one`: the fractional part lands in [0,1). These are the points that get distributed into the Q sub-intervals."
+    },
+    {
+      "id": "interval-map",
+      "title": "The Pigeonhole Assignment",
+      "startLine": 51,
+      "endLine": 65,
+      "mathContext": "$\\operatorname{intervalMap}(j) = \\lfloor Q\\cdot\\operatorname{frac}(j\\alpha)\\rfloor \\in \\{0,\\dots,Q-1\\}$.",
+      "summary": "`intervalMap : Fin (Q+1) → Fin Q` sends point j to the index of the sub-interval containing {jα}. The Fin Q membership obligation is discharged inline by 0 ≤ Q·frac(jα) < Q."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Dirichlet's Approximation Theorem",
+      "startLine": 67,
+      "endLine": 140,
+      "mathContext": "$\\exists p\\in\\mathbb{Z},\\ q\\in\\mathbb{N},\\ 1\\le q\\le Q \\wedge |q\\alpha - p| < 1/Q.$",
+      "summary": "`dirichlet_approximation`: applies pigeonhole to intervalMap, reduces to j < i by wlog, extracts q = i − j and p = ⌊iα⌋ − ⌊jα⌋, and bounds |qα − p| = |frac(iα) − frac(jα)| < 1/Q via interval_bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "Dirichlet's approximation theorem is formalized in Lean 4 with zero sorries and zero axioms, following Dirichlet's 1842 pigeonhole argument exactly: Q+1 fractional parts {jα} are distributed into Q sub-intervals of [0,1), a collision is forced by Fintype.exists_ne_map_eq_of_card_lt, and the two colliding indices yield a fraction p/q with |qα − p| < 1/Q. The geometric 'same drawer ⇒ close' step is reduced to the floor-bracketing lemma interval_bound.",
+    "implications": "The theorem is the gateway to Diophantine approximation: iterating it over growing Q produces infinitely many rationals p/q with |α − p/q| < 1/q² (Hurwitz sharpens the constant), it underlies the theory of continued fractions and Liouville's transcendence criterion, and the same pigeonhole-on-fractional-parts technique seeds Weyl equidistribution and the density-increment step in Roth's theorem.",
+    "openQuestions": [
+      "Can the one-shot bound be upgraded in Lean to the infinitude statement: infinitely many coprime p/q with |α − p/q| < 1/q² for irrational α?",
+      "Can the proof be generalized to the simultaneous approximation theorem (one common denominator approximating several reals at once) via a higher-dimensional pigeonhole?",
+      "Does Mathlib's continued-fraction development subsume this, and can the explicit interval map be replaced by Minkowski's convex-body argument for the same bound?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions — a different, analytic theorem of the same author. Both descend from Dirichlet's methodological innovations, but the approximation theorem is elementary and combinatorial."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/DirichletApproximation.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Int",
+      "Finset"
+    ],
+    "namespace": "DirichletApproximation",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 6
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`Proofs/DirichletApproximation.lean` is a **complete, verified** proof of Dirichlet's Approximation Theorem (0 sorries, 0 axioms, registered in `Proofs.lean`) but had **no gallery directory** under `src/data/proofs/`. This PR adds that entry so the proof surfaces in the web gallery.

- `meta.json` — status `verified`, badge `original`, `axiomCount: 0`, full overview / strategy / key-insights / cross-reference to `dirichlets-theorem` (the distinct primes-in-AP theorem).
- `annotations.json` — 4 annotations: floor-bracketing lemma `interval_bound`, the `frac` definition, the pigeonhole `intervalMap`, and the main theorem `dirichlet_approximation`.

## The theorem

For any real α and positive integer Q, there exist integers p, q with 1 ≤ q ≤ Q and |qα − p| < 1/Q — proved via Dirichlet's 1842 pigeonhole argument (Q+1 fractional parts in Q sub-intervals of [0,1)).

## Validation

- `node` JSON.parse of both files: OK
- `resolver.ts validate`: **4 valid / 0 misaligned**

Validated without `pnpm build` (Docker/Aristotle blackout); JSON-parse + resolver only, which is sufficient since the Lean proof is already merged and registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)