### PR TITLE
ci: add scheduled workflow to prune merged remote branches

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,45 @@
+name: Cleanup merged branches
+
+# Periodically prune local branches whose PRs are merged/closed so that
+# merged-PR branches do not accumulate unbounded (see issue #25339).
+#
+# The script keys off GitHub PR merge status via `gh`, so the job needs a
+# token with permission to read PRs and delete branches. A runner checkout
+# has no local branches/worktrees, so we pass `--remote` to delete the
+# merged/closed branches that have accumulated on origin. Local
+# `.claude`/`.loom` worktree cleanup is a developer-machine concern handled
+# by `make prune` / the Deployer post-merge hook.
+
+on:
+  schedule:
+    # 04:00 UTC daily
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+# Never run two cleanups at once — overlapping branch deletes can race.
+concurrency:
+  group: cleanup-branches
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all branches so the script can evaluate each local branch
+          # against main and against its PR status.
+          fetch-depth: 0
+
+      - name: Prune merged branches
+        env:
+          # clean-branches.sh calls `gh` to check PR merge status and
+          # `git push origin --delete` (authenticated via the token) to
+          # remove merged remote branches.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/clean-branches.sh --force --remote

--- a/.lean/roles/deployer.md
+++ b/.lean/roles/deployer.md
@@ -25,13 +25,31 @@ You are the **Deployer** agent. Your mission is to keep the website current by p
    ./scripts/deploy/sync-and-deploy.sh
    ```
 
-3. **Report results**
+3. **Post-merge cleanup** — for every PR you merged this cycle, prune its
+   branch and worktree so they do not accumulate (see issue #25339):
+   ```bash
+   # For each merged branch <branch> with worktree path <path>:
+   git push origin --delete <branch>        # remove the merged remote branch
+   git worktree remove <path> --force       # remove its clean worktree
+   ```
+   Only remove **clean, unlocked** worktrees for branches you just merged —
+   never touch a locked or actively-running worktree. To prune everything
+   merged across all agents in one pass, run the sweep instead:
+   ```bash
+   ./scripts/clean-branches.sh --force      # local branches + worktrees
+   make prune                               # worktree refs + remote-tracking prune
+   ```
+   A scheduled GitHub Actions workflow (`.github/workflows/cleanup-branches.yml`)
+   runs `clean-branches.sh --force --remote` daily as a safety net, but cleaning
+   up in-cycle keeps the dev host tidy between sweeps.
+
+4. **Report results**
    - How many PRs were merged
    - Any PRs that failed (conflicts)
    - Build/deploy status
    - New deployment URL
 
-4. **Wait for next interval**
+5. **Wait for next interval**
    - Default: 30 minutes
    - Configurable via DEPLOYER_INTERVAL environment variable
 

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -11,6 +11,7 @@
 #   --dry-run       Show what would be cleaned without making changes
 #   -f, --force     Non-interactive mode (auto-confirm all prompts)
 #   --keep-no-pr    Preserve branches that have no associated PR
+#   --remote        Also delete merged/closed branches on origin (for CI use)
 #   -h, --help      Show this help message
 #
 # Safety:
@@ -18,6 +19,8 @@
 #   - Never deletes branches checked out in active worktrees
 #   - Branches with no PR: deleted if 0 commits ahead of main, preserved if ahead
 #   - --keep-no-pr overrides to preserve all branches without PRs
+#   - --remote only deletes origin branches whose PR is MERGED or CLOSED
+#     (OPEN-PR and no-PR remote branches are always preserved)
 
 set -euo pipefail
 
@@ -55,6 +58,7 @@ REPO_ROOT="$(find_repo_root)"
 DRY_RUN=false
 FORCE=false
 KEEP_NO_PR=false
+REMOTE=false
 
 for arg in "$@"; do
     case $arg in
@@ -75,6 +79,10 @@ for arg in "$@"; do
             KEEP_NO_PR=true
             shift
             ;;
+        --remote)
+            REMOTE=true
+            shift
+            ;;
         --help|-h)
             cat << 'HELPEOF'
 Comprehensive Branch & Worktree Cleanup
@@ -85,6 +93,7 @@ Options:
   --dry-run       Show what would be cleaned without making changes
   -f, --force     Non-interactive mode (auto-confirm all prompts)
   --keep-no-pr    Preserve branches that have no associated PR
+  --remote        Also delete merged/closed branches on origin (for CI use)
   -h, --help      Show this help message
 
 Branch cleanup:
@@ -94,6 +103,13 @@ Branch cleanup:
   - If no PR exists and branch is 0 commits ahead of main: DELETE
   - If no PR exists and branch has commits ahead: PRESERVE (or delete with prompt)
   - --keep-no-pr: always preserve branches with no PR
+
+Remote cleanup (--remote):
+  For every branch on origin (except main/master):
+  - If a merged/closed PR exists: DELETE on origin
+  - Otherwise (open PR or no PR): PRESERVE
+  Intended for CI/scheduled runs where a fresh checkout has no local
+  branches but origin has accumulated merged-PR branches.
 
 Worktree cleanup:
   - .claude/worktrees/agent-* without a running claude process: REMOVE
@@ -264,6 +280,11 @@ preserved_no_pr=0
 failed=0
 total_branches=0
 
+# Remote branch counters (--remote)
+remote_deleted=0
+remote_preserved=0
+remote_failed=0
+
 # Get all local branches
 all_branches=$(git branch | sed 's/^[*+ ]*//' | sort)
 total_local=$(echo "$all_branches" | wc -l | tr -d ' ')
@@ -411,6 +432,78 @@ done
 printf "                                                          \r"
 
 echo ""
+
+# =============================================================================
+# PHASE 3b: Process remote branches (--remote)
+# =============================================================================
+# On a fresh CI checkout `git branch` only lists the default branch, so the
+# local-branch phase above is a no-op there. This phase deletes branches on
+# origin whose PR is MERGED or CLOSED, reusing the PR map from Phase 1 and the
+# same safety rules (never touch main; preserve OPEN-PR and no-PR branches).
+
+if [[ "$REMOTE" == true ]]; then
+    header "Phase 3b: Processing remote branches on origin..."
+    echo ""
+
+    # Make sure we have an up-to-date view of origin's branches.
+    git fetch --prune origin &>/dev/null || warning "  git fetch failed; using cached remote refs"
+
+    # List remote-tracking branches under origin/, stripping the prefix.
+    # Skip the symbolic origin/HEAD entry.
+    remote_branches=$(git for-each-ref --format='%(refname:short)' refs/remotes/origin \
+        | sed 's|^origin/||' \
+        | grep -v '^HEAD$' \
+        | sort -u)
+
+    remote_total=$(echo "$remote_branches" | grep -c . || true)
+    info "  Processing $remote_total remote branches..."
+    echo ""
+
+    rprocessed=0
+    for branch in $remote_branches; do
+        ((rprocessed++)) || true
+
+        if [[ $((rprocessed % progress_interval)) -eq 0 ]]; then
+            printf "  Progress: %d/%d remote branches processed...\r" "$rprocessed" "$remote_total"
+        fi
+
+        # Never delete the protected default branch on origin.
+        if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+            ((remote_preserved++)) || true
+            continue
+        fi
+
+        pr_status=$(get_pr_status "$branch")
+
+        case "$pr_status" in
+            MERGED|CLOSED)
+                if [[ "$DRY_RUN" == true ]]; then
+                    info "  [DELETE] origin/$branch (PR $pr_status)"
+                    ((remote_deleted++)) || true
+                else
+                    if git push origin --delete "$branch" &>/dev/null; then
+                        success "  Deleted: origin/$branch (PR $pr_status)"
+                        ((remote_deleted++)) || true
+                    else
+                        warning "  Failed to delete: origin/$branch"
+                        ((remote_failed++)) || true
+                    fi
+                fi
+                ;;
+            *)
+                # OPEN PR or NONE: preserve.
+                ((remote_preserved++)) || true
+                if [[ "$DRY_RUN" == true ]]; then
+                    info "  [KEEP]   origin/$branch (PR ${pr_status:-NONE})"
+                fi
+                ;;
+        esac
+    done
+
+    # Clear progress line
+    printf "                                                          \r"
+    echo ""
+fi
 
 # =============================================================================
 # PHASE 4: Worktree cleanup
@@ -601,6 +694,16 @@ if [[ $failed -gt 0 ]]; then
 fi
 echo -e "    ${BOLD}Total deleted:${NC}            $total_deleted / $((total_branches + preserved_protected)) branches"
 echo ""
+
+if [[ "$REMOTE" == true ]]; then
+    echo -e "  ${BOLD}Remote branches (origin):${NC}"
+    echo -e "    ${GREEN}Deleted (PR merged/closed):${NC} $remote_deleted"
+    echo -e "    ${BLUE}Preserved:${NC}                  $remote_preserved"
+    if [[ $remote_failed -gt 0 ]]; then
+        echo -e "    ${RED}Failed:${NC}                     $remote_failed"
+    fi
+    echo ""
+fi
 
 echo -e "  ${BOLD}Worktrees:${NC}"
 echo -e "    ${GREEN}Removed:${NC}    $worktrees_removed"


### PR DESCRIPTION
## Summary

Merged-PR branches were accumulating on origin (8,324 unpruned) because nothing invoked cleanup on a schedule or after merges. `clean-branches.sh --force` already exists and `make clean-all` calls it, but there was no scheduled/automated entry point. This PR adds a daily GitHub Actions sweep plus a Deployer post-merge cleanup note.

## Changes

- **`.github/workflows/cleanup-branches.yml`** (new): scheduled workflow (daily `cron: "0 4 * * *"`) plus `workflow_dispatch` that runs `./scripts/clean-branches.sh --force --remote`. Has `contents: write` + `pull-requests: read` permissions, passes `GH_TOKEN` from `secrets.GITHUB_TOKEN` (the script uses `gh` for PR status and `git push origin --delete` for branch removal), `fetch-depth: 0`, and a concurrency guard so overlapping runs do not race.
- **`scripts/clean-branches.sh`**: added a `--remote` flag and Phase 3b. On a fresh CI checkout `git branch` only lists the default branch, so the existing local-branch phase is a no-op there. Phase 3b deletes branches **on origin** whose PR is MERGED or CLOSED, reusing the Phase 1 PR-status map and the same safety rules (never touch `main`/`master`; preserve OPEN-PR and no-PR branches). Help text and the SUMMARY block were updated; no existing logic was changed.
- **`.lean/roles/deployer.md`**: added a "Post-merge cleanup" step instructing the Deployer to prune the merged branch and its clean/unlocked worktree in the same cycle, with the sweep commands as a fallback and a pointer to the new scheduled workflow.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Merged-PR branches pruned automatically without manual intervention | done | New `cleanup-branches.yml` runs daily + on demand; `--remote` deletes merged/closed origin branches |
| Clean unlocked worktrees removed automatically; locked/active never touched | done | Handled by existing Phase 4 of `clean-branches.sh` (preserves active `.claude` processes, open issues); Deployer note reinforces in-cycle worktree pruning |
| A documented, scheduled or merge-triggered entry point owns this | done | Workflow file (scheduled + `workflow_dispatch`) and Deployer post-merge step |
| Safety guards preserved (never delete main; preserve open-PR / no-PR-ahead branches) | done | Phase 3b only deletes MERGED/CLOSED; explicitly skips main/master; preserves OPEN and NONE |
| Empty result set handled without error | done | Empty `remote_branches` skips the loop; `grep -c` guarded with `|| true` under `set -e` |

## Test Plan

- `bash -n scripts/clean-branches.sh` — passes.
- `bash scripts/clean-branches.sh --help` — renders the new `--remote` option and "Remote cleanup" section.
- Workflow YAML parsed with PyYAML — valid; `schedule`, `workflow_dispatch`, `concurrency`, `permissions`, and the run step verified.
- `--remote` reuses the existing, already-tested PR-status map; squash-merged PRs are detected via GitHub PR status (not ancestry).
- Post-merge: after the next `workflow_dispatch` run, confirm the Actions log shows merged origin branches deleted and `main`/open-PR branches preserved.

Scoped to the scheduled-invocation gap; worktree-self-cleanup-on-exit (#24857) is intentionally left out of scope.

Closes #25339