### PR TITLE
research(erdos-1047-oq-02): close last sorry in Goodman counterexample certificate (build-green, registered)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -822,6 +822,7 @@ import Proofs.Erdos1045Problem
 import Proofs.Erdos1046Problem
 import Proofs.Erdos1047Problem
 import Proofs.Erdos1047OQ02
+import Proofs.Erdos1047OQ02Certificate
 import Proofs.Erdos1047OQ02Reduction
 import Proofs.Erdos1048Aristotle
 import Proofs.Erdos1048Problem

--- a/proofs/Proofs/Erdos1047OQ02Certificate.lean
+++ b/proofs/Proofs/Erdos1047OQ02Certificate.lean
@@ -18,19 +18,20 @@
 
   The arc is the 4-segment polyline  −i → (1−i)/2 → 2 → (1+i)/2 → +i.
 
-  STATUS: structural skeleton.  PROVED here (no sorry):
+  STATUS: COMPLETE — no `sorry`.  Build-verified.  PROVED here:
     • endpoint evaluations f(±i) = 0  (the `(z²+1)` factor),
     • the chord-exit estimate  c < ‖f(0)‖ = 4,
     • arc endpoint memberships  −i, +i ∈ C,
-    • the full assembly into `goodman_counterexample_proof` via the bridge.
-  REMAINING (two `sorry`s, fully specified in knowledge.md):
     • `goodmanArc_isPreconnected`  — `IsPreconnected.union` of 4 affine images,
     • `goodmanArc_subset_lemniscate` — the 4 segment inequalities
-      ‖f(z(s))‖ ≤ c, each ⟸ normSq = Re²+Im² ⟸ D=(k/16)·SQ·P (ring) ⟸ Bernstein.
+      ‖f(z(s))‖ ≤ c, each ⟸ normSq = Re²+Im² ⟸ D=(k/16)·SQ·P (ring) ⟸ Bernstein,
+    • the full assembly into `goodman_counterexample_proof` via the bridge.
 
-  This file is an UNREGISTERED orphan (not in `Proofs.lean`): it does NOT yet
-  change the axiom count of the gallery entry.  When the two `sorry`s close and
-  it builds green, a downstream restructure removes the parent axiom.
+  `goodman_counterexample_proof` now has the EXACT statement of the parent file's
+  `goodman_counterexample` axiom, proved with no `sorry` and no new axioms — so the
+  parent axiom is mathematically discharged.  This file remains an UNREGISTERED
+  orphan (not in `Proofs.lean`); removing the parent `axiom` itself needs a
+  downstream restructure (the parent cannot import this certificate — circular).
 -/
 
 import Proofs.Erdos1047OQ02Reduction
@@ -127,14 +128,152 @@ lemma goodmanArc_isPreconnected : IsPreconnected goodmanArc := by
   have hABC := hAB.union (2 : ℂ) (Or.inr (mem_seg_right _ _)) (mem_seg_left _ _) hC
   exact hABC.union ((1 + Complex.I) / 2) (Or.inr (mem_seg_right _ _)) (mem_seg_left _ _) hD
 
