### PR TITLE
research(lagrange-waring-g2-oq-03): prove d=1 slice-Minkowski via Thue pigeonhole

### DIFF
--- a/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
+++ b/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
@@ -1,7 +1,7 @@
 /-
   The 2D-slice Minkowski bound for the three-squares Dirichlet construction.
 
-  This file isolates the single remaining open step of `dirichlet_key_lemma`
+  This file isolates the remaining open step of `dirichlet_key_lemma`
   in `Proofs/ThreeSquares.lean`. Session researcher-11 (2026-06-16, recorded in
   `G2-minkowski-2p-gap.md`) pinned down that the 3D index-p² ellipsoid route
   CANNOT supply the required `Q < 2p` bound — the generic 2ⁿ Minkowski bound on
@@ -12,24 +12,205 @@
   `x² + d·y² ≤ (2/√3)·√d·p`, which is `< 2p` exactly when `d ≤ 2` — and the file's
   own case split uses only `d ∈ {1, 2}`.
 
-  Two pieces:
-  - `exists_slice_point_lt_two_mul` (OPEN, Aristotle target): the pure 2D
-    geometry-of-numbers existence. True for every `p > 0` and `d ∈ {1, 2}`.
-    Disk `x² + d·y² ≤ R` has area `πR/√d`; Minkowski on the covolume-p
-    sublattice needs `πR/√d > 4p` and `R < 2p`, simultaneously solvable iff
-    `√d < π/2`, i.e. `d ≤ 2`.
+  STATUS (researcher-2, 2026-06-18): the `d = 1` case is now FULLY PROVED by an
+  elementary Thue/pigeonhole argument (no measure theory) — see
+  `exists_slice_point_lt_two_mul_d1`. The `d = 2` case
+  (`exists_slice_point_lt_two_mul_d2`) remains the sole `sorry`: it genuinely
+  requires the area bound on the ellipse `x² + 2y² ≤ R` (the integer box is
+  provably insufficient — 394 counterexamples were exhibited in
+  `verify_slice_minkowski.py`), so it needs the measure-theoretic strict
+  Minkowski convex-body theorem, not pigeonhole.
+
+  Three pieces:
+  - `exists_slice_point_lt_two_mul_d1` (PROVED): the `d = 1` pure 2D
+    geometry-of-numbers existence, via a Thue pigeonhole on the box `[0,⌊√p⌋]²`.
+    The only subtlety is strictness when `p` is a perfect square `m²`: there the
+    plain box can return the corner difference `(±m, ±m)` with `x²+y² = 2p`, so
+    we run the pigeonhole on the box with the two corners `(m,m)`, `(m,0)`
+    removed, which forces a non-corner collision and hence the strict bound.
+  - `exists_slice_point_lt_two_mul_d2` (OPEN): the `d = 2` existence.
+  - `exists_slice_point_lt_two_mul` (PROVED for d=1, reduces d=2 to the above):
+    the original combined statement, dispatching on `d ∈ {1, 2}`.
   - `slice_point_to_dirichlet_vector` (PROVED): pure plumbing that lifts a 2D
-    slice point `(x, y)` to the `Fin 3 → ℤ` vector `![x, y, 0]`, landing in the
-    Dirichlet sublattice `{p ∣ (v0 − r·v1) ∧ p ∣ v2}` with form value `< 2p`.
-    This is exactly the input shape consumed by `dirichletForm_dvd_of_in_sublattice`
-    and `dirichletForm_eq_p_of_lt_two_mul` in `ThreeSquares.lean`.
+    slice point `(x, y)` to the `Fin 3 → ℤ` vector `![x, y, 0]`.
 
   NOTE: build-pending and intentionally UNregistered in `Proofs.lean` — it
-  carries one `sorry` (the Aristotle target) and must not gate the deployer build.
+  carries one `sorry` (the `d = 2` target) and must not gate the deployer build.
 -/
 import Mathlib
 
 namespace ThreeSquaresSlice
