### PR TITLE
research(dirichlet-approximation-oq-01): full coprime-pair iff converse

### DIFF
--- a/proofs/Proofs/DirichletApproximationOQ01.lean
+++ b/proofs/Proofs/DirichletApproximationOQ01.lean
@@ -90,6 +90,57 @@ theorem infinite_approx_iff_irrational (ξ : ℝ) :
     {q : ℚ | |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2}.Infinite ↔ Irrational ξ :=
   Real.infinite_rat_abs_sub_lt_one_div_den_sq_iff_irrational ξ
 
+/-- **Full coprime integer-pair characterization (converse of
+`infinite_coprime_approx`).** A real number admits infinitely many coprime good
+approximations `|ξ − p/q| < 1/q²` (with `q > 0`, `gcd(|p|, q) = 1`) *iff* it is
+irrational. This upgrades `infinite_coprime_approx` from a one-way implication to
+the full equivalence, matching Hardy & Wright Thm 193: rationals admit only
+finitely many such pairs.
+
+The converse transports the infinitude back through the map `(p, q) ↦ p/q : ℚ`.
+That map is injective on the coprime set (reduced fractions are unique,
+`Rat.div_int_inj`) and lands in the good-rational-approximation set, because for
+coprime `(p, q)` the reduced denominator of `p/q` is exactly `q`
+(`Rat.den_div_eq_of_coprime`). Infinitude then transports to
+`infinite_approx_iff_irrational`. -/
+theorem infinite_coprime_approx_iff_irrational (ξ : ℝ) :
+    {pq : ℤ × ℕ | 0 < pq.2 ∧ Nat.Coprime pq.1.natAbs pq.2 ∧
+        |ξ - (pq.1 : ℝ) / (pq.2 : ℝ)| < 1 / (pq.2 : ℝ) ^ 2}.Infinite ↔ Irrational ξ := by
+  refine ⟨fun hInf => ?_, infinite_coprime_approx⟩
+  rw [← infinite_approx_iff_irrational ξ]
+  set C := {pq : ℤ × ℕ | 0 < pq.2 ∧ Nat.Coprime pq.1.natAbs pq.2 ∧
+      |ξ - (pq.1 : ℝ) / (pq.2 : ℝ)| < 1 / (pq.2 : ℝ) ^ 2} with hC
+  -- The map `(p, q) ↦ p/q : ℚ` is injective on the coprime set.
+  have hginj : Set.InjOn (fun pq : ℤ × ℕ => (pq.1 : ℚ) / (pq.2 : ℚ)) C := by
+    rintro ⟨a, b⟩ ⟨hb, hcop, -⟩ ⟨c, d⟩ ⟨hd, hcop', -⟩ heq
+    simp only at heq
+    have hb' : (0 : ℤ) < (b : ℤ) := by exact_mod_cast hb
+    have hd' : (0 : ℤ) < (d : ℤ) := by exact_mod_cast hd
+    have h1 : Nat.Coprime a.natAbs (b : ℤ).natAbs := by simpa using hcop
+    have h2 : Nat.Coprime c.natAbs (d : ℤ).natAbs := by simpa using hcop'
+    have heq' : (a : ℚ) / ((b : ℤ) : ℚ) = (c : ℚ) / ((d : ℤ) : ℚ) := by
+      push_cast; exact heq
+    obtain ⟨hac, hbd⟩ := Rat.div_int_inj hb' hd' h1 h2 heq'
+    have hbd' : b = d := by exact_mod_cast hbd
+    simp [hac, hbd']
+  -- Its image lands in the good-rational-approximation set.
+  have hsub : (fun pq : ℤ × ℕ => (pq.1 : ℚ) / (pq.2 : ℚ)) '' C ⊆
+      {q : ℚ | |ξ - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2} := by
+    rintro _ ⟨⟨a, b⟩, ⟨hb, hcop, happ⟩, rfl⟩
+    have hb' : (0 : ℤ) < (b : ℤ) := by exact_mod_cast hb
+    have h1 : Nat.Coprime a.natAbs (b : ℤ).natAbs := by simpa using hcop
+    -- The reduced denominator of `p/q` is exactly `q`.
+    have hden : ((a : ℚ) / (b : ℚ)).den = b := by
+      have h := Rat.den_div_eq_of_coprime hb' h1
+      push_cast at h
+      exact_mod_cast h
+    show |ξ - (((a : ℚ) / (b : ℚ) : ℚ) : ℝ)| < 1 / (((a : ℚ) / (b : ℚ)).den : ℝ) ^ 2
+    rw [hden]
+    have hcast : (((a : ℚ) / (b : ℚ) : ℚ) : ℝ) = (a : ℝ) / (b : ℝ) := by push_cast; ring
+    rw [hcast]
+    exact happ
+  exact ((infinite_image_iff hginj).mpr hInf).mono hsub
+
 /-- **Existence corollary.** Every irrational has at least one good rational
 approximation `|ξ − q| < 1/q.den²` (the one-shot Dirichlet bound, recovered as a
 consequence of infinitude). -/

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01/meta.json
@@ -62,10 +62,10 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 178,
+    "lineCount": 229,
     "assumptions": "0 axioms, 0 sorries. The sole hypothesis is Irrational ξ, which the converse (infinite_approx_iff_irrational) shows is exactly necessary and sufficient. The headline infinitude and the converse delegate to Mathlib's DiophantineApproximation development; the coprime-pair reformulation, the InjOn argument, the existence corollary, the image-subset computation, the bounded-denominator finiteness lemma (finite_bounded_den), and the unbounded-denominator strengthening (infinite_good_approx_large_den) are proved in-file. Badge is 'mathlib' because the core infinitude result is a Mathlib theorem; the strengthening to unbounded denominators is original in-file content built only on elementary Mathlib finiteness facts.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -120,24 +120,32 @@
       "summary": "`infinite_approx_iff_irrational`: delegation to Mathlib's iff, exhibiting that Irrational ξ is exactly the necessary-and-sufficient hypothesis (rationals admit only finitely many good approximations)."
     },
     {
+      "id": "coprime-iff",
+      "title": "Full Coprime-Pair Characterization: Iff Converse",
+      "startLine": 93,
+      "endLine": 142,
+      "mathContext": "$\\{(p,q)\\in\\mathbb{Z}\\times\\mathbb{N} : q>0,\\ \\gcd(|p|,q)=1,\\ |\\xi-p/q|<1/q^2\\}$ is infinite $\\iff$ $\\xi$ irrational.",
+      "summary": "`infinite_coprime_approx_iff_irrational`: upgrades the one-way `infinite_coprime_approx` to the full equivalence (Hardy & Wright Thm 193). The converse transports infinitude of the coprime integer-pair set back to Mathlib's rational form along (p,q) ↦ p/q, which is injective on the coprime set (`Rat.div_int_inj`) and preserves the reduced denominator q = p/q.den (`Rat.den_div_eq_of_coprime`)."
+    },
+    {
       "id": "existence-corollary",
       "title": "Existence Corollary",
-      "startLine": 93,
-      "endLine": 99,
+      "startLine": 144,
+      "endLine": 150,
       "mathContext": "Every irrational has at least one good approximation $|\\xi - q| < 1/q.\\mathrm{den}^2$.",
       "summary": "`exists_good_approx`: the one-shot existence statement recovered from infinitude via Set.Infinite.nonempty."
     },
     {
       "id": "unbounded-denominators",
       "title": "Strengthening: Unbounded Denominators",
-      "startLine": 101,
-      "endLine": 178,
+      "startLine": 152,
+      "endLine": 229,
       "mathContext": "For every irrational $\\xi$ and every $N$, infinitely many good approximations satisfy $q.\\mathrm{den} \\ge N$; equivalently the convergent denominators are unbounded.",
       "summary": "`finite_bounded_den`: rationals in a bounded real interval [a,b] with denominator ≤ N form a finite set, proved by embedding q ↦ (q.num, q.den) into the finite integer box Finset.Icc(-M,M) ×ˢ Finset.Icc 1 N with M ≥ max|a||b|·N (numerator bound |q.num| = |q|·q.den ≤ max|a||b|·N), and injectivity via Rat.num_div_den. `infinite_good_approx_large_den`: the full good-approximation set is infinite while its low-denominator part {q.den < N} is finite — each such q has |ξ − q| < 1/q.den² ≤ 1 so lies in [ξ−1, ξ+1] with den ≤ N, a finite_bounded_den set — and an infinite set minus a finite set is infinite. `exists_good_approx_large_den`: the existence corollary. Answers the entry's first open question and shows the denominators of good approximations are genuinely unbounded, strictly stronger than bare infinitude."
     }
   ],
   "conclusion": {
-    "summary": "The parent's one-shot Dirichlet bound is upgraded to the infinitude statement: for every irrational ξ there are infinitely many fractions in lowest terms with |ξ − p/q| < 1/q². The infinitude and its sharp converse delegate to Mathlib's DiophantineApproximation development; the original work is the bridge from Mathlib's set-of-rationals form to the classical coprime integer-pair statement (transporting infinitude along the injective map q ↦ (q.num, q.den)) and a strengthening to unbounded denominators: for every N infinitely many good approximations have q.den ≥ N, via a self-contained finiteness lemma (finite_bounded_den) for rationals of bounded height in a bounded real interval. Zero sorries, zero axioms.",
+    "summary": "The parent's one-shot Dirichlet bound is upgraded to the infinitude statement: for every irrational ξ there are infinitely many fractions in lowest terms with |ξ − p/q| < 1/q². The infinitude and its sharp converse delegate to Mathlib's DiophantineApproximation development; the original work is (i) the bridge from Mathlib's set-of-rationals form to the classical coprime integer-pair statement (transporting infinitude along the injective map q ↦ (q.num, q.den)), (ii) the full coprime-pair iff converse infinite_coprime_approx_iff_irrational, which upgrades the one-way coprime reformulation to an equivalence by transporting infinitude back along (p,q) ↦ p/q (injective on the coprime set via Rat.div_int_inj, denominator-preserving via Rat.den_div_eq_of_coprime), and (iii) a strengthening to unbounded denominators: for every N infinitely many good approximations have q.den ≥ N, via a self-contained finiteness lemma (finite_bounded_den) for rationals of bounded height in a bounded real interval. Zero sorries, zero axioms.",
     "implications": "Re-expressing the infinitude in the (p,q)-coprime form is the version used downstream: it is the launching point for continued fractions, Hurwitz's sharp constant 1/(√5 q²), and Liouville's transcendence criterion. The unbounded-denominators strengthening makes explicit that there is no finite stage past which good approximations stop — the convergent denominators tend to infinity — which is the qualitative input to continued-fraction convergence. The converse direction pins down that good rational approximability of exponent 2 characterizes irrationality exactly.",
     "openQuestions": [
       "Can the constant be improved in Lean to Hurwitz's 1/(√5 q²), and is the √5 shown to be optimal via the golden ratio?",
@@ -171,11 +179,11 @@
       "Set"
     ],
     "namespace": "DirichletApproximationOQ01",
-    "lineCount": 178,
+    "lineCount": 229,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 7
+    "theoremCount": 8
   },
   "sorries": 0
 }

