### PR TITLE
research(abundant-number-oq-01): infinitely many abundant numbers + closure under multiples

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -24,6 +24,8 @@ import Proofs.AbelRuffiniOQ04OQ07
 import Proofs.AbelRuffiniOQ04OQ09Cyclic
 import Proofs.AbelRuffiniOQ09
 import Proofs.AbelRuffiniOQ10
+import Proofs.AbundantMultiplesOQ01
+import Proofs.AbundantNumberOQ01
 import Proofs.AlgebraicNumbersCountable
 import Proofs.AlgebraicNumbersCountableAristotle
 import Proofs.AlgebraicNumbersCountableOQ02

--- a/proofs/Proofs/AbundantMultiplesOQ01.lean
+++ b/proofs/Proofs/AbundantMultiplesOQ01.lean
@@ -20,14 +20,13 @@
   using `σ(a) > 2a` (abundance of `a`) and `t > 0`. Hence `σ(m) > 2m`, i.e. `m`
   is abundant.
 
-  Companion to the minimality result (`AbundantNumberOQ01.lean`, PR #25180):
-  together they pin both the least abundant number (12) and the closure of the
-  abundant numbers under taking multiples.
+  Companion to the minimality result (`AbundantNumberOQ01.lean`): together they
+  pin both the least abundant number (12) and the closure of the abundant numbers
+  under taking multiples. As a structural consequence of that closure we also
+  derive `infinitely_many_abundant`: the abundant numbers form an infinite set,
+  witnessed by the family `{12·(k+1) : k ∈ ℕ}`.
 
   The proof is axiom-free (no `sorry`, no `axiom`, no `native_decide`).
-
-  STATUS: build-pending locally (Docker pool contended this session); all lemma
-  names were checked against the pinned Mathlib v4.26.0 source.
 -/
 import Mathlib
 
@@ -49,7 +48,8 @@ theorem abundant_iff_two_mul_lt_sigma (n : ℕ) :
 abundant). -/
 theorem pos_of_abundant {a : ℕ} (ha : a.Abundant) : 0 < a := by
   rcases Nat.eq_zero_or_pos a with rfl | h
-  · exact absurd ha (by decide)
+  · rw [abundant_iff_two_mul_lt_sigma, Nat.divisors_zero] at ha
+    simp at ha
   · exact h
 
 /-- **If `a` is abundant then every positive multiple `a * t` is abundant.**
@@ -72,11 +72,14 @@ theorem abundant_mul_right {a : ℕ} (ha : a.Abundant) {t : ℕ} (ht : 0 < t) :
   -- scaling is injective on `divisors a` since `t > 0`
   have hinj : Set.InjOn (fun d => t * d) (a.divisors : Set ℕ) :=
     fun x _ y _ h => Nat.eq_of_mul_eq_mul_left ht h
+  -- Summing over the bound variable keeps `sum_image`'s motive `g = id`, so the
+  -- higher-order unification succeeds (a `∑ d, t * d` target would not).
+  have himg : ∑ x ∈ a.divisors.image (fun d => t * d), x = t * (∑ d ∈ a.divisors, d) := by
+    rw [Finset.sum_image hinj, Finset.mul_sum]
   -- σ(a*t) ≥ t · σ(a)
   have hle : t * (∑ d ∈ a.divisors, d) ≤ ∑ e ∈ (a * t).divisors, e :=
     calc t * (∑ d ∈ a.divisors, d)
-        = ∑ d ∈ a.divisors, t * d := by rw [Finset.mul_sum]
-      _ = ∑ x ∈ a.divisors.image (fun d => t * d), x := (Finset.sum_image hinj).symm
+        = ∑ x ∈ a.divisors.image (fun d => t * d), x := himg.symm
       _ ≤ ∑ e ∈ (a * t).divisors, e := Finset.sum_le_sum_of_subset hsub
   rw [abundant_iff_two_mul_lt_sigma (a * t)]
   calc 2 * (a * t)
