### PR TITLE
Fix: divisibility-rules-oq-02 native_decide → axiomatized

### DIFF
--- a/proofs/Proofs/DivisibilityRulesOQ02.lean
+++ b/proofs/Proofs/DivisibilityRulesOQ02.lean
@@ -126,7 +126,7 @@ theorem hundredone_dvd_iff_altDigitSum (n : ℕ) :
 /-!
 ## Summary
 
-**Proved (0 axioms, 0 sorries):**
+**Proved (0 sorries; concrete instances depend on Lean.ofReduceBool via native_decide):**
 1. **seven_modEq_altDigitSum_1000**: n ≡ altDigitSum₁₀₀₀(n) (mod 7)
 2. **seven_dvd_iff_altDigitSum**: 7 | n ↔ 7 | altDigitSum₁₀₀₀(n)
 3. **thirteen_modEq_altDigitSum_1000**: n ≡ altDigitSum₁₀₀₀(n) (mod 13)

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Classical number theory, formalized in Lean 4",
     "date": "",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -14,9 +14,9 @@
       "algorithms"
     ],
     "proofRepoPath": "Proofs/DivisibilityRulesOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 142,
     "originalContributions": [
       "dvd_iff_dvd_altDigitSum: general alternating block divisibility rule",
@@ -25,7 +25,7 @@
       "eleven_dvd_iff_altDigitSum: classical div-by-11 as instance of general rule",
       "hundredone_dvd_iff_altDigitSum: div-by-101 via 2-digit blocks"
     ],
-    "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified.",
+    "assumptions": "Depends on Lean.ofReduceBool. The key modular congruences (thousand_mod_seven, thousand_mod_thirteen) and the side conditions of the named divisibility tests (eleven_dvd_iff_altDigitSum, hundredone_dvd_iff_altDigitSum) are discharged by native_decide, which trusts the Lean compiler's kernel reduction. The general theorem dvd_iff_dvd_altDigitSum is itself native_decide-free; only its concrete instantiations rely on ofReduceBool. 0 literal axiom declarations, 0 sorry(s).",
     "dateAdded": "2026-04-12",
     "theoremCount": 9,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Entry `divisibility-rules-oq-02` was marked `verified` / `original` / `axiomCount: 0` with assumptions "Fully verified", but four of its five named deliverables depend on `native_decide` (which trusts the Lean compiler's kernel reduction via the `Lean.ofReduceBool` axiom — not axiom-free).

## Evidence

The named divisibility tests in `originalContributions` rely on `native_decide`:
- `seven_dvd_iff_altDigitSum` — built on `thousand_mod_seven : 1000 % 7 = 6 := by native_decide` (L38)
- `thirteen_dvd_iff_altDigitSum` — built on `thousand_mod_thirteen : 1000 % 13 = 12 := by native_decide` (L84)
- `eleven_dvd_iff_altDigitSum` — side condition `(by native_decide)` (L118)
- `hundredone_dvd_iff_altDigitSum` — side condition `(by native_decide)` (L124)

The general `dvd_iff_dvd_altDigitSum` is itself `native_decide`-free; only its concrete instantiations carry the dependency.

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, assumptions "Fully verified"; Lean summary claimed "Proved (0 axioms, 0 sorries)".
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`; Lean summary corrected. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Per the project Axiom Integrity Policy: when `native_decide` discharges a substantive result an entry presents as verified, count it (`axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`).

---
Automated fix by lean-mechanic agent.