### PR TITLE
audit(nth-root-irrational-oq-02): restore clobbered tracker entry, clean re-verify

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15875,8 +15875,8 @@
       "issues": []
     },
     "nth-root-irrational-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-18T08:18:39Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-18T08:30:11Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery Integrity Audit — `nth-root-irrational-oq-02`

**Result: CLEAN** (tracker record restoration)

### Background
This entry was audited clean in #25544 (merged), but its `audit-tracker.json`
write was overwritten by a concurrent tracker update (#25535 landed afterward
without the entry). `find-targets --next` consequently kept surfacing it as
"never audited." This PR restores the lost tracker record.

### Re-verification (vs `src/data/proofs/nth-root-irrational-oq-02/meta.json`)
All machine-checkable fields match the Lean source `Proofs/NthRootIrrationalOQ02.lean`:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 189 | 189 ✓ |
| theoremCount | 14 | 14 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True-stub | — | 0 ✓ |

- The two `decide` strings (lines 32, 110) are **docstring prose**, not tactic calls.
- Status `verified` / badge `mathlib` — **Tier B**, correctly conservative: the
  irrationality result delegates to the base file's verified `irrational_nthRoot`
  plus Mathlib factorization lemmas, all disclosed in `mathlibDependencies`.
- `originalContributions` are scoped to the genuinely independent work (the uniform
  prime-factorization not-a-perfect-power criterion). No delegation opacity, no
  axiom masking, no inequality-as-theorem inflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)