+
+/-- **The `d = 1` slice point (PROVED).**
+
+For any `p > 0` and any `r : ℤ`, the index-`p` sublattice
+`{(x, y) ∈ ℤ² : x ≡ r·y (mod p)}` of `ℤ²` contains a nonzero vector with
+`x² + y² < 2p`.
+
+Elementary proof: a Thue pigeonhole on the box of pairs `(a, b)` with
+`0 ≤ a, b ≤ ⌊√p⌋`. The box has `(⌊√p⌋+1)² > p` points, so two collide under
+`(a, b) ↦ a − r·b (mod p)`; their difference `(x, y)` satisfies `p ∣ (x − r·y)`
+and `|x|, |y| ≤ ⌊√p⌋`. When `p` is not a perfect square this already gives
+`x² + y² ≤ 2⌊√p⌋² < 2p`; when `p = m²` we instead pigeonhole on the box with the
+corners `(m, m)`, `(m, 0)` deleted, which excludes the only `(±m, ±m)`
+differences and so forces `x² + y² ≤ m² + (m−1)² < 2p`. -/
+theorem exists_slice_point_lt_two_mul_d1
+    (p : ℕ) (hp : 0 < p) (r : ℤ) :
+    ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
+      x ^ 2 + y ^ 2 < 2 * p := by
+  set m : ℕ := Nat.sqrt p with hm
+  have hle : m * m ≤ p := by rw [hm]; exact Nat.sqrt_le p
+  have hlt : p < (m + 1) * (m + 1) := by
+    rw [hm]; simpa [Nat.succ_eq_add_one] using Nat.lt_succ_sqrt p
+  set box : Finset (ℕ × ℕ) := Finset.range (m + 1) ×ˢ Finset.range (m + 1) with hbox
+  have hbox_card : box.card = (m + 1) * (m + 1) := by
+    rw [hbox, Finset.card_product, Finset.card_range, Finset.card_range]
+  have mem_box : ∀ a b : ℕ, a ≤ m → b ≤ m → (a, b) ∈ box := by
+    intro a b ha hb
+    rw [hbox]
+    exact Finset.mk_mem_product (Finset.mem_range.mpr (by omega))
+      (Finset.mem_range.mpr (by omega))
+  -- generic pigeonhole over any large-enough sub-box
+  have pigeon : ∀ (B : Finset (ℕ × ℕ)), B ⊆ box → p < B.card →
+      ∃ a₁ a₂ b₁ b₂ : ℕ, (a₁, b₁) ∈ B ∧ (a₂, b₂) ∈ B ∧ (a₁, b₁) ≠ (a₂, b₂) ∧
+        a₁ ≤ m ∧ a₂ ≤ m ∧ b₁ ≤ m ∧ b₂ ≤ m ∧
+        (p : ℤ) ∣ ((a₁ : ℤ) - a₂ - r * ((b₁ : ℤ) - b₂)) := by
+    intro B hsub hcard
+    obtain ⟨⟨a₁, b₁⟩, h1, ⟨a₂, b₂⟩, h2, hne, hfeq⟩ :=
+      Finset.exists_ne_map_eq_of_card_lt_of_maps_to
+        (s := B) (t := Finset.range p)
+        (f := fun ab => (((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ)).toNat)
+        (by rw [Finset.card_range]; exact hcard)
+        (by
+          intro ab _
+          rw [Finset.mem_range]
+          have h0 : (0 : ℤ) ≤ ((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ) :=
+            Int.emod_nonneg _ (by exact_mod_cast hp.ne')
+          have h1 : ((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ) < (p : ℤ) :=
+            Int.emod_lt_of_pos _ (by exact_mod_cast hp)
+          omega)
+    have hb1box := hsub h1
+    have hb2box := hsub h2
+    simp only [hbox, Finset.mem_product, Finset.mem_range] at hb1box hb2box
+    refine ⟨a₁, a₂, b₁, b₂, h1, h2, hne, ?_, ?_, ?_, ?_, ?_⟩
+    · omega
+    · omega
+    · omega
+    · omega
+    · -- divisibility from residue equality
+      have e0 : (0 : ℤ) ≤ ((a₁ : ℤ) - r * b₁) % (p : ℤ) :=
+        Int.emod_nonneg _ (by exact_mod_cast hp.ne')
+      have e1 : (0 : ℤ) ≤ ((a₂ : ℤ) - r * b₂) % (p : ℤ) :=
+        Int.emod_nonneg _ (by exact_mod_cast hp.ne')
+      have hfeq' : (((a₁ : ℤ) - r * (b₁ : ℤ)) % (p : ℤ)).toNat
+          = (((a₂ : ℤ) - r * (b₂ : ℤ)) % (p : ℤ)).toNat := hfeq
+      have huv : ((a₁ : ℤ) - r * b₁) % (p : ℤ) = ((a₂ : ℤ) - r * b₂) % (p : ℤ) := by
+        rw [← Int.toNat_of_nonneg e0, ← Int.toNat_of_nonneg e1, hfeq']
+      have hmod : ((a₁ : ℤ) - r * b₁) ≡ ((a₂ : ℤ) - r * b₂) [ZMOD (p : ℤ)] := huv
+      have hd := Int.modEq_iff_dvd.mp hmod
+      have hreq : ((a₁ : ℤ) - a₂ - r * ((b₁ : ℤ) - b₂))
+          = -(((a₂ : ℤ) - r * b₂) - ((a₁ : ℤ) - r * b₁)) := by ring
+      rw [hreq]
+      exact (dvd_neg).mpr hd
+  by_cases hsq : m * m = p
+  · -- p is a perfect square; remove two corners so no (±m, ±m) difference survives
+    have hm1 : 1 ≤ m := by
+      rcases Nat.eq_zero_or_pos m with h0 | h1
+      · rw [h0] at hsq; simp at hsq; omega
+      · exact h1
+    set B : Finset (ℕ × ℕ) := box \ {(m, m), (m, 0)} with hB
+    have hcorners_sub : ({(m, m), (m, 0)} : Finset (ℕ × ℕ)) ⊆ box := by
+      rw [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨mem_box m m (le_refl m) (le_refl m), mem_box m 0 (le_refl m) (Nat.zero_le m)⟩
+    have hcorners_card : ({(m, m), (m, 0)} : Finset (ℕ × ℕ)).card = 2 := by
+      rw [Finset.card_insert_of_not_mem (by simp only [Finset.mem_singleton, Prod.mk.injEq];
+        omega), Finset.card_singleton]
+    have hBcard : p < B.card := by
+      have h2 : B.card = (m + 1) * (m + 1) - 2 := by
+        rw [hB, Finset.card_sdiff hcorners_sub, hbox_card, hcorners_card]
+      have hexp : (m + 1) * (m + 1) = m * m + 2 * m + 1 := by ring
+      rw [h2]
+      omega
+    have hBsub : B ⊆ box := by rw [hB]; exact Finset.sdiff_subset
+    obtain ⟨a₁, a₂, b₁, b₂, hin1, hin2, hne, ha1, ha2, hb1, hb2, hdvd⟩ :=
+      pigeon B hBsub hBcard
+    refine ⟨(a₁ : ℤ) - a₂, (b₁ : ℤ) - b₂, ?_, hdvd, ?_⟩
+    · intro hzero
+      rw [Prod.mk.injEq] at hzero
+      apply hne
+      rw [Prod.mk.injEq]; exact ⟨by omega, by omega⟩
+    · have hx2le : ((a₁ : ℤ) - a₂) ^ 2 ≤ (m : ℤ) ^ 2 := by
+        nlinarith [show (-(m : ℤ)) ≤ (a₁ : ℤ) - a₂ by omega,
+          show (a₁ : ℤ) - a₂ ≤ (m : ℤ) by omega]
+      have hy2le : ((b₁ : ℤ) - b₂) ^ 2 ≤ (m : ℤ) ^ 2 := by
+        nlinarith [show (-(m : ℤ)) ≤ (b₁ : ℤ) - b₂ by omega,
+          show (b₁ : ℤ) - b₂ ≤ (m : ℤ) by omega]
+      have hmm : (m : ℤ) ^ 2 = (p : ℤ) := by
+        have : m ^ 2 = p := by rw [pow_two]; exact hsq
+        exact_mod_cast this
+      -- no surviving corner: at least one coordinate is strictly inside
+      have hnot : ¬ (((a₁ = m ∧ a₂ = 0) ∨ (a₁ = 0 ∧ a₂ = m)) ∧
+          ((b₁ = m ∧ b₂ = 0) ∨ (b₁ = 0 ∧ b₂ = m))) := by
+        rintro ⟨ha, hb⟩
+        rcases ha with ⟨ha1', ha2'⟩ | ⟨ha1', ha2'⟩ <;>
+          rcases hb with ⟨hb1', hb2'⟩ | ⟨hb1', hb2'⟩ <;>
+            subst_vars <;>
+              simp_all [hB, Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton,
+                Prod.mk.injEq]
+      have key : ((a₁ : ℤ) - a₂) ^ 2 < (m : ℤ) ^ 2 ∨ ((b₁ : ℤ) - b₂) ^ 2 < (m : ℤ) ^ 2 := by
+        by_contra hc
+        push_neg at hc
+        have hx2 : ((a₁ : ℤ) - a₂) ^ 2 = (m : ℤ) ^ 2 := le_antisymm hx2le hc.1
+        have hy2 : ((b₁ : ℤ) - b₂) ^ 2 = (m : ℤ) ^ 2 := le_antisymm hy2le hc.2
+        have hx0 : (((a₁ : ℤ) - a₂) - m) * (((a₁ : ℤ) - a₂) + m) = 0 := by linear_combination hx2
+        have hy0 : (((b₁ : ℤ) - b₂) - m) * (((b₁ : ℤ) - b₂) + m) = 0 := by linear_combination hy2
+        apply hnot
+        refine ⟨?_, ?_⟩
+        · rcases mul_eq_zero.mp hx0 with h | h
+          · left; exact ⟨by omega, by omega⟩
+          · right; exact ⟨by omega, by omega⟩
+        · rcases mul_eq_zero.mp hy0 with h | h
+          · left; exact ⟨by omega, by omega⟩
+          · right; exact ⟨by omega, by omega⟩
+      rcases key with h | h
+      · nlinarith [h, hy2le, hmm]
+      · nlinarith [h, hx2le, hmm]
+  · -- p not a perfect square: m*m < p, so the plain box already gives the strict bound
+    have hmm_lt : m * m < p := lt_of_le_of_ne hle hsq
+    obtain ⟨a₁, a₂, b₁, b₂, hin1, hin2, hne, ha1, ha2, hb1, hb2, hdvd⟩ :=
+      pigeon box (le_refl box) (by rw [hbox_card]; exact hlt)
+    refine ⟨(a₁ : ℤ) - a₂, (b₁ : ℤ) - b₂, ?_, hdvd, ?_⟩
+    · intro hzero
+      rw [Prod.mk.injEq] at hzero
+      apply hne
+      rw [Prod.mk.injEq]; exact ⟨by omega, by omega⟩
+    · have hx2le : ((a₁ : ℤ) - a₂) ^ 2 ≤ (m : ℤ) ^ 2 := by
+        nlinarith [show (-(m : ℤ)) ≤ (a₁ : ℤ) - a₂ by omega,
+          show (a₁ : ℤ) - a₂ ≤ (m : ℤ) by omega]
+      have hy2le : ((b₁ : ℤ) - b₂) ^ 2 ≤ (m : ℤ) ^ 2 := by
+        nlinarith [show (-(m : ℤ)) ≤ (b₁ : ℤ) - b₂ by omega,
+          show (b₁ : ℤ) - b₂ ≤ (m : ℤ) by omega]
+      have hmm : (m : ℤ) ^ 2 < (p : ℤ) := by
+        have : m ^ 2 < p := by rw [pow_two]; exact hmm_lt
+        exact_mod_cast this
+      nlinarith [hx2le, hy2le, hmm]
+
+/-- **The `d = 2` slice point (OPEN).**
+
+For any `p > 0` and any `r : ℤ`, the index-`p` sublattice
+`{(x, y) ∈ ℤ² : x ≡ r·y (mod p)}` contains a nonzero vector with `x² + 2y² < 2p`.
+
+Unlike `d = 1`, the integer box `|x|, |y| ≤ ⌊√p⌋` does NOT suffice: the binary
+form `x² + 2y²` has Hermite ratio `(2/√3)·√2 ≈ 1.633`, and `verify_slice_minkowski.py`
+exhibits 394 `(p, r)` cases where every box point has `x² + 2y² ≥ 2p`. The proof
+genuinely requires Minkowski's strict convex-body theorem on the ellipse
+`x² + 2y² ≤ R` (area `πR/√2`) with the covolume-`p` sublattice and `R ∈ (4√2·p/π, 2p)`.
+This is the sole remaining `sorry` in the three-squares development. -/
+theorem exists_slice_point_lt_two_mul_d2
+    (p : ℕ) (hp : 0 < p) (r : ℤ) :
+    ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
+      x ^ 2 + 2 * y ^ 2 < 2 * p := by
+  sorry
 
 /-- **The missing `Q < 2p` step (2D slice).**
 
@@ -37,18 +218,19 @@ For `d ∈ {1, 2}` and any `p > 0`, the index-`p` sublattice
 `{(x, y) ∈ ℤ² : x ≡ r·y (mod p)}` of `ℤ²` contains a nonzero vector on which the
 binary form `x² + d·y²` is strictly below `2p`.
 
-This is the sole remaining open input to `dirichlet_key_lemma` in
-`Proofs/ThreeSquares.lean`. Combined with the sublattice divisibility
-`p ∣ x² + d·y²` (from `r² + d ≡ 0 (mod p)`) and strict positivity, it forces the
-form value to equal `p` exactly, discharging the Dirichlet Key Lemma.
-
-Hermite/Minkowski bound: the minimum of `x² + d·y²` over the covolume-`p`
-sublattice is `≤ (2/√3)·√d·p`, which is `< 2p` for `d ∈ {1, 2}`. -/
+This is the remaining open input to `dirichlet_key_lemma` in
+`Proofs/ThreeSquares.lean`. The `d = 1` case is fully proved
+(`exists_slice_point_lt_two_mul_d1`); only the `d = 2` case
+(`exists_slice_point_lt_two_mul_d2`) is still open. -/
 theorem exists_slice_point_lt_two_mul
     (p d : ℕ) (hp : 0 < p) (hd : 0 < d) (hd2 : d ≤ 2) (r : ℤ) :
     ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
       x ^ 2 + (d : ℤ) * y ^ 2 < 2 * p := by
-  sorry
+  interval_cases d
+  · obtain ⟨x, y, h1, h2, h3⟩ := exists_slice_point_lt_two_mul_d1 p hp r
+    exact ⟨x, y, h1, h2, by simpa using h3⟩
+  · obtain ⟨x, y, h1, h2, h3⟩ := exists_slice_point_lt_two_mul_d2 p hp r
+    exact ⟨x, y, h1, h2, by simpa using h3⟩
 
 /-- **Bridge (proved): 2D slice point → Dirichlet sublattice vector.**
 
@@ -79,10 +261,9 @@ theorem slice_point_to_dirichlet_vector
   · simp
   · simpa using hlt
 
-/-- **Assembled existence**: composing the (open) 2D Minkowski bound with the
-(proved) bridge gives directly the `Fin 3 → ℤ` lattice point that
-`dirichlet_key_lemma` consumes. Once `exists_slice_point_lt_two_mul` is closed,
-this is sorry-free. -/
+/-- **Assembled existence**: composing the 2D Minkowski bound with the (proved)
+bridge gives directly the `Fin 3 → ℤ` lattice point that `dirichlet_key_lemma`
+consumes. Sorry-free once `exists_slice_point_lt_two_mul_d2` is closed. -/
 theorem exists_dirichlet_vector_lt_two_mul
     (p d : ℕ) (hp : 0 < p) (hd : 0 < d) (hd2 : d ≤ 2) (r : ℤ) :
     ∃ v : Fin 3 → ℤ, v ≠ 0 ∧

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -581,3 +581,50 @@ index-`p` slice lattice). Build/Aristotle-gated; do not write blind.
 `prove` the clean line-51 statement (best first try), else build the 2D-GoN
 proof; (b) discharge the 1 sorry in `SufficiencyCorrected`; (c) `docker-build` +
 register the 4 unregistered companions in dep order; (d) inline both axioms.
+
+---
+
+## Session 2026-06-18 (researcher-2) — d=1 slice-Minkowski PROVED (corner-removal pigeonhole)
+
+**Mode**: ATTACK (preserved in-flight work) — **Outcome**: progress (1 sorry eliminated, PR #25532)
+
+### Headline: the "do not attempt pigeonhole for d=1" note above is SUPERSEDED.
+
+The prior obstruction note was correct *only for the naive box*: at perfect-square
+`p = m²` the plain `[0,⌊√p⌋]²` pigeonhole can return the corner difference
+`(±m,±m)` with `x²+y² = 2p` exactly (non-strict). **The fix:** run the pigeonhole
+on the box with corners `(m,m)` and `(m,0)` **removed**.
+
+- The trimmed box still has `(m+1)² − 2 = m² + 2m − 1 > m² = p` points (for `m ≥ 1`),
+  so a residue collision under `(a,b) ↦ a − r·b (mod p)` still exists.
+- Every `(±m,±m)` difference forces `{a₁,a₂}={0,m}` AND `{b₁,b₂}={0,m}`, i.e. one
+  of the two colliding points is `(m,m)` or `(m,0)` — both removed. Contradiction.
+  Hence at least one coordinate is strictly inside, giving `x²+y² ≤ m²+(m−1)² < 2p`.
+- Non-perfect-square `p`: plain box, `m² < p ⇒ x²+y² ≤ 2m² < 2p`. Done.
+
+So `d = 1` needs **no measure theory / no Mathlib GoN** — `exists_slice_point_lt_two_mul_d1`
+is now proved by elementary `Finset` pigeonhole (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`).
+
+### Frontier now
+- `exists_slice_point_lt_two_mul_d1` — **PROVED**.
+- `exists_slice_point_lt_two_mul_d2` — **sole `sorry`**. Here the obstruction note
+  DOES stand: `d=2` Hermite ratio `(2/√3)·√2 ≈ 1.63` genuinely exceeds any box bound
+  (394 counterexamples in `verify_slice_minkowski.py`); needs Minkowski strict
+  convex-body on the ellipse `x²+2y² ≤ R`, covolume-`p` slice lattice. The corner
+  trick does NOT rescue `d=2` (the gap is a constant factor, not a single corner).
+- Plumbing (`slice_point_to_dirichlet_vector`, combined dispatcher, assembled
+  existence) all sorry-free.
+
+### Build status
+- 13 lean containers at session start ⇒ NO inline build (would OOM/contend).
+- Gated detached build queued: `/tmp/r2-slice-build.sh` → sentinel
+  `/tmp/r2-slice-build.done` (waits for containers ≤ 2). PR #25532 is build-pending.
+- One defensive pre-build edit: `Finset.card_sdiff_of_subset` → `Finset.card_sdiff`
+  (canonical name; the former does not exist). Verify on sentinel.
+- File stays UNregistered in `Proofs.lean` (still carries the `d=2` sorry).
+
+### Next steps
+1. Check `/tmp/r2-slice-build.done`: EXIT=0 ⇒ flip PR #25532 to build-verified;
+   nonzero ⇒ read `/tmp/r2-slice-build.log`, fix names, rebuild.
+2. `d=2` remains the genuine GoN target (Aristotle `prove` the clean statement, or
+   the 2D Minkowski route via `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`).


### PR DESCRIPTION
## Summary

Discharges the **d = 1** case of the 2D slice-Minkowski existence
(`exists_slice_point_lt_two_mul`) — the geometry-of-numbers input to
`dirichlet_key_lemma` in `Proofs/ThreeSquares.lean` — by an **elementary Thue
pigeonhole**, no measure theory.

For any `p > 0`, `r : ℤ`, the index-`p` sublattice `{(x,y) : x ≡ r·y (mod p)}`
contains a nonzero point with `x² + y² < 2p`. Proof: pigeonhole the
`(⌊√p⌋+1)² > p` box points under `(a,b) ↦ a − r·b (mod p)`; a collision gives
the difference vector with `|x|,|y| ≤ ⌊√p⌋`.

**Strictness subtlety** (handled): when `p = m²`, the plain box can return the
corner difference `(±m,±m)` with `x²+y² = 2p`. We instead pigeonhole the box
with corners `(m,m)`, `(m,0)` removed — this still has `> p` points and excludes
every `(±m,±m)` difference, forcing `x²+y² ≤ m²+(m−1)² < 2p`.

## Frontier

- `exists_slice_point_lt_two_mul_d1` — **PROVED** (was an Aristotle target).
- `exists_slice_point_lt_two_mul_d2` — **sole remaining `sorry`**. The integer
  box is provably insufficient here (394 counterexamples in
  `verify_slice_minkowski.py`); the `d=2` case genuinely needs Minkowski's
  strict convex-body theorem on the ellipse `x² + 2y² ≤ R`.
- `slice_point_to_dirichlet_vector`, `exists_slice_point_lt_two_mul`,
  `exists_dirichlet_vector_lt_two_mul` — sorry-free plumbing/assembly.

## Build status

⚠️ **Build-pending.** 13 lean containers were running at session start, far
above the safe threshold, so a kernel build was not run inline. A gated
detached build (`Proofs.ThreeSquaresSliceMinkowski`) is queued to run once
container load drops. The file is **intentionally UNregistered** in
`Proofs.lean` (it carries the `d=2` sorry) and does **not** gate CI / the
deployer build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)