### PR TITLE
audit(lebesgue-measure-oq-01-oq-01-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14117,12 +14117,12 @@
       "result": "issues-fixed"
     },
     "lebesgue-measure-oq-01-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
         "Lean source file LebesgueMeasureOQ01OQ01OQ02.lean was missing from main repo; added in PR #15264"
       ],
-      "lastAudited": "2026-05-03T18:35:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-18T09:48:22Z",
+      "result": "clean"
     },
     "cevas-theorem-non-euclidean-oq-02-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: lebesgue-measure-oq-01-oq-01-oq-02 (Thomae's Function: Continuous at Irrationals, Discontinuous at Rationals)
**Result**: clean (auditCount 2→3)

### Machine-checkable claims (all match source)
| Field | meta.json | source | ✓ |
|---|---|---|---|
| lineCount | 240 | 240 | ✓ |
| theoremCount | 11 | 6 `theorem` + 5 `private lemma` | ✓ |
| definitionCount | 1 | `noncomputable def thomae` | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axioms, 0 `native_decide`, 0 `decide`, 0 True stubs | ✓ |

Registered in `Proofs.lean` → CI-compiled.

### Tier classification: A (original) — honest
Thomae's continuity characterization is **not** a Mathlib theorem. The file builds its infrastructure from scratch:
- `finite_rat_bounded` — finiteness of low-denominator rationals in a bounded interval (via `Finset.biUnion` over denominators)
- `pos_min_dist` — positive min distance from an irrational to a finite rational set (Finset induction)
- discontinuity at rationals — direct sequential argument via `r + √2/(n+1)`
- continuity at irrationals — direct epsilon-delta

Only foundational Mathlib analysis API (`Metric.continuousAt_iff`, `irrational_sqrt_two`, `Rat.cast_inj`) is used as building blocks, not as the core result. Badge `original` / status `verified` / axiomCount 0 are all defensible. No `native_decide` → no `Lean.ofReduceBool`; only foundational `Classical.choice` (excluded by policy). The conclusion honestly discloses the classical-choice limitation.

No overclaiming detected.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)