-/-- REMAINING OBLIGATION 2: the polyline lies inside the lemniscate.
-    Per segment `a→b`, with `z(s)=(1−s)•a+s•b`,
-    `‖f(z(s))‖ ≤ c ⟸ ‖f(z(s))‖² ≤ 125/16 ⟸ normSq = Re(s)²+Im(s)²`
-    ⟸ `125/16 − (Re²+Im²) = (k/16)·SQ(s)·P(s)` (ring) with `SQ ≥ 0` (`sq_nonneg`)
-    and `P ≥ 0` (all-nonneg Bernstein coefficients). Tables in knowledge.md. -/
+/-! ## The 4 segment membership inequalities
+
+  Each segment `a→b` lies inside `{‖f‖ ≤ c}`.  The discharge is a uniform,
+  search-free certificate (`research/problems/erdos-1047-oq-02/`):
+
+      ‖f(z(s))‖ ≤ c  ⟸  ‖f(z(s))‖² ≤ 125/16  (`c² = 125/16`)
+                     ⟸  normSq = Re(s)² + Im(s)²   (`Complex.normSq_apply`)
+                     ⟸  125/16 − (Re²+Im²) = (k/16)·SQ(s)·P(s)   (a `ring` identity)
+
+  with `SQ ∈ {s², (1−s)²}` a perfect square and `P` a degree-6 cofactor that is
+  positive on `[0,1]` because it has **all-nonnegative Bernstein coefficients**.
+  So `(k/16)·SQ·P` is a nonnegative ℚ-combination of the monomials
+  `sʲ(1−s)^(8−j)`, and `nlinarith` closes each inequality from the products
+  `mul_nonneg (pow_nonneg hs0 j) (pow_nonneg h1s (8−j))` (`j = 0…8`) — the same
+  hint list works for every segment.  Sympy-verified
+  (`chord_exits_sos_certificate.py`, all identities `True`). -/
+
+/-- `c² = 125/16` (lets the segment work stay over ℚ, avoiding `rpow`). -/
+lemma cval_sq : goodmanCriticalValue ^ 2 = 125 / 16 := by
+  unfold goodmanCriticalValue
+  have key : (5 : ℝ) ^ (3 / 2 : ℝ) = 5 * Real.sqrt 5 := by
+    rw [Real.sqrt_eq_rpow, show (3 / 2 : ℝ) = 1 + 1 / 2 by norm_num,
+      Real.rpow_add (by norm_num : (0 : ℝ) < 5), Real.rpow_one]
+  rw [key, div_pow, mul_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 5)]
+  norm_num
+
+/-- Reduce membership `z ∈ {‖f‖ ≤ c}` to the rational squared bound `normSq ≤ 125/16`. -/
+lemma mem_lemniscate_of_normSq_le {z : ℂ}
+    (h : Complex.normSq (goodmanPolynomial.eval z) ≤ 125 / 16) :
+    z ∈ lemniscate goodmanPolynomial goodmanCriticalValue := by
+  simp only [lemniscate, Set.mem_setOf_eq]
+  have hc0 : (0 : ℝ) ≤ goodmanCriticalValue := by unfold goodmanCriticalValue; positivity
+  nlinarith [Complex.sq_norm (goodmanPolynomial.eval z), h, cval_sq,
+    norm_nonneg (goodmanPolynomial.eval z), hc0]
+
+/-- Segment 1: `−i → (1−i)/2 ⊆ {‖f‖ ≤ c}`. -/
+lemma seg1_subset :
+    seg (-Complex.I) ((1 - Complex.I) / 2) ⊆
+      lemniscate goodmanPolynomial goodmanCriticalValue := by
+  simp only [seg]
+  rintro z ⟨s, ⟨hs0, hs1⟩, rfl⟩
+  refine mem_lemniscate_of_normSq_le ?_
+  have h1s : (0 : ℝ) ≤ 1 - s := by linarith
+  simp only [goodmanPolynomial, eval_mul, eval_add, eval_X, eval_one,
+    eval_sub, eval_ofNat, pow_two, Complex.real_smul, Complex.normSq_apply,
+    Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+    Complex.sub_re, Complex.sub_im, Complex.neg_re, Complex.neg_im,
+    Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+    Complex.one_re, Complex.one_im, Complex.re_ofNat, Complex.im_ofNat,
+    Complex.div_ofNat_re, Complex.div_ofNat_im]
+  nlinarith [mul_nonneg (pow_nonneg hs0 0) (pow_nonneg h1s 8),
+    mul_nonneg (pow_nonneg hs0 1) (pow_nonneg h1s 7),
+    mul_nonneg (pow_nonneg hs0 2) (pow_nonneg h1s 6),
+    mul_nonneg (pow_nonneg hs0 3) (pow_nonneg h1s 5),
+    mul_nonneg (pow_nonneg hs0 4) (pow_nonneg h1s 4),
+    mul_nonneg (pow_nonneg hs0 5) (pow_nonneg h1s 3),
+    mul_nonneg (pow_nonneg hs0 6) (pow_nonneg h1s 2),
+    mul_nonneg (pow_nonneg hs0 7) (pow_nonneg h1s 1),
+    mul_nonneg (pow_nonneg hs0 8) (pow_nonneg h1s 0),
+    sq_nonneg s, sq_nonneg (1 - s), hs0, h1s]
+
+/-- Segment 2: `(1−i)/2 → 2 ⊆ {‖f‖ ≤ c}`. -/
+lemma seg2_subset :
+    seg ((1 - Complex.I) / 2) 2 ⊆
+      lemniscate goodmanPolynomial goodmanCriticalValue := by
+  simp only [seg]
+  rintro z ⟨s, ⟨hs0, hs1⟩, rfl⟩
+  refine mem_lemniscate_of_normSq_le ?_
+  have h1s : (0 : ℝ) ≤ 1 - s := by linarith
+  simp only [goodmanPolynomial, eval_mul, eval_add, eval_X, eval_one,
+    eval_sub, eval_ofNat, pow_two, Complex.real_smul, Complex.normSq_apply,
+    Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+    Complex.sub_re, Complex.sub_im, Complex.neg_re, Complex.neg_im,
+    Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+    Complex.one_re, Complex.one_im, Complex.re_ofNat, Complex.im_ofNat,
+    Complex.div_ofNat_re, Complex.div_ofNat_im]
+  nlinarith [mul_nonneg (pow_nonneg hs0 0) (pow_nonneg h1s 8),
+    mul_nonneg (pow_nonneg hs0 1) (pow_nonneg h1s 7),
+    mul_nonneg (pow_nonneg hs0 2) (pow_nonneg h1s 6),
+    mul_nonneg (pow_nonneg hs0 3) (pow_nonneg h1s 5),
+    mul_nonneg (pow_nonneg hs0 4) (pow_nonneg h1s 4),
+    mul_nonneg (pow_nonneg hs0 5) (pow_nonneg h1s 3),
+    mul_nonneg (pow_nonneg hs0 6) (pow_nonneg h1s 2),
+    mul_nonneg (pow_nonneg hs0 7) (pow_nonneg h1s 1),
+    mul_nonneg (pow_nonneg hs0 8) (pow_nonneg h1s 0),
+    sq_nonneg s, sq_nonneg (1 - s), hs0, h1s]
+
+/-- Segment 3: `2 → (1+i)/2 ⊆ {‖f‖ ≤ c}`. -/
+lemma seg3_subset :
+    seg 2 ((1 + Complex.I) / 2) ⊆
+      lemniscate goodmanPolynomial goodmanCriticalValue := by
+  simp only [seg]
+  rintro z ⟨s, ⟨hs0, hs1⟩, rfl⟩
+  refine mem_lemniscate_of_normSq_le ?_
+  have h1s : (0 : ℝ) ≤ 1 - s := by linarith
+  simp only [goodmanPolynomial, eval_mul, eval_add, eval_X, eval_one,
+    eval_sub, eval_ofNat, pow_two, Complex.real_smul, Complex.normSq_apply,
+    Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+    Complex.sub_re, Complex.sub_im, Complex.neg_re, Complex.neg_im,
+    Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+    Complex.one_re, Complex.one_im, Complex.re_ofNat, Complex.im_ofNat,
+    Complex.div_ofNat_re, Complex.div_ofNat_im]
+  nlinarith [mul_nonneg (pow_nonneg hs0 0) (pow_nonneg h1s 8),
+    mul_nonneg (pow_nonneg hs0 1) (pow_nonneg h1s 7),
+    mul_nonneg (pow_nonneg hs0 2) (pow_nonneg h1s 6),
+    mul_nonneg (pow_nonneg hs0 3) (pow_nonneg h1s 5),
+    mul_nonneg (pow_nonneg hs0 4) (pow_nonneg h1s 4),
+    mul_nonneg (pow_nonneg hs0 5) (pow_nonneg h1s 3),
+    mul_nonneg (pow_nonneg hs0 6) (pow_nonneg h1s 2),
+    mul_nonneg (pow_nonneg hs0 7) (pow_nonneg h1s 1),
+    mul_nonneg (pow_nonneg hs0 8) (pow_nonneg h1s 0),
+    sq_nonneg s, sq_nonneg (1 - s), hs0, h1s]
+
+/-- Segment 4: `(1+i)/2 → +i ⊆ {‖f‖ ≤ c}`. -/
+lemma seg4_subset :
+    seg ((1 + Complex.I) / 2) Complex.I ⊆
+      lemniscate goodmanPolynomial goodmanCriticalValue := by
+  simp only [seg]
+  rintro z ⟨s, ⟨hs0, hs1⟩, rfl⟩
+  refine mem_lemniscate_of_normSq_le ?_
+  have h1s : (0 : ℝ) ≤ 1 - s := by linarith
+  simp only [goodmanPolynomial, eval_mul, eval_add, eval_X, eval_one,
+    eval_sub, eval_ofNat, pow_two, Complex.real_smul, Complex.normSq_apply,
+    Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+    Complex.sub_re, Complex.sub_im, Complex.neg_re, Complex.neg_im,
+    Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+    Complex.one_re, Complex.one_im, Complex.re_ofNat, Complex.im_ofNat,
+    Complex.div_ofNat_re, Complex.div_ofNat_im]
+  nlinarith [mul_nonneg (pow_nonneg hs0 0) (pow_nonneg h1s 8),
+    mul_nonneg (pow_nonneg hs0 1) (pow_nonneg h1s 7),
+    mul_nonneg (pow_nonneg hs0 2) (pow_nonneg h1s 6),
+    mul_nonneg (pow_nonneg hs0 3) (pow_nonneg h1s 5),
+    mul_nonneg (pow_nonneg hs0 4) (pow_nonneg h1s 4),
+    mul_nonneg (pow_nonneg hs0 5) (pow_nonneg h1s 3),
+    mul_nonneg (pow_nonneg hs0 6) (pow_nonneg h1s 2),
+    mul_nonneg (pow_nonneg hs0 7) (pow_nonneg h1s 1),
+    mul_nonneg (pow_nonneg hs0 8) (pow_nonneg h1s 0),
+    sq_nonneg s, sq_nonneg (1 - s), hs0, h1s]
+
+/-- **The polyline lies inside the lemniscate** — the four segments glued. -/
 lemma goodmanArc_subset_lemniscate :
     goodmanArc ⊆ lemniscate goodmanPolynomial goodmanCriticalValue := by
