### PR TITLE
audit(erdos-1147): name all 4 axioms in assumptions field

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4210,10 +4210,10 @@
       "result": "clean"
     },
     "erdos-1147": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:56Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T11:31:46Z",
+      "result": "issues-fixed"
     },
     "erdos-1148": {
       "auditCount": 3,

--- a/src/data/proofs/erdos-1147/meta.json
+++ b/src/data/proofs/erdos-1147/meta.json
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 234,
-    "assumptions": "4 axioms: konieczny_disproof, konieczny_generalized, sqrt2_not_basis, and 1 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: konieczny_disproof (a.e. α: A not a basis), konieczny_generalized (extends to any ε(n)→0), sqrt2_not_basis (√2 counterexample), and diophantine_set_infinite (A infinite via Dirichlet). The disproof theorem erdos_1147_false is derived from the sqrt2_not_basis axiom. See Lean source for complete statements.",
     "theoremCount": 8,
     "definitionCount": 6
   },


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1147

**Result**: issues-fixed (minor credibility polish; entry was materially accurate)

Erdős Problem #1147 — Additive Basis from Diophantine Approximation (disproved by Konieczny [Ko16b]).

### Counts verified exact vs `Proofs/Erdos1147Problem.lean`
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 234 | 234 ✓ |
| axiomCount | 4 | 4 ✓ |
| theoremCount | 8 | 8 ✓ |
| definitionCount | 6 | 6 ✓ |
| sorries | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |
| structure-encoded assumptions | — | 0 ✓ |

- `status: axiomatized` / `badge: axiom` — correct. The conjecture is disproved and the main results (`konieczny_disproof`, `konieczny_generalized`, `sqrt2_not_basis`, `diophantine_set_infinite`) are axiomatized.
- No `native_decide` → no `Lean.ofReduceBool` dependency; `axiomCount: 4` is correct.
- `erdos_1147_false` is honestly noted in keyInsights as following from the √2 counterexample axiom — no overclaim, no axiom masking.

### Fix
The `assumptions` field hedged `"...sqrt2_not_basis, and 1 more"` — the count (4) was correct but the fourth axiom (`diophantine_set_infinite`) went unnamed. Now names all four axioms explicitly and notes that `erdos_1147_false` is derived from the `sqrt2_not_basis` axiom.

No status, badge, or count change.

---
Discovered during gallery integrity audit.