### PR TITLE
Enrich arithmetic-series (q,t)-multichoose entry: re-anchor drifted annotations

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-qt-definitions",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 148, "endLine": 165 },
+    "range": { "startLine": 152, "endLine": 169 },
     "type": "definition",
     "title": "qtBinom and qtMultichoose: The Macdonald (q,t)-Binomial",
     "content": "qtBinom q t N k is defined as the 0-indexed product ∏ i ∈ range k, (1 - q^(N-i) t^i)/(1 - q^(i+1) t^i), the rewrite of Macdonald's 1-indexed (q,t)-binomial ∏_{i=1}^k (1 - q^{N+1-i} t^{i-1})/(1 - q^i t^{i-1}). At t=1 this collapses to the Gaussian binomial qBinom q N k. The (q,t)-multichoose uses the same n+k-1 index shift as the parent: qtMultichoose q t n k := qtBinom q t (n+k-1) k. Both are noncomputable and live over a Field R because the rational product needs division — the Path A choice from the PREP cascade (cheaper than redefining piecewise or lifting to RatFunc).",
@@ -14,7 +14,7 @@
   {
     "id": "ann-qt-k-recurrence",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 206, "endLine": 223 },
+    "range": { "startLine": 210, "endLine": 227 },
     "type": "technique",
     "title": "The Unconditional k-Direction Multiplicative Recurrence",
     "content": "qtBinom_succ is a direct consequence of Finset.prod_range_succ: extracting the top factor of the range-(k+1) product gives qtBinom q t N (k+1) = qtBinom q t N k · ((1 - q^(N-k) t^k)/(1 - q^(k+1) t^k)) with no hypothesis whatsoever. This is the foundational identity of the file. Its denominator depends only on k (not on N), which is exactly why the k-direction recurrence telescopes cleanly while a Pascal-style two-direction recurrence does not — the latter would have an (n,k)-dependent denominator shape.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-qt-mult-qpascal",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 229, "endLine": 247 },
+    "range": { "startLine": 233, "endLine": 251 },
     "type": "insight",
     "title": "CommRing Multiplicative q-Pascal: The Bridge Lemma",
     "content": "The private helper qBinom_mult_recur states qBinom q n (k+1) · (1 - q^(k+1)) = qBinom q n k · (1 - q^(n-k)), unconditionally over any CommRing. It is obtained by subtracting the two standard q-Pascal identities (qBinom_pascal and qBinom_pascal'), both of which expand qBinom q (n+1) (k+1); the differing q-weights q^(k+1) and q^(n-k) cancel via linear_combination. Out-of-range n < k is handled by zeroing both qBinom factors. This is the exact algebraic bridge that connects the rational Macdonald recurrence to the polynomial Gaussian recurrence at t=1.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-qt-t-eq-one",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 249, "endLine": 294 },
+    "range": { "startLine": 253, "endLine": 298 },
     "type": "insight",
     "title": "Recovery of qMultichoose at t = 1 (Conditional)",
     "content": "qtBinom_at_t_eq_one proves qtBinom q 1 N k = qBinom q N k by induction on k. The base case is the empty product (= 1); the inductive step combines the Macdonald-side qtBinom_succ with the Gaussian-side qBinom_mult_recur, bridged by the field identity a·(b/c) = d ↔ a·b = d·c. The Path A hypothesis q^(j+1) ≠ 1 for j < k keeps the denominator 1 - q^(k+1) nonzero. The corollary qtMultichoose_at_t_eq_one specializes via the shared n+k-1 index shift. The hypothesis is necessary, not cosmetic: the parent's qMultichoose is hypothesis-free (no division), so this theorem precisely asserts that the rational Macdonald form agrees with the polynomial Gaussian form on the open dense set of non-roots-of-unity.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-qt-sublattice",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 300, "endLine": 325 },
+    "range": { "startLine": 304, "endLine": 329 },
     "type": "technique",
     "title": "The (2,2) Interior Point: Where t Cancels",
     "content": "qtMultichoose_two_two shows qtMultichoose q t 2 2 = (1 - q^3)/(1 - q), independent of t, under the guard 1 - q^2 t ≠ 0. Mechanism: in qtBinom q t 3 2, the i=1 factor has numerator 1 - q^(3-1) t = 1 - q^2 t and denominator 1 - q^(1+1) t = 1 - q^2 t (because 3-1 = 2 = 1+1), so it cancels to 1 via div_self; the i=0 factor is the t-free (1 - q^3)/(1 - q). This (2,2) point is the unique genuinely interior member of the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} on which qtMultichoose is t-independent as a rational function in ℚ(q,t).",
