### PR TITLE
audit(erdos-234): correct stale prose on partial-result formalization status

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5466,9 +5466,9 @@
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:40:52Z",
+      "result": "issues-fixed"
     },
     "erdos-235": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 510,
-    "assumptions": "2 axioms: gallagher_conditional (RH→exponential distribution), average_normalized_gap (PNT). Previously 5 axioms: density_at_infinity proved via Markov, small_gaps_exist proved via Cesàro contrapositive, large_gaps_exist proved.",
+    "assumptions": "2 axioms: gallagher_conditional (RH→exponential distribution), average_normalized_gap (PNT). Axiom elimination: density_at_infinity (now proved via Markov) and small_gaps_exist (now proved via Cesàro contrapositive) were previously axioms. The large-gaps result (Rankin, Ford–Green–Konyagin–Tao, Maynard) is cited from the literature, not formalized as a named theorem.",
     "mathlib_version": "4.26.0",
     "theoremCount": 28,
     "definitionCount": 8
@@ -160,7 +160,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization of Erdős Problem 234 captures the open question of whether normalized prime gaps $g_n/\\log n$ have a well-defined continuous density function. Cramér's exponential model $f(c) = 1 - e^{-c}$ is defined with full continuity and CDF properties proved in Lean. Gallagher's conditional result (RH $\\implies$ ErdosProblem234) is proved in 8 lines from the axiomatized conditional. Basic properties — $f(0) = 0$, monotonicity, boundedness — are all formally verified, with partial results from GPY, Maynard–Tao, and Ford–Green–Konyagin–Tao axiomatized.",
+    "summary": "The formalization of Erdős Problem 234 captures the open question of whether normalized prime gaps $g_n/\\log n$ have a well-defined continuous density function. Cramér's exponential model $f(c) = 1 - e^{-c}$ is defined with full continuity and CDF properties proved in Lean. Gallagher's conditional result (RH $\\implies$ ErdosProblem234) is proved in 8 lines from the axiomatized conditional. Basic properties — $f(0) = 0$, monotonicity, boundedness — are all formally verified. The small-gaps result (GPY, Maynard–Tao) is proved as `small_gaps_exist` from the PNT axiom; the large-gaps result (Ford–Green–Konyagin–Tao) is cited from the literature, not formalized.",
     "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Prime Number Distribution:** Resolution would establish the precise statistical law governing consecutive prime spacings, settling a fundamental question about the fine structure of the primes.\n\n2. **Cramér's Conjecture:** If $f(c) = 1 - e^{-c}$, this strongly supports Cramér's broader conjecture that $\\max_{p_n \\leq x} g_n = O((\\log x)^2)$, though Granville's refinement suggests $\\limsup g_n/(\\log p_n)^2 \\geq 2e^{-\\gamma}$.\n\n**3. Riemann Hypothesis Connection:** Gallagher's result creates a bridge: proving the density exists and is exponential would provide evidence for (or against) RH, since RH implies the exponential law.\n\n4. **Sieve Methods and $k$-Tuples:** The proof techniques connect to the Hardy–Littlewood prime $k$-tuples conjecture, as Gallagher's approach uses moment calculations from prime $k$-tuple counts.\n\n5. **Computational Evidence:** Numerical data strongly supports $f(c) = 1 - e^{-c}$ for the first $10^{18}$ primes, but unconditional analytic proof remains elusive.",
     "openQuestions": [
       "Does the density $f(c)$ exist unconditionally for all $c \\geq 0$, without assuming RH?",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-234

**Proof**: erdos-234 (Density of Normalized Prime Gaps)
**Tier**: C — axiomatized/axiom, OPEN problem (correct, unchanged)
**Risk note**: references RH (Millennium) — verified RH is correctly framed as a *hypothesis*, not proved.
**Result**: issues-fixed (stale prose)

## Core checks (all pass, unchanged)

- `axiomCount: 2` matches the file: `gallagher_conditional` (RH→exponential, L303) and `average_normalized_gap` (PNT, L328), both disclosed by name.
- Headline `gallagher_implies_conjecture` (L308) is explicitly `RH ⟹ ErdosProblem234` — no axiom masking, RH not overclaimed.
- `status: axiomatized` / `badge: axiom` / `erdosProblemStatus: open` / `sorries: 0` — all accurate. 0 native_decide, 0 True stubs.
- `description` discloses OPEN and the RH-conditionality.

## Issues fixed (prose only)

1. **`assumptions`** claimed `"large_gaps_exist proved"`, but no such theorem or axiom exists in the file — only a docstring comment at L324 (`grep` for `large_gap`/`largeGap`/`arbitrarily_large` finds nothing). Rewrote the axiom-elimination note: only `density_at_infinity` (L228) and `small_gaps_exist` (L420) became proved theorems; the large-gaps result is literature-cited (Rankin/FGKT/Maynard), not formalized.

2. **`conclusion`** stated partial results from GPY / Maynard–Tao / FGKT are *"axiomatized"*. In reality the small-gaps result is **proved** as `small_gaps_exist` (L420, derived from the PNT axiom), and the large-gaps result is **not formalized** at all. Corrected both.

## Evidence

```
$ grep -cE '^\s*axiom ' proofs/Proofs/Erdos234Problem.lean   →  2
$ grep -nE '(axiom|theorem) +large_gaps_exist' proofs/Proofs/Erdos234Problem.lean   →  (none)
$ grep -nE 'theorem +small_gaps_exist' proofs/Proofs/Erdos234Problem.lean   →  420: theorem small_gaps_exist ...
```

Tracker: erdos-234 auditCount 3→4 (issues-fixed).

---
Discovered during gallery integrity audit.