### PR TITLE
Enrich cayley-hamilton-oq-01-oq-03: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-03/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-ch-poly-coeff-def",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 53, "endLine": 60 },
+    "range": { "startLine": 57, "endLine": 60 },
     "type": "definition",
     "title": "expPolyCoeff: the coefficient functions p_k(t) as tsum",
     "content": "Defines `expPolyCoeff M k t = ∑' m : ℕ, t^m / m! * (X^m % minpoly ℝ M).coeff k`. This is the k-th coefficient function in the polynomial expansion exp(t·M) = ∑_{k=0}^{d-1} p_k(t)·M^k. The series in t is established to converge by the companion theorem `expPolyCoeff_summable` (proved without axioms in Section 1b below).",
@@ -25,7 +25,7 @@
   {
     "id": "ann-ch-companion-orbit",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 62, "endLine": 154 },
+    "range": { "startLine": 71, "endLine": 154 },
     "type": "insight",
     "title": "Section 1b: companion matrix orbit identity unlocks axiom-free summability",
     "content": "The crux of the entry's `verified` (axiom-free) status. The auxiliary lemma `coeff_pow_X_eq_companion` proves the identity coeff_k(X^m mod μ) = (C^m)_{k,0} where C = companionMatrix μ_M. The proof: minpoly C = μ (CayleyHamiltonReductionOQ02OQ01.minpoly_companionMatrix), so C^m = aeval_C(X^m) = aeval_C(X^m mod μ) = ∑_{j<d} c_{m,j}·C^j (basis expansion). Taking the (k,0) entry and using the orbit fact (C^j)_{k,0} = δ_{j,k} (companionMatrix_pow_basis) collapses the sum to c_{m,k}. The main theorem `expPolyCoeff_summable` then case-splits on k<d vs k≥d: in the bounded case, ‖C^m‖ ≤ ‖C‖^m gives |c_{m,k}| ≤ ‖C‖^m and Summable.of_norm_bounded compares against summable_pow_div_factorial; in the k≥d case the coefficient is identically 0 (modByMonic_natDegree_lt).",
@@ -51,7 +51,7 @@
   {
     "id": "ann-ch-matrix-exp-tsum",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 156, "endLine": 166 },
+    "range": { "startLine": 160, "endLine": 166 },
     "type": "technique",
     "title": "matrixExp_eq_tsum: NormedSpace.exp as the matrix power series",
     "content": "Proves `exp ℝ (t • M) = ∑' m, (t^m/m!) • M^m` by unfolding `NormedSpace.exp` (the Banach-algebra exponential) and pulling the scalar t through the smul/pow with `Algebra.smul_pow`.",
@@ -72,7 +72,7 @@
   {
     "id": "ann-ch-basis-expansion",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 168, "endLine": 178 },
+    "range": { "startLine": 172, "endLine": 178 },
     "type": "technique",
     "title": "power_eq_basis_sum: M^m as a polynomial in M via minpoly reduction",
     "content": "Proves `M^m = ∑_{k < d} (X^m mod μ_M).coeff k • M^k`. The proof uses: (1) `power_eq_aeval_mod_minpoly` (from CayleyHamiltonOQ01): `M^m = aeval M (X^m mod μ_M)`; (2) `Polynomial.eval₂_eq_sum_range'`: the evaluation of a polynomial is a finite sum up to its degree. The degree bound `natDegree(X^m mod μ_M) < d` ensures the sum stops at k=d-1.",
@@ -95,7 +95,7 @@
   {
     "id": "ann-ch-interchange",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 180, "endLine": 222 },
+    "range": { "startLine": 184, "endLine": 209 },
     "type": "technique",
     "title": "exp_tsum_interchange: exchanging ∑' m with ∑_{k<d} entry-wise",
     "content": "Proves `exp_tsum_interchange`: the entry-wise interchange `∑' m, (∑_{k<d} c_{m,k} a_{m,k}) = ∑_{k<d} (∑' m, c_{m,k} a_{m,k})`. The proof works via `Matrix.ext` (reduce to entries), then applies `tsum_sum` (the real-valued interchange theorem) with summability from `expPolyCoeff_summable`. The `matrixExp_poly_form` main theorem follows by identifying the interchange.",
