### PR TITLE
research(kaprekar-constant-oq-01): register + integrate gallery entry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2545,6 +2545,7 @@ import Proofs.IsoperimetricTheoremOQ01
 import Proofs.IsoperimetricTheoremOQ02
 import Proofs.IsoscelesTriangle
 import Proofs.IsoscelesTriangleOQ01
+import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture
 import Proofs.KeplerConjectureOQ04

--- a/src/data/proofs/kaprekar-constant-oq-01/annotations.json
+++ b/src/data/proofs/kaprekar-constant-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-kap01-01-kaprekar-map",
+    "proofId": "kaprekar-constant-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 78
+    },
+    "type": "concept",
+    "title": "The Kaprekar Map by Pure Arithmetic",
+    "content": "`kaprekarStep` realizes Kaprekar's routine without any list machinery. The four digits of `n` are extracted directly by integer arithmetic — `n / 1000 % 10`, `n / 100 % 10`, `n / 10 % 10`, `n % 10` — and ordered ascending by `sortAsc4`, an explicit five-comparator sorting network `(a,b)(c,d)(a,c)(b,d)(b,c)` built only from `min` and `max`. Writing the sorted digits as `w ≤ x ≤ y ≤ z`, the descending arrangement is `z·1000+y·100+x·10+w` and the ascending arrangement is `w·1000+x·100+y·10+z`, and `T(n)` is their difference.\n\nThe design choice matters: replacing `Nat.digits` and list `mergeSort` with raw `/`, `%`, `min`, `max` keeps each application of `T` cheap to reduce, which is exactly what makes the 10000-input `native_decide` convergence enumeration feasible. `NonRepdigit n` is the predicate 'the four digits are not all equal' (repdigits collapse to 0 and are excluded), and it is given a `Decidable` instance so bounded quantifiers over it are decidable.",
+    "mathContext": "For ascending digits $w \\le x \\le y \\le z$, $T(n) = (z\\cdot 1000 + y\\cdot 100 + x\\cdot 10 + w) - (w\\cdot 1000 + x\\cdot 100 + y\\cdot 10 + z)$. The network $(a,b)(c,d)(a,c)(b,d)(b,c)$ sorts four inputs using only $\\min$/$\\max$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sorting network",
+      "base-10 digit extraction",
+      "Function.iterate",
+      "Decidable instances"
+    ],
+    "prerequisites": [
+      "integer division and remainder in ℕ",
+      "min/max on ℕ",
+      "decidability of equality on ℕ"
+    ]
+  },
+  {
+    "id": "ann-kap01-02-fixed-point",
+    "proofId": "kaprekar-constant-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 81
+    },
+    "type": "concept",
+    "title": "6174 is a Fixed Point (Kernel-Checked)",
+    "content": "`kaprekar_fixed : kaprekarStep 6174 = 6174` is a single concrete evaluation, so it is discharged by kernel `decide` rather than `native_decide` — this one fact is genuinely axiom-free. Concretely, the digits of 6174 are {6,1,7,4}; descending gives 7641, ascending gives 1467, and 7641 − 1467 = 6174.\n\nBecause 6174 is a fixed point, the later convergence statement `T^[7](n) = 6174` is *exactly* the assertion 'the orbit of n reaches 6174 within seven steps and stays there' — there is no need for a separate 'reaches and remains' argument.",
+    "mathContext": "$7641 - 1467 = 6174$, so $T(6174) = 6174$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fixed point",
+      "decide tactic",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "fixed point of a self-map",
+      "kernel decide vs native_decide"
+    ]
+  },
+  {
+    "id": "ann-kap01-03-convergence",
+    "proofId": "kaprekar-constant-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 93
+    },
+    "type": "concept",
+    "title": "Bounded Convergence to 6174",
+    "content": "`kaprekar_converges_all` is the heart of the entry: `∀ n ∈ Finset.range 10000, NonRepdigit n → kaprekarStep^[7] n = 6174`. The predicate is decidable and the domain is finite, so the whole proposition is decidable and is settled by `native_decide`, which compiles the decision procedure and evaluates it over all 10000 inputs. `kaprekar_converges` then repackages it for an arbitrary `n < 10000` via `Finset.mem_range`.\n\nThe seven-step claim is global: every four-digit string with at least two distinct digits, regardless of starting orbit, lands on 6174 after at most seven applications of T. This is the 'global attractor' phenomenon that makes 6174 famous.",
+    "mathContext": "$\\forall n < 10000,\\ \\text{NonRepdigit}(n) \\Rightarrow T^{[7]}(n) = 6174$. Since 6174 is fixed, this is exactly 'reaches 6174 within 7 steps'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "native_decide",
+      "Lean.ofReduceBool",
+      "global attractor",
+      "Finset.range",
+      "bounded quantifier decidability"
+    ],
+    "prerequisites": [
+      "Function.iterate",
+      "decidability of bounded ∀",
+      "native_decide and its axiom dependency"
+    ]
+  },
+  {
+    "id": "ann-kap01-04-uniqueness",
+    "proofId": "kaprekar-constant-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 101
+    },
+    "type": "concept",
+    "title": "Uniqueness of the Fixed Point",
+    "content": "`kaprekar_unique_fixed : ∀ n < 10000, NonRepdigit n → kaprekarStep n = n → n = 6174`. Strikingly, this needs no enumeration of its own: it falls straight out of convergence. If `n` is a fixed point then it is unchanged by any number of iterations, so `kaprekarStep^[7] n = n` (`Function.iterate_fixed`); but `kaprekarStep^[7] n = 6174` by `kaprekar_converges`, hence `n = 6174`. So once every orbit is known to end at 6174, 6174 is automatically the *only* non-repdigit fixed point — the two facts together pin it down as the unique global attractor among non-repdigit four-digit strings, and uniqueness inherits its single native_decide dependency from convergence rather than adding a new one.",
+    "mathContext": "$\\forall n < 10000,\\ \\text{NonRepdigit}(n) \\wedge T(n) = n \\Rightarrow n = 6174$, via $T^{[7]}(n) = n$ (iterate of a fixed point) $= 6174$ (convergence).",
+    "significance": "key",
+    "relatedConcepts": [
+      "fixed point uniqueness",
+      "Function.iterate_fixed",
+      "derived from convergence"
+    ],
+    "prerequisites": [
+      "fixed points",
+      "decidable bounded quantifiers"
+    ]
+  },
+  {
+    "id": "ann-kap01-05-sharpness",
+    "proofId": "kaprekar-constant-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "Sharpness of the Seven-Step Bound",
+    "content": "`kaprekar_bound_sharp : ∃ n ∈ Finset.range 10000, NonRepdigit n ∧ kaprekarStep^[6] n ≠ 6174` certifies that the constant 7 is not an over-estimate: some non-repdigit four-digit string still has not reached 6174 after six steps, so `T^[6]` is genuinely insufficient and seven steps are sometimes necessary. No enumeration is needed — it suffices to exhibit one witness, namely 0014 (`n = 14`), for which `kaprekarStep^[6] 14 = 4176 ≠ 6174`; both the membership/predicate side conditions and the inequality are settled by kernel `decide`, so this fact is itself native_decide-free. It complements convergence (seven steps always suffice) to give a tight bound of exactly seven.",
+    "mathContext": "$\\exists n < 10000,\\ \\text{NonRepdigit}(n) \\wedge T^{[6]}(n) \\neq 6174$; witness $n = 14$ with $T^{[6]}(14) = 4176$, so the worst-case orbit length is exactly 7.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sharp bound",
+      "worst-case orbit length",
+      "explicit witness"
+    ],
+    "prerequisites": [
+      "existential decidability over a finite domain"
+    ]
+  }
+]

