### PR TITLE
Fix: sum-of-divisors native_decide → axiomatized

### DIFF
--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -2,11 +2,11 @@
   "id": "sum-of-divisors",
   "title": "Sum of Divisors Function: Properties and Classification",
   "slug": "sum-of-divisors",
-  "description": "Formalizes the arithmetic function σ(n) = Σ_{d|n} d with concrete values, multiplicativity, prime power formula, and number classification. Proves σ(p) = p+1 for all primes, σ(mn) = σ(m)σ(n) when gcd(m,n)=1, σ(p^k) = Σ p^i, and classifies deficient/perfect/abundant numbers. Verifies amicable pairs (220,284) and (1184,1210). Proves 12 is the smallest abundant number. 81 theorems, 4 definitions, 0 axioms.",
+  "description": "Formalizes the arithmetic function σ(n) = Σ_{d|n} d with concrete values, multiplicativity, prime power formula, and number classification. Proves σ(p) = p+1 for all primes, σ(mn) = σ(m)σ(n) when gcd(m,n)=1, σ(p^k) = Σ p^i, and classifies deficient/perfect/abundant numbers. Verifies amicable pairs (220,284) and (1184,1210). Proves 12 is the smallest abundant number. 81 theorems, 4 definitions; concrete values and classifications use native_decide (Lean.ofReduceBool axiom).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfDivisors.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "perfect-numbers",
       "amicable-numbers"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma.",
+    "axiomCount": 1,
+    "assumptions": "Depends on `Lean.ofReduceBool`: concrete σ-values, classification examples (perfect/abundant/deficient), amicable-pair checks, and the smallest-abundant minimality proof are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction rather than producing a kernel-checked proof. 0 sorries; no literal `axiom` declarations (leanFile.axiomCount = 0).",
     "lineCount": 549,
     "theoremCount": 81,
     "definitionCount": 5,
@@ -52,7 +52,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Sum of divisors function fully formalized: concrete values, multiplicativity, prime power formula, complete number classification (deficient/perfect/abundant with exhaustivity and exclusivity), amicable pairs (220,284) and (1184,1210), 12 as smallest abundant. 81 theorems, 549 lines, 0 axioms.",
+    "summary": "Sum of divisors function fully formalized: concrete values, multiplicativity, prime power formula, complete number classification (deficient/perfect/abundant with exhaustivity and exclusivity), amicable pairs (220,284) and (1184,1210), 12 as smallest abundant. 81 theorems, 549 lines; concrete computations use native_decide (Lean.ofReduceBool axiom).",
     "implications": "This formalization provides the algebraic infrastructure for one of number theory's richest subjects. The multiplicativity of σ connects via Dirichlet series to ζ(s)ζ(s-1), linking divisor sums to the Riemann zeta function. Robin's theorem (1984) shows σ(n) < e^γ n ln(ln(n)) for n > 5040 iff RH holds — a startling connection between a simple arithmetic function and the most famous open problem in mathematics. The classification into deficient/perfect/abundant has been studied since Nicomachus (~100 CE), yet the question of odd perfect numbers remains unsolved after 2000 years of effort.",
     "openQuestions": [
       "Are there odd perfect numbers? Any odd perfect number must satisfy n > 10^1500 and have at least 101 prime factors (Ochem-Rao 2012). In Lean, formalizing even the simplest constraint — that an odd perfect number must have a prime factor ≡ 1 (mod 4) — would require connecting σ(p^a) ≡ 0 (mod 4) conditions to the perfect number equation σ(n) = 2n",


### PR DESCRIPTION
## Fix

`sum-of-divisors` was marked `verified` / badge `mathlib` / `axiomCount: 0` ("None. Fully machine-verified…", "81 theorems, 549 lines, 0 axioms"). But its headline deliverables are discharged by `native_decide`, which depends on `Lean.ofReduceBool` — so the entry is not axiom-free.

## Evidence

`SumOfDivisors.lean` — the entry's "Properties and Classification" deliverables (named theorems, listed in `originalContributions`) use `native_decide` directly, e.g.:

```
55  theorem sigma_one_eq : sigma 1 1 = 1 := by native_decide
169 theorem six_is_perfect : IsPerfect 6 := by ... native_decide
181 theorem twelve_is_abundant : IsAbundant 12 := by ... native_decide
```

Roughly 58 named theorems (concrete σ-values `sigma_*_eq`, prime values, divisor counts, classification `*_is_perfect`/`*_is_abundant`/`*_is_deficient`, amicable pairs `sigma_220`/`sigma_284`/`sigma_1184`/`sigma_1210`, smallest-abundant minimality) route through `native_decide`. `#print axioms` on any of them lists `Lean.ofReduceBool`.

Per the project Axiom Integrity Policy, `native_decide` discharging substantive deliverables must count: `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`.

**Before**: status `verified`, badge `mathlib`, `axiomCount: 0`, "0 axioms" in assumptions/description/conclusion.
**After**: status `axiomatized`, badge `axiom`, `axiomCount: 1`, `Lean.ofReduceBool` disclosed; "0 axioms" prose de-claimed. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only change; no Lean source modified.

Closes part of #25409

---
Automated fix by lean-mechanic agent.