### PR TITLE
Enrich erdos-318: re-anchor 21 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-318/annotations.json
+++ b/src/data/proofs/erdos-318/annotations.json
@@ -72,7 +72,7 @@
     "id": "ann-e318-sign-function",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 58,
+      "startLine": 57,
       "endLine": 63
     },
     "type": "definition",
@@ -94,7 +94,7 @@
     "id": "ann-e318-nonconstant",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 65,
+      "startLine": 64,
       "endLine": 70
     },
     "type": "definition",
@@ -115,7 +115,7 @@
     "id": "ann-e318-property-p1",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 79,
+      "startLine": 80,
       "endLine": 87
     },
     "type": "definition",
@@ -138,7 +138,7 @@
     "id": "ann-e318-ap",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 93,
+      "startLine": 92,
       "endLine": 98
     },
     "type": "definition",
@@ -160,7 +160,7 @@
     "id": "ann-e318-positive-naturals-odds",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 100,
+      "startLine": 99,
       "endLine": 110
     },
     "type": "definition",
@@ -181,7 +181,7 @@
     "id": "ann-e318-erdos-straus",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 116,
+      "startLine": 115,
       "endLine": 120
     },
     "type": "concept",
@@ -203,7 +203,7 @@
     "id": "ann-e318-sattler-odd",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 122,
+      "startLine": 121,
       "endLine": 126
     },
     "type": "concept",
@@ -225,7 +225,7 @@
     "id": "ann-e318-sattler-main",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 128,
+      "startLine": 127,
       "endLine": 133
     },
     "type": "concept",
@@ -247,7 +247,7 @@
     "id": "ann-e318-main-thm",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 139,
+      "startLine": 140,
       "endLine": 148
     },
     "type": "concept",
@@ -268,7 +268,7 @@
     "id": "ann-e318-density-counterex",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 154,
+      "startLine": 153,
       "endLine": 167
     },
     "type": "definition",
@@ -292,8 +292,8 @@
     "id": "ann-e318-counterex-fails",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 177,
-      "endLine": 186
+      "startLine": 215,
+      "endLine": 220
     },
     "type": "concept",
     "title": "Counterexample Fails P₁",
@@ -314,8 +314,8 @@
     "id": "ann-e318-density-insuff",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 188,
-      "endLine": 197
+      "startLine": 222,
+      "endLine": 235
     },
     "type": "concept",
     "title": "Positive Density Insufficient",
@@ -337,8 +337,8 @@
     "id": "ann-e318-squares",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 203,
-      "endLine": 208
+      "startLine": 237,
+      "endLine": 244
     },
     "type": "definition",
     "title": "Squares Excluding One",
@@ -360,8 +360,8 @@
     "id": "ann-e318-why-exclude-1",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 210,
-      "endLine": 217
+      "startLine": 246,
+      "endLine": 256
     },
     "type": "concept",
     "title": "Why Exclude 1",
@@ -383,8 +383,8 @@
     "id": "ann-e318-squares-open",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 219,
-      "endLine": 231
+      "startLine": 293,
+      "endLine": 300
     },
     "type": "definition",
     "title": "Squares Conjecture (OPEN)",
@@ -406,8 +406,8 @@
     "id": "ann-e318-common-denom",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 237,
-      "endLine": 246
+      "startLine": 311,
+      "endLine": 320
     },
     "type": "concept",
     "title": "Common Denominator Technique",
@@ -429,8 +429,8 @@
     "id": "ann-e318-parity",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 248,
-      "endLine": 256
+      "startLine": 341,
+      "endLine": 350
     },
     "type": "definition",
     "title": "Parity Obstruction",
@@ -453,8 +453,8 @@
     "id": "ann-e318-egyptian",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 262,
-      "endLine": 275
+      "startLine": 355,
+      "endLine": 370
     },
     "type": "definition",
     "title": "Egyptian Fractions Connection",
@@ -476,8 +476,8 @@
     "id": "ann-e318-summary",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 281,
-      "endLine": 306
+      "startLine": 381,
+      "endLine": 400
     },
     "type": "concept",
     "title": "Summary Theorem",
@@ -500,8 +500,8 @@
     "id": "ann-e318-status",
     "proofId": "erdos-318",
     "range": {
-      "startLine": 308,
-      "endLine": 315
+      "startLine": 401,
+      "endLine": 408
     },
     "type": "concept",
     "title": "Problem Status",


### PR DESCRIPTION
## Summary
Annotation re-anchoring pass for **erdos-318** (Signed Unit Fractions with Zero Sum).

`Proofs/Erdos318Problem.lean` grew and was restructured since the annotations were written — the sign-function framework, counterexample construction, and squares sections all expanded, shifting every annotation off the construct it describes. The resolver reported 6 hard misalignments (3 `definition`-on-`theorem` type clashes + 3 "no construct found"), and several `concept` annotations were silently landing on the wrong construct.

## Changes
- Re-anchored 21 annotations to their current declarations (`signedUnitSum`, `IsSignFunction`, `IsNonConstant`, `HasPropertyP1`, `arithmeticProgression`, `positiveNaturals`/`oddNumbers`, `erdos_straus_1975`, `sattler_odd_1975`, `sattler_1982`, `erdos_318_arithmetic_progression`, `hasPositiveDensity`/`counterexampleSet`, `counterexample_fails_P1`, `positive_density_insufficient`, `squaresExcludingOne`, `sum_reciprocal_squares_less_than_one`, `erdos_318_squares_conjecture`, `zero_sum_integer_form`, `parityObstruction`, `isEgyptianRepresentation`, `erdos_318_summary`).
- `sections` already cover the file contiguously (Part I–X markers) — unchanged. Annotations-only PR.

## Verification
`npx tsx scripts/annotations/resolver.ts validate` → **23 valid / 0 misaligned** (was 23 with 6 hard misalignments).