### PR TITLE
research(friendship-theorem-oq-04): assemble hub/ℵ₀-regular dichotomy (+1 thm)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04.lean
@@ -85,6 +85,16 @@ that has no infinite analogue:
   free-amalgamation counterexample. Finiteness-free throughout; the spectral step the
   finite proof would invoke next has no infinite analogue.
 
+* `no_universal_infinite_aleph0_regular` — **the counterexample shape, assembled.** An
+  *infinite* hub-free friendship graph is **ℵ₀-regular**: every neighbourhood is infinite
+  *and* all neighbourhoods are pairwise equinumerous. Combines
+  `infinite_friendship_has_infinite_degree` (some infinite-degree vertex) with
+  `no_universal_regular` (all neighbourhoods equinumerous) to push infiniteness onto
+  *every* vertex. Together with `unique_infinite_degree_vertex` (with a hub: exactly one
+  infinite-degree vertex) this completes the structural dichotomy — a friendship graph is
+  either a windmill with a single hub, or hub-free and ℵ₀-regular — entirely without the
+  spectral argument.
+
 Where the finite proof breaks: the spectral step
 `FriendshipTheorem.friendship_regular_implies_universal` is entirely finite-matrix
 algebra (trace, finite eigenvalue multiplicities, integrality) and has no infinite
@@ -539,5 +549,33 @@ theorem no_universal_regular (hF : IsFriendshipGraph G)
   · obtain ⟨z, hzu, hzv⟩ := no_universal_adjacent_has_common_nonneighbor hF hnouniv hadj
     exact neighborSet_equinum_of_common_nonneighbor hF hzu hzv
   · exact nonadjacent_neighborSet_equinum hF hadj
+
+/-- **Infinite + hub-free ⟹ ℵ₀-regular (the counterexample shape).** An *infinite*
+friendship graph with *no universal vertex* is ℵ₀-regular: **every** neighbourhood is
+infinite, and all neighbourhoods are pairwise equinumerous (`Set.BijOn`). This is the
+precise structural shape of the C₅ free-amalgamation counterexample described in the
+file header ("every vertex there has infinite degree"), assembled here as a single
+theorem. The proof combines the two existing pillars: `no_universal_regular` (hub-free
+⟹ regular) supplies, for any vertex `w`, a `Set.BijOn` from the neighbourhood of some
+infinite-degree vertex `w₀` (furnished by `infinite_friendship_has_infinite_degree`)
+onto `N(w)`; the injective image of an infinite set is infinite and sits inside `N(w)`,
+forcing `N(w)` infinite too. Contrast `unique_infinite_degree_vertex`: *with* a hub
+exactly one vertex is infinite-degree, *without* a hub every vertex is. The dichotomy
+"a friendship graph is either a (possibly infinite) windmill with a single hub, or
+hub-free and ℵ₀-regular" is thus complete on the structural (non-spectral) side. No
+`[Fintype V]` is used; finiteness enters only through the ambient `[Infinite V]`. -/
+theorem no_universal_infinite_aleph0_regular (hF : IsFriendshipGraph G) [Infinite V]
+    (hnouniv : ∀ c : V, ¬ FriendshipTheorem.IsUniversalVertex G c) :
+    (∀ w : V, (G.neighborSet w).Infinite) ∧
+      ∀ u v : V, ∃ f : V → V, Set.BijOn f (G.neighborSet u) (G.neighborSet v) := by
+  refine ⟨fun w => ?_, no_universal_regular hF hnouniv⟩
+  obtain ⟨w₀, hw₀⟩ := infinite_friendship_has_infinite_degree hF
+  obtain ⟨f, hf⟩ := no_universal_regular hF hnouniv w₀ w
+  -- `f` maps `N(w₀)` into `N(w)`, injectively; the image is infinite and `⊆ N(w)`.
+  have hsub : f '' (G.neighborSet w₀) ⊆ G.neighborSet w := Set.mapsTo'.mp hf.mapsTo
+  have himg : (f '' (G.neighborSet w₀)).Infinite :=
+    fun hfin => hw₀ (Set.Finite.of_finite_image hfin hf.injOn)
+  intro hwfin
+  exact himg (hwfin.subset hsub)
 
 end FriendshipTheoremOQ04

