### PR TITLE
Fix: divisibility-by-three-oq-02-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Repunit",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -17,7 +17,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ02OQ01.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -43,9 +43,9 @@
       "Verified concrete examples: ord_7(10)=6, ord_11(10)=2, ord_13(10)=6, ord_37(10)=3 via native_decide"
     ],
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 65,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "The headline biconditional repunit_dvd_iff_orderOf and the supporting ZMod identity repunit_ZMod_aux are fully symbolic and native_decide-free. However, the four concrete verification examples (7∣R(6), ¬7∣R(5), 11∣R(2), ¬11∣R(1), 37∣R(3), ¬37∣R(2) — advertised as originalContribution #3) are discharged solely by native_decide, which depends on the Lean.ofReduceBool axiom (trusts the compiler's kernel reduction). Per the project's axiom-integrity policy, this is counted as 1 axiom. No literal axiom declarations or sorries.",
     "theoremCount": 2,
     "definitionCount": 1
   },


### PR DESCRIPTION
## Fix

Reclassify `divisibility-by-three-oq-02-oq-01` from `verified`/`original` to `axiomatized`/`axiom` because an advertised contribution is discharged solely by `native_decide`.

## Evidence

The Lean file `Proofs/DivisibilityByThreeOQ02OQ01.lean` has two layers:

- **Symbolic core (native_decide-free):** the headline biconditional `repunit_dvd_iff_orderOf` (d ∣ R(k) ↔ orderOf(10 : ZMod d) ∣ k) and the supporting ZMod identity `repunit_ZMod_aux` (9·R(k)+1 = 10^k, by induction + `linear_combination`).
- **Concrete verifications (native_decide-only):** 6 anonymous `example` blocks (`7 ∣ repunit 6`, `¬ 7 ∣ repunit 5`, `11 ∣ repunit 2`, `¬ 11 ∣ repunit 1`, `37 ∣ repunit 3`, `¬ 37 ∣ repunit 2`) each proved `by native_decide`.

These concrete examples are explicitly advertised as **originalContribution #3** ("Verified concrete examples: ord_7(10)=6, ord_11(10)=2, ord_13(10)=6, ord_37(10)=3 via native_decide") and have no symbolic alternative in the file. `native_decide` depends on the `Lean.ofReduceBool` axiom, so the entry is not axiom-free.

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, assumptions "None. Fully verified with 0 axioms and 0 sorries."
**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose the `Lean.ofReduceBool` dependency from the native_decide examples while noting the headline theorem is symbolic.

`leanFile.axiomCount` stays `0` (no literal `axiom` declarations); the meta-level `axiomCount` reflects the `ofReduceBool` assumption per the project axiom-integrity policy.

---
Automated fix by lean-mechanic agent.