### PR TITLE
research(erdos-10-oq-02): de-stale build-status docstrings — stack is registered & machine-checked

### DIFF
--- a/proofs/Proofs/Erdos10OQ02.lean
+++ b/proofs/Proofs/Erdos10OQ02.lean
@@ -30,11 +30,10 @@ distinct-exponent count is exactly the binary popcount, which is why the
 underlies the numerical evidence in
 `research/problems/erdos-10-oq-02/`.
 
-This file is **build-pending**: it was authored while the Docker Lean
-toolchain and the Aristotle backend were both unavailable, so it is **not yet
-registered in `Proofs.lean`**. The proofs use only elementary `Multiset`
-algebra (no binary-representation API), and are intended as a verified-on-paper
-drop-in for the next build-enabled session.
+This file is **registered in `Proofs.lean`** and machine-checked under the
+pinned Lean toolchain (the original draft predates the build; it has since been
+elaborated cleanly). The proofs use only elementary `Multiset` algebra (no
+binary-representation API).
 
 ## References
 

--- a/proofs/Proofs/Erdos10OQ02Bridge.lean
+++ b/proofs/Proofs/Erdos10OQ02Bridge.lean
@@ -28,11 +28,9 @@ set**, and restates the Granville–Soundararajan odd conjecture directly agains
 needing 3 powers, `906`) then close by `native_decide` *against the headline
 definition*, not just the OQ-02 reformulation.
 
-**Build status.** Authored under a Docker/Aristotle blackout; the worktree
-olean cache is unavailable, so this file is **not kernel-checked this session**.
-Every step is definitional unfolding of the two definitions plus the existing
-OQ-02 `Decidable` instance; all names are name-checked against the pinned
-toolchain. Registered in `Proofs.lean`; promotion awaits the deployer build.
+**Build status.** Registered in `Proofs.lean` and machine-checked under the
+pinned Lean toolchain. Every step is definitional unfolding of the two
+definitions plus the existing OQ-02 `Decidable` instance.
 -/
 
 import Proofs.Erdos10Problem

--- a/proofs/Proofs/Erdos10OQ02Decidable.lean
+++ b/proofs/Proofs/Erdos10OQ02Decidable.lean
@@ -34,19 +34,20 @@ in `research/problems/erdos-10-oq-02/verify_decidable_membership.py`
 (`RepWithAtMost k n ⟺ bounded-distinct ⟺ popcount n ≤ k`; the bounded prime
 form reproduces the `905`/`906` caps and the Grechuk witness).
 
-**Build status.** Authored under a Docker/Aristotle blackout, so this file is
-**not yet registered in `Proofs.lean`**. The proofs use only elementary
-`Multiset` algebra plus the S3 lemmas; they are a verified-on-paper drop-in.
+**Build status.** Registered in `Proofs.lean` and machine-checked under the
+pinned Lean toolchain. The proofs use only elementary `Multiset` algebra plus
+the S3 lemmas.
 
-### Remaining mechanical step (next build-enabled session)
+### The explicit decidable instance (delivered in S5)
 