@@ -119,7 +119,7 @@
   {
     "id": "ann-ch-main-result",
     "proofId": "cayley-hamilton-oq-01-oq-03",
-    "range": { "startLine": 224, "endLine": 264 },
+    "range": { "startLine": 211, "endLine": 264 },
     "type": "insight",
     "title": "matrixExp_poly_form and corollaries: exp(t·M) ∈ K[M]",
     "content": "The main theorem `matrixExp_poly_form : NormedSpace.exp ℝ (t • M) = ∑ k in Finset.range d, expPolyCoeff M k t • M^k` assembles all steps. Corollaries: `matrixExp_in_span` (exp(t·M) ∈ span{I, M, ..., M^{d-1}}), `matrixExp_zero_eq_one` (exp(0·M) = I, a consistency check), `matrixExp_atMost_n_terms` (at most n terms since deg(minpoly) ≤ n).",

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
@@ -94,7 +94,7 @@
     {
       "id": "coefficient-functions",
       "title": "Section 1: Coefficient Functions p_k(t)",
-      "startLine": 53,
+      "startLine": 57,
       "endLine": 60,
       "summary": "Defines the noncomputable function expPolyCoeff M k t = ∑' m, t^m/m! · coeff_k(X^m mod μ_M), the k-th coefficient in the polynomial expansion of exp(t·M).",
       "mathContext": "The coefficient p_k(t) is the k-th component of the vector ∑' m, t^m/m! · c_m where c_m ∈ ℝ^d encodes the expansion of M^m in the basis {I,...,M^{d-1}}. This is a scalar power series in t with radius of convergence ∞ (entire function)."
@@ -102,7 +102,7 @@
     {
       "id": "summability-companion",
       "title": "Section 1b: Summability via Companion Matrix Orbit",
-      "startLine": 62,
+      "startLine": 71,
       "endLine": 154,
       "summary": "Proves expPolyCoeff_summable as a theorem (no axiom). The key auxiliary lemma coeff_pow_X_eq_companion shows coeff_k(X^m mod μ) = (C^m)_{k,0} where C is the companion matrix of μ_M. Norm bound |C^m_{k,0}| ≤ ‖C‖^m then reduces convergence to the scalar exponential series. Case k ≥ d handled separately (coefficient is 0).",
       "mathContext": "The companion matrix identity is the crux: $C^m = \\mathrm{aeval}_C(X^m) = \\mathrm{aeval}_C(X^m \\bmod \\mu) = \\sum_{j<d} c_{m,j} C^j$ (since $\\mu_C = \\mu_M$). Taking the $(k,0)$ entry and using the orbit structure $(C^j)_{k,0} = \\delta_{j,k}$ (companionMatrix_pow_basis) collapses the sum: $(C^m)_{k,0} = c_{m,k}$. The Banach-algebra norm bound $\\|C^m\\| \\leq \\|C\\|^m$ then gives $|c_{m,k}| \\leq \\|C\\|^m$, so $\\sum_m |t|^m/m! \\cdot |c_{m,k}| \\leq e^{|t|\\|C\\|}$ converges by comparison."
@@ -110,7 +110,7 @@
     {
       "id": "power-series",
       "title": "Section 2: Power Series for Matrix Exponential",
-      "startLine": 156,
+      "startLine": 160,
       "endLine": 166,
       "summary": "matrixExp_eq_tsum proves exp(t·M) = ∑' m, (t^m/m!)·M^m using NormedSpace.exp_eq_tsum and Algebra.smul_pow.",
       "mathContext": "The NormedSpace.exp_eq_tsum gives exp x = ∑' m, m!⁻¹·x^m. For x = t·M: (t·M)^m = t^m·M^m by Algebra.smul_pow, giving exp(t·M) = ∑' m, t^m/m! · M^m."
@@ -118,7 +118,7 @@
     {
       "id": "basis-expansion",
       "title": "Section 3: Basis Expansion of Matrix Powers",
-      "startLine": 168,
+      "startLine": 172,
       "endLine": 178,
       "summary": "power_eq_basis_sum proves M^m = ∑_{k<d} c_{m,k}·M^k via power_eq_aeval_mod_minpoly and eval₂_eq_sum_range'.",
       "mathContext": "Uses aeval M (X^m mod μ) = eval₂ (algebraMap) M (X^m mod μ) = ∑_{k<d} coeff_k · M^k via the polynomial evaluation sum formula. The degree bound natDegree(X^m mod μ) < d enables eval₂_eq_sum_range'."
@@ -126,7 +126,7 @@
     {
       "id": "interchange",
       "title": "Section 4: Component-wise Interchange and Main Theorem",
-      "startLine": 180,
+      "startLine": 184,
       "endLine": 222,
       "summary": "exp_tsum_interchange exchanges ∑' m with ∑ k using Matrix.ext (entry-wise) and tsum_sum. matrixExp_poly_form is the main theorem, assembling matrixExp_eq_tsum + power_eq_basis_sum + the entry-wise interchange.",
       "mathContext": "Working entry-wise reduces the matrix interchange to a real-valued one: ∑_m f_m · ∑_k c_{m,k} · v_k = ∑_k (∑_m f_m · c_{m,k}) · v_k. Real-valued tsum_sum applies with summability from expPolyCoeff_summable."
@@ -134,7 +134,7 @@
     {
       "id": "corollaries",
       "title": "Section 5: Corollaries",
-      "startLine": 224,
+      "startLine": 228,
       "endLine": 264,
       "summary": "expPolyCoeff_depends_only_on_minpoly (similar matrices give same p_k), matrixExp_in_span (exp(tM) ∈ span{I,...,M^{d-1}}), matrixExp_zero_eq_one (consistency check), matrixExp_atMost_n_terms (n-term bound via minpoly_dvd_charpoly).",
       "mathContext": "The span membership follows from the polynomial form. The n-term bound uses deg(minpoly) ≤ deg(charpoly) = n. The minpoly-only dependence is the basis for the spectral viewpoint: exp(tM) is determined by the spectrum of M (with multiplicities matching the minimal, not characteristic, polynomial)."


### PR DESCRIPTION
Enrichment pass for cayley-hamilton-oq-01-oq-03 (matrix exponential as a polynomial in M via minpoly).

## Drift fix
The Lean file had shifted relative to the annotation anchors: **all 6 annotations were misaligned** (whole-set shift; startLines on blank lines before each construct). Re-anchored each onto its construct.
- Resolver before: Valid 0, Misaligned 6
- Resolver after: **Valid 6, Misaligned 0**

Realigned all 6 `sections` boundaries to construct spans.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 6/6 annotations valid, 0 misaligned.
- Axiom integrity confirmed: 0 axioms / 0 sorries in source, matching `axiomCount: 0` / `status: verified`.
- No content changed beyond line ranges.