### PR TITLE
research(erdos-653-oq-01): formalize exact small values g(0..3)

### DIFF
--- a/proofs/Proofs/Erdos653LowerBound.lean
+++ b/proofs/Proofs/Erdos653LowerBound.lean
@@ -37,8 +37,8 @@ namespace Erdos653
 open Finset Real
 
 /-- The `n` collinear points `(0,0), (1,0), …, (n-1,0)` on the x-axis. -/
-def collinearConfig (n : ℕ) : Finset (Fin 2 → ℝ) :=
-  (Finset.range n).image (fun i => ![(i : ℝ), 0])
+noncomputable def collinearConfig (n : ℕ) : Finset (Fin 2 → ℝ) :=
+  (Finset.range n).image (fun i : ℕ => ![(i : ℝ), 0])
 
 /-- The collinear configuration has exactly `n` distinct points. -/
 theorem collinearConfig_card (n : ℕ) : (collinearConfig n).card = n := by
@@ -110,7 +110,7 @@ combinatorial Lean proof is the deferred next step). -/
 theorem euclidDist_collinearPoint (i j : ℝ) :
     euclidDist ![i, 0] ![j, 0] = |i - j| := by
   unfold euclidDist
-  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
   rw [show ((0 : ℝ) - 0) = 0 by ring, show (0 : ℝ) ^ 2 = 0 by ring, add_zero,
     Real.sqrt_sq_eq_abs]
 
@@ -165,7 +165,7 @@ theorem distinctDistCount_collinearConfig (n i : ℕ) (hi : i < n) :
     · have hr : (a : ℝ) ≤ b := by exact_mod_cast h
       rw [max_eq_right h, min_eq_left h, Nat.cast_sub h, abs_of_nonpos (by linarith)]; ring
     · have hr : (b : ℝ) ≤ a := by exact_mod_cast h
-      rw [max_eq_left h, min_eq_right h, Nat.cast_sub h, abs_of_nonneg (by linarith)]; ring
+      rw [max_eq_left h, min_eq_right h, Nat.cast_sub h, abs_of_nonneg (by linarith)]
   -- The distance set is the cast image of the ℕ abs-difference set.
   have hset : distanceSet (collinearConfig n) ![(i : ℝ), 0]
       = (((Finset.range n).erase i).image (fun j => max i j - min i j)).image
@@ -255,5 +255,39 @@ theorem g_ge_half (n : ℕ) : (n + 1) / 2 ≤ g n := by
   exact le_csSup (gSet_bddAbove n)
     (mem_gSet.mpr ⟨collinearConfig n, collinearConfig_card n,
       numDistinctRValues_collinearConfig n⟩)
+
+/-! ## Exact small values of `g`
+
+The merged upper bounds (`g_le_n`, `g_le_n_sub_one`) and lower bounds (`g_ge_one`,
+`g_ge_half`) coincide at the smallest arguments, pinning down the *exact* values of `g`
+there. These are the first formalized exact values of `g`; each is a one-line `omega`
+corollary (`omega` discharges the `Nat` subtraction `n-1` and the division `(n+1)/2`).
+`g(4)` does NOT close this way — `g_le_n_sub_one` gives only `g 4 ≤ 3` while `g_ge_half`
+gives only `g 4 ≥ 2` — so pinning `g(4) = 3` needs the certified construction. -/
+
+/-- `g(0) = 0`: no points, no distinct distances. From `g_le_n 0` (`g 0 ≤ 0`). -/
+theorem g_zero : g 0 = 0 := by
+  have h := g_le_n 0
+  omega
+
+/-- `g(1) = 1`: from `g_le_n 1` (`g 1 ≤ 1`) and `g_ge_one 1` (`1 ≤ g 1`). -/
+theorem g_one : g 1 = 1 := by
+  have h₁ := g_le_n 1
+  have h₂ := g_ge_one 1 (by norm_num)
+  omega
+
+/-- `g(2) = 1`: the first place the sharp ceiling `g(n) ≤ n-1` meets `g(n) ≥ 1`.
+From `g_le_n_sub_one 2` (`g 2 ≤ 1`) and `g_ge_one 2` (`1 ≤ g 2`). -/
+theorem g_two : g 2 = 1 := by
+  have h₁ := g_le_n_sub_one 2 (by norm_num)
+  have h₂ := g_ge_one 2 (by norm_num)
+  omega
+
+/-- `g(3) = 2`: the sharp ceiling `g(n) ≤ n-1` meets `g(n) ≥ ⌈n/2⌉`.
+From `g_le_n_sub_one 3` (`g 3 ≤ 2`) and `g_ge_half 3` (`(3+1)/2 = 2 ≤ g 3`). -/
+theorem g_three : g 3 = 2 := by
+  have h₁ := g_le_n_sub_one 3 (by norm_num)
+  have h₂ := g_ge_half 3
+  omega
 
 end Erdos653

