### PR TITLE
research(bpg-oq030101): de-axiomatize D(5)=12 — kernel-verified, no Lean.ofReduceBool

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
@@ -225,4 +225,8 @@ theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by
     rintro d ⟨H, hcard, hadm, rfl⟩
     exact admissible_5tuple_diam_ge_12 H hcard hadm
 
+-- Axiom-integrity check: must list only propext / Classical.choice / Quot.sound
+-- (no Lean.ofReduceBool), confirming the de-axiomatized headline is kernel-verified.
+#print axioms minAdmissibleDiameter_5
+
 end BoundedPrimeGapsOQ03OQ01OQ01

--- a/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean
@@ -14,7 +14,10 @@
   Engelsma-246 barrier.
 
   Upper bound `D(5) ≤ 12`: the admissible witness {0,2,6,8,12} (reusing the
-  verified `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12`).
+  verified `BoundedPrimeGaps.admissible_quintuple_0_2_6_8_12`); its diameter is
+  computed symbolically by `fsDiameter_0_2_6_8_12` (`max' = 12`, `min' = 0`), so
+  the headline `D(5) = 12` is now `native_decide`-free and carries **no**
+  `Lean.ofReduceBool` axiom — the whole result is fully kernel-verified.
 
   Lower bound `D(5) ≥ 12` (`admissible_5tuple_diam_ge_12`): a self-contained,
   `native_decide`-free parity argument mirroring the verified parent lemma
@@ -42,6 +45,33 @@ open Nat Finset BoundedPrimeGaps BoundedPrimeGapsOQ03OQ01
 theorem admissible_5tuple_0_2_6_8_12 :
     IsAdmissible ({0, 2, 6, 8, 12} : Finset ℕ) :=
   admissible_quintuple_0_2_6_8_12
+
+/-- `fsDiameter {0,2,6,8,12} = 12`, proved symbolically (`max' = 12`,
+    `min' = 0`) so that the headline `D(5) = 12` carries **no**
+    `Lean.ofReduceBool` axiom. This replaces the previous `native_decide`
+    closed-term reductions of the witness diameter, leaving the whole entry
+    fully kernel-verified. -/
+theorem fsDiameter_0_2_6_8_12 :
+    fsDiameter ({0, 2, 6, 8, 12} : Finset ℕ) = 12 := by
+  have hne : ({0, 2, 6, 8, 12} : Finset ℕ).Nonempty := ⟨0, by decide⟩
+  have hmax : ({0, 2, 6, 8, 12} : Finset ℕ).max' hne = 12 := by
+    apply le_antisymm
+    · apply Finset.max'_le
+      intro y hy
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+      omega
+    · apply Finset.le_max'
+      decide
+  have hmin : ({0, 2, 6, 8, 12} : Finset ℕ).min' hne = 0 := by
+    apply le_antisymm
+    · apply Finset.min'_le
+      decide
+    · apply Finset.le_min'
+      intro y hy
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+      omega
+  unfold fsDiameter
+  rw [dif_pos hne, hmax, hmin]
 
 /-- **Lower bound — the real content.** Every admissible 5-tuple has diameter
     ≥ 12. Parity (mod 2) forces same parity; then diameter < 12 confines the set
@@ -186,11 +216,11 @@ theorem minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 := by
   apply le_antisymm
   · -- Upper: {0,2,6,8,12} witnesses D(5) ≤ 12
     apply csInf_le ⟨0, fun _ _ => Nat.zero_le _⟩
-    exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+    exact ⟨{0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, fsDiameter_0_2_6_8_12⟩
   · -- Lower: every admissible 5-tuple has diameter ≥ 12
     have hne : Set.Nonempty
         {d | ∃ H : Finset ℕ, H.card = 5 ∧ IsAdmissible H ∧ fsDiameter H = d} :=
-      ⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, by native_decide⟩
+      ⟨12, {0, 2, 6, 8, 12}, by decide, admissible_5tuple_0_2_6_8_12, fsDiameter_0_2_6_8_12⟩
     apply le_csInf hne
     rintro d ⟨H, hcard, hadm, rfl⟩
     exact admissible_5tuple_diam_ge_12 H hcard hadm

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 33
+      "endLine": 36
     },
     "type": "concept",
     "title": "Setup: Admissible Tuples and the D(k) Series",
