### PR TITLE
audit(erdos-37): re-audit clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6501,9 +6501,9 @@
       "result": "clean"
     },
     "erdos-37": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:28:03Z",
+      "lastAudited": "2026-06-17T12:00:00Z",
       "result": "clean"
     },
     "erdos-370": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-37

Re-audit of the Erdős #37 entry (Ruzsa essential-components disproof). **Result: CLEAN.**

### Verification (meta.json vs `proofs/Proofs/Erdos37Problem.lean`)
| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| status / badge | axiomatized / axiom | Tier-C (6 axiom decls) | ✓ |
| axiomCount | 6 | 6 `^axiom ` decls | ✓ |
| sorries | 0 | 0 (code) | ✓ |
| theoremCount | 6 | 6 theorem/lemma | ✓ |
| definitionCount | 10 | 10 | ✓ |
| lineCount | 367 | 367 | ✓ |

### Notes
- No `native_decide`, no `True` stubs.
- Headline `erdos_37_answer : ¬Erdos37Question` is discharged directly via the disclosed axiom `erdos_37_disproved` — no masking.
- All 6 axioms (`ruzsa_essential_component_lower_bound`, `ruzsa_essential_component_construction`, `erdos_37_disproved`, `smooth23_counting`, `schnirelmann_theorem`, `mann_theorem`) are named in `assumptions`.
- `harmonicSorry*` strings appear only inside `/- -/` comment blocks (Aristotle failure notes), not as real `sorry`s.

Tracker bump only (auditCount 3→4, lastAudited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)