### PR TITLE
Enrich Erdős #671: re-anchor 15 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-671/annotations.json
+++ b/src/data/proofs/erdos-671/annotations.json
@@ -14,8 +14,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 34,
-      "endLine": 75
+      "startLine": 1,
+      "endLine": 23
     }
   },
   {
@@ -32,8 +32,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 37,
-      "endLine": 42
+      "startLine": 34,
+      "endLine": 37
     }
   },
   {
@@ -50,8 +50,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 46,
-      "endLine": 50
+      "startLine": 43,
+      "endLine": 46
     }
   },
   {
@@ -68,8 +68,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 63,
-      "endLine": 66
+      "startLine": 73,
+      "endLine": 75
     }
   },
   {
@@ -86,8 +86,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 80,
-      "endLine": 83
+      "startLine": 118,
+      "endLine": 119
     }
   },
   {
@@ -104,8 +104,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 89,
-      "endLine": 99
+      "startLine": 183,
+      "endLine": 184
     }
   },
   {
@@ -122,8 +122,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 100,
-      "endLine": 105
+      "startLine": 198,
+      "endLine": 200
     }
   },
   {
@@ -140,8 +140,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 115,
-      "endLine": 125
+      "startLine": 216,
+      "endLine": 220
     }
   },
   {
@@ -158,8 +158,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 126,
-      "endLine": 132
+      "startLine": 227,
+      "endLine": 231
     }
   },
   {
@@ -176,8 +176,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 126,
-      "endLine": 132
+      "startLine": 239,
+      "endLine": 244
     }
   },
   {
@@ -194,8 +194,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 156,
-      "endLine": 161
+      "startLine": 259,
+      "endLine": 261
     }
   },
   {
@@ -211,8 +211,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 162,
-      "endLine": 167
+      "startLine": 289,
+      "endLine": 290
     }
   },
   {
@@ -229,8 +229,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 184,
-      "endLine": 194
+      "startLine": 331,
+      "endLine": 334
     }
   },
   {
@@ -247,8 +247,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 195,
-      "endLine": 201
+      "startLine": 342,
+      "endLine": 345
     }
   },
   {
@@ -265,8 +265,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 212,
-      "endLine": 215
+      "startLine": 358,
+      "endLine": 359
     }
   }
 ]


### PR DESCRIPTION
## Re-anchor drifted annotations for `erdos-671`

`proofs/Proofs/Erdos671Problem.lean` grew after its annotations were authored, so **every** annotation's line range had drifted off its intended construct. The resolver flagged 7 as hard type-clashes (`definition`-typed annotations landing on `theorem`s); the rest had silently drifted onto unrelated declarations while remaining "valid" by type.

Re-anchored all 15 annotations to their named constructs by title:

| annotation | now anchors to |
|---|---|
| `ann-e671-header` | module docstring (1–23) |
| `ann-e671-points` | `structure InterpolationPoints` |
| `ann-e671-lagrange` | `def lagrangeBasis` |
| `ann-e671-interp` | `def lagrangeInterp` |
| `ann-e671-lebesgue` | `def lebesgueFunction` |
| `ann-e671-constant` | `def lebesgueConstant` |
| `ann-e671-bernstein` | `theorem bernstein` |
| `ann-e671-ev` | `theorem erdos_vertesi` |
| `ann-e671-q1` / `ann-e671-q2` | `def Question1` / `def Question2` |
| `ann-e671-cheby` / `ann-e671-equi` | `def chebyshevNodes` / `def equidistantNodes` |
| `ann-e671-faber` | `theorem faber` |
| `ann-e671-pos` | `theorem positive_measure_divergence` |
| `ann-e671-main` | `def MainConjecture` |

**Validation:** `resolver.ts validate` now reports **15 valid / 0 misaligned** (was 15 drifted). Only `annotations.json` changed — `meta.json` sections were already aligned with the file's `## Part` markers, and `axiomCount` (3) / `sorries` (7) already match the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)