### PR TITLE
audit(erdos-238): clean 4th re-audit, tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5490,8 +5490,8 @@
     },
     "erdos-238": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T14:43:30Z",
       "result": "clean"
     },
     "erdos-239": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-238 (Consecutive Primes with Large Gaps)

**Result: CLEAN** — no integrity issues. Tracker bumped 3→4.

### Verification (`Proofs/Erdos238Problem.lean`)
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 345 | 345 | ✓ |
| axiomCount | 2 | 2 (`erdos_partial_result`, `prime_number_theorem_asymptotic`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 10 | 10 | ✓ |
| native_decide | — | 0 → no `Lean.ofReduceBool` | ✓ |

### Classification
- **Tier C** (axiomatized). `status: axiomatized` / `badge: axiom` / `erdosProblemStatus: open` — **correct**.
- `mainConjecture` is a `Prop` def (NOT claimed proved); the general case is OPEN. Title/description/status all disclose OPEN.
- The two axioms are Erdős's actual proved partial result and the PNT asymptotic — both disclosed by name in `assumptions`. No axiom masking, no delegation opacity.
- `average_gap_grows` is a genuinely PROVED theorem (factorial-composite argument), not an axiom — comment at L122 correctly notes the prior axiom was eliminated.
- No `originalContributions` or `mainTheorems` fields → no phantom-name risk.
- All 10 section `mathContext` claims accurate vs source.
- Only `True` occurrence is the disclosed `∧ True` vacuous conjunct in `erdos_238_summary` (left conjunct = the real axiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)