### PR TITLE
Fix: certified Jacobi computation (eqr-oq-03-oq-01-oq-02) uses native_decide → axiomatized

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "certified-computation",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 189,
-    "assumptions": "None.",
+    "assumptions": "Relies on `Lean.ofReduceBool`: the headline certified-computation theorems (`certified_J_7_13`, `certified_J_1001_9907`, `certified_J_219_383`, and the `step_J*` lemmas) discharge the final Jacobi-symbol value via `native_decide`, which trusts the Lean compiler's kernel reduction. `#print axioms` therefore lists `Lean.ofReduceBool`, so the entry is not axiom-free. (`leanFile.axiomCount` remains 0 because there are no literal `axiom` declarations.)",
     "dateAdded": "2026-03-30",
     "originalContributions": [
       "Reusable reduce_step, extract_two_step, reciprocity_step lemmas",


### PR DESCRIPTION
## Fix

`elementary-quadratic-reciprocity-oq-03-oq-01-oq-02` ("Certified Jacobi Symbol Computation") was marked `verified` / `badge: mathlib` / `axiomCount: 0`, claiming axiom-freeness. But its headline deliverables are discharged by `native_decide`, which depends on `Lean.ofReduceBool`.

## Evidence

The entry's `originalContributions` list "Certified computation chain for J(7,13)" and "Certified computation chain for J(1001, 9907)" as deliverables. These named theorems close via `native_decide`:

- `certified_J_7_13` (line 94)
- `certified_J_1001_9907` (line 103)
- `certified_J_219_383` (line 113)
- `step_J3_383`, `step_J73_383` (lines 117–118)

`native_decide` trusts the compiler's kernel reduction, so `#print axioms` on these results lists `Lean.ofReduceBool` — the entry is **not** axiom-free. Per the Axiom Integrity Policy, a substantive verified-presented result discharged by `native_decide` must count: `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`.

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `assumptions: "None."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`. (`leanFile.axiomCount` stays 0 — no literal `axiom` declarations.)

Addresses #25409.

---
Automated fix by lean-mechanic agent.