### PR TITLE
research(brouwer-fixed-point-oq-01-oq-03-oq-01): re-anchor 2 drifted annotations

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01/annotations.json
@@ -28,8 +28,8 @@
     "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
     "type": "concept",
     "range": {
-      "startLine": 66,
-      "endLine": 99
+      "startLine": 75,
+      "endLine": 90
     },
     "title": "The Topological Core: ham_sandwich_reduction",
     "content": "**ham_sandwich_reduction** is the entire topological content of Ham Sandwich. Given a continuous odd $F : S^n \\to \\mathbb{R}^n$ (a `SphereFun`) and a bridge predicate where $F(x) = 0 \\Rightarrow \\mathrm{Bisected}(x)$, it produces a point of $S^n$ satisfying $\\mathrm{Bisected}$. The proof is a one-liner: `borsuk_ulam_antipodal_collapse` forces the odd map to vanish, and the bridge converts the vanishing into a bisection.",
@@ -139,8 +139,8 @@
     "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01",
     "type": "context",
     "range": {
-      "startLine": 339,
-      "endLine": 369
+      "startLine": 503,
+      "endLine": 541
     },
     "title": "The Exact Dichotomy: What Was Proved vs. the Lone Input",
     "content": "The closing note makes the file's contribution precise. The parent's `ham_sandwich_theorem` axiom was justified solely by the difficulty of the continuity step, and this file confirms that diagnosis is exact: every other ingredient — the topological reduction, the oddness of the discrepancy, the 'zero ⇒ bisected' bridge, the antipodal swap, and volume finiteness — is dispatched here by elementary means, and two of the three originally-listed side conditions become theorems for the linear parameterization. What remains is a single, self-contained measure-theory fact, and `ham_sandwich_standard_of_scalar_continuity` states the conclusion with exactly that fact (plus finiteness) as its only hypotheses.",


### PR DESCRIPTION
## Summary

Two annotations in `brouwer-fixed-point-oq-01-oq-03-oq-01` (the Ham Sandwich de-axiomatization entry) had drifted off their intended Lean constructs. The source file grew over time — PART 7 (volume partition) and PART 8 (boundary-null / Gap 2) were inserted — shifting later content downward.

- **`hs-reduction`** `66-99 → 75-90`: startLine 66 fell in the blank gap between the `namespace`/`set_option` block and the doc comment of `theorem ham_sandwich_reduction`, so the resolver found no construct. Re-anchored onto the theorem's doc comment + body.
- **`hs-remaining-gap`** `339-369 → 503-541`: the closing "Significance and the Remaining Gap" block comment (which this annotation describes verbatim) moved to lines 503-541; the stale range pointed at PART 7 separator comments. Re-anchored onto the closing note.

## Verification

`validateLineAnnotations` (annotations resolver):
- Before: 5 valid / 2 misaligned ("No Lean construct found")
- After: **7 valid / 0 misaligned**

JSON-only change (4 line-number edits). No Lean source modified, no build required.