### PR TITLE
audit(chinese-remainder-constructive-oq-04): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2060,9 +2060,9 @@
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:32:28Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-04-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: `chinese-remainder-constructive-oq-04` (CRT for Arbitrary-Length Moduli Lists)
**Status/badge**: verified / original — **confirmed accurate**
**Result**: clean (auditCount 4 → 5)

### Machine fields verified vs `proofs/Proofs/ChineseRemainderConstructiveOQ04.lean`
| field | meta | source | ✓ |
|---|---|---|---|
| lineCount | 156 | 156 | ✓ |
| theoremCount | 5 | 3 lemmas + 2 theorems | ✓ |
| definitionCount | 3 | moduli, moduliProd, Satisfies | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### native_decide — incidental, not headline
4 `native_decide` calls, **all inside concrete `example` blocks** (Sunzi 23 mod 105, four-moduli 53 mod 210, six-prime 1 mod 30030). The headline theorems `crt_list` (existence) and `crt_list_unique` (uniqueness) are proved by **genuine symbolic list induction** — no `native_decide`. So no `Lean.ofReduceBool` reaches a substantive result and `axiomCount: 0` is honest.

### Tier B — DEFENSIBLE
The two-moduli core is Mathlib's `Nat.chineseRemainder` (plus `Nat.modEq_and_modEq_iff_modEq_mul` for the uniqueness combination), but the genuine original contribution is the **arbitrary-length list generalization via induction**: `crt_list`, `crt_list_unique`, and the bridge helpers `coprime_prod_of_forall`, `dvd_list_prod`, `modEq_of_dvd`. Mathlib reliance is fully disclosed in the overview, proofStrategy, `mathlibDependencies`, and the scoped `originalContributions`.

No delegation opacity, no axiom masking, no inequality-vs-theorem confusion, no pipeline inflation, no hidden imports. No changes needed beyond the tracker bump.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)