### PR TITLE
research(fermat-defect-one-oq-04): verified no-small-witness lower bound M(n) ≥ 2 in box c ≤ 100 for n ∈ {4,5,6}

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2338,6 +2338,7 @@ import Proofs.FairGamesTheoremOQ03Aristotle
 import Proofs.FermatDefectOne
 import Proofs.FermatDefectOneFamilies
 import Proofs.FermatDefectOneNegInfinitude
+import Proofs.FermatDefectOneOQ04
 import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01
 import Proofs.FermatTwoSquaresOQ01OQ03

--- a/proofs/Proofs/FermatDefectOneOQ04.lean
+++ b/proofs/Proofs/FermatDefectOneOQ04.lean
@@ -1,0 +1,132 @@
+/-
+  Fermat Defect-One — OQ-04: No Small Witnesses (a verified lower bound on M(n))
+
+  Parent problem (`Proofs.FermatDefectOne`): does the Fermat defect
+  $|a^n + b^n - c^n|$ ever equal exactly $1$ for a primitive nontrivial triple
+  $2 \le a \le b < c$, $\gcd(a,b,c) = 1$? For $n = 3$ both signs are witnessed
+  (`6^3 + 8^3 + 1 = 9^3` and `9^3 + 10^3 = 12^3 + 1`). For $n \ge 4$ existence is
+  open, and the competing question (OQ-03) asks whether the minimal defect
+  $M(n) := \min |a^n + b^n - c^n|$ over primitive nontrivial triples grows.
+
+  This file (OQ-04) supplies the complementary computational evidence requested
+  by the issue: a `decide`-style **no-small-witness** result. For each exponent
+  $n \in \{4, 5, 6\}$ we certify, by `native_decide`, that **no** triple with
+  $2 \le a \le b < c \le 100$ has defect one (either sign). Equivalently, within
+  the box $c \le 100$ the minimal defect satisfies $M(n) \ge 2$ for these $n$.
+
+  Two points make the statement clean:
+
+  * **Primitivity is automatic for defect one.** If $a^n + b^n - c^n = \pm 1$ and
+    $d = \gcd(a,b,c)$, then $d^n \mid \pm 1$, so $d = 1$. Hence the box-emptiness
+    below is stated WITHOUT a gcd hypothesis (strictly stronger), and the
+    primitive-witness corollaries follow immediately.
+
+  * **$n = 3$ is genuinely different.** The box $c \le 100$ already contains the
+    witness $(6,8,9)$ at $n = 3$, so the vanishing for $n \ge 4$ is not an
+    artifact of the bound — it is an exponent effect (`defect_one_three_in_box`).
+
+  Honesty note: each headline non-existence theorem is discharged by
+  `native_decide`, which trusts the compiler's kernel reduction and therefore
+  depends on the `Lean.ofReduceBool` axiom. These are finite certificates over a
+  bounded box, not a proof of the (open) infinite statement.
+-/
+
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne.OQ04
+
+open FermatDefectOne
+
+/-! ## Bounded non-existence of defect one (the `native_decide` core)
+
+For each exponent `n`, the proposition below is a fully bounded statement over
+`Nat` (`Nat.decidableBallLT` makes it decidable), checked by `native_decide`.
+The shape `∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a → …` enumerates exactly the
+admissible triples `2 ≤ a ≤ b < c ≤ 100`. -/
+
+/-- No defect-one equation (either sign) holds at exponent `4` for any triple
+with `2 ≤ a ≤ b < c ≤ 100`. -/
+theorem no_defect_one_eqn_below_4 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 4 + b ^ 4 + 1 ≠ c ^ 4 ∧ a ^ 4 + b ^ 4 ≠ c ^ 4 + 1 := by
+  native_decide
+
+/-- No defect-one equation (either sign) holds at exponent `5` for any triple
+with `2 ≤ a ≤ b < c ≤ 100`. -/
+theorem no_defect_one_eqn_below_5 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 5 + b ^ 5 + 1 ≠ c ^ 5 ∧ a ^ 5 + b ^ 5 ≠ c ^ 5 + 1 := by
+  native_decide
+
+/-- No defect-one equation (either sign) holds at exponent `6` for any triple
+with `2 ≤ a ≤ b < c ≤ 100`. -/
+theorem no_defect_one_eqn_below_6 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 6 + b ^ 6 + 1 ≠ c ^ 6 ∧ a ^ 6 + b ^ 6 ≠ c ^ 6 + 1 := by
+  native_decide
+
+/-! ## Box-emptiness without the primitivity hypothesis (strong form)
+
+Restated with the natural ordering hypotheses up front. No `gcd` condition is
+needed: defect one forces primitivity. -/
+
+/-- Strong form, `n = 4`: every triple `2 ≤ a ≤ b < c ≤ 100` has defect `≠ 1`
+(both signs), with no primitivity assumption. -/
+theorem no_small_defect_one_4 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 4 + b ^ 4 + 1 ≠ c ^ 4 ∧ a ^ 4 + b ^ 4 ≠ c ^ 4 + 1 :=
+  no_defect_one_eqn_below_4 c (by omega) b hbc a (by omega) ha
+
+/-- Strong form, `n = 5`. -/
+theorem no_small_defect_one_5 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 5 + b ^ 5 + 1 ≠ c ^ 5 ∧ a ^ 5 + b ^ 5 ≠ c ^ 5 + 1 :=
+  no_defect_one_eqn_below_5 c (by omega) b hbc a (by omega) ha
+
+/-- Strong form, `n = 6`. -/
+theorem no_small_defect_one_6 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 6 + b ^ 6 + 1 ≠ c ^ 6 ∧ a ^ 6 + b ^ 6 ≠ c ^ 6 + 1 :=
+  no_defect_one_eqn_below_6 c (by omega) b hbc a (by omega) ha
+
+/-! ## Primitive-witness corollaries (parent `FermatDefectWitness` form)
+
+These specialize the box-emptiness to the parent predicate, certifying that the
+defect-one *existence* statement `FermatDefectExists n` has no solution with
+`c ≤ 100` for `n ∈ {4, 5, 6}`. -/
+
+/-- No primitive defect-one witness at exponent `4` has `c ≤ 100`. -/
+theorem no_small_witness_4 (a b c : Nat) (hc : c ≤ 100) :
+    ¬ FermatDefectWitness 4 a b c := by
+  rintro ⟨ha, _, hbc, -, hdef⟩
+  exact hdef.elim (no_small_defect_one_4 a b c ha (by omega) hbc hc).1
+                  (no_small_defect_one_4 a b c ha (by omega) hbc hc).2
+
+/-- No primitive defect-one witness at exponent `5` has `c ≤ 100`. -/
+theorem no_small_witness_5 (a b c : Nat) (hc : c ≤ 100) :
+    ¬ FermatDefectWitness 5 a b c := by
+  rintro ⟨ha, _, hbc, -, hdef⟩
+  exact hdef.elim (no_small_defect_one_5 a b c ha (by omega) hbc hc).1
+                  (no_small_defect_one_5 a b c ha (by omega) hbc hc).2
+
+/-- No primitive defect-one witness at exponent `6` has `c ≤ 100`. -/
+theorem no_small_witness_6 (a b c : Nat) (hc : c ≤ 100) :
+    ¬ FermatDefectWitness 6 a b c := by
+  rintro ⟨ha, _, hbc, -, hdef⟩
+  exact hdef.elim (no_small_defect_one_6 a b c ha (by omega) hbc hc).1
+                  (no_small_defect_one_6 a b c ha (by omega) hbc hc).2
+
+/-! ## The `n = 3` contrast
+
+The bound `c ≤ 100` is not what kills the witnesses for `n ≥ 4`: at `n = 3` the
+same box already contains one. -/
+
+/-- At `n = 3` the box `c ≤ 100` DOES contain a primitive defect-one witness,
+namely `(6, 8, 9)` with `6^3 + 8^3 + 1 = 9^3`. The vanishing for `n ≥ 4` is
+therefore an exponent phenomenon, not an artifact of the bound. -/
+theorem defect_one_three_in_box :
+    ∃ a b c : Nat, c ≤ 100 ∧ FermatDefectWitness 3 a b c :=
+  ⟨6, 8, 9, by norm_num, fermat_defect_three_neg⟩
+
+end FermatDefectOne.OQ04

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -68,6 +68,7 @@
       "fermat_defect_three: derived defect-one existence at n=3 from the negative-defect benchmark",
       "defect_pos_witnesses_infinite (FermatDefectOneFamilies.lean): the positive-defect family (9s^3+1, 9s^4, 9s^4+3s) gives infinitely many primitive witnesses at n=3 (set of attainable c is infinite, via a strictly-monotone injection)",
       "defect_neg_witnesses_infinite (FermatDefectOneNegInfinitude.lean): the negative-defect family (9t^3-1, 9t^4-3t, 9t^4) gives infinitely many primitive witnesses at n=3, closing the sign symmetry — both signs occur infinitely often at n=3",
