### PR TITLE
Fix: combinations-formula-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "combinations-formula-oq-01",
   "title": "Extended Binomial Coefficient Identities",
   "slug": "combinations-formula-oq-01",
-  "description": "Formalizes key binomial coefficient identities extending the basic combinations formula: Vandermonde's identity C(m+n,r) = Σ C(m,k)·C(n,r-k), the Hockey Stick identity Σᵢ C(i+r,r) = C(n+r+1,r+1), the double-counting product identity C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j), row sums, bounds C(n,k) ≤ 2ⁿ and C(2n,n) ≤ 4ⁿ, and Fibonacci diagonal sums. 8 theorems, 0 axioms.",
+  "description": "Formalizes key binomial coefficient identities extending the basic combinations formula: Vandermonde's identity C(m+n,r) = Σ C(m,k)·C(n,r-k), the Hockey Stick identity Σᵢ C(i+r,r) = C(n+r+1,r+1), the double-counting product identity C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j), row sums, bounds C(n,k) ≤ 2ⁿ and C(2n,n) ≤ 4ⁿ, and Fibonacci diagonal sums. 8 theorems; the Fibonacci diagonal sums are verified for small cases by native_decide (Lean.ofReduceBool).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "vandermonde",
       "hockey-stick"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's Nat.choose library.",
+    "axiomCount": 1,
+    "assumptions": "The six symbolic identities (Vandermonde, Hockey Stick, double-counting product, row/alternating sums, choose_le_pow2, central_binom_le, identities_summary) are fully machine-verified using Mathlib's Nat.choose library with no assumptions. However, the named 'Fibonacci diagonal sums Σ_j C(n-j,j) = F(n+1)' contribution has no symbolic proof — it is established only for small cases (n=5, n=6) by native_decide examples, which depend on the Lean.ofReduceBool axiom (kernel-trusted compiler reduction). A general inductive proof remains open (see openQuestions). leanFile.axiomCount stays 0 (no literal `axiom` declarations).",
     "lineCount": 185,
     "theoremCount": 8,
     "definitionCount": 0,
@@ -52,7 +52,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Six binomial coefficient identities fully verified: Vandermonde (2 lines), Hockey Stick (induction), double-counting product (30-line factorial algebra), row sum (1 line), binomial bound (via single_le_sum), and central binomial bound. Fibonacci diagonal sums verified by native_decide for small n. 8 theorems, 185 lines, 0 axioms.",
+    "summary": "Six binomial coefficient identities fully verified: Vandermonde (2 lines), Hockey Stick (induction), double-counting product (30-line factorial algebra), row sum (1 line), binomial bound (via single_le_sum), and central binomial bound. Fibonacci diagonal sums verified by native_decide for small n (depends on Lean.ofReduceBool; general proof open). 8 theorems, 185 lines.",
     "implications": "This provides a verified combinatorics toolkit for higher-level proofs. The Vandermonde identity enables combinatorial proofs of hypergeometric identities. The Hockey Stick enables counting arguments in lattice path combinatorics. The product identity enables multinomial coefficient arguments. Together they cover the standard binomial coefficient toolkit for probabilistic and algebraic combinatorics.",
     "openQuestions": [
       "Formal proof of Fibonacci diagonal sum Σ C(n-j,j) = F(n+1) by induction using F(n+2) = F(n+1) + F(n)",


### PR DESCRIPTION
## Fix

`combinations-formula-oq-01` (Extended Binomial Coefficient Identities) was marked `status: verified` / `badge: original` / `axiomCount: 0` with assumptions "None. Fully machine-verified", but a named originalContribution depends on `native_decide`.

## Evidence

**Before**: status `verified`, badge `original`, axiomCount 0, assumptions "None. Fully machine-verified using Mathlib's Nat.choose library."

**After**: status `axiomatized`, badge `axiom`, axiomCount 1, assumptions disclose `Lean.ofReduceBool`.

The six symbolic identities (vandermonde, hockey_stick, choose_product, choose_row_sum/choose_alternating_sum, choose_le_pow2, central_binom_le, identities_summary) are genuinely symbolic and Mathlib-backed — they stay fully verified. **However**, the listed originalContribution *"Fibonacci diagonal sums: Σ_j C(n-j,j) = F(n+1) verified for small cases"* has **no symbolic proof**. It is established solely by `native_decide` examples at lines 168, 171:

```lean
example : Nat.choose 5 0 + Nat.choose 4 1 + Nat.choose 3 2 + Nat.choose 2 3 = 8 := by native_decide
example : Nat.choose 6 0 + Nat.choose 5 1 + Nat.choose 4 2 + Nat.choose 3 3 = 13 := by native_decide
```

The entry's own `openQuestions` confirms the general proof is open ("Formal proof of Fibonacci diagonal sum ... by induction"), and keyInsights states it is "only verified for small n by native_decide". Per the Axiom Integrity Policy, `native_decide` discharging a substantive presented result depends on `Lean.ofReduceBool` and must be counted.

`leanFile.axiomCount` stays 0 (no literal `axiom` declarations); `meta.axiomCount` is 1 for the `ofReduceBool` dependency. Also corrected "0 axioms" claims in the description and conclusion summary.

---
Automated fix by lean-mechanic agent.