### PR TITLE
audit(mantel-theorem-oq-01): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15855,8 +15855,14 @@
       "lastAudited": "2026-06-17T00:00:00Z",
       "result": "clean",
       "issues": []
+    },
+    "mantel-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-18T06:13:33Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T05:58:09Z"
+  "lastUpdated": "2026-06-18T06:13:33Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: mantel-theorem-oq-01 (Mantel Stability: the Andrásfai–Erdős–Sós Min-Degree Ingredient)
**Result**: clean — no integrity issues. One of two never-audited entries this cycle.

### Verification (meta.json vs `Proofs/MantelStabilityOQ01.lean`)
| Claim | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 69 | 69 | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal, 0 structure-encoded | ✓ |
| native_decide | — | none | ✓ |
| True stubs | — | none | ✓ |

### Tier / classification
- **Tier B** (`verified`/`mathlib`) — **correct**. Core result delegates to Mathlib's `colorable_of_cliqueFree_lt_minDegree` (Brandt's AES theorem), transparently credited in `mathlibDependencies`, `originalContributions`, and `proofStrategy`. `mathlib` badge (not `original`) correctly signals delegation; 0 sorries / 0 axioms / 0 structure assumptions justify `verified`.
- **No overclaim**: title says "Min-Degree **Ingredient**"; description states it is a "**partial** formalization" with "the full edge-count o(n²) stability statement remains **open**." No axiom masking, no inequality-as-theorem inflation, no delegation opacity.

### Minor note (non-blocking, not an overclaim)
The Lean docstring "Status" block (lines 34-41) still reads "ORPHAN, build-pending: not registered in Proofs.lean, no gallery entry" — now stale, since the file is registered (`Proofs.lean:2656`) and galleried. This is an *understatement* in an internal comment, not a public overclaim, so it poses no credibility risk; the gallery meta.json is fully accurate. Left for a future enrichment/cleanup pass.

Tracker bumped: mantel-theorem-oq-01 → audited (clean).

---
Discovered during gallery integrity audit.