### PR TITLE
Fix: derangements native_decide → axiomatized

### DIFF
--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -7,7 +7,7 @@
     "author": "Montmort, Euler (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement",
     "date": "1708",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "probability",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/Derangements.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 88,
     "mathlib_version": "4.26.0",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 227,
     "relatedProblems": [
       {
@@ -61,7 +61,7 @@
         "relationship": "Extension of derangements"
       }
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Depends on `Lean.ofReduceBool`: the concrete computations D(2)-D(6) (an advertised original contribution) are discharged solely by `native_decide`, which trusts the Lean compiler's kernel reduction. No literal `axiom` declarations and 0 sorries; the named theorems (recurrence wrapper, not-a-subgroup proof) are symbolic and axiom-free, but the entry as presented relies on `Lean.ofReduceBool` for its computed examples.",
     "theoremCount": 10,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

Re-class `derangements` (Wiedijk #88) from `verified`/`mathlib`/0-axioms to `axiomatized`/`axiom`/1-axiom because an advertised original contribution is discharged solely by `native_decide`, which trusts the Lean compiler's kernel reduction and depends on the `Lean.ofReduceBool` axiom.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `meta.axiomCount: 0`; assumptions claimed "None. Fully verified with 0 axioms and 0 sorries."

**After**: `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1`; assumptions discloses `Lean.ofReduceBool`. `leanFile.axiomCount` stays `0` (no literal `axiom` declarations).

The originalContribution **"Concrete computations D(2)-D(6) via native_decide"** is delivered solely by `native_decide` in `Proofs/Derangements.lean`:
- `example : numDerangements 2 = 1 := by native_decide` (L131)
- `example : numDerangements 3 = 2 := by native_decide` (L134)
- `example : numDerangements 4 = 9 := by native_decide` (L137)
- `example : numDerangements 5 = 44 := by native_decide` (L140)
- `example : numDerangements 6 = 265 := by native_decide` (L143)

These computed values are an explicitly advertised contribution with no symbolic alternative. The headline named theorems (`derangements_recurrence`, a Mathlib wrapper; `derangement_mul_self_not_always_derangement`, a symbolic `fin_cases` proof) remain `native_decide`-free and axiom-free, but the entry as presented relies on `Lean.ofReduceBool` for its computed examples. Per the project Axiom Integrity Policy, `native_decide` on a result the entry presents as verified must be counted.

---
Automated fix by lean-mechanic agent.