### PR TITLE
research(shannon-channel-coding-oq-01): state-sync to merged BSC/BEC reality

### DIFF
--- a/research/problems/shannon-channel-coding-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-oq-01/state.md
@@ -1,25 +1,53 @@
 # Research State: shannon-channel-coding-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT — BSC done & galleried; BEC merged-but-unregistered (build-pending); AWGN open
 **Path**: full
-**Since**: 2026-03-30T11:35:15-07:00
-**Iteration**: 1
+**Since**: 2026-06-16 (state-sync: prior file was a never-updated March OBSERVE/0-attempt stub
+that did not reflect the substantial merged work — see knowledge.md for the real status)
+**Iteration**: 2
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Problem
+Can specific named-channel capacities (BSC, BEC, AWGN) be computed formally, beyond the
+parent's placeholder `True`/axiom statements?
+
+## Current Status (real, per knowledge.md)
+- **BSC — DONE & VERIFIED & GALLERIED.** `ShannonChannelCodingOQ02.lean`
+  (`bsc_capacity_proved`, OQ02.lean:257) proves `channelCapacity (bsc p) = log 2 - h(p)`
+  from first principles, 0 axioms. Registered (`Proofs.lean:2830`), gallery dir
+  `src/data/proofs/shannon-channel-coding-oq-02`. The parent
+  `ShannonChannelCoding.lean` still *declares* `axiom bsc_capacity_eq` as a
+  forward-declaration discharged downstream in OQ02 (cannot be inlined — OQ02 imports
+  the parent, so inlining would create an import cycle).
+- **BEC — PROVEN, MERGED, but UNREGISTERED + build-pending.**
+  `proofs/Proofs/ShannonChannelCodingBEC.lean` (merged #25152, commit abd81e87a08;
+  `bec_capacity` BEC.lean:207, 0 sorries / 0 axioms) proves BEC(p) capacity =
+  (1-p)·log 2 via the engine identity `H(X|Y) = p·H(X)`. It is NOT imported in
+  `Proofs.lean` and was authored during a Docker blackout, so it has NOT been
+  machine-checked. Do NOT create a gallery entry for it while unregistered/unverified
+  (false-green risk).
+- **AWGN — OPEN, hard.** Continuous channel; needs measure-theoretic differential-entropy
+  capacity, much harder than the finite-alphabet BSC/BEC. Not attempted.
 
 ## Active Approach
-None yet.
+None safe this session — see Blockers.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 2 (BSC capacity proof; BEC capacity proof)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 2 (BSC `log 2 - h(p)`; BEC `(1-p)·log 2` via `H(X|Y)=p·H(X)`)
 
 ## Blockers
-None.
+- **Docker blackout** (`docker-build.sh` rc=124, daemon unresponsive). Cannot build, so
+  cannot verify + register `ShannonChannelCodingBEC.lean`. Registering an uncompiled file
+  would risk the fleet-wide registered build (math PRs are deployer-merged with no Lean gate).
+- **Aristotle 404** — not relevant here (BEC is already 0-sorry).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+1. **When Docker is healthy** (`docker run --rm alpine echo ok` returns within seconds):
+   `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingBEC`. If green, add
+   `import Proofs.ShannonChannelCodingBEC` to `Proofs.lean` (in the Shannon block near
+   `:2829`), confirm the full registered build stays green, then add a gallery dir
+   `src/data/proofs/shannon-channel-coding-oq-01` (meta + annotations).
+2. AWGN: assess tractability of measure-theoretic capacity before committing — likely
+   needs non-Mathlib analytic/measure machinery.


### PR DESCRIPTION
## Summary
- The `shannon-channel-coding-oq-01` `state.md` was a never-updated March stub (Phase OBSERVE, 0 attempts, "read problem.md") despite substantial **merged** work. A future claimer would have redone finished work — the exact failure mode documented for the erdos-1179 stale stub (#24551-era state sync).
- Corrects it to the real status (verified offline against the source files this session):
  - **BSC** — DONE/verified/galleried: `ShannonChannelCodingOQ02.lean:257` `bsc_capacity_proved` = `log 2 - h(p)`, registered `Proofs.lean:2830`.
  - **BEC** — proven & merged (#25152) but **unregistered + build-pending**: `ShannonChannelCodingBEC.lean:207` `bec_capacity` = `(1-p)·log 2`, 0 sorries / 0 axioms. Stays unregistered/ungalleried until a green Docker build (false-green risk).
  - **AWGN** — open, measure-theoretic, not attempted.
- Updates phase, attempt counts, blockers (Docker blackout rc=124), and a concrete next action (build-verify → register → gallery once Docker is healthy).

Doc-only. No Lean or gallery JSON changes.

## Test plan
- [x] Verified `bsc_capacity_proved` exists at `ShannonChannelCodingOQ02.lean:257` and is registered.
- [x] Verified `bec_capacity` exists at `ShannonChannelCodingBEC.lean:207`, file 0-sorry/0-axiom, merged via #25152, NOT in `Proofs.lean`.
- [x] No code/gallery changes — nothing to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)