### PR TITLE
Enrich erdos-601: re-anchor 15 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-601/annotations.json
+++ b/src/data/proofs/erdos-601/annotations.json
@@ -27,7 +27,7 @@
     "proofId": "erdos-601",
     "range": {
       "startLine": 37,
-      "endLine": 37
+      "endLine": 38
     },
     "type": "definition",
     "title": "OrdinalGraph",
@@ -50,7 +50,7 @@
     "proofId": "erdos-601",
     "range": {
       "startLine": 40,
-      "endLine": 41
+      "endLine": 42
     },
     "type": "definition",
     "title": "HasInfinitePath",
@@ -73,7 +73,7 @@
     "proofId": "erdos-601",
     "range": {
       "startLine": 44,
-      "endLine": 45
+      "endLine": 46
     },
     "type": "definition",
     "title": "IsIndependent",
@@ -95,7 +95,7 @@
     "proofId": "erdos-601",
     "range": {
       "startLine": 48,
-      "endLine": 49
+      "endLine": 52
     },
     "type": "definition",
     "title": "HasOrderType",
@@ -118,7 +118,7 @@
     "proofId": "erdos-601",
     "range": {
       "startLine": 54,
-      "endLine": 56
+      "endLine": 57
     },
     "type": "definition",
     "title": "PropertyP",
@@ -141,8 +141,8 @@
     "id": "ann-601-finite",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 68,
-      "endLine": 69
+      "startLine": 74,
+      "endLine": 77
     },
     "type": "concept",
     "title": "P(n) for Finite Ordinals",
@@ -162,8 +162,8 @@
     "id": "ann-601-omega",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 80,
-      "endLine": 81
+      "startLine": 86,
+      "endLine": 95
     },
     "type": "concept",
     "title": "P(omega) via Ramsey's Theorem",
@@ -185,8 +185,8 @@
     "id": "ann-601-critical",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 91,
-      "endLine": 91
+      "startLine": 97,
+      "endLine": 98
     },
     "type": "definition",
     "title": "criticalOrdinal",
@@ -208,8 +208,8 @@
     "id": "ann-601-ehm",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 94,
-      "endLine": 96
+      "startLine": 100,
+      "endLine": 104
     },
     "type": "concept",
     "title": "Erdős-Hajnal-Milner Theorem (1970)",
@@ -232,8 +232,8 @@
     "id": "ann-601-critconj",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 105,
-      "endLine": 105
+      "startLine": 111,
+      "endLine": 113
     },
     "type": "definition",
     "title": "CriticalCaseConjecture ($250)",
@@ -255,8 +255,8 @@
     "id": "ann-601-ma",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 120,
-      "endLine": 120
+      "startLine": 128,
+      "endLine": 129
     },
     "type": "concept",
     "title": "Martin's Axiom",
@@ -278,8 +278,8 @@
     "id": "ann-601-larson",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 126,
-      "endLine": 128
+      "startLine": 134,
+      "endLine": 138
     },
     "type": "concept",
     "title": "Larson's Theorem (1990)",
@@ -302,8 +302,8 @@
     "id": "ann-601-hierarchy",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 144,
-      "endLine": 146
+      "startLine": 152,
+      "endLine": 160
     },
     "type": "concept",
     "title": "Ordinal Hierarchy",
@@ -325,8 +325,8 @@
     "id": "ann-601-indnum",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 169,
-      "endLine": 170
+      "startLine": 179,
+      "endLine": 181
     },
     "type": "definition",
     "title": "independenceNumber",
@@ -348,8 +348,8 @@
     "id": "ann-601-general",
     "proofId": "erdos-601",
     "range": {
-      "startLine": 201,
-      "endLine": 202
+      "startLine": 218,
+      "endLine": 220
     },
     "type": "definition",
     "title": "GeneralConjecture ($500)",


### PR DESCRIPTION
## Summary
Annotation re-anchoring pass for **erdos-601** (Property P(α) on ordinal graphs — Erdős–Hajnal–Milner / critical-ordinal frontier).

`Proofs/Erdos601Problem.lean` grew since the annotations were written, shifting every annotation off the construct it describes. The resolver reported 5 hard misalignments (3 `definition`-on-`theorem` type clashes + 2 "no construct found"), with additional concepts silently on the wrong declaration.

## Changes
- Re-anchored 15 annotations to their current declarations (`OrdinalGraph`, `HasInfinitePath`, `IsIndependent`, `HasOrderType`, `PropertyP`, `propertyP_finite`, `propertyP_omega`, `criticalOrdinal`, `erdos_hajnal_milner`, `CriticalCaseConjecture`, `MartinsAxiom`, `larson_MA`, `ordinal_hierarchy`, `independenceNumber`, `GeneralConjecture`).
- Annotations-only PR.

## Verification
`npx tsx scripts/annotations/resolver.ts validate` → **16 valid / 0 misaligned** (was 16 with 5 hard misalignments).