### PR TITLE
Enrich erdos-893: re-anchor 15 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-893/annotations.json
+++ b/src/data/proofs/erdos-893/annotations.json
@@ -26,7 +26,7 @@
     "id": "ann-893-tau",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 35,
+      "startLine": 36,
       "endLine": 36
     },
     "type": "definition",
@@ -48,8 +48,8 @@
     "id": "ann-893-tau-verified",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 44,
-      "endLine": 66
+      "startLine": 45,
+      "endLine": 68
     },
     "type": "concept",
     "title": "Verified $\\tau$ Values for Small Mersenne Numbers",
@@ -72,7 +72,7 @@
     "proofId": "erdos-893",
     "range": {
       "startLine": 69,
-      "endLine": 70
+      "endLine": 71
     },
     "type": "concept",
     "title": "Mersenne Primes Have $\\tau = 2$ (Proved)",
@@ -93,8 +93,8 @@
     "id": "ann-893-f",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 78,
-      "endLine": 79
+      "startLine": 92,
+      "endLine": 94
     },
     "type": "definition",
     "title": "Mersenne Divisor Sum $f(n)$",
@@ -117,8 +117,8 @@
     "id": "ann-893-f-values",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 81,
-      "endLine": 109
+      "startLine": 96,
+      "endLine": 124
     },
     "type": "concept",
     "title": "Verified Values of $f$ and Initial Values Theorem",
@@ -139,8 +139,8 @@
     "id": "ann-893-mono",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 116,
-      "endLine": 119
+      "startLine": 139,
+      "endLine": 143
     },
     "type": "concept",
     "title": "Monotonicity of $f$ (Proved)",
@@ -161,8 +161,8 @@
     "id": "ann-893-fpos",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 122,
-      "endLine": 124
+      "startLine": 145,
+      "endLine": 148
     },
     "type": "concept",
     "title": "Positivity of $f$ (Proved)",
@@ -183,8 +183,8 @@
     "id": "ann-893-ratio",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 131,
-      "endLine": 132
+      "startLine": 276,
+      "endLine": 278
     },
     "type": "definition",
     "title": "Ratio $f(2n)/f(n)$",
@@ -206,8 +206,8 @@
     "id": "ann-893-ratio-ge1",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 135,
-      "endLine": 139
+      "startLine": 280,
+      "endLine": 290
     },
     "type": "concept",
     "title": "Ratio $\\ge 1$ (Proved)",
@@ -229,8 +229,8 @@
     "id": "ann-893-kovac-luca",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 147,
-      "endLine": 148
+      "startLine": 292,
+      "endLine": 294
     },
     "type": "concept",
     "title": "Kovac-Luca: $\\limsup f(2n)/f(n) = \\infty$",
@@ -251,8 +251,8 @@
     "id": "ann-893-unbounded",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 151,
-      "endLine": 155
+      "startLine": 296,
+      "endLine": 306
     },
     "type": "concept",
     "title": "Ratio Unbounded (Proved from Axiom)",
@@ -274,8 +274,8 @@
     "id": "ann-893-conjecture",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 163,
-      "endLine": 165
+      "startLine": 308,
+      "endLine": 311
     },
     "type": "definition",
     "title": "Erdos Problem #893: $f(2n)/f(n) \\to \\infty$",
@@ -297,8 +297,8 @@
     "id": "ann-893-weaker",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 168,
-      "endLine": 172
+      "startLine": 313,
+      "endLine": 322
     },
     "type": "concept",
     "title": "Conjecture Implies Kovac-Luca (Proved)",
@@ -319,8 +319,8 @@
     "id": "ann-893-summary",
     "proofId": "erdos-893",
     "range": {
-      "startLine": 179,
-      "endLine": 185
+      "startLine": 324,
+      "endLine": 330
     },
     "type": "concept",
     "title": "Summary Theorem",


### PR DESCRIPTION
## Summary
The Erdős Problem #893 Lean file (`Proofs/Erdos893Problem.lean`, Mersenne divisor-sum $f(n)$ and the ratio $f(2n)/f(n)$) grew to 332 lines with many new lemmas inserted, leaving all 15 gallery annotations anchored to stale positions. Clean positional re-anchor (flavor-1): every annotated construct still exists.

- Resolver validation: **15 valid / 0 misaligned** (was 10 valid / 5 misaligned — 3 hard type-clashes on the `definition`-typed `f`, `ratio`, `ErdosProblem893`, plus 2 concept annotations resolving to no construct).
- Re-anchored each annotation to its current construct: `tau` + verified τ values, `f` + verified f values/`f_initial_values`, `f_mono`, `f_pos`, `ratio`, `ratio_ge_one`, `kovac_luca_limsup_infinite`, `ratio_unbounded`, `ErdosProblem893`, `kovac_luca_weaker_than_conjecture`, `erdos893_summary`.
- Annotations-only change; `meta.json` sections already align to the current structure and are untouched.

## Test plan
- [x] `npx tsx scripts/annotations/resolver.ts validate` → 15/0