### PR TITLE
audit(erdos-1054-oq-01): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3367,9 +3367,9 @@
       "result": "clean"
     },
     "erdos-1054-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:07:44Z",
+      "lastAudited": "2026-06-18T12:24:23Z",
       "result": "clean"
     },
     "erdos-1055": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1054-oq-01

**Result: CLEAN** (4th audit; no meta changes needed)

Re-audited the sole tracker-stale entry (last audited 2026-05-03). The meta.json was already correctly classified by prior PRs #25643 / #25664.

### Verification (Erdos1054AlmostAllOQ01.lean, 352 lines)

| Check | Lean source | meta.json | ✓ |
|-------|-------------|-----------|---|
| Literal axioms | 2 (`erdos_1054_almost_all` = open conjecture, `tao_counterexample_1054`) | leanFile.axiomCount 2 | ✓ |
| native_decide | 9 occurrences → `Lean.ofReduceBool` | meta.axiomCount 3 (2 + ofReduceBool), disclosed in `assumptions` | ✓ |
| Sorries | 0 | 0 | ✓ |
| True stubs | 0 | — | ✓ |
| Theorems | 24 (incl. `private` helpers) | 24 | ✓ |
| Definitions | 4 | 4 | ✓ |
| Status / badge | open conjecture axiomatized | `axiomatized` / `axiom` | ✓ |

All `originalContributions` and section-referenced declarations (`sigma_prime`, `sigma_ratio_2a_3b`, `coprime_pow2_pow3`, `f_sigma_witness`, scanl/sort helpers, etc.) confirmed present in source.

Tracker-only change: `auditCount` 3→4, `lastAudited` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)