### PR TITLE
research(inverse-galois-d4-oq-01): reconcile stale JSON record to completed

### DIFF
--- a/research/problems/inverse-galois-d4-oq-01/state.md
+++ b/research/problems/inverse-galois-d4-oq-01/state.md
@@ -11,6 +11,13 @@
 > sessions (recorded in `knowledge.md`) drove the problem to completion and
 > merged the work to `main`. The header above now reflects reality. Read
 > `knowledge.md` for the full record.
+>
+> **JSON-SYNC (researcher-2, 2026-06-18).** The structured record
+> `src/data/research/problems/inverse-galois-d4-oq-01.json` was still frozen at
+> the stale `status: available` / `phase: ORIENT` "build-pending" snapshot
+> (where this `state.md` was already `DONE`), so the problem kept surfacing as
+> available work. Reconciled the JSON to `status: completed` / `phase: COMPLETED`
+> to match #24876 and the `verified` gallery entry. No Lean change.
 
 ## Summary of Completed Work
 Both the internal and external ℤ/4 ⋊ ℤ/2 decompositions of the D₄ Galois

--- a/src/data/research/problems/inverse-galois-d4-oq-01.json
+++ b/src/data/research/problems/inverse-galois-d4-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "inverse-galois-d4-oq-01",
   "title": "Semidirect-Product Structure ℤ/4 ⋊ ℤ/2 of the D₄ Galois Action",
-  "phase": "ACT",
-  "status": "available",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "Proofs/InverseGaloisD4OQ01.lean",
   "problemStatement": {
@@ -21,14 +21,9 @@
     ],
     "goal": "Promote the internal decomposition to the explicit external semidirect product and confirm a kernel build."
   },
-  "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-15T00:00:00Z",
-    "iteration": 1,
-    "focus": "Internal structure complete; external SemidirectProduct equivalence blueprinted (lift compatibility reduces to reflection_conj_rotation'). Build + Aristotle unavailable this session."
-  },
+  "currentState": {},
   "knowledge": {
-    "progressSummary": "ACT: external d4Equiv companion file written in full (no sorry), build-pending; SDP/MulAut/TypeTags API source-confirmed; only 3 tactic-level points remain to verify at build.",
+    "progressSummary": "RECONCILED (researcher-2, 2026-06-18): structured record was frozen at the stale \"build-pending\" snapshot while state.md and main moved on. Both files are merged + Docker-verified on main: InverseGaloisD4OQ01.lean (internal D4 = ZMod4 x| ZMod2, 13 thm, 0 sorry/0 axiom) and InverseGaloisD4OQ01External.lean (external MulEquiv SemidirectProduct(Mult(ZMod 4), Mult(ZMod 2), phi) =* DihedralGroup 4 via SemidirectProduct.lift, 8 thm, 0 sorry/0 axiom), both registered in Proofs.lean and shipped via PR #24876. Gallery meta.json already status=verified/badge=original/axiomCount=0. OQ-01 (explicit ZMod4 x| ZMod2 structure) is RESOLVED; the harder OQ-03 Gal(X^4-2/Q) =* D4 bridge is a separate problem, not folded here. --- PRIOR: ACT: external d4Equiv companion file written in full (no sorry), build-pending; SDP/MulAut/TypeTags API source-confirmed; only 3 tactic-level points remain to verify at build.",
     "builtItems": [
       "InverseGaloisD4OQ01.lean: rotations ≅ ℤ/4 (rHom, rHom_injective, rotationsEquiv, card_rotations)",
       "InverseGaloisD4OQ01.lean: rotations_normal, reflection_conj_rotation, reflection_conj_rotation'",
@@ -47,10 +42,7 @@
       "No DihedralGroup n ≃* SemidirectProduct ... result in Mathlib v4.26.0.",
       "Need to confirm exact SemidirectProduct.lift hypothesis form and MulAut.conj_apply at build time."
     ],
-    "nextSteps": [
-      "When Docker ≤2 containers or Aristotle back: copy staged InverseGaloisD4OQ01External.lean into proofs/Proofs/, build via docker-build.sh, fix any of 3 residual tactic points (ZMod-2 if-discharge; MulAut.mul_apply/one_apply names; lift_apply rfl), register in Proofs.lean.",
-      "Then flip gallery meta.json status and upgrade the internal file formalized → verified (0 sorry/0 axiom, under-claimed)."
-    ]
+    "nextSteps": []
   },
   "tags": [
     "galois-theory",
@@ -60,7 +52,7 @@
     "field-extensions"
   ],
   "started": "2026-06-15T00:00:00Z",
-  "lastUpdate": "2026-06-15T00:00:00Z",
+  "lastUpdate": "2026-06-18T00:00:00Z",
   "significance": 5,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Data-integrity reconciliation. The structured research record
`src/data/research/problems/inverse-galois-d4-oq-01.json` was frozen at a stale
`status: available` / `phase: ORIENT` "build-pending, 3 tactic points remain"
snapshot, even though the work landed on `main` via **PR #24876** and the gallery
entry is already `verified`/`original`/0-axiom.

Because the JSON still read `available`, this completed problem kept surfacing as
the sole available research target and wasting picker/researcher cycles (it is how
it reached this session).

## Reality (already on main, unchanged here)

- `proofs/Proofs/InverseGaloisD4OQ01.lean` — internal D₄ ≅ ℤ/4 ⋊ ℤ/2, 13 thm, **0 sorry / 0 axiom**
- `proofs/Proofs/InverseGaloisD4OQ01External.lean` — external `MulEquiv`
  `SemidirectProduct (Mult (ZMod 4)) (Mult (ZMod 2)) φ ≃* DihedralGroup 4` via
  `SemidirectProduct.lift`, 8 thm, **0 sorry / 0 axiom**
- Both registered in `Proofs.lean` (2544–2545); gallery `meta.json` already `verified`.

The companion `state.md` was reconciled by researcher-8 (2026-06-16) but the JSON
was missed.

## Change

- JSON: `status` available→completed, `phase` ORIENT→COMPLETED, `currentState` → {},
  cleared the two already-done `nextSteps`, prepended a reconciliation note to
  `progressSummary`, bumped `lastUpdate`.
- `state.md`: one-line JSON-SYNC breadcrumb.

**No Lean change. No gallery/meta change** (gallery was already correct). OQ-01 is
resolved; the harder OQ-03 `Gal(X⁴−2/ℚ) ≃* D₄` bridge remains a separate problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)