### PR TITLE
audit(erdos-1140): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4168,9 +4168,9 @@
       "result": "clean"
     },
     "erdos-1140": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T19:09:52Z",
+      "lastAudited": "2026-06-18T13:32:43Z",
       "result": "clean"
     },
     "erdos-1141": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1140

**Proof**: Erdős Problem #1140 (Primes of the Form n - 2x², DISPROVED)
**Result**: CLEAN — no meta changes needed, tracker bump only.

### Verification (meta.json ↔ proofs/Proofs/Erdos1140Problem.lean)

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 227 | 227 | ✓ |
| axiomCount | 2 | 2 (`epure_gica_mod_1`, `epure_gica_mod_3`) | ✓ |
| theoremCount | 19 | 19 | ✓ |
| definitionCount | 2 | 2 (`AllShiftsArePrime`, `KnownValues`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 (no `Lean.ofReduceBool`) | ✓ |
| True stubs | — | 0 | ✓ |

### Tier classification: C — axiomatized (CORRECT)

- `status: axiomatized` / `badge: axiom` correctly applied.
- Headline `erdos_1140` / `erdos_1140_finite` is **genuinely derived** from the two axiomatized Epure-Gica (2010) classification results (`epure_gica_mod_1`, `epure_gica_mod_3`) plus an elementary parity argument — no axiom masking. Title says "DISPROVED" and the two axioms (real published theorems) are fully disclosed in `assumptions`, `proofStrategy`, axiom docstrings, and `references`.
- All 4 `originalContributions` map to real proved theorems (`n_eq_*`, `even_case`, `erdos_1140_finite`).
- No phantom `mainTheorems`; section line ranges accurate.

Tracker `auditCount` 3 → 4.

---
Discovered during gallery integrity audit.