### PR TITLE
Enrich Dilworth's Theorem (OQ-01): full-file section coverage

### DIFF
--- a/src/data/proofs/dilworth-theorem-oq-01/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Imports, and Setup",
+      "summary": "The module docstring, `import Mathlib`, `namespace DilworthTheoremOQ01`, and the `variable {α} [PartialOrder α]` context. The docstring defines chains and antichains, states Dilworth's theorem (1950: min chain cover = max antichain) and Mirsky's theorem (1971: min antichain cover = max chain), and scopes the file precisely to the EASY (pigeonhole) directions of both — the ≤ inequalities — built on the single fact that a chain and an antichain meet in at most one point. It explicitly disclaims the hard attainment directions and records 0 sorries / 0 axioms over an arbitrary PartialOrder.",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "Dilworth: $\\min(\\text{chain cover}) = \\max(\\text{antichain})$; Mirsky: $\\min(\\text{antichain cover}) = \\max(\\text{chain})$. This file proves the $\\le$ (easy) directions of both."
+    },
+    {
       "id": "definitions",
       "title": "Chains and Antichains on Finsets",
       "summary": "Defines IsChainOn (pairwise comparable members) and IsAntichainOn (comparable members are equal) over an arbitrary PartialOrder.",


### PR DESCRIPTION
Enrichment pass for `dilworth-theorem-oq-01`.

Already strong (7 complete annotations, 5 key insights, full conclusion). Gap was section coverage: 4 sections spanning lines 49-127, leaving the module docstring + imports + setup (1-48) uncovered.

**Change:** add a *Module Docstring, Imports, and Setup* section (1-48) capturing the Dilworth (1950) / Mirsky (1971) duality statements and the file's precise scope — the easy (pigeonhole) ≤ directions of both, with the hard attainment directions explicitly disclaimed. Sections now cover the full Lean file (4 → 5).

No content removed; claims unchanged (verified / 0 axioms / 0 sorries, matching `Proofs/DilworthTheoremOQ01.lean`).