### PR TITLE
Fix: perfect-numbers native_decide → axiomatized

### DIFF
--- a/src/data/proofs/perfect-numbers/meta.json
+++ b/src/data/proofs/perfect-numbers/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (300 BCE), Euler (1747)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number",
     "date": "300 BCE / 1747",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "perfect-numbers",
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/PerfectNumbers.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,9 +50,9 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 70,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 202,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on `Lean.ofReduceBool`: the concrete example theorems (`six_is_perfect`, `twentyeight_is_perfect`, `fourhundredninetysix_is_perfect`, `eightthousandonetwentyeight_is_perfect`) establish Mersenne primality via `native_decide`, which trusts the Lean compiler's kernel reduction rather than producing a kernel-checked proof. 0 sorries; no literal `axiom` declarations (leanFile.axiomCount = 0).",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0
@@ -134,7 +134,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Perfect Number Theorem is now fully verified using Mathlib's number theory infrastructure. We provide both directions of the Euclid-Euler characterization along with pedagogical examples demonstrating the first four perfect numbers.",
+    "summary": "The Perfect Number Theorem is formalized on top of Mathlib's number theory infrastructure. We provide both directions of the Euclid-Euler characterization along with pedagogical examples demonstrating the first four perfect numbers. The concrete examples establish Mersenne primality via `native_decide`, so they depend on the `Lean.ofReduceBool` axiom.",
     "implications": "The theorem has profound implications:\n\n**1. Perfect Number Generation**\nGiven a Mersenne prime, we can immediately compute the corresponding perfect number.\n\n**2. Rarity of Perfection**\nOnly 51 perfect numbers are known (as of 2024), corresponding to the 51 known Mersenne primes.\n\n**3. Connection to GIMPS**\nThe Great Internet Mersenne Prime Search discovers new Mersenne primes, each yielding a new perfect number.\n\n**4. Open Problems**\nThe existence of odd perfect numbers remains unsolved after 2000+ years. If one exists, it must satisfy incredibly restrictive conditions.\n\n**5. Multiplicative Functions**\nThe proof showcases the power of multiplicative arithmetic functions in number theory.",
     "openQuestions": [
       "Do odd perfect numbers exist? This is one of the oldest open problems in mathematics.",


### PR DESCRIPTION
## Fix

`perfect-numbers` was marked `verified` / badge `mathlib` / `axiomCount: 0` with assumptions "None. Fully verified with 0 axioms and 0 sorries." But its four headline example theorems use `native_decide`, which depends on `Lean.ofReduceBool` — so the entry is not axiom-free.

## Evidence

`PerfectNumbers.lean` — the concrete perfect-number proofs (explicit deliverables in `originalContributions[1]`, "Examples verifying 6, 28, 496, and 8128 are perfect") each discharge Mersenne primality via `native_decide`:

```
132 theorem six_is_perfect : Nat.Perfect 6 := by
133   have h3_prime : (mersenne 2).Prime := by native_decide
141 theorem twentyeight_is_perfect : ...  have h7_prime : (mersenne 3).Prime := by native_decide
150 theorem fourhundredninetysix_is_perfect : ...  have h31_prime := by native_decide
159 theorem eightthousandonetwentyeight_is_perfect : ...  have h127_prime := by native_decide
```

`#print axioms six_is_perfect` therefore lists `Lean.ofReduceBool`. Per the project Axiom Integrity Policy, `native_decide` discharging a substantive deliverable must count: `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`.

**Before**: status `verified`, badge `mathlib`, `axiomCount: 0`, assumptions "None. Fully verified…"
**After**: status `axiomatized`, badge `axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`; conclusion prose de-claimed. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only change; no Lean source modified.

Closes part of #25409

---
Automated fix by lean-mechanic agent.