### PR TITLE
research(zsqrtd-neg-two-oq-03-oq-01): gallery entry for x²+3y² representation theorem

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 4, "endLine": 59 },
+    "type": "context",
+    "title": "Module docstring: completing the $x^2 + 3y^2$ representation theorem",
+    "content": "The file docstring fixes the target `sq_add_three_sq_of_prime_one_mod_three : p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p : ℤ) = a² + 3b²` — the n = 3 Heegner-number analogue of Fermat's two-squares theorem — and records that the parent `Proofs/ZsqrtdNegTwoOQ03.lean` already supplies the Eisenstein integers ℤ[ω], the multiplicative norm N(a + bω) = a² - ab + b², the `EuclideanDomain` instance, and the quadratic-reciprocity characterisation `legendreSym_neg_three_eq_one_iff`. The proof splits into two independent components: a pure-ℤ **form conversion** (a² - ab + b² ↔ x² + 3y²) and a **norm realisation** (the UFD splitting argument producing α with N(α) = p). The status block certifies 0 axioms and 0 sorries (Docker-verified).",
+    "mathContext": "Euler's 1763 theorem sits in the chain Fermat (n=1, p ≡ 1 mod 4 ⟹ p = a² + b²) → n=2 (parent, p ≡ 1,3 mod 8 ⟹ p = a² + 2b²) → n=3 (this file). Each step uses the maximal order of ℚ(√-n) as a UFD; the elementary template stops at the quadratic Heegner numbers n ∈ {1,2,3,7,11}.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein integers", "x² + 3y²", "Heegner numbers", "Fermat two-squares theorem", "splitting argument"],
+    "prerequisites": ["algebraic number theory (orders in quadratic fields)"]
+  },
+  {
+    "id": "ann-form-conversion",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 67, "endLine": 88 },
+    "type": "theorem",
+    "title": "Part I: the norm form $a^2 - ab + b^2$ represents exactly $x^2 + 3y^2$",
+    "content": "`eisenstein_form_to_x_sq_add_three_y_sq` proves `∀ a b : ℤ, ∃ x y, a² - ab + b² = x² + 3y²` — entirely within ℤ, no Eisenstein machinery. The underlying identity is `4(a² - ab + b²) = (2a - b)² + 3b²`; to remove the factor 4 the proof does a three-branch parity case split with explicit witnesses: (i) b = 2k even ⟹ a² - ab + b² = (a-k)² + 3k²; (ii) a = 2m even, b odd ⟹ = (b-m)² + 3m²; (iii) a, b both odd ⟹ = (-m-k-1)² + 3(m-k)². Each branch is closed by `subst; ring`. Branches (ii) and (iii) correspond to first applying the norm-preserving order-6 unit rotation (a,b) ↦ (-b, a-b) of ℤ[ω] to reach an even ω-coordinate.",
+    "mathContext": "The map sending the lattice point a + bω to the value of its norm form is, up to the unit-rotation symmetry, the parametrisation of x² + 3y². This is precisely why a norm realisation N(α) = p translates directly into a representation p = x² + 3y² with no separate descent step — the geometry of the hexagonal Eisenstein lattice already encodes the quadratic form x² + 3y².",
+    "significance": "critical",
+    "relatedConcepts": ["positive-definite quadratic form", "parity case split", "unit rotation of ℤ[ω]", "explicit witnesses"],
+    "prerequisites": ["ring identities over ℤ", "even/odd case analysis"]
+  },
+  {
+    "id": "ann-sqrt-neg-three",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 96, "endLine": 114 },
+    "type": "definition",
+    "title": "The Eisenstein $\\sqrt{-3}$: $\\theta = 1 + 2\\omega$ with $\\theta^2 = -3$",
+    "content": "`eisensteinSqrtNegThree := ⟨1, 2⟩` is the element θ = 1 + 2ω of ℤ[ω], and `eisensteinSqrtNegThree_sq` proves θ² = ofInt(-3) by a direct coordinate computation: using the Eisenstein product `(a+bω)(c+dω) = (ac - bd) + (ad + bc - bd)ω`, the real part is 1·1 - 2·2 = -3 and the ω-part is 1·2 + 2·1 - 2·2 = 0. So θ is a genuine square root of -3 inside the ring.",
+    "mathContext": "In ℚ(√-3) the element √-3 lies in the maximal order ℤ[ω] (indeed √-3 = -1 - 2ω, and here θ = 1 + 2ω = -(√-3) works equally well as a square root of -3). Having an explicit √-3 in the ring is what converts the abstract residue condition `-3 is a QR mod p` into a concrete factorisation of c² + 3.",
+    "significance": "key",
+    "relatedConcepts": ["square root of -3", "Eisenstein multiplication", "coordinate computation", "ω² = -1 - ω"],
+    "prerequisites": ["Eisenstein product formula"]
+  },
+  {
+    "id": "ann-difference-of-squares",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 116, "endLine": 136 },
+    "type": "theorem",
+    "title": "Difference-of-squares factorisation $(c - \\theta)(c + \\theta) = c^2 + 3$",
+    "content": "`ofInt_sub_sqrt_mul_add_sqrt` proves `(ofInt c - θ)(ofInt c + θ) = ofInt (c² + 3)` in ℤ[ω], since (c - θ)(c + θ) = c² - θ² = c² - (-3) = c² + 3. The proof is a coordinate computation (`ext` then `simp [projections]; ring` on each component). This is the bridge that turns the integer divisibility p ∣ c² + 3 (obtained from reciprocity) into a *factored* divisibility p ∣ (c - θ)(c + θ) in the Eisenstein ring, where the UFD structure can act.",
+    "mathContext": "Factoring c² + 3 = (c - √-3)(c + √-3) is the standard device for studying primes represented by x² + 3y²: a rational prime dividing the product but neither factor cannot be prime in ℤ[ω], so it splits. The whole splitting argument hinges on this elementary algebraic identity holding inside the maximal order.",
+    "significance": "key",
+    "relatedConcepts": ["difference of squares", "factorisation in ℤ[ω]", "lifting divisibility", "c² + 3"],
+    "prerequisites": ["θ² = -3", "Eisenstein ring arithmetic"]
+  },
+  {
+    "id": "ann-unit-criterion",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 142, "endLine": 161 },
+    "type": "theorem",
+    "title": "Unit criterion: $\\mathrm{IsUnit}\\,z \\iff N(z) = 1$",
+    "content": "`isUnit_iff_norm_eq_one` proves an Eisenstein integer is a unit iff its norm is 1. Forward: if z·w = 1 then N(z)·N(w) = 1 by multiplicativity, and N(z) > 0 (positivity on nonzero) with N(z) ∣ 1 forces N(z) = 1 (`Int.le_of_dvd` + `omega`). Reverse: if N(z) = 1 then z·conj z = ⟨N(z), 0⟩ = ⟨1,0⟩ = 1, so conj z is a two-sided inverse. This is the load-bearing lemma for the splitting argument: a nonunit has norm > 1, which is exactly what rules out the trivial factor in p = α·β.",
+    "mathContext": "In any ring of integers the unit group is the kernel of the norm restricted to ±1-valued elements; for ℤ[ω] the units are the six sixth-roots of unity {±1, ±ω, ±ω²}, all of norm 1. The criterion N(z) = 1 ⟺ unit makes the multiplicative structure of ℤ[ω] entirely governed by the integer norm.",
+    "significance": "key",
+    "relatedConcepts": ["unit group of ℤ[ω]", "norm multiplicativity", "conjugate", "z · conj z = N(z)"],
+    "prerequisites": ["norm_mul", "Int.le_of_dvd"]
+  },
+  {
+    "id": "ann-splitting-argument",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 163, "endLine": 323 },
+    "type": "theorem",
+    "title": "Part II: norm realisation — $\\exists\\,\\alpha,\\ N(\\alpha) = p$ for $p \\equiv 1 \\pmod 3$",
+    "content": "`exists_eisenstein_norm_eq_prime` is the heart of the proof. (1) From p ≡ 1 mod 3 and the parent's `legendreSym_neg_three_eq_one_iff`, (-3/p) = 1, so -3 is a nonzero square mod p; lift the root to an integer c with p ∣ c² + 3. (2) Factor c² + 3 = (c - θ)(c + θ), giving p ∣ (c - θ)(c + θ) in ℤ[ω]. (3) p divides neither factor: their ω-coordinates are ∓2 and p ∤ 2 (p ≡ 1 mod 3 ⟹ p ≥ 7). So (p : Eisenstein) is not prime. (4) ℤ[ω] is a UFD (parent's `instEuclideanDomain`), so `UniqueFactorizationMonoid.irreducible_iff_prime` makes p reducible: p = α·β with α, β nonunits. (5) Norm-multiplicativity gives p² = N(α)·N(β) with both factors ≥ 2; transferring to ℕ, `Nat.dvd_prime_pow` forces N(α) ∈ {1, p, p²}, and ruling out the extremes leaves N(α) = p.",
+    "mathContext": "This is the classical 'a prime splits in 𝓞_K iff it is a norm' argument, specialised to the Eisenstein integers. The decisive structural input is that the maximal order is a UFD, so detecting non-primality (an easy ω-coordinate divisibility check) is equivalent to producing the desired factorisation. The ℕ divisor count p² = N(α)·N(β) with both > 1 is what pins the norm to exactly p rather than a unit or the whole p².",
+    "significance": "critical",
+    "relatedConcepts": ["splitting of primes", "UFD irreducible ↔ prime", "Legendre symbol", "norm realisation", "divisors of p²"],
+    "prerequisites": ["quadratic reciprocity criterion", "EuclideanDomain ⟹ UFD", "norm_mul", "Nat.dvd_prime_pow"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-01",
+    "range": { "startLine": 327, "endLine": 339 },
+    "type": "theorem",
+    "title": "Main theorem: $p \\equiv 1 \\pmod 3 \\Rightarrow p = a^2 + 3b^2$",
+    "content": "`sq_add_three_sq_of_prime_one_mod_three` assembles the two parts in three lines. Obtain α with N(α) = p (Part II), apply the form conversion to (α.re, α.im) to get x, y with α.re² - α.re·α.im + α.im² = x² + 3y² (Part I), and rewrite p = N(α) = α.re² - α.re·α.im + α.im² = x² + 3y². This is Euler's 1763 representation theorem, fully machine-checked with 0 sorries and 0 axioms.",
+    "mathContext": "The clean two-line assembly is possible precisely because Part I made the value sets of the norm form and x² + 3y² coincide: there is no arithmetic gap between 'p is an Eisenstein norm' and 'p = x² + 3y²'. The result is the n = 3 entry in the Fermat/Euler ladder of quadratic-form representation theorems.",
+    "significance": "critical",
+    "relatedConcepts": ["Euler 1763", "x² + 3y²", "primes represented by quadratic forms", "Fermat two-squares ladder"],
+    "prerequisites": ["norm realisation", "form conversion"]
+  }
+]

