### PR TITLE
research(infinitude-primes-4k1-oq-01): gallery entry for odd-prime two-squares biconditional

### DIFF
--- a/src/data/proofs/infinitude-primes-4k1-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-sq-mod-four",
+    "proofId": "infinitude-primes-4k1-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 59
+    },
+    "type": "lemma",
+    "title": "sq_mod_four — Squares Are 0 or 1 mod 4",
+    "content": "Every perfect square is congruent to 0 or 1 modulo 4. The proof rewrites n² % 4 as (n % 4)² % 4 using `Nat.pow_mod`, then `interval_cases (n % 4)` splits into the four residues 0, 1, 2, 3, each of which `omega` closes (0²=0, 1²=1, 2²=4≡0, 3²=9≡1). This single lemma is the whole obstruction in the backward direction: since squares are only 0 or 1 mod 4, a sum of two squares is 0, 1, or 2 mod 4 and never 3, so a sum of two squares that happens to be odd is forced to be 1 mod 4.",
+    "mathContext": "$n^2 \\bmod 4 \\in \\{0, 1\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues mod 4",
+      "sums of two squares",
+      "Nat.pow_mod reduction"
+    ],
+    "prerequisites": [
+      "Nat.pow_mod: n^k % m = (n % m)^k % m",
+      "interval_cases over a bounded residue",
+      "omega for linear arithmetic over ℕ"
+    ]
+  },
+  {
+    "id": "ann-main-biconditional",
+    "proofId": "infinitude-primes-4k1-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "fermat_two_squares — Odd-Prime Two-Squares Biconditional",
+    "content": "The main result: an odd prime p is a sum of two natural-number squares if and only if p ≡ 1 (mod 4). This is the sharp form of Fermat's theorem on sums of two squares restricted to odd primes — it strengthens Mathlib's one-directional Nat.Prime.sq_add_sq (which only gives p % 4 ≠ 3 ⇒ representable) to a full biconditional by adding the elementary converse. The two hypotheses, p prime and p ≠ 2, are exactly 'p is an odd prime'.",
+    "mathContext": "$p\\ \\text{odd prime} \\Rightarrow \\big(p \\equiv 1 \\pmod 4 \\iff \\exists a\\,b,\\ p = a^2 + b^2\\big)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's theorem on sums of two squares",
+      "Gaussian integers and prime splitting",
+      "quadratic residue −1 mod p"
+    ],
+    "prerequisites": [
+      "Nat.Prime.sq_add_sq (Mathlib)",
+      "biconditional proof by refine ⟨·, ·⟩",
+      "the squares-mod-4 lemma"
+    ]
+  },
+  {
+    "id": "ann-forward-mathlib",
+    "proofId": "infinitude-primes-4k1-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 72
+    },
+    "type": "key-step",
+    "title": "Forward direction via Mathlib's Nat.Prime.sq_add_sq",
+    "content": "The hard direction is delegated to Mathlib. After supplying the `Fact p.Prime` instance, p % 4 = 1 is rewritten to p % 4 ≠ 3 by `omega`, which is exactly the hypothesis of `Nat.Prime.sq_add_sq`. That theorem then produces a, b with a² + b² = p, and `.symm` flips it to p = a² + b². All the genuine number-theoretic depth — that −1 is a quadratic residue mod p ≡ 1 (mod 4) and the ensuing descent / Gaussian-integer factorization — lives inside the Mathlib lemma; this file consumes it as a black box.",
+    "mathContext": "$p \\bmod 4 = 1 \\Rightarrow p \\bmod 4 \\ne 3 \\xRightarrow{\\text{Mathlib}} \\exists a\\,b,\\ a^2 + b^2 = p$",
+    "significance": "high",
+    "relatedConcepts": [
+      "infinite descent",
+      "Fact typeclass instances",
+      "Mathlib SumTwoSquares"
+    ],
+    "prerequisites": [
+      "haveI : Fact p.Prime",
+      "omega to convert = 1 into ≠ 3",
+      "Nat.Prime.sq_add_sq"
+    ]
+  },
+  {
+    "id": "ann-backward-parity",
+    "proofId": "infinitude-primes-4k1-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 91
+    },
+    "type": "key-step",
+    "title": "Backward direction: oddness + squares-mod-4 force p ≡ 1 (mod 4)",
+    "content": "The elementary converse. From p = a² + b² the proof reduces p mod 4 and p mod 2 to the corresponding residues of a² + b². The lemma `sq_mod_four` pins a² % 4, b² % 4 ∈ {0,1}; the parity reductions a² % 2 = (a % 2)² % 2 and the same for b (via `Nat.pow_mod`) pin the mod-2 picture. Crucially, p is odd (`Nat.Prime.eq_two_or_odd` with p ≠ 2 gives p % 2 = 1), which rules out the sum being 0 or 2 mod 4. `omega` assembles these constraints and concludes p % 4 = 1 — no quadratic reciprocity required.",
+    "mathContext": "$p = a^2 + b^2,\\ p\\ \\text{odd} \\Rightarrow p \\bmod 4 = 1$",
+    "significance": "high",
+    "relatedConcepts": [
+      "parity of sums of squares",
+      "case analysis mod 4 and mod 2",
+      "Nat.Prime.eq_two_or_odd"
+    ],
+    "prerequisites": [
+      "sq_mod_four for a and b",
+      "Nat.pow_mod for the mod-2 parity step",
+      "omega closing the residue system"
+    ]
+  },
+  {
+    "id": "ann-mathlib-bearer-context",
+    "proofId": "infinitude-primes-4k1-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 65
+    },
+    "type": "context",
+    "title": "Why both halves are needed for the sharp statement",
+    "content": "Mathlib states Fermat's two-squares result asymmetrically: Nat.Prime.sq_add_sq gives only the existence direction (p % 4 ≠ 3 ⇒ p is a sum of two squares). On its own that does not characterize which primes are sums of two squares — it would also (vacuously) cover any non-3-residue. Pairing it with the elementary converse proved here (a sum of two squares can be 0, 1, or 2 mod 4, and oddness selects 1) upgrades the one-way implication to the biconditional p % 4 = 1 ↔ representable. This is the local representability fact that, summed over primes, drives the infinitude of primes ≡ 1 (mod 4).",
+    "mathContext": "Mathlib gives $\\Rightarrow$; this file adds $\\Leftarrow$ to obtain $\\iff$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "biconditional vs one-directional lemmas",
+      "infinitude of primes ≡ 1 (mod 4)",
+      "norm form of ℤ[i]"
+    ],
+    "prerequisites": [
+      "Mathlib's Nat.Prime.sq_add_sq is one-directional",
+      "the squares-mod-4 converse",
+      "primality giving oddness"
+    ]
+  }
+]

