### PR TITLE
research(abel-ruffini-oq06-galois-direction): fix 3 bearer bugs in Step 3 orphan (build-pending)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean
@@ -103,16 +103,19 @@ theorem sylow_p_is_pcycle
   -- Step A:  p ∣ Nat.card H   (primitivity ⇒ transitivity on a p-point set).
   ----------------------------------------------------------------
   haveI : MulAction.IsPretransitive H (ZMod p) := _hPrim.toIsPretransitive  -- ★
-  have horbit : Nat.card (MulAction.orbit H (0 : ZMod p)) = p := by
+  -- p ∣ |H| via the orbit–stabilizer EQUIV (Nat.card / index form), avoiding the
+  -- Fintype-typed `card_orbit_mul_card_stabilizer_eq_card_group`.
+  have hpH : p ∣ Nat.card H := by
     have huniv : MulAction.orbit H (0 : ZMod p) = Set.univ :=
       MulAction.orbit_eq_univ (0 : ZMod p)                                -- ★
-    rw [huniv, Nat.card_congr (Equiv.Set.univ (ZMod p)),
-        Nat.card_eq_fintype_card, ZMod.card]                             -- ★
-  have hpH : p ∣ Nat.card H := by
-    -- ? bearer (Nat.card form): orbit–stabilizer
-    have hos := MulAction.card_orbit_mul_card_stabilizer_eq_card_group
-      H (0 : ZMod p)
-    exact ⟨Nat.card (MulAction.stabilizer H (0 : ZMod p)), by rw [← hos, horbit]⟩
+    have e : ZMod p ≃ H ⧸ MulAction.stabilizer H (0 : ZMod p) :=
+      ((Equiv.Set.univ (ZMod p)).symm.trans (Equiv.setCongr huniv.symm)).trans
+        (MulAction.orbitEquivQuotientStabilizer H (0 : ZMod p))          -- ★
+    have hidx : (MulAction.stabilizer H (0 : ZMod p)).index = p := by
+      rw [Subgroup.index_eq_card, ← Nat.card_congr e, Nat.card_zmod]     -- ★
+    have hdvd := Subgroup.index_dvd_card
+      (H := MulAction.stabilizer H (0 : ZMod p))                         -- ★
+    rwa [hidx] at hdvd
   ----------------------------------------------------------------
   -- Step B:  Nat.card ↥P = p.
   ----------------------------------------------------------------
@@ -136,8 +139,6 @@ theorem sylow_p_is_pcycle
   have hcardP : Nat.card (P : Subgroup H) = p := by
     have hk1 : (Nat.card H).factorization p = 1 := le_antisymm hvpH hkpos
     rw [P.card_eq_multiplicity, hk1, pow_one]                            -- ★
-  have hcardP_ft : Fintype.card (P : Subgroup H) = p := by
-    rw [← Nat.card_eq_fintype_card]; exact hcardP
   ----------------------------------------------------------------
   -- Step C:  ↥P cyclic of prime order ⇒ generator a; σ := ι a is a p-cycle.
   ----------------------------------------------------------------
@@ -146,17 +147,18 @@ theorem sylow_p_is_pcycle
   haveI hcyc : IsCyclic (P : Subgroup H) := isCyclic_of_prime_card hcardP
   obtain ⟨a, ha⟩ := hcyc.exists_generator                                 -- ★ (∀ x, x ∈ zpowers a)
   have horda : orderOf a = p := by
-    rw [orderOf_eq_card_of_forall_mem_zpowers ha, hcardP_ft]              -- ?
+    rw [orderOf_eq_card_of_forall_mem_zpowers ha, hcardP]                 -- Nat.card form
   have hords : orderOf (ι a) = p := by
     rw [orderOf_injective ι hι_inj a, horda]                             -- ★
   have hcycσ : (ι a).IsCycle := by
     -- ★ `Equiv.Perm.isCycle_of_prime_order (h1 : (orderOf σ).Prime)`
     --   `(h2 : #σ.support < 2 * orderOf σ) : σ.IsCycle`  — TWO args, stated over `orderOf σ`.
-    have hprime : (orderOf (ι a)).Prime := hords ▸ hp
+    have hprime : (orderOf (ι a)).Prime := hords.symm ▸ hp
     have hsupp_lt : (ι a).support.card < 2 * orderOf (ι a) := by
       have hle : (ι a).support.card ≤ Fintype.card (ZMod p) :=
         Finset.card_le_univ _
       rw [ZMod.card] at hle
+      have hp1 : 0 < p := hp.pos
       rw [hords]; omega
     exact Equiv.Perm.isCycle_of_prime_order hprime hsupp_lt
   refine ⟨ι a, hcycσ, ?_, ?_, ?_⟩

--- a/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06-galois-direction/state.md
@@ -762,3 +762,36 @@ discharged.
 `docker-build.sh Proofs.Step3SylowPIsPCycleDraft` to verify the draft, then transcribe
 into `sylow_p_is_pcycle` (replace `sorry`, rename `_hPrim`→`hPrim`). Low-iteration
 expected: bearer surface de-risked, `|P|=p` core reuses Step 5's verified pattern.
