### PR TITLE
Enrich Miquel's Pivot Theorem (OQ-01): full-file section coverage

### DIFF
--- a/src/data/proofs/miquel-pivot-theorem-oq-01/meta.json
+++ b/src/data/proofs/miquel-pivot-theorem-oq-01/meta.json
@@ -58,36 +58,44 @@
   },
   "sections": [
     {
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 43,
+      "description": "Imports Mathlib and lays out the full proof in prose: the cross-ratio criterion for concyclicity, the sharp conditional form of the pivot theorem (M on two circles ⟹ M on the third), and the M-free product identity that is the algebraic heart of the argument. States the result is axiom-free and sorry-free.",
+      "summary": "Imports and Module Docstring",
+      "id": "imports-and-module-docstring"
+    },
+    {
       "title": "Realness Predicate and Closure",
       "startLine": 44,
-      "endLine": 57,
-      "description": "Define IsReal z := ∃ r : ℝ, z = r and prove it is closed under multiplication and division — the only structural facts the proof needs.",
+      "endLine": 56,
+      "description": "Open the namespace and define IsReal z := ∃ r : ℝ, z = r, then prove it is closed under multiplication (IsReal.mul) and division (IsReal.div) — the only structural facts the proof needs.",
       "summary": "Realness Predicate and Closure",
       "id": "realness-predicate-and-closure"
     },
     {
       "title": "Cross-Ratio, Concyclicity, Collinearity",
-      "startLine": 58,
-      "endLine": 64,
-      "description": "The cross-ratio (a,b;c,d) = (a-c)(b-d)/((a-d)(b-c)); four points are concyclic-or-collinear iff it is real, three points collinear iff (a-c)/(b-c) is real.",
+      "startLine": 57,
+      "endLine": 65,
+      "description": "The cross-ratio (a,b;c,d) = (a-c)(b-d)/((a-d)(b-c)); four points are concyclic-or-collinear (Concyclic) iff it is real, three points collinear (Collinear) iff (a-c)/(b-c) is real.",
       "summary": "Cross-Ratio, Concyclicity, Collinearity",
       "id": "cross-ratio-concyclicity-collinearity"
     },
     {
-      "title": "The Pivot-Cancellation Identity",
-      "startLine": 85,
+      "title": "Statement and the Pivot-Cancellation Identity",
+      "startLine": 66,
       "endLine": 90,
-      "description": "The algebraic heart: the product of the three Miquel cross-ratios is independent of M and factors as a product of the three side-collinearity ratios. Proved by field_simp after clearing denominators.",
-      "summary": "The Pivot-Cancellation Identity",
-      "id": "the-pivot-cancellation-identity"
+      "description": "States miquel_pivot in sharp conditional form (M on circles (AYZ) and (BZX), with X, Y, Z on the side lines, ⟹ M on (CXY)), records the eight nonzero-difference facts needed to clear denominators, and proves the key identity: the product of the three Miquel cross-ratios is independent of M and factors as a product of the three side-collinearity ratios (field_simp).",
+      "summary": "Statement and the Pivot-Cancellation Identity",
+      "id": "statement-and-pivot-cancellation-identity"
     },
     {
-      "title": "Miquel's Pivot Theorem",
+      "title": "Conclusion: M Lies on the Third Circle",
       "startLine": 91,
-      "endLine": 113,
-      "description": "Given M on circles (AYZ) and (BZX), and X, Y, Z on the side lines, the product of cross-ratios is real (from collinearity), the first two factors are real and nonzero, so the third — M on (CXY) — is real as a quotient of reals.",
-      "summary": "Miquel's Pivot Theorem",
-      "id": "miquels-pivot-theorem"
+      "endLine": 114,
+      "description": "The first two cross-ratios are nonzero and (from M on the first two circles) real, while collinearity makes the right-hand product real; so the third cross-ratio equals the real product divided by the real product of the first two — a quotient of reals, hence M lies on circle (CXY).",
+      "summary": "Conclusion: M Lies on the Third Circle",
+      "id": "conclusion-m-lies-on-the-third-circle"
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass for `miquel-pivot-theorem-oq-01` (live quality 98 → 100).

## Gap addressed
The `sections` array had 4 entries covering only lines 44–113, leaving the **header (1–43)** — imports and the full proof-idea docstring — and the **theorem statement (66–84)** unsectioned. The cross-ratio/cancellation split was also non-contiguous (a 65–84 gap).

## Change
Restructured into **5 contiguous sections covering the whole file (1–114)**:
1. Imports and Module Docstring (1–43) — *new*
2. Realness Predicate and Closure (44–56)
3. Cross-Ratio, Concyclicity, Collinearity (57–65)
4. Statement and the Pivot-Cancellation Identity (66–90)
5. Conclusion: M Lies on the Third Circle (91–114)

This lifts the `sections` scorer component from 8 → 10 (5 × 2, capped at 10), bringing quality to 100.

Meta-only change — no claims, counts, badges, or Lean source touched. JSON validated; live quality recomputed = 100.