### PR TITLE
Enrich 2 gallery entries: Möbius–Floor Identity + Fermat Two-Squares (odd primes)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/annotations.json
@@ -55,7 +55,7 @@
     "title": "Floor as a Cardinality of Multiples",
     "content": "The only analytic-looking object, `⌊N/d⌋`, is purely combinatorial: it is the **number of multiples of `d` in `{1,…,N}`**.\n\n- `hIcc` normalises `Finset.Icc 1 N = Finset.Ioc 0 N` (matching the counting lemma's interval), by `ext` + `omega`.\n- `hcard` proves `#{k ∈ Icc 1 N : d ∣ k} = N / d` via `Nat.Ioc_filter_dvd_card_eq_div`.\n- `key` rewrites each term `μ(d)·⌊N/d⌋` as the indicator sum `∑_{k ∈ Icc 1 N} (if d ∣ k then μ d else 0)` using `Finset.sum_ite` and `Finset.sum_const`.\n\nThis converts the whole left-hand side into a double sum of Möbius values over the hyperbola region $\\{(d,k) : d \\mid k \\le N\\}$.",
     "mathContext": "μ(d)·⌊N/d⌋ = ∑ over the multiples of d up to N of the constant μ(d). The floor disappears into a count of lattice points under a hyperbola.",
