### PR TITLE
audit(infinitude-primes-4k3-oq-01): badge original→mathlib

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-01/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/InfinitudePrimes4k3OQ01Q12Q24.lean",
     "parentProofId": "infinitude-primes-4k3",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: infinitude-primes-4k3-oq-01
**Severity**: MEDIUM (Mathlib wrapper classified as `original`)

## Evidence

- The entry's `assumptions` field states: *"The infinitude content is supplied entirely by the repository's `DirichletsTheorem.dirichlet_modEq` ... by delegation to Mathlib's `Nat.infinite_setOf_prime_and_modEq`."*
- The Lean file (`Proofs/InfinitudePrimes4k3OQ01Q12Q24.lean`, registered) obtains its core result (infinitude of primes ≡ -1 mod 12/24) entirely from Mathlib's Dirichlet theorem; the file's own work is specialization (`decide`/`omega`/`simp`) + two ZMod↔mod bridge lemmas.
- Per the auditor tier rules (Tier B / failure mode 5), a result whose **core argument relies on a Mathlib theorem** takes badge `mathlib`, not `original`.
- The sibling entry **infinitude-primes-4k1-oq-01** uses badge `mathlib` for exactly this pattern (Fermat two-squares via `Nat.Prime.sq_add_sq`).

## Fix

`badge`: `original` → `mathlib`.

No other change: status remains `verified`, `sorries: 0`, `axiomCount: 0` (file uses `decide`, not `native_decide`, so it is genuinely axiom-free). The title ("Dirichlet Specialization"), description, and `originalContributions` already disclose the delegation honestly — only the badge field was inconsistent.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)