### PR TITLE
audit(sum-of-kth-powers-oq-02): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13294,9 +13294,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:27:02Z",
+      "lastAudited": "2026-06-18T05:11:40Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: sum-of-kth-powers-oq-02 (Sum of Powers: Extension to Non-Integer Exponents)
**Result**: CLEAN — all claims match the Lean source.

## Verification

`proofs/Proofs/SumOfKthPowersOQ02.lean`:
- **14 theorems** (12 `theorem` + 2 `lemma`) and **1 def** (`partialZeta`) — matches `theoremCount: 14`, `definitionCount: 1`.
- **0 sorries, 0 axioms, 0 native_decide, 0 True-stubs** (comment-aware scan) — matches `sorries: 0`, `axiomCount: 0`.
- `lineCount: 175` matches.

## Tier classification

**Tier B** (formalized using Mathlib theorems) — correctly presented:
- Core results derive from Mathlib's `hasSum_zeta_two`, `hasSum_zeta_four`, `Real.summable_nat_rpow_inv`, `Real.rpow_le_rpow_of_exponent_le` (used directly at lines 45, 56, 60, 69).
- `badge: "mathlib"` ✓ (not `original`/`verified`).
- `originalContributions` honestly label wrappers as wrappers.
- `assumptions` field discloses the Mathlib dependency.

No overclaiming. `status: verified` + `badge: mathlib` is the conservative, correct classification.

Tracker bump only (auditCount 3→4).

---
Discovered during gallery integrity audit.