### PR TITLE
audit(wolstenholme-theorem-oq-02): disclose Lean.ofReduceBool from native_decide

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13650,9 +13650,9 @@
     },
     "wolstenholme-theorem-oq-02": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T13:45:45Z",
+      "result": "issues-fixed"
     },
     "wolstenholme-theorem-oq-03": {
       "auditCount": 2,

--- a/src/data/proofs/wolstenholme-theorem-oq-02/meta.json
+++ b/src/data/proofs/wolstenholme-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 30,
     "defCount": 5,
     "lineCount": 262,
@@ -53,7 +53,7 @@
       "Proof that every Wolstenholme prime satisfies the ordinary Wolstenholme theorem (mod p³)"
     ],
     "dateAdded": "2026-03-23",
-    "assumptions": "3 axioms: wp_cb_16843 and wp_cb_2124679 (binomial coefficients too large for kernel computation), no_other_wp_below_billion (McIntosh-Roettger 2008 computational search). All verified computationally in the literature.",
+    "assumptions": "4 assumptions: 3 axiom declarations — wp_cb_16843 and wp_cb_2124679 (binomial coefficients too large for kernel computation), no_other_wp_below_billion (McIntosh-Roettger 2008 computational search) — plus Lean.ofReduceBool, introduced by native_decide. native_decide proves the substantive in-file results prime_16843 and prime_2124679 (feeding isWP_16843/isWP_2124679 and the headline exists_two_distinct_wp) as well as the central modular residue facts (mod 4/8/12); it trusts the compiler's kernel reduction rather than the Lean kernel proper, so these results are not kernel-verified. All computational claims are corroborated in the literature (McIntosh-Roettger 2007/2008). leanFile.axiomCount counts only the 3 literal axiom declarations.",
     "prerequisites": [
       "Binomial coefficients and Wolstenholme's theorem",
       "Modular arithmetic and prime residue classes",


### PR DESCRIPTION
## Gallery Integrity Audit — wolstenholme-theorem-oq-02

**Result: ISSUES-FIXED.** "Wolstenholme Primes and the Mod 4 Question". `status=axiomatized` / `badge=axiom` were already correct, but the entry omitted the `native_decide` compiler-trust axiom.

### Issue
`proofs/Proofs/WolstenholmePrimeMod4.lean` uses `native_decide` (20 calls) to discharge **substantive named results presented as verified**:
- `prime_16843` / `prime_2124679` (`Nat.Prime`, L109/112) — which feed `isWP_16843`, `isWP_2124679`, and the headline `exists_two_distinct_wp` ("At least two distinct Wolstenholme primes exist")
- the central `mod 4 / 8 / 12` residue facts (the entry's core observation)

Per the repo's **Axiom Integrity Policy**, `native_decide` on substantive results depends on `Lean.ofReduceBool` (the proof is *not* axiom-free) and must be disclosed and counted.

### Fix
| Field | Before | After |
|-------|--------|-------|
| `meta.axiomCount` | 3 | 4 (3 literal axioms + `Lean.ofReduceBool`) |
| `assumptions` | no mention of native_decide | discloses `Lean.ofReduceBool` and the results it backs |
| `leanFile.axiomCount` | 3 | 3 (unchanged — counts literal `axiom` declarations only) |

`status`/`badge` unchanged (already `axiomatized`/`axiom`).

### Verified counts (match meta)
262 lines, 30 theorems, 5 defs, **0 sorries**, 0 True stubs. The 3 literal axioms (`wp_cb_16843`, `wp_cb_2124679`, `no_other_wp_below_billion`) are correctly disclosed and attributed to McIntosh-Roettger (2007/2008).

Tracker `auditCount` 3 -> 4, result `issues-fixed`.

---
Discovered during gallery integrity audit.