### PR TITLE
Enrich Ptolemy Inequality (OQ-01): annotate Parts 5-7

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/annotations.json
@@ -117,5 +117,54 @@
       "ptolemy_ratio_pos_of_ccw",
       "PtolemysComplexProof.ptolemy_equality_of_proportional"
     ]
+  },
+  {
+    "id": "ann-ptol-oq01-05",
+    "proofId": "ptolemys-theorem-oq-01",
+    "range": {
+      "startLine": 388,
+      "endLine": 430
+    },
+    "type": "insight",
+    "title": "ptolemy_equality_for_concyclic: From the Unit Circle to Every Circle",
+    "content": "This is the file's capstone, generalizing the unit-circle result to four points on an arbitrary circle. `IsConcyclic\u2084 z\u2081 z\u2082 z\u2083 z\u2084` asserts a common center c and radius r > 0 with \u2016z\u1d62 - c\u2016 = r. The theorem extracts that witness with classical choice (`hcyc.choose`, `hcyc.choose_spec`), normalizes each point to w\u1d62 = (z\u1d62 - c)/r on the unit circle via `concyclic_normalize_to_unit`, applies `ptolemy_equality_for_unit_circle_ccw` to the normalized points, and transfers the equality back to the originals with `ptolemy_iff_normalized`. The crucial fact making this work is that Ptolemy's relation is invariant under similarity transformations: the normalization map z \u21a6 (z - c)/r is a translation followed by a positive scaling, and every term of the identity is a product of two distances, so both sides scale by exactly 1/r\u00b2 and the equation is preserved.",
+    "mathContext": "The similarity z \u21a6 (z-c)/r sends a circle of radius r to the unit circle. Each Ptolemy term \u2016z\u1d62-z\u2c7c\u2016\u00b7\u2016z\u2096-z\u2097\u2016 transforms as $\\frac{|z_i-z_j|}{r}\\cdot\\frac{|z_k-z_l|}{r} = \\frac{1}{r^2}|z_i-z_j||z_k-z_l|$, so the full identity $|z_1-z_3||z_2-z_4| = |z_1-z_2||z_3-z_4| + |z_2-z_3||z_1-z_4|$ is homogeneous of degree 2 and invariant under the normalization. Reducing to the unit circle therefore loses no generality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "concyclicity",
+      "similarity invariance",
+      "classical choice (Exists.choose)",
+      "affine normalization",
+      "homogeneous relation"
+    ],
+    "prerequisites": [
+      "ptolemy_equality_for_unit_circle_ccw",
+      "concyclic_normalize_to_unit",
+      "ptolemy_iff_normalized"
+    ]
+  },
+  {
+    "id": "ann-ptol-oq01-06",
+    "proofId": "ptolemys-theorem-oq-01",
+    "range": {
+      "startLine": 431,
+      "endLine": 470
+    },
+    "type": "context",
+    "title": "Summary: The Four-Way Equivalence and a Mathlib Maintenance Note",
+    "content": "`ptolemy_ineq_summary` re-exports the unconditional Ptolemy inequality \u2016z\u2081-z\u2083\u2016\u00b7\u2016z\u2082-z\u2084\u2016 \u2264 \u2016z\u2081-z\u2082\u2016\u00b7\u2016z\u2083-z\u2084\u2016 + \u2016z\u2082-z\u2083\u2016\u00b7\u2016z\u2081-z\u2084\u2016 from `PtolemysComplexProof`, so the inequality and its equality case live in one place. The numerical example blocks (a unit square giving equality, and {0,1,2,i} giving strict inequality) were removed at Mathlib v4.26.0 because the `Complex.abs` / `Complex.norm_eq_abs` API they relied on was refactored \u2014 an honest maintenance note that does not affect the named theorems' verification status (still 0 sorries, 0 axioms). The closing summary records the full characterization: for four points in convex position, (1) Ptolemy equality, (2) `SameRay \u211d ((z\u2081-z\u2082)(z\u2083-z\u2084)) ((z\u2082-z\u2083)(z\u2081-z\u2084))`, (3) the cross-ratio R = (z\u2082-z\u2083)(z\u2081-z\u2084)/((z\u2081-z\u2082)(z\u2083-z\u2084)) being a positive real, and (4) concyclicity in CCW order are all equivalent. This file supplies the arrows (4 \u2192 3 \u2192 2 \u2192 1) and the reality of R; the reverse arrow (1 \u2192 4) is the standing open question.",
+    "mathContext": "The four conditions form an equivalence only on the convex (CCW) stratum; the hypotheses `hdenom \u2260 0` and `hnumer \u2260 0` exclude the degenerate cases where two of the four points coincide. The SameRay formulation (condition 2) is the most robust: it stays meaningful even when R is not defined because a denominator vanishes.",
+    "significance": "context",
+    "relatedConcepts": [
+      "four-way equivalence",
+      "SameRay",
+      "cross-ratio",
+      "Ptolemy inequality",
+      "Mathlib API churn"
+    ],
+    "prerequisites": [
+      "ptolemy_inequality",
+      "PtolemysComplexProofOQ01 (SameRay characterization)"
+    ]
   }
 ]

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -64,7 +64,8 @@
       "For CCW order θ₁<θ₂<θ₃<θ₄<θ₁+2π, all four half-angle differences (θᵢ-θⱼ)/2 lie in (-π,0). Since sin is negative on (-π,0), all four sines are negative, making their products positive.",
       "The exponential phase factors combine as E₂₃·E₁₄ = exp(i(θ₁+θ₂+θ₃+θ₄)/2) = E₁₂·E₃₄, so they cancel algebraically from the ratio.",
       "The proof is self-contained modulo standard Mathlib trigonometry — no inscribed angle theorem needed.",
