### PR TITLE
audit(leibniz-pi-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12270,9 +12270,9 @@
       "result": "clean"
     },
     "leibniz-pi-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
+      "lastAudited": "2026-06-18T04:59:49Z",
       "result": "clean"
     },
     "leibniz-pi-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — leibniz-pi-oq-01

**Verdict: CLEAN** (re-audit; auditCount 3→4)

Optimal Convergence Rate for Arctangent-Based Pi Series. All public-facing claims verified against `proofs/Proofs/LeibnizPiOQ01OQ01.lean`.

### Checks
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| status / badge | verified / mathlib | core convergence via Mathlib `Real.tendsto_sum_pi_div_four`; error bound proved independently | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 native_decide, 0 True stubs | ✓ |
| lineCount | 134 | 134 | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 1 | 1 (`S`) | ✓ |

### Narrative
- `originalContributions` honestly scoped: error bound `|π/4 - Sₙ| ≤ 1/(2n+1)`, even/odd subsequence monotonicity, rate sharpness via consecutive term differences, Machin formula *statement*.
- Machin exponential-rate (`O(1/m^(2N))`) and `Θ(1/N)` prose is contextual/pedagogical — not formalized, and properly hedged in the `assumptions` field. No overclaim.
- Tier B badge `mathlib` correct (5 of the narrative failure modes checked; none triggered).

### Minor (non-blocking, enricher polish)
`mathlibDependencies` lists `Real.arctan_one` (conceptual — the series *is* the arctan(1) Taylor series) rather than the `exact`-invoked `four_mul_arctan_inv_5_sub_arctan_inv_239`. This is conservative, not overclaiming, so left for an enrichment pass.

Tracker-only change.

---
Discovered during gallery integrity audit.