### PR TITLE
audit(erdos-205): clean 5th re-audit — disproof of 2^k+m few-prime-factors intact

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5249,9 +5249,9 @@
       "result": "clean"
     },
     "erdos-205": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T17:55:00Z",
       "result": "clean"
     },
     "erdos-206": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-205 (clean)

Re-audit of **Erdős 205** (2^k+m few prime factors, **DISPROVED**, Tier C / axiomatized).

### Result: CLEAN

`Erdos205Problem.lean` is unchanged since the prior clean audit and all meta.json claims remain accurate.

**Counts (exact):** 444L / 6 axioms / 0 sorry / 44 theorems / 9 defs / 37 native_decide

**Status:** `axiomatized` / badge `axiom` / `erdosProblemStatus: solved` — correct.

### Verification
- All 6 axioms are real and disclosed: `barreto_leeham_counterexample`, `threshold_dominates_loglog`, `romanoff_positive_density`, `erdos_covering_obstruction`, `average_omega_asymptotic`, `omega_concentration`.
- Headline `erdos_205_disproved` (L183) derives cleanly from the axiomatized counterexample — **no axiom masking**.
- `originalContributions` "Eliminated 3 axioms" is accurate: `bigOmega_prime_pow` (L67), `bigOmega_mul` (L81), `remainder_achieves_min` (L142) are genuine proved theorems.
- The 37 `native_decide` are incidental concrete leaf facts (Ω-values, primality, orders of 2, de Polignac 127/149). The headline does not touch them → **no `Lean.ofReduceBool` disclosure required** (per concrete-example precedent).
- No phantom declarations; every `originalContributions` entry maps to a real decl.

Tracker `auditCount` 3→4, result `clean`.

---
Discovered during autonomous gallery integrity audit.