### PR TITLE
Enrich Erdős #1018 OQ-04: annotate hypergraph framework

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-04/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "definition",
     "title": "Hypergraph Structure: Uniform Simplicial Complex",
-    "content": "The Hypergraph structure captures an r-uniform hypergraph: a collection of edges (Finset of Finsets) where every edge has exactly r vertices. The uniformity field `uniform : \u2200 e \u2208 edges, e.card = r` is a proof-valued field encoding the mathematical constraint directly in the type. This models an r-uniform hypergraph as an (r-1)-dimensional simplicial complex: each edge is an (r-1)-simplex, and the uniformity constraint ensures the complex is pure. The formalization uses Finset (Finset V) rather than Finset (Fin r \u2192 V) to make the edge-as-subset perspective natural.",
+    "content": "The Hypergraph structure captures an r-uniform hypergraph: a collection of edges (Finset of Finsets) where every edge has exactly r vertices. The uniformity field `uniform : ∀ e ∈ edges, e.card = r` is a proof-valued field encoding the mathematical constraint directly in the type. This models an r-uniform hypergraph as an (r-1)-dimensional simplicial complex: each edge is an (r-1)-simplex, and the uniformity constraint ensures the complex is pure. The formalization uses Finset (Finset V) rather than Finset (Fin r → V) to make the edge-as-subset perspective natural.",
     "mathContext": "$$H = (V, E) \\text{ with } E \\subseteq \\binom{V}{r}$$, i.e., $\\forall e \\in E, |e| = r$. As a simplicial complex: $H$ is the pure $(r-1)$-dimensional complex with $(r-1)$-simplices given by $E$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -31,7 +31,7 @@
     },
     "type": "concept",
     "title": "van Kampen-Flores Theorem: K_{2r+1}^(r) is Not Embeddable",
-    "content": "vanKampen_Flores axiomatizes the van Kampen-Flores theorem (proved independently by van Kampen and Flores, both 1933): for r \u2265 2, the complete r-uniform hypergraph on 2r+1 vertices cannot be embedded in R^(2(r-1)) as a simplicial complex. This is the direct generalization of K\u2085 being non-planar (r=2: K\u2085 not in R\u00b2). The proof uses the Borsuk-Ulam theorem via Z/2-equivariant topology: the deleted product construction of K_{2r+1}^(r) has a non-trivial Z/2-map to S^{2(r-1)-1}, which by Borsuk-Ulam cannot exist for an embeddable complex.",
+    "content": "vanKampen_Flores axiomatizes the van Kampen-Flores theorem (proved independently by van Kampen and Flores, both 1933): for r ≥ 2, the complete r-uniform hypergraph on 2r+1 vertices cannot be embedded in R^(2(r-1)) as a simplicial complex. This is the direct generalization of K₅ being non-planar (r=2: K₅ not in R²). The proof uses the Borsuk-Ulam theorem via Z/2-equivariant topology: the deleted product construction of K_{2r+1}^(r) has a non-trivial Z/2-map to S^{2(r-1)-1}, which by Borsuk-Ulam cannot exist for an embeddable complex.",
     "mathContext": "$$K_{2r+1}^{(r)} \\not\\hookrightarrow \\mathbb{R}^{2(r-1)}$$ for $r \\geq 2$, where the embedding is as an $(r-1)$-dimensional simplicial complex. Special cases: $K_5 \\not\\hookrightarrow \\mathbb{R}^2$ (Kuratowski), $K_7^{(3)} \\not\\hookrightarrow \\mathbb{R}^4$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -55,13 +55,13 @@
       "endLine": 172
     },
     "type": "insight",
