### PR TITLE
Fix: divisibility-by-three-oq-01-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root#Properties",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "digital-root",
@@ -17,10 +17,10 @@
       "modular-arithmetic"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01OQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 sorries, 0 axioms. Fully machine-checked.",
+    "axiomCount": 1,
+    "assumptions": "0 sorries, 0 explicit axiom declarations. Several load-bearing lemmas (digitSum_le_self, digitSum_modEq_9, digitSum_single, digitSum_pos) are discharged by `native_decide`, so the headline theorem iterDigitSum_converges transitively depends on the `Lean.ofReduceBool` axiom (trusting compiler kernel reduction). #print axioms iterDigitSum_converges lists Lean.ofReduceBool alongside the standard propext/Classical.choice/Quot.sound.",
     "originalContributions": [
       "digitSum_le_self: (Nat.digits 10 n).sum \u2264 n for all n (manual proof via Nat.digits_def')",
       "digitSum_lt_of_ge_ten: digitSum n < n for n \u2265 10 (manual proof, avoids Nat.sum_digits_lt naming issue)",


### PR DESCRIPTION
## Fix

The Digital Root Iteration convergence entry was marked `verified` / badge `mathlib` / `0 axioms` / "Fully machine-checked", but its headline result transitively depends on `native_decide`.

## Evidence

`native_decide` is **load-bearing** (not redundant verification examples) in four general lemmas:

- `digitSum_le_self` — `interval_cases n <;> native_decide` (n < 10 base cases), line 44
- `digitSum_modEq_9` — `Nat.modEq_digits_sum 9 10 (by native_decide) n`, discharging `10 ≡ 1 (mod 9)`, line 63
- `digitSum_single` — `interval_cases n <;> native_decide`, line 70
- `digitSum_pos` — `interval_cases n <;> native_decide`, line 83

These feed the main theorem `iterDigitSum_converges` (via `digitSum_lt_of_ge_ten → iterDigitSum_terminates`, and `iterDigitSum_modEq_9`). `native_decide` trusts compiler kernel reduction, so `#print axioms iterDigitSum_converges` lists `Lean.ofReduceBool` — the entry is not axiom-free.

Per the project Axiom Integrity Policy (`native_decide` discharging a substantive presented-as-verified result must be counted):

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `assumptions: "0 sorries, 0 axioms. Fully machine-checked."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

No Lean source changed — this is a metadata honesty fix.

---
Automated fix by lean-mechanic agent.