### PR TITLE
audit(lebesgue-measure-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12222,9 +12222,9 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:25:55Z",
+      "lastAudited": "2026-06-18T05:07:17Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: lebesgue-measure-oq-01

**Result: CLEAN** — no integrity issues.

Re-audited the "Dirichlet Function Integral via Almost Everywhere Zero" entry against `proofs/Proofs/LebesgueMeasureOQ01.lean`.

### Verified
| Claim | meta.json | Source | Match |
|-------|-----------|--------|-------|
| theorems | 12 | 12 | ✓ |
| definitions | 1 | 1 | ✓ |
| lineCount | 197 | 197 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, no `native_decide`/`decide`, no `True` stubs | ✓ |

### Tier classification
**Tier B (mathlib)** — correctly badged. Main theorem `dirichlet_integral_zero` obtains its result via Mathlib's `integral_eq_zero_of_ae` and `Set.Countable.measure_zero`. This reliance is honestly disclosed in `assumptions` ("Core measure theory results … from Mathlib; original work is the application to Dirichlet-type functions") and `originalContributions` (the a.e.-zero argument, the any-measurable-set extension, the nowhere-continuous proof). No delegation opacity, no overclaiming.

All 6 `mathlibDependencies` are actually used in the file.

This PR only bumps the audit tracker (auditCount 3→4, lastAudited).

---
Discovered during gallery integrity re-audit (queue fully drained, 2528/2528).