--- a/src/data/proofs/kaprekar-constant-oq-01/meta.json
+++ b/src/data/proofs/kaprekar-constant-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "kaprekar-constant-oq-01",
+  "title": "Kaprekar's Constant 6174: Global Attractor of the Digit-Sort Subtraction Map",
+  "slug": "kaprekar-constant-oq-01",
+  "description": "Formalizes Kaprekar's routine T on four-digit decimal strings: arrange the digits in descending order to form D and ascending order to form A, set T(n) = D - A. Proves that every four-digit number whose digits are not all equal reaches 6174 — Kaprekar's constant — in at most seven steps, that 6174 is the unique non-repdigit fixed point, and that the seven-step bound is sharp. The full convergence claim is the single enumeration over all 10000 four-digit strings, discharged by native_decide; uniqueness is derived symbolically from it (no extra enumeration) and sharpness is a single kernel-decide witness. Status axiomatized (one assumption: Lean.ofReduceBool).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-16",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/KaprekarConstantOQ01.lean",
+    "tags": [
+      "number-theory",
+      "digits",
+      "kaprekar",
+      "fixed-point",
+      "dynamical-systems",
+      "decidable",
+      "native-decide"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-06-16",
+    "axiomCount": 1,
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The single enumeration `kaprekar_converges_all` — every non-repdigit `n < 10000` satisfies `T^[7] n = 6174` — is discharged by `native_decide` over `Finset.range 10000`. The other three results are native_decide-free: `kaprekar_fixed` (T(6174) = 6174) and `kaprekar_bound_sharp` (the witness 0014 still differs from 6174 after six steps) are kernel-checked by `decide`, and `kaprekar_unique_fixed` (6174 is the unique non-repdigit fixed point below 10000) is derived symbolically from `kaprekar_converges_all` via `Function.iterate_fixed` with no separate enumeration. Under the gallery convention (CLAUDE.md), the presented convergence result depends on `native_decide` and hence on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
+    "lineCount": 110,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "originalContributions": [
+      "Arithmetic-only Kaprekar map: digits extracted by `/` and `%`, sorted by an explicit five-comparator sorting network (min/max only), and recombined as (z·1000+y·100+x·10+w) − (w·1000+x·100+y·10+z). Avoids `Nat.digits` and list `mergeSort`, keeping the map cheap to reduce.",
+      "kaprekar_fixed: T(6174) = 6174 — kernel-checked by `decide`",
+      "kaprekar_converges: every n < 10000 with not-all-equal digits satisfies T^[7](n) = 6174 (since 6174 is a fixed point, this is exactly 'reaches 6174 within seven steps')",
+      "kaprekar_unique_fixed: 6174 is the only non-repdigit fixed point of T below 10000",
+      "kaprekar_bound_sharp: seven steps are sometimes necessary — T^[6] does not always reach 6174, so the bound is tight",
+      "sortAsc4: a five-comparator (a,b)(c,d)(a,c)(b,d)(b,c) sorting network for four naturals, used to realize the descending/ascending digit arrangements without sorting lists"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1949 the Indian recreational mathematician D. R. Kaprekar described a curious self-map of four-digit numbers, presented at the Madras Mathematical Conference. Take any four-digit number with at least two distinct digits, write its digits in descending and then ascending order to form two numbers, and subtract the smaller from the larger. Iterating this operation always reaches 6174 — now called Kaprekar's constant — after at most seven steps, and 6174 then maps to itself.\n\nThe number 6174 is a fixed point because its digit arrangements give 7641 − 1467 = 6174. Among four-digit strings (allowing leading zeros) whose digits are not all equal, it is the unique fixed point; repdigits such as 1111 collapse to 0. The analogous three-digit constant is 495 (reached in at most six steps). For most other digit lengths there is no single Kaprekar constant: the routine instead falls into one of several cycles, which is why the four-digit case is mathematically special.\n\nThe statement is a finite, fully decidable dynamical-systems fact: there are only 10000 four-digit strings, and the orbit of each is determined by iterating T. The interest lies less in difficulty than in the surprising global-attractor behaviour of an elementary digit operation, and in giving it a clean machine-checked statement.",
+    "problemStatement": "Define Kaprekar's routine T(n) = D(n) − A(n), where D and A reassemble the four decimal digits of n (leading zeros included) in descending and ascending order. Prove that for every n < 10000 whose digits are not all equal, iterating T reaches 6174 within seven steps; that 6174 is the unique such fixed point; and that the seven-step bound is sharp.",
+    "text": "T is modelled by pure arithmetic. The four digits a, b, c, d of n are extracted with `/` and `%`. A five-comparator sorting network (a,b)(c,d)(a,c)(b,d)(b,c) places them in ascending order w ≤ x ≤ y ≤ z using only min and max — no list operations. The descending arrangement is z·1000+y·100+x·10+w and the ascending arrangement is w·1000+x·100+y·10+z, so T(n) is their difference. Because 6174 is a fixed point, the bounded-convergence claim 'reaches 6174 within seven steps' is exactly the single equation T^[7](n) = 6174.",
+    "proofStrategy": "Convergence is the one enumeration: `kaprekar_converges_all` ranges over `Finset.range 10000` with a decidable predicate (NonRepdigit has a Decidable instance), so the statement ∀ n, NonRepdigit n → T^[7] n = 6174 is decidable and is discharged by `native_decide`, which compiles the decision procedure and evaluates it. The remaining three results avoid native_decide: T(6174) = 6174 (`kaprekar_fixed`) and the sharpness witness (`kaprekar_bound_sharp`, the single string 0014) are kernel-checked by `decide`, and uniqueness (`kaprekar_unique_fixed`) is derived symbolically — a fixed point is unchanged by seven iterations (`Function.iterate_fixed`), which by convergence equal 6174 — so no separate enumeration is needed. All four claims were exhaustively cross-checked in Python before formalization: T(6174)=6174, 6174 is the unique non-repdigit fixed point in [0,10000), T^[7](n)=6174 for every non-repdigit n<10000 with zero exceptions, and the maximum number of steps actually required is 7.",
+    "keyInsights": [
+      "Because 6174 is a fixed point, bounded convergence collapses to the single clean equation T^[7](n) = 6174 — no separate 'reaches and stays' argument is needed.",
+      "Modelling T by raw arithmetic over a five-comparator sorting network (instead of `Nat.digits` + `mergeSort`) keeps each step cheap to evaluate, which is what makes the 10000-input `native_decide` enumerations feasible.",
+      "Repdigits (1111, 2222, …) are exactly the inputs excluded by NonRepdigit: their orbit collapses to 0, so they must be removed for 6174 to be the global attractor.",
+      "Uniqueness follows from convergence for free: any fixed point is unchanged by seven iterations (Function.iterate_fixed), but seven iterations land on 6174 by convergence, so the only non-repdigit fixed point is 6174 — no separate enumeration is needed.",
+      "Sharpness (kaprekar_bound_sharp) shows the constant 7 is not an over-estimate: some four-digit strings genuinely require all seven iterations, so T^[6] is not always enough.",
+      "The four-digit case is special: 495 is the three-digit analogue, but for most other digit lengths the routine has cycles rather than a single fixed constant — there is no general 'Kaprekar constant'."
+    ],
+    "prerequisites": [
+      "Elementary base-10 digit arithmetic (integer division and remainder)",
+      "Iteration of a self-map (Function.iterate) and the notion of a fixed point / global attractor",
+      "Decidability of bounded quantifiers and the role of native_decide / Lean.ofReduceBool"
+    ]
+  },
+  "conclusion": {
+    "summary": "Kaprekar's routine on four-digit strings is fully formalized: every non-repdigit n < 10000 reaches 6174 within seven steps (kaprekar_converges), 6174 is the unique non-repdigit fixed point (kaprekar_unique_fixed), and the seven-step bound is sharp (kaprekar_bound_sharp), with T(6174)=6174 kernel-checked. 6 theorems, 3 definitions, 0 sorries, 0 axiom declarations; the convergence enumeration depends on Lean.ofReduceBool via native_decide.",
+    "implications": "The entry gives a clean, machine-checked statement of a classic recreational-mathematics fact as a finite dynamical-systems theorem. The arithmetic-only encoding of a digit-sort map — extraction by `/`/`%`, ordering by a fixed sorting network, recombination by place value — is a reusable template for formalizing other digit-manipulation maps (e.g. the three-digit constant 495, happy numbers, or narcissistic-number checks) where keeping the step cheap to reduce is what makes exhaustive verification tractable.",
+    "openQuestions": [
+      "Produce a 0-axiom (kernel `decide`) version by quotienting to the ≤715 sorted-digit multiset representatives — T factors through the digit multiset — together with a multiset-invariance lemma, avoiding native_decide entirely.",
+      "Characterize the Kaprekar dynamics for ≥5 digits, where there is no single constant: classify the cycles (e.g. the five-digit cycles) and their basins.",
+      "Prove a structural (non-enumerative) reason for the seven-step bound and for uniqueness of 6174, rather than verifying them by exhaustion."
+    ]
+  },
+  "leanFile": {
+    "namespace": "KaprekarConstantOQ01",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "path": "Proofs/KaprekarConstantOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "kaprekar-map",
+      "title": "The Kaprekar Map by Pure Arithmetic",
+      "startLine": 52,
+      "endLine": 78,
+      "summary": "Defines sortAsc4 (a five-comparator sorting network for four naturals), kaprekarStep (extract digits by /,%; sort; recombine descending minus ascending), and NonRepdigit (digits not all equal), with a Decidable instance for NonRepdigit.",
+      "mathContext": "For ascending digits w ≤ x ≤ y ≤ z, T(n) = (z·1000+y·100+x·10+w) − (w·1000+x·100+y·10+z). The network (a,b)(c,d)(a,c)(b,d)(b,c) sorts four inputs using only min/max."
+    },
+    {
+      "id": "fixed-point",
+      "title": "6174 is a Fixed Point",
+      "startLine": 80,
+      "endLine": 81,
+      "summary": "kaprekar_fixed: T(6174) = 6174, checked by kernel `decide` (no native_decide, so this single fact is axiom-free).",
+      "mathContext": "7641 − 1467 = 6174."
+    },
+    {
+      "id": "convergence",
+      "title": "Bounded Convergence to 6174",
+      "startLine": 83,
+      "endLine": 93,
+      "summary": "kaprekar_converges_all enumerates over Finset.range 10000 (native_decide) that every non-repdigit reaches 6174 in seven steps; kaprekar_converges repackages it for an arbitrary n < 10000.",
+      "mathContext": "Since 6174 is fixed, T^[7](n) = 6174 is exactly 'reaches 6174 within 7 steps'."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the Fixed Point",
+      "startLine": 95,
+      "endLine": 101,
+      "summary": "kaprekar_unique_fixed: among non-repdigit four-digit strings, 6174 is the only fixed point of T. Derived symbolically (no native_decide) from kaprekar_converges via Function.iterate_fixed — a fixed point is unchanged by seven iterations, which equal 6174.",
+      "mathContext": "∀ n < 10000, NonRepdigit n → T(n) = n → n = 6174."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness of the Seven-Step Bound",
+      "startLine": 103,
+      "endLine": 108,
+      "summary": "kaprekar_bound_sharp: there exists a non-repdigit n < 10000 with T^[6](n) ≠ 6174, so six steps do not always suffice and the bound 7 is tight. Proved by exhibiting the single witness 0014 and kernel `decide` (no native_decide).",
+      "mathContext": "∃ n < 10000, NonRepdigit n ∧ T^[6](n) ≠ 6174; witness n = 14 (0014), with T^[6](14) = 4176."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Kaprekar, D. R."
+      ],
+      "title": "An interesting property of the number 6174",
+      "year": "1955",
+      "venue": "Scripta Mathematica, vol. 21, pp. 304",
+      "note": "Original description of the four-digit Kaprekar routine and its constant 6174"
+    },
+    {
+      "authors": [
+        "Hanover, Daniel"
+      ],
+      "title": "The Base Dependent Behavior of Kaprekar's Routine",
+      "year": "2017",
+      "venue": "arXiv:1710.06308",
+      "note": "Survey of Kaprekar dynamics across bases and digit lengths, including the absence of a single constant for most digit counts"
+    },
+    {
+      "authors": [
+        "Nishiyama, Yutaka"
+      ],
+      "title": "Mysterious number 6174",
+      "year": "2006",
+      "venue": "Plus Magazine (University of Cambridge)",
+      "note": "Expository account of the seven-step convergence and the three-digit analogue 495"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the **kaprekar-constant-oq-01** gallery entry, which was stuck purely on the prior Docker outage. The Lean file `proofs/Proofs/KaprekarConstantOQ01.lean` already merged via #25150 but was **unregistered** in `Proofs.lean` and had no gallery data on `main`.

This PR:
- Registers `import Proofs.KaprekarConstantOQ01` in `proofs/Proofs.lean` (alphabetical).
- Adds `src/data/proofs/kaprekar-constant-oq-01/{meta.json,annotations.json}`.
- **Build-verified green**: `docker-build.sh Proofs.KaprekarConstantOQ01` → `Build completed successfully (7743 jobs)`.

## Axiom integrity

`status: axiomatized`, `badge: axiom`, `axiomCount: 1` (`Lean.ofReduceBool`), `leanFile.axiomCount: 0`.

Only the single convergence enumeration `kaprekar_converges_all` (∀ n < 10000, NonRepdigit n → T^[7] n = 6174) uses `native_decide`. The other three results are native_decide-free:
- `kaprekar_fixed` (T(6174)=6174) — kernel `decide`
- `kaprekar_unique_fixed` — derived **symbolically** from convergence via `Function.iterate_fixed` (no enumeration)
- `kaprekar_bound_sharp` — single kernel-`decide` witness 0014

## Prose corrections

The pre-existing gallery data described a **stale design**: it referenced a nonexistent `kaprekar_unique_fixed_all` theorem and labeled both uniqueness and sharpness as `native_decide`. I rewrote `description`, `meta.assumptions`, `proofStrategy`, the relevant key insight, two section summaries, and two annotations to match the actual committed file. Also fixed `lineCount` (106 → 110) and section/annotation line ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)