### PR TITLE
audit(erdos-530): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7729,9 +7729,9 @@
       "result": "clean"
     },
     "erdos-530": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:44Z",
+      "lastAudited": "2026-06-18T06:49:21Z",
       "result": "clean"
     },
     "erdos-531": {


### PR DESCRIPTION
## Gallery Integrity Audit — Erdős Problem #530

Re-audit of `erdos-530` (Maximum Sidon Subsets of Finite Sets). **Result: CLEAN.**

### Checks (all match meta.json exactly)
| Metric | meta.json | Lean source | ✓ |
|---|---|---|---|
| Lines | 430 | 430 | ✓ |
| Axioms | 2 | 2 | ✓ |
| Theorems | 17 | 17 | ✓ |
| Definitions | 5 | 5 | ✓ |
| Sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

Registered in `Proofs.lean`. Tier C; `status=axiomatized` / `badge=axiom` correct.

### Axiom-masking: NONE
Both axioms are fully disclosed:
- `komlos_sulyok_szemeredi` — KSS deep-known √N lower bound (legitimate to axiomatize)
- `alon_erdos_partition_conjecture` — open problem (stated, not used in headline)

The `assumptions` field names both; the conclusion summary explicitly labels KSS as "(axiom)"; `erdosProblemStatus: open`; description says "OPEN". The headline `erdos530_corrected_proof` derives ℓ(N)=Θ(√N) from the KSS axiom plus a genuinely-proved interval upper bound (`sidon_subset_interval_bound`, fully proved via sum counting). Narrative honestly notes the original problem statement was flawed (powers of 2 counterexample) and the corrected version fixes it.

`auditCount` 3→4.

---
Discovered during gallery integrity audit.