@@ -99,5 +102,27 @@ theorem abundant_of_abundant_dvd {a m : ℕ} (ha : a.Abundant) (hdvd : a ∣ m)
 abundant). In particular `24, 36, 48, …` are all abundant. -/
 theorem abundant_twelve_mul (k : ℕ) : (12 * (k + 1)).Abundant :=
   abundant_mul_right Nat.abundant_twelve (Nat.succ_pos k)
+
+/-- The map `k ↦ 12 * (k + 1)` is injective (multiplication by the nonzero
+constant `12` is cancellative on `ℕ`). -/
+theorem twelve_mul_succ_injective :
+    Function.Injective (fun k : ℕ => 12 * (k + 1)) := by
+  intro a b hab
+  have : a + 1 = b + 1 := Nat.eq_of_mul_eq_mul_left (by norm_num) hab
+  omega
+
+/-- **There are infinitely many abundant numbers.** The infinite family
+`{12·(k+1) : k ∈ ℕ} = {12, 24, 36, …}` consists entirely of abundant numbers
+(each is a positive multiple of the abundant number `12`), and these values are
+pairwise distinct, so the set of abundant numbers cannot be finite.
+
+This is the structural complement to minimality (`AbundantNumberOQ01`): not only
+does the smallest abundant number exist (it is `12`), but the abundant numbers
+form an infinite set — a direct consequence of closure under taking multiples
+(`abundant_mul_right`). The proof is elementary and axiom-free. -/
+theorem infinitely_many_abundant : {n : ℕ | n.Abundant}.Infinite :=
+  Set.infinite_of_injective_forall_mem
+    twelve_mul_succ_injective
+    (fun k => abundant_twelve_mul k)
 
 end AbundantMultiplesOQ01

--- a/proofs/Proofs/AbundantNumberOQ01.lean
+++ b/proofs/Proofs/AbundantNumberOQ01.lean
@@ -15,9 +15,6 @@
 
   The proof is axiom-free: `decide` reduces in the kernel, so the result is
   `verified` (no `native_decide`/`Lean.ofReduceBool`).
-
-  STATUS: build-pending locally (Docker pool unavailable this session); the
-  statements were checked end-to-end via the Aristotle Lean+Mathlib backend.
 -/
 import Mathlib
 

--- a/research/problems/abundant-number-oq-01/knowledge.md
+++ b/research/problems/abundant-number-oq-01/knowledge.md
@@ -59,3 +59,56 @@ and 12 has proper-divisor sum 16 > 12. So 12 is the first abundant number.
   kernel, the cases are tiny (n<12) so it should be fine without `native_decide`.
 - Possible follow-up OQ: smallest *odd* abundant number is 945 (much larger
   search, still decidable but a real bound-justification problem).
