### PR TITLE
audit(bertrands-postulate): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -766,9 +766,9 @@
       "result": "clean"
     },
     "bertrands-postulate": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:31:44Z",
+      "lastAudited": "2026-06-18T08:00:00Z",
       "result": "clean"
     },
     "bertrands-postulate-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — `bertrands-postulate`

Re-audit of **Bertrand's Postulate** (Wiedijk #98).

### Result: CLEAN ✓

All machine fields match `meta.json` exactly:

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 151 | 151 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier-B classification (Mathlib wrapper) — properly disclosed

- `badge: "mathlib"` correctly signals the core result delegates to `Nat.exists_prime_lt_and_le_two_mul` / `Nat.exists_prime_lt_and_le_two_mul_eventually` (`Mathlib.NumberTheory.Bertrand`).
- Delegation explicitly credited in the overview `text`, `proofStrategy`, and the Lean docstring ("Foundation (from Mathlib)").
- `originalContributions` scoped honestly to pedagogical wrappers/corollaries: `prime_gap_bounded`, `primes_infinite_via_bertrand`, `no_largest_prime_via_bertrand`.
- `status: "verified"` defensible (0 sorries / 0 axioms / machine-checked) with `mathlib` badge signalling the source of the core argument.

### No narrative failure modes
No delegation opacity (credited everywhere), no axiom masking (no axioms), the existential theorem is genuinely formalized (not an inequality substitute), single-file scope with no pipeline inflation.

`auditCount` 3 → 4, result stays `clean`.

---
Discovered during gallery integrity audit.