--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "zsqrtd-neg-two-oq-03-oq-01",
+  "title": "Primes $p \\equiv 1 \\pmod 3$ are $x^2 + 3y^2$ (Euler/Fermat, $n = 3$)",
+  "slug": "zsqrtd-neg-two-oq-03-oq-01",
+  "description": "Completes the open question deferred by the parent `zsqrtd-neg-two-oq-03`: using the Eisenstein-integer infrastructure built there (the ring ℤ[ω], its multiplicative norm N(a + bω) = a² - ab + b², the EuclideanDomain instance, and the quadratic-reciprocity criterion (-3/p) = 1 ↔ p ≡ 1 mod 3), this file proves the classical n = 3 Heegner-number representation theorem `sq_add_three_sq_of_prime_one_mod_three : p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p : ℤ) = a² + 3b²`. The argument has two independent parts. Part I (`eisenstein_form_to_x_sq_add_three_y_sq`, pure ℤ arithmetic) shows the Eisenstein norm form a² - ab + b² represents exactly the integers x² + 3y², via the identity 4(a² - ab + b²) = (2a - b)² + 3b² and a three-branch parity case split using the order-6 unit rotations of ℤ[ω]. Part II (`exists_eisenstein_norm_eq_prime`) is the splitting argument: for p ≡ 1 mod 3, (-3) is a square mod p (quadratic reciprocity), so p divides (c - θ)(c + θ) where θ = 1 + 2ω satisfies θ² = -3 but divides neither factor (their ω-coordinates are ∓2 and p ∤ 2); hence p is reducible in the UFD ℤ[ω], and norm-multiplicativity forces N(α) = p for some Eisenstein integer α. Combining the two parts gives p = a² + 3b². Fully machine-checked: 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Euler (1763), Fermat (1640), Lagrange (1775)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein_integer",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ZsqrtdNegTwoOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-number-theory",
+      "quadratic-forms",
+      "class-number-one",
+      "eisenstein-integers",
+      "heegner-numbers",
+      "quadratic-reciprocity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 341,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof depends only on Mathlib (Legendre symbols and quadratic reciprocity) and the parent file `Proofs/ZsqrtdNegTwoOQ03.lean`, which supplies the Eisenstein ring, its multiplicative norm, the EuclideanDomain instance (hence the UFD structure), and the splitting criterion `legendreSym_neg_three_eq_one_iff`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.eq_one_iff",
+        "description": "`legendreSym p a = 1 ↔ IsSquare (a : ZMod p)` for `a` nonzero mod `p`, used to extract an integer square root `c` with `c² ≡ -3 (mod p)` from the reciprocity value `(-3/p) = 1`.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "`((n : ℤ) : ZMod p) = 0 ↔ (p : ℤ) ∣ n`, the bridge that turns the `ZMod p` square-root identity into the integer divisibility `p ∣ c² + 3`.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "UniqueFactorizationMonoid.irreducible_iff_prime",
+        "description": "In a UFD, `Irreducible x ↔ Prime x`. Available because the parent's `instEuclideanDomain` makes ℤ[ω] a PID, hence a UFD; this is what converts the non-primality of `(p : Eisenstein)` into a genuine factorisation `p = α·β`.",
+        "module": "Mathlib.RingTheory.UniqueFactorizationDomain"
+      },
+      {
+        "theorem": "Nat.dvd_prime_pow",
+        "description": "`a ∣ p^n ↔ ∃ m ≤ n, a = p^m` for prime `p`, used in the final step: `N(α) ∣ p²` with `N(α) > 1` and `N(β) > 1` forces `N(α) = p`.",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      }
+    ],
+    "originalContributions": [
+      "`eisenstein_form_to_x_sq_add_three_y_sq`: a pure-ℤ proof that the Eisenstein norm form `a² - ab + b²` represents exactly the integers `x² + 3y²`, by the identity `4(a² - ab + b²) = (2a - b)² + 3b²` and a three-branch parity case split (b even; a even, b odd; both odd) with explicit witnesses derived from the order-6 unit rotation `(a,b) ↦ (-b, a-b)`",
+      "`eisensteinSqrtNegThree`: the explicit Eisenstein square root `θ = 1 + 2ω = ⟨1, 2⟩` of `-3`, with `eisensteinSqrtNegThree_sq : θ² = ofInt (-3)` proved by coordinate computation",
+      "`ofInt_sub_sqrt_mul_add_sqrt`: the difference-of-squares factorisation `(c - θ)(c + θ) = ofInt (c² + 3)` in ℤ[ω], which lifts the integer divisibility `p ∣ c² + 3` to a factored divisibility in the Eisenstein integers",
+      "`isUnit_iff_norm_eq_one`: the unit criterion `IsUnit z ↔ N(z) = 1`, proved both directions (forward via `N(z) ∣ 1` and positivity; reverse via `z · conj z = ⟨N(z), 0⟩`)",
+      "`exists_eisenstein_norm_eq_prime`: the full splitting argument that for prime `p ≡ 1 mod 3` there is an Eisenstein integer with norm `p`, assembled from the reciprocity value, the non-divisibility of either factor (ω-coordinate ∓2, `p ∤ 2`), the UFD `irreducible ↔ prime` equivalence, and the ℕ-divisor analysis of `p²`",
+      "`sq_add_three_sq_of_prime_one_mod_three`: the headline Euler theorem `p.Prime → p % 3 = 1 → ∃ a b : ℤ, p = a² + 3b²`, completing the open question the parent deferred to S4–S5"
+    ],
+    "prerequisites": [
+      "Imaginary quadratic number fields and their rings of integers",
+      "Eisenstein integers ℤ[ω], ω = exp(2πi/3), and the norm form a² - ab + b²",
+      "Unique factorisation domains and the prime ↔ irreducible equivalence",
+      "Quadratic reciprocity and the Legendre symbol"
+    ],
+    "dateAdded": "2026-06-16",
+    "relatedProblems": [
+      {
+        "id": "zsqrtd-neg-two-oq-03",
+        "relationship": "Completes: the parent built the Eisenstein ring + EuclideanDomain + reciprocity criterion and deferred the representation theorem to S4–S5; this file proves it"
+      },
+      {
+        "id": "zsqrtd-neg-two",
+        "relationship": "Analogous: the n = 2 case `p ≡ 1, 3 (mod 8) ⟹ p = a² + 2b²`, proved via `Zsqrtd (-2)`"
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 341,
+    "path": "Proofs/ZsqrtdNegTwoOQ03OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 7
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The theorem `prime p ≡ 1 (mod 3) ⟹ p = a² + 3b²` was first proved by **Leonhard Euler** in 1763, generalizing Fermat's two-squares theorem (n = 1). The cleanest modern proof works in the **Eisenstein integers** ℤ[ω], ω = exp(2πi/3) — the ring of integers of ℚ(√-3), a Euclidean domain (hence PID and UFD) under the norm N(a + bω) = a² - ab + b². A prime p ≡ 1 (mod 3) splits in ℤ[ω] (because -3 is a quadratic residue mod p by reciprocity), so it equals N(α) for some α, which converts via 4N = (2a - b)² + 3b² to p = x² + 3y². **Gauss** (Disquisitiones, 1801) generalized this to all imaginary quadratic forms; the class-number-one cases n ∈ {1, 2, 3, 7, 11, 19, 43, 67, 163} (the Heegner numbers) admit such direct constructions, while general n requires class field theory (Cox, Primes of the form x² + ny², 1989).",
+    "problemStatement": "**Open Question (zsqrtd-neg-two-oq-03-oq-01):** Discharge the representation theorem that the parent file `zsqrtd-neg-two-oq-03` deferred to S4–S5 — namely `sq_add_three_sq_of_prime_one_mod_three : p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p : ℤ) = a² + 3b²` — using the Eisenstein ring, norm, EuclideanDomain instance, and reciprocity criterion already built in the parent.",
+    "text": "Every prime p ≡ 1 (mod 3) is of the form a² + 3b² (Euler 1763), formalized via the splitting argument in the Eisenstein integers ℤ[ω].",
+    "proofStrategy": "Two independent parts. **Part I — form conversion** (`eisenstein_form_to_x_sq_add_three_y_sq`, pure ℤ): the norm form a² - ab + b² represents the same integers as x² + 3y², via 4(a² - ab + b²) = (2a - b)² + 3b² and a three-branch parity case split with explicit witnesses (the branches correspond to applying the order-6 unit rotation to make the ω-coordinate even). **Part II — norm realisation** (`exists_eisenstein_norm_eq_prime`): from p ≡ 1 mod 3, reciprocity gives (-3/p) = 1, so ∃ c, p ∣ c² + 3; the explicit square root θ = 1 + 2ω (θ² = -3) factors this as p ∣ (c - θ)(c + θ); p divides neither factor (ω-coordinates ∓2, p ∤ 2), so p is reducible in the UFD ℤ[ω]; norm-multiplicativity and the divisor structure of p² then force N(α) = p. Combining: N(α) = p with α = ⟨re, im⟩ gives p = re² - re·im + im² = x² + 3y².",
+    "keyInsights": [
+      "**The norm form and x² + 3y² coincide as value sets.** The identity 4(a² - ab + b²) = (2a - b)² + 3b² shows every Eisenstein norm is (up to the factor 4) a value of x² + 3y²; the parity case split removes the factor 4 by using that the order-6 unit rotation (a,b) ↦ (-b, a-b) preserves the norm and can be iterated to make a coordinate even. This is why N(α) = p directly yields p = x² + 3y², with no separate descent.",
+      "**Why ℤ[ω] and not ℤ[√-3].** The maximal order of ℚ(√-3) is ℤ[ω] = ℤ[(1+√-3)/2], strictly larger (index 2) than ℤ[√-3]. Only the maximal order is a UFD — ℤ[√-3] fails unique factorisation (4 = 2·2 = (1+√-3)(1-√-3)) — so the splitting argument must take place in ℤ[ω]. The parent supplies exactly this ring and its EuclideanDomain instance.",
+      "**θ = 1 + 2ω is the Eisenstein √-3.** A direct coordinate check gives θ² = ⟨1·1 - 2·2, 1·2 + 2·1 - 2·2⟩ = ⟨-3, 0⟩ = -3. This explicit element is what turns the abstract reciprocity statement (-3 is a QR mod p) into a concrete factorisation p ∣ (c - θ)(c + θ) in the ring.",
+      "**Splitting is detected by the ω-coordinate.** The two factors c ∓ θ have ω-coordinates ∓2. Since p ≡ 1 mod 3 forces p ≥ 7 (in particular p ∤ 2), p divides neither factor, so p is not prime in ℤ[ω]. In a UFD non-prime ⟹ reducible, and reducibility plus N(p) = p² with both norms > 1 pins N(α) = N(β) = p.",
+      "**The final step is elementary ℕ divisor counting.** Once N(α)·N(β) = p² with N(α), N(β) ≥ 2, `Nat.dvd_prime_pow` says N(α) ∈ {1, p, p²}; ruling out 1 (nonunit) and p² (would force N(β) = 1) leaves N(α) = p."
+    ],
+    "prerequisites": [
+      "Imaginary quadratic number fields ℚ(√d), d < 0",
+      "Rings of integers and the Eisenstein integers ℤ[ω]",
+      "Norm forms N : 𝓞_K → ℤ and their multiplicativity",
+      "Unique factorisation domains; prime ↔ irreducible",
+      "Quadratic reciprocity and the Legendre symbol"
+    ]
+  },
+  "conclusion": {
+    "summary": "The headline representation theorem `sq_add_three_sq_of_prime_one_mod_three` is proved with 0 sorries and 0 axioms, completing the n = 3 Heegner-number case the parent deferred. The file is 341 lines, 7 theorems, 1 definition, and rests on the parent's Eisenstein EuclideanDomain plus Mathlib's Legendre-symbol / UFD machinery.",
+    "implications": "The same template — maximal order with multiplicative norm, EuclideanDomain ⟹ UFD, splitting via reciprocity, norm realisation — now stands complete through n = 3, mirroring the n = 1 (Fermat two-squares) and n = 2 (parent zsqrtd-neg-two) cases.",
+    "openQuestions": [
+      "Port the construction to n = 7 and n = 11 (the next quadratic Heegner numbers): build ℤ[(1+√-n)/2] with norm form a² + ab + ((n+1)/4)b². The cyclotomic coincidence ℤ[ω] = ℤ[ζ₃] breaks (the n = 7 maximal order is not cyclotomic) and the unit group collapses to {±1}.",
+      "Characterise the full image of the norm — the Loeschian numbers a² + ab + b² (OEIS A003136): n is a value iff every prime q ≡ 2 mod 3 occurs to an even power in n. The forward (prime) direction is this file's main theorem; the converse needs the split/inert/ramified trichotomy from the UFD structure.",
+      "Establish the converse direction `p = a² + 3b² ∧ p prime ⟹ p ≡ 1 mod 3` (a short modular check: squares are 0,1 mod 3, so a² + 3b² ≡ a² ∈ {0,1}, and primality rules out 0), giving the full iff characterisation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "zsqrtd-neg-two-oq-03",
+      "relationship": "parent",
+      "description": "The parent built the Eisenstein ring ℤ[ω], its multiplicative norm, the EuclideanDomain instance (hence UFD), and the reciprocity criterion (-3/p) = 1 ↔ p ≡ 1 mod 3, explicitly deferring the representation theorem to S4–S5. This file discharges that deferred theorem."
+    },
+    {
+      "targetId": "zsqrtd-neg-two",
+      "relationship": "analogous",
+      "description": "The grandparent gallery proof formalizes the n = 2 case `p ≡ 1, 3 (mod 8) ⟹ p = a² + 2b²` via Mathlib's `Zsqrtd (-2)`. This file is the n = 3 analogue, which needs the fresh Eisenstein structure because ℤ[√-3] is non-maximal."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Gauss's quadratic reciprocity supplies the hinge of the splitting argument: (-3/p) = 1 for p ≡ 1 mod 3, which makes -3 a quadratic residue mod p and hence produces the integer c with p ∣ c² + 3 that the Eisenstein factorisation consumes."
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "analogous",
+      "description": "Lagrange's four-squares theorem uses the Hurwitz quaternions — a maximal-order construction with multiplicative norm — exactly as this file uses the Eisenstein integers ℤ[ω] as the maximal order of ℚ(√-3). Both share the skeleton: build a maximal order with a multiplicative norm, factor a prime in it, and translate N(α) = p back to the target quadratic form."
+    }
+  ]
+}

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03-oq-01.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "zsqrtd-neg-two-oq-03-oq-01",
   "title": "Build the EuclideanDomain Eisenstein instance via rounding-to-ℤ (S3, ~200 lin...",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -70,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T19:32:03.159Z",