--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-01.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-01.json
@@ -28,24 +28,25 @@
       "The infinitude statement is ALREADY in Mathlib: Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational (and the iff version _iff_irrational) in Mathlib.NumberTheory.DiophantineApproximation.Basic. The research value is therefore presentational: re-expressing the set-of-rationals form as the classical coprime integer-pair statement.",
       "The bridge is a transport along the injection q ↦ (q.num, q.den): rationals are stored in lowest terms (Rat.reduced gives gcd(|num|,den)=1) with positive denominator (Rat.pos), and (q.num:ℝ)/(q.den:ℝ) = (q:ℝ) (Rat.cast_def), so the image pair has IDENTICAL error and bound — no analytic estimate is repeated.",
       "Infinitude transports cleanly: Set.infinite_image_iff (InjOn ⇒ image infinite iff domain infinite) + Set.Infinite.mono (subset preserves infinitude) reduce the whole bridge to structural ℚ facts.",
-      "The hypothesis is sharp: Mathlib's iff shows a real admits infinitely many good approximations exactly when irrational (rationals have finitely many, finite_rat_abs_sub_lt_one_div_den_sq), so Irrational α is necessary and sufficient, not just convenient."
+      "The hypothesis is sharp: Mathlib's iff shows a real admits infinitely many good approximations exactly when irrational (rationals have finitely many, finite_rat_abs_sub_lt_one_div_den_sq), so Irrational α is necessary and sufficient, not just convenient.",
+      "The coprime integer-pair infinitude is FULLY equivalent to irrationality (not merely implied by it): the converse follows from the rational-form iff (Mathlib) by transporting along the injective, denominator-preserving embedding (p,q)↦p/q. Key Mathlib bearers: Rat.div_int_inj (reduced-fraction uniqueness) and Rat.den_div_eq_of_coprime (reduced denominator of a coprime ratio)."
     ],
     "builtItems": [
       "infinite_good_rat_approx (DirichletApproximationOQ01.lean:49) — headline infinitude, Mathlib delegation",
       "infinite_coprime_approx (DirichletApproximationOQ01.lean:61) — ORIGINAL: classical coprime (p,q) form via num/den injection",
       "infinite_approx_iff_irrational (DirichletApproximationOQ01.lean:89) — sharp converse, Mathlib iff",
-      "exists_good_approx (DirichletApproximationOQ01.lean:96) — one-shot existence corollary from infinitude"
+      "exists_good_approx (DirichletApproximationOQ01.lean:96) — one-shot existence corollary from infinitude",
+      "infinite_coprime_approx_iff_irrational in Proofs/DirichletApproximationOQ01.lean: full iff converse upgrading the one-way infinite_coprime_approx (Hardy & Wright Thm 193). Transports infinitude of the coprime integer-pair set back to Mathlibs rational form via (p,q)↦p/q, injective on coprimes (Rat.div_int_inj), denominator-preserving (Rat.den_div_eq_of_coprime)."
     ],
     "mathlibGaps": [
       "No Mathlib lemma for finiteness of rationals with bounded denominator inside a bounded interval (would enable the 'unbounded denominators' strengthening). Mathlib's finite_rat_abs_sub_lt_one_div_den_sq is for RATIONAL targets only (uses ξ.den) and does not apply to irrational ξ; a bespoke num/den-injection finiteness argument (~25-30 lines, real→int cast bounds) would be required.",
       "No classical coprime-integer-pair form of the infinitude theorem in Mathlib — only the set-of-rationals form. This file supplies that reformulation."
     ],
     "nextSteps": [
-      "Confirm CI green on PR #25627 (local Docker was saturated; single-module verification build queued in background).",
-      "Strengthening (potential follow-up OQ): infinitely many approximations with UNBOUNDED denominators (∀ N, ∃ good q with q.den ≥ N), via proving the bounded-denominator subset finite — a HARD-but-known finiteness lemma well-suited to Aristotle.",
-      "Further follow-up: Hurwitz's sharp constant 1/(√5 q²) and its optimality (golden ratio) — substantially harder, likely its own entry."
+      "Extend the coprime-pair iff to simultaneous approximation (one denominator for several reals).",
+      "Quantitative refinement: lower bound on number of coprime good approximations with denominator in [N,2N]."
     ],
