### PR TITLE
research(friendship-theorem-oq-04): adjacent-pair regularity step (+2 thms)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -376,4 +376,39 @@ theorem universal_noncentral_adj_iff (hF : IsFriendshipGraph G)
     have hmem : u' ∈ G.neighborSet u := by rw [hset]; simp
     exact (G.mem_neighborSet u u').mp hmem
 
+/-- **Regularity across an adjacent pair (finiteness-free, conditional).** If two
+vertices `u`, `v` of a friendship graph share a common *non-neighbour* `z` — a vertex
+adjacent to neither — then their neighbourhoods are equinumerous. The proof composes
+the two non-adjacent bijections `N(u) ≃ N(z) ≃ N(v)` supplied by
+`nonadjacent_neighborSet_equinum`, bridging the *adjacent* case that lemma cannot
+reach on its own (`nonadjacent_neighborSet_equinum` needs `u`, `v` themselves
+non-adjacent). This is the missing step toward full regularity of a hub-free
+friendship graph: in the C₅ free-amalgamation counterexample every pair of vertices —
+adjacent or not — admits a common non-neighbour, so the graph is ℵ₀-regular. No
+finiteness is used; the conclusion is a `Set.BijOn`, carrying content even on infinite
+neighbourhoods. -/
+theorem neighborSet_equinum_of_common_nonneighbor (hF : IsFriendshipGraph G)
+    {u v z : V} (hzu : ¬ G.Adj u z) (hzv : ¬ G.Adj v z) :
+    ∃ f : V → V, Set.BijOn f (G.neighborSet u) (G.neighborSet v) := by
+  -- `N(u) ≃ N(z)` since `u` and `z` are non-adjacent.
+  obtain ⟨f, hf⟩ := nonadjacent_neighborSet_equinum hF hzu
+  -- `N(z) ≃ N(v)` since `z` and `v` are non-adjacent.
+  obtain ⟨g, hg⟩ := nonadjacent_neighborSet_equinum hF (fun h => hzv h.symm)
+  exact ⟨g ∘ f, hg.comp hf⟩
+
+/-- **Regularity dichotomy of a friendship graph (conditional, finiteness-free).** Any
+two vertices `u`, `v` have equinumerous neighbourhoods whenever they are *either*
+non-adjacent *or* share a common non-neighbour. Combined with the windmill structure
+(`universal_noncentral_neighborSet`), this frames the structural dichotomy behind
+OQ-04: a friendship graph *with* a universal vertex is a windmill (every off-hub vertex
+has degree two), while one *without* a hub is regular on every pair admitting a common
+non-neighbour — precisely the ℵ₀-regular shape of the C₅ free-amalgamation
+counterexample. No finiteness is used. -/
+theorem neighborSet_equinum_of_nonadj_or_common_nonneighbor (hF : IsFriendshipGraph G)
+    {u v : V} (h : ¬ G.Adj u v ∨ ∃ z, ¬ G.Adj u z ∧ ¬ G.Adj v z) :
+    ∃ f : V → V, Set.BijOn f (G.neighborSet u) (G.neighborSet v) := by
+  rcases h with hnadj | ⟨z, hzu, hzv⟩
+  · exact nonadjacent_neighborSet_equinum hF hnadj
+  · exact neighborSet_equinum_of_common_nonneighbor hF hzu hzv
+
 end FriendshipTheoremOQ04

--- a/src/data/proofs/friendship-theorem-oq-04/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 379,
-    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7745 jobs); registered in Proofs.lean. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. Verified green 2026-06-15 (researcher-4) after repairing three Mathlib v4.26.0 errors (Set.mem_biUnion implicit index, a redundant Set.not_infinite.mp after push_neg already normalized to Finite, and a stale `c` identifier after `rintro rfl` substituted it to `w`). Companion file Proofs/FriendshipTheoremOQ04Universal.lean (113 lines, 4 theorems, 0 sorries / 0 axioms) adds the finiteness-free hub-uniqueness results (merged via #25260) and is registered in Proofs.lean; aggregate compilation via `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04Universal` builds green (7746 jobs, Lean v4.26.0, Mathlib pin 2df2f01) — confirmed 2026-06-18 (researcher-8). The hub-uniqueness companion Proofs/FriendshipTheoremOQ04Universal.lean (two_universal_cover, nat_card_eq_three_of_two_universal, finite_of_two_universal, universal_unique_of_card_ne_three, universal_unique_of_infinite) is also registered and Docker build-verified (2026-06-18, 7746 jobs green), 0 axioms / 0 sorries, #print axioms reporting only propext / Classical.choice / Quot.sound.",
+    "lineCount": 414,
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` builds green (Lean v4.26.0, Mathlib pin 2df2f01, 7745 jobs); registered in Proofs.lean. The diameter-2 bound uses no finiteness; the finite-case conclusion is imported from the gallery proof FriendshipTheorem.friendship_theorem. Verified green 2026-06-15 (researcher-4) after repairing three Mathlib v4.26.0 errors (Set.mem_biUnion implicit index, a redundant Set.not_infinite.mp after push_neg already normalized to Finite, and a stale `c` identifier after `rintro rfl` substituted it to `w`). Companion file Proofs/FriendshipTheoremOQ04Universal.lean (113 lines, 4 theorems, 0 sorries / 0 axioms) adds the finiteness-free hub-uniqueness results (merged via #25260) and is registered in Proofs.lean; aggregate compilation via `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04Universal` builds green (7746 jobs, Lean v4.26.0, Mathlib pin 2df2f01) — confirmed 2026-06-18 (researcher-8). The hub-uniqueness companion Proofs/FriendshipTheoremOQ04Universal.lean (two_universal_cover, nat_card_eq_three_of_two_universal, finite_of_two_universal, universal_unique_of_card_ne_three, universal_unique_of_infinite) is also registered and Docker build-verified (2026-06-18, 7746 jobs green), 0 axioms / 0 sorries, #print axioms reporting only propext / Classical.choice / Quot.sound. Extended 2026-06-18 (researcher-10) with the adjacent-pair regularity step (neighborSet_equinum_of_common_nonneighbor, neighborSet_equinum_of_nonadj_or_common_nonneighbor) — Docker build-verified green (`./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04`, 7745 jobs, Lean v4.26.0, Mathlib pin 2df2f01), 0 axioms / 0 sorries; the new theorems compose the existing nonadjacent_neighborSet_equinum bijections and use no finiteness.",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -36,9 +36,11 @@
       "universal_unique_of_card_ne_three (FriendshipTheoremOQ04Universal.lean): away from the three-vertex triangle the universal vertex (windmill centre) is unique — the recovered conclusion has a single well-defined hub; corollaries nat_card_eq_three_of_two_universal and finite_of_two_universal also derived",
       "universal_unique_of_infinite: an infinite friendship graph has at most one universal vertex (Nat.card V = 0 ≠ 3 ⟹ the K₃ two-centre case is excluded) — so even though the friendship theorem fails for infinite graphs, any hub that exists is unique",
       "universal_partner_symm: the partner relation on non-centre vertices is symmetric — N(u) = {c, w} forces N(w) = {c, u} in turn — so with the hub deleted the windmill is a disjoint union of edges (its spokes); finiteness-free. This closes a gap in universal_noncentral_neighborSet, which assigns each vertex a partner without showing the pairing is mutual.",
-      "universal_noncentral_unique_partner / universal_noncentral_adj_iff: each non-centre vertex has exactly one non-centre neighbour (ExistsUnique), and two non-centre vertices are adjacent iff they are partners (N(u) = {c, u'}) — together the perfect-matching characterisation of the entire windmill edge set, with no [Fintype V]."
+      "universal_noncentral_unique_partner / universal_noncentral_adj_iff: each non-centre vertex has exactly one non-centre neighbour (ExistsUnique), and two non-centre vertices are adjacent iff they are partners (N(u) = {c, u'}) — together the perfect-matching characterisation of the entire windmill edge set, with no [Fintype V].",
+      "neighborSet_equinum_of_common_nonneighbor: two vertices u, v sharing a common non-neighbour z have equinumerous neighbourhoods — composing the two non-adjacent bijections N(u) ≃ N(z) ≃ N(v) of nonadjacent_neighborSet_equinum bridges the *adjacent* case that lemma cannot reach directly (it requires u, v themselves non-adjacent). This is the missing step toward full regularity of a hub-free friendship graph; finiteness-free (the conclusion is a Set.BijOn, retaining content on infinite neighbourhoods).",
+      "neighborSet_equinum_of_nonadj_or_common_nonneighbor: unified regularity dichotomy — any two vertices that are non-adjacent OR share a common non-neighbour have equinumerous neighbourhoods, framing the windmill-vs-regular split behind OQ-04 (a graph with a hub is a windmill; one without is regular on every pair admitting a common non-neighbour, exactly the ℵ₀-regular C₅ free-amalgamation counterexample)."
     ],
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 1
   },
   "overview": {
@@ -104,6 +106,14 @@
       "endLine": 196,
       "summary": "universal_noncentral_neighborSet: in any friendship graph (finite or infinite) with a universal vertex c, every non-centre vertex u has N(u) = {c, w} for a unique partner w — a windmill of triangles sharing the centre, proved with no [Fintype V]. universal_noncentral_ncard_two reads off (N(u)).ncard = 2, the finiteness-free analogue of the finite gallery's friendship_noncentral_degree (G.degree u = 2).",
       "mathContext": "$N(u) = \\{c, w\\}$ with $w$ the unique common neighbour of $u$ and $c$; hence $|N(u)| = 2$ even on infinite vertex types."
+    },
+    {
+      "id": "part7-adjacent-regularity",
+      "title": "Part VII: Regularity Across an Adjacent Pair",
+      "startLine": 380,
+      "endLine": 413,
+      "summary": "neighborSet_equinum_of_common_nonneighbor composes the two non-adjacent bijections N(u) ≃ N(z) ≃ N(v) so that two vertices sharing a common non-neighbour z have equinumerous neighbourhoods — bridging the adjacent case that nonadjacent_neighborSet_equinum cannot reach. neighborSet_equinum_of_nonadj_or_common_nonneighbor packages the dichotomy: any pair that is non-adjacent or has a common non-neighbour is equinumerous, the structure of the ℵ₀-regular hub-free counterexample. Finiteness-free.",
+      "mathContext": "The classical finite proof shows a hub-free friendship graph is regular before applying the spectral step; the adjacent-pair equality is obtained by routing through a common non-neighbour. This file supplies that routing finiteness-freely, leaving only the existence of a common non-neighbour (finite-counting in the classical proof) as the open ingredient on the infinite side."
     },
     {
       "id": "part6-perfect-matching",

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S, build-pending): added finiteness-free infinite windmill structure theorems; positive half of OQ-04 now includes the windmill shape, not just universal-vertex existence. Negative half (C5 amalgam) still open.",
+    "progressSummary": "PROGRESS (S, build-verified): added the adjacent-pair regularity step (neighborSet_equinum_of_common_nonneighbor + neighborSet_equinum_of_nonadj_or_common_nonneighbor) — composing the two non-adjacent bijections N(u)≃N(z)≃N(v) extends 'equal neighbourhoods' from non-adjacent pairs to adjacent pairs sharing a common non-neighbour, the missing step toward full regularity of a hub-free friendship graph. Docker green (7745 jobs). Positive (windmill) + hub-uniqueness halves complete; negative half now needs only existence of a common non-neighbour for adjacent pairs (finite-counting classically) + the C5 amalgam construction.",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
@@ -38,7 +38,8 @@
       "univ_finite_of_locallyFinite (:96) + locally_finite_is_finite (:109): local finiteness => Finite V via Set.Finite.biUnion of the 2-ball covering.",
       "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices.",
       "Added import Proofs.FriendshipTheoremOQ04 to proofs/Proofs.lean (manifest registration → file now in the machine-checked build set, deployer-gated)",
-      "universal_noncentral_neighborSet + universal_noncentral_ncard_two in FriendshipTheoremOQ04.lean — finiteness-free infinite windmill structure (N(u)={c,w}, ncard=2)"
+      "universal_noncentral_neighborSet + universal_noncentral_ncard_two in FriendshipTheoremOQ04.lean — finiteness-free infinite windmill structure (N(u)={c,w}, ncard=2)",
+      "proofs/Proofs/FriendshipTheoremOQ04.lean (380-413): neighborSet_equinum_of_common_nonneighbor — two vertices sharing a common non-neighbour z have equinumerous neighbourhoods via N(u)≃N(z)≃N(v) (Set.BijOn.comp of two nonadjacent_neighborSet_equinum bijections); neighborSet_equinum_of_nonadj_or_common_nonneighbor — unified dichotomy. 414L/18thm/0ax/0sorry, Docker green 7745 jobs (researcher-10, 2026-06-18)."
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -49,13 +50,14 @@
       "ACT: the positive OQ-04 result is finiteness-light and spectral-free — the diameter-2 covering (purely local) plus local finiteness gives Finite V directly, bypassing the trace/eigenvalue step that has no infinite analogue.",
       "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting.",
       "Registered FriendshipTheoremOQ04.lean in proofs/Proofs.lean (was the only Friendship sibling absent from the import manifest, so its 8 theorems / 0 sorry / 0 axiom were inspection-only, never machine-checked). Re-verified call convention: friendship_theorem takes G explicitly (variable (G : SimpleGraph V) at FriendshipTheorem.lean:112; internal caller line 232 uses friendship_theorem G hF h), so the capstone call form is sound.",
-      "The finite friendship_noncentral_degree (G.degree u = 2) is Fintype-bound; the underlying set equality N(u)={c,w} needs no finiteness and holds on infinite friendship graphs with a universal vertex — the recovered graph is a genuine (infinite) windmill"
+      "The finite friendship_noncentral_degree (G.degree u = 2) is Fintype-bound; the underlying set equality N(u)={c,w} needs no finiteness and holds on infinite friendship graphs with a universal vertex — the recovered graph is a genuine (infinite) windmill",
+      "Adjacent-pair regularity is finiteness-free GIVEN a common non-neighbour: route N(u)≃N(z)≃N(v) through z adjacent to neither (Set.BijOn.comp). This bridges the gap nonadjacent_neighborSet_equinum leaves (it needs u,v themselves non-adjacent). The only remaining open ingredient for full ℵ₀-regularity of a hub-free friendship graph is the EXISTENCE of a common non-neighbour for an adjacent pair — established by counting in the finite proof, genuinely open on the infinite side."
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."
     ],
     "nextSteps": [
-      "BUILD VERIFY (gated): once Docker/Aristotle backend is up, ./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04, then register import in proofs/Proofs.lean after line 2322.",
+      "NEGATIVE half: prove existence of a common non-neighbour for any adjacent pair in a hub-free friendship graph (the last input to full regularity via neighborSet_equinum_of_common_nonneighbor); classically a finite-counting argument, open infinitely.",
       "Lower-confidence lemma names to confirm at build: Set.finite_univ_iff, Set.univ_eq_empty_iff, Set.Finite.biUnion arity, Set.mem_biUnion.",
       "Optional: formalize the C5-free-amalgamation infinite counterexample (the negative direction) — harder, needs an inductive/colimit construction of the vertex type."
     ],


### PR DESCRIPTION
## Summary

Adds the **adjacent-pair regularity step** to `FriendshipTheoremOQ04.lean` — a finiteness-free advance on the *negative* (hub-free) direction of OQ-04, the open part of the problem.

The existing `nonadjacent_neighborSet_equinum` equates neighbourhoods of *non-adjacent* vertices only. This PR bridges the *adjacent* case:

- **`neighborSet_equinum_of_common_nonneighbor`** — two vertices `u`, `v` sharing a common *non-neighbour* `z` (adjacent to neither) have equinumerous neighbourhoods, by composing the two non-adjacent bijections `N(u) ≃ N(z) ≃ N(v)` (`Set.BijOn.comp`).
- **`neighborSet_equinum_of_nonadj_or_common_nonneighbor`** — unified dichotomy: any pair that is non-adjacent *or* has a common non-neighbour is equinumerous — exactly the ℵ₀-regular shape of the C₅ free-amalgamation counterexample.

This is the missing step toward full regularity of a hub-free friendship graph. The sole remaining open ingredient on the infinite side is the *existence* of a common non-neighbour for an adjacent pair (obtained by counting in the classical finite proof). Conclusions are `Set.BijOn`, so they carry content on infinite neighbourhoods; no finiteness is used.

## Verification

- Docker build-verified green: `./proofs/scripts/docker-build.sh Proofs.FriendshipTheoremOQ04` → **Build completed successfully (7745 jobs)**, Lean v4.26.0, Mathlib pin 2df2f01.
- 0 axioms / 0 sorries. File: 379 → 414 lines, 16 → 18 theorems.
- Composes only existing in-file lemmas + standard Mathlib (`Set.BijOn.comp`); no new dependencies.

## Notes

Distinct from the already-merged hub-uniqueness work (`two_universal_cover` etc. in `FriendshipTheoremOQ04Universal.lean`, #25825/#25260) and r6's windmill perfect-matching theorems — this targets the regularity/negative direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)