-The explicit `Decidable (RepWithAtMost k n)` instance: encode a `Nodup`
-exponent multiset bounded by `n` as a `Finset ⊆ Finset.range (n+1)`, so that
+The bounded characterization here makes `Decidable (RepWithAtMost k n)` an
+exercise, but the actual instance shipped in `Erdos10OQ02Popcount.lean` (S5)
+takes a sharper route: rather than the `2^(n+1)`-candidate powerset search
 `RepWithAtMost k n ↔ ∃ F ∈ (Finset.range (n+1)).powerset, F.card ≤ k ∧
-(∑ a ∈ F, 2^a) = n`, the right side being decidable by `Finset` search. The
-bridge needs `Multiset.toFinset` (sum/card preserved on `Nodup` multisets) and
-`Finset.sum`-as-`Multiset.sum`. With that instance in place, the witnesses
-`906 ∉ S_3`-style facts close by `decide`/`native_decide`.
+(∑ a ∈ F, 2^a) = n`, it identifies the minimal distinct-power count with the
+binary popcount (`(Nat.bitIndices n).length`), giving an `O(log n)` instance.
+With that instance the witnesses `906 ∉ S_3`-style facts close by
+`decide`/`native_decide`.
 
 ## References
 
@@ -153,13 +154,13 @@ theorem isPrimePlusKPowers_iff_bounded_distinct (k n : ℕ) :
 #check @repWithAtMost_iff_repBoundedDistinct
 #check @isPrimePlusKPowers_iff_bounded_distinct
 
-/-! ## Part VIII: Decidability recipe (verified lemma names, build-pending)
+/-! ## Part VIII: Decidability recipe (the powerset route, superseded by S5)
 
 The explicit `Decidable (RepWithAtMost k n)` instance is the last mechanical
-step. The bridge below is fully name-checked against the Mathlib pin `v4.26.0`
-(sibling checkout); only an end-to-end Lean build (Docker-gated) remains to
-confirm elaboration. The target equivalence, with the search pinned to a finite
-`Finset`:
+step. This section records the direct powerset route; the instance actually
+shipped in `Erdos10OQ02Popcount.lean` (S5) uses the sharper `O(log n)` popcount
+characterization instead. The target equivalence, with the search pinned to a
+finite `Finset`:
 
   `RepWithAtMost k n ↔
      ∃ F ∈ (Finset.range (n + 1)).powerset, F.card ≤ k ∧ (∑ a ∈ F, 2 ^ a) = n`

--- a/proofs/Proofs/Erdos10OQ02Popcount.lean
+++ b/proofs/Proofs/Erdos10OQ02Popcount.lean
@@ -35,9 +35,8 @@ This fills the gap recorded in the problem metadata ("no `Decidable` instance
 wired for `sumPrimeAndTwoPows` / `IsPrimePlusKPowers`") with the
 computationally usable instance, rather than the in-principle powerset one.
 
-**Build status.** Authored under a Docker/Aristotle blackout, so this file is
-**not yet registered in `Proofs.lean`**. Every Mathlib lemma is name-checked
-against the pinned v4.26 toolchain. The decision facts are validated
+**Build status.** Registered in `Proofs.lean` and machine-checked under the
+pinned v4.26 toolchain. The decision facts are additionally validated
 independently in `research/problems/erdos-10-oq-02/verify_decidable_membership.py`
 (`RepWithAtMost k m ⟺ popcount m ≤ k`; `IsPrimePlusKPowers 2 906` is false,
 `IsPrimePlusKPowers 3 906` is true; `906` is the smallest even integer in

--- a/src/data/proofs/erdos-10-oq-02/annotations.json
+++ b/src/data/proofs/erdos-10-oq-02/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-10-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 54
+      "endLine": 53
     },
     "type": "concept",
     "title": "Granville–Soundararajan k=3 (Odd Part): the Open Conjecture and What is Formalized",
@@ -27,8 +27,8 @@
     "id": "ann-merge-identity-erdos10oq02",
     "proofId": "erdos-10-oq-02",
     "range": {
-      "startLine": 55,
-      "endLine": 77
+      "startLine": 54,
+      "endLine": 76
     },
     "type": "technique",
     "title": "powSum and the Merge Identity 2^a + 2^a = 2^{a+1}",
@@ -49,8 +49,8 @@
     "id": "ann-representability-erdos10oq02",
     "proofId": "erdos-10-oq-02",
     "range": {
-      "startLine": 78,
-      "endLine": 94
+      "startLine": 77,
+      "endLine": 93
     },
     "type": "definition",
     "title": "Part II: RepWithAtMost vs RepDistinct",
@@ -71,8 +71,8 @@
     "id": "ann-reduction-lemma-erdos10oq02",
     "proofId": "erdos-10-oq-02",
     "range": {
-      "startLine": 95,
-      "endLine": 154
+      "startLine": 94,
+      "endLine": 153
     },
     "type": "theorem",
     "title": "The Reduction Lemma: ≤k Powers ⟺ ≤k Distinct Powers",
@@ -94,8 +94,8 @@
     "id": "ann-gs-statement-erdos10oq02",
     "proofId": "erdos-10-oq-02",
     "range": {
-      "startLine": 155,
-      "endLine": 189
+      "startLine": 154,
+      "endLine": 188
     },
     "type": "concept",
     "title": "Prime-Plus Form and Transfer to the Distinct Representation",

--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -54,39 +54,39 @@
       "title": "Header and Overview",
       "summary": "Header for Erdős #10 OQ-02: the Granville–Soundararajan conjecture (odd part) asks whether every odd $n\\ge3$ is a prime plus at most $3$ powers of $2$. The conjecture is OPEN; the file formalizes the decidable reduction infrastructure beneath it, with the merge identity $2^a+2^a=2^{a+1}$ as the engine.",
       "startLine": 1,
-      "endLine": 54,
+      "endLine": 53,
       "mathContext": "OQ-02: every odd $n\\ge3$ is $p+\\sum_{i\\le3}2^{a_i}$, $p$ prime. Open (Granville–Soundararajan 1998)."
     },
     {
       "id": "part1-pow-sum",
       "title": "Part I: Sums of Powers of Two",
       "summary": "Defines `powSum s` $=\\sum_{a\\in s}2^a$ over a multiset of exponents, with `powSum_zero`, `powSum_cons`, `powSum_add`, and the keystone `powSum_merge`: $2^a+2^a=2^{a+1}$.",
-      "startLine": 55,
-      "endLine": 77,
+      "startLine": 54,
+      "endLine": 76,
       "mathContext": "$\\mathrm{powSum}(a::a::s)=\\mathrm{powSum}((a{+}1)::s)$ — the atomic reduction step."
     },
     {
       "id": "part2-representability",
       "title": "Part II: Representability as ≤ k Powers of Two",
       "summary": "Defines `RepWithAtMost k n` (sum of $\\le k$ powers, repeats allowed) and `RepDistinct k n` (pairwise-distinct exponents), with monotonicity `repWithAtMost_mono`.",
-      "startLine": 78,
-      "endLine": 94,
+      "startLine": 77,
+      "endLine": 93,
       "mathContext": "$\\mathrm{RepWithAtMost}(k,n)$ vs $\\mathrm{RepDistinct}(k,n)$: same sum, distinct vs repeated exponents."
     },
     {
       "id": "part3-reduction-lemma",
       "title": "Part III: The Reduction Lemma",
       "summary": "`exists_nodup_powSum` canonicalizes any exponent multiset to a `Nodup` one of no greater card and equal `powSum` (strong induction on card), giving `repWithAtMost_iff_repDistinct`: $\\le k$ powers $\\iff\\ \\le k$ distinct powers.",
-      "startLine": 95,
-      "endLine": 154,
+      "startLine": 94,
+      "endLine": 153,
       "mathContext": "$\\mathrm{RepWithAtMost}(k,n)\\iff\\mathrm{RepDistinct}(k,n)$ — repeats never reduce the count needed."
     },
     {
       "id": "part4-gs-statement",
       "title": "Part IV: The Granville–Soundararajan Statement (Odd Part)",
       "summary": "Defines `IsPrimePlusKPowers k n` and the open `GranvilleSoundararajanOdd` Prop, and proves `isPrimePlusKPowers_iff_distinct` — the prime-plus form transfers to the distinct representation, the shape a decision procedure consumes.",
-      "startLine": 155,
-      "endLine": 189,
+      "startLine": 154,
+      "endLine": 188,
       "mathContext": "$\\mathrm{IsPrimePlusKPowers}(k,n)\\iff\\exists\\,p\\ \\text{prime},\\ m\\ \\text{with}\\ \\mathrm{RepDistinct}(k,m),\\ n=p+m$."
     }
   ],


### PR DESCRIPTION
## Summary

The four-file Granville–Soundararajan k=3 decidability stack for Erdős #10 OQ-02 (`Erdos10OQ02` / `Decidable` / `Popcount` / `Bridge`) is `verified`/`original`/0-axiom and **registered in `Proofs.lean`** (lines 927-930 since #24527), yet every file still carried docstrings claiming it was *"build-pending"*, *"not yet registered in `Proofs.lean`"*, *"authored under a Docker/Aristotle blackout"*, and a *"verified-on-paper drop-in for the next build-enabled session"*.

Those claims are stale and contradict the entry's own `meta.json` `assumptions` field, which records the stack **Docker-verified green (2026-06-15, 3066 jobs)**.

## Verification (this session)

A fresh `./proofs/scripts/docker-build.sh Proofs.Erdos10OQ02Popcount` (which transitively pulls the whole stack) completes in **3066 jobs**, exit 0, with every keystone theorem elaborating:

```
repWithAtMost_iff_bitIndices_length : ∀ (k n : ℕ), RepWithAtMost k n ↔ n.bitIndices.length ≤ k
isPrimePlusKPowers_iff_range        : ∀ (k n : ℕ), IsPrimePlusKPowers k n ↔ ∃ p ∈ Finset.range (n+1), …
inferInstance : Decidable (RepWithAtMost 3 906)
inferInstance : Decidable (IsPrimePlusKPowers 3 906)
```

## Changes

- **Four "Build status" blocks** rewritten to state the files are registered and machine-checked under the pinned toolchain.
- **`Decidable.lean`**: the *"Remaining mechanical step (next build-enabled session)"* / *"Part VIII … build-pending"* prose narrated an unfinished decidable-instance step that was in fact delivered — and via a sharper `O(log n)` popcount route — in `Popcount.lean` (S5). Reframed to reflect that.
- **`meta.json` + `annotations.json`**: section/annotation line ranges synced to the primary file's −1 line shift (the header comment lost one line). The five ranges remain byte-aligned with the existing, build-accepted section anchoring (resolver reports the same advisory misalignments as the pre-existing baseline — no regression). `lineCount` (542 = the 3-core-file sum) is unchanged and remains correct.

Comment-only Lean edits — no theorem statements, proofs, or counts touched. Status stays `verified`/`original`/0-axiom.