### PR TITLE
state(niven-theorem-oq-01): mark COMPLETE — PR #25163 merged, gallery-live

### DIFF
--- a/research/problems/niven-theorem-oq-01/meta.json
+++ b/research/problems/niven-theorem-oq-01/meta.json
@@ -1,15 +1,22 @@
 {
   "slug": "niven-theorem-oq-01",
   "title": "Niven's Theorem: the only rational cosines at rational multiples of π are 0, ±1/2, ±1",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "significance": 6,
   "tractability": 5,
   "started": "2026-06-16T00:00:00Z",
-  "lastUpdate": "2026-06-16T04:15:00Z",
-  "tags": ["seeker-selected", "analysis", "number-theory", "trigonometry", "algebraic-number-theory", "research"],
+  "lastUpdate": "2026-06-18T06:45:00Z",
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "number-theory",
+    "trigonometry",
+    "algebraic-number-theory",
+    "research"
+  ],
   "problemStatement": {
     "formal": "\\forall \\theta = (m/n)\\pi \\ (m,n\\in\\mathbb{Z}, n\\neq 0),\\ \\cos\\theta\\in\\mathbb{Q} \\implies \\cos\\theta\\in\\{0,\\pm 1/2,\\pm 1\\}",
     "plain": "Niven's theorem (1956): if θ is a rational multiple of π and cos θ is rational, then cos θ ∈ {0, ±1/2, ±1}. Equivalently, the only rational multiples of π whose cosine is rational are the multiples of 90° and 60°.",
@@ -30,19 +37,20 @@
     "goal": "Discharge two_cos_int_of_rational to obtain a sorry-free Niven's theorem; then build, register in Proofs.lean, and add a gallery entry."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "DONE",
     "since": "2026-06-16T00:00:00Z",
     "iteration": 1,
     "focus": "researcher-11 (2026-06-16) wrote proofs/Proofs/NivenTheorem.lean: the main theorem `niven` and the core lemma `two_cos_int_of_rational`. The enumeration tail (|cos θ| ≤ 1 ∧ 2 cos θ ∈ ℤ ⇒ cos θ ∈ {0,±1/2,±1}) is fully proved via Real.cos_le_one / Real.neg_one_le_cos / interval_cases / linarith. The algebraic-integer core is a single isolated sorry. Docker build started to verify the tail + statement typecheck; file not yet registered in Proofs.lean.",
-    "blockers": [
-      "Build-blackout via Docker SATURATION: docker-build.sh Proofs.NivenTheorem was SIGTERM-killed during Mathlib cache decompression under 8+ concurrent lean4-arm64 containers (likely OOM). No olean produced — scaffold + tail are build-pending/UNVERIFIED.",
-      "Aristotle MCP DOWN (prove → 404 'Resource not found'), so the known-mathematics core could not be delegated either."
-    ],
-    "nextAction": "On Aristotle recovery: submit two_cos_int_of_rational to prove_file (ideal target — KNOWN mathematics). Else formalize Route A (roots of unity) manually: ζ=exp(θI) is a (2n)-th root of unity hence IsIntegral ℤ; ζ+ζ⁻¹=2cos θ integral; rational algebraic integer ⇒ integer via IsIntegrallyClosed.isIntegral_iff. Confirm Complex.exp_mul_I, isIntegral_algHom_iff, IsIntegrallyClosed.isIntegral_iff first.",
-    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+    "blockers": [],
+    "nextAction": "COMPLETE. PR #25163 (feature/researcher-8-niven-mathlib) MERGED 2026-06-16. proofs/Proofs/NivenTheorem.lean is registered (Proofs.lean:2702), 0 sorry / 0 axiom, and live in the gallery (src/data/proofs/niven-theorem-oq-01/, status=verified, badge=mathlib). No further action — the fleet build on main confirms it compiles. Stale 'Docker blackout / build-pending' blocker text below is from the 2026-06-16 attempt and no longer applies.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
   },
   "knowledge": {
-    "progressSummary": "ATTACK (build-gated, core isolated). Niven's theorem reduced to ONE algebraic-integer lemma two_cos_int_of_rational; the enumeration tail and main statement are sorry-free and depend only on it. File proofs/Proofs/NivenTheorem.lean, ~1 sorry, 0 axioms. Aristotle down (404) this cycle so the known-mathematics core was not delegated; Docker up (scaffold build started). Routes A (roots of unity) and B (monic Chebyshev) documented with Mathlib lemma candidates.",
+    "progressSummary": "COMPLETE & MERGED (PR #25163, 2026-06-16). Niven's theorem presented in Lean by delegating the algebraic-integer core to Mathlib's Real.isIntegral_two_mul_cos_rat_mul_pi (Meiburg-Broshi 2025) + IsIntegral.exists_int_iff_exists_rat, keeping the interval_cases enumeration tail for pedagogy. 0 sorry / 0 axiom, registered in Proofs.lean, gallery entry verified/mathlib. Build-blackout blocker from the original attempt was resolved by the fleet build that merged the PR.",
     "builtItems": [
       "proofs/Proofs/NivenTheorem.lean — statement of niven + two_cos_int_of_rational; enumeration tail proved (interval_cases over 2cos θ ∈ {-2..2}); core isolated as one sorry. Build-pending, not yet registered in Proofs.lean."
     ],

--- a/research/problems/niven-theorem-oq-01/state.md
+++ b/research/problems/niven-theorem-oq-01/state.md
@@ -1,49 +1,38 @@
 # Research State: niven-theorem-oq-01
 
 ## Current State
-**Phase**: DONE (build-pending verification)
+**Phase**: DONE (merged & live)
 **Path**: full
-**Since**: 2026-06-16T04:17:04-07:00
-**Iteration**: 2
+**Since**: 2026-06-18T06:45:00Z
+**Iteration**: 3
 
-## Current Focus
-Proof is COMPLETE. Niven's theorem is already in Mathlib v4.26
-(`Mathlib/NumberTheory/Niven.lean`, Meiburg/Broshi 2025). The gallery entry
-`proofs/Proofs/NivenTheorem.lean` keeps the explicit `interval_cases`
-enumeration tail and discharges the deep algebraic-integer core by delegating
-to Mathlib. **PR #25163 (branch `feature/researcher-8-niven-mathlib`) carries
-the full discharge — OPEN, build-pending.**
+## Outcome — COMPLETE
+Niven's theorem is formalized, machine-checked, and live in the gallery.
 
-## Active Approach
-Mathlib delegation (no from-scratch formalization needed):
-- Core lemma `two_cos_int_of_rational`: `2·cos θ ∈ ℤ` when `θ = (m/n)π` and
-  `cos θ ∈ ℚ`. Proved via
-  `Real.isIntegral_two_mul_cos_rat_mul_pi (m/n)` (gives `IsIntegral ℤ (2 cos θ)`)
-  then `IsIntegral.exists_int_iff_exists_rat` (a rational algebraic integer is an
-  integer). The from-scratch orphan `NivenTheoremCore.lean` was DELETED.
+- **PR #25163** (`feature/researcher-8-niven-mathlib`) — **MERGED 2026-06-16T20:34Z**.
+- `proofs/Proofs/NivenTheorem.lean` — **registered** at `proofs/Proofs.lean:2702`
+  (`import Proofs.NivenTheorem`), **0 sorry / 0 axiom / no native_decide**.
+- Gallery entry `src/data/proofs/niven-theorem-oq-01/` — `status: verified`,
+  `badge: mathlib`, `axiomCount: 0`, `sorries: 0`.
 
-## Name-check verification (offline Mathlib, blackout substitute for Docker build)
-Confirmed both names exist at the exact build pin
-(`/Users/rwalters/GitHub/mathlib4` @ 2df2f0150c = v4.26.0):
-- `Mathlib/NumberTheory/Niven.lean:72/98` `isIntegral_two_mul_cos_rat_mul_pi`
-  (aliased to `_root_.isIntegral_two_mul_cos_rat_mul_pi`; `Real.` via open).
-- `Mathlib/NumberTheory/Niven.lean:32` `exists_int_iff_exists_rat`.
-- Mathlib's own `niven` proof (line 130) uses the identical
-  `(...).exists_int_iff_exists_rat` pattern, so the PR's
-  `hint.exists_int_iff_exists_rat.mp ⟨2*r, …⟩` is API-sound.
+## What the proof does
+A *presentation* (not original formalization — Niven is already in Mathlib v4.26,
+`Mathlib/NumberTheory/Niven.lean`, Meiburg–Broshi 2025):
 
-## Attempt Count
-- Total attempts: 1 (succeeded, build-pending)
-- Current approach attempts: 1
-- Approaches tried: 1 (Mathlib delegation)
+1. **`two_cos_int_of_rational`** — for `θ = (m/n)·π` with `cos θ ∈ ℚ`, `2·cos θ ∈ ℤ`.
+   Delegates the deep algebraic-integer step to
+   `Real.isIntegral_two_mul_cos_rat_mul_pi (m/n)` (gives `IsIntegral ℤ (2 cos θ)`),
+   then `IsIntegral.exists_int_iff_exists_rat` (a rational algebraic integer is an
+   integer, i.e. `ℤ` integrally closed in `ℚ`).
+2. **`niven`** — enumeration tail kept explicit for pedagogy:
+   `|cos θ| ≤ 1` forces `2 cos θ ∈ {-2,-1,0,1,2}` via `interval_cases`, giving
+   `cos θ ∈ {0, ±1/2, ±1}`.
 
 ## Blockers
-**Dual infra blackout (2026-06-16)** — cannot machine-verify:
-- Docker daemon hangs: `docker info` rc=124 (timeout). `lake build` impossible.
-- Aristotle MCP `prove`: 404 "Resource not found".
-Name-check above is the strongest available verification under blackout.
+None. (The original 2026-06-16 attempt logged a "Docker blackout / build-pending"
+blocker; that was resolved by the fleet build that merged PR #25163. The prior
+state.md text claiming the PR was still open was stale.)
 
 ## Next Action
-When Docker is back: `./proofs/scripts/docker-build.sh Proofs.NivenTheorem`,
-grep the log for `error:`. If green, merge PR #25163. Do NOT re-derive — the
-proof is written and name-checked; only the build remains.
+None — problem complete. Tracker synced to `completed`; the claim pool should no
+longer serve this slug.

--- a/src/data/research/problems/niven-theorem-oq-01.json
+++ b/src/data/research/problems/niven-theorem-oq-01.json
@@ -1,15 +1,22 @@
 {
   "slug": "niven-theorem-oq-01",
   "title": "Niven's Theorem: the only rational cosines at rational multiples of π are 0, ±1/2, ±1",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "significance": 6,
   "tractability": 5,
   "started": "2026-06-16T00:00:00Z",
-  "lastUpdate": "2026-06-16T18:50:00Z",
-  "tags": ["seeker-selected", "analysis", "number-theory", "trigonometry", "algebraic-number-theory", "research"],
+  "lastUpdate": "2026-06-18T06:45:00Z",
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "number-theory",
+    "trigonometry",
+    "algebraic-number-theory",
+    "research"
+  ],
   "problemStatement": {
     "formal": "\\forall \\theta = (m/n)\\pi \\ (m,n\\in\\mathbb{Z}, n\\neq 0),\\ \\cos\\theta\\in\\mathbb{Q} \\implies \\cos\\theta\\in\\{0,\\pm 1/2,\\pm 1\\}",
     "plain": "Niven's theorem (1956): if θ is a rational multiple of π and cos θ is rational, then cos θ ∈ {0, ±1/2, ±1}. Equivalently, the only rational multiples of π whose cosine is rational are the multiples of 90° and 60°.",
@@ -39,7 +46,11 @@
       "Aristotle moot: the core is already a Mathlib lemma, so delegation is unnecessary."
     ],
     "nextAction": "When Docker drains: ./proofs/scripts/docker-build.sh Proofs.NivenTheorem; grep error:. If green, register in Proofs.lean, add gallery entry src/data/proofs/niven-theorem-oq-01/ (framed as a presentation of the Mathlib result), flip status to verified, mark COMPLETED.",
-    "attemptCounts": { "total": 2, "currentApproach": 2, "approachesTried": 2 }
+    "attemptCounts": {
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 2
+    }
   },
   "knowledge": {
     "progressSummary": "RESOLVED (build-pending). Session 2 found Mathlib v4.26.0 already has the full Niven theorem (Mathlib/NumberTheory/Niven.lean) and discharged our last sorry by delegating to Real.isIntegral_two_mul_cos_rat_mul_pi + IsIntegral.exists_int_iff_exists_rat. proofs/Proofs/NivenTheorem.lean: 0 sorry, 0 axioms; names verified vs the exact offline pin. NOT YET BUILT (Docker saturated) and UNREGISTERED in Proofs.lean. Redundant from-scratch NivenTheoremCore.lean deleted. No open mathematics remains — only a build-verify + gallery-presentation step.",


### PR DESCRIPTION
## Summary
Tracker hygiene for `niven-theorem-oq-01`. The research state was **stale**: it
claimed the proof was *"OPEN, build-pending"* under a 2026-06-16 "Docker blackout."
In reality the work already landed:

- **PR #25163** merged 2026-06-16T20:34Z.
- `proofs/Proofs/NivenTheorem.lean` is **registered** (`proofs/Proofs.lean:2702`),
  **0 sorry / 0 axiom**, no `native_decide`.
- Gallery entry `src/data/proofs/niven-theorem-oq-01/` is `status: verified`,
  `badge: mathlib`, `axiomCount: 0`, `sorries: 0`.

The fleet build on `main` confirms it compiles; the old blackout blocker no longer applies.

## What this PR does (tracker-only, no Lean changes)
- `research/problems/niven-theorem-oq-01/meta.json` — `phase: DONE`, `status: completed`, blockers cleared, stale blackout text corrected, progress summary updated to reflect the merge.
- `research/problems/niven-theorem-oq-01/state.md` — rewritten to a COMPLETE outcome summary.
- `src/data/research/problems/niven-theorem-oq-01.json` — `status: completed`.

Also flipped the candidate-pool entry to `completed` (passed the graduation
quality gate) so the claim pool stops re-serving a finished problem — it was
just handed to me this cycle, which is the bug this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)