### PR TITLE
Enrich birch-swinnerton-dyer-oq-06-oq-02: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-weierstrass-equation",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 60, "endLine": 72 },
+    "range": { "startLine": 70, "endLine": 72 },
     "type": "definition",
     "title": "The Weierstrass Equation of Curve 389a",
     "content": "Curve 389a has the Weierstrass equation y² + y = x³ + x² - 2x, corresponding to Weierstrass coefficients [a₁,a₂,a₃,a₄,a₆] = [0,1,1,-2,0]. This is the smallest-conductor elliptic curve of rank 2 (conductor N = 389, a prime). The equation is not in short Weierstrass form (y² = x³ + ax + b) because the a₂ and a₃ coefficients are nonzero.",
@@ -54,7 +54,7 @@
   {
     "id": "ann-addition-formula",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 100, "endLine": 117 },
+    "range": { "startLine": 104, "endLine": 117 },
     "type": "technique",
     "title": "P₁ + P₂ = (1,0) via the Weierstrass Addition Formula",
     "content": "For distinct points P₁ = (0,0) and P₂ = (-1,1), the addition formula gives slope λ = (1-0)/(-1-0) = -1, then x₃ = (-1)² - 1 - 0 - (-1) = 1, and y₃ = -(-1)(1+0) + 0 - 1 = 0. Thus P₁ + P₂ = (1,0). Verification: 0² + 0 = 0 = 1³ + 1² - 2. This shows the generators are not negatives of each other (which would require y₃ = -y₁ - 1 = -1 for x₃ = 0).",
@@ -67,7 +67,7 @@
   {
     "id": "ann-group-law-verification",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 119, "endLine": 174 },
+    "range": { "startLine": 123, "endLine": 174 },
     "type": "technique",
     "title": "Exact Group Law Computation via Weierstrass Formulas",
     "content": "The group law on curve 389a is computed using the exact Weierstrass formulas. For the doubling formula with slope λ = (3x₁² + 2x₁ - 2)/(2y₁+1), the x-coordinate of [2]P is x₂ = λ² - 1 - 2x₁, and the y-coordinate is y₂ = λ(x₁-x₂) - y₁ - 1. All computations are over ℚ and verified by norm_num — giving machine-checked rational arithmetic. The proof decomposes each computation into three sub-theorems: slope, x-coordinate, and y-coordinate.",
@@ -80,7 +80,7 @@
   {
     "id": "ann-height-approximations",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 176, "endLine": 199 },
+    "range": { "startLine": 180, "endLine": 199 },
     "type": "insight",
     "title": "Naive Height Approximations vs. Néron-Tate Canonical Height",
     "content": "The canonical height ĥ(P) is the limit ĥ(P) = lim_{n→∞} h_x([2^n]P)/4^n where h_x(P) = log(max(|x_num|, x_den)). The first two approximations for P₁ are: h_x([2]P₁)/4 = log(3)/4 ≈ 0.275 and h_x([4]P₁)/16 = log(121)/16 ≈ 0.300. The axiomatized value h₁₁ ≈ 0.7622 is much larger. The slow convergence arises from large local height corrections at p = 389 (the conductor prime), which the naive x-coordinate height does not capture.",
@@ -93,7 +93,7 @@
   {
     "id": "ann-height-gap",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 200, "endLine": 213 },
+    "range": { "startLine": 201, "endLine": 213 },
     "type": "insight",
     "title": "Monotonicity of Height Approximations and the Local Height Gap",
     "content": "The proof that log(121)/16 > log(3)/4 uses the identity log(3)/4 = log(81)/16 since 81 = 3⁴, reducing the comparison to log(81) < log(121), which follows from log monotonicity and 81 < 121. This rewriting trick — converting log(a)/4^n to log(a⁴)/4^(n+1) — is the core monotonicity argument for Néron-Tate approximation sequences. For curve 389a with conductor 389, the Néron-Tate height decomposes as ĥ(P) = h_x(P) + Σ_v λ_v(P) where the local contribution λ₃₈₉(P₁) at the conductor prime is large and positive.",
