### PR TITLE
research(sqrt2-plus-sqrt3-irrational-oq-02): Besicovitch n=2 — {1,√2,√3,√6} ℚ-linearly independent (verified, axiom-free)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2920,6 +2920,7 @@ import Proofs.Sqrt2MinpolyOQ02
 import Proofs.Sqrt2MinpolyOQ03
 import Proofs.Sqrt2OQ01
 import Proofs.Sqrt2PlusSqrt3Irrational
+import Proofs.Sqrt2PlusSqrt3IrrationalOQ02
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03Aristotle
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01

--- a/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
@@ -31,28 +31,41 @@ the general (still-`sorry`) reduction lacks.
 
 The proof is elementary (no field-theory tower): regroup `α := a + b√2 + c√3 +
 d√6` as `(a + b√2) + √3·(c + d√2)`, multiply by the ℚ(√2)-conjugate `(c − d√2)`
-to isolate `√3·(c² − 2d²)`, and conclude with `√3 ∉ ℚ(√2)`.  All irrationality
-inputs use kernel `decide` (`¬ IsSquare n` for `n ∈ {3, 6}`), so the file is
-genuinely axiom-free — no `native_decide`, hence no `Lean.ofReduceBool`.
+to isolate `√3·(c² − 2d²)`, and conclude with `√3 ∉ ℚ(√2)`.  The irrationality
+inputs (`¬ IsSquare n` for `n ∈ {3, 6}`) are discharged by an elementary divisor
+bound (`r ∣ n → r ≤ n`) plus a finite case split (`interval_cases`/`omega`),
+*not* by kernel `decide` (which gets stuck on `Nat.sqrt`) and not by
+`native_decide`.  The file is therefore genuinely axiom-free — no
+`Lean.ofReduceBool`, only the standard `propext`/`Classical.choice`/`Quot.sound`.
 
 Tags: number-theory, field-theory, multiquadratic, besicovitch, linear-independence
 -/
 
 import Mathlib.NumberTheory.Real.Irrational
-import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Data.Real.Sqrt
 import Mathlib.Tactic
 
 namespace Sqrt2PlusSqrt3IrrationalOQ02
 
 open Real
 
-/-- `√3` is irrational (3 is not a perfect square). Axiom-free via kernel `decide`. -/
+/-- `√3` is irrational (`3` is not a perfect square). Axiom-free: `¬ IsSquare 3`
+is discharged by an elementary divisor bound (`r ∣ 3 → r ≤ 3`) and a finite case
+split, avoiding kernel `decide` (which gets stuck on `Nat.sqrt`). -/
 theorem irrational_sqrt_three : Irrational (Real.sqrt 3) :=
-  irrational_sqrt_ofNat_iff.mpr (by decide)
+  irrational_sqrt_ofNat_iff.mpr (by
+    rintro ⟨r, hr⟩
+    have hle : r ≤ 3 := Nat.le_of_dvd (by norm_num) ⟨r, hr⟩
+    interval_cases r <;> omega)
 
-/-- `√6` is irrational (6 is not a perfect square). Axiom-free via kernel `decide`. -/
+/-- `√6` is irrational (`6` is not a perfect square). Axiom-free: `¬ IsSquare 6`
+is discharged by an elementary divisor bound (`r ∣ 6 → r ≤ 6`) and a finite case
+split, avoiding kernel `decide` (which gets stuck on `Nat.sqrt`). -/
 theorem irrational_sqrt_six : Irrational (Real.sqrt 6) :=
-  irrational_sqrt_ofNat_iff.mpr (by decide)
+  irrational_sqrt_ofNat_iff.mpr (by
+    rintro ⟨r, hr⟩
+    have hle : r ≤ 6 := Nat.le_of_dvd (by norm_num) ⟨r, hr⟩
+    interval_cases r <;> omega)
 
 /-- No rational is a square root of `2`. (`√2` irrational, stated over ℚ.) -/
 theorem rat_sq_ne_two (q : ℚ) : q ^ 2 ≠ 2 := by

