### PR TITLE
Enrich Dirichlet's approximation theorem: +2 annotations

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem/annotations.json
@@ -1,5 +1,24 @@
 [
   {
+    "id": "ann-floor-base-lemma",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 22, "endLine": 28 },
+    "type": "lemma",
+    "title": "sub_lt_one_of_floor_eq — The One-Directional Floor Core",
+    "content": "The elementary fact underneath interval_bound: if ⌊x⌋ = ⌊y⌋ and x ≥ y, then x − y < 1. The proof rewrites the shared floor and combines x < ⌊x⌋ + 1 (Int.lt_floor_add_one) with ⌊y⌋ ≤ y (Int.floor_le) by `linarith`. interval_bound then only needs to add an absolute-value sign case split to drop the x ≥ y hypothesis, so this directed lemma carries the real content of 'same integer part ⇒ within distance one'.",
+    "mathContext": "$x < \\lfloor x\\rfloor + 1,\\ \\lfloor y\\rfloor \\le y,\\ \\lfloor x\\rfloor = \\lfloor y\\rfloor \\;\\Rightarrow\\; x - y < 1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "floor function",
+      "real number bracketing",
+      "linarith"
+    ],
+    "prerequisites": [
+      "Int.lt_floor_add_one and Int.floor_le",
+      "ordered-field inequalities"
+    ]
+  },
+  {
     "id": "ann-interval-bound",
     "proofId": "dirichlet-approximation-theorem",
     "range": { "startLine": 31, "endLine": 38 },
@@ -79,6 +98,27 @@
       "intervalMap and interval_bound",
       "wlog tactic",
       "Nat/Int/Real casting"
+    ]
+  },
+  {
+    "id": "ann-pigeonhole-collision",
+    "proofId": "dirichlet-approximation-theorem",
+    "range": { "startLine": 75, "endLine": 103 },
+    "type": "insight",
+    "title": "The Pigeonhole Collision and Extraction of p, q",
+    "content": "The conceptual heart of the proof. Because |Fin (Q+1)| = Q+1 > Q = |Fin Q|, the map intervalMap cannot be injective, so `Fintype.exists_ne_map_eq_of_card_lt` produces distinct indices i ≠ j with intervalMap i = intervalMap j — two of the Q+1 fractional parts {iα}, {jα} land in the same sub-interval. After a `wlog` normalises to j < i, the approximation is read off with no further search: the denominator is q = i − j (forced into 1 ≤ q ≤ Q because i, j ∈ {0,…,Q}) and the numerator is p = ⌊iα⌋ − ⌊jα⌋, linked by the exact identity qα − p = frac(iα) − frac(jα). The good approximation thus falls out of the collision itself, not from any explicit construction.",
+    "mathContext": "$|\\mathrm{Fin}(Q{+}1)| = Q+1 > Q = |\\mathrm{Fin}\\,Q| \\Rightarrow$ non-injective; the colliding pair gives $q = i-j$, $p = \\lfloor i\\alpha\\rfloor - \\lfloor j\\alpha\\rfloor$, and $q\\alpha - p = \\{i\\alpha\\} - \\{j\\alpha\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "Fintype.card non-injectivity",
+      "wlog reduction",
+      "denominator extraction"
+    ],
+    "prerequisites": [
+      "Fintype.exists_ne_map_eq_of_card_lt",
+      "Fin n indexing and isLt",
+      "Nat subtraction casts"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem` (quality 91, pass 0).

## Gap addressed
The entry was strong on meta (rich historicalContext, 4 keyInsights, 4 sections, conclusion with 3 open questions) but had only **4 annotations** — under the 5+ target — and two important constructs had a section but no inline annotation. Added 2:

- **`ann-floor-base-lemma`** (lemma, lines 22–28): `sub_lt_one_of_floor_eq`, the one-directional floor core beneath `interval_bound` (⌊x⌋=⌊y⌋, x≥y ⇒ x−y<1). The existing annotations covered `interval_bound` but not the lemma it rests on.
- **`ann-pigeonhole-collision`** (insight, lines 75–103): the conceptual heart — `Fintype.exists_ne_map_eq_of_card_lt` forces a collision among the Q+1 fractional parts, and the approximation data q = i−j, p = ⌊iα⌋−⌊jα⌋ (with qα−p = frac(iα)−frac(jα)) falls out directly.

## Verification
- Resolver `validateLineAnnotations`: **6/6 valid, 0 misaligned**.
- Annotations-only change; meta.json untouched. status/badge/axiomCount accurate (verified, original, 0 axioms, 0 sorries).