### PR TITLE
Fix: re-class 2 native_decide headline entries verified→axiomatized (#25409 batch 6)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ04.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "combinatorics",
       "prime-constellations"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. Uses only Mathlib and the admissible_quadruple_0_2_6_8 witness from BoundedPrimeGaps.lean.",
+    "axiomCount": 1,
+    "assumptions": "Lean.ofReduceBool (via native_decide), 0 sorries, 0 literal axiom declarations. The headline equality minAdmissibleDiameter_4 : minAdmissibleDiameter 4 = 8 proves achievability by discharging the witness card/diameter checks with native_decide, so its #print axioms includes Lean.ofReduceBool (closed-term kernel reduction). The lower bound admissible_quad_diam_ge_8 is itself native_decide-free and fully symbolic, but the presented D(4)=8 result depends on the native_decide upper bound. Reuses the verified admissible_quadruple_0_2_6_8 witness from BoundedPrimeGaps.lean.",
     "lineCount": 187,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/platonic-solids/meta.json
+++ b/src/data/proofs/platonic-solids/meta.json
@@ -8,7 +8,7 @@
     "author": "Euclid (Lean 4 formalization)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Platonic_solid",
     "date": "c. 300 BCE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PlatonicSolids.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "topology"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -34,14 +34,14 @@
       "Proof of duality relationships between Platonic solids"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 419,
     "prerequisites": [
       "Euler's formula for polyhedra: V - E + F = 2",
       "Schlafli symbols and regular polyhedra",
       "Combinatorics of regular tilings and angle constraints"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Lean.ofReduceBool (via native_decide), 0 sorries, 0 literal axiom declarations. The headline theorem number_of_platonic_solids : validPairs.card = 5 (Wiedijk #50) is discharged entirely by native_decide, so its #print axioms includes Lean.ofReduceBool (closed-term kernel reduction). The structural reduction to the regularity constraint (p-2)(q-2) < 4 and the V/E/F and duality results are native_decide-free, but the presented headline count of exactly five Platonic solids depends on the native_decide enumeration.",
     "mathlib_version": "4.26.0",
     "theoremCount": 24,
     "definitionCount": 11


### PR DESCRIPTION
## Summary

Two more residual entries from #25409 where the **presented headline result is discharged by `native_decide`**, so `#print axioms <headline>` includes `Lean.ofReduceBool`. Per the project axiom-integrity policy (CLAUDE.md), `native_decide` on a substantive presented result ⇒ `axiomatized` / `axiom` / `axiomCount=1` with `Lean.ofReduceBool` disclosed in `assumptions`.

Both are clear-cut (not "stirling-trap" incidental nd): the native_decide *is* the headline's proof, not an unused auxiliary lemma.

### Entries flipped (meta-only)

| slug | headline | nd location |
|------|----------|-------------|
| `bounded-prime-gaps-oq-03-oq-01-oq-04` | `minAdmissibleDiameter_4 : minAdmissibleDiameter 4 = 8` (D(4)=8) | upper-bound witness checks `by native_decide` |
| `platonic-solids` | `number_of_platonic_solids : validPairs.card = 5` (Wiedijk #50) | discharged entirely `by native_decide` |

The D(4) case exactly parallels the already-merged D(5)=12 flip (#25475) — same file family, same structure (symbolic lower bound, native_decide upper-bound witness).

### Not changed
- `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).
- Lean source untouched; this is a metadata-accuracy fix.

Refs #25409.