### PR TITLE
research(repunit-oq-01): register + gallery R_m∣R_n ⟺ m∣n (build-green)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2807,6 +2807,7 @@ import Proofs.RandomizedMaxcutOQ02
 import Proofs.RandomizedMaxcutOQ04
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
+import Proofs.RepunitDivisibilityOQ01
 import Proofs.RiemannHypothesis
 import Proofs.RiemannHypothesisConsequences
 import Proofs.RothTheorem

--- a/proofs/Proofs/RepunitDivisibilityOQ01.lean
+++ b/proofs/Proofs/RepunitDivisibilityOQ01.lean
@@ -29,25 +29,6 @@ The bridge from repunits to powers is the additive identity
 common factor `b − 1` (`Nat.mul_dvd_mul_iff_left`).
 
 No axioms, no sorries.
-
-NOTE (2026-06-16): build-pending. The proof is self-contained and elementary, but
-could not be machine-checked this session: the Docker build host is saturated (7
-concurrent `lake build` containers, load avg ~30), so launching another 32 GB build
-would endanger the host and the in-flight builds. Pending verification, the result
-has been certified independently:
-
-* the divisibility criterion `R_b(m) ∣ R_b(n) ↔ m ∣ n` and the bridge identity
-  `(b−1)·R_b(n)+1 = b^n` were checked numerically for all bases `2 ≤ b ≤ 12` and
-  all `m, n ≤ 24` (`research/scripts/verify_repunit_oq01.py`);
-* every Mathlib lemma invoked was confirmed against the offline Mathlib v4.26.0 pin
-  (`Nat.sub_dvd_pow_sub_pow`, `Nat.modEq_iff_dvd'`, `Nat.ModEq.{pow,mul_right}`,
-  `Nat.le_self_pow`, `Nat.one_le_pow`, `Nat.pow_le_pow_right`,
-  `Nat.mul_dvd_mul_iff_left`).
-
-This file is intentionally left UNREGISTERED in `Proofs.lean` until a successful
-build confirms it, so it cannot affect the gallery build. Next session with a free
-Docker host: `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01`,
-then register the import and add the gallery entry.
 -/
 
 namespace RepunitDivisibilityOQ01

--- a/research/problems/repunit-oq-01/state.md
+++ b/research/problems/repunit-oq-01/state.md
@@ -1,51 +1,45 @@
 # Current State
 
-**Phase**: BLOCKED (build-pending)
-**Since**: 2026-06-16T20:00:00Z
-**Iteration**: 2
+**Phase**: COMPLETED
+**Since**: 2026-06-17T21:10:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Verify-and-ship the completed proof `R_b(m) ∣ R_b(n) ↔ m ∣ n`
-(`proofs/Proofs/RepunitDivisibilityOQ01.lean`). Mathematics is finished; the
-sole remaining step is a clean Docker `lake build` + gallery registration.
+Done. The proof `R_b(m) ∣ R_b(n) ↔ m ∣ n`
+(`proofs/Proofs/RepunitDivisibilityOQ01.lean`) is machine-checked green and shipped
+to the gallery as `repunit-oq-01`.
 
 ## Active Approach
 
-Done (no sorries, no axioms):
+Complete (no sorries, no axioms):
 - `repunit b n := ∑_{i<n} b^i`; bridge `(b-1)·R_b(n)+1 = b^n`
   (`pred_mul_repunit_add_one`, induction) and `(b-1)·R_b(n) = b^n-1`.
 - Engine `pow_sub_one_dvd_iff_dvd`: `(b^m-1) ∣ (b^n-1) ↔ m ∣ n` via
   division algorithm + `Nat.ModEq`.
 - Headlines `repunit_dvd_iff` (base b≥2) and `repunit_ten_dvd_iff`.
 
