### PR TITLE
Enrich De Gua's Theorem / 3D Pythagorean (pythagorean-theorem-oq-06)

### DIFF
--- a/src/data/proofs/pythagorean-theorem-oq-06/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-06/annotations.json
@@ -67,7 +67,7 @@
     "title": "de_gua_core — The Core Identity (Edge-Vector Form)",
     "content": "The mathematical heart of the proof. For three vectors u, v, w issuing from a common vertex that are mutually orthogonal (`dot u v = dot v w = dot w u = 0`), the squared cross-product norm of the opposite face equals the sum of the three right-angle faces: `crossSq (v - u) (w - u) = crossSq u v + crossSq v w + crossSq w u`. After `simp` unfolds `crossSq` and `dot`, the goal is a polynomial identity in nine coordinates, discharged by a single `linear_combination`. The three multipliers in the certificate are exactly the orthogonality hypotheses huv, hvw, hwu — algebraically, this is the statement that the Binet–Cauchy cross terms (each a multiple of u·v, v·w, or w·u) cancel. The coefficients were verified numerically over 10⁵ random samples before formalizing.",
     "mathContext": "$u\\cdot v=v\\cdot w=w\\cdot u=0 \\;\\Rightarrow\\; \\operatorname{crossSq}(v-u,\\,w-u)=\\operatorname{crossSq}(u,v)+\\operatorname{crossSq}(v,w)+\\operatorname{crossSq}(w,u)$",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "Binet–Cauchy identity",
       "cross product bilinearity",
@@ -88,7 +88,7 @@
     "title": "de_gua — De Gua's Theorem (Vertex Form)",
     "content": "The headline geometric theorem. For a trirectangular tetrahedron O A B C whose three edges at O are mutually perpendicular, the squared area of the face ABC opposite O equals the sum of the squared areas of the three faces OAB, OBC, OCA meeting at O. The proof rewrites the hypotenuse-face edges B−A and C−A as differences of the corner edges, (B−O)−(A−O) and (C−O)−(A−O), so that `de_gua_core` applied to the corner edges A−O, B−O, C−O discharges the cross-product content; a final `ring` reconciles the ¼ factors. This is the precise three-dimensional analogue of a² + b² = c².",
     "mathContext": "$(A{-}O)\\!\\cdot\\!(B{-}O)=(B{-}O)\\!\\cdot\\!(C{-}O)=(C{-}O)\\!\\cdot\\!(A{-}O)=0 \\Rightarrow \\operatorname{areaSq}(A,B,C)=\\operatorname{areaSq}(O,A,B)+\\operatorname{areaSq}(O,B,C)+\\operatorname{areaSq}(O,C,A)$",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "trirectangular tetrahedron",
       "Pythagorean theorem in 3D",

--- a/src/data/proofs/pythagorean-theorem-oq-06/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-06/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)² when the edges at O are mutually orthogonal.",
+      "summary": "The module docstring stating de Gua's theorem — the 3D Pythagorean analogue for a trirectangular tetrahedron — together with `import Mathlib.Tactic` and `namespace DeGuaTheorem`."
+    },
+    {
       "id": "definitions",
       "title": "Vector Primitives: Dot, Cross-Norm, and Squared Area",
       "startLine": 49,


### PR DESCRIPTION
Enrichment pass for `pythagorean-theorem-oq-06` (quality 96). Branched off current main.

## Changes
- **Schema fix**: two annotations used `significance: "critical"` (`ann-de-gua-core`, `ann-de-gua-vertex`), outside the `key|supporting|technical|context` enum → `"key"`.
- **+1 section** (`header`, 1–48): covers the module docstring + `import Mathlib.Tactic` + namespace, previously uncovered (sections started at line 49).

## Integrity
`status: verified` / `axiomCount: 0` confirmed against `Proofs/DeGuaTheorem.lean` (101 lines): 0 sorries, 0 axioms, no `native_decide`; the core identity closes by `linear_combination` of the three orthogonality hypotheses. The 6 annotations were already correctly line-anchored. Content-only JSON edits; no Lean changes.