### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields-oq-03): S6 — PID build-readiness re-audit + operator↔K[X] bridge recipe

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03/state.md
@@ -1,8 +1,73 @@
 # Current State
 
-**Phase**: ACT — field/operator half COMPLETE + REGISTERED; PID-module half WRITTEN (165-line companion, 0 sorry/0 axiom, UNREGISTERED, build-pending) — proof simplified, no structure-theorem/length machinery
+**Phase**: ACT — field/operator half COMPLETE + REGISTERED; PID-module half WRITTEN + MERGED (#25497, 0 sorry/0 axiom, still UNREGISTERED, build-pending); operator↔K[X] bridge now has a build-ready recipe (key Mathlib lemma `span_minpoly_eq_annihilator` + worked `NormalBasis.lean` template located)
 **Since**: 2026-06-16 (S3 gallery annotation re-anchor under triple blackout — researcher-8)
-**Iteration**: 5
+**Iteration**: 6
+
+## S6 (2026-06-18, researcher-2): PID file build-readiness RE-CONFIRMED + operator↔K[X] bridge recipe (the real remaining content)
+
+**Status reality check.** The PID companion `CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean`
+written in S5 is now **MERGED to origin/main via PR #25497** (commit `6549be30187`), 0 sorry / 0
+axiom — but it is **still UNREGISTERED in `Proofs.lean` and has never been built**. So the only
+gating step for direction (b) remains a single green `docker-build.sh` run + registration.
+
+**Independent build-readiness audit (this session, vs offline pin `2df2f0150c` = v4.26.0).**
+Re-verified every external bearer the merged file references, with exact file:line, AND checked the
+tactic steps are sound:
+- `LinearMap.toSpanSingleton` `Span/Basic.lean:702` (`@[simps!]` ⇒ `toSpanSingleton_apply` exists);
+  `range_toSpanSingleton` `:751`.
+- `LinearMap.quotKerEquivOfSurjective` / `quotKerEquivRange` `Isomorphisms.lean:45/39`.
+- `LinearMap.range_eq_top` `Submodule/Range.lean:95`.
+- `Module.annihilator` / `Module.mem_annihilator` `Ideal/Maps.lean:820/822`; `(annihilator).IsTwoSided`
+  instance `:825` (needed for the next lemma).
+- `Ideal.Quotient.span_singleton_one (I) [I.IsTwoSided] : Submodule.span A {(1 : A⧸I)} = ⊤`
+  `Ideal/Quotient/Operations.lean:483`.
+- `Module.exists_ker_toSpanSingleton_eq_annihilator [Module.Finite R M]` `Algebra/Module/PID.lean:273`
+  (in `namespace Module`; `variable (R M)` is explicit at `:254`, so the file's named-arg call
+  `(R := R) (M := M)` is correct).
+The `smul_comm` step is fine (`CommRing R ⇒ SMulCommClass R R M`). **No bearer or tactic-soundness
+issue found — the file should build green on first try.** (Only residual risk, as S5 flagged: the
+`rw [hx] at e` type-rewrite inside the equiv type in `exists_injective_quotient_annihilator_hom`.)
+
+**Operator↔K[X] bridge — now a build-ready recipe, not a vague "optionally specialize".**
+S5's step 4 ("specialize R:=K[X], M:=V") is the genuine remaining *content* of OQ-03 (it's what the
+problem literally asks: recognize the matrix theorem as an instance of the PID structure theorem via
+`V` as a `K[X]`-module). The infrastructure is all in Mathlib at pin and far lighter than the old
+"heavy AEval bridge" gap estimate:
+- **`Module.AEval' T`** (`Algebra/Polynomial/Module/AEval.lean`): `V` with `X` acting as `T`, for
+  `T : Module.End K V` (= `V →ₗ[K] V`). Canonical equiv `AEval'.of T : V ≃ₗ[K] AEval' T` (`:198`);
+  `AEval'.X_pow_smul_of : Xⁿ • of v = of ((T^n) • v)` (`:205`);
+  instance `Module.Finite K[X] (AEval' T)` when `FiniteDimensional K V` (`:93/211`).
+- **`Module.span_minpoly_eq_annihilator (T) : Ideal.span {minpoly K T} = Module.annihilator K[X] (AEval' T)`**
+  (`LinearAlgebra/AnnihilatingPolynomial.lean:166`) — the linchpin: identifies the K[X]-annihilator
+  with the minpoly ideal, so "order ideal = char ideal" becomes literally `minpoly K T`.
+- **Worked template: `FieldTheory/Galois/NormalBasis.lean:38-58`** uses *exactly* this combo
+  (`exists_ker_toSpanSingleton_eq_annihilator K[X] (AEval' …)` + `span_minpoly_eq_annihilator` +
+  `AEval'.X_pow_smul_of`) to build a cyclic generator. Mirror it.
+
+Draft statements for a new companion `…OQ03Bridge.lean` (imports
+`Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ03PID` to reuse `cyclic_iff_nonempty_equiv_quotient_annihilator`):
+
+    -- Corollary of the merged PID theorem + span_minpoly_eq_annihilator (LOW risk: ~2 rewrites,
+    -- watch the quotient-type motive when rewriting ann → span{minpoly}).
+    theorem aeval_cyclic_iff_equiv_quot_minpoly (T : V →ₗ[K] V) [FiniteDimensional K V] :
+        (∃ w : Module.AEval' T, Submodule.span K[X] {w} = ⊤) ↔
+          Nonempty (Module.AEval' T ≃ₗ[K[X]] K[X] ⧸ Ideal.span {minpoly K T})
+
+    -- Orbit dictionary (HARDER: the genuinely new lemma; transfer span ⊤ across AEval'.of using
+    -- X_pow_smul_of so K[X]·of(v) = of(K-span{Tⁿv})). This is the right Aristotle target once the
+    -- MCP 404 clears.
+    theorem aeval_cyclic_iff_krylov_span_top (T : V →ₗ[K] V) [FiniteDimensional K V] :
+        (∃ w : Module.AEval' T, Submodule.span K[X] {w} = ⊤) ↔
+          (∃ v : V, Submodule.span K (Set.range fun n : ℕ => (T ^ n) v) = ⊤)
+
+Composing the two recovers OQ-03's headline "T nonderogatory (minpoly = charpoly) ⟺ T has a cyclic
+vector" in the K[X]-module vocabulary, completing the conceptual ask of the problem.
+
+**Blackout this session:** BOTH `docker info` (rc=124, daemon unresponsive, load ~19) AND Aristotle
+MCP `prove` (`Resource not found`, 404) are down — could not build or auto-prove, so deliberately did
+NOT blind-commit the bridge `.lean` (the orbit dictionary needs build iteration). Recipe above is the
+ready artifact for the next Docker-up / Aristotle-up session.
 
 ## S5 (2026-06-17, researcher-9): PID half WRITTEN — proof simplified, structure-theorem/length machinery ELIMINATED
 

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-03.json
@@ -17,9 +17,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-15T22:10:00.000Z",
-    "iteration": 3,
-    "focus": "Registered OQ03 in Proofs.lean (completing #24793 oversight); build-pending to flip wip->verified",
+    "since": "2026-06-18T00:30:00.000Z",
+    "iteration": 6,
+    "focus": "PID half MERGED (#25497) but unregistered/build-pending; build-readiness re-audited green; operator->K[X] bridge recipe ready (span_minpoly_eq_annihilator + AEval').",
     "blockers": [
       "Docker contention (>=3 lean-build containers on a 7.65GB VM) blocks local build",
       "Aristotle backend returning 404"
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: operator half (#24793) merged but was UNREGISTERED in Proofs.lean and never built. This session registers it so the aggregate build covers it. Build-pending under Docker contention (3 lean-build containers on 7.65GB VM); flips wip->verified on first green build. PID-module half remains a deep documented gap.",
+    "progressSummary": "PROGRESS: direction (b) PID companion CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean is MERGED to origin/main (PR #25497, 0 sorry/0 axiom) but still UNREGISTERED in Proofs.lean and never built -- single green docker-build + registration flips direction (b) to verified. S6 (researcher-2) independently re-audited all 9 external bearers vs offline pin 2df2f0150c: no bearer/tactic-soundness issue, file should build green. S6 also located the operator->K[X] bridge infrastructure (Module.span_minpoly_eq_annihilator + AEval' API + NormalBasis.lean template), turning S5's vague 'optionally specialize to K[X]' into a build-ready recipe with exact draft statements (see state.md S6). Both Docker (rc=124) and Aristotle MCP (404) in blackout this session -- no build/auto-prove possible; recipe is the ready artifact.",
     "builtItems": [
       "operator_nonderogatory_has_cyclic_vector in CayleyHamiltonCyclicVectorAllFieldsOQ03.lean: nonderogatory operator (minpoly natDegree = finrank) has a cyclic vector",
       "matrix_nonderog_of_minpoly_natDegree: (minpoly K M).natDegree = n implies minpoly = charpoly (monic-cofactor argument on minpoly | charpoly)",
@@ -47,12 +47,12 @@
     ],
     "mathlibGaps": [
       "No Mathlib lemma directly gives the operator-level nonderogatory-implies-cyclic statement; it must be assembled by basis reduction (done here).",
-      "PID direction needs the structure theorem for finitely generated modules over a PID plus a coprime cyclic-recombination lemma (CRT); estimated > 500 lines, not yet attempted."
+      "RESOLVED (S6): the operator<->K[X] bridge is NOT a heavy gap. Module.span_minpoly_eq_annihilator (LinearAlgebra/AnnihilatingPolynomial.lean:166) gives ann_{K[X]}(AEval' T) = span{minpoly K T} directly; AEval'.X_pow_smul_of (Algebra/Polynomial/Module/AEval.lean:205) gives the Krylov orbit dictionary; NormalBasis.lean:38-58 is a worked template combining both."
     ],
     "nextSteps": [
-      "Build under Docker when contention clears (<=2 lean-build containers) and flip badge wip->verified if green.",
-      "Bridge IsCyclicVectorOp to Mathlib's K[X]-module cyclicity (Module.AEval) as the stepping stone to the PID structure theorem.",
-      "Attempt the PID-module generalization via Module.equiv_directSum_of_isTorsion and coprime cyclic recombination (>500 lines, deferred)."
+      "Single Docker-up session (<=2 lean-build containers): docker-build.sh Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ03PID; on GREEN register in Proofs.lean + add gallery dir + flip direction (b) to verified/mathlib.",
+      "Write companion ...OQ03Bridge.lean per the S6 recipe: aeval_cyclic_iff_equiv_quot_minpoly (low risk, ~2 rewrites via cyclic_iff_nonempty_equiv_quotient_annihilator + span_minpoly_eq_annihilator) and aeval_cyclic_iff_krylov_span_top (orbit dictionary -- the genuinely new lemma; good Aristotle target once MCP 404 clears).",
+      "Composing the two bridge theorems recovers OQ-03's headline 'nonderogatory (minpoly=charpoly) <-> cyclic vector' in K[X]-module vocabulary, completing the conceptual ask."
     ]
   },
   "tags": [
@@ -86,7 +86,7 @@
     ]
   },
   "started": "2026-06-15T19:32:03.122Z",
-  "lastUpdate": "2026-06-15T22:10:00.000Z",
+  "lastUpdate": "2026-06-18T00:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",


### PR DESCRIPTION
## Summary

Research session S6 on **cayley-hamilton-cyclic-vector-all-fields-oq-03** (Coordinate-Free Cyclic Vector: Single Operator and PID Modules). Documentation/recipe contribution — **no Lean committed** (both Docker and Aristotle in blackout this session).

### Context
- Direction (a) (operator cyclic-vector theorem) — done, registered, verified.
- Direction (b) PID companion `CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean` — **merged (PR #25497, 0 sorry/0 axiom)** but still **UNREGISTERED in `Proofs.lean` and never built**.

### What this session did
1. **Independent build-readiness re-audit** of the merged PID file against the offline mathlib4 pin `2df2f0150c` (v4.26.0): all 9 external bearers resolve with exact file:line, and the tactic steps are sound. No bearer/soundness issue — the file should build green on first try. A single `docker-build.sh` + registration flips direction (b) to verified.

2. **Located the operator↔K[X] bridge infrastructure**, turning S5's vague "optionally specialize to K[X]" into a build-ready recipe:
   - `Module.span_minpoly_eq_annihilator` — `ann_{K[X]}(AEval' T) = span{minpoly K T}` (`LinearAlgebra/AnnihilatingPolynomial.lean:166`).
   - `Module.AEval'` API — `of` / `X_pow_smul_of` / `Module.Finite K[X] (AEval' T)` instance.
   - Worked template `FieldTheory/Galois/NormalBasis.lean:38-58` combining exactly these.
   - Exact draft statements for the two bridge theorems recorded in `state.md` S6.

### Blackout note
Both `docker info` (rc=124, daemon unresponsive, load ~19) and Aristotle MCP `prove` (`Resource not found`, 404) were down — no build or auto-prove possible. The orbit-dictionary theorem needs build iteration, so it was deliberately **not** blind-written; the S6 recipe is the ready artifact for the next Docker-up / Aristotle-up session.

### Files
- `research/problems/.../state.md` — S6 section.
- `src/data/research/problems/....json` — knowledge block (progressSummary, mathlibGaps, nextSteps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)