### PR TITLE
audit(cauchy-schwarz-integral-oq-02-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1621,9 +1621,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — CLEAN

**Proof**: `cauchy-schwarz-integral-oq-02-oq-01` — *Strict Minkowski Inequality: Equality iff Proportional*
**Result**: clean (auditCount 5 → 6)

### Machine-checkable fields — all match
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 91 | 91 | ✓ |
| theoremCount | 3 | 3 (`inner_eq_of_proportional`, `proportional_of_inner_eq`, `norm_add_eq_iff_proportional`) | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`, no structure-encoded assumptions) | ✓ |
| True stubs | — | 0 | ✓ |

Registered in `Proofs.lean` (line 424).

### Tier / narrative assessment
- **status `verified` / badge `mathlib`** — accurate. 0 sorries, 0 axioms, 0 stubs.
- The three theorems genuinely derive the strict-Minkowski **biconditional** (`‖f+g‖ = ‖f‖+‖g‖ ↔ ‖f‖•g = ‖g‖•f`) from *elementary* inner-product algebra (`norm_add_sq_real`, `norm_sub_sq_real`, `real_inner_smul_{left,right}`, `real_inner_comm`, `mul_right_cancel₀`, `nlinarith`, `ring`) — **not** a wrapper around a deep Mathlib equality-characterization theorem. `originalContributions` are correctly scoped; `mathlibDependencies` lists only the elementary facts. Badge `mathlib` is a **conservative under-claim** (Tier-A `original` would also be defensible) — acceptable.
- No delegation opacity, no axiom masking, no inequality-vs-theorem inflation: proves the actual `↔`, not just a bound.

### Non-blocking nit
- `conclusion.summary` says "proved in 80 lines"; `lineCount` is 91 (≈80 lines of code after the 8-line docstring). Prose approximation, not an integrity issue.

---
Discovered during gallery integrity audit. Queue is fully drained (2531/2531 audited); this is the oldest PR-free re-audit.