### PR TITLE
audit(erdos-16): definitions-only scaffold mislabeled verified/mathlib → axiomatized/wip + phantom-axiom prose fix

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4877,10 +4877,10 @@
       "result": "clean"
     },
     "erdos-16": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T21:12:34Z",
-      "result": "clean"
+      "lastAudited": "2026-06-18T17:38:43Z",
+      "result": "issues-fixed"
     },
     "erdos-160": {
       "auditCount": 3,

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -7,7 +7,7 @@
     "author": "Romanoff (1934), Erdős (1950), Chen (2023)",
     "sourceUrl": "https://erdosproblems.com/16",
     "date": "1950",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos16Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "covering-congruences",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 16,
     "erdosUrl": "https://erdosproblems.com/16",
@@ -46,7 +46,7 @@
       }
     ],
     "lineCount": 203,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "This file formalizes definitions only (IsRomanoff, ExceptionalSet, density, lowerDensity, IsCoveringSystem, ErdosConjecture16, erdosCovering, and the related Props Erdos9/10/11Question). It contains 0 axioms, 0 theorems, and 0 sorries. Romanoff's theorem, Erdős's covering result, Chen's 2023 disproof, the specific exceptional numbers, and the density bounds are described in doc-comments only — none is formalized as a theorem or an axiom (there is no `chen_disproof` declaration in the source).",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
     "definitionCount": 10
@@ -55,7 +55,7 @@
     "historicalContext": "Romanoff (1934) proved that the set $\\{n : n = 2^k + p\\}$ has positive lower density among odd integers, using sieve methods and the prime number theorem to show that the 'expected count' of representations diverges. Erdős (1950) turned to the complementary question: what does the exceptional set $E$ look like? His key tool was covering congruences — systems of residue classes $\\{a_i \\pmod{m_i}\\}$ that tile $\\mathbb{Z}$. By choosing moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$ (whose reciprocals sum to 1), Erdős arranged that for any $n$ in a particular residue class mod $\\text{lcm} = 24$, each $n - 2^k$ is divisible by a small prime. This forced an infinite AP into $E$. Erdős then conjectured — self-deprecatingly calling it 'rather silly' — that $E$ is essentially just this AP plus density-0 noise. After 73 years, Chen (2023) disproved this by showing $E$ contains infinitely many essentially independent APs, each contributing positive density. The exceptional set's structure is far richer than a single covering congruence produces.",
     "problemStatement": "Define the exceptional set E = {odd n : n ≠ 2^k + p for all k ≥ 1 and primes p}. Erdős asked: is E = (arithmetic progression) ∪ (density-0 set)? Chen proved NO: E has more complex structure.",
     "text": "Is the set of odd integers not of the form 2^k + p the union of an arithmetic progression and a density-0 set? DISPROVED by Chen (2023).",
-    "proofStrategy": "The formalization defines Romanoff numbers (n = 2^k + p), the exceptional set, covering congruence systems, and density. Key axioms encode Romanoff's theorem (positive density are representable), Erdős's covering result (E contains a progression), Chen's disproof (the conjecture is false), and the complex structure (multiple independent progressions).",
+    "proofStrategy": "The file defines Romanoff numbers (n = 2^k + p), the exceptional set, covering congruence systems, density / lowerDensity, the Prop ErdosConjecture16, and the related Props for Problems #9–#11. Romanoff's theorem, Erdős's covering result, Chen's disproof, and the density bounds appear in documentation only — none is formalized as a theorem or an axiom.",
     "keyInsights": [
       "Exceptional set E = {1, 127, 149, 251, 331, ...} (OEIS A006285)",
       "127 is exceptional: 127 - 2^k is composite for all valid k",
@@ -89,63 +89,63 @@
       "startLine": 30,
       "endLine": 44,
       "summary": "Introduces Romanoff's theorem and the exceptional set. Lists the first exceptional odd integers from OEIS A006285: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ...",
-      "mathContext": "Verified: Introduces Romanoff's theorem and the exceptional set. Lists the first exceptional odd integers from OEIS A006285: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ..."
+      "mathContext": "Documented: Introduces Romanoff's theorem and the exceptional set. Lists the first exceptional odd integers from OEIS A006285: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ..."
     },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
       "startLine": 45,
       "endLine": 63,
