### PR TITLE
research(erdos-1047-oq-02): make gallery entry AXIOM-FREE via the certificate (axiomCount 1→0)

### DIFF
--- a/proofs/Proofs/Erdos1047OQ02.lean
+++ b/proofs/Proofs/Erdos1047OQ02.lean
@@ -47,15 +47,23 @@
     1. `grunskyConjecture` was redefined to the `∀ c > 0` faithful form (= this
        file's `grunskyConjectureFaithful`).
     2. `axiom grunskyConjecture_false` was converted to a `theorem`, proved from
-       `goodman_counterexample` (no standalone axiom).
-    3. `meta.json` axiomCount `2 → 1` (only `goodman_counterexample` remains).
+       `goodman_counterexample`.
 
-  Consequently `grunskyConjectureFaithful` is now definitionally equal to the
-  parent's `grunskyConjecture`; `faithful_imp_grunsky` below is the identity, and
-  this file stands as a redundant-but-consistent companion documenting the repair.
+  ── This entry is now axiom-free ──────────────────────────────────────────────
+
+  The last analytic assumption has been discharged.  The Goodman counterexample is
+  proved with no `sorry` and no axiom in `Proofs/Erdos1047OQ02Certificate.lean`
+  (`goodman_counterexample_proof`), so `grunsky_false_faithful` below now derives the
+  Erdős #1047 answer from that machine-checked certificate instead of the parent's
+  `goodman_counterexample` *axiom*.  Its `#print axioms` shows only Mathlib's
+  standard `propext`/`Classical.choice`/`Quot.sound`.  `meta.json` axiomCount `1 → 0`.
+
+  Consequently `grunskyConjectureFaithful` is definitionally equal to the parent's
+  `grunskyConjecture`; `faithful_imp_grunsky` below is the identity.
 -/
 
 import Proofs.Erdos1047Problem
+import Proofs.Erdos1047OQ02Certificate
 import Mathlib.Tactic
 
 open Polynomial Set Erdos1047
@@ -80,15 +88,23 @@ def grunskyConjectureFaithful : Prop :=
 theorem faithful_imp_grunsky : grunskyConjectureFaithful → grunskyConjecture :=
   fun h => h
 
-/-- **The corrected axiom, as a theorem.**  The faithful Grunsky statement is
-    false — proved directly from the parent's `goodman_counterexample`
-    (`f = (z²+1)(z−2)²` at `c = 5^{3/2}/4`).  No standalone axiom is needed for the
-    negation; only `goodman_counterexample` (the genuine analytic counterexample)
-    remains as an assumption. -/
+/-- **The corrected axiom, fully proved — no assumptions.**  The faithful Grunsky
+    statement is false (`f = (z²+1)(z−2)²` at `c = 5^{3/2}/4`).  The witness is now
+    `Erdos1047OQ02Cert.goodman_counterexample_proof`, a `sorry`-free, axiom-free
+    theorem (it replaces the parent's `goodman_counterexample` *axiom* with the
+    machine-checked Goodman certificate: a preconnected arc inside the lemniscate
+    whose chord midpoint escapes it, via the topological bridge
+    `componentContaining_lemniscate_not_convex_of_chord_exits`).  So this negation —
+    and hence the Erdős #1047 answer (NO) along this route — rests on **no** analytic
+    axiom. -/
 theorem grunsky_false_faithful : ¬grunskyConjectureFaithful := by
   intro h
-  obtain ⟨z₀, hz₀, hnc⟩ := goodman_counterexample
+  obtain ⟨z₀, hz₀, hnc⟩ := Erdos1047OQ02Cert.goodman_counterexample_proof
   exact hnc (h goodmanPolynomial goodmanPolynomial_monic goodmanPolynomial_degree_pos
     goodmanCriticalValue (by unfold goodmanCriticalValue; positivity) z₀ hz₀)
+
+/- Axiom audit (Docker-verified): `#print axioms grunsky_false_faithful` reports
+   exactly `[propext, Classical.choice, Quot.sound]` — Mathlib's standard axioms,
+   which do not count as assumptions.  No problem-specific axiom, no `sorry`. -/
 
 end Erdos1047OQ02

--- a/src/data/proofs/erdos-1047-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1047-oq-02/annotations.json
@@ -27,11 +27,11 @@
     "proofId": "erdos-1047-oq-02",
     "range": {
       "startLine": 43,
-      "endLine": 55
+      "endLine": 63
     },
     "type": "context",
-    "title": "Parent Patch Applied: Axiom Count 2 → 1",
-    "content": "The repair this companion proposed has **landed** in `Erdos1047Problem.lean` (Docker-verified, PR #24613): (1) `grunskyConjecture` was redefined to the faithful `∀ c > 0` form; (2) `axiom grunskyConjecture_false` was converted to a `theorem` proved from `goodman_counterexample`; (3) the flagship's `axiomCount` dropped `2 → 1`.\n\nConsequently `grunskyConjectureFaithful` is now *definitionally equal* to the flagship's `grunskyConjecture`, and this file stands as a redundant-but-consistent record documenting the repair. Only `goodman_counterexample` — the single genuine analytic input — remains as an assumption.",
+    "title": "Parent Patch Applied, then Axiom Fully Discharged (Count → 0)",
+    "content": "The parent soundness patch landed: `Erdos1047Problem.lean` redefined `grunskyConjecture` to the faithful `∀ c > 0` form and proved `grunskyConjecture_false` as a theorem, leaving `goodman_counterexample` as the sole axiom. **That last axiom is now discharged too**: `Erdos1047OQ02Certificate.lean` proves `goodman_counterexample_proof` — the exact statement — with no `sorry` and no axiom (a preconnected Goodman arc inside the lemniscate whose chord midpoint escapes it, via the topological reduction bridge). This entry now imports that certificate, so `grunsky_false_faithful` derives the Erdős #1047 answer from a fully machine-checked proof. `#print axioms` reports only `propext`/`Classical.choice`/`Quot.sound`; axiomCount **1 → 0**.",
     "mathContext": "Post-patch dependency chain has exactly one axiom, `goodman_counterexample`; `grunskyConjecture_false : ¬grunskyConjecture` is a theorem, not an axiom.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -45,8 +45,8 @@
     "id": "ann-e1047-oq02-faithful",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 65,
-      "endLine": 72
+      "startLine": 73,
+      "endLine": 80
     },
     "type": "definition",
     "title": "Faithful Grunsky Question (∀ c > 0)",
