### PR TITLE
research(four-square-distribution-oq-04): build-verify & register the uniform general-m orbit decomposition

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2363,6 +2363,11 @@ import Proofs.FourColorTheoremOQ02
 import Proofs.FourSquareDistribution
 import Proofs.FourSquareDistributionOQ01
 import Proofs.FourSquareDistributionOQ04
+import Proofs.FourSquareDistributionOQ04Arrange
+import Proofs.FourSquareDistributionOQ04ArrangeProof
+import Proofs.FourSquareDistributionOQ04Bridge
+import Proofs.FourSquareDistributionOQ04Decomp
+import Proofs.FourSquareDistributionOQ04Keystone
 import Proofs.FourSquareDistributionOQ04M8
 import Proofs.FourSquareDistributionOQ04Sign
 import Proofs.FourSquareRepresentations

--- a/proofs/Proofs/FourSquareDistributionOQ04ArrangeProof.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ04ArrangeProof.lean
@@ -75,6 +75,8 @@ re-verified there, but only a Docker build confirms the routine glue.
 namespace FourSquareDistributionOQ04ArrangeProof
 
 open Finset
+open scoped Nat   -- `n !` factorial notation (scoped under `Nat`)
+open scoped List  -- `l₁ ~ l₂` List.Perm notation (scoped under `List`)
 
 /-- The canonical `Finset` of multiset-arrangements (verbatim from the parent file). -/
 def arrangements {m : ℕ} (s : Multiset ℤ) : Finset (Fin m → ℤ) :=
@@ -204,18 +206,19 @@ theorem arrangements_card_mul_prod_count {m : ℕ} (s : Multiset ℤ)
     rw [map_univ_comp_perm_eq g₀ σ, hg₀map]
   -- every fiber has cardinality `∏count!`
   have hfiber : ∀ h ∈ arrangements (m := m) s,
-      ({σ ∈ (Finset.univ : Finset (Equiv.Perm (Fin m))) |
-          g₀ ∘ (σ : Fin m → Fin m) = h}).card = ∏ v ∈ s.toFinset, (s.count v)! := by
+      ((Finset.univ : Finset (Equiv.Perm (Fin m))).filter
+          (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = h)).card
+        = ∏ v ∈ s.toFinset, (s.count v)! := by
     intro h hh
     have hhmap : Multiset.map h (Finset.univ : Finset (Fin m)).val = s :=
       (mem_arrangements_iff s h).mp hh
     obtain ⟨σ₀, hσ₀⟩ := exists_perm_of_map_univ_eq (x := h) (y := g₀)
       (by rw [hhmap, hg₀map])
     -- `hσ₀ : h = g₀ ∘ σ₀`; the fiber over `h` bijects with the stabilizer fiber
-    have hbij : ({σ ∈ (Finset.univ : Finset (Equiv.Perm (Fin m))) |
-            g₀ ∘ (σ : Fin m → Fin m) = h}).card
-        = ({σ ∈ (Finset.univ : Finset (Equiv.Perm (Fin m))) |
-            g₀ ∘ (σ : Fin m → Fin m) = g₀}).card := by
+    have hbij : ((Finset.univ : Finset (Equiv.Perm (Fin m))).filter
+            (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = h)).card
+        = ((Finset.univ : Finset (Equiv.Perm (Fin m))).filter
+            (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = g₀)).card := by
       apply Finset.card_nbij' (fun σ => σ * σ₀⁻¹) (fun σ => σ * σ₀)
       · intro σ hσ
         simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hσ ⊢
@@ -227,8 +230,8 @@ theorem arrangements_card_mul_prod_count {m : ℕ} (s : Multiset ℤ)
         rw [Equiv.Perm.coe_mul, ← Function.comp_assoc, hσ, ← hσ₀]
       · intro σ _; dsimp only; group
       · intro σ _; dsimp only; group
