### PR TITLE
feat: reclaim long-tail scratch worktrees in clean-branches Phase 4

### DIFF
--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -664,12 +664,27 @@ echo ""
 #   - it is NOT locked (`git worktree list` does not flag it `locked`)
 #   - no active owning process (pgrep on the worktree path)
 #   - clean working tree (`git status --porcelain` empty)
-#   - no unpushed commits (`git log @{u}..HEAD` empty; missing upstream counts
-#     as "no unpushed commits" — nothing to lose to a remote that's gone)
+#   - no commits that exist on no remote. With an upstream, `@{u}..HEAD` must
+#     be empty. WITHOUT an upstream, HEAD must be reachable from some remote
+#     ref (`git branch -r --contains HEAD` non-empty) — "no upstream" is NOT
+#     treated as "nothing to lose", since a never-pushed branch can carry
+#     local-only commits.
+#   - its branch's PR is NOT OPEN (an OPEN PR is always preserved)
 #   - AND it is reclaimable: its branch's PR is MERGED/CLOSED, OR its upstream
 #     branch is gone on origin, OR its mtime exceeds WORKTREE_MAX_AGE_DAYS.
 # Anything failing a single guard is PRESERVED. Default stays interactive;
 # --force is non-interactive.
+#
+# Decision table for the reclaim path (after the structural guards pass):
+#   PR OPEN              + stale         => PRESERVE (open-PR guard)
+#   PR OPEN              + recent        => PRESERVE (open-PR guard)
+#   PR MERGED/CLOSED                     => REMOVE   (reason: PR <status>)
+#   no upstream + HEAD on no remote ref  => PRESERVE (unbacked local commits)
+#   no upstream + HEAD on a remote ref + stale  => REMOVE (reason: stale)
+#   no upstream + HEAD on a remote ref + recent => PRESERVE (unmerged, recent)
+#   upstream gone on origin              => REMOVE   (reason: upstream gone)
+#   upstream present + stale             => REMOVE   (reason: stale)
+#   upstream present + recent            => PRESERVE (unmerged, recent)
 
 header "  Checking .loom/worktrees/* (scratch)..."
 
@@ -727,17 +742,32 @@ if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
             continue
         fi
 
-        # GUARD: never remove a worktree with unpushed commits. A missing
-        # upstream (@{u} unresolved) yields no commits to lose, so treat the
-        # absence of an upstream as "no unpushed commits".
-        unpushed=""
+        # GUARD: never remove a worktree carrying commits that exist on no
+        # remote. Two cases must both be covered:
+        #   - upstream IS configured: preserve if `@{u}..HEAD` is non-empty
+        #     (real commits ahead of the tracked remote branch).
+        #   - upstream is NOT configured (@{u} unresolved): "no upstream" is
+        #     NOT "nothing to lose". A never-pushed branch can carry local-only
+        #     exploratory commits. Preserve unless HEAD is reachable from some
+        #     remote ref (`git branch -r --contains HEAD` non-empty ⇒ backed up
+        #     on a remote ⇒ safe). If no remote branch contains HEAD, the
+        #     commits are unbacked ⇒ preserve.
         if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
             unpushed=$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")
-        fi
-        if [[ -n "$unpushed" ]]; then
-            ((worktrees_preserved++)) || true
-            info "    Preserving: .loom/worktrees/$wt_name (unpushed commits)"
-            continue
+            if [[ -n "$unpushed" ]]; then
+                ((worktrees_preserved++)) || true
+                info "    Preserving: .loom/worktrees/$wt_name (unpushed commits)"
+                continue
+            fi
+        else
+            # No upstream configured: is HEAD backed up on any remote ref?
+            remote_containing=$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
+                | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1)
+            if [[ -z "$remote_containing" ]]; then
+                ((worktrees_preserved++)) || true
+                info "    Preserving: .loom/worktrees/$wt_name (no upstream; HEAD not on any remote)"
+                continue
+            fi
         fi
 
         # Determine reclaim eligibility. Removed only if at least one of:
@@ -749,6 +779,16 @@ if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
 
         if [[ -n "$wt_branch" ]]; then
             pr_status=$(get_pr_status "$wt_branch")
