### PR TITLE
Enrich Carnot's Theorem angle form (carnot-theorem-oq-01)

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01/annotations.json
+++ b/src/data/proofs/carnot-theorem-oq-01/annotations.json
@@ -31,7 +31,7 @@
     "title": "Carnot's Theorem (Angle Form)",
     "content": "The headline theorem carnot_cos_sum: for any reals A, B, C summing to π, cos A + cos B + cos C = 1 + 4 sin(A/2)sin(B/2)sin(C/2). Stated for arbitrary reals (not just triangle angles), so the result is a clean trigonometric identity rather than a geometric one.",
     "mathContext": "$A + B + C = \\pi \\implies \\cos A + \\cos B + \\cos C = 1 + 4\\sin\\tfrac{A}{2}\\sin\\tfrac{B}{2}\\sin\\tfrac{C}{2}.$",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Carnot's theorem", "half-angle identities", "angle sum constraint"],
     "prerequisites": ["trigonometry", "real analysis"]
   },
@@ -67,7 +67,7 @@
     "title": "Companion: Fundamental Cosine Identity",
     "content": "carnot_cos_sq_sum proves the polynomial companion cos²A + cos²B + cos²C + 2cosA cosB cosC = 1. Writing C = π − A − B gives cos C = −cos(A+B) = −(cosA cosB − sinA sinB) via Real.cos_pi_sub and Real.cos_add; substituting and applying linear_combination against the Pythagorean identities for A and B finishes it. This degree-2 form is the algebraic twin of the angle form.",
     "mathContext": "$\\cos^2 A + \\cos^2 B + \\cos^2 C + 2\\cos A\\cos B\\cos C = 1.$",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["cosine addition formula", "supplementary angle", "Pythagorean identity"],
     "prerequisites": ["trigonometric identities", "polynomial algebra"]
   }

--- a/src/data/proofs/carnot-theorem-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01/meta.json
@@ -61,26 +61,34 @@
   },
   "sections": [
     {
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 31,
+      "description": "import Mathlib, the module docstring deriving the angle form cos A + cos B + cos C = 1 + r/R from the signed-distance statement and Euler's inradius formula r/R = 4 sin(A/2) sin(B/2) sin(C/2), and `open Real` / `namespace CarnotTheorem`.",
+      "summary": "Imports and module docstring",
+      "id": "header"
+    },
+    {
       "title": "Double-angle helper",
-      "startLine": 39,
-      "endLine": 43,
-      "description": "The sin-form double-angle identity cos(2x) = 1 - 2 sin²x, derived from Mathlib's cos_two_mul' and the Pythagorean identity.",
+      "startLine": 33,
+      "endLine": 36,
+      "description": "The private helper cos_two_mul_sin: the sin-form double-angle identity cos(2x) = 1 - 2 sin²x, derived from Mathlib's Real.cos_two_mul' and the Pythagorean identity Real.cos_sq_add_sin_sq.",
       "summary": "Double-angle helper",
       "id": "double-angle-helper"
     },
     {
       "title": "Carnot's Theorem — angle form",
-      "startLine": 45,
-      "endLine": 72,
-      "description": "The main identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2). Express sin(C/2) via A/2, B/2 using C/2 = π/2 - (A/2 + B/2); rewrite each cosine in 1 - 2 sin² form; close by linear_combination modulo the Pythagorean identities.",
+      "startLine": 38,
+      "endLine": 62,
+      "description": "The main theorem carnot_cos_sum (docstring 38-44, proof 45-62): cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2). Express sin(C/2) via A/2, B/2 using C/2 = π/2 - (A/2 + B/2); rewrite each cosine in 1 - 2 sin² form; close by a single linear_combination modulo the Pythagorean identities.",
       "summary": "Carnot's Theorem — angle form",
       "id": "carnot-theorem-angle-form"
     },
     {
       "title": "Fundamental triangle cosine identity",
-      "startLine": 74,
-      "endLine": 81,
-      "description": "The companion polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1, via cos C = -cos(A+B) and a linear_combination.",
+      "startLine": 64,
+      "endLine": 79,
+      "description": "The companion theorem carnot_cos_sq_sum (docstring 64-70, proof 71-79): cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1, via cos C = -cos(A+B) and a linear_combination of the Pythagorean identities for A and B.",
       "summary": "Fundamental triangle cosine identity",
       "id": "fundamental-triangle-cosine-identity"
     }


### PR DESCRIPTION
Enrichment pass for `carnot-theorem-oq-01` (quality 94, pass 0). Primarily an accuracy fix.

## Changes
- **Section line numbers corrected** (the main fix): the `sections` ranges were misaligned with the source. `double-angle-helper` claimed lines 39–43 but `cos_two_mul_sin` is at **33–36**; `carnot-theorem-angle-form` 45–72 → **38–62** (the real theorem span, was overlapping into the next theorem's docstring); `fundamental-triangle-cosine-identity` 74–81 → **64–79**. Verified each against `Proofs/CarnotTheorem.lean`. The annotations were already correctly aligned; only the sections were off.
- **+1 section** (`header`, 1–31): covers imports + module docstring + namespace, previously uncovered.
- **Schema fix**: two annotations used `significance: "critical"` (not in the `key|supporting|technical|context` enum) → `"key"`.

## Integrity
`status: verified` / `axiomCount: 0` confirmed: 0 sorries, 0 axioms, no `native_decide`; both theorems close by `linear_combination` over Mathlib trig primitives. Content-only JSON edits; no Lean changes.