### PR TITLE
audit(taylor-theorem-oq-03): correct meta to match Lagrange-based source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13462,10 +13462,10 @@
       "result": "clean"
     },
     "taylor-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T04:45:46Z",
+      "result": "issues-fixed"
     },
     "three-place-identity": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/taylor-theorem-oq-03/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-03/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "taylor-theorem-oq-03",
-  "title": "Taylor Series Convergence of exp via the Cauchy Remainder",
+  "title": "Taylor Series Convergence of exp via the Lagrange Remainder",
   "slug": "taylor-theorem-oq-03",
-  "description": "Proves that the Taylor series of exp converges to exp(x) for all real x, with an explicit convergence rate. Using the Lagrange and Cauchy remainder forms, establishes exp(x) = sum x^n/n!, an error bound |e - S_n(1)| <= 3/n!, and the Cauchy remainder applied to exp.",
+  "description": "Proves that the Taylor series of exp converges to exp(x) for all real x. Connecting Real.exp to Mathlib's NormedSpace.exp power series, establishes exp(x) = sum x^n/n!, the vanishing of the Taylor remainder, an error bound |e - S_n(1)| <= 3/n!, and the Lagrange remainder form applied to exp.",
   "meta": {
-    "author": "Taylor (1715), Lagrange (1797), Cauchy (formalized in Lean 4 with Mathlib)",
+    "author": "Taylor (1715), Lagrange (1797) (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Taylor%27s_theorem",
     "date": "1715",
     "status": "verified",
@@ -22,13 +22,13 @@
     "sorries": 0,
     "mathlibDependencies": [
       {
-        "theorem": "taylor_mean_remainder_cauchy",
-        "description": "Cauchy form of the Taylor remainder",
-        "module": "Mathlib.Analysis.Calculus.Taylor"
+        "theorem": "NormedSpace.exp_eq_tsum",
+        "description": "The exponential is the sum of its power series; bridges Real.exp to sum x^n/n!",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exponential"
       },
       {
-        "theorem": "taylor_mean_remainder_bound",
-        "description": "Uniform bound on Taylor remainder",
+        "theorem": "taylor_mean_remainder_lagrange",
+        "description": "Lagrange form of the Taylor remainder",
         "module": "Mathlib.Analysis.Calculus.Taylor"
       },
       {
@@ -42,39 +42,38 @@
         "module": "Mathlib.Analysis.SpecificLimits.Normed"
       },
       {
-        "theorem": "Real.exp_one_gt_d9",
-        "description": "Lower bound on e (exp 1 > 2.718281828)",
-        "module": "Mathlib.Analysis.Complex.ExponentialBounds"
+        "theorem": "Real.add_one_le_exp",
+        "description": "1 + x <= exp x, used to bound e from below",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
       }
     ],
     "originalContributions": [
       "Proved iteratedDeriv n exp = exp by induction on derivative order",
-      "Defined expPartialSum and proved Taylor partial sums converge to exp for all x",
-      "Proved exp(x) = tsum (x^n/n!) via uniqueness of limits",
-      "Established error bound |e - S_n(1)| <= 3/n! with concrete 10-term precision < 10^{-6}",
-      "Applied Cauchy remainder to exp: explicit xi in (0, x) with remainder = exp(xi)(x-xi)^n/n! * x",
-      "Proved Cauchy remainder bound: |remainder| <= exp(x) * x^{n+1}/n!"
+      "Bridged Real.exp to Mathlib's NormedSpace.exp power series to prove exp(x) = tsum (x^n/n!) and the HasSum form",
+      "Proved Taylor partial sums (over Finset.range) converge to exp for all x, and the Taylor remainder tends to zero",
+      "Established error bound |e - S_n(1)| <= 3/n! by bounding the tail with a geometric series (n! * 2^j <= (n+j)!)",
+      "Applied the Lagrange remainder (taylor_mean_remainder_lagrange) to exp: explicit xi in (0, x) with remainder = iteratedDerivWithin (n+1) exp xi * x^(n+1)/(n+1)!",
+      "Proved e > 2 and the five-term partial sum 1/0! + ... + 1/4! = 65/24"
     ],
     "dateAdded": "2026-03-23",
     "axiomCount": 0,
     "lineCount": 268,
     "theoremCount": 17,
     "definitionCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Core Taylor remainder estimates (taylor_mean_remainder_lagrange, taylor_mean_remainder_cauchy) from Mathlib; original work is exponential convergence analysis.",
+    "assumptions": "0 axioms, 0 sorries. Power-series representation (NormedSpace.exp_eq_tsum) and the Lagrange remainder estimate (taylor_mean_remainder_lagrange) come from Mathlib; original work is the exponential convergence analysis and Euler-number tail bound.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Taylor's theorem (1715) provides the theoretical foundation for polynomial approximation of smooth functions, but the question of *convergence* of the Taylor series is more subtle. A function can be infinitely differentiable yet have a divergent Taylor series (e.g., f(x) = e^{-1/x^2} at x=0 in the real-analytic sense). The exponential function is the prototypical example where convergence succeeds everywhere: since every derivative of exp is exp itself, the Lagrange remainder exp(xi) * |x|^{n+1}/(n+1)! tends to zero because factorial growth dominates any fixed power. This was understood by Euler, who used the series e = sum 1/n! to compute e to arbitrary precision. The Cauchy remainder form, introduced by Augustin-Louis Cauchy in his 1823 Resume des lecons, provides an alternative that is sometimes sharper for bounding the error. This formalization answers the third open question from the parent Taylor's theorem entry (Wiedijk #35): can the Cauchy remainder be used to prove convergence of exp's Taylor series?",
-    "problemStatement": "**Main Results**:\n\n1. $\\frac{d^n}{dx^n} e^x = e^x$ for all $n \\in \\mathbb{N}$\n2. $\\left|e^x - \\sum_{k=0}^{n} \\frac{x^k}{k!}\\right| \\leq \\frac{e^{|x|} \\cdot |x|^{n+1}}{n!} \\to 0$\n3. $e^x = \\sum_{n=0}^{\\infty} \\frac{x^n}{n!}$ (Taylor series equals exp)\n4. $\\left|e - \\sum_{k=0}^{n} \\frac{1}{k!}\\right| \\leq \\frac{3}{n!}$ (error bound for computing $e$)\n5. Cauchy remainder: $\\exists\\,\\xi \\in (0,x),\\; e^x - T_n(x) = \\frac{e^\\xi (x-\\xi)^n}{n!} \\cdot x$",
-    "text": "Proves that the Taylor series of exp converges to exp(x) for all real x, with an explicit convergence rate. Using the Lagrange and Cauchy remainder forms, establishes exp(x) = sum x^n/n!, an error bound |e - S_n(1)| <= 3/n!, and the Cauchy remainder applied to exp.",
-    "proofStrategy": "The key insight is that every derivative of exp is exp itself, so the Lagrange remainder at order n is bounded by exp(|x|) * |x|^{n+1}/n!. Since x^n/n! -> 0 for any fixed x (factorial dominates powers), the remainder vanishes. The proof proceeds in seven sections: (I) prove iteratedDeriv n exp = exp by induction, (II) define Taylor partial sums, (III) establish summability of x^n/n!, (IV) state remainder bounds as axioms and prove the unified bound, (V) show partial sums converge to exp and derive exp = tsum, (VI) compute error bounds for Euler's number e, (VII) apply the Cauchy remainder form to exp with an explicit bound.",
+    "historicalContext": "Taylor's theorem (1715) provides the theoretical foundation for polynomial approximation of smooth functions, but the question of *convergence* of the Taylor series is more subtle. A function can be infinitely differentiable yet have a divergent Taylor series (e.g., f(x) = e^{-1/x^2} at x=0 in the real-analytic sense). The exponential function is the prototypical example where convergence succeeds everywhere: since every derivative of exp is exp itself, the Lagrange remainder exp(xi) * |x|^{n+1}/(n+1)! tends to zero because factorial growth dominates any fixed power. This was understood by Euler, who used the series e = sum 1/n! to compute e to arbitrary precision. The Cauchy remainder form, introduced by Augustin-Louis Cauchy in his 1823 Resume des lecons, provides an alternative that is sometimes sharper for bounding the error. This formalization, the third entry under the parent Taylor's theorem (Wiedijk #35), proves convergence of exp's Taylor series and specializes the Lagrange remainder form to exp; a Cauchy-remainder treatment of exp is left as future work.",
+    "problemStatement": "**Main Results**:\n\n1. $\\frac{d^n}{dx^n} e^x = e^x$ for all $n \\in \\mathbb{N}$\n2. $e^x - \\sum_{k=0}^{n} \\frac{x^k}{k!} \\to 0$ as $n \\to \\infty$ (the Taylor remainder vanishes)\n3. $e^x = \\sum_{n=0}^{\\infty} \\frac{x^n}{n!}$ (Taylor series equals exp)\n4. $\\left|e - \\sum_{k=0}^{n} \\frac{1}{k!}\\right| \\leq \\frac{3}{n!}$ (error bound for computing $e$)\n5. Lagrange remainder (for $x>0$): $\\exists\\,\\xi \\in (0,x),\\; e^x - T_n(x) = \\frac{e^\\xi\\, x^{n+1}}{(n+1)!}$",
+    "text": "Proves that the Taylor series of exp converges to exp(x) for all real x. Connecting Real.exp to Mathlib's NormedSpace.exp power series, establishes exp(x) = sum x^n/n!, the vanishing of the Taylor remainder, an error bound |e - S_n(1)| <= 3/n!, and the Lagrange remainder form applied to exp.",
+    "proofStrategy": "Convergence is obtained directly from Mathlib's power-series representation NormedSpace.exp_eq_tsum: connecting Real.exp to NormedSpace.exp shows e^x = sum x^n/n!, with summability inherited from summable_pow_div_factorial. From this the partial sums converge to e^x and the Taylor remainder tends to zero. The file also records that every derivative of exp is exp (by induction), states the Lagrange remainder for exp by specializing Mathlib's taylor_mean_remainder_lagrange (no axioms are introduced), and analyses the Euler number e = sum 1/n!, proving the tail bound |e - S_n(1)| <= 3/n! by dominating the tail with a geometric series (using n! * 2^j <= (n+j)!). Closing results establish e > 2 and the five-term value 1/0! + 1/1! + 1/2! + 1/3! + 1/4! = 65/24.",
     "keyInsights": [
       "Every derivative of exp is exp -- this self-similarity makes exp the ideal test case for Taylor convergence, since the remainder involves exp evaluated at an intermediate point",
-      "The unified remainder bound exp(|x|) * |x|^{n+1}/n! handles both positive and negative x: for x > 0, exp is monotone increasing on [0,x]; for x < 0, exp <= 1 on [x,0]",
-      "Convergence follows from factorial domination: x^n/n! -> 0 for any fixed x, which is a consequence of the ratio test (the ratio x/(n+1) -> 0)",
-      "The tsum identity exp(x) = sum' x^n/n! is proved by uniqueness of limits: partial sums converge to exp(x) by remainder analysis and to the tsum by summability",
-      "The error bound |e - S_n(1)| <= 3/n! gives concrete computational guarantees: 10 terms suffice for 6 decimal places of e",
-      "The Cauchy remainder for exp gives exp(xi)(x-xi)^n/n! * x for some xi in (0,x), providing finer control than the Lagrange form when x is near the expansion point"
+      "The Lagrange remainder for exp specializes Mathlib's taylor_mean_remainder_lagrange: for x > 0 there is a xi in (0,x) with remainder iteratedDerivWithin (n+1) exp xi * x^{n+1}/(n+1)!, i.e. exp(xi) * x^{n+1}/(n+1)!",
+      "Convergence follows from factorial domination: x^n/n! -> 0 for any fixed x, which is a consequence of summability of the exponential series",
+      "The tsum identity exp(x) = sum' x^n/n! follows from Mathlib's power-series representation NormedSpace.exp_eq_tsum, after rewriting the series term (n!)^{-1} . x^n as x^n/n!",
+      "The error bound |e - S_n(1)| <= 3/n! is obtained by dominating the tail with a geometric series (n! * 2^j <= (n+j)!); as a consequence 3/10! < 10^{-6}, so ten terms pin down e to six decimal places"
     ],
     "prerequisites": [
       "Calculus and real analysis",
@@ -86,82 +85,82 @@
       "id": "imports-and-docstring",
       "title": "Imports and Module Documentation",
       "startLine": 1,
-      "endLine": 37,
-      "summary": "Imports from Mathlib (Taylor calculus, exp derivatives, normed limits, infinite sums, exponential bounds) and module documentation explaining the main results and approach.",
-      "mathContext": "Imports for Taylor remainder analysis of $e^x$: Mathlib's calculus of $\\frac{d^n}{dx^n} e^x = e^x$, summability of $\\sum |x|^n / n!$, and bounds on $e = \\exp(1) > 2.718281828$."
+      "endLine": 40,
+      "summary": "Imports Mathlib and opens the relevant namespaces. Module documentation explains the approach: connect Real.exp to NormedSpace.exp's power series and derive convergence, remainder, and Euler-number results.",
+      "mathContext": "Setup for proving $e^x = \\sum_{n} x^n/n!$ via Mathlib's power-series representation of the exponential, together with the Lagrange remainder framework from Taylor's theorem."
+    },
+    {
+      "id": "core-summability",
+      "title": "Section I: Core Summability",
+      "startLine": 42,
+      "endLine": 48,
+      "summary": "Proves exp_series_summable: the power series sum x^n/n! is summable for every x, directly from Mathlib's summable_pow_div_factorial.",
+      "mathContext": "The power series $\\sum_{n} \\frac{x^n}{n!}$ is absolutely convergent for every $x \\in \\mathbb{R}$."
+    },
+    {
+      "id": "main-convergence",
+      "title": "Section II: Main Convergence eˣ = Σ xⁿ/n!",
+      "startLine": 50,
+      "endLine": 82,
+      "summary": "Proves exp_tsum (Real.exp x = sum' x^n/n!) by rewriting Real.exp via NormedSpace.exp_eq_tsum and matching the series term (n!)^{-1} . x^n with x^n/n!, then exp_hasSum and exp_partial_sum_tendsto (partial sums over Finset.range converge to exp x).",
+      "mathContext": "Connecting $\\mathrm{Real.exp}$ to $\\mathrm{NormedSpace.exp}$ gives $e^x = \\sum_{n=0}^{\\infty} \\frac{x^n}{n!}$, the HasSum form, and convergence of the partial sums $\\sum_{k<n} \\frac{x^k}{k!} \\to e^x$."
+    },
+    {
+      "id": "taylor-remainder",
+      "title": "Section III: Taylor Remainder Tends to Zero",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "Proves exp_remainder_tendsto_zero: the Taylor remainder R_n(x) = exp x - sum_{k<n} x^k/k! tends to 0, expressing convergence as vanishing remainder.",
+      "mathContext": "The error $R_n(x) = e^x - \\sum_{k<n} \\frac{x^k}{k!} \\to 0$ as $n \\to \\infty$."
     },
     {
       "id": "iterated-derivatives",
-      "title": "Section I: Iterated Derivatives of exp",
-      "startLine": 38,
-      "endLine": 56,
-      "summary": "Proves iteratedDeriv n exp = exp by induction: the base case is iteratedDeriv_zero, and the inductive step uses Real.deriv_exp. The pointwise version iteratedDeriv_exp_apply is an immediate corollary.",
-      "mathContext": "Proves $\\frac{d^n}{dx^n} e^x = e^x$ for all $n \\in \\mathbb{N}$ by induction: base case $\\frac{d^0}{dx^0} e^x = e^x$ and step $\\frac{d}{dx} e^x = e^x$."
+      "title": "Section IV: Iterated Derivatives of exp",
+      "startLine": 100,
+      "endLine": 109,
+      "summary": "Proves iteratedDeriv_exp: iteratedDeriv k exp = exp by induction (base case iteratedDeriv_zero, step uses Real.hasDerivAt_exp).",
+      "mathContext": "Proves $\\frac{d^k}{dx^k} e^x = e^x$ for all $k \\in \\mathbb{N}$ by induction."
     },
     {
-      "id": "partial-sums",
-      "title": "Section II: Taylor Partial Sums",
-      "startLine": 57,
-      "endLine": 81,
-      "summary": "Defines expPartialSum n x = sum_{k=0}^{n} x^k/k! and proves basic properties: S_0(x) = 1, the successor recurrence, and S_n(0) = 1.",
-      "mathContext": "Taylor partial sums $S_n(x) = \\sum_{k=0}^{n} \\frac{x^k}{k!}$ with properties: $S_0(x) = 1$, $S_{n+1}(x) = S_n(x) + \\frac{x^{n+1}}{(n+1)!}$, and $S_n(0) = 1$."
+      "id": "lagrange-remainder",
+      "title": "Section V: The Lagrange Remainder Form",
+      "startLine": 111,
+      "endLine": 132,
+      "summary": "Proves exp_lagrange_remainder by specializing Mathlib's taylor_mean_remainder_lagrange to exp: for x > 0 there exists xi in (0,x) with exp x - taylorWithinEval exp n (Icc 0 x) 0 x = iteratedDerivWithin (n+1) exp (Icc 0 x) xi * x^(n+1)/(n+1)!. No axioms are introduced.",
+      "mathContext": "Lagrange remainder for $e^x$ (via $\\texttt{taylor\\_mean\\_remainder\\_lagrange}$): for $x>0$, $\\exists\\,\\xi \\in (0,x)$ with $e^x - T_n(x) = \\frac{e^\\xi\\, x^{n+1}}{(n+1)!}$."
     },
     {
-      "id": "factorial-dominates",
-      "title": "Section III: Factorial Dominates Powers",
-      "startLine": 82,
-      "endLine": 95,
-      "summary": "Proves summability of x^n/n! (from Mathlib's summable_pow_div_factorial) and the consequence x^n/n! -> 0, which is the engine driving Taylor convergence.",
-      "mathContext": "Factorial domination: $\\sum_{n=0}^{\\infty} \\frac{|x|^n}{n!}$ converges (ratio test: $\\frac{|x|}{n+1} \\to 0$), so $\\frac{x^n}{n!} \\to 0$ for any fixed $x \\in \\mathbb{R}$."
+      "id": "euler-number",
+      "title": "Section VI: The Euler Number and Tail Bound",
+      "startLine": 134,
+      "endLine": 220,
+      "summary": "Proves euler_number_series (e = sum 1/n!), euler_tsum, euler_partial_sum_tendsto, then the tail bound euler_approx_error: |e - sum_{k<n} 1/k!| <= 3/n! for n >= 1, via the supporting lemmas factorial_double_pow_le (n! * 2^j <= (n+j)!) and tail_term_le_geometric.",
+      "mathContext": "Euler's number $e = \\sum_{n} \\frac{1}{n!}$ with error bound $\\left|e - \\sum_{k<n} \\frac{1}{k!}\\right| \\leq \\frac{3}{n!}$ for $n \\geq 1$, proved by dominating the tail with a geometric series."
     },
     {
-      "id": "remainder-bounds",
-      "title": "Section IV: Remainder Bounds",
-      "startLine": 96,
-      "endLine": 157,
-      "summary": "States the two axioms (remainder bounds for x > 0 and x < 0), proves the unified bound |exp(x) - S_n(x)| <= exp(|x|) * |x|^{n+1}/n! by case analysis, and shows the remainder tends to zero via squeeze theorem.",
-      "mathContext": "States the two axioms (remainder bounds for x > 0 and x < 0), proves the unified bound |exp(x) - S_n(x)| <= exp(|x|) * |x|^{n+1}/n! by case analysis, and shows the remainder tends to zero via squeeze theorem."
-    },
-    {
-      "id": "convergence",
-      "title": "Section V: Convergence of Taylor Series",
-      "startLine": 158,
-      "endLine": 199,
-      "summary": "Proves partial sums converge to exp(x) and derives the tsum identity exp(x) = sum' x^n/n! by uniqueness of limits. The index shift from range(n+1) to range(n) is handled by subtracting the n-th term.",
-      "mathContext": "Proves partial sums converge to exp(x) and derives the tsum identity exp(x) = sum' x^n/n! by uniqueness of limits. The index shift from range(n+1) to range(n) is handled by subtracting the n-th term."
-    },
-    {
-      "id": "euler-computation",
-      "title": "Section VI: Computation of Euler's Number",
-      "startLine": 200,
-      "endLine": 239,
-      "summary": "Defines ePartialSum, proves 2 < e < 3, establishes the error bound |e - S_n(1)| <= 3/n!, and verifies that 10 terms give precision < 10^{-6}.",
-      "mathContext": "Euler's number: $2 < e < 3$ and $\\left|e - \\sum_{k=0}^{n} \\frac{1}{k!}\\right| \\leq \\frac{3}{n!}$. At $n = 10$: error $< 10^{-6}$, giving 6-digit precision for $e \\approx 2.718281828$."
-    },
-    {
-      "id": "cauchy-remainder",
-      "title": "Section VII: The Cauchy Remainder Form",
-      "startLine": 240,
+      "id": "properties-of-e",
+      "title": "Section VII: Radius of Convergence and Properties of e",
+      "startLine": 222,
       "endLine": 268,
-      "summary": "Applies the Cauchy remainder theorem to exp: for x > 0, there exists xi in (0,x) with remainder = exp(xi)(x-xi)^n/n! * x. Proves the bound |remainder| <= exp(x) * x^{n+1}/n! using monotonicity of exp and (x-xi)^n <= x^n.",
-      "mathContext": "Applies the Cauchy remainder theorem to exp: for x > 0, there exists xi in (0,x) with remainder = exp(xi)(x-xi)^n/n! * x. Proves the bound |remainder| <= exp(x) * x^{n+1}/n! using monotonicity of exp and (x-xi)^n <= x^n."
+      "summary": "Proves exp_infinite_radius (the series converges for every real x), exp_one_gt_two (e > 2, via exp(1/2)^2 and add_one_le_exp), and exp_five_term (1/0! + 1/1! + 1/2! + 1/3! + 1/4! = 65/24). Closes with #check verification of the main results.",
+      "mathContext": "Infinite radius of convergence, $e > 2$, and the five-term partial sum $\\frac{1}{0!} + \\frac{1}{1!} + \\frac{1}{2!} + \\frac{1}{3!} + \\frac{1}{4!} = \\frac{65}{24}$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves the Taylor series of the exponential function converges to exp(x) for all real x, establishes the tsum identity exp(x) = sum x^n/n!, and provides concrete error bounds for computing Euler's number e. The Cauchy remainder form is applied to exp with an explicit bound, answering the third open question from the parent Taylor's theorem (Wiedijk #35) entry.",
+    "summary": "This formalization proves the Taylor series of the exponential function converges to exp(x) for all real x, establishes the tsum identity exp(x) = sum x^n/n!, and provides concrete error bounds for computing Euler's number e. The Lagrange remainder form is specialized to exp via Mathlib's taylor_mean_remainder_lagrange, contributing to the parent Taylor's theorem (Wiedijk #35) entry; the Cauchy remainder form for exp remains future work.",
     "implications": "**Theoretical Significance**: The convergence of exp's Taylor series is a foundational result in analysis, connecting the algebraic definition of exp (as a power series) to its analytic definition (as the unique solution of f' = f, f(0) = 1). The error bound |e - S_n(1)| <= 3/n! provides a verified framework for arbitrary-precision computation of e.\n\nThe technique of bounding the Lagrange remainder by a sequence that tends to zero applies to any function whose derivatives grow at most exponentially. The Cauchy remainder form is the foundation for integral remainder estimates and complex-analytic extensions of Taylor's theorem.",
     "openQuestions": [
-      "Can the two remainder axioms be fully proved by bridging taylorWithinEval (Mathlib's internal Taylor polynomial) with expPartialSum, connecting iteratedDerivWithin on Icc to iteratedDeriv for globally smooth functions?",
+      "Can the Lagrange remainder result exp_lagrange_remainder (currently stated for x > 0 via taylorWithinEval on Icc 0 x) be extended to a two-sided statement covering x < 0 by connecting iteratedDerivWithin to iteratedDeriv for globally smooth functions?",
       "Can this approach be extended to prove convergence of Taylor series for sin, cos, and other entire functions?",
       "Can the error bound be sharpened using the alternating series estimation for the exp series at x = 1?",
-      "Does the Cauchy remainder form yield tighter bounds than the Lagrange form for specific applications (e.g., numerical quadrature of exp)?"
+      "Can the Cauchy remainder form be formalized for exp, and does it yield tighter bounds than the Lagrange form for specific applications (e.g., numerical quadrature of exp)?"
     ]
   },
   "crossReferences": [
     {
       "targetId": "taylor-theorem",
       "relationship": "extends",
-      "description": "Parent entry formalizing Taylor's theorem (Wiedijk #35) with Lagrange and Cauchy remainder forms. This entry answers the third open question: using the Cauchy remainder to prove convergence of exp's Taylor series."
+      "description": "Parent entry formalizing Taylor's theorem (Wiedijk #35) with Lagrange and Cauchy remainder forms. This entry formalizes convergence of exp's Taylor series and specializes the Lagrange remainder to exp; the Cauchy-remainder variant of the third open question remains future work."
     },
     {
       "targetId": "euler-identity",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `taylor-theorem-oq-03`
**Severity**: HIGH — multiple public-facing claims describe work absent from the source.

## Problem

`meta.json` described a **Cauchy-remainder, axiom-based** formalization, but `proofs/Proofs/TaylorTheoremOQ03.lean` is **Lagrange-based and axiom-free**. The narrative was evidently written for an earlier/planned version and never reconciled with the merged file.

### Evidence

| meta claimed | source shows |
|---|---|
| Title "via the **Cauchy** Remainder" | uses `taylor_mean_remainder_lagrange`; **no** Cauchy remainder theorem (only one prose mention of "Cauchy/Lagrange framework") |
| deps `taylor_mean_remainder_cauchy`, `taylor_mean_remainder_bound`, `Real.exp_one_gt_d9` | none used; actual deps are `NormedSpace.exp_eq_tsum`, `taylor_mean_remainder_lagrange`, `Real.contDiff_exp`, `summable_pow_div_factorial`, `Real.add_one_le_exp` |
| originalContributions: "Applied Cauchy remainder to exp", "Proved Cauchy remainder bound" | absent |
| originalContributions: "Defined expPartialSum" | no such def (`definitionCount` correctly 0; partial sums use `Finset.range`) |
| "concrete 10-term precision < 10^-6" | not a Lean result (consequence of the proved `3/n!` bound) |
| Section IV "States the two axioms" | **zero** axioms in file |
| Section VII "The Cauchy Remainder Form" (lines 240-268) | those lines are Radius of Convergence + `e>2` + `T5 = 65/24` |

The safety-critical fields — `status: verified`, `sorries: 0`, `axiomCount: 0` — were already **accurate** and are unchanged. This PR corrects only the overstated scope/narrative.

## Fix

Rewrote title, description, `mathlibDependencies`, `originalContributions`, `assumptions`, `problemStatement`, `proofStrategy`, `keyInsights`, all `sections`, `conclusion`, `historicalContext`, and the parent cross-reference to describe the actual Lagrange/power-series content. Cauchy-remainder treatment is now framed as future work.

JSON validated. Found during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)