--- a/research/problems/friendship-theorem-oq-04/state.md
+++ b/research/problems/friendship-theorem-oq-04/state.md
@@ -52,6 +52,16 @@ Done so far:
   pair — adjacent or not — has a `Set.BijOn` between neighbourhoods, the exact
   ℵ₀-regular shape of the C₅ counterexample). Finiteness-free; 0 sorry / 0 axiom.
   Deployer-gated build.
+- **NEW (researcher-11, S13) — DICHOTOMY ASSEMBLED:**
+  `no_universal_infinite_aleph0_regular` — an *infinite* hub-free friendship graph is
+  **ℵ₀-regular**: every neighbourhood is infinite AND all pairwise equinumerous
+  (`Set.BijOn`). Combines `infinite_friendship_has_infinite_degree` (∃ infinite-degree
+  vertex) with `no_universal_regular` (all equinumerous) to push infiniteness onto every
+  vertex (injective-image-of-infinite argument). Together with
+  `unique_infinite_degree_vertex` this completes the structural (non-spectral) dichotomy:
+  a friendship graph is either a windmill with a single infinite-degree hub, or hub-free
+  and ℵ₀-regular. 0 sorry / 0 axiom; finiteness-free apart from ambient `[Infinite V]`.
+  Build-free (Docker blackout: 32 builds, load ~15), deployer-gated.
 
 ## Attempt Count
 - Total attempts: 8

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (structural): positive half + finiteness-free negative-half framing done through hub-free⟹regular; only explicit colimit counterexample construction remains open.",
+    "progressSummary": "COMPLETE (structural): positive half + negative-half framing assembled into the hub/ℵ₀-regular dichotomy through no_universal_infinite_aleph0_regular; only the explicit C₅ colimit counterexample construction remains open.",
     "builtItems": [
       "research/problems/friendship-theorem-oq-04/verify_infinite_friendship.py: certifies linear-invariant preservation across 4 amalgamation rounds (|V| up to 3695, max common-nbrs stays 1), no universal vertex, degree blow-up [4,5,13,83], diameter-2 covering on W_1..W_8, and covering bound |V|<=1+deg(v)+sum deg(x) on W_1..W_13.",
       "proofs/Proofs/FriendshipTheoremOQ04.lean: ACT formalization (build-pending, unregistered under dual blackout). Fintype-free IsFriendshipGraph + 6 theorems.",
@@ -44,7 +44,8 @@
       "edge_unique_triangle (FriendshipTheoremOQ04.lean): unique triangle per edge / N(u) perfect matching, one-line corollary via huv.ne",
       "no_universal_regular (FriendshipTheoremOQ04.lean:535): hub-free friendship graph is regular — Set.BijOn between every pair of neighbourhoods, unconditional & finiteness-free",
       "adjacent_dominating_implies_universal (FriendshipTheoremOQ04.lean:478): a dominating adjacent pair forces a universal vertex (two common_neighbor_unique.unique contradictions)",
-      "no_universal_adjacent_has_common_nonneighbor (FriendshipTheoremOQ04.lean:510): contrapositive — hub-free edge always has a common non-neighbour"
+      "no_universal_adjacent_has_common_nonneighbor (FriendshipTheoremOQ04.lean:510): contrapositive — hub-free edge always has a common non-neighbour",
+      "no_universal_infinite_aleph0_regular (FriendshipTheoremOQ04.lean) — infinite + hub-free ⟹ ℵ₀-regular: every neighbourhood infinite AND all pairwise equinumerous; assembles infinite_friendship_has_infinite_degree + no_universal_regular. 0 sorry/0 axiom."
     ],
     "insights": [
       "Theorem FAILS for infinite graphs: C5 free-amalgamation (Chvatal-Kotzig-Rosenberg-Davies 1976) yields a countable friendship graph with no universal vertex; all vertices have infinite degree.",
@@ -58,7 +59,8 @@
       "The finite friendship_noncentral_degree (G.degree u = 2) is Fintype-bound; the underlying set equality N(u)={c,w} needs no finiteness and holds on infinite friendship graphs with a universal vertex — the recovered graph is a genuine (infinite) windmill",
       "Adjacent-pair regularity is finiteness-free GIVEN a common non-neighbour: route N(u)≃N(z)≃N(v) through z adjacent to neither (Set.BijOn.comp). This bridges the gap nonadjacent_neighborSet_equinum leaves (it needs u,v themselves non-adjacent). The only remaining open ingredient for full ℵ₀-regularity of a hub-free friendship graph is the EXISTENCE of a common non-neighbour for an adjacent pair — established by counting in the finite proof, genuinely open on the infinite side.",
       "edge_unique_triangle: every edge of a friendship graph lies in a UNIQUE triangle, equivalently N(u) induces a perfect matching — the LOCAL windmill structure, holds unconditionally (no universal vertex, no finiteness), so it survives in the hub-free C5 counterexample",
-      "Bridge closed: conditional regularity engine (common non-neighbour required) upgraded to unconditional hub-free⟹regular by proving hub-free edges always admit a common non-neighbour; the adjacent case was the missing half nonadjacent_neighborSet_equinum could not reach."
+      "Bridge closed: conditional regularity engine (common non-neighbour required) upgraded to unconditional hub-free⟹regular by proving hub-free edges always admit a common non-neighbour; the adjacent case was the missing half nonadjacent_neighborSet_equinum could not reach.",
+      "Structural dichotomy now complete (non-spectral side): a friendship graph is either a windmill with a single infinite-degree hub (unique_infinite_degree_vertex) or hub-free and ℵ₀-regular (no_universal_infinite_aleph0_regular)."
     ],
     "mathlibGaps": [
       "No infinite/analytic spectral analogue: ERS spectral step needs finite adjacency matrix trace + finite eigenvalue multiplicities (Mathlib adjMatrix trace is Fintype-bound). Infinite side must avoid it entirely (use diameter-2 covering instead)."


### PR DESCRIPTION
## Summary

Adds **`no_universal_infinite_aleph0_regular`** to `proofs/Proofs/FriendshipTheoremOQ04.lean`: an *infinite* friendship graph with *no universal vertex* is **ℵ₀-regular** — every neighbourhood is infinite **and** all neighbourhoods are pairwise equinumerous (`Set.BijOn`).

This assembles the two existing structural pillars into the precise shape of the C₅ free-amalgamation counterexample described in the file header:

- `infinite_friendship_has_infinite_degree` → *some* vertex `w₀` has infinite degree;
- `no_universal_regular` → a `Set.BijOn N(w₀) → N(w)` for every `w`;
- injective image of an infinite set is infinite and sits inside `N(w)` ⟹ **every** `N(w)` is infinite.

Together with `unique_infinite_degree_vertex` (with a hub: *exactly one* infinite-degree vertex) this completes the structural, **non-spectral** dichotomy:

> A friendship graph is either a windmill with a single infinite-degree hub, or hub-free and ℵ₀-regular.

## Status
- **+1 theorem**, 0 sorry / 0 axiom. Finiteness-free apart from the ambient `[Infinite V]`.
- Proof uses only stable Mathlib lemmas (`Set.mapsTo'`, `Set.BijOn.{mapsTo,injOn}`, `Set.Finite.of_finite_image`, `Set.Finite.subset`).
- Build-free locally (Docker blackout: ~32 concurrent builds, load ~15); **deployer-gated** — deployer builds before merge.
- Aristotle unavailable (404) this cycle.

## Remaining open
The explicit C₅ free-amalgamation colimit *construction* (a multi-session existence build) is the sole remaining gap; the structural characterization side is now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)