### PR TITLE
Enrich Hurwitz Theorem (octonions/G₂ OQ-04): realign drifted annotations + document dim-14 proof

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/annotations.json
@@ -52,7 +52,7 @@
     "id": "ann-hurwitz-oq04-algHom",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 114,
+      "startLine": 127,
       "endLine": 165
     },
     "type": "definition",
@@ -76,7 +76,7 @@
     "id": "ann-hurwitz-oq04-helper-lemmas",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 166,
+      "startLine": 172,
       "endLine": 200
     },
     "type": "concept",
@@ -199,13 +199,13 @@
     "id": "ann-hurwitz-oq04-exceptional-type",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 359,
+      "startLine": 395,
       "endLine": 421
     },
-    "type": "definition",
+    "type": "inductive",
     "title": "ExceptionalType: Formalizing the Five Exceptional Lie Algebras",
-    "content": "The ExceptionalType inductive type enumerates all five exceptional compact simple Lie algebras as constructors: G2, F4, E6, E7, E8. Two computable functions assign their invariants: dim (dimensions 14, 52, 78, 133, 248) and rank (2, 4, 6, 7, 8). These match the Cartan classification exactly. The axiom G2_is_octonion_aut then asserts the mathematical content: the dimension of G₂ equals the cardinality of OctonionAut as a set (which is the definition of dim(G₂) in the context where G₂ = Aut(𝕆)). This axiom is necessarily deep — formalizing it would require Lie group theory (compact simple groups, root systems, exponential map) that was not in Mathlib as of 2026-04.",
-    "mathContext": "The five exceptional Dynkin types: $G_2$ (rank 2, dim 14), $F_4$ (rank 4, dim 52), $E_6$ (rank 6, dim 78), $E_7$ (rank 7, dim 133), $E_8$ (rank 8, dim 248). Axiom: $\\dim(G_2) = |\\mathrm{Aut}(\\mathbb{O})|$, i.e., $14 = \\mathrm{card}(\\mathrm{OctonionAut})$. The dimension 14 = dim(SO(7)) − 7 = 21 − 7: the cross-product constraint cuts codimension 7 from SO(7).",
+    "content": "The `ExceptionalType` inductive enumerates the five exceptional compact simple Lie algebras as constructors G2, F4, E6, E7, E8. Two computable functions assign their Cartan invariants: `ExceptionalType.dim` (14, 52, 78, 133, 248) and `ExceptionalType.rank` (2, 4, 6, 7, 8), matching the classification exactly. The surrounding docstring records *why* G₂ has dimension 14: any octonion automorphism fixes the unit e₀ and preserves the norm, so Aut(𝕆) ⊆ SO(7) (which has dimension 21); preserving the octonion cross product on Im(𝕆) ≅ ℝ⁷ imposes 7 further constraints, cutting the dimension to 21 − 7 = 14. The identifications G₂ ≅ Aut(𝕆) (E. Cartan, 1914) and 𝔤₂ ≅ Der(𝕆) are the deeper geometric content — these are *not* asserted as Lean axioms in this file (there are no axioms here); instead the concrete dimension fact is **proved** as `G2_der_dimension` (PART IV-c.3) via an explicit basis of 14 derivations.",
+    "mathContext": "$\\mathrm{ExceptionalType} = \\{G_2, F_4, E_6, E_7, E_8\\}$ with $\\dim = (14, 52, 78, 133, 248)$ and $\\mathrm{rank} = (2, 4, 6, 7, 8)$. Heuristic for $G_2$: $\\dim G_2 = \\dim SO(7) - 7 = 21 - 7 = 14$.",
     "significance": "key",
     "relatedConcepts": [
       "Dynkin diagram",
@@ -220,91 +220,16 @@
     ]
   },
   {
-    "id": "ann-hurwitz-oq04-magic-square",
-    "proofId": "hurwitz-theorem-oq-04",
-    "range": {
-      "startLine": 422,
-      "endLine": 472
-    },
-    "type": "concept",
-    "title": "The Freudenthal-Tits Magic Square Axioms",
-    "content": "Four axioms axiomatize the Freudenthal-Tits magic square construction. Each asserts that a specific entry of the magic square has the correct dimension: freudenthal_tits_f4 (F₄: dim 52), freudenthal_tits_e6 (E₆: dim 78), freudenthal_tits_e7 (E₇: dim 133), freudenthal_tits_e8 (E₈: dim 248). The docstrings for each axiom contain remarkable additional mathematical content: F₄ is Aut(𝔥₃(𝕆)) the exceptional Jordan algebra automorphism group; E₆ appears in heterotic string theory with 5-graded decomposition 1+16+45+16+1=78; E₇ has a 56-dim fundamental representation; E₈ was used by Viazovska to solve sphere packing in ℝ⁸. Note that freudenthal_tits_f4 asserts 52=52, which is a definitional truth — the axiom really captures the magic square identification, not just the dimension formula.",
-    "mathContext": "Magic square entries (pairing with $\\mathbb{O}$): $\\mathfrak{L}(\\mathbb{O},\\mathbb{R}) = F_4$ (dim 52), $\\mathfrak{L}(\\mathbb{O},\\mathbb{C}) = E_6$ (dim 78), $\\mathfrak{L}(\\mathbb{O},\\mathbb{H}) = E_7$ (dim 133), $\\mathfrak{L}(\\mathbb{O},\\mathbb{O}) = E_8$ (dim 248). Dimension formula: $\\dim \\mathfrak{L}(A,B) = \\dim \\mathfrak{der}(A) + \\dim(\\mathrm{Im}A) \\cdot \\dim(\\mathrm{Im}B) + \\dim \\mathfrak{der}(B) + \\text{correction}$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "magic square",
-      "exceptional Jordan algebra",
-      "E8 lattice",
-      "sphere packing",
-      "string theory"
-    ],
-    "prerequisites": [
-      "Freudenthal construction",
-      "Tits construction",
-      "derivation algebra",
-      "exceptional Jordan algebra"
-    ]
-  },
-  {
-    "id": "ann-hurwitz-oq04-structural",
-    "proofId": "hurwitz-theorem-oq-04",
-    "range": {
-      "startLine": 474,
-      "endLine": 521
-    },
-    "type": "concept",
-    "title": "Structural Consequences: Ordering and Uniqueness Properties",
-    "content": "Five theorems establish structural properties of the exceptional types, all proved by decidability (Lean's `decide` tactic). exceptional_dims_strict_mono proves the dimensions are strictly increasing: 14 < 52 < 78 < 133 < 248. G2_unique_low_rank proves G₂ is the only exceptional type of rank < 4 — reflecting that G₂ is the only exceptional algebra appearing without the octonion cross-pairing in the magic square (it is Der(𝕆) itself). E8_is_largest proves E₈ has the maximum dimension. magic_square_corners_distinct proves all magic-square corner dimensions are pairwise distinct. exceptional_chain shows ranks are also strictly increasing. These proofs by `decide` work because ExceptionalType has decidable equality and all functions are computable.",
-    "mathContext": "Proved facts: $14 < 52 < 78 < 133 < 248$ (strict monotonicity of dimensions), $2 < 4 < 6 < 7 < 8$ (strict monotonicity of ranks), $\\forall e, e.\\mathrm{rank} < 4 \\Rightarrow e = G_2$ (uniqueness of $G_2$ among low-rank exceptional types), $\\forall e, e.\\mathrm{dim} \\leq 248$ (maximality of $E_8$). All proved by Lean's `decide` tactic since all types and functions are computable.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "decidable equality",
-      "rank of Lie algebra",
-      "Dynkin diagram ordering"
-    ],
-    "prerequisites": [
-      "ExceptionalType definition",
-      "decidability",
-      "Lean decide tactic"
-    ]
-  },
-  {
-    "id": "ann-hurwitz-oq04-correspondence",
-    "proofId": "hurwitz-theorem-oq-04",
-    "range": {
-      "startLine": 523,
-      "endLine": 582
-    },
-    "type": "insight",
-    "title": "The Hurwitz-Exceptional Correspondence: Why Exactly Five",
-    "content": "The closing section synthesizes the entire formalization into a single conceptual statement: the four normed division algebras (Hurwitz's theorem) explain why there are exactly five exceptional Lie algebras (Cartan's classification). G₂ = Der(𝕆) pairs 𝕆 with itself (derivations), while F₄, E₆, E₇, E₈ pair 𝕆 with ℝ, ℂ, ℍ, 𝕆 respectively — giving 4+1=5 exceptional types. If Hurwitz's theorem had admitted a 16-dimensional algebra (sedenions fail to be a division algebra), a 6th exceptional type would exist. The physical applications section connects to heterotic string theory (E₈×E₈, dim=496=2×248), M-theory on G₂ manifolds, and N=8 supergravity (E₇(7) symmetry) — showing that fundamental physics is constrained by the same algebraic necessity as Hurwitz's 1898 theorem.",
-    "mathContext": "Five exceptional types from four algebras: $G_2 = \\mathfrak{der}(\\mathbb{O})$, $F_4 = \\mathfrak{L}(\\mathbb{O},\\mathbb{R})$, $E_6 = \\mathfrak{L}(\\mathbb{O},\\mathbb{C})$, $E_7 = \\mathfrak{L}(\\mathbb{O},\\mathbb{H})$, $E_8 = \\mathfrak{L}(\\mathbb{O},\\mathbb{O})$. Note: $\\mathbb{O}$ appears in ALL five. If a 16-dim normed division algebra existed, $\\mathfrak{L}(\\mathbb{O},\\mathbb{S})$ would give a 6th exceptional type. Physical: $E_8 \\times E_8$ heterotic string has $\\dim = 2 \\times 248 = 496$ (anomaly cancellation requires $\\dim G = 496$).",
-    "significance": "key",
-    "relatedConcepts": [
-      "heterotic string theory",
-      "Green-Schwarz anomaly cancellation",
-      "M-theory",
-      "G2 holonomy manifolds",
-      "N=8 supergravity"
-    ],
-    "prerequisites": [
-      "Hurwitz theorem",
-      "magic square",
-      "string theory basics",
-      "supergravity"
-    ]
-  },
-  {
     "id": "ann-hurwitz-oq04-der-submodule",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 558,
-      "endLine": 644
+      "startLine": 579,
+      "endLine": 586
     },
     "type": "definition",
     "title": "OctonionDerSubmodule: Der(𝕆) as Vector Subspace + G₂ Dimension Axiom",
