### PR TITLE
research(fermat-defect-one): modular-obstruction Level 3 at n=4,5,6 (no obstruction)

### DIFF
--- a/proofs/Proofs/FermatDefectOne.lean
+++ b/proofs/Proofs/FermatDefectOne.lean
@@ -129,6 +129,144 @@ theorem fermat_defect_three_negative : FermatDefectNegative 3 := by
   · native_decide
   · native_decide
 
+/-! ## Modular obstructions (Level 3 refutation candidates)
+
+A prime `p` is a *Level-3 modular obstruction* at `(n, ε)` if the defect
+congruence
+
+  negative sign:  `a^n + b^n + 1 ≡ c^n (mod p)`
+  positive sign:  `a^n + b^n ≡ c^n + 1 (mod p)`
+
+has **no** primitive residue solution, i.e. no `(a, b, c) : (ZMod p)³` with
+`(a, b, c) ≠ (0, 0, 0)` satisfying it. Such an obstruction would rule out all
+integer defect-one solutions of that sign and exponent (any integer solution
+reduces mod `p`, and a primitive integer triple stays primitive mod every `p`).
+
+The search at `n ∈ {4, 5, 6}`, `ε ∈ {−1, +1}`, `p ∈ {3, 5, 7, 11, 13}` finds
+**no obstruction**. The reason is structural and rules out *every* prime, not
+just this range:
+
+* Negative sign: `(a, b, c) = (0, 0, 1)` gives `0 + 0 + 1 = 1 = 1^n` in any
+  `ZMod p` (for `n ≥ 1`, since `0^n = 0`). This is a primitive residue triple
+  (`c = 1 ≠ 0`), so it is always a solution.
+* Positive sign: `(a, b, c) = (1, 0, 0)` gives `1^n + 0^n = 1 = 0^n + 1` in any
+  `ZMod p` (for `n ≥ 1`). This is a primitive residue triple (`a = 1 ≠ 0`).
+
+Hence no single-prime congruence obstruction can exist for the defect-one
+problem in either sign. The negative search result is recorded as a claim file
+in `research/problems/fermat-defect-one/claims/`. The theorems below certify
+the structural unit witnesses, both as the explicit `decide`-checked instances
+at each `(n, ε, p)` in scope and as the general all-`n`, all-`p` statements. -/
+
+/-- Negative-sign defect congruence over `ZMod p` has a *primitive* residue
+solution `(a, b, c)` (not all zero): `a^n + b^n + 1 = c^n`. -/
+def ModSolvableNeg (n : Nat) (p : Nat) : Prop :=
+  ∃ a b c : ZMod p, ¬ (a = 0 ∧ b = 0 ∧ c = 0) ∧ a ^ n + b ^ n + 1 = c ^ n
+
+/-- Positive-sign defect congruence over `ZMod p` has a *primitive* residue
+solution `(a, b, c)` (not all zero): `a^n + b^n = c^n + 1`. -/
+def ModSolvablePos (n : Nat) (p : Nat) : Prop :=
+  ∃ a b c : ZMod p, ¬ (a = 0 ∧ b = 0 ∧ c = 0) ∧ a ^ n + b ^ n = c ^ n + 1
+
+/-- **General structural non-obstruction, negative sign.** For every `n ≥ 1`
+and every prime `p`, the negative defect congruence has the primitive residue
+solution `(0, 0, 1)`. Consequently *no* prime is a Level-3 modular obstruction
+for the negative sign at any exponent — in particular none at `n ∈ {4,5,6}`,
+`p ∈ {3,5,7,11,13}`. -/
+theorem fermat_defect_no_obstruction_neg (n p : Nat) (hn : 1 ≤ n)
+    [NeZero p] [Fact (1 < p)] : ModSolvableNeg n p := by
+  refine ⟨0, 0, 1, ?_, ?_⟩
+  · rintro ⟨-, -, h⟩
+    exact (one_ne_zero h)
+  · have h0 : (0 : ZMod p) ^ n = 0 := zero_pow (by omega)
+    simp [h0]
+
+/-- **General structural non-obstruction, positive sign.** For every `n ≥ 1`
+and every prime `p`, the positive defect congruence has the primitive residue
+solution `(1, 0, 0)`. Consequently *no* prime is a Level-3 modular obstruction
+for the positive sign at any exponent. -/
+theorem fermat_defect_no_obstruction_pos (n p : Nat) (hn : 1 ≤ n)
+    [NeZero p] [Fact (1 < p)] : ModSolvablePos n p := by
+  refine ⟨1, 0, 0, ?_, ?_⟩
+  · rintro ⟨h, -, -⟩
+    exact (one_ne_zero h)
+  · have h0 : (0 : ZMod p) ^ n = 0 := zero_pow (by omega)
+    simp [h0]
+
+/-! ### Explicit `decide`-checked instances at the searched `(n, ε, p)`
+
+Each instance exhibits a concrete primitive residue witness and is verified by
+`decide` over the finite type `ZMod p`. The naming follows the issue request,
+`fermat_defect_obstruction_n_<k>_<sign>_mod_<p>`; because the search found *no*
+obstruction, each theorem states `Mod{Neg,Pos}Solvable` — the congruence is
+solvable, hence there is no obstruction at that `(n, ε, p)`. -/
+
+theorem fermat_defect_obstruction_n_4_neg_mod_3 : ModSolvableNeg 4 3 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_neg_mod_5 : ModSolvableNeg 4 5 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_neg_mod_7 : ModSolvableNeg 4 7 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_neg_mod_11 : ModSolvableNeg 4 11 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_neg_mod_13 : ModSolvableNeg 4 13 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+
+theorem fermat_defect_obstruction_n_4_pos_mod_3 : ModSolvablePos 4 3 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_pos_mod_5 : ModSolvablePos 4 5 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_pos_mod_7 : ModSolvablePos 4 7 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_pos_mod_11 : ModSolvablePos 4 11 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_4_pos_mod_13 : ModSolvablePos 4 13 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+
+theorem fermat_defect_obstruction_n_5_neg_mod_3 : ModSolvableNeg 5 3 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_neg_mod_5 : ModSolvableNeg 5 5 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_neg_mod_7 : ModSolvableNeg 5 7 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_neg_mod_11 : ModSolvableNeg 5 11 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_neg_mod_13 : ModSolvableNeg 5 13 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+
+theorem fermat_defect_obstruction_n_5_pos_mod_3 : ModSolvablePos 5 3 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_pos_mod_5 : ModSolvablePos 5 5 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_pos_mod_7 : ModSolvablePos 5 7 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_pos_mod_11 : ModSolvablePos 5 11 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_5_pos_mod_13 : ModSolvablePos 5 13 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+
+theorem fermat_defect_obstruction_n_6_neg_mod_3 : ModSolvableNeg 6 3 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_neg_mod_5 : ModSolvableNeg 6 5 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_neg_mod_7 : ModSolvableNeg 6 7 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_neg_mod_11 : ModSolvableNeg 6 11 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_neg_mod_13 : ModSolvableNeg 6 13 :=
+  ⟨0, 0, 1, by decide, by decide⟩
+
+theorem fermat_defect_obstruction_n_6_pos_mod_3 : ModSolvablePos 6 3 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_pos_mod_5 : ModSolvablePos 6 5 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_pos_mod_7 : ModSolvablePos 6 7 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_pos_mod_11 : ModSolvablePos 6 11 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+theorem fermat_defect_obstruction_n_6_pos_mod_13 : ModSolvablePos 6 13 :=
+  ⟨1, 0, 0, by decide, by decide⟩
+
 /-! ## Open conjecture: defect-one existence for every $n \ge 3$ -/
 
 /-- **Fermat defect-one conjecture (Level 2).** For every exponent $n \ge 3$,

