### PR TITLE
audit(hilbert-14): scope to Basis Theorem — verified/original→axiomatized/wip

### DIFF
--- a/proofs/Proofs/Hilbert14Invariants.lean
+++ b/proofs/Proofs/Hilbert14Invariants.lean
@@ -49,8 +49,11 @@ We demonstrate:
 - [x] Complete (no sorries)
 
 **Formalization Notes:**
-- Uses axioms for statements requiring deep algebraic geometry
-- Demonstrates Mathlib's ring theory infrastructure
+- This file formalizes only Hilbert's Basis Theorem (Noetherian preservation),
+  re-exported from Mathlib, plus definitions of the invariant ring and reductivity.
+- The 14th problem itself (finite generation for reductive groups, Nagata's
+  counterexample) is presented as expository commentary, not formalized.
+- Contains no axioms and no sorries.
 
 ## Mathlib Dependencies
 - `RingTheory.Polynomial.Basic` : Polynomial rings
@@ -173,7 +176,8 @@ In Mathlib, this is captured by `Algebra.FiniteType k A`.
 
     **Answer**: NO in general (Nagata 1959), but YES for reductive groups.
 
-    This axiom represents the main statement of the problem. -/
+    This is stated here as exposition only; it is not formalized as a Lean
+    declaration. -/
 
 end MainQuestion
 

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -7,7 +7,7 @@
     "proofRepoPath": "Proofs/Hilbert14Invariants.lean",
     "author": "Nagata, Hilbert, Mumford, Haboush",
     "date": "1890-1975",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "invariant-theory",
       "algebra",
