### PR TITLE
Fix: lagrange-four-squares-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "lagrange-four-squares-oq-01",
   "title": "Computational Complexity of Four-Square Representations (OQ-01)",
   "slug": "lagrange-four-squares-oq-01",
-  "description": "Addresses the computational aspects of Lagrange's four-square theorem: given n, how efficiently can one find integers a, b, c, d with a² + b² + c² + d² = n? The formalization establishes component bounds (each ≤ √n), implements a computable greedy search algorithm, verifies correctness for all n ≤ 100 via native_decide, analyzes uniqueness of sorted representations, identifies numbers of the excluded form 4^a(8b+7) that require all four nonzero squares, and proves the bounds on the search space. All results are 0 sorry and 0 axioms, with computational proofs using Mathlib's Nat.sum_four_squares.",
+  "description": "Addresses the computational aspects of Lagrange's four-square theorem: given n, how efficiently can one find integers a, b, c, d with a² + b² + c² + d² = n? The formalization establishes component bounds (each ≤ √n), implements a computable greedy search algorithm, verifies correctness for all n ≤ 100 via native_decide, analyzes uniqueness of sorted representations, identifies numbers of the excluded form 4^a(8b+7) that require all four nonzero squares, and proves the bounds on the search space. All results are 0 sorry; the computational verification theorems are discharged by native_decide (depending on the Lean.ofReduceBool axiom), and the core existence result uses Mathlib's Nat.sum_four_squares.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeFourSquaresOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,10 +15,10 @@
       "quadratic-forms",
       "sums-of-squares"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.sum_four_squares",
@@ -26,7 +26,7 @@
         "module": "Mathlib.NumberTheory.SumFourSquares"
       }
     ],
-    "assumptions": "Core existential result (four_square_exists_bounded) uses Mathlib's Nat.sum_four_squares. Algorithm, bounds, and verification proofs are independently proved.",
+    "assumptions": "Core existential result (four_square_exists_bounded) uses Mathlib's Nat.sum_four_squares. The 58 computational verification theorems (find_*, check_all_50, check_all_100, excluded_*, *_needs_*, unique_rep_*, two_reps_*, etc.) are discharged by native_decide, which trusts the Lean compiler and depends on the Lean.ofReduceBool axiom (#print axioms lists it). The entry is therefore axiomatized, not axiom-free. The literal `axiom` declaration count in the Lean file remains 0; the single counted assumption is Lean.ofReduceBool introduced via native_decide.",
     "lineCount": 395,
     "theoremCount": 71,
     "definitionCount": 9,
@@ -124,7 +124,7 @@
       "title": "Summary",
       "startLine": 367,
       "endLine": 395,
-      "summary": "Closing summary docstring: a results table tallying the proved declarations (0 axioms, 0 sorries) — component bounds, greedy algorithm, algorithm correctness for n = 0..10/30/50/99/100, batch verification for n ≤ 100, uniqueness counts, excluded-form detection, structural bounds, finite search, and Lagrange-with-bounds — plus the key insights (the √n component bound makes search polynomial; the greedy algorithm always succeeds by Lagrange; 4^a(8b+7) needs all four squares nonzero; the decision problem is trivially YES while finding a representation is nontrivial).",
+      "summary": "Closing summary docstring: a results table tallying the proved declarations (0 sorries; the computational verifications rely on native_decide / Lean.ofReduceBool) — component bounds, greedy algorithm, algorithm correctness for n = 0..10/30/50/99/100, batch verification for n ≤ 100, uniqueness counts, excluded-form detection, structural bounds, finite search, and Lagrange-with-bounds — plus the key insights (the √n component bound makes search polynomial; the greedy algorithm always succeeds by Lagrange; 4^a(8b+7) needs all four squares nonzero; the decision problem is trivially YES while finding a representation is nontrivial).",
       "mathContext": "Recap of the entry: existence of a four-square representation is guaranteed (Lagrange), and this file adds the computable greedy witness together with simultaneous component bounds (each ≤ √n) and the Legendre excluded-form characterization."
     }
   ],


### PR DESCRIPTION
## Fix

`lagrange-four-squares-oq-01` was labelled `verified` / badge `mathlib` / `axiomCount 0` with prose asserting "0 axioms", but its 58 named computational verification theorems are discharged by `native_decide` — which trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom. Per the project's axiom-integrity policy, a substantive result presented as verified that relies on `native_decide` must be `axiomatized` with `Lean.ofReduceBool` disclosed.

## Evidence

`by native_decide` is the actual tactic in 58 named theorems (verified via `/tmp/mech_named.py`):
`find_0..find_100`, `find_*_val`, `check_all_50`, `check_all_100`, `excluded_*`, `not_excluded_*`, `*_needs_*`, `unique_rep_*`, `two_reps_*`, `three_reps_*`, `four_reps_36`, `sorted_100`, `excluded_form_check_50`. These are the entry's headline computational deliverables (per `originalContributions`).

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`; description/conclusion claimed "0 axioms".
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`; `assumptions` discloses `Lean.ofReduceBool` via `native_decide`; "0 axioms" prose scrubbed. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only; no Lean source change.

Closes #25409 (partial — one entry of the residual set)

---
Automated fix by lean-mechanic agent.