### PR TITLE
audit(shannon-channel-coding-bec): fix inherited axiom count 4→3 (fano discharged)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15911,6 +15911,12 @@
       "lastAudited": "2026-06-18T11:58:09Z",
       "result": "clean",
       "issues": []
+    },
+    "shannon-channel-coding-bec": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-18T12:52:26Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/shannon-channel-coding-bec/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec/meta.json
@@ -2,7 +2,7 @@
     "id": "shannon-channel-coding-bec",
     "title": "BEC Capacity Proof (Binary Erasure Channel)",
     "slug": "shannon-channel-coding-bec",
-    "description": "Proves the binary erasure channel capacity formula C(BEC(p)) = (1 - p) · log 2 from first principles. The BEC has input Bool and output Option Bool (none = erasure); each bit is erased with probability p. The proof rests on the erasure identity H(X|Y) = p · H(X) for any input distribution, giving I(X;Y) = (1 - p) · H(X) by the chain rule, with the uniform input achieving H(X) = log 2. Introduces no new axioms or sorries; inherits 4 axioms from the parent ShannonChannelCoding import.",
+    "description": "Proves the binary erasure channel capacity formula C(BEC(p)) = (1 - p) · log 2 from first principles. The BEC has input Bool and output Option Bool (none = erasure); each bit is erased with probability p. The proof rests on the erasure identity H(X|Y) = p · H(X) for any input distribution, giving I(X;Y) = (1 - p) · H(X) by the chain rule, with the uniform input achieving H(X) = log 2. Introduces no new axioms or sorries; inherits 3 axioms from the parent ShannonChannelCoding import.",
     "meta": {
         "author": "Claude Shannon (1948), formalized in Lean 4",
         "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
@@ -38,9 +38,9 @@
             "Converse I(X;Y) ≤ (1 - p) · log 2 from H(X) ≤ log 2, and achievability via the uniform Bernoulli(1/2) input",
             "Capacity-in-bits corollary, non-negativity, and the ≤ log 2 (one-bit) ceiling"
         ],
-        "assumptions": "4 axioms inherited in scope from ShannonChannelCoding.lean: fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
+        "assumptions": "3 axioms inherited in scope from ShannonChannelCoding.lean: channel_coding_achievability, channel_coding_converse, bsc_capacity_eq. (The parent's fano_inequality is no longer an axiom -- it was discharged to a proven theorem via ShannonChannelCodingOQ02OQ01.fano_inequality_proved.) 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
         "dateAdded": "2026-06-18",
-        "axiomCount": 4,
+        "axiomCount": 3,
         "lineCount": 243,
         "prerequisites": [
             "Shannon entropy and mutual information (ShannonEntropy.lean)",


### PR DESCRIPTION
## Integrity Issue

**Proof**: `shannon-channel-coding-bec`
**Problem**: Inherited axiom count overstated; assumptions list names a non-existent axiom.

## Evidence

**meta.json claimed**: `axiomCount: 4`; assumptions field lists `fano_inequality, channel_coding_achievability, channel_coding_converse, bsc_capacity_eq` as the 4 inherited-in-scope axioms.

**Lean source shows**: `fano_inequality` is no longer an axiom — `ShannonChannelCoding.lean:200` declares it as a `theorem` discharged via `FanoFromConditionalEntropy.fano_inequality_proved` (defined in `ShannonChannelCodingOQ02OQ01.lean:293`, no sorry). The current parent carries exactly **3** real `axiom` declarations:
- `channel_coding_achievability` (ShannonChannelCoding.lean:553)
- `channel_coding_converse` (ShannonChannelCoding.lean:571)
- `bsc_capacity_eq` (ShannonChannelCoding.lean:593)

`ShannonChannelCodingOQ02.lean`, `ShannonChannelCodingOQ04.lean`, `ShannonEntropy.lean`, and `ShannonChannelCodingOQ02OQ01.lean` contain **0** axioms.

## Full audit of `ShannonChannelCodingBEC.lean`

All other meta claims verified accurate against source:
- 243 lines, 12 theorems/lemmas, 1 definition — exact match
- 0 sorries, 0 `native_decide`, 0 literal `axiom`, 0 True stubs
- `bec_capacity` proved from first principles; does not invoke the parent axioms (they are carried only in import scope)

## Fix

- `axiomCount`: 4 → 3
- `assumptions`: drop `fano_inequality`, note it is now a proven theorem
- `description`: "inherits 4 axioms" → "inherits 3 axioms"

Status `axiomatized` / badge `axiom` retained (conservative: 3 axioms remain in import scope).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)