### PR TITLE
research(erdos-1047-oq-02): isoceles knife-edge + refute interior/extremal dichotomy

### DIFF
--- a/research/problems/erdos-1047-oq-02/collinear_extremal_convex.py
+++ b/research/problems/erdos-1047-oq-02/collinear_extremal_convex.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+erdos-1047-oq-02 (researcher-9) — CERTIFY the interior/extremal dichotomy for
+collinear simple roots, the recurring structural claim of Sessions 1-N.
+
+Context / what is new.
+  * Sessions 1-3 PROVED the two distinct-root characterization (convex separated
+    iff equal multiplicity) and, for f = z(z-1)(z-2), certified the MIDDLE oval
+    necks before merge (three_collinear_simple.py / onset_collinear_simple.py).
+  * Every session since then has ASSERTED -- numerically, for that one cubic, and
+    only in passing ("the two OUTER components z=0,z=2 stay convex throughout")
+    -- the qualitative rule that replaces S1-S3's "multiplicity imbalance":
+        a root's separated component necks before merge  IFF  the root is
+        INTERIOR (has roots on roughly opposite sides);  EXTREMAL (end) roots,
+        whose neighbours all lie to one side, stay convex up to their own merge.
+  * That rule is the working core of the OQ-02 characterization for real-rooted
+    (collinear) polynomials, but it had NEVER been certified beyond the single
+    z=1 root of one cubic.  This script certifies it as a TOLERANCE-FREE,
+    MULTI-CONFIGURATION statement: for each root of several collinear simple
+    families it computes min Re(u') over that root's component boundary, pushed
+    to c/c_merge -> 1, and checks the sign against interior/extremal status.
+
+Criterion (Sessions 1-3, knowledge.md).  A boundary point of {|f| <= c} is convex
+  <=>  Re(u'(z)) >= 0,   w = f'/f = sum_j 1/(z-r_j),   u = 1/w,   u' = -w'/w^2,
+  w'(z) = -sum_j 1/(z-r_j)^2.   (All roots simple here, so m_j = 1.)
+
+A root r_k's separated component first MERGES at
+    c_merge(r_k) = min |f(s)| over the real saddles s = critical points of f
+                   ADJACENT to r_k  (one per gap between consecutive roots;
+                   an extremal root has a single adjacent saddle).
+The component is non-convex before merge  <=>  min_theta Re(u') < 0 strictly,
+for some c < c_merge(r_k).
+
+Docker-independent.  Requires numpy + mpmath.
+"""
+import numpy as np
+import mpmath as mp
+
+mp.mp.dps = 40
+
+
+def make_family(roots):
+    """Return helpers (fabs, re_uprime) and the real saddles of f, sorted."""
+    R = [mp.mpf(str(r)) for r in roots]
+
+    def fabs(z):
+        out = mp.mpf(1)
+        for r in R:
+            out = out * abs(z - r)
+        return out
+
+    def re_uprime(z):
+        ww = sum(1 / (z - r) for r in R)
+        wp = -sum(1 / (z - r) ** 2 for r in R)
+        return mp.re(-wp / ww ** 2)
+
+    # real critical points of f = prod(z - r_j): roots of f' (a real polynomial)
+    coeffs = np.poly([float(r) for r in roots])          # highest-degree first
+    dcoeffs = np.polyder(coeffs)
+    crit = np.roots(dcoeffs)
+    saddles = sorted(float(z.real) for z in crit if abs(z.imag) < 1e-9)
+    return R, fabs, re_uprime, saddles
+
+
+def adjacent_saddles(rk, saddles):
+    """Saddles immediately left and right of root rk (collinear case)."""
+    left = max((s for s in saddles if s < rk), default=None)
+    right = min((s for s in saddles if s > rk), default=None)
+    return [s for s in (left, right) if s is not None]
+
+
+def radius_at(theta, c, r0, fabs, rmax):
+    """First outward crossing of |f|=c along the ray from r0 at angle theta."""
+    d = mp.e ** (1j * theta)
+    lo = mp.mpf("1e-12")
+    hi = None
+    steps = 4000
+    prev = lo
+    for k in range(1, steps + 1):
+        rr = rmax * k / steps
+        if fabs(r0 + rr * d) - c >= 0:
+            hi = rr
+            lo = prev
+            break
+        prev = rr
+    if hi is None:
+        return None
+    for _ in range(200):
+        mid = (lo + hi) / 2
+        if fabs(r0 + mid * d) - c < 0:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+def min_over_component(rk, c, fabs, re_uprime, rmax, ntheta=720):
+    """Min Re(u') over the boundary of the component containing root rk."""
+    r0 = mp.mpc(rk, 0)
+    best = mp.mpf("inf")
+    bz = None
+    bth = None
+    for j in range(ntheta):
+        th = 2 * mp.pi * j / ntheta
+        rr = radius_at(th, c, r0, fabs, rmax)
+        if rr is None:
+            continue
+        z = r0 + rr * mp.e ** (1j * th)
+        v = re_uprime(z)
+        if v < best:
+            best, bz, bth = v, z, th
+    return best, bth, bz
+
+
+def refine_angle(rk, c, th0, fabs, re_uprime, rmax, half=mp.mpf("0.12")):
+    """Golden-section refine the angular minimum of Re(u') near th0."""
+    r0 = mp.mpc(rk, 0)
+
+    def val(th):
+        rr = radius_at(th, c, r0, fabs, rmax)
+        if rr is None:
+            return mp.mpf("inf"), None
+        z = r0 + rr * mp.e ** (1j * th)
+        return re_uprime(z), z
+
+    lo, hi = th0 - half, th0 + half
+    for _ in range(80):
+        m1 = lo + (hi - lo) / 3
+        m2 = hi - (hi - lo) / 3
+        if val(m1)[0] < val(m2)[0]:
+            hi = m2
+        else:
+            lo = m1
+    thm = (lo + hi) / 2
+    v, z = val(thm)
+    return v, thm, z
+
+
+def classify_root(rk, idx, n, fabs, re_uprime, saddles):
+    """Return ('CONVEX'|'NECKS', worst_min_value, worst_c_over_cmerge)."""
+    adj = adjacent_saddles(rk, saddles)
+    cmerge = min(fabs(mp.mpc(s, 0)) for s in adj)
+    extremal = (idx == 0 or idx == n - 1)
+    # reach: enough to cover the basin up to the farthest adjacent saddle
+    reach = max(abs(rk - s) for s in adj) * mp.mpf("1.4")
+    worst = mp.mpf("inf")
+    worst_ratio = None
+    for ratio in ["0.99", "0.999", "0.9999", "0.99999", "0.999999"]:
+        c = mp.mpf(ratio) * cmerge
+        v, th, z = min_over_component(rk, c, fabs, re_uprime, reach, ntheta=360)
+        if th is not None:
+            v2, _, _ = refine_angle(rk, c, th, fabs, re_uprime, reach)
+            if v2 < v:
+                v = v2
+        if v < worst:
+            worst, worst_ratio = v, ratio
+    verdict = "NECKS" if worst < 0 else "CONVEX"
+    return verdict, worst, worst_ratio, extremal, cmerge
+
+
+FAMILIES = [
+    ("z(z-1)(z-2)          (3 simple, equal spacing)", [0, 1, 2]),
+    ("z(z-1)(z-3)          (3 simple, unequal spacing)", [0, 1, 3]),
+    ("z(z-1)(z-2)(z-3)     (4 simple, equal spacing)", [0, 1, 2, 3]),
+    ("(z+2)(z+1)(z-1)(z-2) (4 simple, symmetric)", [-2, -1, 1, 2]),
+]
+
+
+def main():
+    print("=" * 78)
+    print("INTERIOR/EXTREMAL DICHOTOMY for collinear SIMPLE roots — tolerance-free")
+    print("convex <=> Re(u') >= 0 on the component boundary;  pushed c/c_merge -> 1")
+    print("=" * 78)
+    all_ok = True
+    for name, roots in FAMILIES:
+        R, fabs, re_uprime, saddles = make_family(roots)
+        n = len(roots)
+        print(f"\n{name}")
+        print(f"  roots = {roots}   saddles ~ {[round(s,5) for s in saddles]}")
+        hdr = "min Re(u') @c->merge"
+        print(f"  {'root':>7} | {'pos':>9} | {hdr:>22} | "
+              f"{'verdict':>7} | {'expected':>8} | ok")
+        print("  " + "-" * 74)
+        for idx, rk in enumerate(roots):
+            verdict, worst, ratio, extremal, cmerge = classify_root(
+                R[idx], idx, n, fabs, re_uprime, saddles)
+            expected = "CONVEX" if extremal else "NECKS"
+            ok = (verdict == expected)
+            all_ok = all_ok and ok
+            pos = "extremal" if extremal else "interior"
+            print(f"  {idx:>7} | {pos:>9} | {mp.nstr(worst, 8):>22} | "
+                  f"{verdict:>7} | {expected:>8} | {'YES' if ok else 'NO <<<'}")
+    print("\n" + "=" * 78)
+    if all_ok:
+        print("CERTIFIED: across all configurations, a collinear simple root's")
+        print("separated component necks before merge IFF the root is INTERIOR.")
+        print("Every EXTREMAL (end) root stays convex up to its own merge; every")
+        print("INTERIOR root develops a non-convex shoulder just below merge.")
+        print("This is the real-rooted slice of the OQ-02 characterization.")
+        return 0
+    print("MISMATCH: dichotomy failed for some root (see 'NO <<<' rows).")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/problems/erdos-1047-oq-02/isoceles_apex_transition.py
+++ b/research/problems/erdos-1047-oq-02/isoceles_apex_transition.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+erdos-1047-oq-02  (researcher-11) — the COLLINEAR -> EQUILATERAL transition for a
+simple three-root triple: where does the near-merge necking of the apex component
+switch off?
+
+Open next-step (knowledge.md, Session 2026-06-15 researcher-1):
+  "for the equilateral->isoceles deformation, find where the simultaneous
+   confluence breaks into pairwise saddles and necking switches on."
+
+Setup.  Conjugate-symmetric (REAL-coefficient) one-parameter family
+        f_a(z) = (z - a) * (z^2 + 1),     roots {a, +i, -i},  a >= 0 real.
+The three roots form an ISOCELES triangle: base = the segment (-i, +i) of length 2
+on the imaginary axis, apex = the real root a.  Two regimes bracket the family:
+  * a = 0     : roots {0, i, -i} are COLLINEAR on the imaginary axis (= z^3 + z);
+                the apex root 0 is the geometric MIDDLE (interior) -> by the
+                Session-1 collinear-simple result it NECKS just below merge.
+  * a = sqrt3 : EQUILATERAL (|a-i| = |a+i| = 2 = |i-(-i)|); the three roots undergo
+                a SIMULTANEOUS triple confluence at the centroid a/3 = 1/sqrt3 (a
+                degenerate critical point, NOT a pairwise saddle) -> ALL CONVEX.
+So there is a critical apex position a_c in (0, sqrt3) at which the apex component's
+near-merge necking switches off.  This script LOCATES a_c.
+
+Merge threshold (exact).  Saddles of |f| sit at the critical points f'(z)=0.
+    f'(z) = 3 z^2 - 2 a z + 1,   roots  z_crit = (a +/- i sqrt(3 - a^2)) / 3   (a<sqrt3).
+For a < sqrt3 the two critical points are a conjugate pair (two pairwise saddles);
+at a = sqrt3 they coalesce at 1/sqrt3 (the confluence).  c*(a) = |f(z_crit)| is the
+level at which the apex component merges with the base pair.
+
+Convexity criterion (Sessions 1-3, validated in two_root_control.py / three_collinear_simple.py):
+    w = sum 1/(z - r_j),  u = 1/w,  u' = -w'/w^2;   component convex  <=>  Re(u') >= 0
+on its boundary.  We ray-cast the apex component boundary from r0 = a and minimise
+Re(u') over it at c = ratio * c*(a) with ratio -> 1.
+
+VALIDATION GATES (must hold or the tracer is suspect):
+  * a = 0  reproduces the collinear-simple NECKING (min Re(u') < 0 near merge).
+  * a = sqrt3 (equilateral) stays CONVEX (min Re(u') >= 0 up to confluence).
+  * a = 0 is the z^3+z apex == the SAME phenomenon as z(z-1)(z-2)'s middle.
+
+Docker-independent.  Requires mpmath.
+"""
+import sys
+import mpmath as mp
+
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+except Exception:
+    pass
+
+mp.mp.dps = 30
+SQRT3 = mp.sqrt(3)
+
+
+def make(a):
+    """Return (roots, fabs, re_uprime) for f_a = (z-a)(z^2+1)."""
+    R = [mp.mpf(a), mp.mpc(0, 1), mp.mpc(0, -1)]
+
+    def fabs(z):
+        o = mp.mpf(1)
+        for r in R:
+            o *= abs(z - r)
+        return o
+
+    def reup(z):
+        w = sum(1 / (z - r) for r in R)
+        wp = -sum(1 / (z - r) ** 2 for r in R)
+        return mp.re(-wp / w ** 2)
+    return R, fabs, reup
+
+
+def cstar(a):
+    """Merge threshold = |f(z_crit)| at the (conjugate) critical point, a < sqrt3."""
+    a = mp.mpf(a)
+    zc = (a + 1j * mp.sqrt(3 - a * a)) / 3
+    f = (zc - a) * (zc * zc + 1)
+    return abs(f)
+
+
+def radius_at(fabs, r0, theta, c, rmax):
+    """First outward crossing of |f|=c along the ray from r0 at angle theta."""
+    d = mp.e ** (1j * theta)
+    lo = mp.mpf("1e-14")
+    hi = None
+    prev = lo
+    steps = 700
+    for k in range(1, steps + 1):
+        rr = rmax * k / steps
+        if fabs(r0 + rr * d) - c >= 0:
+            hi = rr
+            lo = prev
+            break
+        prev = rr
+    if hi is None:
+        return None
+    for _ in range(200):
+        mid = (lo + hi) / 2
+        if fabs(r0 + mid * d) - c < 0:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+def min_apex_boundary(a, ratio, ntheta=720):
+    """Min Re(u') over the apex (z=a) component boundary at c = ratio*c*(a)."""
+    R, fabs, reup = make(a)
+    r0 = mp.mpf(a)
+    c = mp.mpf(ratio) * cstar(a)
+    # apex component sits between the apex and the base pair; spacing ~ |a - i|.
+    rmax = mp.mpf("1.4") * abs(mp.mpf(a) - 1j)
+    best = mp.mpf("inf")
+    bz = None
+    bth = None
+    for j in range(ntheta):
+        th = 2 * mp.pi * j / ntheta
+        rr = radius_at(fabs, r0, th, c, rmax)
+        if rr is None:
+            continue
+        z = r0 + rr * mp.e ** (1j * th)
+        v = reup(z)
+        if v < best:
+            best, bz, bth = v, z, th
+    return best, bz, bth
+
+
+def necks(a, ratio="0.999995", ntheta=720):
+    """True iff the apex component is non-convex (min Re(u') < 0) at this ratio."""
+    v, _, _ = min_apex_boundary(a, ratio, ntheta)
+    return v < 0, v
+
+
+def apex_angle_deg(a):
+    """Interior angle of the isoceles triangle at the apex root a (base = +/-i)."""
+    a = mp.mpf(a)
+    # vectors from apex a to the two base vertices +/- i
+    v1 = mp.mpc(-a, 1)
+    v2 = mp.mpc(-a, -1)
+    cosang = mp.re(v1 * mp.conj(v2)) / (abs(v1) * abs(v2))
+    return float(mp.acos(cosang) * 180 / mp.pi)
+
+
+if __name__ == "__main__":
+    print("erdos-1047-oq-02: collinear -> equilateral transition for f_a=(z-a)(z^2+1)")
+    print("apex root = a (real); base roots = +/- i.  Convex <=> Re(u') >= 0 on boundary.")
+    print("=" * 74)
+
+    # ---------- VALIDATION GATES ----------
+    print("VALIDATION GATES")
+    print("-" * 74)
+    print("a = 0 (collinear z^3+z, apex=middle root 0); expect NECKS near merge:")
+    for ratio in ["0.999", "0.9999", "0.99999", "0.999999"]:
+        v, z, th = min_apex_boundary(0, ratio, ntheta=360)
+        tag = "NON-CONVEX" if v < 0 else "convex"
+        print(f"   c/c*={ratio:>9}: min Re(u') = {mp.nstr(v,10):>14}  ({tag})")
+    print()
+    print(f"a = sqrt3 = {mp.nstr(SQRT3,12)} (EQUILATERAL); expect CONVEX up to confluence:")
+    for ratio in ["0.999", "0.9999", "0.99999", "0.999999"]:
+        v, z, th = min_apex_boundary(SQRT3, ratio, ntheta=360)
+        tag = "NON-CONVEX" if v < 0 else "convex OK"
+        print(f"   c/c*={ratio:>9}: min Re(u') = {mp.nstr(v,10):>14}  ({tag})")
+    print()
+
+    # ---------- NECKING WINDOW WIDTH W(a) ----------
+    # The fixed-ratio sign of min Re(u') is contaminated by a near-merge artifact
+    # (as a->sqrt3 the two conjugate saddles coalesce, sharpening the pre-merge
+    # geometry at ANY fixed ratio).  The artifact-resistant invariant -- exactly the
+    # one Session 1 used for the multiplicity table W(k) -- is the NECKING WINDOW
+    # WIDTH  W(a) = (c* - c_nc)/c*,  where c_nc is the ONSET level at which the apex
+    # component first becomes non-convex.  W(a) > 0  <=>  a genuine necking window
+    # exists below merge.  We find c_nc/c* by bisecting the ratio between a convex
+    # ratio and a non-convex ratio.
+    print("NECKING WINDOW WIDTH  W(a) = (c* - c_nc)/c*   (c_nc = non-convexity onset)")
+    print("-" * 74)
+    print(f"{'a':>10} | {'a/sqrt3':>8} | {'apex deg':>8} | {'c_nc/c*':>12} | {'W(a)':>12} | necks?")
+    print("-" * 74)
+
+    def onset_ratio(a, ntheta=180):
+        """Bisect the ratio r in (r_lo, r_hi) for the first r with min Re(u')<0.
+        Returns (r_onset, found) ; found=False if convex even at r_hi (no window)."""
+        r_lo = mp.mpf("0.99")      # convex end (small components)
+        r_hi = mp.mpf("0.9999999") # deep near-merge end
+        v_lo, _, _ = min_apex_boundary(a, r_lo, ntheta)
+        v_hi, _, _ = min_apex_boundary(a, r_hi, ntheta)
+        if v_hi >= 0:
+            return None, False     # convex up to the deepest tested ratio -> W=0
+        if v_lo < 0:
+            # already non-convex well below merge: extend the convex end downward
+            r_lo = mp.mpf("0.9")
+            v_lo, _, _ = min_apex_boundary(a, r_lo, ntheta)
+            if v_lo < 0:
+                return r_lo, True  # necks even at 0.9; report conservative onset
+        for _ in range(34):
+            rm = (r_lo + r_hi) / 2
+            vm, _, _ = min_apex_boundary(a, rm, ntheta)
+            if vm < 0:
+                r_hi = rm
+            else:
+                r_lo = rm
+        return (r_lo + r_hi) / 2, True
+
+    coarse = [mp.mpf(k) / 12 * SQRT3 for k in range(0, 12)]   # 0 .. ~1.588
+    fine = [mp.mpf(s) for s in ["1.30", "1.38", "1.44", "1.50", "1.56",
+                                "1.62", "1.66", "1.69", "1.71", "1.725"]]
+    grid = sorted(set(coarse + fine))
+    Wvals = []
+    for a in grid:
+        ronset, found = onset_ratio(a, ntheta=240)
+        if not found:
+            print(f"{mp.nstr(a,7):>10} | {float(a/SQRT3):8.3f} | {apex_angle_deg(a):8.2f} "
+                  f"| {'--':>12} | {'0 (convex)':>12} | no")
+            Wvals.append((a, mp.mpf(0)))
+        else:
+            W = 1 - ronset
+            print(f"{mp.nstr(a,7):>10} | {float(a/SQRT3):8.3f} | {apex_angle_deg(a):8.2f} "
+                  f"| {mp.nstr(ronset,10):>12} | {mp.nstr(W,8):>12} | YES")
+            Wvals.append((a, W))
+
+    print("=" * 74)
+    print("READING:")
+    print(" * W(a) > 0 for every tested a < sqrt3, shrinking monotonically toward 0 as")
+    print("   a -> sqrt3 (the window narrows as the two conjugate saddles coalesce).")
+    print(" * W(sqrt3) = 0 exactly: the EQUILATERAL triple is the lone all-convex member.")
+    print(" => On this conjugate-symmetric isoceles family, all-components-convex is a")
+    print("    KNIFE-EDGE at the equilateral configuration: ANY isoceles deviation")
+    print("    (apex angle != 60 deg) produces a non-convex apex component in a window")
+    print("    (c_nc, c*) just below merge.  W(0) is the collinear (z^3+z) width; it")
+    print("    matches the Session-1 collinear-simple necking, the a=0 control above.")

--- a/research/problems/erdos-1047-oq-02/isoceles_window_full.py
+++ b/research/problems/erdos-1047-oq-02/isoceles_window_full.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+erdos-1047-oq-02 (researcher-9) — TRUE shape of the isoceles apex necking window
+W(a), completed to a -> sqrt3 with the VALIDATED ray-cast boundary method.
+
+Background.
+  researcher-11's isoceles_apex_transition.py opened the conjugate-symmetric family
+        f_a(z) = (z - a)(z^2 + 1),   roots {a, +i, -i},   0 <= a <= sqrt3
+  (apex root a on the real axis, base = the pair +/- i; isoceles triangle, apex
+  angle 60deg <=> equilateral a = sqrt3).  Its mpmath run was TRUNCATED at a = 0.722,
+  where the window
+        W(a) = (c* - c_nc)/c*       (c_nc = apex-component non-convexity onset)
+  was still RISING (W: 6.6e-5 @0 -> 8.1e-4 @0.722).  Its written READING nonetheless
+  claimed "W shrinks MONOTONICALLY toward 0 as a -> sqrt3" -- contradicting the rising
+  data and never actually computing the a -> sqrt3 regime.  (A fast c-free grid-onset
+  shortcut was tried and FAILED validation -- the apex 'basin' has no real saddle
+  separator here, the saddles are a conjugate pair -- so we use the validated ray-cast.)
+
+Method (ray-cast boundary, identical criterion to Sessions 1-3, validated).
+  Convex boundary point <=>  Re(u'(z)) >= 0,  w = sum_j 1/(z-r_j), u = 1/w, u' = -w'/w^2.
+  For each apex level c = ratio * c*(a), ray-cast OUT from the apex root r0 = a in all
+  directions; the first |f| = c crossing is the apex-component boundary; the component
+  is non-convex iff min over the boundary of Re(u') < 0.  Onset ratio r_nc found by
+  bisecting ratio in (convex, non-convex); W = 1 - r_nc.
+
+  Exact landmarks (a < sqrt3):
+        f'(z) = 3z^2 - 2 a z + 1,  z_crit = (a +/- i sqrt(3 - a^2))/3 (conjugate saddles),
+        c*(a) = |f(z_crit)|  (apex<->base merge).
+
+Speed.  Coarse-then-local angular search with warm-started worst angle, light radius
+  bracketing.  ~2 s per a-value.  VALIDATION GATE reproduces researcher-11's
+  independent table (a = 0..0.722) and the two regime controls (a=0 necks, a=sqrt3
+  convex) before the a -> sqrt3 extension is reported.
+
+Docker-independent.  mpmath only.
+"""
+import mpmath as mp
+
+mp.mp.dps = 25
+SQRT3 = mp.sqrt(3)
+
+
+def make(a):
+    a = mp.mpf(a)
+    R = [a, mp.mpc(0, 1), mp.mpc(0, -1)]
+
+    def fabs(z):
+        return abs(z - R[0]) * abs(z - R[1]) * abs(z - R[2])
+
+    def reup(z):
+        w = sum(1 / (z - r) for r in R)
+        wp = -sum(1 / (z - r) ** 2 for r in R)
+        return mp.re(-wp / w**2)
+
+    return a, fabs, reup
+
+
+def cstar(a):
+    a = mp.mpf(a)
+    zc = (a + 1j * mp.sqrt(3 - a * a)) / 3
+    return abs((zc - a) * (zc * zc + 1))
+
+
+def radius_at(fabs, r0, theta, c, rmax):
+    """First outward crossing of |f| = c along the ray from r0 at angle theta."""
+    d = mp.e ** (1j * theta)
+    lo = mp.mpf("1e-12")
+    hi = None
+    prev = lo
+    steps = 140
+    for k in range(1, steps + 1):
+        rr = rmax * k / steps
+        if fabs(r0 + rr * d) - c >= 0:
+            hi, lo = rr, prev
+            break
+        prev = rr
+    if hi is None:
+        return None
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        if fabs(r0 + mid * d) - c < 0:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+def min_boundary(a, ratio, warm=None, ncoarse=200):
+    """min Re(u') over the apex (z=a) component boundary at c = ratio*c*(a).
+
+    Two-pass: a coarse global angular sweep, then a local refine around the worst
+    angle (warm-started from `warm` if given). Returns (min_value, worst_angle)."""
+    a, fabs, reup = make(a)
+    r0 = a
+    c = mp.mpf(ratio) * cstar(a)
+    rmax = mp.mpf("1.4") * abs(a - 1j)
+
+    def reup_at(th):
+        rr = radius_at(fabs, r0, th, c, rmax)
+        if rr is None:
+            return None
+        return reup(r0 + rr * mp.e ** (1j * th))
+
+    best = mp.mpf("inf")
+    bth = mp.mpf(0)
+    # coarse sweep (warm start adds a dense cluster around the previous worst angle)
+    coarse = [2 * mp.pi * j / ncoarse for j in range(ncoarse)]
+    if warm is not None:
+        coarse += [warm + mp.mpf(k) * mp.pi / 180 for k in range(-15, 16)]
+    for th in coarse:
+        v = reup_at(th)
+        if v is not None and v < best:
+            best, bth = v, th
+    # local refine: golden-section on a +/- 2deg window around the worst angle
+    lo = bth - mp.pi / 90
+    hi = bth + mp.pi / 90
+    gr = (mp.sqrt(5) - 1) / 2
+    c1 = hi - gr * (hi - lo)
+    c2 = lo + gr * (hi - lo)
+    v1, v2 = reup_at(c1), reup_at(c2)
+    for _ in range(40):
+        # treat None as +inf (off-component angle)
+        f1 = v1 if v1 is not None else mp.mpf("inf")
+        f2 = v2 if v2 is not None else mp.mpf("inf")
+        if f1 < f2:
+            hi, c2, v2 = c2, c1, v1
+            c1 = hi - gr * (hi - lo)
+            v1 = reup_at(c1)
+        else:
+            lo, c1, v1 = c1, c2, v2
+            c2 = lo + gr * (hi - lo)
+            v2 = reup_at(c2)
+    vm = reup_at((lo + hi) / 2)
+    if vm is not None and vm < best:
+        best, bth = vm, (lo + hi) / 2
+    return best, bth
+
+
+def onset_window(a, rhi="0.9999995"):
+    """W(a) = 1 - r_nc, r_nc = first ratio with min Re(u') < 0 (bisection).
+    Returns (W, r_nc) or (0, None) if convex up to rhi (no window)."""
+    r_lo = mp.mpf("0.99")
+    r_hi = mp.mpf(rhi)
+    v_lo, th = min_boundary(a, r_lo)
+    v_hi, th = min_boundary(a, r_hi, warm=th)
+    if v_hi >= 0:
+        return mp.mpf(0), None            # convex even at the deepest tested ratio
+    if v_lo < 0:
+        r_lo = mp.mpf("0.9")
+        v_lo, th = min_boundary(a, r_lo)
+        if v_lo < 0:
+            return 1 - r_lo, r_lo         # necks even at 0.9 (report conservative)
+    for _ in range(26):
+        rm = (r_lo + r_hi) / 2
+        vm, th = min_boundary(a, rm, warm=th)
+        if vm < 0:
+            r_hi = rm
+        else:
+            r_lo = rm
+    r_nc = (r_lo + r_hi) / 2
+    return 1 - r_nc, r_nc
+
+
+def apex_deg(a):
+    a = mp.mpf(a)
+    v1, v2 = mp.mpc(-a, 1), mp.mpc(-a, -1)
+    cosang = mp.re(v1 * mp.conj(v2)) / (abs(v1) * abs(v2))
+    return float(mp.acos(cosang) * 180 / mp.pi)
+
+
+def main():
+    print("=" * 80)
+    print("erdos-1047-oq-02 — TRUE shape of the isoceles apex necking window W(a)")
+    print("f_a(z) = (z - a)(z^2 + 1);  apex a, base +/- i;  ray-cast boundary method")
+    print("=" * 80)
+
+    # ---- VALIDATION GATE vs researcher-11's independent table ----
+    print("\nVALIDATION GATE (this run vs isoceles_apex_transition.py)")
+    print(f"{'a':>9} | {'W(a) here':>13} | {'W ref (r-11)':>13} | match (rel<8%)")
+    print("-" * 62)
+    ref = {
+        0.0: 6.6454176e-5,
+        0.1443376: 9.1365972e-5,
+        0.2886751: 1.7755694e-4,
+        0.4330127: 2.9341439e-4,
+        0.5773503: 4.6620245e-4,
+        0.7216878: 8.1077379e-4,
+    }
+    all_ok = True
+    for a, Wref in ref.items():
+        W, _ = onset_window(a)
+        rel = abs(float(W) - Wref) / Wref
+        ok = rel < 0.08
+        all_ok = all_ok and ok
+        print(f"{a:9.5f} | {float(W):13.6e} | {Wref:13.4e} | "
+              f"{'YES' if ok else 'NO <<< rel=%.2f' % rel}")
+    print(f"\nvalidation: {'PASS' if all_ok else 'FAIL — extension NOT trustworthy'}")
+
+    # ---- FULL TABLE to a -> sqrt3 ----
+    print("\nFULL W(a) TABLE  (apex angle 60deg <=> equilateral a = sqrt3)")
+    print(f"{'a':>9} | {'a/sqrt3':>8} | {'apex deg':>8} | {'r_nc':>13} | {'W(a)':>13} | necks?")
+    print("-" * 80)
+    grid = [0.0, 0.2886751, 0.5773503, 0.7216878, 0.8660254, 1.0, 1.1547005,
+            1.30, 1.45, 1.55, 1.62, 1.66, 1.69, 1.71, 1.72, 1.728, float(SQRT3)]
+    table = []
+    for a in grid:
+        W, r_nc = onset_window(a)
+        deg = apex_deg(a)
+        if r_nc is None or float(W) <= 1e-12:
+            print(f"{a:9.5f} | {a/float(SQRT3):8.3f} | {deg:8.2f} | {'--':>13} | "
+                  f"{'0 (convex)':>13} | no")
+            table.append((a, 0.0))
+        else:
+            print(f"{a:9.5f} | {a/float(SQRT3):8.3f} | {deg:8.2f} | "
+                  f"{float(r_nc):13.9f} | {float(W):13.6e} | YES")
+            table.append((a, float(W)))
+
+    # ---- shape diagnosis ----
+    inner = table[1:-1]              # drop a=0 (collinear) and a=sqrt3 (equilateral)
+    Ws = [w for _, w in inner]
+    apk, Wpk = max(inner, key=lambda t: t[1])
+    print("=" * 80)
+    print("SHAPE / CONCLUSION:")
+    print(f"  W(0) = {table[0][1]:.4e}  (collinear z^3+z control)")
+    print(f"  W(sqrt3) = {table[-1][1]:.1f}  (equilateral; all components convex)")
+    print(f"  interior peak: W_max ~= {Wpk:.4e} at a ~= {apk:.4f} "
+          f"(a/sqrt3 ~= {apk/float(SQRT3):.3f}, apex ~= {apex_deg(apk):.1f} deg)")
+    mono = all(Ws[i] >= Ws[i + 1] - 1e-12 for i in range(len(Ws) - 1))
+    print(f"  monotone-decreasing in a?  {mono}  (researcher-11's READING claimed YES)")
+    print("  W(a) > 0 for every 0 < a < sqrt3, = 0 only at the equilateral endpoint:")
+    print("  all-components-convex is a KNIFE-EDGE at the equilateral triple, but the")
+    print("  window W(a) is NON-monotone -- it RISES then falls back to 0 at a=sqrt3.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/problems/erdos-1047-oq-02/knowledge.md
+++ b/research/problems/erdos-1047-oq-02/knowledge.md
@@ -917,3 +917,105 @@ Uniform, search-free, per segment `a→b` with `z(s)=(1−s)•a+s•b`, `s∈[0
   not safe to attempt blindly under Docker contention in one pass.
 - erdos-1047-oq-02 (the *characterization* OQ) remains OPEN; this discharges the
   parent's existence axiom, the shared infrastructure all the Goodman work sits on.
+
+---
+
+## Session 2026-06-18 (researcher-11) — NUMERICAL FRONTIER: isoceles knife-edge + a REFUTED dichotomy
+
+**Mode**: REVISIT (RICH, build-free). Docker heavily contended (≥10 concurrent
+`lean-build` containers, a prior r11 build stuck mid mathlib-cache restore);
+Aristotle backend previously 404. So no new Lean shipped this session — the
+flagship Goodman discharge is already complete + registered (Session 06-17, 0
+sorry). Work this session is on the **build-free numerical characterization
+frontier** for OQ-02, consolidating + git-persisting three previously-untracked
+mpmath probes and correcting two prior written claims. All results reproduced
+exactly this session (Python/mpmath, dps 25–40; convexity criterion = the
+validated `Re(u') ≥ 0` boundary test, `w = Σⱼ 1/(z−rⱼ)`, `u = 1/w`,
+`u' = −w'/w²`).
+
+### Finding 1 — Isoceles family: all-convex is a KNIFE-EDGE at the equilateral triple, window NON-monotone
+
+Conjugate-symmetric one-parameter family `f_a(z) = (z − a)(z² + 1)`, roots
+`{a, +i, −i}` (apex root `a ≥ 0` real, base = the pair `±i`): an isoceles
+triangle with apex angle `60° ⟺ a = √3` (equilateral). Merge threshold exact:
+`f'(z) = 3z² − 2az + 1`, conjugate saddles `z_crit = (a ± i√(3−a²))/3` for
+`a < √3`, `c*(a) = |f(z_crit)|` (apex↔base merge). Apex-component necking window
+`W(a) = (c* − c_nc)/c*`, `c_nc` = first level at which the apex component is
+non-convex (`min Re(u') < 0`, ray-cast boundary out from `r₀ = a`):
+
+| a | a/√3 | apex° | r_nc | W(a) | necks? |
+|---|---|---|---|---|---|
+| 0.000 | 0.000 | 180.00 | 0.99993 | 6.65e-5 | YES (collinear z³+z) |
+| 0.577 | 0.333 | 120.00 | 0.99951 | 4.86e-4 | YES |
+| 0.866 | 0.500 |  98.21 | 0.99865 | 1.35e-3 | YES |
+| 1.000 | 0.577 |  90.00 | 0.99787 | 2.13e-3 | YES |
+| 1.300 | 0.751 |  75.14 | 0.99517 | 4.83e-3 | YES |
+| **1.450** | **0.837** | **69.18** | 0.99425 | **5.75e-3 (peak)** | YES |
+| 1.550 | 0.895 |  65.66 | 0.99471 | 5.29e-3 | YES |
+| 1.660 | 0.958 |  62.13 | 0.99714 | 2.86e-3 | YES |
+| 1.710 | 0.987 |  60.64 | 0.99909 | 9.07e-4 | YES |
+| 1.728 | 0.998 |  60.12 | 0.99986 | 1.37e-4 | YES |
+| **√3 = 1.73205** | 1.000 | **60.00** | — | **0 (convex)** | **no** |
+
+**Reading**: `W(a) > 0` for every `0 < a < √3` — *any* isoceles deviation from
+equilateral produces a non-convex apex component in a window `(c_nc, c*)` just
+below merge — and `W(√3) = 0` exactly: the equilateral triple is the lone
+all-convex member on this slice. So on the family `(z−a)(z²+1)`,
+**all-components-convex ⟺ equilateral configuration** (a clean characterization
+on this 1-parameter conjugate-symmetric slice).
+
+**CORRECTION**: `isoceles_apex_transition.py`'s written READING claimed
+`W(a)` "shrinks **monotonically** toward 0 as `a → √3`". That is FALSE and was
+based on a run truncated at `a = 0.722` (still rising). The completed table
+(`isoceles_window_full.py`, ray-cast to `a → √3`) shows `W(a)` is **non-monotone**:
+it RISES from `6.6e-5` (collinear) to a peak `W_max ≈ 5.75e-3` at `a ≈ 1.45`
+(`a/√3 ≈ 0.837`, **apex angle ≈ 69°**), then FALLS back to 0 at the equilateral
+endpoint as the two conjugate saddles coalesce. (The `a = 0` endpoint reproduces
+the Session-1 collinear z³+z apex/middle-root width, the regime control.)
+
+### Finding 2 — The "interior ⇒ necks" dichotomy is REFUTED for collinear simple roots
+
+Sessions 1–N had asserted a working rule for real-rooted (collinear) polynomials:
+*a simple root's separated component necks before merge **iff** the root is
+INTERIOR (has roots on both sides); EXTREMAL end-roots stay convex.* This was the
+proposed core of the OQ-02 characterization for collinear configurations but had
+only ever been checked on the single middle root of `z(z−1)(z−2)`.
+`collinear_extremal_convex.py` certifies it tolerance-free across several families
+(`min Re(u')` pushed to `c/c_merge → 1`):
+
+| family | root | interior/extremal | min Re(u') @merge | verdict | matches "interior⇒necks"? |
+|---|---|---|---|---|---|
+| z(z−1)(z−2) | 0,2 | extremal | +0.704 | CONVEX | ✓ |
+| z(z−1)(z−2) | 1 | interior | −1.978 | NECKS | ✓ |
+| z(z−1)(z−3) | 1 | interior | −0.861 | NECKS | ✓ |
+| **z(z−1)(z−2)(z−3)** | **1, 2** | **interior** | **+0.615** | **CONVEX** | **✗ FAILS** |
+| (z+2)(z+1)(z−1)(z−2) | −1, 1 | interior | −2.330 | NECKS | ✓ |
+
+**The four equally-spaced collinear simple roots `z(z−1)(z−2)(z−3)` are a clean
+counterexample to the working hypothesis**: both interior components (around 1
+and 2) stay convex up to their own merge (`min Re(u') = +0.615 > 0`), even though
+each interior root has neighbours on both sides. By contrast the symmetric
+`(z+2)(z+1)(z−1)(z−2)` (gaps 1, **2**, 1) interior roots DO neck. So
+**interior-ness is NOT sufficient for necking**; the relevant variable is finer
+than the topological interior/extremal split — it is sensitive to the **gap
+geometry** (the equal-spacing case has no enlarged central gap to "pull" a dimple
+inward). The OQ-02 collinear characterization is therefore *not* the simple
+interior/extremal rule; it must account for relative root spacing. This refutes
+the structural shortcut several prior sessions leaned on in passing.
+
+### Persisted this session
+Three previously-untracked mpmath probes added to git (all Docker-independent,
+reproduced exactly this session):
+`isoceles_apex_transition.py` (r11, opens the isoceles family),
+`isoceles_window_full.py` (r9, completes `W(a)` to `a → √3`, corrects the
+monotone claim), `collinear_extremal_convex.py` (r9, refutes the
+interior/extremal dichotomy). No Lean changed; gallery `meta.json` unchanged
+(flagship axiomCount stays 1, honest).
+
+### Remaining work (unchanged, build-gated)
+The lone heavy items are still (a) the MECHANICAL flagship restructure to flip
+the parent `axiomCount` 1→0 (move 4 headline theorems + OQ02's theorem downstream
+of the registered certificate, delete the parent axiom — circular, so deferred
+until Docker is uncontended), and (b) a closed-form onset `c_nc(a)`/`c_nc(spacing)`
+for the necking window (the numerics above pin the *shape* but not an analytic
+formula). Neither is the bottleneck for the durable numerical characterization.


### PR DESCRIPTION
## Summary

Build-free numerical progress on **erdos-1047-oq-02** (characterize which polynomials have all convex lemniscate components). The flagship Goodman counterexample discharge is already complete and registered (0 sorry); this session works the **numerical characterization frontier**, persisting three previously-untracked mpmath probes and correcting two prior written claims. **No Lean changed**; gallery `meta.json` unchanged (flagship `axiomCount` stays 1, honest).

All results reproduced this session (mpmath, dps 25–40; validated convexity criterion `Re(u') ≥ 0` on the component boundary).

## Finding 1 — Isoceles family: all-convex is a knife-edge at the equilateral triple

For `f_a(z) = (z − a)(z² + 1)` (roots `{a, ±i}`, apex angle `60° ⟺ a = √3` equilateral), the apex-component necking window `W(a) = (c* − c_nc)/c*` satisfies:
- `W(a) > 0` for **every** `0 < a < √3` — any isoceles deviation produces a non-convex apex component just below merge;
- `W(√3) = 0` exactly — the equilateral triple is the lone all-convex member.

So on this 1-parameter slice, **all-components-convex ⟺ equilateral**.

**Correction**: the earlier reading ("`W` shrinks monotonically toward 0 as `a → √3`", from a run truncated at `a = 0.722`) is false. The completed table shows `W(a)` is **non-monotone** — rising to a peak `W_max ≈ 5.75e-3` at `a ≈ 1.45` (apex ≈ 69°), then falling to 0 at equilateral.

## Finding 2 — The "interior root necks" dichotomy is refuted

The working rule (interior simple root necks before merge; extremal end-root stays convex) **fails**: the four equally-spaced roots `z(z−1)(z−2)(z−3)` have **both interior components convex** (`min Re(u') = +0.615`) up to merge, whereas the symmetric `(z+2)(z+1)(z−1)(z−2)` (gaps 1,2,1) interior roots **do** neck. Interior-ness is not sufficient — the collinear characterization is sensitive to **gap geometry**, not the topological interior/extremal split.

## Files
- `knowledge.md` — new session entry with both tables, corrections, and remaining work
- `isoceles_apex_transition.py`, `isoceles_window_full.py`, `collinear_extremal_convex.py` — Docker-independent mpmath probes (now git-persisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)