### PR TITLE
Enrich dissection-of-cubes-oq-02-oq-02: re-anchor drifted annotations, fix stale axiom claims

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/annotations.json
@@ -27,8 +27,8 @@
     "id": "ann-angle-quot",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 34,
-      "endLine": 50
+      "startLine": 39,
+      "endLine": 51
     },
     "type": "definition",
     "title": "The Angle Quotient Group \u211d/\u03c0\u2124",
@@ -50,8 +50,8 @@
     "id": "ann-angle-props",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 52,
-      "endLine": 82
+      "startLine": 57,
+      "endLine": 83
     },
     "type": "insight",
     "title": "Properties of \u211d/\u03c0\u2124",
@@ -72,8 +72,8 @@
     "id": "ann-dehn-group",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 84,
-      "endLine": 97
+      "startLine": 89,
+      "endLine": 98
     },
     "type": "definition",
     "title": "The Dehn Invariant Group \u211d \u2297_\u2124 (\u211d/\u03c0\u2124)",
@@ -94,8 +94,8 @@
     "id": "ann-torsion-vanishing",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 100,
-      "endLine": 150
+      "startLine": 104,
+      "endLine": 151
     },
     "type": "insight",
     "title": "Rational Angle Vanishing: The Central Algebraic Argument",
@@ -118,8 +118,8 @@
     "id": "ann-special-angles",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 152,
-      "endLine": 180
+      "startLine": 153,
+      "endLine": 181
     },
     "type": "insight",
     "title": "Special Angles and Cube Dehn Invariant",
@@ -139,7 +139,7 @@
     "id": "ann-tetrahedron",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 182,
+      "startLine": 187,
       "endLine": 227
     },
     "type": "insight",
@@ -161,8 +161,8 @@
     "id": "ann-hilbert-third",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 229,
-      "endLine": 244
+      "startLine": 274,
+      "endLine": 285
     },
     "type": "insight",
     "title": "Hilbert's Third Problem: Cube \u2247 Tetrahedron",
@@ -182,8 +182,8 @@
     "id": "ann-octahedron",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 246,
-      "endLine": 283
+      "startLine": 291,
+      "endLine": 328
     },
     "type": "insight",
     "title": "Octahedron: D(oct) = -D(tet)",
@@ -204,12 +204,12 @@
     "id": "ann-dehn-sydler-statement",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 285,
-      "endLine": 333
+      "startLine": 334,
+      "endLine": 382
     },
     "type": "concept",
-    "title": "Dehn-Sydler Completeness Theorem (Axiomatized)",
-    "content": "The Dehn-Sydler theorem is axiomatized: $P \\cong_{\\text{sc}} Q \\iff \\text{Vol}(P) = \\text{Vol}(Q) \\wedge D(P) = D(Q)$. The forward direction ($\\Rightarrow$) is Dehn's 1900 result: cutting creates paired edges with angles summing to $\\pi$, which cancel since $[\\pi] = 0$. The backward direction ($\\Leftarrow$) is Sydler's deep 1965 theorem, requiring analysis of orthogonal prisms and an inductive exchange argument. Two placeholder axioms (`dehn_preserved_by_scissors`, `volume_preserved_by_scissors`) encode the invariance properties; the full `dehn_sydler_theorem` encodes the completeness statement.",
+    "title": "Dehn-Sydler Completeness Theorem (Stated, Not Formalized)",
+    "content": "The Dehn-Sydler theorem states $P \\cong_{\\text{sc}} Q \\iff \\text{Vol}(P) = \\text{Vol}(Q) \\wedge D(P) = D(Q)$. The forward direction ($\\Rightarrow$) is Dehn's 1900 result: cutting creates paired edges with angles summing to $\\pi$, which cancel since $[\\pi] = 0$. The backward direction ($\\Leftarrow$) is Sydler's deep 1965 theorem, requiring analysis of orthogonal prisms and an inductive exchange argument. Note: in this file the invariance properties (`dehn_preserved_by_scissors`, `volume_preserved_by_scissors`) are PLACEHOLDER theorems of the form `True → x = x := fun _ => rfl` — they record the statements but carry no geometric content (the actual scissors-congruence preservation is not formalized). The headline result that IS fully proved here is Hilbert's Third Problem (cube and tetrahedron have different Dehn invariants, hence are not scissors-congruent).",
     "mathContext": "$P \\cong_{\\text{sc}} Q \\iff \\text{Vol}(P) = \\text{Vol}(Q) \\wedge D(P) = D(Q)$. This completely classifies scissors congruence in $\\mathbb{R}^3$ by two computable invariants.",
     "significance": "key",
     "prerequisites": [
@@ -226,8 +226,8 @@
     "id": "ann-2d-contrast",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 335,
-      "endLine": 365
+      "startLine": 388,
+      "endLine": 414
     },
     "type": "insight",
     "title": "2D Contrast: Why Area Suffices for Polygons",