+      "no_small_witness_4/5/6 and no_defect_one_eqn_below_4/5/6 (FermatDefectOneOQ04.lean): a verified no-small-witness lower bound M(n) ≥ 2 inside the box c ≤ 100 for n ∈ {4,5,6}, both signs, via native_decide — strengthening the parent's sorry'd no_witness_n_eq_4_below_20 (c ≤ 20, n=4) to c ≤ 100 across n ∈ {4,5,6}; stated without a gcd hypothesis since defect one forces primitivity, with defect_one_three_in_box exhibiting (6,8,9) at n=3 to show the n ≥ 4 vanishing is an exponent effect",
       "fermat_defect_one_exists: headline open conjecture stated as a sorry'd target for all n ≥ 3"
     ]
   },
@@ -272,6 +273,15 @@
         "axioms": 0,
         "sorries": 0,
         "description": "Negative-defect infinitude at n=3: the family (9t^3-1, 9t^4-3t, 9t^4) yields infinitely many primitive witnesses of a^3+b^3-c^3=-1 (defect_neg_witnesses_infinite), with neg_family_coprime (primitivity) and defect_neg_data (defect identity). Combined with defect_pos_witnesses_infinite (Families.lean) this settles the sign-symmetry of open question OQ-02 at n=3 in its strongest form — each sign of the defect occurs infinitely often along an explicit polynomial family. 4 theorems, 0 axioms, 0 sorries, no native_decide (fully kernel-checked). Namespace FermatDefectOne; imports parent Proofs.FermatDefectOne."
