### PR TITLE
audit(desargues-theorem-oq-01): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2398,9 +2398,9 @@
       "result": "clean"
     },
     "desargues-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:04:55Z",
+      "lastAudited": "2026-06-18T10:07:22Z",
       "result": "clean"
     },
     "desargues-theorem-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — desargues-theorem-oq-01

**Result: CLEAN** — no integrity issues found.

Re-audit (4th pass) of *Desargues Over Any Ring: Algebraic Proof Without Sorries*.

### Counts (all match meta.json ↔ source)
| Field | meta | source |
|-------|------|--------|
| lineCount | 285 | 285 |
| theoremCount | 16 | 16 |
| definitionCount | 7 | 7 |
| sorries | 0 | 0 |
| axiomCount | 0 | 0 |

native_decide: 0 · plain decide: 0 · True stubs: 0 · structures: 0. Registered at `Proofs.lean:623` → CI-compiled.

### Integrity findings
- **Axiom integrity honest**: 0 literal axioms, no assumption-carrying structures, no `native_decide` → `Lean.ofReduceBool` not invoked → `status: verified` / `axiomCount: 0` correct.
- **Badge `mathlib` conservative**: core result is an *original* polynomial identity (custom `cross3`, `threeVecMat`) discharged by `ring` + Mathlib's `Matrix.det_fin_three`; Mathlib has no Desargues theorem. The badge underclaims (could be `original`) — no overclaim risk. `mathlibDependencies` correctly lists only infrastructure (`Matrix.det`, `ring`).
- **Headline non-vacuous**: `desargues_forward_K` / `desargues_converse_K` take real hypotheses and derive real conclusions via the proved master identity; converse uses genuine `IsDomain` cancellation.
- **Narrative accurate**: description, `originalContributions`, and `assumptions` ("None. Fully verified...") all match reality. No delegation opacity or axiom masking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)