### PR TITLE
Fix: cramers-rule-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/cramers-rule-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Efficiency",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CramersRuleOQ02.lean",
     "tags": [
       "computational-complexity",
@@ -19,7 +19,7 @@
       "algorithms",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -52,9 +52,9 @@
     ],
     "dateAdded": "2026-02-26",
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 207,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Relies on `Lean.ofReduceBool`: the small-case results are established by `native_decide`. Specifically, the named contribution \"Gaussian beats Cramer for ALL n ≥ 1\" (`complexity_threshold`) discharges its n = 1, 2, 3 base cases via `native_decide` (the symbolic factorial-growth argument only covers n ≥ 4), and the concrete multiplication counts (`cramer_4/5/6`, e.g. `cramersRuleMuls 4 = 480`) feeding the summary theorem are likewise computed by `native_decide`. These trust the Lean compiler's kernel reduction (`Lean.ofReduceBool`), so the proof is not axiom-free. The abstract n ≥ 4 comparison (`gauss_beats_cramer`) and the asymptotic superiority theorem (`cramer_asymptotically_worse`) are `native_decide`-free. 0 sorries.",
     "theoremCount": 16,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Fix

`cramers-rule-oq-02` was marked `verified` / `mathlib` / 0 axioms with `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`, but a named deliverable relies on `native_decide`.

## Evidence

The native_decide is **load-bearing for a named originalContribution**, not redundant evidence:

- Contribution #5 *"Gaussian beats Cramer for ALL n ≥ 1 in the n³ model"* = `complexity_threshold` (L184), whose **n = 1, 2, 3 base cases are discharged by `native_decide`**. The symbolic factorial-growth argument (`gauss_beats_cramer`) only covers n ≥ 4 — the "ALL n ≥ 1" claim is not provable without the small-case `native_decide`.
- The concrete counts `cramer_4/5/6` (e.g. `cramersRuleMuls 4 = 480`, L79/83/87) feeding `cramer_vs_gauss_summary` part (3) and `cramer_much_worse_at_*` are also `native_decide`.

`native_decide` trusts the compiler's kernel reduction → depends on `Lean.ofReduceBool`, so the proof is **not** axiom-free (per the project's `native_decide` rule).

The abstract n ≥ 4 comparison (`gauss_beats_cramer`) and asymptotic theorem (`cramer_asymptotically_worse`) are genuinely `native_decide`-free.

**Before**: `status: verified`, `badge: mathlib`, `meta.axiomCount: 0`, assumptions claim "0 axioms".
**After**: `status: axiomatized`, `badge: axiom`, `meta.axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and scope which results depend on it. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.