### PR TITLE
Fix: binary-gcd-oq-01-oq-04 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "algorithms",
       "number-theory",
@@ -17,9 +17,9 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ01OQ04.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 157,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
@@ -58,7 +58,7 @@
       "binaryGcdSteps_exceeds_log_by_one: exact equality log₂(2^n - 1) + 1 = binaryGcdSteps 1 (2^n - 1) for n ≥ 2",
       "Computational verification for n = 1,2,3,4,6,8 via native_decide"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. The symbolic results — binaryGcdSteps_one_pow2_sub_one (exact step count = n), binaryGcdSteps_log_lower_bound, and binaryGcdSteps_exceeds_log_by_one — are proved symbolically and are axiom-free. The advertised 'Computational verification for n = 1,2,3,4,6,8 via native_decide' contribution is discharged by native_decide, which trusts the Lean compiler's kernel reduction and adds the Lean.ofReduceBool axiom. 0 sorries. leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 6,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

`binary-gcd-oq-01-oq-04` was marked `status: verified` / `badge: original` / `axiomCount: 0` with assumptions "None. Fully verified with 0 axioms and 0 sorries", but its advertised contribution **"Computational verification for n = 1,2,3,4,6,8 via native_decide"** is discharged solely by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

`proofs/Proofs/BinaryGcdOQ01OQ04.lean` — 8 `native_decide` calls, all in the verification section:
- L146-151 `binaryGcdSteps 1 (2^n - 1) = n` for n = 1,2,3,4,6,8
- L154-155 `Nat.log 2 (2^n - 1)` spot checks (15→3, 255→7)

These specific computations back the named originalContribution #7. The symbolic results (`binaryGcdSteps_one_pow2_sub_one` L76, `binaryGcdSteps_log_lower_bound` L114, `binaryGcdSteps_exceeds_log_by_one` L121) are proved symbolically and remain axiom-free; the prose now scopes this.

Per the Axiom Integrity Policy, `native_decide` on a substantive advertised result requires `status: axiomatized`, `badge: axiom`, `axiomCount ≥ 1`, and disclosure of `Lean.ofReduceBool`.

**Before**: `verified` / `original` / `axiomCount: 0` / "0 axioms, 0 sorries"
**After**: `axiomatized` / `axiom` / `axiomCount: 1` / assumptions disclose `Lean.ofReduceBool`. `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.