### PR TITLE
audit(cevas-theorem-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1983,9 +1983,9 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:32:27Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — CLEAN

**Proof**: \`cevas-theorem-oq-02\` — Ceva's Theorem: Non-Euclidean Geometries, Menelaus Duality, and Gauss-Bonnet
**Status**: verified/original (Tier A) — **confirmed defensible**
**Result**: clean (auditCount 3 → 4)

## Machine-checkable fields (all match)

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 501 | 501 (CevasTheoremOQ02.lean) |
| theoremCount | 22 | 22 |
| definitionCount | 11 | 11 |
| sorries | 0 | 0 |
| axiomCount | 0 | 0 |
| native_decide | — | 0 |
| decide | — | 0 |
| True stubs | — | 0 |

Supplementary file \`CevasTheoremSinRatio.lean\` (145L, 1 thm) also 0 sorry / 0 axiom.

## Tier-A verified/original is defensible

- **No wrapper masking.** Headline \`spherical_menelaus\` / \`hyperbolic_menelaus\` prove the sin/sinh ratio-product ↔ magnitude identity via elementary algebra. \`sinh_pos_of_pos'\` is derived from scratch (\`Real.sinh_eq\` + exp monotonicity), not a Mathlib lemma. All 4 \`mathlibDependencies\` are elementary (\`sin_pos\`, \`exp_strictMono\`, \`div_mul_div_comm\`, \`div_eq_one_iff_eq\`) — no deep theorem does the core work → badge \`original\` honest.
- **No axiom masking.** \`gaussBonnetTriangle\` is a \`def : Prop\` used only as an *explicit hypothesis* in the downstream theorems (\`gauss_bonnet_spherical/hyperbolic/euclidean\`, \`gauss_bonnet_sign_consistency\`); it is never asserted true. So axiomCount=0 is correct.
- **No inequality-as-theorem overclaim.** The meta repeatedly discloses that the actual geometric concurrence/collinearity correspondence and Gauss-Bonnet itself are NOT proved and remain the open question (problemStatement, keyInsights, section mathContext "carried hypothesis", conclusion #4, openQuestions).

## Changes

- \`audit-tracker.json\`: \`cevas-theorem-oq-02\` auditCount 3 → 4, refresh \`lastAudited\`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)