### PR TITLE
audit(ballot-problem-oq-03-oq-02): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -706,9 +706,9 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:27:03Z",
+      "lastAudited": "2026-06-18T05:35:38Z",
       "result": "clean"
     },
     "basel-problem": {


### PR DESCRIPTION
## Gallery Integrity Audit — ballot-problem-oq-03-oq-02

Re-audit (queue drained; oldest-lastAudited re-serve, skipping the 9 entries with open auditor PRs).

**Entry:** General r×r Lindström-Gessel-Viennot Determinant — `verified` / `mathlib`.

### Verdict: CLEAN (no overclaiming)

| Check | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| axioms | 0 | `grep ^axiom` = 0 | ✓ |
| sorries | 0 | comment-aware scan = 0 | ✓ |
| native_decide | — | none (only `by decide` on small `List.countP` goals → kernel, no `ofReduceBool`) | ✓ |
| status/badge | verified / mathlib | core relies on Mathlib `Finset.sum_involution`, determinant machinery → `mathlib` conservatively correct | ✓ |
| definitions | 46 | 46 (comment-aware) | ✓ |
| lineCount | 2589 | `wc -l` = 2589 | ✓ |
| theorems | 94 | 95 (comment-aware) | ⚠ 1-off **undercount** (conservative) |

- **Main theorem** `lgv_lemma_rxr` (`niTupleCount cfg = (pathMatrix cfg).det`) is genuinely closed: `rw [det_pathMatrix_eq_signed_sum]; exact (gv_involution_cancellation cfg hwf).symm` — both supporting lemmas proved in-file.
- **Title correctly scoped** to the LGV determinant lemma — does not claim the ballot problem itself is solved. No inequality≠theorem or pipeline inflation.
- Minor stale descriptors are all in the **conservative** direction (meta.theoremCount 94 < actual 95; conclusion prose "2511 lines" < actual 2589) — they understate, never overclaim, so no fix needed to protect credibility.

Tracker updated (auditCount 4→5, result `clean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)