### PR TITLE
Enrich Möbius–Floor Identity (Σ μ(d)⌊N/d⌋ = 1)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01/meta.json
@@ -44,7 +44,8 @@
       "**The floor hides a count.** The only analytic-looking object, `⌊N/d⌋`, is purely combinatorial: it is the number of multiples of `d` up to `N`. Replacing it with that count (`Nat.Ioc_filter_dvd_card_eq_div`) converts the whole identity into a double sum of Möbius values over the hyperbola region `d·m ≤ N`.",
       "**Fubini is the entire trick.** Summing the region `{(d,k) : d ∣ k ≤ N}` by `d` first gives the floor sum; summing by `k` first gives `∑_k ∑_{d∣k} μ(d)`. The two orders are equated by `Finset.sum_comm`, and the second order trivialises.",
       "**μ ∗ ζ = δ does the collapsing.** The inner sum `∑_{d∣k} μ(d)` is the defining property of the Möbius function as the Dirichlet inverse of `ζ = 1`: it equals `1` for `k = 1` and `0` otherwise. Mathlib packages this as `moebius_mul_coe_zeta`, so the calc chain ends in one rewrite.",
-      "**Integer-valued half of weak Mertens.** Keeping everything in ℤ (rather than passing to ℝ) makes the identity exact and reusable: the real-valued bound `|∑ μ(d)/d| ≤ 1` follows by writing `⌊N/d⌋ = N/d − {N/d}` and bounding the fractional parts, with no further number theory."
+      "**Integer-valued half of weak Mertens.** Keeping everything in ℤ (rather than passing to ℝ) makes the identity exact and reusable: the real-valued bound `|∑ μ(d)/d| ≤ 1` follows by writing `⌊N/d⌋ = N/d − {N/d}` and bounding the fractional parts, with no further number theory.",
+      "**Dirichlet's hyperbola, weighted by μ.** The double sum ranges over the lattice points `(d,m)` with `d·m ≤ N` — exactly Dirichlet's hyperbola, the same region whose unweighted count gives the divisor-sum asymptotic `∑_{n≤N} d(n)`. Weighting those points by `μ(d)` and summing along the `m`-fibres telescopes the entire region down to the single point `(1,1)`, which is what makes the answer the constant `1` independent of `N`."
     ],
     "prerequisites": [
       "Number theory (Möbius function, Dirichlet convolution, μ ∗ ζ = δ)",


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-04-oq-01-oq-01`.

## Improvements
- **Type-conformance fix**: one annotation carried `significance: "important"`, which is not in the canonical `AnnotationSignificance` union (`critical | key | supporting`, per `src/types/proof.ts`; only 6 such strays exist gallery-wide). Normalized to `key` — the floor-as-count realization is a key step.
- **keyInsights 4 → 5**: added the Dirichlet-hyperbola framing — the double sum ranges over lattice points `(d,m)` with `d·m ≤ N` (the same hyperbola behind the divisor-sum asymptotic `∑ d(n)`), and weighting by `μ(d)` telescopes the whole region to the single point `(1,1)`, which is why the answer is the constant 1 independent of N.

Verified the 4 annotations and 4 sections are already correctly anchored to `ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly.lean` (docstring 1-92, theorem from 107). Status/badge/axiomCount unchanged and accurate (verified, original, axiomCount 0 — Mathlib-only, no native_decide; independent of the parent's PNT axioms). Build resolver reports zero errors for this entry.