### PR TITLE
Fix: sum-of-kth-powers native_decide → axiomatized

### DIFF
--- a/src/data/proofs/sum-of-kth-powers/meta.json
+++ b/src/data/proofs/sum-of-kth-powers/meta.json
@@ -8,7 +8,7 @@
     "author": "Johann Faulhaber / Nicomachus (formalized)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Faulhaber%27s_formulas",
     "date": "c. 100 CE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfKthPowers.lean",
     "tags": [
       "algebra",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "induction"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,9 +39,9 @@
       "Closed-form formula for sum of fifth powers: n²(n+1)²(2n²+2n-1)/12"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 600,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Relies on `Lean.ofReduceBool`: 14 named verification theorems (sum_squares_100, sum_cubes_100, sum_sixth_powers_10, sum_seventh_powers_5/10, sum_fourth/fifth_powers_5/10, sum_fourth/fifth_formula_check_10, sum_squares_10, sum_cubes_10, sum_10_squared) are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction (the `Lean.ofReduceBool` axiom). The closed-form Faulhaber/Nicomachus formula proofs themselves are by ordinary induction and are axiom-free; only the concrete numeric instance checks invoke `native_decide`. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

`sum-of-kth-powers` (Faulhaber's Formulas, Wiedijk #77) was marked `verified` / badge `original` / `axiomCount: 0` with assumptions "None. Fully verified with 0 axioms and 0 sorries." — but the Lean file discharges 14 **named** verification theorems with `native_decide`, which depends on the `Lean.ofReduceBool` axiom. Per the Axiom Integrity Policy, a `native_decide`-backed substantive result presented as verified must be counted.

## Evidence

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, "Fully verified with 0 axioms".

14 named theorems via `native_decide` (`Proofs/SumOfKthPowers.lean`, "Verification Examples" section, lines 420–462):
`sum_sixth_powers_10`, `sum_seventh_powers_5`, `sum_seventh_powers_10`, `sum_squares_10`, `sum_cubes_10`, `sum_10_squared`, `sum_squares_100`, `sum_cubes_100`, `sum_fourth_powers_5/10`, `sum_fifth_powers_5/10`, `sum_fourth_formula_check_10`, `sum_fifth_formula_check_10`.

**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and scope it to the numeric instance checks (the closed-form induction proofs remain axiom-free). `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Metadata-only change; no Lean source modified.

---
Automated fix by lean-mechanic agent.