### PR TITLE
audit(erdos-1201): clean re-audit (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13985,8 +13985,8 @@
       "lastResult": "clean"
     },
     "erdos-1201": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-04T04:59:22Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-18T13:09:12Z",
       "result": "clean",
       "lastResult": "issues-fixed",
       "issues": [


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-1201 (Erdős #1201 — greatest prime factor of products of consecutive integers)

Re-audit of a stale tracker entry (auditCount 1, last audited 2026-05-04). meta.json matches `proofs/Proofs/Erdos1201Problem.lean` exactly:

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| axiomCount | 1 | 1 (`erdos_1201_half_case`) | ✓ |
| leanFile.axiomCount | 1 | 1 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ (no ofReduceBool) |
| True-stubs | — | 0 | ✓ |
| theoremCount | 116 | 116 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| lineCount | 1651 | 1651 | ✓ |
| status / badge | axiomatized / axiom | open conjecture + 1 disclosed axiom | ✓ |

The single axiom `erdos_1201_half_case` (the ε=1/2 partial result, proved by Erdős) is correctly disclosed in `assumptions`; the main conjecture `ErdosProblem1201` is a `def Prop` (not asserted). No `native_decide`, so no `Lean.ofReduceBool` exposure.

No meta change required. Tracker auditCount **1 → 2**, result `clean`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)