### PR TITLE
audit(fermats-last-theorem): fix phantom "5 axioms"→2 + phantom axiom names

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11284,9 +11284,9 @@
     },
     "fermats-last-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:03:58Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T19:09:48Z",
+      "result": "issues-fixed"
     },
     "fermats-last-theorem-oq-03": {
       "auditCount": 3,

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -2,7 +2,7 @@
   "id": "fermats-last-theorem",
   "title": "Fermat's Last Theorem",
   "slug": "fermats-last-theorem",
-  "description": "Fermat's Last Theorem: no positive integers $a, b, c$ satisfy $a^n + b^n = c^n$ for $n > 2$. Proved by Andrew Wiles (1995) via the modularity of semistable elliptic curves, settling a 358-year conjecture. Formalized in Lean 4 with 5 axioms encoding the key steps of the Frey-Ribet-Wiles proof chain (modularity theorem, level-lowering, Frey curve, Mazur torsion). Status: axiomatized.",
+  "description": "Fermat's Last Theorem: no positive integers $a, b, c$ satisfy $a^n + b^n = c^n$ for $n > 2$. Proved by Andrew Wiles (1995) via the modularity of semistable elliptic curves, settling a 358-year conjecture. Formalized in Lean 4 as an axiomatized scaffold: the full theorem ($\\forall n \\ge 3$) and the odd-prime case are stated as 2 axioms (the deep, unformalized core), while the $n=3$ and $n=4$ cases are fully proved via Mathlib. Status: axiomatized.",
   "meta": {
     "author": "Andrew Wiles (1995), with Richard Taylor",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_Last_Theorem",
@@ -38,7 +38,7 @@
       }
     ],
     "originalContributions": [
-      "Axiomatized proof structure following the Frey-Ribet-Wiles strategy with 5 axioms",
+      "Axiomatized proof scaffold following the Frey-Ribet-Wiles strategy (2 axioms: the full theorem and the odd-prime case)",
       "Genuine proof that FLT reduces to prime exponents (flt_multiple: FermatLastTheoremFor n → FermatLastTheoremFor (m*n))",
       "Pedagogical exposition of Frey curve construction, modularity, and Ribet's level-lowering in Lean docstrings"
     ],
@@ -52,7 +52,7 @@
     "wiedijkNumber": 33,
     "axiomCount": 2,
     "lineCount": 201,
