### PR TITLE
audit(divisibility-by-3-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2557,9 +2557,9 @@
       "result": "clean"
     },
     "divisibility-by-3-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:42Z",
+      "lastAudited": "2026-06-18T09:34:27Z",
       "result": "clean"
     },
     "divisibility-by-3-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: \`divisibility-by-3-oq-02\` (Base-b Divisibility Rules) — status \`verified\`, badge \`mathlib\`

**Result**: ✅ Clean. All publicly-stated claims match the Lean source.

### Verification (`DivisibilityBy3OQ02.lean`)

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 162 | 162 | ✓ |
| theoremCount | 15 | 15 named thm/lemma | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal, 0 structure fields | ✓ |
| sorries | 0 | 0 | ✓ |
| status/badge | verified / mathlib | — | ✓ |

### `native_decide` check (the sibling gotcha)

`native_decide` appears on **3 lines (126, 129, 132) — all anonymous `example` blocks** (Part V numeric verifications: `15∣255`, `¬15∣256`, `7∣511`). **No named theorem uses `native_decide`.**

The load-bearing `b % d = 1` facts that feed Mathlib's `Nat.modEq_digits_sum` / `Nat.dvd_iff_dvd_digits_sum` are proved by:
- `base_mod_pred` — kernel via `Nat.mod_eq_of_lt`
- `factor_mod` — `omega` + `Nat.add_mul_mod_self_left`

So **no named result is tainted by `Lean.ofReduceBool`**, and `verified` / `axiomCount 0` are honest. This contrasts with the sibling **`divisibility-by-3-oq-04`**, where named theorems discharged `b%d=1` via `native_decide` and the entry was correctly flipped to `axiomatized` (PR #25572).

### Tier classification

Tier B (`mathlib`) is correct. The core (b−1) rule and factor rule delegate to Mathlib's `Nat.modEq_digits_sum` / `Nat.dvd_iff_dvd_digits_sum`, disclosed in `mathlibDependencies`, `assumptions`, `overview` ("one-line applications of Mathlib"), and `proofStrategy`. No delegation opacity. `originalContributions` are honestly scoped to in-file work (`base_mod_pred`, `factor_mod`, base specializations, `cross_base_divisibility`).

Tracker bumped 3 → 4, result `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)