### PR TITLE
Fix: re-class burnside-counting verified→axiomatized (native_decide)

### DIFF
--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "William Burnside (1897), Cauchy (1845), Frobenius (1887), formalized via Mathlib",
     "date": "1897",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BurnsideCounting.lean",
     "tags": [
       "combinatorics",
@@ -17,11 +17,11 @@
       "group-actions",
       "polya-enumeration"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "Axiom-free: 0 `axiom` declarations, 0 sorries, no assumption-carrying structures. All 5 original axioms are discharged across S1–S4 of burnside-counting-oq-01: rotatedIndex_add (S1 / PR #21148, full Nat-modular proof); coloringSetoid + coloringQuotientFintype (S2, AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance); fixed_point_sum_binary_4 (S3, native_decide); binary_necklaces_4 (S4, native_decide on the computable orbit-quotient cardinality). NOTE: the two finite counts (fixed_point_sum_binary_4, binary_necklaces_4) close by `native_decide`, which trusts the Lean compiler (Lean.ofReduceBool) rather than performing kernel reduction; everything else is kernel-checked. burnside_lemma is a re-export of Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (a theorem, not an assumption).",
+    "axiomCount": 1,
+    "assumptions": "Depends on the `Lean.ofReduceBool` axiom (1 assumption) introduced by `native_decide`; 0 literal `axiom` declarations, 0 sorries, no assumption-carrying structures. All 5 original axioms are discharged across S1–S4 of burnside-counting-oq-01: rotatedIndex_add (S1 / PR #21148, full Nat-modular proof); coloringSetoid + coloringQuotientFintype (S2, AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance); fixed_point_sum_binary_4 (S3, native_decide); binary_necklaces_4 (S4, native_decide on the computable orbit-quotient cardinality). NOTE: the two finite counts (fixed_point_sum_binary_4, binary_necklaces_4) close by `native_decide`, which trusts the Lean compiler (Lean.ofReduceBool) rather than performing kernel reduction; everything else is kernel-checked. burnside_lemma is a re-export of Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (a theorem, not an assumption).",
     "lineCount": 404,
     "theoremCount": 9,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

`burnside-counting` claimed `status: verified` / `badge: verified` / `axiomCount: 0` while its own `assumptions` field admits the proof depends on `Lean.ofReduceBool` via two load-bearing `native_decide` calls. Re-classed to `axiomatized` / `axiom` / `axiomCount: 1` per the codified convention.

## Evidence

- **CLAUDE.md:140** convention: when `native_decide` discharges a substantive result presented as verified, count it — `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, disclose `Lean.ofReduceBool`. (`leanFile.axiomCount` still counts only literal `axiom` decls → stays 0.)
- `BurnsideCounting.lean:354` and `:396` close `fixed_point_sum_binary_4` and `binary_necklaces_4` (core finite counts of the presented result) by `native_decide`.
- The entry's existing `assumptions` text already states these "trust the Lean compiler (Lean.ofReduceBool) rather than performing kernel reduction" — self-contradictory with `verified`/`axiomCount: 0`.
- Same class of fix as #25390 (which normalized 3 sibling families for #25373). This is the analogous residual case surfaced by an automated integrity scan.

**Before**: `status: verified`, `badge: verified`, `axiomCount: 0`, assumptions led with "Axiom-free".
**After**: `status: axiomatized`, `badge: axiom`, `meta.axiomCount: 1`, assumptions lead discloses `Lean.ofReduceBool`. `leanFile.axiomCount` unchanged at 0 (literal decls).

---
Automated fix by lean-mechanic agent.