### PR TITLE
Fix: chinese-remainder-constructive-oq-04-oq-04 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Sunzi / CRT), formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
     "date": "3rd century",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ04OQ04.lean",
     "tags": [
       "number-theory",
@@ -16,13 +16,13 @@
       "uniqueness",
       "canonical-form"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "dateAdded": "2026-04-02",
     "mathlib_version": "4.26.0",
     "lineCount": 122,
-    "assumptions": "None. All theorems fully proved with 0 sorries and 0 axioms.",
+    "assumptions": "The abstract CRT framework (satisfies_mod, crt_list_minimal_exists/unique, crt_list_min) is fully proved with 0 sorries and no axioms. However, the named Sunzi problem verification (sunzi_minimal_solution, sunzi_solution_is_23, sunzi_unique — establishing the unique minimal solution x=23) is discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom. Since x=23 is presented as a verified original contribution, the entry is axiomatized: `#print axioms` lists `Lean.ofReduceBool`.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.mod_mod_of_dvd",
@@ -112,7 +112,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization proves the canonical CRT theorem: for any system of congruences with pairwise coprime positive moduli, there exists a unique solution in $[0, M)$, obtained by reducing any solution modulo $M$. All 7 theorems are fully proved with 0 sorries and 0 axioms. The Sunzi problem (x = 23) is verified as a concrete example.",
+    "summary": "The formalization proves the canonical CRT theorem: for any system of congruences with pairwise coprime positive moduli, there exists a unique solution in $[0, M)$, obtained by reducing any solution modulo $M$. The abstract framework is proved with 0 sorries and no axioms. The named Sunzi problem verification (x = 23) is discharged by `native_decide`, which depends on the `Lean.ofReduceBool` axiom, so the entry is axiomatized.",
     "implications": "The `crt_list_min` theorem provides the foundation for practical CRT applications: cryptographic operations (RSA Chinese remainder exponentiation), hash function design, and modular arithmetic in computational number theory all rely on extracting the canonical representative. The formalization shows that `ZMod.val` is the type-theoretic analogue: both give the unique $x \\in [0, M)$ representing a tuple of residues. The connection `ℤ/M ≅ ∏ ℤ/mᵢ` is now proved at the element level in Lean.",
     "openQuestions": [
       "Can `crt_list_min` be connected to Mathlib's `ZMod` and the ring isomorphism `ZMod.chineseRemainder`? This would lift the element-level theorem to the ring isomorphism level.",


### PR DESCRIPTION
## Fix

The named **Sunzi problem verification** ("unique minimal solution x=23 in [0,105)" — an advertised `originalContribution`) is established **solely** by `native_decide`, which trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom. Per the Axiom Integrity Policy, a substantive verified result discharged by `native_decide` must be counted: `axiomatized` / `axiom` badge / `axiomCount ≥ 1`.

## Evidence

`proofs/Proofs/ChineseRemainderConstructiveOQ04OQ04.lean`:
- `sunzi_minimal_solution` (L83) — `native_decide` for coprimality + positivity
- `sunzi_solution_is_23` (L88) — `native_decide` proves 23 satisfies the system
- `sunzi_unique` (L98) — `native_decide` for all modular side conditions

The meta itself self-admitted this (section summary L111): *"`native_decide` handles all modular arithmetic."*

The **abstract CRT framework** (`satisfies_mod`, `crt_list_minimal_exists/unique`, `crt_list_min`) is native_decide-free and stays fully verified — only the prose scope changes, no code stripped.

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, assumptions "None... 0 axioms"
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.