-    "title": "Graph Case Recovery: K\u2085 is Non-Planar",
-    "content": "vanKampen_Flores_graph recovers the classical K\u2085 non-planarity result as a corollary of the van Kampen-Flores axiom for r=2. The proof instantiates vanKampen_Flores at r=2, uses simp to unfold criticalDim 2 = 2*(2-1) = 2, and uses convert to match K\u2085 = completeHypergraph 5 2 (since 2*2+1 = 5). The convert tactic handles the numerical matching, and norm_num closes the arithmetic goals. This shows the framework correctly reduces to the known graph case.",
+    "title": "Graph Case Recovery: K₅ is Non-Planar",
+    "content": "vanKampen_Flores_graph recovers the classical K₅ non-planarity result as a corollary of the van Kampen-Flores axiom for r=2. The proof instantiates vanKampen_Flores at r=2, uses simp to unfold criticalDim 2 = 2*(2-1) = 2, and uses convert to match K₅ = completeHypergraph 5 2 (since 2*2+1 = 5). The convert tactic handles the numerical matching, and norm_num closes the arithmetic goals. This shows the framework correctly reduces to the known graph case.",
     "mathContext": "$$K_5 = K_{2\\cdot 2+1}^{(2)} \\not\\hookrightarrow \\mathbb{R}^{2(2-1)} = \\mathbb{R}^2$$ recovered from \\texttt{vanKampen\\_Flores 2}: \\texttt{criticalDim 2 = 2} and $2 \\cdot 2 + 1 = 5$.",
     "significance": "key",
     "relatedConcepts": [
       "Kuratowski's theorem",
-      "K\u2085 non-planarity",
+      "K₅ non-planarity",
       "convert tactic",
       "criticalDim"
     ],
@@ -80,7 +80,7 @@
     },
     "type": "definition",
     "title": "hypergraph_kostochka_pyber: The Generalized Open Conjecture",
-    "content": "hypergraph_kostochka_pyber formalizes the open conjecture: for every r \u2265 2 and \u03b5 > 0, there exists a constant C = C_{r,\u03b5} such that every r-uniform hypergraph on sufficiently many vertices (n \u2265 N) with \u2265 n^{r-1+\u03b5} edges contains a sub-hypergraph on \u2264 C vertices that is not embeddable in R^{2(r-1)}. The nested quantifiers capture: universality over uniformity r, a \u03b5-threshold, existence of a bounded-size obstruction C and a threshold N, then universality over all large enough vertex sets and dense enough hypergraphs. This is an OPEN problem for r \u2265 3.",
+    "content": "hypergraph_kostochka_pyber formalizes the open conjecture: for every r ≥ 2 and ε > 0, there exists a constant C = C_{r,ε} such that every r-uniform hypergraph on sufficiently many vertices (n ≥ N) with ≥ n^{r-1+ε} edges contains a sub-hypergraph on ≤ C vertices that is not embeddable in R^{2(r-1)}. The nested quantifiers capture: universality over uniformity r, a ε-threshold, existence of a bounded-size obstruction C and a threshold N, then universality over all large enough vertex sets and dense enough hypergraphs. This is an OPEN problem for r ≥ 3.",
     "mathContext": "$$\\forall r \\geq 2, \\forall \\varepsilon > 0, \\exists C, N:\\; \\forall H \\text{ r-uniform on } n \\geq N \\text{ vertices},\\; |E(H)| \\geq n^{r-1+\\varepsilon} \\implies \\exists S \\subseteq V(H),\\; |S| \\leq C,\\; K_{2r+1}^{(r)} \\hookrightarrow H[S] \\text{ non-embeddably}$$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -104,15 +104,15 @@
       "endLine": 251
     },
     "type": "insight",
