### PR TITLE
audit(erdos-211): clean re-audit (tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5292,8 +5292,8 @@
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T15:27:13Z",
       "result": "clean"
     },
     "erdos-212": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-211

Re-audit of **Erdős Problem #211: Lines Formed by Points in the Plane** (axiomatized/axiom). All meta.json claims verified against \`proofs/Proofs/Erdos211Problem.lean\`.

### Verified (exact)
| Field | meta | source |
|-------|------|--------|
| axioms | 10 | 10 ✓ |
| theorems | 1 | 1 ✓ |
| definitions | 9 | 9 ✓ |
| lineCount | 246 | 246 ✓ |
| sorries | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Integrity checks
- **status `axiomatized` / badge `axiom` correct (Tier C):** the headline `erdos_211` theorem is literally `:= beck_szemeredi_trotter` (the main axiom). No masking — title and description disclose "SOLVED by Beck and Szemerédi-Trotter (1983)".
- **All 9 originalContributions** reference real in-file declarations (Point/Line types, numLines/formedLines, maxCollinear, HasBoundedCollinearity, and the named axioms beck_szemeredi_trotter / beck_dichotomy / szemeredi_trotter, ErdosRefinedConjecture, constant_one_sixth_optimal).
- **No phantom mainTheorems field.**
- **No `native_decide`** → no `Lean.ofReduceBool` disclosure needed.
- mathlibDependencies (Finset.card, Nat.card) are basic infrastructure, not the core result → badge `axiom` (not `mathlib`) is correct.

### Result
**Clean.** No meta changes required. Tracker bumped 3→4.

---
Discovered during gallery integrity audit.