### PR TITLE
Enrich Erdős #323: re-anchor 11 annotations + realign 5 sections

### DIFF
--- a/src/data/proofs/erdos-323/annotations.json
+++ b/src/data/proofs/erdos-323/annotations.json
@@ -50,7 +50,7 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 29,
+      "startLine": 30,
       "endLine": 31
     },
     "title": "IsSumOfPowers Predicate",
@@ -74,7 +74,7 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 33,
+      "startLine": 34,
       "endLine": 35
     },
     "title": "Counting Function f_{k,m}(x)",
@@ -98,8 +98,8 @@
     "proofId": "erdos-323",
     "type": "concept",
     "range": {
-      "startLine": 39,
-      "endLine": 42
+      "startLine": 43,
+      "endLine": 46
     },
     "title": "First Powers: Trivial Case k = 1",
     "content": "When $k = 1$, every integer from 0 to $x$ is a sum of $m$ first powers (for $m \\le x$), so $f_{1,m}(x) \\ge m$. This axiom captures the degenerate case where sums of 1st powers are ordinary sums of nonnegative integers.",
@@ -120,8 +120,8 @@
     "proofId": "erdos-323",
     "type": "concept",
     "range": {
-      "startLine": 44,
-      "endLine": 46
+      "startLine": 57,
+      "endLine": 58
     },
     "title": "Monotonicity in Number of Summands",
     "content": "**power_sum_count_mono:** $f_{k,m}(x) \\le f_{k,m+1}(x)$. Adding an extra summand (which can be $0^k = 0$) can only increase the set of representable integers.",
@@ -143,8 +143,8 @@
     "proofId": "erdos-323",
     "type": "concept",
     "range": {
-      "startLine": 50,
-      "endLine": 55
+      "startLine": 107,
+      "endLine": 110
     },
     "title": "Landau's Theorem: Sums of Two Squares",
     "content": "**Landau's classical theorem** (1908): $f_{2,2}(x) \\sim c \\cdot x / \\sqrt{\\log x}$ for the Landau–Ramanujan constant $c > 0$. This completely resolves $k = 2$.",
@@ -167,8 +167,8 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 59,
-      "endLine": 65
+      "startLine": 117,
+      "endLine": 123
     },
     "title": "Part 1: f_{k,k}(x) >> x^{1-ε}",
     "content": "**ErdosProblem323_part1:** for every $k \\ge 2$ and $\\varepsilon > 0$, there exist $c > 0$ and $x_0$ such that $f_{k,k}(x) \\ge c \\cdot x^{1-\\varepsilon}$ for all $x \\ge x_0$. Sums of $k$ $k$-th powers have near-full density.",
@@ -191,8 +191,8 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 67,
-      "endLine": 73
+      "startLine": 125,
+      "endLine": 129
     },
     "title": "Part 2: f_{k,m}(x) >> x^{m/k} for m < k",
     "content": "**ErdosProblem323_part2:** for $1 \\le m < k$ with $k \\ge 2$, there exist $c > 0$ and $x_0$ such that $f_{k,m}(x) \\ge c \\cdot x^{m/k}$ for $x \\ge x_0$.",
@@ -215,8 +215,8 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 75,
-      "endLine": 76
+      "startLine": 131,
+      "endLine": 131
     },
     "title": "Combined Statement",
     "content": "**ErdosProblem323** is the conjunction of both parts: the near-full density bound for $f_{k,k}$ (Part 1) **and** the $x^{m/k}$ lower bound for $f_{k,m}$ when $m < k$ (Part 2).",
@@ -236,8 +236,8 @@
     "proofId": "erdos-323",
     "type": "definition",
     "range": {
-      "startLine": 80,
-      "endLine": 84
+      "startLine": 137,
+      "endLine": 139
     },
     "title": "Density Question: Is f_{k,k}(x) = o(x)?",
     "content": "**DensityQuestion($k$):** for every $\\varepsilon > 0$, for large enough $x$, $f_{k,k}(x) < \\varepsilon \\cdot x$. This asks whether sums of $k$ $k$-th powers have zero natural density for $k > 2$.",

