### PR TITLE
fix: harden get_pr_status branch lookup against regex metacharacters

### DIFF
--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -238,9 +238,13 @@ cat "$PR_MAP_FILE.closed" "$PR_MAP_FILE.open" > "$PR_MAP_FILE"
 # Returns: MERGED, CLOSED, OPEN, or NONE
 get_pr_status() {
     local branch="$1"
-    # Get the LAST matching entry (open overrides closed if both exist)
+    # Exact, literal field match on the tab-separated <branch>\t<status> map.
+    # Using awk (not grep) avoids interpreting regex metacharacters in the
+    # branch name as a BRE pattern, which could false-match another branch's
+    # PR status. The END{print s} form keeps the LAST matching status, so the
+    # open-overrides-closed semantics (open entries appended last) are preserved.
     local status
-    status=$(grep "^${branch}	" "$PR_MAP_FILE" | tail -1 | cut -f2)
+    status=$(awk -F'\t' -v b="$branch" '$1==b {s=$2} END{print s}' "$PR_MAP_FILE")
     echo "${status:-NONE}"
 }
 

--- a/scripts/tests/clean-branches-reclaim.test.sh
+++ b/scripts/tests/clean-branches-reclaim.test.sh
@@ -122,6 +122,37 @@ echo s >> "$w/f"; git -C "$w" -c user.email=t@t -c user.name=t commit -qam c; gi
 age_dir "$w"
 assert "upstream + clean + stale" "REMOVE:stale" "$(PR_STATUS=NONE decide "$w")"
 
+# -----------------------------------------------------------------------------
+# get_pr_status real-lookup tests (issue #25342): exact literal field match.
+# The `decide` cases above stub get_pr_status via PR_STATUS, so they do not
+# exercise the real PR_MAP_FILE lookup. Here we run the real function against a
+# tab-separated map to prove (a) regex metacharacters in the branch name do not
+# false-match another branch, (b) last-wins (open-overrides-closed) is kept, and
+# (c) an absent branch returns NONE.
+# This definition mirrors scripts/clean-branches.sh:get_pr_status.
+get_pr_status_real() {
+    local branch="$1"
+    local status
+    status=$(awk -F'\t' -v b="$branch" '$1==b {s=$2} END{print s}' "$PR_MAP_FILE")
+    echo "${status:-NONE}"
+}
+
+PR_MAP_FILE=$(mktemp)
+printf 'fixxfoo\tMERGED\n'  >> "$PR_MAP_FILE"   # would be false-matched by `fix.foo` under grep BRE
+printf 'fix.foo\tOPEN\n'    >> "$PR_MAP_FILE"
+printf 'feature/a*b\tCLOSED\n' >> "$PR_MAP_FILE"
+printf 'feature/ladder\tCLOSED\n' >> "$PR_MAP_FILE"
+printf 'feature/ladder\tOPEN\n'   >> "$PR_MAP_FILE"   # later entry wins (open overrides closed)
+printf 'fix-2\tMERGED\n'    >> "$PR_MAP_FILE"
+
+assert "metachar literal: fix.foo not matching fixxfoo" "OPEN"   "$(get_pr_status_real 'fix.foo')"
+assert "metachar literal: fixxfoo own status"           "MERGED" "$(get_pr_status_real 'fixxfoo')"
+assert "metachar literal: a*b own status"               "CLOSED" "$(get_pr_status_real 'feature/a*b')"
+assert "last-wins: closed-then-open => OPEN"            "OPEN"   "$(get_pr_status_real 'feature/ladder')"
+assert "absent branch => NONE"                          "NONE"   "$(get_pr_status_real 'feature/missing')"
+assert "substring guard: fix vs fix-2"                  "NONE"   "$(get_pr_status_real 'fix')"
+rm -f "$PR_MAP_FILE"
+
 echo ""
 echo "PASS=$PASS FAIL=$FAIL"
 rm -rf "$ROOT" "$seed"


### PR DESCRIPTION
## Summary

`get_pr_status()` in `scripts/clean-branches.sh` interpolated the branch name into a `grep` BRE pattern:

```bash
status=$(grep "^${branch}\t" "$PR_MAP_FILE" | tail -1 | cut -f2)
```

A branch name containing regex metacharacters (`.`, `+`, `*`, `[`, `^`, `$`) was treated as a pattern, so it could false-match another branch's `<branch>\t<status>` line. This status now governs remote-branch deletion (Phase 3b) and worktree reclaim, making a false `MERGED`/`CLOSED` match a real (low-probability) data-loss risk.

## Fix

Replace the `grep | tail -1 | cut` pipeline with an exact literal field match:

```bash
status=$(awk -F'\t' -v b="$branch" '$1==b {s=$2} END{print s}' "$PR_MAP_FILE")
```

- `awk` matches `$1` as a literal string — no regex interpretation of the branch name.
- `END{print s}` keeps the **last** matching status, preserving the existing open-overrides-closed semantics that `tail -1` provided (the map appends open PRs after closed/merged).
- Empty output on no match is unchanged, so callers still resolve `NONE` via the surrounding `${status:-NONE}` default.

`PR_MAP_FILE` is a tab-separated `<branch>\t<status>` `mktemp` file, so `-F'\t'` is the correct field separator.

## Tests

The existing reclaim harness stubs `get_pr_status` via `PR_STATUS`, so it never exercised the real lookup. Added 6 real-lookup assertions to `scripts/tests/clean-branches-reclaim.test.sh`:

- `fix.foo` does **not** false-match a `fixxfoo` line (returns its own status).
- `fixxfoo` and `feature/a*b` resolve to their own statuses (metacharacter literal).
- last-wins: a branch listed `CLOSED` then `OPEN` resolves to `OPEN`.
- absent branch returns `NONE`.
- substring guard: `fix` vs `fix-2` returns `NONE` (no partial match).

### Validation

- `bash -n scripts/clean-branches.sh` — passes
- `shellcheck -S error scripts/clean-branches.sh` — passes
- `shellcheck -S error scripts/tests/clean-branches-reclaim.test.sh` — passes
- `bash scripts/tests/clean-branches-reclaim.test.sh` — `PASS=14 FAIL=0`

Demonstrated the genuine cross-branch leak with a pathological ordering (real branch entry first, metacharacter false-match line last): old `grep` returns the wrong (false-matched) status; new `awk` returns the correct one.

## Scope

Minimal: only the `get_pr_status()` function in `scripts/clean-branches.sh` plus a focused test case. No other restructuring.

Closes #25342

🤖 Generated with [Claude Code](https://claude.com/claude-code)