--- a/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
@@ -1,0 +1,190 @@
+/-
+# Besicovitch (n = 2): ℚ-linear independence of {1, √2, √3, √6}  (OQ-02)
+
+Open Question (`sqrt2-plus-sqrt3-irrational-oq-02`):
+
+  Formalize **Besicovitch's theorem (1940)**: the square roots of distinct
+  squarefree positive integers are linearly independent over ℚ.  This gives the
+  complete characterization
+        ∑ᵢ rᵢ √aᵢ ∈ ℚ   ⟺   rᵢ = 0  for every aᵢ > 1.
+
+## STATUS — verified, axiom-free: the complete n = 2 instance
+
+The general theorem reduces (see the sibling file
+`Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02`) to a single non-trivial *induction
+heart*: adjoining a new prime square root strictly enlarges the multiquadratic
+field, equivalently `√3 ∉ ℚ(√2)`.  That file leaves the heart as `sorry`.
+
+This file discharges the **smallest non-trivial case completely and without any
+axioms**: it proves
+
+  * `sqrt3_not_in_Qsqrt2`  — `√3` is not of the form `e + f√2` with `e, f ∈ ℚ`
+    (the n = 2 induction heart), and
+
+  * `linearIndependent_one_sqrt2_sqrt3_sqrt6` — for rationals `a, b, c, d`,
+        a + b√2 + c√3 + d√6 = 0  ⟹  a = b = c = d = 0,
+
+i.e. `{1, √2, √3, √6}` is ℚ-linearly independent.  This is exactly the
+"complete characterization" of the open question, specialized to the radicands
+`{1, 2, 3, 6}` (`= {√d : d | 6 squarefree}`), and is the concrete certificate
+the general (still-`sorry`) reduction lacks.
+
+The proof is elementary (no field-theory tower): regroup `α := a + b√2 + c√3 +
+d√6` as `(a + b√2) + √3·(c + d√2)`, multiply by the ℚ(√2)-conjugate `(c − d√2)`
+to isolate `√3·(c² − 2d²)`, and conclude with `√3 ∉ ℚ(√2)`.  All irrationality
+inputs use kernel `decide` (`¬ IsSquare n` for `n ∈ {3, 6}`), so the file is
+genuinely axiom-free — no `native_decide`, hence no `Lean.ofReduceBool`.
+
+Tags: number-theory, field-theory, multiquadratic, besicovitch, linear-independence
+-/
+
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Tactic
+
+namespace Sqrt2PlusSqrt3IrrationalOQ02
+
+open Real
+
+/-- `√3` is irrational (3 is not a perfect square). Axiom-free via kernel `decide`. -/
+theorem irrational_sqrt_three : Irrational (Real.sqrt 3) :=
+  irrational_sqrt_ofNat_iff.mpr (by decide)
+
+/-- `√6` is irrational (6 is not a perfect square). Axiom-free via kernel `decide`. -/
+theorem irrational_sqrt_six : Irrational (Real.sqrt 6) :=
+  irrational_sqrt_ofNat_iff.mpr (by decide)
+
+/-- No rational is a square root of `2`. (`√2` irrational, stated over ℚ.) -/
+theorem rat_sq_ne_two (q : ℚ) : q ^ 2 ≠ 2 := by
+  intro hq
+  have h1 : ((q : ℝ)) ^ 2 = 2 := by exact_mod_cast hq
+  have h2 : Real.sqrt 2 = |(q : ℝ)| := by rw [← h1, Real.sqrt_sq_eq_abs]
+  rw [← Rat.cast_abs] at h2
+  exact irrational_sqrt_two ⟨|q|, h2.symm⟩
+
+/-- `{1, √2}` is ℚ-linearly independent: `p + q√2 = 0` forces `p = q = 0`. -/
+theorem linearIndependent_one_sqrt2 (p q : ℚ)
+    (h : (p : ℝ) + (q : ℝ) * Real.sqrt 2 = 0) : p = 0 ∧ q = 0 := by
+  by_cases hq : q = 0
+  · subst hq
+    simp only [Rat.cast_zero, zero_mul, add_zero] at h
+    exact ⟨by exact_mod_cast h, rfl⟩
+  · exfalso
+    apply irrational_sqrt_two
+    refine ⟨-p / q, ?_⟩
+    have hqR : (q : ℝ) ≠ 0 := by exact_mod_cast hq
+    rw [Rat.cast_div, Rat.cast_neg, div_eq_iff hqR]
+    linear_combination -h
+
+/-- **n = 2 induction heart.** `√3` is not a ℚ-linear combination of `1` and `√2`;
+equivalently `√3 ∉ ℚ(√2)`. This is the smallest non-trivial case of the
+multiquadratic degree-doubling step underlying Besicovitch's theorem. -/
+theorem sqrt3_not_in_Qsqrt2 :
+    ¬ ∃ e f : ℚ, Real.sqrt 3 = (e : ℝ) + (f : ℝ) * Real.sqrt 2 := by
+  rintro ⟨e, f, hef⟩
+  have h2sq : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have h3sq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  -- Square `√3 = e + f√2`:  e² + 2f² + 2ef·√2 = 3.
+  have key : (e : ℝ) ^ 2 + 2 * (f : ℝ) ^ 2 + 2 * (e : ℝ) * (f : ℝ) * Real.sqrt 2 = 3 := by
+    have hexp : ((e : ℝ) + (f : ℝ) * Real.sqrt 2) ^ 2
+        = (e : ℝ) ^ 2 + 2 * (f : ℝ) ^ 2 + 2 * (e : ℝ) * (f : ℝ) * Real.sqrt 2 := by
+      linear_combination (f : ℝ) ^ 2 * h2sq
+    rw [← hexp, ← hef, h3sq]
+  by_cases hf : f = 0
+  · -- √3 = e ∈ ℚ : contradicts irrationality of √3.
+    subst hf
+    have h3 : Real.sqrt 3 = (e : ℝ) := by rw [hef]; push_cast; ring
+    exact irrational_sqrt_three ⟨e, h3.symm⟩
+  · by_cases he : e = 0
+    · -- √3 = f√2, so √6 = 2f ∈ ℚ : contradicts irrationality of √6.
+      subst he
+      have hef0 : Real.sqrt 3 = (f : ℝ) * Real.sqrt 2 := by rw [hef]; push_cast; ring
+      have hsix : Real.sqrt 6 = 2 * (f : ℝ) := by
+        have hm : Real.sqrt 2 * Real.sqrt 3 = Real.sqrt 6 := by
+          rw [← Real.sqrt_mul (by norm_num : (0 : ℝ) ≤ 2)]; norm_num
+        calc Real.sqrt 6 = Real.sqrt 2 * Real.sqrt 3 := hm.symm
+          _ = Real.sqrt 2 * ((f : ℝ) * Real.sqrt 2) := by rw [hef0]
+          _ = (f : ℝ) * Real.sqrt 2 ^ 2 := by ring
+          _ = (f : ℝ) * 2 := by rw [h2sq]
+          _ = 2 * (f : ℝ) := by ring
+      exact irrational_sqrt_six ⟨2 * f, by push_cast; rw [hsix]⟩
+    · -- e, f ≠ 0 : √2 = (3 − e² − 2f²)/(2ef) ∈ ℚ : contradicts irrationality of √2.
+      exfalso
+      apply irrational_sqrt_two
+      refine ⟨(3 - e ^ 2 - 2 * f ^ 2) / (2 * e * f), ?_⟩
+      have hef2 : (2 * (e : ℝ) * (f : ℝ)) ≠ 0 :=
+        mul_ne_zero (mul_ne_zero two_ne_zero (by exact_mod_cast he)) (by exact_mod_cast hf)
+      have hmul2 : Real.sqrt 2 * (2 * (e : ℝ) * (f : ℝ))
+          = 3 - (e : ℝ) ^ 2 - 2 * (f : ℝ) ^ 2 := by linear_combination key
+      have hwit : (((3 - e ^ 2 - 2 * f ^ 2) / (2 * e * f) : ℚ) : ℝ) * (2 * (e : ℝ) * (f : ℝ))
+          = 3 - (e : ℝ) ^ 2 - 2 * (f : ℝ) ^ 2 := by
+        push_cast
+        rw [div_mul_cancel₀ _ hef2]
+      exact mul_right_cancel₀ hef2 (hwit.trans hmul2.symm)
+
+/-- **Besicovitch, n = 2 (main result).** `{1, √2, √3, √6}` is ℚ-linearly
+independent: if `a + b√2 + c√3 + d√6 = 0` with `a, b, c, d ∈ ℚ`, then all four
+coefficients vanish.  Equivalently `[ℚ(√2, √3) : ℚ] = 4`, and the open
+question's characterization `∑ rᵢ√aᵢ ∈ ℚ ⟺ rᵢ = 0` holds for radicands
+`{1, 2, 3, 6}`. -/
+theorem linearIndependent_one_sqrt2_sqrt3_sqrt6 (a b c d : ℚ)
+    (h : (a : ℝ) + (b : ℝ) * Real.sqrt 2 + (c : ℝ) * Real.sqrt 3
+        + (d : ℝ) * Real.sqrt 6 = 0) :
+    a = 0 ∧ b = 0 ∧ c = 0 ∧ d = 0 := by
+  have h2sq : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have h6 : Real.sqrt 6 = Real.sqrt 2 * Real.sqrt 3 := by
+    rw [← Real.sqrt_mul (by norm_num : (0 : ℝ) ≤ 2)]; norm_num
+  -- Regroup over ℚ(√2):  (a + b√2) + √3·(c + d√2) = 0.
+  have h1 : ((a : ℝ) + (b : ℝ) * Real.sqrt 2)
+      + Real.sqrt 3 * ((c : ℝ) + (d : ℝ) * Real.sqrt 2) = 0 := by
+    rw [h6] at h; linear_combination h
+  by_cases hcd : c = 0 ∧ d = 0
+  · -- Coefficient of √3 vanishes:  a + b√2 = 0.
+    obtain ⟨hc, hd⟩ := hcd
+    subst hc; subst hd
+    push_cast at h1
+    have h1' : (a : ℝ) + (b : ℝ) * Real.sqrt 2 = 0 := by linear_combination h1
+    obtain ⟨ha, hb⟩ := linearIndependent_one_sqrt2 a b h1'
+    exact ⟨ha, hb, rfl, rfl⟩
+  · -- Otherwise the ℚ(√2)-conjugate isolates √3 ∈ ℚ(√2), a contradiction.
+    exfalso
+    -- `c² − 2d² ≠ 0` since 2 is not a rational square.
+    have hg : (c ^ 2 - 2 * d ^ 2 : ℚ) ≠ 0 := by
+      intro hg0
+      rcases eq_or_ne d 0 with hd | hd
+      · subst hd
+        apply hcd
+        refine ⟨?_, rfl⟩
+        have hc2 : c ^ 2 = 0 := by simpa using hg0
+        exact sq_eq_zero_iff.mp hc2
+      · apply rat_sq_ne_two (c / d)
+        rw [div_pow, div_eq_iff (pow_ne_zero 2 hd)]
+        linarith [hg0]
+    have hgR : ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2) ≠ 0 := by exact_mod_cast hg
+    -- Multiply `h1` by the conjugate `(c − d√2)` to isolate `√3·(c² − 2d²)`.
+    have hmul : Real.sqrt 3 * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+        = (2 * (b : ℝ) * (d : ℝ) - (a : ℝ) * (c : ℝ))
+          + ((a : ℝ) * (d : ℝ) - (b : ℝ) * (c : ℝ)) * Real.sqrt 2 := by
+      linear_combination ((c : ℝ) - (d : ℝ) * Real.sqrt 2) * h1
+        + ((b : ℝ) * (d : ℝ) + (d : ℝ) ^ 2 * Real.sqrt 3) * h2sq
+    -- Hence `√3 = e + f√2 ∈ ℚ(√2)`, contradicting `sqrt3_not_in_Qsqrt2`.
+    apply sqrt3_not_in_Qsqrt2
+    set e : ℚ := (2 * b * d - a * c) / (c ^ 2 - 2 * d ^ 2) with he_def
+    set f : ℚ := (a * d - b * c) / (c ^ 2 - 2 * d ^ 2) with hf_def
+    refine ⟨e, f, ?_⟩
+    have heG : (e : ℝ) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+        = 2 * (b : ℝ) * (d : ℝ) - (a : ℝ) * (c : ℝ) := by
+      rw [he_def]; push_cast; rw [div_mul_cancel₀ _ hgR]
+    have hfG : (f : ℝ) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+        = (a : ℝ) * (d : ℝ) - (b : ℝ) * (c : ℝ) := by
+      rw [hf_def]; push_cast; rw [div_mul_cancel₀ _ hgR]
+    have key2 : Real.sqrt 3 * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+        = ((e : ℝ) + (f : ℝ) * Real.sqrt 2) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2) := by
+      rw [hmul]
+      have hexp : ((e : ℝ) + (f : ℝ) * Real.sqrt 2) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+          = (e : ℝ) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)
+            + ((f : ℝ) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)) * Real.sqrt 2 := by ring
+      rw [hexp, heG, hfG]
+    exact mul_right_cancel₀ hgR key2
+
+end Sqrt2PlusSqrt3IrrationalOQ02

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/annotations.json
@@ -1,0 +1,144 @@
+[
+  {
+    "id": "ann-bes2-setup",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Setting: Besicovitch's Theorem at n = 2",
+    "content": "Besicovitch's 1940 theorem says the square roots of distinct squarefree positive integers are ℚ-linearly independent. The parent gallery entry's second open question asks to formalize it; this file answers the smallest non-trivial case, the prime set {2, 3}, by proving {1, √2, √3, √6} is ℚ-linearly independent. The radicands {1, 2, 3, 6} are exactly {d : d ∣ 6, d squarefree}, so this is the complete characterization ∑ rᵢ√aᵢ ∈ ℚ ⟺ rᵢ = 0 for that prime set. The proof imports only Real.sqrt and Irrational APIs — no field-extension tower — and is deliberately kept axiom-free.",
+    "mathContext": "Besicovitch (1940): for distinct squarefree $a_1,\\dots,a_n$, the $\\sqrt{a_i}$ are $\\mathbb{Q}$-linearly independent. Here $n=2$, primes $\\{2,3\\}$, radicands $\\{1,2,3,6\\}$, equivalently $[\\mathbb{Q}(\\sqrt2,\\sqrt3):\\mathbb{Q}]=4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Besicovitch's theorem",
+      "linear independence over ℚ",
+      "multiquadratic fields",
+      "squarefree integers"
+    ],
+    "prerequisites": [
+      "irrationality of square roots",
+      "rational vector spaces",
+      "field extension degree"
+    ]
+  },
+  {
+    "id": "ann-bes2-irrationality-inputs",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "Axiom-Free Irrationality without Kernel decide",
+    "content": "irrational_sqrt_three and irrational_sqrt_six are obtained from Mathlib's irrational_sqrt_ofNat_iff, which reduces irrationality of √n to the perfect-square obstruction ¬IsSquare n. The obstructions ¬IsSquare 3 and ¬IsSquare 6 are NOT discharged by `decide`: kernel `decide` gets stuck on Nat.sqrt (its Decidable instance does not reduce), and `native_decide` would trust the compiler and pull in the Lean.ofReduceBool axiom, forcing status 'axiomatized'. Instead each is proved elementarily: from a hypothetical n = r * r we get r ∣ n, hence r ≤ n by Nat.le_of_dvd, and interval_cases on r with omega rules out every candidate. This keeps the file genuinely axiom-free with no reliance on kernel reduction at all. rat_sq_ne_two then restates √2 ∉ ℚ in the convenient form q² ≠ 2 by pulling √2 = |q| out of a hypothetical q² = 2 via Real.sqrt_sq_eq_abs.",
+    "mathContext": "$\\mathrm{Irrational}\\,\\sqrt{n} \\iff \\lnot\\,\\mathrm{IsSquare}\\,n$. For $n\\in\\{3,6\\}$ the right side is proved by a divisor bound: $n=r^2\\Rightarrow r\\mid n\\Rightarrow r\\le n$, then a finite case split. Restated: no $q\\in\\mathbb{Q}$ has $q^2=2$, since otherwise $\\sqrt2=|q|\\in\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irrational_sqrt_ofNat_iff",
+      "Nat.le_of_dvd",
+      "interval_cases / omega",
+      "Real.sqrt_sq_eq_abs"
+    ],
+    "prerequisites": [
+      "IsSquare on ℕ",
+      "axiom accounting in Lean",
+      "Real.sqrt basics"
+    ]
+  },
+  {
+    "id": "ann-bes2-base-case",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Base Case: {1, √2} Linearly Independent",
+    "content": "linearIndependent_one_sqrt2 proves p + q√2 = 0 forces p = q = 0. The argument splits on q: if q = 0 then p = 0 follows by casting; if q ≠ 0, then √2 = −p/q would be rational, exhibited as the explicit witness ⟨−p/q, …⟩ to irrational_sqrt_two and closed with linear_combination. This is the degree-2 base of the multiquadratic tower on which the main result builds.",
+    "mathContext": "$\\{1,\\sqrt2\\}$ is a $\\mathbb{Q}$-basis of $\\mathbb{Q}(\\sqrt2)$: $p+q\\sqrt2=0 \\Rightarrow p=q=0$, since $q\\ne0$ gives $\\sqrt2=-p/q\\in\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear independence",
+      "ℚ(√2) as a vector space",
+      "irrational_sqrt_two",
+      "linear_combination tactic"
+    ],
+    "prerequisites": [
+      "rational arithmetic",
+      "field of fractions casting"
+    ]
+  },
+  {
+    "id": "ann-bes2-induction-heart",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 136
+    },
+    "type": "technique",
+    "title": "Induction Heart: √3 ∉ ℚ(√2)",
+    "content": "sqrt3_not_in_Qsqrt2 is the crux. Assuming √3 = e + f√2 with e, f ∈ ℚ, squaring (using (√2)² = 2) gives the identity e² + 2f² + 2ef√2 = 3. A three-way case analysis derives a contradiction in every branch: (i) f = 0 makes √3 = e rational, contradicting irrational_sqrt_three; (ii) e = 0 makes √3 = f√2, hence √6 = √2·√3 = 2f rational, contradicting irrational_sqrt_six; (iii) e, f both nonzero solves the identity for √2 = (3 − e² − 2f²)/(2ef) ∈ ℚ, contradicting irrational_sqrt_two via mul_right_cancel₀ on the witness. Mathematically this is the statement that adjoining √3 strictly doubles the degree of ℚ(√2) — the engine of Besicovitch's induction, here at its smallest case.",
+    "mathContext": "$\\sqrt3\\notin\\mathbb{Q}(\\sqrt2)$. If $\\sqrt3=e+f\\sqrt2$ then $e^2+2f^2+2ef\\sqrt2=3$; the cases $f=0$, $e=0$, $ef\\ne0$ force $\\sqrt3$, $\\sqrt6$, $\\sqrt2\\in\\mathbb{Q}$ respectively. Equivalently $[\\mathbb{Q}(\\sqrt2,\\sqrt3):\\mathbb{Q}(\\sqrt2)]=2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "degree-doubling step",
+      "multiquadratic tower",
+      "Real.sq_sqrt",
+      "Real.sqrt_mul",
+      "tower law"
+    ],
+    "prerequisites": [
+      "field extension towers",
+      "conjugation in quadratic fields",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "ann-bes2-conjugate-isolation",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 162,
+      "endLine": 201
+    },
+    "type": "technique",
+    "title": "Conjugate Multiplication Isolates √3 ∈ ℚ(√2)",
+    "content": "In the non-vanishing branch of the main theorem, the regrouped relation (a+b√2) + √3(c+d√2) = 0 is multiplied by the ℚ(√2)-conjugate (c − d√2). Since (c+d√2)(c−d√2) = c² − 2d², the √3-coefficient becomes rational and √3·(c²−2d²) equals an explicit ℚ(√2)-element. Crucially c²−2d² ≠ 0: if d = 0 it forces c = 0 (the vanishing case), and if d ≠ 0 then c²=2d² gives (c/d)²=2, contradicting rat_sq_ne_two. Dividing through exhibits √3 = e + f√2 with e = (2bd−ac)/(c²−2d²), f = (ad−bc)/(c²−2d²), contradicting sqrt3_not_in_Qsqrt2. This conjugate trick is the reusable inductive engine: it converts a √p-coefficient over a multiquadratic field into a rational and reduces independence to the single degree-doubling fact.",
+    "mathContext": "Rationalizing the $\\sqrt3$-coefficient: $(c+d\\sqrt2)(c-d\\sqrt2)=c^2-2d^2\\in\\mathbb{Q}^\\times$ (nonzero since $\\sqrt2\\notin\\mathbb{Q}$), so $\\sqrt3=\\frac{(2bd-ac)+(ad-bc)\\sqrt2}{c^2-2d^2}\\in\\mathbb{Q}(\\sqrt2)$ — impossible.",
+    "significance": "key",
+    "relatedConcepts": [
+      "field conjugation",
+      "rationalizing denominators",
+      "linear_combination tactic",
+      "mul_right_cancel₀"
+    ],
+    "prerequisites": [
+      "quadratic field norms",
+      "ℚ(√2)-linear algebra"
+    ]
+  },
+  {
+    "id": "ann-bes2-main-result",
+    "proofId": "sqrt2-plus-sqrt3-irrational-oq-02",
+    "range": {
+      "startLine": 138,
+      "endLine": 203
+    },
+    "type": "concept",
+    "title": "Main Result and Significance",
+    "content": "linearIndependent_one_sqrt2_sqrt3_sqrt6 assembles the pieces: writing √6 = √2·√3 and regrouping a+b√2+c√3+d√6 = (a+b√2) + √3(c+d√2), it either reduces to the {1,√2} base case (when c = d = 0) or derives the √3 ∈ ℚ(√2) contradiction via the conjugate step. The conclusion a = b = c = d = 0 is the complete Besicovitch characterization for radicands {1,2,3,6}, equivalently [ℚ(√2,√3):ℚ] = 4 — the same degree-4 fact proved by minimal-polynomial methods in the sibling oq-03 entry, here reached by elementary linear-independence arithmetic. It also supplies the concrete n = 2 certificate that the general (still-sorry) reduction in the sqrt5 sibling lacks.",
+    "mathContext": "$a+b\\sqrt2+c\\sqrt3+d\\sqrt6=0 \\Rightarrow a=b=c=d=0$. This is Besicovitch's theorem for primes $\\{2,3\\}$ and gives a $\\mathbb{Q}$-basis $\\{1,\\sqrt2,\\sqrt3,\\sqrt6\\}$ of the biquadratic field $\\mathbb{Q}(\\sqrt2,\\sqrt3)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Besicovitch's theorem",
+      "biquadratic field",
+      "ℚ-basis",
+      "minimal polynomial (sibling oq-03)"
+    ],
+    "prerequisites": [
+      "linear independence over ℚ",
+      "multiquadratic field theory"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "sqrt2-plus-sqrt3-irrational-oq-02",
+  "title": "Besicovitch (n = 2): ℚ-Linear Independence of {1, √2, √3, √6}",
+  "slug": "sqrt2-plus-sqrt3-irrational-oq-02",
+  "description": "Answers the open question 'Formalize Besicovitch's theorem (1940): √a₁, …, √aₙ are ℚ-linearly independent for distinct squarefree aᵢ' for the smallest non-trivial case n = 2 (radicands {1, 2, 3, 6}). Proves {1, √2, √3, √6} is ℚ-linearly independent: a + b√2 + c√3 + d√6 = 0 with a,b,c,d ∈ ℚ forces a = b = c = d = 0. The technical heart is sqrt3_not_in_Qsqrt2 (√3 ∉ ℚ(√2)), the degree-doubling step of the multiquadratic tower. Fully verified, axiom-free: the irrationality inputs ¬IsSquare 3 and ¬IsSquare 6 are proved by an elementary divisor bound plus a finite case split (no kernel decide, which gets stuck on Nat.sqrt, and no native_decide), hence no Lean.ofReduceBool. 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-18",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean",
+    "tags": [
+      "number-theory",
+      "field-theory",
+      "multiquadratic",
+      "besicovitch",
+      "linear-independence",
+      "irrationality",
+      "square-roots"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "assumptions": "None. Fully proved: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The irrationality inputs (¬IsSquare 3, ¬IsSquare 6) are discharged by an elementary divisor bound (r ∣ n → r ≤ n) plus a finite case split (interval_cases/omega), NOT by kernel `decide` (which gets stuck on Nat.sqrt) and NOT by `native_decide`, so the file does not depend on Lean.ofReduceBool. Standard foundational axioms (propext, Classical.choice, Quot.sound) only.",
+    "lineCount": 203,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "linearIndependent_one_sqrt2_sqrt3_sqrt6: {1, √2, √3, √6} is ℚ-linearly independent (the complete n = 2 Besicovitch characterization, equivalently [ℚ(√2,√3):ℚ] = 4)",
+      "sqrt3_not_in_Qsqrt2: √3 is not of the form e + f√2 with e,f ∈ ℚ — the n = 2 induction heart (degree-doubling step) that the general sorry-based reduction (sibling Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02) lacks",
+      "linearIndependent_one_sqrt2: {1, √2} is ℚ-linearly independent (base of the tower)",
+      "rat_sq_ne_two: no rational squares to 2 (√2 irrationality restated over ℚ)",
+      "irrational_sqrt_three, irrational_sqrt_six: √3, √6 irrational, with ¬IsSquare 3 / ¬IsSquare 6 proved by an elementary divisor bound + finite case split (axiom-free; avoids kernel decide, which gets stuck on Nat.sqrt, and avoids native_decide)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Besicovitch's 1940 theorem (A. S. Besicovitch, 'On the linear independence of fractional powers of integers', J. London Math. Soc. 15 (1940), 3–6) states that if a₁, …, aₙ are distinct squarefree positive integers, then √a₁, …, √aₙ are linearly independent over ℚ. Equivalently, ∑ rᵢ√aᵢ ∈ ℚ holds only when every rᵢ with aᵢ > 1 vanishes. The full theorem is the precise generalization of the parent entry's squaring trick for √2 + √3, and is exactly the second open question listed there. The proof of the general theorem is an induction on the number of primes, whose engine is a single degree-doubling step: adjoining a new prime square root to a multiquadratic field strictly enlarges it. This entry formalizes the smallest non-trivial instance of that engine — √3 ∉ ℚ(√2) — and assembles it into the complete n = 2 statement for radicands {1, 2, 3, 6} = {√d : d ∣ 6 squarefree}.",
+    "problemStatement": "Prove that {1, √2, √3, √6} is linearly independent over ℚ: for a, b, c, d ∈ ℚ, if a + b√2 + c√3 + d√6 = 0 then a = b = c = d = 0. This is Besicovitch's theorem specialized to the squarefree radicands dividing 6.",
+    "text": "The proof avoids the field-extension tower and works by direct real arithmetic. The crux is the lemma sqrt3_not_in_Qsqrt2: if √3 = e + f√2 with e, f ∈ ℚ, squaring gives e² + 2f² + 2ef√2 = 3. A three-way case split (f = 0 ⟹ √3 ∈ ℚ; e = 0 ⟹ √6 = 2f ∈ ℚ; both nonzero ⟹ √2 = (3 − e² − 2f²)/(2ef) ∈ ℚ) contradicts the irrationality of √3, √6, √2 respectively. For the main result, write √6 = √2·√3 and regroup α = a + b√2 + c√3 + d√6 = (a + b√2) + √3·(c + d√2). If the √3-coefficient c + d√2 is zero (i.e. c = d = 0), then a + b√2 = 0 forces a = b = 0 by the {1,√2} base case. Otherwise c² − 2d² ≠ 0 (since √2 ∉ ℚ), and multiplying the regrouped relation by the ℚ(√2)-conjugate (c − d√2) isolates √3·(c² − 2d²) as a ℚ(√2)-element, exhibiting √3 = e + f√2 — contradicting sqrt3_not_in_Qsqrt2.",
+    "proofStrategy": "Five supporting results feed the main theorem. (1) irrational_sqrt_three / irrational_sqrt_six: irrational_sqrt_ofNat_iff.mpr applied to ¬IsSquare 3 / ¬IsSquare 6, each proved by an elementary divisor bound (r ∣ n → r ≤ n via Nat.le_of_dvd) and interval_cases/omega — no kernel decide (stuck on Nat.sqrt), no native_decide. (2) rat_sq_ne_two: pull √2 = |q| from q² = 2 and contradict irrational_sqrt_two. (3) linearIndependent_one_sqrt2: p + q√2 = 0 with q ≠ 0 exhibits √2 = −p/q ∈ ℚ. (4) sqrt3_not_in_Qsqrt2: square and case-split on (e,f) vanishing as above. (5) Main: regroup over ℚ(√2), establish c² − 2d² ≠ 0 via rat_sq_ne_two (c/d), then linear_combination ((c) − (d)√2)·h1 + …·h2sq isolates √3 as e + f√2 with e = (2bd − ac)/(c²−2d²), f = (ad − bc)/(c²−2d²), and mul_right_cancel₀ closes the contradiction.",
+    "keyInsights": [
+      "The 'induction heart' of Besicovitch for n = 2 is exactly √3 ∉ ℚ(√2), i.e. that adjoining √3 doubles the degree of ℚ(√2). The general theorem's reduction is a sorry in the sibling file Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02; this entry supplies the concrete certificate that reduction lacks at its smallest case.",
+      "Multiplying by the ℚ(√2)-conjugate (c − d√2) is the multiquadratic analogue of rationalizing a denominator: it converts the √3-coefficient (c + d√2) into the rational c² − 2d², isolating √3 as an honest ℚ(√2)-element and reducing the 4-term independence to the single degree-doubling fact.",
+      "Axiom-freeness is achieved without kernel `decide` at all: kernel decide gets stuck on Nat.sqrt for ¬IsSquare 3 / ¬IsSquare 6, and native_decide would incur Lean.ofReduceBool. An elementary divisor bound (n = r² ⟹ r ∣ n ⟹ r ≤ n) followed by a finite case split discharges both, keeping the proof genuinely axiom-free (status verified, not axiomatized).",
+      "The non-vanishing c² − 2d² ≠ 0 is itself an irrationality fact: if c² = 2d² with d ≠ 0 then (c/d)² = 2, contradicting √2 ∉ ℚ; if d = 0 it forces c = 0, the already-handled vanishing case. This reuse of rat_sq_ne_two threads √2's irrationality through both the setup and the conjugate step.",
+      "Specializing to radicands {1, 2, 3, 6}: this is the full set {√d : d ∣ 6, d squarefree}, so the result is the complete Besicovitch statement for the prime set {2, 3}, equivalently [ℚ(√2, √3):ℚ] = 4 — the same degree-4 conclusion proved by minimal-polynomial methods in the sibling entry sqrt2-plus-sqrt3-irrational-oq-03, here obtained by elementary linear-independence arithmetic."
+    ],
+    "prerequisites": [
+      "Real.sqrt: Real.sq_sqrt, Real.sqrt_mul, Real.sqrt_sq_eq_abs",
+      "Mathlib Irrational: irrational_sqrt_two, irrational_sqrt_ofNat_iff",
+      "Rat.cast arithmetic and exact_mod_cast for ℚ ↪ ℝ",
+      "linear_combination and mul_right_cancel₀ for the conjugate isolation"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully verified and axiom-free: {1, √2, √3, √6} is ℚ-linearly independent (a + b√2 + c√3 + d√6 = 0 ⟹ a = b = c = d = 0). This is Besicovitch's theorem at n = 2, radicands {1, 2, 3, 6}, equivalently [ℚ(√2,√3):ℚ] = 4. The technical core sqrt3_not_in_Qsqrt2 (√3 ∉ ℚ(√2)) is the degree-doubling induction heart. 6 theorems, 0 axioms, 0 sorries, ~203 lines, irrationality inputs via an elementary divisor bound + finite case split (no kernel decide, no native_decide, no Lean.ofReduceBool).",
+    "implications": "This supplies the concrete n = 2 certificate for the general Besicovitch reduction, whose induction heart remains a sorry in the sibling sqrt5 file. The elementary conjugate-multiplication method (no field tower, no minimal polynomials) is reusable: the same regroup-and-conjugate step is the inductive engine for adjoining each successive prime square root, suggesting a path to the full theorem by iterating the degree-doubling lemma.",
+    "openQuestions": [
+      "Prove the n = 3 case: {1, √2, √3, √5, √6, √10, √15, √30} is ℚ-linearly independent (radicands dividing 30), the next instance of Besicovitch, requiring two nested conjugate steps.",
+      "Formalize the general induction: adjoining √p (p a new prime) to a multiquadratic field ℚ(√q₁,…,√qₖ) strictly doubles the degree — the abstract degree-doubling lemma that this entry proves concretely for ℚ(√2) → ℚ(√2,√3).",
+      "Discharge the sorry in Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02 by feeding this n = 2 heart into the general reduction, completing the √2 + √3 + √5 irrationality via Besicovitch rather than ad-hoc squaring.",
+      "Connect to the minimal-polynomial route: derive [ℚ(√2,√3):ℚ] = 4 of sqrt2-plus-sqrt3-irrational-oq-03 directly from this linear-independence statement (basis {1,√2,√3,√6})."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2PlusSqrt3IrrationalOQ02",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational",
+      "relationship": "extends",
+      "description": "Parent entry proving √2 + √3 ∉ ℚ via the squaring trick. Its second open question asks to formalize Besicovitch's theorem; this entry answers it for the smallest non-trivial case n = 2 (radicands {1,2,3,6})."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry computing the minimal polynomial X⁴−10X²+1 and deriving [ℚ(√2+√3):ℚ] = 4 by field-theoretic methods. This entry reaches the same degree-4 conclusion by elementary ℚ-linear independence of {1,√2,√3,√6}, avoiding the polynomial tower."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+      "relationship": "related",
+      "description": "Three-radical extension √2+√3+√5. Its OQ-02 formalization leaves the multiquadratic degree-doubling step as a sorry; this entry discharges that step's smallest case (√3 ∉ ℚ(√2)) completely and axiom-free."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "Irrationality of square roots via the non-perfect-square criterion. The contradictions here all reduce to √2, √3, or √6 ∉ ℚ — instances of that classical Pythagorean result."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Overview and Status",
+      "summary": "Module header stating the n = 2 Besicovitch result, the elementary regroup-and-conjugate strategy, and the axiom-free status (no kernel decide, no native_decide). Enters namespace Sqrt2PlusSqrt3IrrationalOQ02.",
+      "startLine": 1,
+      "endLine": 47,
+      "mathContext": "Besicovitch (1940) at n = 2: {1,√2,√3,√6} is ℚ-linearly independent, equivalently [ℚ(√2,√3):ℚ] = 4."
+    },
+    {
+      "id": "irrationality-inputs",
+      "title": "Axiom-Free Irrationality Inputs",
+      "summary": "irrational_sqrt_three and irrational_sqrt_six via irrational_sqrt_ofNat_iff.mpr applied to ¬IsSquare 3 / ¬IsSquare 6, each proved by an elementary divisor bound (r ∣ n → r ≤ n) and interval_cases/omega — no kernel decide (stuck on Nat.sqrt) and no native_decide, keeping the file free of Lean.ofReduceBool. rat_sq_ne_two restates √2 ∉ ℚ over the rationals (q² ≠ 2).",
+      "startLine": 49,
+      "endLine": 63,
+      "mathContext": "√3, √6 irrational (3, 6 not perfect squares, via a divisor bound + finite case split); no rational squares to 2."
+    },
+    {
+      "id": "base-case",
+      "title": "Base Case: {1, √2} Independent",
+      "summary": "linearIndependent_one_sqrt2: p + q√2 = 0 forces p = q = 0, since q ≠ 0 would give √2 = −p/q ∈ ℚ, contradicting irrational_sqrt_two.",
+      "startLine": 65,
+      "endLine": 77,
+      "mathContext": "{1, √2} ℚ-linearly independent — the base of the multiquadratic tower."
+    },
+    {
+      "id": "induction-heart",
+      "title": "Induction Heart: √3 ∉ ℚ(√2)",
+      "summary": "sqrt3_not_in_Qsqrt2: assuming √3 = e + f√2 (e,f ∈ ℚ), squaring yields e²+2f²+2ef√2 = 3 and a three-way case split (f=0, e=0, both nonzero) contradicts irrationality of √3, √6, √2. This is the degree-doubling step.",
+      "startLine": 79,
+      "endLine": 123,
+      "mathContext": "√3 ∉ ℚ(√2): adjoining √3 strictly enlarges ℚ(√2) — the n = 2 instance of Besicovitch's induction engine."
+    },
+    {
+      "id": "main-result",
+      "title": "Main Result: {1, √2, √3, √6} Independent",
+      "summary": "linearIndependent_one_sqrt2_sqrt3_sqrt6: regroup a+b√2+c√3+d√6 = (a+b√2)+√3(c+d√2) over ℚ(√2). Vanishing √3-coefficient reduces to the base case; otherwise c²−2d² ≠ 0 and multiplying by the conjugate (c−d√2) isolates √3 ∈ ℚ(√2), contradicting the induction heart.",
+      "startLine": 125,
+      "endLine": 190,
+      "mathContext": "a+b√2+c√3+d√6 = 0 ⟹ a=b=c=d=0 — the complete n = 2 Besicovitch characterization."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question `sqrt2-plus-sqrt3-irrational-oq-02` (formalize Besicovitch's 1940 theorem — square roots of distinct squarefree integers are ℚ-linearly independent) for the **smallest non-trivial case n = 2**, radicands `{1, 2, 3, 6}`:

- **`linearIndependent_one_sqrt2_sqrt3_sqrt6`** — `a + b√2 + c√3 + d√6 = 0` with `a,b,c,d ∈ ℚ` ⟹ `a = b = c = d = 0`, i.e. `{1, √2, √3, √6}` is ℚ-linearly independent (equivalently `[ℚ(√2,√3):ℚ] = 4`).
- **`sqrt3_not_in_Qsqrt2`** — `√3 ∉ ℚ(√2)`, the degree-doubling induction heart that the general sorry-based reduction lacks.

The proof is elementary (no field-theory tower): regroup `α = (a + b√2) + √3·(c + d√2)`, multiply by the ℚ(√2)-conjugate `(c − d√2)` to isolate `√3·(c² − 2d²)`, and conclude with `√3 ∉ ℚ(√2)`.

## Build status — verified, axiom-free

`✔ Built Proofs.Sqrt2PlusSqrt3IrrationalOQ02` (Docker, clean) — 6 theorems, **0 sorries, 0 axioms, 0 `native_decide`**, no `Lean.ofReduceBool`.

## What this PR fixes

The initial wip commit was committed without a successful build and had two defects, both fixed here:

1. **Bad import** `Mathlib.Analysis.Real.Sqrt` (does not exist at the pin) → `Mathlib.Data.Real.Sqrt`.
2. **`¬ IsSquare 3` / `¬ IsSquare 6` claimed provable by kernel `decide`** — but kernel decide gets stuck on `Nat.sqrt` (`Nat.instDecidablePredIsSquare` does not reduce). Replaced with an elementary divisor bound (`n = r² ⟹ r ∣ n ⟹ r ≤ n` via `Nat.le_of_dvd`) plus `interval_cases`/`omega`. Genuinely axiom-free, no kernel-reduction dependence.

`meta.json` + `annotations.json` updated to drop the false "kernel decide" framing and reflect the actual method; `lineCount` 190 → 203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)