-  sorry
+  unfold goodmanArc
+  exact Set.union_subset
+    (Set.union_subset (Set.union_subset seg1_subset seg2_subset) seg3_subset)
+    seg4_subset
 
 /-! ## Assembly -/
 

--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -867,3 +867,53 @@ Docker recovered: `info: mathlib: cloning` is NORMAL (re-clones source, then pul
 7727 oleans from `lean-mathlib-cache` Azure volume, unpack ~60s); my file compiled in
 8–12s. Memory hard-capped 6144MB via cgroup (host-safe). 3–5 concurrent lean
 containers throughout; small-file build fine.
+
+---
+
+## Session 2026-06-17 (researcher-5) — Certificate.lean COMPLETE + REGISTERED (build-green, 0 sorry)
+
+**Mode**: ACT (Docker up). **Outcome**: the LAST sorry in the Goodman-counterexample
+discharge is CLOSED and machine-checked in the gallery build.
+
+### What shipped
+- Closed `goodmanArc_subset_lemniscate` in `Proofs/Erdos1047OQ02Certificate.lean` —
+  the 4 segment inequalities `‖f(z(s))‖ ≤ c`.  `Erdos1047OQ02Certificate.lean` now
+  has **NO sorry** and proves `goodman_counterexample_proof` (the EXACT statement of
+  the parent's `axiom goodman_counterexample`) with no new axioms.
+- **Registered** it in `Proofs.lean` (after `Erdos1047OQ02`) so the gallery
+  machine-checks it.  `docker-build.sh Proofs.Erdos1047OQ02Certificate` →
+  `Build completed successfully (3060 jobs)`, 0 errors, only cosmetic
+  `unusedSimpArgs` linter notes (shared simp list: `neg_re`/`neg_im` unused on the
+  non-negated segments).
+
+### The proof pattern (validated on a scratch file first, then transcribed ×4)
+Uniform, search-free, per segment `a→b` with `z(s)=(1−s)•a+s•b`, `s∈[0,1]`:
+1. `mem_lemniscate_of_normSq_le`: `‖f(z)‖ ≤ c ⟸ normSq(f z) ≤ 125/16` via
+   `Complex.sq_norm` + `cval_sq` (`c² = 125/16`, proved `5^(3/2)=5√5`) + `nlinarith`
+   (atoms `‖·‖`,`c`; from `N²≤C²`, both `≥0`).
+2. normSq via `simp only [goodmanPolynomial, eval_*, pow_two, Complex.real_smul,
+   Complex.normSq_apply, Complex.{add,mul,sub,neg}_{re,im}, ofReal_{re,im},
+   I_{re,im}, one_{re,im}, re_ofNat, im_ofNat, div_ofNat_re, div_ofNat_im]`
+   → a degree-8 rational inequality in `s`.  KEY lemmas (v4.26): `Complex.sq_norm`
+   (`‖z‖^2 = normSq z`, `Analysis/Complex/Norm.lean`), `Complex.div_ofNat_re/im`
+   (handles `/2` cleanly — avoids messy `Complex.div_re`).  Drop `eval_pow`
+   (`pow_two` does the job and linter flags it unused).
+3. `nlinarith` with the UNIFORM hint list `mul_nonneg (pow_nonneg hs0 j)
+   (pow_nonneg h1s (8−j))` for **j=0…8** (covers both `SQ=s²` and `SQ=(1−s)²`
+   cases) + `sq_nonneg s/(1−s)`.  This is exactly the manifest Bernstein certificate
+   `125/16 − (Re²+Im²) = (1/16)·SQ·P`, `P` all-nonneg-Bernstein.
+
+### Status / honesty
+- `Erdos1047OQ02Certificate.lean`: **verified, 0 sorry, 0 axiom**, registered.
+- The parent `axiom goodman_counterexample` (Erdos1047Problem.lean:184) and its 4
+  transitive consumers (`grunskyConjecture_false`, `erdos_1047`,
+  `erdos_1047_counterexample`, `erdos_1047_answer`) + the registered
+  `Erdos1047OQ02.lean` (uses the axiom at line 90) are UNCHANGED.  So the gallery
+  `meta.json` `axiomCount` stays **1** (honest).  The analytic risk is now zero;
+  flipping axiomCount 1→0 is a purely MECHANICAL flagship restructure (move the 4
+  headline theorems + OQ02's theorem downstream of the certificate, delete the
+  parent axiom — the parent cannot import the certificate, circular).  Deferred:
+  it guts the flagship Main-Results section across 5 files with cascading rebuilds;
+  not safe to attempt blindly under Docker contention in one pass.
+- erdos-1047-oq-02 (the *characterization* OQ) remains OPEN; this discharges the
+  parent's existence axiom, the shared infrastructure all the Goodman work sits on.


### PR DESCRIPTION
## Summary

Closes the **lone remaining `sorry`** in the Goodman-counterexample discharge for Erdős #1047 (Grunsky's convex-lemniscate question), and **registers** the now-complete certificate so the gallery machine-checks it.

`Proofs/Erdos1047OQ02Certificate.lean` now has **no `sorry`** and proves `goodman_counterexample_proof` — the *exact* statement of the parent's `axiom goodman_counterexample` — with **no new axioms**, via the registered topological bridge `componentContaining_lemniscate_not_convex_of_chord_exits` (`Erdos1047OQ02Reduction.lean`).

## What was closed

`goodmanArc_subset_lemniscate`: the 4-segment polyline `−i → (1−i)/2 → 2 → (1+i)/2 → +i` lies inside `{‖f‖ ≤ c}`, i.e. the four degree-8 inequalities `‖f(z(s))‖ ≤ c` on `s ∈ [0,1]`.

Each is the sympy-verified SOS/Bernstein certificate (`chord_exits_sos_certificate.py`) transcribed:

```
‖f(z(s))‖ ≤ c  ⟸  normSq(f z) ≤ 125/16          (c² = 125/16, via 5^(3/2)=5√5)
               ⟸  Re(s)² + Im(s)²                (Complex.normSq_apply)
               ⟸  125/16 − (Re²+Im²) = (1/16)·SQ·P   (a `ring` identity)
```

with `SQ ∈ {s², (1−s)²}` a perfect square and `P` a degree-6 cofactor with **all-nonnegative Bernstein coefficients**, so the gap is a nonnegative ℚ-combination of `sʲ(1−s)^(8−j)`. `nlinarith` closes each segment from the uniform hint list `mul_nonneg (pow_nonneg hs0 j) (pow_nonneg h1s (8−j))`, `j = 0…8` (the same list covers both `SQ=s²` and `SQ=(1−s)²`).

The pattern was validated on a scratch file (segment 1) before transcribing all four.

## Build

```
docker-build.sh Proofs.Erdos1047OQ02Certificate
⚠ [3060/3060] Built Proofs.Erdos1047OQ02Certificate
Build completed successfully (3060 jobs).
```

0 `sorry`, 0 errors. Only cosmetic `linter.unusedSimpArgs` notes (the shared simp list leaves `neg_re`/`neg_im` unused on the non-negated segments). Registered in `Proofs.lean` after `Erdos1047OQ02`.

## Scope / honesty (axiom integrity)

- `Erdos1047OQ02Certificate.lean`: **verified, 0 sorry, 0 axiom**, registered.
- The parent `axiom goodman_counterexample` and its 4 transitive consumers (`grunskyConjecture_false`, `erdos_1047`, `erdos_1047_counterexample`, `erdos_1047_answer`) plus the registered `Erdos1047OQ02.lean` (which still references the axiom) are **unchanged**. The gallery `meta.json` `axiomCount` therefore stays **1** — honest.
- The **analytic risk is now zero**: flipping `axiomCount` 1→0 is a purely *mechanical* restructure (move the headline theorems + OQ02's usage downstream of the certificate and delete the parent `axiom` — the parent can't import the certificate, circular). Deferred here because it guts the flagship Main-Results section across 5 files with cascading rebuilds; not done blindly under Docker contention. Documented in `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)