### PR TITLE
audit(cayley-hamilton-minpoly-oq-05): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1806,9 +1806,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T08:10:00Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`cayley-hamilton-minpoly-oq-05\` (Minimal Polynomial Reduction in General K-Algebras)
**Result**: clean (auditCount 4→5)

### Machine-checkable fields — all match exactly
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 232 | 232 |
| theoremCount | 23 | 23 |
| definitionCount | 0 | 0 |
| axiomCount | 0 | 0 |
| sorries | 0 | 0 |
| native_decide | — | 0 |
| True stubs | — | 0 |
| structure-encoded assumptions | — | none |

### Tier classification — Tier B (verified/mathlib), correct and defensible
- Core results rely on Mathlib's `minpoly` infrastructure (`minpoly.monic`, `minpoly.aeval`, `minpoly.dvd`, `minpoly.eq_of_irreducible_of_monic`).
- Badge is `mathlib` (conservative — not `original`).
- `originalContributions` cleanly separates substantive proofs (the `minpoly_reduction` division-algorithm calc proof, annihilator/congruence `iff` characterizations, tower degree bound) from explicitly-labeled "pedagogical wrappers around Mathlib."
- `assumptions` field discloses the Mathlib dependency.

### Five narrative failure modes — none present
No delegation opacity (Mathlib credited in description + assumptions), no axiom masking (0 axioms), no inequality-vs-theorem confusion, no pipeline inflation, no "0 sorries with hidden imports" misrepresentation (badge correctly `mathlib`).

---
Discovered during gallery integrity audit.