### PR TITLE
research(sqrt2-plus-sqrt3-irrational-oq-02): generalize n=2 Besicovitch to coprime squarefree pairs

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean
@@ -8,7 +8,22 @@ Open Question (`sqrt2-plus-sqrt3-irrational-oq-02`):
   complete characterization
         ∑ᵢ rᵢ √aᵢ ∈ ℚ   ⟺   rᵢ = 0  for every aᵢ > 1.
 
-## STATUS — verified, axiom-free: the complete n = 2 instance
+## STATUS — verified, axiom-free: the n = 2 instance + general biquadratic case
+
+This file now proves two things, both verified and axiom-free:
+
+  1. the concrete `{1, √2, √3, √6}` instance (the original deliverable), and
+  2. its uniform **generalization** `linearIndependent_one_sqrt_sqrt_sqrt`: for
+     *any* coprime squarefree `a, b > 1`, the set `{1, √a, √b, √(ab)}` is
+     ℚ-linearly independent, i.e. `[ℚ(√a, √b) : ℚ] = 4`.  This covers infinitely
+     many multiquadratic biquadratic fields with a single proof, replacing the
+     radicand-specific irrationality inputs by `irrational_sqrt_natCast_iff`
+     (`√n` irrational ⟺ `n` not a perfect square) together with the elementary
+     `not_isSquare_of_squarefree`.  The `{2, 3}` case is recovered as a corollary
+     (`linearIndependent_one_sqrt2_sqrt3_sqrt6'`), confirming non-vacuity.
+
+The general theorem is the genuine n = 2 layer of Besicovitch's induction: the
+degree-doubling step `√b ∉ ℚ(√a)` proved uniformly in the two radicands.
 
 The general theorem reduces (see the sibling file
 `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02`) to a single non-trivial *induction
@@ -199,5 +214,180 @@ theorem linearIndependent_one_sqrt2_sqrt3_sqrt6 (a b c d : ℚ)
             + ((f : ℝ) * ((c : ℝ) ^ 2 - 2 * (d : ℝ) ^ 2)) * Real.sqrt 2 := by ring
       rw [hexp, heG, hfG]
     exact mul_right_cancel₀ hgR key2
