### PR TITLE
Enrich erdos-1050: re-anchor 35 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-1050/annotations.json
+++ b/src/data/proofs/erdos-1050/annotations.json
@@ -18,8 +18,8 @@
       "irrationality criterion"
     ],
     "range": {
-      "startLine": 26,
-      "endLine": 45
+      "startLine": 1,
+      "endLine": 25
     }
   },
   {
@@ -41,7 +41,7 @@
     ],
     "range": {
       "startLine": 33,
-      "endLine": 36
+      "endLine": 34
     }
   },
   {
@@ -61,7 +61,7 @@
     ],
     "range": {
       "startLine": 37,
-      "endLine": 39
+      "endLine": 38
     }
   },
   {
@@ -80,8 +80,8 @@
       "Mathlib tsum definition"
     ],
     "range": {
-      "startLine": 26,
-      "endLine": 45
+      "startLine": 40,
+      "endLine": 42
     }
   },
   {
@@ -102,8 +102,8 @@
       "absolute convergence criterion"
     ],
     "range": {
-      "startLine": 47,
-      "endLine": 69
+      "startLine": 57,
+      "endLine": 95
     }
   },
   {
@@ -123,8 +123,8 @@
       "3 is not a power of 2"
     ],
     "range": {
-      "startLine": 37,
-      "endLine": 39
+      "startLine": 98,
+      "endLine": 127
     }
   },
   {
@@ -143,8 +143,8 @@
       "basic properties of powers of 2"
     ],
     "range": {
-      "startLine": 47,
-      "endLine": 69
+      "startLine": 129,
+      "endLine": 134
     }
   },
   {
@@ -164,7 +164,7 @@
     ],
     "range": {
       "startLine": 136,
-      "endLine": 145
+      "endLine": 144
     }
   },
   {
@@ -235,8 +235,8 @@
       "term computations term_1 through term_3"
     ],
     "range": {
-      "startLine": 98,
-      "endLine": 139
+      "startLine": 161,
+      "endLine": 213
     }
   },
   {
@@ -258,8 +258,8 @@
       "rational approximation theory"
     ],
     "range": {
-      "startLine": 98,
-      "endLine": 139
+      "startLine": 216,
+      "endLine": 221
     }
   },
   {
@@ -280,8 +280,8 @@
       "3 is not a power of 2"
     ],
     "range": {
-      "startLine": 37,
-      "endLine": 39
+      "startLine": 222,
+      "endLine": 256
     }
   },
   {
@@ -302,8 +302,8 @@
       "1 is not a power of 2"
     ],
     "range": {
-      "startLine": 141,
-      "endLine": 205
+      "startLine": 258,
+      "endLine": 275
     }
   },
   {
@@ -322,8 +322,8 @@
       "borwein_irrationality"
     ],
     "range": {
-      "startLine": 141,
-      "endLine": 205
+      "startLine": 277,
+      "endLine": 290
     }
   },
   {
@@ -342,8 +342,8 @@
       "borwein_irrationality"
     ],
     "range": {
-      "startLine": 141,
-      "endLine": 205
+      "startLine": 292,
+      "endLine": 311
     }
   },
   {
@@ -363,8 +363,8 @@
       "T_summable"
     ],
     "range": {
-      "startLine": 141,
-      "endLine": 205
+      "startLine": 313,
+      "endLine": 322
     }
   },
   {
@@ -386,8 +386,8 @@
       "Borwein's irrationality result"
     ],
     "range": {
-      "startLine": 207,
-      "endLine": 236
+      "startLine": 324,
+      "endLine": 327
     }
   },
   {
@@ -407,8 +407,8 @@
       "definition of transcendental number"
     ],
     "range": {
-      "startLine": 207,
-      "endLine": 236
+      "startLine": 329,
+      "endLine": 334
     }
   },
   {
@@ -428,7 +428,7 @@
     ],
     "range": {
       "startLine": 336,
-      "endLine": 353
+      "endLine": 352
     }
   },
   {
@@ -444,8 +444,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 237,
-      "endLine": 257
+      "startLine": 354,
+      "endLine": 364
     }
   },
   {
@@ -465,8 +465,8 @@
       "Problem #1049 series"
     ],
     "range": {
-      "startLine": 237,
-      "endLine": 257
+      "startLine": 366,
+      "endLine": 368
     }
   },
   {
@@ -486,8 +486,8 @@
       "S_1049 definition"
     ],
     "range": {
-      "startLine": 237,
-      "endLine": 257
+      "startLine": 370,
+      "endLine": 376
     }
   },
   {
@@ -506,7 +506,7 @@
       "T_eq_S_1049"
     ],
     "range": {
-      "startLine": 377,
+      "startLine": 378,
       "endLine": 391
     }
   },
