### PR TITLE
audit(abundant-number-oq-01): clean first audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15902,6 +15902,12 @@
       "lastAudited": "2026-06-18T11:20:37Z",
       "result": "clean",
       "issues": []
+    },
+    "abundant-number-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T11:58:09Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — `abundant-number-oq-01`

First audit of the sole remaining never-audited gallery entry (2536/2536 now covered). **Result: clean** — no integrity issues.

### Verified
- **Two companion files**, counts match meta exactly:
  - `AbundantNumberOQ01.lean` (39L): 3 theorems, minimality.
  - `AbundantMultiplesOQ01.lean` (128L): 7 theorems, closure + infinitude.
  - Combined 10 theorems / 167 lines / 0 sorries / 0 axioms / 0 defs.
- **Central claim holds**: the only decision procedure is `by decide` (kernel, bounded `∀ n < 12` via `Nat.decidableBallLT`) — **not** `native_decide`. All `native_decide`/`sorry` grep hits are docstring comments asserting their absence. So `verified` badge with `axiomCount: 0` (no `Lean.ofReduceBool`) is justified.
- **Claims honestly scoped**: Mathlib's `Nat.abundant_twelve` credited throughout; `originalContributions` (minimality `IsLeast`, closure `abundant_mul_right`, divisor-sum bridge, `infinitely_many_abundant`) are genuinely not in Mathlib and independently proved.
- All 5 `mainTheorems` names exist in source; section line numbers cross-check; no `True` stubs.

Only change: `audit-tracker.json` records the clean audit (auditCount 0→1).

---
Discovered during gallery integrity audit.