### PR TITLE
Fix: partition-theorem native_decide → axiomatized

### DIFF
--- a/src/data/proofs/partition-theorem/meta.json
+++ b/src/data/proofs/partition-theorem/meta.json
@@ -8,7 +8,7 @@
     "author": "Leonhard Euler (1748)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Partition_(number_theory)",
     "date": "1748",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PartitionTheorem.lean",
     "tags": [
       "combinatorics",
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -43,9 +43,9 @@
       "Asymptotic formula for Q(n)"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 281,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. The named contribution \"Computational verification for n = 0 through 8 via native_decide\" consists of 18 example blocks computing (Nat.Partition.distincts n).card and (Nat.Partition.odds n).card for n = 0..8, each discharged solely via native_decide, which trusts the Lean compiler's kernel reduction and so adds the Lean.ofReduceBool axiom (#print axioms lists it). The headline result is a pedagogical wrapper around Mathlib's partition_theorem (Euler's identity, distincts.card = odds.card) together with the symbolic characterizations distinct_iff_nodup and odd_iff_all_odd, which are native_decide-free. No literal axiom declarations or sorries (leanFile.axiomCount remains 0).",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

The named original contribution "Computational verification for n = 0 through 8 via native_decide" is proved **solely** via `native_decide`, so the entry depends on `Lean.ofReduceBool` and must be `axiomatized`, not `verified`.

## Evidence

`proofs/Proofs/PartitionTheorem.lean` L159–196: 18 `example` blocks computing `(Nat.Partition.distincts n).card` and `(Nat.Partition.odds n).card` for n = 0..8, each `by native_decide`. These concrete cardinality computations have no symbolic alternative and are exactly the named origContrib #4.

The headline result (a pedagogical wrapper around Mathlib's `partition_theorem`, plus the symbolic characterizations `distinct_iff_nodup` and `odd_iff_all_odd`) is `native_decide`-free.

Per the Axiom Integrity Policy, a substantive named result discharged by `native_decide` must count `Lean.ofReduceBool`.

**Before**: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, `assumptions` discloses `Lean.ofReduceBool` and separates the `native_decide`-backed verification from the symbolic headline.

`leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.