### PR TITLE
audit(bezout-identity-oq-02-oq-02-oq-01): re-audit, fix native_decide count

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -856,10 +856,10 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T00:00:00Z",
+      "result": "issues-fixed"
     },
     "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
       "auditCount": 6,

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -163,7 +163,7 @@
       "title": "Part IV: Computational Verification",
       "startLine": 146,
       "endLine": 169,
-      "summary": "Seven native_decide examples verifying extGcd outputs correct GCD values and Bézout identities for (3,7), (5,7), (17,5), and (252,198).",
+      "summary": "Eight native_decide examples verifying extGcd outputs correct GCD values and Bézout identities for (3,7), (5,7), (17,5), and (252,198).",
       "mathContext": "E.g., $\\text{extGcd}(3,7) = (-2, 1, 1)$: $3(-2) + 7(1) = 1$. Also $\\text{extGcd}(252, 198) = (4, -5, 18)$."
     },
     {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: `bezout-identity-oq-02-oq-02-oq-01` — Constructive Divisibility Algorithm via Bézout Coefficients
**Audit count**: 4 → 5
**Result**: issues-fixed (one LOW prose nit)

## Machine-checkable claims — all match

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| theorems | 11 | 11 ✓ |
| definitions | 2 | 2 ✓ |
| lineCount | 200 | 200 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| True stubs | — | 0 ✓ |

## `native_decide` / axiom integrity

The 8 `native_decide` uses are all confined to anonymous `example` blocks
(lines 151–168) — concrete small-input GCD/Bézout sanity checks. No headline
theorem depends on kernel reduction; the substantive results
(`quotient_formula`, `constructive_div_correct`, `euclids_lemma_via_extGcd`,
`abstract_euclids_lemma`) are proved symbolically. The `Lean.ofReduceBool`
rule is therefore N/A and `verified`/`original`/`axiomCount: 0` is honest.
(`constructive_div` is `noncomputable` via `Classical.choice`, a foundational
axiom that does not count; the meta discloses this and points to the child
entry that removes it.)

## Tier classification: A — defensible

`extGcd` and its correctness proofs are from scratch (strong induction +
`linear_combination`); `quotient_formula` is a from-scratch calc chain valid
in any `CommRing`. Mathlib's `IsCoprime.dvd_of_dvd_mul_left` appears only in an
*agreement* `example`; the main `abstract_euclids_lemma` is proved via the
file's own `euclids_lemma_constructive`. No delegation opacity, no axiom
masking. Badge `original` is correct.

## Fix applied

Section IV (`computational-verification`) summary said **"Seven native_decide
examples"** — there are **eight** (gcd + Bézout checks for (3,7), (5,7),
(17,5), (252,198)). Corrected to "Eight".

---
Discovered during gallery integrity re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)