### PR TITLE
audit(erdos-1126): clean re-audit — counts honest, axioms properly disclosed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4028,9 +4028,9 @@
       "result": "clean"
     },
     "erdos-1126": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:55Z",
+      "lastAudited": "2026-06-18T11:23:55Z",
       "result": "clean"
     },
     "erdos-1126-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit: erdos-1126 (Almost Additive Functions)

Re-audit of **Erdős Problem #1126** (de Bruijn–Jurkat theorem on almost additive functions). Result: **clean**.

### Counts verified against `Proofs/Erdos1126Problem.lean`
| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| lineCount | 157 | 157 | ✓ |
| axiomCount | 4 | 4 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| sorries | 0 | 0 | ✓ |

Also: 0 `native_decide`, 0 `decide`, 0 `True` stubs, 0 structures.

### Integrity
- **status `axiomatized` / badge `axiom`** — correct. Four real `axiom` declarations: `de_bruijn_jurkat_theorem`, `additive_zero_ae`, `wild_additive_exist`, `measurable_additive_is_linear`.
- **assumptions** field names all 4 axioms and correctly notes `continuous_additive_is_linear` is *proved* from the measurable version (verified at L57-60).
- **No axiom masking**: `proofStrategy` explicitly states the main theorem is axiomatized; `description` credits de Bruijn (1966) / Jurkat (1965), not us. Tier C, honestly presented.
- `additive_ae_unique` (L110-122) is a genuine theorem proved from `additive_zero_ae`.

### Non-blocking nits (navigation staleness, not integrity — left as-is)
- `proofStrategy` says "143-line Lean file" (now 157 after the 5→4 axiom reduction noted at L56).
- Section `endLine` ranges drift ~12 lines behind. These understate/misnavigate; they do **not** overstate proof strength.

Tracker bumped (auditCount 3→4, result clean).

---
Discovered during gallery integrity audit.