### PR TITLE
Enrich power-mean negative-exponent equality case: add annotations

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-neg-overview",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 23 },
+    "type": "concept",
+    "title": "Negative Exponents by Reciprocal Duality",
+    "content": "The docstring frames the strategy: rather than re-running the strict-Jensen convexity argument below zero, the negative-exponent equality case is obtained as a corollary of the already-proved positive case via the duality M_p(z,w) = M_{-p}(z⁻¹,w)⁻¹. The file mirrors the compiled template power_mean_monotone_neg line-for-line for the duality bookkeeping, and is registered + build-verified (0 sorry / 0 axiom). The cross-zero regime r < 0 < t is explicitly left as separate follow-up because it must pass through the geometric mean M₀, outside weightedPowerMean's p ≠ 0 domain.",
+    "mathContext": "$M_p(z,w) = M_{-p}(z^{-1},w)^{-1}$; the harmonic mean ($p=-1$) sits at the bottom of the power-mean hierarchy.",
+    "significance": "context",
+    "relatedConcepts": ["power means", "reciprocal duality", "harmonic mean", "Hardy–Littlewood–Pólya"],
+    "prerequisites": ["power-mean inequality", "mean hierarchy"]
+  },
+  {
+    "id": "ann-neg-statement",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 35 },
+    "type": "theorem",
+    "title": "Equality Characterization for r < t < 0",
+    "content": "power_mean_eq_iff_all_eq_neg states that, for positive weights summing to 1 and positive values, with both exponents strictly negative and r < t, the weighted power means at r and t coincide exactly when all values are equal. The hypotheses hrne, htne (r,t ≠ 0) are needed because weightedPowerMean is only defined for nonzero exponents — its 1/p exponent is meaningless at p = 0.",
+    "mathContext": "$M_r(z,w) = M_t(z,w) \\iff \\forall j,k,\\ z_j = z_k$, for $r < t < 0$, where $M_p(z,w) = \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
+    "significance": "critical",
+    "relatedConcepts": ["power means", "equality case", "strict inequality sharpness"],
+    "prerequisites": ["weighted power means", "real exponents"]
+  },
+  {
+    "id": "ann-neg-setup-duality",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 36, "endLine": 41 },
+    "type": "tactic",
+    "title": "Sign Flips and Inverting the Means",
+    "content": "The setup records the positivity of the inverted values z⁻¹ (inv_pos) and the order-reversing sign flips: 0 < -t < -r follows from r < t < 0 by neg_pos and neg_lt_neg. Then power_mean_neg_inv rewrites both M_r(z) and M_t(z) as M_{-r}(z⁻¹)⁻¹ and M_{-t}(z⁻¹)⁻¹, and inv_inj strips the outer inversions — converting the goal M_r(z) = M_t(z) into M_{-r}(z⁻¹) = M_{-t}(z⁻¹), now at positive exponents.",
+    "mathContext": "$r < t < 0 \\Rightarrow 0 < -t < -r$; \\; $M_r(z) = M_t(z) \\iff M_{-r}(z^{-1}) = M_{-t}(z^{-1})$ via $\\mathrm{inv\\_inj}$.",
+    "significance": "key",
+    "relatedConcepts": ["inv_inj", "neg_lt_neg", "order reversal under negation", "power_mean_neg_inv"],
+    "prerequisites": ["ordered fields", "Mathlib inversion lemmas"]
+  },
+  {
+    "id": "ann-neg-apply-positive",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 44 },
+    "type": "tactic",
+    "title": "Reduce to the Positive-Exponent Theorem",
+    "content": "Because the smaller positive exponent is -t (not -r), eq_comm reorders the goal to M_{-t}(z⁻¹) = M_{-r}(z⁻¹), matching the r < t convention of power_mean_eq_iff_all_eq_pos. That theorem, instantiated at the inverted values z⁻¹ and exponents -t < -r, rewrites the means-equality into the all-equal condition on the inverted values: ∀ j k, (z_j)⁻¹ = (z_k)⁻¹.",
+    "mathContext": "$M_{-t}(z^{-1}) = M_{-r}(z^{-1}) \\iff \\forall j,k,\\ (z_j)^{-1} = (z_k)^{-1}$, by the positive-exponent equality case.",
+    "significance": "key",
+    "relatedConcepts": ["eq_comm", "theorem reuse", "positive-exponent equality case"],
+    "prerequisites": ["power_mean_eq_iff_all_eq_pos"]
+  },
+  {
+    "id": "ann-neg-transport",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 47 },
+    "type": "tactic",
+    "title": "Transport All-Equal Through Inversion",
+    "content": "The final constructor closes both directions of the iff by applying inv_inj to the values: (z_j)⁻¹ = (z_k)⁻¹ converts to z_j = z_k via inv_inj.mp, and back via inv_inj.mpr. This is the second use of inv_inj in the proof — once on the means, once on the values — completing the round trip through z ↦ z⁻¹.",
+    "mathContext": "$(z_j)^{-1} = (z_k)^{-1} \\iff z_j = z_k$ (injectivity of inversion on the positive reals).",
+    "significance": "supporting",
+    "relatedConcepts": ["inv_inj", "iff transport", "injectivity"],
+    "prerequisites": ["logical equivalences", "group inversion"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01`

This entry had a rich, accurate `meta.json` but **no `annotations.json`** (quality score 33). Added 5 inline annotations covering the full 49-line proof.

### Added annotations.json (5 annotations, resolver 5/0)
1. **Overview** — the reciprocal-duality strategy and build-verified/registered status
2. **Theorem statement** — `power_mean_eq_iff_all_eq_neg` for `r < t < 0`
3. **Sign flips + inverting the means** — `0 < -t < -r`, `power_mean_neg_inv`, `inv_inj`
4. **Reduce to the positive case** — `eq_comm` + `power_mean_eq_iff_all_eq_pos`
5. **Transport all-equal through inversion** — second use of `inv_inj`

Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

### Verification
- JSON parses cleanly; `validateLineAnnotations` against the Lean source: **5 valid / 0 misaligned**.
- Confirmed meta accuracy against the registered (Proofs.lean:412), build-verified source: no `native_decide`, no `sorry`, no `axiom` → `verified`/`original`/`axiomCount: 0` is correct.
- No `.lean` files touched.