### PR TITLE
Enrich Erdős Problem 1004 (distinct totient runs): annotate Parts III–XII

### DIFF
--- a/src/data/proofs/erdos-1004/annotations.json
+++ b/src/data/proofs/erdos-1004/annotations.json
@@ -285,5 +285,174 @@
       "startLine": 64,
       "endLine": 67
     }
+  },
+  {
+    "id": "ann-1004-trivial-runs",
+    "proofId": "erdos-1004",
+    "type": "lemma",
+    "title": "Trivial Runs and the Maximum Run Length (Parts II–III)",
+    "content": "The base cases: an empty run (`distinctRun_zero`) and a single-element run (`distinctRun_one`) are vacuously/trivially distinct. `maxDistinctRunLength n` is then defined as the supremum $\\sup\\{K : \\varphi(n{+}1),\\dots,\\varphi(n{+}K)\\text{ all distinct}\\}$, and `exists_distinct_run` confirms this set always contains a positive element, so the run-length function is well-posed.",
+    "mathContext": "`IsDistinctTotientRun n K` says $\\varphi$ is injective on $\\{n{+}1,\\dots,n{+}K\\}$. The supremum is taken over $\\mathbb{N}$ via `sSup`; because the index set is nonempty (contains $K=0,1$) and — by the EPS87 bound below — bounded above, the `sSup` is attained and finite for each $n$. This `maxDistinctRunLength` is the central object: Erdős #1004 asks how fast it can grow relative to $\\log n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "supremum (sSup)",
+      "injective restriction",
+      "well-posedness"
+    ],
+    "prerequisites": [
+      "IsDistinctTotientRun",
+      "sSup on ℕ",
+      "Set.Nonempty"
+    ],
+    "range": {
+      "startLine": 85,
+      "endLine": 105
+    }
+  },
+  {
+    "id": "ann-1004-eps87-sublinear",
+    "proofId": "erdos-1004",
+    "type": "theorem",
+    "title": "The EPS87 Upper Bound and Sublinearity (Part IV)",
+    "content": "The deep input, **Erdős–Pomerance–Sárközy (1987)**, is taken as the single axiom `eps87_theorem`: a distinct totient run from $n$ has length $K \\leq n/\\exp(c(\\log n)^{1/3})$ for some $c > 0$ and all large $n$. From it, `eps87_constant`/`eps87_threshold` are extracted via `Exists.choose`, and `eps87_upper_bound` restates the bound. The genuinely proved corollary is `run_length_sublinear`: $\\mathrm{maxDistinctRunLength}(n)/n \\to 0$.",
+    "mathContext": "`run_length_sublinear` is proved by a squeeze (`tendsto_of_tendsto_of_tendsto_of_le_of_le'`): $0 \\leq \\mathrm{maxRun}(n)/n \\leq 1/\\exp(c(\\log n)^{1/3})$, and the upper bound $\\to 0$ because $c(\\log n)^{1/3} \\to \\infty$ (composing `Real.tendsto_log_atTop`, `tendsto_rpow_atTop`, `Real.tendsto_exp_atTop`, `tendsto_inv_atTop_zero`). The middle inequality bounds $\\sup S$ by $\\lfloor n/e \\rfloor$ via `csSup_le` + `Nat.le_floor`. So although the EPS87 *bound* is axiomatized, its asymptotic *consequence* — run length is $o(n)$ — is a real Lean theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős-Pomerance-Sárközy 1987",
+      "squeeze theorem",
+      "Exists.choose extraction",
+      "asymptotic o(n)"
+    ],
+    "prerequisites": [
+      "eps87_theorem axiom",
+      "Filter.Tendsto",
+      "csSup_le and Nat.floor",
+      "tendsto_rpow_atTop"
+    ],
+    "range": {
+      "startLine": 106,
+      "endLine": 188
+    }
+  },
+  {
+    "id": "ann-1004-conjecture-statements",
+    "proofId": "erdos-1004",
+    "type": "definition",
+    "title": "The Main Conjecture and Its Negation (Parts V–VI)",
+    "content": "`Erdos1004Conjecture` formalizes the open question: for every $c > 0$, for all large $x$ there is some $n \\leq x$ with a distinct totient run of length $\\lfloor(\\log x)^c\\rfloor$. `Erdos1004Negation` is its logical negation, and `SmallCaseConjecture` isolates the believed-tractable regime of small exponents $c$. These are `Prop`-valued definitions, not theorems — the conjecture is open and stated, not proved.",
+    "mathContext": "The conjecture asks whether arbitrarily long (poly-log) distinct totient runs occur infinitely often: $\\forall c>0,\\ \\forall^{\\infty} x,\\ \\exists n\\leq x,\\ \\mathrm{IsDistinctTotientRun}\\,n\\,\\lfloor(\\log x)^c\\rfloor$. The EPS87 sublinear bound caps run length at $o(n)$, far above $(\\log x)^c$, so it does not contradict the conjecture — there is a wide gap between the proved upper bound and the conjectured lower bound. `SmallCaseConjecture` ($\\exists c_0, \\forall c < c_0$) reflects the heuristic that short runs are abundant.",
+    "significance": "key",
+    "relatedConcepts": [
+      "open conjecture statement",
+      "eventually filter (∀ᶠ)",
+      "poly-logarithmic growth",
+      "Prop-valued formalization"
+    ],
+    "prerequisites": [
+      "Filter.Eventually atTop",
+      "Real.rpow and Nat.floor",
+      "IsDistinctTotientRun"
+    ],
+    "range": {
+      "startLine": 189,
+      "endLine": 211
+    }
+  },
+  {
+    "id": "ann-1004-examples-collisions",
+    "proofId": "erdos-1004",
+    "type": "theorem",
+    "title": "Concrete Run Examples and Totient Collisions (Parts VII–VIII)",
+    "content": "Worked examples ground the definitions: `example_n1` shows the run from $n=1$ has length exactly $2$ ($\\varphi(2),\\varphi(3)$ distinct but $\\varphi(4)=\\varphi(3)$ would extend), and `example_n2` gives length $1$ from $n=2$. `TotientCollision a b` ($\\varphi(a)=\\varphi(b)$, $a\\neq b$) names the obstruction: `collision_1_2`, `collision_3_4`, and `collision_ends_run` shows a collision within a window is exactly what caps a distinct run.",
+    "mathContext": "$\\varphi(3)=\\varphi(4)=2$ and $\\varphi(1)=\\varphi(2)=1$ are the smallest collisions; they force short runs near the start. `collision_ends_run` makes the link precise: if $\\varphi(n{+}i)=\\varphi(n{+}j)$ for $i<j$ in the window, the run cannot reach length $j$. The axiom `longer_runs_need_larger_n` records (without proof) the expectation that achieving a fixed run length $K$ requires moving to larger $n$, since small integers are dense with totient collisions.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "totient collisions",
+      "Carmichael's conjecture",
+      "concrete witnesses",
+      "run termination"
+    ],
+    "prerequisites": [
+      "Nat.totient evaluation",
+      "native_decide",
+      "IsDistinctTotientRun"
+    ],
+    "range": {
+      "startLine": 224,
+      "endLine": 263
+    }
+  },
+  {
+    "id": "ann-1004-run-length-bounds",
+    "proofId": "erdos-1004",
+    "type": "concept",
+    "title": "Heuristics and Run-Length Bounds (Parts X–XI)",
+    "content": "`birthdayProbabilityHeuristic` models distinct-run probability as a birthday-paradox product $\\prod_{k<K}(1 - k/V)$ with $V \\approx n/\\log n$ totient values available. The proved bounds: `run_length_trivial_bound` ($K \\leq n+K$) and the sharper `run_length_by_distinct_values` ($K \\leq \\mathrm{countDistinctTotients}(n{+}K{+}1)$), which says a length-$K$ distinct run forces at least $K$ distinct totient values below $n+K+1$.",
+    "mathContext": "The sharp bound is proved cleanly: $\\varphi$ injective on $[n{+}1, n{+}K]$ gives $|\\varphi(\\text{Icc})| = K$ (via `Finset.card_image_of_injOn` + `Nat.card_Icc`), and that image embeds in $\\varphi(\\mathrm{range}(n{+}K{+}1))$, so $K \\leq |\\varphi(\\mathrm{range}(n{+}K{+}1))| = \\mathrm{countDistinctTotients}(n{+}K{+}1)$. Combined with the asymptotic axiom $\\#\\{\\varphi(k) : k \\leq x\\} \\sim x/\\log x$ (Erdős 1935 / Ford 1998), this connects run length to the *count* of distinct totient values — the birthday-heuristic intuition made rigorous on the upper-bound side.",
+    "significance": "key",
+    "relatedConcepts": [
+      "birthday paradox",
+      "distinct totient counting",
+      "Finset.card_image_of_injOn",
+      "Ford 1998"
+    ],
+    "prerequisites": [
+      "Finset.image and injOn",
+      "Nat.card_Icc",
+      "countDistinctTotients"
+    ],
+    "range": {
+      "startLine": 303,
+      "endLine": 331
+    }
+  },
+  {
+    "id": "ann-1004-totient-classification",
+    "proofId": "erdos-1004",
+    "type": "theorem",
+    "title": "Classification of Small Totient Values (Part XII)",
+    "content": "The mathematical centerpiece — fully proved, no axioms: `totient_eq_one_iff` ($\\varphi(n)=1 \\iff n\\in\\{1,2\\}$), `totient_eq_two_iff` ($\\iff n\\in\\{3,4,6\\}$), and `totient_eq_four_iff` ($\\iff n\\in\\{5,8,10,12\\}$). Each is a complete inverse-totient computation, supported by seven private helper lemmas (`coprime_two_odd`, `totient_two_mul_odd`, `totient_prime_mul_not_dvd`, `odd_totient_ne_two`, `odd_totient_ne_four`, …) that bound the smallest prime factor and recurse on $n/p$.",
+    "mathContext": "The proofs combine a finite check on small $n$ (`native_decide` once $n$ is bounded) with a structural argument ruling out large $n$: if $\\varphi(n)=v$ then $(\\mathrm{minFac}(n)-1) \\mid v$ (from `Nat.totient_dvd_of_dvd` + `Nat.totient_prime`), forcing $\\mathrm{minFac}(n) \\in$ a small set; then `totient_mul` with coprimality peels off the prime-power factor and recurses (e.g. $\\varphi(2m)=\\varphi(m)$ for odd $m$, $\\varphi(p\\cdot m)=(p{-}1)\\varphi(m)$ for $p\\nmid m$), reducing to the already-solved smaller cases. The increasing preimage sizes $2,3,4$ are concrete data toward Carmichael's conjecture (every totient value has multiplicity $\\geq 2$). The `native_decide` calls here sit inside finite case-checks, not load-bearing headline claims.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inverse totient problem",
+      "Carmichael's conjecture",
+      "smallest prime factor (minFac)",
+      "totient multiplicativity"
+    ],
+    "prerequisites": [
+      "Nat.totient_mul and totient_prime",
+      "Nat.totient_dvd_of_dvd",
+      "Nat.minFac_prime",
+      "strong induction on n/p"
+    ],
+    "range": {
+      "startLine": 333,
+      "endLine": 566
+    }
+  },
+  {
+    "id": "ann-1004-summary",
+    "proofId": "erdos-1004",
+    "type": "concept",
+    "title": "Summary: Proved vs. Axiomatized",
+    "content": "The closing docstring delineates the formalization's honesty boundary. **Open**: Erdős #1004 itself (poly-log distinct runs). **Three axioms** carry the deep analytic inputs: `eps87_theorem` (the EPS87 upper bound), `longer_runs_need_larger_n` (a probabilistic existence claim), and `distinct_totients_asymptotic` (the $x/\\log x$ count, Erdős 1935 / Ford 1998). **Genuinely derived** (not axioms): the extracted constants, `run_length_sublinear`, the run-length counting bound, and the complete $\\varphi^{-1}(\\{1,2,4\\})$ classification.",
+    "mathContext": "This is exactly the `axiomatized` status pattern: the headline conjecture is OPEN and the literature theorems too hard to reprove in Lean are stated as axioms, while everything reachable from them — asymptotics, counting bounds, and the self-contained small-value classification — is machine-checked. The summary's '3 total' axiom count matches the source, and it explicitly distinguishes `eps87_constant`/`eps87_upper_bound`/`run_length_sublinear` as derived results rather than assumptions, so the assumption surface is transparent.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom transparency",
+      "open problem formalization",
+      "Problem 945 (divisor function)",
+      "derived vs. assumed"
+    ],
+    "prerequisites": [
+      "eps87_theorem",
+      "distinct_totients_asymptotic",
+      "axiomatized status conventions"
+    ],
+    "range": {
+      "startLine": 570,
+      "endLine": 609
+    }
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1004` (Erdős Problem #1004: distinct consecutive totient values).

## What changed
Annotation **coverage extended to line 609** (~84% of the 609-line Lean file). The existing annotations covered only scattered intro ranges (maxend 302), leaving the EPS87 sublinearity proof and the entire small-totient-value classification unannotated. This PR adds 7 substantive annotations filling the major gaps.

## Newly annotated sections
| Range | Topic |
|------|-------|
| 85–105 | Trivial runs + maxDistinctRunLength supremum (Parts II–III) |
| 106–188 | EPS87 upper-bound axiom and the proved run_length_sublinear (Part IV) |
| 189–211 | Main conjecture, negation, small-case (Parts V–VI) |
| 224–263 | Concrete run examples and totient collisions (Parts VII–VIII) |
| 303–331 | Birthday heuristic + run-length counting bounds (Parts X–XI) |
| 333–566 | Full classification of φ⁻¹({1,2,4}) with 7 helper lemmas (Part XII) |
| 570–609 | Summary: proved vs. axiomatized boundary (3 axioms) |

## Notes
- Content verified against `Erdos1004Problem.lean`. The axiom/proved boundary is made explicit: EPS87, the asymptotic count, and the run-existence claim are axiomatized; `run_length_sublinear`, the counting bound, and the φ⁻¹ classification are genuinely proved.
- All 7 new annotations **resolve to Lean constructs** (data-gen resolver passes). The multi-construct run-length annotation is typed `concept` since it spans a def + theorems.
- meta.json untouched; no churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)