### PR TITLE
fix(clean-branches): include .shares and .nopr_delete in --remote EXIT trap

### DIFF
--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -568,7 +568,7 @@ if [[ "$REMOTE" == true ]]; then
     # Output: "<branch>\t<STATUS>" per branch; last map entry wins (open
     # overrides closed); absent branches resolve to NONE.
     REMOTE_RESOLVED_FILE=$(mktemp)
-    trap 'rm -f "$PR_MAP_FILE" "${PR_MAP_FILE}.open" "${PR_MAP_FILE}.closed" "$PROTECTED_BRANCHES_FILE" "$RESOLVED_STATUS_FILE" "${RESOLVED_STATUS_FILE}.merged" "$REMOTE_RESOLVED_FILE"' EXIT
+    trap 'rm -f "$PR_MAP_FILE" "${PR_MAP_FILE}.open" "${PR_MAP_FILE}.closed" "$PROTECTED_BRANCHES_FILE" "$RESOLVED_STATUS_FILE" "${RESOLVED_STATUS_FILE}.merged" "${RESOLVED_STATUS_FILE}.shares" "$NOPR_DELETE_SET_FILE" "$REMOTE_RESOLVED_FILE"' EXIT
     printf '%s\n' "$remote_branches" \
         | awk -F'\t' '
             NR==FNR { if ($1 != "") m[$1]=$2; next }

--- a/scripts/tests/clean-branches-phase3.test.sh
+++ b/scripts/tests/clean-branches-phase3.test.sh
@@ -222,6 +222,33 @@ done
 assert "NOPR_DELETE set == per-branch old ahead==0 (all branches)" "0" "$mismatch"
 
 # -----------------------------------------------------------------------------
+# Trap-superset guard (issue #25349): the Phase 3b `--remote` EXIT trap must be
+# a superset of the Phase 3 EXIT trap, otherwise re-registering it (bash traps
+# replace, not append) silently de-registers cleanup for temp files created in
+# Phase 3 -- specifically `${RESOLVED_STATUS_FILE}.shares` and
+# `$NOPR_DELETE_SET_FILE` -- and they leak in $TMPDIR on a `--remote` run.
+#
+# This is a static source check (no live `gh`/remote needed): every temp file
+# mentioned in the Phase 3 trap must also appear in the `--remote` trap.
+# -----------------------------------------------------------------------------
+SRC="$(dirname "$0")/../clean-branches.sh"
+if [[ -f "$SRC" ]]; then
+    # The two trap lines, by the distinguishing temp file each registers last.
+    phase3_trap=$(grep -F '"${RESOLVED_STATUS_FILE}.merged" "${RESOLVED_STATUS_FILE}.shares"' "$SRC" | grep -F 'trap ' | head -1)
+    remote_trap=$(grep -F '"$REMOTE_RESOLVED_FILE"' "$SRC" | grep -F 'trap ' | head -1)
+    assert "phase3 trap line found" "yes" "$([[ -n "$phase3_trap" ]] && echo yes || echo no)"
+    assert "remote trap line found" "yes" "$([[ -n "$remote_trap" ]] && echo yes || echo no)"
+    for tok in \
+        '"$PR_MAP_FILE"' '"${PR_MAP_FILE}.open"' '"${PR_MAP_FILE}.closed"' \
+        '"$PROTECTED_BRANCHES_FILE"' '"$RESOLVED_STATUS_FILE"' \
+        '"${RESOLVED_STATUS_FILE}.merged"' '"${RESOLVED_STATUS_FILE}.shares"' \
+        '"$NOPR_DELETE_SET_FILE"'; do
+        in_remote=$([[ "$remote_trap" == *"$tok"* ]] && echo yes || echo no)
+        assert "remote trap cleans $tok" "yes" "$in_remote"
+    done
+fi
+
+# -----------------------------------------------------------------------------
 # Perf demonstration: scale up to N synthetic even-with-main branches and time
 # the old per-branch ahead-count vs the single for-each-ref. Best-effort; the
 # assertion only requires the batch call to be no slower than the per-branch


### PR DESCRIPTION
## Summary
The Phase 3b `--remote` `trap ... EXIT` in `scripts/clean-branches.sh` (L571) re-registers cleanup *after* the Phase 3 trap (L335). Because bash traps **replace** rather than append, the narrower `--remote` trap silently de-registered cleanup for two temp files created in Phase 3 — `${RESOLVED_STATUS_FILE}.shares` and `$NOPR_DELETE_SET_FILE` (`.nopr_delete`). They leaked in `$TMPDIR` on every `--remote` run.

## Changes
- `scripts/clean-branches.sh`: make the L571 `--remote` EXIT trap a superset of the L335 Phase-3 trap plus `$REMOTE_RESOLVED_FILE` — adds `"${RESOLVED_STATUS_FILE}.shares"` and `"$NOPR_DELETE_SET_FILE"`. One-line change; the other three traps (L177, L261, L335) are untouched.
- `scripts/tests/clean-branches-phase3.test.sh`: add a static trap-superset guard asserting every temp file in the Phase-3 trap also appears in the `--remote` trap. This is a source-level check (no live `gh`/remote needed) and fails if either entry is dropped.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Add `.shares` + `$NOPR_DELETE_SET_FILE` to L571 trap | ✅ | `git diff` shows exactly the two tokens added, matching the curated fix verbatim |
| `bash -n scripts/clean-branches.sh` passes | ✅ | Ran — OK |
| `shellcheck -S error scripts/clean-branches.sh` passes | ✅ | Ran — clean |
| Existing tests stay green | ✅ | `clean-branches-phase3.test.sh` PASS=70 FAIL=0; `clean-branches-reclaim.test.sh` PASS=14 FAIL=0 |
| Other three traps unchanged | ✅ | `git diff` touches only the L571 line |
| Test catches the leak | ✅ | Reverting the trap fix makes the new assertions report `FAIL=2`; restored → PASS |

## Test Plan
- `bash -n scripts/clean-branches.sh` and `bash -n scripts/tests/clean-branches-phase3.test.sh` — OK.
- `shellcheck -S error` on both files — clean.
- `bash scripts/tests/clean-branches-phase3.test.sh` — PASS=70 FAIL=0 (includes 10 new trap-superset assertions).
- `bash scripts/tests/clean-branches-reclaim.test.sh` — PASS=14 FAIL=0.
- Negative control: temporarily reverted the trap to the buggy form → new assertions failed (`remote trap cleans "${RESOLVED_STATUS_FILE}.shares"` and `... "$NOPR_DELETE_SET_FILE"`), confirming the test guards the regression. Restored fix → green.

The manual `--remote --dry-run` `$TMPDIR` check from the issue requires a live `gh`/remote run, so it is covered here by the equivalent static trap-superset assertion instead.

Closes #25349