@@ -527,8 +527,8 @@
       "first terms computation"
     ],
     "range": {
-      "startLine": 258,
-      "endLine": 283
+      "startLine": 393,
+      "endLine": 395
     }
   },
   {
@@ -547,8 +547,8 @@
       "S_first_terms"
     ],
     "range": {
-      "startLine": 37,
-      "endLine": 39
+      "startLine": 396,
+      "endLine": 400
     }
   },
   {
@@ -568,8 +568,8 @@
       "comparison with geometric series"
     ],
     "range": {
-      "startLine": 37,
-      "endLine": 39
+      "startLine": 401,
+      "endLine": 405
     }
   },
   {
@@ -589,8 +589,8 @@
       "S_summable"
     ],
     "range": {
-      "startLine": 284,
-      "endLine": 303
+      "startLine": 406,
+      "endLine": 421
     }
   },
   {
@@ -608,8 +608,8 @@
     ],
     "prerequisites": [],
     "range": {
-      "startLine": 284,
-      "endLine": 303
+      "startLine": 423,
+      "endLine": 427
     }
   },
   {
@@ -627,8 +627,8 @@
       "oeis_A331372 definition"
     ],
     "range": {
-      "startLine": 284,
-      "endLine": 303
+      "startLine": 428,
+      "endLine": 433
     }
   },
   {
@@ -648,8 +648,8 @@
       "basic properties of 2^n"
     ],
     "range": {
-      "startLine": 284,
-      "endLine": 303
+      "startLine": 434,
+      "endLine": 462
     }
   },
   {
@@ -669,8 +669,8 @@
       "borwein_irrationality"
     ],
     "range": {
-      "startLine": 305,
-      "endLine": 340
+      "startLine": 464,
+      "endLine": 466
     }
   },
   {
@@ -688,8 +688,8 @@
       "erdos_1050"
     ],
     "range": {
-      "startLine": 305,
-      "endLine": 340
+      "startLine": 467,
+      "endLine": 470
     }
   },
   {
@@ -708,8 +708,8 @@
       "borwein_irrationality"
     ],
     "range": {
-      "startLine": 305,
-      "endLine": 340
+      "startLine": 475,
+      "endLine": 483
     }
   }
 ]


### PR DESCRIPTION
## Summary
Annotation drift fix for `erdos-1050` (irrationality of ∑ 1/(2ⁿ − 3)).

As the Lean file grew, the 35 annotations bunched onto a handful of wrong constructs (many shared identical stale ranges such as 37–39, 141–205, 305–340), so most highlighted the wrong lines.

## Changes
- Re-anchored all **35** annotations to their current constructs: the series definitions `T`/`S`/`sumTwoMinusThree`, the convergence and per-term lemmas, the Borwein irrationality axiom, the related-series irrationality theorems (∑1/(2ⁿ±1), ∑1/(3ⁿ−1), general), the transcendence conjectures, the Problem #1049 connection, the OEIS sequence, and the main results.
- Annotations-only; sections were already aligned to the Part I–X markers.

## Verification
`npx tsx scripts/annotations/resolver.ts validate ...` → **35 valid / 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)