### PR TITLE
audit(bounded-prime-gaps-oq-03-oq-01-oq-01): native_decide in headline ⇒ axiomatized

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15855,8 +15855,14 @@
       "lastAudited": "2026-06-17T00:00:00Z",
       "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-17T00:00:00Z",
+      "result": "issues-fixed"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T05:58:09Z"
+  "lastUpdated": "2026-06-17T00:00:00Z"
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-17",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "combinatorics",
       "prime-constellations"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-06-17",
-    "axiomCount": 0,
-    "assumptions": "None beyond Mathlib. Fully machine-verified, 0 sorries, 0 axiom declarations. The witness card/diameter checks in minAdmissibleDiameter_5 use native_decide (closed-term Lean.ofReduceBool kernel reduction); the load-bearing lower bound admissible_5tuple_diam_ge_12 is native_decide-free and fully symbolic. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
+    "axiomCount": 1,
+    "assumptions": "Relies on Lean.ofReduceBool: the headline theorem minAdmissibleDiameter_5 (D(5)=12) discharges the witness card/diameter checks for {0,2,6,8,12} with native_decide, which trusts the compiler's kernel reduction and so depends on the Lean.ofReduceBool axiom — its #print axioms is not axiom-free. There are 0 sorries and 0 literal axiom declarations (leanFile.axiomCount = 0). The load-bearing lower bound admissible_5tuple_diam_ge_12 is native_decide-free and fully symbolic, but the main D(5)=12 result as assembled is not. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
     "lineCount": 198,
     "theoremCount": 3,
     "definitionCount": 0,
@@ -78,7 +78,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. The lower bound is fully symbolic (native_decide-free), interrogating only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument. 198 lines, 3 theorems, 0 sorries, 0 axioms.",
+    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. The lower bound is fully symbolic (native_decide-free), interrogating only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument. 198 lines, 3 theorems, 0 sorries, 0 axiom declarations. The headline D(5)=12 assembly verifies the concrete witness diameter with native_decide, so it depends on the Lean.ofReduceBool axiom (badge: axiom).",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, and now $D(5)=12$ all machine-verified, the smallest five prime-constellation diameters are formally established in Lean 4. The two-triple counting argument is the natural successor to the single-AP obstruction used for $D(4)$ and extends the reusable proof infrastructure (parity filtration, residue-complete-block counting) toward $D(6)=16$ and beyond. Under the Elliott–Halberstam conjecture, $D(5)=12$ is the exact predicted span for prime quintuples $n, n+2, n+6, n+8, n+12$.",
     "openQuestions": [
       "Prove $D(6)=16$ by extending the block-counting argument: the candidate window widens and the mod-5 obstruction must be combined with the mod-2 and mod-3 ones used here.",


### PR DESCRIPTION
## Integrity Issue

**Proof**: bounded-prime-gaps-oq-03-oq-01-oq-01 (Minimum Admissible Diameter D(5) = 12)
**Severity**: HIGH — overclaims axiom-freedom for the headline result

## Evidence

The headline theorem `minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12`
(`proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean:185-196`) uses `native_decide`
**twice** to verify the concrete witness `{0,2,6,8,12}`:

```lean
exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩   -- L189
⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩      -- L193
```

Per the project axiom integrity policy, `native_decide` trusts the compiler's
kernel reduction and depends on the `Lean.ofReduceBool` axiom — `#print axioms
minAdmissibleDiameter_5` is **not** axiom-free. This `native_decide` sits inside
the entry's namesake headline theorem (not an unused `example`), so it is the
flip case, not the leave-verified class.

**meta.json claimed**: `status: verified`, `badge: original`, `axiomCount: 0`,
assumptions "Fully machine-verified", conclusion "0 axioms".

## Fix Applied

- `status`: verified → **axiomatized**
- `badge`: original → **axiom**
- `meta.axiomCount`: 0 → **1** (`leanFile.axiomCount` stays 0 — no literal `axiom` declarations)
- `assumptions` and `conclusion.summary`: disclose the `Lean.ofReduceBool` dependency

The load-bearing lower bound `admissible_5tuple_diam_ge_12` genuinely remains
`native_decide`-free and fully symbolic; only the witness card/diameter checks
in the main assembly carry the dependency. A follow-up could discharge those
checks with kernel `decide` to restore axiom-freedom.

---
Discovered during gallery integrity audit.