### PR TITLE
audit(dirichlet-approximation-theorem-oq-01): clean first audit, honest Tier-B Mathlib delegation

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15884,6 +15884,12 @@
       "lastAudited": "2026-06-18T08:30:11Z",
       "result": "clean",
       "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T10:44:06Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — `dirichlet-approximation-theorem-oq-01`

**Result: CLEAN** (first audit). No integrity issues; tracker bumped 0→1.

### Counts (meta ↔ source, all match)
`proofs/Proofs/DirichletApproximationOQ01.lean` — 101 lines, 4 theorems, 0 defs, 0 sorries, 0 axioms, 0 `native_decide`, 0 `decide`, 0 `True`-stubs, 0 structures. Registered at `Proofs.lean:640` (CI-compiled).

### Tier classification: B (verified/mathlib) — honest
- `status: verified` justified: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.
- `badge: mathlib` justified: the headline `infinite_good_rat_approx` and the converse `infinite_approx_iff_irrational` are direct one-line delegations to Mathlib's `Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational` / `_iff_irrational`.

### No narrative failure modes
- **No delegation opacity**: every prose field (description, overview text, proofStrategy, keyInsights[0], assumptions, conclusion) explicitly credits Mathlib for the infinitude + converse, as does the file's own "Status" header.
- **originalContributions correctly scoped** to the genuine in-file bridge: `infinite_coprime_approx` (real `InjOn` proof via `Rat.num_div_den`, image-subset computation via `Rat.pos`/`Rat.reduced`/`Rat.cast_def`, `Set.infinite_image_iff` + `Set.Infinite.mono`) and the `exists_good_approx` corollary. No "first/proved/independent" overclaim.
- No axiom masking, no inequality≠theorem, no pipeline inflation, no hidden-import overclaim.

---
Discovered during gallery integrity audit.