### PR TITLE
audit(erdos-216): remove phantom declaration claims from meta prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5328,9 +5328,9 @@
     },
     "erdos-216": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:10:55Z",
+      "result": "issues-fixed"
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-216/meta.json
+++ b/src/data/proofs/erdos-216/meta.json
@@ -64,19 +64,17 @@
       "IsHortonSet definition and horton_sets_exist axiom",
       "g_7_not_exists theorem (proved from Horton axiom)",
       "g_ge_7_not_exists axiom for k ≥ 7",
-      "g_lower_bound axiom",
-      "g_exists_le_6 theorem",
-      "Horton construction axioms (base, recursive, has_empty_6)",
+      "g_exists_le_6 theorem (case analysis via interval_cases)",
+      "hortonBase definition (single-point base case)",
       "Happy Ending Problem connection (happyEnding function)",
-      "Erdős-Szekeres conjecture formalization",
-      "empty_implies_nonempty axiom",
-      "Computational verification axioms (g_6_lower_witness, g_6_upper)",
+      "Erdős-Szekeres conjecture formalization (erdos_szekeres_conjecture)",
       "erdos_216_summary comprehensive theorem",
+      "erdos_216 theorem (complete answer)",
       "known_g_values theorem",
       "g_exists_iff characterization theorem"
     ],
     "axiomCount": 9,
-    "assumptions": "9 axiom declarations: InGeneralPosition (no three collinear predicate), IsConvexKGon (convex k-gon predicate), IsEmptyConvexKGon (empty interior predicate), g_3 (g(3)=3), g_4 (g(4)=5), g_5 (g(5)=10), g_6 (g(6)=30, Heule-Scheucher 2024), horton_sets_exist (arbitrary-size Horton sets), g_ge_7_not_exists (no g(k) for k>=7). Former axioms convexKGon_card, emptyConvexKGon_sub, g_lower_bound, horton_recursive, horton_has_empty_6, happy_ending_exists, empty_implies_nonempty, g_6_lower_witness, g_6_upper now proved as theorems or definitions.",
+    "assumptions": "9 axiom declarations: InGeneralPosition (no three collinear predicate), IsConvexKGon (convex k-gon predicate), IsEmptyConvexKGon (empty interior predicate), g_3 (g(3)=3), g_4 (g(4)=5), g_5 (g(5)=10), g_6 (g(6)=30, Heule-Scheucher 2024), horton_sets_exist (arbitrary-size Horton sets), g_ge_7_not_exists (no g(k) for k>=7). The exact values g(3)..g(6) and the k>=7 non-existence are taken directly as axioms from the literature; the file does not formalize lower bounds, the Horton recursive construction, or SAT-based computational witnesses (no such declarations are present). Only g_7_not_exists, g_exists_le_6, g_exists_iff, and the summary theorems (erdos_216_summary, erdos_216, known_g_values) are proved in Lean from these axioms.",
     "lineCount": 233,
     "theoremCount": 6,
     "definitionCount": 9
