### PR TITLE
audit(bezout-identity-oq-01-oq-01): clean re-audit (verified/mathlib justified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14201,13 +14201,13 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, 4 axioms, all metadata consistent. Empty issues array was auditor artifact."
     },
     "bezout-identity-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [
         "section-overlap-properties-bezout",
         "oq-id-prefix-mismatch"
       ],
-      "lastAudited": "2026-05-03T22:42:46Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-06-18T13:02:37Z",
+      "result": "clean",
       "notes": "Issues fixed in PR #15376 (merged 2026-05-03T23:13:29Z). Section properties endLine corrected, OQ IDs updated to correct bezout-identity-oq-01-oq-01 prefix.",
       "lastFixed": "2026-05-04T00:00:00Z"
     },


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: bezout-identity-oq-01-oq-01 — Stein's Binary GCD Algorithm
**Result**: CLEAN (no meta changes; tracker auditCount 1→2)

### Verification
| Field | meta.json | Lean source | OK |
|---|---|---|---|
| lineCount | 188 | 188 | ✓ |
| theoremCount | 14 | 8 priv lemmas + 6 theorems | ✓ |
| definitionCount | 1 | binaryGcd | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 structure assumptions | ✓ |
| status/badge | verified / mathlib | justified (Tier B) | ✓ |

### native_decide assessment
File contains 5 `native_decide`, all in **standalone anonymous `example` blocks** (L182-186) verifying concrete numeric instances (`binaryGcd 12 8 = 4`, etc.). They are:
- NOT listed among the 6 `originalContributions` (all symbolic)
- NOT referenced by any named theorem

The substantive deliverables — `binaryGcd_eq_gcd` (correctness via well-founded induction on a+b), `binaryGcd_comm/_dvd_left/_dvd_right`, `dvd_binaryGcd`, `bezout_via_binaryGcd` — do not invoke `native_decide`, so `Lean.ofReduceBool` does not enter the deliverable theorems. Per the axiom-integrity policy this is the incidental-example case (matches sibling `bezout-identity-oq-01`, vetted-leave) → `verified` stands.

### badge
`mathlib` (Tier B) is correct: the algorithm correctness is proved independently via well-founded induction, but the entry uses Mathlib gcd lemmas and delegates the Bézout corollary to `Int.gcdA/gcdB`.

### Prior issues
`section-overlap-properties-bezout` and `oq-id-prefix-mismatch` were fixed in merged #15376 — confirmed no recurrence.

---
Discovered during gallery integrity audit.