### PR TITLE
audit(erdos-1141): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4174,9 +4174,9 @@
       "result": "clean"
     },
     "erdos-1141": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:52Z",
+      "lastAudited": "2026-06-18T13:29:31Z",
       "result": "clean"
     },
     "erdos-1142": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1141

**Result:** CLEAN (no meta change; tracker auditCount 3→4)

Coprime-Square Subtraction Primes — `axiomatized`/`axiom`.

### Verified against Lean source (`proofs/Proofs/Erdos1141Problem.lean`)
| Field | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| lineCount | 210 | 210 | ✓ |
| sorries | 0 | 0 | ✓ |
| leanFile.axiomCount | 1 | 1 (`erdos_1141_finitely_many`) | ✓ |
| theoremCount | 35 | 35 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier C classification correct
- Single literal axiom `erdos_1141_finitely_many` represents the APSSV (2026, arXiv:2604.06609) finiteness result — proved via Pollack's theorem, ineffective by Siegel, **not yet formalized in Mathlib** → correctly axiomatized.
- `axiomCount: 2` = literal axiom + `Lean.ofReduceBool` (from 29 `native_decide` computations), both disclosed in `assumptions`.
- Named contributions `all_known_good` (L173), `classification_100` (L182), `good_count_100` (L186), `knownGoodValues_length` (L139) all real, all `native_decide`-discharged.
- `mainTheorems` empty — no phantom advertised theorems.

No overclaiming detected. status/badge `axiomatized`/`axiom` justified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)