### PR TITLE
Fix: disclose Lean.ofReduceBool for erdos-1099 & erdos-926 (#25409 batch 4)

### DIFF
--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1981 problem), Vose (1984 solution)",
     "sourceUrl": "https://erdosproblems.com/1099",
     "date": "1984",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1099Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "liminf",
       "solved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
@@ -63,9 +63,9 @@
       "power_of_two_h_alpha theorem: h_α(2^k) = k",
       "prime_h_alpha_unbounded theorem: h_α(p) → ∞ over primes"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 723,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries. vose_bounded_sequence proved via trivial witness (constant sequence n_k = 2, h_α(2) = 1). All 34 theorems machine-checked.",
+    "assumptions": "Depends on Lean.ofReduceBool: the resolution theorem erdos_1099 reduces (via vose_liminf_bounded → vose_bounded_sequence → h_alpha_two) to divisorRatios_two, which is proved by native_decide. native_decide trusts the compiler's kernel reduction, so #print axioms erdos_1099 lists Lean.ofReduceBool (the proof is not axiom-free). vose_bounded_sequence uses the trivial witness (constant sequence n_k = 2, h_α(2) = 1). 0 sorries.",
     "theoremCount": 36,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -7,7 +7,7 @@
     "author": "Füredi (1991), Alon-Krivelevich-Sudakov (2003)",
     "sourceUrl": "https://erdosproblems.com/926",
     "date": "1991",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos926Problem.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "turan-number",
       "probabilistic-method"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 926,
     "erdosUrl": "https://erdosproblems.com/926",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 235,
-    "assumptions": "None. 3 theorems fully verified with 0 axioms and 0 sorries (numerical examples via native_decide). Main result (ex(n; H_k) ≪ n^(3/2)) documented as a comment; full formalization requires probabilistic method not in Mathlib.",
+    "assumptions": "Depends on Lean.ofReduceBool: all 3 verified theorems (h4_vertex_count, h5_vertex_count, h4_edge_count) are proved by native_decide, which trusts the compiler's kernel reduction, so #print axioms lists Lean.ofReduceBool (the proofs are not axiom-free). 0 sorries. Main result (ex(n; H_k) ≪ n^(3/2)) documented as a comment; full formalization requires probabilistic method not in Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
     "definitionCount": 3


### PR DESCRIPTION
## Fix

Batch 4 of #25409. Re-class two gallery entries from `verified`/`axiomCount: 0` to `axiomatized`/`badge: axiom`/`axiomCount: 1`, disclosing `Lean.ofReduceBool` in `assumptions`. Each entry's presented result is discharged by `native_decide` (directly or transitively), so `#print axioms <headline>` lists `Lean.ofReduceBool` — the proof is *not* axiom-free (CLAUDE.md:140 convention).

`leanFile.axiomCount` stays `0` (literal `axiom` declarations only).

## Entries and dependency chains (verified by reading source)

| Entry | Presented result → native_decide chain |
|-------|----------------------------------------|
| `erdos-1099` | `erdos_1099` ← `vose_liminf_bounded` ← `vose_bounded_sequence` ← `h_alpha_two` ← `divisorRatios_two` (`native_decide`) |
| `erdos-926` | All 3 verified theorems (`h4_vertex_count`, `h5_vertex_count`, `h4_edge_count`) `native_decide`; main result is documented as a comment |

## Scope discipline

The full candidate scan finds ~160 `verified` + `native_decide` entries. This batch includes **only** entries where the singular substantive presented result provably depends on `native_decide`, with the chain confirmed in the Lean source. Entries whose headline is an axiom-free structural/Mathlib theorem with `native_decide` confined to incidental checks are excluded (the stirling-formula trap that closed #25420). No Docker `#print axioms` was needed because `native_decide` in a proof body guarantees `Lean.ofReduceBool` in that theorem's (and its dependents') axiom set.

`abel-ruffini-oq-04-oq-02` and `lagrange-theorem-oq-01-oq-02` were initially included but **dropped** — they were already flipped by the merged #25465.

## Evidence

**Before**: both entries claim `status: verified`, `axiomCount: 0` while their presented proofs route through `native_decide`.
**After**: `status: axiomatized`, `badge: axiom`, `meta.axiomCount: 1`, `assumptions` discloses the exact `ofReduceBool` dependency.

Metadata-only change. Part of #25409.

---
Automated fix by lean-mechanic agent.