### PR TITLE
research(nth-root-irrational-oq-02): uniform prime-factorization not-a-perfect-power criterion

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2707,6 +2707,7 @@ import Proofs.NthRootIrrationalOQ01OQ01Cos
 import Proofs.NthRootIrrationalOQ01OQ01CosRational
 import Proofs.NthRootIrrationalOQ01OQ01Degree
 import Proofs.NthRootIrrationalOQ01OQ01Real
+import Proofs.NthRootIrrationalOQ02
 import Proofs.OSBridge
 import Proofs.OnePlusOne
 import Proofs.OnePlusOneOQ04

--- a/proofs/Proofs/NthRootIrrationalOQ02.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ02.lean
@@ -1,0 +1,189 @@
+/-
+  Nth Root Irrationality OQ-02:
+  Uniform prime-factorization approach to not-a-perfect-power lemmas
+
+  The base file `NthRootIrrational.lean` proves the general theorem
+  `irrational_nthRoot : ¬(∃ k : ℤ, k ^ n = m) → Irrational (m ^ (1/n))`, but
+  it discharges each *not-a-perfect-power* hypothesis (`2` is not a perfect
+  square, `3` is not a perfect cube, ...) by an ad-hoc bounded case analysis
+  (`interval_cases` / `nlinarith` after deriving an explicit upper bound on the
+  candidate root).  That style does **not** scale: certifying that a large value
+  such as `1000003` is not a perfect square would require an `interval_cases`
+  over roughly `1000` candidates, and certifying that `2` is not a perfect
+  `100`-th power is hopeless that way.
+
+  This file replaces those bounded arguments with a single, uniform
+  **prime-factorization** criterion that scales to arbitrary values and
+  arbitrary exponents:
+
+      a positive `m` is a perfect `n`-th power  ⟹  for every prime `p`,
+      `n ∣ (m.factorization p)`.
+
+  Contrapositive (`not_perfect_pow_of_factorization`): if some prime `p` has an
+  exponent in `m` that is **not** divisible by `n`, then `m` is not a perfect
+  `n`-th power.  From this one lemma we obtain, with no case analysis:
+
+  * `prime_not_perfect_pow` — no prime is a perfect `n`-th power (`n ≥ 2`),
+    because the prime's own exponent is `1`.  This single result subsumes every
+    `p_not_perfect_sq` / `p_not_perfect_cube` / ... lemma of the base file, for
+    *all* primes and *all* exponents at once.
+  * `not_perfect_pow_of_sq_not_dvd` — a value divisible by a prime `p` exactly
+    once (`p ∣ m`, `p² ∤ m`) is not a perfect `n`-th power (`n ≥ 2`).  The two
+    divisibility side-conditions are cheap `decide`s independent of the size of
+    `m`, so this covers composite values (`6`, `12`, `2 · 1000003`, ...) as well.
+
+  Bridging back through `Int.natAbs` (`not_perfect_pow_int`) feeds these into the
+  base `irrational_nthRoot`, giving uniform irrationality corollaries that the
+  bounded approach cannot reach (e.g. `Irrational (¹⁰⁰√2)`).
+
+  Results (0 axioms, 0 sorries):
+  - not_perfect_pow_of_factorization   (the uniform criterion)
+  - not_perfect_pow_int                (ℕ ⟹ ℤ bridge via natAbs)
+  - prime_not_perfect_pow              (primes, all exponents)
+  - not_perfect_pow_of_sq_not_dvd      (single-prime-factor values)
+  - irrational_nthRoot_prime           (irrationality of ⁿ√p)
+  - irrational_nthRoot_of_sq_not_dvd   (irrationality of ⁿ√m)
+  - Concrete corollaries that do not scale under bounded case analysis.
+-/
+
+import Mathlib
+import Proofs.NthRootIrrational
+
+set_option maxHeartbeats 1000000
+
+namespace NthRootIrrationalOQ02
+
+open NthRootIrrational
+
+/-! ## Part 1: The Uniform Prime-Factorization Criterion
+
+The heart of the generalization.  If `m = k ^ n` then, by
+`Nat.factorization_pow`, every prime exponent of `m` is `n` times the
+corresponding exponent of `k`, hence divisible by `n`.  Contrapositively, a
+single prime whose exponent is *not* divisible by `n` certifies that `m` is not
+a perfect `n`-th power — no search over candidate roots is required. -/
+
+/-- **Uniform not-a-perfect-power criterion.**  If some prime exponent
+`m.factorization p` of `m` is not divisible by `n`, then `m` is not a perfect
+`n`-th power.  This is the prime-factorization replacement for the base file's
+per-value `interval_cases` lemmas. -/
+theorem not_perfect_pow_of_factorization {m n p : ℕ}
+    (hndvd : ¬ n ∣ m.factorization p) : ¬ ∃ k : ℕ, k ^ n = m := by
+  rintro ⟨k, rfl⟩
+  apply hndvd
+  rw [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul]
+  exact dvd_mul_right n _
+
+/-! ## Part 2: From ℕ to ℤ
+
+The base `irrational_nthRoot` phrases "not a perfect power" over `ℤ`.  Since
+`(k ^ n).natAbs = k.natAbs ^ n`, an integer `n`-th root of a natural number
+yields a natural `n`-th root, so it suffices to rule out natural roots. -/
+
+/-- If `m` is not a perfect `n`-th power over `ℕ`, it is not one over `ℤ` either.
+For `k ^ n = m` with `m : ℕ`, taking `Int.natAbs` gives `k.natAbs ^ n = m`. -/
+theorem not_perfect_pow_int {m n : ℕ} (h : ¬ ∃ k : ℕ, k ^ n = m) :
+    ¬ ∃ k : ℤ, k ^ n = (m : ℤ) := by
+  rintro ⟨k, hk⟩
+  refine h ⟨k.natAbs, ?_⟩
+  have h2 := congrArg Int.natAbs hk
+  rwa [Int.natAbs_pow, Int.natAbs_natCast] at h2
+
+/-! ## Part 3: Specializations
+
+Two ready-to-use instances of the criterion.  Neither performs any search. -/
+
+/-- **No prime is a perfect `n`-th power** for `n ≥ 2`: the prime's own exponent
+is `1`, which is not divisible by `n`.  One lemma for every prime and every
+exponent — replacing the entire `_not_perfect_sq` / `_not_perfect_cube` / ...
+family of the base file. -/
+theorem prime_not_perfect_pow {p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) :
+    ¬ ∃ k : ℕ, k ^ n = p := by
+  apply not_perfect_pow_of_factorization (p := p)
+  rw [hp.factorization_self]
+  intro hdvd
+  have := Nat.le_of_dvd one_pos hdvd
+  omega
+
+/-- **A value divisible by a prime exactly once is not a perfect power.**  If
+`p ∣ m` but `p² ∤ m` (so `p` appears to exponent `1` in `m`), then `m` is not a
+perfect `n`-th power for `n ≥ 2`.  The hypotheses are size-independent `decide`s,
+so this handles composite values such as `6`, `12`, or `2 · 1000003`. -/
+theorem not_perfect_pow_of_sq_not_dvd {m n p : ℕ} (hp : p.Prime) (hm : m ≠ 0)
+    (hn : 2 ≤ n) (hd : p ∣ m) (hnd : ¬ p ^ 2 ∣ m) : ¬ ∃ k : ℕ, k ^ n = m := by
+  apply not_perfect_pow_of_factorization (p := p)
+  have h1 : 1 ≤ m.factorization p :=
+    (hp.pow_dvd_iff_le_factorization hm).mp (by simpa using hd)
+  have h2 : ¬ 2 ≤ m.factorization p := fun hge =>
+    hnd ((hp.pow_dvd_iff_le_factorization hm).mpr hge)
+  have heq : m.factorization p = 1 := by omega
+  rw [heq]
+  intro hdvd
+  have := Nat.le_of_dvd one_pos hdvd
+  omega
+
+/-! ## Part 4: Uniform Irrationality Corollaries
+
+Feeding the criteria through the base `irrational_nthRoot`.  These reach values
+and exponents the bounded approach cannot. -/
+
+/-- **Irrationality of `ⁿ√p` for any prime `p` and any `n ≥ 2`.**  No bound on
+the candidate root, no case analysis — uniform in both `p` and `n`. -/
+theorem irrational_nthRoot_prime {p n : ℕ} (hp : p.Prime) (hn : 1 < n) :
+    Irrational (nthRoot n p) :=
+  irrational_nthRoot n p hn
+    (not_perfect_pow_int (prime_not_perfect_pow hp (by omega)))
+
+/-- **Irrationality of `ⁿ√m` whenever a prime divides `m` exactly once.**
+Covers composite radicands via cheap divisibility checks. -/
+theorem irrational_nthRoot_of_sq_not_dvd {m n p : ℕ} (hn : 1 < n) (hp : p.Prime)
+    (hm : m ≠ 0) (hd : p ∣ m) (hnd : ¬ p ^ 2 ∣ m) :
+    Irrational (nthRoot n m) :=
+  irrational_nthRoot n m hn
+    (not_perfect_pow_int (not_perfect_pow_of_sq_not_dvd hp hm (by omega) hd hnd))
+
+/-! ## Part 5: Concrete Corollaries the Bounded Approach Cannot Reach
+
+Each of these is a one-liner here.  Under the base file's `interval_cases`
+strategy they would require enumerating hundreds of candidates (large primes)
+or are outright infeasible (high exponents). -/
+
+/-- `√2` irrational — the classic, now a special case. -/
+theorem irrational_sqrt_two : Irrational (nthRoot 2 2) :=
+  irrational_nthRoot_prime (by norm_num) (by norm_num)
+
+/-- `√101` irrational.  No `interval_cases` over `k ≤ 10`. -/
+theorem irrational_sqrt_101 : Irrational (nthRoot 2 101) :=
+  irrational_nthRoot_prime (by norm_num) (by norm_num)
+
+/-- `√1000003` irrational.  The bounded approach would enumerate ~1000
+candidate roots; here the prime exponent argument is immediate. -/
+theorem irrational_sqrt_1000003 : Irrational (nthRoot 2 1000003) :=
+  irrational_nthRoot_prime (by norm_num) (by norm_num)
+
+/-- `¹⁰⁰√2` irrational — *infeasible* under bounded case analysis, trivial here.
+This is the key demonstration that the criterion is uniform in the exponent. -/
+theorem irrational_hundredth_root_two : Irrational (nthRoot 100 2) :=
+  irrational_nthRoot_prime (by norm_num) (by norm_num)
+
+/-- `⁵√7` irrational. -/
+theorem irrational_fifth_root_seven : Irrational (nthRoot 5 7) :=
+  irrational_nthRoot_prime (by norm_num) (by norm_num)
+
+/-- `√6` irrational — composite radicand, `2 ∣ 6` but `4 ∤ 6`. -/
+theorem irrational_sqrt_six : Irrational (nthRoot 2 6) :=
+  irrational_nthRoot_of_sq_not_dvd (by norm_num) (p := 2) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- `√12` irrational — `12 = 2² · 3`, certified via the lone prime `3`
+(`3 ∣ 12`, `9 ∤ 12`), not via the square factor `2`. -/
+theorem irrational_sqrt_twelve : Irrational (nthRoot 2 12) :=
+  irrational_nthRoot_of_sq_not_dvd (by norm_num) (p := 3) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- `∛12` irrational — same radicand, exponent `3`, uniform criterion. -/
+theorem irrational_cbrt_twelve : Irrational (nthRoot 3 12) :=
+  irrational_nthRoot_of_sq_not_dvd (by norm_num) (p := 3) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+end NthRootIrrationalOQ02

