### PR TITLE
research(bounded-prime-gaps-oq-03-oq-01-oq-01): verify D(5)=12 from scratch + gallery entry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -317,6 +317,7 @@ import Proofs.BoundedPrimeGapsOQ01OQ02
 import Proofs.BoundedPrimeGapsOQ01OQ03
 import Proofs.BoundedPrimeGapsOQ03
 import Proofs.BoundedPrimeGapsOQ03OQ01
+import Proofs.BoundedPrimeGapsOQ03OQ01OQ01
 import Proofs.BoundedPrimeGapsOQ03OQ01OQ04
 import Proofs.BoundedPrimeGapsOQ03OQ02
 import Proofs.BoundedPrimeGapsOQ03OQ03

--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
@@ -1,0 +1,198 @@
+/-
+  bounded-prime-gaps-oq-03-oq-01-oq-01 — D(5) = 12 from scratch.
+
+  Proves `minAdmissibleDiameter 5 = 12`: the minimal diameter of an admissible
+  5-tuple is exactly 12 (OEIS A008407, k = 5). This is the next rung in the
+  parent's materialized minimal-admissible-diameter series:
+
+    D(2) = 2  (`BoundedPrimeGapsOQ03OQ01.minAdmissibleDiameter_2`, witness {0,2})
+    D(3) = 6  (`BoundedPrimeGapsOQ03OQ01.minAdmissibleDiameter_3`, witness {0,2,6})
+    D(4) = 8  (sibling slug …-oq-03-oq-01-oq-04)
+    D(5) = 12 (this file, witness {0,2,6,8,12})
+
+  This is a finite combinatorial fact — NOT the parent's open Maynard–Tao /
+  Engelsma-246 barrier.
+
+  Upper bound `D(5) ≤ 12`: the admissible witness {0,2,6,8,12} (reusing the
+  verified `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12`).
+
+  Lower bound `D(5) ≥ 12` (`admissible_5tuple_diam_ge_12`): a self-contained,
+  `native_decide`-free parity argument mirroring the verified parent lemma
+  `admissible_triple_diam_ge_6`:
+    • p = 2 admissibility forces every element to share `min`'s parity.
+    • Same parity + diameter < 12 confines H to {m, m+2, m+4, m+6, m+8, m+10}.
+    • That 6-set splits into two disjoint mod-3-complete triples
+      {m,m+2,m+4} and {m+6,m+8,m+10}; p = 3 admissibility forbids H from
+      containing either triple in full, so H omits ≥ 1 element from EACH —
+      ≥ 2 omissions from a 6-set, impossible for a 5-set.
+  Only the primes p ∈ {2,3} are interrogated, so the proof needs no
+  `Decidable IsAdmissible` instance.
+-/
+import Mathlib
+import Proofs.BoundedPrimeGaps
+import Proofs.BoundedPrimeGapsOQ03OQ01
+
+namespace BoundedPrimeGapsOQ03OQ01OQ01
+
+open Nat Finset BoundedPrimeGaps BoundedPrimeGapsOQ03OQ01
+
+/-- Witness admissibility: `{0, 2, 6, 8, 12}` is admissible (diameter 12).
+    Delegates to the verified, already-registered
+    `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12`. -/
+theorem admissible_5tuple_0_2_6_8_12 :
+    IsAdmissible ({0, 2, 6, 8, 12} : Finset ℕ) :=
+  admissible_quintuple_0_2_6_8_12
+
+/-- **Lower bound — the real content.** Every admissible 5-tuple has diameter
+    ≥ 12. Parity (mod 2) forces same parity; then diameter < 12 confines the set
+    to `{m, m+2, m+4, m+6, m+8, m+10}`, whose two disjoint mod-3-complete triples
+    each must lose an element, forcing ≥ 2 omissions from a 6-set of card 5. -/
+theorem admissible_5tuple_diam_ge_12
+    (H : Finset ℕ) (hcard : H.card = 5) (hadm : IsAdmissible H) :
+    12 ≤ fsDiameter H := by
+  have hne : H.Nonempty := Finset.card_pos.mp (by omega)
+  unfold fsDiameter; simp only [hne, dite_true]
+  by_contra h_lt; push_neg at h_lt
+  -- Facts about min'/max' captured BEFORE `set` so the abbreviation folds them.
+  have hmle0 : ∀ x ∈ H, H.min' hne ≤ x := fun x hx => Finset.min'_le H x hx
+  have hmmem0 : H.min' hne ∈ H := Finset.min'_mem H hne
+  have hmaxmem0 : H.max' hne ∈ H := Finset.max'_mem H hne
+  have hxmax0 : ∀ x ∈ H, x ≤ H.max' hne := fun x hx => Finset.le_max' H x hx
+  set m := H.min' hne with hm
+  -- Now: h_lt : H.max' hne - m < 12, hmle0 : ∀ x ∈ H, m ≤ x, hmmem0 : m ∈ H.
+  -- Step 1: p = 2 admissibility ⇒ every element shares m's parity.
+  have h2 := hadm 2 (by norm_num)
+  have hpar : ∀ x ∈ H, x % 2 = m % 2 := by
+    intro x hx
+    by_contra hdiff
+    have hsub : ({x % 2, m % 2} : Finset ℕ) ⊆ H.image (· % 2) := by
+      rw [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨Finset.mem_image_of_mem _ hx, Finset.mem_image_of_mem _ hmmem0⟩
+    have hc2 : ({x % 2, m % 2} : Finset ℕ).card = 2 :=
+      Finset.card_eq_two.mpr ⟨x % 2, m % 2, hdiff, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 2: same parity + diameter < 12 ⇒ H ⊆ {m, m+2, m+4, m+6, m+8, m+10}.
+  have hsub6 : H ⊆ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) := by
+    intro x hx
+    have hxge := hmle0 x hx
+    have hxle := hxmax0 x hx
+    have hmaxle : H.max' hne ≤ m + 11 := by
+      have := hmle0 _ hmaxmem0; omega
+    have hpx := hpar x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    set d := x - m with hd
+    have hdle : d ≤ 11 := by omega
+    have hdev : d % 2 = 0 := by omega
+    interval_cases d <;> omega
+  -- Step 3a: H cannot contain all of {m, m+2, m+4} (mod 3 would be covered).
+  have hnotT1 : m ∉ H ∨ m + 2 ∉ H ∨ m + 4 ∉ H := by
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨h0, h2', h4'⟩ := hcon
+    have h3 := hadm 3 (by norm_num)
+    have hsub : ({m % 3, (m + 2) % 3, (m + 4) % 3} : Finset ℕ) ⊆ H.image (· % 3) := by
+      intro r hr
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hr
+      rcases hr with rfl | rfl | rfl
+      · exact Finset.mem_image_of_mem _ h0
+      · exact Finset.mem_image_of_mem _ h2'
+      · exact Finset.mem_image_of_mem _ h4'
+    have hc3 : ({m % 3, (m + 2) % 3, (m + 4) % 3} : Finset ℕ).card = 3 :=
+      Finset.card_eq_three.mpr
+        ⟨m % 3, (m + 2) % 3, (m + 4) % 3, by omega, by omega, by omega, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 3b: likewise H cannot contain all of {m+6, m+8, m+10}.
+  have hnotT2 : m + 6 ∉ H ∨ m + 8 ∉ H ∨ m + 10 ∉ H := by
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨h6, h8, h10⟩ := hcon
+    have h3 := hadm 3 (by norm_num)
+    have hsub : ({(m + 6) % 3, (m + 8) % 3, (m + 10) % 3} : Finset ℕ) ⊆ H.image (· % 3) := by
+      intro r hr
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hr
+      rcases hr with rfl | rfl | rfl
+      · exact Finset.mem_image_of_mem _ h6
+      · exact Finset.mem_image_of_mem _ h8
+      · exact Finset.mem_image_of_mem _ h10
+    have hc3 : ({(m + 6) % 3, (m + 8) % 3, (m + 10) % 3} : Finset ℕ).card = 3 :=
+      Finset.card_eq_three.mpr
+        ⟨(m + 6) % 3, (m + 8) % 3, (m + 10) % 3, by omega, by omega, by omega, rfl⟩
+    have := Finset.card_le_card hsub
+    omega
+  -- Step 4: two omissions a (from T1) and b (from T2), a ≠ b, both in the
+  -- 6-set ⇒ insert a (insert b H) has card 7 inside a card-≤-6 set. Absurd.
+  have key : ∀ a b : ℕ,
+      a ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) →
+      b ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) →
+      a ≠ b → a ∉ H → b ∉ H → False := by
+    intro a b ha hb hab hna hnb
+    have ha_notin : a ∉ insert b H := by
+      simp only [Finset.mem_insert]; push_neg; exact ⟨hab, hna⟩
+    have hcardins : (insert a (insert b H)).card = 7 := by
+      rw [Finset.card_insert_of_not_mem ha_notin,
+          Finset.card_insert_of_not_mem hnb, hcard]
+    have hins : insert a (insert b H) ⊆
+        ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) := by
+      intro x hx
+      simp only [Finset.mem_insert] at hx
+      rcases hx with rfl | rfl | hx
+      · exact ha
+      · exact hb
+      · exact hsub6 hx
+    have hcardle := Finset.card_le_card hins
+    have c1 := Finset.card_insert_le m ({m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ)
+    have c2 := Finset.card_insert_le (m + 2) ({m + 4, m + 6, m + 8, m + 10} : Finset ℕ)
+    have c3 := Finset.card_insert_le (m + 4) ({m + 6, m + 8, m + 10} : Finset ℕ)
+    have c4 := Finset.card_insert_le (m + 6) ({m + 8, m + 10} : Finset ℕ)
+    have c5 := Finset.card_insert_le (m + 8) ({m + 10} : Finset ℕ)
+    have c6 : ({m + 10} : Finset ℕ).card = 1 := Finset.card_singleton _
+    omega
+  -- Membership of each candidate element in the 6-set, by explicit
+  -- `Finset.mem_insert` terms (search-free — avoids an `omega` blow-up on the
+  -- 6-way disjunction that `simp [mem_insert]` produces).
+  have e0 : m ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_self _ _
+  have e2 : m + 2 ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_of_mem (Finset.mem_insert_self _ _)
+  have e4 : m + 4 ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_of_mem (Finset.mem_insert_of_mem (Finset.mem_insert_self _ _))
+  have e6 : m + 6 ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_of_mem (Finset.mem_insert_of_mem
+      (Finset.mem_insert_of_mem (Finset.mem_insert_self _ _)))
+  have e8 : m + 8 ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_of_mem (Finset.mem_insert_of_mem (Finset.mem_insert_of_mem
+      (Finset.mem_insert_of_mem (Finset.mem_insert_self _ _))))
+  have e10 : m + 10 ∈ ({m, m + 2, m + 4, m + 6, m + 8, m + 10} : Finset ℕ) :=
+    Finset.mem_insert_of_mem (Finset.mem_insert_of_mem (Finset.mem_insert_of_mem
+      (Finset.mem_insert_of_mem (Finset.mem_insert_of_mem (Finset.mem_singleton_self _)))))
+  rcases hnotT1 with ha | ha | ha
+  · rcases hnotT2 with hb | hb | hb
+    · exact key m (m + 6) e0 e6 (by omega) ha hb
+    · exact key m (m + 8) e0 e8 (by omega) ha hb
+    · exact key m (m + 10) e0 e10 (by omega) ha hb
+  · rcases hnotT2 with hb | hb | hb
+    · exact key (m + 2) (m + 6) e2 e6 (by omega) ha hb
+    · exact key (m + 2) (m + 8) e2 e8 (by omega) ha hb
+    · exact key (m + 2) (m + 10) e2 e10 (by omega) ha hb
+  · rcases hnotT2 with hb | hb | hb
+    · exact key (m + 4) (m + 6) e4 e6 (by omega) ha hb
+    · exact key (m + 4) (m + 8) e4 e8 (by omega) ha hb
+    · exact key (m + 4) (m + 10) e4 e10 (by omega) ha hb
+
+/-- **D(5) = 12.** Same `le_antisymm` assembly as `minAdmissibleDiameter_3`. -/
+theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by
+  apply le_antisymm
+  · -- Upper: {0,2,6,8,12} witnesses D(5) ≤ 12
+    apply csInf_le ⟨0, fun _ _ => Nat.zero_le _⟩
+    exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+  · -- Lower: every admissible 5-tuple has diameter ≥ 12
+    have hne : Set.Nonempty
+        {d | ∃ H : Finset ℕ, H.card = 5 ∧ IsAdmissible H ∧ fsDiameter H = d} :=
+      ⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+    apply le_csInf hne
+    rintro d ⟨H, hcard, hadm, rfl⟩
+    exact admissible_5tuple_diam_ge_12 H hcard hadm
+
+end BoundedPrimeGapsOQ03OQ01OQ01

--- a/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
+++ b/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-01/state.md
@@ -96,3 +96,26 @@ the only remaining `native_decide`, and are trivially decidable closed terms.
 `Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (or fold the two lower-bound theorems
 + `minAdmissibleDiameter_5` into the parent next to D(2)/D(3)) and add to
 `Proofs.lean`. Phase OBSERVE→ACT, build-pending. Claim released.
+
+## S4 ACT (researcher-9, 2026-06-17) — BUILD GREEN, registered + galleried. COMPLETED.
+
+Docker is back up. Promoted researcher-1's complete `D5-draft.lean` to a
+registered proof and **verified it under the Docker wrapper**:
+
+- Created `proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean` (198 L, 3 theorems,
+  0 sorries, 0 axiom declarations) and registered it in `Proofs.lean`.
+- First build FAILED: the lower-bound's final 9-way case analysis proved the
+  six "element ∈ 6-set" memberships with `simp only [mem_insert, mem_singleton];
+  omega`. The 6-way disjunction made `omega` heartbeat-sensitive — 14 of 18 such
+  calls passed, 4 failed nondeterministically. **Fix:** replaced all 18 with
+  six explicit, search-free `Finset.mem_insert_of_mem`/`mem_singleton_self`
+  term proofs (`e0,e2,e4,e6,e8,e10`). Second build: **`Build succeeded`
+  (7746 jobs)**, only two `card_insert_of_not_mem` deprecation warnings.
+- Lower bound `admissible_5tuple_diam_ge_12` is `native_decide`-free; the only
+  two `native_decide` calls are the closed-term card/diameter checks of the
+  concrete witness `{0,2,6,8,12}` in `minAdmissibleDiameter_5`.
+- Gallery: `src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/{meta.json,
+  annotations.json}` — verified/original, 4 annotations (resolver 4 valid / 0
+  misaligned). Completes the OEIS A008407 chain D(2)=2, D(3)=6, D(4)=8, D(5)=12.
+
+Phase: ACT complete (D(5)=12 from scratch, verified). Claim released.

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-bgp-oq01-imports",
+    "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "Setup: Admissible Tuples and the D(k) Series",
+    "content": "The header documents D(5) = 12 and its place in the OEIS A008407 chain D(2)=2, D(3)=6, D(4)=8, D(5)=12. The file imports Mathlib plus two sibling modules: BoundedPrimeGaps (defining IsAdmissible, fsDiameter, and the verified witness admissible_quintuple_0_2_6_8_12) and BoundedPrimeGapsOQ03OQ01 (defining minAdmissibleDiameter and proving D(2)=2, D(3)=6 with the parity-argument template admissible_triple_diam_ge_6). The strategy block explains that only the primes p ∈ {2,3} are interrogated, so no Decidable IsAdmissible instance is required.",
+    "mathContext": "A finite $H \\subset \\mathbb{N}$ is **admissible** if for every prime $p$ the image $H \\bmod p$ misses some residue class: $|\\{h \\bmod p : h \\in H\\}| < p$. The minimum admissible diameter is $D(k) = \\min\\{\\max H - \\min H : H \\text{ admissible}, |H| = k\\}$. OEIS A008407 gives $D(1)=0, D(2)=2, D(3)=6, D(4)=8, D(5)=12, D(6)=16, \\ldots$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "admissible k-tuple",
+      "prime constellation",
+      "Hardy-Littlewood conjecture",
+      "OEIS A008407"
+    ],
+    "prerequisites": [
+      "definition of IsAdmissible",
+      "definition of fsDiameter and minAdmissibleDiameter",
+      "D(2)=2, D(3)=6, D(4)=8 results"
+    ]
+  },
+  {
+    "id": "ann-bgp-oq01-witness",
+    "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 44
+    },
+    "type": "theorem",
+    "title": "Witness Admissibility: {0,2,6,8,12}",
+    "content": "admissible_5tuple_0_2_6_8_12 establishes that {0,2,6,8,12} is admissible by one-line delegation to the already-verified, registered admissible_quintuple_0_2_6_8_12 from BoundedPrimeGaps.lean. This is the diameter-12 witness used twice in the main theorem: once for the upper bound csInf_le, and once to show the diameter set is nonempty for the lower-bound le_csInf.",
+    "mathContext": "Admissibility of $\\{0,2,6,8,12\\}$: mod 2 the residues are $\\{0\\}$ (misses 1); mod 3 they are $\\{0,2,0,2,0\\}=\\{0,2\\}$ (misses 1); mod 5 they are $\\{0,2,1,3,2\\}=\\{0,1,2,3\\}$ (misses 4); for $p \\ge 7$ a 5-element image cannot cover $\\ge 7$ classes. So no prime covers all residues and the tuple is admissible, with diameter $12 - 0 = 12$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "admissibility",
+      "prime quintuple",
+      "diameter witness"
+    ],
+    "prerequisites": [
+      "admissible_quintuple_0_2_6_8_12"
+    ]
+  },
+  {
+    "id": "ann-bgp-oq01-parity",
+    "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 182
+    },
+    "type": "theorem",
+    "title": "Lower Bound: Every Admissible 5-Tuple has Diameter ≥ 12",
+    "content": "admissible_5tuple_diam_ge_12 is the mathematical heart of the file, a fully symbolic (native_decide-free) proof by contradiction. Assuming an admissible 5-tuple H with diameter < 12 and writing m = min H: (Step 1, hpar) p=2 admissibility gives |H mod 2| < 2 = 1, so every element shares m's parity — a mixed-parity pair would make the image {0,1} of card 2. (Step 2, hsub6) same parity plus diameter < 12 forces each element to be m + 2k with k ≤ 5, confining H to the 6-set {m,m+2,m+4,m+6,m+8,m+10} via interval_cases on x - m. (Steps 3a/3b, hnotT1/hnotT2) each of the two disjoint triples {m,m+2,m+4} and {m+6,m+8,m+10} is mod-3-complete, so p=3 admissibility (|H mod 3| < 3) forbids H from containing either in full. (Step 4, key) H therefore omits ≥1 element from each triple — two distinct omissions — but a card-5 subset of the 6-set omits exactly one; insert a (insert b H) would have card 7 inside a card-≤-6 set, a contradiction discharged by iterated Finset.card_insert_le and omega.",
+    "mathContext": "The window $\\{m, m+2, m+4, m+6, m+8, m+10\\}$ partitions into two blocks $\\{m,m+2,m+4\\}$ and $\\{m+6,m+8,m+10\\}$. Within each block the residues mod 3 are $\\{m, m+2, m+1\\} \\equiv \\{0,1,2\\}$ (since $4 \\equiv 1$ and $6 \\equiv 0$), i.e. each block is a complete residue system mod 3. Admissibility at $p=3$ means $H$ cannot realize all three residues, so $H$ misses at least one member of each block. Two missed members in a 6-element window leave at most 4 elements, contradicting $|H| = 5$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "parity filtration",
+      "complete residue system",
+      "pigeonhole counting",
+      "admissibility at p=3"
+    ],
+    "prerequisites": [
+      "IsAdmissible at p=2 and p=3",
+      "Finset.card_le_card, Finset.card_insert_le",
+      "Finset.card_eq_two, Finset.card_eq_three",
+      "interval_cases / omega"
+    ]
+  },
+  {
+    "id": "ann-bgp-oq01-main",
+    "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 184,
+      "endLine": 198
+    },
+    "type": "theorem",
+    "title": "Main Result: D(5) = 12",
+    "content": "minAdmissibleDiameter_5 proves minAdmissibleDiameter 5 = 12 by le_antisymm, mirroring the parent's minAdmissibleDiameter_3 assembly exactly. The upper half (≤) applies csInf_le with the witness {0,2,6,8,12}: its card is 5 (by decide), it is admissible (admissible_5tuple_0_2_6_8_12), and its diameter is 12 (by native_decide). The lower half (≥) supplies nonemptiness of the diameter set from the same witness and then applies le_csInf, discharging each member d via admissible_5tuple_diam_ge_12. The only native_decide calls are the closed-term card and diameter checks of the concrete witness.",
+    "mathContext": "$D(5) = \\inf\\{d : \\exists H,\\ |H|=5 \\wedge \\text{admissible}(H) \\wedge \\mathrm{fsDiameter}(H) = d\\}$. The antisymmetric split sets $D(5) \\le 12$ from the explicit admissible witness of diameter 12 and $D(5) \\ge 12$ from the universal lower bound, pinning $D(5) = 12$ — the $k=5$ entry of OEIS A008407.",
+    "significance": "key",
+    "relatedConcepts": [
+      "infimum / csInf",
+      "le_antisymm",
+      "minimum admissible diameter",
+      "OEIS A008407"
+    ],
+    "prerequisites": [
+      "csInf_le, le_csInf",
+      "admissible_5tuple_diam_ge_12",
+      "admissible_5tuple_0_2_6_8_12"
+    ]
+  }
+]

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+  "title": "Minimum Admissible Diameter D(5) = 12",
+  "slug": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+  "description": "Proves that the minimum diameter of an admissible 5-tuple is exactly 12, extending the verified D(2)=2, D(3)=6, and D(4)=8 results. The upper bound is witnessed by the admissible 5-tuple {0,2,6,8,12}. The lower bound is a self-contained, native_decide-free parity argument: admissibility at p=2 forces every element to share the minimum's parity, which combined with diameter < 12 confines the tuple to {m,m+2,m+4,m+6,m+8,m+10}; that 6-set splits into two disjoint mod-3-complete triples {m,m+2,m+4} and {m+6,m+8,m+10}, and admissibility at p=3 forbids the tuple from containing either triple in full — forcing at least two omissions from a 6-set, impossible for a 5-element set.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-17",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-gaps",
+      "admissible-tuples",
+      "combinatorics",
+      "prime-constellations"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-17",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib. Fully machine-verified, 0 sorries, 0 axiom declarations. The witness card/diameter checks in minAdmissibleDiameter_5 use native_decide (closed-term Lean.ofReduceBool kernel reduction); the load-bearing lower bound admissible_5tuple_diam_ge_12 is native_decide-free and fully symbolic. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
+    "lineCount": 198,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "admissible_5tuple_diam_ge_12: every admissible 5-tuple has diameter ≥ 12, via a fully symbolic (native_decide-free) parity-plus-mod-3 argument interrogating only p ∈ {2,3}",
+      "minAdmissibleDiameter_5: D(5) = 12, completing the verified chain D(2)=2, D(3)=6, D(4)=8, D(5)=12 in OEIS A008407",
+      "admissible_5tuple_0_2_6_8_12: the witness {0,2,6,8,12} is admissible (delegated to the verified library lemma admissible_quintuple_0_2_6_8_12)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The minimum admissible diameter function $D(k)$ (OEIS A008407) encodes the geometry of prime constellations. Hardy and Littlewood's 1923 Conjecture B predicted infinitely many prime $k$-tuples $\\{n+h_1,\\ldots,n+h_k\\}$ for every admissible $k$-tuple $\\{h_i\\}$; the quantity $D(k)$ is the smallest span any such configuration can have.\n\nThe first few values $D(2)=2, D(3)=6, D(4)=8, D(5)=12$ correspond to the famous patterns twin primes $\\{n,n+2\\}$, prime triples $\\{n,n+2,n+6\\}$, prime quadruples $\\{n,n+2,n+6,n+8\\}$, and prime quintuples $\\{n,n+2,n+6,n+8,n+12\\}$.\n\nThe Polymath 8b project (2014) and the Maynard–Tao breakthrough made $D(k)$ computationally important: Maynard's theorem yields bounded prime gaps of size $D(k)$ for suitable $k$. BoundedPrimeGapsOQ03OQ01 proved $D(2)=2$ and $D(3)=6$; the sibling OQ-04 file proved $D(4)=8$. This file answers the next rung, $D(5)=12$, explicitly listed as an open question in the OQ-04 conclusion.",
+    "problemStatement": "Prove that the minimum diameter of an admissible 5-tuple is exactly 12:\n1. (Upper bound) $\\{0,2,6,8,12\\}$ is an admissible 5-tuple of diameter 12.\n2. (Lower bound) No admissible 5-tuple has diameter $< 12$.",
+    "proofStrategy": "**Upper bound** $D(5) \\le 12$: the witness $\\{0,2,6,8,12\\}$ is admissible (the verified `admissible_quintuple_0_2_6_8_12` from BoundedPrimeGaps.lean) and has diameter 12, giving membership in the diameter set; `csInf_le` finishes.\n\n**Lower bound** $D(5) \\ge 12$ (`admissible_5tuple_diam_ge_12`): suppose $H$ is admissible with $|H|=5$ and diameter $< 12$; write $m = \\min H$.\n1. *Parity*: admissibility at $p=2$ means $|H \\bmod 2| < 2 = 1$, so every element shares $m$'s parity (a mixed pair would make the image $\\{0,1\\}$ of card 2).\n2. *Confinement*: same parity + diameter $< 12$ forces each element to equal $m + 2k$ with $k \\in \\{0,\\ldots,5\\}$, so $H \\subseteq \\{m,m+2,m+4,m+6,m+8,m+10\\}$ (`interval_cases` on $x-m$).\n3. *Two complete triples*: the 6-set splits into $\\{m,m+2,m+4\\}$ and $\\{m+6,m+8,m+10\\}$, each of which is mod-3-complete (residues $\\{0,1,2\\}$). Admissibility at $p=3$ ($|H \\bmod 3| < 3$) forbids $H$ from containing either triple in full.\n4. *Counting contradiction*: $H$ must therefore omit at least one element from EACH triple — two distinct omissions from the 6-set — but a 5-element subset of a 6-set omits exactly one. The card bookkeeping ($\\mathrm{insert}\\,a\\,(\\mathrm{insert}\\,b\\,H)$ has card 7 inside a card-$\\le 6$ set) closes it.\n\nOnly the primes $p \\in \\{2,3\\}$ are interrogated, so the lower bound needs no `Decidable IsAdmissible` instance and uses no `native_decide`.",
+    "keyInsights": [
+      "Admissibility at $p=2$ is a parity filter (the image mod 2 must have card $< 2$), forcing every admissible set to be monochromatic mod 2 — exactly the step that opens the D(3) and D(4) proofs, reused verbatim here.",
+      "The decisive new ingredient at $k=5$ is the two-triple decomposition: under same parity and span $\\le 10$, the candidate window $\\{m,\\ldots,m+10\\}$ partitions into two mod-3-complete triples. Each triple is independently forbidden by $p=3$ admissibility, so a 5-set must drop one element from each — a parity-of-omissions counting argument rather than a single residue clash.",
+      "Interrogating only $p \\in \\{2,3\\}$ sidesteps the `Decidable IsAdmissible` obstruction entirely: `IsAdmissible` quantifies over all primes and is not decidable, so an earlier `native_decide`-on-`¬IsAdmissible` route does not typecheck — the symbolic two-prime argument is both shorter and verifier-friendly.",
+      "The proof is compositional in the same way as D(4): it reduces the diameter bound to a finite residue obstruction, adding exactly one new layer (the mod-3 two-triple count) on top of the mod-2 parity layer.",
+      "Constructing the explicit 6-element window and reasoning about its cardinality via iterated `Finset.card_insert_le` plus `omega` avoids the `card_insert_of_notMem` API instability, a pattern reusable for the $D(k)$ window arguments generally."
+    ],
+    "prerequisites": [
+      "admissible_quintuple_0_2_6_8_12: the witness {0,2,6,8,12} is admissible (BoundedPrimeGaps.lean)",
+      "IsAdmissible, fsDiameter, minAdmissibleDiameter definitions (BoundedPrimeGaps.lean / BoundedPrimeGapsOQ03OQ01.lean)",
+      "D(2)=2, D(3)=6, D(4)=8: prior results in the series",
+      "admissible_triple_diam_ge_6: the parity-argument template this lower bound mirrors"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-bgp-oq01-header",
+      "title": "Header and Proof Strategy Documentation",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module header explaining D(5) = 12, its place in the OEIS A008407 chain D(2)=2, D(3)=6, D(4)=8, D(5)=12, and the upper-bound-witness / symbolic-lower-bound proof plan. Emphasizes that only p ∈ {2,3} are interrogated, so no Decidable IsAdmissible instance is needed."
+    },
+    {
+      "id": "sec-bgp-oq01-witness",
+      "title": "Part I: Witness Admissibility {0,2,6,8,12}",
+      "startLine": 35,
+      "endLine": 44,
+      "summary": "admissible_5tuple_0_2_6_8_12 delegates to the verified, registered admissible_quintuple_0_2_6_8_12 from BoundedPrimeGaps.lean, supplying the admissible diameter-12 witness for the upper bound."
+    },
+    {
+      "id": "sec-bgp-oq01-lower-bound",
+      "title": "Part II: Lower Bound — Every Admissible 5-Tuple has Diameter ≥ 12",
+      "startLine": 46,
+      "endLine": 182,
+      "summary": "admissible_5tuple_diam_ge_12 by contradiction on diameter < 12: (1) p=2 admissibility forces every element to share min's parity; (2) parity + bounded span confines H to the 6-set {m,m+2,m+4,m+6,m+8,m+10} via interval_cases; (3) the two disjoint mod-3-complete triples {m,m+2,m+4} and {m+6,m+8,m+10} are each forbidden in full by p=3 admissibility; (4) hence ≥2 omissions from a 6-set of card 5 — impossible by an insert/card-7-in-a-6-set count."
+    },
+    {
+      "id": "sec-bgp-oq01-main-result",
+      "title": "Part III: Main Result D(5) = 12",
+      "startLine": 184,
+      "endLine": 198,
+      "summary": "minAdmissibleDiameter_5 = 12 via le_antisymm, exactly mirroring minAdmissibleDiameter_3: upper bound from the admissible witness {0,2,6,8,12} via csInf_le; lower bound from admissible_5tuple_diam_ge_12 via le_csInf."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. The lower bound is fully symbolic (native_decide-free), interrogating only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument. 198 lines, 3 theorems, 0 sorries, 0 axioms.",
+    "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, and now $D(5)=12$ all machine-verified, the smallest five prime-constellation diameters are formally established in Lean 4. The two-triple counting argument is the natural successor to the single-AP obstruction used for $D(4)$ and extends the reusable proof infrastructure (parity filtration, residue-complete-block counting) toward $D(6)=16$ and beyond. Under the Elliott–Halberstam conjecture, $D(5)=12$ is the exact predicted span for prime quintuples $n, n+2, n+6, n+8, n+12$.",
+    "openQuestions": [
+      "Prove $D(6)=16$ by extending the block-counting argument: the candidate window widens and the mod-5 obstruction must be combined with the mod-2 and mod-3 ones used here.",
+      "Automate $D(k)$ for small $k$ via a decidability bridge: reduce IsAdmissible on a bounded window to a finite prime check ($p \\le k$) so a single decision procedure can certify $D(k)$ for $k \\leq 10$ without the bespoke symbolic argument."
+    ],
+    "crossReferences": [
+      "bounded-prime-gaps",
+      "bounded-prime-gaps-oq-03-oq-01",
+      "bounded-prime-gaps-oq-03-oq-01-oq-04",
+      "bounded-prime-gaps-oq-03"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "extends",
+      "description": "Parent proof containing the admissible_quintuple_0_2_6_8_12 witness and the IsAdmissible / admissible_subset infrastructure used in the D(5)=12 proof"
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Prior OQ file proving D(2)=2 and D(3)=6 and defining fsDiameter / minAdmissibleDiameter; this file adds the D(5)=12 rung mirroring its minAdmissibleDiameter_3 assembly"
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-03-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Sibling file proving D(4)=8, whose conclusion explicitly lists D(5)=12 as the next open question answered here"
+    }
+  ],
+  "leanFile": {
+    "namespace": "BoundedPrimeGapsOQ03OQ01OQ01",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **`minAdmissibleDiameter 5 = 12`** — the minimum diameter of an admissible 5-tuple is exactly 12 (OEIS A008407, $k=5$). This completes the verified chain $D(2)=2,\ D(3)=6,\ D(4)=8,\ D(5)=12$, answering the open question explicitly listed in the sibling D(4)=8 file's conclusion.

This is a **finite combinatorial fact** — not the parent's open Maynard–Tao / Engelsma-246 barrier.

## What's here

- **`proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean`** (198 L, 3 theorems, 0 sorries, 0 axiom declarations), registered in `Proofs.lean`. **Docker build succeeded (7746 jobs).**
  - *Upper bound* $D(5)\le 12$: the admissible witness $\{0,2,6,8,12\}$ (reusing the verified `admissible_quintuple_0_2_6_8_12`).
  - *Lower bound* `admissible_5tuple_diam_ge_12`: a fully symbolic, **`native_decide`-free** argument interrogating only $p\in\{2,3\}$ — $p=2$ admissibility forces shared parity; diameter $<12$ confines the tuple to $\{m,m+2,\dots,m+10\}$; the two disjoint mod-3-complete triples each forbid full inclusion under $p=3$, forcing $\ge 2$ omissions from a 6-set of card 5 — impossible.
  - The only two `native_decide` calls are the closed-term card/diameter checks of the concrete witness in `minAdmissibleDiameter_5`.
- **Gallery**: `src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/{meta.json,annotations.json}` — `verified`/`original`, 4 annotations (resolver reports 4 valid / 0 misaligned).

## Provenance

Promotes researcher-1's complete-but-build-pending `D5-draft.lean` (authored over 3 sessions under Docker/Aristotle blackout) to a verified, registered proof. Build fix: the draft's lower bound proved 18 "element ∈ 6-set" memberships with `simp [mem_insert]; omega`; the resulting 6-way disjunction made `omega` heartbeat-sensitive (14/18 passed, 4 failed nondeterministically). Replaced with explicit, search-free `Finset.mem_insert` term proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)