### PR TITLE
Fix: derangements-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,9 +7,9 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "tags": [
       "combinatorics",
@@ -66,9 +66,9 @@
       "11 native_decide verifications: S(3,k) = {2,3,0,1}, S(4,k) = {9,8,6,0,1}, S(5,2) = 20"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 357,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
+    "assumptions": "The abstract framework (kFixed_iff_support_card, the permSupportEqEquiv bijection, card_perms_with_kfixed = C(n,k)·D(n-k), the special cases S(n,0)/S(n,n)/S(n,n-1), and the summation identity ∑S(n,k) = n!) is proved symbolically with no axioms or sorries. The named contribution \"11 native_decide verifications\" (the concrete value tables S(3,k) = {2,3,0,1}, S(4,k) = {9,8,6,0,1}, and S(5,2) = 20) is established solely by `native_decide`, which trusts the Lean compiler via the `Lean.ofReduceBool` axiom. Per the project's axiom-integrity policy these substantive computed results count: axiomCount = 1 (Lean.ofReduceBool). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. leanFile.axiomCount remains 0 (no literal `axiom` declarations).",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

`derangements-oq-02` advertises **\"11 native_decide verifications\"** as a named `originalContribution`, but the meta claimed `status: verified`, `badge: original`, `axiomCount: 0`, and `assumptions: \"Fully verified: 0 axioms\"`. `native_decide` trusts the Lean compiler via the `Lean.ofReduceBool` axiom, so these substantive computed results are not axiom-free.

## Evidence

`proofs/Proofs/DerangementsOQ02.lean` Section V (lines 196-242): 11 `example ... := by native_decide` establishing the concrete value tables S(3,k) = {2,3,0,1}, S(4,k) = {9,8,6,0,1}, S(5,2) = 20. This is item #11 in `originalContributions` ("11 native_decide verifications"). The abstract framework (the permSupportEqEquiv bijection, `card_perms_with_kfixed`, special cases, and ∑S(n,k) = n!) is `native_decide`-free and stays symbolically proved.

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "Fully verified: 0 axioms, 0 sorries remain."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and distinguish the symbolic framework from the native_decide-backed value tables. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Per the project axiom-integrity policy (`native_decide` discharging a substantive presented result → count `Lean.ofReduceBool`).

---
Automated fix by lean-mechanic agent.