### PR TITLE
Enrich ballot-problem-oq-01-oq-01-oq-02-oq-01: re-anchor 3 drifted annotations

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -72,7 +72,7 @@
     "id": "ann-conjecture-e",
     "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 276,
+      "startLine": 290,
       "endLine": 316
     },
     "type": "core-theorem",
@@ -119,7 +119,7 @@
     "id": "ann-path-b-equality",
     "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 448,
+      "startLine": 462,
       "endLine": 476
     },
     "type": "core-theorem",
@@ -142,8 +142,8 @@
     "id": "ann-sharpest-cap-one",
     "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
     "range": {
-      "startLine": 478,
-      "endLine": 605
+      "startLine": 596,
+      "endLine": 609
     },
     "type": "core-theorem",
     "title": "S12 Headline: x ≤ 1 is the Maximal Clean Alphabet for the Equality",


### PR DESCRIPTION
## Summary
Three annotations had drifted into proof bodies / onto declaration lines as the Lean source grew, clashing the custom `core-theorem` type against the resolved `theorem`/`lemma` constructs.

Re-anchored each `startLine` onto the docstring of the theorem it describes (so it resolves to the doc-comment construct, exactly like the already-valid `ann-m-jump-downward-ivt`):
- **ann-conjecture-e** → `step_in_one_neg_m_count` docstring (line 290)
- **ann-path-b-equality** → `step_in_one_pos_mixed_neg_card_eq` docstring (line 462)
- **ann-sharpest-cap-one** → `step_le_one_card_eq` docstring (line 596)

The `core-theorem` type is preserved (author's design); annotations-only change.

## Verification
`npx tsx scripts/annotations/resolver.ts validate` → **7 valid / 0 misaligned** (was 4 valid / 3 misaligned). JSON parses.