@@ -66,8 +66,8 @@
     "id": "ann-e1047-oq02-coincides",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 74,
-      "endLine": 81
+      "startLine": 82,
+      "endLine": 89
     },
     "type": "theorem",
     "title": "Faithful Coincides with the Flagship (the Implication is the Identity)",
@@ -85,12 +85,12 @@
     "id": "ann-e1047-oq02-negation-theorem",
     "proofId": "erdos-1047-oq-02",
     "range": {
-      "startLine": 83,
-      "endLine": 92
+      "startLine": 91,
+      "endLine": 104
     },
     "type": "theorem",
-    "title": "The Corrected Axiom, as a Theorem",
-    "content": "`grunsky_false_faithful : ¬grunskyConjectureFaithful` proves the faithful Grunsky statement is FALSE — directly from the parent's `goodman_counterexample` (f = (z²+1)(z-2)² at c = 5^{3/2}/4). It destructs the counterexample to exhibit a non-convex component, contradicting convexity for all c > 0.\n\nThe key point: the negation needs **no standalone axiom**. Only `goodman_counterexample` — the single genuine analytic input — remains as an assumption, which is exactly what drops the parent's axiom count from 2 to 1.",
+    "title": "The Corrected Axiom, Now a Fully-Proved Theorem",
+    "content": "`grunsky_false_faithful` destructs the Goodman counterexample to exhibit a non-convex lemniscate component at `f = (z²+1)(z−2)²`, `c = 5^{3/2}/4`, refuting convexity for all `c > 0`. The witness is `Erdos1047OQ02Cert.goodman_counterexample_proof`, an axiom-free, `sorry`-free theorem — so the negation (and the Erdős #1047 answer NO along this route) rests on **no** analytic axiom.",
     "mathContext": "From $\\exists z_0,\\ z_0 \\in$ Goodman component $\\wedge\\ \\neg\\text{convex}$, derive $\\neg\\mathrm{grunskyConjectureFaithful}$. The positivity side-goal for $c = 5^{3/2}/4 > 0$ is discharged by `positivity`. Negation is a deduction, not an axiom.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1047-oq-02/meta.json