-    "significance": "important",
+    "significance": "supporting",
     "prerequisites": [
       "Nat.Ioc_filter_dvd_card_eq_div",
       "Finset.sum_ite, Finset.sum_const"
@@ -88,6 +88,28 @@
       "Dirichlet convolution",
       "μ ∗ ζ = δ",
       "Möbius inversion"
+    ]
+  },
+  {
+    "id": "cb04oq0101-setup",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 106
+    },
+    "type": "context",
+    "title": "Imports, Options, and the Möbius/Zeta Namespace",
+    "content": "The preamble wires up the four Mathlib hooks the proof relies on:\n\n- `import Mathlib` pulls in the entire library — in particular `ArithmeticFunction.moebius`, `ArithmeticFunction.zeta`, `Nat.Ioc_filter_dvd_card_eq_div`, and the Dirichlet-convolution lemma `moebius_mul_coe_zeta`.\n- `open ArithmeticFunction` and `open scoped ArithmeticFunction.Moebius` bring the notations `μ` (Möbius) and `ζ` (the constant-1 arithmetic function) into scope, so the statement can be written `∑ d, μ d * …` rather than spelled out.\n- `set_option maxHeartbeats 1000000` and `maxRecDepth 4000` give the elaborator headroom for the `simp`/`omega` discharges in the divisor-set equality; `autoImplicit false` enforces explicit binders (the recommended hygiene for gallery proofs).\n\nThe single hypothesis is `N ≥ 1`; nothing here imports the parent `ChebyshevBoundsOQ04.lean`, so the two deep PNT axioms it carries (`chebyshevPsi_asymptotic`, `pnt_equivalence`) do not leak into this file — keeping it genuinely 0-axiom.",
+    "mathContext": "The proof's entire arithmetic input is the Dirichlet identity μ ∗ ζ = δ, supplied by `ArithmeticFunction.moebius_mul_coe_zeta`; everything else is `Finset` bookkeeping.",
+    "significance": "context",
+    "prerequisites": [
+      "Lean 4 imports and set_option configuration",
+      "ArithmeticFunction.moebius and zeta notation"
+    ],
+    "relatedConcepts": [
+      "Mathlib ArithmeticFunction library",
+      "scoped notation",
+      "axiom hygiene"
     ]
   }
 ]

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/meta.json
@@ -63,6 +63,14 @@
       "mathContext": "The identity is the integer-valued keystone of Iter 5a-β-2 (weak Mertens M₁ estimate) on the parent file's Selberg–Erdős road to ψ(x)/x → 1."
     },
     {
+      "id": "setup",
+      "title": "Imports, Options, and Namespace",
+      "startLine": 93,
+      "endLine": 106,
+      "summary": "`import Mathlib` plus `open ArithmeticFunction` / `open scoped ArithmeticFunction.Moebius` bring the `μ` and `ζ` notations and the four confirmed hooks into scope; `set_option maxHeartbeats 1000000` / `maxRecDepth 4000` give the elaborator headroom for the divisor-set `simp`/`omega` discharges, and `autoImplicit false` enforces explicit binders. No parent file is imported, so the two deep PNT axioms stay out of this proof's closure.",
+      "mathContext": "The only arithmetic input is μ ∗ ζ = δ (`moebius_mul_coe_zeta`); the rest is Finset bookkeeping."
+    },
+    {
       "id": "theorem",
       "title": "moebius_mul_floor_sum_eq_one",
       "startLine": 107,

--- a/src/data/proofs/infinitude-primes-4k1-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-01/annotations.json
@@ -56,7 +56,7 @@
     "title": "Forward direction via Mathlib's Nat.Prime.sq_add_sq",
     "content": "The hard direction is delegated to Mathlib. After supplying the `Fact p.Prime` instance, p % 4 = 1 is rewritten to p % 4 ≠ 3 by `omega`, which is exactly the hypothesis of `Nat.Prime.sq_add_sq`. That theorem then produces a, b with a² + b² = p, and `.symm` flips it to p = a² + b². All the genuine number-theoretic depth — that −1 is a quadratic residue mod p ≡ 1 (mod 4) and the ensuing descent / Gaussian-integer factorization — lives inside the Mathlib lemma; this file consumes it as a black box.",
     "mathContext": "$p \\bmod 4 = 1 \\Rightarrow p \\bmod 4 \\ne 3 \\xRightarrow{\\text{Mathlib}} \\exists a\\,b,\\ a^2 + b^2 = p$",
-    "significance": "high",
+    "significance": "supporting",
     "relatedConcepts": [
       "infinite descent",
       "Fact typeclass instances",
@@ -79,7 +79,7 @@
     "title": "Backward direction: oddness + squares-mod-4 force p ≡ 1 (mod 4)",
     "content": "The elementary converse. From p = a² + b² the proof reduces p mod 4 and p mod 2 to the corresponding residues of a² + b². The lemma `sq_mod_four` pins a² % 4, b² % 4 ∈ {0,1}; the parity reductions a² % 2 = (a % 2)² % 2 and the same for b (via `Nat.pow_mod`) pin the mod-2 picture. Crucially, p is odd (`Nat.Prime.eq_two_or_odd` with p ≠ 2 gives p % 2 = 1), which rules out the sum being 0 or 2 mod 4. `omega` assembles these constraints and concludes p % 4 = 1 — no quadratic reciprocity required.",
     "mathContext": "$p = a^2 + b^2,\\ p\\ \\text{odd} \\Rightarrow p \\bmod 4 = 1$",
-    "significance": "high",
+    "significance": "supporting",
     "relatedConcepts": [
       "parity of sums of squares",
       "case analysis mod 4 and mod 2",
@@ -102,7 +102,7 @@
     "title": "Why both halves are needed for the sharp statement",
     "content": "Mathlib states Fermat's two-squares result asymmetrically: Nat.Prime.sq_add_sq gives only the existence direction (p % 4 ≠ 3 ⇒ p is a sum of two squares). On its own that does not characterize which primes are sums of two squares — it would also (vacuously) cover any non-3-residue. Pairing it with the elementary converse proved here (a sum of two squares can be 0, 1, or 2 mod 4, and oddness selects 1) upgrades the one-way implication to the biconditional p % 4 = 1 ↔ representable. This is the local representability fact that, summed over primes, drives the infinitude of primes ≡ 1 (mod 4).",
     "mathContext": "Mathlib gives $\\Rightarrow$; this file adds $\\Leftarrow$ to obtain $\\iff$.",
-    "significance": "medium",
+    "significance": "context",
     "relatedConcepts": [
       "biconditional vs one-directional lemmas",
       "infinitude of primes ≡ 1 (mod 4)",

--- a/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
@@ -79,6 +79,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Imports, Module Docstring, and Provenance",
+      "startLine": 1,
+      "endLine": 52,
+      "mathContext": "$p\\ \\text{odd prime} \\Rightarrow \\big(p \\equiv 1 \\pmod 4 \\iff \\exists a\\,b,\\ p = a^2 + b^2\\big)$",
+      "summary": "Imports (Nat.Prime.Basic, ZMod.Basic, NumberTheory.SumTwoSquares, Tactic), the module docstring, and provenance. The docstring is explicit that this odd-prime-only result is a pedagogical wrapper superseded by Proofs/FermatTwoSquares.lean, which proves the strictly stronger biconditional (∃ a b, a²+b² = p) ↔ p % 4 ≠ 3 (also covering p = 2) plus the full classification corollaries under the gallery slug fermat-two-squares. Both files share the Mathlib bearer Nat.Prime.sq_add_sq and the interval_cases (n % 4) + Nat.pow_mod squares-mod-4 step. The namespace opens Nat."
+    },
+    {
       "id": "squares-mod-four",
       "title": "Squares Are 0 or 1 mod 4",
       "startLine": 54,


### PR DESCRIPTION
Two enrichment passes (both content-only JSON, no Lean changes).

## 1. chebyshev-bounds-oq-04-oq-01-oq-01 — Möbius–Floor Identity (quality 91)
- **+1 annotation** (`cb04oq0101-setup`): covers the previously un-annotated preamble (lines 94–106) — `import Mathlib`, the `open ArithmeticFunction`/`Moebius` notations bringing `μ`/`ζ` into scope, `set_option` headroom, and axiom-hygiene note. Entry now has 5 annotations.
- **+1 section** (`setup`): fills the lines 93–106 gap between `header` and `theorem`.
- **Schema fix**: `cb04oq0101-count` significance `"important"` → `"supporting"`.

## 2. infinitude-primes-4k1-oq-01 — Fermat Two-Squares for Odd Primes (quality 92)
- **Schema fixes**: `ann-forward-mathlib`/`ann-backward-parity` significance `"high"` → `"supporting"`; `ann-mathlib-bearer-context` `"medium"` → `"context"`.
- **+1 section** (`header`): covers lines 1–52, surfacing the docstring's honest 'superseded by FermatTwoSquares.lean / pedagogical wrapper' framing.

## Integrity
Both entries re-verified `status: verified` / `axiomCount: 0` against source: 0 sorries, 0 axioms, no `native_decide`. The Möbius–floor file does not import its PNT-axiom-bearing parent, keeping its closure clean. JSON validated.