### PR TITLE
Fix: divisibility-rules-oq-01 uses native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "divisibility-rules-oq-01",
   "title": "Divisibility Rules OQ-01: Extensions with Truncation, Grouping, and Casting Out Nines",
   "slug": "divisibility-rules-oq-01",
-  "description": "A self-contained extension of the divisibility rules gallery adding: the divisibility-by-11 alternating digit sum rule (fully proved), the divisibility-by-13 truncation method (add 4 times the last digit), multi-digit grouping rules for 37, 27, 99, 101, and 999 (sum of consecutive k-digit blocks), a general last-k-digit framework unifying all power-of-2 and power-of-5 rules, divisibility by 16 and 32 via last 4 and 5 decimal digits, casting out nines for both addition and multiplication, and an error-detection theorem. All results are fully machine-verified.",
+  "description": "A self-contained extension of the divisibility rules gallery adding: the divisibility-by-11 alternating digit sum rule (fully proved), the divisibility-by-13 truncation method (add 4 times the last digit), multi-digit grouping rules for 37, 27, 99, 101, and 999 (sum of consecutive k-digit blocks), a general last-k-digit framework unifying all power-of-2 and power-of-5 rules, divisibility by 16 and 32 via last 4 and 5 decimal digits, casting out nines for both addition and multiplication, and an error-detection theorem. All results are machine-checked; the rules discharge their base-side conditions via native_decide, so the proof depends on Lean.ofReduceBool.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityRulesOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "elementary-number-theory",
       "extensions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "Depends on Lean.ofReduceBool: the headline divisibility rules (three_dvd_iff, nine_dvd_iff, thirtyseven_dvd_iff, twentyseven_dvd_iff, nineninenine_dvd_iff, ninetynine_dvd_iff, onehundredone_dvd_iff, the cross-base hex/octal rules, etc.) and the oq01_rules_verification summary discharge their base-coprimality/modulus side conditions via `by native_decide`, which trusts the compiler's kernel reduction (#print axioms lists Lean.ofReduceBool). No literal axiom declarations and no structure-encoded assumptions (leanFile.axiomCount remains 0).",
     "lineCount": 412,
     "theoremCount": 42,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

`divisibility-rules-oq-01` was classed `verified` / `original` / `axiomCount: 0`, but its headline divisibility-rule theorems depend on `Lean.ofReduceBool`. Re-classed as `axiomatized` / `axiom` / `axiomCount: 1` per CLAUDE.md:140.

## Evidence

The deliverable `*_dvd_iff` rules discharge their base-side conditions via `by native_decide`, e.g.:

```lean
theorem three_dvd_iff (n : ℕ) : 3 ∣ n ↔ 3 ∣ (Nat.digits 10 n).sum :=
  dvd_iff_dvd_digits_sum 3 10 (by native_decide) n
```

This pattern is used in the named, load-bearing theorems `three_dvd_iff`, `nine_dvd_iff`, `thirtyseven_dvd_iff`, `twentyseven_dvd_iff`, `nineninenine_dvd_iff`, `ninetynine_dvd_iff`, `onehundredone_dvd_iff`, the cross-base hex/octal rules, and the `oq01_rules_verification` summary (`<;> native_decide`). `native_decide` trusts the compiler's kernel reduction, so `#print axioms` lists `Lean.ofReduceBool` — the proof is not axiom-free. These theorems are exactly the entry's `originalContributions`, so the dependency is load-bearing, not incidental.

Same class as the auditor-confirmed sibling flips: `divisibility-by-3-oq-01` (#25577), `divisibility-by-3-oq-04` (#25572), and `divisibility-rules` (#25607).

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, `assumptions: "None. Fully machine-verified."`
**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations, no structure-encoded assumptions).

Part of #25409.

---
Automated fix by lean-mechanic agent.