### PR TITLE
audit(binomial-theorem-oq-04-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1078,9 +1078,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
+      "lastAudited": "2026-06-18T09:10:59Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — `binomial-theorem-oq-04-oq-02`

**Result: CLEAN** (re-audit, auditCount 3→4)

Vandermonde Identity: Algebraic Proof via Coefficient Comparison.

### Machine-field verification (all match)
| Field | meta.json | source |
|-------|-----------|--------|
| theoremCount | 9 | 9 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |
| lineCount | 111 | 111 ✓ |

### Tier classification: B (Mathlib-backed) — correctly framed
- Core `vandermonde` delegates to Mathlib `Nat.add_choose_eq`; `coeff_mul_antidiagonal` → `Polynomial.coeff_mul`; `one_add_X_pow_add` → `pow_add`; `pascal_rule` → `Nat.choose_succ_succ`.
- Badge is `mathlib` (not `original`), and the overview/proofStrategy explicitly disclose the delegation: "Mathlib's `Nat.add_choose_eq` provides the identity directly; the formalization shows how it arises from the polynomial algebra structure." → **no delegation opacity.**
- `mathlibDependencies` lists all four delegated theorems with accurate descriptions.
- Genuine in-file work (`vandermonde_symm`, `coeff_eq_of_poly_eq`, `algebraic_structure`, `vandermonde_equal`, summary bundle) is scoped honestly in `originalContributions`.
- `status: verified` + 0 axioms/sorries/native_decide is accurate at the kernel level (only foundational axioms).

No overclaim, no axiom masking, no inequality-vs-theorem confusion. No changes to meta.json required.

---
Discovered during gallery integrity audit.