### PR TITLE
audit(erdos-243): clean re-audit (4th), tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5527,8 +5527,8 @@
     },
     "erdos-243": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:28:54Z",
       "result": "clean"
     },
     "erdos-244": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-243 (Sylvester's Sequence Characterization)

**Result: CLEAN** (4th audit). No meta.json changes; tracker bumped 3→4.

### Tier classification
Tier C — axiomatized, OPEN problem. `status: axiomatized`, `badge: axiom` — **correct**. The conjecture is the axiom `erdos_243`.

### Verified exact (meta vs `Erdos243Problem.lean`)
| Field | meta | actual |
|---|---|---|
| lineCount | 128 | 128 ✓ |
| axiomCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 8 | 8 ✓ |
| definitionCount | 4 | 4 ✓ |
| True stubs | — | 0 ✓ |

### native_decide assessment (5 occurrences)
All 5 `native_decide` are on **non-substantive** concrete computations:
- `sylvester_1..4` (= 3, 7, 43, 1807) — definitional unfolding of the recursive `sylvester` function
- `sylvester_strictMono_small` — a small concrete inequality among the first four values

None feed the headline. The substantive theorems are nd-free: `sylvester_pos` (induction + `decide`/`omega`) and `sylvester_hasRationalReciprocalSum` (derived from the disclosed axiom `sylvester_sum_reciprocals`). Per CLAUDE.md, `Lean.ofReduceBool` is counted only when `native_decide` discharges a **substantive** result the entry presents as verified — consistent with the concrete-example precedent (#25425/#25666), **no ofReduceBool disclosure required**.

### Integrity checks
- **No axiom masking**: both axioms (`erdos_243` = the conjecture; `sylvester_sum_reciprocals` = classical Σ1/sₙ → 1) disclosed by name in `assumptions`.
- **originalContributions all real**: conjecture statement (axiom), Sylvester definition + first values, the `EventuallySylvester`/`HasSylvesterGrowth`/`HasRationalReciprocalSum` predicates, educational framing.
- **No phantom claims**: no `mainTheorems` field.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)