### PR TITLE
audit(cauchy-schwarz-integral-oq-01-oq-01-oq-01): clean re-audit, fix prose counts

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1567,10 +1567,10 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T00:00:00Z",
+      "result": "issues-fixed"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02": {
       "auditCount": 3,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
   "title": "Finite-Dimensional Cauchy-Schwarz, AM-GM, Nesbitt, and Titu's Lemma",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
-  "description": "Concrete applications of Cauchy-Schwarz and AM-GM in finite dimensions. Proves CS for ℝ² and ℝ³ via Lagrange identity, Young's inequality (including ε-form), AM-GM via square root, QM-AM, Titu's lemma (Engel form), Nesbitt's inequality, and Schur's inequality. All 13 theorems fully verified from first principles using nlinarith and sum-of-squares decompositions.",
+  "description": "Concrete applications of Cauchy-Schwarz and AM-GM in finite dimensions. Proves CS for ℝ² and ℝ³ via Lagrange identity, Young's inequality (including ε-form), AM-GM via square root, QM-AM, Titu's lemma (Engel form), Nesbitt's inequality, and Schur's inequality. All 11 theorems fully verified from first principles using nlinarith and sum-of-squares decompositions.",
   "meta": {
     "author": "Various (Cauchy 1821, Schwarz 1885, Young 1912, Titu Andreescu)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
@@ -150,7 +150,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A complete toolkit of 10 fundamental inequalities (plus 3 helper lemmas) fully verified from first principles using nlinarith with sum-of-squares certificates. Covers the full Cauchy-Schwarz → Young → AM-GM → Titu → Nesbitt → Schur chain.",
+    "summary": "A complete toolkit of 10 fundamental inequalities (plus 1 helper lemma) fully verified from first principles using nlinarith with sum-of-squares certificates. Covers the full Cauchy-Schwarz → Young → AM-GM → Titu → Nesbitt → Schur chain.",
     "implications": "**For formalization**: Demonstrates that nlinarith + SOS witnesses is a practical strategy for formalizing polynomial inequalities, reducing each proof to identifying the right cross-term squares.\n\n**For competition mathematics**: Provides machine-verified proofs of core olympiad tools, establishing a foundation for formalizing harder competition results.\n\n**For analysis**: Young's inequality with ε (when proved) would connect to PDE energy estimates and Sobolev embedding proofs.",
     "openQuestions": [
       "Extend to n-variable Cauchy-Schwarz using Finset.sum and induction",


### PR DESCRIPTION
## Auditor Re-Audit (6th)

**Slug:** `cauchy-schwarz-integral-oq-01-oq-01-oq-01` — Finite-Dimensional Cauchy-Schwarz, AM-GM, Nesbitt, and Titu's Lemma
**Source:** `Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean`

### Verdict: CLEAN (integrity) — minor prose fixed

All machine-checkable integrity fields verified against the Lean source:

| Field | meta.json | leanFile | Source | Match |
|-------|-----------|----------|--------|-------|
| theoremCount | 11 | 11 | 11 (10 public + 1 private `schur_sorted`) | ✅ |
| definitionCount | 0 | 0 | 0 | ✅ |
| sorries | 0 | 0 | 0 | ✅ |
| axiomCount | 0 | 0 | 0 | ✅ |
| lineCount | 183 | 183 | 183 | ✅ |
| native_decide | — | — | 0 | ✅ |
| True-stubs | — | — | 0 | ✅ |

### No masking (Tier-A DEFENSIBLE)
Proofs are genuine from-first-principles arguments — `nlinarith` with explicit sum-of-squares witnesses (Lagrange-identity cross-terms for CS in ℝ²/ℝ³), completing-the-square (Young), `field_simp` denominator clearing (Titu, Nesbitt), and a WLOG-ordered algebraic factorization (Schur). **No call to Mathlib's `inner_mul_le_norm_mul_norm` or any packaged Cauchy-Schwarz theorem.** The listed `mathlibDependencies` (`sq_nonneg`, `Real.sqrt_le_sqrt`, `div_add_div`, `div_le_div_iff₀`) are elementary helpers, not wrappers masking the headline result. `status: verified` / `badge: mathlib` is conservative and justified.

### Fixed (prose only — structured fields were already correct)
- `description`: "All **13** theorems" → "All **11** theorems"
- `conclusion.summary`: "(plus **3** helper lemmas)" → "(plus **1** helper lemma)"

Tracker: auditCount 5 → 6, result `issues-fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)