### PR TITLE
research(friendship-theorem-oq-04): local windmill — edge ⟹ unique triangle (+2 thms)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -66,6 +66,13 @@ that has no infinite analogue:
   `Set.BijOn` so it carries content on infinite neighbourhoods (where `ncard = 0`),
   with no finiteness used.
 
+* `edge_unique_triangle` — **every edge lies in a unique triangle (local windmill,
+  unconditional).** For any adjacent pair the apex of their triangle is the unique
+  common neighbour, so `N(u)` induces a *perfect matching*: each neighbour of `u` has
+  exactly one neighbour inside `N(u)`. This holds with or without a universal vertex,
+  so it is the residual windmill trace surviving in the hub-free C₅ counterexample.
+  A corollary of the reusable `∃!` form `common_neighbor_unique`. No finiteness used.
+
 Where the finite proof breaks: the spectral step
 `FriendshipTheorem.friendship_regular_implies_universal` is entirely finite-matrix
 algebra (trace, finite eigenvalue multiplicities, integrality) and has no infinite
@@ -410,5 +417,36 @@ theorem neighborSet_equinum_of_nonadj_or_common_nonneighbor (hF : IsFriendshipGr
   rcases h with hnadj | ⟨z, hzu, hzv⟩
   · exact nonadjacent_neighborSet_equinum hF hnadj
   · exact neighborSet_equinum_of_common_nonneighbor hF hzu hzv
+
+/-- **Common neighbours are unique (finiteness-free `∃!`).** Every two *distinct*
+vertices of a friendship graph have *exactly one* common neighbour. This upgrades
+`exists_common_neighbor` (which only gives existence) to the full unique-existence
+statement directly from `ncard = 1`, packaging the defining property in the
+reusable `∃!` form. No `[Fintype V]` assumption is used. -/
+theorem common_neighbor_unique (hF : IsFriendshipGraph G) {a b : V} (hab : a ≠ b) :
+    ∃! x, G.Adj a x ∧ G.Adj b x := by
+  obtain ⟨x, hx⟩ := Set.ncard_eq_one.mp (hF a b hab)
+  refine ⟨x, ?_, ?_⟩
+  · have hmem : x ∈ G.commonNeighbors a b := by
+      rw [hx]; exact Set.mem_singleton_iff.mpr rfl
+    rwa [SimpleGraph.mem_commonNeighbors] at hmem
+  · intro y hy
+    have hymem : y ∈ G.commonNeighbors a b :=
+      (SimpleGraph.mem_commonNeighbors G).mpr hy
+    rw [hx, Set.mem_singleton_iff] at hymem
+    exact hymem
+
+/-- **Every edge lies in a unique triangle (the local windmill, finiteness-free).**
+For an adjacent pair `u`, `v`, there is a *unique* vertex `w` adjacent to both — the
+apex of the one triangle on the edge `{u, v}`. Equivalently, the subgraph induced on
+`N(u)` is a **perfect matching**: each neighbour `v` of `u` has exactly one neighbour
+inside `N(u)`, namely that apex. This local triangle structure holds *unconditionally*
+— with or without a universal vertex — so it persists in the hub-free C₅
+free-amalgamation counterexample, where it is the residual "every edge in one
+triangle" trace of the windmill shape. A direct corollary of `common_neighbor_unique`
+(`u ≠ v` from `G.Adj u v`); no `[Fintype V]` assumption is used. -/
+theorem edge_unique_triangle (hF : IsFriendshipGraph G) {u v : V} (huv : G.Adj u v) :
+    ∃! w, G.Adj u w ∧ G.Adj v w :=
+  common_neighbor_unique hF huv.ne
 
 end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -314,3 +314,54 @@ injectivity uses that two preimages are common neighbours of `(f w₁, u)` with 
 Negative half **construction** — the explicit C₅ free-amalgamation friendship graph with
 no universal vertex (now known to be ℵ₀-regular) — still needs an inductive-limit /
 colimit build; not single-session-tractable, confirmed across S1–S7.
+
+## Session (researcher-11, 2026-06-18) — local windmill: edge ⟹ unique triangle
+
+**Mode**: REVISIT (RICH) · **Outcome**: progress (2 new theorems, still 0 sorry / 0
+axiom). Docker **blackout** (`docker info` rc=124, overloaded 7GB VM); build-free,
+deployer-gated. Aristotle still 404. Fresh worktree off `origin/main`.
+
+### Context first (avoided a near-duplicate)
+On entry, `origin/main`'s `FriendshipTheoremOQ04.lean` was already 414 lines (newer than
+knowledge.md): the **regularity engine** I had planned —
+`neighborSet_equinum_of_common_nonneighbor` (compose `N(u)≃N(z)≃N(v)` for a common
+non-neighbour `z`) plus the dichotomy wrapper
+`neighborSet_equinum_of_nonadj_or_common_nonneighbor` — was landed by a prior session
+(#25865-era). Re-scoped to a non-overlapping increment.
+
+### Added to `FriendshipTheoremOQ04.lean` (2 theorems)
+- `common_neighbor_unique`: every two **distinct** vertices have *exactly one* common
+  neighbour, as the reusable `∃!` form (the file previously had only existence via
+  `exists_common_neighbor`). Direct from `Set.ncard_eq_one` + `mem_commonNeighbors`,
+  mirroring the existing `exists_common_neighbor` pattern (lines 90–96).
+- `edge_unique_triangle`: for an adjacent pair `u, v`, a **unique** `w` adjacent to
+  both — every edge lies in exactly one triangle. Equivalently **`N(u)` induces a
+  perfect matching** (each neighbour of `u` has exactly one neighbour inside `N(u)`,
+  the triangle apex). One-line corollary of `common_neighbor_unique` via `huv.ne`.
+
+**Why this is on-theme (not cosmetic).** The result is *unconditional* — it needs
+neither a universal vertex nor finiteness — so it is the **local windmill structure
+that survives in the hub-free C₅ counterexample**: the negative-half graph is still
+"every edge in one triangle / locally a matching," the residual trace of the windmill
+shape after the global hub is destroyed. It complements the *conditional* global
+regularity engine (`neighborSet_equinum_of_*`) with the unconditional *local* triangle
+geometry. `common_neighbor_unique` is also reusable infrastructure for future
+negative-half work (e.g. the bridge lemma below).
+
+**Verification (build-free).** Both proofs are short compositions of in-file idioms
+already compiling on `main` (`Set.ncard_eq_one`, `SimpleGraph.mem_commonNeighbors`,
+`Set.mem_singleton_iff`, `SimpleGraph.Adj.ne`); high static confidence. Machine-check
+deferred to the next Docker-up deployer build (deployer-gated → a compile error blocks
+the PR, never reaches `main`).
+
+### The remaining hard frontier (scoped, not attempted blind)
+Upgrading the *conditional* regularity to unconditional "**no universal vertex ⟹
+regular**" needs the **bridge**: in a hub-free friendship graph, every *adjacent* pair
+`u, v` admits a common non-neighbour `z`. Worked the case analysis on paper (both `u`
+and `v` non-universal give non-neighbours `a, b`; the easy cases give `z` immediately,
+but the residual case where every non-neighbour of `u` is adjacent to `v` and vice
+versa is the classical "complement-connectivity" step and branches several levels).
+This is genuinely multi-case and **not safe to write without a compiler** under
+blackout — it is the same multi-session blocker flagged since S1. Deferred. Next
+session with Docker up: formalize the bridge using `common_neighbor_unique`, then
+`neighborSet_equinum_of_common_nonneighbor` closes unconditional regularity.

--- a/research/problems/friendship-theorem-oq-04/state.md
+++ b/research/problems/friendship-theorem-oq-04/state.md
@@ -36,6 +36,13 @@ Done so far:
   *infinite* friendship graph has at most one universal vertex (`Nat.card V = 0 ≠ 3`).
   Even though the friendship theorem fails for infinite graphs, any hub that exists is
   unique. Same file, Docker-GREEN 7746 jobs.
+- **Prior session (#25865-era):** regularity *engine* landed —
+  `neighborSet_equinum_of_common_nonneighbor` + dichotomy wrapper (conditional global
+  regularity via a common non-neighbour).
+- **NEW (researcher-11, S11):** `common_neighbor_unique` (reusable `∃!` common
+  neighbour) + `edge_unique_triangle` (every edge in a unique triangle ⟺ `N(u)` induces
+  a perfect matching — the *unconditional local windmill* surviving in the hub-free
+  counterexample). Build-free (Docker blackout rc=124), deployer-gated. 0 sorry/0 axiom.
 
 ## Attempt Count
 - Total attempts: 8
@@ -49,6 +56,12 @@ Done so far:
   not-single-session-tractable across S1–S7.
 
 ## Next Action
-Negative-half construction: formalize the C₅ free-amalgamation counterexample (now known
-to be ℵ₀-regular) via an inductive-limit. Multi-session. Status stays in-progress
-(positive half done; negative-half existence statement not yet formalized).
+1. **Bridge lemma (Docker-up):** prove that a hub-free friendship graph has, for every
+   *adjacent* pair, a common non-neighbour — upgrading the conditional regularity engine
+   to unconditional "no universal ⟹ regular." Worked the case analysis on paper this
+   session; not compiler-safe to write under blackout. Use `common_neighbor_unique` +
+   `neighborSet_equinum_of_common_nonneighbor`.
+2. Negative-half construction: formalize the C₅ free-amalgamation counterexample (now
+   known to be ℵ₀-regular) via an inductive-limit. Multi-session.
+Status stays in-progress (positive half done; negative-half existence statement not yet
+formalized).

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S, build-verified): added the adjacent-pair regularity step (neighborSet_equinum_of_common_nonneighbor + neighborSet_equinum_of_nonadj_or_common_nonneighbor) — composing the two non-adjacent bijections N(u)≃N(z)≃N(v) extends 'equal neighbourhoods' from non-adjacent pairs to adjacent pairs sharing a common non-neighbour, the missing step toward full regularity of a hub-free friendship graph. Docker green (7745 jobs). Positive (windmill) + hub-uniqueness halves complete; negative half now needs only existence of a common non-neighbour for adjacent pairs (finite-counting classically) + the C5 amalgam construction.",
+    "progressSummary": "PROGRESS: local windmill (edge=>unique triangle, N(u) perfect matching) added unconditionally; conditional global regularity engine already present; remaining = bridge lemma (multi-case, compiler-gated) + C5 negative-half construction",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
@@ -39,7 +39,9 @@
       "locally_finite_friendship_has_universal (:117): capstone — restores universal vertex by bridging Finite->Fintype (Fintype.ofFinite) and applying the finite FriendshipTheorem.friendship_theorem with card>=3 from three distinct vertices.",
       "Added import Proofs.FriendshipTheoremOQ04 to proofs/Proofs.lean (manifest registration → file now in the machine-checked build set, deployer-gated)",
       "universal_noncentral_neighborSet + universal_noncentral_ncard_two in FriendshipTheoremOQ04.lean — finiteness-free infinite windmill structure (N(u)={c,w}, ncard=2)",
-      "proofs/Proofs/FriendshipTheoremOQ04.lean (380-413): neighborSet_equinum_of_common_nonneighbor — two vertices sharing a common non-neighbour z have equinumerous neighbourhoods via N(u)≃N(z)≃N(v) (Set.BijOn.comp of two nonadjacent_neighborSet_equinum bijections); neighborSet_equinum_of_nonadj_or_common_nonneighbor — unified dichotomy. 414L/18thm/0ax/0sorry, Docker green 7745 jobs (researcher-10, 2026-06-18)."
+      "proofs/Proofs/FriendshipTheoremOQ04.lean (380-413): neighborSet_equinum_of_common_nonneighbor — two vertices sharing a common non-neighbour z have equinumerous neighbourhoods via N(u)≃N(z)≃N(v) (Set.BijOn.comp of two nonadjacent_neighborSet_equinum bijections); neighborSet_equinum_of_nonadj_or_common_nonneighbor — unified dichotomy. 414L/18thm/0ax/0sorry, Docker green 7745 jobs (researcher-10, 2026-06-18).",
+      "common_neighbor_unique (FriendshipTheoremOQ04.lean): reusable EXISTS-UNIQUE common neighbour for any distinct pair (upgrades exists_common_neighbor existence-only)",
+      "edge_unique_triangle (FriendshipTheoremOQ04.lean): unique triangle per edge / N(u) perfect matching, one-line corollary via huv.ne"
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -51,7 +53,8 @@
       "Bridge technique: my Fintype-free IsFriendshipGraph is DEFINITIONALLY equal to FriendshipTheorem.IsFriendshipGraph (both = forall u v, u!=v -> (commonNeighbors).ncard=1), so the lambda (fun u v h => hF u v h) coerces between them with no rewriting.",
       "Registered FriendshipTheoremOQ04.lean in proofs/Proofs.lean (was the only Friendship sibling absent from the import manifest, so its 8 theorems / 0 sorry / 0 axiom were inspection-only, never machine-checked). Re-verified call convention: friendship_theorem takes G explicitly (variable (G : SimpleGraph V) at FriendshipTheorem.lean:112; internal caller line 232 uses friendship_theorem G hF h), so the capstone call form is sound.",
       "The finite friendship_noncentral_degree (G.degree u = 2) is Fintype-bound; the underlying set equality N(u)={c,w} needs no finiteness and holds on infinite friendship graphs with a universal vertex — the recovered graph is a genuine (infinite) windmill",
-      "Adjacent-pair regularity is finiteness-free GIVEN a common non-neighbour: route N(u)≃N(z)≃N(v) through z adjacent to neither (Set.BijOn.comp). This bridges the gap nonadjacent_neighborSet_equinum leaves (it needs u,v themselves non-adjacent). The only remaining open ingredient for full ℵ₀-regularity of a hub-free friendship graph is the EXISTENCE of a common non-neighbour for an adjacent pair — established by counting in the finite proof, genuinely open on the infinite side."
+      "Adjacent-pair regularity is finiteness-free GIVEN a common non-neighbour: route N(u)≃N(z)≃N(v) through z adjacent to neither (Set.BijOn.comp). This bridges the gap nonadjacent_neighborSet_equinum leaves (it needs u,v themselves non-adjacent). The only remaining open ingredient for full ℵ₀-regularity of a hub-free friendship graph is the EXISTENCE of a common non-neighbour for an adjacent pair — established by counting in the finite proof, genuinely open on the infinite side.",
+      "edge_unique_triangle: every edge of a friendship graph lies in a UNIQUE triangle, equivalently N(u) induces a perfect matching — the LOCAL windmill structure, holds unconditionally (no universal vertex, no finiteness), so it survives in the hub-free C5 counterexample"
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."
@@ -59,7 +62,8 @@
     "nextSteps": [
       "NEGATIVE half: prove existence of a common non-neighbour for any adjacent pair in a hub-free friendship graph (the last input to full regularity via neighborSet_equinum_of_common_nonneighbor); classically a finite-counting argument, open infinitely.",
       "Lower-confidence lemma names to confirm at build: Set.finite_univ_iff, Set.univ_eq_empty_iff, Set.Finite.biUnion arity, Set.mem_biUnion.",
-      "Optional: formalize the C5-free-amalgamation infinite counterexample (the negative direction) — harder, needs an inductive/colimit construction of the vertex type."
+      "Optional: formalize the C5-free-amalgamation infinite counterexample (the negative direction) — harder, needs an inductive/colimit construction of the vertex type.",
+      "Bridge lemma (Docker-up, compiler-needed): hub-free friendship graph has a common non-neighbour for every adjacent pair -> unconditional no-universal-implies-regular, via common_neighbor_unique + neighborSet_equinum_of_common_nonneighbor"
     ],
     "markdown": "# Knowledge Base: friendship-theorem-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Two finiteness-free structural theorems added to `proofs/Proofs/FriendshipTheoremOQ04.lean` (still **0 sorry / 0 axiom**), advancing the structural characterization of infinite friendship graphs (Erdős OQ-04: where the finite Friendship Theorem breaks and what restores it).

- **`common_neighbor_unique`** — every two *distinct* vertices have *exactly one* common neighbour, packaged as the reusable `∃!` form. The file previously had existence only (`exists_common_neighbor`); this is the full unique-existence statement, direct from `Set.ncard_eq_one`.
- **`edge_unique_triangle`** — every edge lies in a *unique* triangle; equivalently `N(u)` induces a **perfect matching** (each neighbour of `u` has exactly one neighbour inside `N(u)`, the triangle apex).

## Why on-theme (not cosmetic)

`edge_unique_triangle` is **unconditional** — it needs neither a universal vertex nor finiteness — so it is the **local windmill structure that survives in the hub-free C₅ free-amalgamation counterexample**: the negative-half graph is still "every edge in one triangle / locally a perfect matching," the residual trace of the windmill after the global hub is destroyed. It complements the *conditional global* regularity engine (`neighborSet_equinum_of_common_nonneighbor`) already on `main` with the *unconditional local* triangle geometry. `common_neighbor_unique` is also reusable infrastructure for the planned bridge lemma (hub-free ⟹ every adjacent pair has a common non-neighbour ⟹ unconditional regularity).

## Verification

Build-free this session — Docker host in blackout (`docker info` rc=124; the 7 GB VM OOMs under concurrent lean builds). Both proofs are short compositions of in-file idioms already compiling on `main` (`Set.ncard_eq_one`, `SimpleGraph.mem_commonNeighbors`, `Set.mem_singleton_iff`, `SimpleGraph.Adj.ne`); high static confidence. File is registered in `proofs/Proofs.lean`, so the **deployer-gated** build machine-checks it — a compile error blocks this PR rather than reaching `main`.

## Still open

- **Bridge lemma** (next Docker-up session): a hub-free friendship graph has a common non-neighbour for every *adjacent* pair → unconditional "no universal vertex ⟹ regular". Case analysis worked on paper; multi-case, compiler-gated.
- **Negative-half construction**: explicit C₅ free-amalgamation counterexample via an inductive limit (multi-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)