### PR TITLE
audit(erdos-242): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5521,8 +5521,8 @@
     },
     "erdos-242": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:22:12Z",
       "result": "clean"
     },
     "erdos-243": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-242 (Erdős-Straus Conjecture)

**Result: CLEAN** (4th audit). No meta.json changes required; tracker bumped 3→4.

### Tier classification
Tier C — axiomatized open conjecture. `status: axiomatized`, `badge: axiom` — **correct**.

### Verified exact (meta vs Lean source `Erdos242Problem.lean`)
| Field | meta | actual |
|---|---|---|
| lineCount | 590 | 590 ✓ |
| axiomCount | 1 | 1 (`dyachenko_box`) ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 50 | 50 ✓ |
| definitionCount | 5 | 4 def + 1 structure ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Integrity checks
- **No axiom masking**: main theorem `ErdosStraus_conjecture : ∀ n ≥ 2, ES n` genuinely depends on the sole axiom `dyachenko_box` (reached via `find_ed2_triple`) for the 6 hard residue classes mod 840 `{1,121,169,289,361,529}`. Title, description, and `assumptions` field all disclose the OPEN status and the precise axiom scope.
- **No ofReduceBool**: `hard_residues_no_small_conic` uses kernel `decide`, not `native_decide` — no `Lean.ofReduceBool` dependency.
- **originalContributions all real**: conic (k,d) family, ED2 triple framework, rectangle-hitting lemma, scaling lemma, "no small conic" machine-checked theorem, 23 conic witnesses (verified count = 23), concrete examples n=3,5,7 — all present and proved.
- **No phantom names**: every prose-referenced identifier (`ES_k2_d1`, `ES_k4_d2`, `ES_prime`, `ES_scale`, `coprime_sq_4k1`, `pmod_dvd`, etc.) exists in the file. No `mainTheorems` field, so no phantom-theorem risk.
- **Mathlib usage**: `Nat.Prime.sq_add_sq` (Fermat) used only in the bridge lemma `prime_mod4_one_has_norm_split`, not for the headline result — badge `axiom` (not `mathlib`) is the correct conservative choice for an axiomatized open conjecture.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)