### PR TITLE
research(mantel-theorem-oq-01): register + gallery the AES min-degree ingredient (build GREEN)

### DIFF
--- a/research/problems/mantel-theorem-oq-01/state.md
+++ b/research/problems/mantel-theorem-oq-01/state.md
@@ -41,14 +41,20 @@ for `Fintype.card α`, so the elaborated threshold is exactly `2 * Fintype.card 
 - Current approach attempts: 1
 - Approaches tried: 1 (degree-cleaning / AES ingredient)
 
+## Result (this session, researcher-2)
+Docker build is healthy again. Built `Proofs.MantelStabilityOQ01` GREEN
+(`✔ [7743/7743] Built Proofs.MantelStabilityOQ01 (1176s)`, "Build completed
+successfully"), then **registered** the file in `Proofs.lean` and added the gallery
+entry `src/data/proofs/mantel-theorem-oq-01/` (meta.json verified/mathlib, 0 sorries /
+0 axioms, Mathlib-only closure; 3 annotations, resolver 3/3). The min-degree
+(Andrásfai–Erdős–Sós) ingredient is now build-verified and galleried.
+
 ## Blockers
-- Docker build blacked out (`docker run --rm alpine echo ok` → rc=124 timeout), so
-  the orphan is build-pending. Registration in `Proofs.lean` + gallery entry are
-  deferred until a green Docker build is possible.
+- None for the ingredient. The **headline** edge-count Erdős–Simonovits stability
+  statement remains open (see Next Action / Open Questions).
 
 ## Next Action
-1. When Docker is healthy: `./proofs/scripts/docker-build.sh Proofs.MantelStabilityOQ01`,
-   then register in `Proofs.lean` and add a gallery entry.
+1. ✅ Done: Docker build green, registered in `Proofs.lean`, gallery entry added.
 2. Next math ingredient: the *edge-count → few low-degree vertices* counting lemma
    (deleting vertices of degree `≤ 2n/5` loses `o(n²)` edges), which combines with
    the AES lemma above to give the full stability statement.


### PR DESCRIPTION
## Summary

`Proofs/MantelStabilityOQ01.lean` (merged in #25255 but left **orphan/unregistered**, so no false "green") is now:

- **Registered** in `Proofs.lean` (`import Proofs.MantelStabilityOQ01`)
- **Built GREEN** under Docker: `✔ [7743/7743] Built Proofs.MantelStabilityOQ01 (1176s)`, "Build completed successfully"
- **Galleried** at `src/data/proofs/mantel-theorem-oq-01/` — meta `verified`/badge `mathlib`, **0 sorries / 0 axioms**, Mathlib-only import closure; 3 annotations (resolver 3/3 valid)

## Math content

The file packages the **triangle-free (r = 2) case of the Andrásfai–Erdős–Sós theorem** — a $K_3$-free graph on $n$ vertices with minimum degree $> 2n/5$ is bipartite — as a thin specialization of Mathlib's `SimpleGraph.colorable_of_cliqueFree_lt_minDegree` (Brandt's proof, FiveWheelLike.lean), where the general threshold $(3r-4)n/(3r-1)$ collapses to $2n/5$ (discharged by `omega`). It also gives the contrapositive **degree-cleaning** form: a non-bipartite triangle-free graph has minimum degree $\le 2n/5$.

This is the load-bearing **min-degree ingredient** of the degree-cleaning route toward the headline open question `mantel-theorem-oq-01` (the edge-count Erdős–Simonovits stability strengthening of Mantel's theorem), which **remains open** — this PR does not claim to settle it.

## Verification
- Docker build green (registered)
- Resolver: 3/3 annotations aligned
- Closure: imports Mathlib only → `verified` eligible (no native_decide, no axioms, no sorries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)