### PR TITLE
Fix: correct Wiedijk numbers for Bertrand (#98) and FTC of Integral Calculus (#15)

### DIFF
--- a/proofs/Proofs/BertrandsPostulate.lean
+++ b/proofs/Proofs/BertrandsPostulate.lean
@@ -44,7 +44,7 @@ Bertrand's Postulate has numerous applications:
 - Foundation for stronger results like the Prime Number Theorem
 - Applications in combinatorics and algorithms requiring "nearby" primes
 
-## Wiedijk's 100 Theorems: #43
+## Wiedijk's 100 Theorems: #98
 -/
 
 namespace BertrandsPostulate

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -38,7 +38,7 @@
       "Expository connection to the Prime Number Theorem (commentary, not formalized)"
     ],
     "dateAdded": "2025-12-26",
-    "wiedijkNumber": 43,
+    "wiedijkNumber": 98,
     "axiomCount": 0,
     "lineCount": 151,
     "relatedProblems": [

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -57,7 +57,7 @@
       "Antiderivative uniqueness theorem with multi-step proof via mean value theorem (antiderivatives_differ_by_constant)"
     ],
     "dateAdded": "2025-12-21",
-    "wiedijkNumber": 46,
+    "wiedijkNumber": 15,
     "axiomCount": 0,
     "lineCount": 165,
     "assumptions": "0 axioms, 0 sorries. Core FTC results (integral_hasDerivAt_right, integral_eq_sub_of_hasDerivAt) derived from Mathlib's measure-theoretic integration framework.",


### PR DESCRIPTION
## Fix

Two gallery entries carried the wrong Wiedijk "Formalizing 100 Theorems" number, each colliding with a correctly-numbered sibling.

## Evidence

Canonical list (https://www.cs.ru.nl/~freek/100/):
- #15 = Fundamental Theorem of Integral Calculus
- #43 = The Isoperimetric Theorem
- #46 = The Solution of the General Quartic Equation
- #98 = Bertrand's Postulate

**Before**:
- `bertrands-postulate` → wiedijkNumber **43** (collides with `isoperimetric-theorem`, also 43; Lean docstring line 47 also said `#43`)
- `fundamental-theorem-calculus` → wiedijkNumber **46** (collides with `general-quartic`, also 46)

**After**:
- `bertrands-postulate` → **98** (meta.json + Lean docstring)
- `fundamental-theorem-calculus` → **15** (meta.json)

The two siblings (`isoperimetric-theorem` #43, `general-quartic` #46) are correct and left unchanged.

Surfaced while triaging peer-review findings (the original review recommended the inverse change, which was not consistent with the canonical list).

Metadata-only + one Lean docstring comment line (no compilation impact; no build needed).

---
Automated fix by lean-mechanic agent.