### PR TITLE
research(erdos-435-oq-01): gallery entry for the prime-power obstruction

### DIFF
--- a/src/data/proofs/erdos-435-oq-01/annotations.json
+++ b/src/data/proofs/erdos-435-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "erdos-435-oq-01",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "concept",
+    "title": "Why Erdős #435 Excludes Prime Powers",
+    "content": "Erdős Problem #435 asks for the largest integer not representable as a non-negative combination of the binomial coefficients $\\binom{n}{1}, \\ldots, \\binom{n}{n-1}$, and it is stated **only for $n$ that are not prime powers**. This file explains the exclusion. When $n = p^k$, every middle coefficient $\\binom{p^k}{j}$ ($1 \\le j < p^k$) is divisible by $p$, so all generators share the factor $p$: the numerical semigroup they generate lands inside $p\\mathbb{N}$, its complement is infinite, and no Frobenius number exists. The main `erdos-435` entry records this only as prose; here it becomes three machine-checked theorems.",
+    "mathContext": "The representable set $S_n = \\{\\sum c_i \\binom{n}{i} : c_i \\ge 0\\}$ has finite complement iff $\\gcd$ of its generators is $1$. For $n = p^k$ that gcd is divisible by $p$, so the complement is infinite.",
+    "significance": "key",
+    "prerequisites": [
+      "binomial coefficients",
+      "numerical semigroups",
+      "the Frobenius number"
+    ],
+    "relatedConcepts": [
+      "Erdős Problem #435",
+      "Hwang–Song formula",
+      "p-adic valuation",
+      "Kummer's theorem"
+    ]
+  },
+  {
+    "id": "ann-core-lemma",
+    "proofId": "erdos-435-oq-01",
+    "range": { "startLine": 28, "endLine": 56 },
+    "type": "theorem",
+    "title": "Core Lemma: p Divides Every Middle Coefficient",
+    "content": "`prime_pow_dvd_choose` proves $p \\mid \\binom{p^k}{j}$ for $1 \\le j < p^k$. The engine is Mathlib's Kummer-type identity `Nat.factorization_choose_prime_pow`, which gives\n$$v_p\\!\\binom{p^k}{j} = k - v_p(j).$$\nThe one fact needed is $v_p(j) < k$: if instead $v_p(j) \\ge k$ then $p^k \\mid j$ (via `pow_dvd_pow` and `Nat.ordProj_dvd`), forcing $p^k \\le j$ and contradicting $j < p^k$. Hence the valuation $k - v_p(j)$ is strictly positive, and `Nat.ordProj_dvd` with `dvd_pow_self` yields $p \\mid \\binom{p^k}{j}$.",
+    "mathContext": "Divisibility holds precisely on $0 < j < p^k$; at the endpoints $j = 0, p^k$ the coefficient is $1$ and $v_p = 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "Kummer's theorem / Legendre's formula",
+      "p-adic valuation Nat.factorization",
+      "Nat.ordProj_dvd"
+    ],
+    "relatedConcepts": [
+      "binomial coefficient valuation",
+      "Kummer's theorem"
+    ]
+  },
+  {
+    "id": "ann-all-generators",
+    "proofId": "erdos-435-oq-01",
+    "range": { "startLine": 58, "endLine": 65 },
+    "type": "theorem",
+    "title": "Every Generator Is Divisible by p",
+    "content": "`prime_dvd_all_generators` specializes the core lemma to the exact index range of the semigroup generators: for $1 \\le j \\le p^k - 1$, $p \\mid \\binom{p^k}{j}$. This is the per-generator statement that feeds the gcd computation; the only bookkeeping is converting the bound $j \\le p^k - 1$ into the strict $j < p^k$ required by `prime_pow_dvd_choose`, using $1 \\le p^k$.",
+    "mathContext": "The generators of $S_n$ for $n = p^k$ are $\\binom{p^k}{1}, \\ldots, \\binom{p^k}{p^k-1}$, and each is a multiple of $p$.",
+    "significance": "important",
+    "prerequisites": [
+      "the core obstruction lemma"
+    ],
+    "relatedConcepts": [
+      "numerical semigroup generators"
+    ]
+  },
+  {
+    "id": "ann-gcd-obstruction",
+    "proofId": "erdos-435-oq-01",
+    "range": { "startLine": 67, "endLine": 83 },
+    "type": "theorem",
+    "title": "Generators Share a Common Factor > 1",
+    "content": "`generators_gcd_ne_one` is the headline: the gcd of all generators over `Finset.Icc 1 (p^k - 1)` is $\\neq 1$. The proof assumes the gcd equals $1$ for contradiction; `Finset.dvd_gcd` shows $p$ divides the gcd (since $p$ divides every term, by the previous lemma), so $p \\mid 1$ — impossible for a prime. Therefore the gcd is divisible by $p$ and in particular $\\neq 1$. This is the precise obstruction: a common prime factor of all generators confines $S_n$ to multiples of $p$, leaving infinitely many residues unrepresentable, so the Frobenius number is undefined and $n = p^k$ must be excluded from Erdős #435.",
+    "mathContext": "$\\gcd\\{\\binom{p^k}{j} : 1 \\le j \\le p^k - 1\\}$ is a multiple of $p$, hence $> 1$; the semigroup complement is infinite.",
+    "significance": "key",
+    "prerequisites": [
+      "Finset.gcd and Finset.dvd_gcd",
+      "the per-generator divisibility lemma"
+    ],
+    "relatedConcepts": [
+      "Frobenius number",
+      "cofinite numerical semigroup",
+      "gcd of generators"
+    ]
+  },
+  {
+    "id": "ann-context",
+    "proofId": "erdos-435-oq-01",
+    "range": { "startLine": 67, "endLine": 83 },
+    "type": "insight",
+    "title": "From a gcd to the Non-Existence of a Frobenius Number",
+    "content": "The chain `prime_pow_dvd_choose → prime_dvd_all_generators → generators_gcd_ne_one` converts a p-adic valuation fact into a structural statement about the numerical semigroup $S_{p^k}$. Because the generators have gcd $> 1$, $S_{p^k} \\subseteq p\\mathbb{N}$: no number coprime to $p$ is ever representable, so the complement $\\mathbb{N} \\setminus S_{p^k}$ is infinite and the 'largest non-representable integer' simply does not exist. This is the formal counterpart to the Hwang–Song dichotomy: the closed-form Frobenius number (formalized in `erdos-435`) is available exactly for non-prime-powers, and this companion certifies the other branch.",
+    "mathContext": "Finite complement $\\iff$ gcd of generators $= 1$. The obstruction realizes the $\\ne 1$ side for prime powers.",
+    "significance": "important",
+    "prerequisites": [
+      "numerical semigroup theory"
+    ],
+    "relatedConcepts": [
+      "Hwang–Song formula",
+      "Frobenius problem dichotomy"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-435-oq-01/meta.json
+++ b/src/data/proofs/erdos-435-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "erdos-435-oq-01",
+  "title": "Erdős Problem #435 (OQ-01): The Prime-Power Obstruction",
+  "slug": "erdos-435-oq-01",
+  "description": "A machine-checked proof of the number-theoretic obstruction that forces Erdős Problem #435 to exclude prime powers: for n = p^k, every middle binomial coefficient C(n,j) (1 ≤ j < n) is divisible by p, so the generators {C(n,1), …, C(n,n-1)} have gcd ≠ 1, the numerical semigroup they generate is not cofinite, and no Frobenius number exists.",
+  "meta": {
+    "author": "lean-genius contributors (companion to Hwang–Song 2024 formalization)",
+    "sourceUrl": "https://erdosproblems.com/435",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos435PrimePowerObstruction.lean",
+    "badge": "original",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "frobenius-number",
+      "numerical-semigroups",
+      "p-adic-valuation",
+      "kummer-theorem",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 83,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "erdosNumber": 435,
+    "erdosUrl": "https://erdosproblems.com/435",
+    "dateAdded": "2026-06-17",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_choose_prime_pow",
+        "description": "Kummer-type identity: v_p(C(p^k, j)) = k - v_p(j) for 0 < j ≤ p^k",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.ordProj_dvd",
+        "description": "p^(v_p(m)) ∣ m: the p-part of m divides m",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Finset.dvd_gcd",
+        "description": "A common divisor of every term divides the Finset gcd",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      }
+    ],
+    "assumptions": "None. Fully machine-checked with 0 axioms, 0 sorries, and no native_decide; the entire import closure is Mathlib-only. The result is unconditional: for any prime p and exponent k ≥ 1 it proves p ∣ C(p^k, j) for all 1 ≤ j < p^k and the gcd consequence.",
+    "originalContributions": [
+      "Upgrades the prime-power exclusion of Erdős #435 — previously recorded only as prose in the 'Why Prime Powers are Special' section of the main file — to three machine-checked theorems.",
+      "prime_pow_dvd_choose: from Kummer's identity v_p(C(p^k,j)) = k - v_p(j), establishes p ∣ C(p^k, j) for 1 ≤ j < p^k by showing v_p(j) < k (else p^k ∣ j contradicts j < p^k).",
+      "prime_dvd_all_generators: the per-generator statement that p divides every C(p^k, j) with 1 ≤ j ≤ p^k − 1.",
+      "generators_gcd_ne_one: the gcd over Finset.Icc 1 (p^k − 1) of the generators is divisible by p, hence ≠ 1 — exactly the obstruction that makes the semigroup complement infinite and the Frobenius number undefined.",
+      "Not a named Mathlib result: the obstruction lemma chain and its packaging as a gcd statement are supplied by the formalization."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #435 asks for the largest integer not representable as a non-negative integer combination of the binomial coefficients C(n,1), …, C(n,n-1). The problem is stated only for n that are NOT prime powers, and this restriction is not cosmetic: when n = p^k the representation problem degenerates. The Hwang–Song (2024) solution and its lean-genius formalization (entry erdos-435) record the prime-power degeneracy informally, in a docstring observing that 'for n = p^k, Lucas' theorem gives p ∣ C(n,i) for all 0 < i < n, making the complement infinite.' This companion entry turns that observation into a theorem, closing the prose gap with a short, fully verified Mathlib argument based on the p-adic valuation of binomial coefficients.",
+    "problemStatement": "**Prime-power obstruction.** Let $p$ be prime and $k \\geq 1$. Then for every $j$ with $1 \\leq j < p^k$ one has $p \\mid \\binom{p^k}{j}$. Consequently\n$$\\gcd\\left\\{ \\binom{p^k}{1}, \\binom{p^k}{2}, \\ldots, \\binom{p^k}{p^k-1} \\right\\} \\neq 1.$$\nA numerical semigroup whose generators share a common factor $> 1$ has infinite complement, so no Frobenius number exists — which is precisely why Erdős #435 excludes prime powers.",
+    "text": "A Lean 4 / Mathlib formalization (83 lines, 0 sorries, 0 axioms, Mathlib-only import closure) of the prime-power obstruction behind Erdős Problem #435. The core lemma prime_pow_dvd_choose applies Mathlib's Kummer identity Nat.factorization_choose_prime_pow, which gives v_p(C(p^k, j)) = k − v_p(j); since 0 < j < p^k forces v_p(j) < k, the valuation k − v_p(j) is positive, so p divides the coefficient (via Nat.ordProj_dvd). prime_dvd_all_generators specializes this to the generator index range, and generators_gcd_ne_one lifts it through Finset.dvd_gcd to conclude the gcd of all generators is divisible by p, hence ≠ 1.",
+    "proofStrategy": "1. **Kummer valuation.** For 1 ≤ j < p^k, `Nat.factorization_choose_prime_pow` gives v_p(C(p^k, j)) = k − v_p(j).\n\n2. **Bound the valuation of j.** v_p(j) < k: otherwise p^k ∣ j (from `pow_dvd_pow` and `Nat.ordProj_dvd`), forcing p^k ≤ j and contradicting j < p^k.\n\n3. **Positive valuation ⟹ divisibility.** Hence v_p(C(p^k, j)) = k − v_p(j) > 0, and `Nat.ordProj_dvd` plus `dvd_pow_self` give p ∣ p^(v_p(C(p^k,j))) ∣ C(p^k, j).\n\n4. **Common factor of the generators.** prime_dvd_all_generators restates step 3 for 1 ≤ j ≤ p^k − 1.\n\n5. **gcd obstruction.** `Finset.dvd_gcd` shows p divides the gcd over Finset.Icc 1 (p^k − 1); if that gcd were 1 then p ∣ 1, impossible for a prime. Hence the gcd is ≠ 1.",
+    "keyInsights": [
+      "**Kummer over Lucas.** The informal note appeals to Lucas' theorem; the formalization instead uses the cleaner p-adic valuation identity v_p(C(p^k,j)) = k − v_p(j), which Mathlib provides directly as `Nat.factorization_choose_prime_pow`. The whole obstruction is then a one-line valuation positivity argument.",
+      "**Why j < p^k is the crux.** Divisibility fails exactly at the endpoints j = 0 and j = p^k, where C(p^k, j) = 1. The hypothesis 0 < j < p^k is what makes v_p(j) < k and hence the binomial valuation strictly positive.",
+      "**From divisibility to non-existence of a Frobenius number.** A common prime factor of all generators confines the semigroup to multiples of p, so infinitely many residues are unrepresentable. The gcd ≠ 1 statement is the formal heart of 'the largest non-representable integer does not exist for prime powers'.",
+      "**Closing a prose gap.** The main erdos-435 entry formalizes the Hwang–Song formula but leaves the prime-power exclusion as docstring commentary. This companion supplies the missing machine-checked justification, with no new axioms."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Kummer's / Lucas' theorem",
+      "p-adic valuation (Nat.factorization, ordProj)",
+      "Numerical semigroups and the Frobenius number"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "prime_pow_dvd_choose",
+      "type": "core",
+      "description": "For a prime p, exponent k ≥ 1, and 1 ≤ j < p^k, the prime p divides C(p^k, j). Proved from the Kummer valuation identity v_p(C(p^k,j)) = k − v_p(j) together with v_p(j) < k.",
+      "leanType": "(hp : p.Prime) (hk : 1 ≤ k) (hj : 1 ≤ j) (hjn : j < p ^ k) : p ∣ (p ^ k).choose j"
+    },
+    {
+      "name": "prime_dvd_all_generators",
+      "type": "supporting",
+      "description": "For a prime power n = p^k (k ≥ 1), the prime p divides every generator C(p^k, j) with 1 ≤ j ≤ p^k − 1.",
+      "leanType": "(hp : p.Prime) (hk : 1 ≤ k) (j : ℕ) (hj : 1 ≤ j) (hjn : j ≤ p ^ k - 1) : p ∣ (p ^ k).choose j"
+    },
+    {
+      "name": "generators_gcd_ne_one",
+      "type": "headline",
+      "description": "For a prime power n = p^k (k ≥ 1), the gcd of the generators {C(n,1), …, C(n,n-1)} is divisible by p, hence ≠ 1 — the obstruction that makes the numerical semigroup's complement infinite and the Frobenius number undefined.",
+      "leanType": "(hp : p.Prime) (hk : 1 ≤ k) : (Finset.Icc 1 (p ^ k - 1)).gcd (fun j => (p ^ k).choose j) ≠ 1"
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Module docstring stating the prime-power obstruction behind Erdős #435 (for n = p^k every middle C(n,j) is divisible by p, so the generators' gcd ≠ 1 and no Frobenius number exists), and imports of Mathlib's binomial-coefficient factorization API.",
+      "mathContext": "Sets up the obstruction: prime powers are excluded from Erdős #435 because the generator gcd exceeds 1, making the semigroup complement infinite."
+    },
+    {
+      "id": "core-lemma",
+      "title": "Prime-Power Obstruction (Core Lemma)",
+      "startLine": 28,
+      "endLine": 56,
+      "summary": "`prime_pow_dvd_choose`: for prime p, k ≥ 1, and 1 ≤ j < p^k, p ∣ C(p^k, j). Uses `Nat.factorization_choose_prime_pow` (v_p = k − v_p(j)), bounds v_p(j) < k via `Nat.ordProj_dvd`, and concludes from positive valuation.",
+      "mathContext": "$v_p\\binom{p^k}{j} = k - v_p(j) > 0$ for $0 < j < p^k$, so $p \\mid \\binom{p^k}{j}$."
+    },
+    {
+      "id": "all-generators",
+      "title": "Common Prime Factor of All Generators",
+      "startLine": 58,
+      "endLine": 65,
+      "summary": "`prime_dvd_all_generators`: specializes the core lemma to the generator index range 1 ≤ j ≤ p^k − 1, the per-generator statement underlying the gcd obstruction.",
+      "mathContext": "Every generator $\\binom{p^k}{j}$, $1 \\le j \\le p^k-1$, is divisible by $p$."
+    },
+    {
+      "id": "gcd-obstruction",
+      "title": "Generators Share a Common Factor > 1",
+      "startLine": 67,
+      "endLine": 83,
+      "summary": "`generators_gcd_ne_one`: via `Finset.dvd_gcd`, p divides the gcd of the generators over Finset.Icc 1 (p^k − 1); were the gcd 1 then p ∣ 1, impossible. Hence the gcd ≠ 1 — the obstruction excluding prime powers from Erdős #435.",
+      "mathContext": "$\\gcd\\{\\binom{p^k}{j} : 1 \\le j \\le p^k-1\\}$ is divisible by $p$, so $\\neq 1$; the semigroup complement is infinite and no Frobenius number exists."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-435",
+      "relationship": "extends",
+      "description": "Formalizes the 'Why Prime Powers are Special' section of the main Erdős #435 entry, which records the prime-power obstruction only as docstring prose. This companion upgrades it to three machine-checked theorems."
+    }
+  ],
+  "conclusion": {
+    "summary": "The prime-power obstruction behind Erdős Problem #435 is formalized in 83 lines with 0 sorries and 0 axioms. For any prime p and k ≥ 1, every middle binomial coefficient C(p^k, j) (1 ≤ j < p^k) is divisible by p, so the generators of the associated numerical semigroup share the common factor p; their gcd is ≠ 1, the complement of the semigroup is infinite, and no Frobenius number exists. This is exactly the reason Erdős #435 restricts to non-prime-powers.",
+    "implications": "Together with the main erdos-435 entry — which formalizes the Hwang–Song closed-form Frobenius number for non-prime-powers — this companion completes the dichotomy: prime powers are excluded for a precise, now machine-checked, p-adic reason, while all other n admit the Hwang–Song formula.",
+    "openQuestions": [
+      "Can the converse refinement be formalized: for n NOT a prime power, gcd{C(n,1), …, C(n,n-1)} = 1, so the semigroup complement is finite and a Frobenius number exists?",
+      "Does the obstruction generalize to q-binomial (Gaussian) coefficients, where the role of the prime p is played by a cyclotomic factor?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Factorization",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "Erdos435.PrimePowerObstruction",
+    "lineCount": 83,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos435PrimePowerObstruction.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the gallery entry for the previously **ungalleried, build-verified** module `Proofs/Erdos435PrimePowerObstruction.lean` (merged in #24725, registered `Proofs.lean:1495`). JSON-only: `meta.json` + 5 annotations. No Lean changes.

The module formalizes the obstruction that forces **Erdős Problem #435** to exclude prime powers — previously recorded only as docstring prose in the main `erdos-435` entry's *'Why Prime Powers are Special'* section.

## Mathematical content

For $n = p^k$, every middle binomial coefficient $\binom{n}{j}$ ($1 \le j < n$) is divisible by $p$, via Mathlib's Kummer identity $v_p\binom{p^k}{j} = k - v_p(j) > 0$. Three theorems:

- `prime_pow_dvd_choose` — $p \mid \binom{p^k}{j}$ for $1 \le j < p^k$ (core lemma)
- `prime_dvd_all_generators` — every generator $\binom{p^k}{j}$, $1 \le j \le p^k-1$, is divisible by $p$
- `generators_gcd_ne_one` — $\gcd$ of the generators $\neq 1$, so the numerical semigroup's complement is infinite and **no Frobenius number exists**

## Verification

- 83 lines, **0 sorries, 0 axioms, no native_decide**; entire import closure is Mathlib-only ⇒ status `verified`, badge `original`.
- Build-verified: registered in `Proofs.lean` and merged via #24725.
- Resolver: **5/5 annotations aligned**, 0 misaligned.
- `meta.json` and `annotations.json` JSON-validated; crossRef target `erdos-435` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)