### PR TITLE
audit(inclusion-exclusion-oq-01-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14109,12 +14109,12 @@
       "issues": []
     },
     "inclusion-exclusion-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
         "badge was original but main theorem wraps Mathlib's Finset.inclusion_exclusion_card_biUnion; corrected to mathlib in PR #15263"
       ],
-      "lastAudited": "2026-05-03T18:35:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-18T09:51:28Z",
+      "result": "clean"
     },
     "lebesgue-measure-oq-01-oq-01-oq-02": {
       "auditCount": 3,


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: inclusion-exclusion-oq-01-oq-01 — General Inclusion-Exclusion for k Sets
**Status**: `verified` / badge `mathlib` — **confirmed honest, no changes needed**
**Result**: clean (auditCount 2→3)

### Machine fields — all match source
| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 276 | 276 | ✓ |
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no axioms, no structures) | ✓ |
| sorries | 0 | 0 | ✓ |

### native_decide check
3 `native_decide` calls, **all in anonymous `example` blocks** (L262/265/269) verifying concrete 4-set numerics. None appear in a named theorem, so no `Lean.ofReduceBool` taints any published result → `verified` / axiomCount 0 is honest (matches the project's native_decide policy).

### Tier classification — Tier B, correctly labeled
The headline `general_inclusion_exclusion` is a one-line wrapper around Mathlib's `Finset.inclusion_exclusion_card_biUnion`. Badge `mathlib` is correct and the delegation is disclosed in the description, overview text, and keyInsights ("the general formula is not new work"). No delegation opacity.

`originalContributions` are scoped to the genuine in-file derived forms: inductive step (`card_biUnion_insert` via `biUnion_inter_right`), complementary counting, Bonferroni union bound, and the 4-set formula built by composition. All proved in-file with elementary tactics.

Registered in `Proofs.lean:2508` → CI-compiled.

---
Discovered during gallery integrity re-audit. No source or meta changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)