### PR TITLE
Enrich erdos-282: re-anchor 16 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-282/annotations.json
+++ b/src/data/proofs/erdos-282/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-e282-imports",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 25,
-      "endLine": 28
+      "startLine": 1,
+      "endLine": 27
     },
     "type": "concept",
     "title": "Imports",
@@ -26,7 +26,7 @@
     "proofId": "erdos-282",
     "range": {
       "startLine": 32,
-      "endLine": 36
+      "endLine": 35
     },
     "type": "definition",
     "title": "Egyptian Fraction Representation",
@@ -49,7 +49,7 @@
     "id": "ann-e282-representable",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 38,
+      "startLine": 37,
       "endLine": 40
     },
     "type": "definition",
@@ -70,8 +70,8 @@
     "id": "ann-e282-greedy-step",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 42,
-      "endLine": 44
+      "startLine": 75,
+      "endLine": 80
     },
     "type": "concept",
     "title": "Greedy Step",
@@ -93,8 +93,8 @@
     "id": "ann-e282-greedy-step-mem",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 46,
-      "endLine": 48
+      "startLine": 81,
+      "endLine": 87
     },
     "type": "concept",
     "title": "Greedy Step Membership",
@@ -115,8 +115,8 @@
     "id": "ann-e282-greedy-step-le",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 50,
-      "endLine": 53
+      "startLine": 88,
+      "endLine": 95
     },
     "type": "concept",
     "title": "Greedy Step Inequality",
@@ -137,8 +137,8 @@
     "id": "ann-e282-greedy-terminates",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 55,
-      "endLine": 57
+      "startLine": 96,
+      "endLine": 101
     },
     "type": "definition",
     "title": "Greedy Termination",
@@ -159,8 +159,8 @@
     "id": "ann-e282-fibonacci",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 61,
-      "endLine": 64
+      "startLine": 103,
+      "endLine": 107
     },
     "type": "concept",
     "title": "Fibonacci's Theorem (1202)",
@@ -182,8 +182,8 @@
     "id": "ann-e282-odd-positives",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 68,
-      "endLine": 69
+      "startLine": 109,
+      "endLine": 110
     },
     "type": "definition",
     "title": "Odd Positive Integers",
@@ -205,8 +205,8 @@
     "id": "ann-e282-has-odd-denom",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 71,
-      "endLine": 73
+      "startLine": 113,
+      "endLine": 114
     },
     "type": "definition",
     "title": "Odd Denominator Predicate",
@@ -228,8 +228,8 @@
     "id": "ann-e282-stein-conjecture",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 75,
-      "endLine": 81
+      "startLine": 121,
+      "endLine": 126
     },
     "type": "concept",
     "title": "Stein's Odd Greedy Conjecture",
@@ -252,8 +252,8 @@
     "id": "ann-e282-cong-class",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 85,
-      "endLine": 86
+      "startLine": 127,
+      "endLine": 128
     },
     "type": "definition",
     "title": "Congruence Class",
@@ -274,8 +274,8 @@
     "id": "ann-e282-graham",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 88,
-      "endLine": 93
+      "startLine": 136,
+      "endLine": 142
     },
     "type": "concept",
     "title": "Graham's Representability (1964)",
@@ -298,8 +298,8 @@
     "id": "ann-e282-perfect-squares",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 97,
-      "endLine": 98
+      "startLine": 143,
+      "endLine": 144
     },
     "type": "definition",
     "title": "Perfect Squares",
@@ -321,8 +321,8 @@
     "id": "ann-e282-squares-conjecture",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 100,
-      "endLine": 103
+      "startLine": 148,
+      "endLine": 155
     },
     "type": "concept",
     "title": "Erdős-Graham Squares Conjecture",
@@ -344,8 +344,8 @@
     "id": "ann-e282-greedy-implies-repr",
     "proofId": "erdos-282",
     "range": {
-      "startLine": 107,
-      "endLine": 112
+      "startLine": 156,
+      "endLine": 160
     },
     "type": "concept",
     "title": "Greedy Implies Representable",


### PR DESCRIPTION
## Summary
Annotation drift fix for `erdos-282` (greedy algorithm for Egyptian fractions).

Annotations had drifted off their constructs as the Lean file grew — the greedy-step annotations sat on helper lemmas, and several definition/conjecture annotations pointed at the wrong lines.

## Changes
- Re-anchored all **16** annotations to their current constructs: the Egyptian-fraction and representability definitions, the `greedyStep` theorems, the Fibonacci and Stein results, Graham representability, the congruence-class and perfect-squares definitions, and the Erdős–Graham squares conjecture.
- Annotations-only; sections were already aligned to the `## Part` markers.

## Verification
`npx tsx scripts/annotations/resolver.ts validate ...` → **16 valid / 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)