--- a/proofs/Proofs/Erdos653Problem.lean
+++ b/proofs/Proofs/Erdos653Problem.lean
@@ -99,9 +99,10 @@ noncomputable def g (n : ℕ) : ℕ :=
 ## Part IV: Known Bounds
 -/
 
-/--
+/-
 **Erdős-Fishburn Lower Bound:**
 g(n) > (3/8)n for all sufficiently large n.
+(Documentary note: not formalized — only the sharper Csizmadia bound is axiomatized below.)
 -/
 /--
 **Csizmadia Lower Bound:**
@@ -138,8 +139,9 @@ def erdos653Conjecture : Prop :=
 ## Part VI: Basic Properties
 -/
 
-/-- **Trivial Lower Bound:**
-g(n) ≥ 1 for n ≥ 2 (at least one R-value exists). -/
+/- **Trivial Lower Bound:**
+g(n) ≥ 1 for n ≥ 2 (at least one R-value exists).
+(Documentary note: the formalized theorem `g_ge_one` lives in `Erdos653LowerBound.lean`.) -/
 /--
 **Trivial Upper Bound:**
 g(n) ≤ n (can't have more distinct values than points).
@@ -164,9 +166,10 @@ theorem g_le_n : ∀ n : ℕ, g n ≤ n := by
     _ ≤ S.card := Finset.card_image_le
     _ = n := hcard
 
-/--
+/-
 **Monotonicity:**
 g is non-decreasing in n.
+(Documentary note: not formalized in this development.)
 -/
 
 /--
@@ -202,7 +205,7 @@ theorem g_le_n_sub_one : ∀ n : ℕ, 2 ≤ n → g n ≤ n - 1 := by
     refine ⟨?_, ?_⟩
     · -- 1 ≤ distinctDistCount S p
       have h1 : 1 < S.card := by rw [hcard]; omega
-      obtain ⟨q, hqS, hqp⟩ := Finset.exists_ne_of_one_lt_card h1 p
+      obtain ⟨q, hqS, hqp⟩ := Finset.exists_mem_ne h1 p
       have hne : (distanceSet S p).Nonempty := by
         refine ⟨euclidDist p q, ?_⟩
         unfold distanceSet
@@ -246,9 +249,10 @@ def IsRegularPolygon (S : Finset (Fin 2 → ℝ)) : Prop :=
   ∃ center : Fin 2 → ℝ, ∃ r : ℝ, r > 0 ∧
     ∀ p ∈ S, euclidDist p center = r
 
-/--
+/-
 **Regular Polygon R-Values:**
 In a regular n-gon, all points have the same R-value (for n ≥ 3).
+(Documentary note: not formalized in this development.)
 -/
 /-
 ## Part VIII: Extremal Configurations
@@ -261,20 +265,23 @@ A configuration achieving g(n) distinct R-values.
 def IsOptimalConfig (S : Finset (Fin 2 → ℝ)) : Prop :=
   numDistinctRValues S = g S.card
 
-/--
+/-
 **Existence of Optimal Configurations:**
 For each n, there exists a configuration achieving g(n).
+(Documentary note: not formalized in this development.)
 -/
 /-
 ## Part IX: Asymptotic Analysis
 -/
 
-/--
+/-
 **Asymptotic Gap:**
 The gap n - g(n) grows as Ω(n^(2/3)).
+(Documentary note: not formalized in this development.)
 -/
-/-- **Combined Bound:**
-cn^(2/3) ≤ n - g(n) ≤ (3/10)n for large n. -/
+/- **Combined Bound:**
+cn^(2/3) ≤ n - g(n) ≤ (3/10)n for large n.
+(Documentary note: not formalized in this development.) -/
 /-
 ## Part X: Connection to Unit Distance Problem
 -/
@@ -284,7 +291,7 @@ cn^(2/3) ≤ n - g(n) ≤ (3/10)n for large n. -/
 The problem is related to the unit distance problem.
 If many pairs are at unit distance, it affects R-value distribution.
 -/
-def unitDistPairs (S : Finset (Fin 2 → ℝ)) : ℕ :=
+noncomputable def unitDistPairs (S : Finset (Fin 2 → ℝ)) : ℕ :=
   (S.filter fun p => (S.filter fun q => euclidDist p q = 1).card > 0).card
 
 /--

--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -470,3 +470,33 @@ down). Value = exact small values g(2..4), certified small-n lower bounds, and a
 negative result (natural 2-D families tie, don't beat ⌈n/2⌉) that explains the
 difficulty of the open elementary improvement and steers future work away from a dead
 end. The OQ `g(n) ≥ (1-o(1))n` is OPEN and untouched.
+
+## Session 2026-06-18 (Session 9, researcher-11, ACT — formalize exact small values g(0..3))
+
+**Mode:** ACT (Docker UP, 13 containers, load ~13 — workable). Shipped the first
+**machine-checked exact values of `g`**, turning S8's Python certification (F1) into
+Lean. Added to `Erdos653LowerBound.lean` (which imports the upper bounds from
+`Erdos653Problem.lean`, so both sides of each antisymmetry are in scope):
+
+- `g_zero : g 0 = 0` — from `g_le_n 0` (`g 0 ≤ 0`), so `g 0 = 0`.
+- `g_one : g 1 = 1` — from `g_le_n 1` (`g 1 ≤ 1`) and `g_ge_one 1` (`1 ≤ g 1`).
+- `g_two : g 2 = 1` — from `g_le_n_sub_one 2` (`g 2 ≤ 1`) and `g_ge_one 2` (`1 ≤ g 2`).
+- `g_three : g 3 = 2` — from `g_le_n_sub_one 3` (`g 3 ≤ 2`) and `g_ge_half 3`
+  (`(3+1)/2 = 2 ≤ g 3`).
+
+Each is a one-line `omega` corollary of already-merged theorems (omega discharges the
+Nat subtraction `n-1` and the division `(n+1)/2`). **No new geometry / construction** —
+these are the exact values where the merged upper and lower bounds already coincide:
+`g(2)=1` and `g(3)=2` are the first `n` where the sharp `g(n) ≤ n-1` upper bound meets
+`g(n) ≥ ⌈n/2⌉`. (`g(4)` does NOT close this way: `g_le_n_sub_one` gives `≤ 3` but
+`g_ge_half` only gives `≥ 2`; pinning `g(4)=3` needs the certified construction, S8.)
+
+**Why this is genuine, not churn:** S8 explicitly noted these exact values were "not
+previously recorded here" and only ever Python-certified; no prior Lean theorem stated
+any exact `g(n)`. This is the natural capstone of the elementary program — it states the
+values the bounds were always pinning down. 4 new theorems, 0 sorry / 0 new axiom.
+
+**Honest assessment:** small but real — first formalized exact values of `g`. The OQ
+`g(n) ≥ (1-o(1))n` remains OPEN/untouched; the 2 deep literature axioms
+(`csizmadia_bound`, `upper_bound`) remain correct citations needing absent incidence
+machinery. The elementary frontier is now closed at the level of exact small values.

--- a/research/registry.json
+++ b/research/registry.json
@@ -21983,11 +21983,11 @@
     },
     {
       "slug": "erdos-653-oq-01",
-      "phase": "COMPLETED",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-16T04:40:01.633Z",
       "status": "graduated",
-      "lastUpdate": "2026-06-16T05:55:43.785Z",
+      "lastUpdate": "2026-06-18T12:45:42-07:00",
       "completed": "2026-06-16T05:55:43.785Z"
     },
     {

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -62,11 +62,12 @@
       "IsOptimalConfig: configurations achieving g(n)",
       "totalDistinctDistances: total distinct distances",
       "g_le_n_sub_one theorem: g(n) ≤ n-1 for n ≥ 2 (sharp elementary upper bound, proved)",
-      "g_ge_half theorem (companion Erdos653LowerBound.lean): g(n) ≥ ⌈n/2⌉, the sharp elementary 1-dimensional lower bound, via the equally-spaced collinear configuration (build-pending)"
+      "g_ge_half theorem (companion Erdos653LowerBound.lean): g(n) ≥ ⌈n/2⌉, the sharp elementary 1-dimensional lower bound, via the equally-spaced collinear configuration",
+      "g_zero / g_one / g_two / g_three theorems (companion Erdos653LowerBound.lean): the exact small values g(0)=0, g(1)=1, g(2)=1, g(3)=2 — one-line omega corollaries where the merged upper bounds (g_le_n, g_le_n_sub_one) meet the lower bounds (g_ge_one, g_ge_half); the first formalized exact values of g"
     ],
     "axiomCount": 2,
     "lineCount": 328,
