### PR TITLE
Fix: euler-totient-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/euler-totient-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02/meta.json
@@ -2,9 +2,9 @@
   "id": "euler-totient-oq-02",
   "title": "Multiplicativity of Euler's Totient Function",
   "slug": "euler-totient-oq-02",
-  "description": "The multiplicative property of Euler's totient: φ(mn) = φ(m)·φ(n) when gcd(m,n) = 1. Proves multiplicativity via CRT, the prime power formula φ(p^k) = p^(k-1)(p-1), three-factor products, φ(2m)=φ(m) for odd m, and native_decide verifications including non-coprime counterexamples. 0 sorries, 0 axioms.",
+  "description": "The multiplicative property of Euler's totient: φ(mn) = φ(m)·φ(n) when gcd(m,n) = 1. Proves multiplicativity via CRT, the prime power formula φ(p^k) = p^(k-1)(p-1), three-factor products, φ(2m)=φ(m) for odd m, and native_decide verifications including non-coprime counterexamples. 0 sorries; concrete totient values (φ(6), φ(12), φ(15), φ(30), φ(100)) are discharged by native_decide, which adds the Lean.ofReduceBool axiom.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "multiplicative-functions",
@@ -12,10 +12,10 @@
       "totient"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT.",
+    "axiomCount": 1,
+    "assumptions": "0 sorries, 0 literal axiom declarations. The named concrete-value theorems (totient_six, totient_twelve, totient_fifteen, totient_thirty, totient_hundred) are discharged by native_decide, so they depend on the Lean.ofReduceBool compiler-reduction axiom; axiomCount=1 reflects this. All structural results (multiplicativity, prime power formula, group-theoretic interpretation) come from Mathlib's Nat.totient API, ZMod, and CRT.",
     "lineCount": 172,
     "theoremCount": 16,
     "definitionCount": 0,
@@ -93,7 +93,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The multiplicativity of Euler's totient function φ(mn) = φ(m)φ(n) for coprime m,n is fully formalized. The proof uses Mathlib's Nat.totient_mul (which implements the CRT argument), extends to three-factor products, verifies the prime power formula φ(p^k) = p^(k-1)(p-1), computes concrete values, and includes non-coprime counterexamples. All 16 theorems are machine-verified with 0 axioms.",
+    "summary": "The multiplicativity of Euler's totient function φ(mn) = φ(m)φ(n) for coprime m,n is fully formalized. The proof uses Mathlib's Nat.totient_mul (which implements the CRT argument), extends to three-factor products, verifies the prime power formula φ(p^k) = p^(k-1)(p-1), computes concrete values, and includes non-coprime counterexamples. All 16 theorems are machine-checked with 0 sorries; the concrete-value theorems use native_decide and therefore depend on the Lean.ofReduceBool axiom (axiomCount=1), while the structural results are axiom-free Mathlib derivations.",
     "implications": "The multiplicativity of φ is the key to the Euler product formula $\\varphi(n) = n \\prod_{p \\mid n}(1-1/p)$, which enables efficient computation of φ(n) from the prime factorization. This is fundamental to RSA cryptography: for $n = pq$, $\\varphi(n) = (p-1)(q-1)$, and the correctness of RSA decryption follows from Euler's theorem $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$.\n\nMore abstractly, multiplicative arithmetic functions form a group under Dirichlet convolution, and φ is a key example. The Möbius function μ is the Dirichlet inverse of the constant-1 function, and φ = μ * id (where * is Dirichlet convolution), which gives another way to compute φ.\n\nIn group theory, φ(n) is the order of the multiplicative group (ℤ/nℤ)*, and Lagrange's theorem implies that the order of any element divides φ(n). A primitive root modulo n (if one exists) is an element of order exactly φ(n), and their existence is connected to the structure of (ℤ/nℤ)*.",
     "openQuestions": [
       "Can the totient product formula φ(n) = n·∏_{p|n}(1-1/p) be formalized directly in Lean using Mathlib's prime factorization infrastructure? This would generalize totient_prime_pow by expressing φ as a product over distinct prime divisors.",


### PR DESCRIPTION
## Fix

`euler-totient-oq-02` (Multiplicativity of Euler's Totient Function) presented as `verified` / `mathlib` / `axiomCount: 0` ("All 16 theorems are machine-verified with 0 axioms"), but five **named** deliverable theorems are discharged by `native_decide`:

```
theorem totient_six     : Nat.totient 6   = 2  := by native_decide
theorem totient_twelve  : Nat.totient 12  = 4  := by native_decide
theorem totient_fifteen : Nat.totient 15  = 8  := by native_decide
theorem totient_thirty  : Nat.totient 30  = 8  := by native_decide
theorem totient_hundred : Nat.totient 100 = 40 := by native_decide
```

`native_decide` trusts kernel reduction and pulls in the `Lean.ofReduceBool` axiom, so these are not axiom-free. Per the Axiom Integrity Policy, a substantive named result presented as verified must be counted.

## Evidence

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`; prose claimed "machine-verified with 0 axioms".
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`; `assumptions`/`description`/`conclusion.summary` disclose `Lean.ofReduceBool`. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only change. The remaining `native_decide` uses are in anonymous `example` blocks (not part of the verified theorem surface).

Refs #25409

---
Automated fix by lean-mechanic agent.