### PR TITLE
audit(erdos-1157): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4300,9 +4300,9 @@
       "result": "clean"
     },
     "erdos-1157": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:44Z",
+      "lastAudited": "2026-06-18T06:37:20Z",
       "result": "clean"
     },
     "erdos-1158": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1157

Re-audit of **Erdős Problem #1157: General Extremal Numbers for r-Uniform Hypergraphs**.

### Result: CLEAN ✅

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | `axiomatized` | Tier C scaffold | ✅ |
| badge | `axiom` | — | ✅ |
| axiomCount | 2 | 2 `axiom` decls | ✅ |
| sorries | 0 | 0 | ✅ |
| native_decide | — | 0 | ✅ |
| True stubs | — | 0 | ✅ |

### Notes
- Both axioms (`brown_erdos_sos_lower_bound`, `delcourt_postle_theorem`) are explicitly named in the `assumptions` field — **no axiom masking**.
- Partial results `ruzsa_szemeredi_bes` (#716) and `glock_bes_k4` are correctly *derived from* the Delcourt-Postle axiom and attributed.
- The central `BESConjecture` is a `Prop` definition — not claimed proved. The open problem is properly framed.
- LOW non-blocking nit: `theoremCount: 27` in meta vs 25 `theorem`/`lemma` declarations found by grep (count nit only).

`auditCount` 3→4.

---
Discovered during gallery integrity audit loop.