### PR TITLE
Fix: quadratic-reciprocity-algorithm-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gauss (algorithm, 1801)",
     "date": "1801",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean",
     "tags": [
       "number-theory",
@@ -16,9 +16,9 @@
       "jacobi-symbol",
       "verified-computation"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "dateAdded": "2026-03-30",
     "lineCount": 220,
     "originalContributions": [
@@ -28,7 +28,7 @@
       "jacobiAlgo_mod_left: algorithm respects residue classes",
       "7 verified example computations via native_decide"
     ],
-    "assumptions": "No axioms, no sorries. Jacobi symbol algorithm fully verified including termination proof via well-founded recursion on a.",
+    "assumptions": "No sorries. The symbolic results (jacobiAlgo definition with well-founded-recursion termination proof, jacobiAlgo_eq_jacobiSym correctness, legendreCompute_eq, jacobiAlgo_mod_left) are native_decide-free. The advertised contribution '7 verified example computations' (lines 179-197) is discharged solely by native_decide, which trusts the Lean compiler's kernel reduction and therefore depends on the Lean.ofReduceBool axiom. axiomCount: 1 (Lean.ofReduceBool). leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "mathlibDependencies": [
       {
         "theorem": "jacobiSym.div_four_left",


### PR DESCRIPTION
## Fix

Reclassify `quadratic-reciprocity-algorithm-oq-01` from `verified`/`original`/axiomCount 0 to `axiomatized`/`axiom`/axiomCount 1, disclosing the `Lean.ofReduceBool` dependency.

## Evidence

The Lean file `QuadraticReciprocityAlgorithmOQ01.lean` advertises as originalContribution #5 **"7 verified example computations via native_decide"** (lines 179–197). These anonymous `example` blocks (e.g. `jacobiAlgo 3 7 false (by omega) = -1 := by native_decide`) are discharged **solely** by `native_decide`, which trusts the Lean compiler's kernel reduction and therefore depends on the `Lean.ofReduceBool` axiom — the proof is not axiom-free.

The four symbolic deliverables (`jacobiAlgo` definition + well-founded termination, `jacobiAlgo_eq_jacobiSym`, `legendreCompute_eq`, `jacobiAlgo_mod_left`) are native_decide-free and remain fully verified.

**Before**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`, assumptions "No axioms, no sorries... fully verified" (masked the ofReduceBool dependency).
**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and scope which results are nd-free vs nd-backed. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

Per the Axiom Integrity Policy: when `native_decide` discharges a substantive advertised result, count it (`axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`, disclose `Lean.ofReduceBool`).

---
Automated fix by lean-mechanic agent.