### PR TITLE
research(erdos-1107-oq-02-oq-01): disclose Lean.ofReduceBool from native_decide

### DIFF
--- a/src/data/proofs/erdos-1107-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02-oq-01/meta.json
@@ -30,9 +30,9 @@
       "Computational verification (native_decide) for all n up to 3000; external (non-Lean) check stable to 10⁷ (verify_cubeful_stability.py)",
       "Motivates the structural r+1 law — ≤3 cubeful summands miss a positive density, so r=3 needs 4 — as the heuristic framing; this density argument is stated in prose, not formalized in the Lean source"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 220,
-    "assumptions": "1 axiom: cubeful_sum_threshold (every n ≥ 2040 is a sum of ≤4 cubeful numbers) — this is the open r=3 asymptotic, the cubeful analogue of Heath-Brown's r=2 theorem, which appears to remain unproven. The finite range [1, 3000] and the 45-element exceptional set are settled by native_decide. Computation independently reproduced (verify_cubeful_stability.py and an external check confirm the 45 exceptions, the tight threshold 2039/2040, and no failures in [2040, 3000]). The Lean file compiles cleanly (machine-verified, Lean 4.26.0 / Mathlib, 3058 jobs): all native_decide blocks and structural lemmas are checked, leaving the single axiom as the only assumption.",
+    "assumptions": "2 assumptions. (1) axiom cubeful_sum_threshold (every n ≥ 2040 is a sum of ≤4 cubeful numbers) — the open r=3 asymptotic, the cubeful analogue of Heath-Brown's r=2 theorem, which appears to remain unproven. (2) Lean.ofReduceBool — the finite range [1, 3000] and the 45-element exceptional set are settled by native_decide (theorems exceptions_not_representable, not_sum4_2039/threshold_tight, below_threshold_nonexceptions, range_2040_2300/2301_2600/2601_3000, threshold_2040, isCubeful_8/16/27/2000, not_isCubeful_24), which trusts the compiler's kernel reduction and so depends on Lean.ofReduceBool (it shows in #print axioms; the computational results are not axiom-free). Computation independently reproduced (verify_cubeful_stability.py and an external check confirm the 45 exceptions, the tight threshold 2039/2040, and no failures in [2040, 3000]). The Lean file compiles cleanly (machine-verified, Lean 4.26.0 / Mathlib, 3058 jobs): all native_decide blocks and structural lemmas are checked. leanFile.axiomCount counts only the literal axiom declaration (1); this meta.axiomCount counts all assumptions including ofReduceBool (2).",
     "theoremCount": 18,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Summary

Axiom-integrity fix for the **Effective Cubeful Sum Threshold (r=3)** gallery entry (Erdős #1107).

The entry settles its headline deliverables — the **45 exceptions**, the **tight threshold 2039/2040**, and the **finite ranges [1, 3000]** — with `native_decide` (16 occurrences). Per the project's `native_decide` axiom rule, `native_decide` trusts the compiler's kernel reduction and depends on `Lean.ofReduceBool` (it appears in `#print axioms`; those results are *not* axiom-free). The meta.json previously reported `axiomCount: 1` (only the conjectural axiom) and never disclosed `Lean.ofReduceBool`.

This mirrors prior auditor precedent (erdos-1054-oq-01, PR #25643): disclosure applies even when an entry is already `axiomatized` for another reason.

## Changes (meta.json only — no status change)

- `meta.axiomCount` 1 → **2** (`cubeful_sum_threshold` + `Lean.ofReduceBool`)
- `leanFile.axiomCount` stays **1** (literal `axiom` declarations only)
- `assumptions`: now discloses `Lean.ofReduceBool` and names the theorems that rely on it

Status remains `axiomatized` / badge `axiom` — the entry already carries the open r=3 asymptotic axiom `cubeful_sum_threshold`. The substantive `native_decide` deliverables are unchanged; only their assumption footprint is now honestly recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)