### PR TITLE
Enrich erdos-268: re-anchor 20 annotations and rebuild sections

### DIFF
--- a/src/data/proofs/erdos-268/annotations.json
+++ b/src/data/proofs/erdos-268/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-268",
     "range": {
       "startLine": 1,
-      "endLine": 36
+      "endLine": 30
     },
     "type": "concept",
     "title": "Problem Statement and Background",
@@ -53,8 +53,8 @@
     "id": "ann-268-convergent-def",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 40,
-      "endLine": 42
+      "startLine": 37,
+      "endLine": 39
     },
     "type": "definition",
     "title": "Convergent Harmonic Subseries",
@@ -78,8 +78,8 @@
     "id": "ann-268-shifted-sum",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 48,
-      "endLine": 50
+      "startLine": 45,
+      "endLine": 47
     },
     "type": "definition",
     "title": "Shifted Harmonic Sum",
@@ -102,8 +102,8 @@
     "id": "ann-268-finite-convergent",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 52,
-      "endLine": 55
+      "startLine": 49,
+      "endLine": 54
     },
     "type": "concept",
     "title": "Finite Sets Have Convergent Subseries",
@@ -124,8 +124,8 @@
     "id": "ann-268-shifted-summable",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 57,
-      "endLine": 61
+      "startLine": 55,
+      "endLine": 93
     },
     "type": "concept",
     "title": "Shifted Series Also Converge",
@@ -148,8 +148,8 @@
     "id": "ann-268-harmonic-point",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 65,
-      "endLine": 68
+      "startLine": 98,
+      "endLine": 101
     },
     "type": "definition",
     "title": "The Harmonic Point Construction",
@@ -173,8 +173,8 @@
     "id": "ann-268-point-set",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 70,
-      "endLine": 87
+      "startLine": 102,
+      "endLine": 118
     },
     "type": "definition",
     "title": "The Point Set X and Alternative Characterization",
@@ -197,8 +197,8 @@
     "id": "ann-268-main-theorem",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 88,
-      "endLine": 107
+      "startLine": 126,
+      "endLine": 150
     },
     "type": "concept",
     "title": "Main Result: Interior is Nonempty",
@@ -222,8 +222,8 @@
     "id": "ann-268-erdos-straus",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 109,
-      "endLine": 122
+      "startLine": 161,
+      "endLine": 173
     },
     "type": "concept",
     "title": "Erdős-Straus Theorem (d=2)",
@@ -247,8 +247,8 @@
     "id": "ann-268-kovac",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 124,
-      "endLine": 140
+      "startLine": 184,
+      "endLine": 196
     },
     "type": "concept",
     "title": "Kovač's Theorem (d=3) with Explicit Ball",
@@ -271,8 +271,8 @@
     "id": "ann-268-kovac-tao",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 142,
-      "endLine": 154
+      "startLine": 197,
+      "endLine": 203
     },
     "type": "concept",
     "title": "Kovač-Tao General Dimension Result",
@@ -296,8 +296,8 @@
     "id": "ann-268-nonempty",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 156,
-      "endLine": 161
+      "startLine": 751,
+      "endLine": 761
     },
     "type": "concept",
     "title": "X is Non-empty",
@@ -320,8 +320,8 @@
     "id": "ann-268-path-connected",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 163,
-      "endLine": 183
+      "startLine": 762,
+      "endLine": 827
     },
     "type": "concept",
     "title": "Path-Connectedness and Density",
@@ -346,8 +346,8 @@
     "id": "ann-268-coordinate-decreasing",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 185,
-      "endLine": 198
+      "startLine": 832,
+      "endLine": 864
     },
     "type": "concept",
     "title": "Coordinates Are Strictly Decreasing",
@@ -370,8 +370,8 @@
     "id": "ann-268-positive",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 200,
-      "endLine": 205
+      "startLine": 740,
+      "endLine": 750
     },
     "type": "concept",
     "title": "All Coordinates Are Positive",
@@ -394,8 +394,8 @@
     "id": "ann-268-projection",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 207,
-      "endLine": 216
+      "startLine": 868,
+      "endLine": 871
     },
     "type": "definition",
     "title": "Dimension Monotonicity via Projection",
@@ -418,8 +418,8 @@
     "id": "ann-268-squares",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 218,
-      "endLine": 229
+      "startLine": 882,
+      "endLine": 883
     },
     "type": "definition",
     "title": "Squares Example: A = {n²}",
@@ -443,8 +443,8 @@
     "id": "ann-268-powers2",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 231,
-      "endLine": 241
+      "startLine": 718,
+      "endLine": 720
     },
     "type": "definition",
     "title": "Powers of 2 Example: A = {2ᵏ}",
