### PR TITLE
audit(solution-of-cubic-oq-03): record clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13067,9 +13067,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
+      "lastAudited": "2026-06-18T04:49:10Z",
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — solution-of-cubic-oq-03

**Result: CLEAN** ✓

Re-audit (4th) of "Vieta's Formulas for the Cubic via Cardano's Roots". Every public claim matches the Lean source `Proofs/SolutionOfCubicOQ03.lean`:

| Claim | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 187 | 187 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| True stubs | — | 0 | ✓ |

- `status: verified` / `badge: mathlib` is appropriately conservative: the 3 listed Mathlib deps (`exp_two_pi_mul_I`, `exp_mul_I`, `sin_pi_div_three`) are genuinely used for the ω-identity lemmas (L43/L52/L58); the Vieta computations are done independently via `ring`/`linear_combination`.
- Section line ranges all align with actual theorem locations.

Only change: tracker entry (`auditCount` 3→4, `lastAudited`).

---
Discovered during gallery integrity audit.