+++ b/src/data/proofs/erdos-1047-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "erdos-1047-oq-02",
   "title": "Erdős #1047 OQ-02: Soundness of the Grunsky-Conjecture Axiom",
   "slug": "erdos-1047-oq-02",
-  "description": "A soundness-correction companion for Erdős #1047. An earlier flagship formalization stated Grunsky's conjecture with a spurious small-c restriction and posited its negation as a false axiom. That patch has now been APPLIED in the flagship (Erdos1047Problem.lean): grunskyConjecture was redefined to the faithful (∀ c > 0) form and grunskyConjecture_false is now a theorem from Goodman's counterexample, leaving goodman_counterexample as the single remaining axiom. This entry mirrors the corrected statement (grunskyConjectureFaithful, now definitionally equal to the flagship's grunskyConjecture) and re-derives its negation, standing as a redundant-but-consistent record of the repair.",
+  "description": "An axiom-free resolution-and-soundness entry for Erdős #1047. An earlier flagship stated Grunsky's conjecture with a spurious small-c restriction and posited its negation as a false axiom; that patch was applied (grunskyConjecture redefined to the faithful ∀ c > 0 form, grunskyConjecture_false proved as a theorem), leaving goodman_counterexample as the sole axiom. That last axiom is now DISCHARGED: Erdos1047OQ02Certificate.lean proves the Goodman counterexample (non-convex lemniscate component of (z²+1)(z-2)² at c=5^(3/2)/4) with no sorry and no axiom, via a preconnected arc whose chord escapes the lemniscate. This entry imports the certificate so its negation theorem grunsky_false_faithful rests on no problem-specific axiom (#print axioms = propext/Classical.choice/Quot.sound only).",
   "meta": {
     "author": "researcher agents (Lean Genius); Grunsky (question), Goodman (1966, counterexample)",
     "sourceUrl": "https://erdosproblems.com/1047",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1047OQ02.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "soundness",
       "axiom-integrity"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 1047,
     "erdosUrl": "https://erdosproblems.com/1047",
@@ -37,14 +37,14 @@
       }
     ],
     "originalContributions": [
-      "Faithful formalization of Grunsky's question with no spurious small-c restriction (grunskyConjectureFaithful, ∀ c > 0), now definitionally equal to the flagship's repaired grunskyConjecture",
-      "Proof that the faithful statement's negation is a THEOREM (grunsky_false_faithful), derived directly from goodman_counterexample — not a standalone axiom",
-      "faithful_imp_grunsky: records that the faithful statement now coincides with the flagship's grunskyConjecture (the implication is the identity, since the flagship was redefined to the ∀-c form)",
-      "Documents the parent soundness patch (PR #24613, applied) that reduced the flagship axiom count from 2 to 1 by replacing the false axiom grunskyConjecture_false with a theorem"
+      "Faithful formalization of Grunsky's question with no spurious small-c restriction (grunskyConjectureFaithful, ∀ c > 0), definitionally equal to the flagship's repaired grunskyConjecture",
+      "AXIOM-FREE proof that the faithful statement's negation is a THEOREM (grunsky_false_faithful), now derived from the machine-checked Goodman certificate (goodman_counterexample_proof) instead of the parent's goodman_counterexample axiom — no problem-specific axiom in the dependency chain",
+      "Discharge of the last analytic axiom: the Goodman counterexample is proved with no sorry/axiom in Erdos1047OQ02Certificate.lean (4 degree-8 segment inequalities ‖f(z(s))‖≤c via a sympy-verified SOS/Bernstein certificate + the topological chord-exit bridge)",
+      "faithful_imp_grunsky: records that the faithful statement coincides with the flagship's grunskyConjecture (the implication is the identity)"
     ],
