### PR TITLE
research(erdos-435): track verified prime-power obstruction companion in additionalFiles

### DIFF
--- a/src/data/proofs/erdos-435/meta.json
+++ b/src/data/proofs/erdos-435/meta.json
@@ -199,7 +199,18 @@
     "theoremCount": 2,
     "definitionCount": 7,
     "path": "Proofs/Erdos435Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/Erdos435PrimePowerObstruction.lean",
+        "lineCount": 83,
+        "theorems": 3,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Formalizes the prime-power obstruction that justifies restricting Erdős #435 to integers n that are NOT prime powers (recorded only as prose in the main file, Parts V–VI). For n = p^k, Kummer's identity (Nat.factorization_choose_prime_pow) gives v_p(C(p^k, j)) = k - v_p(j) > 0 for 1 ≤ j < p^k, so p divides every middle binomial coefficient (prime_pow_dvd_choose, prime_dvd_all_generators); hence the gcd of the generators {C(n,1), …, C(n,n-1)} is divisible by p and thus ≠ 1 (generators_gcd_ne_one). A numerical semigroup whose generators share a common factor > 1 has infinite complement, so no Frobenius number exists — exactly why the Hwang–Song formula is stated only for non-prime-powers. 3 theorems, 0 definitions, 0 axioms, 0 sorries; Mathlib-only, fully kernel-checked (no decide/native_decide). Namespace Erdos435.PrimePowerObstruction."
+      }
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Folds the verified, registered companion file **`Erdos435PrimePowerObstruction.lean`** into the `erdos-435` gallery entry's `leanFile.additionalFiles` array. The file was previously referenced only in the meta's prose (`originalContributions`: *"Prime power exclusion via Kummer's theorem"*) but absent from the structured tracking array, so the gallery did not surface it.

## The companion file

| Property | Value |
|----------|-------|
| Path | `proofs/Proofs/Erdos435PrimePowerObstruction.lean` |
| Registered | `Proofs.lean:1495` |
| Lines | 83 |
| Theorems | 3 |
| sorry / axiom | 0 / 0 |
| Imports | Mathlib-only (no `decide`/`native_decide`) |

It proves the prime-power obstruction underlying Erdős #435's restriction to non-prime-powers:
- `prime_pow_dvd_choose` — `p | C(p^k, j)` for `1 ≤ j < p^k` via Kummer's identity `Nat.factorization_choose_prime_pow`
- `prime_dvd_all_generators` — `p` divides every generator `C(p^k, j)`
- `generators_gcd_ne_one` — `gcd{C(n,1), …, C(n,n-1)} ≠ 1`, so the numerical semigroup has infinite complement and no Frobenius number exists — exactly why the Hwang–Song formula is stated only for non-prime-powers.

## Verification

- JSON-only change to `src/data/proofs/erdos-435/meta.json`; validated with `node` JSON.parse.
- All counts read directly from the source file.
- Companion's import closure is Mathlib-only and fully kernel-checked (closure-clean ⇒ verified).
- Parent entry remains `axiomatized` (the 2 Hwang–Song axioms are unchanged); this companion is the verified supporting infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)