### PR TITLE
Fix: disclose Lean.ofReduceBool for two √-sum irrationality entries (#25409)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3Irrational.lean",
     "tags": [
       "irrationality",
@@ -14,11 +14,11 @@
       "square-roots",
       "number-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff and native_decide for ¬IsSquare 6.",
+    "axiomCount": 1,
+    "assumptions": "Depends on Lean.ofReduceBool: the main theorem irrational_sqrt2_plus_sqrt3 derives the irrationality of √6 via irrational_sqrt_six, which discharges ¬IsSquare 6 with native_decide (kernel compiler reduction). Also uses Mathlib's irrational_sqrt_natCast_iff. No literal axiom declarations (leanFile.axiomCount = 0).",
     "lineCount": 54,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-12",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean",
     "tags": [
       "irrationality",
@@ -16,11 +16,11 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-12",
-    "axiomCount": 0,
-    "assumptions": "None. Uses Mathlib's irrational_sqrt_natCast_iff with native_decide on ¬IsSquare 30, Real.sq_sqrt, Real.sqrt_mul, sqrt_pos, sqrt_nonneg, plus the parent gallery proof's exported identity sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6.",
+    "axiomCount": 1,
+    "assumptions": "Depends on Lean.ofReduceBool: the main theorem irrational_sqrt2_plus_sqrt3_plus_sqrt5 applies irrational_sqrt_thirty, which discharges ¬IsSquare 30 with native_decide (kernel compiler reduction). Also uses Mathlib's irrational_sqrt_natCast_iff, Real.sq_sqrt, Real.sqrt_mul, sqrt_pos, sqrt_nonneg, plus the parent gallery proof's exported identity sqrt2_plus_sqrt3_sq : (√2 + √3)² = 5 + 2√6. No literal axiom declarations (leanFile.axiomCount = 0).",
     "lineCount": 144,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Two gallery entries proved their headline irrationality theorem through a helper lemma whose only nontrivial step is `native_decide`, so they depend on `Lean.ofReduceBool` but were marked `verified` / `axiomCount: 0`. Reclassified to `axiomatized` / `badge: axiom` / `axiomCount: 1` per the Axiom Integrity Policy, and disclosed the dependency in `assumptions`.

## Evidence (source-dispositive)

**`sqrt2-plus-sqrt3-irrational`** — `irrational_sqrt2_plus_sqrt3` applies `irrational_sqrt_six`, whose proof is `native_decide` on `¬ IsSquare (6 : ℕ)` (Sqrt2PlusSqrt3Irrational.lean:21). The native_decide is directly in the headline's dependency chain.

**`sqrt2-plus-sqrt3-plus-sqrt5-irrational`** — `irrational_sqrt2_plus_sqrt3_plus_sqrt5` applies `irrational_sqrt_thirty`, whose proof is `native_decide` on `¬ IsSquare (30 : ℕ)` (Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01.lean:55).

In both, `#print axioms <headline>` lists `Lean.ofReduceBool`.

**Before**: `status: verified`, `badge: mathlib`/`original`, `axiomCount: 0`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `Lean.ofReduceBool` disclosed in `assumptions`

`leanFile.axiomCount` stays `0` (no literal `axiom` declarations) per convention.

## Out of scope (intentionally not flipped)

- `sqrt2-plus-sqrt3-irrational-oq-03` — headline is the minimal polynomial `minpoly_sqrt2_plus_sqrt3` (pure polynomial algebra, axiom-free); native_decide appears only in a secondary irrationality corollary, and the entry is already `status: formalized`. Stirling-style: left as-is.
- `sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-01` — uses the integral-closure API, no `native_decide`. Correctly `verified`.

Part of #25409 (batch 3).

---
Automated fix by lean-mechanic agent.