-Offline certification (Docker unavailable):
-- Numerical check passes: `research/scripts/verify_repunit_oq01.py`
-  (2≤b≤12, m,n≤24) — re-run 2026-06-16, OK.
-- All Mathlib lemmas confirmed against the v4.26.0 offline pin. In particular
-  the deprecated alias `nat_sub_dvd_pow_sub_pow` was replaced by
-  `Nat.sub_dvd_pow_sub_pow` (Mathlib/Algebra/Ring/GeomSum.lean:334, namespace
-  `Nat`, signature `(x y n : ℕ) : x - y ∣ x ^ n - y ^ n`).
+## Resolution (2026-06-17)
+
+Docker single-module build is GREEN:
+`✔ [7743/7743] Built Proofs.RepunitDivisibilityOQ01 (13s)` /
+`Build completed successfully (7743 jobs)` against the v4.26.0 toolchain (an early
+transient git-clone retry recovered automatically). Shipped:
+1. Registered `import Proofs.RepunitDivisibilityOQ01` in `proofs/Proofs.lean`.
+2. Removed the build-pending NOTE block from the `.lean` header.
+3. Added gallery entry `src/data/proofs/repunit-oq-01/` (meta.json status
+   `verified`, badge `original`, 0 axioms, 0 sorries) + 8 annotations
+   (resolver: 8 valid / 0 misaligned).
 
 ## Blockers
 
-Docker build host saturated: load avg ~36, 17 concurrent `lake build`
-processes, `docker info` hangs (daemon unresponsive under load). Launching
-another 32 GB build would endanger the host and in-flight builds. This is an
-environment-wide infra blocker, not a proof issue.
+None.
 
 ## Next Action
 
-When a Docker host is free:
-1. `./proofs/scripts/docker-build.sh Proofs.RepunitDivisibilityOQ01`
-   (grep the log for `error:` — the wrapper exits 0 even on failure).
-2. On green: add `import Proofs.RepunitDivisibilityOQ01` to `proofs/Proofs.lean`,
-   then create the gallery entry under `src/data/proofs/repunit-oq-01/`
-   (meta.json status `verified`, 0 axioms, 0 sorries) and `pnpm build`.
-3. Remove the build-pending NOTE block from the `.lean` file header.
+None — terminal.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (build) — blocked on Docker
-- Approaches tried: 1
+- Total attempts: 3
+- Approaches tried: 1 (single approach, succeeded on build)

