### PR TITLE
Enrich Niven's Theorem: decompose main theorem into 5 sections

### DIFF
--- a/src/data/proofs/niven-theorem-oq-01/annotations.json
+++ b/src/data/proofs/niven-theorem-oq-01/annotations.json
@@ -77,5 +77,25 @@
       "Real.cos_le_one, Real.neg_one_le_cos",
       "interval_cases and linarith"
     ]
+  },
+  {
+    "id": "ann-cast-and-enumerate",
+    "proofId": "niven-theorem-oq-01",
+    "range": { "startLine": 84, "endLine": 92 },
+    "type": "tactic",
+    "title": "From real bounds to a finite integer search",
+    "content": "This block is the bridge between analysis and arithmetic. The real-valued bounds `Real.cos_le_one` and `Real.neg_one_le_cos` give −1 ≤ cos θ ≤ 1; combined with 2·cos θ = (k : ℝ) they yield −2 ≤ (k : ℝ) ≤ 2, which `exact_mod_cast` transports to the integer inequalities −2 ≤ k ≤ 2. Once k is pinned to a bounded integer interval, `interval_cases k` performs an exhaustive split into exactly five goals (k = −2,−1,0,1,2). The `<;> push_cast at hk` then normalizes the integer cast in each branch so that `2 * cos θ = k` becomes a concrete linear equation, leaving `linarith` to read off the matching cosine value. The pattern — bound a real quantity, cast it to a finite integer range, enumerate — is the standard Lean idiom for turning a continuum classification into a finite case check.",
+    "mathContext": "$-1\\le\\cos\\theta\\le 1 \\;\\Rightarrow\\; -2\\le k\\le 2,\\ k\\in\\mathbb{Z} \\;\\Rightarrow\\; k\\in\\{-2,-1,0,1,2\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval_cases",
+      "exact_mod_cast and push_cast",
+      "linarith",
+      "bounding then enumerating"
+    ],
+    "prerequisites": [
+      "integer vs real casts in Lean",
+      "Real.cos_le_one, Real.neg_one_le_cos"
+    ]
   }
 ]

--- a/src/data/proofs/niven-theorem-oq-01/meta.json
+++ b/src/data/proofs/niven-theorem-oq-01/meta.json
@@ -90,12 +90,28 @@
       "mathContext": "$2\\cos((m/n)\\pi)$ integral over $\\mathbb{Z}$ and rational $\\Rightarrow 2\\cos\\theta \\in \\mathbb{Z}$."
     },
     {
-      "id": "main-theorem",
-      "title": "Niven's Theorem: the Five-Way Enumeration",
+      "id": "main-statement",
+      "title": "Niven's Theorem: Statement and Setup",
       "startLine": 76,
+      "endLine": 83,
+      "summary": "`niven`: the headline theorem. Under the same hypotheses (θ = (m/n)·π, cos θ rational) the goal is the five-way disjunction cos θ ∈ {0, 1/2, −1/2, 1, −1}. The proof opens by destructuring the core lemma `two_cos_int_of_rational` to obtain the integer k with 2·cos θ = k, reducing the entire classification to a question about a single integer.",
+      "mathContext": "$\\cos\\theta = 0 \\lor \\cos\\theta = \\pm\\tfrac12 \\lor \\cos\\theta = \\pm 1$, with $\\exists k\\in\\mathbb{Z},\\ 2\\cos\\theta = k$ in hand."
+    },
+    {
+      "id": "integer-bounds",
+      "title": "Confining k to {−2,…,2}",
+      "startLine": 84,
+      "endLine": 91,
+      "summary": "The bridge from analysis to arithmetic. The cosine bounds `Real.cos_le_one` and `Real.neg_one_le_cos` give −1 ≤ cos θ ≤ 1; combined with 2·cos θ = (k : ℝ) and `linarith` they yield −2 ≤ (k : ℝ) ≤ 2 over the reals, which `exact_mod_cast` transports down to the integer inequalities −2 ≤ k ≤ 2. This pins k to a finite interval so that the enumeration that follows is exhaustive.",
+      "mathContext": "$-1 \\le \\cos\\theta \\le 1 \\Rightarrow (-2{:}\\mathbb{R}) \\le (k{:}\\mathbb{R}) \\le 2 \\xrightarrow{\\text{cast}} -2 \\le k \\le 2,\\ k\\in\\mathbb{Z}.$"
+    },
+    {
+      "id": "enumeration",
+      "title": "The Five-Way interval_cases Enumeration",
+      "startLine": 92,
       "endLine": 103,
-      "summary": "`niven`: obtain k = 2·cos θ ∈ ℤ from the core lemma; the bounds −1 ≤ cos θ ≤ 1 give −2 ≤ k ≤ 2; `interval_cases k` splits into k ∈ {−2,−1,0,1,2}, and each branch is closed by `linarith` from 2·cos θ = k, yielding cos θ ∈ {−1,−1/2,0,1/2,1}.",
-      "mathContext": "$-2 \\le 2\\cos\\theta \\le 2,\\ 2\\cos\\theta \\in \\mathbb{Z} \\Rightarrow \\cos\\theta \\in \\{-1,-\\tfrac12,0,\\tfrac12,1\\}.$"
+      "summary": "`interval_cases k` splits the bounded integer into exactly five goals k ∈ {−2,−1,0,1,2}; `<;> push_cast at hk` normalizes the cast in each branch so 2·cos θ = k becomes a concrete linear equation. Each of the five branches selects the matching disjunct and closes by `linarith` (e.g. k = −1 ⇒ cos θ = −1/2), recovering cos θ ∈ {−1,−1/2,0,1/2,1} and completing Niven's classification.",
+      "mathContext": "$2\\cos\\theta \\in \\{-2,-1,0,1,2\\} \\Rightarrow \\cos\\theta \\in \\{-1,-\\tfrac12,0,\\tfrac12,1\\}.$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `niven-theorem-oq-01`.

The entry was already richly annotated (5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, deep historical context, 5 key insights, complete conclusion). The one remaining quality gap was section granularity: the main theorem was a single 28-line section bundling three distinct steps.

**Change:** split the `main-theorem` section (lines 76-103) into three meaningful sections:
- **Statement and Setup** — the five-way disjunction goal + destructuring the core lemma to get `2·cos θ = k`
- **Confining k to {−2,…,2}** — the analysis→arithmetic bridge (cosine bounds → real inequalities → `exact_mod_cast` to ℤ)
- **The Five-Way interval_cases Enumeration** — `interval_cases k` + per-branch `linarith`

Each new section carries its own summary and LaTeX `mathContext`. Sections now cover the full Lean file at finer granularity (3 → 5), taking the entry to the quality target. No content was removed; no claims changed (still verified / 0 axioms / 0 sorries, accurately matching `Proofs/NivenTheorem.lean`).