### PR TITLE
audit(erdos-1145): fix phantom 'axiomatized' prose (Ruzsa proved, Grekos not formalized)

### DIFF
--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -87,7 +87,7 @@
       "title": "Necessity via Ruzsa's Counterexample",
       "startLine": 190,
       "endLine": 619,
-      "summary": "**Proved** (from axiomatized Ruzsa properties): The ratio condition $a_n/b_n \\to 1$ is **necessary**. Ruzsa's binary digit construction gives $A, B$ with $A+B = \\mathbb{N}$ but $r_{A,B}(n) = 1$ for all $n \\geq 1$, and $a_n/b_n \\to 1/2 \\neq 1$. The $n = 0$ case requires a separate argument bounding the pair set by a singleton.",
+      "summary": "**Proved** (from in-file Ruzsa lemmas, no axioms): The ratio condition $a_n/b_n \\to 1$ is **necessary**. Ruzsa's binary digit construction gives $A, B$ with $A+B = \\mathbb{N}$ but $r_{A,B}(n) = 1$ for all $n \\geq 1$, and $a_n/b_n \\to 1/2 \\neq 1$. The Ruzsa properties (uniqueness of representation, infinitude) were previously axiomatized but are now fully derived in-file via `ruzsa_unique_rep`. The $n = 0$ case requires a separate argument bounding the pair set by a singleton.",
       "mathContext": "Ruzsa: $A$ = even binary positions, $B$ = odd positions. Unique representations, bounded $r = 1$, $a_n/b_n \\to 1/2$."
     },
     {
@@ -103,8 +103,8 @@
       "title": "Partial Results (Grekos et al.)",
       "startLine": 692,
       "endLine": 696,
-      "summary": "Axiomatized partial result of Grekos, Haddad, Helou, and Pihko: under the full hypotheses, $r_{A,B}(n) \\geq 6$ infinitely often. This is the best known unconditional bound but far from the conjectured unboundedness.",
-      "mathContext": "$\\forall M,\\, \\exists n > M,\\, r_{A,B}(n) \\geq 6$ (Grekos et al.)."
+      "summary": "Background (not formalized): the best known unconditional partial result of Grekos, Haddad, Helou, and Pihko is $r_{A,B}(n) \\geq 6$ infinitely often under the full hypotheses — far from the conjectured unboundedness. This file records the result only as a docstring (Part IX); it is neither axiomatized nor proved here.",
+      "mathContext": "$\\forall M,\\, \\exists n > M,\\, r_{A,B}(n) \\geq 6$ (Grekos et al.) — literature result, recorded as a docstring, not a Lean declaration."
     },
     {
       "id": "structural-results",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1145

**Proof**: erdos-1145 (Erdős–Sárközy conjecture on two-set bases, OPEN)
**Result**: issues-fixed (prose only — no count/status change)

### Counts verified (all honest)
| field | meta | source | ✓ |
|-------|------|--------|---|
| lineCount | 737 | 737 | ✓ |
| axiomCount | 1 | 1 (`erdos_sarkozy_conjecture`) | ✓ |
| theoremCount | 39 | 39 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| structures | — | 0 (no structure-encoded assumptions) | ✓ |

`status: axiomatized` / `badge: axiom` is correct — single axiom is the OPEN main conjecture. No `ofReduceBool` (no `native_decide`).

### Two prose inaccuracies about file content (fixed)

1. **`ruzsa-counterexample` section** claimed results were derived "from axiomatized Ruzsa properties." The in-file comments confirm these were *"Previously axiomatized; now proved/derived via `ruzsa_unique_rep`"* (lines 338, 429, 438). The only axiom in the file is the main conjecture. Reworded to credit the in-file Ruzsa lemmas and note no axioms are used here.

2. **`partial-results` section** claimed an *"Axiomatized partial result of Grekos, Haddad, Helou, and Pihko"* (r ≥ 6 infinitely often) — but **no such axiom or theorem exists**. Part IX (lines 692–696) is a docstring comment only, immediately followed by the structural-results theorems. Reworded to mark the r ≥ 6 bound as literature background recorded in a docstring, not formalized.

The `historicalContext` (which correctly attributes the r ≥ 6 bound to the literature) was left unchanged — it is accurate math history, not a claim about the formalization.

---
Discovered during gallery integrity audit.