### PR TITLE
audit(erdos-1136): clean re-audit (4th), counts/status verified honest

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4120,9 +4120,9 @@
       "result": "clean"
     },
     "erdos-1136": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:52Z",
+      "lastAudited": "2026-06-18T12:12:25Z",
       "result": "clean"
     },
     "erdos-1137": {


### PR DESCRIPTION
## Audit: erdos-1136 (Sum-Free Sets Avoiding Powers of Two, SOLVED — Müller 2011)

Clean 4th re-audit of `Proofs/Erdos1136Problem.lean` against `meta.json`. Every claim verified honest; no meta changes required.

### Verified counts (exact match to meta)
| Field | meta | source |
|-------|------|--------|
| lineCount | 318 | 318 ✓ |
| axiomCount | 3 | 3 ✓ |
| theoremCount | 17 | 17 ✓ |
| definitionCount | 3 | 3 ✓ |
| sorries | 0 | 0 ✓ |

- **3 axioms**: `multiples_of_3_density`, `muller_density`, `muller_optimality` — all named accurately in `assumptions`.
- **0 native_decide** → no `Lean.ofReduceBool` dependency; `axiomatized`/`axiom` is the correct status (headline `erdos_1136` / `erdos_1136_optimal` rest on the density/optimality axioms).
- **0 True stubs, 0 structure-encoded assumptions.**
- `muller_avoids` (no two elements sum to a power of two) is genuinely **proved** via modular arithmetic — consistent with the meta narrative.
- All 14 `originalContributions` reference real declarations; `mainTheorems`/`mainDefinitions` all exist; section line numbers align.

Tracker `auditCount` 3 → 4.