### PR TITLE
research(four-square-distribution-oq-04): track verified sign-count companion in additionalFiles

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-04/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-04/meta.json
@@ -81,7 +81,18 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 22,
-    "theoremCount": 25
+    "theoremCount": 25,
+    "additionalFiles": [
+      {
+        "path": "Proofs/FourSquareDistributionOQ04Sign.lean",
+        "lineCount": 97,
+        "theorems": 2,
+        "definitions": 1,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Verified sign-count half of the orbit-size lemma for the general B_m = S_m ⋉ (ℤ/2)^m route to OQ-04. Defines signFiber g (tuples agreeing with g coordinatewise up to sign) and proves signFiber_card: its cardinality is 2^(#nonzero coordinates) (signFiber_card), via the single-coordinate count {c,-c}.card = if c=0 then 1 else 2 (card_pair_neg). This is the sign factor 2^(#nonzero) appearing throughout the parent's type-contribution formula (6!/∏mᵢ!)·2^(#nonzero); the file also records the decomposition blueprint reducing the keystone fiber_card_eq_contribution to the single remaining open arrangement-count (multinomial) lemma. 2 theorems, 1 definition, 0 axioms, 0 sorries; Mathlib-only, fully kernel-checked (no decide/native_decide). Registered Proofs.lean:2355 (PR #24885). Namespace FourSquareDistributionOQ04Sign. Standalone reusable infrastructure — does not by itself close OQ-04 (the arrangement-count residue remains open)."
+      }
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Folds the verified, registered companion file **`FourSquareDistributionOQ04Sign.lean`** into the `four-square-distribution-oq-04` gallery entry's `leanFile.additionalFiles` array. The meta's `proofStrategy`/`keyInsights` describe the sign factor `2^(#nonzero)` at length, but the file proving it was not tracked in the structured array.

## The companion file

| Property | Value |
|----------|-------|
| Path | `proofs/Proofs/FourSquareDistributionOQ04Sign.lean` |
| Registered | `Proofs.lean:2355` (via merged PR #24885) |
| Lines | 97 |
| Theorems / Definitions | 2 / 1 |
| sorry / axiom | 0 / 0 |
| Imports | Mathlib-only (no `decide`/`native_decide`) |

It proves the **sign-count half of the orbit-size lemma** for the general `B_m = S_m ⋉ (ℤ/2)^m` route:
- `card_pair_neg` — `{c, -c}.card = if c = 0 then 1 else 2`
- `signFiber_card` — `|signFiber g| = 2^(#{i : g i ≠ 0})`, i.e. the sign factor `2^(#nonzero)` that recurs throughout the parent's contribution formula `(6!/∏mᵢ!)·2^(#nonzero)`.

The file also records the decomposition blueprint reducing the keystone `fiber_card_eq_contribution` to the single remaining open arrangement-count (multinomial) lemma.

## Notes

- The file's own docstring says *"UNREGISTERED / build-pending"* — this is **stale**: it was registered and build-verified by merged PR #24885 (`Proofs.lean:2355`).
- **Honest scope**: this is standalone, reusable infrastructure. It does **not** by itself close OQ-04 — the arrangement-count residue remains open. The entry's `status` is unchanged.
- JSON-only change to `src/data/proofs/four-square-distribution-oq-04/meta.json`; validated with `node` JSON.parse; all counts read directly from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)