### PR TITLE
research(fermat-defect-one-oq-04): mark COMPLETED (merged in #25861, integrated into parent)

### DIFF
--- a/src/data/research/problems/fermat-defect-one-oq-04.json
+++ b/src/data/research/problems/fermat-defect-one-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "fermat-defect-one-oq-04",
   "title": "Fermat Defect-One: a verified no-small-witness lower bound on M(n) for n ≥ 4",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "tags": [],
@@ -15,7 +15,7 @@
     "mathlib": []
   },
   "started": "2026-06-18T00:00:00.000Z",
-  "lastUpdate": "2026-06-18T00:00:00.000Z",
+  "lastUpdate": "2026-06-18T18:50:00.000Z",
   "significance": 5,
   "tractability": 8,
   "problemStatement": {
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "DONE (build-pending): proved a no-small-witness lower bound on the minimal Fermat defect M(n) for n in {4,5,6}. For each such n, NO triple 2 <= a <= b < c <= 100 satisfies a^n+b^n+1=c^n or a^n+b^n=c^n+1 (both signs), so M(n) >= 2 inside the box. Discharged by native_decide over a fully bounded Nat enumeration (Nat.decidableBallLT). Stated WITHOUT a gcd hypothesis (strictly stronger) since defect one forces primitivity: d=gcd(a,b,c) => d^n | 1 => d=1. Contrast n=3, where the same box contains the witness (6,8,9). New file Proofs/FermatDefectOneOQ04.lean, 0 sorries, no literal axiom declarations; native_decide introduces Lean.ofReduceBool.",
+    "progressSummary": "COMPLETED & MERGED (PR #25861): no-small-witness lower bound M(n) >= 2 in the box c <= 100 for n in {4,5,6}, both signs, via native_decide over a bounded Nat.decidableBallLT enumeration. Stated without a gcd hypothesis (defect one forces primitivity: d=gcd(a,b,c) => d^n | 1 => d=1), specialized to the parent FermatDefectWitness predicate (no_small_witness_4/5/6), with defect_one_three_in_box exhibiting (6,8,9) at n=3 to show the n>=4 vanishing is an exponent effect, not a bound artifact. Proofs/FermatDefectOneOQ04.lean (133L, 10 thm, 0 def, 0 sorry, 0 axiom decls; native_decide introduces Lean.ofReduceBool) is registered in Proofs.lean and fully documented in the parent fermat-defect-one gallery entry (additionalFiles + originalContributions). The remaining open core — M(n) >= 2 for ALL n>=4 unbounded — requires Fermat-Catalan-type finiteness with no Mathlib bearer (BLOCKED); box/exponent extensions are native_decide enumeration with no structural value (n>=10 overflows UInt64).",
     "builtItems": [
       "no_defect_one_eqn_below_{4,5,6}: for c<101, b<c, a<b+1, 2<=a, both a^n+b^n+1 != c^n and a^n+b^n != c^n+1 [native_decide core; FermatDefectOneOQ04.lean]",
       "no_small_defect_one_{4,5,6}: same emptiness restated with natural ordering hypotheses (2<=a<=b<c<=100), no gcd assumption (defect one forces primitivity)",


### PR DESCRIPTION
## Summary

`fermat-defect-one-oq-04` was the only MODERATE-knowledge available problem, but its Lean work is **already done**: `Proofs/FermatDefectOneOQ04.lean` (133L / 10 thm / 0 sorry / 0 axiom decls) was **merged in #25861**, is registered in `Proofs.lean`, and is **fully documented in the parent `fermat-defect-one` gallery entry** (`additionalFiles` + `originalContributions`) — matching the project convention where the fermat OQ-siblings (oq-02, oq-03) fold into the parent rather than getting standalone gallery dirs.

The research-dashboard json lagged at `active`/`ACT` ("build-pending"). This PR flips it to `completed`/`COMPLETED` and refreshes `progressSummary`. The gitignored candidate pools (`.lean/state`, `research/`) were reconciled in place (available → completed; 17 → 16 available).

## What was verified
- Lean file merged, registered, deployer-built green at #25861.
- Parent meta counts/contributions for OQ-04 are accurate (10 thm, native_decide → `Lean.ofReduceBool` disclosed).

## Honest assessment — no further proof progress available
- **Open core** (M(n) ≥ 2 for *all* n ≥ 4, unbounded): requires Fermat-Catalan-type finiteness, no Mathlib bearer → **BLOCKED**.
- **Box / exponent extensions**: `native_decide` enumeration with no structural value; n ≥ 10 overflows UInt64 → slow bignum.
- **Congruence obstruction** for a fixed n: none exists for n=4 (4th powers ∈ {0,1} mod 5/16 cover ±1), consistent with the conjecture predicting a solution.
- **Kernel `decide`** to drop `ofReduceBool`: ~166k bignum triples → kernel timeout (that is why native_decide was used).

Data-only change. No `loom:review-requested` (math-agent policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)