-  "lastUpdate": "2026-06-15T19:32:03.159Z",
+  "lastUpdate": "2026-06-16T18:55:00.000Z",
   "significance": 6,
   "tractability": 7,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds a gallery entry for the **complete-but-ungalleried** proof in `Proofs/ZsqrtdNegTwoOQ03OQ01.lean` — a verified (0 sorry / 0 axiom), registered (`Proofs.lean:3105`) proof that had no `src/data/proofs/<slug>/` directory.

This file proves **Euler's 1763 theorem** that every prime `p ≡ 1 (mod 3)` is of the form `a² + 3b²` (`sq_add_three_sq_of_prime_one_mod_three`), discharging the open question the parent `zsqrtd-neg-two-oq-03` explicitly deferred to its S4–S5 follow-up.

### Proof shape
- **Part I — form conversion** (`eisenstein_form_to_x_sq_add_three_y_sq`, pure ℤ): the Eisenstein norm form `a² - ab + b²` represents exactly `x² + 3y²`, via `4(a² - ab + b²) = (2a - b)² + 3b²` and a three-branch parity case split.
- **Part II — norm realisation** (`exists_eisenstein_norm_eq_prime`): reciprocity gives `(-3/p) = 1` ⟹ `p ∣ c² + 3`; factor as `(c - θ)(c + θ)` with `θ = 1 + 2ω`, `θ² = -3`; `p` divides neither factor, so it is reducible in the UFD `ℤ[ω]`; norm-multiplicativity forces `N(α) = p`.
- **Main theorem** assembles the two parts: `p = N(α) = α.re² - α.re·α.im + α.im² = x² + 3y²`.

### What's added
- `src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/meta.json` — status `verified`, badge `original`, axiomCount 0, sorries 0, 341 LOC, 7 theorems, 1 def
- `src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/annotations.json` — 7 annotations (**resolver validate: 7 valid / 0 misaligned**)
- `src/data/research/problems/zsqrtd-neg-two-oq-03-oq-01.json` — marked `completed` / `COMPLETED` (registry already graduated)

No Lean source changed; the proof is already Docker-verified and registered. Gallery JSON validated with `node JSON.parse`; all four crossReference targets exist.

## Test plan
- [x] `node JSON.parse` on meta.json and annotations.json
- [x] `npx tsx scripts/annotations/resolver.ts validate ...` → 7 valid / 0 misaligned
- [x] crossReference targetIds exist as gallery dirs
- [x] confirmed registered in `proofs/Proofs.lean:3105`, 0 sorry / 0 axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)