### PR TITLE
Fix: divisibility-by-three-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ02.lean",
     "tags": [
       "number-theory",
@@ -15,11 +15,11 @@
       "modular-arithmetic",
       "extensions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "The named divisibility-rule theorems (seven_dvd_alt_three_digit, eleven/thirteen/thousand_one_dvd_alt_three_digit and the dependent seven_dvd_alt_blocks_nat) discharge the framework side condition B % d = d - 1 via native_decide, which trusts the Lean compiler and depends on the Lean.ofReduceBool axiom. The general framework theorem dvd_iff_altSum and the structural results are otherwise machine-verified.",
     "lineCount": 432,
     "theoremCount": 31,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Re-class `divisibility-by-three-oq-02` from `verified`/`original`/0-axioms to `axiomatized`/`axiom`/1-axiom. The entry's **named divisibility-rule deliverables** rely on `native_decide`, which trusts the Lean compiler and depends on the `Lean.ofReduceBool` axiom.

## Evidence

Unlike incidental numeric corollaries, the affected theorems are **general ∀n divisibility rules** named in `originalContributions` ("Divisibility by 7, 11, 13, and 1001 via alternating three-digit groups"):

- `seven_dvd_alt_three_digit (n : ℕ)` (L149) `:= dvd_iff_altSum 7 1000 n (by omega) (by native_decide)`
- `eleven_dvd_alt_three_digit` (L183), `thirteen_dvd_alt_three_digit` (L189), `thousand_one_dvd_alt_three_digit` (L196) — same pattern
- `seven_dvd_alt_blocks_nat` (L160) — depends transitively (`rw [← seven_dvd_alt_three_digit]`)

Each discharges the framework side condition `B % d = d - 1` via `native_decide`, so `#print axioms` on these headline rules **would** list `Lean.ofReduceBool`. The general framework theorem `dvd_iff_altSum` itself is axiom-free.

**Before**: `status: "verified"`, `badge: "original"`, `meta.axiomCount: 0`, assumptions "None. Fully machine-verified."

**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`; assumptions discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Sibling of the concurrent `divisibility-by-three-oq-01` flip (#25668), same pattern. Per the project Axiom Integrity Policy.

---
Automated fix by lean-mechanic agent.