### PR TITLE
Fix: re-class bounded-prime-gaps D(5)=12 verified→axiomatized (#25409)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-17",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "combinatorics",
       "prime-constellations"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-06-17",
-    "axiomCount": 0,
-    "assumptions": "None beyond Mathlib. Fully machine-verified, 0 sorries, 0 axiom declarations. The witness card/diameter checks in minAdmissibleDiameter_5 use native_decide (closed-term Lean.ofReduceBool kernel reduction); the load-bearing lower bound admissible_5tuple_diam_ge_12 is native_decide-free and fully symbolic. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
+    "axiomCount": 1,
+    "assumptions": "Lean.ofReduceBool (via native_decide), 0 sorries, 0 literal axiom declarations. The headline equality minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 proves achievability by discharging the witness card/diameter checks with native_decide, so its #print axioms includes Lean.ofReduceBool (closed-term kernel reduction). The lower bound admissible_5tuple_diam_ge_12 is itself native_decide-free and fully symbolic, but the presented D(5)=12 result depends on the native_decide upper bound. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
     "lineCount": 198,
     "theoremCount": 3,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

`bounded-prime-gaps-oq-03-oq-01-oq-01` (D(5)=12) was `verified` / `original` / `axiomCount: 0`, but its presented headline theorem depends on `native_decide` (⇒ `Lean.ofReduceBool`).

## Evidence

The gallery headline is `minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12` (D(5)=12). Its proof discharges the **achievability / upper-bound** direction via `native_decide`:

```lean
theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by
  ...
    exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
  ...
      ⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
    exact admissible_5tuple_diam_ge_12 H hcard hadm
```

The lower bound (`admissible_5tuple_diam_ge_12`, ≥12) is genuinely `native_decide`-free and symbolic, but the full equality `= 12` requires the witness diameter/card check, which uses `native_decide`. So `#print axioms minAdmissibleDiameter_5` includes `Lean.ofReduceBool`. This is the substantive result the entry presents as verified — per the Axiom Integrity Policy it must be `axiomatized`.

This is NOT the stirling trap (axiom-free headline + `native_decide` on a separate unused lemma): here the `native_decide` is inside the headline theorem's own proof. The `assumptions` field already disclosed `Lean.ofReduceBool`.

**Before**: `status: verified`, `badge: original`, `meta.axiomCount: 0`
**After**: `status: axiomatized`, `badge: axiom`, `meta.axiomCount: 1`, `assumptions` clarified (`leanFile.axiomCount` stays 0 — counts only literal `axiom` declarations).

Part of #25409.

---
Automated fix by lean-mechanic agent.