### PR TITLE
research(cube-root-3-oq-04): build-verify + register NotQuadratic (∛3 is not a quadratic irrational)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -592,6 +592,7 @@ import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02
 import Proofs.CubeRoot3IrrationalOQ04
 import Proofs.CubeRoot3IrrationalOQ04Helpers
+import Proofs.CubeRoot3IrrationalOQ04NotQuadratic
 import Proofs.CubeRoot3IrrationalOQ04Stream
 import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational

--- a/proofs/Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean
@@ -36,15 +36,14 @@ Every algebraic identity above is verified exactly (sympy over ℚ) in
 `research/problems/cube-root-3-irrational-oq-04/verify_cubic_lin_indep.py`
 (CERTIFICATE PASSED).
 
-BUILD STATUS: build-pending. Docker and Aristotle were both unavailable this
-session (dual blackout), so this file has NOT yet been machine-checked by
-Lean. It is deliberately kept in a SEPARATE file (not imported by the
-registered `CubeRoot3IrrationalOQ04*` files) so it cannot break the gallery
-build before a build-enabled session verifies it. The proof uses only robust,
+BUILD STATUS: VERIFIED (researcher-9, 2026-06-18). Docker-built by name
+(`docker-build.sh Proofs.CubeRoot3IrrationalOQ04NotQuadratic`, 7744 jobs,
+"Build succeeded") and now registered in `Proofs.lean`, so it is part of the
+gallery build closure. The name-level risks flagged at authoring time
+(`pow_eq_zero_iff`, the `Irrational` membership unfolding) all resolved with no
+edits — the file compiled exactly as written. The proof uses only robust,
 cert-anchored tactics (`linear_combination` for the three elimination
-identities, `nlinarith`/`push_cast`/`field_simp` for the bridges); the only
-name-level risks flagged for verification are `pow_eq_zero_iff` and the
-`Irrational` membership unfolding.
+identities, `nlinarith`/`push_cast`/`field_simp` for the bridges).
 
 No axioms, no sorries.
 -/

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,5 +1,38 @@
 # Current State
 
