### PR TITLE
Fix: erdos-1007-oq-01-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1007OQ01OQ01.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "monotonicity",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,9 +55,9 @@
       "Verified: known deficiency values all satisfy δ(d) ≤ d",
       "Growth classification: d ≤ f(d) ≤ d(d+1)/2 for all d ≥ 1"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 388,
-    "assumptions": "0 axioms, 0 sorries. All 32 theorems fully proved.",
+    "assumptions": "Depends on Lean.ofReduceBool: six theorems are discharged by native_decide — known_deficiency and d4_deficiency_satisfies_bound (the named deliverable 'known deficiency values all satisfy δ(d) ≤ d'), f6_bounds (the f(6) ∈ [6,21] range), optimal_implies_monotone', known_deficiency_bound, and anomaly_gap. native_decide trusts the compiler's kernel reduction, so #print axioms lists Lean.ofReduceBool; these results are not axiom-free. 0 sorries; no literal axiom declarations (leanFile.axiomCount = 0). The abstract framework (deficiency bound theorem, monotonicity equivalences, gap theorem) is native_decide-free.",
     "mathlib_version": "4.26.0",
     "theoremCount": 32,
     "definitionCount": 4
@@ -131,7 +131,7 @@
   "overview": {
     "historicalContext": "The concept of graph dimension was introduced by Erdős, Harary, and Tutte in their 1965 paper 'On the dimension of a graph': the dimension $\\dim(G)$ is the smallest $d$ such that $G$ can be embedded in $\\mathbb{R}^d$ with all edges having unit length. They established $\\dim(K_n) = n - 1$ and initiated the study of which graphs require high dimension.\n\nThe minimum edges question — what is the fewest edges a graph of dimension exactly $d$ can have? — has been studied incrementally. For $d \\leq 3$, the answer is $\\binom{d+1}{2}$ (the complete graph $K_{d+1}$). House (2013) proved $\\operatorname{minEdges}(4) = 9$, showing $K_{3,3}$ is the unique optimal graph for $d = 4$ — the first case where the complete graph is not optimal, since $K_5$ has 10 edges. Chaffee and Noble (2016) proved $\\operatorname{minEdges}(5) = 15 = \\binom{6}{2}$, restoring the complete graph pattern. No values for $d \\geq 6$ are known.\n\nThe monotonicity question — does $d_1 \\leq d_2$ imply $\\operatorname{minEdges}(d_1) \\leq \\operatorname{minEdges}(d_2)$? — is a natural structural conjecture. It is intuitively plausible (higher dimension should require more edge constraints) but the $d = 4$ anomaly shows the function is not simply $\\binom{d+1}{2}$, making a proof non-trivial. The known sequence $0, 1, 3, 6, 9, 15$ is monotone, but the gap at $d = 5 \\to 6$ (where $\\operatorname{minEdges}(6)$ is unknown and could be as low as 6) leaves the conjecture open.",
     "problemStatement": "Is the function minEdges(d) — the minimum number of edges in a graph of dimension exactly d — monotone (non-decreasing) in d? Equivalently, does every dimension d₂ graph need at least as many edges as the most efficient dimension d₁ graph, when d₁ ≤ d₂?",
-    "text": "A 388-line, axiom-free investigation of the monotonicity conjecture for graph dimension minimum edges. The key design choice is the `MinEdgesConstraints` structure, which abstracts over any candidate for the true $\\operatorname{minEdges}$ function — avoiding dependence on placeholder values for $d \\geq 6$. The central result is the **deficiency bound theorem**: if $\\delta(d) = \\binom{d+1}{2} - f(d) \\leq d$ for all $d \\geq 1$, then $f$ is monotone, proved via a three-step inequality chain using Pascal's rule and binomial monotonicity. The formalization reduces the infinite conjecture to a single inequality at the critical gap ($f(6) \\geq 15$) and identifies two weaker sufficient conditions: complete graph optimality and the half-quadratic bound $f(d) \\geq \\binom{d}{2}$. All 32 theorems are fully proved with 0 sorries.",
+    "text": "A 388-line investigation of the monotonicity conjecture for graph dimension minimum edges. The key design choice is the `MinEdgesConstraints` structure, which abstracts over any candidate for the true $\\operatorname{minEdges}$ function — avoiding dependence on placeholder values for $d \\geq 6$. The central result is the **deficiency bound theorem**: if $\\delta(d) = \\binom{d+1}{2} - f(d) \\leq d$ for all $d \\geq 1$, then $f$ is monotone, proved via a three-step inequality chain using Pascal's rule and binomial monotonicity. The formalization reduces the infinite conjecture to a single inequality at the critical gap ($f(6) \\geq 15$) and identifies two weaker sufficient conditions: complete graph optimality and the half-quadratic bound $f(d) \\geq \\binom{d}{2}$. All 32 theorems are proved with 0 sorries; six concrete numeric facts (the known deficiency values, the $f(6)$ range, and the $d=4$ anomaly gap) are discharged by `native_decide`, which adds a dependency on `Lean.ofReduceBool`. The abstract framework theorems are `native_decide`-free.",
     "proofStrategy": "The formalization introduces a `MinEdgesConstraints` structure abstracting over any candidate for the true minEdges function. This avoids dependence on placeholder values for d ≥ 6. The central result is the **deficiency bound theorem**: if δ(d) = C(d+1,2) - f(d) ≤ d for all d ≥ 1, then f is monotone. The proof chains three inequalities: f(d₁) ≤ C(d₁+1,2) (upper bound), C(d₁+1,2) ≤ C(d₂,2) (binomial monotonicity for d₁ < d₂), and C(d₂,2) ≤ f(d₂) (from deficiency bound + Pascal's rule).",
     "keyInsights": [
       "**The deficiency bound is the key**: $\\delta(d) = \\binom{d+1}{2} - f(d) \\leq d$ implies monotonicity via the three-step chain $f(d_1) \\leq \\binom{d_1+1}{2} \\leq \\binom{d_2}{2} \\leq f(d_2)$. This uses Pascal's rule $\\binom{d+1}{2} - d = \\binom{d}{2}$ to convert the deficiency bound into a usable lower bound.",
@@ -147,7 +147,7 @@
     ]
   },
   "conclusion": {
-    "summary": "We establish a structural framework for the monotonicity question, proving it reduces to consecutive monotonicity for d ≥ 5, and identifying the deficiency bound δ(d) ≤ d as the key sufficient condition. All 32 theorems are fully proved with 0 axioms and 0 sorries.",
+    "summary": "We establish a structural framework for the monotonicity question, proving it reduces to consecutive monotonicity for d ≥ 5, and identifying the deficiency bound δ(d) ≤ d as the key sufficient condition. All 32 theorems are proved with 0 sorries; six concrete numeric verifications use native_decide (depending on Lean.ofReduceBool), while the abstract framework is native_decide-free.",
     "implications": "**Concrete targets**: The deficiency bound theorem provides a concrete target for proving monotonicity: show $\\delta(d) = \\binom{d+1}{2} - \\operatorname{minEdges}(d) \\leq d$ for all $d$. Alternatively, the half-quadratic condition ($f(d) \\geq \\binom{d}{2}$) suffices and is weaker.\n\n**Reduction to finite computation**: The reduction to $d \\geq 5$ means the infinite conjecture hinges on the unknown regime. Computing $\\operatorname{minEdges}(6)$ would either confirm or refute the critical gap ($\\operatorname{minEdges}(6) \\geq 15$?).\n\n**Abstract axiomatization pattern**: The `MinEdgesConstraints` design is reusable: any extremal function with known small values and growth bounds can be analyzed for structural properties (monotonicity, convexity, etc.) without committing to specific values in the unknown range.\n\n**Connection to graph rigidity**: The $d=4$ anomaly ($K_{3,3}$ beating $K_5$) suggests that graph dimension is sensitive to the global structure of unit-distance embeddings, not just the number of constraints. Understanding this anomaly may require tools from rigidity theory and algebraic geometry.",
     "openQuestions": [
       "Does $\\operatorname{minEdges}(6) \\geq 15$? This is the critical gap: the formalization shows monotonicity for $d \\leq 5$ is unconditional, but $f(5) \\leq f(6)$ requires $f(6) \\geq 15$ while only $f(6) \\geq 6$ is known.",


### PR DESCRIPTION
## Fix

Flip \`erdos-1007-oq-01-oq-01\` (Is minEdges Monotone in d?) from \`verified\` to \`axiomatized\` — six named-deliverable theorems are discharged by \`native_decide\`, which depends on \`Lean.ofReduceBool\`.

## Evidence

\`grep -n native_decide proofs/Proofs/Erdos1007OQ01OQ01.lean\` → 6 tactic uses (L136, 192, 227, 285, 326, 347), all in theorems that are advertised deliverables in \`originalContributions\`:

- **known_deficiency** (L136) + **d4_deficiency_satisfies_bound** (L192) + **known_deficiency_bound** (L326) — back the contribution *"Verified: known deficiency values all satisfy δ(d) ≤ d"*
- **f6_bounds** (L227) — the *"6 ≤ f(6) ≤ 21"* range cited in the critical-gap contribution
- **optimal_implies_monotone'** (L285) — the *"Optimality implies monotonicity"* contribution
- **anomaly_gap** (L347) — the d=4 anomaly fact

Per the project Axiom Integrity Policy, when \`native_decide\` discharges a substantive presented result, the entry must be \`axiomatized\` and disclose \`Lean.ofReduceBool\`.

**Before**: \`status: verified\`, \`badge: mathlib\`, \`axiomCount: 0\`, assumptions *"0 axioms, 0 sorries. All 32 theorems fully proved."*
**After**: \`status: axiomatized\`, \`badge: axiom\`, \`axiomCount: 1\`, assumptions disclose \`Lean.ofReduceBool\` and name the six native_decide theorems. \`leanFile.axiomCount\` stays 0 (no literal \`axiom\` declarations). The abstract framework (deficiency bound theorem, monotonicity equivalences, gap theorem) is native_decide-free and noted as such.

---
Automated fix by lean-mechanic agent.