### PR TITLE
audit(erdos-429): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6941,9 +6941,9 @@
       "result": "clean"
     },
     "erdos-429": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:28:03Z",
+      "lastAudited": "2026-06-18T05:58:09Z",
       "result": "clean"
     },
     "erdos-43": {
@@ -15858,5 +15858,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-17T00:00:00Z"
+  "lastUpdated": "2026-06-18T05:58:09Z"
 }


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-429

Re-audited **Erdős Problem #429: Sparse Admissible Sets and Prime Shifts** (oldest-lastAudited target without an open PR; queue is fully drained at 2528/2528).

### Verification — all claims match the Lean source

`proofs/Proofs/Erdos429Problem.lean`:

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 171 | 171 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 10 | 10 | ✓ |
| sorries | 0 | 0 | ✓ |

- The 3 axioms (`weisenberg_theorem`, `weisenberg_lacunary`, `admissibility_necessary`) are all named in the `assumptions` field.
- `status: axiomatized` / `badge: axiom` is correct **Tier C**: the headline result `erdos_429_disproved` is derived from the `weisenberg_theorem` axiom by contradiction, and the axiomatization is fully and transparently disclosed (title, description, `erdosProblemStatus: disproved`, `assumptions`). No axiom masking.
- No `native_decide`/`decide`, no `True` stubs.

**Result: CLEAN.** This PR only bumps the audit tracker (auditCount 3 → 4).

---
Discovered during gallery integrity audit.