### PR TITLE
Enrich Kaprekar's Constant: add cross-references to related entries

### DIFF
--- a/src/data/proofs/kaprekar-constant-oq-01/meta.json
+++ b/src/data/proofs/kaprekar-constant-oq-01/meta.json
@@ -71,7 +71,23 @@
     "path": "Proofs/KaprekarConstantOQ01.lean",
     "sorries": 0
   },
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-by-three-oq-01-oq-02",
+      "relationship": "complementary",
+      "description": "The closest analogue in the gallery: digital-root iteration is the other elementary iterated-digit map whose convergence to a fixed point is formalized. Both reduce a four-/many-digit dynamical question to a finite statement, but by opposite techniques — digital-root convergence is proved *structurally* (the digit sum strictly decreases for $n \\geq 10$ and $n \\bmod 9$ is preserved, so iteration terminates at $\\text{digitalRoot}(n)$), whereas Kaprekar convergence here is proved by *exhaustive enumeration* over all $10000$ four-digit strings via `native_decide`. The contrast is exactly the open question raised in this entry: replace the enumeration with a structural decrease/invariant argument (the digital-root proof is a model for what that would look like)."
+    },
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "related",
+      "description": "Another integer self-map studied as a discrete dynamical system (both tagged `dynamical-systems`). Kaprekar's routine is the fully-decidable cousin of the Collatz orbit problem: because the four-digit Kaprekar map has a finite state space ($n < 10000$), its global-attractor behaviour ($T^{[7]}(n) = 6174$ for every non-repdigit) is settled by enumeration, while Collatz convergence remains open and `collatz-cycles` can only rule out *small* cycles and verify $1$–$20$ reach $1$. The link highlights why finiteness of the digit space makes Kaprekar tractable where Collatz is not."
+    },
+    {
+      "targetId": "divisibility-by-three-oq-01",
+      "relationship": "related",
+      "description": "Shares the base-10 digit-arithmetic toolkit. Where this entry extracts and reorders digits with `/` and `%` to build the Kaprekar map, `divisibility-by-three-oq-01` develops the general last-$k$-digit and digit-sum machinery ($2^k \\mid 10^k$, $5^k \\mid 10^k$, digit-sum rules for $3, 9, 27, 99, 999, 37$). Both formalize properties of how a natural number's decimal digits determine its arithmetic behaviour."
+    }
+  ],
   "sections": [
     {
       "id": "kaprekar-map",


### PR DESCRIPTION
## Enrichment pass for `kaprekar-constant-oq-01`

The entry was well-built and honestly calibrated (status `axiomatized`, `axiomCount: 1` disclosing `Lean.ofReduceBool` from the `native_decide` convergence enumeration — matches the CLAUDE.md axiom-integrity convention). Its one genuine gap was an **empty `crossReferences` array**.

Added three accurate cross-references, each verified to point to an existing gallery entry:

| Target | Relationship | Why |
|--------|-------------|-----|
| `divisibility-by-three-oq-01-oq-02` (Digital Root Iteration) | complementary | Closest analogue — another iterated-digit map converging to a fixed point, but proved *structurally* (strict digit-sum decrease + mod-9 invariant) vs. Kaprekar's *exhaustive* `native_decide` enumeration. Directly illustrates this entry's own open question (replace enumeration with a structural argument). |
| `collatz-cycles` | related | Another integer self-map dynamical system. Kaprekar is the finite/decidable cousin of the open Collatz orbit problem — finiteness of the 4-digit state space is exactly what makes it tractable. |
| `divisibility-by-three-oq-01` | related | Shares the base-10 digit-arithmetic toolkit (digit extraction by `/`,`%`; place-value recombination). |

No content was removed; `meta.json` validates as JSON and all three `targetId`s resolve to existing directories. The gallery-wide annotation line-range warnings emitted by `pnpm build` are pre-existing and unrelated to this change (no `kaprekar` errors).