### PR TITLE
audit(angle-trisection-oq-02): fix garbled 'sorries remaining' text in assumptions

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -81,7 +81,7 @@
         "relationship": "Sub-entry connecting to the Gauss-Wantzel theorem for regular polygon constructibility"
       }
     ],
-    "assumptions": "1 axiom: wantzel_galois_characterization — the Wantzel-Galois biconditional: an algebraic number α is constructible by compass and straightedge iff the Galois group of its minimal polynomial over ℚ is a 2-group (IsPGroup 2 (minpoly ℚ α).Gal). Axiomatized because the full proof requires the Galois correspondence for intermediate fields. All other results (non-constructibility of ∛2 and cos(20°), constructibility of √2 and 2^{1/4}, hierarchy of criteria) are fully proved from this axiom with 0 sorries remain. 0 sorries remain.(s) remain.",
+    "assumptions": "1 axiom: wantzel_galois_characterization — the Wantzel-Galois biconditional: an algebraic number α is constructible by compass and straightedge iff the Galois group of its minimal polynomial over ℚ is a 2-group (IsPGroup 2 (minpoly ℚ α).Gal). Axiomatized because the full proof requires the Galois correspondence for intermediate fields. All other results (non-constructibility of ∛2 and cos(20°), constructibility of √2 and 2^{1/4}, hierarchy of criteria) are fully proved from this axiom with 0 sorries remaining.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
     "definitionCount": 1

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -265,10 +265,10 @@
       "result": "clean"
     },
     "angle-trisection-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-18T07:09:29Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T07:25:36Z",
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-02-oq-01": {
       "auditCount": 5,


### PR DESCRIPTION
## Gallery Integrity Audit — angle-trisection-oq-02

**Result:** CLEAN except one user-visible prose corruption (LOW severity, fixed here).

### Issue fixed
The `meta.assumptions` field had a garbled duplicated tail, likely from a botched search/replace in a prior pass:

> ...are fully proved from this axiom with **0 sorries remain. 0 sorries remain.(s) remain.**

Cleaned to:

> ...are fully proved from this axiom with **0 sorries remaining.**

No count, status, or claim changes — purely fixing corrupted display text.

### Verification (all match Lean source `Proofs/AngleTrisectionOQ02.lean`)
| Field | meta.json | source | ✓ |
|---|---|---|---|
| axiomCount | 1 | 1 (`wantzel_galois_characterization`) | ✓ |
| sorries | 0 | 0 (lone hit is `### Proved (no sorry)` docstring) | ✓ |
| theoremCount | 21 | 21 | ✓ |
| definitionCount | 1 | 1 (`IsConstructibleFromQ`) | ✓ |
| lineCount | 298 | 298 | ✓ |
| native_decide | — | 0 (only kernel `decide`) | ✓ |
| True stubs | — | 0 | ✓ |
| struct-encoded assumptions | — | 0 | ✓ |

### Tier / claim assessment
- **Tier C** — `status: axiomatized`, `badge: axiom` is correct: the sole axiom `wantzel_galois_characterization` is the headline biconditional (constructible ↔ Galois group is a 2-group).
- **No axiom masking:** the axiom is disclosed in `description`, `problemStatement`, `proofStrategy`, `assumptions`, `keyInsights`, and `conclusion`.
- **No delegation opacity:** imported `*_gal_order` results delegate to disclosed project-local files (InverseGalois, InverseGaloisD4, AngleTrisectionCos20Gal); the derivations from the axiom (∛2/cos20° non-constructible, √2/2^¼ constructible, OQ-02 ⇒ OQ-01) are genuinely proved with 0 sorries.

---
Discovered during gallery integrity audit.