### PR TITLE
audit(continuum-hypothesis): fix phantom mainTheorems + stale Lean header counts

### DIFF
--- a/proofs/Proofs/ContinuumHypothesis.lean
+++ b/proofs/Proofs/ContinuumHypothesis.lean
@@ -22,17 +22,18 @@ This means: CH can neither be proven nor disproven from ZFC.
 
 ## Status
 - [ ] Complete proof
-- [ ] Uses Mathlib for main result
-- [ ] Proves extensions/corollaries
+- [x] Uses Mathlib for main result
+- [x] Proves extensions/corollaries
 - [x] Pedagogical example
-- [x] Incomplete (has sorries)
+- [ ] Incomplete (has sorries)
 
 ## Mathlib Dependencies
 - `Mathlib.SetTheory.Cardinal.Basic` : Cardinal arithmetic
 - `Mathlib.SetTheory.Cardinal.Ordinal` : Ordinals and aleph hierarchy
 
 **Formalization Notes:**
-- 2 sorries, 5 axioms capturing key metamathematical facts
+- 0 sorries, 4 axioms capturing key metamathematical facts
+  (L exists as a ZFC model and satisfies CH; a Cohen forcing extension exists and violates CH)
 - Full formalization of forcing would require thousands of lines
 - The abstract structures capture the essence of Gödel-Cohen independence
 - See each definition's docstring for implementation rationale

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -244,16 +244,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "ch_independent",
+      "name": "continuum_hypothesis_independent",
       "type": "core",
-      "description": "The continuum hypothesis is independent of ZFC (Godel + Cohen)",
-      "leanType": "Consistent ZFC -> not (Provable ZFC CH) and not (Provable ZFC (not CH))"
+      "description": "Independence of CH, in the scaffolded model-existence form: there is a ZFC model where CH holds and a ZFC model where CH fails. Derived from the Gödel/Cohen axioms (L_exists, L_satisfies_CH, forcing_extension_exists, forcing_violates_CH); the model predicates holds_CH / holds_notCH are placeholders standing in for the deep metamathematical constructions.",
+      "leanType": "(∃ M : ZFCModel, holds_CH M) ∧ (∃ M : ZFCModel, holds_notCH M)"
     },
     {
-      "name": "ch_statement",
+      "name": "ch_equiv_ch_alt",
       "type": "key",
-      "description": "CH: there is no cardinal strictly between aleph_0 and 2^aleph_0",
-      "leanType": "not (exists kappa, aleph_0 < kappa and kappa < 2^aleph_0)"
+      "description": "Genuinely proved (from Mathlib cardinal arithmetic, no axioms): CH (𝔠 = ℵ₁) is equivalent to the no-intermediate-cardinal formulation CH_alt (no κ with ℵ₀ < κ < 𝔠).",
+      "leanType": "CH ↔ CH_alt"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — continuum-hypothesis

**Tier C scaffold** (axiomatized/axiom). Status, badge, and all counts are correct; the issue is **phantom declarations in `mainTheorems`** plus stale prose in the Lean header.

### Counts (verified exact)
395L / 4 axioms / 8 theorems / 12 defs / 0 sorries / 0 native_decide / 0 True-stub theorems — all match meta.json.

### Issue 1 — phantom mainTheorems (HIGH)
`meta.json` `mainTheorems` named two declarations that **do not exist** in `ContinuumHypothesis.lean` (`grep` = 0):
- `ch_independent` → real headline is `continuum_hypothesis_independent`
- `ch_statement` → no such declaration

Both `leanType`s also referenced `Provable` / `Consistent ZFC` constructs absent from the file. The section summaries and `conclusion` already correctly name `continuum_hypothesis_independent` — an internal-inconsistency tell.

**Fix:** repointed to real declarations with their actual Lean types:
- `continuum_hypothesis_independent` — the axiomatized model-existence headline, with a note that `holds_CH` / `holds_notCH` are placeholder predicates standing in for the deep metamathematical constructions.
- `ch_equiv_ch_alt` — `CH ↔ CH_alt`, genuinely proved from Mathlib cardinal arithmetic (no axioms).

### Issue 2 — stale Lean header docstring (LOW)
Source header claimed "2 sorries, 5 axioms" and checkbox "[x] Incomplete (has sorries)". Reality: 0 sorries, 4 axioms. Corrected the count line and status checkboxes. Docstring-only edit — no rebuild required.

### Not changed (correct as-is)
- `status: axiomatized` / `badge: axiom` — correct for a famous independence result scaffolded on 4 disclosed axioms (L exists + satisfies CH; Cohen forcing extension exists + violates CH). No axiom masking: the headline genuinely invokes all four.
- `axiomCount: 4` — the `True`-valued structure fields carry no assumptions and correctly do not count.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)