-      "summary": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and axiomatizes the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$.",
-      "mathContext": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and axiomatizes the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$."
+      "summary": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and documents (not formalized) the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$.",
+      "mathContext": "Defines `IsRomanoff n` ($\\exists k \\geq 1, p$ prime: $n = 2^k + p$), `ExceptionalSet` (odd non-Romanoff integers), and documents (not formalized) the characterization that $n$ is exceptional iff $n - 2^k$ is composite for every valid $k$."
     },
     {
       "id": "the-romanoff-theorem",
       "title": "The Romanoff Theorem",
       "startLine": 64,
       "endLine": 91,
-      "summary": "Defines asymptotic `density` and `lowerDensity`, then axiomatizes Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$.",
-      "mathContext": "Defines asymptotic `density` and `lowerDensity`, then axiomatizes Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$."
+      "summary": "Defines asymptotic `density` and `lowerDensity`, then documents (not formalized) Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$.",
+      "mathContext": "Defines asymptotic `density` and `lowerDensity`, then documents (not formalized) Romanoff's theorem: the Romanoff numbers have positive lower density among odd integers. Corollary: the exceptional set has density less than $1/2$."
     },
     {
       "id": "erd-s-s-covering-congruence-re",
       "title": "Erdős's Covering Congruence Result (1950)",
       "startLine": 92,
       "endLine": 116,
-      "summary": "Defines `IsCoveringSystem` and axiomatizes Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression.",
-      "mathContext": "Formal definition: Defines `IsCoveringSystem` and axiomatizes Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression."
+      "summary": "Defines `IsCoveringSystem` and documents (not formalized) Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression.",
+      "mathContext": "Formal definition: Defines `IsCoveringSystem` and documents (not formalized) Erdős's 1950 result: using covering congruences with moduli $\\{2, 3, 4, 6, 8, 12, 24\\}$, the exceptional set contains an infinite arithmetic progression."
     },
     {
       "id": "the-conjecture-and-its-disproo",
       "title": "The Conjecture and Its Disproof",
       "startLine": 117,
       "endLine": 146,
-      "summary": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Axiomatizes Chen's 2023 disproof (`chen_disproof : ¬ErdosConjecture16`) and the consequence that no single AP captures $E$ up to density 0.",
-      "mathContext": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Axiomatizes Chen's 2023 disproof (`chen_disproof : ¬ErdosConjecture16`) and the consequence that no single AP captures $E$ up to density 0."
+      "summary": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Documents (not formalized) Chen's 2023 disproof (stated as ¬ErdosConjecture16; no such declaration exists in the source) and the consequence that no single AP captures $E$ up to density 0.",
+      "mathContext": "Formalizes `ErdosConjecture16`: $E = (\\text{AP}) \\cup (\\text{density-0 set})$. Documents (not formalized) Chen's 2023 disproof (stated as ¬ErdosConjecture16; no such declaration exists in the source) and the consequence that no single AP captures $E$ up to density 0."
     },
     {
       "id": "known-exceptional-numbers",
       "title": "Known Exceptional Numbers",
       "startLine": 147,
       "endLine": 171,
-      "summary": "Axiomatizes specific exceptional numbers: 127, 149, 251. Includes the manual verification for 127 showing $127 - 2^k$ is composite for $k = 1, \\ldots, 6$ and $2^7 > 127$.",
-      "mathContext": "Axiomatizes specific exceptional numbers: 127, 149, 251. Includes the manual verification for 127 showing $127 - $2^{k}$$ is composite for $k = 1, \\ldots, 6$ and $$2^{7}$ > 127$."
+      "summary": "Documents (not formalized) specific exceptional numbers: 127, 149, 251. The source notes in prose (not checked in Lean) that $127 - 2^k$ is composite for $k = 1, \\ldots, 6$ and $2^7 > 127$.",
+      "mathContext": "Documents (not formalized) specific exceptional numbers: 127, 149, 251. The source notes in prose (not checked in Lean) that $127 - $2^{k}$$ is composite for $k = 1, \\ldots, 6$ and $$2^{7}$ > 127$."
     },
     {
       "id": "connection-to-covering-congrue",
       "title": "Connection to Covering Congruences",
       "startLine": 172,
       "endLine": 188,
-      "summary": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and axiomatizes that for exceptional $n$, each $n - 2^k$ is divisible by some prime $p < 100$ from the covering.",
-      "mathContext": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and axiomatizes that for exceptional $n$, each $n - $2^{k}$$ is divisible by some prime $p < 100$ from the covering."
+      "summary": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and documents (not formalized) that for exceptional $n$, each $n - 2^k$ is divisible by some prime $p < 100$ from the covering.",
+      "mathContext": "Defines `erdosCovering` with moduli $\\{2,3,4,6,8,12,24\\}$ (period 24) and documents (not formalized) that for exceptional $n$, each $n - $2^{k}$$ is divisible by some prime $p < 100$ from the covering."
     },
     {
       "id": "density-bounds",
       "title": "Density Bounds",
       "startLine": 189,
       "endLine": 203,
-      "summary": "Axiomatizes precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers).",
-      "mathContext": "Axiomatized: Axiomatizes precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers)."
+      "summary": "Documents (not formalized) precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers).",
+      "mathContext": "Documents (not formalized) precise density bounds: $\\underline{d}(E) > 0$ (positive density from the arithmetic progression) and $\\underline{d}(E) < 1/10$ (approximately 9% of all integers, 18% of odd integers)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-16 (Erdős #16: Odd Integers Not of Form 2^k + p)
**Severity**: HIGH — solved/disproved problem presented as `verified`; 8 sections claim axioms (incl. a named `chen_disproof` axiom) that do not exist.

### Problem

`proofs/Proofs/Erdos16Problem.lean` (203 lines) contains **only 10 definitions** — `IsRomanoff`, `ExceptionalSet`, `density`, `lowerDensity`, `IsCoveringSystem`, `ErdosConjecture16`, `erdosCovering`, `Erdos9/10/11Question` — with **zero theorems, axioms, or sorries**. Romanoff's theorem, Erdős's covering result, **Chen's 2023 disproof**, the exceptional numbers (127/149/251), and the density bounds are all bare doc-comments. Nothing about Problem #16 is proved.

### meta.json claimed (vs. reality)

| Field | Claimed | Reality |
|-------|---------|---------|
| `status` | `verified` | nothing proven |
| `badge` | `mathlib` | no Mathlib bridge does the core work |
| `assumptions` | "None. Fully verified with 0 axioms and 0 sorries." | defs only |
| 8 `sections` | "axiomatizes Romanoff's theorem / Erdős's result / **Chen's disproof (`chen_disproof : ¬ErdosConjecture16`)** / exceptional numbers / density bounds" | **phantom** — 0 axioms; no `chen_disproof` declaration exists |
| `proofStrategy` | "Key axioms encode …" | **phantom** |

### Fix (this PR)

- `status` verified → **axiomatized**, `badge` mathlib → **wip** (gallery convention for definitions-only scaffolds; companion PRs #25866 erdos-182, #25867 erdos-497).
- `assumptions` / `proofStrategy`: rewritten to be accurate — defs only; named results documented, not formalized; no `chen_disproof` declaration exists.
- `sections`: every "axiomatizes X" → "Documents (not formalized) X"; removed the phantom `chen_disproof` axiom reference; corrected the "127 manual verification" claim to prose-only (not Lean-checked); fixed stray "Verified:"/"Axiomatized:" mathContext prefixes.

Counts (10 def / 0 thm / 0 axiom / 0 sorry / 203 lines) were already correct — status + prose accuracy fix only.

---
Discovered during gallery integrity audit (third in the `verified/mathlib` definitions-only cluster: erdos-182, erdos-497, erdos-16).
🤖 Generated with [Claude Code](https://claude.com/claude-code)