### PR TITLE
Enrich Hilbert Finiteness for Finite-Group Invariant Rings

### DIFF
--- a/src/data/proofs/hilbert-14-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-14-oq-04/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "hilbert-14-oq-04-header",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 3,
+      "endLine": 31
+    },
+    "type": "context",
+    "title": "OQ-04 Framing: From an Unformalizable Meta-Question to a Concrete Target",
+    "content": "The docstring is explicit that the headline OQ-04 — the existence of *uniform effective algorithms* for finite generation of non-reductive invariant rings — is not expressible as a single Lean theorem, since it quantifies over infinite classes of groups. Rather than state a vacuous placeholder, the file scaffolds the algorithmically refinable sibling target: **Hilbert finiteness** for invariant rings of finite-group linear actions on `MvPolynomial`. The docstring pins the exact proof architecture as a chain of five Mathlib bearers (`Algebra.IsInvariant`, `IsInvariant.isIntegral`, `FiniteType.of_restrictScalars_finiteType`, `IsIntegral.finite`, and Artin-Tate `fg_of_fg_of_fg`), all signatures fixed at the v4.26.0 lake SHA. The Scope block draws the IN/OUT line honestly: the qualitative finiteness is proved; Noether's degree bound (`gens ⊆ deg ≤ |G|`), Weitzenböck's locally nilpotent derivations, and the Nagata counterexample are all deferred. This is a model of recording an open question's *formalizable shadow* without overclaiming the question itself.",
+    "mathContext": "OQ-04 (uniform algorithms over infinite group classes) is not a single Lean statement; the formalizable shadow is $R^G$ finitely generated for each finite $G$ — the qualitative half of Noether 1916.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's 14th problem",
+      "non-reductive invariant theory",
+      "Noether's finiteness theorem (1916)",
+      "Nagata counterexample",
+      "formalizable vs unformalizable open questions"
+    ],
+    "prerequisites": [
+      "invariant rings R^G",
+      "finite generation of k-algebras",
+      "Mathlib invariant-theory API"
+    ]
+  },
+  {
     "id": "hilbert-14-oq-04-isinvariant",
     "proofId": "hilbert-14-oq-04",
     "range": {


### PR DESCRIPTION
Enrichment pass for `hilbert-14-oq-04`.

## Improvements
- **Annotation coverage 5 → 6**: added a `context` annotation over the module docstring (lines 3-31), which was the only uncovered section. It explains the OQ-04 framing — that the headline question (uniform effective algorithms for finite generation of non-reductive invariant rings, quantified over infinite group classes) is *not* a single formalizable Lean theorem, and that the file instead formalizes its concrete shadow, Hilbert finiteness for finite-group linear actions. It records the five-bearer Mathlib proof architecture (`Algebra.IsInvariant` → `isIntegral` → `of_restrictScalars_finiteType` → `IsIntegral.finite` → Artin-Tate `fg_of_fg_of_fg`) and the honest IN/OUT scope (Noether degree bound, Weitzenböck, Nagata all deferred).

Verified the existing 5 annotations, 3 sections, and 5 keyInsights are accurately anchored to `Hilbert14OQ04.lean` (header 1-40, two instances 42-58, theorem 60-99). Status/badge unchanged and accurate (verified, badge `mathlib`, axiomCount 0 — assembly of Mathlib bearers, 0 sorries; `hilbert_finiteness` fully proved). Build resolver reports zero errors for this entry.