### PR TITLE
Fix: chebyshev-bounds uses native_decide → axiomatized (#25409)

### DIFF
--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChebyshevBounds.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "bertrand-postulate",
       "analytic-number-theory"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "The lower-bound theorem `primeCounting_ge_log` discharges `Nat.log 2 2 = 1` via `native_decide`, so it depends on the `Lean.ofReduceBool` axiom (which trusts the compiler's kernel reduction; `#print axioms primeCounting_ge_log` lists it). All other results in the file are fully machine-verified. `leanFile.axiomCount` remains 0 since there are no literal `axiom` declarations.",
     "lineCount": 439,
     "theoremCount": 15,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

The `chebyshev-bounds` entry claims `verified` / `axiomCount: 0` / "None. Fully machine-verified.", but its presented lower-bound theorem `primeCounting_ge_log` discharges `Nat.log 2 2 = 1` with `native_decide` (`ChebyshevBounds.lean:312`). Per CLAUDE.md:140, a substantive presented theorem proved via `native_decide` depends on `Lean.ofReduceBool` and must be classed `axiomatized`.

This is a residual of #25409 (verified entries with load-bearing `native_decide` and `axiomCount: 0`).

## Evidence

- `primeCounting_ge_log` is explicitly presented (`#check primeCounting_ge_log` at line 369) and its proof body uses `native_decide` directly — so `#print axioms primeCounting_ge_log` lists `Lean.ofReduceBool`. No build needed to confirm: the tactic is inside the named theorem's own proof term.

**Before**: `status: "verified"`, `badge: "original"`, `meta.axiomCount: 0`, `assumptions: "None. Fully machine-verified."`
**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Minimal metadata-only change (4 lines). Lean source untouched.

Part of #25409

---
Automated fix by lean-mechanic agent.