### PR TITLE
audit(nth-root-irrational-oq-02): clean first audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15873,6 +15873,12 @@
       "lastAudited": "2026-06-18T07:33:48Z",
       "result": "clean",
       "issues": []
+    },
+    "nth-root-irrational-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T08:18:39Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — `nth-root-irrational-oq-02`

First audit of the **Uniform Prime-Factorization Criterion** entry (the sole previously-unaudited proof). Result: **clean**.

### Machine-checkable claims (all match `Proofs/NthRootIrrationalOQ02.lean`)
| Field | meta.json | Source |
|-------|-----------|--------|
| theorems | 14 | 14 ✓ |
| definitions | 0 | 0 ✓ |
| lineCount | 189 | 189 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| native_decide | 0 | 0 ✓ |
| True stubs | 0 | 0 ✓ |

The two `decide` string matches are docstring prose ("cheap `decide`s"), **not** tactic invocations — proofs use `norm_num`/`omega`/`simpa`. No `Lean.ofReduceBool`, so `verified` / `axiomCount: 0` is honest.

### Narrative / tier
- **Tier B, badge `mathlib`** — conservative and appropriate. The core criterion `not_perfect_pow_of_factorization` is a genuine short contrapositive derivation over `Nat.factorization_pow`; the irrationality corollaries rest on the **fully-disclosed** base-file theorem `irrational_nthRoot` (signature verified: `¬∃ k:ℤ, k^n = m → Irrational (nthRoot n m)`).
- All Mathlib dependencies + the base-file dependency are listed in `mathlibDependencies`.
- `originalContributions` accurately scope what is independently proved.
- No delegation opacity, axiom masking, inequality-vs-theorem confusion, or pipeline inflation. Title is descriptive, no famous-theorem overclaim. **LOW risk.**

Only the audit tracker is updated.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)