### PR TITLE
Add converse + biconditional to Simson line theorem

### DIFF
--- a/proofs/Proofs/SimsonLineTheorem.lean
+++ b/proofs/Proofs/SimsonLineTheorem.lean
@@ -4,10 +4,10 @@ import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 /-!
 # Simson's line theorem (simson-line-theorem-oq-01)
 
-Let `A, B, C` be three points of a circle and `P` a fourth point on the **same** circle.
-Drop the perpendicular from `P` onto each of the three side-lines `AB`, `BC`, `CA`, obtaining
-the three feet `F_AB`, `F_BC`, `F_CA`. **Simson's theorem** states that these three feet are
-**collinear** (the line they span is the *Simson line* of `P`).
+Let `A, B, C` be three points of a circle and `P` a fourth point of the plane. Drop the
+perpendicular from `P` onto each of the three side-lines `AB`, `BC`, `CA`, obtaining the three feet
+`F_AB`, `F_BC`, `F_CA`. **Simson's theorem** states that these three feet are **collinear** if and
+only if `P` lies on the **same** circle (the line they span is then the *Simson line* of `P`).
 
 We model the points as complex numbers and normalise the circumcircle to the **unit circle**,
 encoded by `Complex.normSq A = 1` (i.e. `|A|² = 1`), and likewise for `B, C, P`. Any circle is
@@ -30,6 +30,12 @@ a pure `ring` fact, with the symmetric companion (`foot_diff'`). Writing
 complex criterion `w ∈ ℝ`, i.e. `w = conj w` (`simson_key`), equivalently the vanishing of the
 signed-area cross product `w.im = 0` (`simson_collinear`). Substituting `conj z = z⁻¹` (valid on
 the unit circle) turns `simson_key` into a rational-function identity closed by `field_simp; ring`.
+
+Keeping `conj p` **free** (i.e. not assuming `P` on the circle) upgrades this to the master identity
+`w - conj w = (c - a)(b - c)(a - b)(1 - p * conj p)/(4 a b c)` (`simson_area_identity`), whose
+right-hand side carries the deviation `1 - |P|²`. For a nondegenerate triangle this gives the full
+**biconditional** `simson_iff`: the feet are collinear iff `P` is concyclic with `A, B, C`. The new
+converse direction is `simson_converse`.
 
 The proof is fully machine-checked: no axioms, no `sorry`. Not a named Mathlib result.
 -/
@@ -132,6 +138,96 @@ theorem simson_collinear {a b c p : ℂ}
   apply im_eq_zero_of_conj_eq
   rw [map_mul, Complex.conj_conj]
   exact (simson_key ha hb hc hp).symm
