### PR TITLE
Fix: reclassify native_decide entries verified→axiomatized (#25409)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "additionalFiles": [
       "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
@@ -18,11 +18,11 @@
       "solvability",
       "abel-ruffini"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 534,
     "theoremCount": 59,
     "definitionCount": 1,

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Abel (1824), Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
     "date": "1824",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01.lean",
     "tags": [
       "algebra",
@@ -18,10 +18,10 @@
       "eisenstein-criterion",
       "wiedijk-100"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries after PR #6856 eliminated all remaining assumptions. Former axioms B1 (disc_p_neg) and B2 (vandermonde_sq_eq_disc_p) are now proved. Axiom A (three_dvd_gal_card) was proved via complex conjugation. All Galois group order exclusions (|Gal|≠10, ≠20, ≠40) are now proved via Sylow theory.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries after PR #6856 eliminated all remaining assumptions. Former axioms B1 (disc_p_neg) and B2 (vandermonde_sq_eq_disc_p) are now proved. Axiom A (three_dvd_gal_card) was proved via complex conjugation. All Galois group order exclusions (|Gal|≠10, ≠20, ≠40) are now proved via Sylow theory. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "wiedijkNumber": 16,
     "dateAdded": "2026-03-25",
     "mathlibDependencies": [

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Galois, Jordan)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Alternating_groups_and_the_Feit%E2%80%93Thompson_theorem",
     "date": "1832",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
     "tags": [
       "algebra",
@@ -18,7 +18,7 @@
       "research",
       "extension"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -59,9 +59,9 @@
       "alternating_solvable_iff: Complete bidirectional classification A_n solvable ↔ n ≤ 4"
     ],
     "dateAdded": "2026-04-05",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 167,
-    "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction.",
+    "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ03.lean",
     "tags": [
       "group-theory",
@@ -15,11 +15,11 @@
       "burnside-theorem",
       "abel-ruffini"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Core results obtained via Mathlib bridge: pGroup_isSolvable chains hG.isNilpotent + inferInstance; s5_not_solvable aliases Equiv.Perm.fin_5_not_solvable directly; abelian_isSolvable is inferInstance.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. Core results obtained via Mathlib bridge: pGroup_isSolvable chains hG.isNilpotent + inferInstance; s5_not_solvable aliases Equiv.Perm.fin_5_not_solvable directly; abelian_isSolvable is inferInstance. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 104,
     "theoremCount": 4,
     "definitionCount": 0,
@@ -155,21 +155,27 @@
   ],
   "references": [
     {
-      "authors": ["W. Burnside"],
+      "authors": [
+        "W. Burnside"
+      ],
       "title": "On groups of order p^α q^β",
       "year": "1904",
       "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388–392",
       "note": "Proved that every group of order p^a q^b (two primes) is solvable. A₅ (order 60 = 2²·3·5, three primes) is the smallest group escaping this criterion. This result is axiomatized in the formalization for the two-prime orders."
     },
     {
-      "authors": ["P. Hall"],
+      "authors": [
+        "P. Hall"
+      ],
       "title": "A note on soluble groups",
       "year": "1928",
       "venue": "Journal of the London Mathematical Society, 3(2), pp. 98–105",
       "note": "Hall's theorem characterizes solvable groups via the existence of Hall subgroups of every coprime order. Provides the positive structural test complementing Burnside's sufficient condition."
     },
     {
-      "authors": ["J. J. Rotman"],
+      "authors": [
+        "J. J. Rotman"
+      ],
       "title": "An Introduction to the Theory of Groups",
       "year": "1995",
       "venue": "Springer GTM 148, 4th edition",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Lagrange, Galois)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group#Solvable_and_perfect_groups",
     "date": "1832",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02.lean",
     "tags": [
       "algebra",
@@ -19,7 +19,7 @@
       "extension",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,9 +40,9 @@
       "solvable_iff_le_four: Complete bidirectional classification Sₙ solvable ↔ n ≤ 4"
     ],
     "dateAdded": "2026-03-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 154,
-    "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable.",
+    "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ01.lean",
     "tags": [
       "galois-theory",
@@ -16,11 +16,11 @@
       "fermat-primes",
       "regular-polygons"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 366,
     "theoremCount": 44,
     "definitionCount": 3,

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Gauss (1796), Wantzel (1837), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ03.lean",
     "tags": [
       "geometry",
@@ -21,7 +21,7 @@
       "extension",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,7 +55,7 @@
       "Connection to OQ02: Galois group order = φ(n) → 2-group criterion"
     ],
     "dateAdded": "2026-02-24",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 1799,
     "prerequisites": [
       "Euler's totient function and its basic properties",
@@ -63,7 +63,7 @@
       "Galois theory (cyclotomic extensions, 2-groups)",
       "Compass-and-straightedge constructibility criteria (from OQ-01, OQ-02)"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 158,
     "definitionCount": 5

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -27,7 +27,7 @@
     "author": "Formalized in Lean 4 (researcher-4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ01.lean",
     "tags": [
       "geometry",
@@ -40,12 +40,12 @@
       "enumeration",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 12,
     "lineCount": 150,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "A regular n-gon is constructible by compass and marked ruler (neusis) iff n = 2^a · 3^b · p₁ · ... · pₖ where each pᵢ is a Pierpont prime (p-1 = 2^u · 3^v). Verifies 12 Pierpont primes and 4 non-examples, plus neusis constructibility for specific polygons.",
   "meta": {
     "author": "Lean Genius OQ04-OQ03",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ04OQ03.lean",
     "additionalFiles": [
       "Proofs/AngleTrisectionOQ04.lean"
@@ -18,12 +18,12 @@
       "number-theory",
       "galois-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 328,
     "theoremCount": 54,
-    "assumptions": "None. All 54 theorems proved. Pierpont prime verification via native_decide.",
+    "assumptions": "None. All 54 theorems proved. Pierpont prime verification via native_decide. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",

--- a/src/data/proofs/arithmetic-series-oq-00/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Nicomachus of Gerasa (c. 100 CE); formalized in Lean 4",
     "date": "c. 100 CE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ00.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "power-sums",
       "classical-identity"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 160,
-    "assumptions": "0 axioms, 0 sorries. Elementary induction proof: no deep Mathlib dependencies beyond basic Finset sum lemmas and ring arithmetic.",
+    "assumptions": "0 axioms, 0 sorries. Elementary induction proof: no deep Mathlib dependencies beyond basic Finset sum lemmas and ring arithmetic. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hockey-stick_identity",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,11 +18,11 @@
       "Pascal's triangle",
       "generating functions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde).",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde). This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 165,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "G. Pólya (1937); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/P%C3%B3lya_enumeration_theorem",
     "date": "1937",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
     "dateAdded": "2026-04-04",
     "tags": [
@@ -21,9 +21,9 @@
       "zmod",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 30,
     "defCount": 5,
     "lineCount": 507,
@@ -52,7 +52,8 @@
       "Explicit necklace counts necklaceCount n 2 for n=1,...,6 via Burnside helper",
       "Key proof technique: use Eq.trans to avoid binder-name mismatch in Burnside sum"
     ],
-    "definitionCount": 5
+    "definitionCount": 5,
+    "assumptions": "This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations)."
   },
   "overview": {
     "historicalContext": "Pólya's enumeration theorem was published by George Pólya in 1937 ('Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen', Acta Mathematica 68). It gave a systematic method for counting combinatorial objects up to symmetry, with applications ranging from necklace counting to chemical isomer enumeration. The theorem generalizes Burnside's lemma (1897, also called the Cauchy-Frobenius lemma) from counting orbits to counting orbits weighted by color frequencies. Pólya's insight was the 'cycle index' of a group action: Z(G; x₁,...,xₖ) = (1/|G|) Σ_{g∈G} ∏_j xⱼ^{cⱼ(g)}, where cⱼ(g) counts j-cycles in the permutation g. Setting all variables to k gives the number of distinct k-colorings.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Vandermonde (1772), generating function proof",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
     "date": "1772",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
     "tags": [
       "combinatorics",
@@ -16,11 +16,11 @@
       "vandermonde",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 207,
-    "assumptions": "No axioms. All results proved from Mathlib. The generating function proof is an alternative to the inductive proof in the parent file.",
+    "assumptions": "No axioms. All results proved from Mathlib. The generating function proof is an alternative to the inductive proof in the parent file. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Vandermonde (1772), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
     "date": "1772",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
     "tags": [
       "combinatorics",
@@ -15,7 +15,7 @@
       "induction",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,14 +39,14 @@
       "hockey_stick_2d: Σ_{i+j≤n} C(i+a,a)·C(j+b,b) = C(n+a+b+2, a+b+2) — composed from 1D hockey stick + parallel Vandermonde"
     ],
     "dateAdded": "2026-03-22",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Binomial coefficients",
       "Pascal's identity",
       "Simplicial numbers"
     ],
     "lineCount": 154,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 1

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,14 @@
       "permutations",
       "arithmetic-series"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 169,
     "theoremCount": 12,
     "definitionCount": 0,
-    "assumptions": "None. Fully machine-verified. Imports ArithmeticSeriesOQ02OQ04.lean (0 axioms).",
+    "assumptions": "None. Fully machine-verified. Imports ArithmeticSeriesOQ02OQ04.lean (0 axioms). This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "choose_descFactorial: C(n,k) * k! = n.descFactorial(k) — the ordered selection identity",
       "choose_product: explicit product form C(n,k) * k! = ∏ i in range k, (n - i)",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Pochhammer (1870), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Falling_and_rising_factorials",
     "date": "1870",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
     "tags": [
       "combinatorics",
@@ -15,7 +15,7 @@
       "binomial",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -42,14 +42,14 @@
       "factorial_dvd_ascFactorial: k! divides ascFactorial(n+1, k) -- divisibility corollary"
     ],
     "dateAdded": "2026-03-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Binomial coefficients",
       "Ascending factorial",
       "Simplicial numbers"
     ],
     "lineCount": 158,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 0

--- a/src/data/proofs/arithmetic-series-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hockey_stick_identity",
     "date": "~300 BCE (Pascal's triangle; formalized 2026)",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "combinatorics",
@@ -17,7 +17,7 @@
       "induction"
     ],
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -61,9 +61,9 @@
       "simplicial_three_formula: S_3(n) * 6 = (n+1)(n+2)(n+3) — tetrahedral number closed form"
     ],
     "dateAdded": "2026-02-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 209,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 1

--- a/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Johann Faulhaber (1631); formalized in Lean 4",
     "date": "1631",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ04OQ01.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "combinatorics",
       "induction"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 305,
-    "assumptions": "0 axioms, 0 sorries. All theorems proved by induction with push_cast + linarith. Uses Mathlib only for Finset.sum_Ico_succ_top and push_cast.",
+    "assumptions": "0 axioms, 0 sorries. All theorems proved by induction with push_cast + linarith. Uses Mathlib only for Finset.sum_Ico_succ_top and push_cast. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/arithmetic-series-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Johann Faulhaber (1580–1635); Jacob Bernoulli (1713); formalized in Lean 4",
     "date": "1713",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ04.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "arithmetic-series",
       "induction"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 197,
-    "assumptions": "0 axioms, 0 sorries. Core result relies on Mathlib's sum_Ico_pow (Faulhaber's formula) and sum_range_pow. The main theorem faulhaber_formula is a direct alias of sum_Ico_pow. Corollaries (p=1,2,3) and Bernoulli number values are derived from Mathlib.",
+    "assumptions": "0 axioms, 0 sorries. Core result relies on Mathlib's sum_Ico_pow (Faulhaber's formula) and sum_range_pow. The main theorem faulhaber_formula is a direct alias of sum_Ico_pow. Corollaries (p=1,2,3) and Bernoulli number values are derived from Mathlib. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -7,7 +7,7 @@
     "author": "Carl Friedrich Gauss (formalized via Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Intervals.html",
     "date": "~1785",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeries.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "classic",
       "gauss"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,7 +40,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 180,
     "relatedProblems": [
       {
@@ -52,7 +52,7 @@
         "relationship": "Further extensions of simplicial number theory"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical setup; counterexample formalization new",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ballot_problem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ04.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "counterexample",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -33,9 +33,9 @@
       "Scaled ballot formula: (ap-bq)/(ap+bq) for uniform weight scaling"
     ],
     "dateAdded": "2026-04-05",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 311,
-    "assumptions": "0 sorries, 0 axioms. Counterexample verified by native_decide and norm_num. Structural theorems proved directly.",
+    "assumptions": "0 sorries, 0 axioms. Counterexample verified by native_decide and norm_num. Structural theorems proved directly. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
     "definitionCount": 4

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Bertrand (1887), Catalan (1838); formalized by researcher-10",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number#First_proof",
     "date": "1887",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "recurrence",
       "convolution"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "originalContributions": [
       "Bridge cn_eq_catalan: LatticePathLGV.Cn n = catalan n (Mathlib root namespace) via centralBinom characterization",
@@ -26,9 +26,9 @@
       "Verification: small cases n=0,1,2,3,4 via native_decide"
     ],
     "dateAdded": "2026-04-23",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 182,
-    "assumptions": "0 sorries. All proofs are complete. Uses Mathlib's catalan_succ' and catalan_eq_centralBinom_div as infrastructure.",
+    "assumptions": "0 sorries. All proofs are complete. Uses Mathlib's catalan_succ' and catalan_eq_centralBinom_div as infrastructure. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1

--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-26",
-    "status": "verified",
+    "status": "axiomatized",
     "note": "all axioms eliminated: moebius_dirichlet_series_at_two proved 2026-05-03; coprime_pair_density_limit proved via tendsto_tsum_of_dominated_convergence (2026-05-03)",
     "proofRepoPath": "Proofs/BaselProblemOQ04OQ03.lean",
     "tags": [
@@ -18,7 +18,7 @@
       "coprimality",
       "basel-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-26",
     "mathlibDependencies": [
@@ -51,9 +51,9 @@
       "Numerical verification for N=1,2,3,4,5,10 via native_decide",
       "Density bounds: 3/8 < 6/π² < 2/3 (from π > 3 and π < 4)"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 558,
-    "assumptions": "No remaining assumptions — fully verified.",
+    "assumptions": "No remaining assumptions — fully verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 24,
     "definitionCount": 1
   },

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integer#Gaussian_primes",
     "date": "Gauss 1832; formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "algebra",
       "number-theory",
@@ -16,10 +16,10 @@
       "prime-classification"
     ],
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses native_decide for concrete norm primality checks (standard Lean 4 kernel verification). All structural results follow from Mathlib's GaussianInt and Zsqrtd APIs.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. Uses native_decide for concrete norm primality checks (standard Lean 4 kernel verification). All structural results follow from Mathlib's GaussianInt and Zsqrtd APIs. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 193,
     "theoremCount": 14,
     "definitionCount": 0,

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BinaryGcdOQ01.lean",
     "tags": [
       "algorithms",
@@ -16,7 +16,7 @@
       "complexity",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -40,9 +40,9 @@
       "Proof of Binary GCD bound: steps ≤ 2·(log₂(a) + log₂(b)) + 2",
       "Concrete step counts via native_decide"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 215,
-    "assumptions": "None. 0 axiom declarations, 0 sorries.",
+    "assumptions": "None. 0 axiom declarations, 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "prerequisites": [
       "Natural number GCD and divisibility",
       "Logarithmic functions on naturals",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-04-26",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "multinomial",
@@ -19,12 +19,12 @@
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 185,
-    "assumptions": "No axioms, no sorries. Uses native_decide for computational verifications.",
+    "assumptions": "No axioms, no sorries. Uses native_decide for computational verifications. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "Composition.ext_counts: extensionality via counts field using proof irrelevance",
       "compositionEquiv: explicit bijection Composition α s n ≃ ↥(s.piAntidiag n)",

--- a/src/data/proofs/birthday-problem-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01/meta.json
@@ -5,7 +5,7 @@
   "description": "The expected number of shared birthday pairs among n people with d equally likely birthdays is C(n,2)/d = n(n-1)/(2d). Proved: formula, monotonicity, variance bounds, threshold computations (n=28 first exceeds 1 pair for d=365), and general threshold criterion.",
   "meta": {
     "author": "Lean Genius OQ-01",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BirthdayProblemOQ01.lean",
     "tags": [
       "probability",
@@ -14,12 +14,12 @@
       "expected-value",
       "variance"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 513,
     "theoremCount": 53,
-    "assumptions": "None. All 53 theorems fully proved using Mathlib combinatorics.",
+    "assumptions": "None. All 53 theorems fully proved using Mathlib combinatorics. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "researcher-3",
     "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem#Generalizations",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,10 +20,10 @@
       "open-question",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Birthday threshold computed via native_decide.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Birthday threshold computed via native_decide. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "R (slot-based recurrence): computable definition R n e s tracking slot state (e empty, s single)",
       "birthdayCount3: total valid count as R n d 0, terminating in O(n²) recursion",

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -7,7 +7,7 @@
     "author": "von Mises (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem",
     "date": "1939",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "probability",
       "combinatorics",
@@ -20,7 +20,7 @@
     "additionalFiles": [
       "Proofs/BirthdayProblemAsymptotics.lean"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "prerequisites": [
       "Probability theory and finite sample spaces",
@@ -55,8 +55,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 93,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and no structure-encoded assumptions. All 27 theorems are proved using Mathlib (Fintype.card_embedding_eq, Nat.descFactorial, Fintype.card_fun) and native_decide for large integer comparisons (up to 146-digit numbers). No custom axioms or definition sorries.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and no structure-encoded assumptions. All 27 theorems are proved using Mathlib (Fintype.card_embedding_eq, Nat.descFactorial, Fintype.card_fun) and native_decide for large integer comparisons (up to 146-digit numbers). No custom axioms or definition sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "relatedProblems": [
       {
         "id": "ballot-problem",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ04.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "combinatorics",
       "prime-constellations"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. Uses only Mathlib and the admissible_quadruple_0_2_6_8 witness from BoundedPrimeGaps.lean.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. Uses only Mathlib and the admissible_quadruple_0_2_6_8 witness from BoundedPrimeGaps.lean. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 187,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChebyshevBounds.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "bertrand-postulate",
       "analytic-number-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 439,
     "theoremCount": 15,
     "definitionCount": 3,
@@ -149,7 +149,10 @@
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat", "Finset"]
+    "opens": [
+      "Nat",
+      "Finset"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "chebyshev-pnt-bridge-oq-01",
   "description": "Proves the prime power factorization bound for central binomial coefficients: p^{v_p(C(2n,n))} ≤ 2n. Key ingredient in Chebyshev's proof of Bertrand's postulate. Uses the carry-counting interpretation of Kummer's theorem.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01.lean",
     "tags": [
       "number-theory",
@@ -13,11 +13,11 @@
       "Chebyshev",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 210,
-    "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",
+    "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Researcher",
     "date": "2026-05-06",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ04OQ02.lean",
     "tags": [
       "number-theory",
@@ -15,7 +15,7 @@
       "connection",
       "chinese-remainder-theorem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -57,10 +57,10 @@
     ],
     "references": [],
     "dateAdded": "2026-05-06",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 180,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 12,
     "definitionCount": 0
   },

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Sunzi / CRT), formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
     "date": "3rd century",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ04OQ04.lean",
     "tags": [
       "number-theory",
@@ -16,13 +16,13 @@
       "uniqueness",
       "canonical-form"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "dateAdded": "2026-04-02",
     "mathlib_version": "4.26.0",
     "lineCount": 122,
-    "assumptions": "None. All theorems fully proved with 0 sorries and 0 axioms.",
+    "assumptions": "None. All theorems fully proved with 0 sorries and 0 axioms. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.mod_mod_of_dvd",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized here (extending Garner 1959)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "lcm",
       "k-moduli"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,9 +51,9 @@
       "kModuli_necessary: gcd(mᵢ,mⱼ) | (aᵢ - aⱼ) necessary condition"
     ],
     "dateAdded": "2026-04-13",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 249,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
     "definitionCount": 1

--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CollatzCycles.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "cycles",
       "number-sequences"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 256,
     "theoremCount": 27,
     "definitionCount": 4,

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lagarias, Eliahou (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Collatz_conjecture#Cycle_length",
     "date": "1985",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "dynamics",
@@ -16,9 +16,9 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/CollatzCycles.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Function.iterate",
@@ -38,7 +38,7 @@
     "dateAdded": "2026-03-23",
     "lineCount": 256,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 27,
     "definitionCount": 4
   },

--- a/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-04/meta.json
@@ -7,8 +7,8 @@
     "author": "Lean Genius Research Team",
     "date": "2026-05-04",
     "dateAdded": "2026-05-04",
-    "status": "verified",
-    "badge": "original",
+    "status": "axiomatized",
+    "badge": "axiom",
     "tags": [
       "combinatorics",
       "lattice-paths",
@@ -19,7 +19,7 @@
       "binomial-coefficients"
     ],
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 189,
     "theoremCount": 12,
     "definitionCount": 2,
@@ -37,7 +37,7 @@
       "lgv_2x2_not_wellFormed_when_b_zero: well-formedness failure example",
       "lgv_det_is_natural: the determinant is always a natural number"
     ],
-    "assumptions": []
+    "assumptions": "This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations)."
   },
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) Lemma was discovered independently by Bernt Lindström in 1973 (\"On the vector representations of induced matroids\", Bull. London Math. Soc.) and rediscovered by Ira Gessel and Gérard Viennot in 1985 (\"Binomial determinants, paths, and hook length formulae\", Adv. in Math. 58). Karlin and McGregor (1959) had earlier proved a continuous-time analog for non-intersecting Brownian motions, foreshadowing the lattice case. The LGV lemma unifies a remarkable range of classical results: MacMahon's 1916 formula for plane partitions in a box, Cauchy's 1841 determinant identity for Schur polynomials, Catalan numbers as ballot path counts, and the Karlin-McGregor formula. Its modern significance extends to the theory of cluster algebras (Fomin-Zelevinsky), totally positive matrices (the binomial path matrix is totally positive), and the geometric proof of the Cauchy-Binet formula. The sign-reversing involution that drives the proof is itself a paradigmatic example of bijective combinatorics — it turns an algebraic identity (determinant = sum over permutations) into a combinatorial bijection between path tuples.",

--- a/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Efficiency",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CramersRuleOQ02OQ02.lean",
     "tags": [
       "computational-complexity",
@@ -19,7 +19,7 @@
       "factorial-growth",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -54,9 +54,9 @@
     ],
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 189,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 13,
     "definitionCount": 2
   },

--- a/src/data/proofs/cramers-rule-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Efficiency",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CramersRuleOQ02.lean",
     "tags": [
       "computational-complexity",
@@ -19,7 +19,7 @@
       "algorithms",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -52,9 +52,9 @@
     ],
     "dateAdded": "2026-02-26",
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 207,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 16,
     "definitionCount": 3
   },

--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DerangementsOQ02OQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,14 @@
       "probability",
       "generating-functions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 249,
     "theoremCount": 13,
     "definitionCount": 0,
-    "assumptions": "None.",
+    "assumptions": "None. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "Proof of ∑_σ |Fix(σ)| = n! via Burnside's lemma using MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
       "Proof that exactly (n-1)! permutations fix any given point via orbit-stabilizer theorem",

--- a/src/data/proofs/divisibility-by-3-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Extension of Divisibility by 3 (Wiedijk #85)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule",
     "date": "2026-02-10",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "divisibility",
@@ -16,7 +16,7 @@
       "comprehensive"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,9 +50,9 @@
       "Digit-sum rules in 10+ bases (hex, octal, base 7, base 1000)"
     ],
     "dateAdded": "2026-02-10",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 550,
-    "assumptions": "0 axioms, 0 sorries. Core digit-sum congruence from Mathlib's Nat.modEq_digits_sum and Nat.dvd_iff_dvd_digits_sum.",
+    "assumptions": "0 axioms, 0 sorries. Core digit-sum congruence from Mathlib's Nat.modEq_digits_sum and Nat.dvd_iff_dvd_digits_sum. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 56,
     "definitionCount": 1

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -2,9 +2,9 @@
   "id": "divisibility-by-3-oq-03-oq-02",
   "title": "Base-Parametrized Digital Root dr_b(n)",
   "slug": "divisibility-by-3-oq-03-oq-02",
-  "description": "Generalizes the digital root from base 10 to arbitrary base b \u2265 2. Proves the closed-form formula dr_b(n) = 1 + ((n-1) mod (b-1)), idempotence, divisibility criteria, multiplicativity, and specializations to base 10 (casting out nines) and base 2.",
+  "description": "Generalizes the digital root from base 10 to arbitrary base b ≥ 2. Proves the closed-form formula dr_b(n) = 1 + ((n-1) mod (b-1)), idempotence, divisibility criteria, multiplicativity, and specializations to base 10 (casting out nines) and base 2.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03OQ02.lean",
     "tags": [
       "number-theory",
@@ -13,23 +13,23 @@
       "modular-arithmetic",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 211,
     "theoremCount": 21,
     "definitionCount": 1,
-    "assumptions": [],
+    "assumptions": "This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-04-12",
     "mathlibDependencies": [
       {
         "theorem": "Nat.modEq_digits_sum",
-        "description": "n \u2261 (digits b n).sum (mod d) when b \u2261 1 (mod d)",
+        "description": "n ≡ (digits b n).sum (mod d) when b ≡ 1 (mod d)",
         "module": "Mathlib.Data.Nat.Digits"
       },
       {
         "theorem": "Nat.dvd_iff_dvd_digits_sum",
-        "description": "d | n iff d | (digits b n).sum when b \u2261 1 (mod d)",
+        "description": "d | n iff d | (digits b n).sum when b ≡ 1 (mod d)",
         "module": "Mathlib.Data.Nat.Digits"
       },
       {
@@ -41,14 +41,14 @@
     "originalContributions": [
       "Base-parametrized digital root definition and closed form (proved)",
       "Range, fixed point, and idempotence properties (proved)",
-      "Congruence: dr_b(n) \u2261 n mod (b-1) (proved)",
+      "Congruence: dr_b(n) ≡ n mod (b-1) (proved)",
       "Divisibility by (b-1) and factor divisibility rule (proved)",
       "Concrete examples in hex (base 16), octal (base 8), and base 7 (proved)"
     ]
   },
   "parent": "divisibility-by-3-oq-03",
   "openQuestion": "Can Lean 4 formalize a base-parametrized version of the digital root, generalizing the base-10 results to arbitrary base b?",
-  "significance": "This formalization reveals the universal algebraic structure behind digital roots: for any base b \u2265 3, the digital root dr_b(n) depends only on n mod (b-1), because b \u2261 1 (mod b-1). This single congruence explains casting out nines (b=10), casting out sevens in octal (b=8), and every other base's analog. The formalization uses Mathlib's Nat.modEq_digits_sum as the bridge between digit sums and modular arithmetic.",
+  "significance": "This formalization reveals the universal algebraic structure behind digital roots: for any base b ≥ 3, the digital root dr_b(n) depends only on n mod (b-1), because b ≡ 1 (mod b-1). This single congruence explains casting out nines (b=10), casting out sevens in octal (b=8), and every other base's analog. The formalization uses Mathlib's Nat.modEq_digits_sum as the bridge between digit sums and modular arithmetic.",
   "overview": {
     "historicalContext": "The digital root -- the single digit obtained by repeatedly summing a number's digits -- has been used as a divisibility check since at least the 12th century, when it appeared in Fibonacci's *Liber Abaci* (1202) under the name *casting out nines*. The technique was known to Arabic and Indian mathematicians even earlier; al-Khwarizmi described it in his 9th-century treatise on Hindu-Arabic numerals.\n\nThe generalization to arbitrary bases reveals that the digital root is not a peculiarity of base 10, but a consequence of the fundamental fact that $b \\equiv 1 \\pmod{b-1}$ for any base $b$. This means $b^k \\equiv 1 \\pmod{b-1}$, so $n = \\sum_i d_i b^i \\equiv \\sum_i d_i \\pmod{b-1}$ -- the digit sum preserves residues modulo $b-1$.\n\nThe closed-form formula $\\text{dr}_b(n) = 1 + ((n-1) \\bmod (b-1))$ for $n > 0$ was known informally but rarely stated precisely. It maps $\\{1, 2, \\ldots, b-1\\}$ cyclically through the residues, with the adjustment ensuring $\\text{dr}_b(b-1) = b-1$ rather than 0.\n\nIn computer science, the digital root in base $2^k$ (binary, hex, octal) is computed by simple bitmasking, and the factor divisibility rule explains why casting out 15s works in hexadecimal and casting out 7s works in octal -- both are instances of the general principle that divisors of $b-1$ can be tested via digit sums.",
     "problemStatement": "**Definition**: For base $b \\geq 2$ and $n \\in \\mathbb{N}$:\n$$\\text{dr}_b(n) = \\begin{cases} 0 & \\text{if } n = 0 \\\\ 1 + ((n-1) \\bmod (b-1)) & \\text{if } n > 0 \\end{cases}$$\n\n**Prove**:\n1. Range: $1 \\leq \\text{dr}_b(n) \\leq b-1$ for $n > 0$\n2. Fixed point: $\\text{dr}_b(n) = n$ for $1 \\leq n \\leq b-1$\n3. Idempotence: $\\text{dr}_b(\\text{dr}_b(n)) = \\text{dr}_b(n)$\n4. Congruence: $n \\equiv \\text{dr}_b(n) \\pmod{b-1}$\n5. Divisibility: $(b-1) \\mid n \\iff \\text{dr}_b(n) = b-1$ (for $n > 0$)\n6. Factor rule: $d \\mid (b-1) \\Rightarrow (d \\mid n \\iff d \\mid \\text{digitSum}_b(n))$",
@@ -156,7 +156,7 @@
       "title": "An Introduction to the Theory of Numbers",
       "year": "1979",
       "venue": "Oxford University Press, 5th edition",
-      "note": "Section 9.9 discusses digital roots and the general congruence n \u2261 (digit sum) mod (b-1). The factor divisibility rule is implicit in the treatment of divisibility tests."
+      "note": "Section 9.9 discusses digital roots and the general congruence n ≡ (digit sum) mod (b-1). The factor divisibility rule is implicit in the treatment of divisibility tests."
     },
     {
       "authors": "Hare, Kevin; Laishram, Shanta; Stoll, Thomas",

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical result",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root",
     "date": "Classical",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03.lean",
     "tags": [
       "number-theory",
@@ -17,10 +17,10 @@
       "algorithms",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "Fully verified: 0 axiom declarations, 0 sorries.",
+    "axiomCount": 1,
+    "assumptions": "Fully verified: 0 axiom declarations, 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 270,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/divisibility-by-3-oq-04-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-04-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Detection probability analysis (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Casting_out_nines",
     "date": "Classical",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "proofRepoPath": "Proofs/DivisibilityBy3OQ04OQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "prerequisites": [
       "modular arithmetic",
@@ -58,7 +58,7 @@
       "casting_out_base_cong: b ≡ 1 (mod b-1) for any base b ≥ 3"
     ],
     "dateAdded": "2026-03-29",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 228,
     "theoremCount": 22,
     "relatedProblems": [
@@ -71,7 +71,7 @@
         "relationship": "Grandparent proof: the digit-sum divisibility rule (Wiedijk #85)"
       }
     ],
-    "assumptions": "0 axioms, 0 sorries. All theorems derived from Mathlib primitives and verified by native_decide for concrete cases.",
+    "assumptions": "0 axioms, 0 sorries. All theorems derived from Mathlib primitives and verified by native_decide for concrete cases. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "definitionCount": 0
   },

--- a/src/data/proofs/divisibility-by-3-oq-04/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Ancient arithmetic methods (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Casting_out_nines",
     "date": "Ancient",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -16,7 +16,7 @@
       "open-problem"
     ],
     "proofRepoPath": "Proofs/DivisibilityBy3OQ04.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "prerequisites": [
       "modular arithmetic",
@@ -48,7 +48,7 @@
       "Concrete examples: verified arithmetic and detected errors via native_decide"
     ],
     "dateAdded": "2026-03-23",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 229,
     "theoremCount": 17,
     "relatedProblems": [
@@ -61,7 +61,7 @@
         "relationship": "Sibling OQ generalizing to arbitrary bases; this OQ-04 uses the same generalization for casting-out applications"
       }
     ],
-    "assumptions": "0 axioms, 0 sorries. All theorems derived from Mathlib's Nat.modEq_digits_sum and standard modular arithmetic properties.",
+    "assumptions": "0 axioms, 0 sorries. All theorems derived from Mathlib's Nat.modEq_digits_sum and standard modular arithmetic properties. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "definitionCount": 0
   },

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root#Properties",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "digital-root",
@@ -17,10 +17,10 @@
       "modular-arithmetic"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01OQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 sorries, 0 axioms. Fully machine-checked.",
+    "axiomCount": 1,
+    "assumptions": "0 sorries, 0 literal axiom declarations. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "digitSum_le_self: (Nat.digits 10 n).sum \u2264 n for all n (manual proof via Nat.digits_def')",
       "digitSum_lt_of_ge_ten: digitSum n < n for n \u2265 10 (manual proof, avoids Nat.sum_digits_lt naming issue)",

--- a/src/data/proofs/divisibility-by-three-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "modular-arithmetic",
       "three"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 550,
     "theoremCount": 56,
     "definitionCount": 1,

--- a/src/data/proofs/divisibility-by-three-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ02.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "modular-arithmetic",
       "extensions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 432,
     "theoremCount": 31,
     "definitionCount": 5,

--- a/src/data/proofs/divisibility-rules-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityRulesOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "elementary-number-theory",
       "extensions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 412,
     "theoremCount": 42,
     "definitionCount": 2,

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Classical number theory, formalized in Lean 4",
     "date": "",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -14,9 +14,9 @@
       "algorithms"
     ],
     "proofRepoPath": "Proofs/DivisibilityRulesOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 142,
     "originalContributions": [
       "dvd_iff_dvd_altDigitSum: general alternating block divisibility rule",
@@ -25,7 +25,7 @@
       "eleven_dvd_iff_altDigitSum: classical div-by-11 as instance of general rule",
       "hundredone_dvd_iff_altDigitSum: div-by-101 via 2-digit blocks"
     ],
-    "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified.",
+    "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-04-12",
     "theoremCount": 9,
     "definitionCount": 0

--- a/src/data/proofs/divisibility-rules/meta.json
+++ b/src/data/proofs/divisibility-rules/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityRules.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "elementary-number-theory",
       "digit-sum"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 392,
     "theoremCount": 38,
     "definitionCount": 3,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Kronecker (definition), formalized in Lean 4",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -16,9 +16,9 @@
       "multiplicative-functions",
       "open-question"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 164,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -35,7 +35,7 @@
       "Proof that χ(1,n) = 1 for all n",
       "Value characterizations at n = 0, ±1, 2"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 9,
     "definitionCount": 5,
     "additionalFiles": [

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "certified-computation",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 189,
-    "assumptions": "None.",
+    "assumptions": "None. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "dateAdded": "2026-03-30",
     "originalContributions": [
       "Reusable reduce_step, extract_two_step, reciprocity_step lemmas",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -32,7 +32,7 @@
     "author": "Jacobi / Eisenstein (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "quadratic-reciprocity",
@@ -41,7 +41,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -75,10 +75,10 @@
       "Residuacity for primes: J(a,p) = 1 implies QR for prime p (proved)"
     ],
     "dateAdded": "2026-03-22",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 199,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 10,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Conway & Guy (1968), formalized in Lean 4",
     "sourceUrl": "https://erdosproblems.com/1",
     "date": "1968",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1OQ03.lean",
     "tags": [
       "erdos",
@@ -16,10 +16,10 @@
       "distinct-subset-sums",
       "open-question"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Conway-Guy optimality for n=1..5 is computationally proved via native_decide. The minDSSBound sorry was closed by Erdos1Wip01.dss_existence.",
+    "axiomCount": 1,
+    "assumptions": "None. Conway-Guy optimality for n=1..5 is computationally proved via native_decide. The minDSSBound sorry was closed by Erdos1Wip01.dss_existence. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "hasDistinctSubsetSums",
@@ -53,17 +53,17 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Erd\u0151s Problem #1** asks: what is $f(n)$, the minimum value of $\\max(A)$ over all $n$-element sets $A \\subset \\mathbb{Z}^+$ with distinct subset sums? Erd\u0151s conjectured $f(n) \\geq c \\cdot 2^n$ for some constant $c > 0$, and offered $\\$500$ for a proof (one of his largest prizes).\n\n**John Conway and Richard Guy (1968)** discovered a greedy construction achieving $f(n) \\leq c \\cdot 2^n$ with $c = \\sqrt{2/\\pi}/2 \\approx 0.22009$. Each element $a_k = a_{k-1} + \\lceil S_{k-1}/2 \\rceil$ is chosen to be just large enough to avoid subset sum collisions. The resulting sequence 1, 2, 4, 7, 13, 24, 44, 84, ... (OEIS A005318) is conjectured to be exactly optimal, giving $f(n) = a_n$ for all $n$.\n\n**W.F. Lunnon (1988)** verified computational optimality for $n \\leq 10$. **Bohman (1996)** improved the lower bound to $f(n) > 0.22 \\cdot 2^n / \\sqrt{n}$, still far from the conjectured $\\sqrt{2/\\pi}/2 \\cdot 2^n$. The gap between the upper bound (Conway-Guy) and the best lower bounds remains one of the major open problems in additive combinatorics.\n\nThe surprising appearance of $\\sqrt{2/\\pi}$ in the constant connects to the Wallis product: $\\sqrt{2/\\pi}/2 = \\prod_{k=1}^{\\infty}(1 - 1/(2k))$. This suggests a deep connection to probability distributions (specifically the arcsine law and semicircle distribution), though this connection is not yet fully understood.",
+    "historicalContext": "**Erdős Problem #1** asks: what is $f(n)$, the minimum value of $\\max(A)$ over all $n$-element sets $A \\subset \\mathbb{Z}^+$ with distinct subset sums? Erdős conjectured $f(n) \\geq c \\cdot 2^n$ for some constant $c > 0$, and offered $\\$500$ for a proof (one of his largest prizes).\n\n**John Conway and Richard Guy (1968)** discovered a greedy construction achieving $f(n) \\leq c \\cdot 2^n$ with $c = \\sqrt{2/\\pi}/2 \\approx 0.22009$. Each element $a_k = a_{k-1} + \\lceil S_{k-1}/2 \\rceil$ is chosen to be just large enough to avoid subset sum collisions. The resulting sequence 1, 2, 4, 7, 13, 24, 44, 84, ... (OEIS A005318) is conjectured to be exactly optimal, giving $f(n) = a_n$ for all $n$.\n\n**W.F. Lunnon (1988)** verified computational optimality for $n \\leq 10$. **Bohman (1996)** improved the lower bound to $f(n) > 0.22 \\cdot 2^n / \\sqrt{n}$, still far from the conjectured $\\sqrt{2/\\pi}/2 \\cdot 2^n$. The gap between the upper bound (Conway-Guy) and the best lower bounds remains one of the major open problems in additive combinatorics.\n\nThe surprising appearance of $\\sqrt{2/\\pi}$ in the constant connects to the Wallis product: $\\sqrt{2/\\pi}/2 = \\prod_{k=1}^{\\infty}(1 - 1/(2k))$. This suggests a deep connection to probability distributions (specifically the arcsine law and semicircle distribution), though this connection is not yet fully understood.",
     "problemStatement": "Define the Conway-Guy sequence and verify that it gives optimal values of $f(n)$ (the minimum $N$ such that some $n$-element subset of $\\{1, \\ldots, N\\}$ has all $2^n$ subset sums distinct). The sequence satisfies $a_1 = 1$ and $a_k = a_{k-1} + \\lceil S_{k-1}/2 \\rceil$ where $S_k = \\sum_{i=1}^k a_i$.",
     "text": "A 182-line formalization of the Conway-Guy sequence for Erdos Problem #1. The sequence is defined for the first 8 terms, and its key properties are verified: initial values, recurrence relation, the structural property a_k > S_{k-1}/2, the counting bound 2^n <= n*f(n)+1, strict monotonicity, the at-most-doubles growth rate, and the decreasing ratio f(n)/2^n. The optimality conjecture (Conway-Guy gives exact values of f(n)) is stated as an axiom.",
     "proofStrategy": "Small cases are verified by interval_cases and norm_num/simp. The Conway-Guy sequence is defined by pattern matching for n <= 8. Properties are proved by case analysis on the finite range.",
     "keyInsights": [
       "The Conway-Guy greedy construction: a_k = a_{k-1} + ceil(S_{k-1}/2) barely maintains distinct subset sums",
       "The key invariant a_k > S_{k-1}/2 ensures that subsets with/without a_k have non-overlapping sum ranges",
-      "The ratio f(n)/2^n decreases monotonically, approaching sqrt(2/pi)/2 \u2248 0.22009",
-      "Optimality for general n is open \u2014 verified computationally only for n <= 10 (Lunnon 1988)",
-      "The constant \u221a(2/\u03c0)/2 \u2248 0.22009 connects to the Wallis product: \u221a(2/\u03c0)/2 = \u220f_{k\u22651}(1 - 1/(2k)), hinting at a probabilistic interpretation of the Conway-Guy construction via the arcsine distribution",
-      "The `interval_cases k` tactic is the canonical Lean approach for finite verification: it generates one subgoal per value of k in {1,...,8}, each closed by `simp [conwayGuy, conwayGuySum]` or `norm_num` \u2014 no abstract induction needed for claims about specific finite ranges"
+      "The ratio f(n)/2^n decreases monotonically, approaching sqrt(2/pi)/2 ≈ 0.22009",
+      "Optimality for general n is open — verified computationally only for n <= 10 (Lunnon 1988)",
+      "The constant √(2/π)/2 ≈ 0.22009 connects to the Wallis product: √(2/π)/2 = ∏_{k≥1}(1 - 1/(2k)), hinting at a probabilistic interpretation of the Conway-Guy construction via the arcsine distribution",
+      "The `interval_cases k` tactic is the canonical Lean approach for finite verification: it generates one subgoal per value of k in {1,...,8}, each closed by `simp [conwayGuy, conwayGuySum]` or `norm_num` — no abstract induction needed for claims about specific finite ranges"
     ]
   },
   "sections": [
@@ -144,8 +144,8 @@
     "openQuestions": [
       "Can the Conway-Guy optimality be proved for all n, or just verified computationally?",
       "Can the asymptotic constant sqrt(2/pi)/2 be derived from the recurrence?",
-      "Bohman (1996) improved the lower bound to f(n) > 0.22\u00b72^n/\u221an \u2014 can this or a tighter lower bound be formalized in Lean?",
-      "Is there a connection between the Conway-Guy constant and the probability that a random walk returns to 0, explaining the \u221a(2/\u03c0) via the arcsine law?"
+      "Bohman (1996) improved the lower bound to f(n) > 0.22·2^n/√n — can this or a tighter lower bound be formalized in Lean?",
+      "Is there a connection between the Conway-Guy constant and the probability that a random walk returns to 0, explaining the √(2/π) via the arcsine law?"
     ]
   },
   "references": [
@@ -186,13 +186,13 @@
     {
       "name": "conwayGuy_exceeds_half_sum",
       "type": "core",
-      "description": "a_k > S_{k-1}/2 \u2014 the key invariant for distinct subset sums",
+      "description": "a_k > S_{k-1}/2 — the key invariant for distinct subset sums",
       "leanType": "2 * conwayGuy k > conwayGuySum (k - 1)"
     },
     {
       "name": "conwayGuy_exponential_bound",
       "type": "supporting",
-      "description": "3 * f(n) <= 2^n \u2014 crude exponential upper bound",
+      "description": "3 * f(n) <= 2^n — crude exponential upper bound",
       "leanType": "3 * conwayGuy k <= 2 ^ k"
     }
   ],

--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1007OQ01OQ01.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "monotonicity",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,9 +55,9 @@
       "Verified: known deficiency values all satisfy δ(d) ≤ d",
       "Growth classification: d ≤ f(d) ≤ d(d+1)/2 for all d ≥ 1"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 388,
-    "assumptions": "0 axioms, 0 sorries. All 32 theorems fully proved.",
+    "assumptions": "0 axioms, 0 sorries. All 32 theorems fully proved. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 32,
     "definitionCount": 4

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1007OQ01.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "extension",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -68,9 +68,9 @@
       "Under optimality conjecture, successive differences equal d+1",
       "Linear lower bound from rigidity and quadratic upper bound from complete graphs"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 1337,
-    "assumptions": "0 axioms. Fully verified.",
+    "assumptions": "0 axioms. Fully verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 89,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-1054-construction-d/meta.json
+++ b/src/data/proofs/erdos-1054-construction-d/meta.json
@@ -5,7 +5,7 @@
   "description": "For Erdős #1054, proves that 1+p+p² is representable for every prime p (divisors of p² are {1,p,p²}, partial sum = 1+p+p²). Verifies constructions for p=2,3,5,7,11,13. Also proves p+1 is representable via p² witness and Mersenne number representability. 26 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Erdos1054ConstructionD",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1054ConstructionD.lean",
     "tags": [
       "number-theory",
@@ -14,12 +14,12 @@
       "prime-powers",
       "representability"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 250,
     "theoremCount": 26,
-    "assumptions": "None. All 26 theorems proved.",
+    "assumptions": "None. All 26 theorems proved. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",

--- a/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/meta.json
@@ -5,7 +5,7 @@
   "description": "Partial progress on Erdős problem #1054 OQ-01: f(n) is the minimal m whose k smallest divisors sum to n. Proves the sigma bound f(σ(m)) ≤ m, showing f(n) = o(n) along the subsequence of σ-values of superabundant numbers. Includes prime divisor structure, computational evidence for n ≤ 50, and density results. 49 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Erdos1054OQ01",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1054OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,12 +15,12 @@
       "density",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 521,
     "theoremCount": 49,
-    "assumptions": "None. All 49 theorems proved (partial progress on open problem).",
+    "assumptions": "None. All 49 theorems proved (partial progress on open problem). This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",

--- a/src/data/proofs/erdos-1054-oq-02/meta.json
+++ b/src/data/proofs/erdos-1054-oq-02/meta.json
@@ -5,7 +5,7 @@
   "description": "Proves structural representability results for Erdős #1054 using prime products qp. The divisors of qp (distinct primes q < p) are {1,q,p,qp}, so 1+q+p is representable. Proves Goldbach connection: every even n ≥ 4 representable if Goldbach holds. Concrete witnesses for n ∈ [6,20]. 17 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Erdos1054OQ02",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1054OQ02.lean",
     "tags": [
       "number-theory",
@@ -15,12 +15,12 @@
       "prime-products",
       "representability"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 307,
     "theoremCount": 17,
-    "assumptions": "None. All 17 theorems proved (including conditional Goldbach result).",
+    "assumptions": "None. All 17 theorems proved (including conditional Goldbach result). This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",

--- a/src/data/proofs/erdos-1056-oq-01/meta.json
+++ b/src/data/proofs/erdos-1056-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1979); Makowski (1983); Lean Genius OQ-01",
     "sourceUrl": "https://erdosproblems.com/1056",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1056OQ01.lean",
     "tags": [
       "erdos",
@@ -16,16 +16,16 @@
       "computational",
       "primes"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1056,
     "erdosUrl": "https://erdosproblems.com/1056",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 446,
     "theoremCount": 65,
     "definitionCount": 10,
-    "assumptions": "None. All 65 theorems are fully proved. Computational verification via native_decide.",
+    "assumptions": "None. All 65 theorems are fully proved. Computational verification via native_decide. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Finset.prod",

--- a/src/data/proofs/erdos-1061/meta.json
+++ b/src/data/proofs/erdos-1061/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos (question via Guy's collection)",
     "sourceUrl": "https://erdosproblems.com/1061",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1061Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "asymptotic-analysis",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1061,
     "erdosUrl": "https://erdosproblems.com/1061",
@@ -56,9 +56,9 @@
       "hasLinearGrowth formulation of the open problem",
       "Bounds: S(x) >= 2 for x >= 3, S(x) <= x^2/4"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 380,
-    "assumptions": "No axioms. 0 sorries. The main open conjecture (asymptotic count ~ cx) is not asserted — the file proves structural results: the infinite sigma(a)+sigma(2a)=sigma(3a) family for a coprime to 6, and consequences.",
+    "assumptions": "No axioms. 0 sorries. The main open conjecture (asymptotic count ~ cx) is not asserted — the file proves structural results: the infinite sigma(a)+sigma(2a)=sigma(3a) family for a coprime to 6, and consequences. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 48,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1981 problem), Vose (1984 solution)",
     "sourceUrl": "https://erdosproblems.com/1099",
     "date": "1984",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1099Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "liminf",
       "solved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
@@ -63,9 +63,9 @@
       "power_of_two_h_alpha theorem: h_α(2^k) = k",
       "prime_h_alpha_unbounded theorem: h_α(p) → ∞ over primes"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 723,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries. vose_bounded_sequence proved via trivial witness (constant sequence n_k = 2, h_α(2) = 1). All 34 theorems machine-checked.",
+    "assumptions": "Fully verified: 0 axioms, 0 sorries. vose_bounded_sequence proved via trivial witness (constant sequence n_k = 2, h_α(2) = 1). All 34 theorems machine-checked. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 36,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos249OQ01.lean",
     "tags": [
       "erdos",
@@ -17,17 +17,17 @@
       "bounds",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 249,
     "erdosUrl": "https://erdosproblems.com/249",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 303,
     "theoremCount": 26,
     "definitionCount": 0,
-    "assumptions": "None. Imports Erdos249Problem.lean (0 axioms). Fully machine-verified. Open conjecture; all bounding theorems fully verified.",
+    "assumptions": "None. Imports Erdos249Problem.lean (0 axioms). Fully machine-verified. Open conjecture; all bounding theorems fully verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "originalContributions": [
       "termFn_three/four/five/six/seven/eight/nine/ten: exact term values φ(n)/2^n for n = 3–10",
       "partial_sum_6: first 6 terms sum exactly to 5/4",

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Selfridge (1967 problem), Schinzel (partial result)",
     "sourceUrl": "https://erdosproblems.com/891",
     "date": "1967",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos891Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "intervals",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 891,
     "erdosUrl": "https://erdosproblems.com/891",
@@ -64,9 +64,9 @@
       "nthPrime_zero/one/two/three/four_val: concrete values nthPrime k for k=0..4",
       "primorial_eq_primorialComp: bridges noncomputable primorial to computable primorialComp for k≤5"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 439,
-    "assumptions": "",
+    "assumptions": "This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 30,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -7,7 +7,7 @@
     "author": "Füredi (1991), Alon-Krivelevich-Sudakov (2003)",
     "sourceUrl": "https://erdosproblems.com/926",
     "date": "1991",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos926Problem.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "turan-number",
       "probabilistic-method"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 926,
     "erdosUrl": "https://erdosproblems.com/926",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 235,
-    "assumptions": "None. 3 theorems fully verified with 0 axioms and 0 sorries (numerical examples via native_decide). Main result (ex(n; H_k) ≪ n^(3/2)) documented as a comment; full formalization requires probabilistic method not in Mathlib.",
+    "assumptions": "None. 3 theorems fully verified with 0 axioms and 0 sorries (numerical examples via native_decide). Main result (ex(n; H_k) ≪ n^(3/2)) documented as a comment; full formalization requires probabilistic method not in Mathlib. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
     "definitionCount": 3

--- a/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "euler-totient-oq-02-oq-01",
   "description": "Formalizes the Euler product formula φ(n) = n·∏_{p|n}(1−1/p) in three equivalent forms using Mathlib's prime factorization infrastructure. Derives the formula from multiplicativity + prime power formula, proves totient density φ(n)/n = ∏(1−1/p), and shows density depends only on the radical of n. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "multiplicative-functions",
@@ -12,10 +12,10 @@
       "totient"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API and Finsupp infrastructure.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API and Finsupp infrastructure. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 207,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/euler-totient-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02/meta.json
@@ -4,7 +4,7 @@
   "slug": "euler-totient-oq-02",
   "description": "The multiplicative property of Euler's totient: φ(mn) = φ(m)·φ(n) when gcd(m,n) = 1. Proves multiplicativity via CRT, the prime power formula φ(p^k) = p^(k-1)(p-1), three-factor products, φ(2m)=φ(m) for odd m, and native_decide verifications including non-coprime counterexamples. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "multiplicative-functions",
@@ -12,10 +12,10 @@
       "totient"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 172,
     "theoremCount": 16,
     "definitionCount": 0,

--- a/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_arithmetic",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "factorization",
@@ -16,12 +16,12 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmeticOQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 113,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0

--- a/src/data/proofs/gcd-algorithm-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gabriel Lame (1844), formalized in Lean 4",
     "date": "1844",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/GCDAlgorithmOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,7 +15,7 @@
       "fibonacci",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,9 +49,9 @@
       "Finite average computation infrastructure"
     ],
     "dateAdded": "2026-02-10",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 460,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 28,
     "definitionCount": 4

--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Schubert (1879), Hilbert (1900); Chow ring formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schubert_calculus",
     "date": "1879",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert15OQ01.lean",
     "tags": [
       "algebraic-geometry",
@@ -20,7 +20,7 @@
       "poincare-duality",
       "hilbert-problems"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,9 +39,9 @@
       "mul_comm_basis: commutativity of basis multiplication verified by decide"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 351,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. All results follow from the explicit multiplication table.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. All results follow from the explicit multiplication table. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
     "definitionCount": 9

--- a/src/data/proofs/inclusion-exclusion-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/InclusionExclusionOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "derangements",
       "euler-totient"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 382,
     "theoremCount": 41,
     "definitionCount": 5,

--- a/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "kummer-theorem-oq-01-oq-01",
   "description": "Proves that v_p(multinomial(k₁,...,kₘ)) = total carries when adding k₁,...,kₘ in base p, using Mathlib's Nat.factorization_choose' (Kummer's theorem) and the binomial decomposition from OQ-01. Refutes the claim that base-p carry counting is 'not yet in Mathlib'. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "number-theory",
@@ -12,10 +12,10 @@
       "multinomial"
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses Nat.factorization_choose' (Kummer carries formula, in Mathlib 4.26.0), Nat.factorization_mul, Nat.log_mono_right, and List.map_congr_left.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. Uses Nat.factorization_choose' (Kummer carries formula, in Mathlib 4.26.0), Nat.factorization_mul, Nat.log_mono_right, and List.map_congr_left. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 201,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/lagrange-four-squares-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeFourSquaresOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,10 +15,10 @@
       "quadratic-forms",
       "sums-of-squares"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.sum_four_squares",
@@ -26,7 +26,7 @@
         "module": "Mathlib.NumberTheory.SumFourSquares"
       }
     ],
-    "assumptions": "Core existential result (four_square_exists_bounded) uses Mathlib's Nat.sum_four_squares. Algorithm, bounds, and verification proofs are independently proved.",
+    "assumptions": "Core existential result (four_square_exists_bounded) uses Mathlib's Nat.sum_four_squares. Algorithm, bounds, and verification proofs are independently proved. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 395,
     "theoremCount": 71,
     "definitionCount": 9,

--- a/src/data/proofs/lagrange-four-squares-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeFourSquaresOQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "orbit-stabilizer",
       "combinatorics"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 651,
     "theoremCount": 105,
     "definitionCount": 17,

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -5,7 +5,7 @@
   "description": "Every natural number is a sum of at most 4 perfect squares (Lagrange 1770), and 7 is not a sum of 3 squares — hence g(2) = 4. Includes the general exclusion theorem (4^a(8b+7) is never a sum of 3 squares), computable classification, and infinitely many numbers requiring exactly 4 squares.",
   "meta": {
     "author": "Lagrange (1770), Legendre (1798)",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeFourSquaresWaringG2.lean",
     "tags": [
       "number-theory",
@@ -15,12 +15,12 @@
       "combinatorics",
       "modular-arithmetic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 442,
     "theoremCount": 69,
-    "assumptions": "None. All 69 theorems proved. Upper bound uses Mathlib's Nat.sq_add_sq (Lagrange); lower bound is self-contained via mod 8 analysis.",
+    "assumptions": "None. All 69 theorems proved. Upper bound uses Mathlib's Nat.sq_add_sq (Lagrange); lower bound is self-contained via mod 8 analysis. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.sq_add_sq",

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-05",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ02.lean",
     "tags": [
       "group-theory",
@@ -16,11 +16,11 @@
       "finite-groups",
       "subgroup-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-05",
-    "axiomCount": 0,
-    "assumptions": "None — fully verified by finite enumeration via native_decide.",
+    "axiomCount": 1,
+    "assumptions": "None — fully verified by finite enumeration via native_decide. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 121,
     "theoremCount": 8,
     "definitionCount": 1,
@@ -34,8 +34,13 @@
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ01OQ02.lean",
     "namespace": "LagrangeOQ01OQ02",
-    "imports": ["Mathlib"],
-    "opens": ["Subgroup", "Fintype"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Subgroup",
+      "Fintype"
+    ],
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 121,

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-05",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02.lean",
     "tags": [
       "group-theory",
@@ -17,9 +17,9 @@
       "orbit-stabilizer",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 262,
     "theoremCount": 13,
     "definitionCount": 1,
@@ -72,7 +72,7 @@
       "card_conjClass_eq_one_iff_mem_center: |[x]| = 1 ↔ x ∈ Z(G) proved from orbit uniqueness and commutativity",
       "A₄ class equation verification: 4 conjugacy classes of sizes 1+3+4+4=12 via native_decide"
     ],
-    "assumptions": "0 sorries. 0 axiom declarations. All theorems fully machine-checked. card_conjClass_eq_centralizer_index proved via Subgroup.index_comap_of_surjective applied to the ConjAct.toConjAct isomorphism.",
+    "assumptions": "0 sorries. 0 axiom declarations. All theorems fully machine-checked. card_conjClass_eq_centralizer_index proved via Subgroup.index_comap_of_surjective applied to the ConjAct.toConjAct isomorphism. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "additionalFiles": []
   },
   "overview": {

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
     "date": "1969",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "tags": [
       "pde",
@@ -20,9 +20,9 @@
       "analysis",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le",
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-02-26",
     "lineCount": 21110,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
+    "assumptions": "None. Formalized with 0 axioms and 0 sorries remain. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "relatedProblems": [
       {
         "id": "navier-stokes",

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Researcher (lean-genius)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Rogers%E2%80%93Ramanujan_identities",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PartitionTheoremOQ01OQ01.lean",
     "tags": [
       "partitions",
@@ -16,10 +16,10 @@
       "computational verification",
       "q-series"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "No axioms. Computational verification via native_decide. Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions).",
+    "axiomCount": 1,
+    "assumptions": "No axioms. Computational verification via native_decide. Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions). This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "lineCount": 71,
     "relatedProblems": [

--- a/src/data/proofs/partition-theorem/meta.json
+++ b/src/data/proofs/partition-theorem/meta.json
@@ -8,7 +8,7 @@
     "author": "Leonhard Euler (1748)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Partition_(number_theory)",
     "date": "1748",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PartitionTheorem.lean",
     "tags": [
       "combinatorics",
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -43,9 +43,9 @@
       "Asymptotic formula for Q(n)"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 281,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (300 BCE), Euler (1747)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number",
     "date": "300 BCE / 1747",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "perfect-numbers",
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PerfectNumbers.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,9 +50,9 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 70,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 202,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0

--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PicksTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "gcd",
       "coprimality"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-03",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 245,
     "theoremCount": 13,
     "definitionCount": 2,

--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Schlaefli (1852), Coxeter (1973); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Regular_polytope",
     "date": "1852",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PlatonicSolidsOQ01.lean",
     "tags": [
       "geometry",
@@ -18,9 +18,9 @@
       "research",
       "open-question"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 53,
     "defCount": 28,
     "lineCount": 628,
@@ -46,7 +46,7 @@
       "Duality relationships: 5-cell and 24-cell are self-dual, 8-cell/16-cell and 120-cell/600-cell form dual pairs"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The Schlaefli determinant computation uses exact arithmetic in Z[sqrt(5)] to determine the sign of sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) for all candidate symbols.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The Schlaefli determinant computation uses exact arithmetic in Z[sqrt(5)] to determine the sign of sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) for all candidate symbols. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "prerequisites": [
       "Platonic solids classification (parent proof)",
       "Euler's formula for polytopes",

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -8,7 +8,7 @@
     "author": "Euclid (Lean 4 formalization)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Platonic_solid",
     "date": "c. 300 BCE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PlatonicSolids.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "topology"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -34,14 +34,14 @@
       "Proof of duality relationships between Platonic solids"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 419,
     "prerequisites": [
       "Euler's formula for polyhedra: V - E + F = 2",
       "Schlafli symbols and regular polyhedra",
       "Combinatorics of regular tilings and angle constraints"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
     "definitionCount": 11

--- a/src/data/proofs/ramsey-r4k/meta.json
+++ b/src/data/proofs/ramsey-r4k/meta.json
@@ -5,7 +5,7 @@
   "description": "Formalizes structural results for the off-diagonal Ramsey numbers R(4,k): upper bound R(4,k) ≤ C(k+2,3) via the classical Erdős-Szekeres binomial bound, the fundamental Pascal recursion R(r,s) ≤ R(r-1,s) + R(r,s-1) proved via vertex neighborhood splitting, concrete upper bound values for k=3..10, strict monotonicity, cubic growth rate R(4,k) ≤ (k+2)³, and a probabilistic lower bound counting framework. 30 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius RamseyR4k",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/RamseyR4k.lean",
     "tags": [
       "combinatorics",
@@ -15,12 +15,12 @@
       "number-theory",
       "upper-bounds"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 587,
     "theoremCount": 30,
-    "assumptions": "None. All 30 theorems proved. Concrete values via native_decide. The formalized bounds are classical upper bounds (C(k+2,3)), not exact Ramsey numbers.",
+    "assumptions": "None. All 30 theorems proved. Concrete values via native_decide. The formalized bounds are classical upper bounds (C(k+2,3)), not exact Ramsey numbers. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -4,7 +4,7 @@
   "slug": "sqrt2-irrational",
   "description": "The classic proof that √2 is irrational, generalized to show √n is irrational for any non-perfect-square n. Covers √2, √3, √5, √6, √7 and the general theorem.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "classic",
@@ -14,7 +14,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2Irrational.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,9 +51,9 @@
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 222,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "theoremCount": 14,
     "definitionCount": 0
   },

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -4,7 +4,7 @@
   "slug": "sqrt2-minpoly",
   "description": "A complete Lean 4 proof that the minimal polynomial of √2 over ℚ is X² - 2, with corollaries on algebraic degree and field extension structure.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "algebraic-number-theory",
       "minimal-polynomial",
@@ -15,12 +15,12 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2Minpoly.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 140,
     "dateAdded": "2026-04-22",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3Irrational.lean",
     "tags": [
       "irrationality",
@@ -14,11 +14,11 @@
       "square-roots",
       "number-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff and native_decide for ¬IsSquare 6.",
+    "axiomCount": 1,
+    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff and native_decide for ¬IsSquare 6. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 54,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-12",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean",
     "tags": [
       "irrationality",
@@ -16,11 +16,11 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-12",
-    "axiomCount": 0,
-    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff with native_decide on ¬IsSquare 30, Real.sq_sqrt, Real.sqrt_mul, sqrt_pos, sqrt_nonneg, plus the parent gallery proof's exported identity sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6.",
+    "axiomCount": 1,
+    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff with native_decide on ¬IsSquare 30, Real.sq_sqrt, Real.sqrt_mul, sqrt_pos, sqrt_nonneg, plus the parent gallery proof's exported identity sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 144,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -8,7 +8,7 @@
     "author": "James Stirling / Abraham de Moivre (formalized via Mathlib)",
     "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Analysis/SpecialFunctions/Stirling.lean",
     "date": "1730",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/StirlingFormula.lean",
     "tags": [
       "analysis",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "approximation"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -42,7 +42,7 @@
       "Connection to log-factorial approximation for entropy calculations"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 640,
     "prerequisites": [
       "Real analysis: limits, asymptotic equivalence (~), sequences",
@@ -50,7 +50,7 @@
       "The Wallis product: π/2 = ∏(4n²)/(4n²-1)",
       "Logarithmic approximation: log(n!) ≈ n log n - n + (1/2)log(2πn)"
     ],
-    "assumptions": "0 axioms. The error bound stirling_error_bound_ge_2 is now fully proved via telescoping log bounds from Mathlib.",
+    "assumptions": "0 axioms. The error bound stirling_error_bound_ge_2 is now fully proved via telescoping log bounds from Mathlib. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1

--- a/src/data/proofs/subset-count-oq-02-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "subset-count-oq-02-oq-01",
   "description": "Proves that a multiset s has exactly ∏ a ∈ s.toFinset, (s.count a + 1) distinct submultisets, directly from Mathlib's Multiset.card_Iic. Includes the set case (nodup → 2^n), concrete verifications, and a multiplicativity theorem for disjoint supports. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "multiset",
@@ -12,10 +12,10 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/SubsetCountOQ02OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses Multiset.card_Iic (Mathlib.Data.Multiset.Interval), Multiset.nodup_iff_count_le_one, Multiset.count_pos, Multiset.toFinset_card_of_nodup, Finset.disjoint_left, Multiset.count_eq_zero.",
+    "axiomCount": 1,
+    "assumptions": "0 axioms, 0 sorries. Uses Multiset.card_Iic (Mathlib.Data.Multiset.Interval), Multiset.nodup_iff_count_le_one, Multiset.count_pos, Multiset.toFinset_card_of_nodup, Finset.disjoint_left, Multiset.count_eq_zero. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 159,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfDivisors.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "perfect-numbers",
       "amicable-numbers"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 549,
     "theoremCount": 81,
     "definitionCount": 5,

--- a/src/data/proofs/sum-of-kth-powers/meta.json
+++ b/src/data/proofs/sum-of-kth-powers/meta.json
@@ -8,7 +8,7 @@
     "author": "Johann Faulhaber / Nicomachus (formalized)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Faulhaber%27s_formulas",
     "date": "c. 100 CE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfKthPowers.lean",
     "tags": [
       "algebra",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "induction"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,9 +39,9 @@
       "Closed-form formula for sum of fifth powers: n²(n+1)²(2n²+2n-1)/12"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 600,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
     "definitionCount": 0

--- a/src/data/proofs/sylow-theorem-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SylowTheoremOQ04.lean",
     "tags": [
       "group-theory",
@@ -15,11 +15,11 @@
       "finite-groups",
       "applications"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 276,
     "theoremCount": 21,
     "definitionCount": 1,

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylow (1872); Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Properties",
     "date": "1872",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SylowTheoremOQ04.lean",
     "tags": [
       "group-theory",
@@ -17,10 +17,10 @@
       "alternating-group",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axiom declarations, 0 sorries. All results fully verified. Exact Sylow numbers computed by native_decide. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five.",
+    "axiomCount": 1,
+    "assumptions": "0 axiom declarations, 0 sorries. All results fully verified. Exact Sylow numbers computed by native_decide. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 276,
     "theoremCount": 21,
     "definitionCount": 1

--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/WilsonsTheoremOQ01.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "modular-arithmetic",
       "composite-moduli"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 688,
     "theoremCount": 35,
     "definitionCount": 9,

--- a/src/data/proofs/wilsons-theorem-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/WilsonsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "cyclic-groups",
       "involution-lemma"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "None. Fully machine-verified. This entry uses `native_decide` to discharge one or more presented theorems/lemmas, so the proof depends on `Lean.ofReduceBool` (the Lean compiler kernel-reduction axiom) and is not axiom-free. Per the Axiom Integrity Policy (CLAUDE.md), meta.axiomCount reflects this assumption (leanFile.axiomCount still counts only literal `axiom` declarations).",
     "lineCount": 426,
     "theoremCount": 21,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Completes the `native_decide` reclassification sweep — the residual of #25373 that #25390 began (it fixed only 3 sibling families). Closes #25409.

**99 entries** declared `status: "verified"` + `meta.axiomCount: 0` while a **named** `theorem`/`lemma`/`instance` in their Lean source is discharged by `native_decide`. Per CLAUDE.md's Axiom Integrity Policy, `native_decide` depends on `Lean.ofReduceBool`, so the proof is **not** axiom-free and must be classed `axiomatized`.

For each of the 99:
- `status`: `verified` → `axiomatized`
- `badge`: → `axiom`
- `meta.axiomCount`: `0` → `1`
- `assumptions`: appended a `Lean.ofReduceBool` disclosure
- `leanFile.axiomCount`: **left at 0** (counts literal `axiom` declarations only, per policy)

## Scope: which entries were NOT touched

The auditor's coarse scan flagged ~165 `verified` entries containing `native_decide`. Applying CLAUDE.md's actual criterion — *"when `native_decide` discharges a **substantive result the entry presents**"* — narrows this:

- **99 entries** have `native_decide` inside a **named** declaration (`theorem`/`lemma`/`instance`/`def`) → a presented, exported result whose `#print axioms` includes `ofReduceBool` → **fixed here**.
- **~69 entries** have `native_decide` **only** inside anonymous `example` / `#eval` / `#guard` blocks (illustrative numeric demos like `3 ∣ 123`). These are not "results the entry presents"; the headline theorems use term-mode/Mathlib proofs and remain genuinely axiom-free. These correctly **stay `verified`** and were left unchanged. (e.g. `divisibility-by-3`, `bezout-identity`, `binomial-theorem`, the `ballot-problem-*` family.)
- `burnside-counting` is excluded — it is handled by the already-open PR #25408.

## Method

Declaration context was determined by a static classifier (block + line comments stripped first, then each `native_decide` attributed to its enclosing declaration keyword). All 99 edits are metadata-only; JSON validity verified for every file; `badge: "axiom"` / `status: "axiomatized"` are values already used by hundreds of existing entries.

## Evidence

**Before**: 99 entries claim `verified` / `axiomCount 0` despite load-bearing named `native_decide` (e.g. `platonic-solids`: `theorem number_of_platonic_solids : validPairs.card = 5 := by native_decide`).
**After**: those 99 are `axiomatized` / `axiom` / `axiomCount 1` with `Lean.ofReduceBool` disclosed; the 69 example-only entries are left correctly `verified`.

Closes #25409

---
Automated fix by lean-mechanic agent.