### PR TITLE
audit(dirichlets-theorem): fix phantom mainTheorem (dirichlet_arithmetic_progression)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2472,10 +2472,10 @@
       "result": "clean"
     },
     "dirichlets-theorem": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T19:24:37Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18",
+      "result": "issues-fixed"
     },
     "dirichlets-theorem-oq-01": {
       "auditCount": 4,

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -252,10 +252,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "dirichlet_arithmetic_progression",
+      "name": "dirichlet_modEq",
       "type": "core",
-      "description": "There are infinitely many primes in any arithmetic progression a, a+d, a+2d, ... with gcd(a,d)=1",
-      "leanType": "Nat.Coprime a d -> Set.Infinite {p | Nat.Prime p and p % d = a % d}"
+      "description": "Dirichlet's theorem (congruence formulation): for coprime a and q (q ≠ 0), there are infinitely many primes p with p ≡ a (mod q). Derived from Mathlib's Nat.infinite_setOf_prime_and_modEq.",
+      "leanType": "(hq : q ≠ 0) → (ha : Nat.Coprime a q) → Set.Infinite {p : ℕ | Nat.Prime p ∧ p ≡ a [MOD q]}"
+    },
+    {
+      "name": "dirichlet_zmod",
+      "type": "core",
+      "description": "Dirichlet's theorem (ZMod formulation): if a : ZMod q is a unit, there are infinitely many primes p with (p : ZMod q) = a. Derived from Mathlib's Nat.infinite_setOf_prime_and_eq_mod.",
+      "leanType": "[NeZero q] → (a : ZMod q) → (ha : IsUnit a) → Set.Infinite {p : ℕ | Nat.Prime p ∧ (p : ZMod q) = a}"
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Integrity Issue

**Proof**: `dirichlets-theorem` (Dirichlet's theorem on primes in arithmetic progressions; status `verified` / badge `mathlib`)

**Problem**: `mainTheorems` advertised a theorem that does not exist in the Lean source.

## Evidence

**meta.json claimed** — `mainTheorems[0].name = "dirichlet_arithmetic_progression"`

**Lean file shows** — `grep -rn dirichlet_arithmetic_progression proofs/Proofs/` returns 0 hits. The actual headline theorems in `proofs/Proofs/DirichletsTheorem.lean` are:

- `dirichlet_zmod` (L122) — ZMod formulation, `= Nat.infinite_setOf_prime_and_eq_mod a ha`
- `dirichlet_modEq` (L130) — congruence formulation, `= Nat.infinite_setOf_prime_and_modEq hq ha`
- plus `dirichlet_constructive`, `dirichlet_int`, `dirichlet_frequently`, and the four mod-4/mod-6 special cases.

## Fix

Replaced the phantom entry with the two real primary formulations (`dirichlet_modEq`, `dirichlet_zmod`), using their exact source signatures and crediting the Mathlib lemmas they delegate to.

## Everything else verified accurate

- 313 lines (matches `lineCount`), 0 `axiom`, 0 `sorry`, 0 `native_decide`, 0 `True` stubs.
- 10 theorems, 7 defs — matches meta counts.
- `status: verified` / `badge: mathlib` correct — clean Tier-B Mathlib bridge; main results delegate to Mathlib, and `originalContributions` (wrappers, special cases, documentation) + `assumptions` ("None. Fully verified with 0 axioms and 0 sorries.") are honestly scoped.

Tracker bump 4→5, result `issues-fixed`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)