### PR TITLE
Fix: elementary-quadratic-reciprocity-oq-03-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01/meta.json
@@ -4,8 +4,8 @@
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-01",
   "description": "Formalizes the full multiplicative structure of the Jacobi symbol: top and bottom multiplicativity, periodicity, power laws, coprimality characterization, special reciprocity simplifications, and Euclidean reduction steps for efficient computation.",
   "category": "number-theory",
-  "status": "verified",
-  "badge": "mathlib",
+  "status": "axiomatized",
+  "badge": "axiom",
   "difficulty": "intermediate",
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean",
@@ -26,13 +26,15 @@
   },
   "lineCount": 311,
   "theoremCount": 24,
-  "axiomCount": 0,
-  "assumptions": [],
+  "axiomCount": 1,
+  "assumptions": [
+    "Lean.ofReduceBool — the 8 native_decide examples in Part VIII (the advertised '9 computational verifications') trust the Lean compiler's kernel-reduction, depending on the Lean.ofReduceBool axiom. The 24 catalog theorems are axiom-free Mathlib wrappers."
+  ],
   "meta": {
     "author": "Jacobi / Eisenstein (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
     "date": "1837",
-    "status": "verified",
+    "status": "axiomatized",
     "note": "Tier B: All theorems are one-liner wrappers of Mathlib's jacobiSym API. No independent proofs — this is a systematic catalog and bridge.",
     "tags": [
       "number-theory",
@@ -43,7 +45,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -81,10 +83,10 @@
       "Proof that multiplicativity + periodicity + supplements yield O(log^2 n) computation"
     ],
     "dateAdded": "2026-03-28",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 311,
     "mathlib_version": "4.26.0",
-    "assumptions": "0 axioms, 0 sorries. All core results obtained via Mathlib's jacobiSym API (one-liner wrappers). Badge is mathlib, not verified, to reflect Mathlib dependency for all substantive content.",
+    "assumptions": "Depends on Lean.ofReduceBool: the 8 native_decide examples in Part VIII (the advertised '9 computational verifications') trust the Lean compiler's kernel reduction. The 24 catalog theorems are 0-sorry, axiom-free one-liner wrappers of Mathlib's jacobiSym API. Status is axiomatized (badge: axiom) to disclose the native_decide dependency in the named computational-verification contribution.",
     "theoremCount": 24,
     "definitionCount": 0
   },
@@ -234,7 +236,7 @@
     "multiplicative-functions"
   ],
   "conclusion": {
-    "summary": "Complete formalization of the Jacobi symbol's multiplicative structure in Lean 4 with 24 theorems and 9 computational verifications, all with 0 sorries and 0 axioms. Demonstrates that multiplicativity in both arguments, periodicity, power laws, and QR provide a complete system for reducing any J(a,n) computation to base cases in O(log^2 n) steps.",
+    "summary": "Complete formalization of the Jacobi symbol's multiplicative structure in Lean 4 with 24 theorems (0-sorry, axiom-free Mathlib wrappers) and 9 computational verifications (8 discharged by native_decide, hence depending on the Lean.ofReduceBool axiom). Demonstrates that multiplicativity in both arguments, periodicity, power laws, and QR provide a complete system for reducing any J(a,n) computation to base cases in O(log^2 n) steps.",
     "implications": "**Affirmative answer to OQ-03-OQ-01**: The Mathlib API for `jacobiSym` provides complete coverage of the multiplicativity reduction. Every step of the Euclidean algorithm for Jacobi symbols has a corresponding Mathlib lemma.\n\n**Computational significance**: The formalized reduction steps (mod, extract 2s, reciprocate) constitute a verified specification of the Jacobi symbol computation algorithm used in Solovay-Strassen primality testing.\n\n**Proof architecture**: The bilateral multiplicativity J(ab,n) = J(a,n)J(b,n) and J(a,mn) = J(a,m)J(a,n) means the Jacobi symbol is determined by its values on (prime, prime) pairs, which are exactly the Legendre symbols covered by classical QR.",
     "openQuestions": [
       "Can the Kronecker symbol (extending Jacobi to even moduli and n = 0, -1, -2) be formalized as a further generalization?",


### PR DESCRIPTION
## Fix

Reclassify the Jacobi-symbol multiplicativity entry from `verified` to `axiomatized` to disclose its `native_decide` dependency.

## Evidence

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `assumptions: []` / "0 axioms, 0 sorries".

**Root cause**: The advertised originalContribution *"9 computational verifications demonstrating the multiplicative structure"* (Part VIII) rests **solely** on 8 `native_decide` examples (`ElementaryQuadraticReciprocityOQ03OQ01.lean` L197–222: `jacobiSym 2 15 = 1`, `jacobiSym 8 5 = -1`, etc.). `native_decide` trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom — the proof is not axiom-free. Per the project Axiom Integrity Policy (`native_decide` rule), a substantive named deliverable backed by `native_decide` must count: `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`.

**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool`. The 24 catalog theorems remain 0-sorry, axiom-free one-liner wrappers of Mathlib's `jacobiSym` API; `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.