### PR TITLE
Enrich erdos-889: re-anchor 14 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-889/annotations.json
+++ b/src/data/proofs/erdos-889/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-889",
     "range": {
       "startLine": 1,
-      "endLine": 22
+      "endLine": 21
     },
     "type": "concept",
     "title": "Problem Header and Imports",
@@ -25,8 +25,8 @@
     "id": "ann-889-vnk",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 27,
-      "endLine": 32
+      "startLine": 30,
+      "endLine": 34
     },
     "type": "definition",
     "title": "New Prime Factor Count $v(n,k)$",
@@ -49,8 +49,8 @@
     "id": "ann-889-v0",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 38,
-      "endLine": 41
+      "startLine": 46,
+      "endLine": 48
     },
     "type": "definition",
     "title": "Maximum New Prime Count $v_0(n)$",
@@ -73,8 +73,8 @@
     "id": "ann-889-conjecture",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 51,
-      "endLine": 52
+      "startLine": 57,
+      "endLine": 58
     },
     "type": "definition",
     "title": "Erdos Problem #889: Divergence of $v_0(n)$",
@@ -96,8 +96,8 @@
     "id": "ann-889-v0ge2",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 60,
-      "endLine": 61
+      "startLine": 71,
+      "endLine": 73
     },
     "type": "concept",
     "title": "Erdos-Selfridge: $v_0(n) \\ge 2$ for $n \\ge 17$",
@@ -118,8 +118,8 @@
     "id": "ann-889-exceptions",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 65,
-      "endLine": 66
+      "startLine": 66,
+      "endLine": 69
     },
     "type": "concept",
     "title": "Complete Exception List",
@@ -140,8 +140,8 @@
     "id": "ann-889-vshifted",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 72,
-      "endLine": 74
+      "startLine": 84,
+      "endLine": 86
     },
     "type": "definition",
     "title": "Shifted Version $v_l(n)$",
@@ -162,8 +162,8 @@
     "id": "ann-889-general-conj",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 77,
-      "endLine": 78
+      "startLine": 88,
+      "endLine": 90
     },
     "type": "definition",
     "title": "Generalized Conjecture: $v_l(n) \\to \\infty$",
@@ -184,8 +184,8 @@
     "id": "ann-889-general-implies",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 81,
-      "endLine": 82
+      "startLine": 93,
+      "endLine": 95
     },
     "type": "concept",
     "title": "General Implies Base Case",
@@ -206,8 +206,8 @@
     "id": "ann-889-v1-finite",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 90,
-      "endLine": 91
+      "startLine": 97,
+      "endLine": 102
     },
     "type": "concept",
     "title": "Finiteness of $v_1(n) = 1$",
@@ -227,8 +227,8 @@
     "id": "ann-889-exact-power",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 99,
-      "endLine": 102
+      "startLine": 109,
+      "endLine": 112
     },
     "type": "definition",
     "title": "Exact Power New Count $V(n,k)$",
@@ -250,8 +250,8 @@
     "id": "ann-889-exact-shifted",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 105,
-      "endLine": 106
+      "startLine": 115,
+      "endLine": 116
     },
     "type": "definition",
     "title": "Exact Power Shifted $V_l(n)$",
@@ -272,8 +272,8 @@
     "id": "ann-889-exact-v1",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 110,
-      "endLine": 111
+      "startLine": 118,
+      "endLine": 119
     },
     "type": "concept",
     "title": "Exact Power $V_1$ Finiteness",
@@ -293,8 +293,8 @@
     "id": "ann-889-comparison",
     "proofId": "erdos-889",
     "range": {
-      "startLine": 115,
-      "endLine": 116
+      "startLine": 123,
+      "endLine": 130
     },
     "type": "concept",
     "title": "Comparison: $V(n,k) \\ge v(n,k)$",


### PR DESCRIPTION
## Summary
The Erdős Problem #889 Lean file (`Proofs/Erdos889Problem.lean`) had all 14 gallery annotations drifted off their constructs. Clean positional re-anchor (flavor-1): every named construct still exists.

- Resolver validation: **14 valid / 0 misaligned** (was 10 valid / 4 misaligned — 3 hard type-clashes on the `definition`-typed `v₀`, `vShifted`, `ErdosProblem889General`, plus one concept annotation resolving to no construct).
- Re-anchored each annotation to its current construct: `newPrimeFactorCount`, `v₀`, `ErdosProblem889`, `v0_ge_2_for_large`, `v0_exceptions`, `vShifted`, `ErdosProblem889General`, `general_implies_base`, the v₁/V₁ finiteness section/doc-comment blocks, `exactPowerNewCount`, `exactPowerShifted`, and `exact_power_ge_new_prime`.
- Annotations-only change; `meta.json` sections already aligned and are untouched.

## Test plan
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 14/0