### PR TITLE
audit(dissection-of-cubes): fix phantom mainTheorem (dehn_invariant)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2504,10 +2504,10 @@
       "result": "clean"
     },
     "dissection-of-cubes": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T19:24:36Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T12:32:20Z",
+      "result": "issues-fixed"
     },
     "dissection-of-cubes-oq-01": {
       "auditCount": 6,

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -258,10 +258,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "dehn_invariant",
+      "name": "dissection_of_cubes",
       "type": "core",
-      "description": "Dehn's theorem: polyhedra with different Dehn invariants are not scissors-congruent",
-      "leanType": "dehnInvariant P != dehnInvariant Q -> not (scissors_congruent P Q)"
+      "description": "Wiedijk #82 (Littlewood): no dissection of a cube into finitely many smaller cubes can have all different sizes. Proved by infinite descent (chain_length_bounded + omega), modulo two geometric covering axioms.",
+      "leanType": "(d : CubeDissection) -> d.cubes.Nonempty -> ¬ d.allDifferentSizes"
+    },
+    {
+      "name": "two_cubes_same_size",
+      "type": "core",
+      "description": "Equivalent reformulation: any dissection of a cube into smaller cubes must contain at least two distinct cubes of the same size.",
+      "leanType": "(d : CubeDissection) -> d.cubes.Nonempty -> ∃ c₁ ∈ d.cubes, ∃ c₂ ∈ d.cubes, c₁ ≠ c₂ ∧ c₁.size = c₂.size"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — dissection-of-cubes (Wiedijk #82, Littlewood)

Re-audit (4th) of the base `dissection-of-cubes` entry. One integrity issue found and fixed.

### Issue: phantom `mainTheorems`
`meta.json` advertised a single main theorem `dehn_invariant` ("Dehn's theorem: polyhedra with different Dehn invariants are not scissors-congruent"). This theorem **does not exist** in `Proofs/DissectionOfCubes.lean` — `grep -in 'dehn\|scissors'` returns zero hits. It was evidently copied from an unrelated entry.

**Fix:** replaced with the file's two actual core results:
- `dissection_of_cubes` — `(d : CubeDissection) → d.cubes.Nonempty → ¬ d.allDifferentSizes`
- `two_cubes_same_size` — existential reformulation

### Verified correct (no change)
- **366 lines**, **2 axioms** (`smaller_cube_above_axiom`, `all_different_implies_long_chains_axiom`), **0 sorries**, **0 native_decide**, **7 theorems**, **10 definitions** — all match meta.
- **status `axiomatized` / badge `axiom`** is honest: the headline rests on the two geometric covering axioms; `chain_length_bounded` (via `Fintype.card_le_of_injective`) and `dissection_of_cubes` (omega) are the genuinely-proved combinatorial core.
- True-stubs are disclosed: `covers_unit_cube : True` (structure field, noted in section summary), `squaring_the_square_exists := rfl` (placeholder for the 2D contrast, noted as "True placeholder"), and the vacuous `∧ True` in `smallest_cube_top_is_floor`.

Tracker bumped (auditCount 4 → 5; no status/count change).