### PR TITLE
Fix: re-class ballot-problem-oq-01-oq-02-oq-04 verified→axiomatized (native_decide)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical setup; counterexample formalization new",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ballot_problem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ04.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "counterexample",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -33,9 +33,9 @@
       "Scaled ballot formula: (ap-bq)/(ap+bq) for uniform weight scaling"
     ],
     "dateAdded": "2026-04-05",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 311,
-    "assumptions": "0 sorries, 0 axioms. Counterexample verified by native_decide and norm_num. Structural theorems proved directly.",
+    "assumptions": "Depends on Lean.ofReduceBool: the headline counterexample probability (counterexample_good_count, \"out of 6 orderings exactly 2 are good\" \u2192 actual P = 2/6 = 1/3) is discharged by native_decide, so the entry is not axiom-free. 0 sorries, 0 axiom declarations (leanFile.axiomCount stays 0). norm_num and kernel decide carry no extra axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Re-classifies `ballot-problem-oq-01-oq-02-oq-04` from `verified`/`original`/`axiomCount:0` to `axiomatized`/`axiom`/`axiomCount:1`, disclosing `Lean.ofReduceBool`.

## Evidence

The entry's showcased contribution is the **explicit counterexample** that the classical ballot formula fails for weighted votes: votes [2,1] vs [2], **actual P = 1/3** vs classical formula 1/5. That actual probability is established by `counterexample_good_count` (BallotProblemOQ01OQ02OQ04.lean:152–156):

```lean
theorem counterexample_good_count :
    let orderings := [[2,1,-2],[1,2,-2],[2,-2,1],[1,-2,2],[-2,2,1],[-2,1,2]]
    (orderings.filter (fun s => decide (isGoodWeighted s))).length = 2 := by
  native_decide
```

`native_decide` trusts compiler kernel reduction and depends on `Lean.ofReduceBool` (`#print axioms` would list it). Per the Axiom Integrity Policy in CLAUDE.md, when `native_decide` discharges a **substantive** result the entry presents as verified, it must be counted: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, and `Lean.ofReduceBool` disclosed in `assumptions`.

**Before**: `verified` / `original` / `axiomCount: 0` — claimed axiom-free.
**After**: `axiomatized` / `axiom` / meta `axiomCount: 1`, `Lean.ofReduceBool` disclosed. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Part of #25409.

---
Automated fix by lean-mechanic agent.