-    have hconv : ({σ ∈ (Finset.univ : Finset (Equiv.Perm (Fin m))) |
-            g₀ ∘ (σ : Fin m → Fin m) = g₀}).card
+    have hconv : ((Finset.univ : Finset (Equiv.Perm (Fin m))).filter
+            (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = g₀)).card
         = Fintype.card {σ : Equiv.Perm (Fin m) // g₀ ∘ (σ : Fin m → Fin m) = g₀} := by
       rw [Fintype.card_subtype]
     rw [hbij, hconv, stabilizer_card_eq_prod_count s hg₀]

--- a/src/data/proofs/four-square-distribution-oq-04/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-04/meta.json
@@ -29,7 +29,8 @@
       "RepType6.contribution = (6!/∏mᵢ!)·2^(#nonzero): the hyperoctahedral orbit-size formula (★), the 2k=6 instance of the parent's (4!/∏mᵢ!)·2^(#nonzero)",
       "Complete type enumerations for n ∈ {1,2,3,5,6,12,30}, each contribution verified by native_decide",
       "r6_5, r6_6, r6_12, r6_30: the type contributions sum to Jacobi's r₆(n) = 312, 544, 2080, 14144 respectively",
-      "Structural bounds nonzeroCount_le_six and signFactor_le_64 (the sign factor is a power of two ≤ 2⁶)"
+      "Structural bounds nonzeroCount_le_six and signFactor_le_64 (the sign factor is a power of two ≤ 2⁶)",
+      "Uniform general-m proof (Decomp/Arrange/ArrangeProof/Keystone/Bridge, built & registered 2026-06-18): reps_card_eq_sum_shapeContribution proves r_m(n)=∑_shapes m!/∏count!·2^#nonzero for ALL m with 0 axioms / 0 sorries / no native_decide, where reps m n is the genuine representation count (lossless by mem_reps_iff). The orbit-size residue arrangement_card is discharged elementarily (Finset fiber-counting of σ↦g₀∘σ over Equiv.Perm, each fiber a stabilizer coset; arrangement count = Nat.multinomial via Nat.multinomial_spec), avoiding MulAction.orbit Fintype synthesis."
     ]
   },
   "overview": {
@@ -53,7 +54,7 @@
     {
       "id": "header-open-question",
       "title": "Header: Parent, Open Question & Answer",
-      "summary": "The opening docstring recalls the parent r₄(n) type-decomposition (orbit count (4!/∏mᵢ!)·2^#nonzero under the hyperoctahedral group B₄), poses oq-04 — does it generalize to r_{2k}(n) under B_{2k} = S_{2k} ⋉ (ℤ/2)^{2k} — and answers 'yes, verbatim' for 2k = 6, noting the computational (native_decide) approach, the Python certificate validation, and that the file is not yet registered in Proofs.lean (authored under a Docker blackout).",
+      "summary": "The opening docstring recalls the parent r₄(n) type-decomposition (orbit count (4!/∏mᵢ!)·2^#nonzero under the hyperoctahedral group B₄), poses oq-04 — does it generalize to r_{2k}(n) under B_{2k} = S_{2k} ⋉ (ℤ/2)^{2k} — and answers 'yes, verbatim' for 2k = 6, noting the computational (native_decide) approach and the Python certificate validation. This OQ04.lean file is registered in Proofs.lean; the general-m uniform proof now lives in the companion Decomp/Arrange/ArrangeProof/Keystone/Bridge files (also registered, fully kernel-verified).",
       "startLine": 1,
       "endLine": 57,
       "mathContext": "$|B_{2k}| = (2k)!\\,2^{2k}$; contribution$(\\text{type}) = \\dfrac{6!}{\\prod_i m_i!}\\cdot 2^{\\#\\text{nonzero}}$ and $\\sum_{\\text{types of }n}\\text{contribution} = r_6(n)$."
@@ -117,10 +118,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Confirms the 2k = 6 case of the hyperoctahedral type-decomposition: r₆(n) decomposes as a sum of orbit contributions (6!/∏mᵢ!)·2^(#nonzero) under B₆, verified by native_decide on the complete type lists for n ∈ {1,2,3,5,6,12,30} and matched against Jacobi's r₆ values. 25 theorems, 0 sorries, 0 axiom declarations (contributions via native_decide / Lean.ofReduceBool).",
-    "implications": "The orbit/type bookkeeping that underlies Jacobi's r₄ formula is not special to four coordinates — it carries over to six (and, by the same template, to any even 2k). The computational `RepType6` approach scales directly: only the tuple arity, the multinomial denominator, and the type enumerations change. The deeper question — a single uniform Lean proof of the orbit-size formula for general 2k (rather than per-arity computation) — is the subject of the ongoing Decomp/Bridge/Keystone/Arrange development in the same research directory.",
+    "summary": "Confirms the 2k = 6 case of the hyperoctahedral type-decomposition computationally (RepType6 + native_decide on the complete type lists for n ∈ {1,2,3,5,6,12,30}, matched against Jacobi's r₆ values), AND — as of 2026-06-18 — supplies the fully kernel-verified UNIFORM proof for general m: the Decomp/Arrange/ArrangeProof/Keystone/Bridge stack (now built and registered in Proofs.lean) proves reps_card_eq_sum_shapeContribution : ∀ m n, #(reps m n) = ∑_shapes m!/∏count!·2^#nonzero with NO sorry, NO axiom, NO native_decide, where #(reps m n) is the genuine representation count r_m(n). The computational OQ04.lean file (this entry's primary path) still carries Lean.ofReduceBool from its per-arity native_decide, so the entry remains axiomatized; the uniform decomposition itself is now machine-checked.",
+    "implications": "The orbit/type bookkeeping that underlies Jacobi's r₄ formula is not special to four coordinates — it carries over to all m, and this is now a single uniform Lean theorem (Bridge.reps_card_eq_sum_shapeContribution) rather than a per-arity native_decide computation. The verified route avoids MulAction.orbit Fintype synthesis entirely: it counts arrangements directly via precomposition-map fiber counting (each fiber a stabilizer coset), reducing the orbit size to Nat.multinomial · 2^#nonzero. The remaining open work is arithmetic, not combinatorial: instantiating the uniform decomposition with explicit r_{2k}(n) totals from Jacobi/modular formulas.",
     "openQuestions": [
-      "Can the per-arity native_decide computations be replaced by one uniform orbit-stabilizer theorem valid for all 2k, formalizing the B_{2k}-action and its stabilizers directly? This is the goal of the unregistered FourSquareDistributionOQ04Decomp / Bridge / Keystone / Arrange files.",
+      "The uniform orbit-stabilizer theorem for all m is now PROVEN and registered (FourSquareDistributionOQ04Bridge.reps_card_eq_sum_shapeContribution, 0 axioms / 0 sorries). What remains is to feed it explicit arithmetic totals: supply r_{2k}(n) closed forms (Jacobi/modular) so the decomposition yields numeric per-n identities uniformly, replacing the per-arity native_decide cross-checks in OQ04.lean / M8.lean.",
       "Does the 2k = 8 case (B₈, |B₈| = 8!·2⁸ = 10,321,920) admit the same computational treatment, and do the totals reproduce Jacobi's r₈(n) = 16σ₃(n) − 32σ₃(n/2)-type formula?",
       "Is there a generating-function identity that packages ∑_type contribution·q^(∑aᵢ²) into the sixth power of a theta series directly, making the combinatorial decomposition and Jacobi's analytic formula two readings of the same object?"
     ]
@@ -141,6 +142,51 @@
         "axioms": 0,
         "sorries": 0,
         "description": "Verified sign-count half of the orbit-size lemma for the general B_m = S_m ⋉ (ℤ/2)^m route to OQ-04. Defines signFiber g (tuples agreeing with g coordinatewise up to sign) and proves signFiber_card: its cardinality is 2^(#nonzero coordinates) (signFiber_card), via the single-coordinate count {c,-c}.card = if c=0 then 1 else 2 (card_pair_neg). This is the sign factor 2^(#nonzero) appearing throughout the parent's type-contribution formula (6!/∏mᵢ!)·2^(#nonzero); the file also records the decomposition blueprint reducing the keystone fiber_card_eq_contribution to the single remaining open arrangement-count (multinomial) lemma. 2 theorems, 1 definition, 0 axioms, 0 sorries; Mathlib-only, fully kernel-checked (no decide/native_decide). Registered Proofs.lean:2355 (PR #24885). Namespace FourSquareDistributionOQ04Sign. Standalone reusable infrastructure — does not by itself close OQ-04 (the arrangement-count residue remains open)."
+      },
+      {
+        "path": "Proofs/FourSquareDistributionOQ04Decomp.lean",
+        "lineCount": 184,
+        "theorems": 5,
+        "definitions": 4,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "The uniform-partition reduction for ALL m (not per-arity native_decide). Defines reps m n := the Finset of integer m-tuples with Σxᵢ²=n (proved lossless by mem_reps_iff, so #(reps m n) is the genuine representation count r_m(n)), the orbit invariant shape f (multiset of |coordinates|), and shapeContribution m s = m!/∏count! · 2^#nonzero (the orbit-size formula ★). Proves reps_card_eq_sum_fiber (the all-n partition r_m(n)=Σ_shapes fiber-size, via Finset.card_eq_sum_card_fiberwise) and reps_card_eq_sum_contribution m n (FiberFormula m n) — the type decomposition given the orbit-size input, packaged as a discharged hypothesis FiberFormula (proved in Bridge). 5 theorems, 4 definitions, 0 axioms, 0 sorries; Mathlib-only, kernel-checked (no native_decide). Verified-built and registered 2026-06-18 (researcher-12)."
+      },
+      {
+        "path": "Proofs/FourSquareDistributionOQ04ArrangeProof.lean",
+        "lineCount": 263,
+        "theorems": 10,
+        "definitions": 1,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Discharges the sole combinatorial residue — the orbit-size/arrangement count — fully (no sorry, no MulAction.orbit Fintype synthesis). Proves stabilizer_card_eq_prod_count (|{σ : g∘σ=g}| = ∏count!, via DomMulAct.stabilizer_card'), the orbit-surjectivity converse exists_perm_of_map_univ_eq (two tuples with equal value-multiset differ by a permutation, via Tuple.sort + List.Perm.eq_of_sortedLE), nonempty_arrangements, arrangements_card_mul_prod_count (#(arrangements s)·∏count! = m!, by elementary Finset fiber-counting of the precomposition map σ↦g₀∘σ over Equiv.Perm (Fin m), each fiber a stabilizer coset via Finset.card_nbij'), and arrangement_card (= Nat.multinomial, by cancelling ∏count! against Nat.multinomial_spec). 10 theorems, 1 definition, 0 axioms, 0 sorries. Verified-built and registered 2026-06-18 (researcher-12)."
+      },
+      {
+        "path": "Proofs/FourSquareDistributionOQ04Arrange.lean",
+        "lineCount": 148,
+        "theorems": 6,
+        "definitions": 2,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Re-expresses the orbit-size residue in canonical Nat.multinomial form: proves factorial_div_eq_multinomial (m!/∏count! = Nat.multinomial), prod_count_factorial_dvd (so the Nat.div in ★ is exact, non-truncating), mem_arrangements_iff, and arrangement_card_div_form, delegating arrangement_card to ArrangeProof. 6 theorems, 2 definitions, 0 axioms, 0 sorries. Verified-built and registered 2026-06-18 (researcher-12)."
+      },
+      {
+        "path": "Proofs/FourSquareDistributionOQ04Keystone.lean",
+        "lineCount": 185,
+        "theorems": 7,
+        "definitions": 2,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Assembles the fiber-size formula from the sign half (Sign.signFiber_card) and the arrangement half: fiber_card_eq_contribution reduces #(shapeFiber m n s) = shapeContribution m s to the arrangement count, consumed as a hypothesis. 7 theorems, 2 definitions, 0 axioms, 0 sorries. Verified-built and registered 2026-06-18 (researcher-12)."
+      },
+      {
+        "path": "Proofs/FourSquareDistributionOQ04Bridge.lean",
+        "lineCount": 185,
+        "theorems": 7,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "The headline of the uniform stack: proves sumsq_invariant (the sum-of-squares condition is constant on an arrangement class), image_absMap_eq_arrangements (the bridge linking Keystone's image-of-fiber to Arrange's arrangements count), fiber_card_eq_shapeContribution (discharges the orbit-size hypothesis for every attained shape), and the OQ-04 answer reps_card_eq_sum_shapeContribution : ∀ m n, #(reps m n) = ∑ s ∈ image shape (reps m n), shapeContribution m s — i.e. r_m(n) = Σ_shapes 2^#nonzero·m!/∏count! for ALL m, with NO sorry, NO axiom, NO native_decide. fiberFormula_holds discharges Decomp's FiberFormula for all m,n. This is the affirmative, fully kernel-verified answer to OQ-04's combinatorial generalization question (the per-arity native_decide files OQ04.lean/M8.lean are now superseded by this uniform proof for the decomposition itself). 7 theorems, 0 definitions, 0 axioms, 0 sorries. Verified-built and registered 2026-06-18 (researcher-12)."
       }
     ]
   },

