### PR TITLE
audit(erdos-22): remove phantom Turán section + overstated originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5359,9 +5359,9 @@
     },
     "erdos-22": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:03:50Z",
+      "result": "issues-fixed"
     },
     "erdos-220": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-22/meta.json
+++ b/src/data/proofs/erdos-22/meta.json
@@ -47,11 +47,11 @@
     "originalContributions": [
       "Graph structure with adj, symm, loopless fields",
       "IsIndependent, ContainsClique, IsCliqueFree predicates",
-      "rt(n, k, ℓ) Ramsey-Turán number axiomatization with achievability and maximality",
+      "rt(n, k, ℓ) Ramsey-Turán number axiomatization with rt_lower_bound (existence-to-rt) axiom",
       "BollobasErdosConjecture formal definition",
       "fox_loh_zhao_2015 axiom with polylogarithmic independence bound",
       "conjecture_resolved: fully proved theorem deriving BollobasErdosConjecture from axioms",
-      "Ramsey-Turán densities ρ₃=0, ρ₄=1/4, ρ₅=1/4",
+      "density_interpretation: ρ₄ = 1/4 computed as the n²/8 edge bound relative to the maximum n²/2",
       "edge_density_gap and density_interpretation computational verifications",
       "erdos_22_summary combining all main results"
     ],
@@ -107,25 +107,25 @@
       "id": "rt-numbers",
       "title": "Ramsey-Turán Numbers",
       "startLine": 81,
-      "endLine": 103,
-      "summary": "rt(n, k, ℓ) definition with achievability and maximality axioms.",
-      "mathContext": "Formal definition: rt(n, k, ℓ) definition with achievability and maximality axioms."
+      "endLine": 87,
+      "summary": "rt(n, k, ℓ) Ramsey-Turán number defined axiomatically.",
+      "mathContext": "Formal definition: rt(n, k, ℓ) Ramsey-Turán number defined axiomatically."
     },
     {
-      "id": "turan",
-      "title": "Turán's Theorem",
-      "startLine": 104,
-      "endLine": 127,
-      "summary": "Classical Turán number ex(n, K_r) and K₄-free bound.",
-      "mathContext": "Bound: Classical Turán number ex(n, K_r) and K₄-free bound."
+      "id": "axioms-conjecture",
+      "title": "Axioms and the Conjecture",
+      "startLine": 89,
+      "endLine": 119,
+      "summary": "BollobasErdosConjecture definition with the fox_loh_zhao_2015 axiom, rt_lower_bound, and fox_loh_zhao_sublinear axioms.",
+      "mathContext": "Formal definition and axioms: BollobasErdosConjecture, fox_loh_zhao_2015, rt_lower_bound, fox_loh_zhao_sublinear."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture and Solution",
-      "startLine": 128,
+      "startLine": 121,
       "endLine": 182,
-      "summary": "BollobasErdosConjecture, Fox-Loh-Zhao axiom, conjecture_resolved proof.",
-      "mathContext": "Verified: BollobasErdosConjecture, Fox-Loh-Zhao axiom, conjecture_resolved proof."
+      "summary": "conjecture_resolved proof deriving the conjecture from the axioms, plus density summary theorems.",
+      "mathContext": "Verified: conjecture_resolved derives BollobasErdosConjecture from the axioms; edge_density_gap, density_interpretation, erdos_22_summary."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-22 (Ramsey-Turán for K₄)

**Result:** issues-fixed (3 phantom-prose findings)

Erdős Problem #22 (Bollobás-Erdős conjecture, resolved by Fox-Loh-Zhao 2015), `axiomatized`/`axiom`.

### Counts verified exact
182L · 6 axioms (edgeCount, independenceNumber, rt, fox_loh_zhao_2015, rt_lower_bound, fox_loh_zhao_sublinear) · 0 sorries · 0 native_decide · 4 theorems · 5 defs (Graph struct + 4 defs).

`status`/`badge` **correct** (Tier C): `conjecture_resolved` genuinely derives `BollobasErdosConjecture` from the axioms (0 sorry), the headline `fox_loh_zhao_2015` axiom is disclosed in title/description/assumptions — no masking.

### Findings (all phantom prose, counts untouched)

1. **Phantom section `turan`** — meta listed a "Turán's Theorem" section (L104-127) summarized as "Classical Turán number ex(n, K_r) and K₄-free bound". No Turán number / `ex(n,K_r)` is formalized anywhere in the file; L104-127 actually hold the `fox_loh_zhao_2015`/`rt_lower_bound`/`fox_loh_zhao_sublinear` axioms plus the start of `conjecture_resolved`. Replaced with an honest "Axioms and the Conjecture" section (L89-119); realigned `rt-numbers` (81-87) and `conjecture` (121-182).
2. **originalContributions[2]** claimed `rt` "with achievability and maximality" axioms — neither exists (only `rt_lower_bound`; the L112 docstring even references a nonexistent `rt_maximal`). Reworded to `rt_lower_bound`.
3. **originalContributions[6]** claimed formalized "densities ρ₃=0, ρ₄=1/4, ρ₅=1/4" — not formalized; only `density_interpretation` (the 1/4 ratio) exists. Reworded to reflect the actual theorem.

Tracker: erdos-22 auditCount 3→4, result `issues-fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)