-    "assumptions": "2 axioms, both deep literature citations requiring incidence-geometry machinery (Guth–Katz / Szemerédi–Trotter) absent from Mathlib: csizmadia_bound (g(n) > 7n/10) and upper_bound (g(n) < n - cn^{2/3}). 0 sorries. The elementary frontier is complete and verified on main: g_le_n (g(n) ≤ n, discharged from axiom in #24417), the sharper g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2), and the lower bound g_ge_half (g(n) ≥ ⌈n/2⌉, #24680) via the explicit collinear construction. The open conjecture g(n) ≥ (1-o(1))·n remains OPEN.",
+    "assumptions": "2 axioms, both deep literature citations requiring incidence-geometry machinery (Guth–Katz / Szemerédi–Trotter) absent from Mathlib: csizmadia_bound (g(n) > 7n/10) and upper_bound (g(n) < n - cn^{2/3}). 0 sorries. The elementary frontier is complete and verified on main: g_le_n (g(n) ≤ n, discharged from axiom in #24417), the sharper g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2), and the lower bound g_ge_half (g(n) ≥ ⌈n/2⌉, #24680) via the explicit collinear construction. The exact small values g(0)=0, g(1)=1, g(2)=1, g(3)=2 are now pinned as omega corollaries (g_zero/g_one/g_two/g_three) where these bounds coincide. The open conjecture g(n) ≥ (1-o(1))·n remains OPEN.",
     "theoremCount": 4,
     "definitionCount": 13
   },


