### PR TITLE
Enrich Inverse Galois A5: fix annotation types vs Lean constructs

### DIFF
--- a/src/data/proofs/inverse-galois-a5/annotations.json
+++ b/src/data/proofs/inverse-galois-a5/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "inverse-galois-a5-vandermonde",
     "proofId": "inverse-galois-a5",
-    "type": "theorem",
+    "type": "definition",
     "range": {
       "startLine": 1097,
       "endLine": 1650
@@ -74,7 +74,7 @@
   {
     "id": "inverse-galois-a5-axiom",
     "proofId": "inverse-galois-a5",
-    "type": "definition",
+    "type": "axiom",
     "range": {
       "startLine": 309,
       "endLine": 327


### PR DESCRIPTION
## Enrichment pass for `inverse-galois-a5`

Fixed two annotation type mismatches flagged by the annotation resolver:

- `inverse-galois-a5-axiom` (L309) — titled "Axiom: three_dvd_gal_card", anchors `axiom three_dvd_gal_card`; was typed `"definition"` → corrected to `"axiom"`.
- `inverse-galois-a5-vandermonde` (L1097) — anchors `noncomputable def vandermondeProduct`; was typed `"theorem"` → corrected to `"definition"`.

**Verification:** checked `proofs/Proofs/InverseGaloisA5.lean` (L309 is `axiom …`, L1097 is `noncomputable def …`); `annotations.json` validates as JSON; `scripts/annotations/build.ts` now reports **no remaining errors** for this entry (previously 2).

> Pushed on `feature/enricher-1-inverse-galois-a5` to avoid disturbing earlier still-open enricher PRs on `feature/enricher-1`.