--- a/src/data/proofs/nth-root-irrational-oq-02/annotations.json
+++ b/src/data/proofs/nth-root-irrational-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-criterion",
+    "proofId": "nth-root-irrational-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 76
+    },
+    "type": "concept",
+    "title": "The Uniform Prime-Factorization Criterion",
+    "content": "Proves `not_perfect_pow_of_factorization`: if some prime `p` has `m.factorization p` not divisible by `n`, then `m` is not a perfect `n`-th power.\n\n**Proof.** Assume `m = k^n`. By `Nat.factorization_pow`, `(k^n).factorization = n • k.factorization`, so evaluating at `p` (via `Finsupp.smul_apply` and `smul_eq_mul`) gives `m.factorization p = n * k.factorization p`. Hence `n ∣ m.factorization p` (`dvd_mul_right`), contradicting the hypothesis. The argument needs no bound on the candidate root `k` and no primality of `p` — it is purely the scaling law of p-adic valuations under powers.",
+    "mathContext": "If $m = k^n$ then $v_p(m) = n \\cdot v_p(k)$, so $n \\mid v_p(m)$ for every prime $p$. Contrapositive: $n \\nmid v_p(m)$ for one prime $p$ certifies that $m$ is not a perfect $n$-th power.",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime factorization",
+      "p-adic valuation",
+      "Nat.factorization_pow",
+      "perfect power"
+    ],
+    "prerequisites": [
+      "unique factorization",
+      "Nat.factorization"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "nth-root-irrational-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 91
+    },
+    "type": "concept",
+    "title": "Bridging Natural and Integer Roots",
+    "content": "Proves `not_perfect_pow_int`: ruling out natural `n`-th roots of `m` rules out integer roots too. From `k^n = (m : ℤ)`, applying `Int.natAbs` to both sides and using `Int.natAbs_pow` and `Int.natAbs_natCast` yields `k.natAbs ^ n = m` over `ℕ`. This adapts the natural-number factorization criterion to the `¬ ∃ k : ℤ, k^n = m` hypothesis shape required by the base file's `irrational_nthRoot`.",
+    "mathContext": "$(k^n).\\mathrm{natAbs} = (\\lvert k\\rvert)^n$ and $\\lvert (m:\\mathbb{Z})\\rvert = m$, so an integer root collapses to a natural root.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.natAbs",
+      "Int.natAbs_pow",
+      "integer vs natural roots"
+    ],
+    "prerequisites": [
+      "absolute value on integers"
+    ]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "nth-root-irrational-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 124
+    },
+    "type": "concept",
+    "title": "Specializations: Primes and Single-Factor Radicands",
+    "content": "Two ready-to-use instances of the criterion, neither performing any search.\n\n`prime_not_perfect_pow`: a prime `p` is never a perfect `n`-th power for `n ≥ 2`. Since `Nat.Prime.factorization_self` gives `p.factorization p = 1`, and `1` is not divisible by any `n ≥ 2` (`Nat.le_of_dvd` + `omega`), the criterion fires with `p` as the witnessing prime. This single lemma subsumes the base file's entire `two_not_perfect_sq` / `three_not_perfect_cube` / ... family — for all primes and all exponents at once.\n\n`not_perfect_pow_of_sq_not_dvd`: if `p ∣ m` but `p² ∤ m`, then `m` is not a perfect `n`-th power. Using `Nat.Prime.pow_dvd_iff_le_factorization`, the two divisibility facts pin `m.factorization p = 1`. Both side-conditions are size-independent `decide`s, so composite radicands are handled cheaply.",
+    "mathContext": "$v_p(p) = 1$ gives `prime_not_perfect_pow` uniformly; `p \\mid m \\wedge p^2 \\nmid m \\Rightarrow v_p(m) = 1` gives the composite case via `Nat.Prime.pow_dvd_iff_le_factorization`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.Prime.factorization_self",
+      "Nat.Prime.pow_dvd_iff_le_factorization",
+      "squarefree at a prime"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-irrationality",
+    "proofId": "nth-root-irrational-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 144
+    },
+    "type": "concept",
+    "title": "Uniform Irrationality Corollaries",
+    "content": "Composes the criteria with the base general theorem `NthRootIrrational.irrational_nthRoot`. `irrational_nthRoot_prime` gives `Irrational (nthRoot n p)` for every prime `p` and `n ≥ 2`; `irrational_nthRoot_of_sq_not_dvd` gives `Irrational (nthRoot n m)` whenever a prime divides `m` exactly once. Each is a single term-mode line: the not-a-perfect-power obligation is discharged by the uniform criterion rather than by per-value case analysis.",
+    "mathContext": "$\\sqrt[n]{p} \\notin \\mathbb{Q}$ for prime $p$, $n \\ge 2$; $\\sqrt[n]{m} \\notin \\mathbb{Q}$ when some prime divides $m$ exactly once.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "irrational_nthRoot",
+      "Irrational",
+      "term-mode proof"
+    ],
+    "prerequisites": [
+      "base nth-root general theorem"
+    ]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "nth-root-irrational-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 189
+    },
+    "type": "concept",
+    "title": "Corollaries Beyond Bounded Case Analysis",
+    "content": "One-line irrationality results that the base file's `interval_cases` strategy cannot reach: `irrational_sqrt_1000003` (the bounded approach would enumerate ~1000 candidate roots), `irrational_hundredth_root_two` (the 100th root of 2 — outright infeasible by case analysis, demonstrating uniformity in the exponent), `irrational_fifth_root_seven`, and the composite radicands `irrational_sqrt_six`, `irrational_sqrt_twelve`, and `irrational_cbrt_twelve`. Note `√12` is certified through the lone prime `3` (`3 ∣ 12`, `9 ∤ 12`), not through the square factor `2` — illustrating that the witnessing prime need not be the smallest.",
+    "mathContext": "$\\sqrt{1000003}, \\sqrt[100]{2}, \\sqrt[5]{7}, \\sqrt{6}, \\sqrt{12}, \\sqrt[3]{12} \\notin \\mathbb{Q}$, each immediate from the uniform corollaries.",
+    "significance": "key",
+    "relatedConcepts": [
+      "scalability",
+      "high exponents",
+      "composite radicands"
+    ],
+    "prerequisites": [
+      "the uniform corollaries"
+    ]
+  }
+]

