### PR TITLE
Enrich Erdős #681: realign stale annotations + cover the proved body

### DIFF
--- a/src/data/proofs/erdos-681/annotations.json
+++ b/src/data/proofs/erdos-681/annotations.json
@@ -2,165 +2,479 @@
   {
     "id": "erdos-681-header",
     "proofId": "erdos-681",
-    "type": "concept",
     "range": {
       "startLine": 1,
       "endLine": 13
     },
+    "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem 681 asks whether, for all sufficiently large n, there exists a positive integer k such that n+k is composite and its least prime factor exceeds k². Posed by Erdős, Eggleton, and Selfridge, it probes the distribution of smooth numbers near a given integer.",
-    "mathContext": "The question concerns the interplay between additive shifts and multiplicative structure. Near any large n, most composite numbers n+k have small prime factors (of order √(n+k)). The conjecture asserts that some shifted composites have unusually large least prime factors relative to the shift.",
-    "significance": "key",
+    "content": "Erdős Problem 681 (posed by Erdős, Eggleton, and Selfridge) asks whether, for all sufficiently large $n$, there exists a positive integer $k$ such that $n+k$ is composite and its least prime factor exceeds $k^2$. It probes the interplay between additive shifts and multiplicative structure near a given integer.",
+    "significance": "context",
+    "mathContext": "Near any large $n$ most composite shifts $n+k$ have small prime factors (of order $\\sqrt{n+k}$). The conjecture asserts that some shifted composite has an unusually large least prime factor relative to the shift $k$.",
     "relatedConcepts": [
-      "prime-factors",
-      "smooth-numbers",
-      "sieving"
+      "least prime factor",
+      "smooth numbers",
+      "Erdős–Eggleton–Selfridge"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "elementary number theory",
+      "prime factorization"
+    ]
   },
   {
     "id": "erdos-681-imports",
     "proofId": "erdos-681",
-    "type": "concept",
     "range": {
       "startLine": 15,
       "endLine": 18
     },
+    "type": "concept",
     "title": "Imports and Setup",
-    "content": "Imports `Nat.Prime.Basic` for primality definitions and `Tactic` for proof automation. The formalization builds on Mathlib's `Nat.minFac` function.",
+    "content": "Imports `Nat.Prime.Basic` (primality), `Nat.Basic` (arithmetic), and `Tactic` (automation). The formalization is built entirely on Mathlib's `Nat.minFac`, the least prime factor function, rather than axiomatizing it.",
     "significance": "supporting",
+    "mathContext": "All least-prime-factor reasoning routes through `Nat.minFac` and its lemmas `Nat.minFac_prime`, `Nat.minFac_dvd`, `Nat.minFac_le_of_dvd`, and `Nat.minFac_sq_le_self`.",
     "relatedConcepts": [
-      "mathlib",
-      "prime-basic"
+      "Nat.minFac",
+      "Mathlib"
     ],
-    "mathContext": "See annotation content for formal details of imports and setup",
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 syntax",
+      "Mathlib library structure"
+    ]
   },
   {
     "id": "erdos-681-lpf",
     "proofId": "erdos-681",
-    "type": "definition",
     "range": {
       "startLine": 21,
       "endLine": 24
     },
+    "type": "definition",
     "title": "Least Prime Factor",
-    "content": "**`leastPrimeFactor m`** returns the smallest prime dividing m, using Mathlib's `Nat.minFac`. Returns 1 for m ≤ 1.",
-    "mathContext": "The least prime factor p(m) is a fundamental multiplicative function. For composite m, we always have p(m) ≤ √m since m must have a factor at most its square root.",
+    "content": "`leastPrimeFactor m` returns the smallest prime dividing $m$ via `Nat.minFac`, defaulting to 1 for $m \\le 1$. This total function is the computational counterpart of the `IsLeastPrimeFactor` predicate.",
     "significance": "key",
+    "mathContext": "$p(m) = \\mathrm{minFac}(m)$ for $m \\ge 2$. For composite $m$ always $p(m) \\le \\sqrt{m}$, since $m$ must have a prime factor at most its square root.",
     "relatedConcepts": [
-      "minFac",
-      "prime-factorization"
+      "least prime factor",
+      "Nat.minFac",
+      "trial division"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime factorization",
+      "smallest prime divisor"
+    ]
   },
   {
     "id": "erdos-681-is-lpf",
     "proofId": "erdos-681",
-    "type": "definition",
     "range": {
       "startLine": 26,
       "endLine": 28
     },
+    "type": "definition",
     "title": "IsLeastPrimeFactor Predicate",
-    "content": "**`IsLeastPrimeFactor p m`** holds when p is prime, p divides m, and p is minimal among all prime divisors of m. This is a relational characterization that avoids partial functions.",
-    "mathContext": "The predicate approach (rather than function) handles edge cases cleanly and allows stating results about any witness without computing minFac.",
+    "content": "`IsLeastPrimeFactor p m` holds when $p$ is prime, $p \\mid m$, and $p$ is minimal among all prime divisors of $m$. This relational characterization avoids partial functions and lets results be stated about *any* witness without computing `minFac`.",
     "significance": "key",
+    "mathContext": "$\\mathrm{IsLeastPrimeFactor}(p,m) \\iff p\\text{ prime} \\wedge p \\mid m \\wedge \\forall q\\text{ prime},\\ q \\mid m \\to p \\le q$. The conjecture is phrased over all such witnesses, with `lpf_unique` ensuring there is only one.",
     "relatedConcepts": [
-      "predicate-style",
-      "prime-divisors"
+      "predicate-style definitions",
+      "prime divisors",
+      "minimality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime divisibility",
+      "universally quantified predicates"
+    ]
   },
   {
-    "id": "erdos-681-composite-lpf",
+    "id": "erdos-681-minfac-lpf",
     "proofId": "erdos-681",
-    "type": "insight",
     "range": {
-      "startLine": 30,
-      "endLine": 33
+      "startLine": 32,
+      "endLine": 42
     },
-    "title": "Existence of Least Prime Factor",
-    "content": "Every composite number m ≥ 2 has a least prime factor. This is axiomatized since the constructive proof via `Nat.minFac` requires showing the predicate is satisfied.",
+    "type": "technique",
+    "title": "minFac Is the Least Prime Factor",
+    "content": "`minFac_is_lpf` proves `Nat.minFac m` satisfies `IsLeastPrimeFactor` for $m \\ge 2$, bundling `Nat.minFac_prime`, `Nat.minFac_dvd`, and `Nat.minFac_le_of_dvd`. `composite_has_lpf` then gives *existence* of a least prime factor for composite $m$ — a fully proved theorem (not axiomatized), with `m.minFac` as the explicit witness.",
     "significance": "supporting",
+    "mathContext": "$m \\ge 2 \\implies \\mathrm{IsLeastPrimeFactor}(\\mathrm{minFac}(m), m)$. Existence for composites is immediate since `Nat.minFac` always returns a genuine prime divisor for $m \\ge 2$.",
     "relatedConcepts": [
-      "fundamental-theorem",
-      "existence"
+      "Nat.minFac_prime",
+      "Nat.minFac_dvd",
+      "existence proof"
     ],
-    "mathContext": "See annotation content for formal details of existence of least prime factor",
-    "prerequisites": []
+    "prerequisites": [
+      "IsLeastPrimeFactor",
+      "Mathlib minFac API"
+    ]
   },
   {
-    "id": "erdos-681-conjecture",
+    "id": "erdos-681-prime-self",
     "proofId": "erdos-681",
-    "type": "concept",
     "range": {
-      "startLine": 36,
-      "endLine": 43
-    },
-    "title": "Erdős Problem 681",
-    "content": "**The main conjecture**: For all sufficiently large n, there exists k > 0 such that n+k is composite and its least prime factor exceeds k². The composite requirement is essential since primes trivially have large LPF (equal to themselves).",
-    "mathContext": "Formally: ∃ N₀, ∀ n ≥ N₀, ∃ k > 0, ¬(n+k).Prime ∧ 2 ≤ n+k ∧ ∀ p, IsLeastPrimeFactor p (n+k) → k² < p. The condition k² < p(n+k) for a composite is very strong — it says the smallest factor grows quadratically in the shift.",
-    "significance": "key",
-    "relatedConcepts": [
-      "number-theory",
-      "sieving",
-      "open-problem"
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "erdos-681-general",
-    "proofId": "erdos-681",
-    "type": "concept",
-    "range": {
-      "startLine": 47,
+      "startLine": 44,
       "endLine": 53
     },
-    "title": "Generalised Conjecture (Arbitrary Exponent d)",
-    "content": "**Generalization**: For any fixed d, for all large n, there exists k > 0 with n+k composite and p(n+k) > k^d. The original conjecture is the d = 2 case.",
-    "mathContext": "The generalization to arbitrary exponents d asks whether near every large integer, some composite shift has a least prime factor that is a d-th power of the shift. For large d this becomes extremely restrictive.",
+    "type": "insight",
+    "title": "Primes Are Their Own LPF",
+    "content": "`prime_lpf_self`: a prime $p$ is its own least prime factor. This pins down *why* the conjecture demands $n+k$ be **composite** — if $n+k$ were prime its least prime factor would be $n+k$ itself, which trivially exceeds $k^2$ for large $n$. The interesting content lives entirely in the composite case.",
     "significance": "key",
+    "mathContext": "$\\mathrm{IsLeastPrimeFactor}(p,p)$ for prime $p$: the only prime dividing $p$ is $p$. So $n+k$ prime gives $p(n+k)=n+k$, a vacuous win — hence the composite requirement.",
     "relatedConcepts": [
-      "generalization",
-      "exponent-growth"
+      "prime self-divisibility",
+      "why composite matters"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsLeastPrimeFactor",
+      "prime divisors"
+    ]
   },
   {
     "id": "erdos-681-sqrt",
     "proofId": "erdos-681",
-    "type": "insight",
     "range": {
-      "startLine": 66,
-      "endLine": 69
+      "startLine": 55,
+      "endLine": 61
     },
+    "type": "insight",
     "title": "LPF Square Root Bound",
-    "content": "The least prime factor of a composite m satisfies p(m) ≤ √m. This is the trivial upper bound: every composite has a prime factor at most its square root.",
-    "mathContext": "Combined with the conjecture, this means we need k such that k² < p(n+k) ≤ √(n+k), giving k⁴ < n+k. So the conjecture is non-trivial only for k ≪ n^{1/4}.",
-    "significance": "supporting",
+    "content": "`lpf_le_sqrt`: every composite $m$ has $p(m)^2 \\le m$ (i.e. $p(m) \\le \\sqrt{m}$), the standard trial-division fact, proved from Mathlib's `Nat.minFac_sq_le_self`. This is the *upper* bound on the least prime factor that the conjecture's lower bound $k^2 < p(n+k)$ must fight against.",
+    "significance": "key",
+    "mathContext": "Composite $m$: $p(m)^2 \\le m$. Combined with $k^2 < p(n+k)$ this forces $k^4 < (k^2)^2 < p(n+k)^2 \\le n+k$, so the conjecture is non-trivial only for $k \\ll n^{1/4}$.",
     "relatedConcepts": [
-      "trial-division",
-      "composite-structure"
+      "trial division",
+      "composite structure",
+      "square-root bound"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lpf_le_sqrt",
+      "Nat.minFac_sq_le_self"
+    ]
   },
   {
-    "id": "erdos-681-minFac",
+    "id": "erdos-681-unique",
     "proofId": "erdos-681",
-    "type": "insight",
+    "range": {
+      "startLine": 63,
+      "endLine": 69
+    },
+    "type": "technique",
+    "title": "Uniqueness of the LPF",
+    "content": "`lpf_unique`: if both $p$ and $q$ are least prime factors of $m$, then $p=q$, by mutual minimality ($p \\le q$ and $q \\le p$). This makes the predicate-style formulation behave like a function, so the universally-quantified conjecture condition can be discharged via the single witness `m.minFac`.",
+    "significance": "supporting",
+    "mathContext": "Minimality gives $p \\le q$ and $q \\le p$, hence $p = q$ by antisymmetry. Uniqueness is what bridges the $\\forall$-over-witnesses statement and the concrete `minFac`.",
+    "relatedConcepts": [
+      "antisymmetry",
+      "uniqueness",
+      "predicate-to-function bridge"
+    ],
+    "prerequisites": [
+      "IsLeastPrimeFactor",
+      "minimality"
+    ]
+  },
+  {
+    "id": "erdos-681-bridge",
+    "proofId": "erdos-681",
     "range": {
       "startLine": 71,
-      "endLine": 73
+      "endLine": 96
     },
-    "title": "Nat.minFac Connection",
-    "content": "**`Nat.minFac`** gives the least prime factor for m ≥ 2, connecting the Mathlib API to the IsLeastPrimeFactor predicate used throughout the formalization.",
+    "type": "technique",
+    "title": "Bridging leastPrimeFactor and minFac",
+    "content": "A block of API lemmas connecting the total `leastPrimeFactor` to `Nat.minFac` and the predicate: `leastPrimeFactor_eq_minFac` ($=$ for $m \\ge 2$), `leastPrimeFactor_is_lpf`, `leastPrimeFactor_prime` ($p(p)=p$ for primes), `lpf_dvd`, and `lpf_prime`. Together they give the rewriting infrastructure used throughout the structural results.",
     "significance": "supporting",
+    "mathContext": "For $m \\ge 2$: $\\mathrm{leastPrimeFactor}(m) = \\mathrm{minFac}(m)$, it is a genuine least prime factor, it is prime, and it divides $m$. These let proofs freely interchange the function and predicate views.",
     "relatedConcepts": [
-      "mathlib-api",
-      "minFac"
+      "API lemmas",
+      "leastPrimeFactor",
+      "Nat.minFac"
     ],
-    "mathContext": "See annotation content for formal details of nat.minfac connection",
-    "prerequisites": []
+    "prerequisites": [
+      "leastPrimeFactor",
+      "minFac_is_lpf"
+    ]
+  },
+  {
+    "id": "erdos-681-conjecture",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 100,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "Erdős Problem 681 (Main Conjecture)",
+    "content": "`ErdosProblem681`: for all sufficiently large $n$ there exists $k>0$ with $n+k$ composite, $n+k \\ge 2$, and every least prime factor $p$ of $n+k$ satisfies $k^2 < p$. Stated as a `Prop`-valued definition (not asserted), keeping the file assumption-free at the conjecture level. The condition $k^2 < p(n+k)$ for a composite is very strong: the smallest factor must grow quadratically in the shift.",
+    "significance": "key",
+    "mathContext": "$\\exists N_0,\\ \\forall n \\ge N_0,\\ \\exists k>0,\\ \\neg(n+k)\\text{ prime} \\wedge 2 \\le n+k \\wedge \\forall p,\\ \\mathrm{IsLeastPrimeFactor}(p,n+k) \\to k^2 < p$.",
+    "relatedConcepts": [
+      "open problem",
+      "smooth numbers",
+      "quadratic lower bound"
+    ],
+    "prerequisites": [
+      "IsLeastPrimeFactor",
+      "existential-over-shifts"
+    ]
+  },
+  {
+    "id": "erdos-681-general",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 111,
+      "endLine": 117
+    },
+    "type": "concept",
+    "title": "Generalised Conjecture (Arbitrary Exponent d)",
+    "content": "`ErdosProblem681General d`: the same statement with $k^2$ replaced by $k^d$. The original is the $d=2$ case. Larger $d$ makes the requirement progressively more restrictive (the least prime factor must be a higher power of the shift).",
+    "significance": "key",
+    "mathContext": "$\\exists N_0,\\ \\forall n \\ge N_0,\\ \\exists k>0,\\ \\neg(n+k)\\text{ prime} \\wedge 2 \\le n+k \\wedge \\forall p,\\ \\mathrm{IsLeastPrimeFactor}(p,n+k) \\to k^d < p$. Monotone in $d$: harder as $d$ grows.",
+    "relatedConcepts": [
+      "generalization",
+      "exponent parameter"
+    ],
+    "prerequisites": [
+      "ErdosProblem681"
+    ]
+  },
+  {
+    "id": "erdos-681-d2",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 119,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "Original Conjecture = d=2 Case",
+    "content": "`erdos681_is_general_d2`: `ErdosProblem681 ↔ ErdosProblem681General 2`, true by `rfl` since the definitions coincide at $d=2$. This formally records that the parametrised family specializes to the original problem.",
+    "significance": "supporting",
+    "mathContext": "$\\mathrm{ErdosProblem681} \\iff \\mathrm{ErdosProblem681General}\\,2$ definitionally — the two `Prop`s are syntactically identical after substituting $d=2$.",
+    "relatedConcepts": [
+      "definitional equality",
+      "specialization"
+    ],
+    "prerequisites": [
+      "ErdosProblem681",
+      "ErdosProblem681General"
+    ]
+  },
+  {
+    "id": "erdos-681-prime-offset",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 127,
+      "endLine": 135
+    },
+    "type": "concept",
+    "title": "Prime Offsets Trivially Qualify",
+    "content": "`prime_offset_gives_large_lpf`: if $n+k$ is prime and $k^2 < n+k$, then its least prime factor (namely $n+k$ itself, via `prime_lpf_self` + `lpf_unique`) exceeds $k^2$. This isolates the prime case as trivial and confirms the difficulty is concentrated in composites.",
+    "significance": "supporting",
+    "mathContext": "$n+k$ prime $\\implies p(n+k)=n+k > k^2$ whenever $k^2 < n+k$. The result reduces the open content to composite shifts.",
+    "relatedConcepts": [
+      "prime case",
+      "triviality reduction"
+    ],
+    "prerequisites": [
+      "prime_lpf_self",
+      "lpf_unique"
+    ]
+  },
+  {
+    "id": "erdos-681-composite-constraint",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 137,
+      "endLine": 151
+    },
+    "type": "technique",
+    "title": "The Composite Constraint: k⁴ < n+k",
+    "content": "`composite_constraint`: if $n+k$ is composite and $k^2 < p(n+k)$, then $k^4 < n+k$. The proof chains $k^4 = (k^2)^2 < p(n+k)^2 \\le n+k$ using `lpf_le_sqrt`. This bounds the usable shift to $k \\ll n^{1/4}$ — the quantitative heart of why the problem is delicate.",
+    "significance": "key",
+    "mathContext": "$k^4 = (k^2)^2 < p^2 \\le n+k$, combining the conjecture's lower bound $k^2 < p$ with the composite upper bound $p^2 \\le n+k$. So any composite witness has $k < (n+k)^{1/4}$.",
+    "relatedConcepts": [
+      "square-root bound",
+      "search-range constraint",
+      "quartic bound"
+    ],
+    "prerequisites": [
+      "lpf_le_sqrt",
+      "composite numbers"
+    ]
+  },
+  {
+    "id": "erdos-681-small-d",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 153,
+      "endLine": 185
+    },
+    "type": "concept",
+    "title": "Trivial Small-d Cases and Monotonicity",
+    "content": "Three warm-up results: `d1_k1_trivial` ($k=1$, $d=1$ needs only $p(n+1)>1$, automatic since primes are $\\ge 2$); `general_d0_trivial` proves `ErdosProblem681General 0` outright (pick $k=n$, so $n+k=2n$ is composite and $p>1$); and `general_monotone` shows the $d_2$-version implies the $d_1$-version for $d_1 \\le d_2$ (since $k^{d_1} \\le k^{d_2}$). The last gives the implication direction used to relate exponents.",
+    "significance": "supporting",
+    "mathContext": "$d=0$ is fully proved; $k^{d_1} \\le k^{d_2}$ gives `General d₂ → General d₁` for $d_1 \\le d_2$, so the family is monotone (harder as $d$ increases).",
+    "relatedConcepts": [
+      "base cases",
+      "monotonicity in d",
+      "power inequalities"
+    ],
+    "prerequisites": [
+      "ErdosProblem681General",
+      "Nat.pow_le_pow_right"
+    ]
+  },
+  {
+    "id": "erdos-681-k1-reduction",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 189,
+      "endLine": 201
+    },
+    "type": "insight",
+    "title": "k=1 Reduces the Problem to 'n+1 Prime'",
+    "content": "`k1_resolves_all_d`: for ANY $d$, if $n+1$ is composite then $k=1$ works, because $p(n+1) \\ge 2 > 1 = 1^d$. The decisive structural consequence: **the conjecture is open only for those $n$ with $n+1$ prime** (i.e. $n = p-1$). This collapses the problem to shifts of primes and is the organizing principle for the rest of the file.",
+    "significance": "key",
+    "mathContext": "$n+1$ composite $\\implies k=1$ witnesses every $d$ (since $1^d=1 < p(n+1)$). Remaining hard set: $\\{n : n+1 \\text{ prime}\\}$.",
+    "relatedConcepts": [
+      "case reduction",
+      "primes minus one",
+      "trivial witness"
+    ],
+    "prerequisites": [
+      "IsLeastPrimeFactor",
+      "ErdosProblem681General"
+    ]
+  },
+  {
+    "id": "erdos-681-resolved-subcases",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 203,
+      "endLine": 230
+    },
+    "type": "concept",
+    "title": "Sub-cases Resolved by k=1",
+    "content": "Concrete instances of the $k=1$ reduction: `general_d1_at_composite_succ` and `conjecture_at_composite_succ` handle $n$ with $n+1$ composite (for $d=1$ and $d=2$); `general_d1_odd` covers all odd $n \\ge 3$ unconditionally (then $n+1$ is even $\\ge 4$, hence composite, so $k=1$ works). These carve away everything except $n$ with $n+1$ an odd prime.",
+    "significance": "supporting",
+    "mathContext": "Odd $n \\ge 3$: $n+1$ even $\\ge 4 \\implies$ composite $\\implies k=1$ valid. So only $n$ with $n+1$ an odd prime remain open.",
+    "relatedConcepts": [
+      "odd integers",
+      "composite successor",
+      "k=1 witness"
+    ],
+    "prerequisites": [
+      "k1_resolves_all_d",
+      "Even/Odd parity"
+    ]
+  },
+  {
+    "id": "erdos-681-hard-case",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 232,
+      "endLine": 249
+    },
+    "type": "technique",
+    "title": "The Hard Case: n+1 Prime, k≥2",
+    "content": "`hard_case_constraint`: in the remaining regime ($n+1$ prime, so $k=1$ excluded), any composite witness with $k \\ge 2$ and $k^d < p(n+k)$ must satisfy $k^{2d} < n+k$. The proof mirrors `composite_constraint` but for general $d$: $k^{2d}=(k^d)^2 < p^2 \\le n+k$. This bounds the search to $k \\lesssim n^{1/(2d)}$.",
+    "significance": "key",
+    "mathContext": "$k^{2d} = (k^d)^2 < p(n+k)^2 \\le n+k$, so $k < (n+k)^{1/(2d)}$. The hard case is finding *any* such composite $n+k$ when $n+1$ is prime.",
+    "relatedConcepts": [
+      "search-range bound",
+      "general exponent",
+      "square-root bound"
+    ],
+    "prerequisites": [
+      "lpf_le_sqrt",
+      "composite_constraint"
+    ]
+  },
+  {
+    "id": "erdos-681-parity",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 253,
+      "endLine": 298
+    },
+    "type": "technique",
+    "title": "Witness Parity: k Must Be Odd",
+    "content": "A parity-obstruction chain. `minFac_of_even`: even $m \\ge 4$ has $p(m)=2$. `even_of_prime_succ`: if $n+1 \\ge 3$ is prime then $n$ is even. `even_offset_excluded`: for even $n$ and even $k \\ge 2$, the even composite $n+k$ has $p=2 < k^d$, so it cannot witness. `witness_must_be_odd` combines these: when $n+1$ is an odd prime, every witness $k \\ge 2$ must be **odd**. This prunes half the search space in the hard case.",
+    "significance": "supporting",
+    "mathContext": "$n+1$ odd prime $\\implies n$ even; then even $k$ makes $n+k$ even with $p(n+k)=2 \\le k^d$, contradicting $k^d < p$. Hence valid $k$ are odd.",
+    "relatedConcepts": [
+      "parity obstruction",
+      "even least prime factor",
+      "search pruning"
+    ],
+    "prerequisites": [
+      "minFac_of_even",
+      "even_of_prime_succ"
+    ]
+  },
+  {
+    "id": "erdos-681-search-bound",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 300,
+      "endLine": 315
+    },
+    "type": "technique",
+    "title": "Search-Range Bound: k^(2d) < n+k",
+    "content": "`general_constraint` strengthens `hard_case_constraint` to the weaker hypothesis $k \\ge 1$: every valid triple $(n,k,d)$ with $n+k$ composite satisfies $k^{2d} < n+k$. The proof rewrites $k^{2d} = k^d \\cdot k^d$ via `pow_add` and chains through $p^2 \\le n+k$, bounding any witness search to $O(n^{1/(2d)})$.",
+    "significance": "supporting",
+    "mathContext": "$k^{2d} = k^d \\cdot k^d < k^d \\cdot p \\le p \\cdot p \\le n+k$. Uniform over $k \\ge 1$, so it bounds the whole witness search.",
+    "relatedConcepts": [
+      "search complexity",
+      "general exponent",
+      "pow_add"
+    ],
+    "prerequisites": [
+      "lpf_le_sqrt",
+      "general exponent bound"
+    ]
+  },
+  {
+    "id": "erdos-681-residue",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 319,
+      "endLine": 347
+    },
+    "type": "insight",
+    "title": "d=1 Residue-Class Resolution (k=3)",
+    "content": "`d1_at_2_mod_3`: when $n+1 = p$ is prime with $p \\equiv 2 \\pmod 3$ and $n+3$ composite, the shift $k=3$ witnesses the $d=1$ case. Since $n$ is even, $n+3$ is odd ($2 \\nmid n+3$); and $p \\equiv 2 \\pmod 3$ gives $n+3 \\equiv 1 \\pmod 3$ ($3 \\nmid n+3$); so $p(n+3) \\ge 5 > 3 = 3^1$. A genuine non-trivial witness construction in the hard regime, exploiting residue information.",
+    "significance": "key",
+    "mathContext": "$n+1=p$ prime, $p \\equiv 2 \\pmod 3$, $n+3$ composite $\\implies 2\\nmid n+3$ and $3 \\nmid n+3 \\implies p(n+3) \\ge 5 > 3$, witnessing $d=1$ with $k=3$.",
+    "relatedConcepts": [
+      "residue classes",
+      "modular arithmetic",
+      "explicit witness"
+    ],
+    "prerequisites": [
+      "even_of_prime_succ",
+      "divisibility by 2 and 3"
+    ]
+  },
+  {
+    "id": "erdos-681-connection-680",
+    "proofId": "erdos-681",
+    "range": {
+      "startLine": 351,
+      "endLine": 362
+    },
+    "type": "concept",
+    "title": "Connection to Erdős #680",
+    "content": "`lpf_condition_equiv`: the predicate-style condition $\\forall p,\\ \\mathrm{IsLeastPrimeFactor}(p,m) \\to k < p$ is equivalent to $k < \\mathrm{minFac}(m)$. This formally identifies the core condition with the `minFac`-based formulation of the sibling Problem #680, showing the two phrasings are interchangeable.",
+    "significance": "supporting",
+    "mathContext": "$(\\forall p,\\ \\mathrm{IsLeastPrimeFactor}(p,m) \\to k<p) \\iff k < \\mathrm{minFac}(m)$, via `lpf_unique`. Bridges #681's predicate form and #680's `minFac` form.",
+    "relatedConcepts": [
+      "Problem #680",
+      "equivalent formulations",
+      "Nat.minFac"
+    ],
+    "prerequisites": [
+      "lpf_unique",
+      "minFac_is_lpf"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for erdos-681 (Large Least Prime Factor in Shifted Composites)

### Problem found
Annotations covered only lines 1–73 and several had **drifted off their constructs**:
- "Erdős Problem 681" sat at line 36, but `ErdosProblem681` is defined at line **103**
- "Generalised Conjecture" at line 47, but `ErdosProblem681General` is at line **113**
- "LPF Square Root Bound" at line 66, but `lpf_le_sqrt` is at line **55**

The entire proved body (lines 77–362) — the structural reductions and constraints that are the actual mathematical content — had no annotations.

### Changes
- **Rewrote the annotation set (9 → 22)**, every range realigned. `validateLineAnnotations`: **22 valid, 0 misaligned**.
- **Added coverage** for the proved body:
  - the `minFac`/predicate bridge lemmas, `prime_lpf_self`, `lpf_unique`
  - both conjecture defs + the $d=2$ equivalence
  - the composite constraint $k^4 < n+k$ and general $k^{2d} < n+k$ search bound
  - small-$d$ warm-ups and monotonicity
  - **the pivotal `k1_resolves_all_d`** — the problem is open *only* when $n+1$ is prime
  - the $k=1$-resolved sub-cases, the hard case ($n+1$ prime)
  - the **parity obstruction** (any witness $k\ge 2$ must be odd)
  - the $d=1$ residue-class $k=3$ construction, and the equivalence to Problem #680
- **Fixed a factual error**: `composite_has_lpf` was labelled "axiomatized" but it is a proved theorem (witness `m.minFac`).
- **Improved field quality**: filled empty `prerequisites` and replaced placeholder mathContext ("See annotation content for formal details…") with real mathematics.
- Annotation line coverage **73 → 324 of 362**.

### Axiom integrity
0 `axiom` declarations, 0 `native_decide`, 0 sorries. `status: axiomatized` / `badge: wip` (open problem, partial results) and `axiomCount: 0` are accurate — left unchanged.

### Verification
`npx tsx scripts/annotations/resolver.ts validate` → **22 valid, 0 misaligned**. Only one JSON data file changed.