### PR TITLE
perf(clean-branches): batch Phase 3 PR-status and ahead-count into one-shot passes

### DIFF
--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -312,11 +312,97 @@ total_local=$(echo "$all_branches" | wc -l | tr -d ' ')
 info "  Processing $total_local local branches..."
 echo ""
 
+# -----------------------------------------------------------------------------
+# Batch precomputation (performance: avoids O(branches) subprocess spawns)
+# -----------------------------------------------------------------------------
+# The per-branch loop below used to spawn, for EACH local branch:
+#   - one `awk` over the whole PR_MAP_FILE (get_pr_status), and
+#   - in the NONE case, `git merge-base` + `git rev-list --count`.
+# On a ~3k-branch backlog that is ~100-230s of process overhead and times out
+# before Phase 4. We replace both with two one-shot passes whose results are
+# looked up cheaply inside the loop.
+#
+# bash 3.2 (macOS) has no associative arrays, so we precompute newline-delimited
+# set files and a single resolved TSV, then read them back. No `declare -A`.
+
+# (1) PR status for every local branch in ONE awk-join pass.
+#     Joins the branch list against PR_MAP_FILE; last map entry per branch wins
+#     (open-overrides-closed, since PR_MAP_FILE appends .open after .closed),
+#     matching get_pr_status's END{print s} last-wins semantics exactly. Absent
+#     branches resolve to NONE. Output: "<branch>\t<STATUS>" per branch.
+RESOLVED_STATUS_FILE=$(mktemp)
+NOPR_DELETE_SET_FILE="${RESOLVED_STATUS_FILE}.nopr_delete"
+trap 'rm -f "$PR_MAP_FILE" "${PR_MAP_FILE}.open" "${PR_MAP_FILE}.closed" "$PROTECTED_BRANCHES_FILE" "$RESOLVED_STATUS_FILE" "${RESOLVED_STATUS_FILE}.merged" "${RESOLVED_STATUS_FILE}.shares" "$NOPR_DELETE_SET_FILE"' EXIT
+printf '%s\n' "$all_branches" \
+    | awk -F'\t' '
+        NR==FNR { if ($1 != "") m[$1]=$2; next }
+        { print $0 "\t" (($1 in m) ? m[$1] : "NONE") }
+      ' "$PR_MAP_FILE" - > "$RESOLVED_STATUS_FILE"
+
+# (2) Precompute, in O(1) git calls, the set of no-PR branches the OLD per-branch
+#     ahead-count would DELETE, so the NONE fallback is byte-identical.
+#
+#     OLD logic (lines 408-415 of the pre-change script):
+#         merge_base = git merge-base main "$branch"   # EMPTY if no common ancestor
+#         ahead = (merge_base != "") ? rev-list --count merge_base..branch : 0
+#         DELETE iff ahead == 0
+#     So OLD DELETEs a no-PR branch IFF:
+#         (a) it is reachable into main (merge-base non-empty, count 0) — i.e.
+#             `--merged main`; OR
+#         (b) it has NO common ancestor with main (merge-base empty) — the
+#             `ahead` default of 0 makes the old code delete orphan-history
+#             branches too. In this repo those are the retired-master-root
+#             branches from the #13577 divergence (root ecb47b3…, disjoint from
+#             main's root). Reproducing this exactly is REQUIRED: a perf refactor
+#             must not change which branches get deleted, even where the old rule
+#             is surprising.
+#
+#     Both are computable without per-branch git spawns:
+#       MERGED  set = `git for-each-ref --merged main`        (case a)
+#       SHARES  set = branches containing one of main's root commits. A branch
+#                     shares history with main (non-empty merge-base) IFF its
+#                     tip descends from a main root, i.e. it is `--contains
+#                     <root>` for some root of main. Its complement is exactly
+#                     the empty-merge-base (orphan) set (case b). Verified on the
+#                     full 2.9k-branch backlog: contains-root partitions the
+#                     branches by merge-base emptiness with zero exceptions.
+#     OLD-DELETE(no-PR) = MERGED ∪ (ALL \ SHARES) = MERGED ∪ orphans.
+MERGED_SET_FILE="${RESOLVED_STATUS_FILE}.merged"
+SHARES_SET_FILE="${RESOLVED_STATUS_FILE}.shares"
+git for-each-ref --format='%(refname:short)' --merged main refs/heads 2>/dev/null \
+    | sort -u > "$MERGED_SET_FILE" || : > "$MERGED_SET_FILE"
+
+# Branches sharing history with main = union of `--contains <root>` over every
+# root commit of main (handles the multi-root case; main has a single root here).
+: > "$SHARES_SET_FILE"
+while IFS= read -r _root; do
+    [[ -z "$_root" ]] && continue
+    git for-each-ref --format='%(refname:short)' --contains "$_root" refs/heads 2>/dev/null >> "$SHARES_SET_FILE"
+done < <(git rev-list --max-parents=0 main 2>/dev/null)
+sort -u -o "$SHARES_SET_FILE" "$SHARES_SET_FILE"
+
+# Old-DELETE(no-PR) set = MERGED ∪ (all local branches NOT in SHARES).
+# Built once with set ops; membership tested with grep -qxF (literal, exact).
+{
+    cat "$MERGED_SET_FILE"
+    printf '%s\n' "$all_branches" | sort -u | comm -23 - "$SHARES_SET_FILE"
+} | sort -u > "$NOPR_DELETE_SET_FILE"
+
+is_nopr_deletable() {
+    # Reproduces the old `ahead == 0` (incl. empty-merge-base) DELETE decision.
+    grep -qxF "$1" "$NOPR_DELETE_SET_FILE"
+}
+
 # Progress tracking
 processed=0
 progress_interval=20
 
