### PR TITLE
audit(cantors-theorem-oq-03): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1537,9 +1537,9 @@
       "result": "clean"
     },
     "cantors-theorem-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T07:56:37Z",
       "result": "clean"
     },
     "cauchy-schwarz": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`cantors-theorem-oq-03\` — *The Diagonal Argument in Cardinal Arithmetic and Beyond* (König / Lawvere / Cantor diagonal hierarchy)
**Result**: clean (6th audit) — all claims match the Lean source.

### Checks
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 310 | 310 | ✅ |
| theoremCount | 17 | 17 | ✅ |
| definitionCount | 0 | 0 | ✅ |
| axiomCount | 0 | 0 | ✅ |
| sorries | 0 | 0 | ✅ |
| native_decide | — | 0 | ✅ |
| True stubs | — | 0 | ✅ |

### Tier / badge
- **Status `verified` / badge `original` — DEFENSIBLE (Tier A).** `konig_principle` is proved from scratch (`choose` + `congr_fun`); `coordinate_diagonal` is direct; Lawvere's FPT and Cantor (Bool/Prop/Set) are derived as in-file specializations of the diagonal. No Mathlib Cantor/König theorem does the core work — `mathlibDependencies` lists only `Function.Surjective` (a definition) and `congr_fun` (Lean core). No delegation opacity.
- The two `decide` uses (`bool_neg_fpf`, `cantor_bool`) are **ordinary kernel `decide`, not `native_decide`** → no `Lean.ofReduceBool` dependency. The "0 axioms" claim is honest.
- **König framing is honest**: the file proves the no-surjection diagonal statement (Σ → Π), which the meta describes as exactly that — not the full cardinal inequality Σκᵢ < Πλᵢ with the ≤ direction. No inequality≠theorem inflation.

No overclaim, no axiom masking. Tracker `auditCount` 5→6.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)