### PR TITLE
audit(cauchy-schwarz-integral): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1549,9 +1549,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
+      "lastAudited": "2026-06-18T09:08:04Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — cauchy-schwarz-integral

**Result:** CLEAN (re-audit, 3→4x)
**Status/badge:** verified/mathlib — correct.

### Machine facts (all match meta.json)
| field | meta | source |
|-------|------|--------|
| lineCount | 117 | 117 ✓ |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 literal ✓ |
| native_decide | — | 0 ✓ |
| decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Tier classification: B (Mathlib-backed) — properly disclosed
- Core inequality `|⟪f,g⟫| ≤ ‖f‖·‖g‖` is `abs_real_inner_le_norm f g` (Mathlib). Badge `mathlib` is correct, not `original`.
- Disclosure is strong and consistent: `description` ("via L² inner product spaces"), `conclusion.summary` (explicitly "exploiting Mathlib's L2 inner product space structure"), `mathlibDependencies` (lists `abs_real_inner_le_norm`, `L2.inner_def`, `norm_inner_eq_norm_iff`).
- `originalContributions` correctly scoped to genuine in-file work: the bridge theorem `L2_inner_eq_integral` (L2 inner product = ∫f·g), the abs/squared integral forms, and the equality characterization (derived via the disclosed `norm_inner_eq_norm_iff`).
- No delegation opacity, no axiom masking, no inequality-vs-theorem inflation, no hidden-import overclaim.

No changes to meta required. Tracker updated to record the audit.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)