### PR TITLE
audit(erdos-1142): disclose native_decide/ofReduceBool, fix axiomCount + phantom contribution

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4180,10 +4180,10 @@
       "result": "clean"
     },
     "erdos-1142": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:51Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T12:04:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1143": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -13,7 +13,7 @@
       "number-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1142,
     "erdosUrl": "https://erdosproblems.com/1142",
@@ -34,7 +34,6 @@
     "originalContributions": [
       "powersOfTwoBetween",
       "SatisfiesErdos1142",
-      "satisfiesErdos1142Bool",
       "erdos1142_value_4",
       "erdos1142_value_7",
       "erdos1142_value_15",
@@ -48,9 +47,9 @@
       "erdos1142_odd_or_4",
       "erdos1142_ge_4"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 192,
-    "assumptions": "Fully verified. 0 axioms, 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "0 literal `axiom` declarations, 0 sorries. The seven known solutions (erdos1142_value_4/7/15/21/45/75/105), the three non-examples (erdos1142_not_6/9/10), and the completeness theorem erdos1142_complete_le_105 are discharged by `native_decide`, which trusts the Lean compiler and therefore introduces the `Lean.ofReduceBool` axiom (axiomCount: 1). The structural lemmas (erdos1142_ge_4, erdos1142_n_minus_2_prime, erdos1142_odd_or_4, erdos1142_mod2) are proved symbolically without native_decide. The headline conjecture itself remains OPEN — it is stated as a definition (erdos_1142_conjecture), not proved.",
     "dateAdded": "2026-03-15",
     "references": [
       {
@@ -81,12 +80,12 @@
   "overview": {
     "historicalContext": "Erdős Problem #1142 asks whether there are infinitely many integers $n$ such that $n - 2^k$ is prime for every power of two $2^k$ with $1 < 2^k < n$. The known values satisfying this property are $n \\in \\{4, 7, 15, 21, 45, 75, 105\\}$, catalogued as OEIS sequence A039669.\n\nMientka and Weitzenkamp (1969) performed an exhaustive search verifying that no other values exist up to $2^{44} \\approx 1.76 \\times 10^{13}$. Vaughan (1973) proved that the count of such $n$ up to $N$ is extremely sparse, establishing upper bounds on their density.\n\nErdős formulated a stronger conjecture: the number of $k$ with $1 \\leq k$ and $2^k < n$ for which $n - 2^k$ is prime is $o(\\log n)$. If true, this would imply that for large $n$, not all $\\lfloor \\log_2 n \\rfloor$ differences can simultaneously be prime, suggesting the set is finite. This connects to Erdős Problem #236 on the density of prime differences from powers of two.\n\nThe problem sits at the intersection of additive number theory and the distribution of primes, related to covering congruences and the Goldbach-type question of representing integers as sums/differences of primes and powers of two.",
     "problemStatement": "Are there infinitely many n (or any n > 105) such that n − 2^k is prime for all 1 < 2^k < n?",
-    "text": "A 192-line formalization of Erdos Problem #1142 with 0 sorries and 0 axioms. Defines `SatisfiesErdos1142 n` requiring all $n - 2^k$ to be prime for powers of two $2^k \\in (1, n)$. All seven known solutions ($n \\in \\{4, 7, 15, 21, 45, 75, 105\\}$, OEIS A039669) are verified by `native_decide`, along with three non-examples. Structural results include the parity constraint (solutions with $n > 4$ must be odd) and the lower bound $n \\geq 4$. The exhaustive verification `erdos1142_complete_le_105` confirms these are the only solutions up to 105. The stronger $o(\\log n)$ conjecture on prime difference density is formalized and shown to imply eventual non-existence of solutions.",
+    "text": "A 192-line formalization of Erdos Problem #1142 with 0 sorries and 0 literal axiom declarations. Defines `SatisfiesErdos1142 n` requiring all $n - 2^k$ to be prime for powers of two $2^k \\in (1, n)$. All seven known solutions ($n \\in \\{4, 7, 15, 21, 45, 75, 105\\}$, OEIS A039669) are verified by `native_decide`, along with three non-examples; `native_decide` trusts the Lean compiler and so introduces the `Lean.ofReduceBool` axiom. Structural results include the parity constraint (solutions with $n > 4$ must be odd) and the lower bound $n \\geq 4$. The exhaustive verification `erdos1142_complete_le_105` confirms these are the only solutions up to 105. The stronger $o(\\log n)$ conjecture on prime difference density is formalized and shown to imply eventual non-existence of solutions.",
     "proofStrategy": "The formalization defines the property $\\text{SatisfiesErdos1142}(n)$ requiring $n - 2^k$ to be prime for every power of two in the range $(1, n)$. It verifies all seven known values ($n = 4, 7, 15, 21, 45, 75, 105$) using `native_decide`, confirms non-examples ($n = 6, 9, 10$), and proves structural results: solutions must be odd (except $n = 4$), must satisfy $n \\geq 4$, and $n - 2$ must be prime. The completeness theorem `erdos1142_complete_le_105` verifies exhaustively that these are the only solutions up to 105. The stronger $o(\\log n)$ conjecture is formalized and shown to imply eventual non-existence of solutions.",
     "keyInsights": [
       "**Logarithmic constraint growth**: The number of primality conditions grows as $\\lfloor \\log_2 n \\rfloor$, making it increasingly unlikely that all $n - 2^k$ are simultaneously prime for large $n$.",
       "**Parity obstruction**: If $n > 4$ satisfies the property, then $n$ must be odd — otherwise $n - 2$ is even and greater than 2, hence composite. This is formalized as `erdos1142_odd_or_4`.",
-      "**Decidable verification via `native_decide`**: Both positive examples and non-examples are verified computationally using Lean's `native_decide` tactic, giving kernel-level certainty.",
+      "**Decidable verification via `native_decide`**: Both positive examples and non-examples are verified computationally using Lean's `native_decide` tactic. This relies on compiled evaluation and so introduces the `Lean.ofReduceBool` axiom rather than pure kernel reduction.",
       "**Stronger $o(\\log n)$ conjecture implies finiteness**: If the fraction of prime differences tends to zero, then eventually no $n$ can have ALL differences prime, yielding `stronger_implies_eventually_not_all_prime`.",
       "**Connection to covering congruences**: The problem relates to whether a system of congruences can cover all residues modulo small primes, preventing all differences from being prime simultaneously."
     ],
@@ -115,7 +114,7 @@
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "summary": "Defines `powersOfTwoBetween n` as the finset of powers of two in $(1, n)$, and `SatisfiesErdos1142 n` requiring this set to be nonempty with all $n - m$ prime. Includes a Boolean version `satisfiesErdos1142Bool` for computation and a `Decidable` instance.",
+      "summary": "Defines `powersOfTwoBetween n` as the finset of powers of two in $(1, n)$, and `SatisfiesErdos1142 n` requiring this set to be nonempty with all $n - m$ prime. Provides a `Decidable` instance (via `inferInstance`) enabling computational verification.",
       "startLine": 29,
       "endLine": 51,
       "mathContext": "Defines `powersOfTwoBetween n` as the finset of powers of two in $(1, n)$, and `SatisfiesErdos1142 n` requiring this set to be nonempty with all $n - m$ prime."


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1142 (Primes of the form n − 2^k, OPEN)

Re-audit of the sole non-PR'd re-audit candidate. The Lean file uses `native_decide` on substantive, named results, but meta claimed `axiomCount: 0` / `"Fully verified. 0 axioms"` and listed a phantom contribution.

### Evidence (proofs/Proofs/Erdos1142Problem.lean)
- **11 `native_decide` calls** on substantive named results:
  - `erdos1142_value_4/7/15/21/45/75/105` (L53–76) — the seven known solutions, all `originalContributions`
  - `erdos1142_not_6/9/10` (L81–87) — non-examples, all `originalContributions`
  - `erdos1142_complete_le_105` (L177) — headline completeness theorem
- `native_decide` trusts the compiled evaluator → depends on `Lean.ofReduceBool` (per repo Axiom Integrity Policy, count it).
- 0 literal `axiom` declarations, 0 sorries, 0 `True` stubs (structural lemmas `erdos1142_ge_4/_n_minus_2_prime/_odd_or_4/_mod2` are proved symbolically).
- `satisfiesErdos1142Bool` (listed in `originalContributions` and a section summary) **does not exist** — the file has an anonymous `Decidable` instance (L44) instead.

### Fixes (meta.json only)
| Field | Before | After |
|-------|--------|-------|
| `axiomCount` | 0 | 1 (`Lean.ofReduceBool`) |
| `badge` | `wip` | `axiom` (matches `axiomatized` status; 0 sorries so `wip` was wrong) |
| `assumptions` | "Fully verified. 0 axioms…" | discloses `ofReduceBool` + nd-backed vs symbolic results; notes conjecture stays OPEN |
| `text` / keyInsight | "0 axioms" / "kernel-level certainty" | accurate `ofReduceBool` wording |
| `originalContributions` | included phantom `satisfiesErdos1142Bool` | removed |
| core-definitions section | phantom Boolean-version ref | corrected |

`status` stays `axiomatized` (open conjecture, unchanged). `leanFile` literal axiom count remains 0.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)