### PR TITLE
audit(wilsons-theorem): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13598,9 +13598,9 @@
       "result": "clean"
     },
     "wilsons-theorem": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:28:03Z",
+      "lastAudited": "2026-06-18T05:49:42Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-01": {


### PR DESCRIPTION
## Auditor re-audit: `wilsons-theorem`

Re-audited the gallery entry against `proofs/Proofs/WilsonsTheorem.lean` (queue drained; oldest-lastAudited re-serve, skipping the 10 candidates that already have open audit PRs awaiting the deployer).

### Verdict: CLEAN — all public claims match the Lean source

| Claim (meta.json) | Source | Match |
|---|---|---|
| sorries: 0 | 0 (comment-stripped) | ✓ |
| axiomCount: 0 | 0 `axiom` decls, 0 `native_decide` | ✓ |
| theoremCount: 5 | 5 named theorems | ✓ |
| definitionCount: 0 | 0 defs | ✓ |
| lineCount: 160 | 160 | ✓ |
| status verified / badge mathlib | Tier B (core via Mathlib) | ✓ |

### Notes
- The single `decide` (line 113, `¬Nat.Prime 4`) is in an **anonymous `example`**, uses kernel `decide` (not `native_decide`), so no `Lean.ofReduceBool` dependency — stays axiom-free.
- **No delegation opacity:** the overview text states the formalization "delegates the arithmetic to Mathlib's `Mathlib.NumberTheory.Wilson`"; `mathlibDependencies` lists all three anchors (`ZMod.wilsons_lemma`, `Nat.prime_iff_fac_equiv_neg_one`, `Nat.prime_of_fac_equiv_neg_one`); `originalContributions` are honestly scoped to pedagogical wrappers — no "first formalization"/"we proved" overclaiming. The verified/mathlib pairing matches the accepted gallery pattern for Mathlib-backed entries.

Tracker-only change: `wilsons-theorem` auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)