--- a/src/data/proofs/repunit-oq-01/annotations.json
+++ b/src/data/proofs/repunit-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "concept",
+    "title": "Repunits and the Divisibility Criterion",
+    "content": "A base-$b$ repunit of length $n$ is $R_b(n) = 1 + b + b^2 + \\cdots + b^{n-1} = (b^n - 1)/(b - 1)$, the number written as $n$ ones in base $b$ (so $R_{10}(3) = 111$). The file proves the classical criterion $R_b(m) \\mid R_b(n) \\iff m \\mid n$ for every base $b \\ge 2$. The docstring records the two-step plan: a power-difference engine $(b^m - 1) \\mid (b^n - 1) \\iff m \\mid n$, bridged to repunits by $(b-1)R_b(n) = b^n - 1$.",
+    "mathContext": "$R_b(n) = \\sum_{i=0}^{n-1} b^i,\\qquad R_b(m) \\mid R_b(n) \\iff m \\mid n.$",
+    "significance": "key",
+    "relatedConcepts": ["repunit", "geometric series", "divisibility", "OEIS A002275"],
+    "prerequisites": ["finite geometric sums", "elementary divisibility"]
+  },
+  {
+    "id": "ann-defn",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 37, "endLine": 43 },
+    "type": "definition",
+    "title": "Repunit as a Sum of Powers",
+    "content": "`repunit b n` is defined directly as the finite geometric sum $\\sum_{i<n} b^i$ over `Finset.range n`, keeping every value a genuine natural number. `repunit_zero` gives the empty sum $R_b(0) = 0$, and `repunit_succ` exposes the one-step recurrence $R_b(n+1) = R_b(n) + b^n$ as a rewrite lemma (via `Finset.sum_range_succ`), which drives the inductive bridge to powers.",
+    "mathContext": "$R_b(0) = 0,\\qquad R_b(n+1) = R_b(n) + b^n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum", "geometric series", "structural recursion"],
+    "prerequisites": ["finite sums in Lean"]
+  },
+  {
+    "id": "ann-bridge-add",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 46, "endLine": 57 },
+    "type": "theorem",
+    "title": "Subtraction-Free Power Bridge",
+    "content": "The key bridge $(b-1)\\,R_b(n) + 1 = b^n$, stated additively to sidestep $\\mathbb{N}$'s truncated subtraction. The proof substitutes $b = c + 1$ (so $b - 1$ becomes the honest natural number $c$) and inducts: the successor step rearranges $c\\,R_b(n) + c\\,b^n + 1 = (c\\,R_b(n) + 1) + c\\,b^n$, applies the induction hypothesis, and finishes with `ring` — valid precisely because no subtraction remains.",
+    "mathContext": "$(b-1)\\,R_b(n) + 1 = b^n,\\qquad\\text{equivalently } c\\,R_{c+1}(n) + 1 = (c+1)^n.$",
+    "significance": "critical",
+    "relatedConcepts": ["truncated subtraction", "induction", "ring normalization"],
+    "prerequisites": ["natural number subtraction semantics", "mathematical induction"]
+  },
+  {
+    "id": "ann-bridge-mul",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 59, "endLine": 63 },
+    "type": "theorem",
+    "title": "Multiplicative Form of the Bridge",
+    "content": "Restates the additive bridge as $(b-1)\\,R_b(n) = b^n - 1$, the form actually used to transport divisibility. The conversion is a single `omega` step from the additive identity, treating $(b-1)R_b(n)$ and $b^n$ as opaque terms — legitimate because $b^n = (b-1)R_b(n) + 1 \\ge 1$, so the subtraction does not underflow.",
+    "mathContext": "$(b-1)\\,R_b(n) = b^n - 1.$",
+    "significance": "key",
+    "relatedConcepts": ["omega", "ℕ subtraction"],
+    "prerequisites": ["linear arithmetic over ℕ"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 65, "endLine": 120 },
+    "type": "theorem",
+    "title": "Power-Difference Divisibility via the Division Algorithm",
+    "content": "The engine: for $b \\ge 2$, $(b^m - 1) \\mid (b^n - 1) \\iff m \\mid n$. Forward direction — write $n = mq + r$ with $r < m$; modulo $b^m - 1$ one has $b^m \\equiv 1$ (`Nat.modEq_iff_dvd'` applied to `dvd_refl`), so $b^n = (b^m)^q b^r \\equiv b^r$. The hypothesis gives $b^n \\equiv 1$, hence $b^r \\equiv 1$, i.e. $(b^m - 1) \\mid (b^r - 1)$. Since $0 \\le b^r - 1 < b^m - 1$ (as $r < m$, $b \\ge 2$), a positive divisor would be too large, so $b^r - 1 = 0$, forcing $r = 0$ and $m \\mid n$. Converse — for $n = mk$, $(b^m - 1) \\mid (b^m)^k - 1^k = b^{mk} - 1$ by `nat_sub_dvd_pow_sub_pow`.",
+    "mathContext": "$b^n = (b^m)^q\\,b^r \\equiv 1^q\\,b^r = b^r \\pmod{b^m - 1},\\qquad b^r - 1 < b^m - 1.$",
+    "significance": "critical",
+    "relatedConcepts": ["division algorithm", "Nat.ModEq", "multiplicative order", "Mersenne numbers"],
+    "prerequisites": ["modular arithmetic", "the division algorithm"]
+  },
+  {
+    "id": "ann-order",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 96, "endLine": 110 },
+    "type": "insight",
+    "title": "Why the Remainder Must Vanish",
+    "content": "The crux of the forward direction is that $b$ has multiplicative order exactly $m$ modulo $b^m - 1$. Concretely, $(b^m - 1) \\mid (b^r - 1)$ together with the strict bound $b^r - 1 < b^m - 1$ (proved here by writing $b^m = b^r \\cdot b^{m-r}$ with $b^{m-r} \\ge 2$) leaves only $b^r - 1 = 0$. This is the same mechanism that yields $\\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1$.",
+    "mathContext": "$b^r - 1 = 0 \\implies b^r = 1 \\implies r = 0 \\implies m \\mid n.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "gcd of power differences", "strict monotonicity of b^·"],
+    "prerequisites": ["order of an element", "monotone powers"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 122, "endLine": 127 },
+    "type": "theorem",
+    "title": "Repunit Divisibility by Cancelling b − 1",
+    "content": "The main theorem $R_b(m) \\mid R_b(n) \\iff m \\mid n$. Rewriting both repunits through the bridge $(b-1)R_b(\\cdot) = b^{\\cdot} - 1$ turns the goal into $(b-1)R_b(m) \\mid (b-1)R_b(n) \\iff (b^m-1) \\mid (b^n-1)$; cancelling the positive common factor $b - 1$ with `Nat.mul_dvd_mul_iff_left` reduces it to the power-difference engine. The whole criterion thus rests on one cancellation plus the engine.",
+    "mathContext": "$R_b(m) \\mid R_b(n) \\iff (b-1)R_b(m) \\mid (b-1)R_b(n) \\iff (b^m - 1) \\mid (b^n - 1) \\iff m \\mid n.$",
+    "significance": "critical",
+    "relatedConcepts": ["cancellation of common factors", "Nat.mul_dvd_mul_iff_left"],
+    "prerequisites": ["divisibility and cancellation in ℕ"]
+  },
+  {
+    "id": "ann-ten",
+    "proofId": "repunit-oq-01",
+    "range": { "startLine": 129, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Base-Ten Repunits",
+    "content": "Instantiating $b = 10$ recovers the everyday repunits $1, 11, 111, 1111, \\dots$: $R_{10}(m) \\mid R_{10}(n) \\iff m \\mid n$. A corollary worth noting is that $R_{10}(n)$ can be prime only when $n$ is prime, since any proper divisor of $n$ gives a proper repunit divisor.",
+    "mathContext": "$R_{10}(m) \\mid R_{10}(n) \\iff m \\mid n;\\quad R_{10}(n)\\text{ prime} \\implies n\\text{ prime}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["base-ten repunits", "repunit primes", "necessary primality condition"],
+    "prerequisites": ["specialization of a general theorem"]
+  }
+]

