### PR TITLE
research(stern-brocot-tree-oq-01): injectivity + full bijection (+2 thms)

### DIFF
--- a/proofs/Proofs/SternBrocotTreeOQ01.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01.lean
@@ -38,14 +38,13 @@ Beyond the structural heart, this file now also proves:
   homomorphisms `T`, `T'` that intertwine the two boundary folds.
 * `sb_surjective` — **surjectivity**: every reduced positive rational `a/b` labels
   some node, by strong induction on `a + b` via the subtractive Euclidean descent.
-
-## Next steps (not in this file)
-
-* Injectivity: the mediant strictly separates the two subtrees (now available as
-  `sb_left_lt_mediant`/`sb_mediant_lt_right`), so the labelled value is strictly
-  monotone along the in-order traversal — combine with the transfer lemmas to show
-  distinct paths give distinct labels. Together with `sb_surjective` and
-  `sb_isCoprime` this yields the full bijection with the reduced positive rationals.
+* `sb_injective` — **injectivity**: a path is determined by its label. The sign of
+  `num − den` recovers the first move (`L ⟹ num < den`, `R ⟹ num > den`, root
+  `⟹ num = den = 1`) via the transfer lemmas, so a structural induction on the path
+  forces equality.
+* `sb_bijection` — **the full bijection** (this OQ): `(a, b)` is a reduced positive
+  rational `⟺` it is the label of a *unique* Stern–Brocot path. Combines
+  surjectivity, injectivity, positivity, and lowest terms.
 -/
 
 namespace SternBrocot
@@ -295,5 +294,115 @@ theorem sb_surj_aux : ∀ (n : ℕ) (a b : ℤ), (a + b).toNat = n →
 theorem sb_surjective (a b : ℤ) (ha : 1 ≤ a) (hb : 1 ≤ b)
     (hcop : IsCoprime a b) : ∃ p : List Bool, sbNum p = a ∧ sbDen p = b :=
   sb_surj_aux (a + b).toNat a b rfl ha hb hcop
+
+/-! ## Injectivity: distinct paths carry distinct labels
+
+The comparison of `sbNum p` against `sbDen p` recovers the *first* move of `p`.
+By the transfer lemmas, with `1 ≤ sbNum`, `1 ≤ sbDen` everywhere:
+
+* prepending `L` (`false`) gives `(num, den) ↦ (num, num + den)`, so `num < den`;
+* prepending `R` (`true`)  gives `(num, den) ↦ (num + den, den)`, so `num > den`;
+* the root `[]` is the unique node with `num = den = 1`.
+
+Hence two paths with the same label must agree on their first move; stripping it
+off and recursing (a structural induction on the path) forces the whole paths to
+coincide. No interval/order machinery is needed — the sign of `num − den` alone
+pins down each step.
+-/
+
+/-- **Injectivity**: a Stern–Brocot path is uniquely determined by its label.
+If two paths carry the same numerator *and* denominator, they are equal. -/
+theorem sb_injective : ∀ (p q : List Bool),
+    sbNum p = sbNum q → sbDen p = sbDen q → p = q := by
+  intro p
+  induction p with
+  | nil =>
+    intro q hn hd
+    have h1 := sb_root.1
+    have h2 := sb_root.2
+    cases q with
+    | nil => rfl
+    | cons c q' =>
+      exfalso
+      have hnq := sbNum_pos q'
+      have hdq := sbDen_pos q'
+      cases c with
+      | false =>
+        rw [sbNum_false_cons] at hn
+        rw [sbDen_false_cons] at hd
+        omega
+      | true =>
+        rw [sbNum_true_cons] at hn
+        rw [sbDen_true_cons] at hd
+        omega
+  | cons b p' ih =>
+    intro q hn hd
+    have hnp := sbNum_pos p'
+    have hdp := sbDen_pos p'
+    cases b with
+    | false =>
+      cases q with
+      | nil =>
+        exfalso
+        have h2 := sb_root.2
+        rw [sbDen_false_cons] at hd
+        omega
+      | cons c q' =>
+        have hnq := sbNum_pos q'
+        have hdq := sbDen_pos q'
+        cases c with
+        | false =>
+          rw [sbNum_false_cons, sbNum_false_cons] at hn
+          rw [sbDen_false_cons, sbDen_false_cons] at hd
+          have hd' : sbDen p' = sbDen q' := by omega
+          rw [ih q' hn hd']
+        | true =>
+          exfalso
+          rw [sbNum_false_cons, sbNum_true_cons] at hn
+          rw [sbDen_false_cons, sbDen_true_cons] at hd
+          omega
+    | true =>
+      cases q with
+      | nil =>
+        exfalso
+        have h1 := sb_root.1
+        rw [sbNum_true_cons] at hn
+        omega
+      | cons c q' =>
+        have hnq := sbNum_pos q'
+        have hdq := sbDen_pos q'
+        cases c with
+        | false =>
+          exfalso
+          rw [sbNum_true_cons, sbNum_false_cons] at hn
+          rw [sbDen_true_cons, sbDen_false_cons] at hd
+          omega
+        | true =>
+          rw [sbNum_true_cons, sbNum_true_cons] at hn
+          rw [sbDen_true_cons, sbDen_true_cons] at hd
+          have hn' : sbNum p' = sbNum q' := by omega
+          rw [ih q' hn' hd]
+
+/-! ## The full bijection -/
+
+/-- **Full bijection** (the open question, now settled): a pair `(a, b)` of
+integers is a reduced positive rational *if and only if* it is the label of a
+**unique** Stern–Brocot path. Forward direction packages surjectivity
+(`sb_surjective`) with injectivity (`sb_injective`); the reverse repackages
+positivity (`sbNum_pos`, `sbDen_pos`) and lowest terms (`sb_isCoprime`). -/
+theorem sb_bijection (a b : ℤ) :
+    (1 ≤ a ∧ 1 ≤ b ∧ IsCoprime a b) ↔
+      ∃! p : List Bool, sbNum p = a ∧ sbDen p = b := by
+  constructor
+  · rintro ⟨ha, hb, hcop⟩
+    obtain ⟨p, hp1, hp2⟩ := sb_surjective a b ha hb hcop
+    refine ⟨p, ⟨hp1, hp2⟩, ?_⟩
+    rintro q ⟨hq1, hq2⟩
+    exact sb_injective q p (by rw [hq1, hp1]) (by rw [hq2, hp2])
+  · rintro ⟨p, ⟨hp1, hp2⟩, _⟩
+    refine ⟨?_, ?_, ?_⟩
+    · rw [← hp1]; exact sbNum_pos p
+    · rw [← hp2]; exact sbDen_pos p
+    · rw [← hp1, ← hp2]; exact sb_isCoprime p
 
 end SternBrocot

