### PR TITLE
research(wilsons-theorem-oq-02-ext-oq-01): gallery entry for Miller's theorem

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02-ext-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-mul-involution-helper",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "theorem",
+    "title": "mul_involution_on_sq_eq_one: The Multiplication Involution on 2-Torsion",
+    "content": "For c in the 2-torsion (c² = 1) with c ≠ 1, the map x ↦ c·x is a fixed-point-free involution on S = {x | x²=1} with constant pair product c. The four conjuncts establish: (1) c·x stays in S (mul_sq_eq_one), (2) it is an involution (c·(c·x) = c²·x = x), (3) it is fixed-point-free (c·x = x ⇒ c = 1, contradiction), and (4) each pair multiplies to c (x·(c·x) = c·x² = c). This is the CommGroup-general copy of the parent's (private) ZMod helper, supplying exactly the data prod_involution_const consumes.",
+    "mathContext": "For $c \\in S$ with $c \\neq 1$, $\\sigma(x) = c x$ is a fixed-point-free involution on $S = \\{x : x^2 = 1\\}$ satisfying $x \\cdot \\sigma(x) = c$ for all $x \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point-free involution", "2-torsion subgroup", "constant pair product", "CommGroup"],
+    "prerequisites": ["mul_sq_eq_one", "involution definition", "Finset.filter"]
+  },
+  {
+    "id": "ann-prod-eq-one-card-ge-three",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 73, "endLine": 129 },
+    "type": "theorem",
+    "title": "prod_eq_one_of_two_torsion_card_ge_three: The Two-Involution Trick, Generalized",
+    "content": "If the 2-torsion S = {x | x²=1} of a finite abelian group has at least three elements, then ∏G = 1. After reducing ∏G to ∏S, pick distinct c, d ∈ S\\{1}. The involution x↦cx gives ∏S = c^(|S|/2); the involution x↦(cd)x gives ∏S = (cd)^(|S|/2) = c^(|S|/2)·d^(|S|/2). Cancelling c^(|S|/2) forces d^(|S|/2) = 1, and substituting back gives c^(|S|/2) = 1, hence ∏S = 1. This is the direct OQ-01 answer: a verbatim generalization of the parent's (ZMod n)×-specific lemma with the cardinality bound replaced by the hypothesis hcard.",
+    "mathContext": "If $|S| \\geq 3$ for $S = \\{x \\in G : x^2 = 1\\}$, then $\\prod_{x \\in G} x = 1$. Two FPF involutions yield $\\prod S = c^{|S|/2}$ and $\\prod S = (cd)^{|S|/2}$, forcing $d^{|S|/2} = c^{|S|/2} = 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["two-involution trick", "prod_involution_const", "2-torsion", "cancellation"],
+    "prerequisites": ["prod_eq_prod_sq_eq_one", "prod_involution_const", "mul_involution_on_sq_eq_one", "Finset.card_le_card"]
+  },
+  {
+    "id": "ann-prod-eq-one-card-ne-two",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 133, "endLine": 148 },
+    "type": "theorem",
+    "title": "prod_eq_one_of_card_ne_two: Folding in the Trivial Cases",
+    "content": "If |S| ≠ 2 then ∏G = 1. Since 1 ∈ S always, |S| ≥ 1. The case |S| = 1 forces S = {1}, so ∏S = 1 directly; the case |S| ≥ 2 with |S| ≠ 2 gives |S| ≥ 3, handled by the two-involution trick. This packages the full 'non-unique-involution' branch of Miller's theorem into a single hypothesis on the 2-torsion cardinality.",
+    "mathContext": "If $|S| \\neq 2$ then $\\prod_{x \\in G} x = 1$, combining the trivial $|S| = 1$ case ($S = \\{1\\}$) with the $|S| \\geq 3$ trick.",
+    "significance": "key",
+    "relatedConcepts": ["case analysis", "2-torsion cardinality", "Finset.card_eq_one"],
+    "prerequisites": ["prod_eq_one_of_two_torsion_card_ge_three", "Finset.card_pos", "Finset.card_eq_one"]
+  },
+  {
+    "id": "ann-prod-eq-unique-involution",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 152, "endLine": 168 },
+    "type": "theorem",
+    "title": "prod_eq_unique_involution: The Unique-Involution Case",
+    "content": "If t is the unique element of order 2 (t ≠ 1, t² = 1, and every square root of unity is 1 or t), then ∏G = t. The hypotheses pin S = {1, t} exactly (antisymmetry of ⊆), and the product over the pair {1, t} is 1·t = t. This is the second branch of Miller's disjunction — the only way a finite abelian group's element product can fail to be the identity.",
+    "mathContext": "If $S = \\{1, t\\}$ with $t \\neq 1$ the unique involution, then $\\prod_{x \\in G} x = \\prod_{x \\in \\{1,t\\}} x = t$.",
+    "significance": "key",
+    "relatedConcepts": ["unique involution", "Finset.prod_pair", "Finset.Subset.antisymm", "2-torsion"],
+    "prerequisites": ["prod_eq_prod_sq_eq_one", "Finset.prod_pair", "Finset.Subset.antisymm"]
+  },
+  {
+    "id": "ann-miller-prod",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 173, "endLine": 198 },
+    "type": "theorem",
+    "title": "miller_prod: Miller's Theorem (1903)",
+    "content": "The headline result: in a finite abelian group, either ∏G = 1, or there exists a unique element t of order 2 with ∏G = t. The proof cases on whether |S| = 2. If |S| = 2, then S = {1, t}; extracting t (the non-identity element of the pair) gives the unique-involution branch via prod_eq_unique_involution. Otherwise |S| ≠ 2 and prod_eq_one_of_card_ne_two gives ∏G = 1. This is the full Miller disjunction unifying both cases.",
+    "mathContext": "$\\left(\\prod_{x} x = 1\\right) \\lor \\left(\\exists t,\\ t \\neq 1 \\land t^2 = 1 \\land (\\forall s,\\ s^2 = 1 \\to s = 1 \\lor s = t) \\land \\prod_{x} x = t\\right)$.",
+    "significance": "critical",
+    "relatedConcepts": ["Miller's theorem", "disjunction", "unique element of order 2", "Finset.card_eq_two"],
+    "prerequisites": ["prod_eq_one_of_card_ne_two", "prod_eq_unique_involution", "Finset.card_eq_two"]
+  },
+  {
+    "id": "ann-prod-ne-one-iff",
+    "proofId": "wilsons-theorem-oq-02-ext-oq-01",
+    "range": { "startLine": 204, "endLine": 214 },
+    "type": "theorem",
+    "title": "prod_ne_one_iff_unique_involution: Subsumption of the (ZMod n)× Law",
+    "content": "∏G ≠ 1 if and only if G has a unique involution. The forward direction uses miller_prod (if the product is not 1, the disjunction forces the unique-involution branch); the backward direction uses prod_eq_unique_involution (a unique involution t gives ∏G = t ≠ 1). This shows a non-identity ('-1-style') product can arise only through a unique element of order 2 — so the gallery's gaussWilson_abstract_ext is exactly the G = (ZMod n)× instance, whose unique involution is -1 precisely when the group is cyclic.",
+    "mathContext": "$\\prod_{x} x \\neq 1 \\iff \\exists t,\\ t \\neq 1 \\land t^2 = 1 \\land \\forall s,\\ s^2 = 1 \\to s = 1 \\lor s = t$.",
+    "significance": "key",
+    "relatedConcepts": ["converse characterization", "unique involution", "gaussWilson_abstract_ext", "cyclic groups"],
+    "prerequisites": ["miller_prod", "prod_eq_unique_involution"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-02-ext-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02-ext-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "wilsons-theorem-oq-02-ext-oq-01",
+  "title": "Miller's Theorem: The Two-Involution Trick for Finite Abelian Groups",
+  "slug": "wilsons-theorem-oq-02-ext-oq-01",
+  "description": "Generalizes the two-involution trick from (ZMod n)× to arbitrary finite abelian groups, answering OQ-01 of the Gauss-Wilson extension. The headline is Miller's theorem (1903): in a finite abelian group G, the product of all elements is 1, unless G has a unique element of order 2, in which case the product is that element. The proof is purely group-theoretic — it reuses the group-general engines prod_eq_prod_sq_eq_one and prod_involution_const, replacing the ZMod-specific cardinality bound with the abstract hypothesis |{x | x²=1}| ≥ 3. A corollary shows the product is a non-identity value only via a unique involution, so the (ZMod n)× case is the only route to a -1-style product.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ02ExtOQ01.lean",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "lineCount": 220,
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.WilsonsTheoremOQ02Ext"
+    ],
+    "tags": [
+      "group-theory",
+      "abelian-groups",
+      "wilson",
+      "gauss-wilson",
+      "involutions",
+      "2-torsion",
+      "miller-theorem"
+    ],
+    "assumptions": [],
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "module-setup",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports Mathlib.Tactic and the parent WilsonsTheoremOQ02Ext module, opening it to reuse the group-general lemmas prod_eq_prod_sq_eq_one, prod_involution_const, and mul_sq_eq_one. Module documentation explains how the two-involution trick, originally proved for (ZMod n)×, is in fact a theorem about arbitrary finite abelian groups. Sets the variable context [CommGroup G] [Fintype G] [DecidableEq G]."
+    },
+    {
+      "id": "involution-helper",
+      "title": "Generalized Two-Involution Helper",
+      "startLine": 42,
+      "endLine": 63,
+      "summary": "mul_involution_on_sq_eq_one (private): for c in the 2-torsion with c ≠ 1, the map x ↦ c·x is a fixed-point-free involution on S = {x | x²=1} with constant pair product c. This is the CommGroup-general copy of the (private) ZMod helper from the parent file, providing the involution data needed by prod_involution_const."
+    },
+    {
+      "id": "main-trick",
+      "title": "The Two-Involution Trick, Generalized",
+      "startLine": 65,
+      "endLine": 148,
+      "summary": "prod_eq_one_of_two_torsion_card_ge_three: if |S| ≥ 3 then ∏G = 1. Picks distinct c, d ∈ S\\{1}; the involutions x↦cx and x↦cdx both compute ∏S, giving c^(|S|/2) = (cd)^(|S|/2), which forces d^(|S|/2) = 1 and then c^(|S|/2) = 1, so ∏S = 1. prod_eq_one_of_card_ne_two folds in the trivial |S| ∈ {0,1} cases, concluding ∏G = 1 whenever |S| ≠ 2."
+    },
+    {
+      "id": "unique-involution",
+      "title": "Unique-Involution Case and Miller's Disjunction",
+      "startLine": 150,
+      "endLine": 198,
+      "summary": "prod_eq_unique_involution: if t is the unique element of order 2 then ∏G = t (since S = {1, t}). miller_prod: the full Miller (1903) disjunction — either ∏G = 1, or there is a unique involution t with ∏G = t — obtained by casing on whether |S| = 2."
+    },
+    {
+      "id": "subsumption",
+      "title": "Subsumption of the (ZMod n)× Law",
+      "startLine": 200,
+      "endLine": 220,
+      "summary": "prod_ne_one_iff_unique_involution: ∏G ≠ 1 if and only if G has a unique involution. This shows a -1-style (non-identity) product can only arise through a unique element of order 2, so the gallery's gaussWilson_abstract_ext is exactly the instance G = (ZMod n)×, whose unique involution is -1 precisely when the group is cyclic."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The result that the product of all elements of a finite abelian group is the identity — except when there is a unique element of order 2, in which case the product is that element — is due to G. A. Miller (1903) and is the group-theoretic heart of Gauss's generalization of Wilson's theorem (Disquisitiones Arithmeticae, 1801). Wilson's theorem itself, $(p-1)! \\equiv -1 \\pmod p$, was stated around 1770 and proved by Lagrange in 1771. The classical $(\\mathbb{Z}/n)^\\times$ statements are all special cases of Miller's abstract theorem: the product of units is $-1$ exactly when $(\\mathbb{Z}/n)^\\times$ has a unique involution, i.e. when it is cyclic. This file isolates the purely group-theoretic content — the two-involution trick — from the number-theoretic 2-torsion bound, showing the trick never uses anything specific to $\\mathbb{Z}/n$.",
+    "problemStatement": "Let $G$ be a finite abelian group and $S = \\{x \\in G : x^2 = 1\\}$ its 2-torsion subgroup. Prove that $\\prod_{x \\in G} x = 1$ whenever $|S| \\neq 2$, and that $\\prod_{x \\in G} x = t$ when $S = \\{1, t\\}$ has a unique non-identity involution $t$. Equivalently, establish Miller's disjunction: the product of all group elements is $1$ unless $G$ has a unique element of order $2$, in which case it equals that element.",
+    "proofStrategy": "Reduce $\\prod_{x \\in G} x$ to $\\prod_{x \\in S} x$ (the parent lemma prod_eq_prod_sq_eq_one pairs each $x \\notin S$ with $x^{-1}$). Then case on $|S|$. If $|S| \\geq 3$, pick distinct $c, d \\in S \\setminus \\{1\\}$. The map $x \\mapsto c x$ is a fixed-point-free involution on $S$ with constant pair product $c$, so $\\prod S = c^{|S|/2}$ by prod_involution_const; likewise $x \\mapsto (cd) x$ gives $\\prod S = (cd)^{|S|/2} = c^{|S|/2} d^{|S|/2}$. Equating the two forces $d^{|S|/2} = 1$, and symmetrically $c^{|S|/2} = 1$, hence $\\prod S = 1$. The cases $|S| \\in \\{0,1\\}$ are trivial ($1 \\in S$ always, and $|S|=1$ gives $S = \\{1\\}$). If $|S| = 2$, then $S = \\{1, t\\}$ and $\\prod S = t$ directly. Assembling the cases yields miller_prod.",
+    "keyInsights": [
+      "The two-involution trick is entirely group-theoretic: nothing in prod_eq_one_of_two_torsion_card_ge_three uses (ZMod n)× structure. Only the derivation of |S| ≥ 3 is number-theoretic, so abstracting that to a hypothesis turns the trick into a clean theorem about arbitrary finite abelian groups.",
+      "Two distinct fixed-point-free involutions on the same set S each compute ∏S but yield different closed forms — c^(|S|/2) and (cd)^(|S|/2). Equating them and cancelling forces d^(|S|/2) = 1, the algebraic mechanism that collapses the product to the identity.",
+      "The dichotomy is governed solely by |S|: when |S| ≠ 2 the product is 1, and when |S| = 2 the single non-identity involution is the product. The classical 'product = -1' phenomenon is therefore not special to modular arithmetic — it is the unique-involution case of Miller's theorem.",
+      "prod_eq_prod_sq_eq_one and prod_involution_const, proved generically in the parent file, are reused verbatim here; the coercion wrappers needed for (ZMod n)× simply drop away, which is why the generalization is a 'verbatim' lift rather than a re-proof.",
+      "prod_ne_one_iff_unique_involution gives a converse-flavored characterization: the product is a non-identity element precisely when a unique involution exists. This pins down exactly which finite abelian groups exhibit the Wilson-style -1 and shows (ZMod n)× is the canonical instance."
+    ]
+  },
+  "conclusion": {
+    "summary": "Miller's theorem (1903) is machine-checked for arbitrary finite abelian groups with zero axioms and zero sorries: the product of all elements is 1 unless a unique involution exists, in which case it is that involution. The proof lifts the two-involution trick out of the (ZMod n)× setting by abstracting the 2-torsion cardinality bound to a hypothesis.",
+    "implications": "This answers OQ-01 of the Gauss-Wilson extension affirmatively and reusably: the two-involution trick is a theorem about finite abelian groups, not a fact about modular arithmetic. Any concrete Gauss-Wilson product law — over (ZMod n)×, over unit groups of finite rings, or in other finite abelian settings — is now an instance obtained by supplying the relevant 2-torsion count. The converse characterization prod_ne_one_iff_unique_involution localizes the entire -1 phenomenon to the existence of a unique element of order 2.",
+    "openQuestions": [
+      "Does Miller's theorem combine with a 2-torsion count for unit groups of rings of integers $\\mathcal{O}_K$ to characterize when $\\prod_{u} u$ over a finite quotient is a non-identity element?",
+      "Can prod_ne_one_iff_unique_involution be packaged as a Mathlib-level lemma about CommGroup products, with (ZMod n)× cyclicity supplying the unique-involution side condition?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "wilsons-theorem-oq-02-ext",
+      "relationship": "extends",
+      "description": "Generalizes the parent's two-involution trick from (ZMod n)× to arbitrary finite abelian groups, reusing its group-general lemmas prod_eq_prod_sq_eq_one and prod_involution_const."
+    },
+    {
+      "proofId": "wilsons-theorem",
+      "relationship": "extends",
+      "description": "Abstracts the structural mechanism behind Wilson's theorem and its Gauss generalization into a single statement about finite abelian groups (Miller 1903)."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/WilsonsTheoremOQ02ExtOQ01.lean",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "imports": [
+      "import Mathlib.Tactic",
+      "import Proofs.WilsonsTheoremOQ02Ext"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "WilsonsTheoremOQ02ExtOQ01"
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-01.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-01.json
@@ -5,8 +5,8 @@
   "path": "proofs/Proofs/WilsonsTheoremOQ02ExtOQ01.lean",
   "started": "2026-06-15",
   "lastUpdate": "2026-06-15",
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "tier": "B",
   "tractability": 7,
   "tags": [
@@ -26,7 +26,8 @@
       "The classical result is Miller's theorem (1903): in a finite abelian group, ∏ of all elements = 1 unless there is a unique element of order 2 (a unique involution), in which case ∏ = that element.",
       "The gallery's caution note ('general |S| ≥ 3 from ¬cyclic is FALSE, e.g. Z/3×Z/3') is about deriving |S|≥3 from non-cyclicity, NOT about the trick. Z/3×Z/3 has |S|=1 and ∏=1, fully consistent with Miller. Taking |S|≥3 as a hypothesis sidesteps this entirely.",
       "Classification by 2-torsion size: |S|=1 ⟹ ∏=1; |S|=2 ⟹ ∏ = the unique involution; |S|≥3 ⟹ ∏=1 (the trick). 1 ∈ S always, so |S|≥1.",
-      "Mathlib has the finite-abelian structure theorem (GroupTheory.FiniteAbelian.Basic) but not Miller's product-of-all-elements classification; the gallery file recreates the involution machinery from scratch."
+      "Mathlib has the finite-abelian structure theorem (GroupTheory.FiniteAbelian.Basic) but not Miller's product-of-all-elements classification; the gallery file recreates the involution machinery from scratch.",
+      "Proof was complete-but-ungalleried: WilsonsTheoremOQ02ExtOQ01.lean was merged (#24251) and registered but had no src/data/proofs dir; this session supplied gallery data only (no Lean change)"
     ],
     "builtItems": [
       "prod_eq_one_of_two_torsion_card_ge_three (WilsonsTheoremOQ02ExtOQ01.lean): general CommGroup, |S|≥3 ⟹ ∏ G = 1 — the direct OQ-01 answer",
@@ -34,7 +35,8 @@
       "prod_eq_unique_involution: unique involution t ⟹ ∏ G = t",
       "miller_prod: full Miller disjunction (∏=1 ∨ ∃ unique involution t with ∏=t)",
       "prod_ne_one_iff_unique_involution: ∏ G ≠ 1 ⟺ G has a unique involution",
-      "proofs/scripts/verify_miller_two_involution.py: exact group-arithmetic verifier (38 tabulated + 155 exhaustive abelian groups, checks A-E)"
+      "proofs/scripts/verify_miller_two_involution.py: exact group-arithmetic verifier (38 tabulated + 155 exhaustive abelian groups, checks A-E)",
+      "Gallery entry src/data/proofs/wilsons-theorem-oq-02-ext-oq-01/ (meta.json + 6 annotations, resolver 6/0) for the verified Miller-theorem proof (0 sorry/0 axiom, registered Proofs.lean:3087)"
     ],
     "mathlibGaps": [
       "Mathlib (v4.26.0) lacks a general 'product of all elements of a finite abelian group' / Miller's theorem; only the structure theorem is present."
@@ -44,6 +46,6 @@
       "Optionally re-derive gaussWilson_abstract_ext for (ZMod n)ˣ as a corollary of the general theorem to demonstrate full subsumption.",
       "Consider contributing Miller's theorem upstream to Mathlib (self-contained, ~150 LOC, fills an obvious gap)."
     ],
-    "progressSummary": "PROGRESS: OQ-01 answered YES. General Lean theorems written (no sorries), math exact-verified; build-pending under Docker/Aristotle blackout."
+    "progressSummary": "COMPLETE: Miller (1903) two-involution trick generalized to finite abelian groups; verified 0/0; gallery entry added"
   }
 }


