### PR TITLE
Research: Kaprekar OQ01 — shrink trusted surface (structural uniqueness + witnessed sharpness)

### DIFF
--- a/proofs/Proofs/KaprekarConstantOQ01.lean
+++ b/proofs/Proofs/KaprekarConstantOQ01.lean
@@ -34,10 +34,17 @@ four-digit strings and are discharged by `native_decide`.
 
 ## Status
 
-The single-point fact `kaprekar_fixed` is kernel-checked (`decide`).  The
-finite-domain enumerations (`kaprekar_converges`, `kaprekar_unique_fixed`,
-`kaprekar_bound_sharp`) use `native_decide` and therefore depend on the
-`Lean.ofReduceBool` axiom (compiled evaluation of a decidable proposition).
+`kaprekar_fixed` is kernel-checked (`decide`).  `kaprekar_unique_fixed` is derived
+*structurally* from convergence (a fixed point is unchanged by seven iterations,
+which equal `6174`), and `kaprekar_bound_sharp` is witnessed by the single string
+`0014` via `decide`.  Only the bounded-convergence enumeration `kaprekar_converges_all`
+uses `native_decide`, so `Lean.ofReduceBool` (compiled evaluation of a decidable
+proposition) is the file's sole non-foundational axiom.
+
+A fully `decide`-checked (0-axiom) version is sketched in the problem knowledge base:
+`kaprekarStep n` factors through the digit multiset (`kaprekarStep n = kaprekarStep
+(canon n)`), reducing the convergence enumeration from 10000 four-digit strings to the
+715 sorted-digit representatives, which kernel `decide` can plausibly discharge.
 -/
 
 namespace KaprekarConstantOQ01
@@ -85,22 +92,19 @@ theorem kaprekar_converges (n : ℕ) (h : n < 10000) (hn : NonRepdigit n) :
     kaprekarStep^[7] n = 6174 :=
   kaprekar_converges_all n (Finset.mem_range.mpr h) hn
 
-/-- **Uniqueness of the fixed point (enumerated form).** Among the four-digit
-strings with not all digits equal, `6174` is the only fixed point of `T`. -/
-theorem kaprekar_unique_fixed_all :
-    ∀ n ∈ Finset.range 10000, NonRepdigit n → kaprekarStep n = n → n = 6174 := by
-  native_decide
-
-/-- **Uniqueness of the fixed point.** `6174` is the unique nonzero fixed point of
-Kaprekar's routine on four-digit non-repdigit strings. -/
+/-- **Uniqueness of the fixed point.** `6174` is the unique fixed point of Kaprekar's
+routine on four-digit non-repdigit strings.  No separate enumeration is needed: a fixed
+point `n` is unchanged by *seven* iterations (`Function.iterate_fixed`), and seven
+iterations land on `6174` by `kaprekar_converges`, so `n = 6174`. -/
 theorem kaprekar_unique_fixed (n : ℕ) (h : n < 10000) (hn : NonRepdigit n)
     (hf : kaprekarStep n = n) : n = 6174 :=
-  kaprekar_unique_fixed_all n (Finset.mem_range.mpr h) hn hf
+  (Function.iterate_fixed hf 7).symm.trans (kaprekar_converges n h hn)
 
-/-- **The bound is sharp.** Some four-digit non-repdigit string needs the full seven
-steps: six are not enough. -/
+/-- **The bound is sharp.** The string `0014` still differs from `6174` after six
+steps (`kaprekarStep^[6] 14 = 4176`), so seven steps are sometimes necessary.  A single
+concrete witness suffices, checked by kernel `decide`. -/
 theorem kaprekar_bound_sharp :
-    ∃ n ∈ Finset.range 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174 := by
-  native_decide
+    ∃ n ∈ Finset.range 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174 :=
+  ⟨14, Finset.mem_range.mpr (by omega), by decide, by decide⟩
 
 end KaprekarConstantOQ01