-for branch in $all_branches; do
+# Iterate the resolved "<branch>\t<status>" TSV so the PR status is already
+# joined (no per-branch awk). Field 1 = branch, field 2 = resolved PR status.
+# The list is read from FD 3 (not stdin), so the interactive `read -r -p`
+# prompts inside the loop still consume from the terminal in non-force mode.
+while IFS=$'\t' read -r branch pr_status <&3; do
+    [[ -z "$branch" ]] && continue
     ((processed++)) || true
 
     # Show progress every N branches
@@ -332,9 +418,8 @@ for branch in $all_branches; do
 
     ((total_branches++)) || true
 
-    # Look up PR status
-    pr_status=$(get_pr_status "$branch")
-
+    # PR status was resolved in the batch awk-join pass above (read from the
+    # resolved TSV's second field). No per-branch awk spawn here.
     case "$pr_status" in
         MERGED)
             ((deleted_merged++)) || true
@@ -405,14 +490,13 @@ for branch in $all_branches; do
                 continue
             fi
 
-            # Count commits ahead of main (use merge-base for accuracy)
-            ahead=0
-            merge_base=$(git merge-base main "$branch" 2>/dev/null || echo "")
-            if [[ -n "$merge_base" ]]; then
-                ahead=$(git rev-list --count "$merge_base..$branch" 2>/dev/null || echo "0")
-            fi
-
-            if [[ "$ahead" -eq 0 ]]; then
+            # Reproduce the old `ahead == 0` DELETE decision via the precomputed
+            # NOPR_DELETE set (built with a couple of one-shot git calls above)
+            # instead of per-branch `git merge-base` + `git rev-list --count`.
+            # The set is byte-identical to the old test: it is exactly the no-PR
+            # branches the old code would delete (merged-into-main OR
+            # empty-merge-base orphan).
+            if is_nopr_deletable "$branch"; then
                 # Branch is even with main - safe to delete
                 ((deleted_no_pr_even++)) || true
                 if [[ "$DRY_RUN" == true ]]; then
@@ -441,12 +525,12 @@ for branch in $all_branches; do
                 # Branch has unique commits - preserve by default
                 ((preserved_ahead++)) || true
                 if [[ "$DRY_RUN" == true ]]; then
-                    warning "  [KEEP]   $branch (no PR, $ahead commits ahead)"
+                    warning "  [KEEP]   $branch (no PR, commits ahead of main)"
                 fi
             fi
             ;;
     esac
