### PR TITLE
Enrich Descartes Circle Theorem (OQ-01): full-file section coverage

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01/meta.json
@@ -56,8 +56,17 @@
   },
   "sections": [
     {
+      "title": "Imports, Docstring, and Namespace",
+      "startLine": 1,
+      "endLine": 27,
+      "description": "Imports Mathlib and states the Descartes Circle Theorem in prose: for four mutually tangent circles with signed curvatures, (k₁+k₂+k₃+k₄)² = 2(k₁²+k₂²+k₃²+k₄²). Explains the Soddy-circle solutions, scopes the file to the curvature-arithmetic core (not the planar tangency geometry), and distinguishes it from Mathlib's unrelated Descartes' Rule of Signs.",
+      "summary": "Imports and module docstring",
+      "id": "imports-docstring-and-namespace",
+      "mathContext": "Signed curvature $k = \\pm 1/r$; the relation $(k_1+k_2+k_3+k_4)^2 = 2(k_1^2+k_2^2+k_3^2+k_4^2)$ is equivalent to the Soddy pair $k_4 = (k_1+k_2+k_3) \\pm 2\\sqrt{k_1k_2+k_2k_3+k_3k_1}$."
+    },
+    {
       "title": "The Descartes Relation",
-      "startLine": 29,
+      "startLine": 28,
       "endLine": 34,
       "description": "Definition of descartesRel: (k₁+k₂+k₃+k₄)² = 2(k₁²+k₂²+k₃²+k₄²) for four signed curvatures.",
       "summary": "descartesRel definition",


### PR DESCRIPTION
Enrichment pass for `descartes-circle-theorem-oq-01` (live quality 98 → 100).

## Gap addressed
The `sections` array had 4 entries covering only lines 29–103, leaving the **header (1–28)** — imports and the module docstring — unsectioned.

## Change
Added an **Imports, Docstring, and Namespace** section (1–27) and extended the Descartes-relation section to start at line 28 (its docstring). The five sections now cover the whole file contiguously, lifting the `sections` scorer component 8 → 10.

Meta-only change — no claims, counts, badges, or Lean source touched. JSON validated.