### PR TITLE
Enrich Grace's 3D Feuerbach (trirectangular): +2 annotations, fix significance

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02-murakami/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02-murakami/annotations.json
@@ -36,7 +36,7 @@
     "title": "grace_feuerbach_trirectangular: Five Identities, One Sphere",
     "content": "The single theorem bundles five real identities: three incidence goals ((qx−a)²+qy²+qz²=R² and cyclically for B, C) asserting the sphere passes through A, B, C, and two tangency goals ((qx−ρ)²+(qy−ρ)²+(qz−ρ)²=(R−ρ)² for ρ∈{ρin,ρex}) asserting internal tangency to the insphere and the D-exsphere. The surd is encoded as the hypothesis t²=a²b²+b²c²+c²a² (with t≥0), turning a √-problem into a field identity. After `have hσ : a+b+c ≠ 0 := by positivity` and substituting the closed forms, the proof splits into five goals closed by `field_simp; ring` (incidence) and `field_simp; linear_combination 2 * ht` (tangency).",
     "mathContext": "Each incidence identity is a rational-function identity that becomes a pure polynomial identity once the shared 2σ denominator is cleared, hence ring closes it. Each tangency identity holds only modulo the surd relation: linear_combination 2*ht supplies exactly the multiple of (t² − (a²b²+b²c²+c²a²)) needed, the integer coefficient 2 being the post-field_simp image of the analytic factor 1/(2σ²).",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "incidence identity",
       "internal tangency",
@@ -51,6 +51,57 @@
     ]
   },
   {
+    "id": "ann-hypotheses",
+    "proofId": "feuerbachs-theorem-oq-02-murakami",
+    "range": {
+      "startLine": 76,
+      "endLine": 84
+    },
+    "type": "concept",
+    "title": "Encoding the Geometry as Real-Variable Hypotheses",
+    "content": "The hypothesis block pins every geometric quantity to its closed form over the common denominator 2σ: hqx, hqy, hqz fix the centre Θ=(qx,qy,qz); hR fixes the radius R; hρin and hρex fix the insphere and D-exsphere radii. The tangency surd is introduced not via Real.sqrt but algebraically, as the pair ht : t² = a²b²+b²c²+c²a² together with ht0 : 0 ≤ t. This is the key design choice: it keeps the entire statement inside the equational theory of fields, where field_simp, ring, and linear_combination operate, instead of forcing reasoning about an opaque √ term.",
+    "mathContext": "The pair (ht, ht0) recovers t = √(a²b²+b²c²+c²a²) uniquely (a non-negative square root is determined by its square), yet exposes only the polynomial relation t² − (a²b²+b²c²+c²a²) = 0 to the tactics. Every later goal is therefore an identity in ℝ[a,b,c,t] modulo that one relation, with the positivity hypotheses ha, hb, hc supplying a+b+c ≠ 0 so the 2σ denominators are legitimate.",
+    "significance": "key",
+    "relatedConcepts": [
+      "closed-form substitution",
+      "surd encoding",
+      "Real.sqrt avoidance",
+      "equational hypotheses",
+      "field of fractions"
+    ],
+    "prerequisites": [
+      "Lean hypothesis binders",
+      "square roots",
+      "rational functions"
+    ]
+  },
+  {
+    "id": "ann-proof-tactics",
+    "proofId": "feuerbachs-theorem-oq-02-murakami",
+    "range": {
+      "startLine": 93,
+      "endLine": 100
+    },
+    "type": "tactic",
+    "title": "The Five-Goal Proof Script",
+    "content": "The proof is six tactic lines. `have hσ : a + b + c ≠ 0 := by positivity` discharges denominator non-vanishing from a,b,c>0. `subst hqx hqy hqz hR hρin hρex` eliminates the six abbreviating variables, replacing each by its closed form. `refine ⟨?_, ?_, ?_, ?_, ?_⟩` splits the five-way conjunction into independent goals. The three incidence goals then close by `field_simp; ring`; the two tangency goals by `field_simp; linear_combination 2 * ht`. The uniform shape across the five goals reflects the uniform algebraic structure of the underlying identities.",
+    "mathContext": "positivity proves a+b+c ≠ 0 because each of a,b,c is strictly positive. field_simp uses hσ to clear the 2σ (and 2σ²) denominators, lowering rational-function goals to polynomial goals; ring then certifies the incidence polynomials are identically zero. For tangency, linear_combination 2*ht certifies the cleared residual equals 2·(t² − (a²b²+b²c²+c²a²)), which vanishes by ht — so ring closes the residual modulo the surd relation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "positivity",
+      "field_simp",
+      "ring",
+      "linear_combination",
+      "subst",
+      "refine"
+    ],
+    "prerequisites": [
+      "Lean tactic mode",
+      "polynomial normalization",
+      "conjunction splitting"
+    ]
+  },
+  {
     "id": "ann-surd-cancellation",
     "proofId": "feuerbachs-theorem-oq-02-murakami",
     "range": {
@@ -61,7 +112,7 @@
     "title": "Why One Sphere Touches Both: Even-in-t Cancellation",
     "content": "The closing notes record the build status (Lean-checked GREEN 2026-06-15, 0 sorry / 0 axiom, registered in Proofs.lean; symbolic certificate verify_grace_proof_certificate.py 15/15 PASS) and explain the coefficient discipline: a BARE `linear_combination (1/(2σ²)) * ht` fails because ring treats (2σ)⁻¹² and (2σ²)⁻¹ as distinct opaque atoms, so denominators must be cleared by field_simp first, after which the ht-coefficient is the integer 2. The SAME Θ, R close both tangency goals because the odd-in-t part of each tangency residual is identically zero.",
     "mathContext": "Writing each tangency residual as Eeven(a,b,c) + t·Eodd(a,b,c), the surd cancellation is exactly Eodd ≡ 0; the involution t ↦ −t then swaps the insphere identity (ρin) with the D-exsphere identity (ρex), so proving one proves the other. This even/odd decomposition is the 3D analogue of the 2D Feuerbach circle touching both the incircle and an excircle.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "surd cancellation",
       "even-odd decomposition",


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-oq-02-murakami` (quality 83, pass 0).

## Changes (annotations.json only)
- **+2 annotations** (3 → 5, hitting the quality target):
  - `ann-hypotheses` (concept, lines 76–84): how the geometry is encoded as real-variable hypotheses — the tangency surd is captured algebraically via `t² = a²b²+b²c²+c²a²` plus `t ≥ 0` rather than `Real.sqrt`, keeping the whole statement inside the field/equational fragment where `field_simp`, `ring`, and `linear_combination` operate.
  - `ann-proof-tactics` (tactic, lines 93–100): the five-goal proof script — `positivity` → `subst` → `refine` → `field_simp; ring` (incidence) / `field_simp; linear_combination 2 * ht` (tangency).
- **Integrity fix:** two annotations used `significance: "central"`, which is **not** a valid `AnnotationSignificance` (the union in `src/types/proof.ts` is `critical | key | supporting`). Corrected to `"critical"` (the intended 'core to the proof' meaning).

## Verification
- `validateLineAnnotations` resolver: **5/5 valid, 0 misaligned**.
- JSON parses; gallery enrichment build step processed the entry without error.
- meta.json left unchanged — already comprehensive (rich historicalContext, 5 keyInsights, conclusion with implications + 3 open questions, full sections, cross-refs).
- axiomCount/status/badge unchanged and accurate (verified, 0 axioms, 0 sorries).