### PR TITLE
Enrich Quadratic Reciprocity (2/p) criterion: split residue / non-residue sections

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -87,15 +87,29 @@
     },
     {
       "id": "residue-criterion",
-      "title": "Residue Decision Criterion (p mod 8)",
+      "title": "Residue Criterion: (2/p) = 1 ⟺ p ≡ ±1 (mod 8)",
       "startLine": 74,
-      "endLine": 120,
-      "summary": "Two decision-form lemmas. `legendreSym_two_eq_one_iff`: (2/p) = 1 ↔ p % 8 = 1 ∨ p % 8 = 7, by composing `legendreSym.eq_one_iff` with `ZMod.exists_sq_eq_two_iff` after discharging `(2 : ZMod p) ≠ 0` from `p ≠ 2`. `legendreSym_two_eq_neg_one_iff`: (2/p) = -1 ↔ p % 8 = 3 ∨ p % 8 = 5, the complement, closed by `omega` from the oddness of `p`.",
-      "mathContext": "$\\left(\\tfrac{2}{p}\\right) = 1 \\iff p \\equiv 1, 7 \\pmod 8$ and $\\left(\\tfrac{2}{p}\\right) = -1 \\iff p \\equiv 3, 5 \\pmod 8$. An odd prime satisfies $p \\bmod 8 \\in \\{1,3,5,7\\}$, so the two criteria partition all cases.",
+      "endLine": 103,
+      "summary": "`legendreSym_two_eq_one_iff`: for an odd prime p, (2/p) = 1 ↔ p % 8 = 1 ∨ p % 8 = 7. The decision form of the second supplementary law — it composes `legendreSym.eq_one_iff` ((a/p) = 1 ↔ a is a square) with `ZMod.exists_sq_eq_two_iff` (2 is a square mod p ↔ p % 8 ∈ {1, 7}), after discharging the non-vanishing side condition (2 : ZMod p) ≠ 0 from p ≠ 2.",
+      "mathContext": "$\\left(\\tfrac{2}{p}\\right) = 1 \\iff p \\equiv 1, 7 \\pmod 8$. The verdict form is useful when the algorithm needs only the residue/non-residue answer rather than the signed character value.",
       "relatedConcepts": [
         "quadratic residue mod p",
-        "p mod 8 case analysis",
+        "second supplementary law",
         "ZMod.exists_sq_eq_two_iff",
+        "legendreSym.eq_one_iff"
+      ]
+    },
+    {
+      "id": "non-residue-complement",
+      "title": "Non-Residue Complement: (2/p) = -1 ⟺ p ≡ ±3 (mod 8)",
+      "startLine": 105,
+      "endLine": 120,
+      "summary": "`legendreSym_two_eq_neg_one_iff`: (2/p) = -1 ↔ p % 8 = 3 ∨ p % 8 = 5. The complement of the residue criterion: an odd prime has p % 8 ∈ {1, 3, 5, 7} (from `Odd p` via `omega`) and a Legendre symbol of a unit is ±1, so the non-residue cases are exactly {3, 5}. Closed by `omega` after rewriting through `legendreSym.eq_neg_one_iff` and `ZMod.exists_sq_eq_two_iff`.",
+      "mathContext": "$\\left(\\tfrac{2}{p}\\right) = -1 \\iff p \\equiv 3, 5 \\pmod 8$. Together with the residue criterion this partitions the four odd residue classes mod 8 into the two QR and two non-QR classes for the prime 2.",
+      "relatedConcepts": [
+        "p mod 8 case analysis",
+        "legendreSym.eq_neg_one_iff",
+        "odd prime residue classes",
         "omega tactic"
       ]
     },


### PR DESCRIPTION
## Enrichment pass

The 'Residue Decision Criterion' section of `quadratic-reciprocity-oq-03-oq-01` (lines 74–120) bundled two genuinely distinct lemmas:

1. **Residue criterion** — `legendreSym_two_eq_one_iff`: (2/p) = 1 ⟺ p ≡ ±1 (mod 8), composing `legendreSym.eq_one_iff` with `ZMod.exists_sq_eq_two_iff`.
2. **Non-residue complement** — `legendreSym_two_eq_neg_one_iff`: (2/p) = -1 ⟺ p ≡ ±3 (mod 8), the complement via the odd-prime residue classes {1,3,5,7} and `omega`.

Split into two sections, each with its own `mathContext` and `relatedConcepts`. Meta-only change; no Lean source touched.

- Sections 4 → 5, quality 98 → 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)