@@ -466,8 +466,8 @@
     "id": "ann-268-summary",
     "proofId": "erdos-268",
     "range": {
-      "startLine": 244,
-      "endLine": 279
+      "startLine": 918,
+      "endLine": 978
     },
     "type": "concept",
     "title": "Summary and Key Axiom",

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -92,7 +92,7 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 37,
+      "endLine": 33,
       "summary": "Module docstring documenting the problem statement, background, and references; 5 Mathlib imports covering required modules; `open` declarations (Set Filter Topology); namespace `Erdos268`",
       "mathContext": "Let X ⊆ ℝ^d be the set of all points of the form (Σ_{n∈A} 1/n, Σ_{n∈A} 1/(n+1), ..., Σ_{n∈A} 1/(n+d-1)) as A ranges over infinite subsets of ℕ with Σ_{n∈A} 1/n < ∞. Does X have nonempty interior?"
     },
@@ -100,79 +100,93 @@
       "id": "harmonic",
       "title": "Harmonic Subseries",
       "summary": "Defines HasConvergentHarmonicSubseries as Summable (fun n : A => 1/n) and shiftedHarmonicSum for the k-shifted variant. Proves finite_has_convergent (Fintype instance + hasSum_fintype) and shifted_summable (case split on k=0 vs k>0, dominated comparison using 1/(n+k) ≤ 1/n). Both fully proved.",
