### PR TITLE
research(lagrange-four-squares-oq-04): surface ThreeSquaresSingleAP refinement in gallery

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -29,7 +29,8 @@
       "Key modular arithmetic: squares mod 8 ∈ {0,1,4}, so three squares mod 8 ≠ 7",
       "Descent lemma: 4 | (x²+y²+z²) implies 2|x, 2|y, 2|z",
       "Full biconditional combining proved forward + axiomatized backward directions",
-      "Examples: 7, 15, 28, 112 are not sums of three squares"
+      "Examples: 7, 15, 28, 112 are not sums of three squares",
+      "Single-AP witness refinement (ThreeSquaresSingleAP.lean, sorry-free and axiom-free, Mathlib-only): the quadratic side-condition legendreSym p (−n) = 1 of dirichlet_key_lemma is satisfied uniformly by the single arithmetic progression p ≡ 1 (mod 4n), removing the rigid p = d·n − 1 tie and its Residue3 (n ≡ 3 mod 4) carve-out. Pure quadratic reciprocity plus Dirichlet's theorem on primes in AP; the Minkowski lattice key lemma itself remains the axiomatized component."
     ],
     "dateAdded": "2026-04-13",
     "lineCount": 226,
@@ -38,7 +39,8 @@
     "mathlibDependencies": [],
     "mathlib_version": "4.26.0",
     "additionalFiles": [
-      "Proofs/ThreeSquares.lean"
+      "Proofs/ThreeSquares.lean",
+      "Proofs/ThreeSquaresSingleAP.lean"
     ]
   },
   "overview": {
@@ -165,7 +167,8 @@
     "path": "Proofs/LagrangeFourSquaresOQ04.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/ThreeSquares.lean"
+      "Proofs/ThreeSquares.lean",
+      "Proofs/ThreeSquaresSingleAP.lean"
     ]
   },
   "mainTheorems": [


### PR DESCRIPTION
## Summary

`ThreeSquaresSingleAP.lean` (registered `Proofs.lean:3047`, Mathlib-only, 0 sorry / 0 axiom / 0 native_decide) was complete but absent from the **Legendre-Gauss Three-Square Theorem** gallery entry (`lagrange-four-squares-oq-04`), whose `additionalFiles` listed only `ThreeSquares.lean`. This JSON-only PR surfaces it.

The file proves the **single-AP witness** for Legendre's three-square theorem (positive direction):

> For odd `n` and any prime `p ≡ 1 (mod 4n)`, `legendreSym p (−n) = 1`.

This satisfies the quadratic side-condition of `dirichlet_key_lemma` uniformly via the single always-admissible progression `1 (mod 4n)`, **removing the rigid `p = d·n − 1` tie** and its `Residue3` (`n ≡ 3 mod 4`) carve-out. Proof is pure quadratic reciprocity + Dirichlet's theorem on primes in AP.

## Scope / honesty

- **Parent entry is unchanged in status**: it remains axiomatized. This refinement removes the witness-side carve-out but the **Minkowski lattice key lemma** itself stays the axiomatized component (noted explicitly in the new `originalContributions` bullet).
- Added `ThreeSquaresSingleAP.lean` to both `meta.additionalFiles` and `leanFile.additionalFiles`; one accurate `originalContributions` bullet.

## Verification (blackout-safe)

Dual backend blackout this session (Docker `.lake` circular-symlink / 0 oleans; Aristotle 404), so no leaf build. Instead:
- File closure is pure Mathlib (0 `Proofs.` imports), 0 sorry / 0 axiom / 0 native_decide → closure-clean verified-eligible.
- All named Mathlib bearers name-checked against the pinned rev `2df2f0150c` (v4.26.0): `jacobiSym.mod_left'` (JacobiSymbol.lean:225), `jacobiSym.legendreSym.to_jacobiSym` (115, inside `namespace jacobiSym`), `jacobiSym.neg` (319), `jacobiSym.quadratic_reciprocity_one_mod_four`, `ZMod.χ₄_nat_one_mod_four`, `Nat.forall_exists_prime_gt_and_modEq`.
- `node` JSON-parse validated.

## Test plan

- [ ] Deployer leaf-builds `Proofs.ThreeSquaresSingleAP` when Docker pool frees up.
- [x] `meta.json` parses (`node -e require`).
- [x] File confirmed registered and previously ungalleried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)