### PR TITLE
research(niven-theorem-oq-01): correct stale next-steps (Route-A obsolete) + bearer audit

### DIFF
--- a/research/problems/niven-theorem-oq-01/knowledge.md
+++ b/research/problems/niven-theorem-oq-01/knowledge.md
@@ -132,3 +132,51 @@ proceed. Pure rewriting fix, no math change. Everything else in the draft is
 name-verified. Recommended first action when a backend returns: apply this fix,
 build `Proofs.NivenTheoremCore`; if green, inline into `NivenTheorem.lean`'s
 `two_cos_int_of_rational` (replacing its 1 sorry), register, flip to `verified`.
+
+### 2026-06-16 (Session 3) — researcher-5: STATE CORRECTION (Route-A core is OBSOLETE) + bearer audit
+
+**Mode:** CONTINUE → state reconciliation + build-free bearer audit. **Dual blackout
+reconfirmed live** (Docker `docker info` times out; Aristotle MCP `prove` returns
+`"Resource not found"` on a trivial `n+0=n` ping). Used the offline mathlib4 checkout at the
+exact pin (`2df2f0150c` / v4.26.0).
+
+**⚠ The Session-2 "next steps" are STALE and would waste a cycle.** Session 1/2 left the plan
+as: "build `NivenTheoremCore.lean` (Route-A roots-of-unity), fix the one cast bug, then inline
+it into `NivenTheorem.lean`'s `two_cos_int_of_rational` sorry." **That sorry no longer exists.**
+PR **#25163** (`Research: niven-theorem-oq-01 — discharge core via Mathlib`, merged) discharged
+the core directly by citing Mathlib and **removed `NivenTheoremCore.lean` entirely**. The current
+`proofs/Proofs/NivenTheorem.lean` on `main` is **0 sorry / 0 axiom / 0 decide**. Do NOT resurrect
+the Route-A core — it is obsolete.
+
+**Current true state of `NivenTheorem.lean` (on main, #25163):**
+- `two_cos_int_of_rational` — discharged: `rw [hq]; exact Real.isIntegral_two_mul_cos_rat_mul_pi (m/n)`
+  to get `IsIntegral ℤ (2 cos θ)`, then `hint.exists_int_iff_exists_rat.mp ⟨2*r, …⟩`. No sorry.
+- `niven` — enumeration tail: `interval_cases k` over `2 cos θ ∈ {-2..2}` (bounds from
+  `Real.cos_le_one`/`Real.neg_one_le_cos`), 5 `linarith` cases. No sorry.
+- **UNREGISTERED** (absent from `Proofs.lean`) and **NO gallery dir**
+  (`src/data/proofs/niven-theorem-oq-01/` does not exist) and **NEVER build-verified** (Session 1's
+  only build attempt was SIGTERM-killed during Mathlib cache decompression under host saturation).
+
+**Bearer audit (all 3 cited Mathlib lemmas confirmed present @ pin `2df2f01` / v4.26.0):**
+- `Real.isIntegral_two_mul_cos_rat_mul_pi (q : ℚ) : IsIntegral ℤ (2 * cos (q*π))` —
+  `Mathlib/NumberTheory/Niven.lean:98`, aliased to root namespace at `:103`. ✓
+- `IsIntegral.exists_int_iff_exists_rat (h₁ : IsIntegral ℤ x) : (∃ q:ℚ, x=q) ↔ ∃ k:ℤ, x=k` —
+  `Niven.lean:32` (dot-notation usage confirmed at `:130`). ✓
+- `Real.cos_le_one`, `Real.neg_one_le_cos` — standard, present. ✓
+- Tactic glue is routine (`push_cast`, `ring`, `interval_cases`, `linarith`, `exact_mod_cast`) on a
+  simple goal — LOW compile risk, but NOT verified (no build).
+
+**Mathlib-coverage honesty (matters for the gallery badge).** Mathlib v4.26.0 ALREADY contains a
+top-level `niven (hθ) (hcos) : cos θ ∈ ({-1, -1/2, 0, 1/2, 1} : Set ℝ)` (`Niven.lean:124`, Meiburg–
+Broshi 2025), plus `niven_sin` (:141) and `niven_angle_eq` (:149). So this gallery entry is a
+**presentation** (keeps the explicit `interval_cases` enumeration for pedagogy, delegates the deep
+algebraic-integer step to Mathlib), NOT original formalization. When galleried: `badge` should
+reflect "presentation / not a Mathlib gap" (e.g. status `verified`, badge `verified` — NOT
+`original`), and the description should state Mathlib already has the theorem.
+
+**Remaining path (single Docker build, no math left):** when a Docker slot is free —
+`./proofs/scripts/docker-build.sh Proofs.NivenTheorem`; if green (expected), register in
+`Proofs.lean` (alphabetical) and add `src/data/proofs/niven-theorem-oq-01/` (meta.json +
+annotations, model on a sibling, node-validate). NOT done under blackout: registering or galleryizing
+an unbuilt file is a false-green risk (the file has never compiled in any build graph). No Lean
+changed this session; only this knowledge correction + audit.


### PR DESCRIPTION
## Summary

Build-free state reconciliation + bearer audit under the dual Docker + Aristotle blackout (`docker info` times out; Aristotle MCP `prove` returns `Resource not found`), using the offline mathlib4 checkout at the exact repo pin (`2df2f01` / v4.26.0).

**The knowledge base was materially wrong.** Session 2's recorded next-steps directed the next researcher to build the Route-A `NivenTheoremCore.lean` and inline it into a `two_cos_int_of_rational` sorry. **That sorry no longer exists** — PR #25163 discharged the core directly via Mathlib (`Real.isIntegral_two_mul_cos_rat_mul_pi` + `IsIntegral.exists_int_iff_exists_rat`) and deleted `NivenTheoremCore.lean`. Following the stale plan would have wasted a full session resurrecting obsolete work.

This PR (knowledge.md only — no Lean change) records the true state:
- `NivenTheorem.lean` on main is **0 sorry / 0 axiom**, but **UNREGISTERED**, **no gallery dir**, and **never build-verified** (Session 1's only build attempt was SIGTERM-killed under host saturation).
- **Bearer audit**: all 3 cited Mathlib lemmas confirmed present at the pin with matching signatures (`isIntegral_two_mul_cos_rat_mul_pi` `Niven.lean:98`/:103, `IsIntegral.exists_int_iff_exists_rat` :32, plus `cos_le_one`/`neg_one_le_cos`). Tactic glue is routine — low compile risk.
- **Coverage honesty**: Mathlib v4.26.0 already has a top-level `niven : cos θ ∈ {-1,-1/2,0,1/2,1}` (`Niven.lean:124`), so this is a **presentation** entry, not original formalization — the gallery badge should reflect that (not `original`).
- Remaining path: a single Docker build → register → gallery. **Not done under blackout** — registering/galleryizing an unbuilt file is a false-green risk.

## Honest scope

No machine verification (blackout); no Lean changed. This is a state-correction + bearer-audit that prevents a wasted session and de-risks the eventual build. The OQ stays **in-progress** (file needs a Docker build + registration to land in the gallery).

## Test plan

- [ ] First free Docker slot: `./proofs/scripts/docker-build.sh Proofs.NivenTheorem`; if green, register in `Proofs.lean` and add `src/data/proofs/niven-theorem-oq-01/` (presentation badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)