### PR TITLE
Enrich Pascal's Hexagon (Wiedijk #28): realign 11 misaligned annotation ranges

### DIFF
--- a/src/data/proofs/pascals-hexagon/annotations.json
+++ b/src/data/proofs/pascals-hexagon/annotations.json
@@ -216,7 +216,7 @@
     "id": "ann-history",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 313,
+      "startLine": 314,
       "endLine": 321
     },
     "type": "concept",
@@ -240,7 +240,7 @@
     "id": "ann-triple-product",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 374,
+      "startLine": 378,
       "endLine": 403
     },
     "type": "lemma",
@@ -266,7 +266,7 @@
     "id": "ann-projective-invariance",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 405,
+      "startLine": 409,
       "endLine": 513
     },
     "type": "concept",
@@ -292,7 +292,7 @@
     "id": "ann-parametric-coverage",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 515,
+      "startLine": 519,
       "endLine": 562
     },
     "type": "lemma",
@@ -318,7 +318,7 @@
     "id": "ann-bilinearity-infinity",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 592,
+      "startLine": 596,
       "endLine": 683
     },
     "type": "lemma",
@@ -344,7 +344,7 @@
     "id": "ann-scale-invariance",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 685,
+      "startLine": 689,
       "endLine": 727
     },
     "type": "lemma",
@@ -368,7 +368,7 @@
     "id": "ann-assembly-finite",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 755,
+      "startLine": 759,
       "endLine": 806
     },
     "type": "lemma",
@@ -393,7 +393,7 @@
     "id": "ann-coincident-vertices",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 808,
+      "startLine": 812,
       "endLine": 947
     },
     "type": "lemma",
@@ -419,7 +419,7 @@
     "id": "ann-pascal-stdconic",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 949,
+      "startLine": 956,
       "endLine": 1072
     },
     "type": "theorem",
@@ -445,7 +445,7 @@
     "id": "ann-axiom-roadmap",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 1074,
+      "startLine": 1078,
       "endLine": 1103
     },
     "type": "concept",
@@ -471,7 +471,7 @@
     "id": "ann-sylvester-bridge",
     "proofId": "pascals-hexagon",
     "range": {
-      "startLine": 1105,
+      "startLine": 1109,
       "endLine": 1281
     },
     "type": "lemma",


### PR DESCRIPTION
## Enrichment pass — `pascals-hexagon`

### Problem
All 20 annotations existed with correct content, but **11 had startLines landing on `-- ===` section separators** instead of Lean constructs — failing build validation (`validateLineAnnotations`: 9 valid, 11 misaligned).

### Fix
Repointed each misaligned annotation's startLine to its PART's `/-!` section-doc block (which validates type-agnostically). Affected: history/hexagrammum (PART 11), scalar triple product (11b), projective invariance (12), parametric coverage (13), bilinearity (14), point-at-infinity/scale invariance (15–16), assembly (17), coincident-vertex lemmas (18), all-cases theorem (19), axiom roadmap (20), Sylvester/QuadraticForm bridge (20a). Content unchanged.

### Verification
- `resolver.ts validate`: **20 valid, 0 misaligned** (was 9 valid, 11 misaligned)
- `pnpm build`: ✓
- Commit scoped to the single `annotations.json`.