### PR TITLE
audit(erdos-180): axiom-masking fix — erdos_stone_domination is unconditional, not just non-bipartite

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5036,9 +5036,9 @@
     },
     "erdos-180": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T17:57:48Z",
+      "result": "issues-fixed"
     },
     "erdos-181": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-180/meta.json
+++ b/src/data/proofs/erdos-180/meta.json
@@ -40,7 +40,7 @@
       "ExSingle, ExFamily: type aliases for extremal functions ℕ → ℕ",
       "HasDomination: some member has ex(n;G) = O(ex(n;F))",
       "ErdosConjecture180: every finite family has domination",
-      "erdos_stone_domination axiom: non-bipartite families have domination",
+      "erdos_stone_domination axiom: domination assumed for every nonempty family (stated unconditionally, with no bipartite restriction; motivated by Erdős-Stone for the non-bipartite case but as written subsumes the open conjecture)",
       "BipartiteCase: existence of family without domination",
       "folklore_counterexample_infinite axiom: infinite family counterexample",
       "family_le_members axiom: ex(n;F) ≤ min ex(n;G)",
@@ -89,7 +89,7 @@
     "historicalContext": "Erdős and Miklós Simonovits posed this problem in their 1982 survey [ErSi82] on extremal graph theory. The question is motivated by the Erdős-Stone theorem (1946), which determines $\\mathrm{ex}(n; H) = (1 - 1/(\\chi(H)-1) + o(1))\\binom{n}{2}$ for non-bipartite $H$, making the domination question trivial when all forbidden graphs have $\\chi \\geq 3$. The difficulty lies entirely in the bipartite case, where the Zarankiewicz problem (Kővári-Sós-Turán 1954) gives $\\mathrm{ex}(n; K_{s,t}) = O(n^{2-1/s})$ but precise asymptotics are often unknown. The problem connects to Simonovits's broader program of understanding when extremal functions for families are 'simple' — determined by a single member rather than requiring the full family structure.",
     "problemStatement": "For a finite family $\\mathcal{F}$ of graphs, let $\\mathrm{ex}(n; \\mathcal{F})$ be the maximum edges in an $n$-vertex $\\mathcal{F}$-free graph. Does there always exist $G \\in \\mathcal{F}$ such that $\\mathrm{ex}(n; G) = O(\\mathrm{ex}(n; \\mathcal{F}))$? **OPEN.**",
     "text": "For a finite family F of graphs, does there exist G in F such that ex(n;G) = O(ex(n;F))? Yes for non-bipartite families by Erdős-Stone. Folklore counterexample for infinite families. OPEN.",
-    "proofStrategy": "The formalization abstracts the problem to functions $\\mathbb{N} \\to \\mathbb{N}$ (`ExFamily`, `ExSingle`) rather than encoding concrete graph structures. `HasDomination` captures the Big-$O$ relationship via an explicit constant $C > 0$. The non-bipartite case is axiomatized via Erdős-Stone, and the folklore counterexample for infinite families uses `List` (unbounded) rather than `Finset` (finite) to demonstrate that finiteness is essential. The summary theorem `erdos_180_summary` proves both results as a conjunction in a single line.",
+    "proofStrategy": "The formalization abstracts the problem to functions $\\mathbb{N} \\to \\mathbb{N}$ (`ExFamily`, `ExSingle`) rather than encoding concrete graph structures. `HasDomination` captures the Big-$O$ relationship via an explicit constant $C > 0$. The non-bipartite case is axiomatized via Erdős-Stone — but note that the `erdos_stone_domination` axiom is stated *unconditionally* (domination for every nonempty family, with no bipartite hypothesis), so as formalized it assumes more than the non-bipartite case alone and in fact subsumes the open conjecture itself. The folklore counterexample for infinite families uses `List` (unbounded) rather than `Finset` (finite) to demonstrate that finiteness is essential. The summary theorem `erdos_180_summary` proves both results as a conjunction in a single line.",
     "keyInsights": [
       "The domination property asks if a single forbidden graph controls the family's extremal function",
       "Non-bipartite case resolved by Erdős-Stone: chromatic number determines asymptotics up to o(n²)",
@@ -132,7 +132,7 @@
       "title": "Non-Bipartite Case (Erdős-Stone)",
       "startLine": 64,
       "endLine": 75,
-      "summary": "Domination holds for non-bipartite families"
+      "summary": "erdos_stone_domination: domination axiomatized unconditionally for every nonempty family (motivated by Erdős-Stone for the non-bipartite case; stated with no bipartite restriction)"
     },
     {
       "id": "bipartite",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-180 (Turán Numbers for Graph Families)

**Result:** issues-fixed (axiom masking, MEDIUM). Counts/status all already exact.

### Verified exact
- 116 lines, 3 axioms, 1 theorem, 6 defs, 0 sorries, 0 native_decide, 0 True-stubs — all match meta.
- `status: axiomatized` / `badge: axiom` / `erdosProblemStatus: open` — correct (Tier C; headline `erdos_180_summary` derives from axioms).
- All 9 originalContributions map to real decls; all 7 section line-ranges align.

### Issue found
The `erdos_stone_domination` axiom (`Erdos180Problem.lean:71-74`) is stated **unconditionally**:

```lean
axiom erdos_stone_domination :
  ∀ (familyEx : ExFamily) (memberExs : Finset ExSingle),
    memberExs.Nonempty → HasDomination familyEx memberExs
```

There is **no** bipartite hypothesis, and not even the `∀ n, familyEx n ≤ inf' id n` hypothesis that `ErdosConjecture180` carries. As written it is **strictly stronger than the open conjecture** — it asserts domination for *every* nonempty family. The summary theorem's first conjunct is exactly this unconditional statement.

Yet the public prose described it as merely **"non-bipartite families have domination"** (a known Erdős-Stone result), in `originalContributions[4]`, `proofStrategy`, and `sections[erdos-stone].summary`. This is reverse axiom-masking: a sweeping assumption (the whole open problem, unconditionally) dressed up as a narrow known theorem.

### Fix
meta.json prose only — characterize the axiom accurately as unconditional and note it subsumes the open conjecture as stated. No Lean source change; counts/status/badge unchanged.

---
Discovered during gallery integrity audit.