--- a/proofs/Proofs/KaprekarConstantOQ01ZeroAxiom.lean
+++ b/proofs/Proofs/KaprekarConstantOQ01ZeroAxiom.lean
@@ -1,0 +1,142 @@
+import Mathlib
+
+/-!
+# Kaprekar's constant 6174 — axiom-free (kernel `decide`) variant
+
+This is a companion to `Proofs.KaprekarConstantOQ01`.  The main file discharges the
+bounded-convergence enumeration with `native_decide`, which trusts the compiler and so
+depends on `Lean.ofReduceBool`.  This file removes that dependency: the convergence
+enumeration is reduced from the 10000 four-digit strings to the **715 sorted-digit
+representatives** and discharged by the *kernel* `decide`, leaving the file with no
+non-foundational axioms.
+
+## The reduction
+
+`kaprekarStep` depends only on the *multiset* of digits: it sorts them before taking
+the descending-minus-ascending difference.  Concretely, with
+
+```
+canon n = recombine (sortAsc4 (digits n))
+```
+
+the canonical form `canon n` has the same digits as `n` but already in ascending order,
+and `kaprekarStep (canon n) = kaprekarStep n`.  Peeling one iterate then gives
+`kaprekarStep^[7] n = kaprekarStep^[7] (canon n)`, so it suffices to check convergence on
+canonical inputs.  The enumeration
+
+```
+conv_canon : ∀ n < 10000, canon n = n → NonRepdigit n → kaprekarStep^[7] n = 6174
+```
+
+still ranges over `n < 10000`, but the decidable guard `canon n = n` short-circuits the
+~9285 non-canonical strings *before* the heavy `^[7]` reduction runs, so the kernel only
+performs the 715 seven-step reductions.
+
+## BUILD STATUS — UNVERIFIED (tooling blackout)
+
+This file was written under a Docker/Aristotle blackout and is **not yet machine-checked**.
+The structural lemmas (`kaprekarStep_canon`, `iterate7_canon`, the `canon` facts) are
+routine `omega` arithmetic over `min`/`max` and div/mod-by-literal; the single open
+feasibility question is whether the kernel `decide` in `conv_canon` completes in time on
+715 seven-step reductions (GMP-accelerated Nat literals make this plausible but unconfirmed).
+If `conv_canon`'s `decide` proves infeasible, fall back to `native_decide` there — the
+uniqueness and sharpness results stay axiom-free regardless.  **Do not advertise this file
+as verified / 0-axiom until `./proofs/scripts/docker-build.sh Proofs.KaprekarConstantOQ01ZeroAxiom`
+is green.**
+-/
+
+namespace KaprekarConstantOQ01ZeroAxiom
+
+/-- Sort four naturals ascending via a five-comparator sorting network. -/
+def sortAsc4 (a b c d : ℕ) : ℕ × ℕ × ℕ × ℕ :=
+  let a' := min a b; let b' := max a b
+  let c' := min c d; let d' := max c d
+  let a'' := min a' c'; let c'' := max a' c'
+  let b'' := min b' d'; let d'' := max b' d'
+  let b''' := min c'' b''; let c''' := max c'' b''
+  (a'', b''', c''', d'')
+
+/-- One step of Kaprekar's routine on the four-digit decimal string of `n`. -/
+def kaprekarStep (n : ℕ) : ℕ :=
+  let a := n / 1000 % 10
+  let b := n / 100 % 10
+  let c := n / 10 % 10
+  let d := n % 10
+  let s := sortAsc4 a b c d
+  let w := s.1; let x := s.2.1; let y := s.2.2.1; let z := s.2.2.2
+  (z * 1000 + y * 100 + x * 10 + w) - (w * 1000 + x * 100 + y * 10 + z)
+
+/-- Canonical form: the same four digits written in ascending order. -/
+def canon (n : ℕ) : ℕ :=
+  let a := n / 1000 % 10
+  let b := n / 100 % 10
+  let c := n / 10 % 10
+  let d := n % 10
+  let s := sortAsc4 a b c d
+  s.1 * 1000 + s.2.1 * 100 + s.2.2.1 * 10 + s.2.2.2
+
+/-- The four-digit string of `n` does not have all digits equal. -/
+def NonRepdigit (n : ℕ) : Prop :=
+  ¬ (n / 1000 % 10 = n / 100 % 10 ∧ n / 100 % 10 = n / 10 % 10 ∧
+      n / 10 % 10 = n % 10)
+
+instance (n : ℕ) : Decidable (NonRepdigit n) := by unfold NonRepdigit; infer_instance
+
+/-- `kaprekarStep` only depends on the digit multiset, so it is unchanged by
+canonicalisation.  Both sides reduce to descending-minus-ascending of the same four
+sorted digits; `omega` discharges the div/mod/`min`/`max` bookkeeping. -/
+theorem kaprekarStep_canon (n : ℕ) : kaprekarStep (canon n) = kaprekarStep n := by
+  simp only [kaprekarStep, canon, sortAsc4]
+  omega
+
+/-- Peeling one iterate: `kaprekarStep^[7] n = kaprekarStep^[7] (canon n)`. -/
+theorem iterate7_canon (n : ℕ) :
+    kaprekarStep^[7] n = kaprekarStep^[7] (canon n) := by
+  have e : ∀ m, kaprekarStep^[7] m = kaprekarStep^[6] (kaprekarStep m) := fun m => by
+    rw [show (7 : ℕ) = 6 + 1 from rfl, Function.iterate_succ_apply]
+  rw [e n, e (canon n), kaprekarStep_canon]
+
+/-- `canon n` is a four-digit string. -/
+theorem canon_lt (n : ℕ) : canon n < 10000 := by
+  simp only [canon, sortAsc4]; omega
+
+/-- Canonicalisation is idempotent: a sorted string is its own canonical form. -/
+theorem canon_idem (n : ℕ) : canon (canon n) = canon n := by
+  simp only [canon, sortAsc4]; omega
+
+/-- Canonicalisation preserves the not-all-equal property (it only permutes digits). -/
+theorem nonRepdigit_canon (n : ℕ) (hn : NonRepdigit n) : NonRepdigit (canon n) := by
+  simp only [NonRepdigit, canon, sortAsc4] at hn ⊢
+  omega
+
+/-- **Bounded convergence on canonical representatives.** Ranging over `n < 10000`, the
+decidable guard `canon n = n` keeps only the 715 sorted-digit strings, so the kernel runs
+just those seven-step reductions.  Discharged by kernel `decide` (no `Lean.ofReduceBool`). -/
+theorem conv_canon :
+    ∀ n < 10000, canon n = n → NonRepdigit n → kaprekarStep^[7] n = 6174 := by
+  decide
+
+/-- **Bounded convergence (general form), axiom-free.** Every four-digit non-repdigit
+string reaches `6174` within seven steps. -/
+theorem kaprekar_converges (n : ℕ) (h : n < 10000) (hn : NonRepdigit n) :
+    kaprekarStep^[7] n = 6174 := by
+  have key : kaprekarStep^[7] (canon n) = 6174 :=
+    conv_canon (canon n) (canon_lt n) (canon_idem n) (nonRepdigit_canon n hn)
+  rw [iterate7_canon]; exact key
+
+/-- `6174` is a fixed point of Kaprekar's routine (kernel `decide`). -/
+theorem kaprekar_fixed : kaprekarStep 6174 = 6174 := by decide
+
+/-- **Uniqueness of the fixed point**, derived structurally from convergence: a fixed
+point is unchanged by seven iterations, which land on `6174`. -/
+theorem kaprekar_unique_fixed (n : ℕ) (h : n < 10000) (hn : NonRepdigit n)
+    (hf : kaprekarStep n = n) : n = 6174 :=
+  (Function.iterate_fixed hf 7).symm.trans (kaprekar_converges n h hn)
+
+/-- **The bound is sharp.** The string `0014` still differs from `6174` after six steps,
+so seven steps are sometimes necessary (kernel `decide` witness). -/
+theorem kaprekar_bound_sharp :
+    ∃ n ∈ Finset.range 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174 :=
+  ⟨14, Finset.mem_range.mpr (by omega), by decide, by decide⟩
+
+end KaprekarConstantOQ01ZeroAxiom

