### PR TITLE
research(cauchy-schwarz-integral-oq-01...oq-01): gallery data for negative-exponent power-mean equality

### DIFF
--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/knowledge.md
@@ -79,3 +79,25 @@ saturated host. When `ls -ld proofs/.lake` is a real dir (or ≤2 containers):
 Cross-zero case `r < 0 < t`: needs the geometric mean `M₀`, which lies outside
 `weightedPowerMean`'s `p ≠ 0` domain. Requires `M_r ≤ M_0 ≤ M_t` with the
 `M_0 = weightedGeomMean` bridge. Genuinely distinct — do not fold in.
+
+## Session 2026-06-16 (researcher-3) — GALLERY DATA ADDED → slug complete
+
+Found the prior knowledge note (above) STALE: the orphan
+`CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean` is now **build-VERIFIED**
+(`✔ [3060/3060] Built`, researcher-8, 2026-06-16) and **REGISTERED** in `Proofs.lean`
+(line ~411, `import Proofs.CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01`). The file
+header confirms 0 sorry / 0 axiom. So the only remaining gap was the missing gallery entry.
+
+This session (Docker contended — 9 build containers, `docker run` teardown times out, so
+no build attempted; gallery data needs no build) added the gallery data:
+`src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json`
+(status `verified`, badge `original`, axiomCount 0, theoremCount 1, lineCount 49),
+modeled on the positive-case sibling's meta.json and describing the negative-exponent
+result `power_mean_eq_iff_all_eq_neg` and its reciprocal-duality proof. Validated via
+`node JSON.parse` (NOT `pnpm build`, which rewrites ~1380 sibling listings). All four
+crossReference proofIds verified to exist as gallery dirs.
+
+**Status: COMPLETE.** Lean verified+registered (researcher-8) + gallery data (this session).
+Honest framing: the proof is a routine negative-exponent extension via the
+`M_p(z)=M_{-p}(z⁻¹)⁻¹` duality, not a deep new result. Follow-up (separate slug):
+cross-zero case `r < 0 < t` needs the geometric mean M_0 bridge.

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "title": "Power Mean Equality for Negative Exponents: M_r = M_t iff All Elements Equal",
+  "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "description": "Extends the power-mean equality characterization to NEGATIVE exponents: for positive weights w summing to 1 and positive values z, with r < t < 0, the weighted power means M_r and M_t are equal if and only if all z_i are equal. The proof reduces the negative case to the already-proved positive case via the reciprocal duality M_p(z) = M_{-p}(z⁻¹)⁻¹ (power_mean_neg_inv): inverting both means and the values turns r < t < 0 into the positive pair 0 < -t < -r, where power_mean_eq_iff_all_eq_pos applies, and inv_inj transports the all-equal condition back through z ↦ z⁻¹. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Power_mean",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "power-means",
+      "mean-inequalities",
+      "duality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 49,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "power_mean_eq_iff_all_eq_neg: M_r = M_t for r < t < 0 iff all z_i equal, proved by reducing to the positive case via the reciprocal duality M_p(z) = M_{-p}(z⁻¹)⁻¹"
+    ],
+    "prerequisites": [
+      "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01 (Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean): power_mean_eq_iff_all_eq_pos, the positive-exponent equality characterization this entry extends",
+      "AmgmInequalityOQ03 (Proofs/AmgmInequalityOQ03.lean): weightedPowerMean definition and power_mean_neg_inv, the M_p(z) = M_{-p}(z⁻¹)⁻¹ duality"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "inv_inj",
+        "description": "Injectivity of inversion: a⁻¹ = b⁻¹ ↔ a = b (here on the positive reals)",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "theoremCount": 1,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The power-mean inequality M_r ≤ M_t for r ≤ t (Hardy–Littlewood–Pólya, 1934) holds across the entire real exponent line, including negative exponents — the harmonic mean (r = -1) sits at the bottom of the hierarchy. The equality characterization 'M_r = M_t iff all elements equal' gives the inequality its sharpness, and is equally valid for negative exponents. The positive-exponent case is proved by strict Jensen in the sibling entry; this entry completes the picture below zero. The key structural fact is the reciprocal duality M_p(z) = M_{-p}(z⁻¹)⁻¹, which lets the negative regime inherit the positive-case theorem rather than re-running the convexity argument.",
+    "problemStatement": "For positive weights $w_1,\\ldots,w_n$ summing to 1 and positive reals $z_1,\\ldots,z_n$, and exponents $r < t < 0$, prove that\n$$M_r(z,w) = M_t(z,w)$$\nif and only if $z_1 = z_2 = \\cdots = z_n$, where $M_p(z,w) = \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
+    "proofStrategy": "The proof reduces the negative-exponent case to the positive-exponent theorem `power_mean_eq_iff_all_eq_pos` via the reciprocal duality.\n\n1. **Inversion of means**: `power_mean_neg_inv` gives $M_r(z) = M_{-r}(z^{-1})^{-1}$ and $M_t(z) = M_{-t}(z^{-1})^{-1}$. Rewriting both sides and applying `inv_inj` turns $M_r(z) = M_t(z)$ into $M_{-r}(z^{-1}) = M_{-t}(z^{-1})$.\n2. **Reorder to positive pair**: since $r < t < 0$ we have $0 < -t < -r$, so after `eq_comm` the goal is $M_{-t}(z^{-1}) = M_{-r}(z^{-1})$ — an equality of power means at the positive exponents $-t < -r$.\n3. **Apply the positive case**: `power_mean_eq_iff_all_eq_pos` (instantiated at the inverted values $z^{-1}$ and exponents $-t,-r$) reduces this to $\\forall j,k,\\ (z_j)^{-1} = (z_k)^{-1}$.\n4. **Transport back**: `inv_inj` converts $(z_j)^{-1} = (z_k)^{-1}$ to $z_j = z_k$ in both directions.",
+    "keyInsights": [
+      "The reciprocal duality M_p(z) = M_{-p}(z⁻¹)⁻¹ makes the negative-exponent equality case a corollary of the positive case — no separate strict-convexity / Jensen argument is needed.",
+      "Inverting the exponent flips the order: r < t < 0 becomes 0 < -t < -r, so the SMALLER positive exponent is -t. The eq_comm step lines up the goal with power_mean_eq_iff_all_eq_pos's r < t convention.",
+      "inv_inj does double duty: once on the means themselves (M_r = M_t ↔ M_{-r}(z⁻¹) = M_{-t}(z⁻¹)) and once on the values (z_j⁻¹ = z_k⁻¹ ↔ z_j = z_k).",
+      "The bookkeeping mirrors the already-compiled template power_mean_monotone_neg (AmgmInequalityOQ03.lean:292), which derives negative-exponent monotonicity from the positive case by the same duality opening."
+    ],
+    "prerequisites": [
+      "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01 (Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01.lean): power_mean_eq_iff_all_eq_pos (positive-exponent equality case)",
+      "AmgmInequalityOQ03 (Proofs/AmgmInequalityOQ03.lean): weightedPowerMean, power_mean_neg_inv (reciprocal duality), power_mean_monotone_neg (template)"
+    ],
+    "furtherWork": [
+      "Handle the cross-zero case r < 0 < t, which requires bridging through the geometric mean M_0 = ∏ z_i^{w_i} (outside weightedPowerMean's p ≠ 0 domain) — genuinely distinct and not reducible by the reciprocal duality alone.",
+      "Bundle the positive, negative, and cross-zero equality characterizations into a single statement over all r < t with a unified all-equal conclusion.",
+      "Contribute the full real-exponent equality case to Mathlib's MeanInequalitiesPow.lean as the A = B ↔ _ counterpart of the existing inequalities."
+    ]
+  },
+  "annotations": [],
+  "openQuestions": [],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean",
+    "lineCount": 49,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "Establishes the equality characterization of the weighted power-mean monotonicity for NEGATIVE exponents: M_r(z,w) = M_t(z,w) for r < t < 0 if and only if all z_i are equal. The proof is a clean reduction to the positive-exponent theorem via the reciprocal duality M_p(z) = M_{-p}(z⁻¹)⁻¹, with inv_inj transporting the all-equal condition through z ↦ z⁻¹. Verified with 0 sorries and 0 axioms.",
+    "implications": "Together with the positive-exponent sibling, this entry pins the equality case of the power-mean inequality across the whole negative half-line, leaving only the cross-zero case (which must pass through the geometric mean). The reciprocal-duality technique is the negative-exponent analogue of the strict-Jensen argument: rather than re-deriving sharpness below zero, it transfers the positive-case theorem through inversion, exactly mirroring how power_mean_monotone_neg transfers the weak inequality. This is a routine but genuine extension — a structural corollary, not a new deep result — and it demonstrates that the duality bookkeeping suffices to migrate equality characterizations, not just inequalities.",
+    "openQuestions": [
+      "Extend to the cross-zero regime r < 0 < t by bridging through the geometric mean M_0; the reciprocal duality alone does not cover an exponent interval straddling 0.",
+      "Assemble a single all-real-exponent equality theorem (positive + negative + cross-zero) with one all-equal conclusion.",
+      "Upstream the paired iff theorems (positive and negative exponents) to Mathlib's MeanInequalitiesPow.lean."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "title": "Power Mean Equality: M_r = M_s iff All Elements Equal",
+      "relationship": "prerequisite",
+      "description": "The positive-exponent equality characterization (power_mean_eq_iff_all_eq_pos, proved via strict Jensen). This entry reduces the negative-exponent case to it through the reciprocal duality."
+    },
+    {
+      "proofId": "amgm-inequality-oq-03",
+      "title": "Power Mean Interpolation: How Do Weighted Power Means Relate to AM and GM?",
+      "relationship": "prerequisite",
+      "description": "Defines weightedPowerMean and supplies power_mean_neg_inv (the M_p(z) = M_{-p}(z⁻¹)⁻¹ duality) plus power_mean_monotone_neg, the compiled template whose duality opening this entry mirrors."
+    },
+    {
+      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "title": "Full Power Mean Monotonicity: M_r ≤ M_s for All r ≤ s",
+      "relationship": "related",
+      "description": "Proves the full weak inequality across all exponents; this entry is the equality endpoint of that inequality in the negative-exponent regime."
+    },
+    {
+      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+      "title": "Power Mean Inequality Chain",
+      "relationship": "ancestor",
+      "description": "Higher-level entry surveying the HM ≤ GM ≤ AM ≤ QM chain via power means; this entry sharpens the negative-exponent (toward HM) portion to its equality case."
+    }
+  ],
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Hardy, G.H., Littlewood, J.E. & Pólya, G. (1934). Inequalities. Cambridge University Press. §2.9 (Power Means).",
+      "relevance": "Classical reference for the power-mean inequality M_r ≤ M_s across all real exponents, including the negative regime (harmonic mean at r = -1). The equality characterization extended here to r < t < 0 is the sharpness statement of that inequality."
+    },
+    {
+      "type": "textbook",
+      "citation": "Bullen, P.S. (2003). Handbook of Means and Their Inequalities. Mathematics and Its Applications 560, Kluwer. Ch. III (Power Means).",
+      "relevance": "Comprehensive treatment of the power-mean family over the full exponent line, including the reciprocal duality M_p = M_{-p}(·⁻¹)⁻¹ that this entry uses to transfer the equality case from positive to negative exponents."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.Algebra.Group.Basic — inv_inj.\" (accessed 2026).",
+      "relevance": "The injectivity-of-inversion lemma a⁻¹ = b⁻¹ ↔ a = b, used twice: on the power means (to invert the duality) and on the values (to transport the all-equal condition through z ↦ z⁻¹)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the missing **gallery data** for an already build-verified, registered proof. The Lean
theorem `power_mean_eq_iff_all_eq_neg` — for positive weights and values with `r < t < 0`,
`M_r = M_t ↔ all z_i equal` — is on `main` in
`Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean`, build-verified
(`✔ [3060/3060] Built`, 0 sorry / 0 axiom) and registered in `Proofs.lean`, but had no
`src/data/proofs/.../meta.json`, so it was invisible in the gallery.

This PR adds that `meta.json` (status `verified`, badge `original`, axiomCount 0,
theoremCount 1, lineCount 49), modeled on the positive-case sibling and describing the
reciprocal-duality proof `M_p(z) = M_{-p}(z⁻¹)⁻¹`. The stale knowledge note (which still
claimed the file was unregistered/build-unverified) is refreshed.

- Gallery data only — **no Docker build needed**; `meta.json` validated via `node JSON.parse`.
- All four `crossReferences` proofIds verified to exist as gallery dirs.
- Honest framing: a routine negative-exponent extension via the duality, not a deep result.

## Test plan

- [ ] `node -e "JSON.parse(require('fs').readFileSync('src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json'))"` (passes)
- [ ] Gallery build picks up the new entry (renders from meta.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)