+
+/-! ## The converse: collinearity forces `P` onto the circumcircle
+
+`simson_collinear` is the forward half of Simson's theorem: if `P` lies on the circumcircle then
+the three pedal feet are collinear. The **converse** completes the classical biconditional —
+collinearity of the feet *forces* `P` onto the circumcircle.
+
+The engine is a single **master identity** (`simson_area_identity`): for `A, B, C` on the unit
+circle and **any** `P`, the conjugate-difference of the collinearity quantity
+`w = (F_BC - F_AB) * conj (F_CA - F_AB)` factors as
+
+    w - conj w = (c - a) * (b - c) * (a - b) * (1 - p * conj p) / (4 * a * b * c).
+
+The numerator carries the deviation `1 - p * conj p = 1 - |P|²` of `P` from the unit circle, and
+for a nondegenerate triangle the prefactor `(c - a)(b - c)(a - b)/(4 a b c)` is nonzero. Hence `w`
+is real (the feet are collinear) **iff** `|P|² = 1`. This delivers both directions at once: the
+forward direction recovers `simson_key`, and the converse (`simson_converse`) is new. The complete
+biconditional is `simson_iff`. -/
+
+/-- **Master identity.** For `A, B, C` on the unit circle and **any** `P` (no constraint on `P`),
+the conjugate-difference of the collinearity quantity `w = (F_BC - F_AB) * conj (F_CA - F_AB)`
+equals `(c - a)(b - c)(a - b)(1 - p * conj p)/(4 a b c)`. The factor `1 - p * conj p` is `1 - |P|²`,
+the signed deviation of `P` from the unit circumcircle; it vanishes exactly when `P` is concyclic
+with `A, B, C`. Proved, like `simson_key`, by the `conj z = z⁻¹` substitution on `A, B, C` followed
+by `field_simp; ring` — but here `conj p` is left free, so the identity holds off the circle too. -/
+theorem simson_area_identity {a b c p : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1) (hc : Complex.normSq c = 1) :
+    (foot b c p - foot a b p) * conj (foot c a p - foot a b p)
+      - conj ((foot b c p - foot a b p) * conj (foot c a p - foot a b p))
+      = (c - a) * (b - c) * (a - b) * (1 - p * conj p) / (4 * a * b * c) := by
+  rw [foot_diff, foot_diff']
+  simp only [map_mul, map_sub, map_div₀, map_one, map_ofNat, Complex.conj_conj]
+  rw [conj_eq_inv ha, conj_eq_inv hb, conj_eq_inv hc]
+  have ha0 := ne_zero_of_normSq_one ha
+  have hb0 := ne_zero_of_normSq_one hb
+  have hc0 := ne_zero_of_normSq_one hc
+  field_simp
+  ring
+
+/-- **Converse of Simson's theorem.** For a *nondegenerate* triangle `A, B, C` on the unit circle
+(distinct vertices), if the three pedal feet of `P` are collinear then `P` lies on the
+circumcircle: `|P|² = 1`. Extracted from the master identity `simson_area_identity`: collinearity
+makes its left-hand side vanish, and the nonzero triangle prefactor `(c - a)(b - c)(a - b)/(4 a b c)`
+forces the remaining factor `1 - p * conj p` to be `0`. -/
+theorem simson_converse {a b c p : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1) (hc : Complex.normSq c = 1)
+    (hab : a ≠ b) (hbc : b ≠ c) (hca : c ≠ a)
+    (hcol : ((foot b c p - foot a b p) * conj (foot c a p - foot a b p)).im = 0) :
+    Complex.normSq p = 1 := by
+  have ha0 := ne_zero_of_normSq_one ha
+  have hb0 := ne_zero_of_normSq_one hb
+  have hc0 := ne_zero_of_normSq_one hc
+  -- The collinearity quantity is real, so it equals its own conjugate.
+  have hreal :
+      conj ((foot b c p - foot a b p) * conj (foot c a p - foot a b p))
+        = (foot b c p - foot a b p) * conj (foot c a p - foot a b p) := by
+    apply Complex.ext
+    · rw [Complex.conj_re]
+    · rw [Complex.conj_im, hcol, neg_zero]
+  have key := simson_area_identity (a := a) (b := b) (c := c) (p := p) ha hb hc
+  rw [hreal, sub_self] at key
+  -- key : 0 = (c - a) * (b - c) * (a - b) * (1 - p * conj p) / (4 * a * b * c)
+  have hden : (4 : ℂ) * a * b * c ≠ 0 :=
+    mul_ne_zero (mul_ne_zero (mul_ne_zero (by norm_num) ha0) hb0) hc0
+  rw [eq_comm, div_eq_zero_iff] at key
+  rcases key with hnum | hbad
+  · have hpp : (1 : ℂ) - p * conj p = 0 := by
+      rcases mul_eq_zero.mp hnum with h | h
+      · exfalso
+        rcases mul_eq_zero.mp h with h' | h'
+        · rcases mul_eq_zero.mp h' with h'' | h''
+          · exact (sub_ne_zero.mpr hca) h''
+          · exact (sub_ne_zero.mpr hbc) h''
+        · exact (sub_ne_zero.mpr hab) h''
+      · exact h
+    have h2 : p * conj p = 1 := by linear_combination -hpp
+    rw [Complex.mul_conj] at h2
+    exact_mod_cast h2
+  · exact absurd hbad hden
+
+/-- **Simson's theorem (biconditional).** For a nondegenerate triangle `A, B, C` on the unit circle,
+the three pedal feet of `P` are collinear **if and only if** `P` lies on the circumcircle. The
+forward direction is `simson_collinear`; the converse is `simson_converse`. This is the complete
+statement of Simson's (Wallace's) theorem. -/
+theorem simson_iff {a b c p : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1) (hc : Complex.normSq c = 1)
+    (hab : a ≠ b) (hbc : b ≠ c) (hca : c ≠ a) :
+    ((foot b c p - foot a b p) * conj (foot c a p - foot a b p)).im = 0
+      ↔ Complex.normSq p = 1 :=
+  ⟨simson_converse ha hb hc hab hbc hca, fun hp => simson_collinear ha hb hc hp⟩
 
 /-! ## The Simson line bisects the segment to the orthocenter
 

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "simson-line-theorem-oq-01",
   "title": "Simson's Line Theorem",
   "slug": "simson-line-theorem-oq-01",
