### PR TITLE
audit(erdos-228): clean 4th re-audit — flat Littlewood polynomials, axiomatized/axiom verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5420,8 +5420,8 @@
     },
     "erdos-228": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:30:00Z",
       "result": "clean"
     },
     "erdos-229": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-228 (Flat Littlewood Polynomials, BBMST 2019)

**Result: CLEAN** (4th re-audit). No meta changes required; tracker bump only.

### Verified counts (all exact vs meta)
| Metric | meta.json | Lean source | ✓ |
|--------|-----------|-------------|---|
| lineCount | 162 | 162 | ✓ |
| axiomCount | 2 | 2 (`bbmst_theorem`, `bbmst_explicit`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 4 | 4 | ✓ |

### Integrity checks
- **status `axiomatized` / badge `axiom` — CORRECT** (Tier C). Main result `erdos_228_answer := bbmst_theorem` genuinely reduces to the disclosed axiom. No axiom masking: description and `assumptions` credit BBMST (2019) and name both axioms. `erdosProblemStatus: solved` reflects literature status.
- **No structure-encoded assumptions** — both assumptions are literal `axiom` declarations; axiomCount 2 reflects the full assumption count.
- **All 6 `originalContributions` map to real declarations** (`IsLittlewoodPolynomial`, `IsFlatOnUnitCircle`, `bbmst_theorem`, `bbmst_explicit`, `ErdosHaymanQuestion`, `expected_magnitude_heuristic`). `proofStrategy` matches the file 1:1.
- **No `mainTheorems` field** → no phantom-theorem risk.
- **No `native_decide`** → no `Lean.ofReduceBool` dependency.
- Single True stub (`littlewood_original`, L126) is an explicit "historical record placeholder" — not presented as a contribution or headline, and the file is correctly `axiomatized` (not `verified`). Harmless.

Tracker: erdos-228 auditCount 3 → 4, result `clean`.

---
Discovered during autonomous gallery integrity audit loop.