### PR TITLE
research(keith-number-oq-01): the smallest Keith number is 14 (verified, registered + gallery)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2542,6 +2542,7 @@ import Proofs.IsoperimetricTheoremOQ01
 import Proofs.IsoperimetricTheoremOQ02
 import Proofs.IsoscelesTriangle
 import Proofs.IsoscelesTriangleOQ01
+import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture
 import Proofs.KeplerConjectureOQ04
 import Proofs.KnightsTourOblique

--- a/src/data/proofs/keith-number-oq-01/annotations.json
+++ b/src/data/proofs/keith-number-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "keith-ann-intro",
+    "proofId": "keith-number-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "Keith Numbers and the Smallest Case",
+    "content": "A **Keith number** (or *repfigit*, for 'repetitive Fibonacci-like digit') is an $n$-digit number $N \\ge 10$ that reappears in the sequence generated from its own decimal digits: seed the sequence with the $n$ digits of $N$ (most-significant first) and let each later term be the sum of the previous $n$ terms.\n\nFor $14$ the digits are $1, 4$ and the order-2 recurrence runs $1, 4, 5, 9, 14$ (since $1+4=5$, $4+5=9$, $5+9=14$), so $14$ is Keith. The smaller two-digit numbers overshoot: $10 \\to 1,0,1,1,2,3,5,8,13,21$; $11 \\to 1,1,2,3,5,8,13$; $12 \\to 1,2,3,5,8,13$; $13 \\to 1,3,4,7,11,18$. Single-digit numbers are excluded by definition, so **14 is the smallest Keith number** (OEIS A007629).",
+    "mathContext": "The goal is `IsLeast {n | IsKeith n} 14`. Mathlib has no Keith/repfigit predicate, so the entry both introduces `IsKeith` and settles the minimal case.",
+    "significance": "key",
+    "prerequisites": [
+      "decimal digit representations",
+      "Fibonacci-like linear recurrences"
+    ],
+    "relatedConcepts": [
+      "Keith number",
+      "repfigit",
+      "Fibonacci recurrence",
+      "OEIS A007629"
+    ]
+  },
+  {
+    "id": "keith-ann-digits",
+    "proofId": "keith-number-oq-01",
+    "range": {
+      "startLine": 31,
+      "endLine": 42
+    },
+    "type": "definition",
+    "title": "Kernel-Reducible Decimal Digits",
+    "content": "`lsdDigits fuel n` peels the least-significant decimal digits of `n` by **structural recursion on `fuel`**, and `msdDigits n = (lsdDigits n n).reverse` returns the digits most-significant first (so `msdDigits 14 = [1, 4]`). Fuel `n` always suffices, since a positive integer has at most `n` decimal digits.\n\nThe custom function is deliberate: Mathlib's `Nat.digits` is defined by **well-founded** recursion and does not reliably reduce under kernel `decide`. The fuel-bounded structural version keeps the whole decision procedure kernel-reducible, which is what makes the final result axiom-free.",
+    "mathContext": "$\\mathrm{msdDigits}(N)$ is the seed window of the Keith recurrence. Choosing a kernel-reducible digit function is the design pivot that avoids `native_decide` (and hence the `Lean.ofReduceBool` axiom).",
+    "significance": "important",
+    "prerequisites": [
+      "structural vs well-founded recursion",
+      "decimal expansions"
+    ],
+    "relatedConcepts": [
+      "Nat.digits",
+      "structural recursion",
+      "kernel reduction"
+    ]
+  },
+  {
+    "id": "keith-ann-reaches",
+    "proofId": "keith-number-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 58
+    },
+    "type": "definition",
+    "title": "Sliding Window and Reachability",
+    "content": "`step w = w.tail ++ [w.sum]` advances the length-$n$ Keith window by one term: it drops the oldest entry and appends the sum of the current window. `reaches target fuel w` then iterates `step`, summing the window each round — returning `true` the instant the sum **equals** `target`, `false` if it **overshoots**, and recursing otherwise with one unit less `fuel`.\n\nThe early exit is justified by monotonicity: once the window is fixed-length and positive the running sum strictly increases, so an overshoot can never recover. A fuel bound of `40` comfortably exceeds the number of steps any two- or three-digit candidate requires.",
+    "mathContext": "This is the order-$n$ Keith recurrence realised as a length-$n$ sliding window. Reachability of the seed value $N$ is exactly the defining condition for $N$ to be a Keith number.",
+    "significance": "key",
+    "prerequisites": [
+      "linear recurrences",
+      "list operations (tail, append, sum)",
+      "monotone termination arguments"
+    ],
+    "relatedConcepts": [
+      "sliding window",
+      "fuel-bounded recursion",
+      "Keith recurrence"
+    ]
+  },
+  {
+    "id": "keith-ann-predicate",
+    "proofId": "keith-number-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "The Keith Predicate, Made Decidable",
+    "content": "`IsKeith n := 10 ≤ n ∧ reaches n 40 (msdDigits n) = true` packages the two-digit lower bound with the reachability condition. The accompanying `DecidablePred IsKeith` instance is assembled from the decidability of `10 ≤ n` and of the `Bool` equality `reaches … = true`.\n\nDecidability is the linchpin: it lets *both* membership (`IsKeith 14`) and the minimality quantifier (`∀ n < 14, ¬ IsKeith n`) be discharged by kernel `decide` with no hand-written case analysis.",
+    "mathContext": "The `10 ≤ n` clause encodes 'at least two digits', excluding single-digit numbers from the Keith definition.",
+    "significance": "important",
+    "prerequisites": [
+      "DecidablePred",
+      "decidability of bounded quantifiers"
+    ],
+    "relatedConcepts": [
+      "Decidable",
+      "decide tactic",
+      "Nat.decidableBallLT"
+    ]
+  },
+  {
+    "id": "keith-ann-smallest",
+    "proofId": "keith-number-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 82
+    },
+    "type": "theorem",
+    "title": "14 is the Least Keith Number",
+    "content": "`smallest_keith : IsLeast {n : ℕ | IsKeith n} 14` is the headline result. It combines two `decide`-proved facts: `keith_fourteen : IsKeith 14` (membership, witnessed by $1,4,5,9,14$) and `not_keith_below_fourteen : ∀ n < 14, ¬ IsKeith n` (the lower bound, a finite check over $10,11,12,13$ since smaller numbers are excluded by `10 ≤ n`).\n\n`IsLeast S a` asserts both `a ∈ S` and that `a` lower-bounds `S`; here that is precisely the statement that 14 is the smallest Keith number. The whole proof is axiom-free.",
+    "mathContext": "$\\mathrm{IsLeast}(\\{n \\mid \\mathrm{IsKeith}\\,n\\}, 14)$ means $14$ is Keith and no smaller natural number is — the minimal element of OEIS A007629.",
+    "significance": "key",
+    "prerequisites": [
+      "IsLeast",
+      "kernel decide",
+      "proof by contradiction on a bounded range"
+    ],
+    "relatedConcepts": [
+      "IsLeast",
+      "least element",
+      "decidable minimality"
+    ]
+  }
+]

