### PR TITLE
Fix: re-badge sqrt2-minpoly Mathlib-bridge entries original→mathlib

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2MinpolyOQ01OQ02OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 121,

--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
@@ -17,7 +17,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2MinpolyOQ01OQ02PrimePow.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 132,

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -15,7 +15,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2Minpoly.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 140,


### PR DESCRIPTION
## Fix

Re-badge the three `sqrt2-minpoly*` entries whose **main-result irreducibility comes directly from a Mathlib theorem** from `original` → `mathlib`, per the Auditor wrapper rule (a proof that directly calls a major listed Mathlib theorem for its essential difficulty is a bridge/wrapper → badge `mathlib`). Addresses **part 2** of #25373.

## Evidence

The irreducibility — the entire mathematical content of a "minimal polynomial = X^n − a" result — is supplied by Mathlib in exactly these three entries:

| Entry | Mathlib irreducibility bearer | Lean call site |
|-------|-------------------------------|----------------|
| `sqrt2-minpoly` (parent) | `Polynomial.irreducible_of_eisenstein_criterion` | `Sqrt2Minpoly.lean:45` |
| `sqrt2-minpoly-oq-01-oq-02-oq-01` | `X_pow_sub_C_irreducible_iff_of_prime_pow` | `Sqrt2MinpolyOQ01OQ02OQ01.lean:94` |
| `sqrt2-minpoly-oq-01-oq-02-oq-02` | `X_pow_sub_C_irreducible_iff_of_prime_pow` | `Sqrt2MinpolyOQ01OQ02PrimePow.lean:105` |

This matches established precedent (`niven-theorem-oq-01`, `infinitude-primes-4k1-oq-01`, `infinitude-primes-4k3-oq-01`), which are all `mathlib` for the same "package a hard Mathlib bearer" pattern.

**Before**: all three `verified` / `original` / axiomCount 0.
**After**: all three `verified` / `mathlib` / axiomCount 0 (status and axiom count unchanged — still fully machine-checked; only provenance badge corrected).

### Scope note (the other three sqrt2-minpoly entries correctly stay `original`)

The auditor recommended re-badging "the family", but file inspection shows the remaining three do **not** have a Mathlib theorem as their direct main bearer:

- `sqrt2-minpoly-oq-01` and `sqrt2-minpoly-oq-02` delegate to the **in-project** theorem `CubeRoot2IrrationalOQ03.minpoly_nthRoot_eq` (a `Proofs.*` dependency, not Mathlib) — the wrapper rule keys on a *Mathlib* bearer, so it does not trigger.
- `sqrt2-minpoly-oq-01-oq-02` (degree-2 case) invokes no irreducibility theorem at all — minimality is assembled in-file from `minpoly.dvd` + elementary degree-2 reasoning.

This is the "document why some entries remain `original`" alternative the auditor offered.

### Part 1 deferred (native_decide → axiomCount)

Part 1 of #25373 (whether `native_decide`/`Lean.ofReduceBool` should count toward `axiomCount`) is a **gallery-wide convention choice** that touches CLAUDE.md policy and reclassifies several flagship `verified` entries. It is left open pending a documented policy decision rather than fixed unilaterally — so this PR does **not** close #25373.

---
Automated fix by lean-mechanic agent.