### PR TITLE
fix: remove tracked self-referential proofs/.lake symlink

### DIFF
--- a/proofs/.gitignore
+++ b/proofs/.gitignore
@@ -1,4 +1,5 @@
 # Lake build artifacts
+.lake
 .lake/
 lake-packages/
 

--- a/proofs/.lake
+++ b/proofs/.lake
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/proofs/.lake


### PR DESCRIPTION
## Summary

`proofs/.lake` is committed to `main` (since #22746) as a **symlink whose target is its own absolute path**:

```
$ git cat-file -p $(git ls-files -s proofs/.lake | awk '{print $2}')
/Users/rwalters/GitHub/lean-genius/proofs/.lake
$ ls proofs/.lake/packages
ls: proofs/.lake/packages/: Too many levels of symbolic links
```

It is a machine-specific, self-referential link on `origin/main`, so **every checkout and worktree across the fleet inherits it**.

## Why this is wrong

- `.gitignore` already lists `.lake/` — the intent is for `.lake` to be a **local, untracked Lake build directory**, never a tracked symlink. The symlink was almost certainly slurped by a `git add -A` in an audit tracker commit (#22746).
- Docker builds *tolerate* it (the cache-volume bind-mount at `/workspace/proofs/.lake/build` shadows the link inside the container — e.g. a full 7743-job build succeeded today), but it breaks **all host-side tooling**: `pnpm build`, host `lake`, the IDE, and even `ls`/`find` choke on the link.
- It has caused several research sessions to **misdiagnose a "build blackout"** as rooted in `.lake` and to self-censor builds.

## Change

- `git rm --cached proofs/.lake` — untrack it. Lake/Docker recreate the real `.lake` build dir locally as needed (it's gitignored).
- Add a bare `.lake` rule to `proofs/.gitignore` so a stray `.lake` symlink/file can't be re-tracked (the existing `.lake/` rule only matches a directory).

## Verification

By inspection — no build required. After the change, `git ls-files proofs/.lake` returns nothing, and there is no tracked path under `proofs/.lake`. Docker builds are unaffected (the container shadows `.lake` via the cache-volume mount regardless).

🤖 Generated by researcher-1