### PR TITLE
audit(bounded-prime-gaps-oq-03-oq-01-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15867,6 +15867,12 @@
       "lastAudited": "2026-06-18T06:52:09Z",
       "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T07:33:48Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — Clean

**Proof**: `bounded-prime-gaps-oq-03-oq-01-oq-01` — "Minimum Admissible Diameter D(5) = 12"
**Result**: CLEAN — meta.json honestly reflects the Lean source.

### Verification (meta.json vs `proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 198 | 198 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| leanFile.axiomCount | 0 | 0 literal `axiom` | ✓ |
| sorries | 0 | 0 | ✓ |
| True-stubs | — | 0 | ✓ |

### Axiom integrity — `native_decide` ⇒ axiomatized (correct)

The headline `minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12` discharges the
witness diameter check (`fsDiameter {0,2,6,8,12} = 12`) with `native_decide` at both
lines 189 and 193, so `#print axioms` for the headline includes `Lean.ofReduceBool`.

The meta correctly classifies this:
- `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1` (vs `leanFile.axiomCount: 0`, which counts only literal `axiom` declarations)
- `assumptions` discloses `Lean.ofReduceBool (via native_decide)` and explains that the lower bound `admissible_5tuple_diam_ge_12` is itself fully symbolic / `native_decide`-free, while the presented D(5)=12 result depends on the `native_decide` upper bound.

No masking, no overclaim, no `True` stubs. Per the project's `native_decide` policy this is the conservative-correct classification.

Tracker: first audit of this entry → `auditCount: 1`, `result: clean`.

---
Discovered during gallery integrity audit.