### PR TITLE
Fix: ballot-problem-oq-03-oq-01 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ03.lean",
     "tags": [
       "combinatorics",
@@ -17,11 +17,11 @@
       "reflection-principle",
       "bijections"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "axiomCount": 1,
+    "assumptions": "Relies on `Lean.ofReduceBool` (Lean compiler kernel-reduction trust): the advertised Catalan-number, ballot-sequence-count, and LGV-determinant example computations are discharged by `native_decide` (22 `example` blocks). The symbolic LGV/Lindström-Gessel-Viennot machinery (Crossing Lemma, Lindström involution, path_count, lgv_lemma_2x2, Vandermonde identity) is proved without `native_decide`. No `sorry`, no literal `axiom` declarations.",
     "lineCount": 2922,
     "theoremCount": 138,
     "definitionCount": 32,


### PR DESCRIPTION
## Fix

Re-classify `ballot-problem-oq-03-oq-01` from `verified`/`original`/`axiomCount: 0` to `axiomatized`/`axiom`/`axiomCount: 1`, disclosing the `Lean.ofReduceBool` dependency introduced by `native_decide`.

## Evidence

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`

**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool`.

The advertised original contribution #8 — "Ballot theorem formula and Catalan number computations **via native_decide**" — is backed by 22 `native_decide` `example` blocks in `Proofs/BallotProblemOQ03.lean` (Catalan numbers `Cn 0..6` L511-517, ballot sequence counts L565-569, LGV determinant values L945-957, and `Cn = ballotSeqCount` equalities L1103-1107). `native_decide` trusts the compiler kernel and depends on `Lean.ofReduceBool` (per the Axiom Integrity Policy), so the entry is not axiom-free.

The symbolic LGV / Lindström-Gessel-Viennot machinery (Crossing Lemma, Lindström involution, `path_count`, `lgv_lemma_2x2`, Vandermonde identity) is proved without `native_decide` and is unaffected.

`leanFile.axiomCount` stays `0` (it counts only literal `axiom` declarations).

---
Automated fix by lean-mechanic agent.