### PR TITLE
audit(erdos-197): fix stale phantom-axiom prose + realign section ranges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5172,9 +5172,9 @@
     },
     "erdos-197": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T17:08:35Z",
+      "result": "issues-fixed"
     },
     "erdos-198": {
       "agentId": "auditor-session-1777705382",

--- a/src/data/proofs/erdos-197/meta.json
+++ b/src/data/proofs/erdos-197/meta.json
@@ -106,57 +106,57 @@
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "summary": "erdos_197_conjecture axiom - the open two-set question",
+      "summary": "erdos_197_conjecture theorem - the open two-set question (disjunction by excluded middle)",
       "startLine": 123,
-      "endLine": 142,
-      "mathContext": "Axiomatized: erdos_197_conjecture axiom - the open two-set question"
+      "endLine": 151,
+      "mathContext": "Theorem: erdos_197_conjecture states the open two-set question as a disjunction proved by excluded middle (it does not resolve which disjunct holds)"
     },
     {
       "id": "three-set-case",
       "title": "The Three-Set Case (Solved)",
       "summary": "isThreePartition and erdos_graham_three_sets axiom",
-      "startLine": 143,
-      "endLine": 163,
+      "startLine": 152,
+      "endLine": 172,
       "mathContext": "Axiomatized: isThreePartition and erdos_graham_three_sets axiom"
     },
     {
       "id": "properties",
       "title": "Properties of 3-AP Avoidance",
-      "summary": "constant_avoids_3AP, StrictlyIncreasing, StrictlyDecreasing",
-      "startLine": 164,
-      "endLine": 191,
-      "mathContext": "Mathematical content: constant_avoids_3AP, StrictlyIncreasing, StrictlyDecreasing"
+      "summary": "constant_has_3AP theorem, StrictlyIncreasing and StrictlyDecreasing definitions",
+      "startLine": 173,
+      "endLine": 196,
+      "mathContext": "Mathematical content: constant_has_3AP theorem (a constant sequence has trivial 3-APs), StrictlyIncreasing and StrictlyDecreasing definitions"
     },
     {
       "id": "examples",
       "title": "Small Examples",
-      "summary": "identity_has_3AP theorem and powers_of_2_avoid_3AP axiom",
-      "startLine": 192,
-      "endLine": 215,
-      "mathContext": "Verified: identity_has_3AP theorem and powers_of_2_avoid_3AP axiom"
+      "summary": "identity_has_3AP and powers_of_2_avoid_3AP theorems",
+      "startLine": 197,
+      "endLine": 239,
+      "mathContext": "Verified: identity_has_3AP and powers_of_2_avoid_3AP theorems (both proved, not axiomatized)"
     },
     {
       "id": "computational",
       "title": "Computational Intractability",
-      "summary": "erdos_197_not_finite_checkable axiom",
-      "startLine": 216,
-      "endLine": 230,
-      "mathContext": "Axiomatized: erdos_197_not_finite_checkable axiom"
+      "summary": "Prose discussion of why finite computation cannot resolve the problem (no formal declaration)",
+      "startLine": 240,
+      "endLine": 248,
+      "mathContext": "Documentation only: meta-mathematical observation, no axiom or theorem (the former erdos_197_not_finite_checkable axiom was removed as malformed)"
     },
     {
       "id": "related-sequences",
       "title": "Related Sequences",
       "summary": "Stanley sequence definition and properties",
-      "startLine": 231,
-      "endLine": 255,
+      "startLine": 249,
+      "endLine": 278,
       "mathContext": "Formal definition: Stanley sequence definition and properties"
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_197_status and erdos_197_open_question theorems",
-      "startLine": 256,
-      "endLine": 287,
+      "startLine": 279,
+      "endLine": 307,
       "mathContext": "Verified: erdos_197_status and erdos_197_open_question theorems"
     }
   ],


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-197

**Proof**: erdos-197 (Partition of ℕ Avoiding Monotone 3-AP Permutations, axiomatized/axiom, OPEN)

Re-audit of `proofs/Proofs/Erdos197Problem.lean` (307 lines).

### Hard counts — all verified correct (no change)
- **2 axioms**: `erdos_graham_three_sets`, `stanley_avoids_3AP` (both disclosed in `assumptions`)
- 9 theorems, 10 definitions, 0 sorries, 0 `native_decide`, 0 True stubs
- `status: axiomatized` / `badge: axiom` / `erdosProblemStatus: open` — all correct. Headline `erdos_197_conjecture` is an honest excluded-middle disjunction (does **not** claim the conjecture resolved); `erdos_197_status` genuinely invokes the `erdos_graham_three_sets` axiom. No masking.

### Issues fixed (prose / section metadata only)
The `sections` array carried **stale phantom-axiom prose** — an inverse overclaim asserting *more* axiomatization than the file contains:

1. **main-conjecture** called `erdos_197_conjecture` an "axiom" → it is a **theorem** (L138, proved by excluded middle). The `assumptions` field already records it was de-axiomatized.
2. **examples** called `powers_of_2_avoid_3AP` an "axiom" → it is a **theorem** (L221), also explicitly de-axiomatized.
3. **computational** claimed an `erdos_197_not_finite_checkable axiom` → **no such declaration exists**; Part VIII is a prose comment only, and the malformed axiom was previously removed (per `assumptions`).
4. **properties** named `constant_avoids_3AP` → the real theorem is `constant_has_3AP` (wrong name *and* inverted meaning — a constant sequence *has* trivial 3-APs).

Also realigned drifted section line ranges for Parts IV–X to match the 307-line source.

`axiomCount` (2) was already correct because these phantoms were uncounted — this is a pure prose/section-metadata fix.

---
Discovered during gallery integrity audit. No Lean source changes.