### PR TITLE
research(cube-root-3-irrational-oq-04): register + build-verify Stream.lean CF bridge

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -590,6 +590,7 @@ import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02
 import Proofs.CubeRoot3IrrationalOQ04
 import Proofs.CubeRoot3IrrationalOQ04Helpers
+import Proofs.CubeRoot3IrrationalOQ04Stream
 import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational

--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean
@@ -4,11 +4,12 @@ Bridge: the per-aᵢ floor lemmas ⟷ Mathlib's canonical CF API IntFractPair.st
 Research: cube-root-3-irrational-oq-04, open question #1 (carried since S5).
 Date: 2026-06-16 (researcher-3).
 
-STATUS: build-PENDING orphan. Docker was DOWN this session, so this file has
-NOT been elaborated. It is intentionally NOT registered in `proofs/Proofs.lean`,
-so it cannot affect the gallery build until a future Docker-up session
-build-verifies it and adds the import line (the established "register-orphan"
-workflow). The MATHEMATICS is independently verified by
+STATUS: REGISTERED + build-verified 2026-06-18 (researcher-12). Elaborated
+under the Docker wrapper (`Proofs.CubeRoot3IrrationalOQ04Stream`,
+`✔ Built ... (158s)`, full Mathlib pulled transitively) and registered in
+`proofs/Proofs.lean`, so it is now part of the gallery build. 0 sorries,
+0 axioms, 0 native_decide — the parent entry stays verified/original/0-axioms.
+The MATHEMATICS is also independently verified by
 `research/problems/cube-root-3-irrational-oq-04/verify_intfractpair_stream.py`
 (PASS: stream b-components match the proven prefix a₀..a₁₁ and the fract-chain
 identity fract(xᵢ) = xᵢ - aᵢ holds exactly at 120-digit precision).
@@ -69,15 +70,16 @@ Checked against the pinned Mathlib4 checkout `2df2f0150c` (= lakefile
 `import Mathlib.Data.Real.Irrational` still resolves, and this orphan pulls full
 Mathlib transitively via `Proofs.CubeRoot3IrrationalOQ04`.
 
-The numbers are cert-verified and the only name drift (`sub_int`) is now fixed,
-so this orphan should build first-try on the next Docker-up session; remaining
-risk is purely tactic-level (`simp`/`simpa` normalising `IntFractPair.of` /
-`Int.fract` and the `⁻¹ ↔ 1/·` bridge), not name resolution.
+The numbers are cert-verified and the name drift (`sub_int`) was fixed in S36;
+the file built clean on 2026-06-18 (researcher-12) with no further edits to the
+tactic bodies — the `simp`/`simpa` reductions (`IntFractPair.of` / `Int.fract`
+normalisation and the `⁻¹ ↔ 1/·` bridge) went through as written.
 -/
 
 import Proofs.CubeRoot3IrrationalOQ04
 
 open CubeRoot3Irrational
+open CubeRoot3IrrationalOQ04
 open GenContFract
 
 namespace CubeRoot3IrrationalOQ04Stream

--- a/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
@@ -28,7 +28,12 @@
       "cbrt3_floor_eq_one: ⌊∛3⌋ = 1 (a₀), from the cube bounds 1 < 3 < 8",
       "cbrt3_a1 … cbrt3_a11: the next eleven partial quotients 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, each as an explicit nested-reciprocal floor identity",
       "A uniform cubing-sandwich template: cube a rational two-sided bound on the current tail xₙ, substitute (∛3)³ = 3, and discharge the resulting integer inequality, then propagate through the reciprocal/subtraction chain by linarith",
-      "Verification that the prefix matches OEIS A002945 through a₁₁, with the cubing gap shrinking to ≈10⁻⁵ at the sixth and seventh convergents"
+      "Verification that the prefix matches OEIS A002945 through a₁₁, with the cubing gap shrinking to ≈10⁻⁵ at the sixth and seventh convergents",
+      "CubeRoot3IrrationalOQ04Stream.lean: a bridge connecting the ad-hoc nested-floor lemmas cbrt3_a0…cbrt3_a11 to Mathlib's canonical continued-fraction machinery, proving (IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ for every n = 0…11 via a reusable one-reciprocation step lemma cbrt3_stream_succ. This is concrete progress on open question #1 (relate the certified prefix to the canonical CF API)."
+    ],
+    "additionalFiles": [
+      "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
+      "Proofs/CubeRoot3IrrationalOQ04Stream.lean"
     ]
   },
   "overview": {
@@ -133,7 +138,11 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 19
+    "theoremCount": 19,
+    "additionalFiles": [
+      "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
+      "Proofs/CubeRoot3IrrationalOQ04Stream.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Registers the previously build-pending orphan `CubeRoot3IrrationalOQ04Stream.lean` in `proofs/Proofs.lean` and documents it in `meta.json`. The file is now part of the gallery build.

## What the file does

Bridges the entry's ad-hoc nested-floor lemmas (`cbrt3_a0…cbrt3_a11`) to Mathlib's **canonical** continued-fraction API, proving

```
(IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ    for n = 0…11
```

via a reusable one-reciprocation step lemma `cbrt3_stream_succ`. This is concrete progress on the entry's **open question #1** (relate the certified partial-quotient prefix to Mathlib's canonical CF machinery `GenContFract.of` / `IntFractPair.stream`).

## Verification

Build-verified under the Docker wrapper:

```
✔ [7746/7746] Built Proofs.CubeRoot3IrrationalOQ04Stream (158s)
```

- **0 sorries, 0 axioms, 0 native_decide** (37 theorems/lemmas)
- The math is independently cert-verified by `verify_intfractpair_stream.py` (stream b-components match the proven prefix a₀..a₁₁; fract-chain identity holds at 120-digit precision)
- The parent entry stays **verified / original / 0-axioms** — the orphan adds no assumptions

## Changes

- `proofs/Proofs.lean`: add `import Proofs.CubeRoot3IrrationalOQ04Stream`
- `proofs/Proofs/CubeRoot3IrrationalOQ04Stream.lean`: docstring STATUS flipped from build-PENDING to build-verified 2026-06-18
- `src/data/proofs/cube-root-3-irrational-oq-04/meta.json`: document the bridge file under `additionalFiles` and `originalContributions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)