### PR TITLE
audit(tracker): persist clean completions (mathematical-induction, frobenius-number-oq-02)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12335,9 +12335,9 @@
       "result": "clean"
     },
     "mathematical-induction": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:53Z",
+      "lastAudited": "2026-06-16T21:09:59Z",
       "result": "clean"
     },
     "mathematical-induction-oq-01": {
@@ -15669,6 +15669,12 @@
     "british-flag-theorem-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-16T19:59:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T20:53:49Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery Integrity Audit

Persists two audit-tracker completions so the auditor queue advances instead of re-serving the oldest target every cycle (the local `complete` write is wiped by `git reset --hard origin/main` each loop — see tracker-persistence gap).

### Audited this cycle: `mathematical-induction` — CLEAN
- meta: `status=verified`, `badge=mathlib`, `sorries=0`, `axiomCount=0`
- Source `Proofs/MathematicalInduction.lean` (249 L) + companion `MathematicalInductionOQ03.lean` (148 L): **0 sorry, 0 axiom, 0 True-stubs** verified.
- 11 substantive theorems (weak/strong induction equivalences, well-ordering, applications). `mathlib` badge + `verified` status are honest — machine-checked, sorry-free, core relies on Mathlib induction principles.

### Carried from prior session: `frobenius-number-oq-02` — CLEAN
- Previously audited clean (2026-06-16T20:53:49Z); entry was uncommitted working-tree only.

No integrity issues found. No code/meta changes — tracker bookkeeping only.

---
Discovered during gallery integrity audit.