### PR TITLE
audit(erdos-1160): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4326,9 +4326,9 @@
       "result": "clean"
     },
     "erdos-1160": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:45Z",
+      "lastAudited": "2026-06-18T06:58:00Z",
       "result": "clean"
     },
     "erdos-1161": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1160

**Result: CLEAN** — all meta.json claims match the Lean source.

**Proof**: Erdős Problem #1160 (group counting function maximized at powers of 2)
**Tier**: C (axiomatized) — open conjecture
**Source**: `proofs/Proofs/Erdos1160Problem.lean`

### Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 329 | 329 | ✓ |
| axiomCount | 10 | 10 (`^axiom`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 24 | 24 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| status/badge | axiomatized / axiom | open conjecture | ✓ |

### Integrity notes
- **No axiom masking**: the main conjecture `erdos_1160` is an unproved `Prop` def. Only small/special cases are proved as theorems (n=1, prime n, m≤4 exhaustive checks, power-of-two, the strong⇒original implication). Title/description correctly frame it as a conjecture; `erdosProblemStatus: "open"`.
- All 10 axioms (group counting function + structural values) are disclosed in the `assumptions` field and Section I.
- `pantelidakis_odd_theorem` and `numGroups_two_power_growth_theorem` are unproved `Prop` defs (stated known results), correctly disclosed as "unused known results".

Tracker bump only: `auditCount` 3→4, `lastAudited` updated.

---
Discovered during gallery integrity audit.