-      "Ptolemy equality for general concyclic points follows by normalizing to the unit circle (translation + scaling preserves Ptolemy distances)."
+      "Ptolemy equality for general concyclic points follows by normalizing to the unit circle (translation + scaling preserves Ptolemy distances).",
+      "The result sits inside a four-way equivalence (Part 7): Ptolemy equality ⇔ SameRay of the two chord-products ⇔ the cross-ratio R being a positive real ⇔ concyclicity in CCW order. This file proves the chain 4 → 3 → 2 → 1, while the converse 1 → 4 (equality forces convex concyclic order) remains open."
     ],
     "prerequisites": [
       "Complex exponential arithmetic (Complex.exp_add, Complex.exp_ne_zero)",
@@ -136,7 +137,8 @@
     "implications": "This closes the geometric open question: Ptolemy's equality holds for z₁, z₂, z₃, z₄ iff they are concyclic in the correct cyclic order. Together with PtolemysComplexProofOQ01.lean's SameRay characterization, we have the chain: concyclic CCW ↔ Ptolemy equality ↔ SameRay ℝ ((z₁-z₂)(z₃-z₄)) ((z₂-z₃)(z₁-z₄)).",
     "openQuestions": [
       "Prove the converse direction: if Ptolemy equality holds for four unit-circle points, they must be in CCW (or CW) order — connecting algebraic and geometric characterizations fully.",
-      "Extend to other metrics (spherical geometry, hyperbolic geometry) where analogues of Ptolemy's theorem exist."
+      "Extend to other metrics (spherical geometry, hyperbolic geometry) where analogues of Ptolemy's theorem exist.",
+      "Remove the non-degeneracy hypotheses (hdenom ≠ 0, hnumer ≠ 0) by handling the limiting cases where two of the four points coincide, giving a single statement valid for all four-point configurations."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for `ptolemys-theorem-oq-01`

This entry had a genuine annotation-coverage gap that the structural quality heuristic (capped at 100) could not surface: its 5 annotations stopped at **line 380** while the Lean file runs to **470**. Parts 5–7 — the generalization to arbitrary circles and the closing equivalence summary — had no annotation anchor.

### Changes
**annotations.json** (+2, line coverage 380 → 470):
- `ann-ptol-oq01-05` (lines 388–430) — `ptolemy_equality_for_concyclic`: the file's capstone, generalizing the unit-circle result to any circle via **similarity invariance**. Explains the `Exists.choose` witness extraction, the normalization `wᵢ = (zᵢ−c)/r`, and why every Ptolemy term scales by exactly `1/r²` so reducing to the unit circle loses no generality.
- `ann-ptol-oq01-06` (lines 431–470) — Parts 6–7: re-export of the unconditional inequality, an honest note on the Mathlib v4.26.0 removal of the `Complex.abs`-based numerical examples (does not affect verification status), and the **four-way equivalence** (Ptolemy equality ⇔ SameRay ⇔ positive cross-ratio ⇔ concyclic CCW) with the arrows this file supplies.

**meta.json**:
- +1 `keyInsight` framing the result inside the four-way equivalence and noting the open converse (1 → 4).
- +1 `openQuestion` on removing the `hdenom ≠ 0` / `hnumer ≠ 0` non-degeneracy hypotheses.

### Verification
- `tsc -b` ✓ and `vite build` ✓ (the JSON-processing build steps `annotations:build`/`research:build`/`research:enrich` parsed all entries without error).
- Axiom integrity unchanged and accurate: `verified` / `original`, 0 axioms, 0 sorries — consistent with the Lean source.
- No existing content removed; additions only.