### PR TITLE
audit(tracker): record keith-number-oq-01 audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15849,6 +15849,12 @@
       "lastAudited": "2026-06-18T04:15:22Z",
       "result": "clean",
       "issues": []
+    },
+    "keith-number-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — keith-number-oq-01

Independent audit of the freshly-merged keith-number-oq-01 (#25376). Verdict: **CLEAN**.

### Claims vs. reality

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | `verified` | 0 sorry, 0 axiom | ✓ |
| badge | `original` | novel `IsKeith` predicate + custom decidable | ✓ |
| sorries | 0 | 0 (no `sorry`/`admit` tactics) | ✓ |
| axiomCount | 0 | kernel `decide`, **not** `native_decide` | ✓ |

### Key verification

- `KeithNumberOQ01.lean` has 3 real theorems (`keith_fourteen`, `not_keith_below_fourteen`, `smallest_keith`); none are `True` stubs.
- The lone `native_decide` grep hit is **docstring prose** (line 23: "no `native_decide`"). The proofs use kernel `decide`, which reduces in the kernel and carries **no** `Lean.ofReduceBool` axiom → `verified`/`axiomCount: 0` is correct (per project convention distinguishing kernel `decide` from `native_decide`).
- The `assumptions` field honestly documents the deliberate use of a fuel-bounded `lsdDigits` (instead of `Nat.digits`) precisely so the kernel can reduce the decision procedure.
- Badge `original` is defensible: `IsKeith` and its `DecidablePred` instance are absent from Mathlib.

No overclaiming found. Tracker updated (clean).

---
Discovered during autonomous gallery integrity audit loop.