### PR TITLE
audit(triangular-reciprocals): fix phantom mainTheorems (triangular_reciprocal_sum doesn't exist)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13535,10 +13535,10 @@
       "result": "clean"
     },
     "triangular-reciprocals": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T00:00:00Z",
+      "result": "issues-fixed"
     },
     "triangular-reciprocals-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/triangular-reciprocals/meta.json
+++ b/src/data/proofs/triangular-reciprocals/meta.json
@@ -198,10 +198,28 @@
   ],
   "mainTheorems": [
     {
-      "name": "triangular_reciprocal_sum",
+      "name": "sum_reciprocals_triangular",
       "type": "core",
-      "description": "Sum of reciprocals of triangular numbers: sum 2/(n(n+1)) = 2",
-      "leanType": "HasSum (fun n => 2 / ((n+1) * (n+2))) 2"
+      "description": "Sum of reciprocals of triangular numbers: ∑ 2/(n(n+1)) = 2 (Wiedijk #42), proved via telescoping and an ε-N limit argument",
+      "leanType": "HasSum (fun n : ℕ => if n = 0 then 0 else (2 : ℝ) / ((n : ℝ) * (n + 1))) 2"
+    },
+    {
+      "name": "tsum_reciprocals_triangular",
+      "type": "corollary",
+      "description": "The tsum form of the main theorem: ∑' 2/(n(n+1)) = 2",
+      "leanType": "∑' n : ℕ, (if n = 0 then 0 else (2 : ℝ) / ((n : ℝ) * (n + 1))) = 2"
+    },
+    {
+      "name": "sum_reciprocals_one",
+      "type": "corollary",
+      "description": "Unscaled corollary: ∑ 1/(n(n+1)) = 1",
+      "leanType": "HasSum (fun n : ℕ => if n = 0 then 0 else (1 : ℝ) / ((n : ℝ) * (n + 1))) 1"
+    },
+    {
+      "name": "reciprocal_triangular",
+      "type": "supporting",
+      "description": "Connection to triangular numbers: 1/T_n = 2/(n(n+1)), verifying exact division by 2",
+      "leanType": "(n : ℕ) → (hn : n ≠ 0) → (1 : ℝ) / (triangular n) = 2 / (n * (n + 1))"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — triangular-reciprocals

**Result**: issues-fixed (phantom mainTheorems)

### Issue (phantom mainTheorems)
`meta.json` listed a single `mainTheorems` entry:
- name: `triangular_reciprocal_sum`
- leanType: `HasSum (fun n => 2 / ((n+1) * (n+2))) 2`

**No theorem named `triangular_reciprocal_sum` exists** in `Proofs/TriangularNumberReciprocals.lean`. The leanType was also idealized (the real definition guards `if n = 0 then 0 else ...`). The genuine headline theorem is `sum_reciprocals_triangular`.

```
$ grep -n triangular_reciprocal_sum proofs/Proofs/TriangularNumberReciprocals.lean
(no match)
```

### Fix
Replaced the phantom entry with 4 genuine theorems, leanTypes copied verbatim from the file:
- `sum_reciprocals_triangular` (core) — `HasSum (fun n : ℕ => if n = 0 then 0 else (2 : ℝ) / ((n : ℝ) * (n + 1))) 2`
- `tsum_reciprocals_triangular` (corollary) — tsum form
- `sum_reciprocals_one` (corollary) — unscaled sum = 1
- `reciprocal_triangular` (supporting) — 1/T_n = 2/(n(n+1))

### Otherwise CLEAN
- 308 lines, 9 theorems, 1 definition, **0 sorries, 0 axioms** — all match meta.
- `verified` / `mathlib` correct (Tier B): p-series convergence via Mathlib (`Real.summable_nat_rpow_inv`, `Summable.of_nonneg_of_le`); the sum value (= 2) proved independently via telescoping + ε-N argument.
- The 5 `native_decide` are incidental anonymous pedagogical examples on trivial values (`triangular 1 = 1`, …), not in `originalContributions`/`mainTheorems` → leave (no `ofReduceBool` disclosure needed; consistent with bezout-identity-oq-01 vetted-leave precedent).
- Tracker bumped 3→4, result `issues-fixed`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)