@@ -106,7 +106,7 @@
   {
     "id": "ann-summary-theorem",
     "proofId": "birch-swinnerton-dyer-oq-06-oq-02",
-    "range": { "startLine": 215, "endLine": 249 },
+    "range": { "startLine": 219, "endLine": 249 },
     "type": "context",
     "title": "Summary: Collecting All Group Law Results",
     "content": "The weierstrass_group_law_summary theorem assembles all verified results into a single conjunction: curve membership for all six computed rational points, positivity of the first height approximation, and strict monotonicity of the approximation sequence. This conjunction serves as the formal interface to OQ-06's height pairing matrix, giving the computational evidence that the height values h₁₁ ≈ 0.7622 are approached (from below) by iterated doubling.",

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-02/meta.json
@@ -48,56 +48,56 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 65,
+      "endLine": 69,
       "summary": "Imports `Mathlib`, opens `noncomputable section`, and declares the namespace `BirchSwinnertonDyerOQ06OQ02`. Opening docstring describes the goal: connect the OQ-06 axiomatized height pairing matrix (h₁₁, h₁₂, h₂₂ ≈ 0.7622, -0.1323, 0.2720) for curve 389a to explicit Weierstrass group-law computations on generators P₁ = (0, 0) and P₂ = (-1, 1)."
     },
     {
       "id": "sec-curve-membership",
       "title": "Curve Membership Verification — On the Curve 389a",
-      "startLine": 66,
-      "endLine": 99,
+      "startLine": 70,
+      "endLine": 103,
       "summary": "Six theorems (`p1_on_curve`, `p2_on_curve`, `double_p1_on_curve`, `double_p2_on_curve`, `quadruple_p1_on_curve`, `sum_p1_p2_on_curve`) verify by `norm_num` that P₁ = (0, 0), P₂ = (-1, 1), [2]P₁ = (3, 5), [2]P₂ = (10/9, -35/27), [4]P₁ = (114/121, -267/1331), and P₁ + P₂ = (1, 0) all satisfy the curve equation $y^2 + y = x^3 + x^2 - 2x$. Defines `onCurve389a (x y : ℚ) : Prop` as the predicate."
     },
     {
       "id": "sec-addition",
       "title": "Addition Formula: P₁ + P₂ = (1, 0)",
-      "startLine": 100,
-      "endLine": 117,
+      "startLine": 104,
+      "endLine": 122,
       "summary": "Three theorems (`add_p1p2_slope`, `add_p1p2_x`, `add_p1p2_y`) decompose the addition P₁ + P₂ into slope $\\lambda = -1$, x-coordinate $1$, and y-coordinate $0$, using the general Weierstrass addition formula adapted for $a_3 = 1$ (the $+y$ term modifies the y-formula)."
     },
     {
       "id": "sec-double-p1",
       "title": "Doubling [2]P₁ = (3, 5)",
-      "startLine": 119,
-      "endLine": 137,
+      "startLine": 123,
+      "endLine": 141,
       "summary": "Three theorems (`double_p1_slope`, `double_p1_x`, `double_p1_y`) compute $\\lambda = -2$, x-coordinate $= 3$, y-coordinate $= 5$ for $[2]P_1$ using the Weierstrass doubling formula $\\lambda = (3x_1^2 + 2a_2 x_1 + a_4) / (2y_1 + a_3)$ with $a_2 = 1, a_3 = 1, a_4 = -2$."
     },
     {
       "id": "sec-double-p2",
       "title": "Doubling [2]P₂ = (10/9, -35/27)",
-      "startLine": 139,
-      "endLine": 156,
+      "startLine": 142,
+      "endLine": 160,
       "summary": "Three theorems (`double_p2_slope`, `double_p2_x`, `double_p2_y`) compute $\\lambda = -1/3$, x-coordinate $= 10/9$, y-coordinate $= -35/27$ for $[2]P_2$. The non-integer rational coordinates illustrate that the height growth is genuinely logarithmic — naive height $h_x([2]P_2) = \\log\\,9 = 2 \\log 3$."
     },
     {
       "id": "sec-quadruple-p1",
       "title": "Quadrupling [4]P₁ = (114/121, -267/1331)",
-      "startLine": 157,
-      "endLine": 174,
+      "startLine": 161,
+      "endLine": 179,
       "summary": "Three theorems (`quadruple_p1_slope`, `quadruple_p1_x`, `quadruple_p1_y`) compute $\\lambda = 31/11$, x-coordinate $= 114/121$, y-coordinate $= -267/1331$ for $[4]P_1$ via iterated doubling on $[2]P_1 = (3, 5)$. The denominators $121 = 11^2$ and $1331 = 11^3$ illustrate the standard quadratic-growth pattern of denominators under repeated doubling."
     },
     {
       "id": "sec-height-approx",
       "title": "Naive Height Approximations and Monotonicity",
-      "startLine": 176,
-      "endLine": 213,
+      "startLine": 180,
+      "endLine": 218,
       "summary": "Seven theorems on naive height approximations: `double_p1_x_numerator` and `double_p1_height_pos` (height $\\log 3 > 0$ at scale 4), `first_approx_p1_pos` ($\\log 3 / 4 > 0$), `quadruple_p1_height_pos` ($\\log 121 > 0$ at scale 16), `second_approx_p1_pos` ($\\log 121 / 16 > 0$), `second_approx_exceeds_first` (the key monotonicity $\\log 121 / 16 > \\log 3 / 4$ via the rewrite $\\log 3 / 4 = \\log 81 / 16$), and `double_p2_height_pos` ($\\log 10 > 0$ for $[2]P_2$)."
     },
     {
       "id": "sec-summary",
       "title": "weierstrass_group_law_summary",
-      "startLine": 215,
-      "endLine": 247,
+      "startLine": 219,
+      "endLine": 249,
       "summary": "The headline theorem `weierstrass_group_law_summary` bundles all six curve-membership facts plus the height-monotonicity inequality into a single conjunction. The closing docstring records the BSD-formula context: the canonical heights $\\hat h(P_1) \\approx 0.7622$ and $\\hat h(P_2) \\approx 0.2720$ from the OQ-06 height-pairing matrix are connected here to explicit group-law iterates, with naive height approximations bounded below by the verified rationals."
     }
   ],


### PR DESCRIPTION
Enrichment pass for birch-swinnerton-dyer-oq-06-oq-02 (explicit group law on curve 389a connecting to the BSD height pairing).

## Drift fix
The Lean file had shifted relative to the annotation anchors: **6 of 9 annotations were misaligned**. Re-anchored each onto its construct.
- Resolver before: Valid 3, Misaligned 6
- Resolver after: **Valid 9, Misaligned 0**

Realigned all 8 `sections` boundaries to construct spans.

## Axiom integrity (checked, unchanged)
This BSD-family entry is correctly labelled `status: axiomatized` / `badge: axiom` / `axiomCount: 2`. The file's own theorems are all `norm_num`-verified group-law computations (0 `axiom` declarations, 0 sorries in this file), but its height-pairing claims rest on the 2 axioms inherited from the parent OQ-06 (`curve389a_rank`, `BSD_rank_zero_axiom`). For a Millennium-Prize family, the conservative `axiomatized` labeling is the policy-correct choice — left unchanged.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 9/9 annotations valid, 0 misaligned.