### PR TITLE
Fix: lagrange-four-squares-waring-g2 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -5,7 +5,7 @@
   "description": "Every natural number is a sum of at most 4 perfect squares (Lagrange 1770), and 7 is not a sum of 3 squares — hence g(2) = 4. Includes the general exclusion theorem (4^a(8b+7) is never a sum of 3 squares), computable classification, and infinitely many numbers requiring exactly 4 squares.",
   "meta": {
     "author": "Lagrange (1770), Legendre (1798)",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LagrangeFourSquaresWaringG2.lean",
     "tags": [
       "number-theory",
@@ -15,12 +15,12 @@
       "combinatorics",
       "modular-arithmetic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 442,
     "theoremCount": 69,
-    "assumptions": "None. All 69 theorems proved. Upper bound uses Mathlib's Nat.sq_add_sq (Lagrange); lower bound is self-contained via mod 8 analysis.",
+    "assumptions": "Relies on Lean.ofReduceBool: 40 named theorems are discharged by native_decide (the computable classification numSq_0..numSq_31, the excluded_*/not_excluded_* family, all_at_most_four_100, first_needing_four, excluded_matches_four_100, count_*sq_50, needingFour_list_50, and max_four_200), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing a kernel-checked proof term. The mathematical upper bound uses Mathlib's Nat.sq_add_sq (Lagrange); the lower bound is self-contained via mod 8 analysis. (leanFile.axiomCount remains 0 since there are no literal axiom declarations.)",
     "mathlibDependencies": [
       {
         "theorem": "Nat.sq_add_sq",
@@ -133,11 +133,11 @@
       "title": "Summary",
       "startLine": 413,
       "endLine": 442,
-      "summary": "Tabulated recap of all proved results (0 axioms, 0 sorries) and key insights: g(2) = 4 is tight, mod-8 lower bound, descent principle, excluded-form characterization, and G(2) = g(2) = 4."
+      "summary": "Tabulated recap of all proved results (0 sorries; native_decide classification/batch-verification results carry the Lean.ofReduceBool axiom) and key insights: g(2) = 4 is tight, mod-8 lower bound, descent principle, excluded-form characterization, and G(2) = g(2) = 4."
     }
   ],
   "conclusion": {
-    "summary": "Waring's problem for squares is completely resolved: $g(2) = 4$. Upper bound from Mathlib (Lagrange 1770), lower bound self-contained via mod 8 analysis (Legendre 1798). 69 theorems, 0 sorries, 0 axioms.",
+    "summary": "Waring's problem for squares is completely resolved: $g(2) = 4$. Upper bound from Mathlib (Lagrange 1770), lower bound self-contained via mod 8 analysis (Legendre 1798). 69 theorems, 0 sorries; the computable classification and batch-verification results are discharged by native_decide (Lean.ofReduceBool axiom).",
     "implications": "The result is fully formal: both the classical Lagrange upper bound and Legendre's characterization of 3-square-free numbers are proved. The computable `numSquaresNeeded` function and batch verification provide computational evidence alongside the mathematical proofs.",
     "openQuestions": [
       "What is $g(k)$ for $k \\geq 3$? (Waring: $g(3) = 9$, $g(4) = 19$, all known)",


### PR DESCRIPTION
## Fix

The gallery entry **Waring's Problem for Squares: g(2) = 4** (`lagrange-four-squares-waring-g2`) was marked `verified` / badge `mathlib` / `axiomCount: 0` and claimed "0 axioms" throughout, but its `Proofs/LagrangeFourSquaresWaringG2.lean` discharges **40 named theorems** with `native_decide`. Per the project's Axiom Integrity Policy, `native_decide` trusts the Lean compiler's kernel reduction via the `Lean.ofReduceBool` axiom — the result is not axiom-free.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `meta.axiomCount: 0`, `assumptions: "None. All 69 theorems proved..."`, conclusion/summary prose claiming "0 axioms".

**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`, "0 axioms" prose scrubbed.

`leanFile.axiomCount` stays **0** (no literal `axiom` declarations — the conservative `meta.axiomCount: 1` reflects the `native_decide` dependency).

40 NAMED `native_decide` deliverables (substantive results the entry presents as verified): `numSq_0`..`numSq_31` (computable classification, Part 6), `excluded_*`/`not_excluded_*`, `all_at_most_four_100`, `first_needing_four`, `excluded_matches_four_100`, `count_*sq_50`, `needingFour_list_50` (Part 7), `max_four_200` (Part 10 batch verification). 0 anonymous/example `native_decide`.

The separate OQ-01 counting companion files (G4–G7, General) remain genuinely axiom-free (counting+omega, no `native_decide`) and their descriptions are unchanged.

Metadata-only change; no Lean rebuild required.

---
Automated fix by lean-mechanic agent.