### PR TITLE
audit(bounded-prime-gaps D(6)=16): clean first audit, genuinely native_decide-free verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15896,6 +15896,12 @@
       "lastAudited": "2026-06-18T10:57:11Z",
       "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq-03-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T11:20:37Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — `bounded-prime-gaps-oq-03-oq-01-oq-01-oq-01` (D(6) = 16)

First audit of this entry (was the sole never-audited proof in the queue). Distinct from the D(6) sibling work in #25603.

**Verdict: CLEAN.** No overclaim found; tracker bump only, `meta.json` unchanged.

### Checks
| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| lineCount | 254 | 254 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | "native_decide-free" | 0 tactic calls (3 grep hits all docstring comments) | ✓ |

### Notes
- **`native_decide`-free claim is TRUE.** The only `native_decide` occurrences are in `/- … -/` docstrings asserting the property. The proof uses plain kernel `decide` on small decidable ℕ/Finset facts — no `Lean.ofReduceBool`. `verified/original`, `axiomCount 0` justified (Tier A).
- **Main result genuine.** `minAdmissibleDiameter_6 : minAdmissibleDiameter 6 = 16` proved via real `le_antisymm`; the lower bound `admissible_6tuple_diam_ge_16` is a substantive symbolic parity → mod-3 pinning → mod-5 obstruction argument, not a Mathlib delegation.
- **No native_decide leakage.** Imports `BoundedPrimeGaps` + `BoundedPrimeGapsOQ03OQ01` (D(2)/D(3)), not the D(5) file, so the D(5) sibling's `native_decide` does not enter this file's axiom closure.
- **D(5) contrast claims accurate against current main.** The D(5) sibling (`bounded-prime-gaps-oq-03-oq-01-oq-01`) is currently `axiomatized/axiom`, axiomCount 1, 2 `native_decide`. So the meta's "axiomatized D(5) sibling" / "still relies on a native_decide diameter check" are correct, not stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)