### PR TITLE
audit(erdos-1141): disclose Lean.ofReduceBool from native_decide computations

### DIFF
--- a/src/data/proofs/erdos-1141/meta.json
+++ b/src/data/proofs/erdos-1141/meta.json
@@ -60,9 +60,9 @@
       "good_odd_eq_three",
       "good_coprime3_sub9_prime"
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 210,
-    "assumptions": "1 axiom (finiteness theorem by Alexeev-Putterman-Sawhney-Sellke-Valiant 2026, arXiv:2604.06609; proved via Pollack's theorem but not yet formalized in Mathlib). All structural results are fully proved.",
+    "assumptions": "2 assumptions: (1) the axiom erdos_1141_finitely_many (the finiteness theorem of Alexeev-Putterman-Sawhney-Sellke-Valiant 2026, arXiv:2604.06609; proved via Pollack's theorem but not yet formalized in Mathlib), and (2) Lean.ofReduceBool, introduced by native_decide. The computational results — including the named contributions all_known_good (all 41 OEIS A214583 values), classification_100, and good_count_100, plus the small-case good_*/not_good_* examples and knownGoodValues_length — are discharged by native_decide, which trusts the compiler's kernel reduction. All structural results (good_implies_pred_prime, good_ge4_even, good_not_prime_ge5, good_odd_eq_three, good_coprime3_sub9_prime, isErdos1141Good_iff_unbounded) are fully proved with no native_decide.",
     "theoremCount": 35,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1141 (Coprime-Square Subtraction Primes, SOLVED)

**Result:** issues-fixed. Under-disclosure of `Lean.ofReduceBool`.

### Source facts (Erdos1141Problem.lean, 210 L)
- 1 literal `axiom`: `erdos_1141_finitely_many` (APSSV 2026 finiteness, via Pollack) — correctly axiomatized.
- 35 theorems, 3 defs, 0 sorries, 0 True-stubs.
- **29 `native_decide` calls.** Three are **named `originalContributions`**: `all_known_good` (all 41 OEIS A214583 values), `classification_100`, `good_count_100` — plus the `good_*`/`not_good_*` small-case examples and `knownGoodValues_length`.

### Issue
`native_decide` trusts the compiler's kernel reduction → depends on `Lean.ofReduceBool` (`#print axioms` lists it). Per the project axiom-integrity policy this is a distinct assumption that must be disclosed and counted. The entry disclosed only the literal axiom:
- `meta.axiomCount = 1`, `assumptions` claimed "All structural results are fully proved" with no mention of `native_decide`/`ofReduceBool`.

### Fix (meta.json prose only — no Lean change)
- `meta.axiomCount` 1 → **2** (literal axiom + `Lean.ofReduceBool`).
- `assumptions` now names both assumptions, lists which results rely on `native_decide`, and which structural results are genuinely `native_decide`-free.
- `leanFile.axiomCount` stays **1** (literal `axiom` declarations only).
- `status`/`badge` unchanged (`axiomatized`/`axiom` already correct).

Matches the disclosed-precedent `erdos-1054-oq-01` (leanFile.ax 2 / meta.ax 3 with explicit `ofReduceBool`).