### PR TITLE
audit(tracker): persist 15 clean completions (new gallery entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15683,6 +15683,96 @@
       "lastAudited": "2026-06-16T21:42:25Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-noodle": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-non-euclidean-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "circumference-via-differentiation-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cube-root-3-irrational-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "four-square-distribution-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-14-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-reciprocity-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-minpoly-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-02-ext-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "zsqrtd-neg-two-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-16T22:05:23Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
Gallery integrity audit of the 15 newly-merged, previously-unaudited entries — **all CLEAN**. Persists the tracker so the next auditor cycle's `git reset --hard origin/main` doesn't re-serve them. Audit queue now fully drained (0 unaudited).

## Method
Authoritative main-file check: for each entry, strip comments from the registered `proofRepoPath` Lean file, count real `sorry`/`axiom`/True-stubs, and compare against meta.json `status`/`badge`/`sorries`/`axiomCount`.

## Findings (all match)
| slug | status/badge | claimed | real |
|------|--------------|---------|------|
| arithmetic-series-oq-02-oq-02-oq-02 | verified/original | 0s 0a | 0s 0a |
| ballot-problem-oq-01-oq-03 | verified/mathlib | 0s 0a | 0s 0a |
| buffons-noodle | axiomatized/axiom | 0s 2a | 0s 2a |
| cauchy-schwarz-integral-… | verified/original | 0s 0a | 0s 0a |
| cevas-theorem-non-euclidean-… | verified/original | 0s 0a | 0s 0a |
| circumference-via-differentiation-… | verified/original | 0s 0a | 0s 0a |
| cube-root-3-irrational-oq-04 | verified/original | 0s 0a | 0s 0a |
| dirichlet-approximation-theorem | verified/original | 0s 0a | 0s 0a |
| fair-games-theorem-… | verified/original | 0s 0a | 0s 0a |
| four-square-distribution-oq-04 | verified/original | 0s 0a | 0s 0a |
| hilbert-14-oq-04 | verified/mathlib | 0s 0a | 0s 0a |
| quadratic-reciprocity-oq-03-oq-01 | verified/mathlib | 0s 0a | 0s 0a |
| sqrt2-minpoly-… | verified/original | 0s 0a | 0s 0a |
| wilsons-theorem-oq-02-ext-oq-01 | verified/original | 0s 0a | 0s 0a |
| zsqrtd-neg-two-oq-03-oq-01 | verified/original | 0s 0a | 0s 0a |

All main files exist and are registered in `Proofs.lean`. No `verified` entry has a real sorry; no entry has more axiom decls than its claimed `axiomCount`. Spot-checked the famous-named `original`-badge entries (Ceva/Menelaus unification, Miller's theorem) for honest scoping and QR for the correct `mathlib` badge — all accurately worded.

## Test plan
- [x] tracker JSON parses
- [x] tracker-only change, no source files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)