### PR TITLE
gallery: BEC capacity entry (shannon-channel-coding-bec)

### DIFF
--- a/research/problems/shannon-channel-coding-oq-01/knowledge.md
+++ b/research/problems/shannon-channel-coding-oq-01/knowledge.md
@@ -19,8 +19,12 @@ State as of 2026-06-16 (researcher-8 session):
   because OQ02 imports the parent (inlining would create an import cycle).
   So the parent's axiom count (3) is not reducible without a structural
   refactor that moves `bsc`/`channelCapacity` upstream — not attempted.
-- **BEC** — the genuinely-open item ("audit BEC/AWGN separately"). Addressed
-  this session (see Insights).
+- **BEC** — DONE. `ShannonChannelCodingBEC.lean` proves
+  `bec_capacity : channelCapacity (bec p) = (1 - p)·log 2` from first
+  principles, 0 new axioms / 0 sorries. Built green and **registered** in
+  `Proofs.lean` (researcher-1, 2026-06-18, PR #25734) — it was an orphan until
+  then. A gallery entry `src/data/proofs/shannon-channel-coding-bec/` was also
+  added in the same PR. See Insights / "Build + de-rot".
 - **AWGN** — still open; continuous channel, needs measure-theoretic capacity
   (much harder than the finite-alphabet BSC/BEC). Not attempted.
 
@@ -73,9 +77,23 @@ and the general `chain_rule`, `entropy_le_log_card`, `channelMI_le_log_card`,
 
 ---
 
+## Build + de-rot (researcher-1, 2026-06-18, PR #25734)
+
+Docker recovered. Built `ShannonChannelCodingBEC.lean` green and registered it
+in `Proofs.lean`. Registering the orphan forced a real recompile and exposed
+that **`ShannonChannelCodingOQ02.lean` no longer built against the current
+Mathlib pin** — its "verified" status had been riding on a stale cache olean.
+Repaired 8 Mathlib-drift sites in OQ02 + 3 in BEC (all tactic/lemma-name drift,
+no math change). Key patterns: `div_le_iff`→`div_le_iff₀`,
+`smul_eq_mul`→`nsmul_eq_mul` (ℕ•ℝ); drop trailing `ring`/`norm_num` where simp
+got stronger ("No goals to be solved"); `congr 1 <;> ...`; `push_neg` on
+`¬ 0 < x` now yields `x ≤ 0` directly; for the `set ch ... with hch_def` issue
+the fix is to prepend `hch_def` to the `simp_rw`. Full chain builds (7750 jobs).
+**Lesson: orphan/unregistered files mask Mathlib drift via stale cache —
+registering one is a de-rot trigger.**
+
 ## Next Steps
 
-1. When Docker is back: build `ShannonChannelCodingBEC.lean`; fix any
-   simp/lemma-name drift; then register it (add to the import graph / gallery).
-2. Optional: a gallery entry `src/data/proofs/shannon-channel-coding-bec/`.
-3. AWGN capacity (continuous) remains the only untouched concrete channel.
+1. AWGN capacity (continuous channel) remains the only untouched concrete
+   channel — needs measure-theoretic capacity, materially harder.
+2. (Cosmetic) one `<;>`-vs-`;` style lint remains in BEC `hfactor`; harmless.

--- a/src/data/proofs/shannon-channel-coding-bec/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-bec-channel",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 52,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "The Binary Erasure Channel BEC(p)",
+    "content": "Defines bec as a DMChannel from Bool to Option Bool, where none denotes an erasure. Each input is erased with probability p (W x none = p) and otherwise received correctly (W x (some y) = if x = y then 1 - p else 0). The non-negativity and sum-to-one channel laws are discharged for 0 ≤ p ≤ 1.",
+    "mathContext": "$W(? \\mid x) = p,\\quad W(y \\mid x) = (1-p)\\,[x = y]$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discrete memoryless channel",
+      "erasure channel",
+      "packet loss"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-bec-erasure-identity",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 99,
+      "endLine": 161
+    },
+    "type": "insight",
+    "title": "The Erasure Identity H(X|Y) = p · H(X)",
+    "content": "The engine of the whole proof. For ANY input distribution, the input entropy conditioned on the output equals p · H(X). The un-erased (some y) summands all vanish: off-diagonal joint probabilities are 0, and on the diagonal the conditional probability is exactly 1 so log 1 = 0. Only the erasure (none) summand survives, where the denominator marginal is p and the term reproduces the input entropy scaled by p.",
+    "mathContext": "$H(X \\mid Y) = p \\cdot H(X)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "conditional entropy",
+      "erasure channel"
+    ],
+    "prerequisites": [
+      "Shannon entropy",
+      "conditional entropy"
+    ]
+  },
+  {
+    "id": "ann-bec-mi",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 168,
+      "endLine": 180
+    },
+    "type": "concept",
+    "title": "Mutual Information I(X;Y) = (1 - p) · H(X)",
+    "content": "Immediate from the chain rule I(X;Y) = H(X) - H(X|Y) and the erasure identity. The X-marginal of the joint distribution equals the input distribution, so I(X;Y) = H(X) - p · H(X) = (1 - p) · H(X) for every input.",
+    "mathContext": "$I(X;Y) = H(X) - H(X\\mid Y) = (1-p)\\,H(X)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "mutual information",
+      "chain rule"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-bec-converse",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 194,
+      "endLine": 200
+    },
+    "type": "concept",
+    "title": "Converse Bound I(X;Y) ≤ (1 - p) · log 2",
+    "content": "From I(X;Y) = (1 - p) · H(X) and the entropy bound H(X) ≤ log|Bool| = log 2, every input distribution satisfies I(X;Y) ≤ (1 - p) · log 2. This is the upper half of the capacity computation.",
+    "mathContext": "$I(X;Y) \\le (1-p)\\,\\log 2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "entropy bound",
+      "channel converse"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-bec-capacity",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 209,
+      "endLine": 219
+    },
+    "type": "insight",
+    "title": "BEC Capacity = (1 - p) · log 2",
+    "content": "The headline result. Capacity is the supremum of mutual information over input distributions. The converse bounds the supremum above by (1 - p) · log 2, and the uniform Bernoulli(1/2) input achieves it (giving H(X) = log 2), so the supremum equals (1 - p) · log 2. Proved with no new axioms or sorries.",
+    "mathContext": "$C(\\mathrm{BEC}(p)) = (1-p)\\,\\log 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "channel capacity",
+      "supremum",
+      "achievability"
+    ],
+    "prerequisites": [
+      "conditional supremum (csSup)"
+    ]
+  },
+  {
+    "id": "ann-bec-bits",
+    "proofId": "shannon-channel-coding-bec",
+    "range": {
+      "startLine": 224,
+      "endLine": 226
+    },
+    "type": "concept",
+    "title": "Capacity in Bits = 1 - p",
+    "content": "Dividing the capacity by log 2 gives the capacity in bits: C₂(BEC(p)) = 1 - p. This has a transparent operational meaning: a fraction p of transmissions are erased, and the surviving fraction 1 - p each carry one bit.",
+    "mathContext": "$C(\\mathrm{BEC}(p)) / \\log 2 = 1 - p$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "channel capacity",
+      "bits vs nats"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-bec/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec/meta.json
@@ -1,0 +1,67 @@
+{
+    "id": "shannon-channel-coding-bec",
+    "title": "BEC Capacity Proof (Binary Erasure Channel)",
+    "slug": "shannon-channel-coding-bec",
+    "description": "Proves the binary erasure channel capacity formula C(BEC(p)) = (1 - p) · log 2 from first principles. The BEC has input Bool and output Option Bool (none = erasure); each bit is erased with probability p. The proof rests on the erasure identity H(X|Y) = p · H(X) for any input distribution, giving I(X;Y) = (1 - p) · H(X) by the chain rule, with the uniform input achieving H(X) = log 2. Introduces no new axioms or sorries; inherits 4 axioms from the parent ShannonChannelCoding import.",
+    "meta": {
+        "author": "Claude Shannon (1948), formalized in Lean 4",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
+        "date": "1948",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/ShannonChannelCodingBEC.lean",
+        "tags": [
+            "information-theory",
+            "analysis",
+            "probability",
+            "coding-theory",
+            "channel-capacity",
+            "advanced"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "mathlibDependencies": [
+            {
+                "theorem": "Analysis.SpecialFunctions.Log.Basic",
+                "description": "Logarithm properties for entropy and mutual information computations",
+                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+            },
+            {
+                "theorem": "Order.ConditionallyCompleteLattice.Basic",
+                "description": "csSup/csSup_le and le_csSup for capacity as a supremum",
+                "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+            }
+        ],
+        "originalContributions": [
+            "Complete from-first-principles proof that BEC(p) capacity = (1 - p) · log 2 nats (equivalently 1 - p bits)",
+            "The BEC erasure identity H(X|Y) = p · H(X) for any input distribution: un-erased outputs (probability 1 - p) determine the input exactly, erased outputs (probability p) leave the full input entropy",
+            "Mutual information identity I(X;Y) = (1 - p) · H(X) via the chain rule",
+            "Converse I(X;Y) ≤ (1 - p) · log 2 from H(X) ≤ log 2, and achievability via the uniform Bernoulli(1/2) input",
+            "Capacity-in-bits corollary, non-negativity, and the ≤ log 2 (one-bit) ceiling"
+        ],
+        "assumptions": "4 axioms inherited in scope from ShannonChannelCoding.lean: fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
+        "dateAdded": "2026-06-18",
+        "axiomCount": 4,
+        "lineCount": 243,
+        "prerequisites": [
+            "Shannon entropy and mutual information (ShannonEntropy.lean)",
+            "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
+            "BSC development: uniformBool, entropy_uniform_bool (ShannonChannelCodingOQ02.lean)",
+            "Binary entropy function h(p) (ShannonChannelCodingOQ04.lean)"
+        ],
+        "mathlib_version": "4.26.0",
+        "theoremCount": 12,
+        "definitionCount": 1
+    },
+    "overview": {
+        "historicalContext": "The binary erasure channel (BEC) is, with the BSC, one of the two canonical discrete memoryless channels. Each transmitted bit is either received correctly (probability 1 - p) or replaced by an erasure symbol (probability p); crucially, the receiver always knows when an erasure has occurred. This makes the BEC the simplest channel that models packet loss, and its capacity C = 1 - p bits has a transparent operational meaning: a fraction p of the transmissions are lost, and the remaining 1 - p carry one bit each.\n\nUnlike the BSC, the BEC is not weakly symmetric, so the symmetric-channel capacity machinery does not apply. Instead the clean route is the erasure identity H(X|Y) = p · H(X): conditioned on the output, the residual uncertainty about the input is zero when the symbol arrives un-erased and the full H(X) when it is erased. The capacity-achieving input is uniform, exactly as for the BSC, because erasure is symmetric in the input symbol.",
+        "problemStatement": "**BEC Capacity Formula**: For a binary erasure channel with erasure probability $0 < p < 1$:\n$$C(\\text{BEC}(p)) = (1 - p)\\,\\log 2 \\text{ nats} = 1 - p \\text{ bits}.$$\nThe channel has input alphabet $\\{0,1\\}$ and output alphabet $\\{0, 1, ?\\}$ where $?$ denotes an erasure, with $W(x \\mid ?) = p$ and $W(y \\mid x) = (1-p)\\,[x = y]$ for $y \\in \\{0,1\\}$.",
+        "text": "Proves the binary erasure channel capacity C(BEC(p)) = (1 - p) · log 2 from first principles, via the erasure identity H(X|Y) = p · H(X).",
+        "proofStrategy": "The capacity proof has five stages, mirroring the BSC development:\n\n1. **Channel and marginals**: Define bec : DMChannel Bool (Option Bool). Compute the output marginals: the erasure output has probability p for every input, and each un-erased symbol y has marginal p(y) · (1 - p).\n\n2. **Erasure identity** H(X|Y) = p · H(X): In the conditional entropy, the un-erased (some y) summands vanish -- off-diagonal joint probabilities are 0, and on the diagonal the conditional probability is 1 so log 1 = 0. Only the erasure (none) summand survives, and it reproduces the input entropy scaled by p.\n\n3. **Mutual information** I(X;Y) = (1 - p) · H(X): immediate from the chain rule I = H(X) - H(X|Y) and step 2.\n\n4. **Converse**: H(X) ≤ log|Bool| = log 2, so I(X;Y) ≤ (1 - p) · log 2 for every input.\n\n5. **Capacity**: The uniform Bernoulli(1/2) input gives H(X) = log 2 and hence achieves (1 - p) · log 2. The supremum (channel capacity) therefore equals (1 - p) · log 2.",
+        "keyInsights": [
+            "The erasure identity H(X|Y) = p · H(X) is the entire engine: it holds for ANY input distribution, not just the optimal one.",
+            "The BEC is not weakly symmetric (the erasure column sums to 2p while the others sum to 1 - p), so the parent's symmetric-channel capacity lemmas do not apply -- a separate development is genuinely needed.",
+            "Erasure is symmetric in the input symbol, so the capacity-achieving input is still uniform Bernoulli(1/2), exactly as for the BSC.",
+            "Capacity in bits is simply 1 - p: a clean operational reading as the surviving fraction of transmissions."
+        ]
+    }
+}

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -41,7 +41,7 @@
     "assumptions": "4 axioms inherited from ShannonChannelCoding.lean: fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 0 sorries. Note: bsc_capacity_proved in this file independently proves bsc_capacity_eq, but the import still carries those axioms in scope.",
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
-    "lineCount": 297,
+    "lineCount": 294,
     "prerequisites": [
       "Shannon entropy and mutual information (ShannonEntropy.lean)",
       "Discrete memoryless channels and BSC definition (ShannonChannelCoding.lean)",
@@ -177,7 +177,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 297,
+    "lineCount": 294,
     "path": "Proofs/ShannonChannelCodingOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,


### PR DESCRIPTION
Follow-up to #25734 (which registered `ShannonChannelCodingBEC.lean` and repaired the BSC-chain Mathlib drift, now merged). That PR was squash-merged before this gallery data could ride along, so it's split out here.

## Adds

- **`src/data/proofs/shannon-channel-coding-bec/`** — new gallery entry surfacing the now-registered, build-green BEC capacity proof `C(BEC(p)) = (1-p)·log 2`. `meta.json` + 6 annotations (validated with `scripts/annotations/resolver.ts`: 6 valid, 0 misaligned). Conservative framing matching the OQ02 sibling: `axiomatized`/`axiom`, `axiomCount` 4 (inherited from the parent import; BEC itself introduces **0 new axioms / 0 sorries**). 243 lines, 12 theorems, 1 def.
- **`shannon-channel-coding-oq-02/meta.json`** — `lineCount` 297 → 294 (the file shrank by 3 lines in the drift repair; theorem/def/axiom counts unchanged). Existing OQ02 annotations re-validated (5 valid, 0 misaligned).
- **`knowledge.md`** — mark BEC DONE and record the "orphan files mask Mathlib drift via stale cache" de-rot lesson.

No Lean source changes (data/docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)