--- a/research/problems/stern-brocot-tree-oq-01/knowledge.md
+++ b/research/problems/stern-brocot-tree-oq-01/knowledge.md
@@ -18,13 +18,70 @@ factors as: (a) every label is a reduced positive rational [kernel, done];
 - **(a) Structural kernel — DONE** (build-pending orphan, prior session):
   `sb_det` (unimodular invariant `aL·bR − aR·bL = −1`), `sb_pos`, `sbNum_pos`,
   `sbDen_pos`, `sb_isCoprime` (lowest terms via explicit Bézout), `sb_root`.
-- **(b) Surjectivity — DONE this session** (`sb_surjective`).
-- **(c) Injectivity — foundation done** (`sb_left_lt_mediant`,
-  `sb_mediant_lt_right`); full injectivity still open.
+- **(b) Surjectivity — DONE** (`sb_surjective`).
+- **(c) Injectivity — DONE this session** (`sb_injective`).
+- **Full bijection — DONE this session** (`sb_bijection`): the original OQ.
 
 All work is in the **unregistered orphan** `SternBrocotTreeOQ01.lean` (not in
 `Proofs.lean`, no `src/data/proofs/` gallery dir) → zero gallery/build risk
-while build-pending under the Docker blackout.
+while build-pending. **All three pieces of the bijection are now formalized
+(0 sorries, 0 axioms).** Remaining work is operational: a green Docker build,
+then registration in `Proofs.lean` + a `src/data/proofs/` gallery entry.
+
+---
+
+## Session 2026-06-18 (s3, researcher-10) — ACT, injectivity + full bijection
+
+**Mode**: REVISIT (own-team prior in-progress work). **Backend**: Docker `info`
+UP but **29 sibling build wrappers running** → a new full-Mathlib build risks
+OOM-ing peers (CLAUDE.md warning; prior session declined at 14), so **no Lean
+compiled this session**. Aristotle not needed (no HARD/OPEN sorries — the
+remaining piece was a clean structural induction). All tactics mirror the
+already-structured `sb_surj_aux` in the same file.
+
+### What I proved (new, sorry-free by construction)
+
+1. **Injectivity** `sb_injective : ∀ p q, sbNum p = sbNum q → sbDen p = sbDen q →
+   p = q`. Structural induction on `p`, then `cases q`, then `cases` on both first
+   moves. The crux: the **transfer lemmas** make the sign of `num − den` recover
+   the first move, so cross-cases (`L` vs `R`, root vs non-root) are killed by
+   `omega` using `sbNum_pos`/`sbDen_pos` (each ≥ 1), and same-first-move cases
+   recurse via the IH. This **bypasses** the mediant-separation foundation
+   (`sb_left_lt_mediant`/`sb_mediant_lt_right`) — no interval/order machinery
+   needed, only the prepend recurrence + positivity.
+
+2. **Full bijection** `sb_bijection (a b : ℤ) : (1 ≤ a ∧ 1 ≤ b ∧ IsCoprime a b)
+   ↔ ∃! p, sbNum p = a ∧ sbDen p = b`. Forward = `sb_surjective` (existence) +
+   `sb_injective` (uniqueness); reverse = `sbNum_pos`/`sbDen_pos`/`sb_isCoprime`.
+   This is the original open question, now fully assembled.
+
+### Why the sign argument over mediant separation
+
+Mediant separation proves the *order-theoretic* statement (subtrees occupy
+disjoint intervals) and would route injectivity through monotonicity of the
+in-order traversal — more machinery. But the transfer lemmas already give an
+exact *arithmetic* recurrence: prepend `L` ⟹ `den = num + den_old > num`,
+prepend `R` ⟹ `num = num_old + den > den`. So `num ⋚ den` is a total, decidable
+readout of the first move, and injectivity is a one-screen induction. The
+mediant lemmas remain in the file as independent structural facts.
+
+### Files Modified
+- `proofs/Proofs/SternBrocotTreeOQ01.lean` (+~95 lines: `sb_injective`,
+  `sb_bijection`, docstring update; 299 → 408 lines, still 0 sorries).
+
+### Next Steps
+1. **Docker-up (low contention)**: `./proofs/scripts/docker-build.sh
+   Proofs.SternBrocotTreeOQ01`; grep log for `error:`. Tactics to watch:
+   `rw [ih q' hn hd']` auto-closing the `b :: p' = b :: q'` goals (relies on
+   `rw` firing `rfl`); the `ExistsUnique` anonymous-constructor shape in
+   `sb_bijection` (`⟨p, ⟨hp1, hp2⟩, uniqueness⟩`). Both are standard; fixes if
+   needed are local (`exact congrArg _ (ih …)`; `refine ⟨p, ⟨hp1, hp2⟩, fun q hq
+   => ?_⟩`).
+2. **Register**: add to `Proofs.lean` + create `src/data/proofs/
+   stern-brocot-tree-oq-01/` gallery data (meta.json status `verified`,
+   badge `original`, 0 ax / 0 sorry) — only after a green build.
+3. The problem is mathematically COMPLETE pending verification; flip pool/phase
+   to COMPLETED once built.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the last open piece of `stern-brocot-tree-oq-01`. The file already proved the structural kernel (unimodular invariant, positivity, lowest terms via Bézout), **surjectivity**, and mediant separation. This PR adds **injectivity** and assembles the **full bijection** — the original open question.

