### PR TITLE
audit(erdos-1054-oq-01): disclose Lean.ofReduceBool from native_decide σ-witnesses

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01/meta.json
@@ -59,9 +59,9 @@
       "sigma_ratio_2a_3b: σ(2^a·3^b) = (2^(a+1)-1)·((3^(b+1)-1)/2) via multiplicativity",
       "sigma_ratio_2a_3b_bound: σ(2^a·3^b) ≤ 3·2^a·3^b"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 352,
-    "assumptions": "2 axiom(s): erdos_1054_almost_all (open conjecture), tao_counterexample_1054 (Tao's result). All theorems fully proved.",
+    "assumptions": "3 assumptions: 2 axioms — erdos_1054_almost_all (open conjecture) and tao_counterexample_1054 (Tao's result) — plus Lean.ofReduceBool, introduced by native_decide. The concrete σ-witness theorems (f_12_le_6 … f_19344_le_5040), inf_many_small_ratio_one_third, and coprime_pow2_pow3 (feeding sigma_ratio_2a_3b) are discharged by native_decide, which trusts the compiler's kernel reduction (Lean.ofReduceBool) rather than being kernel-checked axiom-free. All other theorems are fully proved.",
     "theoremCount": 24,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1054-oq-01

**Result:** issues-fixed (assumption disclosure gap)

Erdős #1054 OQ-01 ("f(n) = o(n) for almost all n"). Re-audit (4th pass). All structural counts verified accurate; status/badge already honest. One assumption-disclosure gap fixed.

### What was wrong
The entry's concrete σ-witness deliverables are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and therefore depends on the `Lean.ofReduceBool` axiom. This dependency was undisclosed:

- `assumptions` claimed **"All theorems fully proved"** — false for the native_decide'd theorems.
- `meta.axiomCount` was **2**, counting only the two conjecture axioms (`erdos_1054_almost_all`, `tao_counterexample_1054`) and omitting `ofReduceBool`.

Named theorems using `native_decide` (load-bearing deliverables, listed in `originalContributions`):
- `f_12_le_6`, `f_28_le_12`, `f_60_le_24`, `f_360_le_120`, `f_2418_le_720`, `f_19344_le_5040` (the σ-witnesses)
- `inf_many_small_ratio_one_third`
- `coprime_pow2_pow3` (feeds `sigma_ratio_2a_3b`)

### Fix (metadata only)
Per the project's `native_decide` axiom-integrity policy:
- `meta.axiomCount`: **2 → 3** (adds `Lean.ofReduceBool`)
- `leanFile.axiomCount`: **stays 2** (counts only literal `axiom` declarations)
- `assumptions`: now discloses the `native_decide` / `Lean.ofReduceBool` dependency

`status`/`badge` remain **axiomatized / axiom** (already correct via the two conjecture axioms) — no status change.

### Verified accurate (no change)
- 352 lines, 24 theorems, 4 defs, 2 literal axioms, 0 sorries, 0 True-stubs
- Registered at `Proofs.lean:845`
- 4 defs are plain data/Prop (no assumption-carrying structures)
- `conclusion.summary` already honestly states results are "proved via concrete native_decide computations"

---
Discovered during gallery integrity audit.