@@ -27,8 +27,8 @@
     "id": "ann-bgp-oq01-witness",
     "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 39,
-      "endLine": 44
+      "startLine": 42,
+      "endLine": 47
     },
     "type": "theorem",
     "title": "Witness Admissibility: {0,2,6,8,12}",
@@ -45,11 +45,36 @@
     ]
   },
   {
+    "id": "ann-bgp-oq01-diameter",
+    "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Symbolic Witness Diameter: fsDiameter {0,2,6,8,12} = 12",
+    "content": "fsDiameter_0_2_6_8_12 computes the witness diameter symbolically, replacing the previous native_decide. It proves max' {0,2,6,8,12} = 12 and min' {0,2,6,8,12} = 0, each by le_antisymm: the ≤ direction via Finset.max'_le / le_min' (reducing to ∀ y ∈ S, bound, closed by simp [mem_insert] + omega), the ≥ direction via Finset.le_max' / min'_le with a decidable membership witness. Unfolding fsDiameter (the set is nonempty) then gives 12 - 0 = 12. Because no native_decide is used, the headline D(5)=12 no longer depends on Lean.ofReduceBool and is fully kernel-verified.",
+    "mathContext": "$\\mathrm{fsDiameter}(H) = \\max'(H) - \\min'(H)$ when $H \\ne \\emptyset$. For $H = \\{0,2,6,8,12\\}$: $\\max' = 12$, $\\min' = 0$, so the diameter is $12$. Proving the extrema symbolically (rather than by closed-term kernel reduction) keeps the proof inside the ordinary foundational axioms.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.max'",
+      "Finset.min'",
+      "axiom-free verification",
+      "native_decide elimination"
+    ],
+    "prerequisites": [
+      "Finset.max'_le",
+      "Finset.le_max'",
+      "Finset.min'_le",
+      "Finset.le_min'"
+    ]
+  },
+  {
     "id": "ann-bgp-oq01-parity",
     "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 46,
-      "endLine": 87
+      "startLine": 77,
+      "endLine": 115
     },
     "type": "theorem",
     "title": "Reduction: Same Parity Confines H to a 6-Set",
@@ -72,12 +97,12 @@
     "id": "ann-bgp-oq01-main",
     "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 184,
-      "endLine": 198
+      "startLine": 212,
+      "endLine": 226
     },
     "type": "theorem",
     "title": "Main Result: D(5) = 12",
