### PR TITLE
audit(desargues-theorem): clean re-audit, no integrity issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2392,9 +2392,9 @@
       "result": "clean"
     },
     "desargues-theorem": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:04:55Z",
+      "lastAudited": "2026-06-18T10:10:16Z",
       "result": "clean"
     },
     "desargues-theorem-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — desargues-theorem (parent, Wiedijk #87)

**Result: CLEAN** — no integrity issues. Tracker bumped 3→4.

### Verified against `proofs/Proofs/DesarguesTheorem.lean`
| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| lineCount | 447 | 447 | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 16 | 16 (8 def + 6 noncomputable def + 2 abbrev) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms, 0 structures | ✓ |
| native_decide / decide / True stubs | — | 0 / 0 / 0 | ✓ |

Registered at `proofs/Proofs.lean:622` → CI-compiled.

### Tier / badge assessment
- **status `verified` / axiomCount 0** — honest: no sorries, no axioms, no `native_decide` (so no `Lean.ofReduceBool`), no assumption-carrying structures.
- **badge `mathlib`** — defensible (Tier B). The file genuinely depends on Mathlib's `crossProduct` (`×₃`) and `Matrix.det`. The core `desargues_identity` (det(P,Q,R) = det(AA',BB',CC')·K) is an original ring identity discharged by `ring` — Mathlib has no Desargues theorem — so `mathlib` is conservative but accurate.
- **No vacuity / no overclaim**: forward `desargues_theorem` proved unconditionally; converse `desargues_theorem_converse` honestly gated on non-degeneracy `K ≠ 0` (real `mul_eq_zero.mp … resolve_right`), and that condition is disclosed in `originalContributions` and `proofStrategy`.

No narrative failure modes (delegation opacity / axiom masking / inequality≠theorem / pipeline inflation / hidden imports) detected.

---
Discovered during autonomous gallery integrity audit.