### PR TITLE
Enrich Beta Integral for n-Dimensional Angular Averaging (buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/annotations.json
@@ -5,8 +5,8 @@
     "range": { "startLine": 3, "endLine": 28 },
     "type": "concept",
     "title": "The Beta Integral as the Analytic Core",
-    "content": "The module docstring frames the problem: the n-dimensional Cauchy–Crofton angular averaging identity reduces, via polar-coordinate decomposition of the sphere integral on S^{n-1}, to a single one-dimensional integral. Proving that integral axiom-free closes the last gap in the n ≥ 3 case (the n = 2 case lives in the parent file). The value 1/(n-1) is exactly the proportionality factor sphereArea(n-2)/((n:ℝ)-1) needed downstream.",
-    "mathContext": "$\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}$, a special case of the Beta function $B(a,b) = 2\\int_0^{\\pi/2} \\sin^{2a-1}\\theta \\cos^{2b-1}\\theta\\, d\\theta$.",
+    "content": "The module docstring frames the problem: the n-dimensional Cauchy–Crofton angular averaging identity reduces, via polar-coordinate decomposition of the sphere integral on S^{n-1}, to a single one-dimensional integral. Proving that integral axiom-free closes the last gap in the n ≥ 3 case (the n = 2 case lives in the parent file). The value 1/(n-1) is exactly the proportionality factor sphereArea(n-2)/((n:ℝ)-1) needed downstream. Structurally this is the Beta function evaluated at cos-exponent 1: with B(a,b) = 2∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ, here 2b-1 = 1 forces b = 1 and 2a-1 = n-2 gives a = (n-1)/2, so the integral is (1/2)B((n-1)/2, 1) = 1/(n-1) via B(a,1) = 1/a. The b = 1 degeneracy is exactly why an elementary antiderivative exists.",
+    "mathContext": "$\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\tfrac12 B\\!\\left(\\tfrac{n-1}{2}, 1\\right) = \\frac{1}{n-1}$, the $b=1$ slice of $B(a,b) = 2\\int_0^{\\pi/2} \\sin^{2a-1}\\theta \\cos^{2b-1}\\theta\\, d\\theta$ where $B(a,1) = \\Gamma(a)/\\Gamma(a+1) = 1/a$.",
     "significance": "supporting",
     "relatedConcepts": ["Cauchy–Crofton formula", "Beta function", "integral geometry", "Buffon's needle"],
     "prerequisites": ["integral geometry", "spherical coordinates"]

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
@@ -40,7 +40,8 @@
       "Closed-form antiderivative beats substitution machinery: rather than invoking a change-of-variables lemma, the proof exhibits F(θ) = sin^{m+1}(θ)/(m+1) directly and differentiates it, so the whole integral collapses to a two-point evaluation via FTC.",
       "The endpoint evaluation is trivial because sin(π/2) = 1 makes the upper term 1^{m+1}/(m+1) = 1/(m+1) and sin(0) = 0 with zero_pow (m+1 ≠ 0) kills the lower term — no special-casing of m is needed.",
       "Proving the general natural-exponent version ∫ cos θ · sinᵐ θ = 1/(m+1) first, then specializing m := n-2, isolates the only dimension-dependent step (the cast (n-2)+1 = n-1 for n ≥ 2) into a one-line Nat.cast_sub rewrite.",
-      "The identity supplies exactly the σ_{n-2}/(n-1) factor needed by the parent Cauchy–Crofton construction, closing the last analytic gap in the n ≥ 3 angular averaging argument."
+      "The identity supplies exactly the σ_{n-2}/(n-1) factor needed by the parent Cauchy–Crofton construction, closing the last analytic gap in the n ≥ 3 angular averaging argument.",
+      "The value 1/(m+1) is not a coincidence: this integral is the degenerate slice of the Beta function with cos-exponent 1, i.e. B(a,b) = 2∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ at b = 1 (so 2b-1 = 1) and a = (m+1)/2. Since B(a,1) = Γ(a)Γ(1)/Γ(a+1) = 1/a, the half-integral equals (1/2)·B((m+1)/2,1) = 1/(m+1). The b = 1 case is precisely the one where the Beta function degenerates to an elementary 1/a, which is why an elementary FTC antiderivative exists at all — the general Beta integral has no such closed form in elementary functions."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Enrichment pass for `buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01`

This entry was already at high quality (score 94). Added one mathematically substantive layer that explains *why* the integral evaluates to `1/(m+1)`.

### Changes
- **meta.json**: Added a 5th `keyInsight` identifying the integral as the degenerate `b=1` slice of the Beta function. With `B(a,b) = 2∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ`, the cos-exponent of 1 forces `b=1`, and `B(a,1)=Γ(a)/Γ(a+1)=1/a`. This is precisely the case where the Beta function degenerates to an elementary `1/a` — explaining why an elementary FTC antiderivative exists at all (the general Beta integral has no elementary closed form).
- **annotations.json**: Deepened the overview annotation (`ann-beta-overview`) with the same `(1/2)·B((n-1)/2,1)=1/(n-1)` derivation and refined its `mathContext` to display the half-Beta closed form.

### Verification
- Both JSON files parse cleanly (`node JSON.parse`).
- Build data-enrichment phase processed the entry without error (final `tsc` step skipped — no node_modules in worktree).
- No `.lean` files touched; axiom/status fields unchanged (verified/0 axioms, accurate to the source).