### PR TITLE
audit(erdos-104): clean re-audit — open conjecture honestly axiomatized/wip

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3253,9 +3253,9 @@
       "result": "issues-fixed"
     },
     "erdos-104": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:07:44Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "erdos-1040": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `erdos-104` — "Erdős Problem #104: Unit Circles Through Three Points"
**Verdict**: No integrity issues. `status: axiomatized` / `badge: wip` / `axiomCount: 0` / `sorries: 0` all honest.

This is an **open** Erdős problem ($100 prize), so the conservative `axiomatized`/`wip` classification (per the open-conjecture policy) is correct — the headline O(n^{3/2}) bound is *not* claimed proved.

### Verification (against `proofs/Proofs/Erdos104Problem.lean`)
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 330 | 330 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 13 | 13 (incl. `structure UnitCircle`) | ✓ |
| axiomCount | 0 | 0 `axiom` decls, no structure-encoded assumptions | ✓ |
| sorries | 0 | 0 (the only `sorry` token is in a comment on L34) | ✓ |

- **No** `native_decide` / `decide` / `True`-stub theorems → no `Lean.ofReduceBool`, axiom-free.
- `structure UnitCircle` carries only `center : Point` — pure data, **no** Prop/assumption fields → axiomCount 0 honest.
- The headline conjecture is a `def erdos104Conjecture : Prop` (open); `erdos104WeakConjecture`, `erdos104OpenProblem` likewise defs. **Not** asserted as a proved theorem.
- The 4 theorems are genuine supporting lemmas: `two_points_one_circle` (parallelogram-law uniqueness), `two_points_no_circle` (triangle inequality), `strong_implies_weak` (real implication between the two conjecture Props), `quadratic_at_most_two_roots` (difference-of-squares + pigeonhole).
- Public prose honest: description says "OPEN ($100 prize)"; `openQuestions` list the main conjecture and even o(n²) as open; no overclaim of the headline.

Tracker bumped 3→4, result `clean`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)