### PR TITLE
audit(triangular-reciprocals-oq-03): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13548,8 +13548,8 @@
     },
     "triangular-reciprocals-oq-03": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T13:53:17Z",
       "result": "clean"
     },
     "triangular-reciprocals-oq-03-oq-02": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: triangular-reciprocals-oq-03 (Alternating Sum of Triangular Reciprocals = 4·ln2 − 2)
**File**: `proofs/Proofs/TriangularReciprocalAlternatingOQ03.lean`

## Integrity Checks

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status / badge | axiomatized / axiom | Tier C (2 axioms) | ✓ |
| axiomCount | 2 | 2 (`alternating_harmonic_hasSum`, `shifted_alternating_hasSum`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 165 | 165 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

- Both axioms encode the Mercator series boundary convergence (Abel's theorem, not yet in Mathlib) and are disclosed in `assumptions`.
- Main theorem `alternating_triangular_sum` is genuinely derived from the 2 axioms via partial fractions — no axiom masking.
- All 3 `originalContributions` are real deliverables. No `mainTheorems` field → no phantom theorem names.

No metadata changes needed. Tracker bump 3→4 (clean).

---
Gallery integrity audit.