### PR TITLE
refactor(sperner-grid): remove obsolete boundary wrapper; document boundary_doors_odd blocker (#9044)

### DIFF
--- a/proofs/Proofs/SpernerGrid.lean
+++ b/proofs/Proofs/SpernerGrid.lean
@@ -49,13 +49,19 @@ vertices at different positions always differ.
 2. `boundary_doors_odd` — FALSE as stated for d=1;
    requires fundamental redesign of GridSimplex/gridAdj.
 
-## Proved this session
+## Boundary analysis (current state)
 
 - `no_boundary_door_k_lt`: boundary doors cannot occur at k < d
   (under the geometric boundary condition). Full proof, no sorry.
-- `no_boundary_doors_face_lt`: thin wrapper around the above,
-  now uses correct geometric hypothesis (not gridAdj=none).
-- Removed false `boundary_verts_on_face` theorem.
+- Removed false `boundary_verts_on_face` theorem (was unsound).
+- Removed `no_boundary_doors_face_lt` (an obsolete thin wrapper
+  around `no_boundary_door_k_lt` that nothing referenced).
+
+The remaining open piece is `boundary_doors_odd`, which is FALSE
+as currently stated because of a structural double-counting in
+the `GridSimplex`/`gridAdj` representation (see the detailed note
+on that theorem below). It cannot be discharged without a redesign
+of `GridSimplex`/`gridAdj`; see issue #9044 / parent #8998.
 
 ## Known design issues
 
@@ -1687,28 +1693,6 @@ theorem no_boundary_door_k_lt
   -- s.verts i is on face k (by geometric boundary hypothesis)
   -- Sperner forbids color k on face k
   exact hc (s.verts i) k (hbdry i hi_ne) hi_col
-
-/-- On geometric boundary face k (k < d), the Sperner condition prevents doors.
-
-If all vertices j ≠ k of simplex s lie on geometric face k (coords[k] = 0),
-and k < d, then there is no door at position k.
-
-This is a thin wrapper around `no_boundary_door_k_lt` with the same proof,
-kept for compatibility. The key point: doors cannot occur at non-last faces
-on the geometric boundary, because color k is forbidden on face k by Sperner.
-
-NOTE: The original version of this theorem used `gridAdj d N s k = none` as
-hypothesis, but that is WEAKER than the geometric condition — gridAdj incorrectly
-returns `none` for some interior facets (cross-miss adjacency bug). The correct
-hypothesis is the geometric boundary condition used here. -/
-theorem no_boundary_doors_face_lt
-    (c : BaryPoint d N → Fin (d + 1))
-    (hc : IsSperner c)
-    (s : GridSimplex d N) (k : Fin (d + 1))
-    (hk : k.val < d)
-    (hbdry : ∀ j : Fin (d + 1), j ≠ k → (s.verts j).onFace k) :
-    ¬CellComplex.IsDoor c (gridComplex d N) s k :=
-  no_boundary_door_k_lt c hc s k hk hbdry
 
 /-- The boundary door count for Sperner colorings is odd. -/
 theorem boundary_doors_odd (d N : ℕ) (hN : 0 < N)


### PR DESCRIPTION
Closes #9044

## Honest status: partial. `boundary_doors_odd` is NOT proved, and it is documented to be FALSE as currently stated.

After a genuine investigation, the headline acceptance criterion of this issue (`boundary_doors_odd` proved with 0 sorry) **cannot be honestly met within the scope as written**. Details below. I completed the parts that are genuine and correct, and I am explicitly NOT faking the rest.

### What this PR actually changes
- **Removes `no_boundary_doors_face_lt`** from `SpernerGrid.lean` — an obsolete thin wrapper around `no_boundary_door_k_lt` that nothing in `proofs/` or `src/` referenced. The issue explicitly requested its removal. (The `no_boundary_doors_face_lt` in `SpernerNDim.lean` is a different theorem in a different file and is untouched.)
- **Updates the module docstring** to accurately describe the current boundary-analysis state and the `boundary_doors_odd` blocker.

### Acceptance criteria, assessed honestly
- [x] `boundary_verts_on_face` removed — **already done by prior PR #12686** (before this issue was picked up).
- [x] `no_boundary_doors_face_lt` removed — **done in this PR**.
- [ ] `boundary_doors_odd` proved (0 sorry) — **NOT done. It is false as stated** (see below).
- [ ] `sperner_grid` end-to-end — depends on the above plus pre-existing build failures.

### Why `boundary_doors_odd` is false as stated (verified, not hand-waved)
`GridSimplex` carries a `miss : Fin (d+1)` field. For `d=1`, the single geometric edge `{(1,0),(0,1)}` is represented by **two distinct `GridSimplex` cells** (`miss=0` and `miss=1`). Both end up as boundary doors under any Sperner coloring, so the boundary-door count is `2` (even), contradicting `Odd`. A concrete `d=1, N=1` counterexample is documented inline at the theorem. This is a *structural* double-counting in the representation, not a missing lemma. The issue body itself anticipates this ("requires constructing the (d−1)-dimensional boundary complex", and an explicit doubt at the d=0 base case) and presumes a `gridAdj` redesign that does not exist yet.

Honestly discharging it requires redesigning `GridSimplex`/`gridAdj` so each geometric simplex appears exactly once (canonical-form / quotient, with cross-miss adjacency). That is a substantially larger task than "remove two lemmas + prove one theorem" and properly belongs to parent #8998. I did not fabricate an `axiom`, `True`, or vacuous statement to make it "pass".

### Build status
`./proofs/scripts/docker-build.sh Proofs.SpernerGrid` **fails**, but the failures are **pre-existing on `main` and unrelated to this PR**:
- `error` at lines ~1537 / 1556 / 1590 — inside the `gridAdj_vertex` / `gridAdj_ne` interiorFlip proofs (`hk0` rewrite metavariable, `No goals to be solved`, unknown identifier `hs'`). Verified identical on pristine `HEAD`; my diff only touches lines 52/56 (docstring) and the removed wrapper at ~1696.

So the file does not compile today even before this change. Issue #9044 assumed #9042/#9043 left the adjacency proofs complete and the file compiling; in practice those proofs are still broken on `main`. Fixing them is out of scope for this issue.

### Sorry / axiom count (this file)
- Axioms: **0**.
- Sorries: **2** — (1) `CellComplex.sperner` (the acceptable one; proved in `SpernerMathlib4.lean`), and (2) `boundary_doors_odd` (the documented false-as-stated blocker). No change in count from `main`; this PR is a correctness/cleanup + documentation step, not a sorry-elimination.

### Recommendation for reviewer
This issue is **blocked** on a deeper redesign than its title scopes. Suggested next steps (parent #8998): either (a) redesign `GridSimplex`/`gridAdj` with canonical miss-direction selection so geometric simplices are not double-counted, then re-derive `boundary_doors_odd`; or (b) retarget the concrete grid instance onto the already-complete, 0-sorry `SpernerNDimMathlib` / `SpernerMathlib4` machinery. Separately, the pre-existing `gridAdj_*` build errors need their own fix.