### PR TITLE
audit(erdos-1144): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4192,9 +4192,9 @@
       "result": "clean"
     },
     "erdos-1144": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:51Z",
+      "lastAudited": "2026-06-18T00:00:00Z",
       "result": "clean"
     },
     "erdos-1145": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1144

**Erdős Problem #1144: Partial Sums of Random Multiplicative Functions** (OPEN, axiomatized/axiom)

Clean 4th re-audit. Every meta.json claim matches `proofs/Proofs/Erdos1144Problem.lean`:

| Field | meta | source | ✓ |
|-------|------|--------|---|
| lineCount | 226 | 226 | ✓ |
| axiomCount | 1 | 1 (`atherfold_upper_bound`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 16 | 16 | ✓ |
| definitionCount | 5 | 5 | ✓ |

**Tier C — appropriately axiomatized.** The headline conjecture (`erdos_1144_conjecture`) is a `def Prop` (open). The single axiom `atherfold_upper_bound` encodes Atherfold's 2025 published upper bound and is disclosed in `assumptions`. The pinch theorem (`conjecture_and_atherfold_pinch`) assumes the conjecture. No axiom masking, no overclaiming.

- 0 `native_decide` (the `simp +decide` calls use kernel decide, not `Lean.ofReduceBool`).
- 0 True stubs; `mainTheorems` empty (no phantoms).
- All 22 `originalContributions` resolve to real declarations in the file.

No meta change required. Tracker `auditCount` 3→4.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)