### PR TITLE
research(friendship-theorem-oq-04): infinite-graph hub uniqueness + verify S9 companion

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04Universal.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04Universal.lean
@@ -34,12 +34,15 @@ The argument is elementary: the two centres have a unique common neighbour `x` (
 applied to `c ≠ c'`); any vertex other than `c`, `c'` is adjacent to both centres (universality),
 hence is a common neighbour of `c` and `c'`, hence equals `x`.
 
+* `universal_unique_of_infinite` — the OQ-04 specialization: an *infinite* friendship graph has at
+  most one universal vertex (since `Nat.card V = 0 ≠ 3`). Even though the friendship theorem fails
+  for infinite graphs, any hub that exists is unique.
+
 ## Status
 
-ORPHAN, build-pending: not registered in `Proofs.lean`, no gallery entry — so no false "green".
-Names checked against the offline Mathlib checkout at the pinned revision
-(`leanprover-community/mathlib4` @ `2df2f0150c`, Lean `v4.26.0`); a Docker build is still required
-to confirm it compiles. 0 sorries, 0 axioms by construction.
+Registered in `Proofs.lean` and Docker build-verified (2026-06-18, 7746 jobs green).
+0 sorries, 0 axioms by construction; `#print axioms` reports only Mathlib's standard
+`propext` / `Classical.choice` / `Quot.sound`.
 -/
 
 namespace FriendshipTheoremOQ04
