### PR TITLE
research(quadratic-reciprocity-algorithm-oq-03): re-anchor drifted provenance annotation

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-03/annotations.json
@@ -88,7 +88,7 @@
   {
     "id": "ann-verification-provenance",
     "proofId": "quadratic-reciprocity-algorithm-oq-03",
-    "range": { "startLine": 6, "endLine": 59 },
+    "range": { "startLine": 7, "endLine": 59 },
     "type": "concept",
     "title": "Verification Provenance and Build-Free Numerical Certificates",
     "content": "The module docstring records the epistemic status of this entry, which is unusually explicit. Sessions S1–S13 transcribed the proof *blind*, under a simultaneous Docker and Aristotle outage, so no step could be machine-checked; session S14 (the first with a live Docker backend) confirmed the blind transcription compiles green via `docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ03`, with 0 errors / 0 sorries / 0 axioms. Two re-runnable Python scripts certify the mathematics independently of the Lean build: `verify_zolotarev.py` checks the headline identity $(a/p) = \\operatorname{sign}(\\pi_a)$ for every $a$ across all odd primes $3 \\le p < 80$, and `verify_m1_cycle_lemma.py` checks the `IsCycle` constructor obligations for $\\operatorname{mulLeft} g$ across 45 odd primes up to 199. The docstring is equally explicit about scope: sessions S16/S17 (Docker recovered) extended the file beyond Milestone 1 to the verified Euler-side crux and the units-form Zolotarev headline, but the exact OQ-pinned field statement (via mulLeft₀) and Milestone 2 (reciprocity from the grid-transpose sign) are NOT yet in Lean, so the open question is verified *partial* progress, not resolved.",


### PR DESCRIPTION
## Summary
- Gallery-integrity fix for `quadratic-reciprocity-algorithm-oq-03`. The resolver reported 1/7 misaligned: `ann-verification-provenance` was anchored at line 6 — the blank line between the import block (lines 1-5) and the module docstring (lines 7-77) — where no Lean construct exists.
- Its content describes the docstring's verification/provenance Status section, so its range start is moved to **7** (the docstring block). Resolver `validate` now reports **7/7 valid**.
- JSON-only — no Lean edits.

## Test plan
- [x] `node JSON.parse` on annotations.json passes
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 7/7 valid (was 6/7)