### PR TITLE
audit(three-place-identity): replace phantom mainTheorems with actual file theorems

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13476,9 +13476,9 @@
     },
     "three-place-identity": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:15:13Z",
+      "result": "issues-fixed"
     },
     "three-place-identity-oq-02": {
       "auditCount": 3,

--- a/src/data/proofs/three-place-identity/meta.json
+++ b/src/data/proofs/three-place-identity/meta.json
@@ -251,10 +251,22 @@
   ],
   "mainTheorems": [
     {
-      "name": "three_place_identity",
+      "name": "universality",
       "type": "core",
-      "description": "A combinatorial identity involving three-place functions",
-      "leanType": "three_place_sum a b c = normalized_value a b c"
+      "description": "The Universality Theorem: for any ZF set model, the membership derived via the D2/D1 bridges coincides with the original membership, so identity theory interprets ZF.",
+      "leanType": "(M : SetModel U) (y x : U) : M.derivedMem y x <-> M.mem y x"
+    },
+    {
+      "name": "roundtrip",
+      "type": "core",
+      "description": "The Round-Trip Theorem: starting from a well-founded membership relation, forming Id via D2 and then deriving membership via D1 recovers the original membership (Foundation is essential).",
+      "leanType": "(M : WellFoundedMembership U) (y x : U) : MemFromId (RelativeIdentity.fromMembership M) y x <-> M.mem y x"
+    },
+    {
+      "name": "IdFromMem_iff_same_status",
+      "type": "supporting",
+      "description": "Bridge D2 equals Quine indistinguishability: x regards y, z as identical iff they have the same membership status in x.",
+      "leanType": "(mem : U -> U -> Prop) (x y z : U) : IdFromMem mem x y z <-> (mem y x <-> mem z x)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — three-place-identity

**Tier:** A (verified/original) — confirmed correct.

### Issue found & fixed (phantom mainTheorems)

The `mainTheorems` field listed a templated phantom:

```json
{ "name": "three_place_identity",
  "description": "A combinatorial identity involving three-place functions",
  "leanType": "three_place_sum a b c = normalized_value a b c" }
```

None of `three_place_identity`, `three_place_sum`, or `normalized_value` appear anywhere in `Proofs/ThreePlaceIdentity.lean`, and the proof is Etter's universality theorem (relative-identity ↔ ZF membership), not a combinatorial identity.

Replaced with three genuine in-file theorems (verbatim signatures):
- `universality` — `(M : SetModel U) (y x : U) : M.derivedMem y x <-> M.mem y x`
- `roundtrip` — `(M : WellFoundedMembership U) (y x : U) : MemFromId (RelativeIdentity.fromMembership M) y x <-> M.mem y x`
- `IdFromMem_iff_same_status` — `(mem : U -> U -> Prop) (x y z : U) : IdFromMem mem x y z <-> (mem y x <-> mem z x)`

### Verified clean
- 425 lines, 10 theorems, 13 definitions (3 structures + 10 defs) — matches meta.
- 0 sorries, 0 `axiom` declarations, 0 `native_decide`, 0 `True` stubs.
- `verified`/`original` justified: only the `tauto` tactic is used from Mathlib; all structures (RelativeIdentity, bridges D1/D2, round-trip) built from scratch. No deep Mathlib theorem does the core work — Tier A, not a wrapper.
- `axiomCount` 0, `sorries` 0 accurate. The entry's `alternativeInterpretation` section already discloses the meta/object-level scope carefully (no overclaim).

Tracker `auditCount` 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)