### PR TITLE
Enrich erdos-358: re-anchor 16 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-358/annotations.json
+++ b/src/data/proofs/erdos-358/annotations.json
@@ -22,8 +22,8 @@
     "id": "ann-358-intseq",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 35,
-      "endLine": 39
+      "startLine": 36,
+      "endLine": 38
     },
     "type": "definition",
     "title": "IntSequence Structure",
@@ -40,8 +40,8 @@
     "id": "ann-358-count",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 40,
-      "endLine": 45
+      "startLine": 42,
+      "endLine": 44
     },
     "type": "definition",
     "title": "Consecutive Sum Count f(n)",
@@ -58,8 +58,8 @@
     "id": "ann-358-naturals",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 48,
-      "endLine": 56
+      "startLine": 49,
+      "endLine": 51
     },
     "type": "definition",
     "title": "Natural Numbers Sequence",
@@ -76,8 +76,8 @@
     "id": "ann-358-formula",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 57,
-      "endLine": 67
+      "startLine": 81,
+      "endLine": 87
     },
     "type": "concept",
     "title": "Consecutive Sum Formula",
@@ -94,8 +94,8 @@
     "id": "ann-358-classic",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 62,
-      "endLine": 67
+      "startLine": 198,
+      "endLine": 211
     },
     "type": "concept",
     "title": "Classical Characterization",
@@ -112,8 +112,8 @@
     "id": "ann-358-odd-divisors",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 68,
-      "endLine": 71
+      "startLine": 216,
+      "endLine": 230
     },
     "type": "concept",
     "title": "Odd Divisors Connection",
@@ -130,8 +130,8 @@
     "id": "ann-358-strong",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 74,
-      "endLine": 81
+      "startLine": 402,
+      "endLine": 403
     },
     "type": "definition",
     "title": "Strong Conjecture",
@@ -148,8 +148,8 @@
     "id": "ann-358-weak",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 83,
-      "endLine": 89
+      "startLine": 410,
+      "endLine": 411
     },
     "type": "definition",
     "title": "Weak Conjecture",
@@ -166,8 +166,8 @@
     "id": "ann-358-egami",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 95,
-      "endLine": 103
+      "startLine": 421,
+      "endLine": 425
     },
     "type": "concept",
     "title": "Egami's Observation",
@@ -183,8 +183,8 @@
     "id": "ann-358-power2",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 104,
-      "endLine": 111
+      "startLine": 491,
+      "endLine": 495
     },
     "type": "concept",
     "title": "Power of 2 Obstruction",
@@ -201,8 +201,8 @@
     "id": "ann-358-primes",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 114,
-      "endLine": 124
+      "startLine": 527,
+      "endLine": 548
     },
     "type": "concept",
     "title": "The Prime Sequence Case",
@@ -219,8 +219,8 @@
     "id": "ann-358-density",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 131,
-      "endLine": 144
+      "startLine": 564,
+      "endLine": 565
     },
     "type": "definition",
     "title": "Density Conjecture",
@@ -237,8 +237,8 @@
     "id": "ann-358-related",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 145,
-      "endLine": 154
+      "startLine": 570,
+      "endLine": 579
     },
     "type": "concept",
     "title": "Related Problems",
@@ -255,8 +255,8 @@
     "id": "ann-358-status",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 156,
-      "endLine": 173
+      "startLine": 581,
+      "endLine": 597
     },
     "type": "concept",
     "title": "Current Status Summary",
@@ -273,8 +273,8 @@
     "id": "ann-358-main",
     "proofId": "erdos-358",
     "range": {
-      "startLine": 175,
-      "endLine": 183
+      "startLine": 602,
+      "endLine": 606
     },
     "type": "concept",
     "title": "Status Theorem",


### PR DESCRIPTION
## Summary
The Erdős Problem #358 Lean file (`Proofs/Erdos358Problem.lean`) grew to 608 lines, leaving all 16 gallery annotations anchored to stale line ranges in the first ~183 lines. The constructs they describe (the Strong/Weak conjecture definitions, the prime-case definitions, the status blocks) now live 200–400 lines lower. This is a clean positional-shift re-anchor (flavor-1): every named construct still exists; only the annotation `range`s were stale.

- Resolver validation: **16 valid / 0 misaligned** (was 13 valid / 3 hard type-clashes on the `definition`-typed `Erdos358Strong`, `Erdos358Weak`, and `PositiveDensityConjecture`).
- Re-anchored each annotation to its current construct: `IntSequence`/`consecutiveSumCount`/`naturalsSeq` defs, `consecutive_sum_formula`/`consecutive_sum_char`/`naturals_count_odd_divisors`, the Strong/Weak conjectures (402/410), Egami observation (421), `power_of_two_obstruction` (494), prime case (527), `PositiveDensityConjecture` (564), and the Part VII/VIII/IX status blocks.
- Annotations-only change; `meta.json` sections already align to the `## Part` markers and are untouched. No content rewritten.

## Test plan
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 16/0