### PR TITLE
Fix: arithmetic-series-oq-02-oq-02-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hockey-stick_identity",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,11 +18,11 @@
       "Pascal's triangle",
       "generating functions"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde).",
+    "axiomCount": 1,
+    "assumptions": "Relies on `Lean.ofReduceBool`: the named verification theorems `check_3d_zeros` (C(5,3)=10) and `check_2d_a1b0` (C(6,3)=20) are discharged solely by `native_decide`, which trusts the compiler's kernel reduction. The symbolic headline results — `multi_hockey_stick` (the k-dimensional identity, by list induction on `parallel_vandermonde`), the 1D/2D/3D special-case rewrites, and `multiHockeySum_mono`/`multiHockeySum_pos` — are native_decide-free and fully machine-checked. No literal `axiom` declarations (leanFile.axiomCount 0). Depends on ArithmeticSeriesOQ02OQ02 (parallel Vandermonde).",
     "lineCount": 165,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Flip `arithmetic-series-oq-02-oq-02-oq-01` (k-Dimensional Hockey Stick Identity) from `verified`/`original`/0-axioms to `axiomatized`/`axiom`/1-axiom, disclosing `Lean.ofReduceBool`.

## Evidence

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "None. Fully machine-verified."`

**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

The named verification theorems are proved **solely** by `native_decide`, which trusts the compiler's kernel reduction (`Lean.ofReduceBool`), so the proof is not axiom-free:

```
110: theorem check_3d_zeros : multiHockeySum [0, 0, 0] 2 = 10 := by native_decide
114: theorem check_2d_a1b0  : multiHockeySum [1, 0] 3 = 20 := by native_decide
```

Both are advertised as an `originalContribution` ("check_3d_zeros: concrete verification C(5,3) = 10 via native_decide") and referenced in the Lean file summary.

The symbolic headline results — `multi_hockey_stick` (k-dimensional identity by list induction on `parallel_vandermonde`), the 1D/2D/3D special-case rewrites, and `multiHockeySum_mono`/`multiHockeySum_pos` — are `native_decide`-free and remain fully machine-checked. No literal `axiom` declarations, so `leanFile.axiomCount` stays 0.

Per the project Axiom Integrity Policy: `native_decide` discharging a substantive result an entry presents as verified must be counted (`axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`).

---
Automated fix by lean-mechanic agent.