### PR TITLE
research(dirichlet-approximation-oq-01): unbounded-denominator strengthening (+3 thms)

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ01.lean
+++ b/proofs/Proofs/DirichletApproximationOQ01.lean
@@ -78,7 +78,7 @@ theorem infinite_coprime_approx (hξ : Irrational ξ) :
     -- Reduce the `(q.num, q.den).1 / .2` projections to `q.num / q.den`,
     -- then rewrite `q.num/q.den = q` via `Rat.cast_def`.
     show |ξ - (q.num : ℝ) / (q.den : ℝ)| < 1 / (q.den : ℝ) ^ 2
-    have hcast : ((q.num : ℝ) / (q.den : ℝ)) = (q : ℝ) := (Rat.cast_def).symm
+    have hcast : ((q.num : ℝ) / (q.den : ℝ)) = (q : ℝ) := (Rat.cast_def q).symm
     rw [hcast]
     exact hq
   exact ((infinite_image_iff hinj).mpr hS).mono hsub
@@ -97,5 +97,82 @@ theorem exists_good_approx (hξ : Irrational ξ) :
     ∃ q : ℚ, |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2 := by
   obtain ⟨q, hq⟩ := (infinite_good_rat_approx hξ).nonempty
   exact ⟨q, hq⟩
+
+/-- **Bounded-height finiteness (original infrastructure).** The rationals lying
+in a bounded real interval `[a, b]` whose denominator is at most `N` form a
+*finite* set. The numerator/denominator map `q ↦ (q.num, q.den)` embeds them
+into the finite integer box `[-M, M] × [1, N]`, where `M` bounds the numerators
+via `|q.num| = |q|·q.den ≤ max |a| |b| · N`. This is exactly the discreteness
+fact that powers the "unbounded denominators" strengthening below; Mathlib has
+the analogous statement only for *rational* targets (`finite_rat_abs_sub_…`). -/
+theorem finite_bounded_den (a b : ℝ) (N : ℕ) :
+    {q : ℚ | a ≤ (q : ℝ) ∧ (q : ℝ) ≤ b ∧ q.den ≤ N}.Finite := by
+  obtain ⟨M, hM⟩ := exists_nat_ge (max |a| |b| * N)
+  apply Set.Finite.of_finite_image (f := fun q : ℚ => (q.num, q.den))
+  · -- The image is contained in a finite integer box, hence finite.
+    apply Set.Finite.subset
+      ((Finset.Icc (-(M : ℤ)) (M : ℤ) ×ˢ Finset.Icc 1 N).finite_toSet)
+    rintro p ⟨q, ⟨ha, hb, hden⟩, rfl⟩
+    have hdpos : (0 : ℝ) < (q.den : ℝ) := by exact_mod_cast q.pos
+    have hnum : (q.num : ℝ) = (q : ℝ) * (q.den : ℝ) := by
+      rw [Rat.cast_def]; field_simp
+    have hqle : (q : ℝ) ≤ max |a| |b| :=
+      le_trans hb (le_trans (le_abs_self b) (le_max_right _ _))
+    have hqge : -max |a| |b| ≤ (q : ℝ) :=
+      le_trans (le_trans (neg_le_neg (le_max_left _ _)) (neg_abs_le a)) ha
+    have habsq : |(q : ℝ)| ≤ max |a| |b| := abs_le.mpr ⟨hqge, hqle⟩
+    have hdenR : (q.den : ℝ) ≤ (N : ℝ) := by exact_mod_cast hden
+    have habsnum : |(q.num : ℝ)| ≤ (M : ℝ) := by
+      rw [hnum, abs_mul, abs_of_pos hdpos]
+      calc |(q : ℝ)| * (q.den : ℝ)
+          ≤ max |a| |b| * (N : ℝ) := by gcongr
+        _ ≤ (M : ℝ) := hM
+    have hb1 : -(M : ℤ) ≤ q.num := by exact_mod_cast (abs_le.mp habsnum).1
+    have hb2 : q.num ≤ (M : ℤ) := by exact_mod_cast (abs_le.mp habsnum).2
+    simp only [Finset.coe_product, Finset.coe_Icc, Set.mem_prod, Set.mem_Icc]
+    exact ⟨⟨hb1, hb2⟩, q.pos, hden⟩
+  · -- The numerator/denominator map is injective.
+    intro x _ y _ hxy
+    simp only [Prod.mk.injEq] at hxy
+    rw [← Rat.num_div_den x, ← Rat.num_div_den y, hxy.1, hxy.2]
+
+/-- **Unbounded denominators (original strengthening).** For every irrational
+`ξ` and every bound `N`, there remain *infinitely many* good approximations
+`|ξ − q| < 1/q.den²` whose denominator is at least `N`.
+
+Proof: the full good-approximation set is infinite (`infinite_good_rat_approx`),
+while its low-denominator part `{q.den < N}` is finite — each such `q` satisfies
+`|ξ − q| < 1/q.den² ≤ 1`, so it lies in `[ξ−1, ξ+1]` with `q.den ≤ N`, a finite
+set by `finite_bounded_den`. An infinite set minus a finite set is infinite. -/
+theorem infinite_good_approx_large_den (hξ : Irrational ξ) (N : ℕ) :
+    {q : ℚ | |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2 ∧ N ≤ q.den}.Infinite := by
+  have hSinf : {q : ℚ | |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2}.Infinite :=
+    infinite_good_rat_approx hξ
+  have hlow : {q : ℚ | |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2 ∧ q.den < N}.Finite := by
+    apply (finite_bounded_den (ξ - 1) (ξ + 1) N).subset
+    rintro q ⟨hq, hqd⟩
+    have hden1 : (1 : ℝ) ≤ (q.den : ℝ) := by exact_mod_cast q.pos
+    have hbound : 1 / (q.den : ℝ) ^ 2 ≤ 1 := by
+      rw [div_le_one (by positivity)]
+      nlinarith [hden1]
+    have h1 : |ξ - (q : ℝ)| < 1 := lt_of_lt_of_le hq hbound
+    rw [abs_lt] at h1
+    exact ⟨by linarith [h1.1, h1.2], by linarith [h1.1, h1.2], le_of_lt hqd⟩
+  apply (hSinf.diff hlow).mono
+  rintro q ⟨hq, hqlow⟩
+  refine ⟨hq, ?_⟩
+  by_contra h
+  push_neg at h
+  exact hqlow ⟨hq, h⟩
+
+/-- **Existence with large denominator.** A direct corollary: for every
+irrational `ξ` and every `N`, there is a good approximation
+`|ξ − q| < 1/q.den²` with `q.den ≥ N`. In particular the convergent
+denominators are unbounded — there is no single `Q` past which all good
+approximations stop. -/
+theorem exists_good_approx_large_den (hξ : Irrational ξ) (N : ℕ) :
+    ∃ q : ℚ, N ≤ q.den ∧ |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2 := by
+  obtain ⟨q, hq, hqd⟩ := (infinite_good_approx_large_den hξ N).nonempty
+  exact ⟨q, hqd, hq⟩
 
 end DirichletApproximationOQ01

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlet-approximation-theorem-oq-01",
   "title": "Dirichlet Approximation OQ-01: Infinitude of Good Rational Approximations",
   "slug": "dirichlet-approximation-theorem-oq-01",
