### PR TITLE
research(simson-line-theorem-oq-01): antipodal Simson lines are perpendicular

### DIFF
--- a/proofs/Proofs/SimsonLineTheorem.lean
+++ b/proofs/Proofs/SimsonLineTheorem.lean
@@ -199,4 +199,38 @@ theorem simson_bisects_orthocenter_segment {a b c p : ℂ}
   rw [map_mul, Complex.conj_conj]
   exact (simson_bisects_key ha hb hc hp).symm
 
+/-! ## Simson lines of antipodal points are perpendicular
+
+A second classical strengthening of Simson's theorem: if `P` and its **antipode** `-P` (the
+diametrically opposite point on the circumcircle, centre `0`) both lie on the unit circle, then
+the Simson line of `P` and the Simson line of `-P` are **perpendicular**.
+
+The Simson line of a point `q` is spanned by the edge-vector `F_BC - F_AB` of its triangle of
+feet, which `foot_diff` puts in the closed form `(c - a) * (1 - b * conj q) / 2`. For the two
+antipodal points the `conj q` factors are `conj p` and `conj (-p) = -conj p`, and the Hermitian
+product `(F_BC - F_AB)(P) * conj ((F_BC - F_AB)(-P))` reduces — via `conj z = z⁻¹` on the unit
+circle — to `|c - a|² / 4 * (conj b * p - b * conj p)`, a purely imaginary number (it is `z - conj z`
+for `z = conj b * p`). Its vanishing real part is exactly perpendicularity of the two direction
+vectors, hence of the two Simson lines. -/
+
+/-- **Antipodal Simson lines are perpendicular.** For `A, B, C, P` on the unit circle, the Simson
+line of `P` and the Simson line of the antipode `-P` are orthogonal: the real part of
+`(F_BC(P) - F_AB(P)) * conj (F_BC(-P) - F_AB(-P))` vanishes. Each factor is a direction vector of
+the respective Simson line (`foot_diff`, `simson_collinear`), so the vanishing real part of their
+Hermitian product is precisely perpendicularity of the two lines. -/
+theorem antipodal_simson_perp {a b c p : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
+    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) :
+    ((foot b c p - foot a b p) * conj (foot b c (-p) - foot a b (-p))).re = 0 := by
+  apply re_eq_zero_of_conj_eq_neg
+  rw [foot_diff, foot_diff]
+  simp only [map_mul, map_sub, map_add, map_neg, map_div₀, map_one, map_ofNat, Complex.conj_conj]
+  rw [conj_eq_inv ha, conj_eq_inv hb, conj_eq_inv hc, conj_eq_inv hp]
+  have ha0 := ne_zero_of_normSq_one ha
+  have hb0 := ne_zero_of_normSq_one hb
+  have hc0 := ne_zero_of_normSq_one hc
+  have hp0 := ne_zero_of_normSq_one hp
+  field_simp
+  ring
+
 end SimsonLineTheorem

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -47,14 +47,15 @@
       "Difference identity foot bc p − foot ab p = (c − a)(1 − b·conj p)/2 as a pure ring fact",
       "Collinearity reduced to the complex criterion w = conj w (simson_key), then to vanishing signed area w.im = 0 (simson_collinear)",
       "Whole theorem discharged by conj z = z⁻¹ substitution + field_simp + ring, no axioms or sorries",
-      "Bisection theorem: the Simson line of P passes through the midpoint of PH (H = orthocenter = A+B+C for the unit circumcircle), proved by the same conj z = z^-1 + field_simp + ring engine (simson_bisects_orthocenter_segment)"
+      "Bisection theorem: the Simson line of P passes through the midpoint of PH (H = orthocenter = A+B+C for the unit circumcircle), proved by the same conj z = z^-1 + field_simp + ring engine (simson_bisects_orthocenter_segment)",
+      "Antipodal perpendicularity: the Simson lines of P and its antipode -P are perpendicular (antipodal_simson_perp); the antipode flips conj p -> -conj p, collapsing the Hermitian product of the two foot-difference directions to |c-a|²/4·(conj b·p - b·conj p), purely imaginary, so its real part vanishes — same conj z = z⁻¹ + field_simp + ring engine"
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 203,
+    "lineCount": 237,
     "assumptions": "0 axioms. 0 sorries. Fully verified. Circumcircle normalised to the unit circle (Complex.normSq = 1) without loss of generality; on that normalisation the orthocenter is A+B+C.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 3
   },
   "sections": [
@@ -153,9 +154,9 @@
       "ComplexConjugate"
     ],
     "namespace": "SimsonLineTheorem",
-    "lineCount": 203,
+    "lineCount": 237,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/SimsonLineTheorem.lean"


### PR DESCRIPTION
## Summary

Adds a new fully-verified theorem to the already-`verified` `SimsonLineTheorem.lean`:
**the Simson lines of a point `P` and its antipode `-P` (on the unit circumcircle) are perpendicular** — a classical strengthening of Simson's theorem that the entry's `historicalContext` already cites but had not yet formalized.

```lean
theorem antipodal_simson_perp {a b c p : ℂ}
    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) :
    ((foot b c p - foot a b p) * conj (foot b c (-p) - foot a b (-p))).re = 0
```

## Math

The Simson-line direction is the foot-difference `foot b c q - foot a b q = (c-a)(1 - b·conj q)/2` (`foot_diff`). The antipode sends `conj q ↦ -conj q`, so the Hermitian product of the two direction vectors collapses (using `conj z = z⁻¹` on the unit circle) to

  `|c-a|²/4 · (conj b · p − b · conj p) = |c-a|²/4 · (z − conj z)`,  with `z = conj b · p`,

which is purely imaginary, so its real part vanishes — exactly perpendicularity of the two directions, hence of the two Simson lines. Proved with the same `conj z = z⁻¹` substitution + `field_simp; ring` engine that drives `simson_key`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SimsonLineTheorem` → **Build completed successfully (3062 jobs)**.
- 0 axioms, 0 sorries, no `native_decide` (pure `field_simp`/`ring`/`simp`/`rw`). The entry remains `verified`/`original`.
- Gallery meta updated: `lineCount` 203→237, `theoremCount` 10→11, new `originalContributions` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)