### PR TITLE
Fix: re-class 5 entries verified→axiomatized (presented native_decide) (#25409)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Galois, Jordan)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Alternating_groups_and_the_Feit%E2%80%93Thompson_theorem",
     "date": "1832",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
     "tags": [
       "algebra",
@@ -18,7 +18,7 @@
       "research",
       "extension"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -59,9 +59,9 @@
       "alternating_solvable_iff: Complete bidirectional classification A_n solvable ↔ n ≤ 4"
     ],
     "dateAdded": "2026-04-05",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 167,
-    "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. Small cases via inferInstance and isSolvable_of_comm; large cases via the exact-sequence argument with Mathlib's Equiv.Perm.not_solvable. The presented theorem `a4_solvable` discharges solvability of `Perm (Fin 4)` by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -7,7 +7,7 @@
     "author": "Carl Friedrich Gauss (formalized via Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Intervals.html",
     "date": "~1785",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeries.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "classic",
       "gauss"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,7 +40,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 180,
     "relatedProblems": [
       {
@@ -52,7 +52,7 @@
         "relationship": "Further extensions of simplicial number theory"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general Gauss/arithmetic-series formulas are kernel-checked, but the presented concrete corollary `gauss_100` (∑_{i<101} i = 5050) is discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust). Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1

--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CollatzCycles.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "cycles",
       "number-sequences"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented theorem `small_numbers_reach_one` discharges each finite Collatz trajectory (n ≤ 20) by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 256,
     "theoremCount": 27,
     "definitionCount": 4,

--- a/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Efficiency",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CramersRuleOQ02OQ02.lean",
     "tags": [
       "computational-complexity",
@@ -19,7 +19,7 @@
       "factorial-growth",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -54,9 +54,9 @@
     ],
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 189,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented theorems `lu_beats_cramer_all` and `qr_beats_cramer_from_3` discharge their small-n base cases by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust). Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "theoremCount": 13,
     "definitionCount": 2
   },

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylow (1872); Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Properties",
     "date": "1872",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SylowTheoremOQ04.lean",
     "tags": [
       "group-theory",
@@ -17,10 +17,10 @@
       "alternating-group",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axiom declarations, 0 sorries. All results fully verified. Exact Sylow numbers computed by native_decide. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five; the presented theorem `card_A5` (|A₅| = 60) and the exact Sylow-number computations are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 276,
     "theoremCount": 21,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

Re-class 5 gallery entries from `verified` to `axiomatized` because each entry's **gallery-presented main theorem** (a name in `meta.mainTheorems`) is discharged directly by `native_decide`, which depends on `Lean.ofReduceBool`.

This is a deliberate, source-dispositive batch from the #25409 candidate set: I did not flip en masse. I selected only entries where a *presented* theorem is itself proved by `native_decide` (no `#print axioms` judgment needed — the source is dispositive, since `native_decide` always introduces `Lean.ofReduceBool`). Entries where `native_decide` appears only in `example`/sanity-check blocks (~70 candidates) are intentionally **left as `verified`** — their presented theorems are kernel-checked.

| Slug | Presented theorem(s) via native_decide |
|------|----------------------------------------|
| abel-ruffini-oq-04-oq-02-oq-02 | `a4_solvable` (solvability of `Perm (Fin 4)`) |
| arithmetic-series | `gauss_100` (∑_{i<101} i = 5050) |
| collatz-cycles | `small_numbers_reach_one` (n ≤ 20 trajectories) |
| cramers-rule-oq-02-oq-02 | `lu_beats_cramer_all`, `qr_beats_cramer_from_3` |
| sylow-theorems-oq-04 | `card_A5` (|A₅| = 60) + Sylow-number computations |

`burnside-counting` (also in this set) is excluded — already handled by open PR #25408.

## Evidence

**Before**: `status: "verified"`, `badge: <mathlib/original>`, `meta.axiomCount: 0`, assumptions claim "fully verified / 0 axioms".
**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`, `Lean.ofReduceBool` disclosed in `assumptions`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Matches the field pattern of #25390 / #25408 and existing axiomatized native_decide entries (happy-number-oq-01, four-square-distribution).

Part of #25409.

---
Automated fix by lean-mechanic agent.