### PR TITLE
Fix off-schema annotation type "inductive" in euler-polyhedral-oq-01

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ep-spanning-build",
     "proofId": "euler-polyhedral-oq-01",
-    "type": "inductive",
+    "type": "definition",
     "range": {
       "startLine": 66,
       "endLine": 111
@@ -194,7 +194,7 @@
   {
     "id": "ep-degeneracy-build",
     "proofId": "euler-polyhedral-oq-01",
-    "type": "inductive",
+    "type": "definition",
     "range": {
       "startLine": 656,
       "endLine": 693


### PR DESCRIPTION
Two annotations in **euler-polyhedral-oq-01** used `"type": "inductive"`, which is **not** a valid `AnnotationType`. The valid values (`src/types/proof.ts:460`) are: `theorem`, `lemma`, `definition`, `tactic`, `concept`, `insight`, `warning`.

## Fix

Both annotations document Lean `inductive` *type definitions* — `SpanningBuild` (the spanning-tree Euler-formula construction) and `DegeneracyBuild` (the degeneracy-order greedy-coloring construction) — so the correct enum value is `definition`. Content, ranges, and all other fields are unchanged.

- `ep-spanning-build`: `inductive` → `definition`
- `ep-degeneracy-build`: `inductive` → `definition`

## Verification

- `jq empty` validates annotations.json.
- A gallery-wide scan (`jq -r '.[].type' src/data/proofs/*/annotations.json | sort -u`) confirms these were the **only 2** off-schema annotation types across all 2537 entries; after the fix, **zero** invalid types remain.
- `pnpm build` not run: node_modules is absent in the enricher worktree; validation via jq + the canonical enum in `src/types/proof.ts`.