### PR TITLE
audit(cayley-hamilton-minpoly-oq-02-oq-01-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1765,9 +1765,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:32:27Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-02": {
@@ -15876,5 +15876,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T06:52:09Z"
+  "lastUpdated": "2026-06-18T00:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: cayley-hamilton-minpoly-oq-02-oq-01-oq-01 — *Skolem-Noether Theorem: K-Algebra Automorphisms of Mₙ(K)*
**Result**: clean (re-audit 4→5)
**Status/Badge**: verified / mathlib — appropriate (conservative; see below)

## Machine-checkable fields (all match `SkolemNoetherMatrixAut.lean`)

| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 570 | 570 ✓ |
| theoremCount | 26 | 26 ✓ (incl. 6 `private`) |
| definitionCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

## Narrative integrity

- **No delegation opacity / hidden-import overclaim.** The headline `skolemNoether` theorem is genuinely proved from scratch via the elementary matrix-units approach — *no* Mathlib Skolem-Noether or Artin-Wedderburn call. The chain `stdBasis_mul → f_mul → intertwine_prop → p_linearIndependent` constructs an invertible `P` with `φ = conj(P)`. `center_iff_scalar` (Center(Mₙ(K))=K·I) and the PGL kernel results are likewise fully proved.
- **Mathlib delegations honestly disclosed.** Limited to supporting infrastructure: `minpoly.algEquiv_eq` (only for the secondary `automorphism_preserves_minpoly`), `AlgEquiv.ext`, `Units.mul_inv`/`inv_mul`, `inv_inv`, plus standard linear-algebra lemmas (`LinearMap.injective_iff_surjective`, `Matrix.isUnit_iff_isUnit_det`). All listed in `mathlibDependencies`.
- Badge `mathlib` is **conservative** for what is really a Tier-A from-scratch proof — an under-claim, not an over-claim, so left as-is.
- Companion `SkolemNoetherMatrixAutAristotle.lean`'s lone `sorry` is inside a comment line, not a real declaration.

No axiom masking, no inequality≠theorem inflation, no pipeline inflation.

---
Discovered during gallery integrity audit. Tracker bumped 4→5, result `clean`.