### PR TITLE
audit(erdos-240): fix sorry'd-core status (axiomatized→formalized, axiom→wip)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5509,9 +5509,9 @@
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:32:42Z",
+      "result": "issues-fixed"
     },
     "erdos-241": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -7,7 +7,7 @@
     "author": "Wintner (problem), Pólya (1918), Tijdeman (1973)",
     "sourceUrl": "https://erdosproblems.com/240",
     "date": "1973",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos240Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "gaps",
       "solved"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 2,
     "erdosNumber": 240,
     "erdosUrl": "https://erdosproblems.com/240",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-240 (Gaps Between P-Smooth Numbers)

**Result: ISSUES-FIXED.** Status/badge overclaimed a sorry'd-core formalization.

### The problem
The main theorem `erdos240_answer` (L169) closes its final goal with a **`sorry`** (L174) — deriving `gapsTendToInfinity` from Tijdeman's quantitative bound. Consequently the headline `erdos_240` (`:= erdos240_answer`, L262) and `erdos_240_summary` (L237) typecheck **only because of that sorry**. A second sorry sits in `singleton_large_gaps` (L203).

So the result is **not established even modulo the 3 stated axioms** — there is an additional unproven gap. Yet the meta carried:
- `status: "axiomatized"` — communicates "formalized with stated assumptions" (a clean reduction to axioms)
- `badge: "axiom"`

That overclaims relative to what the kernel guarantees.

### Fix
Per the status table (sorries remaining → `formalized`; Tier C sorry'd core → `wip` badge) and matching gallery convention (72 `formalized` entries; `formalized`+`wip`+sorries is the norm):
- `status`: `axiomatized` → **`formalized`**
- `badge`: `axiom` → **`wip`**

### Unchanged (accurate)
- `axiomCount: 3`, `sorries: 2` — already disclosed in `assumptions`: *"3 axioms: smoothEnum, finite_P_unbounded_gaps, tijdeman_main_theorem. 2 sorries."*
- `erdosProblemStatus: "solved"` — refers to Tijdeman (1973) in the literature; a separate field from formalization completeness, left as-is.

### Counts verified exact (meta vs `Erdos240Problem.lean`)
264L / 3 axioms / 2 sorries / 0 native_decide / 0 True stubs / 5 thm / 5 def — all match.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)