-    "axiomCount": 1,
-    "lineCount": 94,
-    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1047OQ02` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 3059 jobs; verified 2026-06-15, researcher-4). Registered in Proofs.lean (import Proofs.Erdos1047OQ02). The parent axiom-elimination patch (PR #24613) landed: Erdos1047Problem.lean defines grunskyConjecture in the faithful ∀ c > 0 form and proves grunskyConjecture_false as a theorem. The only assumption is the inherited goodman_counterexample axiom (Goodman's polynomial (z²+1)(z-2)² has a non-convex lemniscate component at c = 5^(3/2)/4) — the single genuine analytic input. This entry adds NO axioms of its own; goodman_counterexample is the sole axiom in the dependency chain (axiomCount = 1).",
+    "axiomCount": 0,
+    "lineCount": 110,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1047OQ02` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 3061 jobs; verified 2026-06-17, researcher-5). Registered in Proofs.lean. **AXIOM-FREE**: the last analytic assumption (goodman_counterexample) has been discharged in Proofs/Erdos1047OQ02Certificate.lean, which proves `goodman_counterexample_proof` (the exact statement) with no sorry and no axiom — the Goodman polynomial (z²+1)(z-2)² at c = 5^(3/2)/4 has a non-convex lemniscate component, witnessed by a preconnected 4-segment arc inside the lemniscate whose chord midpoint (0, |f|=4>c) escapes it, via the topological reduction bridge componentContaining_lemniscate_not_convex_of_chord_exits. This entry imports that certificate, so `grunsky_false_faithful` no longer depends on any problem-specific axiom. `#print axioms grunsky_false_faithful` = [propext, Classical.choice, Quot.sound] (Mathlib standard, non-counting). axiomCount = 0.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
     "definitionCount": 1
@@ -97,33 +97,32 @@
       "id": "faithful-statement",
       "title": "The Faithful Grunsky Question",
       "summary": "grunskyConjectureFaithful: convexity for every c > 0, with no small-c restriction",
-      "startLine": 65,
-      "endLine": 72,
+      "startLine": 73,
+      "endLine": 80,
       "mathContext": "$\\\\forall f$ monic of positive degree, $\\\\forall c > 0$, every component of $\\\\{|f(z)| \\\\le c\\\\}$ is convex. The statement the #1047 docstring actually describes; it is FALSE."
     },
     {
       "id": "strictly-stronger",
       "title": "Faithful Coincides with the Flagship",
       "summary": "faithful_imp_grunsky: the ∀-c statement now coincides with the flagship's repaired grunskyConjecture (the implication is the identity)",
-      "startLine": 74,
-      "endLine": 81,
+      "startLine": 82,
+      "endLine": 89,
       "mathContext": "Since the flagship was redefined to the faithful $\\\\forall c > 0$ form, `grunskyConjectureFaithful` is definitionally equal to its `grunskyConjecture` and the implication is `fun h => h`."
     },
     {
       "id": "negation-theorem",
       "title": "The Corrected Axiom, as a Theorem",
       "summary": "grunsky_false_faithful: the faithful statement is false, proved from goodman_counterexample",
-      "startLine": 83,
-      "endLine": 93,
+      "startLine": 91,
+      "endLine": 104,
       "mathContext": "Destructs Goodman's counterexample at $f = (z^2+1)(z-2)^2$, $c = 5^{3/2}/4$ to refute convexity for all c > 0 — no standalone negation axiom needed."
     }
   ],
   "conclusion": {
-    "summary": "An earlier flagship Erdős #1047 file negated a spurious small-c restriction of Grunsky's conjecture via a false axiom (grunskyConjecture_false). That patch has now been applied (PR #24613): the flagship was redefined to the faithful ∀-c statement and proves its negation as a theorem directly from Goodman's counterexample, reducing its axiom count from 2 to 1. This open-question entry mirrors the corrected faithful statement (now definitionally equal to the flagship's grunskyConjecture) and re-derives the negation, standing as a redundant-but-consistent record of the repair.",
-    "implications": "Improves the integrity of the #1047 formalization: the falsity of Grunsky's conjecture becomes a machine-checkable consequence of the single genuine analytic input (Goodman's counterexample), rather than a posited axiom that, as stated, was unsound.",
+    "summary": "Erdős #1047 OQ-02 is now AXIOM-FREE. An earlier flagship negated a spurious small-c Grunsky statement via a false axiom; the applied patch made the negation a theorem from goodman_counterexample, and this work discharges that last axiom too — the Goodman counterexample is fully proved (no sorry/axiom) in Erdos1047OQ02Certificate.lean. grunsky_false_faithful now derives the answer NO from a machine-checked certificate; axiomCount 1 → 0.",
+    "implications": "The falsity of Grunsky's conjecture (and the Erdős #1047 answer NO along this route) is now a fully machine-checked consequence with no posited analytic axiom — the Goodman non-convexity is certified by an explicit preconnected arc and a chord-exit estimate, both proved in Lean.",
     "openQuestions": [
-      "Confirm the deployer machine-check of Erdos1047OQ02.lean and the repaired flagship on the next green build.",
-      "Formalize goodman_counterexample itself (the remaining genuine axiom) from explicit complex-analytic estimates.",
+      "Retire the parent flagship's own goodman_counterexample axiom and its 4 downstream consumers by moving the headline theorems downstream of the certificate (mechanical restructure; the analytic content is done).",
       "Goodman's open question: the maximum number of non-convex lemniscate components as a function of degree (a lower bound ⌊d/3⌋ is numerically certified in this problem's research notes)."
     ]
   },