@@ -85,7 +83,7 @@
     "historicalContext": "**Erdős Problem #216: Empty Convex Polygons**\n\nThis problem is a deeper variant of the famous 'Happy Ending Problem' posed by Esther Klein in 1933 at a Budapest mathematics gathering. Klein observed that among any 5 points in general position, 4 must form a convex quadrilateral. Erdős and Szekeres proved the general case in 1935, and Erdős named it the 'Happy Ending Problem' because Klein and Szekeres married shortly afterward.\n\nProblem #216 adds a crucial constraint: the convex polygon must be **empty** — no other points from the set may lie in its interior. This seemingly small change has dramatic consequences.\n\n**Historical Timeline:**\n- 1935: Erdős and Szekeres prove the Ramsey-theoretic result for convex polygons (no emptiness condition)\n- 1935–1970s: Erdős asks whether g(k) exists for all k, with the emptiness condition\n- 1978: Harborth proves g(5) = 10 in a careful case analysis of point configurations\n- 1983: Horton constructs arbitrarily large point sets with no empty 7-gon, proving g(k) does not exist for k ≥ 7. This was a surprise — the empty condition creates a fundamental barrier at k = 7\n- 2007: Nicolás proves g(6) exists (finite but unknown value)\n- 2008: Gerken independently proves g(6) exists using a different approach\n- 2024: Heule and Scheucher determine g(6) = 30 using SAT solvers, completing the picture. Their paper 'Happy Ending: An Empty Hexagon in Every Set of 30 Points' verified all order types on 29 points and proved the universal property for 30 points\n\n**The Problem:** For each k, what is the minimum n = g(k) such that any n points in general position in ℝ² contain an empty convex k-gon?",
     "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet g(k) be the smallest integer (if it exists) such that any g(k) points in ℝ² in general position contains an empty convex k-gon (a convex k-gon with no point in its interior).\n\n**Questions:**\n1. Does g(k) exist for all k?\n2. If so, what is g(k)?\n\n**Complete Answer:**\n- g(3) = 3 (trivial: any 3 points form an empty triangle)\n- g(4) = 5 (Erdős)\n- g(5) = 10 (Harborth, 1978)\n- g(6) = 30 (Heule-Scheucher, 2024)\n- g(k) does NOT exist for k ≥ 7 (Horton, 1983)\n\n**Status: COMPLETELY RESOLVED** - The function g(k) exists if and only if k ≤ 6.",
     "text": "Let g(k) be the smallest integer such that any g(k) points in ℝ² contains an empty convex k-gon. Does g(k) exist? PARTIALLY SOLVED: g(k) exists iff k ≤ 6, with g(3)=3, g(4)=5, g(5)=10, g(6)=30 (Heule-Scheucher 2024). For k ≥ 7, Horton sets prove g(k) does not exist.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Point Sets:** Define Point as EuclideanSpace ℝ (Fin 2), PointSet as Finset Point\n\n2. **General Position:** InGeneralPosition requires no three collinear points, axiomatized since the cross-product definition is unnecessary for the combinatorial structure\n\n3. **Empty Polygons:** IsEmptyConvexKGon requires k vertices forming a convex polygon with no other points inside. The structural axiom emptyConvexKGon_sub guarantees vertices ⊆ S\n\n4. **The Function g:** Defined as Option ℕ using Nat.find — returns some n when a threshold exists, none otherwise. This design choice enables a clean characterization theorem\n\n5. **Known Values:** Axiomatize g(3)=3, g(4)=5, g(5)=10, g(6)=30 from published results\n\n6. **Horton's Theorem:** Define IsHortonSet and axiomatize their existence; prove g(7)=none as a genuine theorem from the axiom, then axiomatize the general case g(k)=none for k ≥ 7\n\n7. **Happy Ending Connection:** Formalize g'(k) for the non-empty variant and the monotonicity g(k) ≥ g'(k)",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Point Sets:** Define Point as EuclideanSpace ℝ (Fin 2), PointSet as Finset Point\n\n2. **General Position:** InGeneralPosition requires no three collinear points, axiomatized since the cross-product definition is unnecessary for the combinatorial structure\n\n3. **Empty Polygons:** IsEmptyConvexKGon is axiomatized as a convex k-gon with no other point of S inside; ContainsEmptyKGon wraps it in an existential over vertex sets\n\n4. **The Function g:** Defined as Option ℕ using Nat.find — returns some n when a threshold exists, none otherwise. This design choice enables a clean characterization theorem\n\n5. **Known Values:** Axiomatize g(3)=3, g(4)=5, g(5)=10, g(6)=30 from published results\n\n6. **Horton's Theorem:** Define IsHortonSet and axiomatize their existence; prove g(7)=none as a genuine theorem from the axiom, then axiomatize the general case g(k)=none for k ≥ 7\n\n7. **Happy Ending Connection:** Define g'(k) for the non-empty variant and state the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 (the monotonicity g(k) ≥ g'(k) is noted in prose but not formalized)",
     "keyInsights": [
       "**Empty vs Non-Empty Threshold:** The empty interior condition creates a sharp dichotomy at k=7 — the non-empty variant (Happy Ending Problem) has g'(k) for all k, while the empty variant terminates. This reflects a deep geometric phenomenon: large convex polygons in dense point sets almost inevitably contain interior points",
       "**Horton's Recursive Interlacing:** Horton sets are built by placing two copies at different heights and interlacing their x-coordinates. Any potential empty 7-gon must alternate between the two layers, but the interlacing forces an interior point from the opposite layer to appear inside the polygon",
@@ -103,93 +101,93 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 48,
+      "endLine": 47,
       "summary": "Module docstring documenting the problem statement, background, and references; 5 Mathlib imports covering required modules; `open` declarations (Finset); namespace `Erdos216`",
       "mathContext": "Let g(k) be the smallest integer (if it exists) such that any g(k) points in ℝ² contains an empty convex k-gon (a convex k-gon with no point in its interior). Does g(k) exist? If so, estimate g(k)."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Point as EuclideanSpace ℝ (Fin 2) and PointSet as Finset Point. Axiomatizes InGeneralPosition (no three collinear) and IsConvexKGon (k vertices in convex position) with the cardinality axiom convexKGon_card.",
+      "summary": "Defines Point as EuclideanSpace ℝ (Fin 2) and PointSet as Finset Point. Axiomatizes InGeneralPosition (no three collinear) and IsConvexKGon (k vertices in convex position), since their full definitions require cross-product and convex-hull infrastructure.",
       "startLine": 49,
-      "endLine": 70,
-      "mathContext": "Defines Point as EuclideanSpace ℝ (Fin 2) and PointSet as Finset Point. Axiomatizes InGeneralPosition (no three collinear) and IsConvexKGon (k vertices in convex position) with the cardinality axiom convexKGon_card."
+      "endLine": 65,
+      "mathContext": "Defines Point as EuclideanSpace ℝ (Fin 2) and PointSet as Finset Point. Axiomatizes InGeneralPosition (no three collinear) and IsConvexKGon (k vertices in convex position), since their full definitions require cross-product and convex-hull infrastructure."
     },
     {
       "id": "empty-polygons",
       "title": "Empty Convex Polygons",
-      "summary": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S. The structural axiom emptyConvexKGon_sub ensures vertices lie in S. Defines ContainsEmptyKGon as the existential wrapper.",
-      "startLine": 71,
-      "endLine": 87,
-      "mathContext": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S. The structural axiom emptyConvexKGon_sub ensures vertices lie in S. Defines ContainsEmptyKGon as the existential wrapper."
+      "summary": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S — since formalizing the interior of a convex hull requires substantial geometric infrastructure. Defines ContainsEmptyKGon as the existential wrapper.",
+      "startLine": 67,
+      "endLine": 78,
+      "mathContext": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S — since formalizing the interior of a convex hull requires substantial geometric infrastructure. Defines ContainsEmptyKGon as the existential wrapper."
     },
     {
       "id": "function-g",
       "title": "The Function g(k)",
       "summary": "Defines g(k) as Option ℕ via Nat.find: returns some n when a finite threshold exists, none otherwise. The predicate gExists checks Option.isSome. This design enables clean biconditional characterization.",
-      "startLine": 88,
-      "endLine": 101,
+      "startLine": 80,
+      "endLine": 92,
       "mathContext": "Defines g(k) as Option ℕ via Nat.find: returns some n when a finite threshold exists, none otherwise. The predicate gExists checks Option.isSome. This design enables clean biconditional characterization."
     },
     {
       "id": "known-values",
       "title": "Known Values",
       "summary": "Axiomatizes four exact values: g(3)=3 (trivial), g(4)=5 (Erdős), g(5)=10 (Harborth 1978), g(6)=30 (Heule-Scheucher 2024). Each is documented with historical attribution.",
-      "startLine": 102,
-      "endLine": 121,
+      "startLine": 94,
+      "endLine": 112,
       "mathContext": "Axiomatized: Axiomatizes four exact values: g(3)=3 (trivial), g(4)=5 (Erdős), g(5)=10 (Harborth 1978), g(6)=30 (Heule-Scheucher 2024). Each is documented with historical attribution."
     },
     {
       "id": "horton-theorem",
       "title": "Horton's Theorem",
       "summary": "Defines IsHortonSet as InGeneralPosition ∧ ¬ContainsEmptyKGon 7. Axiomatizes existence of arbitrarily large Horton sets. Proves g_7_not_exists as a genuine theorem by contradiction: any threshold n is refuted by a Horton set of size n.",
-      "startLine": 122,
-      "endLine": 149,
+      "startLine": 114,
+      "endLine": 140,
       "mathContext": "Defines IsHortonSet as InGeneralPosition ∧ ¬ContainsEmptyKGon 7. Axiomatizes existence of arbitrarily large Horton sets. Proves g_7_not_exists as a genuine theorem by contradiction: any threshold n is refuted by a Horton set of size n."
     },
     {
       "id": "bounds-growth",
       "title": "Bounds and Growth",
-      "summary": "Axiomatizes the lower bound g(k) ≥ 2k−3 for k ∈ {3,...,6}. Proves g_exists_le_6 by case analysis using interval_cases tactic, dispatching each case via the known-value axioms.",
-      "startLine": 150,
-      "endLine": 163,
-      "mathContext": "Axiomatizes the lower bound g(k) $\\geq$ 2k−3 for k ∈ {3,...,6}. Proves g_exists_le_6 by case analysis using interval_cases tactic, dispatching each case via the known-value axioms."
+      "summary": "Proves g_exists_le_6 by case analysis using the interval_cases tactic, dispatching each case k ∈ {3,...,6} via the known-value axioms. (No lower-bound axiom is declared in the file.)",
+      "startLine": 142,
+      "endLine": 150,
+      "mathContext": "Proves g_exists_le_6 by case analysis using the interval_cases tactic, dispatching each case k ∈ {3,...,6} via the known-value axioms. (No lower-bound axiom is declared in the file.)"
     },
     {
       "id": "horton-construction",
       "title": "The Horton Construction",
-      "summary": "Defines hortonBase as a single-point set. Axiomatizes the recursive construction: merging two equal-size Horton sets produces a larger Horton set. Records that Horton sets with ≥ 30 points contain empty hexagons (consistent with g(6)=30).",
-      "startLine": 164,
-      "endLine": 181,
-      "mathContext": "Defines hortonBase as a single-point set. Axiomatizes the recursive construction: merging two equal-size Horton sets produces a larger Horton set. Records that Horton sets with ≥ 30 points contain empty hexagons (consistent with g(6)=30)."
+      "summary": "Defines hortonBase as a single-point set (the base case of the construction). The recursive interlacing step is described in prose only — it is not formalized as a Lean declaration; the existence of arbitrarily large Horton sets is captured by the horton_sets_exist axiom in the Horton's Theorem section.",
+      "startLine": 152,
+      "endLine": 157,
+      "mathContext": "Defines hortonBase as a single-point set (the base case of the construction). The recursive interlacing step is described in prose only — it is not formalized as a Lean declaration; the existence of arbitrarily large Horton sets is captured by the horton_sets_exist axiom in the Horton's Theorem section."
     },
     {
       "id": "happy-ending",
       "title": "Connection to Happy Ending Problem",
-      "summary": "Defines happyEnding (g'(k)) for the non-empty variant. Axiomatizes happy_ending_exists for all k ≥ 3. Formalizes the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1. Proves the monotonicity empty_implies_nonempty: g(k) ≥ g'(k).",
-      "startLine": 182,
-      "endLine": 204,
-      "mathContext": "Defines happyEnding (g'(k)) for the non-empty variant. Axiomatizes happy_ending_exists for all k ≥ 3. Formalizes the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1. Proves the monotonicity empty_implies_nonempty: g(k) ≥ g'(k)."
+      "summary": "Defines happyEnding (g'(k)) for the non-empty variant via Nat.find, and states the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 as the predicate erdos_szekeres_conjecture. (No existence or monotonicity theorem is declared here.)",
+      "startLine": 159,
+      "endLine": 173,
+      "mathContext": "Defines happyEnding (g'(k)) for the non-empty variant via Nat.find, and states the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 as the predicate erdos_szekeres_conjecture. (No existence or monotonicity theorem is declared here.)"
     },
     {
       "id": "computational",
       "title": "Computational Results",
-      "summary": "Axiomatizes both directions for g(6)=30: a 29-point witness with no empty hexagon (lower bound) and the universal property that every 30-point general-position set contains an empty hexagon (upper bound).",
-      "startLine": 205,
-      "endLine": 216,
-      "mathContext": "Axiomatizes both directions for g(6)=30: a 29-point witness with no empty hexagon (lower bound) and the universal property that every 30-point general-position set contains an empty hexagon (upper bound)."
+      "summary": "Placeholder section header only — no computational witnesses are declared. The exact value g(6)=30 (both the 29-point lower-bound witness and the 30-point upper bound of Heule-Scheucher 2024) is captured directly by the g_6 axiom rather than re-derived here.",
+      "startLine": 175,
+      "endLine": 177,
+      "mathContext": "Placeholder section header only — no computational witnesses are declared. The exact value g(6)=30 (both the 29-point lower-bound witness and the 30-point upper bound of Heule-Scheucher 2024) is captured directly by the g_6 axiom rather than re-derived here."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Assembles the complete resolution: erdos_216_summary combines all four known values with g(7)=none and the general non-existence for k ≥ 7. The characterization theorem g_exists_iff proves g(k) exists ↔ k ≤ 6 for k ≥ 3.",
-      "startLine": 217,
+      "startLine": 179,
       "endLine": 233,
       "mathContext": "Assembles the complete resolution: erdos_216_summary combines all four known values with g(7)=none and the general non-existence for k ≥ 7. The characterization theorem g_exists_iff proves g(k) exists ↔ k ≤ 6 for k ≥ 3."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #216 is completely resolved. The function g(k) — the minimum number of points in general position guaranteeing an empty convex k-gon — exists precisely for k ≤ 6. The exact values are g(3)=3, g(4)=5, g(5)=10, and g(6)=30 (the last determined by Heule-Scheucher in 2024 using SAT solvers). Horton's 1983 construction of arbitrarily large point sets with no empty 7-gon proves g(k) does not exist for k ≥ 7. The formalization captures this complete dichotomy in 272 lines of Lean 4, with the key theorem g_exists_iff providing the biconditional characterization.",
+    "summary": "Erdős Problem #216 is completely resolved. The function g(k) — the minimum number of points in general position guaranteeing an empty convex k-gon — exists precisely for k ≤ 6. The exact values are g(3)=3, g(4)=5, g(5)=10, and g(6)=30 (the last determined by Heule-Scheucher in 2024 using SAT solvers). Horton's 1983 construction of arbitrarily large point sets with no empty 7-gon proves g(k) does not exist for k ≥ 7. The formalization captures this complete dichotomy in 233 lines of Lean 4, with the key theorem g_exists_iff providing the biconditional characterization.",
     "implications": "**Theoretical Significance**: **Geometric Ramsey Theory Connections**\n\n1. **Happy Ending Problem:** The non-empty version (Erdős #107) has g'(k) for all k, with the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 still open for k ≥ 7. The sharp contrast with the empty variant reveals how interior-point constraints fundamentally alter Ramsey-type problems in geometry\n\n2. **Computational Methods in Geometry:** The g(6)=30 result by Heule-Scheucher represents a new paradigm where SAT solvers resolve long-standing geometric conjectures. Their approach encoded order types as propositional formulas, extending the tradition of the Four Color Theorem and Hales' proof of the Kepler conjecture\n\n**3. Horton Sets Beyond This Problem:** Horton's construction technique has found applications in visibility graphs, geometric graph theory, and the study of halving lines. The recursive interlacing idea influenced subsequent constructions in discrete geometry\n\n4. **Order Type Enumeration:** The verification of g(6)=30 required analyzing all 2,343 order types on 9 points and extrapolating. This connects to the broader program of classifying point configurations up to combinatorial equivalence\n\n5. **Threshold Phenomena:** The sharp transition at k=7 is an instance of a phase transition in combinatorial geometry, analogous to threshold phenomena in random graphs and probabilistic combinatorics.",
     "openQuestions": [
       "Can the Heule-Scheucher SAT approach be adapted to determine exact values of related Ramsey-type functions in higher dimensions?",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-216 (Empty Convex Polygons)

**Result:** issues-fixed (phantom-prose class)

### What was wrong
The Lean source `Proofs/Erdos216Problem.lean` (233 lines) was trimmed at some point to **9 axioms / 6 theorems / 9 defs / 0 sorry / 0 native_decide / 0 True stubs**. The structural counts and `axiomatized`/`axiom` status in meta.json were all **correct**.

However, the prose still described **9 declarations that do not exist anywhere in the current file**:
`convexKGon_card`, `emptyConvexKGon_sub`, `g_lower_bound`, `horton_recursive`, `horton_has_empty_6`, `happy_ending_exists`, `empty_implies_nonempty`, `g_6_lower_witness`, `g_6_upper`.

The `assumptions` field falsely claimed these were "former axioms now proved as theorems or definitions" — they were removed entirely, not converted. `originalContributions`, six `sections`, and `proofStrategy` referenced them as present.

### Verification
```
$ grep -c "^axiom " ...  -> 9   (matches axiomCount 9)
$ grep -c "^theorem "    -> 6   (matches theoremCount 6)
$ grep -E "^(def|abbrev)"-> 9   (matches definitionCount 9)
$ grep -c sorry          -> 0
# all 9 phantom names: 0 occurrences in the .lean file
```

### Fixes (prose only — no status/count change)
- **assumptions**: removed the false "former axioms now proved" sentence; clarified the g(3)..g(6) values and k≥7 non-existence are taken directly as axioms, and listed which theorems are actually proved.
- **originalContributions**: removed 4 phantom-axiom entries; added the real `hortonBase` definition and `erdos_216` theorem.
- **sections** (basic-definitions, empty-polygons, bounds-growth, horton-construction, happy-ending, computational): rewrote summaries that described phantom axioms; noted Part IX is an empty placeholder header.
- **proofStrategy**: dropped phantom `emptyConvexKGon_sub`; clarified the g(k) ≥ g'(k) monotonicity is prose-only, not formalized.
- **conclusion**: line count 272 → 233.
- realigned all section `startLine`/`endLine` to the current 233-line file (they were shifted 15–35 lines from the older longer version).

JSON validated; no phantom names remain in meta.json.

---
Discovered during gallery integrity audit.