### PR TITLE
Enrich Dirichlet Approximation OQ-01: annotation coverage + cross-refs

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-headline-infinitude",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "concept",
+    "title": "infinite_good_rat_approx — The Qualitative Upgrade",
+    "content": "The headline statement: for irrational ξ the set {q : ℚ | |ξ − q| < 1/q.den²} is infinite. This is the *qualitative* upgrade of the parent entry's one-shot pigeonhole bound (which produced a single fraction per cutoff Q). The proof is a one-line delegation to Mathlib's Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational, so the mathematical novelty of this file is not the infinitude itself but the reformulation that follows. Note the bound is phrased with q.den² (the squared denominator of the rational in lowest terms), which is exactly the classical exponent-2 approximation order.",
+    "mathContext": "$\\text{Irrational } \\xi \\;\\Rightarrow\\; \\bigl|\\{q \\in \\mathbb{Q} : |\\xi - q| < 1/q.\\mathrm{den}^2\\}\\bigr| = \\infty$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Diophantine approximation",
+      "irrational numbers",
+      "approximation order",
+      "pigeonhole principle"
+    ],
+    "prerequisites": [
+      "Set.Infinite",
+      "the rational denominator q.den (lowest terms)",
+      "Mathlib's DiophantineApproximation development"
+    ]
+  },
+  {
+    "id": "ann-coprime-bridge-statement",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 53, "endLine": 63 },
+    "type": "insight",
+    "title": "infinite_coprime_approx — Classical Integer-Pair Form",
+    "content": "The original contribution: restating infinitude over coprime integer pairs (p,q) ∈ ℤ×ℕ with q > 0, gcd(|p|,q)=1, and |ξ − p/q| < 1/q². This is the form quoted in Hardy & Wright (Theorem 193) and the launching point for continued fractions and Hurwitz's sharp constant. Mathlib phrases the result over a set of rationals; textbooks phrase it over reduced integer pairs. The two are equivalent precisely because ℚ is internally represented as a coprime num/den pair — so the bridge is structural rather than analytic, and no error estimate is re-derived.",
+    "mathContext": "$\\exists^{\\infty}\\,(p,q)\\in\\mathbb{Z}\\times\\mathbb{N}:\\; q>0,\\; \\gcd(|p|,q)=1,\\; \\Bigl|\\xi - \\tfrac{p}{q}\\Bigr| < \\tfrac{1}{q^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprime integers",
+      "lowest-terms representation",
+      "continued fractions",
+      "Hurwitz's theorem"
+    ],
+    "prerequisites": [
+      "Nat.Coprime and Int.natAbs",
+      "the num/den encoding of ℚ",
+      "rational-to-real cast"
+    ]
+  },
+  {
+    "id": "ann-injon-numden",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 66, "endLine": 71 },
+    "type": "technique",
+    "title": "InjOn of q ↦ (q.num, q.den)",
+    "content": "To transport infinitude from rationals to integer pairs, the map f : ℚ → ℤ×ℕ, q ↦ (q.num, q.den) must be injective on the good-approximation set. The proof is the standard recovery argument: from equal numerators and equal denominators, q = q.num / q.den = q'.num / q'.den = q' via Rat.num_div_den. Injectivity is what lets Set.infinite_image_iff convert infinitude of the domain into infinitude of the image — without it the image could collapse to a finite set.",
+    "mathContext": "$f(a)=f(b) \\Rightarrow (a.\\mathrm{num},a.\\mathrm{den})=(b.\\mathrm{num},b.\\mathrm{den}) \\Rightarrow a=\\tfrac{a.\\mathrm{num}}{a.\\mathrm{den}}=\\tfrac{b.\\mathrm{num}}{b.\\mathrm{den}}=b$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Set.InjOn",
+      "Rat.num_div_den",
+      "injective image"
+    ],
+    "prerequisites": [
+      "set-theoretic injectivity on a subset",
+      "the identity q = q.num / q.den"
+    ]
+  },
+  {
+    "id": "ann-image-subset",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 72, "endLine": 84 },
+    "type": "technique",
+    "title": "Image Lands in the Coprime-Pair Set",
+    "content": "The crux of the bridge: showing f maps each good rational approximation to a valid coprime pair. Three structural facts of ℚ supply the three clauses for free — Rat.pos gives q.den > 0, Rat.reduced gives gcd(|q.num|,q.den)=1, and Rat.cast_def gives (q.num : ℝ)/(q.den : ℝ) = (q : ℝ). The last is the key move: because the cast of the pair equals the original rational, the error |ξ − p/q| and the bound 1/q.den² are *literally unchanged*, so the analytic hypothesis transfers with no new estimate. Set.Infinite.mono along this subset containment then finishes the proof.",
+    "mathContext": "$\\tfrac{q.\\mathrm{num}}{q.\\mathrm{den}} = q \\;\\Rightarrow\\; \\Bigl|\\xi - \\tfrac{q.\\mathrm{num}}{q.\\mathrm{den}}\\Bigr| = |\\xi - q| < \\tfrac{1}{q.\\mathrm{den}^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Rat.cast_def",
+      "Rat.reduced",
+      "Set.Infinite.mono",
+      "Set.infinite_image_iff"
+    ],
+    "prerequisites": [
+      "positive denominator and lowest-terms invariants of ℚ",
+      "monotonicity of infinitude under subset",
+      "rational cast to ℝ"
+    ]
+  },
+  {
+    "id": "ann-sharp-converse",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 86, "endLine": 91 },
+    "type": "insight",
+    "title": "infinite_approx_iff_irrational — The Hypothesis Is Sharp",
+    "content": "The converse, recorded as an iff: the good-approximation set is infinite *exactly when* ξ is irrational. A rational target admits only finitely many fractions of approximation order 2 (Mathlib's finite_rat_abs_sub_lt_one_div_den_sq), so Irrational ξ is not merely a convenient sufficient condition — it is necessary and sufficient. Including both directions in the entry makes the dichotomy explicit: exponent-2 rational approximability characterizes irrationality.",
+    "mathContext": "$\\bigl\\{q : |\\xi - q| < 1/q.\\mathrm{den}^2\\bigr\\}.\\mathrm{Infinite} \\iff \\mathrm{Irrational}\\,\\xi$",
+    "significance": "key",
+    "relatedConcepts": [
+      "characterization of irrationality",
+      "necessary and sufficient conditions",
+      "rationals have finitely many good approximations"
+    ],
+    "prerequisites": [
+      "Irrational predicate",
+      "biconditional reasoning",
+      "finiteness of good approximations for rational targets"
+    ]
+  },
+  {
+    "id": "ann-existence-corollary",
+    "proofId": "dirichlet-approximation-theorem-oq-01",
+    "range": { "startLine": 93, "endLine": 99 },
+    "type": "concept",
+    "title": "exists_good_approx — Recovering the One-Shot Bound",
+    "content": "The original Dirichlet existence statement (at least one good approximation) is recovered as a trivial corollary of infinitude: an infinite set is nonempty (Set.Infinite.nonempty), so a single witness q falls out. This closes the loop with the parent entry — what the parent proved from scratch via the pigeonhole interval argument is here a one-line consequence of the stronger infinitude theorem, illustrating that infinitude strictly subsumes mere existence.",
+    "mathContext": "$\\text{set infinite} \\Rightarrow \\text{nonempty} \\Rightarrow \\exists q:\\; |\\xi - q| < 1/q.\\mathrm{den}^2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Set.Infinite.nonempty",
+      "existence from infinitude",
+      "one-shot Dirichlet bound"
+    ],
+    "prerequisites": [
+      "an infinite set is nonempty",
+      "existential introduction"
+    ]
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
@@ -70,7 +70,8 @@
       "**Infinitude lives in Mathlib already**: the qualitative 'infinitely many good approximations' is Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational; the work is presentational — re-expressing a set of rationals as a set of coprime integer pairs",
       "**The num/den injection carries the error for free**: because (q.num:ℝ)/(q.den:ℝ) = (q:ℝ), the image pair has identical error |α − p/q| and identical bound 1/q.den², so no analytic estimate is repeated — only structural facts about ℚ are used",
       "**Lowest terms is built into ℚ**: Rat.reduced gives gcd(|q.num|, q.den) = 1 with no extra reduction step, so the coprimality clause of the classical statement is automatic",
