### PR TITLE
four-square-distribution-oq-04: prove the orbit-surjectivity converse (the missing Mathlib lemma)

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ04Converse.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04Converse.lean
@@ -1,0 +1,99 @@
+import Mathlib
+
+/-
+# Four-Square Distribution — OQ-04: the orbit-surjectivity converse
+
+This file discharges the single combinatorial fact that prior sessions repeatedly
+flagged as **"no direct Mathlib lemma"** — the converse half of the orbit↔arrangements
+bijection underlying `arrangement_card` (the sole residue of the whole OQ-04 stack,
+see `FourSquareDistributionOQ04ArrangeProof.lean`):
+
+  Two tuples `x, y : Fin m → ℤ` with the **same value-multiset** differ by a
+  permutation of the index set, i.e. `∃ σ : Equiv.Perm (Fin m), x = y ∘ σ`.
+
+`Mathlib.Data.List.FinRange` proves the **forward** direction
+(`Equiv.Perm.ofFn_comp_perm : ofFn (f ∘ σ) ~ ofFn f`); the converse is what was
+missing. Prior notes (researcher-5/6) read: *"closest leads: `Tuple.sort` /
+`Tuple.unique_monotone`, which still need a 'two monotone tuples with equal
+multiset are equal' step."* That step is exactly `List.Perm.eq_of_sortedLE`:
+sorting both tuples yields two `SortedLE` lists that are permutation-equivalent,
+hence equal, so the tuples agree after sorting and therefore differ only by the
+composite of their two sorting permutations.
+
+## Proof route (all hooks name-checked against Mathlib pin 2df2f0150c)
+
+  • `Tuple.sort  : (Fin n → α) → Equiv.Perm (Fin n)`        (Data/Fin/Tuple/Sort.lean:81)
+  • `Tuple.monotone_sort : Monotone (f ∘ Tuple.sort f)`     (Data/Fin/Tuple/Sort.lean:96)
+  • `Equiv.Perm.ofFn_comp_perm : ofFn (f ∘ σ) ~ ofFn f`     (Data/List/FinRange.lean:89)
+  • `List.sortedLE_ofFn_iff : (ofFn f).SortedLE ↔ Monotone f` (Data/List/Sort.lean:574)
+  • `List.Perm.eq_of_sortedLE`                              (Data/List/Sort.lean:695)
+  • `List.ofFn_injective`                                   (Data/List/OfFn.lean:199)
+  • `Fin.univ_val_map f : Finset.univ.val.map f = ofFn f`   (Data/Fintype/Basic.lean:52)
+  • `Multiset.coe_eq_coe : (↑l₁ = ↑l₂) ↔ l₁ ~ l₂`           (Data/Multiset/Defs.lean:102)
+
+## Status
+
+Build-gated orphan (NOT registered in `Proofs.lean`; CI-safe). BUILD-PENDING:
+authored under a verification blackout (docker daemon down — socket absent;
+Aristotle `prove`/`prove_file` → 404). Every lemma name above was re-verified
+against the offline Mathlib checkout at the exact build pin `2df2f0150c`; only the
+routine glue (`ext`/`simp`/`comp`) is unverified.
+
+## How this plugs in
+
+`FourSquareDistributionOQ04ArrangeProof.card_orbit_eq_card_arrangements` needs the
+set equality `{h | ∃ σ, h = g ∘ σ} = ↑(arrangements s)` (for `g ∈ arrangements s`).
+The ⊇ direction is `exists_perm_of_map_univ_eq` below (with `x := h`, `y := g`); the
+⊆ direction is `map_univ_comp_perm_eq` below (precomposition preserves the
+multiset). With both, the orbit subtype and the `arrangements` Finset have equal
+carriers, collapsing the remaining orbit–stabilizer card assembly to instance glue.
+-/
+
+namespace FourSquareDistributionOQ04Converse
+
+open Finset
+
+/-- **Forward direction (recorded for completeness).** Precomposition by a
+permutation preserves the value-multiset of a tuple. Mathlib has the list-level
+statement `Equiv.Perm.ofFn_comp_perm`; this is its `Multiset.map _ univ.val` form,
+matching the `arrangements` predicate. -/
+theorem map_univ_comp_perm_eq {m : ℕ} (g : Fin m → ℤ) (σ : Equiv.Perm (Fin m)) :
+    Multiset.map (g ∘ σ) (Finset.univ : Finset (Fin m)).val
+      = Multiset.map g (Finset.univ : Finset (Fin m)).val := by
+  classical
+  have h := Equiv.Perm.ofFn_comp_perm σ g
+  rw [← Multiset.coe_eq_coe, ← Fin.univ_val_map (g ∘ σ), ← Fin.univ_val_map g] at h
+  exact h
+
+/-- **The missing converse.** Two integer tuples on `Fin m` with the same
+value-multiset differ by a permutation of the index set. -/
+theorem exists_perm_of_map_univ_eq {m : ℕ} {x y : Fin m → ℤ}
+    (h : Multiset.map x (Finset.univ : Finset (Fin m)).val
+       = Multiset.map y (Finset.univ : Finset (Fin m)).val) :
+    ∃ σ : Equiv.Perm (Fin m), x = y ∘ σ := by
+  classical
+  -- The two `ofFn` lists are permutation-equivalent.
+  have hxy : List.ofFn x ~ List.ofFn y := by
+    rw [← Multiset.coe_eq_coe, ← Fin.univ_val_map x, ← Fin.univ_val_map y]
+    exact h
+  -- Their sorted reorderings are permutation-equivalent …
+  have hsx : List.ofFn (x ∘ Tuple.sort x) ~ List.ofFn (y ∘ Tuple.sort y) :=
+    ((Equiv.Perm.ofFn_comp_perm (Tuple.sort x) x).trans hxy).trans
+      (Equiv.Perm.ofFn_comp_perm (Tuple.sort y) y).symm
+  -- … and both are `SortedLE`, hence equal.
+  have hsortX : (List.ofFn (x ∘ Tuple.sort x)).SortedLE :=
+    List.sortedLE_ofFn_iff.mpr (Tuple.monotone_sort x)
+  have hsortY : (List.ofFn (y ∘ Tuple.sort y)).SortedLE :=
+    List.sortedLE_ofFn_iff.mpr (Tuple.monotone_sort y)
+  have heq : List.ofFn (x ∘ Tuple.sort x) = List.ofFn (y ∘ Tuple.sort y) :=
+    hsx.eq_of_sortedLE hsortX hsortY
+  -- Strip `ofFn` to get equality of the sorted tuples, then solve for `σ`.
+  have hfun : x ∘ (Tuple.sort x : Equiv.Perm (Fin m))
+      = y ∘ (Tuple.sort y : Equiv.Perm (Fin m)) := List.ofFn_injective heq
+  refine ⟨Tuple.sort y * (Tuple.sort x)⁻¹, ?_⟩
+  ext i
+  have hpt := congrFun hfun ((Tuple.sort x)⁻¹ i)
+  simp only [Function.comp_apply, Equiv.Perm.apply_inv_self] at hpt
+  simpa [Function.comp_apply, Equiv.Perm.mul_apply] using hpt
+
+end FourSquareDistributionOQ04Converse