--- a/src/data/proofs/erdos-323/meta.json
+++ b/src/data/proofs/erdos-323/meta.json
@@ -79,7 +79,7 @@
     {
       "id": "sums-of-powers",
       "title": "Sums of k-th Powers",
-      "startLine": 24,
+      "startLine": 27,
       "endLine": 36,
       "summary": "Defines `IsSumOfPowers(n,k,m)` ($\\exists x_1,\\ldots,x_m: n = \\sum x_i^k$) and `powerSumCount` ($f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$).",
       "mathContext": "$\\text{IsSumOfPowers}(n, k, m) \\iff \\exists x_1, \\ldots, x_m \\in \\mathbb{N}: n = \\sum_{i=1}^{m} x_i^k$. $f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$."
@@ -88,31 +88,31 @@
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 37,
-      "endLine": 45,
+      "endLine": 102,
       "summary": "Trivial case $k=1$: $f_{1,m}(x) \\ge m$. Monotonicity: $f_{k,m}(x) \\le f_{k,m+1}(x)$ via zero-padding ($0^k = 0$).",
       "mathContext": "$f_{1,m}(x) \\ge m$ (trivial for first powers). $f_{k,m}(x) \\le f_{k,m+1}(x)$ (monotonicity via zero-padding)."
     },
     {
       "id": "landau",
       "title": "Landau's Theorem",
-      "startLine": 46,
-      "endLine": 53,
+      "startLine": 103,
+      "endLine": 111,
       "summary": "Landau's theorem: $f_{2,2}(x) \\sim c \\cdot x / \\sqrt{\\log x}$ where $c \\approx 0.7642$ is the Landau–Ramanujan constant. Resolves $k = 2$.",
       "mathContext": "$f_{2,2}(x) \\sim \\frac{c \\cdot x}{\\sqrt{\\log x}}$ where $c = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3 \\pmod{4}} \\frac{1}{\\sqrt{1 - p^{-2}}}$ (Landau-Ramanujan constant). An integer is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ divides it to an even power."
     },
     {
       "id": "main-conjectures",
       "title": "Main Conjectures",
-      "startLine": 54,
-      "endLine": 76,
+      "startLine": 112,
+      "endLine": 132,
       "summary": "Part 1: $f_{k,k}(x) \\gg_{\\varepsilon} x^{1-\\varepsilon}$ (near-full density). Part 2: $f_{k,m}(x) \\gg x^{m/k}$ for $m < k$ (dimensional lower bound). Combined as `ErdosProblem323`.",
       "mathContext": "Part 1: $\\forall k \\ge 2,\\, \\forall \\varepsilon > 0,\\, \\exists c > 0,\\, x_0: f_{k,k}(x) \\ge c \\cdot x^{1-\\varepsilon}$ for $x \\ge x_0$. Part 2: $\\forall 1 \\le m < k,\\, k \\ge 2,\\, \\exists c > 0,\\, x_0: f_{k,m}(x) \\ge c \\cdot x^{m/k}$ for $x \\ge x_0$."
     },
     {
       "id": "density-question",
       "title": "Density Question",
-      "startLine": 77,
-      "endLine": 84,
+      "startLine": 133,
+      "endLine": 139,
       "summary": "Open: is $f_{k,k}(x) = o(x)$ for $k > 2$? Known for $k = 2$ (Landau). `DensityQuestion(k)` formalizes $\\lim f_{k,k}(x)/x = 0$.",
       "mathContext": "$\\text{DensityQuestion}(k) \\iff \\forall \\varepsilon > 0,\\, \\exists x_0: f_{k,k}(x) < \\varepsilon \\cdot x$ for $x \\ge x_0$. Equivalently, $f_{k,k}(x) = o(x)$. Known for $k = 2$ (Landau), open for $k > 2$."
     }


### PR DESCRIPTION
## Re-anchor drifted annotations and sections for `erdos-323`

`proofs/Proofs/Erdos323Problem.lean` grew/reordered after its gallery data was authored, so both `annotations.json` ranges and `meta.json` sections had drifted off their targets.

**annotations.json** — re-anchored all **11** annotations to their named constructs by title. The back half had drifted heavily: e.g. `erdos-323-landau` ("Landau's Theorem") pointed at line 50 but the `landau_two_squares` axiom is at line 107; the Part 1/Part 2/Combined conjecture annotations were ~50–60 lines early. **`resolver.ts validate`: 11 valid / 0 misaligned** (4 were hard type-clashes — `definition`-typed annotations on theorems/lemmas).

**meta.json sections** — realigned all **5** sections to the file's `## ` comment markers. "Landau's Theorem", "Main Conjectures", and "Density Question" had drifted onto unrelated early regions (e.g. "Landau's Theorem" pointed at lines 46–53; the actual marker is at line 103).

`axiomCount` (1) and `sorries` (0) already match the source; `status`/`badge` (`axiomatized`/`axiom`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)