### PR TITLE
Fix: re-class 7 presented-native_decide entries verified→axiomatized (#25409)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Lagrange, Galois)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group#Solvable_and_perfect_groups",
     "date": "1832",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02.lean",
     "tags": [
       "algebra",
@@ -19,7 +19,7 @@
       "extension",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,9 +40,9 @@
       "solvable_iff_le_four: Complete bidirectional classification Sₙ solvable ↔ n ≤ 4"
     ],
     "dateAdded": "2026-03-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 154,
-    "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. S₂/S₃ are discharged by `decide`, but the presented theorem `s4_solvable` (derivedSeries 3 = ⊥ over the 24-element group, consumed by the headline `solvable_iff_le_four`) is proved by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ01.lean",
     "tags": [
       "galois-theory",
@@ -16,11 +16,11 @@
       "fermat-primes",
       "regular-polygons"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented Fermat-primality facts (`prime_257`, `prime_65537`) and the regular-n-gon constructibility theorems (`triangle_constructible`, `pentagon_constructible`, `heptadecagon_constructible`, and the non-constructibility witnesses) discharge their decidable cores by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 366,
     "theoremCount": 44,
     "definitionCount": 3,

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -27,7 +27,7 @@
     "author": "Formalized in Lean 4 (researcher-4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ03OQ01.lean",
     "tags": [
       "geometry",
@@ -40,12 +40,12 @@
       "enumeration",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 12,
     "lineCount": 150,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The import chain includes AngleTrisection.lean (1 axiom for π transcendence, used only for the circle-squaring result) but none of the theorems in this file depend on that axiom.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The headline `constructible_upto_100` (the formally verified complete list of 24 constructible n-gons with 3 ≤ n ≤ 100), plus `fermat257_constructible`/`fermat65537_constructible`, are proved by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "researcher-3",
     "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem#Generalizations",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,10 +20,10 @@
       "open-question",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Birthday threshold computed via native_decide.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented thresholds `birthday_threshold_lower` and `birthday_threshold_upper` (n=88 for d=365, via the slot recurrence) are proved by `native_decide`. (The two prior axioms were eliminated by replacing them with `native_decide`.) Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "originalContributions": [
       "R (slot-based recurrence): computable definition R n e s tracking slot state (e empty, s single)",
       "birthdayCount3: total valid count as R n d 0, terminating in O(n²) recursion",

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -7,7 +7,7 @@
     "author": "von Mises (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem",
     "date": "1939",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "probability",
       "combinatorics",
@@ -20,7 +20,7 @@
     "additionalFiles": [
       "Proofs/BirthdayProblemAsymptotics.lean"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "prerequisites": [
       "Probability theory and finite sample spaces",
@@ -55,8 +55,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 93,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and no structure-encoded assumptions. All 27 theorems are proved using Mathlib (Fintype.card_embedding_eq, Nat.descFactorial, Fintype.card_fun) and native_decide for large integer comparisons (up to 146-digit numbers). No custom axioms or definition sorries.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The headline 23-person threshold theorems `birthday_23_exceeds_half` and `birthday_22_below_half` (together with the 99% variants) discharge their large-integer inequalities by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "relatedProblems": [
       {
         "id": "ballot-problem",

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-05",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ02.lean",
     "tags": [
       "group-theory",
@@ -16,11 +16,11 @@
       "finite-groups",
       "subgroup-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-05",
-    "axiomCount": 0,
-    "assumptions": "None — fully verified by finite enumeration via native_decide.",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The headline `A4_no_subgroup_order6_finset` (a finite enumeration over all 2¹² subsets of A₄), together with `A4_card`, `A4_no_element_order6`, and the order-count theorems, are proved by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 121,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-05",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02.lean",
     "tags": [
       "group-theory",
@@ -17,9 +17,9 @@
       "orbit-stabilizer",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 262,
     "theoremCount": 13,
     "definitionCount": 1,
@@ -72,7 +72,7 @@
       "card_conjClass_eq_one_iff_mem_center: |[x]| = 1 ↔ x ∈ Z(G) proved from orbit uniqueness and commutativity",
       "A₄ class equation verification: 4 conjugacy classes of sizes 1+3+4+4=12 via native_decide"
     ],
-    "assumptions": "0 sorries. 0 axiom declarations. All theorems fully machine-checked. card_conjClass_eq_centralizer_index proved via Subgroup.index_comap_of_surjective applied to the ConjAct.toConjAct isomorphism.",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented A₄ class-equation facts `card_A4`, `card_conjClasses_A4`, and `card_center_A4` (sizes 1+3+4+4=12) are proved by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "additionalFiles": []
   },
   "overview": {


### PR DESCRIPTION
## Fix

Batch 3 of #25409. Seven gallery entries claim `status: verified`, `axiomCount: 0` while discharging a **substantive, presented** result via `native_decide`. Per CLAUDE.md, `native_decide` is accepted by the kernel through `Lean.ofReduceBool`, so these must be `axiomatized` / `badge: axiom` / `axiomCount: 1` (with `Lean.ofReduceBool` disclosed in `assumptions`). `leanFile.axiomCount` stays 0 — no literal `axiom` declarations.

Same field pattern as the merged #25416 / #25408 / #25390.

## Entries (nd is load-bearing on the headline, verified by reading each `.lean`)

| Slug | Presented native_decide result |
|------|-------------------------------|
| abel-ruffini-oq-04-oq-02 | `s4_solvable` (derivedSeries 3 = ⊥), consumed by headline `solvable_iff_le_four` |
| birthday-problem | `birthday_23_exceeds_half` / `birthday_22_below_half` (the 23-person threshold) |
| birthday-problem-oq-03-oq-01-oq-01 | `birthday_threshold_lower/upper` (n=88, d=365) — former 2 axioms replaced by nd |
| lagrange-theorem-oq-01-oq-02 | `A4_no_subgroup_order6_finset` (enumeration over all 2¹² subsets) |
| lagrange-theorem-oq-02-oq-02 | `card_A4` / `card_conjClasses_A4` / `card_center_A4` (A₄ class equation) |
| angle-trisection-oq-01 | `prime_257`/`prime_65537` + regular-n-gon constructibility theorems |
| angle-trisection-oq-03-oq-01 | `constructible_upto_100` (complete list of 24 constructible n-gons ≤ 100) |

## Scope discipline

Only entries where `native_decide` is on the **substantive headline** are flipped. Candidates where nd appears only in `example` sanity-checks (e.g. binomial-theorem) or in incidental "numerical verification" lemmas (basel-problem-oq-04-oq-03, ballot-problem-oq-03-oq-01-oq-04, arithmetic-series-oq-02-oq-02-oq-01, divisibility-by-3-oq-04) are **left verified** and excluded here — they require the headline's own axiom set to be clean (the stirling-formula trap).

## Evidence

**Before**: `verified` / `axiomCount: 0` while the presented result is proved by `native_decide`.
**After**: `axiomatized` / `badge: axiom` / `axiomCount: 1`, `Lean.ofReduceBool` disclosed in `assumptions`.

Relates to #25409.

---
Automated fix by lean-mechanic agent.