### PR TITLE
Enrich Fermat's Two-Squares Theorem for Odd Primes

### DIFF
--- a/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1-oq-01/meta.json
@@ -68,7 +68,8 @@
       "**Squares are 0 or 1 mod 4**: n² % 4 ∈ {0, 1} (lemma sq_mod_four) is the entire obstruction — a sum of two squares is 0, 1, or 2 mod 4, never 3, so once the sum is known odd it must be 1 mod 4",
       "**The sharp biconditional needs both halves**: Mathlib's Nat.Prime.sq_add_sq gives only p % 4 ≠ 3 ⇒ representable; the converse (representable ⇒ the right residue) is the elementary mod-4 computation supplied here, and only together do they pin down p ≡ 1 (mod 4)",
       "**Nat.pow_mod turns residue claims into finite case splits**: rewriting n² % 4 as (n % 4)² % 4 reduces an infinite family of squares to four cases n % 4 ∈ {0,1,2,3}, each closed by omega — the same device handles the parity step mod 2",
-      "**Oddness of p does the disambiguation**: a sum of two squares can be 0, 1, or 2 mod 4; the prime's oddness (p % 2 = 1) rules out 0 and 2, leaving exactly 1"
+      "**Oddness of p does the disambiguation**: a sum of two squares can be 0, 1, or 2 mod 4; the prime's oddness (p % 2 = 1) rules out 0 and 2, leaving exactly 1",
+      "**The n = 1 case of a uniform norm-form pattern**: deciding which primes a form x² + ny² represents always factors into an easy congruence obstruction (which residues mod 4n are even possible — here squares-mod-4 forbid p ≡ 3) and a hard converse (every allowed prime is actually represented), the converse needing genus/class-field theory in general. For n = 1 that converse is precisely Mathlib's Nat.Prime.sq_add_sq, so this proof contributes the elementary obstruction half of a theorem whose deep half the library already supplies"
     ],
     "prerequisites": [
       "Modular arithmetic: residues mod 4 and mod 2, and the reduction n^k % m = (n % m)^k % m",


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-4k1-oq-01`.

## Improvements
- **keyInsights 4 → 5**: added the observation that this is the n = 1 case of the uniform `x² + ny²` representability pattern — an easy congruence obstruction (squares mod 4 forbid p ≡ 3) plus a hard converse (every allowed prime is represented, here `Nat.Prime.sq_add_sq`), the converse needing genus/class-field theory in general. This directly connects to the entry's existing open question about `x²+2y²` (p ≡ 1,3 mod 8) and `x²+3y²` (p ≡ 1 mod 3).

Verified the 5 annotations and 3 sections are already accurately anchored to `InfinitudePrimes4k1OQ01.lean` (docstring 1-52, `sq_mod_four` 54-59, `fermat_two_squares` 61-91) and all `significance` values are valid. Status/badge unchanged (verified, badge `mathlib`, axiomCount 0 — the hard direction is Mathlib's bearer, backward is elementary; 0 sorries/axioms). Build resolver reports zero errors for this entry.