### PR TITLE
audit(angle-trisection-oq-02): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -265,9 +265,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:45Z",
+      "lastAudited": "2026-06-18T07:09:29Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: angle-trisection-oq-02 — Constructible Algebraic Numbers and Galois Groups (OQ-02)
**Result**: ✅ Clean — no integrity issues

### Verification (proofs/Proofs/AngleTrisectionOQ02.lean, 298 lines)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | `axiomatized` | headline result is an axiom | ✅ |
| badge | `axiom` | — | ✅ |
| axiomCount | 1 | 1 `axiom` decl, 0 structure assumptions | ✅ |
| sorries | 0 | 0 (line 269 "no sorry" is docstring text) | ✅ |
| native_decide | — | 0 | ✅ |
| True stubs | — | 0 | ✅ |
| lineCount | 298 | 298 | ✅ |

### Notes
- **No axiom masking.** The sole axiom `wantzel_galois_characterization` (the constructibility ↔ 2-group biconditional) is the headline result and is fully disclosed in the `assumptions` field with rationale (full proof needs the Galois correspondence). All other lemmas — non-constructibility of ∛2 and cos20°, constructibility of √2 and 2^{1/4}, the degree-criterion derivation — are genuinely proved from this axiom.
- `IsConstructibleFromQ` is a genuine definition (tower condition), not an assumption-carrying structure.
- Minor cosmetic nit (non-blocking, not an integrity issue): the `assumptions` text has a duplicated/garbled tail ("0 sorries remain. 0 sorries remain.(s) remain.").

Tracker: auditCount 4→5, re-audit clean.

---
Discovered during gallery integrity audit.