@@ -16,7 +16,7 @@
       "noetherian",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -36,17 +36,16 @@
       }
     ],
     "originalContributions": [
-      "Invariant ring definition and structure",
-      "Hilbert's Finiteness Theorem statement (reductive case)",
-      "Nagata's counterexample description",
-      "Modern developments (Hochster-Roberts, Noether bound)",
-      "Classification of when finite generation holds"
+      "Hilbert's Basis Theorem (Noetherian preservation under polynomial extension) re-exported from Mathlib's Polynomial.isNoetherianRing / MvPolynomial.isNoetherianRing",
+      "Definition of the ring of invariants R^G (InvariantElements) for a group action",
+      "Definition of linear reductivity (LinearlyReductive structure)",
+      "Note: the 14th problem itself (finite generation of invariants for reductive groups, Nagata's counterexample, Hochster-Roberts, Noether bound) is presented as mathematical exposition only and is NOT formalized in Lean -- those sections of the source file are doc-comment commentary with no declarations"
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 14,
     "axiomCount": 0,
     "lineCount": 364,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "The Lean file is sorry-free and axiom-free, but it does NOT formalize Hilbert's 14th problem. The only proved theorems are Hilbert's Basis Theorem (Noetherian preservation), obtained directly from Mathlib (Polynomial.isNoetherianRing / MvPolynomial.isNoetherianRing), plus two definitions (ring of invariants, linear reductivity). The positive resolution for reductive groups (Hilbert-Mumford-Haboush) and Nagata's counterexample appear only as expository doc-comments, with no formal statement or proof.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
     "definitionCount": 2
@@ -55,7 +54,7 @@
     "historicalContext": "Hilbert's fourteenth problem arose from 19th century invariant theory, which sought to describe polynomial functions unchanged by group transformations. In 1890, Hilbert revolutionized the field by proving that finitely many invariants always suffice for classical groups like GL_n and SL_n, using his new Basis Theorem.\n\nIn 1900, Hilbert posed the general question: Is the ring of invariants always finitely generated? This remained open for nearly 60 years.\n\n**Timeline:**\n- 1890: Hilbert proves finiteness for classical invariant theory\n- 1900: Hilbert poses the general problem\n- 1959: Nagata constructs a counterexample\n- 1965: Mumford proves finiteness for reductive groups (char 0)\n- 1975: Haboush extends to all characteristics",
     "problemStatement": "**Hilbert's Original Question:**\n\nLet G be an algebraic group acting linearly on the polynomial ring k[x_1, ..., x_n]. Consider the ring of invariants:\n\nR^G = {f in k[x_1,...,x_n] : g(f) = f for all g in G}\n\n**Is R^G always finitely generated as a k-algebra?**\n\nIn other words, are there always finitely many 'fundamental invariants' f_1, ..., f_m such that every invariant is a polynomial expression in f_1, ..., f_m?",
     "text": "Hilbert's 14th problem asked whether the ring of invariants is always finitely generated. Nagata (1959) showed the answer is NO in general, but Hilbert-Mumford proved YES for reductive groups.",
-    "proofStrategy": "We present the resolution of Hilbert's 14th problem in four parts:\n\n**1. Foundation - Hilbert's Basis Theorem:**\n- If R is Noetherian, then R[X] is Noetherian\n- This means k[x_1, ..., x_n] is Noetherian for any field k\n\n**2. Positive Case - Reductive Groups:**\n- For reductive groups (GL_n, SL_n, finite groups, etc.), YES\n- Uses the Reynolds operator: a projection R -> R^G\n- Combined with Hilbert's Basis Theorem gives finite generation\n\n**3. Negative Case - Nagata's Counterexample:**\n- G = (additive group)^13 acting on k^32\n- The invariant ring is NOT finitely generated\n- Key: the additive group is not reductive\n\n**4. Modern Classification:**\n- Reductive groups: always finitely generated\n- Non-reductive groups: may fail finite generation",
+    "proofStrategy": "This entry is a formal scaffold: only Part 1 below is formalized in Lean (via Mathlib). Parts 2-4 are mathematical exposition describing the resolution of Hilbert's 14th problem; they are not formalized.\n\n**1. Foundation - Hilbert's Basis Theorem (FORMALIZED via Mathlib):**\n- If R is Noetherian, then R[X] is Noetherian\n- This means k[x_1, ..., x_n] is Noetherian for any field k\n\n**2. Positive Case - Reductive Groups (exposition only, not formalized):**\n- For reductive groups (GL_n, SL_n, finite groups, etc.), YES\n- Uses the Reynolds operator: a projection R -> R^G\n- Combined with Hilbert's Basis Theorem gives finite generation\n\n**3. Negative Case - Nagata's Counterexample:**\n- G = (additive group)^13 acting on k^32\n- The invariant ring is NOT finitely generated\n- Key: the additive group is not reductive\n\n**4. Modern Classification:**\n- Reductive groups: always finitely generated\n- Non-reductive groups: may fail finite generation",
     "keyInsights": [
       "Noetherian property is necessary but not sufficient for finite generation",
       "Reductivity of the group is the key condition",


### PR DESCRIPTION
## Integrity Issue

**Proof**: hilbert-14 (Hilbert's Fourteenth Problem: Finiteness of Invariant Systems)
**Severity**: HIGH — famous Hilbert problem labeled \`verified\`/\`original\` with \"Fully verified\" assumptions, but the named result is not formalized.

## Evidence

**meta.json claimed**: \`status: verified\`, \`badge: original\`, \`assumptions: "None. Fully verified with 0 axioms and 0 sorries."\`, and originalContributions listing "Hilbert's Finiteness Theorem statement (reductive case)", "Nagata's counterexample description", etc.

**Lean file (`Hilbert14Invariants.lean`) actually contains** (0 axioms, 0 sorries, 4 theorems, 2 defs):
- `hilbert_basis_theorem_univariate := Polynomial.isNoetherianRing`
- `polynomial_ring_noetherian := MvPolynomial.isNoetherianRing`
- `field_is_noetherian := inferInstance`
- `polynomial_ring_over_field_noetherian := MvPolynomial.isNoetherianRing`
- `def InvariantElements` (a Set), `structure LinearlyReductive`

All four theorems are trivial Mathlib wrappers for **Hilbert's Basis Theorem (1888)** — Noetherian preservation — which is *not* the 14th problem. The actual 14th-problem content (finite generation for reductive groups via Hilbert–Mumford–Haboush, **Nagata's counterexample**, Hochster–Roberts, Noether's bound, and even the "Formal Statement" of the question) appears **only as doc-comment prose with no declarations** (Parts III–VI of the source).

This is the erdos-182 class: a scaffold whose named famous result is unformalized exposition, mislabeled verified/original.

Bonus: the Lean docstrings claimed "Uses axioms for statements requiring deep algebraic geometry" / "This axiom represents the main statement" while the file has **0 axioms** (phantom-axiom prose).

## Fix (meta.json + Lean docstrings only; no proof logic touched)

- `status`: verified → **axiomatized**
- `badge`: original → **wip**
- `assumptions`: stop claiming "Fully verified"; scope honestly to the Basis Theorem + 2 definitions, and state that the resolution is exposition only
- `originalContributions`: rescope to what is genuinely formalized; explicitly flag the exposition-only parts
- `overview.proofStrategy`: mark Part 1 (Basis Theorem) as the only formalized part
- Lean docstrings: remove the two phantom-axiom references

Counts (4 thm / 2 def / 0 ax / 0 sorry / 364 L) were already correct and are unchanged. The math history in description/overview/conclusion is accurate and is preserved.

---
Discovered during gallery integrity audit. Sibling famous entries cramers-rule and de-moivre were audited the same cycle and found clean (verified/mathlib, honest Tier B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)