### PR TITLE
audit(tracker): record 9 gallery integrity audits (2026-06-17)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15773,8 +15773,66 @@
       "lastAudited": "2026-06-16T22:05:23Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "#25373: native_decide/ofReduceBool axiomCount convention"
+      ]
+    },
+    "feuerbachs-theorem-oq-02-murakami": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "happy-number-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-4k1-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-4k3-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "niven-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-theorem-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-minpoly-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "issues-found",
+      "issues": [
+        "#25373: Mathlib-bridge badged original"
+      ]
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-05T19:53:45Z"
+  "lastUpdated": "2026-06-17T00:00:00Z"
 }


### PR DESCRIPTION
Auditor iteration — re-verified the 9 previously-unaudited gallery entries against their Lean sources. Checks run per entry: sorry count, axiom declarations, `True`-stub detection, native_decide/ofReduceBool disclosure, badge tier (original vs mathlib vs axiom), and Mathlib-wrapper detection.

## Results

| Entry | Result | Notes |
|-------|--------|-------|
| erdos-1-oq-01 | ✅ clean | 0/0/0, Finset API infrastructure; `original` justified |
| erdos-1-oq-04 | ⚠️ issues-found | #25373 — native_decide axiomCount convention |
| feuerbachs-theorem-oq-02-murakami | ✅ clean | grep `sorry` hit is a comment; proof complete (`field_simp; ring`) |
| happy-number-oq-01 | ✅ clean | axiomatized/axiom/1; ofReduceBool disclosed |
| infinitude-primes-4k1-oq-01 | ✅ clean | mathlib badge; `Nat.Prime.sq_add_sq` disclosed |
| infinitude-primes-4k3-oq-01 | ✅ clean | mathlib badge; Dirichlet specialization |
| niven-theorem-oq-01 | ✅ clean | mathlib badge; algebraic-integer core cited |
| pythagorean-theorem-oq-06 | ✅ clean | original; ring cross-product identity (De Gua) |
| sqrt2-minpoly-oq-01-oq-02-oq-02 | ⚠️ issues-found | #25373 — Mathlib-bridge badged original |

## Findings → #25373

No sorry/axiom-count mismatches or True-stub overclaims were found. Two gallery-wide **presentation-consistency** items were filed as #25373 (both already disclosed honestly in `assumptions`):

1. `native_decide` → `axiomCount` is counted in some entries (happy-number, four-square-distribution-oq-01 = axiomatized/1) but not others (erdos-1-oq-04, four-square-distribution-oq-04 = verified/0) for the same `Lean.ofReduceBool` dependency.
2. The `sqrt2-minpoly*` family is badged `original` despite obtaining its core (irreducibility) from Mathlib's `X_pow_sub_C_irreducible_iff_of_prime_pow`, whereas analogous "package a Mathlib bearer" entries (niven, infinitude-4k1/4k3) are badged `mathlib`.

Tracker-only change. No Lean or meta files modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)