### PR TITLE
audit(erdos-193): fix off-by-one theorem count in assumptions (17 → 18)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5145,9 +5145,9 @@
     },
     "erdos-193": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T17:03:29Z",
+      "result": "issues-fixed"
     },
     "erdos-194": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "lineCount": 403,
-    "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem, published result). Proved: erdos193_rank_le_2 (reduction to 2D via projection + Gerver-Ramsey), plus 17 other theorems including collinearity properties, dimension-1 case, singleton/parallel step sets, and dimension reduction framework.",
+    "assumptions": "1 axiom: gerver_ramsey_2d (Gerver-Ramsey 2D theorem, published result). Proved: erdos193_rank_le_2 (reduction to 2D via projection + Gerver-Ramsey), plus 18 other theorems including collinearity properties, dimension-1 case, singleton/parallel step sets, and dimension reduction framework.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
     "definitionCount": 11


### PR DESCRIPTION
## Gallery Integrity Re-Audit — erdos-193 (Collinear Points in Lattice Walks)

Re-audit of Erdős Problem #193 (Gerver–Ramsey). **Essentially clean** — all
structural counts, status/badge, masking, sections, and conclusion verified
correct. One conservative prose undercount fixed.

### Verified correct
- **403L / 1ax / 0sorry / 0nd / 0True / 19thm / 11def** — every meta count exact
  (the lone `theorem` match at line 402 is prose inside the summary comment).
- **status `axiomatized` / badge `axiom` — CORRECT** (Tier C). Headline
  `ErdosProblem193` is an unproved `Prop` definition (the 3D case is OPEN). The
  single axiom `gerver_ramsey_2d` is the published Gerver–Ramsey 2D theorem,
  disclosed by name; `erdos193_rank_le_2` genuinely invokes it (line 359, full
  proof, no sorry).
- **No masking**: title/description disclose "Proved for ℤ² … the ℤ³ case
  remains open."
- **No phantom claims**: no `originalContributions`/`mainTheorems` fields;
  `conclusion.summary` accurately enumerates the proved cases (dim 1, singleton,
  parallel, rank ≤ 2 via axiom, dimension reduction).
- All 14 section line ranges align with the source.

### Fix
`assumptions` stated "plus **17** other theorems"; there are actually **18**
others (19 total − `erdos193_rank_le_2`). A conservative undercount (claims fewer
proved than reality, no credibility risk) — corrected to 18 for accuracy.

Tracker updated to record the re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)