### PR TITLE
Enrich Shannon Source Coding OQ-04 (Method of Types): annotate proof body

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/annotations.json
@@ -128,5 +128,150 @@
     "prerequisites": [
       "Fintype.card_pi"
     ]
+  },
+  {
+    "id": "ann-ssc-oq04-overview",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "Method of Types: Overview and Shannon Entropy",
+    "content": "Frames the open question (OQ-04: give an alternative proof of the source coding theorem via Csiszar–Korner’s method of types) and defines the central quantity, `shannonEntropy` $H(p) = -\\sum_i p_i\\log p_i$. The method of types is a combinatorial technique: group length-$n$ sequences over a $k$-letter alphabet by their empirical distribution (type), bound each type class by $\\approx 2^{nH}$, and count types polynomially. This converts the asymptotic equipartition argument into exact finite combinatorics.",
+    "significance": "key",
+    "mathContext": "Shannon entropy $H(p) = -\\sum_{i} p_i \\log p_i$ measures the average information per symbol. Source coding: sequences from a source of entropy $H(p)$ compress to $\\approx nH(p)$ bits.",
+    "relatedConcepts": [
+      "Shannon entropy",
+      "method of types",
+      "source coding theorem",
+      "information theory",
+      "Csiszár–Körner"
+    ],
+    "prerequisites": [
+      "information theory: entropy",
+      "probability distributions",
+      "combinatorics"
+    ]
+  },
+  {
+    "id": "ann-ssc-oq04-typeprob",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 184,
+      "endLine": 238
+    },
+    "type": "concept",
+    "title": "Empirical Entropy, Type Probability, and Their Logarithm",
+    "content": "Connects the empirical (per-type) quantities to entropy. `empEntropy_eq_shannonEntropy` shows the empirical entropy of a type $f$ equals $H(Q)$ for the normalized distribution $Q = f/n$. `typeProb` is the probability $\\prod_i (f_i/n)^{f_i}$ that the empirical distribution assigns to any single sequence of type $f$, and `log_typeProb_eq` proves $\\log(\\mathrm{typeProb}) = -n\\,H(Q)$ — i.e. every sequence in the type class has probability exactly $2^{-nH(Q)}$ under its own empirical law. This exact equidistribution is the engine of the method of types.",
+    "significance": "key",
+    "mathContext": "Equidistribution under the empirical law: each sequence of type $f$ has probability $\\prod_i (f_i/n)^{f_i} = e^{-nH(Q)}$, where $Q=f/n$ and $H(Q)$ is the empirical entropy. So $\\log(\\mathrm{typeProb}) = -nH(Q)$.",
+    "relatedConcepts": [
+      "empirical distribution",
+      "type probability",
+      "empirical entropy",
+      "equipartition"
+    ],
+    "prerequisites": [
+      "information theory: entropy",
+      "logarithms of products",
+      "probability"
+    ]
+  },
+  {
+    "id": "ann-ssc-oq04-size-bound",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 239,
+      "endLine": 308
+    },
+    "type": "insight",
+    "title": "Type Class Size Upper Bound |T_f| ≤ exp(n·H(f/n))",
+    "content": "The key combinatorial bound of the method of types, proved cleanly without Stirling. Let $Q = f/n$ be the empirical distribution (which sums to 1). Each sequence $x\\in T_f$ has $\\prod_j Q(x_j) = \\mathrm{typeProb} = e^{-nH(Q)}$. Summing over ALL sequences gives $\\sum_x \\prod_j Q(x_j) = (\\sum_i Q_i)^n = 1$. Since the $|T_f|$ sequences in the type class each contribute $e^{-nH(Q)}$, we get $|T_f|\\cdot e^{-nH(Q)} \\le 1$, hence $|T_f| \\le e^{nH(Q)}$. This is the entropy-as-counting principle: a type class has at most $2^{nH}$ members.",
+    "significance": "key",
+    "mathContext": "Counting bound: $|T_f| \\le e^{\\,n\\,H(f/n)}$. Proof: $|T_f|\\,e^{-nH(Q)} = \\sum_{x\\in T_f}\\prod_j Q(x_j) \\le \\sum_{\\text{all }x}\\prod_j Q(x_j) = \\big(\\textstyle\\sum_i Q_i\\big)^n = 1$.",
+    "relatedConcepts": [
+      "type class size",
+      "entropy bound",
+      "probability normalization",
+      "asymptotic equipartition"
+    ],
+    "prerequisites": [
+      "information theory: typical sets",
+      "combinatorics",
+      "probability"
+    ]
+  },
+  {
+    "id": "ann-ssc-oq04-lower-bound",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 309,
+      "endLine": 361
+    },
+    "type": "insight",
+    "title": "Dominant Type Lower Bound via Pigeonhole",
+    "content": "The complementary lower bound: some \"dominant\" type class has size $\\ge k^n/(n+1)^k$. The argument is pure pigeonhole — there are $k^n$ total sequences distributed among at most $(n+1)^k$ types (each type is a function $\\mathrm{Fin}\\,k\\to\\{0,\\dots,n\\}$), so the largest fiber of the empirical-distribution map has at least $k^n/(n+1)^k$ elements (`Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to`). Since $(n+1)^k$ is polynomial in $n$ while $k^n$ is exponential, the dominant type captures nearly all the $\\approx 2^{n\\log k}$ sequences — the basis for achievability.",
+    "significance": "key",
+    "mathContext": "Pigeonhole lower bound: among $k^n$ sequences and $\\le (n+1)^k$ types, some type class has size $\\ge \\dfrac{k^n}{(n+1)^k}$. Polynomially many types, exponentially many sequences.",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "dominant type",
+      "number of types",
+      "fiber cardinality"
+    ],
+    "prerequisites": [
+      "combinatorics: pigeonhole",
+      "counting types",
+      "information theory"
+    ]
+  },
+  {
+    "id": "ann-ssc-oq04-achievability",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 362,
+      "endLine": 420
+    },
+    "type": "concept",
+    "title": "Source Coding Achievability (Stated; Proved in Degenerate Form)",
+    "content": "States the achievability direction: for any $\\varepsilon>0$, large-$n$ sequences can be coded with length $\\le n(H(p)+\\varepsilon)$ while covering a target type class. Honesty note: as formalized, the theorem is proved in a DEGENERATE form — the source-file comment flags that the parameter $\\delta$ is unused and the witness is the trivial constant-zero sequence (code_length $=0$, covering a single sequence). This is logically true but strictly weaker than the genuine source coding theorem, which would require covering probability $\\ge 1-\\delta$. The substantive content of the entry is the type-counting machinery (size bounds above); the achievability statement is a placeholder skeleton, not a full proof.",
+    "significance": "supporting",
+    "mathContext": "Stated rate: $\\exists$ code with length $\\le n(H(p)+\\varepsilon)$. As proved, degenerate ($\\delta$ unused, covers one sequence) — weaker than the true theorem requiring coverage probability $\\ge 1-\\delta$.",
+    "relatedConcepts": [
+      "source coding theorem",
+      "achievability",
+      "code rate",
+      "honest formalization scope"
+    ],
+    "prerequisites": [
+      "information theory: source coding",
+      "rate-distortion basics",
+      "proof transparency"
+    ]
+  },
+  {
+    "id": "ann-ssc-oq04-auxiliary",
+    "proofId": "shannon-source-coding-oq-04",
+    "range": {
+      "startLine": 421,
+      "endLine": 462
+    },
+    "type": "concept",
+    "title": "Auxiliary Counting Facts and the Multinomial Bound",
+    "content": "Closing combinatorial facts: the number of distinct types is at most $(n+1)^k$ (`count_types_le`, polynomial in $n$), the total sequence count is $k^n$ (`total_sequences_eq`), and every sequence lies in exactly one type class via its empirical distribution (`type_class_partition`). Finally `multinomial_le_entropy_pow` transfers the type-class size bound to the multinomial coefficient: $\\binom{n}{f_1,\\dots,f_k} = |T_f| \\le e^{nH(f/n)}$, i.e. $n!/\\prod_i f_i! \\le 2^{nH}$. (The source docstring’s \"[OPEN: requires Stirling]\" remark is outdated — the bound is actually derived here, Stirling-free, from the type-class size bound.)",
+    "significance": "supporting",
+    "mathContext": "Type counting: $\\#\\text{types} \\le (n+1)^k$, total sequences $= k^n$, and $\\binom{n}{f_1,\\dots,f_k} \\le e^{\\,nH(f/n)}$ — a Stirling-free bound on the multinomial coefficient.",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "number of types",
+      "partition of sequences",
+      "Stirling-free bound"
+    ],
+    "prerequisites": [
+      "combinatorics: multinomial coefficients",
+      "counting",
+      "information theory"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `shannon-source-coding-oq-04`. The 462-line method-of-types file had only 6 annotations covering lines 57–183; the entropy bounds, pigeonhole lower bound, achievability theorem, and auxiliary counting were unannotated.

**Coverage 13% → 83%** (58 → 386 / 463 lines), 6 → 12 annotations.

Added 6 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
- method of types overview + Shannon entropy definition
- empirical entropy, type probability, and $\log(\mathrm{typeProb}) = -nH(Q)$
- type class size upper bound $|T_f| \le e^{nH(f/n)}$ (clean, Stirling-free)
- dominant type lower bound $\ge k^n/(n+1)^k$ via pigeonhole
- source coding achievability — **flagged honestly** as proved in degenerate form (the source comment notes $\delta$ is unused and the witness is a single constant sequence; weaker than the true theorem)
- auxiliary counting facts + multinomial bound (notes the stale `[OPEN: Stirling]` docstring — the bound is actually derived)

Accuracy over polish: the degenerate achievability proof and outdated docstring are surfaced rather than overclaimed. Existing annotations preserved.