### PR TITLE
Fix: divisibility-rules uses native_decide → axiomatized (#25409)

### DIFF
--- a/src/data/proofs/divisibility-rules/meta.json
+++ b/src/data/proofs/divisibility-rules/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityRules.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "elementary-number-theory",
       "digit-sum"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "Relies on Lean.ofReduceBool: many core named theorems discharge load-bearing facts via native_decide. The coprime-factorization rules (six_dvd_iff, twelve_dvd_iff, fifteen_dvd_iff, eighteen_dvd_iff, thirty_dvd_iff) prove their Nat.Coprime side conditions by native_decide; the digit-sum rules (div_by_3, div_by_9, seven_dvd_octal, three_dvd_hex, five_dvd_hex, fifteen_dvd_hex, three_dvd_base7, two_dvd_base7, six_dvd_base7) discharge the b % d = 1 hypothesis by native_decide; and the digital-root value theorems (digitalRoot_nine, digitalRoot_one, digitalRoot_123, digitalRoot_999, digitalRoot_100) are proved entirely by native_decide. native_decide trusts the compiler kernel and so #print axioms lists Lean.ofReduceBool. No literal axiom declarations and no sorries (leanFile.axiomCount = 0).",
     "lineCount": 392,
     "theoremCount": 38,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

`divisibility-rules` claimed `verified` / `original` / `axiomCount: 0` / "None. Fully machine-verified.", but its core named theorems rely on `native_decide`, which trusts the compiler kernel and so depends on `Lean.ofReduceBool` (`#print axioms` lists it). Per the project axiom-integrity policy, such an entry must be `axiomatized` with `axiomCount ≥ 1` and the assumption disclosed.

## Evidence

Load-bearing `native_decide` in named, headline theorems in `proofs/Proofs/DivisibilityRules.lean`:

- Coprime-factorization rules: `six_dvd_iff` (L192), `twelve_dvd_iff` (L201), `fifteen_dvd_iff` (L210), `eighteen_dvd_iff` (L219), `thirty_dvd_iff` (L236) — discharge `Nat.Coprime _ _ := by native_decide`.
- Digit-sum rules: `div_by_3`, `div_by_9`, `seven_dvd_octal`, `three_dvd_hex`, `five_dvd_hex`, `fifteen_dvd_hex`, `three_dvd_base7`, `two_dvd_base7`, `six_dvd_base7` (L250–282) — discharge the `b % d = 1` hypothesis `by native_decide`.
- Digital-root values: `digitalRoot_nine/one/123/999/100` (L332–340) — proved entirely `by native_decide`.

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, `assumptions: "None. Fully machine-verified."`
**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool` and enumerates the tainted theorems. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only change; no Lean source touched.

Part of #25409.

---
Automated fix by lean-mechanic agent.