@@ -249,12 +249,12 @@
     "id": "ann-summary",
     "proofId": "dissection-of-cubes-oq-02-oq-02",
     "range": {
-      "startLine": 367,
-      "endLine": 406
+      "startLine": 420,
+      "endLine": 445
     },
     "type": "insight",
-    "title": "Axiom Budget and Summary",
-    "content": "The axiom budget: 4 substantive axioms (niven_arccos_third, tmul_infinite_order_ne_zero, arccos_neg_third, dehn_sydler_theorem) plus 2 placeholder axioms for scissors congruence preservation. Key proved results: `tmul_torsion_eq_zero`, `rational_angle_vanishes`, `cube_dehn_zero`, `tet_dehn_ne_zero`, `hilbert_third_problem`, `oct_dehn_ne_zero`, `dehn_zero_of_rational_angles`. The `#check` commands verify all key theorems type-check.",
+    "title": "Summary: Zero Axioms",
+    "content": "The closing summary records that the formalization uses 0 axioms (reduced from an earlier 6-axiom draft): `niven_arccos_third` (arccos(1/3) is not a rational multiple of π), `tmul_infinite_order_ne_zero` (the flatness theorem), and `arccos_neg_third` are all now genuinely PROVED rather than assumed. Key proved results: `tmul_torsion_eq_zero`, `rational_angle_vanishes`, `cube_dehn_zero`, `tet_dehn_ne_zero`, `hilbert_third_problem`, `oct_dehn_ne_zero`, `dehn_zero_of_rational_angles`. The two `dehn_*_preserved_by_scissors` declarations remain `True`-valued placeholders, so the Dehn-Sydler completeness direction is stated but not formalized.",
     "mathContext": "The formalization establishes: $D(\\text{cube}) = 0$, $D(\\text{tet}) \\neq 0$, $D(\\text{oct}) = -D(\\text{tet}) \\neq 0$, and $D(P) = 0$ for all rational-angle polyhedra.",
     "significance": "supporting",
     "prerequisites": [

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -99,96 +99,96 @@
       "id": "header",
       "title": "Problem Overview and Imports",
       "startLine": 1,
-      "endLine": 32,
+      "endLine": 38,
       "summary": "Overview of the Dehn-Sydler completeness theorem formalization. Lists key results: rational angle vanishing, cube $D=0$, tetrahedron $D \\neq 0$, Hilbert's Third Problem.",
       "mathContext": "$D(P) = \\sum_e \\ell(e) \\otimes [\\theta(e)] \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$"
     },
     {
       "id": "angle-quotient",
       "title": "Part I: The Angle Quotient Group ℝ/πℤ",
-      "startLine": 34,
-      "endLine": 50,
+      "startLine": 39,
+      "endLine": 56,
       "summary": "Defines `piMultiples` ($\\pi\\mathbb{Z}$), `AngleQuot` ($\\mathbb{R}/\\pi\\mathbb{Z}$), and `angleClass` ($\\theta \\mapsto [\\theta]$) using Mathlib's `AddSubgroup.zmultiples` and `QuotientAddGroup`.",
       "mathContext": "$\\mathbb{R}/\\pi\\mathbb{Z} = \\mathbb{R} / \\text{AddSubgroup.zmultiples}(\\pi)$. Elements $[\\theta]$ identify angles differing by integer multiples of $\\pi$."
     },
     {
       "id": "angle-properties",
       "title": "Part II: Properties of ℝ/πℤ",
-      "startLine": 52,
-      "endLine": 82,
+      "startLine": 57,
+      "endLine": 83,
       "summary": "Proves $[n\\pi] = 0$, $[\\pi] = 0$, $n \\cdot [\\theta] = [n\\theta]$, and the torsion characterization $n \\cdot [\\theta] = 0 \\iff n\\theta \\in \\pi\\mathbb{Z}$.",
       "mathContext": "The $\\mathbb{Z}$-module structure of $\\mathbb{R}/\\pi\\mathbb{Z}$: torsion elements are exactly the classes of rational multiples of $\\pi$."
     },
     {
       "id": "dehn-group",
       "title": "Part III: The Dehn Invariant Group",
-      "startLine": 84,
-      "endLine": 97,
+      "startLine": 89,
+      "endLine": 103,
       "summary": "Defines `DehnGroup = TensorProduct ℤ ℝ AngleQuot` and `edgeTerm len angle = len ⊗ [angle]`. The tensor product enforces $\\mathbb{Z}$-bilinearity: $(n \\cdot r) \\otimes x = r \\otimes (n \\cdot x)$.",
       "mathContext": "$\\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$: the formal $\\mathbb{Z}$-bilinear combinations $\\sum r_i \\otimes [\\theta_i]$."
     },
     {
       "id": "rational-vanishing",
       "title": "Part IV: Rational Angle Vanishing",
-      "startLine": 99,
-      "endLine": 167,
+      "startLine": 104,
+      "endLine": 168,
       "summary": "**Central algebraic argument.** Proves `tmul_torsion_eq_zero` (torsion kills tensor products via $\\mathbb{R}$-divisibility) and `rational_angle_vanishes` ($r \\otimes [q\\pi] = 0$ for $q \\in \\mathbb{Q}$). Corollaries for $\\pi/2$, $\\pi$, and $\\pi/3$.",
       "mathContext": "$r = n \\cdot (r/n) \\Rightarrow r \\otimes x = (r/n) \\otimes (n \\cdot x) = (r/n) \\otimes 0 = 0$ when $n \\cdot x = 0$."
     },
     {
       "id": "cube-zero",
       "title": "Part V: Cube Dehn Invariant is Zero",
-      "startLine": 169,
-      "endLine": 180,
+      "startLine": 174,
+      "endLine": 181,
       "summary": "**Proved.** $D(\\text{cube}) = 12a \\otimes [\\pi/2] = 0$ since $\\pi/2 = (1/2)\\pi$ is a rational multiple of $\\pi$.",
       "mathContext": "$D(\\text{cube}) = 0$ because all 12 cube edges have dihedral angle $\\pi/2$, which is rational $\\times \\pi$."
     },
     {
       "id": "irrational-angles",
       "title": "Part VI-VII: Irrational Angles and Tetrahedron D ≠ 0",
-      "startLine": 182,
-      "endLine": 227,
-      "summary": "Defines `tetAngle = arccos(1/3)`. Niven's theorem (cross-referenced from parent file) shows $\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$, so $[\\arccos(1/3)]$ has infinite order. Flatness axiom gives $D(\\text{tet}) = 6a \\otimes [\\arccos(1/3)] \\neq 0$.",
+      "startLine": 187,
+      "endLine": 252,
+      "summary": "Defines `tetAngle = arccos(1/3)`. Niven's theorem (cross-referenced from parent file) shows $\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$, so $[\\arccos(1/3)]$ has infinite order. Flatness of $\\mathbb{R}$ over $\\mathbb{Z}$ (now proved, not assumed) gives $D(\\text{tet}) = 6a \\otimes [\\arccos(1/3)] \\neq 0$.",
       "mathContext": "$\\arccos(1/3)/\\pi$ irrational (Niven) $\\Rightarrow$ $[\\arccos(1/3)]$ has infinite order $\\Rightarrow$ $6a \\otimes [\\arccos(1/3)] \\neq 0$ by flatness."
     },
     {
       "id": "hilbert-third",
       "title": "Part VIII: Hilbert's Third Problem",
-      "startLine": 229,
-      "endLine": 244,
+      "startLine": 258,
+      "endLine": 285,
       "summary": "**Proved.** $D(\\text{cube}) = 0 \\neq D(\\text{tet})$, so the cube and regular tetrahedron are not scissors congruent.",
       "mathContext": "$D(\\text{cube}) = 0$ and $D(\\text{tet}) \\neq 0 \\Rightarrow$ cube $\\not\\cong_{\\text{sc}}$ tetrahedron."
     },
     {
       "id": "octahedron",
       "title": "Part IX: Octahedron Computation",
-      "startLine": 246,
-      "endLine": 283,
+      "startLine": 291,
+      "endLine": 328,
       "summary": "Uses $\\arccos(-1/3) = \\pi - \\arccos(1/3)$ to show $[\\arccos(-1/3)] = -[\\arccos(1/3)]$. Therefore $D(\\text{oct}) = -D(\\text{tet}) \\neq 0$.",
       "mathContext": "$[\\arccos(-1/3)] = [\\pi] - [\\arccos(1/3)] = -[\\arccos(1/3)]$ since $[\\pi] = 0$."
     },
     {
       "id": "dehn-sydler",
       "title": "Part X: Dehn-Sydler Completeness Theorem",
-      "startLine": 285,
-      "endLine": 333,
-      "summary": "States the full Dehn-Sydler theorem (placeholder): $P \\cong_{\\text{sc}} Q \\iff \\text{Vol}(P) = \\text{Vol}(Q) \\wedge D(P) = D(Q)$. Forward direction is Dehn (1900); sufficiency is Sydler (1965). Placeholder axioms for scissors-congruence preservation of volume and Dehn invariant have been converted to trivial theorems.",
+      "startLine": 334,
+      "endLine": 382,
+      "summary": "States the full Dehn-Sydler theorem: $P \\cong_{\\text{sc}} Q \\iff \\text{Vol}(P) = \\text{Vol}(Q) \\wedge D(P) = D(Q)$. Forward direction is Dehn (1900); sufficiency is Sydler (1965). NOTE: `dehn_preserved_by_scissors` and `volume_preserved_by_scissors` are `True`-valued placeholder theorems — the completeness direction is stated but NOT formalized here. The genuinely proved headline is Hilbert's Third Problem (cube ≠ tetrahedron).",
       "mathContext": "Complete scissors congruence classification in $\\mathbb{R}^3$: volume + Dehn invariant."
     },
     {
       "id": "2d-contrast",
       "title": "Part XI: 2D Contrast and Consequences",
-      "startLine": 335,
-      "endLine": 365,
+      "startLine": 388,
+      "endLine": 414,
       "summary": "Proves `dehn_zero_of_rational_angles`: any polyhedron with rational-$\\times$-$\\pi$ angles has $D = 0$. Explains the 2D Bolyai-Gerwien contrast: polygon angles after triangulation are always integer multiples of $\\pi$, so area alone classifies scissors congruence.",
       "mathContext": "2D: area suffices (Bolyai-Gerwien 1833). 3D: volume + Dehn invariant (Dehn-Sydler 1965)."
     },
     {
       "id": "summary",
       "title": "Part XII: Axiom Budget and Summary",
-      "startLine": 367,
-      "endLine": 406,
-      "summary": "Lists 1 remaining axiom (flatness) and 7+ proved results. Verification via `#check` commands.",
+      "startLine": 420,
+      "endLine": 445,
+      "summary": "Records 0 axioms (reduced from an earlier 6-axiom draft) and 7+ proved results, including the flatness theorem now proved via `Module.Flat ℤ ℝ`. Verification via `#check` commands.",
       "mathContext": "Proved: $D(\\text{cube}) = 0$, $D(\\text{tet}) \\neq 0$, $D(\\text{oct}) \\neq 0$, Hilbert III, rational-angle vanishing."
     }
   ],


