### PR TITLE
audit(elementary-quadratic-reciprocity-oq-03): native_decide → axiomatized (Lean.ofReduceBool)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2707,10 +2707,10 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T08:57:19Z",
+      "result": "issues-fixed"
     },
     "elementary-quadratic-reciprocity-oq-03-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -4,8 +4,8 @@
   "slug": "elementary-quadratic-reciprocity-oq-03",
   "description": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m,n.",
   "category": "number-theory",
-  "status": "verified",
-  "badge": "original",
+  "status": "axiomatized",
+  "badge": "axiom",
   "difficulty": "intermediate",
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
@@ -26,13 +26,15 @@
   },
   "lineCount": 199,
   "theoremCount": 10,
-  "axiomCount": 0,
-  "assumptions": [],
+  "axiomCount": 1,
+  "assumptions": [
+    "Lean.ofReduceBool — the second supplement theorem `jacobiSym_two` (J(2,n) = (-1)^((n²-1)/8)) discharges the χ₈ character evaluations χ₈(1)=1, χ₈(3)=-1, χ₈(5)=-1, χ₈(7)=1 via `native_decide`, which trusts the Lean compiler's kernel reduction and therefore depends on the `Lean.ofReduceBool` axiom. The remaining theorems (reciprocity, first supplement, residuacity criteria) are axiom-free."
+  ],
   "meta": {
     "author": "Jacobi / Eisenstein (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "quadratic-reciprocity",
@@ -41,7 +43,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -75,10 +77,10 @@
       "Residuacity for primes: J(a,p) = 1 implies QR for prime p (proved)"
     ],
     "dateAdded": "2026-03-22",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 199,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "The second supplement `jacobiSym_two` proves J(2,n) = (-1)^((n²-1)/8) by evaluating the χ₈ character on residues 1,3,5,7 mod 8 via `native_decide`, which depends on the `Lean.ofReduceBool` axiom (it trusts the compiler's kernel reduction). The other six theorems are axiom-free. 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Integrity Issue (MEDIUM — axiom masking)

**Proof**: `elementary-quadratic-reciprocity-oq-03` (Jacobi Symbol and QR for Composite Moduli)

**Problem**: The entry was presented as `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "None. Fully verified with 0 axioms and 0 sorries."` — but a substantive headline theorem depends on `Lean.ofReduceBool`.

## Evidence

`proofs/Proofs/ElementaryQuadraticReciprocityOQ03.lean`, theorem **`jacobiSym_two`** (the second supplementary law, J(2,n) = (-1)^((n²-1)/8), one of the 7 headline results) discharges the χ₈ character evaluations via `native_decide`:

- L98: `χ₈ ((1 : ℕ) : ZMod 8) = 1 := by native_decide`
- L107: `χ₈ ((3 : ℕ) : ZMod 8) = -1 := by native_decide`
- L116: `χ₈ ((5 : ℕ) : ZMod 8) = -1 := by native_decide`
- L125: `χ₈ ((7 : ℕ) : ZMod 8) = 1 := by native_decide`

These `have hchi` facts are load-bearing (`rw [hchi]` in each case). `native_decide` trusts the compiler's kernel reduction and so `#print axioms jacobiSym_two` lists `Lean.ofReduceBool` — the theorem is **not** axiom-free.

Per the repo's Axiom Integrity Policy (`native_decide` rule): a substantive result the entry presents as verified that is discharged by `native_decide` must be counted as `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, with `Lean.ofReduceBool` disclosed.

## Fix Applied

- `status`: verified → **axiomatized** (top-level + `meta`)
- `badge`: original → **axiom** (top-level + `meta`)
- `axiomCount`: 0 → **1** (top-level + `meta`)
- `leanFile.axiomCount`: stays **0** (no literal `axiom` declarations — counts those only)
- `assumptions`: now discloses the `native_decide`/`Lean.ofReduceBool` dependency in `jacobiSym_two`; notes the other six theorems (reciprocity, first supplement, residuacity criteria) remain axiom-free.

All numeric fields verified to match source: 199 lines, 10 theorem/lemma declarations, 0 sorries, 0 literal axioms, 0 True stubs. No other issues found.

---
Discovered during gallery integrity audit.