### PR TITLE
Enrich Hilbert 14 finite-group finiteness (hilbert-14-oq-04)

### DIFF
--- a/src/data/proofs/hilbert-14-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-14-oq-04/annotations.json
@@ -93,5 +93,25 @@
       "modular invariant theory"
     ],
     "mathContext": "Finite $\\Rightarrow$ f.g. invariants (Noether); unipotent $\\not\\Rightarrow$ f.g. (Nagata 1959)."
+  },
+  {
+    "id": "hilbert-14-oq-04-setup",
+    "proofId": "hilbert-14-oq-04",
+    "range": {
+      "startLine": 3,
+      "endLine": 40
+    },
+    "type": "context",
+    "title": "Scope: From the OQ-04 Meta-Question to a Formalizable Sibling",
+    "content": "The docstring is careful about what is and is not being proved. OQ-04 itself — the existence of *effective uniform algorithms* for finite generation of *non-reductive* invariant rings — is not expressible as a single Lean theorem, since it quantifies over infinite classes of groups. This file instead formalizes the algorithmically refinable sibling: Hilbert finiteness for finite-group linear actions on `MvPolynomial`, the qualitative half of Noether 1916. The proof is a pinned chain of five Mathlib bearers (`Algebra.IsInvariant`, `.isIntegral`, `Algebra.FiniteType.of_restrictScalars_finiteType`, `Algebra.IsIntegral.finite`, and Artin-Tate `fg_of_fg_of_fg`), all signatures fixed at v4.26.0. The `variable` block sets the stage: a field `k`, finitely many indeterminates `Fin n`, a finite group `G` acting `MulSemiringAction`-ly on `MvPolynomial (Fin n) k`, with `SMulCommClass` ensuring the action is `k`-linear. Explicitly out of scope: Noether's degree bound (deg ≤ |G|), Weitzenböck/locally-nilpotent derivations, and the Nagata counterexample.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's 14th problem",
+      "Noether 1916",
+      "MulSemiringAction",
+      "SMulCommClass",
+      "Mathlib bearer chain"
+    ],
+    "mathContext": "Setup: $G$ finite acting $k$-linearly on $R = k[x_0,\\dots,x_{n-1}]$; goal $R^G$ finitely generated over $k$. The OQ-04 meta-conjecture (uniform algorithms, non-reductive case) is not a single formalizable statement."
   }
 ]


### PR DESCRIPTION
Enrichment pass for `hilbert-14-oq-04` (quality 96). Branched off current main.

## Changes
- **+1 annotation** (`hilbert-14-oq-04-setup`, lines 3–40): fills the only un-annotated region (the module docstring + `variable` block; annotations previously started at line 42). It documents the scope distinction that makes this entry honest — **OQ-04's meta-conjecture** (effective uniform algorithms for non-reductive invariant generation) is *not* a single formalizable Lean theorem, so the file instead proves the formalizable sibling: finite-group Hilbert finiteness (the qualitative half of Noether 1916). Lists the five pinned Mathlib bearers, the `k`-linear finite-group-action setup, and the explicit out-of-scope items (degree bound, Weitzenböck, Nagata). Entry now has 6 annotations.

## Integrity
`status: verified` / `axiomCount: 0` confirmed against `Proofs/Hilbert14OQ04.lean` (100 lines): 0 sorries, 0 axioms, no `native_decide`; `badge: mathlib` is accurate (the proof chains Mathlib bearers). The new annotation reinforces that the open meta-question is *not* claimed as proved. Content-only JSON edit; no Lean changes.