### PR TITLE
Fix: normalize native_decide entries to axiomatized (#25373 part 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ Structure-encoded hypotheses (fields in structures/typeclasses such as `NSAxioms
 - Restructuring axioms into structures is a valid proof architecture choice, but it does not change the mathematical status
 - `grep -c "^axiom "` alone is NOT sufficient to count assumptions — always inspect structure fields too
 
+**`native_decide` rule:** `native_decide` trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (`#print axioms` lists it; the proof is *not* axiom-free). When `native_decide` discharges a **substantive** result the entry presents as verified, count it: `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, and disclose `Lean.ofReduceBool` in `assumptions`. (`leanFile.axiomCount` still counts only literal `axiom` declarations, so it may legitimately read 0 while `meta.axiomCount` is 1.) The ordinary foundational axioms `propext` / `Classical.choice` / `Quot.sound` do NOT count — only `Lean.ofReduceBool` (and `sorryAx`) do. This is the conservative reading of "when in doubt, axiomatized."
+
 **Status field definitions** (meta.json `status` and `badge`):
 
 | Status | Badge | Meaning | Requirements |

--- a/src/data/proofs/erdos-1-oq-04/meta.json
+++ b/src/data/proofs/erdos-1-oq-04/meta.json
@@ -5,7 +5,7 @@
   "description": "The structure of extremal sets for Erdős Problem #1: among n-element sets of positive integers with all 2^n subset sums distinct, which achieve the minimum largest element f(n)? The minima form OEIS A005318 (0,1,2,4,7,13,24,...), conjecturally realized by the Conway-Guy sets (1968). This entry verifies the small cases f(1)=1, f(2)=2, f(3)≤4, f(4)≤7, f(5)≤13 via explicit witnesses and proves, fully and computation-free, that the powers of two {1,2,...,2^{n-1}} always have distinct subset sums (the binary-representation upper bound f(n) ≤ 2^{n-1}). The Conway-Guy conjecture that A005318 gives the exact minima is stated as a Prop and left open.",
   "meta": {
     "author": "Lean Genius",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1OQ04.lean",
     "tags": [
       "erdos",
@@ -14,15 +14,15 @@
       "distinct-subset-sums",
       "conway-guy",
       "open-question",
-      "verified"
+      "axiomatized"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 245,
     "theoremCount": 15,
     "definitionCount": 4,
-    "assumptions": "None (no axiom declarations, no sorries). The verified small-case witnesses f(1)=1 through f(5)≤13 and the `hasDistinctSubsetSums` checks are discharged by `native_decide`, which trusts the Lean compiler's kernel-reduction (`Lean.ofReduceBool`). The headline theorem `powers_of_two_dss` (binary representation gives distinct subset sums, hence f(n) ≤ 2^{n-1}) is proved by structural induction with NO `native_decide`. The Conway-Guy conjecture itself (that A005318 gives the exact minima) is stated as a `Prop` (`conwayGuyConjecture`) and is NOT proved — it remains open.",
+    "assumptions": "One assumption: `Lean.ofReduceBool` (no `axiom` declarations, no sorries). The verified small-case witnesses f(1)=1 through f(5)≤13 and the `hasDistinctSubsetSums` checks are discharged by `native_decide`, which trusts the Lean compiler's kernel-reduction (`Lean.ofReduceBool`) — so under the gallery convention the entry is `axiomatized` (axiomCount 1), not axiom-free. The headline theorem `powers_of_two_dss` (binary representation gives distinct subset sums, hence f(n) ≤ 2^{n-1}) is proved by structural induction with NO `native_decide`. The Conway-Guy conjecture itself (that A005318 gives the exact minima) is stated as a `Prop` (`conwayGuyConjecture`) and is NOT proved — it remains open.",
     "mathlibDependencies": [
       {
         "theorem": "Finset.add_sum_erase",

--- a/src/data/proofs/four-square-distribution-oq-04/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-06-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/FourSquareDistributionOQ04.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "jacobi-formula",
       "combinatorics"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-06-16",
-    "axiomCount": 0,
-    "assumptions": "No `sorry`, no `axiom` declarations. The 16 per-type contribution equalities are discharged by `native_decide` (16 of the 19 native_decide invocations), which the kernel accepts via `Lean.ofReduceBool` — the standard compiler-trust dependency, identical to the parent `four-square-distribution`. The Jacobi values r₆(n) and the completeness of each type enumeration are independently cross-checked by `verify_hyperoctahedral_2k.py` in the problem's research directory.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool` (no `sorry`, no `axiom` declarations). The 16 per-type contribution equalities are discharged by `native_decide` (16 of the 19 native_decide invocations), which the kernel accepts via `Lean.ofReduceBool` — the standard compiler-trust dependency, identical to the parent `four-square-distribution`. Because these are substantive verified equalities, under the gallery convention the entry is `axiomatized` (axiomCount 1), not axiom-free. The Jacobi values r₆(n) and the completeness of each type enumeration are independently cross-checked by `verify_hyperoctahedral_2k.py` in the problem's research directory.",
     "lineCount": 207,
     "theoremCount": 25,
     "definitionCount": 22,

--- a/src/data/proofs/four-square-distribution/meta.json
+++ b/src/data/proofs/four-square-distribution/meta.json
@@ -2,10 +2,10 @@
   "id": "four-square-distribution",
   "title": "Distribution of Four-Square Representations Among Orderings",
   "slug": "four-square-distribution",
-  "description": "Formalizes how the r₄(n) representations of n as a²+b²+c²+d² distribute among representation types based on sorted absolute values. Each type contributes a specific multiplicity (sign changes × permutations). Concrete: type (0,0,0,1) contributes 8, type (a,b,c,d) all distinct contributes 384. 38 theorems, 0 sorries, 0 axioms.",
+  "description": "Formalizes how the r₄(n) representations of n as a²+b²+c²+d² distribute among representation types based on sorted absolute values. Each type contributes a specific multiplicity (sign changes × permutations). Concrete: type (0,0,0,1) contributes 8, type (a,b,c,d) all distinct contributes 384. 38 theorems, 0 sorries, 0 axiom declarations (the multiplicity computations use native_decide, which depends on Lean.ofReduceBool).",
   "meta": {
     "author": "Lean Genius FourSquareDistribution",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/FourSquareDistribution.lean",
     "tags": [
       "number-theory",
@@ -18,12 +18,12 @@
       "hyperoctahedral-group",
       "native-decide"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 400,
     "theoremCount": 38,
-    "assumptions": "None. All 38 theorems proved.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. All 38 theorems are proved with no `sorry` and no `axiom` declarations, but the per-type multiplicity computations are discharged by `native_decide` (20 invocations), which the kernel accepts via `Lean.ofReduceBool` — the standard compiler-trust dependency. Under the gallery convention, native_decide on substantive results makes the entry `axiomatized` (axiomCount 1), not axiom-free.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.decideEq",


### PR DESCRIPTION
## Fix

Resolves **part 1** of #25373 — the gallery-wide inconsistency in how `native_decide` maps to `axiomCount` / `status` / `badge`. (Part 2, the `sqrt2-minpoly` re-badging, is handled separately in #25383.)

`native_decide` trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom — `#print axioms` lists it, so such proofs are **not** axiom-free. The gallery treated this inconsistently: some entries counted it (`axiomatized`/`axiomCount 1`), others disclosed it but kept `verified`/`axiomCount 0`.

This PR adopts the **conservative reading** (matches CLAUDE.md's "when in doubt, axiomatized — overclaiming verified damages credibility") and normalizes the three offenders that present substantive native_decide results as verified:

| Entry | Before | After |
|-------|--------|-------|
| `erdos-1-oq-04` | verified / original / 0 | axiomatized / axiom / 1 |
| `four-square-distribution-oq-04` | verified / original / 0 | axiomatized / axiom / 1 |
| `four-square-distribution` (parent) | verified / original / 0 | axiomatized / axiom / 1 |

This brings them in line with the already-correct `happy-number-oq-01` and `four-square-distribution-oq-01` (both `axiomatized`/`axiom`/1).

The rule is codified in CLAUDE.md's Axiom Integrity Policy so the auditor and future entries stay consistent. `leanFile.axiomCount` is left at 0 (it counts literal `axiom` declarations); only `meta.axiomCount` (all assumptions) becomes 1. `propext`/`Classical.choice`/`Quot.sound` explicitly do **not** count.

## Evidence

**Before**: `erdos-1-oq-04` (10× native_decide), `four-square-distribution-oq-04` (19×), `four-square-distribution` (20×) all claimed `verified`/`original`/`axiomCount 0` while disclosing (or, for the parent, *failing* to disclose) `Lean.ofReduceBool`.
**After**: all three are `axiomatized`/`axiom`/`axiomCount 1` with `Lean.ofReduceBool` disclosed in `assumptions`; the parent's stale `"None. All 38 theorems proved."` disclosure is corrected.

Data pipeline (`research:build` + `research:enrich`) processes all 2029 entries with no JSON errors. (`tsc`/`vite` steps are unrelated TypeScript compilation; `tsc` is not installed in this environment.)

Part of #25373

---
Automated fix by lean-mechanic agent.