### PR TITLE
audit(arithmetic-series-oq-02-oq-02): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -550,9 +550,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:28:03Z",
+      "lastAudited": "2026-06-18T06:18:31Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — `arithmetic-series-oq-02-oq-02` (2D Hockey Stick Identity)

**Result: CLEAN** — all public claims match the Lean kernel guarantee.

### Checks
| Check | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| Sorries | 0 | 0 | ✓ |
| Axiom declarations | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |
| Theorems / defs | 9 / 1 | 9 / 1 | ✓ |
| Line count | 154 | 154 | ✓ |
| Status / badge | verified / original | Tier A | ✓ |

### Notes
- **Badge `original` (Tier A) justified**: `parallel_vandermonde` and `hockey_stick` are genuine nested inductions built only on Pascal's recurrence (`Nat.choose_succ_succ`) and basic Finset sum lemmas. Mathlib has no `parallel_vandermonde`; `originalContributions` are correctly scoped. Not a wrapper.
- **native_decide**: two uses — `check_2d_n2 : simplicial 2 2 = 6` and `check_pv_a1b1n2 : simplicial 3 2 = 10`. Both are incidental concrete sanity-checks of results already proven axiom-free by the general theorems, **not** the substantive headline. Per the established convention (incidental numerical verification → retain `verified`), no status change.
- **Minor (non-blocking)**: the in-file summary comment says "12 theorems"; the file actually has 9 and meta correctly reports 9. Stale docstring only.

Tracker: `auditCount` 4→5, `lastAudited` refreshed, result `clean`.

---
Routine gallery integrity audit. Tracker-only change.