### PR TITLE
research(circumference-via-differentiation-oq-01-oq-02): add gallery entry for L^p ball surface-derivative

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01-oq-02/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "cvd0102-ann-01",
+    "proofId": "circumference-via-differentiation-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "The L^p surface-derivative question and its answer",
+    "content": "The header states the parent entry's open question — the unit ball in $L^p$ has Dirichlet volume $V_n(p) = 2^n\\,\\Gamma(1/p+1)^n / \\Gamma(n/p+1)$; does the identity $dV/dr = \\text{surface area}$ survive for $p \\ne 2$? — and answers it completely. The volume and its $r^n$ scaling are tractable in Mathlib v4.26 via `MeasureTheory.volume_sum_rpow_le`, giving $dV/dr = n\\,V_n(p)\\,r^{n-1}$ by the power rule. But the surface side depends on *which* surface measure is meant: by the coarea formula $dV/dr = \\int_{\\|x\\|_p = r} |\\nabla\\rho|^{-1}\\, d\\mathcal{H}^{n-1}$ with $\\rho(x) = \\|x\\|_p$, and on the sphere $|\\nabla\\rho|^2 = \\sum |x_i|^{2p-2}$, which is identically $1$ only when $p = 2$. So $dV/dr$ equals the Euclidean Hausdorff surface measure for $p = 2$ (the parent theorem) and a $|\\nabla\\rho|^{-1}$-weighted integral for every finite $p \\ne 2$. The concrete witness is the $L^1$ diamond ($n=2$): $V_2(1) = 2$, $dV/dr|_{r=1} = 4$, but the Euclidean perimeter is $4\\sqrt{2}$; the coarea weight reconciles them as $(4\\sqrt{2})/\\sqrt{2} = 4$.",
+    "mathContext": "$V_n(p) = 2^n\\Gamma(1/p+1)^n/\\Gamma(n/p+1)$; $|\\nabla\\rho|^2 = \\sum|x_i|^{2p-2} \\equiv 1$ on the sphere iff $p=2$; $L^1$, $n=2$: $dV/dr = 4$ vs Euclidean perimeter $4\\sqrt2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "coarea formula",
+      "L^p unit ball volume (Dirichlet)",
+      "Hausdorff surface measure",
+      "Archimedes onion-peel identity"
+    ],
+    "prerequisites": [
+      "L^p norms and unit balls",
+      "Hausdorff measure and the coarea formula",
+      "the parent Euclidean identity dV/dr = surface area"
+    ]
+  },
+  {
+    "id": "cvd0102-ann-02",
+    "proofId": "circumference-via-differentiation-oq-01-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 113
+    },
+    "type": "definition",
+    "title": "L^p ball volume and surface definitions",
+    "content": "Four definitions, written to match the constant in `MeasureTheory.volume_sum_rpow_le` *verbatim* so a future volume bridge is a pure rewrite. `lpUnitBallVolume n p = (2\\cdot\\Gamma(1/p+1))^n / \\Gamma(n/p+1)$ is the Dirichlet closed form $V_n(p)$. `lpBallVolumeFn n p r = V_n(p)\\cdot r^n` is the volume as a function of radius — exactly the $r^n$ scaling factor of the Mathlib lemma. `lpSurfaceConst n p = n\\cdot V_n(p)$ is the constant appearing in the derivative, and `lpSurfaceFn n p r = n\\cdot V_n(p)\\cdot r^{n-1}$ is the surface-derivative function. Matching Mathlib's constant exactly is deliberate: it lets a Docker-enabled session discharge `volume = lpBallVolumeFn` by `rw` on `volume_sum_rpow_le` plus `ENNReal.toReal` bookkeeping, with no restatement risk.",
+    "mathContext": "$V_n(p) = (2\\Gamma(1/p+1))^n/\\Gamma(n/p+1)$; $V(r) = V_n(p) r^n$; surface constant $n V_n(p)$; surface function $n V_n(p) r^{n-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MeasureTheory.volume_sum_rpow_le",
+      "Real.Gamma",
+      "Dirichlet volume integral"
+    ],
+    "prerequisites": [
+      "Real.Gamma and rpow",
+      "Lean def syntax"
+    ]
+  },
+  {
+    "id": "cvd0102-ann-03",
+    "proofId": "circumference-via-differentiation-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 130
+    },
+    "type": "theorem",
+    "title": "Main derivative identity (★)",
+    "content": "`lpBallVolumeFn_hasDerivAt`: the $L^p$ ball-volume function $V(r) = V_n(p)\\cdot r^n$ has derivative $n\\cdot V_n(p)\\cdot r^{n-1}$ at every radius $r$. This is the same power-rule computation as the verified parent's Euclidean `nBallVolumeFn_hasDerivAt`; only the leading constant differs. The proof is two lines: `(hasDerivAt_pow n r).const_mul (lpUnitBallVolume n p)` gives the derivative of $V_n(p)\\cdot r^n$ as $V_n(p)\\cdot(n\\cdot r^{n-1})$, and a `ring` rewrite reassociates the constant to $n\\cdot V_n(p)\\cdot r^{n-1} = $ `lpSurfaceFn n p r`. All of the $L^p$-specific geometry lives in the constant $V_n(p)$; the differentiation step never sees it.",
+    "mathContext": "HasDerivAt (lpBallVolumeFn n p) (lpSurfaceFn n p r) r, via hasDerivAt_pow + HasDerivAt.const_mul + ring.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hasDerivAt_pow",
+      "HasDerivAt.const_mul",
+      "power rule"
+    ],
+    "prerequisites": [
+      "HasDerivAt",
+      "the power rule",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "cvd0102-ann-04",
+    "proofId": "circumference-via-differentiation-oq-01-oq-02",
+    "range": {
+      "startLine": 132,
+      "endLine": 140
+    },
+    "type": "theorem",
+    "title": "Differentiability and the deriv value",
+    "content": "Two immediate corollaries of the main theorem. `lpBallVolumeFn_differentiable` states the volume function is differentiable everywhere, obtained from `lpBallVolumeFn_hasDerivAt`'s `.differentiableAt` at each point. `deriv_lpBallVolume` evaluates Mathlib's `deriv` operator: `deriv (lpBallVolumeFn n p) r = lpSurfaceFn n p r`, via `(lpBallVolumeFn_hasDerivAt n p r).deriv`. Together they package the $(\\star)$ identity in the two forms downstream code is most likely to need: as a `Differentiable` fact and as a definitional `deriv` equation.",
+    "mathContext": "Differentiable ℝ (lpBallVolumeFn n p); deriv (lpBallVolumeFn n p) r = lpSurfaceFn n p r.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasDerivAt.differentiableAt",
+      "HasDerivAt.deriv"
+    ],
+    "prerequisites": [
+      "Differentiable",
+      "the deriv operator"
+    ]
+  },
+  {
+    "id": "cvd0102-ann-05",
+    "proofId": "circumference-via-differentiation-oq-01-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "Value at the unit radius",
+    "content": "`lpSurfaceFn_one`: at $r = 1$ the surface-derivative function equals the surface constant, $n\\cdot V_n(p)$. The proof is `one_pow` (so $1^{n-1} = 1$) followed by `mul_one`. This is the value that, for $p = 2$, equals the genuine Euclidean surface area of the unit sphere, and for $p \\ne 2$ equals the $|\\nabla\\rho|^{-1}$-weighted surface integral discussed in the header — the single number at which the whole $p=2$-versus-$p\\ne2$ distinction is sharpest.",
+    "mathContext": "lpSurfaceFn n p 1 = lpSurfaceConst n p = n·V_n(p).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "one_pow",
+      "mul_one",
+      "surface constant"
+    ],
+    "prerequisites": [
+      "Lean simp lemmas one_pow, mul_one"
+    ]
+  }
+]

