### PR TITLE
audit(cevas-theorem-oq-02-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2006,9 +2006,9 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "cevas-theorem-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: cevas-theorem-oq-02-oq-02 (Ceva's Theorem for Spherical Polygons)
**Result**: clean (5th audit)
**Status/Badge**: verified / mathlib — unchanged, correct

### Machine fields (all match source `CevasTheoremOQ02OQ02.lean`)
| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 320 | 320 ✓ |
| theoremCount | 17 | 17 ✓ |
| definitionCount | 4 | struct + 3 defs ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 axiom decls ✓ |

Also: 0 `native_decide`, 0 plain `decide`, 0 `True` stubs.

### Integrity assessment
- **`PolygonCevaConfig` structure fields** (`α_pos`, `β_pos`) are positivity constraints on input data (theorem-hypothesis style), **not** assumption-encoding axioms → `axiomCount: 0` honest, no structure-encoded assumptions.
- **Tier B / badge `mathlib`** is conservative. Core is elementary Finset-product algebra (`Finset.prod_div_distrib`, `div_eq_one_iff_eq`, `Finset.prod_pos`); `mathlibDependencies` accurately disclosed.
- **No overclaim on the geometry**: `angle_product_from_weight_ratios` takes the sin-ratio relation `sinRatio i = β i / α i` as an explicit **hypothesis** (`hsr`); the spherical sin-ratio fact itself is referenced from `CevasTheoremOQ02OQ01.lean`, not re-asserted here. The file proves the algebraic weight-balance criterion and its n=3/n=4/medial/Menelaus-duality/scaling specializations — exactly what `originalContributions` lists.
- `assumptions: "None. Fully verified with 0 axioms and 0 sorries."` is accurate.

No changes to meta.json required. Tracker bumped 4 → 5, result `clean`.

---
Discovered during gallery integrity audit.