### PR TITLE
research(shannon-oq-01): register BEC capacity proof + repair Mathlib drift in BSC chain

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2838,6 +2838,7 @@ import Proofs.SchroederBernsteinOQ04
 import Proofs.SchursTheorem
 import Proofs.SearchMathlib
 import Proofs.ShannonChannelCoding
+import Proofs.ShannonChannelCodingBEC
 import Proofs.ShannonChannelCodingOQ02
 import Proofs.ShannonChannelCodingOQ02OQ01
 import Proofs.ShannonChannelCodingOQ02OQ01Aristotle

--- a/proofs/Proofs/ShannonChannelCodingBEC.lean
+++ b/proofs/Proofs/ShannonChannelCodingBEC.lean
@@ -61,7 +61,7 @@ noncomputable def bec (p : ℝ) (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
     | some y => dsimp only; split_ifs <;> linarith
   sum_one := fun x => by
     rw [Fintype.sum_option, Fintype.sum_bool]
-    cases x <;> simp <;> ring
+    cases x <;> simp
 
 @[simp] lemma bec_W_none {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (x : Bool) :
     (bec p hp0 hp1).W x none = p := rfl
@@ -86,7 +86,7 @@ lemma bec_ymarg_some {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (inp : InputDist 
     (∑ x' : Bool, jointDist (bec p hp0 hp1) inp (x', some y)) = inp.p y * (1 - p) := by
   simp only [jointDist, bec_W_some]
   rw [Fintype.sum_bool]
-  cases y <;> simp <;> ring
+  cases y <;> simp
 
 /-! ## Conditional entropy `H(X|Y) = p · H(X)` -/
 
@@ -144,8 +144,10 @@ theorem bec_conditional_entropy {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1)
             (∑ x' : Bool, jointDist (bec p hp0.le hp1.le) inp (x', o))))
       = (if inp.p x = 0 then 0 else inp.p x * p * Real.log (inp.p x)) := by
     intro x
-    rw [Fintype.sum_option, Fintype.sum_bool, hsome_zero x false, hsome_zero x true,
-        hnone x, add_zero, add_zero]
+    -- Apply `hnone` BEFORE expanding any Bool sum, so the `∑ x'` denominator in the
+    -- `none` term still matches `hnone`'s LHS; then collapse the `some` sum to 0.
+    rw [Fintype.sum_option, hnone x,
+        Finset.sum_eq_zero (fun i _ => hsome_zero x i), add_zero]
   -- Sum over inputs, factor out `p`, and recognise `-H(X)`.
   unfold conditionalEntropy
   rw [Finset.sum_congr rfl (fun x _ => hinner x)]

--- a/proofs/Proofs/ShannonChannelCodingOQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ02.lean
@@ -33,11 +33,11 @@ namespace InformationTheory.ChannelCoding.BSCCapacity
 noncomputable def uniformBool : InputDist Bool where
   p := fun _ => 1 / 2
   nonneg := fun _ => by norm_num
-  sum_one := by simp [Fintype.sum_bool]; ring
+  sum_one := by rw [Fintype.sum_bool]; norm_num
 
 /-- Uniform input on Bool is strictly positive. -/
 lemma uniformBool_pos (b : Bool) : 0 < uniformBool.p b := by
-  simp [uniformBool]; norm_num
+  norm_num [uniformBool]
 
 /-! ## BSC properties for 0 < p < 1 -/
 
@@ -91,8 +91,7 @@ theorem mi_eq_hY_sub_hYgivenX {α β : Type*} [Fintype α] [Fintype β]
   have hp' := transposeJoint_nonneg hp
   have hsum' := transposeJoint_sum hsum
   rw [chain_rule hp' hsum']
-  congr 1
-  ext y; simp [transposeJoint]
+  congr 1 <;> ext y <;> simp [transposeJoint]
 
 /-! ## BSC conditional output entropy H(Y|X) = h(p) -/
 
@@ -141,7 +140,7 @@ theorem bsc_conditional_output_entropy {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1)
   -- Factor out inp.p(b): ∑ b, ∑ a, inp.p(b) * (...) = ∑ b, inp.p(b) * ∑ a, (...)
   simp_rw [← Finset.mul_sum]
   -- Use BSC symmetry: ∑ a, ch.W(b,a) * log(ch.W(b,a)) is constant for all b
-  simp_rw [bsc_output_entropy_per_input hp0 hp1]
+  simp_rw [hch_def, bsc_output_entropy_per_input hp0 hp1]
   -- Factor: ∑ b, inp.p(b) * c = c * ∑ b, inp.p(b) = c * 1 = c
   rw [← Finset.sum_mul, inp.sum_one, one_mul]
   -- Goal: -(p * log p + (1-p) * log(1-p)) = h p
@@ -154,13 +153,12 @@ theorem bsc_conditional_output_entropy {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1)
 theorem entropy_uniform_bool :
     shannonEntropy (fun (_ : Bool) => (1 : ℝ) / 2) = Real.log 2 := by
   unfold shannonEntropy
