### PR TITLE
research(ballot-problem-oq-01-oq-03): gallery entry for Catalan reflection-count proof

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-03/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-ballot-oq0103-reflection-overview",
+    "proofId": "ballot-problem-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "Reflection Principle and the Two Forms of the Catalan Number",
+    "content": "The classical ballot theorem is proved by André's *reflection principle*: the number of 'good' lattice paths (those that stay strictly on one side of the diagonal) equals the total number of monotone paths minus the number of 'bad' paths, where the bad paths are counted bijectively by reflecting their initial segment. For the symmetric Dyck-path case — $n$ up-steps and $n$ down-steps that never dip below the axis — this reflection count is\n\n$$\\operatorname{catalan} n = \\binom{2n}{n} - \\binom{2n}{n+1}.$$\n\nThis *reflection form* is mathematically distinct from Mathlib's *division form* `catalan_eq_centralBinom_div` ($\\operatorname{catalan} n = \\operatorname{centralBinom} n / (n+1)$): it never divides, being a literal 'all paths minus reflected bad paths' difference — exactly what the ballot/reflection argument delivers. The file proves the reflection form and reconciles the two in `choose_sub_choose_eq_centralBinom_div`.",
+    "mathContext": "Mathlib provides the Catalan number only via the recurrence $(n+1)\\cdot\\operatorname{catalan} n = \\operatorname{centralBinom} n$ and the division closed form. The subtraction identity $\\binom{2n}{n} - \\binom{2n}{n+1}$ is not a named Mathlib lemma; it is the combinatorially meaningful 'reflection count' and is derived here from the Catalan and adjacent-binomial recurrences.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflection principle",
+      "ballot theorem",
+      "Catalan number",
+      "Dyck paths",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Monotone lattice paths",
+      "Binomial coefficients",
+      "Definition of the Catalan number"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq0103-all-paths",
+    "proofId": "ballot-problem-oq-01-oq-03",
+    "range": {
+      "startLine": 37,
+      "endLine": 44
+    },
+    "type": "theorem",
+    "title": "All Paths: C(2n, n) = (n+1)·catalan n",
+    "content": "`two_mul_choose_eq` identifies the total monotone-path count with $(n+1)$ copies of the Catalan number:\n\n$$\\binom{2n}{n} = (n+1)\\cdot\\operatorname{catalan} n.$$\n\nThe one-line proof rewrites $\\binom{2n}{n}$ backwards through `Nat.centralBinom_eq_two_mul_choose` to $\\operatorname{centralBinom} n$, then forward through `succ_mul_catalan_eq_centralBinom` to $(n+1)\\cdot\\operatorname{catalan} n$.",
+    "mathContext": "$\\binom{2n}{n}$ counts every monotone path from $(0,0)$ to $(n,n)$. The Catalan defining recurrence $(n+1)\\operatorname{catalan} n = \\operatorname{centralBinom} n$ exhibits this total as $(n+1)$ equal blocks of $\\operatorname{catalan} n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "succ_mul_catalan_eq_centralBinom",
+      "Nat.centralBinom_eq_two_mul_choose"
+    ],
+    "prerequisites": [
+      "Central binomial coefficient",
+      "Catalan recurrence"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq0103-bad-paths",
+    "proofId": "ballot-problem-oq-01-oq-03",
+    "range": {
+      "startLine": 46,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "Bad (Reflected) Paths: C(2n, n+1) = n·catalan n",
+    "content": "`two_mul_choose_succ_eq` computes the count of reflected bad paths:\n\n$$\\binom{2n}{n+1} = n\\cdot\\operatorname{catalan} n.$$\n\nIt starts from the adjacent-binomial recurrence `Nat.choose_succ_right_eq` applied at $(2n, n)$, substitutes the previous identity `two_mul_choose_eq`, simplifies $2n - n = n$ with `omega`, and then cancels the common factor $(n+1)$ via `Nat.eq_of_mul_eq_mul_right` (legal since $n+1 > 0$).",
+    "mathContext": "Reflecting the initial segment of a bad Dyck path sends it bijectively to a monotone path with a shifted endpoint, counted by $\\binom{2n}{n+1}$. Algebraically this equals $n\\cdot\\operatorname{catalan} n$, i.e. $n$ of the $(n+1)$ blocks that make up the total.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflection principle",
+      "Nat.choose_succ_right_eq",
+      "Nat.eq_of_mul_eq_mul_right",
+      "cancellation"
+    ],
+    "prerequisites": [
+      "Adjacent-binomial recurrence",
+      "Cancellation in ℕ"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq0103-reflection-form",
+    "proofId": "ballot-problem-oq-01-oq-03",
+    "range": {
+      "startLine": 65,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "Reflection Form: catalan n = C(2n, n) − C(2n, n+1)",
+    "content": "`catalan_eq_choose_sub_choose` is the headline identity:\n\n$$\\operatorname{catalan} n = \\binom{2n}{n} - \\binom{2n}{n+1}.$$\n\nRewriting both binomials through the two preceding lemmas turns the right-hand side into $(n+1)\\cdot\\operatorname{catalan} n - n\\cdot\\operatorname{catalan} n$, which `omega` reduces to $\\operatorname{catalan} n$. No division appears anywhere — this is the division-free count the reflection principle produces.",
+    "mathContext": "The difference of the two counts is one block: $(n+1)\\operatorname{catalan} n - n\\operatorname{catalan} n = \\operatorname{catalan} n$. Because $\\binom{2n}{n} \\ge \\binom{2n}{n+1}$, the truncated subtraction over $\\mathbb{N}$ is exact, so `omega` closes the goal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Catalan number",
+      "Dyck paths",
+      "ballot theorem",
+      "truncated subtraction over ℕ"
+    ],
+    "prerequisites": [
+      "The two binomial count lemmas",
+      "omega decision procedure"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq0103-reconciliation",
+    "proofId": "ballot-problem-oq-01-oq-03",
+    "range": {
+      "startLine": 80,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Reconciliation with Mathlib's Division Form",
+    "content": "`choose_sub_choose_eq_centralBinom_div` confirms that the reflection form agrees with the standard closed form:\n\n$$\\binom{2n}{n} - \\binom{2n}{n+1} = \\frac{\\operatorname{centralBinom} n}{n+1}.$$\n\nThe proof rewrites the left side backwards through `catalan_eq_choose_sub_choose` to $\\operatorname{catalan} n$, then forward through Mathlib's `catalan_eq_centralBinom_div`. Both expressions compute the same Catalan number.",
+    "mathContext": "This closes the loop between the combinatorial reflection count and the algebraic division form already in Mathlib, certifying that the two standard presentations of the Catalan number coincide.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "catalan_eq_centralBinom_div",
+      "division form",
+      "closed form"
+    ],
+    "prerequisites": [
+      "Reflection form catalan_eq_choose_sub_choose",
+      "Mathlib division form"
+    ]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-03/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "ballot-problem-oq-01-oq-03",
+  "title": "The Catalan Number as a Reflection (Ballot) Count",
+  "slug": "ballot-problem-oq-01-oq-03",
+  "description": "Establishes the division-free reflection form of the Catalan number, catalan n = C(2n, n) − C(2n, n+1), which is exactly the count the reflection principle delivers for the symmetric ballot/Dyck-path problem (all monotone paths minus reflected bad paths), and reconciles it with Mathlib's division form catalan n = centralBinom n / (n+1). Zero sorries, zero axioms; every step is a one- or two-line argument over Mathlib's Catalan and binomial API.",
+  "meta": {
+    "author": "André (1887) reflection principle; formalized by lean-genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "1887",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallotProblemOQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "ballot-problem",
+      "reflection-principle",
+      "binomial-coefficients",
+      "dyck-paths"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-16",
+    "lineCount": 92,
+    "theoremCount": 4,
+    "originalContributions": [
+      "catalan_eq_choose_sub_choose: the reflection form catalan n = C(2n, n) − C(2n, n+1), the literal 'all paths minus reflected bad paths' count produced by the reflection principle. Mathlib has only the division form catalan n = centralBinom n / (n+1); the subtraction form is not a named library lemma.",
+      "two_mul_choose_succ_eq: the count of bad (reflected) Dyck paths, C(2n, n+1) = n · catalan n, derived from the adjacent-binomial recurrence Nat.choose_succ_right_eq by cancelling the factor (n+1).",
+      "two_mul_choose_eq: the central binomial as (n+1) copies of the Catalan number, C(2n, n) = (n+1) · catalan n, a repackaging of succ_mul_catalan_eq_centralBinom via centralBinom = (2n).choose n.",
+      "choose_sub_choose_eq_centralBinom_div: reconciliation of the reflection form with Mathlib's division form, confirming C(2n, n) − C(2n, n+1) = centralBinom n / (n+1)."
+    ],
+    "assumptions": "No axioms, no sorries. The file imports only Mathlib. The good/bad path counts are obtained from Mathlib's Catalan-number API: succ_mul_catalan_eq_centralBinom (the defining recurrence (n+1)·catalan n = centralBinom n), Nat.choose_succ_right_eq (the adjacent-binomial recurrence), and Nat.centralBinom_eq_two_mul_choose. The cancellation of the factor (n+1) uses Nat.eq_of_mul_eq_mul_right; the final subtraction identity is closed by omega over the natural numbers. No native_decide and no decide are used, so the proof depends on no axioms beyond Lean/Mathlib's core.",
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "Defining recurrence for the Catalan number: (n+1) · catalan n = centralBinom n.",
+        "module": "Mathlib.Combinatorics.Catalan"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n, relating the central binomial coefficient to a binomial.",
+        "module": "Mathlib.Combinatorics.Choose.Central"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "Adjacent-binomial recurrence: (n.choose (k+1)) · (k+1) = (n.choose k) · (n - k).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "catalan_eq_centralBinom_div",
+        "description": "Division (closed) form of the Catalan number: catalan n = centralBinom n / (n+1).",
+        "module": "Mathlib.Combinatorics.Catalan"
+      }
+    ],
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The ballot problem — in how many ways can the counts of two candidates be arranged so that one is always strictly ahead — was studied by Whitworth and given its definitive solution by Désiré André in 1887 through the reflection principle: bad lattice paths (those that touch or cross a forbidden line) are put in bijection, by reflecting their initial segment, with a shifted family of paths that is easy to count. For the symmetric Dyck-path case (n up-steps and n down-steps that never dip below the axis), this reflection count is C(2n, n) − C(2n, n+1), which equals the n-th Catalan number. The Catalan numbers, named after Eugène Catalan, count an enormous range of combinatorial objects (Dyck paths, balanced parentheses, triangulations, binary trees), and the reflection form is the one that arises most directly from the ballot argument.",
+    "problemStatement": "Express the Catalan number in the division-free 'reflection' form catalan n = C(2n, n) − C(2n, n+1) — the literal output of the reflection principle, total monotone paths minus reflected bad paths — and prove it agrees with Mathlib's division form catalan n = centralBinom n / (n+1). Along the way, identify C(2n, n) as (n+1)·catalan n (all paths) and C(2n, n+1) as n·catalan n (bad paths).",
+    "proofStrategy": "The two binomial counts are pinned to the Catalan number first. two_mul_choose_eq rewrites C(2n, n) as centralBinom n (via Nat.centralBinom_eq_two_mul_choose) and then as (n+1)·catalan n (via succ_mul_catalan_eq_centralBinom). two_mul_choose_succ_eq feeds the adjacent-binomial recurrence Nat.choose_succ_right_eq, substitutes the previous identity, simplifies 2n − n = n by omega, and cancels the common factor (n+1) with Nat.eq_of_mul_eq_mul_right to obtain C(2n, n+1) = n·catalan n. With both counts in hand, catalan_eq_choose_sub_choose rewrites the right-hand side to (n+1)·catalan n − n·catalan n and closes the goal by omega. Finally, choose_sub_choose_eq_centralBinom_div chains the reflection form with catalan_eq_centralBinom_div to reconcile it with the standard closed form. No path sets are constructed explicitly: the reflection bijection is captured numerically through Mathlib's Catalan recurrence.",
+    "keyInsights": [
+      "The reflection form catalan n = C(2n, n) − C(2n, n+1) is the count the ballot argument actually produces — 'all monotone paths minus reflected bad paths' — and it never divides, unlike the standard closed form centralBinom n / (n+1).",
+      "C(2n, n) = (n+1)·catalan n and C(2n, n+1) = n·catalan n: the total path count is (n+1) copies of catalan n and the bad path count is n copies, so their difference is exactly one copy — the cleanest possible witness that reflection removes precisely n/(n+1) of the paths.",
+      "The bad-path identity comes for free from the adjacent-binomial recurrence Nat.choose_succ_right_eq together with the Catalan recurrence; no explicit reflection bijection on path sets is needed to certify the count.",
+      "Working over ℕ, the subtraction C(2n, n) − C(2n, n+1) is genuine truncated subtraction, but because C(2n, n) ≥ C(2n, n+1) the identity holds on the nose and is dispatched by omega once both terms are expressed through catalan n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "file-setup",
+      "title": "Imports, Doc-Comment, and Namespace",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "A doc-comment (lines 1–29) states the reflection form catalan n = C(2n, n) − C(2n, n+1), contrasts it with Mathlib's division form, and lists the four Mathlib inputs. The file imports all of Mathlib, opens the BallotProblemOQ01OQ03 namespace, and opens Nat so that choose / centralBinom / catalan resolve unqualified.",
+      "mathContext": "Reflection principle: good Dyck paths = total monotone paths − reflected bad paths. For n up- and n down-steps this is C(2n, n) − C(2n, n+1) = catalan n."
+    },
+    {
+      "id": "central-binom-as-catalan",
+      "title": "All Paths: C(2n, n) = (n+1)·catalan n",
+      "startLine": 37,
+      "endLine": 44,
+      "summary": "two_mul_choose_eq rewrites (2n).choose n as centralBinom n (Nat.centralBinom_eq_two_mul_choose) and then as (n+1)·catalan n (succ_mul_catalan_eq_centralBinom). This is the total count of monotone lattice paths.",
+      "mathContext": "C(2n, n) counts all monotone paths from (0,0) to (n,n); the Catalan recurrence (n+1)·catalan n = centralBinom n exhibits it as (n+1) copies of catalan n.",
+      "relatedConcepts": [
+        "central binomial coefficient",
+        "Catalan recurrence",
+        "succ_mul_catalan_eq_centralBinom"
+      ]
+    },
+    {
+      "id": "bad-paths",
+      "title": "Bad (Reflected) Paths: C(2n, n+1) = n·catalan n",
+      "startLine": 46,
+      "endLine": 63,
+      "summary": "two_mul_choose_succ_eq derives the reflected-bad-path count. It applies the adjacent-binomial recurrence Nat.choose_succ_right_eq, substitutes two_mul_choose_eq, simplifies 2n − n = n by omega, and cancels the common factor (n+1) using Nat.eq_of_mul_eq_mul_right to conclude C(2n, n+1) = n·catalan n.",
+      "mathContext": "Under reflection of the initial segment, bad Dyck paths biject with monotone paths to a shifted endpoint counted by C(2n, n+1); algebraically this is n·catalan n.",
+      "relatedConcepts": [
+        "reflection principle",
+        "adjacent-binomial recurrence",
+        "Nat.choose_succ_right_eq",
+        "Nat.eq_of_mul_eq_mul_right"
+      ]
+    },
+    {
+      "id": "reflection-form",
+      "title": "Reflection Form: catalan n = C(2n, n) − C(2n, n+1)",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "catalan_eq_choose_sub_choose substitutes both binomial counts to turn the right-hand side into (n+1)·catalan n − n·catalan n and closes the goal by omega. This is the division-free ballot/reflection count.",
+      "mathContext": "(n+1)·catalan n − n·catalan n = catalan n: reflection removes the n bad copies, leaving exactly one — the Catalan number — with no division.",
+      "relatedConcepts": [
+        "Catalan number",
+        "Dyck paths",
+        "ballot theorem",
+        "truncated subtraction over ℕ"
+      ]
+    },
+    {
+      "id": "reconciliation",
+      "title": "Reconciliation with the Division Form",
+      "startLine": 80,
+      "endLine": 91,
+      "summary": "choose_sub_choose_eq_centralBinom_div chains catalan_eq_choose_sub_choose with Mathlib's catalan_eq_centralBinom_div to prove C(2n, n) − C(2n, n+1) = centralBinom n / (n+1), confirming the reflection count agrees with the standard closed form.",
+      "mathContext": "Both expressions equal catalan n, so the reflection form and the division form centralBinom n / (n+1) compute the same value.",
+      "relatedConcepts": [
+        "catalan_eq_centralBinom_div",
+        "closed form",
+        "division form"
+      ]
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes the reflection (ballot) form of the Catalan number, catalan n = C(2n, n) − C(2n, n+1), by counting all monotone lattice paths as (n+1)·catalan n and the reflected bad paths as n·catalan n, so their difference is exactly catalan n. It then reconciles this division-free form with Mathlib's standard division form centralBinom n / (n+1). The proof has zero sorries and zero axioms and rests entirely on Mathlib's Catalan and binomial recurrences.",
+    "implications": "The reflection form is the shape of the Catalan number that the ballot/reflection principle produces directly, making it the natural bridge between the lattice-path combinatorics of the ballot problem and the closed-form Catalan identities already in Mathlib. Having the subtraction form available — and certified equal to the division form — lets downstream ballot-problem entries reason about Dyck-path counts without invoking natural-number division.",
+    "openQuestions": [
+      "Can the numeric reflection identity be upgraded to an explicit bijection on the underlying lattice-path (or Dyck-word) sets, so that C(2n, n) − C(2n, n+1) is realized as a genuine set difference rather than an algebraic one?",
+      "Does the same recurrence-based bookkeeping yield the asymmetric ballot count C(a+b, a)·(a−b)/(a+b) for a > b, recovering the general Bertrand ballot theorem in division-free form?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem",
+      "relationship": "foundation",
+      "description": "The ballot problem whose reflection-principle solution this Catalan identity packages in division-free form."
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "extends",
+      "description": "Parent open question in the ballot-problem family; this entry contributes the reflection form of the Catalan count."
+    },
+    {
+      "targetId": "ballot-problem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question under ballot-problem-oq-01 in the same reflection/Catalan circle of ideas."
+    }
+  ],
+  "references": {
+    "papers": [
+      {
+        "title": "Solution directe du problème résolu par M. Bertrand",
+        "author": "D. André",
+        "year": 1887,
+        "url": "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
+      }
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Catalan_number",
+      "https://en.wikipedia.org/wiki/Bertrand%27s_ballot_problem"
+    ],
+    "mathlib": [
+      "Mathlib.Combinatorics.Catalan",
+      "Mathlib.Combinatorics.Choose.Central",
+      "Mathlib.Data.Nat.Choose.Basic"
+    ]
+  },
+  "leanFile": {
+    "namespace": "BallotProblemOQ01OQ03",
+    "lineCount": 92,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BallotProblemOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/ballot-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-03.json
@@ -4,10 +4,10 @@
   "tier": "B",
   "significance": 7,
   "tractability": 7,
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "started": "2026-06-15",
-  "lastUpdate": "2026-06-15T00:00:00Z",
+  "lastUpdate": "2026-06-16",
   "path": "research/problems/ballot-problem-oq-01-oq-03",
   "tags": [
     "combinatorics",
@@ -46,7 +46,7 @@
       "Optionally connect to a concrete Dyck-path Finset count = catalan n to make the 'ballot count' interpretation literal rather than documentary.",
       "Add a numeric example theorem (e.g. catalan 3 = C(6,3)-C(6,4) = 5) once build is available."
     ],
-    "progressSummary": "SOLVED/build-pending (2026-06-15): reflection form catalan n = C(2n,n)-C(2n,n+1) proven + reconciled with Mathlib division form in BallotProblemOQ01OQ03.lean (0 sorries/0 axioms). All 4 Mathlib deps name-checked vs v4.26 (researcher-3) — build-ready, unregistered. Only Docker-up build+register remains. PROGRESS: proved the reflection form catalan n = C(2n,n) - C(2n,n+1) (0 sorries, 0 axioms) build-pending under Docker blackout; reconciled with Mathlib's division form."
+    "progressSummary": "COMPLETED (2026-06-16): reflection form catalan n = C(2n,n)-C(2n,n+1) proven + reconciled with Mathlib division form in BallotProblemOQ01OQ03.lean (0 sorries/0 axioms). Registered in Proofs.lean (line 165, merged #24433) and now galleried at src/data/proofs/ballot-problem-oq-01-oq-03 (meta + 5 annotations, resolver 5/5)."
   },
   "leanFiles": [
     {


### PR DESCRIPTION
## Summary
Adds the missing gallery entry for the **complete-but-ungalleried** file `Proofs/BallotProblemOQ01OQ03.lean` (merged in #24433, registered at `Proofs.lean:165`). The file proves the division-free *reflection form* of the Catalan number

  `catalan n = C(2n, n) − C(2n, n+1)`

— the literal "all monotone paths − reflected bad paths" count produced by André's reflection principle — and reconciles it with Mathlib's division form `centralBinom n / (n+1)`.

## What this adds
- `src/data/proofs/ballot-problem-oq-01-oq-03/meta.json` — status `verified`, badge `mathlib`, `axiomCount: 0`, 4 theorems
- `src/data/proofs/ballot-problem-oq-01-oq-03/annotations.json` — 5 annotations (resolver **5/5 valid, 0 misaligned**)
- research registry advanced to `COMPLETED` (corrects a stale "build-pending/unregistered" note — the file is registered and merged)

## Verification
- File imports only Mathlib; uses `rw`/`omega`/`ring` and standard Catalan/binomial recurrences (`succ_mul_catalan_eq_centralBinom`, `Nat.choose_succ_right_eq`, `catalan_eq_centralBinom_div`). **No `native_decide`/`decide`** → no axioms beyond Lean/Mathlib core (0 sorries / 0 axioms).
- Gallery JSON only — validated via `node JSON.parse` and `scripts/annotations/resolver.ts validate`. No Lean source changes.
- crossReference targets (`ballot-problem`, `ballot-problem-oq-01`, `ballot-problem-oq-01-oq-01`) all exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)