### PR TITLE
audit(erdos-208): fix phantom-axiom prose (0 axioms, not axiomatized)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5268,9 +5268,9 @@
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T16:14:28Z",
+      "result": "issues-fixed"
     },
     "erdos-209": {
       "agentId": "auditor-session-1777704127",

--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -61,7 +61,7 @@
     "historicalContext": "This problem concerns gaps between consecutive squarefree numbers (integers not divisible by any perfect square > 1). The sequence 1, 2, 3, 5, 6, 7, 10, 11, ... has density 6/π² ≈ 0.608 in the natural numbers, so 'typical' gaps are small.\n\nErdős posed two questions about how large gaps can be. The first asks whether gaps are always subpolynomial: s_{n+1} - sₙ ≪ sₙ^ε for any ε > 0. The second asks for a precise bound: s_{n+1} - sₙ ≤ (1 + o(1)) · (π²/6) · log(sₙ)/log(log(sₙ)).\n\nErdős himself (1951) proved this second bound would be optimal if true - infinitely many gaps achieve it as a lower bound. The best unconditional upper bound has improved from s_n^{1/5+o(1)} (Filaseta-Trifonov 1992) to s_n^{1/5-c} (Pandey 2024). Granville (1998) showed the first question follows from the ABC conjecture.",
     "problemStatement": "**Question 1**: Is it true that for any $\\epsilon > 0$ and sufficiently large $n$,\n$$s_{n+1} - s_n \\ll_\\epsilon s_n^\\epsilon$$\n\n**Question 2**: Is it true that\n$$s_{n+1} - s_n \\leq (1 + o(1)) \\cdot \\frac{\\pi^2}{6} \\cdot \\frac{\\log s_n}{\\log\\log s_n}$$\n\n**Status**: OPEN\n\n**Best known upper bound**: $s_{n+1} - s_n \\ll s_n^{1/5-c}$ for some $c > 0$ (Pandey 2024)\n\n**Conditional result**: Question 1 follows from the ABC conjecture (Granville 1998)",
     "text": "Let s₁ < s₂ < ... be the squarefree numbers. Is it true that for any ε > 0, the gap s_{n+1} - sₙ ≪ sₙ^ε?",
-    "proofStrategy": "Since both questions are open, we formalize:\n\n1. **The squarefree sequence**: Using Mathlib's `Squarefree` and `Nat.nth`\n2. **The two main conjectures**: As definitions of Props using big-O notation\n3. **Known bounds**: Axiomatize Filaseta-Trifonov and Pandey results\n4. **Lower bound**: Axiomatize Erdős's 1951 result showing optimality of Q2's bound\n5. **Conditional result**: Axiomatize that ABC implies Q1\n6. **Density result**: Axiomatize that squarefree numbers have density 6/π²\n7. **Verified examples**: Small squarefree tests using native_decide",
+    "proofStrategy": "Since both questions are open, we formalize:\n\n1. **The squarefree sequence**: Using Mathlib's `Squarefree` and `Nat.nth`\n2. **The two main conjectures**: As definitions of Props using big-O notation\n3. **Known bounds**: Document Filaseta-Trifonov and Pandey results in source comments (not axiomatized)\n4. **Lower bound**: Document Erdős's 1951 result showing optimality of Q2's bound\n5. **Conditional result**: Document that ABC implies Q1 (Granville 1998)\n6. **Density result**: Document that squarefree numbers have density 6/π²\n7. **Verified examples**: Small squarefree tests using native_decide",
     "keyInsights": [
       "**Squarefree numbers**: Numbers not divisible by any perfect square > 1. First few: 1, 2, 3, 5, 6, 7, 10, 11, 13, ...",
       "**Density 6/π²**: The proportion of integers up to N that are squarefree converges to 6/π² ≈ 0.608.",
@@ -94,7 +94,7 @@
       "title": "Known Upper Bounds",
       "startLine": 76,
       "endLine": 94,
-      "summary": "Axiomatize Filaseta-Trifonov and Pandey bounds."
+      "summary": "Document Filaseta-Trifonov and Pandey bounds in source comments (not axiomatized)."
     },
     {
       "id": "lower-bound",
@@ -126,7 +126,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #208 about gaps between consecutive squarefree numbers. Both questions remain open: whether gaps are always subpolynomial (Question 1), and whether they satisfy a precise log/log-log bound (Question 2). We axiomatize the known partial results including the best unconditional bound (Pandey 2024) and the ABC-conditional result (Granville 1998).",
+    "summary": "We formalize Erdős Problem #208 about gaps between consecutive squarefree numbers. Both questions remain open: whether gaps are always subpolynomial (Question 1), and whether they satisfy a precise log/log-log bound (Question 2). We document the known partial results in source comments — including the best unconditional bound (Pandey 2024) and the ABC-conditional result (Granville 1998) — without axiomatizing them (0 axioms, 0 sorries).",
     "implications": "**Theoretical Significance**: This problem connects to fundamental questions about the distribution of squarefree numbers and the structure of integers.\n\nThe connection to ABC conjecture suggests deep arithmetic content. Progress on this problem would improve our understanding of how 'random' the distribution of squarefree numbers is at various scales.",
     "openQuestions": [
       "Does s_{n+1} - sₙ ≪ sₙ^ε hold for all ε > 0?",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-208 (Gaps Between Squarefree Numbers)

**Result**: issues-fixed (phantom-axiom prose). Re-audit #4.

### What the source actually contains
`Erdos208Problem.lean` (182 lines): **0 axioms, 0 theorems/lemmas, 5 defs, 0 sorries**, 11 `example`s (5 via `native_decide` on concrete `Squarefree n` values). The known partial results (Filaseta-Trifonov 1992, Pandey 2024, Erdős 1951 lower bound, Granville/ABC 1998, density 6/π²) are written as **doc-comments only** — they are *not* axiomatized.

### Issue
`proofStrategy` (4×), the `upper-bounds` section summary, and the `conclusion` summary claimed those results were **"Axiomatize[d]" / "We axiomatize"** — directly contradicting:
- `axiomCount: 0`
- `assumptions: "None. Fully verified with 0 axioms and 0 sorries."`
- `originalContributions[1]: "documented in source comments — not axiomatized"`

This is inverse-overclaim (asserts assumptions that don't exist), but still a meta↔source mismatch.

### Fix
Rewrote the three prose locations to "Document … in source comments (not axiomatized)". No count/status changes — all counts already correct; `status: axiomatized` / `badge: wip` retained as the conservative reading for an OPEN conjecture formalized only as Prop definitions.

### Not an issue
The 5 `native_decide` cases are non-substantive concrete examples with no theorem depending on them → no `Lean.ofReduceBool` disclosure required (consistent with prior concrete-example rulings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)