### PR TITLE
Fix: divisibility-by-3-oq-03-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -4,7 +4,7 @@
   "slug": "divisibility-by-3-oq-03-oq-02",
   "description": "Generalizes the digital root from base 10 to arbitrary base b \u2265 2. Proves the closed-form formula dr_b(n) = 1 + ((n-1) mod (b-1)), idempotence, divisibility criteria, multiplicativity, and specializations to base 10 (casting out nines) and base 2.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03OQ02.lean",
     "tags": [
       "number-theory",
@@ -13,13 +13,15 @@
       "modular-arithmetic",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 211,
     "theoremCount": 21,
     "definitionCount": 1,
-    "assumptions": [],
+    "assumptions": [
+      "Lean.ofReduceBool: the concrete base-specialization examples (hex_root_15/16/255, oct_root_7/64, base7_root_42/43) — the 'concrete examples in hex, octal, and base 7' deliverable — are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom. The general framework theorems (closed form, congruence dr_b(n) ≡ n mod (b-1), idempotence, factor divisibility rule, base-10 specialization) remain axiom-free."
+    ],
     "dateAdded": "2026-04-12",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

`divisibility-by-3-oq-03-oq-02` (Base-Parametrized Digital Root) was marked `verified` / `original` / `axiomCount: 0` while its advertised **concrete base-specialization examples** deliverable is established solely by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, `assumptions: []` — yet the section summary already self-admits *"All computed via `native_decide`"* and `originalContributions` lists *"Concrete examples in hex (base 16), octal (base 8), and base 7 (proved)"*.

The 7 `native_decide` theorems are exactly that deliverable:
- `hex_root_15`, `hex_root_16`, `hex_root_255` (base 16)
- `oct_root_7`, `oct_root_64` (base 8)
- `base7_root_42`, `base7_root_43` (base 7)

`#print axioms` on these would list `Lean.ofReduceBool` → the entry is not axiom-free.

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, and `assumptions` discloses `Lean.ofReduceBool` (scoped to the concrete examples). The general framework theorems (closed form, congruence, idempotence, factor divisibility rule, base-10 specialization) and the Mathlib-backed divisibility rules (`hex_div15`, `oct_div7`) remain axiom-free, so prose was rescoped, not stripped. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

Per the Axiom Integrity Policy `native_decide` rule.

---
Automated fix by lean-mechanic agent.