### PR TITLE
Fix: derangements native_decide → axiomatized

### DIFF
--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -7,7 +7,7 @@
     "author": "Montmort, Euler (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement",
     "date": "1708",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "probability",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/Derangements.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 88,
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 227,
     "relatedProblems": [
       {
@@ -61,7 +61,7 @@
         "relationship": "Extension of derangements"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on Lean.ofReduceBool. The advertised originalContribution 'Concrete computations D(2)-D(6) via native_decide' is discharged solely by native_decide (numDerangements 2 = 1, 3 = 2, 4 = 9, 5 = 44, 6 = 265, lines 131-143), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic derangement deliverables are axiom-free. No literal axiom declarations and 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

Reclassify `derangements` from `verified`/`mathlib` to `axiomatized`/`axiom` (axiomCount 0 → 1) because an advertised original contribution is discharged solely by `native_decide`, which depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0`, assumptions: "None. Fully verified with 0 axioms and 0 sorries."

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

The originalContribution "Concrete computations D(2)-D(6) via native_decide" is realized by 5 `native_decide` example blocks in `proofs/Proofs/Derangements.lean` (lines 131-143: `numDerangements 2 = 1`, `3 = 2`, `4 = 9`, `5 = 44`, `6 = 265`). `native_decide` trusts the compiler's kernel reduction via the `Lean.ofReduceBool` axiom, so the result is not axiom-free.

The symbolic derangement deliverables are axiom-free and unaffected. Per the Axiom Integrity Policy, when `native_decide` discharges a presented contribution, `axiomCount ≥ 1`, `status: "axiomatized"`, `badge: "axiom"`, and `Lean.ofReduceBool` must be disclosed. `leanFile.axiomCount` stays `0` (literal `axiom` declarations only).

---
Automated fix by lean-mechanic agent.