### PR TITLE
audit(pythagorean-theorem-oq-03): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12770,9 +12770,9 @@
       "result": "clean"
     },
     "pythagorean-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:27:02Z",
+      "lastAudited": "2026-06-18T06:28:55Z",
       "result": "clean"
     },
     "pythagorean-triples": {


### PR DESCRIPTION
## Gallery Integrity Audit — pythagorean-theorem-oq-03

**Result: CLEAN** (re-audit; auditCount 3→4)

Non-Euclidean Pythagorean entry: 1431 lines, 105 theorems, 18 defs, 3 structures.

### Checks
- ✅ 0 `axiom` declarations, 0 sorries, 0 `native_decide`, 0 `True` stubs — all match meta.json.
- ✅ Three structure `law` Prop-fields (`HyperbolicRightTriangle.law`, `SphericalRightTriangle.law`, `SphericalRightTriangleR.law`) are **constitutive definitions** of the geometric objects — `hyperbolic_pythagorean := T.law` is a bare projection. This is analogous to defining a Pythagorean triple as `a²+b²=c²`, not open-theorem masking (cf. RHAxioms positing an open conjecture). All three are transparently disclosed in `meta.assumptions`.
- ✅ Badge correctly hedged to `mathlib`; status `verified` / `axiomCount: 0` accurate (the genuinely-proved content is the 100+ consequence theorems built on the constitutive laws).

### Minor (non-blocking, LOW)
- `definitionCount: 21` = 18 `def` + 3 `structure` ✓.
- `theoremCount: 105` vs 104 grepped (`^theorem|^lemma`) — one continuation/inline, cosmetic only.

Tracker bump only.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)