+
+/-! ## General coprime-squarefree pair: `{1, √a, √b, √(ab)}`
+
+The specific result above (`a = 2, b = 3`) is the smallest instance of a uniform
+phenomenon: for **any** two coprime squarefree integers `a, b > 1` the four reals
+`1, √a, √b, √(ab)` are ℚ-linearly independent, i.e. `[ℚ(√a, √b) : ℚ] = 4`.  This
+covers infinitely many multiquadratic biquadratic fields with a single proof,
+replacing the radicand-specific irrationality inputs by the squarefree hypothesis
+via `irrational_sqrt_natCast_iff`.  The algebra is identical — regroup over
+`ℚ(√a)` and multiply by the conjugate `(r − s√a)` to isolate `√b·(r² − a s²)` —
+the same `linear_combination` certificate works verbatim with `a, b` symbolic. -/
+
+/-- A squarefree natural number `> 1` is not a perfect square. -/
+theorem not_isSquare_of_squarefree {n : ℕ} (hsf : Squarefree n) (hn : n ≠ 1) :
+    ¬ IsSquare n := by
+  rintro ⟨r, hr⟩
+  have hru : IsUnit r := hsf r ⟨1, by rw [hr, mul_one]⟩
+  rw [Nat.isUnit_iff] at hru
+  exact hn (by rw [hr, hru, mul_one])
+
+/-- `√n` is irrational for any squarefree `n > 1`.  Axiom-free: combines
+`irrational_sqrt_natCast_iff` with `not_isSquare_of_squarefree`. -/
+theorem irrational_sqrt_of_squarefree {n : ℕ} (hsf : Squarefree n) (hn : n ≠ 1) :
+    Irrational (Real.sqrt n) :=
+  irrational_sqrt_natCast_iff.mpr (not_isSquare_of_squarefree hsf hn)
+
+/-- **General induction heart.** For coprime squarefree `a, b > 1`, `√b` is not a
+ℚ-linear combination of `1` and `√a`; equivalently `√b ∉ ℚ(√a)`.  Stated with the
+three irrationality facts as hypotheses (each supplied by
+`irrational_sqrt_of_squarefree`). -/
+theorem sqrtb_not_in_Qsqrta {a b : ℕ}
+    (ha_irr : Irrational (Real.sqrt a)) (hb_irr : Irrational (Real.sqrt b))
+    (hab_irr : Irrational (Real.sqrt ((a : ℝ) * (b : ℝ)))) :
+    ¬ ∃ e f : ℚ, Real.sqrt b = (e : ℝ) + (f : ℝ) * Real.sqrt a := by
+  rintro ⟨e, f, hef⟩
+  have hasq : Real.sqrt (a : ℝ) ^ 2 = (a : ℝ) := Real.sq_sqrt (by positivity)
+  have hbsq : Real.sqrt (b : ℝ) ^ 2 = (b : ℝ) := Real.sq_sqrt (by positivity)
+  -- Square `√b = e + f√a`:  e² + a·f² + 2ef·√a = b.
+  have key : (e : ℝ) ^ 2 + (a : ℝ) * (f : ℝ) ^ 2 + 2 * (e : ℝ) * (f : ℝ) * Real.sqrt a
+      = (b : ℝ) := by
+    have hexp : ((e : ℝ) + (f : ℝ) * Real.sqrt a) ^ 2
+        = (e : ℝ) ^ 2 + (a : ℝ) * (f : ℝ) ^ 2 + 2 * (e : ℝ) * (f : ℝ) * Real.sqrt a := by
+      linear_combination (f : ℝ) ^ 2 * hasq
+    rw [← hexp, ← hef]; exact hbsq
+  by_cases hf : f = 0
+  · -- √b = e ∈ ℚ : contradicts irrationality of √b.
+    subst hf
+    have hb0 : Real.sqrt b = (e : ℝ) := by rw [hef]; push_cast; ring
+    exact hb_irr ⟨e, hb0.symm⟩
+  · by_cases he : e = 0
+    · -- √b = f√a, so √(ab) = f·a ∈ ℚ : contradicts irrationality of √(ab).
+      subst he
+      have hef0 : Real.sqrt b = (f : ℝ) * Real.sqrt a := by rw [hef]; push_cast; ring
+      have hmul : Real.sqrt ((a : ℝ) * (b : ℝ)) = Real.sqrt a * Real.sqrt b :=
+        Real.sqrt_mul (by positivity) _
+      have hval : Real.sqrt ((a : ℝ) * (b : ℝ)) = (f : ℝ) * (a : ℝ) := by
+        rw [hmul, hef0]
+        have hcollapse : Real.sqrt a * ((f : ℝ) * Real.sqrt a)
+            = (f : ℝ) * Real.sqrt a ^ 2 := by ring
+        rw [hcollapse, hasq]
+      exact hab_irr ⟨f * (a : ℚ), by push_cast; rw [hval]⟩
+    · -- e, f ≠ 0 : √a = (b − e² − a·f²)/(2ef) ∈ ℚ : contradicts irrationality of √a.
+      exfalso
+      apply ha_irr
+      refine ⟨((b : ℚ) - e ^ 2 - (a : ℚ) * f ^ 2) / (2 * e * f), ?_⟩
+      have hef2 : (2 * (e : ℝ) * (f : ℝ)) ≠ 0 :=
+        mul_ne_zero (mul_ne_zero two_ne_zero (by exact_mod_cast he)) (by exact_mod_cast hf)
+      have hmul2 : Real.sqrt a * (2 * (e : ℝ) * (f : ℝ))
+          = (b : ℝ) - (e : ℝ) ^ 2 - (a : ℝ) * (f : ℝ) ^ 2 := by linear_combination key
+      have hwit : ((((b : ℚ) - e ^ 2 - (a : ℚ) * f ^ 2) / (2 * e * f) : ℚ) : ℝ)
+            * (2 * (e : ℝ) * (f : ℝ))
+          = (b : ℝ) - (e : ℝ) ^ 2 - (a : ℝ) * (f : ℝ) ^ 2 := by
+        push_cast
+        rw [div_mul_cancel₀ _ hef2]
+      exact mul_right_cancel₀ hef2 (hwit.trans hmul2.symm)
+
+/-- **Besicovitch, general biquadratic case.** For coprime squarefree `a, b > 1`,
+`{1, √a, √b, √(ab)}` is ℚ-linearly independent: `p + q√a + r√b + s√(ab) = 0` with
+rational `p, q, r, s` forces `p = q = r = s = 0`.  Equivalently
+`[ℚ(√a, √b) : ℚ] = 4`.  The merged `{2, 3}` result is the instance `a = 2, b = 3`. -/
+theorem linearIndependent_one_sqrt_sqrt_sqrt {a b : ℕ}
+    (hsa : Squarefree a) (hsb : Squarefree b)
+    (ha1 : a ≠ 1) (hb1 : b ≠ 1) (hcop : a.Coprime b)
+    (p q r s : ℚ)
+    (h : (p : ℝ) + (q : ℝ) * Real.sqrt a + (r : ℝ) * Real.sqrt b
+        + (s : ℝ) * Real.sqrt ((a : ℝ) * (b : ℝ)) = 0) :
+    p = 0 ∧ q = 0 ∧ r = 0 ∧ s = 0 := by
+  have ha_irr := irrational_sqrt_of_squarefree hsa ha1
+  have hb_irr := irrational_sqrt_of_squarefree hsb hb1
+  have hab_irr : Irrational (Real.sqrt ((a : ℝ) * (b : ℝ))) := by
+    have hsab : Squarefree (a * b) := (Nat.squarefree_mul hcop).mpr ⟨hsa, hsb⟩
+    have hab1 : a * b ≠ 1 := fun hh => ha1 (Nat.eq_one_of_dvd_one ⟨b, hh.symm⟩)
+    have hI := irrational_sqrt_of_squarefree hsab hab1
+    rwa [Nat.cast_mul] at hI
+  have h2sq : Real.sqrt (a : ℝ) ^ 2 = (a : ℝ) := Real.sq_sqrt (by positivity)
+  have hab : Real.sqrt ((a : ℝ) * (b : ℝ)) = Real.sqrt a * Real.sqrt b :=
+    Real.sqrt_mul (by positivity) _
+  -- Regroup over ℚ(√a):  (p + q√a) + √b·(r + s√a) = 0.
+  have h1 : ((p : ℝ) + (q : ℝ) * Real.sqrt a)
+      + Real.sqrt b * ((r : ℝ) + (s : ℝ) * Real.sqrt a) = 0 := by
+    rw [hab] at h; linear_combination h
+  -- No rational squares to `a` (`√a` irrational).
+  have rat_sq : ∀ x : ℚ, x ^ 2 ≠ (a : ℚ) := by
+    intro x hx
+    have hxR : (x : ℝ) ^ 2 = (a : ℝ) := by exact_mod_cast hx
+    have hsab : Real.sqrt (a : ℝ) = |(x : ℝ)| := by rw [← hxR, Real.sqrt_sq_eq_abs]
+    rw [← Rat.cast_abs] at hsab
+    exact ha_irr ⟨|x|, hsab.symm⟩
+  by_cases hrs : r = 0 ∧ s = 0
+  · -- Coefficient of √b vanishes:  p + q√a = 0.
+    obtain ⟨hr, hs⟩ := hrs
+    subst hr; subst hs
+    push_cast at h1
+    have h1' : (p : ℝ) + (q : ℝ) * Real.sqrt a = 0 := by linear_combination h1
+    by_cases hq : q = 0
+    · subst hq
+      simp only [Rat.cast_zero, zero_mul, add_zero] at h1'
+      exact ⟨by exact_mod_cast h1', rfl, rfl, rfl⟩
+    · exfalso
+      apply ha_irr
+      refine ⟨-p / q, ?_⟩
+      have hqR : (q : ℝ) ≠ 0 := by exact_mod_cast hq
+      rw [Rat.cast_div, Rat.cast_neg, div_eq_iff hqR]
+      linear_combination -h1'
+  · -- Otherwise the ℚ(√a)-conjugate isolates √b ∈ ℚ(√a), a contradiction.
+    exfalso
+    have hg : (r ^ 2 - (a : ℚ) * s ^ 2 : ℚ) ≠ 0 := by
+      intro hg0
+      rcases eq_or_ne s 0 with hs | hs
+      · subst hs
+        apply hrs
+        refine ⟨?_, rfl⟩
+        have hr2 : r ^ 2 = 0 := by simpa using hg0
+        exact sq_eq_zero_iff.mp hr2
+      · apply rat_sq (r / s)
+        rw [div_pow, div_eq_iff (pow_ne_zero 2 hs)]
+        linarith [hg0]
+    have hgR : ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2) ≠ 0 := by exact_mod_cast hg
+    -- Multiply `h1` by the conjugate `(r − s√a)` to isolate `√b·(r² − a s²)`.
+    have hmul : Real.sqrt b * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+        = ((a : ℝ) * (q : ℝ) * (s : ℝ) - (p : ℝ) * (r : ℝ))
+          + ((p : ℝ) * (s : ℝ) - (q : ℝ) * (r : ℝ)) * Real.sqrt a := by
+      linear_combination ((r : ℝ) - (s : ℝ) * Real.sqrt a) * h1
+        + ((q : ℝ) * (s : ℝ) + (s : ℝ) ^ 2 * Real.sqrt b) * h2sq
+    apply sqrtb_not_in_Qsqrta ha_irr hb_irr hab_irr
+    set E : ℚ := ((a : ℚ) * q * s - p * r) / (r ^ 2 - (a : ℚ) * s ^ 2) with hE_def
+    set F : ℚ := (p * s - q * r) / (r ^ 2 - (a : ℚ) * s ^ 2) with hF_def
+    refine ⟨E, F, ?_⟩
+    have hEG : (E : ℝ) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+        = (a : ℝ) * (q : ℝ) * (s : ℝ) - (p : ℝ) * (r : ℝ) := by
+      rw [hE_def]; push_cast; rw [div_mul_cancel₀ _ hgR]
+    have hFG : (F : ℝ) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+        = (p : ℝ) * (s : ℝ) - (q : ℝ) * (r : ℝ) := by
+      rw [hF_def]; push_cast; rw [div_mul_cancel₀ _ hgR]
+    have key2 : Real.sqrt b * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+        = ((E : ℝ) + (F : ℝ) * Real.sqrt a) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2) := by
+      rw [hmul]
+      have hexp : ((E : ℝ) + (F : ℝ) * Real.sqrt a) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+          = (E : ℝ) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)
+            + ((F : ℝ) * ((r : ℝ) ^ 2 - (a : ℝ) * (s : ℝ) ^ 2)) * Real.sqrt a := by ring
+      rw [hexp, hEG, hFG]
+    exact mul_right_cancel₀ hgR key2
+
+/-- The merged `{2, 3}` result recovered as the instance `a = 2, b = 3` of the
+general theorem, confirming the two are consistent (and the general statement is
+non-vacuous). -/
+theorem linearIndependent_one_sqrt2_sqrt3_sqrt6' (a b c d : ℚ)
+    (h : (a : ℝ) + (b : ℝ) * Real.sqrt 2 + (c : ℝ) * Real.sqrt 3
+        + (d : ℝ) * Real.sqrt 6 = 0) :
+    a = 0 ∧ b = 0 ∧ c = 0 ∧ d = 0 := by
+  have h6 : Real.sqrt ((2 : ℝ) * (3 : ℝ)) = Real.sqrt 6 := by
+    rw [show ((2 : ℝ) * (3 : ℝ)) = 6 from by norm_num]
+  exact linearIndependent_one_sqrt_sqrt_sqrt Nat.prime_two.squarefree
+    Nat.prime_three.squarefree (by norm_num) (by norm_num) (by decide)
+    a b c d (by push_cast; rw [h6]; linear_combination h)
 
 end Sqrt2PlusSqrt3IrrationalOQ02