-    "content": "OctonionDerSubmodule defines Der(𝕆) as a Submodule of End_ℝ(ℝ⁸) — the ℝ-linear maps satisfying the Leibniz rule D(ab) = D(a)·b + a·D(b) for octonion multiplication. This representation gives Der(𝕆) an inherited finite-dimensional vector space structure, enabling FiniteDimensional.finrank to measure its dimension. The axiom G2_der_dimension asserts finrank ℝ OctonionDerSubmodule = 14. Four structural lemmas follow: der_maps_unit_to_zero (D(e₀) = 0 by Leibniz applied to e₀·e₀ = e₀, giving D(e₀) = 2D(e₀) hence D(e₀) = 0), der_maps_real_part_to_zero (r·D(e₀) = 0), toLinearMap (lifts OctonionDer to End_ℝ(ℝ⁸)), and toSubmoduleMem (bridges OctonionDer structures to OctonionDerSubmodule members). This bridges the 'structure' definition of OctonionDer with the 'submodule' definition for dimension counting.",
-    "mathContext": "$\\text{Der}(\\mathbb{O}) = \\{D \\in \\text{End}_{\\mathbb{R}}(\\mathbb{R}^8) : D(ab) = D(a)b + aD(b)\\}$. Leibniz gives $D(e_0) = 0$. The axiom $\\text{finrank}_{\\mathbb{R}}(\\text{Der}(\\mathbb{O})) = 14$ identifies $\\mathfrak{der}(\\mathbb{O}) \\cong \\mathfrak{g}_2$. A constructive proof would exhibit 14 basis derivations $D_{ij}$ for $1 \\leq i < j \\leq 7$ (imaginary octonion pairs) satisfying $D_{ij}(e_k) = \\delta_{jk}e_i - \\delta_{ik}e_j$ (cross-product derivations on $\\text{Im}(\\mathbb{O}) \\cong \\mathbb{R}^7$), then prove their linear independence.",
+    "content": "`OctonionDerSubmodule` realises Der(𝕆) as a `Submodule ℝ` of `End_ℝ(ℝ⁸)` — the ℝ-linear maps D satisfying the Leibniz rule D(a·b) = D(a)·b + a·D(b) for octonion multiplication. Packaging the derivations as a submodule equips Der(𝕆) with an inherited finite-dimensional vector-space structure, so `FiniteDimensional.finrank` can measure its dimension. Crucially, `G2_der_dimension` is a **fully proved theorem** (not an axiom): `finrank ℝ OctonionDerSubmodule = 14`, established in PART IV-c.3 by exhibiting 14 explicit Baez derivations that are linearly independent (lower bound) together with an injective 14-coordinate evaluation map (upper bound). This makes the dimension count Der(𝕆) ≅ 𝔤₂ machine-checked rather than assumed.",
+    "mathContext": "$\\mathrm{Der}(\\mathbb{O}) = \\{\\, D \\in \\mathrm{End}_\\mathbb{R}(\\mathbb{R}^8) : D(ab) = D(a)\\,b + a\\,D(b) \\,\\}$, an ℝ-submodule. **Proved**: $\\operatorname{finrank}_\\mathbb{R} \\mathrm{Der}(\\mathbb{O}) = 14 = \\dim \\mathfrak{g}_2$.",
     "significance": "key",
     "relatedConcepts": [
       "Lie algebra",
@@ -321,11 +246,83 @@
     ]
   },
   {
+    "id": "ann-hurwitz-oq04-baez-derivations",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 603,
+      "endLine": 718
+    },
+    "type": "technique",
+    "title": "PART IV-c.2: 14 explicit Baez derivations as a basis for Der(𝕆)",
+    "content": "The 14 generators `d12, d13, …, d47` are the explicit derivations of the octonions from Baez's *The Octonions* (§4.1), each given as a concrete 8×8 matrix acting on ℝ⁸. They arise from the formula D_{ij}(x) = [[eᵢ, eⱼ], x] − 3·assoc(eᵢ, eⱼ, x) for imaginary basis pairs (eᵢ, eⱼ); of the 21 such maps the 14 index pairs (1,2),…,(4,7) form a basis. Each `dᵢⱼ` is built as a bundled `LinearMap` whose `map_add'` / `map_smul'` obligations are discharged uniformly by `funext; fin_cases; simp; ring`. The membership lemmas `d12_mem … d47_mem` certify (via the `simp_der_mem` macro) that every generator satisfies the Leibniz rule — i.e. lies in `OctonionDerSubmodule` — and `derBasis14 : Fin 14 → OctonionDerSubmodule` assembles them into the candidate basis whose linear independence pins the dimension at 14.",
+    "mathContext": "$D_{ij}(x) = [[e_i, e_j], x] - 3\\,\\mathrm{assoc}(e_i, e_j, x)$ with $[a,b] = ab - ba$ and $\\mathrm{assoc}(a,b,c) = (ab)c - a(bc)$. Basis index pairs: $(1,2),(1,3),\\dots,(4,7)$ — 14 of the 21 imaginary pairs, spanning $\\mathrm{Der}(\\mathbb{O}) \\cong \\mathfrak{g}_2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "octonion derivations",
+      "Baez construction",
+      "Leibniz rule",
+      "bundled LinearMap",
+      "g2 Lie algebra basis"
+    ],
+    "prerequisites": [
+      "octonion multiplication",
+      "commutator and associator",
+      "LinearMap in Lean"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq04-dim14-proof",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 1024,
+      "endLine": 1416
+    },
+    "type": "insight",
+    "title": "PART IV-c.3: Der(𝕆) has dimension 14 — the machine-checked G₂ dimension",
+    "content": "The technical heart of the file (~700 lines): an axiom-free proof that `finrank ℝ OctonionDerSubmodule = 14`, by `le_antisymm`. **Upper bound (≤ 14):** `derEval14_injective` shows the evaluation map extracting 14 free coordinates from a derivation is injective — a derivation is pinned down by anticommutativity and by killing the real part (lemmas `submodule_der_unit_zero`, `submodule_der_diagonal_kill`, `submodule_der_antisymm`, `submodule_der_real_part`), so `LinearMap.finrank_le_finrank_of_injective` bounds the rank by dim(ℝ¹⁴) = 14. **Lower bound (≥ 14):** `derBasis14_linearIndependent` proves the 14 Baez derivations are linearly independent — applying `derEval14` to a vanishing combination produces 14 two-term equations (7 block pairs, each a 2×2 system of determinant 12), all forced to zero by `nlinarith`; then `LinearIndependent.fintype_card_le_finrank` gives 14 ≤ rank. Together these realise the abstract identity dim 𝔤₂ = dim Der(𝕆) = 14 as a concrete, fully verified computation.",
+    "mathContext": "$\\operatorname{finrank}_\\mathbb{R}\\mathrm{Der}(\\mathbb{O}) = 14$ by antisymmetry: an injective $\\mathrm{Der}(\\mathbb{O}) \\hookrightarrow \\mathbb{R}^{14}$ gives $\\le 14$, and 14 linearly independent derivations give $\\ge 14$. Each independence block is a $2\\times2$ system with $\\det = 12 \\neq 0$, so every coefficient vanishes.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finrank",
+      "le_antisymm dimension argument",
+      "linear independence",
+      "injective linear map",
+      "Der(𝕆) ≅ g2"
+    ],
+    "prerequisites": [
+      "finite-dimensional rank",
+      "LinearIndependent.fintype_card_le_finrank",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq04-der-structural",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 1436,
+      "endLine": 1463
+    },
+    "type": "technique",
+    "title": "PART IV-d: structural properties of octonion derivations",
+    "content": "Four corollaries record the defining structural features of derivations once the dimension is fixed. `der_maps_unit_to_zero` (D(e₀) = 0) and `der_maps_real_part_to_zero` (D(r·e₀) = 0) express that every derivation annihilates the real axis — a derivation has no effect on scalars, consistent with D being a Lie-algebra (tangent) object rather than an automorphism. `OctonionDer.toLinearMap`, `OctonionDer.mem_der_submodule`, and `OctonionDer.toSubmoduleMem` provide the bridge between the bespoke `OctonionDer` structure (convenient for the algebraic lemmas) and the `OctonionDerSubmodule` submodule (needed for the finrank computation), confirming the two presentations of Der(𝕆) agree.",
+    "mathContext": "$D(e_0) = 0$ and $D(r\\,e_0) = 0$ for every $D \\in \\mathrm{Der}(\\mathbb{O})$ — derivations vanish on $\\mathbb{R}\\cdot e_0$. Bridge of presentations: `OctonionDer` $\\leftrightarrow$ `OctonionDerSubmodule`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "derivation kills scalars",
+      "Lie algebra vs automorphism",
+      "structure-submodule bridge"
+    ],
+    "prerequisites": [
+      "consequences of the Leibniz rule",
+      "Lean structure coercions"
+    ]
+  },
+  {
     "id": "ann-hurwitz-oq04-tits-axioms",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 645,
-      "endLine": 749
+      "startLine": 1470,
+      "endLine": 1490
     },
     "type": "insight",
     "title": "Freudenthal-Tits Magic Square Axioms: F₄=52, E₆=78, E₇=133, E₈=248",