--- a/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "infinitude-primes-4k1-oq-01",
+  "title": "Fermat's Two-Squares Theorem for Odd Primes",
+  "slug": "infinitude-primes-4k1-oq-01",
+  "description": "An odd prime p is a sum of two integer squares if and only if p ≡ 1 (mod 4). This is the odd-prime form of Fermat's theorem on sums of two squares: the biconditional p % 4 = 1 ↔ ∃ a b, p = a² + b². The hard forward direction is supplied by Mathlib's Nat.Prime.sq_add_sq; the easy backward direction is an elementary squares-mod-4 case analysis. It is the OQ-01 follow-up to the gallery entry on the infinitude of primes ≡ 1 (mod 4), pinning down exactly which odd primes the two-squares representation singles out.",
+  "meta": {
+    "author": "Pierre de Fermat (1640) / Leonhard Euler (1749 proof), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_theorem_on_sums_of_two_squares",
+    "date": "1640",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InfinitudePrimes4k1OQ01.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-two-squares",
+      "primes",
+      "quadratic-residues",
+      "modular-arithmetic",
+      "fermat"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.sq_add_sq",
+        "description": "Fermat's two-squares theorem in Mathlib: a prime p with p % 4 ≠ 3 is a sum of two squares, ∃ a b, a² + b² = p. This is the hard analytic/algebraic content (descent / Gaussian-integer factorization), and supplies the forward direction once p % 4 = 1 is rewritten to p % 4 ≠ 3.",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Nat.Prime.eq_two_or_odd",
+        "description": "A prime is either 2 or odd (p % 2 = 1). Used in the backward direction to record that the odd prime p has p % 2 = 1, fixing the parity the mod-4 case analysis must reproduce.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.pow_mod",
+        "description": "n^k % m = (n % m)^k % m, the reduction that lets a²/b² mod 4 (and mod 2) be computed from a % 4 / a % 2 by a finite interval_cases split.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Packages the hard Mathlib bearer Nat.Prime.sq_add_sq into the sharp biconditional form p % 4 = 1 ↔ ∃ a b, p = a² + b² for odd primes, rather than the one-directional p % 4 ≠ 3 ⇒ representable that Mathlib states",
+      "A self-contained squares-mod-4 lemma sq_mod_four (n² % 4 ∈ {0,1}) proved by Nat.pow_mod plus a four-case interval_cases on n % 4 and omega",
+      "An elementary backward direction: from p = a² + b² and the oddness of p, an omega-closed case analysis on (a² % 4, b² % 4) and the parities a² % 2, b² % 2 forces p % 4 = 1, with no appeal to quadratic reciprocity"
+    ],
+    "dateAdded": "2026-06-16",
+    "relatedProblems": [
+      {
+        "id": "infinitude-primes-4k1",
+        "relationship": "Parent gallery entry. The infinitude of primes ≡ 1 (mod 4) uses the forward two-squares fact implicitly (via −1 being a quadratic residue mod such primes); this OQ-01 entry isolates the exact representability biconditional for a single odd prime."
+      },
+      {
+        "id": "fermat-two-squares",
+        "relationship": "Stronger sibling. fermat-two-squares proves the full biconditional ∃ a b, a²+b² = p ↔ p % 4 ≠ 3 covering also p = 2, plus the classification corollaries. This file is the odd-prime-only wrapper over the same Mathlib bearer and the same squares-mod-4 step."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 93,
+    "assumptions": "0 axioms, 0 sorries. The hypotheses are that p is prime and p ≠ 2 (i.e. p is an odd prime), both inputs to the statement rather than standing assumptions. The hard forward direction is discharged by the Mathlib theorem Nat.Prime.sq_add_sq; the backward direction is fully elementary. Every lemma and the main theorem are machine-checked.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Fermat announced in a 1640 letter to Mersenne that an odd prime is a sum of two squares precisely when it leaves remainder 1 on division by 4 — for example 5 = 1 + 4, 13 = 4 + 9, 17 = 1 + 16, while 3, 7, 11 admit no such representation. He claimed a proof by infinite descent but, as usual, published none; the first complete proof is due to Euler (1749), who carried out the descent in detail. The result is one of the founding theorems of algebraic number theory: it is equivalent to the statement that a rational prime p ≡ 1 (mod 4) splits in the Gaussian integers ℤ[i], p = (a + bi)(a − bi), while p ≡ 3 (mod 4) stays inert.\n\nThe 'hard' half — that p ≡ 1 (mod 4) actually is a sum of two squares — rests on −1 being a quadratic residue modulo such p, followed by a descent or a Gaussian-integer / Minkowski lattice argument. The 'easy' half — that a sum of two squares is never ≡ 3 (mod 4) — is the observation that squares are 0 or 1 mod 4, so a²+b² is 0, 1, or 2 mod 4 but never 3. Mathlib packages the hard half as Nat.Prime.sq_add_sq; this entry supplies the easy half and assembles the two into the sharp odd-prime biconditional.",
+    "problemStatement": "Let $p$ be an odd prime. Then\n\n$$p \\equiv 1 \\pmod 4 \\iff \\exists\\, a, b \\in \\mathbb{N},\\ p = a^2 + b^2.$$",
+    "text": "Among odd primes, exactly those congruent to 1 mod 4 can be written as a sum of two squares. The forward direction is Mathlib's Fermat two-squares theorem; the backward direction is the elementary fact that a sum of two squares is never 3 mod 4, so an odd sum of two squares must be 1 mod 4.",
+    "proofStrategy": "The main theorem fermat_two_squares is a biconditional proved direction by direction.\n\nForward (p % 4 = 1 ⇒ representable): instantiate the Fact p.Prime instance, rewrite p % 4 = 1 to p % 4 ≠ 3 by omega, and apply Mathlib's Nat.Prime.sq_add_sq to obtain a, b with a² + b² = p; symmetry gives p = a² + b².\n\nBackward (representable ⇒ p % 4 = 1): from p = a² + b², record p % 2 = 1 via Nat.Prime.eq_two_or_odd and the hypothesis p ≠ 2. The supporting lemma sq_mod_four shows every square is 0 or 1 mod 4 (proved by Nat.pow_mod and interval_cases on n % 4). Feeding sq_mod_four a and sq_mod_four b, together with the parity facts a² % 2 = (a % 2)² % 2 and the analogous statement for b (again Nat.pow_mod), leaves an arithmetic system that omega closes: the only way an odd p = a² + b² can sit mod 4 is p % 4 = 1.",
+    "keyInsights": [
+      "**Squares are 0 or 1 mod 4**: n² % 4 ∈ {0, 1} (lemma sq_mod_four) is the entire obstruction — a sum of two squares is 0, 1, or 2 mod 4, never 3, so once the sum is known odd it must be 1 mod 4",
+      "**The sharp biconditional needs both halves**: Mathlib's Nat.Prime.sq_add_sq gives only p % 4 ≠ 3 ⇒ representable; the converse (representable ⇒ the right residue) is the elementary mod-4 computation supplied here, and only together do they pin down p ≡ 1 (mod 4)",
+      "**Nat.pow_mod turns residue claims into finite case splits**: rewriting n² % 4 as (n % 4)² % 4 reduces an infinite family of squares to four cases n % 4 ∈ {0,1,2,3}, each closed by omega — the same device handles the parity step mod 2",
+      "**Oddness of p does the disambiguation**: a sum of two squares can be 0, 1, or 2 mod 4; the prime's oddness (p % 2 = 1) rules out 0 and 2, leaving exactly 1"
+    ],
+    "prerequisites": [
+      "Modular arithmetic: residues mod 4 and mod 2, and the reduction n^k % m = (n % m)^k % m",
+      "Fermat's theorem on sums of two squares as packaged by Mathlib's Nat.Prime.sq_add_sq",
+      "The fact that a prime is either 2 or odd",
+      "Finite case analysis with interval_cases and arithmetic closure with omega"
+    ]
+  },
+  "sections": [
+    {
+      "id": "squares-mod-four",
+      "title": "Squares Are 0 or 1 mod 4",
+      "startLine": 54,
+      "endLine": 59,
+      "mathContext": "$n^2 \\bmod 4 \\in \\{0, 1\\}$ for every $n \\in \\mathbb{N}$.",
+      "summary": "The lemma sq_mod_four: rewriting n² % 4 as (n % 4)² % 4 by Nat.pow_mod and splitting on n % 4 ∈ {0,1,2,3} via interval_cases, each branch is closed by omega. This is the obstruction powering the backward direction — a sum of two squares is never 3 mod 4."
+    },
+    {
+      "id": "main-biconditional",
+      "title": "Fermat's Two-Squares Biconditional for Odd Primes",
+      "startLine": 61,
+      "endLine": 91,
+      "mathContext": "$p\\ \\text{odd prime} \\Rightarrow \\big(p \\equiv 1 \\pmod 4 \\iff \\exists a\\,b,\\ p = a^2 + b^2\\big).$",
+      "summary": "The theorem fermat_two_squares. Forward: rewrite p % 4 = 1 to p % 4 ≠ 3 and apply Mathlib's Nat.Prime.sq_add_sq. Backward: use oddness of p (Nat.Prime.eq_two_or_odd) and the squares-mod-4 lemma on a and b, plus the mod-2 parity reductions, to let omega force p % 4 = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The odd-prime form of Fermat's two-squares theorem is formalized in Lean 4 with zero sorries and zero axioms: for an odd prime p, p ≡ 1 (mod 4) ⇔ p is a sum of two integer squares. The hard forward direction is Mathlib's Nat.Prime.sq_add_sq; the backward direction is the elementary squares-mod-4 argument (sq_mod_four: n² % 4 ∈ {0,1}) combined with the oddness of p and closed by omega.",
+    "implications": "This biconditional is the local representability statement behind the infinitude of primes ≡ 1 (mod 4): each such prime contributes a Gaussian-integer splitting p = (a+bi)(a−bi). It is the prime base case from which the full sum-of-two-squares classification (a positive integer is a sum of two squares iff every prime ≡ 3 mod 4 in its factorization occurs to an even power) is built by multiplicativity of the norm form.",
+    "openQuestions": [
+      "Can the entry be strengthened in place to the p = 2 case and the full classification, matching fermat-two-squares, or is the odd-prime wrapper the right granularity for the infinitude-primes-4k1 research line?",
+      "Does the backward (squares-mod-4) direction generalize cleanly to characterize which primes are represented by other norm forms a² + 2b² and a² + 3b² (p ≡ 1, 3 mod 8 and p ≡ 1 mod 3 respectively)?",
+      "Can the Gaussian-integer splitting p = (a+bi)(a−bi) implied by this representation be made explicit in Lean to connect the residue condition to the factorization behavior in ℤ[i]?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes-4k1",
+      "relationship": "extends",
+      "description": "Parent entry on the infinitude of primes ≡ 1 (mod 4). This OQ-01 follow-up isolates the exact two-squares representability biconditional for a single odd prime that underlies the infinitude argument."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "The full Fermat two-squares classification (covering p = 2 and composite n). This entry is the odd-prime-only biconditional over the same Mathlib bearer Nat.Prime.sq_add_sq and the same squares-mod-4 step."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/InfinitudePrimes4k1OQ01.lean",
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.NumberTheory.SumTwoSquares",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "InfinitudePrimes4k1OQ01",
+    "lineCount": 93,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`proofs/Proofs/InfinitudePrimes4k1OQ01.lean` (93 lines, 0 sorry / 0 axiom, registered in `Proofs/Proofs.lean:2510`, Mathlib-only, no `native_decide`/`decide`) was a **complete-but-ungalleried** proof — it had no `src/data/proofs/` directory. This PR adds the gallery entry. JSON-only; no Lean changes.

The theorem is the sharp odd-prime form of **Fermat's theorem on sums of two squares**:

> For an odd prime `p`:  `p % 4 = 1  ↔  ∃ a b, p = a² + b²`.

- **Forward** (hard): delegated to Mathlib's `Nat.Prime.sq_add_sq` after rewriting `p % 4 = 1` to `p % 4 ≠ 3`.
- **Backward** (elementary): `sq_mod_four` (`n² % 4 ∈ {0,1}`, via `Nat.pow_mod` + `interval_cases` + `omega`) plus the oddness of `p` (`Nat.Prime.eq_two_or_odd`) force `p % 4 = 1` — no quadratic reciprocity.

This is the OQ-01 follow-up to the `infinitude-primes-4k1` gallery entry; it isolates the local two-squares representability fact behind the infinitude argument.

## Files

- `src/data/proofs/infinitude-primes-4k1-oq-01/meta.json` — status `verified`, badge `mathlib`, `axiomCount: 0`
- `src/data/proofs/infinitude-primes-4k1-oq-01/annotations.json` — 5 annotations

## Validation

- `meta.json` and `annotations.json` parse cleanly (`node JSON.parse`).
- `validateLineAnnotations` (resolver): **5/5 valid, 0 misaligned**, anchored to `sq_mod_four` (lemma 54–59) and `fermat_two_squares` (theorem 61–91).
- All `crossReferences` / `relatedProblems` target ids exist (`infinitude-primes-4k1`, `fermat-two-squares`).

## Notes

- The Lean file's own header notes it is a pedagogical odd-prime wrapper superseded *for downstream code reuse* by `FermatTwoSquares.lean`; this gallery entry is the registered artifact for the distinct `infinitude-primes-4k1-oq-01` research line and is cross-linked to the stronger `fermat-two-squares` entry. Badge is `mathlib` (the hard direction is Mathlib's `Nat.Prime.sq_add_sq`), not `original`.
- No `loom:review-requested` — the deployer merges math gallery PRs directly.

## Test plan

- [x] Both JSON files valid
- [x] Resolver annotation validation 5/5
- [x] crossRef ids resolve
- [ ] `pnpm build` gallery render (deployer/CI)