### PR TITLE
Fix: inclusion-exclusion-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "inclusion-exclusion-oq-01",
   "title": "Inclusion-Exclusion: Applications to Number Theory and Combinatorics",
   "slug": "inclusion-exclusion-oq-01",
-  "description": "Applies the inclusion-exclusion principle to connect combinatorics and number theory. Proves sieve formulas (2-set and 3-set), Euler's totient via IE sieve (φ(pq)=(p-1)(q-1)), surjection counting (|Surj(n,k)| = Σ (-1)^j C(k,j)(k-j)^n), derangement formula (D(n) = Σ (-1)^k C(n,k)(n-k)!), derangement recurrence, divisor-totient identity (Σ_{d|n} φ(d) = n), and alternating binomial sum. 41 theorems, 5 definitions, 0 axioms.",
+  "description": "Applies the inclusion-exclusion principle to connect combinatorics and number theory. Proves sieve formulas (2-set and 3-set), Euler's totient via IE sieve (φ(pq)=(p-1)(q-1)), surjection counting (|Surj(n,k)| = Σ (-1)^j C(k,j)(k-j)^n), derangement formula (D(n) = Σ (-1)^k C(n,k)(n-k)!), derangement recurrence, divisor-totient identity (Σ_{d|n} φ(d) = n), and alternating binomial sum. 41 theorems, 5 definitions. Concrete derangement and alternating-binomial-sum values are discharged by native_decide, which depends on the Lean.ofReduceBool axiom.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/InclusionExclusionOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "derangements",
       "euler-totient"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas.",
+    "axiomCount": 1,
+    "assumptions": "Concrete derangement values (D(0)..D(6)) and alternating binomial sums (n=1..10) are verified by native_decide, which trusts the Lean compiler and depends on the Lean.ofReduceBool axiom. The structural results use Mathlib's Nat.totient and Finset.card lemmas.",
     "lineCount": 382,
     "theoremCount": 41,
     "definitionCount": 5,
@@ -52,7 +52,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Inclusion-exclusion applications fully verified: 2-set and 3-set sieves, Euler totient (φ(pq)=(p-1)(q-1) and general properties), surjection counting, derangement formula and two recurrences, alternating binomial sum, divisor-totient identity, Stirling numbers S(n,k), Bell numbers B(n). 41 theorems, 382 lines, 0 axioms.",
+    "summary": "Inclusion-exclusion applications: 2-set and 3-set sieves, Euler totient (φ(pq)=(p-1)(q-1) and general properties), surjection counting, derangement formula and two recurrences, alternating binomial sum, divisor-totient identity, Stirling numbers S(n,k), Bell numbers B(n). 41 theorems, 382 lines. Concrete derangement and alternating-binomial-sum values are discharged by native_decide (Lean.ofReduceBool).",
     "implications": "This file demonstrates the unifying power of inclusion-exclusion: the same alternating-sum principle underlies Euler's totient (sieve over multiples of prime factors), derangements (sieve over fixed points), surjections (sieve over missing image elements), and the Stirling/Bell number hierarchy. The derangement limit D(n)/n! → 1/e connects discrete combinatorics to e ≈ 2.718, one of the fundamental constants of analysis. The divisor-totient identity connects IE to multiplicative number theory and Möbius inversion.",
     "openQuestions": [
       "Formalize the general IE formula for k sets: |U \\ (A₁∪...∪Aₖ)| = Σ_{S⊆[k]} (-1)^|S| |∩_{i∈S} Aᵢ ∩ U|",


### PR DESCRIPTION
## Fix

Re-class `inclusion-exclusion-oq-01` from `verified`/`original`/0-axioms to `axiomatized`/`axiom`/1-axiom because it relies on `native_decide`, which trusts the Lean compiler and depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "original"`, `meta.axiomCount: 0`; prose claimed "0 axioms" / "Fully machine-verified".

**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`; assumptions discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

17 NAMED `native_decide` deliverables in `Proofs/InclusionExclusionOQ01.lean` present computed results as verified facts:
- `derangements_zero` … `derangements_six` (L185-191) — concrete derangement values D(0)..D(6)
- `altBinomSum_1` … `altBinomSum_10` (L256-265) — alternating binomial sums Σ(-1)^k C(n,k)=0

Per the project Axiom Integrity Policy: `native_decide` discharging substantive results the entry presents as verified ⇒ `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`.

---
Automated fix by lean-mechanic agent.