### PR TITLE
research(sqrt2-minpoly-oq-01-oq-02-oq-01): gallery entry for odd-prime-degree radical minimal polynomial

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-sqrt2oq010201-root",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "Part I: The Radical a^(1/p) is a Root of X^p − C a",
+    "content": "Two lemmas establish that the candidate minimal polynomial annihilates the radical. `rpow_inv_pow` proves `(a^(1/p))^p = a` for a nonnegative real `a`: rewrite the outer natural-number power as a real `rpow` (`Real.rpow_natCast`), collapse the nested powers with `Real.rpow_mul` (legal because `a ≥ 0`), and finish with `(1/p)·p = 1` via `inv_mul_cancel₀` and `Real.rpow_one`. `aeval_rpow` then evaluates `X^p − C a` (a polynomial over `ℚ`) at the real radical `(a : ℝ)^(1/p)`: after `simp` reduces `aeval` over the monomial structure, the coercion `algebraMap ℚ ℝ a = (a : ℝ)` (`eq_ratCast`) and the root identity from `rpow_inv_pow` give `a − a = 0`.\n\nThe nonnegativity hypothesis `0 ≤ a` is essential: `Real.rpow_mul` and the power collapse only hold for nonnegative base.",
+    "mathContext": "The root witness $(a^{1/p})^p = a$ for $a \\ge 0$ uses the real power law $a^{(1/p) \\cdot p} = a^1 = a$. Evaluating a $\\mathbb{Q}$-polynomial at a real number factors through $\\operatorname{algebraMap}_{\\mathbb{Q}\\to\\mathbb{R}}$, which `eq_ratCast` identifies with the literal cast — the bridge that lets the real computation discharge the rational polynomial's annihilation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_mul",
+      "Real.rpow_natCast",
+      "inv_mul_cancel₀",
+      "eq_ratCast",
+      "Polynomial.aeval"
+    ],
+    "prerequisites": [
+      "real rpow power laws",
+      "aeval over ℚ[X]",
+      "rational casts into ℝ"
+    ]
+  },
+  {
+    "id": "ann-sqrt2oq010201-main",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 97
+    },
+    "type": "insight",
+    "title": "Part II: Main Theorem via the Kummer Irreducibility Criterion",
+    "content": "`minpoly_rpow_of_odd_prime` is the central result: for an odd prime `p` and a nonnegative rational `a` that is not a `p`-th power in `ℚ`, `minpoly ℚ (a^(1/p)) = X^p − C a`. The proof assembles three facts and invokes `minpoly.eq_of_irreducible_of_monic` (which states: a monic irreducible polynomial annihilating an element equals its minimal polynomial up to `symm`):\n\n1. **Monic.** `monic_X_pow_sub_C a hp0`, using `p ≠ 0` from primality.\n2. **Annihilates.** `aeval_rpow` from Part I.\n3. **Irreducible.** The sharp **Kummer criterion** `X_pow_sub_C_irreducible_iff_of_prime_pow` at exponent `n = 1`: over a field, `X^(p^n) − C a` is irreducible iff `a` is not a `p`-th power. The `.mpr` direction consumes exactly the hypothesis `hnp : ∀ b : ℚ, b^p ≠ a`, and `pow_one` rewrites `p^1` to `p`.\n\nThe hypothesis `p ≠ 2` is required by the criterion — odd primality is what makes `X^p − C a` irreducible from non-`p`-th-power-ness alone.",
+    "mathContext": "$\\operatorname{minpoly}_{\\mathbb{Q}}(a^{1/p}) = X^p - a$ when $p$ is an odd prime and $a \\in \\mathbb{Q}_{\\ge 0}$ is not a $p$-th power. The minimal polynomial is monic by definition, so this monic answer is canonical. Irreducibility is the only non-formal input, supplied by Kummer theory: $X^p - a$ is irreducible over $K$ iff $a \\notin K^p$ (for $p$ an odd prime). The remaining steps — monicity, the root, and 'monic + irreducible + root $\\Rightarrow$ minpoly' — are formal.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "X_pow_sub_C_irreducible_iff_of_prime_pow",
+      "minpoly.eq_of_irreducible_of_monic",
+      "monic_X_pow_sub_C",
+      "Kummer theory",
+      "pow_one"
+    ],
+    "prerequisites": [
+      "minimal polynomial API",
+      "Kummer irreducibility criterion",
+      "monic polynomials"
+    ]
+  },
+  {
+    "id": "ann-sqrt2oq010201-integral",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 99,
+      "endLine": 104
+    },
+    "type": "concept",
+    "title": "Part III(a): Integrality of the Radical over ℚ",
+    "content": "`rpow_isIntegral` proves `a^(1/p)` is integral over `ℚ` for any nonnegative rational `a` and `p ≠ 0`, witnessed directly by the monic `X^p − C a`: the `IsIntegral` structure `⟨X^p − C a, monic_X_pow_sub_C a hp, aeval_rpow a ha p hp⟩` packages the monic polynomial together with its monicity proof and the annihilation from Part I.\n\nCrucially this lemma does **not** require the not-a-`p`-th-power hypothesis or primality — any nonnegative rational radicand gives an integral element. Stating it separately lets the field-extension corollary (Part III(b)) reuse it without dragging in the irreducibility hypotheses.",
+    "mathContext": "An element $\\alpha$ is integral over $K$ if it is a root of a monic polynomial in $K[X]$. Here $\\alpha = a^{1/p}$ and the witness is the monic $X^p - a$; integrality holds for every nonnegative rational $a$, independent of whether $a$ is a $p$-th power. This is the hypothesis `IntermediateField.adjoin.finrank` needs.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsIntegral",
+      "monic_X_pow_sub_C",
+      "integral elements",
+      "minimal polynomial witness"
+    ],
+    "prerequisites": [
+      "integral elements over a field",
+      "monic polynomials",
+      "Part I annihilation lemma"
+    ]
+  },
+  {
+    "id": "ann-sqrt2oq010201-degree",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 119
+    },
+    "type": "concept",
+    "title": "Part III(b): Algebraic Degree and Field-Extension Degree are p",
+    "content": "Two corollaries read off the degree. `minpoly_rpow_natDegree`: `natDegree (minpoly ℚ (a^(1/p))) = p`, by rewriting with the main theorem and `Polynomial.natDegree_X_pow_sub_C`. `adjoin_rpow_finrank`: `[ℚ(a^(1/p)) : ℚ] = p`, obtained from `IntermediateField.adjoin.finrank` applied to the integral element of Part III(a), whose value is the minimal-polynomial degree just computed.\n\nThese exhibit `a^(1/p)` as a primitive element of a degree-`p` extension of `ℚ` for every odd prime `p` and non-`p`-th-power rational `a` — the radical-extension building block.",
+    "mathContext": "For $\\alpha$ integral over $K$, $[K(\\alpha):K] = \\deg \\operatorname{minpoly}_K(\\alpha)$ (`IntermediateField.adjoin.finrank`). Here the degree is $p$, so $[\\mathbb{Q}(a^{1/p}):\\mathbb{Q}] = p$. The extension is not normal for $p > 2$ (the other $p$-th roots of $a$ are non-real), so $\\mathbb{Q}(a^{1/p})/\\mathbb{Q}$ is a degree-$p$ but non-Galois radical extension.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IntermediateField.adjoin.finrank",
+      "Polynomial.natDegree_X_pow_sub_C",
+      "Module.finrank",
+      "radical extension"
+    ],
+    "prerequisites": [
+      "field extension degree",
+      "minimal polynomial degree = extension degree",
+      "Part II main theorem"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+  "title": "Minimal Polynomial of an Odd-Prime-Degree Radical of a Rational",
+  "slug": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+  "description": "A Lean 4 proof that minpoly ℚ (a^(1/p)) = X^p − a for every odd prime p and nonnegative rational a that is not a p-th power in ℚ, with the degree (= p) and field-extension ([ℚ(a^(1/p)) : ℚ] = p) corollaries. Generalizes the parent square-root result (sqrt2-minpoly-oq-01-oq-02) from degree 2 to every odd prime degree via the Kummer irreducibility criterion; together the two files cover all prime degrees.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "algebraic-number-theory",
+      "minimal-polynomial",
+      "field-extensions",
+      "kummer-theory",
+      "irreducibility",
+      "radicals"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 121,
+    "dateAdded": "2026-06-16",
+    "assumptions": "None (0 axioms, 0 sorries). Machine-verified: Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean is registered in Proofs.lean (line 2909) and the file header records a green Docker build (7743 jobs). The whole import closure is Mathlib only — no project axioms, native_decide, or sorries anywhere in the dependency chain.",
+    "mathlibDependencies": [
+      {
+        "theorem": "X_pow_sub_C_irreducible_iff_of_prime_pow",
+        "description": "The Kummer criterion: over a field K, X^(p^n) − C a is irreducible iff a is not a p-th power in K. Specialized at n = 1 to give irreducibility of X^p − C a from the not-a-p-th-power hypothesis.",
+        "module": "Mathlib.FieldTheory.KummerPolynomial"
+      },
+      {
+        "theorem": "minpoly.eq_of_irreducible_of_monic",
+        "description": "A monic irreducible polynomial that annihilates an element equals (up to symm) its minimal polynomial. Turns monic + irreducible + has-the-root into the minimal-polynomial identity.",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "monic_X_pow_sub_C",
+        "description": "X^p − C a is monic for p ≠ 0, supplying both the monicity needed for minpoly.eq_of_irreducible_of_monic and the integrality witness.",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Real.rpow_natCast / Real.rpow_mul",
+        "description": "Real power laws giving (a^(1/p))^p = a^((1/p)·p) = a for a ≥ 0, the root-witness computation rpow_inv_pow.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "eq_ratCast",
+        "description": "Any ring hom out of ℚ is the rational cast, identifying algebraMap ℚ ℝ a with (a : ℝ) when evaluating X^p − C a at the real radical.",
+        "module": "Mathlib.Data.Rat.Cast.Defs"
+      },
+      {
+        "theorem": "IntermediateField.adjoin.finrank",
+        "description": "For an element integral over K, [K(α) : K] equals the degree of its minimal polynomial; applied to α = a^(1/p) with degree p.",
+        "module": "Mathlib.FieldTheory.Adjoin"
+      },
+      {
+        "theorem": "Polynomial.natDegree_X_pow_sub_C",
+        "description": "natDegree (X^p − C a) = p, giving the degree and field-extension values.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "Main theorem: minpoly ℚ (a^(1/p)) = X^p − a for every odd prime p and nonnegative rational a that is not a p-th power in ℚ",
+      "Root-witness lemma rpow_inv_pow: (a^(1/p))^p = a for a ≥ 0, via the real rpow power laws",
+      "Annihilation lemma aeval_rpow: X^p − C a evaluates to 0 at the real radical a^(1/p), using eq_ratCast to identify algebraMap ℚ ℝ a with (a : ℝ)",
+      "Integrality: a^(1/p) is integral over ℚ (root of the monic X^p − C a), stated without the not-a-p-th-power hypothesis so it can feed the finrank corollary",
+      "Algebraic degree: natDegree (minpoly ℚ (a^(1/p))) = p",
+      "Field extension degree: [ℚ(a^(1/p)) : ℚ] = p",
+      "Sharp scope observation: the clean X^p − a answer requires PRIME degree — for composite k it can fail (X⁴ − 4 = (X²−2)(X²+2), so minpoly ℚ (4^(1/4)) = X² − 2), and odd primality is exactly the hypothesis the Kummer criterion needs (it excludes p = 2, which the parent file handles by the elementary irrationality route)"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The minimal polynomial of an algebraic number and the field-extension degree it determines are foundational in algebraic number theory; minpoly_ℚ(√2) = X² − 2 is the prototype. The gallery thread sqrt2-minpoly proves minpoly_ℚ(√n) = X² − n for non-square natural n; sqrt2-minpoly-oq-01-oq-02 generalizes the radicand to an arbitrary nonnegative rational while keeping degree 2. The natural next axis, listed explicitly as an open question on those entries, is to raise the degree: is minpoly_ℚ(a^(1/k)) = X^k − a? This entry resolves the prime-degree case, where Kummer theory supplies the sharp irreducibility criterion.",
+    "problemStatement": "For an odd prime p and a nonnegative rational a, when is minpoly ℚ (a^(1/p)) = X^p − a? Answer: exactly when a is not a p-th power in ℚ. The composite-degree analogue is false without an extra hypothesis (e.g. X⁴ − 4 factors), so prime degree is the natural setting; together with the parent's p = 2 square-root theorem this covers every prime degree.",
+    "proofStrategy": "The minimal polynomial is monic by definition, so the canonical answer is the monic X^p − C a, established by the standard 'monic + irreducible + has the root ⟹ it is the minimal polynomial' argument (minpoly.eq_of_irreducible_of_monic). 1. Root: (a^(1/p))^p = a by the real rpow power laws (valid since a ≥ 0), so X^p − C a annihilates a^(1/p) after identifying algebraMap ℚ ℝ a with (a : ℝ) via eq_ratCast. 2. Monic: monic_X_pow_sub_C, using p ≠ 0. 3. Irreducible: the Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow at exponent n = 1, whose hypothesis is precisely 'a is not a p-th power in ℚ' (∀ b : ℚ, b^p ≠ a). Degree p and the extension degree [ℚ(a^(1/p)) : ℚ] = p then follow from natDegree_X_pow_sub_C and IntermediateField.adjoin.finrank applied to the integral element.",
+    "keyInsights": [
+      "Primality is essential, not cosmetic: for composite k the polynomial X^k − a can factor (X⁴ − 4 = (X²−2)(X²+2)), so a^(1/k) can have a strictly smaller minimal polynomial. The Kummer criterion is sharp precisely at prime exponents.",
+      "Odd primality (p ≠ 2) is exactly what the Mathlib bearer X_pow_sub_C_irreducible_iff_of_prime_pow demands; the excluded prime p = 2 is the parent file's square-root theorem, proved there by an elementary irrationality argument instead of the Kummer machinery. The two files partition the primes.",
+      "The hypothesis ∀ b : ℚ, b^p ≠ a is the odd-prime analogue of the parent's ¬ IsSquare a — both say 'a is not a p-th power in ℚ' for the relevant p.",
+      "eq_ratCast is the load-bearing coercion: evaluating a ℚ-polynomial at a real number routes through algebraMap ℚ ℝ a, which must be identified with the literal cast (a : ℝ) before the rpow root computation applies.",
+      "Integrality is stated separately (rpow_isIntegral, without the not-a-p-th-power hypothesis) so the field-extension finrank corollary can reuse it directly; the monic X^p − C a is the integrality witness regardless of irreducibility."
+    ]
+  },
+  "sections": [
+    {
+      "id": "root",
+      "title": "Part I: The Radical is a Root of X^p − C a",
+      "startLine": 61,
+      "endLine": 77,
+      "summary": "rpow_inv_pow: (a^(1/p))^p = a for a ≥ 0, from the real rpow power laws. aeval_rpow: X^p − C a annihilates the real radical a^(1/p), identifying algebraMap ℚ ℝ a with (a : ℝ) via eq_ratCast.",
+      "mathContext": "The root computation uses Real.rpow_mul and Real.rpow_natCast on the nonnegative radicand, then inv_mul_cancel₀ on the exponent (1/p)·p = 1."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part II: The Minimal Polynomial via the Kummer Criterion",
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "minpoly_rpow_of_odd_prime: minpoly ℚ (a^(1/p)) = X^p − a for odd prime p and a ≥ 0 not a p-th power. Monic (monic_X_pow_sub_C) + irreducible (Kummer criterion at exponent 1) + has the root (Part I) ⟹ it is the minimal polynomial.",
+      "mathContext": "X_pow_sub_C_irreducible_iff_of_prime_pow with n = 1 reduces to pow_one; the .mpr direction consumes the hypothesis ∀ b : ℚ, b^p ≠ a, and minpoly.eq_of_irreducible_of_monic closes the goal up to symm."
+    },
+    {
+      "id": "degree-results",
+      "title": "Part III: Degree and Field-Extension Consequences",
+      "startLine": 99,
+      "endLine": 119,
+      "summary": "rpow_isIntegral: a^(1/p) is integral over ℚ (root of monic X^p − C a). minpoly_rpow_natDegree: natDegree (minpoly ℚ (a^(1/p))) = p. adjoin_rpow_finrank: [ℚ(a^(1/p)) : ℚ] = p.",
+      "mathContext": "IntermediateField.adjoin.finrank applied to the integral radical gives the extension degree as the minimal-polynomial degree, computed by natDegree_X_pow_sub_C."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 121-line Lean 4 formalization raising minpoly ℚ (√r) = X² − r from degree 2 to every odd prime degree: for an odd prime p and a nonnegative rational a that is not a p-th power in ℚ, minpoly ℚ (a^(1/p)) = X^p − a, with corollaries natDegree = p and [ℚ(a^(1/p)) : ℚ] = p. The irreducibility step is Mathlib's sharp Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow at exponent 1. 0 axioms, 0 sorries; the entire import closure is Mathlib only.",
+    "implications": "**Prime-degree radical extensions**: [ℚ(a^(1/p)) : ℚ] = p exhibits a^(1/p) as a primitive element of a degree-p extension for every non-p-th-power rational a, the building block of Kummer and radical extensions. **Sharpness of primality**: the entry documents and depends on the fact that the clean X^p − a answer is a prime-degree phenomenon — composite k requires extra hypotheses because X^k − a can factor. Together with the parent square-root theorem (p = 2, elementary route), every prime radical degree of a rational is now covered.",
+    "openQuestions": [
+      "Handle the remaining composite radical degrees with the correct hypothesis: minpoly ℚ (a^(1/k)) for general k requires a to avoid being a p-th power for every prime p ∣ k (and a ≥ 0, plus the 4 ∣ k sign subtlety), the full Kummer-theory statement.",
+      "Identify the Galois closure and group of ℚ(a^(1/p))/ℚ: it is not normal (the other p-th roots are complex), and adjoining a primitive p-th root of unity gives a degree-p(p−1) Kummer extension with metacyclic Galois group."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-minpoly-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves minpoly ℚ (√r) = X² − r for nonnegative rational r (the p = 2 case, via elementary irrationality); this entry covers every odd prime degree via the Kummer criterion, completing all prime degrees."
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-02",
+      "relationship": "sibling",
+      "description": "OQ-02 handles k-th roots of natural numbers; this entry handles odd-prime roots of rationals. A common generalization (general composite degree over ℚ) is listed as an open question."
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 proves minpoly ℚ (√n) = X² − n for non-square natural n, the degree-2 natural-radicand prototype this thread generalizes along both the radicand and the degree axes."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02OQ01.minpoly_rpow_of_odd_prime",
+      "statement": "minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / p)) = X ^ p - C a, for an odd prime p (p.Prime, p ≠ 2) and a : ℚ with 0 ≤ a and ∀ b : ℚ, b ^ p ≠ a",
+      "description": "Main result: the minimal polynomial of an odd-prime-degree radical of a nonnegative rational that is not a p-th power."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02OQ01.minpoly_rpow_natDegree",
+      "statement": "(minpoly ℚ ((a : ℝ) ^ ((1 : ℝ) / p))).natDegree = p, under the same hypotheses",
+      "description": "The algebraic degree of a^(1/p) over ℚ is p."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02OQ01.adjoin_rpow_finrank",
+      "statement": "Module.finrank ℚ ℚ⟮(a : ℝ) ^ ((1 : ℝ) / p)⟯ = p, under the same hypotheses",
+      "description": "The field extension ℚ(a^(1/p))/ℚ has degree p."
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01OQ02OQ01.aeval_rpow",
+      "statement": "(aeval ((a : ℝ) ^ ((1 : ℝ) / p))) (X ^ p - C a : ℚ[X]) = 0, for a : ℚ with 0 ≤ a and p ≠ 0",
+      "description": "X^p − C a annihilates the real radical, the root-witness feeding the minimal-polynomial argument."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField"
+    ],
+    "namespace": "Sqrt2MinpolyOQ01OQ02OQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the missing gallery directory for the **already-verified, already-registered** proof `Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean` (0 sorry, 0 axiom, Docker-green per file header, registered in `Proofs.lean:2909`). The proof establishes, for an **odd prime `p`** and a nonnegative rational `a` that is **not a `p`-th power** in `ℚ`:

```
minpoly ℚ (a^(1/p)) = X^p − a
```

via Mathlib's sharp **Kummer criterion** `X_pow_sub_C_irreducible_iff_of_prime_pow` (at exponent 1), together with the corollaries `natDegree = p` and `[ℚ(a^(1/p)) : ℚ] = p`. This raises the parent entry's degree-2 square-root result (`sqrt2-minpoly-oq-01-oq-02`) to every odd prime degree; together with the parent's `p = 2` case, all prime radical degrees of a rational are now covered.

This is the **complete-but-ungalleried** vein: no Lean source is touched, the proof was already merged and built green, so there is no build/false-green risk — the gallery renders purely from the added JSON.

### Files added
- `src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/meta.json` — status `verified`, badge `original`, `axiomCount: 0`, full overview/strategy/insights, mathlib dependency table, cross-refs to the parent and siblings (`sqrt2-minpoly-oq-01-oq-02`, `sqrt2-minpoly-oq-02`, `sqrt2-minpoly-oq-01`).
- `src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/annotations.json` — 4 annotations (root witness, Kummer main theorem, integrality, degree/finrank).

### Validation
- `node` `JSON.parse`: both files OK
- `resolver.ts validate`: **4 valid / 0 misaligned**
- Entire import closure is Mathlib only — no project axioms, `native_decide`, or sorries anywhere in the dependency chain (so `verified`/`original`/`axiomCount 0` is honest under the axiom-integrity policy).

## Test plan
- [ ] Deployer merges directly (math PR, no `loom:review-requested`); gallery build regenerates listings from the new `meta.json` + `annotations.json`.