### PR TITLE
audit(kaprekar-constant-oq-01): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15861,8 +15861,14 @@
       "issues": [],
       "lastAudited": "2026-06-18T06:13:33Z",
       "result": "clean"
+    },
+    "kaprekar-constant-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T06:52:09Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T06:13:33Z"
+  "lastUpdated": "2026-06-18T06:52:09Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — `kaprekar-constant-oq-01`

**Result: CLEAN** — no integrity issues.

Verified the gallery entry against the Lean source `proofs/Proofs/KaprekarConstantOQ01.lean` (committed in main via #25150).

### Checks
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| theorems | 6 | 6 | ✅ |
| definitions | 3 | 3 | ✅ |
| lineCount | 106 | 106 | ✅ |
| sorries | 0 | 0 | ✅ |
| `axiom` declarations | 0 (`leanFile.axiomCount`) | 0 | ✅ |
| True stubs | — | 0 | ✅ |

### native_decide convention (per CLAUDE.md)
Three substantive presented results are discharged by `native_decide`:
`kaprekar_converges_all`, `kaprekar_unique_fixed_all`, `kaprekar_bound_sharp`.

The entry correctly applies the conservative convention:
- `status: axiomatized`, `badge: axiom`
- `meta.axiomCount: 1`, `leanFile.axiomCount: 0`
- `Lean.ofReduceBool` disclosed in `assumptions`, `description`, and `conclusion`

`kaprekar_fixed` uses kernel `decide` (axiom-free), correctly disclosed as such.

**No axiom masking, no overclaiming.** Tracker bumped (`auditCount` 1, `result: clean`).

---
Discovered during gallery integrity audit.