### PR TITLE
Fix: re-class collatz-structured-oq-02 verified→axiomatized (presented native_decide)

### DIFF
--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lagarias, Eliahou (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Collatz_conjecture#Cycle_length",
     "date": "1985",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "dynamics",
@@ -16,9 +16,9 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/CollatzCycles.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Function.iterate",
@@ -38,7 +38,7 @@
     "dateAdded": "2026-03-23",
     "lineCount": 256,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented theorem `small_numbers_reach_one` (\"All n ≤ 20 verified to reach 1\") discharges each finite Collatz trajectory (n ≤ 20) by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations). Shares `Proofs/CollatzCycles.lean` with the `collatz-cycles` entry, which carries the identical classification.",
     "theoremCount": 27,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Fix

`collatz-structured-oq-02` was `verified` / `badge: original` / `axiomCount: 0` with `assumptions: "None. Fully verified..."`, but it presents the `native_decide`-discharged result `small_numbers_reach_one` ("All n ≤ 20 verified to reach 1"), so it depends on `Lean.ofReduceBool`.

## Evidence

- `proofRepoPath: Proofs/CollatzCycles.lean` — the **same file** as sibling `collatz-cycles`, already correctly re-classed to `axiomatized` / `axiom` / `axiomCount: 1` for this exact theorem.
- `originalContributions` lists "All n ≤ 20 verified to reach 1" = `small_numbers_reach_one`, proved by 20 `native_decide` cases (`CollatzCycles.lean:198-221`). `proofStrategy` already states this is done "using native_decide".
- Not a stirling-style auxiliary: the entry presents the native_decide result as a headline contribution.

**Before**: `verified` / `original` / `axiomCount: 0` / `assumptions: "None..."`
**After**: `axiomatized` / `axiom` / `axiomCount: 1` / `assumptions` discloses `Lean.ofReduceBool` (matching `collatz-cycles`). `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

No Docker build needed — same Lean file as an already-classified sibling, identical presented theorem.

Part of #25409.

---
Automated fix by lean-mechanic agent.