### PR TITLE
Enrich Mantel Stability (AES min-degree): annotations, section, keyInsight

### DIFF
--- a/src/data/proofs/mantel-theorem-oq-01/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "mantel-oq01-ann-import",
+    "proofId": "mantel-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "context",
+    "title": "A Single `import Mathlib`: Standing on Brandt's Theorem",
+    "content": "The file imports all of Mathlib for one reason: it needs SimpleGraph.colorable_of_cliqueFree_lt_minDegree, which lives in Mathlib.Combinatorics.SimpleGraph.FiveWheelLike and encodes Stephan Brandt's proof of the general Andrásfai–Erdős–Sós colorability theorem. Because the heavy structural work is already upstream, the entry's own contribution is deliberately thin — a numeral specialization and its contrapositive — and carries no new axioms or sorries.",
+    "mathContext": "Brandt (general AES): a $K_{r+1}$-free graph with $\\frac{(3r-4)n}{3r-1} < \\delta(G)$ is $r$-colorable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib", "FiveWheelLike", "Andrásfai–Erdős–Sós theorem", "graph colorability"],
+    "prerequisites": ["simple graphs", "clique-free graphs"]
+  },
+  {
+    "id": "mantel-oq01-ann-setup",
+    "proofId": "mantel-theorem-oq-01",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "context",
+    "title": "Ambient Setup: Finite Graphs with Decidable Adjacency",
+    "content": "The variable block fixes a finite vertex type V with a graph G whose adjacency relation is decidable: [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]. These are exactly the typeclass assumptions under which G.minDegree is well-defined (a minimum over the finite set of vertex degrees) and G.CliqueFree 3 is a meaningful finite condition. Stating the lemmas at this generality — rather than over a concrete Fin n — keeps them drop-in usable for whatever survivor subgraph the degree-cleaning step produces.",
+    "mathContext": "$\\delta(G) = \\min_{v \\in V} \\deg(v)$, defined for finite $V$ with decidable $\\mathrm{Adj}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["minimum degree", "Fintype", "DecidableRel", "finite graphs"],
+    "prerequisites": ["typeclasses", "SimpleGraph.minDegree"]
+  },
+  {
     "id": "mantel-oq01-ann-docstring",
     "proofId": "mantel-theorem-oq-01",
     "range": { "startLine": 7, "endLine": 42 },

--- a/src/data/proofs/mantel-theorem-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-01/meta.json
@@ -53,7 +53,8 @@
       "The hard structural content of triangle-free stability is already in Mathlib: Brandt's colorable_of_cliqueFree_lt_minDegree gives the Andrásfai–Erdős–Sós theorem in full generality, so the min-degree → bipartite step costs only a threshold specialization.",
       "At r = 2 the AES threshold (3r−4)·n/(3r−1) is literally 2n/5; because r is a numeral, omega evaluates the arithmetic and discharges the side condition with no manual rewriting.",
       "Phrasing the result contrapositively — non-bipartite triangle-free ⇒ minimum degree ≤ 2n/5 — produces the 'sparse-at-some-vertex' lemma that the degree-cleaning argument plugs in directly, making the remaining work purely a counting/accounting problem.",
-      "Min-degree stability (high δ forces exact bipartiteness) is logically distinct from edge-count stability (near-maximal edge count forces approximate bipartiteness); the former is the engine inside the proof of the latter, not the latter itself."
+      "Min-degree stability (high δ forces exact bipartiteness) is logically distinct from edge-count stability (near-maximal edge count forces approximate bipartiteness); the former is the engine inside the proof of the latter, not the latter itself.",
+      "The 2n/5 threshold is sharp, and the balanced blow-up of the 5-cycle C₅ is the single example that certifies it: it is triangle-free, non-bipartite, and 2n/5-regular, so it simultaneously shows the AES hypothesis cannot be relaxed below 2n/5 and pins down the exact constant the degree-cleaning step must clear before invoking the lemma."
     ]
   },
   "conclusion": {
@@ -81,6 +82,14 @@
       "endLine": 42,
       "summary": "Module docstring locating the result: the exact extremal form of Mantel's theorem (mantel-theorem, mantel-theorem-uniqueness) is settled, while edge-count stability is open. This file packages the degree-cleaning route's min-degree ingredient — the r = 2 case of Mathlib's colorable_of_cliqueFree_lt_minDegree — and is explicit that this is min-degree stability, distinct from the open edge-count statement.",
       "mathContext": "AES (triangle-free case): K₃-free with δ(G) > 2n/5 ⇒ G is bipartite."
+    },
+    {
+      "id": "setup",
+      "title": "Ambient Setup",
+      "startLine": 44,
+      "endLine": 48,
+      "summary": "Opens Finset, Fintype, and SimpleGraph, enters namespace MantelStability, and fixes the working context: a finite vertex type V with a graph G whose adjacency is decidable ([Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]). These are the minimal typeclass assumptions that make minDegree and CliqueFree 3 well-defined finite quantities, and stating the lemmas at this generality keeps them reusable on any survivor subgraph.",
+      "mathContext": "δ(G) = min over v of deg(v), defined for finite V with decidable adjacency."
     },
     {
       "id": "aes-specialization",


### PR DESCRIPTION
Enrichment pass for `mantel-theorem-oq-01` (quality 83 → 100, meta/annotations only).

**Annotations (3 → 5):**
- `import`-level annotation: the single `import Mathlib` stands on Brandt's `colorable_of_cliqueFree_lt_minDegree` in FiveWheelLike.lean, which is why the entry's own contribution is deliberately thin.
- ambient-setup annotation: why `[Fintype V]` + `[DecidableRel G.Adj]` are the minimal scaffolding under which `minDegree` and `CliqueFree 3` are well-defined, and why the lemmas are stated at that generality (drop-in for the cleaning step's survivor subgraph).

**Sections (4 → 5):** added an *Ambient Setup* section covering the open/namespace/variable block (lines 44–48), previously uncovered.

**keyInsights (4 → 5):** added the sharpness of the 2n/5 threshold via the balanced blow-up of C₅ — the single example that both forbids relaxing the AES hypothesis and pins the constant the degree-cleaning step must clear.

No mathematical claims changed; verified/0-axiom/0-sorry status untouched. JSON validated; quality scorer recomputes to 100.