### PR TITLE
audit(denumerability-rationals-oq-03): clean re-audit, Stern-Brocot verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2312,9 +2312,9 @@
       "result": "clean"
     },
     "denumerability-rationals-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:07:43Z",
+      "lastAudited": "2026-06-18T10:29:39Z",
       "result": "clean"
     },
     "denumerability-rationals-oq-04": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Re-audited **denumerability-rationals-oq-03** (Stern-Brocot Tree Encoding of Rationals). auditCount 3→4. No integrity issues found.

### Verified against `proofs/Proofs/DenumerabilityRationalsOQ03.lean`
Registered at `Proofs.lean:609` (CI-compiled).

| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 600 | 600 | ✓ |
| theoremCount | 31 | 31 (30 plain + 1 `@[simp] det_init`) | ✓ |
| definitionCount | 12 | 12 (9 `def` + `Path` abbrev + `State` structure + `Dir` inductive) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms | ✓ |

### Integrity checks
- **No assumption-carrying structures**: `State` is pure data (4 ℕ fields, `deriving DecidableEq, Repr`), no Prop fields → `axiomCount: 0` is honest.
- **No `native_decide`**, no `True` stubs, no plain `decide` in named theorems.
- **status `verified` / badge `mathlib` — honest, conservative.** The core results are genuine original work: `coprime_of_det_one` is a from-scratch Bézout argument (`gcd | ra·(lb+rb) − rb·(la+ra) = det = 1`), `eval_injective` is a non-vacuous BST-ordering induction over paths. Only foundational Mathlib infrastructure is used (`Nat.gcd`, `Int.natCast_dvd_natCast`, `Int.le_of_dvd`); no deep Mathlib theorem performs the core work. The `mathlib` badge slightly underclaims (this is effectively Tier A) — conservative, not an overclaim.
- **No surjectivity overclaim**: description explicitly states "surjectivity is future work; injectivity and coprimality proved here", and `openQuestions` lists the full bijection. Honest scoping.

### Result
`clean` — no changes to meta.json required. Tracker bump only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)