### PR TITLE
audit(central-limit-theorem): fix phantom mainTheorem name

### DIFF
--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -330,10 +330,10 @@
   },
   "mainTheorems": [
     {
-      "name": "clt_normalized_converges",
+      "name": "central_limit_theorem",
       "type": "core",
-      "description": "Normalized sum of i.i.d. random variables converges in distribution to standard normal",
-      "leanType": "[IID X] -> E[X_i] = mu -> Var(X_i) = sigma^2 -> sigma > 0 -> (S_n - n*mu)/(sigma*sqrt(n)) ->d N(0,1)"
+      "description": "For a probability measure with mean, positive variance, and an integrable third absolute moment, the characteristic function of the normalized sum converges pointwise to the Gaussian characteristic function exp(-t^2/2). Derived from clt_general_case_axiom (the non-standardized CLT, axiomatized).",
+      "leanType": "(mu : Measure R) -> [IsProbabilityMeasure mu] -> (mean variance : R) -> variance > 0 -> (integral x dmu = mean) -> (integral (x-mean)^2 dmu = variance) -> Integrable |x-mean|^3 mu -> forall t, Tendsto (fun n => (charFun mu ((t - n*mean)/(sqrt variance * sqrt n)))^n) atTop (nhds (Complex.exp (-t^2/2)))"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: central-limit-theorem
**Problem**: `mainTheorems[0].name` referenced `clt_normalized_converges`, a declaration that does not exist in `Proofs/CentralLimitTheorem.lean`.

## Evidence

- **meta.json claimed**: main theorem `clt_normalized_converges`
- **Lean source shows**: the headline theorem is `central_limit_theorem` (L375), proving characteristic-function convergence to the Gaussian via `clt_general_case_axiom`. `grep` for `clt_normalized_converges` returns nothing.
- The `conclusion.summary` field already referenced `central_limit_theorem` correctly — internal inconsistency confirming the phantom.

## Fix

Renamed `mainTheorems[0]` to `central_limit_theorem` and aligned its `description` and `leanType` to the real signature.

## Counts (verified exact, no change needed)

620L / 12 axioms / 0 sorry / 0 native_decide / 0 True stubs / 16 theorems. All 12 axioms accurately disclosed in `assumptions`; axiomatized/axiom tier correct — no axiom masking.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)