### PR TITLE
audit(picks-theorem-oq-01-oq-02): fix stale counts; restore inclusion-exclusion record

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14111,9 +14111,10 @@
     "inclusion-exclusion-oq-01-oq-01": {
       "auditCount": 3,
       "issues": [
-        "badge was original but main theorem wraps Mathlib's Finset.inclusion_exclusion_card_biUnion; corrected to mathlib in PR #15263"
+        "badge was original but main theorem wraps Mathlib's Finset.inclusion_exclusion_card_biUnion; corrected to mathlib in PR #15263",
+        "re-audit clean (PR #25585, merged); tracker bump was clobbered by a concurrent merge and is restored here"
       ],
-      "lastAudited": "2026-06-18T09:51:28Z",
+      "lastAudited": "2026-06-18T09:57:00Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-01-oq-01-oq-02": {
@@ -14163,10 +14164,12 @@
       "issues": []
     },
     "picks-theorem-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T18:51:03Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-06-18T09:56:23Z",
+      "result": "issues-fixed",
+      "issues": [
+        "stale machine counts: lineCount 309->324, theoremCount 24->25; leanFile.axiomCount 4->2 (literal axiom count per convention; meta.axiomCount=4 total assumptions stays correct). Status axiomatized/axiom honest, 0 sorries, 0 native_decide, thorough disclosure."
+      ]
     },
     "chinese-remainder-constructive-oq-03-oq-03": {
       "auditCount": 1,

--- a/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-05-03",
     "axiomCount": 4,
     "assumptions": "4 assumptions: 2 axioms (scaled_area — Area(tP)=t²A; scaled_boundary — |∂(tP)|=t·B for t≥1), 1 structure-encoded assumption (the SimpleLatticePolygon.pick_relation field — Pick's formula A=i+B/2-1, carried as data so every polygon value is a genuine lattice polygon; this replaces a previously free-standing axiom picks_theorem that was logically inconsistent because the structure admitted non-Pick polygons, see #23117/#24682), plus 1 opaque constant (scaledPolygon — the integer dilation tP, opaque since its concrete construction is not needed for the theorem). picks_theorem is now a theorem derived from the pick_relation field. The rectangle and triangle Ehrhart polynomials are proved with 0 axioms via Finset combinatorics.",
-    "lineCount": 309,
-    "theoremCount": 24,
+    "lineCount": 324,
+    "theoremCount": 25,
     "definitionCount": 7,
     "originalContributions": [
       "rectangle_ehrhart: L(R_{a,b},t) = (ta+1)(tb+1) via Finset.card_product (0 axioms)",
@@ -99,7 +99,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The 2D Ehrhart polynomial L(P,t) = A·t² + (B/2)·t + 1 is machine-verified via three independent proof routes: combinatorial (rectangles and triangles via Finset), algebraic (from Pick's theorem and scaling axioms). The interior count formula and h*-vector non-negativity are derived as immediate consequences. 24 theorems, 7 definitions, 309 lines.",
+    "summary": "The 2D Ehrhart polynomial L(P,t) = A·t² + (B/2)·t + 1 is machine-verified via three independent proof routes: combinatorial (rectangles and triangles via Finset), algebraic (from Pick's theorem and scaling axioms). The interior count formula and h*-vector non-negativity are derived as immediate consequences. 25 theorems, 7 definitions, 324 lines.",
     "implications": "This formalization establishes the 2D Ehrhart polynomial as a direct corollary of Pick's theorem when combined with the geometric scaling laws. The cross-framework consistency result (rectangle_frameworks_agree) validates that the axiomatic and combinatorial approaches agree. The h*-vector formulation opens the path to Stanley's non-negativity theorem in higher dimensions.",
     "openQuestions": [
       "Prove the Ehrhart-Macdonald reciprocity law in full generality: L(P°,-t) = (-1)^d · i(P,t) where P° is the interior of P",
@@ -110,10 +110,10 @@
   "leanFile": {
     "namespace": "EhrhartPolynomial",
     "path": "Proofs/PicksTheoremOQ01OQ02.lean",
-    "lineCount": 309,
-    "theoremCount": 24,
+    "lineCount": 324,
+    "theoremCount": 25,
     "definitionCount": 7,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "sorries": 0
   },
   "crossReferences": [


### PR DESCRIPTION
## Re-audit: picks-theorem-oq-01-oq-02 (2D Ehrhart Polynomial via Pick's Theorem)

**Substantive integrity: CLEAN.** Status `axiomatized` / badge `axiom` is correct and honest.

- `meta.axiomCount: 4` correctly counts all assumptions: 2 literal axioms (`scaled_area`, `scaled_boundary`) + 1 structure-encoded `pick_relation` field + 1 opaque `scaledPolygon` — all thoroughly disclosed in `assumptions`.
- 0 sorries, **0 native_decide / 0 decide** (no `Lean.ofReduceBool`), 0 True stubs.
- Registered in `Proofs.lean` (CI-compiled).
- Rectangle/triangle Ehrhart parts genuinely 0-axiom via Finset combinatorics; the general formula is honestly axiomatized (Tier C) and clearly framed as such. No overclaim.

### Fixed stale machine-count fields
| field | was | now |
|-------|-----|-----|
| `lineCount` | 309 | **324** |
| `theoremCount` | 24 | **25** (22 `theorem` + 3 `lemma`) |
| `leanFile.axiomCount` | 4 | **2** (literal `axiom` count per gallery convention) |

`meta.axiomCount` stays **4** (total-assumption count) — that is the credibility-bearing field and it remains correct.

### Tracker housekeeping
Restored the `inclusion-exclusion-oq-01-oq-01` audit bump (clean re-audit PR #25585, merged) whose tracker write was clobbered by a concurrent merge, so the queue advances correctly.

---
Discovered during gallery integrity audit.