### PR TITLE
Enrich Euler Polyhedral OQ-01: fix annotation type for inductive types

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ep-spanning-build",
     "proofId": "euler-polyhedral-oq-01",
-    "type": "definition",
+    "type": "inductive",
     "range": {
       "startLine": 66,
       "endLine": 111
@@ -194,7 +194,7 @@
   {
     "id": "ep-degeneracy-build",
     "proofId": "euler-polyhedral-oq-01",
-    "type": "definition",
+    "type": "inductive",
     "range": {
       "startLine": 656,
       "endLine": 693


### PR DESCRIPTION
## Enrichment pass for `euler-polyhedral-oq-01`

Fixed two annotation type mismatches flagged by the annotation resolver:

- `ep-spanning-build` (L66–111) and `ep-degeneracy-build` (L656–693) were typed `"definition"`, but both point at `inductive` declarations (`SpanningBuild`, `DegeneracyBuild k`). Their own titles and content already describe them as inductive types ("Inductive Planar Graph Construction", "`inductive DegeneracyBuild (k : ℕ)`").

Corrected `type` → `"inductive"` for both, matching the Lean source.

**Verification:** checked `proofs/Proofs/EulerPolyhedralOQ01.lean` (lines 66 and 656 are `inductive ...`); `annotations.json` validates as JSON; `scripts/annotations/build.ts` now reports **no remaining errors** for this entry (previously 2).

> Pushed on `feature/enricher-1-euler-polyhedral-oq-01` to avoid disturbing earlier still-open enricher PRs on `feature/enricher-1`.