### PR TITLE
Fix: re-class sylow-theorem-oq-04 verified→axiomatized (presented native_decide)

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SylowTheoremOQ04.lean",
     "tags": [
       "group-theory",
@@ -15,11 +15,11 @@
       "finite-groups",
       "applications"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented results include the exact Sylow numbers for A₅ (`card_A5`, `n2_eq`, `n3_eq`, `n5_eq`) discharged by `native_decide`, on which the non-normality theorems (`sylow{2,3,5}_not_normal`) and the simplicity/non-solvability chain depend. `native_decide` is accepted by the kernel via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations). Shares `Proofs/SylowTheoremOQ04.lean` with the `sylow-theorems-oq-04` entry, which carries the identical classification.",
     "lineCount": 276,
     "theoremCount": 21,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

`sylow-theorem-oq-04` was `verified` / `badge: mathlib` / `axiomCount: 0` with `assumptions: "None. Fully machine-verified."`, but its headline contributions are computed by `native_decide`, so it depends on `Lean.ofReduceBool`.

## Evidence

- `originalContributions[0]` literally reads "Exhaustive computation of exact Sylow numbers for A₅ **via native_decide**". The theorems `card_A5`, `n2_eq` (n₂=5), `n3_eq` (n₃=10), `n5_eq` (n₅=6) are each `:= by native_decide` (`SylowTheoremOQ04.lean:43,111,114,117`).
- The presented `sylow{2,3,5}_not_normal` results derive non-normality from these exact counts (> 1), so `Lean.ofReduceBool` is in the closure of the presented theorems — not a stirling-style isolated auxiliary.
- `proofRepoPath: Proofs/SylowTheoremOQ04.lean` — the **same file** as sibling `sylow-theorems-oq-04`, already correctly classed as `axiomatized` / `axiom` / `axiomCount: 1`.

**Before**: `verified` / `mathlib` / `axiomCount: 0` / `assumptions: "None..."`
**After**: `axiomatized` / `axiom` / `axiomCount: 1` / `assumptions` discloses `Lean.ofReduceBool` (matching the sibling). `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

No Docker build needed — same Lean file as an already-classified sibling, and the entry explicitly presents the native_decide computations.

Part of #25409.

---
Automated fix by lean-mechanic agent.