### PR TITLE
audit(erdos-212): clean re-audit (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5298,8 +5298,8 @@
     },
     "erdos-212": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:20:22Z",
       "result": "clean"
     },
     "erdos-213": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-212 (Rational Distance Sets / Erdős-Ulam)

**Tier C** (axiomatized/axiom, OPEN). Re-audit (4th pass). **No meta changes — clean.**

### Verified

- **Counts exact**: 4 axioms (`BombieriLangConjecture`, `tao_shaffaf_conditional`, `shaffaf_tao_algebraic_curves`, `solymosi_de_zeeuw`) / 0 sorries / 2 theorems / 3 defs / 139 lines — all match `meta.json` and `leanFile`.
- **status `axiomatized` / badge `axiom`** correct: `Erdos212Conjecture` is a `def Prop` (not claimed proved); `erdosProblemStatus: "open"` matches. `summary_erdos_212` genuinely derives from the axioms; `erdos_212_classical` is just LEM. **No masking** — title/description/historicalContext clearly mark the problem OPEN with conditional results axiomatized and fully attributed (Tao 2014, Shaffaf 2018, Solymosi-de Zeeuw 2010).
- 0 True stubs, 0 `native_decide` (no `Lean.ofReduceBool`).
- `originalContributions` (4) and `proofStrategy` (6) all map to real declarations; section line ranges accurate.

### Nit (not fixed — no overclaim)

`assumptions` says "…and 1 more" rather than naming the 4th axiom `solymosi_de_zeeuw`, but the count (4) is correct and the axiom is named in `originalContributions`/`proofStrategy`, so there is no overclaim.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)