### PR TITLE
Fix: arithmetic-series-oq-04-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Johann Faulhaber (1631); formalized in Lean 4",
     "date": "1631",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ04OQ01.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "combinatorics",
       "induction"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 305,
-    "assumptions": "0 axioms, 0 sorries. All theorems proved by induction with push_cast + linarith. Uses Mathlib only for Finset.sum_Ico_succ_top and push_cast.",
+    "assumptions": "Depends on Lean.ofReduceBool: the six Part V numerical-verification theorems (sum_fourth_10, sum_fifth_10, sum_sixth_10, sum_fourth_10_check, sum_fifth_10_check, faulhaber_structure_p5_n10) are discharged by native_decide, which trusts the compiler's kernel reduction, so #print axioms lists Lean.ofReduceBool. The closed-form power-sum formulas and Faulhaber/Nicomachus structural theorems (Parts I–IV) are proved by induction with push_cast + linarith and are axiom-free. 0 sorries; no literal axiom declarations (leanFile.axiomCount = 0). Uses Mathlib for Finset.sum_Ico_succ_top and push_cast.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -96,7 +96,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization extends Faulhaber's formula to p=4,5,6 and demonstrates the structural insight behind it: odd-power sums factor through the triangular number T(n)^2. The uniform proof pattern (induction + push_cast + linarith) scales cleanly to higher powers. All 19 theorems are fully proved with 0 sorries and 0 axioms.",
+    "summary": "This formalization extends Faulhaber's formula to p=4,5,6 and demonstrates the structural insight behind it: odd-power sums factor through the triangular number T(n)^2. The uniform proof pattern (induction + push_cast + linarith) scales cleanly to higher powers. All 19 theorems are proved with 0 sorries; the closed-form and structural theorems are axiom-free, while the six Part V numerical verifications (n=10) use native_decide and so depend on Lean.ofReduceBool.",
     "implications": "Faulhaber's triangular number structure reveals a hidden simplicity in power sums that the Bernoulli number formula obscures. The pattern T(n)^2 * (polynomial in T(n)) for odd p suggests a deeper algebraic explanation, possibly related to the umbral calculus or the representation theory of symmetric polynomials. The even-power common factor n(n+1)(2n+1) connects to the Bernoulli polynomial factorization.",
     "openQuestions": [
       "Can we prove Faulhaber's general structural theorem: for all odd p >= 1, sum k^p is a polynomial in T(n)?",


### PR DESCRIPTION
## Fix

Flip \`arithmetic-series-oq-04-oq-01\` (Higher Power Sums and Faulhaber's Triangular Number Structure) from \`verified\` to \`axiomatized\` — six Part V numerical-verification theorems use \`native_decide\`, which depends on \`Lean.ofReduceBool\`.

## Evidence

\`grep -n native_decide proofs/Proofs/ArithmeticSeriesOQ04OQ01.lean\` → 6 tactic uses (L258–274): \`sum_fourth_10\`, \`sum_fifth_10\`, \`sum_sixth_10\`, \`sum_fourth_10_check\`, \`sum_fifth_10_check\`, \`faulhaber_structure_p5_n10\` — the "Part V: Numerical Verifications" section (n=10 instance checks).

Per the project Axiom Integrity Policy, \`native_decide\` trusts the compiler's kernel reduction, so \`#print axioms\` lists \`Lean.ofReduceBool\`; the entry's "0 axioms" claim is inaccurate. This matches the prior merged flip of the sibling \`sum-of-kth-powers\` (also concrete numeric checks via native_decide → axiomatized).

**Before**: \`status: verified\`, \`badge: original\`, \`axiomCount: 0\`, assumptions/conclusion claim "0 axioms" / "All 19 theorems fully proved with 0 axioms".
**After**: \`status: axiomatized\`, \`badge: axiom\`, \`axiomCount: 1\`, assumptions disclose \`Lean.ofReduceBool\` and name the six native_decide theorems. The closed-form power-sum formulas and Faulhaber/Nicomachus structural theorems (Parts I–IV, proved by induction) remain axiom-free and are noted as such. \`leanFile.axiomCount\` stays 0 (no literal \`axiom\` declarations).

---
Automated fix by lean-mechanic agent.