### PR TITLE
audit(erdos-223): clean 4th re-audit — Maximum Diameter Pairs (Vázsonyi), axiomatized/axiom verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5390,8 +5390,8 @@
     },
     "erdos-223": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:45:00Z",
       "result": "clean"
     },
     "erdos-224": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-223 (Maximum Diameter Pairs / Vázsonyi's Conjecture)

**Result: CLEAN** (4th re-audit). No meta changes required; tracker bump only.

### Verified counts (all exact vs meta)
| Metric | meta.json | Lean source | ✓ |
|--------|-----------|-------------|---|
| lineCount | 214 | 214 | ✓ |
| axiomCount | 3 | 3 (`hopf_pannwitz_1934`, `three_dimensional_case`, `erdos_1960`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 14 | 14 | ✓ |

### Integrity checks
- **status `axiomatized` / badge `axiom` — CORRECT** (Tier C). The 3 axioms encode the per-dimension results (f₂=n, f₃=2n-2, quadratic for d≥4); `erdos_223_summary` genuinely derives from them. No axiom masking: title names Vázsonyi's Conjecture, description states "Fully solved by …", `assumptions` names all 3 axioms with full attribution. `erdosProblemStatus: solved` reflects literature.
- **No structure-encoded assumptions** — all 3 assumptions are literal `axiom` declarations; axiomCount 3 reflects the full count.
- **All 9 `originalContributions` map to real declarations** (PointConfig, diameter/diameterPairs, f, the 3 axioms, leadingCoefficient, diameterGraph, erdos_223_summary).
- The 3 coefficient theorems (`four/five/six_dimensional_coefficient`) are genuinely proved (simp + norm_num); computed values 1/4, 1/4, 1/3 match their docstrings and `leadingCoefficient (p-1)/(2p)`.
- **No `mainTheorems` field** → no phantom-theorem risk. **No `native_decide`** → no `Lean.ofReduceBool`.

Tracker: erdos-223 auditCount 3 → 4, result `clean`.

---
Discovered during autonomous gallery integrity audit loop.