### PR TITLE
Enrich erdos-1047: surface headline erdos_1047 theorem as its own section

### DIFF
--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -107,10 +107,18 @@
     {
       "id": "grunsky-false",
       "title": "Grunsky's Conjecture is False",
-      "summary": "grunskyConjecture_false and its problem-numbered alias erdos_1047: not all lemniscate components are convex (answer NO), via the discharged Goodman counterexample.",
+      "summary": "grunskyConjecture_false: not all lemniscate components are convex. The negation of the faithful ∀ c > 0 conjecture is discharged from the machine-checked Goodman counterexample (no longer an axiom).",
       "startLine": 29,
-      "endLine": 45,
+      "endLine": 41,
       "mathContext": "$\\neg\\,\\text{grunskyConjecture}$ from $\\text{goodman\\_counterexample\\_proof}$, witnessed by $f(z)=(z^2+1)(z-2)^2$ at $c=5^{3/2}/4$."
+    },
+    {
+      "id": "erdos-1047-solved",
+      "title": "Erdős #1047: Solved (Answer NO)",
+      "summary": "erdos_1047 — the headline problem-numbered alias of grunskyConjecture_false, recording the resolution of Erdős Problem #1047: the components need not be convex.",
+      "startLine": 43,
+      "endLine": 45,
+      "mathContext": "$\\text{erdos\\_1047} := \\text{grunskyConjecture\\_false} : \\neg\\,\\text{grunskyConjecture}$."
     },
     {
       "id": "counterexample",


### PR DESCRIPTION
Enrichment pass for `erdos-1047` (Erdős #1047: Convexity of Polynomial Lemniscates).

## Change
Split the bundled section "Grunsky's Conjecture is False" (lines 29–45 of the displayed `Erdos1047Main.lean`) into two sections, aligned with the boundaries the annotations already use:
- **grunsky-false** (29–41): `grunskyConjecture_false`
- **erdos-1047-solved** (43–45): the headline problem-numbered alias `erdos_1047`

The headline #1047 SOLVED statement now has its own navigable section instead of being folded into the Grunsky-negation section.

## Verification
- Quality 98 → 100 (sections 4 → 5; the scorer's last 2 points).
- Annotation build: 0 errors for erdos-1047; all 6 annotations + 5 sections resolve against the 70-line `Erdos1047Main.lean`.
- Meta confirmed accurate after the axiom-discharge (#25695): `axiomCount: 0`, `status: verified`, `lineCount: 842` = exact sum of all 5 development files, and the `leanFile` block (Problem.lean: 265L / 10 thm / 13 def / 0 ax / 0 sorry) matches the source.
- 6 crossReferences all point to existing gallery entries (no phantoms).

No prose was added (scorer is saturated gallery-wide at avg quality ≈99.95); this is a structural navigation improvement only.