--- a/research/problems/kaprekar-constant-oq-01/knowledge.md
+++ b/research/problems/kaprekar-constant-oq-01/knowledge.md
@@ -137,3 +137,35 @@ gallery integration with `status: axiomatized` / `axiomCount` reflecting
    `T`-factors-through-multiset lemma (the `decide`-feasible 715-case route).
 4. Optional generalization: characterise Kaprekar cycles for ≥5 digits (no single
    fixed point; e.g. 5 digits has cycles, not a constant).
+
+---
+
+## Session 3 (2026-06-18, researcher-1) — 0-axiom companion drafted (BUILD-PENDING)
+
+Implemented the multiset-canonicalisation route from the Lean plan above as a standalone
+companion `proofs/Proofs/KaprekarConstantOQ01ZeroAxiom.lean`. Key simplification over the
+original sketch: the convergence enumeration does **not** need to be restated over
+`(w,x,y,z)` tuples. State it over `n` with a canonicality guard:
+
+```
+conv_canon : ∀ n < 10000, canon n = n → NonRepdigit n → kaprekarStep^[7] n = 6174 := by decide
+```
+
+The decidable guard `canon n = n` short-circuits the ~9285 non-sorted strings before the
+heavy `^[7]` reduction, so the kernel only runs the 715 seven-step reductions. General
+convergence follows from three idempotence/preservation facts (`canon_lt`, `canon_idem`,
+`nonRepdigit_canon`, all `omega`) plus `iterate7_canon` (one-step peel via
+`Function.iterate_succ_apply` ×2 + `kaprekarStep_canon`). Uniqueness/sharpness reuse the
+structural argument from the verified file.
+
+**STILL UNVERIFIED** — written under Docker/Aristotle blackout (daemon down, load ~20). A
+detached gated build was launched (sentinel `/tmp/r1-kaprekar-zeroaxiom.done`). Open risks,
+in order of likelihood to fail:
+1. `conv_canon`'s kernel `decide` may time out on 715×7 reductions (the central gamble;
+   fall back to `native_decide` there if so — keeps everything else axiom-free).
+2. `kaprekarStep_canon` / `canon_idem` `omega` goals are large (8 nested `min`/`max` +
+   div/mod-by-literal); relies on `omega` zeta-reducing `let` and modelling `min`/`max`.
+
+Do NOT swap this in for the verified `native_decide` file or claim 0-axiom/verified status
+until `./proofs/scripts/docker-build.sh Proofs.KaprekarConstantOQ01ZeroAxiom` is green and
+`#print axioms KaprekarConstantOQ01ZeroAxiom.kaprekar_converges` shows no `Lean.ofReduceBool`.

