### PR TITLE
audit(erdos-244): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5533,8 +5533,8 @@
     },
     "erdos-244": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:26:19Z",
       "result": "clean"
     },
     "erdos-245": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-244 (Prime Plus Powers of C)

**Result: CLEAN** (4th audit). No meta.json changes; tracker bumped 3→4.

### Tier classification
Tier C — axiomatized, OPEN problem (Kalmár–Erdős). `status: axiomatized`, `badge: axiom` — **correct**. `erdos_244_conjecture` is an unproved `def` Prop.

### Verified exact (meta vs `Erdos244Problem.lean`)
| Field | meta | actual |
|---|---|---|
| lineCount | 233 | 233 ✓ |
| axiomCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 9 | 9 ✓ |
| definitionCount | 8 | 8 ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Integrity checks
- **No axiom masking**: both axioms — `romanoff_theorem` (1934, integer-C case) and `ding_almost_all` (Ding 2025, almost-all C w.r.t. Lebesgue measure) — are cited external results, disclosed by name in `assumptions`. Title/description credit Romanoff and Ding and state the problem is open.
- **originalContributions all real**: representability def (`IsRepresentable`), `representable_nat_iff_real` bridge lemma, the two axiom statements, three constructive proofs (`three_representable`, `five_representable_C2`, `ten_representable_C2`), and `density_vs_universality` (connection to Erdős #10) — all present.
- **No phantom claims**: no `mainTheorems` field.
- **No ofReduceBool**: 0 `native_decide`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)