### PR TITLE
Enrich Erdős #1014: realign stale annotations + cover the proved body

### DIFF
--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -179,7 +179,9 @@
       "**Tight bounds insufficient**: For k=3, the bounds $R(3,l) = \\Theta(l^2/\\log l)$ are tight up to constants, but the ratio convergence needs finer information about the multiplicative constant",
       "**Power-law reduction**: The conjecture follows from any asymptotic of the form $R(k,l) \\sim c_k l^{k-1}/(\\log l)^{k-2}$, making it strictly weaker than the full asymptotic problem",
       "**Difference reformulation**: Equivalently, the discrete increment $R(k,l+1) - R(k,l)$ is $o(R(k,l))$, connecting to finite difference methods in number theory",
-      "**Monotonicity constraint**: Since $R(k,l) \\leq R(k,l+1)$, the ratio is always $\\geq 1$, so convergence to 1 means the ratio decreases toward 1 from above"
+      "**Monotonicity constraint**: Since $R(k,l) \\leq R(k,l+1)$, the ratio is always $\\geq 1$, so convergence to 1 means the ratio decreases toward 1 from above",
+      "**The k=3 case is proved**: While the conjecture is open for general $k$, `R3_ratio_convergence` settles it unconditionally for $k=3$ — the recurrence gives a *linear* increment $R(3,l+1)-R(3,l)\\leq l+1$, negligible against the *superlinear* lower bound $R(3,l)\\geq c\\,l^2/\\log l$, so the relative increment is $O(\\log l/l)\\to 0$. Only the lower bound (not the matching upper bound) is needed",
+      "**Why k≥4 resists this argument**: The k=3 proof hinges on the increment $R(2,l+1)=l+1$ being far smaller than $R(3,l)$. For $k\\geq 4$ the increment $R(k-1,l+1)$ is itself superlinear and of comparable order to $R(k,l)$, so no analogous gap is available and the conjecture remains open"
     ],
     "prerequisites": [
       "Combinatorics and number theory",


### PR DESCRIPTION
## Enrichment pass for erdos-1014 (Ramsey Number Ratio Convergence)

### Problem found
The Lean file (`Erdos1014Problem.lean`) had been **expanded ~5× to 483 lines**, but its annotations stayed clustered at lines 21–104 and had **drifted off the constructs they describe**:
- "Known Small Ramsey Values" sat at line 97, but `R33/R34/R35` are at line **321**
- "Diagonal Ramsey Upper Bound" at line 101, but `diagonal_ramsey_upper` is at line **327**
- "Positivity" at line 31 (a blank/section-comment line), but `ramsey_pos` is at line **70**

The entire proved body (lines 183–483) was unannotated. Because the annotation build **skips cached entries**, the drift went undetected.

### Changes
- **Rewrote the annotation set (14 → 21)**, every range realigned to its actual construct. `validateLineAnnotations` now reports **21 valid, 0 misaligned**.
- **Added coverage** for the convergence machinery that was entirely undocumented:
  - growth-ratio limit lemmas (`tendsto_succ_div_pow`, `tendsto_log_ratio_pow`) and `growth_ratio_close`
  - `ratio_from_asymptotics` (the 3-factor $R'/R=(R'/g')(g'/g)(g/R)$ proof)
  - `ratio_equiv_difference` (proved biconditional: ratio→1 iff increment is $o(R)$)
  - derived properties, the linear increment bound, `R3_asymptotic_bounds`
  - **`R3_ratio_convergence` — the $k=3$ case is unconditionally PROVED**
- **Fixed stale imports content** (the file does `import Mathlib`, not the granular `SimpleGraph.Basic`/`Data.Real.Basic` the old annotation claimed).
- Annotation line coverage **104 → 415 of 483**.
- Added 2 keyInsights: the proved $k=3$ case (linear increment vs superlinear growth) and why $k\ge 4$ resists the same argument.

### Axiom integrity
`status: axiomatized`, `badge: axiom`, `axiomCount: 12` already accurately reflect the 12 `axiom` declarations (Ramsey existence, classical bounds, the open conjecture, three exact values). No `native_decide` is used, so no `Lean.ofReduceBool` dependency. No meta changes needed beyond keyInsights.

### Verification
`npx tsx scripts/annotations/resolver.ts validate` → **21 valid, 0 misaligned**. Only JSON data files changed.