### PR TITLE
Fix: remove false Wiedijk #37 from dissection-of-cubes-oq-02-oq-02

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -15,7 +15,6 @@
       "dehn-invariant",
       "hilbert-problems",
       "tensor-products",
-      "wiedijk-100",
       "research"
     ],
     "badge": "mathlib",
@@ -58,7 +57,6 @@
     "lineCount": 454,
     "assumptions": "0 axioms. All assumptions eliminated. tmul_infinite_order_ne_zero proved via Module.Flat: ℝ is flat over ℤ (Bézout domain + NoZeroSMulDivisors ℤ ℝ), so lTensor ℝ f is injective for any injective f : ℤ →ₗ[ℤ] AngleQuot, giving r⊗x≠0 when r≠0 and x has infinite order. Previously 6 axioms; all eliminated across sessions.",
     "mathlib_version": "4.26.0",
-    "wiedijkNumber": 37,
     "relatedProblems": [
       {
         "id": "dissection-of-cubes-oq-02",
@@ -66,7 +64,7 @@
       },
       {
         "id": "dissection-of-cubes",
-        "relationship": "Root formalization of Hilbert's Third Problem (Wiedijk #37); this file provides the proper tensor product Dehn invariant"
+        "relationship": "Root formalization of Hilbert's Third Problem; this file provides the proper tensor product Dehn invariant"
       }
     ],
     "theoremCount": 24,
@@ -210,7 +208,7 @@
     {
       "targetId": "dissection-of-cubes",
       "relationship": "extends",
-      "description": "Root formalization of Hilbert's Third Problem (Wiedijk #37). This file provides the proper tensor product Dehn invariant and the Dehn-Sydler completeness statement."
+      "description": "Root formalization of Hilbert's Third Problem. This file provides the proper tensor product Dehn invariant and the Dehn-Sydler completeness statement."
     },
     {
       "targetId": "dissection-of-cubes-oq-01",


### PR DESCRIPTION
## Fix

`dissection-of-cubes-oq-02-oq-02` claimed Wiedijk **#37** in its metadata, tag, and two prose strings. Wiedijk #37 is **"The Solution of a Cubic"** — this entry formalizes the **Dehn invariant / Hilbert's Third Problem** (Dehn-Sydler completeness), which does not appear anywhere on Wiedijk's list of 100 theorems.

## Evidence

- Canonical list (https://www.cs.ru.nl/~freek/100/): **#37 = "The Solution of a Cubic"**, **#60 = "Bezout's Theorem"**, **#82 = "Dissection of Cubes" (Littlewood)**. Hilbert's Third Problem / Dehn invariant is not listed.
- The base entry `dissection-of-cubes` correctly carries **#82**; every sibling Dehn-invariant variant (`-oq-02`, `-oq-02-wip-01`, `-oq-04`) carries **no** Wiedijk number. Only this entry was mislabeled #37.

**Before**: `wiedijkNumber: 37`, `"wiedijk-100"` tag, two `(Wiedijk #37)` prose references.
**After**: field removed, tag removed, prose references dropped. JSON validated.

---
Automated fix by lean-mechanic agent.