-    "title": "K\u2087^(3) is Not Embeddable in R\u2074",
-    "content": "K7_3_nonembeddable proves that the complete 3-uniform hypergraph on 7 vertices is not embeddable in R\u2074. This is the r=3 instance of the van Kampen-Flores theorem. The proof follows the same pattern as vanKampen_Flores_graph: instantiate vanKampen_Flores at r=3, unfold criticalDim 3 = 2*(3-1) = 4, and use convert + norm_num to match K\u2087^(3) = completeHypergraph 7 3 (since 2*3+1 = 7). K\u2087^(3) has C(7,3) = 35 edges (proved by K7_3_edge_count via decide), making it the simplest non-planar object in 3-uniform hypergraph theory.",
+    "title": "K₇^(3) is Not Embeddable in R⁴",
+    "content": "K7_3_nonembeddable proves that the complete 3-uniform hypergraph on 7 vertices is not embeddable in R⁴. This is the r=3 instance of the van Kampen-Flores theorem. The proof follows the same pattern as vanKampen_Flores_graph: instantiate vanKampen_Flores at r=3, unfold criticalDim 3 = 2*(3-1) = 4, and use convert + norm_num to match K₇^(3) = completeHypergraph 7 3 (since 2*3+1 = 7). K₇^(3) has C(7,3) = 35 edges (proved by K7_3_edge_count via decide), making it the simplest non-planar object in 3-uniform hypergraph theory.",
     "mathContext": "$$K_7^{(3)} = K_{2\\cdot 3+1}^{(3)} \\not\\hookrightarrow \\mathbb{R}^{2(3-1)} = \\mathbb{R}^4$$ with $|E(K_7^{(3)})| = \\binom{7}{3} = 35$. The analogy: $K_5$ (10 edges) is non-planar, $K_7^{(3)}$ (35 edges) is the 3-uniform non-$\\mathbb{R}^4$-embeddable analogue.",
     "significance": "key",
     "relatedConcepts": [
       "3-uniform hypergraphs",
       "van Kampen-Flores for r=3",
       "K7_3_edge_count",
-      "R\u2074 embeddability"
+      "R⁴ embeddability"
     ],
     "prerequisites": [
       "van Kampen-Flores axiom",
@@ -128,19 +128,211 @@
       "endLine": 278
     },
     "type": "concept",
-    "title": "Super-Linear Density Exceeds All Tur\u00e1n Numbers",
-    "content": "density_exceeds_turan axiomatizes the key comparison: for r \u2265 2, t > r, and \u03b5 > 0, the super-linear density n^{r-1+\u03b5} eventually exceeds the Tur\u00e1n number ex(n, K_t^(r)) for any fixed t. This connects the edge density threshold n^{r-1+\u03b5} to the Tur\u00e1n extremal framework: when a hypergraph is too dense to be K_t^(r)-free (for some bounded t), it must contain complete sub-hypergraphs, which are candidates for the non-embeddable sub-hypergraphs. The turanNumber function is defined with sorry (the exact Tur\u00e1n numbers for r \u2265 3 are largely unknown \u2014 the Tur\u00e1n density problem for K\u2084^(3) is one of the most famous open problems in combinatorics).",
+    "title": "Super-Linear Density Exceeds All Turán Numbers",
+    "content": "density_exceeds_turan axiomatizes the key comparison: for r ≥ 2, t > r, and ε > 0, the super-linear density n^{r-1+ε} eventually exceeds the Turán number ex(n, K_t^(r)) for any fixed t. This connects the edge density threshold n^{r-1+ε} to the Turán extremal framework: when a hypergraph is too dense to be K_t^(r)-free (for some bounded t), it must contain complete sub-hypergraphs, which are candidates for the non-embeddable sub-hypergraphs. The turanNumber function is defined with sorry (the exact Turán numbers for r ≥ 3 are largely unknown — the Turán density problem for K₄^(3) is one of the most famous open problems in combinatorics).",
     "mathContext": "$$\\forall t > r,\\; \\forall \\varepsilon > 0:\\; n^{r-1+\\varepsilon} > \\text{ex}(n, K_t^{(r)}) \\text{ for large } n$$ where $\\text{ex}(n, K_t^{(r)})$ is the maximum edges in an $r$-uniform $K_t^{(r)}$-free hypergraph on $n$ vertices.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Tur\u00e1n problem for hypergraphs",
+      "Turán problem for hypergraphs",
       "turanNumber (sorry)",
