### PR TITLE
Fix: remove false Wiedijk #60 from gelfond-schneider

### DIFF
--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -36,14 +36,12 @@
       "transcendence",
       "number-theory",
       "hilbert-problems",
-      "wiedijk-100",
       "intermediate"
     ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2025-12-29",
     "hilbertNumber": 7,
-    "wiedijkNumber": 60,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -94,7 +92,7 @@
     "definitionCount": 2
   },
   "overview": {
-    "historicalContext": "**Gelfond-Schneider Theorem — Hilbert's 7th Problem, Wiedijk #60**\n\nIn 1900, David Hilbert posed his famous 23 problems at the International Congress of Mathematicians. Problem #7 asked: *Is $a^b$ always transcendental when $a$ is algebraic ($\\neq 0, 1$) and $b$ is irrational algebraic?*\n\n**Historical Development:**\n- **1900**: Hilbert posed the problem, citing $2^{\\sqrt{2}}$ as the motivating example\n- **1929**: Aleksandr Gelfond proved special cases (e.g., $e^\\pi$)\n- **1934**: Gelfond (*Sur le septième problème de Hilbert*) and Theodor Schneider (*Transzendenzuntersuchungen periodischer Funktionen*) independently proved the full theorem\n- **1966**: Alan Baker generalized to linear forms in logarithms, earning the Fields Medal (1970)\n\n**Famous corollaries**: $2^{\\sqrt{2}}$ (the Gelfond-Schneider constant) and $e^\\pi$ (Gelfond's constant) are both transcendental. The $e^\\pi$ result uses the clever observation $e^\\pi = (-1)^{-i}$ from Euler's identity.",
+    "historicalContext": "**Gelfond-Schneider Theorem — Hilbert's 7th Problem**\n\nIn 1900, David Hilbert posed his famous 23 problems at the International Congress of Mathematicians. Problem #7 asked: *Is $a^b$ always transcendental when $a$ is algebraic ($\\neq 0, 1$) and $b$ is irrational algebraic?*\n\n**Historical Development:**\n- **1900**: Hilbert posed the problem, citing $2^{\\sqrt{2}}$ as the motivating example\n- **1929**: Aleksandr Gelfond proved special cases (e.g., $e^\\pi$)\n- **1934**: Gelfond (*Sur le septième problème de Hilbert*) and Theodor Schneider (*Transzendenzuntersuchungen periodischer Funktionen*) independently proved the full theorem\n- **1966**: Alan Baker generalized to linear forms in logarithms, earning the Fields Medal (1970)\n\n**Famous corollaries**: $2^{\\sqrt{2}}$ (the Gelfond-Schneider constant) and $e^\\pi$ (Gelfond's constant) are both transcendental. The $e^\\pi$ result uses the clever observation $e^\\pi = (-1)^{-i}$ from Euler's identity.",
     "problemStatement": "**Theorem (Gelfond-Schneider):** If $a, b \\in \\mathbb{C}$ are algebraic with $a \\neq 0, 1$ and $b \\notin \\mathbb{Q}$ (irrational), then $a^b$ is transcendental.\n\nHere $a^b = \\exp(b \\cdot \\log a)$ for a chosen branch of the logarithm.\n\n**Corollaries formalized:**\n1. $2^{\\sqrt{2}}$ is transcendental (Hilbert's original example)\n2. $e^\\pi = (-1)^{-i}$ is transcendental (Gelfond's constant)\n3. $(\\sqrt{2})^{\\sqrt{2}}$ is transcendental\n4. $2^{\\sqrt[3]{2}}$ is transcendental",
     "text": "If a and b are algebraic numbers with a not equal to 0, 1 and b irrational, then a^b is transcendental. Resolves Hilbert's 7th Problem.",
     "proofStrategy": "The complex version is axiomatized (the full proof requires Siegel's lemma, auxiliary function construction, and analytic function theory). The real version `gelfond_schneider_real` is **proved** from the complex version by:\n\n1. **Lifting**: Embed $\\mathbb{R} \\hookrightarrow \\mathbb{C}$, preserving algebraicity\n2. **Irrationality transfer**: Show $b \\notin \\mathbb{Q}$ in $\\mathbb{R}$ implies $b \\notin \\mathbb{Q}$ in $\\mathbb{C}$\n3. **Power compatibility**: Use `real_cpow_eq_rpow` to equate real and complex powers\n4. **Transcendence transfer**: Push transcendence back from $\\mathbb{C}$ to $\\mathbb{R}$\n\nCorollaries are proved by verifying the three hypotheses (algebraic base, algebraic irrational exponent).",


### PR DESCRIPTION
## Fix

`gelfond-schneider` claimed Wiedijk **#60** in its metadata, tag, and historical-context prose. Wiedijk #60 is **"Bezout's Theorem"** — correctly held by the `bezout-identity` entry. The **Gelfond-Schneider theorem (Hilbert's 7th Problem)** does not appear anywhere on Wiedijk's list of 100 theorems.

## Evidence

- Canonical list (https://www.cs.ru.nl/~freek/100/): **#60 = "Bezout's Theorem"**. Gelfond-Schneider / Hilbert's 7th is absent from both the main list and the supplementary section.
- `bezout-identity` already (correctly) carries Wiedijk #60 — the two entries were colliding on the same number.

**Before**: `wiedijkNumber: 60`, `"wiedijk-100"` tag, `Wiedijk #60` in historical context.
**After**: removed. `hilbertNumber: 7` retained (Hilbert's 7th is correct). JSON validated.

---
Automated fix by lean-mechanic agent.