New theorems (in `proofs/Proofs/SternBrocotTreeOQ01.lean`):

- `sb_injective : ∀ p q, sbNum p = sbNum q → sbDen p = sbDen q → p = q`
  Structural induction on the path. The existing prefix-transfer lemmas make the **sign of `num − den`** a total readout of the first move (prepend `L` ⟹ `num < den`, prepend `R` ⟹ `num > den`, root ⟹ `num = den = 1`). Cross-cases die by `omega` using `sbNum_pos`/`sbDen_pos`; same-first-move cases recurse. No interval/order machinery needed — the mediant-separation lemmas are bypassed (they remain as independent structural facts).

- `sb_bijection (a b : ℤ) : (1 ≤ a ∧ 1 ≤ b ∧ IsCoprime a b) ↔ ∃! p, sbNum p = a ∧ sbDen p = b`
  Forward = `sb_surjective` (existence) + `sb_injective` (uniqueness); reverse = `sbNum_pos`/`sbDen_pos`/`sb_isCoprime`.

299 → 408 lines, **0 sorries, 0 axioms**.

## Build status

**Build-pending.** Docker was up but **29 sibling build wrappers were running**; per CLAUDE.md a new full-Mathlib build risks OOM-ing peers, so no Lean was compiled this session. The file remains an **unregistered orphan** (not in `Proofs.lean`, no gallery dir) → zero gallery/build risk. All tactics (`cases`/`rw`/`omega`/`rintro`/`refine`) mirror the already-structured `sb_surj_aux` in the same file. Should be built under low contention before registering in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)