### PR TITLE
Enrich Minimal Polynomial of Odd-Prime-Degree Radicals

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-sqrt2oq010201-header",
+    "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 7,
+      "endLine": 57
+    },
+    "type": "context",
+    "title": "Why Prime Degree: the Kummer Criterion and the Composite Counterexample",
+    "content": "The docstring frames the open question precisely. The parent file proves minpoly ℚ (√r) = X² − r (degree 2); the natural generalization minpoly ℚ (a^(1/k)) = X^k − a is **false for composite k**: X⁴ − 4 = (X² − 2)(X² + 2) is reducible, so minpoly ℚ (4^(1/4)) = minpoly ℚ (√2) = X² − 2, not X⁴ − 4. The clean statement survives exactly at **prime** degree, where Kummer theory supplies the sharp criterion: for an odd prime p, X^p − C a is irreducible over a field K iff a is not a p-th power in K (`X_pow_sub_C_irreducible_iff_of_prime_pow` at exponent n = 1). This file applies that criterion over ℚ; the remaining prime p = 2 is the parent's square-root theorem, proved there by an elementary irrationality argument because the Kummer lemma explicitly excludes p = 2. Together the two files cover every prime degree, and the hypothesis ∀ b : ℚ, bᵖ ≠ a is precisely 'a is not a p-th power in ℚ', the odd-prime analogue of the parent's ¬ IsSquare a.",
+    "mathContext": "$p$ odd prime, $a \\ge 0$ rational, $\\forall b\\in\\mathbb{Q}\\ b^p \\ne a \\Rightarrow \\mathrm{minpoly}_{\\mathbb{Q}}(a^{1/p}) = X^p - a$. Composite $k$ fails: $X^4-4=(X^2-2)(X^2+2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer theory",
+      "irreducibility of X^p − a",
+      "minimal polynomial",
+      "prime vs composite degree",
+      "radical extensions"
+    ],
+    "prerequisites": [
+      "minimal polynomial over ℚ",
+      "irreducibility criteria for binomials X^n − a",
+      "p-th power residues in ℚ"
+    ]
+  },
+  {
     "id": "ann-sqrt2oq010201-root",
     "proofId": "sqrt2-minpoly-oq-01-oq-02-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `sqrt2-minpoly-oq-01-oq-02-oq-01`.

## Improvements
- **Annotation coverage 4 → 5**: added a `context` annotation over the module docstring (lines 7-57), the only uncovered region. It captures the open-question framing — why the generalization `minpoly ℚ (a^(1/k)) = X^k − a` requires *prime* degree (composite-k counterexample `X⁴−4 = (X²−2)(X²+2)`), the Kummer irreducibility criterion `X_pow_sub_C_irreducible_iff_of_prime_pow` that drives the proof, and the `p = 2` case handled separately by the parent file.

Verified the existing 4 annotations and 3 sections are accurately anchored to `Sqrt2MinpolyOQ01OQ02OQ01.lean` (Part I 64-77, Part II 86-97, Part III 99-119), keyInsights (5), crossReferences (3), and conclusion (summary+implications+openQuestions) are all already present. Status/badge unchanged and accurate (verified, badge `mathlib` — built on Mathlib's Kummer criterion; axiomCount 0, 0 sorries). Build resolver reports zero errors for this entry.