### PR TITLE
Enrich Erdős 105 OQ-02: realign annotations to constructs

### DIFF
--- a/src/data/proofs/erdos-105-oq-02/annotations.json
+++ b/src/data/proofs/erdos-105-oq-02/annotations.json
@@ -28,8 +28,8 @@
     "id": "ann-asymptotic-defs",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 40,
-      "endLine": 58
+      "startLine": 44,
+      "endLine": 60
     },
     "type": "definition",
     "title": "Custom Asymptotic Notation for Discrete Functions",
@@ -50,7 +50,7 @@
     "id": "ann-asymptotics-properties",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 59,
+      "startLine": 63,
       "endLine": 104
     },
     "type": "concept",
@@ -72,8 +72,8 @@
     "id": "ann-axioms",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 106,
-      "endLine": 132
+      "startLine": 122,
+      "endLine": 130
     },
     "type": "concept",
     "title": "Three Axioms: Two Classical Bounds (Beck-SzTr and Xichuan)",
@@ -96,7 +96,7 @@
     "id": "ann-main-theorem",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 134,
+      "startLine": 138,
       "endLine": 168
     },
     "type": "insight",
@@ -119,7 +119,7 @@
     "id": "ann-optimal-constant",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 170,
+      "startLine": 174,
       "endLine": 222
     },
     "type": "insight",
@@ -144,7 +144,7 @@
     "id": "ann-structural-gap",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 224,
+      "startLine": 233,
       "endLine": 254
     },
     "type": "concept",
@@ -168,7 +168,7 @@
     "id": "ann-summary-theorem",
     "proofId": "erdos-105-oq-02",
     "range": {
-      "startLine": 256,
+      "startLine": 260,
       "endLine": 288
     },
     "type": "concept",


### PR DESCRIPTION
Enrichment pass for `erdos-105-oq-02` (threshold function for rich lines; f(n)=Θ(n)).

## Problem found
`pnpm annotations:build` flagged **7 of 8 annotations** with `No Lean construct found` — `startLine`s landed on `════` section dividers.

## Changes
- Realigned each flagged annotation to its actual construct: `BigO`/`BigOmega`/`BigTheta` defs, their refl/trans lemmas, the `threshold_lower_bound`/`threshold_upper_bound` axioms, `threshold_is_Theta`, the optimal-constant defs and `optimalConstant_bounds`, `threshold_gap_axiom`/gap theorems, and `erdos_105_oq02_summary`.
- Content already accurate (no phantom declarations).

Verified: **zero** `No Lean construct found` errors. All 8 annotations retain the four enrichment fields. No other files touched.

Part of the gallery-wide annotation→construct realignment effort (cf. #25892, #25897, #25900, #25901, #25903, #25905).