### PR TITLE
audit(tracker): 8 clean (chebyshev/erdos-435/repunit/leibniz-pi/greens/fermat-2sq/fair-games/triangle-ineq)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11591,9 +11591,9 @@
       "result": "clean"
     },
     "greens-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:53Z",
+      "lastAudited": "2026-06-18T04:25:16Z",
       "result": "clean"
     },
     "greens-theorem-oq-01-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11228,9 +11228,9 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:53Z",
+      "lastAudited": "2026-06-18T04:26:31Z",
       "result": "clean"
     },
     "fair-games-theorem-oq-02": {
@@ -11270,9 +11270,9 @@
       "result": "clean"
     },
     "fermat-two-squares-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:53Z",
+      "lastAudited": "2026-06-18T04:26:31Z",
       "result": "clean"
     },
     "fermats-last-theorem": {
@@ -13510,9 +13510,9 @@
       "result": "clean"
     },
     "triangle-inequality": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
+      "lastAudited": "2026-06-18T04:26:31Z",
       "result": "clean"
     },
     "triangle-inequality-oq-03": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15831,6 +15831,12 @@
       "issues": [
         "#25373: Mathlib-bridge badged original"
       ]
+    },
+    "chebyshev-bounds-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12276,9 +12276,9 @@
       "result": "clean"
     },
     "leibniz-pi-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:24:53Z",
+      "lastAudited": "2026-06-18T04:15:53Z",
       "result": "clean"
     },
     "leibniz-pi-oq-02": {
@@ -15835,6 +15835,18 @@
     "chebyshev-bounds-oq-04-oq-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-435-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T04:14:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "repunit-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T04:15:22Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery Integrity Audit — 4 entries, all clean

Tracker-only update recording audits of four `verified`/`original` gallery entries. No gallery/meta changes were needed — all public claims match the Lean source.

| Slug | Result | Notes |
|------|--------|-------|
| `chebyshev-bounds-oq-04-oq-01-oq-01` | clean | (prior commit) |
| `erdos-435-oq-01` | clean | 0 sorry / 0 axiom / Mathlib-only closure, registered `Proofs.lean:1495`. Kummer identity `Nat.factorization_choose_prime_pow` credited transparently throughout; gcd-obstruction packaging is genuine original work → badge `original` justified. Counts match (3 thm / 0 def / 83 L). Stale `build-pending` line is in the file docstring only (now registered/merged), not a public claim. |
| `repunit-oq-01` | clean | 0 sorry / 0 axiom, core engine `pow_sub_one_dvd_iff_dvd` proved in-file from elementary lemmas; `mathlibDependencies:[]` honest. Registered `Proofs.lean:2810`. Counts match (7 thm / 1 def / 133 L). |
| `leibniz-pi-oq-01-oq-01` | clean | `MachinFromAddition.lean`: derives Machin's formula from `arctan_add`/`arctan_neg`/`arctan_one` rather than Mathlib's prepackaged `Real.four_mul_arctan_inv_5_sub_arctan_inv_239`. Registered `Proofs.lean:2652`. Counts match (4 thm / 0 def / 97 L). |

Checks per entry: True-stub detection, sorry/axiom/native_decide grep, Mathlib-wrapper vs `original` badge, count fields (sorries/axioms/theorems/defs/lineCount), registration in `Proofs.lean`, import-closure cleanliness.

---
Discovered during gallery integrity audit (auditor agent).