### PR TITLE
Enrich Rising ⟷ Standard Vandermonde Connection

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/annotations.json
@@ -73,20 +73,42 @@
     ]
   },
   {
-    "id": "ann-as-oq020202-crosschecks",
+    "id": "ann-as-oq020202-crosscheck-rising",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-02",
     "range": {
       "startLine": 90,
-      "endLine": 100
+      "endLine": 95
     },
     "type": "concept",
-    "title": "Concrete Cross-Checks via native_decide",
-    "content": "Three numeric sanity checks confirm both forms agree on concrete inputs. The rising form at a=b=1, n=2 expands to C(1,1)·C(3,1) + C(2,1)·C(2,1) + C(3,1)·C(1,1) = 1·3 + 2·2 + 3·1 = 10, matching its right-hand side C(5,3) = 10. The standard form at m=4, s=3, r=2 gives C(7,2) = 21 = Σ_{j=0}^{2} C(4,j)·C(3,2-j). These are `example`s discharged by `native_decide`; they are throwaway checks, not part of the headline results, so the two main theorems remain axiom-free.",
-    "mathContext": "Rising: $\\binom{1}{1}\\binom{3}{1}+\\binom{2}{1}\\binom{2}{1}+\\binom{3}{1}\\binom{1}{1}=3+4+3=10=\\binom{5}{3}$. Standard: $\\binom{7}{2}=21=\\binom{4}{0}\\binom{3}{2}+\\binom{4}{1}\\binom{3}{1}+\\binom{4}{2}\\binom{3}{0}=3+12+6=21$.",
+    "title": "Cross-Check: Rising Form at a=b=1, n=2",
+    "content": "A numeric sanity check of the rising convolution on its smallest non-trivial instance. With a=b=1, n=2 the left-hand sum expands to C(1,1)·C(3,1) + C(2,1)·C(2,1) + C(3,1)·C(1,1) = 1·3 + 2·2 + 3·1 = 10, and a companion `example` confirms the closed-form right-hand side C(a+b+n+1, a+b+1) = C(5,3) = 10. The two `example`s are discharged by `native_decide`, so they are disposable numeric witnesses that never enter the proof of the headline `rising_vandermonde` — keeping that theorem free of the `Lean.ofReduceBool` axiom that `native_decide` would otherwise introduce.",
+    "mathContext": "$\\sum_{i=0}^{2}\\binom{1+i}{1}\\binom{1+(2-i)}{1} = \\binom{1}{1}\\binom{3}{1}+\\binom{2}{1}\\binom{2}{1}+\\binom{3}{1}\\binom{1}{1}=3+4+3=10$, and the closed form $\\binom{1+1+2+1}{1+1+1}=\\binom{5}{3}=10$ matches.",
     "significance": "supporting",
     "relatedConcepts": [
       "native_decide",
-      "binomial coefficients",
+      "negative binomial convolution",
+      "numeric verification"
+    ],
+    "prerequisites": [
+      "Nat.choose",
+      "Finset.range"
+    ]
+  },
+  {
+    "id": "ann-as-oq020202-crosscheck-standard",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 100
+    },
+    "type": "concept",
+    "title": "Cross-Check: Standard Form at m=4, s=3, r=2",
+    "content": "The companion numeric check for the standard (fixed-upper-index) form. At m=4, s=3, r=2 the identity reads C(7,2) = 21 = C(4,0)·C(3,2) + C(4,1)·C(3,1) + C(4,2)·C(3,0) = 3 + 12 + 6, again confirmed by `native_decide`. Placing the rising and standard checks side by side in the same `range`-sum convention makes the structural parallel concrete: identical sum shape, the sole difference being whether the upper indices stay fixed (4, 3) or co-vary (a+i, b+(n-i)).",
+    "mathContext": "$\\binom{4+3}{2}=\\binom{7}{2}=21=\\sum_{j=0}^{2}\\binom{4}{j}\\binom{3}{2-j}=\\binom{4}{0}\\binom{3}{2}+\\binom{4}{1}\\binom{3}{1}+\\binom{4}{2}\\binom{3}{0}=3+12+6=21$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "native_decide",
+      "Vandermonde's identity",
       "numeric verification"
     ],
     "prerequisites": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/meta.json
@@ -55,7 +55,8 @@
       "The standard and rising Vandermonde are the *same* identity over $\\mathbb{Z}$, linked by upper negation $\\binom{a+i}{i} = (-1)^i\\binom{-a-1}{i}$: applying it twice turns the rising convolution into a standard Vandermonde at negative upper index $\\binom{-a-b-2}{n}$, which negates back to $\\binom{a+b+n+1}{n}$.",
       "The distinction is purely a matter of which index is fixed: the standard form fixes the upper indices $m, s$; the rising form lets them co-vary as $a+i, b+j$ with the summation variable.",
       "In generating-function language the rising convolution is $[x^n]\\,(1-x)^{-(a+1)}(1-x)^{-(b+1)}$, the $(1+x) \\leftrightarrow (1-x)^{-1}$ dual of the standard Vandermonde $[x^r]\\,(1+x)^m(1+x)^s$.",
-      "Mathlib supplies the standard form for free (`Nat.add_choose_eq`) but not the rising form — the rising convolution must be obtained by the parent's $\\mathbb{N}$-native induction, since the slick $\\mathbb{Z}$ upper-negation proof would require negative-upper-index binomials Mathlib lacks."
+      "Mathlib supplies the standard form for free (`Nat.add_choose_eq`) but not the rising form — the rising convolution must be obtained by the parent's $\\mathbb{N}$-native induction, since the slick $\\mathbb{Z}$ upper-negation proof would require negative-upper-index binomials Mathlib lacks.",
+      "Combinatorially the rising form needs no generating function at all: $\\binom{a+i}{a}$ counts size-$i$ multisets from $a+1$ types (stars and bars), so $\\sum_{i+j=n}\\binom{a+i}{a}\\binom{b+j}{b}=\\binom{a+b+n+1}{a+b+1}$ says that choosing a size-$n$ multiset from $a+b+2$ types is the same as splitting the types into a first block of $a+1$ and a second block of $b+1$ and summing over how many of the $n$ picks fall in each block — a direct bijective reading of the convolution."
     ],
     "prerequisites": [
       "Binomial coefficients",


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-02`.

## Improvements
- **Annotation coverage 4 → 5**: split the single bundled `native_decide` cross-check annotation into two — one for the rising form (a=b=1, n=2) and one for the standard form (m=4, s=3, r=2). Each is now anchored on its own `example` construct (lines 90 and 98) and carries distinct `mathContext`, so the rising/standard parallel reads cleanly side by side.
- **Axiom-integrity note**: made explicit *why* the numeric checks are kept as throwaway `example`s — discharging them with `native_decide` inside the headline theorems would pull in the `Lean.ofReduceBool` axiom, so isolating them preserves the 0-axiom status of `rising_vandermonde` / `standard_vandermonde`.
- **keyInsights 4 → 5**: added the combinatorial (stars-and-bars / multiset) bijective reading of the rising convolution, complementing the existing upper-negation and generating-function insights with a proof that needs no GF machinery.

No `index.ts` added: this gallery bundles entries from JSON at build time (only 3 of 2527 dirs carry `index.ts`); the role doc's Vite-glob note is stale for this codebase.

Status/badge/axiomCount unchanged and verified accurate against the Lean source (verified, original, axiomCount 0; the two headline theorems are axiom-free, native_decide only in disposable examples).