### PR TITLE
audit(erdos-124): realign stale section line ranges

### DIFF
--- a/src/data/proofs/erdos-124-complete-sequences/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences/meta.json
@@ -84,54 +84,54 @@
       "id": "algebraic-inequality",
       "title": "Algebraic Gap Lemma",
       "startLine": 62,
-      "endLine": 72,
+      "endLine": 98,
       "summary": "Key inequality derived from the reciprocal sum condition.",
       "mathContext": "Bound: Key inequality derived from the reciprocal sum condition."
     },
     {
       "id": "browns-criterion",
       "title": "Brown's Criterion",
-      "startLine": 73,
-      "endLine": 110,
+      "startLine": 100,
+      "endLine": 128,
       "summary": "The central insight: sequences with small gaps allow all integers as subset sums.",
       "mathContext": "Mathematical content: The central insight: sequences with small gaps allow all integers as subset sums."
     },
     {
       "id": "sequence-construction",
       "title": "Greedy Sequence Construction",
-      "startLine": 111,
-      "endLine": 137,
+      "startLine": 130,
+      "endLine": 154,
       "summary": "Definitions of min_index, next_e, e_seq, and u_seq for the greedy algorithm.",
       "mathContext": "Formal definition: Definitions of min_index, next_e, e_seq, and u_seq for the greedy algorithm."
     },
     {
       "id": "sequence-properties",
       "title": "Sequence Properties",
-      "startLine": 138,
-      "endLine": 171,
+      "startLine": 156,
+      "endLine": 350,
       "summary": "Proofs that u_seq is monotone and has bounded gaps.",
       "mathContext": "Verified: Proofs that u_seq is monotone and has bounded gaps."
     },
     {
       "id": "digit-decomposition",
       "title": "Digit Decomposition",
-      "startLine": 172,
-      "endLine": 188,
+      "startLine": 352,
+      "endLine": 406,
       "summary": "Converting subset sums back to 0/1 digit representations in each base.",
       "mathContext": "Mathematical content: Converting subset sums back to 0/1 digit representations in each base."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
-      "startLine": 189,
-      "endLine": 231,
+      "startLine": 408,
+      "endLine": 456,
       "summary": "The complete proof combining all components.",
       "mathContext": "Verified: The complete proof combining all components."
     },
     {
       "id": "formal-conjectures",
       "title": "Formal Conjectures Compatibility",
-      "startLine": 232,
+      "startLine": 458,
       "endLine": 507,
       "summary": "Versions matching Google DeepMind's Formal Conjectures project statements.",
       "mathContext": "Mathematical content: Versions matching Google DeepMind's Formal Conjectures project statements."


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-124-complete-sequences

**Result:** clean on all counts and claims; one navigation fix.

### Verified accurate (no changes)
- **Counts**: 0 axioms, 0 sorries, 0 True stubs, 18 theorems/lemmas, 6 defs, 507 lines — all match meta.json.
- **No masking**: main theorem `erdos_conjecture_true` (L415) is genuinely proven in-file via `browns_criterion`, `u_seq_monotone`, `u_seq_gap`, `digits_of_subset_sum_u_seq` — all real in-file proofs built on basic Mathlib infrastructure (`Nat.digits`/`Nat.ofDigits`, `Finset`, `geom_sum`). Not a deep-theorem wrapper.
- The two `… ↔ true` formal-conjecture theorems do prove their content (`simp only [iff_true]` then a full proof).
- `verified`/`mathlib` status is defensible: machine-checked with 0 assumptions; `mathlib` badge conservatively signals Mathlib infra reliance. Left unchanged.

### Fixed — section line ranges had drifted ~200 lines
The `sections` block pointed at stale line numbers (file grew/rearranged since they were authored):

| Section | Was | Now (grep-verified) |
|---------|-----|---------------------|
| algebraic-inequality | 62–72 | 62–98 |
| browns-criterion | 73–110 | 100–128 |
| sequence-construction | 111–137 | 130–154 |
| sequence-properties | 138–171 | 156–350 |
| digit-decomposition | 172–188 | 352–406 |
| main-theorem | 189–231 | 408–456 |
| formal-conjectures | 232–507 | 458–507 |

`historical-context` (3–48) was already correct. meta.json-only change; no Lean edits.

---
Discovered during gallery integrity audit.