@@ -62,7 +62,7 @@
   {
     "id": "ann-qt-field-trap",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 327, "endLine": 362 },
+    "range": { "startLine": 331, "endLine": 366 },
     "type": "insight",
     "title": "The Field R 0/0 Trap at q = t = 1",
     "content": "qtBinom_at_one_one_eq_zero proves qtBinom 1 1 N (k+1) = 0. Under Lean's Field convention (0:R)/0 = 0, the i=0 factor (1 - 1^N·1^0)/(1 - 1^1·1^0) is exactly 0/0 = 0, and a single zero factor zeros the whole product (extracted via Finset.prod_range_succ', closed by simp). This is the NEGATIVE statement: the naive q=t=1 substitution does not recover Nat.multichoose — it collapses to 0. It formalizes why the Path A hypothesis q^(j+1) ≠ 1 is mandatory and motivates a future RatFunc.eval lift (Path C) to obtain the positive recovery as a genuine removable-singularity limit rather than a field artifact.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-qt-ratio-form",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 368, "endLine": 396 },
+    "range": { "startLine": 372, "endLine": 400 },
     "type": "technique",
     "title": "The Ratio-Form Recurrence for Telescoping",
     "content": "qtBinom_succ_div divides qtBinom_succ by qtBinom q t N k (when nonzero) to expose the clean consecutive ratio (1 - q^(N-k) t^k)/(1 - q^(k+1) t^k). This ratio form is the natural foundation for telescoping or chain proofs where the residual qtBinom q t N k factor of the multiplicative form would otherwise need to be carried; the multiplicative form is preferred for substitution proofs (as in the t=1 specialization).",