### PR DESCRIPTION
Enrichment pass for dissection-of-cubes-oq-02-oq-02 (Dehn invariant / Hilbert's Third Problem).

## Drift fix
The Lean file had shifted relative to the annotation anchors. **6 of 12 annotations were hard-misaligned** (startLines on blank lines), and a further **5 passed the resolver but were semantically mis-anchored** — they landed inside the large `tmul_infinite_order_ne_zero` theorem body (lines 214–252) rather than on their actual subjects (octahedron, Hilbert III, Dehn-Sydler, 2D contrast, summary). Remapped all 11 to their true constructs.
- Resolver before: Valid 6, Misaligned 6 (plus 5 silent semantic mis-anchors)
- Resolver after: **Valid 12, Misaligned 0**, each on its correct subject

Realigned all 12 `sections` boundaries to construct spans.

## Content accuracy fixes (stale claims corrected)
Several annotation/section texts were stale relative to the current source:
- The "Axiom Budget" annotation claimed **6 axioms**; the file actually uses **0** (source line 423: "0 axioms, reduced from 6" — `niven_arccos_third`, `tmul_infinite_order_ne_zero`, `arccos_neg_third` are now genuinely proved). Corrected.
- The Dehn-Sydler annotation called `dehn_preserved_by_scissors` / `volume_preserved_by_scissors` "placeholder **axioms**" and referenced a `dehn_sydler_theorem`. In fact these are `True → x = x := fun _ => rfl` **placeholder theorems** (no geometric content), and no `dehn_sydler_theorem` declaration exists. Reworded to state plainly that the Dehn-Sydler **completeness** direction is *stated but not formalized*.

## Heads-up for maintainers (status left unchanged)
`meta.status: verified` is technically correct (0 axioms, 0 sorries), but a reader could mistake the **completeness** direction (Sydler 1965) for being formalized. It is not — only Hilbert's Third Problem (cube ≠ tetrahedron) and the rational-angle vanishing results are genuinely proved. Flagging in case the gallery wants to scope the claim more tightly.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 12/12 annotations valid, 0 misaligned.