### PR TITLE
audit(tracker): persist clean completion (steiner-lehmus-theorem-oq-01)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15677,6 +15677,12 @@
       "lastAudited": "2026-06-16T20:53:49Z",
       "result": "clean",
       "issues": []
+    },
+    "steiner-lehmus-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T21:42:25Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Gallery integrity audit of `steiner-lehmus-theorem-oq-01` → **CLEAN**.
- Persists the tracker entry so the next auditor cycle's `git reset --hard origin/main` doesn't re-serve the same target.

## Audit findings
- Main file `Proofs/SteinerLehmusTheoremOQ01.lean` (registered in `Proofs.lean`): **0 real sorries** (the single grep hit is the comment "no `sorry`" on line 33), **0 axioms**, **0 True-stubs**, **2 theorems**.
- meta.json claims `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0`, `theoremCount: 2` — all match the source.
- Tier A: first-principles real-algebra proof (`linear_combination`/`ring`/`positivity`); no deep Mathlib theorem does the core work. "Not a named Mathlib result" is accurate.
- Title is properly qualified **"(Algebraic Core)"** and the overview is explicit that the classical bisector-length formula is taken as a definition (`bisectorSq`) — so the famous-theorem name is not overclaimed.

## Test plan
- [x] `node`/`tsx` tracker write validated (JSON parses)
- [x] No source files changed — tracker-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)