### PR TITLE
audit(erdos-1124-oq-01): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4016,9 +4016,9 @@
       "result": "clean"
     },
     "erdos-1124-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:08:56Z",
+      "lastAudited": "2026-06-18T14:00:00Z",
       "result": "clean"
     },
     "erdos-1125": {


### PR DESCRIPTION
## Audit: erdos-1124-oq-01 (Circle-squaring minimum piece count, OPEN)

Re-audit of the gallery entry vs Lean source `Proofs/Erdos1124OQ01.lean`.

### Verification (EXACT match to meta)
- **454 lines**, **5 axioms**, **0 sorries**, **0 native_decide**, **0 True-stubs**, **22 theorems**, **9 defs** (8 def + 1 abbrev)
- Status `axiomatized` / badge `axiom` — **CORRECT** (Tier C open problem)

### Axioms (all substantive & disclosed)
- `minPieceCount`, `minPieceCount_achieves`, `minPieceCount_is_min` — the open quantity and its achievability/minimality
- `laczkovich_upper_bound` — 10^50 via translations (non-measurable, uses AC)
- `lower_bound_three` — 2 pieces never suffice (topological)

GMP and Marks–Unger bounds are cited in prose, **not** formalized — correctly disclosed in `assumptions`.

### Findings
- `mainTheorems` empty (no phantom theorem claims)
- All 22 named theorems exist in source
- Meta already correct post-#25697 (phantom axiom claims fixed 9→5)

**No meta change required.** Tracker bumped: auditCount 3→4, lastAudited refreshed. The stale tracker (lastAudited 05-03) is the known worktree-path bug where #25697 fixed meta but didn't propagate the tracker bump to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)