-  "description": "An upgrade of the parent one-shot Dirichlet bound to the infinitude statement: for every irrational α there are infinitely many fractions p/q in lowest terms with |α − p/q| < 1/q². The infinitude over the set {q : ℚ | |α − q| < 1/q.den²} is Mathlib's Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational; the original contribution is the bridge from that set-of-rationals form to the classical coprime integer-pair statement (∃ infinitely many (p,q) ∈ ℤ×ℕ with q>0, gcd(|p|,q)=1, |α − p/q| < 1/q²), transported along the injection q ↦ (q.num, q.den). The sharp converse (only irrationals admit infinitely many such approximations) is recorded as well.",
+  "description": "An upgrade of the parent one-shot Dirichlet bound to the infinitude statement: for every irrational α there are infinitely many fractions p/q in lowest terms with |α − p/q| < 1/q². The infinitude over the set {q : ℚ | |α − q| < 1/q.den²} is Mathlib's Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational; the original contribution is the bridge from that set-of-rationals form to the classical coprime integer-pair statement (∃ infinitely many (p,q) ∈ ℤ×ℕ with q>0, gcd(|p|,q)=1, |α − p/q| < 1/q²), transported along the injection q ↦ (q.num, q.den). The sharp converse (only irrationals admit infinitely many such approximations) is recorded as well, together with a strengthening to unbounded denominators (for every N infinitely many good approximations have denominator ≥ N), built on a self-contained finiteness lemma for rationals of bounded height in a bounded real interval.",
   "meta": {
     "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
@@ -39,13 +39,20 @@
         "theorem": "Rat.cast_def / Rat.num_div_den / Rat.pos / Rat.reduced",
         "description": "Rational-structure facts: (q : ℝ) = q.num/q.den, (q.num:ℚ)/(q.den:ℚ) = q, 0 < q.den, and gcd(|q.num|,q.den)=1 (stored in lowest terms). These witness that the image of a good rational approximation is a positive coprime pair with the same error.",
         "module": "Mathlib.Data.Rat.Cast.Defs / Mathlib.Data.Rat.Defs"
+      },
+      {
+        "theorem": "Set.Finite.of_finite_image / Set.Infinite.diff / Finset.Icc",
+        "description": "Elementary finiteness machinery for the strengthening: a set with finite image under an injective map is finite (finite_bounded_den), the finite integer box Finset.Icc(-M,M) ×ˢ Finset.Icc 1 N is finite, and an infinite set minus a finite set is infinite (infinite_good_approx_large_den). No analytic input beyond the order bound 1/q.den² ≤ 1.",
+        "module": "Mathlib.Data.Set.Finite.Basic / Mathlib.Order.Interval.Finset.Basic"
       }
     ],
     "originalContributions": [
       "infinite_coprime_approx: the classical textbook form of the infinitude theorem — infinitely many pairs (p,q) ∈ ℤ×ℕ with q > 0, gcd(|p|,q)=1, and |ξ − p/q| < 1/q² — obtained by transporting Mathlib's set-of-rationals infinitude along the injection q ↦ (q.num, q.den) and verifying the image lands in the coprime-pair set (positive denominator, lowest terms, equal error)",
       "A clean InjOn proof for the numerator/denominator map on the good-approximation set, and an image-subset computation reducing the bridge to Rat.pos, Rat.reduced, and Rat.cast_def",
       "Packaging of the sharp converse (infinite_approx_iff_irrational) so the entry exhibits both directions: irrationality is necessary and sufficient for infinitely many good approximations",
-      "exists_good_approx: recovery of the one-shot existence statement (a single good approximation) as a corollary of infinitude"
+      "exists_good_approx: recovery of the one-shot existence statement (a single good approximation) as a corollary of infinitude",
+      "finite_bounded_den: a self-contained finiteness lemma — the rationals lying in a bounded real interval [a,b] with denominator ≤ N form a finite set — proved in-file by embedding the num/den map into the finite integer box [-M,M]×[1,N] with M ≥ max|a||b|·N. Mathlib supplies the analogous discreteness only for rational targets (finite_rat_abs_sub_lt_one_div_den_sq); this is the real-interval version",
+      "infinite_good_approx_large_den + exists_good_approx_large_den: the unbounded-denominators strengthening answering the entry's first open question — for every N there remain infinitely many good approximations with q.den ≥ N, obtained as (infinite good set) ∖ (finite low-denominator part), where finiteness of the low part follows from finite_bounded_den after noting |ξ − q| < 1/q.den² ≤ 1 confines q to [ξ−1, ξ+1]. Shows the convergent denominators are genuinely unbounded, strictly stronger than bare infinitude"
     ],
     "dateAdded": "2026-06-18",
     "relatedProblems": [
@@ -55,10 +62,10 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 101,
-    "assumptions": "0 axioms, 0 sorries. The sole hypothesis is Irrational ξ, which the converse (infinite_approx_iff_irrational) shows is exactly necessary and sufficient. The headline infinitude and the converse delegate to Mathlib's DiophantineApproximation development; the coprime-pair reformulation, the InjOn argument, the existence corollary, and the image-subset computation are proved in-file. Badge is 'mathlib' because the core infinitude result is a Mathlib theorem.",
+    "lineCount": 178,
+    "assumptions": "0 axioms, 0 sorries. The sole hypothesis is Irrational ξ, which the converse (infinite_approx_iff_irrational) shows is exactly necessary and sufficient. The headline infinitude and the converse delegate to Mathlib's DiophantineApproximation development; the coprime-pair reformulation, the InjOn argument, the existence corollary, the image-subset computation, the bounded-denominator finiteness lemma (finite_bounded_den), and the unbounded-denominator strengthening (infinite_good_approx_large_den) are proved in-file. Badge is 'mathlib' because the core infinitude result is a Mathlib theorem; the strengthening to unbounded denominators is original in-file content built only on elementary Mathlib finiteness facts.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {
@@ -119,15 +126,23 @@
       "endLine": 99,
       "mathContext": "Every irrational has at least one good approximation $|\\xi - q| < 1/q.\\mathrm{den}^2$.",
       "summary": "`exists_good_approx`: the one-shot existence statement recovered from infinitude via Set.Infinite.nonempty."
+    },
+    {
+      "id": "unbounded-denominators",
+      "title": "Strengthening: Unbounded Denominators",
+      "startLine": 101,
+      "endLine": 178,
+      "mathContext": "For every irrational $\\xi$ and every $N$, infinitely many good approximations satisfy $q.\\mathrm{den} \\ge N$; equivalently the convergent denominators are unbounded.",
+      "summary": "`finite_bounded_den`: rationals in a bounded real interval [a,b] with denominator ≤ N form a finite set, proved by embedding q ↦ (q.num, q.den) into the finite integer box Finset.Icc(-M,M) ×ˢ Finset.Icc 1 N with M ≥ max|a||b|·N (numerator bound |q.num| = |q|·q.den ≤ max|a||b|·N), and injectivity via Rat.num_div_den. `infinite_good_approx_large_den`: the full good-approximation set is infinite while its low-denominator part {q.den < N} is finite — each such q has |ξ − q| < 1/q.den² ≤ 1 so lies in [ξ−1, ξ+1] with den ≤ N, a finite_bounded_den set — and an infinite set minus a finite set is infinite. `exists_good_approx_large_den`: the existence corollary. Answers the entry's first open question and shows the denominators of good approximations are genuinely unbounded, strictly stronger than bare infinitude."
     }
   ],
   "conclusion": {
-    "summary": "The parent's one-shot Dirichlet bound is upgraded to the infinitude statement: for every irrational ξ there are infinitely many fractions in lowest terms with |ξ − p/q| < 1/q². The infinitude and its sharp converse delegate to Mathlib's DiophantineApproximation development; the original work is the bridge from Mathlib's set-of-rationals form to the classical coprime integer-pair statement, proved by transporting infinitude along the injective map q ↦ (q.num, q.den). Zero sorries, zero axioms.",
-    "implications": "Re-expressing the infinitude in the (p,q)-coprime form is the version used downstream: it is the launching point for continued fractions, Hurwitz's sharp constant 1/(√5 q²), and Liouville's transcendence criterion. The converse direction pins down that good rational approximability of exponent 2 characterizes irrationality exactly.",
+    "summary": "The parent's one-shot Dirichlet bound is upgraded to the infinitude statement: for every irrational ξ there are infinitely many fractions in lowest terms with |ξ − p/q| < 1/q². The infinitude and its sharp converse delegate to Mathlib's DiophantineApproximation development; the original work is the bridge from Mathlib's set-of-rationals form to the classical coprime integer-pair statement (transporting infinitude along the injective map q ↦ (q.num, q.den)) and a strengthening to unbounded denominators: for every N infinitely many good approximations have q.den ≥ N, via a self-contained finiteness lemma (finite_bounded_den) for rationals of bounded height in a bounded real interval. Zero sorries, zero axioms.",
+    "implications": "Re-expressing the infinitude in the (p,q)-coprime form is the version used downstream: it is the launching point for continued fractions, Hurwitz's sharp constant 1/(√5 q²), and Liouville's transcendence criterion. The unbounded-denominators strengthening makes explicit that there is no finite stage past which good approximations stop — the convergent denominators tend to infinity — which is the qualitative input to continued-fraction convergence. The converse direction pins down that good rational approximability of exponent 2 characterizes irrationality exactly.",
     "openQuestions": [
-      "Can the infinitude be strengthened to unbounded denominators — for every N there is a good approximation with denominator ≥ N — by proving the bounded-denominator subset finite (a num/den-injection finiteness argument analogous to Mathlib's finite_rat_abs_sub_lt_one_div_den_sq for rational targets)?",
       "Can the constant be improved in Lean to Hurwitz's 1/(√5 q²), and is the √5 shown to be optimal via the golden ratio?",
-      "Does the coprime-pair reformulation extend to the simultaneous approximation theorem (one denominator approximating several reals at once)?"
+      "Can the unbounded-denominators result be made quantitative — a lower bound on how many good approximations have denominator in [N, 2N], or the density of convergent denominators below x?",
+      "Does the coprime-pair reformulation (and its unbounded-denominator strengthening) extend to the simultaneous approximation theorem (one denominator approximating several reals at once)?"
     ]
   },
   "crossReferences": [
@@ -156,11 +171,11 @@
       "Set"
     ],
     "namespace": "DirichletApproximationOQ01",