--- a/src/data/proofs/repunit-oq-01/meta.json
+++ b/src/data/proofs/repunit-oq-01/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "repunit-oq-01",
+  "slug": "repunit-oq-01",
+  "title": "Repunit Divisibility: R_m ∣ R_n if and only if m ∣ n",
+  "description": "A base-b repunit R_b(n) = 1 + b + b² + ⋯ + b^{n-1} is the number written as n ones in base b (R₁₀(3) = 111). This entry proves, fully machine-checked with 0 sorries and 0 axioms, the classical divisibility criterion R_b(m) ∣ R_b(n) ⟺ m ∣ n for every base b ≥ 2, with the base-ten case as a corollary. The result is a genuine theorem over all pairs (m, n), not an enumeration: the engine is the power-difference fact (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n (proved via the division algorithm and modular arithmetic), bridged to repunits by the identity (b − 1)·R_b(n) = b^n − 1.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "RepunitDivisibilityOQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 1,
+    "definitionCount": 1,
+    "path": "Proofs/RepunitDivisibilityOQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Classical (repunits popularized by A. H. Beiler, 1966)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Repunit",
+    "date": "1966",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RepunitDivisibilityOQ01.lean",
+    "tags": [
+      "number-theory",
+      "repunit",
+      "divisibility",
+      "modular-arithmetic",
+      "geometric-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Repunits are defined directly as ∑_{i<n} b^i in ℕ; all results are proved from elementary divisibility with no axioms and no structure-encoded hypotheses.",
+    "dateAdded": "2026-06-16",
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Repunit divisibility criterion repunit_dvd_iff: for base b ≥ 2, R_b(m) ∣ R_b(n) ⟺ m ∣ n",
+      "Power-difference engine pow_sub_one_dvd_iff_dvd: (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n, proved via the division algorithm and Nat.ModEq",
+      "Subtraction-free repunit↔power bridge pred_mul_repunit_add_one / pred_mul_repunit: (b − 1)·R_b(n) + 1 = b^n, hence (b − 1)·R_b(n) = b^n − 1",
+      "Base-ten corollary repunit_ten_dvd_iff: R₁₀(m) ∣ R₁₀(n) ⟺ m ∣ n"
+    ],
+    "prerequisites": [
+      "Geometric series / finite sums of powers",
+      "The division algorithm and modular arithmetic (Nat.ModEq)",
+      "Elementary divisibility in ℕ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 133,
+    "relatedProblems": [],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Repunits — integers consisting entirely of the digit 1 — were named by Albert H. Beiler in 1966, though their arithmetic was studied much earlier. The base-ten repunits $R_n = (10^n - 1)/9$ are $1, 11, 111, 1111, \\dots$ (OEIS A002275); the question of which are prime ($R_2 = 11$, $R_{19}$, $R_{23}$, $\\dots$) remains open and is a famous source of large probable primes. The divisibility law proved here, $R_m \\mid R_n \\iff m \\mid n$, is the structural fact underlying repunit factorization tables and the elementary observation that a repunit can only be prime when its length is prime. It is the base-$b$ generalization of the classical statement about $b^n - 1$, itself central to the theory of cyclotomic factorizations and Mersenne numbers ($b = 2$).",
+    "problemStatement": "Fix an integer base $b \\ge 2$ and define the repunit of length $n$ by $R_b(n) = \\sum_{i=0}^{n-1} b^i = 1 + b + \\cdots + b^{n-1}$ (so $R_{10}(3) = 111$). Prove that for all natural numbers $m, n$, $R_b(m) \\mid R_b(n)$ if and only if $m \\mid n$.",
+    "proofStrategy": "Reduce repunit divisibility to power divisibility. The identity $(b-1)\\,R_b(n) = b^n - 1$ (proved in the subtraction-free additive form $(b-1)R_b(n) + 1 = b^n$ to avoid $\\mathbb{N}$ underflow, by induction after substituting $b = c+1$) lets us cancel the common positive factor $b-1$: $R_b(m) \\mid R_b(n) \\iff (b^m-1) \\mid (b^n-1)$. The core lemma $(b^m-1)\\mid(b^n-1) \\iff m \\mid n$ is then proved by the division algorithm. Writing $n = mq + r$ with $r < m$, modular arithmetic modulo $b^m - 1$ gives $b^m \\equiv 1$, hence $b^n = (b^m)^q b^r \\equiv b^r$; if $(b^m-1)\\mid(b^n-1)$ then $b^r \\equiv 1$, i.e. $(b^m-1)\\mid(b^r-1)$. Since $0 \\le b^r - 1 < b^m - 1$, this forces $b^r - 1 = 0$, so $r = 0$ and $m \\mid n$. The converse is the geometric factorization $(b^m - 1) \\mid (b^m)^k - 1 = b^{mk} - 1$.",
+    "keyInsights": [
+      "Repunit divisibility is exactly power-difference divisibility in disguise: clearing the universal factor $b - 1$ turns $R_b(m) \\mid R_b(n)$ into $(b^m - 1) \\mid (b^n - 1)$, so the whole problem reduces to the order of $b$ modulo $b^m - 1$.",
+      "Modulo $b^m - 1$ the base $b$ has multiplicative order exactly $m$: $b^m \\equiv 1$, and no smaller exponent works because $b^r - 1 < b^m - 1$ for $r < m$. This single observation gives both directions of the criterion.",
+      "The result is a theorem about all infinitely many pairs $(m, n)$, proved by the division algorithm — not a finite check. The 'remainder must vanish' step is the same argument that computes $\\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1$.",
+      "Working in $\\mathbb{N}$ forces care with truncated subtraction; stating the power bridge additively as $(b-1)R_b(n) + 1 = b^n$ and substituting $b = c + 1$ makes the inductive step a pure `ring` identity with no underflow side conditions.",
+      "An immediate corollary: $R_b(n)$ can be prime only when $n$ is prime, since any proper divisor $1 < m < n$ of $n$ yields a proper repunit divisor $R_b(m)$ of $R_b(n)$."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "repunit_dvd_iff",
+      "statement": "2 ≤ b → (repunit b m ∣ repunit b n ↔ m ∣ n)",
+      "description": "The main result: for any base b ≥ 2, the length-m repunit divides the length-n repunit if and only if m divides n."
+    },
+    {
+      "name": "pow_sub_one_dvd_iff_dvd",
+      "statement": "2 ≤ b → ((b^m − 1) ∣ (b^n − 1) ↔ m ∣ n)",
+      "description": "The power-difference engine, proved via the division algorithm and modular arithmetic. Specializes to Mersenne numbers at b = 2."
+    },
+    {
+      "name": "pred_mul_repunit",
+      "statement": "1 ≤ b → (b − 1) * repunit b n = b^n − 1",
+      "description": "The bridge identity relating repunits to powers, derived from the subtraction-free additive form (b − 1)·R_b(n) + 1 = b^n."
+    },
+    {
+      "name": "repunit_ten_dvd_iff",
+      "statement": "repunit 10 m ∣ repunit 10 n ↔ m ∣ n",
+      "description": "Base-ten corollary: the ordinary repunits 1, 11, 111, … obey R_m ∣ R_n ⟺ m ∣ n."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Repunits and the Power Bridge",
+      "startLine": 37,
+      "endLine": 63,
+      "summary": "Defines repunit b n = ∑_{i<n} b^i, gives the base case and successor rewrite (repunit_succ), and proves the bridge to powers: the subtraction-free additive identity (b−1)·R_b(n) + 1 = b^n (pred_mul_repunit_add_one, by induction after substituting b = c+1) and its multiplicative form (b−1)·R_b(n) = b^n − 1 (pred_mul_repunit)."
+    },
+    {
+      "id": "power-engine",
+      "title": "Power-Difference Divisibility Criterion",
+      "startLine": 65,
+      "endLine": 120,
+      "summary": "Proves pow_sub_one_dvd_iff_dvd: for b ≥ 2, (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n. The forward direction uses the division algorithm n = mq + r and Nat.ModEq (b^m ≡ 1, so b^n ≡ b^r), reducing to (b^m−1) ∣ (b^r−1) with b^r − 1 < b^m − 1, forcing r = 0. The converse is the geometric factorization via nat_sub_dvd_pow_sub_pow."
+    },
+    {
+      "id": "main",
+      "title": "Repunit Divisibility and the Base-Ten Case",
+      "startLine": 122,
+      "endLine": 132,
+      "summary": "Concludes repunit_dvd_iff by cancelling the common factor b − 1 (Nat.mul_dvd_mul_iff_left) to transport the power-difference criterion to repunits, and instantiates the base-ten corollary repunit_ten_dvd_iff."
+    }
+  ],
+  "references": [
+    {
+      "title": "Repunit",
+      "url": "https://en.wikipedia.org/wiki/Repunit"
+    },
+    {
+      "title": "OEIS A002275 — Repunits (10^n − 1)/9",
+      "url": "https://oeis.org/A002275"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sylvester-sequence-oq-01",
+      "relationship": "Elementary divisibility via a product/difference identity",
+      "description": "Both reduce a divisibility question to a single algebraic identity — here $(b-1)R_b(n) = b^n - 1$, there $a_{n+1} - 1 = a_n(a_n-1)$ — and conclude with elementary divisibility in ℕ rather than factorization."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "Length-must-be-prime corollary",
+      "description": "Repunit divisibility forces a prime repunit to have prime length, mirroring how Euclid-style number-theoretic constraints control where primes can appear."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every base b ≥ 2, the repunit divisibility criterion R_b(m) ∣ R_b(n) ⟺ m ∣ n is fully machine-checked with zero sorries and zero axioms. The proof reduces repunits to power differences via the identity (b − 1)·R_b(n) = b^n − 1, then settles (b^m − 1) ∣ (b^n − 1) ⟺ m ∣ n with the division algorithm and modular arithmetic modulo b^m − 1.",
+    "implications": "The criterion is the structural backbone of repunit arithmetic: it explains repunit factorization patterns, specializes at b = 2 to the divisibility law for Mersenne numbers 2^n − 1, and yields the necessary condition that a prime repunit must have prime length. The formalization also models the standard ℕ-recurrence discipline — prove a subtraction-free additive identity, then derive the subtractive form — keeping every step inside the kernel with no native_decide or axioms.",
+    "openQuestions": [
+      "Can the criterion be sharpened to the gcd form gcd(R_b(m), R_b(n)) = R_b(gcd(m, n)), the natural strengthening that subsumes the divisibility iff?",
+      "Is the converse primality direction worth formalizing — R_b(n) prime ⟹ n prime — as an explicit corollary of repunit_dvd_iff?"
+    ]
+  }
+}

