### PR TITLE
Enrich erdos-977: re-anchor 16 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-977/annotations.json
+++ b/src/data/proofs/erdos-977/annotations.json
@@ -18,8 +18,8 @@
       "Nat.Primes in Mathlib"
     ],
     "range": {
-      "startLine": 30,
-      "endLine": 71
+      "startLine": 33,
+      "endLine": 40
     }
   },
   {
@@ -40,8 +40,8 @@
       "prime divisor existence"
     ],
     "range": {
-      "startLine": 30,
-      "endLine": 71
+      "startLine": 42,
+      "endLine": 44
     }
   },
   {
@@ -62,8 +62,8 @@
       "existence of prime factors"
     ],
     "range": {
-      "startLine": 30,
-      "endLine": 71
+      "startLine": 46,
+      "endLine": 48
     }
   },
   {
@@ -85,7 +85,7 @@
     ],
     "range": {
       "startLine": 57,
-      "endLine": 59
+      "endLine": 58
     }
   },
   {
@@ -107,8 +107,8 @@
       "limit definition"
     ],
     "range": {
-      "startLine": 72,
-      "endLine": 82
+      "startLine": 75,
+      "endLine": 77
     }
   },
   {
@@ -131,8 +131,8 @@
       "Baker's theory basics"
     ],
     "range": {
-      "startLine": 72,
-      "endLine": 82
+      "startLine": 79,
+      "endLine": 81
     }
   },
   {
@@ -154,8 +154,8 @@
       "Fermat's little theorem"
     ],
     "range": {
-      "startLine": 72,
-      "endLine": 82
+      "startLine": 85,
+      "endLine": 92
     }
   },
   {
@@ -177,8 +177,8 @@
       "iterated logarithm"
     ],
     "range": {
-      "startLine": 85,
-      "endLine": 95
+      "startLine": 97,
+      "endLine": 110
     }
   },
   {
@@ -198,8 +198,8 @@
       "Mersenne number definition"
     ],
     "range": {
-      "startLine": 85,
-      "endLine": 95
+      "startLine": 112,
+      "endLine": 130
     }
   },
   {
@@ -221,8 +221,8 @@
       "divisibility of 2^n - 1"
     ],
     "range": {
-      "startLine": 57,
-      "endLine": 59
+      "startLine": 134,
+      "endLine": 135
     }
   },
   {
@@ -243,8 +243,8 @@
       "P(p) = p for primes"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 112
+      "startLine": 137,
+      "endLine": 145
     }
   },
   {
@@ -266,8 +266,8 @@
       "comparison with Mersenne case"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 112
+      "startLine": 149,
+      "endLine": 156
     }
   },
   {
@@ -288,8 +288,8 @@
       "sieve theory basics"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 112
+      "startLine": 158,
+      "endLine": 162
     }
   },
   {
@@ -310,8 +310,8 @@
       "multiplicative order mod p"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 229
+      "startLine": 167,
+      "endLine": 169
     }
   },
   {
@@ -333,8 +333,8 @@
       "Mersenne number factorization"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 229
+      "startLine": 171,
+      "endLine": 179
     }
   },
   {
@@ -356,8 +356,8 @@
       "Lagrange's theorem for finite groups"
     ],
     "range": {
-      "startLine": 97,
-      "endLine": 229
+      "startLine": 183,
+      "endLine": 197
     }
   }
 ]


### PR DESCRIPTION
## Summary
The Erdős Problem #977 Lean file (`Proofs/Erdos977Problem.lean`, greatest prime factor of $2^n-1$) had all 16 gallery annotations drifted, with several collapsed onto overlapping stale ranges (three annotations sat on `97-229`). Clean positional/untangle re-anchor (flavor-1): every named construct still exists.

- Resolver validation: **16 valid / 0 misaligned** (was 13 valid / 3 hard type-clashes on the `definition`-typed `RelatedQuestion`, `IsPrimitivePrimeFactor`, `ord2`).
- Re-anchored each annotation to its current construct, using the Part I–X section structure as a guide: `greatestPrimeFactor`/`gpf_dvd`/`gpf_prime`, `mersenne`, `MainQuestion`/`stewart_2013`, `schinzel_bound`, `stewart_quantitative`, small cases, `IsMersennePrime`/`gpf_mersenne_prime`, `RelatedQuestion`/`lai_limsup_bound`, `IsPrimitivePrimeFactor`/`zsygmondy`, `ord2`.
- Annotations-only change; `meta.json` sections already align to the `## Part` markers and are untouched.

## Test plan
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 16/0