### PR TITLE
audit(cayley-hamilton-reduction-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1872,9 +1872,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:32:27Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — cayley-hamilton-reduction-oq-01

**Result: CLEAN** (re-audit, auditCount 4→5)

Efficient Cayley-Hamilton reduction for sparse matrices (`verified` / badge `mathlib`, Tier B).

### Machine fields — all match source exactly
| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 304 | 304 ✓ |
| theoremCount | 14 | 14 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True-stubs | — | 0 ✓ |

### Narrative integrity
- **Badge `mathlib` is correct and conservative.** Several core structural results are direct one-line Mathlib wrappers: `upper_tri_charpoly_eq_prod` (= `Matrix.charpoly_of_upperTriangular`), the three block factorizations (`charpoly_fromBlocks_zero₁₂/₂₁`, `BlockTriangular.charpoly`), and `matrix_charpoly_monic`.
- **No delegation opacity.** The `assumptions` field states "Core reduction and nilpotency results rely on Mathlib's Cayley-Hamilton theorem (`Matrix.aeval_self_charpoly`)", and `proofStrategy` names each Mathlib theorem used per section.
- **originalContributions are honest.** The genuine in-file work — `upper_tri_aeval_eq_aeval_mod` (polynomial-division reduction via `modByMonic_add_div`), the nilpotency chain (`strictly_upper_tri_charpoly/nilpotent/pow_vanish`), and the diagonal-power inductions (`diagonal_pow_off_diagonal/diagonal`) — is correctly listed.
- No `verified`-vs-axiom overclaim (genuinely 0 axioms, 0 sorries), no True stubs, title carries no famous-theorem overreach.

Tracker updated to clean 5×.

---
Discovered during autonomous gallery integrity audit.