### PR TITLE
audit(erdos-430): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6953,9 +6953,9 @@
       "result": "clean"
     },
     "erdos-430": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
+      "lastAudited": "2026-06-18T08:52:00Z",
       "result": "clean"
     },
     "erdos-431": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-430

**Result: CLEAN** (re-audit, auditCount 3→4)

Erdős Problem #430: Composite Numbers in Greedy Large-Factor Sequences. Status `axiomatized` / badge `axiom`.

### Machine fields verified vs `Proofs/Erdos430Problem.lean`

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 275 | 275 | ✓ |
| axiomCount | 1 | 1 (`erdos_430_conjecture`) | ✓ |
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| structures | — | 0 | ✓ |

No structures present, so `axiomCount=1` captures all assumptions (1 literal axiom + 0 structure-encoded).

### Tier-C assessment — DEFENSIBLE

- **Headline honestly axiomatized.** `erdos_430_conjecture` (∃N₀, ∀n≥N₀, hasComposite n) is the OPEN problem and is declared as an `axiom`, not claimed proved. Status `axiomatized`, badge `axiom` — correct.
- **Genuine in-file work fully proved.** `erdos_385_equivalence` (Adenwalla's equivalence, both directions via strong induction), `greedySeq_terminates`, and the greedy structural lemmas (`greedyNext_admissible`, `greedySeq_admissible`, `greedyNext_lt`, `greedySeq_le`) are complete with 0 sorries.
- **native_decide disclosed.** 4 `native_decide` uses are on small-n witnesses (`hasComposite_5/7/9`) and `example_n8` — concrete/auxiliary, not the headline. The `assumptions` field explicitly states these are "verified by `native_decide`". No `verified` overclaim (entry is `axiomatized`).

No delegation opacity, axiom masking, inequality-as-theorem, pipeline inflation, or hidden-import issues.

---
Discovered during gallery integrity audit.