### PR TITLE
research(hilbert-14-oq-04): gallery entry for verified Hilbert finiteness proof

### DIFF
--- a/src/data/proofs/hilbert-14-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-14-oq-04/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "hilbert-14-oq-04-isinvariant",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 42,
+      "endLine": 49
+    },
+    "type": "insight",
+    "title": "Fixed-Points Subalgebra is G-Invariant",
+    "content": "Registers the Algebra.IsInvariant instance for the fixed-points subalgebra B = FixedPoints.subalgebra k R G inside R. The witness is definitional: any b ∈ R that is fixed by every g already lies in the image of B's inclusion, so the membership obligation is discharged by ⟨⟨b, hb⟩, rfl⟩. This instance is the entry point that lets the downstream integrality and Artin-Tate machinery fire automatically.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fixed points",
+      "invariant subring",
+      "typeclass instance",
+      "Algebra.IsInvariant"
+    ],
+    "mathContext": "$B = R^G = \\{b \\in R : g\\cdot b = b \\ \\forall g \\in G\\}$; the IsInvariant predicate holds definitionally."
+  },
+  {
+    "id": "hilbert-14-oq-04-integral",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 51,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "Integrality of R over the Invariant Subring",
+    "content": "Records Algebra.IsIntegral (R^G) R via Mathlib's Algebra.IsInvariant.isIntegral. The mathematical content is the orbit polynomial: for r ∈ R the product ∏_{g∈G}(X − g·r) is monic of degree |G|, and its coefficients are the elementary symmetric functions of the orbit, which are G-invariant and therefore live in R^G. Hence every element of R is integral over R^G — the engine of the whole finiteness argument.",
+    "significance": "key",
+    "relatedConcepts": [
+      "integral extension",
+      "orbit polynomial",
+      "elementary symmetric functions",
+      "monic polynomial"
+    ],
+    "mathContext": "$r$ is a root of $\\prod_{g\\in G}(X - g\\cdot r)$, monic of degree $|G|$ with coefficients in $R^G$."
+  },
+  {
+    "id": "hilbert-14-oq-04-main",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 60,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "Hilbert Finiteness: R^G is a Finitely Generated k-Algebra",
+    "content": "The headline result hilbert_finiteness: the invariant subring R^G = FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G is Algebra.FiniteType over k for any finite group G. This is the qualitative half of Emmy Noether's 1916 theorem, proved with 0 sorries and 0 axioms. The quantitative degree bound (generators in degree ≤ |G|) is deferred.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finite generation",
+      "Noether 1916",
+      "Hilbert's 14th problem",
+      "invariant theory"
+    ],
+    "mathContext": "$R^G$ is finitely generated as a $k$-algebra — the positive finite-group case of Hilbert's 14th problem."
+  },
+  {
+    "id": "hilbert-14-oq-04-artin-tate",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 84,
+      "endLine": 98
+    },
+    "type": "key-step",
+    "title": "The Artin-Tate Tower Argument",
+    "content": "The proof works the tower k → R^G → R. Restrict-scalars upgrades the automatic Algebra.FiniteType k R to Algebra.FiniteType (R^G) R; combined with integrality this yields Module.Finite (R^G) R, hence R is a finitely generated R^G-module (fg_top). With k → R algebra-f.g. and the inclusion R^G ↪ R injective, the Artin-Tate lemma fg_of_fg_of_fg forces the intermediate subalgebra k → R^G to be finitely generated; Subalgebra.fg_iff_finiteType translates this back to Algebra.FiniteType k (R^G).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Artin-Tate lemma",
+      "tower of algebras",
+      "module finiteness",
+      "restrict scalars"
+    ],
+    "mathContext": "Tower $k \\to R^G \\to R$: $k\\to R$ algebra-f.g. and $R$ a f.g. $R^G$-module $\\Rightarrow k \\to R^G$ finitely generated."
+  },
+  {
+    "id": "hilbert-14-oq-04-context",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 60,
+      "endLine": 99
+    },
+    "type": "context",
+    "title": "Why the Finite Case is the Tame Case",
+    "content": "Hilbert's 14th problem has a famously mixed answer: finitely generated for reductive groups (Hilbert, Weyl) but not in general (Nagata's 1959 unipotent counterexample). Finite groups sit squarely on the positive side — Noether settled them in 1916. The orbit-polynomial route used here is characteristic-free, sidestepping the Reynolds averaging operator that breaks in the modular case (when char k divides |G|).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Hilbert's 14th problem",
+      "reductive groups",
+      "Nagata counterexample",
+      "modular invariant theory"
+    ],
+    "mathContext": "Finite $\\Rightarrow$ f.g. invariants (Noether); unipotent $\\not\\Rightarrow$ f.g. (Nagata 1959)."
+  }
+]