-      "**The hypothesis is sharp**: infinite_approx_iff_irrational shows infinitude of good approximations characterizes irrationality — a rational target has only finitely many, so Irrational α is exactly the right assumption rather than a convenient sufficient condition"
+      "**The hypothesis is sharp**: infinite_approx_iff_irrational shows infinitude of good approximations characterizes irrationality — a rational target has only finitely many, so Irrational α is exactly the right assumption rather than a convenient sufficient condition",
+      "**Infinitude subsumes existence**: exists_good_approx recovers the parent's one-shot Dirichlet bound as a one-line corollary (an infinite set is nonempty), making explicit that the qualitative infinitude statement is strictly stronger than the single-fraction existence the pigeonhole argument delivers"
     ],
     "prerequisites": [
       "The Mathlib DiophantineApproximation development (infinitude of good rational approximations)",
@@ -126,6 +127,16 @@
       "targetId": "dirichlet-approximation-theorem",
       "relationship": "extends",
       "description": "Parent entry proving the finite one-shot pigeonhole bound. This OQ-01 answers its first open question by upgrading to the infinitude statement and recasting it in the classical coprime integer-pair form."
+    },
+    {
+      "targetId": "hurwitz-theorem",
+      "relationship": "sharpens",
+      "description": "Hurwitz's theorem sharpens the constant 1 in this entry's bound |α − p/q| < 1/q² to the best-possible 1/(√5 q²), still over infinitely many coprime pairs. The coprime integer-pair form proved here is exactly the statement Hurwitz refines; the golden ratio shows √5 cannot be improved."
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "contrasts",
+      "description": "Liouville's theorem runs in the opposite direction: algebraic irrationals of degree n cannot be approximated to order better than n, which combined with the unconditional order-2 approximability proved here yields explicit transcendental numbers (Liouville numbers approximable to every order)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem-oq-01`.

## Gap closed
This was the **only entry of 2535** in the gallery with no `annotations.json`. Added one with **6 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. `infinite_good_rat_approx` — the qualitative infinitude upgrade (headline delegation)
2. `infinite_coprime_approx` — the classical coprime integer-pair reformulation (the original contribution)
3. InjOn of `q ↦ (q.num, q.den)` — injectivity sub-step
4. Image-subset computation — how `Rat.pos`/`Rat.reduced`/`Rat.cast_def` transfer the error for free
5. `infinite_approx_iff_irrational` — the sharp converse (characterizes irrationality)
6. `exists_good_approx` — one-shot existence recovered from infinitude

## meta.json
- Added a 5th `keyInsight`: infinitude strictly subsumes the parent's one-shot existence bound.
- Added two cross-references (already named in `implications`): `hurwitz-theorem` (sharpens the constant 1 → 1/√5) and `liouville-theorem` (contrasting upper bound for algebraic irrationals).

## Validation
- JSON parses cleanly for both files.
- `pnpm annotations:build` line-range resolver: **0 errors** for this entry (the 2681 reported are the pre-existing gallery-wide anchor-drift baseline, untouched here).
- `research:build`/`research:enrich` complete. Full `tsc`/`vite` could not run in the fresh worktree (`better-sqlite3` native compile fails under node v26); the change is data-only JSON and cannot affect TypeScript type-checking.
- No status/badge/axiom changes — meta was already audited clean (verified/mathlib, 0 axioms) in #25631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)