### PR TITLE
Fix: divisibility-by-three-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "modular-arithmetic",
       "three"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "Relies on Lean.ofReduceBool via native_decide. Numerous named deliverables — the multi-digit grouping rules (thirtyseven_dvd_base1000, ninetynine_dvd_base100, nineninenine_dvd_base1000, twentyseven_dvd_base1000), alternate-base rules (seven_dvd_octal, three_dvd_hex, five_dvd_hex, fifteen_dvd_hex, three_dvd_base7, six_dvd_base7), casting out nines/threes (casting_out_nines, casting_out_threes), the coprime composite-divisor rules (six/twelve/fifteen/eighteen/thirtysix/fortyfive/sixty/ninety_dvd_iff), and divisibility_rules_summary — discharge their base congruences via native_decide, which trusts the Lean compiler (Lean.ofReduceBool axiom). The general theorems (digitSum_dvd_iff, coprime_mul_dvd_iff, dvd_iff_dvd_mod, etc.) are axiom-free; only the concrete instances depend on ofReduceBool.",
     "lineCount": 550,
     "theoremCount": 56,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Flip `divisibility-by-three-oq-01` from `verified`/`original`/`axiomCount: 0` to `axiomatized`/`axiom`/`axiomCount: 1`, disclosing `Lean.ofReduceBool`.

## Evidence

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, `assumptions: "None. Fully machine-verified."`

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

22 **named deliverable theorems** discharge their base congruences via `native_decide`, including the headline `originalContributions` — the multi-digit grouping rules (`thirtyseven_dvd_base1000`, `ninetynine_dvd_base100`, `nineninenine_dvd_base1000`, `twentyseven_dvd_base1000`), alternate-base rules (`seven_dvd_octal`, `three_dvd_hex`, …), casting out nines/threes (`casting_out_nines`, `casting_out_threes`), and the coprime composite-divisor rules (`six/twelve/…/ninety_dvd_iff`).

`native_decide` trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom — the proofs are not axiom-free. Per the project Axiom Integrity Policy, a substantive result presented as verified that relies on `native_decide` must be counted: `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, with `Lean.ofReduceBool` disclosed.

`leanFile.axiomCount` stays `0` (it counts only literal `axiom` declarations; there are none). The general theorems (`digitSum_dvd_iff`, `coprime_mul_dvd_iff`, …) remain axiom-free; only the concrete instances depend on `ofReduceBool`.

Metadata-only change; no Lean source modified.

---
Automated fix by lean-mechanic agent.