### PR TITLE
research(cube-root-3-irrational-oq-04): add gallery entry for CF prefix proof

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-04/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-04/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-cbrt3oq04-header",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 41, "endLine": 68 },
+    "type": "concept",
+    "title": "Continued Fraction Prefix of ∛3 — Strategy",
+    "content": "This file certifies the leading partial quotients of the simple continued fraction of cbrt3 = (3:ℝ)^(1/3). Because ∛3 is a cubic irrational, Lagrange's theorem (1770) forbids the continued fraction from being eventually periodic, so no closed form exists and a finite formalization can only verify a fixed-length prefix one quotient at a time. The strategy: each partial-quotient identity aₙ = ⌊xₙ⌋ reduces to two rational bounds on ∛3, and each bound is proved by cubing both sides and substituting (∛3)³ = 3.",
+    "mathContext": "The continued-fraction tails are x₀ = ∛3, xₙ₊₁ = 1/(xₙ − aₙ), aₙ = ⌊xₙ⌋. The non-periodicity of $[a_0; a_1, a_2, \\dots]$ for a degree-3 irrational is exactly Lagrange's characterization of quadratic irrationals by periodicity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple continued fraction",
+      "Lagrange periodicity theorem",
+      "cubic irrational",
+      "OEIS A002945"
+    ],
+    "prerequisites": [
+      "CubeRoot3Irrational.cbrt3_cubed",
+      "Int.le_floor / Int.floor_lt"
+    ]
+  },
+  {
+    "id": "ann-cbrt3oq04-nonneg",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 74, "endLine": 94 },
+    "type": "lemma",
+    "title": "Sign and Base Bounds for ∛3",
+    "content": "cbrt3_nonneg (0 ≤ ∛3) is immediate from the rpow definition. one_le_cbrt3 (1 ≤ ∛3) and cbrt3_lt_two (∛3 < 2) are the first cubing arguments: assuming the negation gives ∛3³ < 1 or ∛3³ ≥ 8, each contradicting ∛3³ = 3. These are the bounds 1 < 3 < 8 that pin a₀.",
+    "mathContext": "From $0 \\le \\sqrt[3]{3} < 1$ one gets $(\\sqrt[3]{3})^3 < 1$; from $2 \\le \\sqrt[3]{3}$ one gets $(\\sqrt[3]{3})^3 \\ge 8$. Both contradict $(\\sqrt[3]{3})^3 = 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["rpow nonnegativity", "cubing a bound", "nlinarith"],
+    "prerequisites": ["Real.rpow_nonneg", "CubeRoot3Irrational.cbrt3_cubed"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a0",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 112, "endLine": 129 },
+    "type": "theorem",
+    "title": "a₀ = 1 — First Partial Quotient ⌊∛3⌋ = 1",
+    "content": "cbrt3_floor_eq_one combines 1 ≤ ∛3 and ∛3 < 2 via le_antisymm using Int.le_floor and Int.floor_lt. This is a₀ = 1 in the prefix [1; 2, 3, 1, 4, …] of OEIS A002945 and establishes the le_antisymm + floor-characterization template reused for every subsequent quotient.",
+    "mathContext": "$\\lfloor \\sqrt[3]{3} \\rfloor = 1$ because $1 \\le \\sqrt[3]{3} < 2$. The upper half uses `Int.floor_lt` (⌊x⌋ < 2 ⟸ x < 2) then `omega`; the lower half uses `Int.le_floor` (1 ≤ ⌊x⌋ ⟸ 1 ≤ x).",
+    "significance": "key",
+    "relatedConcepts": ["floor function", "le_antisymm", "continued fraction a₀"],
+    "prerequisites": ["Int.le_floor", "Int.floor_lt"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a1",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 173, "endLine": 203 },
+    "type": "theorem",
+    "title": "a₁ = 2 — ⌊1/(∛3 − 1)⌋ = 2",
+    "content": "cbrt3_a1 uses the strict bounds 4/3 < ∛3 < 3/2 (cube targets 64/27 < 3 < 27/8) to get 1/3 < ∛3 − 1 < 1/2, hence 2 < 1/(∛3 − 1) < 3. The denominator positivity 0 < ∛3 − 1 comes from 4/3 < ∛3, and the reciprocal step is handled by div_lt_iff₀ / le_div_iff₀.",
+    "mathContext": "$\\tfrac{4}{3} < \\sqrt[3]{3} < \\tfrac{3}{2}$ gives $\\tfrac{1}{3} < \\sqrt[3]{3}-1 < \\tfrac{1}{2}$, so $2 < \\tfrac{1}{\\sqrt[3]{3}-1} < 3$ and the floor is 2.",
+    "significance": "key",
+    "relatedConcepts": ["reciprocal of a tail", "div_lt_iff₀", "continued fraction a₁"],
+    "prerequisites": ["div_lt_iff₀", "le_div_iff₀", "Int.le_floor"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a2",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 260, "endLine": 304 },
+    "type": "theorem",
+    "title": "a₂ = 3 — Tight Cubing Sandwich 10/7 < ∛3 < 13/9",
+    "content": "cbrt3_a2 proves ⌊1/(1/(∛3−1)−2)⌋ = 3. The needed bounds 10/7 < ∛3 < 13/9 have cube targets 1000/343 < 3 < 2197/729, both within 0.1 of 3 — the cubing argument is delicate but follows the S2/S3 template. The algebraic chain 9/4 < 1/(∛3−1) < 7/3 ⟹ 1/4 < tail < 1/3 ⟹ 3 < 1/tail < 4 is purely linear after inverting positive denominators.",
+    "mathContext": "$(10/7)^3 = 1000/343 < 1029/343 = 3$ and $(13/9)^3 = 2197/729 > 2187/729 = 3$. The convergents $10/7$ and $13/9$ are $h_2/k_2$ and $h_3/k_3$.",
+    "significance": "key",
+    "relatedConcepts": ["convergents", "cubing sandwich", "continued fraction a₂"],
+    "prerequisites": ["lt_div_iff₀", "div_lt_iff₀"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a3-a4",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 346, "endLine": 462 },
+    "type": "insight",
+    "title": "a₃ = 1, a₄ = 4 — The Reciprocal Chain Deepens",
+    "content": "cbrt3_a3 (⟶ 1) and cbrt3_a4 (⟶ 4) introduce the nested tails x₂, x₃, x₄. Each new quotient adds one reciprocal layer: from a two-sided bound on ∛3 (here 23/16 < ∛3 < 13/9 for a₃, then 62/43 < ∛3 < 75/52 for a₄, imported from the helper file) the proof propagates strict bounds through xₙ₊₁ = 1/xₙ − aₙ by a uniform chain of lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ rewrites, each closed by linarith. The mathematics does not change — only the bookkeeping depth.",
+    "mathContext": "The convergent endpoints tighten: the a₄ sandwich $62/43 < \\sqrt[3]{3} < 75/52$ has cube gaps $\\approx 2.4\\cdot10^{-3}$ and $3.6\\cdot10^{-4}$, the tightest so far, consistent with $62/43$ being the fifth convergent.",
+    "significance": "supporting",
+    "relatedConcepts": ["nested reciprocals", "uniform proof template", "convergent tightening"],
+    "prerequisites": ["CubeRoot3IrrationalOQ04Helpers"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a5-a6",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 576, "endLine": 738 },
+    "type": "theorem",
+    "title": "a₅ = 1, a₆ = 5 — Cubing Gap Reaches 10⁻⁵",
+    "content": "cbrt3_a5 (⟶ 1) and cbrt3_a6 (⟶ 5) use the sixth and seventh convergents 437/303 and 512/355. The lower bound 437/303 has cube target 83453453/27818127 < 3, off by only ≈ 3.3·10⁻⁵; the upper bound 512/355 (from a₇ = 1: p₇ = 1·437+75, q₇ = 1·303+52) has gap ≈ 2.5·10⁻⁵ — the tightest cubing boundaries in the prefix. The eleven- and twelve-step reciprocal chains remain entirely linear.",
+    "mathContext": "$512^3 = 134{,}217{,}728 > 134{,}216{,}625 = 3\\cdot355^3$, gap $1103/44{,}738{,}875$. The sixth convergent $437/303$ lies below ∛3, the seventh $512/355$ above — a strictly two-sided sandwich.",
+    "significance": "key",
+    "relatedConcepts": ["convergent recurrence", "alternating convergents", "continued fraction a₅ a₆"],
+    "prerequisites": ["CubeRoot3IrrationalOQ04Helpers"]
+  },
+  {
+    "id": "ann-cbrt3oq04-a7-a11",
+    "proofId": "cube-root-3-irrational-oq-04",
+    "range": { "startLine": 893, "endLine": 1777 },
+    "type": "insight",
+    "title": "a₇..a₁₁ = 1, 1, 6, 2, 5 — Completing the OEIS A002945 Prefix",
+    "content": "cbrt3_a7 through cbrt3_a11 extend the certified prefix to twelve terms [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5], matching OEIS A002945. Each is the same cubing-sandwich template one reciprocal layer deeper, using progressively finer convergent bounds from the helper file. Past this point, adding quotients yields more digits of an astronomically tight sandwich but no new structural information — the Lagrange obstruction (no closed form for a cubic irrational's continued fraction) is sharp.",
+    "mathContext": "The prefix $[1;2,3,1,4,1,5,1,1,6,2,5]$ shows no large partial quotient, consistent with — but not proving — the open conjecture that algebraic irrationals of degree $\\ge 3$ have bounded continued-fraction quotients.",
+    "significance": "context",
+    "relatedConcepts": ["OEIS A002945", "bounded partial quotients conjecture", "Lagrange obstruction"],
+    "prerequisites": ["CubeRoot3IrrationalOQ04Helpers"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
@@ -1,0 +1,101 @@
+{
+  "id": "cube-root-3-irrational-oq-04",
+  "title": "Continued Fraction Prefix of ∛3: First Twelve Partial Quotients",
+  "slug": "cube-root-3-irrational-oq-04",
+  "description": "Computes and machine-verifies the first twelve partial quotients of the simple continued fraction of ∛3, confirming the prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5] of OEIS A002945. Each partial quotient aₙ = ⌊xₙ⌋ is pinned by a two-sided rational sandwich obtained from successive convergents; the irrational xₙ is compared to its rational bounds by cubing both sides and substituting (∛3)³ = 3, reducing every step to linear arithmetic. Because ∛3 has degree 3 over ℚ, Lagrange's theorem forbids the continued fraction from being eventually periodic, so no closed form exists and a finite formalization can only certify a fixed-length prefix one quotient at a time.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-05-13",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ04.lean",
+    "tags": [
+      "continued-fractions",
+      "number-theory",
+      "cube-roots",
+      "irrationality",
+      "diophantine-approximation",
+      "oeis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "None — fully verified. Depends on CubeRoot3Irrational (for cbrt3 and cbrt3_cubed) and CubeRoot3IrrationalOQ04Helpers (for the convergent cubing bounds 23/16, 62/43, 75/52, 437/303, 512/355, …).",
+    "lineCount": 1999,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "originalContributions": [
+      "cbrt3_floor_eq_one: ⌊∛3⌋ = 1 (a₀), from the cube bounds 1 < 3 < 8",
+      "cbrt3_a1 … cbrt3_a11: the next eleven partial quotients 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, each as an explicit nested-reciprocal floor identity",
+      "A uniform cubing-sandwich template: cube a rational two-sided bound on the current tail xₙ, substitute (∛3)³ = 3, and discharge the resulting integer inequality, then propagate through the reciprocal/subtraction chain by linarith",
+      "Verification that the prefix matches OEIS A002945 through a₁₁, with the cubing gap shrinking to ≈10⁻⁵ at the sixth and seventh convergents"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The simple continued fraction of an algebraic irrational of degree ≥ 3 is one of the oldest unsolved structural problems in number theory. **Lagrange** (1770, Additions au mémoire sur la résolution des équations numériques) proved that a continued fraction is eventually periodic if and only if its value is a quadratic irrational. Since ∛3 is a root of the Eisenstein-irreducible cubic X³ − 3 (degree exactly 3 over ℚ), its continued fraction is provably non-periodic — yet no one knows whether its partial quotients are bounded, nor any pattern governing them. This is a special case of a famous open problem: it is unknown whether the partial quotients of any algebraic number of degree ≥ 3 are bounded. The numerical prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, …] is catalogued as OEIS A002945. **Roth's theorem** (1955) shows the irrationality measure of ∛3 is exactly 2, which constrains but does not determine the growth of the partial quotients.",
+    "problemStatement": "**Open Question OQ-04 from cube-root-3-irrational**: the simple continued fraction of ∛3 has no closed form (Lagrange forbids periodicity for a cubic irrational). What can be formally certified is a finite prefix. This file pins the first twelve partial quotients a₀, …, a₁₁ of ∛3, each as a Lean theorem about a concrete nested-reciprocal floor.",
+    "proofStrategy": "Each partial quotient is the floor of a tail value xₙ defined by the continued-fraction algorithm x₀ = ∛3, xₙ₊₁ = 1/(xₙ − aₙ). To show aₙ = ⌊xₙ⌋ = k it suffices to prove the two strict bounds k ≤ xₙ < k+1, which unfold into a two-sided rational sandwich on ∛3 itself. Each rational bound p/q ⋛ ∛3 is decided by cubing: (p/q)³ ⋛ 3, an exact integer comparison, after substituting (∛3)³ = 3 via the explicit factorization ∛3·∛3·∛3 and nlinarith. The rational endpoints are exactly the continued-fraction convergents hₙ/kₙ, so the sandwich tightens geometrically — the cube gap at the sixth convergent 437/303 is already ≈ 3.3·10⁻⁵. With ∛3 trapped, every downstream reciprocal/subtraction step xₙ₊₁ = 1/(xₙ − aₙ) is linear (inverting a strictly-positive denominator with lt_div_iff₀ / div_lt_iff₀), and the floor identity closes by le_antisymm through Int.le_floor / Int.floor_lt.",
+    "keyInsights": [
+      "**Cubing converts an algebraic comparison into integer arithmetic.** The only non-elementary fact used is (∛3)³ = 3 (cbrt3_cubed). Every bound p/q ⋛ ∛3 becomes p³ ⋛ 3q³, decided by norm_num/nlinarith — no analytic estimates of ∛3 are ever needed.",
+      "**Convergents are the natural sandwich endpoints.** The rational bounds are not guessed: they are the CF convergents hₙ/kₙ, which alternate above and below ∛3 and converge at rate O(1/(kₙ kₙ₊₁)). This is why the bounds in the helper file (23/16, 62/43, 75/52, 437/303, 512/355, …) get tighter at each step and why the cubing comparison stays decidable in exact rational arithmetic.",
+      "**The Lagrange obstruction is sharp.** Because ∛3 is a cubic irrational, no recursive formula aₙ = f(n) with f simpler than the CF algorithm itself can exist; a finite prefix is the most a formalization can deliver. Adding further quotients yields more digits of an astronomically tight sandwich but no new structural information.",
+      "**Each quotient is one application of a fixed template.** The proofs of a₃ through a₁₁ are structurally identical chains of lt_div_iff₀ / div_lt_iff₀ / le_div_iff₀ rewrites, deepening by one reciprocal layer per quotient. The difficulty is bookkeeping the nested expression, not new mathematics.",
+      "**Boundedness of the quotients is open.** The computed prefix shows no large partial quotient, consistent with — but not proving — the conjecture that algebraic numbers of degree ≥ 3 have bounded continued-fraction quotients. That conjecture is wide open; this file is purely descriptive of the prefix."
+    ],
+    "prerequisites": [
+      "CubeRoot3Irrational.lean: the definition cbrt3 = (3:ℝ)^(1/3:ℝ) and the identity cbrt3_cubed : cbrt3 ^ 3 = 3",
+      "CubeRoot3IrrationalOQ04Helpers.lean: the convergent cubing bounds (lt_cbrt3_iff_cube_lt / cbrt3_lt_iff_three_lt_cube and the specific rational bounds 23/16, 62/43, 75/52, 437/303, 512/355)",
+      "Mathlib floor API: Int.le_floor, Int.floor_lt, and the ordered-field reciprocal lemmas lt_div_iff₀, div_lt_iff₀, le_div_iff₀"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "extends",
+      "description": "Parent proof that ∛3 is irrational. This file goes further, exhibiting the explicit continued-fraction prefix whose very existence (non-periodicity) is a refinement of irrationality, guaranteed by Lagrange's theorem for the cubic irrational ∛3."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02",
+      "relationship": "thematic",
+      "description": "Sibling open question: proves ∛3 irrational via Eisenstein irreducibility of X³−3. That irreducibility (degree exactly 3 over ℚ) is precisely the hypothesis Lagrange's theorem needs to conclude the continued fraction here is non-periodic, so no closed form exists."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verifies the first twelve partial quotients of the simple continued fraction of ∛3 — the prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5] of OEIS A002945 — by a uniform cubing-sandwich method that reduces each algebraic floor identity to exact integer arithmetic plus linear reciprocal chains. 19 theorems, 0 sorries, 0 axioms.",
+    "implications": "**Descriptive, not structural.** The continued fraction of a cubic irrational is non-periodic (Lagrange) and has no known closed form; a formalization can therefore only certify a finite prefix, which this file does as far as a₁₁. The cubing-sandwich template is reusable for the continued fraction of any algebraic number whose defining power identity (here (∛3)³ = 3) lets a rational comparison be cubed into integer arithmetic.",
+    "openQuestions": [
+      "Are the partial quotients of ∛3 bounded? This is open and is a special case of the conjecture that every algebraic irrational of degree ≥ 3 has bounded continued-fraction quotients — one of the central unsolved problems in Diophantine approximation.",
+      "Can the prefix be extended indefinitely by an automated tactic that generates the convergent bounds and the cubing certificates from the recurrence, rather than hand-stating each aₙ? The convergent denominators grow, but each step remains decidable in exact rational arithmetic.",
+      "Does any subsequence of the partial quotients of ∛3 exhibit statistical regularity matching the Gauss–Kuzmin distribution, as expected for almost every real number? Algebraic numbers of degree ≥ 3 are conjectured (but not known) to be 'normal' continued fractions."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 1999,
+    "path": "Proofs/CubeRoot3IrrationalOQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 19
+  },
+  "references": [
+    {
+      "authors": "J.-L. Lagrange",
+      "title": "Additions au mémoire sur la résolution des équations numériques",
+      "year": "1770",
+      "note": "Proves a continued fraction is eventually periodic iff its value is a quadratic irrational. Since ∛3 has degree 3 over ℚ, its continued fraction is non-periodic — the structural reason no closed form exists."
+    },
+    {
+      "authors": "K. F. Roth",
+      "title": "Rational approximations to algebraic numbers",
+      "year": "1955",
+      "note": "Mathematika 2, 1–20. Gives irrationality measure exactly 2 for every algebraic irrational of degree ≥ 2, constraining the growth of the partial quotients without determining them."
+    },
+    {
+      "authors": "N. J. A. Sloane (ed.)",
+      "title": "OEIS A002945: Continued fraction for the cube root of 3",
+      "year": "—",
+      "note": "The integer sequence 1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, … catalogued; this file certifies its first twelve terms."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`CubeRoot3IrrationalOQ04.lean` is a **complete (0 sorry / 0 axiom), registered** proof (`import Proofs.CubeRoot3IrrationalOQ04` in `proofs/Proofs.lean`) that certifies the first twelve partial quotients of the simple continued fraction of ∛3 — the prefix `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5]` of OEIS A002945. It had **no `src/data/proofs/` gallery directory**, so it never rendered in the gallery.

This PR adds that gallery entry (the "complete-but-ungalleried" gap):

- `meta.json` — status `verified`, badge `original`, `axiomCount: 0`, `theoremCount: 19`, rich overview/strategy/cross-references (Lagrange non-periodicity, cubing-sandwich method, OEIS A002945).
- `annotations.json` — 8 annotations anchoring the strategy header, the base sign/bound lemmas, and the partial-quotient theorems a₀..a₁₁.

**Distinct from the open ladder PRs.** The many existing OQ-04 PRs (#24809, #24802, #24767, … #23388) extend the *Lean* proof with further convergents (a12–a27). This PR touches **only** JSON gallery data for the already-merged a₀..a₁₁ content; no `.lean` files are modified.

## Verification (build-free — gallery is JSON)

- `node JSON.parse` on both files: OK
- `npx tsx scripts/annotations/resolver.ts validate …`: **8 valid / 0 misaligned**
- Gallery build discovers proofs by directory scan (`build.ts` `readdirSync`), so no central index edit is required.

## Test plan

- [ ] `pnpm build` regenerates `listings.json` / `data-manifest.json` and the new entry renders
- [ ] Annotations display against `Proofs/CubeRoot3IrrationalOQ04.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)