@@ -86,7 +86,7 @@
   {
     "id": "ann-qt-bridges",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
-    "range": { "startLine": 402, "endLine": 518 },
+    "range": { "startLine": 406, "endLine": 561 },
     "type": "context",
     "title": "Bridges to the Parent's Named Objects",
     "content": "Three sections of bridge lemmas connect each polynomial-sub-lattice point to the parent gallery entry's named objects. Section VIII (S5 ACT) bridges to qNumber via qNumber_geometric: qtMultichoose_one_right_eq_qNumber and qtMultichoose_two_two_eq_qNumber. Section IX (S5b ACT) bridges the k ≤ 1 slice directly to qBinom/qMultichoose. Section X (S5c ACT) bridges the (2,2) interior point to qMultichoose via the parent's qMultichoose_two_left. Together they make the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} fully transparent: every point is equated to a parent-side object, so gallery readers can identify the (q,t)-multichoose with the established q-multichoose wherever it is t-independent.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -105,87 +105,87 @@
       "id": "preamble",
       "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 142,
+      "endLine": 151,
       "summary": "Extensive docstring tracing the S1–S6 PREP cascade and the S2–S5c ACT iterations, stating what the file does and does NOT contain (no positive q=t=1 recovery, no Pascal-style recurrence, no Macdonald-polynomial axiom). Imports Mathlib and the parent q-multichoose entry. Works over a Field R (Path A) so the Macdonald rational product is well-typed.",
       "mathContext": "Open question: does the Macdonald (q,t)-binomial, evaluated at N = n+k-1, give a well-behaved (q,t)-multichoose?"
     },
     {
       "id": "definitions",
       "title": "I. Definitions of qtBinom and qtMultichoose",
-      "startLine": 144,
-      "endLine": 165,
+      "startLine": 152,
+      "endLine": 174,
       "summary": "Defines qtBinom q t N k := ∏ i ∈ range k, (1 - q^(N-i) t^i)/(1 - q^(i+1) t^i), the 0-indexed form of the Macdonald (q,t)-binomial, and qtMultichoose q t n k := qtBinom q t (n+k-1) k. Both noncomputable over a Field R.",
       "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k) := \\prod_{i=0}^{k-1} \\frac{1 - q^{N-i} t^i}{1 - q^{i+1} t^i}, \\quad \\mathrm{qtMultichoose}(q,t,n,k) := \\mathrm{qtBinom}(q,t,n+k-1,k)$$"
     },
     {
       "id": "boundary-k0",
       "title": "II. Boundary Cases (k = 0)",
-      "startLine": 167,
-      "endLine": 180,
+      "startLine": 175,
+      "endLine": 189,
       "summary": "Empty-product boundaries: qtBinom q t N 0 = 1 and qtMultichoose q t n 0 = 1, both by simp. Tagged @[simp].",
       "mathContext": "$$\\mathrm{qtBinom}(q,t,N,0) = 1, \\quad \\mathrm{qtMultichoose}(q,t,n,0) = 1$$"
     },
     {
       "id": "boundary-k1",
       "title": "III. Boundary Cases (k = 1)",
-      "startLine": 182,
-      "endLine": 200,
+      "startLine": 190,
+      "endLine": 209,
       "summary": "Single-factor evaluations qtBinom q t N 1 = (1 - q^N)/(1 - q) and qtMultichoose q t n 1 = (1 - q^n)/(1 - q), both independent of t because the product runs over the single term i=0 where t^0 = 1.",
       "mathContext": "$$\\mathrm{qtBinom}(q,t,N,1) = \\frac{1 - q^N}{1 - q}, \\quad \\text{independent of } t$$"
     },
     {
       "id": "k-recurrence",
       "title": "IV. k-Direction Multiplicative Recurrence",
-      "startLine": 202,
-      "endLine": 223,
+      "startLine": 210,
+      "endLine": 232,
       "summary": "The foundational unconditional recurrence qtBinom_succ: qtBinom q t N (k+1) = qtBinom q t N k · ((1 - q^(N-k) t^k)/(1 - q^(k+1) t^k)), a direct application of Finset.prod_range_succ. No hypothesis on q, t, N, k.",
       "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k+1) = \\mathrm{qtBinom}(q,t,N,k) \\cdot \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$"
     },
     {
       "id": "t-eq-one",
       "title": "V. Specialization at t = 1 (S3 ACT)",
-      "startLine": 225,
-      "endLine": 294,
+      "startLine": 233,
+      "endLine": 303,
       "summary": "The private helper qBinom_mult_recur (CommRing multiplicative q-Pascal, derived by subtracting the two q-Pascal identities) bridges the Macdonald side to the Gaussian side. The headline qtBinom_at_t_eq_one (induction on k) and its corollary qtMultichoose_at_t_eq_one establish qtBinom q 1 N k = qBinom q N k and qtMultichoose q 1 n k = qMultichoose q n k, under the Path A non-degeneracy hypothesis q^(j+1) ≠ 1 for j < k.",
       "mathContext": "$$\\mathrm{qtMultichoose}(q,1,n,k) = \\mathrm{qMultichoose}(q,n,k) \\quad \\text{for } q^{j+1} \\neq 1,\\ j < k$$"
     },
     {
       "id": "sublattice-trap",
       "title": "VI. Polynomial Sub-lattice and the Field 0/0 Trap (S4 ACT)",
-      "startLine": 296,
-      "endLine": 362,
+      "startLine": 304,
+      "endLine": 371,
       "summary": "qtMultichoose_two_two: the unique interior point (2,2) cancels its t-dependence to (1 - q^3)/(1 - q) under the guard 1 - q^2 t ≠ 0. qtBinom_at_one_one_eq_zero and its qtMultichoose corollary formalize the Field-R 0/0 trap: the naive q=t=1 substitution collapses to 0, not Nat.multichoose, because the i=0 factor is 0/0 = 0.",
       "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\frac{1 - q^3}{1 - q}; \\qquad \\mathrm{qtBinom}(1,1,N,k+1) = 0 \\text{ (Field } R \\text{ trap)}$$"
     },
     {
       "id": "ratio-form",
       "title": "VII. k-Direction Telescoping Ratio Identity (S6 ACT)",
-      "startLine": 364,
-      "endLine": 396,
+      "startLine": 372,
+      "endLine": 405,
       "summary": "qtBinom_succ_div: when qtBinom q t N k ≠ 0, the consecutive ratio is the clean rational function (1 - q^(N-k) t^k)/(1 - q^(k+1) t^k). The ratio form is the natural foundation for telescoping/chain arguments, complementing the multiplicative qtBinom_succ.",
       "mathContext": "$$\\frac{\\mathrm{qtBinom}(q,t,N,k+1)}{\\mathrm{qtBinom}(q,t,N,k)} = \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$"
     },
     {
       "id": "bridges-qnumber",
       "title": "VIII. Polynomial-Form Bridges to the Parent's qNumber (S5 ACT)",
-      "startLine": 398,
-      "endLine": 457,
+      "startLine": 406,
+      "endLine": 466,
       "summary": "Three bridges expressing the polynomial-sub-lattice points as the parent's polynomial qNumber: qtBinom_one_right_eq_qNumber, qtMultichoose_one_right_eq_qNumber (at k=1, under 1 - q ≠ 0), and qtMultichoose_two_two_eq_qNumber (at (2,2), under both guards), all via qNumber_geometric.",
       "mathContext": "$$\\mathrm{qtMultichoose}(q,t,n,1) = \\mathrm{qNumber}(q,n), \\quad \\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qNumber}(q,3)$$"
     },
     {
       "id": "bridges-qbinom",
       "title": "IX. Direct Bridges to the Parent's qBinom / qMultichoose (S5b ACT)",
-      "startLine": 459,
-      "endLine": 492,
+      "startLine": 467,
+      "endLine": 501,
       "summary": "Four direct bridges from the k ≤ 1 slice to the parent's named objects: qtBinom_zero_right_eq_qBinom and qtMultichoose_zero_right_eq_qMultichoose (unconditional, both = 1), and qtBinom_one_right_eq_qBinom and qtMultichoose_one_right_eq_qMultichoose (under 1 - q ≠ 0), composing the qNumber bridges with the parent's qBinom_one_right / qMultichoose_one_right.",
       "mathContext": "$$\\mathrm{qtMultichoose}(q,t,n,1) = \\mathrm{qMultichoose}(q,n,1) \\quad (1 - q \\neq 0)$$"
     },
     {
       "id": "bridge-interior",
       "title": "X. (2,2) Interior Bridge to qMultichoose (S5c ACT)",
-      "startLine": 494,
-      "endLine": 518,
+      "startLine": 502,
+      "endLine": 561,
       "summary": "qtMultichoose_two_two_eq_qMultichoose: the unique interior polynomial-sub-lattice point equals the parent's qMultichoose q 2 2 under both Path A guards, composing qtMultichoose_two_two_eq_qNumber with the parent's qMultichoose_two_left. This closes the bridge chain: every point of {k ≤ 1} ∪ {(2,2)} is now equated directly to a parent-side named object.",
       "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qMultichoose}(q,2,2) \\quad (1 - q^2 t \\neq 0,\\ 1 - q \\neq 0)$$"
     }


### PR DESCRIPTION
Enrichment pass for arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02 (Macdonald (q,t)-binomial / multichoose coefficients).

## Drift fix
The Lean file had shifted relative to the annotation anchors. **6 of 8 annotations were hard-misaligned**, and the other **2 passed the resolver but were silently mis-anchored** (their startLines landed inside the wrong theorem bodies — e.g. the "t = 1" annotation landed inside the q-Pascal bridge lemma, and the "Field 0/0 trap" annotation landed inside the sub-lattice theorem). Remapped all 8 to their true constructs by title.
- Resolver before: Valid 2, Misaligned 6 (plus 2 silent mis-anchors)
- Resolver after: **Valid 8, Misaligned 0**, each on its correct subject

Realigned all 11 `sections` boundaries to construct spans, and extended the final section to cover the previously-uncovered `at_one_one` recovery + Path-C sharpness theorems (lines 526–561).

## Axiom integrity (checked, unchanged)
0 `axiom` declarations, 0 sorries. `status: axiomatized` is the conservative choice here because the headline t=1 / bridge results carry Path-A non-degeneracy hypotheses (conditional results); left unchanged.

## Verification
- meta.json and annotations.json parse as valid JSON.
- Resolver: 8/8 annotations valid, 0 misaligned.