### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): surface General.lean parametric capstone in gallery

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -217,6 +217,15 @@
         "sorries": 0,
         "theoremCount": 1,
         "definitionCount": 1
+      },
+      {
+        "path": "Proofs/LagrangeFourSquaresWaringG2OQ01General.lean",
+        "description": "Waring's Problem OQ-01, parametric general-k lower bound: a single statement waring_lower_general subsuming the five fixed-k instances above. For every k ≥ 1 the witness n_k = ⌊(3/2)^k⌋·2^k − 1 is not a sum of 2^k + ⌊(3/2)^k⌋ − 3 perfect k-th powers, hence g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2 (OEIS A002804). Defines the parametric IsSumOfKthPowers; the uniform proof rests on the fact that the only k-th powers ≤ n_k are 0, 1, 2^k (since n_k < 3^k), collapsing every representation to a 2-equation linear system whose ℕ-infeasibility is closed by a deterministic linear_combination certificate for the product witness (M−1)(Q−1−c₂), then linarith. Mathlib-only, sorry-free, axiom-free, no native_decide.",
+        "lineCount": 208,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 1,
+        "definitionCount": 1
       }
     ]
   },


### PR DESCRIPTION
## Summary

The gallery entry `lagrange-four-squares-waring-g2` lists the five fixed-`k` OQ-01 lower-bound files (`…OQ01.lean` k=3, `…Counting.lean` k=3, `…CountingG4/G5/G6/G7.lean`) in `leanFile.additionalFiles`, but **omits the parametric capstone** `LagrangeFourSquaresWaringG2OQ01General.lean`, which subsumes all of them in a single theorem:

> `waring_lower_general` — for every `k ≥ 1`, `n_k = ⌊(3/2)^k⌋·2^k − 1` is not a sum of `2^k + ⌊(3/2)^k⌋ − 3` perfect `k`-th powers; hence `g(k) ≥ 2^k + ⌊(3/2)^k⌋ − 2` (OEIS A002804).

This PR adds that file to `additionalFiles` so the verified general result is surfaced alongside its fixed-`k` specialisations.

## Why this is blackout-safe and correct

- **Registered + build-verified**: `import Proofs.LagrangeFourSquaresWaringG2OQ01General` is present at `proofs/Proofs.lean:2585`, added by the machine-check manifest PR #24510 and hardened in #24439. (The file's own docstring still says "NOT registered / not build-verified" — that header is **stale**, predating registration.)
- **Closure-clean**: the file is Mathlib-only (no `import Proofs.` parents), sorry-free, axiom-free, and uses no `native_decide` — fully verified.
- **JSON-only**: this PR edits only `meta.json`; no Lean changes.
- **No contention**: no open gallery PR for this slug (the one open PR, #22889, is fixed-`k` Lean work).

## Note

The headline open question (determine `g(k)` exactly for all `k`) remains **open** — only the unconditional lower-bound direction is proven/galleried here. Problem status unchanged.

## Test plan

- [x] `node` / `python3` parse of meta.json succeeds (7 additionalFiles)
- [x] All 7 referenced Lean files exist on disk
- [x] New file is 0 sorry / 0 axiom / 0 native_decide on `origin/main`