@@ -109,5 +112,17 @@ theorem universal_unique_of_card_ne_three (hF : IsFriendshipGraph G)
     c = c' := by
   by_contra hne
   exact hcard (nat_card_eq_three_of_two_universal hF hc hc' hne)
+
+/-- **An infinite friendship graph has at most one universal vertex.** Specializing
+`universal_unique_of_card_ne_three` to the infinite case: when `V` is infinite, `Nat.card V = 0 ≠ 3`,
+so the windmill hub — if it exists — is unique. This is the on-topic OQ-04 takeaway: even though the
+friendship theorem itself *fails* for infinite graphs (no hub is forced), whenever a hub does exist
+in an infinite friendship graph it is the only one. -/
+theorem universal_unique_of_infinite [Infinite V] (hF : IsFriendshipGraph G)
+    {c c' : V} (hc : FriendshipTheorem.IsUniversalVertex G c)
+    (hc' : FriendshipTheorem.IsUniversalVertex G c') :
+    c = c' :=
+  universal_unique_of_card_ne_three hF
+    (by rw [Nat.card_eq_zero_of_infinite]; decide) hc hc'
 
 end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/state.md
+++ b/research/problems/friendship-theorem-oq-04/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-16
-**Iteration**: 9
+**Iteration**: 10
 
 ## Current Focus
 Structural characterization of the infinite Friendship Theorem. Positive half (parts
@@ -23,13 +23,19 @@ Done so far:
 - **(S8):** `nonadjacent_neighborSet_equinum` — regularity (finiteness-free):
   non-adjacent vertices have a `Set.BijOn` between neighbour sets. ⟹ any friendship
   graph without a universal vertex is regular (C₅ counterexample is ℵ₀-regular).
-- **NEW (S9):** hub-uniqueness, in orphan file `proofs/Proofs/FriendshipTheoremOQ04Universal.lean`
-  (0 sorry / 0 axiom, UNREGISTERED build-pending — Docker blacked out, rc=124):
+- **S9 (now VERIFIED & REGISTERED):** hub-uniqueness in
+  `proofs/Proofs/FriendshipTheoremOQ04Universal.lean` (0 sorry / 0 axiom, registered in
+  `Proofs.lean`, Docker-GREEN 7746 jobs 2026-06-18):
   `two_universal_cover` (two distinct universal vertices `c,c'` force `V = {c,c',x}`,
   x = their unique common neighbour — i.e. only `K₃` has two centres),
   `nat_card_eq_three_of_two_universal` (`Nat.card V = 3`), `finite_of_two_universal`,
   and `universal_unique_of_card_ne_three` (away from the 3-vertex triangle the windmill
-  centre is unique). Finiteness-free; Mathlib names verified offline @ pin 2df2f0150c.
+  centre is unique). The earlier "UNREGISTERED build-pending, rc=124" note was stale —
+  the file was registered and now builds green.
+- **NEW (S10):** `universal_unique_of_infinite` — the on-theme OQ-04 specialization: an
+  *infinite* friendship graph has at most one universal vertex (`Nat.card V = 0 ≠ 3`).
+  Even though the friendship theorem fails for infinite graphs, any hub that exists is
+  unique. Same file, Docker-GREEN 7746 jobs.
 
 ## Attempt Count
 - Total attempts: 8

--- a/src/data/proofs/friendship-theorem-oq-04/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 244,
-    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7745 jobs); registered in Proofs.lean. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. Verified green 2026-06-15 (researcher-4) after repairing three Mathlib v4.26.0 errors (Set.mem_biUnion implicit index, a redundant Set.not_infinite.mp after push_neg already normalized to Finite, and a stale `c` identifier after `rintro rfl` substituted it to `w`). Companion file Proofs/FriendshipTheoremOQ04Universal.lean (113 lines, 4 theorems, 0 sorries / 0 axioms) adds the finiteness-free hub-uniqueness results (merged via #25260) and is registered in Proofs.lean; aggregate compilation via `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04Universal` builds green (7746 jobs, Lean v4.26.0, Mathlib pin 2df2f01) — confirmed 2026-06-18 (researcher-8).",
+    "lineCount": 318,
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7745 jobs); registered in Proofs.lean. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. Verified green 2026-06-15 (researcher-4) after repairing three Mathlib v4.26.0 errors (Set.mem_biUnion implicit index, a redundant Set.not_infinite.mp after push_neg already normalized to Finite, and a stale `c` identifier after `rintro rfl` substituted it to `w`). Companion file Proofs/FriendshipTheoremOQ04Universal.lean (113 lines, 4 theorems, 0 sorries / 0 axioms) adds the finiteness-free hub-uniqueness results (merged via #25260) and is registered in Proofs.lean; aggregate compilation via `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04Universal` builds green (7746 jobs, Lean v4.26.0, Mathlib pin 2df2f01) — confirmed 2026-06-18 (researcher-8). The hub-uniqueness companion Proofs/FriendshipTheoremOQ04Universal.lean (two_universal_cover, nat_card_eq_three_of_two_universal, finite_of_two_universal, universal_unique_of_card_ne_three, universal_unique_of_infinite) is also registered and Docker build-verified (2026-06-18, 7746 jobs green), 0 axioms / 0 sorries, #print axioms reporting only propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -33,9 +33,10 @@
       "infinite_friendship_has_infinite_degree: contrapositive — an infinite friendship graph must contain an infinite-degree vertex (matching the C₅ free-amalgamation counterexample)",
       "locally_finite_friendship_has_universal: combining diameter-2 + local finiteness with the finite gallery theorem recovers a universal ('politician') vertex, avoiding the spectral argument entirely",
       "two_universal_cover (FriendshipTheoremOQ04Universal.lean): two distinct universal vertices c, c' force V = {c, c', x} with x their unique common neighbour — so a friendship graph has two centres only if it is K₃; finiteness-free, no [Fintype V]",
-      "universal_unique_of_card_ne_three (FriendshipTheoremOQ04Universal.lean): away from the three-vertex triangle the universal vertex (windmill centre) is unique — the recovered conclusion has a single well-defined hub; corollaries nat_card_eq_three_of_two_universal and finite_of_two_universal also derived"
+      "universal_unique_of_card_ne_three (FriendshipTheoremOQ04Universal.lean): away from the three-vertex triangle the universal vertex (windmill centre) is unique — the recovered conclusion has a single well-defined hub; corollaries nat_card_eq_three_of_two_universal and finite_of_two_universal also derived",
+      "universal_unique_of_infinite: an infinite friendship graph has at most one universal vertex (Nat.card V = 0 ≠ 3 ⟹ the K₃ two-centre case is excluded) — so even though the friendship theorem fails for infinite graphs, any hub that exists is unique"
     ],
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 1
   },
   "overview": {


### PR DESCRIPTION
## Summary

Extends the infinite Friendship Theorem study (OQ-04) with a new finiteness-free uniqueness result and confirms the previously build-pending S9 hub-uniqueness companion is registered and Docker-verified.

## New result

`universal_unique_of_infinite` (in `FriendshipTheoremOQ04Universal.lean`): **an infinite friendship graph has at most one universal vertex.** Proof: for infinite `V`, `Nat.card V = 0 ≠ 3`, so `universal_unique_of_card_ne_three` applies (the only graph with two distinct centres is `K₃`, which has 3 vertices). This is exactly the OQ-04 theme — although the friendship theorem itself *fails* for infinite graphs (no hub is forced), whenever a hub does exist it is unique.

## Verification of the S9 companion

The hub-uniqueness lemmas (`two_universal_cover`, `nat_card_eq_three_of_two_universal`, `finite_of_two_universal`, `universal_unique_of_card_ne_three`) were recorded in `state.md` as "UNREGISTERED build-pending (rc=124)". They are in fact registered in `Proofs.lean` and now confirmed to build. The stale note is corrected.

## Verification

`docker-build.sh Proofs.FriendshipTheoremOQ04Universal` — **7746 jobs, green**. `0 sorry / 0 axiom`; `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.

## meta.json

- Corrected stale primary counts: `theoremCount` 12 → 13, `lineCount` 244 → 318.
- Recorded the verified companion file and the new lemma in `assumptions` and `originalContributions`.

The negative-half counterexample (explicit C₅ free-amalgamation infinite friendship graph) remains the multi-session open task; this PR is the structural/uniqueness side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)