### PR TITLE
Enrich: fix 32 annotation type mismatches across 28 entries

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-09/annotations.json
@@ -29,7 +29,7 @@
       "startLine": 79,
       "endLine": 88
     },
-    "type": "definition",
+    "type": "concept",
     "title": "DiffField Typeclass",
     "content": "A **differential field** is a field F equipped with a derivation D : F → F satisfying:\n1. **Additivity**: D(f + g) = D(f) + D(g)\n2. **Leibniz rule**: D(f·g) = D(f)·g + f·D(g)\n\nThis abstracts the familiar derivative on ℝ(x). In Lean 4, this is encoded as a typeclass extending `Field F`, with `deriv` as the derivation. The constants of F are {f : D(f) = 0} — this forms a subfield (proved in `constants_add`, `constants_mul`).\n\n**Why this structure?** Liouville's theorem characterizes when f ∈ F has an elementary antiderivative in terms of the differential field structure. The theorem holds for arbitrary differential fields, not just ℝ(x).",
     "mathContext": "A derivation $D$ on a ring satisfies $D(f+g) = D(f) + D(g)$ and $D(fg) = D(f)g + fD(g)$. The constants $C = \\ker D$ form a subfield of $F$.",

--- a/src/data/proofs/amgm-inequality-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04/annotations.json
@@ -131,7 +131,7 @@
       "startLine": 248,
       "endLine": 273
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "agm: The AGM as the Infimum of the a-Sequence",
     "content": "agm a b = \u2a05 n, agmA a b n defines the AGM as the infimum (greatest lower bound) of the decreasing a-sequence. Since agm_common_limit proves this infimum equals the supremum of the b-sequence, either choice would work; the infimum is used because the a-sequence is the more natural 'envelope.' agm_eq_limit_A and agm_eq_limit_B confirm the AGM is indeed the limit of both sequences. agm_bounds proves b \u2264 agm a b \u2264 a: the lower bound uses b = b\u2080 \u2264 b\u2081 \u2264 ... \u2264 a\u2099, so b is a lower bound for the a\u2099 (via ciInf_le); the upper bound uses agm \u2264 a\u2080 = a (also via ciInf_le).",
     "mathContext": "$M(a,b) = \\inf_n a_n = \\lim_{n\\to\\infty} a_n = \\lim_{n\\to\\infty} b_n$, with $b \\leq M(a,b) \\leq a$.",

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/annotations.json
@@ -75,7 +75,7 @@
   {
     "id": "cf-orbit-same-dyck",
     "proofId": "ballot-problem-oq-01-oq-04-oq-01",
-    "type": "theorem",
+    "type": "lemma",
     "range": {
       "startLine": 388,
       "endLine": 456

--- a/src/data/proofs/bertrands-postulate-oq-03/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/annotations.json
@@ -153,7 +153,7 @@
       "startLine": 232,
       "endLine": 308
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "PrimeGapConjecture: Formal Definition, Monotonicity, and Summary",
     "content": "`PrimeGapConjecture θ` is defined as: for all x ≥ 2, there exists a prime p with x ≤ p ≤ x + x^θ. Three results follow: `prime_gap_conjecture_bhp` proves PrimeGapConjecture 0.525 from the BHP axiom. `prime_gap_conjecture_monotone` proves that if PrimeGapConjecture θ₁ holds and θ₂ ≥ θ₁, then PrimeGapConjecture θ₂ holds — using `Real.rpow_le_rpow_of_exponent_le`. `density_question_status` proves three simultaneous goals: BHP (θ=0.525), Bertrand (θ=1), and existence of θ < 1 with PrimeGapConjecture. The Bertrand proof applies PrimeGapBounds.bertrand_postulate to ⌊x⌋₊, then uses floor bounds to convert between real and natural number arithmetic. `prime_density_summary` gives a clean four-way conjunction of the main proved results.",
     "mathContext": "$\\text{PrimeGapConjecture}(\\theta) \\iff \\forall x \\geq 2, \\exists p \\text{ prime}, x \\leq p \\leq x + x^\\theta$. The infimum $\\theta^* = \\inf\\{\\theta : \\text{PrimeGapConjecture}(\\theta)\\}$ satisfies $\\theta^* \\leq 0.525$ (BHP) and is conjectured to equal 0.",

--- a/src/data/proofs/bezout-identity-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/annotations.json
@@ -56,7 +56,7 @@
       "startLine": 78,
       "endLine": 109
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Smith Normal Form Structure: Invariant Factors and Decomposition",
     "content": "The `SmithNormalForm m n` structure encodes all components of the SNF decomposition: unimodular `U : Matrix (Fin m) (Fin m) ℤ`, diagonal `D : Matrix (Fin m) (Fin n) ℤ`, and unimodular `V : Matrix (Fin n) (Fin n) ℤ`. The `hD_diag` field enforces diagonality: all off-diagonal entries are zero. The `hD_div` field encodes the **invariant factor divisibility chain**: $d_k \\mid d_{k+1}$ for consecutive diagonal entries, requiring five separate bounds proofs to correctly handle the finite type indexing. `isDecompOf A` simply states $A = U \\cdot D \\cdot V$.",
     "mathContext": "The invariant factors $d_1 \\mid d_2 \\mid \\cdots \\mid d_k$ are uniquely determined by $A$ (up to sign): $d_i = \\gcd_{i \\times i \\text{ minors}}(A) / \\gcd_{(i-1) \\times (i-1) \\text{ minors}}(A)$. This uniqueness is what makes SNF a complete invariant for equivalence of integer matrices under unimodular row/column operations. The divisibility chain is NOT present in general diagonal decompositions — it is the distinguishing feature of Smith Normal Form.",

--- a/src/data/proofs/birch-swinnerton-dyer/annotations.json
+++ b/src/data/proofs/birch-swinnerton-dyer/annotations.json
@@ -401,7 +401,7 @@
       "startLine": 2857,
       "endLine": 2958
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Iwasawa Theory for Elliptic Curves",
     "content": "**Iwasawa theory** provides a completely independent approach to BSD through p-adic analysis. The Selmer group over the cyclotomic $\\mathbb{Z}_p$-extension is a module over the Iwasawa algebra $\\Lambda = \\mathbb{Z}_p\\llbracket T \\rrbracket$, described by $\\mu$ and $\\lambda$ invariants. The **Iwasawa Main Conjecture** (Kato 2004 + Skinner-Urban 2014) equates the characteristic ideal of the dual Selmer group with the p-adic L-function: $\\text{char}_\\Lambda(X^\\vee) = (L_p(E))$.\n\nThis recovers BSD for rank 0 and 1 via an entirely different method, and additionally controls the p-part of $|\\text{III}|$.",
     "mathContext": "$$\\text{char}_\\Lambda(X(E/\\mathbb{Q}_\\infty)^\\vee) = (L_p(E)) \\quad \\text{as ideals of } \\Lambda$$\n$\\mu = 0$ conjecture (known in many cases). $\\lambda \\geq \\text{rank}(E(\\mathbb{Q}))$. The `IwasawaMainConjecture` structure combines both Kato's and Skinner-Urban's divisibilities.",

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-01/annotations.json
@@ -71,7 +71,7 @@
   {
     "id": "brouwer-oq02-oq01-strip-parity",
     "proofId": "brouwer-fixed-point-oq-02-oq-01",
-    "type": "theorem",
+    "type": "lemma",
     "range": {
       "startLine": 564,
       "endLine": 636

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -77,7 +77,7 @@
       "startLine": 83,
       "endLine": 90
     },
-    "type": "theorem",
+    "type": "definition",
     "title": "permitted_satisfies_konig: Cofinality Constraint Free of Charge",
     "content": "The theorem `permitted_satisfies_konig` shows the König constraint cf(κ) > ℵ₀ falls out of the two-clause definition. The proof is two lines: rewrite cf(κ) = κ via `IsRegular.cof_eq` (regularity), then the second clause ℵ₀ < κ is the goal. This is the structural justification for the minimal definition: it correctly sits underneath the König constraint without redundancy. The lemma is itself a useful interface theorem for downstream proofs that need cf-bounds rather than regularity directly.",
     "mathContext": "$\\mathsf{IsPermittedValue}(\\kappa) \\Rightarrow \\mathrm{cf}(\\kappa) > \\aleph_0$. Proof: $\\mathrm{cf}(\\kappa) = \\kappa$ since $\\kappa$ is regular, and $\\kappa > \\aleph_0$ by hypothesis.",
@@ -171,7 +171,7 @@
       "startLine": 140,
       "endLine": 159
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "IsEastonFunction: Three Constraints in a Lean Structure",
     "content": "The structure `IsEastonFunction F` packages the three Easton constraints as fields: `succ_le` (F(κ) ≥ κ⁺, the Cantor-style strict bound), `monotone` (κ ≤ ν ⇒ F(κ) ≤ F(ν), monotonicity restricted to regular infinite cardinals), and `konig_pointwise` (κ < cf(F κ), the König constraint). All three are quantified over regular κ ≥ ℵ₀ — exactly the domain on which Easton's theorem governs the continuum function. Using a `structure` rather than a Π-type bundle gives named fields and dot-notation access (`hF.succ_le`, `hF.monotone`), which the downstream witness theorem exploits.",
     "mathContext": "$\\mathsf{IsEastonFunction}(F) \\iff $ for all regular $\\kappa, \\nu \\geq \\aleph_0$: (E1) $F(\\kappa) \\geq \\kappa^+$, (E2) $\\kappa \\leq \\nu \\Rightarrow F(\\kappa) \\leq F(\\nu)$, (E3) $\\mathrm{cf}(F(\\kappa)) > \\kappa$. Easton 1970: these conditions are exactly the necessary AND sufficient constraints for $F$ to be realizable as $\\kappa \\mapsto 2^\\kappa$ on regular cardinals in some forcing extension.",
@@ -195,7 +195,7 @@
       "startLine": 168,
       "endLine": 191
     },
-    "type": "theorem",
+    "type": "definition",
     "title": "isEastonFunction_continuum: 2^· is the Canonical Witness",
     "content": "The actual continuum function κ ↦ 2^κ satisfies all three Easton constraints axiom-free, so the constraint set is non-vacuous. `succ_le` is `Order.succ_le_of_lt (Cardinal.cantor κ)` — Cantor's strict inequality 2^κ > κ becomes succ(κ) ≤ 2^κ. `konig_pointwise` is `Cardinal.lt_cof_power` applied with base 2 — directly König's theorem cf(2^κ) > κ. The `monotone` field is `Cardinal.power_le_power_left` (note the Mathlib naming convention: `power_le_power_left` varies the EXPONENT, while `power_le_power_right` varies the BASE — the opposite of what the names suggest), with the base-nonzero side condition `(2 : Cardinal) ≠ 0` discharged by `norm_num`. The witness theorem is structurally important: it confirms the constraint set is the right one (forced by the actual continuum function), making the realizability axioms in Phase3b non-vacuous. Companion theorem `isEastonFunction_nonempty` packages this as ∃ F, IsEastonFunction F.",
     "mathContext": "Witness: $F(\\kappa) = 2^\\kappa$. Cantor: $\\kappa < 2^\\kappa \\Rightarrow \\mathrm{succ}(\\kappa) \\leq 2^\\kappa$. König: $\\mathrm{cf}(2^\\kappa) > \\kappa$. Monotonicity: $\\kappa \\leq \\nu \\Rightarrow 2^\\kappa \\leq 2^\\nu$ via `power_le_power_left`. All three constraints discharged from Mathlib without forcing infrastructure.",

--- a/src/data/proofs/central-limit-theorem-oq-03/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/annotations.json
@@ -163,7 +163,7 @@
       "startLine": 229,
       "endLine": 241
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Domain of Attraction",
     "content": "**InDomainOfAttraction** and related theorems\n\nA distribution $\\mu$ is in the domain of attraction of the Gaussian if its normalized convolution powers converge to $N(0,1)$. Three key results:\n\n1. **clt_domain_of_attraction:** Every distribution with positive variance is in the DOA\n2. **gaussian_in_own_domain:** The Gaussian is trivially in its own DOA\n3. **doa_closed_under_convolution:** If $\\mu, \\nu$ are in the DOA, so is $\\mu * \\nu$\n\nThe DOA is thus a convolution-closed subset: a sub-monoid of ProbMeasure.",
     "mathContext": "$\\text{DOA}(N(0,1)) = \\{\\mu : \\text{normalizedConvPow}(\\mu, n) \\to N(0,1)\\}$ is closed under $*$",

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/annotations.json
@@ -74,7 +74,7 @@
   {
     "id": "cb04oq01-base-values",
     "proofId": "chebyshev-bounds-oq-04-oq-01",
-    "type": "theorem",
+    "type": "definition",
     "range": {
       "startLine": 109,
       "endLine": 148

--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -75,7 +75,7 @@
     "id": "ann-qdetf-eq-qdet00",
     "proofId": "cramers-rule-oq-01-oq-02-oq-01-oq-01",
     "range": { "startLine": 153, "endLine": 168 },
-    "type": "theorem",
+    "type": "lemma",
     "title": "n=2 (0,0)-specialization via mul_right_cancel₀",
     "content": "Bridges `qdetF A 0 0` (the uniform commutative form) to the parent's 2×2 (0,0)-quasideterminant `qdet00 A = A 0 0 - A 0 1 * (A 1 1)⁻¹ * A 1 0`. The strategy is multiplicative cancellation: under `A 1 1 ≠ 0`, *both* sides multiply against `A 1 1` to give `A.det` — `qdetF` via `qdetF_field_quotient` (using `minorIJ_22_00_det` to identify the minor as `A 1 1`), and `qdet00` via the parent's `qdet00_mul_eq_det`. Two quantities with the same product against a nonzero `A 1 1` must be equal, so `mul_right_cancel₀` closes the goal. No further non-degeneracy is needed beyond the standard `A 1 1 ≠ 0` already carried in the parent's API.",
     "mathContext": "For a 2×2 matrix $A$ with $A_{11} \\neq 0$: $|A|_{00}^{(F)} = \\dfrac{\\det A}{A_{11}}$ and $|A|_{00}^{(\\text{Schur})} = A_{00} - A_{01} A_{11}^{-1} A_{10}$. Both satisfy $|A|_{00} \\cdot A_{11} = \\det A$, so they coincide. The Schur form is the non-commutative-friendly version; the quotient form is the commutative one.",

--- a/src/data/proofs/denumerability-rationals-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-02-oq-02/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 56,
       "endLine": 68
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "ℝ Is a Complete Ordered Field",
     "content": "The three instance declarations confirm that ℝ satisfies ConditionallyCompleteLinearOrderedField — the Mathlib typeclass encoding 'complete ordered field'. The real_archimedean theorem (inferInstance) and real_lub theorem (isLUB_csSup) make the two most important properties explicit: ℕ is cofinal in ℝ, and nonempty bounded-above sets have suprema.",
     "mathContext": "A ConditionallyCompleteLinearOrderedField is a field with a linear order satisfying: (1) order compatibility with field operations, (2) conditional completeness — every nonempty bounded-above set has a supremum. For ℝ, this is the least-upper-bound property (Dedekind completeness).",

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/annotations.json
@@ -145,7 +145,7 @@
       "startLine": 173,
       "endLine": 195
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Root Count in Half-Open Intervals",
     "content": "`rootsInInterval p a b` counts roots of $p$ in $(a, b]$ with multiplicity, using Mathlib's `Polynomial.roots` multiset. For $p = 0$, it returns 0 (convention). For $p \\neq 0$, it filters `p.roots` to elements in $(a, b]$ and takes the cardinality.\n\nThe `rootsInInterval_C` theorem proves constants have no roots: if $c \\neq 0$, then `C c` has no roots (since `eval c = c \u2260 0`), so the filtered multiset is empty. The proof uses `Multiset.filter_eq_nil` and `Polynomial.IsRoot` to derive a contradiction from any supposed root.",
     "mathContext": "For $p \\neq 0$ of degree $n$, $p$ has at most $n$ roots in $\\mathbb{C}$ (counted with multiplicity), hence at most $n$ real roots. `rootsInInterval p a b = |\\{r \\in \\text{roots}(p) : a < r \\leq b\\}|$ where roots are counted with multiplicity. The half-open convention $(a, b]$ avoids double-counting when splitting intervals.",

--- a/src/data/proofs/ehrhart-cube-proven-oq-03/annotations.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/annotations.json
@@ -51,7 +51,7 @@
     "id": "ann-k-one-target",
     "proofId": "ehrhart-cube-proven-oq-03",
     "range": { "startLine": 66, "endLine": 78 },
-    "type": "theorem",
+    "type": "definition",
     "title": "S2 Target: `hypersimplex_count_k_one`",
     "content": "States `hypersimplexLatticeCount d 1 n = (n + d - 1).choose (d - 1)`. The `sorry` placeholder for the S2 iteration. Proof strategy: lattice points are weak compositions of $n$ into $d$ nonneg parts each $\\le n$ — but with $k = 1$ the upper bound $n$ is non-binding (a single coordinate carries the whole sum unless distributed), so this collapses to the unrestricted multiset bijection $\\mathrm{Sym}\\,(\\mathrm{Fin}\\,d)\\,n$ used in `EhrhartSimplexProven.simplex_lattice_count` (giving $\\binom{n + d - 1}{d - 1}$). The hypothesis `1 ≤ d` is required because `d - 1` is `Nat`-subtraction: without it, $d = 0$ would make the RHS `(n - 1).choose 0 = 1` while the LHS is $0$ (no lattice point in $\\Delta(0, 1)$, which is empty).",
     "mathContext": "$L(\\Delta(d, 1), n) = \\binom{n + d - 1}{d - 1}$ — same as the count for a $(d - 1)$-simplex scaled by $n$. Equivalently the number of weak compositions of $n$ into exactly $d$ parts, which is the classical stars-and-bars formula $\\binom{n + d - 1}{d - 1}$.",

--- a/src/data/proofs/ehrhart-cube-proven-oq-04/annotations.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/annotations.json
@@ -75,7 +75,7 @@
     "id": "ann-hstar-def",
     "proofId": "ehrhart-cube-proven-oq-04",
     "range": { "startLine": 225, "endLine": 250 },
-    "type": "definition",
+    "type": "theorem",
     "title": "Cube h*-Polynomial: cubeHStarPoly d : Polynomial ℕ",
     "content": "Defines `cubeHStarPoly d : Polynomial ℕ` as the Eulerian generating polynomial $A_d(t) = \\sum_{k=0}^{d-1} A(d, k) t^k$ (with the convention $A_0(t) = 1$ for the degenerate 0-cube). The Lean implementation uses `Finset.sum` over `Finset.range d`, with each term `eulerianNumber d k • X^k` (scalar-multiplication of the indeterminate power by the corresponding Eulerian number, lifted from ℕ). The theorem `cube_h_star_eulerian` asserts the coefficient extraction `(cubeHStarPoly d).coeff k = eulerianNumber d k` for k < d — automatic by the construction, but stated for documentation. The *substantive* content (deferred) is connecting `cubeHStarPoly` to the Ehrhart polynomial via Worpitzky.",
     "mathContext": "$\\text{cubeHStarPoly}(d) = \\sum_{k=0}^{d-1} A(d, k) X^k \\in \\mathbb{N}[X]$. Coefficient: $[X^k] \\text{cubeHStarPoly}(d) = A(d, k)$ for $0 \\leq k < d$.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/annotations.json
@@ -39,7 +39,7 @@
     "id": "ann-classical-gauss-sum",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
     "range": { "startLine": 90, "endLine": 97 },
-    "type": "definition",
+    "type": "theorem",
     "title": "Assembling the Classical Gauss Sum",
     "content": "`classicalGaussSum` assembles the two ingredients: the **multiplicative character** `quadCharC` (Legendre symbol in ℂ) and the **additive character** `ZMod.stdAddChar` (which maps a ↦ exp(2πia/p)). Mathlib's bilinear `gaussSum` combines them as Σ_{a} χ(a)·ψ(a).\n\nThe key fact consumed in the main theorem is `ZMod.isPrimitive_stdAddChar`: the standard additive character of ZMod p is **primitive** — it does not factor through any proper subgroup. This is a non-trivial result from the theory of exponential sums; it is what prevents the Gauss sum from vanishing due to character orthogonality, and it is a required hypothesis of `gaussSum_sq`.",
     "mathContext": "$\\tau_p = \\text{classicalGaussSum}(p) = \\sum_{a \\in \\mathbb{Z}/p\\mathbb{Z}} \\left(\\frac{a}{p}\\right) e^{2\\pi i a/p} \\in \\mathbb{C}$",

--- a/src/data/proofs/erdos-1001/annotations.json
+++ b/src/data/proofs/erdos-1001/annotations.json
@@ -178,7 +178,7 @@
       "startLine": 82,
       "endLine": 84
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Limit Exists",
     "content": "**limitExists(A, c):**\n\nThe central question: does lim_{N→∞} S(N, A, c) exist?\n\nThis is formalized using filter convergence:\n\n```lean\ndef limitExists (A c : ℝ) : Prop :=\n  ∃ L : ℝ, Tendsto (fun N => S N A c) atTop (nhds L)\n```",
     "significance": "key",

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/annotations.json
@@ -216,7 +216,7 @@
       "startLine": 148,
       "endLine": 150
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Distance to Nearest Integer",
     "content": "Defines ‖x‖ = min({x}, 1-{x}), the distance from x to the nearest integer. This is the standard notation in Diophantine approximation, measuring how well x can be approximated by integers.",
     "mathContext": "$\\|x\\| = \\min(\\{x\\}, 1 - \\{x\\}) = \\inf_{n \\in \\mathbb{Z}} |x - n|$. For $x = q\\alpha$, $\\|q\\alpha\\|$ measures the quality of rational approximation $p/q \\approx \\alpha$.",
@@ -238,7 +238,7 @@
       "startLine": 152,
       "endLine": 155
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Badly Approximable Numbers",
     "content": "Defines HasBoundedPartialQuotients: α satisfies ‖qα‖ ≥ C/q for all q ≥ 1 and some C > 0. Equivalently, the continued fraction expansion [a₀; a₁, a₂, ...] has bounded partial quotients (sup aₙ < ∞). This class includes all quadratic irrationals (√2, φ) by Lagrange's theorem, but excludes Liouville numbers which are extremely well approximable.",
     "mathContext": "$\\alpha$ is badly approximable if $\\exists C > 0: \\|q\\alpha\\| \\geq C/q$ for all $q \\geq 1$. By Hurwitz's theorem, $C \\leq 1/\\sqrt{5}$. The set of badly approximable numbers has full Hausdorff dimension 1 but Lebesgue measure zero.",

--- a/src/data/proofs/erdos-1009-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1009-oq-01/annotations.json
@@ -49,7 +49,7 @@
     "id": "optimal-bound-sinf",
     "proofId": "erdos-1009-oq-01",
     "range": { "startLine": 84, "endLine": 121 },
-    "type": "definition",
+    "type": "theorem",
     "title": "optimalBound as sInf: The Infimum of Valid Constants",
     "content": "optimalBound is defined as sInf {C : ℝ | ValidBound C} — the real infimum (greatest lower bound) of the set of all valid bound constants. This is noncomputable since sInf on ℝ uses classical logic.\n\nFour properties are proved:\n1. validBounds_bddBelow: the set is bounded below by 0 (from ValidBound.nonneg)\n2. optimalBound_le: for any valid C, optimalBound ≤ C (by csInf_le)\n3. optimalBound_nonneg: optimalBound ≥ 0 (by le_csInf with the valid set nonempty + each member ≥ 0)\n4. lt_optimalBound_not_valid: C < optimalBound → ¬ValidBound C (contrapositive of optimalBound_le)\n\nThe proof of optimalBound_nonneg uses `le_csInf` from Mathlib, which requires: (a) the set is nonempty (from validBound_exists), and (b) every member is ≥ 0 (from ValidBound.nonneg).",
     "mathContext": "In analysis: $C^* = \\inf\\{C : \\forall c > 0, f(c) \\leq Cc^2\\} = \\sup_{c>0} \\frac{f(c)}{c^2}$. The second equality holds by duality of inf/sup for linear constraints. In Lean: `sInf` on ℝ requires `BddBelow` (≥ 0 suffices) and `Nonempty` (from Györi's theorem). `csInf_le` gives the upper bound property; `le_csInf` gives the lower bound property.",

--- a/src/data/proofs/erdos-1012-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-03/annotations.json
@@ -202,7 +202,7 @@
       "startLine": 946,
       "endLine": 1030
     },
-    "type": "definition",
+    "type": "lemma",
     "title": "Directed Cycle Infrastructure: IsDirectedCycleList and sc_tournament_has_cycle",
     "content": "`IsDirectedCycleList D l` defines a directed cycle as a `Nodup` list with $\\text{length} \\geq 2$ and modular arc condition: `arc(l[i], l[(i+1) % k])` for all $i < k$. The modular index handles the wrap-around arc $l[k-1] \\to l[0]$. `nodup_length_le_card` is a simple cardinality lemma used throughout. `sc_tournament_has_cycle` (marked `sorry` in the status checklist) extracts an initial directed cycle from a strongly connected tournament on $\\geq 3$ vertices: use the Hamiltonian path `hl`, take the SC walk from `hl[n-1]` back to `hl[0]`, find the first step `w₁ = walk[1]` in `hl` at position `j < n-1`, and return `hl.drop j` as a directed cycle of length $n-j \\geq 2$.",
     "mathContext": "The strategy for `sc_tournament_has_cycle` is: Hamiltonian path $p_0 \\to \\cdots \\to p_{n-1}$ + SC walk from $p_{n-1}$ back to $p_0$ gives a closed walk. The first internal step $p_{n-1} \\to w_1$ where $w_1 = p_j$ for $j < n-1$ (since $w_1 \\neq p_{n-1}$ by looplessness) gives the cycle $p_j \\to p_{j+1} \\to \\cdots \\to p_{n-1} \\to p_j$ — equivalently `hl.drop j`. This is a clean existence argument: the Hamiltonian path provides global structure, SC provides the closing arc.",

--- a/src/data/proofs/erdos-1014/annotations.json
+++ b/src/data/proofs/erdos-1014/annotations.json
@@ -28,7 +28,7 @@
       "startLine": 27,
       "endLine": 29
     },
-    "type": "definition",
+    "type": "axiom",
     "title": "Ramsey Number R(k,l)",
     "content": "The Ramsey number R(k,l) is the minimum n such that every 2-coloring of K_n's edges contains a red K_k or blue K_l. Axiomatized here since a constructive definition would require significant graph-theoretic machinery including Ramsey's theorem and the well-ordering of ℕ.",
     "significance": "key",

--- a/src/data/proofs/erdos-1019/annotations.json
+++ b/src/data/proofs/erdos-1019/annotations.json
@@ -182,7 +182,7 @@
       "startLine": 154,
       "endLine": 178
     },
-    "type": "definition",
+    "type": "concept",
     "title": "Cycle Plus Two Apex Vertices: $C_\\ell + 2K_1$",
     "content": "`containsCyclePlus2K1 G l` checks for a cycle $C_\\ell$ ($\\ell \\ge 3$) with two additional 'apex' vertices, each adjacent to every vertex of the cycle. This graph has $\\ell + 2$ vertices and $\\ell + 2\\ell = 3\\ell$ edges (cycle edges + apex-to-cycle edges). Since $3\\ell = 3(\\ell + 2) - 6$, it is saturated planar. It can be visualized as a 'wheel with two hubs'—two cones over a polygon sharing the same base.",
     "mathContext": "$C_\\ell + 2K_1$: $|V| = \\ell + 2$, $|E| = 3\\ell = 3(\\ell + 2) - 6$; two apex vertices each adjacent to all $\\ell$ cycle vertices",
@@ -294,7 +294,7 @@
       "startLine": 252,
       "endLine": 266
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Complete Bipartite Graph and Turán Connection",
     "content": "Defines `completeBipartite m n` as the graph on `Fin m ⊕ Fin n` with edges between parts. For $m, n \\ge 3$, $K_{m,n}$ is planar iff $m \\le 2$ or $n \\le 2$ (Kuratowski). So large complete bipartite graphs are not planar, hence not saturated planar—connecting the construction to the planarity constraints.",
     "mathContext": "$K_{m,n}$ is planar $\\iff m \\le 2$ or $n \\le 2$ (Kuratowski's theorem)",

--- a/src/data/proofs/erdos-1026/annotations.json
+++ b/src/data/proofs/erdos-1026/annotations.json
@@ -178,7 +178,7 @@
       "startLine": 114,
       "endLine": 121
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Monotonic Decomposition",
     "content": "A **monotonic decomposition** partitions [1,n] into disjoint monotonic subsequences.\n\nThe structure tracks:\n- Number of parts (numParts)\n- Each part is a monotonic subsequence (Σ m, Subsequence n m)\n- Parts are disjoint (distinct indices across parts)\n- Parts cover all indices (every k : Fin n appears in some part)",
     "mathContext": "A partition $\\{S_1, \\ldots, S_p\\}$ of $\\{0, \\ldots, n-1\\}$ where each $S_i$ is a monotonic subsequence. The `parts` field uses a dependent sigma type `Σ m, Subsequence n m` to allow parts of varying lengths. Disjointness: $i \\neq j \\implies \\forall k_1\\, k_2,\\; \\sigma_i(k_1) \\neq \\sigma_j(k_2)$. Covering: $\\forall k \\in \\text{Fin}\\, n,\\; \\exists i\\, m\\, h_m,\\; \\sigma_i(\\langle m, h_m \\rangle) = k$.",

--- a/src/data/proofs/erdos-1027/annotations.json
+++ b/src/data/proofs/erdos-1027/annotations.json
@@ -69,7 +69,7 @@
   {
     "id": "ann-1027-propertyb",
     "proofId": "erdos-1027",
-    "type": "definition",
+    "type": "theorem",
     "title": "Property B and 2-Colorability",
     "content": "`HasPropertyB F` holds if at least one good set exists. `Is2Colorable F` requires a function $f: \\alpha \\to \\text{Bool}$ such that every $A \\in \\mathcal{F}$ has both true-colored and false-colored elements. `propertyB_implies_2colorable` and `coloring_implies_propertyB` prove the equivalence: a good set $B$ defines the coloring $f(x) = (x \\in B)$, and conversely $B = f^{-1}(\\text{true})$ is a good set. Both proofs are sorry-free.",
     "mathContext": "$\\text{HasPropertyB}(\\mathcal{F}) \\iff \\text{Is2Colorable}(\\mathcal{F})$: good sets correspond to proper 2-colorings",

--- a/src/data/proofs/erdos-1033/annotations.json
+++ b/src/data/proofs/erdos-1033/annotations.json
@@ -140,7 +140,7 @@
       "startLine": 119,
       "endLine": 130
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "The Erdős-Laskar Constant",
     "content": "**The constant $2(\\sqrt{3}-1) \\approx 1.464$** appears in the conjectured asymptotic value of $h(n)/n$. Erdős and Laskar (1985) showed this is an upper bound by constructing explicit graphs where all triangles have degree sum at most $2(\\sqrt{3}-1)n + o(n)$.",
     "mathContext": "The constant arises from optimizing the structure of near-bipartite graphs. The extremal construction involves a balanced bipartite graph plus a carefully chosen set of edges within one part, tuned so the constant $2(\\sqrt{3}-1)$ emerges from the optimization.",

--- a/src/data/proofs/erdos-1040/annotations.json
+++ b/src/data/proofs/erdos-1040/annotations.json
@@ -310,7 +310,7 @@
       "startLine": 111,
       "endLine": 114
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Line Segment Predicate",
     "content": "Defines when a set $F$ is a line segment in $\\mathbb{C}$, expressed as a closed interval $[a, b]$ with $a \\neq b$. Line segments are one of the special cases where Erdős, Herzog, and Piranian (1958) resolved the conjecture affirmatively.",
     "mathContext": "$F = [a, b] = \\{ta + (1-t)b : t \\in [0, 1]\\}$ for distinct $a, b \\in \\mathbb{C}$",

--- a/src/data/proofs/erdos-1043/annotations.json
+++ b/src/data/proofs/erdos-1043/annotations.json
@@ -72,7 +72,7 @@
       "startLine": 67,
       "endLine": 80
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Direction, projectOnto, projectSet, projectionMeasure",
     "content": "Defines projection onto lines: a **Direction** is a unit vector $u \\in \\mathbb{C}$ with $|u|=1$; the projection $\\pi_u(z) = \\operatorname{Re}(z \\cdot \\bar{u})$; and the **projection measure** $\\mu(\\pi_u(S))$ is the Lebesgue measure of the image.",
     "significance": "key",

--- a/src/data/proofs/erdos-1047/annotations.json
+++ b/src/data/proofs/erdos-1047/annotations.json
@@ -25,7 +25,7 @@
       "startLine": 60,
       "endLine": 62
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Strict Lemniscate",
     "content": "The **strict lemniscate** uses < instead of ≤:\n\n{z : |f(z)| < c}\n\nThis is the interior of the lemniscate. The distinction matters for topological properties like connectedness.",
     "significance": "supporting",


### PR DESCRIPTION
## Coordinated annotation type-mismatch cleanup

The annotation resolver (`scripts/annotations/resolver.ts`) flags annotations whose structural `type` disagrees with the Lean construct they anchor (`Annotation type "X" but found "Y" at line N`). This PR corrects **32 such mismatches across 28 gallery entries** in one pass, mirroring the earlier gallery-wide enum-migration precedent (#25676).

### Mapping (annotation `type` ← resolver's parsed construct kind)
| Found construct | New annotation type |
|---|---|
| `theorem` / `example` | `theorem` |
| `lemma` | `lemma` |
| `def` / `structure` | `definition` |
| `axiom` | `axiom` |
| `instance` / `class` | `concept` (no structural annotation type matches these; a semantic type is the resolver-valid, enum-consistent choice) |

### Scope & safety
- **Only the `type` field changed** — 32 lines across 28 `annotations.json` files (`32 insertions, 32 deletions`). All `range`, `content`, `mathContext`, and `significance` preserved.
- Each fix matches the resolver's own source parse (the `found` kind is parsed from the Lean file, not guessed).
- Spot-checked the non-`theorem` cases directly against the Lean sources: `abel-ruffini-oq-09` L79 `class DiffField`, `erdos-1014` L27 `axiom ramseyNumber`, `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01` L168 `structure IsEastonFunction`, `erdos-1019` L153–154 `instance completeGraph_decidable`, `denumerability-rationals-oq-02-oq-02` L56 `example … := inferInstance`.
- Every modified file validates as JSON.

> Note: the resolver's full error set is run-dependent (it only validates Lean files present/parseable in the worktree), so this addresses the 32 mismatches surfaced in this pass, not necessarily every mismatch gallery-wide.
>
> Pushed on `feature/enricher-1-annotation-type-fixes` to keep it separate from earlier still-open enricher PRs.