-      "startLine": 38,
-      "endLine": 62,
+      "startLine": 34,
+      "endLine": 93,
       "mathContext": "Defines HasConvergentHarmonicSubseries as Summable (fun n : A => 1/n) and shiftedHarmonicSum for the k-shifted variant. Proves finite_has_convergent (Fintype instance + hasSum_fintype) and shifted_summable (dominated by original series). Both fully proved."
     },
     {
       "id": "point-set",
       "title": "The Point Set X",
       "summary": "Defines harmonicPoint as Fin d → ℝ with each coordinate being a shifted sum, and harmonicPointSet as the image over infinite A with convergent sum. Provides an alternative definition harmonicPointSet' for formal-conjectures compatibility and proves extensional equality via ext/simp (fully proved, no sorry).",
-      "startLine": 63,
-      "endLine": 87,
+      "startLine": 94,
+      "endLine": 118,
       "mathContext": "Defines harmonicPoint as Fin d → ℝ with each coordinate being a shifted sum, and harmonicPointSet as the image over infinite A with convergent sum."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
       "summary": "Axiomatizes erdos_268_solved: (interior (harmonicPointSet d)).Nonempty for all d. The derived theorem contains_open_ball is fully proved: it extracts a point from the interior, uses mem_interior to find an open set, then Metric.isOpen_iff to find a ball. This is a genuine deduction from the axiom.",
-      "startLine": 88,
-      "endLine": 108,
+      "startLine": 119,
+      "endLine": 150,
       "mathContext": "Axiomatizes erdos_268_solved: (interior (harmonicPointSet d)).Nonempty for all d. The derived theorem contains_open_ball is fully proved: it extracts a point from the interior, uses mem_interior to find an open set, then Metric.isOpen_iff to find a ball. This is a genuine deduction from the axiom."
     },
     {
       "id": "dim-2",
       "title": "2-Dimensional Case (Erdős-Straus)",
       "summary": "Axiomatizes the Erdős-Straus result that (interior (harmonicPointSet 2)).Nonempty. States dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) using matrix notation (sorry for the definitional unfolding).",
-      "startLine": 109,
-      "endLine": 123,
+      "startLine": 151,
+      "endLine": 173,
       "mathContext": "Axiomatizes the Erdős-Straus result that (interior (harmonicPointSet 2)).Nonempty. States dim2_point_form showing the concrete 2D point is (harmonicSubseriesSum A, shiftedHarmonicSum A 1) using matrix notation (sorry for the definitional unfolding)."
     },
     {
       "id": "dim-3",
       "title": "3-Dimensional Case (Kovač 2024)",
       "summary": "Axiomatizes kovac_3d for the d=3 interior result. Defines placeholder kovacBallCenter and kovacBallRadius for Kovač's explicit construction. Axiomatizes kovac_explicit_ball: the ball lies inside harmonicPointSet 3.",
-      "startLine": 124,
-      "endLine": 141,
+      "startLine": 174,
+      "endLine": 187,
       "mathContext": "Axiomatizes kovac_3d for the d=3 interior result. Defines placeholder kovacBallCenter and kovacBallRadius for Kovač's explicit construction. Axiomatizes kovac_explicit_ball: the ball lies inside harmonicPointSet 3."
     },
     {
       "id": "general",
       "title": "General Dimension (Kovač-Tao 2024)",
       "summary": "The theorem kovac_tao_general for d ≥ 1 is a direct application of erdos_268_solved. Defines AhmesSeries as a synonym for harmonicSubseriesSum, recording the Egyptian fraction connection that powered the Kovač-Tao proof.",
-      "startLine": 142,
-      "endLine": 155,
+      "startLine": 188,
+      "endLine": 203,
       "mathContext": "The theorem kovac_tao_general for d ≥ 1 is a direct application of erdos_268_solved. Defines AhmesSeries as a synonym for harmonicSubseriesSum, recording the Egyptian fraction connection that powered the Kovač-Tao proof."
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy Harmonic Construction",
+      "startLine": 204,
+      "endLine": 448,
+      "summary": "Greedy construction of an infinite set with a prescribed harmonic sum. `greedyBudget` tracks the remaining target after each decision and `greedySet` selects n when affordable; lemmas establish nonnegativity, antitonicity, the budget recurrence, summability, and that the budget tends to zero (so the realized sum hits the target)."
+    },
+    {
+      "id": "unit-fraction",
+      "title": "Unit Fraction Infrastructure",
+      "startLine": 449,
+      "endLine": 712,
+      "summary": "Unit-fraction infrastructure used for the d = 1 path-connectedness argument. Defines `consecutiveProductsSet`, proves the telescoping partial-sum identity, shows the set is infinite with a convergent harmonic subseries, and establishes `exists_infinite_harmonic_set` realizing any positive target sum."
     },
     {
       "id": "properties",
       "title": "Properties of X",
       "summary": "Fully proves harmonicPointSet_nonempty (powers-of-2 witness via infinite range), harmonicPointSet_path_connected (d=0: singleton via Fin.elim0; d=1: convexity of positive half-line via greedy construction; d≥2: harmonicPointSet_path_connected_large axiom), harmonicPointSet_dense_somewhere (direct from erdos_268_solved + isOpen_interior).",
-      "startLine": 156,
-      "endLine": 184,
+      "startLine": 713,
+      "endLine": 827,
       "mathContext": "Fully proves harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_path_connected (d=0 singleton, d=1 convex, d≥2 axiom), harmonicPointSet_dense_somewhere (interior axiom). All three theorems proved with no sorries."
     },
     {
       "id": "coordinates",
       "title": "Coordinate Properties",
       "summary": "Fully proves coordinate_decreasing (tsum_lt_tsum with strict inequality witness at a positive element of A; requires 0 ∉ A), first_coordinate_largest (corollary via Fin.val case split), and all_coordinates_positive (tsum_pos with element witness). Together: X lies in the strict cone {x₀ > x₁ > ··· > x_{d-1} > 0}.",
-      "startLine": 185,
-      "endLine": 206,
+      "startLine": 828,
+      "endLine": 864,
       "mathContext": "Fully proves coordinate_decreasing (tsum_lt_tsum), first_coordinate_largest (corollary), all_coordinates_positive (tsum_pos). All proved with no sorries."
     },
     {
       "id": "monotonicity",
       "title": "Dimension Monotonicity",
       "summary": "Defines projectionMap from ℝᵈ² to ℝᵈ¹ for d₁ ≤ d₂ via coordinate restriction. Proves projection_preserves: the same set A generating a d₂-dimensional point also generates its d₁-dimensional projection. Fully proved (Fin lifting via Nat.lt_of_lt_of_le).",
-      "startLine": 207,
-      "endLine": 217,
+      "startLine": 865,
+      "endLine": 877,
       "mathContext": "Defines projectionMap from ℝᵈ² to ℝᵈ¹ for d₁ ≤ d₂ via coordinate restriction. Proves projection_preserves: the projected point is still in harmonicPointSet d₁."
     },
     {
       "id": "examples",
       "title": "Specific Examples",
       "summary": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. Proves squares_convergent (bijection ℕ ≃ squaresSet + p-series for p=2) and powers_convergent (bijection ℕ ≃ powersOf2Set + geometric series). Defines squaresPoint and powers2Point as concrete elements of X. Adds harmonicPointSet_one_eq (X₁ = positive half-line) and harmonicSubseriesSum_surjective_on_pos (every s > 0 achievable).",
-      "startLine": 218,
+      "startLine": 878,
       "endLine": 979,
       "mathContext": "Proves squares_convergent and powers_convergent. Adds two new public theorems: harmonicPointSet_one_eq and harmonicSubseriesSum_surjective_on_pos."
     }


### PR DESCRIPTION
## Summary
Annotation + section drift fix for `erdos-268` (interior of harmonic-subseries points).

The Lean file grew to ~980 lines. Every annotation had been compressed into the first ~280 lines, and the sections had drifted (e.g. "The Point Set X" pointed at 63–87 while its constructs are at 94–118; everything past line 218 was lumped into a catch-all "Specific Examples").

## Changes
- Re-anchored all **20** annotations to their current constructs across the full file (harmonic-subseries definitions, the point-set construction, main theorem, the d=2/d=3/general-dimension results, properties/coordinate/monotonicity theorems, and the squares/powers-of-2 examples).
- Re-mapped all sections to the `Part I–X` markers and added **two previously-missing sections** — "Greedy Harmonic Construction" (Part VIb) and "Unit Fraction Infrastructure" (Part XI) — for full file coverage.

## Verification
`npx tsx scripts/annotations/resolver.ts validate ...` → **20 valid / 0 misaligned**; meta.json parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)