### PR TITLE
Enrich Erdős 1054 OQ-01 (f-norm): realign annotations to constructs

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
+++ b/src/data/proofs/erdos-1054-oq-01-fnorm/annotations.json
@@ -95,7 +95,7 @@
     "id": "ann-erdos1054fnorm-computational",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 118,
+      "startLine": 120,
       "endLine": 148
     },
     "type": "concept",
@@ -118,7 +118,7 @@
     "id": "ann-erdos1054fnorm-even-odd",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 151,
+      "startLine": 154,
       "endLine": 188
     },
     "type": "insight",
@@ -141,7 +141,7 @@
     "id": "ann-erdos1054fnorm-open-conjecture",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 193,
+      "startLine": 209,
       "endLine": 213
     },
     "type": "concept",
@@ -164,7 +164,7 @@
     "id": "ann-erdos1054fnorm-one-in-sums",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 217,
+      "startLine": 219,
       "endLine": 253
     },
     "type": "concept",
@@ -188,7 +188,7 @@
     "id": "ann-erdos1054fnorm-scanl-infra",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 259,
+      "startLine": 261,
       "endLine": 330
     },
     "type": "concept",
@@ -258,7 +258,7 @@
     "id": "ann-erdos1054fnorm-scanl-ge-infra",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 396,
+      "startLine": 401,
       "endLine": 419
     },
     "type": "concept",
@@ -304,7 +304,7 @@
     "id": "ann-erdos1054fnorm-sigma-values",
     "proofId": "erdos-1054-oq-01-fnorm",
     "range": {
-      "startLine": 447,
+      "startLine": 451,
       "endLine": 521
     },
     "type": "insight",


### PR DESCRIPTION
Enrichment pass for `erdos-1054-oq-01-fnorm`.

## Problem found
`pnpm annotations:build` flagged **7 of 14 annotations** with `No Lean construct found` — `startLine`s landed on section dividers.

## Changes
- Realigned each flagged annotation to its actual construct: the `native_decide` computational examples (`f_3_eq`…`f_32_eq`), `even_representable_small`/`odd_representable_small`, `almost_all_little_o`, `one_in_partial_sums`, the scanl sigma-bound infrastructure (`sortedDivisors_ne_nil`…`sortedDivisors_sum_eq`), `scanl_add_ge_init`, and `sigma_values_representable`.
- Content already accurate (no phantom declarations).

Verified: **zero** `No Lean construct found` errors. All 14 annotations retain the four enrichment fields. No other files touched.

Part of the gallery-wide annotation→construct realignment effort (cf. #25892, #25897, #25900, #25901, #25903, #25905, #25909).