--- a/src/data/research/problems/four-square-distribution-oq-04.json
+++ b/src/data/research/problems/four-square-distribution-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "four-square-distribution-oq-04",
   "title": "Type-Decomposition of Sums of 2k Squares via the Hyperoctahedral Group",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -26,20 +26,18 @@
     "goal": "Formalize the orbit-stabilizer decomposition for r_{2k}(n) (at least fixed 2k in {4,6,8}): define the signed-permutation action, prove orbit size = 2^{#nonzero}*(2k)!/prod m_i!, and recover the total as a sum over shapes."
   },
   "currentState": {
-    "phase": "ACT (arrangement_card discharged 2026-06-18, researcher-3, build-pending)",
+    "phase": "DONE (build-verified & registered 2026-06-18, researcher-12)",
     "since": "2026-06-15T07:05:00.000Z",
-    "iteration": 6,
-    "focus": "S6 ACT (researcher-1; build-pending; triple blackout re-confirmed live: docker rc=124, no local Mathlib, Aristotle prove 404 via mcp-smoke-test). Formalized the 2k=8 (|B8|=10321920) case, the example named in the OQ and the only one of {4,6,8} left: new FourSquareDistributionOQ04M8.lean mirrors the PROVEN computational route (RepType8 + (star)=8!/prod count! * 2^nonzero, native_decide contributions + r8(n) totals for n in {1..8,12}; all-ones shape at n=8 gives 2^8=256). Cert verify_r8_decomposition.py PASS (9 n: exhaustive shapes vs file, (star) vs brute signed-ordering count, sum==r8(n) vs convolution). Also refined the residue analysis: arrangement_card has TWO sub-residues lacking direct Mathlib lemmas (orbit-surjectivity + stabilizer order), not one -- corrects prior 'easy half' framing.",
-    "blockers": [
-      "Docker build verification pending (gated detached build under host contention ~9 lean containers / load ~18); arrangement_card itself is now sorry-free pending compile confirmation."
-    ],
-    "nextAction": "ACT (researcher-3, 2026-06-18): arrangement_card — the sole combinatorial residue — is now DISCHARGED in FourSquareDistributionOQ04ArrangeProof.lean (sorry-free). The two prior sorrys (orbit<->arrangements bijection + orbit-stabilizer assembly) are replaced by an ELEMENTARY Finset fiber-counting proof of arrangements_card_mul_prod_count: Finset.card_eq_sum_card_fiberwise for the precomposition map sigma |-> g0 . sigma from Perm(Fin m) onto arrangements s, each fiber over h=g0.sigma0 a coset of the stabilizer (Finset.card_nbij' sigma|->sigma*sigma0^-1) of size prod count! via the already-proved stabilizer_card_eq_prod_count. This avoids MulAction.orbit and its orbit-Fintype synthesis entirely (the landmine that stalled prior sessions). Added nonempty_arrangements (witness from s.toList via List.ofFn_get) + folded in the converse lemmas (Tuple.sort + List.Perm.eq_of_sortedLE). All names re-verified vs offline Mathlib pin 2df2f0150c. BUILD-PENDING under a gated detached Docker build (sentinel /tmp/r3-arrcard.done). NEXT after green: (1) register the OQ04 family in Proofs.lean; (2) assemble fiber_card_eq_contribution in Decomp.lean from arrangement_card_div_form x signFiber_card, discharging Decomp.lean's lone sorry; (3) wire to the headline OQ-04 statement.",
+    "iteration": 7,
+    "focus": "S7 DONE (researcher-12): BUILD-VERIFIED the full uniform OQ-04 stack and registered it. Prior sessions claimed 'sorry-free build-pending' but the stack had NEVER compiled. FourSquareDistributionOQ04ArrangeProof.lean carried 3 genuine build errors: (1) factorial `!` notation out of scope (only `open Finset`) -> added `open scoped Nat`; (2) List.Perm `~` notation out of scope -> added `open scoped List`; (3) the set-builder `{σ ∈ (univ : Finset (Perm (Fin m))) | g₀ ∘ (σ : Fin m → Fin m) = h}` with an UNANNOTATED binder + a (σ : Fin m → Fin m) ascription forced σ's type to a function, coercing univ into an IMAGE of functions (rendered `do let a ← univ; pure ⇑a`), a Finset of the wrong element type -> apply card_nbij'/Fintype.card_subtype/card_eq_sum_card_fiberwise all failed. Fix: rewrite the three set-builders as `(univ).filter (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = X)` (annotate the binder, matching hmaps). With those, `lake build Proofs.FourSquareDistributionOQ04Bridge` SUCCEEDED (Docker, 7748 jobs, ~40min). Registered Decomp/Arrange/ArrangeProof/Keystone/Bridge in Proofs.lean.",
+    "blockers": [],
+    "nextAction": "DONE — the OQ-04 combinatorial generalization is affirmatively answered with a fully kernel-verified uniform proof for ALL m: FourSquareDistributionOQ04Bridge.reps_card_eq_sum_shapeContribution : ∀ m n, #(reps m n) = ∑ s ∈ image shape (reps m n), shapeContribution m s, where #(reps m n) is the genuine representation count r_m(n) (lossless via mem_reps_iff). 0 axioms, 0 sorries, no native_decide across the Decomp/Arrange/ArrangeProof/Keystone/Bridge stack; all registered in Proofs.lean and build-verified. The only REMAINING (separate, arithmetic) work is to instantiate the decomposition with explicit r_{2k}(n) totals from Jacobi/modular formulas — but the structural OQ is closed. Note: companion FourSquareDistributionOQ04Converse.lean is now a redundant orphan (its lemmas are folded into ArrangeProof) and carries the same latent `~` notation gap; left unregistered.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 2
     },
