### PR TITLE
research(euler-totient-oq-01-oq-03): constructive RSA key generation discharges e·d ≡ 1 (mod λ(n))

### DIFF
--- a/proofs/Proofs/EulerTotientOQ01OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ03.lean
@@ -193,4 +193,47 @@ theorem rsa_decrypt_encrypt {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
   rw [← pow_mul, hed, Nat.add_comm 1 (k * carmichael (p * q))]
   exact rsa_correct_carmichael hcop a (dvd_mul_left _ k)
 
+/-! ### Key generation: discharging the congruence `e·d ≡ 1 (mod λ(n))`
+
+The round-trip `rsa_decrypt_encrypt` above *assumes* a private exponent `d`
+satisfying `e·d = 1 + k·λ(n)`.  RSA key generation must produce such a `d` from
+the public exponent `e`, and it can do so precisely when `gcd(e, λ(n)) = 1`.
+We discharge this hypothesis **constructively**: by Euler's theorem
+`e^φ(λ) ≡ 1 (mod λ)`, so the explicit exponent `d = e^(φ(λ) − 1)` satisfies
+`e·d = e^φ(λ) ≡ 1 (mod λ)`, i.e. `e·d = 1 + k·λ`.  This turns the conditional
+round-trip into an unconditional *existence of a working key pair*. -/
+
+/-- **Existence of a private exponent (modular inverse).**  If `gcd(e, λ) = 1`
+    (with `e ≥ 1` and `λ ≥ 1`) then there are `d, k` with `e·d = 1 + k·λ` — i.e.
+    `e` is invertible modulo `λ`, with inverse `d` realised explicitly as
+    `e^(φ(λ) − 1)` via Euler's theorem.  This is the number-theoretic core of RSA
+    key generation. -/
+theorem exists_inverse_exponent {e lam : ℕ} (he : 1 ≤ e) (hlam : 1 ≤ lam)
+    (hcop : Nat.Coprime e lam) : ∃ d k : ℕ, e * d = 1 + k * lam := by
+  have htot : 1 ≤ Nat.totient lam := Nat.totient_pos.mpr hlam
+  have hed : e * e ^ (Nat.totient lam - 1) = e ^ Nat.totient lam := by
+    rw [← pow_succ']; congr 1; omega
+  have hmod : e * e ^ (Nat.totient lam - 1) ≡ 1 [MOD lam] := by
+    rw [hed]; exact Nat.ModEq.pow_totient hcop
+  have hge : 1 ≤ e * e ^ (Nat.totient lam - 1) := by
+    rw [hed]; exact Nat.one_le_pow _ _ he
+  obtain ⟨k, hk⟩ := (Nat.modEq_iff_dvd' hge).mp hmod.symm
+  exact ⟨e ^ (Nat.totient lam - 1), k, by rw [Nat.mul_comm k lam]; omega⟩
+
+/-- **RSA key generation works (unconditional round-trip).**  For `n = p·q`
+    (distinct primes) and a public exponent `e ≥ 1` coprime to `λ(n)`, there
+    *exists* a private exponent `d` for which decryption inverts encryption on
+    every message `a : ZMod n`:
+        `rsaDecrypt d (rsaEncrypt e a) = a`   for all `a`.
+    The congruence hypothesis of `rsa_decrypt_encrypt` is discharged by
+    `exists_inverse_exponent`, so a usable RSA key pair always exists once
+    `gcd(e, λ(n)) = 1`. -/
+theorem exists_rsa_keypair {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hcop : Nat.Coprime p q) (e : ℕ) (he : 1 ≤ e)
+    (hlam : 1 ≤ carmichael (p * q))
+    (hecop : Nat.Coprime e (carmichael (p * q))) :
+    ∃ d : ℕ, ∀ a : ZMod (p * q), rsaDecrypt d (rsaEncrypt e a) = a := by
+  obtain ⟨d, k, hed⟩ := exists_inverse_exponent he hlam hecop
+  exact ⟨d, fun a => rsa_decrypt_encrypt hcop a hed⟩
+
 end EulerTotientOQ01OQ03

--- a/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified: docker-build of Proofs.EulerTotientOQ01OQ03 completed successfully on 2026-06-15 (7744 jobs), confirming 0 axioms and 0 sorries against the pinned Mathlib (v4.26.0). The build first surfaced — and this session fixed — seven Mathlib-API mismatches in the imported Carmichael-function dependency Proofs/EulerTotientOQ01.lean (exponent_dvd / exp_eq_one_iff / exp_eq_one_of_subsingleton renames, IsCyclic.exponent_eq_card now returning Nat.card, Group.exponent_dvd_card, and invalid `▸` motives replaced by Eq.le), which had blocked the whole chain. Every arithmetic claim is additionally certified build-free by research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py (all-a correctness over 55 moduli, λ < φ strictly, and the explicit p² failure set — all pass).",
+    "assumptions": "None. Fully machine-verified: docker-build of Proofs.EulerTotientOQ01OQ03 completed successfully (7744 jobs) — first on 2026-06-15 and re-verified on 2026-06-18 after adding the constructive key-generation theorems (exists_inverse_exponent, exists_rsa_keypair) — confirming 0 axioms and 0 sorries against the pinned Mathlib (v4.26.0). The build first surfaced — and this session fixed — seven Mathlib-API mismatches in the imported Carmichael-function dependency Proofs/EulerTotientOQ01.lean (exponent_dvd / exp_eq_one_iff / exp_eq_one_of_subsingleton renames, IsCyclic.exponent_eq_card now returning Nat.card, Group.exponent_dvd_card, and invalid `▸` motives replaced by Eq.le), which had blocked the whole chain. Every arithmetic claim is additionally certified build-free by research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py (all-a correctness over 55 moduli, λ < φ strictly, and the explicit p² failure set — all pass).",
     "mathlibDependencies": [
       {
         "theorem": "ZMod.pow_card_sub_one_eq_one",
@@ -32,6 +32,11 @@
         "theorem": "ZMod.chineseRemainder",
         "description": "CRT ring isomorphism ZMod (p·q) ≃+* ZMod p × ZMod q for coprime p, q",
         "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.ModEq.pow_totient",
+        "description": "Euler's theorem: a^φ(n) ≡ 1 (mod n) when gcd(a, n) = 1 — used to build the explicit modular inverse d = e^(φ(λ) − 1) in key generation",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
       }
     ],
     "originalContributions": [
@@ -43,14 +48,16 @@
       "carmichael_mul_coprime: identifies the concrete exponent lcm(p−1, q−1) with the parent's abstract λ(n) = Monoid.exponent (ZMod n)ˣ, by transporting the group exponent across the CRT-induced units isomorphism (Units.mapEquiv + MulEquiv.prodUnits) and evaluating Monoid.exponent_prod",
       "rsa_correct_carmichael: the open question's headline statement — RSA correctness stated directly against the minimal universal exponent λ(n) = carmichael(p·q), via the divisibility bridges (p−1) ∣ λ(n) and (q−1) ∣ λ(n)",
       "rsaEncrypt / rsaDecrypt and rsa_decrypt_encrypt: a literal end-to-end RSA implementation (encryption a ↦ aᵉ, decryption c ↦ cᵈ in ZMod n) with the verified round-trip rsaDecrypt d (rsaEncrypt e a) = a for every a, given the key-generation congruence e·d = 1 + k·λ(n) — encryption and decryption are proved mutual inverses against the Carmichael exponent",
-      "carmichael_dvd_iff_unit_rsa (companion file EulerTotientOQ01OQ03Minimal.lean): the matching CONVERSE/sharpness — λ(n) ∣ m ↔ (a^(m+1) = a for every unit a : (ZMod n)ˣ). Together with the sufficiency results above this pins λ(n) as the EXACT minimal universal RSA exponent — no smaller exponent works for all messages coprime to n — making precise the open question's 'minimal universal exponent λ(n)' claim. Proved via the parent's carmichael_minimal (Monoid.exponent is the least universal exponent of the unit group); restricting to units is essential since non-units (e.g. 0) satisfy a^(m+1) = a for every m and carry no information about the minimal exponent"
+      "carmichael_dvd_iff_unit_rsa (companion file EulerTotientOQ01OQ03Minimal.lean): the matching CONVERSE/sharpness — λ(n) ∣ m ↔ (a^(m+1) = a for every unit a : (ZMod n)ˣ). Together with the sufficiency results above this pins λ(n) as the EXACT minimal universal RSA exponent — no smaller exponent works for all messages coprime to n — making precise the open question's 'minimal universal exponent λ(n)' claim. Proved via the parent's carmichael_minimal (Monoid.exponent is the least universal exponent of the unit group); restricting to units is essential since non-units (e.g. 0) satisfy a^(m+1) = a for every m and carry no information about the minimal exponent",
+      "exists_inverse_exponent: discharges the key-generation congruence CONSTRUCTIVELY — for gcd(e, λ) = 1 (with e, λ ≥ 1) there exist d, k with e·d = 1 + k·λ, realising the private exponent explicitly as d = e^(φ(λ) − 1) via Euler's theorem (Nat.ModEq.pow_totient). This is the number-theoretic core of RSA key generation: e is invertible mod λ exactly when coprime to it",
+      "exists_rsa_keypair: turns the conditional round-trip rsa_decrypt_encrypt into an UNCONDITIONAL existence theorem — for n = p·q and any public exponent e ≥ 1 coprime to λ(n), there EXISTS a private exponent d for which rsaDecrypt d (rsaEncrypt e a) = a for every message a. The previously-assumed congruence e·d = 1 + k·λ(n) is now derived from gcd(e, λ(n)) = 1 rather than hypothesised, so a usable RSA key pair is proved to always exist"
     ],
     "additionalFiles": [
       "Proofs/EulerTotientOQ01OQ03Minimal.lean"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 196,
-    "theoremCount": 8,
+    "lineCount": 239,
+    "theoremCount": 10,
     "definitionCount": 2,
     "prerequisites": [
       "Carmichael's function λ(n) = Monoid.exponent (ZMod n)ˣ (parent file euler-totient-oq-01)",
@@ -71,7 +78,8 @@
       "Squarefreeness is necessary, not incidental: for n = p² the all-a fixed point fails (a divisible by p stays ≡ 0 mod p but need not return mod p²), so RSA's n = p·q moduli are exactly the safe regime — the certificate exhibits the explicit failure set for n = 49",
       "The theorem is stated for any exponent m divisible by both p−1 and q−1, which is more general than 'a multiple of λ(n)' and makes the CRT reduction immediate",
       "The bridge λ(p·q) = lcm(λ(p), λ(q)) is proved abstractly — by transporting Monoid.exponent across the CRT-induced units isomorphism (Monoid.exponent_eq_of_mulEquiv + Monoid.exponent_prod) rather than by computing orders — so the final theorem speaks about the genuinely minimal exponent λ(n) = Monoid.exponent (ZMod n)ˣ, not merely a convenient common multiple",
-      "Sufficiency is matched by sharpness: the companion file proves the converse carmichael_dvd_iff_unit_rsa — over the units, a^(m+1) = a for all a IFF λ(n) ∣ m — so λ(n) is not just A working exponent but the MINIMAL one. The test must be on units: every non-unit (in particular 0) satisfies a^(m+1) = a for all m, so non-units cannot detect the threshold, and it is precisely the unit group whose exponent is λ(n)"
+      "Sufficiency is matched by sharpness: the companion file proves the converse carmichael_dvd_iff_unit_rsa — over the units, a^(m+1) = a for all a IFF λ(n) ∣ m — so λ(n) is not just A working exponent but the MINIMAL one. The test must be on units: every non-unit (in particular 0) satisfies a^(m+1) = a for all m, so non-units cannot detect the threshold, and it is precisely the unit group whose exponent is λ(n)",
+      "Key generation needs no extra cryptographic primitive: the private exponent is just the modular inverse of e mod λ(n), and Euler's theorem hands it over explicitly as d = e^(φ(λ(n)) − 1) — coprimality gcd(e, λ(n)) = 1 is exactly the condition that makes e invertible, so the conditional round-trip becomes an unconditional existence statement (exists_rsa_keypair) with no remaining hypothesis beyond coprimality"
     ]
   },
   "sections": [
@@ -124,6 +132,14 @@
       "mathContext": "$\\mathrm{rsaDecrypt}_d(\\mathrm{rsaEncrypt}_e(a)) = a^{ed} = a$ when $ed = 1 + k\\,\\lambda(n)$."
     },
     {
+      "id": "key-generation",
+      "title": "Constructive Key Generation",
+      "startLine": 197,
+      "endLine": 239,
+      "summary": "Discharges the key-generation congruence assumed by rsa_decrypt_encrypt. exists_inverse_exponent: for gcd(e, λ) = 1 (e, λ ≥ 1) there are d, k with e·d = 1 + k·λ — the private exponent is realised explicitly as d = e^(φ(λ) − 1), since by Euler's theorem (Nat.ModEq.pow_totient) e·d = e^φ(λ) ≡ 1 (mod λ), and Nat.modEq_iff_dvd' extracts the witness k. exists_rsa_keypair then feeds this d into rsa_decrypt_encrypt to obtain the unconditional ∃ d, ∀ a, rsaDecrypt d (rsaEncrypt e a) = a: a usable RSA key pair always exists once e is coprime to λ(n).",
+      "mathContext": "$\\gcd(e,\\lambda)=1 \\Rightarrow \\exists d,\\ e d \\equiv 1 \\pmod\\lambda$ with $d = e^{\\varphi(\\lambda)-1}$; hence $\\exists d,\\ \\forall a,\\ \\mathrm{rsaDecrypt}_d(\\mathrm{rsaEncrypt}_e(a))=a$."
+    },
+    {
       "id": "minimality-sharpness",
       "title": "Minimality of λ(n) (companion file)",
       "startLine": 37,
@@ -145,10 +161,10 @@
     }
   ],
   "conclusion": {
-    "summary": "RSA decryption correctness is formalized with the Carmichael exponent λ(n) = lcm(p−1, q−1): for n = p·q and any exponent divisible by both p−1 and q−1, a^(m+1) = a holds for every message a, giving the textbook a^(e·d) = a once e·d = 1 + k·λ. The proof reduces through CRT to a per-prime Fermat fixed point that explicitly covers the non-unit case. A bridge section then connects this to the parent's abstract λ(n) = Monoid.exponent (ZMod n)ˣ, proving λ(p·q) = lcm(λ(p), λ(q)) and stating correctness directly against the minimal universal exponent (rsa_correct_carmichael). A companion file (EulerTotientOQ01OQ03Minimal.lean) supplies the matching converse: λ(n) ∣ m ↔ a^(m+1) = a for every unit a, so λ(n) is verified to be the EXACT minimal universal exponent, not merely one that works. 0 axioms, 0 sorries.",
+    "summary": "RSA decryption correctness is formalized with the Carmichael exponent λ(n) = lcm(p−1, q−1): for n = p·q and any exponent divisible by both p−1 and q−1, a^(m+1) = a holds for every message a, giving the textbook a^(e·d) = a once e·d = 1 + k·λ. The proof reduces through CRT to a per-prime Fermat fixed point that explicitly covers the non-unit case. A bridge section then connects this to the parent's abstract λ(n) = Monoid.exponent (ZMod n)ˣ, proving λ(p·q) = lcm(λ(p), λ(q)) and stating correctness directly against the minimal universal exponent (rsa_correct_carmichael). A companion file (EulerTotientOQ01OQ03Minimal.lean) supplies the matching converse: λ(n) ∣ m ↔ a^(m+1) = a for every unit a, so λ(n) is verified to be the EXACT minimal universal exponent, not merely one that works. Finally, constructive key generation (exists_inverse_exponent, exists_rsa_keypair) discharges the key-generation congruence: from gcd(e, λ(n)) = 1 it builds the private exponent d = e^(φ(λ(n)) − 1) via Euler's theorem and proves that a working key pair (∃ d, ∀ a, rsaDecrypt d (rsaEncrypt e a) = a) always exists — so the round-trip is now unconditional. 0 axioms, 0 sorries.",
     "implications": "Provides the verified core of a textbook-correct RSA implementation keyed on the Carmichael function rather than φ(n), pins down why squarefree moduli n = p·q are necessary for all-message correctness, and identifies the concrete exponent lcm(p−1, q−1) with the abstract group-exponent definition λ(n) = Monoid.exponent (ZMod n)ˣ. Both directions are formalized — sufficiency (λ(n) works for all messages) and minimality (no smaller exponent works for every unit) — so correctness is stated against the genuinely minimal universal exponent, which divides φ(n) and yields a no-larger private key.",
     "openQuestions": [
-      "Complete the verified key-generation pipeline: the end-to-end round-trip rsaDecrypt d (rsaEncrypt e a) = a is now proved (rsa_decrypt_encrypt) assuming e·d = 1 + k·λ(n); what remains is to derive d constructively as a modular inverse of e mod λ(n) (requiring gcd(e, λ(n)) = 1) so the congruence hypothesis is discharged rather than assumed",
+      "RESOLVED (2026-06-18): the key-generation pipeline is now complete and unconditional — exists_inverse_exponent derives the private exponent d constructively as the modular inverse e^(φ(λ(n)) − 1) of e mod λ(n) from gcd(e, λ(n)) = 1 (Euler's theorem), and exists_rsa_keypair packages it as ∃ d, ∀ a, rsaDecrypt d (rsaEncrypt e a) = a, so the congruence hypothesis of rsa_decrypt_encrypt is discharged rather than assumed. Remaining refinement: produce d in the canonical reduced range 0 ≤ d < λ(n) (rather than e^(φ(λ)−1)) and expose a computable keygen function",
       "Generalize the all-message fixed point to arbitrary squarefree n = ∏ pᵢ via the multi-prime CRT",
       "Quantify the efficiency gain of λ(n) over φ(n): characterize the moduli where λ(n) ≪ φ(n) and the consequent reduction in the private exponent's size"
     ]
@@ -177,9 +193,9 @@
       "Classical"
     ],
     "namespace": "EulerTotientOQ01OQ03",
-    "lineCount": 196,
+    "lineCount": 239,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 2,
     "path": "Proofs/EulerTotientOQ01OQ03.lean",
     "sorries": 0
@@ -232,6 +248,18 @@
       "type": "supporting",
       "description": "Divisibility bridge: (q−1) ∣ λ(p·q), since q−1 = λ(q) divides lcm(λ(p), λ(q))",
       "leanType": "(q - 1) ∣ carmichael (p * q)"
+    },
+    {
+      "name": "exists_rsa_keypair",
+      "type": "core",
+      "description": "Key generation works: for n = p·q and a public exponent e ≥ 1 coprime to λ(n), there exists a private exponent d with rsaDecrypt d (rsaEncrypt e a) = a for every a — the round-trip's congruence hypothesis is discharged, not assumed",
+      "leanType": "∃ d : ℕ, ∀ a : ZMod (p * q), rsaDecrypt d (rsaEncrypt e a) = a"
+    },
+    {
+      "name": "exists_inverse_exponent",
+      "type": "supporting",
+      "description": "Constructive modular inverse: for gcd(e, λ) = 1 (e, λ ≥ 1) there exist d, k with e·d = 1 + k·λ, with d = e^(φ(λ) − 1) by Euler's theorem — the number-theoretic core of RSA key generation",
+      "leanType": "∃ d k : ℕ, e * d = 1 + k * lam"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/euler-totient-oq-01-oq-03.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-03.json
@@ -1,18 +1,18 @@
 {
   "slug": "euler-totient-oq-01-oq-03",
   "title": "Verified RSA with the Carmichael function lambda(n)",
-  "phase": "ORIENT",
-  "status": "active",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": "Open question #2 of euler-totient-oq-01: can Carmichael's function lambda(n) be used for a Lean-verified RSA with correct decryption m^(e*d) = m (mod n) for all m, using the minimal universal exponent lambda(n) instead of Euler's phi(n)?",
   "knownResults": "Parent EulerTotientOQ01.lean defines carmichael n = Monoid.exponent (ZMod n)^x and proves a^lambda(n)=1 for units, lambda|phi, lambda(p)=p-1. Missing: all-m decryption correctness.",
-  "currentState": "ORIENT complete: theorem + CRT/Fermat proof + squarefree necessity + bearers; build-pending Lean.",
+  "currentState": "DONE: machine-verified (docker-build 7744 jobs, 0 ax / 0 sorry). All-m RSA correctness via CRT+Fermat (rsa_correct), Carmichael bridge lambda(p*q)=lcm(p-1,q-1) (carmichael_mul_coprime), end-to-end round-trip (rsa_decrypt_encrypt), minimality converse (companion), AND (2026-06-18) constructive key generation: exists_inverse_exponent builds d=e^(phi(lambda)-1) from gcd(e,lambda)=1 via Euler, exists_rsa_keypair makes the round-trip unconditional. gallery status verified/original.",
   "knowledge": {
-    "progressSummary": "ORIENT: RSA-lambda correctness for n=p*q (distinct primes): e*d == 1 (mod lambda(n)) ⟹ m^(e*d) == m (mod n) for ALL m. Proof = CRT ZMod(p*q)≃ZMod p×ZMod q + per-prime Fermat fixed point (a^(m+1)=a when (p-1)|m). Squarefree necessary (fails for p^2). No Mathlib gap. Verifier ALL PASS; sorry-free build-pending Lean (per-prime core proven, CRT assembly build-pending).",
+    "progressSummary": "DONE (machine-verified, 7744-job docker-build, 0 ax / 0 sorry): RSA-lambda correctness for n=p*q (distinct primes), e*d == 1 (mod lambda(n)) ⟹ m^(e*d) == m (mod n) for ALL m, via CRT ZMod(p*q)≃ZMod p×ZMod q + per-prime Fermat fixed point (a^(m+1)=a when (p-1)|m). Carmichael bridge lambda(p*q)=lcm(p-1,q-1), end-to-end round-trip, minimality converse (companion). 2026-06-18 ACT: constructive key generation closes openQuestion #1 — exists_inverse_exponent (d=e^(phi(lambda)-1) via Euler's theorem from gcd(e,lambda)=1) + exists_rsa_keypair (unconditional ∃ d, ∀ a, rsaDecrypt d (rsaEncrypt e a)=a). Squarefree necessary (fails for p^2).",
     "builtItems": [
       "research/problems/euler-totient-oq-01-oq-03/verify_rsa_lambda.py - exhaustive all-residue verifier (correctness, lambda<phi, squarefree necessity), ALL PASS",
-      "proofs/Proofs/EulerTotientOQ01OQ03.lean (build-pending, UNREGISTERED): zmod_pow_eq_self (per-prime fixed point, PROVEN), rsa_correct (n=p*q via ZMod.chineseRemainder), rsa_decrypt_correct (textbook e*d=1+k*lambda).",
+      "proofs/Proofs/EulerTotientOQ01OQ03.lean (VERIFIED, registered): zmod_pow_eq_self (per-prime fixed point), rsa_correct (n=p*q via ZMod.chineseRemainder), rsa_decrypt_correct, carmichael_mul_coprime + bridges, rsaEncrypt/rsaDecrypt + rsa_decrypt_encrypt round-trip, and exists_inverse_exponent/exists_rsa_keypair (constructive key generation, 2026-06-18).",
       "EulerTotientOQ01OQ03Minimal.lean: carmichael_dvd_iff_unit_rsa — sharp IFF carmichael n ∣ m ↔ ∀ unit a, a^(m+1)=a (minimality/converse of RSA correctness)"
     ],
     "insights": [
@@ -21,16 +21,15 @@
       "lambda(n) | phi(n) and is strictly smaller in all tested moduli, giving a no-larger private exponent with the same decryption map.",
       "Squarefree is NECESSARY: for n=p^2 the all-m fixed point fails on multiples of p (n=9→{3,6}, n=25→{5,10,15,20}).",
       "carmichael_pow_eq_one alone (units only) cannot prove the all-m statement; the CRT/per-prime route is essential.",
-      "The RSA round-trip a^(m+1)=a carries no exponent info on non-units (0^(m+1)=0 always); over (ZMod n)ˣ it holds for all units IFF λ(n)∣m, pinning λ(n) as the minimal universal exponent via carmichael_minimal (Monoid.exponent is least common exponent)"
+      "The RSA round-trip a^(m+1)=a carries no exponent info on non-units (0^(m+1)=0 always); over (ZMod n)ˣ it holds for all units IFF λ(n)∣m, pinning λ(n) as the minimal universal exponent via carmichael_minimal (Monoid.exponent is least common exponent)",
+      "Key generation needs no new machinery: the private exponent is the modular inverse of e mod λ(n), and Euler's theorem (Nat.ModEq.pow_totient) supplies it explicitly as d=e^(φ(λ(n))-1); coprimality gcd(e,λ(n))=1 is exactly the invertibility condition, turning the conditional round-trip into the unconditional exists_rsa_keypair"
     ],
     "mathlibGaps": [
       "None for the n=p*q theorem (ZMod.pow_card_sub_one_eq_one + ZMod.chineseRemainder suffice).",
       "For a carmichael-phrased corollary, need carmichael(p*q)=lcm(carmichael p, carmichael q) (exponent of product of coprime-order groups) - not yet in the parent file."
     ],
     "nextSteps": [
-      "ACT (live build): compile EulerTotientOQ01OQ03.lean, repair any CRT-assembly lemma names (Prod.ext_iff/Prod.fst_pow/ZMod.pow_card_sub_one_eq_one), register in Proofs/Proofs.lean.",
-      "Add bridge (p-1)|carmichael(p*q) and (q-1)|carmichael(p*q) so rsa_correct restates as carmichael(p*q)|m → a^(m+1)=a.",
-      "Optional: def rsaEncrypt/rsaDecrypt on ZMod n + round-trip corollary."
+      "COMPLETE. Optional future refinements: produce the canonical reduced private exponent 0 ≤ d < λ(n) and a computable keygen function; generalize all-message correctness to arbitrary squarefree n = ∏ pᵢ via multi-prime CRT; quantify the λ(n) ≪ φ(n) efficiency gain."
     ]
   },
   "tags": [
@@ -46,22 +45,22 @@
   ],
   "references": [],
   "started": "2026-06-15",
-  "lastUpdate": "2026-06-15",
+  "lastUpdate": "2026-06-18",
   "significance": 5,
   "tractability": 8,
   "leanFiles": [
     {
       "path": "Proofs/EulerTotientOQ01OQ03.lean",
       "filename": "EulerTotientOQ01OQ03.lean",
-      "lineCount": 108,
-      "theoremCount": 3,
+      "lineCount": 239,
+      "theoremCount": 10,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03.lean",
-      "buildPending": true,
-      "registered": false
+      "buildPending": false,
+      "registered": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes **open question #1** of the gallery entry *Verified RSA Correctness with Carmichael's Function λ(n)* (`euler-totient-oq-01-oq-03`): derive the private exponent **constructively** rather than assuming the key-generation congruence.

Two new machine-verified theorems in `proofs/Proofs/EulerTotientOQ01OQ03.lean` (docker-build **7744 jobs, 0 axioms / 0 sorries**, Mathlib v4.26.0, re-verified 2026-06-18):

- **`exists_inverse_exponent`** — for `gcd(e, λ) = 1` (with `e, λ ≥ 1`) there exist `d, k` with `e·d = 1 + k·λ`. The private exponent is realised explicitly as `d = e^(φ(λ) − 1)` via Euler's theorem (`Nat.ModEq.pow_totient`): `e·d = e^φ(λ) ≡ 1 (mod λ)`, and `Nat.modEq_iff_dvd'` extracts the witness `k`. This is the number-theoretic core of RSA key generation — `e` is invertible mod `λ` precisely when coprime to it.
- **`exists_rsa_keypair`** — turns the previously *conditional* round-trip `rsa_decrypt_encrypt` into an **unconditional existence theorem**: for `n = p·q` (distinct primes) and any public exponent `e ≥ 1` coprime to `λ(n)`, there **exists** a private exponent `d` with `rsaDecrypt d (rsaEncrypt e a) = a` for every message `a`. The congruence `e·d = 1 + k·λ(n)` is now *derived* from `gcd(e, λ(n)) = 1`, not hypothesised.

Together with the existing sufficiency (`rsa_correct_carmichael`) and minimality (`carmichael_dvd_iff_unit_rsa`, companion file), the RSA-with-λ(n) story is now complete: correctness for all messages, minimality of the exponent, and constructive key generation.

## Changes

- `proofs/Proofs/EulerTotientOQ01OQ03.lean`: +2 theorems (8→10), +43 lines (196→239).
- `src/data/proofs/euler-totient-oq-01-oq-03/meta.json`: counts, `originalContributions`, `mainTheorems`, new `key-generation` section, `mathlibDependencies` (Euler), conclusion, key insights, re-verification note. Status stays `verified`/`original`, 0 axioms.
- `src/data/research/problems/euler-totient-oq-01-oq-03.json`: marked `completed`/`DONE`, refreshed knowledge + leanFiles metadata.

## Verification

`./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ01OQ03` → `Build completed successfully (7744 jobs)`, exit 0. No `axiom`/`native_decide`/`sorry` in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)