### PR TITLE
research(feuerbachs-theorem-oq-02): reconcile stale Lean stats post-deaxiomatization (#25746)

### DIFF
--- a/src/data/research/problems/feuerbachs-theorem-oq-02.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/FeuerbachsTheoremOQ02.lean",
       "filename": "FeuerbachsTheoremOQ02.lean",
-      "lineCount": 744,
-      "theoremCount": 12,
-      "axiomCount": 1,
-      "defCount": 47,
-      "sorryCount": 1,
+      "lineCount": 1050,
+      "theoremCount": 35,
+      "axiomCount": 0,
+      "defCount": 51,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02.lean"
     },


### PR DESCRIPTION
## Summary

Reconciles the parent research record `feuerbachs-theorem-oq-02.json` with the merged source after PR #25746 de-axiomatized `feuerbach_3d_fails_general`.

The `leanFiles` entry for `FeuerbachsTheoremOQ02.lean` was stale:

| field | before | after (verified) |
|-------|--------|-------|
| lineCount | 744 | 1050 |
| axiomCount | **1** | **0** |
| sorryCount | **1** | **0** |
| theoremCount | 12 | 35 |
| defCount | 47 | 51 |

### Why

PR #25746 (`research(feuerbach-oq02): de-axiomatize — prove feuerbach_3d_fails_general`) replaced the `axiom feuerbach_3d_fails_general` with a theorem discharged by the explicit non-orthocentric witness `witnessT1` / `witnessT1_fails` (surd-separation kernel, sympy-certified). The file is now 0-axiom / 0-sorry. The gallery `meta.json` for both `feuerbachs-theorem-oq-02` and `-murakami` already reads `verified` / `axiomCount: 0`; only the research record's `leanFiles` stats lagged, overstating the parent's assumption count in research listings.

### Verification

- Counts computed directly from `proofs/Proofs/FeuerbachsTheoremOQ02.lean` (block + line comments stripped): 0 `^axiom`, 0 `sorry`, 35 theorem/lemma, 51 def/structure/abbrev/instance, 1050 lines.
- The remaining `^axiom`-prefixed grep hit (line 758) is prose inside a docstring, not a declaration.
- JSON validated with `json.load`; surgical 5-field diff, no reformat noise.

No Lean rebuild required (source unchanged; metadata-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)