+      },
+      {
+        "path": "Proofs/FermatDefectOneOQ04.lean",
+        "lineCount": 132,
+        "theorems": 10,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-04 — a verified no-small-witness lower bound on the minimal defect M(n). For each n in {4,5,6}, NO triple 2 ≤ a ≤ b < c ≤ 100 has defect one in either sign (a^n+b^n+1=c^n or a^n+b^n=c^n+1), so M(n) ≥ 2 inside the box (no_defect_one_eqn_below_4/5/6). Restated without a gcd hypothesis (no_small_defect_one_4/5/6) — defect one forces primitivity (d^n | 1 ⇒ d=1) — and specialized to the parent predicate (no_small_witness_4/5/6: no FermatDefectWitness n a b c with c ≤ 100). defect_one_three_in_box exhibits (6,8,9) at n=3 inside the same box, showing the vanishing for n ≥ 4 is an exponent effect, not a bound artifact. Strengthens the parent's sorry'd no_witness_n_eq_4_below_20 (c ≤ 20, n=4) to c ≤ 100 across n in {4,5,6}. 10 theorems, 0 axioms, 0 sorries; the three headline non-existence theorems are discharged by native_decide (Nat.decidableBallLT enumeration), which introduces Lean.ofReduceBool. Namespace FermatDefectOne.OQ04; imports parent Proofs.FermatDefectOne."
       }
     ]
   },

