### PR TITLE
research(erdos-653-oq-01): exact small g(n) + 2-D lower-bound frontier negative result

### DIFF
--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -421,3 +421,52 @@ a new construction + Lean proof + Docker build — NOT attempted this session (b
 
 ### Blackout this session
 `docker run --rm alpine echo` rc=124 (daemon hung, ~9 stuck sibling builds); Aristotle `prove` 404.
+
+## Session 2026-06-18 (Session 8, researcher-1, ORIENT — small exact g(n) + 2-D frontier negative result)
+
+**Mode:** REVISIT / ORIENT. **Blackout:** Docker down (`docker info` times out, 0
+containers — daemon hung), so NO new Lean shipped (writing unverified Lean = the
+build-pending churn anti-pattern prior sessions fell into). Contribution is a
+deterministic, exact-integer **computational ORIENT** of the one genuinely OPEN
+elementary frontier this slug has left: *can an explicit 2-D family beat ⌈n/2⌉ for
+all n?* The Lean program is COMPLETE and verified on main (`Erdos653Problem.lean`:
+0 sorries / 2 deep cited axioms `csizmadia_bound`,`upper_bound`; `Erdos653LowerBound.lean`:
+0 axioms / 0 sorries / `g_ge_half` proved). No Lean re-attempted — confirmed via
+`git show origin/main`.
+
+**New durable artifact:** `verify_g_small_values.py` (exact integer squared-distance
+arithmetic, no float/RNG/Date; deterministic; ALL CHECKS PASS). Findings:
+
+- **(F1) Certified exact small values.** Grid search reaches the proven UB `n-1`
+  for n=2,3,4, **pinning g(2)=1, g(3)=2, g(4)=3 exactly** (lower bound = upper bound).
+  These are concrete exact values of g, not previously recorded here.
+- **(F2) Small-n lower bounds.** Irregular integer-grid configs certify
+  **g(6)≥4, g(7)≥5, g(8)≥5** (each beats ⌈n/2⌉ by exactly 1). But **g(5) is stuck at
+  3 = ⌈5/2⌉ on grids up to 7×7** (UB is 4) — a genuine small-n irregularity (whether
+  g(5)=3 or 4 needs a non-grid/irrational config or a proof; integer grids do not
+  certify >3).
+- **(F3) NEGATIVE structural result (the useful one).** The two *natural parametric*
+  2-D generalizations of the collinear line — **two parallel rows** and **two
+  columns** (all splits a+b=n, gaps 1..3) — **only TIE ⌈n/2⌉; neither beats it for any
+  n=4..12.** So the elementary improvement beyond ⌈n/2⌉ **cannot** come from the
+  obvious row/column generalization of the collinear construction; the sporadic
+  small-n beats (F2) require genuinely IRREGULAR point sets. This sharpens S2's
+  finding 4b ("2-D beats it at small n") into *why* no closed-form 2-D family beating
+  ⌈n/2⌉ is known: the clean families top out exactly at the 1-D optimum.
+- **(F4) Sidon byproduct.** Points on a parabola (all pairwise distances distinct →
+  every point sees n-1 distinct distances) give **D=1** — a second minimal-diversity
+  configuration alongside the regular n-gon (D=1 there too).
+
+**Strategic consequence for any future ACT.** A formalizable elementary lower bound
+beating ⌈n/2⌉ must be built from an *irregular* family, NOT a 2-row/2-column pattern
+(those are now ruled out empirically). The collinear `g_ge_half` therefore remains the
+best *clean closed-form* elementary lower bound, and Csizmadia's 0.7n (axiomatized,
+needs absent incidence machinery) stays the frontier. No closed-form irregular family
+with a provable uniform `D(n) > ⌈n/2⌉` is exhibited here — that remains the OPEN
+elementary question.
+
+**Honest assessment:** modest ORIENT, no new mathematics proven and no Lean (Docker
+down). Value = exact small values g(2..4), certified small-n lower bounds, and a clean
+negative result (natural 2-D families tie, don't beat ⌈n/2⌉) that explains the
+difficulty of the open elementary improvement and steers future work away from a dead
+end. The OQ `g(n) ≥ (1-o(1))n` is OPEN and untouched.

--- a/research/problems/erdos-653-oq-01/verify_g_small_values.py
+++ b/research/problems/erdos-653-oq-01/verify_g_small_values.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Erdős #653 OQ-01 — small exact values of g(n) and the 2-D lower-bound frontier.
+
+g(n) = max over n-point configurations of the number of DISTINCT R-values, where
+R(x) = number of distinct distances from x to the other points.
+
+Proven bounds already in the gallery (Erdos653Problem.lean / Erdos653LowerBound.lean):
+        ceil(n/2)  <=  g(n)  <=  n - 1   (n >= 2).
+The collinear construction is the *1-dimensional optimum* (ceil(n/2)); the deep
+0.7n (Csizmadia) lives above it and needs incidence machinery absent from Mathlib.
+
+This script (Session 8, 2026-06-18) sharpens the OPEN elementary question
+"can an explicit 2-D family beat ceil(n/2) for all n?" with three deterministic,
+exact-integer-arithmetic findings:
+
+  (F1) Certified small values: grid search hits the proven UB n-1 for n=2,3,4,
+       PINNING  g(2)=1, g(3)=2, g(4)=3  exactly.
+  (F2) For n=6,7,8 irregular integer-grid configs beat ceil(n/2) by exactly 1,
+       certifying g(6)>=4, g(7)>=5, g(8)>=5. But g(5) stays at ceil(5/2)=3 on
+       grids up to 7x7 (UB is 4) — a genuine small-n irregularity.
+  (F3) NEGATIVE structural result: the two natural *parametric* 2-D
+       generalizations of the collinear line — two parallel rows and two
+       columns — only TIE ceil(n/2); neither beats it for any tested n. So the
+       elementary improvement beyond ceil(n/2) cannot come from the obvious
+       row/column generalization; the sporadic small-n beats (F2) require
+       genuinely IRREGULAR configurations. This is *why* no closed-form 2-D
+       family beating ceil(n/2) is known.
+  (F4) Sidon byproduct: points on a parabola (all pairwise distances distinct)
+       give D=1 — a second minimal-diversity configuration alongside the
+       regular n-gon.
+
+Exact integer squared-distance arithmetic throughout (distance distinct
+<=> squared distance distinct, both non-negative); no floats, no RNG, no Date.
+Deterministic: re-running gives identical output.
+"""
+from itertools import combinations
+
+
+def D(pts):
+    """Number of distinct R-values of a point configuration (exact)."""
+    Rvals = set()
+    for i, p in enumerate(pts):
+        ds = set()
+        for j, q in enumerate(pts):
+            if i == j:
+                continue
+            ds.add((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2)
+        Rvals.add(len(ds))
+    return len(Rvals)
+
+
+def ceil_half(n):
+    return (n + 1) // 2
+
+
+def best_D_on_grid(n, k):
+    """Max D over all n-subsets of a k x k integer grid (a LOWER bound on g(n));
+    early-exits if it reaches the proven upper bound n-1."""
+    grid = [(x, y) for x in range(k) for y in range(k)]
+    best, cfg = 0, None
+    for combo in combinations(grid, n):
+        d = D(combo)
+        if d > best:
+            best, cfg = d, combo
+            if best == n - 1:
+                return best, cfg
+    return best, cfg
+
+
+def two_columns(a, b, dx):
+    """a points stacked at x=0, b points stacked at x=dx."""
+    return [(0, i) for i in range(a)] + [(dx, j) for j in range(b)]
+
+
+def two_rows(a, b, dy):
+    """a points in a row at y=0, b points in a row at y=dy."""
+    return [(i, 0) for i in range(a)] + [(j, dy) for j in range(b)]
+
+
+def parabola(n):
+    return [(i, i * i) for i in range(n)]
+
+
+# ----------------------------------------------------------------------------
+# (F1)/(F2): certified small values via grid search.
+# ----------------------------------------------------------------------------
+print("== (F1)/(F2) certified small g(n): ceil(n/2) <= g(n) <= n-1 ==")
+GRID = {2: 2, 3: 3, 4: 3, 5: 7, 6: 5, 7: 5, 8: 5}
+PINNED = {}
+LOWER = {}
+for n in range(2, 9):
+    ch, ub = ceil_half(n), n - 1
+    lb, cfg = best_D_on_grid(n, GRID[n])
+    assert ch <= lb <= ub, f"bound violated at n={n}: {ch}<={lb}<={ub}"
+    if lb == ub:
+        PINNED[n] = ub
+        tag = f"PINNED g({n})={ub}"
+    elif lb > ch:
+        LOWER[n] = lb
+        tag = f"g({n})>={lb} (beats ceil by {lb - ch}, UB {ub})"
+    else:
+        LOWER[n] = lb
+        tag = f"g({n})>={lb}=ceil (UB {ub})"
+    print(f"  n={n}: ceil={ch} gridLB={lb} (grid {GRID[n]}x{GRID[n]}) UB={ub}  {tag}")
+assert PINNED == {2: 1, 3: 2, 4: 3}, PINNED
+print("  -> exact: g(2)=1, g(3)=2, g(4)=3 ; g(5) stuck at 3 on grids<=7x7 (UB 4).")
+
+# ----------------------------------------------------------------------------
+# (F3): natural parametric 2-D families only TIE ceil(n/2).
+# ----------------------------------------------------------------------------
+print("\n== (F3) two-column / two-row families never beat ceil(n/2) ==")
+any_beat = False
+for n in range(4, 13):
+    ch = ceil_half(n)
+    best_col = best_row = 0
+    for a in range(1, n):
+        b = n - a
+        for d in (1, 2, 3):
+            for fam, store in ((two_columns(a, b, d), "c"), (two_rows(a, b, d), "r")):
+                if len(set(fam)) != n:
+                    continue
+                v = D(fam)
+                if store == "c":
+                    best_col = max(best_col, v)
+                else:
+                    best_row = max(best_row, v)
+    top = max(best_col, best_row)
+    if top > ch:
+        any_beat = True
+    print(f"  n={n}: ceil={ch}  best 2-col={best_col}  best 2-row={best_row}  "
+          f"{'TIE' if top == ch else ('BEATS' if top > ch else 'below')}")
+assert not any_beat, "a natural 2-col/2-row family beat ceil(n/2) — revisit F3!"
+print("  -> confirmed: obvious row/column generalization tops out AT ceil(n/2).")
+print("     Beating it (the OPEN elementary question) needs irregular configs.")
+
+# ----------------------------------------------------------------------------
+# (F4): Sidon / parabola -> D = 1.
+# ----------------------------------------------------------------------------
+print("\n== (F4) parabola (Sidon set) has all distances distinct -> D=1 ==")
+for n in range(3, 13):
+    assert D(parabola(n)) == 1, f"parabola D!=1 at n={n}"
+print("  -> D(parabola(n))=1 for n=3..12 (every point sees n-1 distinct "
+      "distances; a 2nd minimal-diversity config alongside the regular n-gon).")
+
+print("\nALL CHECKS PASSED.")


### PR DESCRIPTION
## Summary

Erdős #653 OQ-01 (distinct R-value counts `g(n)` in the plane). The **elementary
Lean program is already complete and verified on main** (`Erdos653LowerBound.lean`
proves `g_ge_half`: g(n) ≥ ⌈n/2⌉, 0 axioms/0 sorries; `Erdos653Problem.lean` keeps
the 2 deep cited literature axioms). The OQ `g(n) ≥ (1-o(1))n` is OPEN.

Docker was down this session (dual blackout), so **no Lean is shipped** — writing
unverified Lean would be the build-pending churn anti-pattern. Instead this is a
deterministic **computational ORIENT** of the one genuine OPEN elementary frontier
left here: *can an explicit 2-D family beat ⌈n/2⌉ for all n?*

## New artifact: `verify_g_small_values.py`

Exact integer squared-distance arithmetic (no floats/RNG/Date; deterministic, ALL
CHECKS PASS):

- **(F1)** Pins **g(2)=1, g(3)=2, g(4)=3 exactly** (grid lower bound meets the proven
  upper bound n−1).
- **(F2)** Certifies **g(6)≥4, g(7)≥5, g(8)≥5** (each beats ⌈n/2⌉ by 1); **g(5) is
  stuck at ⌈5/2⌉=3 on grids up to 7×7** (UB 4) — a small-n irregularity.
- **(F3) Negative structural result:** the natural parametric 2-D generalizations
  (two parallel rows; two columns, all splits/gaps) **only TIE ⌈n/2⌉, never beat it**
  for n=4..12. So the open elementary improvement cannot come from the obvious
  row/column generalization — it needs genuinely irregular configs. Sharpens S2's
  "2-D beats it at small n" into *why* no closed-form family is known.
- **(F4)** Parabola/Sidon set gives **D=1** (a 2nd minimal-diversity config alongside
  the regular n-gon).

## Honest assessment

Modest ORIENT: no new mathematics proven, no Lean (Docker down). Value = exact small
values, certified small-n lower bounds, and a clean negative result steering future
elementary work away from the 2-row/2-column dead end. OQ untouched and OPEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)