-done
+done 3< "$RESOLVED_STATUS_FILE"
 
 # Clear progress line
 printf "                                                          \r"
@@ -479,8 +563,21 @@ if [[ "$REMOTE" == true ]]; then
     info "  Processing $remote_total remote branches..."
     echo ""
 
+    # Resolve PR status for every remote branch in ONE awk-join pass (same
+    # technique as Phase 3) instead of a per-branch awk scan of PR_MAP_FILE.
+    # Output: "<branch>\t<STATUS>" per branch; last map entry wins (open
+    # overrides closed); absent branches resolve to NONE.
+    REMOTE_RESOLVED_FILE=$(mktemp)
+    trap 'rm -f "$PR_MAP_FILE" "${PR_MAP_FILE}.open" "${PR_MAP_FILE}.closed" "$PROTECTED_BRANCHES_FILE" "$RESOLVED_STATUS_FILE" "${RESOLVED_STATUS_FILE}.merged" "$REMOTE_RESOLVED_FILE"' EXIT
+    printf '%s\n' "$remote_branches" \
+        | awk -F'\t' '
+            NR==FNR { if ($1 != "") m[$1]=$2; next }
+            { print $0 "\t" (($1 in m) ? m[$1] : "NONE") }
+          ' "$PR_MAP_FILE" - > "$REMOTE_RESOLVED_FILE"
+
     rprocessed=0
-    for branch in $remote_branches; do
+    while IFS=$'\t' read -r branch pr_status; do
+        [[ -z "$branch" ]] && continue
         ((rprocessed++)) || true
 
         if [[ $((rprocessed % progress_interval)) -eq 0 ]]; then
@@ -492,8 +589,6 @@ if [[ "$REMOTE" == true ]]; then
             ((remote_preserved++)) || true
             continue
         fi
-
-        pr_status=$(get_pr_status "$branch")
 
         case "$pr_status" in
             MERGED|CLOSED)
@@ -518,7 +613,7 @@ if [[ "$REMOTE" == true ]]; then
                 fi
                 ;;
         esac
-    done
+    done < "$REMOTE_RESOLVED_FILE"
 
     # Clear progress line
     printf "                                                          \r"

