### PR TITLE
research(dirichlet-approximation-oq-01): re-land orphaned knowledge file

### DIFF
--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-01.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-01.json
@@ -1,0 +1,71 @@
+{
+  "slug": "dirichlet-approximation-theorem-oq-01",
+  "title": "Infinitude of good rational approximations |α − p/q| < 1/q² for irrational α",
+  "problemStatement": "Upgrade the parent one-shot Dirichlet pigeonhole bound to the infinitude statement: for every irrational α there are infinitely many fractions p/q in lowest terms with |α − p/q| < 1/q². Equivalently, the set {q : ℚ | |α − q| < 1/q.den²} is infinite, and this characterizes irrationality.",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 7,
+  "path": "full",
+  "started": "2026-06-18",
+  "lastUpdate": "2026-06-18",
+  "tags": [
+    "number-theory",
+    "diophantine-approximation",
+    "rational-approximation",
+    "irrational-numbers",
+    "infinitude"
+  ],
+  "currentState": {
+    "summary": "Formalized (PR #25627). Headline infinitude delegates to Mathlib; the original contribution is the bridge to the classical coprime integer-pair form. 0 sorry / 0 axiom. CI is the build gate (local Docker saturated this cycle).",
+    "leanFile": "proofs/Proofs/DirichletApproximationOQ01.lean",
+    "sorries": 0,
+    "axioms": 0
+  },
+  "knowledge": {
+    "insights": [
+      "The infinitude statement is ALREADY in Mathlib: Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational (and the iff version _iff_irrational) in Mathlib.NumberTheory.DiophantineApproximation.Basic. The research value is therefore presentational: re-expressing the set-of-rationals form as the classical coprime integer-pair statement.",
+      "The bridge is a transport along the injection q ↦ (q.num, q.den): rationals are stored in lowest terms (Rat.reduced gives gcd(|num|,den)=1) with positive denominator (Rat.pos), and (q.num:ℝ)/(q.den:ℝ) = (q:ℝ) (Rat.cast_def), so the image pair has IDENTICAL error and bound — no analytic estimate is repeated.",
+      "Infinitude transports cleanly: Set.infinite_image_iff (InjOn ⇒ image infinite iff domain infinite) + Set.Infinite.mono (subset preserves infinitude) reduce the whole bridge to structural ℚ facts.",
+      "The hypothesis is sharp: Mathlib's iff shows a real admits infinitely many good approximations exactly when irrational (rationals have finitely many, finite_rat_abs_sub_lt_one_div_den_sq), so Irrational α is necessary and sufficient, not just convenient."
+    ],
+    "builtItems": [
+      "infinite_good_rat_approx (DirichletApproximationOQ01.lean:49) — headline infinitude, Mathlib delegation",
+      "infinite_coprime_approx (DirichletApproximationOQ01.lean:61) — ORIGINAL: classical coprime (p,q) form via num/den injection",
+      "infinite_approx_iff_irrational (DirichletApproximationOQ01.lean:89) — sharp converse, Mathlib iff",
+      "exists_good_approx (DirichletApproximationOQ01.lean:96) — one-shot existence corollary from infinitude"
+    ],
+    "mathlibGaps": [
+      "No Mathlib lemma for finiteness of rationals with bounded denominator inside a bounded interval (would enable the 'unbounded denominators' strengthening). Mathlib's finite_rat_abs_sub_lt_one_div_den_sq is for RATIONAL targets only (uses ξ.den) and does not apply to irrational ξ; a bespoke num/den-injection finiteness argument (~25-30 lines, real→int cast bounds) would be required.",
+      "No classical coprime-integer-pair form of the infinitude theorem in Mathlib — only the set-of-rationals form. This file supplies that reformulation."
+    ],
+    "nextSteps": [
+      "Confirm CI green on PR #25627 (local Docker was saturated; single-module verification build queued in background).",
+      "Strengthening (potential follow-up OQ): infinitely many approximations with UNBOUNDED denominators (∀ N, ∃ good q with q.den ≥ N), via proving the bounded-denominator subset finite — a HARD-but-known finiteness lemma well-suited to Aristotle.",
+      "Further follow-up: Hurwitz's sharp constant 1/(√5 q²) and its optimality (golden ratio) — substantially harder, likely its own entry."
+    ],
+    "progressSummary": "PROGRESS: infinitude upgrade formalized (PR #25627). Original contribution = classical coprime-pair reformulation; 0 sorry / 0 axiom. Awaiting CI build confirmation."
+  },
+  "approaches": [
+    {
+      "name": "Transport Mathlib infinitude along the num/den injection",
+      "outcome": "success",
+      "notes": "Set.infinite_image_iff + Set.Infinite.mono carry infinitude from {q:ℚ|...} to the coprime (p,q) set; image-subset proved via Rat.pos/Rat.reduced/Rat.cast_def."
+    }
+  ],
+  "knownResults": [
+    "Dirichlet (1842): one-shot bound (parent entry).",
+    "Hardy & Wright, Theorem 193: infinitely many p/q with |α − p/q| < 1/q² for irrational α.",
+    "Hurwitz: sharp constant 1/(√5 q²), best possible.",
+    "Mathlib: Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational and the iff characterization."
+  ],
+  "references": [
+    "Mathlib/NumberTheory/DiophantineApproximation/Basic.lean",
+    "Hardy & Wright, An Introduction to the Theory of Numbers, Thm 193",
+    "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem"
+  ],
+  "relatedProofs": [
+    "dirichlet-approximation-theorem (parent, one-shot bound)"
+  ]
+}


### PR DESCRIPTION
Follow-up to the merged #25627. The problem knowledge file (`src/data/research/problems/dirichlet-approximation-theorem-oq-01.json`) was committed just after the deployer fast-merged #25627, so it never reached main. This re-lands it — research bookkeeping only, no Lean or gallery changes.

Captures the next-step worth not losing: the **unbounded-denominators** strengthening (∀ N, ∃ good q with q.den ≥ N) needs a bounded-denominator finiteness lemma that Mathlib lacks for irrational targets (`finite_rat_abs_sub_lt_one_div_den_sq` is rational-target only) — a HARD-but-known ~25-30 line argument well-suited to Aristotle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)