### PR TITLE
Fix: re-class 6 presented-native_decide entries verified→axiomatized (#25409)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Gauss (1796), Wantzel (1837), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ03.lean",
     "tags": [
       "geometry",
@@ -21,7 +21,7 @@
       "extension",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,7 +55,7 @@
       "Connection to OQ02: Galois group order = φ(n) → 2-group criterion"
     ],
     "dateAdded": "2026-02-24",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 1799,
     "prerequisites": [
       "Euler's totient function and its basic properties",
@@ -63,7 +63,7 @@
       "Galois theory (cyclotomic extensions, 2-groups)",
       "Compass-and-straightedge constructibility criteria (from OQ-01, OQ-02)"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "The totient/Fermat-prime computations underlying constructibility of the 257-gon and 65537-gon (totient_257_eq, totient_65537_eq, prime_257, prime_65537, and the *_pow2 witnesses) are discharged by native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free).",
     "mathlib_version": "4.26.0",
     "theoremCount": 158,
     "definitionCount": 5

--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "A regular n-gon is constructible by compass and marked ruler (neusis) iff n = 2^a · 3^b · p₁ · ... · pₖ where each pᵢ is a Pierpont prime (p-1 = 2^u · 3^v). Verifies 12 Pierpont primes and 4 non-examples, plus neusis constructibility for specific polygons.",
   "meta": {
     "author": "Lean Genius OQ04-OQ03",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AngleTrisectionOQ04OQ03.lean",
     "additionalFiles": [
       "Proofs/AngleTrisectionOQ04.lean"
@@ -18,12 +18,12 @@
       "number-theory",
       "galois-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 328,
     "theoremCount": 54,
-    "assumptions": "None. All 54 theorems proved. Pierpont prime verification via native_decide.",
+    "assumptions": "All 54 theorems proved. Pierpont prime verification (3-smoothness and totient computations underlying the neusis constructibility criterion) is discharged by native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Conway & Guy (1968), formalized in Lean 4",
     "sourceUrl": "https://erdosproblems.com/1",
     "date": "1968",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1OQ03.lean",
     "tags": [
       "erdos",
@@ -16,10 +16,10 @@
       "distinct-subset-sums",
       "open-question"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. Conway-Guy optimality for n=1..5 is computationally proved via native_decide. The minDSSBound sorry was closed by Erdos1Wip01.dss_existence.",
+    "axiomCount": 1,
+    "assumptions": "Conway-Guy optimality for n=1..5 is computationally proved via native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free). The minDSSBound sorry was closed by Erdos1Wip01.dss_existence.",
     "mathlibDependencies": [
       {
         "theorem": "hasDistinctSubsetSums",

--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Schubert (1879), Hilbert (1900); Chow ring formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schubert_calculus",
     "date": "1879",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert15OQ01.lean",
     "tags": [
       "algebraic-geometry",
@@ -20,7 +20,7 @@
       "poincare-duality",
       "hilbert-problems"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,9 +39,9 @@
       "mul_comm_basis: commutativity of basis multiplication verified by decide"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 351,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. All results follow from the explicit multiplication table.",
+    "assumptions": "All results follow from the explicit multiplication table, but the Schubert-class products (Littlewood-Richardson table, sigma1_fourth = 2, Poincare duality, Giambelli) are discharged by native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free).",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
     "definitionCount": 9

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Researcher (lean-genius)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Rogers%E2%80%93Ramanujan_identities",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PartitionTheoremOQ01OQ01.lean",
     "tags": [
       "partitions",
@@ -16,10 +16,10 @@
       "computational verification",
       "q-series"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "No axioms. Computational verification via native_decide. Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions).",
+    "axiomCount": 1,
+    "assumptions": "The entire entry is computational verification of the Rogers-Ramanujan identities for n = 0..8 via native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free). Depends on PartitionTheoremOQ01 for definitions (rr1GapPartitions, rr1Mod5Partitions, rr2GapPartitions, rr2Mod5Partitions).",
     "mathlib_version": "4.26.0",
     "lineCount": 71,
     "relatedProblems": [

--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Schlaefli (1852), Coxeter (1973); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Regular_polytope",
     "date": "1852",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PlatonicSolidsOQ01.lean",
     "tags": [
       "geometry",
@@ -18,9 +18,9 @@
       "research",
       "open-question"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 53,
     "defCount": 28,
     "lineCount": 628,
@@ -46,7 +46,7 @@
       "Duality relationships: 5-cell and 24-cell are self-dual, 8-cell/16-cell and 120-cell/600-cell form dual pairs"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The Schlaefli determinant computation uses exact arithmetic in Z[sqrt(5)] to determine the sign of sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) for all candidate symbols.",
+    "assumptions": "The classification counts (5 Platonic solids, 6 regular 4-polytopes, 3 regular 5-polytopes) and the Schlaefli determinant sign tests are discharged by native_decide, which depends on Lean.ofReduceBool (the proof is not axiom-free). The Schlaefli determinant computation uses exact arithmetic in Z[sqrt(5)] to determine the sign of sin^2(pi/p)*sin^2(pi/r) - cos^2(pi/q) for all candidate symbols.",
     "prerequisites": [
       "Platonic solids classification (parent proof)",
       "Euler's formula for polytopes",


### PR DESCRIPTION
## Fix

Batch 4 of #25409. Re-classes 6 gallery entries whose **substantive presented headline** is discharged by `native_decide` (hence depends on `Lean.ofReduceBool`, per CLAUDE.md:140) but were marked `verified` / `axiomCount: 0`.

Each: `status` → `axiomatized`, `badge` → `axiom`, `meta.axiomCount` 0 → 1, and `Lean.ofReduceBool` disclosed in `assumptions`. `leanFile.axiomCount` (literal decls) is unaffected.

| Entry | Why load-bearing |
|-------|------------------|
| `erdos-1-oq-03` | Conway-Guy optimality f(n) for n=1..5 (`conwayGuy_optimal_*`, lower bounds `lower_1..5`) is `native_decide` |
| `platonic-solids-oq-01` | Classification counts (5 Platonic, 6 regular 4-polytopes, 3 regular 5-polytopes) + Schläfli determinant sign tests are `native_decide` |
| `angle-trisection-oq-04-oq-03` | Pierpont-prime / totient constructibility criterion via `native_decide` (assumptions already said so) |
| `angle-trisection-oq-02-oq-03` | Fermat-prime constructibility of 257-gon / 65537-gon (`totient_257/65537`, `prime_257/65537`) via `native_decide` |
| `hilbert-15-oq-01` | Entire Schubert-calculus multiplication table (LR products, σ₁⁴=2, Poincaré duality, Giambelli) via `native_decide` |
| `partition-theorem-oq-01-oq-01` | Entire entry is Rogers-Ramanujan identity verification for n=0..8 via `native_decide` |

## Evidence

**Before**: `status: "verified"`, `axiomCount: 0`, claiming axiom-free while the headline rests on `native_decide` → `Lean.ofReduceBool`.
**After**: `axiomatized` / `axiom` / `axiomCount: 1` with `Lean.ofReduceBool` disclosed.

Verified per-entry by reading each Lean source to confirm `native_decide` is on the **presented** result, not an incidental `example`/sanity check (stirling-trap). Entries with incidental-only framing (e.g. `ballot-problem-oq-01-oq-02-oq-04`, where structural results are nd-free and only a concrete count uses nd) were deliberately **left** `verified`.

Part of #25409.

---
Automated fix by lean-mechanic agent.