### PR TITLE
Enrich erdos-1047: re-align annotations + sections to displayed Main.lean

### DIFF
--- a/src/data/proofs/erdos-1047/annotations.source.json
+++ b/src/data/proofs/erdos-1047/annotations.source.json
@@ -2,126 +2,130 @@
   {
     "id": "ann-e1047-overview",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 1,
-      "endLine": 22
+    "anchor": {
+      "type": "block-comment",
+      "contains": "Main Results (axiom-free)"
     },
     "type": "concept",
     "title": "Erdős #1047 and the Convexity of Lemniscates",
     "content": "**The question (Grunsky, reported by Erdős–Herzog–Piranian 1958):** the *lemniscate* of a monic polynomial $f$ at level $c$ is $\\{z : |f(z)| \\le c\\}$. It splits into finitely many connected components. *Must every component be convex?*\n\n**Answer: NO.** The first counterexample is due to **Pommerenke (1961)**, with further explicit examples by **Goodman (1966)**. This file collects the four headline results of Erdős #1047.\n\nThis `Main` file exists for a purely architectural reason: the headline theorems consume the machine-checked geometric certificate `Erdos1047OQ02Cert.goodman_counterexample_proof`, whose import chain (`Certificate → Reduction → Problem`) means they must live *downstream* of the parent `Erdos1047Problem.lean` (which holds the definitions `grunskyConjecture`, `goodmanPolynomial`, `lemniscate`, `IsConvexComplex`, …). Re-opening `namespace Erdos1047` keeps every public name unchanged.",
     "mathContext": "Lemniscate $E_c(f) = \\{z \\in \\mathbb{C} : |f(z)| \\le c\\}$ for monic $f \\in \\mathbb{C}[X]$. Grunsky's question: is every connected component of $E_c(f)$ convex? The answer is negative.",
     "significance": "key",
-    "prerequisites": [
-      "complex polynomials",
-      "connected components",
-      "convex sets in ℂ"
-    ],
     "relatedConcepts": [
       "polynomial lemniscates",
       "convexity",
       "Erdős–Herzog–Piranian",
       "complex analysis"
+    ],
+    "prerequisites": [
+      "complex polynomials",
+      "connected components",
+      "convex sets in ℂ"
     ]
   },
   {
     "id": "ann-e1047-grunsky-false",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 29,
-      "endLine": 41
+    "anchor": {
+      "type": "declaration",
+      "name": "grunskyConjecture_false",
+      "kind": "theorem"
     },
     "type": "insight",
     "title": "Grunsky's Conjecture is False",
     "content": "The conjecture that every lemniscate component is convex is **refuted**. The witness is **Goodman's polynomial** $f(z) = (z^2+1)(z-2)^2$ at the critical level $c = 5^{3/2}/4$: at this level a component of the lemniscate fails to be convex.\n\nWhat was once an `axiom` (`goodman_counterexample`) is now a genuine **theorem**: the non-convex component is exhibited by the machine-checked certificate `Erdos1047OQ02Cert.goodman_counterexample_proof` (0 sorry / 0 axiom), and convexity-for-all would contradict it.",
     "mathContext": "$\\neg\\,\\text{grunskyConjecture}$: there exist monic $f$ and $c > 0$ with a non-convex component of $\\{|f| \\le c\\}$. Witness $f(z) = (z^2+1)(z-2)^2$, $c = 5^{3/2}/4$.",
     "significance": "key",
-    "prerequisites": [
-      "ann-e1047-overview"
-    ],
     "relatedConcepts": [
       "Goodman polynomial",
       "counterexample",
       "non-convex components"
+    ],
+    "prerequisites": [
+      "ann-e1047-overview"
     ]
   },
   {
     "id": "ann-e1047-solved",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 43,
-      "endLine": 45
+    "anchor": {
+      "type": "declaration",
+      "name": "erdos_1047",
+      "kind": "theorem"
     },
     "type": "insight",
     "title": "Erdős #1047: Solved",
     "content": "The headline statement of Erdős Problem #1047, recorded under its problem number. It is definitionally `grunskyConjecture_false`: not all lemniscate components are convex, so the answer to the problem is **NO**.",
     "mathContext": "$\\text{erdos\\_1047} : \\neg\\,\\text{grunskyConjecture}$, by definition equal to $\\text{grunskyConjecture\\_false}$.",
     "significance": "key",
-    "prerequisites": [
-      "ann-e1047-grunsky-false"
-    ],
     "relatedConcepts": [
       "Erdős problems"
+    ],
+    "prerequisites": [
+      "ann-e1047-grunsky-false"
     ]
   },
   {
     "id": "ann-e1047-counterexample",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 47,
-      "endLine": 54
+    "anchor": {
+      "type": "declaration",
+      "name": "erdos_1047_counterexample",
+      "kind": "theorem"
     },
     "type": "technique",
     "title": "The Explicit Counterexample",
     "content": "The existential form of the result, packaging the explicit witness: a monic polynomial of positive degree (`goodmanPolynomial`), a positive level (`goodmanCriticalValue`, positive by `positivity`), and a point $z_0$ on the lemniscate whose component is non-convex. The final witness is supplied directly by the certificate `goodman_counterexample_proof`.",
     "mathContext": "$\\exists f \\text{ monic}, \\deg f > 0, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with the component of $z_0$ non-convex. Instantiated at $f = (z^2+1)(z-2)^2$, $c = 5^{3/2}/4$.",
     "significance": "supporting",
-    "prerequisites": [
-      "ann-e1047-grunsky-false"
-    ],
     "relatedConcepts": [
       "existential witness",
       "Goodman polynomial",
       "positivity"
+    ],
+    "prerequisites": [
+      "ann-e1047-grunsky-false"
     ]
   },
   {
     "id": "ann-e1047-answer",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 56,
-      "endLine": 60
+    "anchor": {
+      "type": "declaration",
+      "name": "erdos_1047_answer",
+      "kind": "theorem"
     },
     "type": "context",
     "title": "The Answer, Stated Cleanly",
     "content": "A streamlined existential restatement of the answer, dropping the monic/degree bookkeeping to leave just the essential claim: there is a polynomial, a level, and a boundary point whose lemniscate component is not convex. Derived in two lines from `erdos_1047_counterexample`.",
     "mathContext": "$\\exists f, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with a non-convex component — the minimal form of \"some lemniscate component is non-convex\".",
     "significance": "supporting",
-    "prerequisites": [
-      "ann-e1047-counterexample"
-    ],
     "relatedConcepts": [
       "existential statement"
+    ],
+    "prerequisites": [
+      "ann-e1047-counterexample"
     ]
   },
   {
     "id": "ann-e1047-axiom-audit",
     "proofId": "erdos-1047",
-    "range": {
-      "startLine": 64,
-      "endLine": 70
+    "anchor": {
+      "type": "block-comment",
+      "contains": "Axiom audit"
     },
     "type": "insight",
     "title": "Axiom-Free (Machine-Verified)",
     "content": "A Docker-verified audit (3061 jobs, 2026-06-18): `#print axioms` for `erdos_1047`, `grunskyConjecture_false`, and `erdos_1047_answer` reports exactly `[propext, Classical.choice, Quot.sound]` — Mathlib's standard foundational axioms. No problem-specific axiom remains (the former `goodman_counterexample` is now the proved theorem `goodman_counterexample_proof`), no `sorry`, and no `Lean.ofReduceBool`. Erdős #1047 is therefore **verified**, not merely axiomatized.",
     "mathContext": "Trusted base $= \\{\\text{propext}, \\text{Classical.choice}, \\text{Quot.sound}\\}$ only — no `sorry`, no `Lean.ofReduceBool`, no problem-specific axiom.",
     "significance": "key",
-    "prerequisites": [
-      "ann-e1047-grunsky-false"
-    ],
     "relatedConcepts": [
       "axiom audit",
       "formal verification",
       "trusted kernel"
+    ],
+    "prerequisites": [
+      "ann-e1047-grunsky-false"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -97,92 +97,36 @@
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Lemniscate Definitions",
-      "summary": "Basic definitions: lemniscate, strictLemniscate, lemniscateBoundary",
-      "startLine": 50,
-      "endLine": 67,
-      "mathContext": "Lemniscate: $\\\\{z : |f(z)| = c\\\\}$. Sublevel set: $\\\\{z : |f(z)| \\\\leq c\\\\}$. Strict: $\\\\{z : |f(z)| < c\\\\}$."
+      "id": "overview",
+      "title": "Overview: Axiom-Free Relocation",
+      "summary": "File docstring — why the four headline theorems live in Erdos1047Main.lean (downstream of the geometric certificate) and Erdős #1047 background.",
+      "startLine": 1,
+      "endLine": 27,
+      "mathContext": "Lemniscate $E_c(f)=\\{z:|f(z)|\\le c\\}$ for monic $f$. Grunsky's question (Erdős–Herzog–Piranian 1958): must every connected component of $E_c(f)$ be convex?"
     },
     {
-      "id": "properties",
-      "title": "Lemniscate Properties",
-      "summary": "Closedness, compactness, and component counting theorems",
-      "startLine": 68,
-      "endLine": 84,
-      "mathContext": "Sublevel sets are closed and compact. Component count depends on root distribution and level $c$."
+      "id": "grunsky-false",
+      "title": "Grunsky's Conjecture is False",
+      "summary": "grunskyConjecture_false and its problem-numbered alias erdos_1047: not all lemniscate components are convex (answer NO), via the discharged Goodman counterexample.",
+      "startLine": 29,
+      "endLine": 45,
+      "mathContext": "$\\neg\\,\\text{grunskyConjecture}$ from $\\text{goodman\\_counterexample\\_proof}$, witnessed by $f(z)=(z^2+1)(z-2)^2$ at $c=5^{3/2}/4$."
     },
     {
-      "id": "components",
-      "title": "Connected Components",
-      "summary": "Component counting and componentContaining helper",
-      "startLine": 85,
-      "endLine": 103,
-      "mathContext": "Connected components of $\\\\{|f(z)| \\\\leq c\\\\}$. For small $c$: components cluster near roots. For large $c$: single component."
+      "id": "counterexample",
+      "title": "The Explicit Counterexample",
+      "summary": "erdos_1047_counterexample and erdos_1047_answer: the existential forms packaging Goodman's monic polynomial, positive critical level, and a boundary point with a non-convex component.",
+      "startLine": 47,
+      "endLine": 60,
+      "mathContext": "$\\exists f\\text{ monic},\\deg f>0,\\exists c>0,\\exists z_0\\in\\{|f|\\le c\\}$ whose component is non-convex."
     },
     {
-      "id": "convexity",
-      "title": "Convexity in ℂ",
-      "summary": "IsConvexComplex definition and closedBall convexity",
-      "startLine": 104,
-      "endLine": 118,
-      "mathContext": "Convexity: $S$ is convex if $\\\\forall x,y \\\\in S$, the line segment $[x,y] \\\\subseteq S$. Closed disks are convex."
-    },
-    {
-      "id": "grunsky",
-      "title": "The Grunsky Conjecture",
-      "summary": "Statement of grunskyConjecture and grunskyConjecture_false",
-      "startLine": 119,
-      "endLine": 134,
-      "mathContext": "Grunsky conjecture (faithful form): all connected components of $\\\\{|f(z)| \\\\leq c\\\\}$ are convex for every $c > 0$. DISPROVED. The negation grunskyConjecture_false is now a theorem (from goodman_counterexample), not an axiom."
-    },
-    {
-      "id": "pommerenke",
-      "title": "Pommerenke's Counterexample",
-      "summary": "The 1961 counterexample: z^k(z-a) for large k",
-      "startLine": 135,
-      "endLine": 167,
-      "mathContext": "Pommerenke (1961): $f(z) = z^k(z-a)$ for large $k$. The sublevel set near 0 is non-convex (elongated toward $a$)."
-    },
-    {
-      "id": "goodman",
-      "title": "Goodman's Counterexamples",
-      "summary": "(z²+1)(z-2)² and the simple-roots degree-4 example",
-      "startLine": 168,
-      "endLine": 197,
-      "mathContext": "Goodman: $f(z) = (z^2+1)(z-2)^2$. Degree-4 with simple roots. Non-convex component."
-    },
-    {
-      "id": "referee",
-      "title": "Referee's Example",
-      "summary": "z(z⁵-1) with symmetric root configuration",
-      "startLine": 198,
-      "endLine": 220,
-      "mathContext": "Referee example: $f(z) = z(z^5-1)$. Symmetric root configuration on unit circle. Non-convex sublevel near origin."
-    },
-    {
-      "id": "positive",
-      "title": "Positive Results",
-      "summary": "Single-root lemniscates are disks (hence convex)",
-      "startLine": 221,
-      "endLine": 231,
-      "mathContext": "Single-root lemniscates: $\\\\{|z-a|^n \\\\leq c\\\\} = \\\\overline{B}(a, c^{1/n})$ (disk). Always convex."
-    },
-    {
-      "id": "open-question",
-      "title": "Goodman's Open Question",
-      "summary": "maxNonConvexComponents as a function of degree",
-      "startLine": 232,
-      "endLine": 250,
-      "mathContext": "OPEN: what is $\\\\max$ number of non-convex components as a function of degree $n$?"
-    },
-    {
-      "id": "main",
-      "title": "Main Results Summary",
-      "summary": "erdos_1047 theorem and existence of counterexamples",
-      "startLine": 251,
-      "endLine": 252,
-      "mathContext": "DISPROVED (Pommerenke 1961). Components can be non-convex even for arbitrarily small $c > 0$."
+      "id": "axiom-audit",
+      "title": "Axiom Audit",
+      "summary": "Docker-verified #print axioms: each headline theorem rests only on propext, Classical.choice, Quot.sound — no problem-specific axiom, no sorry, no Lean.ofReduceBool.",
+      "startLine": 64,
+      "endLine": 70,
+      "mathContext": "Trusted base $=\\{\\text{propext},\\text{Classical.choice},\\text{Quot.sound}\\}$ only."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Problem

PR #25695 made **Erdős #1047 axiom-free** by relocating its four headline theorems into a new `Erdos1047Main.lean` (70 lines) and repointing `meta.proofRepoPath` at it. The entry's annotations and sections were left behind, authored against the original 265-line `Erdos1047Problem.lean`:

- All **17 annotations** resolved *out of bounds* (`file has 71 lines`) → silently dropped → the page showed **zero annotations**.
- The **11 sections** pointed at lines 50–252 of a 70-line file.

`tsx scripts/annotations/build.ts` resolves/validates against `meta.meta.proofRepoPath`, which is now `Erdos1047Main.lean`, so the displayed file and the annotation/section metadata had completely diverged.

## Fix

Re-align the entry to the file the gallery actually displays (`Erdos1047Main.lean`):

- **Added `annotations.source.json`** (anchor-based — robust to future line drift, unlike the old line-based file). 6 annotations cover: the header docstring (overview + Grunsky/Pommerenke/Goodman history), `grunskyConjecture_false` / `erdos_1047`, the explicit counterexample (`erdos_1047_counterexample` / `erdos_1047_answer`), and the axiom-audit footer. The build regenerates `annotations.json` from it.
- **Rewrote the 11 stale sections → 4** matching Main.lean's actual structure (overview / Grunsky disproof / counterexample / axiom audit).

Definition-level material (lemniscate defs, Pommerenke parameter choices, referee's example) lives in `Erdos1047Problem.lean`, which is no longer the displayed source, so it is folded into framing rather than anchored to constructs absent from Main.lean.

## Verification

- All 6 anchors resolve (verified via the resolver); `build.ts` reports **no errors** for erdos-1047.
- meta.json round-trip touched only the `sections` array (25 ins / 81 del); JSON validated.
- `leanFile` stats (which describe the broader Problem.lean development via `additionalFiles`) and the `verified` / axiom-free status are **unchanged**.