### PR TITLE
audit(erdos-1145): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4198,9 +4198,9 @@
       "result": "clean"
     },
     "erdos-1145": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:56Z",
+      "lastAudited": "2026-06-18T13:17:29Z",
       "result": "clean"
     },
     "erdos-1146": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1145

**Erdős–Sárközy Conjecture on Two-Set Bases** (OPEN problem, axiomatized).

### Verification (exact match against meta.json)

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 737 | 737 | ✓ |
| axiomCount | 1 | 1 (`erdos_sarkozy_conjecture`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 39 | 39 | ✓ |
| definitionCount | 9 | 9 | ✓ |

### Tier C classification correct
- `status: axiomatized`, `badge: axiom` — correct. The sole axiom is the **open** Erdős–Sárközy conjecture itself (`erdos_sarkozy_conjecture`), properly disclosed in `assumptions`.
- Named contributions are all genuine proved theorems (not axioms/sorries): `erdos_1145_implies_28`, `ratio_condition_necessary`, `ruzsa_unique_rep` (now derived in-file, previously axiomatized), `sum_of_reps_lower_bound`.
- Grekos et al. partial result correctly recorded as docstring only ("not formalized") — phantom-axiom prose already fixed in #25692.

### Result
Clean. No meta change needed; tracker `auditCount` 3→4.

---
Discovered during gallery integrity audit.