### PR TITLE
Fix: correct Wiedijk number for FTA variant oq-04 (95 -> 2)

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04/meta.json
@@ -63,7 +63,7 @@
       "Basic polynomial algebra (roots, evaluation, degree)",
       "Familiarity with Lean 4 and Mathlib"
     ],
-    "wiedijkNumber": 95,
+    "wiedijkNumber": 2,
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
     "date": "1799",
     "relatedProblems": [


### PR DESCRIPTION
## Fix

`fundamental-theorem-algebra-oq-04` ("C is the Unique Algebraic Closure of R") carried Wiedijk number **95**, which is Ptolemy's Theorem — colliding with `ptolemys-theorem`.

## Evidence

Canonical list (https://www.cs.ru.nl/~freek/100/): **#2 = Fundamental Theorem of Algebra**, **#95 = Ptolemy's Theorem**.

This entry is a variant of the FTA; the base entry `fundamental-theorem-algebra` correctly uses **#2**.

**Before**: wiedijkNumber 95
**After**: wiedijkNumber 2

Metadata-only, one line.

---
Automated fix by lean-mechanic agent.