### PR TITLE
Enrich shannon-channel-coding-bec: add BEC-vs-BSC capacity insight

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec/meta.json
@@ -61,7 +61,8 @@
             "The erasure identity H(X|Y) = p · H(X) is the entire engine: it holds for ANY input distribution, not just the optimal one.",
             "The BEC is not weakly symmetric (the erasure column sums to 2p while the others sum to 1 - p), so the parent's symmetric-channel capacity lemmas do not apply -- a separate development is genuinely needed.",
             "Erasure is symmetric in the input symbol, so the capacity-achieving input is still uniform Bernoulli(1/2), exactly as for the BSC.",
-            "Capacity in bits is simply 1 - p: a clean operational reading as the surviving fraction of transmissions."
+            "Capacity in bits is simply 1 - p: a clean operational reading as the surviving fraction of transmissions.",
+            "Erasures are strictly cheaper than errors: because the decoder knows *where* information was lost, C_BEC = 1 - p exceeds the binary symmetric channel's C_BSC = 1 - H₂(p) for every p ∈ (0, 1) (with equality only at the endpoints) -- quantifying the operational value of knowing the location of corruption."
         ]
     },
     "sections": [


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-bec` (Binary Erasure Channel capacity).

## Change
Added a 5th `keyInsight` capturing the classic information-theoretic comparison between the BEC and the BSC:

> Erasures are strictly cheaper than errors: because the decoder knows *where* information was lost, C_BEC = 1 − p exceeds the binary symmetric channel's C_BSC = 1 − H₂(p) for every p ∈ (0, 1) (equality only at the endpoints) — quantifying the operational value of knowing the location of corruption.

This is distinct from the existing four insights (erasure identity, non-weak-symmetry, uniform-input optimality, and the 1 − p operational reading), and ties the entry's C = 1 − p result to the broader channel-capacity landscape.

## Verification
- Quality 98 → 100 (keyInsights 4 → 5; the scorer's last 2 points).
- Annotation build: 0 errors for this entry.
- No structural changes; all 8 annotations, 7 sections, conclusion, and 3 crossReferences were already complete and accurate (axiomatized, axiomCount 3, verified earlier in #25759/#25772).