### PR TITLE
audit(derangements): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2322,9 +2322,9 @@
       "result": "clean"
     },
     "derangements": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:45Z",
+      "lastAudited": "2026-06-18T07:02:21Z",
       "result": "clean"
     },
     "derangements-convergence": {


### PR DESCRIPTION
## Gallery Integrity Audit — derangements (Wiedijk #88)

Re-audit of the `derangements` gallery entry against `proofs/Proofs/Derangements.lean`. **Result: clean — no integrity issues.**

### Verified against source

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 227 | 227 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, 0 structure assumptions | ✓ |
| theoremCount | 10 | 10 named theorems | ✓ |
| definitionCount | 0 | 0 | ✓ |
| status / badge | verified / mathlib | correct (Tier B) | ✓ |

### native_decide assessment

5 `native_decide` calls (`numDerangements 2 = 1` … `numDerangements 6 = 265`) appear **only in anonymous `example` blocks** — incidental concrete computations, not the substantive headline result. The headline theorems (recurrence, closed form, cardinality bridge) delegate to Mathlib's `Combinatorics.Derangements`; the two genuinely original results (`one_not_mem_derangements`, `derangement_mul_self_not_always_derangement`) are kernel-verified without `native_decide`. Per the axiom-integrity policy, `ofReduceBool` disclosure applies only when `native_decide` discharges a substantive presented-as-verified result — not the case here. `verified` / 0 axioms is correct.

### Narrative checks
- **No delegation opacity**: overview/description explicitly credit Mathlib's derangement module.
- **No axiom masking**: no axioms present.
- **originalContributions correctly scoped** to the two new proofs + computations + pedagogical presentation.

Tracker: `auditCount` 3 → 4, `lastAudited` refreshed.

---
Discovered during autonomous gallery integrity audit. Tracker-only change.