--- a/research/problems/fermat-defect-one/claims/2026-06-17-modular-obstruction-n456-level3.md
+++ b/research/problems/fermat-defect-one/claims/2026-06-17-modular-obstruction-n456-level3.md
@@ -1,0 +1,87 @@
+# Claim — No Level-3 modular obstruction at n = 4, 5, 6 (and, structurally, at any prime)
+
+- **Vector attempted**: modular-obstruction
+- **Date**: 2026-06-17
+- **Author**: Loom builder (issue #22636)
+- **Status**: failed (no obstruction found) — negative result, fully decisive
+
+## What was tried
+
+For each $(n, \epsilon, p)$ with
+
+- $n \in \{4, 5, 6\}$,
+- $\epsilon \in \{-1, +1\}$ (negative defect $a^n + b^n + 1 \equiv c^n$, positive
+  defect $a^n + b^n \equiv c^n + 1$),
+- $p \in \{3, 5, 7, 11, 13\}$,
+
+an exhaustive search over all residue triples $(a, b, c) \in (\mathbb{Z}/p)^3$
+was run, excluding only the all-zero triple $(0,0,0) \equiv 0$ as non-primitive.
+A prime $p$ is a *Level-3 modular obstruction* at $(n, \epsilon)$ iff **no**
+primitive residue triple satisfies the corresponding congruence. The search
+script (`claims/scripts/modular_obstruction_search.py`) is a trivial triple loop
+over residues mod $p$ (30 cells, each $p^3 \le 2197$ triples); it ran in well
+under a second.
+
+## What happened
+
+**Every** $(n, \epsilon, p)$ in scope admits a primitive residue solution, so
+**no obstruction exists** anywhere in the searched range. Full table (all 30
+cells found a solution; representative witnesses shown):
+
+| $n$ | sign | $p=3$ | $p=5$ | $p=7$ | $p=11$ | $p=13$ |
+|----|------|-------|-------|-------|--------|--------|
+| 4 | neg ($+1$) | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ |
+| 4 | pos ($-1$) | $(0,1,0)$ | $(0,1,0)$ | $(0,1,0)$ | $(0,1,0)$ | $(0,1,0)$ |
+| 5 | neg ($+1$) | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ |
+| 5 | pos ($-1$) | $(0,0,2)$ | $(0,0,4)$ | $(0,0,6)$ | $(0,0,2)$ | $(0,0,12)$ |
+| 6 | neg ($+1$) | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ | $(0,0,1)$ |
+| 6 | pos ($-1$) | $(0,1,0)$ | $(0,0,2)$ | $(0,1,0)$ | $(0,1,0)$ | $(0,0,2)$ |
+
+The non-obstruction is **structural and rules out every prime**, not just the
+searched range. There are universal "unit" residue witnesses valid in any
+$\mathbb{Z}/p$ for all $n \ge 1$:
+
+- Negative sign: $(a, b, c) = (0, 0, 1)$ gives $0^n + 0^n + 1 = 1 = 1^n$. This is
+  primitive ($c = 1 \ne 0$).
+- Positive sign: $(a, b, c) = (1, 0, 0)$ gives $1^n + 0^n = 1 = 0^n + 1$. This is
+  primitive ($a = 1 \ne 0$).
+
+Intuitively, a unit-offset Fermat congruence is *trivially* satisfiable mod any
+$p$ precisely because the "$\pm 1$" can be absorbed by the residue $1 = 1^n =
+\dots$. So single-prime congruence obstructions cannot exist for the defect-one
+problem in either sign at any exponent — this attack vector is a dead end for
+*all* $n$, not merely $n \in \{4,5,6\}$.
+
+### Lean formalization
+
+The structural result is machine-checked in `proofs/Proofs/FermatDefectOne.lean`
+(built clean under the Docker wrapper, 0 sorry / 0 axiom / no `native_decide` in
+the new declarations — the existing $n=3$ benchmarks' `native_decide` is
+untouched):
+
+- `fermat_defect_no_obstruction_neg (n p : Nat) (hn : 1 ≤ n) [NeZero p]
+  [Fact (1 < p)] : ModSolvableNeg n p` — general negative-sign witness $(0,0,1)$.
+- `fermat_defect_no_obstruction_pos (n p : Nat) (hn : 1 ≤ n) [NeZero p]
+  [Fact (1 < p)] : ModSolvablePos n p` — general positive-sign witness $(1,0,0)$.
+- 30 explicit `decide`-checked instances
+  `fermat_defect_obstruction_n_<k>_<sign>_mod_<p>` for the searched
+  $(n, \epsilon, p)$, each stating `Mod{Neg,Pos}Solvable <k> <p>` (the congruence
+  is solvable, hence *no* obstruction).
+
+`ModSolvableNeg`/`ModSolvablePos` package "the defect congruence has a primitive
+residue solution over $\mathbb{Z}/p$".
+
+## What this suggests for next iteration
+
+- **Abandon the single-prime `modular-obstruction` vector for all $n$.** The
+  unit witnesses $(0,0,1)$ / $(1,0,0)$ make it provably impossible. Record this
+  in `notes/dead-ends.md`.
+- A *composite* / CRT modulus inherits the same unit witnesses, so it cannot
+  obstruct either — combining primes does not help.
+- More promising remaining vectors for refuting Level 3 (if it is false at some
+  $(n, \epsilon)$) are non-congruence: the `reduction` vector (Fermat–Catalan /
+  Mason–Stothers finiteness; see the parameterization claim #22637 which already
+  closed the $\mathbb{Z}[t]$ polynomial-family route) and direct
+  `witness-search` (issue #22635) to find or bound integer witnesses.
+- The genuine arithmetic obstruction, if any exists, is global (archimedean /
+  size-based), not local at a prime.

--- a/research/problems/fermat-defect-one/claims/scripts/modular_obstruction_search.py
+++ b/research/problems/fermat-defect-one/claims/scripts/modular_obstruction_search.py
@@ -1,0 +1,46 @@
+# Modular obstruction search for Fermat defect-one, Level 3.
+# For each (n, eps, p): does a^n + b^n + eps == c^n (mod p) have ANY primitive
+# solution (a,b,c not all == 0 mod p)? If NO solution exists -> obstruction.
+
+def search(n, eps, p):
+    # eps in {+1,-1}. Work in Z/p. eps mod p:
+    e = eps % p
+    found = None
+    for a in range(p):
+        for b in range(p):
+            for c in range(p):
+                if a == 0 and b == 0 and c == 0:
+                    continue  # exclude all-zero (non-primitive)
+                lhs = (pow(a, n, p) + pow(b, n, p) + e) % p
+                rhs = pow(c, n, p) % p
+                if lhs == rhs:
+                    found = (a, b, c)
+                    break
+            if found: break
+        if found: break
+    return found  # None means OBSTRUCTION
+
+primes = [3,5,7,11,13]
+ns = [4,5,6]
+signs = {'neg': +1, 'pos': -1}
+# Mapping: negative defect a^n+b^n+1=c^n  -> eps=+1
+#          positive defect a^n+b^n=c^n+1 -> a^n+b^n-1=c^n -> eps=-1
+
+print("n  sign  p   result")
+obstructions = []
+for n in ns:
+    for sname, eps in signs.items():
+        for p in primes:
+            r = search(n, eps, p)
+            status = "SOLUTION "+str(r) if r else "*** OBSTRUCTION ***"
+            print(f"{n}  {sname}({'+1' if eps==1 else '-1'}) {p:3d}  {status}")
+            if r is None:
+                obstructions.append((n, sname, eps, p))
+        print()
+
+print("=== OBSTRUCTIONS FOUND ===")
+if obstructions:
+    for o in obstructions:
+        print(o)
+else:
+    print("NONE in p in {3,5,7,11,13} for n in {4,5,6}, both signs.")

--- a/research/problems/fermat-defect-one/notes/dead-ends.md
+++ b/research/problems/fermat-defect-one/notes/dead-ends.md
@@ -22,10 +22,11 @@ claim closes off a direction definitively.
     **conditional/axiomatized** finiteness lemma (not the headline, not
     `verified`).
   - *Productive vectors instead*: `witness-search` (#22635, per-$n$ verified
-    witnesses), `modular-obstruction` (#22636, the only rigorous-refutation
-    route). NB: `parameterization` was named here as "the only
+    witnesses). NB: `parameterization` was named here as "the only
     unconditional-existence route" — that is now **also closed for $n \ge 3$**;
-    see the next entry.
+    see below. And `modular-obstruction` was named "the only rigorous-refutation
+    route" — that is now **also closed for all $n$** (no prime, and no composite
+    modulus, can obstruct); see below.
 
 - **`parameterization` (polynomial families $a(t)^n + b(t)^n - c(t)^n \equiv
   \pm 1$)** — dead end for the headline existence conjecture at $n \ge 3$. See
