### PR TITLE
audit(cauchy-schwarz-oq-01-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1651,9 +1651,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T07:43:36Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: cauchy-schwarz-oq-01-oq-01 (Cauchy-Schwarz Equality for Complex Inner Product Spaces)
**Result**: clean (5th audit). Tier A — `verified` / `original` is defensible.

### Verified against `proofs/Proofs/CauchySchwarzOQ01OQ01.lean`

| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| lineCount | 185 | 185 | ✓ |

- No `sorry`/`admit`, no `native_decide`, no `True`-stubs, no structure-encoded assumptions.
- **No delegation opacity / Mathlib-wrapper masking**: the core forward direction `cs_equality_implies_smul` is a genuine ~40-line proof via orthogonal projection (`c = ⟪v,u⟫/⟪v,v⟫`, residual `w ⊥ v`) + Pythagoras (`norm_add_sq`). It does **not** call any Mathlib CS equality/inequality theorem. `norm_inner_le_norm` is mentioned only in a docstring comment, never invoked in code; the listed `mathlibDependencies` are elementary inner-product identities, appropriate for an original proof.
- The summary theorem `cauchy_schwarz_equality_works_for_complex` bundles the two main `iff` theorems (real conjunction of ∀-statements), not a placeholder.

Tracker: auditCount 4 → 5, result `clean`.

---
Discovered during gallery integrity audit.