-      "K\u2084^(3) Tur\u00e1n density problem",
+      "K₄^(3) Turán density problem",
       "extremal numbers"
     ],
     "prerequisites": [
-      "Tur\u00e1n numbers for hypergraphs",
-      "Hypergraph Tur\u00e1n densities (mostly unknown for r \u2265 3)"
+      "Turán numbers for hypergraphs",
+      "Hypergraph Turán densities (mostly unknown for r ≥ 3)"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-hypergraph-ops",
+    "proofId": "erdos-1018-oq-04",
+    "type": "technique",
+    "range": {
+      "startLine": 41,
+      "endLine": 58
+    },
+    "title": "Hypergraph Operations: Edge Count and Induced Subhypergraph",
+    "content": "The basic operations on the `Hypergraph` structure. `edgeCount` is the cardinality of the edge set; `induced S` restricts to edges contained in a vertex subset $S$ (preserving $r$-uniformity via the inherited `uniform` field). `induced_le_edges` proves the obvious monotonicity $|E(H[S])|\\leq|E(H)|$ from `card_filter_le`. These make precise the notion of a 'sub-hypergraph on $\\leq k$ vertices' central to the Kostochka–Pyber statement.",
+    "significance": "supporting",
+    "mathContext": "$H[S]=\\{e\\in E(H):e\\subseteq S\\}$, an $r$-uniform hypergraph with $|E(H[S])|\\leq|E(H)|$.",
+    "relatedConcepts": [
+      "induced subhypergraph",
+      "Finset.filter",
+      "r-uniformity",
+      "card_filter_le"
+    ],
+    "prerequisites": [
+      "Finset operations",
+      "structure fields",
+      "subset filtering"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-complete",
+    "proofId": "erdos-1018-oq-04",
+    "type": "technique",
+    "range": {
+      "startLine": 64,
+      "endLine": 86
+    },
+    "title": "Complete $r$-Uniform Hypergraph Has $\\binom{t}{r}$ Edges",
+    "content": "`completeHypergraph t r` is the hypergraph of all $r$-subsets of $\\{0,\\dots,t-1\\}$. `completeHypergraph_edgeCount` proves it has exactly $\\binom{t}{r}$ edges by identifying the filtered edge set with `powersetCard r` and applying `Finset.card_powersetCard`. The $r=2$ specialization `complete_graph_edge_count` recovers $\\binom{t}{2}=t(t-1)/2$, the complete graph $K_t$, anchoring the hypergraph generalization to the familiar graph case.",
+    "significance": "key",
+    "mathContext": "$K_t^{(r)}$ has $\\binom{t}{r}$ edges; the $r$-subsets of a $t$-set are `(univ).powersetCard r` of card $\\binom{t}{r}$. For $r=2$: $\\binom{t}{2}$.",
+    "relatedConcepts": [
+      "complete hypergraph",
+      "binomial coefficient",
+      "powersetCard",
+      "K_t"
+    ],
+    "prerequisites": [
+      "Finset.powersetCard",
+      "Nat.choose",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-density",
+    "proofId": "erdos-1018-oq-04",
+    "type": "technique",
+    "range": {
+      "startLine": 92,
+      "endLine": 117
+    },
+    "title": "Density Threshold and Maximum Edge Count",
+    "content": "`isDenseHypergraph` formalizes the super-linear density regime: at least $n^{r-1+\\varepsilon}$ edges (generalizing the graph threshold $n^{1+\\varepsilon}$ at $r=2$). `max_edges` proves the matching upper bound $|E(H)|\\leq\\binom{n}{r}$ for every $r$-uniform hypergraph on $n$ vertices, via `card_le_card` against the full $r$-subset family. Together these pin down the density scale at which the topological obstruction is conjectured to appear.",
+    "significance": "supporting",
+    "mathContext": "Dense: $|E(H)|\\geq n^{(r-1)+\\varepsilon}$, $n=|V|$. Always $|E(H)|\\leq\\binom{n}{r}$. At $r=2$: threshold $n^{1+\\varepsilon}$, max $\\binom n2$.",
+    "relatedConcepts": [
+      "super-linear density",
+      "extremal bound",
+      "Turán regime",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "real exponentiation",
+      "card_le_card",
+      "powersetCard"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-embeddability",
+    "proofId": "erdos-1018-oq-04",
+    "type": "concept",
+    "range": {
+      "startLine": 139,
+      "endLine": 164
+    },
+    "title": "Embeddability via Convex-Hull Intersection",
+    "content": "`isEmbeddable H d` gives a concrete 'almost-embedding' notion from topological combinatorics: an injective vertex map $\\varphi:V\\to\\mathbb{R}^d$ such that the convex hulls of distinct edges meet only in the hull of their shared vertices. For $r=2$ this is the classical planarity-style embedding into $\\mathbb{R}^2$. The critical dimension `criticalDim r = 2(r-1)` marks where non-embeddability of complete hypergraphs first arises -- the higher analogue of the plane for graphs.",
+    "significance": "key",
+    "mathContext": "$\\varphi:V\\hookrightarrow\\mathbb{R}^d$ with $\\text{conv}(\\varphi e_1)\\cap\\text{conv}(\\varphi e_2)\\subseteq\\text{conv}(\\varphi(e_1\\cap e_2))$ for $e_1\\neq e_2$. Critical $d=2(r-1)$ (for $r=2$, $d=2$).",
+    "relatedConcepts": [
+      "geometric realization",
+      "convex hull",
+      "almost-embedding",
+      "simplicial complex"
+    ],
+    "prerequisites": [
+      "convexHull",
+      "injective maps",
+      "topological combinatorics"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-vkf",
+    "proofId": "erdos-1018-oq-04",
+    "type": "context",
+    "range": {
+      "startLine": 166,
+      "endLine": 189
+    },
+    "title": "van Kampen–Flores Obstruction (Axiom) and Planar Recovery",
+    "content": "`vanKampen_Flores` is taken as an axiom: the complete $r$-uniform hypergraph $K_{2r+1}^{(r)}$ is not embeddable in $\\mathbb{R}^{2(r-1)}$ (van Kampen 1933, Flores 1933, via the Borsuk–Ulam method). From it `vanKampen_Flores_graph` *derives* that $K_5$ is non-planar, recovering the classical fact at $r=2$. The companion axioms `triangle_planar` and `K4_planar` record that $K_3,K_4$ *are* planar. These three axioms (plus `density_exceeds_turan`) are why the entry is honestly `axiomatized`/`axiom`, not `verified`.",
+    "significance": "key",
+    "mathContext": "vKF: $K_{2r+1}^{(r)}\\not\\hookrightarrow\\mathbb{R}^{2(r-1)}$. $r=2$: $K_5\\not\\hookrightarrow\\mathbb{R}^2$ (non-planar). $K_3,K_4\\hookrightarrow\\mathbb{R}^2$.",
+    "relatedConcepts": [
+      "van Kampen–Flores theorem",
+      "Borsuk–Ulam method",
+      "non-planarity of K5",
+      "axiomatized assumption"
+    ],
+    "prerequisites": [
+      "isNonEmbeddable",
+      "criticalDim",
+      "Borsuk-Ulam"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-conjecture",
+    "proofId": "erdos-1018-oq-04",
+    "type": "concept",
+    "range": {
+      "startLine": 195,
+      "endLine": 235
+    },
+    "title": "Generalized Kostochka–Pyber Conjecture and Graph Recovery",
+    "content": "`hypergraph_kostochka_pyber` states the central open question: for $r\\geq2$ and $\\varepsilon>0$, every $r$-uniform hypergraph with $\\geq n^{r-1+\\varepsilon}$ edges contains a sub-hypergraph on $O_{r,\\varepsilon}(1)$ vertices that is non-embeddable in $\\mathbb{R}^{2(r-1)}$. The supporting `criticalDim_graph` ($2(r-1)=2$), `density_exponent_graph` ($r-1+\\varepsilon=1+\\varepsilon$), and `obstruction_size_graph` ($2r+1=5$) verify that at $r=2$ this collapses exactly to the original Kostochka–Pyber theorem (1988). For $r\\geq3$ it is OPEN.",
+    "significance": "key",
+    "mathContext": "Conjecture: dense $\\Rightarrow$ $\\exists S$, $|S|\\leq C_{r,\\varepsilon}$, $H[S]\\not\\hookrightarrow\\mathbb{R}^{2(r-1)}$. At $r=2$: $2(r-1)=2$, $r-1+\\varepsilon=1+\\varepsilon$, $2r+1=5$ → original theorem.",
+    "relatedConcepts": [
+      "Kostochka–Pyber theorem",
+      "open conjecture",
+      "graph specialization",
+      "O(1) obstruction"
+    ],
+    "prerequisites": [
+      "hasSmallNonEmbeddable",
+      "isDenseHypergraph",
+      "criticalDim"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-3uniform",
+    "proofId": "erdos-1018-oq-04",
+    "type": "insight",
+    "range": {
+      "startLine": 252,
+      "endLine": 271
+    },
+    "title": "The 3-Uniform Case (First Non-Trivial Instance)",
+    "content": "The $r=3$ case is the first genuinely open instance. `K7_3_edge_count` computes $\\binom73=35$ edges (`decide`), and `K7_3_nonembeddable` derives from van Kampen–Flores that $K_7^{(3)}$ is not embeddable in $\\mathbb{R}^4$. `conjecture_3uniform` specializes the general conjecture: does $n^{2+\\varepsilon}$ edge density force a non-embeddable-in-$\\mathbb{R}^4$ sub-hypergraph on $O_\\varepsilon(1)$ vertices? This is the concrete frontier of the problem.",
+    "significance": "key",
+    "mathContext": "$K_7^{(3)}$: $\\binom73=35$ edges, $\\not\\hookrightarrow\\mathbb{R}^4$. 3-uniform conjecture: density $n^{2+\\varepsilon}$, critical dimension $4$, minimal obstruction $K_7^{(3)}$.",
+    "relatedConcepts": [
+      "3-uniform hypergraph",
+      "K7^(3)",
+      "R^4 embedding",
+      "open frontier"
+    ],
+    "prerequisites": [
+      "vanKampen_Flores",
+      "completeHypergraph_edgeCount",
+      "criticalDim"
+    ]
+  },
+  {
+    "id": "erdos-1018-oq04-turan-summary",
+    "proofId": "erdos-1018-oq-04",
+    "type": "context",
+    "range": {
+      "startLine": 277,
+      "endLine": 316
+    },
+    "title": "Turán-Type Threshold and Honest Status Summary",
+    "content": "`turanNumber` (the extremal count avoiding $K_t^{(r)}$) is left as a `def` with `sorry` -- only the graph case $\\mathrm{ex}(n,K_t)$ is classical (Turán), and even $\\pi(K_4^{(3)})$ is a famous open problem. The axiom `density_exceeds_turan` records that the super-linear density $n^{r-1+\\varepsilon}$ eventually overtakes any subquadratic Turán number, forcing complete subhypergraphs. The file's summary is candid about its status: 4 axioms, 1 definitional sorry, the full conjecture OPEN for $r\\geq3$ -- matching the entry's `axiomatized`/`axiom` badge and `sorries: 1`.",
+    "significance": "supporting",
+    "mathContext": "$\\mathrm{ex}(n,K_t)=(1-\\tfrac1{t-1})\\tfrac{n^2}2$ (Turán, $r=2$); $r\\geq3$ largely unknown. Axiom: $n^{r-1+\\varepsilon}>\\mathrm{ex}(n,K_t^{(r)})$ for large $n$. Status: 4 axioms, 1 sorry, open for $r\\geq3$.",
+    "relatedConcepts": [
+      "Turán number",
+      "Turán density",
+      "extremal hypergraph theory",
+      "formalization integrity"
+    ],
+    "prerequisites": [
+      "Turán theorem",
+      "extremal combinatorics",
+      "axiomatized status"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-04` (Hypergraph Extension of Non-Planar Subgraph Density).

## Gap addressed
Existing annotations covered only **28/318 lines** (short section headers). The structural and proved content across all 8 parts was largely uncovered.

## Changes
Added 8 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:

- Hypergraph operations (`edgeCount`, induced subhypergraph)
- Complete hypergraph edge count $\binom{t}{r}$; density threshold $n^{r-1+\varepsilon}$ and `max_edges`
- Embeddability via convex-hull intersection; critical dimension $2(r-1)$
- **van Kampen–Flores** obstruction (axiom) and $K_5$ non-planar recovery
- **Generalized Kostochka–Pyber** conjecture + $r=2$ graph-recovery lemmas
- The **3-uniform case** ($K_7^{(3)}$, $\mathbb{R}^4$); Turán threshold + honest status summary

Annotation line coverage: **28/318 → 228/318**.

## Integrity check
Verified meta matches source: `sorries: 1` (the `turanNumber` definitional sorry), `axiomCount: 4` (vanKampen_Flores, triangle_planar, K4_planar, density_exceeds_turan), `status: axiomatized`, `badge: axiom` — all honest. No existing content removed.