### PR TITLE
audit(stern-brocot-tree-oq-01): soften "First" formalization claim

### DIFF
--- a/src/data/proofs/stern-brocot-tree-oq-01/meta.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01/meta.json
@@ -42,7 +42,7 @@
       }
     ],
     "originalContributions": [
-      "First self-contained Lean 4 development of the Stern–Brocot tree (Mathlib v4.26 has no Stern–Brocot tree, mediant, or Farey machinery)",
+      "Self-contained Lean 4 development of the Stern–Brocot tree — to our knowledge no independent Lean formalization exists (Mathlib v4.26 has no Stern–Brocot tree, mediant, or Farey machinery)",
       "Nodes encoded as List Bool paths over an integer boundary-pair fold; the unimodular invariant aL·bR − aR·bL = −1 carried by induction over the path",
       "Lowest-terms proof via an explicit Bézout witness (−bR)·num + aR·den = 1 extracted directly from the unimodular invariant",
       "Conjugation homomorphisms T, T' that intertwine the boundary fold and give exact prefix-transfer recurrences for the label numerator and denominator",


### PR DESCRIPTION
## Gallery Integrity Audit — stern-brocot-tree-oq-01

**Proof**: stern-brocot-tree-oq-01 (Stern–Brocot bijection, **verified/original**, Tier A)
**Risk**: LOW (one language-precision nit on an otherwise impeccable entry)

### Verified correct (no change) — `verified/original` badge fully justified
- 408 lines, **0 axioms, 0 sorries, 0 native_decide, 0 True stubs**.
- The `SB` structure is **pure data** (`aL, bL, aR, bR : ℤ`) — no assumption-carrying fields, so "0 axioms / 0 assumptions" is genuine.
- All 5 `mainTheorems` exist with **exactly matching signatures**: `sb_bijection` (L393), `sb_det` (L108), `sb_isCoprime` (L151), `sb_surjective` (L294), `sb_injective` (L315).
- `mathlibDependencies` are basic infrastructure only (`IsCoprime`, `IsCoprime.of_add_mul_left_left`, `Int.isUnit_iff`, `Nat.strong_induction_on`) — the core argument (unimodular invariant, conjugation transfer lemmas, Euclidean-descent surjectivity, sign-based injectivity) is **genuinely built in-file**. No delegation opacity; Tier A `original` is correct.
- Counts exact: theoremCount 30, definitionCount 10, structureCount 1, lineCount 408.

### Fixed (language precision)
- `originalContributions[0]` claimed *"**First** self-contained Lean 4 development"*. Per the auditor Language Precision Rules, an unverifiable "First formalization" claim is softened to *"to our knowledge no independent Lean formalization exists"*. The factual Mathlib-absence qualifier (v4.26 has no Stern–Brocot / mediant / Farey machinery) is retained.

---
Discovered during gallery integrity audit. Counts and status unchanged; this only tempers an unverifiable priority claim on a high-credibility `verified/original` entry.