### PR DESCRIPTION
## Summary
- Adds the missing gallery directory for `WilsonsTheoremOQ02ExtOQ01.lean` — **Miller's theorem (1903)**: in a finite abelian group the product of all elements is `1`, unless the group has a unique element of order 2, in which case the product is that element.
- The proof is **verified** (0 sorry / 0 axiom), merged via #24251, and registered at `proofs/Proofs.lean:3087`, but had no `src/data/proofs/<slug>/` entry — it was complete-but-ungalleried.
- Adds `meta.json` (status `verified`, badge `original`, axiomCount 0, 5 sections) and `annotations.json` (6 annotations, one per theorem; resolver reports **6 valid / 0 misaligned**).
- Advances research problem `wilsons-theorem-oq-02-ext-oq-01` to `COMPLETED`.

This generalizes the two-involution trick from `(ZMod n)ˣ` (parent entry `wilsons-theorem-oq-02-ext`) to arbitrary finite abelian groups, reusing the parent's group-general lemmas `prod_eq_prod_sq_eq_one` and `prod_involution_const`. The corollary `prod_ne_one_iff_unique_involution` shows a `-1`-style product can only arise via a unique involution, so `(ZMod n)ˣ` is the canonical instance.

**No Lean source changes** — gallery data only.

## Test plan
- [x] `node JSON.parse` on meta.json and annotations.json
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 6 valid / 0 misaligned
- [x] Confirmed file registered in Proofs.lean and 0 sorry / 0 axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)