### PR TITLE
audit(erdos-172): re-audit clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4966,9 +4966,9 @@
       "result": "clean"
     },
     "erdos-172": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:44Z",
+      "lastAudited": "2026-06-18T06:45:02Z",
       "result": "clean"
     },
     "erdos-173": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-172

**Result: CLEAN** — no integrity issues found.

**Proof**: Erdős Problem #172 (Monochromatic Sums and Products) — an OPEN conjecture formalized with axiomatized partial results.

### Verification (`Proofs/Erdos172Problem.lean`, 144 lines)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status / badge | `axiomatized` / `axiom` | open conjecture, 3 axioms | ✅ correct (Tier C) |
| axiomCount | 3 | `moreira_2017`, `alweiss_2023_rationals`, `hindman_1980_counterexample` | ✅ |
| sorries | 0 | 0 | ✅ |
| theoremCount | 4 | 4 | ✅ |
| definitionCount | 6 | 6 | ✅ |
| lineCount | 144 | 144 | ✅ |

### Integrity notes
- **No axiom-masking**: all 3 axioms disclosed in the `assumptions` field; title and description frame the result as an open problem. Consistent with the Axiom Integrity Policy (open conjectures → always `axiomatized`).
- **No delegation opacity / Mathlib wrapper**: Mathlib deps are basic infrastructure (`Finset.sum/prod`, `Set.Infinite`); the core conjecture is not delegated.
- The lone `harmonicSorry666373` string is inside an Aristotle `/- … -/` diagnostic comment block (lines 34–37), **not** a real declaration — confirmed 0 actual sorries.
- `native_decide`: none. True stubs: none.

Tracker: `auditCount` 3 → 4, `lastAudited` bumped, `result: clean`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)