--- a/src/data/proofs/hilbert-14-oq-04/meta.json
+++ b/src/data/proofs/hilbert-14-oq-04/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "hilbert-14-oq-04",
+  "title": "Hilbert Finiteness for Finite-Group Invariant Rings",
+  "slug": "hilbert-14-oq-04",
+  "description": "Machine-checked proof that the invariant subring (MvPolynomial (Fin n) k)^G is finitely generated as a k-algebra for any finite group G acting linearly — the qualitative half of Emmy Noether's 1916 theorem — assembled from Mathlib's invariant-theory and Artin-Tate API.",
+  "meta": {
+    "author": "Emmy Noether (1916)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_fourteenth_problem",
+    "date": "1916",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert14OQ04.lean",
+    "tags": [
+      "invariant-theory",
+      "algebra",
+      "group-actions",
+      "hilbert-problems",
+      "finite-generation",
+      "artin-tate"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms. The headline OQ-04 question (effective uniform algorithms for non-reductive invariants) is not formalizable as a single Lean theorem; this entry formalizes the algorithmically refinable sibling target, qualitative Hilbert finiteness for finite groups.",
+    "dateAdded": "2026-06-16",
+    "mathlibDependencies": [
+      {
+        "theorem": "Algebra.IsInvariant.isIntegral",
+        "description": "For finite G, every element of R is integral over the fixed subring R^G (satisfies its monic orbit polynomial of degree |G|).",
+        "module": "Mathlib.RingTheory.Invariant.Basic"
+      },
+      {
+        "theorem": "Algebra.FiniteType.of_restrictScalars_finiteType",
+        "description": "Restricts Algebra.FiniteType k R down the tower to Algebra.FiniteType (R^G) R.",
+        "module": "Mathlib.RingTheory.FiniteType"
+      },
+      {
+        "theorem": "Algebra.IsIntegral.finite",
+        "description": "Integral + algebra-finite ⇒ module-finite: gives Module.Finite (R^G) R.",
+        "module": "Mathlib.RingTheory.IntegralClosure.Basic"
+      },
+      {
+        "theorem": "fg_of_fg_of_fg (Artin-Tate)",
+        "description": "Artin-Tate lemma: in a tower k → B → R with k → R algebra-f.g., R a f.g. B-module, and B ↪ R injective, the subalgebra k → B is finitely generated.",
+        "module": "Mathlib.RingTheory.Adjoin.Tower"
+      },
+      {
+        "theorem": "Subalgebra.fg_iff_finiteType",
+        "description": "Translates Subalgebra.FG of the top subalgebra to Algebra.FiniteType.",
+        "module": "Mathlib.RingTheory.FiniteType"
+      }
+    ],
+    "originalContributions": [
+      "Assembles the qualitative Hilbert/Noether finiteness theorem for finite-group linear actions on MvPolynomial as a single named Lean result (hilbert_finiteness), 0 sorries / 0 axioms",
+      "Supplies the Algebra.IsInvariant instance for the fixed-points subalgebra of a finite group action (definitional via membership)",
+      "Records the integrality instance R / R^G for finite G as a reusable typeclass instance"
+    ],
+    "lineCount": 100,
+    "theoremCount": 1,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Hilbert's 14th Problem (1900) asked whether invariant rings k[V]^G are always finitely generated. The reductive case was settled affirmatively: Hilbert (1890) for GL_n via his basis theorem, and Weyl (1939) for all reductive groups. Nagata (1959) gave the celebrated negative answer in general, with a 13-dimensional unipotent group whose invariant ring is not finitely generated. The finite-group case, however, is entirely positive — it is the qualitative half of Emmy Noether's 1916 theorem, which also supplies the degree bound (generators in degree ≤ |G|). This entry formalizes that qualitative half: for any finite group G acting linearly on a polynomial ring, the invariant subring is a finitely generated k-algebra.",
+    "problemStatement": "For a finite group G acting by k-algebra automorphisms on R = MvPolynomial (Fin n) k, show the invariant subring R^G is finitely generated as a k-algebra.",
+    "text": "A fully machine-checked formalization of finite-group Hilbert finiteness via the Artin-Tate tower argument.",
+    "proofStrategy": "Work the tower k → R^G → R. (1) R is integral over R^G because each element satisfies its monic G-orbit polynomial of degree |G| with invariant coefficients. (2) R is automatically Algebra.FiniteType over k (polynomial ring); restrict scalars to get Algebra.FiniteType (R^G) R. (3) Integral + algebra-finite gives Module.Finite (R^G) R. (4) Apply the Artin-Tate lemma to the tower: k → R algebra-f.g. and R a f.g. R^G-module force the intermediate algebra k → R^G to be finitely generated.",
+    "keyInsights": [
+      "**The finite case is the easy, positive case** of Hilbert's 14th — Noether (1916) settled it, in sharp contrast with Nagata's unipotent counterexample.",
+      "**Integrality is the engine**: every r ∈ R is a root of ∏_{g∈G}(X − g·r), a monic degree-|G| polynomial whose coefficients (elementary symmetric functions of the orbit) are G-invariant, hence lie in R^G.",
+      "**Artin-Tate converts module-finiteness into algebra-finiteness** for the bottom of the tower — this is exactly what is needed to descend finite generation from R to R^G.",
+      "**No Reynolds operator is required**: the orbit-polynomial / integrality route works in arbitrary characteristic, avoiding the averaging operator that fails in modular (char | |G|) settings.",
+      "Mathlib already carries every bearer lemma (invariant integrality, restrict-scalars finite type, integral⇒module-finite, Artin-Tate), so the theorem assembles without new foundational infrastructure."
+    ],
+    "prerequisites": [
+      "Commutative ring theory (finite generation, integral extensions)",
+      "Group actions on rings and the fixed subring R^G",
+      "Module finiteness and the Artin-Tate lemma"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: Finite Group Action on a Polynomial Ring",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Scope statement and typeclass setup: a finite group G acting by k-algebra automorphisms (MulSemiringAction + SMulCommClass) on R = MvPolynomial (Fin n) k. Clarifies that the headline OQ-04 (uniform effective algorithms) is not a single formalizable theorem and that this file targets qualitative Hilbert finiteness.",
+      "mathContext": "$R = k[x_1,\\dots,x_n]$, $G$ finite acting $k$-linearly; target is $R^G = \\mathrm{FixedPoints}(G)$ finitely generated over $k$."
+    },
+    {
+      "id": "integrality",
+      "title": "Invariance and Integrality of R over R^G",
+      "startLine": 42,
+      "endLine": 58,
+      "summary": "Registers the Algebra.IsInvariant instance for the fixed-points subalgebra (definitional via membership) and the integrality instance Algebra.IsIntegral (R^G) R via Mathlib's Algebra.IsInvariant.isIntegral. 0 sorries.",
+      "mathContext": "Each $r \\in R$ is a root of $\\prod_{g \\in G}(X - g\\cdot r)$, monic of degree $|G|$ with coefficients in $R^G$, so $R$ is integral over $R^G$."
+    },
+    {
+      "id": "finiteness",
+      "title": "Hilbert Finiteness via Artin-Tate",
+      "startLine": 60,
+      "endLine": 99,
+      "summary": "The main theorem hilbert_finiteness: R^G is Algebra.FiniteType over k. Chains restrict-scalars finite type, integral⇒module-finite, and the Artin-Tate fg_of_fg_of_fg lemma on the tower k → R^G → R, then translates Subalgebra.FG back to Algebra.FiniteType. 0 sorries, 0 axioms.",
+      "mathContext": "Tower $k \\to R^G \\to R$: $k \\to R$ algebra-f.g. and $R$ a f.g. $R^G$-module $\\Rightarrow$ $k \\to R^G$ finitely generated (Artin-Tate)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-14",
+      "relationship": "extends",
+      "description": "Provides the machine-checked qualitative finiteness result for the finite-group case of the parent Hilbert 14 formalization."
+    },
+    {
+      "targetId": "hilbert-14-oq-01",
+      "relationship": "related",
+      "description": "Companion entry surveying the non-reductive (Grosshans) case; this entry settles the positive finite-group case in full."
+    }
+  ],
+  "conclusion": {
+    "summary": "For any finite group acting linearly on a polynomial ring, the invariant subring is finitely generated as a k-algebra — Noether's 1916 qualitative theorem — formalized with 0 sorries and 0 axioms by chaining Mathlib's invariant integrality and the Artin-Tate lemma.",
+    "implications": "1. **Finite groups are always tame**: unlike the unipotent counterexamples (Nagata), finite-group invariants are unconditionally finitely generated.\n2. **Characteristic-free**: the orbit-polynomial/integrality route avoids the Reynolds averaging operator, so it covers the modular case.\n3. **Reusable instances**: the IsInvariant and IsIntegral instances on the fixed-points subalgebra can be reused for downstream invariant-theory formalizations.",
+    "openQuestions": [
+      "Formalize Noether's quantitative degree bound: generators of R^G exist in degree ≤ |G| (deferred S3-bound target).",
+      "Extend to reductive groups via a formalized Reynolds operator (Weyl's theorem)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Noether, Emmy",
+      "title": "Der Endlichkeitssatz der Invarianten endlicher Gruppen",
+      "year": "1916",
+      "venue": "Mathematische Annalen 77, 89-92",
+      "note": "Finite generation (and the degree ≤ |G| bound) for finite-group invariant rings"
+    },
+    {
+      "authors": "Hilbert, David",
+      "title": "Über die Theorie der algebraischen Formen",
+      "year": "1890",
+      "venue": "Mathematische Annalen 36, 473-534",
+      "note": "Basis theorem; finite generation for GL_n invariants"
+    },
+    {
+      "authors": "Nagata, Masayoshi",
+      "title": "On the 14th problem of Hilbert",
+      "year": "1959",
+      "venue": "American Journal of Mathematics 81, 766-772",
+      "note": "Counterexample: a non-finitely-generated invariant ring (unipotent group)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MvPolynomial"
+    ],
+    "namespace": "Hilbert14OQ04",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 2,
+    "path": "Proofs/Hilbert14OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds a gallery entry for the **complete-but-ungalleried** proof `Proofs/Hilbert14OQ04.lean` — build-verified and registered (`Proofs.lean`), `0 sorry / 0 axiom`, but missing a `src/data/proofs/<slug>/` directory.

The theorem `hilbert_finiteness` proves that the invariant subring `R^G = FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G` is finitely generated as a `k`-algebra for any **finite** group `G` — the qualitative half of Emmy Noether's 1916 theorem, and the positive finite-group case of Hilbert's 14th problem. The proof chains Mathlib's invariant integrality (`Algebra.IsInvariant.isIntegral`) with the Artin-Tate lemma (`fg_of_fg_of_fg`) on the tower `k → R^G → R`.

- `meta.json`: status `verified`, badge `mathlib`, `axiomCount 0`, 3 sections
- `annotations.json`: 5 annotations, resolver validates **5/5 aligned, 0 misaligned**
- No Lean source change (gallery is JSON only)
- crossReferences point to existing entries `hilbert-14`, `hilbert-14-oq-01`

The headline OQ-04 question (uniform effective algorithms for non-reductive invariants) is not formalizable as a single Lean theorem and the quantitative degree bound (`deg ≤ |G|`) remains a deferred S3-bound target; the entry scopes this explicitly.

## Test plan
- [x] `node` JSON.parse on meta.json + annotations.json
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 5 valid / 0 misaligned
- [x] crossReference targetIds exist in `src/data/proofs/`
- [x] Underlying Lean proof is registered (`import Proofs.Hilbert14OQ04`) and previously build-verified (#18988)

🤖 Generated with [Claude Code](https://claude.com/claude-code)