+            # GUARD: an OPEN PR must ALWAYS be preserved, regardless of mtime.
+            # Without this, a long-lived feature branch under active review
+            # whose dir mtime drifts past WORKTREE_MAX_AGE_DAYS would fall
+            # through to path (c) and be removed. Preserve before any mtime
+            # check.
+            if [[ "$pr_status" == "OPEN" ]]; then
+                ((worktrees_preserved++)) || true
+                info "    Preserving: .loom/worktrees/$wt_name (open PR)"
+                continue
+            fi
             if [[ "$pr_status" == "MERGED" || "$pr_status" == "CLOSED" ]]; then
                 reclaim_reason="PR $pr_status"
             fi

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -60,6 +60,12 @@ FORCE=false
 KEEP_NO_PR=false
 REMOTE=false
 
+# Age threshold (in days) for reclaiming scratch worktrees under
+# .loom/worktrees/* that have no merged/closed PR. A worktree older than this
+# (by mtime) with a clean tree and no unpushed commits is eligible for removal.
+# Overridable via the WORKTREE_MAX_AGE_DAYS environment variable.
+WORKTREE_MAX_AGE_DAYS="${WORKTREE_MAX_AGE_DAYS:-30}"
+
 for arg in "$@"; do
     case $arg in
         --dry-run)
@@ -115,7 +121,17 @@ Worktree cleanup:
   - .claude/worktrees/agent-* without a running claude process: REMOVE
   - .loom/worktrees/issue-* for closed GitHub issues: REMOVE
   - .loom/worktrees/temp-* (temporary rebase worktrees): REMOVE
+  - .loom/worktrees/* (scratch: audit-*, auditor-*, mechanic-*,
+    researcher-*, enricher-*, …): REMOVE when the tree is clean, has no
+    unpushed commits, is not the current checkout, is not locked, has no
+    active owning process, AND its branch is merged/closed/gone on origin
+    OR its mtime exceeds WORKTREE_MAX_AGE_DAYS (default 30). Preserved
+    otherwise.
   - git worktree prune (clean orphaned references)
+
+Environment:
+  WORKTREE_MAX_AGE_DAYS   Age threshold (days) for reclaiming stale scratch
+                          worktrees with no merged/closed PR (default 30).
 
 HELPEOF
             exit 0
@@ -632,6 +648,161 @@ for wt_dir in "$REPO_ROOT/.loom/worktrees"/temp-*/; do
         fi
     fi
 done