@@ -45,5 +46,24 @@ claim closes off a direction definitively.
     $\forall n \ge 3$ existence statement has **no known uniform-construction
     route**; `witness-search` settles one exponent at a time, and a genuinely
     new idea is needed for the universal statement.
+
+- **`modular-obstruction` (single prime $p$, Level-3 refutation)** — dead end
+  for refuting Level 3 at *any* $(n, \epsilon)$, at *any* prime. See
+  `claims/2026-06-17-modular-obstruction-n456-level3.md` (issue #22636).
+  - *Exhaustive search.* All $(n, \epsilon, p)$ with $n \in \{4,5,6\}$,
+    $\epsilon \in \{-1,+1\}$, $p \in \{3,5,7,11,13\}$ — every one of the 30
+    cells admits a primitive residue solution mod $p$. No obstruction.
+  - *Unconditional obstruction to the method.* Universal "unit" residue
+    witnesses exist in *every* $\mathbb{Z}/p$ for all $n \ge 1$:
+    $(a,b,c) = (0,0,1)$ for the negative sign ($0^n + 0^n + 1 = 1^n$) and
+    $(1,0,0)$ for the positive sign ($1^n + 0^n = 0^n + 1$). The unit offset
+    "$\pm 1$" is absorbed by $1 = 1^n$, so the congruence is trivially solvable
+    mod any modulus; composite/CRT moduli inherit the same witnesses.
+  - *Consequence.* Single-modulus congruence obstructions cannot exist for
+    defect-one. Any genuine arithmetic obstruction (if Level 3 fails somewhere)
+    must be global/archimedean (size-based), not local at a prime. Formalized
+    in `proofs/Proofs/FermatDefectOne.lean`
+    (`fermat_defect_no_obstruction_{neg,pos}` + 30 `decide`-checked instances,
+    built clean: 0 sorry / 0 axiom / no new `native_decide`).
 
 (Seeded 2026-06-09 by issue #22628.)


### PR DESCRIPTION
Closes #22636

## Summary

Implements the `modular-obstruction` vector for the Fermat defect-one problem (Level 3) at n = 4, 5, 6.

**Result: NO obstruction found — and provably none can exist at any prime.**

## Modular search (executed)

Exhaustive search over every residue triple `(a,b,c) in (ZMod p)^3` (excluding the all-zero non-primitive triple) for all 30 combinations of:
- `n in {4, 5, 6}`
- `eps in {-1, +1}` (negative defect `a^n+b^n+1=c^n`, positive defect `a^n+b^n=c^n+1`)
- `p in {3, 5, 7, 11, 13}`

Every one of the 30 cases admits a primitive residue solution, so **no prime obstructs** any `(n, eps)` in range. The script lives at `research/problems/fermat-defect-one/claims/scripts/modular_obstruction_search.py` (runs in <1s).

## Why no prime can ever obstruct (structural)

There are universal "unit" residue witnesses in any `ZMod p` for all `n >= 1`:
- Negative sign: `(0,0,1)` gives `0^n + 0^n + 1 = 1 = 1^n`.
- Positive sign: `(1,0,0)` gives `1^n + 0^n = 1 = 0^n + 1`.

The unit offset `+/-1` is absorbed by `1 = 1^n`, so the congruence is trivially solvable mod any modulus (composite/CRT moduli inherit the same witnesses). Single-modulus congruence obstructions therefore cannot exist for this problem at any exponent.

## Lean formalization (verified)

Added to `proofs/Proofs/FermatDefectOne.lean`, **built clean under `./proofs/scripts/docker-build.sh Proofs.FermatDefectOne`** (7743 jobs, only the pre-existing `sorry` on the open headline conjecture warns; the new declarations have 0 sorry / 0 axiom / no `native_decide`):

- `ModSolvableNeg` / `ModSolvablePos` — predicates: the defect congruence has a primitive residue solution over `ZMod p`.
- `fermat_defect_no_obstruction_neg` / `fermat_defect_no_obstruction_pos` — general theorems, all `n >= 1` and all primes, via the unit witnesses (`zero_pow` + `simp`).
- 30 explicit `decide`-checked instances `fermat_defect_obstruction_n_<k>_<sign>_mod_<p>` for the searched `(n, eps, p)`.

## Negative result documented

- `research/problems/fermat-defect-one/claims/2026-06-17-modular-obstruction-n456-level3.md` (matches PROBLEMS-STRUCTURE.md claim format; status: failed/decisive).
- `research/problems/fermat-defect-one/notes/dead-ends.md` updated — `modular-obstruction` is now recorded as closed for all `n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)