### PR TITLE
audit(erdos-153): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4827,9 +4827,9 @@
       "result": "clean"
     },
     "erdos-153": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:22:18Z",
+      "lastAudited": "2026-06-18T13:41:58Z",
       "result": "clean"
     },
     "erdos-154": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-153

**Result: CLEAN** (4th audit). No meta.json changes required; tracker bumped.

Erdős Problem #153: Gap Variance in Sidon Sumsets. Status `axiomatized` / badge `axiom` — **correct** (Tier C).

### Verified against `proofs/Proofs/Erdos153Problem.lean`
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 542 | 542 | ✓ |
| axiomCount | 1 | 1 (`erdos_153_conjecture`) | ✓ |
| theoremCount | 22 | 22 (incl. `private`) | ✓ |
| definitionCount | 8 | 8 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Integrity findings
- The single axiom `erdos_153_conjecture : ErdosProblem153` **is** the genuine open conjecture (mean squared gap in a Sidon sumset diverges), transparently disclosed in-file as "This is an open problem" and in `assumptions`. No axiom masking.
- `infinite_sidon_gap_from_finite` honestly derives from the axiom (Section IX, "Derived from Finite Conjecture") — dependency is transparent, not overclaimed.
- `ess_1994_result` (mean squared gap ≥ positive constant) is independently proved, matching the literature attribution.
- `assumptions` lists only real, present theorems.
- No `mainTheorems`/`originalContributions` phantom references.
- Prose (overview/conclusion) correctly states "full divergence remains open" and attributes Erdős–Sárközy–Sós (1994).

Tracker `auditCount` 3 → 4.

---
Discovered during gallery integrity audit.