### PR TITLE
audit(erdos-235): remove phantom axiom claims from originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5472,9 +5472,9 @@
     },
     "erdos-235": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:36:50Z",
+      "result": "issues-fixed"
     },
     "erdos-236": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-235/meta.json
+++ b/src/data/proofs/erdos-235/meta.json
@@ -51,9 +51,9 @@
       "exponentialCDF = 1 - e^{-c}",
       "hooley_theorem axiom",
       "erdos_235_proved theorem",
-      "hooley_uniform and hooley_error_term axioms",
+      "countSmallGaps and distribution property theorems (distribution_at_zero, distribution_at_infinity, median_gap)",
       "jacobsthal function",
-      "mertens_third axiom"
+      "eulerGamma constant (Euler-Mascheroni)"
     ],
     "axiomCount": 1,
     "lineCount": 329,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-235

**Proof**: erdos-235 (Gaps Between Coprime Integers / Hooley 1965)
**Tier**: C — axiomatized/axiom (correct, unchanged)
**Result**: issues-fixed (phantom contributions)

## Issue

`originalContributions` listed **two phantom axiom entries** that do not exist in `Proofs/Erdos235Problem.lean`:

- `"hooley_uniform and hooley_error_term axioms"` — no such declarations; only docstring comments at L250–258 (Part VII headers, no `axiom`/`theorem`).
- `"mertens_third axiom"` — no such declaration; the only related decl is `noncomputable def eulerGamma` at L291.

The file has **exactly 1 axiom** (`axiom hooley_theorem`, L179), which `axiomCount: 1` already reflects correctly. The phantom entries overstated the formalized axiom infrastructure.

## Evidence

```
$ grep -cE '^\s*axiom ' proofs/Proofs/Erdos235Problem.lean   →  1   (hooley_theorem, L179)
$ grep -n 'hooley_uniform\|hooley_error_term\|mertens_third' proofs/Proofs/Erdos235Problem.lean   →  (no matches)
```

## Fix

Replaced the two phantom axiom entries in `originalContributions` with real in-file content:
- distribution property theorems (`distribution_at_zero`, `distribution_at_infinity`, `median_gap`) + `countSmallGaps`
- `eulerGamma` constant (Euler-Mascheroni)

## Unchanged (verified correct)

- `axiomCount: 1`, `status: axiomatized`, `badge: axiom`, `sorries: 0` — all accurate.
- Main theorem `erdos_235` genuinely derives from the single disclosed axiom `hooley_theorem`; `assumptions` discloses it. No axiom masking.
- 8 theorems / 14 defs match meta. 0 sorries, 0 True stubs, 0 native_decide.

Tracker: erdos-235 auditCount 3→4 (issues-fixed).

---
Discovered during gallery integrity audit.