### PR TITLE
audit(erdos-1129): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4054,9 +4054,9 @@
       "result": "clean"
     },
     "erdos-1129": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:55Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "erdos-1129-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1129 (Optimal Lagrange Interpolation Nodes)

**Result: CLEAN.** No meta changes; tracker auditCount 3→4.

Verified `proofs/Proofs/Erdos1129Problem.lean` against `meta.json`:

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 454 | 454 | ✓ |
| axiomCount | 5 | 5 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 30 | 30 | ✓ |
| definitionCount | 10 | 10 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

**Axioms (all 5 disclosed in `assumptions`):** `erdos_lower_bound`, `chebyshev_upper_bound`, `kilgore_cheney_existence`, `brutman_odd`, `brutman_pinkus_even`.

**Tier C (axiomatized/axiom) — correct.** Headline `erdos_1129` rests on the disclosed bound/existence axioms; small cases `optimal_n2`/`optimal_n3` are genuinely machine-checked; `erdos_complex_conjecture` derived by parity case-split from the two Brutman axioms. No axiom masking, no overclaiming. All named theorems present.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)