--- a/scripts/tests/clean-branches-phase3.test.sh
+++ b/scripts/tests/clean-branches-phase3.test.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Decision-equivalence + perf harness for the Phase 3 batch optimization in
+# scripts/clean-branches.sh (issue #25345).
+#
+# Phase 3 used to spawn, per local branch:
+#   - one `awk` over the whole PR_MAP_FILE (get_pr_status), and
+#   - on the NONE path, `git merge-base` + `git rev-list --count` (ahead count).
+# Both are replaced with two one-shot passes:
+#   (1) a single awk-join resolving every branch's PR status, and
+#   (2) a single `git for-each-ref --merged main` set for "0 commits ahead".
+#
+# This test builds a sandbox repo with one branch of each class and asserts the
+# NEW batched resolution produces a BYTE-IDENTICAL DELETE/KEEP verdict to the
+# OLD per-branch logic, for every branch. It also demonstrates the two batch
+# primitives are correct and shows a before/after timing for the ahead-count
+# hot path. Runs on bash 3.2 (no `declare -A`).
+#
+# Run: bash scripts/tests/clean-branches-phase3.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+PASS=0; FAIL=0
+assert() { # <desc> <expected> <actual>
+    if [[ "$3" == "$2" ]]; then echo "  ok: $1 -> $3"; ((PASS++))
+    else echo "  FAIL: $1 expected [$2] got [$3]"; ((FAIL++)); fi
+}
+
+GIT="git -c user.email=t@t -c user.name=t -c commit.gpgsign=false"
+
+# -----------------------------------------------------------------------------
+# Reference implementations of the OLD (per-branch) and NEW (batched) verdict
+# logic. Both consume the SAME inputs and must agree on every branch.
+# -----------------------------------------------------------------------------
+
+# verdict_for STATUS NOPR_DELETE KEEP_NO_PR -> DELETE | KEEP
+# Mirrors the Phase 3 case/NONE decision tree: DELETE for MERGED/CLOSED, KEEP
+# for OPEN; on NONE: --keep-no-pr=>KEEP, else the no-PR-deletable flag decides
+# (1 => DELETE, 0 => KEEP).
+verdict_for() {
+    local status="$1" nopr_del="$2" keep="$3"
+    case "$status" in
+        MERGED|CLOSED) echo DELETE ;;
+        OPEN)          echo KEEP ;;
+        NONE)
+            if [[ "$keep" == true ]]; then echo KEEP
+            elif [[ "$nopr_del" -eq 1 ]]; then echo DELETE
+            else echo KEEP; fi ;;
+        *) echo KEEP ;;
+    esac
+}
+
+# OLD per-branch resolution: awk-scan PR_MAP_FILE + merge-base/rev-list ahead.
+old_status() {
+    local b="$1"
+    local s; s=$(awk -F'\t' -v b="$b" '$1==b {s=$2} END{print s}' "$PR_MAP_FILE")
+    echo "${s:-NONE}"
+}
+# OLD no-PR DELETE decision (1=delete, 0=keep), reproducing the old code:
+#   merge_base = git merge-base main b   (EMPTY if no common ancestor)
+#   ahead = (merge_base != "") ? rev-list --count merge_base..b : 0
+#   delete iff ahead == 0   (note: empty merge-base => ahead defaults 0 => delete)
+old_nopr_delete() {
+    local b="$1" mb a=0
+    mb=$($GIT -C "$REPO" merge-base main "$b" 2>/dev/null || echo "")
+    if [[ -n "$mb" ]]; then a=$($GIT -C "$REPO" rev-list --count "$mb..$b" 2>/dev/null || echo 0); fi
+    [[ "$a" -eq 0 ]] && echo 1 || echo 0
+}
+
+# NEW batched resolution: one awk-join + the NOPR_DELETE set (merged ∪ orphans).
+# NOPR_DELETE = MERGED ∪ (ALL \ SHARES), where SHARES = branches containing a
+# root of main (non-empty merge-base). Its complement of SHARES is exactly the
+# empty-merge-base orphan set, so this reproduces the old empty-merge-base
+# DELETE behavior without per-branch git spawns.
+build_new_caches() {
+    RESOLVED=$(mktemp)
+    printf '%s\n' "$ALL_BRANCHES" \
+        | awk -F'\t' '
+            NR==FNR { if ($1 != "") m[$1]=$2; next }
+            { print $0 "\t" (($1 in m) ? m[$1] : "NONE") }
+          ' "$PR_MAP_FILE" - > "$RESOLVED"
+    MERGED_SET=$(mktemp); SHARES_SET=$(mktemp); NOPR_DELETE=$(mktemp)
+    $GIT -C "$REPO" for-each-ref --format='%(refname:short)' --merged main refs/heads | sort -u > "$MERGED_SET"
+    : > "$SHARES_SET"
+    while IFS= read -r r; do
+        [[ -z "$r" ]] && continue
+        $GIT -C "$REPO" for-each-ref --format='%(refname:short)' --contains "$r" refs/heads >> "$SHARES_SET"
+    done < <($GIT -C "$REPO" rev-list --max-parents=0 main)
+    sort -u -o "$SHARES_SET" "$SHARES_SET"
+    {
+        cat "$MERGED_SET"
+        printf '%s\n' "$ALL_BRANCHES" | sort -u | comm -23 - "$SHARES_SET"
+    } | sort -u > "$NOPR_DELETE"
+}
+new_status()      { awk -F'\t' -v b="$1" '$1==b {print $2; exit}' "$RESOLVED"; }
+new_nopr_delete() { if grep -qxF "$1" "$NOPR_DELETE"; then echo 1; else echo 0; fi; }
+
+# -----------------------------------------------------------------------------
+# Build a sandbox repo with one branch of each class.
+# -----------------------------------------------------------------------------
+ROOT=$(mktemp -d)
+REPO="$ROOT/repo"
+$GIT init -q "$REPO"; $GIT -C "$REPO" checkout -q -b main
+echo base > "$REPO/f"; $GIT -C "$REPO" add f; $GIT -C "$REPO" commit -qm base
+
+# Class: no-PR, even with main (branch points at main's tip) -> DELETE
+$GIT -C "$REPO" branch nopr-even main
+
+# Class: no-PR, ahead of main (unique commit) -> KEEP
+$GIT -C "$REPO" checkout -q -b nopr-ahead
+echo ahead >> "$REPO/f"; $GIT -C "$REPO" commit -qam ahead
+$GIT -C "$REPO" checkout -q main
+
+# Class: merged-PR branch (has unique commit but PR is MERGED) -> DELETE
+$GIT -C "$REPO" checkout -q -b feat-merged
+echo m >> "$REPO/f"; $GIT -C "$REPO" commit -qam merged
+$GIT -C "$REPO" checkout -q main
+
+# Class: closed-PR branch -> DELETE
+$GIT -C "$REPO" checkout -q -b feat-closed
+echo c >> "$REPO/f"; $GIT -C "$REPO" commit -qam closed
+$GIT -C "$REPO" checkout -q main
+
+# Class: open-PR branch (must be preserved even though ahead) -> KEEP
+$GIT -C "$REPO" checkout -q -b feat-open
+echo o >> "$REPO/f"; $GIT -C "$REPO" commit -qam open
+$GIT -C "$REPO" checkout -q main
+
+# Class: merged-PR branch that is ALSO even with main (0 ahead) -> DELETE
+$GIT -C "$REPO" branch feat-merged-even main
+
+# Edge: branch name with a regex metacharacter, no PR, even with main -> DELETE
+$GIT -C "$REPO" branch 'odd.name' main
+
+# Class: ORPHAN-history branch, no PR (empty merge-base with main). The OLD code
+# leaves `ahead` at its default 0 when merge-base is empty, so it DELETES these
+# (this is the #13577 retired-master-root situation). The batched logic must
+# reproduce that exactly via the SHARES (contains-root) complement. -> DELETE
+$GIT -C "$REPO" checkout -q --orphan orphan-nopr
+echo orphan > "$REPO/g"; $GIT -C "$REPO" add g; $GIT -C "$REPO" rm -q --cached f 2>/dev/null || true
+$GIT -C "$REPO" commit -qm orphan-root
+$GIT -C "$REPO" checkout -q main
+
+# Class: ORPHAN-history branch WITH a CLOSED PR. Both old and new DELETE via the
+# primary PR signal regardless of the orphan ahead-count. -> DELETE
+$GIT -C "$REPO" checkout -q --orphan orphan-closed
+echo oc > "$REPO/h"; $GIT -C "$REPO" add h; $GIT -C "$REPO" rm -q --cached f g 2>/dev/null || true
+$GIT -C "$REPO" commit -qm orphan-closed-root
+$GIT -C "$REPO" checkout -q main
+
+# Synthetic PR map (tab-separated <branch>\t<state>); .closed then .open order
+# so open-overrides-closed last-wins is exercised.
+PR_MAP_FILE=$(mktemp)
+{
+    printf 'feat-merged\tMERGED\n'
+    printf 'feat-merged-even\tMERGED\n'
+    printf 'feat-closed\tCLOSED\n'
+    printf 'feat-open\tCLOSED\n'   # closed first...
+    printf 'feat-open\tOPEN\n'     # ...open later wins
+    printf 'orphan-closed\tCLOSED\n'
+} > "$PR_MAP_FILE"
+
+ALL_BRANCHES=$($GIT -C "$REPO" branch | sed 's/^[*+ ]*//' | sort)
+build_new_caches
+
+# -----------------------------------------------------------------------------
+# Equivalence: for every branch, OLD verdict == NEW verdict, both KEEP_NO_PR
+# modes. Also assert against the hand-derived expected verdict.
+# -----------------------------------------------------------------------------
+# NOTE: `main` is omitted — it is PROTECTED in Phase 2 before the verdict tree
+# runs, so its raw verdict (DELETE, being even+no-PR) is never reached. The
+# old==new verdict-equivalence assertion still covers `main`; only the
+# hand-derived protected-aware expectation is skipped for it.
+EXPECTED="$(cat <<'EOF'
+nopr-even DELETE KEEP
+nopr-ahead KEEP KEEP
+feat-merged DELETE DELETE
+feat-closed DELETE DELETE
+feat-open KEEP KEEP
+feat-merged-even DELETE DELETE
+odd.name DELETE KEEP
+orphan-nopr DELETE KEEP
+orphan-closed DELETE DELETE
+EOF
+)"
+
+for b in $ALL_BRANCHES; do
+    # main is protected in the real script; here we just confirm verdict logic
+    os=$(old_status "$b"); od=$(old_nopr_delete "$b")
+    ns=$(new_status "$b"); [[ -z "$ns" ]] && ns=NONE
+    nd=$(new_nopr_delete "$b")
+
+    # Status must match exactly between old scan and new join.
+    assert "status($b)" "$os" "$ns"
+    # No-PR deletable flag must match: old 1 <=> new 1 (covers merged AND orphan).
+    assert "nopr-delete-flag($b)" "$od" "$nd"
+
+    for keep in false true; do
+        ov=$(verdict_for "$os" "$od" "$keep")
+        nv=$(verdict_for "$ns" "$nd" "$keep")
+        assert "verdict-equiv($b,keep=$keep)" "$ov" "$nv"
+    done
+
+    # Cross-check against hand-derived expected table.
+    exp_false=$(echo "$EXPECTED" | awk -v b="$b" '$1==b{print $2}')
+    exp_true=$(echo "$EXPECTED" | awk -v b="$b" '$1==b{print $3}')
+    if [[ -n "$exp_false" ]]; then
+        assert "expected($b,keep=false)" "$exp_false" "$(verdict_for "$ns" "$nd" false)"
+        assert "expected($b,keep=true)"  "$exp_true"  "$(verdict_for "$ns" "$nd" true)"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Prove the batched NOPR_DELETE set == per-branch (old ahead==0 incl. empty
+# merge-base) on the WHOLE branch set — this is the byte-identical-decisions
+# guarantee for the no-PR path, including orphan-history branches.
+# -----------------------------------------------------------------------------
+mismatch=0
+for b in $ALL_BRANCHES; do
+    o=$(old_nopr_delete "$b")
+    n=$(grep -qxF "$b" "$NOPR_DELETE" && echo 1 || echo 0)
+    [[ "$o" != "$n" ]] && { mismatch=$((mismatch+1)); echo "  MISMATCH: $b old_nopr_delete=$o nopr_set=$n"; }
+done
+assert "NOPR_DELETE set == per-branch old ahead==0 (all branches)" "0" "$mismatch"
+
+# -----------------------------------------------------------------------------
+# Perf demonstration: scale up to N synthetic even-with-main branches and time
+# the old per-branch ahead-count vs the single for-each-ref. Best-effort; the
+# assertion only requires the batch call to be no slower than the per-branch
+# loop (it is dramatically faster in practice).
+# -----------------------------------------------------------------------------
+N=300
+i=0
+while [[ $i -lt $N ]]; do $GIT -C "$REPO" branch "perf/$i" main; i=$((i+1)); done
+PERF_BRANCHES=$($GIT -C "$REPO" for-each-ref --format='%(refname:short)' refs/heads/perf)
+
+t0=$(date +%s)
+for b in $PERF_BRANCHES; do old_nopr_delete "$b" >/dev/null; done
+t1=$(date +%s)
+$GIT -C "$REPO" for-each-ref --format='%(refname:short)' --merged main refs/heads/perf >/dev/null
+t2=$(date +%s)
+old_secs=$((t1 - t0)); new_secs=$((t2 - t1))
+echo "  perf: per-branch ahead-count over $N branches = ${old_secs}s; single for-each-ref = ${new_secs}s"
+# Sanity: the one-shot call must not be slower than the per-branch loop.
+if [[ "$new_secs" -le "$old_secs" ]]; then
+    echo "  ok: batch for-each-ref not slower than per-branch loop"; ((PASS++))
+else
+    echo "  FAIL: batch slower than per-branch loop (${new_secs}s > ${old_secs}s)"; ((FAIL++))
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+rm -rf "$ROOT"; rm -f "$PR_MAP_FILE" "$RESOLVED" "$MERGED_SET" "$SHARES_SET" "$NOPR_DELETE"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`scripts/clean-branches.sh` Phase 3 did not scale: a full `--dry-run` against this repo's ~2,919 local branches timed out before reaching the Phase 4 worktree sweep. The bottleneck was per-branch subprocess spawning in the O(branches) loop:

1. **Primary (~75-200s):** the no-PR fallback ran `git merge-base main "$branch"` + `git rev-list --count` per branch (two git spawns at ~86ms each), hit by the majority of branches.
2. **Secondary (~20s):** `get_pr_status` ran one `awk` that re-scanned the entire `PR_MAP_FILE` per call (O(branches × map_size)).

Both are replaced with one-shot precomputation. bash 3.2 safe (no `declare -A`).

## Changes

- **PR status (single awk-join):** resolve every local/remote branch against `PR_MAP_FILE` in one `awk` pass producing a `<branch>\t<status>` TSV; last-write-wins preserves open-overrides-closed. Phase 3 reads the resolved TSV from FD 3 so interactive `read -p` prompts still consume the terminal. Phase 3b uses the same join. Measured ~20s -> ~0.01s.
- **Ahead-count (one-shot git):** precompute the exact set of no-PR branches the old code would delete = `git for-each-ref --merged main` UNION orphan-history (branches not containing any root of main = empty merge-base). This reproduces the old `ahead == 0` decision **byte-identically**, including the empty-merge-base case where the old code deletes #13577 retired-master-root branches. Measured ~75-200s -> ~0.7s.
- `get_pr_status` retained for Phase 4's per-worktree lookups (O(worktrees), unaffected).
- New test `scripts/tests/clean-branches-phase3.test.sh` asserts decision-equivalence on a synthetic repo covering every branch class (merged/closed/open/no-PR-even/no-PR-ahead/orphan-no-PR/orphan-closed), plus a whole-set NOPR_DELETE-equivalence assertion and a before/after timing demo.

### Semantic-equivalence note

The old no-PR test (`merge-base(main,b)..b` empty) is NOT simply `--merged main`: when `merge-base` is empty (orphan histories), the old code's `ahead` default of 0 causes it to DELETE the branch. Verified on the full backlog that `contains-main-root` partitions branches exactly by merge-base emptiness, so `MERGED ∪ orphans` reproduces the old delete set with zero exceptions.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--dry-run` completes & reaches Phase 4 under prior timeout | OK | Full `--dry-run` exits 0, prints Phase 4/5 + SUMMARY; Phase 3 git work measured at 0.66s for 2,919 branches |
| PR-status uses a single awk/map pass | OK | One `awk` NR==FNR join; no per-branch awk spawn in the loop |
| No-PR ahead-count uses one-shot git, not per-branch merge-base+rev-list | OK | `git for-each-ref --merged main` + `--contains <root>` precompute; loop does `grep -qxF` set lookup |
| Branch-deletion decisions byte-identical for every class | OK | Live-repo diff: new vs old verdict identical for all 2,864 non-protected branches (0 mismatches); phase3 test 60/60 |
| Scheduled `--remote` completes in CI budget | OK | Phase 3b uses the same single awk-join; no new per-branch network/process cost |
| Runs on bash 3.2 (no `declare -A`) | OK | `bash -n` + full test run green on bash 3.2.57 |
| Safety semantics from #25339 / #24857 unchanged | OK | Phase 4 reclaim logic untouched; reclaim test stays 14/14 |

## Test Plan

- `bash -n` + `shellcheck -S error` pass on the script and both tests.
- `scripts/tests/clean-branches-reclaim.test.sh`: 14/14 (unchanged).
- `scripts/tests/clean-branches-phase3.test.sh`: 60/60, on bash 3.2.57.
- Live-repo before/after: per-branch ahead-count ~75-200s -> single `for-each-ref` 0.12s; per-branch awk status ~20s -> single join <0.01s; full `--dry-run` reaches Phase 4 (exit 0).

Closes #25345