-    "lastUpdate": "2026-06-15T14:05:00.000Z"
+    "lastUpdate": "2026-06-18T00:00:00.000Z"
   },
   "knowledge": {
     "progressSummary": "S(researcher-3, 2026-06-18, ACT) FULL OQ-04 STACK SORRY-FREE (build-pending verification): The sole remaining residue arrangement_card was discharged sorry-free in ArrangeProof.lean (prior PR #25542); this session WIRED it into the live stack and closed the last open input. (1) Arrange.lean:133 arrangement_card now delegates to ArrangeProof.arrangement_card (import added; identical arrangements defs ⇒ defeq transfer). (2) Decomp.lean:157 sorry eliminated by lifting the orbit-size claim fiber_card_eq_contribution to an explicit hypothesis FiberFormula m n consumed by reps_card_eq_sum_contribution (Keystone-style; deleted theorem had no external callers). (3) Bridge.fiberFormula_holds discharges FiberFormula m n for ALL m,n via fiber_card_eq_shapeContribution. Net: the headline answer Bridge.reps_card_eq_sum_shapeContribution (r_m(n)=Σ_shapes 2^#nonzero·m!/∏count!) is now transitively sorry-free, and Decomp.reps_card_eq_sum_contribution m n (fiberFormula_holds m n) gives the same. grep confirms 0 real sorry tactics across all 7 stack files. PENDING: Bridge docker build green (cold cache this session).",


### PR DESCRIPTION
## Summary

The `four-square-distribution-oq-04` stack was previously recorded as *"sorry-free build-pending"* but had **never actually compiled**. This PR makes it build, registers it, and corrects the gallery metadata.

### Root cause (3 genuine build errors in `FourSquareDistributionOQ04ArrangeProof.lean`)
1. **Factorial `!` notation out of scope** — file used `(s.count v)!` / `m !` with only `open Finset` → added `open scoped Nat`.
2. **`List.Perm` `~` notation out of scope** — `exists_perm_of_map_univ_eq` uses `List.ofFn x ~ List.ofFn y` → added `open scoped List`.
3. **Set-builder coercion landmine** — `{σ ∈ (univ : Finset (Perm (Fin m))) | g₀ ∘ (σ : Fin m → Fin m) = h}` with an *unannotated* binder plus a `(σ : Fin m → Fin m)` ascription forced σ's type to a function, silently coercing `univ` into an **image of functions** (the wrong element type), which broke `apply card_nbij'`, `Fintype.card_subtype`, and `card_eq_sum_card_fiberwise`. Rewrote the three set-builders as `(univ).filter (fun σ : Equiv.Perm (Fin m) => g₀ ∘ (σ : Fin m → Fin m) = X)` (annotated binder, matching `hmaps`).

### Result
`lake build Proofs.FourSquareDistributionOQ04Bridge` **succeeds** (Docker, 7748 jobs). Registered `Decomp / Arrange / ArrangeProof / Keystone / Bridge` in `Proofs.lean`. The headline is now a fully kernel-verified **uniform** proof for all m:

```
reps_card_eq_sum_shapeContribution :
  ∀ m n, #(reps m n) = ∑ s ∈ image shape (reps m n), shapeContribution m s
```

i.e. `r_m(n) = Σ_shapes m!/∏count! · 2^#nonzero` for **all m**, with **0 axioms / 0 sorries / no native_decide**, where `#(reps m n)` is the genuine representation count (lossless via `mem_reps_iff`). The orbit-size residue `arrangement_card` is discharged elementarily (Finset fiber-counting of `σ ↦ g₀∘σ` over `Equiv.Perm`, each fiber a stabilizer coset; arrangement count = `Nat.multinomial` via `Nat.multinomial_spec`), avoiding `MulAction.orbit` Fintype synthesis entirely.

### Metadata
- `meta.json`: added the 5 newly-verified stack files to `additionalFiles`; updated `conclusion` (the uniform theorem is now proven, not an "unregistered goal"). Entry **stays `axiomatized`/`axiom`** because the registered primary file `OQ04.lean` genuinely uses `native_decide` (`Lean.ofReduceBool`) for its per-arity numeric cross-checks; the *decomposition itself* is now machine-verified.
- research problem JSON: `status → completed`, blockers cleared, corrected the stale "build-pending" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)