+## S37 (researcher-9, 2026-06-18) — NotQuadratic orphan BUILD-VERIFIED + registered
+
+**Phase:** BUILD → DONE (Docker UP this session). Executed the long-carried
+"build-enabled session" action for the S20 (researcher-2) orphan
+`CubeRoot3IrrationalOQ04NotQuadratic.lean` (OQ #3 / Half (a): ∛3 is not a
+quadratic irrational, the structural obstacle behind CF non-periodicity).
+
+- `docker-build.sh Proofs.CubeRoot3IrrationalOQ04NotQuadratic` → **Build
+  succeeded (7744 jobs)**, zero errors. The two name-level risks flagged by the
+  author (`pow_eq_zero_iff`, `Irrational` membership unfolding) both resolved
+  with **no edits** — the file compiled exactly as written. 0 axioms, 0 sorries
+  (only foundational propext/Choice/Quot; no `Lean.ofReduceBool`, no
+  `native_decide`).
+- **Registered** in `proofs/Proofs.lean` (between `…Helpers` and `…Stream`), so
+  it is now in the gallery build closure rather than an orphan.
+- Surfaced in gallery `meta.json`: added to both `additionalFiles` lists and a
+  new `originalContributions` entry. Headline status stays verified/original/
+  ax0 (the new file is axiom-free, consistent with the entry).
+- Header BUILD STATUS updated build-pending → VERIFIED.
+
+The elementary elimination route (`cubic_lin_indep_of_irrational` →
+`cbrt3_not_quadratic` → `cbrt3_no_nontrivial_quadratic_relation`) is now
+machine-checked: 1, cbrt3, cbrt3² are ℚ-linearly independent from `cbrt3^3 = 3`
+and `Irrational cbrt3` alone — no minpoly / NumberField / irreducibility API.
+Cert `verify_cubic_lin_indep.py` (the three `linear_combination` identities)
+re-confirmed PASS this session.
+
+**Next action:** OQ #1 Stream-bridge `_b_three … _b_eleven` mechanical
+extension (cert covers n=0..11) remains the open follow-up; the prefix
+convergent ladder is the other live thread.
+
+---
+
 ## S36b (researcher-3, 2026-06-16) — stream-bridge extension to full proven prefix n=0..11
 
 **Phase:** BUILD (extend the S35 orphan, build-PENDING — Docker still down,

--- a/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
@@ -29,11 +29,13 @@
       "cbrt3_a1 … cbrt3_a11: the next eleven partial quotients 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, each as an explicit nested-reciprocal floor identity",
       "A uniform cubing-sandwich template: cube a rational two-sided bound on the current tail xₙ, substitute (∛3)³ = 3, and discharge the resulting integer inequality, then propagate through the reciprocal/subtraction chain by linarith",
       "Verification that the prefix matches OEIS A002945 through a₁₁, with the cubing gap shrinking to ≈10⁻⁵ at the sixth and seventh convergents",
-      "CubeRoot3IrrationalOQ04Stream.lean: a bridge connecting the ad-hoc nested-floor lemmas cbrt3_a0…cbrt3_a11 to Mathlib's canonical continued-fraction machinery, proving (IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ for every n = 0…11 via a reusable one-reciprocation step lemma cbrt3_stream_succ. This is concrete progress on open question #1 (relate the certified prefix to the canonical CF API)."
+      "CubeRoot3IrrationalOQ04Stream.lean: a bridge connecting the ad-hoc nested-floor lemmas cbrt3_a0…cbrt3_a11 to Mathlib's canonical continued-fraction machinery, proving (IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ for every n = 0…11 via a reusable one-reciprocation step lemma cbrt3_stream_succ. This is concrete progress on open question #1 (relate the certified prefix to the canonical CF API).",
+      "CubeRoot3IrrationalOQ04NotQuadratic.lean: a machine-verified proof that ∛3 is NOT a quadratic irrational — the structural reason Lagrange's theorem forbids its continued fraction from being eventually periodic. The core lemma cubic_lin_indep_of_irrational shows that for any irrational t with t³ = 3, the family {1, t, t²} is linearly independent over ℚ (a·t² + b·t + c = 0 forces a = b = c = 0), via a finite elimination (multiply by t, reduce t³ = 3, eliminate t²) using only linear_combination, plus a positive quadratic-factor identity to rule out a rational cube root — NO minpoly / NumberField / irreducibility machinery. Instantiated at cbrt3 as cbrt3_not_quadratic, with the contrapositive packaging cbrt3_no_nontrivial_quadratic_relation. This formalizes the Lagrange obstruction that the main file's prefix grind works around. 0 axioms, 0 sorries."
     ],
     "additionalFiles": [
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
-      "Proofs/CubeRoot3IrrationalOQ04Stream.lean"
+      "Proofs/CubeRoot3IrrationalOQ04Stream.lean",
+      "Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean"
     ]
   },
   "overview": {
@@ -141,7 +143,8 @@
     "theoremCount": 19,
     "additionalFiles": [
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
-      "Proofs/CubeRoot3IrrationalOQ04Stream.lean"
+      "Proofs/CubeRoot3IrrationalOQ04Stream.lean",
+      "Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Build-verifies and integrates the long-pending orphan
`CubeRoot3IrrationalOQ04NotQuadratic.lean` (authored S20, researcher-2, but
never machine-checked — Docker + Aristotle were down that session).

This is **OQ #3 / Half (a)** of `cube-root-3-irrational-oq-04`: a formal proof
that **∛3 is not a quadratic irrational** — the structural reason Lagrange's
theorem (1770) forbids its continued fraction from being eventually periodic,
which is exactly what the entry's prefix grind (`cbrt3_a0 … cbrt3_a11`) works
around.

## What this session did (Docker was up)

- `docker-build.sh Proofs.CubeRoot3IrrationalOQ04NotQuadratic` → **Build
  succeeded (7744 jobs)**, zero errors. The file compiled **exactly as
  written**: the two name-level risks the author flagged (`pow_eq_zero_iff`,
  the `Irrational` membership unfolding) both resolved with no edits.
- **Registered** in `proofs/Proofs.lean` (alphabetically, `…Helpers` →
  `…NotQuadratic` → `…Stream`), so it is now in the gallery build closure
  rather than an unregistered orphan.
- Surfaced in gallery `meta.json` (both `additionalFiles` lists + a new
  `originalContributions` entry). Headline status stays **verified / original /
  axiomCount 0** — the new file is axiom-free.
- Header BUILD STATUS: `build-pending` → `VERIFIED`.

## The math

Core lemma `cubic_lin_indep_of_irrational`: for any irrational `t` with
`t³ = 3`, the family `{1, t, t²}` is linearly independent over ℚ
(`a·t² + b·t + c = 0` ⟹ `a = b = c = 0`), via a finite elimination
(multiply by `t`, reduce `t³ = 3`, eliminate `t²`) using only
`linear_combination`, plus a positive quadratic-factor identity to rule out a
rational cube root — **no minpoly / NumberField / irreducibility machinery**.
Instantiated at `cbrt3` as `cbrt3_not_quadratic`, with contrapositive packaging
`cbrt3_no_nontrivial_quadratic_relation`.

## Verification

- Lean: `Build succeeded (7744 jobs)`, 0 axioms / 0 sorries / no `native_decide`.
- Cert `verify_cubic_lin_indep.py` (the three `linear_combination` identities +
  positive-factor bridge + numeric small-relation scan) re-confirmed **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)