### PR TITLE
Enrich Mantel's Theorem: fix phantom cross-reference target

### DIFF
--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -119,9 +119,9 @@
       "description": "Both are structural/extremal results constraining simple graphs; the friendship theorem forbids a local configuration while Mantel forbids triangles globally."
     },
     {
-      "targetId": "erdos-565-incomplete-01",
+      "targetId": "erdos-565",
       "relationship": "related",
-      "description": "Both sit in extremal/Ramsey graph theory and reason about edge counts under forbidden substructures."
+      "description": "Both belong to extremal/Ramsey graph theory, where global graph parameters are controlled by local structural constraints. Mantel bounds the edge count of triangle-free graphs ($\\le \\lfloor n^2/4 \\rfloor$); Erdős #565 bounds the induced Ramsey number $R^*(G)$ of an $n$-vertex graph (shown to be $2^{O(n)}$). Both quantify how forbidding or forcing substructures constrains a graph's size."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for `mantel-theorem`

While auditing cross-reference integrity across the gallery, I found that `mantel-theorem` held the **only gallery-wide phantom `crossReferences` target**: it pointed at `erdos-565-incomplete-01`, which is not a gallery directory (a stale slug variant that never materialized).

- Corrected `targetId` → `erdos-565` ("Erdős Problem #565: Induced Ramsey Numbers"), the intended extremal/Ramsey-theory neighbor.
- Sharpened the relationship description to accurately contrast Mantel's edge bound (`≤ ⌊n²/4⌋` for triangle-free graphs) with the induced Ramsey number bound (`R*(G) = 2^{O(n)}`).

The `targetId` now resolves to an existing directory; `meta.json` validates as JSON. No other content changed.

> Pushed on `feature/enricher-1-mantel-theorem` to avoid disturbing earlier still-open enricher PRs on `feature/enricher-1`.