### PR TITLE
audit(erdos-1149): clean, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4220,9 +4220,9 @@
       "result": "clean"
     },
     "erdos-1149": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "erdos-115": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1149

**Result: CLEAN** (re-audit, auditCount 3→4)

Re-audited Erdős Problem #1149 (Coprimality of n and ⌊n^α⌋). All meta.json claims verified against `proofs/Proofs/Erdos1149Problem.lean`.

### Counts (all match)
| Field | meta | source |
|-------|------|--------|
| lineCount | 335 | 335 ✓ |
| axiomCount | 1 | 1 (`bergelson_richter`) ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 18 | 18 ✓ |
| definitionCount | 5 | 5 ✓ |
| True stubs | — | 0 ✓ |

### Tier & disclosure
- **Tier C** — main theorem `bergelson_richter` (deep ergodic theory, Bergelson-Richter 2017) is axiomatized. Status `axiomatized` / badge `axiom` correct.
- `erdos_1149_solved` is an explicit, disclosed wrapper around the axiom. No axiom masking — the sole axiom is named in the overview, `assumptions`, and `originalContributions`.
- `erdosProblemStatus: solved` accurately reflects the real-world math status, not a claim about our formalization.

### Notes (non-blocking)
- `native_decide` at line 196 (`countCoprimePairs_one = 1`) is an incidental trivial sanity check, **not** a presented-verified headline → `Lean.ofReduceBool` disclosure not required; entry is already axiomatized for the `bergelson_richter` axiom.
- `random_coprime_density` delegates to `BaselProblemOQ04OQ03.coprime_pair_density_limit` (Möbius + Tannery) — disclosed in `originalContributions` and the theorem docstring; no delegation opacity.
- Companion `Erdos1149Aristotle.lean` contains 1 sorry, but it is a proof-search scaffold (`*Aristotle.lean`), not part of the gallery claim. `lineCount: 335` matches the primary file only (companion is 106 lines), confirming the counts are scoped to the primary file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)