### PR TITLE
Fix: binomial-theorem-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://en.wikipedia.org/wiki/Multinomial_theorem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "algebra",
       "combinatorics",
@@ -15,7 +15,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,9 +55,9 @@
       "Numerical examples via native_decide: C(3;1,1,1)=6, C(4;2,1,1)=12, C(6;2,2,2)=90"
     ],
     "dateAdded": "2026-02-23",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 280,
-    "assumptions": "0 axioms, 0 sorries. Core multinomial theorem derived from Mathlib's Finset.sum_pow_eq_sum_piAntidiag; most coefficient properties also from Mathlib.",
+    "assumptions": "Depends on Lean.ofReduceBool. The symbolic core (multinomial_theorem and the coefficient/recurrence theorems) is derived from Mathlib's Finset.sum_pow_eq_sum_piAntidiag and is axiom-free, but the advertised 'Numerical examples via native_decide' contribution (C(3;1,1,1)=6, C(4;2,1,1)=12, C(6;2,2,2)=90 and the piAntidiag sum checks) is discharged by native_decide, which trusts the Lean compiler's kernel reduction and adds the Lean.ofReduceBool axiom. 0 sorries. leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 17,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

`binomial-theorem-oq-02` (Multinomial Theorem) was marked `status: verified` / `badge: mathlib` / `axiomCount: 0` with assumptions "0 axioms, 0 sorries", but its advertised contribution **"Numerical examples via native_decide: C(3;1,1,1)=6, C(4;2,1,1)=12, C(6;2,2,2)=90"** is discharged solely by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

`proofs/Proofs/BinomialTheoremOQ02.lean` — 5 `native_decide` calls, all in the Numerical Examples section:
- L200 `Nat.multinomial univ (fun _ : Fin 3 => 1) = 6`
- L204 `Nat.multinomial univ (![2,1,1]) = 12`
- L208 `Nat.multinomial univ (![2,2,2]) = 90`
- L211, L215 piAntidiag multinomial-sum checks (= 9, = 64)

These specific computations have no symbolic alternative in the file and back the named originalContribution #8. Per the Axiom Integrity Policy, `native_decide` on a substantive advertised result requires `status: axiomatized`, `badge: axiom`, `axiomCount ≥ 1`, and disclosure of `Lean.ofReduceBool`.

The symbolic core (`multinomial_theorem`, `multinomial_recurrence`, `multinomial_eq_binomial`, `multinomial_total`, etc., L65-246) is genuine Mathlib-derived and axiom-free; the prose now scopes this.

**Before**: `verified` / `mathlib` / `axiomCount: 0` / "0 axioms, 0 sorries"
**After**: `axiomatized` / `axiom` / `axiomCount: 1` / assumptions disclose `Lean.ofReduceBool`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.