--- a/src/data/proofs/circumference-via-differentiation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01-oq-02/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "circumference-via-differentiation-oq-01-oq-02",
+  "title": "L^p Unit Ball Volume and the Surface-Derivative Identity",
+  "slug": "circumference-via-differentiation-oq-01-oq-02",
+  "description": "Extends the parent 'surface area via differentiation of volume' to the L^p unit ball, whose Dirichlet volume is V_n(p) = (2·Γ(1/p+1))^n / Γ(n/p+1). The radial scaling V(r) = V_n(p)·r^n gives the power-rule derivative dV/dr = n·V_n(p)·r^(n-1) (proven in Lean, mirroring the verified parent). The mathematical answer: this derivative equals the Euclidean (n-1)-surface area ONLY for p=2 — for every finite p≠2 it is a |∇‖·‖_p|^{-1}-weighted coarea integral, not the Hausdorff surface measure (L^1 diamond witness: dV/dr|_{r=1} = 4, Euclidean perimeter = 4√2). 4 theorems, 4 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean",
+    "tags": [
+      "geometry",
+      "calculus",
+      "lp-spaces",
+      "surface-area",
+      "gamma-function",
+      "differentiation",
+      "coarea-formula",
+      "verified"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "assumptions": "None. The Lean theorems are proved from Mathlib's power rule (hasDerivAt_pow) and HasDerivAt.const_mul. The closed-form volume is defined to match Mathlib's MeasureTheory.volume_sum_rpow_le verbatim. NOTE ON SCOPE: the Lean content proves the derivative of the closed-form L^p volume function; the surface-side analysis (that dV/dr is a weighted coarea integral, not the Euclidean Hausdorff surface, for p≠2) is documented and independently checked in Python (research/problems/.../verify_lp_ball.py, all pass) but is NOT formalized — Mathlib v4.26 has no coarea formula to state it faithfully.",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasDerivAt_pow",
+        "description": "Power rule: d/dr(r^n) = n·r^(n-1)",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Pow"
+      },
+      {
+        "theorem": "HasDerivAt.const_mul",
+        "description": "Scaling a derivative by a constant: if HasDerivAt f f' x then HasDerivAt (c·f) (c·f') x",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Mul"
+      },
+      {
+        "theorem": "MeasureTheory.volume_sum_rpow_le",
+        "description": "Closed form for the L^p ball volume: volume {x | (∑|x i|^p)^(1/p) ≤ r} = ofReal r^n · ofReal ((2·Γ(1/p+1))^n / Γ(n/p+1)); the definitions in this file are written to match this constant verbatim for a future volume bridge",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"
+      }
+    ],
+    "originalContributions": [
+      "L^p ball-volume derivative theorem: d/dr((2·Γ(1/p+1))^n/Γ(n/p+1) · r^n) = n·V_n(p)·r^(n-1) for all n, p, r",
+      "Identification of the precise scope of the parent identity: dV/dr equals the Euclidean Hausdorff (n-1)-surface measure iff p=2",
+      "Coarea analysis showing |∇‖x‖_p|^2 = ∑|x_i|^{2p-2} ≡ 1 on the sphere only when p=2, so dV/dr is a |∇ρ|^{-1}-weighted surface integral for p≠2",
+      "Concrete L^1 'diamond' witness (n=2): dV/dr|_{r=1} = 4 while the Euclidean perimeter is 4√2, with the coarea weight (4√2)/√2 = 4 reconciling the two"
+    ],
+    "dateAdded": "2026-06-16",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The identity 'the derivative of a ball's volume is its surface area' is the Archimedean onion-peel argument (c. 250 BCE, *On the Sphere and Cylinder*), made into a calculus theorem by Maclaurin (*Treatise of Fluxions*, 1742) and generalized to all dimensions via the Gamma function (Euler 1729, Legendre 1811) and the n-ball volume formula (Liouville 1836). The parent gallery entry `circumference-via-differentiation-oq-01` formalizes the Euclidean (L^2) case for every n. The L^p balls — whose volume V_n(p) = 2^n·Γ(1/p+1)^n/Γ(n/p+1) goes back to Dirichlet's integral and is sharpened in the convex-geometry literature (Pisier, *The Volume of Convex Bodies and Banach Space Geometry*, 1989) — are the natural next family to test the identity against. The coarea formula needed to phrase the L^p surface side correctly is due to Federer (*Geometric Measure Theory*, 1969); it is precisely the tool absent from Mathlib v4.26 that keeps the surface half of this entry at the documentation level.",
+    "problemStatement": "The parent entry's open question #2 asks: the unit ball in L^p has volume V_n(p) = 2^n·Γ(1/p+1)^n/Γ(n/p+1); does the volume-derivative-equals-surface identity dV/dr = surface area still hold for the L^p surface area when p ≠ 2? Formalize the part of the answer that Mathlib v4.26 admits, and resolve the geometric question precisely.",
+    "proofStrategy": "Two layers. (1) FORMALIZED: define lpUnitBallVolume, lpBallVolumeFn(r) = V_n(p)·r^n, lpSurfaceConst = n·V_n(p), and lpSurfaceFn(r) = n·V_n(p)·r^(n-1) to match MeasureTheory.volume_sum_rpow_le verbatim, then prove HasDerivAt (lpBallVolumeFn) (lpSurfaceFn r) r by `(hasDerivAt_pow n r).const_mul (lpUnitBallVolume n p)` plus a `ring` rearrangement of the constant. Differentiability and the `deriv` value follow immediately, and lpSurfaceFn_one specializes r=1 to the surface constant. (2) DOCUMENTED (not formalized): by the coarea formula dV/dr = ∫_{‖x‖_p=r} 1/|∇ρ| dH^{n-1} with ρ(x)=‖x‖_p, |∇ρ|^2 = ∑|x_i|^{2p-2} on the sphere, which is identically 1 iff p=2. Hence dV/dr is the Euclidean Hausdorff surface measure only for p=2; for p≠2 it is a |∇ρ|^{-1}-weighted integral. The L^1 diamond (n=2) is the concrete witness.",
+    "keyInsights": [
+      "**The derivative is still a one-line power rule**: Just as in the parent, the entire formalized content reduces to `hasDerivAt_pow n r` scaled by the constant V_n(p). The L^p-specific geometry lives entirely in that leading constant; differentiation never sees it.",
+      "**Definitions are written to match Mathlib's volume lemma verbatim**: lpUnitBallVolume n p = (2·Γ(1/p+1))^n / Γ(n/p+1) and lpBallVolumeFn n p r = V_n(p)·r^n are the exact constant and r^n scaling of `MeasureTheory.volume_sum_rpow_le`. This is deliberate: a future Docker-enabled session can discharge a `volume = lpBallVolumeFn` bridge by rewriting with that lemma plus ENNReal.toReal bookkeeping, with zero restatement risk.",
+      "**The naive identity is FALSE for every finite p ≠ 2**: This is the real mathematical content. On the L^p sphere ∑|x_i|^p = 1 the Euclidean gradient of the norm has |∇ρ|^2 = ∑|x_i|^{2p-2}, equal to 1 identically only when 2p-2 = p, i.e. p = 2. So for p ≠ 2 the radial derivative dV/dr is a |∇ρ|^{-1}-weighted surface integral, not the Euclidean Hausdorff (n-1)-measure of the L^p sphere.",
+      "**The L^1 diamond makes the failure concrete and checkable**: For n=2, p=1, V_2(1) = 2 and dV/dr|_{r=1} = 4, while the Euclidean perimeter of the unit diamond is 4√2 ≈ 5.66. The coarea weight reconciles them: the constant |∇ρ| = √2 on each edge gives (4√2)/√2 = 4 = dV/dr. All three numbers are verified independently in Python.",
+      "**The surface side is genuinely Mathlib-blocked, and the entry says so**: Mathlib v4.26 has Hausdorff measure (Measure/Hausdorff.lean) but no coarea formula, so the weighted surface identity cannot be stated faithfully in Lean yet. Rather than encode a false Euclidean identity as a theorem, the file records the surface analysis only as documentation — an honest scope boundary, not a sorry."
+    ],
+    "prerequisites": [
+      "Real analysis: `HasDerivAt`, the power rule, `HasDerivAt.const_mul`",
+      "Mathlib's `Real.Gamma` and the L^p ball volume lemma `MeasureTheory.volume_sum_rpow_le`",
+      "The parent entry `circumference-via-differentiation-oq-01` (the Euclidean / L^2 case)",
+      "The coarea formula and Hausdorff surface measure (for the documented surface analysis)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-header",
+      "title": "Header: the L^p surface-derivative question and its answer",
+      "startLine": 1,
+      "endLine": 79,
+      "summary": "Docstring stating the parent's open question (does dV/dr = surface area survive for L^p, p≠2?) and the full answer: the volume + r^n scaling are tractable via MeasureTheory.volume_sum_rpow_le, but the surface identity holds only for p=2 — for p≠2, dV/dr is a |∇ρ|^{-1}-weighted coarea integral. Includes the L^1 diamond witness and notes the surface side is Mathlib-blocked (no coarea formula in v4.26).",
+      "mathContext": "V_n(p) = 2^n·Γ(1/p+1)^n/Γ(n/p+1); |∇ρ|^2 = ∑|x_i|^{2p-2} ≡ 1 on the sphere iff p=2; L^1 n=2: dV/dr=4 vs perimeter 4√2."
+    },
+    {
+      "id": "section-defs",
+      "title": "L^p ball volume and surface definitions",
+      "startLine": 88,
+      "endLine": 113,
+      "summary": "Four definitions matching MeasureTheory.volume_sum_rpow_le verbatim: lpUnitBallVolume n p = (2·Γ(1/p+1))^n/Γ(n/p+1), lpBallVolumeFn n p r = V_n(p)·r^n (the r^n scaling factor), lpSurfaceConst n p = n·V_n(p), and lpSurfaceFn n p r = n·V_n(p)·r^(n-1).",
+      "mathContext": "V_n(p) Dirichlet closed form; V(r) = V_n(p)·r^n; surface constant n·V_n(p); surface function n·V_n(p)·r^(n-1)."
+    },
+    {
+      "id": "section-deriv",
+      "title": "The derivative identity (★)",
+      "startLine": 115,
+      "endLine": 140,
+      "summary": "lpBallVolumeFn_hasDerivAt: V(r) = V_n(p)·r^n has derivative n·V_n(p)·r^(n-1) at every r, via (hasDerivAt_pow n r).const_mul plus a ring rearrangement. lpBallVolumeFn_differentiable and deriv_lpBallVolume follow immediately.",
+      "mathContext": "HasDerivAt (lpBallVolumeFn n p) (lpSurfaceFn n p r) r; deriv (lpBallVolumeFn n p) r = lpSurfaceFn n p r."
+    },
+    {
+      "id": "section-unit",
+      "title": "Value at the unit radius",
+      "startLine": 142,
+      "endLine": 148,
+      "summary": "lpSurfaceFn_one: at r=1 the derivative equals the surface constant n·V_n(p), via one_pow and mul_one.",
+      "mathContext": "lpSurfaceFn n p 1 = lpSurfaceConst n p = n·V_n(p)."
+    }
+  ],
+  "conclusion": {
+    "summary": "For the L^p unit ball with Dirichlet volume V_n(p) = 2^n·Γ(1/p+1)^n/Γ(n/p+1), the file formalizes the radial-scaling derivative dV/dr = n·V_n(p)·r^(n-1) — the same power-rule computation as the verified parent, differing only in the leading constant — and resolves the parent's open question on the surface side. The resolution: the identity dV/dr = (Euclidean surface area) holds exactly when p = 2 and fails for every finite p ≠ 2, where dV/dr is instead a |∇ρ|^{-1}-weighted coarea integral. The Lean content (4 theorems, 4 definitions, 0 sorries, 0 axioms) proves the derivative; the surface analysis is documented and Python-checked rather than formalized, because Mathlib v4.26 lacks a coarea formula.",
+    "implications": "This pins down the exact scope of the Archimedean 'volume-derivative-is-surface' identity: it is a special feature of the Euclidean (L^2) norm, whose unit sphere is a level set of the radius function with unit Euclidean gradient. For p ≠ 2 the level set of ‖·‖_p still has its volume given by V_n(p)·r^n, so the derivative still computes cleanly — but it measures a gradient-weighted surface, not the metric surface area. The result is a clean cautionary example for high-dimensional convex geometry, where L^p balls are ubiquitous (Pisier 1989) and the temptation to read dV/dr as 'the surface area' is strong. The definitions are deliberately Mathlib-aligned so the remaining volume bridge (volume = lpBallVolumeFn) and, once a coarea formula lands in Mathlib, the weighted-surface identity, can both be formalized with minimal restatement.",
+    "openQuestions": [
+      "**Volume bridge**: discharge `volume {x | (∑|x_i|^p)^(1/p) ≤ r}.toReal = lpBallVolumeFn n p r` by rewriting with MeasureTheory.volume_sum_rpow_le plus ENNReal.toReal bookkeeping. Blocked only on Docker (the lemma uses a bare `card ι` whose Fintype.card resolution should not be settled blind), not on mathematics.",
+      "**Weighted-surface formalization**: once Mathlib gains a coarea formula, state and prove dV/dr = ∫_{‖x‖_p=r} |∇ρ|^{-1} dH^{n-1}, recovering the Euclidean surface measure as the p=2 special case.",
+      "**p = ∞ degeneracy**: for the sup norm, |∇‖·‖_∞| = 1 on the open faces of the cube (a.e.), so the identity dV/dr = Euclidean surface holds a.e.. Make the 'almost everywhere' precise and formalize the cube case.",
+      "**Sharp constant as a function of p**: study n·V_n(p) = n·2^n·Γ(1/p+1)^n/Γ(n/p+1) as a function of p ∈ [1, ∞]; its monotonicity and extrema connect to the digamma function and to volume-ratio inequalities in Banach-space geometry."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "circumference-via-differentiation-oq-01",
+      "relationship": "parent",
+      "description": "The Euclidean (L^2) n-dimensional case; this entry answers its open question #2 on L^p generalization"
+    },
+    {
+      "targetId": "circumference-via-differentiation",
+      "relationship": "uses",
+      "description": "The original 2D identity C = dA/dr that the whole family generalizes"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean",
+    "filename": "CircumferenceViaDifferentiationOQ01OQ02.lean",
+    "lineCount": 148,
+    "theoremCount": 4,
+    "axiomCount": 0,
+    "definitionCount": 4,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean"
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/circumference-via-differentiation-oq-01-oq-02.json
+++ b/src/data/research/problems/circumference-via-differentiation-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "circumference-via-differentiation-oq-01-oq-02",
   "title": "Generalizing to $L^p$ unit balls: The unit ball in $L^p$ has volume $\\frac{2^n \\Gamma(1/p+1)^n}{\\Gam",
-  "phase": "ORIENT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -11,17 +11,23 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "FORMALIZED (CircumferenceViaDifferentiationOQ01OQ02.lean, 0 sorry / 0 axiom, registered + build-verified via deployer-gated PR #24486): the L^p ball-volume function V(r) = V_n(p)·r^n has derivative dV/dr = n·V_n(p)·r^(n-1), where V_n(p) = (2·Γ(1/p+1))^n/Γ(n/p+1) matches MeasureTheory.volume_sum_rpow_le verbatim. Power rule via hasDerivAt_pow + const_mul.",
+      "RESOLVED (documented + Python-checked, not formalized): the identity dV/dr = (Euclidean surface area) holds iff p = 2. On the L^p sphere |∇ρ|^2 = ∑|x_i|^{2p-2}, which is ≡1 only for p=2; for p≠2, dV/dr is a |∇ρ|^{-1}-weighted coarea integral. L^1 diamond witness (n=2): dV/dr=4 vs Euclidean perimeter 4√2; coarea weight (4√2)/√2 = 4."
+    ],
+    "open": [
+      "Volume bridge volume{‖x‖_p≤r}.toReal = lpBallVolumeFn (Docker-gated rewrite on volume_sum_rpow_le, not mathematically open).",
+      "Weighted-surface formalization awaits a coarea formula in Mathlib (absent in v4.26)."
+    ],
+    "goal": "Answer the parent's L^p open question and gallery the formalized derivative half. DONE: gallery entry added at src/data/proofs/circumference-via-differentiation-oq-01-oq-02."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-06-15T00:57:02-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "COMPLETED",
+    "since": "2026-06-16T00:00:00Z",
+    "iteration": 2,
+    "focus": "Gallery entry added (meta.json + 5 annotations, resolver 5/0) for the build-verified, registered derivative file. The headline question is answered: dV/dr equals the Euclidean surface area iff p=2. Lean scope = derivative of the closed-form volume; surface side documented (coarea), Mathlib-blocked.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optional future Docker session: discharge the volume bridge; formalize the weighted-surface identity once Mathlib gains a coarea formula.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## Summary

The file `proofs/Proofs/CircumferenceViaDifferentiationOQ01OQ02.lean` (0 sorry / 0 axiom) was **registered and build-verified** via deployer-gated PR #24486 but had **no gallery entry** (`src/data/proofs/circumference-via-differentiation-oq-01-oq-02/` was missing). This adds it — the classic complete-but-ungalleried completion, JSON-only, no Lean edits.

This answers **open question #2 of the parent** `circumference-via-differentiation-oq-01`: does the volume-derivative-equals-surface identity survive for the $L^p$ unit ball when $p \ne 2$?

## What is formalized vs documented (honest scope)

- **FORMALIZED (Lean, 0/0):** the $L^p$ ball-volume function $V(r) = V_n(p)\cdot r^n$, with $V_n(p) = (2\Gamma(1/p+1))^n/\Gamma(n/p+1)$ matching `MeasureTheory.volume_sum_rpow_le` verbatim, has derivative $dV/dr = n\cdot V_n(p)\cdot r^{n-1}$ (power rule). 4 theorems, 4 definitions.
- **RESOLVED but documented (not formalized):** the identity $dV/dr = $ (Euclidean surface area) holds **iff $p = 2$**. On the $L^p$ sphere $|\nabla\rho|^2 = \sum|x_i|^{2p-2}$, which is $\equiv 1$ only for $p=2$; for $p\ne2$, $dV/dr$ is a $|\nabla\rho|^{-1}$-weighted coarea integral. Concrete $L^1$ diamond witness ($n=2$): $dV/dr = 4$ vs Euclidean perimeter $4\sqrt2$. This half is Python-checked (all pass) but **not** a Lean theorem — Mathlib v4.26 has no coarea formula to state it faithfully. The meta/annotations say so explicitly to avoid over-claiming.

## Changes
- `src/data/proofs/circumference-via-differentiation-oq-01-oq-02/meta.json` (status `verified`, badge `original`, 4 thms / 4 defs / 0 sorry / 0 axiom)
- `src/data/proofs/circumference-via-differentiation-oq-01-oq-02/annotations.json` (5 annotations, resolver **5 valid / 0 misaligned**)
- `src/data/research/problems/circumference-via-differentiation-oq-01-oq-02.json` → `completed`

## Validation
- `node JSON.parse` on all three files: OK
- `npx tsx scripts/annotations/resolver.ts validate`: 5 valid / 0 misaligned
- Lean file unchanged; build status inherited from the deployer-gated registration (#24486)

🤖 Generated with [Claude Code](https://claude.com/claude-code)