### PR TITLE
audit(erdos-679): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8871,9 +8871,9 @@
       "result": "clean"
     },
     "erdos-679": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:27:02Z",
+      "lastAudited": "2026-06-18T05:18:47Z",
       "result": "clean"
     },
     "erdos-68": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-679

Re-audit of the oldest-lastAudited gallery entry (queue drained 2528/2528). All public claims match the Lean source `Proofs/Erdos679Problem.lean`.

### Verification

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| sorries | 10 | 10 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`, no structure assumptions) | ✓ |
| theoremCount | 16 | 16 | ✓ |
| definitionCount | 18 | 18 | ✓ |
| lineCount | 259 | 259 | ✓ |
| status / badge | formalized / wip | scaffold w/ 10 disclosed sorries | ✓ |

### Tier & narrative
- **Tier C** (scaffold / open problem). Badge `wip` correct.
- The 3 `True` Prop *defs* (Problem248/413Connection, ProbabilisticHeuristic) are honestly labeled placeholders — no theorem proves `True` while claiming verified.
- Description honestly states the main question is **OPEN** and the stronger O(1) version is **FALSE**. No delegation opacity, no axiom masking, no inequality-as-theorem inflation.

Tracker: auditCount 3→4, result `clean`.

---
Discovered during gallery integrity audit.