-  simp only [Fintype.sum_bool]
   have hne : ¬((1 : ℝ) / 2 = 0) := by norm_num
-  rw [if_neg hne, if_neg hne]
+  rw [Fintype.sum_bool]
+  simp only [if_neg hne]
   -- Goal: -(1/2 * log(1/2) + 1/2 * log(1/2)) = log 2
-  have h1 : (1 : ℝ) / 2 * Real.log (1 / 2) + 1 / 2 * Real.log (1 / 2) =
-      Real.log (1 / 2) := by ring
-  rw [h1, show (1 : ℝ) / 2 = (2 : ℝ)⁻¹ from by norm_num, Real.log_inv, neg_neg]
+  rw [show (1 : ℝ) / 2 = (2 : ℝ)⁻¹ from by norm_num, Real.log_inv]
+  ring
 
 /-! ## MI computations for BSC -/
 
@@ -221,7 +219,7 @@ theorem bsc_mi_le_general {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1)
   · -- Some input prob is 0 → input is point mass on Bool → H(X) = 0 → MI ≤ 0
     push_neg at h
     obtain ⟨b₀, hb₀⟩ := h
-    have hb₀_eq : inp.p b₀ = 0 := le_antisymm (not_lt.mp hb₀) (inp.nonneg b₀)
+    have hb₀_eq : inp.p b₀ = 0 := le_antisymm hb₀ (inp.nonneg b₀)
     set ch := bsc p (le_of_lt hp0) (le_of_lt hp1)
     have hjoint_nn : ∀ xy, 0 ≤ jointDist ch inp xy :=
       fun xy => mul_nonneg (inp.nonneg xy.1) (ch.nonneg xy.1 xy.2)
@@ -286,12 +284,11 @@ theorem random_coding_existence {ι : Type*} [Fintype ι] [Nonempty ι]
   by_contra h
   push_neg at h
   have hcard_pos : (0 : ℝ) < Fintype.card ι := Nat.cast_pos.mpr Fintype.card_pos
-  have : ε * Fintype.card ι < ∑ i : ι, error i :=
-    calc ε * Fintype.card ι
-        = ∑ _ : ι, ε := by rw [Finset.sum_const, smul_eq_mul, Finset.card_univ]
-      _ < ∑ i : ι, error i :=
-        Finset.sum_lt_sum (fun i _ => le_of_lt (h i))
-          ⟨Classical.arbitrary ι, Finset.mem_univ _, h _⟩
-  linarith [div_le_iff hcard_pos |>.mpr (le_of_lt this)]
+  have hlt : ∑ _ : ι, ε < ∑ i : ι, error i :=
+    Finset.sum_lt_sum (fun i _ => le_of_lt (h i))
+      ⟨Classical.arbitrary ι, Finset.mem_univ _, h _⟩
+  rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul] at hlt
+  rw [div_le_iff₀ hcard_pos] at avg_bound
+  linarith [hlt, avg_bound]
 
 end InformationTheory.ChannelCoding.BSCCapacity


### PR DESCRIPTION
## Summary

`ShannonChannelCodingBEC.lean` (binary erasure channel capacity = `(1-p)·log 2`, **0 axioms / 0 sorries**) was committed in #25152 but **never registered in `Proofs.lean`** — so it was an orphan that CI never compiled. This PR registers it.

Registering it forced a real recompile of its dependency chain, which surfaced a latent integrity issue: **`ShannonChannelCodingOQ02.lean` no longer builds against the current Mathlib pin** — its gallery "verified" status was riding on a stale cache `.olean`. This PR repairs that drift so the whole chain compiles for real.

## Repairs (all Mathlib-drift; no mathematical content changed)

**`ShannonChannelCodingOQ02.lean`** (8 sites) — the from-scratch proof of the parent's `bsc_capacity_eq`:
- `div_le_iff` → `div_le_iff₀` (renamed upstream); `random_coding_existence` reworked to use `nsmul_eq_mul`
- dropped now-redundant trailing tactics where `simp`/`norm_num` got stronger ("No goals to be solved")
- `congr 1 <;> ext y <;> simp` (congr now closes early); unfold `set` local via `hch_def` before `simp_rw`; `if_neg` via `simp only`; `push_neg` now yields `≤ 0` directly

**`ShannonChannelCodingBEC.lean`** (3 sites):
- `bec_conditional_entropy`: apply `hnone` before expanding any Bool sum (so the `∑ x'` denominator still matches), then collapse the `some` sum with `Finset.sum_eq_zero` — the old `rw` let `Fintype.sum_bool` fire on the denominator instead
- dropped two redundant `<;> ring`

## Verification

Full chain builds green via the Docker wrapper: `Build completed successfully (7750 jobs)`. Both files remain **0-axiom / 0-sorry** (verified by grep + clean build). One cosmetic style lint remains (`<;>` vs `;` in `hfactor`), non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)