### PR TITLE
audit(erdos-1118): clean re-audit, honest axiomatization of Camera-Gol'dberg

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3942,9 +3942,9 @@
       "result": "clean"
     },
     "erdos-1118": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:07:44Z",
+      "lastAudited": "2026-06-18T10:40:00Z",
       "result": "clean"
     },
     "erdos-1118-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Re-audited **erdos-1118** (Erdős #1118: Entire Functions with Finite Measure Superlevel Sets). auditCount 3→4. No integrity issues.

### Verified against `proofs/Proofs/Erdos1118Problem.lean` (`Proofs.lean:960`)

| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 234 | 234 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 13 | 13 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 literal axioms (no structures) | ✓ |

### Integrity checks
- **No native_decide, no `True` stubs, no assumption-carrying structures** → `axiomCount: 3` captures all assumptions.
- **status `axiomatized` / badge `axiom` — honest.** The 3 axioms are real published results not in Mathlib:
  - `camera_goldberg_theorem` (Hayman's conjecture, Camera 1977 / Gol'dberg 1979)
  - `goldberg_counterexample` (threshold set need not extend to 0)
  - `goldberg_threshold_classification` (all threshold shapes realizable)

  All three are disclosed in the `assumptions` field and explicitly labeled as axioms in `originalContributions`.
- **No axiom masking (failure mode #2):** description says "SOLVED: Camera-Gol'dberg 1977-79" (credits the literature, not the formalization); conclusion states the work "proves the measure-theoretic core constructively while axiomatizing the deep analytic results."
- **Genuine in-file derivations:** `superlevel_nested`, `finite_measure_monotone`, `threshold_is_upper_set`, and `erdos_1118_question2_negative` (a real `linarith` proof exhibiting a threshold-set gap from `goldberg_counterexample`). The headline `erdos_1118` / `erdos_1118_summary` are honest assemblies of the disclosed axioms.

### Result
`clean` — no changes to meta.json required. Tracker bump only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)