### PR TITLE
audit(lebesgue-measure-oq-01): re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12222,9 +12222,9 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-18T05:07:17Z",
+      "lastAudited": "2026-06-18T06:30:00Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: lebesgue-measure-oq-01

Re-verified meta.json claims against \`proofs/Proofs/LebesgueMeasureOQ01.lean\`. **All claims match — clean.**

### Verification
| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 1 | 1 (`dirichletFunction`) | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 197 | 197 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier / Badge
Tier-B (Mathlib-backed). Core result $\int_0^1 \mathbf{1}_{\mathbb{Q}} = 0$ obtained via Mathlib's `integral_eq_zero_of_ae` + `Set.Countable.measure_zero`. Badge `mathlib` / status `verified` is conservative-correct; the Mathlib reliance is disclosed in `assumptions`. No delegation opacity, axiom masking, or overclaim.

Tracker bumped (auditCount 4→5, result clean).

---
Discovered during periodic gallery integrity audit (queue drained 2528/2528; oldest non-PR re-audit target).