### PR TITLE
research(stern-brocot-tree-oq-01): register orphan proof into build, fix T_step/T'_step

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2942,6 +2942,7 @@ import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ01
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ02
 import Proofs.Sqrt2PlusSqrt3PlusSqrt5PlusSqrt7IrrationalOQ01
 import Proofs.SteinerLehmusTheoremOQ01
+import Proofs.SternBrocotTreeOQ01
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula

--- a/proofs/Proofs/SternBrocotTreeOQ01.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01.lean
@@ -210,10 +210,10 @@ def T (s : SB) : SB := ⟨s.aL, s.aL + s.bL, s.aR, s.aR + s.bR⟩
 def T' (s : SB) : SB := ⟨s.aL + s.bL, s.bL, s.aR + s.bR, s.bR⟩
 
 theorem T_step (s : SB) (b : Bool) : (T s).step b = T (s.step b) := by
-  cases b <;> cases s <;> simp only [T, SB.step, SB.mk.injEq] <;> omega
+  cases b <;> cases s <;> simp only [T, SB.step] <;> congr 1 <;> ring
 
 theorem T'_step (s : SB) (b : Bool) : (T' s).step b = T' (s.step b) := by
-  cases b <;> cases s <;> simp only [T', SB.step, SB.mk.injEq] <;> omega
+  cases b <;> cases s <;> simp only [T', SB.step] <;> congr 1 <;> ring
 
 theorem T_sbFrom (s : SB) (q : List Bool) : sbFrom (T s) q = T (sbFrom s q) := by
   induction q generalizing s with

--- a/src/data/proofs/stern-brocot-tree-oq-01/meta.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01/meta.json
@@ -55,7 +55,7 @@
     "lineCount": 408,
     "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; all arithmetic is over ℤ.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 30,
+    "theoremCount": 28,
     "definitionCount": 10,
     "structureCount": 1
   },
@@ -170,7 +170,7 @@
     "namespace": "SternBrocot",
     "lineCount": 408,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 28,
     "definitionCount": 10,
     "structureCount": 1,
     "path": "Proofs/SternBrocotTreeOQ01.lean",


### PR DESCRIPTION
## Summary

`Proofs/SternBrocotTreeOQ01.lean` landed on `main` (via #25839/#25208) but was **never imported** into `Proofs.lean`, so it had never been build-confirmed. This PR registers it into the gallery build.

Registering surfaced **two real errors** that the orphan file had been hiding:
- `T_step` / `T'_step` used `simp only [T, SB.step, SB.mk.injEq] <;> omega`, which left a goal `omega` rejected ("no usable constraints").
- Fixed with `simp only [T, SB.step] <;> congr 1 <;> ring` — `congr 1` closes the refl fields and `ring` discharges the lone mediant-fold conjugation identity (associativity/commutativity of ℤ addition).

## Verification
- Build green: `✔ [7743/7743] Built Proofs.SternBrocotTreeOQ01 (207s)` → `Build succeeded`.
- File: **408L / 28thm / 10def / 1struct / 0 axiom / 0 sorry / 0 native_decide** → `verified/original` status is honest.
- `meta.json` `theoremCount` corrected **30 → 28** to match the actual file; all other counts verified exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)