### PR TITLE
audit(desargues-theorem-oq-02): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2404,9 +2404,9 @@
       "result": "clean"
     },
     "desargues-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:04:00Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "desargues-theorem-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit — desargues-theorem-oq-02

**Result: CLEAN** (re-audit, auditCount 3 → 4)

Re-audited the Moulton plane non-Desarguesian counterexample. All `meta.json` claims verified against `proofs/Proofs/DesarguesTheoremOQ02.lean`.

### Machine-count checks (all match)
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 332 | 332 ✓ |
| theoremCount | 37 | 37 ✓ |
| definitionCount | 23 | 23 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |

Also: 0 `native_decide`, 0 plain `decide`, 0 `True` stubs.

### Status / badge integrity
- **status `verified` / badge `mathlib`** — honest and conservative. Mathlib is used only for ℚ arithmetic (`Rat.Defs`); the Moulton plane construction, the concrete 6-point counterexample, and the non-collinearity case analysis are all original in-file work. Badge could arguably be `original`, but conservative classification is acceptable (underclaiming is not an integrity issue).
- **axiomCount 0 honest** — `MLine` is a data inductive with no assumption-carrying fields; no structures encode hypotheses. No `Lean.ofReduceBool` exposure (no `native_decide`).

### Substance / non-vacuity
- Headline `desargues_fails_in_moulton` is a genuine non-vacuous conjunction (9 perspectivity incidences + 6 side incidences + `¬ MoultonCollinear α β γ`), assembled from independently proved components.
- `not_moulton_collinear` is real exhaustive case analysis over all three `MLine` constructors (standard / bent / vertical), each branch discharged by resolving the piecewise incidence and applying `linarith`.
- `onLine` and `MoultonCollinear` are meaningful definitions (piecewise slope-doubling incidence + standard existential collinearity) — the negation is not trivially satisfiable.
- Registered in `Proofs.lean:625` → CI-compiled.

No narrative overclaiming; Mathlib delegation (ℚ arithmetic only) is appropriately disclosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)