--- a/src/data/research/problems/fermat-defect-one-oq-04.json
+++ b/src/data/research/problems/fermat-defect-one-oq-04.json
@@ -1,0 +1,81 @@
+{
+  "slug": "fermat-defect-one-oq-04",
+  "title": "Fermat Defect-One: a verified no-small-witness lower bound on M(n) for n ≥ 4",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "tags": [],
+  "relatedProofs": [
+    "fermat-defect-one"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-18T00:00:00.000Z",
+  "lastUpdate": "2026-06-18T00:00:00.000Z",
+  "significance": 5,
+  "tractability": 8,
+  "problemStatement": {
+    "formal": "\\forall n \\in \\{4,5,6\\}:\\quad \\neg\\,\\exists\\, a,b,c \\in \\mathbb{N},\\ 2 \\le a \\le b < c \\le 100\\ \\wedge\\ \\big(a^n + b^n + 1 = c^n\\ \\vee\\ a^n + b^n = c^n + 1\\big)",
+    "plain": "Complementing OQ-03 (does the minimal Fermat defect M(n) = min |a^n + b^n - c^n| grow with n?), this question asks for a verified, machine-checked LOWER bound: certify that no primitive nontrivial defect-one triple with c ≤ 100 exists at exponents n = 4,5,6 (either sign). Equivalently, within the box c ≤ 100 the minimal defect satisfies M(n) ≥ 2 for these n, while at n = 3 the same box already contains a witness (6,8,9). The deliverable is a fully bounded `native_decide` certificate, strengthening the parent's `sorry`-gated no_witness_n_eq_4_below_20 (c ≤ 20, single exponent) to c ≤ 100 across n = 4,5,6.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-18T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Bounded no-small-witness lower bound on M(n), n in {4,5,6}, c <= 100, both signs, discharged by native_decide.",
+    "blockers": [],
+    "nextAction": "Optionally extend the box (c <= 200) or the exponent range; the open infinite statement (M(n) >= 2 for all n >= 4) needs Fermat-Catalan finiteness with no Mathlib bearer.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "DONE (build-pending): proved a no-small-witness lower bound on the minimal Fermat defect M(n) for n in {4,5,6}. For each such n, NO triple 2 <= a <= b < c <= 100 satisfies a^n+b^n+1=c^n or a^n+b^n=c^n+1 (both signs), so M(n) >= 2 inside the box. Discharged by native_decide over a fully bounded Nat enumeration (Nat.decidableBallLT). Stated WITHOUT a gcd hypothesis (strictly stronger) since defect one forces primitivity: d=gcd(a,b,c) => d^n | 1 => d=1. Contrast n=3, where the same box contains the witness (6,8,9). New file Proofs/FermatDefectOneOQ04.lean, 0 sorries, no literal axiom declarations; native_decide introduces Lean.ofReduceBool.",
+    "builtItems": [
+      "no_defect_one_eqn_below_{4,5,6}: for c<101, b<c, a<b+1, 2<=a, both a^n+b^n+1 != c^n and a^n+b^n != c^n+1 [native_decide core; FermatDefectOneOQ04.lean]",
+      "no_small_defect_one_{4,5,6}: same emptiness restated with natural ordering hypotheses (2<=a<=b<c<=100), no gcd assumption (defect one forces primitivity)",
+      "no_small_witness_{4,5,6} (a b c) (hc:c<=100): not FermatDefectWitness n a b c — specializes box-emptiness to the parent predicate; certifies FermatDefectExists n has no solution with c<=100",
+      "defect_one_three_in_box: at n=3 the box c<=100 DOES contain a primitive witness (6,8,9), via fermat_defect_three_neg — the vanishing for n>=4 is an exponent effect, not an artifact of the bound"
+    ],
+    "insights": [
+      "Defect one forces primitivity: if a^n+b^n-c^n = +/-1 and d=gcd(a,b,c) then d^n | 1 so d=1; hence the bounded non-existence can be stated WITHOUT a gcd hypothesis and is strictly stronger than the FermatDefectWitness form (which carries gcd=1).",
+      "The shape forall c<101, forall b<c, forall a<b+1, 2<=a -> P enumerates exactly the admissible triples 2<=a<=b<c<=100 and is decidable via Nat.decidableBallLT, so native_decide compiles the whole finite check.",
+      "This strengthens the parent's sorry-gated no_witness_n_eq_4_below_20 (c<=20, n=4 only) to c<=100 across n in {4,5,6}, both signs — a genuine discharge of an open bounded-search target, not a restatement.",
+      "n=3 is genuinely different: the box c<=100 contains (6,8,9), so M(3)=1 already inside the box, whereas M(n)>=2 inside the box for n=4,5,6. The defect-one phenomenon at n=3 is a critical-exponent artifact (cf. OQ-02 insight: expected solution count scales like X^(3-n))."
+    ],
+    "mathlibGaps": [
+      "No abc-conjecture / Fermat-Catalan finiteness in Mathlib to lift the bounded M(n)>=2 to the open infinite statement (all triples, n>=4).",
+      "The bounded result needs nothing beyond Nat.decidableBallLT + native_decide."
+    ],
+    "nextSteps": [
+      "Optionally widen the box (c<=200) or extend the exponent range (n up to ~12); the native_decide cost grows but stays finite.",
+      "The genuine open core (M(n)>=2 for ALL n>=4, unbounded) requires Fermat-Catalan-type finiteness — no Mathlib bearer.",
+      "Optionally derive an explicit M(n)>=2-in-box corollary phrased via a min over the box for presentation."
+    ],
+    "markdown": "# Knowledge Base: fermat-defect-one-oq-04\n\n## Source\nGallery-extracted open question extending **fermat-defect-one**: a verified no-small-witness lower bound on the minimal defect M(n).\n\n## Progress Summary\nProved (build-pending) bounded non-existence of defect-one triples (both signs) for n in {4,5,6}, c <= 100, via native_decide. See Proofs/FermatDefectOneOQ04.lean.\n"
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/FermatDefectOneOQ04.lean",
+      "filename": "FermatDefectOneOQ04.lean",
+      "lineCount": 132,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A new gallery proof file `Proofs/FermatDefectOneOQ04.lean` supplying the **no-small-witness** lower bound on the minimal Fermat defect $M(n) = \min |a^n + b^n - c^n|$, complementing OQ-03 (does $M(n)$ grow?).

For each exponent $n \in \{4, 5, 6\}$, `native_decide` certifies that **no** triple $2 \le a \le b < c \le 100$ has defect one in either sign ($a^n+b^n+1=c^n$ or $a^n+b^n=c^n+1$). Equivalently, $M(n) \ge 2$ inside the box $c \le 100$ for these $n$.

## Key points

- **Primitivity is automatic for defect one.** If $a^n+b^n-c^n = \pm 1$ and $d=\gcd(a,b,c)$ then $d^n \mid 1$ so $d=1$. The box-emptiness is therefore stated **without** a gcd hypothesis (strictly stronger than the parent `FermatDefectWitness` form), with the primitive-witness corollaries `no_small_witness_4/5/6` following immediately.
- **$n=3$ is genuinely different.** `defect_one_three_in_box` exhibits $(6,8,9)$ ($6^3+8^3+1=9^3$) inside the *same* box, so the vanishing for $n \ge 4$ is an exponent effect, not an artifact of the bound.
- **Strengthens the parent.** The companion `FermatDefectOneAristotle.lean` has a `sorry`'d `no_witness_n_eq_4_below_20` (c ≤ 20, n=4 only); this discharges c ≤ 100 across n ∈ {4,5,6}, both signs.

## Verification

- **Docker build:** `Build completed successfully (7744 jobs)`. (The lone `sorry` warning is the parent's headline open conjecture at `FermatDefectOne.lean:280`, not this file.)
- 10 theorems, 0 axioms, 0 sorries.

## Honesty note

The three headline non-existence theorems are discharged by `native_decide`, which depends on `Lean.ofReduceBool`. These are finite certificates over a bounded box ($c \le 100$), **not** a proof of the open infinite statement ($M(n) \ge 2$ for all $n \ge 4$), which would need Fermat–Catalan finiteness with no current Mathlib bearer. This is disclosed in `meta.json` `assumptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)