### PR TITLE
audit(sqrt2-plus-sqrt3-irrational-oq-02): clean first audit, verified axiom-free confirmed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15890,6 +15890,12 @@
       "lastAudited": "2026-06-18T10:44:06Z",
       "result": "clean",
       "issues": []
+    },
+    "sqrt2-plus-sqrt3-irrational-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T10:57:11Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

First audit of **sqrt2-plus-sqrt3-irrational-oq-02** (Besicovitch n=2: ℚ-linear independence of {1, √2, √3, √6}).

### Result
All gallery claims match the Lean source `Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean` (registered `Proofs.lean:2930`, CI-compiled).

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 203 | 203 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| status / badge | verified / original | — | honest |

### Integrity checks
- **No hidden axioms**: no `native_decide`, no kernel `decide`, no `sorry`/`admit`, no `True`-stubs. Every grep hit for those tokens is in a comment/docstring → no `Lean.ofReduceBool` → genuinely axiom-free.
- **Tier A original is defensible**: the headline `linearIndependent_one_sqrt2_sqrt3_sqrt6` is a non-vacuous, from-scratch conjugate-multiplication proof; `sqrt3_not_in_Qsqrt2` is a real degree-doubling three-way case split. Mathlib has no Besicovitch / multiquadratic-independence theorem.
- **No delegation opacity / axiom masking**: the description explicitly discloses the Mathlib inputs used (`irrational_sqrt_two`, `irrational_sqrt_ofNat_iff`); `¬IsSquare 3` / `¬IsSquare 6` are proved in-file via an elementary divisor bound + `interval_cases`/`omega`. The "verified, axiom-free" claim is accurate.

No changes to meta.json required. Tracker bump only (`auditCount → 1`, result `clean`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)