--- a/src/data/research/problems/repunit-oq-01.json
+++ b/src/data/research/problems/repunit-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "repunit-oq-01",
   "title": "Repunit Divisibility: R_m divides R_n iff m divides n",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {


### PR DESCRIPTION
## Summary

Registers and galleries the **base-$b$ repunit divisibility criterion** $R_b(m) \mid R_b(n) \iff m \mid n$, which was previously merged (#25169, #25188, #25189) as an *unregistered orphan* pending a clean Docker build.

This session the single-module build is **green** against the v4.26.0 toolchain:

```
✔ [7743/7743] Built Proofs.RepunitDivisibilityOQ01 (13s)
Build completed successfully (7743 jobs).
=== Build succeeded ===
```

(An early transient git-clone error during dependency fetch was retried automatically by lake; the compile itself is clean.)

## Changes

- **Register** `import Proofs.RepunitDivisibilityOQ01` in `proofs/Proofs.lean` (alphabetical, between `RelativizedHaltingBridge` and `RiemannHypothesis`).
- **Remove** the build-pending `NOTE` block from the `.lean` header now that the build is confirmed.
- **Add gallery entry** `src/data/proofs/repunit-oq-01/`:
  - `meta.json` — status `verified`, badge `original`, `axiomCount 0`, `sorries 0`.
  - `annotations.json` — 8 annotations, resolver-validated **8 valid / 0 misaligned**.
- Mark per-problem json `completed`; update `state.md`.

## The proof (0 sorries, 0 axioms, Mathlib-only)

- `repunit b n := ∑_{i<n} bⁱ`, with the subtraction-free bridge `(b−1)·R_b(n) + 1 = bⁿ` (`pred_mul_repunit_add_one`, by induction after `b = c+1`) and its form `(b−1)·R_b(n) = bⁿ − 1`.
- Engine `pow_sub_one_dvd_iff_dvd`: for `b ≥ 2`, `(bᵐ−1) ∣ (bⁿ−1) ⟺ m ∣ n`, via the division algorithm `n = mq+r` and `Nat.ModEq` (so `bᵐ ≡ 1`, `bⁿ ≡ bʳ`, and `bʳ−1 < bᵐ−1` forces `r = 0`).
- Headlines `repunit_dvd_iff` (base `b ≥ 2`) and `repunit_ten_dvd_iff` (base ten).

Closure is Mathlib-only with no `decide`/`native_decide`, so the entry is axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)