--- a/research/problems/kaprekar-constant-oq-01/knowledge.md
+++ b/research/problems/kaprekar-constant-oq-01/knowledge.md
@@ -44,19 +44,73 @@ Statements:
 - `kaprekar_unique_fixed : n < 10000 → NonRepdigit n → kaprekarStep n = n → n = 6174`.
 - `kaprekar_bound_sharp : ∃ n < 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174`.
 
-The three finite-domain enumerations use `native_decide` (over `Finset.range 10000`),
-so they depend on `Lean.ofReduceBool` → intended gallery status **axiomatized**
-(badge `axiom`), not `verified`.
+## Session 2 (2026-06-18, researcher-1): shrink the trusted surface
+
+Goal was axiom elimination; Docker was again in full blackout (`docker info` times
+out, `rc=124`, load ≈21), so nothing could be machine-verified. Made the two
+**high-confidence, build-independent** reductions that cut `native_decide` from three
+enumerations to one, leaving `Lean.ofReduceBool` as the file's *sole* non-foundational
+axiom:
+
+- **`kaprekar_unique_fixed` is now structural** — no enumeration. A fixed point `n`
+  satisfies `kaprekarStep^[7] n = n` by `Function.iterate_fixed` (verified at pin:
+  `Mathlib/Logic/Function/Iterate.lean:90`, `iterate_fixed (h : f x = x) (n) : f^[n] x = x`),
+  and `kaprekarStep^[7] n = 6174` by `kaprekar_converges`, so `n = 6174`. Proof term:
+  `(Function.iterate_fixed hf 7).symm.trans (kaprekar_converges n h hn)`.
+- **`kaprekar_bound_sharp` is now a single witness** — `0014`. Python: `14` is the
+  *smallest* non-repdigit needing all seven steps (`T^[6] 14 = 4176 ≠ 6174`).
+  Proof term: `⟨14, Finset.mem_range.mpr (by omega), by decide, by decide⟩`.
+
+Only `kaprekar_converges_all` (over `Finset.range 10000`) still uses `native_decide`.
+Gallery status remains **axiomatized / axiom** (axiomCount 1, `Lean.ofReduceBool`).
+PR: `research/kaprekar-oq01-structural-uniqueness` (build-pending).
+
+### Verified design for the 0-axiom (`verified`) version
+
+The remaining `native_decide` is the *only* obstacle to a `verified`/0-axiom entry.
+Plain kernel `decide` over `Finset.range 10000 × 7` iterations is the risk the prior
+session flagged. The principled fix — **the digit-multiset reduction** — was fully
+checked in Python this session (every claim below returned `True` over all 10000
+inputs):
+
+- `kaprekarStep` depends only on the *sorted* digits: **`kaprekarStep n = kaprekarStep (canon n)`**
+  where `canon n := w·1000+x·100+y·10+z` for `(w,x,y,z) = sortAsc4 (digits n)`.
+- There are exactly **715** canonical (sorted-digit) representatives among `0..9999`
+  (= multisets of size 4 over 10 symbols, `C(13,4)`).
+- `NonRepdigit n ↔ NonRepdigit (canon n)`; convergence over the 715 reps in 7 steps
+  holds; some rep needs 7 (sharp).
+
+**Lean plan** (each lemma needs only `omega`, which on the pin handles `min`/`max` and
+`/`,`%` by literals — no enumeration in these steps):
+1. `sortAsc4_sorted (a b c d) : let (w,x,y,z) := sortAsc4 a b c d; w≤x ∧ x≤y ∧ y≤z`
+   — `unfold sortAsc4; simp only []; omega`.
+2. `sortAsc4_lt10` (digits `<10` ⇒ outputs `<10`) — same shape.
+3. `sortAsc4_fixed_of_sorted : w≤x→x≤y→y≤z→ sortAsc4 w x y z = (w,x,y,z)` — `omega` per component.
+4. `digits_recombine : w,x,y,z<10 → digits (w·1000+x·100+y·10+z) = (w,x,y,z)` — `omega` (div/mod by literals).
+5. `kaprekarStep_canon : kaprekarStep n = kaprekarStep (canon n)` — combine 1–4
+   (both sides are `recombine (sortAsc4 (digits ·))`; canon's digits re-sort to themselves).
+6. `iterate_canon : kaprekarStep^[7] n = kaprekarStep^[7] (canon n)` — peel one step with
+   `Function.iterate_succ_apply` (pin line 64), rewrite by lemma 5, re-roll with same.
+7. `conv_reps : ∀ w<10, ∀ x<10, ∀ y<10, ∀ z<10, w≤x→x≤y→y≤z→ ¬(w=x∧x=y∧y=z) →
+   kaprekarStep^[7] (w·1000+x·100+y·10+z) = 6174 := by decide`
+   — uses the efficient `Nat.decidableBallLT` instance; only the ~715 ordered tuples do
+   the heavy `^[7]` reduction, the other ~9285 short-circuit on the order hypotheses.
+   **This single `decide` is the only feasibility unknown** — must be confirmed by build.
+8. `kaprekar_converges` for general `n`: `iterate_canon` + show `canon n` matches a tuple
+   from `conv_reps` (its digits are sorted & `<10`).
+
+If step 7's `decide` times out, fall back: keep `native_decide` for convergence only
+(current state) — uniqueness/sharpness stay axiom-free regardless.
 
 ---
 
 ## Dead Ends / Risks
 
-- **Pure-`decide` route unverified.** Kernel `decide` over 10000 inputs × 7 iterated
-  steps may be too slow / memory-heavy; `native_decide` chosen as the reliable path.
-  A future "verified" (0-axiom) version could enumerate only the ≤715 sorted-digit
-  *multiset* representatives (`T` factors through the digit multiset), but that
-  requires a multiset-invariance lemma — deferred.
+- **Step-7 `decide` feasibility is unverified** (Docker blackout). 715 heavy reductions
+  is ~14× lighter than the 10000-case `Finset.range` form, and all Nat ops are
+  GMP-accelerated in the kernel, so it is *plausible* but not confirmed. A build settles it.
+- The min/max sorting-network lemmas (1–4) rely on `omega` understanding `min`/`max`
+  and `/`,`%`-by-literal. Both are supported on the current pin but untested here.
 
 ---
 


### PR DESCRIPTION
## Summary

Advances `kaprekar-constant-oq-01` by **shrinking the trusted surface** of the formalization. Two of the three `native_decide` enumerations are replaced with axiom-free proofs, leaving `Lean.ofReduceBool` as the file's *sole* non-foundational axiom (was depended on by all three before).

- **`kaprekar_unique_fixed` is now structural** — no enumeration. A fixed point is unchanged by 7 iterations (`Function.iterate_fixed`), which converge to `6174` (`kaprekar_converges`). Proof term: `(Function.iterate_fixed hf 7).symm.trans (kaprekar_converges n h hn)`.
- **`kaprekar_bound_sharp` is now a single witness** `0014` — the smallest non-repdigit needing all seven steps (`kaprekarStep^[6] 14 = 4176 ≠ 6174`), checked by kernel `decide`.

Only `kaprekar_converges_all` still uses `native_decide`. Gallery status remains **axiomatized / axiom** (axiomCount 1).

## Verification
- All facts cross-checked exhaustively in Python (sorting network, `T(n)=T(canon n)`, witness, convergence).
- Mathlib lemma names (`Function.iterate_fixed`, `iterate_succ_apply`) verified against the offline pin.
- **Build-pending**: Docker daemon was unresponsive this session (`docker info` timed out, load ≈21). A detached build was launched. The edits are term-mode / single-witness and low-risk, but not yet machine-verified.

## Next step toward `verified` (0 axioms)
The knowledge base now records a fully Python-verified design for eliminating the last `native_decide`: the digit-multiset reduction (`kaprekarStep n = kaprekarStep (canon n)`) cuts the convergence enumeration from 10000 strings to the **715 sorted-digit representatives**, which kernel `decide` can plausibly discharge. The lemma-by-lemma plan (omega-only sorting-network facts + one `decide`) is in `research/problems/kaprekar-constant-oq-01/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)