### PR TITLE
feat(scripts): reclaim agent worktrees on stop via shared safety guards

### DIFF
--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -63,6 +63,10 @@ print_success() { echo -e "${GREEN}+ $1${NC}"; }
 print_info() { echo -e "${BLUE}i $1${NC}"; }
 print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -261,6 +265,13 @@ stop_agent() {
 
     # Clean up signal
     rm -f "$SIGNALS_DIR/stop-auditor"
+
+    # Reclaim the agent's worktree now that its session is gone. The session is
+    # dead (kill-session above) so the worktree is idle; remove_own_worktree
+    # applies the shared safety guards (dirty / unpushed-or-unbacked / locked /
+    # active-process / current-checkout) and is a no-op if there is nothing to
+    # remove.
+    remove_own_worktree "$WORKTREE_PATH"
 }
 
 # Graceful stop (just create signal, don't kill)

--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -38,6 +38,10 @@ print_success() { echo -e "${GREEN}✓ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 print_error() { echo -e "${RED}x $1${NC}" >&2; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -196,28 +200,51 @@ stop_agents() {
     # Cleanup stale claims
     print_info "Cleaning up claims..."
     "$REPO_ROOT/scripts/enricher/claim-target.sh" cleanup 2>/dev/null || true
+
+    # Reclaim the now-idle worktrees. The sessions are killed above, so each
+    # enricher-N worktree is idle; the shared guards preserve any that are
+    # dirty / unpushed-or-unbacked / locked / current-checkout. Previously only
+    # the explicit --cleanup path removed worktrees, leaking them on --stop.
+    reclaim_worktrees
+}
+
+# Reclaim each enricher-N worktree using the shared safety guards. A dirty,
+# unpushed/unbacked, locked, busy, or current-checkout worktree is preserved.
+# Idempotent and quiet when there is nothing to remove.
+reclaim_worktrees() {
+    for i in $(seq 1 "$MAX_AGENTS"); do
+        local worktree_path="$WORKTREES_DIR/enricher-$i"
+        [[ -d "$worktree_path" ]] || continue
+        remove_own_worktree "$worktree_path"
+    done
+    git worktree prune 2>/dev/null || true
 }
 
 # Cleanup all enricher worktrees
 cleanup_worktrees() {
     echo "Cleaning up enricher worktrees..."
 
-    # First stop any running agents
+    # First stop any running agents (this also reclaims idle worktrees via the
+    # shared guards).
     stop_agents
 
-    # Remove worktrees
-    for i in $(seq 1 $MAX_AGENTS); do
+    # Reclaim any worktrees that survived stop_agents (e.g. no agent was
+    # running), and delete their fully-backed-up branches.
+    for i in $(seq 1 "$MAX_AGENTS"); do
         local worktree_path="$WORKTREES_DIR/enricher-$i"
         local branch_name="feature/enricher-$i"
 
         if [[ -d "$worktree_path" ]]; then
-            print_info "Removing worktree: $worktree_path"
-            git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path"
+            remove_own_worktree "$worktree_path"
         fi
 
-        # Delete branch
-        git branch -D "$branch_name" 2>/dev/null && \
-            print_info "Deleted branch: $branch_name" || true
+        # Delete branch only if its worktree was actually reclaimed (git refuses
+        # to delete a branch still checked out in a worktree). A preserved
+        # worktree keeps its branch.
+        if [[ ! -d "$worktree_path" ]]; then
+            git branch -D "$branch_name" 2>/dev/null && \
+                print_info "Deleted branch: $branch_name" || true
+        fi
     done
 
     # Prune worktree references

--- a/scripts/lib/worktree-cleanup.sh
+++ b/scripts/lib/worktree-cleanup.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# worktree-cleanup.sh - shared per-workflow worktree reclaim helper.
+#
+# Provides `remove_own_worktree <worktree_path>`: safely removes an agent's own
+# worktree once the agent has stopped. This is the per-workflow ("at the
+# source") counterpart to the centralized backstop janitor in
+# scripts/clean-branches.sh Phase 4 (issue #24857 / PR #25343). It reuses the
+# EXACT structural safety guards 1-5 from that janitor so the two paths share a
+# single decision contract and a crashed agent mid-edit never loses work.
+#
+# Guards (a worktree is removed ONLY when ALL hold):
+#   1. Not the current checkout (real-path normalized compare).
+#   2. Not locked (`git worktree list --porcelain` does not flag it `locked`).
+#   3. No active owning process (`pgrep -f "<path>"`).
+#   4. Clean working tree (`git -C <path> status --porcelain` empty).
+#   5. No commits that exist on no remote:
+#        - upstream configured  => `@{u}..HEAD` must be empty.
+#        - no upstream          => HEAD must be reachable from some remote ref
+#                                  (`git branch -r --contains HEAD` non-empty).
+#
+# Unlike the backstop janitor, this helper does NOT re-implement the reclaim
+# *trigger* logic (PR merged/closed, upstream-gone, mtime-stale). At agent-stop
+# time the worktree being removed is, by construction, the agent's own and is
+# meant to be reclaimed; the structural guards above are the only protection
+# required. The backstop janitor remains responsible for crashed-without-stop
+# cases.
+#
+# Usage (source then call):
+#   source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+#   remove_own_worktree "$WORKTREE_PATH"
+#
+# Return codes:
+#   0 - worktree removed, OR nothing to remove (idempotent), OR preserved by a
+#       guard. The caller's stop path should not treat a preserved/absent
+#       worktree as a failure, so guard-preservation is NOT an error.
+#
+# The helper is intentionally quiet by default. Set WORKTREE_CLEANUP_VERBOSE=1
+# to emit a one-line reason on every decision (useful for debugging / tests).
+
+# Emit a message only when verbose mode is enabled. Goes to stderr so it never
+# pollutes a caller that captures stdout.
+_wc_log() {
+    [[ "${WORKTREE_CLEANUP_VERBOSE:-0}" == "1" ]] && echo "worktree-cleanup: $*" >&2
+    return 0
+}
+
+# remove_own_worktree <worktree_path>
+#
+# Idempotent: if the path does not exist (already removed), returns 0 quietly.
+# Applies structural guards 1-5; on any guard hit, preserves and returns 0.
+# Only when all guards pass does it `git worktree remove --force` (falling back
+# to `rm -rf` + `git worktree prune` if the git removal fails).
+remove_own_worktree() {
+    local wt_path="$1"
+
+    # Idempotency: nothing to remove.
+    if [[ -z "$wt_path" || ! -d "$wt_path" ]]; then
+        _wc_log "skip (absent): ${wt_path:-<empty>}"
+        return 0
+    fi
+
+    local wt_real
+    wt_real="$(cd "$wt_path" 2>/dev/null && pwd -P || echo "$wt_path")"
+
+    # GUARD 1: never remove the current checkout.
+    local current_wt_path current_real
+    current_wt_path="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+    if [[ -n "$current_wt_path" ]]; then
+        current_real="$(cd "$current_wt_path" 2>/dev/null && pwd -P || echo "$current_wt_path")"
+        if [[ "$wt_real" == "$current_real" ]]; then
+            _wc_log "preserve (current checkout): $wt_path"
+            return 0
+        fi
+    fi
+
+    # GUARD 2: never remove a locked worktree. Porcelain marks them `locked`.
+    # Compare on real paths: `git worktree list` emits canonical paths (e.g.
+    # /private/tmp on macOS) while the caller may pass a symlinked path
+    # (/tmp), so a literal string compare can miss a genuine lock.
+    local locked_wt_paths
+    locked_wt_paths="$(git worktree list --porcelain 2>/dev/null \
+        | awk '/^worktree /{p=$2} /^locked/{print p}')"
+    if [[ -n "$locked_wt_paths" ]]; then
+        local locked_path locked_real
+        while IFS= read -r locked_path; do
+            [[ -z "$locked_path" ]] && continue
+            locked_real="$(cd "$locked_path" 2>/dev/null && pwd -P || echo "$locked_path")"
+            if [[ "$locked_real" == "$wt_real" ]]; then
+                _wc_log "preserve (locked): $wt_path"
+                return 0
+            fi
+        done <<< "$locked_wt_paths"
+    fi
+
+    # GUARD 3: never remove a worktree with an active owning process.
+    if pgrep -f "$wt_path" &>/dev/null; then
+        _wc_log "preserve (active process): $wt_path"
+        return 0
+    fi
+
+    # GUARD 4: never remove a worktree with a dirty working tree.
+    if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+        _wc_log "preserve (uncommitted changes): $wt_path"
+        return 0
+    fi
+
+    # GUARD 5: never remove a worktree carrying commits that exist on no remote.
+    #   - upstream IS configured: preserve if `@{u}..HEAD` is non-empty (real
+    #     commits ahead of the tracked remote branch).
+    #   - upstream is NOT configured: "no upstream" is NOT "nothing to lose". A
+    #     never-pushed branch can carry local-only commits. Preserve unless HEAD
+    #     is reachable from some remote ref (`git branch -r --contains HEAD`).
+    if git -C "$wt_path" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+        local unpushed
+        unpushed="$(git -C "$wt_path" log --oneline '@{u}..HEAD' 2>/dev/null || echo "")"
+        if [[ -n "$unpushed" ]]; then
+            _wc_log "preserve (unpushed commits): $wt_path"
+            return 0
+        fi
+    else
+        local remote_containing
+        remote_containing="$(git -C "$wt_path" branch -r --contains HEAD 2>/dev/null \
+            | grep -v '\->' | sed 's/^[[:space:]]*//' | head -n 1)"
+        if [[ -z "$remote_containing" ]]; then
+            _wc_log "preserve (no upstream; HEAD not on any remote): $wt_path"
+            return 0
+        fi
+    fi
+
+    # All guards passed: this worktree is the agent's own, idle, clean, and
+    # fully backed up. Remove it.
+    if git worktree remove "$wt_path" --force 2>/dev/null; then
+        _wc_log "removed: $wt_path"
+    else
+        # Fallback: directory may be a stale/orphaned worktree git no longer
+        # tracks. Remove on disk and prune the dangling reference.
+        rm -rf "$wt_path" 2>/dev/null || true
+        git worktree prune 2>/dev/null || true
+        _wc_log "removed (rm -rf fallback): $wt_path"
+    fi
+    return 0
+}

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -63,6 +63,10 @@ print_success() { echo -e "${GREEN}+ $1${NC}"; }
 print_info() { echo -e "${BLUE}i $1${NC}"; }
 print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -260,6 +264,13 @@ stop_agent() {
 
     # Clean up signal
     rm -f "$SIGNALS_DIR/stop-mechanic"
+
+    # Reclaim the agent's worktree now that its session is gone. The session is
+    # dead (kill-session above) so the worktree is idle; remove_own_worktree
+    # applies the shared safety guards (dirty / unpushed-or-unbacked / locked /
+    # active-process / current-checkout) and is a no-op if there is nothing to
+    # remove.
+    remove_own_worktree "$WORKTREE_PATH"
 }
 
 # Graceful stop (just create signal, don't kill)

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -35,6 +35,10 @@ LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 CLAIM_SCRIPT="$REPO_ROOT/scripts/research/claim-problem.sh"
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -353,6 +357,17 @@ signal_graceful_stop() {
     fi
 }
 
+# Reclaim each researcher-N worktree using the shared safety guards. A dirty,
+# unpushed/unbacked, locked, busy, or current-checkout worktree is preserved.
+# Idempotent and quiet when there is nothing to remove.
+reclaim_worktrees() {
+    for worktree in "$WORKTREES_DIR"/researcher-*; do
+        [[ -d "$worktree" ]] || continue
+        remove_own_worktree "$worktree"
+    done
+    git worktree prune 2>/dev/null || true
+}
+
 # Force stop all agents
 force_stop() {
     print_info "Force stopping all research agents..."
@@ -368,22 +383,20 @@ force_stop() {
 
     # Clean up stale claims
     "$CLAIM_SCRIPT" cleanup 2>/dev/null || true
+
+    # Reclaim the now-idle worktrees. The sessions are killed above, so each
+    # researcher-N worktree is idle; the shared guards preserve any that are
+    # dirty / unpushed-or-unbacked / locked / current-checkout. Previously only
+    # the explicit --cleanup path removed worktrees, leaking them on --stop.
+    reclaim_worktrees
 }
 
 # Cleanup everything
 cleanup_all() {
     force_stop
 
-    print_info "Removing researcher worktrees..."
-    for worktree in "$WORKTREES_DIR"/researcher-*; do
-        if [[ -d "$worktree" ]]; then
-            git worktree remove "$worktree" --force 2>/dev/null && \
-                print_success "Removed $worktree" || \
-                print_warning "Could not remove $worktree"
-        fi
-    done
-
-    git worktree prune 2>/dev/null || true
+    print_info "Reclaiming researcher worktrees..."
+    reclaim_worktrees
     print_success "Cleanup complete"
 }
 

--- a/scripts/tests/worktree-cleanup.test.sh
+++ b/scripts/tests/worktree-cleanup.test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Isolated harness for remove_own_worktree in scripts/lib/worktree-cleanup.sh
+# (issue #25344, Phase 2a per-workflow worktree cleanup contract).
+#
+# Exercises the decision table against real throwaway git worktrees in a
+# sandbox. A worktree must be REMOVED only when it is clean AND fully backed up
+# (merged/stale-but-pushed); it must be PRESERVED when dirty, when it carries
+# unpushed or unbacked commits, when locked, or when it is the current checkout.
+#
+# Run: bash scripts/tests/worktree-cleanup.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$SCRIPT_DIR/../lib/worktree-cleanup.sh"
+
+PASS=0
+FAIL=0
+
+assert_removed() { # <desc> <wt_path>
+    if [[ -d "$2" ]]; then
+        echo "  FAIL: $1 -> expected REMOVED, dir still present: $2"
+        ((FAIL++))
+    else
+        echo "  ok: $1 -> REMOVED"
+        ((PASS++))
+    fi
+}
+
+assert_preserved() { # <desc> <wt_path>
+    if [[ -d "$2" ]]; then
+        echo "  ok: $1 -> PRESERVED"
+        ((PASS++))
+    else
+        echo "  FAIL: $1 -> expected PRESERVED, dir gone: $2"
+        ((FAIL++))
+    fi
+}
+
+# Build a sandbox bare "remote" + a main worktree we attach throwaway worktrees
+# to. We operate the worktrees relative to MAIN (so they are real linked
+# worktrees of one repo and `git worktree remove` works).
+ROOT="$(mktemp -d)"
+REMOTE="$ROOT/remote.git"
+git init -q --bare "$REMOTE"
+git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+
+MAIN="$ROOT/main"
+git clone -q "$REMOTE" "$MAIN" 2>/dev/null
+echo base > "$MAIN/f"
+git -C "$MAIN" -c user.email=t@t -c user.name=t add f
+git -C "$MAIN" -c user.email=t@t -c user.name=t commit -qm base
+git -C "$MAIN" push -q -u origin main
+
+WT_DIR="$ROOT/worktrees"
+mkdir -p "$WT_DIR"
+
+# Helper: add a linked worktree on a fresh branch off main.
+add_wt() { # <name> <branch> -> echoes path
+    local name="$1" branch="$2" path="$WT_DIR/$1"
+    git -C "$MAIN" worktree add -q -b "$branch" "$path" main
+    echo "$path"
+}
+
+run() { # run remove_own_worktree from inside MAIN so guard-1 compares vs MAIN
+    ( cd "$MAIN" && remove_own_worktree "$1" )
+}
+
+# --- Case 1: clean + merged (pushed, branch on remote) => REMOVE ---
+w="$(add_wt c1_clean_merged feat/c1)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit
+git -C "$w" push -q -u origin feat/c1   # fully pushed: @{u}..HEAD empty
+run "$w"
+assert_removed "clean + fully-pushed (merged/stale)" "$w"
+
+# --- Case 2: clean + stale-but-pushed via detached HEAD on a remote ref => REMOVE ---
+# No upstream configured, but HEAD reachable from origin/main => backed up.
+w="$(add_wt c2_detached_remote feat/c2)"
+git -C "$w" checkout -q --detach origin/main
+run "$w"
+assert_removed "no-upstream + HEAD on remote ref" "$w"
+
+# --- Case 3: dirty working tree => PRESERVE ---
+w="$(add_wt c3_dirty feat/c3)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit
+git -C "$w" push -q -u origin feat/c3       # backed up...
+echo uncommitted >> "$w/f"                  # ...but now dirty (guard 4)
+run "$w"
+assert_preserved "dirty working tree" "$w"
+[[ "$(tail -n1 "$w/f" 2>/dev/null)" == "uncommitted" ]] \
+    && { echo "    (dirty change survived)"; } \
+    || { echo "    FAIL: dirty change lost!"; ((FAIL++)); }
+
+# --- Case 4: upstream configured + unpushed commits ahead => PRESERVE ---
+w="$(add_wt c4_unpushed feat/c4)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam base-edit
+git -C "$w" push -q -u origin feat/c4
+echo b >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam ahead   # @{u}..HEAD non-empty
+run "$w"
+assert_preserved "upstream + unpushed commits ahead" "$w"
+
+# --- Case 5: no upstream + local-only (unbacked) commits => PRESERVE ---
+w="$(add_wt c5_unbacked feat/c5)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam local-only  # never pushed
+run "$w"
+assert_preserved "no upstream + unbacked local commits" "$w"
+
+# --- Case 6: locked => PRESERVE (even though clean + pushed) ---
+w="$(add_wt c6_locked feat/c6)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit
+git -C "$w" push -q -u origin feat/c6
+git -C "$MAIN" worktree lock "$w"
+run "$w"
+assert_preserved "locked worktree" "$w"
+git -C "$MAIN" worktree unlock "$w" 2>/dev/null || true
+
+# --- Case 7: current checkout => PRESERVE ---
+# Run remove_own_worktree from INSIDE the target so guard 1 fires.
+w="$(add_wt c7_current feat/c7)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit
+git -C "$w" push -q -u origin feat/c7
+( cd "$w" && remove_own_worktree "$w" )
+assert_preserved "current checkout" "$w"
+
+# --- Case 8: idempotent / absent path => no error, quiet ---
+out="$(run "$WT_DIR/does-not-exist" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 && -z "$out" ]]; then
+    echo "  ok: absent path -> quiet no-op (rc=0)"
+    ((PASS++))
+else
+    echo "  FAIL: absent path -> rc=$rc out='$out'"
+    ((FAIL++))
+fi
+
+# --- Case 9: idempotent second call on an already-removed worktree ---
+w="$(add_wt c9_twice feat/c9)"
+echo a >> "$w/f"
+git -C "$w" -c user.email=t@t -c user.name=t commit -qam edit
+git -C "$w" push -q -u origin feat/c9
+run "$w"
+assert_removed "second-call setup: first removal" "$w"
+out="$(run "$w" 2>&1)"; rc=$?
+if [[ $rc -eq 0 && -z "$out" ]]; then
+    echo "  ok: second call -> quiet no-op (rc=0)"
+    ((PASS++))
+else
+    echo "  FAIL: second call -> rc=$rc out='$out'"
+    ((FAIL++))
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+rm -rf "$ROOT"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Phase 2a of the per-workflow worktree cleanup contract (#25344, follow-up to #24857 / PR #25343). Agent launch scripts spawned worktrees but never removed them at stop time, leaking ~154 GB. This adds a shared, guarded reclaim helper and wires it into the stop/cleanup paths of the highest-traffic leakers so the Phase 1 janitor becomes a backstop rather than the only defense.

## Changes

- **New `scripts/lib/worktree-cleanup.sh`** exposing `remove_own_worktree <path>`. It reuses the EXACT structural guards 1-5 from the merged Phase 1 janitor (`clean-branches.sh` Phase 4): preserves a worktree that is the current checkout, locked, has an active owning process, has a dirty `git status --porcelain`, or carries unpushed (`@{u}..HEAD`) / unbacked (no upstream AND `git branch -r --contains HEAD` empty) commits. Removal is idempotent and quiet when there is nothing to remove. It does NOT re-implement the backstop's reclaim *trigger* logic (PR-merged / upstream-gone / mtime) — at agent-stop time the worktree is the agent's own by construction, so the structural guards are the only protection needed.
- **`scripts/auditor/launch-agent.sh`, `scripts/mechanic/launch-agent.sh`**: call `remove_own_worktree "$WORKTREE_PATH"` from `stop_agent()` after `tmux kill-session`. (The launchers detach into a tmux session and the launcher process exits immediately, so a launcher-level `EXIT` trap would fire while the agent is still alive — the stop path is the correct hook, per the curator's design note.)
- **`scripts/research/parallel-research.sh`, `scripts/enricher/parallel-enrich.sh`**: extract a guarded `reclaim_worktrees()` used by BOTH the `--stop` path and the `--cleanup` path, closing the stop-signal gap where only `--cleanup` removed worktrees. `--cleanup` now honors the same guards instead of force-removing unconditionally (so a dirty/unpushed worktree survives `--cleanup` too). Enricher branch deletion now only fires when the worktree was actually reclaimed.
- **New `scripts/tests/worktree-cleanup.test.sh`**: exercises the full decision table against real throwaway git worktrees.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each listed launch script removes its worktree on stop/cleanup | ✅ | `stop_agent()` (auditor/mechanic) and `--stop`/`--cleanup` (research/enricher) all call the guarded helper |
| Cleanup honors dirty / unpushed-or-unbacked / locked / current-checkout guards (no data loss on crash mid-edit) | ✅ | Helper reuses guards 1-5 verbatim from `clean-branches.sh` Phase 4; test asserts each PRESERVE case + that the dirty change survives |
| Removal idempotent and quiet when nothing to remove | ✅ | Test cases 8-9: absent path and second-call both return rc=0 with empty output |
| Phase 1 janitor remains the backstop | ✅ | `clean-branches.sh` untouched; existing `clean-branches-reclaim.test.sh` still passes (14/14) |
| Stop hook is in `stop_agent()` / stop path, not a launcher `EXIT` trap | ✅ | Wired into `stop_agent()` after `tmux kill-session` and into the `--stop` paths of the parallel scripts |

## Test Plan

- `bash -n` + `shellcheck -S error` on all 6 modified/new scripts → clean.
- New decision-table test (`bash scripts/tests/worktree-cleanup.test.sh`) → **PASS=10 FAIL=0** covering: clean+fully-pushed → REMOVE; no-upstream+HEAD-on-remote → REMOVE; dirty → PRESERVE (change survives); upstream+unpushed-ahead → PRESERVE; no-upstream+unbacked → PRESERVE; locked → PRESERVE; current-checkout → PRESERVE; absent-path idempotent no-op; second-call idempotent no-op.
- Regression: existing `bash scripts/tests/clean-branches-reclaim.test.sh` → **PASS=14 FAIL=0** (backstop unaffected).

## Deferred to Phase 2b (NOT in this PR)

Per the curator's scoping, these remain for a follow-up to keep this PR reviewable:
- `scripts/peer-reviewer/launch-agent.sh` — wire helper into `stop_agent()`.
- `scripts/aristotle/launch-agent.sh` — wire helper into `stop_agent()` **after** the jobs-file salvage step (`save_jobs_state()`) — needs care to avoid losing job state.
- `scripts/deploy/launch-agent.sh` — wire helper into `stop_agent()` (`.env` is gitignored / re-copied on next launch).
- `scripts/clean-branches.sh` — optional refactor of Phase 4 guards 1-5 to source the same helper so the per-workflow and backstop paths cannot diverge.

(Read-only herald/test agents use no worktree and are out of scope.)

Closes #25344