### PR TITLE
audit(buffons-needle): scope claims to integral+algebra, not a formalized probability

### DIFF
--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -32,15 +32,15 @@
       }
     ],
     "originalContributions": [
-      "Complete formalization of Buffon's Needle formula",
-      "Proof of the key integral computation",
-      "Connection to Monte Carlo pi estimation",
-      "Pedagogical explanation of the geometric probability framework"
+      "Formalization of the key integral computation ∫₀^π (ℓ/2)sin θ dθ = ℓ underlying Buffon's Needle (via Mathlib's integral_sin)",
+      "Closed-form algebraic identity ℓ/(πd/2) = 2ℓ/(πd) for the crossing probability",
+      "Geometric model of the crossing event via the crossingRegion and sampleSpace set definitions",
+      "Pedagogical explanation of the geometric probability framework and the Monte Carlo π connection"
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 0,
     "lineCount": 266,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. What is machine-checked is the integral computation ∫₀^π (ℓ/2)sin θ dθ = ℓ (via Mathlib's integral_sin) and the algebraic identity ℓ/(πd/2) = 2ℓ/(πd). The step 'probability = crossing-region area / sample-space area' is encoded by the crossingRegion and sampleSpace set definitions rather than derived measure-theoretically: no probability measure, random variable, or set measure is formalized, so the probabilistic statement P(crossing) = 2ℓ/(πd) is modeled geometrically, not proved as a theorem about a measure.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 3
@@ -48,12 +48,12 @@
   "overview": {
     "historicalContext": "Buffon's Needle Problem was posed by Georges-Louis Leclerc, Comte de Buffon in his 1777 *Essai d'arithmétique morale*, making it one of the earliest problems in geometric probability. Buffon was a polymath — naturalist, mathematician, and director of the Jardin du Roi — who used this problem to explore the foundations of probability theory. The elegant answer $P = 2\\ell/(\\pi d)$ stunned contemporaries: how could $\\pi$, a geometric constant, arise from a probability calculation about random needle drops? Pierre-Simon Laplace recognized its deeper significance and connected it to what we now call integral geometry. In 1812, Laplace used the needle experiment to propose one of the first Monte Carlo methods for estimating $\\pi$: drop $n$ needles, count $k$ crossings, then $\\pi \\approx 2\\ell n/(kd)$. The Italian mathematician Mario Lazzarini claimed in 1901 to have estimated $\\pi$ to six decimal places with 3,408 throws — a result widely suspected to be fabricated, as the ratio $355/113$ (an excellent rational approximation to $\\pi$) fits suspiciously well. In the 20th century, Augustin-Louis Cauchy and later Mark Kac generalized Buffon's result to the Cauchy-Crofton formula, which relates the length of any rectifiable curve to its expected number of intersections with random lines, founding the field of integral geometry.",
     "problemStatement": "**Theorem (Buffon, 1777)**: If a needle of length $\\ell$ is dropped randomly onto a floor with parallel lines spaced distance $d$ apart (where $\\ell \\le d$), the probability it crosses a line is:\n\n$$P = \\frac{2\\ell}{\\pi d}$$\n\nThis is Wiedijk's 100 Theorems #99.",
-    "text": "This formalization proves Buffon's needle formula P = 2ℓ/(πd) for a needle of length ℓ dropped onto parallel lines spaced distance d apart (with ℓ ≤ d). The proof models the random drop with two uniform variables — angle θ ∈ [0, π) and position x ∈ [0, d/2] — and computes the crossing probability as the ratio of favorable area ∫₀^π (ℓ/2)sin(θ) dθ = ℓ to total area πd/2, yielding P = ℓ/(πd/2) = 2ℓ/(πd).\n\nThe file establishes the geometric probability setup using Mathlib's measure theory, computes the integral via `MeasureTheory.integral_sin`, and derives the clean formula with `field_simp` and `ring`. Commentary connects to the remarkable consequence that the formula provides a probabilistic method for estimating π: dropping N needles and counting C crossings gives π ≈ 2ℓN/(Cd), one of the earliest Monte Carlo methods (predating the term by two centuries). Wiedijk 100 theorem #99.",
+    "text": "This formalization develops the integral computation and closed-form algebra behind Buffon's needle formula P = 2ℓ/(πd) for a needle of length ℓ dropped onto parallel lines spaced distance d apart (with ℓ ≤ d). It models the random drop with two uniform variables — angle θ ∈ [0, π) and position x ∈ [0, d/2] — defines the crossing event geometrically via the crossingRegion and sampleSpace sets, computes the favorable area ∫₀^π (ℓ/2)sin(θ) dθ = ℓ via Mathlib's `integral_sin`, and derives the closed form ℓ/(πd/2) = 2ℓ/(πd) with `field_simp` and `ring`.\n\nScope note: the file machine-checks the integral and the algebraic identity, but it does not formalize a probability measure or random variable — the step 'probability = favorable area / total area' is licensed by the uniform-independence model (recorded in the set definitions and prose) rather than derived measure-theoretically. So the probabilistic statement P(crossing) = 2ℓ/(πd) is modeled, not proved as a theorem about a measure; the PMF and Lebesgue imports are present but the body uses only the interval integral. Commentary connects to the Monte Carlo consequence that dropping N needles and counting C crossings gives π ≈ 2ℓN/(Cd), one of the earliest Monte Carlo methods (predating the term by two centuries). Wiedijk 100 theorem #99.",
     "proofStrategy": "**Geometric Probability Setup**:\n\n1. Model the needle drop with two uniform random variables:\n   - Angle $\\theta \\in [0, \\pi)$: orientation of the needle\n   - Position $x \\in [0, d/2]$: distance from center to nearest line\n2. The needle crosses a line when $x \\le (\\ell/2)\\sin\\theta$\n3. Compute the probability as the ratio of favorable to total area:\n   - Crossing region area: $\\int_0^\\pi (\\ell/2)\\sin\\theta\\,d\\theta = \\ell$\n   - Sample space area: $(d/2) \\cdot \\pi = \\pi d/2$\n4. Therefore $P = \\ell / (\\pi d/2) = 2\\ell/(\\pi d)$\n\nThe key computation is $\\int_0^\\pi \\sin\\theta\\,d\\theta = 2$, which follows from $[-\\cos\\theta]_0^\\pi = -(-1) - (-1) = 2$.",
     "keyInsights": [
       "The appearance of $\\pi$ is not coincidental: it arises from integrating $\\sin\\theta$ over the angle variable, which connects circular geometry (the needle can point in any direction) to the probability via $\\int_0^\\pi \\sin\\theta\\,d\\theta = 2$",
       "The short needle assumption $\\ell \\le d$ ensures the needle crosses at most one line, simplifying the crossing condition to the clean inequality $x \\le (\\ell/2)\\sin\\theta$. For long needles ($\\ell > d$), the formula involves $\\arccos(d/\\ell)$ and is significantly more complex",
-      "The step 'probability = area of crossing region / area of sample space' is not automatic — it is licensed precisely because $\\theta$ and $x$ are *independent and uniform*, so their joint density is the constant $\\frac{1}{\\pi}\\cdot\\frac{2}{d}$ on the rectangle $[0,\\pi)\\times[0,d/2]$. For a constant density, probability of any event reduces to a ratio of Lebesgue areas, which is exactly what the `crossingRegion` and `sampleSpace` set definitions encode. With a non-uniform density the answer would instead be $\\frac{1}{\\pi}\\int_0^\\pi \\frac{\\ell\\sin\\theta}{d}\\,d\\theta$, the expectation of the conditional crossing probability $P(\\text{cross}\\mid\\theta)=\\frac{\\ell\\sin\\theta}{d}$",
+      "The step 'probability = area of crossing region / area of sample space' is not automatic — it is licensed precisely because $\\theta$ and $x$ are *independent and uniform*, so their joint density is the constant $\\frac{1}{\\pi}\\cdot\\frac{2}{d}$ on the rectangle $[0,\\pi)\\times[0,d/2]$. For a constant density, probability of any event reduces to a ratio of Lebesgue areas, which the `crossingRegion` and `sampleSpace` set definitions record geometrically — though the Lean file computes the area ratio rather than deriving the probability=ratio identity from a formalized measure. With a non-uniform density the answer would instead be $\\frac{1}{\\pi}\\int_0^\\pi \\frac{\\ell\\sin\\theta}{d}\\,d\\theta$, the expectation of the conditional crossing probability $P(\\text{cross}\\mid\\theta)=\\frac{\\ell\\sin\\theta}{d}$",
       "Buffon's Needle is a special case of the Cauchy-Crofton formula: for any rectifiable curve of length $L$ dropped on lines spaced $d$ apart, the expected number of crossings is $2L/(\\pi d)$. A straight needle of length $\\ell$ has $L = \\ell$, recovering Buffon's result",
       "The Monte Carlo connection goes deeper than estimation: Buffon's problem demonstrates that randomness can be a computational tool. This philosophical insight anticipated the development of Monte Carlo methods by Ulam, von Neumann, and Metropolis at Los Alamos in the 1940s",
       "The Lean formalization uses `field_simp` and `ring` to handle the algebraic manipulation $\\ell/(\\pi d/2) = 2\\ell/(\\pi d)$, which is the step where the geometric computation becomes the clean formula"
@@ -95,7 +95,7 @@
       "title": "The Main Theorem",
       "startLine": 116,
       "endLine": 146,
-      "summary": "Buffon's Needle Theorem (Wiedijk #99): P(crossing) = 2ℓ/(πd). Assembles the integral computation and area ratio into the final formula. Uses field_simp and ring for the algebraic simplification.",
+      "summary": "The headline theorem buffon_needle_probability proves the algebraic identity ℓ/(πd/2) = 2ℓ/(πd) (via field_simp and ring), and buffon_needle_probability' shows the favorable-area integral divided by the sample-space area equals 2ℓ/(πd). These deliver the closed form 2ℓ/(πd); the identification of this ratio with the crossing probability is via the geometric model, not a formalized measure.",
       "mathContext": "$P(\\text{crossing}) = \\frac{2\\ell}{\\pi d}$ for $0 < \\ell \\leq d$. Special cases: $\\ell = d \\Rightarrow P = 2/\\pi \\approx 0.6366$; $\\ell = d/2 \\Rightarrow P = 1/\\pi \\approx 0.3183$."
     },
     {
@@ -226,10 +226,10 @@
   },
   "mainTheorems": [
     {
-      "name": "buffon_probability",
+      "name": "buffon_needle_probability",
       "type": "core",
-      "description": "Probability a needle of length L crosses parallel lines distance D apart is 2L/(pi*D)",
-      "leanType": "L <= D -> P(needle crosses line) = 2 * L / (pi * D)"
+      "description": "Algebraic identity for the closed-form crossing probability: the favorable-area / sample-space-area ratio equals 2ℓ/(πd)",
+      "leanType": "ℓ / (π * d / 2) = 2 * ℓ / (π * d)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: buffons-needle (Buffon's Needle Problem, Wiedijk #99, `verified`/`mathlib`)
**Failure mode**: #3 "inequality/computation ≠ theorem" — the famous probabilistic result is presented as a complete formalization, but no probability is formalized.

## Evidence

**meta.json claimed**: `originalContributions[0]` = "Complete formalization of Buffon's Needle formula"; `assumptions` = "None. Fully verified..."; overview "computes the crossing probability as the ratio ... using Mathlib's measure theory"; `mainTheorems[0]` named `buffon_probability` with leanType `... -> P(needle crosses line) = 2L/(piD)`.

**Lean file shows** (`Proofs/BuffonsNeedle.lean`, 266L/9thm/3def/0ax/0sorry — all counts exact):
- The headline theorem `buffon_needle_probability` is just `ℓ / (π*d/2) = 2*ℓ/(π*d)`, proved by `field_simp; ring`. It mentions no measure, random variable, or needle.
- Despite importing `ProbabilityMassFunction` and `Lebesgue`, the body uses **neither** — only `integral_sin` (a plain interval integral). `grep` for `volume|Measure|PMF|measurable` in the body = 0 hits.
- `crossingRegion`/`sampleSpace` are defined as `Set`s but their measures are never computed or related to any probability.
- `mainTheorems[0].name` = `buffon_probability` is phantom (grep = 0); real name is `buffon_needle_probability`.
- `long_needle_remark` proves `(1:ℕ)+1 = 2 := rfl` — a placeholder, not the long-needle formula.

The leap from geometry to probability lives entirely in prose comments — the Lean kernel guarantees the integral computation (∫₀^π (ℓ/2)sinθ = ℓ) and an algebraic identity, **not** P(crossing) = 2ℓ/(πd).

## Fix

Lemmas are genuinely machine-checked, so `verified`/`mathlib` are **kept** (per the cevas/halting-problem precedent: scope the prose, don't downgrade). Reworded `assumptions`, `originalContributions[0]`, `overview.text`, the main-theorem section summary, the probability=area-ratio keyInsight, and `mainTheorems[0]` (phantom name + fictional type) to state exactly what is proved: the integral computation and the closed-form algebra, with the probability=ratio identity modeled geometrically rather than derived measure-theoretically.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)