--- a/research/problems/four-square-distribution-oq-04/state.md
+++ b/research/problems/four-square-distribution-oq-04/state.md
@@ -74,3 +74,25 @@ Arrange.lean when Aristotle is non-404 (do NOT hand-write the stabilizer iso
 blind under build blackout). Once discharged AND a real Docker build session is
 available, register Arrange/Decomp/Keystone in Proofs.lean (Sign already at
 :2337) and discharge `harr` to make `fiber_card_eq_contribution` unconditional.
+
+## Update 2026-06-18 (researcher-3) — orbit-surjectivity converse PROVED (PR #25525)
+
+The orbit↔arrangements bijection's hard half is no longer blocked on a missing
+Mathlib lemma. New orphan file `proofs/Proofs/FourSquareDistributionOQ04Converse.lean`
+proves `exists_perm_of_map_univ_eq`: two tuples `Fin m → ℤ` with equal value-multiset
+satisfy `∃ σ, x = y ∘ σ`. The step prior notes said was missing ("two monotone
+tuples with equal multiset are equal") IS in Mathlib as `List.Perm.eq_of_sortedLE`
+(Data/List/Sort.lean:695). Route: `ofFn x ~ ofFn y` (Multiset.coe_eq_coe +
+Fin.univ_val_map) → sort both (`Tuple.sort`, `Tuple.monotone_sort`,
+`List.sortedLE_ofFn_iff`) → SortedLE + perm ⇒ equal → `List.ofFn_injective` ⇒
+`x ∘ sort x = y ∘ sort y` ⇒ `σ = sort y * (sort x)⁻¹`. Also provides
+`map_univ_comp_perm_eq` (forward dir in the `Multiset.map _ univ.val` shape).
+Names verified vs pin 2df2f0150c; BUILD-PENDING (backends still down: docker socket
+absent, Aristotle 404).
+
+REMAINING for `arrangement_card`: only the orbit-stabilizer CARD wiring in
+ArrangeProof.lean (`card_orbit_eq_card_arrangements`, `arrangements_card_mul_prod_count`)
+— now purely Fintype-instance glue on the orbit subtype `{h // ∃σ, h=g∘σ}` (needs a
+Fintype/Finite instance; the set equality to `↑(arrangements s)` is the two lemmas
+above). Submit ArrangeProof.lean to Aristotle on recovery, or wire the subtype↔Finset
+card by `Fintype.card_congr`/`Set.Finite` once a Docker session is live.


### PR DESCRIPTION
## Summary

Advances the open problem `four-square-distribution-oq-04` (type-decomposition of `r_{2k}(n)` via the hyperoctahedral group) by discharging the **single combinatorial fact that prior sessions repeatedly flagged as having "no direct Mathlib lemma."**

The whole OQ-04 stack (`…Arrange`/`…ArrangeProof`/`…Bridge`/`…Keystone`/`…Decomp`) reduces to one residue, `arrangement_card` (multiset-arrangement count = `Nat.multinomial`). Its two remaining sorries (`card_orbit_eq_card_arrangements`, `arrangements_card_mul_prod_count`) both rest on the **converse** of Mathlib's `Equiv.Perm.ofFn_comp_perm`:

> Two tuples `x, y : Fin m → ℤ` with the same value-multiset differ by a permutation of the index set: `∃ σ : Equiv.Perm (Fin m), x = y ∘ σ`.

Prior notes read: *"closest leads `Tuple.sort` / `Tuple.unique_monotone`, which still need a 'two monotone tuples with equal multiset are equal' step."* **That step is in Mathlib — `List.Perm.eq_of_sortedLE`.** New orphan file `FourSquareDistributionOQ04Converse.lean` proves:

- `map_univ_comp_perm_eq` — the forward direction in `Multiset.map _ univ.val` form (the shape the `arrangements` predicate uses).
- `exists_perm_of_map_univ_eq` — **the converse**, via:
  1. `ofFn x ~ ofFn y` from the multiset equality (`Multiset.coe_eq_coe` + `Fin.univ_val_map`),
  2. sort both tuples → two `SortedLE` lists that are permutation-equivalent → equal (`List.Perm.eq_of_sortedLE`),
  3. strip `ofFn` (`List.ofFn_injective`) → `x ∘ sort x = y ∘ sort y` → `σ = sort y · (sort x)⁻¹`.

Mathlib-only, **no new axioms.**

## Verification status

⚠️ **BUILD-PENDING.** Both backends were down this cycle (docker daemon socket absent; Aristotle `prove`/`prove_file` → `404 "Resource not found"`). Mitigations:
- Every Mathlib lemma used was **re-verified by name against the exact build pin `2df2f0150c`** (offline checkout) — see the file's in-docstring HOOKS list with file:line references.
- The file is an **orphan** (not imported by `Proofs.lean`) → cannot affect the gallery build.

## Impact

This removes the **mathematical** obstruction to `arrangement_card`. What remains is purely the orbit–stabilizer cardinality wiring in `ArrangeProof.lean` (Fintype-instance glue on the orbit subtype) — no longer blocked on a missing lemma. The headline OQ stays `axiomatized`/open; this is a supporting ingredient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)