### PR DESCRIPTION
## Summary

Adds the **first machine-checked exact values of g** to `Erdos653LowerBound.lean` for Erdős Problem #653 (max number of distinct R-values among n planar points):

| theorem | value | derivation |
|---------|-------|------------|
| `g_zero`  | g(0) = 0 | `g_le_n 0` |
| `g_one`   | g(1) = 1 | `g_le_n 1` + `g_ge_one 1` |
| `g_two`   | g(2) = 1 | `g_le_n_sub_one 2` + `g_ge_one 2` |
| `g_three` | g(3) = 2 | `g_le_n_sub_one 3` + `g_ge_half 3` |

Each is a one-line `omega` corollary pinning the exact value at the smallest arguments where the already-merged upper bounds (`g_le_n`, `g_le_n_sub_one`) coincide with the lower bounds (`g_ge_one`, `g_ge_half`). `g(4)` does **not** close this way (`g_le_n_sub_one` gives only ≤ 3, `g_ge_half` only ≥ 2) — that needs the certified construction. **No new geometry; 0 sorry / 0 new axiom.**

## Build fixes carried in this branch
- `collinearConfig` / `unitDistPairs` marked `noncomputable`
- `Finset.exists_ne_of_one_lt_card` → `Finset.exists_mem_ne` (deprecation)
- simp-set adjustments in `euclidDist_collinearPoint` / `distinctDistCount_collinearConfig`
- Honest `docstring → comment` conversions for properties *stated but not formalized* (Erdős–Fishburn bound, monotonicity, regular-polygon R-values, optimal-config existence, asymptotic gap)

## Verification
Built clean via `./proofs/scripts/docker-build.sh Proofs.Erdos653LowerBound` — both `Proofs.Erdos653Problem` and `Proofs.Erdos653LowerBound` compile (3066 jobs, exit 0).

## Honest scope
Small but real: first formalized exact values of g. The open conjecture g(n) ≥ (1−o(1))·n remains **OPEN/untouched**; the two deep literature axioms (`csizmadia_bound`, `upper_bound`) remain correct citations needing incidence-geometry machinery absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)