### PR TITLE
Enrich erdos-679: re-anchor 11 drifted annotations

### DIFF
--- a/src/data/proofs/erdos-679/annotations.json
+++ b/src/data/proofs/erdos-679/annotations.json
@@ -27,7 +27,7 @@
     "id": "ann-679-omega",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 30,
+      "startLine": 33,
       "endLine": 51
     },
     "type": "definition",
@@ -52,7 +52,7 @@
     "id": "ann-679-hardy-ramanujan",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 53,
+      "startLine": 59,
       "endLine": 72
     },
     "type": "concept",
@@ -78,8 +78,8 @@
     "id": "ann-679-threshold",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 74,
-      "endLine": 90
+      "startLine": 80,
+      "endLine": 93
     },
     "type": "definition",
     "title": "Threshold Function and Main Conjecture",
@@ -103,8 +103,8 @@
     "id": "ann-679-stronger-false",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 92,
-      "endLine": 109
+      "startLine": 98,
+      "endLine": 114
     },
     "type": "concept",
     "title": "Stronger Version (Disproven)",
@@ -128,8 +128,8 @@
     "id": "ann-679-bigomega",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 111,
-      "endLine": 128
+      "startLine": 117,
+      "endLine": 136
     },
     "type": "definition",
     "title": "Ω Function Variant",
@@ -152,8 +152,8 @@
     "id": "ann-679-special",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 130,
-      "endLine": 143
+      "startLine": 144,
+      "endLine": 153
     },
     "type": "concept",
     "title": "Special Cases: Powers of 2 and Primorials",
@@ -177,8 +177,8 @@
     "id": "ann-679-lower-bounds",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 145,
-      "endLine": 157
+      "startLine": 159,
+      "endLine": 171
     },
     "type": "concept",
     "title": "Lower Bounds on ω(n-k)",
@@ -202,8 +202,8 @@
     "id": "ann-679-related",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 159,
-      "endLine": 167
+      "startLine": 173,
+      "endLine": 181
     },
     "type": "definition",
     "title": "Connections to Problems #248 and #413",
@@ -223,8 +223,8 @@
     "id": "ann-679-heuristics",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 169,
-      "endLine": 188
+      "startLine": 183,
+      "endLine": 196
     },
     "type": "definition",
     "title": "Probabilistic Heuristics",
@@ -247,8 +247,8 @@
     "id": "ann-679-dichotomy",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 190,
-      "endLine": 197
+      "startLine": 204,
+      "endLine": 212
     },
     "type": "concept",
     "title": "Key Dichotomy",
@@ -272,8 +272,8 @@
     "id": "ann-679-density",
     "proofId": "erdos-679",
     "range": {
-      "startLine": 199,
-      "endLine": 212
+      "startLine": 213,
+      "endLine": 225
     },
     "type": "concept",
     "title": "Density Considerations",


### PR DESCRIPTION
## Summary
Annotation re-anchoring pass for **erdos-679** (ω(n): distinct-prime-factor counting function).

`Proofs/Erdos679Problem.lean` grew since the annotations were written, shifting the umbrella annotations off the constructs they describe. The resolver reported 6 hard misalignments (3 `definition`-on-`theorem` type clashes + 3 "no construct found").

## Changes
- Re-anchored 11 annotations to their current declarations (`omega` + properties, Hardy–Ramanujan normal order, `threshold`/`MainConjecture`, `StrongerVersion`, `bigOmega`/`OmegaVariant`, `power_of_two_case`/`primorial`, `existence_of_large_omega`, problem #248/#413 connections, probabilistic heuristics, `dichotomy`, density bounds).
- Annotations-only PR.

## Verification
`npx tsx scripts/annotations/resolver.ts validate` → **12 valid / 0 misaligned** (was 12 with 6 hard misalignments).