### PR TITLE
Enrich Feuerbach OQ-02 (Murakami / Grace trirectangular): split sections

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02-murakami/meta.json
@@ -67,20 +67,36 @@
   },
   "sections": [
     {
-      "id": "header-setup",
-      "title": "Statement Setup and Geometric Data",
+      "id": "docstring-geometry",
+      "title": "Doc-comment: Geometry and Closed Forms",
       "startLine": 1,
-      "endLine": 74,
-      "summary": "Doc-comment fixing the trirectangular tetrahedron A=(a,0,0), B=(0,b,0), C=(0,0,c), D=0, and recording the closed forms for the tangent sphere centre Θ, radius R, and the insphere/D-exsphere radii ρin, ρex (carrying the surd t). Lists the prior S0–S7 hand/numeric verification and the Maehara–Martini reference, then the Mathlib import and pretty-printing options.",
-      "mathContext": "The trirectangular tetrahedron is the simplest non-degenerate tetrahedron with a clean Feuerbach analogue: legs along the coordinate axes make every distinguished sphere explicit. The insphere and D-exsphere form a D-homothety pair, both centred on the diagonal (1,1,1) direction, which is what lets a single sphere through A,B,C be tangent to both."
+      "endLine": 39,
+      "summary": "The doc-comment fixes the trirectangular tetrahedron A=(a,0,0), B=(0,b,0), C=(0,0,c), D=0 and records the closed forms for the tangent-sphere centre Θ, radius R, and the insphere/D-exsphere radii ρin, ρex (carrying the surd t=√(a²b²+b²c²+c²a²)). It cites the prior S0–S7 hand/numeric verification, the base case T0=(2,3,6) giving Θ=(40,45,72)/22, R=85/22, and the Maehara–Martini reference, and notes the proof tactics and the symbolic certificate (15/15 PASS).",
+      "mathContext": "The trirectangular tetrahedron is the simplest non-degenerate tetrahedron with a clean Feuerbach analogue: legs along the coordinate axes make every distinguished sphere explicit. Θ and R are RATIONAL in (a,b,c) — the surd t cancels — the 3D analogue of the 2D nine-point centre being rational in the triangle data."
+    },
+    {
+      "id": "imports-options",
+      "title": "Imports, Options & noncomputable section",
+      "startLine": 40,
+      "endLine": 67,
+      "summary": "Imports all of Mathlib, opens the BigOperators/Real/Nat/Classical/Pointwise scopes, and sets elaboration and pretty-printing options: maxHeartbeats 0 (unbounded, for the heavy field_simp/ring), bounded synthInstance limits, full pp.fullNames/binder-type printing, and autoImplicit/relaxedAutoImplicit false for binder hygiene; opens a noncomputable section since the reals and √ are noncomputable.",
+      "mathContext": "maxHeartbeats 0 lifts the elaboration budget for the denominator-clearing ring normalisation; the statement is over ℝ, so `noncomputable section` is required for the surd t and the rational closed forms."
     },
     {
       "id": "grace-theorem",
       "title": "Grace's Theorem (Trirectangular): the Five Defining Identities",
-      "startLine": 75,
+      "startLine": 70,
+      "endLine": 92,
+      "summary": "The theorem grace_feuerbach_trirectangular bundles five real identities under the hypotheses a,b,c>0, t²=a²b²+b²c²+c²a², t≥0 and the closed forms for Θ=(qx,qy,qz), R, ρin, ρex: (1)–(3) the sphere through A, B, C; (4) internal tangency to the insphere centred at ρin·(1,1,1); (5) internal tangency to the D-exsphere centred at ρex·(1,1,1).",
+      "mathContext": "Each incidence goal $(q_x-a)^2+q_y^2+q_z^2 = R^2$ (and cyclic) is a rational-function identity in $(a,b,c)$; each tangency goal $(q_x-\\rho)^2+(q_y-\\rho)^2+(q_z-\\rho)^2 = (R-\\rho)^2$ holds modulo the single surd relation $t^2=a^2b^2+b^2c^2+c^2a^2$."
+    },
+    {
+      "id": "proof-tactics",
+      "title": "The Proof: Substitute, Clear, Combine",
+      "startLine": 93,
       "endLine": 100,
-      "summary": "The theorem grace_feuerbach_trirectangular bundles five real identities under the hypotheses a,b,c>0, t²=a²b²+b²c²+c²a², t≥0 and the closed forms for Θ=(qx,qy,qz), R, ρin, ρex: (1)–(3) the sphere passes through A, B, C; (4) it is internally tangent to the insphere; (5) it is internally tangent to the D-exsphere. Proof: σ≠0 by positivity, substitute the closed forms, then field_simp;ring for incidence and field_simp;linear_combination 2*ht for tangency.",
-      "mathContext": "Each incidence goal (qx−a)²+qy²+qz² = R² (and cyclic) is a rational-function identity in (a,b,c) that becomes a polynomial identity after clearing 2σ. Each tangency goal (qx−ρ)²+(qy−ρ)²+(qz−ρ)² = (R−ρ)² holds modulo the single surd relation t²=a²b²+b²c²+c²a²; the linear_combination coefficient 2 is the post-field_simp image of the analytic 1/(2σ²)."
+      "summary": "After establishing σ = a+b+c ≠ 0 by positivity and substituting all six closed forms, the goal splits into the five conjuncts: the three incidence goals close by `field_simp; ring` (genuine 2σ-cleared polynomial identities), and the two tangency goals close by `field_simp; linear_combination 2 * ht`, the surd relation entering with the post-clear coefficient 2.",
+      "mathContext": "$\\texttt{linear\\_combination}\\,2\\cdot ht$ supplies $2(t^2 - (a^2b^2+b^2c^2+c^2a^2)) = 0$ to `ring`; the coefficient 2 is the image of the analytic $1/(2\\sigma^2)$ after `field_simp` clears the $(2\\sigma)^{-1}$ denominators."
     },
     {
       "id": "proof-notes",


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-oq-02-murakami` (quality 96 → 100).

## Changes
- Split the 3 broad `sections[]` entries into **5 finer ones** — the only scored gap (sections 6 → 10): doc-comment geometry/closed-forms, imports/options/`noncomputable`, the theorem statement (five identities), the proof tactics (substitute → `field_simp;ring` / `field_simp;linear_combination 2*ht`), and the proof notes (coefficient discipline, surd cancellation).
- Each section carries `startLine`/`endLine` and a LaTeX `mathContext`.

All other buckets already maxed (annotations 25, mathContext/significance/historicalContext/keyInsights/conclusion/crossRefs all full). Verified 96 → 100 via `find-targets.ts --json` and `pnpm build`.