-    "assumptions": "2 axioms with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p) and fermatLastTheoremFive (FermatLastTheoremFor 5). The n=3 and n=4 cases are fully proved via Mathlib. FreyCurve_is_semistable and RibetTheorem were placeholder True-stubs and have been replaced with documentation comments. 2 with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p, the consequence of Modularity+Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n). 3 placeholder axioms concluding with True (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem) — these serve as proof-structure markers documenting the Frey-Ribet-Wiles chain without encoding actual mathematical statements. The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour).",
+    "assumptions": "2 axioms with real mathematical content: FLT_for_odd_primes (axiomatizes FermatLastTheoremFor p for odd primes p — the consequence of Modularity + Ribet) and fermatLastTheorem (the full FLT statement: ∀ n ≥ 3, FermatLastTheoremFor n; since this already covers all exponents, the odd-prime axiom is mathematically subsumed). The n=3 and n=4 cases are fully proved via Mathlib (fermatLastTheoremThree, fermatLastTheoremFour), and flt_multiple proves the classical reduction FermatLastTheoremFor n → FermatLastTheoremFor (m*n). The Frey curve construction, the Modularity theorem, and Ribet's level-lowering appear only as documentation comments tracing the Frey-Ribet-Wiles chain — they are NOT declarations or axioms (no True-stubs remain).",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 0
@@ -60,7 +60,7 @@
   "overview": {
     "historicalContext": "In 1637, Pierre de Fermat wrote in the margin of his copy of Diophantus's *Arithmetica*: \"I have discovered a truly marvelous proof of this, which this margin is too narrow to contain.\" This tantalizing note launched 358 years of mathematical obsession.\n\nGenerations of mathematicians attacked the problem. Euler proved the case n=3 (1770). Sophie Germain developed techniques for certain primes (1823). Ernst Kummer's work on ideal class groups proved it for all regular primes (1850), but infinitely many cases remained.\n\nThe modern breakthrough came from an unexpected direction. In 1984, Gerhard Frey proposed that a counterexample to Fermat would yield an elliptic curve with impossible properties. Jean-Pierre Serre refined this, and in 1986, Ken Ribet proved the key connection: if Fermat's Last Theorem were false, it would contradict the Taniyama-Shimura-Weil conjecture about modular forms.\n\nAndrew Wiles, who had dreamed of proving FLT since childhood, worked in secret for seven years. In June 1993, he announced his proof of enough of the modularity conjecture to imply FLT. But a gap was found. After a year of anguish, Wiles and Richard Taylor patched the proof using a brilliant new technique. On October 25, 1994, the proof was complete. It was published in 1995, ending the longest-standing unsolved problem in mathematics.",
     "problemStatement": "For any integer $n > 2$, there are no three positive integers $a$, $b$, $c$ such that:\n\n$$a^n + b^n = c^n$$\n\nEquivalently: the only integer solutions to $x^n + y^n = z^n$ for $n > 2$ are the trivial ones where $xyz = 0$.\n\nNote that $n = 2$ has infinitely many solutions (Pythagorean triples like $3^2 + 4^2 = 5^2$), but something fundamentally changes at $n = 3$.",
-    "text": "A 204-line axiomatized formalization of Fermat's Last Theorem with 0 sorries and 5 axioms. Imports Mathlib's `FermatLastTheoremFor` (the statement predicate), `fermatLastTheoremFour` ($n=4$ by Fermat's infinite descent), and `fermatLastTheoremThree` ($n=3$ by Euler via Eisenstein integers). The file provides `fermat_four` and `fermat_three` as thin wrappers around these Mathlib results, `flt_multiple` as a genuine proof of the classical reduction to prime exponents, and three proof-structure axioms (FreyCurve_is_semistable, ModularityTheorem_semistable, RibetTheorem concluding with True) documenting the Frey-Ribet-Wiles chain. The axioms `FLT_for_odd_primes` (for odd prime exponents) and `fermatLastTheorem` (the full statement) encode the deep unformalized results. Lean docstrings trace each step: Frey curve construction, semi-stability, Ribet's level-lowering, and Taylor-Wiles patching.",
+    "text": "A 201-line axiomatized formalization of Fermat's Last Theorem with 0 sorries and 2 axioms. Imports Mathlib's `FermatLastTheoremFor` (the statement predicate), `fermatLastTheoremFour` ($n=4$ by Fermat's infinite descent), and `fermatLastTheoremThree` ($n=3$ by Euler via Eisenstein integers). The file provides `fermat_four` and `fermat_three` as thin wrappers around these Mathlib results, and `flt_multiple` as a genuine proof of the classical reduction to prime exponents. The two axioms `FLT_for_odd_primes` (for odd prime exponents) and `fermatLastTheorem` (the full statement $\\forall n \\ge 3$) encode the deep unformalized results. The Frey-Ribet-Wiles chain (Frey curve construction, semi-stability, Modularity, Ribet's level-lowering, Taylor-Wiles patching) is traced only in Lean docstrings/comments — not as declarations.",
     "proofStrategy": "Wiles' proof proceeds by contradiction through a remarkable chain of ideas:\n\n1. **ASSUME** a counterexample exists: $a^n + b^n = c^n$ with $n > 2$ and $a, b, c$ positive integers.\n\n2. **CONSTRUCT** the Frey curve: From this hypothetical solution, build the elliptic curve\n   $$E: y^2 = x(x - a^n)(x + b^n)$$\n   This curve has unusual properties: it is semi-stable with discriminant divisible by enormous prime powers.\n\n3. **APPLY RIBET'S THEOREM** (1986): The Frey curve, if it existed, would be modular but have a conductor too small to match any modular form. This is impossible.\n\n4. **PROVE MODULARITY**: Wiles proves that all semistable elliptic curves over $\\mathbb{Q}$ are modular (the Taniyama-Shimura-Weil conjecture for semistable curves).\n\n5. **CONTRADICTION**: The Frey curve must be modular (by step 4), but cannot be modular (by step 3). Therefore, no counterexample exists.\n\nThe bulk of Wiles' 100+ page proof establishes the modularity theorem. The Taylor-Wiles patching method, developed to fix the gap, has become a fundamental tool in modern number theory.",
     "keyInsights": [
       "**Frey Curve:** A counterexample $a^n + b^n = c^n$ yields the elliptic curve $E: y^2 = x(x - a^n)(x + b^n)$ with discriminant $\\Delta \\sim (abc)^{2n}$ — a curve with 'impossibly' large conductor for its simple equation.",
@@ -295,9 +295,9 @@
   },
   "mainTheorems": [
     {
-      "name": "flt",
+      "name": "fermatLastTheorem",
       "type": "core",
-      "description": "No three positive integers a, b, c satisfy a^n + b^n = c^n for n > 2",
+      "description": "No three positive integers a, b, c satisfy a^n + b^n = c^n for n > 2 (axiomatized: the full statement ∀ n ≥ 3)",
       "leanType": "(n : Nat) -> 2 < n -> not (exists a b c : Nat, 0 < a and 0 < b and 0 < c and a^n + b^n = c^n)"
     }
   ],


### PR DESCRIPTION
## Gallery Integrity Audit — fermats-last-theorem

**Tier C** (axiomatized scaffold). Status `axiomatized` / badge `axiom` are **correct**. All numeric count fields verified exact against `proofs/Proofs/FermatsLastTheorem.lean`:
- axiomCount **2** ✓ (`FLT_for_odd_primes` L132, `fermatLastTheorem` L182)
- theoremCount **6** ✓, definitionCount **0** ✓, sorries **0** ✓, lineCount **201** ✓
- **0** True-stubs ✓

### Issues fixed (prose only — no Lean change)

1. **Phantom "5 axioms"** in `description`, `originalContributions[0]`, `overview.text` — the file has exactly **2** axioms. Corrected throughout.
2. **Phantom axiom names** in `assumptions`: named `fermatLastTheoremFive` (grep=0; real axiom is `fermatLastTheorem`, the **full** `∀ n ≥ 3` statement) and "3 placeholder axioms concluding with True" (`FreyCurve_is_semistable` / `ModularityTheorem_semistable` / `RibetTheorem`) — these exist only as `/- -/` documentation comments, not declarations. The `assumptions` field was also internally doubled/contradictory; rewrote it to describe the 2 real axioms and note the odd-prime axiom is mathematically subsumed by the full statement.
3. `overview.text` stale "204-line" → **201**; dropped the "three proof-structure axioms ... concluding with True" framing (no True-stubs remain).
4. `mainTheorems[0].name` "flt" (phantom; this field is **not** rendered in the gallery) → `fermatLastTheorem`.

No overclaim of verification — the headline result remains honestly axiomatized.

---
Discovered during gallery integrity audit.