### PR TITLE
chore(launchers): reclaim worktree on stop for peer-reviewer/aristotle/deploy

### DIFF
--- a/scripts/aristotle/launch-agent.sh
+++ b/scripts/aristotle/launch-agent.sh
@@ -61,6 +61,10 @@ print_success() { echo -e "${GREEN}✓ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}⚠ $1${NC}"; }
 print_error() { echo -e "${RED}✗ $1${NC}" >&2; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -194,6 +198,7 @@ stop_agent() {
         print_info "Dry run: would stop Aristotle agent"
         print_info "Would kill tmux session if running: $SESSION_NAME"
         print_info "Would remove stop signal: $SIGNALS_DIR/stop-aristotle"
+        print_info "Would salvage jobs + remove worktree: $WORKTREE_PATH"
         return
     fi
 
@@ -205,6 +210,15 @@ stop_agent() {
     fi
 
     rm -f "$SIGNALS_DIR/stop-aristotle" 2>/dev/null || true
+
+    # Reclaim the agent's worktree now that its session is gone. Salvage MUST run
+    # FIRST so in-flight Aristotle job state ($WORKTREE_PATH/research/aristotle-jobs.json)
+    # is persisted to $PERSIST_JOBS before the worktree is removed; restore_jobs_file
+    # repopulates the next worktree on the following launch. remove_own_worktree
+    # applies the shared safety guards (dirty / unpushed-or-unbacked / locked /
+    # active-process / current-checkout) and is a no-op if there is nothing to remove.
+    salvage_jobs_file
+    remove_own_worktree "$WORKTREE_PATH"
 }
 
 # Attach to session

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -64,6 +64,10 @@ print_success() { echo -e "${GREEN}✓ $1${NC}"; }
 print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -280,6 +284,14 @@ stop_agent() {
 
     # Clean up signal
     rm -f "$SIGNALS_DIR/stop-deployer"
+
+    # Reclaim the agent's worktree now that its session is gone. The session is
+    # dead (kill-session above) so the worktree is idle; remove_own_worktree
+    # applies the shared safety guards (dirty / unpushed-or-unbacked / locked /
+    # active-process / current-checkout) and is a no-op if there is nothing to
+    # remove. No .env salvage needed: .env is gitignored and the canonical copy
+    # lives at $REPO_ROOT/.env, re-copied into the worktree on every launch.
+    remove_own_worktree "$WORKTREE_PATH"
 }
 
 # Check status

--- a/scripts/peer-reviewer/launch-agent.sh
+++ b/scripts/peer-reviewer/launch-agent.sh
@@ -59,6 +59,10 @@ print_success() { echo -e "${GREEN}✓ $1${NC}"; }
 print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 
+# Shared worktree reclaim helper (remove_own_worktree, guards 1-5).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
+
 # Check dependencies
 check_deps() {
     local missing=()
@@ -215,6 +219,13 @@ stop_agent() {
     fi
 
     rm -f "$SIGNALS_DIR/stop-${AGENT_ID}"
+
+    # Reclaim the agent's worktree now that its session is gone. The session is
+    # dead (kill-session above) so the worktree is idle; remove_own_worktree
+    # applies the shared safety guards (dirty / unpushed-or-unbacked / locked /
+    # active-process / current-checkout) and is a no-op if there is nothing to
+    # remove.
+    remove_own_worktree "$WORKTREE_PATH"
 }
 
 # Check status

--- a/scripts/tests/aristotle-stop-order.test.sh
+++ b/scripts/tests/aristotle-stop-order.test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Guards the load-bearing ordering in scripts/aristotle/launch-agent.sh
+# stop_agent(): in-flight Aristotle job state must be persisted by
+# salvage_jobs_file BEFORE the worktree is reclaimed by remove_own_worktree,
+# or job state is lost (issue #25350, Phase 2b).
+#
+# Also asserts neither call leaks into the DRY_RUN early-return branch (a
+# --dry-run --stop must touch nothing).
+#
+# Run: bash scripts/tests/aristotle-stop-order.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER="$SCRIPT_DIR/../aristotle/launch-agent.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ok: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+
+# Extract the body of stop_agent(): from "stop_agent() {" up to the first line
+# that is exactly "}".
+stop_body="$(awk '
+    /^stop_agent\(\) \{/ { capture=1; next }
+    capture && /^\}$/ { capture=0 }
+    capture { print }
+' "$LAUNCHER")"
+
+if [[ -z "$stop_body" ]]; then
+    fail "could not locate stop_agent() body in $LAUNCHER"
+    echo ""
+    echo "PASS=$PASS FAIL=$FAIL"
+    exit 1
+fi
+
+# 1) Both salvage and remove are present in stop_agent() as actual calls.
+# Match invocation lines (token at start of a line, ignoring leading whitespace)
+# so prose mentions inside `#` comments do not count.
+salvage_line="$(grep -nE '^[[:space:]]*salvage_jobs_file([[:space:]]|$)' <<<"$stop_body" | head -n1 | cut -d: -f1)"
+remove_line="$(grep -nE '^[[:space:]]*remove_own_worktree([[:space:]]|$)' <<<"$stop_body" | head -n1 | cut -d: -f1)"
+
+if [[ -n "$salvage_line" ]]; then
+    pass "stop_agent() calls salvage_jobs_file"
+else
+    fail "stop_agent() does not call salvage_jobs_file"
+fi
+
+if [[ -n "$remove_line" ]]; then
+    pass "stop_agent() calls remove_own_worktree"
+else
+    fail "stop_agent() does not call remove_own_worktree"
+fi
+
+# 2) salvage runs BEFORE remove (load-bearing ordering).
+if [[ -n "$salvage_line" && -n "$remove_line" ]]; then
+    if (( salvage_line < remove_line )); then
+        pass "salvage_jobs_file precedes remove_own_worktree (job state persisted first)"
+    else
+        fail "salvage_jobs_file must precede remove_own_worktree (got salvage@$salvage_line, remove@$remove_line)"
+    fi
+fi
+
+# 3) Neither call appears in the DRY_RUN early-return branch. Extract the lines
+# between the DRY_RUN guard and its `return`.
+dry_body="$(awk '
+    /if \[\[ "\$DRY_RUN" == "true" \]\]; then/ { capture=1; next }
+    capture && /return/ { capture=0 }
+    capture { print }
+' <<<"$stop_body")"
+
+if grep -qE '^[[:space:]]*(salvage_jobs_file|remove_own_worktree)([[:space:]]|$)' <<<"$dry_body"; then
+    fail "DRY_RUN branch must NOT actually salvage or remove (a preview line is fine, an actual call is not)"
+else
+    pass "DRY_RUN branch does not invoke salvage/remove"
+fi
+
+# 4) The launcher sources the shared helper exactly once.
+src_count="$(grep -cE '^source .*scripts/lib/worktree-cleanup\.sh' "$LAUNCHER")"
+if [[ "$src_count" -eq 1 ]]; then
+    pass "sources scripts/lib/worktree-cleanup.sh exactly once"
+else
+    fail "expected exactly one source of worktree-cleanup.sh, found $src_count"
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Phase 2b of the per-workflow worktree cleanup contract. Wires the existing shared helper `scripts/lib/worktree-cleanup.sh`'s `remove_own_worktree` into the `stop_agent()` teardown path of the three remaining worktree-creating launchers (peer-reviewer, aristotle, deploy), mirroring the Phase 2a auditor/mechanic wiring. The helper is reused unchanged — no reimplementation.

## Changes

- **`scripts/peer-reviewer/launch-agent.sh`** — source the helper once after the print functions; append `remove_own_worktree "$WORKTREE_PATH"` as the final statement of `stop_agent()`, after the `rm -f "$SIGNALS_DIR/stop-${AGENT_ID}"`.
- **`scripts/aristotle/launch-agent.sh`** — source the helper once; in the **non-dry-run** path of `stop_agent()` only, call `salvage_jobs_file` FIRST, then `remove_own_worktree "$WORKTREE_PATH"` (load-bearing order: in-flight job state is persisted to `$PERSIST_JOBS` before the worktree is reclaimed; `restore_jobs_file` repopulates the next worktree on relaunch). DRY_RUN early-return branch left untouched except for a parity preview line.
- **`scripts/deploy/launch-agent.sh`** — source the helper once; append `remove_own_worktree "$WORKTREE_PATH"` after the `rm -f "$SIGNALS_DIR/stop-deployer"`. No `.env` salvage step (`.env` is gitignored; canonical copy at `$REPO_ROOT/.env`, re-copied each launch).
- **`scripts/tests/aristotle-stop-order.test.sh`** (new) — statically asserts `salvage_jobs_file` precedes `remove_own_worktree` in the aristotle stop path, neither leaks into the DRY_RUN branch, and the helper is sourced exactly once.

The shared helper (`scripts/lib/worktree-cleanup.sh`) was **not** modified (no bug found; the optional `clean-branches.sh` guard de-dup was out of minimal scope).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each listed launcher removes its worktree on stop, honoring all safety guards | done | `remove_own_worktree` (guards 1-5) is the final teardown statement in each `stop_agent()` |
| Aristotle cleanup runs strictly after `salvage_jobs_file`; non-dry-run only | done | New `aristotle-stop-order.test.sh` asserts salvage@line < remove@line and DRY_RUN branch has no actual calls (PASS=5) |
| Deploy removes worktree with no `.env` preservation step | done | Only `remove_own_worktree` appended; comment documents canonical `.env` rationale |
| Each launcher sources the helper exactly once; call is final teardown statement (not an EXIT trap) | done | One `source` line per launcher near the top; cleanup is last line of `stop_agent()` |
| `bash -n` + `shellcheck -S error` clean on all modified scripts | done | All 4 files pass `bash -n` and `shellcheck -S error` |
| `scripts/tests/worktree-cleanup.test.sh` stays green | done | PASS=10 FAIL=0 |

## Test Plan

- `bash -n` + `shellcheck -S error` clean on all 3 launchers, the helper, and the new test.
- `scripts/tests/worktree-cleanup.test.sh` → PASS=10.
- `scripts/tests/clean-branches-reclaim.test.sh` → PASS=14.
- `scripts/tests/clean-branches-phase3.test.sh` → PASS=70.
- New `scripts/tests/aristotle-stop-order.test.sh` → PASS=5 (proves salvage-before-remove ordering and DRY_RUN safety).

Closes #25350