--- a/src/data/proofs/keith-number-oq-01/meta.json
+++ b/src/data/proofs/keith-number-oq-01/meta.json
@@ -1,0 +1,96 @@
+{
+  "id": "keith-number-oq-01",
+  "title": "The Smallest Keith Number is 14",
+  "slug": "keith-number-oq-01",
+  "description": "A Keith number (repfigit) is an n-digit number N ≥ 10 that appears in the Fibonacci-like sequence generated from its own decimal digits. This entry defines the Keith predicate via a fuel-bounded sliding-window digit recurrence, proves it decidable, and establishes that 14 is the least Keith number — fully machine-checked by kernel `decide` with 0 axioms.",
+  "meta": {
+    "author": "Mike Keith (concept, 1987); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Keith_number",
+    "date": "1987 (Keith numbers introduced); OEIS A007629",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KeithNumberOQ01.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "digits",
+      "recurrence",
+      "decidability",
+      "recreational",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 84,
+    "theoremCount": 3,
+    "definitionCount": 5,
+    "dateAdded": "2026-06-17",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. The result uses kernel `decide` (not `native_decide`), so it carries no `Lean.ofReduceBool` axiom. The digit recurrence is implemented with a custom fuel-bounded `lsdDigits` rather than Mathlib's `Nat.digits` precisely so the kernel can reduce the decision procedure.",
+    "originalContributions": [
+      "Defines a Keith-number predicate `IsKeith : ℕ → Prop` — a notion absent from Mathlib — as a fuel-bounded sliding-window digit recurrence (`reaches`) over the most-significant-first decimal digits.",
+      "Supplies a `DecidablePred IsKeith` instance so both membership and the bounded minimality quantifier `∀ n < 14` reduce under kernel `decide`.",
+      "Uses a custom structurally-recursive `lsdDigits` (fuel-bounded) instead of `Nat.digits` (well-founded recursion, which does not reliably reduce under kernel `decide`), keeping the whole result axiom-free — no `native_decide`/`Lean.ofReduceBool`.",
+      "Proves `IsLeast {n | IsKeith n} 14`: 14 is Keith (1,4,5,9,14) and every smaller number fails (single-digit numbers are excluded; 10,11,12,13 overshoot)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Keith numbers — also called repfigit numbers, for 'repetitive Fibonacci-like digit' — were introduced by Mike Keith in 1987. An n-digit number N is Keith if, seeding a sequence with the n decimal digits of N (most-significant first) and forming each subsequent term as the sum of the previous n terms, the value N itself eventually appears. They are computationally rare (only a few dozen are known below 10^15) and are a staple of recreational number theory. Mathlib has no notion of Keith numbers, so this formalization both introduces the predicate and settles the smallest case. The smallest Keith number is 14, and the sequence of Keith numbers (OEIS A007629) begins 14, 19, 28, 47, 61, 75, ….",
+    "problemStatement": "**The smallest Keith number is 14.** Define `IsKeith n` to hold iff `n ≥ 10` and the Keith digit recurrence seeded by the decimal digits of `n` reaches `n`. Then `IsLeast {n : ℕ | IsKeith n} 14`: 14 is a Keith number and is a lower bound for the set of all Keith numbers.",
+    "text": "A Lean 4 / Mathlib formalization in 84 lines with 0 sorries and 0 axioms. The Keith recurrence is modelled as a fuel-bounded sliding window: `step` drops the oldest window term and appends the window sum, `reaches target fuel w` iterates `step` until the running sum meets the target (success) or overshoots it (failure). `IsKeith n` packages the two-digit lower bound `10 ≤ n` with `reaches n 40 (msdDigits n) = true`. A `DecidablePred IsKeith` instance makes `keith_fourteen : IsKeith 14` and `not_keith_below_fourteen : ∀ n < 14, ¬ IsKeith n` provable by `decide`, and `smallest_keith : IsLeast {n | IsKeith n} 14` assembles them.",
+    "proofStrategy": "1. **Decimal digits, kernel-reducible.** `lsdDigits fuel n` peels least-significant digits by structural recursion on `fuel`; `msdDigits n = (lsdDigits n n).reverse` gives the most-significant-first digit list (`msdDigits 14 = [1,4]`). Fuel `n` always suffices.\n\n2. **Sliding-window step.** `step w = w.tail ++ [w.sum]` advances the length-`d` Keith window by one term.\n\n3. **Bounded reachability.** `reaches target fuel w` sums the window; returns `true` on an exact hit, `false` on overshoot (the running sum is monotone once the window is positive), and otherwise recurses on `step w` with one less fuel. Fuel `40` dwarfs the steps any two- or three-digit candidate needs.\n\n4. **Predicate + decidability.** `IsKeith n := 10 ≤ n ∧ reaches n 40 (msdDigits n) = true`, with a `DecidablePred` instance assembled from the decidability of `≤` and `Bool` equality.\n\n5. **The two facts.** `keith_fourteen` and `not_keith_below_fourteen` are discharged by `decide` (the latter via `Nat.decidableBallLT` over the 14 cases).\n\n6. **Minimality.** `smallest_keith` combines membership (`keith_fourteen`) with the lower bound: any `n < 14` would contradict `not_keith_below_fourteen`.",
+    "keyInsights": [
+      "**Kernel `decide` forces the data structures.** Mathlib's `Nat.digits` is defined by well-founded recursion and does not reliably reduce in the kernel, so a `decide`-based minimality proof would stall. Replacing it with a fuel-bounded structurally-recursive `lsdDigits` keeps every step kernel-reducible and the result axiom-free (no `native_decide`, hence no `Lean.ofReduceBool`).",
+      "**Monotone early-exit makes the recurrence terminating and cheap.** Once the window is fixed-length and positive the running sum strictly increases, so `reaches` can stop the instant the sum meets-or-exceeds the target; a fuel bound of 40 is a comfortable over-estimate for the small candidates checked.",
+      "**Minimality is a finite computation.** With `IsKeith` decidable, the lower bound `∀ n < 14, ¬ IsKeith n` is a single bounded check over 10,11,12,13 (numbers below 10 are excluded by the `10 ≤ n` clause), discharged by `decide` with no case-by-case hand proof.",
+      "**A new predicate, not a Mathlib lookup.** Mathlib has no Keith/repfigit notion; the predicate, its decidability instance, and the smallest-element theorem are all supplied by the formalization."
+    ],
+    "prerequisites": [
+      "Decimal digit representations of natural numbers",
+      "Linear recurrences (Fibonacci-like sums)",
+      "Decidability and kernel `decide` in Lean 4",
+      "`IsLeast` and bounded quantifiers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Keith Numbers and the Claim",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Module docstring: defines Keith (repfigit) numbers, works the example 1,4,5,9,14 for 14, notes that 10,11,12,13 overshoot, and states the goal `IsLeast {n | IsKeith n} 14`. Records that the proof is axiom-free via kernel `decide`.",
+      "mathContext": "A Keith number is an n-digit N ≥ 10 appearing in the order-n linear recurrence seeded by its own digits. 14 is the smallest such number (OEIS A007629)."
+    },
+    {
+      "id": "lsddigits",
+      "title": "Decimal Digits (fuel-bounded)",
+      "startLine": 31,
+      "endLine": 42,
+      "summary": "`lsdDigits fuel n` extracts least-significant-first decimal digits by structural recursion on `fuel`; `msdDigits n = (lsdDigits n n).reverse` yields most-significant-first digits. Fuel-bounded so the kernel can reduce it under `decide`.",
+      "mathContext": "A kernel-reducible replacement for `Nat.digits` (which uses well-founded recursion); fuel `n` suffices since a positive integer has at most `n` decimal digits."
+    },
+    {
+      "id": "step-reaches",
+      "title": "Sliding Window and Reachability",
+      "startLine": 44,
+      "endLine": 58,
+      "summary": "`step w = w.tail ++ [w.sum]` advances the Keith window by one term; `reaches target fuel w` iterates `step`, returning `true` on an exact hit, `false` on overshoot, recursing otherwise. Monotone running sum gives the early exit.",
+      "mathContext": "The order-n Keith recurrence as a length-n sliding window; reachability of the seed value N is the defining condition of a Keith number."
+    },
+    {
+      "id": "iskeith",
+      "title": "The Keith Predicate and Decidability",
+      "startLine": 60,
+      "endLine": 66,
+      "summary": "`IsKeith n := 10 ≤ n ∧ reaches n 40 (msdDigits n) = true` defines a Keith number; the `DecidablePred IsKeith` instance is assembled from decidability of `≤` and `Bool` equality.",
+      "mathContext": "Decidability is what lets both membership and the minimality quantifier reduce under kernel `decide`."
+    },
+    {
+      "id": "theorems",
+      "title": "14 is the Smallest Keith Number",
+      "startLine": 68,
+      "endLine": 82,
+      "summary": "`keith_fourteen : IsKeith 14` and `not_keith_below_fourteen : ∀ n < 14, ¬ IsKeith n` are proved by `decide`; `smallest_keith : IsLeast {n | IsKeith n} 14` combines membership with the lower bound.",
+      "mathContext": "`IsLeast S 14` means 14 ∈ S and 14 is a lower bound for S — exactly 'smallest Keith number'."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

`Proofs/KeithNumberOQ01.lean` was complete but **unregistered and build-gated**. This session **Docker-built it GREEN**, registered it, and added the gallery entry.

```
✔ [7743/7743] Built Proofs.KeithNumberOQ01 (91s)
Build completed successfully (7743 jobs).
```

**Axiom-free**: the proof uses kernel `decide` (no `native_decide`, hence no `Lean.ofReduceBool`), 0 sorry / 0 axiom ⇒ `verified`.

## Result

`smallest_keith : IsLeast {n : ℕ | IsKeith n} 14` — 14 is the least [Keith number](https://en.wikipedia.org/wiki/Keith_number) (repfigit; OEIS A007629 begins 14, 19, 28, 47, …). The digits `1,4` generate `1,4,5,9,14`; the smaller two-digit numbers 10–13 overshoot, and single-digit numbers are excluded.

## What's in this PR

- **Register** `import Proofs.KeithNumberOQ01` in `Proofs.lean` (alphabetical, before `KeplerConjecture`).
- **Gallery** `src/data/proofs/keith-number-oq-01/`: `meta.json` (status `verified`, badge `original` — Mathlib has no Keith/repfigit predicate; lineCount 84, 5 defs, 3 theorems, axiomCount 0) + `annotations.json` (5 line annotations, **resolver validates 5/5**).

## Design note (why it's axiom-free)

`IsKeith` is built on a custom **fuel-bounded** `lsdDigits` rather than Mathlib's `Nat.digits` (well-founded recursion, which doesn't reliably reduce under kernel `decide`). With `DecidablePred IsKeith`, both `keith_fourteen` and `not_keith_below_fourteen : ∀ n < 14, ¬ IsKeith n` are discharged by `decide`, and minimality follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)