### PR TITLE
Fix: re-class 12 entries verified→axiomatized (presented native_decide, batch 2)

### DIFF
--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -7,7 +7,7 @@
     "author": "von Mises (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem",
     "date": "1939",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "probability",
       "combinatorics",
@@ -20,7 +20,7 @@
     "additionalFiles": [
       "Proofs/BirthdayProblemAsymptotics.lean"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "prerequisites": [
       "Probability theory and finite sample spaces",
@@ -55,8 +55,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 93,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and no structure-encoded assumptions. All 27 theorems are proved using Mathlib (Fintype.card_embedding_eq, Nat.descFactorial, Fintype.card_fun) and native_decide for large integer comparisons (up to 146-digit numbers). No custom axioms or definition sorries.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete probability-threshold corollaries (e.g. `birthday_23_exceeds_half`, `birthday_22_below_half`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "relatedProblems": [
       {
         "id": "ballot-problem",

--- a/src/data/proofs/divisibility-rules/meta.json
+++ b/src/data/proofs/divisibility-rules/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityRules.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "elementary-number-theory",
       "digit-sum"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete divisibility-rule and digital-root corollaries (e.g. `six_dvd_iff`, `digitalRoot_999`, `rules_verification`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 392,
     "theoremCount": 38,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Selfridge (1967 problem), Schinzel (partial result)",
     "sourceUrl": "https://erdosproblems.com/891",
     "date": "1967",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos891Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "intervals",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 891,
     "erdosUrl": "https://erdosproblems.com/891",
@@ -64,9 +64,9 @@
       "nthPrime_zero/one/two/three/four_val: concrete values nthPrime k for k=0..4",
       "primorial_eq_primorialComp: bridges noncomputable primorial to computable primorialComp for k≤5"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 439,
-    "assumptions": "",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete \u03a9-value and verified-range corollaries (e.g. `bigOmega_eight`, `k2_verified_range`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "theoremCount": 30,
     "definitionCount": 11
   },

--- a/src/data/proofs/euler-totient-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02/meta.json
@@ -4,7 +4,7 @@
   "slug": "euler-totient-oq-02",
   "description": "The multiplicative property of Euler's totient: φ(mn) = φ(m)·φ(n) when gcd(m,n) = 1. Proves multiplicativity via CRT, the prime power formula φ(p^k) = p^(k-1)(p-1), three-factor products, φ(2m)=φ(m) for odd m, and native_decide verifications including non-coprime counterexamples. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "multiplicative-functions",
@@ -12,10 +12,10 @@
       "totient"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete totient-value corollaries (e.g. `totient_six`, `totient_twelve`, `totient_hundred`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 172,
     "theoremCount": 16,
     "definitionCount": 0,

--- a/src/data/proofs/inclusion-exclusion-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/InclusionExclusionOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "derangements",
       "euler-totient"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete alternating-binomial-sum and derangement-count corollaries (e.g. `altBinomSum_10`, `derangements_six`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 382,
     "theoremCount": 41,
     "definitionCount": 5,

--- a/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "kummer-theorem-oq-01-oq-01",
   "description": "Proves that v_p(multinomial(k₁,...,kₘ)) = total carries when adding k₁,...,kₘ in base p, using Mathlib's Nat.factorization_choose' (Kummer's theorem) and the binomial decomposition from OQ-01. Refutes the claim that base-p carry counting is 'not yet in Mathlib'. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "number-theory",
@@ -12,10 +12,10 @@
       "multinomial"
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses Nat.factorization_choose' (Kummer carries formula, in Mathlib 4.26.0), Nat.factorization_mul, Nat.log_mono_right, and List.map_congr_left.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete multinomial corollaries `multinomial_123_p2`, `multinomial_123_p3`, `multinomial_123_value` are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 201,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (300 BCE), Euler (1747)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number",
     "date": "300 BCE / 1747",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "perfect-numbers",
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PerfectNumbers.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,9 +50,9 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 70,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 202,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but establish that 6, 28, 496, and 8128 are perfect numbers via `native_decide` (Mersenne-prime checks), which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -8,7 +8,7 @@
     "author": "Euclid (Lean 4 formalization)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Platonic_solid",
     "date": "c. 300 BCE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PlatonicSolids.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "topology"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -34,14 +34,14 @@
       "Proof of duality relationships between Platonic solids"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 419,
     "prerequisites": [
       "Euler's formula for polyhedra: V - E + F = 2",
       "Schlafli symbols and regular polyhedra",
       "Combinatorics of regular tilings and angle constraints"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the presented theorem `number_of_platonic_solids` is discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
     "definitionCount": 11

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -4,7 +4,7 @@
   "slug": "sqrt2-irrational",
   "description": "The classic proof that √2 is irrational, generalized to show √n is irrational for any non-perfect-square n. Covers √2, √3, √5, √6, √7 and the general theorem.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "classic",
@@ -14,7 +14,7 @@
     ],
     "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/Sqrt2Irrational.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,9 +51,9 @@
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 222,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the presented corollary `irrational_sqrt_six` is discharged by `native_decide` (the \u221a2 result itself is kernel-checked via Mathlib), which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "theoremCount": 14,
     "definitionCount": 0
   },

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -8,7 +8,7 @@
     "author": "James Stirling / Abraham de Moivre (formalized via Mathlib)",
     "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Analysis/SpecialFunctions/Stirling.lean",
     "date": "1730",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/StirlingFormula.lean",
     "tags": [
       "analysis",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "approximation"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -42,7 +42,7 @@
       "Connection to log-factorial approximation for entropy calculations"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 640,
     "prerequisites": [
       "Real analysis: limits, asymptotic equivalence (~), sequences",
@@ -50,7 +50,7 @@
       "The Wallis product: π/2 = ∏(4n²)/(4n²-1)",
       "Logarithmic approximation: log(n!) ≈ n log n - n + (1/2)log(2πn)"
     ],
-    "assumptions": "0 axioms. The error bound stirling_error_bound_ge_2 is now fully proved via telescoping log bounds from Mathlib.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete factorial corollaries `factorial_10` and `factorial_20` are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfDivisors.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "perfect-numbers",
       "amicable-numbers"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the many concrete \u03c3-value, perfect/deficient/abundant, and divisor-count corollaries (e.g. `six_is_perfect`, `sigma_one_eq`, `twelve_is_abundant`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 549,
     "theoremCount": 81,
     "definitionCount": 5,

--- a/src/data/proofs/sum-of-kth-powers/meta.json
+++ b/src/data/proofs/sum-of-kth-powers/meta.json
@@ -8,7 +8,7 @@
     "author": "Johann Faulhaber / Nicomachus (formalized)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Faulhaber%27s_formulas",
     "date": "c. 100 CE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfKthPowers.lean",
     "tags": [
       "algebra",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "induction"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,9 +39,9 @@
       "Closed-form formula for sum of fifth powers: n²(n+1)²(2n²+2n-1)/12"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 600,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The general results are kernel-checked, but the concrete power-sum corollaries (e.g. `sum_squares_100`, `sum_cubes_100`, `sum_seventh_powers_10`) are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Batch 2 of the #25409 cleanup: 12 gallery entries that present a `native_decide`-discharged theorem as a verified result are re-classed `verified → axiomatized`, `badge → axiom`, `meta.axiomCount 0 → 1`, with `Lean.ofReduceBool` disclosed in `assumptions`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Follows the field pattern of #25390 / #25408 / #25416 (batch 1).

## Entries (each names its presented native_decide theorem in `assumptions`)

| slug | presented native_decide theorem(s) |
|------|------------------------------------|
| perfect-numbers | `six_is_perfect`, `twentyeight_is_perfect`, `fourhundredninetysix_is_perfect`, `eightthousandonetwentyeight_is_perfect` |
| birthday-problem | `birthday_23_exceeds_half`, `birthday_22_below_half`, … |
| sum-of-divisors | `six_is_perfect`, `sigma_*`, `divisor_count_*`, `*_is_abundant`, … |
| stirling-formula | `factorial_10`, `factorial_20` |
| platonic-solids | `number_of_platonic_solids` |
| sqrt2-irrational | `irrational_sqrt_six` (√2 itself stays kernel-checked) |
| euler-totient-oq-02 | `totient_six`, `totient_twelve`, `totient_hundred`, … |
| inclusion-exclusion-oq-01 | `altBinomSum_*`, `derangements_*` |
| erdos-891 | `bigOmega_*`, `k2_verified_range` |
| kummer-theorem-oq-01-oq-01 | `multinomial_123_p2/p3/value` |
| divisibility-rules | `six_dvd_iff`, `digitalRoot_*`, `rules_verification` |
| sum-of-kth-powers | `sum_squares_100`, `sum_cubes_100`, `sum_seventh_powers_10`, … |

## Classification method

Comment-stripped scan of each entry's Lean source attributing every `native_decide` to its enclosing declaration. These 12 all have `native_decide` inside **named `theorem`/`lemma`** declarations (not `example`/sanity blocks), so the presented theorems' axiom sets necessarily include `Lean.ofReduceBool` per the CLAUDE.md:140 convention. Entries whose `native_decide` appears only in unnamed `example` blocks are correctly left `verified` and excluded.

## Evidence

**Before**: `status: "verified"`, `axiomCount: 0`, `assumptions` claiming "0 axioms".
**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`, `assumptions` disclosing `Lean.ofReduceBool` and naming the specific presented theorem(s).

Part of #25409 (~165 total; batch 1 = #25416, burnside = #25408). Remaining candidates continue in subsequent batches.

---
Automated fix by lean-mechanic agent.