### PR TITLE
Fix annotation resolver: accept definition type for inductive constructs

### DIFF
--- a/scripts/annotations/resolver.ts
+++ b/scripts/annotations/resolver.ts
@@ -298,7 +298,7 @@ export function validateLineAnnotations(
     const typeMatches =
       (ann.type === 'theorem' && (construct.kind === 'theorem' || construct.kind === 'example')) ||
       (ann.type === 'lemma' && construct.kind === 'lemma') ||
-      (ann.type === 'definition' && (construct.kind === 'def' || construct.kind === 'abbrev' || construct.kind === 'structure')) ||
+      (ann.type === 'definition' && (construct.kind === 'def' || construct.kind === 'abbrev' || construct.kind === 'structure' || construct.kind === 'inductive')) ||
       (ann.type === 'axiom' && construct.kind === 'axiom') ||
       (ann.type === 'inductive' && construct.kind === 'inductive') ||
       (ann.type === 'structure' && construct.kind === 'structure') ||


### PR DESCRIPTION
## Summary

Drains the last 2 gallery-wide annotation **type-mismatch** validation errors (`scripts/annotations/build.ts`):

```
[euler-polyhedral-oq-01] ep-spanning-build:   Annotation type "definition" but found "inductive" at line 66
[euler-polyhedral-oq-01] ep-degeneracy-build: Annotation type "definition" but found "inductive" at line 656
```

## Root cause

The site annotation schema (`src/types/proof.ts` `AnnotationType`) only permits `theorem | lemma | definition | tactic | concept | insight | warning`. `inductive` is **not** a valid annotation type, so authors must annotate `inductive` declarations as `definition` (this convention was established in #25776, which changed these very annotations from the off-schema `inductive` → `definition`).

However the resolver's `typeMatches` (`scripts/annotations/resolver.ts`) only let a `definition` annotation match `def | abbrev | structure` — not `inductive`. So the two conventions contradicted each other: the schema forbids the `inductive` annotation type, and the resolver rejects the `definition` annotation type against an `inductive` construct. Result: two unfixable type-mismatch errors.

## Fix

Allow a `definition` annotation to match an `inductive` Lean construct (an inductive *is* a definition). The annotations at `SpanningBuild` (L66) and `DegeneracyBuild` (L656) now validate.

## Verification

- `DISABLE_BUILD_CACHE=1 npx tsx scripts/annotations/build.ts`: type-mismatch errors **2 → 0**.
- Line-drift (`No Lean construct found`) count unchanged at 2387 — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)