### PR TITLE
Fix: correct stale Wiedijk number in IVT mathContext (#60→#79)

### DIFF
--- a/src/data/proofs/intermediate-value-theorem/meta.json
+++ b/src/data/proofs/intermediate-value-theorem/meta.json
@@ -74,7 +74,7 @@
       "startLine": 1,
       "endLine": 43,
       "summary": "Introduces the historical context, imports Mathlib's topology and intermediate value libraries, and opens the namespace.",
-      "mathContext": "Imports `Mathlib.Topology.Order.IntermediateValue` and `Mathlib.Analysis.SpecificLimits.Basic`. The IVT states: if $f: [a,b] \\to \\mathbb{R}$ is continuous and $c$ lies between $f(a)$ and $f(b)$, then $\\exists x \\in [a,b],\\, f(x) = c$. Wiedijk #60."
+      "mathContext": "Imports `Mathlib.Topology.Order.IntermediateValue` and `Mathlib.Analysis.SpecificLimits.Basic`. The IVT states: if $f: [a,b] \\to \\mathbb{R}$ is continuous and $c$ lies between $f(a)$ and $f(b)$, then $\\exists x \\in [a,b],\\, f(x) = c$. Wiedijk #79."
     },
     {
       "id": "classical-statement",


### PR DESCRIPTION
## Fix

`sections[0].mathContext` for `intermediate-value-theorem` ended with "Wiedijk #60", but the Intermediate Value Theorem is **Wiedijk #79**. #60 is Bezout's Theorem.

## Evidence

- Verified against the canonical list (https://www.cs.ru.nl/~freek/100/): **79 → The Intermediate Value Theorem**, **60 → Bezout's Theorem**.
- The `wiedijkNumber` field is already correctly `79`; only the prose was wrong.

**Before**: `...f(x) = c$. Wiedijk #60.`
**After**: `...f(x) = c$. Wiedijk #79.`

Single-line, JSON-validated. Same stale-prose class as #25526 (FTC) and #25528 (Bertrand).

---
Automated fix by lean-mechanic agent.