### PR TITLE
Enrich Prime-Power Radical Minpoly: split out 'The Subtle Point' section

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01-oq-02-oq-02/meta.json
@@ -95,11 +95,19 @@
   "sections": [
     {
       "id": "section-header",
-      "title": "Header: Statement, Subtlety, and Strategy",
+      "title": "Header: Statement and Proof Strategy",
       "startLine": 1,
-      "endLine": 64,
-      "summary": "Block comment stating the prime-power generalization minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a, the 'subtle point' that the obstruction ∀ b, b^p ≠ a is independent of n (X⁹ − 2 irreducible because 2 is not a cube), the composite-exponent failure (X⁴ − 4 factors), and the three-step monic+irreducible+root proof outline.",
+      "endLine": 31,
+      "summary": "Block comment stating the prime-power generalization minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for an odd prime p, exponent n ≥ 1, and a nonnegative rational a that is not a p-th power, together with the degree (= pⁿ) and field-extension corollaries. Obtained by pushing Mathlib's Kummer criterion X_pow_sub_C_irreducible_iff_of_prime_pow to general n; setting n = 1 recovers the odd-prime companion.",
       "mathContext": "minpoly ℚ (a^(1/pⁿ)) = X^(pⁿ) − a for odd prime p, n ≥ 1, a ≥ 0 not a p-th power."
+    },
+    {
+      "id": "the-subtle-point",
+      "title": "The Subtle Point: the obstruction is n-independent",
+      "startLine": 33,
+      "endLine": 63,
+      "summary": "The irreducibility hypothesis is ∀ b : ℚ, b^p ≠ a — 'a is not a p-th power' — and is independent of n, not the weaker 'a is not a pⁿ-th power'. X⁹ − 2 is irreducible because 2 is not a cube (p = 3); whether 2 is a 9-th power is never tested. Being a non-p-th-power is the single Diophantine obstruction for the whole tower of prime-power exponents, in sharp contrast to composite exponents where early collapse occurs (minpoly ℚ (4^(1/4)) = X² − 2, since X⁴ − 4 = (X² − 2)(X² + 2)). The section closes with the three-step monic + irreducible + root proof outline and build status.",
+      "mathContext": "Prime-power exponents pⁿ admit no intermediate field collapse: [ℚ(a^(1/pⁿ)) : ℚ] = pⁿ as soon as ∀ b, b^p ≠ a, unlike composite exponents."
     },
     {
       "id": "section-root",


### PR DESCRIPTION
## Enrichment pass

The header section of `sqrt2-minpoly-oq-01-oq-02-oq-02` (lines 1–64) collapsed four distinct markdown blocks into one. Broke out the conceptual heart — **The Subtle Point** — as its own section:

- The irreducibility obstruction `∀ b, b^p ≠ a` is **independent of n**, not the weaker 'not a pⁿ-th power'.
- `X⁹ − 2` is irreducible because 2 is not a **cube** (p = 3) — being a 9-th power is never tested.
- Sharp contrast with composite exponents: `minpoly ℚ (4^(1/4)) = X² − 2` since `X⁴ − 4 = (X² − 2)(X² + 2)`.

The remaining header keeps the statement and proof strategy. Meta-only change; no Lean source touched.

- Sections 4 → 5, quality 98 → 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)