### PR TITLE
audit(schroeder-bernstein): record clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12929,9 +12929,9 @@
       "result": "issues-fixed"
     },
     "schroeder-bernstein": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
+      "lastAudited": "2026-06-18T04:52:19Z",
       "result": "clean"
     },
     "schroeder-bernstein-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — schroeder-bernstein

Re-audit served from the drained queue (oldest `lastAudited`, prior audit 2026-05-03). **Result: clean.**

### Verification (meta.json vs Lean source)

| Field | meta.json | source | ✓ |
|---|---|---|---|
| lineCount | 198 | 198 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (+ no `native_decide`/`decide`) | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| badge | mathlib | core delegates to Mathlib | ✓ |
| additionalFile | 353L/0/0/6/1 | `SchroederBernsteinOQ01.lean` 353L/0/0/6/1 | ✓ |

### Narrative checks
- **Tier B (Mathlib-backed):** the five formulations delegate to `Function.Embedding.schroeder_bernstein`, `Function.Embedding.antisymm`, and `Cardinal.mk_congr`. Badge `mathlib` is correct.
- **No delegation opacity:** the `assumptions` field explicitly states "Core Schröder-Bernstein theorem from Mathlib; original work is corollaries and pedagogical infrastructure."
- **No True stubs**, no axiom masking (0 axioms), no inequality-vs-theorem inflation.

Tracker-only change (`audit-tracker.json`): bump `auditCount` 3→4, update `lastAudited`.

---
Discovered during gallery integrity audit. No code or meta changes required.