-    "lineCount": 101,
+    "lineCount": 178,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4
+    "theoremCount": 7
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Strengthens the **Dirichlet Approximation OQ-01** entry (already verified/mathlib on `main`) from *infinitude* of good rational approximations to **infinitude with unbounded denominators** — answering the entry's `openQuestions[0]`.

For every irrational `ξ` and every bound `N`, there remain **infinitely many** rationals `q` with `|ξ − q| < 1/q.den²` **and** `q.den ≥ N`. In particular the good-approximation denominators are unbounded: there is no `Q` past which good approximations stop.

## New theorems (3, in `proofs/Proofs/DirichletApproximationOQ01.lean`)

- `finite_bounded_den` — the rationals in a bounded real interval `[a,b]` with denominator `≤ N` form a **finite** set. Proved by embedding `q ↦ (q.num, q.den)` into the finite integer box `[-M, M] × [1, N]`, where `M` bounds the numerators via `|q.num| = |q|·q.den ≤ max|a||b|·N`. (Mathlib has the analogous discreteness fact only for *rational* targets.)
- `infinite_good_approx_large_den` — infinitude with `q.den ≥ N`: the full good-approximation set is infinite, while its low-denominator part is finite (each low-den `q` satisfies `|ξ−q| < 1/q.den² ≤ 1`, hence lies in `[ξ−1, ξ+1]` with `q.den ≤ N`). Infinite minus finite is infinite.
- `exists_good_approx_large_den` — existence corollary.

## Verification

- `0 sorry`, `0 axiom`, status stays `verified` / badge `mathlib`.
- Built on the standard discreteness/finiteness API (`Set.Finite.of_finite_image`, `Set.Finite.subset`, `Set.Infinite.diff`, `Set.Infinite.mono`, `Rat.cast_def`, `Rat.pos`, `Rat.reduced`).
- Gallery `meta.json` updated: lineCount 101→178, theoremCount 4→7, +2 originalContributions, +1 section; `openQuestions[0]` marked answered and replaced with a quantitative-density follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)