@@ -347,11 +344,86 @@
     ]
   },
   {
+    "id": "ann-hurwitz-oq04-magic-square",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 1496,
+      "endLine": 1517
+    },
+    "type": "concept",
+    "title": "The Freudenthal-Tits Magic Square Axioms",
+    "content": "PART V records the four magic-square corner dimensions as theorems, each proved definitionally by `rfl`: `freudenthal_tits_f4` (F₄ = 52), `freudenthal_tits_e6` (E₆ = 78), `freudenthal_tits_e7` (E₇ = 133), `freudenthal_tits_e8` (E₈ = 248). These are *not* axioms — they hold by `rfl` because each `ExceptionalType.dim` value is defined to be the stated number, so the file only does dimension bookkeeping here. The mathematically deep claim each docstring records — that the Tits construction gives 𝔏(𝕆,ℝ) = F₄, 𝔏(𝕆,ℂ) = E₆, 𝔏(𝕆,ℍ) = E₇, 𝔏(𝕆,𝕆) = E₈ as Lie algebras — requires Lie-group theory not yet in Mathlib. (E₈ is the lattice behind Viazovska's 2016 Fields-Medal solution of 8-dimensional sphere packing.)",
+    "mathContext": "$\\dim F_4 = 52,\\ \\dim E_6 = 78,\\ \\dim E_7 = 133,\\ \\dim E_8 = 248$ — each a `rfl` theorem from `ExceptionalType.dim`. Tits formula: $\\mathfrak{L}(A,B) = \\mathfrak{der}(A) \\oplus (\\mathrm{Im}\\,A \\otimes \\mathrm{Im}\\,B) \\oplus \\mathfrak{der}(B)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "magic square",
+      "exceptional Jordan algebra",
+      "E8 lattice",
+      "sphere packing",
+      "string theory"
+    ],
+    "prerequisites": [
+      "Freudenthal construction",
+      "Tits construction",
+      "derivation algebra",
+      "exceptional Jordan algebra"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq04-structural",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 1524,
+      "endLine": 1565
+    },
+    "type": "concept",
+    "title": "Structural Consequences: Ordering and Uniqueness Properties",
+    "content": "Five theorems establish structural properties of the exceptional types, all proved by decidability (Lean's `decide` tactic). exceptional_dims_strict_mono proves the dimensions are strictly increasing: 14 < 52 < 78 < 133 < 248. G2_unique_low_rank proves G₂ is the only exceptional type of rank < 4 — reflecting that G₂ is the only exceptional algebra appearing without the octonion cross-pairing in the magic square (it is Der(𝕆) itself). E8_is_largest proves E₈ has the maximum dimension. magic_square_corners_distinct proves all magic-square corner dimensions are pairwise distinct. exceptional_chain shows ranks are also strictly increasing. These proofs by `decide` work because ExceptionalType has decidable equality and all functions are computable.",
+    "mathContext": "Proved facts: $14 < 52 < 78 < 133 < 248$ (strict monotonicity of dimensions), $2 < 4 < 6 < 7 < 8$ (strict monotonicity of ranks), $\\forall e, e.\\mathrm{rank} < 4 \\Rightarrow e = G_2$ (uniqueness of $G_2$ among low-rank exceptional types), $\\forall e, e.\\mathrm{dim} \\leq 248$ (maximality of $E_8$). All proved by Lean's `decide` tactic since all types and functions are computable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decidable equality",
+      "rank of Lie algebra",
+      "Dynkin diagram ordering"
+    ],
+    "prerequisites": [
+      "ExceptionalType definition",
+      "decidability",
+      "Lean decide tactic"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq04-correspondence",
+    "proofId": "hurwitz-theorem-oq-04",
+    "range": {
+      "startLine": 1571,
+      "endLine": 1588
+    },
+    "type": "insight",
+    "title": "The Hurwitz-Exceptional Correspondence: Why Exactly Five",
+    "content": "The closing section synthesizes the entire formalization into a single conceptual statement: the four normed division algebras (Hurwitz's theorem) explain why there are exactly five exceptional Lie algebras (Cartan's classification). G₂ = Der(𝕆) pairs 𝕆 with itself (derivations), while F₄, E₆, E₇, E₈ pair 𝕆 with ℝ, ℂ, ℍ, 𝕆 respectively — giving 4+1=5 exceptional types. If Hurwitz's theorem had admitted a 16-dimensional algebra (sedenions fail to be a division algebra), a 6th exceptional type would exist. The physical applications section connects to heterotic string theory (E₈×E₈, dim=496=2×248), M-theory on G₂ manifolds, and N=8 supergravity (E₇(7) symmetry) — showing that fundamental physics is constrained by the same algebraic necessity as Hurwitz's 1898 theorem.",
+    "mathContext": "Five exceptional types from four algebras: $G_2 = \\mathfrak{der}(\\mathbb{O})$, $F_4 = \\mathfrak{L}(\\mathbb{O},\\mathbb{R})$, $E_6 = \\mathfrak{L}(\\mathbb{O},\\mathbb{C})$, $E_7 = \\mathfrak{L}(\\mathbb{O},\\mathbb{H})$, $E_8 = \\mathfrak{L}(\\mathbb{O},\\mathbb{O})$. Note: $\\mathbb{O}$ appears in ALL five. If a 16-dim normed division algebra existed, $\\mathfrak{L}(\\mathbb{O},\\mathbb{S})$ would give a 6th exceptional type. Physical: $E_8 \\times E_8$ heterotic string has $\\dim = 2 \\times 248 = 496$ (anomaly cancellation requires $\\dim G = 496$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "heterotic string theory",
+      "Green-Schwarz anomaly cancellation",
+      "M-theory",
+      "G2 holonomy manifolds",
+      "N=8 supergravity"
+    ],
+    "prerequisites": [
+      "Hurwitz theorem",
+      "magic square",
+      "string theory basics",
+      "supergravity"
+    ]
+  },
+  {
     "id": "ann-hurwitz-oq04-physics-summary",
     "proofId": "hurwitz-theorem-oq-04",
     "range": {
-      "startLine": 750,
-      "endLine": 822
+      "startLine": 1589,
+      "endLine": 1612
     },
     "type": "concept",
     "title": "Hurwitz-Exceptional Correspondence: Why 4 Algebras Give 5 Exceptional Types",


### PR DESCRIPTION
## Enrichment pass — `hurwitz-theorem-oq-04`

### Problem
The ~700-line `finrank Der(𝕆) = 14` proof inserted at PART IV-c froze the existing annotation ranges. Result:
- **5 annotations misaligned** (build-validation failures).
- The proof core (PARTS IV-c.2 → VII) was mis-anchored or completely uncovered.
- Several annotations still called `G2_der_dimension` and the magic-square dimensions **axioms** — they are now **fully proved theorems**. The file has **0 axioms, 0 sorries**, so `status: verified` is correct (the `sorry` strings in the source are stale docstring notes, not real sorries — confirmed).

### Realigned 7 drifted annotations to the sections they describe
| Annotation | Was | Now |
|---|---|---|
| ExceptionalType | theorem @359 (type `definition`) | inductive @395 (type `inductive`); removed phantom `axiom G2_is_octonion_aut` wording |
| magic-square dims | @422 (no construct), "axioms" | PART V theorems @1496, "`rfl` theorems" |
| Tits construction | @645 | PART V @1470 |
| structural consequences | @474 | PART VI @1524 |
| Hurwitz correspondence | @523 | PART VII @1571 |
| physics summary | @750 | PART VII @1589 |
| OctonionDerSubmodule | @558 (no construct), "axiom" | def @579, "proved theorem" |
| algHom / helper lemmas | @114 / @166 | structure @127 / @172 |

### Added 3 annotations for the previously-undocumented core
- **PART IV-c.2** — the 14 explicit Baez derivations (`d12 … d47`) as a basis for Der(𝕆)
- **PART IV-c.3** — the machine-checked `finrank Der(𝕆) = 14` proof (`le_antisymm`: injective eval map for ≤, 14 linearly independent derivations for ≥)
- **PART IV-d** — structural properties of derivations

### Verification
- `resolver.ts validate`: **18 valid, 0 misaligned** (was 13 valid, 5 misaligned)
- `pnpm build`: ✓
- Commit scoped to the single `annotations.json`.

### Axiom integrity
Corrected stale "axiom" prose in 3 annotations to reflect that the file is genuinely axiom-free; `status: verified / badge: original / axiomCount: 0` in meta.json remains accurate (no flip needed).