+
+### Session 2026-06-18 (Session 2) — REVISIT / integrate + extend (researcher-4)
+
+**Mode**: REVISIT · **Outcome**: progress (BUILD CONFIRMED GREEN, PR opened)
+
+#### What I Did
+- Found Session-1's `AbundantNumberOQ01.lean` and a sibling
+  `AbundantMultiplesOQ01.lean` (multiples-of-abundant-are-abundant, from
+  merged-but-clobbered PRs #25180/#25190) both present on disk but ORPHANED:
+  unregistered in `Proofs.lean`, no gallery dir.
+- Discovered the bare minimality result is ALSO already in the gallery under
+  `sum-of-divisors` (`twelve_smallest_abundant`, via `native_decide` on a
+  file-local `sigma`/`IsAbundant`). To avoid pure duplication and add genuine
+  value, framed the new entry around STRUCTURE, not just minimality.
+- Added headline theorem `infinitely_many_abundant : {n | n.Abundant}.Infinite`
+  to `AbundantMultiplesOQ01.lean`, via injective family `k ↦ 12·(k+1)`
+  (`twelve_mul_succ_injective` + `Set.infinite_of_injective_forall_mem`),
+  resting on the existing `abundant_twelve_mul` / `abundant_mul_right`.
+- Registered both files in `Proofs.lean` (regen script); created gallery entry
+  `src/data/proofs/abundant-number-oq-01/` (meta.json + annotations.json).
+
+#### Key Findings
+- Infinitude is elementary (no analytic input): closure under multiples turns
+  the single witness 12 into an infinite family. Distinct from the deep density
+  statement (≈ 0.2476, Davenport).
+- The entry's distinct value vs `sum-of-divisors`: canonical `Nat.Abundant`
+  (not file-local), axiom-free kernel `decide` for minimality, plus closure +
+  infinitude that `sum-of-divisors` does not contain.
+
+#### Files Modified
+- `proofs/Proofs/AbundantMultiplesOQ01.lean` (+2 theorems, header updated)
+- `proofs/Proofs.lean` (registered both Abundant modules)
+- `src/data/proofs/abundant-number-oq-01/{meta.json,annotations.json}` (new)
+
+#### Build Outcome (this session)
+- Docker build of `Proofs.AbundantMultiplesOQ01` + `Proofs.AbundantNumberOQ01`
+  **succeeded** (7743 jobs, Lean v4.26.0). The Session-1 "checked via Aristotle"
+  note was WRONG — first build caught two real errors, now fixed:
+  1. `pos_of_abundant`: `by decide` could not synthesize `Decidable ¬Nat.Abundant 0`.
+     Fixed by rewriting via `abundant_iff_two_mul_lt_sigma` + `Nat.divisors_zero`
+     then `simp`.
+  2. `abundant_mul_right`: `Finset.sum_image hinj` higher-order unification failed
+     on the `∑ d, t*d` target (`?g (t*d) =?= t*d` is not a Miller pattern). Fixed
+     by introducing `himg : ∑ x ∈ image …, x = t * σ(a)` so the sum is over the
+     bound variable (`?g x =?= x` ⇒ `g = id`), discharged by
+     `rw [Finset.sum_image hinj, Finset.mul_sum]`.
+- LESSON: never trust an unbuilt "verified via external backend" note — kernel
+  `decide` decidability-instance gaps and `sum_image` HO-unification are exactly
+  the failures that only surface at `lake build`.
+
+#### Next Steps
+- (Follow-ups) positive natural density (Davenport ≈ 0.2476); smallest ODD
+  abundant = 945; every integer > 20161 is a sum of two abundant numbers.

--- a/src/data/proofs/abundant-number-oq-01/annotations.json
+++ b/src/data/proofs/abundant-number-oq-01/annotations.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "abundant-ann-intro",
+    "proofId": "abundant-number-oq-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "Abundant Numbers: Minimality, Closure, Infinitude",
+    "content": "A natural number $n$ is **abundant** when the sum of its proper divisors exceeds $n$, equivalently $\\sigma(n) > 2n$ where $\\sigma(n) = \\sum_{d \\mid n} d$. The abundant numbers begin $12, 18, 20, 24, 30, 36, \\dots$ (OEIS A005101).\n\nThis entry pins three facts using Mathlib's canonical `Nat.Abundant` predicate. **Minimality:** $12$ is the smallest abundant number (its proper divisors $1+2+3+4+6 = 16 > 12$), proved axiom-free by kernel `decide` in the companion file `AbundantNumberOQ01.lean`. **Closure:** every positive multiple of an abundant number is again abundant. **Infinitude:** the abundant numbers form an infinite set — the multiples $12, 24, 36, \\dots$ alone give an explicit infinite family.",
+    "mathContext": "`Nat.Abundant n := n < ∑_{d ∈ properDivisors n} d`. Mathlib records `Nat.abundant_twelve` but neither minimality, closure, nor infinitude.",
+    "significance": "key",
+    "prerequisites": [
+      "sum-of-divisors function σ",
+      "deficient / perfect / abundant classification"
+    ],
+    "relatedConcepts": [
+      "abundant number",
+      "abundancy index",
+      "OEIS A005101",
+      "divisor sum"
+    ]
+  },
+  {
+    "id": "abundant-ann-bridge",
+    "proofId": "abundant-number-oq-01",
+    "range": { "startLine": 38, "endLine": 53 },
+    "type": "technique",
+    "title": "From Proper Divisors to the Full Divisor Sum",
+    "content": "Mathlib defines abundance with *proper* divisors, but the multiplicative argument is cleanest with the *full* divisor sum. `abundant_iff_two_mul_lt_sigma` bridges the two: for any $n$,\n$$ n.\\mathrm{Abundant} \\iff 2n < \\sum_{d \\mid n} d. $$\nThe proof rewrites the full divisor sum as proper-divisor sum plus $n$ (`Nat.sum_divisors_eq_sum_properDivisors_add_self`) and finishes with `omega`. `pos_of_abundant` records the easy fact that an abundant number is positive (zero has no proper divisors).",
+    "mathContext": "Two equivalent forms of abundance: proper divisors exceed $n$, or the full divisor sum exceeds $2n$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Finset divisor sums",
+      "`Nat.sum_divisors_eq_sum_properDivisors_add_self`"
+    ],
+    "relatedConcepts": [
+      "σ(n)",
+      "proper divisors"
+    ]
+  },
+  {
+    "id": "abundant-ann-closure",
+    "proofId": "abundant-number-oq-01",
+    "range": { "startLine": 55, "endLine": 99 },
+    "type": "technique",
+    "title": "Abundance Is Closed Under Taking Multiples",
+    "content": "The structural heart of the entry: if $a$ is abundant and $t > 0$, then $a \\cdot t$ is abundant (`abundant_mul_right`). The proof injects the **scaled divisors** $d \\mapsto t \\cdot d$ of $a$ into the divisors of $a \\cdot t$. Since this map is injective (as $t > 0$) and its image is a subset of $\\mathrm{divisors}(a \\cdot t)$,\n$$ \\sigma(a \\cdot t) \\;\\ge\\; \\sum_{d \\mid a} t\\,d \\;=\\; t\\,\\sigma(a) \\;>\\; t \\cdot 2a \\;=\\; 2(a \\cdot t), $$\nso $a \\cdot t$ is abundant. `abundant_of_abundant_dvd` restates this via divisibility ($a \\mid m$, $m > 0$). Conceptually this says the abundancy index $\\sigma(n)/n$ is non-decreasing along divisibility.",
+    "mathContext": "An explicit injection of divisor finsets realizes monotonicity of σ(n)/n under multiplication.",
+    "significance": "key",
+    "prerequisites": [
+      "injections between Finsets",
+      "`Finset.sum_le_sum_of_subset`, `Finset.sum_image`"
+    ],
+    "relatedConcepts": [
+      "abundancy index",
+      "divisor injection",
+      "multiplicativity"
+    ]
+  },
+  {
+    "id": "abundant-ann-infinitude",
+    "proofId": "abundant-number-oq-01",
+    "range": { "startLine": 101, "endLine": 128 },
+    "type": "concept",
+    "title": "Infinitely Many Abundant Numbers",
+    "content": "Closure immediately yields infinitude. Instantiating `abundant_mul_right` at the abundant number $12$ gives `abundant_twelve_mul k : (12 \\cdot (k+1)).\\mathrm{Abundant}$ — every term of $12, 24, 36, \\dots$ is abundant. The family $k \\mapsto 12(k+1)$ is injective (`twelve_mul_succ_injective`, by cancelling the nonzero factor $12$), so `Set.infinite_of_injective_forall_mem` delivers\n$$ \\{\\, n : \\mathbb{N} \\mid n.\\mathrm{Abundant} \\,\\}\\ \\text{is infinite}. $$\nThis is the **structural complement to minimality**: not only does a smallest abundant number exist (it is $12$), the abundant numbers go on forever. Note infinitude is elementary — no analytic input — in contrast to the much deeper natural-density statement (density $\\approx 0.2476$).",
+    "mathContext": "An injective family of abundant numbers proves the set is infinite; `Set.infinite_of_injective_forall_mem`.",
+    "significance": "key",
+    "prerequisites": [
+      "`Set.Infinite`",
+      "injective families into a set"
+    ],
+    "relatedConcepts": [
+      "infinitude",
+      "natural density (Davenport)",
+      "multiples of 12"
+    ]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "abundant-number-oq-01",
+  "title": "Abundant Numbers: 12 Is Smallest, and There Are Infinitely Many",
+  "slug": "abundant-number-oq-01",
+  "description": "An abundant number n satisfies σ(n) > 2n (the sum of its proper divisors exceeds n). Working with Mathlib's canonical Nat.Abundant predicate, this entry establishes three facts: (1) minimality — 12 is the least abundant number, proved axiom-free by kernel decide; (2) closure — every positive multiple of an abundant number is abundant; and (3) infinitude — the abundant numbers form an infinite set, witnessed by the family {12·(k+1)}. All results are fully machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Antiquity (Nicomachus, ~100 CE); OEIS A005101",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantMultiplesOQ01.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "decidability",
+      "infinitude",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 167,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-18",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries across both source files. Minimality (AbundantNumberOQ01.lean) uses kernel `decide` — not `native_decide` — so it carries no `Lean.ofReduceBool` axiom; it builds directly on Mathlib's `Nat.abundant_twelve`. The closure and infinitude results (AbundantMultiplesOQ01.lean) are elementary Finset/divisor-sum arithmetic over ℕ with no decision procedure at all.",
+    "originalContributions": [
+      "Proves `IsLeast {n | n.Abundant} 12` (minimality of the smallest abundant number) using Mathlib's canonical `Nat.Abundant` predicate and the bounded kernel-`decide` check `∀ n < 12, ¬ Nat.Abundant n` — keeping the result axiom-free (no `native_decide`, hence no `Lean.ofReduceBool`).",
+      "Proves `abundant_mul_right` / `abundant_of_abundant_dvd`: every positive multiple of an abundant number is abundant — a structural closure fact Mathlib does not record. The proof injects the scaled divisors `d ↦ t·d` of `a` into the divisors of `a·t`, giving σ(a·t) ≥ t·σ(a) > t·(2a) = 2(a·t).",
+      "Supplies the bridge lemma `abundant_iff_two_mul_lt_sigma`: for n the proper-divisor form `n < ∑_{d∣n, d<n} d` is equivalent to the full divisor-sum form `2n < ∑_{d∣n} d`.",
+      "Proves `infinitely_many_abundant : {n : ℕ | n.Abundant}.Infinite` — there are infinitely many abundant numbers — by exhibiting the injective family `k ↦ 12·(k+1)` of abundant numbers, a direct consequence of closure under multiples."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of integers as deficient (σ(n) < 2n), perfect (σ(n) = 2n), or abundant (σ(n) > 2n) dates to Nicomachus of Gerasa (~100 CE) and is among the oldest themes in number theory. The abundant numbers begin 12, 18, 20, 24, 30, 36, … (OEIS A005101); 12 is the smallest, and Mathlib records its abundance as `Nat.abundant_twelve` but does not record minimality, closure, or infinitude. That abundant numbers are infinite is classical and elementary — every multiple of a perfect or abundant number is itself abundant, so the multiples of 12 alone already give an infinite supply. (Quantitatively, the abundant numbers have natural density ≈ 0.2476, a much deeper fact due to Davenport and others.)",
+    "problemStatement": "Working with Mathlib's `Nat.Abundant n := n < ∑_{d ∈ properDivisors n} d`, establish: (1) `IsLeast {n | n.Abundant} 12` — 12 is the least abundant number; (2) if `a.Abundant`, `a ∣ m`, `0 < m`, then `m.Abundant` — closure under multiples; and (3) `{n | n.Abundant}.Infinite` — there are infinitely many abundant numbers.",
+    "text": "A Lean 4 / Mathlib formalization in two companion files (166 lines total, 0 sorries, 0 axioms). `AbundantNumberOQ01.lean` settles minimality: `Nat.Abundant` is a decidable comparison of concrete divisor sums, so `not_abundant_below_twelve : ∀ n < 12, ¬ Nat.Abundant n` is discharged by kernel `decide` (the bounded quantifier via `Nat.decidableBallLT`), and combined with `Nat.abundant_twelve` yields `smallest_abundant : IsLeast {n | n.Abundant} 12`. `AbundantMultiplesOQ01.lean` proves the structural half: a bridge lemma rewriting abundance into the full divisor-sum form `2n < σ(n)`, then `abundant_mul_right` (positive multiples of an abundant number are abundant) via an injection of scaled divisors, and finally `infinitely_many_abundant` — the abundant numbers are infinite — from the injective abundant family `k ↦ 12·(k+1)`.",
+    "proofStrategy": "1. **Minimality (axiom-free decide).** `Nat.Abundant n` unfolds to a decidable inequality between concrete `ℕ` sums, so both `twelve_abundant := Nat.abundant_twelve` and `not_abundant_below_twelve : ∀ n < 12, ¬ Nat.Abundant n` are closed by kernel `decide`. `smallest_abundant : IsLeast {n | n.Abundant} 12` pairs membership with the lower bound: any abundant `n < 12` would contradict the bounded check.\n\n2. **Divisor-sum bridge.** `abundant_iff_two_mul_lt_sigma` rewrites `Nat.Abundant n` (proper-divisor form) into `2n < ∑_{d ∣ n} d` using `Nat.sum_divisors_eq_sum_properDivisors_add_self` and `omega`.\n\n3. **Closure under multiples.** For `a` abundant and `t > 0`, the map `d ↦ t·d` is injective on `a.divisors` and lands inside `(a·t).divisors`, so `∑_{e ∣ a·t} e ≥ t · ∑_{d ∣ a} d > t · 2a = 2(a·t)` — hence `a·t` is abundant (`abundant_mul_right`), and dividing through gives `abundant_of_abundant_dvd`.\n\n4. **Infinitude.** `abundant_twelve_mul k : (12·(k+1)).Abundant` instantiates closure at `a = 12`. The witnessing map `k ↦ 12·(k+1)` is injective, so `Set.infinite_of_injective_forall_mem` yields `infinitely_many_abundant : {n | n.Abundant}.Infinite`.",
+    "keyInsights": [
+      "**Minimality is a finite kernel computation.** Because `Nat.Abundant` is decidable, the lower bound `∀ n < 12, ¬ Nat.Abundant n` is a single bounded `decide` over eleven cases — no hand case analysis — and because it is kernel `decide` (not `native_decide`) the result is genuinely axiom-free, avoiding the `Lean.ofReduceBool` axiom.",
+      "**Abundance propagates upward along divisibility.** The abundancy index σ(n)/n is non-decreasing under multiplication: scaling the divisors of `a` by a factor `t` injects them into the divisors of `a·t`, so σ(a·t) ≥ t·σ(a). This single monotonicity is what turns one abundant number into an infinite family.",
+      "**Infinitude needs no analytic input.** Unlike the density statement (abundant numbers have density ≈ 0.2476, a 20th-century result), mere infinitude is elementary: the multiples of 12 are all abundant by closure, and there are infinitely many of them. The proof reduces to injectivity of `k ↦ 12·(k+1)`.",
+      "**Canonical predicate, axiom-free.** The entry works with Mathlib's own `Nat.Abundant` and `Nat.abundant_twelve` rather than a bespoke σ definition, and discharges minimality with kernel `decide`, so every claim is machine-checked with 0 axioms."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and proper divisors",
+      "Abundant / deficient / perfect classification",
+      "Finset sums, divisor finsets, and injections between them",
+      "Decidability and kernel `decide`; `IsLeast`, `Set.Infinite`, and injective families"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Closure and Infinitude: Statement",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring of AbundantMultiplesOQ01.lean: defines abundance via σ(n) > 2n, states the closure fact (every positive multiple of an abundant number is abundant) and its structural consequence (the abundant numbers form an infinite set, witnessed by {12·(k+1)}), and notes the proof is axiom-free.",
+      "mathContext": "Abundance propagates along divisibility because the abundancy index σ(n)/n is non-decreasing under multiplication."
+    },
+    {
+      "id": "bridge",
+      "title": "Divisor-Sum Bridge and Positivity",
+      "startLine": 38,
+      "endLine": 53,
+      "summary": "`abundant_iff_two_mul_lt_sigma` rewrites `Nat.Abundant n` (proper-divisor form) into the full divisor-sum form `2n < ∑_{d ∣ n} d` via `Nat.sum_divisors_eq_sum_properDivisors_add_self` and `omega`. `pos_of_abundant` records that abundant numbers are positive.",
+      "mathContext": "Two equivalent ways to say a number is abundant: proper divisors exceed n, or the full divisor sum exceeds 2n."
+    },
+    {
+      "id": "closure",
+      "title": "Multiples of an Abundant Number Are Abundant",
+      "startLine": 55,
+      "endLine": 99,
+      "summary": "`abundant_mul_right`: for abundant `a` and `t > 0`, the scaled divisors `d ↦ t·d` inject into the divisors of `a·t`, giving σ(a·t) ≥ t·σ(a) > t·2a = 2(a·t); hence `a·t` is abundant. `abundant_of_abundant_dvd` restates this via divisibility.",
+      "mathContext": "An explicit injection of divisor sets realizes the monotonicity of the abundancy index along divisibility."
+    },
+    {
+      "id": "infinitude",
+      "title": "Infinitely Many Abundant Numbers",
+      "startLine": 101,
+      "endLine": 128,
+      "summary": "`abundant_twelve_mul k` instantiates closure at 12: each `12·(k+1)` is abundant. `twelve_mul_succ_injective` shows the family is injective, and `Set.infinite_of_injective_forall_mem` delivers `infinitely_many_abundant : {n | n.Abundant}.Infinite`.",
+      "mathContext": "An injective family of abundant numbers proves the set of abundant numbers is infinite."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "infinitely_many_abundant",
+      "type": "core",
+      "description": "{n : ℕ | n.Abundant}.Infinite — there are infinitely many abundant numbers, witnessed by the injective family k ↦ 12·(k+1) of multiples of 12 (each abundant by closure). In AbundantMultiplesOQ01.lean.",
+      "leanType": "{n : ℕ | n.Abundant}.Infinite"
+    },
+    {
+      "name": "smallest_abundant",
+      "type": "core",
+      "description": "IsLeast {n : ℕ | n.Abundant} 12 — 12 is abundant (Nat.abundant_twelve) and a lower bound for the abundant numbers, i.e. the smallest abundant number. Proved axiom-free by kernel decide. In AbundantNumberOQ01.lean.",
+      "leanType": "IsLeast {n : ℕ | n.Abundant} 12"
+    },
+    {
+      "name": "abundant_mul_right",
+      "type": "supporting",
+      "description": "If a.Abundant and 0 < t then (a * t).Abundant — closure of abundance under positive multiplication, via an injection of scaled divisors. In AbundantMultiplesOQ01.lean.",
+      "leanType": "a.Abundant → 0 < t → (a * t).Abundant"
+    },
+    {
+      "name": "abundant_of_abundant_dvd",
+      "type": "supporting",
+      "description": "If a.Abundant, a ∣ m, 0 < m then m.Abundant — divisibility form of closure under multiples. In AbundantMultiplesOQ01.lean.",
+      "leanType": "a.Abundant → a ∣ m → 0 < m → m.Abundant"
+    },
+    {
+      "name": "not_abundant_below_twelve",
+      "type": "supporting",
+      "description": "∀ n < 12, ¬ Nat.Abundant n — the lower bound for minimality; a finite divisor-sum check discharged by kernel decide via Nat.decidableBallLT. In AbundantNumberOQ01.lean.",
+      "leanType": "∀ n < 12, ¬ Nat.Abundant n"
+    }
+  ],
+  "conclusion": {
+    "summary": "Using Mathlib's canonical Nat.Abundant predicate, the entry pins three facts about abundant numbers: 12 is the smallest (axiom-free kernel decide), abundance is closed under taking positive multiples, and the abundant numbers form an infinite set (the multiples 12·(k+1) give an explicit injective abundant family). All 10 theorems are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "Closure under multiples is the structural engine: it converts a single witness (12) into an infinite family and underlies the elementary proof of infinitude, which needs no analytic input — in contrast to the natural-density statement (abundant numbers have density ≈ 0.2476), which is a far deeper 20th-century result. The same scaled-divisor injection shows the abundancy index σ(n)/n is non-decreasing along divisibility, a fact useful for any argument that propagates abundance, perfection-adjacency, or related divisor-sum inequalities upward.",
+    "openQuestions": [
+      "Prove that the abundant numbers have positive natural density (Davenport: the density of {n : σ(n) > 2n} exists and is ≈ 0.2476), or at least a clean lower bound such as density ≥ 1/4 from the multiples of any fixed abundant number.",
+      "Formalize that 945 is the smallest odd abundant number — a minimality statement whose bounded check is far larger and likely needs a kernel-reducible σ to remain axiom-free.",
+      "Show every integer greater than 20161 is the sum of two abundant numbers (the largest integer that is not such a sum is 20161), connecting closure to an additive-basis question."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant (superabundant)."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005101: Abundant numbers (sum of divisors of n exceeds 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The sequence 12, 18, 20, 24, 30, 36, … of abundant numbers; 12 is the smallest."
+    },
+    {
+      "authors": "H. Davenport",
+      "title": "Über numeri abundantes",
+      "year": "1933",
+      "venue": "Sitzungsber. Preuss. Akad. Wiss.",
+      "note": "Establishes that the abundant numbers have a well-defined natural density (≈ 0.2476)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "related",
+      "description": "The sum-of-divisors entry formalizes σ broadly with file-local IsAbundant/sigma definitions and independently records that 12 is the smallest abundant number (there via native_decide). This entry instead uses Mathlib's canonical Nat.Abundant, proves minimality axiom-free with kernel decide, and adds the closure and infinitude results that sum-of-divisors does not contain."
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related",
+      "description": "Perfect numbers satisfy σ(n) = 2n, the boundary case between deficient and abundant. The same divisor-sum function and classification underlie both entries; closure under multiples shows any proper multiple of a perfect number is abundant."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantMultiplesOQ01.lean",
+    "namespace": "AbundantMultiplesOQ01",
+    "imports": [
+      "Mathlib"
+    ],
+    "lineCount": 128,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 7,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Registers two orphaned modules and adds a gallery entry for **abundant-number-oq-01**, pinning three facts about abundant numbers using Mathlib's canonical `Nat.Abundant` predicate:

1. **Minimality** — `IsLeast {n | n.Abundant} 12`: 12 is the least abundant number, proved axiom-free by kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool`).
2. **Closure** — `abundant_mul_right` / `abundant_of_abundant_dvd`: every positive multiple of an abundant number is abundant, via an injection of scaled divisors `d ↦ t·d` giving `σ(a·t) ≥ t·σ(a) > 2(a·t)`.
3. **Infinitude** (headline) — `infinitely_many_abundant : {n : ℕ | n.Abundant}.Infinite`, witnessed by the injective family `k ↦ 12·(k+1)` of multiples of 12.

## Verification

- **Docker build of `Proofs.AbundantMultiplesOQ01` + `Proofs.AbundantNumberOQ01` succeeds** (Lean v4.26.0, 7743 jobs).
- 0 sorries, 0 axioms, no `native_decide` → `status: verified`, `badge: verified`.
- Annotations validated against the Lean source (4/4 valid, 0 misaligned).

The prior session's "checked via Aristotle, build-pending" note was inaccurate — the first build surfaced two real errors, both fixed here:
- `pos_of_abundant`: `by decide` could not synthesize `Decidable ¬Nat.Abundant 0`; rewritten via the divisor-sum bridge + `Nat.divisors_zero`.
- `abundant_mul_right`: `Finset.sum_image` higher-order unification failed on a `∑ d, t·d` target; restructured so the image sum is over the bound variable (`g = id` Miller pattern).

## Distinct value vs `sum-of-divisors`

The existing `sum-of-divisors` entry records minimality of 12 via a file-local `sigma`/`IsAbundant` and `native_decide`. This entry instead uses Mathlib's canonical `Nat.Abundant`, proves minimality axiom-free with kernel `decide`, and adds the closure and infinitude results that `sum-of-divisors` does not contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)