### PR TITLE
audit(e-transcendental): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2660,9 +2660,9 @@
       "result": "clean"
     },
     "e-transcendental": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:42Z",
+      "lastAudited": "2026-06-18T09:20:28Z",
       "result": "clean"
     },
     "e-transcendental-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — e-transcendental

**Result**: CLEAN ✓ (re-audit, axiomatized/axiom)

Re-audited **Transcendence of e** (Wiedijk #67). All public claims match the Lean source.

### Verified counts (meta.json vs `proofs/Proofs/eTranscendental.lean`)
| Field | meta | source | ✓ |
|-------|------|--------|---|
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 304 | 304 | ✓ |
| leanFile.axiomCount | 0 | 0 (no in-file `axiom`) | ✓ |
| native_decide / decide / True stubs | — | 0 / 0 / 0 | ✓ |

### Axiom integrity
- Sole assumption: imported `axiom hermite_lindemann` (`Proofs/HermiteLindemann.lean:147`), the Hermite–Lindemann theorem (Lindemann–Weierstrass is not in Mathlib).
- `axiomCount: 1`, `status: axiomatized`, `badge: axiom` — all honest. Conditional nature is thoroughly disclosed in the `assumptions` field and overview text ("proved from an explicit `hermite_lindemann` axiom").
- Main theorem `e_transcendental` = `HermiteLindemann.e_transcendental_int`; corollaries (`e_irrational`, `exp_nat_transcendental`, `e_inv_transcendental`, `e_plus_one_transcendental`) are genuinely proved in-file from it.

### Narrative checks
- No axiom masking (badge/status surface the assumption).
- No delegation opacity (Mathlib deps are definitional `Real.exp`/`Transcendental`, not the load-bearing result).
- No inequality-as-theorem, no pipeline inflation, no "0 sorries" hidden-import overclaim.

No changes needed beyond the audit-tracker bump.

---
Discovered during autonomous gallery integrity audit.