### PR TITLE
Enrich erdos-453: re-anchor 21 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-453/annotations.json
+++ b/src/data/proofs/erdos-453/annotations.json
@@ -54,8 +54,8 @@
     "id": "ann-e453-nthprime",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 46,
-      "endLine": 51
+      "startLine": 51,
+      "endLine": 55
     },
     "type": "definition",
     "title": "The n-th Prime",
@@ -78,8 +78,8 @@
     "id": "ann-e453-nthprime-props",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 56,
-      "endLine": 68
+      "startLine": 68,
+      "endLine": 93
     },
     "type": "concept",
     "title": "Prime Sequence: Values and Monotonicity",
@@ -103,8 +103,8 @@
     "id": "ann-e453-erdos-straus",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 74,
-      "endLine": 80
+      "startLine": 103,
+      "endLine": 109
     },
     "type": "definition",
     "title": "Erdős-Straus Conjecture",
@@ -128,8 +128,8 @@
     "id": "ann-e453-selfridge",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 82,
-      "endLine": 89
+      "startLine": 111,
+      "endLine": 117
     },
     "type": "definition",
     "title": "Selfridge's Counter-Conjecture",
@@ -154,8 +154,8 @@
     "id": "ann-e453-exclusive",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 91,
-      "endLine": 101
+      "startLine": 119,
+      "endLine": 127
     },
     "type": "concept",
     "title": "Mutually Exclusive Conjectures",
@@ -179,8 +179,8 @@
     "id": "ann-e453-logprime",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 107,
-      "endLine": 112
+      "startLine": 136,
+      "endLine": 142
     },
     "type": "definition",
     "title": "Log-Prime Function",
@@ -204,8 +204,8 @@
     "id": "ann-e453-ratio",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 114,
-      "endLine": 120
+      "startLine": 144,
+      "endLine": 150
     },
     "type": "concept",
     "title": "Ratio Tends to Zero (PNT Consequence)",
@@ -231,8 +231,8 @@
     "id": "ann-e453-vertex",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 122,
-      "endLine": 128
+      "startLine": 152,
+      "endLine": 158
     },
     "type": "definition",
     "title": "Convex Hull Vertex Characterization",
@@ -256,8 +256,8 @@
     "id": "ann-e453-lemma",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 130,
-      "endLine": 136
+      "startLine": 159,
+      "endLine": 170
     },
     "type": "concept",
     "title": "Pomerance's Convex Hull Lemma",
@@ -283,8 +283,8 @@
     "id": "ann-e453-convexity",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 142,
-      "endLine": 150
+      "startLine": 171,
+      "endLine": 183
     },
     "type": "concept",
     "title": "Convexity Implies Product Bound",
@@ -310,8 +310,8 @@
     "id": "ann-e453-pomerance",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 152,
-      "endLine": 159
+      "startLine": 184,
+      "endLine": 196
     },
     "type": "concept",
     "title": "Pomerance's Theorem (1979)",
@@ -336,8 +336,8 @@
     "id": "ann-e453-selfridge-correct",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 161,
-      "endLine": 164
+      "startLine": 197,
+      "endLine": 201
     },
     "type": "concept",
     "title": "Selfridge Was Correct",
@@ -360,8 +360,8 @@
     "id": "ann-e453-erdos-wrong",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 166,
-      "endLine": 171
+      "startLine": 202,
+      "endLine": 219
     },
     "type": "concept",
     "title": "Erdős-Straus Were Wrong",
@@ -385,8 +385,8 @@
     "id": "ann-e453-solution",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 177,
-      "endLine": 188
+      "startLine": 220,
+      "endLine": 225
     },
     "type": "concept",
     "title": "Erdős Problem #453: SOLVED",
@@ -409,8 +409,8 @@
     "id": "ann-e453-negative",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 190,
-      "endLine": 197
+      "startLine": 226,
+      "endLine": 240
     },
     "type": "concept",
     "title": "Infinitely Many Counterexamples (Positive Formulation)",
@@ -434,8 +434,8 @@
     "id": "ann-e453-primegraph",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 200,
-      "endLine": 219
+      "startLine": 241,
+      "endLine": 246
     },
     "type": "definition",
     "title": "The Prime Number Graph",
@@ -460,8 +460,8 @@
     "id": "ann-e453-logconvex",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 225,
-      "endLine": 237
+      "startLine": 262,
+      "endLine": 267
     },
     "type": "definition",
     "title": "Log Convexity: Definition and Equivalence",
@@ -485,8 +485,8 @@
     "id": "ann-e453-logtoproduct",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 239,
-      "endLine": 245
+      "startLine": 279,
+      "endLine": 314
     },
     "type": "concept",
     "title": "Log-to-Product Bridge",
@@ -512,8 +512,8 @@
     "id": "ann-e453-density",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 251,
-      "endLine": 261
+      "startLine": 315,
+      "endLine": 331
     },
     "type": "concept",
     "title": "Infinite Counterexample Set",
@@ -537,8 +537,8 @@
     "id": "ann-e453-guy",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 268,
-      "endLine": 275
+      "startLine": 332,
+      "endLine": 356
     },
     "type": "concept",
     "title": "Problem A14 in Guy's UPINT",
@@ -561,8 +561,8 @@
     "id": "ann-e453-summary",
     "proofId": "erdos-453",
     "range": {
-      "startLine": 281,
-      "endLine": 302
+      "startLine": 357,
+      "endLine": 364
     },
     "type": "concept",
     "title": "Summary: Both Conjectures Resolved",


### PR DESCRIPTION
## Summary
Annotation re-anchoring pass for **erdos-453** (Erdős–Straus vs Selfridge on the prime sequence; resolved by Pomerance 1979).

`Proofs/Erdos453Problem.lean` grew and was restructured since the annotations were written, shifting every annotation off the construct it describes. The resolver reported 6 hard misalignments (3 `definition`-on-`theorem` type clashes + 3 "no construct found"), and several `concept` annotations were silently sitting on the wrong declaration.

## Changes
- Re-anchored 21 annotations to their current declarations (`nthPrime`, `ErdosStrausConjecture`, `SelfridgeConjecture`, `conjectures_mutually_exclusive`, `logPrime`, `logPrime_ratio_tendsto_zero`, `IsConvexHullVertex`, `pomerance_convex_hull_lemma`, `convexity_implies_product_bound`, `pomerance_1979`, `selfridge_correct`, `erdos_straus_wrong`, `erdos_453_solution`, `erdos_453_negative_answer`, `primeGraph`, `LogConvexityProperty`, `log_to_product`, `counterexample_set_infinite`, `guy_problem_A14`, `erdos_453_summary`).
- `sections` already cover the file contiguously — unchanged. Annotations-only PR.

## Verification
`npx tsx scripts/annotations/resolver.ts validate` → **23 valid / 0 misaligned** (was 23 with 6 hard misalignments).