-    "content": "minAdmissibleDiameter_5 proves minAdmissibleDiameter 5 = 12 by le_antisymm, mirroring the parent's minAdmissibleDiameter_3 assembly exactly. The upper half (≤) applies csInf_le with the witness {0,2,6,8,12}: its card is 5 (by decide), it is admissible (admissible_5tuple_0_2_6_8_12), and its diameter is 12 (by native_decide). The lower half (≥) supplies nonemptiness of the diameter set from the same witness and then applies le_csInf, discharging each member d via admissible_5tuple_diam_ge_12. The only native_decide calls are the closed-term card and diameter checks of the concrete witness.",
+    "content": "minAdmissibleDiameter_5 proves minAdmissibleDiameter 5 = 12 by le_antisymm, mirroring the parent's minAdmissibleDiameter_3 assembly exactly. The upper half (≤) applies csInf_le with the witness {0,2,6,8,12}: its card is 5 (by decide), it is admissible (admissible_5tuple_0_2_6_8_12), and its diameter is 12 (fsDiameter_0_2_6_8_12, proved symbolically). The lower half (≥) supplies nonemptiness of the diameter set from the same witness and then applies le_csInf, discharging each member d via admissible_5tuple_diam_ge_12. No native_decide is used anywhere, so #print axioms shows only the foundational axioms — D(5)=12 is fully kernel-verified.",
     "mathContext": "$D(5) = \\inf\\{d : \\exists H,\\ |H|=5 \\wedge \\text{admissible}(H) \\wedge \\mathrm{fsDiameter}(H) = d\\}$. The antisymmetric split sets $D(5) \\le 12$ from the explicit admissible witness of diameter 12 and $D(5) \\ge 12$ from the universal lower bound, pinning $D(5) = 12$ — the $k=5$ entry of OEIS A008407.",
     "significance": "key",
     "relatedConcepts": [
@@ -96,8 +121,8 @@
     "id": "ann-bgp-oq01-pigeonhole",
     "proofId": "bounded-prime-gaps-oq-03-oq-01-oq-01",
     "range": {
-      "startLine": 88,
-      "endLine": 182
+      "startLine": 116,
+      "endLine": 210
     },
     "type": "insight",
     "title": "Mod-3 Pigeonhole: Two Forced Omissions Beat a 5-Set",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -119,7 +119,7 @@
   ],
   "leanFile": {
     "namespace": "BoundedPrimeGapsOQ03OQ01OQ01",
-    "lineCount": 226,
+    "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-06-17",
     "axiomCount": 0,
     "assumptions": "None beyond Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). 0 sorries, 0 literal axiom declarations, 0 native_decide. The headline equality minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 is fully kernel-verified: the upper-bound witness diameter is now computed symbolically by fsDiameter_0_2_6_8_12 (max' = 12, min' = 0) rather than by native_decide, so #print axioms no longer lists Lean.ofReduceBool. The lower bound admissible_5tuple_diam_ge_12 is a self-contained symbolic parity-plus-mod-3 argument. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
-    "lineCount": 226,
+    "lineCount": 232,
     "theoremCount": 4,
     "definitionCount": 0,
     "originalContributions": [
@@ -87,7 +87,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. Both bounds are fully symbolic (native_decide-free): the lower bound interrogates only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument, and the upper-bound witness diameter is computed symbolically by `fsDiameter_0_2_6_8_12`. The result carries no `Lean.ofReduceBool` axiom and is fully kernel-verified. 226 lines, 4 theorems, 0 sorries, 0 axioms.",
+    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. Both bounds are fully symbolic (native_decide-free): the lower bound interrogates only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument, and the upper-bound witness diameter is computed symbolically by `fsDiameter_0_2_6_8_12`. The result carries no `Lean.ofReduceBool` axiom and is fully kernel-verified. 232 lines, 4 theorems, 0 sorries, 0 axioms.",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, and now $D(5)=12$ all machine-verified, the smallest five prime-constellation diameters are formally established in Lean 4. The two-triple counting argument is the natural successor to the single-AP obstruction used for $D(4)$ and extends the reusable proof infrastructure (parity filtration, residue-complete-block counting) toward $D(6)=16$ and beyond. Under the Elliott–Halberstam conjecture, $D(5)=12$ is the exact predicted span for prime quintuples $n, n+2, n+6, n+8, n+12$.",
     "openQuestions": [
       "Prove $D(6)=16$ by extending the block-counting argument: the candidate window widens and the mod-5 obstruction must be combined with the mod-2 and mod-3 ones used here.",

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-17",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,16 +15,17 @@
       "combinatorics",
       "prime-constellations"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-06-17",
-    "axiomCount": 1,
-    "assumptions": "Lean.ofReduceBool (via native_decide), 0 sorries, 0 literal axiom declarations. The headline equality minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 proves achievability by discharging the witness card/diameter checks with native_decide, so its #print axioms includes Lean.ofReduceBool (closed-term kernel reduction). The lower bound admissible_5tuple_diam_ge_12 is itself native_decide-free and fully symbolic, but the presented D(5)=12 result depends on the native_decide upper bound. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
-    "lineCount": 198,
-    "theoremCount": 3,
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). 0 sorries, 0 literal axiom declarations, 0 native_decide. The headline equality minAdmissibleDiameter_5 : minAdmissibleDiameter 5 = 12 is fully kernel-verified: the upper-bound witness diameter is now computed symbolically by fsDiameter_0_2_6_8_12 (max' = 12, min' = 0) rather than by native_decide, so #print axioms no longer lists Lean.ofReduceBool. The lower bound admissible_5tuple_diam_ge_12 is a self-contained symbolic parity-plus-mod-3 argument. Reuses the verified admissible_quintuple_0_2_6_8_12 witness from BoundedPrimeGaps.lean.",
+    "lineCount": 226,
+    "theoremCount": 4,
     "definitionCount": 0,
     "originalContributions": [
       "admissible_5tuple_diam_ge_12: every admissible 5-tuple has diameter ≥ 12, via a fully symbolic (native_decide-free) parity-plus-mod-3 argument interrogating only p ∈ {2,3}",
+      "fsDiameter_0_2_6_8_12: the witness diameter fsDiameter {0,2,6,8,12} = 12 proved symbolically (max' = 12, min' = 0), eliminating the last native_decide and the Lean.ofReduceBool axiom so D(5)=12 is fully kernel-verified",
       "minAdmissibleDiameter_5: D(5) = 12, completing the verified chain D(2)=2, D(3)=6, D(4)=8, D(5)=12 in OEIS A008407",
       "admissible_5tuple_0_2_6_8_12: the witness {0,2,6,8,12} is admissible (delegated to the verified library lemma admissible_quintuple_0_2_6_8_12)"
     ]
@@ -32,7 +33,7 @@
   "overview": {
     "historicalContext": "The minimum admissible diameter function $D(k)$ (OEIS A008407) encodes the geometry of prime constellations. Hardy and Littlewood's 1923 Conjecture B predicted infinitely many prime $k$-tuples $\\{n+h_1,\\ldots,n+h_k\\}$ for every admissible $k$-tuple $\\{h_i\\}$; the quantity $D(k)$ is the smallest span any such configuration can have.\n\nThe first few values $D(2)=2, D(3)=6, D(4)=8, D(5)=12$ correspond to the famous patterns twin primes $\\{n,n+2\\}$, prime triples $\\{n,n+2,n+6\\}$, prime quadruples $\\{n,n+2,n+6,n+8\\}$, and prime quintuples $\\{n,n+2,n+6,n+8,n+12\\}$.\n\nThe Polymath 8b project (2014) and the Maynard–Tao breakthrough made $D(k)$ computationally important: Maynard's theorem yields bounded prime gaps of size $D(k)$ for suitable $k$. BoundedPrimeGapsOQ03OQ01 proved $D(2)=2$ and $D(3)=6$; the sibling OQ-04 file proved $D(4)=8$. This file answers the next rung, $D(5)=12$, explicitly listed as an open question in the OQ-04 conclusion.",
     "problemStatement": "Prove that the minimum diameter of an admissible 5-tuple is exactly 12:\n1. (Upper bound) $\\{0,2,6,8,12\\}$ is an admissible 5-tuple of diameter 12.\n2. (Lower bound) No admissible 5-tuple has diameter $< 12$.",
-    "proofStrategy": "**Upper bound** $D(5) \\le 12$: the witness $\\{0,2,6,8,12\\}$ is admissible (the verified `admissible_quintuple_0_2_6_8_12` from BoundedPrimeGaps.lean) and has diameter 12, giving membership in the diameter set; `csInf_le` finishes.\n\n**Lower bound** $D(5) \\ge 12$ (`admissible_5tuple_diam_ge_12`): suppose $H$ is admissible with $|H|=5$ and diameter $< 12$; write $m = \\min H$.\n1. *Parity*: admissibility at $p=2$ means $|H \\bmod 2| < 2 = 1$, so every element shares $m$'s parity (a mixed pair would make the image $\\{0,1\\}$ of card 2).\n2. *Confinement*: same parity + diameter $< 12$ forces each element to equal $m + 2k$ with $k \\in \\{0,\\ldots,5\\}$, so $H \\subseteq \\{m,m+2,m+4,m+6,m+8,m+10\\}$ (`interval_cases` on $x-m$).\n3. *Two complete triples*: the 6-set splits into $\\{m,m+2,m+4\\}$ and $\\{m+6,m+8,m+10\\}$, each of which is mod-3-complete (residues $\\{0,1,2\\}$). Admissibility at $p=3$ ($|H \\bmod 3| < 3$) forbids $H$ from containing either triple in full.\n4. *Counting contradiction*: $H$ must therefore omit at least one element from EACH triple — two distinct omissions from the 6-set — but a 5-element subset of a 6-set omits exactly one. The card bookkeeping ($\\mathrm{insert}\\,a\\,(\\mathrm{insert}\\,b\\,H)$ has card 7 inside a card-$\\le 6$ set) closes it.\n\nOnly the primes $p \\in \\{2,3\\}$ are interrogated, so the lower bound needs no `Decidable IsAdmissible` instance and uses no `native_decide`.",
+    "proofStrategy": "**Upper bound** $D(5) \\le 12$: the witness $\\{0,2,6,8,12\\}$ is admissible (the verified `admissible_quintuple_0_2_6_8_12` from BoundedPrimeGaps.lean) and has diameter 12 — computed symbolically by `fsDiameter_0_2_6_8_12` ($\\max' = 12$, $\\min' = 0$, via `le_antisymm` with `Finset.max'_le`/`le_max'`), so no `native_decide` is used — giving membership in the diameter set; `csInf_le` finishes.\n\n**Lower bound** $D(5) \\ge 12$ (`admissible_5tuple_diam_ge_12`): suppose $H$ is admissible with $|H|=5$ and diameter $< 12$; write $m = \\min H$.\n1. *Parity*: admissibility at $p=2$ means $|H \\bmod 2| < 2 = 1$, so every element shares $m$'s parity (a mixed pair would make the image $\\{0,1\\}$ of card 2).\n2. *Confinement*: same parity + diameter $< 12$ forces each element to equal $m + 2k$ with $k \\in \\{0,\\ldots,5\\}$, so $H \\subseteq \\{m,m+2,m+4,m+6,m+8,m+10\\}$ (`interval_cases` on $x-m$).\n3. *Two complete triples*: the 6-set splits into $\\{m,m+2,m+4\\}$ and $\\{m+6,m+8,m+10\\}$, each of which is mod-3-complete (residues $\\{0,1,2\\}$). Admissibility at $p=3$ ($|H \\bmod 3| < 3$) forbids $H$ from containing either triple in full.\n4. *Counting contradiction*: $H$ must therefore omit at least one element from EACH triple — two distinct omissions from the 6-set — but a 5-element subset of a 6-set omits exactly one. The card bookkeeping ($\\mathrm{insert}\\,a\\,(\\mathrm{insert}\\,b\\,H)$ has card 7 inside a card-$\\le 6$ set) closes it.\n\nOnly the primes $p \\in \\{2,3\\}$ are interrogated, so the lower bound needs no `Decidable IsAdmissible` instance and uses no `native_decide`.",
     "keyInsights": [
       "Admissibility at $p=2$ is a parity filter (the image mod 2 must have card $< 2$), forcing every admissible set to be monochromatic mod 2 — exactly the step that opens the D(3) and D(4) proofs, reused verbatim here.",
       "The decisive new ingredient at $k=5$ is the two-triple decomposition: under same parity and span $\\le 10$, the candidate window $\\{m,\\ldots,m+10\\}$ partitions into two mod-3-complete triples. Each triple is independently forbidden by $p=3$ admissibility, so a 5-set must drop one element from each — a parity-of-omissions counting argument rather than a single residue clash.",
@@ -52,41 +53,41 @@
       "id": "sec-bgp-oq01-header",
       "title": "Header and Proof Strategy Documentation",
       "startLine": 1,
-      "endLine": 33,
-      "summary": "Module header explaining D(5) = 12, its place in the OEIS A008407 chain D(2)=2, D(3)=6, D(4)=8, D(5)=12, and the upper-bound-witness / symbolic-lower-bound proof plan. Emphasizes that only p ∈ {2,3} are interrogated, so no Decidable IsAdmissible instance is needed."
+      "endLine": 36,
+      "summary": "Module header explaining D(5) = 12, its place in the OEIS A008407 chain D(2)=2, D(3)=6, D(4)=8, D(5)=12, and the symbolic-witness / symbolic-lower-bound proof plan. Emphasizes that the result is fully native_decide-free (no Lean.ofReduceBool axiom) and that only p ∈ {2,3} are interrogated, so no Decidable IsAdmissible instance is needed."
     },
     {
       "id": "sec-bgp-oq01-witness",
-      "title": "Part I: Witness Admissibility {0,2,6,8,12}",
-      "startLine": 35,
-      "endLine": 44,
-      "summary": "admissible_5tuple_0_2_6_8_12 delegates to the verified, registered admissible_quintuple_0_2_6_8_12 from BoundedPrimeGaps.lean, supplying the admissible diameter-12 witness for the upper bound."
+      "title": "Part I: Witness Admissibility & Symbolic Diameter {0,2,6,8,12}",
+      "startLine": 38,
+      "endLine": 75,
+      "summary": "admissible_5tuple_0_2_6_8_12 delegates to the verified, registered admissible_quintuple_0_2_6_8_12 from BoundedPrimeGaps.lean, supplying the admissible diameter-12 witness. fsDiameter_0_2_6_8_12 then proves fsDiameter {0,2,6,8,12} = 12 symbolically (max' = 12 and min' = 0, each by le_antisymm with Finset.max'_le / le_max' / min'_le / le_min'), so the upper bound uses no native_decide and the headline carries no Lean.ofReduceBool axiom."
     },
     {
       "id": "sec-bgp-oq01-lower-bound",
       "title": "Part II: Lower Bound — Same Parity Confines H to a 6-Set",
-      "startLine": 46,
-      "endLine": 87,
+      "startLine": 77,
+      "endLine": 115,
       "summary": "First half of admissible_5tuple_diam_ge_12. By contradiction from diameter < 12: p=2 admissibility forces all elements to share the minimum's parity, and parity plus the diameter bound confine H to the 6-element block {m, m+2, m+4, m+6, m+8, m+10} (interval_cases + omega)."
     },
     {
       "id": "sec-bgp-oq01-mod3",
       "title": "Part II (cont.): Mod-3 Pigeonhole Forces Diameter ≥ 12",
-      "startLine": 88,
-      "endLine": 182,
+      "startLine": 116,
+      "endLine": 210,
       "summary": "Second half: the 6-set splits into two disjoint mod-3-complete triples {m,m+2,m+4} and {m+6,m+8,m+10}; p=3 admissibility forbids H from containing either triple in full, so H omits ≥1 element from each — two omissions from a 6-set, impossible for |H|=5. The `key` lemma encodes the pigeonhole and a nested rcases closes all 9 cases.",
       "mathContext": "Two disjoint mod-3-complete triples $\\Rightarrow \\ge 2$ omissions $\\Rightarrow |H| \\le 4$, contradicting $|H|=5$."
     },
     {
       "id": "sec-bgp-oq01-main-result",
       "title": "Part III: Main Result D(5) = 12",
-      "startLine": 184,
-      "endLine": 198,
-      "summary": "minAdmissibleDiameter_5 = 12 via le_antisymm, exactly mirroring minAdmissibleDiameter_3: upper bound from the admissible witness {0,2,6,8,12} via csInf_le; lower bound from admissible_5tuple_diam_ge_12 via le_csInf."
+      "startLine": 212,
+      "endLine": 226,
+      "summary": "minAdmissibleDiameter_5 = 12 via le_antisymm, exactly mirroring minAdmissibleDiameter_3: upper bound from the admissible witness {0,2,6,8,12} via csInf_le (witness diameter discharged by fsDiameter_0_2_6_8_12); lower bound from admissible_5tuple_diam_ge_12 via le_csInf. No native_decide anywhere."
     }
   ],
   "conclusion": {
-    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. The lower bound is fully symbolic (native_decide-free), interrogating only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument. 198 lines, 3 theorems, 0 sorries, 0 axioms.",
+    "summary": "Proved $D(5)=12$: every admissible 5-tuple has diameter $\\geq 12$, witnessed by $\\{0,2,6,8,12\\}$. Both bounds are fully symbolic (native_decide-free): the lower bound interrogates only $p \\in \\{2,3\\}$ via a parity filter plus a two-mod-3-complete-triple counting argument, and the upper-bound witness diameter is computed symbolically by `fsDiameter_0_2_6_8_12`. The result carries no `Lean.ofReduceBool` axiom and is fully kernel-verified. 226 lines, 4 theorems, 0 sorries, 0 axioms.",
     "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$, and now $D(5)=12$ all machine-verified, the smallest five prime-constellation diameters are formally established in Lean 4. The two-triple counting argument is the natural successor to the single-AP obstruction used for $D(4)$ and extends the reusable proof infrastructure (parity filtration, residue-complete-block counting) toward $D(6)=16$ and beyond. Under the Elliott–Halberstam conjecture, $D(5)=12$ is the exact predicted span for prime quintuples $n, n+2, n+6, n+8, n+12$.",
     "openQuestions": [
       "Prove $D(6)=16$ by extending the block-counting argument: the candidate window widens and the mod-5 obstruction must be combined with the mod-2 and mod-3 ones used here.",
@@ -118,9 +119,9 @@
   ],
   "leanFile": {
     "namespace": "BoundedPrimeGapsOQ03OQ01OQ01",
-    "lineCount": 198,
+    "lineCount": 226,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/BoundedPrimeGapsOQ03OQ01OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

De-axiomatizes the headline result **D(5) = 12** in `bounded-prime-gaps-oq-03-oq-01-oq-01`, flipping the entry from `axiomatized`/`axiom`/axiomCount 1 → `verified`/`original`/axiomCount 0.

The previous upper-bound witness diameter was discharged by `native_decide`, which pulls in `Lean.ofReduceBool` (closed-term kernel reduction) — so the entry was correctly flagged axiomatized. This PR replaces that with a fully symbolic proof:

```lean
theorem fsDiameter_0_2_6_8_12 :
    fsDiameter ({0, 2, 6, 8, 12} : Finset ℕ) = 12
```

proving `max' = 12` and `min' = 0` via `le_antisymm` (`Finset.max'_le`/`le_max'`, `Finset.min'_le`/`le_min'`), so `fsDiameter = max' - min' = 12 - 0 = 12` with no `native_decide` anywhere. The lower bound `admissible_5tuple_diam_ge_12` was already `native_decide`-free.

## Verification

Docker build succeeds, and the in-file `#print axioms` integrity check confirms the headline is fully kernel-verified:

```
'BoundedPrimeGapsOQ03OQ01OQ01.minAdmissibleDiameter_5' depends on axioms:
  [propext, Classical.choice, Quot.sound]
```

No `Lean.ofReduceBool`, no `sorryAx`, 0 sorries, 0 literal axioms.

## Metadata sync

- `status` axiomatized → verified, `badge` axiom → original, `axiomCount` 1 → 0
- `lineCount` 198 → 232, `theoremCount` 3 → 4 (new `fsDiameter_0_2_6_8_12`)
- `assumptions`, `proofStrategy`, `conclusion`, section ranges, and annotations realigned to the symbolic upper bound

Completes the fully kernel-verified chain D(2)=2, D(3)=6, D(4)=8, **D(5)=12** in OEIS A008407.