### PR TITLE
Fix: fundamental-arithmetic native_decide → axiomatized

### DIFF
--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid, Gauss (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_arithmetic",
     "date": "~300 BCE (Euclid), 1801 (Gauss)",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "primes",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmetic.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -48,9 +48,9 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 80,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 224,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. The advertised concrete computational examples (originalContribution: 'Concrete computational examples via native_decide') are discharged solely by native_decide (e.g. (12).primeFactorsList = [2,2,3], factor counts at lines 155-216), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic deliverables (unified FTA statement, coprime disjoint prime factors corollary, pedagogical bridge theorems) are axiom-free Mathlib wrappers. No literal axiom declarations and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Reclassify `fundamental-arithmetic` from `verified`/`mathlib` to `axiomatized`/`axiom` (axiomCount 0 → 1) because an advertised original contribution is discharged solely by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0`, `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

The originalContribution "Concrete computational examples via native_decide" is realized by 8 `native_decide` example blocks in `proofs/Proofs/FundamentalArithmetic.lean` (lines 155-216, e.g. `(12 : ℕ).primeFactorsList = [2, 2, 3]`, prime-factor counts). `native_decide` trusts the compiler's kernel reduction via the `Lean.ofReduceBool` axiom; `#print axioms` would list it, so the result is not axiom-free.

The symbolic deliverables (unified FTA statement, coprime disjoint prime factors corollary, pedagogical bridge theorems) are axiom-free Mathlib wrappers and are unaffected. Per the Axiom Integrity Policy, when `native_decide` discharges a result the entry presents as a verified contribution, `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, and `Lean.ofReduceBool` must be disclosed. `leanFile.axiomCount` stays `0` (it counts only literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.