### PR TITLE
Fix: chinese-remainder-constructive-oq-04-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Researcher",
     "date": "2026-05-06",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ04OQ02.lean",
     "tags": [
       "number-theory",
@@ -15,7 +15,7 @@
       "connection",
       "chinese-remainder-theorem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -57,10 +57,10 @@
     ],
     "references": [],
     "dateAdded": "2026-05-06",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 180,
     "mathlib_version": "4.26.0",
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. The named contribution example_8_mod3_mod5 (x ≡ 2 mod 3, x ≡ 3 mod 5 has unique minimal solution 8) discharges its congruence-membership conditions solely via native_decide, which trusts the Lean compiler's kernel reduction and so adds the Lean.ofReduceBool axiom (#print axioms lists it). The eight ring-theoretic bridge contributions (satisfies_pair_iff, chineseRemainder_natCast, satisfies_pair_iff_chineseRemainder, chineseRemainder_symm_val_lt, chineseRemainder_symm_satisfies, crt_min_eq_chineseRemainder_val, crt_exists_via_zmod, crt_unique_two_fold) are symbolic and native_decide-free. No literal axiom declarations or sorries (leanFile.axiomCount remains 0).",
     "theoremCount": 12,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

The named original contribution `example_8_mod3_mod5` is proved **solely** via `native_decide`, so the entry depends on `Lean.ofReduceBool` and must be `axiomatized`, not `verified`.

## Evidence

`proofs/Proofs/ChineseRemainderConstructiveOQ04OQ02.lean` — the only `native_decide` uses are at L173 and L178, both inside `example_8_mod3_mod5` (origContrib #9: "verified example x≡2 mod 3, x≡3 mod 5 has unique solution 8"), discharging its congruence-membership conditions. There is no symbolic alternative for these specific concrete checks.

The other eight original contributions (`satisfies_pair_iff`, `chineseRemainder_natCast`, `satisfies_pair_iff_chineseRemainder`, `chineseRemainder_symm_val_lt`, `chineseRemainder_symm_satisfies`, `crt_min_eq_chineseRemainder_val`, `crt_exists_via_zmod`, `crt_unique_two_fold`) are symbolic ring-theoretic bridges and are `native_decide`-free.

Per the Axiom Integrity Policy, a substantive named result discharged by `native_decide` must count `Lean.ofReduceBool`.

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool` and names which contribution is `native_decide`-backed vs symbolic.

`leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.