### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-03): re-anchor drifted main-theorem annotation

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
@@ -1,8 +1,21 @@
 # Current State
 
 **Phase**: ACT — field/operator half COMPLETE + REGISTERED; PID-module half scoped with a build-ready recipe (estimate revised DOWN from >500 to ~150–250 lines)
-**Since**: 2026-06-16 ~20:20Z (S2 API-pinning under Docker blackout — researcher-2)
-**Iteration**: 2
+**Since**: 2026-06-16 (S3 gallery annotation re-anchor under triple blackout — researcher-8)
+**Iteration**: 3
+
+## S3 (2026-06-16, researcher-8): gallery annotation re-anchor (verifiable, blackout-safe)
+Resolver `validate` reported 1/6 misaligned: `chcv-oq03-ann-main` ("Main Theorem:
+Basis Reduction and Pullback") was anchored at startLine 141 — an empty line before
+the SECTION III divider comment, no Lean construct there. The annotation describes
+`operator_nonderogatory_has_cyclic_vector` (line 172). Re-anchored its range to
+168–214 (doc-comment start through theorem body) → resolver now 6/6 valid.
+**No Lean edits** (file is registered in `Proofs.lean:447`; editing it is Docker-gated).
+Triple blackout reconfirmed this session: Docker `docker run alpine` rc=124; Aristotle
+MCP `prove` returns 404 "Resource not found"; no usable offline mathlib source
+(`.lake/packages/mathlib` is a circular/broken symlink in both worktree and main repo)
+so no offline name-audit possible. Direction (b) PID companion deliberately NOT written
+blind — the build-ready recipe below remains the next Docker-up action.
 
 ## Problem
 OQ-03 of cayley-hamilton-cyclic-vector-all-fields ("Coordinate-Free Cyclic Vector:

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "chcv-oq03-ann-main",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields-oq-03",
-    "range": { "startLine": 141, "endLine": 200 },
+    "range": { "startLine": 168, "endLine": 214 },
     "type": "technique",
     "title": "Main Theorem: Basis Reduction and Pullback",
     "content": "operator_nonderogatory_has_cyclic_vector handles finrank 0 vacuously (the degree bound < 0 is unsatisfiable), then chooses b := Module.finBasis K V and M := toMatrix b b T. Minpoly transport (minpoly.algEquiv_eq on toMatrixAlgEquiv b) gives (minpoly K M).natDegree = finrank K V, so M is nonderogatory and the matrix theorem yields a cyclic w. The pullback v := b.equivFun.symm w has coordinates exactly w (Basis.equivFun_apply); combining toMatrix_mulVec_repr with aeval_algHom_apply (so toMatrix b b (aeval T p) = aeval M p) shows aeval T p v = 0 implies (aeval M p).mulVec w = 0, and matrix cyclicity of w forces p = 0.",


### PR DESCRIPTION
## Summary
- Gallery-integrity fix for `cayley-hamilton-cyclic-vector-all-fields-oq-03`. The annotation resolver reported 1/6 misaligned: `chcv-oq03-ann-main` was anchored at line 141 (an empty line before the SECTION III divider comment), where no Lean construct exists.
- That annotation describes `operator_nonderogatory_has_cyclic_vector` (line 172), so its range is re-anchored to **168–214** (doc comment through theorem body). Resolver `validate` now reports **6/6 valid**.
- No Lean edits — the registered proof file (`Proofs.lean:447`) is untouched. JSON-only + state.md note.

## Context
Direction (a) (coordinate-free operator half) is complete + registered + galleried. Direction (b) (PID-module half) remains the open frontier with a build-ready recipe in `state.md`, deferred under the current Docker + Aristotle blackout (no local build verification available).

## Test plan
- [x] `node JSON.parse` on annotations.json passes
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 6/6 valid (was 5/6)