### PR TITLE
Enrich Connecting Rising to Standard Vandermonde: full-file section coverage

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-02/meta.json
@@ -74,6 +74,14 @@
       "mathContext": "Frames the duality: $\\sum_{i+j=n}\\binom{a+i}{a}\\binom{b+j}{b} = (-1)^n\\sum_{i+j=n}\\binom{-a-1}{i}\\binom{-b-1}{j} = (-1)^n\\binom{-a-b-2}{n} = \\binom{a+b+n+1}{n}$, equivalently $[x^n](1-x)^{-(a+1)}(1-x)^{-(b+1)}$."
     },
     {
+      "id": "setup",
+      "title": "Parent Import and Namespace Setup",
+      "startLine": 43,
+      "endLine": 54,
+      "summary": "`import Proofs.ArithmeticSeriesOQ02OQ02` to reuse the parent's parallel_vandermonde, `open Finset`, and `namespace ArithmeticSeriesOQ02OQ02OQ02` with `open ArithmeticSeriesOQ02OQ02` to bring the parent's results into scope. This establishes the dependency that lets the rising-form identity be derived against the standard form without re-proving the parent material.",
+      "mathContext": "Depends on the parent entry arithmetic-series-oq-02-oq-02 (the rising Vandermonde `parallel_vandermonde`), reused here rather than re-proved."
+    },
+    {
       "id": "standard-vandermonde",
       "title": "Standard Vandermonde (range form)",
       "startLine": 55,


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-02`.

Already strong (7 annotations, 5 key insights, full conclusion). The remaining gap was a small section-coverage hole: lines 43-54 (the parent import, opens, and namespace setup) sat between the header and the first theorem section with no section covering them.

**Change:** add a *Parent Import and Namespace Setup* section (43-54) documenting the dependency on the parent entry's `parallel_vandermonde` and the namespace opens. Sections now cover the full file (4 → 5).

No content removed; claims unchanged (verified / 0 axioms / 0 sorries, matching `Proofs/ArithmeticSeriesOQ02OQ02OQ02.lean`).