### PR TITLE
research(spherical-law-of-cosines-oq-03): re-anchor drifted toolkit annotation

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-03/annotations.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "spherical-oq03-ann-toolkit",
     "proofId": "spherical-law-of-cosines-oq-03",
-    "range": { "startLine": 100, "endLine": 178 },
+    "range": { "startLine": 95, "endLine": 178 },
     "type": "definition",
     "title": "Part I — Vector Toolkit in ℝ³",
     "content": "Defines the 3-field structure V with dot, cross, and scalar triple products, and proves the algebraic identities the whole development rests on: binet_cauchy (⟨a×b, c×d⟩ = ⟨a,c⟩⟨b,d⟩ − ⟨a,d⟩⟨b,c⟩), lagrange_identity (‖a×b‖² = ‖a‖²‖b‖² − ⟨a,b⟩²), triple_sq ([u v w]² = the Gram determinant), and the orthogonality facts ⟨a×b, a⟩ = ⟨a×b, b⟩ = 0 — all by ring. Nonnegativity facts (triple_sq, cross_norm_sq_nonneg, 1−⟨u,v⟩² ≥ 0) guarantee the side sines √(1−ca²) are well defined.",


### PR DESCRIPTION
## Summary
- Gallery-integrity fix for `spherical-law-of-cosines-oq-03`. The annotation resolver reported 1/6 misaligned: `spherical-oq03-ann-toolkit` ("Part I — Vector Toolkit in ℝ³") was anchored at line 100 (a blank line in the gap between `structure V` and `def dot`), where no Lean construct exists.
- That annotation describes the Part I vector definitions (`structure V`, `dot`, `cross`, `triple`), so its range start is moved to **95** (the doc comment of `structure V`). Resolver `validate` now reports **6/6 valid**.
- JSON-only — no Lean edits.

## Test plan
- [x] `node JSON.parse` on annotations.json passes
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 6/6 valid (was 5/6)