### PR TITLE
audit(triangle-angle-sum): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13493,9 +13493,9 @@
       "result": "clean"
     },
     "triangle-angle-sum": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-clean-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:30:00Z",
       "result": "clean"
     },
     "triangle-angle-sum-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — triangle-angle-sum (Wiedijk #27)

**Result: CLEAN.** No issues found. Tracker bumped 3→4.

### Verification against `Proofs/TriangleAngleSum.lean`
| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| lineCount | 157 | 157 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier classification (Tier B — Mathlib bridge)
- `status: verified` / `badge: mathlib` is correct. The main result `triangle_angle_sum` is a direct application of Mathlib's `EuclideanGeometry.angle_add_angle_add_angle_eq_pi`.
- **No delegation opacity**: the Mathlib dependency is disclosed in the overview ("direct application of Mathlib's..."), description, proofStrategy, and the `mathlib` badge.
- `mainTheorems.triangle_angle_sum` is a real in-file theorem; declared `leanType` matches the actual signature.
- All 5 `originalContributions` map to genuine theorems: `triangle_angle_sum_of_distinct`, `third_angle_eq`, `right_triangle_acute_sum`, `exterior_angle_theorem`, `triangle_angle_sum_degrees`.

No overclaim, no axiom masking, no phantom theorems.

---
Discovered during gallery integrity audit loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)