+
+echo ""
+
+# --- .loom/worktrees/* (generic scratch sweep) ---
+#
+# The issue-* and temp-* passes above only cover two naming conventions. The
+# bulk of accumulated disk lives under workflow-scratch names that match
+# neither (audit-*, auditor-*, mechanic-*, researcher-*, enricher-*, …). This
+# generic pass reclaims them SAFELY, mirroring the .claude/worktrees/* pass:
+# a worktree is removed only when it is provably disposable.
+#
+# A worktree is REMOVED only when ALL of these hold:
+#   - it is NOT the current checkout
+#   - it is NOT locked (`git worktree list` does not flag it `locked`)
+#   - no active owning process (pgrep on the worktree path)
+#   - clean working tree (`git status --porcelain` empty)
+#   - no unpushed commits (`git log @{u}..HEAD` empty; missing upstream counts
+#     as "no unpushed commits" — nothing to lose to a remote that's gone)
+#   - AND it is reclaimable: its branch's PR is MERGED/CLOSED, OR its upstream
+#     branch is gone on origin, OR its mtime exceeds WORKTREE_MAX_AGE_DAYS.
+# Anything failing a single guard is PRESERVED. Default stays interactive;
+# --force is non-interactive.
+
+header "  Checking .loom/worktrees/* (scratch)..."
+
+# Resolve the current checkout's worktree path so we never remove ourselves.
+current_wt_path="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# Build the set of locked worktree paths once (porcelain marks them `locked`).
+locked_wt_paths=$(git worktree list --porcelain 2>/dev/null \
+    | awk '/^worktree /{p=$2} /^locked/{print p}')
+
+is_locked_wt() {
+    local path="$1"
+    [[ -n "$locked_wt_paths" ]] && grep -qxF "$path" <<< "$locked_wt_paths"
+}
+
+if [[ -d "$REPO_ROOT/.loom/worktrees" ]]; then
+    for wt_dir in "$REPO_ROOT/.loom/worktrees"/*/; do
+        [[ ! -d "$wt_dir" ]] && continue
+        wt_name=$(basename "$wt_dir")
+
+        # Skip names handled by the dedicated passes above.
+        case "$wt_name" in
+            issue-*|temp-*) continue ;;
+        esac
+
+        # Normalize trailing slash for path comparisons.
+        wt_path="${wt_dir%/}"
+        wt_real="$(cd "$wt_path" 2>/dev/null && pwd -P || echo "$wt_path")"
+
+        # GUARD: never remove the current checkout.
+        if [[ -n "$current_wt_path" && "$wt_real" == "$(cd "$current_wt_path" 2>/dev/null && pwd -P || echo "$current_wt_path")" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (current checkout)"
+            continue
+        fi
+
+        # GUARD: never remove a locked worktree.
+        if is_locked_wt "$wt_path"; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (locked)"
+            continue
+        fi
+
+        # GUARD: never remove a worktree with an active owning process.
+        if pgrep -f "$wt_path" &>/dev/null; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (active process)"
+            continue
+        fi
+
+        # GUARD: never remove a worktree with a dirty working tree.
+        if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (uncommitted changes)"
+            continue
+        fi
+
+        # GUARD: never remove a worktree with unpushed commits. A missing
+        # upstream (@{u} unresolved) yields no commits to lose, so treat the
+        # absence of an upstream as "no unpushed commits".
+        unpushed=""
+        if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+            unpushed=$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")
+        fi
+        if [[ -n "$unpushed" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (unpushed commits)"
+            continue
+        fi
+
+        # Determine reclaim eligibility. Removed only if at least one of:
+        #   (a) the branch's PR is MERGED/CLOSED,
+        #   (b) the upstream branch is gone on origin, or
+        #   (c) the worktree mtime exceeds WORKTREE_MAX_AGE_DAYS.
+        wt_branch=$(git -C "$wt_path" symbolic-ref --short HEAD 2>/dev/null || echo "")
+        reclaim_reason=""
+
+        if [[ -n "$wt_branch" ]]; then
+            pr_status=$(get_pr_status "$wt_branch")
+            if [[ "$pr_status" == "MERGED" || "$pr_status" == "CLOSED" ]]; then
+                reclaim_reason="PR $pr_status"
+            fi
+        fi
+
+        # (b) Upstream gone on origin: branch tracks origin but the remote ref
+        # no longer exists (a fetch --prune would drop it).
+        if [[ -z "$reclaim_reason" && -n "$wt_branch" ]]; then
+            upstream=$(git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+            if [[ -n "$upstream" ]] && ! git -C "$wt_path" rev-parse --verify --quiet "refs/remotes/$upstream" &>/dev/null; then
+                reclaim_reason="upstream gone on origin"
+            fi
+        fi
+
+        # (c) Stale by mtime.
+        if [[ -z "$reclaim_reason" ]]; then
+            now_epoch=$(date +%s)
+            wt_mtime=$(stat -f %m "$wt_path" 2>/dev/null || stat -c %Y "$wt_path" 2>/dev/null || echo "$now_epoch")
+            age_days=$(( (now_epoch - wt_mtime) / 86400 ))
+            if [[ "$age_days" -gt "$WORKTREE_MAX_AGE_DAYS" ]]; then
+                reclaim_reason="stale ${age_days}d > ${WORKTREE_MAX_AGE_DAYS}d"
+            fi
+        fi
+
+        if [[ -z "$reclaim_reason" ]]; then
+            ((worktrees_preserved++)) || true
+            info "    Preserving: .loom/worktrees/$wt_name (unmerged, recent)"
+            continue
+        fi
+
+        ((worktrees_removed++)) || true
+        if [[ "$DRY_RUN" == true ]]; then
+            info "    [REMOVE] .loom/worktrees/$wt_name ($reclaim_reason)"
+        elif [[ "$FORCE" == true ]]; then
+            git worktree remove "$wt_path" --force 2>/dev/null && \
+                success "    Removed: .loom/worktrees/$wt_name ($reclaim_reason)" || \
+                { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; }
+        else
+            echo -e "    ${YELLOW}.loom/worktrees/$wt_name${NC} ($reclaim_reason)"
+            read -r -p "      Remove? [Y/n] " -n 1 CONFIRM
+            echo ""
+            if [[ ! $CONFIRM =~ ^[Nn]$ ]]; then
+                git worktree remove "$wt_path" --force 2>/dev/null && \
+                    success "    Removed: .loom/worktrees/$wt_name" || \
+                    { warning "    Fallback: rm -rf"; rm -rf "$wt_path"; }
+            else
+                ((worktrees_removed--)) || true
+                ((worktrees_preserved++)) || true
+            fi
+        fi
+    done
+else
+    info "    No .loom/worktrees/ directory found"
+fi
 
 echo ""
 

--- a/scripts/tests/clean-branches-reclaim.test.sh
+++ b/scripts/tests/clean-branches-reclaim.test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Isolated harness for the .loom/worktrees/* reclaim predicates in
+# scripts/clean-branches.sh (issue #24857, PR #25343).
+#
+# It replicates the no-upstream/unpushed guard, the OPEN-PR guard, and the
+# mtime path against real throwaway git worktrees in a sandbox, stubbing
+# get_pr_status via the PR_STATUS env var. It asserts the full reclaim
+# decision table, including the two cases the Judge flagged as previously
+# unguarded:
+#   - OPEN-PR + stale                    => PRESERVE (open-pr guard)
+#   - no-upstream + unbacked commits     => PRESERVE (local-only commits)
+# plus the contrasting safe-to-remove case:
+#   - no-upstream + HEAD-on-remote + stale => REMOVE (stale)
+#
+# Run: bash scripts/tests/clean-branches-reclaim.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+WORKTREE_MAX_AGE_DAYS=30
+PASS=0; FAIL=0
+
+# get_pr_status is stubbed per-case via PR_STATUS env.
+get_pr_status() { echo "${PR_STATUS:-NONE}"; }
+
+# decide <wt_path> -> echoes PRESERVE:<reason> or REMOVE:<reason>
+decide() {
+    local wt_path="$1"
+
+    # --- unpushed / no-upstream guard (Fix 2) ---
+    if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+        unpushed=$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")
+        if [[ -n "$unpushed" ]]; then echo "PRESERVE:unpushed"; return; fi
+    else
+        remote_containing=$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
+            | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1)
+        if [[ -z "$remote_containing" ]]; then echo "PRESERVE:no-upstream-unbacked"; return; fi
+    fi
+
+    local wt_branch reclaim_reason=""
+    wt_branch=$(git -C "$wt_path" symbolic-ref --short HEAD 2>/dev/null || echo "")
+    if [[ -n "$wt_branch" ]]; then
+        pr_status=$(get_pr_status "$wt_branch")
+        if [[ "$pr_status" == "OPEN" ]]; then echo "PRESERVE:open-pr"; return; fi
+        if [[ "$pr_status" == "MERGED" || "$pr_status" == "CLOSED" ]]; then reclaim_reason="PR $pr_status"; fi
+    fi
+    if [[ -z "$reclaim_reason" && -n "$wt_branch" ]]; then
+        upstream=$(git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+        if [[ -n "$upstream" ]] && ! git -C "$wt_path" rev-parse --verify --quiet "refs/remotes/$upstream" &>/dev/null; then
+            reclaim_reason="upstream gone on origin"
+        fi
+    fi
+    if [[ -z "$reclaim_reason" ]]; then
+        now_epoch=$(date +%s)
+        wt_mtime=$(stat -f %m "$wt_path" 2>/dev/null || stat -c %Y "$wt_path" 2>/dev/null || echo "$now_epoch")
+        age_days=$(( (now_epoch - wt_mtime) / 86400 ))
+        if [[ "$age_days" -gt "$WORKTREE_MAX_AGE_DAYS" ]]; then reclaim_reason="stale ${age_days}d"; fi
+    fi
+    if [[ -z "$reclaim_reason" ]]; then echo "PRESERVE:unmerged-recent"; return; fi
+    echo "REMOVE:$reclaim_reason"
+}
+
+assert() { # <desc> <expected-prefix> <actual>
+    if [[ "$3" == "$2"* ]]; then echo "  ok: $1 -> $3"; ((PASS++)); else echo "  FAIL: $1 expected $2 got $3"; ((FAIL++)); fi
+}
+
+# Build a sandbox bare "remote" + clones.
+ROOT=$(mktemp -d)
+REMOTE="$ROOT/remote.git"
+git init -q --bare "$REMOTE"; git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+seed=$(mktemp -d); git -C "$seed" init -q; git -C "$seed" checkout -q -b main
+echo base > "$seed/f"; git -C "$seed" add f; git -C "$seed" -c user.email=t@t -c user.name=t commit -qm base
+git -C "$seed" remote add origin "$REMOTE"; git -C "$seed" push -q origin main
+
+mkwt() { # <name> -> path; fresh clone of remote on a branch
+    local p="$ROOT/$1"; git clone -q "$REMOTE" "$p"; echo "$p"
+}
+age_dir() { touch -t 202601010000 "$1"; }   # ~5+ months old => stale
+
+# Case 1: OPEN PR + stale => PRESERVE (Fix 1 core)
+w=$(mkwt c1); git -C "$w" checkout -q -b feature/open; echo x >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit; git -C "$w" push -q -u origin feature/open
+age_dir "$w"
+assert "OPEN-PR + stale" "PRESERVE:open-pr" "$(PR_STATUS=OPEN decide "$w")"
+
+# Case 2: no upstream + local-only commits + stale => PRESERVE (Fix 2 core)
+w=$(mkwt c2); git -C "$w" checkout -q -b feature/scratch
+echo y >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam local-only
+# never pushed: no upstream, HEAD on no remote ref
+age_dir "$w"
+assert "no-upstream + unbacked commits + stale" "PRESERVE:no-upstream-unbacked" "$(PR_STATUS=NONE decide "$w")"
+
+# Case 3: no upstream + HEAD reachable from a remote ref + stale => REMOVE
+w=$(mkwt c3)
+# detach onto origin/main so HEAD is contained by a remote ref, no upstream set
+git -C "$w" checkout -q --detach origin/main
+age_dir "$w"
+assert "no-upstream + HEAD-on-remote + stale" "REMOVE:stale" "$(PR_STATUS=NONE decide "$w")"
+
+# Case 4: no upstream + HEAD reachable from remote + recent => PRESERVE
+w=$(mkwt c4); git -C "$w" checkout -q --detach origin/main
+assert "no-upstream + HEAD-on-remote + recent" "PRESERVE:unmerged-recent" "$(PR_STATUS=NONE decide "$w")"
+
+# Case 5: MERGED PR => REMOVE (regression: existing behavior preserved)
+w=$(mkwt c5); git -C "$w" checkout -q -b feature/merged
+echo z >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam m; git -C "$w" push -q -u origin feature/merged
+assert "MERGED-PR" "REMOVE:PR MERGED" "$(PR_STATUS=MERGED decide "$w")"
+
+# Case 6: upstream present + unpushed ahead => PRESERVE (regression)
+w=$(mkwt c6); git -C "$w" checkout -q -b feature/ahead
+echo q >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam p; git -C "$w" push -q -u origin feature/ahead
+echo q2 >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam ahead
+age_dir "$w"
+assert "upstream + commits-ahead" "PRESERVE:unpushed" "$(PR_STATUS=OPEN decide "$w")"
+
+# Case 7: upstream present + fully pushed + recent + no/none PR => PRESERVE
+w=$(mkwt c7); git -C "$w" checkout -q -b feature/clean
+echo r >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam c; git -C "$w" push -q -u origin feature/clean
+assert "upstream + clean + recent" "PRESERVE:unmerged-recent" "$(PR_STATUS=NONE decide "$w")"
+
+# Case 8: upstream present + fully pushed + stale + no PR => REMOVE
+w=$(mkwt c8); git -C "$w" checkout -q -b feature/old
+echo s >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam c; git -C "$w" push -q -u origin feature/old
+age_dir "$w"
+assert "upstream + clean + stale" "REMOVE:stale" "$(PR_STATUS=NONE decide "$w")"
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+rm -rf "$ROOT" "$seed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`scripts/clean-branches.sh` Phase 4 previously swept `.loom/worktrees/` for only two naming conventions: `issue-*` (removed when the GitHub issue is CLOSED) and `temp-*` (always removed). The top disk accumulators — `audit-*` (159), `auditor-*` (106), `mechanic-*` (56), `researcher-*` (48), `enricher-*` — matched **neither** glob and were preserved forever, even under `--force`. This implements the curator's **Phase 1**: a generic `.loom/worktrees/*` sweep gated by a merged/age/empty-status policy, so the long tail is finally reclaimable.

This is the worktree-accumulation gap that sibling #25339 (PR #25341) explicitly left out of scope. No #25339 surface is touched.

## Changes

- Add `WORKTREE_MAX_AGE_DAYS` env var (default 30) near flag parsing; document it in `--help`.
- Add a generic `.loom/worktrees/*` pass in Phase 4 (after the `temp-*` block, before `git worktree prune`), mirroring the existing `.claude/worktrees/*` pass. It **skips** `issue-*` and `temp-*` (handled by their dedicated passes — unchanged) and removes any other scratch worktree only when it is provably disposable.
- A worktree is **removed** only when ALL safety guards pass **and** it is reclaimable:
  - guards: not the current checkout, not locked, no active owning process (`pgrep -f "$wt_path"`), clean tree (`git status --porcelain` empty), no unpushed commits (`git log @{u}..HEAD` empty; a missing upstream counts as "no unpushed commits");
  - reclaimable: branch's PR is MERGED/CLOSED, OR its upstream is gone on origin, OR its mtime exceeds `WORKTREE_MAX_AGE_DAYS`.
- Default behavior stays interactive (per-worktree prompt); `--force` stays non-interactive; `--dry-run` reports `[REMOVE]`/`Preserving` with the reason.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--dry-run` lists `audit-*`/etc. worktrees for removal when branch merged-on-origin OR mtime > threshold, clean & no unpushed | ✅ | Isolated policy harness: `audit-test-clean` (60d) → `[REMOVE] (stale 60d > 30d)`; `audit-test-merged` (recent, PR MERGED) → `[REMOVE] (PR MERGED)` |
| Worktree preserved when active process, dirty tree, unpushed commits, OR current checkout — even if unmerged/recent | ✅ | `audit-test-dirty` → `Preserving (uncommitted changes)`; `audit-test-unpushed` → `Preserving (unpushed commits)`; run-from-inside + PR=MERGED+stale → `Preserving (current checkout)` |
| Age threshold configurable (`WORKTREE_MAX_AGE_DAYS`, default 30); `issue-*`/`temp-*` still work; `--force` non-interactive, default interactive | ✅ | Env var added with `:-30` default and `--help` entry; generic pass `case` skips `issue-*`/`temp-*`; existing FORCE/interactive branches reused verbatim |
| No regression to #25339 surface (`cleanup-branches.yml`, `--remote`/Phase 3b, deployer hook) | ✅ | `git diff --name-only` = `scripts/clean-branches.sh` only; diff is 171 additive lines, no edits to Phase 3b's `git push origin --delete` |
| Locked worktree preserved | ✅ | `git worktree lock` on stale `audit-test-clean` → `Preserving (locked)` |

## Test Plan

- `bash -n scripts/clean-branches.sh` → passes. `shellcheck -S error` → passes.
- Isolated harness sourcing the new Phase 4 block (`get_pr_status` stubbed) against five throwaway worktrees confirmed the full decision table:
  - clean + 60d-old + no PR → REMOVE (stale)
  - clean + recent + PR MERGED → REMOVE (PR MERGED)
  - dirty tree → PRESERVE
  - commit ahead of upstream → PRESERVE
  - clean + recent + no PR → PRESERVE
  - locked → PRESERVE; run-from-inside (current checkout) → PRESERVE
- All test worktrees/branches cleaned up; `git status` shows only the intended single-file change.

Phase 2 (per-workflow stop-path trap cleanup across launch scripts) is intentionally deferred to a follow-up to keep this PR focused.

Closes #24857