### PR TITLE
Fix: bezout-identity native_decide → axiomatized

### DIFF
--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -7,7 +7,7 @@
     "author": "Bezout (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/B%C3%A9zout%27s_identity",
     "date": "~1770",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "algorithms",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BezoutIdentity.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -72,7 +72,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 60,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 237,
     "relatedProblems": [
       {
@@ -88,7 +88,7 @@
         "relationship": "Further extensions"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. Of the advertised originalContribution 'Six worked examples verified with native_decide and norm_num', three concrete gcd examples are discharged solely by native_decide (Nat.gcd 12 8 = 4, Nat.gcd 35 15 = 5, Nat.gcd 17 5 = 1, lines 196-202), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic Bézout deliverables are axiom-free Mathlib wrappers. No literal axiom declarations and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Reclassify `bezout-identity` from `verified`/`mathlib` to `axiomatized`/`axiom` (axiomCount 0 → 1) because an advertised original contribution is partly discharged by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0`, assumptions: "None. Fully verified with 0 axioms and 0 sorries."

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

The originalContribution "Six worked examples verified with native_decide and norm_num" is realized in part by 3 `native_decide` example blocks in `proofs/Proofs/BezoutIdentity.lean` (lines 196-202: `Nat.gcd 12 8 = 4`, `Nat.gcd 35 15 = 5`, `Nat.gcd 17 5 = 1`). `native_decide` trusts the compiler's kernel reduction via the `Lean.ofReduceBool` axiom, so those examples are not axiom-free.

The symbolic Bézout deliverables are axiom-free Mathlib wrappers and are unaffected. Per the Axiom Integrity Policy, when `native_decide` discharges a presented contribution, `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, and `Lean.ofReduceBool` must be disclosed. `leanFile.axiomCount` stays `0` (literal `axiom` declarations only).

---
Automated fix by lean-mechanic agent.