### PR TITLE
Fix: wilsons-theorem-oq-02 native_decide → axiomatized

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/WilsonsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "cyclic-groups",
       "involution-lemma"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "Relies on Lean.ofReduceBool. The advertised computational contributions — gaussWilson_verified_le_250/300 (Gauss-Wilson verified for all n ≤ 300) and no_wilson_primes_14_to_100 (no Wilson primes between 14 and 100), plus five_is_wilson_prime / thirteen_is_wilson_prime — are discharged by native_decide, which trusts compiler kernel reduction (Lean.ofReduceBool axiom). The abstract Gauss-Wilson machinery (selfInverse_units_eq_pair, prod_univ_sq_eq_one, prod_eq_prod_sq_eq_one, prod_units_neg_one_of_cyclic, prod_units_one_of_not_cyclic, gaussWilson_abstract) is fully symbolic and native_decide-free.",
     "lineCount": 426,
     "theoremCount": 21,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

The entry advertises substantive computational contributions that are discharged by `native_decide`, so it cannot be `verified`/`original`/`axiomCount 0`. Flip to `axiomatized` and disclose `Lean.ofReduceBool`.

## Evidence

`proofs/Proofs/WilsonsTheoremOQ02.lean` proves these **named, advertised** theorems *solely* by `native_decide`:
- `gaussWilson_verified_le_250` / `gaussWilson_verified_le_300` (L361/L365) — ∀-range verification "Gauss-Wilson verified computationally for all n ≤ 300" (origContribution #7)
- `no_wilson_primes_14_to_100` (L404) — completeness/search claim "no Wilson primes between 14 and 100" (origContribution #8)
- `five_is_wilson_prime` / `thirteen_is_wilson_prime` — concrete `p² ∣ (p-1)!+1` checks via `native_decide`

Per the Axiom Integrity Policy, `native_decide` depends on `Lean.ofReduceBool` (trusts compiler kernel reduction), so when it discharges substantive results the entry presents as verified, this must count: `axiomCount ≥ 1`, `status: axiomatized`, `badge: axiom`.

The abstract Gauss-Wilson machinery (origContributions #0–6: `selfInverse_units_eq_pair`, `prod_univ_sq_eq_one`, `prod_eq_prod_sq_eq_one`, `prod_units_neg_one_of_cyclic`, `prod_units_one_of_not_cyclic`, `gaussWilson_abstract`) is fully symbolic and `native_decide`-free.

**Before**: `status: verified`, `badge: original`, `axiomCount: 0`, `assumptions: "None. Fully machine-verified."`
**After**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`, assumptions disclose `Lean.ofReduceBool` and which contributions rely on `native_decide`.

`leanFile.axiomCount` stays `0` (no literal `axiom` declarations) — legitimately differs from `meta.axiomCount: 1` per policy.

---
Automated fix by lean-mechanic agent.