### PR TITLE
research(erdos-998-oq-04): S8 — backend re-probe + verify three-gap witnesses sound

### DIFF
--- a/research/problems/erdos-998-oq-04/knowledge.md
+++ b/research/problems/erdos-998-oq-04/knowledge.md
@@ -325,3 +325,25 @@ This is a documentation/decomposition session, NOT a proving session — both ba
 1. Land STEPS A–C as named sorry-free lemmas (manual or per-lemma Aristotle `prove`), then submit STEP D / the whole file to Aristotle `prove_file`.
 2. `docker-build Proofs.Erdos998ThreeGapOQ04` (when ≤8 containers) to re-verify after each lemma lands.
 3. Once `exists_gap_triple` is sorry-free: flip status to `verified` (0 axioms) and add a gallery entry.
+
+---
+
+## S8 (researcher-1, 2026-06-18 11:08) — backend still down; witnesses verified sound
+
+- **Re-probe**: Aristotle MCP `prove_file` on `Erdos998ThreeGapOQ04.lean` →
+  `{"status":"error","message":"Resource not found."}` (404) — STILL down, same as
+  S4/S5/S6. Docker OOM-unsafe (load ~14, 11 `lean-build-*` containers on a 7.65 GiB
+  VM). No build attempted, no Lean shipped — protecting the registered CI file.
+- **NEW datum (statement-soundness check, de-risks next Aristotle run)**: hand-verified
+  the `refine ⟨a, b, _, rfl, ?_⟩` witnesses at line ~290 are the CORRECT three-gap
+  values, so a future `prove_file` targets a true goal (no wasted solver budget on a
+  mis-stated lemma):
+  - `a = min_{1≤i<N} {iα}` = the classical short gap `{pα}` (`p` = the minimizer).
+  - `b = min_{1≤i<N} {−iα} = min_{1≤i<N} (1 − {iα}) = 1 − max_{1≤i<N} {iα}` = the
+    classical short gap `1 − {qα}` (`q` = the maximizer of `{iα}`, i.e. `{qα}` nearest 1).
+  - `c = a + b` (`rfl`) = the long gap `{pα} + (1 − {qα})`. Matches Sós/van Ravenstein.
+  So `a + b = c` holds by construction and the `⊆ {a,b,c}` goal (STEP D) is the *only*
+  remaining content — statement confirmed correct, not subtly wrong.
+- **Status**: unchanged frontier — 1 `sorry` (STEP D, N≥2 classification), 0 axioms,
+  build-verified at HEAD. BLOCKED on backend availability (Aristotle is the right tool
+  for this known-math crux). Moving on per the 3+-sessions-stuck rule.

--- a/src/data/research/problems/erdos-998-oq-04.json
+++ b/src/data/research/problems/erdos-998-oq-04.json
@@ -30,7 +30,7 @@
     "phase": "ACT",
     "since": "2026-06-18T00:00:00Z",
     "iteration": 6,
-    "focus": "researcher-1, 2026-06-18 (S6): documentation/decomposition session — both backends down (Aristotle MCP prove → 404 'Resource not found'; Docker gated at 15 build containers / ~5.7 GiB of 7.65 GiB VM, OOM-unsafe), so no Lean shipped. Frontier unchanged from S5: 1 sorry = the N≥2 case of exists_gap_triple, build-verified green, registered. Sharpened S5's prose proof-path into an explicit 4-step lemma scaffold (in-file comment lines 138–204): STEP A forwardGap α N P_k = min_{j≠k} Int.fract((j−k)α) via integer-shift invariance of Int.fract; STEP B split index diff on sign → forwardGap = min(F_k,B_k) with forward-return min F_k and backward-return min B_k; STEP C subset-min bounds F_k≥a, B_k≥b and full-range attainment F_0=a, B_{N−1}=b (so a,b are attained gap lengths and forwardGap ≥ min a b); STEP D (sole hard, known-not-open crux) with p,q the least minimizers of a,b show min(F_k,B_k) ∈ {a,b,a+b}. STEPS A–C are routine/provable; STEP D is the genuine van Ravenstein content. Comments-only edit — sorry count unchanged (1), file stays build-verified.",
+    "focus": "researcher-1, 2026-06-18 (S8): Aristotle MCP re-probed → still 404 'Resource not found'; Docker OOM-unsafe (load ~14, 11 containers). No Lean shipped (protect registered CI). NEW: hand-verified the line-290 witnesses a=min{iα}, b=min{-iα}=1-max{iα}, c=a+b are exactly the classical short/short/long three-gap values {pα},1-{qα},{pα}+(1-{qα}) — so the future Aristotle prove_file targets a CORRECT goal (no wasted budget). Frontier unchanged: 1 sorry (STEP D, N>=2 classification), 0 axioms, build-verified. BLOCKED on backend; moving on per 3+-sessions-stuck rule.",
     "blockers": [
       "Aristotle MCP returns 404 'Resource not found' (S4/S5/S6) — the right tool for this KNOWN-math sorry is offline.",
       "Docker gated this cycle: 15 lean-build containers, ~5.7 GiB of a 7.65 GiB VM — a new build is OOM-unsafe (defer if >8 containers / >5 GiB). Cannot verify any manual Lean changes, so none were shipped.",
@@ -130,7 +130,7 @@
     ]
   },
   "started": "2026-06-15T00:00:00Z",
-  "lastUpdate": "2026-06-18",
+  "lastUpdate": "2026-06-18T11:08:00-08:00",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Documentation/continuity session on the Three-Gap (Steinhaus) theorem (`erdos-998-oq-04`). **No Lean changed** — the registered, build-verified `Erdos998ThreeGapOQ04.lean` is left untouched.

### Why no Lean
- **Aristotle MCP still down**: `prove_file` → `{"status":"error","message":"Resource not found."}` (404), same as S4/S5/S6. It's the right tool for this known-math `sorry`.
- **Docker OOM-unsafe**: load ~14, 11 `lean-build-*` containers on a 7.65 GiB VM. A 7743-job Mathlib build risks crashing the host (per CLAUDE.md), so none attempted.

### New this session (de-risks the next Aristotle run)
Hand-verified the `refine ⟨a, b, _, rfl, ?_⟩` witnesses (line ~290) are the **correct** three-gap values, so a future `prove_file` targets a true goal rather than a subtly mis-stated one:

| witness | value | classical gap |
|---|---|---|
| `a` | `min_{1≤i<N} {iα}` | short `{pα}` |
| `b` | `min_{1≤i<N} {−iα} = 1 − max{iα}` | short `1−{qα}` |
| `c` | `a + b` (`rfl`) | long `{pα}+(1−{qα})` |

Matches Sós / van Ravenstein.

### Status
Frontier unchanged: **1 sorry** (STEP D, the N≥2 classification), 0 axioms, build-verified at HEAD. Problem remains **BLOCKED on backend availability**; flagged across sessions 3–8.

Docs-only (knowledge.md + research JSON focus); status stays `in-progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)