### PR TITLE
research(cevas-theorem-non-euclidean-oq-02-oq-01-oq-01): gallery entry for unified Menelaus theorem

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-unified-header",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "concept",
+    "title": "One Menelaus Theorem for Three Geometries",
+    "content": "The Euclidean, spherical, and hyperbolic Menelaus theorems differ only in the function used to measure signed geodesic arcs: the identity for the plane, sin on the sphere, sinh in the hyperbolic plane. All three are odd functions, f(-x) = -f(x). This file isolates that shared structure into a SignedMeasure and proves one unified theorem from which all three classical cases follow as instances. It directly answers the open question posed by the parent spherical-Menelaus entry.",
+    "mathContext": "**Unified claim**: for any odd $f$ and six arcs with $f(\\text{denominators}) \\neq 0$, $\\frac{f(BD)}{f(DC)}\\cdot\\frac{f(CE)}{f(EA)}\\cdot\\frac{f(AF)}{f(FB)} = -1 \\iff f(BD)f(CE)f(AF) = -(f(DC)f(EA)f(FB))$. Setting $f \\in \\{\\mathrm{id}, \\sin, \\sinh\\}$ recovers the Euclidean, spherical, and hyperbolic theorems.",
+    "significance": "key",
+    "relatedConcepts": ["Menelaus theorem", "non-Euclidean geometry", "odd functions", "signed arcs", "unification"],
+    "prerequisites": ["Menelaus theorem classical", "spherical and hyperbolic Menelaus", "odd functions"]
+  },
+  {
+    "id": "ann-signed-measure",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 52 },
+    "type": "definition",
+    "title": "SignedMeasure: the unifying abstraction",
+    "content": "A SignedMeasure packages a single field — an odd function f : ℝ → ℝ together with the proof f(-x) = -f(x). This is the entire data distinguishing the three Menelaus geometries. Oddness is not a convenience: it is exactly the property encoding the signed-arc sign convention, where reversing an arc's orientation negates its measure. The Menelaus ratioProduct (a/b)·(c/d)·(e/g) is defined alongside it.",
+    "mathContext": "`structure SignedMeasure where f : ℝ → ℝ; odd : ∀ x, f (-x) = -f x`. Instances: `idMeasure` (oddness by rfl), `sinMeasure` (Real.sin_neg), `sinhMeasure` (Real.sinh_neg).",
+    "significance": "key",
+    "relatedConcepts": ["odd function", "signed arc length", "abstraction"],
+    "prerequisites": ["structures in Lean", "odd functions"]
+  },
+  {
+    "id": "ann-algebraic-core",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 74 },
+    "type": "technique",
+    "title": "Function-agnostic algebraic core",
+    "content": "ratioProduct_eq_neg_one_iff is the heart of every Menelaus theorem, and it assumes nothing about the values beyond nonzero denominators: (a/b)(c/d)(e/g) = -1 iff a·c·e = -(b·d·g). The proof clears denominators with div_mul_div_comm and div_eq_iff, then finishes by linarith. Because it is purely formal, the same lemma serves the plane, the sphere, and the hyperbolic plane — only the inputs (id-, sin-, or sinh-values) change.",
+    "mathContext": "With $D = bdg \\neq 0$, the equation $\\frac{ace}{bdg} = -1$ is equivalent to $ace = -bdg$ via `div_eq_iff`. The companion `ratioProduct_eq_one_iff` gives the Ceva condition $ace = bdg$.",
+    "significance": "key",
+    "relatedConcepts": ["field arithmetic", "Menelaus condition", "geometry-independence"],
+    "prerequisites": ["div_eq_iff", "div_mul_div_comm"]
+  },
+  {
+    "id": "ann-unified-menelaus",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 98 },
+    "type": "theorem",
+    "title": "unified_menelaus: the single parametrized theorem",
+    "content": "For any SignedMeasure μ and six arcs whose denominator measures are nonzero, the μ-Menelaus product equals -1 iff the numerator-measure product equals minus the denominator-measure product. This is a two-line consequence of the algebraic core, applied to the f-values of the arcs. It is the affirmative answer to the parent entry's open question: yes, there is one Menelaus theorem parametrized by the measure function.",
+    "mathContext": "`unified_menelaus (μ : SignedMeasure) ... : ratioProduct (μ.f bd) ... = -1 ↔ μ.f bd * μ.f ce * μ.f af = -(μ.f dc * μ.f ea * μ.f fb)`, proved by `ratioProduct_eq_neg_one_iff _ _ _ _ _ _ hdc hea hfb`.",
+    "significance": "key",
+    "relatedConcepts": ["Menelaus theorem", "parametrized theorem", "specialization"],
+    "prerequisites": ["ratioProduct_eq_neg_one_iff", "SignedMeasure"]
+  },
+  {
+    "id": "ann-oddness-toggle",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 140, "endLine": 147 },
+    "type": "insight",
+    "title": "Why oddness: the Ceva ↔ Menelaus toggle",
+    "content": "This is the conceptual payoff. ceva_iff_menelaus_after_reverse shows a configuration satisfies the Ceva condition (product = 1) iff, after reversing a single arc, it satisfies the Menelaus condition (product = -1). The proof uses ratioProduct_reverse_den, which negates the product precisely because μ.f(-ea) = -μ.f(ea). Thus oddness is what buys signed-arc coherence: an odd number of orientation reversals toggles between concurrency (Ceva) and collinearity (Menelaus). The bare algebraic identity holds for any function; oddness is needed only for this sign convention.",
+    "mathContext": "Reversing one denominator arc sends the product $P \\mapsto -P$ (`ratioProduct_reverse_den`, via $f(-x) = -f(x)$ and `div_neg`). Hence $P = 1 \\iff -P = -1$, i.e. Ceva $\\iff$ reversed-Menelaus.",
+    "significance": "key",
+    "relatedConcepts": ["Ceva's theorem", "orientation reversal", "sign convention", "Z/2 grading"],
+    "prerequisites": ["odd functions", "ratioProduct_reverse_den"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+    "range": { "startLine": 169, "endLine": 173 },
+    "type": "technique",
+    "title": "Recovering the three classical theorems",
+    "content": "With the unified theorem in hand, each classical Menelaus theorem is a one-line instance. euclidean_menelaus applies unified_menelaus to idMeasure, spherical_menelaus to sinMeasure, hyperbolic_menelaus to sinhMeasure. The only per-geometry input is the oddness witness (rfl for id, Real.sin_neg for sin, Real.sinh_neg for sinh) and the domain condition on denominators (sin excludes multiples of π; id and sinh exclude only 0).",
+    "mathContext": "`euclidean_menelaus ... := unified_menelaus idMeasure ...`; likewise `sinMeasure` and `sinhMeasure`. The hypotheses specialize to $dc, ea, fb \\neq 0$ (Euclidean) and $\\sin/\\sinh$ of those nonzero (spherical/hyperbolic).",
+    "significance": "important",
+    "relatedConcepts": ["instantiation", "Euclidean/spherical/hyperbolic Menelaus", "Real.sin_neg", "Real.sinh_neg"],
+    "prerequisites": ["unified_menelaus", "SignedMeasure instances"]
+  }
+]

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+  "title": "Unified Menelaus Theorem via Odd Measure Functions",
+  "slug": "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01",
+  "description": "Answers the open question posed by the spherical Menelaus entry: is there a single Menelaus theorem parametrized by the measure function? Yes. Isolating the shared structure into a SignedMeasure (an odd f : ℝ → ℝ) yields one unified_menelaus theorem from which the Euclidean (id), spherical (sin), and hyperbolic (sinh) cases follow as instances. Oddness is identified as exactly the property providing signed-arc coherence (the Ceva ↔ Menelaus sign toggle).",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Menelaus%27_theorem",
+    "date": "2026-06-16",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CevasTheoremNonEuclideanOQ02OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "menelaus",
+      "ceva",
+      "transversal",
+      "signed-ratios",
+      "odd-function",
+      "unification"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified from Mathlib.",
+    "lineCount": 232,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "originalContributions": [
+      "SignedMeasure: the abstraction unifying all three Menelaus geometries — an odd function f : ℝ → ℝ, with oddness encoding the signed-arc sign convention",
+      "unified_menelaus: a single Menelaus characterization for any SignedMeasure, specializing to Euclidean/spherical/hyperbolic",
+      "ratioProduct_eq_neg_one_iff / ratioProduct_eq_one_iff: function-agnostic algebraic cores for the Menelaus (−1) and Ceva (+1) conditions, requiring no hypothesis on values",
+      "ratioProduct_reverse_num / ratioProduct_reverse_den: a single arc-orientation reversal negates the Menelaus product",
+      "ceva_iff_menelaus_after_reverse: one reversal toggles Ceva (+1) and Menelaus (−1) — the precise geometric role of oddness",
+      "euclidean_menelaus / spherical_menelaus / hyperbolic_menelaus: the three classical theorems recovered as one-line instances of unified_menelaus via idMeasure/sinMeasure/sinhMeasure"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Menelaus of Alexandria (c. 70-140 CE) stated his transversal theorem for the sphere in the 'Sphaerica'; the Euclidean planar version is a limiting case. Over two millennia the spherical (sin), hyperbolic (sinh), and Euclidean (identity) Menelaus theorems were treated as three separate results. This entry collapses them into one: the only thing the three geometries supply is a measure function for signed geodesic arcs, and the single algebraic property they share is oddness, f(-x) = -f(x). The parent spherical-Menelaus entry explicitly raised this as an open question — 'is there a unified Menelaus theorem parametrized by an odd function f?' — and this file answers it affirmatively.",
+    "problemStatement": "Is there a single Menelaus theorem parametrized by the choice of measure function f, with the Euclidean (f = id), spherical (f = sin), and hyperbolic (f = sinh) theorems as instances? Identify the minimal hypothesis on f that makes the signed-ratio framework coherent.",
+    "proofStrategy": "Two observations decompose the problem. (1) The algebraic core is function-free: for nonzero denominators, (a/b)(c/d)(e/g) = -1 iff a·c·e = -(b·d·g) (ratioProduct_eq_neg_one_iff), proved by div_mul_div_comm and div_eq_iff. Applying it to f-values of six arcs immediately gives unified_menelaus for any f. (2) Oddness is what makes the SIGN convention coherent: reversing one arc (x ↦ -x) uses f(-x) = -f(x) to negate exactly one ratio, flipping the product +1 ↔ -1 (ratioProduct_reverse_num/den, ceva_iff_menelaus_after_reverse). The three classical theorems are then literal one-line instances obtained by packaging id/sin/sinh as SignedMeasure records (oddness witnessed by rfl, Real.sin_neg, Real.sinh_neg).",
+    "keyInsights": [
+      "The Menelaus identity itself needs no hypothesis on the measure function — it is a formal algebraic identity in the six arc measures for any nonzero denominators",
+      "Oddness f(-x) = -f(x) is the exact property buying signed-arc coherence: it is required for the Ceva (+1) ↔ Menelaus (−1) toggle under orientation reversal, not for the bare identity",
+      "Packaging the measure as a structure (SignedMeasure) turns the three classical theorems into one-line specializations, with oddness witnessed by rfl / Real.sin_neg / Real.sinh_neg",
+      "An odd number of arc reversals switches concurrency (Ceva) and collinearity (Menelaus) — captured formally by ceva_iff_menelaus_after_reverse",
+      "The appropriate domain is geometry-specific only through where f vanishes: id and sinh vanish only at 0, sin vanishes at every multiple of π"
+    ],
+    "prerequisites": [
+      "Menelaus' theorem (Euclidean version) and Ceva's theorem",
+      "Parent spherical Menelaus theorem (cevas-theorem-non-euclidean-oq-02-oq-01) and the hyperbolic sibling (oq-02)",
+      "Oddness of sin and sinh (Real.sin_neg, Real.sinh_neg in Mathlib)",
+      "Basic field arithmetic with nonzero denominators (div_eq_iff, div_mul_div_comm)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-signed-measure",
+      "title": "Part 1: Signed Measure Functions",
+      "startLine": 37,
+      "endLine": 52,
+      "summary": "The SignedMeasure structure (an odd f : ℝ → ℝ) abstracting the three classical measure functions, and the Menelaus ratioProduct (a/b)·(c/d)·(e/g)."
+    },
+    {
+      "id": "part2-algebraic-core",
+      "title": "Part 2: Unified Algebraic Core",
+      "startLine": 54,
+      "endLine": 98,
+      "summary": "ratioProduct_eq_neg_one_iff and ratioProduct_eq_one_iff (function-agnostic cores for the Menelaus −1 and Ceva +1 conditions) and unified_menelaus, the single Menelaus theorem for any SignedMeasure."
+    },
+    {
+      "id": "part3-coherence",
+      "title": "Part 3: Signed-Arc Coherence (the role of oddness)",
+      "startLine": 100,
+      "endLine": 147,
+      "summary": "measure_neg, measure_neg_ne_zero, ratioProduct_reverse_num/den, and ceva_iff_menelaus_after_reverse — reversing one arc negates the product, toggling Ceva and Menelaus exactly because f is odd."
+    },
+    {
+      "id": "part4-instances",
+      "title": "Part 4: The Three Classical Instances",
+      "startLine": 149,
+      "endLine": 193,
+      "summary": "idMeasure/sinMeasure/sinhMeasure and the corollaries euclidean_menelaus, spherical_menelaus, hyperbolic_menelaus, each a one-line specialization of unified_menelaus."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 195,
+      "endLine": 229,
+      "summary": "Recap: SignedMeasure abstraction, the unified theorem and its algebraic cores, the oddness/coherence lemmas, the three instances, and the domain characterization (0 sorries, 0 axioms)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The three classical Menelaus theorems are unified into a single result parametrized by an odd measure function. unified_menelaus holds for any SignedMeasure, and Euclidean/spherical/hyperbolic Menelaus are one-line instances via id/sin/sinh. The proof separates the function-free algebraic core from the role of oddness, which is shown to be exactly the property providing signed-arc (Ceva ↔ Menelaus) coherence. 0 sorries, 0 axioms.",
+    "implications": "Identifying oddness as the operative hypothesis suggests the 'real' object is a signed arc-measure on an oriented geodesic, with the three geometries as special cases of a one-parameter family. The Ceva/Menelaus toggle under reversal is a Z/2 grading on configurations.",
+    "openQuestions": [
+      "Is there a unified Ceva–Menelaus duality realized as a single statement about cross-ratios in projective space, with the +1/−1 dichotomy as orientation parity?",
+      "Which non-odd measure functions, if any, still admit a coherent signed-ratio Menelaus theorem on a restricted domain?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CevasTheoremNonEuclideanOQ02OQ01OQ01",
+    "lineCount": 232,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "path": "Proofs/CevasTheoremNonEuclideanOQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "proofId": "cevas-theorem-non-euclidean-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent spherical Menelaus (via sin) whose stated open question — a unified Menelaus parametrized by an odd function — this file answers"
+    },
+    {
+      "proofId": "cevas-theorem-non-euclidean-oq-02",
+      "relationship": "sibling",
+      "description": "Hyperbolic Menelaus (via sinh); recovered here as the sinhMeasure instance of unified_menelaus"
+    },
+    {
+      "proofId": "cevas-theorem-non-euclidean",
+      "relationship": "ancestor",
+      "description": "Spherical Ceva's theorem; the concurrency (+1) counterpart toggled to the transversal (−1) condition via ceva_iff_menelaus_after_reverse"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
- Adds the missing gallery entry for `CevasTheoremNonEuclideanOQ02OQ01OQ01.lean` (232L, **0 sorry / 0 axiom**), which is registered in `Proofs.lean:507` and already graduated in `research/registry.json` but had no `src/data/proofs/` directory — a complete-but-ungalleried proof.
- `meta.json` (status `verified`, badge `original`) + `annotations.json` (6 annotations, resolver **6/6 aligned**).

## Why this is a substantive entry
This proof **answers the open question explicitly posed by the parent** spherical-Menelaus entry (`cevas-theorem-non-euclidean-oq-02-oq-01`): *is there a unified Menelaus theorem parametrized by an odd measure function?*

- `SignedMeasure` abstracts the three geometries into a single odd `f : ℝ → ℝ`.
- `unified_menelaus` holds for any `SignedMeasure`; Euclidean (`id`), spherical (`sin`), and hyperbolic (`sinh`) Menelaus are recovered as **one-line instances**.
- Oddness is identified as exactly the property providing signed-arc coherence — `ceva_iff_menelaus_after_reverse` shows one orientation reversal toggles Ceva (+1) and Menelaus (−1).

## Validation (build-free)
- `node` JSON.parse: both files parse.
- `scripts/annotations/resolver.ts validate`: 6 valid, 0 misaligned.
- No Lean source changed; proof was already built/registered. Docker daemon is wedged (`docker info` rc=124), so this gallery-only JSON change is the blackout-safe completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)