+
+## Iteration 17 (researcher-4, 2026-06-17) — Step 3 orphan: 3 real build bugs fixed, build-verifying
+
+**Phase:** S17 ACT. **Backend:** Docker build-CAPABLE this session (rc=0; built
+KeithNumberOQ01 + repunit elsewhere). Aristotle still 404. Build pool SEVERELY
+contended (10 concurrent lean-build containers from other agents → each cache-get
+of 7727 oleans is IO-starved, ~20-40 min/build).
+
+Built `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3` (the up-to-date
+S18-strengthened orphan with the `σ ∈ H` conjunct, signature VERBATIM-identical to
+the registered `sylow_p_is_pcycle` stub). First build surfaced the `?`-flagged
+bearer bugs the author predicted; fixed THREE against the offline pin `2df2f0150c`:
+
+1. **Step C `hcardP_ft` (Fintype synth fail @139)**: `orderOf_eq_card_of_forall_mem_zpowers`
+   returns `Nat.card α` (Cyclic.lean:218), NOT `Fintype.card`. Deleted the
+   `Fintype.card (P:Subgroup H)=p` helper; `horda` now `rw [..., hcardP]` (Nat.card).
+2. **Step C `hprime` (type mismatch @155)**: `hords ▸ hp` rewrote the wrong way
+   (`Nat.Prime p` stayed `Nat.Prime p`, wanted `Nat.Prime (orderOf (ι a))`). Fixed to
+   `hords.symm ▸ hp`.
+3. **Step A `hpH` (Fintype synth fail on orbit/stabilizer)**:
+   `MulAction.card_orbit_mul_card_stabilizer_eq_card_group` needs Fintype instances
+   that don't synthesize for `↥H`. Replaced with the **Nat.card/index** route from the
+   older `step3-sylow-p-is-pcycle-draft.lean`: `orbitEquivQuotientStabilizer` +
+   `Subgroup.index_eq_card` (Index.lean:390) + `Subgroup.index_dvd_card` (Index.lean:398),
+   giving `p ∣ Nat.card H` with no Fintype. Also added `have hp1 : 0 < p := hp.pos`
+   to feed the `hsupp_lt` omega.
+
+**Next:** once the (slow, contended) build returns GREEN, register the orphan
+(`import Proofs.…Step3` in Proofs.lean) and discharge the registered
+`sylow_p_is_pcycle` `sorry` by one-line delegation
+`exact …Step3.sylow_p_is_pcycle H hPrim hSolv P` (rename the registered binders
+`_hPrim _hSolv`→`hPrim hSolv`). That drops the registered file's open sorries 9→8.
+Remaining: Step 1 `sylow_p_unique` (hardest), Step 4 `normalizer_iso_AGL1Z`, main thm.


### PR DESCRIPTION
## Summary

Incremental, de-risking progress on the **Galois direction** of the AGL(1,p) classification (abel-ruffini-galois-extensions-oq-06-galois-direction). The unregistered turnkey orphan `AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep3.lean` proves `sylow_p_is_pcycle` (Step 3 of the 5-step plan) with a signature **verbatim-identical** to the registered `sorry` stub.

A Docker build this session surfaced the exact `?`-flagged bearer bugs the orphan's author anticipated. **All three fixed**, each verified against the lake-pinned Mathlib (`2df2f0150c`):

| # | Error | Fix |
|---|-------|-----|
| 1 | `Fintype ↥↑P` synth fail (`hcardP_ft`) | `orderOf_eq_card_of_forall_mem_zpowers` returns **`Nat.card`** (Cyclic.lean:218), not `Fintype.card` → deleted the helper, `horda` uses `hcardP` |
| 2 | `hprime` type mismatch | `hords ▸ hp` rewrote the wrong way → **`hords.symm ▸ hp`** |
| 3 | `Fintype` synth fail on orbit/stabilizer (`hpH`) | replaced `card_orbit_mul_card_stabilizer_eq_card_group` with the **Nat.card/index** route (`orbitEquivQuotientStabilizer` + `Subgroup.index_eq_card` + `index_dvd_card`), Fintype-free; added `0<p` for the `hsupp_lt` omega |

## Build status — honest

**Build-pending.** Final green confirmation was blocked this session by the 40-min Docker timeout under ~10 concurrent build containers (`lake exe cache get` IO-starved). The file is **unregistered**, so it cannot affect the registered/CI build. Each fix targets a specific reported error and is source-verified, but the file is **not** yet machine-checked end-to-end — I deliberately did **not** touch the registered flagship.

## Next (build-capable session)

Confirm the orphan builds green → register it (`import Proofs.…Step3` in `Proofs.lean`) → discharge the registered `sylow_p_is_pcycle` `sorry` by one-line delegation `exact …Step3.sylow_p_is_pcycle H hPrim hSolv P` (rename binders `_hPrim _hSolv`→`hPrim hSolv`). That drops the registered file's open sorries **9 → 8**. Remaining deep steps: Step 1 `sylow_p_unique` (hardest), Step 4 `normalizer_iso_AGL1Z`, main theorem. Plan recorded in `state.md` S17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)