### PR TITLE
audit(cevas-theorem-oq-02-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1989,9 +1989,9 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T07:37:47Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `cevas-theorem-oq-02-oq-01` (Spherical Ceva via Unit Vectors and Weight Balance)
**Result**: clean — all claims match the Lean source. No changes to gallery content; tracker bump only (auditCount 4→5).

## Verification

Checked `src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json` against `proofs/Proofs/CevasTheoremOQ02OQ01.lean`:

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 262 | 262 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

## Tier classification: A (verified/original) — defensible

- Headline `sin_ratio_cevian_point` is a genuine from-scratch derivation: the algebraic identity `n² − (α+βm)² = β²(1−m²)` discharged via `nlinarith`/`field_simp`, with `sin_arccos` and basic inner-product norms as building blocks. There is **no** Mathlib spherical-Ceva theorem doing the core work.
- `mathlibDependencies` are all elementary inner-product/trig identities (`Real.sin_arccos`, `inner_smul_right`, `norm_add_sq_real`, etc.) — appropriately scoped, no delegation opacity.
- `originalContributions` honestly disclose that the sin-ratio formula is **re-derived** here rather than imported from CevasTheoremSinRatio.lean.
- No axioms ⇒ no axiom masking. `assumptions` ("None. Fully verified with 0 axioms and 0 sorries.") is accurate.

**Risk**: LOW. Famous-theorem title carries qualifier ("via Unit Vectors and Weight Balance") and is an OQ variant.

---
Discovered during gallery integrity audit.