@@ -165,6 +164,7 @@
   "leanFile": {
     "imports": [
       "Proofs.Erdos1047Problem",
+      "Proofs.Erdos1047OQ02Certificate",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -173,8 +173,8 @@
       "Erdos1047"
     ],
     "namespace": "Erdos1047OQ02",
-    "lineCount": 94,
-    "axiomCount": 1,
+    "lineCount": 110,
+    "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 1,
     "path": "Proofs/Erdos1047OQ02.lean",


### PR DESCRIPTION
## Summary

Follow-up to #25406 (the build-green Goodman certificate, now merged). This makes the **erdos-1047-oq-02 gallery entry genuinely axiom-free**.

The entry's registered `leanFile` is `Erdos1047OQ02.lean`, whose only axiom use was `grunsky_false_faithful` destructing the parent's `axiom goodman_counterexample`. This PR rewires it to consume the merged certificate's proven `Erdos1047OQ02Cert.goodman_counterexample_proof` (sorry-free, axiom-free), eliminating the last analytic assumption from the entry's dependency chain — **without touching the flagship**.

## Verification

```
docker-build.sh Proofs.Erdos1047OQ02  →  Built Proofs.Erdos1047OQ02 (3061 jobs)
#print axioms grunsky_false_faithful  →  [propext, Classical.choice, Quot.sound]
```

Only Mathlib's standard axioms (non-counting per the repo's Axiom Integrity Policy) — no problem-specific axiom, no `sorry`.

## Changes

- **`Erdos1047OQ02.lean`**: `import Proofs.Erdos1047OQ02Certificate`; `grunsky_false_faithful` now obtains the witness from `Erdos1047OQ02Cert.goodman_counterexample_proof`. Header docstring updated to the axiom-free state.
- **`meta.json`**: status `axiomatized → verified`, badge `axiom → original`, `axiomCount 1 → 0`, `lineCount 94 → 110`, `leanFile.imports += Erdos1047OQ02Certificate`; `description`/`assumptions`/`conclusion`/`originalContributions` refreshed; section line-ranges shifted.
- **`annotations.json`**: 5 anchors re-anchored to the shifted lines (resolver validates **5/5**, 0 misaligned); the patch/negation annotations refreshed to reflect the discharge.

## Scope

The parent flagship `Erdos1047Problem.lean` still declares its **own** `goodman_counterexample` axiom (used by its own headline theorems `grunskyConjecture_false`/`erdos_1047`/…); its separate entry `erdos-1047` stays `axiomatized`. Retiring that is a purely mechanical downstream restructure — the analytic content is fully done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)