### PR TITLE
audit(cayley-hamilton-minpoly-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1753,9 +1753,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T18:32:27Z",
+      "lastAudited": "2026-06-18T08:33:19Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: cayley-hamilton-minpoly-oq-02 — *Similar Matrices Have Identical Minimal Polynomials*
**Result**: CLEAN (re-audit, auditCount 5 → 6)
**Tier**: B (Mathlib-delegated) · badge `mathlib` · status `verified`

### Machine-checkable claims — all match
Verified against `proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean`:

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 131 | 131 | ✓ |
| theoremCount | 7 | 7 (2 lemmas + 5 theorems) | ✓ |
| definitionCount | 1 | 1 (`conjAlgHom`) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Narrative integrity
- **No delegation opacity.** The core minimal-polynomial uniqueness comes from Mathlib (`minpoly.unique`, `minpoly.monic`, `minpoly.aeval`, `minpoly.min`, `Polynomial.aeval_algHom_apply`). This is disclosed in the overview, conclusion ("uses … Mathlib's `aeval_algHom_apply`"), and `assumptions` field.
- **originalContributions correctly scoped** to what the file genuinely proves independently: the conjugation `K`-algebra endomorphism `conjAlgHom`, the commutation lemma `aeval_conj`, and `conj_eq_zero_iff` (conjugation reflects zero), plus the assembled `minpoly_similar` and corollaries.
- **badge `mathlib` is conservative and correct** (failure mode #5 "0 sorries with hidden imports" handled properly — not claimed as `original`).
- No axiom masking, no inequality-vs-theorem inflation, no pipeline inflation.

**Risk**: LOW. Publish as-is.

---
Discovered during gallery integrity audit. Tracker-only change.