### PR TITLE
audit(elementary-quadratic-reciprocity): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2684,9 +2684,9 @@
       "result": "clean"
     },
     "elementary-quadratic-reciprocity": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:42Z",
+      "lastAudited": "2026-06-18T09:17:40Z",
       "result": "clean"
     },
     "elementary-quadratic-reciprocity-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — `elementary-quadratic-reciprocity`

**Result: CLEAN** (4th audit; previously clean ×3). Tier B, badge `mathlib` — correct and well-disclosed.

### Machine fields (all match meta.json)
| Field | meta | source |
|-------|------|--------|
| lineCount | 357 | 357 ✓ |
| theoremCount | 11 | 9 `theorem` + 2 `private lemma` ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 (no axioms, no structures) ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Tier B classification — properly disclosed (no opacity)
Every named theorem is a one-line delegation to Mathlib:
- `gauss_lemma_statement` → `ZMod.gauss_lemma`
- `eisenstein_lemma_statement` → `ZMod.eisenstein_lemma`
- `lattice_point_identity` → `ZMod.sum_mul_div_add_sum_mul_div_eq_mul`
- `elementary_quadratic_reciprocity` → `legendreSym.quadratic_reciprocity`
- `qr_when_p_one_mod_four` / `qr_when_both_three_mod_four` → `legendreSym.quadratic_reciprocity_one/three_mod_four`
- `first_supplement` / `second_supplement` → `ZMod.exists_sq_eq_neg_one_iff` / `exists_sq_eq_two_iff`

Disclosure is complete: badge `mathlib`; all 4 core theorems in `mathlibDependencies`; "formalized in Lean 4 with Mathlib" in author/conclusion; the in-file Summary (lines 335–342) names each delegated theorem per step.

**Genuine in-file work** (scoped correctly in originalContributions): `eisenstein_proof_chain` (assembles the three Mathlib lemmas into one conjunction) + 2 private helper lemmas `prime_odd_mod` (omega) and `prime_ne_cast_ne_zero` (case analysis).

### native_decide check
0 `native_decide`. The 9 plain `decide` are kernel `Decidable.decide` on `Fact (Nat.Prime n)` instances and the example QR checks — they do **not** introduce `Lean.ofReduceBool`, so `axiomCount: 0` + `status: verified` / badge `mathlib` is honest.

No failure modes detected (delegation opacity / axiom masking / inequality≠theorem / pipeline inflation / hidden-import overclaim).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)