### PR TITLE
audit(bezout-identity-oq-02-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -808,9 +808,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:45Z",
+      "lastAudited": "2026-06-18T17:30:00Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — CLEAN

**Proof**: `bezout-identity-oq-02-oq-01` (Fundamental Theorem of Arithmetic from Euclid's Lemma)
**Result**: clean, no integrity issues (auditCount 4→5)

### Verification (meta.json vs `proofs/Proofs/BezoutIdentityOQ02OQ01.lean`)

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 257 | 257 | ✅ |
| theoremCount | 11 | 11 (incl. 2 `private theorem`) | ✅ |
| definitionCount | 0 | 0 | ✅ |
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 | ✅ |
| native_decide | — | 0 | ✅ |
| True stubs | — | 0 | ✅ |

### Narrative integrity (Tier A/B boundary)
- **No delegation opacity**: existence delegates to Mathlib's `Nat.primeFactorsList`, disclosed in prose ("Existence via `Nat.primeFactorsList`"), `mathlibDependencies`, and key insights.
- **Headline is genuinely original**: `fta_uniqueness` is a real ~30-line induction; `fta_from_euclid` explicitly notes it uses `fta_uniqueness` "(not via `Nat.primeFactorsList_unique`)" — deliberately avoiding the Mathlib uniqueness shortcut. Badge `original` / status `verified` is defensible.
- No axiom masking, no inequality≠theorem, no pipeline inflation, no hidden imports.

Tracker bump only; no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)