### PR TITLE
audit(sqrt2-from-axioms-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13181,9 +13181,9 @@
       "result": "clean"
     },
     "sqrt2-from-axioms-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:27:02Z",
+      "lastAudited": "2026-06-18T05:15:32Z",
       "result": "clean"
     },
     "sqrt2-irrational": {


### PR DESCRIPTION
## Gallery Integrity Audit — sqrt2-from-axioms-oq-01

Re-audited `Irrationality of √p for Any Prime p (From Axioms)` against `proofs/Proofs/Sqrt2FromAxiomsOQ01.lean`. **No integrity issues found.**

### Verification

| Claim | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom decls, no `native_decide` | ✓ |
| status | verified | legitimate (Tier B) | ✓ |
| badge | mathlib | conservative — see below | ✓ |
| theoremCount | 18 | 18 | ✓ |
| definitionCount | 3 | 3 (Divides, EuclidPrime, CoprimeMod) | ✓ |
| lineCount | 365 | 365 | ✓ |
| True stubs | — | none | ✓ |

### Notes
- **Badge `mathlib` is conservative and correct.** The core parametric theorem `sqrt_prime_irrational` is built fully from scratch (EuclidPrime defined independently). The bridge theorems `natPrime_is_euclidPrime` and `sqrt_natPrime_irrational` genuinely call Mathlib's `Nat.Prime.dvd_mul`, so `mathlib` honestly discloses the dependency rather than overclaiming `original`.
- `mathlibDependencies` lists `Nat.mul_mod` (used at lines 121/136/149) and `Nat.Prime.dvd_mul` (line 169) — both genuinely used.
- `originalContributions` accurately scoped to what the file proves.

Tracker bump only (auditCount 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)