--- a/research/problems/sqrt2-plus-sqrt3-irrational-oq-02/knowledge.md
+++ b/research/problems/sqrt2-plus-sqrt3-irrational-oq-02/knowledge.md
@@ -2,16 +2,56 @@
 
 ## Established Facts
 
-(None yet — populated during OBSERVE.)
+- **n = 2 concrete case (merged, PR #25630).** `{1, √2, √3, √6}` is ℚ-linearly
+  independent, axiom-free, via the elementary regroup-over-ℚ(√2) +
+  conjugate-multiplication method. Induction heart: `√3 ∉ ℚ(√2)`.
+- **General biquadratic case (this session).** For *any* coprime squarefree
+  `a, b > 1`, `{1, √a, √b, √(ab)}` is ℚ-linearly independent, i.e.
+  `[ℚ(√a, √b) : ℚ] = 4`. The same `linear_combination` certificate that proves
+  the `{2,3}` instance works verbatim with `a, b` symbolic — verified by an
+  explicit polynomial-identity check before building (the conjugate identity
+  `√b·(r² − a·s²) = (a·q·s − p·r) + (p·s − q·r)·√a` is the same in both).
+- Squarefree `n > 1` ⟹ `¬ IsSquare n` (`not_isSquare_of_squarefree`) ⟹
+  `Irrational (√n)` via Mathlib `irrational_sqrt_natCast_iff`. This replaces the
+  radicand-specific divisor-bound irrationality inputs of the n=2 file.
 
 ## Open Questions Within This Problem
 
-- The main open question (see `problem.md`).
+- The main open question (general Besicovitch, see `problem.md`).
+- n = 3 concrete: `{√d : d ∣ 30 squarefree}` (8 radicands) — needs two nested
+  conjugate steps / degree-8 multiquadratic field.
+- The general induction heart `sqrt_prime_not_mem_multiquadratic` (arbitrary
+  finite prime set) remains `sorry` in the sibling
+  `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02` — BUILD-class (~250–450 LOC),
+  needs the "squares of a multiquadratic field are `r²·∏_{T⊆ps} q`" lemma.
 
 ## Failed Approaches
 
-(None yet.)
+(None this session — the generalization went through as designed.)
 
 ## Promising Leads
 
-(None yet.)
+- The two-radicand degree-doubling lemma (`sqrtb_not_in_Qsqrta`, general `a,b`)
+  is the genuine n=2 layer of Besicovitch's induction. The next structural step
+  is to make the conjugate-multiplication argument relative: `√c ∉ ℚ(√a, √b)`
+  for a third coprime squarefree `c`, using a ℚ(√a,√b)-conjugate. If that
+  generalizes uniformly it gives the induction heart elementarily, bypassing the
+  powerset-squares characterization route currently sketched in the sibling file.
+- `irrational_sqrt_of_squarefree` and `not_isSquare_of_squarefree` are clean,
+  reusable, and plausibly Mathlib-contribution candidates.
+
+## Session Log
+
+### 2026-06-18 (REVISIT, FRESH-continuation) — generalize n=2 to coprime squarefree pairs
+
+**Outcome:** progress (added verified, axiom-free general theorem).
+
+- Confirmed PR #25630 (n=2 concrete `{1,√2,√3,√6}`) merged to main.
+- Generalized to `linearIndependent_one_sqrt_sqrt_sqrt`: coprime squarefree
+  `a,b > 1` ⟹ `{1,√a,√b,√(ab)}` ℚ-independent. Added supporting
+  `not_isSquare_of_squarefree`, `irrational_sqrt_of_squarefree`, general heart
+  `sqrtb_not_in_Qsqrta`, and a consistency corollary recovering the `{2,3}` case.
+- Verified the symbolic transfer of the conjugate identity by hand before
+  building (no enumeration; one structural generalization covering infinitely
+  many biquadratic fields).
+- File: `proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean` (already registered).

--- a/research/problems/sqrt2-plus-sqrt3-irrational-oq-02/state.md
+++ b/research/problems/sqrt2-plus-sqrt3-irrational-oq-02/state.md
@@ -1,17 +1,30 @@
 # State: sqrt2-plus-sqrt3-irrational-oq-02
 
-**Phase**: OBSERVE
-**Since**: 2026-06-09
+**Phase**: SHIP
+**Since**: 2026-06-18
 **Path**: full
 
 ## Phase History
 
 - 2026-06-09: Initialized in OBSERVE phase by Seeker.
+- 2026-06-18: Concrete n=2 instance {1,√2,√3,√6} merged (#25630). Generalized to all
+  coprime squarefree pairs {1,√a,√b,√(ab)}; PR #25713 opened, then re-landed onto fresh
+  `main` after the branch went 188 commits behind (CONFLICTING).
 
 ## Current Focus
 
-Reading the source gallery proof `sqrt2-plus-sqrt3-irrational` and translating the open question into a precise Lean statement.
+Re-landing PR #25713 (the coprime-squarefree generalization). The branch had fallen
+behind `main`, turning the PR CONFLICTING. Reset the branch onto fresh `origin/main`
+and replayed only the intended 4-file delta (the Lean file, its meta.json, knowledge.md,
+state.md); `Proofs.lean` import and corrected annotation enums already on main.
+Build-verified `Proofs.Sqrt2PlusSqrt3IrrationalOQ02` green (3058 jobs), then force-pushed.
 
 ## Notes
 
-Selected by Seeker on 2026-06-09 from candidate pool. Significance/tractability scores recorded in `research/db/knowledge.db`.
+- The file is a clean SUPERSET of main's 203-line version: all 6 original theorems kept,
+  5 added (not_isSquare_of_squarefree, irrational_sqrt_of_squarefree, sqrtb_not_in_Qsqrta,
+  linearIndependent_one_sqrt_sqrt_sqrt, linearIndependent_one_sqrt2_sqrt3_sqrt6'). 393 lines,
+  11 theorems.
+- Status stays verified / original / axiomCount 0. No sorry, no native_decide; irrationality
+  inputs from squarefree hypothesis via irrational_sqrt_natCast_iff (no Lean.ofReduceBool).
+- Next lead: relative conjugate-multiplication (√c ∉ ℚ(√a,√b)) → unlocks n=3 induction.

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "sqrt2-plus-sqrt3-irrational-oq-02",
   "title": "Besicovitch (n = 2): ℚ-Linear Independence of {1, √2, √3, √6}",
   "slug": "sqrt2-plus-sqrt3-irrational-oq-02",
-  "description": "Answers the open question 'Formalize Besicovitch's theorem (1940): √a₁, …, √aₙ are ℚ-linearly independent for distinct squarefree aᵢ' for the smallest non-trivial case n = 2 (radicands {1, 2, 3, 6}). Proves {1, √2, √3, √6} is ℚ-linearly independent: a + b√2 + c√3 + d√6 = 0 with a,b,c,d ∈ ℚ forces a = b = c = d = 0. The technical heart is sqrt3_not_in_Qsqrt2 (√3 ∉ ℚ(√2)), the degree-doubling step of the multiquadratic tower. Fully verified, axiom-free: the irrationality inputs ¬IsSquare 3 and ¬IsSquare 6 are proved by an elementary divisor bound plus a finite case split (no kernel decide, which gets stuck on Nat.sqrt, and no native_decide), hence no Lean.ofReduceBool. 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "description": "Answers the open question 'Formalize Besicovitch's theorem (1940): √a₁, …, √aₙ are ℚ-linearly independent for distinct squarefree aᵢ' for the smallest non-trivial case n = 2 (radicands {1, 2, 3, 6}). Proves {1, √2, √3, √6} is ℚ-linearly independent: a + b√2 + c√3 + d√6 = 0 with a,b,c,d ∈ ℚ forces a = b = c = d = 0. The technical heart is sqrt3_not_in_Qsqrt2 (√3 ∉ ℚ(√2)), the degree-doubling step of the multiquadratic tower. Fully verified, axiom-free: the irrationality inputs ¬IsSquare 3 and ¬IsSquare 6 are proved by an elementary divisor bound plus a finite case split (no kernel decide, which gets stuck on Nat.sqrt, and no native_decide), hence no Lean.ofReduceBool. 6 theorems, 0 definitions, 0 axioms, 0 sorries. The file now also proves the uniform generalization linearIndependent_one_sqrt_sqrt_sqrt: for ANY coprime squarefree a, b > 1, {1, √a, √b, √(ab)} is ℚ-linearly independent — covering infinitely many biquadratic fields with a single axiom-free proof, with the {2,3} case recovered as a corollary.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-18",
@@ -22,15 +22,14 @@
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
     "assumptions": "None. Fully proved: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The irrationality inputs (¬IsSquare 3, ¬IsSquare 6) are discharged by an elementary divisor bound (r ∣ n → r ≤ n) plus a finite case split (interval_cases/omega), NOT by kernel `decide` (which gets stuck on Nat.sqrt) and NOT by `native_decide`, so the file does not depend on Lean.ofReduceBool. Standard foundational axioms (propext, Classical.choice, Quot.sound) only.",
-    "lineCount": 203,
-    "theoremCount": 6,
+    "lineCount": 393,
+    "theoremCount": 11,
     "definitionCount": 0,
     "originalContributions": [
-      "linearIndependent_one_sqrt2_sqrt3_sqrt6: {1, √2, √3, √6} is ℚ-linearly independent (the complete n = 2 Besicovitch characterization, equivalently [ℚ(√2,√3):ℚ] = 4)",
-      "sqrt3_not_in_Qsqrt2: √3 is not of the form e + f√2 with e,f ∈ ℚ — the n = 2 induction heart (degree-doubling step) that the general sorry-based reduction (sibling Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02) lacks",
-      "linearIndependent_one_sqrt2: {1, √2} is ℚ-linearly independent (base of the tower)",
-      "rat_sq_ne_two: no rational squares to 2 (√2 irrationality restated over ℚ)",
-      "irrational_sqrt_three, irrational_sqrt_six: √3, √6 irrational, with ¬IsSquare 3 / ¬IsSquare 6 proved by an elementary divisor bound + finite case split (axiom-free; avoids kernel decide, which gets stuck on Nat.sqrt, and avoids native_decide)"
+      "linearIndependent_one_sqrt_sqrt_sqrt: for ANY coprime squarefree a,b > 1, {1, √a, √b, √(ab)} is ℚ-linearly independent (equivalently [ℚ(√a,√b):ℚ] = 4) — a uniform generalization covering infinitely many biquadratic fields with one proof; the radicand-specific irrationality inputs are replaced by irrational_sqrt_natCast_iff + not_isSquare_of_squarefree",
+      "sqrtb_not_in_Qsqrta: general induction heart — √b ∉ ℚ(√a) for coprime squarefree a,b, the degree-doubling step proved uniformly in both radicands",
+      "not_isSquare_of_squarefree, irrational_sqrt_of_squarefree: squarefree n > 1 ⟹ ¬IsSquare n ⟹ Irrational √n (clean, reusable; Mathlib-contribution candidates)",
+      "linearIndependent_one_sqrt2_sqrt3_sqrt6' / linearIndependent_one_sqrt2_sqrt3_sqrt6: the concrete {1, √2, √3, √6} n = 2 Besicovitch case (recovered as the a=2,b=3 instance of the general theorem, confirming non-vacuity)"
     ]
   },
   "overview": {
@@ -64,9 +63,9 @@
   },
   "leanFile": {
     "namespace": "Sqrt2PlusSqrt3IrrationalOQ02",
-    "lineCount": 203,
+    "lineCount": 393,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/Sqrt2PlusSqrt3IrrationalOQ02.lean",
     "sorries": 0
@@ -133,6 +132,12 @@
       "startLine": 125,
       "endLine": 190,
       "mathContext": "a+b√2+c√3+d√6 = 0 ⟹ a=b=c=d=0 — the complete n = 2 Besicovitch characterization."
+    },
+    {
+      "title": "General Biquadratic Case: {1, √a, √b, √(ab)} for Coprime Squarefree a, b",
+      "startLine": 218,
+      "endLine": 393,
+      "description": "Uniform generalization of the n = 2 result: not_isSquare_of_squarefree and irrational_sqrt_of_squarefree supply the irrationality inputs from the squarefree hypothesis; sqrtb_not_in_Qsqrta is the general degree-doubling heart (√b ∉ ℚ(√a)); linearIndependent_one_sqrt_sqrt_sqrt proves ℚ-linear independence of {1, √a, √b, √(ab)} for any coprime squarefree a, b > 1; and linearIndependent_one_sqrt2_sqrt3_sqrt6' recovers the {2,3} instance."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Generalizes the merged `{1, √2, √3, √6}` n=2 Besicovitch result (PR #25630) to a **uniform** theorem over all coprime squarefree pairs.

`linearIndependent_one_sqrt_sqrt_sqrt`: for *any* coprime squarefree `a, b > 1`, the set `{1, √a, √b, √(ab)}` is ℚ-linearly independent, i.e. `[ℚ(√a, √b) : ℚ] = 4`. A single axiom-free proof covers infinitely many biquadratic fields; the original `{2,3}` case is recovered as the corollary `linearIndependent_one_sqrt2_sqrt3_sqrt6'`, confirming non-vacuity.

The same regroup-over-ℚ(√a) + conjugate-multiplication `linear_combination` certificate that proved the concrete case works verbatim with `a, b` symbolic.

## New theorems
- `not_isSquare_of_squarefree`, `irrational_sqrt_of_squarefree` — squarefree `n > 1` ⟹ `Irrational √n` (clean, reusable; Mathlib-contribution candidates)
- `sqrtb_not_in_Qsqrta` — general degree-doubling induction heart: `√b ∉ ℚ(√a)`, proved uniformly in both radicands
- `linearIndependent_one_sqrt_sqrt_sqrt` — the general biquadratic independence theorem
- `linearIndependent_one_sqrt2_sqrt3_sqrt6'` — `{2,3}` instance / consistency corollary

## Verification
- **Green build**: 3058 jobs, `Build completed successfully`
- **Axiom-free**: no `sorry`, no `axiom`, no `native_decide`; only plain kernel `decide` on `Nat.Coprime 2 3` (no `Lean.ofReduceBool`)
- Status remains `verified`/`original`/`axiomCount 0`
- meta.json updated: line/theorem counts 203/6 → 393/11, `originalContributions` + new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)