### PR TITLE
audit(bezout-identity-oq-02-oq-02): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -850,9 +850,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:29:45Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: bezout-identity-oq-02-oq-02 (Euclid's Lemma in Bézout Domains and PIDs)
**Result**: clean — no integrity issues. 5th audit.

### Checks (all match meta.json)
| Check | meta | source | ok |
|-------|------|--------|----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 285 | 285 | ✓ |

### Tier classification
`verified` / `original` is **defensible**. The headline `euclids_lemma_ring` proves Euclid's lemma in any `CommRing` via a genuine from-axioms `linear_combination v * hk - c * huv` ring-identity proof — it destructs the `IsCoprime` existential and supplies an explicit witness, rather than wrapping Mathlib's `IsCoprime.dvd_of_dvd_mul_right`. So it is genuinely Tier A original, not a Mathlib bridge.

Secondary results (`isBezout_relPrime_to_isCoprime`, `irred_iff_prime_decomp`) do delegate to Mathlib (`IsBezout.span_pair_isPrincipal`, `irreducible_iff_prime`), but **all such delegations are disclosed** in `mathlibDependencies` and credited in `originalContributions`. No delegation opacity, no axiom masking, no inequality-vs-theorem, no pipeline inflation.

### Nit (non-blocking)
Section `euclids-ring` mathContext says the proof "Uses `IsCoprime.dvd_of_dvd_mul_right` from Mathlib", but the actual proof uses `linear_combination`. This *under*-attributes originality (no overclaim) — cosmetic only.

Only the audit-tracker entry is updated (auditCount 4→5).

---
Discovered during gallery integrity audit.