-  "description": "For a point P on the circumcircle of triangle ABC, the feet of the perpendiculars from P onto the three side-lines AB, BC, CA are collinear. The line they span is the Simson line of P.",
+  "description": "Simson's theorem as a biconditional: the feet of the perpendiculars from a point P to the three side-lines of triangle ABC are collinear if and only if P lies on the circumcircle of ABC. Formalized in complex coordinates with the circumcircle normalised to the unit circle.",
   "meta": {
     "author": "Robert Simson / William Wallace (attributed)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Simson_line",
@@ -39,6 +39,11 @@
         "theorem": "Complex.conj_im",
         "description": "Imaginary part of a conjugate, used in the real/collinearity criterion",
         "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "div_eq_zero_iff",
+        "description": "a / b = 0 ↔ a = 0 ∨ b = 0, used to extract the vanishing factor in the converse",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
       }
     ],
     "originalContributions": [
@@ -48,14 +53,17 @@
       "Collinearity reduced to the complex criterion w = conj w (simson_key), then to vanishing signed area w.im = 0 (simson_collinear)",
       "Whole theorem discharged by conj z = z⁻¹ substitution + field_simp + ring, no axioms or sorries",
       "Bisection theorem: the Simson line of P passes through the midpoint of PH (H = orthocenter = A+B+C for the unit circumcircle), proved by the same conj z = z^-1 + field_simp + ring engine (simson_bisects_orthocenter_segment)",
-      "Antipodal perpendicularity: the Simson lines of P and its antipode -P are perpendicular (antipodal_simson_perp); the antipode flips conj p -> -conj p, collapsing the Hermitian product of the two foot-difference directions to |c-a|²/4·(conj b·p - b·conj p), purely imaginary, so its real part vanishes — same conj z = z⁻¹ + field_simp + ring engine"
+      "Antipodal perpendicularity: the Simson lines of P and its antipode -P are perpendicular (antipodal_simson_perp); the antipode flips conj p -> -conj p, collapsing the Hermitian product of the two foot-difference directions to |c-a|²/4·(conj b·p - b·conj p), purely imaginary, so its real part vanishes — same conj z = z⁻¹ + field_simp + ring engine",
+      "Master identity simson_area_identity: keeping conj p free gives w - conj w = (c-a)(b-c)(a-b)(1 - p*conj p)/(4abc), valid for ANY P (off the circle too)",
+      "Converse direction simson_converse: for a nondegenerate triangle, collinearity of the three feet forces |P|² = 1 (P concyclic with A,B,C), via the nonzero triangle prefactor",
+      "Headline biconditional simson_iff: the three pedal feet are collinear if and only if P lies on the circumcircle — the complete statement of Simson's (Wallace's) theorem"
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 237,
+    "lineCount": 332,
     "assumptions": "0 axioms. 0 sorries. Fully verified. Circumcircle normalised to the unit circle (Complex.normSq = 1) without loss of generality; on that normalisation the orthocenter is A+B+C.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 3
   },
   "sections": [
@@ -98,19 +106,28 @@
       "description": "simson_key: the complex collinearity criterion w = conj w for the triangle of feet. simson_collinear: the equivalent vanishing signed area w.im = 0, proving the three feet are collinear.",
       "summary": "Simson's Theorem",
       "id": "simsons-theorem"
+    },
+    {
+      "title": "The Converse & Biconditional",
+      "startLine": 142,
+      "endLine": 230,
+      "description": "Completes Simson's theorem to a biconditional. Keeping conj p free in the collinearity computation yields the master identity w - conj w = (c-a)(b-c)(a-b)(1 - p*conj p)/(4abc) (simson_area_identity), valid for any P. For a nondegenerate triangle the prefactor is nonzero, so the feet are collinear iff 1 - |P|² = 0, i.e. P is concyclic with A, B, C.",
+      "summary": "Master identity simson_area_identity (any P) gives the converse simson_converse (collinear feet ⇒ |P|²=1) and the headline biconditional simson_iff.",
+      "id": "converse-biconditional"
     }
   ],
   "overview": {
     "historicalContext": "The Simson line is named after the Scottish mathematician Robert Simson (1687–1768), though the result does not appear in his surviving work; it was first explicitly published by William Wallace in 1797 and is sometimes called the Wallace line. The theorem is a cornerstone of triangle geometry: it characterizes the circumcircle as exactly the locus of points whose three perpendicular feet onto the side-lines are collinear (a point off the circumcircle produces a genuine 'pedal triangle' of positive area).\n\nThe Simson line carries a rich further structure. As P traverses the circumcircle, the Simson line envelopes a deltoid (Steiner's deltoid), and the Simson lines of diametrically opposite points are perpendicular. The Simson line of P also bisects the segment joining P to the orthocenter of the triangle. These refinements make the Simson line a gateway to the deeper projective and metric geometry of the triangle.\n\nThe complex-number proof used here is the standard modern treatment: placing the circumcircle at the unit circle turns the orthogonal projection onto a chord into a rational expression in the vertices and their conjugates, and the unit-circle constraint conj z = 1/z collapses the collinearity condition to a polynomial identity.",
     "problemStatement": "**Simson's Line Theorem**: Let ABC be a triangle and P a point on its circumcircle. Let F_AB, F_BC, F_CA be the feet of the perpendiculars dropped from P onto the lines AB, BC, CA respectively. Then F_AB, F_BC, F_CA are collinear; the line through them is called the Simson line (or Wallace line) of P with respect to the triangle.",
     "text": "For a point P on the circumcircle of a triangle, the three feet of the perpendiculars from P to the sides of the triangle lie on a single line — the Simson line.",
-    "proofStrategy": "The proof uses **complex coordinates** with the circumcircle normalised to the **unit circle**.\n\n1. **Foot formula**: For u, v on the unit circle, the foot of the perpendicular from any p onto the chord-line uv has the closed form foot(u,v,p) = (u + v + p − u·v·conj p)/2. This is verified to be the orthogonal projection by checking perpendicularity (Re((p−foot)·conj(v−u)) = 0) and incidence on the line (Im((foot−u)·conj(v−u)) = 0).\n\n2. **Difference identity**: foot(b,c,p) − foot(a,b,p) = (c−a)(1 − b·conj p)/2, a pure algebraic identity. Symmetrically, foot(c,a,p) − foot(a,b,p) = (c−b)(1 − a·conj p)/2.\n\n3. **Collinearity criterion**: three complex points are collinear iff w = (z₂−z₁)·conj(z₃−z₁) is real, i.e. w = conj w (equivalently Im w = 0, the vanishing of the signed area). Applying this to the three feet and substituting conj z = z⁻¹ (valid on the unit circle) reduces the statement to a rational-function identity, closed by field_simp and ring.",
+    "proofStrategy": "The proof uses **complex coordinates** with the circumcircle normalised to the **unit circle**.\n\n1. **Foot formula**: For u, v on the unit circle, the foot of the perpendicular from any p onto the chord-line uv has the closed form foot(u,v,p) = (u + v + p − u·v·conj p)/2. This is verified to be the orthogonal projection by checking perpendicularity (Re((p−foot)·conj(v−u)) = 0) and incidence on the line (Im((foot−u)·conj(v−u)) = 0).\n\n2. **Difference identity**: foot(b,c,p) − foot(a,b,p) = (c−a)(1 − b·conj p)/2, a pure algebraic identity. Symmetrically, foot(c,a,p) − foot(a,b,p) = (c−b)(1 − a·conj p)/2.\n\n3. **Collinearity criterion**: three complex points are collinear iff w = (z₂−z₁)·conj(z₃−z₁) is real, i.e. w = conj w (equivalently Im w = 0, the vanishing of the signed area). Applying this to the three feet and substituting conj z = z⁻¹ (valid on the unit circle) reduces the statement to a rational-function identity, closed by field_simp and ring.\n\n4. **Converse (biconditional)**: keeping conj p free turns the collinearity computation into the master identity w − conj w = (c−a)(b−c)(a−b)(1 − p·conj p)/(4abc) (simson_area_identity). For distinct vertices the prefactor is nonzero, so collinearity (w real) forces 1 − |P|² = 0, i.e. P lies on the circumcircle (simson_converse). Combined with the forward direction this is the headline biconditional simson_iff.",
     "keyInsights": [
       "**Unit-circle normalisation**: placing the circumcircle at |z| = 1 makes conj z = z⁻¹, turning conjugation into a rational operation and the whole theorem into a polynomial identity",
       "**Closed-form foot**: foot(u,v,p) = (u+v+p − u·v·conj p)/2 packages the orthogonal projection onto a chord; it needs only u, v on the circle, not p",
       "**Difference identity**: foot(b,c,p) − foot(a,b,p) = (c−a)(1 − b·conj p)/2 is a pure ring fact — the geometric content is entirely in this factorisation through the chord direction c−a",
       "**Real-ratio = collinear**: the classical criterion that (z₂−z₁)·conj(z₃−z₁) ∈ ℝ encodes collinearity (its imaginary part is twice the signed area of the triangle of feet)",
-      "**Circumcircle is essential**: the same computation off the unit circle yields a nonzero signed area, recovering the converse that only circumcircle points give a degenerate pedal triangle"
+      "**Circumcircle is essential**: the same computation off the unit circle yields a nonzero signed area, recovering the converse that only circumcircle points give a degenerate pedal triangle",
+      "**Free conj p ⇒ biconditional**: not assuming P on the circle yields the master identity w - conj w = (c-a)(b-c)(a-b)(1 - p·conj p)/(4abc); the factor 1 - |P|² makes collinearity of the feet equivalent to P being on the circumcircle, giving the full iff (simson_iff)"
     ],
     "prerequisites": [
       "Complex numbers and arithmetic in ℂ",
@@ -124,7 +141,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Simson's theorem is formalized with complex coordinates and the circumcircle normalised to the unit circle. The closed-form perpendicular foot foot(u,v,p) = (u+v+p − u·v·conj p)/2 and its difference identity reduce collinearity of the three feet to the complex criterion w = conj w, discharged by substituting conj z = z⁻¹ and applying field_simp with ring. The perpendicular foot is independently certified by perpendicularity and incidence lemmas.",
+    "summary": "Simson's theorem is formalized as a complete biconditional in complex coordinates with the circumcircle normalised to the unit circle. The closed-form perpendicular foot foot(u,v,p) = (u+v+p − u·v·conj p)/2 and its difference identity reduce collinearity of the three feet to the complex criterion w = conj w. Keeping conj p free upgrades this to the master identity w − conj w = (c−a)(b−c)(a−b)(1 − p·conj p)/(4abc), whose 1 − |P|² factor delivers both directions: the feet are collinear iff P lies on the circumcircle (simson_iff). All steps are discharged by the conj z = z⁻¹ substitution with field_simp and ring; no axioms, no sorries.",
     "implications": "**Theoretical Significance**: The proof again demonstrates the leverage of complex coordinates in classical plane geometry: a metric statement about perpendicular feet on a circle becomes a rational identity. The unit-circle substitution conj z = z⁻¹ is the same device that powers the complex proofs of Ptolemy's and Napoleon's theorems, situating Simson's line within a common algebraic toolkit for circle and triangle geometry.",
     "openQuestions": [
       "Can the Steiner deltoid envelope of Simson lines be formalized?",
@@ -154,9 +171,9 @@
       "ComplexConjugate"
     ],
     "namespace": "SimsonLineTheorem",
-    "lineCount": 237,
+    "lineCount": 332,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/SimsonLineTheorem.lean"


### PR DESCRIPTION
## Summary

Extends the Simson line formalization (`simson-line-theorem-oq-01`) with the **converse** and the headline **biconditional**.

- **`simson_area_identity`** — master identity, keeping `conj p` free:
  `w - conj w = (c-a)(b-c)(a-b)(1 - p * conj p) / (4abc)`, valid for any P, via `conj z = z⁻¹` substitution + `field_simp` + `ring`.
- **`simson_converse`** — for a nondegenerate triangle the prefactor `(c-a)(b-c)(a-b)/(4abc)` is nonzero, so collinearity of the three pedal feet forces `|P|² = 1` (P lies on the circumcircle).
- **`simson_iff`** — headline biconditional: the three feet are collinear **iff** P lies on the circumcircle (forward `simson_collinear` + `simson_converse`).

## Verification

- 0 axioms, 0 `sorry`
- 237 → 332 lines, 11 → 14 theorems
- Same `simson_key` engine as the forward direction (`foot_diff` + `conj = inv` + `field_simp` + `ring`)
- Docker build passing

meta.json updated: description, 3 new originalContributions, new section "The Converse & Biconditional", proofStrategy step 5, keyInsight, conclusion, both leanFile blocks → 332L / 14thm. Status remains `verified` / `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)