### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-04 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Bertrand (1887), Catalan (1838); formalized by researcher-10",
     "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number#First_proof",
     "date": "1887",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "recurrence",
       "convolution"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "originalContributions": [
       "Bridge cn_eq_catalan: LatticePathLGV.Cn n = catalan n (Mathlib root namespace) via centralBinom characterization",
@@ -26,9 +26,9 @@
       "Verification: small cases n=0,1,2,3,4 via native_decide"
     ],
     "dateAdded": "2026-04-23",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 182,
-    "assumptions": "0 sorries. All proofs are complete. Uses Mathlib's catalan_succ' and catalan_eq_centralBinom_div as infrastructure.",
+    "assumptions": "0 sorries. Depends on Lean.ofReduceBool via native_decide: the advertised small-case verifications (Cn 1..4 recurrence, the 4 anonymous examples) and theorem Cn_two (Cn 2 = 2) are discharged solely by native_decide, which trusts the Lean compiler's kernel reduction. The symbolic bridge results — Cn_eq_catalan, Cn_recurrence (catalan_succ'), and Cn_ballot_recurrence — are proved without native_decide and remain axiom-free. Counts the conservative ofReduceBool assumption (meta.axiomCount = 1); leanFile.axiomCount remains 0 as there are no literal axiom declarations. Uses Mathlib's catalan_succ' and catalan_eq_centralBinom_div as infrastructure.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

`ballot-problem-oq-03-oq-01-oq-04` is marked `status: verified` / `badge: mathlib` / `axiomCount: 0`, but its advertised verifications are discharged solely by `native_decide`, which depends on `Lean.ofReduceBool`. Per the Axiom Integrity Policy, this requires `status: axiomatized` / `badge: axiom` with the assumption disclosed.

## Evidence

`native_decide` appears at:
- **Lines 129–132** — the 4 anonymous `example`s proving the Catalan recurrence small cases `Cn 1..4`. These ARE originalContribution #4: *"Verification: small cases n=0,1,2,3,4 via native_decide"* (a named deliverable).
- **Line 150** — `theorem Cn_two : Cn 2 = 2 := by native_decide` (a named result; `Cn_zero`/`Cn_one` use `simp`, only `Cn_two` uses `native_decide`).

The symbolic bridge results — `Cn_eq_catalan`, `Cn_recurrence` (via `catalan_succ'`), `Cn_ballot_recurrence` — are `native_decide`-free and remain axiom-free.

**Before**: `status: verified`, `badge: mathlib`, `meta.axiomCount: 0`, assumptions silent on `native_decide`.
**After**: `status: axiomatized`, `badge: axiom`, `meta.axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and separate the native_decide-backed results from the symbolic ones. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.