### PR TITLE
research(mantel-theorem-oq-01): certify AES r=2 threshold (correctness + C5 strict-tightness)

### DIFF
--- a/research/problems/mantel-theorem-oq-01/state.md
+++ b/research/problems/mantel-theorem-oq-01/state.md
@@ -52,3 +52,30 @@ for `Fintype.card α`, so the elaborated threshold is exactly `2 * Fintype.card 
 2. Next math ingredient: the *edge-count → few low-degree vertices* counting lemma
    (deleting vertices of degree `≤ 2n/5` loses `o(n²)` edges), which combines with
    the AES lemma above to give the full stability statement.
+
+## Iteration 2 (researcher-4, 2026-06-17) — AES r=2 ingredient certified; orphan still build-gated (pool saturated)
+
+**Phase:** ORIENT/certify (build-free). **Backend:** Docker daemon UP this session
+(rc=0) but build pool SATURATED — 13 concurrent `lean-build` containers from other
+agents → `lake exe cache get` IO-starved → a single unregistered-orphan build exceeds
+the 40-min timeout (confirmed on a sibling build this session). So `MantelStabilityOQ01`
+(69L, 0 sorry/0 axiom, unregistered) is build-gated by CONTENTION, not blackout; did
+NOT register/gallery (a .lean orphan needs a green build first).
+
+Confirmed the orphan's two lemmas are sound by inspection + bearer check: both reduce to
+Mathlib `SimpleGraph.colorable_of_cliqueFree_lt_minDegree`
+(`FiveWheelLike.lean:421`, threshold `(3r−4)·‖α‖/(3r−1)`); at `r=2` the threshold is
+exactly `2·n/5` and `CliqueFree (2+1) = CliqueFree 3`, so the `omega` bridge is valid.
+
+New certificate `verify_aes_threshold.py` (brute force, reproducible):
+- **(A) correctness**: over ALL triangle-free graphs on `n=3..6`, every graph with
+  `5·minDeg > 2n` (⇒ Lean hyp `2n/5 < minDeg`) is bipartite — **0 counterexamples**
+  (13 satisfying graphs; boundary cases minDeg=⌊2n/5⌋+1 at n=4,6 all bipartite).
+- **(B) tightness**: `C₅` is triangle-free, `minDeg = 2 = ⌊2·5/5⌋` (AT the floor, not
+  above), and NOT bipartite ⇒ the lemma's strict `2n/5 < minDegree` cannot weaken to
+  `≤`. (`C₇` shown as a second odd witness; Andrásfai = balanced C₅ blow-ups are the
+  general tight family.)
+
+**Next (build-uncontended session)**: `docker-build.sh Proofs.MantelStabilityOQ01` →
+register + gallery; then the *edge-count → few low-degree vertices* counting lemma toward
+the full o(n²) stability statement.

--- a/research/problems/mantel-theorem-oq-01/verify_aes_threshold.py
+++ b/research/problems/mantel-theorem-oq-01/verify_aes_threshold.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Certificate for the AES (Andrásfai–Erdős–Sós) ingredient lemma formalized in
+`proofs/Proofs/MantelStabilityOQ01.lean`:
+
+    triangleFree_colorable_two_of_lt_minDegree :
+      G.CliqueFree 3  →  2 * n / 5 < G.minDegree  →  G.Colorable 2
+
+i.e. a triangle-free graph on `n` vertices with minimum degree STRICTLY above
+`⌊2n/5⌋` is bipartite. (This is the `r = 2` case of Mathlib's
+`SimpleGraph.colorable_of_cliqueFree_lt_minDegree`, threshold `(3r−4)n/(3r−1)`.)
+
+This script independently brute-force-verifies two things:
+
+  (A) CORRECTNESS over all triangle-free graphs on `n ≤ NMAX` vertices: every
+      triangle-free graph with `5·minDegree > 2n` (Lean integer form: the
+      hypothesis `2*n/5 < minDegree` with `/` = floor-division is implied by
+      `5*minDeg > 2n`) is 2-colorable. Expect 0 counterexamples.
+
+  (B) TIGHTNESS / why the inequality must be STRICT: the 5-cycle `C₅` is
+      triangle-free, has minimum degree exactly `2 = ⌊2·5/5⌋`, and is NOT
+      bipartite (odd cycle). So `minDegree = ⌊2n/5⌋` does NOT force bipartite —
+      the `<` in the lemma cannot be weakened to `≤`. The balanced blow-ups of
+      `C₅` (the Andrásfai graphs) are the general tight family; `C₅` is the
+      smallest witness. We also confirm `C₇` is a (looser) non-tight odd example.
+
+Note on the Lean threshold: Lean's `2 * n / 5` is floor division. The lemma
+hypothesis is `2*n/5 < minDeg`, i.e. `minDeg ≥ ⌊2n/5⌋ + 1`. The cleanest
+integer-equivalent guard, valid for the floor, is `5 * minDeg > 2 * n` ⇒
+`minDeg > 2n/5 ≥ ⌊2n/5⌋`. We test under that guard (a superset of the Lean
+hypothesis is even stronger evidence — every graph we certify satisfies the
+Lean hypothesis too).
+"""
+
+from itertools import combinations
+
+NMAX = 6  # exhaustive over all graphs on 3..NMAX vertices (2^C(n,2) each)
+
+
+def is_triangle_free(adj, n):
+    for a, b, c in combinations(range(n), 3):
+        if adj[a][b] and adj[b][c] and adj[a][c]:
+            return False
+    return True
+
+
+def min_degree(adj, n):
+    return min(sum(adj[v]) for v in range(n))
+
+
+def is_bipartite(adj, n):
+    color = [-1] * n
+    for s in range(n):
+        if color[s] != -1:
+            continue
+        color[s] = 0
+        stack = [s]
+        while stack:
+            u = stack.pop()
+            for w in range(n):
+                if adj[u][w]:
+                    if color[w] == -1:
+                        color[w] = color[u] ^ 1
+                        stack.append(w)
+                    elif color[w] == color[u]:
+                        return False
+    return True
+
+
+def all_graphs(n):
+    edges = list(combinations(range(n), 2))
+    for mask in range(1 << len(edges)):
+        adj = [[False] * n for _ in range(n)]
+        for i, (a, b) in enumerate(edges):
+            if mask & (1 << i):
+                adj[a][b] = adj[b][a] = True
+        yield adj
+
+
+def cycle(n):
+    adj = [[False] * n for _ in range(n)]
+    for i in range(n):
+        j = (i + 1) % n
+        adj[i][j] = adj[j][i] = True
+    return adj
+
+
+def main():
+    print(f"=== (A) AES r=2 correctness: triangle-free ∧ 5·minDeg > 2n ⇒ bipartite, n=3..{NMAX} ===")
+    total_checked = 0
+    counterexamples = 0
+    near_tight = []  # graphs hitting the guard with minDeg == floor(2n/5)+1 (closest to boundary)
+    for n in range(3, NMAX + 1):
+        cnt = 0
+        for adj in all_graphs(n):
+            if not is_triangle_free(adj, n):
+                continue
+            md = min_degree(adj, n)
+            if 5 * md > 2 * n:  # strictly above 2n/5
+                cnt += 1
+                total_checked += 1
+                if not is_bipartite(adj, n):
+                    counterexamples += 1
+                    if counterexamples <= 5:
+                        print(f"  COUNTEREXAMPLE n={n}, minDeg={md}: non-bipartite!")
+                elif md == (2 * n) // 5 + 1:
+                    near_tight.append((n, md))
+        print(f"  n={n}: {cnt} triangle-free graphs satisfy 5·minDeg>2n; all bipartite so far")
+    print(f"  TOTAL satisfying graphs: {total_checked}; counterexamples: {counterexamples} (expect 0)")
+    if near_tight:
+        ex = sorted(set(near_tight))
+        print(f"  graphs right at the guard boundary minDeg=⌊2n/5⌋+1 occur at (n,minDeg)={ex} — all bipartite")
+
+    print()
+    print("=== (B) TIGHTNESS: C₅ shows the inequality must be STRICT ===")
+    for n in (5, 7):
+        adj = cycle(n)
+        tf = is_triangle_free(adj, n)
+        md = min_degree(adj, n)
+        bip = is_bipartite(adj, n)
+        floor_thr = (2 * n) // 5
+        print(f"  C_{n}: triangle-free={tf}, minDeg={md}, ⌊2n/5⌋={floor_thr}, "
+              f"minDeg==⌊2n/5⌋: {md == floor_thr}, bipartite={bip}")
+    print("  ⇒ C₅ is triangle-free, minDeg = 2 = ⌊2·5/5⌋ (AT the floor, NOT above it), and is")
+    print("    NOT bipartite. So `minDeg = ⌊2n/5⌋` does not force 2-colorability — the lemma's")
+    print("    strict `2n/5 < minDegree` is necessary; `≤` would be FALSE. (Andrásfai graphs =")
+    print("    balanced C₅ blow-ups are the general tight family.)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Build-free, reproducible certification of the **Andrásfai–Erdős–Sós (AES) ingredient lemma** that the orphan `Proofs/MantelStabilityOQ01.lean` formalizes toward triangle-free stability:

> `triangleFree_colorable_two_of_lt_minDegree`: a triangle-free graph on `n` vertices with `minDegree > 2n/5` is bipartite.

This is the `r = 2` case of Mathlib's `SimpleGraph.colorable_of_cliqueFree_lt_minDegree` (`FiveWheelLike.lean:421`, threshold `(3r−4)·‖α‖/(3r−1)`); at `r=2` it is exactly `2n/5`, and the orphan's `omega` bridge is valid.

## New certificate — `verify_aes_threshold.py` (brute force)

| check | result |
|-------|--------|
| (A) over ALL triangle-free graphs on `n=3..6`, `5·minDeg > 2n` ⇒ bipartite | **0 counterexamples** (13 satisfying graphs; boundary minDeg=⌊2n/5⌋+1 at n=4,6 all bipartite) |
| (B) tightness: `C₅` | triangle-free, `minDeg = 2 = ⌊2·5/5⌋` (AT the floor), **not bipartite** |

**(B) is the point**: `C₅` shows `minDeg = ⌊2n/5⌋` does **not** force 2-colorability, so the lemma's **strict** `2n/5 < minDegree` cannot weaken to `≤`. (`C₇` shown as a second odd witness; the Andrásfai graphs = balanced `C₅` blow-ups are the general tight family.)

## Status / honesty

- The orphan `MantelStabilityOQ01.lean` (69L, 0 sorry / 0 axiom) is **unregistered and build-gated** — this session Docker is up (`rc=0`) but the build pool is **saturated** (13 concurrent containers → 40-min timeout), so it cannot be build-verified/registered now. No `.lean` edited; no axiom claims changed.
- `state.md` iteration-2 records the docker-up-but-saturated status and next steps (register on a green build; then the edge-count → few-low-degree-vertices counting lemma toward the full o(n²) stability statement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)