--- a/src/data/proofs/nth-root-irrational-oq-02/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-02/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "nth-root-irrational-oq-02",
+  "title": "Nth Root Irrationality: Uniform Prime-Factorization Criterion",
+  "slug": "nth-root-irrational-oq-02",
+  "description": "Replaces the base nth-root file's per-value bounded case-analysis 'not a perfect power' lemmas with a single uniform prime-factorization criterion: if a prime p divides m to an exponent not divisible by n, then m is not a perfect nth power. The criterion scales to arbitrary radicands and exponents, reaching results the bounded approach cannot (e.g. the irrationality of the 100th root of 2 and of the square root of 1000003).",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "generalization",
+      "prime-factorization",
+      "research"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/NthRootIrrationalOQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_pow",
+        "description": "(n^k).factorization = k • n.factorization — every prime exponent of a power is scaled by the exponent",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.Prime.factorization_self",
+        "description": "p.factorization p = 1 for a prime p",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "p^k ∣ m ↔ k ≤ m.factorization p, for prime p and m ≠ 0",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Int.natAbs_pow",
+        "description": "(a^n).natAbs = a.natAbs ^ n — bridges integer roots to natural roots",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "irrational_nthRoot",
+        "description": "Base-file general theorem: not a perfect nth power over ℤ implies the nth root is irrational",
+        "module": "Proofs.NthRootIrrational"
+      }
+    ],
+    "originalContributions": [
+      "Uniform prime-factorization not-a-perfect-power criterion (not_perfect_pow_of_factorization) replacing the base file's per-value interval_cases lemmas",
+      "prime_not_perfect_pow: a single lemma showing no prime is a perfect nth power for all primes and all exponents n ≥ 2",
+      "not_perfect_pow_of_sq_not_dvd: certifies composite radicands via size-independent divisibility checks (p ∣ m, p² ∤ m)",
+      "Integer-to-natural bridge via Int.natAbs feeding the base general theorem",
+      "Concrete corollaries unreachable by bounded case analysis: 100th root of 2, square root of 1000003, and composite radicands 6, 12"
+    ],
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "lineCount": 189,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Builds on the base file's verified general theorem irrational_nthRoot.",
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The base entry nth-root-irrational proves that m^(1/n) is irrational whenever m is not a perfect nth power, but discharges each 'not a perfect power' obligation by an ad-hoc bounded case analysis — deriving an explicit upper bound on the candidate root and running interval_cases. That entry's own open-questions list asked whether 'a more uniform approach (e.g., via prime factorization) scale to larger values'. This entry answers that question. The relevant fact — m is a perfect nth power iff every prime exponent in its factorization is divisible by n — is the standard unique-factorization criterion found in Hardy & Wright, but here it is turned into a reusable Lean lemma that eliminates the search entirely.",
+    "problemStatement": "The base file certifies 'm is not a perfect n-th power' one value at a time, via case analysis bounded by m. This does not scale: large radicands force enormous interval_cases, and large exponents are infeasible. Can these obligations be discharged uniformly?\n\n$$m = k^n \\implies \\forall p \\text{ prime}, \\; n \\mid v_p(m).$$\n\nContrapositively, a single prime $p$ with $n \\nmid v_p(m)$ certifies that $m$ is not a perfect $n$-th power — with no search over candidate roots.",
+    "text": "A uniform prime-factorization criterion for 'not a perfect nth power', replacing the base file's per-value bounded case analysis and scaling to arbitrary radicands and exponents.",
+    "proofStrategy": "1. **Uniform criterion** (`not_perfect_pow_of_factorization`): if `m = k^n`, then by `Nat.factorization_pow` we have `m.factorization p = n * k.factorization p` for every prime `p`, hence `n ∣ m.factorization p`. Contrapositively, a prime whose exponent is not divisible by `n` rules out `m` being a perfect `n`-th power.\n\n2. **Specializations**: `prime_not_perfect_pow` instantiates `p = m` (a prime has exponent `1` at itself, never divisible by `n ≥ 2`); `not_perfect_pow_of_sq_not_dvd` uses `Nat.Prime.pow_dvd_iff_le_factorization` to read off exponent `1` from the cheap conditions `p ∣ m` and `p² ∤ m`.\n\n3. **Bridge to ℤ** (`not_perfect_pow_int`): an integer root `k` of `m` yields a natural root `k.natAbs` via `Int.natAbs_pow`, so ruling out natural roots suffices.\n\n4. **Irrationality**: feed the criteria into the base `irrational_nthRoot`.",
+    "keyInsights": [
+      "The single identity (m^(1/n) is rational iff m is a perfect nth power) reduces to a divisibility condition on prime exponents, which Mathlib's Nat.factorization captures directly via Nat.factorization_pow.",
+      "Because a prime p has factorization exponent exactly 1 at itself, the lemma prime_not_perfect_pow covers ALL primes and ALL exponents n ≥ 2 in one stroke — no per-value proofs.",
+      "For composite radicands it suffices to exhibit one prime dividing m exactly once; the witnessing conditions p ∣ m and p² ∤ m are decided in time independent of the size of m.",
+      "The 100th root of 2 and the square root of 1000003 are immediate here, yet hopeless under the base file's interval_cases strategy — concretely demonstrating that the criterion scales in both the radicand and the exponent.",
+      "Working over ℕ and bridging to ℤ via Int.natAbs keeps the factorization machinery in its natural setting."
+    ],
+    "prerequisites": [
+      "Number theory (unique prime factorization, p-adic valuation / Nat.factorization)",
+      "The base entry nth-root-irrational (general theorem irrational_nthRoot)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup and Motivation",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Module documentation contrasting the bounded case analysis with the uniform criterion, imports, and namespace opening the base file.",
+      "mathContext": "Imports Mathlib and the base file Proofs.NthRootIrrational (reusing nthRoot and irrational_nthRoot). The goal is to replace per-value not-a-perfect-power lemmas with a single criterion in terms of the prime factorization $v_p(m)$."
+    },
+    {
+      "id": "criterion",
+      "title": "The Uniform Prime-Factorization Criterion",
+      "startLine": 58,
+      "endLine": 76,
+      "summary": "not_perfect_pow_of_factorization: a prime exponent not divisible by n certifies m is not a perfect nth power.",
+      "mathContext": "If $m = k^n$ then $v_p(m) = n \\cdot v_p(k)$ by `Nat.factorization_pow`, so $n \\mid v_p(m)$ for every prime $p$. Contrapositive: $n \\nmid v_p(m)$ for some prime $p$ implies $m$ is not a perfect $n$-th power."
+    },
+    {
+      "id": "bridge",
+      "title": "From ℕ to ℤ",
+      "startLine": 77,
+      "endLine": 91,
+      "summary": "not_perfect_pow_int: an integer nth root yields a natural nth root via Int.natAbs.",
+      "mathContext": "For $k^n = m$ with $m \\in \\mathbb{N}$, taking $\\lvert\\cdot\\rvert$ gives $\\lvert k\\rvert^n = m$ via `Int.natAbs_pow`, so ruling out natural roots rules out integer roots — matching the hypothesis shape of the base `irrational_nthRoot`."
+    },
+    {
+      "id": "specializations",
+      "title": "Specializations: Primes and Single-Factor Radicands",
+      "startLine": 92,
+      "endLine": 124,
+      "summary": "prime_not_perfect_pow (no prime is a perfect nth power) and not_perfect_pow_of_sq_not_dvd (radicand divisible by a prime exactly once).",
+      "mathContext": "A prime has $v_p(p) = 1$, never divisible by $n \\ge 2$, giving `prime_not_perfect_pow` for all primes and exponents at once. `Nat.Prime.pow_dvd_iff_le_factorization` converts the cheap conditions $p \\mid m$, $p^2 \\nmid m$ into $v_p(m) = 1$, handling composite radicands."
+    },
+    {
+      "id": "irrationality",
+      "title": "Uniform Irrationality Corollaries",
+      "startLine": 125,
+      "endLine": 144,
+      "summary": "irrational_nthRoot_prime and irrational_nthRoot_of_sq_not_dvd, feeding the criteria into the base general theorem.",
+      "mathContext": "Composing the criteria with the base `irrational_nthRoot` yields $\\sqrt[n]{p} \\notin \\mathbb{Q}$ for every prime $p$ and $n \\ge 2$, and $\\sqrt[n]{m} \\notin \\mathbb{Q}$ whenever a prime divides $m$ exactly once."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Corollaries Beyond Bounded Case Analysis",
+      "startLine": 145,
+      "endLine": 189,
+      "summary": "One-line irrationality results unreachable by interval_cases: sqrt(101), sqrt(1000003), the 100th root of 2, fifth root of 7, and composite radicands sqrt(6), sqrt(12), cbrt(12).",
+      "mathContext": "Each result is immediate from the uniform corollaries. $\\sqrt{1000003}$ would require enumerating ~1000 candidate roots under the bounded approach; $\\sqrt[100]{2}$ is outright infeasible there. Composite cases ($\\sqrt{6}, \\sqrt{12}, \\sqrt[3]{12}$) are certified by a single prime dividing the radicand once."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers an open question posed by the base nth-root file: the per-value, interval_cases 'not a perfect power' obligations are replaced by a single uniform prime-factorization criterion. A prime whose exponent in m is not divisible by n certifies that m is not a perfect nth power, with no search over candidate roots. The criterion scales in both the radicand and the exponent, yielding irrationality results — the 100th root of 2, the square root of 1000003, composite radicands — that the bounded approach cannot reach.",
+    "implications": "**Methodological**: The result illustrates how moving from an extensional (enumerate candidates) to an intensional (read off a structural invariant) argument turns an unscalable family of lemmas into one reusable theorem. The key enabler is Mathlib's Nat.factorization together with Nat.factorization_pow, which exposes the p-adic valuation algebraically.\n\n**Reusability**: To certify any new radicand it now suffices to exhibit one prime with the wrong exponent — for primes this is automatic, and for composites a single divisibility pair (p ∣ m, p² ∤ m) suffices, both checked in size-independent time.",
+    "openQuestions": [
+      "Can the criterion be packaged as an iff (m is a perfect nth power ↔ n divides every prime exponent), giving a decision procedure for perfect-power testing?",
+      "The composite corollary requires a prime appearing to exponent exactly 1. Can the general criterion be exposed ergonomically for radicands all of whose prime exponents are ≥ 2 but not all divisible by n (e.g. 72 = 2³·3²)?",
+      "Does an analogous factorization criterion give clean irrationality proofs for nth roots in number fields or for rational radicands a/b?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "extends",
+      "description": "Directly answers the base entry's open question on whether a prime-factorization approach could replace its bounded case-analysis not-a-perfect-power lemmas and scale to larger values. Reuses the base general theorem irrational_nthRoot."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The criterion is a direct application of unique factorization: m is a perfect nth power iff every prime in its factorization appears with multiplicity divisible by n. Mathlib's Nat.factorization encodes exactly this prime-exponent data."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Recovers the irrationality of sqrt(2) (and of every nth root of a prime) as a one-line instance of prime_not_perfect_pow, with no parity or bounded argument."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.NthRootIrrational"
+    ],
+    "opens": [
+      "NthRootIrrational"
+    ],
+    "namespace": "NthRootIrrationalOQ02",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "path": "Proofs/NthRootIrrationalOQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hardy, G.H.; Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "The unique-factorization characterization of perfect powers underlying the criterion."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "not_perfect_pow_of_factorization",
+      "type": "core",
+      "description": "If a prime p has m.factorization p not divisible by n, then m is not a perfect nth power",
+      "leanType": "{m n p : Nat} -> not (n ∣ m.factorization p) -> not (exists k : Nat, k^n = m)"
+    },
+    {
+      "name": "prime_not_perfect_pow",
+      "type": "core",
+      "description": "No prime is a perfect nth power for n ≥ 2 — uniform in the prime and the exponent",
+      "leanType": "{p n : Nat} -> p.Prime -> 2 ≤ n -> not (exists k : Nat, k^n = p)"
+    },
+    {
+      "name": "irrational_nthRoot_prime",
+      "type": "application",
+      "description": "The nth root of any prime is irrational, for any n ≥ 2",
+      "leanType": "{p n : Nat} -> p.Prime -> 1 < n -> Irrational (nthRoot n p)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the base entry `nth-root-irrational`'s literal open question OQ-02: replacing the ad-hoc, per-value `interval_cases` not-a-perfect-power arguments with a **single uniform prime-factorization criterion** that scales to arbitrary radicands and exponents.

New file `proofs/Proofs/NthRootIrrationalOQ02.lean` (189 lines, 14 theorems, **0 sorries, 0 axioms**).

## The criterion

`not_perfect_pow_of_factorization`: if some prime `p` has `¬ n ∣ m.factorization p`, then `m` is not a perfect `n`-th power. Proof: if `m = k^n`, `Nat.factorization_pow` forces every prime exponent to be a multiple of `n`. No search over candidate roots.

## Consequences (no case analysis)

- `prime_not_perfect_pow` — no prime is a perfect `n`-th power (exponent is `1`); subsumes the entire `_not_perfect_sq`/`_not_perfect_cube`/… family for all primes and exponents at once.
- `not_perfect_pow_of_sq_not_dvd` — `p ∣ m`, `p² ∤ m` ⟹ not a perfect power; handles composites (`6`, `12`, `2·1000003`) via size-independent `decide`s.
- `not_perfect_pow_int` — `ℕ ⟹ ℤ` bridge via `Int.natAbs`, feeding the base `irrational_nthRoot`.

## Demonstrations unreachable by the bounded approach

`Irrational (¹⁰⁰√2)` (infeasible under `interval_cases`), `√1000003` (~1000 candidates avoided), plus `√101`, `⁵√7`, `√6`, `√12`, `∛12`.

## Verification

Docker build `Proofs.NthRootIrrationalOQ02` — **exit 0, no errors/sorries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)