### PR TITLE
audit(erdos-1128): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4048,9 +4048,9 @@
       "result": "clean"
     },
     "erdos-1128": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:55Z",
+      "lastAudited": "2026-06-18T13:11:41Z",
       "result": "clean"
     },
     "erdos-1129": {


### PR DESCRIPTION
## Clean Re-Audit: Erdős #1128

Gallery integrity re-audit of **Erdős Problem #1128** (Monochromatic Cubes in Cardinal Products — Prikry-Mills 1978 disproof).

### Verification (meta.json ⇄ `proofs/Proofs/Erdos1128Problem.lean`)

| Field | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| lineCount | 166 | 166 | ✓ |
| axiomCount | 4 | 4 (`A`, `B`, `C`, `prikry_mills_disproof`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| status / badge | axiomatized / axiom | Tier C (rests on `prikry_mills_disproof`) | ✓ |

- All 7 `originalContributions` correspond to real declarations.
- The 2D analogue (Part V) is **comment-only**, not a phantom axiom — consistent with the phantom-2D-axiom fix in #25669 (merged today).
- `axiomatized`/`axiom` correctly reflects that the headline negative result rests on the axiomatized Prikry-Mills construction (ordinal combinatorics beyond current Mathlib).

**No meta change required.** Tracker bump 3→4.

---
Discovered during gallery integrity audit.