### PR TITLE
audit(binomial-theorem-oq-04): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1066,9 +1066,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
+      "lastAudited": "2026-06-18T09:13:52Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — binomial-theorem-oq-04

**Result: CLEAN** (auditCount 3 → 4)

Re-audited *Vandermonde's Identity* `C(m+n,r) = Σ C(m,k)·C(n,r-k)` (status `verified`, badge `mathlib`). All machine-checkable claims match the Lean source `Proofs/BinomialTheoremOQ04.lean`.

### Verified counts
| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 195 | 195 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms, 0 structures | ✓ |
| True stubs | — | 0 | ✓ |

### `native_decide` is incidental
3 `native_decide` calls (lines 65, 70, 73) are all in anonymous `example` blocks doing concrete numeric verification (C(8,4)=70, C(10,3)=120, sum-of-squares). None appear in a named headline theorem, so the presented results carry no `Lean.ofReduceBool` dependency. `axiomCount 0` / `status verified` are honest. (No plain `decide` in named results either.)

### Tier B, properly disclosed
The core `vandermonde_identity` delegates to Mathlib's `Nat.add_choose_eq` + `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`. Badge `mathlib` is the correct, conservative call. The delegation is **explicitly disclosed** in `proofStrategy`, `keyInsights`, the `assumptions` field, and `originalContributions` ("from Mathlib's antidiagonal API") — no delegation opacity. The corollaries (symmetry, sum-of-squares `C(2n,n)=ΣC(n,k)²`, monotonicity, summand bound, Pascal-rule connection) are genuine in-file work scoped honestly.

No changes to meta.json required; only the audit tracker is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)