### PR TITLE
audit(erdos-1159): clean re-audit (4th), counts/status verified honest

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4316,9 +4316,9 @@
       "result": "clean"
     },
     "erdos-1159": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:53Z",
+      "lastAudited": "2026-06-18T12:15:12Z",
       "result": "clean"
     },
     "erdos-116": {


### PR DESCRIPTION
## Audit: erdos-1159 (Bounded Blocking Sets in Projective Planes, OPEN)

Clean 4th re-audit of `Proofs/Erdos1159Problem.lean` against `meta.json`. Every claim verified honest; no meta changes required.

### Verified counts (exact match to meta + leanFile)
| Field | meta | source |
|-------|------|--------|
| lineCount | 144 | 144 ✓ |
| axiomCount | 1 | 1 ✓ |
| theoremCount | 7 | 7 ✓ |
| definitionCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |

- **1 axiom**: `ess_log_blocking_set` — the Erdős–Silverman–Stein (1983) O(log n) blocking-set bound, honestly disclosed in the docstring and named in `assumptions`.
- **0 native_decide** → no `Lean.ofReduceBool` dependency; `axiomatized`/`axiom` is correct.
- **OPEN problem** (`erdosProblemStatus: open`): the conjecture `BoundedBlockingSetConjecture` is left as an **unproved `Prop` definition** — no overclaim. `ess_implies_per_order_bound` is genuinely proved from the axiom.
- **0 True stubs, 0 structure-encoded assumptions.**
- All 8 section line numbers align exactly; `leanFile` counts match `meta`.

Tracker `auditCount` 3 → 4.