### PR TITLE
audit(cevas-theorem): fix phantom mainTheorem + converse section range

### DIFF
--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -113,14 +113,14 @@
       "id": "converse",
       "title": "Converse Forms",
       "startLine": 200,
-      "endLine": 208,
+      "endLine": 215,
       "summary": "Direct and converse implications extracted from the main equivalence theorem.",
       "mathContext": "The equivalence $\\text{cevaProduct} = 1 \\iff \\text{paramCondition}$ splits into: (forward) product $= 1 \\implies$ parameter condition, and (converse) parameter condition $\\implies$ product $= 1$. Both are extracted from the main `Iff` via `.mp` and `.mpr`."
     },
     {
       "id": "historical-context",
       "title": "Historical Context",
-      "startLine": 209,
+      "startLine": 216,
       "endLine": 263,
       "summary": "Extended discussion of Menelaus's theorem, applications, and generalizations.",
       "mathContext": "Menelaus's theorem (dual): points $D, E, F$ on sides $BC, CA, AB$ are collinear $\\iff$ $(AF/FB) \\cdot (BD/DC) \\cdot (CE/EA) = -1$. The sign difference ($+1$ for Ceva, $-1$ for Menelaus) reflects the parity: concurrent cevians require an even number of external divisions, while a transversal requires an odd number."
@@ -215,10 +215,10 @@
   ],
   "mainTheorems": [
     {
-      "name": "ceva_theorem",
+      "name": "cevas_theorem",
       "type": "core",
-      "description": "Three cevians of a triangle are concurrent iff (AF/FB)(BD/DC)(CE/EA) = 1",
-      "leanType": "cevians_concurrent <-> (AF/FB) * (BD/DC) * (CE/EA) = 1"
+      "description": "The Ceva product (AF/FB)(BD/DC)(CE/EA) equals 1 iff the parameter condition def = (1-d)(1-e)(1-f) holds. This is the algebraic form; geometric concurrency is discussed in commentary but not formalized.",
+      "leanType": "cevaProduct cfg = 1 <-> cevaParameterCondition cfg"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit: cevas-theorem

**Tier A** (algebraic equivalence fully proved, 0 axioms/sorries, basic Mathlib tactics only). Status `verified` / badge `original` retained — correct.

Counts verified exact against `proofs/Proofs/CevasTheorem.lean`: **263L / 0ax / 0sorry / 0 native_decide / 0 True-stub / 8 thm / 4 def** (3 def + 1 structure).

The public-facing description, problemStatement, and proofStrategy are honest — a prior audit clearly cleaned them to disclaim that geometric concurrency is *commentary only, not formalized*. Two internal-consistency defects remained:

### 1. Phantom `mainTheorems[0]`
- **name** `ceva_theorem` — phantom; real decl is `cevas_theorem` (grep confirms).
- **leanType** `cevians_concurrent <-> (AF/FB)*(BD/DC)*(CE/EA) = 1` — asserts a `cevians_concurrent` predicate that **does not exist** in the file, directly contradicting the description's disclaimer.
- **Fix**: repointed to the real algebraic equivalence `cevaProduct cfg = 1 <-> cevaParameterCondition cfg`.

### 2. Converse section range drift
The "Converse Forms" section ended at line 208, excluding its own second theorem `ceva_param_implies_product` (L212–214), which was mis-attributed to "Historical Context" (startLine 209). Realigned to **200–215 / 216–263**.

No public-facing prose overclaim; status/badge/counts all correct.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)