### PR TITLE
research(sqrt2-minpoly-oq-01-oq-02-oq-02): gallery entry for prime-power-degree radical minimal polynomial

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "sqrt2oq010202-ann-header",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 7, "endLine": 64 },
+    "type": "concept",
+    "title": "Prime-Power Generalization and the Independence-of-n Subtlety",
+    "content": "The header states the goal: for an odd prime $p$, exponent $n \\ge 1$, and a nonnegative rational $a$ that is not a $p$-th power, $\\operatorname{minpoly}_{\\mathbb Q}(a^{1/p^n}) = X^{p^n} - a$. The crucial observation is that Mathlib's Kummer criterion $X^{p^n} - C\\,a$ irreducible $\\iff \\forall b,\\ b^p \\ne a$ is governed by a condition on $p$ alone, **independent of $n$**. So $X^9 - 2$ is irreducible because $2$ is not a *cube* ($p = 3$); whether $2$ is a $9$-th power is never tested. This makes $a^{1/p^n}$ a degree-$p^n$ element with no intermediate collapse — in sharp contrast to composite exponents, where $X^4 - 4 = (X^2-2)(X^2+2)$ forces $\\operatorname{minpoly}_{\\mathbb Q}(4^{1/4}) = X^2 - 2$.",
+    "mathContext": "$\\operatorname{minpoly}_{\\mathbb Q}(a^{1/p^n}) = X^{p^n} - a$; irreducibility obstruction $\\forall b\\in\\mathbb Q,\\ b^p \\ne a$, independent of $n$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Kummer extension",
+      "irreducibility criterion",
+      "prime-power exponent",
+      "p-th power obstruction"
+    ],
+    "prerequisites": [
+      "Minimal polynomial over ℚ",
+      "Kummer theory",
+      "sibling entry sqrt2-minpoly-oq-01-oq-02-oq-01"
+    ]
+  },
+  {
+    "id": "sqrt2oq010202-ann-root",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 70, "endLine": 85 },
+    "type": "technique",
+    "title": "The Radical is a Root of X^N − C a",
+    "content": "Two general-$N$ lemmas supply the root witness. `rpow_inv_pow` proves $(a^{1/N})^N = a$ for $a \\ge 0$, $N \\ne 0$, by rewriting the natural power as a real `rpow` (`Real.rpow_natCast`), folding the exponents with `Real.rpow_mul` (legal because $a \\ge 0$), and cancelling $\\tfrac1N\\cdot N = 1$. `aeval_rpow` then evaluates $X^N - C\\,a$ at the real radical $a^{1/N}$ and gets $0$: after `simp` pushes the algebra map through `X^N - C a`, the load-bearing step is `eq_ratCast`, which identifies $\\operatorname{algebraMap}_{\\mathbb Q\\to\\mathbb R} a$ with the literal cast $(a:\\mathbb R)$ so the `rpow_inv_pow` value applies. Both are stated for arbitrary $N$, so they serve every prime-power exponent without specialization.",
+    "mathContext": "$(a^{1/N})^N = a$ for $a \\ge 0$; $\\operatorname{aeval}_{a^{1/N}}(X^N - C\\,a) = 0$ via eq_ratCast.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "real rpow power laws",
+      "eq_ratCast coercion",
+      "polynomial evaluation"
+    ],
+    "prerequisites": [
+      "Real.rpow_natCast / Real.rpow_mul",
+      "algebraMap ℚ ℝ"
+    ]
+  },
+  {
+    "id": "sqrt2oq010202-ann-main",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 106 },
+    "type": "theorem",
+    "title": "Main Theorem: minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a",
+    "content": "`minpoly_rpow_of_odd_prime_pow` is the heart of the file. It assembles the three ingredients of the monic-irreducible-root characterization `minpoly.eq_of_irreducible_of_monic`: monicity from `monic_X_pow_sub_C` (using $p^n \\ne 0$), the root from `aeval_rpow`, and irreducibility from the Kummer criterion `X_pow_sub_C_irreducible_iff_of_prime_pow` invoked at **general $n$** (its `.mpr` direction fed the hypothesis $\\forall b,\\ b^p \\ne a$). The result is $\\operatorname{minpoly}_{\\mathbb Q}(a^{1/p^n}) = X^{p^n} - C\\,a$ (after a `.symm`). Setting $n = 1$ recovers the odd-prime sibling; the only difference from that proof is that no `pow_one` rewrite is needed, since the criterion already lands on exponent $p^n$.",
+    "mathContext": "minpoly.eq_of_irreducible_of_monic applied to the monic irreducible X^(pⁿ) − C a annihilating a^(1/pⁿ).",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "minpoly.eq_of_irreducible_of_monic",
+      "X_pow_sub_C_irreducible_iff_of_prime_pow",
+      "monic_X_pow_sub_C"
+    ],
+    "prerequisites": [
+      "Kummer irreducibility criterion",
+      "monic-irreducible-root characterization of minpoly"
+    ]
+  },
+  {
+    "id": "sqrt2oq010202-ann-integral",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 110, "endLine": 114 },
+    "type": "insight",
+    "title": "Integrality, Stated Hypothesis-Free",
+    "content": "`rpow_isIntegral` records that $a^{1/N}$ is integral over $\\mathbb Q$ for any $a \\ge 0$ and $N \\ne 0$, witnessed by the monic $X^N - C\\,a$ together with `aeval_rpow`. Deliberately it carries **no** not-a-$p$-th-power hypothesis: integrality holds for every nonnegative rational radicand, and stating it separately lets the field-extension corollary reuse it directly without dragging the irreducibility assumption through.",
+    "mathContext": "IsIntegral ℚ (a^(1/N)) via the monic witness X^N − C a.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral element",
+      "monic witness"
+    ],
+    "prerequisites": [
+      "IsIntegral",
+      "monic_X_pow_sub_C"
+    ]
+  },
+  {
+    "id": "sqrt2oq010202-ann-degree",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 116, "endLine": 122 },
+    "type": "theorem",
+    "title": "Algebraic Degree pⁿ",
+    "content": "`minpoly_rpow_natDegree` computes $\\deg_{\\mathbb Q} a^{1/p^n} = p^n$ by rewriting the minimal polynomial to $X^{p^n} - C\\,a$ via the main theorem and then applying `Polynomial.natDegree_X_pow_sub_C`. This is the quantitative payoff: the radical genuinely has the maximal possible degree $p^n$, confirming there is no early factorization collapse.",
+    "mathContext": "natDegree (minpoly ℚ (a^(1/pⁿ))) = pⁿ.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "natDegree_X_pow_sub_C",
+      "algebraic degree"
+    ],
+    "prerequisites": [
+      "natDegree of X^N − C a"
+    ]
+  },
+  {
+    "id": "sqrt2oq010202-ann-finrank",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+    "range": { "startLine": 124, "endLine": 131 },
+    "type": "application",
+    "title": "Field Extension Degree [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ",
+    "content": "`adjoin_rpow_finrank` concludes that the simple extension $\\mathbb Q(a^{1/p^n})/\\mathbb Q$ has degree $p^n$. It applies `IntermediateField.adjoin.finrank` to the integral element (from `rpow_isIntegral`), reducing the rank to the minimal-polynomial degree, then closes with `minpoly_rpow_natDegree`. This is the field-theoretic statement the whole file builds toward: a prime-power radical of a non-$p$-th-power rational generates an extension of degree exactly $p^n$.",
+    "mathContext": "Module.finrank ℚ ℚ⟮a^(1/pⁿ)⟯ = pⁿ.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IntermediateField.adjoin.finrank",
+      "simple extension degree"
+    ],
+    "prerequisites": [
+      "field extension degree",
+      "adjoin of an integral element"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+  "title": "Minimal Polynomial of a Prime-Power-Degree Radical of a Rational",
+  "slug": "sqrt2-minpoly-oq-01-oq-02-oq-02",
+  "description": "A Lean 4 proof that minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for every odd prime p, exponent n ≥ 1, and nonnegative rational a that is not a p-th power in ℚ, with the degree (= pⁿ) and field-extension ([ℚ(a^(1/pⁿ)) : ℚ] = pⁿ) corollaries. Pushes Mathlib's Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow to its full prime-power strength, generalizing the odd-prime sibling (sqrt2-minpoly-oq-01-oq-02-oq-01, the n=1 case) from prime degree p to every prime-power degree pⁿ. The key subtlety: the irreducibility obstruction 'a is not a p-th power' depends only on p, never on n.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "tags": [
+      "algebraic-number-theory",
+      "minimal-polynomial",
+      "field-extensions",
+      "kummer-theory",
+      "irreducibility",
+      "radicals",
+      "prime-power"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None (0 axioms, 0 sorries). Registered in Proofs.lean (line 2911) and added to the build manifest by PR #24843; the entire import closure is Mathlib only — no project axioms, native_decide, or sorries anywhere in the dependency chain. All Mathlib bearers (X_pow_sub_C_irreducible_iff_of_prime_pow, minpoly.eq_of_irreducible_of_monic, monic_X_pow_sub_C, natDegree_X_pow_sub_C, IntermediateField.adjoin.finrank, the real rpow power laws, eq_ratCast) were confirmed present at the pinned Mathlib v4.26.0 (2df2f0150c). The file is a verbatim adaptation of the machine-verified odd-prime sibling Sqrt2MinpolyOQ01OQ02OQ01.lean with the exponent p replaced by the prime power pⁿ.",
+    "mathlibDependencies": [
+      {
+        "theorem": "X_pow_sub_C_irreducible_iff_of_prime_pow",
+        "description": "The Kummer criterion: over a field K, for an odd prime p and n ≠ 0, X^(pⁿ) − C a is irreducible iff a is not a p-th power in K. Applied here at general n (not just n = 1), which is the whole point of the prime-power generalization.",
+        "module": "Mathlib.FieldTheory.KummerExtension"
+      },
+      {
+        "theorem": "minpoly.eq_of_irreducible_of_monic",
+        "description": "A monic irreducible polynomial that annihilates an element equals (up to symm) its minimal polynomial. Turns monic + irreducible + has-the-root into the minimal-polynomial identity.",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "monic_X_pow_sub_C",
+        "description": "X^(pⁿ) − C a is monic for pⁿ ≠ 0, supplying both the monicity for minpoly.eq_of_irreducible_of_monic and the integrality witness.",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Real.rpow_natCast / Real.rpow_mul",
+        "description": "Real power laws giving (a^(1/pⁿ))^(pⁿ) = a^((1/pⁿ)·pⁿ) = a for a ≥ 0, the root-witness computation rpow_inv_pow.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "eq_ratCast",
+        "description": "Any ring hom out of ℚ is the rational cast, identifying algebraMap ℚ ℝ a with (a : ℝ) when evaluating X^(pⁿ) − C a at the real radical.",
+        "module": "Mathlib.Data.Rat.Cast.Defs"
+      },
+      {
+        "theorem": "IntermediateField.adjoin.finrank",
+        "description": "For an element integral over K, [K(α) : K] equals the degree of its minimal polynomial; applied to α = a^(1/pⁿ) with degree pⁿ.",
+        "module": "Mathlib.FieldTheory.Adjoin"
+      },
+      {
+        "theorem": "Polynomial.natDegree_X_pow_sub_C",
+        "description": "natDegree (X^(pⁿ) − C a) = pⁿ, giving the degree and field-extension values.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      }
+    ],
+    "originalContributions": [
+      "Main theorem: minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for every odd prime p, exponent n ≥ 1, and nonnegative rational a that is not a p-th power in ℚ",
+      "Generalizes the odd-prime sibling (its n = 1 case) to arbitrary prime-power degree pⁿ by applying the Kummer criterion at general n instead of specializing to n = 1",
+      "Sharp obstruction observation: irreducibility hinges on 'a is not a p-th power' — a condition independent of n — not on the weaker-looking 'a is not a pⁿ-th power'; e.g. X⁹ − 2 is irreducible because 2 is not a cube (p = 3), and whether 2 is a 9-th power is never tested",
+      "Root-witness lemma rpow_inv_pow: (a^(1/N))^N = a for a ≥ 0 and N ≠ 0, via the real rpow power laws (stated for general N so it serves every prime-power exponent)",
+      "Annihilation lemma aeval_rpow: X^N − C a evaluates to 0 at the real radical a^(1/N), using eq_ratCast to identify algebraMap ℚ ℝ a with (a : ℝ)",
+      "Integrality rpow_isIntegral: a^(1/N) is integral over ℚ (root of the monic X^N − C a), stated without the not-a-p-th-power hypothesis so it can feed the finrank corollary",
+      "Algebraic degree minpoly_rpow_natDegree: natDegree (minpoly ℚ (a^(1/pⁿ))) = pⁿ",
+      "Field extension degree adjoin_rpow_finrank: [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ"
+    ],
+    "dateAdded": "2026-06-16"
+  },
+  "overview": {
+    "historicalContext": "The minimal polynomial of an algebraic number and the field-extension degree it determines are foundational in algebraic number theory; minpoly_ℚ(√2) = X² − 2 is the prototype. The gallery thread sqrt2-minpoly proves minpoly_ℚ(√n) = X² − n for non-square n; sqrt2-minpoly-oq-01-oq-02 generalizes the radicand to an arbitrary nonnegative rational at degree 2; and the odd-prime sibling sqrt2-minpoly-oq-01-oq-02-oq-01 raises the degree to an arbitrary odd prime p via Kummer theory. The remaining axis is the exponent tower: the same Kummer criterion governs not just X^p − C a but X^(pⁿ) − C a for every n ≥ 1. This entry resolves that prime-power case, completing the picture for radicals a^(1/pⁿ) whose denominator is a prime power.",
+    "problemStatement": "For an odd prime p, an exponent n ≥ 1, and a nonnegative rational a, when is minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a? Answer: exactly when a is not a p-th power in ℚ — the same condition as the prime-degree case, independent of n. The composite-exponent analogue is false without an extra hypothesis (X⁴ − 4 factors as (X²−2)(X²+2), so minpoly ℚ (4^(1/4)) = X² − 2), so prime-power exponents with a non-p-th-power radicand are exactly where the clean X^(pⁿ) − a answer holds.",
+    "proofStrategy": "The minimal polynomial is monic by definition, so the canonical answer is the monic X^(pⁿ) − C a, established by the standard 'monic + irreducible + has the root ⟹ it is the minimal polynomial' argument (minpoly.eq_of_irreducible_of_monic). 1. Root: (a^(1/pⁿ))^(pⁿ) = a by the real rpow power laws (valid since a ≥ 0), so X^(pⁿ) − C a annihilates a^(1/pⁿ) after identifying algebraMap ℚ ℝ a with (a : ℝ) via eq_ratCast. 2. Monic: monic_X_pow_sub_C, using pⁿ ≠ 0. 3. Irreducible: the Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow applied at general n, whose hypothesis is precisely 'a is not a p-th power in ℚ' (∀ b : ℚ, b^p ≠ a). Degree pⁿ and the extension degree [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ then follow from natDegree_X_pow_sub_C and IntermediateField.adjoin.finrank applied to the integral element. The proof differs from the odd-prime sibling only in not needing a pow_one rewrite to land on exponent p^n.",
+    "keyInsights": [
+      "The irreducibility obstruction depends only on p, never on n: X^(pⁿ) − C a is irreducible over ℚ iff a is not a p-th power, so the same single Diophantine condition ∀ b, b^p ≠ a governs the entire tower of prime-power exponents. X⁹ − 2 is irreducible because 2 is not a cube; 2 being a 9-th power is irrelevant.",
+      "Prime-power exponents are the natural maximal setting for the clean answer: for composite exponents the polynomial can factor early (X⁴ − 4 = (X²−2)(X²+2)), collapsing the minimal polynomial, whereas a^(1/pⁿ) keeps full degree pⁿ as long as a avoids being a p-th power.",
+      "The generalization is essentially free given Mathlib: the odd-prime sibling specialized the Kummer criterion to n = 1; here the same lemma is invoked at general n, so the only change is dropping the pow_one rewrite. This is a clean example of a Mathlib API being stated more generally than the first application needed.",
+      "Integrality is stated hypothesis-free (rpow_isIntegral, no not-a-p-th-power assumption) so the field-extension finrank corollary can reuse it directly; the monic X^N − C a is the integrality witness regardless of irreducibility.",
+      "eq_ratCast is the load-bearing coercion: evaluating a ℚ-polynomial at a real number routes through algebraMap ℚ ℝ a, which must be identified with the literal cast (a : ℝ) before the rpow root computation applies."
+    ],
+    "prerequisites": [
+      "Kummer theory: irreducibility of X^(pⁿ) − a over a field",
+      "Minimal polynomials and the monic-irreducible characterization (minpoly.eq_of_irreducible_of_monic)",
+      "Real rpow power laws for nonnegative bases",
+      "Field-extension degree via IntermediateField.adjoin.finrank",
+      "Sibling entry sqrt2-minpoly-oq-01-oq-02-oq-01 (the odd-prime n = 1 case)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-header",
+      "title": "Header: Statement, Subtlety, and Strategy",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Block comment stating the prime-power generalization minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a, the 'subtle point' that the obstruction ∀ b, b^p ≠ a is independent of n (X⁹ − 2 irreducible because 2 is not a cube), the composite-exponent failure (X⁴ − 4 factors), and the three-step monic+irreducible+root proof outline.",
+      "mathContext": "minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for odd prime p, n ≥ 1, a ≥ 0 not a p-th power."
+    },
+    {
+      "id": "section-root",
+      "title": "Part I: The Radical is a Root of X^N − C a",
+      "startLine": 68,
+      "endLine": 85,
+      "summary": "rpow_inv_pow: (a^(1/N))^N = a for a ≥ 0, N ≠ 0, via Real.rpow_natCast and Real.rpow_mul. aeval_rpow: X^N − C a annihilates the real radical a^(1/N), using eq_ratCast to identify algebraMap ℚ ℝ a with (a : ℝ). Both stated for general N so they serve every prime-power exponent.",
+      "mathContext": "(a^(1/N))^N = a; aeval_{a^(1/N)} (X^N − C a) = 0."
+    },
+    {
+      "id": "section-main",
+      "title": "Part II: The Minimal Polynomial",
+      "startLine": 87,
+      "endLine": 106,
+      "summary": "minpoly_rpow_of_odd_prime_pow: the main theorem minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a, assembled from monic_X_pow_sub_C (monic), aeval_rpow (root), and the Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow at general n (irreducible), via minpoly.eq_of_irreducible_of_monic.",
+      "mathContext": "minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − C a."
+    },
+    {
+      "id": "section-consequences",
+      "title": "Part III: Degree and Field-Extension Consequences",
+      "startLine": 108,
+      "endLine": 131,
+      "summary": "rpow_isIntegral: a^(1/N) is integral over ℚ (hypothesis-free). minpoly_rpow_natDegree: natDegree (minpoly ℚ (a^(1/pⁿ))) = pⁿ, from natDegree_X_pow_sub_C. adjoin_rpow_finrank: [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ, from IntermediateField.adjoin.finrank on the integral element.",
+      "mathContext": "IsIntegral ℚ (a^(1/N)); deg = pⁿ; [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an odd prime p, exponent n ≥ 1, and a nonnegative rational a that is not a p-th power in ℚ, the minimal polynomial of the radical a^(1/pⁿ) over ℚ is exactly X^(pⁿ) − a, and the extension ℚ(a^(1/pⁿ))/ℚ has degree pⁿ. The proof is the monic-irreducible-root characterization driven by Mathlib's Kummer criterion applied at general prime-power exponent, generalizing the odd-prime sibling (its n = 1 case) for free. 6 theorems, 0 definitions, 0 sorries, 0 axioms; Mathlib-only import closure.",
+    "implications": "Together with the parent square-root entry (p = 2, elementary irrationality route) and the odd-prime sibling (n = 1), this completes the minimal-polynomial computation for radicals a^(1/pⁿ) whose denominator is any prime power: the answer is the obvious monic X^(pⁿ) − a precisely when the radicand is not a p-th power. The sharp dependence on prime-power exponents — and the failure for composite exponents — mirrors the structure of Kummer extensions and the lattice of intermediate fields ℚ ⊂ ℚ(a^(1/p)) ⊂ ⋯ ⊂ ℚ(a^(1/pⁿ)), each step of degree p with no early collapse. The result is a clean illustration of how a single Mathlib criterion, stated at full generality, subsumes a whole family of degree computations.",
+    "openQuestions": [
+      "Composite exponents with squarefree obstruction: for a general exponent N = ∏ pᵢ^(eᵢ), characterize exactly when minpoly ℚ (a^(1/N)) = X^N − a (the answer involves a being a non-pᵢ-th power for each prime pᵢ ∣ N, by Kummer-extension compositum arguments) and formalize the first non-prime-power case N = 6.",
+      "The excluded prime p = 2 at higher exponent: extend to 2^n-th roots, where the Kummer criterion requires the extra hypothesis ruling out a ∈ −4·ℚ^4 (the X⁴ + 4 = (X²−2X+2)(X²+2X+2) obstruction), and identify exactly when minpoly ℚ (a^(1/2ⁿ)) = X^(2ⁿ) − a.",
+      "Galois-theoretic refinement: compute the Galois group of the splitting field of X^(pⁿ) − a over ℚ (a semidirect product of the cyclic root group with a cyclotomic part) and formalize the degree of the splitting field as p^n · ord_{p^n}-type data."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Odd-prime sibling: minpoly ℚ (a^(1/p)) = X^p − a, the n = 1 case of this prime-power generalization"
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Degree-2 parent (minpoly ℚ (√r) = X² − r for nonnegative rational non-square r) and source of the higher-degree open question"
+    },
+    {
+      "targetId": "sqrt2-minpoly",
+      "relationship": "related",
+      "description": "Root of the thread: minpoly ℚ (√n) = X² − n for non-square n"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean",
+    "filename": "Sqrt2MinpolyOQ01OQ02PrimePow.lean",
+    "lineCount": 132,
+    "theoremCount": 6,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Gallery entry for the **verified, registered-but-ungalleried** proof
`Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean` (132 lines, 0 sorries, 0 axioms,
registered in `Proofs.lean:2911` via #24843, Mathlib-only import closure).

The file proves, for every odd prime `p`, exponent `n ≥ 1`, and nonnegative
rational `a` that is **not** a `p`-th power in ℚ:

> `minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a`,  with  `deg = pⁿ`  and  `[ℚ(a^(1/pⁿ)) : ℚ] = pⁿ`.

It pushes Mathlib's Kummer criterion `X_pow_sub_C_irreducible_iff_of_prime_pow`
to its full **prime-power** strength, generalizing the odd-prime sibling
`sqrt2-minpoly-oq-01-oq-02-oq-01` (#25298, the `n = 1` case) from prime degree
`p` to every prime-power degree `pⁿ`.

**Key subtlety (documented in the entry):** the irreducibility obstruction
`∀ b, b^p ≠ a` ("a is not a p-th power") depends only on `p`, never on `n` —
`X⁹ − 2` is irreducible because `2` is not a *cube*, not because of anything at
exponent 9. Composite exponents can collapse (`X⁴ − 4` factors), so prime-power
exponents are the natural maximal setting.

## Contents

- `src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json` — full gallery
  metadata (status `verified`, badge `original`, 6 theorems / 0 defs, honest
  build-provenance note, mathlibDependencies confirmed at pin v4.26.0).
- `src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/annotations.json` — 6
  line-anchored annotations (resolver validate: **6 valid, 0 misaligned**).

JSON-only; no Lean source changes. All Mathlib bearers were confirmed present at
the pinned commit `2df2f0150c` via an offline Mathlib checkout.

## Test plan

- [x] `node -e JSON.parse` on both files (valid JSON)
- [x] `scripts/annotations/resolver.ts validate` → 6/6 annotations anchor
- [x] crossReference targets verified (parent + thread root present on main; the
      `-oq-01` sibling is in open PR #25298 and will resolve on its merge)
- [ ] `pnpm build` gallery render (deferred — Docker/build blackout this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)