-    "progressSummary": "PROGRESS: infinitude upgrade formalized (PR #25627). Original contribution = classical coprime-pair reformulation; 0 sorry / 0 axiom. Awaiting CI build confirmation."
+    "progressSummary": "COMPLETE: full coprime-pair iff converse infinite_coprime_approx_iff_irrational added (8 theorems, 0 sorry, 0 axiom). Upgrades the one-way coprime reformulation to an equivalence."
   },
   "approaches": [
     {


### PR DESCRIPTION
## Summary

Adds `infinite_coprime_approx_iff_irrational` to `Proofs/DirichletApproximationOQ01.lean`, upgrading the existing one-way `infinite_coprime_approx` to a **full equivalence** (Hardy & Wright Thm 193):

> A real number $\xi$ admits infinitely many coprime good approximations $|\xi - p/q| < 1/q^2$ (with $q>0$, $\gcd(|p|,q)=1$) **iff** $\xi$ is irrational.

## Proof

The forward direction is the pre-existing `infinite_coprime_approx`. The new **converse** transports infinitude of the coprime integer-pair set back to Mathlib's rational-form characterization (`infinite_approx_iff_irrational`) along the map $(p,q) \mapsto p/q : \mathbb{Q}$, which is:
- **injective on the coprime set** — reduced fractions are unique (`Rat.div_int_inj`);
- **denominator-preserving** for coprime pairs — the reduced denominator of $p/q$ is exactly $q$ (`Rat.den_div_eq_of_coprime`).

Infinitude then transports via `infinite_image_iff` and `Set.Infinite.mono`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ01` — **Build succeeded** (7743 jobs)
- 0 sorries, 0 axioms, 8 theorems (was 7)
- meta.json + research knowledge updated (counts, new section, conclusion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)