### PR TITLE
audit(erdos-1125 Kemperman/Laczkovich): clean re-audit — counts exact, axioms honestly disclosed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4022,9 +4022,9 @@
       "result": "clean"
     },
     "erdos-1125": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:55Z",
+      "lastAudited": "2026-06-18T11:28:17Z",
       "result": "clean"
     },
     "erdos-1126": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1125 (Kemperman's Inequality and Monotonicity)

**Result: CLEAN** (auditCount 3→4, status `axiomatized`/`axiom`)

Re-audit of the highest-priority PR-free target (the sole never-audited entry, `bounded-prime-gaps-oq-03-oq-01-oq-01-oq-01`, already has open PR #25674; the top re-audit slugs erdos-1054-oq-01/1128/1129/1126 all have my open PRs from today).

### Verification (Lean source vs meta.json)

| Check | meta.json | `Erdos1125Problem.lean` | Match |
|-------|-----------|--------------------------|-------|
| axioms | 3 | 3 (`kemperman_1969`, `laczkovich_1984`, `convex_satisfies`) | ✓ |
| theorems | 8 | 8 | ✓ |
| definitions | 6 | 6 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| structures | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| lineCount | 174 | 174 | ✓ |

### Integrity findings

- **Status correct**: `axiomatized`/`axiom`. The core mathematical content (Kemperman's 1969 measurable case and Laczkovich's 1984 unconditional resolution) is axiomatized, not proved — consistent with the badge.
- **Assumptions honest**: the `assumptions` field names all three axioms exactly. No axiom masking.
- **originalContributions honest**: clearly separates proved theorems (`kemperman_equiv`, `kemperman_interpretation`, `constant_satisfies`, `linear_satisfies`, `square_satisfies`) from axioms.
- **No native_decide** → no `Lean.ofReduceBool` dependency; `axiomCount=3` is correct.
- **No overclaim**: the description's "Laczkovich (1984) proved YES unconditionally" is presented as historical context; the meta `status` correctly reflects that the formalization axiomatizes that result.

No changes to meta.json required. This PR only records the audit-tracker bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)